### PR TITLE
test(viewer): pin the direct SVG export's world-mm to paper-mm transform

### DIFF
--- a/apps/viewer/src/hooks/svgExportViewport.test.ts
+++ b/apps/viewer/src/hooks/svgExportViewport.test.ts
@@ -1,0 +1,122 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The direct SVG export's world-metres -> paper-mm viewport arithmetic
+ * (`useDrawingExport.ts`'s `generateExportSVG`, extracted here per the PR
+ * #2119 follow-up: this was the fourth of four "world metres -> paper mm at
+ * scale N" transforms, and the only one not yet pinned by a test — it was
+ * inline, unexported, inside a hook with `useViewerStore` dependencies).
+ *
+ * Distinctive contract, unlike the other three: this transform does NOT map
+ * points into paper-mm space. Path data is emitted in raw (axis-flipped)
+ * WORLD units; the mm-per-world-unit scaling is entirely delegated to the
+ * ratio between the SVG's `width`/`height` (mm) and its `viewBox` (world
+ * units) — a renderer does the actual scaling when it lays the `viewBox`
+ * into the `width`x`height` box.
+ *
+ * Equivalence with the pre-extraction inline code was established out of
+ * band (not committed) by running the OLD formula and `computeSvgExportViewport`
+ * side by side over 6 representative inputs (typical bounds at two scales,
+ * a degenerate zero-size bounds, a falsy `scale` exercising the `|| 100`
+ * default, and all three axes) and asserting `assert.strictEqual` — exact
+ * bit-for-bit match, not "close enough" — on every returned field.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { computeSvgExportViewport, svgExportMmToWorld, type SvgExportBounds } from './svgExportViewport.js';
+
+const bounds: SvgExportBounds = { min: { x: 0, y: 0 }, max: { x: 10, y: 5 } };
+// width=10, height=5 -> padding = max(10,5)*0.1 = 1
+// viewBoxWidth = 10 + 2 = 12, viewBoxHeight = 5 + 2 = 7
+
+describe('computeSvgExportViewport', () => {
+  it('sets width/height mm from the viewBox extent at the given scale (1:100)', () => {
+    const v = computeSvgExportViewport(bounds, 100, 'down');
+    // widthMm = viewBoxWidth * 1000 / scale = 12 * 1000 / 100 = 120
+    assert.strictEqual(v.widthMm, 120);
+    // heightMm = 7 * 1000 / 100 = 70
+    assert.strictEqual(v.heightMm, 70);
+    assert.strictEqual(v.viewBoxWidth, 12);
+    assert.strictEqual(v.viewBoxHeight, 7);
+    assert.strictEqual(v.effectiveScale, 100);
+  });
+
+  it('halves mm dimensions when the scale doubles (1:200) — same world extent', () => {
+    const v100 = computeSvgExportViewport(bounds, 100, 'down');
+    const v200 = computeSvgExportViewport(bounds, 200, 'down');
+    // Same viewBox (world units) at every scale — only the paper mm changes.
+    assert.strictEqual(v200.viewBoxWidth, v100.viewBoxWidth);
+    assert.strictEqual(v200.viewBoxHeight, v100.viewBoxHeight);
+    assert.strictEqual(v200.widthMm, v100.widthMm / 2);
+    assert.strictEqual(v200.heightMm, v100.heightMm / 2);
+    assert.strictEqual(v200.widthMm, 60);
+    assert.strictEqual(v200.heightMm, 35);
+  });
+
+  it('falls back to scale 100 for a falsy scale (0), matching the `|| 100` default', () => {
+    const v = computeSvgExportViewport(bounds, 0, 'down');
+    assert.strictEqual(v.effectiveScale, 100);
+    assert.strictEqual(v.widthMm, 120);
+  });
+
+  it('does not flip Y or X for the "down" (plan) axis', () => {
+    const v = computeSvgExportViewport(bounds, 100, 'down');
+    assert.strictEqual(v.flipY, false);
+    assert.strictEqual(v.flipX, false);
+    // Unflipped: viewBoxMin == bounds.min - padding, no mirroring.
+    assert.strictEqual(v.viewBoxMinX, -1);
+    assert.strictEqual(v.viewBoxMinY, -1);
+  });
+
+  it('flips Y (not X) for the "front" axis', () => {
+    const v = computeSvgExportViewport(bounds, 100, 'front');
+    assert.strictEqual(v.flipY, true);
+    assert.strictEqual(v.flipX, false);
+    // viewBoxMinX unflipped: bounds.min.x - padding = -1.
+    assert.strictEqual(v.viewBoxMinX, -1);
+    // viewBoxMinY flipped: -viewMinY - viewBoxHeight = -(-1) - 7 = -6.
+    assert.strictEqual(v.viewBoxMinY, -6);
+  });
+
+  it('flips both Y and X for the "side" axis', () => {
+    const v = computeSvgExportViewport(bounds, 100, 'side');
+    assert.strictEqual(v.flipY, true);
+    assert.strictEqual(v.flipX, true);
+    // viewBoxMinX flipped: -viewMinX - viewBoxWidth = -(-1) - 12 = -11.
+    assert.strictEqual(v.viewBoxMinX, -11);
+    // viewBoxMinY flipped: -viewMinY - viewBoxHeight = -(-1) - 7 = -6.
+    assert.strictEqual(v.viewBoxMinY, -6);
+  });
+
+  it('pads by 10% of max(width, height) of the UNPADDED bounds, in WORLD units', () => {
+    // width=10, height=5 -> max=10 -> padding=1 (world units, not mm).
+    const v = computeSvgExportViewport(bounds, 100, 'down');
+    assert.strictEqual(v.viewBoxWidth, 10 + 2 * 1);
+    assert.strictEqual(v.viewBoxHeight, 5 + 2 * 1);
+
+    // A taller-than-wide bounds: padding tracks max(width, height), not width.
+    const tall: SvgExportBounds = { min: { x: 0, y: 0 }, max: { x: 4, y: 20 } };
+    const vTall = computeSvgExportViewport(tall, 100, 'down');
+    const expectedPadding = Math.max(4, 20) * 0.1; // 2
+    assert.strictEqual(vTall.viewBoxWidth, 4 + 2 * expectedPadding);
+    assert.strictEqual(vTall.viewBoxHeight, 20 + 2 * expectedPadding);
+
+    // Padding is unaffected by scale — it's a world-unit quantity, not mm.
+    const vTallScaled = computeSvgExportViewport(tall, 500, 'down');
+    assert.strictEqual(vTallScaled.viewBoxWidth, vTall.viewBoxWidth);
+    assert.strictEqual(vTallScaled.viewBoxHeight, vTall.viewBoxHeight);
+  });
+});
+
+describe('svgExportMmToWorld', () => {
+  it('converts paper mm to world units via scale/1000 (inverse of the mm-per-world-unit ratio)', () => {
+    // At 1:100, 1mm on paper = 0.1 world units (metres).
+    assert.strictEqual(svgExportMmToWorld(1, 100), 0.1);
+    assert.strictEqual(svgExportMmToWorld(10, 100), 1);
+    // At 1:200, 1mm on paper = 0.2 world units.
+    assert.strictEqual(svgExportMmToWorld(1, 200), 0.2);
+  });
+});

--- a/apps/viewer/src/hooks/svgExportViewport.ts
+++ b/apps/viewer/src/hooks/svgExportViewport.ts
@@ -1,0 +1,109 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The direct (non-sheet) SVG export's world-metres -> paper-mm arithmetic
+ * (`useDrawingExport.ts`'s `generateExportSVG`). Pulled out per the PR #2119
+ * follow-up: three sibling "world metres -> paper mm at scale N" transforms
+ * (`dxfExportGeoref.ts`, the sheet export's `calculateDrawingTransform`, and
+ * the PDF exporter) are already pinned by tests; this was the fourth,
+ * unreachable because it lived inline in a hook with `useViewerStore`
+ * dependencies.
+ *
+ * Unlike the other three, this transform does NOT map world points into
+ * paper-mm space at all. `polygonToPath` etc. below emit path data directly
+ * in (axis-flipped) WORLD units; the mm-per-world-unit scaling is entirely
+ * delegated to the SVG element itself, via the ratio between its `width`/
+ * `height` attributes (paper mm) and its `viewBox` (world units). A renderer
+ * (browser, printer, `rsvg`) does the actual paper-mm placement when it lays
+ * the `viewBox` out into the `width`x`height` box.
+ *
+ * `computeSvgExportViewport` is that arithmetic, extracted verbatim (no
+ * behaviour change — see `svgExportViewport.test.ts`'s equivalence note).
+ */
+
+export interface SvgExportBounds {
+  min: { x: number; y: number };
+  max: { x: number; y: number };
+}
+
+export type SectionAxis = 'down' | 'front' | 'side';
+
+export interface SvgExportViewport {
+  /** `<svg width>`, paper mm. */
+  widthMm: number;
+  /** `<svg height>`, paper mm. */
+  heightMm: number;
+  /** `viewBox` min-x, world units (post axis-flip). */
+  viewBoxMinX: number;
+  /** `viewBox` min-y, world units (post axis-flip). */
+  viewBoxMinY: number;
+  /** `viewBox` width, world units (padded, flip-invariant). */
+  viewBoxWidth: number;
+  /** `viewBox` height, world units (padded, flip-invariant). */
+  viewBoxHeight: number;
+  /** Mirror X — true only for the 'side' axis. */
+  flipX: boolean;
+  /** Mirror Y — true for every axis except 'down' (plan). */
+  flipY: boolean;
+  /** `displayOptions.scale`, defaulted to 100 — the drawing scale (1:N). */
+  effectiveScale: number;
+}
+
+/**
+ * Compute the direct SVG export's paper dimensions, `viewBox`, and
+ * axis-driven mirroring from the drawing bounds, the requested scale
+ * (1:`scale`, e.g. 100), and the active section axis.
+ *
+ * Padding: 10% of `max(width, height)` of the UNPADDED drawing bounds,
+ * in WORLD units (not mm) — deliberately not 10% of the paper size, so the
+ * margin scales with the model rather than the sheet.
+ *
+ * Y-flip: 'down' (plan) doesn't flip, so north (world +Z, drawing +Y) reads
+ * as up; 'front'/'side' flip Y so height (+Y) reads as up. X-flip: only
+ * 'side', to view from the conventional direction. `viewBoxMinX`/`Y`
+ * incorporate the flip so the flipped content (drawn by the caller with the
+ * same flipX/flipY signs) still lands inside `[0, viewBoxWidth/Height]`.
+ */
+export function computeSvgExportViewport(
+  bounds: SvgExportBounds,
+  scale: number,
+  axis: SectionAxis,
+): SvgExportViewport {
+  const width = bounds.max.x - bounds.min.x;
+  const height = bounds.max.y - bounds.min.y;
+
+  // Padding around the drawing, in world units.
+  const padding = Math.max(width, height) * 0.1;
+  const viewMinX = bounds.min.x - padding;
+  const viewMinY = bounds.min.y - padding;
+  const viewBoxWidth = width + padding * 2;
+  const viewBoxHeight = height + padding * 2;
+
+  // SVG dimensions in mm (assuming model is in metres, scale 1:100 default).
+  const effectiveScale = scale || 100;
+  const widthMm = (viewBoxWidth * 1000) / effectiveScale;
+  const heightMm = (viewBoxHeight * 1000) / effectiveScale;
+
+  // Axis-specific flipping (matching canvas rendering):
+  // - 'down' (plan view): DON'T flip Y so north (Z+) is up.
+  // - 'front' and 'side': flip Y so height (Y+) is up.
+  // - 'side': also flip X to look from the conventional direction.
+  const flipY = axis !== 'down';
+  const flipX = axis === 'side';
+
+  const viewBoxMinX = flipX ? -viewMinX - viewBoxWidth : viewMinX;
+  const viewBoxMinY = flipY ? -viewMinY - viewBoxHeight : viewMinY;
+
+  return { widthMm, heightMm, viewBoxMinX, viewBoxMinY, viewBoxWidth, viewBoxHeight, flipX, flipY, effectiveScale };
+}
+
+/**
+ * Convert paper mm (a line weight, font size, etc.) to world units, given
+ * the same effective scale {@link computeSvgExportViewport} resolved —
+ * `mm * scale / 1000`, the inverse ratio `widthMm`/`viewBoxWidth` encodes.
+ */
+export function svgExportMmToWorld(mm: number, effectiveScale: number): number {
+  return (mm * effectiveScale) / 1000;
+}

--- a/apps/viewer/src/hooks/useDrawingExport.ts
+++ b/apps/viewer/src/hooks/useDrawingExport.ts
@@ -27,6 +27,7 @@ import type { IfcDataStore } from '@ifc-lite/parser';
 import { useViewerStore } from '@/store';
 import { buildDxfExportTransform, resolveDxfExportGeoreference } from '@/hooks/dxfExportGeoref';
 import { DEFAULT_SCAN_SVG_CAP, type ScanBandPoint } from '@/hooks/scanSectionMath';
+import { computeSvgExportViewport, svgExportMmToWorld } from '@/hooks/svgExportViewport';
 
 /** Map a DXF vertical justification onto an SVG dominant-baseline. */
 function dxfValignToBaseline(valign: 'baseline' | 'bottom' | 'middle' | 'top'): string {
@@ -210,25 +211,18 @@ function useDrawingExport({
     if (!drawing) return null;
 
     const { bounds } = drawing;
-    const width = bounds.max.x - bounds.min.x;
-    const height = bounds.max.y - bounds.min.y;
 
-    // Add padding around the drawing
-    const padding = Math.max(width, height) * 0.1;
-    const viewMinX = bounds.min.x - padding;
-    const viewMinY = bounds.min.y - padding;
-    const viewWidth = width + padding * 2;
-    const viewHeight = height + padding * 2;
-
-    // SVG dimensions in mm (assuming model is in meters, scale 1:100)
-    const scale = displayOptions.scale || 100;
-    const svgWidthMm = (viewWidth * 1000) / scale;
-    const svgHeightMm = (viewHeight * 1000) / scale;
+    // World-metres -> paper-mm arithmetic for the direct SVG export,
+    // extracted to svgExportViewport.ts (see that file's docstring for why
+    // this transform doesn't map points at all — the SVG's own
+    // width/height-vs-viewBox ratio does the scaling).
+    const viewport = computeSvgExportViewport(bounds, displayOptions.scale, sectionPlane.axis);
+    const { widthMm: svgWidthMm, heightMm: svgHeightMm, viewBoxMinX, viewBoxMinY, viewBoxWidth: viewWidth, viewBoxHeight: viewHeight, flipX, flipY, effectiveScale } = viewport;
 
     // Convert mm on paper to model units (meters)
     // At 1:100 scale, 1mm on paper = 0.1m in model space
     // Formula: modelUnits = paperMm * scale / 1000
-    const mmToModel = (mm: number) => mm * scale / 1000;
+    const mmToModel = (mm: number) => svgExportMmToWorld(mm, effectiveScale);
 
     // Helper to escape XML
     const escapeXml = (str: string): string => {
@@ -240,13 +234,9 @@ function useDrawingExport({
         .replace(/'/g, '&apos;');
     };
 
-    // Axis-specific flipping (matching canvas rendering)
-    // - 'down' (plan view): DON'T flip Y so north (Z+) is up
-    // - 'front' and 'side': flip Y so height (Y+) is up
-    // - 'side': also flip X to look from conventional direction
-    const currentAxis = sectionPlane.axis;
-    const flipY = currentAxis !== 'down';
-    const flipX = currentAxis === 'side';
+    // flipX/flipY (axis-specific, matching canvas rendering) come from
+    // `viewport` above — computeSvgExportViewport resolves the same
+    // 'down'/'front'/'side' rule this hook used to compute inline.
 
     // Helper to get polygon path with axis-specific coordinate transformation
     const polygonToPath = (polygon: { outer: { x: number; y: number }[]; holes: { x: number; y: number }[][] }): string => {
@@ -278,10 +268,6 @@ function useDrawingExport({
       }
       return path;
     };
-
-    // Calculate viewBox with axis-specific flipping
-    const viewBoxMinX = flipX ? -viewMinX - viewWidth : viewMinX;
-    const viewBoxMinY = flipY ? -viewMinY - viewHeight : viewMinY;
 
     // Start building SVG
     let svg = `<?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
## Summary

Follow-up to the PR #2119 investigation, which compared four "world metres -> paper mm at scale N" transforms in the export code and correctly concluded they should not be consolidated (four different contracts), but flagged that the fourth — the inline arithmetic in `generateExportSVG` (`apps/viewer/src/hooks/useDrawingExport.ts`) — was untested because it lived inline in a hook with `useViewerStore` dependencies, unlike the codebase's pattern of extracting pure math into small testable modules (e.g. `dxfExportGeoref.ts`).

Confirmed the description at `apps/viewer/src/hooks/useDrawingExport.ts:212-231,243-249,282-284` (pre-extraction line numbers): this transform is distinctive because it does **not** map points into paper-mm space at all — path data is emitted directly in (axis-flipped) world units, and the mm-per-world-unit scaling is delegated entirely to the ratio between the SVG's `width`/`height` (mm) and its `viewBox` (world units). Padding is 10% of `max(width, height)` of the *unpadded* drawing bounds, in world units, not mm.

- Extracted the pure arithmetic into `apps/viewer/src/hooks/svgExportViewport.ts` (`computeSvgExportViewport`, `svgExportMmToWorld`), following the `dxfExportGeoref.ts` precedent. The hook now calls it — no behaviour change.
- Pinned it in `apps/viewer/src/hooks/svgExportViewport.test.ts`: the mm-per-world-unit relationship at two scales (1:100, 1:200) plus the falsy-scale `|| 100` fallback, the axis-dependent Y/X flip for all three axes (`down`, `front`, `side`), and the 10%-of-max-extent padding in world units (independent of scale).

## Equivalence method (pure refactor safety net)

Before wiring the hook to the new module, I ran the *original* inline formula (copied verbatim into a throwaway script) side by side with `computeSvgExportViewport` over 6 representative inputs — typical bounds at two scales, a degenerate zero-size bounds, a falsy `scale` (0) exercising the `|| 100` default, and all three axes — asserting `assert.strictEqual` (exact bit-for-bit match, not "close enough") on every field. All 6 matched exactly before the hook was touched.

## Mutation testing

Two targeted mutations via python3 exact-substring replacement (occurrence count asserted `== 1`, region re-read, restored by file copy — never `git checkout --`):
- Perturbed the scale factor (`widthMm` off by 1.5x) — killed 3/8 tests.
- Flipped the Y-flip sign (`axis !== 'down'` -> `axis === 'down'`) — killed 3/8 tests.

Both restored cleanly; final state re-verified green (8/8).

## Test plan

- [x] `apps/viewer`: baseline 2709 tests (2707 pass, 2 skipped) -> final 2717 tests (2715 pass, 2 skipped, 0 fail) — +8 tests / +2 suites, all new.
- [x] `pnpm typecheck` — clean.
- [x] No changeset: `@ifc-lite/viewer` is `"private": true` (verified in `package.json`, not assumed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)