### PR TITLE
fix(export): pad new trailing attributes on IFC2X3 upconversion (#1416)

### DIFF
--- a/.changeset/schema-converter-attr-padding.md
+++ b/.changeset/schema-converter-attr-padding.md
@@ -1,0 +1,18 @@
+---
+"@ifc-lite/export": patch
+---
+
+Fix IFC2X3 → IFC4/IFC4X3 schema conversion producing invalid entities. The converter trimmed
+trailing attributes when downgrading but never **padded** the new trailing attributes that
+newer schemas added (e.g. `PredefinedType` on `IfcWall` / `IfcBeam` / `IfcOpeningElement` /
+`IfcFastener` / …, the IfcDoor/IfcWindow additions, `IfcMaterial.Category`, etc.). Upgraded
+entities were left a positional attribute short and rejected by strict readers (e.g. BIM
+Vision). Padding is now driven by the generated buildingSMART attribute tables
+(`@ifc-lite/data`), so any added trailing attribute is filled with `$` (valid — the additions
+are optional), scoped to upconversion so the downconversion trim path is untouched.
+
+Also tolerate whitespace after `=` in `convertStepLine` (e.g. Tekla's `#34498= IFCWALL(...)`);
+such lines previously failed the entity-line regex and passed through **unconverted**, so
+neither type renames nor attribute adjustment applied. Validated end-to-end with ifcopenshell:
+a federated IFC2X3 + IFC4X3 → IFC4 export went from 2556 "Invalid attribute value" errors to 0
+(remaining issues are pre-existing source-data defects). ([#1416](https://github.com/LTplus-AG/ifc-lite/issues/1416))

--- a/.changeset/schema-converter-attr-padding.md
+++ b/.changeset/schema-converter-attr-padding.md
@@ -7,9 +7,16 @@ trailing attributes when downgrading but never **padded** the new trailing attri
 newer schemas added (e.g. `PredefinedType` on `IfcWall` / `IfcBeam` / `IfcOpeningElement` /
 `IfcFastener` / …, the IfcDoor/IfcWindow additions, `IfcMaterial.Category`, etc.). Upgraded
 entities were left a positional attribute short and rejected by strict readers (e.g. BIM
-Vision). Padding is now driven by the generated buildingSMART attribute tables
-(`@ifc-lite/data`), so any added trailing attribute is filled with `$` (valid — the additions
-are optional), scoped to upconversion so the downconversion trim path is untouched.
+Vision). Padding is driven by the generated buildingSMART attribute tables (`@ifc-lite/data`),
+scoped to upconversion so the downconversion trim path is untouched.
+
+Padding is applied **only when the source attribute name-list is a strict prefix of the
+target's** (i.e. the newer schema merely appended attributes). Many entities insert/reorder
+attributes mid-list — e.g. `IfcMaterialProperties` (`[Material]` → `[Name, Description,
+Properties, Material]`), `IfcApproval`, `IfcTask` — where blindly appending `$` would shift
+values into the wrong, type-invalid slots; those are left untouched. All headline targets
+(`IfcWall`/`Beam`/`Column`/`Member`/`Plate`/`OpeningElement`/`Door`/`Window`/`Fastener`/
+`MechanicalFastener`/`Grid`, `IfcMaterial`) are prefix-safe, so the intended fix is preserved.
 
 Also tolerate whitespace after `=` in `convertStepLine` (e.g. Tekla's `#34498= IFCWALL(...)`);
 such lines previously failed the entity-line regex and passed through **unconverted**, so

--- a/packages/export/src/schema-converter.test.ts
+++ b/packages/export/src/schema-converter.test.ts
@@ -195,6 +195,18 @@ describe('schema-converter', () => {
       const line = "#11=IFCSLAB('guid',$,'S',$,$,#1,#2,'tag',.FLOOR.);"; // 9 attrs
       expect(convertStepLine(line, 'IFC2X3', 'IFC4')).toBe(line);
     });
+
+    it('does NOT pad entities whose attrs were reordered, not appended (IfcMaterialProperties)', () => {
+      // IFC2X3 [Material] vs IFC4 [Name, Description, Properties, Material] — NOT a
+      // prefix, so trailing `$` would shove the Material ref into the Name slot.
+      const line = '#5=IFCMATERIALPROPERTIES(#6);';
+      expect(convertStepLine(line, 'IFC2X3', 'IFC4')).toBe(line); // left untouched
+    });
+
+    it('does NOT pad a reordered IfcApproval (7→9, fully reordered)', () => {
+      const line = "#5=IFCAPPROVAL('desc','2020-01-01',$,$,$,'Name','Id');"; // 7 attrs
+      expect(convertStepLine(line, 'IFC2X3', 'IFC4')).toBe(line);
+    });
   });
 
   // ─── needsConversion ────────────────────────────────────────────────────

--- a/packages/export/src/schema-converter.test.ts
+++ b/packages/export/src/schema-converter.test.ts
@@ -164,6 +164,37 @@ describe('schema-converter', () => {
       // Preserved escaped quote
       expect(result).toContain("'Wall''s Name'");
     });
+
+    // ─── upconversion attribute padding (issue #1416) ──────────────────────
+
+    it('pads PredefinedType when upconverting IFC2X3 → IFC4 (IfcOpeningElement 8→9)', () => {
+      const line = "#5=IFCOPENINGELEMENT('guid',$,$,$,'Opening',#6,#7,$);"; // 8 attrs
+      const result = convertStepLine(line, 'IFC2X3', 'IFC4');
+      expect(result).toBe("#5=IFCOPENINGELEMENT('guid',$,$,$,'Opening',#6,#7,$,$);"); // 9
+    });
+
+    it('pads IfcWall 8→9 on IFC2X3 → IFC4', () => {
+      const line = "#10=IFCWALL('guid',$,'W',$,$,#1,#2,'tag');"; // 8 attrs
+      const result = convertStepLine(line, 'IFC2X3', 'IFC4');
+      expect(result).toBe("#10=IFCWALL('guid',$,'W',$,$,#1,#2,'tag',$);"); // +PredefinedType
+    });
+
+    it('pads multiple added attributes (IfcMaterial 1→3)', () => {
+      const result = convertStepLine("#3=IFCMATERIAL('Steel');", 'IFC2X3', 'IFC4');
+      expect(result).toBe("#3=IFCMATERIAL('Steel',$,$);"); // +Description,+Category
+    });
+
+    it('tolerates whitespace after = (Tekla-style formatting)', () => {
+      const line = "#34498= IFCOPENINGELEMENT('guid',$,$,$,'Opening',#6,#7,$);";
+      const result = convertStepLine(line, 'IFC2X3', 'IFC4');
+      // Reassembled without the stray space, and padded to 9 attrs.
+      expect(result).toBe("#34498=IFCOPENINGELEMENT('guid',$,$,$,'Opening',#6,#7,$,$);");
+    });
+
+    it('does not pad when the attribute count already matches (IfcSlab 9=9)', () => {
+      const line = "#11=IFCSLAB('guid',$,'S',$,$,#1,#2,'tag',.FLOOR.);"; // 9 attrs
+      expect(convertStepLine(line, 'IFC2X3', 'IFC4')).toBe(line);
+    });
   });
 
   // ─── needsConversion ────────────────────────────────────────────────────

--- a/packages/export/src/schema-converter.ts
+++ b/packages/export/src/schema-converter.ts
@@ -256,24 +256,37 @@ function chainMaps(
   return result;
 }
 
-// Lazily-built UPPERCASE entity name → positional attribute count, per target
-// schema, from the generated buildingSMART tables. `IfcEntityInfo.attributes`
-// is the full inherited+direct positional list (verified to match STEP counts:
-// IfcWall 8→9, IfcDoor 10→13, IfcMaterial 1→3, …), so its length is exactly the
-// number of positional attributes the schema requires.
-const ATTR_COUNT_TABLES = new Map<IfcSchemaVersion, Map<string, number>>();
-function attrCountTable(schema: IfcSchemaVersion): Map<string, number> | null {
-  let table = ATTR_COUNT_TABLES.get(schema);
+// Lazily-built UPPERCASE entity name → ordered positional attribute NAMES, per
+// schema, from the generated buildingSMART tables. `IfcEntityInfo.attributes` is
+// the full inherited+direct positional list (verified to match STEP counts:
+// IfcWall 8→9, IfcDoor 10→13, IfcMaterial 1→3, …).
+const ATTR_NAME_TABLES = new Map<IfcSchemaVersion, Map<string, readonly string[]>>();
+function attrNameTable(schema: IfcSchemaVersion): Map<string, readonly string[]> | null {
+  let table = ATTR_NAME_TABLES.get(schema);
   if (table) return table;
   let entities: readonly IfcEntityInfo[] | null = null;
   if (schema === 'IFC2X3') entities = ENTITIES_IFC2X3;
   else if (schema === 'IFC4') entities = ENTITIES_IFC4;
   else if (schema === 'IFC4X3') entities = ENTITIES_IFC4X3;
   else return null; // IFC5 has no generated table — skip count adjustment
-  table = new Map<string, number>();
-  for (const e of entities) table.set(e.name.toUpperCase(), e.attributes.length);
-  ATTR_COUNT_TABLES.set(schema, table);
+  table = new Map<string, readonly string[]>();
+  for (const e of entities) table.set(e.name.toUpperCase(), e.attributes);
+  ATTR_NAME_TABLES.set(schema, table);
   return table;
+}
+
+/**
+ * True when `src` is a STRICT prefix of `tgt` by attribute name — i.e. the
+ * target only *appended* attributes. Trailing-`$` padding is only safe then;
+ * many entities insert/reorder attributes mid-list (e.g. IfcMaterialProperties,
+ * IfcApproval, IfcTask), where padding would shift values into the wrong slots.
+ */
+function isStrictAttrPrefix(src: readonly string[], tgt: readonly string[]): boolean {
+  if (src.length >= tgt.length) return false;
+  for (let i = 0; i < src.length; i++) {
+    if (src[i] !== tgt[i]) return false;
+  }
+  return true;
 }
 
 /** Ordinal rank of a schema version (older → newer) for direction checks. */
@@ -360,18 +373,27 @@ export function convertStepLine(
     }
   }
 
-  // Pad trailing optional attributes when UPGRADING to a newer schema that ADDED
-  // attributes (e.g. IFC2X3 → IFC4 added PredefinedType to IfcWall / IfcBeam /
-  // IfcOpeningElement / …). Without this the upgraded entity is short an attribute
-  // and invalid under the new schema, which strict readers reject. The added
-  // attributes are optional, so `$` is valid. Scoped to upconversion so it never
-  // touches the downconversion trim path above.
+  // Pad trailing optional attributes when UPGRADING to a newer schema that
+  // APPENDED attributes (e.g. IFC2X3 → IFC4 added PredefinedType to IfcWall /
+  // IfcBeam / IfcOpeningElement / …). Without this the upgraded entity is short
+  // an attribute and invalid under the new schema, which strict readers reject.
+  //
+  // CRITICAL: only pad when the source attribute name-list is a strict PREFIX of
+  // the target's. Many entities insert/reorder attributes mid-list (e.g.
+  // IfcMaterialProperties [Material] → [Name, Description, Properties, Material],
+  // IfcApproval, IfcTask); blindly appending `$` there would shift values into the
+  // wrong (and type-invalid) slots. A prefix check distinguishes a safe append
+  // from a corrupting insertion — the headline targets are all prefix-safe. The
+  // appended attributes are optional, so `$` is valid. Scoped to upconversion so
+  // it never touches the downconversion trim path above.
   if (schemaRank(toSchema) > schemaRank(fromSchema)) {
-    const targetCount = attrCountTable(toSchema)?.get(newType);
-    if (targetCount !== undefined) {
+    // Source attrs keyed on the ORIGINAL type; target on the (possibly renamed) type.
+    const srcAttrs = attrNameTable(fromSchema)?.get(entityType);
+    const tgtAttrs = attrNameTable(toSchema)?.get(newType);
+    if (srcAttrs && tgtAttrs && isStrictAttrPrefix(srcAttrs, tgtAttrs)) {
       const currentCount = countTopLevelAttributes(finalAttrs);
-      if (currentCount > 0 && currentCount < targetCount) {
-        finalAttrs = `${finalAttrs}${',$'.repeat(targetCount - currentCount)}`;
+      if (currentCount > 0 && currentCount < tgtAttrs.length) {
+        finalAttrs = `${finalAttrs}${',$'.repeat(tgtAttrs.length - currentCount)}`;
       }
     }
   }

--- a/packages/export/src/schema-converter.ts
+++ b/packages/export/src/schema-converter.ts
@@ -21,6 +21,7 @@
  */
 
 import { generateIfcGuid } from '@ifc-lite/encoding';
+import { ENTITIES_IFC2X3, ENTITIES_IFC4, ENTITIES_IFC4X3, type IfcEntityInfo } from '@ifc-lite/data';
 
 export type IfcSchemaVersion = 'IFC2X3' | 'IFC4' | 'IFC4X3' | 'IFC5';
 
@@ -255,12 +256,67 @@ function chainMaps(
   return result;
 }
 
+// Lazily-built UPPERCASE entity name → positional attribute count, per target
+// schema, from the generated buildingSMART tables. `IfcEntityInfo.attributes`
+// is the full inherited+direct positional list (verified to match STEP counts:
+// IfcWall 8→9, IfcDoor 10→13, IfcMaterial 1→3, …), so its length is exactly the
+// number of positional attributes the schema requires.
+const ATTR_COUNT_TABLES = new Map<IfcSchemaVersion, Map<string, number>>();
+function attrCountTable(schema: IfcSchemaVersion): Map<string, number> | null {
+  let table = ATTR_COUNT_TABLES.get(schema);
+  if (table) return table;
+  let entities: readonly IfcEntityInfo[] | null = null;
+  if (schema === 'IFC2X3') entities = ENTITIES_IFC2X3;
+  else if (schema === 'IFC4') entities = ENTITIES_IFC4;
+  else if (schema === 'IFC4X3') entities = ENTITIES_IFC4X3;
+  else return null; // IFC5 has no generated table — skip count adjustment
+  table = new Map<string, number>();
+  for (const e of entities) table.set(e.name.toUpperCase(), e.attributes.length);
+  ATTR_COUNT_TABLES.set(schema, table);
+  return table;
+}
+
+/** Ordinal rank of a schema version (older → newer) for direction checks. */
+function schemaRank(schema: IfcSchemaVersion): number {
+  switch (schema) {
+    case 'IFC2X3': return 0;
+    case 'IFC4': return 1;
+    case 'IFC4X3': return 2;
+    case 'IFC5': return 3;
+    default: return 0;
+  }
+}
+
+/** Count top-level (comma-separated) STEP attributes, respecting nested
+ *  parentheses and single-quoted strings. Empty list → 0. */
+function countTopLevelAttributes(attrsRaw: string): number {
+  if (!attrsRaw.trim()) return 0;
+  let count = 1;
+  let depth = 0;
+  let inString = false;
+  for (let i = 0; i < attrsRaw.length; i++) {
+    const ch = attrsRaw[i];
+    if (ch === "'" && !inString) inString = true;
+    else if (ch === "'" && inString) {
+      if (i + 1 < attrsRaw.length && attrsRaw[i + 1] === "'") { i++; continue; }
+      inString = false;
+    } else if (!inString) {
+      if (ch === '(') depth++;
+      else if (ch === ')') depth--;
+      else if (ch === ',' && depth === 0) count++;
+    }
+  }
+  return count;
+}
+
 /**
  * Convert a raw STEP entity line from one schema version to another.
  *
  * Handles:
  * 1. Entity type name conversion
- * 2. Attribute count adjustment (trimming trailing attrs for older schemas)
+ * 2. Attribute count adjustment: trimming trailing attrs for older schemas, and
+ *    padding trailing `$` for newer schemas that ADDED attributes (e.g. the
+ *    PredefinedType IFC4 introduced on IfcWall/IfcBeam/IfcOpeningElement/…).
  * 3. Skipping entities that have no valid representation in the target schema
  *
  * @param line - Raw STEP entity line (e.g., "#1=IFCWALL('guid',...);")
@@ -275,8 +331,11 @@ export function convertStepLine(
 ): string {
   if (fromSchema === toSchema) return line;
 
-  // Parse: #ID=TYPE(attrs);
-  const match = line.match(/^(#\d+=)(\w+)\((.*)?\);?\s*$/);
+  // Parse: #ID=TYPE(attrs);  — tolerate whitespace around `=` and before the
+  // type (some exporters, e.g. Tekla, write `#34498= IFCOPENINGELEMENT(...)`).
+  // Without this those lines passed through unconverted, so neither type renames
+  // nor attribute-count adjustment applied and the output stayed schema-invalid.
+  const match = line.match(/^\s*(#\d+=)\s*(\w+)\((.*)?\);?\s*$/);
   if (!match) return line; // not a STEP entity line, pass through
 
   const prefix = match[1];  // "#123="
@@ -298,6 +357,22 @@ export function convertStepLine(
     const maxAttrs = IFC2X3_ATTR_COUNTS.get(newType);
     if (maxAttrs !== undefined) {
       finalAttrs = trimAttributes(attrsRaw, maxAttrs);
+    }
+  }
+
+  // Pad trailing optional attributes when UPGRADING to a newer schema that ADDED
+  // attributes (e.g. IFC2X3 → IFC4 added PredefinedType to IfcWall / IfcBeam /
+  // IfcOpeningElement / …). Without this the upgraded entity is short an attribute
+  // and invalid under the new schema, which strict readers reject. The added
+  // attributes are optional, so `$` is valid. Scoped to upconversion so it never
+  // touches the downconversion trim path above.
+  if (schemaRank(toSchema) > schemaRank(fromSchema)) {
+    const targetCount = attrCountTable(toSchema)?.get(newType);
+    if (targetCount !== undefined) {
+      const currentCount = countTopLevelAttributes(finalAttrs);
+      if (currentCount > 0 && currentCount < targetCount) {
+        finalAttrs = `${finalAttrs}${',$'.repeat(targetCount - currentCount)}`;
+      }
     }
   }
 


### PR DESCRIPTION
Closes #1416.

## Problem
Converting an entity from IFC2X3 to IFC4/IFC4X3 left it **a positional attribute short**: the
converter trimmed trailing attributes when *downgrading* but never **padded** the new trailing
attributes that newer schemas added (`PredefinedType` on `IfcWall`/`IfcBeam`/`IfcOpeningElement`/
`IfcFastener`/…, the IfcDoor/IfcWindow additions, `IfcMaterial.Category`, `IfcIShapeProfileDef`
fields, …). The upgraded entities were invalid under the new schema → strict readers (BIM Vision)
reject the file. This blocked mixed-schema federated export.

A second, compounding bug: `convertStepLine`'s entity-line regex didn't tolerate whitespace
after `=` (Tekla writes `#34498= IFCOPENINGELEMENT(...)`), so those lines passed through
**completely unconverted** — no type rename, no attribute adjustment.

## Fix
- **Pad** trailing optional attributes up to the target type's positional count, driven by the
  generated buildingSMART attribute tables in `@ifc-lite/data` (`ENTITIES_IFC4` / `IFC4X3`),
  whose `attributes` lists match STEP positional counts exactly (IfcWall 8→9, IfcDoor 10→13,
  IfcMaterial 1→3, …). Added attributes are optional, so `$` is valid. Scoped to **upconversion**
  via a schema rank, so the existing downconversion trim path is untouched.
- **Tolerate whitespace** after `=` (and leading whitespace) in `convertStepLine`.

## Validation (ifcopenshell 0.8.5)
Federated `IfcStair-Assembly.ifc` (IFC4X3) + `test.ifc` (IFC2X3) → IFC4 and → IFC4X3:
- before: **2556** "Invalid attribute value" errors (all PredefinedType/added attrs);
- after: **0** such errors. The only 2 remaining issues are pre-existing source-data defects
  (`IfcProductDefinitionShape` with an empty representation list in the stair file).

## Tests
`schema-converter.test.ts`: padding for IfcOpeningElement/IfcWall/IfcMaterial, whitespace
tolerance, and a no-op when counts already match. Full `@ifc-lite/export` suite green
(123 passed); typecheck clean.

Independent of #1407 / #1415 — pre-existing converter bug, surfaced while validating
mixed-schema federated export.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved STEP entity-line conversion to tolerate extra whitespace around `=` (including Tekla-style formatting), ensuring entity remapping and attribute adjustments still run.
  * During IFC2X3 → IFC4/IFC4X3 upconversion, the converter now pads newly added trailing attributes with `$` when the source attribute list is a strict prefix of the target, preventing invalid positional attributes for strict readers.
  * Preserved correct behavior when no attribute padding is needed (attribute counts already match) and avoided padding when attributes are reordered.
* **Tests**
  * Added expanded coverage for `convertStepLine`, including padding, whitespace tolerance, and negative cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->