### PR TITLE
feat(renderer,viewer): render the DXF reference layer in the 3D viewport

### DIFF
--- a/.changeset/dxf-3d-reference-layer.md
+++ b/.changeset/dxf-3d-reference-layer.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/renderer": minor
+---
+
+Add a 3D DXF reference-layer overlay to the WebGPU renderer: `uploadDxfLines3D` / `clearDxfLines3D` upload a flat `[x,y,z,x,y,z,...]` line-list (mirroring the existing `uploadGridLines3D`/`uploadAlignmentLines3D` pattern — a dedicated buffer, drawn through the shared reference-overlay line pipeline and colour) and render it alongside the grid/alignment/annotation overlays.
+
+Follow-up to the viewer's DXF import feature (issue #1782/#1929), which only ever rendered the imported DXF as a 2D drawing-panel underlay. Issue #2043 adds a 3D viewport toggle for the same DXF data (`apps/viewer`'s `DxfUnderlayPanel`, private package, no changeset needed for that half); this changeset covers the new renderer API those toggles call into.
+
+Only line paths (walls/boundaries) are lifted to 3D in this iteration — DXF fills/hatches and text labels are not yet rendered in the 3D scene, and per-DXF-layer colour is not carried through (the 3D overlay shares one colour with the grid/alignment/annotation line family, same as those already do among themselves).

--- a/apps/viewer/src/components/viewer/DxfUnderlayPanel.test.tsx
+++ b/apps/viewer/src/components/viewer/DxfUnderlayPanel.test.tsx
@@ -44,6 +44,7 @@ function underlayState(overrides: Partial<DxfUnderlayState> = {}): DxfUnderlaySt
     name: 'site.dxf',
     underlay: emptyUnderlay('site.dxf'),
     visible: true,
+    visible3D: true,
     opacity: 1,
     layerVisibility: {},
     placement: { ...DEFAULT_DXF_PLACEMENT },
@@ -142,5 +143,52 @@ describe('DxfUnderlayPanel: "Align to model georeference" tri-state control (PR 
     useViewerStore.setState({ dxfUnderlays: [underlayState({ id: 'u1', georeferenced: false })] });
     const container = renderPanel(true); // availability true, but pinned false wins
     assert.equal(georefCheckbox(container).checked, false, 'pinned false must not follow availability=true');
+  });
+});
+
+describe('DxfUnderlayPanel: independent 2D/3D visibility toggles (issue #2043)', () => {
+  beforeEach(() => {
+    useViewerStore.setState({ dxfUnderlays: [] });
+  });
+
+  afterEach(() => {
+    for (const { root, container } of mounted.splice(0)) {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    }
+    useViewerStore.setState({ dxfUnderlays: [] });
+  });
+
+  function toggleButton(container: HTMLElement, titleSubstring: string): HTMLButtonElement {
+    const btn = [...container.querySelectorAll('button')].find((el) =>
+      el.getAttribute('title')?.includes(titleSubstring),
+    );
+    assert.ok(btn instanceof HTMLButtonElement, `expected a button titled like "${titleSubstring}"`);
+    return btn;
+  }
+
+  it('both default to visible, and are independent toggles wired to distinct store actions', async () => {
+    useViewerStore.setState({ dxfUnderlays: [underlayState({ id: 'u1' })] });
+    const container = renderPanel(false);
+    assert.equal(useViewerStore.getState().dxfUnderlays[0].visible, true);
+    assert.equal(useViewerStore.getState().dxfUnderlays[0].visible3D, true);
+
+    // Hide only the 3D overlay; the 2D underlay's flag must be untouched.
+    await act(async () => {
+      toggleButton(container, 'Hide in 3D view').click();
+    });
+    let entry = useViewerStore.getState().dxfUnderlays.find((u) => u.id === 'u1');
+    assert.equal(entry?.visible3D, false, '3D toggle must flip visible3D');
+    assert.equal(entry?.visible, true, '3D toggle must NOT touch the 2D visible flag');
+
+    // Hiding the 2D underlay must not touch the (now-off) 3D flag either.
+    await act(async () => {
+      toggleButton(container, 'Hide in 2D drawing view').click();
+    });
+    entry = useViewerStore.getState().dxfUnderlays.find((u) => u.id === 'u1');
+    assert.equal(entry?.visible, false, '2D toggle must flip visible');
+    assert.equal(entry?.visible3D, false, '2D toggle must NOT touch visible3D');
   });
 });

--- a/apps/viewer/src/components/viewer/DxfUnderlayPanel.tsx
+++ b/apps/viewer/src/components/viewer/DxfUnderlayPanel.tsx
@@ -175,9 +175,21 @@ function UnderlayCard({
         </div>
       )}
 
-      {/* Opacity */}
+      {/* Opacity — PR #2114 review: the slider only affects the 2D drawing
+          panel. The 3D viewport's line pipeline (`Section2DOverlayRenderer`)
+          shares one un-blended `linePipeline`/uniform colour across the
+          grid, alignment, annotation and DXF line overlays; giving each DXF
+          underlay its own alpha would mean splitting the merged 3D DXF
+          line buffer (`useDxfUnderlays3DLines`) into a per-underlay draw
+          call and adding blend state to that shared pipeline — out of
+          scope here, so `useDxfUnderlays3DLines`'s `opacity > 0` check
+          stays a binary gate. The title below and the "(2D)" suffix make
+          that explicit rather than leaving the control silently no-op in
+          3D. */}
       <div className="flex items-center gap-2 px-1">
-        <Label className="text-[10px] text-muted-foreground w-12">Opacity</Label>
+        <Label className="text-[10px] text-muted-foreground w-12" title="Opacity applies to the 2D drawing only — the 3D view always renders this underlay fully opaque when its 3D toggle is on">
+          Opacity (2D)
+        </Label>
         <input
           type="range"
           min={0.1}
@@ -186,6 +198,7 @@ function UnderlayCard({
           value={state.opacity}
           onChange={(e) => setDxfUnderlayOpacity(state.id, Number.parseFloat(e.target.value))}
           className="flex-1 h-1.5 accent-primary"
+          title="Opacity applies to the 2D drawing only — the 3D view always renders this underlay fully opaque when its 3D toggle is on"
         />
         <span className="text-[10px] text-muted-foreground w-8 text-right">{Math.round(state.opacity * 100)}%</span>
       </div>

--- a/apps/viewer/src/components/viewer/DxfUnderlayPanel.tsx
+++ b/apps/viewer/src/components/viewer/DxfUnderlayPanel.tsx
@@ -23,6 +23,15 @@
  * (`resolveEffectiveGeoreferenced`, following `georeferenceAvailable`
  * while in auto mode) and only becomes an explicit `true`/`false` — pinned
  * regardless of anchor availability — once the user actually clicks it.
+ *
+ * Issue #2043: the 2D underlay is one of TWO independent visibility
+ * toggles per entry — `visible` (2D drawing panel, this panel's original
+ * behaviour) and `visible3D` (3D viewport overlay, `Viewport.tsx`'s
+ * `useDxfUnderlays3DLines`). Both default to on and are controlled here,
+ * not at import time, per the issue's explicit rejection of a load-time
+ * 2D-vs-3D choice. The 3D overlay currently renders line paths only
+ * (walls/boundaries); fills/hatches and text labels are not lifted to 3D
+ * yet (`dxfUnderlayToWorldLines3D`'s doc in `dxfUnderlayMath.ts`).
  */
 
 import React, { useCallback, useRef, useState } from 'react';
@@ -97,6 +106,7 @@ function UnderlayCard({
 }): React.ReactElement {
   const removeDxfUnderlay = useViewerStore((s) => s.removeDxfUnderlay);
   const setDxfUnderlayVisible = useViewerStore((s) => s.setDxfUnderlayVisible);
+  const setDxfUnderlayVisible3D = useViewerStore((s) => s.setDxfUnderlayVisible3D);
   const setDxfUnderlayOpacity = useViewerStore((s) => s.setDxfUnderlayOpacity);
   const toggleDxfUnderlayLayer = useViewerStore((s) => s.toggleDxfUnderlayLayer);
   const updateDxfUnderlayPlacement = useViewerStore((s) => s.updateDxfUnderlayPlacement);
@@ -112,14 +122,28 @@ function UnderlayCard({
   return (
     <div className="border rounded-md p-2 space-y-2 bg-muted/20">
       <div className="flex items-center gap-1.5 min-w-0">
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          onClick={() => setDxfUnderlayVisible(state.id, !state.visible)}
-          title={state.visible ? 'Hide underlay' : 'Show underlay'}
-        >
-          {state.visible ? <Eye className="h-3.5 w-3.5" /> : <EyeOff className="h-3.5 w-3.5" />}
-        </Button>
+        <div className="flex items-center">
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={() => setDxfUnderlayVisible(state.id, !state.visible)}
+            title={state.visible ? 'Hide in 2D drawing view' : 'Show in 2D drawing view'}
+          >
+            {state.visible ? <Eye className="h-3.5 w-3.5" /> : <EyeOff className="h-3.5 w-3.5" />}
+          </Button>
+          <span className="text-[8px] leading-none text-muted-foreground -ml-1">2D</span>
+        </div>
+        <div className="flex items-center">
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={() => setDxfUnderlayVisible3D(state.id, !state.visible3D)}
+            title={state.visible3D ? 'Hide in 3D view' : 'Show in 3D view'}
+          >
+            {state.visible3D ? <Eye className="h-3.5 w-3.5" /> : <EyeOff className="h-3.5 w-3.5" />}
+          </Button>
+          <span className="text-[8px] leading-none text-muted-foreground -ml-1">3D</span>
+        </div>
         <span className="text-xs font-medium truncate flex-1" title={state.name}>{state.name}</span>
         <Button
           variant="ghost"

--- a/apps/viewer/src/components/viewer/Viewport.tsx
+++ b/apps/viewer/src/components/viewer/Viewport.tsx
@@ -58,6 +58,7 @@ import {
 } from '../../hooks/useSymbolicAnnotations.js';
 import { useAlignmentLines3D } from '../../hooks/useAlignmentLines3D.js';
 import { useGridLines3D } from '../../hooks/useGridLines3D.js';
+import { useDxfUnderlays3DLines } from '../../hooks/useDxfUnderlay.js';
 
 interface ViewportProps {
   geometry: MeshData[] | null;
@@ -1150,6 +1151,23 @@ export function Viewport({
       renderer.uploadGridLines3D(gridVertices3D);
     }
   }, [gridVertices3D, ifcGridVisible, isInitialized]);
+
+  // DXF reference-layer line paths in the 3D viewport (issue #2043,
+  // follow-up to #1782/#1929's 2D-only DXF underlay). Gated by each
+  // underlay's own `visible3D` toggle (visibility-layers-panel control, not
+  // a load-time choice — see DxfUnderlayPanel.tsx), independent of the 2D
+  // drawing panel's underlay. Only line paths are lifted to 3D; fills/text
+  // are not (see dxfUnderlayToWorldLines3D's doc).
+  const dxfLines3D = useDxfUnderlays3DLines(coordinateInfo);
+  useEffect(() => {
+    const renderer = rendererRef.current;
+    if (!renderer || !isInitialized) return;
+    if (dxfLines3D.length === 0) {
+      renderer.clearDxfLines3D();
+    } else {
+      renderer.uploadDxfLines3D(dxfLines3D);
+    }
+  }, [dxfLines3D, isInitialized]);
 
   // Upload IfcAnnotation text + fill data for the WebGPU symbolic overlay
   // pipelines. Map the hook's per-annotation records into the SymbolicFillInput

--- a/apps/viewer/src/components/viewer/Viewport.tsx
+++ b/apps/viewer/src/components/viewer/Viewport.tsx
@@ -59,6 +59,7 @@ import {
 import { useAlignmentLines3D } from '../../hooks/useAlignmentLines3D.js';
 import { useGridLines3D } from '../../hooks/useGridLines3D.js';
 import { useDxfUnderlays3DLines } from '../../hooks/useDxfUnderlay.js';
+import { uploadDxfLines3DGuarded } from './dxf-lines-3d-upload.js';
 
 interface ViewportProps {
   geometry: MeshData[] | null;
@@ -1162,11 +1163,14 @@ export function Viewport({
   useEffect(() => {
     const renderer = rendererRef.current;
     if (!renderer || !isInitialized) return;
-    if (dxfLines3D.length === 0) {
-      renderer.clearDxfLines3D();
-    } else {
-      renderer.uploadDxfLines3D(dxfLines3D);
-    }
+    // PR #2114 review: createBuffer/writeBuffer can throw on device loss or
+    // GPU memory pressure. This effect re-runs on every dxfLines3D change
+    // (a DXF underlay toggle, opacity edit, or reload), so an unguarded
+    // throw here is not a one-off. `uploadDxfLines3DGuarded` contains it via
+    // `runGpuUpload` (same guard as the geometry-streaming upload sites,
+    // warns once per call site, not once per re-run) and drops the
+    // underlay on failure instead of drawing from a half-uploaded buffer.
+    uploadDxfLines3DGuarded(renderer, dxfLines3D);
   }, [dxfLines3D, isInitialized]);
 
   // Upload IfcAnnotation text + fill data for the WebGPU symbolic overlay

--- a/apps/viewer/src/components/viewer/dxf-lines-3d-upload.test.ts
+++ b/apps/viewer/src/components/viewer/dxf-lines-3d-upload.test.ts
@@ -1,0 +1,91 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { uploadDxfLines3DGuarded, type DxfLines3DUploadTarget } from './dxf-lines-3d-upload.js';
+import { resetGpuUploadGuardForTests } from './gpu-upload-guard.js';
+
+/** Renderer stub that counts calls and can be told to throw on upload. */
+function makeRenderer(opts?: { throwOnUpload?: boolean }): DxfLines3DUploadTarget & {
+  uploadCount: number;
+  clearCount: number;
+} {
+  const target = {
+    uploadCount: 0,
+    clearCount: 0,
+    uploadDxfLines3D(_vertices: Float32Array): void {
+      target.uploadCount += 1;
+      if (opts?.throwOnUpload) {
+        throw new RangeError(
+          "Failed to execute 'createBuffer' on 'GPUDevice': createBuffer failed",
+        );
+      }
+    },
+    clearDxfLines3D(): void {
+      target.clearCount += 1;
+    },
+  };
+  return target;
+}
+
+let warnings: unknown[][] = [];
+const realWarn = console.warn;
+
+beforeEach(() => {
+  resetGpuUploadGuardForTests();
+  warnings = [];
+  console.warn = (...args: unknown[]) => { warnings.push(args); };
+});
+
+afterEach(() => {
+  console.warn = realWarn;
+});
+
+describe('uploadDxfLines3DGuarded', () => {
+  it('clears without uploading when the vertex buffer is empty', () => {
+    const renderer = makeRenderer();
+    uploadDxfLines3DGuarded(renderer, new Float32Array(0));
+    assert.equal(renderer.uploadCount, 0);
+    assert.equal(renderer.clearCount, 1);
+  });
+
+  it('uploads and does not clear on success', () => {
+    const renderer = makeRenderer();
+    uploadDxfLines3DGuarded(renderer, new Float32Array([0, 0, 0, 1, 0, 0]));
+    assert.equal(renderer.uploadCount, 1);
+    assert.equal(renderer.clearCount, 0);
+    assert.equal(warnings.length, 0);
+  });
+
+  it('drops the underlay (clears) instead of propagating when the upload throws', () => {
+    const renderer = makeRenderer({ throwOnUpload: true });
+    assert.doesNotThrow(() => {
+      uploadDxfLines3DGuarded(renderer, new Float32Array([0, 0, 0, 1, 0, 0]));
+    });
+    assert.equal(renderer.clearCount, 1);
+  });
+
+  it('warns once per call site, not once per re-run (render-effect re-execution)', () => {
+    const renderer = makeRenderer({ throwOnUpload: true });
+    for (let i = 0; i < 25; i++) {
+      uploadDxfLines3DGuarded(renderer, new Float32Array([0, 0, 0, 1, 0, 0]));
+    }
+    assert.equal(renderer.uploadCount, 25);
+    assert.equal(renderer.clearCount, 25);
+    assert.equal(warnings.length, 1);
+  });
+
+  it('a fresh context (guard reset) reports again', () => {
+    const renderer = makeRenderer({ throwOnUpload: true });
+    uploadDxfLines3DGuarded(renderer, new Float32Array([0, 0, 0, 1, 0, 0]));
+    assert.equal(warnings.length, 1);
+
+    // Simulate a fresh session/context (e.g. a new renderer instance after
+    // the old device was lost) — the latch must not stay closed forever.
+    resetGpuUploadGuardForTests();
+    uploadDxfLines3DGuarded(renderer, new Float32Array([0, 0, 0, 1, 0, 0]));
+    assert.equal(warnings.length, 2);
+  });
+});

--- a/apps/viewer/src/components/viewer/dxf-lines-3d-upload.ts
+++ b/apps/viewer/src/components/viewer/dxf-lines-3d-upload.ts
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { runGpuUpload } from './gpu-upload-guard.js';
+
+/** The slice of `Renderer` the DXF 3D upload effect needs. */
+export interface DxfLines3DUploadTarget {
+  uploadDxfLines3D(vertices: Float32Array): void;
+  clearDxfLines3D(): void;
+}
+
+/**
+ * Upload the merged DXF-in-3D line buffer (issue #2043), containing any
+ * `createBuffer`/`writeBuffer` throw from device loss or GPU memory
+ * pressure (PR #2114 review) via `runGpuUpload` — same guard as the
+ * geometry-streaming upload sites (`useGeometryStreaming.ts`).
+ *
+ * Extracted from the `Viewport.tsx` effect so the drop-on-failure branch is
+ * unit-testable with a mock renderer: this function has no GPU dependency,
+ * only `renderer.uploadDxfLines3D`/`clearDxfLines3D`. The actual buffer
+ * upload itself is not covered here — that requires a real GPUDevice.
+ *
+ * An empty `vertices` array clears the overlay (nothing to upload). A
+ * failed upload also clears it — drawing from a half-written buffer would
+ * be worse than showing no DXF overlay for that frame.
+ */
+export function uploadDxfLines3DGuarded(
+  renderer: DxfLines3DUploadTarget,
+  vertices: Float32Array,
+): void {
+  if (vertices.length === 0) {
+    renderer.clearDxfLines3D();
+    return;
+  }
+  const uploaded = runGpuUpload('uploadDxfLines3D', () => {
+    renderer.uploadDxfLines3D(vertices);
+    return true;
+  });
+  if (!uploaded) {
+    renderer.clearDxfLines3D();
+  }
+}

--- a/apps/viewer/src/hooks/dxfExportGeoref.test.ts
+++ b/apps/viewer/src/hooks/dxfExportGeoref.test.ts
@@ -237,6 +237,7 @@ describe('buildDxfExportTransform', () => {
       id: 'u1',
       name: 'roundtrip.dxf',
       visible: true,
+      visible3D: true,
       opacity: 1,
       layerVisibility: {},
       placement: { offsetX: 0, offsetY: 0, rotationDeg: 0, scale: 1 },

--- a/apps/viewer/src/hooks/dxfUnderlayMath.test.ts
+++ b/apps/viewer/src/hooks/dxfUnderlayMath.test.ts
@@ -8,7 +8,14 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { dxfWorldShift, dxfUnderlayToDrawing, dxfUnderlayDrawingBounds, resolveEffectiveGeoreferenced } from './dxfUnderlayMath.js';
+import {
+  dxfWorldShift,
+  dxfElevationRenderY,
+  dxfUnderlayToDrawing,
+  dxfUnderlayToWorldLines3D,
+  dxfUnderlayDrawingBounds,
+  resolveEffectiveGeoreferenced,
+} from './dxfUnderlayMath.js';
 import type { DxfUnderlayState } from '@/store/slices/drawing2DSlice';
 
 const close = (a: number, b: number, eps = 1e-9) =>
@@ -45,6 +52,7 @@ describe('dxfUnderlayToDrawing', () => {
     id: 'u1',
     name: 'test.dxf',
     visible: true,
+    visible3D: true,
     opacity: 1,
     layerVisibility: {},
     placement: { offsetX: 0, offsetY: 0, rotationDeg: 0, scale: 1, ...placement },
@@ -234,6 +242,7 @@ describe('dxfUnderlayToDrawing auto-mode (PR #1965 review: closes the import-tim
     id: 'u1',
     name: 'test.dxf',
     visible: true,
+    visible3D: true,
     opacity: 1,
     layerVisibility: {},
     placement: { offsetX: 0, offsetY: 0, rotationDeg: 0, scale: 1, ...placement },
@@ -297,6 +306,7 @@ describe('dxfUnderlayDrawingBounds (PR #1965 review: NaN bounds must become null
     id: 'u1',
     name: 'test.dxf',
     visible: true,
+    visible3D: true,
     opacity: 1,
     layerVisibility: {},
     placement: { offsetX: 0, offsetY: 0, rotationDeg: 0, scale: 1 },
@@ -325,5 +335,97 @@ describe('dxfUnderlayDrawingBounds (PR #1965 review: NaN bounds must become null
     const nanTransform = (p: { x: number; y: number }): { x: number; y: number } => ({ x: p.x + NaN, y: p.y });
     const bounds = dxfUnderlayDrawingBounds(e, { x: 0, y: 0 }, false, nanTransform);
     assert.strictEqual(bounds, null);
+  });
+});
+
+describe('dxfElevationRenderY (issue #2043)', () => {
+  it('defaults elevationIfcZ to 0 and subtracts originShift.y + rtc.z', () => {
+    // Y-axis counterpart of dxfWorldShift's X/Z-axis (IFC X/Y) shift:
+    // renderY = ifcZ - originShift.y - rtc.z (rtc_as_yup.y = rtc.z).
+    const y = dxfElevationRenderY({
+      wasmRtcOffset: { x: 0, y: 0, z: 5 },
+      originShift: { x: 0, y: 2, z: 0 },
+    } as never);
+    close(y, 0 - 2 - 5);
+  });
+
+  it('honours an explicit elevationIfcZ', () => {
+    const y = dxfElevationRenderY({
+      wasmRtcOffset: { x: 0, y: 0, z: 1 },
+      originShift: { x: 0, y: 3, z: 0 },
+    } as never, 10);
+    close(y, 10 - 3 - 1);
+  });
+
+  it('degenerates to 0 with no coordinateInfo', () => {
+    close(dxfElevationRenderY(undefined), 0);
+  });
+});
+
+describe('dxfUnderlayToWorldLines3D (issue #2043)', () => {
+  const entry = (paths: DxfUnderlayState['underlay']['layers'][number]['paths']): DxfUnderlayState => ({
+    id: 'u1',
+    name: 'test.dxf',
+    visible: true,
+    visible3D: true,
+    opacity: 1,
+    layerVisibility: {},
+    placement: { offsetX: 0, offsetY: 0, rotationDeg: 0, scale: 1 },
+    underlay: {
+      name: 'test.dxf',
+      unitScale: 1,
+      skipped: {},
+      warnings: [],
+      bounds: { min: { x: 0, y: 0 }, max: { x: 10, y: 10 } },
+      layers: [
+        { name: 'L', color: '#000000', visible: true, fills: [], texts: [], paths },
+      ],
+    },
+  });
+
+  it('lifts an open 2-point path to one 3D segment at the given elevation, X unmirrored', () => {
+    const e = entry([{ points: [{ x: 0, y: 0 }, { x: 10, y: 20 }], closed: false }]);
+    const verts = dxfUnderlayToWorldLines3D(e, { x: 100, y: 200 }, 5);
+    // worldToDrawing (mirrorX=false): x = world.x - shiftX; z = -(world.y - shiftY)
+    // p0 = (0,0)   -> x=-100,           z=-(0-200)=200
+    // p1 = (10,20) -> x=10-100=-90,     z=-(20-200)=180
+    assert.deepStrictEqual(Array.from(verts), [-100, 5, 200, -90, 5, 180]);
+  });
+
+  it('closes a closed path with an extra segment back to the first point', () => {
+    const e = entry([{
+      points: [{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 10, y: 10 }],
+      closed: true,
+    }]);
+    const verts = dxfUnderlayToWorldLines3D(e, { x: 0, y: 0 }, 0);
+    // 3 points, closed -> 3 segments (2 consecutive + 1 closing), 6 verts each
+    assert.strictEqual(verts.length, 3 * 6);
+    // Closing segment: last point (10,10) -> first point (0,0).
+    const closingStart = [verts[12], verts[13], verts[14]];
+    const closingEnd = [verts[15], verts[16], verts[17]];
+    assert.deepStrictEqual(closingStart, [10, 0, -10]);
+    assert.deepStrictEqual(closingEnd, [0, 0, 0]);
+  });
+
+  it('skips a layer whose visibility is toggled off', () => {
+    const e = entry([{ points: [{ x: 0, y: 0 }, { x: 1, y: 1 }], closed: false }]);
+    e.layerVisibility = { L: false };
+    const verts = dxfUnderlayToWorldLines3D(e, { x: 0, y: 0 }, 0);
+    assert.strictEqual(verts.length, 0);
+  });
+
+  it('skips a degenerate single-point path', () => {
+    const e = entry([{ points: [{ x: 0, y: 0 }], closed: false }]);
+    const verts = dxfUnderlayToWorldLines3D(e, { x: 0, y: 0 }, 0);
+    assert.strictEqual(verts.length, 0);
+  });
+
+  it('applies mapToWorld only when the effective georeferenced state is on', () => {
+    const e = entry([{ points: [{ x: 0, y: 0 }, { x: 1, y: 0 }], closed: false }]);
+    e.georeferenced = true;
+    const mapToWorld = (p: { x: number; y: number }): { x: number; y: number } => ({ x: p.x + 1000, y: p.y + 2000 });
+    const verts = dxfUnderlayToWorldLines3D(e, { x: 0, y: 0 }, 0, mapToWorld, true);
+    assert.strictEqual(verts[0], 1000);
+    assert.strictEqual(verts[2], -2000);
   });
 });

--- a/apps/viewer/src/hooks/dxfUnderlayMath.ts
+++ b/apps/viewer/src/hooks/dxfUnderlayMath.ts
@@ -161,6 +161,36 @@ export function dxfWorldShift(coordinateInfo: GeometryResult['coordinateInfo'] |
 }
 
 /**
+ * IFC-elevation (Z-up) -> renderer world Y (Y-up, RTC-subtracted), for the
+ * 3D DXF overlay (issue #2043).
+ *
+ * Per the canonical Z-up -> Y-up conversion (`reproject.ts`'s
+ * `computeProjectedCenter` doc, `ifc-origin.ts`'s `totalYupOffset`):
+ * `viewerY = ifcZ`, and the render-frame subtracts `originShift` (already
+ * Y-up) and the RTC offset lifted to Y-up (`rtcYup = {x: rtc.x, y: rtc.z,
+ * z: -rtc.y}`). So `renderY = ifcZ - originShift.y - rtc.z` — the Y-axis
+ * counterpart of `dxfWorldShift`'s X/Z-axis (IFC X/Y) shift above.
+ *
+ * `elevationIfcZ` defaults to 0 (IFC model origin / grade), the smallest
+ * sane default for a DXF floor plan: DXF carries no Z, and unlike
+ * IfcAnnotation (`useSymbolicAnnotations.ts`'s `ensureBucket`) a DXF
+ * underlay has no per-entity Z or storey association to bucket by, so
+ * picking a per-storey elevation would require inventing an association
+ * the DXF import pipeline (issue #1782/#1929) never captured. 0 keeps the
+ * layer at the model's reference plane, which is where a site/ground-floor
+ * plan — the common case (see the issue) — actually belongs; a storey- or
+ * user-elevation picker is a reasonable follow-up but out of scope here.
+ */
+export function dxfElevationRenderY(
+  coordinateInfo: GeometryResult['coordinateInfo'] | undefined,
+  elevationIfcZ = 0,
+): number {
+  const rtc = coordinateInfo?.wasmRtcOffset;
+  const shift = coordinateInfo?.originShift;
+  return elevationIfcZ - (shift?.y ?? 0) - (rtc?.z ?? 0);
+}
+
+/**
  * Resolve an underlay entry's TRI-STATE `georeferenced` field to the actual
  * boolean the world→drawing mapping applies (PR #1965 review). `true` /
  * `false` are explicit (the user toggled the checkbox) and always win;
@@ -303,5 +333,64 @@ export function dxfUnderlayDrawingBounds(
   const maxY = Math.max(...corners.map((c) => c.y));
   if (![minX, minY, maxX, maxY].every(Number.isFinite)) return null;
   return { min: { x: minX, y: minY }, max: { x: maxX, y: maxY } };
+}
+
+/**
+ * Map one underlay entry's line paths to a flat `[x1,y1,z1, x2,y2,z2, ...]`
+ * 3D line-list in renderer world space (Y-up, RTC-subtracted), for the 3D
+ * viewport overlay (issue #2043).
+ *
+ * Reuses the same `worldToDrawing` point transform as
+ * {@link dxfUnderlayToDrawing} (map/CRS -> world, render-frame shift, user
+ * placement) with `mirrorX` always `false` — the flipped-section mirror is
+ * a 2D-section-specific rule that doesn't apply to the 3D scene — so the
+ * transform's `{x, y}` output IS the renderer's `(x, z)` plane exactly (see
+ * the module doc's world_yup derivation): `x` matches 1:1, and drawing-space
+ * `y` was already defined as `-(world.y - shiftY)`, which is the same
+ * expression `dxfElevationRenderY`'s sibling derives for renderer `z`. Every
+ * vertex shares the single `elevationRenderY` (see
+ * {@link dxfElevationRenderY}) since DXF carries no per-point Z.
+ *
+ * Only line paths (walls, boundaries — layer.paths) are lifted to 3D in
+ * this first iteration; fills (hatches) and text labels are not (tracked as
+ * follow-up, not silently dropped — see the PR description). Per-DXF-layer
+ * color is also not carried through: the renderer's 3D reference-line
+ * pipeline (`uploadDxfLines3D` / `Renderer.setOverlayLineColor`) shares one
+ * color across the grid/alignment/annotation/DXF overlay family, the same
+ * way grid and alignment already do — see `section-2d-overlay.ts`.
+ */
+export function dxfUnderlayToWorldLines3D(
+  entry: DxfUnderlayState,
+  shift: { x: number; y: number },
+  elevationRenderY: number,
+  mapToWorld: (p: Point2D) => Point2D = (p) => p,
+  georeferenceAvailable = false,
+): Float32Array {
+  const t: WorldToDrawingParams = {
+    shiftX: shift.x,
+    shiftY: shift.y,
+    mirrorX: false,
+    placement: entry.placement,
+    mapToWorld: resolveEffectiveGeoreferenced(entry, georeferenceAvailable) ? mapToWorld : undefined,
+  };
+  const verts: number[] = [];
+  for (const layer of entry.underlay.layers) {
+    if (!(entry.layerVisibility[layer.name] ?? layer.visible)) continue;
+    for (const path of layer.paths) {
+      if (path.points.length < 2) continue;
+      const mapped = path.points.map((p) => worldToDrawing(p, t));
+      for (let i = 0; i < mapped.length - 1; i++) {
+        verts.push(mapped[i].x, elevationRenderY, mapped[i].y);
+        verts.push(mapped[i + 1].x, elevationRenderY, mapped[i + 1].y);
+      }
+      if (path.closed && mapped.length > 2) {
+        const a = mapped[mapped.length - 1];
+        const b = mapped[0];
+        verts.push(a.x, elevationRenderY, a.y);
+        verts.push(b.x, elevationRenderY, b.y);
+      }
+    }
+  }
+  return new Float32Array(verts);
 }
 

--- a/apps/viewer/src/hooks/useDxfUnderlay.ts
+++ b/apps/viewer/src/hooks/useDxfUnderlay.ts
@@ -125,6 +125,17 @@ export function useDxfUnderlays3DLines(
   const { transform: mapToWorld, available: georeferenceAvailable } = useDxfMapToWorldTransform();
 
   return useMemo(() => {
+    // PR #2114 review: `opacity` is intentionally an on/off gate here, not
+    // an alpha value — the merged 3D line buffer below carries positions
+    // only (no per-vertex/per-underlay alpha), and the shared
+    // `Section2DOverlayRenderer.linePipeline` (also used by the grid,
+    // alignment and annotation line overlays) has no blend state, so a
+    // passed-through alpha wouldn't visibly blend anyway. Plumbing real
+    // per-underlay opacity through would mean adding blend state to that
+    // shared pipeline and splitting this single merged draw into one draw
+    // per underlay — out of scope for the DXF-in-3D feature. The opacity
+    // slider is labelled "Opacity (2D)" in `DxfUnderlayPanel.tsx` so this
+    // is surfaced in the UI, not just here.
     const visible = dxfUnderlays.filter((u) => u.visible3D && u.opacity > 0);
     if (visible.length === 0) return EMPTY_LINES_3D;
     const shift = dxfWorldShift(coordinateInfo);

--- a/apps/viewer/src/hooks/useDxfUnderlay.ts
+++ b/apps/viewer/src/hooks/useDxfUnderlay.ts
@@ -29,11 +29,18 @@ import type { Point2D } from '@ifc-lite/drawing-2d';
 import type { GeometryResult } from '@ifc-lite/geometry';
 import { useViewerStore } from '@/store';
 import { buildDxfMapToWorldTransform, resolveDxfExportGeoreference } from './dxfExportGeoref';
-import { dxfUnderlayToDrawing, dxfWorldShift } from './dxfUnderlayMath';
+import {
+  dxfElevationRenderY,
+  dxfUnderlayToDrawing,
+  dxfUnderlayToWorldLines3D,
+  dxfWorldShift,
+} from './dxfUnderlayMath';
 
 export {
   dxfWorldShift,
+  dxfElevationRenderY,
   dxfUnderlayToDrawing,
+  dxfUnderlayToWorldLines3D,
   dxfUnderlayDrawingBounds,
   type DxfUnderlayRenderData,
   type DxfUnderlayRenderLine,
@@ -42,6 +49,8 @@ export {
 } from './dxfUnderlayMath';
 
 import type { DxfUnderlayRenderData } from './dxfUnderlayMath';
+
+const EMPTY_LINES_3D = new Float32Array(0);
 
 export interface DxfMapToWorld {
   /** Map/CRS -> IFC-world transform; identity when `available` is false. */
@@ -99,4 +108,40 @@ export function useDxfUnderlaysForDrawing(params: {
     // projectTo2D's flipped-U rule); the underlay must follow.
     return visible.map((u) => dxfUnderlayToDrawing(u, shift, flipped, mapToWorld, georeferenceAvailable));
   }, [enabled, sectionAxis, isCustomPlane, flipped, coordinateInfo, dxfUnderlays, mapToWorld, georeferenceAvailable]);
+}
+
+/**
+ * DXF underlays flagged `visible3D`, flattened into one 3D line-list ready
+ * for `renderer.uploadDxfLines3D` (issue #2043). Independent of the 2D
+ * panel's section-axis/plan-view gating in {@link useDxfUnderlaysForDrawing}
+ * — the 3D overlay renders regardless of section state, matching how the
+ * alignment/grid 3D overlays are always-eligible (`useAlignmentLines3D`,
+ * `useGridLines3D`).
+ */
+export function useDxfUnderlays3DLines(
+  coordinateInfo: GeometryResult['coordinateInfo'] | undefined,
+): Float32Array {
+  const dxfUnderlays = useViewerStore((s) => s.dxfUnderlays);
+  const { transform: mapToWorld, available: georeferenceAvailable } = useDxfMapToWorldTransform();
+
+  return useMemo(() => {
+    const visible = dxfUnderlays.filter((u) => u.visible3D && u.opacity > 0);
+    if (visible.length === 0) return EMPTY_LINES_3D;
+    const shift = dxfWorldShift(coordinateInfo);
+    const elevationRenderY = dxfElevationRenderY(coordinateInfo);
+    const arrays = visible.map((u) =>
+      dxfUnderlayToWorldLines3D(u, shift, elevationRenderY, mapToWorld, georeferenceAvailable),
+    );
+    let total = 0;
+    for (const a of arrays) total += a.length;
+    if (total === 0) return EMPTY_LINES_3D;
+    if (arrays.length === 1) return arrays[0];
+    const merged = new Float32Array(total);
+    let offset = 0;
+    for (const a of arrays) {
+      merged.set(a, offset);
+      offset += a.length;
+    }
+    return merged;
+  }, [dxfUnderlays, coordinateInfo, mapToWorld, georeferenceAvailable]);
 }

--- a/apps/viewer/src/store/slices/drawing2DSlice.test.ts
+++ b/apps/viewer/src/store/slices/drawing2DSlice.test.ts
@@ -66,3 +66,30 @@ describe('drawing2DSlice.addDxfUnderlay (PR #1965 review: tri-state georeference
     assert.strictEqual(s.getState().dxfUnderlays.find((u) => u.id === id)?.georeferenced, false);
   });
 });
+
+// Issue #2043: `visible` (2D) and `visible3D` (3D) are independent toggles,
+// both defaulting to on -- the issue's explicit "default to visible in both
+// 2D and 3D" requirement, and a load-time-only 2D-vs-3D choice was rejected.
+describe('drawing2DSlice: independent 2D/3D DXF underlay visibility (issue #2043)', () => {
+  it('addDxfUnderlay defaults both visible and visible3D to true', () => {
+    const s = makeStore();
+    const id = s.getState().addDxfUnderlay(makeUnderlay());
+    const entry = s.getState().dxfUnderlays.find((u) => u.id === id);
+    assert.strictEqual(entry?.visible, true);
+    assert.strictEqual(entry?.visible3D, true);
+  });
+
+  it('setDxfUnderlayVisible3D flips only visible3D, leaving visible untouched', () => {
+    const s = makeStore();
+    const id = s.getState().addDxfUnderlay(makeUnderlay());
+    s.getState().setDxfUnderlayVisible3D(id, false);
+    let entry = s.getState().dxfUnderlays.find((u) => u.id === id);
+    assert.strictEqual(entry?.visible3D, false);
+    assert.strictEqual(entry?.visible, true);
+
+    s.getState().setDxfUnderlayVisible(id, false);
+    entry = s.getState().dxfUnderlays.find((u) => u.id === id);
+    assert.strictEqual(entry?.visible, false);
+    assert.strictEqual(entry?.visible3D, false, 'toggling 2D must not touch the already-off 3D flag');
+  });
+});

--- a/apps/viewer/src/store/slices/drawing2DSlice.ts
+++ b/apps/viewer/src/store/slices/drawing2DSlice.ts
@@ -73,9 +73,17 @@ export interface DxfUnderlayState {
   name: string;
   /** Parsed + converted geometry in drawing space */
   underlay: DxfUnderlay;
-  /** Master visibility toggle */
+  /** Master visibility toggle for the 2D drawing panel underlay */
   visible: boolean;
-  /** Render opacity (0-1) */
+  /**
+   * Visibility toggle for the 3D viewport overlay (issue #2043, follow-up
+   * to #1782/#1929's 2D-only underlay). Independent of `visible` — the
+   * user loads a DXF once and then chooses where it shows, per the issue's
+   * explicit rejection of a load-time 2D-vs-3D choice. Defaults to `true`
+   * in both contexts (`addDxfUnderlay` below), matching `visible`.
+   */
+  visible3D: boolean;
+  /** Render opacity (0-1), shared by the 2D and 3D renderers */
   opacity: number;
   /** Per-DXF-layer visibility, seeded from the DXF layer table */
   layerVisibility: Record<string, boolean>;
@@ -326,6 +334,8 @@ export interface Drawing2DSlice extends Drawing2DState {
   addDxfUnderlay: (underlay: DxfUnderlay, options?: { georeferenced?: boolean | 'auto' }) => string;
   removeDxfUnderlay: (id: string) => void;
   setDxfUnderlayVisible: (id: string, visible: boolean) => void;
+  /** Toggle the 3D viewport overlay independently of the 2D underlay (issue #2043) */
+  setDxfUnderlayVisible3D: (id: string, visible3D: boolean) => void;
   setDxfUnderlayOpacity: (id: string, opacity: number) => void;
   /** Toggle one DXF layer within an underlay */
   toggleDxfUnderlayLayer: (id: string, layerName: string) => void;
@@ -782,6 +792,7 @@ export const createDrawing2DSlice: StateCreator<Drawing2DSlice, [], [], Drawing2
       name: underlay.name,
       underlay,
       visible: true,
+      visible3D: true,
       opacity: 1,
       layerVisibility,
       placement: { ...DEFAULT_DXF_PLACEMENT },
@@ -797,6 +808,10 @@ export const createDrawing2DSlice: StateCreator<Drawing2DSlice, [], [], Drawing2
 
   setDxfUnderlayVisible: (id, visible) => set((state) => ({
     dxfUnderlays: state.dxfUnderlays.map((u) => (u.id === id ? { ...u, visible } : u)),
+  })),
+
+  setDxfUnderlayVisible3D: (id, visible3D) => set((state) => ({
+    dxfUnderlays: state.dxfUnderlays.map((u) => (u.id === id ? { ...u, visible3D } : u)),
   })),
 
   setDxfUnderlayOpacity: (id, opacity) => set((state) => ({

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -2847,6 +2847,9 @@ export class Renderer {
             if (this.section2DOverlayRenderer?.hasGridLines3D()) {
                 this.section2DOverlayRenderer.drawGridLines3D(pass, viewProj);
             }
+            if (this.section2DOverlayRenderer?.hasDxfLines3D()) {
+                this.section2DOverlayRenderer.drawDxfLines3D(pass, viewProj);
+            }
             if (this.section2DOverlayRenderer?.hasClashBoxLines3D()) {
                 this.section2DOverlayRenderer.drawClashBoxLines3D(pass, viewProj);
             }
@@ -3365,6 +3368,29 @@ export class Renderer {
     clearGridLines3D(): void {
         if (this.section2DOverlayRenderer) {
             this.section2DOverlayRenderer.clearGridLines3D();
+            this.requestRender();
+        }
+    }
+
+    /**
+     * Upload the DXF reference-layer's line paths as a flat
+     * [x,y,z,x,y,z,...] line-list in world space (issue #2043, follow-up to
+     * the 2D-only DXF underlay from #1782/#1929). Mirrors
+     * `uploadGridLines3D`: a dedicated buffer so 3D DXF visibility is
+     * independent of the 2D underlay's own toggle, and does NOT expand
+     * model bounds/reframe the camera on upload — it's behind its own
+     * visibility toggle, like grid axes. Pass an empty Float32Array to clear.
+     */
+    uploadDxfLines3D(vertices: Float32Array): void {
+        if (!this.section2DOverlayRenderer) return;
+        this.section2DOverlayRenderer.uploadDxfLines3D(vertices);
+        this.requestRender();
+    }
+
+    /** Clear the 3D DXF reference-layer overlay. */
+    clearDxfLines3D(): void {
+        if (this.section2DOverlayRenderer) {
+            this.section2DOverlayRenderer.clearDxfLines3D();
             this.requestRender();
         }
     }

--- a/packages/renderer/src/section-2d-overlay.ts
+++ b/packages/renderer/src/section-2d-overlay.ts
@@ -157,6 +157,15 @@ export class Section2DOverlayRenderer {
   private gridLineVertexBuffer: GPUBuffer | null = null;
   private gridLineVertexCount = 0;
 
+  // Standalone 3D DXF reference-layer overlay (issue #2043, follow-up to
+  // #1782/#1929's 2D-only DXF underlay). Independent buffer so 3D DXF
+  // visibility is independent of the 2D underlay and the other overlays
+  // above, but reuses the same line pipeline + shared overlay colour —
+  // mirrors the grid overlay exactly. Line paths only (walls/boundaries);
+  // DXF fills/text are not lifted to 3D in this iteration.
+  private dxfLineVertexBuffer: GPUBuffer | null = null;
+  private dxfLineVertexCount = 0;
+
   // Standalone 3D clash-overlap-box overlay (#1277): the wireframe AABB of a
   // focused clash, drawn in its OWN distinct colour (not the shared overlay
   // line colour) so the overlap region reads as a third colour next to the two
@@ -922,6 +931,65 @@ export class Section2DOverlayRenderer {
     pass.draw(this.gridLineVertexCount);
   }
 
+  /**
+   * Upload the DXF reference-layer's line paths as a flat `[x,y,z, x,y,z, …]`
+   * line-list in world space (issue #2043). Mirrors `uploadGridLines3D` with
+   * a separate buffer so 3D DXF visibility is independent of the 2D
+   * underlay and the other overlays above. Pass an empty array (or omit)
+   * to clear.
+   */
+  uploadDxfLines3D(vertices: Float32Array): void {
+    this.init();
+
+    if (this.dxfLineVertexBuffer) {
+      this.dxfLineVertexBuffer.destroy();
+      this.dxfLineVertexBuffer = null;
+    }
+    this.dxfLineVertexCount = 0;
+
+    if (vertices.length < 6) return;
+
+    this.dxfLineVertexBuffer = this.device.createBuffer({
+      size: vertices.byteLength,
+      usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
+    });
+    this.device.queue.writeBuffer(this.dxfLineVertexBuffer, 0, vertices);
+    this.dxfLineVertexCount = vertices.length / 3;
+  }
+
+  clearDxfLines3D(): void {
+    if (this.dxfLineVertexBuffer) {
+      this.dxfLineVertexBuffer.destroy();
+      this.dxfLineVertexBuffer = null;
+    }
+    this.dxfLineVertexCount = 0;
+  }
+
+  hasDxfLines3D(): boolean {
+    return this.dxfLineVertexCount > 0;
+  }
+
+  /**
+   * Draw the 3D DXF reference-layer overlay. Identical pipeline/uniform
+   * setup as `drawGridLines3D`, reading from the separate DXF buffer.
+   */
+  drawDxfLines3D(pass: GPURenderPassEncoder, viewProj: Float32Array): void {
+    this.init();
+    if (!this.linePipeline || !this.uniformBuffer || !this.bindGroup) return;
+    if (!this.dxfLineVertexBuffer || this.dxfLineVertexCount === 0) return;
+
+    const uniforms = new Float32Array(40);
+    uniforms.set(viewProj, 0);
+    // planeOffset = 0 — vertices are already in world space.
+    uniforms.set(this.overlayLineColor, 36); // lineColor (byte offset 144)
+    this.device.queue.writeBuffer(this.uniformBuffer, 0, uniforms);
+
+    pass.setPipeline(this.linePipeline);
+    pass.setBindGroup(0, this.bindGroup);
+    pass.setVertexBuffer(0, this.dxfLineVertexBuffer);
+    pass.draw(this.dxfLineVertexCount);
+  }
+
   /** Colour for the clash-overlap box (its own, not the shared overlay colour). */
   setClashBoxLineColor(color: readonly [number, number, number, number]): void {
     this.clashBoxLineColor = color;
@@ -1099,6 +1167,7 @@ export class Section2DOverlayRenderer {
     this.clearAnnotationLines3D();
     this.clearAlignmentLines3D();
     this.clearGridLines3D();
+    this.clearDxfLines3D();
     if (this.uniformBuffer) {
       this.uniformBuffer.destroy();
       this.uniformBuffer = null;


### PR DESCRIPTION
Closes #2043.

## Current pipeline (before this PR)

DXF import landed in #1794 (the issue text names #1782, which is actually the *issue* this PR closed — the implementation PR is #1794):

- **Parser**: `packages/drawing-2d/src/dxf/` — ASCII DXF parser producing `DxfUnderlay` (world plan geometry, metres, +Y = north, both DXF and IFC are Z-up).
- **Store**: `apps/viewer/src/store/slices/drawing2DSlice.ts` — `DxfUnderlayState` holds the parsed underlay plus viewer state: `visible`, `opacity`, per-layer visibility, `placement` (offset/rotation/scale), and a tri-state `georeferenced` flag (issue #1929).
- **Math**: `apps/viewer/src/hooks/dxfUnderlayMath.ts` — pure, unit-tested `dxfUnderlayToDrawing` maps an underlay's raw points through: optional map/CRS→IFC-world transform (georeference) → render-frame shift (RTC + originShift) → 2D-only Y-flip/mirror → user placement. Output is 2D drawing-space geometry.
- **Render**: `Section2DPanel.tsx` / `Drawing2DCanvas.tsx` — draws the mapped underlay beneath the generated 2D section/plan drawing. `DxfUnderlayPanel.tsx` is the per-DXF control surface (visibility, opacity, layer toggles, placement, georeference checkbox, centre-on-model).
- There is **no unified "visibility layers panel"** in this codebase — each reference-layer feature (point cloud, Cesium/terrain, DXF, grid/annotation type-visibility) has its own independent toggle/panel. `DxfUnderlayPanel` is the closest thing to a DXF-specific visibility panel, so that's where I added the new 3D toggle.
- **3D reference overlays already exist** for grid axes (`useGridLines3D`) and `IfcAlignment` centerlines (`useAlignmentLines3D`): a flat `[x,y,z,...]` line-list in renderer Y-up world space, uploaded via `Renderer.uploadGridLines3D`/`uploadAlignmentLines3D` into a dedicated GPU buffer in `packages/renderer/src/section-2d-overlay.ts`, drawn through one shared line pipeline + one shared colour (`setOverlayLineColor`). DXF had no such path before this PR.

## What this PR adds

- `DxfUnderlayState` gets a second, independent visibility flag: `visible3D` (default `true`, alongside the existing `visible` for the 2D panel). Both are user-toggleable in `DxfUnderlayPanel` (new "2D"/"3D" eye buttons) — never chosen at load time, matching the issue's explicit rejection of that alternative.
- `dxfUnderlayMath.ts` gains two new pure functions:
  - `dxfElevationRenderY(coordinateInfo, elevationIfcZ = 0)` — the Y-axis (elevation) counterpart of the existing `dxfWorldShift` (X/Z-axis shift): `renderY = ifcZ - originShift.y - rtc.z`, derived from the same Z-up→Y-up conversion the mesh/grid/alignment pipeline already uses (`reproject.ts`, `ifc-origin.ts`).
  - `dxfUnderlayToWorldLines3D(entry, shift, elevationRenderY, mapToWorld?, georeferenceAvailable?)` — reuses the existing internal `worldToDrawing` point transform with `mirrorX` always `false` (the 2D flipped-section mirror doesn't apply to 3D) to produce a flat 3D line-list from an underlay's line paths.
- `useDxfUnderlay.ts` gains `useDxfUnderlays3DLines(coordinateInfo)`, filtering on `visible3D` and merging all eligible underlays into one buffer, independent of the 2D panel's section-axis/plan-view gating (the 3D overlay is always eligible, like grid/alignment).
- `packages/renderer`: `uploadDxfLines3D` / `clearDxfLines3D` / `hasDxfLines3D` / `drawDxfLines3D`, a new dedicated buffer mirroring `uploadGridLines3D` exactly (own buffer, shared line pipeline, shared `overlayLineColor`, does not expand model bounds/reframe the camera on upload since it's behind its own toggle).
- `Viewport.tsx` wires it all together, mirroring the existing grid-lines upload effect.

## Design decision: elevation

**DXF carries no Z**, and unlike `IfcAnnotation` (which has a per-primitive Z or falls back to a storey elevation via `elementToStorey`) a DXF underlay has no per-entity Z or storey association the #1782/#1929 import pipeline ever captured. Inventing one (e.g. guessing "ground floor" from spatial hierarchy) would be new, unrequested scope.

**Chosen default: IFC Z = 0 (model origin/grade).** This is the smallest sane default — no data is invented, and it matches the common case the issue describes (a site plan or ground-floor DXF). It is very likely wrong for a DXF meant to sit at some other storey's elevation; there is currently no UI to change it. A per-underlay elevation field (or "snap to nearest storey") is a reasonable follow-up but explicitly out of scope here — please push back if Z=0 is the wrong call for how this is actually used.

## Scope cut: lines only, no fills or per-layer colour in 3D

Only DXF **line paths** (walls/boundaries — the highest-value content of a floor-plan reference layer) are lifted to 3D. **Fills/hatches and text labels are not rendered in 3D in this PR.** The renderer does have a generic fill/text overlay pipeline with per-item colour (used by `IfcAnnotation`'s 3D overlay, `uploadAnnotationFills3D`/`uploadAnnotationTexts3D`), so extending it to DXF fills/text is plausible follow-up work, but doing it well (tessellated hatch fills at the same elevation, billboarded/oriented text) is materially more work than the line-list path and I judged it out of scope for a first iteration.

The **3D lines also lose per-DXF-layer colour**: the renderer's reference-overlay line pipeline already shares ONE colour across grid/alignment/annotation lines (a pre-existing constraint, not something I introduced), and I extended DXF into that same family rather than building a new per-vertex-coloured line pipeline. 2D keeps full per-layer colour, unaffected.

## Verification

- **RED→GREEN + mutation-tested** (python3 exact-substring replace, occurrence count asserted `== 1`, restored by file copy, `diff` confirmed identical):
  - `dxfElevationRenderY`: sign-flip mutation on the `originShift.y` term → 2 tests failed, confirmed caught.
  - `dxfUnderlayToWorldLines3D`: disabled the closed-path branch → 1 test failed; forced `mirrorX: true` → 3 tests failed.
  - `DxfUnderlayPanel`'s new 3D toggle button: wired it to the wrong store action → the new panel test failed.
  - `drawing2DSlice`'s `visible3D` default: flipped `true`→`false` → the new default-value test failed.
- Test counts: `apps/viewer` full suite (`npm test`, node:test) went from baseline (2606 pass / 2608 total, pre-existing 2 skipped) to **2609 pass / 2611 total**, 0 fail. `packages/renderer` suite: 414 pass / 0 fail (its own buffer/upload/draw methods for grid/alignment/DXF are GPU-device-backed and were already untested at that layer before this PR — I did not add tests there either, consistent with existing precedent, not a new gap).
- `pnpm typecheck` and `pnpm build` both green across the whole workspace.
- `pnpm check:api-surface` passes unchanged (new methods on an already-exported `Renderer` class don't change the tracked export surface).
- **Not verified**: I did not run this in a browser — no GPU/visual confirmation that the DXF overlay actually renders correctly against a real model. The renderer-side buffer/pipeline code follows the grid/alignment pattern exactly (same buffer creation, same draw call, same uniform layout), but I have not visually confirmed it. If you can smoke-test it against a model with a georeferenced or plain DXF, that would close the gap the mutation-tested math alone can't.

## Correction to the issue brief

My brief referenced "#1782 (the DXF import PR)" — #1782 is actually the **issue**; the implementing PR was **#1794** ("feat(drawing-2d,viewer): DXF import as 2D reference underlay"). Referenced #1794 throughout instead.

## Changeset

`@ifc-lite/renderer` is published, so it gets a `minor` changeset for the new public methods. `apps/viewer` is private (`@ifc-lite/viewer`) — no changeset for the viewer-side changes.