### PR TITLE
fix(ci): stop excluding ifc-lite-wasm from clippy and Rust tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -464,12 +464,15 @@ jobs:
       # notices if that ever stops being true.
       - name: Cargo.lock is in sync with the manifests
         run: cargo metadata --locked --format-version 1 > /dev/null
-      # Workspace exclusions:
-      #   - ifc-lite-wasm: dev-deps on wasm-bindgen-test; tests target wasm32.
+      # ifc-lite-wasm is included: its only wasm32-only test file,
+      # tests/mesh_determinism.rs, self-gates with `#![cfg(target_arch =
+      # "wasm32")]` and compiles to an empty test binary on the native host
+      # (`running 0 tests ... ok`), so no workspace-wide exclusion is needed.
+      # That wasm32 leg runs on its own schedule in determinism.yml.
       - name: Clippy (lint gate)
-        run: cargo clippy --workspace --exclude ifc-lite-wasm --all-targets -- -D warnings
+        run: cargo clippy --workspace --all-targets -- -D warnings
       - name: Rust tests
-        run: cargo test --workspace --exclude ifc-lite-wasm
+        run: cargo test --workspace
 
   # Geometry watertightness / triangulation-invariance census.
   #


### PR DESCRIPTION
## Summary

Closes #2049.

`.github/workflows/test.yml` excluded `ifc-lite-wasm` entirely from both the
`Clippy (lint gate)` and `Rust tests` steps, justified as avoiding
wasm-bindgen-test dev-deps that "target wasm32". That justification only
applies to one file in the crate: `tests/mesh_determinism.rs`, which already
gates its whole contents with `#![cfg(target_arch = "wasm32")]` — on a native
target it compiles to an empty test binary (`running 0 tests ... ok`). It
neither fails to build nor fails at runtime natively, so no exclusion was
needed to keep it out of the native gate.

The rest of the crate is 27 plain native `#[test]`s plus the crate's own
clippy lint, both of which were never run by the required PR gate. That gap
is how two real clippy violations (`bool2d.rs:70`, `mesh.rs:342`) sat on
`main` invisibly until #2051 fixed them directly (already merged, prior to
this PR).

Per the issue thread investigation, the fix is to just drop
`--exclude ifc-lite-wasm` from both `cargo clippy` and `cargo test` lines —
no separate `-p ifc-lite-wasm` step, no feature gating needed. The wasm32
leg (`wasm-pack test --node ... --test mesh_determinism`) keeps running on
its existing schedule/dispatch-only lane in `determinism.yml`, untouched.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` on current
  `upstream/main` (post-#2051): clean, including `ifc-lite-wasm`.
- `cargo test -p ifc-lite-wasm`: 27 unit tests pass in ~0.01s;
  `tests/mesh_determinism.rs` runs 0 tests natively, confirming it
  self-gates and does not need workspace exclusion.
- Proved the newly-enabled gates actually catch regressions by injecting
  (then reverting via file copy, never `git checkout --`) a deliberate
  violation in each:
  - a clippy `if_same_then_else` violation in `rust/wasm-bindings/src/lib.rs`
    made `cargo clippy -p ifc-lite-wasm --all-targets -- -D warnings` fail
    with `error: this if has identical blocks`.
  - a deliberate failing `#[test]` in the same file made
    `cargo test -p ifc-lite-wasm --lib` fail with
    `test result: FAILED. 27 passed; 1 failed`.
- `cargo test --workspace` also shows 34 pre-existing failures in
  `ifc-lite-export`, all missing fixtures (`tests/models/ara3d/duplex.ifc`
  and friends) — reproduced identically on unmodified `upstream/main` via
  `git stash`, confirming they are unrelated to this change (same trap
  noted in the issue thread).

Not verified locally (workflow-only, CI-only): actual GitHub Actions runner
behavior, `Swatinem/rust-cache` caching effect on wall-clock, and whether
the wasm32 target's presence in `rust-toolchain.toml` has any interaction
with the runner beyond what was checked here.

## Test plan

- [ ] CI: `Clippy (lint gate)` step passes with `ifc-lite-wasm` included
- [ ] CI: `Rust tests` step passes with `ifc-lite-wasm`'s 27 unit tests included
- [ ] CI wall-clock for the `rust-tests` job does not regress meaningfully (cached after first run)