### PR TITLE
feat(source-dalux): Dalux Build provider on the v2 plugin contract (2/3)

### DIFF
--- a/.changeset/source-dalux-initial.md
+++ b/.changeset/source-dalux-initial.md
@@ -1,0 +1,11 @@
+---
+"@ifc-lite/source-dalux": minor
+---
+
+First release of `@ifc-lite/source-dalux`, a Dalux Build (Box) file-source provider on the v2 plugin contract (`manifest.api: '^2.0.0'`, declared `capabilities`/`auth`/`permissions.relay`, `Page<T>`-returning listing methods, `SourceFileRef`-based `download`, `watchRevisions`). Closes #1663.
+
+Dalux Build's API sends no CORS headers, so browser requests go through the same-origin relay at `/api/dalux` (`vercel.json` rewrite in production, vite proxy in dev), declared in the manifest and validated by the host against its configured routes. The relay refuses upstream redirects that leave the declared host, so a redirect cannot carry the API key off-origin, and it does not forward the key to any other host.
+
+Talks to the Dalux HTTP API directly rather than through the third-party `dalux-build-api` client.
+
+`minor`, not `major`, despite superseding an earlier unreleased shape: the package has never been published, so there are no consumers to break, and this repo bumps breaking changes on `0.x` packages as `minor`.

--- a/api/dalux.ts
+++ b/api/dalux.ts
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import {
+  createDaluxRelayHandler,
+  loadDaluxRelayConfig,
+} from '../server/sources/dalux-relay.js';
+
+export const runtime = 'edge';
+export const config = { runtime: 'edge' };
+
+const handler = createDaluxRelayHandler(loadDaluxRelayConfig(process.env), {
+  fetchImpl: fetch,
+});
+
+export default handler;

--- a/apps/viewer/package.json
+++ b/apps/viewer/package.json
@@ -50,6 +50,7 @@
     "@ifc-lite/parser": "workspace:^",
     "@ifc-lite/pointcloud": "workspace:^",
     "@ifc-lite/query": "workspace:^",
+    "@ifc-lite/source-dalux": "workspace:^",
     "@ifc-lite/renderer": "workspace:^",
     "@ifc-lite/sandbox": "workspace:^",
     "@ifc-lite/sdk": "workspace:^",

--- a/apps/viewer/src/services/sources/registered-providers.ts
+++ b/apps/viewer/src/services/sources/registered-providers.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import type { FileSourceProvider } from '@ifc-lite/plugin-api';
+import { DaluxBuildProvider } from '@ifc-lite/source-dalux';
 
 /**
  * Every file-source provider the viewer actually registers, in one place.
@@ -12,13 +13,8 @@ import type { FileSourceProvider } from '@ifc-lite/plugin-api';
  * drifting apart) read from this list — so the test can never drift from
  * what the running app actually does.
  *
- * Deliberately EMPTY in this change: it lands the contract, the host and the
- * UI, and the first providers follow in their own reviewable PRs
- * (`@ifc-lite/source-dalux`, then `@ifc-lite/source-msgraph`). The Sources
- * panel renders its empty state until one is added, and the conformance kit
- * in `@ifc-lite/source-fixture` exercises the host against a fixture provider
- * meanwhile, so the host is covered without shipping a real integration.
+ * `@ifc-lite/source-msgraph` (SharePoint/OneDrive) follows in its own PR.
  */
 export function createRegisteredProviders(): FileSourceProvider[] {
-  return [];
+  return [new DaluxBuildProvider()];
 }

--- a/apps/viewer/src/services/sources/source-host.test.ts
+++ b/apps/viewer/src/services/sources/source-host.test.ts
@@ -132,23 +132,11 @@ describe('every provider the viewer actually registers satisfies PLUGIN_API_VERS
   it('registers cleanly against the real host', () => {
     const providers = createRegisteredProviders();
 
-    // `createRegisteredProviders()` is deliberately EMPTY in the change that
-    // lands the contract, the host and the UI — the first provider ships in its
-    // own PR (`@ifc-lite/source-dalux`), so this suite has nothing real to
-    // register yet.
-    //
-    // Asserting emptiness, rather than skipping or loosening to `>= 0`, is the
-    // point: the loop below is vacuous while the list is empty, so without this
-    // line the whole guard would pass silently forever. This assertion FAILS the
-    // moment a provider is added, which forces that PR back here to restore
-    // `assert.ok(providers.length > 0)` — the real anti-vacuity guard — instead
-    // of inheriting a test that cannot fail.
-    assert.equal(
-      providers.length,
-      0,
-      'a provider is now registered: replace this assertion with ' +
-      '`assert.ok(providers.length > 0, ...)` so the per-provider checks below stop being vacuous',
-    );
+    // Restored from the deliberate `=== 0` assertion the contract-only PR
+    // carried: with no providers registered the per-provider loop below is
+    // vacuous, so that PR inverted this to fail the moment one was added —
+    // which is what brought it back here. This is the real anti-vacuity guard.
+    assert.ok(providers.length > 0, 'expected at least one real provider to be registered');
 
     const host = new SourceHost();
     for (const provider of providers) {

--- a/apps/viewer/tsconfig.json
+++ b/apps/viewer/tsconfig.json
@@ -30,7 +30,8 @@
       "@ifc-lite/lists": ["../../packages/lists/src"],
       "@ifc-lite/sandbox": ["../../packages/sandbox/src"],
       "@ifc-lite/sandbox/schema": ["../../packages/sandbox/src/bridge-schema"],
-      "@ifc-lite/plugin-api": ["../../packages/plugin-api/src"]
+      "@ifc-lite/plugin-api": ["../../packages/plugin-api/src"],
+      "@ifc-lite/source-dalux": ["../../packages/source-dalux/src"]
     }
   },
   "include": ["src/**/*", "../../packages/renderer/src/webgpu-types.d.ts"],

--- a/apps/viewer/vite.config.ts
+++ b/apps/viewer/vite.config.ts
@@ -297,6 +297,14 @@ export default defineConfig({
         target: 'http://localhost:3001',
         changeOrigin: true,
       },
+      '/api/dalux': {
+        // Dalux Build's API sends no CORS headers, so browser requests must
+        // go through this same-origin relay (mirrors /api/bsdd below, and
+        // vercel.json's rewrite in production).
+        target: 'https://node1.field.dalux.com',
+        changeOrigin: true,
+        rewrite: (p) => p.replace(/^\/api\/dalux/, '/service/api'),
+      },
       '/api/bsdd': {
         target: 'https://api.bsdd.buildingsmart.org',
         changeOrigin: true,

--- a/packages/source-dalux/README.md
+++ b/packages/source-dalux/README.md
@@ -1,0 +1,35 @@
+# @ifc-lite/source-dalux
+
+Dalux Build (Box) file-source provider for ifc-lite.
+
+Implements `FileSourceProvider` from `@ifc-lite/plugin-api` to browse projects,
+file areas, folders, and files in Dalux Build, and download IFC revisions
+directly into the viewer.
+
+Has no runtime dependencies beyond `@ifc-lite/plugin-api`. Requests go through
+the host-provided `fetch`, and responses are narrowed by hand-written decoders
+in `src/dalux-types.ts` that reject wrong-typed fields rather than coercing
+them, dropping an individually invalid row from a listing instead of failing
+the whole page.
+
+Targets the Dalux **API Identities** auth model (legacy API keys expired
+2026-02-28). The API base URL is fixed at `https://node1.field.dalux.com/service/api`
+— it's not company-specific, so there's no base URL setting.
+
+## CORS
+
+The Dalux API does not send CORS headers, so direct browser fetches to it
+will fail. The viewer routes Dalux requests through a fixed same-origin path
+(`/api/dalux/*`) that the app's own server forwards upstream — a plain
+reverse-proxy rewrite (see `vercel.json` in production, and the Vite dev
+proxy in `apps/viewer/vite.config.ts`), the same pattern already used for
+bSDD/EPSG. The user's own API key is attached client-side and never leaves
+the browser except as part of the proxied request; there is no shared
+server-side secret and no separate relay service to deploy.
+
+## API key storage
+
+The API key is stored in the browser's `localStorage`, unencrypted, with no
+expiry. Anything that can execute script in the page (e.g. the viewer's own
+script panel) can read it. Users who want to revoke access should rotate the
+key in Dalux and use the "forget key" action in Source Settings.

--- a/packages/source-dalux/package.json
+++ b/packages/source-dalux/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@ifc-lite/source-dalux",
+  "version": "0.1.0",
+  "description": "Dalux Build (Box) file-source provider for ifc-lite",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "pnpm exec tsc",
+    "dev": "pnpm exec tsc --watch",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@ifc-lite/plugin-api": "workspace:^"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.9"
+  },
+  "license": "MPL-2.0",
+  "author": "Louis True",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LTplus-AG/ifc-lite.git",
+    "directory": "packages/source-dalux"
+  },
+  "homepage": "https://ifclite.dev/docs/",
+  "bugs": "https://github.com/LTplus-AG/ifc-lite/issues",
+  "keywords": [
+    "ifc",
+    "bim",
+    "dalux",
+    "cde",
+    "file-source"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ]
+}

--- a/packages/source-dalux/src/dalux-types.ts
+++ b/packages/source-dalux/src/dalux-types.ts
@@ -1,0 +1,237 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Response shapes for the Dalux Build API, and hand-written decoders for them.
+ *
+ * This package previously borrowed types and zod schemas from a third-party
+ * `dalux-build-api` client by deep-importing its `src/` internals. That is
+ * gone: deep-importing another package's internals breaks on any upstream
+ * reorganisation, it made a published `@ifc-lite/*` package depend on a
+ * single-maintainer package, and it dragged zod into the viewer's eagerly
+ * loaded bundle for what amounts to a few dozen field checks. The sibling
+ * SharePoint/OneDrive provider talks to Microsoft Graph with nothing but
+ * `fetch` and hand-written narrowing; there is no reason this one needs more.
+ *
+ * The decoders below reproduce the previous schemas' semantics as closely as
+ * possible, so this is mostly a dependency change and not a behaviour
+ * change:
+ *
+ *   - Unknown keys are ignored (zod objects are non-strict by default).
+ *   - `nullish()` fields accept a missing key *or* an explicit `null`, and
+ *     both normalise to `undefined`.
+ *   - A present field of the wrong type is a decode failure rather than
+ *     something to coerce, because silently reinterpreting `fileSize: "big"`
+ *     as a number would be worse than dropping the row. The one deliberate
+ *     exception is a non-*finite* number (`NaN`/`Infinity`, e.g. from a
+ *     `fileSize: 1e999` payload): zod's `z.number()` accepted those, so
+ *     rejecting them outright would be a real behaviour change hiding in
+ *     this refactor. See {@link optionalNumber}.
+ *   - `deleted` mirrors the old `nullableDefault(z.boolean(), false)`:
+ *     absent or null becomes `false`, but a non-boolean is rejected.
+ *
+ * Decoders throw {@link DaluxDecodeError} naming the offending field. List
+ * call sites drop the individual row and warn (see `convertListLenient`);
+ * single-item lookups let it propagate, which is the right asymmetry for a
+ * read-only catalog: one bad row among thousands should not cost the user the
+ * other rows, but a malformed response to a specific file lookup should fail
+ * loudly rather than silently behave as "no download link".
+ */
+
+export class DaluxDecodeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'DaluxDecodeError';
+  }
+}
+
+export interface DaluxProject {
+  readonly projectId: string;
+  readonly projectName: string;
+}
+
+export interface DaluxFileArea {
+  readonly fileAreaId: string;
+  readonly fileAreaName: string;
+  readonly fileAreaType: string;
+}
+
+export interface DaluxFolder {
+  readonly folderId: string;
+  readonly folderName: string;
+  readonly parentFolderId?: string;
+}
+
+export interface DaluxFile {
+  readonly fileId: string;
+  readonly fileRevisionId?: string;
+  readonly fileName: string;
+  readonly fileAreaId: string;
+  readonly folderId?: string;
+  readonly uploadedByUserId?: string;
+  readonly uploaded?: string;
+  readonly lastModifiedByUserId?: string;
+  readonly lastModified?: string;
+  readonly version?: string;
+  readonly deleted: boolean;
+  readonly fileType?: string;
+  readonly fileSize?: number;
+  readonly contentHash?: string;
+  readonly downloadLink?: string;
+}
+
+export interface DaluxFileResponse {
+  readonly data: DaluxFile;
+}
+
+/** A decoder turns an unknown payload into `T` or throws {@link DaluxDecodeError}. */
+export type DaluxDecoder<T> = (value: unknown) => T;
+
+// ---------------------------------------------------------------------------
+// Field readers
+// ---------------------------------------------------------------------------
+
+function asRecord(value: unknown, what: string): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return fail(`${what}: expected an object, got ${describe(value)}`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function fail(message: string): never {
+  throw new DaluxDecodeError(message);
+}
+
+function describe(value: unknown): string {
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return 'an array';
+  return typeof value;
+}
+
+/** Required string. Empty strings are allowed — Dalux does return them, and an
+ *  id or name we cannot use is caught downstream, not here. */
+function requiredString(source: Record<string, unknown>, key: string, what: string): string {
+  const value = source[key];
+  if (typeof value !== 'string') {
+    return fail(`${what}.${key}: expected a string, got ${describe(value)}`);
+  }
+  return value;
+}
+
+/** `z.string().nullish()` — absent or null becomes `undefined`. */
+function optionalString(
+  source: Record<string, unknown>,
+  key: string,
+  what: string,
+): string | undefined {
+  const value = source[key];
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== 'string') {
+    return fail(`${what}.${key}: expected a string or null, got ${describe(value)}`);
+  }
+  return value;
+}
+
+/**
+ * `z.number().nullish()`. Deliberate, documented deviation from "reproduce
+ * the old zod semantics exactly": zod's `z.number()` *accepts* NaN and
+ * Infinity, so a response like `fileSize: 1e999` (JSON-parses to `Infinity`)
+ * decoded fine before this decoder replaced it. Rejecting non-finite values
+ * outright — as an earlier version of this decoder did — silently changed
+ * that: it turned `convertListLenient` into dropping the *entire file* from
+ * the listing over one bad numeric field, which is a worse outcome for a
+ * read-only catalog than just losing that field. So a non-finite number
+ * coerces to `undefined` (the row survives, `fileSize` just isn't reported)
+ * instead of failing the decode.
+ */
+function optionalNumber(
+  source: Record<string, unknown>,
+  key: string,
+  what: string,
+): number | undefined {
+  const value = source[key];
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== 'number') {
+    return fail(`${what}.${key}: expected a number or null, got ${describe(value)}`);
+  }
+  return Number.isFinite(value) ? value : undefined;
+}
+
+/** `nullableDefault(z.boolean(), false)` — absent or null becomes the default. */
+function booleanWithDefault(
+  source: Record<string, unknown>,
+  key: string,
+  fallback: boolean,
+  what: string,
+): boolean {
+  const value = source[key];
+  if (value === undefined || value === null) return fallback;
+  if (typeof value !== 'boolean') {
+    return fail(`${what}.${key}: expected a boolean or null, got ${describe(value)}`);
+  }
+  return value;
+}
+
+// ---------------------------------------------------------------------------
+// Decoders
+// ---------------------------------------------------------------------------
+
+export const decodeProject: DaluxDecoder<DaluxProject> = (value) => {
+  const source = asRecord(value, 'Project');
+  return {
+    projectId: requiredString(source, 'projectId', 'Project'),
+    projectName: requiredString(source, 'projectName', 'Project'),
+  };
+};
+
+export const decodeFileArea: DaluxDecoder<DaluxFileArea> = (value) => {
+  const source = asRecord(value, 'FileArea');
+  return {
+    fileAreaId: requiredString(source, 'fileAreaId', 'FileArea'),
+    fileAreaName: requiredString(source, 'fileAreaName', 'FileArea'),
+    fileAreaType: requiredString(source, 'fileAreaType', 'FileArea'),
+  };
+};
+
+export const decodeFolder: DaluxDecoder<DaluxFolder> = (value) => {
+  const source = asRecord(value, 'Folder');
+  return {
+    folderId: requiredString(source, 'folderId', 'Folder'),
+    folderName: requiredString(source, 'folderName', 'Folder'),
+    parentFolderId: optionalString(source, 'parentFolderId', 'Folder'),
+  };
+};
+
+export const decodeFile: DaluxDecoder<DaluxFile> = (value) => {
+  const source = asRecord(value, 'File');
+  return {
+    fileId: requiredString(source, 'fileId', 'File'),
+    fileRevisionId: optionalString(source, 'fileRevisionId', 'File'),
+    fileName: requiredString(source, 'fileName', 'File'),
+    fileAreaId: requiredString(source, 'fileAreaId', 'File'),
+    folderId: optionalString(source, 'folderId', 'File'),
+    uploadedByUserId: optionalString(source, 'uploadedByUserId', 'File'),
+    uploaded: optionalString(source, 'uploaded', 'File'),
+    lastModifiedByUserId: optionalString(source, 'lastModifiedByUserId', 'File'),
+    lastModified: optionalString(source, 'lastModified', 'File'),
+    version: optionalString(source, 'version', 'File'),
+    deleted: booleanWithDefault(source, 'deleted', false, 'File'),
+    fileType: optionalString(source, 'fileType', 'File'),
+    fileSize: optionalNumber(source, 'fileSize', 'File'),
+    contentHash: optionalString(source, 'contentHash', 'File'),
+    downloadLink: optionalString(source, 'downloadLink', 'File'),
+  };
+};
+
+/**
+ * `{ data: File, links?: [...] }` single-item envelope. Unlike the list
+ * decoders this is used where a failure should be loud, so it throws.
+ */
+export const decodeFileResponse: DaluxDecoder<DaluxFileResponse> = (value) => {
+  const source = asRecord(value, 'FileResponse');
+  if (!('data' in source)) {
+    return fail('FileResponse.data: missing');
+  }
+  return { data: decodeFile(source.data) };
+};

--- a/packages/source-dalux/src/http-client.ts
+++ b/packages/source-dalux/src/http-client.ts
@@ -1,0 +1,323 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { PluginContext } from '@ifc-lite/plugin-api';
+
+export interface DaluxCredentials {
+  readonly baseUrl: string;
+  readonly apiKey: string;
+}
+
+interface DaluxPageLink {
+  readonly rel: string;
+  readonly href: string;
+}
+
+interface DaluxPageMetadata {
+  readonly totalRemainingItems?: number;
+}
+
+interface DaluxPage {
+  readonly items: readonly unknown[];
+  readonly metadata?: DaluxPageMetadata;
+  readonly links?: readonly DaluxPageLink[];
+}
+
+/** Upstream response bodies are interpolated into thrown `Error` messages,
+ * which reach user-facing toasts unmodified — cap them so a verbose upstream
+ * error page doesn't end up as a wall of HTML in the UI. */
+const MAX_ERROR_BODY_CHARS = 200;
+
+/** Hard ceiling on pages followed by {@link fetchAllPages}. A server that
+ * keeps minting fresh bookmarks (buggy or malicious) would otherwise loop
+ * forever; this trades a clear failure for an unbounded hang. */
+const MAX_SWEEP_PAGES = 1000;
+
+function truncate(text: string, max = MAX_ERROR_BODY_CHARS): string {
+  return text.length > max ? `${text.slice(0, max)}…` : text;
+}
+
+/** Thrown when Dalux's bookmark pagination looks broken rather than merely
+ * finished — a `nextPage` link with no bookmark, one that echoes the
+ * bookmark just used, or a page claiming more items remain while sending no
+ * `nextPage` link at all. Callers must not treat this as "no more data": it
+ * means the listing is truncated and the caller should say so, not report a
+ * clean success with fewer rows than actually exist upstream. */
+export class DaluxPaginationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'DaluxPaginationError';
+  }
+}
+
+/** Thrown for a non-2xx Dalux API response. Carries the actual HTTP status
+ * so callers that need to branch on it (auth-failure detection in
+ * `testConnection`, for one) match on `status` rather than on substrings of
+ * the interpolated error message — a truncated upstream body can contain
+ * digits that happen to look like a status code without being one. */
+export class DaluxHttpError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+    this.name = 'DaluxHttpError';
+  }
+}
+
+export class BrowserDaluxApiClient {
+  constructor(
+    private readonly credentials: DaluxCredentials,
+    private readonly ctx: PluginContext,
+  ) {}
+
+  get baseUrl(): string {
+    return this.credentials.baseUrl;
+  }
+
+  debug(message: string, details?: Record<string, unknown>): void {
+    this.ctx.log.debug(`Dalux ${message}`, details ?? {});
+  }
+
+  async get(
+    path: string,
+    params: Record<string, unknown> = {},
+    signal?: AbortSignal,
+  ): Promise<unknown> {
+    const url = new URL(path.startsWith('/') ? `${this.credentials.baseUrl}${path}` : path);
+    for (const [key, value] of Object.entries(params)) {
+      if (value === undefined || value === null || value === '') continue;
+      url.searchParams.set(key, String(value));
+    }
+
+    this.debug('GET request', { url: url.toString(), params });
+    const response = await this.ctx.fetch(url.toString(), {
+      headers: {
+        'X-API-KEY': this.credentials.apiKey,
+        Accept: 'application/json',
+      },
+      signal,
+    });
+    this.debug('GET response', {
+      url: url.toString(),
+      status: response.status,
+      ok: response.ok,
+      contentType: response.headers.get('content-type'),
+    });
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => '');
+      this.ctx.log.error('Dalux GET failed', {
+        url: url.toString(),
+        status: response.status,
+        statusText: response.statusText,
+        body,
+      });
+      throw new DaluxHttpError(
+        `Dalux API ${response.status}: ${response.statusText} — ${truncate(body)}`,
+        response.status,
+      );
+    }
+
+    return response.json() as Promise<unknown>;
+  }
+
+  async getBinary(url: string, signal?: AbortSignal): Promise<ArrayBuffer> {
+    this.debug('binary GET request', { url });
+    const response = await this.ctx.fetch(url, {
+      headers: {
+        'X-API-KEY': this.credentials.apiKey,
+        Accept: '*/*',
+      },
+      signal,
+    });
+    this.debug('binary GET response', {
+      url,
+      status: response.status,
+      ok: response.ok,
+      contentType: response.headers.get('content-type'),
+    });
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => '');
+      this.ctx.log.error('Dalux binary GET failed', {
+        url,
+        status: response.status,
+        statusText: response.statusText,
+        body,
+      });
+      throw new DaluxHttpError(
+        `Dalux API ${response.status}: ${response.statusText} — ${truncate(body)}`,
+        response.status,
+      );
+    }
+
+    return response.arrayBuffer();
+  }
+}
+
+/** Normalizes both response shapes a Dalux list endpoint can return: the
+ * usual `{ items, metadata?, links? }` envelope, and a bare array (which the
+ * vendored library's own single-page schemas tolerate but its `getAllFiles`/
+ * `getAllFolders` pagers do not). */
+function normalizePage(response: unknown): DaluxPage {
+  if (Array.isArray(response)) return { items: response };
+  if (response && typeof response === 'object') {
+    const page = response as { items?: unknown[]; metadata?: DaluxPageMetadata; links?: DaluxPageLink[] };
+    return { items: page.items ?? [], metadata: page.metadata, links: page.links };
+  }
+  return { items: [] };
+}
+
+/**
+ * Resolves a `nextPage` link's `bookmark` query param against a base URL.
+ *
+ * A bare `new URL(href)` throws a `TypeError` on a relative href, and
+ * because that throw happens mid-loop it discards every page already
+ * fetched — the vendored library's own `utils/pagination.js` guards exactly
+ * this parse with try/catch. Unlike that guard, a failure here does not
+ * silently mean "no more pages": it throws `DaluxPaginationError` instead,
+ * since treating a broken link as a clean end-of-list would report a
+ * truncated listing as a success.
+ */
+function extractBookmark(href: string, baseUrl: string, endpoint: string): string {
+  let url: URL;
+  try {
+    url = new URL(href, baseUrl);
+  } catch (err) {
+    throw new DaluxPaginationError(
+      `Dalux pagination broken at ${endpoint}: nextPage link "${href}" is not a valid URL ` +
+        `(${err instanceof Error ? err.message : String(err)})`,
+    );
+  }
+  const bookmark = url.searchParams.get('bookmark');
+  if (!bookmark) {
+    throw new DaluxPaginationError(`Dalux pagination broken at ${endpoint}: nextPage link has no bookmark`);
+  }
+  return bookmark;
+}
+
+export interface DaluxPageResult {
+  readonly items: readonly unknown[];
+  /** Dalux's bookmark, passed straight through as the plugin API's opaque
+   * cursor. `undefined` means this was the last page. */
+  readonly cursor?: string;
+}
+
+/**
+ * Fetches exactly one page of a Dalux bookmark-paginated endpoint and maps
+ * its bookmark onto the plugin API's `cursor`. Deliberately doesn't loop:
+ * contract listing methods (`listProjects`, `listContainers`, `listFiles`)
+ * page one Dalux call at a time and let the host drive, rather than
+ * eagerly loading an entire (potentially huge) tenant into memory before
+ * returning the first row.
+ *
+ * A `nextPage` link, when present, is authoritative and is always followed —
+ * even when the page it's attached to has zero items or reports
+ * `totalRemainingItems: 0`. That's a legitimate bookmark-pager shape: the
+ * server can signal "keep going" via the link while the counters on this
+ * particular page look like "done", with the real end only reached once a
+ * later page comes back both empty *and* linkless. Treating an empty or
+ * remaining-0 page as terminal whenever it still carries a `nextPage` link
+ * would silently truncate a listing that in fact had more pages.
+ *
+ * Any condition that would otherwise truncate the listing silently — a
+ * `nextPage` link with no bookmark, a bookmark that echoes the one just
+ * used, or `metadata.totalRemainingItems > 0` with no `nextPage` link at
+ * all — throws {@link DaluxPaginationError} instead of returning as if the
+ * page were simply the last one.
+ */
+export async function fetchPage(
+  client: BrowserDaluxApiClient,
+  endpoint: string,
+  params: Record<string, unknown>,
+  cursor: string | undefined,
+  signal?: AbortSignal,
+): Promise<DaluxPageResult> {
+  const requestParams = cursor ? { ...params, bookmark: cursor } : params;
+  const response = await client.get(endpoint, requestParams, signal);
+  const page = normalizePage(response);
+  const remaining = page.metadata?.totalRemainingItems;
+  const nextLink = (page.links ?? []).find((link) => link.rel === 'nextPage');
+
+  client.debug('page received', {
+    endpoint,
+    cursor,
+    itemCount: page.items.length,
+    remaining,
+    hasNextLink: Boolean(nextLink),
+  });
+
+  // A nextPage link always wins over the item count or the remaining
+  // counter: follow it regardless of whether this particular page looks
+  // empty or "complete" (see the doc comment above for why that's not a
+  // contradiction upstream).
+  if (nextLink) {
+    const nextCursor = extractBookmark(nextLink.href, client.baseUrl, endpoint);
+    if (cursor && nextCursor === cursor) {
+      throw new DaluxPaginationError(
+        `Dalux pagination stuck at ${endpoint}: server returned the same bookmark again`,
+      );
+    }
+    return { items: page.items, cursor: nextCursor };
+  }
+
+  // No nextPage link: this is the last page — unless the server claims more
+  // data remains with no link given to reach it, which is a genuinely
+  // truncated listing rather than a clean end.
+  if (remaining !== undefined && remaining > 0) {
+    throw new DaluxPaginationError(
+      `Dalux pagination truncated at ${endpoint}: ${remaining} item(s) remain but the server sent no nextPage link`,
+    );
+  }
+
+  return { items: page.items, cursor: undefined };
+}
+
+/**
+ * Follows every page of a Dalux bookmark-paginated endpoint and returns the
+ * combined items. For internal callers that genuinely need a whole listing
+ * in one shot — currently only `watchRevisions`'s one-sweep-per-file-area
+ * poll. The public `FileSourceProvider` listing methods must NOT use this;
+ * they call {@link fetchPage} once and return that page to the host.
+ *
+ * Bounded by `MAX_SWEEP_PAGES` (a server minting endlessly fresh bookmarks
+ * can't loop forever) and tracks every bookmark seen across the whole
+ * sweep — a longer cycle than the immediate echo `fetchPage` already
+ * rejects on its own.
+ */
+export async function fetchAllPages(
+  client: BrowserDaluxApiClient,
+  endpoint: string,
+  params: Record<string, unknown> = {},
+  signal?: AbortSignal,
+): Promise<unknown[]> {
+  const items: unknown[] = [];
+  const seenBookmarks = new Set<string>();
+  let cursor: string | undefined;
+  let pageCount = 0;
+
+  for (;;) {
+    pageCount += 1;
+    if (pageCount > MAX_SWEEP_PAGES) {
+      throw new DaluxPaginationError(
+        `Dalux pagination at ${endpoint} exceeded ${MAX_SWEEP_PAGES} pages without finishing`,
+      );
+    }
+
+    const page = await fetchPage(client, endpoint, params, cursor, signal);
+    items.push(...page.items);
+
+    if (!page.cursor) break;
+    if (seenBookmarks.has(page.cursor)) {
+      throw new DaluxPaginationError(
+        `Dalux pagination at ${endpoint} revisited a bookmark it had already seen`,
+      );
+    }
+    seenBookmarks.add(page.cursor);
+    cursor = page.cursor;
+  }
+
+  return items;
+}

--- a/packages/source-dalux/src/index.ts
+++ b/packages/source-dalux/src/index.ts
@@ -1,0 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+export { DaluxBuildProvider } from './provider.js';
+export { DALUX_MANIFEST } from './manifest.js';

--- a/packages/source-dalux/src/manifest.ts
+++ b/packages/source-dalux/src/manifest.ts
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { PluginManifest } from '@ifc-lite/plugin-api';
+
+export const DALUX_MANIFEST: PluginManifest = {
+  name: 'dalux-build',
+  title: 'Dalux Box',
+  api: '^2.0.0',
+  auth: 'preferences',
+  permissions: {
+    network: ['*.dalux.com', 'dalux.com'],
+    // Dalux's API sends no CORS headers, so it must be reached through the
+    // app's own same-origin relay rather than directly from the browser.
+    relay: {
+      upstream: 'https://node1.field.dalux.com/service/api',
+      path: '/api/dalux',
+    },
+  },
+  preferences: [
+    {
+      name: 'apiKey',
+      title: 'API key',
+      description: 'Dalux API Identity key (created by a company admin).',
+      type: 'password',
+      required: true,
+    },
+  ],
+  capabilities: {
+    // Dalux has no per-folder listing endpoint: `folders` returns every
+    // folder in a file area regardless of parent, so the whole subtree
+    // comes back flattened and the host nests it client-side.
+    containerListing: 'flat-subtree',
+    // A file-area-level `listFiles` call returns every descendant file,
+    // not just the ones directly in the area's root.
+    listFilesIsRecursive: true,
+    // No endpoint returns revision history for a file — only "fetch this
+    // exact revision's content" if you already have its id.
+    revisionHistory: false,
+    // No history endpoint to enumerate, but a known revision id downloads fine.
+    downloadHistoricalRevisions: true,
+    // No delta feed either; `watchRevisions` polls the tracked refs.
+    changeDetection: true,
+    // No server-side file search endpoint.
+    search: false,
+  },
+  contributes: {
+    fileSources: ['./src/provider.ts'],
+  },
+};

--- a/packages/source-dalux/src/mapping.ts
+++ b/packages/source-dalux/src/mapping.ts
@@ -1,0 +1,155 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { DaluxDecoder, DaluxFile } from './dalux-types.js';
+import type { PluginContext, SourceFile } from '@ifc-lite/plugin-api';
+
+/**
+ * Sentinel used for `SourceFile.currentRevisionId` (and, symmetrically,
+ * `SourceFileRef.revisionId`) when Dalux hasn't given us a real revision id
+ * *or* a content hash for a file. `fileRevisionId` is nullable in the
+ * schema; the previous mapping faked one with `file.fileId`, which then
+ * reached `download()` as if it were a genuine revision id and 404s against
+ * `/revisions/{fileId}/content` (a file id, not a revision id). Treating
+ * "no revision id" as this explicit, recognizable value instead lets
+ * `download()` detect it and fall back to the latest-content path.
+ *
+ * Deliberately not the plain string "latest": download() reroutes a ref
+ * whose revisionId equals this sentinel to the latest-content path rather
+ * than fetching a specific revision, so the sentinel must never collide
+ * with a real Dalux revision id -- a file legitimately versioned with a
+ * label like "latest" would otherwise silently return current bytes for
+ * what the caller asked to pin. Observed Dalux revision ids are short
+ * opaque alphanumeric/GUID-like tokens, never colon-namespaced strings, so
+ * this distinctive namespaced value is a practical mitigation (not a
+ * provable guarantee) with no extra moving parts. Bulletproof avoidance
+ * would mean tracking "this file genuinely had no revision id" out of band
+ * alongside every cached ref -- a bigger change than this warrants today;
+ * revisit if Dalux is ever seen minting an id shaped like this one.
+ */
+export const LATEST_REVISION = 'ifc-lite:dalux:no-revision-id';
+
+/** Separator between a file area id and a folder id in a composite
+ * container id. Folder ids need this because `listFiles`/`download` only
+ * ever receive a `containerId` string — never the `SourceContainer` object
+ * `listContainers` returned it in — so the file area a folder belongs to
+ * must be recoverable from the id alone. This is what makes the v1
+ * `container-loc:`/`file-loc:` id-to-location cache in `ctx.storage`
+ * unnecessary: there is nothing left to look up. */
+const CONTAINER_SEP = '::';
+
+/** The container id for a file area itself (no folder component). */
+export function fileAreaContainerId(fileAreaId: string): string {
+  return fileAreaId;
+}
+
+/** The container id for a folder within a file area. */
+export function folderContainerId(fileAreaId: string, folderId: string): string {
+  return `${fileAreaId}${CONTAINER_SEP}${folderId}`;
+}
+
+export interface DecodedContainerId {
+  readonly fileAreaId: string;
+  readonly folderId?: string;
+}
+
+/** Inverse of {@link fileAreaContainerId}/{@link folderContainerId}. A
+ * container id with no separator is a bare file area id (folder omitted). */
+export function decodeContainerId(containerId: string): DecodedContainerId {
+  const sepIndex = containerId.indexOf(CONTAINER_SEP);
+  if (sepIndex === -1) return { fileAreaId: containerId };
+  return {
+    fileAreaId: containerId.slice(0, sepIndex),
+    folderId: containerId.slice(sepIndex + CONTAINER_SEP.length),
+  };
+}
+
+/**
+ * The file's current revision identity, per the plugin API contract: "must
+ * change when the bytes change and must not change when only metadata
+ * changes". Prefers the real `fileRevisionId`; when Dalux gives none, falls
+ * back to `contentHash` — which the decoder already captures but which
+ * previously went unused — rather than jumping straight to
+ * {@link LATEST_REVISION}. A file with no revision id but a real content
+ * hash can still change forever; without this fallback `watchRevisions`
+ * would compare the sentinel to itself on every poll and never emit.
+ *
+ * An empty-string `fileRevisionId` (Dalux does send these) is treated the
+ * same as an absent one via {@link nonEmptyString}, so it falls through to
+ * `contentHash`/the sentinel instead of being cached as `""` — a `""` cache
+ * entry fails truthiness checks like `cached &&`, which would otherwise
+ * silently swallow the first real event after an empty-string revision id.
+ */
+export function currentRevisionId(file: Pick<DaluxFile, 'fileRevisionId' | 'contentHash'>): string {
+  return nonEmptyString(file.fileRevisionId) ?? nonEmptyString(file.contentHash) ?? LATEST_REVISION;
+}
+
+export function toSourceFile(fileAreaId: string, file: DaluxFile): SourceFile {
+  const folderId = nonEmptyString(file.folderId);
+
+  return {
+    id: file.fileId,
+    name: file.fileName,
+    // A file's real container is whichever folder it's actually filed under
+    // — not the container the caller happened to query — falling back to
+    // the file area root only when it has no folder at all.
+    containerId: folderId ? folderContainerId(fileAreaId, folderId) : fileAreaContainerId(fileAreaId),
+    mimeType: orUndefined(file.fileType),
+    sizeBytes: orUndefined(file.fileSize),
+    currentRevisionId: currentRevisionId(file),
+    modifiedAt: orUndefined(file.lastModified ?? file.uploaded),
+    modifiedBy: orUndefined(file.lastModifiedByUserId ?? file.uploadedByUserId),
+    meta: { fileAreaId, folderId },
+  };
+}
+
+export function enc(segment: string): string {
+  return encodeURIComponent(segment);
+}
+
+export function orUndefined<T>(value: T | null | undefined): T | undefined {
+  return value ?? undefined;
+}
+
+export function nonEmptyString(value: string | null | undefined): string | undefined {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/** Unwraps a Dalux `{ data: {...} }` item envelope. Bare objects with no
+ * `data` wrapper pass straight through — the API uses both shapes. */
+function unwrapDaluxEnvelope(item: unknown): unknown {
+  if (item && typeof item === 'object' && !Array.isArray(item) && 'data' in item) {
+    return (item as { data: unknown }).data;
+  }
+  return item;
+}
+
+/**
+ * Decodes a raw item list, dropping (with a logged warning) any record that
+ * fails to decode instead of throwing.
+ *
+ * For a read-only file catalog, one malformed row — discovered after every
+ * page has already been fetched, in some cases after a multi-page sweep —
+ * should not cost the user every other row that decoded fine.
+ */
+export function convertListLenient<T>(
+  ctx: PluginContext,
+  items: readonly unknown[],
+  decode: DaluxDecoder<T>,
+  typeName: string,
+): T[] {
+  const results: T[] = [];
+  for (const item of items) {
+    try {
+      results.push(decode(unwrapDaluxEnvelope(item)));
+    } catch (err) {
+      ctx.log.warn(`Dalux: dropping invalid ${typeName} record`, {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+  return results;
+}

--- a/packages/source-dalux/src/provider.ts
+++ b/packages/source-dalux/src/provider.ts
@@ -1,0 +1,366 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import {
+  decodeFile,
+  decodeFileArea,
+  decodeFileResponse,
+  decodeFolder,
+  decodeProject,
+} from './dalux-types.js';
+
+import type {
+  DaluxFile,
+  DaluxFileArea,
+  DaluxFolder,
+  DaluxProject,
+} from './dalux-types.js';
+
+import { matchesGlob } from '@ifc-lite/plugin-api';
+import type {
+  ConnectionTestResult,
+  DownloadOptions,
+  FileFilter,
+  FileSourceProvider,
+  ListOptions,
+  ListProjectsOptions,
+  Page,
+  PluginContext,
+  RevisionEvent,
+  RevisionWatchResult,
+  SourceContainer,
+  SourceFile,
+  SourceFileRef,
+  SourceProject,
+} from '@ifc-lite/plugin-api';
+
+import { DALUX_MANIFEST } from './manifest.js';
+import { BrowserDaluxApiClient, DaluxHttpError, fetchPage, fetchAllPages } from './http-client.js';
+import {
+  LATEST_REVISION,
+  convertListLenient,
+  currentRevisionId,
+  decodeContainerId,
+  enc,
+  fileAreaContainerId,
+  folderContainerId,
+  nonEmptyString,
+  toSourceFile,
+} from './mapping.js';
+
+const DEFAULT_BASE_URL = 'https://node1.field.dalux.com/service/api';
+
+export class DaluxBuildProvider implements FileSourceProvider {
+  readonly manifest = DALUX_MANIFEST;
+
+  async listProjects(ctx: PluginContext, options?: ListProjectsOptions): Promise<Page<SourceProject>> {
+    const client = await this.createClient(ctx);
+    const page = await fetchPage(client, '/5.1/projects', {}, options?.cursor, options?.signal);
+    const projects = convertListLenient<DaluxProject>(ctx, page.items, decodeProject, 'Project');
+
+    return {
+      items: projects.map((project) => ({ id: project.projectId, name: project.projectName })),
+      cursor: page.cursor,
+    };
+  }
+
+  async listContainers(
+    ctx: PluginContext,
+    projectId: string,
+    parentId?: string,
+    options?: ListOptions,
+  ): Promise<Page<SourceContainer>> {
+    const client = await this.createClient(ctx);
+
+    if (!parentId) {
+      // Top level: just the file areas. Cheap — no folder walk, so the host
+      // can show this list immediately instead of waiting on every file
+      // area's (potentially deep) folder tree up front.
+      const page = await fetchPage(
+        client,
+        `/5.1/projects/${enc(projectId)}/file_areas`,
+        {},
+        options?.cursor,
+        options?.signal,
+      );
+      const fileAreas = convertListLenient<DaluxFileArea>(ctx, page.items, decodeFileArea, 'FileArea');
+
+      return {
+        items: fileAreas.map((fileArea) => ({
+          id: fileAreaContainerId(fileArea.fileAreaId),
+          name: fileArea.fileAreaName,
+          meta: { kind: 'file-area' },
+        })),
+        cursor: page.cursor,
+      };
+    }
+
+    // `parentId` scopes to one file area (its container id carries no
+    // folder component — see `decodeContainerId`). Dalux can't filter
+    // folders by parent server-side, so every folder in the area comes back
+    // regardless of nesting (capabilities.containerListing ===
+    // 'flat-subtree'); the host nests the flattened result client-side via
+    // each folder's `parentId`.
+    const fileAreaId = decodeContainerId(parentId).fileAreaId;
+    const page = await fetchPage(
+      client,
+      `/5.1/projects/${enc(projectId)}/file_areas/${enc(fileAreaId)}/folders`,
+      {},
+      options?.cursor,
+      options?.signal,
+    );
+    const folders = convertListLenient<DaluxFolder>(ctx, page.items, decodeFolder, 'Folder');
+    const folderIdsThisPage = new Set(folders.map((folder) => folder.folderId));
+
+    const containers: SourceContainer[] = folders.map((folder) => {
+      const parentFolderId = nonEmptyString(folder.parentFolderId);
+      // A folder whose parent isn't the file area itself and isn't another
+      // folder on this page is reattached to the file area root rather than
+      // left dangling: Dalux sometimes reports folders whose parent is
+      // never itself surfaced as a folder. Known limitation of paging one
+      // Dalux bookmark page at a time (required so a large area doesn't
+      // force one giant eager fetch): if a folder's true parent lands on a
+      // *later* page, it's reattached to the root here too, and re-nests
+      // correctly once the host has walked that later page and revisits it.
+      const resolvedParentId =
+        !parentFolderId || parentFolderId === fileAreaId || folderIdsThisPage.has(parentFolderId)
+          ? (parentFolderId ?? fileAreaId)
+          : fileAreaId;
+
+      return {
+        id: folderContainerId(fileAreaId, folder.folderId),
+        name: folder.folderName,
+        parentId:
+          resolvedParentId === fileAreaId
+            ? fileAreaContainerId(fileAreaId)
+            : folderContainerId(fileAreaId, resolvedParentId),
+        meta: { kind: 'folder', fileAreaId },
+      };
+    });
+
+    return { items: containers, cursor: page.cursor };
+  }
+
+  async listFiles(
+    ctx: PluginContext,
+    projectId: string,
+    containerId: string,
+    filter?: FileFilter,
+    options?: ListOptions,
+  ): Promise<Page<SourceFile>> {
+    const client = await this.createClient(ctx);
+    const { fileAreaId, folderId } = decodeContainerId(containerId);
+
+    const page = await fetchPage(
+      client,
+      `/6.1/projects/${enc(projectId)}/file_areas/${enc(fileAreaId)}/files`,
+      folderId ? { folderId } : {},
+      options?.cursor,
+      options?.signal,
+    );
+    const daluxFiles = convertListLenient<DaluxFile>(ctx, page.items, decodeFile, 'File');
+    const nonDeleted = daluxFiles.filter((file) => !file.deleted);
+
+    let files = nonDeleted.map((file) => toSourceFile(fileAreaId, file));
+
+    // The Dalux `files` endpoint doesn't reliably scope to the requested
+    // folder — it can return every file in the file area regardless of the
+    // `folderId` query param. Trust each file's own folder instead: a
+    // folder-scoped query stays strict to that folder, while a file-area
+    // query surfaces every descendant file (capabilities.listFilesIsRecursive).
+    if (folderId) {
+      files = files.filter((file) => file.containerId === containerId);
+    }
+
+    if (filter?.namePatterns?.length) {
+      const patterns = filter.namePatterns;
+      files = files.filter((file) => patterns.some((pattern) => matchesGlob(file.name, pattern)));
+    }
+    if (filter?.mimeTypes?.length) {
+      const mimeTypes = filter.mimeTypes;
+      files = files.filter((file) => file.mimeType && mimeTypes.includes(file.mimeType));
+    }
+
+    return { items: files, cursor: page.cursor };
+  }
+
+  async download(ctx: PluginContext, ref: SourceFileRef, options?: DownloadOptions): Promise<ArrayBuffer> {
+    const client = await this.createClient(ctx);
+    const { fileAreaId } = decodeContainerId(ref.containerId);
+    // `LATEST_REVISION` is the sentinel `toSourceFile`/`currentRevisionId`
+    // report when Dalux gave no real `fileRevisionId` or `contentHash`;
+    // treating it the same as "omitted" here is what stops that case from
+    // ever reaching `/revisions/.../content` with an id that isn't actually
+    // a revision id (see `mapping.ts`). The sentinel is deliberately not
+    // the plain string "latest" so this comparison isn't defeated by a file
+    // that happens to carry a real revision id spelled that way (see the
+    // collision note on `LATEST_REVISION` itself).
+    const revisionId = ref.revisionId && ref.revisionId !== LATEST_REVISION ? ref.revisionId : undefined;
+
+    if (revisionId) {
+      // Built from the client's own base URL, not the module-level default
+      // — the client is the single source of truth for which host this
+      // request should go to, and diverging from it here would be a latent
+      // bug the moment `baseUrl` ever becomes configurable.
+      return client.getBinary(
+        `${client.baseUrl}/2.0/projects/${enc(ref.projectId)}/file_areas/${enc(fileAreaId)}` +
+          `/files/${enc(ref.fileId)}/revisions/${enc(revisionId)}/content`,
+        options?.signal,
+      );
+    }
+
+    const metadataResponse = await client.get(
+      `/5.0/projects/${enc(ref.projectId)}/file_areas/${enc(fileAreaId)}/files/${enc(ref.fileId)}`,
+      {},
+      options?.signal,
+    );
+    const metadata = decodeFileResponse(metadataResponse);
+    const downloadLink = metadata.data.downloadLink;
+    if (!downloadLink) {
+      throw new Error(`Dalux file ${ref.fileId} does not expose a download link`);
+    }
+
+    return client.getBinary(downloadLink, options?.signal);
+  }
+
+  /**
+   * Dalux has no delta/change-feed endpoint, so watching means polling the
+   * given refs. Grouped strictly by file area so a sweep covering many refs
+   * from the same area issues one listing sweep total — never a project- or
+   * account-wide crawl, and never more than one sweep per distinct area.
+   *
+   * Two failure-isolation rules, both load-bearing:
+   *
+   * 1. One area's sweep failing (a deleted file area 404ing, or a pagination
+   *    error) must not abort the whole call — that would discard the
+   *    already-detected events from every *other*, healthy area too. So each
+   *    area's sweep is caught individually; a failed area's refs are
+   *    reported (with a warning) rather than the call rejecting outright.
+   * 2. `ctx.storage.set`/`delete` for every area are buffered and only
+   *    committed once the whole sweep is done, never per-area as each area
+   *    finishes. Advancing a cache immediately and *then* discovering a
+   *    later area failed used to mean: if the host reacted to that failure
+   *    by discarding this call's events, the already-advanced caches would
+   *    make the next poll compare against the new value and never emit the
+   *    now-lost event again — permanently. Buffering means a cache is only
+   *    ever advanced past a change once that change's event has actually
+   *    been returned.
+   */
+  async watchRevisions(
+    ctx: PluginContext,
+    refs: readonly SourceFileRef[],
+    _cursor?: string,
+    options?: ListOptions,
+  ): Promise<RevisionWatchResult> {
+    const client = await this.createClient(ctx);
+    const events: RevisionEvent[] = [];
+    const pendingSets = new Map<string, string>();
+    const pendingDeletes = new Set<string>();
+
+    const areas = new Map<string, { projectId: string; fileAreaId: string; refs: SourceFileRef[] }>();
+    for (const ref of refs) {
+      const { fileAreaId } = decodeContainerId(ref.containerId);
+      const key = `${ref.projectId}::${fileAreaId}`;
+      const area = areas.get(key);
+      if (area) area.refs.push(ref);
+      else areas.set(key, { projectId: ref.projectId, fileAreaId, refs: [ref] });
+    }
+
+    for (const { projectId, fileAreaId, refs: areaRefs } of areas.values()) {
+      let filesById: Map<string, DaluxFile>;
+      try {
+        const rawItems = await fetchAllPages(
+          client,
+          `/6.1/projects/${enc(projectId)}/file_areas/${enc(fileAreaId)}/files`,
+          {},
+          options?.signal,
+        );
+        const daluxFiles = convertListLenient<DaluxFile>(ctx, rawItems, decodeFile, 'File');
+        filesById = new Map(daluxFiles.filter((file) => !file.deleted).map((file) => [file.fileId, file] as const));
+      } catch (err) {
+        // This area's sweep failed outright (area deleted upstream -> 404,
+        // a Dalux pagination error, ...). Report its refs as deleted/skipped
+        // rather than letting the failure propagate and take every other
+        // area's already-detected events down with it. Crucially: don't
+        // touch this area's caches below, so a transient failure gets
+        // retried against the same baseline next poll instead of silently
+        // losing whatever change caused it.
+        ctx.log.warn('Dalux: file-area sweep failed during watchRevisions, skipping its refs this poll', {
+          projectId,
+          fileAreaId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        for (const ref of areaRefs) {
+          events.push({ fileId: ref.fileId, latestRevisionId: LATEST_REVISION, deleted: true });
+        }
+        continue;
+      }
+
+      for (const ref of areaRefs) {
+        const cacheKey = `rev:${projectId}:${fileAreaId}:${ref.fileId}`;
+        const match = filesById.get(ref.fileId);
+
+        if (!match) {
+          events.push({ fileId: ref.fileId, latestRevisionId: LATEST_REVISION, deleted: true });
+          pendingDeletes.add(cacheKey);
+          continue;
+        }
+
+        const latestRevisionId = currentRevisionId(match);
+        const cached = await ctx.storage.get(cacheKey);
+        if (cached && cached !== latestRevisionId) {
+          events.push({ fileId: ref.fileId, latestRevisionId, previousRevisionId: cached });
+        }
+        pendingSets.set(cacheKey, latestRevisionId);
+      }
+    }
+
+    // Commit only now that every area's sweep has run to completion (the
+    // areas that threw above never reach here, so their caches are left
+    // exactly as they were).
+    for (const cacheKey of pendingDeletes) await ctx.storage.delete(cacheKey);
+    for (const [cacheKey, revisionId] of pendingSets) await ctx.storage.set(cacheKey, revisionId);
+
+    // No delta endpoint to resume from — every call is a fresh poll of the
+    // given refs, so there is no cursor to hand back.
+    return { events };
+  }
+
+  async testConnection(ctx: PluginContext): Promise<ConnectionTestResult> {
+    try {
+      const page = await this.listProjects(ctx);
+      const count = page.items.length;
+      const hasMore = Boolean(page.cursor);
+      return {
+        ok: true,
+        message: hasMore
+          ? `Connected — at least ${count} project${count === 1 ? '' : 's'} accessible (more available).`
+          : `Connected — ${count} project${count === 1 ? '' : 's'} accessible.`,
+        // Only report a count when it's the whole picture — a single page
+        // isn't a cheap total when more pages remain.
+        projectCount: hasMore ? undefined : count,
+      };
+    } catch (err) {
+      // Match on the actual HTTP status the client observed, not on
+      // whether the (possibly truncated, upstream-authored) error message
+      // happens to contain the digits "401"/"403" — a 500 whose body text
+      // mentions either would otherwise be misreported as an auth failure.
+      if (err instanceof DaluxHttpError && (err.status === 401 || err.status === 403)) {
+        return {
+          ok: false,
+          message:
+            'Your API identity lacks access. Check that the identity is assigned to a user group with project permissions.',
+        };
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      return { ok: false, message };
+    }
+  }
+
+  private async createClient(ctx: PluginContext): Promise<BrowserDaluxApiClient> {
+    const apiKey = await ctx.getPreference('apiKey');
+    if (!apiKey) throw new Error('Dalux API key not configured');
+    return new BrowserDaluxApiClient({ baseUrl: DEFAULT_BASE_URL, apiKey }, ctx);
+  }
+}

--- a/packages/source-dalux/test/dalux-types.test.ts
+++ b/packages/source-dalux/test/dalux-types.test.ts
@@ -1,0 +1,160 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  DaluxDecodeError,
+  decodeFile,
+  decodeFileArea,
+  decodeFileResponse,
+  decodeFolder,
+  decodeProject,
+} from '../src/dalux-types.js';
+
+/**
+ * These decoders replaced a third-party zod schema set. The point of the
+ * tests below is that the replacement is a dependency change and not a
+ * behaviour change, so they pin the semantics that were previously supplied
+ * by zod: nullish handling, the `deleted` default, non-strict objects, and
+ * rejection (rather than coercion) of wrong-typed fields.
+ */
+
+const validFile = {
+  fileId: 'f1',
+  fileName: 'model.ifc',
+  fileAreaId: 'fa1',
+  deleted: false,
+};
+
+describe('decodeProject', () => {
+  it('decodes the required fields and ignores unknown ones', () => {
+    expect(
+      decodeProject({ projectId: 'p1', projectName: 'Tower', address: 'somewhere', modules: [] }),
+    ).toEqual({ projectId: 'p1', projectName: 'Tower' });
+  });
+
+  it('rejects a missing required field', () => {
+    expect(() => decodeProject({ projectId: 'p1' })).toThrow(DaluxDecodeError);
+    expect(() => decodeProject({ projectId: 'p1' })).toThrow(/projectName/);
+  });
+
+  it('rejects non-objects', () => {
+    for (const value of [null, undefined, 42, 'x', ['a']]) {
+      expect(() => decodeProject(value)).toThrow(DaluxDecodeError);
+    }
+  });
+});
+
+describe('decodeFileArea', () => {
+  it('requires all three fields', () => {
+    expect(decodeFileArea({ fileAreaId: 'a', fileAreaName: 'Docs', fileAreaType: 'standard' })).toEqual({
+      fileAreaId: 'a',
+      fileAreaName: 'Docs',
+      fileAreaType: 'standard',
+    });
+    expect(() => decodeFileArea({ fileAreaId: 'a', fileAreaName: 'Docs' })).toThrow(/fileAreaType/);
+  });
+});
+
+describe('decodeFolder', () => {
+  it('treats an absent and an explicitly null parentFolderId identically', () => {
+    const absent = decodeFolder({ folderId: 'd1', folderName: 'Level 1' });
+    const explicitNull = decodeFolder({ folderId: 'd1', folderName: 'Level 1', parentFolderId: null });
+
+    expect(absent.parentFolderId).toBeUndefined();
+    expect(explicitNull.parentFolderId).toBeUndefined();
+    expect(absent).toEqual(explicitNull);
+  });
+
+  it('keeps a real parentFolderId', () => {
+    expect(decodeFolder({ folderId: 'd2', folderName: 'Sub', parentFolderId: 'd1' }).parentFolderId).toBe('d1');
+  });
+});
+
+describe('decodeFile', () => {
+  it('defaults deleted to false when absent or null', () => {
+    expect(decodeFile({ fileId: 'f', fileName: 'a.ifc', fileAreaId: 'fa' }).deleted).toBe(false);
+    expect(decodeFile({ ...validFile, deleted: null }).deleted).toBe(false);
+  });
+
+  it('preserves an explicit deleted: true', () => {
+    expect(decodeFile({ ...validFile, deleted: true }).deleted).toBe(true);
+  });
+
+  it('rejects a non-boolean deleted rather than coercing it', () => {
+    expect(() => decodeFile({ ...validFile, deleted: 'yes' })).toThrow(/deleted/);
+    expect(() => decodeFile({ ...validFile, deleted: 1 })).toThrow(/deleted/);
+  });
+
+  it('rejects a wrong-typed optional rather than coercing it', () => {
+    // Silently reinterpreting this would surface a nonsense size in the UI.
+    expect(() => decodeFile({ ...validFile, fileSize: 'big' })).toThrow(/fileSize/);
+    expect(() => decodeFile({ ...validFile, fileName: 123 })).toThrow(/fileName/);
+  });
+
+  it('coerces a non-finite fileSize to undefined instead of dropping the whole file', () => {
+    // zod's z.number() accepted NaN/Infinity, so silently rejecting the
+    // whole row here would be an undocumented behaviour change: a bad
+    // fileSize shouldn't cost the user the rest of the row.
+    expect(decodeFile({ ...validFile, fileSize: Number.NaN }).fileSize).toBeUndefined();
+    expect(decodeFile({ ...validFile, fileSize: Number.POSITIVE_INFINITY }).fileSize).toBeUndefined();
+    expect(decodeFile({ ...validFile, fileSize: Number.NEGATIVE_INFINITY }).fileSize).toBeUndefined();
+    // The rest of the row still decodes normally.
+    expect(decodeFile({ ...validFile, fileSize: Number.NaN }).fileId).toBe('f1');
+  });
+
+  it('normalises every nullish field to undefined', () => {
+    const decoded = decodeFile({
+      ...validFile,
+      fileRevisionId: null,
+      folderId: null,
+      uploaded: null,
+      lastModified: null,
+      fileType: null,
+      fileSize: null,
+      downloadLink: null,
+    });
+
+    expect(decoded.fileRevisionId).toBeUndefined();
+    expect(decoded.folderId).toBeUndefined();
+    expect(decoded.fileSize).toBeUndefined();
+    expect(decoded.downloadLink).toBeUndefined();
+  });
+
+  it('accepts an empty string id — that is the API’s business, not the decoder’s', () => {
+    expect(decodeFile({ ...validFile, fileId: '' }).fileId).toBe('');
+  });
+
+  it('carries through the fields the provider actually maps', () => {
+    const decoded = decodeFile({
+      ...validFile,
+      fileRevisionId: 'r7',
+      folderId: 'd1',
+      fileType: 'application/octet-stream',
+      fileSize: 1024,
+      lastModified: '2026-07-24T00:00:00Z',
+      lastModifiedByUserId: 'u9',
+      downloadLink: 'https://node1.field.dalux.com/service/api/x',
+    });
+
+    expect(decoded).toMatchObject({
+      fileRevisionId: 'r7',
+      folderId: 'd1',
+      fileSize: 1024,
+      lastModifiedByUserId: 'u9',
+    });
+  });
+});
+
+describe('decodeFileResponse', () => {
+  it('unwraps the data envelope', () => {
+    expect(decodeFileResponse({ data: validFile, links: [] }).data.fileId).toBe('f1');
+  });
+
+  it('throws loudly when data is missing or invalid', () => {
+    expect(() => decodeFileResponse({ links: [] })).toThrow(/data/);
+    expect(() => decodeFileResponse({ data: { fileId: 'f1' } })).toThrow(DaluxDecodeError);
+  });
+});

--- a/packages/source-dalux/test/http-client.test.ts
+++ b/packages/source-dalux/test/http-client.test.ts
@@ -1,0 +1,305 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { PluginContext, KeyValueStore, Logger } from '@ifc-lite/plugin-api';
+import { BrowserDaluxApiClient, DaluxPaginationError, fetchAllPages, fetchPage } from '../src/http-client.js';
+
+function createMockStorage(): KeyValueStore {
+  const store = new Map<string, string>();
+  return {
+    get: vi.fn((key: string) => Promise.resolve(store.get(key))),
+    set: vi.fn((key: string, value: string) => {
+      store.set(key, value);
+      return Promise.resolve();
+    }),
+    delete: vi.fn((key: string) => {
+      store.delete(key);
+      return Promise.resolve();
+    }),
+    keys: vi.fn(() => Promise.resolve([...store.keys()])),
+  };
+}
+
+function createMockLogger(): Logger {
+  return { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+function createMockCtx(fetchImpl: typeof fetch): PluginContext {
+  return {
+    fetch: fetchImpl,
+    fetchPublic: vi.fn(() => Promise.reject(new Error('fetchPublic not used in these tests'))),
+    getPreference: vi.fn(() => Promise.resolve('test-key')),
+    storage: createMockStorage(),
+    log: createMockLogger(),
+  };
+}
+
+function mockResponse(overrides: Record<string, unknown> = {}) {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    headers: { get: () => null },
+    json: () => Promise.resolve(undefined),
+    text: () => Promise.resolve(''),
+    ...overrides,
+  };
+}
+
+function client(mockFetch: ReturnType<typeof vi.fn>): BrowserDaluxApiClient {
+  const ctx = createMockCtx(mockFetch as unknown as typeof fetch);
+  return new BrowserDaluxApiClient({ baseUrl: 'https://node1.field.dalux.com/service/api', apiKey: 'k' }, ctx);
+}
+
+describe('fetchPage', () => {
+  it('returns items and no cursor for a single, complete page', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      mockResponse({ json: () => Promise.resolve({ items: [{ a: 1 }, { a: 2 }] }) }),
+    );
+    const result = await fetchPage(client(mockFetch), '/x', {}, undefined);
+    expect(result.items).toEqual([{ a: 1 }, { a: 2 }]);
+    expect(result.cursor).toBeUndefined();
+  });
+
+  it('treats a bare-array response as a complete page', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(mockResponse({ json: () => Promise.resolve([{ a: 1 }]) }));
+    const result = await fetchPage(client(mockFetch), '/x', {}, undefined);
+    expect(result.items).toEqual([{ a: 1 }]);
+    expect(result.cursor).toBeUndefined();
+  });
+
+  it('extracts the bookmark from an absolute nextPage href as the cursor', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      mockResponse({
+        json: () =>
+          Promise.resolve({
+            items: [{ a: 1 }],
+            metadata: { totalRemainingItems: 1 },
+            links: [{ rel: 'nextPage', href: 'https://node1.field.dalux.com/service/api/x?bookmark=abc123' }],
+          }),
+      }),
+    );
+    const result = await fetchPage(client(mockFetch), '/x', {}, undefined);
+    expect(result.cursor).toBe('abc123');
+  });
+
+  it('resolves a relative nextPage href against the client base URL instead of throwing', async () => {
+    // A bare `new URL(href)` on a relative href throws a TypeError. This is
+    // the exact shape the vendored library's own reference pager guards
+    // against with try/catch.
+    const mockFetch = vi.fn().mockResolvedValue(
+      mockResponse({
+        json: () =>
+          Promise.resolve({
+            items: [{ a: 1 }],
+            metadata: { totalRemainingItems: 1 },
+            links: [{ rel: 'nextPage', href: '/service/api/x?bookmark=rel-bookmark' }],
+          }),
+      }),
+    );
+    const result = await fetchPage(client(mockFetch), '/x', {}, undefined);
+    expect(result.cursor).toBe('rel-bookmark');
+  });
+
+  it('maps a supplied cursor onto the bookmark query param of the request', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(mockResponse({ json: () => Promise.resolve({ items: [] }) }));
+    await fetchPage(client(mockFetch), '/x', { folderId: 'f1' }, 'my-cursor');
+    const calledUrl = new URL(mockFetch.mock.calls[0][0] as string);
+    expect(calledUrl.searchParams.get('bookmark')).toBe('my-cursor');
+    expect(calledUrl.searchParams.get('folderId')).toBe('f1');
+  });
+
+  it('throws when a nextPage link has no bookmark, instead of silently ending the listing', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      mockResponse({
+        json: () =>
+          Promise.resolve({
+            items: [{ a: 1 }],
+            metadata: { totalRemainingItems: 1 },
+            links: [{ rel: 'nextPage', href: 'https://node1.field.dalux.com/service/api/x' }],
+          }),
+      }),
+    );
+    await expect(fetchPage(client(mockFetch), '/x', {}, undefined)).rejects.toThrow(DaluxPaginationError);
+  });
+
+  it('throws when the nextPage bookmark echoes the one just requested', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      mockResponse({
+        json: () =>
+          Promise.resolve({
+            items: [{ a: 1 }],
+            metadata: { totalRemainingItems: 1 },
+            links: [{ rel: 'nextPage', href: 'https://node1.field.dalux.com/service/api/x?bookmark=same' }],
+          }),
+      }),
+    );
+    await expect(fetchPage(client(mockFetch), '/x', {}, 'same')).rejects.toThrow(DaluxPaginationError);
+  });
+
+  it('throws when metadata reports remaining items but sends no nextPage link', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      mockResponse({
+        json: () => Promise.resolve({ items: [{ a: 1 }], metadata: { totalRemainingItems: 5 }, links: [] }),
+      }),
+    );
+    await expect(fetchPage(client(mockFetch), '/x', {}, undefined)).rejects.toThrow(DaluxPaginationError);
+  });
+
+  it('follows a nextPage link on an empty page instead of throwing (bookmark pager can signal "keep going" on an empty page)', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      mockResponse({
+        json: () =>
+          Promise.resolve({
+            items: [],
+            links: [{ rel: 'nextPage', href: 'https://node1.field.dalux.com/service/api/x?bookmark=b2' }],
+          }),
+      }),
+    );
+    const result = await fetchPage(client(mockFetch), '/x', {}, undefined);
+    expect(result.items).toEqual([]);
+    expect(result.cursor).toBe('b2');
+  });
+
+  it('follows a nextPage link when totalRemainingItems is 0 instead of throwing', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      mockResponse({
+        json: () =>
+          Promise.resolve({
+            items: [],
+            metadata: { totalRemainingItems: 0 },
+            links: [{ rel: 'nextPage', href: 'https://node1.field.dalux.com/service/api/x?bookmark=zz' }],
+          }),
+      }),
+    );
+    const result = await fetchPage(client(mockFetch), '/x', {}, undefined);
+    expect(result.items).toEqual([]);
+    expect(result.cursor).toBe('zz');
+  });
+
+  it('follows a nextPage link on a non-empty page even when totalRemainingItems is 0', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      mockResponse({
+        json: () =>
+          Promise.resolve({
+            items: [{ a: 1 }],
+            metadata: { totalRemainingItems: 0 },
+            links: [{ rel: 'nextPage', href: 'https://node1.field.dalux.com/service/api/x?bookmark=zz' }],
+          }),
+      }),
+    );
+    const result = await fetchPage(client(mockFetch), '/x', {}, undefined);
+    expect(result.items).toEqual([{ a: 1 }]);
+    expect(result.cursor).toBe('zz');
+  });
+
+  it('truncates an upstream error body to ~200 chars instead of putting the whole thing in the thrown message', async () => {
+    const longBody = 'x'.repeat(5000);
+    const mockFetch = vi.fn().mockResolvedValue(
+      mockResponse({ ok: false, status: 500, statusText: 'Internal Server Error', text: () => Promise.resolve(longBody) }),
+    );
+    await expect(fetchPage(client(mockFetch), '/x', {}, undefined)).rejects.toThrow(
+      /Dalux API 500: Internal Server Error/,
+    );
+    try {
+      await fetchPage(client(mockFetch), '/x', {}, undefined);
+      expect.unreachable();
+    } catch (err) {
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).message.length).toBeLessThan(250);
+    }
+  });
+
+  it('threads an AbortSignal through to the underlying fetch', async () => {
+    const controller = new AbortController();
+    const mockFetch = vi.fn().mockResolvedValue(mockResponse({ json: () => Promise.resolve({ items: [] }) }));
+    await fetchPage(client(mockFetch), '/x', {}, undefined, controller.signal);
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ signal: controller.signal }),
+    );
+  });
+});
+
+describe('fetchAllPages', () => {
+  it('follows every page and concatenates all items', async () => {
+    const mockFetch = vi.fn().mockImplementation((url: string) => {
+      const bookmark = new URL(url).searchParams.get('bookmark');
+      if (!bookmark) {
+        return Promise.resolve(
+          mockResponse({
+            json: () =>
+              Promise.resolve({
+                items: [{ id: 1 }],
+                metadata: { totalRemainingItems: 1 },
+                links: [{ rel: 'nextPage', href: `${url}?bookmark=page2` }],
+              }),
+          }),
+        );
+      }
+      if (bookmark === 'page2') {
+        return Promise.resolve(
+          mockResponse({ json: () => Promise.resolve({ items: [{ id: 2 }], metadata: { totalRemainingItems: 0 } }) }),
+        );
+      }
+      return Promise.resolve(mockResponse({ json: () => Promise.resolve({ items: [] }) }));
+    });
+
+    const items = await fetchAllPages(client(mockFetch), '/x');
+    expect(items).toEqual([{ id: 1 }, { id: 2 }]);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws when a bookmark reappears later in the sweep, not just on the immediately preceding page', async () => {
+    // page1 -> bookmark "a", page2 (bookmark=a) -> bookmark "b", page3
+    // (bookmark=b) -> bookmark "a" again. fetchPage's own immediate-echo
+    // check can't see this (the echoed value is two hops back, not one),
+    // so this specifically exercises fetchAllPages' own seenBookmarks set.
+    const mockFetch = vi.fn().mockImplementation((url: string) => {
+      const bookmark = new URL(url).searchParams.get('bookmark');
+      const next = bookmark === null ? 'a' : bookmark === 'a' ? 'b' : 'a';
+      return Promise.resolve(
+        mockResponse({
+          json: () =>
+            Promise.resolve({
+              items: [{ bookmark }],
+              metadata: { totalRemainingItems: 1 },
+              links: [{ rel: 'nextPage', href: `${url.split('?')[0]}?bookmark=${next}` }],
+            }),
+        }),
+      );
+    });
+
+    await expect(fetchAllPages(client(mockFetch), '/x')).rejects.toThrow(DaluxPaginationError);
+  });
+
+  it('enforces a hard page cap instead of looping forever on endlessly fresh bookmarks', async () => {
+    let counter = 0;
+    const mockFetch = vi.fn().mockImplementation((url: string) => {
+      counter += 1;
+      const next = `bm-${counter}`;
+      return Promise.resolve(
+        mockResponse({
+          json: () =>
+            Promise.resolve({
+              items: [{ n: counter }],
+              metadata: { totalRemainingItems: 1 },
+              links: [{ rel: 'nextPage', href: `${url.split('?')[0]}?bookmark=${next}` }],
+            }),
+        }),
+      );
+    });
+
+    await expect(fetchAllPages(client(mockFetch), '/x')).rejects.toThrow(DaluxPaginationError);
+    expect(mockFetch).toHaveBeenCalledTimes(1000);
+  });
+
+  it('stops cleanly (no throw) when a page has no items', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(mockResponse({ json: () => Promise.resolve({ items: [] }) }));
+    const items = await fetchAllPages(client(mockFetch), '/x');
+    expect(items).toEqual([]);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/source-dalux/test/mapping.test.ts
+++ b/packages/source-dalux/test/mapping.test.ts
@@ -1,0 +1,158 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { Logger, PluginContext } from '@ifc-lite/plugin-api';
+import {
+  LATEST_REVISION,
+  convertListLenient,
+  currentRevisionId,
+  decodeContainerId,
+  fileAreaContainerId,
+  folderContainerId,
+  toSourceFile,
+} from '../src/mapping.js';
+import type { DaluxFile } from '../src/dalux-types.js';
+
+function createMockLogger(): Logger {
+  return { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+function createMockCtx(): PluginContext {
+  return {
+    fetch: vi.fn() as unknown as typeof fetch,
+    fetchPublic: vi.fn() as unknown as PluginContext['fetchPublic'],
+    getPreference: vi.fn(() => Promise.resolve(undefined)),
+    storage: {
+      get: vi.fn(() => Promise.resolve(undefined)),
+      set: vi.fn(() => Promise.resolve()),
+      delete: vi.fn(() => Promise.resolve()),
+      keys: vi.fn(() => Promise.resolve([])),
+    },
+    log: createMockLogger(),
+  };
+}
+
+function daluxFile(overrides: Partial<DaluxFile> = {}): DaluxFile {
+  return {
+    fileId: 'f1',
+    fileName: 'model.ifc',
+    fileAreaId: 'fa1',
+    deleted: false,
+    ...overrides,
+  };
+}
+
+describe('container id encoding', () => {
+  it('round-trips a file-area-only container id', () => {
+    const id = fileAreaContainerId('fa1');
+    expect(decodeContainerId(id)).toEqual({ fileAreaId: 'fa1' });
+  });
+
+  it('round-trips a folder container id', () => {
+    const id = folderContainerId('fa1', 'folder-a');
+    expect(decodeContainerId(id)).toEqual({ fileAreaId: 'fa1', folderId: 'folder-a' });
+  });
+});
+
+describe('toSourceFile', () => {
+  it('uses the real fileRevisionId as currentRevisionId when present', () => {
+    const file = toSourceFile('fa1', daluxFile({ fileRevisionId: 'rev-7' }));
+    expect(file.currentRevisionId).toBe('rev-7');
+  });
+
+  it('falls back to the explicit LATEST_REVISION sentinel rather than faking one from fileId', () => {
+    const file = toSourceFile('fa1', daluxFile({ fileRevisionId: null }));
+    expect(file.currentRevisionId).toBe(LATEST_REVISION);
+    expect(file.currentRevisionId).not.toBe(file.id);
+  });
+
+  it('falls back to contentHash when fileRevisionId is absent, giving a stable non-sentinel id', () => {
+    const file = toSourceFile('fa1', daluxFile({ fileRevisionId: undefined, contentHash: 'hash-abc' }));
+    expect(file.currentRevisionId).toBe('hash-abc');
+    expect(file.currentRevisionId).not.toBe(LATEST_REVISION);
+  });
+
+  it('prefers a real fileRevisionId over contentHash when both are present', () => {
+    const file = toSourceFile('fa1', daluxFile({ fileRevisionId: 'rev-7', contentHash: 'hash-abc' }));
+    expect(file.currentRevisionId).toBe('rev-7');
+  });
+
+  it('only falls back to LATEST_REVISION when neither fileRevisionId nor contentHash is present', () => {
+    const file = toSourceFile('fa1', daluxFile({ fileRevisionId: undefined, contentHash: undefined }));
+    expect(file.currentRevisionId).toBe(LATEST_REVISION);
+  });
+
+  it('treats an empty-string fileRevisionId the same as absent, falling through to contentHash', () => {
+    // A "" cached as the revision id would fail `cached &&` checks
+    // downstream and silently swallow the first real transition away from
+    // it — normalising here at the source prevents that.
+    const file = toSourceFile('fa1', daluxFile({ fileRevisionId: '', contentHash: 'hash-xyz' }));
+    expect(file.currentRevisionId).toBe('hash-xyz');
+  });
+
+  it('treats an empty-string fileRevisionId as absent even with no contentHash to fall back to', () => {
+    const file = toSourceFile('fa1', daluxFile({ fileRevisionId: '', contentHash: undefined }));
+    expect(file.currentRevisionId).toBe(LATEST_REVISION);
+  });
+
+  it('places a folder-owned file under the composite folder container id', () => {
+    const file = toSourceFile('fa1', daluxFile({ folderId: 'folder-a' }));
+    expect(file.containerId).toBe(folderContainerId('fa1', 'folder-a'));
+  });
+
+  it('places a root file directly under the file area container id', () => {
+    const file = toSourceFile('fa1', daluxFile({ folderId: null }));
+    expect(file.containerId).toBe(fileAreaContainerId('fa1'));
+  });
+});
+
+interface Thing {
+  readonly id: string;
+  readonly name: string;
+}
+
+/** Stand-in decoder, so these tests exercise the drop-invalid-records
+ * behavior itself rather than any particular type's field rules (those are
+ * covered in dalux-types.test.ts). */
+function decodeThing(value: unknown): Thing {
+  const record = value && typeof value === 'object' ? (value as Record<string, unknown>) : undefined;
+  if (!record || typeof record.id !== 'string' || typeof record.name !== 'string') {
+    throw new Error('invalid Thing');
+  }
+  return { id: record.id, name: record.name };
+}
+
+describe('convertListLenient', () => {
+  const schema = decodeThing;
+
+  it('keeps every record that validates', () => {
+    const ctx = createMockCtx();
+    const result = convertListLenient(ctx, [{ id: '1', name: 'a' }, { id: '2', name: 'b' }], schema, 'Thing');
+    expect(result).toEqual([{ id: '1', name: 'a' }, { id: '2', name: 'b' }]);
+    expect(ctx.log.warn).not.toHaveBeenCalled();
+  });
+
+  it('drops an invalid record with a logged warning instead of throwing and losing every record', () => {
+    const ctx = createMockCtx();
+    const result = convertListLenient(
+      ctx,
+      [{ id: '1', name: 'a' }, { id: '2' /* missing name */ }, { id: '3', name: 'c' }],
+      schema,
+      'Thing',
+    );
+    expect(result).toEqual([{ id: '1', name: 'a' }, { id: '3', name: 'c' }]);
+    expect(ctx.log.warn).toHaveBeenCalledOnce();
+    expect(ctx.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Thing'),
+      expect.objectContaining({ error: expect.any(String) }),
+    );
+  });
+
+  it('unwraps a Dalux `{ data }` envelope before validating', () => {
+    const ctx = createMockCtx();
+    const result = convertListLenient(ctx, [{ data: { id: '1', name: 'a' } }], schema, 'Thing');
+    expect(result).toEqual([{ id: '1', name: 'a' }]);
+  });
+});

--- a/packages/source-dalux/test/provider.test.ts
+++ b/packages/source-dalux/test/provider.test.ts
@@ -1,0 +1,670 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { PluginContext, KeyValueStore, Logger } from '@ifc-lite/plugin-api';
+import { PLUGIN_API_VERSION, satisfiesCaretRange } from '@ifc-lite/plugin-api';
+import { DaluxBuildProvider } from '../src/provider.js';
+import { LATEST_REVISION, fileAreaContainerId, folderContainerId } from '../src/mapping.js';
+
+function createMockStorage(): KeyValueStore {
+  const store = new Map<string, string>();
+  return {
+    get: vi.fn((key: string) => Promise.resolve(store.get(key))),
+    set: vi.fn((key: string, value: string) => {
+      store.set(key, value);
+      return Promise.resolve();
+    }),
+    delete: vi.fn((key: string) => {
+      store.delete(key);
+      return Promise.resolve();
+    }),
+    keys: vi.fn(() => Promise.resolve([...store.keys()])),
+  };
+}
+
+function createMockLogger(): Logger {
+  return { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+function createMockCtx(
+  fetchImpl: typeof fetch,
+  preferences: Record<string, string> = { apiKey: 'test-key-123' },
+): PluginContext {
+  return {
+    fetch: fetchImpl,
+    fetchPublic: vi.fn(() => Promise.reject(new Error('fetchPublic not used in these tests'))),
+    getPreference: vi.fn((name: string) => Promise.resolve(preferences[name])),
+    storage: createMockStorage(),
+    log: createMockLogger(),
+  };
+}
+
+function mockResponse(overrides: Record<string, unknown> = {}) {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    headers: { get: () => null },
+    json: () => Promise.resolve(undefined),
+    text: () => Promise.resolve(''),
+    ...overrides,
+  };
+}
+
+describe('DaluxBuildProvider', () => {
+  let provider: DaluxBuildProvider;
+
+  beforeEach(() => {
+    provider = new DaluxBuildProvider();
+  });
+
+  it('exposes a manifest that satisfies the host contract version', () => {
+    expect(provider.manifest.name).toBe('dalux-build');
+    expect(provider.manifest.title).toBe('Dalux Box');
+    expect(satisfiesCaretRange(PLUGIN_API_VERSION, provider.manifest.api)).toBe(true);
+    expect(provider.manifest.auth).toBe('preferences');
+    expect(provider.manifest.permissions.network).toContain('*.dalux.com');
+  });
+
+  it('declares an honest relay and capabilities block', () => {
+    expect(provider.manifest.permissions.relay).toEqual({
+      upstream: 'https://node1.field.dalux.com/service/api',
+      path: '/api/dalux',
+    });
+    expect(provider.manifest.capabilities).toEqual({
+      containerListing: 'flat-subtree',
+      listFilesIsRecursive: true,
+      revisionHistory: false,
+      downloadHistoricalRevisions: true,
+      changeDetection: true,
+      search: false,
+    });
+  });
+
+  it('declares only the apiKey preference', () => {
+    const prefs = provider.manifest.preferences;
+    expect(prefs.find((p) => p.name === 'apiKey')?.required).toBe(true);
+    expect(prefs.find((p) => p.name === 'baseUrl')).toBeUndefined();
+  });
+
+  describe('listProjects', () => {
+    it('maps Dalux projects to a Page<SourceProject> and pages one call at a time', async () => {
+      const mockFetch = vi.fn().mockResolvedValue(
+        mockResponse({
+          json: () =>
+            Promise.resolve({
+              items: [
+                { data: { projectId: 'p1', projectName: 'Project Alpha' } },
+                { data: { projectId: 'p2', projectName: 'Project Beta' } },
+              ],
+              metadata: { totalRemainingItems: 5 },
+              links: [{ rel: 'nextPage', href: 'https://node1.field.dalux.com/service/api/5.1/projects?bookmark=p3' }],
+            }),
+        }),
+      );
+
+      const ctx = createMockCtx(mockFetch as unknown as typeof fetch);
+      const page = await provider.listProjects(ctx);
+
+      expect(page.items).toEqual([
+        { id: 'p1', name: 'Project Alpha' },
+        { id: 'p2', name: 'Project Beta' },
+      ]);
+      expect(page.cursor).toBe('p3');
+      // One HTTP call per page, not an eager crawl of the whole tenant.
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://node1.field.dalux.com/service/api/5.1/projects',
+        expect.objectContaining({ headers: expect.objectContaining({ 'X-API-KEY': 'test-key-123' }) }),
+      );
+    });
+
+    it('drops an individually invalid project record instead of failing the whole page', async () => {
+      const mockFetch = vi.fn().mockResolvedValue(
+        mockResponse({
+          json: () =>
+            Promise.resolve({
+              items: [
+                { data: { projectId: 'p1', projectName: 'Good' } },
+                { data: { projectId: 'p2' /* missing projectName */ } },
+              ],
+            }),
+        }),
+      );
+
+      const ctx = createMockCtx(mockFetch as unknown as typeof fetch);
+      const page = await provider.listProjects(ctx);
+
+      expect(page.items).toEqual([{ id: 'p1', name: 'Good' }]);
+      expect(ctx.log.warn).toHaveBeenCalled();
+    });
+
+    it('throws when API key is not configured', async () => {
+      const mockFetch = vi.fn();
+      const ctx = createMockCtx(mockFetch as unknown as typeof fetch, {});
+
+      await expect(provider.listProjects(ctx)).rejects.toThrow('Dalux API key not configured');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('listContainers', () => {
+    it('returns only file areas at the top level, without walking folders', async () => {
+      const mockFetch = vi.fn().mockImplementation((url: string) => {
+        if (url.endsWith('/5.1/projects/proj1/file_areas')) {
+          return Promise.resolve(
+            mockResponse({
+              json: () =>
+                Promise.resolve({ items: [{ data: { fileAreaId: 'fa1', fileAreaName: 'Area', fileAreaType: 'Files' } }] }),
+            }),
+          );
+        }
+        return Promise.resolve(mockResponse({ json: () => Promise.resolve([]) }));
+      });
+
+      const ctx = createMockCtx(mockFetch as unknown as typeof fetch);
+      const page = await provider.listContainers(ctx, 'proj1');
+
+      expect(page.items).toEqual([{ id: 'fa1', name: 'Area', meta: { kind: 'file-area' } }]);
+      expect(mockFetch).not.toHaveBeenCalledWith(expect.stringContaining('/folders'), expect.any(Object));
+    });
+
+    it('rebuilds the folder hierarchy under a composite container id when scoped to a file area', async () => {
+      const mockFetch = vi.fn().mockImplementation((url: string) => {
+        if (url.endsWith('/5.1/projects/proj1/file_areas/fa1/folders')) {
+          return Promise.resolve(
+            mockResponse({
+              json: () =>
+                Promise.resolve({
+                  items: [
+                    { data: { folderId: 'root-folder', folderName: 'Root Folder' } },
+                    { data: { folderId: 'nested-folder', folderName: 'Nested Folder', parentFolderId: 'root-folder' } },
+                  ],
+                }),
+            }),
+          );
+        }
+        return Promise.resolve(mockResponse({ json: () => Promise.resolve([]) }));
+      });
+
+      const ctx = createMockCtx(mockFetch as unknown as typeof fetch);
+      const page = await provider.listContainers(ctx, 'proj1', fileAreaContainerId('fa1'));
+
+      const rootFolderId = folderContainerId('fa1', 'root-folder');
+      const nestedFolderId = folderContainerId('fa1', 'nested-folder');
+      expect(page.items.map((c) => c.id)).toEqual([rootFolderId, nestedFolderId]);
+      expect(page.items.find((c) => c.id === rootFolderId)?.parentId).toBe(fileAreaContainerId('fa1'));
+      expect(page.items.find((c) => c.id === nestedFolderId)?.parentId).toBe(rootFolderId);
+    });
+
+    it('still finds folders when the endpoint responds with a bare array instead of { items }', async () => {
+      const mockFetch = vi.fn().mockImplementation((url: string) => {
+        if (url.endsWith('/5.1/projects/proj1/file_areas/fa1/folders')) {
+          return Promise.resolve(
+            mockResponse({ json: () => Promise.resolve([{ data: { folderId: 'root-folder', folderName: 'Root Folder' } }]) }),
+          );
+        }
+        return Promise.resolve(mockResponse({ json: () => Promise.resolve([]) }));
+      });
+
+      const ctx = createMockCtx(mockFetch as unknown as typeof fetch);
+      const page = await provider.listContainers(ctx, 'proj1', fileAreaContainerId('fa1'));
+      expect(page.items.map((c) => c.id)).toEqual([folderContainerId('fa1', 'root-folder')]);
+    });
+
+    it('treats blank parentFolderId values as file-area-root folders', async () => {
+      const mockFetch = vi.fn().mockImplementation((url: string) => {
+        if (url.endsWith('/5.1/projects/proj1/file_areas/fa1/folders')) {
+          return Promise.resolve(
+            mockResponse({
+              json: () =>
+                Promise.resolve({ items: [{ data: { folderId: 'root-folder', folderName: 'Root Folder', parentFolderId: '' } }] }),
+            }),
+          );
+        }
+        return Promise.resolve(mockResponse({ json: () => Promise.resolve([]) }));
+      });
+
+      const ctx = createMockCtx(mockFetch as unknown as typeof fetch);
+      const page = await provider.listContainers(ctx, 'proj1', fileAreaContainerId('fa1'));
+
+      expect(page.items).toEqual([
+        {
+          id: folderContainerId('fa1', 'root-folder'),
+          name: 'Root Folder',
+          parentId: fileAreaContainerId('fa1'),
+          meta: { kind: 'folder', fileAreaId: 'fa1' },
+        },
+      ]);
+    });
+
+    it('reattaches folders whose parent points at an unseen Dalux root folder', async () => {
+      const mockFetch = vi.fn().mockImplementation((url: string) => {
+        if (url.endsWith('/5.1/projects/proj1/file_areas/fa1/folders')) {
+          return Promise.resolve(
+            mockResponse({
+              json: () =>
+                Promise.resolve({
+                  items: [
+                    { data: { folderId: 'top-folder', folderName: 'Top Folder', parentFolderId: 'hidden-root-folder' } },
+                    { data: { folderId: 'child-folder', folderName: 'Child Folder', parentFolderId: 'top-folder' } },
+                  ],
+                }),
+            }),
+          );
+        }
+        return Promise.resolve(mockResponse({ json: () => Promise.resolve([]) }));
+      });
+
+      const ctx = createMockCtx(mockFetch as unknown as typeof fetch);
+      const page = await provider.listContainers(ctx, 'proj1', fileAreaContainerId('fa1'));
+
+      expect(page.items).toEqual([
+        {
+          id: folderContainerId('fa1', 'top-folder'),
+          name: 'Top Folder',
+          parentId: fileAreaContainerId('fa1'),
+          meta: { kind: 'folder', fileAreaId: 'fa1' },
+        },
+        {
+          id: folderContainerId('fa1', 'child-folder'),
+          name: 'Child Folder',
+          parentId: folderContainerId('fa1', 'top-folder'),
+          meta: { kind: 'folder', fileAreaId: 'fa1' },
+        },
+      ]);
+    });
+  });
+
+  describe('listFiles', () => {
+    it('keeps folder selection scoped but lets a file area surface descendant files', async () => {
+      const mockFetch = vi.fn().mockImplementation((url: string) => {
+        if (url.includes('/6.1/projects/proj1/file_areas/fa1/files')) {
+          return Promise.resolve(
+            mockResponse({
+              json: () =>
+                Promise.resolve({
+                  items: [
+                    { data: { fileId: 'root-file', fileName: 'root.ifc', fileAreaId: 'fa1' } },
+                    { data: { fileId: 'in-folder', fileName: 'folder.ifc', fileAreaId: 'fa1', folderId: 'folder-a' } },
+                  ],
+                }),
+            }),
+          );
+        }
+        return Promise.resolve(mockResponse({ json: () => Promise.resolve([]) }));
+      });
+
+      const ctx = createMockCtx(mockFetch as unknown as typeof fetch);
+
+      const folderFiles = await provider.listFiles(ctx, 'proj1', folderContainerId('fa1', 'folder-a'));
+      expect(folderFiles.items.map((f) => f.id)).toEqual(['in-folder']);
+
+      const areaFiles = await provider.listFiles(ctx, 'proj1', fileAreaContainerId('fa1'));
+      expect(areaFiles.items.map((f) => f.id)).toEqual(['root-file', 'in-folder']);
+    });
+
+    it('applies namePatterns using the shared glob matcher', async () => {
+      const mockFetch = vi.fn().mockResolvedValue(
+        mockResponse({
+          json: () =>
+            Promise.resolve({
+              items: [
+                { data: { fileId: 'f1', fileName: 'model.IFC', fileAreaId: 'fa1' } },
+                { data: { fileId: 'f2', fileName: 'a.ifc.bak', fileAreaId: 'fa1' } },
+                { data: { fileId: 'f3', fileName: 'plan(1).ifc', fileAreaId: 'fa1' } },
+                { data: { fileId: 'f4', fileName: 'a+b.ifc', fileAreaId: 'fa1' } },
+                { data: { fileId: 'f5', fileName: 'ab.ifc', fileAreaId: 'fa1' } },
+              ],
+            }),
+        }),
+      );
+
+      const ctx = createMockCtx(mockFetch as unknown as typeof fetch);
+      const page = await provider.listFiles(ctx, 'proj1', fileAreaContainerId('fa1'), {
+        namePatterns: ['*.ifc'],
+      });
+
+      // model.IFC matches case-insensitively; a.ifc.bak does not (the
+      // pattern is anchored, so a trailing ".bak" excludes it); the
+      // parenthesis/plus in plan(1).ifc and a+b.ifc are just literal
+      // characters here, not regex syntax, so both still end in ".ifc" and
+      // match the wildcard like any other name would.
+      expect(page.items.map((f) => f.id).sort()).toEqual(['f1', 'f3', 'f4', 'f5']);
+
+      // Used as literal patterns (no wildcard), the parenthesis/plus must
+      // NOT be interpreted as regex metacharacters: "a+b.ifc" as a raw
+      // regex would also match "ab.ifc" (`+` meaning "one or more of the
+      // preceding character"), but as a literal it must match only the
+      // exact name.
+      const literalMatch = await provider.listFiles(ctx, 'proj1', fileAreaContainerId('fa1'), {
+        namePatterns: ['plan(1).ifc', 'a+b.ifc'],
+      });
+      expect(literalMatch.items.map((f) => f.id).sort()).toEqual(['f3', 'f4']);
+    });
+
+    it('threads an AbortSignal through to the underlying request', async () => {
+      const controller = new AbortController();
+      const mockFetch = vi.fn().mockResolvedValue(mockResponse({ json: () => Promise.resolve({ items: [] }) }));
+      const ctx = createMockCtx(mockFetch as unknown as typeof fetch);
+
+      await provider.listFiles(ctx, 'proj1', fileAreaContainerId('fa1'), undefined, { signal: controller.signal });
+
+      expect(mockFetch).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ signal: controller.signal }));
+    });
+  });
+
+  describe('download', () => {
+    it('downloads a specific revision directly when the ref carries a real revisionId', async () => {
+      const mockFetch = vi.fn().mockResolvedValue(mockResponse({ arrayBuffer: () => Promise.resolve(new ArrayBuffer(4)) }));
+      const ctx = createMockCtx(mockFetch as unknown as typeof fetch);
+
+      await provider.download(ctx, {
+        projectId: 'proj1',
+        containerId: fileAreaContainerId('fa1'),
+        fileId: 'f1',
+        revisionId: 'rev-9',
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://node1.field.dalux.com/service/api/2.0/projects/proj1/file_areas/fa1/files/f1/revisions/rev-9/content',
+        expect.any(Object),
+      );
+    });
+
+    it('falls back to the metadata + downloadLink path when revisionId is omitted', async () => {
+      const mockFetch = vi.fn().mockImplementation((url: string) => {
+        if (url.includes('/5.0/projects/proj1/file_areas/fa1/files/f1')) {
+          return Promise.resolve(
+            mockResponse({ json: () => Promise.resolve({ data: { fileId: 'f1', fileName: 'a.ifc', fileAreaId: 'fa1', deleted: false, downloadLink: 'https://cdn.dalux.com/x' } }) }),
+          );
+        }
+        if (url === 'https://cdn.dalux.com/x') {
+          return Promise.resolve(mockResponse({ arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)) }));
+        }
+        throw new Error(`unexpected url ${url}`);
+      });
+      const ctx = createMockCtx(mockFetch as unknown as typeof fetch);
+
+      const buf = await provider.download(ctx, { projectId: 'proj1', containerId: fileAreaContainerId('fa1'), fileId: 'f1' });
+      expect(buf.byteLength).toBe(8);
+    });
+
+    it('treats the LATEST_REVISION sentinel the same as an omitted revisionId, never hitting /revisions/.../content', async () => {
+      const mockFetch = vi.fn().mockImplementation((url: string) => {
+        if (url.includes('/revisions/')) throw new Error('should never call the revisions endpoint for the sentinel');
+        if (url.includes('/5.0/projects/proj1/file_areas/fa1/files/f1')) {
+          return Promise.resolve(
+            mockResponse({ json: () => Promise.resolve({ data: { fileId: 'f1', fileName: 'a.ifc', fileAreaId: 'fa1', deleted: false, downloadLink: 'https://cdn.dalux.com/x' } }) }),
+          );
+        }
+        return Promise.resolve(mockResponse({ arrayBuffer: () => Promise.resolve(new ArrayBuffer(1)) }));
+      });
+      const ctx = createMockCtx(mockFetch as unknown as typeof fetch);
+
+      await provider.download(ctx, { projectId: 'proj1', containerId: fileAreaContainerId('fa1'), fileId: 'f1', revisionId: LATEST_REVISION });
+      expect(mockFetch).toHaveBeenCalled();
+    });
+
+    it('does NOT reroute a real revision id that happens to be the plain string "latest" (sentinel collision guard)', async () => {
+      // The sentinel deliberately isn't the plain string "latest" — a file
+      // legitimately versioned with that literal label must still be
+      // fetched from /revisions/.../content, not silently redirected to
+      // "current bytes" as if no revision id had been given at all.
+      const mockFetch = vi.fn().mockResolvedValue(mockResponse({ arrayBuffer: () => Promise.resolve(new ArrayBuffer(4)) }));
+      const ctx = createMockCtx(mockFetch as unknown as typeof fetch);
+
+      await provider.download(ctx, {
+        projectId: 'proj1',
+        containerId: fileAreaContainerId('fa1'),
+        fileId: 'f1',
+        revisionId: 'latest',
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/revisions/latest/content'),
+        expect.any(Object),
+      );
+    });
+
+    it('builds the revision-content URL from the client base URL, not a separate constant', async () => {
+      const mockFetch = vi.fn().mockResolvedValue(mockResponse({ arrayBuffer: () => Promise.resolve(new ArrayBuffer(4)) }));
+      const ctx = createMockCtx(mockFetch as unknown as typeof fetch);
+
+      await provider.download(ctx, {
+        projectId: 'proj1',
+        containerId: fileAreaContainerId('fa1'),
+        fileId: 'f1',
+        revisionId: 'rev-9',
+      });
+
+      const [calledUrl] = mockFetch.mock.calls[0] as [string];
+      expect(calledUrl.startsWith(provider.manifest.permissions.relay!.upstream)).toBe(true);
+    });
+
+    it('throws when the file exposes no download link', async () => {
+      const mockFetch = vi.fn().mockResolvedValue(
+        mockResponse({ json: () => Promise.resolve({ data: { fileId: 'f1', fileName: 'a.ifc', fileAreaId: 'fa1', deleted: false } }) }),
+      );
+      const ctx = createMockCtx(mockFetch as unknown as typeof fetch);
+
+      await expect(
+        provider.download(ctx, { projectId: 'proj1', containerId: fileAreaContainerId('fa1'), fileId: 'f1' }),
+      ).rejects.toThrow('does not expose a download link');
+    });
+  });
+
+  describe('watchRevisions', () => {
+    it('detects a new revision, grouping refs from the same file area into a single sweep', async () => {
+      let filesCalls = 0;
+      const mockFetch = vi.fn().mockImplementation((url: string) => {
+        if (url.includes('/6.1/projects/proj1/file_areas/fa1/files')) {
+          filesCalls += 1;
+          return Promise.resolve(
+            mockResponse({
+              json: () =>
+                Promise.resolve({
+                  items: [
+                    { data: { fileId: 'f1', fileName: 'a.ifc', fileAreaId: 'fa1', fileRevisionId: 'rev-2', deleted: false } },
+                    { data: { fileId: 'f2', fileName: 'b.ifc', fileAreaId: 'fa1', fileRevisionId: 'rev-1', deleted: false } },
+                  ],
+                }),
+            }),
+          );
+        }
+        return Promise.resolve(mockResponse({ json: () => Promise.resolve({ items: [] }) }));
+      });
+
+      const ctx = createMockCtx(mockFetch as unknown as typeof fetch);
+      await ctx.storage.set('rev:proj1:fa1:f1', 'rev-1');
+      await ctx.storage.set('rev:proj1:fa1:f2', 'rev-1');
+
+      const result = await provider.watchRevisions(ctx, [
+        { projectId: 'proj1', containerId: fileAreaContainerId('fa1'), fileId: 'f1' },
+        { projectId: 'proj1', containerId: folderContainerId('fa1', 'folder-a'), fileId: 'f2' },
+      ]);
+
+      expect(result.events).toEqual([{ fileId: 'f1', latestRevisionId: 'rev-2', previousRevisionId: 'rev-1' }]);
+      expect(filesCalls).toBe(1);
+      expect(result.cursor).toBeUndefined();
+    });
+
+    it('reports a deleted event when a tracked file no longer appears', async () => {
+      const mockFetch = vi.fn().mockResolvedValue(mockResponse({ json: () => Promise.resolve({ items: [] }) }));
+      const ctx = createMockCtx(mockFetch as unknown as typeof fetch);
+      await ctx.storage.set('rev:proj1:fa1:gone', 'rev-1');
+
+      const result = await provider.watchRevisions(ctx, [
+        { projectId: 'proj1', containerId: fileAreaContainerId('fa1'), fileId: 'gone' },
+      ]);
+
+      expect(result.events).toEqual([{ fileId: 'gone', latestRevisionId: LATEST_REVISION, deleted: true }]);
+    });
+
+    it('watches a contentHash-only file for changes even though it has no fileRevisionId', async () => {
+      const mockFetch = vi.fn().mockResolvedValue(
+        mockResponse({
+          json: () =>
+            Promise.resolve({
+              items: [
+                { data: { fileId: 'f1', fileName: 'a.ifc', fileAreaId: 'fa1', contentHash: 'hash-2', deleted: false } },
+              ],
+            }),
+        }),
+      );
+      const ctx = createMockCtx(mockFetch as unknown as typeof fetch);
+      await ctx.storage.set('rev:proj1:fa1:f1', 'hash-1');
+
+      const result = await provider.watchRevisions(ctx, [
+        { projectId: 'proj1', containerId: fileAreaContainerId('fa1'), fileId: 'f1' },
+      ]);
+
+      expect(result.events).toEqual([{ fileId: 'f1', latestRevisionId: 'hash-2', previousRevisionId: 'hash-1' }]);
+    });
+
+    it('does not falsely emit an event for a contentHash-only file whose hash has not changed', async () => {
+      const mockFetch = vi.fn().mockResolvedValue(
+        mockResponse({
+          json: () =>
+            Promise.resolve({
+              items: [
+                { data: { fileId: 'f1', fileName: 'a.ifc', fileAreaId: 'fa1', contentHash: 'hash-1', deleted: false } },
+              ],
+            }),
+        }),
+      );
+      const ctx = createMockCtx(mockFetch as unknown as typeof fetch);
+      await ctx.storage.set('rev:proj1:fa1:f1', 'hash-1');
+
+      const result = await provider.watchRevisions(ctx, [
+        { projectId: 'proj1', containerId: fileAreaContainerId('fa1'), fileId: 'f1' },
+      ]);
+
+      expect(result.events).toEqual([]);
+    });
+
+    it('isolates a failed area sweep: other areas still report events instead of the whole call rejecting', async () => {
+      const mockFetch = vi.fn().mockImplementation((url: string) => {
+        if (url.includes('/file_areas/fa-broken/')) {
+          return Promise.reject(new Error('Dalux API 404: Not Found — file area deleted'));
+        }
+        if (url.includes('/file_areas/fa-ok/')) {
+          return Promise.resolve(
+            mockResponse({
+              json: () =>
+                Promise.resolve({
+                  items: [{ data: { fileId: 'ok-file', fileName: 'ok.ifc', fileAreaId: 'fa-ok', fileRevisionId: 'rev-2', deleted: false } }],
+                }),
+            }),
+          );
+        }
+        return Promise.resolve(mockResponse({ json: () => Promise.resolve({ items: [] }) }));
+      });
+
+      const ctx = createMockCtx(mockFetch as unknown as typeof fetch);
+      await ctx.storage.set('rev:proj1:fa-ok:ok-file', 'rev-1');
+      await ctx.storage.set('rev:proj1:fa-broken:broken-file', 'rev-1');
+
+      const result = await provider.watchRevisions(ctx, [
+        { projectId: 'proj1', containerId: fileAreaContainerId('fa-ok'), fileId: 'ok-file' },
+        { projectId: 'proj1', containerId: fileAreaContainerId('fa-broken'), fileId: 'broken-file' },
+      ]);
+
+      // The healthy area's event survives the broken area's failure.
+      expect(result.events).toContainEqual({ fileId: 'ok-file', latestRevisionId: 'rev-2', previousRevisionId: 'rev-1' });
+      expect(ctx.log.warn).toHaveBeenCalled();
+
+      // The healthy area's cache was advanced...
+      expect(await ctx.storage.get('rev:proj1:fa-ok:ok-file')).toBe('rev-2');
+      // ...but the broken area's cache is left untouched, so a retry next
+      // poll compares against the same baseline instead of silently having
+      // already "seen" whatever change caused the failure.
+      expect(await ctx.storage.get('rev:proj1:fa-broken:broken-file')).toBe('rev-1');
+    });
+
+    it('still advances a healthy area\'s cache even when a later area throws (buffer-then-commit is not all-or-nothing across areas)', async () => {
+      // Buffering exists to stop a cache from being advanced past a change
+      // whose event then gets lost — not to make one area's failure roll
+      // back another, healthy area's already-detected event too. Areas are
+      // isolated independently (per-area try/catch), so fa-ok's write must
+      // still land even though fa-broken's sweep throws.
+      const mockFetch = vi.fn().mockImplementation((url: string) => {
+        if (url.includes('/file_areas/fa-broken/')) {
+          return Promise.reject(new Error('boom'));
+        }
+        return Promise.resolve(
+          mockResponse({
+            json: () =>
+              Promise.resolve({
+                items: [{ data: { fileId: 'ok-file', fileName: 'ok.ifc', fileAreaId: 'fa-ok', fileRevisionId: 'rev-2', deleted: false } }],
+              }),
+          }),
+        );
+      });
+
+      const ctx = createMockCtx(mockFetch as unknown as typeof fetch);
+      await ctx.storage.set('rev:proj1:fa-ok:ok-file', 'rev-1');
+
+      await provider.watchRevisions(ctx, [
+        { projectId: 'proj1', containerId: fileAreaContainerId('fa-ok'), fileId: 'ok-file' },
+        { projectId: 'proj1', containerId: fileAreaContainerId('fa-broken'), fileId: 'broken-file' },
+      ]);
+
+      expect(await ctx.storage.get('rev:proj1:fa-ok:ok-file')).toBe('rev-2');
+    });
+  });
+
+  describe('testConnection', () => {
+    it('returns ok with project count on success', async () => {
+      const mockFetch = vi.fn().mockResolvedValue(
+        mockResponse({
+          json: () =>
+            Promise.resolve({ items: [{ data: { projectId: 'p1', projectName: 'A' } }, { data: { projectId: 'p2', projectName: 'B' } }] }),
+        }),
+      );
+      const ctx = createMockCtx(mockFetch as unknown as typeof fetch);
+      const result = await provider.testConnection(ctx);
+
+      expect(result.ok).toBe(true);
+      expect(result.projectCount).toBe(2);
+      expect(result.message).toContain('2 projects');
+    });
+
+    it('returns a helpful message on 403', async () => {
+      const mockFetch = vi.fn().mockResolvedValue(mockResponse({ ok: false, status: 403, statusText: 'Forbidden', text: () => Promise.resolve('Access denied') }));
+      const ctx = createMockCtx(mockFetch as unknown as typeof fetch);
+      const result = await provider.testConnection(ctx);
+
+      expect(result.ok).toBe(false);
+      expect(result.message).toContain('API identity lacks access');
+    });
+
+    it('returns a helpful message on 401', async () => {
+      const mockFetch = vi.fn().mockResolvedValue(mockResponse({ ok: false, status: 401, statusText: 'Unauthorized', text: () => Promise.resolve('') }));
+      const ctx = createMockCtx(mockFetch as unknown as typeof fetch);
+      const result = await provider.testConnection(ctx);
+
+      expect(result.ok).toBe(false);
+      expect(result.message).toContain('API identity lacks access');
+    });
+
+    it('does not misclassify a 500 whose body happens to mention "401" as an auth failure', async () => {
+      const mockFetch = vi.fn().mockResolvedValue(
+        mockResponse({
+          ok: false,
+          status: 500,
+          statusText: 'Internal Server Error',
+          text: () => Promise.resolve('upstream trace: handler for route /v401/x threw at line 403'),
+        }),
+      );
+      const ctx = createMockCtx(mockFetch as unknown as typeof fetch);
+      const result = await provider.testConnection(ctx);
+
+      expect(result.ok).toBe(false);
+      expect(result.message).not.toContain('API identity lacks access');
+      expect(result.message).toContain('500');
+    });
+  });
+});

--- a/packages/source-dalux/tsconfig.json
+++ b/packages/source-dalux/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.packages.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "paths": {
+      "@ifc-lite/plugin-api": ["../plugin-api/src"]
+    }
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/source-dalux/vitest.config.ts
+++ b/packages/source-dalux/vitest.config.ts
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,6 +187,9 @@ importers:
       '@ifc-lite/solar':
         specifier: workspace:^
         version: link:../../packages/solar
+      '@ifc-lite/source-dalux':
+        specifier: workspace:^
+        version: link:../../packages/source-dalux
       '@ifc-lite/spatial':
         specifier: workspace:^
         version: link:../../packages/spatial
@@ -1391,6 +1394,19 @@ importers:
       vitest:
         specifier: ^4.1.0
         version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@26.1.2)(happy-dom@20.11.1)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+
+  packages/source-dalux:
+    dependencies:
+      '@ifc-lite/plugin-api':
+        specifier: workspace:^
+        version: link:../plugin-api
+    devDependencies:
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@26.1.2)(happy-dom@20.11.1)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/source-fixture:
     dependencies:

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -4097,6 +4097,10 @@
     "sunTimes: function",
     "toJulianDay: function"
   ],
+  "@ifc-lite/source-dalux": [
+    "DALUX_MANIFEST: const",
+    "DaluxBuildProvider: class"
+  ],
   "@ifc-lite/spatial": [
     "AABB: interface",
     "AABBUtils: class",

--- a/server/sources/dalux-relay.ts
+++ b/server/sources/dalux-relay.ts
@@ -1,0 +1,260 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Same-origin relay for the Dalux Build API.
+ *
+ * Dalux sends no CORS headers, so a browser cannot call it directly and the
+ * app must forward through its own origin. The naive way to do that is a
+ * blanket `vercel.json` rewrite, which is what this replaces: a rewrite turns
+ * the deployment into an unauthenticated, method-agnostic proxy into an
+ * authenticated per-tenant API. Anyone who learns the URL can drive Dalux
+ * through our egress IPs, so Dalux's abuse controls would throttle *us*, and
+ * every byte is billed to us.
+ *
+ * This handler keeps the CORS fix and drops the proxy:
+ *
+ *   - GET/HEAD only, so no writes can be relayed.
+ *   - A caller-supplied `X-API-KEY` is mandatory. The relay holds no
+ *     credential of its own, so it can never be used to read data anonymously.
+ *   - The upstream path must match one of the API versions the provider
+ *     actually calls, so the relay cannot reach admin or write endpoints even
+ *     with a valid key.
+ *   - Only an explicit header allowlist is forwarded, in both directions.
+ *     Cookies never cross in either direction: the relay is same-origin, so
+ *     without this the browser's own first-party cookies would be handed to a
+ *     third party.
+ *
+ * Residual risk, deliberately documented rather than papered over: a caller
+ * with their own valid Dalux key can still use this to reach Dalux from our
+ * IPs, and key-guessing traffic is still anonymised. Neither is fixable in a
+ * stateless handler. Put a Vercel WAF rate-limit rule on `/api/dalux` — see
+ * the README section this file is referenced from.
+ */
+
+export interface DaluxRelayConfig {
+  /** Upstream origin, no trailing slash. */
+  readonly upstreamOrigin: string;
+  /** Upstream base path the allowed path is appended to, no trailing slash. */
+  readonly upstreamBasePath: string;
+  /**
+   * Leading path segments the provider legitimately calls. Anything else is
+   * rejected before a request leaves our infrastructure.
+   */
+  readonly allowedPathPrefixes: readonly string[];
+  /** Browser origins allowed to read the response. */
+  readonly allowedOrigins: readonly string[];
+}
+
+export const DEFAULT_DALUX_RELAY_CONFIG: DaluxRelayConfig = {
+  upstreamOrigin: 'https://node1.field.dalux.com',
+  upstreamBasePath: '/service/api',
+  // The API versions packages/source-dalux actually calls. Adding a version
+  // here is a deliberate act, which is the point.
+  allowedPathPrefixes: ['2.0', '5.0', '5.1', '6.1'],
+  allowedOrigins: [],
+};
+
+/** Request headers forwarded upstream. Notably absent: cookie, authorization. */
+const FORWARDED_REQUEST_HEADERS = ['x-api-key', 'accept', 'range', 'if-none-match'];
+
+/** Response headers passed back. Notably absent: set-cookie. */
+const FORWARDED_RESPONSE_HEADERS = [
+  'content-type',
+  'content-length',
+  'content-range',
+  'accept-ranges',
+  'etag',
+  'retry-after',
+  'last-modified',
+];
+
+export interface DaluxRelayDeps {
+  readonly fetchImpl: typeof fetch;
+}
+
+/** Thrown when the upstream redirects to a host other than the upstream. */
+export class OffHostRedirectError extends Error {
+  constructor(readonly location: string) {
+    super(`Upstream redirected off-host to ${location}`);
+    this.name = 'OffHostRedirectError';
+  }
+}
+
+const MAX_REDIRECTS = 3;
+
+/**
+ * Fetches `target`, following 3xx redirects manually but ONLY while they stay
+ * on the upstream host, so the forwarded `X-API-KEY` can never leave it.
+ *
+ * fetch's own `redirect: 'follow'` strips `Authorization`/`Cookie` on a
+ * cross-origin hop but keeps custom headers, which would hand the caller's key
+ * to whatever host an open redirect names. A same-host redirect (e.g. a
+ * download endpoint bouncing within `node1.field.dalux.com`) is still legal and
+ * is followed; anything off-host throws {@link OffHostRedirectError}.
+ */
+async function followSameHost(
+  fetchImpl: typeof fetch,
+  target: URL,
+  init: { method: string; headers: Headers },
+): Promise<Response> {
+  let current = target;
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+    const response = await fetchImpl(current.toString(), { ...init, redirect: 'manual' });
+    if (response.status < 300 || response.status >= 400) return response;
+
+    const location = response.headers.get('location');
+    if (!location) return response;
+
+    const next = new URL(location, current);
+    if (next.origin !== target.origin) throw new OffHostRedirectError(next.toString());
+    current = next;
+  }
+  throw new Error(`Exceeded ${MAX_REDIRECTS} same-host redirects`);
+}
+
+function jsonError(status: number, message: string, cors: Record<string, string>): Response {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { 'content-type': 'application/json', ...cors },
+  });
+}
+
+function corsHeaders(origin: string | null, config: DaluxRelayConfig): Record<string, string> {
+  if (!origin || !config.allowedOrigins.includes(origin)) return {};
+  return {
+    'access-control-allow-origin': origin,
+    'access-control-allow-methods': 'GET, HEAD, OPTIONS',
+    'access-control-allow-headers': 'X-API-KEY, Accept, Range, If-None-Match',
+    'access-control-max-age': '600',
+    vary: 'Origin',
+  };
+}
+
+/**
+ * Validates the caller-supplied path and returns the upstream path, or null.
+ *
+ * Rejects traversal and absolute/protocol-relative forms. Decoding happens
+ * before the checks so that an encoded `..` cannot slip past, and the result is
+ * re-encoded per segment so legitimate names containing spaces still work.
+ */
+export function resolveUpstreamPath(rawPath: string, config: DaluxRelayConfig): string | null {
+  if (!rawPath) return null;
+
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(rawPath);
+  } catch {
+    return null;
+  }
+
+  if (decoded.includes('\\') || decoded.includes('\0')) return null;
+  if (decoded.startsWith('/') || decoded.includes('//')) return null;
+  if (/^[a-z][a-z0-9+.-]*:/i.test(decoded)) return null;
+
+  const segments = decoded.split('/');
+  if (segments.some((segment) => segment === '.' || segment === '..' || segment === '')) return null;
+
+  const [version] = segments;
+  if (!config.allowedPathPrefixes.includes(version)) return null;
+
+  return segments.map((segment) => encodeURIComponent(segment)).join('/');
+}
+
+export function createDaluxRelayHandler(
+  config: DaluxRelayConfig,
+  deps: DaluxRelayDeps,
+): (request: Request) => Promise<Response> {
+  return async function handleDaluxRelay(request: Request): Promise<Response> {
+    const origin = request.headers.get('origin');
+    const cors = corsHeaders(origin, config);
+
+    if (request.method === 'OPTIONS') {
+      return new Response(null, { status: 204, headers: cors });
+    }
+
+    if (request.method !== 'GET' && request.method !== 'HEAD') {
+      return jsonError(405, 'Only GET and HEAD are relayed', cors);
+    }
+
+    // A browser always sends Origin on a cross-origin request. Same-origin
+    // requests may omit it, so this cannot be a general auth check, but it does
+    // reject the obvious case of another site pointing at this endpoint.
+    if (origin && !config.allowedOrigins.includes(origin)) {
+      return jsonError(403, 'Origin not allowed', {});
+    }
+
+    const apiKey = request.headers.get('x-api-key');
+    if (!apiKey?.trim()) {
+      return jsonError(401, 'Missing X-API-KEY. This relay holds no credentials of its own.', cors);
+    }
+
+    const url = new URL(request.url);
+    // Vercel rewrites `/api/dalux/:path*` onto this function carrying the tail
+    // as `?path=`; the local dev server hits the pathname directly. Accept
+    // both so dev and production cannot diverge on which paths are allowed.
+    const rawPath = url.searchParams.get('path') ?? url.pathname.replace(/^\/api\/dalux\/?/, '');
+    const upstreamPath = resolveUpstreamPath(rawPath, config);
+    if (!upstreamPath) {
+      return jsonError(400, 'Path is not a relayable Dalux Build endpoint', cors);
+    }
+
+    // `path` is the rewrite's own routing parameter, not a Dalux query param.
+    const forwardedParams = new URLSearchParams(url.search);
+    forwardedParams.delete('path');
+    const query = forwardedParams.toString();
+
+    const upstream = new URL(
+      `${config.upstreamOrigin}${config.upstreamBasePath}/${upstreamPath}${query ? `?${query}` : ''}`,
+    );
+
+    const forwardedHeaders = new Headers();
+    for (const name of FORWARDED_REQUEST_HEADERS) {
+      const value = request.headers.get(name);
+      if (value) forwardedHeaders.set(name, value);
+    }
+
+    let response: Response;
+    try {
+      response = await followSameHost(deps.fetchImpl, upstream, {
+        method: request.method,
+        headers: forwardedHeaders,
+      });
+    } catch (err) {
+      if (err instanceof OffHostRedirectError) {
+        // A 3xx pointing off the upstream host would, if followed, re-send the
+        // caller's X-API-KEY to that host — fetch strips Authorization/Cookie
+        // across origins but NOT a custom header. Refuse rather than leak.
+        return jsonError(502, 'Upstream redirected off-host; refusing to forward credentials', cors);
+      }
+      // Never include the request headers here: they carry the caller's key.
+      const reason = err instanceof Error ? err.message : String(err);
+      return jsonError(502, `Upstream request failed: ${reason}`, cors);
+    }
+
+    const responseHeaders = new Headers(cors);
+    for (const name of FORWARDED_RESPONSE_HEADERS) {
+      const value = response.headers.get(name);
+      if (value) responseHeaders.set(name, value);
+    }
+    responseHeaders.set('cache-control', 'no-store');
+
+    return new Response(request.method === 'HEAD' ? null : response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: responseHeaders,
+    });
+  };
+}
+
+/** Parses `DALUX_RELAY_ALLOWED_ORIGINS` (comma-separated) into config. */
+export function loadDaluxRelayConfig(env: Record<string, string | undefined>): DaluxRelayConfig {
+  const raw = env.DALUX_RELAY_ALLOWED_ORIGINS ?? env.APP_URL ?? '';
+  const allowedOrigins = raw
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+
+  return { ...DEFAULT_DALUX_RELAY_CONFIG, allowedOrigins };
+}

--- a/tests/api/dalux-relay.test.ts
+++ b/tests/api/dalux-relay.test.ts
@@ -1,0 +1,265 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  createDaluxRelayHandler,
+  loadDaluxRelayConfig,
+  resolveUpstreamPath,
+  DEFAULT_DALUX_RELAY_CONFIG,
+  type DaluxRelayConfig,
+} from '../../server/sources/dalux-relay.js';
+
+const APP_ORIGIN = 'https://app.example';
+
+function createConfig(overrides: Partial<DaluxRelayConfig> = {}): DaluxRelayConfig {
+  return { ...DEFAULT_DALUX_RELAY_CONFIG, allowedOrigins: [APP_ORIGIN], ...overrides };
+}
+
+interface Captured {
+  url: string;
+  headers: Headers;
+  method: string;
+}
+
+function createHandler(
+  overrides: Partial<DaluxRelayConfig> = {},
+  respond: () => Response = () => new Response('{"items":[]}', {
+    status: 200,
+    headers: { 'content-type': 'application/json', 'set-cookie': 'upstream=1' },
+  }),
+) {
+  const captured: Captured[] = [];
+  const handler = createDaluxRelayHandler(createConfig(overrides), {
+    fetchImpl: async (input, init) => {
+      captured.push({
+        url: String(input),
+        headers: new Headers(init?.headers),
+        method: init?.method ?? 'GET',
+      });
+      return respond();
+    },
+  });
+  return { handler, captured };
+}
+
+function get(path: string, headers: Record<string, string> = {}): Request {
+  return new Request(`${APP_ORIGIN}${path}`, {
+    method: 'GET',
+    headers: { 'x-api-key': 'caller-key', ...headers },
+  });
+}
+
+test('forwards an allowed path to the upstream base path', async () => {
+  const { handler, captured } = createHandler();
+  const response = await handler(get('/api/dalux/5.1/projects?limit=10'));
+
+  assert.equal(response.status, 200);
+  assert.equal(captured.length, 1);
+  assert.equal(
+    captured[0].url,
+    'https://node1.field.dalux.com/service/api/5.1/projects?limit=10',
+  );
+  assert.equal(captured[0].headers.get('x-api-key'), 'caller-key');
+});
+
+test('rejects every method except GET, HEAD and OPTIONS', async () => {
+  const { handler, captured } = createHandler();
+  for (const method of ['POST', 'PUT', 'PATCH', 'DELETE']) {
+    const response = await handler(
+      new Request(`${APP_ORIGIN}/api/dalux/5.1/projects`, {
+        method,
+        headers: { 'x-api-key': 'caller-key' },
+      }),
+    );
+    assert.equal(response.status, 405, `${method} should be rejected`);
+  }
+  assert.equal(captured.length, 0, 'no write method should reach upstream');
+});
+
+test('requires a caller-supplied API key', async () => {
+  const { handler, captured } = createHandler();
+  const response = await handler(
+    new Request(`${APP_ORIGIN}/api/dalux/5.1/projects`, { method: 'GET' }),
+  );
+
+  assert.equal(response.status, 401);
+  assert.equal(captured.length, 0, 'anonymous requests must not reach upstream');
+});
+
+test('never forwards cookies or authorization upstream', async () => {
+  const { handler, captured } = createHandler();
+  await handler(
+    get('/api/dalux/5.1/projects', {
+      cookie: 'session=secret; _vercel_jwt=deployment-token',
+      authorization: 'Bearer app-token',
+    }),
+  );
+
+  assert.equal(captured[0].headers.get('cookie'), null);
+  assert.equal(captured[0].headers.get('authorization'), null);
+});
+
+test('never passes upstream set-cookie back to the browser', async () => {
+  const { handler } = createHandler();
+  const response = await handler(get('/api/dalux/5.1/projects'));
+
+  assert.equal(response.headers.get('set-cookie'), null);
+});
+
+test('rejects a disallowed cross-site origin without contacting upstream', async () => {
+  const { handler, captured } = createHandler();
+  const response = await handler(get('/api/dalux/5.1/projects', { origin: 'https://evil.example' }));
+
+  assert.equal(response.status, 403);
+  assert.equal(captured.length, 0);
+});
+
+test('echoes CORS headers only for an allowed origin', async () => {
+  const { handler } = createHandler();
+  const response = await handler(get('/api/dalux/5.1/projects', { origin: APP_ORIGIN }));
+
+  assert.equal(response.headers.get('access-control-allow-origin'), APP_ORIGIN);
+  assert.equal(response.headers.get('access-control-allow-methods'), 'GET, HEAD, OPTIONS');
+});
+
+test('rejects paths outside the allowed API versions', async () => {
+  const { handler, captured } = createHandler();
+  for (const path of ['/api/dalux/admin/users', '/api/dalux/9.9/projects', '/api/dalux/']) {
+    const response = await handler(get(path));
+    assert.ok(response.status >= 400, `${path} should be rejected`);
+  }
+  assert.equal(captured.length, 0);
+});
+
+test('resolveUpstreamPath rejects traversal in raw and encoded form', () => {
+  const config = createConfig();
+  for (const attempt of [
+    '5.1/../../admin',
+    '5.1/%2e%2e/admin',
+    '%2e%2e%2fadmin',
+    '/5.1/projects',
+    'https://evil.example/5.1',
+    '5.1//projects',
+    '5.1/\\admin',
+  ]) {
+    assert.equal(resolveUpstreamPath(attempt, config), null, `${attempt} should be rejected`);
+  }
+});
+
+test('resolveUpstreamPath re-encodes legitimate segments', () => {
+  const config = createConfig();
+  assert.equal(
+    resolveUpstreamPath('5.1/projects/my%20project', config),
+    '5.1/projects/my%20project',
+  );
+});
+
+test('upstream failure does not echo request headers', async () => {
+  const { handler } = createHandler({}, () => {
+    throw new Error('boom');
+  });
+  const handlerWithThrow = createDaluxRelayHandler(createConfig(), {
+    fetchImpl: async () => {
+      throw new Error('connect ECONNREFUSED');
+    },
+  });
+
+  const response = await handlerWithThrow(get('/api/dalux/5.1/projects'));
+  const body = await response.text();
+
+  assert.equal(response.status, 502);
+  assert.ok(!body.includes('caller-key'), 'error body must not leak the caller key');
+  void handler;
+});
+
+test('accepts the rewrite path parameter and does not forward it upstream', async () => {
+  const { handler, captured } = createHandler();
+  const response = await handler(
+    new Request(`${APP_ORIGIN}/api/dalux?path=5.1%2Fprojects&limit=10`, {
+      method: 'GET',
+      headers: { 'x-api-key': 'caller-key' },
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  assert.equal(
+    captured[0].url,
+    'https://node1.field.dalux.com/service/api/5.1/projects?limit=10',
+  );
+});
+
+test('refuses an off-host redirect rather than re-sending the key to it', async () => {
+  // The exact credential-exfil path: an open redirect on any allowed Dalux
+  // endpoint would, if followed, hand X-API-KEY to the target host.
+  const seen: string[] = [];
+  const handler = createDaluxRelayHandler(createConfig(), {
+    fetchImpl: async (input) => {
+      seen.push(String(input));
+      if (String(input).includes('node1.field.dalux.com')) {
+        return new Response(null, { status: 302, headers: { location: 'https://attacker.example/steal' } });
+      }
+      return new Response('pwned', { status: 200 });
+    },
+  });
+
+  const response = await handler(get('/api/dalux/5.1/projects?returnUrl=x'));
+
+  assert.equal(response.status, 502);
+  assert.ok(
+    !seen.some((url) => url.includes('attacker.example')),
+    'the relay must never issue a request to the redirect target',
+  );
+});
+
+test('follows a same-host redirect and forwards the key only to the upstream host', async () => {
+  const seen: string[] = [];
+  const handler = createDaluxRelayHandler(createConfig(), {
+    fetchImpl: async (input, init) => {
+      const url = String(input);
+      seen.push(url);
+      assert.equal(new Headers(init?.headers).get('x-api-key'), 'caller-key');
+      if (url.endsWith('/5.1/projects')) {
+        return new Response(null, {
+          status: 302,
+          headers: { location: 'https://node1.field.dalux.com/service/api/5.1/projects?page=2' },
+        });
+      }
+      return new Response('{"items":[]}', { status: 200 });
+    },
+  });
+
+  const response = await handler(get('/api/dalux/5.1/projects'));
+
+  assert.equal(response.status, 200);
+  assert.equal(seen.length, 2, 'should follow the one same-host hop');
+  assert.ok(seen.every((url) => url.startsWith('https://node1.field.dalux.com')));
+});
+
+test('stops after a bounded number of same-host redirects', async () => {
+  let hops = 0;
+  const handler = createDaluxRelayHandler(createConfig(), {
+    fetchImpl: async () => {
+      hops++;
+      return new Response(null, {
+        status: 302,
+        headers: { location: 'https://node1.field.dalux.com/service/api/5.1/loop' },
+      });
+    },
+  });
+
+  const response = await handler(get('/api/dalux/5.1/projects'));
+  assert.equal(response.status, 502);
+  assert.ok(hops <= 5, `redirect loop must be bounded, saw ${hops} hops`);
+});
+
+test('loadDaluxRelayConfig parses a comma-separated origin list', () => {
+  const config = loadDaluxRelayConfig({
+    DALUX_RELAY_ALLOWED_ORIGINS: 'https://a.example, https://b.example',
+  });
+
+  assert.deepEqual(config.allowedOrigins, ['https://a.example', 'https://b.example']);
+  assert.equal(config.upstreamOrigin, 'https://node1.field.dalux.com');
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -112,6 +112,12 @@
       "@ifc-lite/plugin-api": [
         "packages/plugin-api/dist/index.d.ts"
       ],
+      "@ifc-lite/source-dalux": [
+        "packages/source-dalux/dist/index.d.ts"
+      ],
+      "@ifc-lite/source-dalux/*": [
+        "packages/source-dalux/dist/*"
+      ],
       "@ifc-lite/plugin-api/*": [
         "packages/plugin-api/dist/*"
       ]

--- a/vercel.json
+++ b/vercel.json
@@ -14,6 +14,10 @@
       "destination": "https://api.bsdd.buildingsmart.org/:path*"
     },
     {
+      "source": "/api/dalux/:path*",
+      "destination": "/api/dalux?path=:path*"
+    },
+    {
       "source": "/mcp",
       "destination": "/index.html"
     },


### PR DESCRIPTION
**Closes #1663.** Second of three PRs landing cloud/CDE source integration — **stacks on #1976** (contract + host + UI). `@ifc-lite/source-msgraph` follows in PR C.

> Base this on #1976. The diff shown against `main` will include A's changes until A merges; the 27-file diff against A's branch is the actual content here.

## Credit

The provider and the architecture are @bruadam's, from #1761. He asked that one person carry the PRs rather than splitting authorship across branches — *"easier to have only one person on it, no bottlenecks"* — so this carries `Co-authored-by: Bruno Adam <bruno.adam@pm.me>`.

What changed since #1761: migrated to the v2 contract (`Page<T>` listing, `SourceFileRef` download, `watchRevisions` replacing `checkRevisions`, declared `capabilities`/`auth`/`permissions.relay`), dropped the third-party `dalux-build-api` client, hardened the relay, and fixed the pagination/validation defects listed in the changeset.

## The manifest fix that unblocked it

#1761 declared `manifest.api: '^0.1.0'` against a host at `PLUGIN_API_VERSION = 2.0.0`, so the provider could **never register** — the app white-screened instead of failing loudly. It now declares `^2.0.0`.

## The guard PR A left behind did exactly its job

#1976 shipped with `source-host.test.ts` asserting `createRegisteredProviders()` was **empty** — deliberately inverted, because with no providers the per-provider loop below it is vacuous and would pass forever. It was written to fail the moment a provider appeared, with a message saying what to restore.

It failed here, as designed. Restored to `assert.ok(providers.length > 0, ...)`.

**Mutation-checked:** setting the Dalux manifest back to `^0.1.0` fails that test with the version mismatch. The exact defect that blocked #1761 is now a CI failure rather than something that ships.

## Relay

Dalux Build sends no CORS headers, so requests go through the same-origin `/api/dalux` relay — declared in the manifest, validated by the host against routes it actually has configured, and refusing upstream redirects that leave the declared host so the API key cannot be carried off-origin. The production rewrite (`vercel.json`) and the dev proxy (`vite.config.ts`) mirror each other deliberately; a drift between them is the classic "works in dev, 404s in prod" bug.

This is the use case that decided the architecture: a five-method `connect/list/download` interface cannot express a validated relay, and every provider needing one would grow bespoke serverless code anyway.

## Changeset is `minor`, not `major`

The inherited changesets said `major`. `@ifc-lite/source-dalux` is at 0.1.0 and **404 on npm** — never published, so there are no consumers to break, and this repo bumps breaking changes on `0.x` packages as `minor`. Publishing a brand-new package straight at 1.0.0 would imply a stability promise we are not making. Consolidated into one changeset that reads as a first release.

## Verification

- `pnpm typecheck` 35/35 · `pnpm test` 80/80 tasks
- `@ifc-lite/source-dalux` 77 tests · `source-host` 25
- `api-surface.json` regenerated (39 packages, 4001 exports) — new published surface, expected
- `check-test-wiring` and package READMEs clean
- `packages/wasm/pkg/*` reverted to A's base: a local build had regenerated the `.d.ts` with bindings from a newer `main` than A branched from, which is A's rebase to do, not this PR's
