### PR TITLE
test(parser): close two mutation-verified coverage gaps

### DIFF
--- a/packages/parser/test/deferred-entity-index-material-properties.test.ts
+++ b/packages/parser/test/deferred-entity-index-material-properties.test.ts
@@ -1,0 +1,103 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Coverage for the `deferredEntityIndex` fallback in `refFromStore()`
+ * (on-demand-extractors.ts): `store.entityIndex.byId.get(id) ??
+ * store.deferredEntityIndex?.get(id)`.
+ *
+ * On large files parsed with `deferPropertyAtomIndex: true`, property atoms
+ * (IfcPropertySingleValue, etc.) are indexed separately into
+ * `deferredEntityIndex` and are deliberately absent from the primary
+ * `entityIndex.byId`. Material-property-set resolution
+ * (`getMaterialPropertyIndex` in on-demand-extractors.ts) walks
+ * *MaterialProperties entities and their referenced IfcProperty atoms through
+ * `refFromStore()`, so it must fall back to the deferred index or every
+ * property on a deferred-index model silently resolves to nothing.
+ *
+ * No existing test builds a store with a populated `deferredEntityIndex`
+ * (`grep -rl deferredEntityIndex test/` returns nothing before this file),
+ * so dropping the `?? store.deferredEntityIndex?.get(id)` fallback survives
+ * the full suite.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { extractMaterialPropertiesForMaterialId } from '../src/columnar-parser.js';
+import type { IfcDataStore } from '../src/columnar-parser.js';
+import type { EntityRef } from '../src/types.js';
+
+// #20 (the property atom) is deliberately built into `deferredEntityIndex`
+// ONLY — never `entityIndex.byId` — to model the deferred-atom-index shape
+// that a real large-file parse with `deferPropertyAtomIndex: true` produces.
+const FIXTURE = [
+  `#10=IFCMATERIAL('Concrete',$,'concrete');`,
+  `#20=IFCPROPERTYSINGLEVALUE('Strength',$,30.0,$);`,
+  `#30=IFCMATERIALPROPERTIES('Pset_MaterialConcrete',$,(#20),#10);`,
+];
+
+/** Build a minimal store where one referenced entity (the property atom)
+ *  lives ONLY in `deferredEntityIndex`, not the primary `entityIndex.byId`. */
+function buildDeferredAtomStore(): IfcDataStore {
+  const text = FIXTURE.join('\n');
+  const source = new TextEncoder().encode(text);
+
+  const byId = new Map<number, EntityRef>();
+  const deferredById = new Map<number, EntityRef>();
+  const byType = new Map<string, number[]>();
+
+  let cursor = 0;
+  for (const line of FIXTURE) {
+    const start = text.indexOf(line, cursor);
+    const match = line.match(/^#(\d+)\s*=\s*(\w+)\(/);
+    if (match) {
+      const expressId = parseInt(match[1], 10);
+      const type = match[2];
+      const ref: EntityRef = {
+        expressId,
+        type,
+        byteOffset: start,
+        byteLength: line.length,
+        lineNumber: 1,
+      };
+      // #20 is the deferred property atom: index it into deferredById only.
+      if (expressId === 20) {
+        deferredById.set(expressId, ref);
+      } else {
+        byId.set(expressId, ref);
+      }
+      const typeUpper = type.toUpperCase();
+      let list = byType.get(typeUpper);
+      if (!list) { list = []; byType.set(typeUpper, list); }
+      list.push(expressId);
+    }
+    cursor = start + line.length;
+  }
+
+  return {
+    source,
+    entityIndex: { byId, byType },
+    deferredEntityIndex: deferredById,
+  } as unknown as IfcDataStore;
+}
+
+describe('refFromStore deferredEntityIndex fallback (material property atoms)', () => {
+  it('resolves a material pset whose property atom lives only in deferredEntityIndex', () => {
+    const store = buildDeferredAtomStore();
+
+    // Sanity: the property atom is genuinely absent from the primary index —
+    // otherwise this test would pass without ever exercising the fallback.
+    expect(store.entityIndex.byId.has(20)).toBe(false);
+    expect(store.deferredEntityIndex!.has(20)).toBe(true);
+
+    const groups = extractMaterialPropertiesForMaterialId(store, 10);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].materialId).toBe(10);
+    expect(groups[0].psets).toHaveLength(1);
+    expect(groups[0].psets[0].name).toBe('Pset_MaterialConcrete');
+    expect(groups[0].psets[0].properties).toHaveLength(1);
+    expect(groups[0].psets[0].properties[0].name).toBe('Strength');
+    expect(groups[0].psets[0].properties[0].value).toBe(30.0);
+  });
+});

--- a/packages/parser/test/schema-version-detection.test.ts
+++ b/packages/parser/test/schema-version-detection.test.ts
@@ -1,0 +1,98 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Coverage for `detectSchemaVersion()` (columnar-parser.ts), which reads the
+ * `FILE_SCHEMA` token out of the STEP header and classifies it via an
+ * ordered ladder of `.includes()` checks:
+ *
+ *   if (headerText.includes('IFC5'))    return 'IFC5';
+ *   if (headerText.includes('IFC4X3'))  return 'IFC4X3';
+ *   if (headerText.includes('IFC4'))    return 'IFC4';
+ *   if (headerText.includes('IFC2X3'))  return 'IFC2X3';
+ *   return 'IFC4'; // default fallback
+ *
+ * The ORDER is load-bearing: 'IFC4X3'.includes('IFC4') is true, so the
+ * IFC4X3 check must run before the IFC4 check or every IFC4X3 file
+ * silently misdetects as IFC4. No existing test drives a real IFC4X3-headed
+ * buffer through the public `parseLite()` entry point and asserts
+ * `schemaVersion` — the other IFC4X3 references in this package
+ * (inheritance-chain-equivalence, instantiable-across-schemas) exercise the
+ * entity-dictionary tables, not header detection. Swapping the IFC4X3/IFC4
+ * lines survives the full test suite before this file.
+ *
+ * `detectSchemaVersion` is module-private; this exercises it exclusively
+ * through the public `ColumnarParser.parseLite()` entry point rather than
+ * exporting it, since the whole point of the ladder is what schemaVersion
+ * a real caller observes on the resulting store.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { StepTokenizer } from '../src/tokenizer.js';
+import { ColumnarParser } from '../src/columnar-parser.js';
+import type { EntityRef } from '../src/types.js';
+
+function scan(ifc: string): { source: Uint8Array; entityRefs: EntityRef[] } {
+  const source = new TextEncoder().encode(ifc);
+  const tokenizer = new StepTokenizer(source);
+  const entityRefs: EntityRef[] = [];
+  for (const ref of tokenizer.scanEntitiesFast()) {
+    entityRefs.push({
+      expressId: ref.expressId,
+      type: ref.type,
+      byteOffset: ref.offset,
+      byteLength: ref.length,
+      lineNumber: ref.line,
+    });
+  }
+  return { source, entityRefs };
+}
+
+function buildStep(schemaToken: string): string {
+  return [
+    'ISO-10303-21;',
+    'HEADER;',
+    "FILE_DESCRIPTION(('schema detection test'),'2;1');",
+    "FILE_NAME('','',(''),(''),'','','');",
+    `FILE_SCHEMA(('${schemaToken}'));`,
+    'ENDSEC;',
+    'DATA;',
+    "#1=IFCPROJECT('proj-gid',$,'Project',$,$,$,$,$,$);",
+    'ENDSEC;',
+    'END-ISO-10303-21;',
+    '',
+  ].join('\n');
+}
+
+async function detect(schemaToken: string) {
+  const { source, entityRefs } = scan(buildStep(schemaToken));
+  const parser = new ColumnarParser();
+  const store = await parser.parseLite(source.buffer.slice(0) as ArrayBuffer, entityRefs, {});
+  return store.schemaVersion;
+}
+
+describe('detectSchemaVersion via ColumnarParser.parseLite (FILE_SCHEMA header)', () => {
+  it('detects IFC4X3 — the critical ordering case ("IFC4X3".includes("IFC4") is true)', async () => {
+    expect(await detect('IFC4X3')).toBe('IFC4X3');
+  });
+
+  it('detects plain IFC4', async () => {
+    expect(await detect('IFC4')).toBe('IFC4');
+  });
+
+  it('detects IFC2X3', async () => {
+    expect(await detect('IFC2X3')).toBe('IFC2X3');
+  });
+
+  it('detects IFC5', async () => {
+    expect(await detect('IFC5')).toBe('IFC5');
+  });
+
+  it('falls back to IFC4 for an unrecognized schema token (matches none of the ladder substrings)', async () => {
+    // Deliberately contains none of 'IFC5', 'IFC4X3', 'IFC4', 'IFC2X3' as
+    // substrings, so this exercises the trailing `return 'IFC4'` default,
+    // not the 'IFC4' `.includes()` branch above it.
+    expect(await detect('IFC2X2')).toBe('IFC4');
+  });
+});


### PR DESCRIPTION
## Summary

Two mutation-verified coverage gaps in `packages/parser`, both confirmed by directly applying the mutation, watching the full suite stay green, then adding a test that fails under the mutation.

### Gap 1 — IFC4X3 schema detection is order-dependent and unpinned

`packages/parser/src/columnar-parser.ts` `detectSchemaVersion()` classifies the `FILE_SCHEMA` header token with an ordered `.includes()` ladder:

```ts
if (headerText.includes('IFC5')) return 'IFC5';
if (headerText.includes('IFC4X3')) return 'IFC4X3';
if (headerText.includes('IFC4')) return 'IFC4';
if (headerText.includes('IFC2X3')) return 'IFC2X3';
```

`'IFC4X3'.includes('IFC4')` is `true`, so the ordering is load-bearing: swapping the IFC4X3 and IFC4 lines makes every IFC4X3 file silently misdetect as IFC4. No existing test drove a real IFC4X3-headed buffer through `parseLite`/`parseColumnar` and asserted `schemaVersion === 'IFC4X3'` — the other IFC4X3 references in the suite (`inheritance-chain-equivalence.test.ts`, `instantiable-across-schemas.test.ts`) exercise entity-dictionary tables, not header detection.

Added `test/schema-version-detection.test.ts`, driving `ColumnarParser.parseLite()` (the public entry point) with a minimal STEP buffer per schema token and asserting `store.schemaVersion`. Covers IFC5, IFC4X3, IFC4, IFC2X3, and the unrecognized-token default fallback. `detectSchemaVersion` stayed module-private — the whole point of the ladder is what a real caller observes on the resulting store, so there was a reasonable public path and no export was needed.

**Acceptance mutation**: swap the IFC4X3/IFC4 lines. Applied via exact-substring replacement, confirmed the new "detects IFC4X3" test fails (`expected 'IFC4' to be 'IFC4X3'`), restored the file by copy from `git show HEAD:...`, confirmed green again.

### Gap 2 — the deferred-atom fallback in `refFromStore` is untested

`packages/parser/src/on-demand-extractors.ts`:

```ts
function refFromStore(store: IfcDataStore, id: number) {
    return store.entityIndex.byId.get(id) ?? store.deferredEntityIndex?.get(id);
}
```

Used when resolving material property sets (`getMaterialPropertyIndex`) for both the `*MaterialProperties` entity and the `IfcProperty` atoms it references — the fallback exists because large files parsed with `deferPropertyAtomIndex: true` keep property atoms out of the primary `entityIndex.byId`, indexed instead into `deferredEntityIndex`. Dropping the `?? store.deferredEntityIndex?.get(id)` fallback survived the full suite; `grep -rl deferredEntityIndex test/` returned nothing before this PR.

Added `test/deferred-entity-index-material-properties.test.ts`, constructing a minimal store where the referenced `IfcPropertySingleValue` atom lives *only* in `deferredEntityIndex` (with an explicit sanity assertion that it's absent from `entityIndex.byId`), then calling the public `extractMaterialPropertiesForMaterialId()` and asserting the property resolves.

**Acceptance mutation**: remove the `?? store.deferredEntityIndex?.get(id)` fallback. Applied via exact-substring replacement, confirmed the new test fails (`expected [] to have a length of 1 but got +0`), restored by file copy, confirmed green again.

### Gap 3 (skipped)

`packages/data/src/property-table.ts:340-341`'s `si >= 0 && si < strings.count` guard was flagged as a third, marginal survivor (`<=` also survives). Skipped per the brief: it's reachable only from corrupted transport data, `StringTable.get()` already bounds-checks and returns `''`, and the only observable difference is `''` vs `null` at exactly `si === strings.count` — cheap to state, not cheap to fixture without contorting internal `PropertyTable`/`StringTable` state. Not included, no changes to `packages/data`.

## Test plan

- [x] Baseline: 370/370 across 45 files (`packages/parser`)
- [x] RED: Gap 1 mutation (swap IFC4X3/IFC4 lines) makes the new "detects IFC4X3" test fail
- [x] RED: Gap 2 mutation (drop deferredEntityIndex fallback) makes the new test fail
- [x] Both mutations restored by file copy (`git show HEAD:<path>`), not `git checkout --`
- [x] GREEN: 376/376 across 47 files after restore
- [x] `pnpm typecheck` passes repo-wide
- [x] Test-only change — no changeset (no source files touched, no exported surface changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when resolving material properties referenced indirectly in IFC data.
  * Improved schema-version detection across supported IFC formats, including fallback handling for unrecognized schema identifiers.

* **Tests**
  * Added coverage to help ensure material-property extraction and IFC schema detection continue working consistently across supported scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->