### PR TITLE
fix(viewer,ci): gate WASM handle disposal instead of policing it by hand

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -333,6 +333,12 @@ jobs:
         run: pnpm fixtures
       - name: Check test wiring
         run: node scripts/check-test-wiring.mjs
+      # Every `new GeometryProcessor(...)` must free its WASM handle on all
+      # paths. AGENTS.md required this already, but self-policing decayed one
+      # call site at a time until 12 sites leaked (#1959) -- including the
+      # viewer's canonical load path, which fires on every IFC load.
+      - name: Check WASM handle disposal
+        run: node scripts/check-wasm-disposal.mjs
       # Guard the published API surface: the exported names of every
       # non-private packages/* package (read from the dist d.ts in the
       # build artifact downloaded above) must match the committed

--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -1047,6 +1047,14 @@ export function useIfcLoader() {
       // Initialize geometry processor first (WASM init is fast if already loaded)
       // Reuses the merge-layers snapshot taken above for the cache key so the
       // key and the WASM tessellation always agree (issues #540, #1107).
+      //
+      // `using`, not `const`: this fires on EVERY load, primary and federated,
+      // and previously leaked its `IfcAPI` handle on every one of them (#1959).
+      // Scope exit covers the paths a `finally` on the try below would miss —
+      // the engine-init await and the parse stages between construction and
+      // that try. Safe to free here: meshes are copied into JS and `.free()`d
+      // as they are extracted, so `dispose()` only releases the long-lived
+      // handle, and it is idempotent.
       const geometryProcessor = new GeometryProcessor({
         quality: GeometryQuality.Balanced,
         // Auto-low vertex density for heavy models (or `?geomTier=` override);
@@ -1776,6 +1784,26 @@ export function useIfcLoader() {
         setLoading(false);
         setGeometryStreamingActive(false);
         return;
+      } finally {
+        // Free the engine's `IfcAPI` handle. This fires on EVERY load, primary
+        // and federated, and leaked on every one of them before #1959 — the
+        // single highest-frequency WASM handle leak in the app.
+        //
+        // Here rather than `using`: `using` type-checks, but rolldown (Vite 8)
+        // panics rendering chunks on it, so the viewer will not build. Revisit
+        // when that is fixed — `GeometryProcessor` already implements
+        // `[Symbol.dispose]()` (#1563).
+        //
+        // Covers the streaming block and every `return` out of the catch above.
+        // NOT covered: a throw between construction and this `try` (engine-init
+        // or the parse stages), which unwinds to the outer catch where this
+        // binding is out of scope. Widening the try instead would reroute those
+        // errors into the catch above, which handles stream failures
+        // specifically — a behaviour change, not a disposal fix.
+        //
+        // Safe here: meshes are copied into JS and freed as they are extracted,
+        // so this only releases the long-lived handle, and it is idempotent.
+        geometryProcessor.dispose();
       }
 
       if (loadSessionRef.current !== currentSession) {

--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -1047,14 +1047,6 @@ export function useIfcLoader() {
       // Initialize geometry processor first (WASM init is fast if already loaded)
       // Reuses the merge-layers snapshot taken above for the cache key so the
       // key and the WASM tessellation always agree (issues #540, #1107).
-      //
-      // `using`, not `const`: this fires on EVERY load, primary and federated,
-      // and previously leaked its `IfcAPI` handle on every one of them (#1959).
-      // Scope exit covers the paths a `finally` on the try below would miss —
-      // the engine-init await and the parse stages between construction and
-      // that try. Safe to free here: meshes are copied into JS and `.free()`d
-      // as they are extracted, so `dispose()` only releases the long-lived
-      // handle, and it is idempotent.
       const geometryProcessor = new GeometryProcessor({
         quality: GeometryQuality.Balanced,
         // Auto-low vertex density for heavy models (or `?geomTier=` override);
@@ -1784,26 +1776,6 @@ export function useIfcLoader() {
         setLoading(false);
         setGeometryStreamingActive(false);
         return;
-      } finally {
-        // Free the engine's `IfcAPI` handle. This fires on EVERY load, primary
-        // and federated, and leaked on every one of them before #1959 — the
-        // single highest-frequency WASM handle leak in the app.
-        //
-        // Here rather than `using`: `using` type-checks, but rolldown (Vite 8)
-        // panics rendering chunks on it, so the viewer will not build. Revisit
-        // when that is fixed — `GeometryProcessor` already implements
-        // `[Symbol.dispose]()` (#1563).
-        //
-        // Covers the streaming block and every `return` out of the catch above.
-        // NOT covered: a throw between construction and this `try` (engine-init
-        // or the parse stages), which unwinds to the outer catch where this
-        // binding is out of scope. Widening the try instead would reroute those
-        // errors into the catch above, which handles stream failures
-        // specifically — a behaviour change, not a disposal fix.
-        //
-        // Safe here: meshes are copied into JS and freed as they are extracted,
-        // so this only releases the long-lived handle, and it is idempotent.
-        geometryProcessor.dispose();
       }
 
       if (loadSessionRef.current !== currentSession) {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "test:integration": "tsx --tsconfig tests/tsconfig.json tests/integration.test.ts",
     "test:wasm-contract": "node scripts/test-wasm-contract.mjs",
     "check:test-wiring": "node scripts/check-test-wiring.mjs",
+    "check:wasm-disposal": "node scripts/check-wasm-disposal.mjs",
     "check:api-surface": "node scripts/check-api-surface.mjs",
     "api-surface:update": "node scripts/check-api-surface.mjs --update",
     "check:git-lfs": "node scripts/check-git-lfs.mjs",

--- a/scripts/check-wasm-disposal.mjs
+++ b/scripts/check-wasm-disposal.mjs
@@ -144,6 +144,58 @@ function disposedInFinally(scope, name) {
 }
 
 /**
+ * Is the handle handed to something that owns its disposal?
+ *
+ *     geometryHandle = createGeometryProcessorDisposer(() => processor.dispose());
+ *
+ * A lexical `finally` is not always correct. In `useIfcLoader` the processor is
+ * shared with the data-model parser via `getApi()`, so freeing it at the end of
+ * the geometry block would free a handle the parser is still reading — the
+ * disposal has to wait for whichever consumer finishes last (#2127). That is a
+ * real disposal, expressed through an indirection this gate must not punish:
+ * a check that fails the *correct* fix is the thing that gets checks disabled.
+ *
+ * Accepted shape: `name.dispose()` inside a function passed as an argument to a
+ * call. Deliberately narrower than "mentions dispose anywhere" — a bare
+ * `p.dispose()` on the success path only would still be flagged.
+ */
+function handedToDisposer(scope, name) {
+  let found = false;
+  const disposesName = (node) => {
+    let hit = false;
+    const scan = (n) => {
+      if (hit) return;
+      if (
+        ts.isCallExpression(n) &&
+        ts.isPropertyAccessExpression(n.expression) &&
+        n.expression.name.text === 'dispose' &&
+        ts.isIdentifier(n.expression.expression) &&
+        n.expression.expression.text === name
+      ) {
+        hit = true;
+      }
+      ts.forEachChild(n, scan);
+    };
+    scan(node);
+    return hit;
+  };
+  const visit = (node) => {
+    if (found) return;
+    if (ts.isCallExpression(node)) {
+      for (const arg of node.arguments) {
+        if ((ts.isArrowFunction(arg) || ts.isFunctionExpression(arg)) && disposesName(arg)) {
+          found = true;
+          break;
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(scope);
+  return found;
+}
+
+/**
  * Does `name` escape the scope that constructed it?
  *
  * A processor that is returned, or stored on an object/field, is owned by
@@ -209,7 +261,7 @@ function isFactoryBody(newExpr) {
 }
 
 const violations = [];
-const accepted = { using: 0, finally: 0, factory: 0, allowlisted: 0, escapes: 0 };
+const accepted = { using: 0, finally: 0, factory: 0, allowlisted: 0, escapes: 0, disposer: 0 };
 let scanned = 0;
 
 for (const scanDir of SCAN_DIRS) {
@@ -236,6 +288,7 @@ for (const scanDir of SCAN_DIRS) {
         else if (decl && isUsingBinding(decl)) accepted.using++;
         else if (key && ALLOWLIST.has(key)) accepted.allowlisted++;
         else if (name && disposedInFinally(scope, name)) accepted.finally++;
+        else if (name && handedToDisposer(scope, name)) accepted.disposer++;
         else if (name && escapesScope(scope, name)) accepted.escapes++;
         else {
           violations.push({
@@ -253,7 +306,7 @@ for (const scanDir of SCAN_DIRS) {
 }
 
 const total =
-  violations.length + accepted.using + accepted.finally + accepted.factory + accepted.allowlisted + accepted.escapes;
+  violations.length + accepted.using + accepted.finally + accepted.factory + accepted.allowlisted + accepted.escapes + accepted.disposer;
 
 if (violations.length > 0) {
   console.error(
@@ -281,6 +334,6 @@ ALLOWLIST in scripts/check-wasm-disposal.mjs with the reason. See issue #1959.`)
 console.log(
   `✅ All ${total} WASM-handle construction(s) release deterministically ` +
     `(${accepted.using} using, ${accepted.finally} try/finally, ${accepted.factory} factory, ` +
-    `${accepted.escapes} ownership-transferred, ${accepted.allowlisted} allowlisted) ` +
+    `${accepted.disposer} disposer-owned, ${accepted.escapes} ownership-transferred, ${accepted.allowlisted} allowlisted) ` +
     `across ${scanned} file(s).`,
 );

--- a/scripts/check-wasm-disposal.mjs
+++ b/scripts/check-wasm-disposal.mjs
@@ -244,8 +244,24 @@ function escapesScope(scope, name) {
    */
   const declaredLocally = (target) => {
     let found = false;
-    const scan = (n) => {
+    const scan = (n, depth = 0) => {
       if (found) return;
+      // Do NOT descend into nested function scopes. A callback parameter that
+      // happens to share the name — `[1].forEach((sharedProcessor) => …)` —
+      // is a different binding, and treating it as a local declaration marks a
+      // genuine module-level ownership transfer as a leak. That is a FALSE
+      // POSITIVE, the direction that gets a gate switched off, so it matters
+      // more than the over-acceptance cases this function also guards
+      // (CodeRabbit, #2129 review).
+      if (
+        depth > 0 &&
+        (ts.isFunctionDeclaration(n) ||
+          ts.isFunctionExpression(n) ||
+          ts.isArrowFunction(n) ||
+          ts.isMethodDeclaration(n))
+      ) {
+        return;
+      }
       // VariableDeclaration covers `let alias`; ParameterDeclaration covers
       // `function f(alias)`; BindingElement covers a destructured parameter or
       // declaration. A parameter is every bit as local as a `let` — checking
@@ -259,11 +275,11 @@ function escapesScope(scope, name) {
       ) {
         found = true;
       }
-      ts.forEachChild(n, scan);
+      ts.forEachChild(n, (c) => scan(c, depth + 1));
     };
     // Parameters hang off the function node itself, not its body, so scan the
     // whole scope node rather than descending into the body first.
-    scan(scope);
+    scan(scope, 0);
     return found;
   };
   const mentionsName = (node) => {

--- a/scripts/check-wasm-disposal.mjs
+++ b/scripts/check-wasm-disposal.mjs
@@ -246,11 +246,23 @@ function escapesScope(scope, name) {
     let found = false;
     const scan = (n) => {
       if (found) return;
-      if (ts.isVariableDeclaration(n) && ts.isIdentifier(n.name) && n.name.text === target) {
+      // VariableDeclaration covers `let alias`; ParameterDeclaration covers
+      // `function f(alias)`; BindingElement covers a destructured parameter or
+      // declaration. A parameter is every bit as local as a `let` — checking
+      // only VariableDeclaration let `function f(alias) { const p = new
+      // GeometryProcessor(); alias = p; }` through as "ownership transfer",
+      // accepting an undisposed handle.
+      if (
+        (ts.isVariableDeclaration(n) || ts.isParameter(n) || ts.isBindingElement(n)) &&
+        ts.isIdentifier(n.name) &&
+        n.name.text === target
+      ) {
         found = true;
       }
       ts.forEachChild(n, scan);
     };
+    // Parameters hang off the function node itself, not its body, so scan the
+    // whole scope node rather than descending into the body first.
     scan(scope);
     return found;
   };

--- a/scripts/check-wasm-disposal.mjs
+++ b/scripts/check-wasm-disposal.mjs
@@ -1,0 +1,286 @@
+#!/usr/bin/env node
+/**
+ * Guard: every `new GeometryProcessor(...)` must release its WASM handle
+ * deterministically.
+ *
+ * `AGENTS.md` requires WASM handles to be freed in `try/finally`, but the rule
+ * was self-policed, so compliance decayed one call site at a time. The audit in
+ * issue #1959 found 12 sites that never disposed on any path -- including the
+ * viewer's canonical model-load path, which fires on EVERY IFC load. Fixing
+ * those individually does not stop the 13th from landing next week; only a gate
+ * does.
+ *
+ * `GeometryProcessor` implements `[Symbol.dispose]()` (#1563), so the cheapest
+ * correct form is `using processor = new GeometryProcessor(...)`.
+ *
+ * A construction is accepted when any of these holds:
+ *
+ *   1. `using` / `await using` binding    -- scope exit frees it.
+ *   2. `try { ... } finally { p.dispose() }` in the enclosing function.
+ *   3. The expression is the whole body of an arrow/function (a factory) --
+ *      ownership transfers to the caller, which this gate checks separately at
+ *      the call site.
+ *   4. The site is in ALLOWLIST below, with a reason.
+ *
+ * Run via `pnpm check:wasm-disposal` (wired into the CI node-test job).
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, dirname, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const SCAN_DIRS = ['apps', 'packages'];
+const SKIP_DIRS = new Set(['node_modules', 'dist', 'pkg', 'build', 'coverage', '.turbo', 'e2e']);
+const SOURCE_RE = /\.(ts|tsx|mts)$/;
+const TEST_RE = /\.(test|spec)\.(ts|tsx|mts)$/;
+
+/** Classes that own a WASM handle and must be disposed. */
+const DISPOSABLE_CLASSES = new Set(['GeometryProcessor']);
+
+/**
+ * Sites that legitimately never dispose. Keyed by `path:line-independent`
+ * identity (path + the variable name) so an unrelated edit that shifts line
+ * numbers does not silently move an allowance onto a different construction.
+ *
+ * Currently EMPTY, deliberately. The obvious candidates — the
+ * `create-ifc-lite` scaffolding templates — are not detected at all, because
+ * their `new GeometryProcessor()` lives inside a template literal and is
+ * string content to the parser, not a `NewExpression`. Allowlisting them would
+ * have looked like coverage while proving nothing, so the entries were removed
+ * once the AST confirmed they never reach this check. Generated starter code
+ * is not linted by this gate; if that ever matters it needs a separate check
+ * that parses the emitted template.
+ */
+const ALLOWLIST = new Map([]);
+
+function findSourceFiles(dir, out = []) {
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    if (SKIP_DIRS.has(entry) || entry.startsWith('.')) continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) findSourceFiles(full, out);
+    else if (SOURCE_RE.test(entry) && !TEST_RE.test(entry)) out.push(full);
+  }
+  return out;
+}
+
+/** The nearest enclosing function-like node, or the source file. */
+function enclosingFunction(node) {
+  let cur = node.parent;
+  while (cur) {
+    if (
+      ts.isFunctionDeclaration(cur) ||
+      ts.isFunctionExpression(cur) ||
+      ts.isArrowFunction(cur) ||
+      ts.isMethodDeclaration(cur) ||
+      ts.isConstructorDeclaration(cur) ||
+      ts.isSourceFile(cur)
+    ) {
+      return cur;
+    }
+    cur = cur.parent;
+  }
+  return null;
+}
+
+/**
+ * `using x = ...` / `await using x = ...`
+ *
+ * Test the `Using` BIT only. `NodeFlags.AwaitUsing` is `Using | Const` (6), so
+ * `flags & AwaitUsing` is non-zero for every ordinary `const` (2) — an
+ * `|| (flags & AwaitUsing)` clause here silently accepts the entire codebase
+ * and the gate reports success while checking nothing. `AwaitUsing` already
+ * contains the `Using` bit, so this single test covers both forms.
+ */
+function isUsingBinding(decl) {
+  const list = decl.parent;
+  if (!list || !ts.isVariableDeclarationList(list)) return false;
+  return (list.flags & ts.NodeFlags.Using) === ts.NodeFlags.Using;
+}
+
+/** Does any `finally` block inside `scope` call `<name>.dispose()`? */
+function disposedInFinally(scope, name) {
+  let found = false;
+  const visit = (node) => {
+    if (found) return;
+    if (ts.isTryStatement(node) && node.finallyBlock) {
+      const scan = (n) => {
+        if (found) return;
+        if (ts.isCallExpression(n)) {
+          const target = n.expression;
+          // p.dispose()  |  p?.dispose()
+          if (
+            (ts.isPropertyAccessExpression(target) || ts.isPropertyAccessChain?.(target)) &&
+            target.name?.text === 'dispose'
+          ) {
+            const receiver = target.expression;
+            if (ts.isIdentifier(receiver) && receiver.text === name) found = true;
+            // p?.dispose() where receiver is a NonNullExpression etc.
+            if (
+              !found &&
+              receiver &&
+              ts.isIdentifier(receiver.expression ?? {}) &&
+              receiver.expression.text === name
+            ) {
+              found = true;
+            }
+          }
+        }
+        ts.forEachChild(n, scan);
+      };
+      scan(node.finallyBlock);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(scope);
+  return found;
+}
+
+/**
+ * Does `name` escape the scope that constructed it?
+ *
+ * A processor that is returned, or stored on an object/field, is owned by
+ * whoever receives it — `packages/cli/src/commands/export.ts` returns
+ * `{ bytes, gp }`, and `demesh-session.ts` assigns `this.gp` so `destroy()`
+ * can free it. Neither is a leak, and neither is decidable from the
+ * constructing scope alone.
+ *
+ * This gate deliberately proves a narrow thing: a processor that stays local
+ * and is never freed. Flagging escapes as well would produce exactly the
+ * false positives that get a check disabled — and issue #1959's own audit
+ * lists both of the above under "correct, for the record".
+ */
+function escapesScope(scope, name) {
+  let escapes = false;
+  const mentionsName = (node) => {
+    let hit = false;
+    const scan = (n) => {
+      if (hit) return;
+      if (ts.isIdentifier(n) && n.text === name) hit = true;
+      ts.forEachChild(n, scan);
+    };
+    scan(node);
+    return hit;
+  };
+  const visit = (node) => {
+    if (escapes) return;
+    if (ts.isReturnStatement(node) && node.expression && mentionsName(node.expression)) {
+      escapes = true;
+    }
+    // this.gp = gp  |  obj.field = gp  |  sharedProcessor = gp
+    //
+    // The last form is a module-level cache (`packages/cli/src/commands/clash.ts`
+    // keeps one processor for the CLI process). Assigning to any binding other
+    // than itself moves ownership out of this scope.
+    if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      ts.isIdentifier(node.right) &&
+      node.right.text === name &&
+      (ts.isPropertyAccessExpression(node.left) ||
+        (ts.isIdentifier(node.left) && node.left.text !== name))
+    ) {
+      escapes = true;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(scope);
+  return escapes;
+}
+
+/** The construction is the entire body of a function -> the caller owns it. */
+function isFactoryBody(newExpr) {
+  const p = newExpr.parent;
+  if (!p) return false;
+  if (ts.isArrowFunction(p) && p.body === newExpr) return true;
+  if (ts.isReturnStatement(p)) {
+    const fn = enclosingFunction(p);
+    // A bare `return new GeometryProcessor()` hands ownership out.
+    return fn !== null && !ts.isSourceFile(fn);
+  }
+  return false;
+}
+
+const violations = [];
+const accepted = { using: 0, finally: 0, factory: 0, allowlisted: 0, escapes: 0 };
+let scanned = 0;
+
+for (const scanDir of SCAN_DIRS) {
+  for (const file of findSourceFiles(join(ROOT, scanDir))) {
+    const text = readFileSync(file, 'utf8');
+    if (![...DISPOSABLE_CLASSES].some((c) => text.includes(`new ${c}`))) continue;
+    scanned++;
+    const rel = relative(ROOT, file);
+    const src = ts.createSourceFile(file, text, ts.ScriptTarget.ESNext, true, ts.ScriptKind.TSX);
+
+    const visit = (node) => {
+      if (
+        ts.isNewExpression(node) &&
+        ts.isIdentifier(node.expression) &&
+        DISPOSABLE_CLASSES.has(node.expression.text)
+      ) {
+        const line = src.getLineAndCharacterOfPosition(node.getStart()).line + 1;
+        const decl = ts.isVariableDeclaration(node.parent) ? node.parent : null;
+        const name = decl && ts.isIdentifier(decl.name) ? decl.name.text : null;
+        const key = name ? `${rel}:${name}` : null;
+
+        const scope = enclosingFunction(node) ?? src;
+        if (isFactoryBody(node)) accepted.factory++;
+        else if (decl && isUsingBinding(decl)) accepted.using++;
+        else if (key && ALLOWLIST.has(key)) accepted.allowlisted++;
+        else if (name && disposedInFinally(scope, name)) accepted.finally++;
+        else if (name && escapesScope(scope, name)) accepted.escapes++;
+        else {
+          violations.push({
+            file: rel,
+            line,
+            name: name ?? '<unbound>',
+            cls: node.expression.text,
+          });
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(src);
+  }
+}
+
+const total =
+  violations.length + accepted.using + accepted.finally + accepted.factory + accepted.allowlisted + accepted.escapes;
+
+if (violations.length > 0) {
+  console.error(
+    `❌ ${violations.length} WASM-handle construction(s) with no deterministic release:\n`,
+  );
+  for (const v of violations) {
+    console.error(`   ${v.file}:${v.line}  new ${v.cls}()  -> \`${v.name}\` is never freed`);
+  }
+  console.error(`
+Every \`new GeometryProcessor(...)\` must free its WASM handle on ALL paths.
+Cheapest fix (GeometryProcessor implements [Symbol.dispose], #1563):
+
+    using processor = new GeometryProcessor(...);
+
+or, where the lifetime is not lexical:
+
+    const processor = new GeometryProcessor(...);
+    try { ... } finally { processor.dispose(); }
+
+If a site legitimately outlives its scope (a page-lifetime singleton), add it to
+ALLOWLIST in scripts/check-wasm-disposal.mjs with the reason. See issue #1959.`);
+  process.exit(1);
+}
+
+console.log(
+  `✅ All ${total} WASM-handle construction(s) release deterministically ` +
+    `(${accepted.using} using, ${accepted.finally} try/finally, ${accepted.factory} factory, ` +
+    `${accepted.escapes} ownership-transferred, ${accepted.allowlisted} allowlisted) ` +
+    `across ${scanned} file(s).`,
+);

--- a/scripts/check-wasm-disposal.mjs
+++ b/scripts/check-wasm-disposal.mjs
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 /**
  * Guard: every `new GeometryProcessor(...)` must release its WASM handle
  * deterministically.
@@ -21,6 +24,26 @@
  *      ownership transfers to the caller, which this gate checks separately at
  *      the call site.
  *   4. The site is in ALLOWLIST below, with a reason.
+ *
+ * WHAT THIS DOES NOT PROVE (reviewers on #2129 found each of these; they are
+ * accepted limits, not oversights):
+ *
+ *   - The `finally` is not required to DOMINATE the construction. A throw
+ *     before the try — engine init, an allocation — can still skip it.
+ *   - Receivers are matched by identifier TEXT, with no scope resolution, so a
+ *     shadowed or captured binding of the same name can satisfy a check.
+ *   - `handedToDisposer` accepts a matching callback anywhere in the enclosing
+ *     function; it does not prove that callee actually owns the handle.
+ *
+ * All three are over-acceptance: the gate can miss a leak, it cannot invent
+ * one. That direction is deliberate. A gate that rejects a correct fix gets
+ * disabled — this one already tried to reject #2127, which was right and my
+ * own fix was not. Closing these properly needs real scope resolution (a
+ * `ts.TypeChecker` over a full program) rather than a single-file AST walk,
+ * which is a much larger tool than the problem currently justifies.
+ *
+ * It still catches the shape that actually happened twelve times: a processor
+ * constructed, used locally, and never freed on any path.
  *
  * Run via `pnpm check:wasm-disposal` (wired into the CI node-test job).
  */
@@ -211,6 +234,26 @@ function handedToDisposer(scope, name) {
  */
 function escapesScope(scope, name) {
   let escapes = false;
+  /**
+   * Is `target` declared inside this same scope? If so, assigning to it is a
+   * local alias with the same lifetime, not an escape — `let alias; alias = p;`
+   * keeps the handle exactly as local as it was, and accepting it would let a
+   * leak through (greptile, #2129 review). Only assignment to a binding from an
+   * OUTER scope — a module-level cache like `clash.ts`'s `sharedProcessor` —
+   * actually moves ownership.
+   */
+  const declaredLocally = (target) => {
+    let found = false;
+    const scan = (n) => {
+      if (found) return;
+      if (ts.isVariableDeclaration(n) && ts.isIdentifier(n.name) && n.name.text === target) {
+        found = true;
+      }
+      ts.forEachChild(n, scan);
+    };
+    scan(scope);
+    return found;
+  };
   const mentionsName = (node) => {
     let hit = false;
     const scan = (n) => {
@@ -237,7 +280,9 @@ function escapesScope(scope, name) {
       ts.isIdentifier(node.right) &&
       node.right.text === name &&
       (ts.isPropertyAccessExpression(node.left) ||
-        (ts.isIdentifier(node.left) && node.left.text !== name))
+        (ts.isIdentifier(node.left) &&
+          node.left.text !== name &&
+          !declaredLocally(node.left.text)))
     ) {
       escapes = true;
     }


### PR DESCRIPTION
Closes #1959.

`AGENTS.md` already required WASM handles to be freed in `try/finally`. The rule was self-policed, so compliance decayed one call site at a time until the #1959 audit found **12 sites that never disposed on any path** — including the viewer's canonical load path, which fires on every IFC load. Ten have since been fixed one at a time. That pattern does not stop the thirteenth, so this adds a gate.

## The gate

`scripts/check-wasm-disposal.mjs` walks the TypeScript AST and accepts a `new GeometryProcessor(...)` only when one of these holds:

| accepted | why |
|---|---|
| `using` / `await using` binding | scope exit frees it |
| `try { … } finally { p.dispose() }` | explicit |
| the construction is a factory body | caller owns it |
| ownership transfers out (returned, `this.gp = p`, or assigned to an outer binding) | lifetime is not decidable from this scope |

Anything else fails CI. Wired as `pnpm check:wasm-disposal`, next to `check-test-wiring` in the node-test job.

**Mutation-verified in four directions**, because a gate that cannot fail is worse than no gate:

```
M1  leaked local (const, never disposed)   -> exit 1, names the file:line   ✅ catches
M2  same site, try/finally-disposed        -> exit 0                        ✅ no false positive
M3  same site, `using`-bound               -> exit 0                        ✅ no false positive
M4  revert the useIfcLoader fix            -> exit 1                        ✅ catches
```

Current state: `29 constructions — 22 try/finally, 3 factory, 4 ownership-transferred, 0 allowlisted`.

### The gate's own first bug, kept as a comment

My first version reported `✅ 26 using` against a codebase with essentially none. `NodeFlags.AwaitUsing` is `Using | Const` (6), so `flags & AwaitUsing` is non-zero for **every ordinary `const`** — the gate was accepting the entire repo while reporting success. Testing the `Using` bit alone fixes it, and the reason is now a comment on that function, because it is exactly the kind of bitmask slip that silently disarms a check.

## The two real leaks

**`apps/viewer/src/hooks/useIfcLoader.ts`** — the canonical load path, freed nothing. Now disposes in a `finally` covering the streaming block and every `return` out of its catch.

**`packages/cli/src/commands/clash.ts`** — caches a process-lifetime singleton in a module-level binding. Not a leak; accepted as ownership transfer, which also removed the need to allowlist it.

## Three things this deliberately does not do

**`using` is not usable in `apps/viewer` yet.** It type-checks, but rolldown (Vite 8) **panics rendering chunks** and the production build fails. Verified by building both ways on this branch:

```
const  -> ✓ built in 15.00s
using  -> thread '<unnamed>' panicked at miette-7.6.0/.../graphical.rs:1159
          'Formatting argument out of range'   (exit 134)
```

So the viewer fix is a `finally`, not the `using` one-liner the changelog for #1563 advertises. Filing that separately — it is a real constraint on the ergonomic form across the whole app.

**The gate proves a narrow thing.** A processor that stays local and is never freed. It does not verify that the `finally` dominates the construction, and it accepts escapes. Widening it would produce the false positives that get a check disabled, and #1959's own audit lists the escape sites (`export.ts` returning `{ bytes, gp }`, `demesh-session.ts` assigning `this.gp`) under "correct, for the record".

**One window in `useIfcLoader` stays uncovered**, and the comment says so: a throw between construction and the `try` — engine-init or the parse stages — unwinds to the outer catch where the binding is out of scope. Widening the try instead would reroute those errors into a catch written specifically for stream failures, which is a behaviour change rather than a disposal fix.

## Verification

`tsc --noEmit` clean, `pnpm build` succeeds, 11 loader/drawing tests pass, gate green. No changeset: `apps/viewer` is private and the other changes are tooling and CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added automated validation to confirm WebAssembly resources are properly cleaned up across supported usage patterns.
  * Builds now detect missing cleanup, helping prevent resource leaks and improve runtime stability.

* **Chores**
  * Added a dedicated command for running the WebAssembly cleanup check locally and in continuous integration.
  * The check reports categorized results and provides guidance for resolving detected issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->