### PR TITLE
fix: resolve npm version queries on Windows

### DIFF
--- a/.changeset/fix-create-ifc-lite-windows-npm.md
+++ b/.changeset/fix-create-ifc-lite-windows-npm.md
@@ -1,0 +1,17 @@
+---
+"create-ifc-lite": patch
+---
+
+Fix npm package version resolution when scaffolding projects on Windows.
+
+`create-ifc-lite` resolves published `@ifc-lite/*` package versions by
+calling `npm view` before writing the generated template's `package.json`.
+On Windows, spawning `npm` directly from Node can fail with
+`spawnSync npm ENOENT` because the executable is exposed through the
+shell shim (`npm.cmd`) rather than as a directly spawnable binary in all
+environments. The CLI then reports this as a registry access failure, even
+though `npm view @ifc-lite/geometry version` works from the same terminal.
+
+Run the npm query through `cmd.exe /c npm ...` on Windows so template
+creation follows the same command resolution path as the user's shell,
+while keeping the direct `npm` spawn path unchanged on other platforms.

--- a/packages/create-ifc-lite/src/utils/config-fixers.ts
+++ b/packages/create-ifc-lite/src/utils/config-fixers.ts
@@ -14,7 +14,9 @@ const NPM_TIMEOUT_MS = 30000;
 const MAX_VERSION_CANDIDATES = 10;
 
 function readJsonFromNpm(args: string[]): unknown {
-  const result = execFileSync('npm', args, {
+  const command = process.platform === 'win32' ? process.env.ComSpec ?? 'cmd.exe' : 'npm';
+  const commandArgs = process.platform === 'win32' ? ['/d', '/s', '/c', 'npm', ...args] : args;
+  const result = execFileSync(command, commandArgs, {
     stdio: 'pipe',
     timeout: NPM_TIMEOUT_MS,
   }).toString().trim();


### PR DESCRIPTION
## Summary
Fix `create-ifc-lite` scaffolding on Windows when it resolves published `@ifc-lite/*` package versions.

The CLI currently calls `execFileSync('npm', ...)` before writing the generated template `package.json`. On Windows that can fail with `spawnSync npm ENOENT` because npm is commonly exposed through the shell shim, while the same `npm view` command works from the terminal. The error is then surfaced as a registry access failure, which is misleading.

This runs the npm query through `cmd.exe /c npm ...` on Windows only, keeping the direct `npm` spawn path unchanged on other platforms.

## Repro
- `corepack pnpm view @ifc-lite/geometry version` returns `1.17.0`
- `node -e "require('child_process').execFileSync('npm', ['view', '@ifc-lite/geometry', 'version'])"` fails with `ENOENT` on my Windows environment
- `corepack pnpm dlx create-ifc-lite ifclite-lab --template react` fails while resolving `@ifc-lite/geometry`

## Test plan
- `corepack pnpm --filter create-ifc-lite build`
- `node packages/create-ifc-lite/dist/index.js <temp-project> --template react`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/louistrue/codesmith/ifc-lite/pr/632"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed npm package version resolution errors on Windows when running `create-ifc-lite`. The scaffolding tool now properly retrieves published package versions before generating project configuration, preventing initialization failures and ensuring consistent setup across all platforms.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/louistrue/ifc-lite/pull/632)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->