### PR TITLE
feat(viewer): add morphable workbench layout

### DIFF
--- a/.changeset/workbench-layout-morph.md
+++ b/.changeset/workbench-layout-morph.md
@@ -1,0 +1,6 @@
+---
+"@ifc-lite/extensions": minor
+"@ifc-lite/viewer": minor
+---
+
+Add a typed workbench layout model for flavors and introduce the viewer UI morph foundation: persisted panel sizing/collapse state, registry-backed desktop zones, drag-to-dock panel movement, toolbar/status/keybinding slot wiring, and basic personal panels.

--- a/.changeset/workbench-layout-morph.md
+++ b/.changeset/workbench-layout-morph.md
@@ -1,5 +1,6 @@
 ---
 "@ifc-lite/extensions": minor
+"@ifc-lite/customization": minor
 "@ifc-lite/viewer": minor
 ---
 

--- a/apps/viewer/package.json
+++ b/apps/viewer/package.json
@@ -31,6 +31,7 @@
     "@ifc-lite/bcf": "workspace:^",
     "@ifc-lite/cache": "workspace:^",
     "@ifc-lite/create": "workspace:^",
+    "@ifc-lite/customization": "workspace:^",
     "@ifc-lite/data": "workspace:^",
     "@ifc-lite/drawing-2d": "workspace:^",
     "@ifc-lite/encoding": "workspace:^",

--- a/apps/viewer/src/components/extensions/ExtensionStatusBarSlot.tsx
+++ b/apps/viewer/src/components/extensions/ExtensionStatusBarSlot.tsx
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { useMemo } from 'react';
+import { evaluateWhen, parseWhen, type StatusBarContribution } from '@ifc-lite/extensions';
+import { useSlotContributions } from '@/hooks/useSlotContributions';
+import { useOptionalExtensionHost } from '@/sdk/ExtensionHostProvider';
+import { useViewerStore } from '@/store';
+
+export function ExtensionStatusBarSlot({ slot }: { slot: StatusBarContribution['slot'] }) {
+  const host = useOptionalExtensionHost();
+  const contributions = useSlotContributions<StatusBarContribution>(slot);
+  const modelCount = useViewerStore((s) => s.models.size);
+  const selectedCount = useViewerStore((s) => s.selectedEntityIds.size);
+  const visible = useMemo(() => {
+    const context = {
+      'model.loaded': modelCount > 0,
+      'model.count': modelCount,
+      'selection.count': selectedCount,
+      'viewer.open': true,
+    };
+    return contributions
+      .filter((contribution) => {
+        const when = contribution.payload.when;
+        if (!when) return true;
+        const parsed = parseWhen(when);
+        return parsed.ok && evaluateWhen(parsed.value, context);
+      })
+      .sort((a, b) => (a.payload.order ?? 100) - (b.payload.order ?? 100));
+  }, [contributions, modelCount, selectedCount]);
+
+  if (visible.length === 0) return null;
+  return (
+    <>
+      {visible.map((contribution) => {
+        const command = contribution.payload.command;
+        const content = <span>{contribution.payload.text}</span>;
+        if (!command) {
+          return <span key={`${contribution.extensionId}:${contribution.payload.id}`}>{content}</span>;
+        }
+        return (
+          <button
+            key={`${contribution.extensionId}:${contribution.payload.id}`}
+            type="button"
+            className="hover:text-primary"
+            onClick={() => {
+              void host?.runCommand(command);
+            }}
+          >
+            {content}
+          </button>
+        );
+      })}
+    </>
+  );
+}

--- a/apps/viewer/src/components/extensions/FlavorDialog.tsx
+++ b/apps/viewer/src/components/extensions/FlavorDialog.tsx
@@ -147,7 +147,8 @@ export function FlavorDialog({ open, onClose }: FlavorDialogProps) {
         toast.error(`Flavor "${flavorId}" not found.`);
         return;
       }
-      const savedLenses = useViewerStore.getState().savedLenses;
+      const viewerState = useViewerStore.getState();
+      const savedLenses = viewerState.savedLenses;
       const lenses = savedLenses.map((lens) => ({
         id: lens.id,
         name: lens.name ?? lens.id,
@@ -156,6 +157,7 @@ export function FlavorDialog({ open, onClose }: FlavorDialogProps) {
       const next = {
         ...target,
         lenses,
+        layout: { state: viewerState.workbenchLayout },
         updatedAt: new Date().toISOString(),
       };
       await host.flavors.put(next, 'capture current state');
@@ -180,8 +182,9 @@ export function FlavorDialog({ open, onClose }: FlavorDialogProps) {
       const slug = opts.name.toLowerCase().replace(/[^a-z0-9-]+/g, '-').replace(/^-+|-+$/g, '');
       const id = `local.${slug || 'flavor'}.${stamp}`;
       const now = new Date().toISOString();
+      const viewerState = useViewerStore.getState();
       const lenses = opts.snapshot
-        ? useViewerStore.getState().savedLenses.map((lens) => ({
+        ? viewerState.savedLenses.map((lens) => ({
             id: lens.id,
             name: lens.name ?? lens.id,
             definition: lens as unknown as Parameters<typeof host.flavors.put>[0]['lenses'][number]['definition'],
@@ -200,7 +203,7 @@ export function FlavorDialog({ open, onClose }: FlavorDialogProps) {
         lenses,
         savedQueries: [],
         keybindings: [],
-        layout: { state: {} },
+        layout: { state: opts.snapshot ? viewerState.workbenchLayout : {} },
         settings: {},
       };
       await host.flavors.put(flavor, opts.snapshot ? 'created from current state' : 'created empty');

--- a/apps/viewer/src/components/extensions/FlavorMergeDialog.tsx
+++ b/apps/viewer/src/components/extensions/FlavorMergeDialog.tsx
@@ -322,5 +322,8 @@ function applyChoice(
       if (idx >= 0) merged.keybindings[idx] = src;
       break;
     }
+    case 'layout':
+      merged.layout = source.layout;
+      break;
   }
 }

--- a/apps/viewer/src/components/extensions/FlavorMergeDialog.tsx
+++ b/apps/viewer/src/components/extensions/FlavorMergeDialog.tsx
@@ -175,6 +175,11 @@ export function FlavorMergeDialog({ open, theirs, onClose, onMerged }: FlavorMer
                         {conflict.kind}
                       </code>
                       <span className="font-mono text-[11px] break-all">{conflict.key}</span>
+                      {conflict.kind === 'layout' && (
+                        <span className="text-[11px] text-muted-foreground">
+                          {describeLayoutConflict(conflict.key)}
+                        </span>
+                      )}
                     </div>
                     <div
                       className={`grid gap-2 text-[11px] ${hasBase ? 'grid-cols-3' : 'grid-cols-2'}`}
@@ -222,6 +227,15 @@ export function FlavorMergeDialog({ open, theirs, onClose, onMerged }: FlavorMer
       </DialogContent>
     </Dialog>
   );
+}
+
+function describeLayoutConflict(key: string): string {
+  if (key.startsWith('panel_move:')) return 'Panel was moved differently.';
+  if (key.startsWith('zone_order:')) return 'Panel tab order changed on both sides.';
+  if (key.startsWith('split_resize:')) return 'Resize/collapse value changed on both sides.';
+  if (key.startsWith('panel_chrome:')) return 'Panel title/icon/visibility changed on both sides.';
+  if (key.startsWith('personal_panel:')) return 'Personal panel content changed on both sides.';
+  return 'Workbench layout changed on both sides.';
 }
 
 function ResolutionChip({

--- a/apps/viewer/src/components/viewer/CommandPalette.tsx
+++ b/apps/viewer/src/components/viewer/CommandPalette.tsx
@@ -455,6 +455,19 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
         action: () => {
           useViewerStore.getState().setFlavorDialogRequested(true);
         } },
+      { id: 'layout:morph', label: 'Morph UI layout…',
+        keywords: 'customize workbench panels drag dock layout resize move',
+        category: 'Panels', icon: Layout,
+        action: () => {
+          const state = useViewerStore.getState();
+          state.setWorkbenchMorphMode(!state.workbenchMorphMode);
+        } },
+      { id: 'layout:reset', label: 'Reset UI layout',
+        keywords: 'customize workbench panels default reset',
+        category: 'Preferences', icon: RotateCcw,
+        action: () => {
+          useViewerStore.getState().resetWorkbenchLayout();
+        } },
     );
 
     // ── Schedule / 4D (Tools) ─────────────────────────────

--- a/apps/viewer/src/components/viewer/CommandPalette.tsx
+++ b/apps/viewer/src/components/viewer/CommandPalette.tsx
@@ -462,6 +462,12 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
           const state = useViewerStore.getState();
           state.setWorkbenchMorphMode(!state.workbenchMorphMode);
         } },
+      { id: 'customization:studio', label: 'Open Customization Studio…',
+        keywords: 'customize studio morph templates extensions panels automations ai',
+        category: 'Panels', icon: Sparkles,
+        action: () => {
+          window.dispatchEvent(new CustomEvent('ifc-lite:open-customization-studio'));
+        } },
       { id: 'layout:reset', label: 'Reset UI layout',
         keywords: 'customize workbench panels default reset',
         category: 'Preferences', icon: RotateCcw,

--- a/apps/viewer/src/components/viewer/MainToolbar.tsx
+++ b/apps/viewer/src/components/viewer/MainToolbar.tsx
@@ -1106,6 +1106,8 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
         </Tooltip>
       )}
 
+      <ExtensionToolbarSlot slot="toolbar.left" />
+
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button variant="ghost" size="icon-sm" disabled={!geometryResult}>
@@ -1510,6 +1512,8 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
 
       <ActionButton icon={Eye} label="Show All (Reset Filters)" onClick={handleShowAll} shortcut="A" />
       <ActionButton icon={Maximize2} label="Fit All" onClick={() => cameraCallbacks.fitAll?.()} shortcut="Z" />
+
+      <ExtensionToolbarSlot slot="toolbar.center" />
 
       <DropdownMenu>
         <Tooltip>

--- a/apps/viewer/src/components/viewer/StatusBar.tsx
+++ b/apps/viewer/src/components/viewer/StatusBar.tsx
@@ -11,6 +11,7 @@ import { useIfc } from '@/hooks/useIfc';
 import { useWebGPU } from '@/hooks/useWebGPU';
 import { FlavorIndicator } from '@/components/extensions/FlavorIndicator';
 import { FlavorDialog } from '@/components/extensions/FlavorDialog';
+import { ExtensionStatusBarSlot } from '@/components/extensions/ExtensionStatusBarSlot';
 
 export function StatusBar() {
   const { loading, geometryResult, ifcDataStore } = useIfc();
@@ -134,6 +135,7 @@ export function StatusBar() {
             Cancel
           </button>
         )}
+        <ExtensionStatusBarSlot slot="statusBar.left" />
       </div>
 
       {/* Center: Model Stats */}
@@ -184,6 +186,10 @@ export function StatusBar() {
             {webgpu.checking ? 'Checking...' : webgpu.supported ? 'WebGPU' : 'No WebGPU'}
           </span>
         </div>
+
+        <Separator orientation="vertical" className="h-3.5" />
+
+        <ExtensionStatusBarSlot slot="statusBar.right" />
 
         <Separator orientation="vertical" className="h-3.5" />
 

--- a/apps/viewer/src/components/viewer/ViewerLayout.tsx
+++ b/apps/viewer/src/components/viewer/ViewerLayout.tsx
@@ -15,11 +15,13 @@ import { StatusBar } from './StatusBar';
 import { ViewportContainer } from './ViewportContainer';
 import { KeyboardShortcutsDialog, useKeyboardShortcutsDialog } from './KeyboardShortcutsDialog';
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
+import { useExtensionKeybindings } from '@/hooks/useExtensionKeybindings';
 import { useActionLogger } from '@/hooks/useActionLogger';
 import { usePrivacyDisclosure } from '@/hooks/usePrivacyDisclosure';
 import { isSafeMode } from '@/lib/safe-mode';
 import { ShieldAlert } from 'lucide-react';
 import { ExtensionDockHost } from '@/components/extensions/ExtensionDockHost';
+import { WorkbenchDesktopLayout } from '@/components/workbench/WorkbenchDesktopLayout';
 import { useIfc } from '@/hooks/useIfc';
 import { useViewerStore } from '@/store';
 import { EntityContextMenu } from './EntityContextMenu';
@@ -49,6 +51,7 @@ const BOTTOM_PANEL_MAX_RATIO = 0.7; // max 70% of container
 export function ViewerLayout() {
   // Initialize keyboard shortcuts
   useKeyboardShortcuts();
+  useExtensionKeybindings();
   // ⌘D / Ctrl+D to duplicate the current selection.
   useDuplicateShortcut();
   // Bridge viewer state transitions into the extension action log
@@ -283,108 +286,7 @@ export function ViewerLayout() {
         {!isMobile && <DesktopEntitlementBanner />}
 
         {/* Main Content Area - Desktop Layout */}
-        {!isMobile && (
-          <div ref={containerRef} className="flex-1 min-h-0 flex flex-col">
-            {/* Top: horizontal split (hierarchy | viewport | properties) */}
-            <div className="flex-1 min-h-0">
-              <PanelGroup orientation="horizontal" className="h-full">
-                {/* Left Panel - Hierarchy */}
-                <Panel
-                  id="left-panel"
-                  defaultSize={20}
-                  minSize={10}
-                  collapsible
-                  collapsedSize={0}
-                  panelRef={leftPanelRef}
-                  onResize={() => {
-                    const collapsed = leftPanelRef.current?.isCollapsed() ?? false;
-                    if (collapsed !== leftPanelCollapsed) setLeftPanelCollapsed(collapsed);
-                  }}
-                >
-                  <div className="h-full w-full overflow-hidden panel-container flex flex-col">
-                    <div className="flex-1 min-h-0 overflow-hidden">
-                      <HierarchyPanel />
-                    </div>
-                    {/* Extension dock.left — collapses when no extension
-                        contributes. Sits beneath the hierarchy panel. */}
-                    <ExtensionDockHost slot="dock.left" className="max-h-[40%] border-t" />
-                  </div>
-                </Panel>
-
-                <PanelResizeHandle className="w-1.5 bg-border hover:bg-primary/50 active:bg-primary/70 transition-colors cursor-col-resize" />
-
-                {/* Center - Viewport */}
-                <Panel id="viewport-panel" defaultSize={58} minSize={30}>
-                  <div className="h-full w-full overflow-hidden">
-                    <ViewportContainer />
-                  </div>
-                </Panel>
-
-                <PanelResizeHandle className="w-1.5 bg-border hover:bg-primary/50 active:bg-primary/70 transition-colors cursor-col-resize" />
-
-                {/* Right Panel - Properties, BCF, or IDS */}
-                <Panel
-                  id="right-panel"
-                  defaultSize={22}
-                  minSize={15}
-                  collapsible
-                  collapsedSize={0}
-                  panelRef={rightPanelRef}
-                  onResize={() => {
-                    const collapsed = rightPanelRef.current?.isCollapsed() ?? false;
-                    if (collapsed !== rightPanelCollapsed) setRightPanelCollapsed(collapsed);
-                  }}
-                >
-                  <div className="h-full w-full overflow-hidden panel-container">
-                    {activeRightAnalysisExtension ? (
-                      activeRightAnalysisExtension.renderPanel({ onClose: closeActiveAnalysisExtension })
-                    ) : activeTool === 'addElement' ? (
-                      <AddElementPanel onClose={() => setActiveTool('select')} />
-                    ) : lensPanelVisible ? (
-                      <LensPanel onClose={() => setLensPanelVisible(false)} />
-                    ) : idsPanelVisible ? (
-                      <IDSPanel onClose={() => setIdsPanelVisible(false)} />
-                    ) : bcfPanelVisible ? (
-                      <BCFPanel onClose={() => setBcfPanelVisible(false)} />
-                    ) : extensionsPanelVisible ? (
-                      <ExtensionsPanel onClose={() => setExtensionsPanelVisible(false)} />
-                    ) : (
-                      <div className="h-full flex flex-col">
-                        <div className="flex-1 min-h-0 overflow-hidden">
-                          <PropertiesPanel />
-                        </div>
-                        {/* Extension dock.right — collapses when empty. */}
-                        <ExtensionDockHost slot="dock.right" className="max-h-[40%] border-t" />
-                      </div>
-                    )}
-                  </div>
-                </Panel>
-              </PanelGroup>
-            </div>
-
-            {/* Bottom Panel - Lists / Script / Gantt / analysis ext (custom resizable) */}
-            {(listPanelVisible || scriptPanelVisible || ganttPanelVisible || !!activeBottomAnalysisExtension) && (
-              <div style={{ height: bottomHeight, flexShrink: 0 }} className="relative">
-                {/* Drag handle */}
-                <div
-                  className="absolute inset-x-0 top-0 h-1.5 bg-border hover:bg-primary/50 active:bg-primary/70 transition-colors cursor-row-resize z-10"
-                  onMouseDown={handleResizeStart}
-                />
-                <div className="h-full w-full overflow-hidden border-t pt-1.5">
-                  {activeBottomAnalysisExtension ? (
-                    activeBottomAnalysisExtension.renderPanel({ onClose: closeActiveAnalysisExtension })
-                  ) : ganttPanelVisible ? (
-                    <GanttPanel onClose={() => setGanttPanelVisible(false)} />
-                  ) : scriptPanelVisible ? (
-                    <ScriptPanel onClose={() => setScriptPanelVisible(false)} />
-                  ) : (
-                    <ListPanel onClose={() => setListPanelVisible(false)} />
-                  )}
-                </div>
-              </div>
-            )}
-          </div>
-        )}
+        {!isMobile && <WorkbenchDesktopLayout analysisExtensionState={analysisExtensionState} />}
 
         {/* Main Content Area - Mobile Layout */}
         {isMobile && (
@@ -493,14 +395,6 @@ export function ViewerLayout() {
                 </button>
               </div>
             )}
-          </div>
-        )}
-
-        {/* Extension dock.bottom slot — collapses to nothing when no
-            extension contributes here. */}
-        {!isMobile && (
-          <div className="max-h-[40vh]">
-            <ExtensionDockHost slot="dock.bottom" />
           </div>
         )}
 

--- a/apps/viewer/src/components/workbench/AiCustomizationPanel.tsx
+++ b/apps/viewer/src/components/workbench/AiCustomizationPanel.tsx
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { useState } from 'react';
+import { draftCustomizationPlanFromPrompt, validateCustomizationPlan } from '@ifc-lite/customization';
+import { Button } from '@/components/ui/button';
+import { previewWorkbenchPatch } from './WorkbenchPatchDialog';
+
+export function AiCustomizationPanel({ onPreview }: { onPreview?: () => void }) {
+  const [prompt, setPrompt] = useState('Make me a fire safety review workspace');
+  const plan = draftCustomizationPlanFromPrompt(prompt);
+  const errors = validateCustomizationPlan(plan);
+  return (
+    <div className="space-y-3">
+      <textarea
+        value={prompt}
+        onChange={(event) => setPrompt(event.currentTarget.value)}
+        rows={4}
+        className="w-full rounded border bg-background px-3 py-2 text-sm"
+      />
+      <div className="rounded border bg-muted/30 p-3">
+        <div className="font-medium">{plan.summary}</div>
+        <div className="mt-1 text-xs text-muted-foreground">
+          Intent: {plan.intent} · Capabilities: {plan.requiredCapabilities.length || 'none'}
+        </div>
+        {plan.risks.map((risk, index) => (
+          <div key={index} className="mt-2 rounded bg-background px-2 py-1 text-xs">
+            {risk.tier}: {risk.message}
+          </div>
+        ))}
+        {errors.length > 0 && <div className="mt-2 text-xs text-destructive">{errors.join(' ')}</div>}
+      </div>
+      <Button
+        type="button"
+        disabled={!plan.patch || errors.length > 0}
+        onClick={() => {
+          if (plan.patch) previewWorkbenchPatch(plan.patch);
+          onPreview?.();
+        }}
+      >
+        Preview AI plan
+      </Button>
+    </div>
+  );
+}

--- a/apps/viewer/src/components/workbench/CustomizationStudioDialog.tsx
+++ b/apps/viewer/src/components/workbench/CustomizationStudioDialog.tsx
@@ -2,13 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { LayoutDashboard, Wand2 } from 'lucide-react';
+import { Clock, GitMerge, LayoutDashboard, PanelsTopLeft, Settings2, Wand2, Workflow } from 'lucide-react';
 import { listCustomizationTemplates, simulateWorkbenchPatch } from '@ifc-lite/customization';
+import { useState, type ReactNode } from 'react';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { useViewerStore } from '@/store';
 import { previewWorkbenchPatch } from './WorkbenchPatchDialog';
+import { WidgetBuilderPanel } from './WidgetBuilderPanel';
+import { EditableZonesPanel } from './EditableZonesPanel';
+import { AiCustomizationPanel } from './AiCustomizationPanel';
+import { WorkbenchMergePreviewPanel } from './WorkbenchMergePreviewPanel';
+
+type StudioTab = 'templates' | 'builder' | 'zones' | 'automations' | 'history' | 'merge' | 'ai';
 
 interface CustomizationStudioDialogProps {
   open: boolean;
@@ -18,6 +25,7 @@ interface CustomizationStudioDialogProps {
 export function CustomizationStudioDialog({ open, onClose }: CustomizationStudioDialogProps) {
   const layout = useViewerStore((s) => s.workbenchLayout);
   const templates = listCustomizationTemplates();
+  const [tab, setTab] = useState<StudioTab>('templates');
 
   return (
     <Dialog open={open} onOpenChange={(next) => !next && onClose()}>
@@ -30,14 +38,16 @@ export function CustomizationStudioDialog({ open, onClose }: CustomizationStudio
         </DialogHeader>
         <div className="grid gap-4 md:grid-cols-[180px,1fr]">
           <aside className="space-y-1 rounded border bg-muted/20 p-2 text-sm">
-            <div className="rounded bg-background px-2 py-1.5 font-medium">Templates</div>
-            <div className="px-2 py-1.5 text-muted-foreground">Panels</div>
-            <div className="px-2 py-1.5 text-muted-foreground">Automations</div>
-            <div className="px-2 py-1.5 text-muted-foreground">History</div>
-            <div className="px-2 py-1.5 text-muted-foreground">AI plans</div>
+            <StudioNav tab={tab} value="templates" icon={<LayoutDashboard className="h-3.5 w-3.5" />} onSelect={setTab}>Templates</StudioNav>
+            <StudioNav tab={tab} value="builder" icon={<PanelsTopLeft className="h-3.5 w-3.5" />} onSelect={setTab}>Widget builder</StudioNav>
+            <StudioNav tab={tab} value="zones" icon={<Settings2 className="h-3.5 w-3.5" />} onSelect={setTab}>Built-ins</StudioNav>
+            <StudioNav tab={tab} value="automations" icon={<Workflow className="h-3.5 w-3.5" />} onSelect={setTab}>Automations</StudioNav>
+            <StudioNav tab={tab} value="history" icon={<Clock className="h-3.5 w-3.5" />} onSelect={setTab}>History</StudioNav>
+            <StudioNav tab={tab} value="merge" icon={<GitMerge className="h-3.5 w-3.5" />} onSelect={setTab}>Merge</StudioNav>
+            <StudioNav tab={tab} value="ai" icon={<Wand2 className="h-3.5 w-3.5" />} onSelect={setTab}>AI plans</StudioNav>
           </aside>
           <ScrollArea className="max-h-[62vh] pr-3">
-            <div className="space-y-3">
+            {tab === 'templates' && <div className="space-y-3">
               {templates.map((template) => {
                 const patch = template.plan.patch;
                 const simulation = patch ? simulateWorkbenchPatch(layout, patch) : undefined;
@@ -80,10 +90,72 @@ export function CustomizationStudioDialog({ open, onClose }: CustomizationStudio
                   </div>
                 );
               })}
-            </div>
+            </div>}
+            {tab === 'builder' && <WidgetBuilderPanel />}
+            {tab === 'zones' && <EditableZonesPanel />}
+            {tab === 'automations' && <AutomationRunLogPanel />}
+            {tab === 'history' && <HistoryPanel />}
+            {tab === 'merge' && <WorkbenchMergePreviewPanel />}
+            {tab === 'ai' && <AiCustomizationPanel onPreview={onClose} />}
           </ScrollArea>
         </div>
       </DialogContent>
     </Dialog>
+  );
+}
+
+function StudioNav({
+  tab,
+  value,
+  icon,
+  children,
+  onSelect,
+}: {
+  tab: StudioTab;
+  value: StudioTab;
+  icon: ReactNode;
+  children: ReactNode;
+  onSelect: (tab: StudioTab) => void;
+}) {
+  return (
+    <button
+      type="button"
+      className={`flex w-full items-center gap-2 rounded px-2 py-1.5 text-left ${tab === value ? 'bg-background font-medium' : 'text-muted-foreground hover:bg-background/60'}`}
+      onClick={() => onSelect(value)}
+    >
+      {icon}
+      {children}
+    </button>
+  );
+}
+
+function AutomationRunLogPanel() {
+  const runs = useViewerStore((s) => s.workbenchLayout.automationRuns);
+  return (
+    <div className="space-y-2">
+      {runs.slice().reverse().map((run) => (
+        <div key={run.id} className="rounded border p-3 text-sm">
+          <div className="font-medium">{run.automationName}</div>
+          <div className="text-xs text-muted-foreground">{run.status} · {run.trigger} · {run.createdAt}</div>
+          {run.message && <div className="mt-1 text-xs">{run.message}</div>}
+        </div>
+      ))}
+      {runs.length === 0 && <div className="rounded border border-dashed p-4 text-sm text-muted-foreground">No automation runs yet.</div>}
+    </div>
+  );
+}
+
+function HistoryPanel() {
+  const history = useViewerStore((s) => s.workbenchLayout.history);
+  return (
+    <div className="space-y-2">
+      {history.slice().reverse().map((entry) => (
+        <div key={entry.id} className="rounded border p-3 text-sm">
+          <div className="font-medium">{entry.label}</div>
+          <div className="text-xs text-muted-foreground">{entry.createdAt}{entry.patchId ? ` · ${entry.patchId}` : ''}</div>
+        </div>
+      ))}
+      {history.length === 0 && <div className="rounded border border-dashed p-4 text-sm text-muted-foreground">No workbench history yet.</div>}
+    </div>
   );
 }

--- a/apps/viewer/src/components/workbench/CustomizationStudioDialog.tsx
+++ b/apps/viewer/src/components/workbench/CustomizationStudioDialog.tsx
@@ -1,0 +1,89 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { LayoutDashboard, Wand2 } from 'lucide-react';
+import { listCustomizationTemplates, simulateWorkbenchPatch } from '@ifc-lite/customization';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { useViewerStore } from '@/store';
+import { previewWorkbenchPatch } from './WorkbenchPatchDialog';
+
+interface CustomizationStudioDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function CustomizationStudioDialog({ open, onClose }: CustomizationStudioDialogProps) {
+  const layout = useViewerStore((s) => s.workbenchLayout);
+  const templates = listCustomizationTemplates();
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !next && onClose()}>
+      <DialogContent className="max-w-4xl">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Wand2 className="h-4 w-4" />
+            Customization Studio
+          </DialogTitle>
+        </DialogHeader>
+        <div className="grid gap-4 md:grid-cols-[180px,1fr]">
+          <aside className="space-y-1 rounded border bg-muted/20 p-2 text-sm">
+            <div className="rounded bg-background px-2 py-1.5 font-medium">Templates</div>
+            <div className="px-2 py-1.5 text-muted-foreground">Panels</div>
+            <div className="px-2 py-1.5 text-muted-foreground">Automations</div>
+            <div className="px-2 py-1.5 text-muted-foreground">History</div>
+            <div className="px-2 py-1.5 text-muted-foreground">AI plans</div>
+          </aside>
+          <ScrollArea className="max-h-[62vh] pr-3">
+            <div className="space-y-3">
+              {templates.map((template) => {
+                const patch = template.plan.patch;
+                const simulation = patch ? simulateWorkbenchPatch(layout, patch) : undefined;
+                return (
+                  <div key={template.id} className="rounded border bg-background p-4">
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <div className="flex items-center gap-2 font-medium">
+                          <LayoutDashboard className="h-4 w-4 text-primary" />
+                          {template.name}
+                        </div>
+                        <p className="mt-1 text-sm text-muted-foreground">{template.description}</p>
+                        <div className="mt-2 text-xs text-muted-foreground">
+                          {simulation?.changes.length ?? 0} operation{simulation?.changes.length === 1 ? '' : 's'}
+                          {simulation && simulation.warnings.length > 0 ? ` · ${simulation.warnings.length} warning(s)` : ''}
+                        </div>
+                      </div>
+                      <Button
+                        type="button"
+                        size="sm"
+                        disabled={!patch}
+                        onClick={() => {
+                          if (patch) previewWorkbenchPatch(patch);
+                          onClose();
+                        }}
+                      >
+                        Preview
+                      </Button>
+                    </div>
+                    {simulation && (
+                      <div className="mt-3 rounded bg-muted/30 p-2">
+                        {simulation.changes.slice(0, 4).map((change, index) => (
+                          <div key={`${change.operation}-${index}`} className="text-xs">
+                            <span className="font-medium">{change.label}</span>
+                            {change.detail ? <span className="text-muted-foreground"> — {change.detail}</span> : null}
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </ScrollArea>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/viewer/src/components/workbench/EditableZonesPanel.tsx
+++ b/apps/viewer/src/components/workbench/EditableZonesPanel.tsx
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { listBuiltInEditableZones } from '@ifc-lite/customization';
+import { Button } from '@/components/ui/button';
+import { useViewerStore } from '@/store';
+
+export function EditableZonesPanel() {
+  const layout = useViewerStore((s) => s.workbenchLayout);
+  const setConfig = useViewerStore((s) => s.setWorkbenchPanelConfig);
+  const zones = listBuiltInEditableZones();
+  return (
+    <div className="space-y-3">
+      {zones.map((zone) => {
+        const current = layout.panelConfigs[zone.panelId] ?? zone.defaults;
+        return (
+          <div key={zone.panelId} className="rounded border p-3">
+            <div className="font-medium">{zone.label}</div>
+            <p className="mt-1 text-sm text-muted-foreground">{zone.description}</p>
+            <pre className="mt-2 overflow-x-auto rounded bg-muted/30 p-2 text-xs">{JSON.stringify(current, null, 2)}</pre>
+            <Button type="button" size="sm" className="mt-2" onClick={() => setConfig(zone.panelId, zone.defaults)}>
+              Apply defaults
+            </Button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/viewer/src/components/workbench/MorphToolbar.tsx
+++ b/apps/viewer/src/components/workbench/MorphToolbar.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { LayoutDashboard, Library, Plus, RotateCcw } from 'lucide-react';
+import { LayoutDashboard, Library, Plus, RotateCcw, Wand2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 
 interface MorphToolbarProps {
@@ -10,6 +10,7 @@ interface MorphToolbarProps {
   onToggle: () => void;
   onAddPanel: () => void;
   onLibrary: () => void;
+  onModes: () => void;
   onReset: () => void;
 }
 
@@ -18,6 +19,7 @@ export function MorphToolbar({
   onToggle,
   onAddPanel,
   onLibrary,
+  onModes,
   onReset,
 }: MorphToolbarProps) {
   return (
@@ -33,6 +35,9 @@ export function MorphToolbar({
           </Button>
           <Button type="button" size="icon-sm" variant="ghost" onClick={onLibrary} aria-label="Open panel library">
             <Library className="h-3.5 w-3.5" />
+          </Button>
+          <Button type="button" size="icon-sm" variant="ghost" onClick={onModes} aria-label="Open workspace modes and automations">
+            <Wand2 className="h-3.5 w-3.5" />
           </Button>
           <Button type="button" size="icon-sm" variant="ghost" onClick={onReset} aria-label="Reset layout">
             <RotateCcw className="h-3.5 w-3.5" />

--- a/apps/viewer/src/components/workbench/MorphToolbar.tsx
+++ b/apps/viewer/src/components/workbench/MorphToolbar.tsx
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { LayoutDashboard, Library, Plus, RotateCcw } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+interface MorphToolbarProps {
+  enabled: boolean;
+  onToggle: () => void;
+  onAddPanel: () => void;
+  onLibrary: () => void;
+  onReset: () => void;
+}
+
+export function MorphToolbar({
+  enabled,
+  onToggle,
+  onAddPanel,
+  onLibrary,
+  onReset,
+}: MorphToolbarProps) {
+  return (
+    <div className="absolute right-3 top-3 z-20 flex items-center gap-1 rounded border bg-background/90 p-1 shadow-sm backdrop-blur">
+      <Button type="button" size="sm" variant={enabled ? 'default' : 'secondary'} onClick={onToggle}>
+        <LayoutDashboard className="mr-1 h-3.5 w-3.5" />
+        {enabled ? 'Morphing' : 'Morph UI'}
+      </Button>
+      {enabled && (
+        <>
+          <Button type="button" size="icon-sm" variant="ghost" onClick={onAddPanel} aria-label="Add personal panel">
+            <Plus className="h-3.5 w-3.5" />
+          </Button>
+          <Button type="button" size="icon-sm" variant="ghost" onClick={onLibrary} aria-label="Open panel library">
+            <Library className="h-3.5 w-3.5" />
+          </Button>
+          <Button type="button" size="icon-sm" variant="ghost" onClick={onReset} aria-label="Reset layout">
+            <RotateCcw className="h-3.5 w-3.5" />
+          </Button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/viewer/src/components/workbench/MorphToolbar.tsx
+++ b/apps/viewer/src/components/workbench/MorphToolbar.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { LayoutDashboard, Library, Plus, RotateCcw, Wand2 } from 'lucide-react';
+import { LayoutDashboard, Library, Plus, RotateCcw, Sparkles, Wand2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 
 interface MorphToolbarProps {
@@ -11,6 +11,7 @@ interface MorphToolbarProps {
   onAddPanel: () => void;
   onLibrary: () => void;
   onModes: () => void;
+  onStudio: () => void;
   onReset: () => void;
 }
 
@@ -20,6 +21,7 @@ export function MorphToolbar({
   onAddPanel,
   onLibrary,
   onModes,
+  onStudio,
   onReset,
 }: MorphToolbarProps) {
   return (
@@ -38,6 +40,9 @@ export function MorphToolbar({
           </Button>
           <Button type="button" size="icon-sm" variant="ghost" onClick={onModes} aria-label="Open workspace modes and automations">
             <Wand2 className="h-3.5 w-3.5" />
+          </Button>
+          <Button type="button" size="icon-sm" variant="ghost" onClick={onStudio} aria-label="Open Customization Studio">
+            <Sparkles className="h-3.5 w-3.5" />
           </Button>
           <Button type="button" size="icon-sm" variant="ghost" onClick={onReset} aria-label="Reset layout">
             <RotateCcw className="h-3.5 w-3.5" />

--- a/apps/viewer/src/components/workbench/PanelChromeDialog.tsx
+++ b/apps/viewer/src/components/workbench/PanelChromeDialog.tsx
@@ -4,12 +4,15 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import { Trash2 } from 'lucide-react';
-import type { PersonalPanelDefinition } from '@ifc-lite/extensions';
+import { validateWidget, type JsonValue, type PersonalPanelDefinition } from '@ifc-lite/extensions';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { useOptionalExtensionHost } from '@/sdk/ExtensionHostProvider';
 import { useViewerStore } from '@/store';
+import { WidgetRenderer, type WidgetRendererContext } from '@/components/extensions/widget/WidgetRenderer';
 import { getWorkbenchPanelTitle } from './panelRegistry';
 
 interface PanelChromeDialogProps {
@@ -26,14 +29,16 @@ export function PanelChromeDialog({ panelId, onClose }: PanelChromeDialogProps) 
   const initialTitle = useMemo(() => panelId ? getWorkbenchPanelTitle(layout, panelId) : '', [layout, panelId]);
   const [title, setTitle] = useState(initialTitle);
   const [accent, setAccent] = useState('');
-  const [markdown, setMarkdown] = useState('');
+  const [widgetJson, setWidgetJson] = useState('');
+  const preview = useWidgetPreview(widgetJson);
+  const ctx = useWidgetContext();
 
   useEffect(() => {
     if (!panelId) return;
     const personal = layout.personalPanels[panelId];
     setTitle(getWorkbenchPanelTitle(layout, panelId));
     setAccent(layout.panelChrome[panelId]?.accent ?? '');
-    setMarkdown(readMarkdown(personal));
+    setWidgetJson(JSON.stringify(personal?.widget ?? { type: 'Markdown', content: '' }, null, 2));
   }, [layout, panelId]);
 
   const handleSave = () => {
@@ -41,10 +46,11 @@ export function PanelChromeDialog({ panelId, onClose }: PanelChromeDialogProps) 
     const nextTitle = title.trim() || initialTitle || panelId;
     setChrome(panelId, { title: nextTitle, accent: accent.trim() || undefined });
     if (panel) {
+      if (!preview.ok) return;
       updatePersonal({
         ...panel,
         title: nextTitle,
-        widget: { type: 'Markdown', content: markdown },
+        widget: preview.value,
         updatedAt: new Date().toISOString(),
       });
     }
@@ -53,7 +59,7 @@ export function PanelChromeDialog({ panelId, onClose }: PanelChromeDialogProps) 
 
   return (
     <Dialog open={!!panelId} onOpenChange={(next) => !next && onClose()}>
-      <DialogContent className="max-w-lg">
+      <DialogContent className="max-w-4xl">
         <DialogHeader>
           <DialogTitle>Edit panel chrome</DialogTitle>
         </DialogHeader>
@@ -72,15 +78,34 @@ export function PanelChromeDialog({ panelId, onClose }: PanelChromeDialogProps) 
             />
           </div>
           {panel && (
-            <div className="space-y-1.5">
-              <Label htmlFor="panel-markdown">Personal panel Markdown</Label>
-              <textarea
-                id="panel-markdown"
-                value={markdown}
-                onChange={(event) => setMarkdown(event.currentTarget.value)}
-                rows={9}
-                className="w-full rounded border bg-background px-2 py-1.5 text-sm font-mono"
-              />
+            <div className="grid gap-3 md:grid-cols-2">
+              <div className="space-y-1.5">
+                <Label htmlFor="panel-widget-json">Widget JSON</Label>
+                <textarea
+                  id="panel-widget-json"
+                  value={widgetJson}
+                  onChange={(event) => setWidgetJson(event.currentTarget.value)}
+                  rows={16}
+                  className="w-full rounded border bg-background px-2 py-1.5 text-xs font-mono"
+                />
+                {!preview.ok && (
+                  <div className="rounded border border-destructive/40 bg-destructive/10 px-2 py-1 text-xs text-destructive">
+                    {preview.error}
+                  </div>
+                )}
+              </div>
+              <div className="space-y-1.5">
+                <Label>Live preview</Label>
+                <ScrollArea className="h-[360px] rounded border bg-background">
+                  <div className="p-3">
+                    {preview.ok ? (
+                      <WidgetRenderer node={preview.node} ctx={ctx} />
+                    ) : (
+                      <div className="text-xs text-muted-foreground">Fix JSON/validation errors to preview this panel.</div>
+                    )}
+                  </div>
+                </ScrollArea>
+              </div>
             </div>
           )}
           <div className="flex items-center justify-between gap-2">
@@ -100,7 +125,7 @@ export function PanelChromeDialog({ panelId, onClose }: PanelChromeDialogProps) 
             ) : <span />}
             <div className="flex gap-2">
               <Button type="button" variant="ghost" size="sm" onClick={onClose}>Cancel</Button>
-              <Button type="button" size="sm" onClick={handleSave}>Save</Button>
+              <Button type="button" size="sm" onClick={handleSave} disabled={panel ? !preview.ok : false}>Save</Button>
             </div>
           </div>
         </div>
@@ -109,9 +134,38 @@ export function PanelChromeDialog({ panelId, onClose }: PanelChromeDialogProps) 
   );
 }
 
-function readMarkdown(panel: PersonalPanelDefinition | undefined): string {
-  const widget = panel?.widget;
-  if (!widget || typeof widget !== 'object' || Array.isArray(widget)) return '';
-  const content = widget.content;
-  return typeof content === 'string' ? content : '';
+type WidgetPreview =
+  | { ok: true; value: JsonValue; node: Parameters<typeof WidgetRenderer>[0]['node'] }
+  | { ok: false; error: string };
+
+function useWidgetPreview(widgetJson: string): WidgetPreview {
+  return useMemo(() => {
+    try {
+      const parsed = JSON.parse(widgetJson) as unknown;
+      const validated = validateWidget(parsed, 'personal-panel.widget');
+      if (!validated.ok) {
+        const first = validated.errors[0];
+        return { ok: false, error: `${first?.path ?? 'widget'} ${first?.message ?? 'failed validation'}` };
+      }
+      return {
+        ok: true,
+        value: validated.value as unknown as JsonValue,
+        node: validated.value,
+      };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  }, [widgetJson]);
+}
+
+function useWidgetContext(): WidgetRendererContext {
+  const host = useOptionalExtensionHost();
+  return useMemo(() => ({
+    state: {},
+    invokeCommand: (commandId: string) => {
+      host?.runCommand(commandId).catch((err) => {
+        console.warn('[PanelChromeDialog] widget command failed:', err);
+      });
+    },
+  }), [host]);
 }

--- a/apps/viewer/src/components/workbench/PanelChromeDialog.tsx
+++ b/apps/viewer/src/components/workbench/PanelChromeDialog.tsx
@@ -1,0 +1,117 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { useEffect, useMemo, useState } from 'react';
+import { Trash2 } from 'lucide-react';
+import type { PersonalPanelDefinition } from '@ifc-lite/extensions';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { useViewerStore } from '@/store';
+import { getWorkbenchPanelTitle } from './panelRegistry';
+
+interface PanelChromeDialogProps {
+  panelId: string | null;
+  onClose: () => void;
+}
+
+export function PanelChromeDialog({ panelId, onClose }: PanelChromeDialogProps) {
+  const layout = useViewerStore((s) => s.workbenchLayout);
+  const setChrome = useViewerStore((s) => s.setWorkbenchPanelChrome);
+  const updatePersonal = useViewerStore((s) => s.updateWorkbenchPersonalPanel);
+  const removePersonal = useViewerStore((s) => s.removeWorkbenchPersonalPanel);
+  const panel = panelId ? layout.personalPanels[panelId] : undefined;
+  const initialTitle = useMemo(() => panelId ? getWorkbenchPanelTitle(layout, panelId) : '', [layout, panelId]);
+  const [title, setTitle] = useState(initialTitle);
+  const [accent, setAccent] = useState('');
+  const [markdown, setMarkdown] = useState('');
+
+  useEffect(() => {
+    if (!panelId) return;
+    const personal = layout.personalPanels[panelId];
+    setTitle(getWorkbenchPanelTitle(layout, panelId));
+    setAccent(layout.panelChrome[panelId]?.accent ?? '');
+    setMarkdown(readMarkdown(personal));
+  }, [layout, panelId]);
+
+  const handleSave = () => {
+    if (!panelId) return;
+    const nextTitle = title.trim() || initialTitle || panelId;
+    setChrome(panelId, { title: nextTitle, accent: accent.trim() || undefined });
+    if (panel) {
+      updatePersonal({
+        ...panel,
+        title: nextTitle,
+        widget: { type: 'Markdown', content: markdown },
+        updatedAt: new Date().toISOString(),
+      });
+    }
+    onClose();
+  };
+
+  return (
+    <Dialog open={!!panelId} onOpenChange={(next) => !next && onClose()}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Edit panel chrome</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-3">
+          <div className="space-y-1.5">
+            <Label htmlFor="panel-title">Title</Label>
+            <Input id="panel-title" value={title} onChange={(event) => setTitle(event.currentTarget.value)} />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="panel-accent">Accent token</Label>
+            <Input
+              id="panel-accent"
+              value={accent}
+              onChange={(event) => setAccent(event.currentTarget.value)}
+              placeholder="e.g. fire, qa, review"
+            />
+          </div>
+          {panel && (
+            <div className="space-y-1.5">
+              <Label htmlFor="panel-markdown">Personal panel Markdown</Label>
+              <textarea
+                id="panel-markdown"
+                value={markdown}
+                onChange={(event) => setMarkdown(event.currentTarget.value)}
+                rows={9}
+                className="w-full rounded border bg-background px-2 py-1.5 text-sm font-mono"
+              />
+            </div>
+          )}
+          <div className="flex items-center justify-between gap-2">
+            {panel ? (
+              <Button
+                type="button"
+                variant="destructive"
+                size="sm"
+                onClick={() => {
+                  removePersonal(panel.id);
+                  onClose();
+                }}
+              >
+                <Trash2 className="mr-1 h-3.5 w-3.5" />
+                Delete panel
+              </Button>
+            ) : <span />}
+            <div className="flex gap-2">
+              <Button type="button" variant="ghost" size="sm" onClick={onClose}>Cancel</Button>
+              <Button type="button" size="sm" onClick={handleSave}>Save</Button>
+            </div>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function readMarkdown(panel: PersonalPanelDefinition | undefined): string {
+  const widget = panel?.widget;
+  if (!widget || typeof widget !== 'object' || Array.isArray(widget)) return '';
+  const content = widget.content;
+  return typeof content === 'string' ? content : '';
+}

--- a/apps/viewer/src/components/workbench/PanelLibraryDialog.tsx
+++ b/apps/viewer/src/components/workbench/PanelLibraryDialog.tsx
@@ -3,12 +3,13 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { Eye, EyeOff, MoveRight } from 'lucide-react';
-import type { WorkbenchPanelId, WorkbenchZoneId } from '@ifc-lite/extensions';
+import type { PanelContribution, WorkbenchPanelId, WorkbenchZoneId } from '@ifc-lite/extensions';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { ScrollArea } from '@/components/ui/scroll-area';
+import { useSlotContributions } from '@/hooks/useSlotContributions';
 import { useViewerStore } from '@/store';
-import { listWorkbenchPanels, ZONE_LABEL } from './panelRegistry';
+import { extensionPanelWorkbenchId, listWorkbenchPanels, ZONE_LABEL, type WorkbenchPanelSummary } from './panelRegistry';
 
 interface PanelLibraryDialogProps {
   open: boolean;
@@ -20,7 +21,20 @@ export function PanelLibraryDialog({ open, onClose, onEdit }: PanelLibraryDialog
   const layout = useViewerStore((s) => s.workbenchLayout);
   const setChrome = useViewerStore((s) => s.setWorkbenchPanelChrome);
   const movePanel = useViewerStore((s) => s.moveWorkbenchPanel);
-  const panels = listWorkbenchPanels(layout);
+  const extensionPanels = useSlotContributions<PanelContribution>('workbench.panels');
+  const panels: WorkbenchPanelSummary[] = [
+    ...listWorkbenchPanels(layout),
+    ...extensionPanels.map((contribution) => {
+      const id = extensionPanelWorkbenchId(contribution.extensionId, contribution.payload.id);
+      return {
+        id,
+        title: layout.panelChrome[id]?.title ?? contribution.payload.title,
+        kind: 'extension' as const,
+        zone: findPanelZone(id),
+        hidden: layout.panelChrome[id]?.hidden === true,
+      };
+    }),
+  ];
 
   const showInZone = (panelId: string, zone: WorkbenchZoneId) => {
     setChrome(panelId, { hidden: false });
@@ -76,4 +90,12 @@ export function PanelLibraryDialog({ open, onClose, onEdit }: PanelLibraryDialog
       </DialogContent>
     </Dialog>
   );
+}
+
+function findPanelZone(panelId: string): WorkbenchZoneId | undefined {
+  const layout = useViewerStore.getState().workbenchLayout;
+  if (layout.zones.left.includes(panelId)) return 'left';
+  if (layout.zones.right.includes(panelId)) return 'right';
+  if (layout.zones.bottom.includes(panelId)) return 'bottom';
+  return undefined;
 }

--- a/apps/viewer/src/components/workbench/PanelLibraryDialog.tsx
+++ b/apps/viewer/src/components/workbench/PanelLibraryDialog.tsx
@@ -1,0 +1,79 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { Eye, EyeOff, MoveRight } from 'lucide-react';
+import type { WorkbenchPanelId, WorkbenchZoneId } from '@ifc-lite/extensions';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { useViewerStore } from '@/store';
+import { listWorkbenchPanels, ZONE_LABEL } from './panelRegistry';
+
+interface PanelLibraryDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onEdit: (panelId: WorkbenchPanelId) => void;
+}
+
+export function PanelLibraryDialog({ open, onClose, onEdit }: PanelLibraryDialogProps) {
+  const layout = useViewerStore((s) => s.workbenchLayout);
+  const setChrome = useViewerStore((s) => s.setWorkbenchPanelChrome);
+  const movePanel = useViewerStore((s) => s.moveWorkbenchPanel);
+  const panels = listWorkbenchPanels(layout);
+
+  const showInZone = (panelId: string, zone: WorkbenchZoneId) => {
+    setChrome(panelId, { hidden: false });
+    movePanel(panelId, zone);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !next && onClose()}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Panel library</DialogTitle>
+        </DialogHeader>
+        <ScrollArea className="max-h-[60vh] pr-3">
+          <div className="space-y-2">
+            {panels.map((panel) => (
+              <div key={panel.id} className="rounded border bg-background p-3">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <div className="font-medium text-sm">{panel.title}</div>
+                    <div className="mt-0.5 text-[11px] text-muted-foreground">
+                      {panel.kind} · {panel.zone ? ZONE_LABEL[panel.zone] : 'not docked'}
+                      {panel.hidden ? ' · hidden' : ''}
+                    </div>
+                    <code className="mt-1 block text-[10px] text-muted-foreground break-all">{panel.id}</code>
+                  </div>
+                  <div className="flex shrink-0 items-center gap-1">
+                    <Button type="button" size="sm" variant="ghost" onClick={() => onEdit(panel.id)}>
+                      Edit
+                    </Button>
+                    <Button
+                      type="button"
+                      size="icon-sm"
+                      variant="ghost"
+                      aria-label={panel.hidden ? 'Show panel' : 'Hide panel'}
+                      onClick={() => setChrome(panel.id, { hidden: !panel.hidden })}
+                    >
+                      {panel.hidden ? <Eye className="h-3.5 w-3.5" /> : <EyeOff className="h-3.5 w-3.5" />}
+                    </Button>
+                  </div>
+                </div>
+                <div className="mt-3 flex flex-wrap items-center gap-1.5">
+                  {(['left', 'right', 'bottom'] as const).map((zone) => (
+                    <Button key={zone} type="button" size="sm" variant="secondary" onClick={() => showInZone(panel.id, zone)}>
+                      <MoveRight className="mr-1 h-3.5 w-3.5" />
+                      {ZONE_LABEL[zone]}
+                    </Button>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </ScrollArea>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/viewer/src/components/workbench/PersonalPanelDialog.tsx
+++ b/apps/viewer/src/components/workbench/PersonalPanelDialog.tsx
@@ -3,12 +3,14 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { useState } from 'react';
-import type { WorkbenchZoneId } from '@ifc-lite/extensions';
+import type { JsonValue, WorkbenchZoneId } from '@ifc-lite/extensions';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useViewerStore } from '@/store';
+
+type PanelTemplate = 'markdown' | 'command-stack' | 'dashboard' | 'selection-helper';
 
 interface PersonalPanelDialogProps {
   open: boolean;
@@ -19,6 +21,7 @@ export function PersonalPanelDialog({ open, onClose }: PersonalPanelDialogProps)
   const addPanel = useViewerStore((s) => s.addWorkbenchPersonalPanel);
   const [title, setTitle] = useState('My panel');
   const [zone, setZone] = useState<WorkbenchZoneId>('right');
+  const [template, setTemplate] = useState<PanelTemplate>('markdown');
   const [markdown, setMarkdown] = useState('### Personal panel\n\nAdd notes, prompts, and command buttons here.');
 
   const handleCreate = () => {
@@ -27,10 +30,7 @@ export function PersonalPanelDialog({ open, onClose }: PersonalPanelDialogProps)
     addPanel({
       id,
       title: title.trim() || 'My panel',
-      widget: {
-        type: 'Markdown',
-        content: markdown,
-      },
+      widget: createWidget(template, markdown),
       createdAt: now,
       updatedAt: now,
     }, zone);
@@ -62,6 +62,20 @@ export function PersonalPanelDialog({ open, onClose }: PersonalPanelDialogProps)
             </select>
           </div>
           <div className="space-y-1.5">
+            <Label htmlFor="personal-panel-template">Template</Label>
+            <select
+              id="personal-panel-template"
+              value={template}
+              onChange={(event) => setTemplate(event.currentTarget.value as PanelTemplate)}
+              className="w-full rounded border bg-background px-2 py-1.5 text-sm"
+            >
+              <option value="markdown">Markdown notes</option>
+              <option value="command-stack">Command stack</option>
+              <option value="dashboard">Dashboard scaffold</option>
+              <option value="selection-helper">Selection helper</option>
+            </select>
+          </div>
+          <div className="space-y-1.5">
             <Label htmlFor="personal-panel-markdown">Markdown content</Label>
             <textarea
               id="personal-panel-markdown"
@@ -79,4 +93,47 @@ export function PersonalPanelDialog({ open, onClose }: PersonalPanelDialogProps)
       </DialogContent>
     </Dialog>
   );
+}
+
+function createWidget(template: PanelTemplate, markdown: string): JsonValue {
+  if (template === 'command-stack') {
+    const children: JsonValue[] = [
+      { type: 'Text', variant: 'heading', text: 'Command stack' },
+      { type: 'Markdown', content: markdown },
+      { type: 'Text', tone: 'muted', text: 'Add extension-backed command buttons here as the command registry expands.' },
+    ];
+    return {
+      type: 'Stack',
+      direction: 'vertical',
+      gap: 'sm',
+      children,
+    };
+  }
+  if (template === 'dashboard') {
+    const children: JsonValue[] = [
+      { type: 'Text', variant: 'heading', text: 'Dashboard' },
+      { type: 'KeyValueGrid', rows: [{ label: 'Status', value: 'Ready' }, { label: 'Source', value: 'Personal flavor' }] },
+      { type: 'Markdown', content: markdown },
+    ];
+    return {
+      type: 'Stack',
+      direction: 'vertical',
+      gap: 'md',
+      children,
+    };
+  }
+  if (template === 'selection-helper') {
+    const children: JsonValue[] = [
+      { type: 'Text', variant: 'heading', text: 'Selection helper' },
+      { type: 'Text', tone: 'muted', text: 'Use this panel for entity review prompts and shortcuts.' },
+      { type: 'Markdown', content: markdown },
+    ];
+    return {
+      type: 'Stack',
+      direction: 'vertical',
+      gap: 'sm',
+      children,
+    };
+  }
+  return { type: 'Markdown', content: markdown };
 }

--- a/apps/viewer/src/components/workbench/PersonalPanelDialog.tsx
+++ b/apps/viewer/src/components/workbench/PersonalPanelDialog.tsx
@@ -1,0 +1,82 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { useState } from 'react';
+import type { WorkbenchZoneId } from '@ifc-lite/extensions';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { useViewerStore } from '@/store';
+
+interface PersonalPanelDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function PersonalPanelDialog({ open, onClose }: PersonalPanelDialogProps) {
+  const addPanel = useViewerStore((s) => s.addWorkbenchPersonalPanel);
+  const [title, setTitle] = useState('My panel');
+  const [zone, setZone] = useState<WorkbenchZoneId>('right');
+  const [markdown, setMarkdown] = useState('### Personal panel\n\nAdd notes, prompts, and command buttons here.');
+
+  const handleCreate = () => {
+    const now = new Date().toISOString();
+    const id = `user:panel:${crypto.randomUUID()}`;
+    addPanel({
+      id,
+      title: title.trim() || 'My panel',
+      widget: {
+        type: 'Markdown',
+        content: markdown,
+      },
+      createdAt: now,
+      updatedAt: now,
+    }, zone);
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !next && onClose()}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Add personal panel</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-3">
+          <div className="space-y-1.5">
+            <Label htmlFor="personal-panel-title">Title</Label>
+            <Input id="personal-panel-title" value={title} onChange={(event) => setTitle(event.currentTarget.value)} />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="personal-panel-zone">Dock target</Label>
+            <select
+              id="personal-panel-zone"
+              value={zone}
+              onChange={(event) => setZone(event.currentTarget.value as WorkbenchZoneId)}
+              className="w-full rounded border bg-background px-2 py-1.5 text-sm"
+            >
+              <option value="left">Left</option>
+              <option value="right">Right</option>
+              <option value="bottom">Bottom</option>
+            </select>
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="personal-panel-markdown">Markdown content</Label>
+            <textarea
+              id="personal-panel-markdown"
+              value={markdown}
+              onChange={(event) => setMarkdown(event.currentTarget.value)}
+              rows={8}
+              className="w-full rounded border bg-background px-2 py-1.5 text-sm font-mono"
+            />
+          </div>
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="ghost" size="sm" onClick={onClose}>Cancel</Button>
+            <Button type="button" size="sm" onClick={handleCreate}>Create panel</Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/viewer/src/components/workbench/WidgetBuilderPanel.tsx
+++ b/apps/viewer/src/components/workbench/WidgetBuilderPanel.tsx
@@ -1,0 +1,120 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { useMemo, useState } from 'react';
+import { validateWidget, type JsonValue } from '@ifc-lite/extensions';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { useViewerStore } from '@/store';
+import { WidgetRenderer, type WidgetRendererContext } from '@/components/extensions/widget/WidgetRenderer';
+import { useOptionalExtensionHost } from '@/sdk/ExtensionHostProvider';
+
+const BLOCKS: Array<{ label: string; node: JsonValue }> = [
+  { label: 'Heading', node: { type: 'Text', variant: 'heading', text: 'New heading' } },
+  { label: 'Markdown', node: { type: 'Markdown', content: 'Write notes here.' } },
+  { label: 'Key/value grid', node: { type: 'KeyValueGrid', rows: [{ label: 'Status', value: 'Draft' }] } },
+  { label: 'Button placeholder', node: { type: 'Text', tone: 'muted', text: 'Button placeholder: bind to an extension command.' } },
+];
+
+export function WidgetBuilderPanel() {
+  const addPanel = useViewerStore((s) => s.addWorkbenchPersonalPanel);
+  const [title, setTitle] = useState('Visual panel');
+  const [children, setChildren] = useState<JsonValue[]>([
+    { type: 'Text', variant: 'heading', text: 'Visual panel' },
+    { type: 'Markdown', content: 'Use the block palette to compose this panel.' },
+  ]);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const widget = useMemo<JsonValue>(() => ({ type: 'Stack', direction: 'vertical', gap: 'md', children }), [children]);
+  const validated = useMemo(() => validateWidget(widget, 'widget-builder'), [widget]);
+  const ctx = useWidgetContext();
+
+  const updateSelected = (raw: string) => {
+    try {
+      const parsed = JSON.parse(raw) as JsonValue;
+      setChildren((items) => items.map((item, index) => index === selectedIndex ? parsed : item));
+    } catch {
+      // Keep editing local text tolerant; validation catches once valid JSON is entered.
+    }
+  };
+
+  return (
+    <div className="grid gap-3 md:grid-cols-[150px,1fr,260px]">
+      <div className="space-y-2 rounded border p-2">
+        <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Blocks</div>
+        {BLOCKS.map((block) => (
+          <Button key={block.label} type="button" size="sm" variant="secondary" className="w-full justify-start" onClick={() => setChildren((items) => [...items, block.node])}>
+            {block.label}
+          </Button>
+        ))}
+      </div>
+      <div className="space-y-2">
+        <div className="flex items-center gap-2">
+          <input value={title} onChange={(event) => setTitle(event.currentTarget.value)} className="rounded border bg-background px-2 py-1 text-sm" />
+          <Button
+            type="button"
+            size="sm"
+            disabled={!validated.ok}
+            onClick={() => {
+              const now = new Date().toISOString();
+              addPanel({
+                id: `user:panel:${crypto.randomUUID()}`,
+                title,
+                widget,
+                createdAt: now,
+                updatedAt: now,
+              }, 'right');
+            }}
+          >
+            Save panel
+          </Button>
+        </div>
+        <ScrollArea className="h-[380px] rounded border bg-background">
+          <div className="p-3">
+            {validated.ok ? (
+              <WidgetRenderer node={validated.value} ctx={ctx} />
+            ) : (
+              <div className="text-xs text-destructive">{validated.errors[0]?.message ?? 'Widget invalid'}</div>
+            )}
+          </div>
+        </ScrollArea>
+      </div>
+      <div className="space-y-2 rounded border p-2">
+        <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Layers</div>
+        <div className="space-y-1">
+          {children.map((child, index) => (
+            <button
+              key={index}
+              type="button"
+              className={`w-full rounded px-2 py-1 text-left text-xs ${selectedIndex === index ? 'bg-primary/10 text-primary' : 'hover:bg-muted'}`}
+              onClick={() => setSelectedIndex(index)}
+            >
+              {typeof child === 'object' && child && !Array.isArray(child) && typeof child.type === 'string' ? child.type : `Node ${index + 1}`}
+            </button>
+          ))}
+        </div>
+        <Label htmlFor="selected-node-json">Selected node JSON</Label>
+        <textarea
+          id="selected-node-json"
+          value={JSON.stringify(children[selectedIndex] ?? {}, null, 2)}
+          onChange={(event) => updateSelected(event.currentTarget.value)}
+          rows={12}
+          className="w-full rounded border bg-background px-2 py-1 text-xs font-mono"
+        />
+      </div>
+    </div>
+  );
+}
+
+function useWidgetContext(): WidgetRendererContext {
+  const host = useOptionalExtensionHost();
+  return useMemo(() => ({
+    state: {},
+    invokeCommand: (commandId: string) => {
+      host?.runCommand(commandId).catch((err) => {
+        console.warn('[WidgetBuilderPanel] command failed:', err);
+      });
+    },
+  }), [host]);
+}

--- a/apps/viewer/src/components/workbench/WorkbenchDesktopLayout.tsx
+++ b/apps/viewer/src/components/workbench/WorkbenchDesktopLayout.tsx
@@ -28,6 +28,8 @@ import { PanelLibraryDialog } from './PanelLibraryDialog';
 import { MorphToolbar } from './MorphToolbar';
 import { getWorkbenchPanelTitle, ZONE_LABEL } from './panelRegistry';
 import { WorkbenchPanelHost } from './WorkbenchPanelHost';
+import { WorkspaceModesDialog } from './WorkspaceModesDialog';
+import { firePanelOpenedAutomation, useWorkbenchAutomations } from '@/hooks/useWorkbenchAutomations';
 
 const BOTTOM_PANEL_MIN_HEIGHT = 120;
 const BOTTOM_PANEL_MAX_RATIO = 0.7;
@@ -46,6 +48,7 @@ export function WorkbenchDesktopLayout({ analysisExtensionState }: WorkbenchDesk
   const resetLayout = useViewerStore((s) => s.resetWorkbenchLayout);
   const [personalOpen, setPersonalOpen] = useState(false);
   const [libraryOpen, setLibraryOpen] = useState(false);
+  const [modesOpen, setModesOpen] = useState(false);
   const [editingPanelId, setEditingPanelId] = useState<string | null>(null);
   const leftPanelRef = useRef<PanelImperativeHandle>(null);
   const rightPanelRef = useRef<PanelImperativeHandle>(null);
@@ -60,6 +63,7 @@ export function WorkbenchDesktopLayout({ analysisExtensionState }: WorkbenchDesk
 
   useLegacyPanelSync();
   useAutoPersistLayout();
+  useWorkbenchAutomations();
 
   useEffect(() => {
     const panel = leftPanelRef.current;
@@ -84,6 +88,7 @@ export function WorkbenchDesktopLayout({ analysisExtensionState }: WorkbenchDesk
         onToggle={() => setMorphMode(!morphMode)}
         onAddPanel={() => setPersonalOpen(true)}
         onLibrary={() => setLibraryOpen(true)}
+        onModes={() => setModesOpen(true)}
         onReset={() => {
           resetLayout();
           toast.success('Layout reset to IFC Lite default.');
@@ -161,6 +166,7 @@ export function WorkbenchDesktopLayout({ analysisExtensionState }: WorkbenchDesk
         }}
       />
       <PanelChromeDialog panelId={editingPanelId} onClose={() => setEditingPanelId(null)} />
+      <WorkspaceModesDialog open={modesOpen} onClose={() => setModesOpen(false)} />
     </div>
   );
 }
@@ -183,7 +189,10 @@ function WorkbenchZone({ zone, morphMode }: { zone: WorkbenchZoneId; morphMode: 
               panelId={panelId}
               active={panelId === activePanel}
               morphMode={morphMode}
-              onClick={() => setActive(zone, panelId)}
+              onClick={() => {
+                setActive(zone, panelId);
+                firePanelOpenedAutomation(panelId);
+              }}
             />
           ))}
           {morphMode && (

--- a/apps/viewer/src/components/workbench/WorkbenchDesktopLayout.tsx
+++ b/apps/viewer/src/components/workbench/WorkbenchDesktopLayout.tsx
@@ -1,0 +1,426 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { useCallback, useEffect, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent, type ReactNode, type RefObject } from 'react';
+import { Panel, Group as PanelGroup, Separator as PanelResizeHandle } from 'react-resizable-panels';
+import type { PanelImperativeHandle } from 'react-resizable-panels';
+import { GripVertical, LayoutDashboard, Plus, RotateCcw, X } from 'lucide-react';
+import {
+  BUILTIN_PANEL_IDS,
+  type WorkbenchPanelId,
+  type WorkbenchZoneId,
+} from '@ifc-lite/extensions';
+import { Button } from '@/components/ui/button';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { toast } from '@/components/ui/toast';
+import { cn } from '@/lib/utils';
+import { useViewerStore } from '@/store';
+import { AddElementPanel } from '@/components/viewer/AddElementPanel';
+import { BCFPanel } from '@/components/viewer/BCFPanel';
+import { ExtensionsPanel } from '@/components/extensions/ExtensionsPanel';
+import { GanttPanel } from '@/components/viewer/schedule/GanttPanel';
+import { HierarchyPanel } from '@/components/viewer/HierarchyPanel';
+import { IDSPanel } from '@/components/viewer/IDSPanel';
+import { LensPanel } from '@/components/viewer/LensPanel';
+import { ListPanel } from '@/components/viewer/lists/ListPanel';
+import { PropertiesPanel } from '@/components/viewer/PropertiesPanel';
+import { ScriptPanel } from '@/components/viewer/ScriptPanel';
+import { ViewportContainer } from '@/components/viewer/ViewportContainer';
+import { ExtensionDockHost } from '@/components/extensions/ExtensionDockHost';
+import { WidgetRenderer, type WidgetRendererContext } from '@/components/extensions/widget/WidgetRenderer';
+import { useOptionalExtensionHost } from '@/sdk/ExtensionHostProvider';
+import {
+  closeActiveAnalysisExtension,
+  getAnalysisExtensionById,
+  getAnalysisExtensionsSnapshot,
+} from '@/services/analysis-extensions';
+import { PersonalPanelDialog } from './PersonalPanelDialog';
+
+const ZONE_LABEL: Record<WorkbenchZoneId, string> = { left: 'Left dock', right: 'Right dock', bottom: 'Bottom dock' };
+const BOTTOM_PANEL_MIN_HEIGHT = 120;
+const BOTTOM_PANEL_MAX_RATIO = 0.7;
+
+interface WorkbenchDesktopLayoutProps {
+  analysisExtensionState: ReturnType<typeof getAnalysisExtensionsSnapshot>;
+}
+
+export function WorkbenchDesktopLayout({ analysisExtensionState }: WorkbenchDesktopLayoutProps) {
+  const layout = useViewerStore((s) => s.workbenchLayout);
+  const morphMode = useViewerStore((s) => s.workbenchMorphMode);
+  const setMorphMode = useViewerStore((s) => s.setWorkbenchMorphMode);
+  const setSizes = useViewerStore((s) => s.setWorkbenchHorizontalSizes);
+  const setBottomHeight = useViewerStore((s) => s.setWorkbenchBottomHeight);
+  const setCollapsed = useViewerStore((s) => s.setWorkbenchCollapsed);
+  const resetLayout = useViewerStore((s) => s.resetWorkbenchLayout);
+  const [personalOpen, setPersonalOpen] = useState(false);
+  const leftPanelRef = useRef<PanelImperativeHandle>(null);
+  const rightPanelRef = useRef<PanelImperativeHandle>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const activeAnalysisExtension = getAnalysisExtensionById(analysisExtensionState.activeId);
+  const activeRightAnalysisExtension = (activeAnalysisExtension?.placement ?? 'right') === 'right'
+    ? activeAnalysisExtension
+    : null;
+  const activeBottomAnalysisExtension = activeAnalysisExtension?.placement === 'bottom'
+    ? activeAnalysisExtension
+    : null;
+
+  useLegacyPanelSync();
+  useAutoPersistLayout();
+
+  useEffect(() => {
+    const panel = leftPanelRef.current;
+    if (!panel) return;
+    if (layout.collapsed.left && !panel.isCollapsed()) panel.collapse();
+    else if (!layout.collapsed.left && panel.isCollapsed()) panel.expand();
+  }, [layout.collapsed.left]);
+
+  useEffect(() => {
+    const panel = rightPanelRef.current;
+    if (!panel) return;
+    if (layout.collapsed.right && !panel.isCollapsed()) panel.collapse();
+    else if (!layout.collapsed.right && panel.isCollapsed()) panel.expand();
+  }, [layout.collapsed.right]);
+
+  const handleResizeStart = useBottomResize(containerRef, layout.sizes.bottomHeight, setBottomHeight);
+
+  return (
+    <div ref={containerRef} className="flex-1 min-h-0 flex flex-col relative">
+      <MorphToolbar
+        enabled={morphMode}
+        onToggle={() => setMorphMode(!morphMode)}
+        onAddPanel={() => setPersonalOpen(true)}
+        onReset={() => {
+          resetLayout();
+          toast.success('Layout reset to IFC Lite default.');
+        }}
+      />
+      <div className="flex-1 min-h-0">
+        <PanelGroup
+          orientation="horizontal"
+          className="h-full"
+          onLayout={(sizes) => {
+            if (sizes.length === 3) setSizes([sizes[0], sizes[1], sizes[2]]);
+          }}
+        >
+          <Panel
+            id="left-panel"
+            defaultSize={layout.sizes.horizontal[0]}
+            minSize={10}
+            collapsible
+            collapsedSize={0}
+            panelRef={leftPanelRef}
+            onResize={() => setCollapsed('left', leftPanelRef.current?.isCollapsed() ?? false)}
+          >
+            <WorkbenchZone zone="left" morphMode={morphMode} />
+          </Panel>
+          <PanelResizeHandle className="w-1.5 bg-border hover:bg-primary/50 active:bg-primary/70 transition-colors cursor-col-resize" />
+          <Panel id="viewport-panel" defaultSize={layout.sizes.horizontal[1]} minSize={30}>
+            <div className="h-full w-full overflow-hidden">
+              <ViewportContainer />
+            </div>
+          </Panel>
+          <PanelResizeHandle className="w-1.5 bg-border hover:bg-primary/50 active:bg-primary/70 transition-colors cursor-col-resize" />
+          <Panel
+            id="right-panel"
+            defaultSize={layout.sizes.horizontal[2]}
+            minSize={15}
+            collapsible
+            collapsedSize={0}
+            panelRef={rightPanelRef}
+            onResize={() => setCollapsed('right', rightPanelRef.current?.isCollapsed() ?? false)}
+          >
+            {activeRightAnalysisExtension
+              ? <div className="h-full panel-container">{activeRightAnalysisExtension.renderPanel({ onClose: closeActiveAnalysisExtension })}</div>
+              : <WorkbenchZone zone="right" morphMode={morphMode} />}
+          </Panel>
+        </PanelGroup>
+      </div>
+      {(activeBottomAnalysisExtension || layout.activeTabs.bottom) && !layout.collapsed.bottom && (
+        <div style={{ height: layout.sizes.bottomHeight, flexShrink: 0 }} className="relative">
+          <div
+            className="absolute inset-x-0 top-0 h-1.5 bg-border hover:bg-primary/50 active:bg-primary/70 transition-colors cursor-row-resize z-10"
+            onMouseDown={handleResizeStart}
+          />
+          <div className="h-full w-full overflow-hidden border-t pt-1.5">
+            {activeBottomAnalysisExtension
+              ? activeBottomAnalysisExtension.renderPanel({ onClose: closeActiveAnalysisExtension })
+              : <WorkbenchZone zone="bottom" morphMode={morphMode} />}
+          </div>
+        </div>
+      )}
+      <div className="max-h-[32vh]">
+        <ExtensionDockHost slot="dock.bottom" />
+      </div>
+      <PersonalPanelDialog open={personalOpen} onClose={() => setPersonalOpen(false)} />
+    </div>
+  );
+}
+
+function WorkbenchZone({ zone, morphMode }: { zone: WorkbenchZoneId; morphMode: boolean }) {
+  const layout = useViewerStore((s) => s.workbenchLayout);
+  const activeTab = layout.activeTabs[zone] ?? layout.zones[zone][0];
+  const setActive = useViewerStore((s) => s.setWorkbenchActiveTab);
+  const movePanel = useViewerStore((s) => s.moveWorkbenchPanel);
+  const zonePanels = layout.zones[zone].filter((id) => !layout.panelChrome[id]?.hidden);
+  const activePanel = zonePanels.includes(activeTab ?? '') ? activeTab : zonePanels[0];
+
+  return (
+    <DropZone zone={zone} enabled={morphMode} onDropPanel={(panelId) => movePanel(panelId, zone)}>
+      <div className="h-full w-full overflow-hidden panel-container flex flex-col">
+        <div className={cn('flex items-center gap-1 border-b bg-muted/30 overflow-x-auto', morphMode && 'ring-1 ring-primary/40')}>
+          {zonePanels.map((panelId) => (
+            <PanelTab
+              key={panelId}
+              panelId={panelId}
+              active={panelId === activePanel}
+              morphMode={morphMode}
+              onClick={() => setActive(zone, panelId)}
+            />
+          ))}
+          {morphMode && (
+            <div className="ml-auto px-2 py-1 text-[10px] uppercase tracking-wide text-muted-foreground">
+              {ZONE_LABEL[zone]}
+            </div>
+          )}
+        </div>
+        <div className="flex-1 min-h-0 overflow-hidden">
+          {activePanel ? <WorkbenchPanel panelId={activePanel} zone={zone} /> : <EmptyZone zone={zone} />}
+        </div>
+        {zone !== 'bottom' && <ExtensionDockHost slot={zone === 'left' ? 'dock.left' : 'dock.right'} className="max-h-[35%] border-t" />}
+      </div>
+    </DropZone>
+  );
+}
+
+function PanelTab({ panelId, active, morphMode, onClick }: { panelId: string; active: boolean; morphMode: boolean; onClick: () => void }) {
+  const title = usePanelTitle(panelId);
+  return (
+    <button
+      type="button"
+      draggable={morphMode}
+      onDragStart={(event) => event.dataTransfer.setData('application/x-ifc-lite-panel', panelId)}
+      onClick={onClick}
+      className={cn(
+        'shrink-0 flex items-center gap-1 px-2.5 py-1.5 text-xs border-b-2 transition-colors',
+        active ? 'border-primary text-primary' : 'border-transparent text-muted-foreground hover:text-foreground',
+      )}
+      title={morphMode ? `Drag ${title} to another dock` : title}
+    >
+      {morphMode && <GripVertical className="h-3 w-3" />}
+      {title}
+    </button>
+  );
+}
+
+function WorkbenchPanel({ panelId, zone }: { panelId: string; zone: WorkbenchZoneId }) {
+  const closePanel = useClosePanel(panelId, zone);
+  const personal = useViewerStore((s) => s.workbenchLayout.personalPanels[panelId]);
+  const ctx = usePersonalWidgetContext();
+  if (personal) {
+    return (
+      <ScrollArea className="h-full">
+        <div className="p-3">
+          <WidgetRenderer node={personal.widget as Parameters<typeof WidgetRenderer>[0]['node']} ctx={ctx} />
+        </div>
+      </ScrollArea>
+    );
+  }
+  switch (panelId) {
+    case BUILTIN_PANEL_IDS.hierarchy: return <HierarchyPanel />;
+    case BUILTIN_PANEL_IDS.properties: return <PropertiesPanel />;
+    case BUILTIN_PANEL_IDS.bcf: return <BCFPanel onClose={closePanel} />;
+    case BUILTIN_PANEL_IDS.ids: return <IDSPanel onClose={closePanel} />;
+    case BUILTIN_PANEL_IDS.lens: return <LensPanel onClose={closePanel} />;
+    case BUILTIN_PANEL_IDS.extensions: return <ExtensionsPanel onClose={closePanel} />;
+    case BUILTIN_PANEL_IDS.addElement: return <AddElementPanel onClose={closePanel} />;
+    case BUILTIN_PANEL_IDS.lists: return <ListPanel onClose={closePanel} />;
+    case BUILTIN_PANEL_IDS.script: return <ScriptPanel onClose={closePanel} />;
+    case BUILTIN_PANEL_IDS.gantt: return <GanttPanel onClose={closePanel} />;
+    default: return <EmptyPanel panelId={panelId} />;
+  }
+}
+
+function MorphToolbar({ enabled, onToggle, onAddPanel, onReset }: { enabled: boolean; onToggle: () => void; onAddPanel: () => void; onReset: () => void }) {
+  return (
+    <div className="absolute right-3 top-3 z-20 flex items-center gap-1 rounded border bg-background/90 p-1 shadow-sm backdrop-blur">
+      <Button type="button" size="sm" variant={enabled ? 'default' : 'secondary'} onClick={onToggle}>
+        <LayoutDashboard className="mr-1 h-3.5 w-3.5" />
+        {enabled ? 'Morphing' : 'Morph UI'}
+      </Button>
+      {enabled && (
+        <>
+          <Button type="button" size="icon-sm" variant="ghost" onClick={onAddPanel} aria-label="Add personal panel">
+            <Plus className="h-3.5 w-3.5" />
+          </Button>
+          <Button type="button" size="icon-sm" variant="ghost" onClick={onReset} aria-label="Reset layout">
+            <RotateCcw className="h-3.5 w-3.5" />
+          </Button>
+        </>
+      )}
+    </div>
+  );
+}
+
+function DropZone({ zone, enabled, onDropPanel, children }: { zone: WorkbenchZoneId; enabled: boolean; onDropPanel: (panelId: string) => void; children: ReactNode }) {
+  const [over, setOver] = useState(false);
+  return (
+    <div
+      className={cn('h-full w-full', over && 'outline outline-2 outline-primary outline-offset-[-2px]')}
+      onDragOver={(event) => {
+        if (!enabled || !event.dataTransfer.types.includes('application/x-ifc-lite-panel')) return;
+        event.preventDefault();
+        setOver(true);
+      }}
+      onDragLeave={() => setOver(false)}
+      onDrop={(event) => {
+        setOver(false);
+        const panelId = event.dataTransfer.getData('application/x-ifc-lite-panel');
+        if (enabled && panelId) onDropPanel(panelId);
+      }}
+      aria-label={`${ZONE_LABEL[zone]} drop zone`}
+    >
+      {children}
+    </div>
+  );
+}
+
+function useLegacyPanelSync() {
+  const bcf = useViewerStore((s) => s.bcfPanelVisible);
+  const ids = useViewerStore((s) => s.idsPanelVisible);
+  const lens = useViewerStore((s) => s.lensPanelVisible);
+  const extensions = useViewerStore((s) => s.extensionsPanelVisible);
+  const lists = useViewerStore((s) => s.listPanelVisible);
+  const script = useViewerStore((s) => s.scriptPanelVisible);
+  const gantt = useViewerStore((s) => s.ganttPanelVisible);
+  const addElement = useViewerStore((s) => s.activeTool === 'addElement');
+  const open = useViewerStore((s) => s.openWorkbenchPanel);
+  useEffect(() => {
+    if (bcf) open(BUILTIN_PANEL_IDS.bcf);
+    if (ids) open(BUILTIN_PANEL_IDS.ids);
+    if (lens) open(BUILTIN_PANEL_IDS.lens);
+    if (extensions) open(BUILTIN_PANEL_IDS.extensions);
+    if (lists) open(BUILTIN_PANEL_IDS.lists);
+    if (script) open(BUILTIN_PANEL_IDS.script);
+    if (gantt) open(BUILTIN_PANEL_IDS.gantt);
+    if (addElement) open(BUILTIN_PANEL_IDS.addElement);
+  }, [addElement, bcf, extensions, gantt, ids, lens, lists, open, script]);
+}
+
+function useClosePanel(panelId: string, zone: WorkbenchZoneId): () => void {
+  return useCallback(() => {
+    const state = useViewerStore.getState();
+    if (panelId === BUILTIN_PANEL_IDS.bcf) state.setBcfPanelVisible(false);
+    if (panelId === BUILTIN_PANEL_IDS.ids) state.setIdsPanelVisible(false);
+    if (panelId === BUILTIN_PANEL_IDS.lens) state.setLensPanelVisible(false);
+    if (panelId === BUILTIN_PANEL_IDS.extensions) state.setExtensionsPanelVisible(false);
+    if (panelId === BUILTIN_PANEL_IDS.lists) state.setListPanelVisible(false);
+    if (panelId === BUILTIN_PANEL_IDS.script) state.setScriptPanelVisible(false);
+    if (panelId === BUILTIN_PANEL_IDS.gantt) state.setGanttPanelVisible(false);
+    if (panelId === BUILTIN_PANEL_IDS.addElement) state.setActiveTool('select');
+    state.setWorkbenchActiveTab(zone, zone === 'right' ? BUILTIN_PANEL_IDS.properties : undefined);
+  }, [panelId, zone]);
+}
+
+function usePanelTitle(panelId: string): string {
+  return useViewerStore((s) => {
+    const chromeTitle = s.workbenchLayout.panelChrome[panelId]?.title;
+    if (chromeTitle) return chromeTitle;
+    const personal = s.workbenchLayout.personalPanels[panelId];
+    if (personal) return personal.title;
+    return BUILTIN_TITLES[panelId] ?? panelId;
+  });
+}
+
+function usePersonalWidgetContext(): WidgetRendererContext {
+  const host = useOptionalExtensionHost();
+  return useMemo(() => ({
+    state: {},
+    invokeCommand: (commandId: string) => {
+      host?.runCommand(commandId).catch((err) => {
+        console.warn('[WorkbenchDesktopLayout] personal panel command failed:', err);
+      });
+    },
+  }), [host]);
+}
+
+function useAutoPersistLayout() {
+  const layout = useViewerStore((s) => s.workbenchLayout);
+  const host = useOptionalExtensionHost();
+  const lastSavedRef = useRef('');
+  useEffect(() => {
+    if (!host) return;
+    const serialized = JSON.stringify(layout);
+    if (serialized === lastSavedRef.current) return;
+    const handle = window.setTimeout(() => {
+      void (async () => {
+        const active = await host.flavors.getActive();
+        if (!active) return;
+        lastSavedRef.current = serialized;
+        await host.flavors.put({
+          ...active,
+          layout: { state: layout },
+          updatedAt: new Date().toISOString(),
+        }, 'layout morph');
+      })().catch((err) => {
+        console.warn('[WorkbenchDesktopLayout] layout persistence failed:', err);
+      });
+    }, 600);
+    return () => window.clearTimeout(handle);
+  }, [host, layout]);
+}
+
+function useBottomResize(
+  containerRef: RefObject<HTMLDivElement | null>,
+  bottomHeight: number,
+  setBottomHeight: (height: number) => void,
+): (event: ReactMouseEvent) => void {
+  return useCallback((event) => {
+    event.preventDefault();
+    const startY = event.clientY;
+    const startHeight = bottomHeight;
+    const onMouseMove = (moveEvent: MouseEvent) => {
+      const container = containerRef.current;
+      if (!container) return;
+      const maxHeight = container.clientHeight * BOTTOM_PANEL_MAX_RATIO;
+      const delta = startY - moveEvent.clientY;
+      setBottomHeight(Math.min(maxHeight, Math.max(BOTTOM_PANEL_MIN_HEIGHT, startHeight + delta)));
+    };
+    const cleanup = () => {
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', cleanup);
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+    };
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', cleanup);
+    document.body.style.cursor = 'row-resize';
+    document.body.style.userSelect = 'none';
+  }, [bottomHeight, containerRef, setBottomHeight]);
+}
+
+function EmptyZone({ zone }: { zone: WorkbenchZoneId }) {
+  return <div className="p-4 text-xs text-muted-foreground">Drop a panel into the {ZONE_LABEL[zone].toLowerCase()}.</div>;
+}
+
+function EmptyPanel({ panelId }: { panelId: string }) {
+  return (
+    <div className="flex h-full items-center justify-center p-4 text-xs text-muted-foreground">
+      <X className="mr-2 h-4 w-4" />
+      Panel unavailable: {panelId}
+    </div>
+  );
+}
+
+const BUILTIN_TITLES: Record<string, string> = {
+  [BUILTIN_PANEL_IDS.hierarchy]: 'Hierarchy',
+  [BUILTIN_PANEL_IDS.properties]: 'Properties',
+  [BUILTIN_PANEL_IDS.bcf]: 'BCF',
+  [BUILTIN_PANEL_IDS.ids]: 'IDS',
+  [BUILTIN_PANEL_IDS.lens]: 'Lens',
+  [BUILTIN_PANEL_IDS.extensions]: 'Extensions',
+  [BUILTIN_PANEL_IDS.addElement]: 'Add element',
+  [BUILTIN_PANEL_IDS.lists]: 'Lists',
+  [BUILTIN_PANEL_IDS.script]: 'Script',
+  [BUILTIN_PANEL_IDS.gantt]: 'Schedule',
+};

--- a/apps/viewer/src/components/workbench/WorkbenchDesktopLayout.tsx
+++ b/apps/viewer/src/components/workbench/WorkbenchDesktopLayout.tsx
@@ -2,33 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { useCallback, useEffect, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent, type ReactNode, type RefObject } from 'react';
+import { useCallback, useEffect, useRef, useState, type MouseEvent as ReactMouseEvent, type ReactNode, type RefObject } from 'react';
 import { Panel, Group as PanelGroup, Separator as PanelResizeHandle } from 'react-resizable-panels';
 import type { PanelImperativeHandle } from 'react-resizable-panels';
-import { GripVertical, LayoutDashboard, Plus, RotateCcw, X } from 'lucide-react';
+import { EyeOff, GripVertical, Pencil } from 'lucide-react';
 import {
   BUILTIN_PANEL_IDS,
   type WorkbenchPanelId,
   type WorkbenchZoneId,
 } from '@ifc-lite/extensions';
-import { Button } from '@/components/ui/button';
-import { ScrollArea } from '@/components/ui/scroll-area';
 import { toast } from '@/components/ui/toast';
 import { cn } from '@/lib/utils';
 import { useViewerStore } from '@/store';
-import { AddElementPanel } from '@/components/viewer/AddElementPanel';
-import { BCFPanel } from '@/components/viewer/BCFPanel';
-import { ExtensionsPanel } from '@/components/extensions/ExtensionsPanel';
-import { GanttPanel } from '@/components/viewer/schedule/GanttPanel';
-import { HierarchyPanel } from '@/components/viewer/HierarchyPanel';
-import { IDSPanel } from '@/components/viewer/IDSPanel';
-import { LensPanel } from '@/components/viewer/LensPanel';
-import { ListPanel } from '@/components/viewer/lists/ListPanel';
-import { PropertiesPanel } from '@/components/viewer/PropertiesPanel';
-import { ScriptPanel } from '@/components/viewer/ScriptPanel';
 import { ViewportContainer } from '@/components/viewer/ViewportContainer';
 import { ExtensionDockHost } from '@/components/extensions/ExtensionDockHost';
-import { WidgetRenderer, type WidgetRendererContext } from '@/components/extensions/widget/WidgetRenderer';
 import { useOptionalExtensionHost } from '@/sdk/ExtensionHostProvider';
 import {
   closeActiveAnalysisExtension,
@@ -36,8 +23,12 @@ import {
   getAnalysisExtensionsSnapshot,
 } from '@/services/analysis-extensions';
 import { PersonalPanelDialog } from './PersonalPanelDialog';
+import { PanelChromeDialog } from './PanelChromeDialog';
+import { PanelLibraryDialog } from './PanelLibraryDialog';
+import { MorphToolbar } from './MorphToolbar';
+import { getWorkbenchPanelTitle, ZONE_LABEL } from './panelRegistry';
+import { WorkbenchPanelHost } from './WorkbenchPanelHost';
 
-const ZONE_LABEL: Record<WorkbenchZoneId, string> = { left: 'Left dock', right: 'Right dock', bottom: 'Bottom dock' };
 const BOTTOM_PANEL_MIN_HEIGHT = 120;
 const BOTTOM_PANEL_MAX_RATIO = 0.7;
 
@@ -54,6 +45,8 @@ export function WorkbenchDesktopLayout({ analysisExtensionState }: WorkbenchDesk
   const setCollapsed = useViewerStore((s) => s.setWorkbenchCollapsed);
   const resetLayout = useViewerStore((s) => s.resetWorkbenchLayout);
   const [personalOpen, setPersonalOpen] = useState(false);
+  const [libraryOpen, setLibraryOpen] = useState(false);
+  const [editingPanelId, setEditingPanelId] = useState<string | null>(null);
   const leftPanelRef = useRef<PanelImperativeHandle>(null);
   const rightPanelRef = useRef<PanelImperativeHandle>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -90,6 +83,7 @@ export function WorkbenchDesktopLayout({ analysisExtensionState }: WorkbenchDesk
         enabled={morphMode}
         onToggle={() => setMorphMode(!morphMode)}
         onAddPanel={() => setPersonalOpen(true)}
+        onLibrary={() => setLibraryOpen(true)}
         onReset={() => {
           resetLayout();
           toast.success('Layout reset to IFC Lite default.');
@@ -158,6 +152,15 @@ export function WorkbenchDesktopLayout({ analysisExtensionState }: WorkbenchDesk
         <ExtensionDockHost slot="dock.bottom" />
       </div>
       <PersonalPanelDialog open={personalOpen} onClose={() => setPersonalOpen(false)} />
+      <PanelLibraryDialog
+        open={libraryOpen}
+        onClose={() => setLibraryOpen(false)}
+        onEdit={(panelId) => {
+          setLibraryOpen(false);
+          setEditingPanelId(panelId);
+        }}
+      />
+      <PanelChromeDialog panelId={editingPanelId} onClose={() => setEditingPanelId(null)} />
     </div>
   );
 }
@@ -190,7 +193,7 @@ function WorkbenchZone({ zone, morphMode }: { zone: WorkbenchZoneId; morphMode: 
           )}
         </div>
         <div className="flex-1 min-h-0 overflow-hidden">
-          {activePanel ? <WorkbenchPanel panelId={activePanel} zone={zone} /> : <EmptyZone zone={zone} />}
+          {activePanel ? <WorkbenchPanelHost panelId={activePanel} zone={zone} /> : <EmptyZone zone={zone} />}
         </div>
         {zone !== 'bottom' && <ExtensionDockHost slot={zone === 'left' ? 'dock.left' : 'dock.right'} className="max-h-[35%] border-t" />}
       </div>
@@ -198,71 +201,55 @@ function WorkbenchZone({ zone, morphMode }: { zone: WorkbenchZoneId; morphMode: 
   );
 }
 
-function PanelTab({ panelId, active, morphMode, onClick }: { panelId: string; active: boolean; morphMode: boolean; onClick: () => void }) {
+function PanelTab({
+  panelId,
+  active,
+  morphMode,
+  onClick,
+}: {
+  panelId: string;
+  active: boolean;
+  morphMode: boolean;
+  onClick: () => void;
+}) {
   const title = usePanelTitle(panelId);
+  const setChrome = useViewerStore((s) => s.setWorkbenchPanelChrome);
+  const [editingPanelId, setEditingPanelId] = useWorkbenchPanelEditor();
   return (
-    <button
-      type="button"
+    <div
       draggable={morphMode}
       onDragStart={(event) => event.dataTransfer.setData('application/x-ifc-lite-panel', panelId)}
-      onClick={onClick}
       className={cn(
         'shrink-0 flex items-center gap-1 px-2.5 py-1.5 text-xs border-b-2 transition-colors',
         active ? 'border-primary text-primary' : 'border-transparent text-muted-foreground hover:text-foreground',
       )}
       title={morphMode ? `Drag ${title} to another dock` : title}
     >
-      {morphMode && <GripVertical className="h-3 w-3" />}
-      {title}
-    </button>
-  );
-}
-
-function WorkbenchPanel({ panelId, zone }: { panelId: string; zone: WorkbenchZoneId }) {
-  const closePanel = useClosePanel(panelId, zone);
-  const personal = useViewerStore((s) => s.workbenchLayout.personalPanels[panelId]);
-  const ctx = usePersonalWidgetContext();
-  if (personal) {
-    return (
-      <ScrollArea className="h-full">
-        <div className="p-3">
-          <WidgetRenderer node={personal.widget as unknown as Parameters<typeof WidgetRenderer>[0]['node']} ctx={ctx} />
-        </div>
-      </ScrollArea>
-    );
-  }
-  switch (panelId) {
-    case BUILTIN_PANEL_IDS.hierarchy: return <HierarchyPanel />;
-    case BUILTIN_PANEL_IDS.properties: return <PropertiesPanel />;
-    case BUILTIN_PANEL_IDS.bcf: return <BCFPanel onClose={closePanel} />;
-    case BUILTIN_PANEL_IDS.ids: return <IDSPanel onClose={closePanel} />;
-    case BUILTIN_PANEL_IDS.lens: return <LensPanel onClose={closePanel} />;
-    case BUILTIN_PANEL_IDS.extensions: return <ExtensionsPanel onClose={closePanel} />;
-    case BUILTIN_PANEL_IDS.addElement: return <AddElementPanel onClose={closePanel} />;
-    case BUILTIN_PANEL_IDS.lists: return <ListPanel onClose={closePanel} />;
-    case BUILTIN_PANEL_IDS.script: return <ScriptPanel onClose={closePanel} />;
-    case BUILTIN_PANEL_IDS.gantt: return <GanttPanel onClose={closePanel} />;
-    default: return <EmptyPanel panelId={panelId} />;
-  }
-}
-
-function MorphToolbar({ enabled, onToggle, onAddPanel, onReset }: { enabled: boolean; onToggle: () => void; onAddPanel: () => void; onReset: () => void }) {
-  return (
-    <div className="absolute right-3 top-3 z-20 flex items-center gap-1 rounded border bg-background/90 p-1 shadow-sm backdrop-blur">
-      <Button type="button" size="sm" variant={enabled ? 'default' : 'secondary'} onClick={onToggle}>
-        <LayoutDashboard className="mr-1 h-3.5 w-3.5" />
-        {enabled ? 'Morphing' : 'Morph UI'}
-      </Button>
-      {enabled && (
+      <button type="button" className="flex items-center gap-1" onClick={onClick}>
+        {morphMode && <GripVertical className="h-3 w-3" />}
+        {title}
+      </button>
+      {morphMode && (
         <>
-          <Button type="button" size="icon-sm" variant="ghost" onClick={onAddPanel} aria-label="Add personal panel">
-            <Plus className="h-3.5 w-3.5" />
-          </Button>
-          <Button type="button" size="icon-sm" variant="ghost" onClick={onReset} aria-label="Reset layout">
-            <RotateCcw className="h-3.5 w-3.5" />
-          </Button>
+          <button
+            type="button"
+            className="ml-1 rounded p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+            aria-label={`Edit ${title}`}
+            onClick={() => setEditingPanelId(panelId)}
+          >
+            <Pencil className="h-3 w-3" />
+          </button>
+          <button
+            type="button"
+            className="rounded p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+            aria-label={`Hide ${title}`}
+            onClick={() => setChrome(panelId, { hidden: true })}
+          >
+            <EyeOff className="h-3 w-3" />
+          </button>
         </>
       )}
+      <PanelChromeDialog panelId={editingPanelId} onClose={() => setEditingPanelId(null)} />
     </div>
   );
 }
@@ -312,41 +299,14 @@ function useLegacyPanelSync() {
   }, [addElement, bcf, extensions, gantt, ids, lens, lists, open, script]);
 }
 
-function useClosePanel(panelId: string, zone: WorkbenchZoneId): () => void {
-  return useCallback(() => {
-    const state = useViewerStore.getState();
-    if (panelId === BUILTIN_PANEL_IDS.bcf) state.setBcfPanelVisible(false);
-    if (panelId === BUILTIN_PANEL_IDS.ids) state.setIdsPanelVisible(false);
-    if (panelId === BUILTIN_PANEL_IDS.lens) state.setLensPanelVisible(false);
-    if (panelId === BUILTIN_PANEL_IDS.extensions) state.setExtensionsPanelVisible(false);
-    if (panelId === BUILTIN_PANEL_IDS.lists) state.setListPanelVisible(false);
-    if (panelId === BUILTIN_PANEL_IDS.script) state.setScriptPanelVisible(false);
-    if (panelId === BUILTIN_PANEL_IDS.gantt) state.setGanttPanelVisible(false);
-    if (panelId === BUILTIN_PANEL_IDS.addElement) state.setActiveTool('select');
-    state.setWorkbenchActiveTab(zone, zone === 'right' ? BUILTIN_PANEL_IDS.properties : undefined);
-  }, [panelId, zone]);
-}
-
 function usePanelTitle(panelId: string): string {
   return useViewerStore((s) => {
-    const chromeTitle = s.workbenchLayout.panelChrome[panelId]?.title;
-    if (chromeTitle) return chromeTitle;
-    const personal = s.workbenchLayout.personalPanels[panelId];
-    if (personal) return personal.title;
-    return BUILTIN_TITLES[panelId] ?? panelId;
+    return getWorkbenchPanelTitle(s.workbenchLayout, panelId);
   });
 }
 
-function usePersonalWidgetContext(): WidgetRendererContext {
-  const host = useOptionalExtensionHost();
-  return useMemo(() => ({
-    state: {},
-    invokeCommand: (commandId: string) => {
-      host?.runCommand(commandId).catch((err) => {
-        console.warn('[WorkbenchDesktopLayout] personal panel command failed:', err);
-      });
-    },
-  }), [host]);
+function useWorkbenchPanelEditor(): [string | null, (panelId: string | null) => void] {
+  return useState<string | null>(null);
 }
 
 function useAutoPersistLayout() {
@@ -408,24 +368,4 @@ function EmptyZone({ zone }: { zone: WorkbenchZoneId }) {
   return <div className="p-4 text-xs text-muted-foreground">Drop a panel into the {ZONE_LABEL[zone].toLowerCase()}.</div>;
 }
 
-function EmptyPanel({ panelId }: { panelId: string }) {
-  return (
-    <div className="flex h-full items-center justify-center p-4 text-xs text-muted-foreground">
-      <X className="mr-2 h-4 w-4" />
-      Panel unavailable: {panelId}
-    </div>
-  );
-}
 
-const BUILTIN_TITLES: Record<string, string> = {
-  [BUILTIN_PANEL_IDS.hierarchy]: 'Hierarchy',
-  [BUILTIN_PANEL_IDS.properties]: 'Properties',
-  [BUILTIN_PANEL_IDS.bcf]: 'BCF',
-  [BUILTIN_PANEL_IDS.ids]: 'IDS',
-  [BUILTIN_PANEL_IDS.lens]: 'Lens',
-  [BUILTIN_PANEL_IDS.extensions]: 'Extensions',
-  [BUILTIN_PANEL_IDS.addElement]: 'Add element',
-  [BUILTIN_PANEL_IDS.lists]: 'Lists',
-  [BUILTIN_PANEL_IDS.script]: 'Script',
-  [BUILTIN_PANEL_IDS.gantt]: 'Schedule',
-};

--- a/apps/viewer/src/components/workbench/WorkbenchDesktopLayout.tsx
+++ b/apps/viewer/src/components/workbench/WorkbenchDesktopLayout.tsx
@@ -99,8 +99,13 @@ export function WorkbenchDesktopLayout({ analysisExtensionState }: WorkbenchDesk
         <PanelGroup
           orientation="horizontal"
           className="h-full"
-          onLayout={(sizes) => {
-            if (sizes.length === 3) setSizes([sizes[0], sizes[1], sizes[2]]);
+          onLayoutChanged={(sizes) => {
+            const left = sizes['left-panel'];
+            const viewport = sizes['viewport-panel'];
+            const right = sizes['right-panel'];
+            if (left !== undefined && viewport !== undefined && right !== undefined) {
+              setSizes([left, viewport, right]);
+            }
           }}
         >
           <Panel
@@ -221,7 +226,7 @@ function WorkbenchPanel({ panelId, zone }: { panelId: string; zone: WorkbenchZon
     return (
       <ScrollArea className="h-full">
         <div className="p-3">
-          <WidgetRenderer node={personal.widget as Parameters<typeof WidgetRenderer>[0]['node']} ctx={ctx} />
+          <WidgetRenderer node={personal.widget as unknown as Parameters<typeof WidgetRenderer>[0]['node']} ctx={ctx} />
         </div>
       </ScrollArea>
     );

--- a/apps/viewer/src/components/workbench/WorkbenchDesktopLayout.tsx
+++ b/apps/viewer/src/components/workbench/WorkbenchDesktopLayout.tsx
@@ -32,6 +32,7 @@ import { WorkspaceModesDialog } from './WorkspaceModesDialog';
 import { firePanelOpenedAutomation, useWorkbenchAutomations } from '@/hooks/useWorkbenchAutomations';
 import { WorkbenchFloatingPanels } from './WorkbenchFloatingPanels';
 import { WorkbenchPatchDialog } from './WorkbenchPatchDialog';
+import { CustomizationStudioDialog } from './CustomizationStudioDialog';
 
 const BOTTOM_PANEL_MIN_HEIGHT = 120;
 const BOTTOM_PANEL_MAX_RATIO = 0.7;
@@ -51,6 +52,7 @@ export function WorkbenchDesktopLayout({ analysisExtensionState }: WorkbenchDesk
   const [personalOpen, setPersonalOpen] = useState(false);
   const [libraryOpen, setLibraryOpen] = useState(false);
   const [modesOpen, setModesOpen] = useState(false);
+  const [studioOpen, setStudioOpen] = useState(false);
   const [editingPanelId, setEditingPanelId] = useState<string | null>(null);
   const leftPanelRef = useRef<PanelImperativeHandle>(null);
   const rightPanelRef = useRef<PanelImperativeHandle>(null);
@@ -66,6 +68,12 @@ export function WorkbenchDesktopLayout({ analysisExtensionState }: WorkbenchDesk
   useLegacyPanelSync();
   useAutoPersistLayout();
   useWorkbenchAutomations();
+
+  useEffect(() => {
+    const openStudio = () => setStudioOpen(true);
+    window.addEventListener('ifc-lite:open-customization-studio', openStudio);
+    return () => window.removeEventListener('ifc-lite:open-customization-studio', openStudio);
+  }, []);
 
   useEffect(() => {
     const panel = leftPanelRef.current;
@@ -91,6 +99,7 @@ export function WorkbenchDesktopLayout({ analysisExtensionState }: WorkbenchDesk
         onAddPanel={() => setPersonalOpen(true)}
         onLibrary={() => setLibraryOpen(true)}
         onModes={() => setModesOpen(true)}
+        onStudio={() => setStudioOpen(true)}
         onReset={() => {
           resetLayout();
           toast.success('Layout reset to IFC Lite default.');
@@ -169,6 +178,7 @@ export function WorkbenchDesktopLayout({ analysisExtensionState }: WorkbenchDesk
       />
       <PanelChromeDialog panelId={editingPanelId} onClose={() => setEditingPanelId(null)} />
       <WorkspaceModesDialog open={modesOpen} onClose={() => setModesOpen(false)} />
+      <CustomizationStudioDialog open={studioOpen} onClose={() => setStudioOpen(false)} />
       <WorkbenchFloatingPanels />
       <WorkbenchPatchDialog />
     </div>

--- a/apps/viewer/src/components/workbench/WorkbenchDesktopLayout.tsx
+++ b/apps/viewer/src/components/workbench/WorkbenchDesktopLayout.tsx
@@ -5,7 +5,7 @@
 import { useCallback, useEffect, useRef, useState, type MouseEvent as ReactMouseEvent, type ReactNode, type RefObject } from 'react';
 import { Panel, Group as PanelGroup, Separator as PanelResizeHandle } from 'react-resizable-panels';
 import type { PanelImperativeHandle } from 'react-resizable-panels';
-import { EyeOff, GripVertical, Pencil } from 'lucide-react';
+import { EyeOff, GripVertical, Maximize2, Pencil } from 'lucide-react';
 import {
   BUILTIN_PANEL_IDS,
   type WorkbenchPanelId,
@@ -30,6 +30,8 @@ import { getWorkbenchPanelTitle, ZONE_LABEL } from './panelRegistry';
 import { WorkbenchPanelHost } from './WorkbenchPanelHost';
 import { WorkspaceModesDialog } from './WorkspaceModesDialog';
 import { firePanelOpenedAutomation, useWorkbenchAutomations } from '@/hooks/useWorkbenchAutomations';
+import { WorkbenchFloatingPanels } from './WorkbenchFloatingPanels';
+import { WorkbenchPatchDialog } from './WorkbenchPatchDialog';
 
 const BOTTOM_PANEL_MIN_HEIGHT = 120;
 const BOTTOM_PANEL_MAX_RATIO = 0.7;
@@ -167,6 +169,8 @@ export function WorkbenchDesktopLayout({ analysisExtensionState }: WorkbenchDesk
       />
       <PanelChromeDialog panelId={editingPanelId} onClose={() => setEditingPanelId(null)} />
       <WorkspaceModesDialog open={modesOpen} onClose={() => setModesOpen(false)} />
+      <WorkbenchFloatingPanels />
+      <WorkbenchPatchDialog />
     </div>
   );
 }
@@ -223,6 +227,7 @@ function PanelTab({
 }) {
   const title = usePanelTitle(panelId);
   const setChrome = useViewerStore((s) => s.setWorkbenchPanelChrome);
+  const setFloating = useViewerStore((s) => s.setWorkbenchFloatingPanel);
   const [editingPanelId, setEditingPanelId] = useWorkbenchPanelEditor();
   return (
     <div
@@ -247,6 +252,17 @@ function PanelTab({
             onClick={() => setEditingPanelId(panelId)}
           >
             <Pencil className="h-3 w-3" />
+          </button>
+          <button
+            type="button"
+            className="rounded p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+            aria-label={`Float ${title}`}
+            onClick={() => {
+              setFloating({ panelId, x: 96, y: 96, width: 420, height: 520 });
+              setChrome(panelId, { hidden: true });
+            }}
+          >
+            <Maximize2 className="h-3 w-3" />
           </button>
           <button
             type="button"

--- a/apps/viewer/src/components/workbench/WorkbenchFloatingPanels.tsx
+++ b/apps/viewer/src/components/workbench/WorkbenchFloatingPanels.tsx
@@ -1,0 +1,107 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { useCallback, useState, type MouseEvent as ReactMouseEvent } from 'react';
+import { Dock, GripHorizontal, X } from 'lucide-react';
+import type { FloatingPanelPlacement } from '@ifc-lite/extensions';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { useViewerStore } from '@/store';
+import { getWorkbenchPanelTitle } from './panelRegistry';
+import { WorkbenchPanelHost } from './WorkbenchPanelHost';
+
+export function WorkbenchFloatingPanels() {
+  const placements = useViewerStore((s) => s.workbenchLayout.floating);
+  if (placements.length === 0) return null;
+  return (
+    <>
+      {placements.map((placement) => (
+        <FloatingPanelWindow key={placement.panelId} placement={placement} />
+      ))}
+    </>
+  );
+}
+
+function FloatingPanelWindow({ placement }: { placement: FloatingPanelPlacement }) {
+  const layout = useViewerStore((s) => s.workbenchLayout);
+  const setFloating = useViewerStore((s) => s.setWorkbenchFloatingPanel);
+  const removeFloating = useViewerStore((s) => s.removeWorkbenchFloatingPanel);
+  const movePanel = useViewerStore((s) => s.moveWorkbenchPanel);
+  const setChrome = useViewerStore((s) => s.setWorkbenchPanelChrome);
+  const title = getWorkbenchPanelTitle(layout, placement.panelId);
+  const [dragging, setDragging] = useState(false);
+
+  const startDrag = useCallback((event: ReactMouseEvent) => {
+    event.preventDefault();
+    setDragging(true);
+    const startX = event.clientX;
+    const startY = event.clientY;
+    const initial = placement;
+    const onMouseMove = (move: MouseEvent) => {
+      setFloating({
+        ...initial,
+        x: Math.max(0, initial.x + move.clientX - startX),
+        y: Math.max(48, initial.y + move.clientY - startY),
+      });
+    };
+    const cleanup = () => {
+      setDragging(false);
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', cleanup);
+      document.body.style.userSelect = '';
+    };
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', cleanup);
+    document.body.style.userSelect = 'none';
+  }, [placement, setFloating]);
+
+  return (
+    <div
+      className={cn(
+        'absolute z-40 flex flex-col overflow-hidden rounded-md border bg-background shadow-2xl',
+        dragging && 'ring-2 ring-primary',
+      )}
+      style={{
+        left: placement.x,
+        top: placement.y,
+        width: placement.width,
+        height: placement.height,
+      }}
+      role="dialog"
+      aria-label={`Floating panel ${title}`}
+    >
+      <div className="flex items-center gap-2 border-b bg-muted/50 px-2 py-1.5 text-xs">
+        <button type="button" className="cursor-move text-muted-foreground" onMouseDown={startDrag} aria-label={`Move ${title}`}>
+          <GripHorizontal className="h-4 w-4" />
+        </button>
+        <span className="min-w-0 flex-1 truncate font-medium">{title}</span>
+        <Button
+          type="button"
+          size="icon-sm"
+          variant="ghost"
+          aria-label="Dock floating panel"
+          onClick={() => {
+            removeFloating(placement.panelId);
+            setChrome(placement.panelId, { hidden: false });
+            movePanel(placement.panelId, 'right');
+          }}
+        >
+          <Dock className="h-3.5 w-3.5" />
+        </Button>
+        <Button
+          type="button"
+          size="icon-sm"
+          variant="ghost"
+          aria-label="Close floating panel"
+          onClick={() => removeFloating(placement.panelId)}
+        >
+          <X className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+      <div className="min-h-0 flex-1 overflow-hidden">
+        <WorkbenchPanelHost panelId={placement.panelId} zone="right" />
+      </div>
+    </div>
+  );
+}

--- a/apps/viewer/src/components/workbench/WorkbenchMergePreviewPanel.tsx
+++ b/apps/viewer/src/components/workbench/WorkbenchMergePreviewPanel.tsx
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { createDefaultWorkbenchLayout, mergeWorkbenchLayouts, type WorkbenchLayoutState, type WorkbenchZoneId } from '@ifc-lite/extensions';
+import { useViewerStore } from '@/store';
+import { ZONE_LABEL } from './panelRegistry';
+
+export function WorkbenchMergePreviewPanel() {
+  const ours = useViewerStore((s) => s.workbenchLayout);
+  const base = createDefaultWorkbenchLayout();
+  const theirs = createDefaultWorkbenchLayout();
+  theirs.zones.bottom = ['builtin:panel:ids', ...theirs.zones.bottom.filter((id) => id !== 'builtin:panel:ids')];
+  theirs.zones.right = theirs.zones.right.filter((id) => id !== 'builtin:panel:ids');
+  const result = mergeWorkbenchLayouts(base, theirs, ours);
+  return (
+    <div className="space-y-3">
+      <div className="grid gap-3 md:grid-cols-3">
+        <LayoutColumn title="Mine" layout={ours} />
+        <LayoutColumn title="Incoming example" layout={theirs} />
+        <LayoutColumn title="Merged preview" layout={result.merged} />
+      </div>
+      <div className="rounded border p-3">
+        <div className="font-medium">Conflicts</div>
+        {result.conflicts.length === 0 ? (
+          <div className="mt-1 text-sm text-muted-foreground">No conflicts in this preview.</div>
+        ) : result.conflicts.map((conflict) => (
+          <div key={`${conflict.kind}:${conflict.key}`} className="mt-2 rounded bg-muted/30 p-2 text-xs">
+            {conflict.kind}: {conflict.key}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function LayoutColumn({ title, layout }: { title: string; layout: WorkbenchLayoutState }) {
+  return (
+    <div className="rounded border p-3">
+      <div className="font-medium">{title}</div>
+      {(['left', 'right', 'bottom'] as WorkbenchZoneId[]).map((zone) => (
+        <div key={zone} className="mt-2">
+          <div className="text-[10px] uppercase tracking-wide text-muted-foreground">{ZONE_LABEL[zone]}</div>
+          <div className="mt-1 space-y-1">
+            {layout.zones[zone].map((panelId) => (
+              <div key={panelId} className="rounded bg-muted/40 px-2 py-1 text-xs truncate">{panelId}</div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/viewer/src/components/workbench/WorkbenchPanelHost.tsx
+++ b/apps/viewer/src/components/workbench/WorkbenchPanelHost.tsx
@@ -2,9 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { X } from 'lucide-react';
-import { BUILTIN_PANEL_IDS, type WorkbenchZoneId } from '@ifc-lite/extensions';
+import { BUILTIN_PANEL_IDS, validateWidget, type PanelContribution, type SlotContribution, type WorkbenchZoneId } from '@ifc-lite/extensions';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { AddElementPanel } from '@/components/viewer/AddElementPanel';
 import { BCFPanel } from '@/components/viewer/BCFPanel';
@@ -17,12 +17,15 @@ import { ListPanel } from '@/components/viewer/lists/ListPanel';
 import { PropertiesPanel } from '@/components/viewer/PropertiesPanel';
 import { ScriptPanel } from '@/components/viewer/ScriptPanel';
 import { WidgetRenderer, type WidgetRendererContext } from '@/components/extensions/widget/WidgetRenderer';
+import { useSlotContributions } from '@/hooks/useSlotContributions';
 import { useOptionalExtensionHost } from '@/sdk/ExtensionHostProvider';
 import { useViewerStore } from '@/store';
+import { parseExtensionPanelWorkbenchId } from './panelRegistry';
 
 export function WorkbenchPanelHost({ panelId, zone }: { panelId: string; zone: WorkbenchZoneId }) {
   const closePanel = useClosePanel(panelId, zone);
   const personal = useViewerStore((s) => s.workbenchLayout.personalPanels[panelId]);
+  const extensionPanels = useSlotContributions<PanelContribution>('workbench.panels');
   const ctx = usePersonalWidgetContext();
   if (personal) {
     return (
@@ -32,6 +35,14 @@ export function WorkbenchPanelHost({ panelId, zone }: { panelId: string; zone: W
         </div>
       </ScrollArea>
     );
+  }
+  const parsedExtensionPanel = parseExtensionPanelWorkbenchId(panelId);
+  if (parsedExtensionPanel) {
+    const contribution = extensionPanels.find((entry) =>
+      entry.extensionId === parsedExtensionPanel.extensionId
+      && entry.payload.id === parsedExtensionPanel.panelId,
+    );
+    return contribution ? <ExtensionWorkbenchPanel contribution={contribution} ctx={ctx} /> : <EmptyPanel panelId={panelId} />;
   }
   switch (panelId) {
     case BUILTIN_PANEL_IDS.hierarchy: return <HierarchyPanel />;
@@ -46,6 +57,50 @@ export function WorkbenchPanelHost({ panelId, zone }: { panelId: string; zone: W
     case BUILTIN_PANEL_IDS.gantt: return <GanttPanel onClose={closePanel} />;
     default: return <EmptyPanel panelId={panelId} />;
   }
+}
+
+function ExtensionWorkbenchPanel({
+  contribution,
+  ctx,
+}: {
+  contribution: SlotContribution<PanelContribution>;
+  ctx: WidgetRendererContext;
+}) {
+  const host = useOptionalExtensionHost();
+  const [state, setState] = useState<{ widget?: Parameters<typeof WidgetRenderer>[0]['node']; error?: string }>({});
+  useEffect(() => {
+    let cancelled = false;
+    try {
+      const bundle = host?.loader.getBundle(contribution.extensionId);
+      const file = bundle?.files.get(contribution.payload.widget);
+      if (!file) {
+        setState({ error: `Widget ${contribution.payload.widget} not found.` });
+        return;
+      }
+      const text = file.text ?? new TextDecoder().decode(file.bytes);
+      const json = JSON.parse(text);
+      const validated = validateWidget(json, contribution.payload.widget);
+      if (!validated.ok) {
+        const first = validated.errors[0];
+        setState({ error: `${first?.path ?? 'widget'} ${first?.message ?? 'failed validation'}` });
+        return;
+      }
+      if (!cancelled) setState({ widget: validated.value });
+    } catch (err) {
+      if (!cancelled) setState({ error: err instanceof Error ? err.message : String(err) });
+    }
+    return () => { cancelled = true; };
+  }, [contribution, host]);
+
+  if (state.error) return <div className="p-3 text-xs text-destructive">{state.error}</div>;
+  if (!state.widget) return <div className="p-3 text-xs text-muted-foreground">Loading extension panel...</div>;
+  return (
+    <ScrollArea className="h-full">
+      <div className="p-3">
+        <WidgetRenderer node={state.widget} ctx={ctx} />
+      </div>
+    </ScrollArea>
+  );
 }
 
 function useClosePanel(panelId: string, zone: WorkbenchZoneId): () => void {

--- a/apps/viewer/src/components/workbench/WorkbenchPanelHost.tsx
+++ b/apps/viewer/src/components/workbench/WorkbenchPanelHost.tsx
@@ -1,0 +1,85 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { useCallback, useMemo } from 'react';
+import { X } from 'lucide-react';
+import { BUILTIN_PANEL_IDS, type WorkbenchZoneId } from '@ifc-lite/extensions';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { AddElementPanel } from '@/components/viewer/AddElementPanel';
+import { BCFPanel } from '@/components/viewer/BCFPanel';
+import { ExtensionsPanel } from '@/components/extensions/ExtensionsPanel';
+import { GanttPanel } from '@/components/viewer/schedule/GanttPanel';
+import { HierarchyPanel } from '@/components/viewer/HierarchyPanel';
+import { IDSPanel } from '@/components/viewer/IDSPanel';
+import { LensPanel } from '@/components/viewer/LensPanel';
+import { ListPanel } from '@/components/viewer/lists/ListPanel';
+import { PropertiesPanel } from '@/components/viewer/PropertiesPanel';
+import { ScriptPanel } from '@/components/viewer/ScriptPanel';
+import { WidgetRenderer, type WidgetRendererContext } from '@/components/extensions/widget/WidgetRenderer';
+import { useOptionalExtensionHost } from '@/sdk/ExtensionHostProvider';
+import { useViewerStore } from '@/store';
+
+export function WorkbenchPanelHost({ panelId, zone }: { panelId: string; zone: WorkbenchZoneId }) {
+  const closePanel = useClosePanel(panelId, zone);
+  const personal = useViewerStore((s) => s.workbenchLayout.personalPanels[panelId]);
+  const ctx = usePersonalWidgetContext();
+  if (personal) {
+    return (
+      <ScrollArea className="h-full">
+        <div className="p-3">
+          <WidgetRenderer node={personal.widget as unknown as Parameters<typeof WidgetRenderer>[0]['node']} ctx={ctx} />
+        </div>
+      </ScrollArea>
+    );
+  }
+  switch (panelId) {
+    case BUILTIN_PANEL_IDS.hierarchy: return <HierarchyPanel />;
+    case BUILTIN_PANEL_IDS.properties: return <PropertiesPanel />;
+    case BUILTIN_PANEL_IDS.bcf: return <BCFPanel onClose={closePanel} />;
+    case BUILTIN_PANEL_IDS.ids: return <IDSPanel onClose={closePanel} />;
+    case BUILTIN_PANEL_IDS.lens: return <LensPanel onClose={closePanel} />;
+    case BUILTIN_PANEL_IDS.extensions: return <ExtensionsPanel onClose={closePanel} />;
+    case BUILTIN_PANEL_IDS.addElement: return <AddElementPanel onClose={closePanel} />;
+    case BUILTIN_PANEL_IDS.lists: return <ListPanel onClose={closePanel} />;
+    case BUILTIN_PANEL_IDS.script: return <ScriptPanel onClose={closePanel} />;
+    case BUILTIN_PANEL_IDS.gantt: return <GanttPanel onClose={closePanel} />;
+    default: return <EmptyPanel panelId={panelId} />;
+  }
+}
+
+function useClosePanel(panelId: string, zone: WorkbenchZoneId): () => void {
+  return useCallback(() => {
+    const state = useViewerStore.getState();
+    if (panelId === BUILTIN_PANEL_IDS.bcf) state.setBcfPanelVisible(false);
+    if (panelId === BUILTIN_PANEL_IDS.ids) state.setIdsPanelVisible(false);
+    if (panelId === BUILTIN_PANEL_IDS.lens) state.setLensPanelVisible(false);
+    if (panelId === BUILTIN_PANEL_IDS.extensions) state.setExtensionsPanelVisible(false);
+    if (panelId === BUILTIN_PANEL_IDS.lists) state.setListPanelVisible(false);
+    if (panelId === BUILTIN_PANEL_IDS.script) state.setScriptPanelVisible(false);
+    if (panelId === BUILTIN_PANEL_IDS.gantt) state.setGanttPanelVisible(false);
+    if (panelId === BUILTIN_PANEL_IDS.addElement) state.setActiveTool('select');
+    state.setWorkbenchActiveTab(zone, zone === 'right' ? BUILTIN_PANEL_IDS.properties : undefined);
+  }, [panelId, zone]);
+}
+
+function usePersonalWidgetContext(): WidgetRendererContext {
+  const host = useOptionalExtensionHost();
+  return useMemo(() => ({
+    state: {},
+    invokeCommand: (commandId: string) => {
+      host?.runCommand(commandId).catch((err) => {
+        console.warn('[WorkbenchPanelHost] personal panel command failed:', err);
+      });
+    },
+  }), [host]);
+}
+
+function EmptyPanel({ panelId }: { panelId: string }) {
+  return (
+    <div className="flex h-full items-center justify-center p-4 text-xs text-muted-foreground">
+      <X className="mr-2 h-4 w-4" />
+      Panel unavailable: {panelId}
+    </div>
+  );
+}

--- a/apps/viewer/src/components/workbench/WorkbenchPatchDialog.tsx
+++ b/apps/viewer/src/components/workbench/WorkbenchPatchDialog.tsx
@@ -5,6 +5,7 @@
 import { useEffect, useState } from 'react';
 import { Check, Wand2, X } from 'lucide-react';
 import type { WorkbenchPatch } from '@ifc-lite/extensions';
+import { simulateWorkbenchPatch } from '@ifc-lite/customization';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { ScrollArea } from '@/components/ui/scroll-area';
@@ -14,7 +15,9 @@ const PATCH_EVENT = 'ifc-lite:preview-workbench-patch';
 
 export function WorkbenchPatchDialog() {
   const applyPatch = useViewerStore((s) => s.applyWorkbenchPatch);
+  const layout = useViewerStore((s) => s.workbenchLayout);
   const [patch, setPatch] = useState<WorkbenchPatch | null>(null);
+  const simulation = patch ? simulateWorkbenchPatch(layout, patch) : null;
 
   useEffect(() => {
     const handler = (event: Event) => {
@@ -41,10 +44,23 @@ export function WorkbenchPatchDialog() {
             <div><span className="font-medium">Patch:</span> <code>{patch.id}</code></div>
             <div><span className="font-medium">Author:</span> {patch.author}</div>
             <div><span className="font-medium">Operations:</span> {patch.operations.length}</div>
+            {simulation && simulation.warnings.length > 0 && (
+              <div className="mt-2 rounded border border-amber-500/40 bg-amber-500/10 px-2 py-1 text-xs text-amber-700 dark:text-amber-300">
+                {simulation.warnings.join(' ')}
+              </div>
+            )}
           </div>
           <ScrollArea className="max-h-[360px] rounded border">
             <div className="divide-y">
-              {patch.operations.map((operation, index) => (
+              {(simulation?.changes ?? []).map((change, index) => (
+                <div key={`${change.operation}-${index}`} className="p-3">
+                  <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{change.operation}</div>
+                  <div className="mt-1 text-sm font-medium">{change.label}</div>
+                  {change.detail && <div className="text-xs text-muted-foreground">{change.detail}</div>}
+                  <pre className="mt-1 overflow-x-auto text-[11px]">{JSON.stringify(patch.operations[index], null, 2)}</pre>
+                </div>
+              ))}
+              {!simulation && patch.operations.map((operation, index) => (
                 <div key={`${operation.op}-${index}`} className="p-3">
                   <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{operation.op}</div>
                   <pre className="mt-1 overflow-x-auto text-[11px]">{JSON.stringify(operation, null, 2)}</pre>

--- a/apps/viewer/src/components/workbench/WorkbenchPatchDialog.tsx
+++ b/apps/viewer/src/components/workbench/WorkbenchPatchDialog.tsx
@@ -1,0 +1,89 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { useEffect, useState } from 'react';
+import { Check, Wand2, X } from 'lucide-react';
+import type { WorkbenchPatch } from '@ifc-lite/extensions';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { useViewerStore } from '@/store';
+
+const PATCH_EVENT = 'ifc-lite:preview-workbench-patch';
+
+export function WorkbenchPatchDialog() {
+  const applyPatch = useViewerStore((s) => s.applyWorkbenchPatch);
+  const [patch, setPatch] = useState<WorkbenchPatch | null>(null);
+
+  useEffect(() => {
+    const handler = (event: Event) => {
+      if (!(event instanceof CustomEvent)) return;
+      const candidate = event.detail;
+      if (isWorkbenchPatch(candidate)) setPatch(candidate);
+    };
+    window.addEventListener(PATCH_EVENT, handler);
+    return () => window.removeEventListener(PATCH_EVENT, handler);
+  }, []);
+
+  if (!patch) return null;
+  return (
+    <Dialog open={!!patch} onOpenChange={(next) => !next && setPatch(null)}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Wand2 className="h-4 w-4" />
+            Preview workbench patch
+          </DialogTitle>
+        </DialogHeader>
+        <div className="space-y-3">
+          <div className="rounded border bg-muted/30 p-3 text-sm">
+            <div><span className="font-medium">Patch:</span> <code>{patch.id}</code></div>
+            <div><span className="font-medium">Author:</span> {patch.author}</div>
+            <div><span className="font-medium">Operations:</span> {patch.operations.length}</div>
+          </div>
+          <ScrollArea className="max-h-[360px] rounded border">
+            <div className="divide-y">
+              {patch.operations.map((operation, index) => (
+                <div key={`${operation.op}-${index}`} className="p-3">
+                  <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{operation.op}</div>
+                  <pre className="mt-1 overflow-x-auto text-[11px]">{JSON.stringify(operation, null, 2)}</pre>
+                </div>
+              ))}
+            </div>
+          </ScrollArea>
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="ghost" size="sm" onClick={() => setPatch(null)}>
+              <X className="mr-1 h-3.5 w-3.5" />
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              onClick={() => {
+                applyPatch(patch);
+                setPatch(null);
+              }}
+            >
+              <Check className="mr-1 h-3.5 w-3.5" />
+              Apply patch
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export function previewWorkbenchPatch(patch: WorkbenchPatch) {
+  window.dispatchEvent(new CustomEvent(PATCH_EVENT, { detail: patch }));
+}
+
+function isWorkbenchPatch(value: unknown): value is WorkbenchPatch {
+  if (!value || typeof value !== 'object') return false;
+  const patch = value as Partial<WorkbenchPatch>;
+  return typeof patch.id === 'string'
+    && typeof patch.author === 'string'
+    && typeof patch.createdAt === 'string'
+    && Array.isArray(patch.operations);
+}

--- a/apps/viewer/src/components/workbench/WorkspaceModesDialog.tsx
+++ b/apps/viewer/src/components/workbench/WorkspaceModesDialog.tsx
@@ -1,0 +1,140 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { useState } from 'react';
+import { Play, Save, Trash2, Zap } from 'lucide-react';
+import type { UiAutomationTrigger, WorkbenchZoneId } from '@ifc-lite/extensions';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { useViewerStore } from '@/store';
+import { listWorkbenchPanels, ZONE_LABEL } from './panelRegistry';
+
+interface WorkspaceModesDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function WorkspaceModesDialog({ open, onClose }: WorkspaceModesDialogProps) {
+  const layout = useViewerStore((s) => s.workbenchLayout);
+  const saveMode = useViewerStore((s) => s.saveWorkbenchMode);
+  const applyMode = useViewerStore((s) => s.applyWorkbenchMode);
+  const deleteMode = useViewerStore((s) => s.deleteWorkbenchMode);
+  const upsertAutomation = useViewerStore((s) => s.upsertWorkbenchAutomation);
+  const deleteAutomation = useViewerStore((s) => s.deleteWorkbenchAutomation);
+  const [modeName, setModeName] = useState('Review workspace');
+  const [automationName, setAutomationName] = useState('Open Properties on selection');
+  const [trigger, setTrigger] = useState<UiAutomationTrigger['kind']>('selection.changed');
+  const [panelId, setPanelId] = useState('builtin:panel:properties');
+  const [zone, setZone] = useState<WorkbenchZoneId>('right');
+  const panels = listWorkbenchPanels(layout);
+
+  const handleSaveMode = () => {
+    saveMode(modeName.trim() || 'Workspace mode');
+  };
+
+  const handleAddAutomation = () => {
+    upsertAutomation({
+      id: `automation:${crypto.randomUUID()}`,
+      name: automationName.trim() || 'Workbench automation',
+      enabled: true,
+      trigger: trigger === 'panel.opened' ? { kind: trigger, panelId } : { kind: trigger },
+      actions: [
+        { kind: 'layout.movePanel', panelId, zone },
+        { kind: 'layout.openPanel', panelId },
+      ],
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !next && onClose()}>
+      <DialogContent className="max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>Workspace modes & automations</DialogTitle>
+        </DialogHeader>
+        <div className="grid gap-4 md:grid-cols-2">
+          <section className="space-y-3">
+            <div className="rounded border p-3">
+              <Label htmlFor="workspace-mode-name">Save current layout as mode</Label>
+              <div className="mt-2 flex gap-2">
+                <Input id="workspace-mode-name" value={modeName} onChange={(event) => setModeName(event.currentTarget.value)} />
+                <Button type="button" size="sm" onClick={handleSaveMode}>
+                  <Save className="mr-1 h-3.5 w-3.5" />
+                  Save
+                </Button>
+              </div>
+            </div>
+            <ScrollArea className="h-[330px] pr-3">
+              <div className="space-y-2">
+                {Object.values(layout.workspaceModes).map((mode) => (
+                  <div key={mode.id} className="rounded border p-3">
+                    <div className="font-medium text-sm">{mode.name}</div>
+                    <div className="mt-0.5 text-[11px] text-muted-foreground">{mode.id}</div>
+                    <div className="mt-2 flex gap-2">
+                      <Button type="button" size="sm" onClick={() => applyMode(mode.id)}>
+                        <Play className="mr-1 h-3.5 w-3.5" />
+                        Apply
+                      </Button>
+                      <Button type="button" size="sm" variant="ghost" onClick={() => deleteMode(mode.id)}>
+                        <Trash2 className="mr-1 h-3.5 w-3.5" />
+                        Delete
+                      </Button>
+                    </div>
+                  </div>
+                ))}
+                {Object.keys(layout.workspaceModes).length === 0 && (
+                  <div className="rounded border border-dashed p-4 text-sm text-muted-foreground">
+                    No workspace modes yet. Morph the UI, then save the current arrangement.
+                  </div>
+                )}
+              </div>
+            </ScrollArea>
+          </section>
+
+          <section className="space-y-3">
+            <div className="rounded border p-3 space-y-2">
+              <Label>Add behavior automation</Label>
+              <Input value={automationName} onChange={(event) => setAutomationName(event.currentTarget.value)} />
+              <div className="grid grid-cols-3 gap-2">
+                <select value={trigger} onChange={(event) => setTrigger(event.currentTarget.value as UiAutomationTrigger['kind'])} className="rounded border bg-background px-2 py-1.5 text-sm">
+                  <option value="selection.changed">Selection changes</option>
+                  <option value="model.loaded">Model loads</option>
+                  <option value="panel.opened">Panel opens</option>
+                </select>
+                <select value={panelId} onChange={(event) => setPanelId(event.currentTarget.value)} className="rounded border bg-background px-2 py-1.5 text-sm">
+                  {panels.map((panel) => <option key={panel.id} value={panel.id}>{panel.title}</option>)}
+                </select>
+                <select value={zone} onChange={(event) => setZone(event.currentTarget.value as WorkbenchZoneId)} className="rounded border bg-background px-2 py-1.5 text-sm">
+                  {(['left', 'right', 'bottom'] as const).map((z) => <option key={z} value={z}>{ZONE_LABEL[z]}</option>)}
+                </select>
+              </div>
+              <Button type="button" size="sm" onClick={handleAddAutomation}>
+                <Zap className="mr-1 h-3.5 w-3.5" />
+                Add automation
+              </Button>
+            </div>
+            <ScrollArea className="h-[245px] pr-3">
+              <div className="space-y-2">
+                {layout.automations.map((automation) => (
+                  <div key={automation.id} className="rounded border p-3">
+                    <div className="font-medium text-sm">{automation.name}</div>
+                    <div className="mt-0.5 text-[11px] text-muted-foreground">
+                      {automation.trigger.kind} · {automation.actions.length} action{automation.actions.length === 1 ? '' : 's'}
+                    </div>
+                    <Button type="button" size="sm" variant="ghost" className="mt-2" onClick={() => deleteAutomation(automation.id)}>
+                      <Trash2 className="mr-1 h-3.5 w-3.5" />
+                      Delete
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            </ScrollArea>
+          </section>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/viewer/src/components/workbench/panelRegistry.ts
+++ b/apps/viewer/src/components/workbench/panelRegistry.ts
@@ -1,0 +1,77 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { BUILTIN_PANEL_IDS, type WorkbenchLayoutState, type WorkbenchPanelId, type WorkbenchZoneId } from '@ifc-lite/extensions';
+
+export interface WorkbenchPanelSummary {
+  id: WorkbenchPanelId;
+  title: string;
+  kind: 'built-in' | 'personal' | 'missing';
+  zone?: WorkbenchZoneId;
+  hidden: boolean;
+}
+
+export const BUILTIN_TITLES: Record<string, string> = {
+  [BUILTIN_PANEL_IDS.hierarchy]: 'Hierarchy',
+  [BUILTIN_PANEL_IDS.properties]: 'Properties',
+  [BUILTIN_PANEL_IDS.bcf]: 'BCF',
+  [BUILTIN_PANEL_IDS.ids]: 'IDS',
+  [BUILTIN_PANEL_IDS.lens]: 'Lens',
+  [BUILTIN_PANEL_IDS.extensions]: 'Extensions',
+  [BUILTIN_PANEL_IDS.addElement]: 'Add element',
+  [BUILTIN_PANEL_IDS.lists]: 'Lists',
+  [BUILTIN_PANEL_IDS.script]: 'Script',
+  [BUILTIN_PANEL_IDS.gantt]: 'Schedule',
+};
+
+export const BUILTIN_PANEL_ORDER: string[] = [
+  BUILTIN_PANEL_IDS.hierarchy,
+  BUILTIN_PANEL_IDS.properties,
+  BUILTIN_PANEL_IDS.bcf,
+  BUILTIN_PANEL_IDS.ids,
+  BUILTIN_PANEL_IDS.lens,
+  BUILTIN_PANEL_IDS.extensions,
+  BUILTIN_PANEL_IDS.addElement,
+  BUILTIN_PANEL_IDS.lists,
+  BUILTIN_PANEL_IDS.script,
+  BUILTIN_PANEL_IDS.gantt,
+];
+
+export const ZONE_LABEL: Record<WorkbenchZoneId, string> = {
+  left: 'Left dock',
+  right: 'Right dock',
+  bottom: 'Bottom dock',
+};
+
+export function getWorkbenchPanelTitle(layout: WorkbenchLayoutState, panelId: string): string {
+  const chromeTitle = layout.panelChrome[panelId]?.title;
+  if (chromeTitle) return chromeTitle;
+  const personal = layout.personalPanels[panelId];
+  if (personal) return personal.title;
+  return BUILTIN_TITLES[panelId] ?? panelId;
+}
+
+export function findWorkbenchPanelZone(layout: WorkbenchLayoutState, panelId: string): WorkbenchZoneId | undefined {
+  if (layout.zones.left.includes(panelId)) return 'left';
+  if (layout.zones.right.includes(panelId)) return 'right';
+  if (layout.zones.bottom.includes(panelId)) return 'bottom';
+  return undefined;
+}
+
+export function listWorkbenchPanels(layout: WorkbenchLayoutState): WorkbenchPanelSummary[] {
+  const ids = new Set<string>([
+    ...BUILTIN_PANEL_ORDER,
+    ...Object.keys(layout.personalPanels),
+    ...layout.zones.left,
+    ...layout.zones.right,
+    ...layout.zones.bottom,
+  ]);
+  return Array.from(ids).map((id) => ({
+    id,
+    title: getWorkbenchPanelTitle(layout, id),
+    kind: id in layout.personalPanels ? 'personal' : id in BUILTIN_TITLES ? 'built-in' : 'missing',
+    zone: findWorkbenchPanelZone(layout, id),
+    hidden: layout.panelChrome[id]?.hidden === true,
+  }));
+}

--- a/apps/viewer/src/components/workbench/panelRegistry.ts
+++ b/apps/viewer/src/components/workbench/panelRegistry.ts
@@ -7,9 +7,19 @@ import { BUILTIN_PANEL_IDS, type WorkbenchLayoutState, type WorkbenchPanelId, ty
 export interface WorkbenchPanelSummary {
   id: WorkbenchPanelId;
   title: string;
-  kind: 'built-in' | 'personal' | 'missing';
+  kind: 'built-in' | 'personal' | 'extension' | 'missing';
   zone?: WorkbenchZoneId;
   hidden: boolean;
+}
+
+export function extensionPanelWorkbenchId(extensionId: string, panelId: string): string {
+  return `extension:${extensionId}:panel:${panelId}`;
+}
+
+export function parseExtensionPanelWorkbenchId(panelId: string): { extensionId: string; panelId: string } | undefined {
+  const match = /^extension:([^:]+):panel:(.+)$/.exec(panelId);
+  if (!match) return undefined;
+  return { extensionId: match[1], panelId: match[2] };
 }
 
 export const BUILTIN_TITLES: Record<string, string> = {

--- a/apps/viewer/src/hooks/useExtensionKeybindings.ts
+++ b/apps/viewer/src/hooks/useExtensionKeybindings.ts
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { useEffect, useMemo } from 'react';
+import { evaluateWhen, parseWhen, type KeybindingContribution } from '@ifc-lite/extensions';
+import { useSlotContributions } from './useSlotContributions';
+import { useOptionalExtensionHost } from '@/sdk/ExtensionHostProvider';
+import { useViewerStore } from '@/store';
+
+export function useExtensionKeybindings() {
+  const host = useOptionalExtensionHost();
+  const contributions = useSlotContributions<KeybindingContribution>('keybindings');
+  const modelCount = useViewerStore((s) => s.models.size);
+  const selectedCount = useViewerStore((s) => s.selectedEntityIds.size);
+  const bindings = useMemo(() => contributions.map((c) => c.payload), [contributions]);
+
+  useEffect(() => {
+    if (!host || bindings.length === 0) return;
+    const context = {
+      'model.loaded': modelCount > 0,
+      'model.count': modelCount,
+      'selection.count': selectedCount,
+      'viewer.open': true,
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
+      if (target?.tagName === 'INPUT' || target?.tagName === 'TEXTAREA' || target?.isContentEditable) return;
+      const match = bindings.find((binding) => {
+        if (!matchesKey(event, binding.key)) return false;
+        if (!binding.when) return true;
+        const parsed = parseWhen(binding.when);
+        return parsed.ok && evaluateWhen(parsed.value, context);
+      });
+      if (!match) return;
+      event.preventDefault();
+      void host.dispatcher
+        .fire(`onCommand:${match.command}` as `onCommand:${string}`)
+        .then(() => host.runCommand(match.command));
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [bindings, host, modelCount, selectedCount]);
+}
+
+function matchesKey(event: KeyboardEvent, keySpec: string): boolean {
+  const parts = keySpec.toLowerCase().split('+').map((part) => part.trim()).filter(Boolean);
+  const key = parts[parts.length - 1];
+  const wantsCtrl = parts.includes('ctrl') || parts.includes('cmd') || parts.includes('meta');
+  const wantsShift = parts.includes('shift');
+  const wantsAlt = parts.includes('alt') || parts.includes('option');
+  if (wantsCtrl !== (event.ctrlKey || event.metaKey)) return false;
+  if (wantsShift !== event.shiftKey) return false;
+  if (wantsAlt !== event.altKey) return false;
+  return event.key.toLowerCase() === key;
+}

--- a/apps/viewer/src/hooks/useWorkbenchAutomations.ts
+++ b/apps/viewer/src/hooks/useWorkbenchAutomations.ts
@@ -1,0 +1,79 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { useEffect, useRef } from 'react';
+import { evaluateWhen, parseWhen, type UiAutomation, type UiAutomationTrigger } from '@ifc-lite/extensions';
+import { toast } from '@/components/ui/toast';
+import { useOptionalExtensionHost } from '@/sdk/ExtensionHostProvider';
+import { useViewerStore } from '@/store';
+
+export function useWorkbenchAutomations() {
+  const host = useOptionalExtensionHost();
+  const automations = useViewerStore((s) => s.workbenchLayout.automations);
+  const modelCount = useViewerStore((s) => s.models.size);
+  const selectionCount = useViewerStore((s) => s.selectedEntityIds.size);
+  const previousModelCount = useRef(modelCount);
+  const previousSelectionCount = useRef(selectionCount);
+
+  useEffect(() => {
+    if (modelCount > 0 && previousModelCount.current === 0) {
+      runAutomations('model.loaded', automations, host);
+    }
+    previousModelCount.current = modelCount;
+  }, [automations, host, modelCount]);
+
+  useEffect(() => {
+    if (selectionCount !== previousSelectionCount.current) {
+      runAutomations('selection.changed', automations, host);
+    }
+    previousSelectionCount.current = selectionCount;
+  }, [automations, host, selectionCount]);
+}
+
+export function firePanelOpenedAutomation(panelId: string) {
+  const state = useViewerStore.getState();
+  const automations = state.workbenchLayout.automations.filter((automation) =>
+    automation.enabled
+    && automation.trigger.kind === 'panel.opened'
+    && automation.trigger.panelId === panelId,
+  );
+  for (const automation of automations) runAutomation(automation);
+}
+
+function runAutomations(
+  trigger: UiAutomationTrigger['kind'],
+  automations: readonly UiAutomation[],
+  host: ReturnType<typeof useOptionalExtensionHost>,
+): void {
+  for (const automation of automations) {
+    if (!automation.enabled || automation.trigger.kind !== trigger) continue;
+    if (!whenMatches(automation.when)) continue;
+    runAutomation(automation, host);
+  }
+}
+
+function runAutomation(automation: UiAutomation, host?: ReturnType<typeof useOptionalExtensionHost>): void {
+  const state = useViewerStore.getState();
+  for (const action of automation.actions) {
+    if (action.kind === 'layout.openPanel') state.openWorkbenchPanel(action.panelId);
+    else if (action.kind === 'layout.movePanel') state.moveWorkbenchPanel(action.panelId, action.zone);
+    else if (action.kind === 'layout.collapse') state.setWorkbenchCollapsed(action.zone, action.collapsed);
+    else if (action.kind === 'layout.applyMode') state.applyWorkbenchMode(action.modeId);
+    else if (action.kind === 'toast.show') toast.info(action.message);
+    else if (action.kind === 'command.run') void host?.runCommand(action.commandId);
+  }
+}
+
+function whenMatches(when: string | undefined): boolean {
+  if (!when) return true;
+  const state = useViewerStore.getState();
+  const parsed = parseWhen(when);
+  if (!parsed.ok) return false;
+  return evaluateWhen(parsed.value, {
+    'model.loaded': state.models.size > 0,
+    'model.count': state.models.size,
+    'selection.count': state.selectedEntityIds.size,
+    'viewer.open': true,
+  });
+}

--- a/apps/viewer/src/hooks/useWorkbenchAutomations.ts
+++ b/apps/viewer/src/hooks/useWorkbenchAutomations.ts
@@ -8,6 +8,9 @@ import { toast } from '@/components/ui/toast';
 import { useOptionalExtensionHost } from '@/sdk/ExtensionHostProvider';
 import { useViewerStore } from '@/store';
 
+const RUN_GUARD_MS = 1_000;
+const recentRuns = new Map<string, number>();
+
 export function useWorkbenchAutomations() {
   const host = useOptionalExtensionHost();
   const automations = useViewerStore((s) => s.workbenchLayout.automations);
@@ -38,7 +41,7 @@ export function firePanelOpenedAutomation(panelId: string) {
     && automation.trigger.kind === 'panel.opened'
     && automation.trigger.panelId === panelId,
   );
-  for (const automation of automations) runAutomation(automation);
+  for (const automation of automations) runAutomation(automation, undefined, 'panel.opened');
 }
 
 function runAutomations(
@@ -49,20 +52,50 @@ function runAutomations(
   for (const automation of automations) {
     if (!automation.enabled || automation.trigger.kind !== trigger) continue;
     if (!whenMatches(automation.when)) continue;
-    runAutomation(automation, host);
+    runAutomation(automation, host, trigger);
   }
 }
 
-function runAutomation(automation: UiAutomation, host?: ReturnType<typeof useOptionalExtensionHost>): void {
+function runAutomation(automation: UiAutomation, host?: ReturnType<typeof useOptionalExtensionHost>, trigger = automation.trigger.kind): void {
   const state = useViewerStore.getState();
-  for (const action of automation.actions) {
-    if (action.kind === 'layout.openPanel') state.openWorkbenchPanel(action.panelId);
-    else if (action.kind === 'layout.movePanel') state.moveWorkbenchPanel(action.panelId, action.zone);
-    else if (action.kind === 'layout.collapse') state.setWorkbenchCollapsed(action.zone, action.collapsed);
-    else if (action.kind === 'layout.applyMode') state.applyWorkbenchMode(action.modeId);
-    else if (action.kind === 'toast.show') toast.info(action.message);
-    else if (action.kind === 'command.run') void host?.runCommand(action.commandId);
+  const guardKey = `${automation.id}:${trigger}`;
+  const now = Date.now();
+  const last = recentRuns.get(guardKey) ?? 0;
+  if (now - last < RUN_GUARD_MS) {
+    appendRun(automation, trigger, 'skipped', 'Skipped to prevent rapid automation loop.');
+    return;
   }
+  recentRuns.set(guardKey, now);
+  try {
+    for (const action of automation.actions.slice(0, 12)) {
+      if (action.kind === 'layout.openPanel') state.openWorkbenchPanel(action.panelId);
+      else if (action.kind === 'layout.movePanel') state.moveWorkbenchPanel(action.panelId, action.zone);
+      else if (action.kind === 'layout.collapse') state.setWorkbenchCollapsed(action.zone, action.collapsed);
+      else if (action.kind === 'layout.applyMode') state.applyWorkbenchMode(action.modeId);
+      else if (action.kind === 'toast.show') toast.info(action.message);
+      else if (action.kind === 'command.run') void host?.runCommand(action.commandId);
+    }
+    appendRun(automation, trigger, 'success');
+  } catch (err) {
+    appendRun(automation, trigger, 'failed', err instanceof Error ? err.message : String(err));
+  }
+}
+
+function appendRun(
+  automation: UiAutomation,
+  trigger: string,
+  status: 'success' | 'failed' | 'skipped',
+  message?: string,
+) {
+  useViewerStore.getState().appendWorkbenchAutomationRun({
+    id: crypto.randomUUID(),
+    automationId: automation.id,
+    automationName: automation.name,
+    trigger,
+    status,
+    message,
+    createdAt: new Date().toISOString(),
+  });
 }
 
 function whenMatches(when: string | undefined): boolean {

--- a/apps/viewer/src/services/extensions/flavor-service.ts
+++ b/apps/viewer/src/services/extensions/flavor-service.ts
@@ -15,6 +15,7 @@
 
 import {
   DEFAULT_FLAVOR_ID,
+  createDefaultWorkbenchLayout,
   flavorImportedId,
   packFlavor,
   switchFlavor,
@@ -160,7 +161,7 @@ export class FlavorService {
       lenses: [],
       savedQueries: [],
       keybindings: [],
-      layout: { state: {} },
+      layout: { state: createDefaultWorkbenchLayout() },
       settings: {},
     };
     await this.storage.putFlavor(flavor, 'reset to defaults');

--- a/apps/viewer/src/services/extensions/host.ts
+++ b/apps/viewer/src/services/extensions/host.ts
@@ -40,6 +40,7 @@ import {
   IdleMineScheduler,
   SlotRegistry,
   filterAgainstInstalled,
+  normalizeWorkbenchLayout,
   parseCapabilities,
   planFromPattern,
   revalidateAgainstSdk,
@@ -432,9 +433,11 @@ export class ExtensionHostService {
       // Late import keeps the host service free of UI store deps for
       // headless test environments — only the browser viewer wires it.
       const { useViewerStore } = await import('@/store');
-      useViewerStore.getState().setSavedLenses(lenses);
+      const store = useViewerStore.getState();
+      store.setSavedLenses(lenses);
+      store.setWorkbenchLayout(normalizeWorkbenchLayout(target.layout.state));
     } catch (err) {
-      console.warn('[ext-host] lens restore on switch failed:', err);
+      console.warn('[ext-host] viewer state restore on switch failed:', err);
     }
     this.emit();
   }

--- a/apps/viewer/src/store/index.ts
+++ b/apps/viewer/src/store/index.ts
@@ -46,6 +46,7 @@ import { createAddElementSlice, type AddElementSlice } from './slices/addElement
 import { createSplitToolSlice, type SplitToolSlice } from './slices/splitToolSlice.js';
 import { createLevelDisplaySlice, type LevelDisplaySlice } from './slices/levelDisplaySlice.js';
 import { createPointCloudSlice, type PointCloudSlice, POINT_CLOUD_DEFAULTS } from './slices/pointCloudSlice.js';
+import { createWorkbenchSlice, type WorkbenchSlice } from './slices/workbenchSlice.js';
 import { invalidateVisibleBasketCache } from './basketVisibleSet.js';
 
 // Import constants for reset function
@@ -99,6 +100,7 @@ export type { CesiumSlice, CesiumDataSource, CesiumPlacementDraft } from './slic
 export type { ScheduleSlice, ScheduleTimeRange, GanttTimeScale } from './slices/scheduleSlice.js';
 export type { PlaybackSlice } from './slices/playbackSlice.js';
 export type { OverlaySlice, OverlayLayer, RGBA as OverlayRGBA } from './slices/overlaySlice.js';
+export type { WorkbenchSlice } from './slices/workbenchSlice.js';
 export { composeLayers as composeOverlayLayers } from './slices/overlaySlice.js';
 export {
   computeScheduleRange,
@@ -142,6 +144,7 @@ export type ViewerState = LoadingSlice &
   SplitToolSlice &
   LevelDisplaySlice &
   PointCloudSlice &
+  WorkbenchSlice &
   ExtensionsSlice & {
     resetViewerState: () => void;
   };
@@ -182,6 +185,7 @@ const createViewerStore = () => create<ViewerState>()((...args) => ({
   ...createSplitToolSlice(...args),
   ...createLevelDisplaySlice(...args),
   ...createPointCloudSlice(...args),
+  ...createWorkbenchSlice(...args),
   ...createExtensionsSlice(...args),
 
   // Reset all viewer state when loading new file

--- a/apps/viewer/src/store/slices/workbenchSlice.ts
+++ b/apps/viewer/src/store/slices/workbenchSlice.ts
@@ -1,0 +1,130 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { StateCreator } from 'zustand';
+import {
+  createDefaultWorkbenchLayout,
+  normalizeWorkbenchLayout,
+  type PersonalPanelDefinition,
+  type WorkbenchLayoutState,
+  type WorkbenchPanelChrome,
+  type WorkbenchPanelId,
+  type WorkbenchZoneId,
+} from '@ifc-lite/extensions';
+
+export interface WorkbenchSlice {
+  workbenchLayout: WorkbenchLayoutState;
+  workbenchMorphMode: boolean;
+  setWorkbenchMorphMode: (enabled: boolean) => void;
+  setWorkbenchLayout: (layout: WorkbenchLayoutState | unknown) => void;
+  resetWorkbenchLayout: () => void;
+  openWorkbenchPanel: (panelId: WorkbenchPanelId) => void;
+  setWorkbenchActiveTab: (zone: WorkbenchZoneId, panelId: WorkbenchPanelId | undefined) => void;
+  moveWorkbenchPanel: (panelId: WorkbenchPanelId, toZone: WorkbenchZoneId, toIndex?: number) => void;
+  setWorkbenchHorizontalSizes: (sizes: [number, number, number]) => void;
+  setWorkbenchBottomHeight: (height: number) => void;
+  setWorkbenchCollapsed: (zone: WorkbenchZoneId, collapsed: boolean) => void;
+  setWorkbenchPanelChrome: (panelId: WorkbenchPanelId, chrome: WorkbenchPanelChrome) => void;
+  addWorkbenchPersonalPanel: (panel: PersonalPanelDefinition, zone?: WorkbenchZoneId) => void;
+}
+
+export const createWorkbenchSlice: StateCreator<WorkbenchSlice, [], [], WorkbenchSlice> = (set, get) => ({
+  workbenchLayout: createDefaultWorkbenchLayout(),
+  workbenchMorphMode: false,
+
+  setWorkbenchMorphMode: (workbenchMorphMode) => set({ workbenchMorphMode }),
+  setWorkbenchLayout: (layout) => set({ workbenchLayout: normalizeWorkbenchLayout(layout) }),
+  resetWorkbenchLayout: () => set({ workbenchLayout: createDefaultWorkbenchLayout() }),
+
+  openWorkbenchPanel: (panelId) => {
+    const layout = get().workbenchLayout;
+    const zone = findPanelZone(layout, panelId);
+    if (!zone) return;
+    set({
+      workbenchLayout: {
+        ...layout,
+        collapsed: { ...layout.collapsed, [zone]: false },
+        activeTabs: { ...layout.activeTabs, [zone]: panelId },
+      },
+    });
+  },
+
+  setWorkbenchActiveTab: (zone, panelId) => {
+    const layout = get().workbenchLayout;
+    set({ workbenchLayout: { ...layout, activeTabs: { ...layout.activeTabs, [zone]: panelId } } });
+  },
+
+  moveWorkbenchPanel: (panelId, toZone, toIndex) => {
+    const layout = get().workbenchLayout;
+    const zones = {
+      left: layout.zones.left.filter((id) => id !== panelId),
+      right: layout.zones.right.filter((id) => id !== panelId),
+      bottom: layout.zones.bottom.filter((id) => id !== panelId),
+    };
+    const next = [...zones[toZone]];
+    const index = Math.min(Math.max(toIndex ?? next.length, 0), next.length);
+    next.splice(index, 0, panelId);
+    zones[toZone] = next;
+    set({
+      workbenchLayout: {
+        ...layout,
+        zones,
+        collapsed: { ...layout.collapsed, [toZone]: false },
+        activeTabs: { ...layout.activeTabs, [toZone]: panelId },
+      },
+    });
+  },
+
+  setWorkbenchHorizontalSizes: (horizontal) => {
+    const layout = get().workbenchLayout;
+    set({ workbenchLayout: { ...layout, sizes: { ...layout.sizes, horizontal } } });
+  },
+
+  setWorkbenchBottomHeight: (bottomHeight) => {
+    const layout = get().workbenchLayout;
+    set({ workbenchLayout: { ...layout, sizes: { ...layout.sizes, bottomHeight } } });
+  },
+
+  setWorkbenchCollapsed: (zone, collapsed) => {
+    const layout = get().workbenchLayout;
+    set({ workbenchLayout: { ...layout, collapsed: { ...layout.collapsed, [zone]: collapsed } } });
+  },
+
+  setWorkbenchPanelChrome: (panelId, chrome) => {
+    const layout = get().workbenchLayout;
+    set({
+      workbenchLayout: {
+        ...layout,
+        panelChrome: {
+          ...layout.panelChrome,
+          [panelId]: { ...layout.panelChrome[panelId], ...chrome },
+        },
+      },
+    });
+  },
+
+  addWorkbenchPersonalPanel: (panel, zone = 'right') => {
+    const layout = get().workbenchLayout;
+    const zones = {
+      ...layout.zones,
+      [zone]: layout.zones[zone].includes(panel.id) ? layout.zones[zone] : [...layout.zones[zone], panel.id],
+    };
+    set({
+      workbenchLayout: {
+        ...layout,
+        zones,
+        personalPanels: { ...layout.personalPanels, [panel.id]: panel },
+        activeTabs: { ...layout.activeTabs, [zone]: panel.id },
+        collapsed: { ...layout.collapsed, [zone]: false },
+      },
+    });
+  },
+});
+
+function findPanelZone(layout: WorkbenchLayoutState, panelId: string): WorkbenchZoneId | undefined {
+  if (layout.zones.left.includes(panelId)) return 'left';
+  if (layout.zones.right.includes(panelId)) return 'right';
+  if (layout.zones.bottom.includes(panelId)) return 'bottom';
+  return undefined;
+}

--- a/apps/viewer/src/store/slices/workbenchSlice.ts
+++ b/apps/viewer/src/store/slices/workbenchSlice.ts
@@ -7,7 +7,10 @@ import {
   createDefaultWorkbenchLayout,
   normalizeWorkbenchLayout,
   type PersonalPanelDefinition,
+  type UiAutomation,
   type WorkbenchLayoutState,
+  type WorkbenchMode,
+  type WorkbenchModeSnapshot,
   type WorkbenchPanelChrome,
   type WorkbenchPanelId,
   type WorkbenchZoneId,
@@ -29,6 +32,12 @@ export interface WorkbenchSlice {
   addWorkbenchPersonalPanel: (panel: PersonalPanelDefinition, zone?: WorkbenchZoneId) => void;
   updateWorkbenchPersonalPanel: (panel: PersonalPanelDefinition) => void;
   removeWorkbenchPersonalPanel: (panelId: WorkbenchPanelId) => void;
+  saveWorkbenchMode: (name: string, description?: string) => WorkbenchMode;
+  applyWorkbenchMode: (modeId: string) => void;
+  deleteWorkbenchMode: (modeId: string) => void;
+  upsertWorkbenchAutomation: (automation: UiAutomation) => void;
+  deleteWorkbenchAutomation: (automationId: string) => void;
+  appendWorkbenchHistory: (label: string, patchId?: string) => void;
 }
 
 export const createWorkbenchSlice: StateCreator<WorkbenchSlice, [], [], WorkbenchSlice> = (set, get) => ({
@@ -159,6 +168,79 @@ export const createWorkbenchSlice: StateCreator<WorkbenchSlice, [], [], Workbenc
       },
     });
   },
+
+  saveWorkbenchMode: (name, description) => {
+    const layout = get().workbenchLayout;
+    const now = new Date().toISOString();
+    const id = `mode:${slugify(name)}:${Date.now().toString(36)}`;
+    const mode: WorkbenchMode = {
+      id,
+      name,
+      description,
+      createdAt: now,
+      updatedAt: now,
+      snapshot: snapshotLayout(layout),
+    };
+    set({
+      workbenchLayout: {
+        ...layout,
+        workspaceModes: { ...layout.workspaceModes, [id]: mode },
+        history: [...layout.history, { id: crypto.randomUUID(), label: `Saved mode: ${name}`, createdAt: now }].slice(-50),
+      },
+    });
+    return mode;
+  },
+
+  applyWorkbenchMode: (modeId) => {
+    const layout = get().workbenchLayout;
+    const mode = layout.workspaceModes[modeId];
+    if (!mode) return;
+    const now = new Date().toISOString();
+    set({
+      workbenchLayout: {
+        ...layout,
+        ...mode.snapshot,
+        workspaceModes: layout.workspaceModes,
+        automations: layout.automations,
+        personalPanels: layout.personalPanels,
+        history: [...layout.history, { id: crypto.randomUUID(), label: `Applied mode: ${mode.name}`, createdAt: now }].slice(-50),
+      },
+    });
+  },
+
+  deleteWorkbenchMode: (modeId) => {
+    const layout = get().workbenchLayout;
+    const { [modeId]: _deleted, ...workspaceModes } = layout.workspaceModes;
+    set({ workbenchLayout: { ...layout, workspaceModes } });
+  },
+
+  upsertWorkbenchAutomation: (automation) => {
+    const layout = get().workbenchLayout;
+    set({
+      workbenchLayout: {
+        ...layout,
+        automations: [
+          ...layout.automations.filter((entry) => entry.id !== automation.id),
+          automation,
+        ],
+      },
+    });
+  },
+
+  deleteWorkbenchAutomation: (automationId) => {
+    const layout = get().workbenchLayout;
+    set({ workbenchLayout: { ...layout, automations: layout.automations.filter((entry) => entry.id !== automationId) } });
+  },
+
+  appendWorkbenchHistory: (label, patchId) => {
+    const layout = get().workbenchLayout;
+    set({
+      workbenchLayout: {
+        ...layout,
+        history: [...layout.history, { id: crypto.randomUUID(), label, patchId, createdAt: new Date().toISOString() }].slice(-50),
+      },
+    });
+  },
 });
 
 function findPanelZone(layout: WorkbenchLayoutState, panelId: string): WorkbenchZoneId | undefined {
@@ -166,4 +248,19 @@ function findPanelZone(layout: WorkbenchLayoutState, panelId: string): Workbench
   if (layout.zones.right.includes(panelId)) return 'right';
   if (layout.zones.bottom.includes(panelId)) return 'bottom';
   return undefined;
+}
+
+function snapshotLayout(layout: WorkbenchLayoutState): WorkbenchModeSnapshot {
+  return {
+    zones: structuredClone(layout.zones),
+    sizes: structuredClone(layout.sizes),
+    collapsed: structuredClone(layout.collapsed),
+    activeTabs: structuredClone(layout.activeTabs),
+    floating: structuredClone(layout.floating),
+    panelChrome: structuredClone(layout.panelChrome),
+  };
+}
+
+function slugify(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'workspace';
 }

--- a/apps/viewer/src/store/slices/workbenchSlice.ts
+++ b/apps/viewer/src/store/slices/workbenchSlice.ts
@@ -8,7 +8,9 @@ import {
   createDefaultWorkbenchLayout,
   normalizeWorkbenchLayout,
   type FloatingPanelPlacement,
+  type JsonValue,
   type PersonalPanelDefinition,
+  type AutomationRunLogEntry,
   type UiAutomation,
   type WorkbenchLayoutState,
   type WorkbenchMode,
@@ -32,6 +34,7 @@ export interface WorkbenchSlice {
   setWorkbenchBottomHeight: (height: number) => void;
   setWorkbenchCollapsed: (zone: WorkbenchZoneId, collapsed: boolean) => void;
   setWorkbenchPanelChrome: (panelId: WorkbenchPanelId, chrome: WorkbenchPanelChrome) => void;
+  setWorkbenchPanelConfig: (panelId: WorkbenchPanelId, config: JsonValue) => void;
   setWorkbenchFloatingPanel: (placement: FloatingPanelPlacement) => void;
   removeWorkbenchFloatingPanel: (panelId: WorkbenchPanelId) => void;
   applyWorkbenchPatch: (patch: WorkbenchPatch) => void;
@@ -43,6 +46,7 @@ export interface WorkbenchSlice {
   deleteWorkbenchMode: (modeId: string) => void;
   upsertWorkbenchAutomation: (automation: UiAutomation) => void;
   deleteWorkbenchAutomation: (automationId: string) => void;
+  appendWorkbenchAutomationRun: (entry: AutomationRunLogEntry) => void;
   appendWorkbenchHistory: (label: string, patchId?: string) => void;
 }
 
@@ -117,6 +121,16 @@ export const createWorkbenchSlice: StateCreator<WorkbenchSlice, [], [], Workbenc
           ...layout.panelChrome,
           [panelId]: { ...layout.panelChrome[panelId], ...chrome },
         },
+      },
+    });
+  },
+
+  setWorkbenchPanelConfig: (panelId, config) => {
+    const layout = get().workbenchLayout;
+    set({
+      workbenchLayout: {
+        ...layout,
+        panelConfigs: { ...layout.panelConfigs, [panelId]: config },
       },
     });
   },
@@ -282,6 +296,16 @@ export const createWorkbenchSlice: StateCreator<WorkbenchSlice, [], [], Workbenc
     set({ workbenchLayout: { ...layout, automations: layout.automations.filter((entry) => entry.id !== automationId) } });
   },
 
+  appendWorkbenchAutomationRun: (entry) => {
+    const layout = get().workbenchLayout;
+    set({
+      workbenchLayout: {
+        ...layout,
+        automationRuns: [...layout.automationRuns, entry].slice(-100),
+      },
+    });
+  },
+
   appendWorkbenchHistory: (label, patchId) => {
     const layout = get().workbenchLayout;
     set({
@@ -308,6 +332,7 @@ function snapshotLayout(layout: WorkbenchLayoutState): WorkbenchModeSnapshot {
     activeTabs: structuredClone(layout.activeTabs),
     floating: structuredClone(layout.floating),
     panelChrome: structuredClone(layout.panelChrome),
+    panelConfigs: structuredClone(layout.panelConfigs),
   };
 }
 

--- a/apps/viewer/src/store/slices/workbenchSlice.ts
+++ b/apps/viewer/src/store/slices/workbenchSlice.ts
@@ -27,6 +27,8 @@ export interface WorkbenchSlice {
   setWorkbenchCollapsed: (zone: WorkbenchZoneId, collapsed: boolean) => void;
   setWorkbenchPanelChrome: (panelId: WorkbenchPanelId, chrome: WorkbenchPanelChrome) => void;
   addWorkbenchPersonalPanel: (panel: PersonalPanelDefinition, zone?: WorkbenchZoneId) => void;
+  updateWorkbenchPersonalPanel: (panel: PersonalPanelDefinition) => void;
+  removeWorkbenchPersonalPanel: (panelId: WorkbenchPanelId) => void;
 }
 
 export const createWorkbenchSlice: StateCreator<WorkbenchSlice, [], [], WorkbenchSlice> = (set, get) => ({
@@ -117,6 +119,43 @@ export const createWorkbenchSlice: StateCreator<WorkbenchSlice, [], [], Workbenc
         personalPanels: { ...layout.personalPanels, [panel.id]: panel },
         activeTabs: { ...layout.activeTabs, [zone]: panel.id },
         collapsed: { ...layout.collapsed, [zone]: false },
+      },
+    });
+  },
+
+  updateWorkbenchPersonalPanel: (panel) => {
+    const layout = get().workbenchLayout;
+    set({
+      workbenchLayout: {
+        ...layout,
+        personalPanels: { ...layout.personalPanels, [panel.id]: panel },
+        panelChrome: {
+          ...layout.panelChrome,
+          [panel.id]: { ...layout.panelChrome[panel.id], title: panel.title },
+        },
+      },
+    });
+  },
+
+  removeWorkbenchPersonalPanel: (panelId) => {
+    const layout = get().workbenchLayout;
+    const { [panelId]: _removedPanel, ...personalPanels } = layout.personalPanels;
+    const { [panelId]: _removedChrome, ...panelChrome } = layout.panelChrome;
+    set({
+      workbenchLayout: {
+        ...layout,
+        zones: {
+          left: layout.zones.left.filter((id) => id !== panelId),
+          right: layout.zones.right.filter((id) => id !== panelId),
+          bottom: layout.zones.bottom.filter((id) => id !== panelId),
+        },
+        activeTabs: {
+          left: layout.activeTabs.left === panelId ? undefined : layout.activeTabs.left,
+          right: layout.activeTabs.right === panelId ? undefined : layout.activeTabs.right,
+          bottom: layout.activeTabs.bottom === panelId ? undefined : layout.activeTabs.bottom,
+        },
+        panelChrome,
+        personalPanels,
       },
     });
   },

--- a/apps/viewer/src/store/slices/workbenchSlice.ts
+++ b/apps/viewer/src/store/slices/workbenchSlice.ts
@@ -4,8 +4,10 @@
 
 import type { StateCreator } from 'zustand';
 import {
+  applyWorkbenchPatch,
   createDefaultWorkbenchLayout,
   normalizeWorkbenchLayout,
+  type FloatingPanelPlacement,
   type PersonalPanelDefinition,
   type UiAutomation,
   type WorkbenchLayoutState,
@@ -13,6 +15,7 @@ import {
   type WorkbenchModeSnapshot,
   type WorkbenchPanelChrome,
   type WorkbenchPanelId,
+  type WorkbenchPatch,
   type WorkbenchZoneId,
 } from '@ifc-lite/extensions';
 
@@ -29,6 +32,9 @@ export interface WorkbenchSlice {
   setWorkbenchBottomHeight: (height: number) => void;
   setWorkbenchCollapsed: (zone: WorkbenchZoneId, collapsed: boolean) => void;
   setWorkbenchPanelChrome: (panelId: WorkbenchPanelId, chrome: WorkbenchPanelChrome) => void;
+  setWorkbenchFloatingPanel: (placement: FloatingPanelPlacement) => void;
+  removeWorkbenchFloatingPanel: (panelId: WorkbenchPanelId) => void;
+  applyWorkbenchPatch: (patch: WorkbenchPatch) => void;
   addWorkbenchPersonalPanel: (panel: PersonalPanelDefinition, zone?: WorkbenchZoneId) => void;
   updateWorkbenchPersonalPanel: (panel: PersonalPanelDefinition) => void;
   removeWorkbenchPersonalPanel: (panelId: WorkbenchPanelId) => void;
@@ -112,6 +118,50 @@ export const createWorkbenchSlice: StateCreator<WorkbenchSlice, [], [], Workbenc
           [panelId]: { ...layout.panelChrome[panelId], ...chrome },
         },
       },
+    });
+  },
+
+  setWorkbenchFloatingPanel: (placement) => {
+    const layout = get().workbenchLayout;
+    set({
+      workbenchLayout: {
+        ...layout,
+        floating: [
+          ...layout.floating.filter((entry) => entry.panelId !== placement.panelId),
+          placement,
+        ],
+      },
+    });
+  },
+
+  removeWorkbenchFloatingPanel: (panelId) => {
+    const layout = get().workbenchLayout;
+    set({
+      workbenchLayout: {
+        ...layout,
+        floating: layout.floating.filter((entry) => entry.panelId !== panelId),
+      },
+    });
+  },
+
+  applyWorkbenchPatch: (patch) => {
+    const layout = get().workbenchLayout;
+    set({
+      workbenchLayout: applyWorkbenchPatch(layout, {
+        ...patch,
+        operations: [
+          ...patch.operations,
+          {
+            op: 'appendHistory',
+            entry: {
+              id: crypto.randomUUID(),
+              label: `Applied patch: ${patch.id}`,
+              patchId: patch.id,
+              createdAt: new Date().toISOString(),
+            },
+          },
+        ],
+      }),
     });
   },
 

--- a/apps/viewer/tsconfig.json
+++ b/apps/viewer/tsconfig.json
@@ -24,6 +24,7 @@
       "@ifc-lite/server-client": ["../../packages/server-client/src"],
       "@ifc-lite/ifcx": ["../../packages/ifcx/src"],
       "@ifc-lite/create": ["../../packages/create/src"],
+      "@ifc-lite/customization": ["../../packages/customization/src"],
       "@ifc-lite/ids": ["../../packages/ids/src"],
       "@ifc-lite/encoding": ["../../packages/encoding/src"],
       "@ifc-lite/lists": ["../../packages/lists/src"],

--- a/packages/customization/README.md
+++ b/packages/customization/README.md
@@ -1,0 +1,7 @@
+# @ifc-lite/customization
+
+Customization Studio core for IFC-Lite.
+
+This package is intentionally UI-free. It owns workbench patch simulation,
+change summaries, starter templates, and AI plan contracts that the viewer
+or future desktop/web hosts can render through their own host adapters.

--- a/packages/customization/package.json
+++ b/packages/customization/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@ifc-lite/customization",
+  "version": "0.1.0",
+  "description": "Customization Studio core: workbench patches, templates, simulation, and AI plan contracts for IFC-Lite",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "pnpm exec tsc",
+    "dev": "pnpm exec tsc --watch",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@ifc-lite/extensions": "workspace:^"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3",
+    "vitest": "^1.6.0"
+  },
+  "license": "MPL-2.0",
+  "author": "Louis True",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LTplus-AG/ifc-lite.git",
+    "directory": "packages/customization"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ]
+}

--- a/packages/customization/src/ai.ts
+++ b/packages/customization/src/ai.ts
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { BUILTIN_PANEL_IDS, type WorkbenchPatch } from '@ifc-lite/extensions';
+import { createFireSafetyPanelTemplate, createReviewWorkspaceTemplate } from './templates.js';
+import type { CustomizationPlan } from './types.js';
+
+export function draftCustomizationPlanFromPrompt(prompt: string, now = new Date().toISOString()): CustomizationPlan {
+  const normalized = prompt.toLowerCase();
+  if (normalized.includes('fire')) return createFireSafetyPanelTemplate(now).plan;
+  if (normalized.includes('qa') || normalized.includes('review') || normalized.includes('ids')) {
+    return createReviewWorkspaceTemplate(now).plan;
+  }
+  const patch: WorkbenchPatch = {
+    id: `ai.layout.${Date.now().toString(36)}`,
+    author: 'ai',
+    createdAt: now,
+    operations: [
+      { op: 'movePanel', panelId: BUILTIN_PANEL_IDS.properties, toZone: 'right', toIndex: 0 },
+      { op: 'setPanelChrome', panelId: BUILTIN_PANEL_IDS.properties, chrome: { title: 'Inspector' } },
+      {
+        op: 'appendHistory',
+        entry: { id: `history.ai.${Date.now().toString(36)}`, label: `AI draft: ${prompt.slice(0, 60)}`, createdAt: now },
+      },
+    ],
+  };
+  return {
+    schemaVersion: 1,
+    id: `plan.ai.${Date.now().toString(36)}`,
+    intent: 'morph-layout',
+    summary: `Draft UI morph for: ${prompt}`,
+    risks: [{ tier: 'caution', message: 'This is a heuristic local draft; review before applying.' }],
+    requiredCapabilities: [],
+    patch,
+  };
+}

--- a/packages/customization/src/customization.test.ts
+++ b/packages/customization/src/customization.test.ts
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, it } from 'vitest';
+import { BUILTIN_PANEL_IDS, createDefaultWorkbenchLayout } from '@ifc-lite/extensions';
+import { createReviewWorkspaceTemplate, simulateWorkbenchPatch, validateCustomizationPlan } from './index.js';
+
+describe('@ifc-lite/customization', () => {
+  it('simulates a workbench patch and summarizes changes', () => {
+    const layout = createDefaultWorkbenchLayout();
+    const template = createReviewWorkspaceTemplate('2026-01-01T00:00:00.000Z');
+    const patch = template.plan.patch;
+    if (!patch) throw new Error('template should include patch');
+    const result = simulateWorkbenchPatch(layout, patch);
+    expect(result.ok).toBe(true);
+    expect(result.next.zones.bottom).toContain(BUILTIN_PANEL_IDS.ids);
+    expect(result.changes.some((change) => change.operation === 'movePanel')).toBe(true);
+  });
+
+  it('validates plan shape', () => {
+    const template = createReviewWorkspaceTemplate('2026-01-01T00:00:00.000Z');
+    expect(validateCustomizationPlan(template.plan)).toEqual([]);
+    expect(validateCustomizationPlan({ ...template.plan, patch: undefined, widget: undefined })).toContain(
+      'Plan must include a workbench patch or widget.',
+    );
+  });
+});

--- a/packages/customization/src/customization.test.ts
+++ b/packages/customization/src/customization.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, expect, it } from 'vitest';
 import { BUILTIN_PANEL_IDS, createDefaultWorkbenchLayout } from '@ifc-lite/extensions';
-import { createReviewWorkspaceTemplate, simulateWorkbenchPatch, validateCustomizationPlan } from './index.js';
+import { createReviewWorkspaceTemplate, draftCustomizationPlanFromPrompt, listBuiltInEditableZones, simulateWorkbenchPatch, validateCustomizationPlan } from './index.js';
 
 describe('@ifc-lite/customization', () => {
   it('simulates a workbench patch and summarizes changes', () => {
@@ -24,5 +24,12 @@ describe('@ifc-lite/customization', () => {
     expect(validateCustomizationPlan({ ...template.plan, patch: undefined, widget: undefined })).toContain(
       'Plan must include a workbench patch or widget.',
     );
+  });
+
+  it('drafts AI customization plans and exposes built-in editable zones', () => {
+    const plan = draftCustomizationPlanFromPrompt('make a fire safety workspace', '2026-01-01T00:00:00.000Z');
+    expect(plan.intent).toBe('create-panel');
+    expect(plan.patch?.operations.some((operation) => operation.op === 'addPersonalPanel')).toBe(true);
+    expect(listBuiltInEditableZones().map((zone) => zone.panelId)).toContain(BUILTIN_PANEL_IDS.properties);
   });
 });

--- a/packages/customization/src/index.ts
+++ b/packages/customization/src/index.ts
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+export * from './types.js';
+export * from './simulate.js';
+export * from './templates.js';
+export * from './plan.js';

--- a/packages/customization/src/index.ts
+++ b/packages/customization/src/index.ts
@@ -6,3 +6,5 @@ export * from './types.js';
 export * from './simulate.js';
 export * from './templates.js';
 export * from './plan.js';
+export * from './zones.js';
+export * from './ai.js';

--- a/packages/customization/src/plan.ts
+++ b/packages/customization/src/plan.ts
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { CustomizationPlan } from './types.js';
+
+export function validateCustomizationPlan(plan: CustomizationPlan): string[] {
+  const errors: string[] = [];
+  if (plan.schemaVersion !== 1) errors.push('Unsupported customization plan schemaVersion.');
+  if (!plan.id) errors.push('Customization plan id is required.');
+  if (!plan.summary) errors.push('Customization plan summary is required.');
+  if (!plan.patch && !plan.widget) errors.push('Plan must include a workbench patch or widget.');
+  if (plan.patch && plan.patch.operations.length === 0) errors.push('Workbench patch contains no operations.');
+  return errors;
+}

--- a/packages/customization/src/simulate.ts
+++ b/packages/customization/src/simulate.ts
@@ -48,8 +48,12 @@ export function describeOperation(operation: WorkbenchOperation): PatchChangeSum
       return { operation: operation.op, label: 'Configure automation', detail: operation.automation.name };
     case 'deleteAutomation':
       return { operation: operation.op, label: 'Delete automation', detail: operation.automationId };
+    case 'appendAutomationRun':
+      return { operation: operation.op, label: 'Append automation run log', detail: operation.entry.automationName };
     case 'appendHistory':
       return { operation: operation.op, label: 'Append history', detail: operation.entry.label };
+    case 'setPanelConfig':
+      return { operation: operation.op, label: 'Update built-in panel config', detail: operation.panelId };
     case 'setHorizontalSizes':
       return { operation: operation.op, label: 'Resize horizontal layout', detail: operation.sizes.join(' / ') };
     case 'setBottomHeight':

--- a/packages/customization/src/simulate.ts
+++ b/packages/customization/src/simulate.ts
@@ -1,0 +1,86 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import {
+  applyWorkbenchPatch,
+  type WorkbenchLayoutState,
+  type WorkbenchOperation,
+  type WorkbenchPatch,
+} from '@ifc-lite/extensions';
+import type { PatchChangeSummary, PatchSimulationResult } from './types.js';
+
+export function simulateWorkbenchPatch(
+  base: WorkbenchLayoutState,
+  patch: WorkbenchPatch,
+): PatchSimulationResult {
+  const warnings = validatePatch(base, patch);
+  const next = applyWorkbenchPatch(base, patch);
+  return {
+    ok: warnings.length === 0,
+    base,
+    next,
+    changes: patch.operations.map(describeOperation),
+    warnings,
+  };
+}
+
+export function describeOperation(operation: WorkbenchOperation): PatchChangeSummary {
+  switch (operation.op) {
+    case 'movePanel':
+      return { operation: operation.op, label: 'Move panel', detail: `${operation.panelId} -> ${operation.toZone}` };
+    case 'setPanelChrome':
+      return { operation: operation.op, label: 'Update panel chrome', detail: operation.panelId };
+    case 'addPersonalPanel':
+      return { operation: operation.op, label: 'Add personal panel', detail: operation.panel.title };
+    case 'removePanel':
+      return { operation: operation.op, label: 'Remove panel', detail: operation.panelId };
+    case 'setFloatingPanel':
+      return { operation: operation.op, label: 'Float panel', detail: operation.placement.panelId };
+    case 'removeFloatingPanel':
+      return { operation: operation.op, label: 'Close floating panel', detail: operation.panelId };
+    case 'saveWorkspaceMode':
+      return { operation: operation.op, label: 'Save workspace mode', detail: operation.mode.name };
+    case 'deleteWorkspaceMode':
+      return { operation: operation.op, label: 'Delete workspace mode', detail: operation.modeId };
+    case 'addAutomation':
+    case 'updateAutomation':
+      return { operation: operation.op, label: 'Configure automation', detail: operation.automation.name };
+    case 'deleteAutomation':
+      return { operation: operation.op, label: 'Delete automation', detail: operation.automationId };
+    case 'appendHistory':
+      return { operation: operation.op, label: 'Append history', detail: operation.entry.label };
+    case 'setHorizontalSizes':
+      return { operation: operation.op, label: 'Resize horizontal layout', detail: operation.sizes.join(' / ') };
+    case 'setBottomHeight':
+      return { operation: operation.op, label: 'Resize bottom dock', detail: `${operation.height}px` };
+    case 'setCollapsed':
+      return { operation: operation.op, label: operation.collapsed ? 'Collapse dock' : 'Expand dock', detail: operation.zone };
+  }
+  const _exhaustive: never = operation;
+  throw new Error(`Unhandled workbench operation: ${JSON.stringify(_exhaustive)}`);
+}
+
+function validatePatch(base: WorkbenchLayoutState, patch: WorkbenchPatch): string[] {
+  const warnings: string[] = [];
+  if (patch.operations.length === 0) warnings.push('Patch contains no operations.');
+  for (const operation of patch.operations) {
+    if (operation.op === 'movePanel' || operation.op === 'removePanel') {
+      if (!panelExists(base, operation.panelId)) warnings.push(`Panel is not currently registered: ${operation.panelId}`);
+    }
+    if (operation.op === 'setFloatingPanel' && operation.placement.width < 240) {
+      warnings.push(`Floating panel ${operation.placement.panelId} is narrower than 240px.`);
+    }
+    if (operation.op === 'setBottomHeight' && operation.height < 120) {
+      warnings.push('Bottom dock height is below the minimum 120px.');
+    }
+  }
+  return warnings;
+}
+
+function panelExists(layout: WorkbenchLayoutState, panelId: string): boolean {
+  return layout.zones.left.includes(panelId)
+    || layout.zones.right.includes(panelId)
+    || layout.zones.bottom.includes(panelId)
+    || panelId in layout.personalPanels;
+}

--- a/packages/customization/src/templates.ts
+++ b/packages/customization/src/templates.ts
@@ -1,0 +1,95 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { BUILTIN_PANEL_IDS, type WorkbenchPatch } from '@ifc-lite/extensions';
+import type { CustomizationTemplate } from './types.js';
+
+export function createReviewWorkspaceTemplate(now = new Date().toISOString()): CustomizationTemplate {
+  const patch: WorkbenchPatch = {
+    id: `template.review.${Date.now().toString(36)}`,
+    author: 'system',
+    createdAt: now,
+    operations: [
+      { op: 'movePanel', panelId: BUILTIN_PANEL_IDS.bcf, toZone: 'right', toIndex: 1 },
+      { op: 'movePanel', panelId: BUILTIN_PANEL_IDS.ids, toZone: 'bottom', toIndex: 0 },
+      { op: 'setBottomHeight', height: 360 },
+      { op: 'setPanelChrome', panelId: BUILTIN_PANEL_IDS.bcf, chrome: { title: 'Issues' } },
+      { op: 'setPanelChrome', panelId: BUILTIN_PANEL_IDS.ids, chrome: { title: 'IDS QA' } },
+      {
+        op: 'appendHistory',
+        entry: {
+          id: `history.review.${Date.now().toString(36)}`,
+          label: 'Applied Review workspace template',
+          patchId: `template.review.${Date.now().toString(36)}`,
+          createdAt: now,
+        },
+      },
+    ],
+  };
+  return {
+    id: 'template.review-workspace',
+    name: 'Review workspace',
+    description: 'Moves issue and IDS review surfaces into a focused QA workspace.',
+    plan: {
+      schemaVersion: 1,
+      id: 'plan.review-workspace',
+      intent: 'morph-layout',
+      summary: 'Create a review-focused workspace with issues and IDS visible.',
+      risks: [{ tier: 'info', message: 'Only layout and panel chrome are changed.' }],
+      requiredCapabilities: [],
+      patch,
+    },
+  };
+}
+
+export function createFireSafetyPanelTemplate(now = new Date().toISOString()): CustomizationTemplate {
+  const panelId = `user:panel:fire-safety:${Date.now().toString(36)}`;
+  return {
+    id: 'template.fire-safety-panel',
+    name: 'Fire safety panel',
+    description: 'Creates a personal dashboard scaffold for fire-safety review prompts.',
+    plan: {
+      schemaVersion: 1,
+      id: 'plan.fire-safety-panel',
+      intent: 'create-panel',
+      summary: 'Add a fire-safety review panel to the right dock.',
+      risks: [{ tier: 'info', message: 'Adds a local personal panel only.' }],
+      requiredCapabilities: [],
+      patch: {
+        id: `template.fire-safety.${Date.now().toString(36)}`,
+        author: 'system',
+        createdAt: now,
+        operations: [
+          {
+            op: 'addPersonalPanel',
+            zone: 'right',
+            panel: {
+              id: panelId,
+              title: 'Fire safety',
+              createdAt: now,
+              updatedAt: now,
+              widget: {
+                type: 'Stack',
+                direction: 'vertical',
+                gap: 'md',
+                children: [
+                  { type: 'Text', variant: 'heading', text: 'Fire safety review' },
+                  { type: 'Markdown', content: 'Track missing fire ratings, doors, exits, and compartment notes here.' },
+                  { type: 'KeyValueGrid', rows: [{ label: 'Status', value: 'Draft' }, { label: 'Source', value: 'Personal flavor' }] },
+                ],
+              },
+            },
+          },
+        ],
+      },
+    },
+  };
+}
+
+export function listCustomizationTemplates(): CustomizationTemplate[] {
+  return [
+    createReviewWorkspaceTemplate(),
+    createFireSafetyPanelTemplate(),
+  ];
+}

--- a/packages/customization/src/types.ts
+++ b/packages/customization/src/types.ts
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type {
+  JsonValue,
+  WorkbenchLayoutState,
+  WorkbenchOperation,
+  WorkbenchPatch,
+} from '@ifc-lite/extensions';
+
+export type CustomizationIntentKind =
+  | 'morph-layout'
+  | 'create-panel'
+  | 'edit-panel'
+  | 'create-extension'
+  | 'create-automation'
+  | 'merge-flavor'
+  | 'debug-customization';
+
+export interface CustomizationRisk {
+  tier: 'info' | 'caution' | 'requires-review';
+  message: string;
+}
+
+export interface CustomizationPlan {
+  schemaVersion: 1;
+  id: string;
+  intent: CustomizationIntentKind;
+  summary: string;
+  risks: CustomizationRisk[];
+  requiredCapabilities: string[];
+  patch?: WorkbenchPatch;
+  widget?: JsonValue;
+  notes?: string[];
+}
+
+export interface PatchChangeSummary {
+  operation: WorkbenchOperation['op'];
+  label: string;
+  detail?: string;
+}
+
+export interface PatchSimulationResult {
+  ok: boolean;
+  base: WorkbenchLayoutState;
+  next: WorkbenchLayoutState;
+  changes: PatchChangeSummary[];
+  warnings: string[];
+}
+
+export interface CustomizationTemplate {
+  id: string;
+  name: string;
+  description: string;
+  plan: CustomizationPlan;
+}

--- a/packages/customization/src/zones.ts
+++ b/packages/customization/src/zones.ts
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { BUILTIN_PANEL_IDS, type JsonValue } from '@ifc-lite/extensions';
+
+export interface BuiltInEditableZoneDescriptor {
+  panelId: string;
+  label: string;
+  description: string;
+  defaults: JsonValue;
+}
+
+export function listBuiltInEditableZones(): BuiltInEditableZoneDescriptor[] {
+  return [
+    {
+      panelId: BUILTIN_PANEL_IDS.properties,
+      label: 'Properties panel',
+      description: 'Control density, default expansion, and pinned property fields.',
+      defaults: { density: 'comfortable', defaultExpanded: ['Identity'], pinnedFields: ['GlobalId', 'Name', 'Type'] },
+    },
+    {
+      panelId: BUILTIN_PANEL_IDS.hierarchy,
+      label: 'Hierarchy panel',
+      description: 'Control grouping, sort order, and badge display.',
+      defaults: { grouping: 'spatial', sort: 'ifc', badges: ['Type'] },
+    },
+    {
+      panelId: 'builtin:toolbar',
+      label: 'Toolbar',
+      description: 'Control toolbar density and command grouping.',
+      defaults: { density: 'compact', groups: ['file', 'tools', 'view', 'extensions'] },
+    },
+    {
+      panelId: 'builtin:status-bar',
+      label: 'Status bar',
+      description: 'Control visible status segments.',
+      defaults: { segments: ['status', 'stats', 'performance', 'flavor', 'version'] },
+    },
+  ];
+}

--- a/packages/customization/tsconfig.json
+++ b/packages/customization/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/customization/vitest.config.ts
+++ b/packages/customization/vitest.config.ts
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+});

--- a/packages/extensions/src/flavor/merge.ts
+++ b/packages/extensions/src/flavor/merge.ts
@@ -27,6 +27,7 @@
 
 import type { Flavor, FlavorExtension, KeybindingOverride, SavedLens, SavedQuery } from './types.js';
 import type { JsonValue } from '../types.js';
+import { mergeWorkbenchLayouts, normalizeWorkbenchLayout } from '../layout/index.js';
 
 export interface MergeConflict {
   kind:
@@ -35,7 +36,8 @@ export interface MergeConflict {
     | 'lens'
     | 'saved_query'
     | 'keybinding'
-    | 'setting';
+    | 'setting'
+    | 'layout';
   /** Stable identifier within the conflict kind (extension id, setting key, etc.). */
   key: string;
   /** Display-only labels. */
@@ -69,6 +71,20 @@ export function mergeFlavors(base: Flavor, theirs: Flavor, ours: Flavor): MergeR
   });
 
   const settings = mergeSettings(base, theirs, ours, conflicts);
+  const layoutMerge = mergeWorkbenchLayouts(
+    normalizeWorkbenchLayout(base.layout.state),
+    normalizeWorkbenchLayout(theirs.layout.state),
+    normalizeWorkbenchLayout(ours.layout.state),
+  );
+  for (const conflict of layoutMerge.conflicts) {
+    conflicts.push({
+      kind: 'layout',
+      key: `${conflict.kind}:${conflict.key}`,
+      ours: conflict.ours,
+      theirs: conflict.theirs,
+      base: conflict.base,
+    });
+  }
   const promptOverlay = mergePromptOverlay(theirs, ours);
 
   const merged: Flavor = {
@@ -82,7 +98,7 @@ export function mergeFlavors(base: Flavor, theirs: Flavor, ours: Flavor): MergeR
     lenses,
     savedQueries,
     keybindings,
-    layout: theirs.layout, // theirs wins
+    layout: { state: layoutMerge.merged },
     settings,
     promptOverlay,
     author: ours.author,

--- a/packages/extensions/src/flavor/schema.ts
+++ b/packages/extensions/src/flavor/schema.ts
@@ -11,6 +11,7 @@
 
 import type { Flavor, FlavorExtension } from './types.js';
 import type { ValidationError, ValidationResult } from '../types.js';
+import { normalizeWorkbenchLayout } from '../layout/index.js';
 
 const ID_RE = /^[a-z0-9]+([._-][a-z0-9]+)*$/;
 const SEMVER_RE = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
@@ -86,7 +87,7 @@ export function validateFlavor(input: unknown): ValidationResult<Flavor> {
       lenses: flavor.lenses ?? [],
       savedQueries: flavor.savedQueries ?? [],
       keybindings: flavor.keybindings ?? [],
-      layout: flavor.layout ?? { state: {} },
+      layout: { state: normalizeWorkbenchLayout(flavor.layout?.state ?? flavor.layout) },
       settings: flavor.settings ?? {},
     },
   };

--- a/packages/extensions/src/flavor/types.ts
+++ b/packages/extensions/src/flavor/types.ts
@@ -14,6 +14,7 @@
  */
 
 import type { JsonValue } from '../types.js';
+import type { WorkbenchLayoutState } from '../layout/types.js';
 
 /** Top-level flavor record. */
 export interface Flavor {
@@ -78,8 +79,8 @@ export interface KeybindingOverride {
 }
 
 export interface LayoutOverride {
-  /** Opaque shape — the viewer's layout slice owns it. */
-  state: Record<string, JsonValue>;
+  /** Viewer workbench layout. Empty legacy state normalises to viewer defaults. */
+  state: WorkbenchLayoutState | Record<string, JsonValue>;
 }
 
 export interface PromptOverlay {

--- a/packages/extensions/src/host/loader.test.ts
+++ b/packages/extensions/src/host/loader.test.ts
@@ -70,6 +70,23 @@ describe('manifestToContributions', () => {
     expect(out[0].slot).toBe('toolbar.right');
   });
 
+  it('translates first-class workbench panels into the workbench slot', () => {
+    const out = manifestToContributions('ext-a', {
+      panels: [{
+        id: 'qa',
+        title: 'QA panel',
+        widget: 'widgets/qa.json',
+        defaultPlacement: 'right',
+      }],
+    } as ManifestContributions);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      extensionId: 'ext-a',
+      slot: 'workbench.panels',
+      payload: { id: 'qa', defaultPlacement: 'right' },
+    });
+  });
+
   it('keeps extension ids consistent', () => {
     const out = manifestToContributions('ext-a', {
       commands: [{ id: 'x', title: 'X' }],

--- a/packages/extensions/src/host/loader.ts
+++ b/packages/extensions/src/host/loader.ts
@@ -257,6 +257,9 @@ export function manifestToContributions(
   for (const c of contributes.commands ?? []) {
     out.push({ extensionId, slot: 'commandPalette', payload: c });
   }
+  for (const p of contributes.panels ?? []) {
+    out.push({ extensionId, slot: 'workbench.panels', payload: p });
+  }
   for (const t of contributes.toolbar ?? []) {
     const cmd = commandIndex.get(t.command);
     out.push({

--- a/packages/extensions/src/index.ts
+++ b/packages/extensions/src/index.ts
@@ -92,6 +92,7 @@ export * from './signing/index.js';
 
 // ---------- Flavors (Phase 3 library)
 export * from './flavor/index.js';
+export * from './layout/index.js';
 
 // ---------- Action log + miner (Phase 4 library)
 export * from './log/index.js';

--- a/packages/extensions/src/index.ts
+++ b/packages/extensions/src/index.ts
@@ -33,6 +33,7 @@ export type {
   ExporterContribution,
   ExtensionManifest,
   IdsValidatorContribution,
+  JsonValue,
   KeybindingContribution,
   LensContribution,
   ManifestAuthor,

--- a/packages/extensions/src/index.ts
+++ b/packages/extensions/src/index.ts
@@ -39,6 +39,8 @@ export type {
   ManifestAuthor,
   ManifestContributions,
   ManifestEntry,
+  PanelContribution,
+  PanelPlacement,
   ManifestTest,
   ManifestTestExpect,
   RiskTier,

--- a/packages/extensions/src/layout/defaults.ts
+++ b/packages/extensions/src/layout/defaults.ts
@@ -1,0 +1,60 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { WorkbenchLayoutState } from './types.js';
+
+export const DEFAULT_WORKBENCH_LAYOUT_ID = 'ifc-lite.viewer.default.v1';
+
+export const BUILTIN_PANEL_IDS = {
+  hierarchy: 'builtin:panel:hierarchy',
+  properties: 'builtin:panel:properties',
+  bcf: 'builtin:panel:bcf',
+  ids: 'builtin:panel:ids',
+  lens: 'builtin:panel:lens',
+  extensions: 'builtin:panel:extensions',
+  addElement: 'builtin:panel:add-element',
+  lists: 'builtin:panel:lists',
+  script: 'builtin:panel:script',
+  gantt: 'builtin:panel:gantt',
+} as const;
+
+export function createDefaultWorkbenchLayout(): WorkbenchLayoutState {
+  return {
+    schemaVersion: 1,
+    baseLayoutId: DEFAULT_WORKBENCH_LAYOUT_ID,
+    zones: {
+      left: [BUILTIN_PANEL_IDS.hierarchy],
+      right: [
+        BUILTIN_PANEL_IDS.properties,
+        BUILTIN_PANEL_IDS.bcf,
+        BUILTIN_PANEL_IDS.ids,
+        BUILTIN_PANEL_IDS.lens,
+        BUILTIN_PANEL_IDS.extensions,
+        BUILTIN_PANEL_IDS.addElement,
+      ],
+      bottom: [
+        BUILTIN_PANEL_IDS.lists,
+        BUILTIN_PANEL_IDS.script,
+        BUILTIN_PANEL_IDS.gantt,
+      ],
+    },
+    sizes: {
+      horizontal: [20, 58, 22],
+      bottomHeight: 300,
+    },
+    collapsed: {
+      left: false,
+      right: false,
+      bottom: false,
+    },
+    activeTabs: {
+      left: BUILTIN_PANEL_IDS.hierarchy,
+      right: BUILTIN_PANEL_IDS.properties,
+      bottom: undefined,
+    },
+    floating: [],
+    panelChrome: {},
+    personalPanels: {},
+  };
+}

--- a/packages/extensions/src/layout/defaults.ts
+++ b/packages/extensions/src/layout/defaults.ts
@@ -56,5 +56,8 @@ export function createDefaultWorkbenchLayout(): WorkbenchLayoutState {
     floating: [],
     panelChrome: {},
     personalPanels: {},
+    workspaceModes: {},
+    automations: [],
+    history: [],
   };
 }

--- a/packages/extensions/src/layout/defaults.ts
+++ b/packages/extensions/src/layout/defaults.ts
@@ -55,9 +55,11 @@ export function createDefaultWorkbenchLayout(): WorkbenchLayoutState {
     },
     floating: [],
     panelChrome: {},
+    panelConfigs: {},
     personalPanels: {},
     workspaceModes: {},
     automations: [],
+    automationRuns: [],
     history: [],
   };
 }

--- a/packages/extensions/src/layout/index.ts
+++ b/packages/extensions/src/layout/index.ts
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+export * from './types.js';
+export * from './defaults.js';
+export * from './normalize.js';
+export * from './merge.js';

--- a/packages/extensions/src/layout/index.ts
+++ b/packages/extensions/src/layout/index.ts
@@ -6,3 +6,4 @@ export * from './types.js';
 export * from './defaults.js';
 export * from './normalize.js';
 export * from './merge.js';
+export * from './patch.js';

--- a/packages/extensions/src/layout/layout.test.ts
+++ b/packages/extensions/src/layout/layout.test.ts
@@ -60,10 +60,12 @@ describe('applyWorkbenchPatch', () => {
         { op: 'movePanel', panelId: BUILTIN_PANEL_IDS.ids, toZone: 'bottom', toIndex: 0 },
         { op: 'setPanelChrome', panelId: BUILTIN_PANEL_IDS.ids, chrome: { title: 'QA checks' } },
         { op: 'setBottomHeight', height: 420 },
+        { op: 'appendHistory', entry: { id: 'hist.one', label: 'AI layout morph', createdAt: '2026-01-01T00:00:00.000Z' } },
       ],
     });
     expect(next.zones.bottom[0]).toBe(BUILTIN_PANEL_IDS.ids);
     expect(next.panelChrome[BUILTIN_PANEL_IDS.ids].title).toBe('QA checks');
     expect(next.sizes.bottomHeight).toBe(420);
+    expect(next.history[0].label).toBe('AI layout morph');
   });
 });

--- a/packages/extensions/src/layout/layout.test.ts
+++ b/packages/extensions/src/layout/layout.test.ts
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, it } from 'vitest';
+import { BUILTIN_PANEL_IDS, createDefaultWorkbenchLayout, mergeWorkbenchLayouts, normalizeWorkbenchLayout } from './index.js';
+
+describe('workbench layout normalization', () => {
+  it('defaults legacy empty layout state', () => {
+    const layout = normalizeWorkbenchLayout({});
+    expect(layout.schemaVersion).toBe(1);
+    expect(layout.zones.left).toEqual([BUILTIN_PANEL_IDS.hierarchy]);
+  });
+
+  it('keeps valid user panel order and clamps bottom height', () => {
+    const layout = normalizeWorkbenchLayout({
+      schemaVersion: 1,
+      zones: { left: ['a', 'a', 'b'], right: [], bottom: [] },
+      sizes: { horizontal: [25, 50, 25], bottomHeight: 9999 },
+    });
+    expect(layout.zones.left).toEqual(['a', 'b']);
+    expect(layout.sizes.horizontal).toEqual([25, 50, 25]);
+    expect(layout.sizes.bottomHeight).toBe(1200);
+  });
+});
+
+describe('mergeWorkbenchLayouts', () => {
+  it('takes one-sided panel moves without conflict', () => {
+    const base = createDefaultWorkbenchLayout();
+    const theirs = createDefaultWorkbenchLayout();
+    const ours = createDefaultWorkbenchLayout();
+    ours.zones.left = [...ours.zones.left, BUILTIN_PANEL_IDS.bcf];
+    ours.zones.right = ours.zones.right.filter((id) => id !== BUILTIN_PANEL_IDS.bcf);
+    const result = mergeWorkbenchLayouts(base, theirs, ours);
+    expect(result.conflicts).toEqual([]);
+    expect(result.merged.zones.left).toContain(BUILTIN_PANEL_IDS.bcf);
+  });
+
+  it('surfaces conflicting panel moves', () => {
+    const base = createDefaultWorkbenchLayout();
+    const theirs = createDefaultWorkbenchLayout();
+    const ours = createDefaultWorkbenchLayout();
+    theirs.zones.bottom = [...theirs.zones.bottom, BUILTIN_PANEL_IDS.bcf];
+    theirs.zones.right = theirs.zones.right.filter((id) => id !== BUILTIN_PANEL_IDS.bcf);
+    ours.zones.left = [...ours.zones.left, BUILTIN_PANEL_IDS.bcf];
+    ours.zones.right = ours.zones.right.filter((id) => id !== BUILTIN_PANEL_IDS.bcf);
+    const result = mergeWorkbenchLayouts(base, theirs, ours);
+    expect(result.conflicts.some((c) => c.kind === 'panel_move')).toBe(true);
+  });
+});

--- a/packages/extensions/src/layout/layout.test.ts
+++ b/packages/extensions/src/layout/layout.test.ts
@@ -59,12 +59,14 @@ describe('applyWorkbenchPatch', () => {
       operations: [
         { op: 'movePanel', panelId: BUILTIN_PANEL_IDS.ids, toZone: 'bottom', toIndex: 0 },
         { op: 'setPanelChrome', panelId: BUILTIN_PANEL_IDS.ids, chrome: { title: 'QA checks' } },
+        { op: 'setFloatingPanel', placement: { panelId: BUILTIN_PANEL_IDS.bcf, x: 10, y: 20, width: 300, height: 400 } },
         { op: 'setBottomHeight', height: 420 },
         { op: 'appendHistory', entry: { id: 'hist.one', label: 'AI layout morph', createdAt: '2026-01-01T00:00:00.000Z' } },
       ],
     });
     expect(next.zones.bottom[0]).toBe(BUILTIN_PANEL_IDS.ids);
     expect(next.panelChrome[BUILTIN_PANEL_IDS.ids].title).toBe('QA checks');
+    expect(next.floating[0]).toMatchObject({ panelId: BUILTIN_PANEL_IDS.bcf, x: 10 });
     expect(next.sizes.bottomHeight).toBe(420);
     expect(next.history[0].label).toBe('AI layout morph');
   });

--- a/packages/extensions/src/layout/layout.test.ts
+++ b/packages/extensions/src/layout/layout.test.ts
@@ -61,6 +61,7 @@ describe('applyWorkbenchPatch', () => {
         { op: 'setPanelChrome', panelId: BUILTIN_PANEL_IDS.ids, chrome: { title: 'QA checks' } },
         { op: 'setFloatingPanel', placement: { panelId: BUILTIN_PANEL_IDS.bcf, x: 10, y: 20, width: 300, height: 400 } },
         { op: 'setBottomHeight', height: 420 },
+        { op: 'setPanelConfig', panelId: BUILTIN_PANEL_IDS.properties, config: { density: 'compact' } },
         { op: 'appendHistory', entry: { id: 'hist.one', label: 'AI layout morph', createdAt: '2026-01-01T00:00:00.000Z' } },
       ],
     });
@@ -68,6 +69,7 @@ describe('applyWorkbenchPatch', () => {
     expect(next.panelChrome[BUILTIN_PANEL_IDS.ids].title).toBe('QA checks');
     expect(next.floating[0]).toMatchObject({ panelId: BUILTIN_PANEL_IDS.bcf, x: 10 });
     expect(next.sizes.bottomHeight).toBe(420);
+    expect(next.panelConfigs[BUILTIN_PANEL_IDS.properties]).toEqual({ density: 'compact' });
     expect(next.history[0].label).toBe('AI layout morph');
   });
 });

--- a/packages/extensions/src/layout/layout.test.ts
+++ b/packages/extensions/src/layout/layout.test.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { describe, expect, it } from 'vitest';
-import { BUILTIN_PANEL_IDS, createDefaultWorkbenchLayout, mergeWorkbenchLayouts, normalizeWorkbenchLayout } from './index.js';
+import { applyWorkbenchPatch, BUILTIN_PANEL_IDS, createDefaultWorkbenchLayout, mergeWorkbenchLayouts, normalizeWorkbenchLayout } from './index.js';
 
 describe('workbench layout normalization', () => {
   it('defaults legacy empty layout state', () => {
@@ -46,5 +46,24 @@ describe('mergeWorkbenchLayouts', () => {
     ours.zones.right = ours.zones.right.filter((id) => id !== BUILTIN_PANEL_IDS.bcf);
     const result = mergeWorkbenchLayouts(base, theirs, ours);
     expect(result.conflicts.some((c) => c.kind === 'panel_move')).toBe(true);
+  });
+});
+
+describe('applyWorkbenchPatch', () => {
+  it('applies AI-friendly layout operations in order', () => {
+    const base = createDefaultWorkbenchLayout();
+    const next = applyWorkbenchPatch(base, {
+      id: 'patch.one',
+      author: 'ai',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      operations: [
+        { op: 'movePanel', panelId: BUILTIN_PANEL_IDS.ids, toZone: 'bottom', toIndex: 0 },
+        { op: 'setPanelChrome', panelId: BUILTIN_PANEL_IDS.ids, chrome: { title: 'QA checks' } },
+        { op: 'setBottomHeight', height: 420 },
+      ],
+    });
+    expect(next.zones.bottom[0]).toBe(BUILTIN_PANEL_IDS.ids);
+    expect(next.panelChrome[BUILTIN_PANEL_IDS.ids].title).toBe('QA checks');
+    expect(next.sizes.bottomHeight).toBe(420);
   });
 });

--- a/packages/extensions/src/layout/merge.ts
+++ b/packages/extensions/src/layout/merge.ts
@@ -35,6 +35,9 @@ export function mergeWorkbenchLayouts(
     floating: mergeValue(base.floating, theirs.floating, ours.floating, conflicts, 'panel_move', 'floating'),
     panelChrome: mergeRecord(base.panelChrome, theirs.panelChrome, ours.panelChrome, conflicts, 'panel_chrome'),
     personalPanels: mergeRecord(base.personalPanels, theirs.personalPanels, ours.personalPanels, conflicts, 'personal_panel'),
+    workspaceModes: mergeRecord(base.workspaceModes, theirs.workspaceModes, ours.workspaceModes, conflicts, 'panel_chrome'),
+    automations: mergeValue(base.automations, theirs.automations, ours.automations, conflicts, 'panel_chrome', 'automations'),
+    history: [...ours.history, ...theirs.history.filter((entry) => !ours.history.some((oursEntry) => oursEntry.id === entry.id))].slice(-50),
   };
   return { merged, conflicts };
 }

--- a/packages/extensions/src/layout/merge.ts
+++ b/packages/extensions/src/layout/merge.ts
@@ -1,0 +1,152 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { JsonValue } from '../types.js';
+import type {
+  LayoutMergeConflict,
+  LayoutMergeResult,
+  WorkbenchLayoutState,
+  WorkbenchPanelId,
+  WorkbenchZoneId,
+} from './types.js';
+
+const ZONES: WorkbenchZoneId[] = ['left', 'right', 'bottom'];
+
+export function mergeWorkbenchLayouts(
+  base: WorkbenchLayoutState,
+  theirs: WorkbenchLayoutState,
+  ours: WorkbenchLayoutState,
+): LayoutMergeResult {
+  const conflicts: LayoutMergeConflict[] = [];
+  const merged: WorkbenchLayoutState = {
+    ...ours,
+    zones: mergeZones(base, theirs, ours, conflicts),
+    sizes: {
+      horizontal: mergeValue(base.sizes.horizontal, theirs.sizes.horizontal, ours.sizes.horizontal, conflicts, 'split_resize', 'horizontal'),
+      bottomHeight: mergeValue(base.sizes.bottomHeight, theirs.sizes.bottomHeight, ours.sizes.bottomHeight, conflicts, 'split_resize', 'bottomHeight'),
+    },
+    collapsed: {
+      left: mergeValue(base.collapsed.left, theirs.collapsed.left, ours.collapsed.left, conflicts, 'split_resize', 'collapsed.left'),
+      right: mergeValue(base.collapsed.right, theirs.collapsed.right, ours.collapsed.right, conflicts, 'split_resize', 'collapsed.right'),
+      bottom: mergeValue(base.collapsed.bottom, theirs.collapsed.bottom, ours.collapsed.bottom, conflicts, 'split_resize', 'collapsed.bottom'),
+    },
+    activeTabs: { ...theirs.activeTabs, ...ours.activeTabs },
+    floating: mergeValue(base.floating, theirs.floating, ours.floating, conflicts, 'panel_move', 'floating'),
+    panelChrome: mergeRecord(base.panelChrome, theirs.panelChrome, ours.panelChrome, conflicts, 'panel_chrome'),
+    personalPanels: mergeRecord(base.personalPanels, theirs.personalPanels, ours.personalPanels, conflicts, 'personal_panel'),
+  };
+  return { merged, conflicts };
+}
+
+function mergeZones(
+  base: WorkbenchLayoutState,
+  theirs: WorkbenchLayoutState,
+  ours: WorkbenchLayoutState,
+  conflicts: LayoutMergeConflict[],
+): Record<WorkbenchZoneId, WorkbenchPanelId[]> {
+  const out: Record<WorkbenchZoneId, WorkbenchPanelId[]> = { left: [], right: [], bottom: [] };
+  const allPanels = new Set<string>();
+  for (const layout of [base, theirs, ours]) {
+    for (const zone of ZONES) for (const panelId of layout.zones[zone]) allPanels.add(panelId);
+  }
+  for (const panelId of allPanels) {
+    const baseZone = findZone(base, panelId);
+    const theirZone = findZone(theirs, panelId);
+    const ourZone = findZone(ours, panelId);
+    const zone = resolvePanelZone(panelId, baseZone, theirZone, ourZone, conflicts);
+    if (zone) out[zone].push(panelId);
+  }
+  for (const zone of ZONES) {
+    out[zone] = orderPanels(zone, out[zone], base, theirs, ours, conflicts);
+  }
+  return out;
+}
+
+function resolvePanelZone(
+  panelId: string,
+  baseZone: WorkbenchZoneId | undefined,
+  theirZone: WorkbenchZoneId | undefined,
+  ourZone: WorkbenchZoneId | undefined,
+  conflicts: LayoutMergeConflict[],
+): WorkbenchZoneId | undefined {
+  if (theirZone === ourZone) return theirZone;
+  if (baseZone === ourZone) return theirZone;
+  if (baseZone === theirZone) return ourZone;
+  conflicts.push({
+    kind: 'panel_move',
+    key: panelId,
+    ours: (ourZone ?? null) as JsonValue,
+    theirs: (theirZone ?? null) as JsonValue,
+    base: (baseZone ?? null) as JsonValue,
+  });
+  return ourZone ?? theirZone;
+}
+
+function orderPanels(
+  zone: WorkbenchZoneId,
+  panels: string[],
+  base: WorkbenchLayoutState,
+  theirs: WorkbenchLayoutState,
+  ours: WorkbenchLayoutState,
+  conflicts: LayoutMergeConflict[],
+): string[] {
+  const theirOrder = theirs.zones[zone].filter((id) => panels.includes(id));
+  const ourOrder = ours.zones[zone].filter((id) => panels.includes(id));
+  if (arraysEqual(theirOrder, ourOrder)) return ourOrder;
+  if (arraysEqual(base.zones[zone].filter((id) => panels.includes(id)), ourOrder)) return theirOrder;
+  if (arraysEqual(base.zones[zone].filter((id) => panels.includes(id)), theirOrder)) return ourOrder;
+  conflicts.push({
+    kind: 'zone_order',
+    key: zone,
+    ours: ourOrder as JsonValue,
+    theirs: theirOrder as JsonValue,
+    base: base.zones[zone] as JsonValue,
+  });
+  return stableUnion(ourOrder, theirOrder);
+}
+
+function mergeRecord<T>(
+  base: Record<string, T>,
+  theirs: Record<string, T>,
+  ours: Record<string, T>,
+  conflicts: LayoutMergeConflict[],
+  kind: LayoutMergeConflict['kind'],
+): Record<string, T> {
+  const out: Record<string, T> = {};
+  for (const key of new Set([...Object.keys(base), ...Object.keys(theirs), ...Object.keys(ours)])) {
+    out[key] = mergeValue(base[key], theirs[key], ours[key], conflicts, kind, key);
+  }
+  return out;
+}
+
+function mergeValue<T>(
+  base: T,
+  theirs: T,
+  ours: T,
+  conflicts: LayoutMergeConflict[],
+  kind: LayoutMergeConflict['kind'],
+  key: string,
+): T {
+  if (deepEqual(theirs, ours)) return ours;
+  if (deepEqual(base, ours)) return theirs;
+  if (deepEqual(base, theirs)) return ours;
+  conflicts.push({ kind, key, ours: ours as JsonValue, theirs: theirs as JsonValue, base: base as JsonValue });
+  return ours;
+}
+
+function findZone(layout: WorkbenchLayoutState, panelId: string): WorkbenchZoneId | undefined {
+  return ZONES.find((zone) => layout.zones[zone].includes(panelId));
+}
+
+function stableUnion(a: string[], b: string[]): string[] {
+  return [...a, ...b.filter((item) => !a.includes(item))];
+}
+
+function arraysEqual(a: readonly string[], b: readonly string[]): boolean {
+  return a.length === b.length && a.every((item, index) => item === b[index]);
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}

--- a/packages/extensions/src/layout/merge.ts
+++ b/packages/extensions/src/layout/merge.ts
@@ -34,9 +34,11 @@ export function mergeWorkbenchLayouts(
     activeTabs: { ...theirs.activeTabs, ...ours.activeTabs },
     floating: mergeValue(base.floating, theirs.floating, ours.floating, conflicts, 'panel_move', 'floating'),
     panelChrome: mergeRecord(base.panelChrome, theirs.panelChrome, ours.panelChrome, conflicts, 'panel_chrome'),
+    panelConfigs: mergeRecord(base.panelConfigs, theirs.panelConfigs, ours.panelConfigs, conflicts, 'panel_chrome'),
     personalPanels: mergeRecord(base.personalPanels, theirs.personalPanels, ours.personalPanels, conflicts, 'personal_panel'),
     workspaceModes: mergeRecord(base.workspaceModes, theirs.workspaceModes, ours.workspaceModes, conflicts, 'panel_chrome'),
     automations: mergeValue(base.automations, theirs.automations, ours.automations, conflicts, 'panel_chrome', 'automations'),
+    automationRuns: [...ours.automationRuns, ...theirs.automationRuns.filter((entry) => !ours.automationRuns.some((oursEntry) => oursEntry.id === entry.id))].slice(-100),
     history: [...ours.history, ...theirs.history.filter((entry) => !ours.history.some((oursEntry) => oursEntry.id === entry.id))].slice(-50),
   };
   return { merged, conflicts };

--- a/packages/extensions/src/layout/normalize.ts
+++ b/packages/extensions/src/layout/normalize.ts
@@ -7,7 +7,9 @@ import { createDefaultWorkbenchLayout } from './defaults.js';
 import type {
   FloatingPanelPlacement,
   PersonalPanelDefinition,
+  UiAutomation,
   WorkbenchLayoutState,
+  WorkbenchMode,
   WorkbenchPanelChrome,
   WorkbenchZoneId,
 } from './types.js';
@@ -54,6 +56,9 @@ export function normalizeWorkbenchLayout(input: unknown): WorkbenchLayoutState {
     floating: readFloating(raw.floating),
     panelChrome: readRecord(raw.panelChrome, isPanelChrome),
     personalPanels: readRecord(raw.personalPanels, isPersonalPanel),
+    workspaceModes: readRecord(raw.workspaceModes, isWorkbenchMode),
+    automations: readAutomations(raw.automations),
+    history: Array.isArray(raw.history) ? raw.history.filter(isHistoryEntry).slice(-50) : [],
   };
 }
 
@@ -117,6 +122,41 @@ function isPersonalPanel(value: unknown): value is PersonalPanelDefinition {
     && isJsonValue(value.widget)
     && typeof value.createdAt === 'string'
     && typeof value.updatedAt === 'string';
+}
+
+function isWorkbenchMode(value: unknown): value is WorkbenchMode {
+  if (!isPlainObject(value) || typeof value.id !== 'string' || typeof value.name !== 'string') return false;
+  if (typeof value.createdAt !== 'string' || typeof value.updatedAt !== 'string') return false;
+  const snapshot = value.snapshot;
+  return isPlainObject(snapshot)
+    && isPlainObject(snapshot.zones)
+    && isPlainObject(snapshot.sizes)
+    && isPlainObject(snapshot.collapsed)
+    && isPlainObject(snapshot.activeTabs)
+    && Array.isArray(snapshot.floating)
+    && isPlainObject(snapshot.panelChrome);
+}
+
+function readAutomations(raw: unknown): UiAutomation[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.filter(isAutomation);
+}
+
+function isAutomation(value: unknown): value is UiAutomation {
+  if (!isPlainObject(value)) return false;
+  return typeof value.id === 'string'
+    && typeof value.name === 'string'
+    && typeof value.enabled === 'boolean'
+    && isPlainObject(value.trigger)
+    && typeof value.trigger.kind === 'string'
+    && Array.isArray(value.actions);
+}
+
+function isHistoryEntry(value: unknown): value is WorkbenchLayoutState['history'][number] {
+  return isPlainObject(value)
+    && typeof value.id === 'string'
+    && typeof value.label === 'string'
+    && typeof value.createdAt === 'string';
 }
 
 function isFloating(value: unknown): value is FloatingPanelPlacement {

--- a/packages/extensions/src/layout/normalize.ts
+++ b/packages/extensions/src/layout/normalize.ts
@@ -1,0 +1,142 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { JsonValue, ValidationError, ValidationResult } from '../types.js';
+import { createDefaultWorkbenchLayout } from './defaults.js';
+import type {
+  FloatingPanelPlacement,
+  PersonalPanelDefinition,
+  WorkbenchLayoutState,
+  WorkbenchPanelChrome,
+  WorkbenchZoneId,
+} from './types.js';
+
+const ZONES: WorkbenchZoneId[] = ['left', 'right', 'bottom'];
+
+export function normalizeWorkbenchLayout(input: unknown): WorkbenchLayoutState {
+  const base = createDefaultWorkbenchLayout();
+  const raw = isPlainObject(input) && isPlainObject(input.state) ? input.state : input;
+  if (!isPlainObject(raw) || raw.schemaVersion !== 1) return base;
+
+  const zones = { ...base.zones };
+  if (isPlainObject(raw.zones)) {
+    for (const zone of ZONES) {
+      const value = raw.zones[zone];
+      if (Array.isArray(value) && value.every((item) => typeof item === 'string')) {
+        zones[zone] = dedupe(value);
+      }
+    }
+  }
+
+  const horizontal = readHorizontal(raw, base.sizes.horizontal);
+  const bottomHeight = readNumber(raw.sizes, 'bottomHeight', base.sizes.bottomHeight, 120, 1200);
+  const collapsed = { ...base.collapsed };
+  if (isPlainObject(raw.collapsed)) {
+    for (const zone of ZONES) collapsed[zone] = raw.collapsed[zone] === true;
+  }
+
+  const activeTabs = { ...base.activeTabs };
+  if (isPlainObject(raw.activeTabs)) {
+    for (const zone of ZONES) {
+      const value = raw.activeTabs[zone];
+      if (typeof value === 'string' || value === undefined) activeTabs[zone] = value;
+    }
+  }
+
+  return {
+    schemaVersion: 1,
+    baseLayoutId: typeof raw.baseLayoutId === 'string' ? raw.baseLayoutId : base.baseLayoutId,
+    zones,
+    sizes: { horizontal, bottomHeight },
+    collapsed,
+    activeTabs,
+    floating: readFloating(raw.floating),
+    panelChrome: readRecord(raw.panelChrome, isPanelChrome),
+    personalPanels: readRecord(raw.personalPanels, isPersonalPanel),
+  };
+}
+
+export function validateWorkbenchLayout(input: unknown): ValidationResult<WorkbenchLayoutState> {
+  const errors: ValidationError[] = [];
+  if (!isPlainObject(input)) {
+    return { ok: false, errors: [{ path: '', code: 'type_mismatch', message: 'Layout must be an object.' }] };
+  }
+  if (input.schemaVersion !== 1) {
+    errors.push({ path: 'schemaVersion', code: 'invalid_manifest_version', message: 'Unsupported layout schemaVersion.' });
+  }
+  if (!isPlainObject(input.zones)) {
+    errors.push({ path: 'zones', code: 'required', message: 'zones is required.' });
+  }
+  if (!isPlainObject(input.sizes)) {
+    errors.push({ path: 'sizes', code: 'required', message: 'sizes is required.' });
+  }
+  if (errors.length > 0) return { ok: false, errors };
+  return { ok: true, value: normalizeWorkbenchLayout(input) };
+}
+
+function readHorizontal(raw: Record<string, unknown>, fallback: [number, number, number]): [number, number, number] {
+  const sizes = isPlainObject(raw.sizes) ? raw.sizes.horizontal : undefined;
+  if (!Array.isArray(sizes) || sizes.length !== 3) return fallback;
+  const next = sizes.map((item) => typeof item === 'number' && Number.isFinite(item) ? item : 0);
+  if (next.some((item) => item <= 0)) return fallback;
+  return [next[0], next[1], next[2]];
+}
+
+function readNumber(raw: unknown, key: string, fallback: number, min: number, max: number): number {
+  if (!isPlainObject(raw)) return fallback;
+  const value = raw[key];
+  if (typeof value !== 'number' || !Number.isFinite(value)) return fallback;
+  return Math.min(max, Math.max(min, value));
+}
+
+function readFloating(raw: unknown): FloatingPanelPlacement[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.filter(isFloating);
+}
+
+function readRecord<T>(raw: unknown, guard: (value: unknown) => value is T): Record<string, T> {
+  if (!isPlainObject(raw)) return {};
+  const out: Record<string, T> = {};
+  for (const [key, value] of Object.entries(raw)) {
+    if (guard(value)) out[key] = value;
+  }
+  return out;
+}
+
+function isPanelChrome(value: unknown): value is WorkbenchPanelChrome {
+  if (!isPlainObject(value)) return false;
+  return ['title', 'icon', 'accent'].every((key) => value[key] === undefined || typeof value[key] === 'string')
+    && (value.hidden === undefined || typeof value.hidden === 'boolean');
+}
+
+function isPersonalPanel(value: unknown): value is PersonalPanelDefinition {
+  return isPlainObject(value)
+    && typeof value.id === 'string'
+    && typeof value.title === 'string'
+    && isJsonValue(value.widget)
+    && typeof value.createdAt === 'string'
+    && typeof value.updatedAt === 'string';
+}
+
+function isFloating(value: unknown): value is FloatingPanelPlacement {
+  return isPlainObject(value)
+    && typeof value.panelId === 'string'
+    && ['x', 'y', 'width', 'height'].every((key) => typeof value[key] === 'number');
+}
+
+function isJsonValue(value: unknown): value is JsonValue {
+  if (value === null) return true;
+  if (['string', 'number', 'boolean'].includes(typeof value)) return true;
+  if (Array.isArray(value)) return value.every(isJsonValue);
+  if (!isPlainObject(value)) return false;
+  return Object.values(value).every(isJsonValue);
+}
+
+function dedupe(values: string[]): string[] {
+  return Array.from(new Set(values));
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/extensions/src/layout/normalize.ts
+++ b/packages/extensions/src/layout/normalize.ts
@@ -55,9 +55,11 @@ export function normalizeWorkbenchLayout(input: unknown): WorkbenchLayoutState {
     activeTabs,
     floating: readFloating(raw.floating),
     panelChrome: readRecord(raw.panelChrome, isPanelChrome),
+    panelConfigs: readJsonRecord(raw.panelConfigs),
     personalPanels: readRecord(raw.personalPanels, isPersonalPanel),
     workspaceModes: readRecord(raw.workspaceModes, isWorkbenchMode),
     automations: readAutomations(raw.automations),
+    automationRuns: Array.isArray(raw.automationRuns) ? raw.automationRuns.filter(isAutomationRun).slice(-100) : [],
     history: Array.isArray(raw.history) ? raw.history.filter(isHistoryEntry).slice(-50) : [],
   };
 }
@@ -109,6 +111,15 @@ function readRecord<T>(raw: unknown, guard: (value: unknown) => value is T): Rec
   return out;
 }
 
+function readJsonRecord(raw: unknown): Record<string, JsonValue> {
+  if (!isPlainObject(raw)) return {};
+  const out: Record<string, JsonValue> = {};
+  for (const [key, value] of Object.entries(raw)) {
+    if (isJsonValue(value)) out[key] = value;
+  }
+  return out;
+}
+
 function isPanelChrome(value: unknown): value is WorkbenchPanelChrome {
   if (!isPlainObject(value)) return false;
   return ['title', 'icon', 'accent'].every((key) => value[key] === undefined || typeof value[key] === 'string')
@@ -150,6 +161,16 @@ function isAutomation(value: unknown): value is UiAutomation {
     && isPlainObject(value.trigger)
     && typeof value.trigger.kind === 'string'
     && Array.isArray(value.actions);
+}
+
+function isAutomationRun(value: unknown): value is WorkbenchLayoutState['automationRuns'][number] {
+  return isPlainObject(value)
+    && typeof value.id === 'string'
+    && typeof value.automationId === 'string'
+    && typeof value.automationName === 'string'
+    && typeof value.trigger === 'string'
+    && typeof value.status === 'string'
+    && typeof value.createdAt === 'string';
 }
 
 function isHistoryEntry(value: unknown): value is WorkbenchLayoutState['history'][number] {

--- a/packages/extensions/src/layout/patch.ts
+++ b/packages/extensions/src/layout/patch.ts
@@ -43,6 +43,47 @@ export function applyWorkbenchOperation(
         personalPanels,
       };
     }
+    case 'setFloatingPanel':
+      return {
+        ...layout,
+        floating: [
+          ...layout.floating.filter((placement) => placement.panelId !== operation.placement.panelId),
+          operation.placement,
+        ],
+      };
+    case 'removeFloatingPanel':
+      return {
+        ...layout,
+        floating: layout.floating.filter((placement) => placement.panelId !== operation.panelId),
+      };
+    case 'saveWorkspaceMode':
+      return {
+        ...layout,
+        workspaceModes: { ...layout.workspaceModes, [operation.mode.id]: operation.mode },
+      };
+    case 'deleteWorkspaceMode': {
+      const { [operation.modeId]: _mode, ...workspaceModes } = layout.workspaceModes;
+      return { ...layout, workspaceModes };
+    }
+    case 'addAutomation':
+    case 'updateAutomation':
+      return {
+        ...layout,
+        automations: [
+          ...layout.automations.filter((automation) => automation.id !== operation.automation.id),
+          operation.automation,
+        ],
+      };
+    case 'deleteAutomation':
+      return {
+        ...layout,
+        automations: layout.automations.filter((automation) => automation.id !== operation.automationId),
+      };
+    case 'appendHistory':
+      return {
+        ...layout,
+        history: [...layout.history.filter((entry) => entry.id !== operation.entry.id), operation.entry].slice(-50),
+      };
     case 'setHorizontalSizes':
       return { ...layout, sizes: { ...layout.sizes, horizontal: operation.sizes } };
     case 'setBottomHeight':

--- a/packages/extensions/src/layout/patch.ts
+++ b/packages/extensions/src/layout/patch.ts
@@ -79,10 +79,20 @@ export function applyWorkbenchOperation(
         ...layout,
         automations: layout.automations.filter((automation) => automation.id !== operation.automationId),
       };
+    case 'appendAutomationRun':
+      return {
+        ...layout,
+        automationRuns: [...layout.automationRuns.filter((entry) => entry.id !== operation.entry.id), operation.entry].slice(-100),
+      };
     case 'appendHistory':
       return {
         ...layout,
         history: [...layout.history.filter((entry) => entry.id !== operation.entry.id), operation.entry].slice(-50),
+      };
+    case 'setPanelConfig':
+      return {
+        ...layout,
+        panelConfigs: { ...layout.panelConfigs, [operation.panelId]: operation.config },
       };
     case 'setHorizontalSizes':
       return { ...layout, sizes: { ...layout.sizes, horizontal: operation.sizes } };

--- a/packages/extensions/src/layout/patch.ts
+++ b/packages/extensions/src/layout/patch.ts
@@ -1,0 +1,87 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { WorkbenchLayoutState, WorkbenchOperation, WorkbenchPatch, WorkbenchZoneId } from './types.js';
+
+export function applyWorkbenchPatch(layout: WorkbenchLayoutState, patch: WorkbenchPatch): WorkbenchLayoutState {
+  return patch.operations.reduce(applyWorkbenchOperation, cloneLayout(layout));
+}
+
+export function applyWorkbenchOperation(
+  layout: WorkbenchLayoutState,
+  operation: WorkbenchOperation,
+): WorkbenchLayoutState {
+  switch (operation.op) {
+    case 'movePanel':
+      return movePanel(layout, operation.panelId, operation.toZone, operation.toIndex);
+    case 'setPanelChrome':
+      return {
+        ...layout,
+        panelChrome: {
+          ...layout.panelChrome,
+          [operation.panelId]: { ...layout.panelChrome[operation.panelId], ...operation.chrome },
+        },
+      };
+    case 'addPersonalPanel':
+      return {
+        ...movePanel(layout, operation.panel.id, operation.zone ?? 'right'),
+        personalPanels: { ...layout.personalPanels, [operation.panel.id]: operation.panel },
+      };
+    case 'removePanel': {
+      const { [operation.panelId]: _panel, ...personalPanels } = layout.personalPanels;
+      const { [operation.panelId]: _chrome, ...panelChrome } = layout.panelChrome;
+      return {
+        ...layout,
+        zones: removeFromZones(layout, operation.panelId),
+        activeTabs: {
+          left: layout.activeTabs.left === operation.panelId ? undefined : layout.activeTabs.left,
+          right: layout.activeTabs.right === operation.panelId ? undefined : layout.activeTabs.right,
+          bottom: layout.activeTabs.bottom === operation.panelId ? undefined : layout.activeTabs.bottom,
+        },
+        panelChrome,
+        personalPanels,
+      };
+    }
+    case 'setHorizontalSizes':
+      return { ...layout, sizes: { ...layout.sizes, horizontal: operation.sizes } };
+    case 'setBottomHeight':
+      return { ...layout, sizes: { ...layout.sizes, bottomHeight: operation.height } };
+    case 'setCollapsed':
+      return { ...layout, collapsed: { ...layout.collapsed, [operation.zone]: operation.collapsed } };
+  }
+}
+
+function movePanel(
+  layout: WorkbenchLayoutState,
+  panelId: string,
+  toZone: WorkbenchZoneId,
+  toIndex?: number,
+): WorkbenchLayoutState {
+  const zones = removeFromZones(layout, panelId);
+  const next = [...zones[toZone]];
+  const index = Math.min(Math.max(toIndex ?? next.length, 0), next.length);
+  next.splice(index, 0, panelId);
+  zones[toZone] = next;
+  return {
+    ...layout,
+    zones,
+    collapsed: { ...layout.collapsed, [toZone]: false },
+    activeTabs: { ...layout.activeTabs, [toZone]: panelId },
+  };
+}
+
+function removeFromZones(
+  layout: WorkbenchLayoutState,
+  panelId: string,
+): WorkbenchLayoutState['zones'] {
+  return {
+    left: layout.zones.left.filter((id) => id !== panelId),
+    right: layout.zones.right.filter((id) => id !== panelId),
+    bottom: layout.zones.bottom.filter((id) => id !== panelId),
+  };
+}
+
+function cloneLayout(layout: WorkbenchLayoutState): WorkbenchLayoutState {
+  return structuredClone(layout);
+}

--- a/packages/extensions/src/layout/types.ts
+++ b/packages/extensions/src/layout/types.ts
@@ -34,6 +34,53 @@ export interface FloatingPanelPlacement {
   height: number;
 }
 
+export interface WorkbenchModeSnapshot {
+  zones: Record<WorkbenchZoneId, WorkbenchPanelId[]>;
+  sizes: WorkbenchLayoutState['sizes'];
+  collapsed: Record<WorkbenchZoneId, boolean>;
+  activeTabs: Partial<Record<WorkbenchZoneId, WorkbenchPanelId>>;
+  floating: FloatingPanelPlacement[];
+  panelChrome: Record<WorkbenchPanelId, WorkbenchPanelChrome>;
+}
+
+export interface WorkbenchMode {
+  id: string;
+  name: string;
+  description?: string;
+  createdAt: string;
+  updatedAt: string;
+  snapshot: WorkbenchModeSnapshot;
+}
+
+export type UiAutomationTrigger =
+  | { kind: 'model.loaded' }
+  | { kind: 'selection.changed' }
+  | { kind: 'panel.opened'; panelId: WorkbenchPanelId };
+
+export type UiAutomationAction =
+  | { kind: 'layout.openPanel'; panelId: WorkbenchPanelId }
+  | { kind: 'layout.movePanel'; panelId: WorkbenchPanelId; zone: WorkbenchZoneId }
+  | { kind: 'layout.collapse'; zone: WorkbenchZoneId; collapsed: boolean }
+  | { kind: 'layout.applyMode'; modeId: string }
+  | { kind: 'command.run'; commandId: string }
+  | { kind: 'toast.show'; message: string };
+
+export interface UiAutomation {
+  id: string;
+  name: string;
+  enabled: boolean;
+  trigger: UiAutomationTrigger;
+  when?: string;
+  actions: UiAutomationAction[];
+}
+
+export interface WorkbenchHistoryEntry {
+  id: string;
+  label: string;
+  createdAt: string;
+  patchId?: string;
+}
+
 export interface WorkbenchLayoutState {
   schemaVersion: 1;
   /**
@@ -52,6 +99,9 @@ export interface WorkbenchLayoutState {
   floating: FloatingPanelPlacement[];
   panelChrome: Record<WorkbenchPanelId, WorkbenchPanelChrome>;
   personalPanels: Record<WorkbenchPanelId, PersonalPanelDefinition>;
+  workspaceModes: Record<string, WorkbenchMode>;
+  automations: UiAutomation[];
+  history: WorkbenchHistoryEntry[];
 }
 
 export interface LayoutMergeConflict {
@@ -72,6 +122,14 @@ export type WorkbenchOperation =
   | { op: 'setPanelChrome'; panelId: WorkbenchPanelId; chrome: WorkbenchPanelChrome }
   | { op: 'addPersonalPanel'; panel: PersonalPanelDefinition; zone?: WorkbenchZoneId }
   | { op: 'removePanel'; panelId: WorkbenchPanelId }
+  | { op: 'setFloatingPanel'; placement: FloatingPanelPlacement }
+  | { op: 'removeFloatingPanel'; panelId: WorkbenchPanelId }
+  | { op: 'saveWorkspaceMode'; mode: WorkbenchMode }
+  | { op: 'deleteWorkspaceMode'; modeId: string }
+  | { op: 'addAutomation'; automation: UiAutomation }
+  | { op: 'updateAutomation'; automation: UiAutomation }
+  | { op: 'deleteAutomation'; automationId: string }
+  | { op: 'appendHistory'; entry: WorkbenchHistoryEntry }
   | { op: 'setHorizontalSizes'; sizes: [number, number, number] }
   | { op: 'setBottomHeight'; height: number }
   | { op: 'setCollapsed'; zone: WorkbenchZoneId; collapsed: boolean };

--- a/packages/extensions/src/layout/types.ts
+++ b/packages/extensions/src/layout/types.ts
@@ -1,0 +1,68 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { JsonValue } from '../types.js';
+
+export const WORKBENCH_LAYOUT_SCHEMA_VERSION = 1;
+
+export type WorkbenchZoneId = 'left' | 'right' | 'bottom';
+export type WorkbenchPanelId = string;
+
+export interface WorkbenchPanelChrome {
+  title?: string;
+  icon?: string;
+  accent?: string;
+  hidden?: boolean;
+}
+
+export interface PersonalPanelDefinition {
+  id: WorkbenchPanelId;
+  title: string;
+  description?: string;
+  icon?: string;
+  widget: JsonValue;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface FloatingPanelPlacement {
+  panelId: WorkbenchPanelId;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface WorkbenchLayoutState {
+  schemaVersion: 1;
+  /**
+   * Built-in app layout this state was derived from. The viewer owns
+   * the concrete default; this id lets future migrations/rebases know
+   * what ancestor the user morphed.
+   */
+  baseLayoutId: string;
+  zones: Record<WorkbenchZoneId, WorkbenchPanelId[]>;
+  sizes: {
+    horizontal: [number, number, number];
+    bottomHeight: number;
+  };
+  collapsed: Record<WorkbenchZoneId, boolean>;
+  activeTabs: Partial<Record<WorkbenchZoneId, WorkbenchPanelId>>;
+  floating: FloatingPanelPlacement[];
+  panelChrome: Record<WorkbenchPanelId, WorkbenchPanelChrome>;
+  personalPanels: Record<WorkbenchPanelId, PersonalPanelDefinition>;
+}
+
+export interface LayoutMergeConflict {
+  kind: 'panel_move' | 'zone_order' | 'split_resize' | 'panel_chrome' | 'personal_panel';
+  key: string;
+  ours: JsonValue;
+  theirs: JsonValue;
+  base?: JsonValue;
+}
+
+export interface LayoutMergeResult {
+  merged: WorkbenchLayoutState;
+  conflicts: LayoutMergeConflict[];
+}

--- a/packages/extensions/src/layout/types.ts
+++ b/packages/extensions/src/layout/types.ts
@@ -41,6 +41,7 @@ export interface WorkbenchModeSnapshot {
   activeTabs: Partial<Record<WorkbenchZoneId, WorkbenchPanelId>>;
   floating: FloatingPanelPlacement[];
   panelChrome: Record<WorkbenchPanelId, WorkbenchPanelChrome>;
+  panelConfigs: Record<WorkbenchPanelId, JsonValue>;
 }
 
 export interface WorkbenchMode {
@@ -81,6 +82,16 @@ export interface WorkbenchHistoryEntry {
   patchId?: string;
 }
 
+export interface AutomationRunLogEntry {
+  id: string;
+  automationId: string;
+  automationName: string;
+  trigger: string;
+  status: 'dry-run' | 'success' | 'failed' | 'skipped';
+  message?: string;
+  createdAt: string;
+}
+
 export interface WorkbenchLayoutState {
   schemaVersion: 1;
   /**
@@ -98,9 +109,11 @@ export interface WorkbenchLayoutState {
   activeTabs: Partial<Record<WorkbenchZoneId, WorkbenchPanelId>>;
   floating: FloatingPanelPlacement[];
   panelChrome: Record<WorkbenchPanelId, WorkbenchPanelChrome>;
+  panelConfigs: Record<WorkbenchPanelId, JsonValue>;
   personalPanels: Record<WorkbenchPanelId, PersonalPanelDefinition>;
   workspaceModes: Record<string, WorkbenchMode>;
   automations: UiAutomation[];
+  automationRuns: AutomationRunLogEntry[];
   history: WorkbenchHistoryEntry[];
 }
 
@@ -129,7 +142,9 @@ export type WorkbenchOperation =
   | { op: 'addAutomation'; automation: UiAutomation }
   | { op: 'updateAutomation'; automation: UiAutomation }
   | { op: 'deleteAutomation'; automationId: string }
+  | { op: 'appendAutomationRun'; entry: AutomationRunLogEntry }
   | { op: 'appendHistory'; entry: WorkbenchHistoryEntry }
+  | { op: 'setPanelConfig'; panelId: WorkbenchPanelId; config: JsonValue }
   | { op: 'setHorizontalSizes'; sizes: [number, number, number] }
   | { op: 'setBottomHeight'; height: number }
   | { op: 'setCollapsed'; zone: WorkbenchZoneId; collapsed: boolean };

--- a/packages/extensions/src/layout/types.ts
+++ b/packages/extensions/src/layout/types.ts
@@ -66,3 +66,19 @@ export interface LayoutMergeResult {
   merged: WorkbenchLayoutState;
   conflicts: LayoutMergeConflict[];
 }
+
+export type WorkbenchOperation =
+  | { op: 'movePanel'; panelId: WorkbenchPanelId; toZone: WorkbenchZoneId; toIndex?: number }
+  | { op: 'setPanelChrome'; panelId: WorkbenchPanelId; chrome: WorkbenchPanelChrome }
+  | { op: 'addPersonalPanel'; panel: PersonalPanelDefinition; zone?: WorkbenchZoneId }
+  | { op: 'removePanel'; panelId: WorkbenchPanelId }
+  | { op: 'setHorizontalSizes'; sizes: [number, number, number] }
+  | { op: 'setBottomHeight'; height: number }
+  | { op: 'setCollapsed'; zone: WorkbenchZoneId; collapsed: boolean };
+
+export interface WorkbenchPatch {
+  id: string;
+  author: 'user' | 'ai' | 'extension' | 'system';
+  createdAt: string;
+  operations: WorkbenchOperation[];
+}

--- a/packages/extensions/src/manifest/contributions.ts
+++ b/packages/extensions/src/manifest/contributions.ts
@@ -24,6 +24,7 @@ const CONTEXT_MENU_SLOTS = new Set([
   'contextMenu.tree',
 ]);
 const STATUS_BAR_SLOTS = new Set(['statusBar.left', 'statusBar.right']);
+const PANEL_PLACEMENTS = new Set(['left', 'right', 'bottom', 'floating']);
 
 export function validateContributions(
   ctx: ValidationContext,
@@ -46,6 +47,15 @@ export function validateContributions(
     validateArray(ctx, obj.toolbar, `${path}.toolbar`, (item, p) => {
       requireStringInObj(ctx, item, p, 'command');
       validateSlot(ctx, item, p, TOOLBAR_SLOTS, 'toolbar');
+      validateOptionalWhen(ctx, item, p);
+    });
+  }
+  if ('panels' in obj && obj.panels !== undefined) {
+    validateArray(ctx, obj.panels, `${path}.panels`, (item, p) => {
+      requireStringInObj(ctx, item, p, 'id');
+      requireStringInObj(ctx, item, p, 'title');
+      requireStringInObj(ctx, item, p, 'widget');
+      validatePlacement(ctx, item, p);
       validateOptionalWhen(ctx, item, p);
     });
   }
@@ -102,6 +112,23 @@ export function validateContributions(
       validateSlot(ctx, item, p, STATUS_BAR_SLOTS, 'statusBar');
       validateOptionalWhen(ctx, item, p);
     });
+  }
+}
+
+function validatePlacement(ctx: ValidationContext, item: unknown, path: string): void {
+  if (!isPlainObject(item)) return;
+  const placement = (item as Record<string, unknown>).defaultPlacement;
+  if (typeof placement !== 'string' || !PANEL_PLACEMENTS.has(placement)) {
+    ctx.add(`${path}.defaultPlacement`, 'invalid_value',
+      `Invalid panel placement ${JSON.stringify(placement)}.`,
+      `Allowed: ${Array.from(PANEL_PLACEMENTS).join(', ')}.`);
+  }
+  const allowed = (item as Record<string, unknown>).allowedPlacements;
+  if (allowed !== undefined) {
+    if (!Array.isArray(allowed) || allowed.some((value) => typeof value !== 'string' || !PANEL_PLACEMENTS.has(value))) {
+      ctx.add(`${path}.allowedPlacements`, 'invalid_value',
+        `allowedPlacements must contain only: ${Array.from(PANEL_PLACEMENTS).join(', ')}.`);
+    }
   }
 }
 

--- a/packages/extensions/src/types.ts
+++ b/packages/extensions/src/types.ts
@@ -186,6 +186,7 @@ export interface ManifestEntry {
 
 export interface ManifestContributions {
   commands?: CommandContribution[];
+  panels?: PanelContribution[];
   toolbar?: ToolbarContribution[];
   dock?: DockContribution[];
   contextMenu?: ContextMenuContribution[];
@@ -202,6 +203,20 @@ export interface CommandContribution {
   description?: string;
   icon?: string;
   paletteCategory?: string;
+}
+
+export type PanelPlacement = 'left' | 'right' | 'bottom' | 'floating';
+
+export interface PanelContribution {
+  id: string;
+  title: string;
+  icon?: string;
+  widget: string;
+  defaultPlacement: PanelPlacement;
+  allowedPlacements?: PanelPlacement[];
+  when?: string;
+  order?: number;
+  configSchema?: string;
 }
 
 export type ToolbarSlot = 'toolbar.left' | 'toolbar.right' | 'toolbar.center';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -265,6 +265,9 @@ importers:
       '@ifc-lite/create':
         specifier: workspace:^
         version: link:../../packages/create
+      '@ifc-lite/customization':
+        specifier: workspace:^
+        version: link:../../packages/customization
       '@ifc-lite/data':
         specifier: workspace:^
         version: link:../../packages/data
@@ -893,6 +896,19 @@ importers:
       typescript:
         specifier: ^5.3.0
         version: 5.9.3
+
+  packages/customization:
+    dependencies:
+      '@ifc-lite/extensions':
+        specifier: workspace:^
+        version: link:../extensions
+    devDependencies:
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.13)(@types/node@25.9.1)(happy-dom@20.9.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)
 
   packages/data:
     devDependencies:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -54,6 +54,12 @@
       "@ifc-lite/data/*": [
         "packages/data/dist/*"
       ],
+      "@ifc-lite/customization": [
+        "packages/customization/dist/index.d.ts"
+      ],
+      "@ifc-lite/customization/*": [
+        "packages/customization/dist/*"
+      ],
       "@ifc-lite/mutations": [
         "packages/mutations/dist/index.d.ts"
       ],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Adds new independent `@ifc-lite/customization` package for Customization Studio core: workbench patch simulation, change summaries, starter templates, editable-zone descriptors, local AI plan drafting, and AI/customization plan validation contracts.
- Adds a typed workbench layout model to `@ifc-lite/extensions` with defaults, normalization, validation, structural merge helpers, history, workspace modes, automations, automation run logs, panel configs, floating placements, and AI/command-friendly workbench patch operations.
- Introduces a registry-style desktop workbench renderer for built-in viewer panels with drag-to-dock panel movement, persisted sizes/collapse state, and a Morph UI toolbar.
- Adds a production-style Customization Studio shell with tabs for templates, visual widget builder, built-in editable zones, automations/run history, workbench history, merge preview, and AI plans.
- Adds a visual widget builder MVP with block palette, live preview, layer selection, selected-node JSON inspector, and save-to-personal-panel flow.
- Adds built-in editable-zone MVP for Properties, Hierarchy, Toolbar, and Status bar configs persisted in workbench layout state.
- Adds local AI customization bridge: prompt-to-`CustomizationPlan` heuristics that generate previewable `WorkbenchPatch` payloads.
- Adds visual merge/rebase preview MVP showing Mine / Incoming / Merged workbench zones plus conflicts.
- Adds automation safety primitives: rapid loop guard, max-action cap, run log, skipped/success/failure statuses.
- Adds a panel library, panel chrome editor, hide/show flow, built-in/personal/extension panel movement controls, editable personal panels, and richer personal panel templates.
- Adds first-class extension panel manifest skeleton via `contributes.panels`, registering extension panels to `workbench.panels`; the viewer can list/render those panels in the workbench.
- Adds floating/tear-off panel runtime: visible panels can be floated, dragged as windows, closed, and docked back into the workbench.
- Upgrades personal panel editing to a JSON widget editor with validation and live preview using the existing widget DSL renderer.
- Adds workbench patch preview/apply dialog for AI or command-generated `WorkbenchPatch` payloads via the `ifc-lite:preview-workbench-patch` event.
- Adds workspace mode management and behavior morphing automations.
- Persists workbench layout into active flavors, restores layout on flavor switch, captures layout in flavor snapshots, and surfaces layout-specific conflict descriptions in the flavor merge UI.
- Wires additional extension surfaces: `toolbar.left`, `toolbar.center`, `statusBar.left/right`, and extension keybindings.

## Testing
- `pnpm install` / `pnpm install --lockfile-only` for the new workspace package and lockfile
- `pnpm -F @ifc-lite/extensions build` ✅
- `pnpm -F @ifc-lite/extensions test` ✅ — 53 files / 586 tests
- `pnpm -F @ifc-lite/customization build` ✅
- `pnpm -F @ifc-lite/customization test` ✅ — 1 file / 3 tests
- `pnpm -F @ifc-lite/viewer typecheck` ⚠️ new customization/workbench errors cleared after fixes; remaining failures are pre-existing/generated-package environment issues for missing `@ifc-lite/mcp/browser`, `@ifc-lite/ids/bridge`, `@ifc-lite/pointcloud`, and `@ifc-lite/wasm` declarations/artifacts in the fresh checkout.
- `pnpm -F @ifc-lite/viewer test` ⚠️ fails for the same missing generated/runtime artifacts (`@ifc-lite/pointcloud/dist`, `@ifc-lite/wasm/pkg`) before workbench-specific assertions run.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b39855e-3fe1-4351-a27d-bbd3731ce6ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b39855e-3fe1-4351-a27d-bbd3731ce6ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

