### PR TITLE
fix(server-client): throw when an SSE stream ends without a terminal event

### DIFF
--- a/.changeset/parse-stream-truncation-and-silent-catches.md
+++ b/.changeset/parse-stream-truncation-and-silent-catches.md
@@ -1,0 +1,18 @@
+---
+"@ifc-lite/server-client": patch
+"@ifc-lite/extensions": patch
+"@ifc-lite/collab-server": patch
+"@ifc-lite/sdk": patch
+---
+
+Stop `IfcServerClient.parseStream()` reporting a truncated stream as a successful parse, and log four failures that were previously invisible.
+
+**Behaviour change (`@ifc-lite/server-client`):** `parseStream()` now throws `Stream ended without a complete event` when the SSE stream finishes without a `complete` or `error` event. Previously, a connection that dropped mid-parse — or a final frame truncated mid-JSON, whose `JSON.parse` failure was swallowed by a bare `catch {}` — ended the async generator normally, so `for await (const event of client.parseStream(file))` simply exited and the caller saw a successful parse that had produced only part of the model. The sibling `parseStreamToParquet()` already enforced this contract (`Stream ended without complete event`); the two paths now agree. Consumers that `break` out of the loop early are unaffected: an early return does not run the check.
+
+Two further `parseStream()` fixes: a malformed SSE frame is now reported via `console.warn` instead of being dropped silently, and `yield` has been moved out of the `try` that wraps `JSON.parse`, so an error thrown into the generator by the consumer propagates instead of being swallowed as if it were a bad frame.
+
+New warnings elsewhere, no behaviour change:
+
+- `@ifc-lite/extensions` — an `AuditLog` subscriber that throws now warns once per listener (latched, so a persistently broken subscriber cannot log once per audited action). Delivery to the other listeners is unchanged.
+- `@ifc-lite/collab-server` — the layer-registry auto-merge path warns when it skips because the pushed layer cannot be read, when a ref layer cannot be read during the idempotency probe, and when a merge attempt throws. Auto-merge failures are still contained and still never fail the push that triggered them; they are just no longer invisible to the operator.
+- `@ifc-lite/sdk` — `bsdd` warns when the paginated `classProperties` fallback fails. The partial result is still returned, but it is also cached, so one transient failure otherwise answered every later call for that URI until the entry expired.

--- a/docs/guide/server.md
+++ b/docs/guide/server.md
@@ -713,6 +713,10 @@ try {
 
 ### Streaming Errors
 
+A stream can fail in two different ways, and they surface differently.
+
+The server can **report** a failure, which arrives as an `error` event:
+
 ```typescript
 for await (const event of client.parseStream(file)) {
   if (event.type === 'error') {
@@ -721,6 +725,31 @@ for await (const event of client.parseStream(file)) {
   }
 }
 ```
+
+Or the stream can simply **stop** — the connection drops, or the server dies
+mid-parse — in which case no `error` event is ever sent. There is nothing to
+inspect in the loop, so `parseStream()` **throws** once the body ends without a
+terminal event. Handle both:
+
+```typescript
+try {
+  for await (const event of client.parseStream(file)) {
+    if (event.type === 'error') {
+      console.error('Stream error:', event.message);
+      break;
+    }
+  }
+} catch (error) {
+  // "Stream ended without a complete event (connection dropped or the server
+  // failed mid-parse)" — the parse did NOT finish, and no partial result
+  // should be treated as one.
+  console.error('Stream did not complete:', error);
+}
+```
+
+Checking only for `event.type === 'error'` leaves the second case unhandled: the
+loop ends early and the throw escapes uncaught. `parseStreamToParquet()` raises
+the same error for the same condition.
 
 ### Connection Errors
 

--- a/packages/collab-server/src/layer-registry-route.ts
+++ b/packages/collab-server/src/layer-registry-route.ts
@@ -162,10 +162,15 @@ function runAutoMerges(
   pushedId: string,
   webhooks: readonly RegistryWebhook[]
 ): void {
+  // Containment is by design (see above), but an operator whose auto-merge
+  // ref quietly stopped merging has no other signal that it did — so every
+  // contained failure is logged. Warnings are per push, not per event.
   let manifest;
   try {
     manifest = getProvenance(registry.loadLayer(pushedId));
-  } catch {
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn(`[collab-server] auto-merge skipped: cannot read pushed layer ${pushedId}:`, err);
     return;
   }
   if (!manifest?.base) return;
@@ -173,6 +178,8 @@ function runAutoMerges(
   // required checks: a failing check the policy forgot to require must
   // still keep the merge attended.
   if ((manifest.checks ?? []).some((check) => check.result !== 'pass')) return;
+  /** Layer ids already reported as unreadable in this pass; caps the log. */
+  const unreadable = new Set<string>();
   for (const [name, entry] of Object.entries(registry.listRefs())) {
     const policy = entry.policy;
     if (!policy?.autoMerge || policy.requireHumanApproval) continue;
@@ -183,7 +190,14 @@ function runAutoMerges(
     const alreadyMerged = entry.layers.some((layerId) => {
       try {
         return getProvenance(registry.loadLayer(layerId))?.merge?.candidate === pushedId;
-      } catch {
+      } catch (err) {
+        // An unreadable layer reads as "not the merge we're looking for",
+        // which can let the same candidate land twice — worth a warning.
+        if (!unreadable.has(layerId)) {
+          unreadable.add(layerId);
+          // eslint-disable-next-line no-console
+          console.warn(`[collab-server] auto-merge: cannot read ref layer ${layerId}:`, err);
+        }
         return false;
       }
     });
@@ -203,8 +217,10 @@ function runAutoMerges(
           ...(outcome.status === 'merged' ? { merge_layer: outcome.mergeLayerId } : {}),
         });
       }
-    } catch {
-      // Contained by contract (see above).
+    } catch (err) {
+      // Contained by contract (see above) — the push still succeeds.
+      // eslint-disable-next-line no-console
+      console.warn(`[collab-server] auto-merge of ${pushedId} into ref '${name}' failed:`, err);
     }
   }
 }

--- a/packages/collab-server/src/layer-registry-route.ts
+++ b/packages/collab-server/src/layer-registry-route.ts
@@ -170,7 +170,7 @@ function runAutoMerges(
     manifest = getProvenance(registry.loadLayer(pushedId));
   } catch (err) {
     // eslint-disable-next-line no-console
-    console.warn(`[collab-server] auto-merge skipped: cannot read pushed layer ${pushedId}:`, err);
+    console.warn(`[collab-server] auto-merge skipped: cannot read pushed layer ${JSON.stringify(pushedId)}:`, err);
     return;
   }
   if (!manifest?.base) return;
@@ -196,7 +196,7 @@ function runAutoMerges(
         if (!unreadable.has(layerId)) {
           unreadable.add(layerId);
           // eslint-disable-next-line no-console
-          console.warn(`[collab-server] auto-merge: cannot read ref layer ${layerId}:`, err);
+          console.warn(`[collab-server] auto-merge: cannot read ref layer ${JSON.stringify(layerId)}:`, err);
         }
         return false;
       }
@@ -220,7 +220,7 @@ function runAutoMerges(
     } catch (err) {
       // Contained by contract (see above) — the push still succeeds.
       // eslint-disable-next-line no-console
-      console.warn(`[collab-server] auto-merge of ${pushedId} into ref '${name}' failed:`, err);
+      console.warn(`[collab-server] auto-merge of ${JSON.stringify(pushedId)} into ref ${JSON.stringify(name)} failed:`, err);
     }
   }
 }

--- a/packages/extensions/src/audit/log.test.ts
+++ b/packages/extensions/src/audit/log.test.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { AuditLog } from './log.js';
 
 describe('AuditLog — append + list', () => {
@@ -115,5 +115,38 @@ describe('AuditLog — clear', () => {
     expect(log.size()).toBe(0);
     const next = log.append({ kind: 'install', extensionId: 'b' });
     expect(next.seq).toBe(2);
+  });
+});
+
+describe('AuditLog — faulting listeners', () => {
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it('warns once per faulting listener and keeps delivering to the others', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const log = new AuditLog();
+    const bad = () => { throw new Error('subscriber blew up'); };
+    const seen: string[] = [];
+    log.subscribe(bad);
+    log.subscribe((e) => { seen.push(e.extensionId); });
+
+    log.append({ kind: 'install', extensionId: 'ext-a' });
+    log.append({ kind: 'install', extensionId: 'ext-b' });
+    log.append({ kind: 'install', extensionId: 'ext-c' });
+
+    // Every event still reaches the healthy listener.
+    expect(seen).toEqual(['ext-a', 'ext-b', 'ext-c']);
+    // ...and the fault is reported exactly once, not once per event.
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0]?.[0])).toContain('[audit]');
+  });
+
+  it('latches per listener, so a second faulting subscriber still warns', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const log = new AuditLog();
+    log.subscribe(() => { throw new Error('one'); });
+    log.subscribe(() => { throw new Error('two'); });
+    log.append({ kind: 'install', extensionId: 'ext-a' });
+    log.append({ kind: 'install', extensionId: 'ext-b' });
+    expect(warn).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/extensions/src/audit/log.ts
+++ b/packages/extensions/src/audit/log.ts
@@ -60,6 +60,8 @@ export class AuditLog {
   private readonly maxBytes: number;
   private readonly now: () => Date;
   private listeners = new Set<(event: AuditEvent) => void>();
+  /** Listeners that have already thrown once; see `append`'s flood latch. */
+  private faultedListeners = new WeakSet<(event: AuditEvent) => void>();
 
   constructor(opts: AuditLogOptions = {}) {
     this.maxEvents = opts.maxEvents ?? DEFAULT_MAX_EVENTS;
@@ -115,7 +117,19 @@ export class AuditLog {
     this.totalBytes += byteSize;
     this.evict();
     for (const listener of this.listeners) {
-      try { listener(frozen); } catch (err) { /* listener faults must not bubble */ }
+      try {
+        listener(frozen);
+      } catch (err) {
+        // Listener faults must not bubble — an audit subscriber that keeps
+        // throwing would otherwise drop every event it was meant to forward
+        // with no trace. Latched per listener so one broken subscriber
+        // cannot flood the console once per audited action.
+        if (!this.faultedListeners.has(listener)) {
+          this.faultedListeners.add(listener);
+          // eslint-disable-next-line no-console
+          console.warn('[audit] listener threw; further faults from it are suppressed:', err);
+        }
+      }
     }
     return frozen;
   }

--- a/packages/sdk/src/namespaces/bsdd.ts
+++ b/packages/sdk/src/namespaces/bsdd.ts
@@ -288,8 +288,13 @@ export class BsddNamespace {
         if (propsList && propsList.length > 0) {
           info = { ...info, classProperties: propsList.map((p) => mapProperty(p, true)) };
         }
-      } catch {
-        // ignore — primary call already succeeded
+      } catch (err) {
+        // Non-fatal — the primary call already succeeded. Logged because
+        // the partial result (no classProperties) is what gets cached, so
+        // one transient failure silently answers every later call for this
+        // URI until the entry expires.
+        // eslint-disable-next-line no-console
+        console.warn(`[bsdd] classProperties fallback failed for ${uri}; caching partial result:`, err);
       }
     }
 

--- a/packages/server-client/src/client.ts
+++ b/packages/server-client/src/client.ts
@@ -860,6 +860,9 @@ export class IfcServerClient {
    *
    * @param file - File or ArrayBuffer containing IFC data
    * @yields Stream events (start, progress, batch, complete, error)
+   * @throws If the stream ends without a `complete` or `error` event — a
+   *   dropped connection or a server-side failure mid-parse. Breaking out
+   *   of the loop early does not trigger this.
    *
    * @example
    * ```typescript
@@ -917,6 +920,24 @@ export class IfcServerClient {
     const reader = response.body.getReader();
     const decoder = new TextDecoder();
     let buffer = '';
+    // A stream that stops before `complete`/`error` is a failed parse, not
+    // a finished one — the same contract `parseStreamToParquet` enforces.
+    let terminated = false;
+
+    // Decode one SSE frame. Returns undefined (and warns) for a frame we
+    // cannot parse, so a dropped event is never invisible. The yield must
+    // stay outside the try: an error thrown *into* this generator by the
+    // consumer surfaces at the yield point and would be swallowed as if it
+    // were a malformed frame.
+    const decodeFrame = (frame: string): StreamEvent | undefined => {
+      if (!frame.startsWith('data: ')) return undefined;
+      try {
+        return JSON.parse(frame.slice(6)) as StreamEvent;
+      } catch (err) {
+        console.warn('[client] Skipping malformed SSE event:', frame, err);
+        return undefined;
+      }
+    };
 
     try {
       while (true) {
@@ -930,25 +951,24 @@ export class IfcServerClient {
         buffer = lines.pop() || '';
 
         for (const line of lines) {
-          if (line.startsWith('data: ')) {
-            try {
-              const data = JSON.parse(line.slice(6)) as StreamEvent;
-              yield data;
-            } catch {
-              // Skip malformed events
-            }
-          }
+          const data = decodeFrame(line);
+          if (!data) continue;
+          if (data.type === 'complete' || data.type === 'error') terminated = true;
+          yield data;
         }
       }
 
       // Process remaining buffer
-      if (buffer.startsWith('data: ')) {
-        try {
-          const data = JSON.parse(buffer.slice(6)) as StreamEvent;
-          yield data;
-        } catch {
-          // Skip malformed events
-        }
+      const tail = decodeFrame(buffer);
+      if (tail) {
+        if (tail.type === 'complete' || tail.type === 'error') terminated = true;
+        yield tail;
+      }
+
+      if (!terminated) {
+        throw new Error(
+          'Stream ended without a complete event (connection dropped or the server failed mid-parse)',
+        );
       }
     } finally {
       reader.releaseLock();

--- a/packages/server-client/src/client.ts
+++ b/packages/server-client/src/client.ts
@@ -23,6 +23,20 @@ import type {
 import { decodeParquetGeometry, decodeOptimizedParquetGeometry, isParquetAvailable } from './parquet-decoder.js';
 
 /**
+ * Raised when an SSE parse stream ends with no terminal event.
+ *
+ * Shared by `parseStream` and `parseStreamToParquet` so the two cannot drift
+ * apart by an article. The wording has to hold on BOTH paths, which it does:
+ * `parseStreamToParquet` throws on an `error` event at its own `case 'error'`,
+ * so it can only reach its `!stats || !metadata` check in the same state
+ * `parseStream`'s `!terminated` describes — the stream stopped without ever
+ * saying why. Not exported: it is an internal guarantee about two call sites,
+ * not part of the published surface.
+ */
+const STREAM_ENDED_WITHOUT_TERMINAL_EVENT =
+  'Stream ended without a complete event (connection dropped or the server failed mid-parse)';
+
+/**
  * Compress a file or ArrayBuffer using gzip compression.
  * Uses the browser's CompressionStream API for efficient compression.
  *
@@ -438,7 +452,7 @@ export class IfcServerClient {
     }
 
     if (!stats || !metadata) {
-      throw new Error('Stream ended without complete event');
+      throw new Error(STREAM_ENDED_WITHOUT_TERMINAL_EVENT);
     }
 
     return {
@@ -966,9 +980,7 @@ export class IfcServerClient {
       }
 
       if (!terminated) {
-        throw new Error(
-          'Stream ended without a complete event (connection dropped or the server failed mid-parse)',
-        );
+        throw new Error(STREAM_ENDED_WITHOUT_TERMINAL_EVENT);
       }
     } finally {
       reader.releaseLock();

--- a/packages/server-client/src/parse-stream.test.ts
+++ b/packages/server-client/src/parse-stream.test.ts
@@ -1,0 +1,165 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { IfcServerClient } from './client.js';
+import type { StreamEvent } from './types.js';
+
+/** Build a Response whose body streams `chunks` as SSE text. */
+function sseResponse(chunks: string[]): Response {
+  const encoder = new TextEncoder();
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const c of chunks) controller.enqueue(encoder.encode(c));
+      controller.close();
+    },
+  });
+  return new Response(body, {
+    status: 200,
+    headers: { 'Content-Type': 'text/event-stream' },
+  });
+}
+
+function frame(event: unknown): string {
+  return `data: ${JSON.stringify(event)}\n\n`;
+}
+
+function stubFetch(response: Response): void {
+  vi.stubGlobal('fetch', vi.fn(async () => response));
+}
+
+function client(): IfcServerClient {
+  return new IfcServerClient({ baseUrl: 'https://example.invalid' });
+}
+
+async function drain(gen: AsyncGenerator<StreamEvent>): Promise<StreamEvent[]> {
+  const out: StreamEvent[] = [];
+  for await (const ev of gen) out.push(ev);
+  return out;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('parseStream', () => {
+  it('yields every event of a well-formed stream', async () => {
+    stubFetch(
+      sseResponse([
+        frame({ type: 'start', total_estimate: 2 }),
+        frame({ type: 'progress', processed: 1, total: 2 }),
+        frame({
+          type: 'complete',
+          stats: { total_time_ms: 1 },
+          metadata: {},
+        }),
+      ]),
+    );
+
+    const events = await drain(client().parseStream(new ArrayBuffer(4)));
+    expect(events.map((e) => e.type)).toEqual(['start', 'progress', 'complete']);
+  });
+
+  it('throws when the stream ends before a terminal event', async () => {
+    // Server died after the first progress event: the transport closed
+    // cleanly, so `reader.read()` reports done and nothing else signals
+    // that the parse never finished.
+    stubFetch(
+      sseResponse([
+        frame({ type: 'start', total_estimate: 2 }),
+        frame({ type: 'progress', processed: 1, total: 2 }),
+      ]),
+    );
+
+    const events: StreamEvent[] = [];
+    await expect(async () => {
+      for await (const ev of client().parseStream(new ArrayBuffer(4))) {
+        events.push(ev);
+      }
+    }).rejects.toThrow(/ended without/i);
+    // The events that did arrive were still delivered before the throw.
+    expect(events.map((e) => e.type)).toEqual(['start', 'progress']);
+  });
+
+  it('throws when the final frame is truncated mid-JSON', async () => {
+    stubFetch(
+      sseResponse([
+        frame({ type: 'start', total_estimate: 2 }),
+        'data: {"type":"complete","stats":{"total_ti',
+      ]),
+    );
+
+    await expect(
+      drain(client().parseStream(new ArrayBuffer(4))),
+    ).rejects.toThrow(/ended without/i);
+  });
+
+  it('surfaces a terminal error event without throwing', async () => {
+    // `error` is a documented event type callers switch on; reaching it
+    // means the server reported the failure, so the stream is complete.
+    stubFetch(
+      sseResponse([
+        frame({ type: 'start', total_estimate: 2 }),
+        frame({ type: 'error', message: 'boom', code: 'E_BOOM' }),
+      ]),
+    );
+
+    const events = await drain(client().parseStream(new ArrayBuffer(4)));
+    expect(events.map((e) => e.type)).toEqual(['start', 'error']);
+  });
+
+  it('does not throw when the consumer breaks out early', async () => {
+    stubFetch(
+      sseResponse([
+        frame({ type: 'start', total_estimate: 2 }),
+        frame({ type: 'progress', processed: 1, total: 2 }),
+      ]),
+    );
+
+    const seen: StreamEvent[] = [];
+    for await (const ev of client().parseStream(new ArrayBuffer(4))) {
+      seen.push(ev);
+      break;
+    }
+    expect(seen.map((e) => e.type)).toEqual(['start']);
+  });
+
+  it('propagates an error thrown by the consumer instead of swallowing it', async () => {
+    stubFetch(
+      sseResponse([
+        frame({ type: 'start', total_estimate: 2 }),
+        frame({
+          type: 'complete',
+          stats: { total_time_ms: 1 },
+          metadata: {},
+        }),
+      ]),
+    );
+
+    const gen = client().parseStream(new ArrayBuffer(4));
+    await gen.next();
+    await expect(gen.throw(new Error('consumer blew up'))).rejects.toThrow(
+      'consumer blew up',
+    );
+  });
+
+  it('warns about a malformed mid-stream frame instead of dropping it silently', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    stubFetch(
+      sseResponse([
+        'data: {not json}\n\n',
+        frame({
+          type: 'complete',
+          stats: { total_time_ms: 1 },
+          metadata: {},
+        }),
+      ]),
+    );
+
+    const events = await drain(client().parseStream(new ArrayBuffer(4)));
+    expect(events.map((e) => e.type)).toEqual(['complete']);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});


### PR DESCRIPTION
**First branch pushed to this repo rather than the fork**, per your request on #2082 — so the Vercel rows on this one should actually build.

Follow-through from #2080's survey into the smaller published packages. As with #2082, the logging was secondary; **it found a real defect.**

## A truncated stream was reported as a successful one

`parseStream()` never checked that the SSE stream reached `complete` or `error`. A connection dropping mid-parse — or a final frame truncated mid-JSON, whose `JSON.parse` failure was eaten by `catch { /* Skip malformed events */ }` — ended the async generator **normally**. So `for await (const ev of client.parseStream(file))` exited cleanly and the caller believed it had the whole model.

What settles it as a defect rather than a deliberate contract is 500 lines up in the same file: `parseStreamToParquet()` (`client.ts:437`) ends with

```ts
throw new Error('Stream ended without complete event');
```

Two SSE readers against the same server, opposite contracts. One of them is wrong, and it is not the one that throws.

**Second defect in the same block:** `yield data` sat *inside* the `try` whose `catch {}` was labelled "Skip malformed events". An error thrown **into** the generator by the consumer surfaces at the yield point, and was swallowed as if it were a bad frame. A RED test confirms that was reachable, not theoretical.

**Behaviour change, on failing streams only.** Well-formed streams, an early `break`, and a terminal `error` event are unchanged — pinned by three tests that pass both before and after the fix, so they are not vacuous.

## Checked specifically for failing open — it does not

`mcp/safe-path.ts:124` was the site I most wanted to be wrong about. The swallowed `realpath` there can only fail to **add** a root; it can never widen the allowed set. Fails closed. Explicitly verified rather than assumed.

## Three more swallows that hid something real

- **`extensions/audit/log.ts:118`** — a throwing subscriber silently stopped receiving audit events **forever**, with no trace. The `catch (err)` did not even use its binding. Now latched per listener, so a persistently faulty one cannot flood.
- **`collab-server/layer-registry-route.ts`** — auto-merge silently ceasing to work; `:186` could let the same candidate land twice on a corrupt layer.
- **`sdk/bsdd.ts:291`** — a fallback failure caches the *incomplete* result, so one transient error answers every later call for that URI until the TTL expires.

Everything else surveyed is genuinely benign and listed as such rather than padded: wasm-handle cleanup inside a rethrow, socket writes to already-dead peers, absent-data probes, a logger's own env check.

## Found and deliberately NOT fixed — needs your call

`packages/pointcloud/src/streaming/laz-source.ts:46-92`: `modulePromise` is assigned once and **never reset on rejection**, so a transient wasm fetch failure poisons every future LAZ open for the page lifetime — re-dropping the file gets the identical failure with no retry attempted.

`query/duckdb-integration.ts:78` carries a comment fixing exactly this shape ("so a transient failure does not poison every future `init()` call"), so the repo already treats it as a defect. I left it because `loadLazPerf` has **no test seam** — it is module-private and both dynamic imports resolve identically under vitest, so any test I could write would pass against the broken code. Rather than ship an unpinned fix, it is worth its own issue.

## Evidence

| mutation | result |
|---|---|
| `if (!terminated)` → `if (false)` | 2 tests fail |
| malformed-frame `console.warn` → `void err` | 1 test fails |
| audit latch → always-warn | 2 tests fail |

I re-ran the first myself on the pushed tree (`REPLACEMENTS=1`, line re-read): `throws when the stream ends before a terminal event` and `throws when the final frame is truncated mid-JSON` both fail, restored 27/27.

Baselines were measured after building workspace deps — `collab-server` and `sdk` both fail to *import* before that, which looks exactly like a regression and is not. server-client 27 (was 20), extensions 600 (was 598), collab-server 138, sdk 62, `tsc --noEmit` clean in all four.

Changeset covers all four packages and leads with the behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
