### PR TITLE
perf(geometry): skip the content-dedup signature walk on large single BREPs (#1909)

### DIFF
--- a/.changeset/brep-dedup-large-single-instance.md
+++ b/.changeset/brep-dedup-large-single-instance.md
@@ -1,0 +1,13 @@
+---
+'@ifc-lite/wasm': patch
+---
+
+Skip the content-dedup signature walk on large single-instance faceted BREPs (#1909). A model consisting of one large `IfcFacetedBrep` took ~30 s to reach geometry where web-ifc does open + geometry in ~2.85 s. The cost was not exact arithmetic — a faceted BREP never enters the exact kernel — but a duplicate full traversal: `item_dedup_key` walked every face, bound, loop and point to build a dedup key, mirroring the mesher's own traversal, for a key that cannot pay off when there is exactly one instance.
+
+`item_dedup_key` now skips the signature walk for an `IfcFacetedBrep` above `FACETED_BREP_DEDUP_FACE_LIMIT` (20,000 faces), determined from the shell reference and face-list length without decoding any points.
+
+Dedup and GPU instancing are **not** disabled for large repeated geometry — only the pre-mesh, item-level cache is skipped. `get_or_cache_by_hash` (post-mesh, sampled, O(1) in mesh size) and `direct_rep_identity` still run, so two structurally identical large BREPs still mesh identically and still share a `rep_identity`. That is asserted by test rather than reasoned about, since trading a load-time win for a rendering regression would be a bad bargain. What is genuinely lost is the mesh-skip-on-cache-hit optimisation for a >20k-face item that really is duplicated.
+
+Measured with a deterministic counter rather than wall-clock: on a synthetic 980,000-face BREP, dedup on did 5,880,000 point-cache accesses against 2,940,000 with it off — exactly 2.00× — and 1.00× after the fix.
+
+An end-to-end suite verdict **cannot** be produced for this change and none is claimed: the largest BREP across all 163 fixtures is 8,848 faces, so nothing in the corpus crosses the gate, and a base-vs-branch A/B swings with run order. That finding, and the instruction not to repeat the experiment, are recorded in the perf lever ledger. The 20,000 threshold is a judgement call chosen an order of magnitude clear of realistic repeated parts (connection plates and bolts run to low hundreds of faces), not a measured optimum.

--- a/rust/geometry/src/lib.rs
+++ b/rust/geometry/src/lib.rs
@@ -190,7 +190,7 @@ pub use router::take_bool2d_stats;
 pub use router::{take_prism_defers, take_prism_stats};
 pub use router::{
     aggregate_diagnostics, local_frame_set_enabled_override, ClassificationStats,
-    GEOMETRY_DIAGNOSTICS_SCHEMA_VERSION,
+    GEOMETRY_DIAGNOSTICS_SCHEMA_VERSION, FACETED_BREP_DEDUP_FACE_LIMIT,
     ClassificationSummary, GeometryDiagnostics, GeometryProcessor, GeometryRouter,
     HostOpeningDiagnostic, ItemDedupCache, MappedInstancePlan, OpeningDiagnostic, OpeningKindDiag,
     ReasonCount, RectFastSummary, RectParam, SharedMappedItemCache, WorstHost,

--- a/rust/geometry/src/router/content_hash.rs
+++ b/rust/geometry/src/router/content_hash.rs
@@ -205,7 +205,16 @@ fn try_faceted_brep_signature(decoder: &mut EntityDecoder, brep_id: u32) -> Opti
 /// any plausible detail-part face count and well below the scale where a
 /// single giant mesh becomes measurably worse — a 2.5 M-triangle model
 /// reported ~30 s where web-ifc took ~2.85 s, traced to this hash.
-pub(super) const FACETED_BREP_DEDUP_FACE_LIMIT: usize = 20_000;
+///
+/// `pub` (re-exported through `router` and the crate root — see `lib.rs`,
+/// same pattern as `GEOMETRY_DIAGNOSTICS_SCHEMA_VERSION`) rather than
+/// `pub(super)`/`pub(crate)`, specifically so the #1909 regression test
+/// (`tests/issue_1909_large_single_brep_dedup.rs`, an external integration
+/// test crate that only sees this crate's public API) reads the real
+/// threshold instead of hard-coding `20_000` a second time (PR #1977
+/// review: that duplication is exactly the shape of the 341/88 checklist
+/// drift on #1963 — assertion and constant silently disagreeing).
+pub const FACETED_BREP_DEDUP_FACE_LIMIT: usize = 20_000;
 
 /// Cheap pre-check for [`FACETED_BREP_DEDUP_FACE_LIMIT`]: the face count of the
 /// `IfcFacetedBrep` at `brep_id`, read via the SAME fast ref-list path

--- a/rust/geometry/src/router/content_hash.rs
+++ b/rust/geometry/src/router/content_hash.rs
@@ -192,6 +192,35 @@ fn try_faceted_brep_signature(decoder: &mut EntityDecoder, brep_id: u32) -> Opti
     Some(acc)
 }
 
+/// Face-count threshold above which [`faceted_brep_face_count`] tells the
+/// caller to skip the structural signature walk entirely (#1909). The walk in
+/// [`try_faceted_brep_signature`] mirrors the mesher's own traversal
+/// face-by-face, bound-by-bound, point-by-point — for dedup to pay off there
+/// must be at least one OTHER item sharing this exact signature. Tekla-style
+/// duplication (thousands of connection plates/bolts, the case this cache
+/// exists for) tops out at low hundreds of faces per part; a SINGLE huge
+/// faceted import — a terrain, a scanned mesh, one big BREP with no sibling —
+/// has none, so hashing every point is pure loss that DOUBLES the traversal
+/// cost of an already-expensive mesh with no possible payback. Set well above
+/// any plausible detail-part face count and well below the scale where a
+/// single giant mesh becomes measurably worse — a 2.5 M-triangle model
+/// reported ~30 s where web-ifc took ~2.85 s, traced to this hash.
+pub(super) const FACETED_BREP_DEDUP_FACE_LIMIT: usize = 20_000;
+
+/// Cheap pre-check for [`FACETED_BREP_DEDUP_FACE_LIMIT`]: the face count of the
+/// `IfcFacetedBrep` at `brep_id`, read via the SAME fast ref-list path
+/// [`try_faceted_brep_signature`] uses for its first two hops (shell ref, face
+/// list) — no per-point decode, so this stays O(faces) even when the full
+/// signature would be O(faces × points). `None` on any structural surprise
+/// (missing shell ref, malformed list): the caller then falls through to
+/// computing the full signature as before, so a surprise never silently skips
+/// a legitimately dedupable item — only a confirmed large brep does.
+pub(super) fn faceted_brep_face_count(decoder: &mut EntityDecoder, brep_id: u32) -> Option<usize> {
+    let bytes = decoder.get_raw_bytes(brep_id)?;
+    let shell_id = parse_first_ref(bytes)?;
+    decoder.get_entity_ref_list_fast(shell_id).map(|v| v.len())
+}
+
 /// 128-bit structural hash of the representation item rooted at `root_id`. `memo`
 /// caches per-entity hashes so shared sub-entities (a profile reused by many
 /// solids, the representation context) are visited once; it keys on entity ids,

--- a/rust/geometry/src/router/mod.rs
+++ b/rust/geometry/src/router/mod.rs
@@ -28,6 +28,7 @@ pub use diagnostics::{
 };
 pub(crate) use diagnostics::ClassificationKind;
 pub(super) use rep_filter::{effective_rep_type, is_body_representation, is_direct_body_representation};
+pub use content_hash::FACETED_BREP_DEDUP_FACE_LIMIT;
 
 #[cfg(test)]
 mod tests;

--- a/rust/geometry/src/router/processing.rs
+++ b/rust/geometry/src/router/processing.rs
@@ -754,6 +754,30 @@ impl GeometryRouter {
         if !(base || extra) {
             return None;
         }
+        // Skip the hash walk entirely for a faceted BREP too large for dedup to
+        // ever pay off (#1909): `try_faceted_brep_signature` mirrors the
+        // mesher's own face/bound/loop/point traversal, so on a huge one-off
+        // BREP (a single ~2.5M-triangle import, no sibling item to match) the
+        // hash is a full second traversal with zero possible payback — it
+        // measured ~30s where the equivalent web-ifc load took ~2.85s, almost
+        // entirely this walk. The face-count probe is a cheap O(faces) prefix
+        // of the same walk (shell ref + face list, no per-point decode), so
+        // bailing here costs nothing extra. Below the threshold (Tekla-style
+        // small repeated parts, the case this cache exists for) behavior is
+        // unchanged. Skipping this pre-mesh cache does NOT disable dedup for a
+        // genuinely repeated large BREP: the post-mesh `get_or_cache_by_hash`
+        // (sampled, O(1) regardless of mesh size) and the instancing
+        // `rep_identity` (`direct_rep_identity`, computed unconditionally after
+        // meshing) both still run, so repeated large geometry still collapses
+        // to one GPU-instanced template — it just re-meshes each occurrence
+        // instead of skipping the mesh on a cache hit.
+        if item.ifc_type == IfcType::IfcFacetedBrep {
+            if let Some(face_count) = super::content_hash::faceted_brep_face_count(decoder, item.id) {
+                if face_count > super::content_hash::FACETED_BREP_DEDUP_FACE_LIMIT {
+                    return None;
+                }
+            }
+        }
         let structural = {
             let mut memo = self.content_sig_memo.borrow_mut();
             super::content_hash::item_signature(decoder, item.id, &mut memo)

--- a/rust/geometry/tests/issue_1909_large_single_brep_dedup.rs
+++ b/rust/geometry/tests/issue_1909_large_single_brep_dedup.rs
@@ -29,7 +29,7 @@
 //! rather than requiring the reporter's un-shippable `BigModel.ifc`.
 
 use ifc_lite_core::{build_entity_index, EntityDecoder};
-use ifc_lite_geometry::GeometryRouter;
+use ifc_lite_geometry::{GeometryRouter, FACETED_BREP_DEDUP_FACE_LIMIT};
 use std::fmt::Write as _;
 use std::time::Instant;
 
@@ -137,18 +137,21 @@ fn run_once(content: &str, brep_id: u32, dedup_on: bool) -> RunResult {
     }
 }
 
-/// Baseline + regression guard: a single large (above the #1909 face-count
-/// threshold) `IfcFacetedBrep` with content-dedup ON must NOT touch the point
-/// cache measurably more than the same item with dedup OFF. Pre-fix, dedup ON
-/// did a full extra pass (the signature walk) BEFORE meshing, roughly
-/// doubling point-cache traffic; this is the deterministic (non-timing) proof
-/// that the duplicate traversal is gone.
-///
-/// Also asserts byte-identical mesh output between dedup on/off (hard
-/// constraint: skipping the hash must never change vertices/indices) and
-/// prints wall-clock timing for both as a secondary, illustrative signal.
+/// Manual sanity check, NOT a performance verdict (PR #1977 review): one
+/// synthetic fixture on one machine, printed for a human to eyeball, is not
+/// evidence of a speedup. The 163-fixture corpus can't stand in for that
+/// evidence either -- its largest real `IfcFacetedBrep` is 8,848 faces
+/// (`tests/models/manifest.json`), well under `FACETED_BREP_DEDUP_FACE_LIMIT`
+/// (20,000), so nothing in it ever exercises this gate; an end-to-end
+/// suite-level wall-clock A/B on this change swung -10%/+9%/-7% across runs
+/// with the sign tracking run order -- pure noise, not signal, precisely
+/// because the gate can't fire on any fixture we have. `large_single_instance_
+/// brep_skips_duplicate_traversal` below, with its deterministic
+/// point-cache-access ratio, is the real regression guard; this test only
+/// asserts the hard correctness constraint (byte-identical mesh output on/off)
+/// and prints timing for a human running it manually, nothing more.
 #[test]
-#[ignore = "manual perf check: cargo test -p ifc-lite-geometry --release --test issue_1909_large_single_brep_dedup -- --ignored --nocapture large_scale"]
+#[ignore = "manual sanity check, not a perf verdict -- see doc comment. Run: cargo test -p ifc-lite-geometry --release --test issue_1909_large_single_brep_dedup -- --ignored --nocapture large_scale"]
 fn large_scale_wall_clock() {
     // ~700x700 grid -> 980,000 faces / 490,000 quads worth of triangles,
     // approaching the reported model's order of magnitude (~2.5M triangles),
@@ -174,11 +177,17 @@ fn large_scale_wall_clock() {
 #[test]
 fn large_single_instance_brep_skips_duplicate_traversal() {
     // 120 x 120 grid -> 28,800 faces, well above FACETED_BREP_DEDUP_FACE_LIMIT
-    // (20,000) so this item is squarely in the "cannot benefit from dedup"
-    // regime the fix targets, while still finishing in well under a second per
-    // run for a default (non-ignored, non-release) `cargo test`.
+    // so this item is squarely in the "cannot benefit from dedup" regime the
+    // fix targets, while still finishing in well under a second per run for
+    // a default (non-ignored, non-release) `cargo test`. Reads the real
+    // constant (PR #1977 review) rather than hard-coding 20_000 a second
+    // time, so the fixture and the gate it's meant to exceed can't drift
+    // apart silently.
     let (body, brep_id, face_count) = build_grid_faceted_brep(120, 120);
-    assert!(face_count > 20_000, "fixture must exceed the dedup threshold");
+    assert!(
+        face_count > FACETED_BREP_DEDUP_FACE_LIMIT,
+        "fixture must exceed the dedup threshold ({FACETED_BREP_DEDUP_FACE_LIMIT})"
+    );
     let content = wrap_step(&body);
 
     let off = run_once(&content, brep_id, false);
@@ -196,6 +205,16 @@ fn large_single_instance_brep_skips_duplicate_traversal() {
     assert_eq!(
         off.indices, on.indices,
         "content-dedup must not change mesh indices (hard constraint)"
+    );
+
+    // PR #1977 review: a ratio computed from a zero denominator (or two
+    // zero numerators) would pass vacuously -- exactly the false-pass shape
+    // this deterministic instrument exists to rule out. Pin that the dedup
+    // OFF baseline actually touched the point cache before trusting any
+    // ratio derived from it.
+    assert!(
+        off.accesses > 0,
+        "dedup-off baseline did zero point-cache accesses -- the ratio below would pass vacuously instead of proving anything"
     );
 
     // Pre-fix this ratio was ~2.0 (signature walk = all misses, then the mesh
@@ -226,7 +245,10 @@ fn large_single_instance_brep_skips_duplicate_traversal() {
 #[test]
 fn repeated_large_brep_still_shares_rep_identity() {
     let (body_a, brep_a, face_count) = build_grid_faceted_brep(120, 120);
-    assert!(face_count > 20_000, "fixture must exceed the dedup threshold");
+    assert!(
+        face_count > FACETED_BREP_DEDUP_FACE_LIMIT,
+        "fixture must exceed the dedup threshold ({FACETED_BREP_DEDUP_FACE_LIMIT})"
+    );
     // Second, textually independent copy of the SAME shape at different entity
     // ids (simulating an exporter that duplicated a representation item
     // instead of sharing it via IfcMappedItem).

--- a/rust/geometry/tests/issue_1909_large_single_brep_dedup.rs
+++ b/rust/geometry/tests/issue_1909_large_single_brep_dedup.rs
@@ -1,0 +1,303 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Regression for #1909: content-dedup's structural signature walk
+//! (`item_dedup_key` -> `content_hash::item_signature` ->
+//! `try_faceted_brep_signature`) mirrors the mesher's own face/bound/loop/point
+//! traversal of an `IfcFacetedBrep`. On a model consisting of ONE large faceted
+//! BREP (reported: ~2.5M triangles, no curved surfaces, no booleans) that hash
+//! has no possible payback -- there is no sibling item to match -- so computing
+//! it doubles the traversal cost of an already-expensive mesh. The reporter
+//! measured `GeometryProcessor.processStreaming` at ~30s where web-ifc's
+//! `StreamAllMeshes` (open + geometry) took ~2.85s on the same file.
+//!
+//! `EntityDecoder::point_cache_stats()` (hits, misses) is a pre-existing,
+//! always-on counter fed by `get_polyloop_coords_cached` -- the SAME cache both
+//! the signature walk and the faceted mesher read through. It gives a
+//! deterministic, non-timing proxy for "how many times was every point of this
+//! BREP visited": one full traversal (dedup off, or dedup on but skipped for
+//! size) touches every point once (all misses); two traversals (the pre-fix
+//! bug) touch every point twice -- once to build the signature (misses, since
+//! nothing is cached yet) and once to mesh (hits, since the signature walk
+//! already warmed the cache).
+//!
+//! Synthesizes a large single-instance faceted BREP procedurally (no fixture
+//! file: a `nx` x `ny` grid of shared `IfcCartesianPoint`s triangulated into
+//! `2*nx*ny` `IfcFace`s in one `IfcClosedShell`/`IfcFacetedBrep`, mirroring the
+//! shared-point structure of `tests/fixtures/shared_point_faceted_brep.ifc`)
+//! rather than requiring the reporter's un-shippable `BigModel.ifc`.
+
+use ifc_lite_core::{build_entity_index, EntityDecoder};
+use ifc_lite_geometry::GeometryRouter;
+use std::fmt::Write as _;
+use std::time::Instant;
+
+/// Build a STEP `DATA` body containing a single `IfcFacetedBrep` shaped as an
+/// `nx` x `ny` grid of unit quads, each split into 2 triangles (`IfcFace` with
+/// one `IfcFaceOuterBound`/`IfcPolyLoop` of 3 points), all faces sharing the
+/// `(nx+1)*(ny+1)` `IfcCartesianPoint` grid (so point re-visits inside ONE
+/// traversal are real, matching a real mesh, not an artifact of the test).
+/// Returns `(entities_text, brep_entity_id, face_count)`.
+fn build_grid_faceted_brep(nx: usize, ny: usize) -> (String, u32, usize) {
+    let mut out = String::with_capacity((nx + 1) * (ny + 1) * 40 + nx * ny * 200);
+    let mut next_id: u32 = 1;
+
+    // Point grid: point_id(i, j) = base + j * (nx + 1) + i.
+    let point_base = next_id;
+    for j in 0..=ny {
+        for i in 0..=nx {
+            let x = i as f64;
+            let y = j as f64;
+            // A little vertical relief so this isn't a degenerate flat plane.
+            let z = ((i + j) % 5) as f64 * 0.1;
+            let _ = writeln!(out, "#{next_id}=IFCCARTESIANPOINT(({x:.4},{y:.4},{z:.4}));");
+            next_id += 1;
+        }
+    }
+    let point_id = |i: usize, j: usize| -> u32 { point_base + (j * (nx + 1) + i) as u32 };
+
+    let mut face_ids: Vec<u32> = Vec::with_capacity(2 * nx * ny);
+    for j in 0..ny {
+        for i in 0..nx {
+            let p00 = point_id(i, j);
+            let p10 = point_id(i + 1, j);
+            let p11 = point_id(i + 1, j + 1);
+            let p01 = point_id(i, j + 1);
+            for tri in [[p00, p10, p11], [p00, p11, p01]] {
+                let loop_id = next_id;
+                let _ = writeln!(
+                    out,
+                    "#{loop_id}=IFCPOLYLOOP((#{},#{},#{}));",
+                    tri[0], tri[1], tri[2]
+                );
+                next_id += 1;
+                let bound_id = next_id;
+                let _ = writeln!(out, "#{bound_id}=IFCFACEOUTERBOUND(#{loop_id},.T.);");
+                next_id += 1;
+                let face_id = next_id;
+                let _ = writeln!(out, "#{face_id}=IFCFACE((#{bound_id}));");
+                next_id += 1;
+                face_ids.push(face_id);
+            }
+        }
+    }
+
+    let shell_id = next_id;
+    next_id += 1;
+    let refs: Vec<String> = face_ids.iter().map(|id| format!("#{id}")).collect();
+    let _ = writeln!(out, "#{shell_id}=IFCCLOSEDSHELL(({}));", refs.join(","));
+
+    let brep_id = next_id;
+    let _ = writeln!(out, "#{brep_id}=IFCFACETEDBREP(#{shell_id});");
+
+    (out, brep_id, face_ids.len())
+}
+
+/// Wrap a `DATA` body in the minimal ISO-10303-21 envelope the scanner/decoder
+/// need. No `IfcProject`/units on purpose (`GeometryRouter::with_units` falls
+/// back to scale 1.0 when none is found) -- this test is about the item-level
+/// dedup hash, not unit handling.
+fn wrap_step(body: &str) -> String {
+    format!(
+        "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\nFILE_NAME('','',(''),(''),'','','' );\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n{body}ENDSEC;\nEND-ISO-10303-21;\n"
+    )
+}
+
+/// Total point-cache traffic (hits + misses) `process_representation_item`
+/// generates for one `IfcFacetedBrep`, plus wall time, plus the resulting mesh
+/// (for byte-identical comparison) and rep_identity (for instancing).
+struct RunResult {
+    accesses: u64,
+    elapsed: std::time::Duration,
+    positions: Vec<f32>,
+    indices: Vec<u32>,
+}
+
+fn run_once(content: &str, brep_id: u32, dedup_on: bool) -> RunResult {
+    let mut decoder = EntityDecoder::with_index(content, build_entity_index(content));
+    let mut router = GeometryRouter::with_units(content, &mut decoder);
+    if !dedup_on {
+        router.disable_content_dedup();
+    }
+    let item = decoder.decode_by_id(brep_id).expect("decode brep item");
+
+    let t0 = Instant::now();
+    let mesh = router
+        .process_representation_item(&item, &mut decoder)
+        .expect("mesh the synthetic brep");
+    let elapsed = t0.elapsed();
+
+    let (hits, misses) = decoder.point_cache_stats();
+    RunResult {
+        accesses: hits + misses,
+        elapsed,
+        positions: mesh.positions.clone(),
+        indices: mesh.indices.clone(),
+    }
+}
+
+/// Baseline + regression guard: a single large (above the #1909 face-count
+/// threshold) `IfcFacetedBrep` with content-dedup ON must NOT touch the point
+/// cache measurably more than the same item with dedup OFF. Pre-fix, dedup ON
+/// did a full extra pass (the signature walk) BEFORE meshing, roughly
+/// doubling point-cache traffic; this is the deterministic (non-timing) proof
+/// that the duplicate traversal is gone.
+///
+/// Also asserts byte-identical mesh output between dedup on/off (hard
+/// constraint: skipping the hash must never change vertices/indices) and
+/// prints wall-clock timing for both as a secondary, illustrative signal.
+#[test]
+#[ignore = "manual perf check: cargo test -p ifc-lite-geometry --release --test issue_1909_large_single_brep_dedup -- --ignored --nocapture large_scale"]
+fn large_scale_wall_clock() {
+    // ~700x700 grid -> 980,000 faces / 490,000 quads worth of triangles,
+    // approaching the reported model's order of magnitude (~2.5M triangles),
+    // while still fitting in a few seconds of test time.
+    let (body, brep_id, face_count) = build_grid_faceted_brep(700, 700);
+    let content = wrap_step(&body);
+    println!("issue_1909 large_scale: faces={face_count}");
+
+    let off = run_once(&content, brep_id, false);
+    let on = run_once(&content, brep_id, true);
+    println!(
+        "dedup_off: {} point-cache accesses, {:?} wall",
+        off.accesses, off.elapsed
+    );
+    println!(
+        "dedup_on:  {} point-cache accesses, {:?} wall",
+        on.accesses, on.elapsed
+    );
+    assert_eq!(off.positions, on.positions);
+    assert_eq!(off.indices, on.indices);
+}
+
+#[test]
+fn large_single_instance_brep_skips_duplicate_traversal() {
+    // 120 x 120 grid -> 28,800 faces, well above FACETED_BREP_DEDUP_FACE_LIMIT
+    // (20,000) so this item is squarely in the "cannot benefit from dedup"
+    // regime the fix targets, while still finishing in well under a second per
+    // run for a default (non-ignored, non-release) `cargo test`.
+    let (body, brep_id, face_count) = build_grid_faceted_brep(120, 120);
+    assert!(face_count > 20_000, "fixture must exceed the dedup threshold");
+    let content = wrap_step(&body);
+
+    let off = run_once(&content, brep_id, false);
+    let on = run_once(&content, brep_id, true);
+
+    println!(
+        "issue_1909: faces={face_count} dedup_off: {} point-cache accesses in {:?} | dedup_on: {} point-cache accesses in {:?}",
+        off.accesses, off.elapsed, on.accesses, on.elapsed
+    );
+
+    assert_eq!(
+        off.positions, on.positions,
+        "content-dedup must not change mesh positions (hard constraint)"
+    );
+    assert_eq!(
+        off.indices, on.indices,
+        "content-dedup must not change mesh indices (hard constraint)"
+    );
+
+    // Pre-fix this ratio was ~2.0 (signature walk = all misses, then the mesh
+    // pass on the same item = all hits, so total accesses roughly doubled).
+    // Post-fix both runs do exactly one traversal, so the ratio should be ~1.0;
+    // allow slack for the shell/face list reads that aren't point-cache
+    // traffic and aren't identical in count between the two code paths.
+    let ratio = on.accesses as f64 / off.accesses as f64;
+    assert!(
+        ratio < 1.2,
+        "content-dedup ON did {} point-cache accesses vs {} with dedup OFF (ratio {:.2}) -- \
+         the structural signature walk is re-traversing a large single-instance BREP \
+         that can never benefit from dedup (#1909)",
+        on.accesses,
+        off.accesses,
+        ratio
+    );
+}
+
+/// Genuinely repeated large geometry must still collapse to one instanced
+/// template even though the item-level pre-mesh cache is skipped above the
+/// face-count threshold: two textually distinct `IfcFacetedBrep` entities with
+/// IDENTICAL structure (same grid, different entity ids) must mesh to
+/// byte-identical geometry AND get the SAME `rep_identity`, because
+/// `direct_rep_identity` (fed by the post-mesh, sampled `compute_mesh_hash_full`)
+/// runs unconditionally after meshing regardless of whether the pre-mesh
+/// structural-hash cache fired.
+#[test]
+fn repeated_large_brep_still_shares_rep_identity() {
+    let (body_a, brep_a, face_count) = build_grid_faceted_brep(120, 120);
+    assert!(face_count > 20_000, "fixture must exceed the dedup threshold");
+    // Second, textually independent copy of the SAME shape at different entity
+    // ids (simulating an exporter that duplicated a representation item
+    // instead of sharing it via IfcMappedItem).
+    let (body_b, brep_b_local, _) = build_grid_faceted_brep(120, 120);
+    // Renumber body_b's ids to start after body_a's so both coexist in one file.
+    let offset: u32 = 10_000_000;
+    let body_b_shifted = renumber_step_ids(&body_b, offset);
+    let brep_b = brep_b_local + offset;
+
+    let content = wrap_step(&format!("{body_a}{body_b_shifted}"));
+
+    let mut decoder = EntityDecoder::with_index(&content, build_entity_index(&content));
+    let router = GeometryRouter::with_units(&content, &mut decoder);
+
+    let item_a = decoder.decode_by_id(brep_a).expect("decode brep A");
+    let mesh_a = router
+        .process_representation_item(&item_a, &mut decoder)
+        .expect("mesh brep A");
+    let item_b = decoder.decode_by_id(brep_b).expect("decode brep B");
+    let mesh_b = router
+        .process_representation_item(&item_b, &mut decoder)
+        .expect("mesh brep B");
+
+    assert_eq!(
+        mesh_a.positions, mesh_b.positions,
+        "two structurally identical large BREPs must mesh to identical positions"
+    );
+    assert_eq!(
+        mesh_a.indices, mesh_b.indices,
+        "two structurally identical large BREPs must mesh to identical indices"
+    );
+
+    let rep_a = mesh_a
+        .instance_meta
+        .as_ref()
+        .map(|m| m.rep_identity)
+        .expect("mesh A should be instance-tagged (instancing default on)");
+    let rep_b = mesh_b
+        .instance_meta
+        .as_ref()
+        .map(|m| m.rep_identity)
+        .expect("mesh B should be instance-tagged (instancing default on)");
+    assert_eq!(
+        rep_a, rep_b,
+        "repeated large geometry must still share one rep_identity for GPU instancing \
+         even though the item-level content-dedup cache is skipped above the size threshold"
+    );
+}
+
+/// Shift every `#<id>` reference and every `#<id>=` definition in a STEP body
+/// by `offset`, so two independently generated bodies can be concatenated into
+/// one file without id collisions.
+fn renumber_step_ids(body: &str, offset: u32) -> String {
+    let bytes = body.as_bytes();
+    let mut out = String::with_capacity(body.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'#' && i + 1 < bytes.len() && bytes[i + 1].is_ascii_digit() {
+            out.push('#');
+            let mut j = i + 1;
+            let mut id: u32 = 0;
+            while j < bytes.len() && bytes[j].is_ascii_digit() {
+                id = id * 10 + (bytes[j] - b'0') as u32;
+                j += 1;
+            }
+            let _ = write!(out, "{}", id + offset);
+            i = j;
+        } else {
+            out.push(bytes[i] as char);
+            i += 1;
+        }
+    }
+    out
+}

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -242,6 +242,24 @@ SHIPPED (landed with a PR), or RE-REFUTED / NOT SHIPPABLE. Do not read the secti
   engine every week and turns red when this changes. See
   `docs/architecture/wasm-wide-arithmetic.md` (delivery status verified 2026-07-31).
 
+- **Content-dedup signature walk on large single BREPs** (~2.00x traversal, SHIPPED #1909):
+  `item_dedup_key` walked every face/bound/loop/point of an `IfcFacetedBrep` to build a
+  dedup key — a second full traversal mirroring the mesher's own. On a model that is one
+  large BREP with no repeats, that key can never pay off. Gated on
+  `FACETED_BREP_DEDUP_FACE_LIMIT` (20,000 faces), measured with a **deterministic counter**
+  (`EntityDecoder::point_cache_stats()`), not wall-clock: 5,880,000 accesses with dedup on
+  vs 2,940,000 with it off on a synthetic 980k-face BREP — exactly 2.00x — and 1.00x after.
+  Post-mesh `get_or_cache_by_hash` and `direct_rep_identity` still run, so genuinely repeated
+  large geometry still dedups and still instances (asserted by test).
+  **Lesson, and the reason this entry exists:** an end-to-end suite verdict **cannot be
+  produced for this lever on the current corpus.** The largest BREP across all 163 fixtures
+  is 8,848 faces, so nothing in the suite crosses a 20,000-face gate; a base-vs-branch A/B
+  swung -10%/+9%/-7% with the sign tracking run order, i.e. pure noise. Do not spend another
+  afternoon on `probe.sh --suite` for a threshold this corpus cannot reach — either add a
+  fixture above the gate, or measure with a deterministic counter as above. The 20,000 figure
+  is a judgement call (an order of magnitude clear of realistic repeated parts, which run to
+  low hundreds of faces), not a measured optimum.
+
 ### Standing constraints
 - Geometry is **client-side only** (no server meshing).
 - One mesh home: `produce_element_meshes` - a fix in one pipeline diverges the other.


### PR DESCRIPTION
## What and why

Closes #1909.

One large faceted BREP took ~30 s where web-ifc does open + geometry in ~2.85 s. Your diagnosis holds: it is a duplicate full traversal for a dedup key that can never pay off.

`item_dedup_key` (`router/processing.rs`) unconditionally calls `content_hash::item_signature`, whose `try_faceted_brep_signature` walks **every face, bound, loop and point** of an `IfcFacetedBrep` to build a dedup key — a mirror of the mesher's own traversal in `faceted.rs`. With exactly one instance of a huge BREP, that is a second full walk with no possible benefit.

## Measured, not asserted

Wall-clock alone would be too noisy to defend, so this is pinned with a **deterministic counter**: `point_cache_stats()` counts accesses through the cache that both the signature walk and the mesher read.

On a synthetic 980,000-face BREP (~1.96 M triangles, built procedurally — no fixture needed):

| | point-cache accesses | wall time |
|---|---|---|
| dedup ON (before) | **5,880,000** | 861 ms |
| dedup OFF | 2,940,000 | 509 ms |
| **after fix** | **2,940,000** (ratio 1.00) | ~690 ms |

Exactly 2.00×, which is what "duplicate traversal" predicts.

## The rule, and why it is safe

Skip the signature walk for an `IfcFacetedBrep` whose face count exceeds `FACETED_BREP_DEDUP_FACE_LIMIT` (20,000), determined from the shell reference and face-list length **without decoding any points**.

- 20,000 sits far above realistic repeated parts. The connection plates and bolts that the existing 5.8× dedup win on the 170_KM model depends on run to low hundreds of faces, so they stay well under the threshold and keep deduping.
- It sits far below the reported ~1 M-face single BREP.

**Dedup and GPU instancing are not disabled for large repeated geometry** — only the *pre-mesh, item-level* cache is skipped. `get_or_cache_by_hash` (post-mesh, sampled, O(1) in mesh size) and `direct_rep_identity` both still run.

That mattered enough to test rather than reason about: `repeated_large_brep_still_shares_rep_identity` builds two textually independent, structurally identical 28,800-face BREPs and asserts they mesh to byte-identical positions/indices **and share a `rep_identity`**, so instancing still collapses them to one template. Trading a load-time win for a rendering regression would have been a bad bargain.

What is genuinely lost for this rare case: the mesh-skip-on-cache-hit optimisation for a >20k-face item that really is duplicated. Correctness and instancing are unaffected.

## Verification

- 3 new tests in `rust/geometry/tests/issue_1909_large_single_brep_dedup.rs`, including an `#[ignore]`d wall-clock check for real timing runs
- **Mutation-tested**: reverting `item_dedup_key` reproduces the exact symptom — `content-dedup ON did 172800 point-cache accesses vs 86400 with dedup OFF (ratio 2.00)`
- `geom_hash` **9/9**, no hash values touched — only `content_hash.rs` and `processing.rs` changed
- `cargo test --workspace --no-fail-fast`: 37 pre-existing failures, every one classified as a missing private fixture (`No such file or directory` on `tests/models/ara3d/*.ifc`, or `run pnpm fixtures`) — none outside that shape
- `pnpm typecheck` 33/33. No wasm-facing API changed, so no rebuild needed.

## Not verified

`BigModel.ifc` is not in the repo (external harness), so **the ~30 s → X s number itself is unconfirmed**. The synthetic reproduction matches the described symptom exactly and the traversal doubling is now provably gone, but running the reporter's actual model is the check I would most value before this is considered closed.

**On benchmarking this, from the maintainer:** an end-to-end suite verdict **cannot be produced for this change**. The largest BREP in the entire 163-fixture corpus is 8,848 faces, against a 20,000-face gate — so nothing in the corpus crosses the threshold, and his A/B swung −10% / +9% / −7% with the sign tracking run order, i.e. pure noise. The deterministic point-cache ratio above is the correct instrument here; please don't ask for a wall-clock figure, because any number produced would be meaningless.

Also worth a second opinion: **20,000 is a judgement call**, not a measured optimum. I picked it to sit an order of magnitude clear of both realistic repeated parts and the reported case. If you have a model that straddles it, that would be better evidence than my reasoning.

## Checklist

- [x] A test asserts the new behaviour, verified to fail when it is broken
- [x] No geometry output changed (byte-identical assertion in the test)
- [x] No geometry hash or determinism manifest regenerated
- [x] No client or project identifiers in code, tests, commit messages, or this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved processing of very large faceted BREP geometry by avoiding expensive duplicate-geometry analysis.
  * Preserved deduplication for smaller and repeated identical BREP models.
  * Malformed or unresolved geometry continues through existing handling without disrupting processing.

* **Bug Fixes**
  * Added regression coverage for large single-instance and repeated BREP scenarios, including mesh output consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
