### PR TITLE
fix(viewer): quarantine unreadable stored data instead of deleting it

### DIFF
--- a/apps/viewer/src/components/viewer/SearchModal.filter.builder.tsx
+++ b/apps/viewer/src/components/viewer/SearchModal.filter.builder.tsx
@@ -45,6 +45,7 @@ import {
   deleteSavedFilter,
   type SavedFilterPreset,
 } from '@/lib/search/saved-filters';
+import { toast } from '@/components/ui/toast';
 import { RuleRow, RULE_KIND_LABEL } from './SearchModal.filter.editors';
 
 export function SearchModalFilterBuilder() {
@@ -191,7 +192,13 @@ export function SearchModalFilterBuilder() {
     // eslint-disable-next-line no-alert
     const name = window.prompt('Save filter as…', '');
     if (!name) return;
-    setSavedPresets(saveFilter(name, filter.combinator, filter.rules));
+    const result = saveFilter(name, filter.combinator, filter.rules);
+    setSavedPresets(result.presets);
+    // A refused write used to return the in-memory catalog as though saved —
+    // the user saw the filter and lost it next session (#2089).
+    if (!result.persisted) {
+      toast.error('Filter could not be saved — browser storage is unavailable or full.');
+    }
   }, [filter.combinator, filter.rules]);
 
   const handleLoadPreset = useCallback((preset: SavedFilterPreset) => {
@@ -203,7 +210,11 @@ export function SearchModalFilterBuilder() {
   }, [filter.limit, setSearchFilter]);
 
   const handleDeletePreset = useCallback((name: string) => {
-    setSavedPresets(deleteSavedFilter(name));
+    const result = deleteSavedFilter(name);
+    setSavedPresets(result.presets);
+    if (!result.persisted) {
+      toast.error('Filter could not be deleted — browser storage is unavailable or full.');
+    }
   }, []);
 
   return (

--- a/apps/viewer/src/lib/clash/persistence.ts
+++ b/apps/viewer/src/lib/clash/persistence.ts
@@ -26,6 +26,7 @@ import {
   type ClashSeverity,
 } from '@ifc-lite/clash';
 import { downloadFile } from '../export/download.js';
+import { optionalLocalStorage, preserveUnreadableEntry } from '../storage/unreadable-entry.js';
 
 /** A built-in or user-defined clash rule preset, with editor/runtime flags. */
 export type ClashPreset = ClashRulePreset & { enabled: boolean; builtin: boolean };
@@ -45,7 +46,7 @@ export interface ClashGlobalSettings {
 
 export type SaveResult =
   | { ok: true }
-  | { ok: false; reason: 'quota' | 'serialize' | 'too_many'; message: string };
+  | { ok: false; reason: 'quota' | 'serialize' | 'too_many' | 'unreadable'; message: string };
 
 const PRESETS_KEY = 'ifc-lite-clash-presets';
 const SETTINGS_KEY = 'ifc-lite-clash-settings';
@@ -86,6 +87,30 @@ let builtinPresetIdsCache: Set<string> | null = null;
 function builtinPresetIds(): Set<string> {
   return (builtinPresetIdsCache ??= new Set(CLASH_RULE_PRESETS.map((p) => p.id)));
 }
+
+/**
+ * Keys whose stored value we failed to read *and* failed to move aside. Both
+ * loaders below degrade to defaults on a read failure, so without this the next
+ * ordinary edit would serialize those defaults over data we never managed to
+ * see. Entries are added by the loader and cleared by a later clean read.
+ */
+const unwritableKeys = new Set<string>();
+
+/** Handle a loader throwing: preserve what is stored, or block writes to `key`. */
+function onReadFailure(key: string, cause: unknown): void {
+  if (preserveUnreadableEntry(optionalLocalStorage(), key, cause)) unwritableKeys.delete(key);
+  else unwritableKeys.add(key);
+}
+
+/** A refusal to overwrite a value we could neither read nor preserve. */
+function refuseOverwrite(what: string): SaveResult {
+  return {
+    ok: false,
+    reason: 'unreadable',
+    message: `Stored ${what} could not be read and could not be backed up — they were left untouched.`,
+  };
+}
+
 const SEVERITIES: ClashSeverity[] = ['critical', 'major', 'minor', 'info'];
 const GROUP_BYS: ClashSettingsGroupBy[] = ['severity', 'rule', 'typePair'];
 
@@ -122,6 +147,7 @@ function isValidStoredPreset(p: unknown): p is ClashPreset {
 /** Read stored presets, accepting the versioned wrapper or a legacy bare array. */
 function readStoredPresets(): ClashPreset[] {
   try {
+    unwritableKeys.delete(PRESETS_KEY);
     const raw = localStorage.getItem(PRESETS_KEY);
     if (!raw) return [];
     const parsed: unknown = JSON.parse(raw);
@@ -142,7 +168,8 @@ function readStoredPresets(): ClashPreset[] {
         enabled: p.enabled !== false,
         builtin: builtinPresetIds().has(p.id),
       }));
-  } catch {
+  } catch (err) {
+    onReadFailure(PRESETS_KEY, err);
     return [];
   }
 }
@@ -198,6 +225,7 @@ export function presetsToStore(presets: ClashPreset[]): ClashPreset[] {
 
 /** Persist only custom presets + modified built-ins (quota-safe). */
 export function savePresets(presets: ClashPreset[]): SaveResult {
+  if (unwritableKeys.has(PRESETS_KEY)) return refuseOverwrite('clash rules');
   const custom = presets.filter((p) => !p.builtin);
   if (custom.length > MAX_PRESETS) {
     return { ok: false, reason: 'too_many', message: `Too many custom rules (max ${MAX_PRESETS}).` };
@@ -276,6 +304,7 @@ function isReviewStatus(v: unknown): v is ClashReviewStatus {
 export function loadReviews(): Map<string, ClashReview> {
   const map = new Map<string, ClashReview>();
   try {
+    unwritableKeys.delete(REVIEWS_KEY);
     const raw = localStorage.getItem(REVIEWS_KEY);
     if (!raw) return map;
     const parsed: unknown = JSON.parse(raw);
@@ -295,7 +324,11 @@ export function loadReviews(): Map<string, ClashReview> {
       // Skip default entries a stale writer may have left behind.
       if (isMeaningfulReview(review)) map.set(key, review);
     }
-  } catch {
+  } catch (err) {
+    // A half-built map is as destructive as an empty one: the next triage edit
+    // writes it back and the entries we never parsed are gone. (#2085)
+    map.clear();
+    onReadFailure(REVIEWS_KEY, err);
     return map;
   }
   return map;
@@ -303,6 +336,7 @@ export function loadReviews(): Map<string, ClashReview> {
 
 /** Persist reviews (default-state entries pruned, capped, quota-safe). */
 export function saveReviews(reviews: Map<string, ClashReview>): SaveResult {
+  if (unwritableKeys.has(REVIEWS_KEY)) return refuseOverwrite('clash reviews');
   const entries: Record<string, ClashReview> = {};
   let count = 0;
   for (const [key, review] of reviews) {

--- a/apps/viewer/src/lib/clash/persistence.unreadable.test.ts
+++ b/apps/viewer/src/lib/clash/persistence.unreadable.test.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { describe, it, beforeEach } from 'node:test';
+import { describe, it, beforeEach, after } from 'node:test';
 import assert from 'node:assert';
 import type { ClashReview } from '@ifc-lite/clash';
 import {
@@ -50,6 +50,22 @@ describe('clash persistence: an unreadable entry is never overwritten', () => {
     ls = new MemoryStorage();
     g.localStorage = ls;
     // Clear the module-level "unwritable" flags via a clean read of empty storage.
+    buildInitialPresets();
+    loadReviews();
+  });
+
+  after(() => {
+    // The last test in this suite deliberately leaves both keys latched
+    // unwritable (the backup write itself fails). `apps/viewer` runs every
+    // test file in one `tsx --test` process, so persistence.ts's
+    // module-level `unwritableKeys` would otherwise carry that latch into
+    // whichever test file runs next and imports it — `savePresets`/
+    // `saveReviews` check the flag before ever touching storage, so a later
+    // file's first save (not preceded by its own clean read) would be
+    // spuriously refused for storage it never actually corrupted. A clean
+    // read against ordinary storage clears the flags the same way `beforeEach`
+    // does above.
+    g.localStorage = new MemoryStorage();
     buildInitialPresets();
     loadReviews();
   });

--- a/apps/viewer/src/lib/clash/persistence.unreadable.test.ts
+++ b/apps/viewer/src/lib/clash/persistence.unreadable.test.ts
@@ -1,0 +1,144 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import type { ClashReview } from '@ifc-lite/clash';
+import {
+  buildInitialPresets,
+  savePresets,
+  loadReviews,
+  saveReviews,
+  type ClashPreset,
+} from './persistence.js';
+
+class MemoryStorage {
+  readonly store = new Map<string, string>();
+  getItem(key: string): string | null { return this.store.get(key) ?? null; }
+  setItem(key: string, value: string): void { this.store.set(key, value); }
+  removeItem(key: string): void { this.store.delete(key); }
+}
+
+const g = globalThis as { localStorage?: unknown };
+const PRESETS_KEY = 'ifc-lite-clash-presets';
+const REVIEWS_KEY = 'ifc-lite-clash-reviews';
+
+/** Truncated JSON — the shape a half-written or externally mangled entry has. */
+const CORRUPT_PRESETS = '{"schemaVersion":1,"presets":[{"id":"custom-1","name":"My rule"';
+const CORRUPT_REVIEWS = '{"schemaVersion":1,"reviews":{"rule-a G1 G2":{"status":"resol';
+
+/** True when `raw` is still somewhere in storage (original key or a backup). */
+function survives(ls: MemoryStorage, raw: string): boolean {
+  return [...ls.store.values()].includes(raw);
+}
+
+const customPreset: ClashPreset = {
+  id: 'custom-new',
+  name: 'Ducts vs beams',
+  description: '',
+  severity: 'major',
+  selectorA: 'IfcDuctSegment',
+  selectorB: 'IfcBeam',
+  enabled: true,
+  builtin: false,
+};
+
+describe('clash persistence: an unreadable entry is never overwritten', () => {
+  let ls: MemoryStorage;
+  beforeEach(() => {
+    ls = new MemoryStorage();
+    g.localStorage = ls;
+    // Clear the module-level "unwritable" flags via a clean read of empty storage.
+    buildInitialPresets();
+    loadReviews();
+  });
+
+  it('preserves unreadable presets across the save that follows the failed read', () => {
+    ls.setItem(PRESETS_KEY, CORRUPT_PRESETS);
+
+    // The read degrades to built-ins only — the user's customs are not visible.
+    const presets = buildInitialPresets();
+    assert.ok(presets.every((p) => p.builtin), 'expected only built-ins after a failed read');
+
+    // ...and the very next edit persists that degraded list.
+    assert.deepStrictEqual(savePresets([...presets, customPreset]), { ok: true });
+
+    assert.ok(survives(ls, CORRUPT_PRESETS), 'the unreadable presets blob was destroyed by the save');
+  });
+
+  it('preserves unreadable reviews across the save that follows the failed read', () => {
+    ls.setItem(REVIEWS_KEY, CORRUPT_REVIEWS);
+
+    assert.strictEqual(loadReviews().size, 0);
+    const map = new Map<string, ClashReview>([['rule-b G3 G4', { status: 'accepted' }]]);
+    assert.deepStrictEqual(saveReviews(map), { ok: true });
+
+    assert.ok(survives(ls, CORRUPT_REVIEWS), 'the unreadable reviews blob was destroyed by the save');
+  });
+
+  // ── Negative cases: the guard must not turn into "never write again" ────────
+
+  it('still round-trips normally when the stored entry is readable', () => {
+    assert.deepStrictEqual(savePresets([customPreset]), { ok: true });
+    const reloaded = buildInitialPresets().filter((p) => !p.builtin);
+    assert.deepStrictEqual(reloaded.map((p) => p.id), ['custom-new']);
+  });
+
+  it('keeps saving after an unreadable read — the panel stays usable', () => {
+    ls.setItem(PRESETS_KEY, CORRUPT_PRESETS);
+    buildInitialPresets();
+
+    assert.deepStrictEqual(savePresets([customPreset]), { ok: true });
+    // The new rule must be readable back, not just "not an error".
+    assert.deepStrictEqual(
+      buildInitialPresets().filter((p) => !p.builtin).map((p) => p.id),
+      ['custom-new'],
+    );
+
+    // And a user-initiated delete of that rule still deletes it.
+    assert.deepStrictEqual(savePresets([]), { ok: true });
+    assert.deepStrictEqual(buildInitialPresets().filter((p) => !p.builtin), []);
+    // ...while the preserved copy of the unreadable blob is still untouched.
+    assert.ok(survives(ls, CORRUPT_PRESETS));
+  });
+
+  it('keeps saving reviews after an unreadable read, and honours a clearing edit', () => {
+    ls.setItem(REVIEWS_KEY, CORRUPT_REVIEWS);
+    loadReviews();
+
+    saveReviews(new Map<string, ClashReview>([['k', { status: 'resolved' }]]));
+    assert.strictEqual(loadReviews().get('k')?.status, 'resolved');
+
+    saveReviews(new Map<string, ClashReview>());
+    assert.strictEqual(loadReviews().size, 0);
+    assert.ok(survives(ls, CORRUPT_REVIEWS));
+  });
+
+  it('refuses to save when the unreadable value could not even be backed up', () => {
+    // Quota is exhausted, so the value cannot be moved aside — writes must stop
+    // rather than destroy it.
+    // Only the backup write is rejected: rejecting every write would make the
+    // assertion vacuous, since the save would fail on quota either way.
+    const full = new (class extends MemoryStorage {
+      override setItem(key: string, value: string): void {
+        if (key.includes(':unreadable')) throw new DOMException('quota', 'QuotaExceededError');
+        super.setItem(key, value);
+      }
+    })();
+    full.setItem(PRESETS_KEY, CORRUPT_PRESETS);
+    full.setItem(REVIEWS_KEY, CORRUPT_REVIEWS);
+    g.localStorage = full;
+
+    buildInitialPresets();
+    loadReviews();
+
+    const presetResult = savePresets([customPreset]);
+    assert.strictEqual(presetResult.ok === false && presetResult.reason, 'unreadable');
+    assert.strictEqual(full.getItem(PRESETS_KEY), CORRUPT_PRESETS);
+
+    const reviewResult = saveReviews(new Map<string, ClashReview>([['k', { status: 'resolved' }]]));
+    assert.strictEqual(reviewResult.ok === false && reviewResult.reason, 'unreadable');
+    assert.strictEqual(full.getItem(REVIEWS_KEY), CORRUPT_REVIEWS);
+  });
+});

--- a/apps/viewer/src/lib/search/saved-filters.test.ts
+++ b/apps/viewer/src/lib/search/saved-filters.test.ts
@@ -148,6 +148,35 @@ describe('saved-filters: an unreadable catalog is never deleted', () => {
     assert.ok(survives(), 'the unreadable catalog was deleted by the read');
   });
 
+  it('does not delete the stored catalog when it parses to a non-array (#2089 review)', () => {
+    // Valid JSON, wrong shape — a future format wrapping the array in an
+    // object, or a hand-edited file. This is not a parse error, so it must go
+    // through the same preserve-and-quarantine path as the catch below, not
+    // fall through a silent `return []`.
+    const nonArray = '{"presets":[{"name":"Important"}]}';
+    ls.setItem(__internal.STORAGE_KEY, nonArray);
+    assert.deepStrictEqual(loadSavedFilters(), []);
+    assert.ok(
+      [...ls.store.values()].includes(nonArray),
+      'the non-array catalog was deleted by the read instead of being quarantined',
+    );
+    assert.ok(
+      [...ls.store.keys()].some((k) => k !== __internal.STORAGE_KEY && k.startsWith(`${__internal.STORAGE_KEY}:unreadable`)),
+      'no :unreadable backup was created for the non-array catalog',
+    );
+  });
+
+  it('does not overwrite a non-array catalog with the save that follows (#2089 review)', () => {
+    const nonArray = '{"presets":[{"name":"Important"}]}';
+    ls.setItem(__internal.STORAGE_KEY, nonArray);
+    loadSavedFilters();
+    saveFilter('New preset', 'AND', [Rule.ifcType(['IfcSlab'])]);
+    assert.ok(
+      [...ls.store.values()].includes(nonArray),
+      'the non-array catalog was destroyed by the save that followed the failed read',
+    );
+  });
+
   it('does not overwrite the stored catalog with the save that follows', () => {
     ls.setItem(__internal.STORAGE_KEY, CORRUPT);
     loadSavedFilters();

--- a/apps/viewer/src/lib/search/saved-filters.test.ts
+++ b/apps/viewer/src/lib/search/saved-filters.test.ts
@@ -38,7 +38,11 @@ describe('saved-filters', () => {
   });
 
   it('saves a preset and reads it back sorted by name', () => {
-    saveFilter('Bravo', 'AND', [Rule.ifcType(['IfcWall'])]);
+    const bravo = saveFilter('Bravo', 'AND', [Rule.ifcType(['IfcWall'])]);
+    // An ordinary save actually reaches storage: `persisted` must be true here,
+    // not merely absent-of-false, or the flag could be hardcoded `false` and a
+    // check that only looks for `false` elsewhere would still pass. (#2089)
+    assert.strictEqual(bravo.persisted, true);
     saveFilter('Alpha', 'OR', [Rule.name('contains', 'EXT')]);
     const list = loadSavedFilters();
     assert.deepStrictEqual(list.map((p) => p.name), ['Alpha', 'Bravo']);
@@ -191,7 +195,10 @@ describe('saved-filters: an unreadable catalog is never deleted', () => {
     g.localStorage = full;
 
     loadSavedFilters();
-    saveFilter('New preset', 'AND', [Rule.ifcType(['IfcSlab'])]);
+    const result = saveFilter('New preset', 'AND', [Rule.ifcType(['IfcSlab'])]);
     assert.strictEqual(full.getItem(__internal.STORAGE_KEY), CORRUPT);
+    // The write never reached storage: the caller must be told, not left to
+    // infer it from the returned catalog still looking populated. (#2089)
+    assert.strictEqual(result.persisted, false);
   });
 });

--- a/apps/viewer/src/lib/search/saved-filters.test.ts
+++ b/apps/viewer/src/lib/search/saved-filters.test.ts
@@ -116,3 +116,82 @@ describe('saved-filters', () => {
     assert.strictEqual(list[0].rules[0].kind, 'ifcType');
   });
 });
+
+/** Same as `MemoryStorage`, but the backing map is readable by the assertions. */
+class InspectableStorage implements MemoryStorageLike {
+  readonly store = new Map<string, string>();
+  getItem(key: string): string | null { return this.store.get(key) ?? null; }
+  setItem(key: string, value: string): void { this.store.set(key, value); }
+  removeItem(key: string): void { this.store.delete(key); }
+}
+
+/** Truncated JSON — the shape an externally mangled entry has. */
+const CORRUPT = '[{"name":"Ground floor walls","combinator":"AND","rules":[{"kind":"ifcTy';
+
+describe('saved-filters: an unreadable catalog is never deleted', () => {
+  let ls: InspectableStorage;
+  beforeEach(() => {
+    ls = new InspectableStorage();
+    g.localStorage = ls;
+    loadSavedFilters(); // clean read clears the module-level "unwritable" flag
+  });
+
+  const survives = () => [...ls.store.values()].includes(CORRUPT);
+
+  it('does not delete the stored catalog when it fails to parse', () => {
+    ls.setItem(__internal.STORAGE_KEY, CORRUPT);
+    assert.deepStrictEqual(loadSavedFilters(), []);
+    assert.ok(survives(), 'the unreadable catalog was deleted by the read');
+  });
+
+  it('does not overwrite the stored catalog with the save that follows', () => {
+    ls.setItem(__internal.STORAGE_KEY, CORRUPT);
+    loadSavedFilters();
+    saveFilter('New preset', 'AND', [Rule.ifcType(['IfcSlab'])]);
+    assert.ok(survives(), 'the unreadable catalog was destroyed by the save');
+  });
+
+  // ── Negative cases ─────────────────────────────────────────────────────────
+
+  it('keeps saving after an unreadable read — the toolbar stays usable', () => {
+    ls.setItem(__internal.STORAGE_KEY, CORRUPT);
+    loadSavedFilters();
+
+    saveFilter('New preset', 'AND', [Rule.ifcType(['IfcSlab'])]);
+    assert.deepStrictEqual(loadSavedFilters().map((p) => p.name), ['New preset']);
+
+    // A user-initiated delete still deletes.
+    deleteSavedFilter('New preset');
+    assert.deepStrictEqual(loadSavedFilters(), []);
+    assert.ok(survives(), 'the preserved copy should outlive an unrelated delete');
+  });
+
+  it('clearSavedFilters still wipes everything, preserved copy included', () => {
+    ls.setItem(__internal.STORAGE_KEY, CORRUPT);
+    loadSavedFilters();
+    saveFilter('New preset', 'AND', [Rule.ifcType(['IfcSlab'])]);
+    clearSavedFilters();
+    assert.deepStrictEqual(loadSavedFilters(), []);
+    assert.strictEqual(ls.store.size, 0, 'an explicit wipe leaves nothing behind');
+  });
+
+  it('refuses to write when the unreadable catalog could not even be backed up', () => {
+    // Quota is exhausted for the backup write specifically. `safeStorage`
+    // probes storage first, so rejecting every write here would make the test
+    // vacuous — it would pass because the module saw no storage at all.
+    const full = new (class extends InspectableStorage {
+      override setItem(key: string, value: string): void {
+        if (key.startsWith(`${__internal.STORAGE_KEY}:unreadable`)) {
+          throw new DOMException('quota', 'QuotaExceededError');
+        }
+        super.setItem(key, value);
+      }
+    })();
+    full.setItem(__internal.STORAGE_KEY, CORRUPT);
+    g.localStorage = full;
+
+    loadSavedFilters();
+    saveFilter('New preset', 'AND', [Rule.ifcType(['IfcSlab'])]);
+    assert.strictEqual(full.getItem(__internal.STORAGE_KEY), CORRUPT);
+  });
+});

--- a/apps/viewer/src/lib/search/saved-filters.ts
+++ b/apps/viewer/src/lib/search/saved-filters.ts
@@ -35,6 +35,16 @@ export interface SavedFilterPreset {
   updatedAt: number;
 }
 
+/**
+ * Outcome of a catalog mutation. `persisted: false` means the returned list is
+ * what you would see now but NOT what is on disk — the caller must say so
+ * rather than showing a filter that vanishes next session (#2089).
+ */
+export interface SavedFilterMutation {
+  presets: SavedFilterPreset[];
+  persisted: boolean;
+}
+
 interface StorageLike {
   getItem(key: string): string | null;
   setItem(key: string, value: string): void;
@@ -91,13 +101,33 @@ function readRaw(): SavedFilterPreset[] {
   }
 }
 
-function writeRaw(list: SavedFilterPreset[]): void {
+/**
+ * Persist the catalog. Returns false when nothing was written, so a caller can
+ * tell the user rather than showing a filter that vanishes next session.
+ *
+ * The three no-write paths are deliberately distinguished only by the log: a
+ * blocked storage policy, a latched refusal to overwrite an unreadable
+ * catalog, and a failed write. All three mean "not saved" to the caller.
+ */
+function writeRaw(list: SavedFilterPreset[]): boolean {
   const ls = safeStorage();
-  if (!ls || catalogUnwritable) return;
+  if (!ls) return false;
+  if (catalogUnwritable) {
+    console.warn(
+      `[ifc-lite] "${STORAGE_KEY}" is preserved as unreadable, so saved filters are not being written. ` +
+        `Repair or remove the backup to resume saving.`,
+    );
+    return false;
+  }
   try {
     ls.setItem(STORAGE_KEY, JSON.stringify(list));
-  } catch {
-    // Quota exceeded — swallow; the next save attempt may succeed.
+    return true;
+  } catch (err) {
+    // Not swallowed, and not described as transient: if the quota is genuinely
+    // full, every later attempt fails the same way, so an optimistic "the next
+    // save may succeed" would be wrong for the case that actually matters.
+    console.warn(`[ifc-lite] saved filters could not be written to "${STORAGE_KEY}".`, err);
+    return false;
   }
 }
 
@@ -117,9 +147,10 @@ export function saveFilter(
   name: string,
   combinator: Combinator,
   rules: readonly FilterRule[],
-): SavedFilterPreset[] {
+): SavedFilterMutation {
   const trimmed = name.trim();
-  if (!trimmed || trimmed.length > MAX_NAME_LEN) return loadSavedFilters();
+  // Rejected name: nothing was asked of storage, so nothing is unpersisted.
+  if (!trimmed || trimmed.length > MAX_NAME_LEN) return { presets: loadSavedFilters(), persisted: true };
 
   const existing = readRaw();
   const idx = existing.findIndex((p) => p.name.toLowerCase() === trimmed.toLowerCase());
@@ -140,20 +171,21 @@ export function saveFilter(
     .slice()
     .sort((a, b) => b.updatedAt - a.updatedAt)
     .slice(0, MAX_ENTRIES);
-  writeRaw(sortedByRecency);
+  const persisted = writeRaw(sortedByRecency);
 
-  return loadSavedFilters();
+  return { presets: loadSavedFilters(), persisted };
 }
 
 /** Delete a preset by exact (case-insensitive) name. Returns the new list. */
-export function deleteSavedFilter(name: string): SavedFilterPreset[] {
+export function deleteSavedFilter(name: string): SavedFilterMutation {
   const trimmed = name.trim().toLowerCase();
-  if (!trimmed) return loadSavedFilters();
+  if (!trimmed) return { presets: loadSavedFilters(), persisted: true };
   const existing = readRaw();
   const next = existing.filter((p) => p.name.toLowerCase() !== trimmed);
-  if (next.length === existing.length) return loadSavedFilters();
-  writeRaw(next);
-  return loadSavedFilters();
+  // Name not found: no write attempted, so nothing is unpersisted.
+  if (next.length === existing.length) return { presets: loadSavedFilters(), persisted: true };
+  const persisted = writeRaw(next);
+  return { presets: loadSavedFilters(), persisted };
 }
 
 /** Wipe the entire catalog, including any preserved-but-unreadable copy. */

--- a/apps/viewer/src/lib/search/saved-filters.ts
+++ b/apps/viewer/src/lib/search/saved-filters.ts
@@ -36,9 +36,12 @@ export interface SavedFilterPreset {
 }
 
 /**
- * Outcome of a catalog mutation. `persisted: false` means the returned list is
- * what you would see now but NOT what is on disk — the caller must say so
- * rather than showing a filter that vanishes next session (#2089).
+ * Outcome of a catalog mutation. `persisted: false` means the write did not
+ * reach storage: `presets` is a fresh re-read of what is actually on disk —
+ * the prior readable catalog, not the attempted mutation — so it will not
+ * include the preset just saved (or will still include one just "deleted").
+ * The caller must say so explicitly rather than showing the attempted change
+ * as if it were saved, only for it to be gone next session (#2089).
  */
 export interface SavedFilterMutation {
   presets: SavedFilterPreset[];
@@ -79,7 +82,16 @@ function readRaw(): SavedFilterPreset[] {
   if (!raw) return [];
   try {
     const parsed: unknown = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return [];
+    if (!Array.isArray(parsed)) {
+      // Valid JSON, wrong shape — a future format wrapping the array in an
+      // object, or a hand-edited file. This is not a parse error, but it is
+      // just as unreadable to this loader: it must go through the same
+      // preserve-and-quarantine path as the catch below, not a silent `[]`
+      // that the next ordinary save would serialize over the entry. (#2089
+      // review)
+      catalogUnwritable = !preserveUnreadableEntry(ls, STORAGE_KEY, new Error('saved filter catalog is not an array'));
+      return [];
+    }
     const out: SavedFilterPreset[] = [];
     for (const item of parsed) {
       if (typeof item !== 'object' || item === null) continue;

--- a/apps/viewer/src/lib/search/saved-filters.ts
+++ b/apps/viewer/src/lib/search/saved-filters.ts
@@ -21,6 +21,7 @@ import {
   type Combinator,
   type FilterRule,
 } from './filter-rules.js';
+import { forgetEntryAndBackups, preserveUnreadableEntry } from '../storage/unreadable-entry.js';
 
 const STORAGE_KEY = 'ifc-lite:search:saved-filters';
 const MAX_ENTRIES = 50;
@@ -53,9 +54,17 @@ function safeStorage(): StorageLike | null {
   }
 }
 
+/**
+ * Set when the stored catalog could neither be parsed nor moved aside. `readRaw`
+ * degrades to an empty list, so writing while this is set would serialize that
+ * empty list over presets we never managed to read. (#2085)
+ */
+let catalogUnwritable = false;
+
 function readRaw(): SavedFilterPreset[] {
   const ls = safeStorage();
   if (!ls) return [];
+  catalogUnwritable = false;
   const raw = ls.getItem(STORAGE_KEY);
   if (!raw) return [];
   try {
@@ -73,15 +82,18 @@ function readRaw(): SavedFilterPreset[] {
       out.push({ name, combinator, rules, updatedAt });
     }
     return out;
-  } catch {
-    ls.removeItem(STORAGE_KEY);
+  } catch (err) {
+    // Deleting the catalog because we failed to read it is the data loss, not
+    // the recovery: move it aside instead, and if even that fails, refuse to
+    // write over it. (#2085)
+    catalogUnwritable = !preserveUnreadableEntry(ls, STORAGE_KEY, err);
     return [];
   }
 }
 
 function writeRaw(list: SavedFilterPreset[]): void {
   const ls = safeStorage();
-  if (!ls) return;
+  if (!ls || catalogUnwritable) return;
   try {
     ls.setItem(STORAGE_KEY, JSON.stringify(list));
   } catch {
@@ -144,11 +156,13 @@ export function deleteSavedFilter(name: string): SavedFilterPreset[] {
   return loadSavedFilters();
 }
 
-/** Wipe the entire catalog. */
+/** Wipe the entire catalog, including any preserved-but-unreadable copy. */
 export function clearSavedFilters(): void {
   const ls = safeStorage();
   if (!ls) return;
-  ls.removeItem(STORAGE_KEY);
+  // Explicit, user-initiated — unlike a failed read, this may delete.
+  forgetEntryAndBackups(ls, STORAGE_KEY);
+  catalogUnwritable = false;
 }
 
 export const __internal = { STORAGE_KEY, MAX_ENTRIES, MAX_NAME_LEN };

--- a/apps/viewer/src/lib/storage/unreadable-entry.test.ts
+++ b/apps/viewer/src/lib/storage/unreadable-entry.test.ts
@@ -1,0 +1,87 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import {
+  preserveUnreadableEntry,
+  forgetEntryAndBackups,
+  type UnreadableEntryStorage,
+} from './unreadable-entry.js';
+
+/** In-memory storage; `failSetKeys` makes specific writes throw. */
+function stubStorage(failSetKeys: readonly string[] = []): UnreadableEntryStorage & {
+  map: Map<string, string>;
+} {
+  const map = new Map<string, string>();
+  return {
+    map,
+    // `length`/`key()` are part of the real Storage interface, and
+    // `forgetEntryAndBackups` uses them to find counter-suffixed copies. A stub
+    // without them silently skips that branch, so the double has to carry them
+    // or the wipe test passes for the wrong reason.
+    get length() {
+      return map.size;
+    },
+    key: (i: number) => [...map.keys()][i] ?? null,
+    getItem: (k) => (map.has(k) ? map.get(k)! : null),
+    setItem: (k, v) => {
+      if (failSetKeys.includes(k)) throw new DOMException('quota', 'QuotaExceededError');
+      map.set(k, v);
+    },
+    removeItem: (k) => {
+      map.delete(k);
+    },
+  };
+}
+
+describe('preserveUnreadableEntry', () => {
+  it('never clobbers an earlier preserved copy, even within one millisecond', () => {
+    // The guard used to suffix with `Date.now()`, so two quarantines of the same
+    // key inside a single millisecond picked the same backup name and the second
+    // overwrote the first — the exact thing the guard exists to prevent. A
+    // counter cannot collide regardless of clock resolution, and this test runs
+    // all three quarantines synchronously, which is what `Date.now()` could not
+    // survive (maintainer finding on #2089).
+    const st = stubStorage();
+
+    st.map.set('K', 'first');
+    assert.strictEqual(preserveUnreadableEntry(st, 'K', new Error('x')), true);
+
+    st.map.set('K', 'second');
+    assert.strictEqual(preserveUnreadableEntry(st, 'K', new Error('x')), true);
+
+    st.map.set('K', 'third');
+    assert.strictEqual(preserveUnreadableEntry(st, 'K', new Error('x')), true);
+
+    // Every payload survives under a distinct key, and the live key is cleared.
+    const preserved = [...st.map.entries()]
+      .filter(([k]) => k !== 'K')
+      .map(([, v]) => v)
+      .sort();
+    assert.deepStrictEqual(preserved, ['first', 'second', 'third']);
+    assert.strictEqual(st.map.get('K'), undefined);
+  });
+
+  it('reports failure when the backup itself cannot be written, and leaves the value alone', () => {
+    // The caller uses this to refuse a later overwrite: a blocked quarantine
+    // must not also destroy the original.
+    const st = stubStorage(['K:unreadable']);
+    st.map.set('K', 'precious');
+
+    assert.strictEqual(preserveUnreadableEntry(st, 'K', new Error('x')), false);
+    assert.strictEqual(st.map.get('K'), 'precious');
+  });
+
+  it('forgetEntryAndBackups removes the entry and every preserved copy', () => {
+    const st = stubStorage();
+    st.map.set('K', 'a');
+    preserveUnreadableEntry(st, 'K', new Error('x'));
+    st.map.set('K', 'b');
+    preserveUnreadableEntry(st, 'K', new Error('x'));
+
+    forgetEntryAndBackups(st, 'K');
+    assert.deepStrictEqual([...st.map.keys()], []);
+  });
+});

--- a/apps/viewer/src/lib/storage/unreadable-entry.ts
+++ b/apps/viewer/src/lib/storage/unreadable-entry.ts
@@ -60,8 +60,15 @@ export function preserveUnreadableEntry(
 
   let backup = unreadableKey(key);
   try {
-    // Never clobber an earlier preserved copy — it may hold the older, better data.
-    if (storage.getItem(backup) !== null) backup = `${backup}:${Date.now()}`;
+    // Never clobber an earlier preserved copy — it may hold the older, better
+    // data. A counter rather than Date.now(): two quarantines of the same key
+    // inside one millisecond pick the same timestamp, so the second setItem
+    // would overwrite the first — the exact thing this guard exists to stop.
+    if (storage.getItem(backup) !== null) {
+      let n = 2;
+      while (storage.getItem(`${backup}:${n}`) !== null) n += 1;
+      backup = `${backup}:${n}`;
+    }
     storage.setItem(backup, raw);
     storage.removeItem(key);
   } catch (err) {

--- a/apps/viewer/src/lib/storage/unreadable-entry.ts
+++ b/apps/viewer/src/lib/storage/unreadable-entry.ts
@@ -111,7 +111,12 @@ export function optionalLocalStorage(): UnreadableEntryStorage | null {
   try {
     return (globalThis as typeof globalThis & { localStorage?: UnreadableEntryStorage }).localStorage ?? null;
   } catch {
-    // Storage access can throw outright under a blocking cookie policy.
+    // Deliberately silent, and the one shape AGENTS.md:17's rule is not aimed
+    // at: merely *reading* `globalThis.localStorage` throws under a blocking
+    // cookie policy, there is nothing to report that `null` does not already
+    // say, and every caller degrades on `null` anyway. Logging here would fire
+    // on every call for a browser configuration the user chose. Left explicit
+    // so a future silent-catch sweep does not re-flag it.
     return null;
   }
 }

--- a/apps/viewer/src/lib/storage/unreadable-entry.ts
+++ b/apps/viewer/src/lib/storage/unreadable-entry.ts
@@ -25,6 +25,15 @@ export interface UnreadableEntryStorage {
   getItem(key: string): string | null;
   setItem(key: string, value: string): void;
   removeItem(key: string): void;
+  /**
+   * Enumeration members of the real `Storage` interface. Optional because a
+   * caller may pass a narrower double — `forgetEntryAndBackups` needs them to
+   * find counter-suffixed copies and narrows on them at runtime. Declared here
+   * rather than reached through a widening cast: the cast is what let this
+   * interface stay wrong, and it made a faithful test double untypeable.
+   */
+  readonly length?: number;
+  key?(i: number): string | null;
 }
 
 /** The key an unreadable `key` is preserved under. */
@@ -95,12 +104,12 @@ export function forgetEntryAndBackups(storage: UnreadableEntryStorage, key: stri
   storage.removeItem(key);
   const prefix = unreadableKey(key);
   storage.removeItem(prefix);
-  // Timestamped copies from repeated failures, if the host exposes its keys.
-  const enumerable = storage as UnreadableEntryStorage & { length?: number; key?(i: number): string | null };
-  if (typeof enumerable.length !== 'number' || typeof enumerable.key !== 'function') return;
+  // Counter-suffixed copies from repeated failures, when the host enumerates.
+  const { length, key: keyAt } = storage;
+  if (typeof length !== 'number' || typeof keyAt !== 'function') return;
   const stale: string[] = [];
-  for (let i = 0; i < enumerable.length; i += 1) {
-    const k = enumerable.key(i);
+  for (let i = 0; i < length; i += 1) {
+    const k = keyAt.call(storage, i);
     if (k && k.startsWith(`${prefix}:`)) stale.push(k);
   }
   for (const k of stale) storage.removeItem(k);

--- a/apps/viewer/src/lib/storage/unreadable-entry.ts
+++ b/apps/viewer/src/lib/storage/unreadable-entry.ts
@@ -1,0 +1,110 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Failing to *read* a localStorage entry must never license destroying it.
+ *
+ * A loader that returns a default (or a partial result) on a parse error hands
+ * the caller a state that looks empty; the next ordinary edit then serializes
+ * that empty state straight over the entry, and whatever was there — custom
+ * clash rules, triage decisions, saved filters — is gone for good. Deleting the
+ * entry outright in the catch has the same effect, sooner.
+ *
+ * The remedy here is to *move the value aside* rather than keep it in place and
+ * refuse to write: the app stays usable (the feature resets to defaults and
+ * saves normally from then on), and the bytes we could not parse survive under
+ * `<key>:unreadable` for the user to inspect or repair. Refusing all writes
+ * instead would preserve the data but leave the feature permanently read-only
+ * with no in-app way out, so it is kept only as the fallback for when the
+ * value cannot be moved aside at all (a full quota) — in that case the caller
+ * must skip the write, which is still better than destroying data.
+ */
+
+export interface UnreadableEntryStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+/** The key an unreadable `key` is preserved under. */
+function unreadableKey(key: string): string {
+  return `${key}:unreadable`;
+}
+
+/**
+ * Preserve the value stored at `key` after a read of it failed, then clear it so
+ * the feature can start fresh.
+ *
+ * @returns `true` when the caller may write `key` again — either the value is
+ *   safely preserved, or there was nothing stored to lose. `false` when the
+ *   value is still at `key` and unpreserved, in which case the caller MUST NOT
+ *   overwrite it.
+ */
+export function preserveUnreadableEntry(
+  storage: UnreadableEntryStorage | null,
+  key: string,
+  cause: unknown,
+): boolean {
+  // No storage at all: nothing is at risk, and a later write would fail anyway.
+  if (!storage) return true;
+
+  let raw: string | null;
+  try {
+    raw = storage.getItem(key);
+  } catch (err) {
+    console.warn(`[ifc-lite] "${key}" is unreadable and could not be inspected; leaving it alone.`, err);
+    return false;
+  }
+  if (raw === null) return true;
+
+  let backup = unreadableKey(key);
+  try {
+    // Never clobber an earlier preserved copy — it may hold the older, better data.
+    if (storage.getItem(backup) !== null) backup = `${backup}:${Date.now()}`;
+    storage.setItem(backup, raw);
+    storage.removeItem(key);
+  } catch (err) {
+    console.warn(
+      `[ifc-lite] "${key}" could not be parsed and could not be backed up; refusing to overwrite it.`,
+      cause,
+      err,
+    );
+    return false;
+  }
+  console.warn(
+    `[ifc-lite] "${key}" could not be parsed; it was moved to "${backup}" and the feature reset to defaults. ` +
+      'Nothing was deleted — recover the value from that key if it is needed.',
+    cause,
+  );
+  return true;
+}
+
+/**
+ * Drop both `key` and any preserved copy of it. For an explicit, user-initiated
+ * wipe only — never as a reaction to a failed read.
+ */
+export function forgetEntryAndBackups(storage: UnreadableEntryStorage, key: string): void {
+  storage.removeItem(key);
+  const prefix = unreadableKey(key);
+  storage.removeItem(prefix);
+  // Timestamped copies from repeated failures, if the host exposes its keys.
+  const enumerable = storage as UnreadableEntryStorage & { length?: number; key?(i: number): string | null };
+  if (typeof enumerable.length !== 'number' || typeof enumerable.key !== 'function') return;
+  const stale: string[] = [];
+  for (let i = 0; i < enumerable.length; i += 1) {
+    const k = enumerable.key(i);
+    if (k && k.startsWith(`${prefix}:`)) stale.push(k);
+  }
+  for (const k of stale) storage.removeItem(k);
+}
+
+/** The app's `localStorage`, or null when it is absent or blocked. */
+export function optionalLocalStorage(): UnreadableEntryStorage | null {
+  try {
+    return (globalThis as typeof globalThis & { localStorage?: UnreadableEntryStorage }).localStorage ?? null;
+  } catch {
+    // Storage access can throw outright under a blocking cookie policy.
+    return null;
+  }
+}


### PR DESCRIPTION
From the #2085 sweep's "left for a maintainer decision" list — the two where the remedy needs no UX call.

## Reachability first, because it is weaker than #2085 implied

**All three sites are hardening, not defects reachable today.** Stating that up front rather than letting the fix imply otherwise:

- **`persistence.ts:145`** — the only writer of `PRESETS_KEY` is `savePresets`, which writes `JSON.stringify` output, so the app cannot produce a value that makes `JSON.parse` throw. The *partial* read is also unreachable: `createClashPreset` and `importPresets` both validate, and `updateClashPreset` — which does not — is only reachable behind a Save button gated on `draftValid` (`ClashSettingsDialog.tsx:123-124`).
- **`persistence.ts:298`** — same shape. `saveReviews` refuses over `MAX_REVIEWS` rather than truncating, and the status filter only drops values the app never writes. It becomes reachable the moment a new status ships and a user runs two app versions.
- **`saved-filters.ts:76`** — `parseFilterRules` cannot throw and `getItem` sits outside the `try`, so only externally-corrupted JSON reaches it.

External corruption is the shared trigger for all three: a mid-write browser crash, devtools editing, an extension, or a downgrade to an older schema.

**`saved-filters.ts` is fixed as a correctness bug regardless of reachability**, because it *deletes on read failure* rather than merely enabling a later overwrite — and `loadSavedFilters()` alone triggers it, with no save required.

## One latent trigger worth naming

The `persistence.ts` catch also swallows a throw from `builtinPresetIds()` (`:143`), and the comment at `:79-84` records that exact `CLASH_RULE_PRESETS` chunk-ordering hazard **actually firing on boot**. Deferring it into the loader turned a loud boot crash into a swallowed one whose next consequence is `savePresets` writing `{presets: []}`.

## The remedy: move it aside, don't refuse forever

On a read failure the raw bytes are copied to `<key>:unreadable` and `<key>` is cleared. The feature resets to defaults, stays usable, and nothing is lost.

I rejected "mark not-loaded and refuse to save" — it leaves the panel permanently read-only with **no in-app way out**, which is the trap of trading one data-loss bug for a usability dead end. Refusal is kept only for when quarantine *itself* fails (quota): there a blocked feature beats destroyed data, surfaced through the existing `toast.error(result.message)` path, and the flag clears on the next clean read.

**Recovery path:** the original bytes sit at `ifc-lite-clash-presets:unreadable` (etc.) with a `console.warn` naming the key — repair the JSON in devtools and copy it back, or re-import from an `exportPresets` file. An explicit `clearSavedFilters` drops the backups too: a user wipe may delete, a failed read may not.

## Evidence

| mutation | result |
|---|---|
| restore the destructive `removeItem` | **4 fail** |
| bare `catch {}` in `readStoredPresets` | 3 fail |
| bare `catch {}` in `loadReviews` | 2 fail |
| drop either save-refusal guard | 1 fail each |

I re-ran the first myself on the pushed tree (`REPLACEMENTS=1`, line re-read): 4 failed, and `clearSavedFilters still wipes everything` correctly **survived** — which is what shows the fix did not just stop all deletion.

**One mutation initially killed nothing** (the reviews-side refusal was an untested branch), so the quota test was extended before re-running rather than reported as a survivor.

**Two vacuity traps found in my own tests:** the quota cases first rejected *every* `setItem`, which made `safeStorage()`'s probe fail so the module saw no storage at all — they would have passed against broken code. They now reject only the backup write.

Negative cases, all passing in RED too so they cannot be what the fix "fixed": normal round trip unaffected; after a failed read a save still succeeds **and reads back**; a user-initiated delete still deletes.

2582 passing (was 2571, measured from pristine sources with the new test files removed), typecheck 34/34.

## Deliberately left

`loadSettings` (`persistence.ts:236`) has the identical shape. The payload is six scalars the user can re-set in seconds, and a refusal there would silently no-op `persistSettings()` on every slider move — worse than the thing it guards against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
