### PR TITLE
fix(sandbox): make the captured-log byte budget a real ceiling

### DIFF
--- a/.changeset/sandbox-log-budget-ceiling.md
+++ b/.changeset/sandbox-log-budget-ceiling.md
@@ -1,0 +1,11 @@
+---
+"@ifc-lite/sandbox": patch
+---
+
+Make the captured-log byte budget an actual ceiling.
+
+The bridge caps captured console output by cumulative serialized size (4 MB), because `vm.dump` copies sandbox values onto the host heap, which the QuickJS memory limit does not bound. The check ran *before* an entry was sized: it compared the running total against the budget, then retained the entry unconditionally, so a single oversized argument (e.g. one `console.log` of a 40 MB string) was retained in full — the check only caught up on the next call, by which point the overshoot was already on the host heap and bounded only by whatever the script chose to log.
+
+The check now runs against the entry about to be added, before it is retained: an entry that would push the cumulative total over the 4 MB budget is refused and replaced by the truncation marker instead of being kept. This is a deliberate behavior change — a script logging one very large payload now sees truncation on that call rather than after it, and the existing boundary test's expectations moved accordingly (three full 1 MB entries plus a marker, not four).
+
+The entry-count cap (1000 entries) is unchanged: it increments by exactly one per call, so its overshoot was already bounded to a single entry and does not have the same unbounded-overshoot shape.

--- a/packages/sandbox/src/bridge-console-budget.test.ts
+++ b/packages/sandbox/src/bridge-console-budget.test.ts
@@ -107,24 +107,72 @@ describe('captured-log byte budget', () => {
     }
   });
 
+  it('refuses a single entry that would overshoot the byte ceiling, rather than retaining it in full', async () => {
+    // #2117: the budget used to be checked BEFORE the entry about to be added,
+    // never against it — so `totalBytes` started at 0 (< MAX_TOTAL_BYTES) and a
+    // single oversized argument sailed through and was retained whole, with the
+    // overshoot bounded only by whatever the script chose to log. One 5 MB
+    // string (well over the 4 MiB budget) must now be refused outright and
+    // replaced by the truncation marker, not retained.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      await withSandbox(async (sandbox) => {
+        const result = await sandbox.eval(
+          'console.log("x".repeat(5 * 1024 * 1024)); 1;',
+        );
+        expect(result.value).toBe(1);
+
+        // The oversized entry must not be present at all.
+        expect(result.logs).toHaveLength(1);
+        expect(result.logs[0]).toMatchObject({ level: 'warn', args: [TRUNCATION_MARKER] });
+
+        // Whatever *is* retained must stay within the 4 MiB budget — this is
+        // the actual property under test: cumulative retained bytes must never
+        // exceed MAX_TOTAL_BYTES, no matter how large a single call's argument.
+        const retainedBytes = JSON.stringify(result.logs.flatMap((entry) => entry.args)).length;
+        expect(retainedBytes).toBeLessThan(4 * 1024 * 1024);
+      });
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
   it('charges serializable entries exactly as before and truncates on the same entry', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     try {
       await withSandbox(async (sandbox) => {
         // Each entry serializes to ["x"*1048576] = 1048576 + 2 quotes +
-        // 2 brackets = 1048580 bytes. Four entries reach 4194320, just past
-        // the 4194304-byte budget, so the fifth call is the one that
-        // truncates and the fourth is not. An off-by-more-than-four-bytes
-        // change in per-entry sizing moves that boundary.
+        // 2 brackets = 1048580 bytes.
+        //
+        // #2117 deliberately moved this boundary. The OLD check-before-add
+        // code (`totalBytes >= MAX_TOTAL_BYTES`, evaluated before the entry
+        // about to be added was even sized) let a fourth full entry land:
+        // 4 x 1048580 = 4194320, which is 16 bytes OVER the 4194304 budget —
+        // the bug this issue fixed, illustrated exactly by that overshoot —
+        // and only the fifth call truncated.
+        //
+        // The NEW check (`totalBytes + entryBytes > MAX_TOTAL_BYTES`,
+        // evaluated before the entry is pushed) walks the running total entry
+        // by entry:
+        //   entry 1: totalBytes   0 + 1048580 = 1048580 <= 4194304 -> pushed
+        //   entry 2: totalBytes 1048580 + 1048580 = 2097160 <= 4194304 -> pushed
+        //   entry 3: totalBytes 2097160 + 1048580 = 3145740 <= 4194304 -> pushed
+        //   entry 4: totalBytes 3145740 + 1048580 = 4194320 >  4194304 -> REFUSED,
+        //            truncation marker pushed instead, `truncated` latches true
+        //   entries 5, 6: `truncated` is already true, eval returns immediately
+        //
+        // So only 3 full entries land (3145740 bytes retained, not 4194320 —
+        // a 4th would put the total 16 bytes over budget), followed by one
+        // truncation marker: `result.logs` has length 4, not 5.
         const result = await sandbox.eval(
           'const payload = "x".repeat(1048576);\nfor (let i = 0; i < 6; i++) console.log(payload);\n7;',
         );
         expect(result.value).toBe(7);
-        expect(result.logs).toHaveLength(5);
-        expect(result.logs.slice(0, 4).map((entry) => (entry.args[0] as string).length)).toEqual([
-          1048576, 1048576, 1048576, 1048576,
+        expect(result.logs).toHaveLength(4);
+        expect(result.logs.slice(0, 3).map((entry) => (entry.args[0] as string).length)).toEqual([
+          1048576, 1048576, 1048576,
         ]);
-        expect(result.logs[4]).toMatchObject({ level: 'warn', args: [TRUNCATION_MARKER] });
+        expect(result.logs[3]).toMatchObject({ level: 'warn', args: [TRUNCATION_MARKER] });
         // Nothing here is unsizeable: the sizing path must stay silent.
         expect(warn.mock.calls.filter((call) => String(call[0]).includes(SIZING_WARNING))).toHaveLength(0);
       });

--- a/packages/sandbox/src/bridge.ts
+++ b/packages/sandbox/src/bridge.ts
@@ -73,7 +73,24 @@ function buildConsole(vm: QuickJSContext, logs: LogEntry[]): () => void {
   // serialized size so an untrusted script (e.g. `for(;;) console.log('x'.repeat(1e6))`)
   // cannot exhaust host memory before the eval timeout fires.
   const MAX_LOG_ENTRIES = 1000;
-  const MAX_TOTAL_BYTES = 4 * 1024 * 1024; // 4MB host budget for captured logs
+  // 4MB host budget for captured logs. Sized via `JSON.stringify(...).length`,
+  // which counts UTF-16 code units, not real UTF-8 bytes — for ASCII content
+  // the two coincide, but multi-byte UTF-8 (e.g. CJK) is undercounted by up to
+  // ~133% (`JSON.stringify(['日本語のログ出力']).length` is 12,
+  // `Buffer.byteLength(...)` is 28). Switching to a byte-accurate measure
+  // (`new TextEncoder().encode(str).length`, not `Buffer.byteLength` — this
+  // runs in browsers too) was evaluated and deliberately not done: a
+  // microbenchmark (`.length` vs `TextEncoder().encode().length` on 1MB/10MB
+  // ASCII strings) measured the encode call ~1000-2000x slower than `.length`,
+  // because it allocates a whole new buffer proportional to the string being
+  // measured. That cost lands on every captured log call, including the
+  // adversarial ones this budget exists to cheaply reject (e.g. a script
+  // logging a single 40MB string) — before the entry is even rejected, sizing
+  // it would itself allocate tens of MB of scratch buffer. Undercounting
+  // code-unit length against a byte budget is a real gap, but not one worth
+  // paying an O(n) allocation on every call, including the ones this cap is
+  // supposed to make cheap to refuse. See #2117.
+  const MAX_TOTAL_BYTES = 4 * 1024 * 1024;
   let totalBytes = 0;
   let truncated = false;
   // The sizing failure below is script-controlled, so it must not be logged
@@ -99,7 +116,10 @@ function buildConsole(vm: QuickJSContext, logs: LogEntry[]): () => void {
     for (const level of ['log', 'warn', 'error', 'info'] as const) {
       const fn = vm.newFunction(level, (...args: QuickJSHandle[]) => {
         if (truncated) return;
-        if (logs.length >= MAX_LOG_ENTRIES || totalBytes >= MAX_TOTAL_BYTES) {
+        // Entry-count is checked up front: it is a per-call increment of
+        // exactly 1, so overshoot is bounded to one entry past the cap. The
+        // byte budget cannot be checked this way — see below.
+        if (logs.length >= MAX_LOG_ENTRIES) {
           truncated = true;
           logs.push({ level: 'warn', args: ['[log output truncated: limit reached]'], timestamp: Date.now() });
           return;
@@ -126,6 +146,20 @@ function buildConsole(vm: QuickJSContext, logs: LogEntry[]): () => void {
               err,
             );
           }
+        }
+        // Checked AGAINST the entry about to be added, before it is pushed
+        // (#2117): the old `totalBytes >= MAX_TOTAL_BYTES` check ran before
+        // this entry's size was even known, so a single oversized argument
+        // (e.g. a script logging one 40MB string) was retained in full — the
+        // check only caught up on the *next* call, by which point the
+        // overshoot had already happened and was bounded only by what the
+        // script chose to log. Refusing here means the ceiling is an actual
+        // ceiling: an entry that would push totalBytes over budget is dropped
+        // in favor of the truncation marker, not retained.
+        if (totalBytes + entryBytes > MAX_TOTAL_BYTES) {
+          truncated = true;
+          logs.push({ level: 'warn', args: ['[log output truncated: limit reached]'], timestamp: Date.now() });
+          return;
         }
         totalBytes += entryBytes;
         logs.push({ level, args: entryArgs, timestamp: Date.now() });

--- a/packages/sandbox/src/log-budget-reset.test.ts
+++ b/packages/sandbox/src/log-budget-reset.test.ts
@@ -30,10 +30,14 @@ const TRUNCATION_MARKER = '[log output truncated: limit reached]';
 const MAX_LOG_ENTRIES = 1000;
 
 /**
- * Logs six 1 MB strings: four entries reach 4194320 bytes, just past the
- * 4194304-byte budget, so the fifth call truncates. Returns the marker entry
- * as proof the budget was actually reached — without it every assertion about
- * the *next* eval would be vacuous.
+ * Logs six 1 MB strings. Each entry serializes to 1048580 bytes
+ * (1048576 chars + 2 quotes + 2 brackets). The budget is checked as
+ * `totalBytes + entryBytes > MAX_TOTAL_BYTES` before an entry is pushed
+ * (#2117), so the running total after 3 entries is 3145740 (<= 4194304, all
+ * pushed) and a 4th would be 4194320 (> 4194304, refused): the 4th call is
+ * the one that truncates, not the 5th. Returns the marker entry as proof the
+ * budget was actually reached — without it every assertion about the *next*
+ * eval would be vacuous.
  */
 const EXHAUST_BYTE_BUDGET = logPayloads(6);
 
@@ -64,8 +68,8 @@ describe('captured-log budget scope', () => {
     await withSandbox(async (sandbox) => {
       const first = await sandbox.eval(EXHAUST_BYTE_BUDGET, { typescript: false });
       // The budget really was reached — otherwise this test proves nothing.
-      expect(first.logs).toHaveLength(5);
-      expect(first.logs[4]).toMatchObject({ level: 'warn', args: [TRUNCATION_MARKER] });
+      expect(first.logs).toHaveLength(4);
+      expect(first.logs[3]).toMatchObject({ level: 'warn', args: [TRUNCATION_MARKER] });
 
       const second = await sandbox.eval('console.log("second"); 2;', { typescript: false });
 
@@ -94,11 +98,11 @@ describe('captured-log budget scope', () => {
       const result = await sandbox.eval(EXHAUST_BYTE_BUDGET, { typescript: false });
 
       expect(result.value).toBe(1);
-      expect(result.logs).toHaveLength(5);
-      expect(result.logs.slice(0, 4).map((entry) => (entry.args[0] as string).length)).toEqual([
-        1048576, 1048576, 1048576, 1048576,
+      expect(result.logs).toHaveLength(4);
+      expect(result.logs.slice(0, 3).map((entry) => (entry.args[0] as string).length)).toEqual([
+        1048576, 1048576, 1048576,
       ]);
-      expect(result.logs[4]).toMatchObject({ level: 'warn', args: [TRUNCATION_MARKER] });
+      expect(result.logs[3]).toMatchObject({ level: 'warn', args: [TRUNCATION_MARKER] });
     });
   }, 60_000);
 
@@ -119,7 +123,7 @@ describe('captured-log budget scope', () => {
   it('does not let an exhausting script silence an eval that throws', async () => {
     await withSandbox(async (sandbox) => {
       const first = await sandbox.eval(EXHAUST_BYTE_BUDGET, { typescript: false });
-      expect(first.logs[4]).toMatchObject({ args: [TRUNCATION_MARKER] });
+      expect(first.logs[3]).toMatchObject({ args: [TRUNCATION_MARKER] });
 
       await expect(
         sandbox.eval('console.log("before throw"); throw new Error("boom");', { typescript: false }),


### PR DESCRIPTION
Closes #2117

## The defect

`buildConsole` in `packages/sandbox/src/bridge.ts` checked `totalBytes >= MAX_TOTAL_BYTES` *before* the entry about to be added was sized, never against it. So `totalBytes` started at 0 (`< MAX_TOTAL_BYTES`) and a single oversized argument — e.g. one `console.log` of a 40 MB string — was retained in full. The check only caught up on the *next* call, by which point the overshoot was already on the host heap and bounded only by whatever the untrusted script chose to log (measured: 10x overshoot at 40 MB, 100x at 400 MB, per the issue's probe data).

## The fix

Size the entry first, then check `totalBytes + entryBytes > MAX_TOTAL_BYTES` *before* pushing it. An entry that would cross the ceiling is refused (replaced by the truncation marker) instead of retained, so the 4 MB budget is an actual ceiling rather than advisory.

The entry-count cap (1000 entries) is unchanged — it increments by exactly one per call, so its overshoot was already bounded to a single entry and doesn't have the same unbounded shape.

## The boundary moved — deliberately

The existing test `charges serializable entries exactly as before and truncates on the same entry` pinned the *old* boundary honestly: 4 full 1 MB entries (4 × 1048580 = 4,194,320 bytes) landed against the 4,194,304-byte budget — 16 bytes over by design — before the 5th call truncated.

Under the new check, walking the running total entry by entry:
- entry 1: `0 + 1048580 = 1048580 <= 4194304` → pushed
- entry 2: `1048580 + 1048580 = 2097160 <= 4194304` → pushed
- entry 3: `2097160 + 1048580 = 3145740 <= 4194304` → pushed
- entry 4: `3145740 + 1048580 = 4194320 > 4194304` → **refused**, truncation marker pushed instead

So only 3 full entries land (3,145,740 bytes), followed by the marker — `result.logs` has length 4, not 5. Updated that test (and the analogous boundary assertions in `log-budget-reset.test.ts`) with the derivation in a comment, not just the new numbers.

Also added a new test, `refuses a single entry that would overshoot the byte ceiling, rather than retaining it in full`, which is the direct regression test for the issue: one 5 MB `console.log` argument must be refused outright (not retained), and cumulative retained bytes must stay under the 4 MiB budget.

## Byte-unit question (evaluated, not changed)

The issue also asked to evaluate switching from `String.length` (UTF-16 code units) to real UTF-8 byte counting (`TextEncoder().encode(str).length`, not `Buffer.byteLength` — this runs in browsers too), since code units undercount multi-byte UTF-8 by up to ~133% for e.g. CJK.

Measured `.length` vs `new TextEncoder().encode(str).length` on 1 MB / 10 MB ASCII strings: the encode call was roughly 1000–2000x slower, because it allocates a new buffer proportional to the string being measured. That cost would land on *every* captured log call, including the adversarial ones this cap exists to cheaply reject — sizing a 40 MB adversarial string would itself allocate tens of MB of scratch buffer before the entry is even refused. Left as code-unit counting for now; documented the tradeoff in a comment above `MAX_TOTAL_BYTES` in `bridge.ts` so the gap is recorded rather than silent.

## Testing

- RED: new regression test written first, failed against unfixed code (full 5 MB string retained instead of the truncation marker).
- GREEN: `packages/sandbox` full suite — 11 files / 69 tests passing (baseline before this change: 68 tests).
- `pnpm exec tsc --noEmit` in `packages/sandbox`: clean.
- Mutation test: reverted the pre-push byte check back to the old check-before-add shape via an exact-substring Python replacement (verified `n == 1`), re-ran the suite — 5 failures (the new regression test, the updated boundary test, and 3 in `log-budget-reset.test.ts`), confirming the tests actually pin this fix. Restored the fixed file by copy (not `git checkout --`), suite green again.

## Changeset

`.changeset/sandbox-log-budget-ceiling.md` — patch bump for `@ifc-lite/sandbox`, states the behavior change plainly: a script logging one very large payload now sees truncation on that call rather than after it.