### PR TITLE
test(viewer): pin that the LocationMap's own WebGL handled reports survive scrub

### DIFF
--- a/apps/viewer/src/lib/analytics.test.ts
+++ b/apps/viewer/src/lib/analytics.test.ts
@@ -231,6 +231,45 @@ describe('scrubEvent — noise filter + PII guard (regression)', () => {
     assert.notEqual(scrubEvent(uncaught('Failed to initialize WebGPU adapter')), null);
     assert.notEqual(scrubEvent(uncaught('WebGL warning: drawArrays: no program bound')), null);
   });
+
+  // #2112: PostHog auto-filed a GitHub issue from the LocationMap's own
+  // `context_lost` handled report. That report's message is
+  // 'Failed to initialize WebGL (context lost)' — a string LocationMap.tsx
+  // synthesizes itself, never MapLibre's own wording, and it does not match
+  // EITHER arm of MAPLIBRE_WEBGL_UNAVAILABLE (the bare arm is anchored with
+  // `$`, so the trailing "(context lost)" fails it; there is no JSON blob for
+  // the other arm). That is fine: these two cases are already `mechanism:
+  // {handled: true}` captures (an explicit `posthog.captureException`, not an
+  // autocaptured throw), so `isUnactionableThirdPartyException`'s `isUnhandled`
+  // gate would keep them even if the message DID match. These tests pin that
+  // down for the two suffixed forms specifically — `probe_no_context` and
+  // `context_lost` — the ones #1914's original test (above) never exercised.
+  it('KEEPS the LocationMap\'s own handled report for context_lost and probe_no_context', () => {
+    const handledReport = (value: string, reason: string): CaptureEvent => ({
+      event: '$exception',
+      properties: {
+        $exception_list: [{
+          type: 'Error',
+          value,
+          mechanism: { handled: true, type: 'generic' },
+        }],
+        context: 'location_map_webgl',
+        map_unavailable_reason: reason,
+      },
+    });
+
+    const contextLost = scrubEvent(
+      handledReport('Failed to initialize WebGL (context lost)', 'context_lost'),
+    );
+    assert.notEqual(contextLost, null);
+    assert.equal(contextLost?.properties?.map_unavailable_reason, 'context_lost');
+
+    const preflight = scrubEvent(
+      handledReport('Failed to initialize WebGL (pre-flight probe)', 'probe_no_context'),
+    );
+    assert.notEqual(preflight, null);
+    assert.equal(preflight?.properties?.map_unavailable_reason, 'probe_no_context');
+  });
 });
 
 describe('scrubEvent — issue grouping', () => {


### PR DESCRIPTION
Investigated the condition behind #2112 (auto-filed by PostHog: *"Failed to initialize WebGL (context lost)"*). **Conclusion: no production change is warranted.** This PR is the one thing that was genuinely missing — a test.

## My starting premise was wrong, and the code says so explicitly

I went in thinking the scrub rule had an anchoring gap: `MAPLIBRE_WEBGL_UNAVAILABLE` matches the bare message with `\s*$`, while `LocationMap.tsx` synthesizes suffixed forms (`(context lost)` at `:604`, `(pre-flight probe)` at `:519`), so our own handled degradations would slip past the filter and auto-file.

The anchoring is real but **irrelevant here**, and for a reason I had not considered: these are `captureException` calls, so posthog-js stamps `mechanism.handled: true`, and the drop rule is gated on `isUnhandled(entry)` (`analytics-scrub.ts:255`). They were never eligible to be scrubbed **regardless of message text**. The comment two lines up already says this is deliberate:

> Scoped to the UNCAUGHT form only: the LocationMap's own once-per-session handled report carries the same message and has to survive, otherwise this rule would blind us to the very condition it exists to de-noise.

So the report reaching error tracking is the system working. `degradeMap` latches the failure for the session, shows a real fallback ("Map preview unavailable on this device", with coordinates, search and export still working — `LocationMap.tsx:835-850`), and reports **once** per session via `takeMapWebglReportSlot()`. Same pattern as `gpu-upload-guard.ts:68-74`, so it is an established convention rather than a one-off.

Two things I deliberately did **not** do:
- **Did not loosen `MAPLIBRE_WEBGL_UNAVAILABLE`.** It would not have changed anything for handled captures, and for the uncaught form it would reintroduce exactly the risk the comment at `:211-215` warns about — a loose matcher goes blind where it matters.
- **Did not stop `degradeMap` using `captureException`.** That is an architectural change against a deliberate, shared pattern, not something scoped to this issue.

Also ruled out a grouping defect: the message is a constant literal with no embedded volatile data, so PostHog's default per-message hashing already collapses every occurrence into one issue. Nothing to fingerprint.

## What was actually missing

Coverage. The existing precedent test covered only the `map_construction_failed` shape (MapLibre's own JSON blob). Nothing pinned the two suffixed messages `LocationMap` itself constructs — the shapes #2112 is actually about. So the guarantee the comment describes was load-bearing and untested.

New test: **KEEPS the LocationMap's own handled report for context_lost and probe_no_context**.

## Evidence

The test was **green immediately with no production change** — which is the finding, not a shortcut: it confirms nothing was broken.

Non-vacuity needed a paired mutation, and that pairing is itself informative — **either mutation alone is insufficient**, because the two mechanisms are independently protective:

| mutation | result |
|---|---|
| drop `&& isUnhandled(entry)` **and** loosen the anchored arm to a substring | **3 fail** — the new test plus the two pre-existing #1914 tests |

Counts printed and asserted `== 1` per replacement, regions re-read, restored by file copy (never `git checkout --`), green again after: 47/47 in `analytics.test.ts`.

Negative cases named in the earlier review still pass: `'Failed to initialize WebGL renderer for the section overlay'` and `'SectionOverlay: Failed to initialize WebGL'` are still NOT scrubbed.

`apps/viewer` full suite 2637 → 2638 (2636 pass, 2 skipped, 0 fail); typecheck clean. No changeset — `@ifc-lite/viewer` is private.

## Not verified

I could not reproduce a real GPU context loss locally. Everything about the WebGL failure mechanics is reasoned from the code and its comments; what I directly tested is the scrub behaviour on events shaped exactly as `degradeMap` constructs them, and that this behaviour is load-bearing.

Issue #2112 untouched — how automated telemetry artifacts get triaged is your call, and if the answer is "PostHog should not open issues for handled captures", that is a setting rather than a code change.