### PR TITLE
fix(mcp): diagnose two of the three silent catches flagged on #2100

### DIFF
--- a/.changeset/mcp-viewer-manager-diagnostics.md
+++ b/.changeset/mcp-viewer-manager-diagnostics.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/mcp": patch
+---
+
+`ViewerManager` now warns once per session when an SSE frame from the viewer fails to parse as JSON, or when GlobalId enrichment fails for a picked selection (#2100 follow-up). Both paths still degrade the same way as before — a bad frame is dropped, a selection without a GlobalId is still reported — but they no longer swallow the failure with no diagnostic at all. Both triggers are viewer-client controlled and can repeat at high frequency (once per frame, once per pick), so the warning is a once-per-session latch rather than a per-occurrence log, reset the next time `open()` starts a session.

--- a/packages/mcp/src/viewer-manager.test.ts
+++ b/packages/mcp/src/viewer-manager.test.ts
@@ -85,7 +85,7 @@ describe('ViewerManager silent catches', () => {
       expect(warnSpy.mock.calls[0][0]).toContain('[viewer-manager]');
     });
 
-    it('warns again after a fresh session (open() resets the latch)', () => {
+    it('warns again after a fresh session (open() resets the latch)', async () => {
       const vm = new ViewerManager(() => null);
       const handleSseFrame = vm['handleSseFrame'].bind(vm);
 
@@ -93,11 +93,16 @@ describe('ViewerManager silent catches', () => {
       handleSseFrame('data: {still not json');
       expect(warnSpy).toHaveBeenCalledTimes(1);
 
-      // A fresh session (as open() would start) resets the per-session latch.
-      vm['sseParseWarned'] = false;
-
-      handleSseFrame('data: {yet another bad frame');
-      expect(warnSpy).toHaveBeenCalledTimes(2);
+      // Drive the reset through the real entry point — open() — rather than
+      // poking the private field. Port 0 binds an ephemeral port so this
+      // stays a fast, parallel-safe unit test.
+      await vm.open(model);
+      try {
+        handleSseFrame('data: {yet another bad frame');
+        expect(warnSpy).toHaveBeenCalledTimes(2);
+      } finally {
+        vm.close();
+      }
     });
   });
 
@@ -114,7 +119,7 @@ describe('ViewerManager silent catches', () => {
       expect(warnSpy.mock.calls[0][0]).toContain('[viewer-manager]');
     });
 
-    it('warns again after a fresh session (open() resets the latch)', () => {
+    it('warns again after a fresh session (open() resets the latch)', async () => {
       const vm = new ViewerManager(() => model);
       const handlePicked = vm['handlePicked'].bind(vm);
 
@@ -122,10 +127,16 @@ describe('ViewerManager silent catches', () => {
       handlePicked(wallExpressId, 'IfcWall');
       expect(warnSpy).toHaveBeenCalledTimes(1);
 
-      vm['globalIdWarned'] = false;
-
-      handlePicked(wallExpressId, 'IfcWall');
-      expect(warnSpy).toHaveBeenCalledTimes(2);
+      // Drive the reset through the real entry point — open() — rather than
+      // poking the private field. Port 0 binds an ephemeral port so this
+      // stays a fast, parallel-safe unit test.
+      await vm.open(model);
+      try {
+        handlePicked(wallExpressId, 'IfcWall');
+        expect(warnSpy).toHaveBeenCalledTimes(2);
+      } finally {
+        vm.close();
+      }
     });
   });
 });

--- a/packages/mcp/src/viewer-manager.test.ts
+++ b/packages/mcp/src/viewer-manager.test.ts
@@ -1,0 +1,131 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ViewerManager } from './viewer-manager.js';
+import { loadIfcModel } from './loader.js';
+import type { LoadedModel } from './context.js';
+
+// EntityNode is mocked so `handlePicked`'s globalId enrichment can be forced
+// to throw without depending on a real malformed row. `handlePicked` invokes
+// this with `new`, so the mock must be a real class (vitest warns — and, left
+// as an arrow-function mockImplementation, pollutes the very console.warn spy
+// under test — if a `vi.fn()` is `new`'d without one).
+vi.mock('@ifc-lite/query', () => ({
+  EntityNode: class ThrowingEntityNode {
+    constructor() {
+      throw new Error('boom: malformed entity row');
+    }
+  },
+}));
+
+const MODEL = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('m','2026',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1= IFCPROJECT('0$aXM2u710w8JJXA1sQ$4',$,'Proj',$,$,$,$,(#20),#30);
+#20= IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#21,$);
+#21= IFCAXIS2PLACEMENT3D(#22,$,$);
+#22= IFCCARTESIANPOINT((0.,0.,0.));
+#30= IFCUNITASSIGNMENT((#31));
+#31= IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#40= IFCLOCALPLACEMENT($,#21);
+#72= IFCWALL('0$aXM2u710w8JJXA1sQ$5',$,'Wall A',$,$,#40,$,'tagA',$);
+ENDSEC;
+END-ISO-10303-21;
+`;
+
+describe('ViewerManager silent catches', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let dir: string;
+  let model: LoadedModel;
+  let wallExpressId: number;
+
+  beforeAll(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'ifc-lite-viewer-manager-'));
+    const filePath = join(dir, 'model.ifc');
+    await writeFile(filePath, MODEL);
+    model = await loadIfcModel(filePath);
+    const wall = [...model.store.entityIndex.byId.entries()].find(
+      ([, row]) => row.type === 'IFCWALL',
+    );
+    if (!wall) throw new Error('fixture wall not found in parsed store');
+    wallExpressId = wall[0];
+  });
+
+  afterAll(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  describe('SSE frame parse failure', () => {
+    it('warns once even across many malformed frames in the same session', () => {
+      const vm = new ViewerManager(() => null);
+      const handleSseFrame = vm['handleSseFrame'].bind(vm);
+
+      for (let i = 0; i < 5; i++) {
+        handleSseFrame('data: {not json');
+      }
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toContain('[viewer-manager]');
+    });
+
+    it('warns again after a fresh session (open() resets the latch)', () => {
+      const vm = new ViewerManager(() => null);
+      const handleSseFrame = vm['handleSseFrame'].bind(vm);
+
+      handleSseFrame('data: {not json');
+      handleSseFrame('data: {still not json');
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+
+      // A fresh session (as open() would start) resets the per-session latch.
+      vm['sseParseWarned'] = false;
+
+      handleSseFrame('data: {yet another bad frame');
+      expect(warnSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('globalId enrichment failure', () => {
+    it('warns once even across many picked events in the same session', () => {
+      const vm = new ViewerManager(() => model);
+      const handlePicked = vm['handlePicked'].bind(vm);
+
+      for (let i = 0; i < 5; i++) {
+        handlePicked(wallExpressId, 'IfcWall');
+      }
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toContain('[viewer-manager]');
+    });
+
+    it('warns again after a fresh session (open() resets the latch)', () => {
+      const vm = new ViewerManager(() => model);
+      const handlePicked = vm['handlePicked'].bind(vm);
+
+      handlePicked(wallExpressId, 'IfcWall');
+      handlePicked(wallExpressId, 'IfcWall');
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+
+      vm['globalIdWarned'] = false;
+
+      handlePicked(wallExpressId, 'IfcWall');
+      expect(warnSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/packages/mcp/src/viewer-manager.ts
+++ b/packages/mcp/src/viewer-manager.ts
@@ -56,6 +56,15 @@ export class ViewerManager {
   private listeners = new Set<SelectionListener>();
   private sseAbort: AbortController | null = null;
   private resolveModel: (id: string | null) => LoadedModel | null;
+  /**
+   * Once-per-session latches for the two high-frequency degradation paths
+   * below (`handleSseFrame`, `handlePicked`). Both triggers are viewer/client
+   * controlled and can repeat once per frame or once per pick — logging every
+   * occurrence would let a misbehaving or hostile viewer client flood the
+   * host console. Reset in `open()` so a fresh session reports again.
+   */
+  private sseParseWarned = false;
+  private globalIdWarned = false;
 
   constructor(resolveModel: (id: string | null) => LoadedModel | null) {
     this.resolveModel = resolveModel;
@@ -111,6 +120,8 @@ export class ViewerManager {
     this.modelId = model.id;
     this.startedAt = Date.now();
     this.currentSelection = [];
+    this.sseParseWarned = false;
+    this.globalIdWarned = false;
     this.subscribeToEvents();
     return this.state() as ViewerState;
   }
@@ -200,11 +211,22 @@ export class ViewerManager {
     let parsed: { action?: string; expressId?: number; ifcType?: string };
     try {
       parsed = JSON.parse(payload) as typeof parsed;
-    } catch {
-      // Legitimately silent: the viewer's SSE stream carries frames this
-      // client does not model (and comment/keepalive lines). A frame we can't
-      // parse is one we don't act on — dropping it loses nothing, and logging
-      // would fire per frame on an unrelated producer.
+    } catch (err) {
+      // Legitimately silent as a *control-flow* matter: the viewer's SSE
+      // stream carries frames this client does not model (and
+      // comment/keepalive lines). A frame we can't parse is one we don't act
+      // on — dropping it loses nothing, and the caller's contract (no throw)
+      // is unchanged. But it should not be silent as a *diagnostic* matter:
+      // warn once per session rather than once per frame, since this trigger
+      // is server-controlled and can repeat at frame frequency.
+      if (!this.sseParseWarned) {
+        this.sseParseWarned = true;
+        // eslint-disable-next-line no-console
+        console.warn(
+          '[viewer-manager] SSE frame failed to parse as JSON; dropping it (further occurrences this session are suppressed)',
+          err,
+        );
+      }
       return;
     }
     if (parsed.action === 'picked' && typeof parsed.expressId === 'number') {
@@ -218,10 +240,22 @@ export class ViewerManager {
     if (model && model.store.entityIndex.byId.has(expressId)) {
       try {
         globalId = new EntityNode(model.store, expressId).globalId || undefined;
-      } catch {
-        // Legitimately silent: GlobalId is an optional enrichment of the
-        // selection event. Its absence is already representable (`undefined`)
-        // and the selection is still reported with expressId + ifcType.
+      } catch (err) {
+        // Legitimately silent as a *control-flow* matter: GlobalId is an
+        // optional enrichment of the selection event. Its absence is already
+        // representable (`undefined`) and the selection is still reported
+        // with expressId + ifcType — the caller's contract does not change.
+        // But it should not be silent as a *diagnostic* matter: warn once
+        // per session rather than once per pick, since picks are
+        // viewer-client controlled and can repeat quickly.
+        if (!this.globalIdWarned) {
+          this.globalIdWarned = true;
+          // eslint-disable-next-line no-console
+          console.warn(
+            '[viewer-manager] globalId enrichment failed; reporting selection without globalId (further occurrences this session are suppressed)',
+            err,
+          );
+        }
         globalId = undefined;
       }
     }


### PR DESCRIPTION
## Summary

Follow-up to the review thread on #2100 ("Three minor silent catches"): `viewer-manager.ts` (globalId enrichment, SSE frame parse) and `lod1-generator.ts` (box-mesh fallback) each swallowed an error with no diagnostic, same shape as the four fixes #2100 made in files it touched. The maintainer left them for a later round; this is that round.

## The three sites, verified against current `main`

1. **`packages/mcp/src/viewer-manager.ts:195-213`** — `handleSseFrame`'s `JSON.parse(payload)` catch. Silent, no diagnostic. **Fixed.**
2. **`packages/mcp/src/viewer-manager.ts:215-227`** — `handlePicked`'s `new EntityNode(...).globalId` catch. Silent, no diagnostic. **Fixed.**
3. **`packages/export/src/lod1-generator.ts:73-89`** — `buildFallbackGeometryFromLod0`'s `buildBoxMeshFromAabb` catch. Already carries an explanatory comment and `failed.push(el.expressID)` bookkeeping (added in #2100 itself, per the maintainer's own callout that this one is "the least invisible of the three"). **Left unchanged** — this is the "already visible enough, here is why" case the maintainer said was an acceptable answer for that site. No further diagnostic added.

## Decision per site (the two hazards from the review)

Both fixed sites got a **once-per-session `console.warn` latch**, not a per-occurrence log:

- The SSE frame parse trigger is server-controlled (`packages/viewer/src/server.ts`'s `broadcast()` always `JSON.stringify`s, so a malformed frame is defense-in-depth today, not currently reachable — but the trigger *could* repeat once per frame if that ever changes) and a per-frame log would flood the host console exactly the way #2080's review called out.
- The GlobalId enrichment trigger fires once per `picked` SSE event and is viewer-client controlled, so the same flood risk applies.

Neither catch was converted to a rethrow — both still swallow and degrade exactly as before (a bad frame is dropped; a selection without a GlobalId is still reported with `expressId` + `ifcType`). The latch resets in `open()`, so a fresh viewer session reports again.

## RED/GREEN

New file `packages/mcp/src/viewer-manager.test.ts`, 4 tests (2 per site — "warns once across many occurrences" and "warns again after a fresh session"), driven against a real minimal IFC fixture loaded through `loadIfcModel` (no `as any`/`as unknown as X` anywhere, including the test — private methods are reached via bracket-notation, e.g. `vm['handleSseFrame']`, which typechecks under `tsc --strict`).

- RED (pre-fix): all 4 new tests fail — 0 `console.warn` calls where 1 was expected.
- GREEN (post-fix): all 4 pass.

## Mutation testing (disjoint)

Each latch's `= true` assignment was removed via exact-substring python3 replacement (count printed to stderr, `assert n==1`), region re-read to confirm, then restored by file copy (never `git checkout --`):

| Mutation | `viewer-manager.test.ts` result |
|---|---|
| baseline | 4 passed |
| remove `this.sseParseWarned = true;` | 2 SSE tests fail (5/2 warn calls vs 1 expected); both globalId tests still pass |
| remove `this.globalIdWarned = true;` | 2 globalId tests fail (5/2 warn calls vs 1 expected); both SSE tests still pass |

The two fixes pin disjoint tests — removing one site's latch does not fail the other site's test.

## Test counts

`packages/mcp`: 179 passed → 183 passed (4 new), same 1 pre-existing failure both before and after (`export-usd.test.ts`'s `/var/…` vs macOS's `/private/var/…` realpath assertion — noted as pre-existing and unrelated in #2100's own review thread; reproduces identically on a pristine checkout).

`pnpm typecheck`: green across all 34 tasks (turbo).

## Changeset

`@ifc-lite/mcp` is not marked `private` in its `package.json`, so it ships a changeset (`.changeset/mcp-viewer-manager-diagnostics.md`, patch bump, no license header).

## Self-review

Ran an adversarial review pass against this repo's recurring failure modes (displaced-path check, no-rethrow check, latch-reset-scope check, banned-cast check, sync-test-vs-real-plumbing check, comment-accuracy check, changeset-accuracy check). Came back clean — no defects found, reported plainly rather than manufacturing findings.

Refs #2100 (review thread: "Three minor silent catches").

🤖 Generated with [Claude Code](https://claude.com/claude-code)