### PR TITLE
fix(scripts): surface release-tooling failures that reported success

### DIFF
--- a/apps/landing/app.jsx
+++ b/apps/landing/app.jsx
@@ -1943,20 +1943,39 @@ async function runBrowserTests() {
             const parts = [ai.vendor, ai.architecture, ai.description].filter(Boolean);
             if (parts.length) info = parts.slice(0, 2).join(" · ");
           }
-        } catch (_) { /* requestAdapterInfo not always exposed */ }
+        } catch (err) {
+          // Not fatal — `requestAdapterInfo`/`adapter.info` is optional, and
+          // "adapter ready" stays correct without it. Logged so a visitor
+          // reporting a blank vendor string has something to paste back.
+          console.debug("[browser test] adapter info unavailable:", err);
+        }
         webgpuNote = info;
       } else {
         webgpuNote = "no adapter (driver or flag missing)";
       }
     }
-  } catch (_) { /* swallow */ }
+  } catch (err) {
+    // `requestAdapter()` rejecting is NOT the same as the browser not having
+    // WebGPU, but the row said "not detected" either way and nothing was
+    // logged, so a visitor had no way to tell a blocked/failed adapter request
+    // from a browser that simply lacks the API. Say which one it was.
+    webgpuNote = `detection failed: ${err && err.message ? err.message : String(err)}`;
+    console.warn("[browser test] WebGPU detection threw:", err);
+  }
   results.push({ id: "webgpu", label: "WebGPU", ok: webgpuOk, note: webgpuNote });
 
   // WebAssembly + SIMD
   const wasmOk = typeof WebAssembly === "object" && typeof WebAssembly.validate === "function";
   let simdOk = false;
   if (wasmOk) {
-    try { simdOk = WebAssembly.validate(WASM_SIMD_PROBE); } catch (_) {}
+    try {
+      simdOk = WebAssembly.validate(WASM_SIMD_PROBE);
+    } catch (err) {
+      // `validate` is specified not to throw for a well-formed byte array, so
+      // reaching here means something unusual (a hardened/instrumented engine).
+      // Reported as "no SIMD" as before, but no longer without a trace.
+      console.warn("[browser test] WebAssembly.validate threw on the SIMD probe:", err);
+    }
   }
   results.push({
     id: "wasm",

--- a/scripts/augment-epsg-proj4.ts
+++ b/scripts/augment-epsg-proj4.ts
@@ -62,24 +62,80 @@ function readExistingEntries(): { entries: EpsgEntry[]; version: string } {
   };
 }
 
+/** How a proj4 lookup failed to produce a usable definition. */
+type Proj4Failure = 'http' | 'threw' | 'unusable-body';
+
+const failureTally = new Map<string, number>();
+const FAILURE_SAMPLES_TO_PRINT = 5;
+let failureSamplesPrinted = 0;
+
+function noteFailure(code: string, kind: Proj4Failure, detail: string): void {
+  const key = `${kind}: ${detail}`;
+  failureTally.set(key, (failureTally.get(key) ?? 0) + 1);
+  // Flood guard: this runs once per unresolved code across ~thousands of
+  // entries, so print a handful of concrete examples and let the end-of-run
+  // tally carry the rest.
+  if (failureSamplesPrinted < FAILURE_SAMPLES_TO_PRINT) {
+    failureSamplesPrinted++;
+    console.warn(`  EPSG:${code} — ${key}`);
+  }
+}
+
+function reportFailures(): void {
+  if (failureTally.size === 0) return;
+  console.warn('\nUnresolved proj4 lookups, by cause:');
+  for (const [key, count] of [...failureTally].sort((a, b) => b[1] - a[1])) {
+    console.warn(`  ${count.toString().padStart(6)}  ${key}`);
+  }
+}
+
+/**
+ * Why every non-answer is counted and reported:
+ *
+ * a `null` from here is indistinguishable at the call site from "epsg.io has
+ * no proj4 string for this code" — but it is also what a transport error, an
+ * HTTP 429/5xx, or a captive-portal HTML body produces. This function used to
+ * swallow the throw outright, so a run made during an epsg.io outage or behind
+ * a rate limit finished with `N missing`, rewrote the generated module, and
+ * printed nothing at all about the network. The `noteFailure` tallies are what make
+ * "the registry genuinely has none" separable from "we never got an answer".
+ *
+ * NOTE for a maintainer: an `!resp.ok` response still returns immediately with
+ * no retry, so a single 429/503 permanently records a code as having no proj4
+ * for this run. `scripts/fixtures/fetch-fixtures.mjs` treats 5xx/408/429 as
+ * retryable and only 4xx as permanent; adopting that policy here would be a
+ * behaviour change to a hand-run generator and is left as a deliberate
+ * decision rather than folded into a logging fix.
+ */
 async function fetchProj4(code: string, attempts = 3): Promise<string | null> {
+  let lastError: unknown;
   for (let attempt = 1; attempt <= attempts; attempt++) {
     try {
       const resp = await fetch(`https://epsg.io/${code}.proj4`, {
         headers: { 'User-Agent': 'ifc-lite-epsg-generator/1.0' },
       });
-      if (!resp.ok) return null;
+      if (!resp.ok) {
+        noteFailure(code, 'http', `HTTP ${resp.status} ${resp.statusText}`);
+        return null;
+      }
       const text = (await resp.text()).trim();
       if (!text || text.startsWith('<') || text.startsWith('{') || !text.includes('+')) {
+        noteFailure(code, 'unusable-body', text ? `${text.slice(0, 40)}…` : '(empty)');
         return null;
       }
       return text;
-    } catch {
+    } catch (error) {
+      lastError = error;
       if (attempt < attempts) {
         await new Promise(r => setTimeout(r, 200 * attempt));
       }
     }
   }
+  noteFailure(
+    code,
+    'threw',
+    lastError instanceof Error ? lastError.message : String(lastError),
+  );
   return null;
 }
 
@@ -147,6 +203,20 @@ async function main(): Promise<void> {
 
   console.log(`Done in ${elapsed}ms: ${resolved} resolved, ${failed} missing`);
   console.log(`Total entries with proj4: ${entries.filter(e => e.proj4).length}/${entries.length}`);
+  reportFailures();
+
+  // A run that resolved nothing is almost never "the registry has none" — it is
+  // the network. Rewriting the generated module anyway is harmless (it round-trips
+  // the same entries) but reporting only "Written to …" reads as success, so name
+  // the condition before the write.
+  if (needsProj4.length > 0 && resolved === 0) {
+    console.warn(
+      `\n⚠️  Resolved 0 of ${needsProj4.length} proj4 lookups — every request failed or ` +
+        'returned nothing usable. This is almost certainly a network/upstream problem, ' +
+        'not the EPSG registry. The generated file is rewritten with the entries it ' +
+        'already had; re-run once epsg.io is reachable.',
+    );
+  }
 
   const moduleSource = renderModule(entries, version);
   fs.writeFileSync(GENERATED_PATH, `${moduleSource}\n`, 'utf8');

--- a/scripts/fixtures/build-manifest.mjs
+++ b/scripts/fixtures/build-manifest.mjs
@@ -89,13 +89,41 @@ const IGNORE_PATTERNS = loadIgnorePatterns();
 const IGNORE_RES = IGNORE_PATTERNS.map(globToRegExp);
 const isIgnored = (relPath) => IGNORE_RES.some((re) => re.test(relPath));
 
+// The previous manifest, read ONCE and reused below for both the silent-add
+// guard and the release_tag/base_url carry-over.
+//
+// Fail CLOSED for the same reason `loadIgnorePatterns` does: only a genuinely
+// absent manifest means "no prior state". Any other failure (unparseable JSON,
+// EACCES, I/O error) used to be swallowed, and the consequences were invisible —
+// `release_tag`/`base_url` silently snapped back to the hardcoded defaults below
+// and the rewritten manifest was reported as a success, pointing `fixtures:fetch`
+// at the wrong bucket and `fixtures:upload` at the wrong release tag.
+function readPreviousManifest() {
+  let text;
+  try {
+    text = readFileSync(MANIFEST_PATH, 'utf8');
+  } catch (error) {
+    if (error && typeof error === 'object' && error.code === 'ENOENT') return null;
+    throw new Error(`cannot read ${MANIFEST_PATH}: ${error.message}`, { cause: error });
+  }
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    throw new Error(
+      `${MANIFEST_PATH} exists but is not valid JSON (${error.message}). Refusing to ` +
+        'overwrite it, because doing so would reset "release_tag"/"base_url" to the ' +
+        'built-in defaults without saying so. Fix or delete the file and re-run.',
+      { cause: error },
+    );
+  }
+}
+
+const previousManifest = readPreviousManifest();
+
 // Previous manifest's path set — used to flag NEW fixtures (silent-add guard).
 let prevPaths = new Set();
-try {
-  const prev = JSON.parse(readFileSync(MANIFEST_PATH, 'utf8'));
-  if (Array.isArray(prev.files)) prevPaths = new Set(prev.files.map((f) => f.path));
-} catch {
-  // No prior manifest — every fixture is "new"; the warning below still fires.
+if (Array.isArray(previousManifest?.files)) {
+  prevPaths = new Set(previousManifest.files.map((f) => f.path));
 }
 
 // Files at the top level of tests/models/ that aren't fixtures.
@@ -175,12 +203,9 @@ let header = {
   release_tag: 'fixtures-v1',
   base_url: 'https://github.com/LTplus-AG/ifc-lite/releases/download/fixtures-v1',
 };
-try {
-  const existing = JSON.parse(readFileSync(MANIFEST_PATH, 'utf8'));
-  if (existing.release_tag) header.release_tag = existing.release_tag;
-  if (existing.base_url) header.base_url = existing.base_url;
-} catch {
-  // No existing manifest — use defaults.
+if (previousManifest) {
+  if (previousManifest.release_tag) header.release_tag = previousManifest.release_tag;
+  if (previousManifest.base_url) header.base_url = previousManifest.base_url;
 }
 
 const out = {

--- a/scripts/sync-versions.js
+++ b/scripts/sync-versions.js
@@ -38,12 +38,22 @@ function getWorkspacePackages() {
         try {
           statSync(pkgJsonPath);
           packages.push(pkgJsonPath);
-        } catch {
-          // no package.json in this directory, skip
+        } catch (error) {
+          // A directory with no package.json is ordinary. Anything else means
+          // a package is missing from the max-version scan below, which would
+          // sync the whole release to a version LOWER than what was published.
+          if (error.code !== 'ENOENT') {
+            console.warn(`⚠️  Could not stat ${pkgJsonPath}, excluding it from the version scan (${error.message})`);
+          }
         }
       }
-    } catch {
-      // parent directory doesn't exist, skip
+    } catch (error) {
+      // Same, one level up: an unreadable `packages/`/`apps/` silently shrinks
+      // the scan to nothing and the sync then reports success at the wrong
+      // version.
+      if (error.code !== 'ENOENT') {
+        console.warn(`⚠️  Could not list ${parentDir}, excluding it from the version scan (${error.message})`);
+      }
     }
   }
   return packages;
@@ -180,7 +190,15 @@ function syncVersions() {
     let memberToml;
     try {
       memberToml = readFileSync(memberTomlPath, 'utf8');
-    } catch {
+    } catch (error) {
+      // Same reasoning as syncCargoLock's member read above: this list of
+      // crate directories is hardcoded, so a rename, a move, or an unreadable
+      // file makes this loop a silent no-op and leaves the internal
+      // `version = "…"` literals on the previous release — the exact
+      // version/path mismatch the comment above warns about. Say so.
+      console.warn(
+        `⚠️  Could not read rust/${member}/Cargo.toml; its internal dep versions are left at the previous release (${error.message})`
+      );
       continue;
     }
     const updated = memberToml.replace(

--- a/scripts/verify-npm-publish.js
+++ b/scripts/verify-npm-publish.js
@@ -49,15 +49,29 @@ function sleep(ms) {
 
 /**
  * Query npm for the published version of `name@version`.
- * Returns true when the exact version is available, false otherwise.
+ *
+ * Returns `{ ok, error }`. `npm view` exits non-zero both for the answer this
+ * script is looking for ("that version is not published", E404) and for every
+ * way the query itself can fail — no network, a 5xx from the registry, an
+ * expired token, a proxy refusing CONNECT. Collapsing those to a bare `false`
+ * made a registry outage read exactly like a missing publish, so the failure
+ * text is carried out and printed with the ❌ line instead of discarded.
  */
-function isPublished(name, version) {
+function queryPublished(name, version) {
   try {
     const result = execSync(`npm view ${name}@${version} version`, { stdio: 'pipe' });
-    return result.toString().trim() === version;
-  } catch {
-    return false;
+    return { ok: result.toString().trim() === version, error: null };
+  } catch (error) {
+    return { ok: false, error };
   }
+}
+
+/** First line of whatever npm complained about, for a one-line report. */
+function npmReason(error) {
+  if (!error) return null;
+  const stderr = error.stderr ? error.stderr.toString().trim() : '';
+  const text = stderr || error.message || String(error);
+  return text.split('\n').find((l) => l.trim()) ?? null;
 }
 
 function getWorkspacePackages() {
@@ -70,12 +84,20 @@ function getWorkspacePackages() {
         try {
           statSync(pkgJsonPath);
           packages.push(pkgJsonPath);
-        } catch {
-          // no package.json, skip
+        } catch (error) {
+          // A directory with no package.json is ordinary; anything else means
+          // we may be skipping a package we were asked to verify.
+          if (error.code !== 'ENOENT') {
+            console.warn(`⚠️  Could not stat ${pkgJsonPath}, skipping it (${error.message})`);
+          }
         }
       }
-    } catch {
-      // parent dir doesn't exist, skip
+    } catch (error) {
+      // Same: an absent `apps/` or `packages/` is ordinary, but an unreadable
+      // one silently shrinks the set this release gate checks.
+      if (error.code !== 'ENOENT') {
+        console.warn(`⚠️  Could not list ${parentDir}, skipping it (${error.message})`);
+      }
     }
   }
   return packages;
@@ -87,6 +109,13 @@ async function main() {
   const { retries, delay } = parseArgs();
 
   const packagePaths = getWorkspacePackages();
+  // Distinct from "every package is private": finding no package.json at all
+  // means the discovery step itself failed, and exiting 0 there would report a
+  // release as verified having checked nothing.
+  if (packagePaths.length === 0) {
+    console.error('No package.json found under packages/ or apps/ — nothing was verified.');
+    process.exit(2);
+  }
   const toCheck = [];
 
   for (const pkgPath of packagePaths) {
@@ -106,8 +135,11 @@ async function main() {
 
   for (const { name, version } of toCheck) {
     let published = false;
+    let lastError = null;
     for (let attempt = 1; attempt <= retries; attempt++) {
-      published = isPublished(name, version);
+      const res = queryPublished(name, version);
+      published = res.ok;
+      lastError = res.error;
       if (published) break;
       if (attempt < retries) {
         console.log(`  ⏳  ${name}@${version} not yet visible — waiting ${delay / 1000}s (attempt ${attempt}/${retries})…`);
@@ -118,8 +150,9 @@ async function main() {
     if (published) {
       console.log(`  ✅  ${name}@${version}`);
     } else {
-      console.log(`  ❌  ${name}@${version} — NOT found on npm`);
-      failed.push({ name, version });
+      const reason = npmReason(lastError);
+      console.log(`  ❌  ${name}@${version} — NOT found on npm${reason ? ` (npm said: ${reason})` : ''}`);
+      failed.push({ name, version, reason });
     }
   }
 
@@ -127,8 +160,8 @@ async function main() {
 
   if (failed.length > 0) {
     console.error(`${failed.length} package(s) missing from npm after publish:\n`);
-    for (const { name, version } of failed) {
-      console.error(`  • ${name}@${version}`);
+    for (const { name, version, reason } of failed) {
+      console.error(`  • ${name}@${version}${reason ? ` — ${reason}` : ''}`);
     }
     console.error(
       '\nThis usually means the package was not included in the changeset or\n' +

--- a/tests/benchmark/viewer-benchmark-page.ts
+++ b/tests/benchmark/viewer-benchmark-page.ts
@@ -51,68 +51,28 @@ export class ViewerBenchmarkPage {
   private loadStartTime: number = 0;
   private loadEndTime: number = 0;
   private cacheMode: string;
-  /** How long a blocked `deleteDatabase` gets to complete before it is reported. */
-  private static readonly BLOCKED_DELETE_GRACE_MS = 3000;
 
   constructor(page: Page) {
     this.page = page;
     this.cacheMode = process.env.VIEWER_BENCHMARK_CACHE_MODE ?? 'default';
   }
 
-  /**
-   * Wipe the browser-side caches so `cacheMode=cold` measures a cold load.
-   *
-   * This runs AFTER `page.goto` + wait-for-interactive, so the app is booted
-   * and holding IndexedDB connections (`services/ifc-cache.ts` and
-   * `services/extensions/idb-storage.ts` both memoise an open handle and never
-   * close it). `deleteDatabase` against an open connection fires `blocked` and
-   * does NOT delete — and every failure here used to be swallowed, so a run
-   * that cleared nothing still got written out tagged `cacheMode: 'cold'`.
-   * `services/extensions/idb-storage.ts` rejects on the same `blocked` event
-   * for exactly this reason; this reports rather than throws, because failing
-   * the benchmark run outright is a maintainer's call, not a logging fix.
-   */
   private async clearBrowserCaches() {
-    const problems = await this.page.evaluate(async (blockedGraceMs: number) => {
-      // NOTE: no named helper functions in here. This body is serialised into
-      // the page, and a transform that injects a `__name` helper (esbuild's
-      // keep-names does) turns any named inner function into a ReferenceError
-      // at evaluation time.
-      const found: string[] = [];
-
-      // Separate try blocks: sharing one meant a throwing localStorage.clear()
-      // also skipped sessionStorage.clear().
+    await this.page.evaluate(async () => {
       try {
         localStorage.clear();
-      } catch (e) {
-        found.push(`localStorage.clear() threw — ${e instanceof Error ? `${e.name}: ${e.message}` : String(e)}`);
-      }
-      try {
         sessionStorage.clear();
-      } catch (e) {
-        found.push(`sessionStorage.clear() threw — ${e instanceof Error ? `${e.name}: ${e.message}` : String(e)}`);
+      } catch {
+        // Ignore storage issues.
       }
 
       try {
         if ('caches' in globalThis) {
           const cacheKeys = await caches.keys();
-          for (const key of cacheKeys) {
-            try {
-              // `caches.delete` RESOLVES WITH false when the entry was not
-              // removed — it does not reject, so the old `Promise.all` could
-              // not have noticed either way.
-              if (!(await caches.delete(key))) {
-                found.push(`caches.delete(${key}) returned false — entry NOT removed`);
-              }
-            } catch (e) {
-              found.push(`caches.delete(${key}) threw — ${e instanceof Error ? `${e.name}: ${e.message}` : String(e)}`);
-            }
-          }
-        } else {
-          found.push('Cache API unavailable — HTTP caches were not cleared');
+          await Promise.all(cacheKeys.map((key) => caches.delete(key)));
         }
-      } catch (e) {
-        found.push(`caches.keys() threw — ${e instanceof Error ? `${e.name}: ${e.message}` : String(e)}`);
+      } catch {
+        // Ignore Cache API issues.
       }
 
       try {
@@ -124,48 +84,16 @@ export class ViewerBenchmarkPage {
               .filter((name): name is string => Boolean(name))
               .map((name) => new Promise<void>((resolve) => {
                 const request = indexedDB.deleteDatabase(name);
-                // A `blocked` delete is not a failed delete yet — it still
-                // completes if the blocking connection closes. So give it a
-                // bounded moment and only report if it never completed.
-                // Bounded, because the viewer never closes those handles, so
-                // usually it will not.
-                const timer = setTimeout(() => {
-                  found.push(
-                    `indexedDB.deleteDatabase(${name}) did not complete within ${blockedGraceMs}ms ` +
-                    '— an open connection is blocking it and the database was NOT deleted'
-                  );
-                  resolve();
-                }, blockedGraceMs);
-                request.onsuccess = () => {
-                  clearTimeout(timer);
-                  resolve();
-                };
-                request.onerror = () => {
-                  clearTimeout(timer);
-                  found.push(
-                    `indexedDB.deleteDatabase(${name}) errored — ${request.error?.message ?? 'unknown error'}`
-                  );
-                  resolve();
-                };
+                request.onsuccess = () => resolve();
+                request.onerror = () => resolve();
+                request.onblocked = () => resolve();
               }))
           );
-        } else {
-          found.push('indexedDB.databases() unavailable — IndexedDB was NOT cleared');
         }
-      } catch (e) {
-        found.push(`IndexedDB enumeration threw — ${e instanceof Error ? `${e.name}: ${e.message}` : String(e)}`);
+      } catch {
+        // Ignore IndexedDB issues.
       }
-
-      return found;
-    }, ViewerBenchmarkPage.BLOCKED_DELETE_GRACE_MS);
-
-    if (problems.length > 0) {
-      console.warn(
-        `[Benchmark] cacheMode=cold was requested but the caches were NOT fully cleared ` +
-        `(${problems.length} problem(s)). The numbers from this run are not a cold-cache measurement:`
-      );
-      for (const problem of problems) console.warn(`[Benchmark]   - ${problem}`);
-    }
+    });
   }
 
   async setup() {

--- a/tests/benchmark/viewer-benchmark-page.ts
+++ b/tests/benchmark/viewer-benchmark-page.ts
@@ -51,28 +51,68 @@ export class ViewerBenchmarkPage {
   private loadStartTime: number = 0;
   private loadEndTime: number = 0;
   private cacheMode: string;
+  /** How long a blocked `deleteDatabase` gets to complete before it is reported. */
+  private static readonly BLOCKED_DELETE_GRACE_MS = 3000;
 
   constructor(page: Page) {
     this.page = page;
     this.cacheMode = process.env.VIEWER_BENCHMARK_CACHE_MODE ?? 'default';
   }
 
+  /**
+   * Wipe the browser-side caches so `cacheMode=cold` measures a cold load.
+   *
+   * This runs AFTER `page.goto` + wait-for-interactive, so the app is booted
+   * and holding IndexedDB connections (`services/ifc-cache.ts` and
+   * `services/extensions/idb-storage.ts` both memoise an open handle and never
+   * close it). `deleteDatabase` against an open connection fires `blocked` and
+   * does NOT delete — and every failure here used to be swallowed, so a run
+   * that cleared nothing still got written out tagged `cacheMode: 'cold'`.
+   * `services/extensions/idb-storage.ts` rejects on the same `blocked` event
+   * for exactly this reason; this reports rather than throws, because failing
+   * the benchmark run outright is a maintainer's call, not a logging fix.
+   */
   private async clearBrowserCaches() {
-    await this.page.evaluate(async () => {
+    const problems = await this.page.evaluate(async (blockedGraceMs: number) => {
+      // NOTE: no named helper functions in here. This body is serialised into
+      // the page, and a transform that injects a `__name` helper (esbuild's
+      // keep-names does) turns any named inner function into a ReferenceError
+      // at evaluation time.
+      const found: string[] = [];
+
+      // Separate try blocks: sharing one meant a throwing localStorage.clear()
+      // also skipped sessionStorage.clear().
       try {
         localStorage.clear();
+      } catch (e) {
+        found.push(`localStorage.clear() threw — ${e instanceof Error ? `${e.name}: ${e.message}` : String(e)}`);
+      }
+      try {
         sessionStorage.clear();
-      } catch {
-        // Ignore storage issues.
+      } catch (e) {
+        found.push(`sessionStorage.clear() threw — ${e instanceof Error ? `${e.name}: ${e.message}` : String(e)}`);
       }
 
       try {
         if ('caches' in globalThis) {
           const cacheKeys = await caches.keys();
-          await Promise.all(cacheKeys.map((key) => caches.delete(key)));
+          for (const key of cacheKeys) {
+            try {
+              // `caches.delete` RESOLVES WITH false when the entry was not
+              // removed — it does not reject, so the old `Promise.all` could
+              // not have noticed either way.
+              if (!(await caches.delete(key))) {
+                found.push(`caches.delete(${key}) returned false — entry NOT removed`);
+              }
+            } catch (e) {
+              found.push(`caches.delete(${key}) threw — ${e instanceof Error ? `${e.name}: ${e.message}` : String(e)}`);
+            }
+          }
+        } else {
+          found.push('Cache API unavailable — HTTP caches were not cleared');
         }
-      } catch {
-        // Ignore Cache API issues.
+      } catch (e) {
+        found.push(`caches.keys() threw — ${e instanceof Error ? `${e.name}: ${e.message}` : String(e)}`);
       }
 
       try {
@@ -84,16 +124,48 @@ export class ViewerBenchmarkPage {
               .filter((name): name is string => Boolean(name))
               .map((name) => new Promise<void>((resolve) => {
                 const request = indexedDB.deleteDatabase(name);
-                request.onsuccess = () => resolve();
-                request.onerror = () => resolve();
-                request.onblocked = () => resolve();
+                // A `blocked` delete is not a failed delete yet — it still
+                // completes if the blocking connection closes. So give it a
+                // bounded moment and only report if it never completed.
+                // Bounded, because the viewer never closes those handles, so
+                // usually it will not.
+                const timer = setTimeout(() => {
+                  found.push(
+                    `indexedDB.deleteDatabase(${name}) did not complete within ${blockedGraceMs}ms ` +
+                    '— an open connection is blocking it and the database was NOT deleted'
+                  );
+                  resolve();
+                }, blockedGraceMs);
+                request.onsuccess = () => {
+                  clearTimeout(timer);
+                  resolve();
+                };
+                request.onerror = () => {
+                  clearTimeout(timer);
+                  found.push(
+                    `indexedDB.deleteDatabase(${name}) errored — ${request.error?.message ?? 'unknown error'}`
+                  );
+                  resolve();
+                };
               }))
           );
+        } else {
+          found.push('indexedDB.databases() unavailable — IndexedDB was NOT cleared');
         }
-      } catch {
-        // Ignore IndexedDB issues.
+      } catch (e) {
+        found.push(`IndexedDB enumeration threw — ${e instanceof Error ? `${e.name}: ${e.message}` : String(e)}`);
       }
-    });
+
+      return found;
+    }, ViewerBenchmarkPage.BLOCKED_DELETE_GRACE_MS);
+
+    if (problems.length > 0) {
+      console.warn(
+        `[Benchmark] cacheMode=cold was requested but the caches were NOT fully cleared ` +
+        `(${problems.length} problem(s)). The numbers from this run are not a cold-cache measurement:`
+      );
+      for (const problem of problems) console.warn(`[Benchmark]   - ${problem}`);
+    }
   }
 
   async setup() {


### PR DESCRIPTION
The clusters the earlier sweeps skipped — `scripts/`, `tests/`, `apps/landing/`, root tooling. **Three real defects, two in tooling that reported success while doing the wrong thing.**

## 1. A corrupt manifest silently reset the release tag and base URL — exit 0

`scripts/fixtures/build-manifest.mjs:97` and `:182` conflated "no manifest yet" (legitimate) with "manifest present but unparseable". The fallback is the hardcoded `fixtures-v1` defaults, so a manifest pointed at a mirror got rewritten. Reproduced:

```
BEFORE: release_tag "fixtures-v9-custom", base_url "https://example.invalid/mirror"
RUN   : "Wrote …/manifest.json"   EXIT=0
AFTER : release_tag "fixtures-v1",  base_url "…/fixtures-v1"
```

Downstream that is a wrong bucket for `fixtures:fetch` and a wrong tag for `fixtures:upload`.

**The argument that silence is wrong comes from the same file.** `loadIgnorePatterns()` at `:37-48` catches the identical read, returns `[]` **only** on `ENOENT`, and rethrows everything else — with a comment saying a swallowed read "would silently disable the guard and let a private fixture be manifested and pushed to the public bucket". Two sites in one file, opposite policies.

**Behaviour change:** a corrupt manifest now exits 1 **without writing**. Not in CI — `fixtures:manifest` is a maintainer command.

## 2. A cold-cache benchmark could measure a warm cache and publish it as cold

`tests/benchmark/viewer-benchmark-page.ts:93` resolved on `request.onblocked`. `blocked` means the delete was **refused** — the database is still there. It runs at `:263`, after `page.goto` and wait-for-interactive, so the app is booted, and both `ifc-cache.ts:165` and `idb-storage.ts:156` memoise their open handle and never close it. `viewer-benchmark.spec.ts:258` then writes `cacheMode: 'cold'` into the published results.

**The counter-example is our own code:** `idb-storage.ts:196` **rejects** on the same event, with a comment explaining why ignoring it is wrong.

Reproduced in real Chromium, driving the actual class, with the page holding an open IDB connection:

```
RED    (HEAD)   : returned after 2ms — silent; databases AFTER: ['held-db']
GREEN  (patched): "cacheMode=cold was requested but the caches were NOT fully cleared…"
CONTROL(patched, connection closed): silent, 2ms, databases AFTER: []
```

The control is what makes it non-vacuous — the warning is not a blanket false positive. It **reports rather than throws**, since failing a benchmark run is your call. Two smaller hidden failures in the same function are fixed too: `localStorage.clear()` and `sessionStorage.clear()` shared a `try` (a throw in the first skipped the second), and `caches.delete()` **resolves `false`** when it deleted nothing, which the old `Promise.all` could not notice.

## 3. A generator that did nothing reported nothing

`scripts/augment-epsg-proj4.ts:77` made a network failure indistinguishable from "the registry has no proj4", then `main()` rewrote the generated file and printed success. A run during an epsg.io outage or behind a 429 finished looking normal. No data loss — the rewrite round-trips what it had — but a no-op run was silent. Errors are now bound and classified, first 5 printed with the EPSG code (it loops over thousands), with a tally and an explicit warning when nothing resolved.

**Left for you, stated in the code:** `!resp.ok` still returns immediately with no retry, so one 429 permanently records a code as having no proj4 for that run. `fetch-fixtures.mjs` already documents the right policy (retry 5xx/408/429, only 4xx permanent) — adopting it is a behaviour change to a hand-run generator with no test home, so I did not fold it into a logging fix.

## Hardening — real mechanism, not reachable in a healthy checkout

Said plainly rather than dressed up. `sync-versions.js:183` (I verified all 7 crate dirs exist and there is **no live drift**; its own `syncCargoLock` at `:92` already warns for the identical case), the duplicated `getWorkspacePackages()` in two scripts, and `verify-npm-publish.js:58` where an npm registry 5xx read exactly like a missing publish.

**The sharpest of these is a release gate.** `verify-npm-publish.js:98-101` printed "No publishable packages found." and **exited 0 having verified nothing** — and it runs from `release.yml:262`. Now split: zero `package.json` discovered exits 2 (**behaviour change**), all-private still exits 0. Both pinned with a fake `npm` on PATH so CI cannot regress into the exit-0 case.

`apps/landing/app.jsx:1952`'s `/* swallow */` — a comment justifying nothing — was the only landing site producing a **wrong answer**: a rejected `requestAdapter()` rendered as "WebGPU — not detected", identical to a browser without WebGPU.

## Counts, and the reading used

| scope | catches | narrow (empty after comment strip) | broad (no log/throw/exit/reject) |
|---|---|---|---|
| baseline | 152 | 23 | 73 |
| after | 154 | **11** | **63** |

The narrow reading undercounts here too, but less than in the viewer — most broad-only hits are `scripts/moonshot/**` research tooling that returns a sentinel and reports later.

## Left alone, with reasons

`check-api-surface.mjs` (diffed against a committed snapshot, so drift fails loudly), tempdir/unlink cleanup, `moonshot/**`, and `server/chat`'s fail-closed origin checks. I read `check-git-lfs.mjs` and both fixture scripts **specifically hunting the swallow-then-report-success shape** — they are already careful: LFS checks the printed value not the exit status, the fetcher verifies sha256 and exits 1, the uploader exits 1 on any failed upload.

## What I could and could not verify

`scripts/` and `apps/landing/` have **no test suite**, and `apps/landing` has no `package.json` so it is outside `pnpm typecheck` and `pnpm lint` entirely. Not implying coverage I do not have.

Instead: `node --check` on all modified `.js/.mjs`; `tsc --strict --types node` on the `.ts`; `@babel/parser` with `sourceType: 'script'` + `jsx`, matching how `index.html:612` actually loads `app.jsx`; real end-to-end runs restored afterwards (`sync-versions` idempotent, `build-manifest` against the real repo with the header preserved and `git status` clean); scratch-tree runs for every failure path; and real Chromium for the benchmark defect. `tests/` typecheck is 35 errors before and after — same files, all pre-existing `TS2591` from an unresolved `@types/node` in a worktree without `node_modules`.

**Could not run** `pnpm test:benchmark:viewer` (needs a built viewer, a served app and fixtures) or `check:api-surface` (needs built dists).

**Two behaviour changes to weigh:** `build-manifest.mjs` exits 1 on a corrupt manifest instead of overwriting it, and `verify-npm-publish.js` exits 2 when discovery finds nothing at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
