### PR TITLE
test(geometry): fix two mutation-verified vacuous tests

### DIFF
--- a/.changeset/geometry-vacuous-diagnostics-payload.md
+++ b/.changeset/geometry-vacuous-diagnostics-payload.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/geometry": patch
+---
+
+Extract the streaming `complete` event's diagnostics payload builder (`geometry.worker.ts`'s `emitSessionEnd`) into a standalone `buildGeometryWorkerCompleteMessage` in `diagnostics.ts`, and have the worker call it instead of inlining the conditional spread. No behaviour change: the emitted payload is identical (diagnostics still omitted entirely, not sent as `undefined`, on a clean load). This lets `diagnostics.test.ts` exercise the real production logic directly — the worker module cannot be imported under vitest (it assigns `self.onmessage` at module load time), so the payload shape is now factored out where a plain unit test can reach it.

--- a/packages/geometry/src/diagnostics.test.ts
+++ b/packages/geometry/src/diagnostics.test.ts
@@ -3,7 +3,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { describe, it, expect } from 'vitest';
-import { mergeGeometryDiagnostics, type GeometryDiagnostics } from './diagnostics.js';
+import {
+  mergeGeometryDiagnostics,
+  buildGeometryWorkerCompleteMessage,
+  type GeometryDiagnostics,
+} from './diagnostics.js';
 
 function make(partial: Partial<GeometryDiagnostics> = {}): GeometryDiagnostics {
   return {
@@ -113,15 +117,18 @@ describe('mergeGeometryDiagnostics', () => {
   });
 });
 
-describe('the streaming `complete` event payload (geometry.worker.ts:901)', () => {
-  // The worker attaches diagnostics with `...(session.diagnostics ? { diagnostics: session.diagnostics } : {})`
-  // so a clean load (no CSG issues) omits the field entirely rather than sending
-  // an all-zero object — callers must gate on presence (`if (event.diagnostics)`),
-  // not just truthy counts. This test mirrors that exact conditional-spread and
-  // pins the full field shape (including the per-product bbox/triangleCount
-  // detail) without needing a real Worker or a full model load.
+describe('the streaming `complete` event payload (buildGeometryWorkerCompleteMessage, used by geometry.worker.ts emitSessionEnd)', () => {
+  // The worker builds its `complete` event via `buildGeometryWorkerCompleteMessage`
+  // (extracted from geometry.worker.ts's emitSessionEnd so it can be exercised
+  // directly here — the worker module itself assigns `self.onmessage` at import
+  // time and cannot be loaded outside a Worker/browser-like global). It spreads
+  // diagnostics conditionally so a clean load (no CSG issues) omits the field
+  // entirely rather than sending an all-zero object — callers must gate on
+  // presence (`if (event.diagnostics)`), not just truthy counts. These tests
+  // call the real production function and pin the full field shape (including
+  // the per-product bbox/triangleCount detail).
   function buildCompleteEvent(diagnostics: GeometryDiagnostics | null) {
-    return { type: 'complete' as const, totalMeshes: 10, ...(diagnostics ? { diagnostics } : {}) };
+    return buildGeometryWorkerCompleteMessage(10, diagnostics);
   }
 
   it('omits `diagnostics` entirely on a clean load', () => {

--- a/packages/geometry/src/diagnostics.ts
+++ b/packages/geometry/src/diagnostics.ts
@@ -150,3 +150,34 @@ export function mergeGeometryDiagnostics(
     worstHosts,
   };
 }
+
+/** Payload shape of the geometry worker's streaming `complete` message. */
+export interface GeometryWorkerCompleteMessage {
+  type: 'complete';
+  totalMeshes: number;
+  /** CSG / opening diagnostics merged over this worker's batches (the
+   *  GeometryDiagnostics contract). Omitted when none were recorded. */
+  diagnostics?: GeometryDiagnostics;
+}
+
+/**
+ * Build the streaming `complete` event payload (`geometry.worker.ts`'s
+ * `emitSessionEnd`, the only caller). Extracted so it can be exercised
+ * directly by tests without importing the worker module itself, which
+ * assigns `self.onmessage` at module load time and therefore cannot be
+ * imported outside a Worker/browser-like global (see diagnostics.test.ts).
+ *
+ * `diagnostics` is omitted from the returned object entirely (not sent as
+ * `undefined`) when `null` — callers gate on presence
+ * (`if (event.diagnostics)`), not just truthy counts.
+ */
+export function buildGeometryWorkerCompleteMessage(
+  totalMeshes: number,
+  diagnostics: GeometryDiagnostics | null,
+): GeometryWorkerCompleteMessage {
+  return {
+    type: 'complete',
+    totalMeshes,
+    ...(diagnostics ? { diagnostics } : {}),
+  };
+}

--- a/packages/geometry/src/geometry-processor-streaming.test.ts
+++ b/packages/geometry/src/geometry-processor-streaming.test.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const wasmMocks = vi.hoisted(() => {
   const buildPrePassOnce = vi.fn();
@@ -59,21 +59,25 @@ vi.mock('@ifc-lite/wasm', () => ({
 
 import { GeometryProcessor } from './index.js';
 
-describe('GeometryProcessor byte streaming fallback', () => {
-  const originalThreshold = (GeometryProcessor as any).largeFileByteStreamingThreshold;
-
+// `processStreaming()` always runs the byte-based prepass/batch path — it is
+// not gated by file size (there is no "small file" alternative streaming
+// path to fall back from). This suite mocks the WASM bridge and exercises
+// `processStreaming()` directly to pin that behaviour: the byte prepass and
+// batch-processing calls it makes, the event sequence it yields, and its
+// WASM-handle `.free()` / re-entrancy discipline. It does NOT depend on
+// `GeometryProcessor`'s private `largeFileByteStreamingThreshold` static
+// (`index.ts`) — that field is never read by production code (see
+// `processAdaptive`'s separate, locally-scoped `sizeThreshold`, which is the
+// actual small/large-file gate, and only applies to `processAdaptive`, not
+// `processStreaming`).
+describe('GeometryProcessor byte streaming (processStreaming, mocked WASM)', () => {
   beforeEach(() => {
     wasmMocks.init.mockClear();
     wasmMocks.buildPrePassOnce.mockReset();
     wasmMocks.processGeometryBatch.mockReset();
-    (GeometryProcessor as any).largeFileByteStreamingThreshold = 1;
   });
 
-  afterEach(() => {
-    (GeometryProcessor as any).largeFileByteStreamingThreshold = originalThreshold;
-  });
-
-  it('uses byte-based prepass and batch processing for large files', async () => {
+  it('uses byte-based prepass and batch processing', async () => {
     wasmMocks.buildPrePassOnce.mockReturnValue({
       jobs: new Uint32Array([11, 0, 42]),
       totalJobs: 1,

--- a/packages/geometry/src/geometry.worker.ts
+++ b/packages/geometry/src/geometry.worker.ts
@@ -6,7 +6,12 @@ import init, { initSync, IfcAPI } from '@ifc-lite/wasm';
 import { initWasmWithRetry } from './wasm-init-retry.js';
 import { largeFilePrepassError } from './huge-file-error.js';
 import type { MeshData, TessellationQuality } from './types.js';
-import { mergeGeometryDiagnostics, type GeometryDiagnostics } from './diagnostics.js';
+import {
+  mergeGeometryDiagnostics,
+  buildGeometryWorkerCompleteMessage,
+  type GeometryDiagnostics,
+  type GeometryWorkerCompleteMessage,
+} from './diagnostics.js';
 import {
   extractGeometryFingerprints,
   writeGeometryAabbAt,
@@ -394,14 +399,6 @@ export interface GeometryWorkerProgressMessage {
   /** Jobs handed to WASM so far within the current slice (pre-call count). */
   processedJobs: number;
   totalJobs: number;
-}
-
-export interface GeometryWorkerCompleteMessage {
-  type: 'complete';
-  totalMeshes: number;
-  /** CSG / opening diagnostics merged over this worker's batches (the
-   *  GeometryDiagnostics contract). Omitted when none were recorded. */
-  diagnostics?: GeometryDiagnostics;
 }
 
 export interface GeometryWorkerErrorMessage {
@@ -1298,11 +1295,10 @@ function emitSessionEnd(session: ProcessingSession): void {
   // forwards its own subtotal on the message; logging here would print one partial
   // line per worker.
   (self as unknown as Worker).postMessage(
-    {
-      type: 'complete',
-      totalMeshes: session.totalMeshesEmitted,
-      ...(session.diagnostics ? { diagnostics: session.diagnostics } : {}),
-    } as GeometryWorkerCompleteMessage,
+    buildGeometryWorkerCompleteMessage(
+      session.totalMeshesEmitted,
+      session.diagnostics,
+    ) satisfies GeometryWorkerCompleteMessage,
   );
 }
 


### PR DESCRIPTION
## Summary

Two vacuous tests in `packages/geometry` — both mutation-verified (a targeted production-code mutation left the suite green).

**1. `geometry-processor-streaming.test.ts` — dead private-state poke**

The test did `(GeometryProcessor as any).largeFileByteStreamingThreshold = 1` to claim it forces a "large file" streaming path. That private static (`index.ts:262`) is declared and never read anywhere in production code. `processStreaming()`/`processStreamingUnlocked()` run the byte-based prepass/batch path unconditionally, with no size gate at all — the real size gate lives in the unrelated `processAdaptive()`, as its own local `sizeThreshold` (default 2MB).

Verified: deleting the set/restore lines leaves the file at 2/2 passed, identical to baseline.

Fix: removed the dead poke, renamed/re-documented the `describe` block to say what it actually exercises (`processStreaming`'s behaviour against a mocked WASM bridge — event sequence, `.free()` discipline, re-entrancy guard).

On the field itself: `largeFileByteStreamingThreshold` looks like dead code (declared, assigned once, read nowhere), not an unwired gate — there's no code path anywhere that reads it, not even under a different name/getter. Left it in place since deleting a production field wasn't asked for here and is a separate call; noting it for whoever picks that up.

**2. `diagnostics.test.ts` — tests that never touch the code they name**

`describe('the streaming complete event payload (geometry.worker.ts:901)')` (3 tests) defined a local `buildCompleteEvent()` that reimplemented the worker's conditional diagnostics spread, and never imported `geometry.worker.ts`. The `:901` line reference was stale too (current call site was line ~1297 pre-fix).

Verified (mutation): replacing `...(session.diagnostics ? { diagnostics: session.diagnostics } : {})` with `diagnostics: session.diagnostics ?? undefined` — which breaks the "omit the key entirely on a clean load" contract those tests claim to pin — left the suite at 10/10 passed.

`geometry.worker.ts` can't be imported directly under vitest: it assigns `self.onmessage` at module load time, and `self` is undefined in vitest's default (node) environment — confirmed by probing the import directly (`ReferenceError: self is not defined`).

Fix: extracted the payload-building logic into `buildGeometryWorkerCompleteMessage(totalMeshes, diagnostics)` in `diagnostics.ts` (same extract-and-share shape as `dxfExportGeoref.ts`/`svgExportViewport.ts`), and had `geometry.worker.ts`'s `emitSessionEnd` call it instead of inlining the spread. The tests now import and call the real function. Also fixed the stale `:901` reference in the `describe` name.

## Mutation-test evidence (RED-first, python3 exact-substring)

- Mutation: `diagnostics: diagnostics ?? undefined,` replacing `...(diagnostics ? { diagnostics } : {}),` in `diagnostics.ts`'s `buildGeometryWorkerCompleteMessage`. Occurrence count printed to stderr and asserted `== 1` before replacing.
- RED: `omits diagnostics entirely on a clean load` failed (`AssertionError: expected { type: 'complete', …(2) } to not have property "diagnostics"`) — 9/10 passed, 1 failed.
- Restored by re-running the exact-substring replace back to the original (single occurrence, asserted).
- GREEN: 10/10 passed after restore; `git diff --stat` on `diagnostics.ts` shows only the intended additions, no mutation residue.

## Test counts

- Baseline (with wasm built via `scripts/build-wasm.sh`): 20 files / 202 tests, matches the expected baseline exactly.
- After this change: 20 files / 202 tests, all passing (both target files pass: 2/2 and 10/10).
- `pnpm typecheck` (full workspace, wasm-free lane): passes.
- `pnpm knip`: no new flags on the touched files.

## Test plan

- [x] RED-first mutation reproduced against the rewritten `diagnostics.test.ts`, confirmed to fail
- [x] Restored via exact python3 substring replace (not `git checkout`), confirmed GREEN
- [x] `pnpm --filter @ifc-lite/geometry test` (via `vitest run`): 20/20 files, 202/202 tests
- [x] `pnpm typecheck`: passes across the workspace
- [x] Changeset added (`@ifc-lite/geometry` patch) since `diagnostics.ts`/`geometry.worker.ts` (production code) changed, not just tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved consistency in geometry streaming completion messages.
  - Completion responses continue to include mesh totals and optional diagnostics without changing existing behavior.

- **Tests**
  - Expanded coverage for geometry worker completion payloads.
  - Strengthened streaming geometry tests for event sequencing, batch processing, resource cleanup, and repeated execution.

- **Documentation**
  - Added a patch-release note for the geometry diagnostics updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->