### PR TITLE
fix(cli): re-audit #1959 remaining sites — dispose the shared GeometryProcessor in `ifc-lite clash`

### DIFF
--- a/.changeset/clash-cli-dispose-shared-processor.md
+++ b/.changeset/clash-cli-dispose-shared-processor.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/cli": patch
+---
+
+Free the WASM geometry handle `ifc-lite clash` allocates for meshing (#1959).
+
+`clash.ts` lazily creates a module-scoped `sharedProcessor` (`getProcessor()`) the first time a run needs to mesh a model, and reuses it for every subsequent mesh within the same process. It was never disposed on any exit path — success, a thrown clash/BCF error, or an early return — leaking the handle for the life of the process. Low real-world impact (the CLI is a one-shot process, so the OS reclaims the WASM memory on exit either way), but it violates the deterministic-disposal rule the audit in #1959 is checking, so it is fixed to the same shape as the rest of that sweep: the whole run now sits inside `try { … } finally { sharedProcessor?.dispose(); sharedProcessor = undefined; }`, so a subsequent `clashCommand` call in the same process (e.g. a long-lived host embedding the CLI's command functions) starts from a fresh handle instead of accumulating one per call.

--- a/packages/cli/src/commands/clash.test.ts
+++ b/packages/cli/src/commands/clash.test.ts
@@ -17,7 +17,7 @@
  * rather than proving nothing on a silent model.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { existsSync } from 'node:fs';
@@ -26,6 +26,8 @@ import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { IfcCreator } from '@ifc-lite/create';
+import { GeometryProcessor } from '@ifc-lite/geometry';
+import { clashCommand } from './clash.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -85,4 +87,75 @@ describe('clash --json stdout hygiene', () => {
     },
     180_000,
   );
+});
+
+describe('clashCommand GeometryProcessor disposal (#1959 P2 leak)', () => {
+  // `sharedProcessor` (clash.ts) is module-scoped, so each test uses a
+  // uniquely-named model file — `meshModel`'s cache key is `basename(filePath)`
+  // only (not the full path), so two tests both writing to `model.ifc` in
+  // different tmpdirs would collide and the second call would skip meshing
+  // (and therefore skip `getProcessor()`) entirely, making the assertion
+  // pass for the wrong reason.
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  async function withTempModel(basename: string, fn: (path: string) => Promise<void>): Promise<void> {
+    const dir = await mkdtemp(join(tmpdir(), 'ifc-lite-clash-dispose-'));
+    const modelPath = join(dir, basename);
+    try {
+      await writeFile(modelPath, buildClashModel());
+      await fn(modelPath);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  }
+
+  it('disposes the GeometryProcessor WASM handle on the success path', async () => {
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const disposeSpy = vi.spyOn(GeometryProcessor.prototype, 'dispose');
+
+    await withTempModel('dispose-success.ifc', async (modelPath) => {
+      await clashCommand([modelPath, '--json']);
+      expect(disposeSpy).toHaveBeenCalledTimes(1);
+    });
+  }, 60_000);
+
+  it('disposes the GeometryProcessor WASM handle even when clashing throws after meshing', async () => {
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const disposeSpy = vi.spyOn(GeometryProcessor.prototype, 'dispose');
+    // Force the throw downstream of `getProcessor()`/meshing (mirrors how
+    // `process()` genuinely fails), so this exercises the `finally` on the
+    // error path rather than only the happy path.
+    vi.spyOn(GeometryProcessor.prototype, 'process').mockRejectedValue(
+      new Error('forced meshing failure for #1959 dispose test'),
+    );
+
+    await withTempModel('dispose-throw.ifc', async (modelPath) => {
+      await expect(clashCommand([modelPath, '--json'])).rejects.toThrow(
+        'forced meshing failure for #1959 dispose test',
+      );
+      expect(disposeSpy).toHaveBeenCalledTimes(1);
+    });
+  }, 60_000);
+
+  it('never constructs a GeometryProcessor when argument parsing fails before meshing', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((() => {
+      throw new Error('process.exit called');
+    }) as unknown) as (code?: number) => never);
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const disposeSpy = vi.spyOn(GeometryProcessor.prototype, 'dispose');
+    try {
+      await expect(clashCommand(['--mode', 'not-a-real-mode', 'some-file.ifc'])).rejects.toThrow(
+        'process.exit called',
+      );
+      // getProcessor() is never reached — nothing to dispose. Pins that the
+      // fix did not turn a lazy processor into an eager one.
+      expect(disposeSpy).not.toHaveBeenCalled();
+    } finally {
+      exitSpy.mockRestore();
+    }
+  }, 30_000);
 });

--- a/packages/cli/src/commands/clash.test.ts
+++ b/packages/cli/src/commands/clash.test.ts
@@ -158,6 +158,15 @@ describe('clashCommand GeometryProcessor disposal (#1959 P2 leak)', () => {
       .mockImplementation(() => {
         throw new Error('dispose boom');
       });
+    // Assert on CONSTRUCTION, not disposal. Counting disposals cannot
+    // discriminate the ordering: with the reset skipped, the second run reuses
+    // the stale processor and disposes THAT a second time, so `dispose` is
+    // called twice either way. `getProcessor()` only calls `init()` when it
+    // builds a fresh instance (`if (!sharedProcessor)`), so init-count is the
+    // observable that distinguishes "fresh handle" from "reused dead handle".
+    // (maintainer mutation on #2128: moving the reset back inside the try left
+    // the disposal-count assertion green.)
+    const initSpy = vi.spyOn(GeometryProcessor.prototype, 'init');
 
     // Distinct filenames: `meshModel`'s cache key is basename-only, so reusing
     // one name would skip meshing on the second call and never reach dispose.
@@ -165,13 +174,16 @@ describe('clashCommand GeometryProcessor disposal (#1959 P2 leak)', () => {
       await clashCommand([modelPath, '--json']);
     });
     expect(disposeSpy).toHaveBeenCalledTimes(1);
+    expect(initSpy).toHaveBeenCalledTimes(1);
 
-    // The binding was cleared despite the throw, so a second run constructs a
-    // fresh processor and disposes it again rather than reusing a freed one.
+    // The binding was cleared despite the throw, so a second run CONSTRUCTS a
+    // fresh processor rather than reusing the one whose dispose just failed.
     await withTempModel('dispose-throws-b.ifc', async (modelPath) => {
       await clashCommand([modelPath, '--json']);
     });
     expect(disposeSpy).toHaveBeenCalledTimes(2);
+    // The discriminating assertion: a fresh construction happened.
+    expect(initSpy).toHaveBeenCalledTimes(2);
 
     // Not silent — the cleanup failure is reported.
     expect(warnSpy.mock.calls.some((c) => String(c[0]).includes('dispose failed'))).toBe(true);

--- a/packages/cli/src/commands/clash.test.ts
+++ b/packages/cli/src/commands/clash.test.ts
@@ -141,6 +141,60 @@ describe('clashCommand GeometryProcessor disposal (#1959 P2 leak)', () => {
     });
   }, 60_000);
 
+  it('clears the shared processor even when dispose() throws, so the next call gets a fresh handle', async () => {
+    // Ordering guard (#2128 review). The reset used to sit AFTER `dispose()`,
+    // so a throwing dispose skipped it and left `sharedProcessor` pointing at
+    // a processor whose handle may be half-freed — the next `clashCommand` in
+    // the same host would reuse it. That is the dangling reference the reset
+    // exists to prevent, reintroduced on the failure path.
+    //
+    // Not hypothetical: #1922 is an OOM inside a drained job aborting the WASM
+    // module at dispose time — precisely a throwing dispose().
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const disposeSpy = vi
+      .spyOn(GeometryProcessor.prototype, 'dispose')
+      .mockImplementation(() => {
+        throw new Error('dispose boom');
+      });
+
+    // Distinct filenames: `meshModel`'s cache key is basename-only, so reusing
+    // one name would skip meshing on the second call and never reach dispose.
+    await withTempModel('dispose-throws-a.ifc', async (modelPath) => {
+      await clashCommand([modelPath, '--json']);
+    });
+    expect(disposeSpy).toHaveBeenCalledTimes(1);
+
+    // The binding was cleared despite the throw, so a second run constructs a
+    // fresh processor and disposes it again rather than reusing a freed one.
+    await withTempModel('dispose-throws-b.ifc', async (modelPath) => {
+      await clashCommand([modelPath, '--json']);
+    });
+    expect(disposeSpy).toHaveBeenCalledTimes(2);
+
+    // Not silent — the cleanup failure is reported.
+    expect(warnSpy.mock.calls.some((c) => String(c[0]).includes('dispose failed'))).toBe(true);
+  }, 90_000);
+
+  it('does not let a failing dispose() mask the error the caller was reporting', async () => {
+    // A cleanup exception replacing the real clash error would tell the user
+    // the wrong thing entirely. (#2128 review)
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(GeometryProcessor.prototype, 'dispose').mockImplementation(() => {
+      throw new Error('dispose boom');
+    });
+    vi.spyOn(GeometryProcessor.prototype, 'process').mockRejectedValue(
+      new Error('the real clash failure'),
+    );
+
+    await withTempModel('dispose-mask.ifc', async (modelPath) => {
+      await expect(clashCommand([modelPath, '--json'])).rejects.toThrow('the real clash failure');
+    });
+  }, 60_000);
+
   it('never constructs a GeometryProcessor when argument parsing fails before meshing', async () => {
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((() => {
       throw new Error('process.exit called');

--- a/packages/cli/src/commands/clash.ts
+++ b/packages/cli/src/commands/clash.ts
@@ -178,50 +178,61 @@ export async function clashCommand(args: string[]): Promise<void> {
 
   const { store } = await createHeadlessContext(filePath);
 
-  const modelId = basename(filePath);
-  if (!jsonOutput) process.stderr.write(`  Meshing ${modelId} ...\n`);
-  const meshes = await meshModel(store, modelId, filePath);
+  // `getProcessor()` (called from `meshModel` below) lazily creates and caches
+  // `sharedProcessor` at module scope, session-scoped for this one `clash`
+  // invocation — a fresh CLI process per run, so it was never freed on any
+  // path out of this function (#1959 P2). Wrap the whole run in try/finally
+  // so the WASM handle is freed on success, on a thrown clash/BCF error, and
+  // is a no-op (nothing to dispose) when meshing itself never ran.
+  try {
+    const modelId = basename(filePath);
+    if (!jsonOutput) process.stderr.write(`  Meshing ${modelId} ...\n`);
+    const meshes = await meshModel(store, modelId, filePath);
 
-  const { elements, exclusions } = elementsFromStep({ store, meshes, modelId });
+    const { elements, exclusions } = elementsFromStep({ store, meshes, modelId });
 
-  const rules = buildRules(args, mode, tolerance, clearance);
+    const rules = buildRules(args, mode, tolerance, clearance);
 
-  const engine = createClashEngine({ backend: 'ts' });
-  const result = await engine.run(elements, rules, {
-    exclusions,
-    tolerance,
-    onProgress: (p) => {
-      if (!jsonOutput) {
-        process.stderr.write(`\r  Clashing: ${p.phase} ${p.rule} (${p.done}/${p.total})`);
-      }
-    },
-  });
-  if (!jsonOutput) process.stderr.write('\n');
-
-  if (bcfPath) {
-    const groups = groupClashes(result, { by: bcfGroupBy });
-    const project = await createBCFFromClashResult(result, groups, {
-      author: 'ifc-lite clash',
-      projectName: 'Clash report',
-      // Headless: no snapshots (no renderer) — viewer export embeds those.
-      ...(bcfStatus ? { status: bcfStatus } : {}),
-      ...(maxTopics != null ? { maxTopics } : {}),
+    const engine = createClashEngine({ backend: 'ts' });
+    const result = await engine.run(elements, rules, {
+      exclusions,
+      tolerance,
+      onProgress: (p) => {
+        if (!jsonOutput) {
+          process.stderr.write(`\r  Clashing: ${p.phase} ${p.rule} (${p.done}/${p.total})`);
+        }
+      },
     });
-    const blob = await writeBCF(project);
-    const buffer = Buffer.from(await blob.arrayBuffer());
-    await writeFile(bcfPath, buffer);
-    process.stderr.write(`  BCF report written to ${bcfPath} (${groups.length} topic group(s), grouped by ${bcfGroupBy})\n`);
-  }
+    if (!jsonOutput) process.stderr.write('\n');
 
-  if (jsonOutput) {
-    const total = result.clashes.length;
-    const clashes = result.clashes.slice(0, JSON_CLASH_CAP);
-    const truncated = total > clashes.length
-      ? { reason: `capped at ${JSON_CLASH_CAP} clashes for display`, dropped: total - clashes.length }
-      : null;
-    printJson({ summary: result.summary, truncated, clashes });
-    return;
-  }
+    if (bcfPath) {
+      const groups = groupClashes(result, { by: bcfGroupBy });
+      const project = await createBCFFromClashResult(result, groups, {
+        author: 'ifc-lite clash',
+        projectName: 'Clash report',
+        // Headless: no snapshots (no renderer) — viewer export embeds those.
+        ...(bcfStatus ? { status: bcfStatus } : {}),
+        ...(maxTopics != null ? { maxTopics } : {}),
+      });
+      const blob = await writeBCF(project);
+      const buffer = Buffer.from(await blob.arrayBuffer());
+      await writeFile(bcfPath, buffer);
+      process.stderr.write(`  BCF report written to ${bcfPath} (${groups.length} topic group(s), grouped by ${bcfGroupBy})\n`);
+    }
 
-  printHumanSummary(result);
+    if (jsonOutput) {
+      const total = result.clashes.length;
+      const clashes = result.clashes.slice(0, JSON_CLASH_CAP);
+      const truncated = total > clashes.length
+        ? { reason: `capped at ${JSON_CLASH_CAP} clashes for display`, dropped: total - clashes.length }
+        : null;
+      printJson({ summary: result.summary, truncated, clashes });
+      return;
+    }
+
+    printHumanSummary(result);
+  } finally {
+    sharedProcessor?.dispose();
+    sharedProcessor = undefined;
+  }
 }

--- a/packages/cli/src/commands/clash.ts
+++ b/packages/cli/src/commands/clash.ts
@@ -232,7 +232,27 @@ export async function clashCommand(args: string[]): Promise<void> {
 
     printHumanSummary(result);
   } finally {
-    sharedProcessor?.dispose();
+    // Reset BEFORE disposing, and never let a cleanup failure escape.
+    //
+    // Ordering: if `dispose()` throws, an assignment placed after it is
+    // skipped, leaving `sharedProcessor` pointing at a processor whose handle
+    // may be half-freed — the next `clashCommand` in the same host would then
+    // reuse it. That is the dangling-reference case the reset exists to
+    // prevent, reintroduced on the failure path. Clearing first cannot be
+    // skipped. (#2128 review)
+    //
+    // Not hypothetical: #1922 is an OOM inside a drained job aborting the
+    // WASM module at dispose time — precisely a throwing `dispose()`.
+    //
+    // Swallowed: a cleanup failure must not replace the clash/BCF error the
+    // caller was about to see. Warned, not silent, per the no-silent-catch
+    // rule.
+    const processor = sharedProcessor;
     sharedProcessor = undefined;
+    try {
+      processor?.dispose();
+    } catch (err) {
+      console.warn('[clash] geometry processor dispose failed; continuing', err);
+    }
   }
 }


### PR DESCRIPTION
## Summary

Re-audit of the remaining #1959 sites on current `upstream/main`, as requested in the issue's status-check comments (PR #2127 explicitly scoped itself to `useIfcLoader.ts` only and said the other eight were not re-verified).

Full classification of every `new GeometryProcessor(` site — the issue's own table is a starting point, verified fresh rather than trusted — is posted as a comment on #1959.

**Result: only one genuine leak remains**, and it's a new find, not one of the original eight:

- `packages/cli/src/commands/clash.ts:49-51` — a module-scoped `sharedProcessor`, created lazily by `getProcessor()` and never disposed on any exit path (success, thrown clash/BCF error, or early return). This is the same shape as the P2 CLI-hygiene bucket the original issue flagged (low urgency — the CLI is a one-shot process, so the OS reclaims the handle on exit either way) but it was still a real, unaddressed violation of the try/finally rule in `AGENTS.md` §7.

Everything else — all P0 sites, `packages/mcp/src/tools/clash.ts`, `headless-backend.ts` (the site no longer exists — the module has no `GeometryProcessor` usage at all now), `lod1-generator.ts` (both processors), `diagnose-geometry.ts`, `extract-entities.ts`, `cli/commands/export.ts`, `gym.ts`, `create-ifc-lite/templates/react.ts`, and two viewer sites added since the original audit (`UsdExportDialog.tsx`, `CommandPalette.tsx`) — already dispose correctly on every path, either because they were fixed by other merged PRs or were already correct. The example/vanilla-template page-lifetime singletons (`babylonjs.ts`, `threejs.ts` x2 in examples + 2 in create-ifc-lite templates) are confirmed still page-lifetime by design, not leaks, per the issue's original carve-out.

## Fix

`clashCommand` now wraps its whole run in `try { … } finally { sharedProcessor?.dispose(); sharedProcessor = undefined; }`, same shape as every other fix in this sweep (`PlaygroundViewer`, `playground-dispatcher`, `HbjsonExportDialog`, `gym.ts`). Resetting to `undefined` in the `finally` also means a long-lived host that calls `clashCommand` more than once per process (e.g. a test harness) doesn't accumulate one handle per call — mirrors the fix already landed in `gym.ts` for the same pattern.

`useIfcLoader.ts` is intentionally **not** touched — PR #2127 is open against that exact site with its own approach and tests; redoing it here would conflict.

## Test plan

- [x] RED: added 3 tests to `clash.test.ts` (success-path disposal, throw-path disposal, no-eager-construction-before-meshing) — 2 of 3 fail against the pre-fix code (`toHaveBeenCalledTimes(1)` → `0`), confirmed by mutation-testing (python3 exact-substring removal of the `dispose()` call, count asserted `==1`, restored by file copy — never `git checkout --`).
- [x] GREEN: full `clash.test.ts` passes (4/4) with the fix in place.
- [x] Full `packages/cli` suite: 270 passed, 8 skipped (pre-existing dist/wasm-build-gated subprocess tests, unrelated), 0 failed.
- [x] `pnpm typecheck`: 34/34 workspace tasks clean.
- [x] Changeset added (`@ifc-lite/cli` is published, not private).

Refs #1959.