### PR TITLE
test(geometry): make the sub-unit/nonuniform instancing loop real (#2064 follow-up)

### DIFF
--- a/rust/geometry/tests/fixtures/issue_1985_metre_submm_scale.ifc
+++ b/rust/geometry/tests/fixtures/issue_1985_metre_submm_scale.ifc
@@ -19,9 +19,27 @@ DATA;
 #11=IFCEXTRUDEDAREASOLID(#8,#10,#9,1734.5);
 #12=IFCSHAPEREPRESENTATION(#5,'Body','SweptSolid',(#11));
 #13=IFCREPRESENTATIONMAP(#2,#12);
-/* ---- Map B: wraps map A through a NESTED IfcMappedItem (inner Scale=0.001) ---- */
+/* ---- Map A2: a SEPARATE copy of map A's solid, used only by the nested wrap
+   below. The router's occurrence-count plan (#1623 Phase 2) tallies every
+   IfcMappedItem referencing a source, including one nested inside another
+   map's representation -- so if the nested wrap pointed at #13 itself, its
+   IfcMappedItem (#15) would inflate #13's count to 3 and (being the
+   lowest express id) get PICKED as the don't-bake template, even though it
+   never runs through the top-level template/retag path (only depth == 0
+   items do, see router/processing.rs). That starves both top-level
+   occurrences of #13 of a real template and routes them through orphan
+   recovery instead -- silently correct output, but instancing never
+   actually engages. Giving the nested wrap its own source keeps #13's count
+   at exactly 2 (occurrences A and B below), so instancing engages for real. ---- */
+#200=IFCCARTESIANPOINT((0.,0.));
+#201=IFCAXIS2PLACEMENT2D(#200,$);
+#202=IFCCIRCLEPROFILEDEF(.AREA.,'P',#201,50.);
+#203=IFCEXTRUDEDAREASOLID(#202,#10,#9,1734.5);
+#204=IFCSHAPEREPRESENTATION(#5,'Body','SweptSolid',(#203));
+#205=IFCREPRESENTATIONMAP(#2,#204);
+/* ---- Map B: wraps map A2 through a NESTED IfcMappedItem (inner Scale=0.001) ---- */
 #14=IFCCARTESIANTRANSFORMATIONOPERATOR3D($,$,#1,0.001,$);
-#15=IFCMAPPEDITEM(#13,#14);
+#15=IFCMAPPEDITEM(#205,#14);
 #16=IFCSHAPEREPRESENTATION(#5,'Body','MappedRepresentation',(#15));
 #17=IFCREPRESENTATIONMAP(#2,#16);
 /* ---- Operators ---- */

--- a/rust/processing/tests/issue_1985_mapped_item_transform.rs
+++ b/rust/processing/tests/issue_1985_mapped_item_transform.rs
@@ -188,6 +188,21 @@ fn mapping_origin_is_composed_inside_the_mapping_target() {
 /// #1985's reporter later narrowed their file to `IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.)`
 /// with a pipe whose `Length` property reads `1734.50 mm`; the fixture uses those
 /// exact numbers so a dropped or doubled 1000× would be unmissable.
+///
+/// Occurrences A (#74, uniform `Scale = 0.001`) and B (#81, non-uniform
+/// `(0.001, 0.001, 0.002)`) share the SAME `IfcRepresentationMap` (#13, differing
+/// only by `MappingTarget`), which is exactly the router's don't-bake eligibility
+/// condition (see `router/processing.rs`'s "occurrences sharing a map but
+/// differing by target collate under one template" and
+/// `router/instancing.rs::mapped_source_single_item`) — so under
+/// `enable_instancing` A materializes as the template and B rides as an
+/// `InstanceRecord`. That makes this fixture, not just `issue_1985_mapping_origin.ifc`,
+/// exercise the instanced path — and it is the one the non-uniform/sub-unit scale
+/// composition actually depends on, since B's `local_transform` under instancing
+/// is the same non-uniform scale baked under materialization. #88's nested map
+/// (its own, separate source — see the fixture comment) is never don't-bake
+/// eligible (`mapped_source_single_item` excludes nested-mapped sources), so it
+/// materializes flat under both settings.
 #[test]
 fn sub_unit_scales_nonuniform_and_nested_maps_match_direct_metre_authoring() {
     for instancing in [false, true] {
@@ -199,14 +214,60 @@ fn sub_unit_scales_nonuniform_and_nested_maps_match_direct_metre_authoring() {
 
         // #99: the pipe authored directly in metres — the reference.
         assert_close(size(99), [0.1, 0.1, 1.7345], "direct metre pipe");
-        // #74: mm-authored map, uniform Scale = 0.001.
+        // #74: mm-authored map, uniform Scale = 0.001 — the don't-bake TEMPLATE
+        // occurrence of #13, so it materializes under both settings.
         assert_close(size(74), size(99), "uniform 0.001 vs direct");
-        // #88: the same map reached through a NESTED IfcMappedItem — inner
-        // Scale = 0.001 composed inside an outer Scale = 1.
+        // #88: the same solid reached through a NESTED IfcMappedItem — inner
+        // Scale = 0.001 composed inside an outer Scale = 1. Never don't-bake
+        // eligible, so it materializes flat under both settings too.
         assert_close(size(88), size(99), "nested map vs direct");
-        // #81: IfcCartesianTransformationOperator3DnonUniform (0.001, 0.001,
-        // 0.002) — Z twice the others, so an operator that collapsed to its X
-        // scale (or read Scale3 from the wrong attribute) halves this.
-        assert_close(size(81), [0.1, 0.1, 3.469], "non-uniform 3D operator");
+
+        if !instancing {
+            // #81: IfcCartesianTransformationOperator3DnonUniform (0.001, 0.001,
+            // 0.002) — Z twice the others, so an operator that collapsed to its X
+            // scale (or read Scale3 from the wrong attribute) halves this.
+            assert_close(size(81), [0.1, 0.1, 3.469], "non-uniform 3D operator");
+            continue;
+        }
+
+        // With instancing on, #81 shares #13 with the #74 template and skips
+        // materialization, riding as an InstanceRecord instead. Reconstruct it
+        // the way the renderer and the GLB exporter do — template world vertices
+        // placed by the record's mat4 — and assert the ABSOLUTE result, so a
+        // non-uniform scale dropped or miscomposed ONLY on the instanced
+        // `local_transform` path (as opposed to the materialized-mesh path
+        // `size(74)` above already covers) cannot pass silently.
+        let record = res
+            .instances
+            .iter()
+            .find(|i| i.express_id == 81)
+            .expect("occurrence #81 (non-uniform) should ride as an instance record");
+        assert_eq!(record.template_express_id, 74, "template for #81");
+        let template = mesh_by_id(&res, 74);
+        let (mut min, mut max) = ([f64::INFINITY; 3], [f64::NEG_INFINITY; 3]);
+        for v in template.positions.chunks_exact(3) {
+            let (x, y, z) = (
+                template.origin[0] + v[0] as f64,
+                template.origin[1] + v[1] as f64,
+                template.origin[2] + v[2] as f64,
+            );
+            let t = record.transform.map(|c| c as f64);
+            let w = [
+                t[0] * x + t[1] * y + t[2] * z + t[3],
+                t[4] * x + t[5] * y + t[6] * z + t[7],
+                t[8] * x + t[9] * y + t[10] * z + t[11],
+            ];
+            let h = t[12] * x + t[13] * y + t[14] * z + t[15];
+            for k in 0..3 {
+                min[k] = min[k].min(w[k] / h);
+                max[k] = max[k].max(w[k] / h);
+            }
+        }
+        let reconstructed = [max[0] - min[0], max[1] - min[1], max[2] - min[2]];
+        assert_close(
+            reconstructed,
+            [0.1, 0.1, 3.469],
+            "instanced #81 reconstructed non-uniform size",
+        );
     }
 }


### PR DESCRIPTION
Follow-up to #2064, which merged at 13:44 while this was being worked. Rebased onto current `main` and opened separately rather than pushed to a merged branch.

Closes the finding @louistrue raised on #2064: `for instancing in [false, true]` in `sub_unit_scales_nonuniform_and_nested_maps_match_direct_metre_authoring` reads as a coverage matrix it cannot deliver — his probe showed `instances=0` on both iterations, so the second re-runs the first.

## Chose option (2), and the router says why

He offered two remedies and said we were better placed to judge: drop the loop, or give the fixture a shared map so the instanced path is real. The deciding question was whether sub-unit scaling and instancing *can* interact — and they can.

`router/instancing.rs::mapped_source_single_item` and the `instance_solid_id`/`nontrivial_target` composition in `router/processing.rs` take the don't-bake path whenever **two or more top-level `IfcMappedItem`s share one `IfcRepresentationMap`, even with different `MappingTarget`s** — the code documents it directly: *"occurrences sharing a map but differing by target collate under one template."*

That is exactly the sub-unit / non-uniform scale composition this test pins, so the instanced path is reachable for it and deserved real coverage. Dropping the loop would have been the cheaper answer to the wrong question.

## The fixture was starving instancing, not merely failing to use it

Worth stating because it changes what the old loop was doing. The nested-map occurrence previously reused `#13`, so `#13`'s occurrence count included a nested `IfcMappedItem` with a lower express id, which was miscounted as the don't-bake template. Both real occurrences were starved and everything routed through orphan recovery — correct output, instancing never engaged, no signal that anything was off.

Now: occurrences A (uniform `0.001`) and B (non-uniform `0.001/0.001/0.002`) share `#13`; the nested-map occurrence gets its own source (`#205`).

```
before:  instancing=false meshes=4 instances=0
         instancing=true  meshes=4 instances=0
after:   instancing=true  meshes=3 instances=1   (template_express_id == 74)
```

The test now branches like `mapping_origin_is_composed_inside_the_mapping_target` already did — materialized assertions when `!instancing`, and for `instancing=true` it reconstructs occurrence B's world geometry from its `InstanceRecord` transform against the A template.

## Evidence

Mutating the router's non-template composition to identity (`local_rm = mapping_transform.map(|_t| IDENTITY_ROW_MAJOR)`; single replacement asserted, region re-read, restored by file copy):

```
before this change:  sub_unit test PASSES  — the instanced branch never ran
after:               2 failed  (sub_unit + mapping_origin)
```

That is the whole point: the sub-unit test could not previously have caught a broken instanced transform, and now does. `mapping_origin` failing alongside is expected — it always covered that path.

`cargo test -p ifc-lite-processing` green; `cargo clippy -p ifc-lite-core -p ifc-lite-processing --all-targets -- -D warnings` clean on this base.

**A note on clippy**, since it was reported as failing during the work: those errors came from the old branch being 30 commits behind, not from this change. On current `main` the same crates lint clean, which is why this is rebased rather than merged.

No changeset — test and fixture only, no published behaviour change.