### PR TITLE
fix(pointcloud): retry the laz-perf wasm load instead of caching the failure

### DIFF
--- a/.changeset/laz-perf-load-retry.md
+++ b/.changeset/laz-perf-load-retry.md
@@ -1,0 +1,11 @@
+---
+"@ifc-lite/pointcloud": patch
+---
+
+Retry the `laz-perf` wasm load after a transient failure instead of poisoning every future `.laz` open.
+
+`LazStreamingSource.open()` shares one lazily-instantiated wasm module across every source, memoised in a module-level `modulePromise`. That promise was assigned once and never cleared, so a rejection was cached exactly like a success: a single failed wasm fetch — a 404 from a misconfigured asset path, an offline blip, a 5xx from the CDN — left every subsequent LAZ open replaying the same rejected promise for the lifetime of the page. The user re-dropped the file and got the identical error, with no fetch ever attempted again; only a reload recovered.
+
+The memo now lives in a small `memoizeAsync` helper that drops the cached promise when the load rejects, so the next `open()` retries. A fulfilled module is still cached forever, and concurrent opens still collapse onto a single in-flight load — dropping several `.laz` files at once instantiates the wasm once, as before. This matches the remedy already applied to `@ifc-lite/query`'s `DuckDBIntegration.init()`, which clears its cached `initPromise` on failure for the same reason.
+
+There is deliberately no backoff: retries here are driven by a user re-opening a file, not by a polling loop, and a batch of simultaneous opens already shares one attempt.

--- a/packages/pointcloud/src/streaming/laz-source.test.ts
+++ b/packages/pointcloud/src/streaming/laz-source.test.ts
@@ -1,0 +1,116 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  LazStreamingSource,
+  setLazPerfLoaderForTesting,
+  type LasZipInstance,
+  type LazPerfModule,
+} from './laz-source.js';
+
+const RECORD_LEN = 20; // LAS point format 0
+
+/**
+ * A minimal LAS 1.2 header. `open()` parses the header before it touches
+ * laz-perf, so the payload never has to be real LAZ — the stub module
+ * below stands in for the decompressor.
+ */
+function buildLazFile(pointCount: number): Blob {
+  const headerSize = 227;
+  const buf = new ArrayBuffer(headerSize + pointCount * RECORD_LEN);
+  const view = new DataView(buf);
+  view.setUint32(0, 0x4653414c, true); // "LASF"
+  view.setUint8(24, 1);
+  view.setUint8(25, 2);
+  view.setUint16(94, headerSize, true);
+  view.setUint32(96, headerSize, true);
+  view.setUint32(100, 0, true);
+  view.setUint8(104, 0);
+  view.setUint16(105, RECORD_LEN, true);
+  view.setUint32(107, pointCount, true);
+  view.setFloat64(131, 1, true);
+  view.setFloat64(139, 1, true);
+  view.setFloat64(147, 1, true);
+  return new Blob([buf], { type: 'application/octet-stream' });
+}
+
+/** Stand-in for the emscripten module, with a bump allocator over a fake heap. */
+function stubLazPerfModule(): LazPerfModule {
+  const heap = new Uint8Array(1 << 16);
+  let next = 8;
+  class StubLasZip implements LasZipInstance {
+    open(): void { /* no-op — the stub never decompresses */ }
+    getPoint(): void { /* no-op */ }
+    getCount(): number { return 0; }
+    getPointLength(): number { return RECORD_LEN; }
+    getPointFormat(): number { return 0; }
+    delete(): void { /* no-op */ }
+  }
+  return {
+    LASZip: StubLasZip,
+    HEAPU8: heap,
+    _malloc: (size: number) => {
+      const ptr = next;
+      next += size;
+      return ptr;
+    },
+    _free: () => { /* no-op */ },
+  };
+}
+
+describe('LazStreamingSource wasm loading', () => {
+  let restore: (() => void) | null = null;
+
+  afterEach(() => {
+    restore?.();
+    restore = null;
+  });
+
+  it('retries the wasm load after a transient failure instead of poisoning every future open', async () => {
+    let calls = 0;
+    restore = setLazPerfLoaderForTesting(async () => {
+      calls++;
+      if (calls === 1) throw new Error('wasm fetch failed (503)');
+      return stubLazPerfModule();
+    });
+
+    // First drop of the file: the wasm fetch fails.
+    await expect(new LazStreamingSource(buildLazFile(4)).open())
+      .rejects.toThrow('wasm fetch failed (503)');
+
+    // The user re-drops the file. This must retry, not replay the cached
+    // rejection — which is exactly what the un-reset memo used to do.
+    const info = await new LazStreamingSource(buildLazFile(4)).open();
+    expect(info.totalPointCount).toBe(4);
+    expect(calls).toBe(2);
+  });
+
+  it('shares one wasm load between concurrent opens', async () => {
+    let calls = 0;
+    restore = setLazPerfLoaderForTesting(async () => {
+      calls++;
+      return stubLazPerfModule();
+    });
+
+    await Promise.all([
+      new LazStreamingSource(buildLazFile(1)).open(),
+      new LazStreamingSource(buildLazFile(2)).open(),
+      new LazStreamingSource(buildLazFile(3)).open(),
+    ]);
+    expect(calls).toBe(1);
+  });
+
+  it('keeps memoising a successful load', async () => {
+    let calls = 0;
+    restore = setLazPerfLoaderForTesting(async () => {
+      calls++;
+      return stubLazPerfModule();
+    });
+
+    await new LazStreamingSource(buildLazFile(1)).open();
+    await new LazStreamingSource(buildLazFile(1)).open();
+    expect(calls).toBe(1);
+  });
+});

--- a/packages/pointcloud/src/streaming/laz-source.ts
+++ b/packages/pointcloud/src/streaming/laz-source.ts
@@ -21,13 +21,15 @@ import {
   sampleMaxRgbChannel,
   type LasHeader,
 } from '../formats/las.js';
+import { memoizeAsync } from './memo.js';
 import type {
   DownsampleHint,
   PointSourceInfo,
   StreamingPointSource,
 } from './types.js';
 
-interface LasZipInstance {
+/** @internal — exported only so the loader seam below can be typed. */
+export interface LasZipInstance {
   delete(): void;
   open(ptr: number, length: number): void;
   getPoint(dest: number): void;
@@ -36,59 +38,53 @@ interface LasZipInstance {
   getPointFormat(): number;
 }
 
-interface LazPerfModule {
+/** @internal — exported only so the loader seam below can be typed. */
+export interface LazPerfModule {
   LASZip: { new (): LasZipInstance };
   HEAPU8: Uint8Array;
   _malloc(size: number): number;
   _free(ptr: number): void;
 }
 
-let modulePromise: Promise<LazPerfModule> | null = null;
+async function importLazPerf(): Promise<LazPerfModule> {
+  // The shipped `laz-perf.js` shim resolves the wasm via emscripten's
+  // `locateFile` and tries `fetch("laz-perf.wasm")` relative to the
+  // worker's script directory — which under Vite ends up at
+  // `/assets/<chunk>.wasm` (404) or `/laz-perf.wasm` (404 → SPA index
+  // HTML served as text/plain, which is what triggered the
+  // "MIME type 'text/plain'" failure on autzen-classified.laz).
+  //
+  // Pre-fetch the wasm via Vite's `?url` asset pipeline (hashed,
+  // served with `application/wasm`) and hand the bytes to emscripten
+  // as `Module.wasmBinary` so its own fetch is skipped entirely.
+  const wasmBinary = await fetchLazPerfWasm();
 
-async function loadLazPerf(): Promise<LazPerfModule> {
-  if (!modulePromise) {
-    modulePromise = (async () => {
-      // The shipped `laz-perf.js` shim resolves the wasm via emscripten's
-      // `locateFile` and tries `fetch("laz-perf.wasm")` relative to the
-      // worker's script directory — which under Vite ends up at
-      // `/assets/<chunk>.wasm` (404) or `/laz-perf.wasm` (404 → SPA index
-      // HTML served as text/plain, which is what triggered the
-      // "MIME type 'text/plain'" failure on autzen-classified.laz).
-      //
-      // Pre-fetch the wasm via Vite's `?url` asset pipeline (hashed,
-      // served with `application/wasm`) and hand the bytes to emscripten
-      // as `Module.wasmBinary` so its own fetch is skipped entirely.
-      const wasmBinary = await fetchLazPerfWasm();
-
-      // Dynamic import keeps `laz-perf` out of bundles that don't touch
-      // LAZ. The package is shipped as CommonJS (`lib/{node,web}/index.js`),
-      // and Vite/webpack wrap CJS imports under `.default` — but the way
-      // they do that varies, so probe every shape we might see:
-      //   • { createLazPerf }                     — pure-ESM build
-      //   • { default: { createLazPerf } }        — Vite default-wrapper
-      //   • { default: createLazPerf }            — esModuleInterop on a fn
-      //   • module-as-function (legacy UMD)        — `lazPerf` IS the factory
-      const ns = (await import('laz-perf')) as unknown as Record<string, unknown>;
-      type Factory = (moduleOverrides?: Record<string, unknown>) => Promise<LazPerfModule>;
-      const dflt = ns.default as Record<string, unknown> | (() => unknown) | undefined;
-      const candidates: Array<unknown> = [
-        ns.createLazPerf,
-        typeof dflt === 'object' && dflt !== null ? (dflt as Record<string, unknown>).createLazPerf : undefined,
-        dflt,
-        // Some bundlers expose the CJS module as the namespace object itself.
-        ns,
-      ];
-      const factory = candidates.find((c) => typeof c === 'function') as Factory | undefined;
-      if (!factory) {
-        const keys = Object.keys(ns as Record<string, unknown>).join(', ');
-        throw new Error(
-          `laz-perf: could not find createLazPerf factory (saw keys: ${keys || '<empty>'})`,
-        );
-      }
-      return factory({ wasmBinary });
-    })();
+  // Dynamic import keeps `laz-perf` out of bundles that don't touch
+  // LAZ. The package is shipped as CommonJS (`lib/{node,web}/index.js`),
+  // and Vite/webpack wrap CJS imports under `.default` — but the way
+  // they do that varies, so probe every shape we might see:
+  //   • { createLazPerf }                     — pure-ESM build
+  //   • { default: { createLazPerf } }        — Vite default-wrapper
+  //   • { default: createLazPerf }            — esModuleInterop on a fn
+  //   • module-as-function (legacy UMD)        — `lazPerf` IS the factory
+  const ns = (await import('laz-perf')) as unknown as Record<string, unknown>;
+  type Factory = (moduleOverrides?: Record<string, unknown>) => Promise<LazPerfModule>;
+  const dflt = ns.default as Record<string, unknown> | (() => unknown) | undefined;
+  const candidates: Array<unknown> = [
+    ns.createLazPerf,
+    typeof dflt === 'object' && dflt !== null ? (dflt as Record<string, unknown>).createLazPerf : undefined,
+    dflt,
+    // Some bundlers expose the CJS module as the namespace object itself.
+    ns,
+  ];
+  const factory = candidates.find((c) => typeof c === 'function') as Factory | undefined;
+  if (!factory) {
+    const keys = Object.keys(ns as Record<string, unknown>).join(', ');
+    throw new Error(
+      `laz-perf: could not find createLazPerf factory (saw keys: ${keys || '<empty>'})`,
+    );
   }
-  return modulePromise;
+  return factory({ wasmBinary });
 }
 
 async function fetchLazPerfWasm(): Promise<Uint8Array> {
@@ -112,6 +108,28 @@ async function fetchLazPerfWasm(): Promise<Uint8Array> {
   }
   const buffer = await response.arrayBuffer();
   return new Uint8Array(buffer);
+}
+
+/**
+ * The wasm module is instantiated once and shared by every `open()`.
+ * `memoizeAsync` drops the memo if the load rejects, so a transient wasm
+ * fetch failure no longer poisons every future LAZ open for the lifetime
+ * of the page — the next dropped file retries.
+ */
+let loadLazPerf = memoizeAsync(importLazPerf);
+
+/**
+ * @internal Test seam. The real loader fetches wasm over the network and
+ * instantiates an emscripten module, neither of which a unit test can
+ * drive, so tests swap in a stub. Returns a restore function.
+ */
+export function setLazPerfLoaderForTesting(
+  loader: () => Promise<LazPerfModule>,
+): () => void {
+  loadLazPerf = memoizeAsync(loader);
+  return () => {
+    loadLazPerf = memoizeAsync(importLazPerf);
+  };
 }
 
 export class LazStreamingSource implements StreamingPointSource {

--- a/packages/pointcloud/src/streaming/memo.test.ts
+++ b/packages/pointcloud/src/streaming/memo.test.ts
@@ -1,0 +1,93 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect } from 'vitest';
+import { memoizeAsync } from './memo.js';
+
+/** A factory whose settlement each caller controls, plus a call counter. */
+function deferredFactory<T>() {
+  const gates: Array<{ resolve: (v: T) => void; reject: (e: unknown) => void }> = [];
+  let calls = 0;
+  const factory = (): Promise<T> => {
+    calls++;
+    return new Promise<T>((resolve, reject) => {
+      gates.push({ resolve, reject });
+    });
+  };
+  return { factory, gates, get calls() { return calls; } };
+}
+
+describe('memoizeAsync', () => {
+  it('caches a fulfilled value and never calls the factory again', async () => {
+    let calls = 0;
+    const load = memoizeAsync(async () => {
+      calls++;
+      return 'module';
+    });
+
+    expect(await load()).toBe('module');
+    expect(await load()).toBe('module');
+    expect(calls).toBe(1);
+  });
+
+  it('shares one in-flight promise between concurrent callers', async () => {
+    const d = deferredFactory<string>();
+    const load = memoizeAsync(d.factory);
+
+    const a = load();
+    const b = load();
+    // The factory call is deferred by a microtask; let it happen.
+    await Promise.resolve();
+    expect(d.calls).toBe(1);
+
+    d.gates[0].resolve('module');
+    expect(await a).toBe('module');
+    expect(await b).toBe('module');
+  });
+
+  it('retries after a rejection instead of caching the failure', async () => {
+    let calls = 0;
+    const load = memoizeAsync(async () => {
+      calls++;
+      if (calls === 1) throw new Error('transient fetch failure');
+      return 'module';
+    });
+
+    await expect(load()).rejects.toThrow('transient fetch failure');
+    expect(await load()).toBe('module');
+    expect(calls).toBe(2);
+  });
+
+  it('rejects concurrent callers together, then lets a later caller retry', async () => {
+    const d = deferredFactory<string>();
+    const load = memoizeAsync(d.factory);
+
+    const a = load();
+    const b = load();
+    await Promise.resolve();
+    expect(d.calls).toBe(1);
+
+    d.gates[0].reject(new Error('boom'));
+    await expect(a).rejects.toThrow('boom');
+    await expect(b).rejects.toThrow('boom');
+
+    const c = load();
+    await Promise.resolve();
+    expect(d.calls).toBe(2);
+    d.gates[1].resolve('module');
+    expect(await c).toBe('module');
+  });
+
+  it('surfaces a synchronous throw as a rejection and still allows a retry', async () => {
+    let calls = 0;
+    const load = memoizeAsync((): Promise<string> => {
+      calls++;
+      if (calls === 1) throw new Error('sync boom');
+      return Promise.resolve('module');
+    });
+
+    await expect(load()).rejects.toThrow('sync boom');
+    expect(await load()).toBe('module');
+  });
+});

--- a/packages/pointcloud/src/streaming/memo.ts
+++ b/packages/pointcloud/src/streaming/memo.ts
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Memoise a one-shot async factory, retrying after failure.
+ *
+ * Concurrent callers share a single in-flight promise (the point of the
+ * memo — one wasm fetch, not one per `open()`), and a fulfilled value is
+ * cached forever. A *rejection* clears the memo so a transient failure
+ * does not poison every future call: the next caller retries. The same
+ * fix exists in `@ifc-lite/query`'s `duckdb-integration.ts`.
+ *
+ * There is deliberately no backoff. Retries here are driven by a user
+ * re-opening a file rather than by a polling loop, and callers that open
+ * several files at once already collapse onto the one in-flight promise.
+ */
+export function memoizeAsync<T>(factory: () => Promise<T>): () => Promise<T> {
+  let pending: Promise<T> | null = null;
+  return () => {
+    // `Promise.resolve().then(factory)` defers the call by a microtask so
+    // the `catch` below can never run before `pending` has been assigned —
+    // which is what would happen if `factory` threw synchronously.
+    pending ??= Promise.resolve().then(factory).catch((err: unknown) => {
+      pending = null;
+      throw err;
+    });
+    return pending;
+  };
+}


### PR DESCRIPTION
Closes the item flagged and deliberately left unfixed in #2083.

## The defect

`laz-source.ts:46-91` assigned `modulePromise` inside `if (!modulePromise)` and **never cleared it on rejection**. A rejected promise caches exactly like a fulfilled one, so one failed wasm fetch made `loadLazPerf()` replay that rejection for the life of the page — every later LAZ open failed identically, **with no fetch attempted**, and only a reload recovered.

## Followed the in-repo remedy rather than inventing one

`duckdb-integration.ts:78-100` clears its memo on failure and rethrows, with a comment naming this exact reason: *"so a transient failure does not poison every future `init()` call"*. Same remedy here, including its choice of no backoff. I did not copy its *structure* — duckdb's memo is per-instance class state, laz-perf's is module-level — so the memo became a small helper instead.

## The seam was the point, and is why this was declined once

`loadLazPerf` was module-private and both dynamic imports resolve identically under vitest, so any test would have passed against the broken code. #2083 correctly refused to ship an unpinned fix.

**`memoizeAsync` is called by production** (`laz-source.ts:118`), not just by tests — an extracted helper the production path bypasses would be the same vacuity in a new place. And the laz-source test drives the real `LazStreamingSource.open()` end to end with a stub emscripten module, so it pins production behaviour rather than the helper in isolation.

Public API unchanged: none of the three new exports is re-exported from `src/index.ts`.

## Two things a naive "clear on reject" breaks

- **Concurrency.** `pending ??=` keeps concurrent callers on one in-flight promise; the reset runs in the rejection handler, after every current holder already has it. They fail together, and only a *later* call retries. Asserted at both the helper level and via three concurrent `open()`s (loader ran once).
- **Synchronous throws.** `Promise.resolve().then(factory)` defers the factory by a microtask, so a sync throw cannot run the `catch` before `pending` is assigned — which would cache the rejection permanently, i.e. **reintroduce this exact bug inside its own fix**. Covered by a test.

## No backoff, deliberately

Retries are user-driven (re-dropping a file), simultaneous opens already collapse onto one attempt, and the in-repo precedent has none. A sequential loop over N failing files does N fetches — strictly better than permanent poisoning, and stated in the changeset rather than left implicit.

## Evidence

| mutation | result |
|---|---|
| restore the original memo semantics (drop the reset) | **4 tests fail** |
| drop the `??=` guard — the naive "clear on reject" | **5 fail**, incl. both concurrency negatives |

I re-ran the first myself on the pushed tree (`REPLACEMENTS=1`, region re-read): 4 failed / 127 passed, including the end-to-end `retries the wasm load after a transient failure instead of poisoning every future open`. Restored 131/133.

The two negative-case tests stayed **green** under that mutation — they are not what drives the RED, which is what makes the pair meaningful.

131 passing (was 123), typecheck 34/34. Baseline was re-measured like-for-like: a first raw read showed `120 passed | 5 skipped`, and the 3 extra skips were `worker-bundle.test.ts`'s `hasBuild` guards un-skipping once `dist/` was built — not a regression.

**Not claimed:** a real wasm fetch failure could not be exercised here — no network fault injection, no browser. The pin is via the injected loader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
