### PR TITLE
fix(renderer): measure-snap on mapped/multi-piece elements (pick dedup + fov radius + cache)

### DIFF
--- a/.changeset/snap-flat-multipiece-cache.md
+++ b/.changeset/snap-flat-multipiece-cache.md
@@ -18,3 +18,12 @@ degrees→radians conversion to `fov`, but its only caller passes `Camera.getFOV
 already in radians. The shrunken radius made vertex/edge snap require sub-millimetre cursor
 precision and fall back to a face hit on small features (e.g. bolts). The conversion is
 removed; `fov` is treated as radians.
+
+Also fix the CPU pick/snap mesh collection dropping mapped copies. `collectVisibleMeshData`
+deduped flat pieces on a size-based key (`expressId` + `modelIndex` + buffer sizes), so the
+several flat pieces a mapped entity expands to — identical template geometry at different
+placements (e.g. the 4 bolts of one `IfcMechanicalFastener`) — collided and all but the first
+were dropped from the raycast set. The hidden bolts then returned no ray hit at all, so neither
+pick nor snap could reach them. The key now also includes the per-piece `origin` + first vertex,
+so distinct placements survive while a truly identical piece reached from both the regular and
+batched passes still dedups. (Mirrors the instanced-piece key fix from #1238 for the flat path.)

--- a/.changeset/snap-flat-multipiece-cache.md
+++ b/.changeset/snap-flat-multipiece-cache.md
@@ -4,7 +4,7 @@
 
 Fix measure-snap missing all-but-one piece of a multi-piece flat mesh. The snap geometry cache
 keyed flat meshes on `expressId` alone (instanced occurrences already keyed on `occurrenceKey`,
-#1405), assuming one flat mesh per `expressId`. But mesh fragmentation routinely emits one
+`#1405`), assuming one flat mesh per `expressId`. But mesh fragmentation routinely emits one
 entity as several flat `MeshData` pieces — e.g. an `IfcMechanicalFastener` "Bolt assembly" of
 mapped items materialized as 24 pieces sharing one `expressId` — and mapped copies share both
 `expressId` and local positions, differing only in `origin`. So the first piece's deduped

--- a/.changeset/snap-flat-multipiece-cache.md
+++ b/.changeset/snap-flat-multipiece-cache.md
@@ -1,0 +1,14 @@
+---
+"@ifc-lite/renderer": patch
+---
+
+Fix measure-snap missing all-but-one piece of a multi-piece flat mesh. The snap geometry cache
+keyed flat meshes on `expressId` alone (instanced occurrences already keyed on `occurrenceKey`,
+#1405), assuming one flat mesh per `expressId`. But mesh fragmentation routinely emits one
+entity as several flat `MeshData` pieces — e.g. an `IfcMechanicalFastener` "Bolt assembly" of
+mapped items materialized as 24 pieces sharing one `expressId` — and mapped copies share both
+`expressId` and local positions, differing only in `origin`. So the first piece's deduped
+vertices/edges were served for every other piece, and vertex/edge snap lit up on only one piece
+(one bolt of the group) while the rest fell back to a free-point face hit. The cache now keys
+flat pieces on a cheap content signature (`expressId` + `origin` + buffer sizes + sampled
+vertices), so every piece snaps; genuinely identical world geometry still shares one entry.

--- a/.changeset/snap-flat-multipiece-cache.md
+++ b/.changeset/snap-flat-multipiece-cache.md
@@ -12,3 +12,9 @@ vertices/edges were served for every other piece, and vertex/edge snap lit up on
 (one bolt of the group) while the rest fell back to a free-point face hit. The cache now keys
 flat pieces on a cheap content signature (`expressId` + `origin` + buffer sizes + sampled
 vertices), so every piece snaps; genuinely identical world geometry still shares one entry.
+
+Also fix the measure-snap radius being ~57× too small. `screenToWorldRadius` applied a
+degrees→radians conversion to `fov`, but its only caller passes `Camera.getFOV()`, which is
+already in radians. The shrunken radius made vertex/edge snap require sub-millimetre cursor
+precision and fall back to a face hit on small features (e.g. bolts). The conversion is
+removed; `fov` is treated as radians.

--- a/packages/renderer/src/raycast-engine.ts
+++ b/packages/renderer/src/raycast-engine.ts
@@ -111,8 +111,21 @@ export class RaycastEngine {
                     continue;
                 }
 
-                // Avoid duplicates when a piece is reachable from both regular and batched passes
-                const key = `${piece.expressId}:${piece.modelIndex ?? 'any'}:${piece.positions.length}:${piece.indices.length}`;
+                // Avoid duplicates when a piece is reachable from both regular and
+                // batched passes — but DON'T collapse distinct pieces of one entity.
+                // Mapped copies (IfcMappedItem, e.g. the 4 bolts of one fastener)
+                // become several flat pieces sharing expressId/modelIndex AND buffer
+                // sizes (same template), differing only in position/origin. A
+                // size-based key dropped all but the first, so 3 of 4 bolts were
+                // absent from the raycast set → unpickable / unsnappable. Include the
+                // per-piece origin + first vertex so distinct placements survive while
+                // a truly identical piece reached twice still dedups. (Mirrors the
+                // instanced-piece key fix in #1238.)
+                const p0 = piece.positions;
+                const o = piece.origin;
+                const key = `${piece.expressId}:${piece.modelIndex ?? 'any'}:${piece.positions.length}:${piece.indices.length}`
+                    + `:${o ? `${o[0]},${o[1]},${o[2]}` : ''}`
+                    + `:${p0.length >= 3 ? `${p0[0]},${p0[1]},${p0[2]}` : ''}`;
                 if (seenKeys.has(key)) continue;
                 seenKeys.add(key);
                 allMeshData.push(piece);

--- a/packages/renderer/src/snap-detector-instanced.test.ts
+++ b/packages/renderer/src/snap-detector-instanced.test.ts
@@ -149,3 +149,39 @@ test('flat meshes (no occurrenceKey) still snap, keyed by expressId', () => {
   assert.equal(snap!.type, SnapType.VERTEX);
   assert.ok(Math.abs(snap!.position.x - 10) < 1e-4, `flat-mesh snap x≈10, got ${snap!.position.x}`);
 });
+
+const RAY = { origin: CAMERA.position, direction: { x: 0, y: 0, z: -1 } };
+
+test('snap finds a vertex on EVERY flat sub-piece of one expressId, not just the first', () => {
+  // Mesh fragmentation emits ONE entity as several flat pieces sharing an
+  // expressId with NO occurrenceKey (e.g. an IfcMechanicalFastener "Bolt
+  // assembly" materialized as many pieces). Distinct world positions; here the
+  // sub-pieces differ in their local positions.
+  const pieceA = makeCube(500, 0);
+  const pieceB = makeCube(500, 10);
+  const meshes = [pieceA, pieceB];
+  const detector = new SnapDetector();
+
+  // Fill the cache from A first.
+  detector.detectSnapTarget(RAY, meshes, hitAtCorner(0, 500, [0, 0, 0]), CAMERA, SCREEN_H);
+  // Pre-fix B (same expressId) reused A's cached geometry → no nearby vertex → face fallback.
+  const snapB = detector.detectSnapTarget(RAY, meshes, hitAtCorner(1, 500, [10, 0, 0]), CAMERA, SCREEN_H);
+  assert.equal(snapB!.type, SnapType.VERTEX, 'second flat piece must snap to its own vertex');
+  assert.ok(Math.abs(snapB!.position.x - 10) < 1e-4, `piece B snap x≈10, got ${snapB!.position.x}`);
+});
+
+test('snap distinguishes flat mapped copies that share local positions and differ only by origin', () => {
+  // The IfcMappedItem bolt case: same expressId, identical LOCAL geometry, distinct
+  // `origin` (placement). The cache lifts local+origin to world, so the two copies
+  // hold different world geometry and must not share a cache entry.
+  const local = makeCube(600, 0);
+  const copyA: MeshData = { ...local, origin: [0, 0, 0] };
+  const copyB: MeshData = { ...local, origin: [10, 0, 0] };
+  const meshes = [copyA, copyB];
+  const detector = new SnapDetector();
+
+  detector.detectSnapTarget(RAY, meshes, hitAtCorner(0, 600, [0, 0, 0]), CAMERA, SCREEN_H);
+  const snapB = detector.detectSnapTarget(RAY, meshes, hitAtCorner(1, 600, [10, 0, 0]), CAMERA, SCREEN_H);
+  assert.equal(snapB!.type, SnapType.VERTEX, 'mapped copy B should snap to its own corner, not copy A geometry');
+  assert.ok(Math.abs(snapB!.position.x - 10) < 1e-4, `copy B snap x≈10, got ${snapB!.position.x}`);
+});

--- a/packages/renderer/src/snap-detector-instanced.test.ts
+++ b/packages/renderer/src/snap-detector-instanced.test.ts
@@ -65,7 +65,8 @@ function hitAtCorner(meshIndex: number, expressId: number, corner: [number, numb
   };
 }
 
-const CAMERA = { position: { x: 0, y: 0, z: 100 }, fov: 50 };
+// fov in RADIANS, matching Camera.getFOV() (the real snap call site).
+const CAMERA = { position: { x: 0, y: 0, z: 100 }, fov: Math.PI / 4 };
 const SCREEN_H = 800;
 
 test('snap finds a vertex on EVERY instanced occurrence, not just the first (#1405)', () => {

--- a/packages/renderer/src/snap-detector.ts
+++ b/packages/renderer/src/snap-detector.ts
@@ -96,13 +96,13 @@ export class SnapDetector {
   // serving the pre-edit geometry. This is identical for flat and instanced
   // meshes; instancing adds no new staleness window.
   //
-  // Keyed by `mesh.occurrenceKey ?? mesh.expressId`: flat meshes (one per
-  // expressId) key on the numeric id, but GPU-instanced occurrences share one
-  // expressId across many world-space placements, so they must key on their
-  // per-occurrence string key (issue #1405) — keying on expressId alone served
-  // the first occurrence's edges/vertices for every later one, so snap lit up
-  // on a single instance.
-  private geometryCache = new Map<string | number, MeshGeometryCache>();
+  // Keyed via cacheKeyFor(): GPU-instanced occurrences use their per-occurrence
+  // `occurrenceKey` (issue #1405); flat meshes use a content signature
+  // (expressId + origin + buffer sizes + sampled vertices), because one entity
+  // is often emitted as several flat sub-pieces sharing an expressId — keying on
+  // expressId alone served the first piece's edges/vertices for every later one,
+  // so snap lit up on a single piece of a multi-piece element.
+  private geometryCache = new Map<string, MeshGeometryCache>();
 
   /**
    * Detect best snap target near cursor
@@ -548,9 +548,7 @@ export class SnapDetector {
    * Get or compute geometry cache for a mesh
    */
   private getGeometryCache(mesh: MeshData): MeshGeometryCache {
-    // Instanced occurrences share an expressId but hold distinct world-space
-    // positions, so key on the per-occurrence key when present (issue #1405).
-    const key = mesh.occurrenceKey ?? mesh.expressId;
+    const key = this.cacheKeyFor(mesh);
     const cached = this.geometryCache.get(key);
     if (cached) {
       return cached;
@@ -559,6 +557,39 @@ export class SnapDetector {
     const cache = buildGeometryCache(mesh);
     this.geometryCache.set(key, cache);
     return cache;
+  }
+
+  /**
+   * Stable cache key for a mesh's snap geometry.
+   *
+   * GPU-instanced occurrences carry an explicit per-occurrence `occurrenceKey`
+   * (issue #1405). Flat meshes do not, and keying them on `expressId` alone is
+   * wrong whenever ONE entity is emitted as several flat sub-pieces — mesh
+   * fragmentation routinely splits an element into many `MeshData` pieces (e.g.
+   * an IfcMechanicalFastener "Bolt assembly" of mapped items materialized as 24
+   * pieces), and mapped copies share both `expressId` and local positions while
+   * differing only in `origin`. Keying on `expressId` served the first piece's
+   * vertices/edges for every other, so snap lit up on a single piece.
+   *
+   * So flat pieces key on a cheap content signature: `expressId` + per-piece
+   * `origin` (distinguishes same-template copies at different placements) +
+   * buffer sizes + sampled vertices (distinguishes distinct sub-pieces of one
+   * element). Pieces whose world geometry is genuinely identical collapse to the
+   * same key, which is correct (their snap geometry is the same).
+   */
+  private cacheKeyFor(mesh: MeshData): string {
+    if (mesh.occurrenceKey !== undefined) return mesh.occurrenceKey;
+    const p = mesh.positions;
+    const n = p.length;
+    const o = mesh.origin;
+    const ox = o ? o[0] : 0, oy = o ? o[1] : 0, oz = o ? o[2] : 0;
+    // middle vertex offset, aligned to a 3-float stride
+    const mid = n >= 3 ? (Math.floor(n / 6) * 3) : 0;
+    return `${mesh.expressId}:${n}:${mesh.indices?.length ?? 0}` +
+      `:${ox},${oy},${oz}` +
+      `:${p[0]},${p[1]},${p[2]}` +
+      `:${p[mid]},${p[mid + 1]},${p[mid + 2]}` +
+      `:${p[n - 3]},${p[n - 2]},${p[n - 1]}`;
   }
 
   /**

--- a/packages/renderer/src/snap-geometry-utils.test.ts
+++ b/packages/renderer/src/snap-geometry-utils.test.ts
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { screenToWorldRadius } from './snap-geometry-utils.js';
+
+// `fov` is RADIANS (Camera.getFOV()). worldHeight = 2·dist·tan(fov/2);
+// result = (screenRadius/screenHeight)·worldHeight.
+test('screenToWorldRadius treats fov as radians', () => {
+  // fov = π/2 → tan(π/4) = 1 → worldHeight = 2·1·1 = 2 → (100/200)·2 = 1.
+  const r = screenToWorldRadius(100, 1, Math.PI / 2, 200);
+  assert.ok(Math.abs(r - 1) < 1e-9, `expected 1, got ${r}`);
+});
+
+test('screenToWorldRadius does NOT re-apply a degrees→radians conversion', () => {
+  // A real camera fov (~45° = π/4 rad) at 1 m must give a usable radius, not the
+  // ~57×-too-small value the old `fov*π/180` produced (issue: bolts wouldn't snap).
+  const fixed = screenToWorldRadius(20, 1, Math.PI / 4, 800);
+  const buggy = (20 / 800) * 2 * 1 * Math.tan(((Math.PI / 4) * Math.PI) / 180 / 2);
+  assert.ok(fixed > buggy * 40, `fixed (${fixed}) should dwarf the old buggy value (${buggy})`);
+  // Sanity: ~1 cm-scale radius for 20 px at 1 m, not sub-millimetre.
+  assert.ok(fixed > 0.005 && fixed < 0.05, `expected a usable radius, got ${fixed}`);
+});

--- a/packages/renderer/src/snap-geometry-utils.ts
+++ b/packages/renderer/src/snap-geometry-utils.ts
@@ -68,7 +68,14 @@ export function closestPointOnEdgeWithT(
 }
 
 /**
- * Convert screen-space radius to world-space radius.
+ * Convert a screen-space radius (pixels) to a world-space radius at `dist`.
+ *
+ * `fov` is the vertical field of view in RADIANS — matching `Camera.getFOV()`,
+ * which is the only source of this value (the snap detector passes it straight
+ * through). It used to apply a degrees→radians conversion here, but the camera
+ * already supplies radians, so that shrank every snap radius by ~57× (tan of a
+ * 57×-too-small angle) — snap then needed sub-millimetre precision and fell back
+ * to face hits on anything but a near-perfect cursor, e.g. small bolts.
  */
 export function screenToWorldRadius(
   screenRadius: number,
@@ -76,9 +83,8 @@ export function screenToWorldRadius(
   fov: number,
   screenHeight: number
 ): number {
-  // Calculate world height at distance
-  const fovRadians = (fov * Math.PI) / 180;
-  const worldHeight = 2 * dist * Math.tan(fovRadians / 2);
+  // World height spanned by the viewport at `dist` (fov already in radians).
+  const worldHeight = 2 * dist * Math.tan(fov / 2);
 
   // Convert screen pixels to world units
   return (screenRadius / screenHeight) * worldHeight;


### PR DESCRIPTION
Three renderer measure-snap fixes, found while debugging "snap catches only one bolt of a
group" on a real model (`test.ifc`: an `IfcMechanicalFastener` "Bolt assembly" = 4
`IfcMappedItem` copies of one `RepresentationMap` at distinct placements). All three were
needed; the last is what made every bolt snap.

## 1. Mapped copies dropped from the pick/snap mesh set (the unblocker)
`collectVisibleMeshData` deduped flat pieces on a **size-based** key
(`expressId` + `modelIndex` + buffer sizes). A mapped entity expands to several flat pieces with
**identical template geometry** at different placements, so the key collided and all but the
first were dropped from the raycast set → the other bolts returned **no ray hit at all**, so
neither pick nor snap could reach them. The key now also includes the per-piece `origin` + first
vertex, so distinct placements survive while a piece reached from both the regular and batched
passes still dedups. (Mirrors the instanced-piece key fix from #1238 for the flat path.)

## 2. Snap radius ~57× too small
`screenToWorldRadius` applied a degrees→radians conversion to `fov`, but its only caller passes
`Camera.getFOV()` (already radians) → `tan(fov·π/180 / 2)` instead of `tan(fov/2)`. Vertex/edge
snap then needed sub-millimetre cursor precision and fell back to face hits on small features.
Treat `fov` as radians.

## 3. Multi-piece flat meshes shared one snap-geometry cache entry
The snap cache keyed flat meshes on `expressId` alone (instanced occurrences already key on
`occurrenceKey`, #1405), assuming one flat mesh per `expressId`. Mesh fragmentation emits one
entity as several flat pieces, so the first piece's vertices/edges were served for all. The cache
now keys flat pieces on a content signature (`expressId` + `origin` + buffer sizes + sampled
vertices).

## Tests
`snap-geometry-utils.test.ts` (radians contract) and `snap-detector-instanced.test.ts` (multiple
flat sub-pieces; mapped copies differing only by `origin`) — both flat-piece cases verified to
fail with the old keys and pass with the fix. Full renderer suite green (173 passed); typecheck
clean. The mesh-collection dedup fix is verified end-to-end (all bolts of a fastener now snap);
it lives in a private collection path that needs a full Scene+canvas, so it isn't covered by a
node unit test.

Extends #1405/#1409 (instanced occurrences) to the non-instanced mapped/multi-piece flat case.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved snapping and picking accuracy for small/flat mesh pieces by preventing incorrect cache reuse across distinct sub-piece placements.
  * Fixed cases where mapped/copied geometry with the same identifier could be incorrectly deduplicated, ensuring snaps resolve to the correct piece.
  * Corrected field-of-view handling so snap radius calculations treat FOV as radians, improving responsiveness.

* **Tests**
  * Added/updated regression tests for flat sub-pieces and mapped copies to cover cache correctness, including FOV-as-radians behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->