### PR TITLE
test(viewer): close two mutation-verified coverage gaps

### DIFF
--- a/apps/viewer/src/lib/storage/save-result.test.ts
+++ b/apps/viewer/src/lib/storage/save-result.test.ts
@@ -62,3 +62,45 @@ describe('saveJson — a value JSON.stringify cannot round-trip (PR #2091 review
     assert.equal(data.get('k'), '{"a":1}');
   });
 });
+
+describe('saveJson — quota vs. unavailable DOMException discrimination', () => {
+  beforeEach(() => { installStubStorage(); });
+
+  it('reports "quota" for a genuine QuotaExceededError', () => {
+    (globalThis as unknown as { localStorage: Storage }).localStorage = {
+      ...(globalThis as unknown as { localStorage: Storage }).localStorage,
+      setItem: () => { throw new DOMException('quota', 'QuotaExceededError'); },
+    } as Storage;
+    const result = saveJson('k', { a: 1 }, 'lens changes');
+    assert.equal(result.ok, false);
+    assert.equal(!result.ok && result.reason, 'quota');
+    assert.ok(!result.ok && result.message.includes('full'), 'quota message must say storage is full');
+  });
+
+  it('reports "unavailable", not "quota", for a SecurityError DOMException (e.g. Safari private mode)', () => {
+    // Safari's private-mode `setItem` throws a `SecurityError` DOMException,
+    // not a quota error. Misreporting this as "quota" tells the user their
+    // storage is full and sends them deleting data that is not the problem
+    // (`&&` -> `||` on the QUOTA_ERROR_NAMES check would misclassify this).
+    (globalThis as unknown as { localStorage: Storage }).localStorage = {
+      ...(globalThis as unknown as { localStorage: Storage }).localStorage,
+      setItem: () => { throw new DOMException('The operation is insecure.', 'SecurityError'); },
+    } as Storage;
+    const result = saveJson('k', { a: 1 }, 'lens changes');
+    assert.equal(result.ok, false);
+    assert.equal(!result.ok && result.reason, 'unavailable',
+      'a non-quota DOMException must not be classified as quota');
+    assert.ok(!result.ok && result.message.includes('unavailable'),
+      'unavailable message must not claim storage is full');
+  });
+
+  it('reports "unavailable" for a non-DOMException error (e.g. a plain thrown Error)', () => {
+    (globalThis as unknown as { localStorage: Storage }).localStorage = {
+      ...(globalThis as unknown as { localStorage: Storage }).localStorage,
+      setItem: () => { throw new Error('blocked by extension'); },
+    } as Storage;
+    const result = saveJson('k', { a: 1 }, 'lens changes');
+    assert.equal(result.ok, false);
+    assert.equal(!result.ok && result.reason, 'unavailable');
+  });
+});

--- a/apps/viewer/src/lib/storage/save-result.test.ts
+++ b/apps/viewer/src/lib/storage/save-result.test.ts
@@ -94,6 +94,30 @@ describe('saveJson — quota vs. unavailable DOMException discrimination', () =>
       'unavailable message must not claim storage is full');
   });
 
+  it('reports "unavailable" for a quota-NAMED error that is not a DOMException', () => {
+    // Pins the `err instanceof DOMException` half of the guard, which the
+    // other fixtures cannot: they all agree with a name-only check, so
+    // dropping the instanceof survives them (maintainer mutation on #2138).
+    //
+    // `name` is a plain writable string, so anything that re-wraps or
+    // normalises a storage error can carry a quota-ish name without being a
+    // DOMException — and classifying that as quota produces the same wrong
+    // advice this file exists to prevent: "free up space" when space was
+    // never the problem.
+    (globalThis as unknown as { localStorage: Storage }).localStorage = {
+      ...(globalThis as unknown as { localStorage: Storage }).localStorage,
+      setItem: () => {
+        const impostor = new Error('not a DOMException');
+        impostor.name = 'QuotaExceededError';
+        throw impostor;
+      },
+    } as Storage;
+    const result = saveJson('k', { a: 1 }, 'lens changes');
+    assert.equal(result.ok, false);
+    assert.equal(!result.ok && result.reason, 'unavailable',
+      'the name matches, the type does not — type must win');
+  });
+
   it('reports "unavailable" for a non-DOMException error (e.g. a plain thrown Error)', () => {
     (globalThis as unknown as { localStorage: Storage }).localStorage = {
       ...(globalThis as unknown as { localStorage: Storage }).localStorage,

--- a/apps/viewer/src/store/slices/modelSlice.test.ts
+++ b/apps/viewer/src/store/slices/modelSlice.test.ts
@@ -393,4 +393,40 @@ describe('ModelSlice', () => {
       assert.strictEqual(phantom, null);
     });
   });
+
+  describe('resolveGlobalIdFromModels — maxExpressId boundary', () => {
+    it('resolves the highest parsed express id through the fast (first) pass', () => {
+      const model = createMockModel('model-1', 'First');
+      model.idOffset = 0;
+      model.maxExpressId = 10_000;
+      state.addModel(model);
+
+      // No mutation views registered at all — if the boundary id fell
+      // through to the second pass, there would be nothing to catch it
+      // and this would resolve to null instead of the model.
+      const boundary = state.resolveGlobalIdFromModels(model.maxExpressId);
+      assert.deepStrictEqual(boundary, { modelId: 'model-1', expressId: model.maxExpressId });
+    });
+
+    it('resolves the first model boundary id in a federated (offset) setup, not the second model', () => {
+      const first = createMockModel('model-1', 'First');
+      first.idOffset = 0;
+      first.maxExpressId = 10_000;
+      state.addModel(first);
+
+      const second = createMockModel('model-2', 'Second');
+      second.idOffset = 10_000;
+      second.maxExpressId = 5_000;
+      state.addModel(second);
+
+      // globalId 10_000 is the last express id parsed for `model-1`
+      // (localId = 10_000 - 0 = 10_000 === maxExpressId) and simultaneously
+      // localId 0 of `model-2` (10_000 - 10_000 = 0), which is also in
+      // range for the second model. Models are sorted by offset ascending,
+      // so the first model — the one that actually owns this id as its
+      // boundary — must win.
+      const boundary = state.resolveGlobalIdFromModels(10_000);
+      assert.deepStrictEqual(boundary, { modelId: 'model-1', expressId: 10_000 });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Closes two confirmed mutation-testing survivors in `apps/viewer` by adding tests only — no production behaviour changed.

### Gap 1 — `apps/viewer/src/lib/storage/save-result.ts:61`

```ts
const quota = err instanceof DOMException && QUOTA_ERROR_NAMES.has(err.name);
```

**Surviving mutation:** `&&` → `||`. Every `DOMException` — including Safari private mode's `SecurityError` thrown by `setItem` — is then classified `reason: 'quota'` ("Browser storage is full"), when the correct diagnosis is `'unavailable'`. A user hitting this is sent to delete data that was never the problem.

No existing test threw a non-quota `DOMException`; `lensSlice.save-failure.test.ts` only exercises the true `QuotaExceededError` path.

**Fix:** added tests in `save-result.test.ts` asserting:
- a genuine `QuotaExceededError` still reports `'quota'` (no regression)
- a `SecurityError` `DOMException` reports `'unavailable'`, not `'quota'`
- a plain non-`DOMException` `Error` also reports `'unavailable'`

### Gap 2 — `apps/viewer/src/store/slices/modelSlice.ts:327`

```ts
if (localId >= 0 && localId <= model.maxExpressId) { return { modelId: model.id, expressId: localId }; }
```

**Surviving mutation:** `<=` → `<`. The boundary id (`localId === model.maxExpressId`, the highest express id parsed for that model) drops out of the fast path. The second-pass overlay loop explicitly `continue`s on `localId <= model.maxExpressId`, so the boundary id resolves to `null` — selection, basket, and property lookups silently fail for the last parsed entity of every model.

`modelSlice.test.ts`'s existing `resolveGlobalIdFromModels — overlay-allocated ids` test only used `42` (well inside range) and `11_001`/`99_999` (overlay/phantom); nothing pinned the boundary.

**Fix:** added a `resolveGlobalIdFromModels — maxExpressId boundary` describe block with two tests:
- a single model resolves `expressId === maxExpressId` through the fast path (no mutation views registered, so a mutant that drops to the second pass has nothing to catch it and returns `null`)
- a federated two-model setup where the first model's boundary id is numerically also in-range for the second model (offset-adjacent), so a naive resolver would misattribute it

Per the brief, the second-pass `localId <= model.maxExpressId` guard at line 335 is **not** touched — that branch only runs for ids the first pass already rejected, so `<` vs `<=` there is unreachable (an equivalent mutant), not a defect.

## Verification (RED-GREEN per gap)

Both mutations applied via python3 exact-substring replacement (count asserted `== 1`), confirmed the new tests **fail**, then restored by file copy (not `git checkout --`) and confirmed **pass**.

- Gap 1: `&&` → `||` in `save-result.ts` → new "SecurityError" test failed (`expected: 'unavailable', actual: 'quota'`). Restored → all pass.
- Gap 2: `<=` → `<` in `modelSlice.ts` → both new boundary tests failed (single-model boundary resolved to `null`; federated boundary resolved to `{ modelId: 'model-2', expressId: 0 }` instead of `{ modelId: 'model-1', expressId: 10000 }`). Restored → all pass.

## Test plan

- [x] `pnpm build:wasm` then `pnpm build` (full monorepo, including `@ifc-lite/viewer`)
- [x] `cd apps/viewer && npm test` — baseline 2723 tests / 2721 pass / 2 skipped → final **2728 tests / 2726 pass / 2 skipped** (+5 new tests, all passing)
- [x] `pnpm typecheck` — green
- [x] Only test files changed (`save-result.test.ts`, `modelSlice.test.ts`); no production code touched
- [x] No changeset — `@ifc-lite/viewer` is a private package (verified against `apps/viewer/package.json`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage to ensure storage errors are accurately classified, distinguishing quota limits from unavailable storage.
  * Added regression coverage for resolving model identifiers at boundary values, including federated model overlaps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->