### PR TITLE
perf(export): speed up GLB assembly and bound large-model memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1508,6 +1508,7 @@ name = "ifc-lite-export"
 version = "4.3.0"
 dependencies = [
  "arrow",
+ "bytemuck",
  "ifc-lite-core",
  "ifc-lite-geometry",
  "ifc-lite-processing",
@@ -1515,6 +1516,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
+ "xxhash-rust",
  "zip",
 ]
 

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -276,6 +276,13 @@ export class IfcAPI {
      * taken in order from the concatenated `positions`/`normals`/`indices`; `colors` is
      * RGBA per mesh, `origins` xyz per mesh, `express_ids` labels each mesh (indices are
      * per-mesh local). The caller passes exactly the meshes it wants emitted.
+     *
+     * Fails CLOSED: if the declared vertex/index counts run past the flattened
+     * `positions` / `indices`, there are fewer `index_counts` than meshes, or `normals`
+     * is empty or too short to cover every vertex, this throws an `Error` whose message
+     * starts with `MALFORMED_MESH_INPUT` — instead of silently emitting a GLB with those
+     * meshes dropped. (The viewer always passes fully-backed, normal-covered arrays, so
+     * this only fires on a caller bug.)
      */
     exportGlbFromMeshes(positions: Float32Array, normals: Float32Array, indices: Uint32Array, vertex_counts: Uint32Array, index_counts: Uint32Array, colors: Float32Array, origins: Float64Array, express_ids: Uint32Array, include_metadata: boolean, lit?: boolean | null, emissive?: boolean | null): Uint8Array;
     /**

--- a/rust/export/Cargo.toml
+++ b/rust/export/Cargo.toml
@@ -13,6 +13,10 @@ ifc-lite-core = { workspace = true }
 ifc-lite-geometry = { workspace = true }
 ifc-lite-processing = { workspace = true }
 rustc-hash = "2.1"
+# Bulk little-endian reinterpret of f32/u32 slices to bytes (glTF vertex encoding)
+# and a single-pass 128-bit content hash for mesh dedup; both pure-Rust + wasm-safe.
+bytemuck = "1.25"
+xxhash-rust = { version = "0.8", features = ["xxh3"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/rust/export/src/error.rs
+++ b/rust/export/src/error.rs
@@ -39,6 +39,16 @@ pub enum ExportError {
         /// The underlying error's `Display` output.
         detail: String,
     },
+    /// The from-meshes assembler was handed inconsistent inputs: the per-mesh
+    /// `vertex_counts` / `index_counts` sum past the end of the flattened
+    /// `positions` / `normals` / `indices` buffers. The infallible
+    /// [`crate::export_glb_from_meshes`] silently drops the un-backed tail (a valid
+    /// GLB missing part of the model, reported as success); the `try_` variant
+    /// surfaces this instead so a caller bug can't ship truncated geometry.
+    MalformedMeshInput {
+        /// Which buffer was too short, with the expected vs actual lengths.
+        detail: String,
+    },
 }
 
 impl ExportError {
@@ -49,6 +59,7 @@ impl ExportError {
             ExportError::NoRenderGeometry => "NO_RENDER_GEOMETRY",
             ExportError::TooLarge { .. } => "TOO_LARGE",
             ExportError::Serialization { .. } => "SERIALIZATION_FAILED",
+            ExportError::MalformedMeshInput { .. } => "MALFORMED_MESH_INPUT",
         }
     }
 }
@@ -69,6 +80,9 @@ impl fmt::Display for ExportError {
             ),
             ExportError::Serialization { stage, detail } => {
                 write!(f, "{}: failed to serialize {stage}: {detail}", self.code())
+            }
+            ExportError::MalformedMeshInput { detail } => {
+                write!(f, "{}: from-meshes inputs are inconsistent: {detail}", self.code())
             }
         }
     }

--- a/rust/export/src/frame.rs
+++ b/rust/export/src/frame.rs
@@ -27,44 +27,82 @@ pub(crate) fn yup_f64(p: [f64; 3]) -> [f64; 3] {
     [p[0], p[2], -p[1]]
 }
 
-/// One mesh's geometry converted from the IFC Z-up `process_geometry` frame into
-/// the WebGL Y-up frame (owned buffers), ready to feed the shared glTF assembler.
-pub(crate) struct YUpMesh {
+/// Reusable owned buffers for the streaming Y-up conversion. The streaming/bounded
+/// export passes convert one mesh at a time and drop it; reusing a single scratch across
+/// meshes (clear + refill, capacity persists) avoids the 3 fresh heap allocations per
+/// mesh that per-call [`to_yup`] incurred — on a million-submesh model, per pass.
+pub(crate) struct YUpScratch {
     pub positions: Vec<f32>,
     pub normals: Vec<f32>,
     pub indices: Vec<u32>,
     pub origin: [f64; 3],
 }
 
-/// Convert Z-up `positions`/`normals`/`indices`/`origin` to Y-up owned buffers.
-///
-/// The faceted-brep per-face vertex duplication is now collapsed at the mesh
-/// SOURCE (`ifc_lite_processing::element::build_mesh_data` runs
-/// `ifc_lite_geometry::mesh_weld::weld_indexed` on every element), so
-/// `process_geometry`'s `MeshData` arrives pre-welded and this frame conversion
-/// is a faithful pass-through — no export-local re-weld.
-pub(crate) fn to_yup(
+impl YUpScratch {
+    pub(crate) fn new() -> Self {
+        Self { positions: Vec::new(), normals: Vec::new(), indices: Vec::new(), origin: [0.0; 3] }
+    }
+}
+
+/// [`to_yup`] into a reusable [`YUpScratch`] instead of freshly allocated buffers. The
+/// scratch is cleared and refilled, so its capacity is retained across calls; every value
+/// is identical to [`to_yup`], so output is unchanged.
+pub(crate) fn to_yup_into(
+    scratch: &mut YUpScratch,
     positions: &[f32],
     normals: &[f32],
     indices: &[u32],
     origin: [f64; 3],
-) -> YUpMesh {
-    let mut p = Vec::with_capacity(positions.len());
+) {
+    scratch.positions.clear();
+    scratch.positions.reserve(positions.len());
     for c in positions.chunks_exact(3) {
-        p.extend_from_slice(&yup_f32([c[0], c[1], c[2]]));
+        scratch.positions.extend_from_slice(&yup_f32([c[0], c[1], c[2]]));
     }
-    let mut n = Vec::with_capacity(normals.len());
+    scratch.normals.clear();
+    scratch.normals.reserve(normals.len());
     for c in normals.chunks_exact(3) {
-        n.extend_from_slice(&yup_f32([c[0], c[1], c[2]]));
+        scratch.normals.extend_from_slice(&yup_f32([c[0], c[1], c[2]]));
     }
-    // Reverse winding to compensate the handedness convention (identical to
-    // `MeshDataJs::new`): swap the 2nd/3rd index of every triangle.
-    let mut idx = indices.to_vec();
-    let tri_end = idx.len() - idx.len() % 3;
+    scratch.indices.clear();
+    scratch.indices.extend_from_slice(indices);
+    let tri_end = scratch.indices.len() - scratch.indices.len() % 3;
     let mut i = 0;
     while i < tri_end {
-        idx.swap(i + 1, i + 2);
+        scratch.indices.swap(i + 1, i + 2);
         i += 3;
     }
-    YUpMesh { positions: p, normals: n, indices: idx, origin: yup_f64(origin) }
+    scratch.origin = yup_f64(origin);
+}
+
+/// In-place variant of [`to_yup`]: rewrites `positions` / `normals` / `indices` /
+/// `origin` from IFC Z-up to WebGL Y-up WITHOUT allocating new buffers. The in-memory
+/// GLB path owns its `MeshData` and drops it immediately after assembly, so mutating it
+/// is invisible to any other consumer. Every value matches [`to_yup`]
+/// (`(x,y,z) -> (x,z,-y)`, winding reversed), so the emitted GLB is byte-for-byte
+/// unchanged — it just skips the full second copy of the model's geometry.
+pub(crate) fn to_yup_in_place(
+    positions: &mut [f32],
+    normals: &mut [f32],
+    indices: &mut [u32],
+    origin: &mut [f64; 3],
+) {
+    for c in positions.chunks_exact_mut(3) {
+        // new = (x, z, -y); read y and z before overwriting.
+        let (y, z) = (c[1], c[2]);
+        c[1] = z;
+        c[2] = -y;
+    }
+    for c in normals.chunks_exact_mut(3) {
+        let (y, z) = (c[1], c[2]);
+        c[1] = z;
+        c[2] = -y;
+    }
+    let tri_end = indices.len() - indices.len() % 3;
+    let mut i = 0;
+    while i < tri_end {
+        indices.swap(i + 1, i + 2);
+        i += 3;
+    }
+    *origin = yup_f64(*origin);
 }

--- a/rust/export/src/gltf.rs
+++ b/rust/export/src/gltf.rs
@@ -11,8 +11,13 @@
 //! keep f32 vertex precision (node translation carries the large offset). When `origin` is
 //! zero (local-frame feature off) the output is byte-equivalent to the old TS path.
 
-use std::collections::HashMap;
 use std::sync::Arc;
+
+use rustc_hash::{FxHashMap, FxHashSet};
+// Only the test module uses std's SipHash-keyed `HashMap` (its own scratch maps); the
+// exporter's own dedup/material maps are all `FxHashMap`.
+#[cfg(test)]
+use std::collections::HashMap;
 
 use crate::error::ExportError;
 use ifc_lite_core::EntityIndex;
@@ -248,24 +253,55 @@ struct Buffer {
 
 // ── Build ───────────────────────────────────────────────────────────────────
 
+/// Precomputed visibility filter. The express-id allow/deny lists and the hidden-type
+/// set are hashed ONCE per export instead of linearly scanned per mesh — `mesh_visible`
+/// ran `Vec::contains` over `opts.hidden`/`opts.isolated`/`opts.hidden_types` for every
+/// mesh, i.e. O(meshes × filter_len), and on the bounded path it ran in BOTH passes.
+/// Same decisions as the old scan, so no output changes.
+struct VisibilityFilter {
+    hidden: FxHashSet<u32>,
+    isolated: FxHashSet<u32>,
+    isolated_active: bool,
+    hidden_types: FxHashSet<String>,
+}
+
+impl VisibilityFilter {
+    fn new(opts: &GltfOptions) -> Self {
+        Self {
+            hidden: opts.hidden.iter().copied().collect(),
+            isolated: opts.isolated.iter().copied().collect(),
+            isolated_active: !opts.isolated.is_empty(),
+            hidden_types: opts.hidden_types.iter().cloned().collect(),
+        }
+    }
+
+    fn visible(&self, mesh: &MeshData) -> bool {
+        if mesh.geometry_class == 2 {
+            return false; // instanced type library duplicates occurrence geometry
+        }
+        if self.hidden.contains(&mesh.express_id) {
+            return false;
+        }
+        if self.isolated_active && !self.isolated.contains(&mesh.express_id) {
+            return false;
+        }
+        if self.hidden_types.contains(&mesh.ifc_type) {
+            return false;
+        }
+        // Geometry sanity: matching, non-empty, triangulated.
+        !mesh.indices.is_empty()
+            && mesh.positions.len() >= 9
+            && mesh.positions.len().is_multiple_of(3)
+            && mesh.normals.len() == mesh.positions.len()
+    }
+}
+
+/// Convenience wrapper that builds a one-shot [`VisibilityFilter`] — used by tests that
+/// check a single mesh. Production hot loops build the filter once and call
+/// [`VisibilityFilter::visible`] directly, so this is test-only.
+#[cfg(test)]
 fn mesh_visible(mesh: &MeshData, opts: &GltfOptions) -> bool {
-    if mesh.geometry_class == 2 {
-        return false; // instanced type library duplicates occurrence geometry
-    }
-    if opts.hidden.contains(&mesh.express_id) {
-        return false;
-    }
-    if !opts.isolated.is_empty() && !opts.isolated.contains(&mesh.express_id) {
-        return false;
-    }
-    if opts.hidden_types.iter().any(|t| t == &mesh.ifc_type) {
-        return false;
-    }
-    // Geometry sanity: matching, non-empty, triangulated.
-    !mesh.indices.is_empty()
-        && mesh.positions.len() >= 9
-        && mesh.positions.len().is_multiple_of(3)
-        && mesh.normals.len() == mesh.positions.len()
+    VisibilityFilter::new(opts).visible(mesh)
 }
 
 /// Material dedup key: RGBA rounded to 2 decimals (matches the TS exporter's key).
@@ -302,25 +338,30 @@ fn make_material(color: [f32; 4], lit: bool, emissive: bool) -> Material {
 /// colour. Two meshes the rep-identity collator did NOT flag instanceable but whose
 /// BAKED local buffers are nonetheless bit-identical (same shape, same orientation,
 /// same colour) share one emitted glTF mesh placed by a node translation. Colour is
-/// in the key because the glTF material rides the primitive, not the node. Two
-/// independently-seeded streams give a 128-bit key (collision ~2^-127).
+/// in the key because the glTF material rides the primitive, not the node.
+///
+/// One single-pass `xxh3_128` over the three attribute runs (reinterpreted as bytes,
+/// which is a no-op on the LE-only targets this crate builds for — the exact same bit
+/// patterns the old per-`f32::to_bits` fold hashed) plus a `u64` length frame before
+/// each run so concatenated buffers can't alias. The digest only ever gates key
+/// EQUALITY (dedup grouping) and never appears in the output, so bit-identical meshes
+/// still collapse together and the emitted GLB is byte-for-byte unchanged; the win is
+/// ~20-50x less hashing on large models (xxh3 bulk vs element-wise SipHash-1-3).
 fn geom_color_key(positions: &[f32], normals: &[f32], indices: &[u32], color: [f32; 4]) -> u128 {
-    use std::hash::{Hash, Hasher};
-    let stream = |seed: u64| -> u64 {
-        let mut h = std::collections::hash_map::DefaultHasher::new();
-        seed.hash(&mut h);
-        positions.len().hash(&mut h);
-        for &p in positions {
-            p.to_bits().hash(&mut h);
-        }
-        for &n in normals {
-            n.to_bits().hash(&mut h);
-        }
-        indices.hash(&mut h);
-        color_key(color).hash(&mut h);
-        h.finish()
-    };
-    ((stream(0x9E37_79B9_7F4A_7C15) as u128) << 64) | stream(0xD1B5_4A32_D192_ED03) as u128
+    use xxhash_rust::xxh3::Xxh3;
+    let mut h = Xxh3::new();
+    h.update(&(positions.len() as u64).to_le_bytes());
+    h.update(bytemuck::cast_slice::<f32, u8>(positions));
+    h.update(&(normals.len() as u64).to_le_bytes());
+    h.update(bytemuck::cast_slice::<f32, u8>(normals));
+    h.update(&(indices.len() as u64).to_le_bytes());
+    h.update(bytemuck::cast_slice::<u32, u8>(indices));
+    let (r, g, b, a) = color_key(color);
+    h.update(&r.to_le_bytes());
+    h.update(&g.to_le_bytes());
+    h.update(&b.to_le_bytes());
+    h.update(&a.to_le_bytes());
+    h.digest128()
 }
 
 // ── Instancing matrix math (row-major f64 4x4) ──────────────────────────────
@@ -491,7 +532,6 @@ struct Chunker<'s> {
     cap: usize,
     next_buffer: u32,
     sink: Option<&'s mut dyn FnMut(String, Vec<u8>)>,
-    embedded_bin: Vec<u8>, // the single chunk's bytes on the GLB path (sink == None)
 }
 
 impl<'s> Chunker<'s> {
@@ -506,7 +546,6 @@ impl<'s> Chunker<'s> {
             cap,
             next_buffer: 0,
             sink,
-            embedded_bin: Vec::new(),
         }
     }
 
@@ -560,22 +599,27 @@ impl<'s> Chunker<'s> {
             buffer: buf, byte_offset: (pl + nl) as u32, byte_length: il as u32,
             byte_stride: None, target: 34963,
         });
-        let mut bin = Vec::with_capacity(total);
-        bin.extend_from_slice(&self.pos);
-        bin.extend_from_slice(&self.norm);
-        bin.extend_from_slice(&self.idx);
-        self.pos.clear();
-        self.norm.clear();
-        self.idx.clear();
         match self.sink.as_mut() {
             Some(sink) => {
+                // Multi-buffer: concatenate this chunk's three runs, hand it to the sink,
+                // and reset the runs for the next chunk.
+                let mut bin = Vec::with_capacity(total);
+                bin.extend_from_slice(&self.pos);
+                bin.extend_from_slice(&self.norm);
+                bin.extend_from_slice(&self.idx);
+                self.pos.clear();
+                self.norm.clear();
+                self.idx.clear();
                 let name = format!("buffer{buf}.bin");
                 self.buffers.push(Buffer { byte_length: total as u32, uri: Some(name.clone()) });
                 sink(name, bin);
             }
             None => {
+                // Single embedded GLB buffer: leave pos/norm/idx in place so the packer
+                // writes them straight into the container — no intermediate concatenated
+                // copy. `cap == usize::MAX` on this path, so `flush` runs exactly once and
+                // the runs are never reset mid-stream.
                 self.buffers.push(Buffer { byte_length: total as u32, uri: None });
-                self.embedded_bin = bin;
             }
         }
         self.next_buffer += 1;
@@ -594,7 +638,7 @@ fn push_mesh(
     accessors: &mut Vec<Accessor>,
     meshes: &mut Vec<Mesh>,
     materials: &mut Vec<Material>,
-    material_map: &mut HashMap<(i32, i32, i32, i32), u32>,
+    material_map: &mut FxHashMap<(i32, i32, i32, i32), u32>,
     mesh: &MeshView,
     vertex_offset: [f64; 3],
     lit: bool,
@@ -609,12 +653,21 @@ fn push_mesh(
     let norm_off = ch.norm.len() as u32;
     let idx_off = ch.idx.len() as u32;
 
+    // One reservation per run instead of amortized regrowth on every 4-byte push.
+    ch.pos.reserve(mesh.positions.len() * 4);
+    ch.norm.reserve(mesh.normals.len() * 4);
+    ch.idx.reserve(mesh.indices.len() * 4);
+
     let mut min = [f32::INFINITY; 3];
     let mut max = [f32::NEG_INFINITY; 3];
     for p in mesh.positions.chunks_exact(3) {
+        // Bake each component (f64 add, monotone f32 downcast) into a 12-byte vertex
+        // and write it in one extend; the bytes equal three back-to-back
+        // `f32::to_le_bytes`, so the buffer is unchanged.
+        let mut vbuf = [0u8; 12];
         for k in 0..3 {
             let baked = (p[k] as f64 + vertex_offset[k]) as f32;
-            ch.pos.extend_from_slice(&baked.to_le_bytes());
+            vbuf[k * 4..k * 4 + 4].copy_from_slice(&baked.to_le_bytes());
             if baked < min[k] {
                 min[k] = baked;
             }
@@ -622,13 +675,13 @@ fn push_mesh(
                 max[k] = baked;
             }
         }
+        ch.pos.extend_from_slice(&vbuf);
     }
-    for &n in mesh.normals {
-        ch.norm.extend_from_slice(&n.to_le_bytes());
-    }
-    for &i in mesh.indices {
-        ch.idx.extend_from_slice(&i.to_le_bytes());
-    }
+    // Normals + indices are copied verbatim (no per-element transform), so reinterpret
+    // each whole slice as LE bytes in one memcpy — byte-identical on LE targets (the
+    // only ones this crate builds for) to the per-element `to_le_bytes` loop.
+    ch.norm.extend_from_slice(bytemuck::cast_slice::<f32, u8>(mesh.normals));
+    ch.idx.extend_from_slice(bytemuck::cast_slice::<u32, u8>(mesh.indices));
 
     let pos_acc = accessors.len() as u32;
     accessors.push(Accessor {
@@ -699,7 +752,7 @@ fn push_mesh_quantized(
     accessors: &mut Vec<Accessor>,
     meshes: &mut Vec<Mesh>,
     materials: &mut Vec<Material>,
-    material_map: &mut HashMap<(i32, i32, i32, i32), u32>,
+    material_map: &mut FxHashMap<(i32, i32, i32, i32), u32>,
     mesh: &MeshView,
     lit: bool,
     emissive: bool,
@@ -736,24 +789,29 @@ fn push_mesh_quantized(
     // padding. The pad makes the per-vertex stride 8 bytes: a bufferView shared by
     // multiple accessors must declare a `byteStride`, which glTF requires to be a
     // multiple of 4 (a tight SHORT VEC3 is 6).
+    ch.pos.reserve(nverts as usize * 8);
     let pos_off = ch.pos.len() as u32;
     let mut qmin = [i16::MAX; 3];
     let mut qmax = [i16::MIN; 3];
     for p in mesh.positions.chunks_exact(3) {
+        // 3 SHORT + 1 SHORT pad, built in a stack buffer and written once; the trailing
+        // two bytes stay zero (== `0i16` LE pad), so the stream is byte-identical.
+        let mut vbuf = [0u8; 8];
         for k in 0..3 {
             let n = ((p[k] as f64 - center[k]) / half[k]).clamp(-1.0, 1.0);
             let q = (n * 32767.0).round() as i16;
-            ch.pos.extend_from_slice(&q.to_le_bytes());
+            vbuf[k * 2..k * 2 + 2].copy_from_slice(&q.to_le_bytes());
             qmin[k] = qmin[k].min(q);
             qmax[k] = qmax[k].max(q);
         }
-        ch.pos.extend_from_slice(&0i16.to_le_bytes()); // pad to 8-byte stride
+        ch.pos.extend_from_slice(&vbuf);
     }
 
     // Normals: SHORT normalized. The mesh node carries the non-uniform dequant scale
     // `half`, so the renderer applies its inverse-transpose `S(1/half)` to each stored
     // normal. Pre-multiply by `half` and renormalize so that cancels and the rendered
     // direction is the true normal. Padded to the same 8-byte stride as positions.
+    ch.norm.reserve(nverts as usize * 8);
     let norm_off = ch.norm.len() as u32;
     for nrm in mesh.normals.chunks_exact(3) {
         let mut v = [
@@ -765,11 +823,13 @@ fn push_mesh_quantized(
         if len > 0.0 {
             v = [v[0] / len, v[1] / len, v[2] / len];
         }
-        for c in v {
+        // 3 SHORT + 1 SHORT pad in a stack buffer; trailing zero pad unchanged.
+        let mut vbuf = [0u8; 8];
+        for (k, c) in v.into_iter().enumerate() {
             let q = (c.clamp(-1.0, 1.0) * 32767.0).round() as i16;
-            ch.norm.extend_from_slice(&q.to_le_bytes());
+            vbuf[k * 2..k * 2 + 2].copy_from_slice(&q.to_le_bytes());
         }
-        ch.norm.extend_from_slice(&0i16.to_le_bytes()); // pad to 8-byte stride
+        ch.norm.extend_from_slice(&vbuf);
     }
 
     // Indices: u16 when every index fits (max index = nverts - 1 <= 65535, i.e.
@@ -777,14 +837,14 @@ fn push_mesh_quantized(
     // mesh stays 4-aligned regardless of this mesh's index width.
     let small = nverts <= u16::MAX as u32 + 1;
     let idx_off = ch.idx.len() as u32;
+    ch.idx.reserve(mesh.indices.len() * if small { 2 } else { 4 } + 3);
     if small {
         for &i in mesh.indices {
             ch.idx.extend_from_slice(&(i as u16).to_le_bytes());
         }
     } else {
-        for &i in mesh.indices {
-            ch.idx.extend_from_slice(&i.to_le_bytes());
-        }
+        // u32 indices are copied verbatim — one memcpy of the whole run (LE targets).
+        ch.idx.extend_from_slice(bytemuck::cast_slice::<u32, u8>(mesh.indices));
     }
     while !ch.idx.len().is_multiple_of(4) {
         ch.idx.push(0);
@@ -975,7 +1035,7 @@ fn build_gltf(
     // Binary blobs, concatenated as [positions | normals | indices].
 
     let mut materials: Vec<Material> = Vec::new();
-    let mut material_map: HashMap<(i32, i32, i32, i32), u32> = HashMap::new();
+    let mut material_map: FxHashMap<(i32, i32, i32, i32), u32> = FxHashMap::default();
 
     let mut accessors: Vec<Accessor> = Vec::new();
     let mut meshes: Vec<Mesh> = Vec::new();
@@ -1053,14 +1113,14 @@ fn build_gltf(
         .iter()
         .map(|&i| geom_color_key(visible[i].positions, visible[i].normals, visible[i].indices, visible[i].color))
         .collect();
-    let mut flat_counts: HashMap<u128, u32> = HashMap::new();
+    let mut flat_counts: FxHashMap<u128, u32> = FxHashMap::default();
     for &k in &flat_keys {
         *flat_counts.entry(k).or_insert(0) += 1;
     }
     // Cache key -> (mesh_idx, dequant center, dequant half-extent). The dequant fields
     // are dummy on the f32 path (node scale stays `None`); on the quantized path they
     // are the per-mesh dequant the node folds in.
-    let mut flat_cache: HashMap<u128, (u32, [f64; 3], [f64; 3])> = HashMap::new();
+    let mut flat_cache: FxHashMap<u128, (u32, [f64; 3], [f64; 3])> = FxHashMap::default();
     for (j, &idx) in flat.iter().enumerate() {
         let mesh = visible[idx];
         let placement = [
@@ -1141,7 +1201,7 @@ fn build_gltf(
         // First-seen colour-bucket order keeps the emitted mesh/material/node
         // ordering deterministic (HashMap iteration order is not).
         let mut bucket_order: Vec<(i32, i32, i32, i32)> = Vec::new();
-        let mut by_color: HashMap<(i32, i32, i32, i32), Vec<usize>> = HashMap::new();
+        let mut by_color: FxHashMap<(i32, i32, i32, i32), Vec<usize>> = FxHashMap::default();
         for (oi, occ) in template.occurrences.iter().enumerate() {
             let ck = color_key(visible[occ.mesh_index].color);
             by_color
@@ -1379,7 +1439,7 @@ pub fn export_glb_with_stats_with_index(
 /// (`export_gltf_streaming_from_result`) paths; the views borrow scratch that lives only
 /// for `f`'s duration.
 fn with_result_views<R>(
-    result: ProcessingResult,
+    mut result: ProcessingResult,
     opts: &GltfOptions,
     f: impl FnOnce(&[MeshView], [f64; 3]) -> R,
 ) -> R {
@@ -1387,27 +1447,42 @@ fn with_result_views<R>(
     // swap normally happens at the wasm FFI, which this path never crosses). glTF
     // mandates +Y-up, so convert each visible mesh to Y-up — positions/normals
     // swapped, winding reversed, origin swapped — matching the viewer/legacy output.
-    let visible: Vec<&MeshData> =
-        result.meshes.iter().filter(|m| mesh_visible(m, opts)).collect();
-    let yup: Vec<crate::frame::YUpMesh> = visible
+    //
+    // The visible indices are collected first so the immutable visibility borrow ends
+    // before the in-place mutation; then each visible mesh is converted to Y-up IN PLACE
+    // (no allocation of a full second copy of the model's geometry — the old `Vec<YUpMesh>`
+    // held +1× the whole model resident for the entire assembly). `result` is owned and
+    // dropped after `f`, so the mutation is invisible to any other consumer.
+    let filter = VisibilityFilter::new(opts);
+    let vis_idx: Vec<usize> = result
+        .meshes
         .iter()
-        .map(|m| crate::frame::to_yup(&m.positions, &m.normals, &m.indices, m.origin))
+        .enumerate()
+        .filter(|(_, m)| filter.visible(m))
+        .map(|(i, _)| i)
         .collect();
-    let views: Vec<MeshView> = visible
+    for &i in &vis_idx {
+        let m = &mut result.meshes[i];
+        crate::frame::to_yup_in_place(&mut m.positions, &mut m.normals, &mut m.indices, &mut m.origin);
+    }
+    let views: Vec<MeshView> = vis_idx
         .iter()
-        .zip(yup.iter())
-        .map(|(m, y)| MeshView {
-            express_id: m.express_id,
-            ifc_type: &m.ifc_type,
-            global_id: m.global_id.as_deref(),
-            positions: &y.positions,
-            normals: &y.normals,
-            indices: &y.indices,
-            color: m.color,
-            origin: y.origin,
-            // Z-up instancing side-channel; rep-identity grouping is frame- and
-            // bake-invariant (the assembler conjugates the transform into Y-up).
-            instance: m.instance.as_ref(),
+        .map(|&i| {
+            let m = &result.meshes[i];
+            MeshView {
+                express_id: m.express_id,
+                ifc_type: &m.ifc_type,
+                global_id: m.global_id.as_deref(),
+                positions: &m.positions,
+                normals: &m.normals,
+                indices: &m.indices,
+                color: m.color,
+                origin: m.origin,
+                // Z-up instancing side-channel; rep-identity grouping is frame- and
+                // bake-invariant (the assembler conjugates the transform into Y-up). Left
+                // untouched by the in-place swap above, exactly as before.
+                instance: m.instance.as_ref(),
+            }
         })
         .collect();
     // RTC / site-local offset the baker subtracted (Z-up); the instancing path needs
@@ -1424,7 +1499,7 @@ fn export_glb_from_result(result: ProcessingResult, opts: &GltfOptions) -> (Vec<
             rtc_zup, opts.quantize, &mut ch,
         );
         let json = serde_json::to_vec(&gltf).expect("glTF JSON serializes");
-        (pack_glb(&json, &ch.embedded_bin), stats)
+        (pack_glb(&json, &ch.pos, &ch.norm, &ch.idx), stats)
     })
 }
 
@@ -1491,6 +1566,10 @@ fn export_gltf_streaming_impl(
         entity_index: index.clone(),
         ..StreamingOptions::default()
     };
+    let filter = VisibilityFilter::new(opts);
+    // One reusable Y-up scratch for BOTH passes (they run sequentially, so the mutable
+    // borrow never overlaps) instead of 3 fresh allocations per mesh per pass.
+    let mut yscratch = crate::frame::YUpScratch::new();
 
     let mut wmin = [f64::INFINITY; 3];
     let mut wmax = [f64::NEG_INFINITY; 3];
@@ -1500,10 +1579,11 @@ fn export_gltf_streaming_impl(
         stream_opts(),
         |batch, _, _| {
             for m in batch {
-                if !mesh_visible(m, opts) {
+                if !filter.visible(m) {
                     continue;
                 }
-                let y = crate::frame::to_yup(&m.positions, &m.normals, &m.indices, m.origin);
+                crate::frame::to_yup_into(&mut yscratch, &m.positions, &m.normals, &m.indices, m.origin);
+                let y = &yscratch;
                 for p in y.positions.chunks_exact(3) {
                     for k in 0..3 {
                         let w = p[k] as f64 + y.origin[k];
@@ -1530,7 +1610,7 @@ fn export_gltf_streaming_impl(
     let mut meshes: Vec<Mesh> = Vec::new();
     let mut nodes: Vec<Node> = Vec::new();
     let mut materials: Vec<Material> = Vec::new();
-    let mut material_map: HashMap<(i32, i32, i32, i32), u32> = HashMap::new();
+    let mut material_map: FxHashMap<(i32, i32, i32, i32), u32> = FxHashMap::default();
     let mut element_node_indices: Vec<u32> = Vec::new();
     let mut stats = GltfStats { meshes: 0, vertices: 0, triangles: 0, materials: 0 };
     let mut adapt = |name: String, bytes: Vec<u8>| sink(GltfBuffer { name, bytes });
@@ -1542,10 +1622,11 @@ fn export_gltf_streaming_impl(
         stream_opts(),
         |batch, _, _| {
             for m in batch {
-                if !mesh_visible(m, opts) {
+                if !filter.visible(m) {
                     continue;
                 }
-                let y = crate::frame::to_yup(&m.positions, &m.normals, &m.indices, m.origin);
+                crate::frame::to_yup_into(&mut yscratch, &m.positions, &m.normals, &m.indices, m.origin);
+                let y = &yscratch;
                 let view = MeshView {
                     express_id: m.express_id,
                     ifc_type: &m.ifc_type,
@@ -1666,7 +1747,10 @@ fn export_gltf_streaming_impl(
 /// into the output on the second pass).
 struct StreamedMeshMeta {
     express_id: u32,
-    ifc_type: String,
+    /// Interned per export (Arc<str>): IFC type names come from a tiny fixed set, so the
+    /// bounded plan holds one shared allocation per distinct type instead of one String
+    /// clone per mesh — the path that exists to bound memory keeps its metadata small.
+    ifc_type: Arc<str>,
     global_id: Option<String>,
     color: [f32; 4],
     /// Y-up per-element origin (world = origin + position).
@@ -1933,6 +2017,10 @@ fn plan_bounded_glb(
     };
 
     // ── Pass 1: metadata + world AABB ────────────────────────────────────────
+    let filter = VisibilityFilter::new(opts);
+    let mut yscratch = crate::frame::YUpScratch::new();
+    // Intern IFC type names so each distinct type is heap-allocated once, not per mesh.
+    let mut type_intern: FxHashMap<String, Arc<str>> = FxHashMap::default();
     let mut metas: Vec<StreamedMeshMeta> = Vec::new();
     let mut wmin = [f64::INFINITY; 3];
     let mut wmax = [f64::NEG_INFINITY; 3];
@@ -1942,10 +2030,11 @@ fn plan_bounded_glb(
         stream_opts(),
         |batch, _, _| {
             for m in batch {
-                if !mesh_visible(m, opts) {
+                if !filter.visible(m) {
                     continue;
                 }
-                let y = crate::frame::to_yup(&m.positions, &m.normals, &m.indices, m.origin);
+                crate::frame::to_yup_into(&mut yscratch, &m.positions, &m.normals, &m.indices, m.origin);
+                let y = &yscratch;
                 // Same geometry-sanity gate as `view_ok` on the in-memory path.
                 if y.indices.is_empty()
                     || y.positions.len() < 9
@@ -1972,9 +2061,19 @@ fn plan_bounded_glb(
                     wmin[k] = wmin[k].min(lmin[k] as f64 + y.origin[k]);
                     wmax[k] = wmax[k].max(lmax[k] as f64 + y.origin[k]);
                 }
+                // Intern: clone the String key only the first time a type is seen; every
+                // later mesh of that type just bumps the shared Arc<str> refcount.
+                let ifc_type = match type_intern.get(m.ifc_type.as_str()) {
+                    Some(a) => a.clone(),
+                    None => {
+                        let a: Arc<str> = Arc::from(m.ifc_type.as_str());
+                        type_intern.insert(m.ifc_type.clone(), a.clone());
+                        a
+                    }
+                };
                 metas.push(StreamedMeshMeta {
                     express_id: m.express_id,
-                    ifc_type: m.ifc_type.clone(),
+                    ifc_type,
                     global_id: m.global_id.clone(),
                     color: m.color,
                     origin: y.origin,
@@ -2001,7 +2100,7 @@ fn plan_bounded_glb(
     };
 
     // ── Build the glTF JSON (mirrors build_gltf's flat branch exactly) ──────
-    let mut key_counts: HashMap<u128, u32> = HashMap::new();
+    let mut key_counts: FxHashMap<u128, u32> = FxHashMap::default();
     for meta in &metas {
         *key_counts.entry(meta.key).or_insert(0) += 1;
     }
@@ -2009,13 +2108,13 @@ fn plan_bounded_glb(
     let mut meshes: Vec<Mesh> = Vec::new();
     let mut nodes: Vec<Node> = Vec::new();
     let mut materials: Vec<Material> = Vec::new();
-    let mut material_map: HashMap<(i32, i32, i32, i32), u32> = HashMap::new();
+    let mut material_map: FxHashMap<(i32, i32, i32, i32), u32> = FxHashMap::default();
     let mut element_node_indices: Vec<u32> = Vec::new();
     let mut stats = GltfStats { meshes: 0, vertices: 0, triangles: 0, materials: 0 };
     // key -> (mesh_idx, dequant center, dequant half). center/half are dummy
     // zeros/ones on the f32 path (node scale stays None), the per-mesh dequant
     // the node folds in on the quantized path (mirrors build_gltf's flat_cache).
-    let mut shared_cache: HashMap<u128, (u32, [f64; 3], [f64; 3])> = HashMap::new();
+    let mut shared_cache: FxHashMap<u128, (u32, [f64; 3], [f64; 3])> = FxHashMap::default();
     let (mut pos_len, mut norm_len, mut idx_len) = (0u64, 0u64, 0u64);
     let quantize = opts.quantize;
 
@@ -2218,7 +2317,7 @@ fn plan_bounded_glb(
             extras: node_extras(
                 opts.include_metadata,
                 meta.express_id,
-                &meta.ifc_type,
+                meta.ifc_type.as_ref(),
                 meta.global_id.as_deref(),
                 opts.model_id.as_deref(),
             ),
@@ -2366,6 +2465,8 @@ fn write_bounded_glb(
     let norm_base = bin_base + pos_len as usize;
     let idx_base = bin_base + (pos_len + norm_len) as usize;
 
+    let filter = VisibilityFilter::new(opts);
+    let mut yscratch = crate::frame::YUpScratch::new();
     let mut cursor = 0usize;
     process_geometry_streaming_filtered_with_options(
         content,
@@ -2373,10 +2474,11 @@ fn write_bounded_glb(
         stream_opts(),
         |batch, _, _| {
             for m in batch {
-                if !mesh_visible(m, opts) {
+                if !filter.visible(m) {
                     continue;
                 }
-                let y = crate::frame::to_yup(&m.positions, &m.normals, &m.indices, m.origin);
+                crate::frame::to_yup_into(&mut yscratch, &m.positions, &m.normals, &m.indices, m.origin);
+                let y = &yscratch;
                 if y.indices.is_empty()
                     || y.positions.len() < 9
                     || !y.positions.len().is_multiple_of(3)
@@ -2481,11 +2583,80 @@ fn write_bounded_glb(
     (out, stats)
 }
 
+/// Fail-closed [`export_glb_from_meshes`]: validates that the per-mesh
+/// `vertex_counts` / `index_counts` (and normals) are fully backed by the flattened
+/// buffers BEFORE assembling. If a count runs past the end of `positions` / `indices`
+/// / `normals`, returns [`ExportError::MalformedMeshInput`] instead of silently
+/// dropping the un-backed tail (which the infallible variant does — a valid GLB
+/// missing part of the model, reported as success). Prefer this at any boundary where
+/// the counts and buffers come from separate sources (the wasm FFI).
+#[allow(clippy::too_many_arguments)]
+pub fn try_export_glb_from_meshes(
+    positions: &[f32],
+    normals: &[f32],
+    indices: &[u32],
+    vertex_counts: &[u32],
+    index_counts: &[u32],
+    colors: &[f32],
+    origins: &[f64],
+    express_ids: &[u32],
+    include_metadata: bool,
+    lit: bool,
+    emissive: bool,
+) -> Result<(Vec<u8>, GltfStats), ExportError> {
+    // Sum the declared counts and check they fit the flattened buffers. `u64` sums so a
+    // caller passing absurd counts can't overflow `usize` on wasm32 before the compare.
+    // `index_counts` is truncated to `vertex_counts.len()`, matching the assembler, which
+    // treats a missing `index_counts[i]` as 0 and ignores any surplus entries.
+    let n = vertex_counts.len();
+    let vsum: u64 = vertex_counts.iter().map(|&c| c as u64).sum();
+    let isum: u64 = index_counts.iter().take(n).map(|&c| c as u64).sum();
+    if vsum * 3 > positions.len() as u64 {
+        return Err(ExportError::MalformedMeshInput {
+            detail: format!(
+                "vertex_counts sum to {vsum} vertices ({} position floats) but `positions` has {}",
+                vsum * 3,
+                positions.len()
+            ),
+        });
+    }
+    // Normals must be either absent (0) or cover every emitted vertex; a short-but-nonzero
+    // normals buffer would make the under-covered meshes silently fail `view_ok` and vanish.
+    if !normals.is_empty() && (normals.len() as u64) < vsum * 3 {
+        return Err(ExportError::MalformedMeshInput {
+            detail: format!(
+                "`normals` has {} floats but the meshes need {} (vertex_counts sum to {vsum})",
+                normals.len(),
+                vsum * 3
+            ),
+        });
+    }
+    if isum > indices.len() as u64 {
+        return Err(ExportError::MalformedMeshInput {
+            detail: format!(
+                "index_counts sum to {isum} but `indices` has {}",
+                indices.len()
+            ),
+        });
+    }
+    // Every count is backed, so the infallible assembler's malformed-input `break` is
+    // unreachable and no mesh is dropped.
+    Ok(export_glb_from_meshes(
+        positions, normals, indices, vertex_counts, index_counts, colors, origins,
+        express_ids, include_metadata, lit, emissive,
+    ))
+}
+
 /// Assemble a GLB from already-produced meshes (the viewer's MeshData — **no re-meshing**).
 /// Per mesh `i`: `vertex_counts[i]` vertices + `index_counts[i]` indices, taken in order
 /// from the concatenated `positions`/`normals`/`indices`; `colors` is RGBA per mesh,
 /// `origins` is xyz per mesh, `express_ids` labels each mesh. Indices are per-mesh LOCAL.
 /// Callers pass exactly the meshes they want emitted (visibility filtering is theirs).
+///
+/// NOTE: on malformed input — a `vertex_counts`/`index_counts` entry that runs past the
+/// end of the flattened buffers — this stops at the first un-backed mesh and returns the
+/// valid prefix, so a caller bug ships a GLB missing the model's tail as "success". Use
+/// [`try_export_glb_from_meshes`] to turn that into [`ExportError::MalformedMeshInput`].
 #[allow(clippy::too_many_arguments)]
 // The index `i` walks several parallel count/offset arrays in lockstep; a
 // range loop is the clearest expression and avoids zipping ragged slices.
@@ -2559,15 +2730,19 @@ pub fn export_glb_from_meshes(
     let (gltf, stats) =
         build_gltf(&views, include_metadata, None, lit, emissive, [0.0, 0.0, 0.0], false, &mut ch);
     let json = serde_json::to_vec(&gltf).expect("glTF JSON serializes");
-    (pack_glb(&json, &ch.embedded_bin), stats)
+    (pack_glb(&json, &ch.pos, &ch.norm, &ch.idx), stats)
 }
 
-/// Pack a glTF JSON document and binary buffer into a GLB container (little-endian).
-fn pack_glb(json_bytes: &[u8], bin: &[u8]) -> Vec<u8> {
+/// Pack a glTF JSON document and the binary buffer's three runs (positions | normals |
+/// indices) into a GLB container (little-endian). The runs are appended straight into the
+/// output — no intermediate concatenated `bin` copy — so the single-buffer GLB path holds
+/// only one full copy of the geometry at pack time instead of two.
+fn pack_glb(json_bytes: &[u8], pos: &[u8], norm: &[u8], idx: &[u8]) -> Vec<u8> {
+    let bin_len = pos.len() + norm.len() + idx.len();
     let json_pad = (4 - (json_bytes.len() % 4)) % 4;
-    let bin_pad = (4 - (bin.len() % 4)) % 4;
+    let bin_pad = (4 - (bin_len % 4)) % 4;
     let padded_json = json_bytes.len() + json_pad;
-    let padded_bin = bin.len() + bin_pad;
+    let padded_bin = bin_len + bin_pad;
 
     let total = 12 + 8 + padded_json + 8 + padded_bin;
     // The GLB container total and chunk lengths are u32 (little-endian). This is
@@ -2592,10 +2767,13 @@ fn pack_glb(json_bytes: &[u8], bin: &[u8]) -> Vec<u8> {
     out.extend_from_slice(json_bytes);
     out.extend(std::iter::repeat_n(0x20, json_pad));
 
-    // BIN chunk (zero-padded)
+    // BIN chunk (zero-padded): the three runs written back-to-back are byte-identical to
+    // the old `positions ++ normals ++ indices` concatenation.
     out.extend_from_slice(&(padded_bin as u32).to_le_bytes());
     out.extend_from_slice(b"BIN\0");
-    out.extend_from_slice(bin);
+    out.extend_from_slice(pos);
+    out.extend_from_slice(norm);
+    out.extend_from_slice(idx);
     out.extend(std::iter::repeat_n(0x00, bin_pad));
 
     out
@@ -3349,6 +3527,56 @@ mod tests {
     }
 
     #[test]
+    fn try_from_meshes_matches_infallible_on_valid_input() {
+        // A single unit quad supplied as flat buffers. The fail-closed variant must
+        // return byte-for-byte the same GLB as the infallible one when counts are valid.
+        let positions: Vec<f32> = vec![0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0];
+        let normals: Vec<f32> = vec![0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0];
+        let indices: Vec<u32> = vec![0, 1, 2, 0, 2, 3];
+        let (vc, ic) = (vec![4u32], vec![6u32]);
+        let color = vec![0.5, 0.5, 0.5, 1.0];
+        let origin = vec![0.0, 0.0, 0.0];
+        let ids = vec![1u32];
+        let (want, _) = export_glb_from_meshes(
+            &positions, &normals, &indices, &vc, &ic, &color, &origin, &ids, false, true, false,
+        );
+        let (got, _) = try_export_glb_from_meshes(
+            &positions, &normals, &indices, &vc, &ic, &color, &origin, &ids, false, true, false,
+        )
+        .expect("valid counts must not be MalformedMeshInput");
+        assert_eq!(want, got, "try_ path equals infallible path on valid input");
+    }
+
+    #[test]
+    fn try_from_meshes_rejects_counts_past_buffers() {
+        // Buffers hold one quad (4 verts / 6 indices) but the counts claim two meshes —
+        // the second runs past the end. The infallible path silently drops it (returns
+        // only the valid prefix); the fail-closed path must reject.
+        let positions: Vec<f32> = vec![0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0];
+        let normals: Vec<f32> = vec![0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0];
+        let indices: Vec<u32> = vec![0, 1, 2, 0, 2, 3];
+        // Two meshes of 4 verts each, but only 4 verts of positions exist.
+        let (vc, ic) = (vec![4u32, 4u32], vec![6u32, 6u32]);
+        let color = vec![0.5, 0.5, 0.5, 1.0, 0.5, 0.5, 0.5, 1.0];
+        let origin = vec![0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
+        let ids = vec![1u32, 2u32];
+
+        // Infallible: silently truncates to the first (valid) mesh — the data-loss bug.
+        let (_, stats) = export_glb_from_meshes(
+            &positions, &normals, &indices, &vc, &ic, &color, &origin, &ids, false, true, false,
+        );
+        assert_eq!(stats.meshes, 1, "infallible path drops the un-backed second mesh silently");
+
+        // Fail-closed: surfaces it as a typed error the caller can act on.
+        let err = try_export_glb_from_meshes(
+            &positions, &normals, &indices, &vc, &ic, &color, &origin, &ids, false, true, false,
+        )
+        .expect_err("counts past the buffers must be MalformedMeshInput");
+        assert!(matches!(err, ExportError::MalformedMeshInput { .. }), "got {err:?}");
+        assert_eq!(err.code(), "MALFORMED_MESH_INPUT");
+    }
+
+    #[test]
     fn export_is_byte_deterministic() {
         // Instancing groups by HashMap keys (rep colour buckets, material dedup);
         // emission order must be fixed so repeated exports are byte-identical.
@@ -3598,11 +3826,13 @@ mod tests {
         let default_opts = GltfOptions::default();
         let mut truth: HashMap<u32, Vec<[f64; 3]>> = HashMap::new();
         let mut dup_ids: std::collections::HashSet<u32> = std::collections::HashSet::new();
+        let mut yscratch = crate::frame::YUpScratch::new();
         for m in &result.meshes {
             if !super::mesh_visible(m, &default_opts) || m.positions.len() < 9 {
                 continue;
             }
-            let y = crate::frame::to_yup(&m.positions, &m.normals, &m.indices, m.origin);
+            crate::frame::to_yup_into(&mut yscratch, &m.positions, &m.normals, &m.indices, m.origin);
+            let y = &yscratch;
             let verts: Vec<[f64; 3]> = y
                 .positions
                 .chunks_exact(3)

--- a/rust/export/src/gltf.rs
+++ b/rust/export/src/gltf.rs
@@ -39,6 +39,14 @@ use ifc_lite_processing::{
 use serde::Serialize;
 use serde_json::{json, Value};
 
+// Split-out submodules (kept child modules so they can reach this module's private
+// assembler internals via `super`; the code moved verbatim, so output is unchanged).
+mod from_meshes;
+mod matrix;
+
+pub use from_meshes::{export_glb_from_meshes, try_export_glb_from_meshes};
+use matrix::{affine_inverse, compose_world_meta, occurrence_node_matrix};
+
 /// Options for glTF/GLB export.
 pub struct GltfOptions {
     /// Attach `asset.extras` (counts) and per-node `extras.expressId`.
@@ -372,158 +380,6 @@ fn geom_color_key(positions: &[f32], normals: &[f32], indices: &[u32], color: [f
     h.update(&b.to_le_bytes());
     h.update(&a.to_le_bytes());
     h.digest128()
-}
-
-// ── Instancing matrix math (row-major f64 4x4) ──────────────────────────────
-//
-// An occurrence's node matrix must map the shared template's Y-up LOCAL geometry
-// to that occurrence's Y-up BAKED world position, minus the model-wide
-// `scene_center` that the root node carries:
-//
-//   N_k = T(-scene_center) · S · [ T(-rtc) · (M_k · M_ref⁻¹) · T(rtc) ] · S⁻¹ · T(template_origin_yup)
-//
-// where `M = transform · local · canonical` is the per-occurrence world placement
-// from `InstanceMeta` (Z-up, **pre-RTC**), `rtc` is the model RTC/site offset the
-// baker subtracted (Z-up), and `S` is the Z-up→Y-up basis `(x,y,z) → (x, z, -y)`.
-// The `T(-rtc)·…·T(rtc)` conjugation moves the relative transform from the pre-RTC
-// frame `M` lives in into the POST-RTC baked frame the template geometry is in —
-// without it, a rotated occurrence under a non-zero site/georef offset is
-// mis-translated by `(R_rel - I)·rtc` (kilometres at national-grid scale). Everything
-// is f64, recomputed from the f64 `InstanceMeta` (NOT the collator's f32 `rel`), so
-// the absolute-magnitude terms cancel to a small, f32-precise translation before the
-// final downcast even at national-grid coordinates.
-
-/// Z-up→Y-up basis as a row-major 4x4 (linear part only; `(x,y,z) → (x, z, -y)`).
-const S_YUP: [f64; 16] = [
-    1.0, 0.0, 0.0, 0.0, //
-    0.0, 0.0, 1.0, 0.0, //
-    0.0, -1.0, 0.0, 0.0, //
-    0.0, 0.0, 0.0, 1.0,
-];
-/// Inverse (transpose, since `S_YUP` is a proper rotation): `(x,y,z) → (x, -z, y)`.
-const S_YUP_INV: [f64; 16] = [
-    1.0, 0.0, 0.0, 0.0, //
-    0.0, 0.0, -1.0, 0.0, //
-    0.0, 1.0, 0.0, 0.0, //
-    0.0, 0.0, 0.0, 1.0,
-];
-const IDENTITY16: [f64; 16] = [
-    1.0, 0.0, 0.0, 0.0, //
-    0.0, 1.0, 0.0, 0.0, //
-    0.0, 0.0, 1.0, 0.0, //
-    0.0, 0.0, 0.0, 1.0,
-];
-
-/// Row-major 4x4 multiply `a · b`.
-fn mat4_mul(a: &[f64; 16], b: &[f64; 16]) -> [f64; 16] {
-    let mut out = [0.0f64; 16];
-    for r in 0..4 {
-        for c in 0..4 {
-            let mut s = 0.0;
-            for k in 0..4 {
-                s += a[r * 4 + k] * b[k * 4 + c];
-            }
-            out[r * 4 + c] = s;
-        }
-    }
-    out
-}
-
-/// Row-major translation matrix.
-fn mat4_translation(t: [f64; 3]) -> [f64; 16] {
-    [
-        1.0, 0.0, 0.0, t[0], //
-        0.0, 1.0, 0.0, t[1], //
-        0.0, 0.0, 1.0, t[2], //
-        0.0, 0.0, 0.0, 1.0,
-    ]
-}
-
-/// Transpose a row-major f64 4x4 into the column-major `[f32; 16]` glTF expects.
-fn row_major_f64_to_col_major_f32(m: &[f64; 16]) -> [f32; 16] {
-    let mut out = [0.0f32; 16];
-    for r in 0..4 {
-        for c in 0..4 {
-            out[c * 4 + r] = m[r * 4 + c] as f32;
-        }
-    }
-    out
-}
-
-/// Inverse of a row-major AFFINE 4x4 (last row `[0,0,0,1]`): invert the upper 3x3
-/// (cofactor / determinant) and map the translation by `-R⁻¹·t`. Returns `None` if
-/// the 3x3 is singular (degenerate placement) so the caller can fall back to flat.
-fn affine_inverse(m: &[f64; 16]) -> Option<[f64; 16]> {
-    let a = m[0]; let b = m[1]; let c = m[2];
-    let d = m[4]; let e = m[5]; let f = m[6];
-    let g = m[8]; let h = m[9]; let i = m[10];
-    let det = a * (e * i - f * h) - b * (d * i - f * g) + c * (d * h - e * g);
-    if det.abs() < 1e-18 {
-        return None;
-    }
-    let inv_det = 1.0 / det;
-    // Inverse of the 3x3 (row-major) via the transposed cofactor matrix.
-    let r = [
-        (e * i - f * h) * inv_det,
-        (c * h - b * i) * inv_det,
-        (b * f - c * e) * inv_det,
-        (f * g - d * i) * inv_det,
-        (a * i - c * g) * inv_det,
-        (c * d - a * f) * inv_det,
-        (d * h - e * g) * inv_det,
-        (b * g - a * h) * inv_det,
-        (a * e - b * d) * inv_det,
-    ];
-    let (tx, ty, tz) = (m[3], m[7], m[11]);
-    // Translation of the inverse: -R⁻¹ · t.
-    let it = [
-        -(r[0] * tx + r[1] * ty + r[2] * tz),
-        -(r[3] * tx + r[4] * ty + r[5] * tz),
-        -(r[6] * tx + r[7] * ty + r[8] * tz),
-    ];
-    Some([
-        r[0], r[1], r[2], it[0], //
-        r[3], r[4], r[5], it[1], //
-        r[6], r[7], r[8], it[2], //
-        0.0, 0.0, 0.0, 1.0,
-    ])
-}
-
-/// Compose an `InstanceMeta`'s world placement `transform · local · canonical`
-/// (row-major f64), the same product the collator's `compose_world` builds.
-fn compose_world_meta(meta: &InstanceMeta) -> [f64; 16] {
-    let local = meta.local_transform.unwrap_or(IDENTITY16);
-    let canonical = meta.canonical_transform.unwrap_or(IDENTITY16);
-    mat4_mul(&meta.transform, &mat4_mul(&local, &canonical))
-}
-
-/// Build the column-major glTF node matrix placing a shared template (Y-up local
-/// geometry, relative to `template_origin_yup`) at one occurrence's BAKED pose.
-/// Recomputed in f64 from the occurrence's `InstanceMeta`, the precomputed template
-/// inverse `m_ref_inv` (`affine_inverse(compose_world_meta(template))`, computed once
-/// per group), and the model `rtc` offset (Z-up) the baker subtracted.
-fn occurrence_node_matrix(
-    occ: &InstanceMeta,
-    m_ref_inv: &[f64; 16],
-    rtc_zup: [f64; 3],
-    template_origin_yup: [f64; 3],
-    scene_center: [f64; 3],
-) -> [f32; 16] {
-    let m_k = compose_world_meta(occ);
-    // rel maps the template's PRE-RTC world geometry onto occurrence k's.
-    let rel_pre = mat4_mul(&m_k, m_ref_inv);
-    // Conjugate into the POST-RTC baked frame the geometry actually lives in.
-    let rel_baked = mat4_mul(
-        &mat4_translation([-rtc_zup[0], -rtc_zup[1], -rtc_zup[2]]),
-        &mat4_mul(&rel_pre, &mat4_translation(rtc_zup)),
-    );
-    // Conjugate Z-up→Y-up (the template was converted by the same S).
-    let rel_yup = mat4_mul(&mat4_mul(&S_YUP, &rel_baked), &S_YUP_INV);
-    let n = mat4_mul(
-        &mat4_translation([-scene_center[0], -scene_center[1], -scene_center[2]]),
-        &mat4_mul(&rel_yup, &mat4_translation(template_origin_yup)),
-    );
-    row_major_f64_to_col_major_f32(&n)
 }
 
 /// Streams geometry into one or more glTF buffers. Each buffer holds three bufferViews
@@ -2600,155 +2456,6 @@ fn write_bounded_glb(
     (out, stats)
 }
 
-/// Fail-closed [`export_glb_from_meshes`]: validates that the per-mesh
-/// `vertex_counts` / `index_counts` (and normals) are fully backed by the flattened
-/// buffers BEFORE assembling. If a count runs past the end of `positions` / `indices`
-/// / `normals`, returns [`ExportError::MalformedMeshInput`] instead of silently
-/// dropping the un-backed tail (which the infallible variant does — a valid GLB
-/// missing part of the model, reported as success). Prefer this at any boundary where
-/// the counts and buffers come from separate sources (the wasm FFI).
-#[allow(clippy::too_many_arguments)]
-pub fn try_export_glb_from_meshes(
-    positions: &[f32],
-    normals: &[f32],
-    indices: &[u32],
-    vertex_counts: &[u32],
-    index_counts: &[u32],
-    colors: &[f32],
-    origins: &[f64],
-    express_ids: &[u32],
-    include_metadata: bool,
-    lit: bool,
-    emissive: bool,
-) -> Result<(Vec<u8>, GltfStats), ExportError> {
-    // Sum the declared counts and check they fit the flattened buffers. `u64` sums so a
-    // caller passing absurd counts can't overflow `usize` on wasm32 before the compare.
-    // `index_counts` is truncated to `vertex_counts.len()`, matching the assembler, which
-    // treats a missing `index_counts[i]` as 0 and ignores any surplus entries.
-    let n = vertex_counts.len();
-    let vsum: u64 = vertex_counts.iter().map(|&c| c as u64).sum();
-    let isum: u64 = index_counts.iter().take(n).map(|&c| c as u64).sum();
-    if vsum * 3 > positions.len() as u64 {
-        return Err(ExportError::MalformedMeshInput {
-            detail: format!(
-                "vertex_counts sum to {vsum} vertices ({} position floats) but `positions` has {}",
-                vsum * 3,
-                positions.len()
-            ),
-        });
-    }
-    // Normals must be either absent (0) or cover every emitted vertex; a short-but-nonzero
-    // normals buffer would make the under-covered meshes silently fail `view_ok` and vanish.
-    if !normals.is_empty() && (normals.len() as u64) < vsum * 3 {
-        return Err(ExportError::MalformedMeshInput {
-            detail: format!(
-                "`normals` has {} floats but the meshes need {} (vertex_counts sum to {vsum})",
-                normals.len(),
-                vsum * 3
-            ),
-        });
-    }
-    if isum > indices.len() as u64 {
-        return Err(ExportError::MalformedMeshInput {
-            detail: format!(
-                "index_counts sum to {isum} but `indices` has {}",
-                indices.len()
-            ),
-        });
-    }
-    // Every count is backed, so the infallible assembler's malformed-input `break` is
-    // unreachable and no mesh is dropped.
-    Ok(export_glb_from_meshes(
-        positions, normals, indices, vertex_counts, index_counts, colors, origins,
-        express_ids, include_metadata, lit, emissive,
-    ))
-}
-
-/// Assemble a GLB from already-produced meshes (the viewer's MeshData — **no re-meshing**).
-/// Per mesh `i`: `vertex_counts[i]` vertices + `index_counts[i]` indices, taken in order
-/// from the concatenated `positions`/`normals`/`indices`; `colors` is RGBA per mesh,
-/// `origins` is xyz per mesh, `express_ids` labels each mesh. Indices are per-mesh LOCAL.
-/// Callers pass exactly the meshes they want emitted (visibility filtering is theirs).
-///
-/// NOTE: on malformed input — a `vertex_counts`/`index_counts` entry that runs past the
-/// end of the flattened buffers — this stops at the first un-backed mesh and returns the
-/// valid prefix, so a caller bug ships a GLB missing the model's tail as "success". Use
-/// [`try_export_glb_from_meshes`] to turn that into [`ExportError::MalformedMeshInput`].
-#[allow(clippy::too_many_arguments)]
-// The index `i` walks several parallel count/offset arrays in lockstep; a
-// range loop is the clearest expression and avoids zipping ragged slices.
-#[allow(clippy::needless_range_loop)]
-pub fn export_glb_from_meshes(
-    positions: &[f32],
-    normals: &[f32],
-    indices: &[u32],
-    vertex_counts: &[u32],
-    index_counts: &[u32],
-    colors: &[f32],
-    origins: &[f64],
-    express_ids: &[u32],
-    include_metadata: bool,
-    lit: bool,
-    emissive: bool,
-) -> (Vec<u8>, GltfStats) {
-    let n = vertex_counts.len();
-    // The viewer's `MeshData` arrives pre-welded from the mesh source
-    // (`ifc_lite_processing::element::build_mesh_data` welds every element via
-    // `ifc_lite_geometry::mesh_weld::weld_indexed`), so this path no longer
-    // re-welds — it slices each mesh's block straight into a borrowing
-    // `MeshView`. Views borrow the caller's buffers, which outlive the call.
-    let mut views: Vec<MeshView> = Vec::with_capacity(n);
-    let mut vbase = 0usize; // running vertex offset
-    let mut ibase = 0usize; // running index offset
-    for i in 0..n {
-        let vc = vertex_counts[i] as usize;
-        let ic = index_counts.get(i).copied().unwrap_or(0) as usize;
-        if (vbase + vc) * 3 > positions.len() || ibase + ic > indices.len() {
-            break; // malformed counts — stop rather than panic
-        }
-        let pslice = &positions[vbase * 3..(vbase + vc) * 3];
-        let nslice: &[f32] = if normals.len() >= (vbase + vc) * 3 {
-            &normals[vbase * 3..(vbase + vc) * 3]
-        } else {
-            &[]
-        };
-        let islice = &indices[ibase..ibase + ic];
-        let color = [
-            colors.get(i * 4).copied().unwrap_or(0.8),
-            colors.get(i * 4 + 1).copied().unwrap_or(0.8),
-            colors.get(i * 4 + 2).copied().unwrap_or(0.8),
-            colors.get(i * 4 + 3).copied().unwrap_or(1.0),
-        ];
-        let origin = [
-            origins.get(i * 3).copied().unwrap_or(0.0),
-            origins.get(i * 3 + 1).copied().unwrap_or(0.0),
-            origins.get(i * 3 + 2).copied().unwrap_or(0.0),
-        ];
-        views.push(MeshView {
-            express_id: express_ids.get(i).copied().unwrap_or(0),
-            ifc_type: "",
-            global_id: None,
-            positions: pslice,
-            normals: nslice,
-            indices: islice,
-            color,
-            origin,
-            // The viewer's MeshData drops the instancing side-channel across the
-            // worker boundary (it is `#[serde(skip)]`), so this path is always flat.
-            instance: None,
-        });
-        vbase += vc;
-        ibase += ic;
-    }
-    // From-meshes geometry is already absolute Y-up and never instances (no
-    // side-channel), so there is no RTC frame to compensate. Quantization is a
-    // from-bytes feature; the viewer path stays f32.
-    let mut ch = Chunker::new(12, usize::MAX, None);
-    let (gltf, stats) =
-        build_gltf(&views, include_metadata, None, lit, emissive, [0.0, 0.0, 0.0], false, &mut ch);
-    let json = serde_json::to_vec(&gltf).expect("glTF JSON serializes");
-    (pack_glb(&json, &ch.pos, &ch.norm, &ch.idx), stats)
-}
 
 /// Pack a glTF JSON document and the binary buffer's three runs (positions | normals |
 /// indices) into a GLB container (little-endian). The runs are appended straight into the
@@ -3594,6 +3301,49 @@ mod tests {
     }
 
     #[test]
+    fn try_from_meshes_rejects_short_normals() {
+        // One quad (4 verts) needs 12 normal floats, but only 6 are supplied — the
+        // under-covered mesh would fall back to an empty normal slice and vanish.
+        let positions: Vec<f32> = vec![0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0];
+        let normals: Vec<f32> = vec![0.0, 0.0, 1.0, 0.0, 0.0, 1.0]; // short of vsum*3 = 12
+        let indices: Vec<u32> = vec![0, 1, 2, 0, 2, 3];
+        let (vc, ic) = (vec![4u32], vec![6u32]);
+        let color = vec![0.5, 0.5, 0.5, 1.0];
+        let origin = vec![0.0, 0.0, 0.0];
+        let ids = vec![1u32];
+        let err = try_export_glb_from_meshes(
+            &positions, &normals, &indices, &vc, &ic, &color, &origin, &ids, false, true, false,
+        )
+        .expect_err("short normals must be MalformedMeshInput");
+        assert!(matches!(err, ExportError::MalformedMeshInput { .. }), "got {err:?}");
+
+        // Empty normals is the degenerate case that would drop the WHOLE model.
+        let err_empty = try_export_glb_from_meshes(
+            &positions, &[], &indices, &vc, &ic, &color, &origin, &ids, false, true, false,
+        )
+        .expect_err("empty normals must be MalformedMeshInput");
+        assert!(matches!(err_empty, ExportError::MalformedMeshInput { .. }), "got {err_empty:?}");
+    }
+
+    #[test]
+    fn try_from_meshes_rejects_index_counts_past_buffer() {
+        // `index_counts` declares more indices than `indices` holds — the overrun the
+        // infallible path's per-mesh `break` would silently truncate at.
+        let positions: Vec<f32> = vec![0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0];
+        let normals: Vec<f32> = vec![0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0];
+        let indices: Vec<u32> = vec![0, 1, 2, 0, 2, 3];
+        let (vc, ic) = (vec![4u32], vec![12u32]); // 12 > indices.len() == 6
+        let color = vec![0.5, 0.5, 0.5, 1.0];
+        let origin = vec![0.0, 0.0, 0.0];
+        let ids = vec![1u32];
+        let err = try_export_glb_from_meshes(
+            &positions, &normals, &indices, &vc, &ic, &color, &origin, &ids, false, true, false,
+        )
+        .expect_err("index_counts past `indices` must be MalformedMeshInput");
+        assert!(matches!(err, ExportError::MalformedMeshInput { .. }), "got {err:?}");
+    }
+
+    #[test]
     fn export_is_byte_deterministic() {
         // Instancing groups by HashMap keys (rep colour buckets, material dedup);
         // emission order must be fixed so repeated exports are byte-identical.
@@ -3706,122 +3456,6 @@ mod tests {
                  (run `pnpm fixtures`)"
             );
         }
-    }
-
-    #[test]
-    fn occurrence_matrix_reconstructs_rotated_instance_under_national_grid_rtc() {
-        // Decisive synthetic test for the RTC/rotation frame (review finding C1+M1):
-        // a ROTATED occurrence at NATIONAL-GRID coordinates. The node matrix is built
-        // from the same InstanceMeta the baker would carry; reconstructing the
-        // occurrence from the template's baked-local geometry must land on the
-        // occurrence's own baked geometry to sub-millimetre, even though the relative
-        // transform's absolute terms are ~1e5 m. (A pre-RTC `rel` applied to post-RTC
-        // geometry — the bug — misplaces this by ~(R-I)·rtc, i.e. hundreds of metres.)
-        use ifc_lite_geometry::InstanceMeta;
-
-        // Row-major helpers.
-        let translate = |t: [f64; 3]| -> [f64; 16] {
-            [1., 0., 0., t[0], 0., 1., 0., t[1], 0., 0., 1., t[2], 0., 0., 0., 1.]
-        };
-        // Rotation about Z (Z-up): (x,y) rotate, z fixed.
-        let rot_z = |deg: f64| -> [f64; 16] {
-            let (s, c) = (deg.to_radians().sin(), deg.to_radians().cos());
-            [c, -s, 0., 0., s, c, 0., 0., 0., 0., 1., 0., 0., 0., 0., 1.]
-        };
-        let apply = |m: &[f64; 16], p: [f64; 3]| -> [f64; 3] {
-            [
-                m[0] * p[0] + m[1] * p[1] + m[2] * p[2] + m[3],
-                m[4] * p[0] + m[5] * p[1] + m[6] * p[2] + m[7],
-                m[8] * p[0] + m[9] * p[1] + m[10] * p[2] + m[11],
-            ]
-        };
-
-        // Placements (Z-up, pre-RTC): template upright, occurrence rotated 37° about Z.
-        let m_ref = super::mat4_mul(&translate([10., 20., 5.]), &rot_z(0.0));
-        let m_k = super::mat4_mul(&translate([60., 35., 5.]), &rot_z(37.0));
-        // National-grid RTC the baker subtracts (e.g. Dutch RD-ish easting/northing).
-        let rtc = [155_000.0_f64, 463_000.0, 0.0];
-
-        // Canonical (rep-local) geometry — a few non-degenerate points.
-        let canonical = [
-            [0.0, 0.0, 0.0],
-            [1.0, 0.0, 0.0],
-            [0.0, 2.0, 0.0],
-            [0.5, 0.5, 1.5],
-            [2.0, 0.3, 0.7],
-        ];
-        // Baked = placement·canonical - rtc, in Z-up.
-        let bake = |m: &[f64; 16]| -> Vec<[f64; 3]> {
-            canonical
-                .iter()
-                .map(|&x| {
-                    let w = apply(m, x);
-                    [w[0] - rtc[0], w[1] - rtc[1], w[2] - rtc[2]]
-                })
-                .collect()
-        };
-        let tmpl_baked = bake(&m_ref);
-        let occ_baked = bake(&m_k);
-
-        // Template origin = centroid of its baked geometry; local = baked - origin.
-        let n = canonical.len() as f64;
-        let origin_z = {
-            let mut o = [0.0; 3];
-            for p in &tmpl_baked {
-                for k in 0..3 {
-                    o[k] += p[k] / n;
-                }
-            }
-            o
-        };
-        // Convert template origin + local, and the occurrence's baked truth, to Y-up.
-        let origin_yup = crate::frame::yup_f64(origin_z);
-        let tmpl_local_yup: Vec<[f64; 3]> = tmpl_baked
-            .iter()
-            .map(|p| crate::frame::yup_f64([p[0] - origin_z[0], p[1] - origin_z[1], p[2] - origin_z[2]]))
-            .collect();
-        let occ_world_yup: Vec<[f64; 3]> = occ_baked.iter().map(|p| crate::frame::yup_f64(*p)).collect();
-
-        // scene_center = centre of the combined baked Y-up AABB.
-        let mut lo = [f64::INFINITY; 3];
-        let mut hi = [f64::NEG_INFINITY; 3];
-        for p in tmpl_baked.iter().chain(occ_baked.iter()) {
-            let y = crate::frame::yup_f64(*p);
-            for k in 0..3 {
-                lo[k] = lo[k].min(y[k]);
-                hi[k] = hi[k].max(y[k]);
-            }
-        }
-        let scene_center = [(lo[0] + hi[0]) * 0.5, (lo[1] + hi[1]) * 0.5, (lo[2] + hi[2]) * 0.5];
-
-        let meta = |transform: [f64; 16]| InstanceMeta {
-            transform,
-            local_transform: None,
-            canonical_transform: None,
-            rep_identity: 42,
-            instanceable: true,
-        };
-        let m_ref_inv = super::affine_inverse(&super::compose_world_meta(&meta(m_ref)))
-            .expect("template placement invertible");
-        let node = super::occurrence_node_matrix(&meta(m_k), &m_ref_inv, rtc, origin_yup, scene_center);
-
-        // Reconstruct: world = scene_center(root) + node(col-major) · template_local.
-        let mut max_err = 0.0f64;
-        for (lv, truth) in tmpl_local_yup.iter().zip(&occ_world_yup) {
-            let (x, y, z) = (lv[0], lv[1], lv[2]);
-            let world = [
-                scene_center[0] + node[0] as f64 * x + node[4] as f64 * y + node[8] as f64 * z + node[12] as f64,
-                scene_center[1] + node[1] as f64 * x + node[5] as f64 * y + node[9] as f64 * z + node[13] as f64,
-                scene_center[2] + node[2] as f64 * x + node[6] as f64 * y + node[10] as f64 * z + node[14] as f64,
-            ];
-            for k in 0..3 {
-                max_err = max_err.max((world[k] - truth[k]).abs());
-            }
-        }
-        assert!(
-            max_err < 1e-3,
-            "rotated instance under national-grid RTC mis-reconstructed by {max_err} m"
-        );
     }
 
     #[test]

--- a/rust/export/src/gltf.rs
+++ b/rust/export/src/gltf.rs
@@ -19,6 +19,16 @@ use rustc_hash::{FxHashMap, FxHashSet};
 #[cfg(test)]
 use std::collections::HashMap;
 
+// The GLB binary layout is little-endian, and several hot paths reinterpret f32/u32
+// slices as raw bytes via `bytemuck::cast_slice` (vertex/normal/index encoding and the
+// content-dedup hash) — only byte-equivalent to `to_le_bytes` on a LE target. Every
+// target this crate ships for (wasm32, x86_64, aarch64) is LE; make a big-endian build
+// fail HERE rather than silently emit corrupt GLBs.
+const _: () = assert!(
+    cfg!(target_endian = "little"),
+    "ifc-lite-export assumes a little-endian target (GLB is LE; cast_slice byte reinterpretation)",
+);
+
 use crate::error::ExportError;
 use ifc_lite_core::EntityIndex;
 use ifc_lite_geometry::{collate_refs, InstanceMeshRef, InstanceMeta, InstanceTemplate};
@@ -618,7 +628,13 @@ impl<'s> Chunker<'s> {
                 // Single embedded GLB buffer: leave pos/norm/idx in place so the packer
                 // writes them straight into the container — no intermediate concatenated
                 // copy. `cap == usize::MAX` on this path, so `flush` runs exactly once and
-                // the runs are never reset mid-stream.
+                // the runs are never reset mid-stream. Pin that load-bearing invariant: a
+                // second non-empty flush here would push a duplicate buffer AND leave the
+                // now-unreset runs to be written twice.
+                debug_assert!(
+                    self.next_buffer == 0,
+                    "single-buffer GLB path must flush exactly once (cap == usize::MAX)",
+                );
                 self.buffers.push(Buffer { byte_length: total as u32, uri: None });
             }
         }
@@ -987,7 +1003,8 @@ fn view_ok(v: &MeshView) -> bool {
 /// Build the glTF document, streaming geometry through `ch` (single embedded buffer for
 /// GLB, or chunked external buffers for multi-buffer glTF). Returns the `Gltf` for the
 /// caller to pack (GLB) or serialize (glTF); the binary lives in `ch` afterwards
-/// (`ch.embedded_bin` for the single-buffer case, or already handed to the chunk sink).
+/// (the `ch.pos`/`ch.norm`/`ch.idx` runs for the single-buffer case, which `pack_glb`
+/// writes straight into the container, or already handed to the chunk sink).
 // Cohesive builder: these are the orthogonal knobs of one glTF pass (metadata,
 // model id, lit/emissive material, RTC origin, quantization) and packing them
 // into a struct would not reduce the real coupling. #1427 added `emissive`.

--- a/rust/export/src/gltf/from_meshes.rs
+++ b/rust/export/src/gltf/from_meshes.rs
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: MPL-2.0
+//! The **from-meshes** GLB path: assemble a GLB from already-produced meshes (the
+//! viewer's `MeshData`, flattened) with no re-meshing, plus its fail-closed wrapper.
+//!
+//! Split out of `gltf.rs` to keep that module under its size ratchet; the logic is
+//! unchanged, so the emitted bytes are identical.
+
+use super::{build_gltf, pack_glb, Chunker, GltfStats, MeshView};
+use crate::error::ExportError;
+
+/// Fail-closed [`export_glb_from_meshes`]: validates that the per-mesh
+/// `vertex_counts` / `index_counts` (and normals) are fully backed by the flattened
+/// buffers BEFORE assembling. If a declared vertex/index count runs past the end of
+/// `positions` / `indices`, an `index_counts` entry is missing, or `normals` is empty or
+/// too short to cover every emitted vertex, returns [`ExportError::MalformedMeshInput`]
+/// instead of silently dropping the un-backed meshes (which the infallible variant does —
+/// a valid GLB missing part of the model, reported as success). Prefer this at any
+/// boundary where the counts and buffers come from separate sources (the wasm FFI).
+#[allow(clippy::too_many_arguments)]
+pub fn try_export_glb_from_meshes(
+    positions: &[f32],
+    normals: &[f32],
+    indices: &[u32],
+    vertex_counts: &[u32],
+    index_counts: &[u32],
+    colors: &[f32],
+    origins: &[f64],
+    express_ids: &[u32],
+    include_metadata: bool,
+    lit: bool,
+    emissive: bool,
+) -> Result<(Vec<u8>, GltfStats), ExportError> {
+    // Sum the declared counts and check they fit the flattened buffers. `u64` sums so a
+    // caller passing absurd counts can't overflow `usize` on wasm32 before the compare.
+    let n = vertex_counts.len();
+    let vsum: u64 = vertex_counts.iter().map(|&c| c as u64).sum();
+    let isum: u64 = index_counts.iter().take(n).map(|&c| c as u64).sum();
+    if vsum * 3 > positions.len() as u64 {
+        return Err(ExportError::MalformedMeshInput {
+            detail: format!(
+                "vertex_counts sum to {vsum} vertices ({} position floats) but `positions` has {}",
+                vsum * 3,
+                positions.len()
+            ),
+        });
+    }
+    // Parallel-array contract: each declared mesh needs its own `index_counts` entry.
+    // With fewer entries the assembler reads a missing count as 0 indices, so those
+    // meshes fail `view_ok` and vanish from a "successful" GLB.
+    if index_counts.len() < n {
+        return Err(ExportError::MalformedMeshInput {
+            detail: format!(
+                "`index_counts` has {} entries but `vertex_counts` declares {n} meshes",
+                index_counts.len()
+            ),
+        });
+    }
+    // Normals must cover EVERY emitted vertex. Empty (or short) normals make the
+    // under-covered meshes fall back to an empty normal slice, silently failing the
+    // `view_ok` `normals.len() == positions.len()` gate — with empty normals that drops
+    // the WHOLE model into a valid-but-empty GLB.
+    if (normals.len() as u64) < vsum * 3 {
+        return Err(ExportError::MalformedMeshInput {
+            detail: format!(
+                "`normals` has {} floats but the meshes need {} (vertex_counts sum to {vsum})",
+                normals.len(),
+                vsum * 3
+            ),
+        });
+    }
+    if isum > indices.len() as u64 {
+        return Err(ExportError::MalformedMeshInput {
+            detail: format!(
+                "index_counts sum to {isum} but `indices` has {}",
+                indices.len()
+            ),
+        });
+    }
+    // Every count is backed and every mesh's normals/indices are present, so the
+    // infallible assembler's malformed-input `break` is unreachable and no mesh is dropped.
+    Ok(export_glb_from_meshes(
+        positions, normals, indices, vertex_counts, index_counts, colors, origins,
+        express_ids, include_metadata, lit, emissive,
+    ))
+}
+
+/// Assemble a GLB from already-produced meshes (the viewer's MeshData — **no re-meshing**).
+/// Per mesh `i`: `vertex_counts[i]` vertices + `index_counts[i]` indices, taken in order
+/// from the concatenated `positions`/`normals`/`indices`; `colors` is RGBA per mesh,
+/// `origins` is xyz per mesh, `express_ids` labels each mesh. Indices are per-mesh LOCAL.
+/// Callers pass exactly the meshes they want emitted (visibility filtering is theirs).
+///
+/// NOTE: on malformed input — a `vertex_counts`/`index_counts` entry that runs past the
+/// end of the flattened buffers — this stops at the first un-backed mesh and returns the
+/// valid prefix, so a caller bug ships a GLB missing the model's tail as "success". Use
+/// [`try_export_glb_from_meshes`] to turn that into [`ExportError::MalformedMeshInput`].
+#[allow(clippy::too_many_arguments)]
+// The index `i` walks several parallel count/offset arrays in lockstep; a
+// range loop is the clearest expression and avoids zipping ragged slices.
+#[allow(clippy::needless_range_loop)]
+pub fn export_glb_from_meshes(
+    positions: &[f32],
+    normals: &[f32],
+    indices: &[u32],
+    vertex_counts: &[u32],
+    index_counts: &[u32],
+    colors: &[f32],
+    origins: &[f64],
+    express_ids: &[u32],
+    include_metadata: bool,
+    lit: bool,
+    emissive: bool,
+) -> (Vec<u8>, GltfStats) {
+    let n = vertex_counts.len();
+    // The viewer's `MeshData` arrives pre-welded from the mesh source
+    // (`ifc_lite_processing::element::build_mesh_data` welds every element via
+    // `ifc_lite_geometry::mesh_weld::weld_indexed`), so this path no longer
+    // re-welds — it slices each mesh's block straight into a borrowing
+    // `MeshView`. Views borrow the caller's buffers, which outlive the call.
+    let mut views: Vec<MeshView> = Vec::with_capacity(n);
+    let mut vbase = 0usize; // running vertex offset
+    let mut ibase = 0usize; // running index offset
+    for i in 0..n {
+        let vc = vertex_counts[i] as usize;
+        let ic = index_counts.get(i).copied().unwrap_or(0) as usize;
+        if (vbase + vc) * 3 > positions.len() || ibase + ic > indices.len() {
+            break; // malformed counts — stop rather than panic
+        }
+        let pslice = &positions[vbase * 3..(vbase + vc) * 3];
+        let nslice: &[f32] = if normals.len() >= (vbase + vc) * 3 {
+            &normals[vbase * 3..(vbase + vc) * 3]
+        } else {
+            &[]
+        };
+        let islice = &indices[ibase..ibase + ic];
+        let color = [
+            colors.get(i * 4).copied().unwrap_or(0.8),
+            colors.get(i * 4 + 1).copied().unwrap_or(0.8),
+            colors.get(i * 4 + 2).copied().unwrap_or(0.8),
+            colors.get(i * 4 + 3).copied().unwrap_or(1.0),
+        ];
+        let origin = [
+            origins.get(i * 3).copied().unwrap_or(0.0),
+            origins.get(i * 3 + 1).copied().unwrap_or(0.0),
+            origins.get(i * 3 + 2).copied().unwrap_or(0.0),
+        ];
+        views.push(MeshView {
+            express_id: express_ids.get(i).copied().unwrap_or(0),
+            ifc_type: "",
+            global_id: None,
+            positions: pslice,
+            normals: nslice,
+            indices: islice,
+            color,
+            origin,
+            // The viewer's MeshData drops the instancing side-channel across the
+            // worker boundary (it is `#[serde(skip)]`), so this path is always flat.
+            instance: None,
+        });
+        vbase += vc;
+        ibase += ic;
+    }
+    // From-meshes geometry is already absolute Y-up and never instances (no
+    // side-channel), so there is no RTC frame to compensate. Quantization is a
+    // from-bytes feature; the viewer path stays f32.
+    let mut ch = Chunker::new(12, usize::MAX, None);
+    let (gltf, stats) =
+        build_gltf(&views, include_metadata, None, lit, emissive, [0.0, 0.0, 0.0], false, &mut ch);
+    let json = serde_json::to_vec(&gltf).expect("glTF JSON serializes");
+    (pack_glb(&json, &ch.pos, &ch.norm, &ch.idx), stats)
+}

--- a/rust/export/src/gltf/matrix.rs
+++ b/rust/export/src/gltf/matrix.rs
@@ -160,8 +160,7 @@ pub(super) fn occurrence_node_matrix(
 mod tests {
     #[test]
     fn occurrence_matrix_reconstructs_rotated_instance_under_national_grid_rtc() {
-        // Decisive synthetic test for the RTC/rotation frame (review finding C1+M1):
-        // a ROTATED occurrence at NATIONAL-GRID coordinates. The node matrix is built
+        // A ROTATED occurrence at NATIONAL-GRID coordinates: the node matrix is built
         // from the same InstanceMeta the baker would carry; reconstructing the
         // occurrence from the template's baked-local geometry must land on the
         // occurrence's own baked geometry to sub-millimetre, even though the relative
@@ -272,5 +271,81 @@ mod tests {
             max_err < 1e-3,
             "rotated instance under national-grid RTC mis-reconstructed by {max_err} m"
         );
+    }
+
+    #[test]
+    fn affine_inverse_rejects_singular_placement() {
+        // Zero scale on X collapses the upper 3x3, so there is no affine inverse and the
+        // caller must fall back to the flat (non-instanced) path.
+        let m = [
+            0.0, 0.0, 0.0, 5.0, //
+            0.0, 1.0, 0.0, 0.0, //
+            0.0, 0.0, 1.0, 0.0, //
+            0.0, 0.0, 0.0, 1.0,
+        ];
+        assert!(super::affine_inverse(&m).is_none());
+    }
+
+    #[test]
+    fn compose_world_meta_applies_canonical_then_local_then_transform() {
+        use ifc_lite_geometry::InstanceMeta;
+        // Non-commuting factors so the ORDER is observable: canonical shifts +x, local
+        // rotates 90° about z, transform shifts +x again. A point at the origin must go
+        // origin -(canonical)-> (1,0,0) -(local rot)-> (0,1,0) -(transform)-> (10,1,0).
+        let rot_z90 = [
+            0.0, -1.0, 0.0, 0.0, //
+            1.0, 0.0, 0.0, 0.0, //
+            0.0, 0.0, 1.0, 0.0, //
+            0.0, 0.0, 0.0, 1.0,
+        ];
+        let translate = |t: [f64; 3]| {
+            [
+                1.0, 0.0, 0.0, t[0], //
+                0.0, 1.0, 0.0, t[1], //
+                0.0, 0.0, 1.0, t[2], //
+                0.0, 0.0, 0.0, 1.0,
+            ]
+        };
+        let meta = InstanceMeta {
+            transform: translate([10.0, 0.0, 0.0]),
+            local_transform: Some(rot_z90),
+            canonical_transform: Some(translate([1.0, 0.0, 0.0])),
+            rep_identity: 1,
+            instanceable: true,
+        };
+        let m = super::compose_world_meta(&meta);
+        // Row-major apply to the origin: the translation column is (m[3], m[7], m[11]).
+        let world = [m[3], m[7], m[11]];
+        let want = [10.0, 1.0, 0.0];
+        for k in 0..3 {
+            assert!((world[k] - want[k]).abs() < 1e-9, "axis {k}: {} != {}", world[k], want[k]);
+        }
+    }
+
+    #[test]
+    fn zero_rtc_leaves_relative_transform_unchanged() {
+        use ifc_lite_geometry::InstanceMeta;
+        // With rtc = 0, an identity template and identity occurrence at zero scene-center
+        // must produce the identity node matrix — proving the RTC conjugation is a no-op
+        // when the baker subtracted no offset.
+        let meta = |transform: [f64; 16]| InstanceMeta {
+            transform,
+            local_transform: None,
+            canonical_transform: None,
+            rep_identity: 7,
+            instanceable: true,
+        };
+        let m_ref = super::compose_world_meta(&meta(super::IDENTITY16));
+        let m_ref_inv = super::affine_inverse(&m_ref).expect("identity invertible");
+        let node = super::occurrence_node_matrix(
+            &meta(super::IDENTITY16),
+            &m_ref_inv,
+            [0.0; 3],
+            [0.0; 3],
+            [0.0; 3],
+        );
+        for (got, want) in node.iter().zip(super::IDENTITY16.iter()) {
+            assert!((*got as f64 - *want).abs() < 1e-6, "node != identity: {got} vs {want}");
+        }
     }
 }

--- a/rust/export/src/gltf/matrix.rs
+++ b/rust/export/src/gltf/matrix.rs
@@ -323,29 +323,61 @@ mod tests {
     }
 
     #[test]
-    fn zero_rtc_leaves_relative_transform_unchanged() {
+    fn zero_rtc_places_non_identity_occurrence() {
         use ifc_lite_geometry::InstanceMeta;
-        // With rtc = 0, an identity template and identity occurrence at zero scene-center
-        // must produce the identity node matrix — proving the RTC conjugation is a no-op
-        // when the baker subtracted no offset.
+        // With rtc = 0 (the baker subtracted no offset) the conjugation is a no-op, but the
+        // node must STILL place a NON-identity occurrence correctly. Reconstructing the
+        // template's local geometry through the node has to land on the occurrence's own
+        // Y-up world geometry — this catches translation / rotation / matrix-layout errors
+        // an identity-in/identity-out check cannot.
+        let rot_z = |deg: f64| -> [f64; 16] {
+            let (s, c) = (deg.to_radians().sin(), deg.to_radians().cos());
+            [c, -s, 0., 0., s, c, 0., 0., 0., 0., 1., 0., 0., 0., 0., 1.]
+        };
+        let translate = |t: [f64; 3]| {
+            [1., 0., 0., t[0], 0., 1., 0., t[1], 0., 0., 1., t[2], 0., 0., 0., 1.]
+        };
+        let apply = |m: &[f64; 16], p: [f64; 3]| {
+            [
+                m[0] * p[0] + m[1] * p[1] + m[2] * p[2] + m[3],
+                m[4] * p[0] + m[5] * p[1] + m[6] * p[2] + m[7],
+                m[8] * p[0] + m[9] * p[1] + m[10] * p[2] + m[11],
+            ]
+        };
         let meta = |transform: [f64; 16]| InstanceMeta {
             transform,
             local_transform: None,
             canonical_transform: None,
-            rep_identity: 7,
+            rep_identity: 3,
             instanceable: true,
         };
+
+        // Template at identity placement (baked geometry = canonical, origin 0); occurrence
+        // rotated 25° about Z and translated. rtc / origin / scene_center all zero.
         let m_ref = super::compose_world_meta(&meta(super::IDENTITY16));
         let m_ref_inv = super::affine_inverse(&m_ref).expect("identity invertible");
-        let node = super::occurrence_node_matrix(
-            &meta(super::IDENTITY16),
-            &m_ref_inv,
-            [0.0; 3],
-            [0.0; 3],
-            [0.0; 3],
-        );
-        for (got, want) in node.iter().zip(super::IDENTITY16.iter()) {
-            assert!((*got as f64 - *want).abs() < 1e-6, "node != identity: {got} vs {want}");
+        let m_k = super::compose_world_meta(&meta(
+            super::mat4_mul(&translate([7.0, -3.0, 2.0]), &rot_z(25.0)),
+        ));
+        let node = super::occurrence_node_matrix(&meta(m_k), &m_ref_inv, [0.0; 3], [0.0; 3], [0.0; 3]);
+
+        let canonical = [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.3, 0.4, 0.5]];
+        let mut max_err = 0.0f64;
+        for &p in &canonical {
+            // Template local (Y-up): identity template at origin 0, so just the Y-up point.
+            let lv = crate::frame::yup_f64(p);
+            // Truth: the occurrence's own baked (rtc = 0) geometry, in Y-up.
+            let truth = crate::frame::yup_f64(apply(&m_k, p));
+            let world = [
+                node[0] as f64 * lv[0] + node[4] as f64 * lv[1] + node[8] as f64 * lv[2] + node[12] as f64,
+                node[1] as f64 * lv[0] + node[5] as f64 * lv[1] + node[9] as f64 * lv[2] + node[13] as f64,
+                node[2] as f64 * lv[0] + node[6] as f64 * lv[1] + node[10] as f64 * lv[2] + node[14] as f64,
+            ];
+            for k in 0..3 {
+                max_err = max_err.max((world[k] - truth[k]).abs());
+            }
         }
+        // The node matrix is downcast to f32, so the bound is f32 precision, not f64.
+        assert!(max_err < 1e-4, "zero-rtc non-identity occurrence mis-placed by {max_err}");
     }
 }

--- a/rust/export/src/gltf/matrix.rs
+++ b/rust/export/src/gltf/matrix.rs
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: MPL-2.0
+//! Instancing matrix math for the glTF exporter (row-major f64 4x4).
+//!
+//! Split out of `gltf.rs` to keep that module under its size ratchet; the logic is
+//! unchanged, so instanced-occurrence placement (and the exported bytes) is identical.
+//!
+//! An occurrence's node matrix must map the shared template's Y-up LOCAL geometry
+//! to that occurrence's Y-up BAKED world position, minus the model-wide
+//! `scene_center` that the root node carries:
+//!
+//!   N_k = T(-scene_center) · S · [ T(-rtc) · (M_k · M_ref⁻¹) · T(rtc) ] · S⁻¹ · T(template_origin_yup)
+//!
+//! where `M = transform · local · canonical` is the per-occurrence world placement
+//! from `InstanceMeta` (Z-up, **pre-RTC**), `rtc` is the model RTC/site offset the
+//! baker subtracted (Z-up), and `S` is the Z-up→Y-up basis `(x,y,z) → (x, z, -y)`.
+//! The `T(-rtc)·…·T(rtc)` conjugation moves the relative transform from the pre-RTC
+//! frame `M` lives in into the POST-RTC baked frame the template geometry is in —
+//! without it, a rotated occurrence under a non-zero site/georef offset is
+//! mis-translated by `(R_rel - I)·rtc` (kilometres at national-grid scale). Everything
+//! is f64, recomputed from the f64 `InstanceMeta` (NOT the collator's f32 `rel`), so
+//! the absolute-magnitude terms cancel to a small, f32-precise translation before the
+//! final downcast even at national-grid coordinates.
+
+use ifc_lite_geometry::InstanceMeta;
+
+/// Z-up→Y-up basis as a row-major 4x4 (linear part only; `(x,y,z) → (x, z, -y)`).
+const S_YUP: [f64; 16] = [
+    1.0, 0.0, 0.0, 0.0, //
+    0.0, 0.0, 1.0, 0.0, //
+    0.0, -1.0, 0.0, 0.0, //
+    0.0, 0.0, 0.0, 1.0,
+];
+/// Inverse (transpose, since `S_YUP` is a proper rotation): `(x,y,z) → (x, -z, y)`.
+const S_YUP_INV: [f64; 16] = [
+    1.0, 0.0, 0.0, 0.0, //
+    0.0, 0.0, -1.0, 0.0, //
+    0.0, 1.0, 0.0, 0.0, //
+    0.0, 0.0, 0.0, 1.0,
+];
+const IDENTITY16: [f64; 16] = [
+    1.0, 0.0, 0.0, 0.0, //
+    0.0, 1.0, 0.0, 0.0, //
+    0.0, 0.0, 1.0, 0.0, //
+    0.0, 0.0, 0.0, 1.0,
+];
+
+/// Row-major 4x4 multiply `a · b`.
+fn mat4_mul(a: &[f64; 16], b: &[f64; 16]) -> [f64; 16] {
+    let mut out = [0.0f64; 16];
+    for r in 0..4 {
+        for c in 0..4 {
+            let mut s = 0.0;
+            for k in 0..4 {
+                s += a[r * 4 + k] * b[k * 4 + c];
+            }
+            out[r * 4 + c] = s;
+        }
+    }
+    out
+}
+
+/// Row-major translation matrix.
+fn mat4_translation(t: [f64; 3]) -> [f64; 16] {
+    [
+        1.0, 0.0, 0.0, t[0], //
+        0.0, 1.0, 0.0, t[1], //
+        0.0, 0.0, 1.0, t[2], //
+        0.0, 0.0, 0.0, 1.0,
+    ]
+}
+
+/// Transpose a row-major f64 4x4 into the column-major `[f32; 16]` glTF expects.
+fn row_major_f64_to_col_major_f32(m: &[f64; 16]) -> [f32; 16] {
+    let mut out = [0.0f32; 16];
+    for r in 0..4 {
+        for c in 0..4 {
+            out[c * 4 + r] = m[r * 4 + c] as f32;
+        }
+    }
+    out
+}
+
+/// Inverse of a row-major AFFINE 4x4 (last row `[0,0,0,1]`): invert the upper 3x3
+/// (cofactor / determinant) and map the translation by `-R⁻¹·t`. Returns `None` if
+/// the 3x3 is singular (degenerate placement) so the caller can fall back to flat.
+pub(super) fn affine_inverse(m: &[f64; 16]) -> Option<[f64; 16]> {
+    let a = m[0]; let b = m[1]; let c = m[2];
+    let d = m[4]; let e = m[5]; let f = m[6];
+    let g = m[8]; let h = m[9]; let i = m[10];
+    let det = a * (e * i - f * h) - b * (d * i - f * g) + c * (d * h - e * g);
+    if det.abs() < 1e-18 {
+        return None;
+    }
+    let inv_det = 1.0 / det;
+    // Inverse of the 3x3 (row-major) via the transposed cofactor matrix.
+    let r = [
+        (e * i - f * h) * inv_det,
+        (c * h - b * i) * inv_det,
+        (b * f - c * e) * inv_det,
+        (f * g - d * i) * inv_det,
+        (a * i - c * g) * inv_det,
+        (c * d - a * f) * inv_det,
+        (d * h - e * g) * inv_det,
+        (b * g - a * h) * inv_det,
+        (a * e - b * d) * inv_det,
+    ];
+    let (tx, ty, tz) = (m[3], m[7], m[11]);
+    // Translation of the inverse: -R⁻¹ · t.
+    let it = [
+        -(r[0] * tx + r[1] * ty + r[2] * tz),
+        -(r[3] * tx + r[4] * ty + r[5] * tz),
+        -(r[6] * tx + r[7] * ty + r[8] * tz),
+    ];
+    Some([
+        r[0], r[1], r[2], it[0], //
+        r[3], r[4], r[5], it[1], //
+        r[6], r[7], r[8], it[2], //
+        0.0, 0.0, 0.0, 1.0,
+    ])
+}
+
+/// Compose an `InstanceMeta`'s world placement `transform · local · canonical`
+/// (row-major f64), the same product the collator's `compose_world` builds.
+pub(super) fn compose_world_meta(meta: &InstanceMeta) -> [f64; 16] {
+    let local = meta.local_transform.unwrap_or(IDENTITY16);
+    let canonical = meta.canonical_transform.unwrap_or(IDENTITY16);
+    mat4_mul(&meta.transform, &mat4_mul(&local, &canonical))
+}
+
+/// Build the column-major glTF node matrix placing a shared template (Y-up local
+/// geometry, relative to `template_origin_yup`) at one occurrence's BAKED pose.
+/// Recomputed in f64 from the occurrence's `InstanceMeta`, the precomputed template
+/// inverse `m_ref_inv` (`affine_inverse(compose_world_meta(template))`, computed once
+/// per group), and the model `rtc` offset (Z-up) the baker subtracted.
+pub(super) fn occurrence_node_matrix(
+    occ: &InstanceMeta,
+    m_ref_inv: &[f64; 16],
+    rtc_zup: [f64; 3],
+    template_origin_yup: [f64; 3],
+    scene_center: [f64; 3],
+) -> [f32; 16] {
+    let m_k = compose_world_meta(occ);
+    // rel maps the template's PRE-RTC world geometry onto occurrence k's.
+    let rel_pre = mat4_mul(&m_k, m_ref_inv);
+    // Conjugate into the POST-RTC baked frame the geometry actually lives in.
+    let rel_baked = mat4_mul(
+        &mat4_translation([-rtc_zup[0], -rtc_zup[1], -rtc_zup[2]]),
+        &mat4_mul(&rel_pre, &mat4_translation(rtc_zup)),
+    );
+    // Conjugate Z-up→Y-up (the template was converted by the same S).
+    let rel_yup = mat4_mul(&mat4_mul(&S_YUP, &rel_baked), &S_YUP_INV);
+    let n = mat4_mul(
+        &mat4_translation([-scene_center[0], -scene_center[1], -scene_center[2]]),
+        &mat4_mul(&rel_yup, &mat4_translation(template_origin_yup)),
+    );
+    row_major_f64_to_col_major_f32(&n)
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn occurrence_matrix_reconstructs_rotated_instance_under_national_grid_rtc() {
+        // Decisive synthetic test for the RTC/rotation frame (review finding C1+M1):
+        // a ROTATED occurrence at NATIONAL-GRID coordinates. The node matrix is built
+        // from the same InstanceMeta the baker would carry; reconstructing the
+        // occurrence from the template's baked-local geometry must land on the
+        // occurrence's own baked geometry to sub-millimetre, even though the relative
+        // transform's absolute terms are ~1e5 m. (A pre-RTC `rel` applied to post-RTC
+        // geometry — the bug — misplaces this by ~(R-I)·rtc, i.e. hundreds of metres.)
+        use ifc_lite_geometry::InstanceMeta;
+
+        // Row-major helpers.
+        let translate = |t: [f64; 3]| -> [f64; 16] {
+            [1., 0., 0., t[0], 0., 1., 0., t[1], 0., 0., 1., t[2], 0., 0., 0., 1.]
+        };
+        // Rotation about Z (Z-up): (x,y) rotate, z fixed.
+        let rot_z = |deg: f64| -> [f64; 16] {
+            let (s, c) = (deg.to_radians().sin(), deg.to_radians().cos());
+            [c, -s, 0., 0., s, c, 0., 0., 0., 0., 1., 0., 0., 0., 0., 1.]
+        };
+        let apply = |m: &[f64; 16], p: [f64; 3]| -> [f64; 3] {
+            [
+                m[0] * p[0] + m[1] * p[1] + m[2] * p[2] + m[3],
+                m[4] * p[0] + m[5] * p[1] + m[6] * p[2] + m[7],
+                m[8] * p[0] + m[9] * p[1] + m[10] * p[2] + m[11],
+            ]
+        };
+
+        // Placements (Z-up, pre-RTC): template upright, occurrence rotated 37° about Z.
+        let m_ref = super::mat4_mul(&translate([10., 20., 5.]), &rot_z(0.0));
+        let m_k = super::mat4_mul(&translate([60., 35., 5.]), &rot_z(37.0));
+        // National-grid RTC the baker subtracts (e.g. Dutch RD-ish easting/northing).
+        let rtc = [155_000.0_f64, 463_000.0, 0.0];
+
+        // Canonical (rep-local) geometry — a few non-degenerate points.
+        let canonical = [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 2.0, 0.0],
+            [0.5, 0.5, 1.5],
+            [2.0, 0.3, 0.7],
+        ];
+        // Baked = placement·canonical - rtc, in Z-up.
+        let bake = |m: &[f64; 16]| -> Vec<[f64; 3]> {
+            canonical
+                .iter()
+                .map(|&x| {
+                    let w = apply(m, x);
+                    [w[0] - rtc[0], w[1] - rtc[1], w[2] - rtc[2]]
+                })
+                .collect()
+        };
+        let tmpl_baked = bake(&m_ref);
+        let occ_baked = bake(&m_k);
+
+        // Template origin = centroid of its baked geometry; local = baked - origin.
+        let n = canonical.len() as f64;
+        let origin_z = {
+            let mut o = [0.0; 3];
+            for p in &tmpl_baked {
+                for k in 0..3 {
+                    o[k] += p[k] / n;
+                }
+            }
+            o
+        };
+        // Convert template origin + local, and the occurrence's baked truth, to Y-up.
+        let origin_yup = crate::frame::yup_f64(origin_z);
+        let tmpl_local_yup: Vec<[f64; 3]> = tmpl_baked
+            .iter()
+            .map(|p| crate::frame::yup_f64([p[0] - origin_z[0], p[1] - origin_z[1], p[2] - origin_z[2]]))
+            .collect();
+        let occ_world_yup: Vec<[f64; 3]> = occ_baked.iter().map(|p| crate::frame::yup_f64(*p)).collect();
+
+        // scene_center = centre of the combined baked Y-up AABB.
+        let mut lo = [f64::INFINITY; 3];
+        let mut hi = [f64::NEG_INFINITY; 3];
+        for p in tmpl_baked.iter().chain(occ_baked.iter()) {
+            let y = crate::frame::yup_f64(*p);
+            for k in 0..3 {
+                lo[k] = lo[k].min(y[k]);
+                hi[k] = hi[k].max(y[k]);
+            }
+        }
+        let scene_center = [(lo[0] + hi[0]) * 0.5, (lo[1] + hi[1]) * 0.5, (lo[2] + hi[2]) * 0.5];
+
+        let meta = |transform: [f64; 16]| InstanceMeta {
+            transform,
+            local_transform: None,
+            canonical_transform: None,
+            rep_identity: 42,
+            instanceable: true,
+        };
+        let m_ref_inv = super::affine_inverse(&super::compose_world_meta(&meta(m_ref)))
+            .expect("template placement invertible");
+        let node = super::occurrence_node_matrix(&meta(m_k), &m_ref_inv, rtc, origin_yup, scene_center);
+
+        // Reconstruct: world = scene_center(root) + node(col-major) · template_local.
+        let mut max_err = 0.0f64;
+        for (lv, truth) in tmpl_local_yup.iter().zip(&occ_world_yup) {
+            let (x, y, z) = (lv[0], lv[1], lv[2]);
+            let world = [
+                scene_center[0] + node[0] as f64 * x + node[4] as f64 * y + node[8] as f64 * z + node[12] as f64,
+                scene_center[1] + node[1] as f64 * x + node[5] as f64 * y + node[9] as f64 * z + node[13] as f64,
+                scene_center[2] + node[2] as f64 * x + node[6] as f64 * y + node[10] as f64 * z + node[14] as f64,
+            ];
+            for k in 0..3 {
+                max_err = max_err.max((world[k] - truth[k]).abs());
+            }
+        }
+        assert!(
+            max_err < 1e-3,
+            "rotated instance under national-grid RTC mis-reconstructed by {max_err} m"
+        );
+    }
+}

--- a/rust/export/src/lib.rs
+++ b/rust/export/src/lib.rs
@@ -38,9 +38,9 @@ pub use gltf::{
     export_glb, export_glb_from_meshes, export_glb_streaming_bounded,
     export_glb_streaming_bounded_with_index, export_glb_with_stats,
     export_glb_with_stats_with_index, export_gltf_streaming, export_gltf_streaming_with_index,
-    project_glb_size, project_glb_size_with_index, try_export_glb, try_export_glb_streaming_bounded,
-    try_export_glb_streaming_bounded_with_index, try_export_glb_with_stats, GlbSizeProjection,
-    GltfBuffer, GltfOptions, GltfStats,
+    project_glb_size, project_glb_size_with_index, try_export_glb, try_export_glb_from_meshes,
+    try_export_glb_streaming_bounded, try_export_glb_streaming_bounded_with_index,
+    try_export_glb_with_stats, GlbSizeProjection, GltfBuffer, GltfOptions, GltfStats,
 };
 pub use hbjson::Model;
 // Re-exported so a caller can `build_entity_index` once and share it across the

--- a/rust/wasm-bindings/src/api/export_glb.rs
+++ b/rust/wasm-bindings/src/api/export_glb.rs
@@ -85,10 +85,12 @@ impl IfcAPI {
     /// RGBA per mesh, `origins` xyz per mesh, `express_ids` labels each mesh (indices are
     /// per-mesh local). The caller passes exactly the meshes it wants emitted.
     ///
-    /// Fails CLOSED: if the per-mesh `vertex_counts` / `index_counts` sum past the end of
-    /// the flattened `positions` / `normals` / `indices` buffers this throws an `Error`
-    /// whose message starts with `MALFORMED_MESH_INPUT`, instead of silently emitting a
-    /// GLB missing the un-backed tail of the model.
+    /// Fails CLOSED: if the declared vertex/index counts run past the flattened
+    /// `positions` / `indices`, there are fewer `index_counts` than meshes, or `normals`
+    /// is empty or too short to cover every vertex, this throws an `Error` whose message
+    /// starts with `MALFORMED_MESH_INPUT` — instead of silently emitting a GLB with those
+    /// meshes dropped. (The viewer always passes fully-backed, normal-covered arrays, so
+    /// this only fires on a caller bug.)
     #[wasm_bindgen(js_name = exportGlbFromMeshes)]
     #[allow(clippy::too_many_arguments)]
     pub fn export_glb_from_meshes(

--- a/rust/wasm-bindings/src/api/export_glb.rs
+++ b/rust/wasm-bindings/src/api/export_glb.rs
@@ -84,6 +84,11 @@ impl IfcAPI {
     /// taken in order from the concatenated `positions`/`normals`/`indices`; `colors` is
     /// RGBA per mesh, `origins` xyz per mesh, `express_ids` labels each mesh (indices are
     /// per-mesh local). The caller passes exactly the meshes it wants emitted.
+    ///
+    /// Fails CLOSED: if the per-mesh `vertex_counts` / `index_counts` sum past the end of
+    /// the flattened `positions` / `normals` / `indices` buffers this throws an `Error`
+    /// whose message starts with `MALFORMED_MESH_INPUT`, instead of silently emitting a
+    /// GLB missing the un-backed tail of the model.
     #[wasm_bindgen(js_name = exportGlbFromMeshes)]
     #[allow(clippy::too_many_arguments)]
     pub fn export_glb_from_meshes(
@@ -99,8 +104,8 @@ impl IfcAPI {
         include_metadata: bool,
         lit: Option<bool>,
         emissive: Option<bool>,
-    ) -> Vec<u8> {
-        ifc_lite_export::export_glb_from_meshes(
+    ) -> Result<Vec<u8>, JsValue> {
+        ifc_lite_export::try_export_glb_from_meshes(
             positions,
             normals,
             indices,
@@ -113,7 +118,8 @@ impl IfcAPI {
             lit.unwrap_or(true),
             emissive.unwrap_or(false),
         )
-        .0
+        .map(|(glb, _)| glb)
+        .map_err(|e| JsValue::from(js_sys::Error::new(&e.to_string())))
     }
 
     /// Package an already-produced **GLB** + georeference into a **KMZ** (`Uint8Array`)

--- a/scripts/test-wasm-contract.mjs
+++ b/scripts/test-wasm-contract.mjs
@@ -686,6 +686,54 @@ test('exportGlb returns a binary glTF (GLB magic "glTF") with real meshes', () =
   assert.ok(Array.isArray(gltf.meshes) && gltf.meshes.length > 0, 'GLB should declare meshes');
 });
 
+// exportGlbFromMeshes assembles a GLB straight from flattened mesh arrays (the viewer's
+// GPU meshes) and fails closed on malformed counts — exercised HERE through the real wasm
+// boundary, since the Rust-level tests can't prove the JS throw contract.
+test('exportGlbFromMeshes returns a GLB for valid flattened meshes', () => {
+  const positions = new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]);
+  const normals = new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]);
+  const indices = new Uint32Array([0, 1, 2]);
+  const glb = api.exportGlbFromMeshes(
+    positions, normals, indices,
+    new Uint32Array([3]), new Uint32Array([3]),
+    new Float32Array([0.5, 0.5, 0.5, 1]), new Float64Array([0, 0, 0]), new Uint32Array([1]),
+    false, true, false,
+  );
+  assert.ok(glb instanceof Uint8Array && glb.length > 20, 'valid meshes produce a GLB');
+  assert.deepEqual(Array.from(glb.slice(0, 4)), [0x67, 0x6c, 0x54, 0x46]); // "glTF"
+});
+
+test('exportGlbFromMeshes fails closed on malformed inputs (MALFORMED_MESH_INPUT)', () => {
+  const positions = new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]);
+  const fullNormals = new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]);
+  const indices = new Uint32Array([0, 1, 2]);
+  const vc = new Uint32Array([3]);
+  const color = new Float32Array([0.5, 0.5, 0.5, 1]);
+  const origin = new Float64Array([0, 0, 0]);
+  const ids = new Uint32Array([1]);
+  const startsWithMalformed = (e) => e instanceof Error && e.message.startsWith('MALFORMED_MESH_INPUT');
+
+  // Short normals (6 floats, mesh needs 9): the mesh would silently vanish.
+  assert.throws(
+    () => api.exportGlbFromMeshes(
+      positions, new Float32Array([0, 0, 1, 0, 0, 1]), indices, vc, new Uint32Array([3]),
+      color, origin, ids, false, true, false,
+    ),
+    startsWithMalformed,
+    'short normals must throw MALFORMED_MESH_INPUT',
+  );
+
+  // Fewer index_counts than declared meshes (0 entries for 1 mesh).
+  assert.throws(
+    () => api.exportGlbFromMeshes(
+      positions, fullNormals, indices, vc, new Uint32Array([]),
+      color, origin, ids, false, true, false,
+    ),
+    startsWithMalformed,
+    'missing index_counts must throw MALFORMED_MESH_INPUT',
+  );
+});
+
 test('exportKmz packs a stored-zip KMZ (PK header, doc.kml + model.glb, axis-derived heading)', () => {
   const kmz = api.exportKmz(glbBytes, 47.5, 8.5, 412, 1, 0, 'Contract Bldg');
   assert.ok(kmz instanceof Uint8Array, 'KMZ should be a Uint8Array');


### PR DESCRIPTION
## What and why

Optimizes the glTF/GLB exporter's assembly + serialization phase — flagged by a Fable code review as the dominant non-meshing cost — and bounds peak memory on large models. Output is **byte-for-byte identical** across every export path (in-memory instanced, quantized, unlit/emissive, bounded streaming, multi-buffer glTF, from-meshes); the keys/maps changed only gate dedup *equality* and never reach the bytes.

Also fixes one real correctness gap surfaced by the review: `export_glb_from_meshes` silently dropped meshes whose per-mesh counts ran past the flattened buffers (a valid GLB missing the model's tail, reported as success).

**Speed**
- `geom_color_key`: replace the double element-wise SipHash with one `xxh3_128` pass over `bytemuck::cast_slice` of positions/normals/indices (+ `u64` length frames + colour). ~20–50× less hashing; also makes the bounded path's release-mode determinism assert cheap.
- `push_mesh` / `push_mesh_quantized`: reserve the three byte runs once and write normals/indices via a single `cast_slice` memcpy (LE targets), positions via a per-vertex stack buffer, instead of per-element `to_le_bytes` pushes.
- `FxHashMap` for the dedup/material maps (insertion-order emit, unchanged bytes).

**Large-model memory**
- `with_result_views` converts Y-up **in place** on the owned `ProcessingResult` instead of allocating a full second `Vec<YUpMesh>` copy of all geometry.
- `pack_glb` writes `pos`/`norm`/`idx` straight into the container, dropping the `embedded_bin` intermediate copy on the single-buffer path.
- Streaming/bounded passes reuse one `YUpScratch` instead of 3 fresh allocations per mesh per pass; the bounded plan interns `ifc_type` as `Arc<str>`.
- `VisibilityFilter` precomputes `HashSet`s, replacing per-mesh linear `Vec::contains` scans (which also ran twice on the bounded path).

**Correctness**
- Add `try_export_glb_from_meshes` + `ExportError::MalformedMeshInput`, and make the wasm `exportGlbFromMeshes` boundary **fail closed** (throws `MALFORMED_MESH_INPUT`) instead of shipping a truncated model. The infallible core is unchanged for existing Rust callers; the TS success type stays `Uint8Array`.

**Hardening** (from adversarial review): compile-time little-endian assertion (the `cast_slice` paths assume LE), a `debug_assert` pinning the single-flush invariant the `embedded_bin` removal relies on.

## How it was verified

- `cargo test -p ifc-lite-export` — **84 passed / 0 failed**, including every existing byte-identical/determinism test and 2 new `try_from_meshes_*` tests.
- **Byte-identical golden diff** vs a pre-change baseline across all 9 export configurations on a real 2.38 MB model (`ara3d/duplex.ifc`) — re-checked after each implementation round.
- `cargo clippy -p ifc-lite-export --lib --tests -- -D warnings` — clean.
- `cargo build -p ifc-lite-wasm --release --target wasm32-unknown-unknown` — compiles (xxhash-rust builds for wasm; new `Result` boundary intact).
- 4 independent adversarial reviews (hash/ordering, byte-encoding/in-place, pack/flush, fail-closed edge cases) found **no output-affecting bug**; their hardening notes are folded in.

- [x] `cargo test --workspace` (Rust) and/or `pnpm test` (TS) pass locally — ran `cargo test -p ifc-lite-export` (84/84); full workspace via CI
- [ ] Geometry/WASM change: ran `scripts/build-wasm.sh` then `pnpm test:wasm-contract` — *in progress (browser/wasm validation)*

## Checklist

- [x] A test asserts the new behavior through a fixture or a stated invariant (byte-identical cross-path tests + new malformed-input tests)
- [x] Geometry-output change: re-pinned **both** determinism jsons **(N/A — output is byte-identical, no geometry output changed)**
- [x] House rules: no `as any` / `@ts-ignore`, no silent `catch {}`, no repo-wide `cargo fmt`
- [x] No client or project identifiers in code, tests, commit messages, or this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GuGVRxintkLHg9PpoRmgZN)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GLB export directly from flattened mesh data, with optional quantization.
  * Added support for shared geometry, instancing, and improved coordinate conversion.

* **Performance**
  * Improved export speed and memory efficiency for large and streaming models.
  * Reduced unnecessary allocations during geometry conversion and GLB generation.

* **Bug Fixes**
  * Malformed mesh buffers now fail safely with a `MALFORMED_MESH_INPUT` error.
  * Improved consistency for geometry transforms and exported model data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->