### PR TITLE
fix(data,cache,create,cli): four failures that rendered as legitimate results

### DIFF
--- a/.changeset/package-silent-catches-round2.md
+++ b/.changeset/package-silent-catches-round2.md
@@ -1,0 +1,27 @@
+---
+'@ifc-lite/data': patch
+'@ifc-lite/cache': patch
+'@ifc-lite/create': patch
+'@ifc-lite/cli': patch
+'@ifc-lite/geometry': patch
+---
+
+Stop four package-level failures from being reported as ordinary results.
+
+- `@ifc-lite/data` / `@ifc-lite/cache`: a List-typed property with no value
+  came back as `[]` — a real empty list — because the NULL string sentinel
+  resolved to `''` and the resulting `JSON.parse` throw was swallowed. NULL
+  now reads as `null`, matching the string branch beside it, and a genuinely
+  unparseable list value logs once (latched) before falling back to `[]`.
+- `@ifc-lite/create`: `extractWallSegmentsForStorey` silently defaulted to a
+  metre length-unit scale when unit extraction threw, mis-scaling every
+  extracted wall segment on a millimetre model. It now warns with the error,
+  matching `resolveSpatialAnchor` / `resolveDuplicateSource`.
+- `@ifc-lite/cli`: `ifc-lite schema` printed a reduced built-in schema as if
+  it were the full SDK surface when `@ifc-lite/sandbox/schema` could not be
+  loaded; it now says so on stderr. `--version` no longer reports a
+  hard-coded `0.4.0` when `package.json` is unreadable — it reports
+  `0.0.0-unknown` and explains why on stderr.
+- `@ifc-lite/geometry`: the shard and finalise paths that fall back from a
+  SharedArrayBuffer view to a materialised (file-sized) copy now say so once
+  per worker, matching the streaming-prepass path that already did.

--- a/.changeset/package-silent-catches-round2.md
+++ b/.changeset/package-silent-catches-round2.md
@@ -19,9 +19,11 @@ Stop four package-level failures from being reported as ordinary results.
   matching `resolveSpatialAnchor` / `resolveDuplicateSource`.
 - `@ifc-lite/cli`: `ifc-lite schema` printed a reduced built-in schema as if
   it were the full SDK surface when `@ifc-lite/sandbox/schema` could not be
-  loaded; it now says so on stderr. `--version` no longer reports a
-  hard-coded `0.4.0` when `package.json` is unreadable — it reports
-  `0.0.0-unknown` and explains why on stderr.
+  loaded; it now says so on stderr and exits non-zero (stdout is still pure
+  JSON, unchanged shape), so a piping caller that discards stderr still sees
+  the failure. `--version` no longer reports a hard-coded `0.4.0` when
+  `package.json` is unreadable — it reports `0.0.0-unknown` and explains why
+  on stderr.
 - `@ifc-lite/geometry`: the shard and finalise paths that fall back from a
   SharedArrayBuffer view to a materialised (file-sized) copy now say so once
   per worker, matching the streaming-prepass path that already did.

--- a/packages/cache/src/sections/properties-list-values.test.ts
+++ b/packages/cache/src/sections/properties-list-values.test.ts
@@ -1,0 +1,90 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Cache rehydration of List-typed property values.
+ *
+ * `valueString` is a Uint32Array, so the NULL sentinel -1 wraps to
+ * 4294967295 and `StringTable.get` answers `''`. The string branch of the
+ * cache's `getPropertyValue` guards against that so a NULL stays `null`; the
+ * List branch fed `''` straight into `JSON.parse` and swallowed the throw,
+ * so a property with no list came back from cache as a real empty list.
+ * Same defect and same fix as `@ifc-lite/data`'s property table.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { StringTable, PropertyValueType, propertyTableFromColumns } from '@ifc-lite/data';
+import { BufferWriter, BufferReader } from '../utils/buffer-utils.js';
+import {
+  writeProperties,
+  readProperties,
+  __resetListParseWarningLatch,
+} from './properties.js';
+
+const NULL_STRING_SENTINEL = 0xffffffff; // -1 written into a Uint32Array
+
+/**
+ * Build a one-column-per-field table of List rows and round-trip it through
+ * the cache section. Slot 0 of the string table must be the canonical empty
+ * string (`fromArray` inserts one otherwise and shifts every index), so
+ * payload strings start at index 1.
+ */
+function roundTripListRows(payloadStrings: string[], valueStringIndices: number[]) {
+  const strings = StringTable.fromArray(['', ...payloadStrings]);
+  const count = valueStringIndices.length;
+  const table = propertyTableFromColumns(
+    {
+      count,
+      entityId: Uint32Array.from(valueStringIndices.map((_, i) => 100 + i)),
+      psetName: new Uint32Array(count).fill(1),
+      psetGlobalId: new Uint32Array(count).fill(0),
+      propName: new Uint32Array(count).fill(2),
+      propType: new Uint8Array(count).fill(PropertyValueType.List),
+      valueString: Uint32Array.from(valueStringIndices),
+      valueReal: new Float64Array(count),
+      valueInt: new Int32Array(count),
+      valueBool: new Uint8Array(count).fill(255),
+      unitId: new Int32Array(count).fill(-1),
+    },
+    strings,
+  );
+
+  const writer = new BufferWriter();
+  writeProperties(writer, table);
+  return readProperties(new BufferReader(writer.build()), strings);
+}
+
+beforeEach(() => {
+  __resetListParseWarningLatch();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('cached List property values', () => {
+  it('round-trips a well-formed list', () => {
+    const restored = roundTripListRows(['Pset_Test', 'Tags', '["a","b"]'], [3]);
+    expect(restored.getPropertyValue(100, 'Pset_Test', 'Tags')).toEqual(['a', 'b']);
+  });
+
+  it('reports a NULL list as null, not as an empty list', () => {
+    const restored = roundTripListRows(['Pset_Test', 'Tags'], [NULL_STRING_SENTINEL]);
+    expect(restored.getPropertyValue(100, 'Pset_Test', 'Tags')).toBeNull();
+  });
+
+  it('warns once, with the error bound, when a cached list is not JSON', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const restored = roundTripListRows(['Pset_Test', 'Tags', '{not json'], [3, 3]);
+
+    expect(restored.getPropertyValue(100, 'Pset_Test', 'Tags')).toEqual([]);
+    expect(restored.getPropertyValue(101, 'Pset_Test', 'Tags')).toEqual([]);
+
+    const calls = warn.mock.calls.filter(
+      (args) => typeof args[0] === 'string' && args[0].includes('not valid JSON'),
+    );
+    expect(calls, 'expected exactly one latched warning').toHaveLength(1);
+    expect(calls[0][1]).toBeInstanceOf(Error);
+  });
+});

--- a/packages/cache/src/sections/properties.ts
+++ b/packages/cache/src/sections/properties.ts
@@ -11,6 +11,28 @@ import { comparePropertyValues, PropertyValueType } from '@ifc-lite/data';
 import { BufferWriter, BufferReader } from '../utils/buffer-utils.js';
 
 /**
+ * List-value parse failures are per-property on a cache-rehydration path, so
+ * the warning is latched: a corrupt cache would otherwise emit one line per
+ * row.
+ */
+let listParseWarningShown = false;
+
+/** @internal test seam — reset the once-per-process list-parse warning latch. */
+export function __resetListParseWarningLatch(): void {
+  listParseWarningShown = false;
+}
+
+function warnListParseFailureOnce(listStr: string, err: unknown): void {
+  if (listParseWarningShown) return;
+  listParseWarningShown = true;
+  console.warn(
+    `[cache] cached property list value is not valid JSON; reporting an empty ` +
+      `list (further occurrences suppressed). value=${JSON.stringify(listStr.slice(0, 120))}`,
+    err,
+  );
+}
+
+/**
  * Write PropertyTable to buffer
  * Format:
  *   - count: uint32
@@ -92,13 +114,23 @@ export function readProperties(reader: BufferReader, strings: StringTable): Prop
       case PropertyValueType.Logical:
         const boolVal = valueBool[idx];
         return boolVal === 255 ? null : boolVal === 1;
-      case PropertyValueType.List:
-        const listStr = strings.get(valueString[idx]);
+      case PropertyValueType.List: {
+        // Mirrors the string branch above (and @ifc-lite/data's
+        // `getPropertyValue`): the NULL sentinel -1 wraps to 4294967295 and
+        // `strings.get` answers '' for it, so without this guard a NULL list
+        // property was rehydrated from cache as `[]` — a real empty list —
+        // with the silent catch hiding the difference.
+        const li = valueString[idx];
+        if (!(li >= 0 && li < strings.count)) return null;
+        const listStr = strings.get(li);
+        if (listStr === '') return null;
         try {
           return JSON.parse(listStr);
-        } catch {
+        } catch (err) {
+          warnListParseFailureOnce(listStr, err);
           return [];
         }
+      }
       default:
         return null;
     }

--- a/packages/cli/src/commands/layer-push.ts
+++ b/packages/cli/src/commands/layer-push.ts
@@ -55,6 +55,8 @@ function errorOf(body: string): string {
     const parsed = JSON.parse(body) as { error?: string; reason?: string };
     return parsed.error ?? parsed.reason ?? body;
   } catch {
+    // Legitimately silent: this only formats an error the caller is already
+    // reporting. A non-JSON body is surfaced verbatim, so nothing is lost.
     return body;
   }
 }

--- a/packages/cli/src/commands/schema.invalid-export.test.ts
+++ b/packages/cli/src/commands/schema.invalid-export.test.ts
@@ -1,0 +1,70 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The third state of `@ifc-lite/sandbox/schema`: present, but unusable.
+ *
+ * `schema.test.ts` covers the import *throwing* and `schema.success.test.ts`
+ * covers it resolving correctly. Between them sits a partial or version-skewed
+ * `dist/` that resolves the module with `NAMESPACE_SCHEMAS` absent or the wrong
+ * shape. The import succeeds, so the `catch` never fires — and `schemas.map()`
+ * runs outside the `try`, so the command died on an uncaught TypeError with no
+ * fallback schema, no stderr warning and no exit code (maintainer finding on
+ * #2100).
+ *
+ * That is strictly worse than the silence this command was fixed for: the
+ * fallback, the warning and the non-zero exit are all bypassed at once.
+ *
+ * NOTE ON THE MOCK SHAPE, because the obvious one tests nothing. Mocking the
+ * module as `{}` makes vitest throw on access to an undefined export, so the
+ * `catch` fires for a reason that does not exist in Node ESM — where a missing
+ * named export simply reads as `undefined`. The test would then pass against
+ * the unfixed command. `{ NAMESPACE_SCHEMAS: undefined }` is what reproduces
+ * the real failure.
+ */
+
+import { describe, expect, it, vi, afterEach } from 'vitest';
+
+vi.mock('@ifc-lite/sandbox/schema', () => ({ NAMESPACE_SCHEMAS: undefined }));
+
+const { schemaCommand } = await import('./schema.js');
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('schemaCommand when the schema export is present but unusable', () => {
+  it('falls back, warns and exits non-zero instead of throwing', async () => {
+    const out: string[] = [];
+    const err: string[] = [];
+    vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+      out.push(String(chunk));
+      return true;
+    });
+    vi.spyOn(process.stderr, 'write').mockImplementation((chunk: unknown) => {
+      err.push(String(chunk));
+      return true;
+    });
+
+    const previousExitCode = process.exitCode;
+    try {
+      process.exitCode = 0;
+
+      // Must not throw — before the guard this rejected with
+      // "Cannot read properties of undefined (reading 'map')".
+      await expect(schemaCommand([])).resolves.toBeUndefined();
+
+      // All three signals the fallback path owes the caller.
+      expect(err.join('')).toContain('reduced');
+      expect(process.exitCode).toBe(1);
+
+      // stdout is still pure, well-formed JSON — the reduced schema.
+      const parsed = JSON.parse(out.join(''));
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed.length).toBeGreaterThan(0);
+    } finally {
+      process.exitCode = previousExitCode;
+    }
+  });
+});

--- a/packages/cli/src/commands/schema.success.test.ts
+++ b/packages/cli/src/commands/schema.success.test.ts
@@ -1,0 +1,80 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The other half of the `ifc-lite schema` exit-code contract.
+ *
+ * `schema.test.ts` mocks `@ifc-lite/sandbox/schema` to throw at module level,
+ * so every test in that file exercises the fallback branch and nothing there
+ * can observe the success path. That leaves the signal pinned in one
+ * direction only: adding `process.exitCode = 1` to the successful load keeps
+ * that whole file green (maintainer negative control on #2100).
+ *
+ * The resulting regression would be worse than the bug it guards. A degraded
+ * schema reported as success is wrong on the fallback path alone; an
+ * always-non-zero exit breaks EVERY invocation, so any CI step running
+ * `ifc-lite schema` fails outright — and the test written to protect the exit
+ * code would not notice.
+ *
+ * Same shape as the `persisted` gap closed on #2089: a one-directional
+ * assertion on a two-valued signal. This file supplies the other direction,
+ * which needs its own module mock and therefore its own file.
+ */
+
+import { describe, expect, it, vi, afterEach } from 'vitest';
+
+// A schema export that loads normally. Shape matches what the command reads:
+// `NAMESPACE_SCHEMAS[].{name,doc,methods[]}`.
+vi.mock('@ifc-lite/sandbox/schema', () => ({
+  NAMESPACE_SCHEMAS: [
+    {
+      name: 'query',
+      doc: 'Query entities',
+      methods: [{ name: 'byType', doc: 'Filter by IFC type', params: [], returns: 'Entity[]' }],
+    },
+  ],
+}));
+
+const { schemaCommand } = await import('./schema.js');
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('schemaCommand when the sandbox schema loads', () => {
+  it('leaves the exit code at 0 and writes nothing to stderr', async () => {
+    const out: string[] = [];
+    const err: string[] = [];
+    vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+      out.push(String(chunk));
+      return true;
+    });
+    vi.spyOn(process.stderr, 'write').mockImplementation((chunk: unknown) => {
+      err.push(String(chunk));
+      return true;
+    });
+
+    const previousExitCode = process.exitCode;
+    try {
+      process.exitCode = 0;
+
+      await schemaCommand([]);
+
+      // The success path must not borrow the failure signal.
+      expect(process.exitCode).toBe(0);
+      expect(err.join('')).toBe('');
+
+      // And it is genuinely the real schema being emitted, not the fallback
+      // reached without a warning — otherwise this would pass for the wrong
+      // reason if the mock ever stopped taking effect.
+      const parsed = JSON.parse(out.join(''));
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0]).toMatchObject({ namespace: 'query', description: 'Query entities' });
+    } finally {
+      // The test runner's own exit-status flag, not a per-test sandbox.
+      process.exitCode = previousExitCode;
+    }
+  });
+});

--- a/packages/cli/src/commands/schema.test.ts
+++ b/packages/cli/src/commands/schema.test.ts
@@ -63,4 +63,24 @@ describe('schemaCommand with the sandbox schema unavailable', () => {
     // The caught error must be named, not dropped.
     expect(warning).toContain('sandbox schema export unavailable');
   });
+
+  it('sets a non-zero exit code, since stderr alone is a channel a `schema | jq` caller discards', async () => {
+    const { out } = captureStdio();
+    const previousExitCode = process.exitCode;
+    try {
+      process.exitCode = 0;
+
+      await schemaCommand([]);
+
+      // stdout is still pure, well-formed JSON of the same shape — the exit
+      // code is the only thing that tells a piping caller the schema is
+      // truncated, not the real one.
+      expect(() => JSON.parse(out.join(''))).not.toThrow();
+      expect(process.exitCode).toBe(1);
+    } finally {
+      // Restore: this is the test *runner's* own exit-status flag, not a
+      // per-test sandbox — leaking `1` here would fail the whole vitest run.
+      process.exitCode = previousExitCode;
+    }
+  });
 });

--- a/packages/cli/src/commands/schema.test.ts
+++ b/packages/cli/src/commands/schema.test.ts
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `ifc-lite schema` must not present its reduced built-in fallback as the
+ * real API surface.
+ *
+ * The command exists so tools (and LLM agents) can discover the SDK. When
+ * `@ifc-lite/sandbox/schema` can't be imported — package not built, a
+ * version skew after a partial install — the command falls back to a small
+ * hand-maintained subset and prints it on stdout as valid JSON. Nothing
+ * distinguishes that from the full schema, so the consumer concludes the
+ * missing namespaces do not exist. The fallback stays; the silence goes.
+ */
+
+import { describe, expect, it, vi, afterEach } from 'vitest';
+
+// Stand in for a sandbox build whose schema export can't be read (stale or
+// partial `dist/`). A throwing getter reproduces the failure at the same
+// point the real one does — inside the command's `try` — while keeping the
+// module shape the command touches (`.NAMESPACE_SCHEMAS`) intact.
+vi.mock('@ifc-lite/sandbox/schema', () => ({
+  get NAMESPACE_SCHEMAS(): unknown {
+    throw new Error('sandbox schema export unavailable');
+  },
+}));
+
+const { schemaCommand } = await import('./schema.js');
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function captureStdio(): { out: string[]; err: string[] } {
+  const out: string[] = [];
+  const err: string[] = [];
+  vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+    out.push(String(chunk));
+    return true;
+  });
+  vi.spyOn(process.stderr, 'write').mockImplementation((chunk: unknown) => {
+    err.push(String(chunk));
+    return true;
+  });
+  return { out, err };
+}
+
+describe('schemaCommand with the sandbox schema unavailable', () => {
+  it('warns on stderr that the emitted schema is the reduced fallback', async () => {
+    const { out, err } = captureStdio();
+
+    await schemaCommand([]);
+
+    // stdout stays pure JSON — the fallback is still emitted.
+    const parsed = JSON.parse(out.join(''));
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed.length).toBeGreaterThan(0);
+
+    const warning = err.join('');
+    expect(warning, 'expected a stderr warning about the degraded schema').toContain('Warning');
+    expect(warning).toContain('reduced');
+    // The caught error must be named, not dropped.
+    expect(warning).toContain('sandbox schema export unavailable');
+  });
+});

--- a/packages/cli/src/commands/schema.ts
+++ b/packages/cli/src/commands/schema.ts
@@ -31,6 +31,10 @@ export async function schemaCommand(args: string[]): Promise<void> {
         `emitting a reduced built-in schema that omits namespaces and methods.\n`,
     );
     schemas = getStaticSchema();
+    // stderr is the one channel a `schema | jq` pipeline routinely discards;
+    // a non-zero exit is the signal such a caller can't ignore without
+    // opting out of error handling altogether. stdout stays pure JSON.
+    process.exitCode = 1;
   }
 
   const output = schemas.map(ns => ({

--- a/packages/cli/src/commands/schema.ts
+++ b/packages/cli/src/commands/schema.ts
@@ -19,8 +19,17 @@ export async function schemaCommand(args: string[]): Promise<void> {
   try {
     const mod = await import('@ifc-lite/sandbox/schema');
     schemas = mod.NAMESPACE_SCHEMAS;
-  } catch {
-    // Fallback: provide a static schema summary
+  } catch (err) {
+    // Fallback: a small hand-maintained subset of the real schema. Callers
+    // of `ifc-lite schema` are usually LLM tools discovering the API — being
+    // handed a truncated namespace list that looks authoritative is worse
+    // than being told the load failed, so say so on stderr (stdout stays
+    // pure JSON).
+    process.stderr.write(
+      `Warning: could not load the full SDK schema from @ifc-lite/sandbox/schema ` +
+        `(${err instanceof Error ? err.message : String(err)}); ` +
+        `emitting a reduced built-in schema that omits namespaces and methods.\n`,
+    );
     schemas = getStaticSchema();
   }
 

--- a/packages/cli/src/commands/schema.ts
+++ b/packages/cli/src/commands/schema.ts
@@ -18,6 +18,18 @@ export async function schemaCommand(args: string[]): Promise<void> {
   let schemas: any[];
   try {
     const mod = await import('@ifc-lite/sandbox/schema');
+    // The import succeeding does not mean the export is usable. A partial or
+    // skewed `dist/` can resolve the module with `NAMESPACE_SCHEMAS` absent
+    // (`undefined` under Node ESM) or the wrong shape, and `schemas.map(...)`
+    // below runs OUTSIDE this try — so without the check the command dies on
+    // an uncaught TypeError with no fallback, no warning and no exit code,
+    // which is a worse outcome than the silence this command was fixed for.
+    // Throwing here routes it through the catch that already does all three.
+    if (!Array.isArray(mod.NAMESPACE_SCHEMAS)) {
+      throw new TypeError(
+        `NAMESPACE_SCHEMAS is ${mod.NAMESPACE_SCHEMAS === undefined ? 'missing' : 'not an array'}`,
+      );
+    }
     schemas = mod.NAMESPACE_SCHEMAS;
   } catch (err) {
     // Fallback: a small hand-maintained subset of the real schema. Callers

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -42,25 +42,15 @@ import { extCommand } from './commands/ext.js';
 import { layerCommand } from './commands/layer.js';
 import { refCommand } from './commands/ref.js';
 import { gymCommand } from './commands/gym.js';
-import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { readCliVersion } from './version.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-function getVersion(): string {
-  try {
-    // Try to read from package.json (works in both src/ and dist/)
-    const pkgPath = join(__dirname, '..', 'package.json');
-    const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
-    return pkg.version ?? '0.4.0';
-  } catch {
-    return '0.4.0';
-  }
-}
-
-const VERSION = getVersion();
+// package.json sits one level above both `src/` and `dist/`.
+const VERSION = readCliVersion(join(__dirname, '..', 'package.json'));
 
 const HELP = `
   ifc-lite v${VERSION} — BIM toolkit for the terminal

--- a/packages/cli/src/version.test.ts
+++ b/packages/cli/src/version.test.ts
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { readCliVersion, UNKNOWN_VERSION } from './version.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function captureStderr(): string[] {
+  const err: string[] = [];
+  vi.spyOn(process.stderr, 'write').mockImplementation((chunk: unknown) => {
+    err.push(String(chunk));
+    return true;
+  });
+  return err;
+}
+
+describe('readCliVersion', () => {
+  it('returns the declared version and stays quiet', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ifc-lite-version-'));
+    const pkgPath = join(dir, 'package.json');
+    writeFileSync(pkgPath, JSON.stringify({ name: '@ifc-lite/cli', version: '9.9.9' }));
+    const err = captureStderr();
+
+    expect(readCliVersion(pkgPath)).toBe('9.9.9');
+    expect(err.join('')).toBe('');
+  });
+
+  it('reports an unreadable manifest on stderr instead of inventing a version', () => {
+    const missing = join(mkdtempSync(join(tmpdir(), 'ifc-lite-version-')), 'package.json');
+    const err = captureStderr();
+
+    expect(readCliVersion(missing)).toBe(UNKNOWN_VERSION);
+    const warning = err.join('');
+    expect(warning, 'expected a stderr warning about the unreadable manifest').toContain('Warning');
+    // The caught error must be named, not dropped.
+    expect(warning).toContain('ENOENT');
+  });
+
+  it('reports a manifest with no version rather than reporting a wrong one', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ifc-lite-version-'));
+    const pkgPath = join(dir, 'package.json');
+    writeFileSync(pkgPath, JSON.stringify({ name: '@ifc-lite/cli' }));
+    const err = captureStderr();
+
+    expect(readCliVersion(pkgPath)).toBe(UNKNOWN_VERSION);
+    expect(err.join('')).toContain('no "version"');
+  });
+});

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The CLI's own version, read from its `package.json` at startup.
+ *
+ * Kept out of `index.ts` so the read can be tested without executing the
+ * CLI's top-level `main()`.
+ */
+
+import { readFileSync } from 'node:fs';
+
+/** Reported when `package.json` can't be read — deliberately not a plausible
+ * version number, so a bug report never carries a fabricated one. */
+export const UNKNOWN_VERSION = '0.0.0-unknown';
+
+/**
+ * Read `version` from the package manifest at `pkgPath`.
+ *
+ * A failure here is a broken install (missing/unreadable/corrupt
+ * `package.json`), not a normal condition: it used to fall back to a
+ * hard-coded `'0.4.0'`, which by 0.22.0 meant `--version` confidently
+ * reported a version the binary had not been for eighteen releases. Report
+ * the failure on stderr and return a value that reads as unknown.
+ */
+export function readCliVersion(pkgPath: string): string {
+  try {
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8')) as { version?: string };
+    if (typeof pkg.version === 'string' && pkg.version.length > 0) return pkg.version;
+    process.stderr.write(
+      `Warning: ${pkgPath} declares no "version"; reporting ${UNKNOWN_VERSION}.\n`,
+    );
+    return UNKNOWN_VERSION;
+  } catch (err) {
+    process.stderr.write(
+      `Warning: could not read the CLI version from ${pkgPath} ` +
+        `(${err instanceof Error ? err.message : String(err)}); ` +
+        `reporting ${UNKNOWN_VERSION}.\n`,
+    );
+    return UNKNOWN_VERSION;
+  }
+}

--- a/packages/create/src/in-store/extract-walls-unit-scale.test.ts
+++ b/packages/create/src/in-store/extract-walls-unit-scale.test.ts
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * A length-unit extraction failure must not be silent.
+ *
+ * `extractWallSegmentsForStorey` scales every segment it emits by the
+ * model's length-unit scale. When the extraction throws it falls back to
+ * 1.0 (metres) — correct for a metre model, silently 1000x wrong for a
+ * millimetre one, which collapses the panel's metre-based snap tolerance
+ * and yields garbage segments with no indication anything went wrong.
+ * The two write-side siblings (`resolve-anchor.ts`, `resolve-source.ts`)
+ * already warn on exactly this failure; this pins the read side to match.
+ */
+
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import type { IfcDataStore } from '@ifc-lite/parser';
+
+vi.mock('@ifc-lite/parser', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@ifc-lite/parser')>();
+  return {
+    ...actual,
+    extractLengthUnitScale: () => {
+      throw new Error('unit table unreadable');
+    },
+  };
+});
+
+const { extractWallSegmentsForStorey } = await import('./extract-walls.js');
+
+/**
+ * Minimal store that exercises the unit block and then finds no dividers.
+ * `source` must be non-empty (the unit block is guarded on it) and the
+ * index lookups the divider walk performs must all be present, or the
+ * test would pass for the wrong reason (never reaching the catch).
+ */
+function makeStore(): IfcDataStore {
+  return {
+    source: new TextEncoder().encode("ISO-10303-21;\nDATA;\nENDSEC;\nEND-ISO-10303-21;\n"),
+    entityIndex: { byId: new Map(), byType: new Map() },
+    entities: { getTypeName: () => undefined },
+  } as unknown as IfcDataStore;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('extractWallSegmentsForStorey: length-unit extraction failure', () => {
+  it('warns with the error bound instead of silently defaulting to metres', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = extractWallSegmentsForStorey(makeStore(), 1);
+
+    // The fallback itself is unchanged — metres.
+    expect(result.lengthUnitScale).toBe(1.0);
+
+    const call = warn.mock.calls.find(
+      (args) => typeof args[0] === 'string' && args[0].includes('length unit scale'),
+    );
+    expect(call, 'expected a console.warn naming the length-unit failure').toBeDefined();
+    // The caught error must be bound, not dropped.
+    expect(call?.[1]).toBeInstanceOf(Error);
+    expect((call?.[1] as Error).message).toBe('unit table unreadable');
+  });
+});

--- a/packages/create/src/in-store/extract-walls.ts
+++ b/packages/create/src/in-store/extract-walls.ts
@@ -147,7 +147,15 @@ export function extractWallSegmentsForStorey(
     try {
       lengthUnitScale = extractLengthUnitScale(store.source, store.entityIndex);
       if (!Number.isFinite(lengthUnitScale) || lengthUnitScale <= 0) lengthUnitScale = 1.0;
-    } catch {
+    } catch (error) {
+      // Keep the metre fallback, but don't hide the failure — a wrong scale
+      // silently mis-scales every extracted segment (a millimetre model read
+      // as metres yields coords like 31614, collapsing the snap tolerance).
+      // Mirrors resolve-anchor.ts / resolve-source.ts on the write side.
+      console.warn(
+        'extractWallSegmentsForStorey: failed to extract length unit scale; defaulting to metres',
+        error,
+      );
       lengthUnitScale = 1.0;
     }
   }

--- a/packages/create/src/in-store/extract-walls.ts
+++ b/packages/create/src/in-store/extract-walls.ts
@@ -148,10 +148,19 @@ export function extractWallSegmentsForStorey(
       lengthUnitScale = extractLengthUnitScale(store.source, store.entityIndex);
       if (!Number.isFinite(lengthUnitScale) || lengthUnitScale <= 0) lengthUnitScale = 1.0;
     } catch (error) {
-      // Keep the metre fallback, but don't hide the failure — a wrong scale
-      // silently mis-scales every extracted segment (a millimetre model read
-      // as metres yields coords like 31614, collapsing the snap tolerance).
-      // Mirrors resolve-anchor.ts / resolve-source.ts on the write side.
+      // Keep the metre fallback, but don't hide a THROWN failure — a wrong
+      // scale silently mis-scales every extracted segment (a millimetre model
+      // read as metres yields coords like 31614, collapsing the snap
+      // tolerance). Mirrors resolve-anchor.ts / resolve-source.ts.
+      //
+      // Deliberately NOT claiming the case is covered: extractLengthUnitScale
+      // returns 1.0 in band for most failures rather than throwing — 11
+      // `return 1.0` paths against 2 warnings — so no missing IFCPROJECT, no
+      // UnitsInContext, or a malformed unit declaration reaches this catch at
+      // all. Those still read as metres, silently. Fixing that means either
+      // warning on the in-band paths or returning null for "unknown", and the
+      // function has 7+ callers, so it is tracked separately rather than
+      // widened here.
       console.warn(
         'extractWallSegmentsForStorey: failed to extract length unit scale; defaulting to metres',
         error,

--- a/packages/data/src/property-table-list-values.test.ts
+++ b/packages/data/src/property-table-list-values.test.ts
@@ -1,0 +1,94 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * List-typed property values: a NULL is not an empty list, and an
+ * unparseable one is not silence.
+ *
+ * `valueString` is a Uint32Array, so the NULL sentinel -1 wraps to
+ * 4294967295 and `StringTable.get` answers `''` for it. The string branch of
+ * `getPropertyValue` already rejects out-of-range indices so a NULL stays
+ * `null`; the List branch fed `''` straight into `JSON.parse`, whose throw
+ * was swallowed and rendered as `[]`. A caller asking "does this element
+ * declare a list?" was told "yes, and it's empty".
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { StringTable } from './string-table.js';
+import { PropertyValueType } from './types.js';
+import {
+  propertyTableFromColumns,
+  __resetListParseWarningLatch,
+  type PropertyTableColumns,
+} from './property-table.js';
+
+const NULL_STRING_SENTINEL = 0xffffffff; // -1 written into a Uint32Array
+
+/**
+ * One row per string index supplied. `strings` seeds the table, so the
+ * indices in `valueString` address real slots — a double that omitted the
+ * string table would make every lookup fall out of range and pass for the
+ * wrong reason. Slot 0 must be the canonical empty string (`fromArray`
+ * inserts one otherwise and shifts every index), so callers pass 1-based
+ * payload strings and the leading '' is added here.
+ */
+function tableWithListValues(payloadStrings: string[], valueStringIndices: number[]) {
+  const strings = ['', ...payloadStrings];
+  const count = valueStringIndices.length;
+  const columns: PropertyTableColumns = {
+    count,
+    entityId: Uint32Array.from(valueStringIndices.map((_, i) => 100 + i)),
+    psetName: new Uint32Array(count).fill(1),
+    psetGlobalId: new Uint32Array(count).fill(0),
+    propName: new Uint32Array(count).fill(2),
+    propType: new Uint8Array(count).fill(PropertyValueType.List),
+    valueString: Uint32Array.from(valueStringIndices),
+    valueReal: new Float64Array(count),
+    valueInt: new Int32Array(count),
+    valueBool: new Uint8Array(count).fill(255),
+    unitId: new Int32Array(count).fill(-1),
+  };
+  return propertyTableFromColumns(columns, StringTable.fromArray(strings));
+}
+
+beforeEach(() => {
+  __resetListParseWarningLatch();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('getPropertyValue: List values', () => {
+  it('parses a well-formed list', () => {
+    // strings[0] = pset name, strings[1] = prop name, strings[2] = the value.
+    const table = tableWithListValues(['Pset_Test', 'Tags', '["a","b"]'], [3]);
+    expect(table.getPropertyValue(100, 'Pset_Test', 'Tags')).toEqual(['a', 'b']);
+  });
+
+  it('reports a NULL list as null, not as an empty list', () => {
+    const table = tableWithListValues(['Pset_Test', 'Tags'], [NULL_STRING_SENTINEL]);
+    expect(table.getPropertyValue(100, 'Pset_Test', 'Tags')).toBeNull();
+  });
+
+  it('reports an empty stored value as null, not as an empty list', () => {
+    const table = tableWithListValues(['Pset_Test', 'Tags', ''], [3]);
+    expect(table.getPropertyValue(100, 'Pset_Test', 'Tags')).toBeNull();
+  });
+
+  it('warns once, with the error bound, when a stored list is not JSON', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // Two corrupt rows: the latch must collapse them to a single warning.
+    const table = tableWithListValues(['Pset_Test', 'Tags', '{not json'], [3, 3]);
+
+    expect(table.getPropertyValue(100, 'Pset_Test', 'Tags')).toEqual([]);
+    expect(table.getPropertyValue(101, 'Pset_Test', 'Tags')).toEqual([]);
+
+    const calls = warn.mock.calls.filter(
+      (args) => typeof args[0] === 'string' && args[0].includes('not valid JSON'),
+    );
+    expect(calls, 'expected exactly one latched warning').toHaveLength(1);
+    expect(calls[0][1]).toBeInstanceOf(Error);
+  });
+});

--- a/packages/data/src/property-table.ts
+++ b/packages/data/src/property-table.ts
@@ -307,6 +307,27 @@ function addToIndex(index: Map<number, number[]>, key: number, value: number): v
   list.push(value);
 }
 
+/**
+ * List-value parse failures are per-property on a hot read path, so the
+ * warning is latched: a corrupt table would otherwise emit one line per row.
+ */
+let listParseWarningShown = false;
+
+/** @internal test seam — reset the once-per-process list-parse warning latch. */
+export function __resetListParseWarningLatch(): void {
+  listParseWarningShown = false;
+}
+
+function warnListParseFailureOnce(listStr: string, err: unknown): void {
+  if (listParseWarningShown) return;
+  listParseWarningShown = true;
+  console.warn(
+    `[data] property list value is not valid JSON; reporting an empty list ` +
+      `(further occurrences suppressed). value=${JSON.stringify(listStr.slice(0, 120))}`,
+    err,
+  );
+}
+
 function getPropertyValue(table: PropertyTable, idx: number, strings: StringTableType): PropertyValue {
   const type = table.propType[idx];
   
@@ -329,10 +350,19 @@ function getPropertyValue(table: PropertyTable, idx: number, strings: StringTabl
       return boolVal === 255 ? null : boolVal === 1;
     }
     case PropertyValueType.List: {
-      const listStr = strings.get(table.valueString[idx]);
+      // Same NULL handling as the string branch above: `valueString` is a
+      // Uint32Array, so the -1 sentinel wraps to 4294967295 and `strings.get`
+      // answers '' for it. Without this guard a NULL list property came back
+      // as `[]` — an empty list is a value, and the silent catch below made
+      // that indistinguishable from a real one.
+      const si = table.valueString[idx];
+      if (!(si >= 0 && si < strings.count)) return null;
+      const listStr = strings.get(si);
+      if (listStr === '') return null;
       try {
         return JSON.parse(listStr);
-      } catch {
+      } catch (err) {
+        warnListParseFailureOnce(listStr, err);
         return [];
       }
     }

--- a/packages/export/src/lod1-generator.ts
+++ b/packages/export/src/lod1-generator.ts
@@ -77,6 +77,11 @@ function buildFallbackGeometryFromLod0(lod0: Lod0Json): { meshes: MeshData[]; fa
     try {
       meshes.push(buildBoxMeshFromAabb(el.bbox.min, el.bbox.max, el.expressID));
     } catch {
+      // Legitimately silent: `buildBoxMeshFromAabb` is pure arithmetic over
+      // `el.bbox`, which `generateLod0` always populates, so this is
+      // defence-in-depth against a malformed LOD0 rather than a runtime path.
+      // The caller's `meta.failedElements` already lists every element on the
+      // fallback path, so a dropped box is not additionally hidden.
       failed.push(el.expressID);
     }
   }

--- a/packages/geometry/src/geometry.worker.ts
+++ b/packages/geometry/src/geometry.worker.ts
@@ -717,6 +717,26 @@ function materialiseSharedBytes(sharedBuffer: SharedArrayBuffer): Uint8Array {
 }
 
 /**
+ * SAB-view rejection is a property of the runtime, not of one shard: if
+ * wasm-bindgen refuses one view it refuses them all, and every retry
+ * materialises a *file-sized* copy in this worker. The shard entry points are
+ * called once per slice, so the notice is latched — once per worker, not once
+ * per shard. The streaming-prepass paths warn on their own (they run once per
+ * load); this only covers the shard/finalise paths that were silent.
+ */
+let sabViewFallbackWarned = false;
+function warnSabViewFallbackOnce(context: string, err: unknown): void {
+  if (sabViewFallbackWarned) return;
+  sabViewFallbackWarned = true;
+  console.warn(
+    `[Worker] ${context} rejected the SAB view ` +
+      `(${err instanceof Error ? err.message : String(err)}); retrying with a ` +
+      `materialised copy — each retry allocates a full copy of the file ` +
+      `(further occurrences suppressed)`,
+  );
+}
+
+/**
  * Per-load processing session shared by the legacy `process` path and the
  * streaming `stream-*` path. Holds the metadata (RTC, voids, styles) and
  * the per-mesh accumulators between successive `stream-chunk` calls.
@@ -1323,8 +1343,9 @@ async function handleMessage(e: MessageEvent<GeometryWorkerRequest>): Promise<vo
         let res;
         try {
           res = styleApi.resolveStyledItemsShard(viewSharedBytes(sharedBuffer), spans);
-        } catch {
+        } catch (err) {
           // SAB-view rejection fallback (see scan-shard above).
+          warnSabViewFallbackOnce('resolve-styles-shard', err);
           res = styleApi.resolveStyledItemsShard(materialiseSharedBytes(sharedBuffer), spans);
         }
         (self as unknown as Worker).postMessage(
@@ -1423,8 +1444,9 @@ async function handleMessage(e: MessageEvent<GeometryWorkerRequest>): Promise<vo
       let payload;
       try {
         payload = callFinalize(viewSharedBytes(m.sharedBuffer));
-      } catch {
+      } catch (err) {
         // SAB-view rejection fallback (see scan-shard above).
+        warnSabViewFallbackOnce('finalize-prepass-styles', err);
         payload = callFinalize(materialiseSharedBytes(m.sharedBuffer));
       }
       (self as unknown as Worker).postMessage({ type: 'styles-final', payload });
@@ -1485,9 +1507,10 @@ async function handleMessage(e: MessageEvent<GeometryWorkerRequest>): Promise<vo
       let shard;
       try {
         shard = scanApi.scanEntityIndexShard(view, rangeStart, rangeEnd);
-      } catch {
+      } catch (err) {
         // Some runtimes reject SAB-backed views at the wasm boundary (same
         // fallback the streaming pre-pass ships) — retry with a copy.
+        warnSabViewFallbackOnce('scan-entity-index-shard', err);
         shard = scanApi.scanEntityIndexShard(materialiseSharedBytes(sharedBuffer), rangeStart, rangeEnd);
       }
       (self as unknown as Worker).postMessage(

--- a/packages/ids/src/audit/ifc-schema/index.ts
+++ b/packages/ids/src/audit/ifc-schema/index.ts
@@ -724,6 +724,11 @@ async function resolveEntityCandidates(
           .filter((e) => rx.test(e.name.toUpperCase()) || rx.test(e.name))
           .map((e) => e.name);
       } catch {
+        // Empty means "no candidates resolved", and the one caller skips the
+        // pset-applicability cross-check in that case rather than reporting a
+        // pass. Bad patterns are already reported by the coherence audit; a
+        // failure to load the schema entity list is reported by every other
+        // check in this file, all of which need it.
         return [];
       }
     }

--- a/packages/ids/src/facets/entity-facet.ts
+++ b/packages/ids/src/facets/entity-facet.ts
@@ -266,6 +266,10 @@ export function getMatchingEntityTypes(
         const regex = new RegExp(`^${constraint.pattern}$`, 'i');
         return allTypes.filter((t) => regex.test(t));
       } catch {
+        // Legitimately silent: an uncompilable pattern matches no entity type,
+        // and the IDS audit reports the bad pattern itself under
+        // W_REGEX_UNVERIFIED / the coherence regex check. Warning here would
+        // duplicate that per candidate-type resolution.
         return [];
       }
     default:

--- a/packages/mcp/src/viewer-manager.ts
+++ b/packages/mcp/src/viewer-manager.ts
@@ -201,6 +201,10 @@ export class ViewerManager {
     try {
       parsed = JSON.parse(payload) as typeof parsed;
     } catch {
+      // Legitimately silent: the viewer's SSE stream carries frames this
+      // client does not model (and comment/keepalive lines). A frame we can't
+      // parse is one we don't act on — dropping it loses nothing, and logging
+      // would fire per frame on an unrelated producer.
       return;
     }
     if (parsed.action === 'picked' && typeof parsed.expressId === 'number') {
@@ -215,6 +219,9 @@ export class ViewerManager {
       try {
         globalId = new EntityNode(model.store, expressId).globalId || undefined;
       } catch {
+        // Legitimately silent: GlobalId is an optional enrichment of the
+        // selection event. Its absence is already representable (`undefined`)
+        // and the selection is still reported with expressId + ifcType.
         globalId = undefined;
       }
     }

--- a/packages/mutations/src/csv-connector.ts
+++ b/packages/mutations/src/csv-connector.ts
@@ -486,6 +486,9 @@ export class CsvConnector {
         try {
           return JSON.parse(value);
         } catch {
+          // Legitimately silent: two accepted CSV encodings for a list value,
+          // JSON first then semicolon-separated. A non-JSON cell is the normal
+          // second form, not a failure.
           return value.split(';').map((s) => s.trim());
         }
 

--- a/packages/server-bin/src/binary.ts
+++ b/packages/server-bin/src/binary.ts
@@ -71,6 +71,9 @@ export async function isBinaryCached(): Promise<boolean> {
     const currentVersion = await getPackageVersion();
     return cachedVersion === currentVersion;
   } catch {
+    // Legitimately silent: an unreadable version sidecar means "not cached",
+    // which triggers a fresh download — the same, safe outcome as a genuine
+    // cache miss. The download path reports its own failures.
     return false;
   }
 }
@@ -227,6 +230,10 @@ export async function downloadBinary(onProgress?: ProgressCallback): Promise<str
         downloaded = true;
         break;
       } catch {
+        // Legitimately silent: these are speculative URL shapes, and a miss on
+        // one is the expected case. The alternates that were tried are printed
+        // above; if none work, the `if (!downloaded)` below throws naming the
+        // original download failure.
         continue;
       }
     }

--- a/packages/viewer/src/server.ts
+++ b/packages/viewer/src/server.ts
@@ -108,6 +108,11 @@ async function resolveWasmDir(): Promise<string> {
     return resolvePackageDirFromModuleUrl(entryUrl);
   } catch {
     // Fallback: resolve from the sibling @ifc-lite/wasm package directory.
+    // Legitimately silent: `import.meta.resolve` throws on runtimes that
+    // don't implement it and in bundles where the specifier isn't resolvable,
+    // both of which the workspace-relative layout covers. A genuinely missing
+    // wasm directory surfaces as a 404 on the asset request, which is
+    // reported there.
     return resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', 'wasm');
   }
 }


### PR DESCRIPTION
Second sweep, over the packages not yet covered. The headline is exactly the shape this exercise was aimed at.

## 1. A NULL list property was reported as a real empty list — in two packages

`packages/data/src/property-table.ts:331` and `packages/cache/src/sections/properties.ts:117`. `valueString` is a `Uint32Array`, so the `-1` NULL sentinel wraps to `4294967295`; `StringTable.get` answers `''` for any out-of-range index; `JSON.parse('')` throws straight into `catch { return [] }`.

A caller asking *"does this element declare a list?"* was told **"yes, and it is empty."**

**The branch immediately above already guards this**, with a comment saying *"so a genuine NULL property value stays null instead of becoming `''`"*. The `List` branch two lines below did not — and the same pair exists in two packages.

## 2. A silent length-unit fallback its own siblings already warn about

`packages/create/src/in-store/extract-walls.ts:150` pinned `lengthUnitScale` to 1.0 on failure. On a millimetre model that leaves coordinates like 31614 and collapses the panel's metre-based snap tolerance — garbage geometry, no signal.

`resolve-anchor.ts:50` and `resolve-source.ts:158` `console.warn` on the **identical** failure, with the comment *"don't hide the failure — a wrong scale emits silently mis-sized geometry"*. `resolve-anchor` even says it *"mirrors the read-side conversion in extract-walls.ts"*. The read side never got the fix.

## 3. A truncated capability list printed as the API

`packages/cli/src/commands/schema.ts:22` — on any failure importing `@ifc-lite/sandbox/schema` (unbuilt package, partial install, version skew) it silently substituted a hand-maintained **6-namespace** subset and printed it to stdout as valid JSON. The documented consumer is *"LLM tools to discover available commands"*, which then conclude the missing namespaces do not exist.

## 4. `--version` lied by 18 releases

`packages/cli/src/index.ts:58` — `catch { return '0.4.0' }` with the package at `0.22.0`. Low reachability, but it is the version-mismatch-hiding shape and it poisons bug reports.

## Verdict on the three packages checked for fabricated passes — clean

Worth reporting the negative rather than padding:

- **`clash`**: 2 catches, **both already `console.warn` with the error bound**. Neither can turn a failure into "no collisions" — the clash engine itself has **no catches at all**.
- **`ids`**: **no audit reports "pass" because it failed.** The two `return []` sites (`entity-facet.ts:268`, `audit/ifc-schema/index.ts:726`) are a *missed cross-check*, and bad patterns are reported separately via `W_REGEX_UNVERIFIED`; `:726`'s sole caller **skips** the applicability check on an empty list rather than emitting a pass. Commented, not changed.
- **`query`**: cleanup with comments; `isAvailable → false` is correct.

## The geometry leftovers

The three silent SAB-view fallbacks get a once-per-worker latch. They run **N times per model**, which is why they could not simply copy their warning sibling at `:1456` (once per load). **Log-only, and explicitly not mutation-tested** — `geometry.worker.ts` has no message-handler harness across the package's 19 test files, and I am not claiming one.

## Evidence

Removing the NULL guard fails **both** list tests — I re-ran that myself on the pushed tree (`REPLACEMENTS=1`, region re-read): 2 failed / 79 passed, restored 81/81. The latch mutations each produce 2 warnings where 1 is asserted.

**A vacuous test was caught in my own fixture**, and it is worth naming because it is the fifth of the day: `StringTable.fromArray` **prepends `''`** when slot 0 is not the canonical empty string, shifting every index — so two "expects null" cases would have passed for the wrong reason, via a fall-through rather than the guard. Building the leading `''` explicitly is why the guard-removal mutation now fails 2 tests rather than 1.

**Behaviour changes**, both RED-tested: a NULL `List` property reads `null` instead of `[]`; `--version` reports `0.0.0-unknown` when the manifest is unreadable.

data 81 passing (was 77), cache 45 (was 42), cli 264 (was 260), create 119 (was 118), geometry 189 unchanged. `turbo typecheck` green across 31 tasks.

One pre-existing failure, verified not mine: `mcp/src/tools/export-usd.test.ts` asserts `/var/…` against macOS's `/private/var/…` realpath. Restoring the pristine file from HEAD reproduces it identically.

## Triage

181 catches across the swept packages; **9** empty-bodied, **84** by the wider "mentions no reporting call" reading — a deliberate superset that includes sites surfacing via `process.stderr.write`, `fatal()` or an `errors[]` array, which turned out to be the majority. `drawing-2d`, `lens`, `encoding`, `merge`, `spatial`, `solar`, `embed-protocol` and `wasm` source have **zero** catch blocks.

Ten sites where silence is correct now carry a one-line reason so the next sweep skips them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of null, empty, and malformed list property values, with clearer one-time warnings.
  - CLI schema generation now reports fallback failures while still producing valid output.
  - CLI version detection now identifies missing or invalid version information.
  - Wall-unit extraction failures now provide diagnostic warnings while retaining the metre fallback.
  - Geometry processing reports SharedArrayBuffer compatibility fallbacks once per worker.

- **Documentation**
  - Clarified expected error-handling behavior across several command-line, import, export, and runtime workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->