### PR TITLE
fix(collab-server): stop flaky adminClaims() double-call race in access-control test

### DIFF
--- a/packages/collab-server/test/access-control.test.ts
+++ b/packages/collab-server/test/access-control.test.ts
@@ -385,11 +385,14 @@ describe('revocation retention', () => {
       ),
     ).toBeNull();
     // Re-persisting upgrades to the jti -> exp shape with a fallback horizon.
-    await ac.serverOptions.revokeEndpoint!.recordRevocation('new-jti', 'm/old', adminClaims('m/old').exp);
+    // Capture claims once: two independent adminClaims() calls each recompute
+    // Date.now() and can straddle a wall-clock second boundary (#2094).
+    const claims = adminClaims('m/old');
+    await ac.serverOptions.revokeEndpoint!.recordRevocation('new-jti', 'm/old', claims.exp);
     await ac.flush();
     const state = readState(dir);
     expect(typeof state.revoked!['legacy-jti']).toBe('number');
-    expect(state.revoked!['new-jti']).toBe(adminClaims('m/old').exp);
+    expect(state.revoked!['new-jti']).toBe(claims.exp);
   });
 
   it('prunes revocations once their tokens have expired on their own', async () => {


### PR DESCRIPTION
## Summary
- Fixes the intermittent CI red at `packages/collab-server/test/access-control.test.ts` > `revocation retention` > `loads the legacy revoked array shape and keeps those revocations biting`.
- The test's helper `adminClaims()` (`test/access-control.test.ts:60-63`) computes `exp` from `Math.floor(Date.now() / 1000)` on every call. The test called `adminClaims('m/old').exp` twice (lines 388 and 392) and asserted the two results were equal. If the wall-clock second ticks between the two calls — plausible across the debounced persist + `await ac.flush()` in between — the second call returns `exp + 1` and the assertion fails, exactly matching the reported `1785838912` vs `1785838913` mismatch.
- Fix: capture `adminClaims('m/old')` once into a `claims` local and reuse `claims.exp` for both the `recordRevocation` call and the final assertion.
- This is test-only: `@ifc-lite/collab-server` is a published package but no runtime/src behavior changed, so no changeset is included.

## Investigation notes
- Grepped the whole file and package (`grep -n "adminClaims(" test/access-control.test.ts`, and `grep -rn "Date.now()" test/`) for the same shape (comparing two independent fresh calls that each recompute the clock). The only instance of that exact race is the one fixed here (lines 388/392); every other `adminClaims(...)` call in the file is a single call passed straight into `authorize(...)`, not compared against a second independent call. No other test helper in the package recomputes `Date.now()` and compares two fresh reads against each other.
- Proved the race is real (not just inferred) by temporarily stubbing `Date.now()` to advance 1000ms on every read for just this test, forcing the two `adminClaims()` calls to land in different seconds:
  - Before the fix: test fails deterministically (`expected 1785847068 to be 1785847071`).
  - After the fix (claims captured once): same forced-boundary stub, test passes.
  - The stub was then removed; the shipped diff is only the capture-once change.
- Mutation-tested the fix: reverted the capture-once change via an exact-substring Python replacement (asserted exactly 1 occurrence replaced), re-applied the same forced-boundary `Date.now()` stub, and confirmed the mutated (un-fixed) region fails again — the mutation is caught, not a no-op. Restored the real fix via file copy afterward.

## Test plan
- [x] `pnpm turbo run test --filter=@ifc-lite/collab-server` — 30 test files, 138 tests, all passing (same counts before and after this change).
- [x] `pnpm typecheck` — 34/34 tasks pass.
- [x] Forced-boundary RED/GREEN proof and mutation test described above (temporary instrumentation only, not part of the shipped diff).

Closes #2094