### PR TITLE
test(extensions,create): close 5 mutation-verified coverage gaps (1 security-relevant)

### DIFF
--- a/packages/create/src/in-store/resolve-anchor-zero-scale.test.ts
+++ b/packages/create/src/in-store/resolve-anchor-zero-scale.test.ts
@@ -1,0 +1,64 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `resolveSpatialAnchor` guards `extractLengthUnitScale`'s result with
+ * `s > 0` before trusting it — a zero (or negative/non-finite) scale must
+ * fall back to the metre default, not be accepted verbatim, since a zero
+ * scale would collapse every subsequently emitted length to 0. The real
+ * `extractLengthUnitScale` implementation never returns exactly 0 (its own
+ * guards route degenerate cases back to the 1.0 fallback), so this pins the
+ * `resolveSpatialAnchor` guard directly by mocking that one export, mirroring
+ * the pattern in `extract-walls-unit-scale.test.ts`.
+ */
+
+import { describe, expect, it, vi, afterEach } from 'vitest';
+
+vi.mock('@ifc-lite/parser', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@ifc-lite/parser')>();
+  return {
+    ...actual,
+    extractLengthUnitScale: () => 0,
+  };
+});
+
+const { IfcParser } = await import('@ifc-lite/parser');
+const { resolveSpatialAnchor } = await import('./resolve-anchor.js');
+
+/** Minimal IFC4 model with one storey — enough for `resolveSpatialAnchor`. */
+const STOREY_MODEL = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('t.ifc','',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0proj00000000000000000',$,'P',$,$,$,$,(#7),#9);
+#5=IFCCARTESIANPOINT((0.,0.,0.));
+#6=IFCAXIS2PLACEMENT3D(#5,$,$);
+#7=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-05,#6,$);
+#8=IFCGEOMETRICREPRESENTATIONSUBCONTEXT('Body','Model',*,*,*,*,#7,$,.MODEL_VIEW.,$);
+#9=IFCUNITASSIGNMENT((#91));
+#91=IFCSIUNIT(*,.LENGTHUNIT.,.MILLI.,.METRE.);
+#20=IFCLOCALPLACEMENT($,#6);
+#30=IFCBUILDINGSTOREY('0storey000000000000000',$,'Level 0',$,$,#20,$,$,.ELEMENT.,0.);
+ENDSEC;
+END-ISO-10303-21;`;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('resolveSpatialAnchor: zero length-unit scale', () => {
+  it('falls back to the metre default instead of accepting a zero scale', async () => {
+    const store = await new IfcParser().parseColumnar(
+      new TextEncoder().encode(STOREY_MODEL).buffer as ArrayBuffer,
+      { disableWorkerScan: true },
+    );
+
+    const anchor = resolveSpatialAnchor(store, 30);
+
+    expect(anchor.lengthUnitScale).toBe(1.0);
+  });
+});

--- a/packages/create/src/in-store/wall.test.ts
+++ b/packages/create/src/in-store/wall.test.ts
@@ -73,6 +73,39 @@ describe('addWallToStore', () => {
     )).toThrow(/distinct/);
   });
 
+  it('rejects zero Thickness', () => {
+    const store = makeStore(50);
+    const view = new MutablePropertyView(null, 'm1');
+    const editor = new StoreEditor(store, view);
+    expect(() => addWallToStore(
+      editor,
+      { ownerHistoryId: 5, bodyContextId: 14, storeyId: 43, storeyPlacementId: 54 },
+      { Start: [0, 0, 0], End: [5, 0, 0], Thickness: 0, Height: 3 },
+    )).toThrow(/positive/);
+  });
+
+  it('rejects zero Height', () => {
+    const store = makeStore(50);
+    const view = new MutablePropertyView(null, 'm1');
+    const editor = new StoreEditor(store, view);
+    expect(() => addWallToStore(
+      editor,
+      { ownerHistoryId: 5, bodyContextId: 14, storeyId: 43, storeyPlacementId: 54 },
+      { Start: [0, 0, 0], End: [5, 0, 0], Thickness: 0.2, Height: 0 },
+    )).toThrow(/positive/);
+  });
+
+  it('rejects a sloped (non-coplanar) Start/End', () => {
+    const store = makeStore(50);
+    const view = new MutablePropertyView(null, 'm1');
+    const editor = new StoreEditor(store, view);
+    expect(() => addWallToStore(
+      editor,
+      { ownerHistoryId: 5, bodyContextId: 14, storeyId: 43, storeyPlacementId: 54 },
+      { Start: [0, 0, 0], End: [5, 0, 2], Thickness: 0.2, Height: 3 },
+    )).toThrow(/same storey plane/);
+  });
+
   it('drops PredefinedType for IFC2X3', () => {
     const store = makeStore(50);
     const view = new MutablePropertyView(null, 'm1');

--- a/packages/extensions/src/capability/match.test.ts
+++ b/packages/extensions/src/capability/match.test.ts
@@ -76,6 +76,19 @@ describe('matchCapability — wildcards', () => {
     ).toBe(false);
   });
 
+  it('prefix glob does not match a value that merely contains the prefix', () => {
+    // Regression: the prefix check must be startsWith, not includes. A
+    // grant of Pset_* must not match a value where "Pset_" appears
+    // mid-string (e.g. behind an attacker-controlled prefix) — that would
+    // turn a prefix glob into an over-permissive substring match.
+    expect(
+      matchCapability(
+        parse('model.mutate:Pset_*'),
+        parse('model.mutate:Custom_Pset_Secret'),
+      ),
+    ).toBe(false);
+  });
+
   it('bare-* segment matches a single segment', () => {
     expect(
       matchCapability(parse('command.invoke:*.export'), parse('command.invoke:ext-foo.export')),

--- a/packages/extensions/src/manifest/manifest.test.ts
+++ b/packages/extensions/src/manifest/manifest.test.ts
@@ -107,6 +107,45 @@ describe('validateManifest — direct inputs', () => {
     }
   });
 
+  it('rejects a bare-prefix activation event with an empty target', () => {
+    // Regression: isActivationEvent must require v.length > prefix.length,
+    // not >=. A bare "onCommand:" (empty target after the colon) must not
+    // be accepted as valid.
+    const r = validateManifest({
+      manifestVersion: 1,
+      id: 'com.example.bare-activation',
+      name: 'Bare Activation',
+      description: '...',
+      version: '1.0.0',
+      engines: { ifcLiteSdk: '>=2.0.0' },
+      capabilities: ['model.read'],
+      activation: ['onCommand:'],
+      entry: {},
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.errors.some((e) => e.code === 'invalid_activation')).toBe(true);
+    }
+  });
+
+  it('accepts a real onCommand activation event with a non-empty target', () => {
+    const r = validateManifest({
+      manifestVersion: 1,
+      id: 'com.example.real-activation',
+      name: 'Real Activation',
+      description: '...',
+      version: '1.0.0',
+      engines: { ifcLiteSdk: '>=2.0.0' },
+      capabilities: ['model.read'],
+      activation: ['onCommand:something'],
+      entry: {},
+    });
+    if (!r.ok) {
+      console.error('Unexpected errors:', r.errors);
+    }
+    expect(r.ok).toBe(true);
+  });
+
   it('error paths point at offending field', () => {
     const r = validateManifest({
       manifestVersion: 1,


### PR DESCRIPTION
## Security-relevant — read first

**GAP 1 — `packages/extensions/src/capability/match.ts:110`.** `matchSegment`'s glob-prefix check is `requestedValue.startsWith(prefix)`. Mutating it to `.includes(prefix)` survived the full 600-test suite: the existing fixtures test `Pset_*` against `Pset_WallCommon` (matches either way) and against `Qto_WallBase` (matches neither way, no `Pset_` substring at all) — neither discriminates `startsWith` from `includes`. That gap matters because a substring match turns a prefix glob into an over-permissive capability grant: `model.mutate:Pset_*` would also match `model.mutate:Custom_Pset_Secret`. Added a fixture that contains the prefix without starting with it (`Pset_*` vs `Custom_Pset_Secret`), asserting `false`.

## Other gaps

**GAP 2 — `packages/extensions/src/manifest/validate.ts:210`.** `isActivationEvent`'s `v.length > p.length` mutated to `>=` survived, which (combined with the `startsWith` check) accepts a bare-prefix activation with an empty target, e.g. `activation: ["onCommand:"]`. Added a case asserting a bare `"onCommand:"` is rejected and a real `"onCommand:something"` is accepted.

**GAP 3 — `packages/create/src/in-store/wall.ts:59`.** `Thickness <= 0 || Height <= 0` mutated to `< 0` survived because every existing fixture used `Thickness: 0.2` (or similar) — none hit exactly zero. Added cases asserting exact-zero Thickness and exact-zero Height are both rejected.

**GAP 4 — `packages/create/src/in-store/wall.ts:84`.** The coplanarity guard `Math.abs(dz) > Math.max(1e-6 * wallLen, 1e-9)` mutated to `if (false)` survived because no fixture used a sloped (non-coplanar) Start/End. Added a case with `End: [5, 0, 2]` asserting rejection.

**GAP 5 — `packages/create/src/in-store/resolve-anchor.ts:48`.** `s > 0` mutated to `s >= 0` survived because only the no-source fallback path was exercised. The real `extractLengthUnitScale` never returns exactly 0 (its own internal guards route degenerate cases back to the 1.0 default), so the test mocks that one export — mirroring the existing pattern in `extract-walls-unit-scale.test.ts` — to return 0 and asserts `resolveSpatialAnchor` falls back to the metre default rather than accepting it.

## Method

Each gap was verified RED-first: applied the exact mutation described above via an exact-substring Python replacement (count asserted `== 1`), ran the new test and confirmed it failed for the stated reason, then restored the original file by copy (never `git checkout --`) and confirmed the full suite passes again.

## Counts

- `packages/extensions`: 600 tests / 53 files → 603 tests / 53 files (2 new assertions added to existing files)
- `packages/create`: 119 tests / 15 files → 123 tests / 16 files (1 new file, 3 new cases in `wall.test.ts`)

Test-only changes; no production code touched, no changeset needed.

## Test plan

- [x] `pnpm test` in `packages/extensions`: 53 files / 603 tests passing
- [x] `pnpm test` in `packages/create`: 16 files / 123 tests passing
- [x] `pnpm typecheck` (turbo, both packages) clean
- [x] Each gap RED-verified (mutation applied → new test fails) then GREEN-verified (file restored by copy → full suite passes)