### PR TITLE
fix(parser): unwrap typed values whose text spans multiple lines

### DIFF
--- a/packages/parser/src/entity-extractor.test.ts
+++ b/packages/parser/src/entity-extractor.test.ts
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect } from 'vitest';
+import { EntityExtractor } from './entity-extractor.js';
+import type { EntityRef } from './types.js';
+
+/** Build an EntityExtractor over a single STEP record and extract it. */
+function extract(record: string) {
+  const bytes = new TextEncoder().encode(record);
+  const ref: EntityRef = {
+    expressId: 1,
+    type: 'IFCPROPERTYSINGLEVALUE',
+    byteOffset: 0,
+    byteLength: bytes.length,
+    lineNumber: 1,
+  };
+  return new EntityExtractor(bytes).extractEntity(ref);
+}
+
+describe('EntityExtractor typed-value unwrapping', () => {
+  it('unwraps a single-line typed string value', () => {
+    const ent = extract(`#1=IFCPROPERTYSINGLEVALUE('Category',$,IFCLABEL('3410_balustrades'),$);`);
+    expect(ent?.attributes[2]).toEqual(['IFCLABEL', '3410_balustrades']);
+  });
+
+  it('unwraps a typed string value whose text is broken across physical lines', () => {
+    // Authoring tools wrap long STEP lines; a raw newline can land inside the
+    // string literal. The typed value must still be decomposed, not leaked as a
+    // raw `IFCLABEL('...')` literal.
+    const ent = extract(
+      `#1=IFCPROPERTYSINGLEVALUE('Category',$,IFCLABEL('3410_balustrades en leuningen\r\n - balustrades'),$);`,
+    );
+    expect(ent?.attributes[2]).toEqual([
+      'IFCLABEL',
+      '3410_balustrades en leuningen\r\n - balustrades',
+    ]);
+  });
+
+  it('unwraps a numeric typed value split across lines and keeps it numeric', () => {
+    const ent = extract(`#1=IFCPROPERTYSINGLEVALUE('N',$,IFCREAL(\r\n1.5\r\n),$);`);
+    expect(ent?.attributes[2]).toEqual(['IFCREAL', 1.5]);
+  });
+});

--- a/packages/parser/src/entity-extractor.ts
+++ b/packages/parser/src/entity-extractor.ts
@@ -132,8 +132,12 @@ export class EntityExtractor {
     }
 
     // TypedValue: IFCTYPENAME(value) - must check before list check
-    // Pattern: identifier followed by parentheses (e.g., IFCNORMALISEDRATIOMEASURE(0.5))
-    const typedValueMatch = value.match(/^([A-Z][A-Z0-9_]*)\((.+)\)$/i);
+    // Pattern: identifier followed by parentheses (e.g., IFCNORMALISEDRATIOMEASURE(0.5)).
+    // The `s` (dotall) flag lets `.+` span line terminators so a wrapped value —
+    // e.g. an IFCLABEL/IFCTEXT string an authoring tool broke across physical
+    // lines — is still unwrapped. Without it the match fails and the raw
+    // `IFCLABEL('...')` literal (mis-typed as a plain string) leaks to callers.
+    const typedValueMatch = value.match(/^([A-Z][A-Z0-9_]*)\((.+)\)$/is);
     if (typedValueMatch) {
       const typeName = typedValueMatch[1];
       const innerValue = typedValueMatch[2].trim();


### PR DESCRIPTION
## Problem

`EntityExtractor.parseAttributeValue` unwraps typed STEP values (e.g. `IFCLABEL('x')` → `['IFCLABEL', 'x']`) with this regex:

```js
const typedValueMatch = value.match(/^([A-Z][A-Z0-9_]*)\((.+)\)$/i);
```

`.+` does not match line terminators without the `s` (dotall) flag. When a value's string literal is broken across physical lines — authoring tools routinely wrap long STEP records, and a raw newline can land inside the quoted string — the match fails. The value is then returned as the **raw literal** `IFCLABEL('...')` and, because it is now an unrecognised plain string, it is also **mis-typed** (a numeric measure loses its numeric type).

A consumer surfaced this as a property value rendering literally as:

```
IFCLABEL('3410_balustrades en leuningen
 - balustrades')
```

instead of `3410_balustrades en leuningen\r\n - balustrades`.

The on-demand `parsePropertyValue` and the list-parsing branch already handle multi-line content correctly; only this typed-value regex was missing the treatment. Note the outer record regex in `extractEntity` already uses `[\s\S]*` for exactly this multi-line reason.

## Fix

Add the `s` flag: `/^([A-Z][A-Z0-9_]*)\((.+)\)$/is`. `.+` stays greedy and `\)$` still anchors the final `)`, so single-line values are unchanged; values with internal line breaks now unwrap. Since a non-typed value that starts with a quote/`#`/digit can never match `^IDENT\(`, this only affects genuine typed values.

## Tests

New `entity-extractor.test.ts`:
- single-line typed string → unwrapped
- typed string broken across physical lines → unwrapped (previously leaked)
- numeric typed value split across lines → unwrapped **and** kept numeric

Full parser suite: 242 passed.
