### PR TITLE
fix(sandbox): reset the log budget per eval, not per sandbox

### DIFF
--- a/.changeset/sandbox-log-budget-per-eval.md
+++ b/.changeset/sandbox-log-budget-per-eval.md
@@ -1,0 +1,13 @@
+---
+"@ifc-lite/sandbox": patch
+---
+
+Reset the captured-log budget on every `eval()`, so one log-heavy script no longer silences every later script on the same sandbox.
+
+The bridge caps captured console output twice — by entry count (1000) and by cumulative serialized size (4 MB) — because `vm.dump` copies sandbox values onto the host heap, which the QuickJS memory limit does not bound. `eval()` clears the log buffer in place at the start of every run and hands each result its own copy, so the caps bound one run's output; but `totalBytes` and the `truncated` latch were closed over at construction and never reset. Once a script tripped either cap, `truncated` stayed `true` for the life of the sandbox and the console handlers returned immediately, so every subsequent `eval()` on that sandbox produced **no log entries at all** — not even the truncation marker, which is pushed only on the run that trips the cap.
+
+This affects embedders that reuse a sandbox across evals, which is the normal path for two of them: `bim.sandbox.eval()` keeps one `activeSandbox` alive across calls, and the extension host holds one sandbox per activated extension and re-enters it for every command and exporter invocation. (The viewer's script editor creates a fresh sandbox per run and was never affected.) The observable symptom was a script whose `console.log` calls appeared not to fire, with nothing to indicate the limit belonged to an earlier run.
+
+`buildConsole` now owns the reset: it returns a `resetLogs()` that empties the buffer *and* zeroes both counters, and `eval()` calls only that instead of clearing the array itself — the two can no longer drift apart. A single script that genuinely exceeds either cap is truncated exactly as before.
+
+**Embedder-visible:** captured output is now bounded per eval rather than per sandbox, so a long-lived sandbox can hand back up to 4 MB of logs per run instead of 4 MB in total. Embedders that retain every `ScriptResult` across many runs hold correspondingly more. `buildBridge()`, exported for advanced embedders, gains a `resetLogs` property on its return value; existing callers are unaffected.

--- a/docs/api/typescript.md
+++ b/docs/api/typescript.md
@@ -990,6 +990,8 @@ Scripting SDK: the `bim.*` API for BIM automation. `createBimContext` builds a `
 
 QuickJS-in-WASM sandboxed script execution: `createSandbox` / `Sandbox`, `buildBridge` (marshals the `bim.*` API across the sandbox boundary), and `transpileTypeScript`.
 
+`buildBridge` returns `{ logs, resetLogs, dispose }`. `resetLogs` is part of the contract, not an implementation detail: the console capture budget (byte total and entry count) is scoped to **one run**, so a caller driving `buildBridge` directly must invoke `resetLogs()` at the start of every run. Skip it and a script that exhausts the budget silences the logs of every later run on the same bridge. `Sandbox.eval` already does this for you — only direct `buildBridge` callers carry the obligation.
+
 ## @ifc-lite/extensions
 
 Extension manifest, capability grammar, and slot registry for user customization: `validateManifest`, `migrateManifest`, `SlotRegistry`, capability and `when`-clause evaluation, bundle and storage helpers.

--- a/packages/sandbox/src/bridge.ts
+++ b/packages/sandbox/src/bridge.ts
@@ -23,19 +23,22 @@ import { buildSchemaNamespaces, disposeSchemaNamespaceSession, type BridgeCallCo
 
 /**
  * Build the `bim` API object inside the QuickJS VM.
- * Returns captured log entries from console.* calls.
+ *
+ * Returns the captured log entries from console.* calls, plus `resetLogs` —
+ * the caller must invoke it at the start of every run, because the capture
+ * budget is scoped to one run (see `buildConsole`).
  */
 export function buildBridge(
   vm: QuickJSContext,
   sdk: BimContext,
   permissions: SandboxPermissions = {},
   context: BridgeCallContext,
-): { logs: LogEntry[]; dispose: () => void } {
+): { logs: LogEntry[]; resetLogs: () => void; dispose: () => void } {
   const perms = { ...DEFAULT_PERMISSIONS, ...permissions } as Required<SandboxPermissions>;
   const logs: LogEntry[] = [];
 
   // ── console.log / warn / error / info ──────────────────────
-  buildConsole(vm, logs);
+  const resetLogs = buildConsole(vm, logs);
 
   // ── bim global ─────────────────────────────────────────────
   // The handle is freed in a `finally`: if namespace construction throws,
@@ -53,6 +56,7 @@ export function buildBridge(
 
   return {
     logs,
+    resetLogs,
     dispose: () => {
       disposeSchemaNamespaceSession(context);
     },
@@ -61,7 +65,7 @@ export function buildBridge(
 
 // ── Console ──────────────────────────────────────────────────
 
-function buildConsole(vm: QuickJSContext, logs: LogEntry[]): void {
+function buildConsole(vm: QuickJSContext, logs: LogEntry[]): () => void {
   const consoleHandle = vm.newObject();
 
   // vm.dump copies sandbox strings onto the host JS heap, which is NOT bound by
@@ -72,6 +76,20 @@ function buildConsole(vm: QuickJSContext, logs: LogEntry[]): void {
   const MAX_TOTAL_BYTES = 4 * 1024 * 1024; // 4MB host budget for captured logs
   let totalBytes = 0;
   let truncated = false;
+
+  // The budget bounds *one run's* captured output: the buffer holds only the
+  // current run (`resetLogs` empties it, and each result gets a copy), and the
+  // eval timeout is what bounds how long a script has to fill it. So the
+  // counters must reset with the buffer — a sandbox is reused across evals
+  // (`bim.sandbox.eval`, and one sandbox per activated extension), and a
+  // latched `truncated` would otherwise silence every later script for the
+  // life of the sandbox (#2099). Resetting the buffer without the counters is
+  // exactly the bug, so both happen here and `eval()` calls only this.
+  const resetLogs = (): void => {
+    logs.length = 0;
+    totalBytes = 0;
+    truncated = false;
+  };
 
   try {
     for (const level of ['log', 'warn', 'error', 'info'] as const) {
@@ -105,4 +123,6 @@ function buildConsole(vm: QuickJSContext, logs: LogEntry[]): void {
   } finally {
     consoleHandle.dispose();
   }
+
+  return resetLogs;
 }

--- a/packages/sandbox/src/log-budget-reset.test.ts
+++ b/packages/sandbox/src/log-budget-reset.test.ts
@@ -1,0 +1,129 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Regression tests for the captured-log budget latching per sandbox (#2099).
+ *
+ * The bridge caps captured console output twice — by entry count
+ * (MAX_LOG_ENTRIES = 1000) and by cumulative serialized size
+ * (MAX_TOTAL_BYTES = 4MB) — because `vm.dump` copies sandbox values onto the
+ * host heap, which the QuickJS memory limit does not bound. `eval()` clears
+ * the log buffer at the start of every run, so the caps bound one script's
+ * output; the counters behind them used to live for the sandbox's lifetime,
+ * so one log-heavy script silenced every later script on the same sandbox.
+ *
+ * Every script here exhausts the budget by logging, never by allocating, so
+ * no test in this file can OOM-abort the shared WASM module.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { BimContext } from '@ifc-lite/sdk';
+import { createSandbox, type Sandbox } from './sandbox.js';
+
+/** The scripts under test never touch `bim`, so an empty context suffices. */
+const EMPTY_SDK = {} as unknown as BimContext;
+
+const TRUNCATION_MARKER = '[log output truncated: limit reached]';
+
+/** Mirrors bridge.ts — the caps are private, so the tests drive their edges. */
+const MAX_LOG_ENTRIES = 1000;
+
+/**
+ * Logs six 1 MB strings: four entries reach 4194320 bytes, just past the
+ * 4194304-byte budget, so the fifth call truncates. Returns the marker entry
+ * as proof the budget was actually reached — without it every assertion about
+ * the *next* eval would be vacuous.
+ */
+const EXHAUST_BYTE_BUDGET = logPayloads(6);
+
+/**
+ * A script that logs `count` 1 MB strings. Wrapped in an IIFE because the
+ * sandbox realm outlives the eval: a top-level `const` would make a second run
+ * of the same script fail with "redeclaration of 'payload'".
+ */
+function logPayloads(count: number): string {
+  return `(() => { const payload = "x".repeat(1048576); for (let i = 0; i < ${count}; i++) console.log(payload); })();\n1;`;
+}
+
+function logArgs(logs: readonly { args: unknown[] }[]): unknown[][] {
+  return logs.map((entry) => entry.args);
+}
+
+async function withSandbox<T>(run: (sandbox: Sandbox) => Promise<T>): Promise<T> {
+  const sandbox = await createSandbox(EMPTY_SDK);
+  try {
+    return await run(sandbox);
+  } finally {
+    sandbox.dispose();
+  }
+}
+
+describe('captured-log budget scope', () => {
+  it('does not let a byte-budget-exhausting script silence the next one', async () => {
+    await withSandbox(async (sandbox) => {
+      const first = await sandbox.eval(EXHAUST_BYTE_BUDGET, { typescript: false });
+      // The budget really was reached — otherwise this test proves nothing.
+      expect(first.logs).toHaveLength(5);
+      expect(first.logs[4]).toMatchObject({ level: 'warn', args: [TRUNCATION_MARKER] });
+
+      const second = await sandbox.eval('console.log("second"); 2;', { typescript: false });
+
+      expect(second.value).toBe(2);
+      expect(logArgs(second.logs)).toEqual([['second']]);
+    });
+  }, 60_000);
+
+  it('does not let an entry-cap-exhausting script silence the next one', async () => {
+    await withSandbox(async (sandbox) => {
+      const first = await sandbox.eval(
+        `for (let i = 0; i < ${MAX_LOG_ENTRIES + 5}; i++) console.log(i);\n1;`,
+        { typescript: false },
+      );
+      expect(first.logs).toHaveLength(MAX_LOG_ENTRIES + 1);
+      expect(first.logs[MAX_LOG_ENTRIES]).toMatchObject({ level: 'warn', args: [TRUNCATION_MARKER] });
+
+      const second = await sandbox.eval('console.log("second"); 2;', { typescript: false });
+
+      expect(logArgs(second.logs)).toEqual([['second']]);
+    });
+  }, 60_000);
+
+  it('keeps truncating a single script that genuinely exceeds the byte cap', async () => {
+    await withSandbox(async (sandbox) => {
+      const result = await sandbox.eval(EXHAUST_BYTE_BUDGET, { typescript: false });
+
+      expect(result.value).toBe(1);
+      expect(result.logs).toHaveLength(5);
+      expect(result.logs.slice(0, 4).map((entry) => (entry.args[0] as string).length)).toEqual([
+        1048576, 1048576, 1048576, 1048576,
+      ]);
+      expect(result.logs[4]).toMatchObject({ level: 'warn', args: [TRUNCATION_MARKER] });
+    });
+  }, 60_000);
+
+  it('charges each eval its own budget rather than accumulating across evals', async () => {
+    await withSandbox(async (sandbox) => {
+      // Three 1 MB entries per eval: under the 4 MB cap on its own, over it if
+      // the charge carried across evals. Repeated three times, so a carried
+      // charge would show up by the second or third run at the latest.
+      const script = logPayloads(3);
+      for (let run = 0; run < 3; run++) {
+        const result = await sandbox.eval(script, { typescript: false });
+        expect(result.logs).toHaveLength(3);
+        expect(logArgs(result.logs).flat().some((arg) => arg === TRUNCATION_MARKER)).toBe(false);
+      }
+    });
+  }, 60_000);
+
+  it('does not let an exhausting script silence an eval that throws', async () => {
+    await withSandbox(async (sandbox) => {
+      const first = await sandbox.eval(EXHAUST_BYTE_BUDGET, { typescript: false });
+      expect(first.logs[4]).toMatchObject({ args: [TRUNCATION_MARKER] });
+
+      await expect(
+        sandbox.eval('console.log("before throw"); throw new Error("boom");', { typescript: false }),
+      ).rejects.toMatchObject({ logs: [expect.objectContaining({ args: ['before throw'] })] });
+    });
+  }, 60_000);
+});

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -69,6 +69,12 @@ export class Sandbox {
   private runtime: QuickJSRuntime | null = null;
   private vm: QuickJSContext | null = null;
   private logs: LogEntry[] = [];
+  /**
+   * Clears the log buffer *and* the bridge's capture budget. Set by init();
+   * eval() calls it instead of emptying `logs` itself, so the budget can never
+   * again be left latched across runs (#2099).
+   */
+  private resetLogs: (() => void) | null = null;
   private config: Required<SandboxConfig>;
   private bridgeDispose: (() => void) | null = null;
   /** Mutable start time — updated by eval(), read by interrupt handler */
@@ -120,10 +126,11 @@ export class Sandbox {
       this.vm = this.runtime.newContext();
 
       // Build the bim API inside the sandbox
-      const { logs, dispose } = buildBridge(this.vm, this.sdk, this.config.permissions, {
+      const { logs, resetLogs, dispose } = buildBridge(this.vm, this.sdk, this.config.permissions, {
         sandboxSessionId: this.sessionId,
       });
       this.logs = logs;
+      this.resetLogs = resetLogs;
       this.bridgeDispose = dispose;
     } catch (err) {
       // dispose() is idempotent — it clears each field before freeing it, so
@@ -139,12 +146,13 @@ export class Sandbox {
    * Supports both JavaScript and TypeScript (TypeScript is type-stripped before execution).
    */
   async eval(code: string, options?: { filename?: string; typescript?: boolean }): Promise<ScriptResult> {
-    if (!this.vm) {
+    if (!this.vm || !this.resetLogs) {
       throw new Error('Sandbox not initialized. Call init() first.');
     }
 
-    // Clear previous logs
-    this.logs.length = 0;
+    // Clear the previous run's logs and, with them, the capture budget that
+    // bounds them — the two are one operation (see buildConsole).
+    this.resetLogs();
 
     // Transpile TypeScript — always strip types for safety.
     // The transpiler is a no-op for plain JavaScript, and the heuristic
@@ -319,6 +327,7 @@ export class Sandbox {
     const vm = this.vm;
     const runtime = this.runtime;
     this.bridgeDispose = null;
+    this.resetLogs = null;
     this.vm = null;
     this.runtime = null;
 


### PR DESCRIPTION
Closes #2099.

## The defect is worse than the issue states

#2099 says a later script "gets one `[log output truncated]` entry and nothing else". In fact the marker is pushed only on the run that trips the cap; **every later eval hits `if (truncated) return;` at the top of the handler and gets zero entries.** RED shows `expected [] to deeply equal [['second']]` — a completely empty array.

**Sandboxes really are reused**, verified on `upstream/main`:
- `packages/sdk/src/namespaces/sandbox.ts:150-158` — `eval()` reuses `this.activeSandbox` across every call.
- The extension host returns the cached activation record while `sandbox.isDisposed` is false (`host/runtime.ts:213-218`), and `host-commands.ts:136` / `host-exporters.ts:195` call `activation.sandbox.run(...)` per invocation, mapped to `sandbox.eval` at `sandbox-factory.ts:166`. One sandbox per activated extension, re-entered for every command.
- **Not affected:** `useSandbox.ts:184-224` creates a fresh sandbox per run and disposes it in `finally`.

`MAX_LOG_ENTRIES` had the same problem by a different route: its *counter* was already fine (it compares `logs.length`, cleared per eval), but tripping it set the same `truncated` latch and silenced later evals identically. That path has its own test and failed RED too.

## What the caps are for — which is what decides the fix

The comment at `bridge.ts:67-70` frames them against a single runaway script (`for(;;) console.log('x'.repeat(1e6))` before the timeout fires) — a **per-run** threat model. The code agrees: `eval()` clears the buffer every run, and each `ScriptResult`/`ScriptError` gets a **copy** (`sandbox.ts:282`, `:351`), so the sandbox itself never retains more than one run's logs.

So the per-sandbox `totalBytes` bounded nothing the sandbox holds — it only stopped later scripts from logging. It was simply missed when `this.logs.length = 0` was written.

**Reset per eval**, and made structurally hard to drift again: `buildConsole` now returns a `resetLogs()` that clears the buffer **and** both counters, and `eval()` calls only that rather than touching the array. A null `resetLogs` throws in the init guard rather than silently skipping the clear.

**The bound genuinely changes** — 4 MB per eval instead of 4 MB per sandbox-lifetime for an embedder retaining every `ScriptResult` — and the changeset says so.

**Deliberately not chosen:** keep it per-sandbox but surface the truncation. The bound it provides is illusory (an embedder can hold N results from N sandboxes anyway) and it leaves the silencing in place.

## Evidence

| mutation | result |
|---|---|
| `this.resetLogs()` → `this.logs.length = 0` (pre-fix) | **exactly the 4 cross-eval tests fail**, negative stays green |
| neutralise `totalBytes = 0` | 3 fail |
| neutralise `truncated = false` | 3 fail |
| neutralise `logs.length = 0` | 6 fail |

I re-ran the first myself on the pushed tree (`REPLACEMENTS=1`, line re-read): 4 failed / 58 passed, restored 62/62.

**Non-vacuity:** every cross-eval test first asserts script A's own logs end in `[log output truncated: limit reached]` **at the exact expected index** — 5 entries for the byte cap, 1001 for the entry cap — so the budget provably was reached rather than the test passing on a run that never logged. The test uses a plain `console.log` loop, never an allocation, so it cannot poison the WASM module for the rest of the worker.

One self-inflicted RED failure was my own bug and is worth noting: a top-level `const payload` redeclared on the second run in the same realm. The script is now an IIFE, with a comment saying why.

Negative cases: a single script genuinely over the byte cap is still truncated at exactly the same entry (4 full 1 MB entries + marker), and the entry cap still gives 1000 + marker. Both pass before *and* after and stay green under every mutant.

62 passing (was **57** — measured on `upstream/main` after building `@ifc-lite/sdk`, without which vitest cannot resolve it in a fresh worktree), `tsc --noEmit` clean, `check-test-wiring` passes.

## #2096 sequencing

Open, not merged. Same function, **different hunks** — it rewrites the `JSON.stringify` catch and appends helpers; this touches the counter declarations, the signature and `buildBridge`'s return type. Git merges them mechanically, and the test filenames differ.

One decision for whoever lands second: #2096 adds a `sizingWarningShown` latch in the same closure. **It should not go into `resetLogs` by reflex** — its rationale is about the *context* (a script-controlled trigger must not flood the host console), not the run. Left untouched here so that stays a deliberate call.

`buildBridge`'s return type gains `resetLogs`, which is additive public surface since it is exported from `index.ts` — noted in the changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Console log budgets now reset for each sandbox evaluation, allowing independent log capture across repeated runs.
  * Direct bridge usage now provides a way to reset captured logs and budget state.

* **Bug Fixes**
  * Prevented log truncation from carrying over between evaluations.
  * Preserved captured logs when a later evaluation fails.

* **Documentation**
  * Clarified bridge behavior and per-evaluation log-budget handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->