### PR TITLE
fix(sandbox): copy the logs into ScriptError instead of aliasing them

### DIFF
--- a/.changeset/sandbox-script-error-logs-copy.md
+++ b/.changeset/sandbox-script-error-logs-copy.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/sandbox": patch
+---
+
+Stop a caught `ScriptError`'s `logs` from being emptied by the next `eval()` (#2092).
+
+`ScriptError` stored the constructor's `logs` argument by reference, and every `ScriptError` is constructed with the sandbox's single log buffer — the same array `Sandbox.eval()` clears in place (`this.logs.length = 0`) at the start of each run. An embedder that caught an error, kept it for a retry or a report, and then ran another script found the error's logs empty, after having already inspected them. `ScriptError` now copies the array at construction, so a caught error keeps the console output of the run that failed for as long as the error is held.
+
+Only the error path was affected: the success path already returned `logs: [...this.logs]`, and the two are now consistent. Sandboxes that never retain an error across evals see no change.

--- a/packages/sandbox/src/error-logs.test.ts
+++ b/packages/sandbox/src/error-logs.test.ts
@@ -1,0 +1,118 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Regression tests for a caught `ScriptError` losing its logs (#2092).
+ *
+ * `eval()` clears the sandbox's log buffer in place at the start of every run,
+ * so a `ScriptError` that stored that same array by reference had its logs
+ * emptied retroactively by the next `eval()` — after the embedder had already
+ * inspected them.
+ *
+ * The scripts here fail with a plain `throw`, never a resource limit, so no
+ * test in this file can abort the shared WASM module.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { BimContext } from '@ifc-lite/sdk';
+import { createSandbox, ScriptError, type Sandbox } from './sandbox.js';
+
+/** The scripts under test never touch `bim`, so an empty context suffices. */
+const EMPTY_SDK = {} as unknown as BimContext;
+
+/** Runs `script` and returns the `ScriptError` it must reject with. */
+async function evalScriptError(sandbox: Sandbox, script: string): Promise<ScriptError> {
+  try {
+    const result = await sandbox.eval(script, { typescript: false });
+    throw new Error(`expected a ScriptError, but eval resolved with ${JSON.stringify(result.value)}`);
+  } catch (err) {
+    expect(err).toBeInstanceOf(ScriptError);
+    return err as ScriptError;
+  }
+}
+
+/** Flattens a log entry's arguments so assertions read like the console call. */
+function logArgs(err: ScriptError): unknown[][] {
+  return err.logs.map((entry) => entry.args);
+}
+
+describe('ScriptError logs', () => {
+  it('captures the logs written before the throw', async () => {
+    const sandbox = await createSandbox(EMPTY_SDK);
+    try {
+      const err = await evalScriptError(
+        sandbox,
+        'console.log("from first eval"); throw new Error("boom");',
+      );
+
+      expect(err.message).toBe('boom');
+      expect(logArgs(err)).toEqual([['from first eval']]);
+    } finally {
+      sandbox.dispose();
+    }
+  }, 30_000);
+
+  it('keeps a caught error\'s logs after a later eval clears the buffer', async () => {
+    const sandbox = await createSandbox(EMPTY_SDK);
+    try {
+      const err = await evalScriptError(
+        sandbox,
+        'console.log("from first eval"); throw new Error("boom");',
+      );
+      expect(logArgs(err)).toEqual([['from first eval']]);
+
+      await sandbox.eval('1;', { typescript: false });
+
+      expect(logArgs(err)).toEqual([['from first eval']]);
+    } finally {
+      sandbox.dispose();
+    }
+  }, 30_000);
+
+  it('keeps two caught errors\' logs independent of each other', async () => {
+    const sandbox = await createSandbox(EMPTY_SDK);
+    try {
+      const first = await evalScriptError(
+        sandbox,
+        'console.log("first"); throw new Error("boom 1");',
+      );
+      const second = await evalScriptError(
+        sandbox,
+        'console.log("second"); throw new Error("boom 2");',
+      );
+
+      expect(logArgs(first)).toEqual([['first']]);
+      expect(logArgs(second)).toEqual([['second']]);
+    } finally {
+      sandbox.dispose();
+    }
+  }, 30_000);
+});
+
+describe('ScriptResult logs', () => {
+  it('returns the logs a successful eval wrote', async () => {
+    const sandbox = await createSandbox(EMPTY_SDK);
+    try {
+      const result = await sandbox.eval('console.log("ok"); 42;', { typescript: false });
+
+      expect(result.value).toBe(42);
+      expect(result.logs.map((entry) => entry.args)).toEqual([['ok']]);
+    } finally {
+      sandbox.dispose();
+    }
+  }, 30_000);
+
+  it('does not leak one eval\'s logs into the next result', async () => {
+    const sandbox = await createSandbox(EMPTY_SDK);
+    try {
+      const first = await sandbox.eval('console.log("first"); 1;', { typescript: false });
+      const second = await sandbox.eval('console.log("second"); 2;', { typescript: false });
+
+      expect(first.logs.map((entry) => entry.args)).toEqual([['first']]);
+      expect(second.logs.map((entry) => entry.args)).toEqual([['second']]);
+    } finally {
+      sandbox.dispose();
+    }
+  }, 30_000);
+});

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -262,13 +262,23 @@ export class Sandbox {
 
 /** Error thrown when a sandboxed script fails */
 export class ScriptError extends Error {
+  /**
+   * Console output captured before the failure.
+   *
+   * Copied from the caller's array: `eval()` reuses one log buffer and clears
+   * it in place on every run, so storing that array by reference emptied a
+   * caught error's diagnostics the moment the next script started (#2092).
+   */
+  public readonly logs: LogEntry[];
+
   constructor(
     message: string,
-    public readonly logs: LogEntry[],
+    logs: LogEntry[],
     public readonly durationMs: number,
   ) {
     super(message);
     this.name = 'ScriptError';
+    this.logs = [...logs];
   }
 }
 


### PR DESCRIPTION
Closes #2092, which you filed off #2078 — taking it since you noted it is a one-line fix and not that PR's to make.

## The fix removes an inconsistency rather than adding a convention

Worth leading with, because it changes how the fix should be read: the **success path already copied**. `sandbox.ts:212` returns `logs: [...this.logs]`, while `ScriptError` aliased. Success copied, failure aliased. Both now hand out a snapshot.

A shallow copy is sufficient — `LogEntry` objects are pushed fresh per `console.*` call (`bridge.ts:82,95`) and never mutated afterwards; `eval()` only detaches them via `length = 0`. A deep clone would buy nothing.

## Construction-site audit: 3, not 5

`grep -rn "new ScriptError"` across the repo finds **three**, all in `sandbox.ts` — `:181` (dumped QuickJS exception), `:196` (`'interrupted'`), `:203` (realm invalid during `vm.dump`). All pass `this.logs`.

The 5 figure came from #2078, which is **not merged into `upstream/main`** — `git log upstream/main --grep=2078` is empty and there is no `rejected-promise.test.ts` in the tree. Since the fix is in the **constructor** rather than at the call sites, it covers #2078's two new sites automatically when they land.

## Scope

This affects an embedder that **retains** a caught `ScriptError` across a later `eval()` on the same sandbox — a report, a retry, a deferred serialization. One that reads `err.logs` and discards the error before the next eval was never affected, and nothing in the repo's own callers does the former. Pre-existing, not a regression, exactly as you established.

## Evidence

Restoring the alias fails exactly the two aliasing tests (`REPLACEMENTS=1`, region re-read — I re-ran this myself on the pushed tree): 2 failed / 47 passed, restored 49/49.

**The three negatives pass before *and* after**, which is what makes them meaningful rather than decoration:
- `captures the logs written before the throw` asserts `[['from first eval']]` immediately, so a version returning `[]` could not pass it;
- `returns the logs a successful eval wrote` keeps the success path honest;
- `does not leak one eval's logs into the next result` confirms the live buffer is still cleared per run, so the fix did not turn `logs` into an accumulator.

The two-caught-errors case doubles as the error-path negative: pre-fix it fails with the **later** run's logs rather than an empty array, which distinguishes "aliased" from "never populated".

49 passing (was 44 on this base — the 49 in the issue thread is post-#2078), typecheck 34/34, `check:test-wiring` passes.

## One process note

Restoring the mutation with the obvious anchor `this.logs = logs;` reported `REPLACEMENTS=2` and the `assert n==1` aborted the write. The second occurrence is `sandbox.ts:99` — the **intentional** bridge-buffer alias in `init()`. A naive replace-all would have silently rewritten it, and the resulting failure would have looked like a problem with the fix rather than with the tooling.

That is the third distinct way a mutation has misapplied today, and the first two were caught by the same count-and-assert step rather than by the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed script errors so their captured logs remain available after subsequent script executions.
  * Prevented log entries from leaking between separate evaluations.
  * Preserved independent logs for multiple caught errors.

* **Tests**
  * Added coverage for error logging, successful evaluations, and sequential executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->