### PR TITLE
fix(viewer): three defects the silent catches were hiding

### DIFF
--- a/apps/viewer/src/components/viewer/BulkPropertyEditor.tsx
+++ b/apps/viewer/src/components/viewer/BulkPropertyEditor.tsx
@@ -404,7 +404,12 @@ export function BulkPropertyEditor({ trigger }: BulkPropertyEditorProps) {
       try {
         matchedIds = queryEngine.select(currentCriteria);
         count = matchedIds.length;
-      } catch {
+      } catch (err) {
+        // A count of 0 reads as "nothing matches these criteria", which is the
+        // answer the user acts on — so a query that FAILED must not be
+        // indistinguishable from one that matched nothing. Debounced per
+        // criteria edit, so this is not a hot path.
+        console.warn('[bulk-edit] criteria query failed; showing 0 matches', err);
         // leave at 0
       }
 

--- a/apps/viewer/src/components/viewer/RoomPanel.tsx
+++ b/apps/viewer/src/components/viewer/RoomPanel.tsx
@@ -178,8 +178,12 @@ export function RoomPanel({ onClose }: RoomPanelProps) {
       useViewerStore.getState().setCollabLastShareToken(token);
       setCopied(true);
       setTimeout(() => setCopied(false), 1600);
-    } catch {
-      // clipboard / mint can fail silently; the dialog Share flow is the fallback
+    } catch (err) {
+      // The button simply never turns into "Copied!" — the only feedback the
+      // user gets. Mint failures (expired admin bearer, room revoked) look
+      // exactly like a blocked clipboard from the outside, so name the cause
+      // here; the dialog Share flow remains the fallback. One per click.
+      console.warn('[collab] could not copy the room link', err);
     }
   }, [collabRoomId, isAdmin, selfRole]);
 

--- a/apps/viewer/src/components/viewer/chat/ExecutableCodeBlock.tsx
+++ b/apps/viewer/src/components/viewer/chat/ExecutableCodeBlock.tsx
@@ -29,6 +29,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
+import { resolveChatViewportScreenshot } from './chatViewportCapture.js';
 import { useSandbox } from '@/hooks/useSandbox';
 import { useViewerStore } from '@/store';
 import type { CodeBlock, CodeExecResult } from '@/lib/llm/types';
@@ -117,13 +118,14 @@ export const ExecutableCodeBlock = memo(function ExecutableCodeBlock({
         if (block.code.includes('loadIfc') || block.code.includes('bim.create') || block.code.includes('colorize')) {
           // Small delay to let the renderer finish presenting the frame
           setTimeout(() => {
-            try {
-              const canvas = document.querySelector('canvas');
-              if (canvas) {
-                const dataUrl = captureCompressedCanvasImage(canvas as HTMLCanvasElement);
-                useViewerStore.getState().setChatViewportScreenshot(dataUrl);
-              }
-            } catch { /* screenshot capture failed — non-critical */ }
+            // Always WRITE the slot, including on failure: it is only cleared
+            // when the user sends, so skipping the write would leave the
+            // previous run's screenshot attached to a message about this one.
+            // See resolveChatViewportScreenshot.
+            const canvas = document.querySelector('canvas') as HTMLCanvasElement | null;
+            useViewerStore.getState().setChatViewportScreenshot(
+              resolveChatViewportScreenshot(canvas, captureCompressedCanvasImage),
+            );
           }, 500);
         }
       } else {

--- a/apps/viewer/src/components/viewer/chat/chatViewportCapture.test.ts
+++ b/apps/viewer/src/components/viewer/chat/chatViewportCapture.test.ts
@@ -11,6 +11,8 @@
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert';
 import { resolveChatViewportScreenshot } from './chatViewportCapture.js';
+import { create } from 'zustand';
+import { createChatSlice, type ChatSlice } from '../../../store/slices/chatSlice.js';
 
 const canvas = {} as HTMLCanvasElement;
 
@@ -50,5 +52,29 @@ describe('resolveChatViewportScreenshot', () => {
 
   it('treats an empty capture as no screenshot', () => {
     assert.strictEqual(resolveChatViewportScreenshot(canvas, () => ''), null);
+  });
+});
+
+describe('the caller writes the slot unconditionally', () => {
+  it('clears a previous run\'s image when this run\'s capture fails', () => {
+    // Pins the CALLER-side behaviour change, not just the resolver.
+    // ExecutableCodeBlock writes the slot unconditionally, so a failed capture
+    // replaces the prior image with null. Writing only on success is what
+    // attached run A's screenshot to a message about run B (#2085), and the
+    // slot is cleared only at send time, so the stale value survived.
+    const store = create<ChatSlice>()((...a) => createChatSlice(...a));
+    const canvas = {} as HTMLCanvasElement;
+
+    store.getState().setChatViewportScreenshot(
+      resolveChatViewportScreenshot(canvas, () => 'data:image/png;base64,AAAA'),
+    );
+    assert.strictEqual(store.getState().chatViewportScreenshot, 'data:image/png;base64,AAAA');
+
+    store.getState().setChatViewportScreenshot(
+      resolveChatViewportScreenshot(canvas, () => {
+        throw new Error('capture failed');
+      }),
+    );
+    assert.strictEqual(store.getState().chatViewportScreenshot, null);
   });
 });

--- a/apps/viewer/src/components/viewer/chat/chatViewportCapture.test.ts
+++ b/apps/viewer/src/components/viewer/chat/chatViewportCapture.test.ts
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The auto-captured chat screenshot must never go stale: the slot is consumed
+ * at send time, so a failed capture that leaves the previous value in place
+ * ships the WRONG viewport to the model.
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import { resolveChatViewportScreenshot } from './chatViewportCapture.js';
+
+const canvas = {} as HTMLCanvasElement;
+
+let warnings: unknown[][];
+const realWarn = console.warn;
+beforeEach(() => {
+  warnings = [];
+  console.warn = (...args: unknown[]) => { warnings.push(args); };
+});
+afterEach(() => { console.warn = realWarn; });
+
+describe('resolveChatViewportScreenshot', () => {
+  it('returns the captured data URL', () => {
+    assert.strictEqual(
+      resolveChatViewportScreenshot(canvas, () => 'data:image/jpeg;base64,AAA'),
+      'data:image/jpeg;base64,AAA',
+    );
+    assert.deepStrictEqual(warnings, [], 'the happy path must stay quiet');
+  });
+
+  it('returns null — not the previous shot — when the capture throws', () => {
+    // A tainted canvas (SecurityError) or a lost context. The caller stores
+    // this value unconditionally, so null is what CLEARS the stale screenshot;
+    // returning undefined / skipping the write is the bug this guards.
+    const boom = new Error('SecurityError: tainted canvas');
+    const out = resolveChatViewportScreenshot(canvas, () => { throw boom; });
+    assert.strictEqual(out, null);
+    assert.strictEqual(warnings.length, 1);
+    assert.match(String(warnings[0][0]), /screenshot capture failed/);
+    assert.strictEqual(warnings[0][1], boom);
+  });
+
+  it('returns null without logging when there is no canvas', () => {
+    assert.strictEqual(resolveChatViewportScreenshot(null, () => 'x'), null);
+    assert.deepStrictEqual(warnings, [], 'a missing canvas is not an error');
+  });
+
+  it('treats an empty capture as no screenshot', () => {
+    assert.strictEqual(resolveChatViewportScreenshot(canvas, () => ''), null);
+  });
+});

--- a/apps/viewer/src/components/viewer/chat/chatViewportCapture.ts
+++ b/apps/viewer/src/components/viewer/chat/chatViewportCapture.ts
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Failure policy for the auto-captured viewport screenshot that a chat turn
+ * attaches to the next message.
+ *
+ * The store slot is written after a script run and consumed (and only then
+ * cleared) when the user sends. So a capture that FAILS must not simply be
+ * skipped: the slot would still hold the screenshot from an EARLIER run, and
+ * the model would be shown a viewport that no longer matches the model state
+ * it is being asked about. "No screenshot" is a degrade; "the previous
+ * screenshot" is a wrong answer. The resolver therefore always produces the
+ * value to store — the new capture, or `null` to clear the stale one.
+ */
+
+/** Resolve the screenshot to store, or `null` when there is nothing to attach. */
+export function resolveChatViewportScreenshot(
+  canvas: HTMLCanvasElement | null,
+  capture: (canvas: HTMLCanvasElement) => string,
+): string | null {
+  if (!canvas) return null;
+  try {
+    return capture(canvas) || null;
+  } catch (err) {
+    // `toDataURL` on a tainted canvas (SecurityError) or a lost drawing
+    // context. Once per script run that touches geometry — not a hot path.
+    console.warn('[chat] viewport screenshot capture failed; sending without one', err);
+    return null;
+  }
+}

--- a/apps/viewer/src/hooks/meshOutlineProvider.test.ts
+++ b/apps/viewer/src/hooks/meshOutlineProvider.test.ts
@@ -1,0 +1,148 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Outline provider used by the drawing projection stage: origin folding,
+ * WASM handle lifetime, and the once-per-generation failure log that keeps a
+ * systematically-broken binding visible without one line per element.
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import {
+  createMeshOutlineProvider,
+  type MeshOutlineHandle,
+  type MeshOutline2dFn,
+} from './meshOutlineProvider.js';
+
+/** A handle over one square contour, recording whether it was freed. */
+function stubHandle(contours: Float32Array[]): MeshOutlineHandle & { freed: number } {
+  return {
+    axisMin: -1,
+    axisMax: 3,
+    contourCount: contours.length,
+    contour: (i: number) => contours[i],
+    free() { this.freed += 1; },
+    freed: 0,
+  };
+}
+
+const mesh = (positions: number[], origin?: number[]) => ({
+  positions: new Float32Array(positions),
+  indices: new Uint32Array([0, 1, 2]),
+  ...(origin ? { origin } : {}),
+});
+
+let warnings: unknown[][];
+const realWarn = console.warn;
+beforeEach(() => {
+  warnings = [];
+  console.warn = (...args: unknown[]) => { warnings.push(args); };
+});
+afterEach(() => { console.warn = realWarn; });
+
+describe('createMeshOutlineProvider', () => {
+  it('folds the mesh origin into the positions handed to the binding', () => {
+    let seen: Float32Array | null = null;
+    const fn: MeshOutline2dFn = (positions) => {
+      seen = positions;
+      return stubHandle([new Float32Array([0, 0, 1, 1])]);
+    };
+    const provider = createMeshOutlineProvider(fn);
+    provider(mesh([1, 2, 3], [10, 20, 30]), 'y', false);
+    assert.deepStrictEqual(Array.from(seen!), [11, 22, 33]);
+  });
+
+  it('passes positions through untouched when the origin is absent or zero', () => {
+    const seen: Float32Array[] = [];
+    const fn: MeshOutline2dFn = (positions) => {
+      seen.push(positions);
+      return stubHandle([new Float32Array([0, 0, 1, 1])]);
+    };
+    const provider = createMeshOutlineProvider(fn);
+    const noOrigin = mesh([1, 2, 3]);
+    const zeroOrigin = mesh([4, 5, 6], [0, 0, 0]);
+    provider(noOrigin, 'y', false);
+    provider(zeroOrigin, 'y', false);
+    // Same object, not a copy: the zero-origin path must not allocate.
+    assert.strictEqual(seen[0], noOrigin.positions);
+    assert.strictEqual(seen[1], zeroOrigin.positions);
+  });
+
+  it('maps the semantic axis to the binding axis code', () => {
+    const codes: number[] = [];
+    const fn: MeshOutline2dFn = (_p, _i, axis) => {
+      codes.push(axis);
+      return stubHandle([new Float32Array([0, 0, 1, 1])]);
+    };
+    const provider = createMeshOutlineProvider(fn);
+    provider(mesh([1, 2, 3]), 'x', false);
+    provider(mesh([1, 2, 3]), 'y', false);
+    provider(mesh([1, 2, 3]), 'z', false);
+    assert.deepStrictEqual(codes, [0, 1, 2]);
+  });
+
+  it('copies contours off the WASM heap and frees the handle', () => {
+    const ring = new Float32Array([0, 0, 1, 0, 1, 1]);
+    const handle = stubHandle([ring]);
+    const provider = createMeshOutlineProvider(() => handle);
+    const out = provider(mesh([1, 2, 3]), 'y', false);
+    assert.ok(out);
+    assert.strictEqual(handle.freed, 1);
+    assert.notStrictEqual(out.contours[0], ring, 'contour must be copied off the WASM heap');
+    assert.deepStrictEqual(Array.from(out.contours[0]), [0, 0, 1, 0, 1, 1]);
+    assert.deepStrictEqual([out.axisMin, out.axisMax], [-1, 3]);
+  });
+
+  it('frees the handle and returns null when there are no contours', () => {
+    const handle = stubHandle([]);
+    const provider = createMeshOutlineProvider(() => handle);
+    assert.strictEqual(provider(mesh([1, 2, 3]), 'y', false), null);
+    assert.strictEqual(handle.freed, 1);
+  });
+
+  it('returns null without logging when the binding answers undefined', () => {
+    const provider = createMeshOutlineProvider(() => undefined);
+    assert.strictEqual(provider(mesh([1, 2, 3]), 'y', false), null);
+    assert.strictEqual(warnings.length, 0, 'a no-outline answer is not a failure');
+  });
+
+  it('logs the FIRST binding failure once and stays quiet for the rest of the drawing', () => {
+    // A wasm bundle whose meshOutline2d ABI no longer matches this JS throws
+    // for EVERY mesh. Before the latch this was a bare `catch { return null }`:
+    // an entire drawing silently downgraded to the TS silhouette with nothing
+    // in the console. One line per element is equally unusable, so exactly one
+    // line per generation is the contract.
+    const boom = new Error('unreachable executed');
+    const provider = createMeshOutlineProvider(() => { throw boom; });
+
+    for (let i = 0; i < 50; i++) {
+      assert.strictEqual(provider(mesh([1, 2, 3]), 'y', false), null);
+    }
+
+    assert.strictEqual(warnings.length, 1, 'exactly one warning for 50 failing meshes');
+    assert.match(String(warnings[0][0]), /meshOutline2d failed/);
+    assert.strictEqual(warnings[0][1], boom, 'the cause must be bound to the log');
+  });
+
+  it('reports again for the next drawing generation (the latch is per provider)', () => {
+    const failing: MeshOutline2dFn = () => { throw new Error('unreachable executed'); };
+    createMeshOutlineProvider(failing)(mesh([1, 2, 3]), 'y', false);
+    createMeshOutlineProvider(failing)(mesh([1, 2, 3]), 'y', false);
+    assert.strictEqual(warnings.length, 2, 'each generation gets its own budget');
+  });
+
+  it('reports a failure raised while reading contours, and still frees the handle', () => {
+    const handle = stubHandle([]);
+    const provider = createMeshOutlineProvider(() => ({
+      ...handle,
+      contourCount: 1,
+      contour: () => { throw new Error('detached wasm memory'); },
+      free() { handle.freed += 1; },
+    }));
+    assert.strictEqual(provider(mesh([1, 2, 3]), 'y', false), null);
+    assert.strictEqual(handle.freed, 1, 'the finally must run before the catch');
+    assert.strictEqual(warnings.length, 1);
+  });
+});

--- a/apps/viewer/src/hooks/meshOutlineProvider.ts
+++ b/apps/viewer/src/hooks/meshOutlineProvider.ts
@@ -1,0 +1,104 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Winding-robust 2D outline provider backed by the Rust `meshOutline2d`
+ * binding (issue #979), for the projection stage of `useDrawingGeneration`.
+ *
+ * Split out of the hook so the failure policy is testable on its own: the
+ * provider is called ONCE PER MESH, so a binding that throws for every mesh
+ * (a wasm bundle whose exported ABI no longer matches this JS — the same
+ * deployment-skew class as issue #2079) would otherwise emit one log line per
+ * element and drown the console. The provider therefore reports only the FIRST
+ * failure and then stays quiet; a fresh provider is built per drawing
+ * generation, so the next generation reports again.
+ */
+
+import type { MeshOutline2D } from '@ifc-lite/drawing-2d';
+
+/** Handle returned by the wasm binding. Freed by the provider before it returns. */
+export interface MeshOutlineHandle {
+  readonly axisMin: number;
+  readonly axisMax: number;
+  readonly contourCount: number;
+  contour(index: number): Float32Array | undefined;
+  free(): void;
+}
+
+/** The `meshOutline2d` free function as exported by `@ifc-lite/wasm`. */
+export type MeshOutline2dFn = (
+  positions: Float32Array,
+  indices: Uint32Array,
+  axis: number,
+  flipped: boolean,
+) => MeshOutlineHandle | undefined;
+
+/** Mesh shape the drawing generator hands to the outline provider. */
+export interface MeshOutlineInput {
+  positions: Float32Array;
+  indices: Uint32Array;
+  origin?: readonly number[];
+}
+
+export type MeshOutlineProvider = (
+  mesh: MeshOutlineInput,
+  axis: 'x' | 'y' | 'z',
+  flipped: boolean,
+) => MeshOutline2D | null;
+
+export const AXIS_CODE: Record<'x' | 'y' | 'z', number> = { x: 0, y: 1, z: 2 };
+
+/**
+ * Build the per-generation outline provider around `outlineFn`. Returns `null`
+ * from a call whose binding failed, which the generator reads as "no outline
+ * for this mesh" and answers with the TS mesh silhouette instead.
+ */
+export function createMeshOutlineProvider(outlineFn: MeshOutline2dFn): MeshOutlineProvider {
+  // Once-per-provider (= once-per-drawing-generation) log latch — see the
+  // module comment for why a per-mesh log is not an option here.
+  let reportedFailure = false;
+
+  return (mesh, axis, flipped) => {
+    try {
+      // Positions are in the element's local frame (world = origin +
+      // position). Feed WORLD positions to the outline extractor so its
+      // contours + axisMin/axisMax come back in the same render-frame
+      // world space as the (origin-folded) section cut. No-op when the
+      // origin is absent/[0,0,0].
+      const o = mesh.origin;
+      let outlinePositions = mesh.positions;
+      if (o && (o[0] !== 0 || o[1] !== 0 || o[2] !== 0)) {
+        outlinePositions = new Float32Array(mesh.positions.length);
+        for (let i = 0; i < mesh.positions.length; i += 3) {
+          outlinePositions[i] = mesh.positions[i] + o[0];
+          outlinePositions[i + 1] = mesh.positions[i + 1] + o[1];
+          outlinePositions[i + 2] = mesh.positions[i + 2] + o[2];
+        }
+      }
+      const handle = outlineFn(outlinePositions, mesh.indices, AXIS_CODE[axis], flipped);
+      if (!handle) return null;
+      try {
+        const contours: Float32Array[] = [];
+        for (let i = 0; i < handle.contourCount; i++) {
+          const ring = handle.contour(i);
+          if (ring) contours.push(ring.slice()); // copy off the WASM heap
+        }
+        if (contours.length === 0) return null;
+        return { contours, axisMin: handle.axisMin, axisMax: handle.axisMax };
+      } finally {
+        handle.free();
+      }
+    } catch (err) {
+      if (!reportedFailure) {
+        reportedFailure = true;
+        console.warn(
+          '[drawing-2d] meshOutline2d failed; projection falls back to the TS mesh '
+          + 'silhouette for the rest of this drawing. Further failures are not logged.',
+          err,
+        );
+      }
+      return null; // binding unavailable/failed → silhouette fallback
+    }
+  };
+}

--- a/apps/viewer/src/hooks/useConstructionUnderlay.ts
+++ b/apps/viewer/src/hooks/useConstructionUnderlay.ts
@@ -78,7 +78,11 @@ export function useConstructionUnderlay(
           hidden: l.visibility === 'hidden',
         }));
         setLines(out);
-      } catch {
+      } catch (err) {
+        // An empty underlay renders identically to "this storey genuinely has
+        // no elements at the cut", so a failed generation is invisible in the
+        // sketch. One line per (storey, geometry) change — not a render loop.
+        console.warn('[underlay] construction underlay generation failed', err);
         if (!cancelled) setLines([]);
       } finally {
         if (!cancelled) setLoading(false);

--- a/apps/viewer/src/hooks/useDrawingGeneration.ts
+++ b/apps/viewer/src/hooks/useDrawingGeneration.ts
@@ -24,8 +24,8 @@ import {
   type DrawingLine,
   type SectionConfig,
   type ProfileEntry,
-  type MeshOutline2D,
 } from '@ifc-lite/drawing-2d';
+import { createMeshOutlineProvider, type MeshOutline2dFn } from './meshOutlineProvider.js';
 import { GeometryProcessor, type GeometryResult } from '@ifc-lite/geometry';
 import type { SpatialHierarchy } from '@ifc-lite/data';
 import * as IfcWasm from '@ifc-lite/wasm';
@@ -36,21 +36,7 @@ import { customPlaneCenter } from '@/store';
 // undefined and projection falls back to the TS mesh silhouette. The wasm
 // module is already initialised (the model loaded through it), so the free
 // function can be called without a GeometryProcessor instance.
-interface MeshOutlineHandle {
-  readonly axisMin: number;
-  readonly axisMax: number;
-  readonly contourCount: number;
-  contour(index: number): Float32Array | undefined;
-  free(): void;
-}
-type MeshOutline2dFn = (
-  positions: Float32Array,
-  indices: Uint32Array,
-  axis: number,
-  flipped: boolean,
-) => MeshOutlineHandle | undefined;
 const meshOutline2dFn = (IfcWasm as unknown as { meshOutline2d?: MeshOutline2dFn }).meshOutline2d;
-const AXIS_CODE: Record<'x' | 'y' | 'z', number> = { x: 0, y: 1, z: 2 };
 
 // Axis conversion from semantic (down/front/side) to geometric (x/y/z)
 export const AXIS_MAP: Record<'down' | 'front' | 'side', 'x' | 'y' | 'z'> = {
@@ -700,40 +686,7 @@ export function useDrawingGeneration({
       // build → the generator falls back to the TS mesh silhouette.
       const outlineProvider =
         projectionOn && typeof meshOutline2dFn === 'function'
-          ? (mesh: { positions: Float32Array; indices: Uint32Array; origin?: readonly number[] }, axis: 'x' | 'y' | 'z', flipped: boolean): MeshOutline2D | null => {
-              try {
-                // Positions are in the element's local frame (world = origin +
-                // position). Feed WORLD positions to the outline extractor so its
-                // contours + axisMin/axisMax come back in the same render-frame
-                // world space as the (origin-folded) section cut. No-op when the
-                // origin is absent/[0,0,0].
-                const o = mesh.origin;
-                let outlinePositions = mesh.positions;
-                if (o && (o[0] !== 0 || o[1] !== 0 || o[2] !== 0)) {
-                  outlinePositions = new Float32Array(mesh.positions.length);
-                  for (let i = 0; i < mesh.positions.length; i += 3) {
-                    outlinePositions[i] = mesh.positions[i] + o[0];
-                    outlinePositions[i + 1] = mesh.positions[i + 1] + o[1];
-                    outlinePositions[i + 2] = mesh.positions[i + 2] + o[2];
-                  }
-                }
-                const handle = meshOutline2dFn(outlinePositions, mesh.indices, AXIS_CODE[axis], flipped);
-                if (!handle) return null;
-                try {
-                  const contours: Float32Array[] = [];
-                  for (let i = 0; i < handle.contourCount; i++) {
-                    const ring = handle.contour(i);
-                    if (ring) contours.push(ring.slice()); // copy off the WASM heap
-                  }
-                  if (contours.length === 0) return null;
-                  return { contours, axisMin: handle.axisMin, axisMax: handle.axisMax };
-                } finally {
-                  handle.free();
-                }
-              } catch {
-                return null; // binding unavailable/failed → silhouette fallback
-              }
-            }
+          ? createMeshOutlineProvider(meshOutline2dFn)
           : undefined;
 
       const result = await generator.generate(

--- a/apps/viewer/src/lib/geo/cesium-bridge.test.ts
+++ b/apps/viewer/src/lib/geo/cesium-bridge.test.ts
@@ -85,6 +85,23 @@ describe('computeGridConvergence (#1408)', () => {
     const longlat = '+proj=longlat +datum=WGS84 +no_defs';
     assert.strictEqual(computeGridConvergence(longlat, 14.5, 50, 14.5, 50), 0);
   });
+
+  it('names the cause when the probe hop throws instead of returning a bare 0', () => {
+    // A convergence of 0 is a legitimate answer (on a UTM central meridian),
+    // so the give-up path is otherwise indistinguishable from success: the
+    // model would be placed grid-aligned in Cesium's true-north frame with
+    // nothing said. Log then, not silence.
+    const warnings: unknown[][] = [];
+    const realWarn = console.warn;
+    console.warn = (...args: unknown[]) => { warnings.push(args); };
+    try {
+      assert.strictEqual(computeGridConvergence('+proj=not-a-projection', 0, 0, 14.5, 50), 0);
+    } finally {
+      console.warn = realWarn;
+    }
+    assert.strictEqual(warnings.length, 1);
+    assert.match(String(warnings[0][0]), /grid convergence unavailable/);
+  });
 });
 
 describe('viewerToEnuRotation — model/camera share one convergence-corrected rotation (#1408 follow-up)', () => {

--- a/apps/viewer/src/lib/geo/cesium-bridge.ts
+++ b/apps/viewer/src/lib/geo/cesium-bridge.ts
@@ -201,7 +201,17 @@ export function computeGridConvergence(
   let lon2: number, lat2: number;
   try {
     [lon2, lat2] = proj4(projDef, 'WGS84', [easting, northing + step]);
-  } catch {
+  } catch (err) {
+    // Zero is not a neutral answer here: it is indistinguishable from a
+    // genuinely zero convergence, so the model silently keeps its GRID
+    // alignment inside Cesium's TRUE-north ENU frame — a rotation of up to ~3°
+    // (UTM zone edge) or ~7-8° (Krovak). Called once per model, so logging it
+    // costs nothing and names the cause if it ever happens.
+    console.warn(
+      `[cesium] grid convergence unavailable for ${projDef}; the model is placed `
+      + 'grid-aligned in a true-north frame (rotation up to a few degrees).',
+      err,
+    );
     return 0;
   }
   if (!Number.isFinite(lon2) || !Number.isFinite(lat2)) return 0;

--- a/apps/viewer/src/lib/recent-files.test.ts
+++ b/apps/viewer/src/lib/recent-files.test.ts
@@ -1,0 +1,177 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Recent-files metadata + IndexedDB blob cache.
+ *
+ * Focus: the failure paths the silent catches used to hide — a connection
+ * that was never closed when the body threw, an `open` that fires `blocked`
+ * (which fires INSTEAD of success/error, so an unhandled one never settles),
+ * and a corrupt metadata payload that parses but is not an array.
+ */
+
+// fake-indexeddb installs a Node-compatible IDB implementation on
+// `globalThis.indexedDB`; the round-trip test uses it. The failure-path tests
+// swap in their own stub for the duration of the test.
+import 'fake-indexeddb/auto';
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import {
+  getRecentFiles,
+  cacheFileBlobs,
+  getCachedFileNames,
+  getCachedFile,
+} from './recent-files.js';
+
+interface MemoryStorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+class MemoryStorage implements MemoryStorageLike {
+  private store = new Map<string, string>();
+  getItem(key: string): string | null { return this.store.get(key) ?? null; }
+  setItem(key: string, value: string): void { this.store.set(key, value); }
+  removeItem(key: string): void { this.store.delete(key); }
+}
+
+const g = globalThis as { localStorage?: unknown; indexedDB?: unknown };
+const KEY = 'ifc-lite:recent-files';
+
+const realIndexedDB = g.indexedDB;
+let warnings: unknown[][];
+const realWarn = console.warn;
+
+beforeEach(() => {
+  g.localStorage = new MemoryStorage();
+  warnings = [];
+  console.warn = (...args: unknown[]) => { warnings.push(args); };
+});
+afterEach(() => {
+  g.indexedDB = realIndexedDB;
+  console.warn = realWarn;
+});
+
+/**
+ * An `indexedDB` stand-in whose `open` settles via `outcome`, handing back a
+ * database object that counts `close()` calls and can be told to throw from
+ * `transaction()` (the shape of `InvalidStateError` / `NotFoundError`).
+ */
+function stubIndexedDb(
+  outcome: 'success' | 'error' | 'blocked',
+  opts: { transactionThrows?: boolean } = {},
+): { closes: number } {
+  const counter = { closes: 0 };
+  const db = {
+    close() { counter.closes += 1; },
+    transaction() {
+      if (opts.transactionThrows) throw new Error('InvalidStateError: database is closing');
+      throw new Error('unreachable: transaction not expected in this test');
+    },
+  };
+  g.indexedDB = {
+    open() {
+      const req: Record<string, unknown> = { result: db, error: new Error('open failed'), transaction: null };
+      // Handlers are assigned by openDB AFTER open() returns, so fire on a
+      // later turn — exactly as the platform does.
+      queueMicrotask(() => {
+        const handler = req[`on${outcome}`];
+        if (typeof handler === 'function') (handler as () => void)();
+      });
+      return req;
+    },
+  };
+  return counter;
+}
+
+/** Reject rather than hang the suite if a promise never settles. */
+function withDeadline<T>(p: Promise<T>, ms = 1000): Promise<T> {
+  return Promise.race([
+    p,
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error('promise never settled')), ms).unref?.()),
+  ]);
+}
+
+describe('getRecentFiles', () => {
+  it('reads back stored entries', () => {
+    (g.localStorage as MemoryStorageLike).setItem(
+      KEY, JSON.stringify([{ name: 'a.ifc', size: 1, timestamp: 2 }]),
+    );
+    assert.deepStrictEqual(getRecentFiles(), [{ name: 'a.ifc', size: 1, timestamp: 2 }]);
+  });
+
+  it('returns an empty list for a payload that parses but is not an array', () => {
+    // `JSON.parse('{}')` succeeds, so the catch never fires; the object then
+    // reached CommandPalette/ViewportContainer, which `.map`/`.slice` it during
+    // render. Callers must always get an array.
+    for (const corrupt of ['{}', '"5"', 'null', '17']) {
+      (g.localStorage as MemoryStorageLike).setItem(KEY, corrupt);
+      assert.deepStrictEqual(getRecentFiles(), [], `payload ${corrupt}`);
+    }
+  });
+
+  it('returns an empty list for unparseable JSON', () => {
+    (g.localStorage as MemoryStorageLike).setItem(KEY, '{not json');
+    assert.deepStrictEqual(getRecentFiles(), []);
+  });
+});
+
+describe('IndexedDB blob cache — failure paths', () => {
+  it('settles instead of hanging when `open` reports blocked', async () => {
+    // `blocked` fires INSTEAD of success/error. Unhandled, the promise never
+    // settles and the awaiting click handler parks forever.
+    stubIndexedDb('blocked');
+    assert.strictEqual(await withDeadline(getCachedFile('a.ifc')), null);
+    assert.deepStrictEqual(await withDeadline(getCachedFileNames()), []);
+    assert.strictEqual(warnings.length, 2, 'both callers must say why they gave up');
+    assert.match(String(warnings[0][1]), /blocked by another open connection/);
+  });
+
+  it('closes the connection when the body throws after open succeeded', async () => {
+    const counter = stubIndexedDb('success', { transactionThrows: true });
+    assert.strictEqual(await withDeadline(getCachedFile('a.ifc')), null);
+    assert.strictEqual(counter.closes, 1, 'getCachedFile must close on the error path');
+
+    const counter2 = stubIndexedDb('success', { transactionThrows: true });
+    assert.deepStrictEqual(await withDeadline(getCachedFileNames()), []);
+    assert.strictEqual(counter2.closes, 1, 'getCachedFileNames must close on the error path');
+  });
+
+  it('closes the connection when cacheFileBlobs fails mid-transaction', async () => {
+    const counter = stubIndexedDb('success', { transactionThrows: true });
+    await withDeadline(cacheFileBlobs([new File([new Uint8Array([1, 2, 3])], 'a.ifc')]));
+    assert.strictEqual(counter.closes, 1);
+  });
+
+  it('names the cause instead of degrading in silence', async () => {
+    stubIndexedDb('success', { transactionThrows: true });
+    await withDeadline(getCachedFile('a.ifc'));
+    assert.strictEqual(warnings.length, 1);
+    assert.match(String(warnings[0][0]), /could not read "a\.ifc"/);
+
+    warnings = [];
+    stubIndexedDb('success', { transactionThrows: true });
+    await withDeadline(getCachedFileNames());
+    assert.strictEqual(warnings.length, 1);
+    assert.match(String(warnings[0][0]), /could not list the cached files/);
+  });
+});
+
+describe('IndexedDB blob cache — round trip', () => {
+  it('caches a file and reads it back', async () => {
+    await cacheFileBlobs([new File([new Uint8Array([1, 2, 3])], 'roundtrip.ifc')]);
+    assert.ok((await getCachedFileNames()).includes('roundtrip.ifc'));
+    const file = await getCachedFile('roundtrip.ifc');
+    assert.ok(file, 'the cached file must come back');
+    assert.strictEqual(file.name, 'roundtrip.ifc');
+    assert.deepStrictEqual(new Uint8Array(await file.arrayBuffer()), new Uint8Array([1, 2, 3]));
+    assert.deepStrictEqual(warnings, [], 'the happy path must stay quiet');
+  });
+
+  it('answers null for a name that was never cached', async () => {
+    assert.strictEqual(await getCachedFile('never-seen.ifc'), null);
+  });
+});

--- a/apps/viewer/src/lib/recent-files.test.ts
+++ b/apps/viewer/src/lib/recent-files.test.ts
@@ -7,14 +7,19 @@
  *
  * Focus: the failure paths the silent catches used to hide — a connection
  * that was never closed when the body threw, an `open` that fires `blocked`
- * (which fires INSTEAD of success/error, so an unhandled one never settles),
- * and a corrupt metadata payload that parses but is not an array.
+ * (which fires IN ADDITION TO success/error and earlier, so an unhandled one
+ * leaves the promise unsettled until the blocking tab closes, and a handled
+ * one still has a connection arriving after the fact), and a corrupt metadata
+ * payload that parses but is not an array.
  */
 
 // fake-indexeddb installs a Node-compatible IDB implementation on
 // `globalThis.indexedDB`; the round-trip test uses it. The failure-path tests
 // swap in their own stub for the duration of the test.
 import 'fake-indexeddb/auto';
+// The factory constructor, for a private database instance — the `/lib/*`
+// subpaths ship no types under "exports", the root entry does.
+import { IDBFactory as FakeIDBFactory } from 'fake-indexeddb';
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert';
 import {
@@ -39,6 +44,8 @@ class MemoryStorage implements MemoryStorageLike {
 
 const g = globalThis as { localStorage?: unknown; indexedDB?: unknown };
 const KEY = 'ifc-lite:recent-files';
+/** Mirrors the module-private `DB_NAME`, so the leak test can hold it open. */
+const DB_NAME_UNDER_TEST = 'ifc-lite-file-cache';
 
 const realIndexedDB = g.indexedDB;
 let warnings: unknown[][];
@@ -121,13 +128,66 @@ describe('getRecentFiles', () => {
 
 describe('IndexedDB blob cache — failure paths', () => {
   it('settles instead of hanging when `open` reports blocked', async () => {
-    // `blocked` fires INSTEAD of success/error. Unhandled, the promise never
-    // settles and the awaiting click handler parks forever.
+    // `blocked` fires before success/error, and the request keeps waiting on
+    // the blocking connection. Unhandled, the promise stays unsettled for as
+    // long as the other tab lives and the awaiting click handler parks with it
+    // — here the stub never follows up at all, the worst case.
     stubIndexedDb('blocked');
     assert.strictEqual(await withDeadline(getCachedFile('a.ifc')), null);
     assert.deepStrictEqual(await withDeadline(getCachedFileNames()), []);
     assert.strictEqual(warnings.length, 2, 'both callers must say why they gave up');
     assert.match(String(warnings[0][1]), /blocked by another open connection/);
+  });
+
+  it('closes the connection that still arrives after a `blocked` rejection', async () => {
+    // `blocked` is NOT terminal: it fires before upgradeneeded/success, and the
+    // request is never abandoned. When the blocking connection goes away the
+    // same request proceeds and delivers a live `req.result` — which the
+    // already-rejected promise has no way to hand to a caller. Unless openDB
+    // closes it, it leaks and then blocks the NEXT version upgrade, trading the
+    // hang this handler fixed for a hang one version later.
+    //
+    // A private factory so the round-trip suite's database (already at v2) does
+    // not decide the outcome; this one starts empty.
+    const factory = new FakeIDBFactory();
+    g.indexedDB = factory;
+
+    // The blocking tab: a v1 connection. Exactly the returning user's state —
+    // DB_VERSION was 1 until #1777 bumped it to 2, so the 1 → 2 upgrade is live.
+    const blocker = await new Promise<IDBDatabase>((resolve, reject) => {
+      const req = factory.open(DB_NAME_UNDER_TEST, 1);
+      req.onupgradeneeded = () => {
+        req.result.createObjectStore('files', { keyPath: 'name' });
+      };
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => reject(req.error);
+    });
+
+    // openDB() asks for v2 and gets `blocked`, because the blocker holds v1.
+    assert.strictEqual(await withDeadline(getCachedFile('a.ifc')), null);
+    assert.match(
+      String(warnings.at(-1)?.[1]), /blocked by another open connection/,
+      'vacuity guard: the blocked path must actually have fired',
+    );
+
+    // The blocking tab closes. The v2 request resumes: upgradeneeded, then
+    // success with a live connection.
+    blocker.close();
+    // NOT unref'd: this timer has to hold the loop open while the resumed
+    // request runs, otherwise the test exits before the connection is delivered.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // If that connection leaked it is holding v2 open, and this v3 request
+    // blocks — the very hang the `onblocked` handler was added to prevent.
+    const v3 = await withDeadline(new Promise<IDBDatabase>((resolve, reject) => {
+      const req = factory.open(DB_NAME_UNDER_TEST, 3);
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => reject(req.error);
+      req.onblocked = () => reject(new Error(
+        'the connection delivered after the `blocked` rejection was leaked: it still holds the database',
+      ));
+    }));
+    v3.close();
   });
 
   it('closes the connection when the body throws after open succeeded', async () => {

--- a/apps/viewer/src/lib/recent-files.ts
+++ b/apps/viewer/src/lib/recent-files.ts
@@ -98,13 +98,25 @@ function openDB(): Promise<IDBDatabase> {
     req.onsuccess = () => resolve(req.result);
     req.onerror = () => reject(req.error);
     // `blocked` fires when another connection still holds the database at an
-    // older version, and it fires INSTEAD of success/error — without this the
-    // promise never settles and every awaiting caller parks forever (a click
-    // on a recent file would simply do nothing, with no error). Reject so the
-    // callers reach their catch and degrade to "no cache".
-    req.onblocked = () => reject(
-      new Error(`[recent-files] IndexedDB upgrade to v${DB_VERSION} blocked by another open connection`),
-    );
+    // older version. It is not an outcome: it fires IN ADDITION TO success or
+    // error, and earlier — the request stays pending until the blocking
+    // connection goes away, and only then does it run upgradeneeded/success.
+    // Left unhandled, the promise sits unsettled for as long as the other tab
+    // lives, and every awaiting caller parks with it (a click on a recent file
+    // would simply do nothing, with no error). Reject so the callers reach
+    // their catch and degrade to "no cache" now instead of waiting.
+    req.onblocked = () => {
+      reject(
+        new Error(`[recent-files] IndexedDB upgrade to v${DB_VERSION} blocked by another open connection`),
+      );
+      // Having rejected, nobody is left to receive the connection this request
+      // will still deliver once the blocker closes — so close it here. An
+      // orphan holds the database at DB_VERSION and blocks the NEXT upgrade,
+      // which would trade the hang above for a hang one version later. This
+      // handler replaces the resolver only on the path that already rejected;
+      // an open that never reported `blocked` keeps resolving normally.
+      req.onsuccess = () => req.result.close();
+    };
   });
 }
 

--- a/apps/viewer/src/lib/recent-files.ts
+++ b/apps/viewer/src/lib/recent-files.ts
@@ -37,8 +37,14 @@ export type RecentFileInput = {
 // ── localStorage (metadata) ─────────────────────────────────────────────
 
 export function getRecentFiles(): RecentFileEntry[] {
-  try { return JSON.parse(localStorage.getItem(KEY) ?? '[]'); }
-  catch { return []; }
+  try {
+    // The catch only covers a PARSE failure. A payload that parses to a
+    // non-array (`{}`, `"5"`, `null`) sails past it and reaches the callers,
+    // which `.map` / `.slice` it during render (CommandPalette, ViewportContainer)
+    // — a corrupt key would take the whole viewport down. Shape-check here.
+    const parsed: unknown = JSON.parse(localStorage.getItem(KEY) ?? '[]');
+    return Array.isArray(parsed) ? parsed as RecentFileEntry[] : [];
+  } catch { return []; }
 }
 
 // Browser uploads don't expose filesystem paths, so the file name is the
@@ -91,11 +97,20 @@ function openDB(): Promise<IDBDatabase> {
     };
     req.onsuccess = () => resolve(req.result);
     req.onerror = () => reject(req.error);
+    // `blocked` fires when another connection still holds the database at an
+    // older version, and it fires INSTEAD of success/error — without this the
+    // promise never settles and every awaiting caller parks forever (a click
+    // on a recent file would simply do nothing, with no error). Reject so the
+    // callers reach their catch and degrade to "no cache".
+    req.onblocked = () => reject(
+      new Error(`[recent-files] IndexedDB upgrade to v${DB_VERSION} blocked by another open connection`),
+    );
   });
 }
 
 /** Cache file blobs in IndexedDB for instant reload from palette. */
 export async function cacheFileBlobs(files: File[]): Promise<void> {
+  let db: IDBDatabase | undefined;
   try {
     // Only stage up to the cache capacity. The store keeps at most
     // MAX_CACHED_FILES entries, so reading every blob of a large multi-file drop
@@ -121,7 +136,7 @@ export async function cacheFileBlobs(files: File[]): Promise<void> {
     }
     if (records.length === 0) return;
 
-    const db = await openDB();
+    db = await openDB();
     const tx = db.transaction(STORE_NAME, 'readwrite');
     const store = tx.objectStore(STORE_NAME);
 
@@ -149,9 +164,14 @@ export async function cacheFileBlobs(files: File[]): Promise<void> {
       tx.oncomplete = () => resolve();
       tx.onerror = () => reject(tx.error);
     });
-    db.close();
   } catch (err) {
     console.warn('[recent-files] failed to cache file blobs', err);
+  } finally {
+    // Every early exit from the block above used to skip this, leaving the
+    // connection open for the life of the tab. An orphaned connection at the
+    // current version also blocks the next DB_VERSION upgrade — see openDB's
+    // `onblocked`. Close on every path.
+    db?.close();
   }
 }
 
@@ -162,26 +182,31 @@ export async function cacheFileBlobs(files: File[]): Promise<void> {
  * activation a file dialog needs.
  */
 export async function getCachedFileNames(): Promise<string[]> {
+  let db: IDBDatabase | undefined;
   try {
-    const db = await openDB();
+    db = await openDB();
     const tx = db.transaction(STORE_NAME, 'readonly');
     const req = tx.objectStore(STORE_NAME).getAllKeys();
     const keys = await new Promise<IDBValidKey[]>((resolve, reject) => {
       req.onsuccess = () => resolve(req.result);
       req.onerror = () => reject(req.error);
     });
-    db.close();
     return keys.map(String);
-  } catch {
+  } catch (err) {
+    // Called on every palette open, but only ONCE per open — not a render loop.
+    console.warn('[recent-files] could not list the cached files', err);
     return [];
+  } finally {
+    db?.close();
   }
 }
 
 /** Retrieve a cached file blob and reconstruct a File object. */
 export async function getCachedFile(target: string | RecentFileEntry): Promise<File | null> {
   const name = typeof target === 'string' ? target : target.name;
+  let db: IDBDatabase | undefined;
   try {
-    const db = await openDB();
+    db = await openDB();
     const tx = db.transaction(STORE_NAME, 'readonly');
     const store = tx.objectStore(STORE_NAME);
     const req = store.get(name);
@@ -189,10 +214,14 @@ export async function getCachedFile(target: string | RecentFileEntry): Promise<F
       req.onsuccess = () => resolve(req.result);
       req.onerror = () => reject(req.error);
     });
-    db.close();
     if (!result) return null;
     return new File([result.blob], result.name, { type: result.type || 'application/octet-stream' });
-  } catch {
+  } catch (err) {
+    // The caller falls back to the file picker, which looks to the user like
+    // the cache simply missed — name the real cause here. One per click.
+    console.warn(`[recent-files] could not read "${name}" from the blob cache`, err);
     return null;
+  } finally {
+    db?.close();
   }
 }

--- a/apps/viewer/src/store/slices/lensSlice.ts
+++ b/apps/viewer/src/store/slices/lensSlice.ts
@@ -83,8 +83,13 @@ function saveLenses(lenses: Lens[]): void {
         JSON.stringify(l.autoColor) !== JSON.stringify(original.autoColor);
     });
     localStorage.setItem(STORAGE_KEY, JSON.stringify([...custom, ...builtinOverrides]));
-  } catch {
-    // quota exceeded or unavailable — silently ignore
+  } catch (err) {
+    // Every caller commits the new lens list to the store regardless, so the
+    // edit LOOKS applied and is gone on reload. Surfacing that to the user
+    // needs a failure channel this void-returning helper does not have (see
+    // lib/clash/persistence.ts for the SaveResult shape) — a maintainer call.
+    // Until then, at least name it. Lens edits are user-driven and rare.
+    console.warn('[lens] could not persist lenses; this change will not survive a reload', err);
   }
 }
 


### PR DESCRIPTION
#2082's method applied to `apps/viewer`, the largest remaining cluster. The logging is secondary — these are the three that hid something real.

**Count correction first:** the brief said 83 silent catches. My regenerated scan — a catch whose body neither logs, rethrows, nor propagates an `Error` — finds **206**. The 83 was the narrower "empty or comment-only body" reading. I used the wider one so nothing was excluded by definition. 206 → 198 here.

## 1. `lib/recent-files.ts` — an IndexedDB connection leak, with a latent hang

`db.close()` sat on the **success path only** in all three IDB functions, and the silent `catch { return [] }` swallowed every failure and skipped the close. `getCachedFileNames` runs on **every command-palette open**, so the leak repeats all session.

Compounding it, `openDB` had no `onblocked` handler. `blocked` fires *instead of* `onsuccess`/`onerror`, so that promise **never settles** — and `getCachedFile` is awaited inside a click handler with no timeout (`ViewportContainer.tsx:1252`). Clicking a recent file would do nothing, forever, silently.

**Precise scope, because it matters:** `blocked` requires an open connection at an older version, so with `DB_VERSION` static at 2 the hang is **latent** — armed by the next version bump, and armed *by* the leaked connections. Both halves fixed.

Also hardened `getRecentFiles`: its catch covers parse failure only, so a payload parsing to a non-array (`{}`, `null`) reached `.map`/`.slice` during render and would white-screen the viewport.

## 2. `chat/ExecutableCodeBlock.tsx:126` — a stale screenshot reaching the model — **BEHAVIOUR CHANGE**

The auto-capture wrote the store slot only on success; the slot is cleared only at send time (`ChatPanel.tsx:619`). So: run script A (capture succeeds) → run script B (capture throws, or no canvas) → send, and **the message about B carries A's viewport image**, with nothing said.

The `// non-critical` comment was wrong about the failure mode. It is not "no screenshot", it is "the wrong screenshot" — handed to a model as evidence about a different script.

The caller now writes the slot unconditionally, `null` on failure. **Previously a failed capture preserved the prior image; it now clears it.**

## 3. `useDrawingGeneration.ts:733` — the #2079 shape on a per-mesh hot path

`meshOutline2dFn` is read defensively off `@ifc-lite/wasm` because the binding is CI-built. If it **exists but throws** — a wasm bundle whose ABI no longer matches this JS — *every* element silently degrades to the TS silhouette, and the user gets a plausible-looking but wrong drawing with an empty console.

Called once per mesh, so a per-occurrence log would itself be a defect. Latched once per provider, fresh budget each generation.

## Also logged (no behaviour change)

Each is a case where failure is indistinguishable from a legitimate empty result: a cesium convergence probe returning `0` (the model placed grid-aligned in a true-north frame, up to ~3° UTM / ~7–8° Krovak — **not claimed as observed**, proj4 succeeding at the base point and throwing 1 m north is near-unreachable; it is a consistency guard on a cold path), a failed underlay rendering as "no elements at this cut", a failed bulk query showing "0 matches", a mint failure looking like a blocked clipboard.

## Left for you — silent data loss needing a UX channel, not a log

- **`lensSlice.ts:86`** — `saveLenses` returns `void` and every caller commits to the store regardless, so a lens create/rename/delete/import **looks applied and is gone on reload**. Needs the `SaveResult` channel `lib/clash/persistence.ts` already has, plus a toast. Logged; the UX call is yours.
- **`chatSlice.ts:219`** — quota failure loses chat history; `toStore` is 50 messages with full content, code blocks and attachments.
- **`clash/persistence.ts:145`/`:298`** — a read failure returns `[]` or a **partial** map, and the next `savePresets`/`saveReviews` overwrites storage with it, destroying custom clash rules or triage. Only reachable on already-corrupt data, so: suspicious, not confirmed.
- **`search/saved-filters.ts:76`** — `removeItem` **inside a read catch** wipes the whole preset catalog on one bad parse.
- **`clashSlice.ts:308/314/320`** — discard a non-silent `{ok:false}` `SaveResult`; the persistence layer did its job and the caller re-silences it.

## Cleared as benign, by tracing rather than assumption

All localStorage preference writes, clipboard fallbacks, collab teardown catches (they *prevent* a leak), `lib/geo/reproject.ts` (every path `Number.isFinite`-guarded before returning), `share-link.ts:152` (fails closed to `'viewer'`), `SpaceSketchOverlay.tsx:911` (verified in the Rust — `remove_edge`/`merge_faces` validate before the first mutation, so the swallowed rejection leaves the plate byte-identical), `wasm-version-skew.ts` (already exemplary).

I also re-checked the two shapes that bit #2082 and found **neither**: `federationAlign.ts:413` captures `firstProjError` and *does* re-check it on both exit paths, and no viewer loop terminates on a flag an error path forgets to set.

## Evidence

**12 mutants, 12 killed.** I re-ran the stale-screenshot one myself on the pushed tree (`REPLACEMENTS=1`, line re-read): `returns null — not the previous shot — when the capture throws` fails, restored 22/22 across the three new suites.

The `onblocked` mutant is the interesting one — removing it makes the suite hit a 1 s deadline guard, i.e. **the hang demonstrated** rather than argued.

**Two initial mutants survived, and that was my fault rather than the tests'** — they were additive and left the `finally` in place. Rebuilt as true pre-fix states and both killed. Stating it because a survivor I'd hand-waved would have been exactly the false green.

On vacuity: the failure tests assert on a **counted** `console.warn` and a `close()` counter, so they cannot pass against a harness that never ran the path, and each has a mutant proving it fails when the behaviour is removed. The recent-files round-trip additionally asserts `warnings` is empty, so a silently-degraded happy path fails too.

2594 passing (was 2571), typecheck 34/34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
