### PR TITLE
fix(viewer): drop ResizeObserver loop noise from error tracking

### DIFF
--- a/apps/viewer/src/lib/analytics-scrub.ts
+++ b/apps/viewer/src/lib/analytics-scrub.ts
@@ -224,6 +224,24 @@ const MAPLIBRE_WEBGL_UNAVAILABLE =
 // if a "Script error." ever arrives with a usable stack, it is ours to fix.
 const OPAQUE_CROSS_ORIGIN = /^Script error\.?$/i;
 
+// The browser dispatches this as a bare ErrorEvent on `window` whenever a
+// ResizeObserver callback resized something, so a notification round has to
+// be deferred to the next frame — the spec's documented, intentionally
+// non-fatal condition, not a hung page or an infinite loop. It fires from
+// textbook-correct observer code (this repo's dozen ResizeObserver call
+// sites in Viewport.tsx, Drawing2DCanvas.tsx, GanttTimeline.tsx,
+// AnnotationLayer.tsx, etc. were audited for #2120 and none mutates the
+// element it observes), which is exactly why it surfaces as a warning-shaped
+// message rather than throwing a real Error: no Error object, no file/line,
+// no stack — the same opaque, information-free shape as "Script error."
+// above, so it gets the same `frameCount === 0` gate: if this message ever
+// arrives WITH a stack, something in our code threw it deliberately, and
+// that is ours to look at, not noise. Anchored to the two known browser
+// wordings (Chromium's current text and the older/WebKit "loop limit
+// exceeded"), never a substring test — dropping is irreversible.
+const RESIZE_OBSERVER_LOOP =
+  /^ResizeObserver loop (?:completed with undelivered notifications\.?|limit exceeded)$/i;
+
 const frameCount = (e: unknown): number => {
   const frames = (e as { stacktrace?: { frames?: unknown } } | null)
     ?.stacktrace?.frames;
@@ -254,6 +272,7 @@ const isUnactionableThirdPartyException = (
     // this rule would blind us to the very condition it exists to de-noise.
     if (MAPLIBRE_WEBGL_UNAVAILABLE.test(value) && isUnhandled(entry)) return true;
     if (OPAQUE_CROSS_ORIGIN.test(value.trim()) && frameCount(entry) === 0) return true;
+    if (RESIZE_OBSERVER_LOOP.test(value.trim()) && frameCount(entry) === 0) return true;
     return false;
   });
 };

--- a/apps/viewer/src/lib/analytics.test.ts
+++ b/apps/viewer/src/lib/analytics.test.ts
@@ -270,6 +270,51 @@ describe('scrubEvent — noise filter + PII guard (regression)', () => {
     assert.notEqual(preflight, null);
     assert.equal(preflight?.properties?.map_unavailable_reason, 'probe_no_context');
   });
+
+  // ── ResizeObserver loop noise (issue #2120) ───────────────────────────────
+  // The browser dispatches this as a bare ErrorEvent on `window` (via
+  // `onerror`) whenever a ResizeObserver callback resizes something, so a
+  // notification has to be deferred to the next frame — no Error object, no
+  // stack, no file/line. It fires from textbook-correct observer code, which
+  // is exactly why the spec authors made it a warning-shaped message instead
+  // of an actual error. Two wordings exist in the wild: Chromium's current
+  // "…completed with undelivered notifications." and the older/WebKit
+  // "…loop limit exceeded".
+  it('drops the ResizeObserver loop noise (both known wordings, no stack)', () => {
+    assert.equal(
+      scrubEvent(uncaught('ResizeObserver loop completed with undelivered notifications.')),
+      null,
+    );
+    assert.equal(scrubEvent(uncaught('ResizeObserver loop limit exceeded')), null);
+  });
+
+  it('KEEPS a ResizeObserver message that ever arrives WITH a stack', () => {
+    // If this ever carries frames, it is not the opaque browser-dispatched
+    // form — something in our code threw it, and that is ours to look at.
+    const withStack: CaptureEvent = {
+      event: '$exception',
+      properties: {
+        $exception_list: [{
+          type: 'Error',
+          value: 'ResizeObserver loop completed with undelivered notifications.',
+          mechanism: { handled: false },
+          stacktrace: { frames: [{ source: '/assets/index.js' }] },
+        }],
+      },
+    };
+    assert.notEqual(scrubEvent(withStack), null);
+  });
+
+  it('KEEPS an unrelated message that merely MENTIONS ResizeObserver', () => {
+    // Narrowness guard: the matcher is anchored to the exact browser strings,
+    // not a loose substring test, so a genuine bug of ours that happens to
+    // mention ResizeObserver in passing must survive.
+    assert.notEqual(
+      scrubEvent(uncaught("Cannot read properties of undefined (reading 'ResizeObserver')")),
+      null,
+    );
+    assert.notEqual(scrubEvent(uncaught('ResizeObserver is not defined')), null);
+  });
 });
 
 describe('scrubEvent — issue grouping', () => {


### PR DESCRIPTION
## Summary

- #2120 was auto-filed by PostHog from `ResizeObserver loop completed with undelivered notifications.` — the browser's documented, non-fatal signal that a resize notification had to be deferred a frame. It fires from correct observer code and (per Chromium/WebKit) carries no Error object, file/line, or stack.
- Audited every `ResizeObserver` call site in the viewer (`Viewport.tsx`, `Drawing2DCanvas.tsx`, `GanttTimeline.tsx`, `AnnotationLayer.tsx`, `SidebarDock.tsx`, `FloatingPanelHost.tsx`, and the MCP landing/playground/hero demos) — none of them mutates the size of the element it observes, so there is no runaway resize loop of ours behind this message; it's third-party browser noise, same class as the existing Cesium/Outlook/MapLibre/opaque-cross-origin entries in `analytics-scrub.ts`.
- Added a matcher following that file's conventions: anchored to the two known browser wordings (Chromium's current text and the older/WebKit "loop limit exceeded"), gated on zero stack frames (mirroring the `OPAQUE_CROSS_ORIGIN` "Script error." matcher) — if this message ever arrives WITH a stack, it means our own code threw it, and that stays reported.

## Test plan

- [x] RED: new test asserting the message is dropped, failing before the matcher existed
- [x] GREEN: `apps/viewer` — `analytics.test.ts` 47 → 50 tests, all passing
- [x] Negative cases: a message merely mentioning "ResizeObserver" (unrelated bug), and the same message WITH a stack, both survive
- [x] Mutation test: disabling the new matcher branch kills exactly 1 test (49 pass / 1 fail), restored by file copy
- [x] Full `apps/viewer` suite: 1990 → 1993 tests, pass count +3, the same 80 pre-existing unrelated failures (missing built workspace packages in a fresh worktree) before and after
- [x] No changeset — `@ifc-lite/viewer` is `private: true`