### PR TITLE
fix(viewer): free the geometry WASM handle on the canonical load path (#1959)

### DIFF
--- a/apps/viewer/src/hooks/ingest/geometryHandleDisposal.test.ts
+++ b/apps/viewer/src/hooks/ingest/geometryHandleDisposal.test.ts
@@ -1,0 +1,94 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The #1959 leak in `useIfcLoader` is the one the rest of the issue could not
+ * take: the processor's raw handle goes to `IfcParser.parseColumnar` via
+ * `getApi()`, so freeing it when the geometry block ends would pull memory out
+ * from under a live parse. These cases pin the ordering rule that makes the
+ * free safe — never before the parse settles, always after — plus the two ways
+ * the parse can be absent entirely.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createGeometryProcessorDisposer } from './geometryHandleDisposal.js';
+
+describe('createGeometryProcessorDisposer', () => {
+  it('frees immediately when no parse was ever scheduled', () => {
+    // The engine-init / SharedArrayBuffer window: the processor exists but the
+    // parse chain was never started, so there is nothing to wait for.
+    let frees = 0;
+    const disposer = createGeometryProcessorDisposer(() => { frees += 1; });
+
+    disposer.release();
+
+    assert.equal(frees, 1);
+  });
+
+  it('holds the handle while a scheduled parse is still in flight', () => {
+    let frees = 0;
+    const disposer = createGeometryProcessorDisposer(() => { frees += 1; });
+
+    disposer.parseScheduled();
+    disposer.release();
+
+    assert.equal(frees, 0, 'freeing here would pull the handle out from under parseColumnar');
+  });
+
+  it('frees when the parse settles after the geometry stream released', () => {
+    let frees = 0;
+    const disposer = createGeometryProcessorDisposer(() => { frees += 1; });
+
+    disposer.parseScheduled();
+    disposer.release();
+    disposer.parseSettled();
+
+    assert.equal(frees, 1);
+  });
+
+  it('frees when the geometry stream releases after the parse settled', () => {
+    // The reverse order: the parser finished first and the stream drained (or
+    // threw) later. Whichever consumer is last must trigger the free.
+    let frees = 0;
+    const disposer = createGeometryProcessorDisposer(() => { frees += 1; });
+
+    disposer.parseScheduled();
+    disposer.parseSettled();
+    assert.equal(frees, 0, 'the geometry stream still holds it');
+
+    disposer.release();
+
+    assert.equal(frees, 1);
+  });
+
+  it('frees exactly once across repeated release and settle calls', () => {
+    // `release()` is wired to the outer `finally`, which runs on every exit
+    // path including ones that already released — a second free would be a
+    // double-free rather than a leak.
+    let frees = 0;
+    const disposer = createGeometryProcessorDisposer(() => { frees += 1; });
+
+    disposer.parseScheduled();
+    disposer.release();
+    disposer.parseSettled();
+    disposer.release();
+    disposer.parseSettled();
+
+    assert.equal(frees, 1);
+  });
+
+  it('never frees while the load is still running, even once the parse settled', () => {
+    // No `release()` at all: the handle stays live, because the geometry
+    // stream has not finished with it.
+    let frees = 0;
+    const disposer = createGeometryProcessorDisposer(() => { frees += 1; });
+
+    disposer.parseScheduled();
+    disposer.parseSettled();
+
+    assert.equal(frees, 0);
+  });
+});

--- a/apps/viewer/src/hooks/ingest/geometryHandleDisposal.ts
+++ b/apps/viewer/src/hooks/ingest/geometryHandleDisposal.ts
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Coordinates freeing a `GeometryProcessor`'s WASM handle between the two
+ * consumers a single `loadFile` hands it to.
+ *
+ * The geometry stream is the obvious one (`processAdaptive`). The other is the
+ * data-model parser: on the main-thread fallback path `loadFile` passes the
+ * processor's raw handle to `IfcParser.parseColumnar` via
+ * `geometryProcessor.getApi()`. So a `finally { dispose() }` around the
+ * geometry block alone would free a handle the parser is still reading — the
+ * disposal has to wait for whichever consumer finishes last. That coupling is
+ * why the site went unfixed while the rest of #1959 landed.
+ *
+ * The parser is an *opt-in* consumer (`parseScheduled`) rather than one assumed
+ * to be pending, because a load can fail between constructing the processor and
+ * scheduling the parse — engine init downloads the WASM binary, and the
+ * `SharedArrayBuffer` allocation can throw. In that window there is no parser to
+ * wait for and `release()` must free the handle immediately rather than defer
+ * forever on a parse that will never run.
+ */
+export interface GeometryProcessorDisposer {
+  /**
+   * `loadFile` is done with the handle. Idempotent, and safe to call while the
+   * parse is still in flight — the free is deferred until `parseSettled`.
+   */
+  release(): void;
+  /**
+   * The data-model parse chain has been scheduled and may take the raw handle.
+   * Must be paired with a `parseSettled` on every path the chain can end.
+   */
+  parseScheduled(): void;
+  /**
+   * The parse chain ended — resolved, rejected, or abandoned as a stale
+   * session. The parser no longer touches the handle.
+   */
+  parseSettled(): void;
+}
+
+/**
+ * Builds the two-consumer gate described above. `dispose` runs at most once,
+ * when `release()` has been called and no parse is outstanding — whichever of
+ * the two comes last triggers it.
+ */
+export function createGeometryProcessorDisposer(
+  dispose: () => void,
+): GeometryProcessorDisposer {
+  let released = false;
+  let parsePending = false;
+  let disposed = false;
+
+  const disposeIfIdle = () => {
+    if (disposed || !released || parsePending) return;
+    disposed = true;
+    dispose();
+  };
+
+  return {
+    release() {
+      released = true;
+      disposeIfIdle();
+    },
+    parseScheduled() {
+      parsePending = true;
+    },
+    parseSettled() {
+      parsePending = false;
+      disposeIfIdle();
+    },
+  };
+}

--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -57,6 +57,10 @@ import { useIfcServer } from './useIfcServer.js';
 
 import { getMaxExpressId, parseGlbViewerModel, parseIfcxViewerModel } from './ingest/viewerModelIngest.js';
 import { boundedIteratorReturn } from './ingest/streamCleanup.js';
+import {
+  createGeometryProcessorDisposer,
+  type GeometryProcessorDisposer,
+} from './ingest/geometryHandleDisposal.js';
 import { detectPointCloudFormat, ingestPointCloud } from './ingest/pointCloudIngest.js';
 import { removePointCloudScanCache } from './ingest/pointCloudScanCache.js';
 import { getGlobalRenderer } from './useBCF.js';
@@ -308,6 +312,14 @@ export function useIfcLoader() {
     let loadStage:
       | 'read-file' | 'cache-lookup' | 'server-fetch' | 'engine-init'
       | 'parse' | 'geometry-stream' | 'finalize' = 'read-file';
+
+    /**
+     * Frees the geometry processor's WASM handle (#1959). Declared at function
+     * scope so the outer `finally` reaches it from every exit — the cache,
+     * server and error paths above return before a processor exists, and it
+     * stays null for those.
+     */
+    let geometryHandle: GeometryProcessorDisposer | null = null;
 
     /**
      * Resource-limit recovery, shared by BOTH failure paths.
@@ -1068,6 +1080,10 @@ export function useIfcLoader() {
         // doesn't consume and silently dropped.
         enableInstancing: target.kind === 'primary',
       });
+      // Armed BEFORE init() so an engine-init failure still frees whatever the
+      // partially-initialised bridge allocated (dispose() is a no-op when it
+      // allocated nothing).
+      geometryHandle = createGeometryProcessorDisposer(() => geometryProcessor.dispose());
       // The engine binary's own download lives here (wasm-bindgen fetches
       // `ifc-lite_bg.wasm` from `import.meta.url`), so this is the one stage a
       // first-visit user can fail in before a single IFC byte is touched.
@@ -1231,10 +1247,22 @@ export function useIfcLoader() {
             console.log(`[useIfc] Data model parsing failed for ${file.name}: ${metadataFailedMs.toFixed(0)}ms`);
             memoryAccounting.recordPhase({ phase: 'parser-failed' });
             rejectDataStore(err);
+          })
+          // The parser is done with the raw handle here on EVERY ending —
+          // including the one `dataStorePromise` never reports: a stale
+          // `onFullDataStore` returns without resolving it (#1959). Gating
+          // disposal on the chain rather than on the promise is what keeps a
+          // superseded load from leaking its handle.
+          .finally(() => {
+            geometryHandle?.parseSettled();
           });
       };
 
       // Start data model parsing IMMEDIATELY — runs in parallel with geometry.
+      // Declared pending before the timer is armed: the chain can hand the raw
+      // WASM handle to IfcParser.parseColumnar (main-thread fallback), so the
+      // handle must outlive it.
+      geometryHandle.parseScheduled();
       setTimeout(startDataModelParsing, 0);
 
       // Use adaptive processing: sync for small files, streaming for large files
@@ -1883,6 +1911,14 @@ export function useIfcLoader() {
       });
       setLoading(false);
       setGeometryStreamingActive(false);
+    } finally {
+      // #1959: the one release point that no exit path can skip. Every early
+      // `return` in this function — stale session, resource retry, the inner
+      // geometry catch, the cache and server fast paths — runs through here,
+      // and a `dispose()` placed after the last statement would miss all of
+      // them. The free itself still waits on the parse chain; see
+      // createGeometryProcessorDisposer.
+      geometryHandle?.release();
     }
   }, [setLoading, setGeometryStreamingActive, setError, setProgress, setIfcDataStore, setGeometryResult, appendGeometryBatch, appendInstancedShards, updateMeshColors, updateCoordinateInfo, loadFromCache, saveToCache, loadFromServer, revalidateSourceDecoupledHit]);
 


### PR DESCRIPTION
## Summary

Closes the last open site from #1959: `useIfcLoader.loadFile` (the canonical
load path, primary and federated, every model open) constructs a
`GeometryProcessor` and never disposed it, leaking a WASM handle per load on
every exit — success or failure.

The reason it stayed open while the other eleven sites were fixed: the
handle is not private to geometry. On the main-thread parser fallback,
`loadFile` hands the raw handle to `IfcParser.parseColumnar` via
`geometryProcessor.getApi()` (`apps/viewer/src/hooks/useIfcLoader.ts:1177`).
A `finally { dispose() }` around the geometry block alone risks freeing
memory the parser is still reading — worse than the leak.

## Approach

Extracted `createGeometryProcessorDisposer` (`apps/viewer/src/hooks/ingest/geometryHandleDisposal.ts`),
mirroring `streamCleanup.ts`. It gates the free on **both** consumers finishing:
`release()` (the geometry stream / outer `finally`) and `parseSettled()` (the
parser chain), whichever finishes last triggers `dispose()`, exactly once.

`parseSettled()` is wired off the parser **chain's** `.finally()`, not off
`dataStorePromise`. That distinction matters: a superseded load's
`onFullDataStore` returns early without ever resolving `dataStorePromise`
(`useIfcLoader.ts:1154-1155`), so a disposer gated on the promise would leak
exactly the handle a model swap should free. The chain's `.finally()` runs on
all three endings — resolve, reject, and this stale/abandoned case — so
gating there is what makes the free reliable.

The parser is opt-in via `parseScheduled()` rather than assumed pending,
because engine init / `SharedArrayBuffer` allocation can throw before a parse
is ever scheduled; in that window there's no parser to wait for and the
handle should free immediately.

`release()` sits in a `finally` on `loadFile`'s outer `try` (not after the
last statement) — the function has many early returns past the point the
processor exists, and a trailing `dispose()` would miss all of them.

## Testing

- `apps/viewer/src/hooks/ingest/geometryHandleDisposal.test.ts` — 6 cases:
  frees immediately when no parse was scheduled; holds the handle while a
  scheduled parse is in flight; frees once the parse settles after release;
  frees once release happens after the parse settled; frees exactly once
  across repeated release/settle calls (dedupe); never frees while still
  running even after the parse settles.
- Two directions covered explicitly: freeing before the parse settles (the
  dangerous direction — a live use-after-free) is pinned as a failing case,
  and double-free/leak-via-missing-once-guard is pinned separately.
- Mutation-tested by hand: removing the once-guard (`disposed ||`) fails the
  dedupe test; removing the `parsePending` guard entirely fails the
  "holds the handle while a scheduled parse is in flight" test. Both
  mutations caught by a distinct test.
- `npm test` in `apps/viewer`: 2715 tests, 2711 pass, 2 pre-existing failures
  in `buildFingerprints.test.ts` (#2021/#1891 diff work) unrelated to this
  change — same failures reproduce on `upstream/main` at the branch's base
  commit before this fix is applied.
- `pnpm typecheck`: all 34 workspace tasks pass.

## Scope

This closes the `useIfcLoader.ts` site specifically. Per the issue's own
status check, the other three P0 sites (`PlaygroundViewer`,
`playground-dispatcher`, `HbjsonExportDialog`) are already fixed on `main`.
Not verifying here whether all 12 originally-audited sites are closed —
only that this PR closes this one.

No changeset: `@ifc-lite/viewer` is private.

Refs #1959.

🤖 Generated with [Claude Code](https://claude.com/claude-code)