### PR TITLE
fix(viewer): report a refused clash-settings write instead of reverting silently

### DIFF
--- a/apps/viewer/src/components/viewer/ClashSettingsDialog.tsx
+++ b/apps/viewer/src/components/viewer/ClashSettingsDialog.tsx
@@ -14,7 +14,7 @@
  *    localStorage; shareable via export / import.
  */
 
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Settings2, Plus, Pencil, Trash2, RotateCcw, Upload, Download, Check, X,
 } from 'lucide-react';
@@ -33,6 +33,7 @@ import { toast } from '@/components/ui/toast';
 import { useViewerStore } from '@/store';
 import { matchesSelector, type ClashSeverity } from '@ifc-lite/clash';
 import { exportPresets, importPresets, type ClashPreset, type SaveResult } from '@/lib/clash/persistence';
+import { setClashSettingsSaveReporter } from '@/lib/clash/settings-save-notice';
 
 const SEVERITY: Record<ClashSeverity, { label: string; color: string }> = {
   critical: { label: 'Critical', color: '#f7768e' },
@@ -82,6 +83,14 @@ export function ClashSettingsDialog({ trigger }: ClashSettingsDialogProps) {
 
   const [draft, setDraft] = useState<Draft | null>(null);
   const fileRef = useRef<HTMLInputElement>(null);
+
+  // Detection settings commit optimistically and persist in the background, so
+  // a refused write (quota, or storage blocked) is only visible if something
+  // says so. This component is mounted with the clash panel header — i.e.
+  // whenever the user can reach the Detection tab — so give the slice's
+  // once-per-session notice a toast to land in; it falls back to console.warn
+  // when nothing is mounted. The effect returns the unregister.
+  useEffect(() => setClashSettingsSaveReporter(toast.error), []);
 
   const matchCount = useCallback(
     (selector: string): number | null => {

--- a/apps/viewer/src/lib/clash/settings-save-notice.ts
+++ b/apps/viewer/src/lib/clash/settings-save-notice.ts
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Where a refused clash-settings write gets reported.
+ *
+ * The clash slice commits detection-setting changes before it persists them
+ * (see `persistSettings` in `store/slices/clashSlice.ts`), so a refused write —
+ * localStorage over quota, or blocked entirely by the browser's site settings —
+ * would otherwise be invisible until the setting reverted on the next reload.
+ * The slice reports it once per session through here.
+ *
+ * The default reporter is `console.warn`, because the slice must not import a
+ * React component. `ClashSettingsDialog` — the surface where these settings are
+ * edited — swaps in a toast while it is mounted, so a user changing a setting
+ * sees the notice rather than only the console.
+ */
+
+export type ClashSettingsSaveReporter = (message: string) => void;
+
+const consoleReporter: ClashSettingsSaveReporter = (message) => {
+  console.warn(`[clash] ${message}`);
+};
+
+let reporter: ClashSettingsSaveReporter = consoleReporter;
+
+/**
+ * Route save-failure notices to `fn` (e.g. a toast) instead of the console.
+ * Returns an unregister that restores the console fallback — but only if `fn`
+ * is still the active reporter, so an out-of-order unmount cannot silently
+ * detach a reporter registered after it.
+ */
+export function setClashSettingsSaveReporter(fn: ClashSettingsSaveReporter): () => void {
+  reporter = fn;
+  return () => {
+    if (reporter === fn) reporter = consoleReporter;
+  };
+}
+
+/** Report one refused settings write. The caller owns the once-per-session gate. */
+export function reportClashSettingsSaveFailure(message: string): void {
+  reporter(message);
+}

--- a/apps/viewer/src/store/slices/clashSlice.settings.test.ts
+++ b/apps/viewer/src/store/slices/clashSlice.settings.test.ts
@@ -1,0 +1,230 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * A refused detection-settings write must not be silent.
+ *
+ * `persistSettings` used to call `saveSettings(...)` and drop the `SaveResult`,
+ * so with localStorage over quota or blocked entirely the user's tolerance (or
+ * mode, clearance, cluster radius, grazing-contacts, grouping) looked applied
+ * and reverted on the next reload with nothing said.
+ *
+ * The remedy is a one-shot session notice rather than gating the `set`: these
+ * setters feed controlled inputs, so refusing to commit would freeze the field
+ * the user is typing into, and they fire per keystroke, so an ungated notice
+ * would repeat. These tests pin all three properties — reported, reported ONCE,
+ * and still committed — plus the quiet path when the write succeeds.
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import { createClashSlice, type ClashSlice } from './clashSlice.js';
+import {
+  setClashSettingsSaveReporter,
+  reportClashSettingsSaveFailure,
+} from '@/lib/clash/settings-save-notice.js';
+
+const SETTINGS_KEY = 'ifc-lite-clash-settings';
+const PRESETS_KEY = 'ifc-lite-clash-presets';
+
+/**
+ * A real, working storage that can be told to refuse writes to ONE key. Reads
+ * always work and every other key keeps writing, so the code under test still
+ * sees a functioning localStorage: a stub that threw on every `setItem` would
+ * make the whole persistence layer look absent and pass for the wrong reason.
+ */
+class MemoryStorage {
+  private store = new Map<string, string>();
+  /** Key whose `setItem` throws, mimicking a quota / blocked-storage refusal. */
+  failKey: string | null = null;
+  /** Every successful write, in order (lets a test prove nothing persisted). */
+  writes: string[] = [];
+  getItem(key: string): string | null {
+    return this.store.get(key) ?? null;
+  }
+  setItem(key: string, value: string): void {
+    if (key === this.failKey) throw new DOMException('quota', 'QuotaExceededError');
+    this.store.set(key, value);
+    this.writes.push(key);
+  }
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+  get length(): number {
+    return this.store.size;
+  }
+  key(i: number): string | null {
+    return [...this.store.keys()][i] ?? null;
+  }
+}
+
+const g = globalThis as { localStorage?: unknown };
+
+/** A tolerance no default would produce, so "loaded from storage" is provable. */
+const SEEDED_TOLERANCE = 0.037;
+
+function seedStoredSettings(storage: MemoryStorage): void {
+  storage.setItem(
+    SETTINGS_KEY,
+    JSON.stringify({
+      schemaVersion: 1,
+      settings: {
+        mode: 'hard',
+        tolerance: SEEDED_TOLERANCE,
+        clearance: 0.05,
+        clusterEpsilon: 1.5,
+        reportTouch: false,
+        groupBy: 'severity',
+      },
+    }),
+  );
+  storage.writes.length = 0; // the seed is setup, not a write under test
+}
+
+describe('ClashSlice detection settings - a refused write is reported once', () => {
+  let storage: MemoryStorage;
+  let state: ClashSlice;
+  let notices: string[];
+  let restoreReporter: () => void;
+
+  const build = () => {
+    const setState = (
+      partial: Partial<ClashSlice> | ((s: ClashSlice) => Partial<ClashSlice>),
+    ) => {
+      state = { ...state, ...(typeof partial === 'function' ? partial(state) : partial) };
+    };
+    state = createClashSlice(setState, () => state, {} as never);
+  };
+
+  beforeEach(() => {
+    storage = new MemoryStorage();
+    g.localStorage = storage;
+    seedStoredSettings(storage);
+    notices = [];
+    restoreReporter = setClashSettingsSaveReporter((m) => notices.push(m));
+    build();
+  });
+
+  afterEach(() => {
+    restoreReporter();
+  });
+
+  it('the stub is selective: only the settings key refuses, other keys round-trip', () => {
+    storage.failKey = SETTINGS_KEY;
+    assert.throws(() => storage.setItem(SETTINGS_KEY, 'x'));
+    storage.setItem(PRESETS_KEY, 'y');
+    assert.strictEqual(storage.getItem(PRESETS_KEY), 'y');
+    // Reads still work while writes are refused...
+    assert.ok(storage.getItem(SETTINGS_KEY)?.includes(String(SEEDED_TOLERANCE)));
+    // ...and the slice really did load the seeded settings through the real path,
+    // so these tests exercise persistence rather than a storage-less fallback.
+    assert.strictEqual(state.clashTolerance, SEEDED_TOLERANCE);
+  });
+
+  it('reports the refused write when the tolerance cannot be saved', () => {
+    storage.failKey = SETTINGS_KEY;
+    state.setClashTolerance(0.5);
+    assert.strictEqual(notices.length, 1, 'a refused settings write must tell the user');
+    assert.match(notices[0], /not saved/i);
+    assert.deepStrictEqual(storage.writes, [], 'nothing was persisted');
+  });
+
+  it('still commits the change so the control does not freeze mid-edit', () => {
+    storage.failKey = SETTINGS_KEY;
+    state.setClashTolerance(0.5);
+    assert.strictEqual(state.clashTolerance, 0.5);
+    state.setClashMode('clearance');
+    assert.strictEqual(state.clashMode, 'clearance');
+  });
+
+  it('reports ONCE across many refused writes, including across setters', () => {
+    storage.failKey = SETTINGS_KEY;
+    // Six keystrokes on the tolerance field, then five other settings.
+    for (const v of [0.1, 0.11, 0.111, 0.2, 0.21, 0.3]) state.setClashTolerance(v);
+    state.setClashClearance(0.4);
+    state.setClashClusterEpsilon(2);
+    state.setClashReportTouch(true);
+    state.setClashGroupBy('rule');
+    state.setClashMode('clearance');
+    state.resetClashSettings();
+    assert.strictEqual(notices.length, 1, 'the notice must not repeat within a session');
+  });
+
+  it('says nothing when the write succeeds, and persists the value', () => {
+    state.setClashTolerance(0.25);
+    assert.deepStrictEqual(notices, []);
+    assert.deepStrictEqual(storage.writes, [SETTINGS_KEY]);
+    const stored = JSON.parse(storage.getItem(SETTINGS_KEY) ?? '{}') as {
+      settings?: { tolerance?: number };
+    };
+    assert.strictEqual(stored.settings?.tolerance, 0.25);
+  });
+
+  it('stays quiet for successful writes that follow a reported failure', () => {
+    storage.failKey = SETTINGS_KEY;
+    state.setClashTolerance(0.5);
+    assert.strictEqual(notices.length, 1);
+    storage.failKey = null;
+    state.setClashTolerance(0.6);
+    assert.strictEqual(notices.length, 1);
+    assert.deepStrictEqual(storage.writes, [SETTINGS_KEY]);
+  });
+
+  it('latches per store instance, so a fresh session can report again', () => {
+    storage.failKey = SETTINGS_KEY;
+    state.setClashTolerance(0.5);
+    build(); // new store == new session
+    state.setClashTolerance(0.6);
+    assert.strictEqual(notices.length, 2);
+  });
+});
+
+describe('clash settings save-notice reporter', () => {
+  it('falls back to console.warn when no reporter is registered', () => {
+    const warned: unknown[][] = [];
+    const original = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warned.push(args);
+    };
+    try {
+      reportClashSettingsSaveFailure('storage is full');
+    } finally {
+      console.warn = original;
+    }
+    assert.strictEqual(warned.length, 1);
+    assert.match(String(warned[0][0]), /storage is full/);
+  });
+
+  it('unregistering restores the console fallback', () => {
+    const seen: string[] = [];
+    const restore = setClashSettingsSaveReporter((m) => seen.push(m));
+    reportClashSettingsSaveFailure('one');
+    restore();
+
+    const warned: unknown[][] = [];
+    const original = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warned.push(args);
+    };
+    try {
+      reportClashSettingsSaveFailure('two');
+    } finally {
+      console.warn = original;
+    }
+    assert.deepStrictEqual(seen, ['one']);
+    assert.strictEqual(warned.length, 1);
+  });
+
+  it('a stale unregister does not detach a reporter registered after it', () => {
+    const first: string[] = [];
+    const second: string[] = [];
+    const restoreFirst = setClashSettingsSaveReporter((m) => first.push(m));
+    const restoreSecond = setClashSettingsSaveReporter((m) => second.push(m));
+    restoreFirst(); // out-of-order unmount
+    reportClashSettingsSaveFailure('x');
+    restoreSecond();
+    assert.deepStrictEqual(first, []);
+    assert.deepStrictEqual(second, ['x']);
+  });
+});

--- a/apps/viewer/src/store/slices/clashSlice.ts
+++ b/apps/viewer/src/store/slices/clashSlice.ts
@@ -45,6 +45,7 @@ import {
   type ClashSettingsGroupBy,
   type SaveResult,
 } from '@/lib/clash/persistence';
+import { reportClashSettingsSaveFailure } from '@/lib/clash/settings-save-notice';
 
 export type ClashGroupBy = ClashSettingsGroupBy;
 export type { ClashPreset, ClashGlobalSettings, SaveResult };
@@ -194,8 +195,32 @@ function snapshotSettings(s: ClashSlice): ClashGlobalSettings {
 
 export const createClashSlice: StateCreator<ClashSlice, [], [], ClashSlice> = (set, get) => {
   const initial = loadSettings();
-  // Persist the current settings snapshot after a state change.
-  const persistSettings = () => saveSettings(snapshotSettings(get()));
+  /**
+   * Whether this session has already reported a refused settings write. Lives
+   * in the store's closure, so "once" means once per store instance.
+   */
+  let settingsSaveFailureReported = false;
+  /**
+   * Persist the current settings snapshot after a state change.
+   *
+   * The caller has already committed the change with `set`, and that stays
+   * committed even when the write is refused (quota, or storage blocked by the
+   * browser's site settings): the detection controls are controlled inputs fed
+   * from this state (`NumberField` / `Select` / `Switch` in
+   * `ClashSettingsDialog.tsx`), so rolling the commit back would freeze the
+   * field the user is typing into. What must not happen is the failure being
+   * silent — the setting then reverts on the next reload with nothing said.
+   *
+   * So: commit, and report the refusal ONCE per session. Once, because these
+   * setters fire per keystroke and per spinner step, and a per-write notice
+   * would bury the user in duplicates of the same message.
+   */
+  const persistSettings = () => {
+    const result = saveSettings(snapshotSettings(get()));
+    if (result.ok || settingsSaveFailureReported) return;
+    settingsSaveFailureReported = true;
+    reportClashSettingsSaveFailure(result.message);
+  };
 
   return {
     clashPanelVisible: false,


### PR DESCRIPTION
Follow-up to #2101, and the resolution of a contradiction between it and the in-flight flavor-config branch. Both were partly wrong.

## The bug

`persistSettings` discarded the `SaveResult` from `saveSettings`. A refused write (quota, or storage blocked by site settings) left the value committed in the store and absent from disk, so **tolerance, mode, clearance, cluster radius, grazing and grouping silently revert on the next reload**. #2101's read — *"settings-only and commit-then-persist by design"* — describes the mechanism accurately but does not follow it through to the reload.

## Why not the #2101 gate

The sibling branch argued for a different fix on the grounds that gating `set` would *"freeze the slider and fire one report per drag tick."* That reasoning is right in substance and **wrong about the widget** — there is no range input anywhere in the Detection tab. The three numerics are `NumberField`, an `<input type="number">` whose `value` comes from the store and whose `onChange` calls the setter directly, with no debounce and no commit-on-blur. So it is one write **per keystroke**, not per drag tick: typing `0.005` fires ~5.

That makes the conclusion stronger, not weaker. Because `value={value}` is fed from store state, gating `set` on the result would render the field **literally untypable** under blocked storage. #2101's gate is right where it is — the preset controls are a list, not a text field — and wrong here.

## Remedy

Commit as before; report the refusal **once per store instance**.

- `clashSlice.ts` — a `settingsSaveFailureReported` latch in the `createClashSlice` closure, so "once per session" means once per store instance and tests get isolation with no module-global reset hatch.
- `lib/clash/settings-save-notice.ts` (new) — dependency-free reporter indirection, default `console.warn`. The slice must not import the toast module: that would pull React into every store test. `setClashSettingsSaveReporter` returns an unregister that only restores the fallback if it is still the active reporter (out-of-order unmount safety).
- `ClashSettingsDialog.tsx` — points the reporter at `toast.error` while mounted, which is exactly when the Detection tab is reachable. This is the same surface #2101 uses for presets, so the two are coherent: per-action there, one-shot here.

The latch stays set for the session even if storage later recovers — deliberate, and documented.

## RED / GREEN

10 new tests. RED by reverting **only** `persistSettings` to the pre-fix one-liner, keeping the new module so the failure is behavioural rather than an import error: **6 pass / 4 fail**. Restored by file copy: 10/10.

Mutations (python-scoped, replacement count printed and asserted `==1`, region re-read, restored by file copy — never `git checkout`):

| Mutation | Count | Result |
|---|---|---|
| drop `\|\| settingsSaveFailureReported` (latch neutralised) | 1 | 9/1 — the one-shot test caught it |
| delete the report call (notice neutralised) | 1 | 6/4 |
| roll `setClashTolerance` back on refusal (the rejected gate) | 1 | 7/3 |

The third is the one that matters: it pins the property the remedy must **not** break, and it passes both before and after the fix.

**Anti-vacuity:** the storage double is selective — `failKey` makes only `ifc-lite-clash-settings` throw while `ifc-lite-clash-presets` still round-trips, reads keep working while writes are refused, and it implements `length`/`key()`. The test asserts all of that, and asserts a seeded `clashTolerance === 0.037` that no default produces, proving the slice loaded through the real persistence path rather than a storage-less fallback.

## Validation

Rebased onto #2101 (`531a9559`). The predicted clean auto-merge **did not quite hold** — one import-line conflict in the dialog, where #2101 added `type SaveResult` to the same line; both kept. Post-rebase: **2608 pass, 0 fail, 2 skipped**; `tsc --noEmit` clean. No changeset (`@ifc-lite/viewer` is private).

## Out of scope, but worth knowing

`showClashRegionBox` sits in the Detection tab but is not part of `ClashGlobalSettings` and is never persisted — it resets on every reload regardless of storage health. A separate design gap, left alone.

Also: the flavor-config branch calls `saveSettings` **directly** rather than via `persistSettings`, so this latch does not cover it and it returns its own `SaveResult` to the extension host. Complementary, not duplicative — but if both land, a storage failure during a flavor apply produces the host's report rather than the one-shot. Not a conflict, just a coherence question for you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added an error notification when clash settings cannot be saved.
  * Settings changes now remain applied in the current session even if storage persistence fails.
  * Repeated save failures are limited to one notification per session to avoid noise.
  * Successful saves continue to persist normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->