### PR TITLE
fix(viewer): only commit a clash preset change that actually persisted

### DIFF
--- a/apps/viewer/src/components/viewer/ClashSettingsDialog.tsx
+++ b/apps/viewer/src/components/viewer/ClashSettingsDialog.tsx
@@ -32,7 +32,7 @@ import { cn } from '@/lib/utils';
 import { toast } from '@/components/ui/toast';
 import { useViewerStore } from '@/store';
 import { matchesSelector, type ClashSeverity } from '@ifc-lite/clash';
-import { exportPresets, importPresets, type ClashPreset } from '@/lib/clash/persistence';
+import { exportPresets, importPresets, type ClashPreset, type SaveResult } from '@/lib/clash/persistence';
 
 const SEVERITY: Record<ClashSeverity, { label: string; color: string }> = {
   critical: { label: 'Critical', color: '#f7768e' },
@@ -141,6 +141,13 @@ export function ClashSettingsDialog({ trigger }: ClashSettingsDialogProps) {
     [importClashPresets],
   );
 
+  // Delete / toggle / reset only commit when the write landed (clashSlice), so
+  // a refused write leaves the row, the switch and the rule set exactly as they
+  // were — all this has to add is the reason.
+  const reportSaveFailure = useCallback((result: SaveResult) => {
+    if (!result.ok) toast.error(result.message);
+  }, []);
+
   const enabledCount = useMemo(() => presets.filter((p) => p.enabled).length, [presets]);
 
   return (
@@ -239,7 +246,7 @@ export function ClashSettingsDialog({ trigger }: ClashSettingsDialogProps) {
                 <Plus className="h-3.5 w-3.5 mr-1" /> Add rule
               </Button>
               <div className="ml-auto flex items-center gap-1">
-                <Button variant="ghost" size="sm" className="h-7 px-2 text-xs" title="Reset to the built-in rules" onClick={resetPresets}>
+                <Button variant="ghost" size="sm" className="h-7 px-2 text-xs" title="Reset to the built-in rules" onClick={() => reportSaveFailure(resetPresets())}>
                   <RotateCcw className="h-3.5 w-3.5" />
                 </Button>
                 <Button variant="ghost" size="sm" className="h-7 px-2 text-xs" title="Export rules" onClick={() => exportPresets(presets)}>
@@ -275,7 +282,7 @@ export function ClashSettingsDialog({ trigger }: ClashSettingsDialogProps) {
                       !p.enabled && 'opacity-55',
                     )}
                   >
-                    <Switch checked={p.enabled} onCheckedChange={(v) => setPresetEnabled(p.id, v)} />
+                    <Switch checked={p.enabled} onCheckedChange={(v) => reportSaveFailure(setPresetEnabled(p.id, v))} />
                     <span className="h-2 w-2 shrink-0 rounded-full" style={{ background: SEVERITY[p.severity].color }} />
                     <div className="min-w-0 flex-1">
                       <div className="truncate text-xs font-medium">
@@ -292,7 +299,7 @@ export function ClashSettingsDialog({ trigger }: ClashSettingsDialogProps) {
                     {p.builtin ? (
                       <span className="w-6" />
                     ) : (
-                      <Button variant="ghost" size="icon" className="h-6 w-6" title="Delete" onClick={() => deletePreset(p.id)}>
+                      <Button variant="ghost" size="icon" className="h-6 w-6" title="Delete" onClick={() => reportSaveFailure(deletePreset(p.id))}>
                         <Trash2 className="h-3 w-3" />
                       </Button>
                     )}

--- a/apps/viewer/src/store/slices/clashSlice.presets.test.ts
+++ b/apps/viewer/src/store/slices/clashSlice.presets.test.ts
@@ -1,0 +1,235 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Preset CRUD must only commit what actually persisted.
+ *
+ * `createClashPreset` / `updateClashPreset` / `importClashPresets` already
+ * gate their `set` on `savePresets(...).ok`; `deleteClashPreset`,
+ * `setClashPresetEnabled` and `resetClashPresets` used to discard the
+ * `SaveResult` and commit unconditionally, so with storage refusing the write
+ * (quota, or storage blocked entirely) the panel showed the change as saved and
+ * it vanished on reload. These tests pin the gate on all three, and pin that a
+ * successful write still commits.
+ */
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import { createClashSlice, type ClashSlice } from './clashSlice.js';
+
+const PRESETS_KEY = 'ifc-lite-clash-presets';
+const SETTINGS_KEY = 'ifc-lite-clash-settings';
+
+/**
+ * A real, working storage that can be told to refuse writes to ONE key. Reads
+ * always work and every other key keeps writing, so the module under test still
+ * sees a functioning localStorage: a stub that rejected every `setItem` would
+ * make the whole persistence layer look absent and pass for the wrong reason.
+ */
+class MemoryStorage {
+  private store = new Map<string, string>();
+  /** Key whose `setItem` throws, mimicking a quota / blocked-storage refusal. */
+  failKey: string | null = null;
+  /** Every successful write, in order (lets a test prove nothing was persisted). */
+  writes: string[] = [];
+  getItem(key: string): string | null {
+    return this.store.get(key) ?? null;
+  }
+  setItem(key: string, value: string): void {
+    if (key === this.failKey) throw new DOMException('quota', 'QuotaExceededError');
+    this.store.set(key, value);
+    this.writes.push(key);
+  }
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+  get length(): number {
+    return this.store.size;
+  }
+  key(i: number): string | null {
+    return [...this.store.keys()][i] ?? null;
+  }
+}
+
+const g = globalThis as { localStorage?: unknown };
+
+const CUSTOM_ID = 'custom-seeded-1';
+const BUILTIN_ID = 'MEPxSTR'; // first entry of CLASH_RULE_PRESETS
+
+/** Seed storage with one custom preset so `buildInitialPresets()` loads it. */
+function seedStoredCustom(storage: MemoryStorage): void {
+  storage.setItem(
+    PRESETS_KEY,
+    JSON.stringify({
+      schemaVersion: 1,
+      presets: [
+        {
+          id: CUSTOM_ID,
+          name: 'Seeded custom',
+          description: '',
+          severity: 'major',
+          selectorA: 'IfcWall',
+          selectorB: 'IfcDoor',
+          enabled: true,
+        },
+      ],
+    }),
+  );
+  storage.writes.length = 0; // the seed is setup, not a write under test
+}
+
+describe('ClashSlice preset CRUD - only commit what persisted', () => {
+  let storage: MemoryStorage;
+  let state: ClashSlice;
+
+  const build = () => {
+    const setState = (
+      partial: Partial<ClashSlice> | ((s: ClashSlice) => Partial<ClashSlice>),
+    ) => {
+      state = { ...state, ...(typeof partial === 'function' ? partial(state) : partial) };
+    };
+    state = createClashSlice(setState, () => state, {} as never);
+  };
+
+  beforeEach(() => {
+    storage = new MemoryStorage();
+    g.localStorage = storage;
+    seedStoredCustom(storage);
+    build();
+  });
+
+  it('the stub is selective: only the presets key refuses writes', () => {
+    storage.failKey = PRESETS_KEY;
+    assert.throws(() => storage.setItem(PRESETS_KEY, 'x'));
+    storage.setItem(SETTINGS_KEY, 'y');
+    assert.strictEqual(storage.getItem(SETTINGS_KEY), 'y');
+    // ...and the slice really did load the seeded custom through the real path.
+    assert.ok(state.clashPresets.some((p) => p.id === CUSTOM_ID));
+  });
+
+  // ── deleteClashPreset ──────────────────────────────────────────────────────
+
+  it('deleteClashPreset keeps the preset listed when the write is refused', () => {
+    storage.failKey = PRESETS_KEY;
+    const result = state.deleteClashPreset(CUSTOM_ID);
+    assert.ok(
+      state.clashPresets.some((p) => p.id === CUSTOM_ID),
+      'a delete that did not persist must not disappear from the list',
+    );
+    assert.deepStrictEqual(storage.writes, []);
+    assert.strictEqual(result.ok, false);
+    assert.ok(!result.ok && result.message.length > 0);
+  });
+
+  it('deleteClashPreset commits and reports ok when the write succeeds', () => {
+    const result = state.deleteClashPreset(CUSTOM_ID);
+    assert.deepStrictEqual(result, { ok: true });
+    assert.ok(!state.clashPresets.some((p) => p.id === CUSTOM_ID));
+    assert.deepStrictEqual(storage.writes, [PRESETS_KEY]);
+  });
+
+  it('deleteClashPreset is a silent no-op for a built-in / unknown id', () => {
+    storage.failKey = PRESETS_KEY; // would throw if it tried to persist
+    assert.deepStrictEqual(state.deleteClashPreset(BUILTIN_ID), { ok: true });
+    assert.deepStrictEqual(state.deleteClashPreset('nope'), { ok: true });
+    assert.deepStrictEqual(storage.writes, []);
+    assert.ok(state.clashPresets.some((p) => p.id === BUILTIN_ID));
+  });
+
+  // ── setClashPresetEnabled ──────────────────────────────────────────────────
+
+  it('setClashPresetEnabled leaves the toggle unchanged when the write is refused', () => {
+    storage.failKey = PRESETS_KEY;
+    const result = state.setClashPresetEnabled(BUILTIN_ID, false);
+    assert.strictEqual(
+      state.clashPresets.find((p) => p.id === BUILTIN_ID)?.enabled,
+      true,
+      'a toggle that did not persist must stay on',
+    );
+    assert.deepStrictEqual(storage.writes, []);
+    assert.strictEqual(result.ok, false);
+  });
+
+  it('setClashPresetEnabled commits and reports ok when the write succeeds', () => {
+    const result = state.setClashPresetEnabled(BUILTIN_ID, false);
+    assert.deepStrictEqual(result, { ok: true });
+    assert.strictEqual(state.clashPresets.find((p) => p.id === BUILTIN_ID)?.enabled, false);
+    assert.deepStrictEqual(storage.writes, [PRESETS_KEY]);
+  });
+
+  // ── resetClashPresets ──────────────────────────────────────────────────────
+
+  it('resetClashPresets keeps the custom rules when the write is refused', () => {
+    storage.failKey = PRESETS_KEY;
+    const result = state.resetClashPresets();
+    assert.ok(
+      state.clashPresets.some((p) => p.id === CUSTOM_ID),
+      'a reset that did not persist must not drop the customs from the list',
+    );
+    assert.deepStrictEqual(storage.writes, []);
+    assert.strictEqual(result.ok, false);
+  });
+
+  it('resetClashPresets commits and reports ok when the write succeeds', () => {
+    const result = state.resetClashPresets();
+    assert.deepStrictEqual(result, { ok: true });
+    assert.ok(!state.clashPresets.some((p) => p.id === CUSTOM_ID));
+    assert.ok(state.clashPresets.every((p) => p.builtin && p.enabled));
+    assert.deepStrictEqual(storage.writes, [PRESETS_KEY]);
+  });
+
+  // ── siblings: unchanged behaviour ──────────────────────────────────────────
+
+  it('createClashPreset still gates its commit on the SaveResult', () => {
+    storage.failKey = PRESETS_KEY;
+    const before = state.clashPresets.length;
+    const result = state.createClashPreset({
+      name: 'New rule',
+      severity: 'minor',
+      selectorA: 'IfcBeam',
+      selectorB: 'IfcSlab',
+    });
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(state.clashPresets.length, before);
+
+    storage.failKey = null;
+    assert.deepStrictEqual(
+      state.createClashPreset({ name: 'New rule', severity: 'minor', selectorA: 'IfcBeam', selectorB: 'IfcSlab' }),
+      { ok: true },
+    );
+    assert.strictEqual(state.clashPresets.length, before + 1);
+  });
+
+  it('updateClashPreset still gates its commit on the SaveResult', () => {
+    storage.failKey = PRESETS_KEY;
+    assert.strictEqual(state.updateClashPreset(CUSTOM_ID, { name: 'Renamed' }).ok, false);
+    assert.strictEqual(state.clashPresets.find((p) => p.id === CUSTOM_ID)?.name, 'Seeded custom');
+
+    storage.failKey = null;
+    assert.deepStrictEqual(state.updateClashPreset(CUSTOM_ID, { name: 'Renamed' }), { ok: true });
+    assert.strictEqual(state.clashPresets.find((p) => p.id === CUSTOM_ID)?.name, 'Renamed');
+  });
+
+  it('importClashPresets still gates its commit on the SaveResult', () => {
+    const incoming = [
+      {
+        id: 'custom-imported',
+        name: 'Imported',
+        description: '',
+        severity: 'info' as const,
+        selectorA: 'IfcPipeSegment',
+        selectorB: 'IfcWall',
+        enabled: true,
+        builtin: false,
+      },
+    ];
+    storage.failKey = PRESETS_KEY;
+    assert.strictEqual(state.importClashPresets(incoming).ok, false);
+    assert.ok(!state.clashPresets.some((p) => p.id === 'custom-imported'));
+
+    storage.failKey = null;
+    assert.deepStrictEqual(state.importClashPresets(incoming), { ok: true });
+    assert.ok(state.clashPresets.some((p) => p.id === 'custom-imported'));
+  });
+});

--- a/apps/viewer/src/store/slices/clashSlice.ts
+++ b/apps/viewer/src/store/slices/clashSlice.ts
@@ -155,13 +155,17 @@ export interface ClashSlice {
   setClashOverlapBox: (box: { min: [number, number, number]; max: [number, number, number] } | null) => void;
   setClashContactLines: (lines: { vertices: number[]; color: [number, number, number, number] } | null) => void;
   setShowClashRegionBox: (show: boolean) => void;
-  // Preset CRUD (persisted). create/update/import return a SaveResult so the UI
-  // can surface quota / cap failures; the rest are best-effort.
+  // Preset CRUD (persisted). Every one of these returns a SaveResult and only
+  // commits to the store when the write actually landed, so the panel can never
+  // show a rule change as applied that a refused write (quota, or storage
+  // blocked entirely) would undo on the next reload. Callers surface the
+  // failure via `result.message`.
   createClashPreset: (input: NewClashPreset) => SaveResult;
   updateClashPreset: (id: string, patch: Partial<Omit<ClashPreset, 'id' | 'builtin'>>) => SaveResult;
-  deleteClashPreset: (id: string) => void;
-  setClashPresetEnabled: (id: string, enabled: boolean) => void;
-  resetClashPresets: () => void;
+  /** No-op (and `{ ok: true }`) for a built-in or unknown id: nothing to persist. */
+  deleteClashPreset: (id: string) => SaveResult;
+  setClashPresetEnabled: (id: string, enabled: boolean) => SaveResult;
+  resetClashPresets: () => SaveResult;
   importClashPresets: (presets: ClashPreset[]) => SaveResult;
   /** Merge a patch into a clash's review (status and/or comment) and persist.
    *  Resetting to the default (open, empty comment) drops the entry. (#1468) */
@@ -303,22 +307,27 @@ export const createClashSlice: StateCreator<ClashSlice, [], [], ClashSlice> = (s
 
     deleteClashPreset: (id) => {
       const target = get().clashPresets.find((p) => p.id === id);
-      if (!target || target.builtin) return; // built-ins are reset, never deleted
+      // Built-ins are reset, never deleted. Nothing was asked of storage, so
+      // this is a success, not a failure the caller should report.
+      if (!target || target.builtin) return { ok: true };
       const next = get().clashPresets.filter((p) => p.id !== id);
-      savePresets(next);
-      set({ clashPresets: next });
+      const result = savePresets(next);
+      if (result.ok) set({ clashPresets: next });
+      return result;
     },
 
     setClashPresetEnabled: (id, enabled) => {
       const next = get().clashPresets.map((p) => (p.id === id ? { ...p, enabled } : p));
-      savePresets(next);
-      set({ clashPresets: next });
+      const result = savePresets(next);
+      if (result.ok) set({ clashPresets: next });
+      return result;
     },
 
     resetClashPresets: () => {
       const next = defaultPresets(); // drops all overrides + customs
-      savePresets(next);
-      set({ clashPresets: next });
+      const result = savePresets(next);
+      if (result.ok) set({ clashPresets: next });
+      return result;
     },
 
     importClashPresets: (presets) => {


### PR DESCRIPTION
Closes the item flagged on both #2085 and #2098 and deferred twice.

`deleteClashPreset`, `setClashPresetEnabled` and `resetClashPresets` called `savePresets(next)`, **discarded the `{ok:false}` `SaveResult`**, then `set(...)` unconditionally. The UI reported success while storage refused the write, and the change vanished on reload.

## Not a design question — the same file already answers it

`createClashPreset` (`:292-294`), `updateClashPreset` (`:299-301`) and `importClashPresets` (`:326-328`) each return the result and only `set` when `ok`, surfaced by `ClashSettingsDialog.tsx:116-120` and `:135-136`. The pattern is established **three times in the same file**; these three were left behind.

## Per action, following that precedent

- **delete** — the preset **stays listed**. Dropping it and having it reappear on reload is exactly the "user believes it saved" failure.
- **toggle** — the switch **does not move**. It is fully controlled by `p.enabled` from the store, so not committing *is* the revert: no local state to roll back, no flicker-then-snap-back.
- **reset** — **does not apply**. The most destructive of the three, and showing an empty rule set that silently resurrects on reload is the worst to get wrong.

One judgement beyond the three: `deleteClashPreset`'s early return for a built-in or unknown id reports `{ ok: true }`. Nothing was asked of storage, so a toast there would be a spurious error on a path that previously returned `void` silently. It has its own test and its own mutation.

**No caller is left unable to report** — all three have exactly one call site each, in `ClashSettingsDialog`, which already imports `toast`. Grep over `**/*.ts{,x}` found no others.

## Evidence

RED puts the **state** assertion before the `result.ok` check, so it proves the silent commit rather than just a missing return value:

```
not ok 2 - deleteClashPreset keeps the preset listed when the write is refused
  error: 'a delete that did not persist must not disappear from the list'
not ok 5 - setClashPresetEnabled leaves the toggle unchanged when the write is refused
not ok 7 - resetClashPresets keeps the custom rules when the write is refused
```

Tests 9–11 (the three siblings) **pass in RED**, proving they are untouched.

Dropping any one gate fails exactly its own test while the other five survive — I re-ran the delete one myself on the pushed tree (`REPLACEMENTS=1`, scoped to the function body since all six gate lines are now textually identical, gate count 6→5 confirmed): 1 failed / 10 passed, restored 11/11.

**Stub selectivity is asserted, not assumed** — test 1 checks the double fails `setItem` for the presets key **only**, that reads always work, that `SETTINGS_KEY` writes still succeed, and that the slice really loaded a seeded preset through the real `buildInitialPresets()` → `readStoredPresets()` path. That is the trap that produced three vacuous tests earlier today: a stub rejecting everything makes the module see no storage at all.

2591 passing (was 2580 — measured after building the workspace; unbuilt it reports a bogus 1717/82), typecheck 34/34.

## Same shape found and deliberately NOT fixed

`applyClashFlavorConfig` (`:365-378`) discards **both** `savePresets` and `saveSettings` after an unconditional `set(...)`, so activating a flavor whose write is refused shows the rule set applied and reverts on reload. Different callers and another `void` signature to widen, so it is flagged rather than folded in. The detection-tab setters (`:235-249`, `:265`) discard `saveSettings` too, but they are settings-only and commit-then-persist by design — worth a separate look.

## Sequencing

`lib/clash/persistence.ts` is **untouched**, so no conflict with #2089; this consumes `SaveResult` opaquely and only tests `.ok` / reads `.message`, so its `'unreadable'` reason needs nothing here. I did **not** import #2091's `lib/storage/save-result.ts` — it is not on main. `SaveResult` now has three near-identical definitions (clash, lens, scripts); worth unifying once those land, but not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clash preset changes now report persistence failures instead of failing silently.
  * Presets are only updated in the viewer after changes are successfully saved.
  * Resetting, enabling, disabling, and deleting presets now preserve the existing state when saving fails.

* **Tests**
  * Added coverage for successful and failed preset persistence scenarios, including create, update, import, reset, and deletion workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->