### PR TITLE
feat(instancing): fix mapped-item instancing + instanced streaming output foundation (#1623)

### DIFF
--- a/rust/ffi/src/tests.rs
+++ b/rust/ffi/src/tests.rs
@@ -33,6 +33,7 @@ fn processing_result(
 
     ProcessingResult {
         meshes: vec![mesh_a, mesh_b],
+        instances: Vec::new(),
         mesh_coordinate_space: mesh_coordinate_space.map(str::to_string),
         site_transform: site_transform.map(|m| m.to_vec()),
         building_transform: None,

--- a/rust/geometry/src/router/processing.rs
+++ b/rust/geometry/src/router/processing.rs
@@ -412,32 +412,37 @@ impl GeometryRouter {
                         continue;
                     }
 
-                    // Apply MappedItem transform to newly added sub-meshes
+                    // Apply MappedItem transform to newly added sub-meshes.
                     if let Some(mut transform) = mapping_transform {
                         self.scale_transform(&mut transform);
-                        // The MappingTarget is baked into the vertices here, but
-                        // `rep_identity` was hashed from the canonical (pre-target)
-                        // geometry during the recursion. Two occurrences sharing a map
-                        // with DIFFERENT targets would therefore collate under one
-                        // template and reuse the reference's target offset/orientation.
-                        // When the target actually changes the geometry, re-hash the
-                        // post-target local geometry so rep_identity matches what is
-                        // baked. Identity targets (the common Revit case) leave the
-                        // geometry unchanged, so the canonical hash already matches —
-                        // skip the re-hash there to avoid the O(verts) cost.
+                        // The MappingTarget is a PER-OCCURRENCE transform, not part of the
+                        // shared geometry. It is baked into the vertices here (the
+                        // materialized/flat output is byte-for-byte unchanged), but for
+                        // INSTANCING it is recorded in `local_transform` — mirroring the
+                        // single-mesh `process_mapped_item_cached` — while `rep_identity`
+                        // keeps the canonical, pre-target content hash. So occurrences that
+                        // share a RepresentationMap but differ only by target collate under
+                        // ONE template (collate composes transform·local_transform to place
+                        // each). Previously this re-hashed the post-target geometry, giving
+                        // every distinct target a unique rep_identity and silently disabling
+                        // instancing for per-occurrence-target mapped items (metering
+                        // stations / MEP: ~4.8x reuse was rendered flat). #1623
                         let nontrivial_target = !transform.is_identity(1e-9);
                         for sub in &mut sub_meshes.sub_meshes[count_before..] {
                             self.transform_mesh_local(&mut sub.mesh, &transform);
-                            if nontrivial_target
-                                && sub
-                                    .mesh
-                                    .instance_meta
-                                    .as_ref()
-                                    .is_some_and(|im| im.instanceable)
-                            {
-                                let h = Self::compute_mesh_hash_full(&sub.mesh) | DIRECT_SOLID_TAG;
+                            if instancing_enabled() && nontrivial_target {
                                 if let Some(im) = sub.mesh.instance_meta.as_mut() {
-                                    im.rep_identity = h;
+                                    if im.instanceable {
+                                        im.local_transform = Some(match im.local_transform {
+                                            // Nested mapping: outer target ∘ inner target,
+                                            // matching the vertex bake order.
+                                            Some(inner) => mat4_to_row_major(
+                                                &(transform
+                                                    * nalgebra::Matrix4::from_row_slice(&inner)),
+                                            ),
+                                            None => mat4_to_row_major(&transform),
+                                        });
+                                    }
                                 }
                             }
                         }

--- a/rust/processing/src/lib.rs
+++ b/rust/processing/src/lib.rs
@@ -45,14 +45,14 @@ pub use processor::{
     process_geometry_streaming, process_geometry_streaming_filtered,
     process_geometry_streaming_filtered_with_options, process_geometry_streaming_with_options,
     process_geometry_streaming_with_options_and_bootstrap,
-    OpeningFilterMode, ProcessingResult, StreamingOptions,
+    InstanceRecord, OpeningFilterMode, ProcessingResult, StreamingOptions,
 };
 pub use style::{default_color_for_type, Rgba, TRANSPARENCY_ALPHA_THRESHOLD};
 pub use symbolic::{
     extract_symbolic_data, SymbolicCircle, SymbolicData, SymbolicFillArea, SymbolicGridAxis,
     SymbolicPolyline, SymbolicText,
 };
-pub use types::mesh::{InstanceRecord, MeshData};
+pub use types::mesh::MeshData;
 pub use types::response::{
     CoordinateInfo, ModelMetadata, ParseResponse, ProcessingStats,
     QuickMetadataBootstrap, QuickMetadataEntitySummary, QuickMetadataSpatialNode,

--- a/rust/processing/src/lib.rs
+++ b/rust/processing/src/lib.rs
@@ -52,7 +52,7 @@ pub use symbolic::{
     extract_symbolic_data, SymbolicCircle, SymbolicData, SymbolicFillArea, SymbolicGridAxis,
     SymbolicPolyline, SymbolicText,
 };
-pub use types::mesh::MeshData;
+pub use types::mesh::{InstanceRecord, MeshData};
 pub use types::response::{
     CoordinateInfo, ModelMetadata, ParseResponse, ProcessingStats,
     QuickMetadataBootstrap, QuickMetadataEntitySummary, QuickMetadataSpatialNode,

--- a/rust/processing/src/processor/instancing.rs
+++ b/rust/processing/src/processor/instancing.rs
@@ -1,0 +1,163 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Instanced streaming output (#1623).
+//!
+//! Post-pass collation of the retained, already-materialized meshes: occurrences
+//! sharing a representation identity collapse onto one template `MeshData` plus a
+//! lightweight [`InstanceRecord`] each. This is an OUTPUT/memory dedup — the
+//! occurrences are still meshed and streamed first; collation runs afterwards.
+//! The separate CPU (don't-bake) win layers on top later. Split out of
+//! `processor/mod.rs` so the orchestrator stays under its module-size budget.
+
+use crate::types::mesh::MeshData;
+
+/// One occurrence of a shared template geometry, emitted INSTEAD of a full
+/// materialized mesh when `StreamingOptions.enable_instancing` is set (#1623).
+///
+/// On instance-heavy models (metering stations, MEP, steel) many products share
+/// one representation; rather than keep a materialized world mesh per occurrence,
+/// the engine retains the shared geometry ONCE (a template `MeshData`) and emits
+/// one of these per additional occurrence. The consumer draws the template placed
+/// by `transform` and identifies/colours the occurrence from the remaining
+/// fields. Purely in-memory (recomputed each load, never round-trips a cache),
+/// like [`ifc_lite_geometry::InstanceMeta`].
+#[derive(Debug, Clone)]
+pub struct InstanceRecord {
+    /// This occurrence's IFC element id.
+    pub express_id: u32,
+    /// IFC type name (e.g. "IfcFlowFitting").
+    pub ifc_type: String,
+    /// IFC GlobalId when available.
+    pub global_id: Option<String>,
+    /// IFC Name when available.
+    pub name: Option<String>,
+    /// IFC presentation layer assignment name when available.
+    pub presentation_layer: Option<String>,
+    /// This occurrence's RGBA colour (may differ from the template occurrence's).
+    pub color: [f32; 4],
+    /// Index of the template `MeshData` in the returned `ProcessingResult.meshes`
+    /// — the stable, O(1) binding from this record to its geometry. Prefer this
+    /// over [`template_express_id`](Self::template_express_id), which is not unique.
+    pub template_mesh_index: u32,
+    /// `express_id` of the template occurrence's `MeshData`. INFORMATIONAL only —
+    /// it is the product id and is NOT unique (a multi-item Tekla product yields
+    /// several retained submeshes sharing it), so it must not be used to bind an
+    /// instance to a template; use [`template_mesh_index`](Self::template_mesh_index).
+    pub template_express_id: u32,
+    /// Representation-identity (content identity) of the shared geometry: a full
+    /// 128-bit content hash on the direct-solid path, or the `IfcRepresentationMap`
+    /// id for mapped items. The same key that grouped these occurrences (and that
+    /// the GLB export instancing keys on); carried for dedup/parity reasoning.
+    pub rep_identity: u128,
+    /// Row-major, TEMPLATE-RELATIVE mat4: applied to the template's baked world
+    /// geometry (`template.origin + positions`) it yields this occurrence's world
+    /// geometry (`collate_refs`' `rel_k = m_k · m_ref⁻¹`; identity for the template
+    /// occurrence itself, which is why the template is never emitted as a record).
+    pub transform: [f32; 16],
+}
+
+/// Result of [`collate_into_instances`]: the per-occurrence records plus the mesh
+/// counters RECOMPUTED from the retained `meshes` after the instanced occurrences
+/// were dropped, so `ProcessingStats` reports the returned data rather than the
+/// pre-collation materialized figures.
+pub(crate) struct InstancingResult {
+    pub instances: Vec<InstanceRecord>,
+    pub total_meshes: usize,
+    pub total_vertices: usize,
+    pub total_triangles: usize,
+}
+
+/// Collate materialized meshes by representation identity (#1623): every occurrence
+/// beyond the first of each shared template becomes an [`InstanceRecord`] and its
+/// `MeshData` is removed from `meshes`, leaving one template per group (plus all
+/// non-instanced meshes). The per-occurrence transform is template-relative, the
+/// same collation the GLB export instancing (#1443) uses. `rtc` is the model RTC
+/// offset (see `collate_refs`). The returned counters reflect the retained meshes.
+pub(crate) fn collate_into_instances(meshes: &mut Vec<MeshData>, rtc: [f64; 3]) -> InstancingResult {
+    use ifc_lite_geometry::{collate_refs, InstanceMeshRef};
+
+    let refs: Vec<InstanceMeshRef> = meshes
+        .iter()
+        .map(|m| InstanceMeshRef {
+            positions: &m.positions,
+            normals: &m.normals,
+            indices: &m.indices,
+            origin: m.origin,
+            instance_meta: m.instance.as_ref(),
+            entity_id: m.express_id,
+            color: m.color,
+        })
+        .collect();
+    let collated = collate_refs(&refs, 2, rtc);
+
+    // Pass 1: mark which meshes are folded out (every non-template occurrence).
+    // Templates are never dropped, so their post-retain index is well-defined.
+    let mut drop_mesh = vec![false; meshes.len()];
+    for tpl in &collated.templates {
+        for occ in &tpl.occurrences {
+            if occ.mesh_index != tpl.template_index {
+                drop_mesh[occ.mesh_index] = true;
+            }
+        }
+    }
+    // Map each surviving mesh's pre-collation index to its index in the retained
+    // vec (running count of kept meshes before it), so records can point straight
+    // at their template in `ProcessingResult.meshes`.
+    let mut retained_index = vec![0u32; meshes.len()];
+    let mut kept = 0u32;
+    for (i, dropped) in drop_mesh.iter().enumerate() {
+        retained_index[i] = kept;
+        if !dropped {
+            kept += 1;
+        }
+    }
+
+    let mut instances = Vec::new();
+    for tpl in &collated.templates {
+        let template_express_id = meshes[tpl.template_index].express_id;
+        let template_mesh_index = retained_index[tpl.template_index];
+        for occ in &tpl.occurrences {
+            // The template occurrence is drawn directly from its retained MeshData.
+            if occ.mesh_index == tpl.template_index {
+                continue;
+            }
+            let m = &meshes[occ.mesh_index];
+            instances.push(InstanceRecord {
+                express_id: m.express_id,
+                ifc_type: m.ifc_type.clone(),
+                global_id: m.global_id.clone(),
+                name: m.name.clone(),
+                presentation_layer: m.presentation_layer.clone(),
+                color: m.color,
+                template_mesh_index,
+                template_express_id,
+                rep_identity: tpl.rep_identity,
+                transform: occ.transform,
+            });
+        }
+    }
+
+    // Drop the instanced (non-template) occurrence meshes; `retain` visits in order.
+    let mut idx = 0;
+    meshes.retain(|_| {
+        let keep = !drop_mesh[idx];
+        idx += 1;
+        keep
+    });
+
+    // Recompute the mesh counters from what actually remains: the pre-collation
+    // `total_*` counted every materialized occurrence, but those are now folded
+    // into `instances`, so reporting them would overstate the returned geometry.
+    InstancingResult {
+        instances,
+        total_meshes: meshes.len(),
+        total_vertices: meshes.iter().map(|m| m.vertex_count()).sum(),
+        total_triangles: meshes.iter().map(|m| m.triangle_count()).sum(),
+    }
+}
+
+#[cfg(test)]
+#[path = "instancing_tests.rs"]
+mod instancing_tests;

--- a/rust/processing/src/processor/instancing_tests.rs
+++ b/rust/processing/src/processor/instancing_tests.rs
@@ -1,0 +1,166 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Unit coverage for the `collate_into_instances` producer (#1623): conservation
+//! (nothing gained or lost), exact recomposition of an occurrence against its
+//! flag-off world geometry, and that `rep_identity` — not the shared product id —
+//! is what disambiguates a multi-submesh (Tekla-style) product.
+
+use super::collate_into_instances;
+use crate::types::mesh::MeshData;
+use ifc_lite_geometry::InstanceMeta;
+
+/// Row-major translation mat4.
+fn translate(tx: f64, ty: f64, tz: f64) -> [f64; 16] {
+    [
+        1.0, 0.0, 0.0, tx, //
+        0.0, 1.0, 0.0, ty, //
+        0.0, 0.0, 1.0, tz, //
+        0.0, 0.0, 0.0, 1.0,
+    ]
+}
+
+/// Canonical unit-triangle local geometry, shared by every occurrence of a rep.
+fn unit_triangle() -> Vec<f32> {
+    vec![0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0]
+}
+
+/// Bake a canonical `xyz` triplet buffer into world space under a translation.
+fn bake(local: &[f32], tx: f64, ty: f64, tz: f64) -> Vec<f32> {
+    local
+        .chunks_exact(3)
+        .flat_map(|v| {
+            [
+                v[0] + tx as f32,
+                v[1] + ty as f32,
+                v[2] + tz as f32,
+            ]
+        })
+        .collect()
+}
+
+/// A materialized occurrence: canonical geometry `local` baked under a pure
+/// translation, carrying the matching `InstanceMeta` (transform == that same
+/// translation, `local_transform` None) so `collate_refs` reconstructs it exactly.
+fn occurrence(express_id: u32, rep_identity: u128, local: &[f32], t: (f64, f64, f64)) -> MeshData {
+    let positions = bake(local, t.0, t.1, t.2);
+    let normals = vec![0.0; positions.len()];
+    let indices: Vec<u32> = (0..(positions.len() / 3) as u32).collect();
+    MeshData::new(
+        express_id,
+        "IfcFlowFitting".to_string(),
+        positions,
+        normals,
+        indices,
+        [1.0, 1.0, 1.0, 1.0],
+    )
+    .with_instance(Some(InstanceMeta {
+        transform: translate(t.0, t.1, t.2),
+        local_transform: None,
+        canonical_transform: None,
+        rep_identity,
+        instanceable: true,
+    }))
+}
+
+/// Apply a row-major mat4 to a point, perspective-divided.
+fn apply(t: &[f32; 16], x: f32, y: f32, z: f32) -> (f32, f32, f32) {
+    let x = x as f64;
+    let y = y as f64;
+    let z = z as f64;
+    let wx = t[0] as f64 * x + t[1] as f64 * y + t[2] as f64 * z + t[3] as f64;
+    let wy = t[4] as f64 * x + t[5] as f64 * y + t[6] as f64 * z + t[7] as f64;
+    let wz = t[8] as f64 * x + t[9] as f64 * y + t[10] as f64 * z + t[11] as f64;
+    let ww = t[12] as f64 * x + t[13] as f64 * y + t[14] as f64 * z + t[15] as f64;
+    ((wx / ww) as f32, (wy / ww) as f32, (wz / ww) as f32)
+}
+
+#[test]
+fn collation_conserves_meshes_and_recomposes_the_occurrence() {
+    let l = unit_triangle();
+    // Two occurrences share rep 1 (collate); a singleton rep 2 stays flat.
+    let template = occurrence(10, 1, &l, (0.0, 0.0, 0.0));
+    let flag_off_occurrence = occurrence(11, 1, &l, (10.0, 0.0, 0.0));
+    let singleton = occurrence(12, 2, &l, (0.0, 5.0, 0.0));
+
+    // The world geometry the occurrence would have had with instancing OFF.
+    let expected_world = flag_off_occurrence.positions.clone();
+
+    let mut meshes = vec![template.clone(), flag_off_occurrence, singleton];
+    let before = meshes.len();
+    let out = collate_into_instances(&mut meshes, [0.0, 0.0, 0.0]);
+
+    // Conservation: nothing gained or lost across the split.
+    assert_eq!(
+        before,
+        meshes.len() + out.instances.len(),
+        "meshes_before must equal meshes_after + instances"
+    );
+    assert_eq!(out.instances.len(), 1, "exactly one occurrence instanced");
+    assert_eq!(out.total_meshes, meshes.len(), "counter tracks retained meshes");
+    // Template (rep 1) + singleton (rep 2) retained; occurrence 11 folded out.
+    assert_eq!(meshes.len(), 2);
+    assert!(meshes.iter().any(|m| m.express_id == 10));
+    assert!(meshes.iter().any(|m| m.express_id == 12));
+
+    // Recomposition: the record's template-relative transform applied to the
+    // template's baked world geometry reproduces the flag-off occurrence exactly.
+    let rec = &out.instances[0];
+    assert_eq!(rec.express_id, 11);
+    assert_eq!(rec.rep_identity, 1);
+    // The index binds straight to the retained template mesh (express 10, rep 1).
+    let bound = &meshes[rec.template_mesh_index as usize];
+    assert_eq!(bound.express_id, 10);
+    assert_eq!(bound.instance.as_ref().unwrap().rep_identity, rec.rep_identity);
+    for (i, v) in template.positions.chunks_exact(3).enumerate() {
+        let (wx, wy, wz) = apply(&rec.transform, v[0], v[1], v[2]);
+        assert!((wx - expected_world[i * 3]).abs() < 1e-4);
+        assert!((wy - expected_world[i * 3 + 1]).abs() < 1e-4);
+        assert!((wz - expected_world[i * 3 + 2]).abs() < 1e-4);
+    }
+}
+
+#[test]
+fn rep_identity_disambiguates_multi_submesh_product() {
+    // A multi-item (Tekla-style) product emits several submeshes that SHARE its
+    // express_id but carry DISTINCT rep_identity. Two such products (100, 200)
+    // each contribute one submesh per rep; the collator must group by rep_identity,
+    // never by the shared express_id.
+    let l1 = unit_triangle();
+    let l2 = vec![0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 2.0, 0.0];
+
+    let mut meshes = vec![
+        occurrence(100, 10, &l1, (0.0, 0.0, 0.0)), // product 100, rep 10 (template)
+        occurrence(100, 20, &l2, (0.0, 0.0, 0.0)), // product 100, rep 20 (template)
+        occurrence(200, 10, &l1, (10.0, 0.0, 0.0)), // product 200, rep 10 -> instance
+        occurrence(200, 20, &l2, (10.0, 0.0, 0.0)), // product 200, rep 20 -> instance
+    ];
+    let out = collate_into_instances(&mut meshes, [0.0, 0.0, 0.0]);
+
+    assert_eq!(meshes.len(), 2, "one template retained per rep_identity");
+    assert_eq!(out.instances.len(), 2, "one instanced occurrence per rep");
+
+    // Both instances come from product 200 and carry the SAME template_express_id
+    // (100, the ambiguous product id) yet bind to DIFFERENT templates — proving the
+    // ambiguous product id must NOT be the join key. `template_mesh_index` resolves
+    // each to the correct retained submesh, matched by rep_identity.
+    for rec in &out.instances {
+        assert_eq!(rec.express_id, 200);
+        assert_eq!(rec.template_express_id, 100);
+        let bound = &meshes[rec.template_mesh_index as usize];
+        assert_eq!(
+            bound.instance.as_ref().unwrap().rep_identity,
+            rec.rep_identity,
+            "template_mesh_index must point at the submesh of the matching rep_identity"
+        );
+    }
+    let idxs: Vec<u32> = out.instances.iter().map(|r| r.template_mesh_index).collect();
+    assert_ne!(
+        idxs[0], idxs[1],
+        "the two same-product instances must bind to distinct template meshes"
+    );
+    let mut reps: Vec<u128> = out.instances.iter().map(|r| r.rep_identity).collect();
+    reps.sort_unstable();
+    assert_eq!(reps, vec![10, 20], "rep_identity distinguishes the two submeshes");
+}

--- a/rust/processing/src/processor/job_metadata.rs
+++ b/rust/processing/src/processor/job_metadata.rs
@@ -1,0 +1,74 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Entity-job metadata backfill for the wasm32 serial path.
+//!
+//! Split out of `processor/mod.rs` (module-size ratchet); `jobs.rs` is already
+//! near its own budget. `populate_entity_job_metadata` lazily resolves an
+//! `EntityJob`'s GlobalId / Name / ProductDefinitionShape plus the derived colour
+//! and presentation-layer, memoized per ProductDefinitionShape id. Native builds
+//! resolve this up front in the parallel scan, so the function is wasm-only.
+
+use super::*;
+
+// Only invoked on the wasm32 serial path; dead on the native build.
+#[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
+// Threads the full metadata-resolution context; splitting it would not improve clarity.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn populate_entity_job_metadata(
+    job: &mut EntityJob,
+    geometry_style_index: &FxHashMap<u32, GeometryStyleInfo>,
+    element_material_color: &FxHashMap<u32, [f32; 4]>,
+    layer_by_assigned_representation: &FxHashMap<u32, String>,
+    color_cache_by_product_definition_shape: &mut FxHashMap<u32, Option<[f32; 4]>>,
+    layer_cache_by_product_definition_shape: &mut FxHashMap<u32, Option<String>>,
+    layer_cache_by_representation: &mut FxHashMap<u32, Option<String>>,
+    decoder: &mut EntityDecoder,
+    include_presentation_layers: bool,
+) {
+    if job.global_id.is_some() || job.name.is_some() || job.product_definition_shape_id.is_some() {
+        return;
+    }
+
+    let Ok(entity) = decoder.decode_at(job.start, job.end) else {
+        return;
+    };
+
+    job.global_id = normalize_optional_string(entity.get_string(0));
+    job.name = normalize_optional_string(entity.get_string(2));
+    job.product_definition_shape_id = entity.get_ref(6);
+
+    let Some(product_definition_shape_id) = job.product_definition_shape_id else {
+        return;
+    };
+
+    let resolved_color = color_cache_by_product_definition_shape
+        .entry(product_definition_shape_id)
+        .or_insert_with(|| {
+            resolve_element_color_for_product_definition_shape(
+                product_definition_shape_id,
+                geometry_style_index,
+                decoder,
+            )
+        });
+    if let Some(color) = resolved_color {
+        job.element_color = *color;
+    } else if let Some(color) = element_material_color.get(&job.id) {
+        job.element_color = *color;
+    }
+
+    if include_presentation_layers {
+        let resolved_layer = layer_cache_by_product_definition_shape
+            .entry(product_definition_shape_id)
+            .or_insert_with(|| {
+                resolve_presentation_layer_for_product_definition_shape(
+                    product_definition_shape_id,
+                    layer_by_assigned_representation,
+                    layer_cache_by_representation,
+                    decoder,
+                )
+            });
+        job.presentation_layer = resolved_layer.clone();
+    }
+}

--- a/rust/processing/src/processor/mod.rs
+++ b/rust/processing/src/processor/mod.rs
@@ -6,7 +6,7 @@
 //!
 //! Originally contributed by Mathias Søndergaard (Sonderwoods/Linkajou).
 
-use crate::types::mesh::MeshData;
+use crate::types::mesh::{InstanceRecord, MeshData};
 use crate::types::response::{
     CoordinateInfo, ModelMetadata, ProcessingStats, QuickMetadataBootstrap,
     QuickMetadataEntitySummary,
@@ -106,6 +106,11 @@ impl OpeningFilterMode {
 /// Result of processing an IFC file.
 pub struct ProcessingResult {
     pub meshes: Vec<MeshData>,
+    /// Per-occurrence instance records emitted when `StreamingOptions.enable_instancing`
+    /// is set (#1623): products whose body is one shared `IfcRepresentationMap` are
+    /// meshed once (a template `MeshData`) and listed here as lightweight placements
+    /// instead of a materialized mesh each. Empty otherwise.
+    pub instances: Vec<InstanceRecord>,
     /// Declares the coordinate space used by serialized mesh vertices.
     pub mesh_coordinate_space: Option<String>,
     /// IfcSite ObjectPlacement as column-major 4x4 matrix (in meters).
@@ -114,6 +119,64 @@ pub struct ProcessingResult {
     pub building_transform: Option<Vec<f64>>,
     pub metadata: ModelMetadata,
     pub stats: ProcessingStats,
+}
+
+/// Collate materialized meshes by representation identity (#1623): every occurrence
+/// beyond the first of each shared template becomes an [`InstanceRecord`] and its
+/// `MeshData` is removed from `meshes`, leaving one template per group (plus all
+/// non-instanced meshes). The per-occurrence transform is template-relative, the
+/// same collation the GLB export instancing (#1443) uses. `rtc` is the model RTC
+/// offset (see `collate_refs`).
+fn collate_into_instances(meshes: &mut Vec<MeshData>, rtc: [f64; 3]) -> Vec<InstanceRecord> {
+    use ifc_lite_geometry::{collate_refs, InstanceMeshRef};
+
+    let refs: Vec<InstanceMeshRef> = meshes
+        .iter()
+        .map(|m| InstanceMeshRef {
+            positions: &m.positions,
+            normals: &m.normals,
+            indices: &m.indices,
+            origin: m.origin,
+            instance_meta: m.instance.as_ref(),
+            entity_id: m.express_id,
+            color: m.color,
+        })
+        .collect();
+    let collated = collate_refs(&refs, 2, rtc);
+
+    let mut instances = Vec::new();
+    let mut drop_mesh = vec![false; meshes.len()];
+    for tpl in &collated.templates {
+        let template_express_id = meshes[tpl.template_index].express_id;
+        for occ in &tpl.occurrences {
+            // The template occurrence is drawn directly from its retained MeshData.
+            if occ.mesh_index == tpl.template_index {
+                continue;
+            }
+            let m = &meshes[occ.mesh_index];
+            instances.push(InstanceRecord {
+                express_id: m.express_id,
+                ifc_type: m.ifc_type.clone(),
+                global_id: m.global_id.clone(),
+                name: m.name.clone(),
+                presentation_layer: m.presentation_layer.clone(),
+                color: m.color,
+                template_express_id,
+                rep_identity: tpl.rep_identity,
+                transform: occ.transform,
+            });
+            drop_mesh[occ.mesh_index] = true;
+        }
+    }
+
+    // Drop the instanced (non-template) occurrence meshes; `retain` visits in order.
+    let mut idx = 0;
+    meshes.retain(|_| {
+        let keep = !drop_mesh[idx];
+        idx += 1;
+        keep
+    });
+    instances
 }
 
 /// Controls the tradeoff between first-frame latency and richer upfront metadata.
@@ -1131,6 +1194,8 @@ pub fn process_geometry_streaming_filtered_with_options(
         FxHashMap::default();
     let mut layer_cache_by_representation: FxHashMap<u32, Option<String>> = FxHashMap::default();
     let mut meshes: Vec<MeshData> = Vec::new();
+    // Instanced output (#1623), populated only when options.enable_instancing.
+    let mut instances: Vec<InstanceRecord> = Vec::new();
     let mut processed_jobs = 0usize;
     let mut total_meshes = 0usize;
     let mut total_vertices = 0usize;
@@ -1498,8 +1563,21 @@ pub fn process_geometry_streaming_filtered_with_options(
         "Geometry processing complete"
     );
 
+    // Instanced output (#1623): collate the retained meshes so occurrences sharing
+    // a template geometry become lightweight InstanceRecords and their materialized
+    // MeshData drop out of `meshes`. Reuses the same rep-identity collation as the
+    // GLB export instancing (#1443). This is the output/memory dedup; the CPU
+    // (don't-bake) win layers on top separately.
+    if options.enable_instancing && options.retain_emitted_meshes {
+        instances = collate_into_instances(
+            &mut meshes,
+            [rtc_offset.0, rtc_offset.1, rtc_offset.2],
+        );
+    }
+
     ProcessingResult {
         meshes,
+        instances,
         mesh_coordinate_space: Some(coord_space.to_string()),
         site_transform,
         building_transform,

--- a/rust/processing/src/processor/mod.rs
+++ b/rust/processing/src/processor/mod.rs
@@ -156,6 +156,16 @@ pub struct StreamingOptions {
     /// so it must not present the result as a completed parse. Used by the
     /// server to stop burning a core when an SSE client disconnects.
     pub cancel: Option<Arc<std::sync::atomic::AtomicBool>>,
+    /// Emit product-level `IfcMappedItem` occurrences as INSTANCES instead of
+    /// materializing a full world-space mesh per occurrence (#1623). When a
+    /// product's representation is a single mapped item onto a shared
+    /// `IfcRepresentationMap`, the map's LOCAL geometry is meshed once (a
+    /// class-2 template) and each occurrence emits only a lightweight instance
+    /// record (placement transform + colour + element id) via `InstanceMeta`.
+    /// On instance-heavy models (metering stations, MEP) this skips the
+    /// per-occurrence 43M-vertex materialize. `false` reproduces the historical
+    /// materialized output byte-for-byte (determinism/parity unaffected).
+    pub enable_instancing: bool,
 }
 
 impl Default for StreamingOptions {
@@ -171,6 +181,7 @@ impl Default for StreamingOptions {
             tessellation_quality: TessellationQuality::default(),
             entity_index: None,
             cancel: None,
+            enable_instancing: false,
         }
     }
 }

--- a/rust/processing/src/processor/mod.rs
+++ b/rust/processing/src/processor/mod.rs
@@ -6,7 +6,7 @@
 //!
 //! Originally contributed by Mathias Søndergaard (Sonderwoods/Linkajou).
 
-use crate::types::mesh::{InstanceRecord, MeshData};
+use crate::types::mesh::MeshData;
 use crate::types::response::{
     CoordinateInfo, ModelMetadata, ProcessingStats, QuickMetadataBootstrap,
     QuickMetadataEntitySummary,
@@ -23,14 +23,21 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 
 mod color_layer;
+mod instancing;
+mod job_metadata;
 mod jobs;
 mod opening_filter;
 mod properties;
 mod quick_metadata;
 mod site_local;
 
+pub use instancing::InstanceRecord;
+use instancing::collate_into_instances;
 pub use site_local::convert_mesh_to_site_local;
 
+// Only invoked on the wasm32 serial path (its sole caller is wasm-gated).
+#[cfg(target_arch = "wasm32")]
+use job_metadata::populate_entity_job_metadata;
 use jobs::{build_color_updates_for_jobs, process_entity_job};
 
 use color_layer::{
@@ -107,9 +114,9 @@ impl OpeningFilterMode {
 pub struct ProcessingResult {
     pub meshes: Vec<MeshData>,
     /// Per-occurrence instance records emitted when `StreamingOptions.enable_instancing`
-    /// is set (#1623): products whose body is one shared `IfcRepresentationMap` are
-    /// meshed once (a template `MeshData`) and listed here as lightweight placements
-    /// instead of a materialized mesh each. Empty otherwise.
+    /// is set (#1623): occurrences sharing a template's geometry are folded into these
+    /// lightweight placements and their materialized meshes drop out of `meshes`.
+    /// Empty otherwise. See [`InstanceRecord`].
     pub instances: Vec<InstanceRecord>,
     /// Declares the coordinate space used by serialized mesh vertices.
     pub mesh_coordinate_space: Option<String>,
@@ -119,64 +126,6 @@ pub struct ProcessingResult {
     pub building_transform: Option<Vec<f64>>,
     pub metadata: ModelMetadata,
     pub stats: ProcessingStats,
-}
-
-/// Collate materialized meshes by representation identity (#1623): every occurrence
-/// beyond the first of each shared template becomes an [`InstanceRecord`] and its
-/// `MeshData` is removed from `meshes`, leaving one template per group (plus all
-/// non-instanced meshes). The per-occurrence transform is template-relative, the
-/// same collation the GLB export instancing (#1443) uses. `rtc` is the model RTC
-/// offset (see `collate_refs`).
-fn collate_into_instances(meshes: &mut Vec<MeshData>, rtc: [f64; 3]) -> Vec<InstanceRecord> {
-    use ifc_lite_geometry::{collate_refs, InstanceMeshRef};
-
-    let refs: Vec<InstanceMeshRef> = meshes
-        .iter()
-        .map(|m| InstanceMeshRef {
-            positions: &m.positions,
-            normals: &m.normals,
-            indices: &m.indices,
-            origin: m.origin,
-            instance_meta: m.instance.as_ref(),
-            entity_id: m.express_id,
-            color: m.color,
-        })
-        .collect();
-    let collated = collate_refs(&refs, 2, rtc);
-
-    let mut instances = Vec::new();
-    let mut drop_mesh = vec![false; meshes.len()];
-    for tpl in &collated.templates {
-        let template_express_id = meshes[tpl.template_index].express_id;
-        for occ in &tpl.occurrences {
-            // The template occurrence is drawn directly from its retained MeshData.
-            if occ.mesh_index == tpl.template_index {
-                continue;
-            }
-            let m = &meshes[occ.mesh_index];
-            instances.push(InstanceRecord {
-                express_id: m.express_id,
-                ifc_type: m.ifc_type.clone(),
-                global_id: m.global_id.clone(),
-                name: m.name.clone(),
-                presentation_layer: m.presentation_layer.clone(),
-                color: m.color,
-                template_express_id,
-                rep_identity: tpl.rep_identity,
-                transform: occ.transform,
-            });
-            drop_mesh[occ.mesh_index] = true;
-        }
-    }
-
-    // Drop the instanced (non-template) occurrence meshes; `retain` visits in order.
-    let mut idx = 0;
-    meshes.retain(|_| {
-        let keep = !drop_mesh[idx];
-        idx += 1;
-        keep
-    });
-    instances
 }
 
 /// Controls the tradeoff between first-frame latency and richer upfront metadata.
@@ -219,14 +168,11 @@ pub struct StreamingOptions {
     /// so it must not present the result as a completed parse. Used by the
     /// server to stop burning a core when an SSE client disconnects.
     pub cancel: Option<Arc<std::sync::atomic::AtomicBool>>,
-    /// Emit product-level `IfcMappedItem` occurrences as INSTANCES instead of
-    /// materializing a full world-space mesh per occurrence (#1623). When a
-    /// product's representation is a single mapped item onto a shared
-    /// `IfcRepresentationMap`, the map's LOCAL geometry is meshed once (a
-    /// class-2 template) and each occurrence emits only a lightweight instance
-    /// record (placement transform + colour + element id) via `InstanceMeta`.
-    /// On instance-heavy models (metering stations, MEP) this skips the
-    /// per-occurrence 43M-vertex materialize. `false` reproduces the historical
+    /// Collapse occurrences of a shared representation into instanced output (#1623):
+    /// after meshing, occurrences that share a template's geometry are folded into
+    /// `ProcessingResult.instances` and their materialized meshes drop out of
+    /// `meshes` (an OUTPUT/memory dedup — the occurrences are still materialized and
+    /// streamed first; collation runs afterwards). `false` reproduces the historical
     /// materialized output byte-for-byte (determinism/parity unaffected).
     pub enable_instancing: bool,
 }
@@ -265,67 +211,6 @@ pub(super) struct EntityJob {
     /// id to render directly (baking its MappingOrigin) instead of walking the
     /// element's `IfcProductDefinitionShape`. `None` for ordinary product jobs.
     pub(super) representation_map_id: Option<u32>,
-}
-
-// Only invoked on the wasm32 serial path; dead on the native build.
-#[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
-// Threads the full metadata-resolution context; splitting it would not improve clarity.
-#[allow(clippy::too_many_arguments)]
-fn populate_entity_job_metadata(
-    job: &mut EntityJob,
-    geometry_style_index: &FxHashMap<u32, GeometryStyleInfo>,
-    element_material_color: &FxHashMap<u32, [f32; 4]>,
-    layer_by_assigned_representation: &FxHashMap<u32, String>,
-    color_cache_by_product_definition_shape: &mut FxHashMap<u32, Option<[f32; 4]>>,
-    layer_cache_by_product_definition_shape: &mut FxHashMap<u32, Option<String>>,
-    layer_cache_by_representation: &mut FxHashMap<u32, Option<String>>,
-    decoder: &mut EntityDecoder,
-    include_presentation_layers: bool,
-) {
-    if job.global_id.is_some() || job.name.is_some() || job.product_definition_shape_id.is_some() {
-        return;
-    }
-
-    let Ok(entity) = decoder.decode_at(job.start, job.end) else {
-        return;
-    };
-
-    job.global_id = normalize_optional_string(entity.get_string(0));
-    job.name = normalize_optional_string(entity.get_string(2));
-    job.product_definition_shape_id = entity.get_ref(6);
-
-    let Some(product_definition_shape_id) = job.product_definition_shape_id else {
-        return;
-    };
-
-    let resolved_color = color_cache_by_product_definition_shape
-        .entry(product_definition_shape_id)
-        .or_insert_with(|| {
-            resolve_element_color_for_product_definition_shape(
-                product_definition_shape_id,
-                geometry_style_index,
-                decoder,
-            )
-        });
-    if let Some(color) = resolved_color {
-        job.element_color = *color;
-    } else if let Some(color) = element_material_color.get(&job.id) {
-        job.element_color = *color;
-    }
-
-    if include_presentation_layers {
-        let resolved_layer = layer_cache_by_product_definition_shape
-            .entry(product_definition_shape_id)
-            .or_insert_with(|| {
-                resolve_presentation_layer_for_product_definition_shape(
-                    product_definition_shape_id,
-                    layer_by_assigned_representation,
-                    layer_cache_by_representation,
-                    decoder,
-                )
-            });
-        job.presentation_layer = resolved_layer.clone();
-    }
 }
 
 // `GeometryStyleInfo` moved to `crate::style` — it is shared by this
@@ -1196,6 +1081,7 @@ pub fn process_geometry_streaming_filtered_with_options(
     let mut meshes: Vec<MeshData> = Vec::new();
     // Instanced output (#1623), populated only when options.enable_instancing.
     let mut instances: Vec<InstanceRecord> = Vec::new();
+    let mut instanced_occurrences = 0usize;
     let mut processed_jobs = 0usize;
     let mut total_meshes = 0usize;
     let mut total_vertices = 0usize;
@@ -1565,14 +1451,16 @@ pub fn process_geometry_streaming_filtered_with_options(
 
     // Instanced output (#1623): collate the retained meshes so occurrences sharing
     // a template geometry become lightweight InstanceRecords and their materialized
-    // MeshData drop out of `meshes`. Reuses the same rep-identity collation as the
-    // GLB export instancing (#1443). This is the output/memory dedup; the CPU
-    // (don't-bake) win layers on top separately.
+    // MeshData drop out of `meshes`. The counters are recomputed from what remains,
+    // so `stats.total_*` describe the returned meshes, not the pre-collation output.
     if options.enable_instancing && options.retain_emitted_meshes {
-        instances = collate_into_instances(
-            &mut meshes,
-            [rtc_offset.0, rtc_offset.1, rtc_offset.2],
-        );
+        let collated =
+            collate_into_instances(&mut meshes, [rtc_offset.0, rtc_offset.1, rtc_offset.2]);
+        instanced_occurrences = collated.instances.len();
+        instances = collated.instances;
+        total_meshes = collated.total_meshes;
+        total_vertices = collated.total_vertices;
+        total_triangles = collated.total_triangles;
     }
 
     ProcessingResult {
@@ -1596,12 +1484,15 @@ pub fn process_geometry_streaming_filtered_with_options(
             total_meshes,
             total_vertices,
             total_triangles,
+            instanced_occurrences: instanced_occurrences as u64,
             parse_time_ms: parse_time.as_millis() as u64,
             entity_scan_time_ms: entity_scan_time.as_millis() as u64,
             lookup_time_ms: lookup_time.as_millis() as u64,
             preprocess_time_ms: preprocess_time.as_millis() as u64,
             geometry_time_ms: geometry_time.as_millis() as u64,
-            total_time_ms: total_time.as_millis() as u64,
+            // Re-measured here (not `total_time` above) so it includes the
+            // post-pass instancing collation, keeping the counter honest.
+            total_time_ms: total_start.elapsed().as_millis() as u64,
             from_cache: false,
             total_csg_failures: total_csg_failures as u64,
             products_with_failures: products_with_failures as u64,

--- a/rust/processing/src/types/mesh.rs
+++ b/rust/processing/src/types/mesh.rs
@@ -215,39 +215,3 @@ impl MeshData {
         self.positions.is_empty() || self.indices.is_empty()
     }
 }
-
-/// One occurrence of a shared template geometry, emitted INSTEAD of a full
-/// materialized mesh when `StreamingOptions.enable_instancing` is set (#1623).
-///
-/// On instance-heavy models (metering stations, MEP, steel) many products share
-/// one `IfcRepresentationMap`; rather than bake a world mesh per occurrence, the
-/// engine meshes the shared geometry ONCE (a `MeshData` template, emitted with
-/// `express_id == template_express_id`) and emits one of these per occurrence.
-/// The consumer draws the template placed by `transform` and identifies/colours
-/// the occurrence from the remaining fields. Purely in-memory (recomputed each
-/// load, never round-trips a cache), like [`MeshData::instance`].
-#[derive(Debug, Clone)]
-pub struct InstanceRecord {
-    /// This occurrence's IFC element id.
-    pub express_id: u32,
-    /// IFC type name (e.g. "IfcFlowFitting").
-    pub ifc_type: String,
-    /// IFC GlobalId when available.
-    pub global_id: Option<String>,
-    /// IFC Name when available.
-    pub name: Option<String>,
-    /// IFC presentation layer assignment name when available.
-    pub presentation_layer: Option<String>,
-    /// This occurrence's RGBA colour (may differ from the template occurrence's).
-    pub color: [f32; 4],
-    /// `express_id` of the template `MeshData` this occurrence instantiates —
-    /// the consumer's link from record to geometry (JS-safe u32).
-    pub template_express_id: u32,
-    /// Representation-identity of the shared geometry (RepresentationMap id).
-    pub rep_identity: u128,
-    /// Row-major, TEMPLATE-RELATIVE mat4: applied to the template's baked world
-    /// geometry (`template.origin + positions`) it yields this occurrence's world
-    /// geometry (`collate_refs`' `rel_k = m_k · m_ref⁻¹`; identity for the template
-    /// occurrence itself, which is why the template is never emitted as a record).
-    pub transform: [f32; 16],
-}

--- a/rust/processing/src/types/mesh.rs
+++ b/rust/processing/src/types/mesh.rs
@@ -215,3 +215,39 @@ impl MeshData {
         self.positions.is_empty() || self.indices.is_empty()
     }
 }
+
+/// One occurrence of a shared template geometry, emitted INSTEAD of a full
+/// materialized mesh when `StreamingOptions.enable_instancing` is set (#1623).
+///
+/// On instance-heavy models (metering stations, MEP, steel) many products share
+/// one `IfcRepresentationMap`; rather than bake a world mesh per occurrence, the
+/// engine meshes the shared geometry ONCE (a `MeshData` template, emitted with
+/// `express_id == template_express_id`) and emits one of these per occurrence.
+/// The consumer draws the template placed by `transform` and identifies/colours
+/// the occurrence from the remaining fields. Purely in-memory (recomputed each
+/// load, never round-trips a cache), like [`MeshData::instance`].
+#[derive(Debug, Clone)]
+pub struct InstanceRecord {
+    /// This occurrence's IFC element id.
+    pub express_id: u32,
+    /// IFC type name (e.g. "IfcFlowFitting").
+    pub ifc_type: String,
+    /// IFC GlobalId when available.
+    pub global_id: Option<String>,
+    /// IFC Name when available.
+    pub name: Option<String>,
+    /// IFC presentation layer assignment name when available.
+    pub presentation_layer: Option<String>,
+    /// This occurrence's RGBA colour (may differ from the template occurrence's).
+    pub color: [f32; 4],
+    /// `express_id` of the template `MeshData` this occurrence instantiates —
+    /// the consumer's link from record to geometry (JS-safe u32).
+    pub template_express_id: u32,
+    /// Representation-identity of the shared geometry (RepresentationMap id).
+    pub rep_identity: u128,
+    /// Row-major, TEMPLATE-RELATIVE mat4: applied to the template's baked world
+    /// geometry (`template.origin + positions`) it yields this occurrence's world
+    /// geometry (`collate_refs`' `rel_k = m_k · m_ref⁻¹`; identity for the template
+    /// occurrence itself, which is why the template is never emitted as a record).
+    pub transform: [f32; 16],
+}

--- a/rust/processing/src/types/response.rs
+++ b/rust/processing/src/types/response.rs
@@ -115,6 +115,12 @@ pub struct ProcessingStats {
     pub total_vertices: usize,
     /// Total number of triangles.
     pub total_triangles: usize,
+    /// Occurrences folded into `ProcessingResult.instances` by the instanced
+    /// output path (#1623). 0 unless `StreamingOptions.enable_instancing` was set;
+    /// when non-zero, `total_meshes` counts only the retained (post-collation)
+    /// meshes, so `total_meshes + instanced_occurrences` is the materialized total.
+    #[serde(default)]
+    pub instanced_occurrences: u64,
     /// Time spent parsing entities (ms).
     pub parse_time_ms: u64,
     /// Time spent scanning entities and building initial job lists (ms).


### PR DESCRIPTION
Two related pieces toward #1623 (the instanced streaming output). Everything new is
behind `StreamingOptions.enable_instancing` (default off) or changes only always-on
instance *metadata*, so the materialized/flat output is byte-for-byte unchanged —
mesh-determinism and ifcopenshell-parity are unaffected.

## 1. Fix: instance per-occurrence-target `IfcMappedItem`

`IfcMappedItem` occurrences that share an `IfcRepresentationMap` but differ by
`MappingTarget` were **silently not instanced** — the submesh path baked the target
into the vertices and re-hashed the post-target geometry into `rep_identity`, so
`collate_refs` saw a unique key per occurrence and rendered every one flat. That's
the whole per-occurrence-target class (metering stations, MEP, Tekla steel).

Fix (mirrors the single-mesh `process_mapped_item_cached`): record the target in
`InstanceMeta.local_transform` (composed for nested maps), keep the canonical,
pre-target `rep_identity`. Occurrences sharing a map now collate under one template.
This also immediately improves the GLB export instancing (#1443), which consumes
`local_transform`.

On a 462 MB metering station (22283 `IfcMappedItem` over 4652 `IfcRepresentationMap`):
distinct `rep_identity` 22280 → 4163, collated templates 3 → 2328.

## 2. Instanced output contract + producer

- `InstanceRecord` (exported) + `ProcessingResult.instances`.
- `StreamingOptions.enable_instancing` (default off).
- `collate_into_instances`: when enabled, collate the retained meshes by
  `rep_identity` (the same collation #1443 uses); every occurrence beyond the first
  of each template becomes an `InstanceRecord` and its `MeshData` drops out of
  `meshes`, leaving one template per group.

Same model: `result.meshes` 22283 → 6819, `instances` 15464 (all accounted for),
retained tris 43.3M → 29.6M. This is the **output/memory** dedup.

## Follow-up (tracked in #1623)

This does not yet cut the open *time* — `collate_into_instances` runs after
materialization. The CPU/open-time win (skip meshing the instanced occurrences up
front) is a deeper, per-item, determinism-sensitive change in the router; the plan
is written up in a comment on #1623.

## Tests

- `cargo test -p ifc-lite-geometry` — 400/400 (collate / congruence / recomposition).
- `cargo test -p ifc-lite-processing` — pass (the local Windows `mesh_determinism`
  mismatch is the pre-existing libm normal gap vs the Linux-pinned manifest; it also
  fails on `main` and passes on CI).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional instancing support for repeated geometry, helping reduce duplicated mesh output when enabled.
  * Geometry results can now include instance records with per-occurrence transforms and identifiers alongside shared mesh templates.
  * Added a new setting to turn instancing on or off.

* **Bug Fixes**
  * Improved handling of mapped geometry so per-occurrence transforms are preserved correctly, including nested mappings.
  * Updated processing results to consistently include instance data in downstream outputs and tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->