### PR TITLE
docs(mutations): document importMutations is not a full inverse for created entities

### DIFF
--- a/.changeset/mutations-document-create-entity-import.md
+++ b/.changeset/mutations-document-create-entity-import.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/mutations": patch
+---
+
+Document that `MutablePropertyView.importMutations()` is not a full inverse of `exportMutations()` for overlay-created entities (#2044).
+
+A `CREATE_ENTITY` record only carries the expressId in the mutation history, not the entity's type and attributes, so `importMutations()` cannot rebuild the entity from the record alone — it logs a `console.warn` and skips the record, dropping every other mutation recorded against that same id in the same batch too. This behaviour was already correct (fixed in #2045), but was undocumented on the public surface: neither the package README nor the `exportMutations`/`importMutations` JSDoc (which reaches the published `.d.ts`) said so. Both now state the asymmetry plainly and point at `restoreNewEntity()` as the companion path a caller must use to carry a created entity across before calling `importMutations()`. No runtime behaviour changes.

--- a/packages/mutations/README.md
+++ b/packages/mutations/README.md
@@ -122,6 +122,39 @@ Reset back to the source data:
 view.clear();
 ```
 
+### Serializing history: `exportMutations` / `importMutations`
+
+```typescript
+const json = view.exportMutations();
+// → ship to a teammate, persist, or replay onto another MutablePropertyView
+
+mutationView.importMutations(json);
+```
+
+**`importMutations` is not a full inverse of `exportMutations` for created
+entities.** A `CREATE_ENTITY` record (from `view.createEntity(...)`) carries
+only the expressId in the history — not the entity's type and attributes —
+so `importMutations` cannot rebuild the entity from the record alone. It
+logs a `console.warn` and skips the record, and also drops every other
+mutation recorded against that same entity id in the same batch (so the
+round trip is lossy — the entity and its edits are both dropped — rather
+than leaving an orphaned property/attribute/quantity keyed to an id that
+was never created on the receiving view).
+
+To carry a created entity across, call `restoreNewEntity()` with its
+`NewEntity` payload (read via `getNewEntity`/`getNewEntities` on the source
+view) **before** calling `importMutations`:
+
+```typescript
+const created = view.getNewEntity(expressId)!;
+mutationView.restoreNewEntity(created);
+mutationView.importMutations(json); // dependent property/attribute/quantity mutations now replay
+```
+
+Mutations recorded against a pre-existing (source-buffer) entity always
+round-trip — this caveat is scoped to entities created via `createEntity` /
+`StoreEditor.addEntity`.
+
 ## Bulk updates
 
 ```typescript

--- a/packages/mutations/src/mutable-property-view.ts
+++ b/packages/mutations/src/mutable-property-view.ts
@@ -1909,7 +1909,9 @@ export class MutablePropertyView {
   }
 
   /**
-   * Export mutations as JSON
+   * Export mutations as JSON. Includes every record in `mutationHistory`,
+   * including `CREATE_ENTITY` — but see `importMutations` for why replaying
+   * that record on another view does not reconstruct the entity.
    */
   exportMutations(): string {
     return JSON.stringify({
@@ -1920,7 +1922,23 @@ export class MutablePropertyView {
   }
 
   /**
-   * Import mutations from JSON
+   * Import mutations from JSON produced by `exportMutations`.
+   *
+   * **Not a full inverse of `exportMutations`.** A `CREATE_ENTITY` record
+   * carries only the expressId in the history — not the entity's type and
+   * attributes — so `importMutations` cannot rebuild the entity from the
+   * record alone: it logs a `console.warn` and skips the record, and drops
+   * every other mutation recorded against that same entity id in the same
+   * batch too (so the round trip is lossy — entity and edits both dropped —
+   * rather than leaving an orphaned property/attribute/quantity keyed to an
+   * id that was never created on the receiving view).
+   *
+   * To carry an overlay-created entity across, call `restoreNewEntity()`
+   * with its `NewEntity` payload (from `getNewEntity`/`getNewEntities` on
+   * the source view) **before** calling `importMutations`. Once the id is
+   * live in `newEntities`, its dependent mutations replay normally — only
+   * the `console.warn` for the (now redundant) `CREATE_ENTITY` record still
+   * fires.
    */
   importMutations(json: string): void {
     const data = JSON.parse(json);

--- a/packages/mutations/test/retype.test.ts
+++ b/packages/mutations/test/retype.test.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   MutablePropertyView,
   StoreEditor,
@@ -264,6 +264,45 @@ describe('MutablePropertyView.importMutations — skipped CREATE_ENTITY (#2044)'
       { name: 'Name', value: 'Restored Wall' },
     ]);
     expect(b.hasChanges(created.expressId)).toBe(true);
+  });
+
+  it('warns via console.warn when a CREATE_ENTITY record is skipped on import (pins the documented behaviour)', () => {
+    // README.md / the exportMutations+importMutations JSDoc both claim
+    // importMutations "logs a console.warn" for a skipped CREATE_ENTITY —
+    // pin that claim so it can't silently go stale (no existing test spied
+    // on console output before this one).
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const a = new MutablePropertyView(null, 'm1');
+      a.setExpressIdWatermark(1000);
+      const created = a.createEntity('IfcWall', ['$', '$', '$']);
+      a.setProperty(created.expressId, 'Pset_WallCommon', 'FireRating', 'F90', PropertyValueType.String);
+      const json = a.exportMutations();
+
+      // Unrestored import: still warns, exactly once, naming both the
+      // skipped id and the restoreNewEntity() recovery path.
+      const b = new MutablePropertyView(null, 'm1');
+      b.setExpressIdWatermark(1000);
+      b.importMutations(json);
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toContain(`#${created.expressId}`);
+      expect(warnSpy.mock.calls[0][0]).toContain('restoreNewEntity()');
+      warnSpy.mockClear();
+
+      // The companion path (restoreNewEntity() before importMutations())
+      // still hits the same CREATE_ENTITY switch case unconditionally, so
+      // the warning fires here too — the README documents this ("only the
+      // console.warn ... still fires").
+      const c = new MutablePropertyView(null, 'm1');
+      c.setExpressIdWatermark(1000);
+      c.restoreNewEntity(a.getNewEntity(created.expressId)!);
+      c.importMutations(json);
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });
 


### PR DESCRIPTION
Closes #2044.

## What #2045 already fixed

PR #2045 (merged, in `upstream/main` at `f4939309`) closed the **corruption half** of #2044: `applyMutations` now skips every mutation recorded against an id whose `CREATE_ENTITY` it skipped in the same batch, so the round trip for a created entity is lossy (entity + edits both dropped) instead of corrupting (edits surviving without their entity). It also added the round-trip test coverage the issue named as missing — `test/retype.test.ts` now has a `describe('MutablePropertyView.importMutations — skipped CREATE_ENTITY (#2044)')` block covering: the orphan-prevention case, an out-of-order `CREATE_ENTITY` case, replay against a pre-existing entity (unaffected), and the `restoreNewEntity()` companion-path success case.

Re-ran the issue's exact repro against current `upstream/main` to confirm:

```
expressId 1001
getNewEntities() []
isDeleted(1001) false
getForEntity(1001) []
```

`getForEntity(1001)` is empty — no orphaned property set. The corruption bug and its test coverage are both already gone.

## What was still open

Nothing on the *public surface* documented the asymmetry: not the README, not the JSDoc on `exportMutations`/`importMutations` (which reaches the published `.d.ts`). A caller reading only the published API had no way to learn that `importMutations()` is not a full inverse of `exportMutations()` for overlay-created entities, or that `restoreNewEntity()` is the companion path.

## What this PR adds

- JSDoc on `exportMutations`/`importMutations` in `mutable-property-view.ts` stating the asymmetry and pointing at `restoreNewEntity()`. Verified it reaches the built `.d.ts`.
- A new README section ("Serializing history: `exportMutations` / `importMutations`") with the same explanation and a worked example of the `restoreNewEntity()` recovery flow.
- One new test in `test/retype.test.ts` spying on `console.warn`, pinning the exact behaviour the new docs describe (fires once, names the id and `restoreNewEntity()`, and still fires even on the companion path) — no existing test asserted on console output.
- A changeset (`@ifc-lite/mutations` patch) noting the doc-only change.

No runtime behaviour changes.

## Verification

- `packages/mutations` vitest: 129 → 130 passed (10 pre-existing skips, fixture-gated), all green.
- Mutation test: disabled the #2045 guard (`if (...) { continue; }` → `if (false) { continue; }`) via exact python3 substring replace (count asserted `== 1`), reran `test/retype.test.ts` — 2 of the pre-existing orphan-prevention tests failed exactly as expected, confirming the guard (and its test coverage) is real, not vacuous. Restored the exact original guard text via a second asserted substring replace; `git diff` on that region confirmed no change after restore, and the full suite passed again at 130.
- `pnpm docs:check-samples`: new README snippet typechecks; the one failure it reports (`docs/guide/collab-server.md:106`, missing `@types/node`) is pre-existing on `upstream/main` (reproduced with my changes stashed) and unrelated to this PR.
- `pnpm typecheck` (full monorepo, after `pnpm install`): 34/34 tasks pass.
- `packages/mutations`: `tsc --noEmit` clean.

## Where the brief was wrong

The task brief assumed the round-trip test for a created entity was still missing (per the issue's own text). It is not — PR #2045 added it in the same commit that fixed the guard (`f4939309`, an ancestor of the branch base). I did not duplicate that coverage; I added only the one test that pins a claim my new docs make (`console.warn`) which genuinely had no prior test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)