### PR TITLE
fix(viewer): reopen the model cache when its connection dies underneath us

### DIFF
--- a/apps/viewer/src/services/ifc-cache.test.ts
+++ b/apps/viewer/src/services/ifc-cache.test.ts
@@ -225,3 +225,172 @@ describe('ifc-cache LRU eviction correctness (blocker #2)', () => {
     assert.ok(c && await bytesEqual(c.buffer, patterned(2 * KB, 12)), 'survivor is uncorrupted');
   });
 });
+
+// ---------------------------------------------------------------------------
+// A connection closed underneath the memo (issue: the cache dies for the tab)
+// ---------------------------------------------------------------------------
+
+type OpenFactory = typeof indexedDB.open;
+
+/** Count `indexedDB.open` calls; returns a restore fn. */
+function countOpens(): { calls: () => number; restore: () => void } {
+  const factory = indexedDB as unknown as { open: OpenFactory };
+  const real = factory.open.bind(indexedDB) as OpenFactory;
+  let calls = 0;
+  factory.open = ((name: string, version?: number) => {
+    calls++;
+    return real(name, version);
+  }) as OpenFactory;
+  return { calls: () => calls, restore: () => { factory.open = real; } };
+}
+
+/** Replace `indexedDB.open` with one that always fails asynchronously. */
+function breakOpen(): { calls: () => number; restore: () => void } {
+  const factory = indexedDB as unknown as { open: OpenFactory };
+  const real = factory.open.bind(indexedDB) as OpenFactory;
+  let calls = 0;
+  factory.open = (() => {
+    calls++;
+    const request = {
+      error: new DOMException('simulated open failure', 'UnknownError'),
+      onerror: null as null | (() => void),
+      onsuccess: null,
+      onupgradeneeded: null,
+    };
+    setTimeout(() => request.onerror?.(), 0);
+    return request as unknown as IDBOpenDBRequest;
+  }) as OpenFactory;
+  return { calls: () => calls, restore: () => { factory.open = real; } };
+}
+
+/**
+ * Put the module's memoised connection into the state this suite is about: the
+ * connection object is still memoised but is closed, so `db.transaction()`
+ * throws `InvalidStateError` synchronously. Asserts that state is really
+ * reached, so none of the tests below can pass vacuously.
+ */
+async function closeMemoisedConnection(): Promise<IDBDatabase> {
+  const db = await openDatabase();
+  db.close();
+  assert.throws(
+    () => db.transaction(STORE_NAME_FOR_TEST, 'readonly'),
+    (err: unknown) => (err as DOMException).name === 'InvalidStateError',
+    'precondition: the memoised connection must now be dead',
+  );
+  return db;
+}
+
+// Mirrors the module-private DB_NAME / STORE_NAME.
+const STORE_NAME_FOR_TEST = 'models';
+const DB_NAME_FOR_TEST = 'ifc-lite-cache';
+
+describe('ifc-cache survives a connection closed underneath the memo', () => {
+  beforeEach(async () => {
+    await clearCache();
+    stubEstimateUnavailable();
+  });
+  afterEach(restoreNavigator);
+
+  it('a read after the connection closes still hits the cache (reopens)', async () => {
+    await setCached('live', patterned(4 * KB, 20), 'live.ifc', 4 * KB);
+    await closeMemoisedConnection();
+
+    const got = await getCached('live');
+    assert.ok(got, 'the read must reopen and hit, not degrade to a permanent miss');
+    assert.ok(await bytesEqual(got!.buffer, patterned(4 * KB, 20)));
+  });
+
+  it('a write after the connection closes still persists (reopens)', async () => {
+    await closeMemoisedConnection();
+
+    await setCached('after-close', patterned(4 * KB, 21), 'after-close.ifc', 4 * KB);
+    const got = await getCached('after-close');
+    assert.ok(got, 'the write must reopen rather than being silently skipped');
+    assert.ok(await bytesEqual(got!.buffer, patterned(4 * KB, 21)));
+  });
+
+  it('the cache stays usable for every later operation, not just the first', async () => {
+    await closeMemoisedConnection();
+    await setCached('one', patterned(2 * KB, 22), 'one.ifc', 2 * KB);
+    assert.ok(await getCached('one'));
+    await setCached('two', patterned(2 * KB, 23), 'two.ifc', 2 * KB);
+    assert.ok(await getCached('two'));
+    assert.ok(await getCached('one'), 'the first entry is still readable');
+  });
+
+  it('concurrent operations after a close share ONE reopen', async () => {
+    await setCached('shared', patterned(2 * KB, 24), 'shared.ifc', 2 * KB);
+    await closeMemoisedConnection();
+
+    const spy = countOpens();
+    try {
+      const results = await Promise.all([
+        getCached('shared'),
+        getCached('shared'),
+        getCached('shared'),
+        getCached('shared'),
+      ]);
+      assert.equal(spy.calls(), 1, 'four concurrent reads must collapse onto a single reopen');
+      for (const r of results) assert.ok(r, 'every concurrent read must succeed');
+    } finally {
+      spy.restore();
+    }
+  });
+
+  it('a healthy operation never reopens', async () => {
+    await setCached('healthy', patterned(2 * KB, 25), 'healthy.ifc', 2 * KB);
+    const spy = countOpens();
+    try {
+      assert.ok(await getCached('healthy'));
+      await setCached('healthy2', patterned(2 * KB, 26), 'healthy2.ifc', 2 * KB);
+      assert.ok(await getCached('healthy2'));
+      assert.equal(spy.calls(), 0, 'a live memoised connection is reused, never reopened');
+    } finally {
+      spy.restore();
+    }
+  });
+
+  it('another tab deleting the database (versionchange) neither blocks it nor kills the cache', async () => {
+    await setCached('vc', patterned(1 * KB, 29), 'vc.ifc', 1 * KB);
+    const db = await openDatabase();
+
+    // "Another tab" deletes the database. Our connection receives
+    // `versionchange`; if it does not close, the delete is BLOCKED forever.
+    const del = indexedDB.deleteDatabase(DB_NAME_FOR_TEST);
+    const outcome = await new Promise<string>((resolve) => {
+      const timer = setTimeout(() => resolve('blocked-or-hung'), 500);
+      del.onsuccess = () => { clearTimeout(timer); resolve('deleted'); };
+      del.onerror = () => { clearTimeout(timer); resolve('errored'); };
+    });
+    assert.equal(outcome, 'deleted', 'we must close on versionchange so another tab is not blocked');
+    assert.throws(
+      () => db.transaction(STORE_NAME_FOR_TEST, 'readonly'),
+      (err: unknown) => (err as DOMException).name === 'InvalidStateError',
+      'the connection really is closed after versionchange',
+    );
+
+    await setCached('after-vc', patterned(1 * KB, 30), 'after-vc.ifc', 1 * KB);
+    assert.ok(await getCached('after-vc'), 'the cache reopens and keeps working');
+  });
+
+  it('a database that cannot be opened at all does not retry unboundedly', async () => {
+    await closeMemoisedConnection();
+    const broken = breakOpen();
+    try {
+      // Each operation is bounded: it may reopen at most once, so a genuinely
+      // unopenable database costs one open attempt per op, never a loop.
+      assert.equal(await getCached('nope'), null, 'read degrades to a miss');
+      const afterRead = broken.calls();
+      assert.ok(afterRead <= 2, `bounded open attempts per read, got ${afterRead}`);
+
+      await assert.doesNotReject(setCached('nope', patterned(1 * KB, 27), 'nope.ifc', 1 * KB));
+      const afterWrite = broken.calls() - afterRead;
+      assert.ok(afterWrite <= 2, `bounded open attempts per write, got ${afterWrite}`);
+    } finally {
+      broken.restore();
+    }
+    // And the cache recovers once the database can be opened again.
+    await setCached('recovered', patterned(1 * KB, 28), 'recovered.ifc', 1 * KB);
+    assert.ok(await getCached('recovered'), 'cache works again after the outage');
+  });
+});

--- a/apps/viewer/src/services/ifc-cache.ts
+++ b/apps/viewer/src/services/ifc-cache.ts
@@ -59,6 +59,14 @@ export const QUOTA_HEADROOM_BYTES = 128 * 1024 * 1024;
 
 let dbPromise: Promise<IDBDatabase> | null = null;
 
+/**
+ * The connection `dbPromise` last resolved to. Kept alongside the memo so an
+ * invalidation can be IDENTITY-CHECKED: a caller that trips over a dead
+ * connection must only clear the memo if the memo still holds *that* dead
+ * connection, never one a concurrent caller has already reopened.
+ */
+let memoisedDb: IDBDatabase | null = null;
+
 /** Bytes a cache record occupies on disk (cache buffer + optional source). */
 function entryBytes(buffer: Blob | ArrayBuffer, sourceBuffer?: ArrayBuffer): number {
   const bufferBytes = buffer instanceof Blob ? buffer.size : buffer.byteLength;
@@ -175,13 +183,14 @@ export function openDatabase(): Promise<IDBDatabase> {
 
     request.onsuccess = () => {
       const db = request.result;
-      
+
       // Verify the object store exists (handles corrupted DB state)
       if (!db.objectStoreNames.contains(STORE_NAME)) {
         console.warn('[IFC Cache] Object store missing, recreating database...');
         db.close();
         dbPromise = null;
-        
+        memoisedDb = null;
+
         // Delete and recreate the database
         const deleteRequest = indexedDB.deleteDatabase(DB_NAME);
         deleteRequest.onsuccess = () => {
@@ -193,7 +202,26 @@ export function openDatabase(): Promise<IDBDatabase> {
         };
         return;
       }
-      
+
+      // A connection can go away underneath the memo. Drop it PROACTIVELY on
+      // the two events that announce it, so the next call opens a fresh one
+      // instead of handing out a dead handle:
+      //  - `versionchange`: another tab is upgrading/deleting the database. We
+      //    must close, or we block it; after our own close() no `close` event
+      //    fires, so invalidate here explicitly.
+      //  - `close`: the connection was closed ABNORMALLY (e.g. the browser
+      //    reclaiming storage), which is the case no code path can predict.
+      db.onversionchange = () => {
+        console.warn('[IFC Cache] Database version change requested elsewhere; closing connection');
+        db.close();
+        invalidateConnection(db);
+      };
+      db.onclose = () => {
+        console.warn('[IFC Cache] Database connection closed unexpectedly; will reopen on next use');
+        invalidateConnection(db);
+      };
+
+      memoisedDb = db;
       resolve(db);
     };
 
@@ -210,6 +238,83 @@ export function openDatabase(): Promise<IDBDatabase> {
   });
 
   return dbPromise;
+}
+
+/**
+ * Drop the memoised connection, but only if it is still `dead`. Concurrent
+ * callers all trip over the same dead connection; without this check the second
+ * one would clear the memo the first has already refilled, and we would open
+ * the database once per in-flight operation instead of once.
+ */
+function invalidateConnection(dead: IDBDatabase): void {
+  if (memoisedDb !== dead) return;
+  memoisedDb = null;
+  dbPromise = null;
+}
+
+/**
+ * A closed connection is the one failure that `openDatabase`'s memo cannot see:
+ * `IDBDatabase.transaction()` throws `InvalidStateError` SYNCHRONOUSLY once the
+ * connection is closed, and none of the operations below can produce that name
+ * any other way (an inactive/finished transaction throws
+ * `TransactionInactiveError`, a read-only write throws `ReadOnlyError`).
+ */
+function isClosedConnectionError(err: unknown): boolean {
+  return err instanceof Error && err.name === 'InvalidStateError';
+}
+
+/**
+ * Run `use` against the memoised connection, reopening ONCE if that connection
+ * turns out to be closed.
+ *
+ * `use` must be synchronous and must not have applied any persistent effect
+ * before it throws — the only failure treated as retryable is the synchronous
+ * `InvalidStateError` from `transaction()`, which means no transaction was ever
+ * created and therefore nothing was written. That is what makes the retry
+ * safe: it replays a no-op, never a half-applied write.
+ *
+ * Bounded on purpose: exactly one reopen per operation. If the fresh connection
+ * also fails (or the database cannot be opened at all) the error propagates to
+ * the caller's non-fatal handler — one broken database must not become an
+ * endless open loop.
+ */
+async function withConnection<T>(use: (db: IDBDatabase) => T): Promise<T> {
+  const db = await openDatabase();
+  try {
+    return use(db);
+  } catch (err) {
+    if (!isClosedConnectionError(err)) throw err;
+    console.warn('[IFC Cache] Connection was closed underneath the cache; reopening', err);
+    invalidateConnection(db);
+    return use(await openDatabase());
+  }
+}
+
+/**
+ * Begin a transaction on a live connection, reopening once if needed.
+ *
+ * The caller must use the returned transaction IMMEDIATELY: an IndexedDB
+ * transaction stays active only until control returns to the event loop, and
+ * every `await` on the path here settles within the same microtask checkpoint
+ * (either an already-memoised connection or the open event that just fired).
+ * Awaiting anything else between this call and the first request would
+ * deactivate it (`TransactionInactiveError`).
+ */
+function beginTransaction(mode: IDBTransactionMode): Promise<IDBTransaction> {
+  return withConnection((db) => db.transaction(STORE_NAME, mode));
+}
+
+/**
+ * A connection that was live a moment ago, for the callers that need the
+ * `IDBDatabase` itself (the quota guard opens its own transactions). The probe
+ * is an empty read-only transaction: it does no I/O, and creating it is exactly
+ * the operation that throws when the connection is closed.
+ */
+function liveConnection(): Promise<IDBDatabase> {
+  return withConnection((db) => {
+    db.transaction(STORE_NAME, 'readonly').abort();
+    return db;
+  });
 }
 
 export interface CacheResult {
@@ -233,9 +338,8 @@ export interface CacheEntryMeta {
  */
 export async function getCached(key: string): Promise<CacheResult | null> {
   try {
-    const db = await openDatabase();
+    const tx = await beginTransaction('readonly');
     return new Promise((resolve, reject) => {
-      const tx = db.transaction(STORE_NAME, 'readonly');
       const store = tx.objectStore(STORE_NAME);
       const request = store.get(key);
 
@@ -276,7 +380,10 @@ export async function setCached(
   meta?: CacheEntryMeta,
 ): Promise<void> {
   try {
-    const db = await openDatabase();
+    // A connection verified live, so a write does not silently skip just
+    // because the memo was holding a closed one (the quota guard below opens
+    // its own transactions, so it needs the connection, not a transaction).
+    const db = await liveConnection();
 
     // Quota/eviction guard (prerequisite for the mesh-only tier — entries can be
     // 100s of MB): refuse oversized records and LRU-evict older entries when the
@@ -301,7 +408,10 @@ export async function setCached(
       try {
         tx = db.transaction(STORE_NAME, 'readwrite');
       } catch (err) {
-        // e.g. InvalidStateError if the connection is closing.
+        // The connection was verified live above, so reaching here means it
+        // died inside the quota guard's await. Not retried: a retry would also
+        // re-run eviction, and a skipped write is a slow next load, not a
+        // failure. The next operation reopens.
         console.warn('[IFC Cache] Could not open write transaction; skipping cache write', err);
         done();
         return;
@@ -354,9 +464,8 @@ export async function setCached(
  */
 export async function hasCached(key: string): Promise<boolean> {
   try {
-    const db = await openDatabase();
+    const tx = await beginTransaction('readonly');
     return new Promise((resolve, reject) => {
-      const tx = db.transaction(STORE_NAME, 'readonly');
       const store = tx.objectStore(STORE_NAME);
       const request = store.count(IDBKeyRange.only(key));
 
@@ -378,9 +487,8 @@ export async function hasCached(key: string): Promise<boolean> {
  */
 export async function deleteCached(key: string): Promise<void> {
   try {
-    const db = await openDatabase();
+    const tx = await beginTransaction('readwrite');
     return new Promise((resolve, reject) => {
-      const tx = db.transaction(STORE_NAME, 'readwrite');
       const store = tx.objectStore(STORE_NAME);
       const request = store.delete(key);
 
@@ -397,9 +505,8 @@ export async function deleteCached(key: string): Promise<void> {
  */
 export async function clearCache(): Promise<void> {
   try {
-    const db = await openDatabase();
+    const tx = await beginTransaction('readwrite');
     return new Promise((resolve, reject) => {
-      const tx = db.transaction(STORE_NAME, 'readwrite');
       const store = tx.objectStore(STORE_NAME);
       const request = store.clear();
 
@@ -423,9 +530,8 @@ export async function getCacheStats(): Promise<{
   entries: Array<{ fileName: string; fileSize: number; createdAt: Date }>;
 }> {
   try {
-    const db = await openDatabase();
+    const tx = await beginTransaction('readonly');
     return new Promise((resolve, reject) => {
-      const tx = db.transaction(STORE_NAME, 'readonly');
       const store = tx.objectStore(STORE_NAME);
       const request = store.getAll();
 


### PR DESCRIPTION
The root cause behind the defect #2098 makes non-fatal.

`openDatabase()` memoises the connection in `dbPromise` and clears it **only** in `request.onerror`. Nothing clears it when the connection is later closed — by another tab's `versionchange`, or the browser reclaiming under storage pressure. After that, `db.transaction()` throws `InvalidStateError` synchronously and **every cache operation fails for the tab's lifetime**: the model cache silently stops working, and every load is a miss, forever.

#2098 stopped that breaking the load. This stops it happening.

## Design — two layers

Both extend the in-repo memo-reset idea (`duckdb-integration.ts:78`, `pointcloud/streaming/memo.ts`) for the part neither covers: **a memoised value going bad *after* it resolved**.

- **Proactive** — `db.onversionchange` closes and invalidates, so we stop blocking another tab's upgrade or delete; `db.onclose` covers an abnormal close.
- **Reactive** — `withConnection(use)` retries a synchronous `use(db)` once on `InvalidStateError`.

## The three concurrency decisions

**Concurrent callers share one reopen.** `invalidateConnection(dead)` is **identity-checked**, so of N callers tripping over the same dead handle the first clears the memo and the rest no-op, then all collapse onto one in-flight open. Asserted: 4 concurrent reads → `indexedDB.open` called **exactly once**.

**Detection is narrow.** Only the synchronous `InvalidStateError` from `transaction()` counts. Nothing else in these ops produces that name — an inactive transaction gives `TransactionInactiveError`, a read-only write gives `ReadOnlyError`. The proactive handlers mean the common cases never reach the throw at all.

**Exactly one reopen per operation.** A second failure propagates to the caller's non-fatal handler, so an unopenable database costs at most one extra open per op rather than a retry loop. The retry is idempotent because the only retryable failure happens **before a transaction exists** — nothing was written, so the replay replays a no-op.

**Deliberate non-coverage, documented at the catch:** if the connection dies inside `setCached`'s quota guard *after* the liveness probe, the write is skipped non-fatally rather than retried, because a retry would also re-run LRU eviction.

## Independently corroborates #2098

On `upstream/main` the "degrade to a miss" catch **does not fire** for anything inside the returned promise — `return new Promise(...)` inside a `try` does not route that promise's rejection to the `catch`. In RED that made `clearCache()` reject out of a `beforeEach`. This change removes that escape for the transaction path; the `request.onerror` path is #2098's and is left alone.

## Evidence

| mutation | result |
|---|---|
| kill the reactive reopen | **4 fail** |
| drop the identity check | 1 fail — the concurrency test, opens > 1 |
| drop `onversionchange` close+invalidate | 1 fail — another tab's delete blocked/hung |
| drop the liveness probe | 2 fail — both write paths |

I re-ran the first myself on the pushed tree (`REPLACEMENTS=1`, line re-read): 4 failed including *"the cache stays usable for every later operation, not just the first"*, restored 18/18.

**Negatives, all asserted:** healthy ops reopen **zero** times; an unopenable database degrades to `null`, does not reject on write, costs ≤2 opens per op, and **recovers** once open works again; another tab's `deleteDatabase` completes rather than blocking.

**Non-vacuity:** `closeMemoisedConnection()` asserts `db.transaction()` really throws `InvalidStateError` before each test proceeds, so a test cannot pass by never reaching the dead state. `fake-indexeddb` provides the real `versionchange`/blocked semantics — a one-event stub cannot express this, which is what defeated an earlier attempt on `recent-files.ts`.

18 passing in `ifc-cache.test.ts` (was 11).

## One measurement caveat, stated rather than papered over

The full-suite number from that worktree is **not** comparable: it had no `node_modules`, and with a borrowed install 80 test *files* fail to load on missing transitive deps (sampled: `Cannot find package 'jszip'` from `packages/parser`). Those 80 are identical before and after and unrelated, but a clean install is needed for a true total. The per-file numbers above were re-run against a proper install and are sound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
