### PR TITLE
fix(renderer): surface non-intentional GPU device loss via onDeviceLost

### DIFF
--- a/.changeset/renderer-device-lost-event.md
+++ b/.changeset/renderer-device-lost-event.md
@@ -1,0 +1,13 @@
+---
+'@ifc-lite/renderer': minor
+---
+
+Add `Renderer.onDeviceLost` so hosts can recover from a lost GPU device instead of a permanently blank canvas.
+
+When the GPU device is lost for a non-intentional reason — e.g. a Windows TDR driver reset or VRAM exhaustion while rotating/re-opening a large model on a weak or integrated GPU — every pipeline and buffer created from it is dead and the viewport can never present again. Previously the renderer only logged a warning and kept trying to configure the lost device, leaving a permanently blank canvas until a full reload.
+
+The renderer now:
+
+- Distinguishes a real loss from an intentional teardown (`GPUDeviceLostInfo.reason === 'destroyed'`) and only reacts to the former.
+- Exposes `Renderer.onDeviceLost(listener)` (returns an unsubscribe) and `Renderer.isDeviceLost()`. Hosts subscribe and typically respond by disposing the renderer and reloading the model. Camera and model state are CPU-side and survive the loss, so the reload restores the model at its current orientation.
+- Makes `render()` a no-op after a loss instead of emitting a stream of GPU validation errors.

--- a/packages/renderer/src/device.ts
+++ b/packages/renderer/src/device.ts
@@ -21,6 +21,19 @@ export class WebGPUDevice {
   _lastUncapturedError: string = '';
 
   /**
+   * Notified when the GPU device is lost for a reason OTHER than intentional
+   * teardown (`reason === 'destroyed'`) — e.g. a driver reset from the OS GPU
+   * watchdog (Windows TDR) or VRAM exhaustion on a weak/integrated GPU. Once a
+   * device is lost every GPU resource created from it is dead, so the renderer
+   * cannot present again until it is fully re-initialised. Consumers subscribe
+   * (see `Renderer.onDeviceLost`) to react — e.g. reload the model — instead of
+   * leaving a permanently blank canvas.
+   */
+  private deviceLostHandler: ((info: { message: string; reason: string }) => void) | null = null;
+  /** Guards against firing the handler more than once for a single device. */
+  private deviceLostFired: boolean = false;
+
+  /**
    * Initialize WebGPU device and canvas context
    */
   async init(canvas: HTMLCanvasElement): Promise<void> {
@@ -73,12 +86,22 @@ export class WebGPUDevice {
     };
 
     // Handle device lost - mark context as needing reconfiguration
-    // Use type assertion as 'lost' may not be in all WebGPU type definitions
-    const deviceWithLost = this.device as GPUDevice & { lost?: Promise<{ message: string }> };
+    // Use type assertion as 'lost'/'reason' may not be in all WebGPU type definitions
+    const deviceWithLost = this.device as GPUDevice & {
+      lost?: Promise<{ message: string; reason?: string }>;
+    };
     if (deviceWithLost.lost) {
       deviceWithLost.lost.then((info) => {
-        console.warn('[WebGPU] Device lost:', info.message);
+        const reason = info.reason ?? 'unknown';
+        console.warn('[WebGPU] Device lost:', info.message, `(reason: ${reason})`);
         this.contextConfigured = false;
+        // `reason === 'destroyed'` is an intentional teardown (a `device.destroy()`
+        // call or the page dropping the device) — not a fault, so don't wake the
+        // recovery path. Any other reason is a real loss the consumer must react to.
+        if (reason !== 'destroyed' && !this.deviceLostFired) {
+          this.deviceLostFired = true;
+          this.deviceLostHandler?.({ message: info.message, reason });
+        }
       });
     }
 
@@ -165,6 +188,16 @@ export class WebGPUDevice {
       throw new Error('Device not initialized');
     }
     return this.device;
+  }
+
+  /**
+   * Register the callback fired when this device is lost for a non-intentional
+   * reason (see `deviceLostHandler`). Only one handler is kept; the renderer
+   * owns it and fans out to its own subscribers. Set before `init()` so a loss
+   * during the very first frames is not missed.
+   */
+  onDeviceLost(handler: (info: { message: string; reason: string }) => void): void {
+    this.deviceLostHandler = handler;
   }
 
   /**

--- a/packages/renderer/src/device.ts
+++ b/packages/renderer/src/device.ts
@@ -37,6 +37,11 @@ export class WebGPUDevice {
    * Initialize WebGPU device and canvas context
    */
   async init(canvas: HTMLCanvasElement): Promise<void> {
+    // Each init() begins a fresh GPUDevice lifetime. Clear the once-per-device
+    // guard so a destroy()+init() re-entry can still report a later loss (the
+    // previous device's `lost` promise already resolved and set this true).
+    this.deviceLostFired = false;
+
     if (!navigator.gpu) {
       throw new Error('WebGPU not available');
     }

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -214,6 +214,16 @@ export class Renderer {
     /** Set true at the end of `init()`; gates `whenReady()`. */
     private ready = false;
     private readyWaiters: Array<() => void> = [];
+
+    /**
+     * Set once the GPU device is lost for a non-intentional reason (driver
+     * reset / VRAM exhaustion — see `WebGPUDevice`). Every GPU resource is then
+     * dead, so `render()` becomes a no-op (it would only spew validation errors)
+     * until the host re-initialises the renderer. Consumers learn of this via
+     * `onDeviceLost` and typically respond by reloading the model.
+     */
+    private deviceLost = false;
+    private deviceLostListeners = new Set<(info: { message: string; reason: string }) => void>();
     private deviationPipeline: DeviationPipeline | null = null;
     /**
      * Cache of which mesh-set the BVH was built from. We rebuild on
@@ -287,6 +297,10 @@ export class Renderer {
      * Initialize renderer
      */
     async init(): Promise<void> {
+        // Subscribe before the device exists so a loss during the first frames
+        // is never missed — the handler is only invoked when `device.lost`
+        // actually resolves (a real fault), long after init in practice.
+        this.device.onDeviceLost((info) => this.handleDeviceLost(info));
         await this.device.init(this.canvas);
 
         // Get canvas dimensions (use pixel dimensions if set, otherwise use CSS dimensions)
@@ -400,6 +414,40 @@ export class Renderer {
         const waiters = this.readyWaiters;
         this.readyWaiters = [];
         for (const w of waiters) w();
+    }
+
+    /**
+     * Subscribe to non-intentional GPU device loss (driver reset / VRAM
+     * exhaustion — NOT an intentional `destroy()`). Fired at most once per
+     * device. After it fires, `render()` is a no-op until the renderer is
+     * re-initialised, so the typical response is to dispose this renderer and
+     * reload the model. Returns an unsubscribe function.
+     *
+     * Camera and model state live on the CPU (JS) and survive device loss, so a
+     * reload restores the model at its current orientation — the loss is a GPU
+     * event, not a data loss.
+     */
+    onDeviceLost(listener: (info: { message: string; reason: string }) => void): () => void {
+        this.deviceLostListeners.add(listener);
+        return () => this.deviceLostListeners.delete(listener);
+    }
+
+    /** True once the GPU device has been lost for a non-intentional reason. */
+    isDeviceLost(): boolean {
+        return this.deviceLost;
+    }
+
+    private handleDeviceLost(info: { message: string; reason: string }): void {
+        if (this.deviceLost) return;
+        this.deviceLost = true;
+        console.warn('[Renderer] GPU device lost — halting rendering until re-init:', info.message);
+        for (const listener of this.deviceLostListeners) {
+            try {
+                listener(info);
+            } catch (e) {
+                console.error('[Renderer] onDeviceLost listener threw:', e);
+            }
+        }
     }
 
     /**
@@ -1079,6 +1127,12 @@ export class Renderer {
 
     render(options: RenderOptions = {}): void {
         this._renderCallCount++;
+        // A lost device leaves every pipeline/buffer dead; rendering would only
+        // emit a stream of validation errors. Stay quiet until re-init.
+        if (this.deviceLost) {
+            this._renderSkipCount++;
+            return;
+        }
         if (!this.device.isInitialized() || !this.pipeline) {
             this._renderSkipCount++;
             return;

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -297,6 +297,9 @@ export class Renderer {
      * Initialize renderer
      */
     async init(): Promise<void> {
+        // Clear the lost flag so a re-init (destroy()+init() on the same instance)
+        // resumes rendering instead of staying a permanent no-op from an earlier loss.
+        this.deviceLost = false;
         // Subscribe before the device exists so a loss during the first frames
         // is never missed — the handler is only invoked when `device.lost`
         // actually resolves (a real fault), long after init in practice.


### PR DESCRIPTION
Closes #1746.

## Problem

On a weak/integrated GPU (repro: AMD Radeon 780M, ~420 MB dedicated video memory), rotating or re-opening a large model (~354 MB IFC, ~50M triangles) can trigger a WebGPU **device lost** — a Windows TDR watchdog reset (a single frame exceeds ~2 s) or VRAM exhaustion. Once the device is lost, every pipeline and buffer created from it is dead and the canvas can never present again.

Previously the renderer only did `console.warn(...)` and marked the context for reconfiguration, then kept reconfiguring the **same lost device** — so the viewport stayed **permanently blank** until a full reload. The same model renders fine on a discrete GPU.

## Change (renderer-only, additive API)

- `device.ts`: inspect `GPUDeviceLostInfo.reason`. Fire the recovery path only for a real loss; ignore intentional teardown (`reason === 'destroyed'`). Fires at most once per device.
- `index.ts`: add `Renderer.onDeviceLost(listener)` (returns an unsubscribe) and `Renderer.isDeviceLost()`. Hosts subscribe and respond by disposing the renderer and reloading the model. `render()` becomes a no-op after a loss instead of emitting a stream of validation errors.

Camera and model state are CPU-side (JS) and survive device loss, so a host-driven reload restores the model at its **current orientation** — the loss is a GPU event, not a data loss.

This is the resilience half of the fix (self-heal after a loss). Reducing the *likelihood* of the loss on weak GPUs (e.g. adaptive MSAA) is tracked separately in #1746 and intentionally not in this PR.

## Testing

- `pnpm --filter @ifc-lite/renderer test` — 259/259 pass.
- `tsc --noEmit` clean.
- The device-lost path itself needs a real GPU fault and is verified on-device by the host (ifc-viewer wiring in a follow-up PR).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `Renderer.onDeviceLost(...)` with unsubscribe support so applications can react to unexpected GPU device loss.
  * Added `Renderer.isDeviceLost()` to check current loss status.
* **Behavior Changes**
  * `render()` now becomes a no-op after non-intentional device loss to prevent ongoing GPU validation errors.
  * Recovery notifications are not triggered for intentional teardown scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->