### PR TITLE
fix: reject overlapping geometry streams

### DIFF
--- a/.changeset/cold-walls-wait.md
+++ b/.changeset/cold-walls-wait.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/geometry": patch
+---
+
+Reject overlapping WASM streaming geometry runs with a controlled JavaScript error before re-entering the processor.

--- a/packages/geometry/src/geometry-processor-streaming.test.ts
+++ b/packages/geometry/src/geometry-processor-streaming.test.ts
@@ -179,6 +179,37 @@ describe('GeometryProcessor byte streaming fallback', () => {
     expect((completeEvent?.coordinateInfo as { buildingRotation?: number })?.buildingRotation).toBe(0.5);
   });
 
+  it('rejects overlapping WASM streaming runs before re-entering the processor', async () => {
+    const firstGeometry = new GeometryProcessor();
+    const secondGeometry = new GeometryProcessor();
+    const buffer = new Uint8Array([65, 66, 67]);
+
+    const firstStream = firstGeometry.processStreaming(buffer);
+    await expect(firstStream.next()).resolves.toMatchObject({
+      value: { type: 'start' },
+      done: false,
+    });
+
+    const overlappingStream = secondGeometry.processStreaming(buffer);
+    await expect(overlappingStream.next()).rejects.toThrow(
+      'GeometryProcessor processStreaming cannot start while processStreaming is still running.',
+    );
+    const overlappingInstancedStream = secondGeometry.processInstancedStreaming(buffer);
+    await expect(overlappingInstancedStream.next()).rejects.toThrow(
+      'GeometryProcessor processInstancedStreaming cannot start while processStreaming is still running.',
+    );
+    expect(wasmMocks.buildPrePassOnce).not.toHaveBeenCalled();
+
+    await firstStream.return?.(undefined);
+
+    const retryStream = secondGeometry.processStreaming(buffer);
+    await expect(retryStream.next()).resolves.toMatchObject({
+      value: { type: 'start' },
+      done: false,
+    });
+    await retryStream.return?.(undefined);
+  });
+
   it('uses byte-based instanced batch processing for large files', async () => {
     wasmMocks.buildPrePassOnce.mockReturnValue({
       jobs: new Uint32Array([21, 0, 84]),

--- a/packages/geometry/src/index.ts
+++ b/packages/geometry/src/index.ts
@@ -100,6 +100,23 @@ export interface GeometryProcessorOptions {
   mergeLayers?: boolean;
 }
 
+let activeWasmStreamingOperation: string | null = null;
+
+function acquireWasmStreamingOperation(operation: string): () => void {
+  if (activeWasmStreamingOperation) {
+    throw new Error(
+      `GeometryProcessor ${operation} cannot start while ${activeWasmStreamingOperation} is still running. ` +
+      'Wait for the active stream to finish, or cancel it before starting another geometry operation.',
+    );
+  }
+  activeWasmStreamingOperation = operation;
+  return () => {
+    if (activeWasmStreamingOperation === operation) {
+      activeWasmStreamingOperation = null;
+    }
+  };
+}
+
 /**
  * Dynamic batch configuration for ramp-up streaming
  * Starts with small batches for fast first frame, ramps up for throughput
@@ -541,6 +558,23 @@ export class GeometryProcessor {
     // per-model; federation-level override requires collector API changes.
     sharedRtcOffset?: { x: number; y: number; z: number },
   ): AsyncGenerator<StreamingGeometryEvent> {
+    const releaseWasmOperation = this.isNative
+      ? null
+      : acquireWasmStreamingOperation('processStreaming');
+
+    try {
+      yield* this.processStreamingUnlocked(buffer, _entityIndex, batchConfig, sharedRtcOffset);
+    } finally {
+      releaseWasmOperation?.();
+    }
+  }
+
+  private async *processStreamingUnlocked(
+    buffer: Uint8Array,
+    _entityIndex?: Map<number, any>,
+    batchConfig: number | DynamicBatchConfig = 25,
+    sharedRtcOffset?: { x: number; y: number; z: number },
+  ): AsyncGenerator<StreamingGeometryEvent> {
     // Initialize if needed
     if (this.isNative) {
       if (!this.platformBridge) {
@@ -754,6 +788,21 @@ export class GeometryProcessor {
    * @param batchSize Number of unique geometries per batch (default: 25)
    */
   async *processInstancedStreaming(
+    buffer: Uint8Array,
+    batchSize: number = 25
+  ): AsyncGenerator<StreamingInstancedGeometryEvent> {
+    const releaseWasmOperation = this.isNative
+      ? null
+      : acquireWasmStreamingOperation('processInstancedStreaming');
+
+    try {
+      yield* this.processInstancedStreamingUnlocked(buffer, batchSize);
+    } finally {
+      releaseWasmOperation?.();
+    }
+  }
+
+  private async *processInstancedStreamingUnlocked(
     buffer: Uint8Array,
     batchSize: number = 25
   ): AsyncGenerator<StreamingInstancedGeometryEvent> {


### PR DESCRIPTION
## Summary
- reject overlapping browser/WASM `GeometryProcessor` streaming runs before they can re-enter IFCLite internals
- cover both mesh and instanced streaming entrypoints with the same module-level guard
- add a regression test that starts one stream, verifies the second stream fails with a controlled JS error, then confirms the guard is released after cancellation
- add a patch changeset for `@ifc-lite/geometry`

## Repro
In React/Vite dev mode, StrictMode or quick modal remounts can start a second `GeometryProcessor.processStreaming(...)` run while the previous WASM-backed stream is still initializing or parsing. With large IFC files this can surface as a Rust/WASM `RefCell already borrowed` panic instead of a recoverable JS error.

## Test plan
- `corepack pnpm --filter @ifc-lite/data build`
- `corepack pnpm --filter @ifc-lite/geometry test`
- `corepack pnpm --filter @ifc-lite/geometry build`
- `corepack pnpm --filter @ifc-lite/geometry exec tsc --noEmit`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/louistrue/codesmith/ifc-lite/pr/656"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Geometry processor now rejects concurrent WASM streaming operations, throwing an error when a second streaming run is initiated while a previous operation is still active.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/louistrue/ifc-lite/pull/656)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->