### PR TITLE
fix(sandbox): don't retain a log argument the byte budget cannot size

### DIFF
--- a/.changeset/sandbox-log-budget-accounting.md
+++ b/.changeset/sandbox-log-budget-accounting.md
@@ -1,0 +1,11 @@
+---
+"@ifc-lite/sandbox": patch
+---
+
+Stop captured log entries that cannot be sized from escaping the sandbox's host-memory budget.
+
+The bridge caps captured console output twice: by entry count (1000) and by cumulative serialized size (4 MB), because `vm.dump` copies sandbox values onto the host heap, which the QuickJS memory limit does not bound. The size charge came from `JSON.stringify`, and when that threw the entry was charged zero bytes and retained anyway. A top-level `BigInt` is the value that reaches the host in that state — it survives `vm.dump` intact but has no JSON form, and QuickJS will allocate one of a million bits — so a script could park up to 1000 such values, tens of megabytes, that the byte budget never saw. (An object the VM cannot serialize never got that far: `vm.dump` already flattens it to the string `"[object Object]"`.)
+
+The bridge now refuses to retain what it cannot size. When sizing an entry fails, each argument is sized on its own: arguments that serialize are kept untouched, and only those that do not are replaced by bounded text, charged at exactly the length of that text. Retained memory is therefore always what the budget can see. Serializable logs are sized and capped exactly as before.
+
+**Embedder-visible:** `LogEntry.args` no longer contains `BigInt` values. A small BigInt is retained as its literal text (`42n`), a very large one as `[BigInt too large to retain]`; other arguments on the same line are unaffected, so the log still shows which script logged what. The failure is reported to the host console once per sandbox context — not once per entry, since the trigger is script-supplied.

--- a/packages/sandbox/src/bridge-console-budget.test.ts
+++ b/packages/sandbox/src/bridge-console-budget.test.ts
@@ -133,6 +133,43 @@ describe('captured-log byte budget', () => {
     }
   });
 
+  it('charges the fallback path something proportionate, not a wild overestimate', async () => {
+    // The magnitude of the FALLBACK charge was unpinned (maintainer negative
+    // control on #2096): replacing `bytes += json?.length ?? 0` inside
+    // retainSizeableArgs with a 10-million-fold constant left every other test
+    // in this file green. Nothing noticed, because the exact-charge test above
+    // drives the happy path — `retainSizeableArgs` only runs once
+    // `JSON.stringify` of the whole argument array has already thrown.
+    //
+    // Over-charging is the mirror image of the bug #2087 fixed: instead of
+    // retaining entries the budget cannot see, it would discard entries the
+    // budget should have had room for. Approximate is fine here (the comment
+    // in bridge.ts says "approximate host cost", and String.length undercounts
+    // UTF-8 bytes for non-ASCII anyway) — orders of magnitude wrong is not.
+    //
+    // Observable proxy for `totalBytes`, which is private: one entry carrying
+    // an unsizeable argument must not exhaust a 4MB budget by itself. Under
+    // the 10-million mutation the very next entry truncates.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      await withSandbox(async (sandbox) => {
+        const result = await sandbox.eval(
+          'console.log(1n, "small");\nfor (let i = 0; i < 3; i++) console.log("after", i);\n9;',
+        );
+        expect(result.value).toBe(9);
+        // 4 entries, and none of them the truncation marker: the first entry's
+        // fallback charge left room for the rest.
+        expect(result.logs).toHaveLength(4);
+        expect(result.logs.map((entry) => entry.args[0])).not.toContain(TRUNCATION_MARKER);
+        // The sizing failure still happened — otherwise this test would pass
+        // by never reaching the fallback path at all.
+        expect(warn.mock.calls.filter((call) => String(call[0]).includes(SIZING_WARNING))).toHaveLength(1);
+      });
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
   it('still caps the entry count', async () => {
     await withSandbox(async (sandbox) => {
       const result = await sandbox.eval(

--- a/packages/sandbox/src/bridge-console-budget.test.ts
+++ b/packages/sandbox/src/bridge-console-budget.test.ts
@@ -1,0 +1,145 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The bridge caps captured console output twice: by entry count
+ * (MAX_LOG_ENTRIES = 1000) and by cumulative serialized size
+ * (MAX_TOTAL_BYTES = 4MB). Both caps exist because `vm.dump` copies sandbox
+ * values onto the host heap, which the QuickJS memory limit does not bound.
+ *
+ * The byte cap can only charge for what it can measure. A top-level BigInt is
+ * the one sandbox value that survives `vm.dump` intact but has no JSON form
+ * (an object the VM cannot serialize arrives already flattened to the string
+ * "[object Object]"), so `JSON.stringify` throws — and a BigInt is unbounded
+ * in size. Retaining such an argument would consume an entry slot while
+ * contributing nothing to the byte budget (#2087), so the bridge replaces it
+ * with bounded text and charges exactly that.
+ *
+ * Two further properties are pinned here, and they pull against each other:
+ *   - the sizing failure is *reported* (house rule: no silent catch), and
+ *   - it is reported at most once per context — the trigger is script-supplied,
+ *     so a per-entry log would let `for(;;) console.log(1n)` flood the host.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type { BimContext } from '@ifc-lite/sdk';
+import { createSandbox } from './sandbox.js';
+
+const SIZING_WARNING = 'could not be sized';
+const TRUNCATION_MARKER = '[log output truncated: limit reached]';
+
+/** Mirrors bridge.ts — the caps are private, so the tests drive their edges. */
+const MAX_LOG_ENTRIES = 1000;
+
+async function withSandbox<T>(run: (sandbox: Awaited<ReturnType<typeof createSandbox>>) => Promise<T>): Promise<T> {
+  const sandbox = await createSandbox({} as unknown as BimContext);
+  try {
+    return await run(sandbox);
+  } finally {
+    sandbox.dispose();
+  }
+}
+
+describe('captured-log byte budget', () => {
+  it('does not retain a log argument it could not size', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      await withSandbox(async (sandbox) => {
+        // `1n << 100000n` is ~12.5 KB of host BigInt — small enough to keep
+        // the test quick and to pose no risk to the shared WASM module, but
+        // repeated to the entry cap it is ~12 MB of host memory the byte
+        // budget used to charge nothing for. (QuickJS itself refuses to
+        // allocate a BigInt much past a million bits.)
+        const result = await sandbox.eval(
+          'const huge = 1n << 100000n;\nfor (let i = 0; i < 6; i++) console.log(huge);\n42;',
+        );
+        expect(result.value).toBe(42);
+        expect(result.logs).toHaveLength(6);
+
+        // Nothing unsizeable survives on the host heap, so what the budget
+        // charged and what the host actually holds are the same thing.
+        const retained = result.logs.flatMap((entry) => entry.args);
+        expect(retained.some((arg) => typeof arg === 'bigint')).toBe(false);
+        expect(() => JSON.stringify(retained)).not.toThrow();
+        expect(JSON.stringify(retained).length).toBeLessThan(1024);
+        expect(result.logs[0]?.args).toEqual(['[BigInt too large to retain]']);
+
+        // The catch really fired — without this the rest of the test is vacuous.
+        const sizingWarnings = warn.mock.calls.filter((call) => String(call[0]).includes(SIZING_WARNING));
+        expect(sizingWarnings).toHaveLength(1);
+      });
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('keeps a small BigInt readable and leaves its neighbours untouched', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      await withSandbox(async (sandbox) => {
+        const result = await sandbox.eval('console.log("count", 42n, { ok: true }); 1;');
+        expect(result.logs).toHaveLength(1);
+        expect(warn.mock.calls.filter((call) => String(call[0]).includes(SIZING_WARNING))).toHaveLength(1);
+        // The failure costs the offending argument only, not the log line.
+        expect(result.logs[0]?.args).toEqual(['count', '42n', { ok: true }]);
+      });
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('warns once, not per entry, when entries cannot be sized', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      await withSandbox(async (sandbox) => {
+        const result = await sandbox.eval('console.log(1n); console.log(2n); console.log(3n); 42;');
+        // Logging still succeeds — a sizing failure must not drop the entry.
+        expect(result.value).toBe(42);
+        expect(result.logs).toHaveLength(3);
+        expect(result.logs.map((entry) => entry.args)).toEqual([['1n'], ['2n'], ['3n']]);
+
+        const sizingWarnings = warn.mock.calls.filter((call) => String(call[0]).includes(SIZING_WARNING));
+        expect(sizingWarnings).toHaveLength(1);
+      });
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('charges serializable entries exactly as before and truncates on the same entry', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      await withSandbox(async (sandbox) => {
+        // Each entry serializes to ["x"*1048576] = 1048576 + 2 quotes +
+        // 2 brackets = 1048580 bytes. Four entries reach 4194320, just past
+        // the 4194304-byte budget, so the fifth call is the one that
+        // truncates and the fourth is not. An off-by-more-than-four-bytes
+        // change in per-entry sizing moves that boundary.
+        const result = await sandbox.eval(
+          'const payload = "x".repeat(1048576);\nfor (let i = 0; i < 6; i++) console.log(payload);\n7;',
+        );
+        expect(result.value).toBe(7);
+        expect(result.logs).toHaveLength(5);
+        expect(result.logs.slice(0, 4).map((entry) => (entry.args[0] as string).length)).toEqual([
+          1048576, 1048576, 1048576, 1048576,
+        ]);
+        expect(result.logs[4]).toMatchObject({ level: 'warn', args: [TRUNCATION_MARKER] });
+        // Nothing here is unsizeable: the sizing path must stay silent.
+        expect(warn.mock.calls.filter((call) => String(call[0]).includes(SIZING_WARNING))).toHaveLength(0);
+      });
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('still caps the entry count', async () => {
+    await withSandbox(async (sandbox) => {
+      const result = await sandbox.eval(
+        `for (let i = 0; i < ${MAX_LOG_ENTRIES + 5}; i++) console.log(i);\n1;`,
+      );
+      expect(result.logs).toHaveLength(MAX_LOG_ENTRIES + 1);
+      expect(result.logs[MAX_LOG_ENTRIES]).toMatchObject({ level: 'warn', args: [TRUNCATION_MARKER] });
+    });
+  });
+});

--- a/packages/sandbox/src/bridge.ts
+++ b/packages/sandbox/src/bridge.ts
@@ -72,6 +72,10 @@ function buildConsole(vm: QuickJSContext, logs: LogEntry[]): void {
   const MAX_TOTAL_BYTES = 4 * 1024 * 1024; // 4MB host budget for captured logs
   let totalBytes = 0;
   let truncated = false;
+  // The sizing failure below is script-controlled, so it must not be logged
+  // per occurrence: `for(;;) console.log(1n)` would then flood the host
+  // console. One notice per context is enough to make it non-silent.
+  let sizingWarningShown = false;
 
   try {
     for (const level of ['log', 'warn', 'error', 'info'] as const) {
@@ -83,16 +87,30 @@ function buildConsole(vm: QuickJSContext, logs: LogEntry[]): void {
           return;
         }
         const nativeArgs = args.map(a => vm.dump(a));
-        // Approximate host cost of retaining this entry; treat unserializable
-        // args (e.g. cyclic) as zero-cost rather than failing the log call.
+        // Approximate host cost of retaining this entry.
+        let entryArgs: unknown[] = nativeArgs;
         let entryBytes = 0;
         try {
           entryBytes = JSON.stringify(nativeArgs)?.length ?? 0;
-        } catch {
-          entryBytes = 0; /* unserializable args — skip cost accounting */
+        } catch (err) {
+          // An entry that cannot be sized must not be retained as it is: it
+          // would take one of the MAX_LOG_ENTRIES slots while adding nothing
+          // to totalBytes, so a script could park host memory the 4MB budget
+          // never sees (#2087). Keep the arguments that can be sized, swap
+          // the rest for bounded text, and charge exactly what is kept.
+          const retained = retainSizeableArgs(nativeArgs);
+          entryArgs = retained.args;
+          entryBytes = retained.bytes;
+          if (!sizingWarningShown) {
+            sizingWarningShown = true;
+            console.warn(
+              `[ifc-lite/sandbox] ${retained.replaced} captured log argument(s) could not be sized and were replaced by a placeholder; further occurrences in this context are not reported`,
+              err,
+            );
+          }
         }
         totalBytes += entryBytes;
-        logs.push({ level, args: nativeArgs, timestamp: Date.now() });
+        logs.push({ level, args: entryArgs, timestamp: Date.now() });
       });
       try {
         vm.setProp(consoleHandle, level, fn);
@@ -105,4 +123,60 @@ function buildConsole(vm: QuickJSContext, logs: LogEntry[]): void {
   } finally {
     consoleHandle.dispose();
   }
+}
+
+/**
+ * Bound on the BigInt kept as text. Rendering a BigInt to decimal is itself a
+ * memory hazard — a million-bit BigInt, which QuickJS will allocate, renders to
+ * ~300k characters — while comparing against a bound is cheap, so anything
+ * larger is described rather than printed.
+ */
+const MAX_RETAINED_BIGINT = 10n ** 64n;
+
+/**
+ * Bounded stand-in for a console argument the host cannot size.
+ *
+ * `vm.dump` flattens any sandbox value its own serializer rejects to the
+ * string "[object Object]" (a cyclic object arrives as that string, already
+ * stripped of its payload), so the value that actually reaches the host
+ * unserializable is a top-level BigInt — and a BigInt is unbounded in size.
+ * Every branch here returns at most ~70 characters.
+ */
+function describeUnsizeableArg(arg: unknown): string {
+  if (typeof arg === 'bigint') {
+    return arg < MAX_RETAINED_BIGINT && arg > -MAX_RETAINED_BIGINT
+      ? `${arg}n`
+      : '[BigInt too large to retain]';
+  }
+  return `[unserializable ${typeof arg} — not retained]`;
+}
+
+/**
+ * Rebuild a dumped argument list so that every retained element has a known
+ * serialized size, and report that size.
+ *
+ * The byte budget can only cap what it can measure: retaining an argument
+ * whose size is unknown lets a script hold host memory for free (#2087).
+ * Arguments that serialize are kept untouched — a sizing failure in one
+ * argument must not cost the caller the rest of the log line.
+ */
+function retainSizeableArgs(nativeArgs: unknown[]): { args: unknown[]; bytes: number; replaced: number } {
+  let bytes = 0;
+  let replaced = 0;
+  const args = nativeArgs.map(arg => {
+    let json: string | undefined;
+    try {
+      json = JSON.stringify(arg);
+    } catch {
+      // Not silent: the caller warns once per context. Warning per occurrence
+      // would let a script flood the host console (see sizingWarningShown).
+      const placeholder = describeUnsizeableArg(arg);
+      replaced += 1;
+      bytes += placeholder.length;
+      return placeholder;
+    }
+    bytes += json?.length ?? 0;
+    return arg;
+  });
+  return { args, bytes, replaced };
 }


### PR DESCRIPTION
Closes #2087, which I filed after you confirmed it on #2080.

## I overstated the exposure in that issue — correcting it here

I wrote "up to 1000 arbitrarily large objects". Probing `vm.dump` directly shows it already flattens **any** value its in-VM serializer rejects to the string `"[object Object]"` — cyclic objects, functions, and crucially **an object with a nested BigInt** all survive `JSON.stringify` afterwards.

**The only value that reaches the host unsizeable is a top-level BigInt.** So it is not arbitrarily large *objects*, it is arbitrarily large *BigInts*. QuickJS allocates `1n << 1000000n` (~125 KB) and refuses ~`3000000n`, so the honest ceiling is roughly 1000 × 125 KB ≈ **125 MB** a script author can retain that the 4 MB cap never sees. `vm.dump` of a huge BigInt is also quadratic — ~2 s for a 1M-bit one — so the practical rate is low. Real, but not fast.

## Option (2), and the narrowing is what justifies it

Because the failure is always a **top-level argument**, per-argument handling is exact by construction and costs nothing in debuggability. An estimate (option 1) would have to over-estimate a BigInt *without rendering it* — and rendering is the expensive part, so any honest estimate is either wrong or as costly as the payload. Option 3 leaves a window where the payload is held.

**The fast path is untouched:** one `JSON.stringify` for the whole entry, so serializable logs are charged byte-for-byte what they were before. Only on throw does it size each argument alone, keep the ones that serialize **untouched**, and replace the rest:

```
console.log('count', 42n, {ok:true})  ->  count 42n { ok: true }
console.log(1n << 100000n)            ->  [BigInt too large to retain]
```

Level, timestamp and neighbouring arguments all intact; every placeholder is ≤ ~70 chars and charged its exact length. **A sizing failure never drops a log line.**

## Evidence

Retaining the arg fails **3** tests — I re-ran that myself on the pushed tree (`REPLACEMENTS=1`, region re-read): 3 failed / 46 passed, restored 49/49.

The two byte-accounting negatives **pass before and after**, which is what shows the normal path is unchanged. The sharper one pins the truncation boundary exactly: six 1 MB logs, each entry serializing to 1 048 580 B, four of which just pass `MAX_TOTAL_BYTES` — so a per-entry sizing error of more than ~4 bytes moves that boundary and fails the test. That is the no-double-counting case.

The RED asserts **retention** first, not the warning — so it demonstrates the accounting hole rather than a missing notice — with the latched warning asserted in the same test as the oracle that the catch actually fired.

**One mutation survives, and I believe it is unobservable rather than untested:** not charging the placeholder leaves at most 1000 × 70 B ≈ 70 KB uncharged, and you would need ~60 000 entries to reach 4 MB against a 1000-entry cap. No public-API test can distinguish it. Charging it is still correct, so it stays — flagging it rather than claiming a clean sweep.

## #2080 is not merged, so the latch is here

`upstream/main` has the bare `catch { entryBytes = 0; }` and no `bridge-console.test.ts`. Since my catch must not be silent and the latch is the stated design constraint, it is implemented here with **#2080's exact variable name and rationale comment** so the rebase is trivial. My test file is named `bridge-console-budget.test.ts`, so either PR can merge first without a file-add conflict.

## One house-rule judgement call for you

`retainSizeableArgs` has a `catch` that neither logs nor rethrows — it returns the placeholder and increments a counter, and the **caller** warns once per context with the error and the replaced count. Reporting inside the map is exactly the console flood the latch exists to prevent. If you read `AGENTS.md:17` more literally, the alternative is threading the caught error out of the map and warning with it — identical behaviour, more plumbing. Your call.

49 passing (was **44** — the 49 figure assumed #2080 merged), typecheck 34/34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
