### PR TITLE
test(merge): cover two mutation-verified gaps in the ref-merge flow

### DIFF
--- a/packages/merge/src/ref-flow-policy-ancestor.test.ts
+++ b/packages/merge/src/ref-flow-policy-ancestor.test.ts
@@ -1,0 +1,248 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Two branches of the shared ref-merge flow that no test in `merge`, `cli`
+ * or `collab-server` reached:
+ *
+ * 1. `checkRefPolicy` failing CLOSED on a candidate with NO provenance
+ *    manifest. On the registry paths this is masked by defense in depth
+ *    (the manual endpoint rejects manifest-less candidates on
+ *    `requireHumanApproval` refs before calling `mergeIntoRef`, and
+ *    `runAutoMerges` skips those refs), so it is reachable unmasked only
+ *    through `ifc layer merge`.
+ *
+ * 2. `resolveAncestor`'s `base.kind === 'layer'` branch, which must include
+ *    the named base layer ITSELF in the ancestor stack. `packages/mcp`
+ *    emits a layer base when a draft is seeded from a specific published
+ *    layer, so such candidates do reach the merge flow.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { computeLayerId, computeStackHash, createProvenanceManifest, setProvenance } from '@ifc-lite/ifcx';
+import type { IfcxFile, IfcxNode, ProvenanceBase } from '@ifc-lite/ifcx';
+import { extractStackState } from './component-state.js';
+import { mergeIntoRef, resolveAncestor } from './ref-flow.js';
+import type { LayerRefStore, RefEntry } from './ref-flow.js';
+
+const FIRE = 'bsi::ifc::v5a::Pset_FireSafety::FireRating';
+const SOUND = 'bsi::ifc::v5a::Pset_Acoustic::Rw';
+
+class MemoryStore implements LayerRefStore {
+  private layers = new Map<string, IfcxFile>();
+  private refs = new Map<string, RefEntry>();
+  storeLayer(file: IfcxFile): string {
+    this.layers.set(file.header.id, structuredClone(file));
+    return file.header.id;
+  }
+  loadLayer(id: string): IfcxFile {
+    const f = this.layers.get(id);
+    if (!f) throw new Error(`no layer ${id}`);
+    return structuredClone(f);
+  }
+  getRef(name: string): RefEntry | undefined {
+    const e = this.refs.get(name);
+    return e ? structuredClone(e) : undefined;
+  }
+  setRef(name: string, entry: RefEntry): void {
+    this.refs.set(name, structuredClone(entry));
+  }
+}
+
+function bare(data: IfcxNode[]): IfcxFile {
+  return {
+    header: {
+      id: '',
+      ifcxVersion: 'ifcx_alpha',
+      dataVersion: '1.0.0',
+      author: 't',
+      timestamp: '2026-08-04T00:00:00Z',
+    },
+    imports: [],
+    schemas: {},
+    data,
+  };
+}
+
+function withId(file: IfcxFile): IfcxFile {
+  return { ...file, header: { ...file.header, id: computeLayerId(file) } };
+}
+
+/** A publishable layer carrying a provenance manifest with an explicit base. */
+function publishable(data: IfcxNode[], intent: string, base: ProvenanceBase | null): IfcxFile {
+  const manifest = createProvenanceManifest({
+    author: { kind: 'human', principal: 'alice' },
+    intent,
+    base,
+    created: '2026-08-04T00:00:00Z',
+  });
+  return withId(setProvenance(bare(data), manifest));
+}
+
+/** A layer with NO provenance manifest at all (`getProvenance` → undefined). */
+function manifestLess(data: IfcxNode[]): IfcxFile {
+  return withId(bare(data));
+}
+
+describe('checkRefPolicy fails closed on a manifest-less candidate', () => {
+  /**
+   * A candidate with no manifest could be an agent layer with the manifest
+   * stripped, so `requireHumanApproval` must still bite. Treating "no
+   * manifest" as "not agent-authored" would let any unapproved layer walk
+   * straight onto a protected ref.
+   */
+  function protectedRef() {
+    const store = new MemoryStore();
+    const base = publishable(
+      [{ path: 'wall-1', attributes: { 'bsi::ifc::class': { code: 'IfcWall', uri: 'u' }, [FIRE]: 'REI30' } }],
+      'Base',
+      null,
+    );
+    store.storeLayer(base);
+    store.setRef('protected', {
+      layers: [base.header.id],
+      policy: { requireHumanApproval: true },
+    });
+    // Touches a path the ref does not, so the three-way plan is
+    // conflict-free and the flow reaches the policy gate.
+    const candidate = manifestLess([
+      { path: 'wall-2', attributes: { 'bsi::ifc::class': { code: 'IfcWall', uri: 'u' }, [FIRE]: 'REI90' } },
+    ]);
+    store.storeLayer(candidate);
+    return { store, base, candidate };
+  }
+
+  it('refuses a manifest-less candidate on a requireHumanApproval ref', () => {
+    const { store, base, candidate } = protectedRef();
+    const outcome = mergeIntoRef(store, { candidateId: candidate.header.id, into: 'protected' });
+    expect(outcome.status).toBe('policy-failure');
+    if (outcome.status !== 'policy-failure') return;
+    expect(outcome.reason).toMatch(/human approval/i);
+    // The ref must be untouched by the refused merge.
+    expect(store.getRef('protected')?.layers).toEqual([base.header.id]);
+  });
+
+  it('admits the same manifest-less candidate once a human approves it', () => {
+    const { store, candidate } = protectedRef();
+    const outcome = mergeIntoRef(store, {
+      candidateId: candidate.header.id,
+      into: 'protected',
+      approvedBy: 'bob',
+      principal: 'bob',
+      created: '2026-08-04T01:00:00Z',
+    });
+    expect(outcome.status).toBe('merged');
+  });
+
+  it('still admits a manifest-less candidate on a ref with no approval requirement', () => {
+    const { store, base, candidate } = protectedRef();
+    store.setRef('open', { layers: [base.header.id] });
+    const outcome = mergeIntoRef(store, {
+      candidateId: candidate.header.id,
+      into: 'open',
+      principal: 'bob',
+      created: '2026-08-04T01:00:00Z',
+    });
+    expect(outcome.status).toBe('merged');
+  });
+});
+
+describe('resolveAncestor: layer base includes the named layer itself', () => {
+  /**
+   * Ref stack is [L0, L1, L2]; the candidate declares `{ kind: 'layer', id: L1 }`.
+   *
+   * The correct ancestor is [L0, L1]. An ancestor one layer short ([L0])
+   * still reports `matched: true`, so the unrelated-base refusal cannot
+   * catch it — only the merge OUTCOME can. The fixture is built so the two
+   * ancestors disagree: the candidate restates L1's FireRating verbatim.
+   *
+   *   - correct ancestor [L0, L1]: FIRE is REI60 in both ancestor and
+   *     theirs → theirs did not change it → ours (REI90) wins cleanly.
+   *   - short ancestor [L0]: FIRE is REI30 in the ancestor while theirs
+   *     ([L0, candidate]) says REI60 and ours says REI90 → both sides
+   *     changed it divergently → CONFLICT.
+   */
+  function layerBasedSetup() {
+    const store = new MemoryStore();
+    const l0 = publishable(
+      [
+        {
+          path: 'wall-1',
+          attributes: { 'bsi::ifc::class': { code: 'IfcWall', uri: 'u' }, [FIRE]: 'REI30', [SOUND]: 40 },
+        },
+      ],
+      'L0',
+      null,
+    );
+    store.storeLayer(l0);
+    const l1 = publishable([{ path: 'wall-1', attributes: { [FIRE]: 'REI60' } }], 'L1', {
+      kind: 'stack',
+      id: computeStackHash([l0.header.id]),
+    });
+    store.storeLayer(l1);
+    const l2 = publishable([{ path: 'wall-1', attributes: { [FIRE]: 'REI90' } }], 'L2', {
+      kind: 'stack',
+      id: computeStackHash([l0.header.id, l1.header.id]),
+    });
+    store.storeLayer(l2);
+    store.setRef('main', { layers: [l0.header.id, l1.header.id, l2.header.id] });
+
+    // Draft seeded from L1 (the shape `packages/mcp` emits): it rewrites
+    // the fire pset unchanged and bumps the acoustic rating.
+    const candidate = publishable(
+      [{ path: 'wall-1', attributes: { [FIRE]: 'REI60', [SOUND]: 50 } }],
+      'Draft off L1',
+      { kind: 'layer', id: l1.header.id },
+    );
+    store.storeLayer(candidate);
+    return { store, l0, l1, l2, candidate };
+  }
+
+  it('resolves a layer base to the prefix ENDING AT that layer', () => {
+    const { store, l0, l1, l2 } = layerBasedSetup();
+    const resolved = resolveAncestor(store, [l0.header.id, l1.header.id, l2.header.id], {
+      kind: 'layer',
+      id: l1.header.id,
+    });
+    expect(resolved.matched).toBe(true);
+    expect(resolved.ids).toEqual([l0.header.id, l1.header.id]);
+    expect(resolved.layers).toHaveLength(2);
+  });
+
+  it('merges without conflict — a one-layer-short ancestor would conflict', () => {
+    const { store, candidate } = layerBasedSetup();
+    const outcome = mergeIntoRef(store, {
+      candidateId: candidate.header.id,
+      into: 'main',
+      principal: 'bob',
+      created: '2026-08-04T01:00:00Z',
+    });
+    // Under a short ancestor ([L0] instead of [L0, L1]) the candidate's
+    // verbatim REI60 reads as a change away from REI30 and collides with
+    // ours (REI90): the status would be 'conflicts', not 'merged'.
+    expect(outcome.status).toBe('merged');
+    if (outcome.status !== 'merged') return;
+    expect(outcome.ancestorMatched).toBe(true);
+    expect(outcome.plan.conflicts).toEqual([]);
+
+    const state = extractStackState(outcome.refLayers.map((id) => store.loadLayer(id)));
+    const wall = state.get('wall-1');
+    // Ours kept its later fire rating; the candidate's acoustic edit landed.
+    expect(wall?.components.get('pset:Pset_FireSafety')?.[FIRE]).toBe('REI90');
+    expect(wall?.components.get('pset:Pset_Acoustic')?.[SOUND]).toBe(50);
+  });
+
+  it('previews the same layer-based candidate as a conflict-free plan', () => {
+    const { store, candidate } = layerBasedSetup();
+    const outcome = mergeIntoRef(store, {
+      candidateId: candidate.header.id,
+      into: 'main',
+      preview: true,
+    });
+    expect(outcome.status).toBe('preview');
+    if (outcome.status !== 'preview') return;
+    expect(outcome.ancestorMatched).toBe(true);
+    expect(outcome.plan.conflicts).toEqual([]);
+  });
+});


### PR DESCRIPTION
Test-only. Two branches of `packages/merge/src/ref-flow.ts` were reached by **no** test in `merge`, `cli` or `collab-server`. A mutation probe confirmed both: the mutation below survived the full suite in each case. The production logic is correct — only the coverage was missing, so nothing outside the new test file changes.

Method for both: apply the exact mutation with an exact-substring replacement that asserts a replacement count of 1, re-read the mutated region to confirm the text changed, run the new test (RED), restore `ref-flow.ts` by copying back a saved backup (never `git checkout --`), run again (GREEN).

## Gap 1 — `checkRefPolicy` fails closed on a manifest-less candidate

```
-    (manifest === undefined || manifest.author.kind === 'agent') &&
+    (manifest !== undefined && manifest.author.kind === 'agent') &&
```

Replacement count 1. Under the mutation a candidate with **no provenance manifest** stops being treated as agent-authored and walks straight past the `requireHumanApproval` gate — which is exactly what the comment above the clause forbids ("a candidate with no provenance manifest could be an agent layer with the manifest stripped").

On the registry paths this is masked by defense in depth — the manual endpoint rejects manifest-less candidates on `requireHumanApproval` refs before calling `mergeIntoRef`, and `runAutoMerges` skips those refs entirely — so it is reachable unmasked only through `ifc layer merge` on the CLI.

New test `refuses a manifest-less candidate on a requireHumanApproval ref` merges a layer with no manifest into a protected ref and asserts `policy-failure` plus an unchanged ref. **RED under the mutation** (`expected 'merged' to be 'policy-failure'`), green with the code restored. Two counter-cases pin the boundary: the same candidate merges once `approvedBy` is supplied, and merges on a ref with no approval requirement.

## Gap 2 — `resolveAncestor`, the `base.kind === 'layer'` branch

```
-      const ids = refLayerIds.slice(0, idx + 1);
+      const ids = refLayerIds.slice(0, idx);
```

Replacement count 1. The mutation drops the base layer **itself** from the ancestor while still reporting `matched: true`, so the unrelated-base refusal cannot catch it and the three-way merge plans against a one-layer-short ancestor. The branch is reachable: `packages/mcp/src/tools/layer-store.ts:211` emits `{ kind: 'layer', id: ref }` when a draft is seeded from a specific published layer, and such a candidate can be pushed and merged.

The hard part here was building a fixture that **discriminates** the correct ancestor from the short one, not merely one that exercises the branch. It does. Ref stack is `[L0, L1, L2]`; the candidate declares `{ kind: 'layer', id: L1 }` and restates L1's `FireRating` verbatim while bumping an unrelated acoustic rating:

| | ancestor `FireRating` | theirs | ours | outcome |
|---|---|---|---|---|
| correct ancestor `[L0, L1]` | `REI60` | `REI60` (unchanged) | `REI90` | clean `merged`, ours wins |
| short ancestor `[L0]` | `REI30` | `REI60` (looks like an edit) | `REI90` | **conflict** |

So the merge *outcome* separates the two, not just the internal ids. Three tests fail under the mutation: the direct `resolveAncestor` assertion, the merge (`'conflicts'` instead of `'merged'`), and the preview (a non-empty `plan.conflicts`). All three pass restored.

## Counts

- Baseline: `Test Files 6 passed | 1 skipped (7)`, `Tests 65 passed | 4 skipped (69)`
- Final: `Test Files 7 passed | 1 skipped (8)`, `Tests 71 passed | 4 skipped (75)`

The skipped file is `src/real-model-fuzz.test.ts`, gated on absent LFS fixtures — unchanged and expected. `pnpm typecheck` passes at the repo root (34/34 tasks).

## Unrelated observation, offered as a question rather than a change

While reading the flow: `FsLayerRegistry` has no cross-process lock, so the `getRef` → `setRef` read-modify-write inside `mergeIntoRef` is atomic *per write* (temp file + fsync + rename) but is not serialized across two collab-server processes sharing one registry directory. Single-process safety appears to rest on `mergeIntoRef` being fully synchronous.

Is a single writer per registry directory an intended deployment constraint, or is multi-process sharing something you want supported? Nothing is changed here either way — flagging it only so the assumption is written down somewhere.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for ref-flow behavior involving manifest-less candidates and human-approval policies.
  * Added validation for layer-based ancestry resolution, approval handling, open-ref merging, conflict-free results, and preview behavior.
  * Expanded test fixtures for identified, publishable, and manifest-less layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->