### PR TITLE
fix(build): allow `using` declarations in apps/viewer (#2130)

### DIFF
--- a/apps/viewer/src/lib/using-declaration-build.test.ts
+++ b/apps/viewer/src/lib/using-declaration-build.test.ts
@@ -1,0 +1,116 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Regression guard for #2130.
+ *
+ * `vite-plugin-top-level-await` re-parses every emitted ES chunk with SWC. Its
+ * parser config asks for plain `ecmascript` without `explicitResourceManagement`,
+ * and `@swc/core`'s `Visitor` base class has no `UsingDeclaration` arm — so a
+ * single `using x = ...` anywhere in `apps/viewer` failed the production build
+ * long after a clean `tsc --noEmit`, with a diagnostic that crashed the error
+ * formatter and showed no line number.
+ *
+ * Both holes are closed by patches (`patches/vite-plugin-top-level-await@1.6.0.patch`,
+ * `patches/@swc__core@1.15.8.patch`). This test drives a real `vite.build()` over
+ * a four-line fixture that uses `using`, so the guard is the actual build path
+ * rather than an assertion about patch file contents.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { build } from 'vite';
+import topLevelAwait from 'vite-plugin-top-level-await';
+
+/** The fixture the viewer cannot express today: a `using` declaration plus a TLA. */
+const FIXTURE = `
+export const order: string[] = [];
+
+class Handle {
+  constructor(private readonly name: string) {
+    order.push('open:' + this.name);
+  }
+  [Symbol.dispose]() {
+    order.push('close:' + this.name);
+  }
+}
+
+export function withHandles(): number {
+  using a = new Handle('a');
+  using b = new Handle('b');
+  order.push('body');
+  return 42;
+}
+
+// Present so the plugin actually engages: without a top-level await it may skip
+// the chunk entirely and the parse that #2130 trips over never happens.
+export const tla = await Promise.resolve('tla');
+`;
+
+interface BuiltChunk {
+  code: string;
+  order: string[];
+  result: number;
+}
+
+/** Builds the fixture at `target`, returning the single emitted chunk. */
+async function buildFixture(target: string, run: boolean): Promise<BuiltChunk> {
+  const root = mkdtempSync(join(tmpdir(), 'ifclite-2130-'));
+  try {
+    writeFileSync(join(root, 'entry.ts'), FIXTURE);
+    const outDir = join(root, 'dist');
+    mkdirSync(outDir, { recursive: true });
+    await build({
+      root,
+      logLevel: 'silent',
+      configFile: false,
+      build: {
+        target,
+        outDir,
+        emptyOutDir: true,
+        lib: { entry: join(root, 'entry.ts'), formats: ['es'], fileName: 'chunk' },
+      },
+      plugins: [topLevelAwait()],
+    });
+    const emitted = readdirSync(outDir).filter((f) => f.endsWith('.mjs') || f.endsWith('.js'));
+    assert.equal(emitted.length, 1, `expected exactly one chunk, got ${emitted.join(', ')}`);
+    const file = join(outDir, emitted[0]!);
+    const code = readFileSync(file, 'utf8');
+    if (!run) return { code, order: [], result: 0 };
+    const mod = (await import(file)) as {
+      withHandles: () => number;
+      order: string[];
+      tla: string;
+    };
+    const result = mod.withHandles();
+    return { code, order: mod.order, result };
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+describe('using declarations survive the vite-plugin-top-level-await pipeline (#2130)', () => {
+  it('builds a chunk containing a `using` declaration at target esnext', async () => {
+    // Before the patches this rejected with an SWC parse error
+    // ("Using declaration is not enabled"), surfacing in the real viewer build
+    // as a miette panic with no line number.
+    const { code } = await buildFixture('esnext', false);
+    // esnext keeps `using` un-lowered, so the plugin's SWC round trip has to
+    // both parse and re-print it. Assert it survived rather than being dropped:
+    // a chunk that silently lost the declaration would never dispose the handle.
+    assert.match(code, /\busing\b/, 'the `using` declaration was lost in the SWC round trip');
+  });
+
+  it('preserves disposal semantics when the target lowers `using`', async () => {
+    // es2022 makes esbuild lower `using` to a try/finally stack, so the emitted
+    // chunk is executable here and the ordering contract can be asserted for real.
+    const { order, result } = await buildFixture('es2022', true);
+    assert.equal(result, 42);
+    assert.deepEqual(order, ['open:a', 'open:b', 'body', 'close:b', 'close:a']);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -110,6 +110,10 @@
       "read-yaml-file": "^2.1.0",
       "brace-expansion": "^5.0.8",
       "minimatch": "^10.2.5"
+    },
+    "patchedDependencies": {
+      "vite-plugin-top-level-await@1.6.0": "patches/vite-plugin-top-level-await@1.6.0.patch",
+      "@swc/core@1.15.8": "patches/@swc__core@1.15.8.patch"
     }
   }
 }

--- a/patches/@swc__core@1.15.8.patch
+++ b/patches/@swc__core@1.15.8.patch
@@ -1,0 +1,24 @@
+diff --git a/Visitor.js b/Visitor.js
+index 3844d231086cfeae20905e0406a330bd217d3ee9..48231fd1f466f951d3dc48e27452a1f9dc921c5f 100644
+--- a/Visitor.js
++++ b/Visitor.js
+@@ -269,6 +269,8 @@ class Visitor {
+                 return this.visitWithStatement(stmt);
+             case "ExpressionStatement":
+                 return this.visitExpressionStatement(stmt);
++            case "UsingDeclaration":
++                return this.visitUsingDeclaration(stmt);
+             default:
+                 throw new Error(`Unknown statement type: ` + stmt.type);
+         }
+@@ -414,6 +416,10 @@ class Visitor {
+         n.declarations = this.visitVariableDeclarators(n.declarations);
+         return n;
+     }
++    visitUsingDeclaration(n) {
++        n.decls = this.visitVariableDeclarators(n.decls);
++        return n;
++    }
+     visitVariableDeclarators(nodes) {
+         return nodes.map(this.visitVariableDeclarator.bind(this));
+     }

--- a/patches/vite-plugin-top-level-await@1.6.0.patch
+++ b/patches/vite-plugin-top-level-await@1.6.0.patch
@@ -1,0 +1,14 @@
+diff --git a/dist/bundle-info.js b/dist/bundle-info.js
+index fec6ef5417214d2b612f685790279253daf7bdf0..5939733f87c1f7e6bfe7c35398beef2a318d05c3 100644
+--- a/dist/bundle-info.js
++++ b/dist/bundle-info.js
+@@ -43,7 +43,8 @@ async function parseBundleAsts(bundleChunks) {
+         filename,
+         await SWC.parse(code, {
+             syntax: "ecmascript",
+-            target: "es2022"
++            target: "es2022",
++            explicitResourceManagement: true
+         })
+     ])));
+ }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,14 @@ overrides:
   brace-expansion: ^5.0.8
   minimatch: ^10.2.5
 
+patchedDependencies:
+  '@swc/core@1.15.8':
+    hash: f503a4ec701f193ef8db43cf396349b5ef3d39508fa6469bf0f36ab31f549c24
+    path: patches/@swc__core@1.15.8.patch
+  vite-plugin-top-level-await@1.6.0:
+    hash: 250521d8ad2a8063f42539e889cf813250ca05aae49cf24dd6ab40c320784958
+    path: patches/vite-plugin-top-level-await@1.6.0.patch
+
 importers:
 
   .:
@@ -356,7 +364,7 @@ importers:
         version: 4.1.1(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       vite-plugin-top-level-await:
         specifier: ^1.6.0
-        version: 1.6.0(@swc/helpers@0.5.21)(rollup@4.62.2)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 1.6.0(patch_hash=250521d8ad2a8063f42539e889cf813250ca05aae49cf24dd6ab40c320784958)(@swc/helpers@0.5.21)(rollup@4.62.2)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       vite-plugin-wasm:
         specifier: ^3.6.0
         version: 3.6.0(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
@@ -480,7 +488,7 @@ importers:
         version: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
       vite-plugin-top-level-await:
         specifier: ^1.6.0
-        version: 1.6.0(@swc/helpers@0.5.21)(rollup@4.62.2)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 1.6.0(patch_hash=250521d8ad2a8063f42539e889cf813250ca05aae49cf24dd6ab40c320784958)(@swc/helpers@0.5.21)(rollup@4.62.2)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       vite-plugin-wasm:
         specifier: ^3.6.0
         version: 3.6.0(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
@@ -524,7 +532,7 @@ importers:
         version: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
       vite-plugin-top-level-await:
         specifier: ^1.6.0
-        version: 1.6.0(@swc/helpers@0.5.21)(rollup@4.62.2)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 1.6.0(patch_hash=250521d8ad2a8063f42539e889cf813250ca05aae49cf24dd6ab40c320784958)(@swc/helpers@0.5.21)(rollup@4.62.2)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       vite-plugin-wasm:
         specifier: ^3.6.0
         version: 3.6.0(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
@@ -552,7 +560,7 @@ importers:
         version: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
       vite-plugin-top-level-await:
         specifier: ^1.5.0
-        version: 1.6.0(@swc/helpers@0.5.21)(rollup@4.62.2)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 1.6.0(patch_hash=250521d8ad2a8063f42539e889cf813250ca05aae49cf24dd6ab40c320784958)(@swc/helpers@0.5.21)(rollup@4.62.2)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       vite-plugin-wasm:
         specifier: ^3.6.0
         version: 3.6.0(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
@@ -7020,7 +7028,7 @@ snapshots:
   '@swc/core-win32-x64-msvc@1.15.8':
     optional: true
 
-  '@swc/core@1.15.8(@swc/helpers@0.5.21)':
+  '@swc/core@1.15.8(patch_hash=f503a4ec701f193ef8db43cf396349b5ef3d39508fa6469bf0f36ab31f549c24)(@swc/helpers@0.5.21)':
     dependencies:
       '@swc/counter': 0.1.3
       '@swc/types': 0.1.25
@@ -9535,10 +9543,10 @@ snapshots:
       tinyglobby: 0.2.17
       vite: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
 
-  vite-plugin-top-level-await@1.6.0(@swc/helpers@0.5.21)(rollup@4.62.2)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)):
+  vite-plugin-top-level-await@1.6.0(patch_hash=250521d8ad2a8063f42539e889cf813250ca05aae49cf24dd6ab40c320784958)(@swc/helpers@0.5.21)(rollup@4.62.2)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       '@rollup/plugin-virtual': 3.0.2(rollup@4.62.2)
-      '@swc/core': 1.15.8(@swc/helpers@0.5.21)
+      '@swc/core': 1.15.8(patch_hash=f503a4ec701f193ef8db43cf396349b5ef3d39508fa6469bf0f36ab31f549c24)(@swc/helpers@0.5.21)
       '@swc/wasm': 1.15.8
       uuid: 11.1.1
       vite: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)


### PR DESCRIPTION
Fixes #2130.

## Root cause — two holes, not one

`vite-plugin-top-level-await` re-parses **every emitted ES chunk** with SWC in `generateBundle`. Two independent things break on a `using` declaration:

1. **`dist/bundle-info.js:44-47`** parses with `syntax: "ecmascript"`, `target: "es2022"` and no `explicitResourceManagement`, so `using` is a hard parse error — the diagnostic @louistrue narrowed to in the correcting comment.
2. **Not visible until (1) is fixed:** with the parser flag on, the AST now contains `UsingDeclaration` nodes, and `@swc/core`'s `Visitor` base class has no arm for them in `visitStatement` — so the plugin's own `FindPatternsVisitor` (`dist/find.js:26`) throws `Unknown statement type: UsingDeclaration`.

Fixing only the parser gets you a different crash, which is why this needs two patches.

## Fix

Two minimal `pnpm patch`es:

- `patches/vite-plugin-top-level-await@1.6.0.patch` — one line, `explicitResourceManagement: true` on the parse config.
- `patches/@swc__core@1.15.8.patch` — a `case "UsingDeclaration"` arm plus a `visitUsingDeclaration(n)` that walks `n.decls` exactly as `visitVariableDeclaration` walks `n.declarations`.

Both are additive; neither changes any existing path.

### Is the parser flag safe for code that has no `using`?

Checked the ASI hazard directly — `using` as an ordinary identifier, parsed and re-printed with the flag **off** and **on**:

| source | flag off | flag on |
|---|---|---|
| `var using = 5; console.log(using);` | `var using = 5; console.log(using);` | identical |
| `let using = 1;\nusing\n(2);` | `let using = 1; using(2);` | identical |
| `function f(using){return using}` | unchanged | identical |
| `const o={using:1};console.log(o.using);` | unchanged | identical |
| `using\nx\n` | `using; x;` | identical |

No divergence. And `pnpm build` (turbo, 40 tasks) passes on this branch with both patches applied, so nothing in the existing 5843-module viewer bundle is affected.

## Reproduction (RED) — the issue's own repro, end to end

`apps/viewer/src/hooks/useGridLines3D.ts:49`, one keyword changed (`const processor` → `using processor`), on the real viewer build with the patches **removed**:

```
$ pnpm --filter viewer build
thread '<unnamed>' panicked at .../miette-7.6.0/src/handlers/graphical.rs:1159:22
EXIT=134
```

Same edit **with** the patches:

```
$ pnpm --filter viewer build
✓ built in 14.73s        EXIT=0
```

That temporary edit is not part of this branch — the committed change is the patches plus the test.

## Regression guard

`apps/viewer/src/lib/using-declaration-build.test.ts` — 2 cases, driving a real `vite.build()` over a four-line fixture with `using` plus a top-level await (the TLA is needed or the plugin may skip the chunk and never reach the parse):

- `esnext` target: build resolves, **and** the emitted chunk still contains `using` — a "fix" that silently dropped the declaration (and therefore never disposed) would fail here.
- `es2022` target: esbuild lowers `using` to a try/finally stack, so the chunk is executable — asserts `['open:a','open:b','body','close:b','close:a']`, i.e. disposal actually runs, in reverse order.

## Mutation evidence

Each mutation was applied as an exact-substring replacement with an asserted replacement count of 1, followed by `pnpm install` to re-apply the patch, and the mutated text re-read from the installed package before running.

| # | mutation | verified in node_modules | result |
|---|---|---|---|
| 1 | `explicitResourceManagement: true` → `false` in the plugin patch (1 replacement) | `dist/bundle-info.js:47` reads `false` | **RED** — 2/2 fail, `x Using declaration is not enabled` |
| 2 | drop the `case "UsingDeclaration": return this.visitUsingDeclaration(stmt);` arm from the `@swc/core` patch, keeping the `visitUsingDeclaration` method (1 replacement) | `Visitor.js` has the method at `:417`, no case arm | **RED** — 2/2 fail, `Unknown statement type: UsingDeclaration` |

Mutation 2 is deliberately narrow: the method is left in place, so the kill is attributable to the dispatch arm alone and not to removing the whole patch. Patches restored from a saved copy (no `git checkout --`); GREEN reconfirmed, 2/2 pass.

## Test counts (`apps/viewer`)

| | tests | pass | fail | skipped |
|---|---|---|---|---|
| baseline (this branch, test file removed) | 2745 | 2743 | 0 | 2 |
| final | 2747 | 2745 | 0 | 2 |

`pnpm typecheck` at the root: 34/34 tasks green. `pnpm install --frozen-lockfile` succeeds with the committed lockfile. `node scripts/check-test-wiring.mjs` green.

## One thing to weigh before merging

The patches are keyed to exact versions (`vite-plugin-top-level-await@1.6.0`, `@swc/core@1.15.8`). A bump of either will fail the install loudly rather than silently dropping the fix — which I think is the right failure mode, but it is a maintenance cost, and `@swc/core` is a transitive dep that can move under a lockfile refresh. Happy to key them by name only (fuzzy apply, warn instead of fail) if you'd rather. The upstream fixes are one line each and worth filing regardless; this unblocks the repo in the meantime.

No changeset: no published package's API surface changes — the patches affect build tooling, and no source in the repo uses `using` today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
