### PR TITLE
fix(viewer): a cache read failure must degrade to a miss, not break the load

### DIFF
--- a/apps/viewer/src/services/ifc-cache.read-failure.test.ts
+++ b/apps/viewer/src/services/ifc-cache.read-failure.test.ts
@@ -1,0 +1,135 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * A cache READ failure must degrade to a MISS, never break the load.
+ *
+ * `setCached` already guarantees this on the WRITE path ("A cache write must
+ * NEVER break the load"). The read/maintenance helpers each wrap their work in
+ * a `try`/`catch` that documents the same contract — warn and return
+ * `null`/`false`/zeros — but they used to `return new Promise(...)` INSIDE the
+ * try without `await`, so the promise's own rejection bypassed the catch
+ * entirely and propagated to the caller. That bug is fixed with `return await`.
+ *
+ * Failure induction: #2102 (`withConnection` / `beginTransaction`) added a
+ * ONE-SHOT reopen for a connection that was closed underneath the cache
+ * (`InvalidStateError` from `db.transaction()`), so closing the memoised
+ * connection is no longer a failure at all — it's a recoverable condition
+ * `beginTransaction` transparently papers over. These tests instead force a
+ * `request.onerror` — the failure mode #2102 deliberately leaves alone,
+ * because by the time a request exists the transaction was already created
+ * successfully, so there is nothing left to retry. We do this by aborting the
+ * transaction the moment the request is issued: IndexedDB fires `onerror`
+ * (with `AbortError`), not `onsuccess`, on every request still pending when
+ * its transaction aborts — a spec-guaranteed way to fail a request without
+ * needing invalid data or a broken store.
+ *
+ * Lives in its own file because the assertions monkeypatch
+ * `IDBObjectStore.prototype`; `tsx --test` runs each file in its own process.
+ */
+
+// fake-indexeddb installs a Node-compatible IDB implementation on
+// `globalThis.indexedDB` (+ the IDB* constructors) via the `/auto` entry.
+import 'fake-indexeddb/auto';
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  setCached,
+  getCached,
+  hasCached,
+  deleteCached,
+  clearCache,
+  getCacheStats,
+} from './ifc-cache.js';
+
+/** Resolve to the settled outcome, or the literal 'HUNG' after `ms`. */
+async function settleOrHang<T>(p: Promise<T>, ms = 500): Promise<
+  { kind: 'resolved'; value: T } | { kind: 'rejected'; error: unknown } | { kind: 'hung' }
+> {
+  return Promise.race([
+    p.then(
+      (value) => ({ kind: 'resolved' as const, value }),
+      (error: unknown) => ({ kind: 'rejected' as const, error }),
+    ),
+    new Promise<{ kind: 'hung' }>((resolve) => {
+      setTimeout(() => resolve({ kind: 'hung' as const }), ms).unref?.();
+    }),
+  ]);
+}
+
+/**
+ * One-shot: patch `IDBObjectStore.prototype[methodName]` so the NEXT call
+ * issues a real request, then immediately aborts that request's transaction
+ * before returning control to the caller. Per spec, a pending request whose
+ * transaction aborts fires `onerror` (with an `AbortError`), never
+ * `onsuccess` — this fails the request without any invalid data, and without
+ * touching `openDatabase`'s memo, so `beginTransaction`'s reopen path is never
+ * even triggered (the transaction it handed back was created just fine).
+ */
+function failNextRequest(methodName: 'get' | 'count' | 'delete' | 'clear' | 'getAll'): void {
+  const proto = IDBObjectStore.prototype as unknown as Record<string, (...args: unknown[]) => IDBRequest>;
+  const original = proto[methodName];
+  proto[methodName] = function (this: IDBObjectStore, ...args: unknown[]) {
+    proto[methodName] = original; // restore immediately: strictly one-shot
+    const request = original.apply(this, args);
+    try {
+      request.transaction!.abort();
+    } catch {
+      /* transaction may already be inactive; the request still errors */
+    }
+    return request;
+  };
+}
+
+describe('ifc-cache: a read failure degrades to a miss, it does not break the load', () => {
+  it('getCached resolves null (not rejects) when the underlying request errors', async () => {
+    await setCached('req-error', new ArrayBuffer(64), 'a.ifc', 64);
+
+    // Guard against a vacuous pass: the entry must really be readable first,
+    // so a later `null` means "degraded to a miss", not "was never there".
+    assert.notEqual(await getCached('req-error'), null, 'precondition: entry is readable');
+
+    failNextRequest('get');
+    const outcome = await settleOrHang(getCached('req-error'));
+    assert.equal(outcome.kind, 'resolved', 'getCached must not reject on a read failure');
+    assert.equal(outcome.kind === 'resolved' ? outcome.value : undefined, null);
+
+    // The entry is untouched — this was a transient failure, not a corruption
+    // or a real miss. Confirms we degraded rather than actually losing data.
+    assert.notEqual(await getCached('req-error'), null, 'entry survives the induced failure');
+  });
+
+  it('hasCached / getCacheStats / deleteCached / clearCache also degrade instead of rejecting', async () => {
+    await setCached('req-error-2', new ArrayBuffer(64), 'b.ifc', 64);
+    assert.equal(await hasCached('req-error-2'), true, 'precondition: entry is present');
+
+    failNextRequest('count');
+    const has = await settleOrHang(hasCached('req-error-2'));
+    assert.equal(has.kind, 'resolved', 'hasCached must not reject');
+    assert.equal(has.kind === 'resolved' ? has.value : undefined, false, 'degrades to "not found", not a throw');
+
+    failNextRequest('getAll');
+    const stats = await settleOrHang(getCacheStats());
+    assert.equal(stats.kind, 'resolved', 'getCacheStats must not reject');
+    assert.deepEqual(
+      stats.kind === 'resolved' ? stats.value : undefined,
+      { entryCount: 0, totalSize: 0, entries: [] },
+      'degrades to an empty report, not a throw',
+    );
+
+    failNextRequest('delete');
+    const del = await settleOrHang(deleteCached('req-error-2'));
+    assert.equal(del.kind, 'resolved', 'deleteCached must not reject');
+    // The delete request errored, so the entry must still be there — deleteCached
+    // degraded (silently skipped), it did not silently "succeed" on a lie.
+    assert.equal(await hasCached('req-error-2'), true, 'entry survives the failed delete');
+
+    failNextRequest('clear');
+    const cleared = await settleOrHang(clearCache());
+    assert.equal(cleared.kind, 'resolved', 'clearCache must not reject');
+    assert.equal(await hasCached('req-error-2'), true, 'entry survives the failed clear');
+  });
+});

--- a/apps/viewer/src/services/ifc-cache.ts
+++ b/apps/viewer/src/services/ifc-cache.ts
@@ -339,7 +339,10 @@ export interface CacheEntryMeta {
 export async function getCached(key: string): Promise<CacheResult | null> {
   try {
     const tx = await beginTransaction('readonly');
-    return new Promise((resolve, reject) => {
+    // `return await` is load-bearing: a bare `return promise` inside a try
+    // hands the promise straight to the caller, so its rejection would bypass
+    // the catch below and break the load instead of degrading to a miss.
+    return await new Promise((resolve, reject) => {
       const store = tx.objectStore(STORE_NAME);
       const request = store.get(key);
 
@@ -465,7 +468,7 @@ export async function setCached(
 export async function hasCached(key: string): Promise<boolean> {
   try {
     const tx = await beginTransaction('readonly');
-    return new Promise((resolve, reject) => {
+    return await new Promise((resolve, reject) => {
       const store = tx.objectStore(STORE_NAME);
       const request = store.count(IDBKeyRange.only(key));
 
@@ -477,7 +480,8 @@ export async function hasCached(key: string): Promise<boolean> {
         reject(request.error);
       };
     });
-  } catch {
+  } catch (err) {
+    console.warn('[IFC Cache] Cache existence check failed; treating as a miss:', err);
     return false;
   }
 }
@@ -488,7 +492,7 @@ export async function hasCached(key: string): Promise<boolean> {
 export async function deleteCached(key: string): Promise<void> {
   try {
     const tx = await beginTransaction('readwrite');
-    return new Promise((resolve, reject) => {
+    return await new Promise((resolve, reject) => {
       const store = tx.objectStore(STORE_NAME);
       const request = store.delete(key);
 
@@ -506,7 +510,7 @@ export async function deleteCached(key: string): Promise<void> {
 export async function clearCache(): Promise<void> {
   try {
     const tx = await beginTransaction('readwrite');
-    return new Promise((resolve, reject) => {
+    return await new Promise((resolve, reject) => {
       const store = tx.objectStore(STORE_NAME);
       const request = store.clear();
 
@@ -531,7 +535,7 @@ export async function getCacheStats(): Promise<{
 }> {
   try {
     const tx = await beginTransaction('readonly');
-    return new Promise((resolve, reject) => {
+    return await new Promise((resolve, reject) => {
       const store = tx.objectStore(STORE_NAME);
       const request = store.getAll();
 
@@ -550,7 +554,8 @@ export async function getCacheStats(): Promise<{
 
       request.onerror = () => reject(request.error);
     });
-  } catch {
+  } catch (err) {
+    console.warn('[IFC Cache] Cache stats read failed; reporting an empty cache:', err);
     return { entryCount: 0, totalSize: 0, entries: [] };
   }
 }

--- a/apps/viewer/src/store/slices/chatSlice.test.ts
+++ b/apps/viewer/src/store/slices/chatSlice.test.ts
@@ -6,7 +6,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { buildErrorFeedbackContent } from './chatSlice.js';
 import { create } from 'zustand';
-import { createChatSlice, type ChatSlice } from './chatSlice.js';
+import { createChatSlice, __resetChatPersistWarningForTests, type ChatSlice } from './chatSlice.js';
 import { createPatchDiagnostic, createPreflightDiagnostic } from '../../lib/llm/script-diagnostics.js';
 import { DEFAULT_FREE_MODEL, DEFAULT_BYOK_MODEL } from '../../lib/llm/models.js';
 
@@ -253,3 +253,60 @@ test('removeChatAttachment only removes the targeted attachment id', () => {
   );
 });
 
+test('a chat-history persist failure warns exactly once per session, not per message', () => {
+  // Storage that rejects ONLY the messages key: the model / panel-visible
+  // preference writes must still succeed, so this exercises the persist path
+  // rather than making the module see no storage at all.
+  const original = globalThis.localStorage;
+  const store = new Map<string, string>();
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        if (key.includes('messages')) throw new Error('QuotaExceededError');
+        store.set(key, value);
+      },
+      removeItem: (key: string) => { store.delete(key); },
+    },
+  });
+  const originalWarn = console.warn;
+  const warnings: unknown[][] = [];
+  console.warn = (...args: unknown[]) => { warnings.push(args); };
+
+  try {
+    __resetChatPersistWarningForTests();
+    const useChatStore = create<ChatSlice>()((...args) => createChatSlice(...args));
+    for (let i = 0; i < 5; i += 1) {
+      useChatStore.getState().addChatMessage({
+        id: `m-${i}`,
+        role: 'user',
+        content: `message ${i}`,
+        createdAt: Date.now(),
+      });
+    }
+
+    // Premise: the stub really is selective — non-message writes succeed and
+    // only the messages key is refused. Without this, a stub that rejected
+    // EVERY write would make the module see no storage at all and the test
+    // would pass for the wrong reason.
+    globalThis.localStorage.setItem('probe-key', 'ok');
+    assert.equal(store.get('probe-key'), 'ok', 'premise: non-message writes succeed');
+    assert.throws(() => globalThis.localStorage.setItem('x-messages-x', 'v'), /Quota/);
+    assert.equal(
+      [...store.keys()].some((k) => k.includes('messages')),
+      false,
+      'premise: the messages key was never written',
+    );
+    // In-memory conversation is unaffected — only durability is lost.
+    assert.equal(useChatStore.getState().chatMessages.length, 5);
+
+    assert.equal(warnings.length, 1, 'exactly one warning for five failed writes');
+    assert.match(String(warnings[0][0]), /Could not persist chat history/);
+    assert.ok(warnings[0][1] instanceof Error, 'the error is bound into the log');
+  } finally {
+    console.warn = originalWarn;
+    Object.defineProperty(globalThis, 'localStorage', { configurable: true, value: original });
+    __resetChatPersistWarningForTests();
+  }
+});

--- a/apps/viewer/src/store/slices/chatSlice.ts
+++ b/apps/viewer/src/store/slices/chatSlice.ts
@@ -201,6 +201,14 @@ function loadStoredMessages(userId: string | null): ChatMessage[] {
   }
 }
 
+/** One-shot latch for the persist-failure warning (see persistMessages). */
+let persistWarned = false;
+
+/** Reset the persist-failure latch. Test-only seam. */
+export function __resetChatPersistWarningForTests(): void {
+  persistWarned = false;
+}
+
 /** Persist messages to localStorage. */
 function persistMessages(messages: ChatMessage[], userId: string | null) {
   try {
@@ -216,7 +224,20 @@ function persistMessages(messages: ChatMessage[], userId: string | null) {
       execResults: m.execResults ? Array.from(m.execResults.entries()) : undefined,
     }));
     localStorage.setItem(getMessagesStorageKey(userId), JSON.stringify(toStore));
-  } catch { /* quota exceeded — ignore */ }
+  } catch (err) {
+    // Non-fatal: the in-memory conversation is unaffected, but nothing will
+    // survive a reload. Latched to once per session — this runs on EVERY
+    // message add / exec-result update, so an unlatched log would flood the
+    // console for the whole session once the quota is full.
+    if (!persistWarned) {
+      persistWarned = true;
+      console.warn(
+        '[chat] Could not persist chat history to localStorage (quota exceeded or storage blocked); '
+        + 'this conversation will not survive a reload. Further failures are not logged.',
+        err,
+      );
+    }
+  }
 }
 
 function trimChatMessages(messages: ChatMessage[]): ChatMessage[] {


### PR DESCRIPTION
Second pass over `apps/viewer/src`. One real defect, and it is a language-level trap rather than a missing log.

## Update: rebased onto #2102 (merged as `55f78f05`)

`#2102` landed on main and added `withConnection`/`beginTransaction`, which retries once on `InvalidStateError` by reopening the connection. That makes "the memoised connection was closed" a **recoverable** condition, not a failure — so the original two tests (which induced the read failure by calling `db.close()`) went vacuous: `getCached` now returns the entry via the reopen, `hasCached` now returns `true`. Rebasing surfaced this immediately (both failed with `#2102`'s own `[IFC Cache] Connection was closed underneath the cache; reopening` log firing in between).

**The fix itself is still needed and is unchanged.** Main had (and this PR still closes) the same five bare `return new Promise(...)` inside a `try` — the rejection-escape on the `request.onerror` path, which `#2102` deliberately left alone (it only retries the synchronous `InvalidStateError` from `transaction()`; by the time a request exists, the transaction was already created, so there's nothing left to retry).

Both conflicting fixes are combined at all five sites: `#2102`'s `const tx = await beginTransaction(mode)` plus this PR's `return await new Promise(...)`. Verified: zero bare `return new Promise(` remain inside a `try` in `ifc-cache.ts` (`evictToFree`'s own bare `return new Promise` is fine — it isn't wrapped in a `try` itself, and its caller does `await` it), and `withConnection`/`beginTransaction`/the reopen path are intact.

**Tests re-targeted.** The two tests in `ifc-cache.read-failure.test.ts` no longer close the connection. They now force a `request.onerror` directly — by one-shot monkeypatching the relevant `IDBObjectStore.prototype` method to abort the transaction the instant the request is issued (a pending request whose transaction aborts fires `onerror` with `AbortError`, per spec, never `onsuccess`). This is the path `#2102`'s reopen cannot touch, since no `InvalidStateError` is ever thrown. Confirmed each test fails for the *right* reason, not merely "didn't throw": mutating any one of the five `return await new Promise(` back to a bare `return new Promise(` (verified file-copy restore afterward) makes the corresponding assertion fail — all five sites are pinned by these two tests, not just the two originally exercised.

`apps/viewer`: 2640 tests, 2638 passing (2 pre-existing skips), typecheck 34/34.

---

## `return new Promise` inside a `try` makes the catch dead code

Five async functions in `services/ifc-cache.ts` did `return new Promise(...)` **inside** a `try`. A bare `return promise` in an async function hands the promise straight to the caller, so the enclosing `catch` never runs on that promise's own rejection. Every one of those catch blocks was dead while its comment documented the opposite contract — `return null`, `return false`, warn-and-continue, zeros.

**The sibling write path is the evidence this was an oversight, not a design.** `setCached` carries:

```
// A cache write must NEVER break the load (AGENTS.md; task blocker #2)
```

and correctly uses `await new Promise`. The read path was left behind.

## Reachability — verified, not assumed

- `openDatabase()` memoises the connection in a module-level `dbPromise` and clears it **only on open error** — never when the connection is later closed (another tab's `versionchange`, or the browser reclaiming under storage pressure). *(Superseded by `#2102`, which now reopens on a closed connection — the read-failure route that matters post-rebase is `request.onerror`, not a closed connection; see the Update section above.)*
- `db.transaction()` on a closed connection throws `InvalidStateError` **synchronously inside the executor**, so the promise rejects and the rejection escapes.
- `await getCached(cacheKey)` at `useIfcLoader.ts:933` (`loadStage = 'cache-lookup'`) then throws out of `loadFile` into the outer catch at `:1857`. **The user sees "failed to load" for a file that would have parsed fine**, plus a `posthog.captureException`. `deleteCached` at `:952` is on the same path.

I also probed the transaction-abort variant: `tx.abort()` mid-request rejects with `AbortError` rather than hanging, so the same fix covers it — no speculative `tx.onabort` handlers added.

**Scope honesty:** `hasCached` and `getCacheStats` have **no callers** in the viewer, so those two are hardening. `getCached`, `deleteCached` and `clearCache` are live.

## Also: `chatSlice.ts:219`, one of the two you left open

Now warns **once per session** with the error bound — `persistMessages` runs on every message add and exec-result update, so an unlatched log would flood.

**This closes the silence, not the loss.** On quota exhaustion 50 messages with attachments still fail to persist. The real fix is a degradation strategy — strip attachments, or persist fewer messages — which is a product decision about what to drop, so it stays with you.

## Evidence (pre-rebase; the `ifc-cache` half is superseded — see the Update section at the top for the current mutation results)

Removing any one `await` fails that function's own test; **all five killed**. I re-ran the `getCached` one myself on the pushed tree (`TOTAL_AWAITS=5`, `AWAITS_LEFT=4` asserted, region re-read): its test fails, `hasCached` survives, restored 23/23. *(This ran against the pre-rebase tests, which closed the connection to induce failure — no longer valid post-`#2102`; the current tests induce failure via `request.onerror` instead, see the Update section.)*

**Anti-vacuity work, since two of today's traps were in the test's own stub:** the cache test asserted the entry is readable **before** closing the connection, so a later `null` meant "degraded to a miss" rather than "was never there" — the rewritten tests keep this same precondition-readability guard, just against `request.onerror` instead of `close()`. The chatSlice stub is proven **selective** — a non-messages write succeeds while a messages write throws — because a stub rejecting every `setItem` makes the module see no storage at all. (The chatSlice half of this PR is untouched by the rebase.)

Two mutation-harness misfires were caught rather than papered over: an anchor matched `store.delete(key)` inside `evictToFree`, and a `git checkout --` in the same loop silently reverted the fix. Detected via a printed `restored awaits: 0`, then redone with asserted counts and file-copy restore.

## Triage

480 `catch` clauses under `apps/viewer/src`; **81** empty-bodied, **205** strict (no log, no throw) — the strict reading reproduces the first pass's 206. 177 in scope after the skip list.

| category | n | verdict |
|---|---|---|
| storage preference read/write | 54 | benign, documented |
| `JSON.parse` of stored/foreign data | 24 | benign, defined default |
| pointer-capture / dispose / close | 14 | benign, idempotent |
| `fetch` fallbacks | 8 | benign, defined empty |
| render-loop / per-entity | 12 | benign, `setStatus`-surfaced |
| **IndexedDB** | **5** | **the defect above** |
| already surfaces via `setStatus`/`{error}`/`reject` | 60 | benign |

`hooks/ingest/federationAlign.ts:412` and `setCached` are worth citing as the house pattern — the first captures an error and *does* re-check it on both exits.

## Left for you

- **`clashSlice.ts:308/314/320`** — still open. `deleteClashPreset`, `setClashPresetEnabled` and `resetClashPresets` discard a `{ok:false}` `SaveResult` and `set(...)` unconditionally, so the UI reports success while storage refused. Their siblings return the result and only `set` when `ok`. Closing it means widening three `void` signatures, and `lib/clash/persistence.ts` is already being touched on `fix/clash-read-failure-destroys-data`.
- ~~`ifc-cache.ts`'s `dbPromise` is never cleared on a closed connection~~ — **done, by `#2102`** (merged as `55f78f05`): it now reopens once on `InvalidStateError` instead of staying dead for the tab's lifetime. See the Update section at the top.

2583 passing (was **2580** — the ~2595 figure in circulation is from a different base), typecheck 34/34. Strict count 205 → 202.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cache reliability when browser storage operations fail. Cache lookups, statistics, deletion, and clearing now complete gracefully instead of hanging or producing unhandled errors.
  - Chat history persistence failures no longer interrupt in-memory chat functionality.
  - Reduced repeated warning messages by displaying a persistence warning only once per session.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
