### PR TITLE
test(processing,geometry): close 3 mutation-verified coverage gaps

### DIFF
--- a/rust/geometry/src/router/instancing.rs
+++ b/rust/geometry/src/router/instancing.rs
@@ -143,4 +143,39 @@ mod tests {
         router.ensure_shared_mapped_source(&flat_rep, 14, &mut decoder);
         assert_eq!(router.mapped_shared_unique_count(), 1);
     }
+
+    /// The empty-mesh guard: a source that decodes fine but walks to ZERO items
+    /// (`#40` is a well-formed `IfcShapeRepresentation` with an empty items list)
+    /// must not be published into the shared registry — an empty/truncated source
+    /// cached under `source_id` would be served to every later occurrence sharing
+    /// that `IfcRepresentationMap`, per the doc on `ensure_shared_mapped_source`.
+    ///
+    /// The second half proves the guard doesn't poison the id going forward: a
+    /// later call with the SAME `source_id` but a real single-solid source (`#13`)
+    /// must still register, because the aborted empty attempt inserted nothing.
+    #[test]
+    fn empty_mesh_source_not_registered_then_real_source_still_is() {
+        let content = fixture();
+        let entity_index = ifc_lite_core::build_entity_index(&content);
+        let mut decoder = EntityDecoder::with_index(&content, entity_index);
+        let mut router = GeometryRouter::with_units(&content, &mut decoder);
+        router.enable_shared_mapped_item_cache(GeometryRouter::new_mapped_item_cache());
+
+        let empty_rep = decoder.decode_by_id(40).expect("decode #40");
+        router.ensure_shared_mapped_source(&empty_rep, 999, &mut decoder);
+        assert_eq!(
+            router.mapped_shared_unique_count(),
+            0,
+            "a source that meshes to zero positions must not be cached"
+        );
+
+        let flat_rep = decoder.decode_by_id(13).expect("decode #13");
+        router.ensure_shared_mapped_source(&flat_rep, 999, &mut decoder);
+        assert_eq!(
+            router.mapped_shared_unique_count(),
+            1,
+            "a real mesh for the same source id must still register after an \
+             aborted empty attempt didn't poison the entry"
+        );
+    }
 }

--- a/rust/geometry/tests/fixtures/nested_mapped_item.ifc
+++ b/rust/geometry/tests/fixtures/nested_mapped_item.ifc
@@ -49,5 +49,8 @@ DATA;
 #37=IFCRELAGGREGATES('0REL256789ABCDEFGHIJKL',$,$,$,#23,(#25));
 #38=IFCRELAGGREGATES('0REL356789ABCDEFGHIJKL',$,$,$,#25,(#27));
 #39=IFCRELCONTAINEDINSPATIALSTRUCTURE('0REL456789ABCDEFGHIJKL',$,$,$,(#35),#27);
+/* Empty-items source: a well-formed representation with NO geometry items, so
+   walking it in `ensure_shared_mapped_source` completes with `mesh` still empty. */
+#40=IFCSHAPEREPRESENTATION(#5,'Body','SweptSolid',());
 ENDSEC;
 END-ISO-10303-21;

--- a/rust/processing/src/processor/quick_metadata.rs
+++ b/rust/processing/src/processor/quick_metadata.rs
@@ -227,4 +227,22 @@ mod tests {
         let tree = build_quick_spatial_tree_node(1, &nodes, &summaries);
         assert!(tree.is_ok(), "cyclic tree should build (cycle pruned), got {tree:?}");
     }
+
+    /// `IfcBuildingStorey`'s `Elevation` attribute sits at index 9 in the IFC4
+    /// attribute layout this parser targets; index 8 is only a fallback (e.g. an
+    /// off-by-one attribute count from a schema variant). Indices 8 and 9 hold
+    /// DIFFERENT numeric values here specifically so a priority swap (checking 8
+    /// before 9) is observable — equal values would let a `[9, 8]` -> `[8, 9]`
+    /// swap pass silently.
+    #[test]
+    fn storey_elevation_prefers_index_9_over_index_8() {
+        let args: Vec<&[u8]> = vec![
+            b"$", b"$", b"$", b"$", b"$", b"$", b"$", b"$", b"3.5", b"7.25",
+        ];
+        assert_eq!(
+            extract_storey_elevation_from_args(&args),
+            Some(7.25),
+            "index 9 (the real Elevation attribute) must win over index 8"
+        );
+    }
 }

--- a/rust/processing/src/shard_classes.rs
+++ b/rust/processing/src/shard_classes.rs
@@ -151,3 +151,44 @@ pub fn classify_type_name(type_name: &str) -> u8 {
     }
     class
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The type-candidate check ORs two independent suffix tests
+    /// (`ends_with("TYPE")` and `ends_with("STYLE")`) before confirming the
+    /// resolved `IfcType` is a subtype of `IfcTypeProduct`. Pin that the TYPE
+    /// arm alone is load-bearing: `IFCWALLTYPE` (a real `IfcTypeProduct`
+    /// subtype) must set the flag even though it does NOT end in "STYLE", so a
+    /// mutation that drops the `ends_with("TYPE")` disjunct and keeps only the
+    /// STYLE check would misclassify it and lose #957's orphan type-geometry
+    /// pass for every walltype-shaped keyword.
+    #[test]
+    fn type_suffix_sets_type_candidate_flag() {
+        let class = classify_type_name("IFCWALLTYPE");
+        assert_eq!(
+            class & PREPASS_CLASS_FLAG_TYPE_CANDIDATE,
+            PREPASS_CLASS_FLAG_TYPE_CANDIDATE,
+            "IFCWALLTYPE is an IfcTypeProduct subtype ending in TYPE, not STYLE — \
+             it must set the type-candidate flag via the TYPE arm alone"
+        );
+    }
+
+    /// The STYLE arm is deliberately distinct from the TYPE arm: a keyword
+    /// ending in "STYLE" that is NOT an `IfcTypeProduct` subtype (`IFCSURFACESTYLE`
+    /// is an `IfcPresentationStyle`) must NOT set the flag. Combined with
+    /// `type_suffix_sets_type_candidate_flag` above, this pins that the two
+    /// suffix checks gate genuinely different keyword sets rather than one
+    /// subsuming the other.
+    #[test]
+    fn style_suffix_without_type_product_subtype_does_not_set_flag() {
+        let class = classify_type_name("IFCSURFACESTYLE");
+        assert_eq!(
+            class & PREPASS_CLASS_FLAG_TYPE_CANDIDATE,
+            0,
+            "IFCSURFACESTYLE is not an IfcTypeProduct subtype, so the type-candidate \
+             flag must stay clear even though the name ends in STYLE"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Closes three mutation-verified coverage gaps in `rust/processing` and `rust/geometry`. Each mutation below survived the existing suite before this PR; each new test now fails under the stated mutation and passes with it reverted (verified locally, RED then GREEN, before committing).

### 1. `rust/geometry/src/router/instancing.rs` — the empty-mesh guard

`ensure_shared_mapped_source` only publishes a meshed source into the shared registry when `!mesh.positions.is_empty() && !budget::tripped()`. Its own doc comment calls this load-bearing: without it, a source that walks to zero geometry gets cached under its source id and is then served to *every later occurrence* sharing that `IfcRepresentationMap`.

**Mutation**: drop the `!mesh.positions.is_empty()` conjunct — no existing test caught it (the file's prior tests cover the nested-source early-return, not this guard).

**Fix**: extended `tests/fixtures/nested_mapped_item.ifc` with `#40`, a well-formed `IfcShapeRepresentation` with an empty items list. The new test walks `#40` through `ensure_shared_mapped_source`, asserts nothing is registered, then registers a real source (`#13`) under the *same* source id and asserts it now succeeds — proving the aborted empty attempt didn't poison the entry for later, real occurrences.

### 2. `rust/processing/src/shard_classes.rs` — `classify_type_name`'s `TYPE`-suffix arm

The type-candidate check is `type_name.ends_with("TYPE") || type_name.ends_with("STYLE")` before confirming the resolved `IfcType` is an `IfcTypeProduct` subtype.

**Mutation**: drop `ends_with("TYPE")`, keeping only the `STYLE` check — no test referenced `PREPASS_CLASS_FLAG_TYPE_CANDIDATE` at all.

**Fix**: two new unit tests — `IFCWALLTYPE` (ends `TYPE`, a real `IfcTypeProduct` subtype) must set the flag; `IFCSURFACESTYLE` (ends `STYLE`, an `IfcPresentationStyle`, not `IfcTypeProduct`) must not. Together they pin that the two suffix arms gate genuinely different keyword sets.

### 3. `rust/processing/src/processor/quick_metadata.rs` — `extract_storey_elevation_from_args`'s index priority

`IfcBuildingStorey.Elevation` is read by checking attribute indices `[9, 8]` in that order (9 first, matching the IFC4 attribute layout this parser targets; 8 is a fallback).

**Mutation**: swap to `[8, 9]` — no test in `rust/processing/tests` asserts `.elevation` at all, and this function is called in production from `processor/mod.rs:606`.

**Fix**: new unit test with *different* numeric values at indices 8 and 9 (equal values would let the swap pass silently) and asserts index 9's value wins.

## Scope

Tests only — no production code changed, no changeset needed (Rust-only test additions, not a published `packages/*` surface change).

## Verification

- **Baselines confirmed before changes**: `ifc-lite-processing` lib target 57 passed; `ifc-lite-geometry` lib target 576 passed / 1 ignored, plus the 3 disclosed pre-existing `tests/wall_opening_cut_regression.rs` failures (unfetched-fixture skip, `pnpm fixtures`).
- **Per-gap RED/GREEN**: each mutation applied via exact-substring Python replacement, confirmed the new test fails, reverted via the same mechanism, confirmed it passes again. `git status --porcelain -- rust/` checked clean of stray edits after each restore.
- **Final counts**: `ifc-lite-processing` lib target 60 passed (57 + 3 new); `ifc-lite-geometry` lib target 577 passed / 1 ignored (576 + 1 new); the same 3 `wall_opening_cut_regression.rs` failures remain, unchanged in count and identity.
- **Clippy**: `cargo clippy -p ifc-lite-processing -p ifc-lite-geometry --all-targets -- -D warnings` currently fails on `main` for reasons unrelated to this PR — see note below. None of the reported errors/warnings touch any file this PR changes.

### Clippy note (pre-existing, not introduced by this PR)

Running the exact required command against `upstream/main` (no changes from this PR) currently fails: `ifc-lite-core` (a path dependency clippy also lints) fails to compile under `-D warnings` with 4 errors from newly-default-warn lints (e.g. `clippy::question_mark`, `clippy::chunks_exact_to_as_chunks`, `clippy::collapsible_match`) — apparently toolchain/clippy drift on the pinned nightly (`rustc 1.99.0-nightly 2026-08-01`) since the "currently clean" baseline was established, not anything in this diff. Running clippy without `-D warnings` shows the same lint families firing across many pre-existing files in `rust/processing`, `rust/geometry`, and `rust/core` that this PR does not touch. I did not attempt to fix these — `rust/core` is out of scope for this PR (a separate agent is concurrently working there on `test/rust-coverage-gaps`), and fixing pre-existing lint debt across two crates is out of scope for a coverage-gap PR. Flagging for the maintainer's awareness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)