### PR TITLE
test(mcp): close 10 mutation-verified coverage gaps

### DIFF
--- a/packages/mcp/src/auth/scope.test.ts
+++ b/packages/mcp/src/auth/scope.test.ts
@@ -1,0 +1,92 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Scope gating is the only thing standing between a read-only or
+ * model-narrowed token and the full tool surface, and until now every test in
+ * the package built its context with `fullScope()` or `readOnlyScope()` —
+ * neither of which sets `modelIds`. The per-model allowlist could therefore be
+ * deleted outright (`modelAllowed` → `return true`) and the suite stayed green,
+ * as could the `admin` escalation arm of `scopeAllows`, because no fixture ever
+ * held a scope that needed it.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  FULL_ACCESS,
+  READ_ONLY,
+  fullScope,
+  modelAllowed,
+  readOnlyScope,
+  scopeAllows,
+  type AuthScope,
+} from './scope.js';
+
+describe('scopeAllows', () => {
+  it('permits a tool that declares no scope', () => {
+    expect(scopeAllows({ scopes: [] }, undefined)).toBe(true);
+  });
+
+  it('permits exactly the scopes the token holds', () => {
+    const s = readOnlyScope();
+    expect(scopeAllows(s, 'read')).toBe(true);
+    expect(scopeAllows(s, 'validate')).toBe(true);
+    expect(scopeAllows(s, 'export')).toBe(true);
+    expect(scopeAllows(s, 'mutate')).toBe(false);
+    expect(scopeAllows(s, 'admin')).toBe(false);
+  });
+
+  it('lets `admin` stand in for a scope the token does not list', () => {
+    // The escalation arm, which no `fullScope()` fixture can reach: a token
+    // holding *only* `admin` short-circuits on the first `includes` for every
+    // one of the five scopes, so `|| includes('admin')` never runs. An operator
+    // minting an admin-only token would find every read tool denied.
+    const adminOnly: AuthScope = { scopes: ['admin'] };
+    for (const required of ['read', 'validate', 'mutate', 'export'] as const) {
+      expect(scopeAllows(adminOnly, required), required).toBe(true);
+    }
+  });
+
+  it('does not let a non-admin scope stand in for another', () => {
+    // Counter-example to the test above: escalation is `admin`-only, not
+    // "holding any scope implies the rest".
+    expect(scopeAllows({ scopes: ['export'] }, 'mutate')).toBe(false);
+  });
+});
+
+describe('modelAllowed', () => {
+  it('permits every model when no allowlist is configured', () => {
+    expect(modelAllowed({ scopes: ['read'] }, 'anything')).toBe(true);
+    expect(modelAllowed({ scopes: ['read'], modelIds: [] }, 'anything')).toBe(true);
+  });
+
+  it('permits only the listed models when an allowlist is configured', () => {
+    const narrowed: AuthScope = { scopes: ['read'], modelIds: ['alpha', 'beta'] };
+    expect(modelAllowed(narrowed, 'alpha')).toBe(true);
+    expect(modelAllowed(narrowed, 'beta')).toBe(true);
+    expect(modelAllowed(narrowed, 'gamma')).toBe(false);
+  });
+
+  it('is not defeated by `admin` — the allowlist is orthogonal to scopes', () => {
+    expect(modelAllowed({ scopes: ['admin'], modelIds: ['alpha'] }, 'gamma')).toBe(false);
+  });
+});
+
+describe('scope constructors', () => {
+  it('hand back copies, so a caller mutating one does not widen the next', () => {
+    const a = fullScope();
+    a.scopes = ['read'];
+    expect(fullScope().scopes).toEqual(FULL_ACCESS.scopes);
+
+    const b = readOnlyScope();
+    b.modelIds = ['only-this-one'];
+    expect(readOnlyScope().modelIds).toBeUndefined();
+    expect(READ_ONLY.scopes).not.toContain('mutate');
+  });
+
+  it('read-only really is read-only', () => {
+    expect(scopeAllows(readOnlyScope(), 'mutate')).toBe(false);
+    expect(scopeAllows(fullScope(), 'mutate')).toBe(true);
+  });
+});

--- a/packages/mcp/src/safe-path.test.ts
+++ b/packages/mcp/src/safe-path.test.ts
@@ -61,6 +61,21 @@ describe('resolveSafePath', () => {
       }
     });
 
+    it('accepts the allowed root itself, not just paths beneath it', async () => {
+      // `ensureWithinRoots` is `absolute === root || absolute.startsWith(root + sep)`.
+      // Every other test in this file passes a path strictly *inside* a root, so
+      // the equality arm was never exercised and could be deleted: an operator
+      // who passed `--allow <dir>` and then named that same directory as a tool
+      // argument would be told their own allowed root is outside allowed roots.
+      await expect(resolveSafePath(scratch, makeCtx([scratch]), 'read')).resolves.toBe(scratch);
+
+      // Counter-example, so the assertion above is about the boundary rule and
+      // not about the guard being off: the root's *parent* is still refused.
+      await expect(
+        resolveSafePath(resolve(scratch, '..'), makeCtx([scratch]), 'read'),
+      ).rejects.toThrow(/outside allowed roots/i);
+    });
+
     it('rejects a sibling whose prefix matches by string but not by path boundary', async () => {
       // /tmp/scratchAB vs allowed=/tmp/scratch
       const sibling = `${scratch}-sibling`;

--- a/packages/mcp/src/tools/export-usd.test.ts
+++ b/packages/mcp/src/tools/export-usd.test.ts
@@ -10,7 +10,7 @@
  * by `scripts/test-wasm-contract.mjs` and `tests/e2e/usd-export.e2e.spec.ts`.
  */
 
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -69,7 +69,13 @@ let tmp: string;
 let ctx: ToolContext;
 
 beforeAll(async () => {
-  tmp = await mkdtemp(join(tmpdir(), 'ifc-lite-mcp-usd-'));
+  // realpath() so the scratch root is canonical. `export_usd` returns the
+  // realpath-canonicalised `filePath` (every tool path goes through
+  // `resolveSafePath`), and on macOS tmpdir() is /var — a symlink to
+  // /private/var — so an uncanonicalised expectation fails on the assertion
+  // below for a reason that has nothing to do with the export. Same fix, and
+  // same reason, as `safe-path.test.ts`.
+  tmp = await realpath(await mkdtemp(join(tmpdir(), 'ifc-lite-mcp-usd-')));
   await writeFile(join(tmp, 'm.ifc'), MODEL, 'utf-8');
 });
 

--- a/packages/mcp/src/tools/layer-store.test.ts
+++ b/packages/mcp/src/tools/layer-store.test.ts
@@ -2,15 +2,23 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { createCollabDoc, entityToJSON, getEntity } from '@ifc-lite/collab';
+import { computeStackHash } from '@ifc-lite/ifcx';
 import type { IfcxFile } from '@ifc-lite/ifcx';
-import { seedDraftDoc } from './layer-store.js';
+import {
+  createLayerWorkspace,
+  refLayerFiles,
+  resolveAncestorFiles,
+  resolveBase,
+  seedDraftDoc,
+  type LayerWorkspace,
+} from './layer-store.js';
 
-function layer(data: IfcxFile['data']): IfcxFile {
+function layer(data: IfcxFile['data'], id = 'l'): IfcxFile {
   return {
     header: {
-      id: 'l',
+      id,
       ifcxVersion: 'ifcx_alpha',
       dataVersion: '1.0.0',
       author: 'test',
@@ -74,5 +82,91 @@ describe('seedDraftDoc', () => {
     ]);
 
     expect(getEntity(doc, 'wall-1')).toBeFalsy();
+  });
+});
+
+/**
+ * `resolveBase` decides what provenance a draft records and what baseline it is
+ * seeded from. Its `ProvenanceBase.kind` is not cosmetic: `resolveAncestorFiles`
+ * dispatches on it — a `'stack'` base is matched against a *stack hash* of a ref
+ * prefix, a `'layer'` base against a *layer id*. Only `seedDraftDoc` had tests,
+ * so `{ kind: 'layer', id: ref }` could be written as `{ kind: 'stack', id: ref }`
+ * with the suite green, and every draft seeded from a published layer would then
+ * resolve to an empty ancestor set: the draft is silently rebased onto nothing,
+ * and the merge planner is handed the wrong baseline.
+ */
+describe('resolveBase', () => {
+  let ws: LayerWorkspace;
+  let a: IfcxFile;
+  let b: IfcxFile;
+
+  beforeEach(() => {
+    ws = createLayerWorkspace();
+    a = layer([{ path: 'wall-1', attributes: { Name: 'A' } }], 'layer-a');
+    b = layer([{ path: 'wall-1', attributes: { Name: 'B' } }], 'layer-b');
+    ws.layers.set('layer-a', a);
+    ws.layers.set('layer-b', b);
+    ws.refs.set('main', ['layer-a', 'layer-b']);
+  });
+
+  it('records no base when no ref is asked for', () => {
+    expect(resolveBase(ws)).toEqual({ base: null, files: [] });
+  });
+
+  it('records a stack base for a ref name, hashed over the ref contents', () => {
+    const out = resolveBase(ws, 'main');
+    expect(out.base).toEqual({ kind: 'stack', id: computeStackHash(['layer-a', 'layer-b']) });
+    expect(out.files).toEqual([a, b]);
+  });
+
+  it('records an empty ref as no base at all, not as a stack of nothing', () => {
+    ws.refs.set('empty', []);
+    expect(resolveBase(ws, 'empty')).toEqual({ base: null, files: [] });
+  });
+
+  it('records a *layer* base for a published layer id, and seeds the whole ancestor stack', () => {
+    const out = resolveBase(ws, 'layer-a');
+    // `kind` is the load-bearing half: a 'stack' base carrying a layer id
+    // resolves through the stack-hash arm of `resolveAncestorFiles` and finds
+    // nothing, because a layer id is not a stack hash.
+    expect(out.base).toEqual({ kind: 'layer', id: 'layer-a' });
+    // Seeded from the ancestor prefix ending at that layer, not the lone delta.
+    expect(out.files).toEqual([a]);
+    // The property that makes `kind` observable, asserted directly.
+    expect(resolveAncestorFiles(ws, out.base, ['layer-a', 'layer-b'])).toEqual([a]);
+    expect(resolveAncestorFiles(ws, { kind: 'stack', id: 'layer-a' }, ['layer-a', 'layer-b'])).toEqual([]);
+  });
+
+  it('seeds the full prefix when the layer sits mid-history', () => {
+    const out = resolveBase(ws, 'layer-b');
+    expect(out.base).toEqual({ kind: 'layer', id: 'layer-b' });
+    expect(out.files).toEqual([a, b]);
+  });
+
+  it('falls back to the lone layer when it belongs to no ref', () => {
+    const stray = layer([{ path: 'wall-9', attributes: { Name: 'S' } }], 'stray');
+    ws.layers.set('stray', stray);
+    const out = resolveBase(ws, 'stray');
+    expect(out.base).toEqual({ kind: 'layer', id: 'stray' });
+    expect(out.files).toEqual([stray]);
+  });
+
+  it('rejects a base that is neither a ref name nor a published layer id', () => {
+    expect(() => resolveBase(ws, 'nope')).toThrow(/not a ref name or published layer id/);
+  });
+});
+
+describe('refLayerFiles', () => {
+  it('errors on an unknown ref rather than answering an empty stack', () => {
+    const ws = createLayerWorkspace();
+    expect(() => refLayerFiles(ws, 'nope')).toThrow(/Unknown ref/);
+    // `main` exists and is empty — a genuinely empty stack is not an error.
+    expect(refLayerFiles(ws, 'main')).toEqual([]);
+  });
+
+  it('errors on a ref pointing at a layer that is no longer stored', () => {
+    const ws = createLayerWorkspace();
+    ws.refs.set('main', ['ghost']);
+    expect(() => refLayerFiles(ws, 'main')).toThrow(/points at unknown layer ghost/);
   });
 });

--- a/packages/mcp/src/tools/model-scope.test.ts
+++ b/packages/mcp/src/tools/model-scope.test.ts
@@ -1,0 +1,217 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Per-model access control, end to end.
+ *
+ * `AuthScope.modelIds` narrows a token to a subset of the loaded models. The
+ * server enforces it at three places — `resolveModel`/`assertModelAccess` (the
+ * choke point every tool goes through), `model_list` (so an out-of-scope id is
+ * not leaked by enumeration) and `model_unload` (so a narrowed token cannot
+ * evict someone else's session). None of them had a test: every fixture in the
+ * package used `fullScope()`/`readOnlyScope()`, which leave `modelIds`
+ * undefined, so `modelAllowed` could be replaced by `return true` and the whole
+ * suite stayed green.
+ *
+ * A token narrowed to one model would then read, mutate and unload every other
+ * model in the process.
+ */
+
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import type { AuthScope } from '../auth/scope.js';
+import type { ToolContext } from '../context.js';
+import { DEFAULT_CONFIG, InMemoryModelRegistry, NOOP_PROGRESS, SILENT_LOGGER } from '../context.js';
+import { ToolErrorCode, ToolExecutionError } from '../errors.js';
+import { loadIfcModel } from '../loader.js';
+import { discoveryTools } from './discovery.js';
+import { queryTools } from './query.js';
+import { assertModelAccess, resolveModel } from './util.js';
+
+function guid(mnemonic: string): string {
+  return (mnemonic + '0'.repeat(22)).slice(0, 22);
+}
+
+function minimalModel(projectGuid: string): string {
+  return `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('m','2026',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1= IFCPROJECT('${projectGuid}',$,'Proj',$,$,$,$,(#20),#30);
+#20= IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#21,$);
+#21= IFCAXIS2PLACEMENT3D(#22,$,$);
+#22= IFCCARTESIANPOINT((0.,0.,0.));
+#30= IFCUNITASSIGNMENT((#31));
+#31= IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#40= IFCLOCALPLACEMENT($,#21);
+#72= IFCWALL('${guid('WALL')}',$,'Wall',$,$,#40,$,'tag',$);
+ENDSEC;
+END-ISO-10303-21;
+`;
+}
+
+const ALL_TOOLS = [...discoveryTools, ...queryTools];
+
+function tool(name: string) {
+  const found = ALL_TOOLS.find((t) => t.name === name);
+  if (!found) throw new Error(`${name} not registered`);
+  return found;
+}
+
+/** Invoke a tool. Handlers may throw synchronously or reject; normalise to a
+ *  rejection so `.rejects` works for both. */
+async function call(name: string, input: Record<string, unknown>) {
+  return tool(name).handler(input, ctx);
+}
+
+let tmp: string;
+let ctx: ToolContext;
+
+/** Two models loaded; the caller's scope is narrowed to `alpha` only. */
+async function sessionWithScope(scope: AuthScope): Promise<void> {
+  ctx = {
+    registry: new InMemoryModelRegistry(),
+    scope,
+    progress: NOOP_PROGRESS,
+    log: SILENT_LOGGER,
+    signal: new AbortController().signal,
+    config: { ...DEFAULT_CONFIG, allowedPaths: [tmp] },
+  };
+  ctx.registry.add(await loadIfcModel(join(tmp, 'alpha.ifc'), { modelId: 'alpha' }));
+  ctx.registry.add(await loadIfcModel(join(tmp, 'beta.ifc'), { modelId: 'beta' }));
+}
+
+const NARROWED: AuthScope = { scopes: ['read', 'validate', 'export', 'admin'], modelIds: ['alpha'] };
+
+beforeAll(async () => {
+  tmp = await mkdtemp(join(tmpdir(), 'ifc-lite-mcp-model-scope-'));
+  await writeFile(join(tmp, 'alpha.ifc'), minimalModel(guid('ALPH')), 'utf-8');
+  await writeFile(join(tmp, 'beta.ifc'), minimalModel(guid('BETA')), 'utf-8');
+});
+
+afterAll(async () => {
+  await rm(tmp, { recursive: true, force: true });
+});
+
+describe('a token narrowed to one model', () => {
+  beforeEach(async () => {
+    await sessionWithScope(NARROWED);
+  });
+
+  it('reaches the model it is allowed to', () => {
+    expect(resolveModel(ctx, 'alpha').id).toBe('alpha');
+    // Sanity: `beta` is genuinely loaded, so the denial below is about scope
+    // and not about a missing model.
+    expect(ctx.registry.get('beta')?.id).toBe('beta');
+    expect(ctx.registry.count()).toBe(2);
+  });
+
+  it('is denied the model it is not allowed to, with PERMISSION_DENIED not MODEL_NOT_FOUND', () => {
+    // The distinction matters: MODEL_NOT_FOUND would tell the agent to load it,
+    // and would also confirm the id does not exist — which is untrue.
+    try {
+      resolveModel(ctx, 'beta');
+      expect.unreachable('resolveModel should have thrown for an out-of-scope model');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ToolExecutionError);
+      expect((err as ToolExecutionError).code).toBe(ToolErrorCode.PERMISSION_DENIED);
+    }
+  });
+
+  it('does not leak out-of-scope ids in the MODEL_NOT_FOUND `available` list', () => {
+    try {
+      resolveModel(ctx, 'does-not-exist');
+      expect.unreachable('resolveModel should have thrown for an unknown model');
+    } catch (err) {
+      const e = err as ToolExecutionError;
+      expect(e.code).toBe(ToolErrorCode.MODEL_NOT_FOUND);
+      expect((e.details as { available: string[] }).available).toEqual(['alpha']);
+    }
+  });
+
+  it('is denied by assertModelAccess directly, admin scope notwithstanding', () => {
+    const beta = ctx.registry.get('beta');
+    expect(beta).not.toBeNull();
+    expect(() => assertModelAccess(ctx, beta!)).toThrow(/not permitted for this token/);
+    expect(assertModelAccess(ctx, ctx.registry.get('alpha')!).id).toBe('alpha');
+  });
+
+  it('sees only the permitted model from model_list', async () => {
+    const res = await call('model_list', {});
+    const out = res.structuredContent as { count: number; models: Array<{ id: string }> };
+    expect(out.models.map((m) => m.id)).toEqual(['alpha']);
+    // The count has to agree with the filtered list, not with the registry —
+    // "2 models loaded" next to one row is the leak in a friendlier costume.
+    expect(out.count).toBe(1);
+  });
+
+  it('cannot unload a model outside its allowlist', async () => {
+    await expect(call('model_unload', { model_id: 'beta' }))
+      .rejects.toThrow(/not permitted for this token/);
+    expect(ctx.registry.get('beta')).not.toBeNull();
+
+    // Counter-example: the permitted model unloads fine, so the rejection above
+    // is about the allowlist and not about `model_unload` being broken.
+    await call('model_unload', { model_id: 'alpha' });
+    expect(ctx.registry.get('alpha')).toBeNull();
+  });
+
+  it('cannot read entities out of an out-of-scope model', async () => {
+    await expect(call('query_entities', { model_id: 'beta', type: 'IfcWall' }))
+      .rejects.toThrow(/not permitted for this token/);
+    const ok = await call('query_entities', { model_id: 'alpha', type: 'IfcWall' });
+    expect((ok.structuredContent as { count: number }).count).toBe(1);
+  });
+});
+
+describe('a token with no allowlist', () => {
+  it('reaches every loaded model', async () => {
+    await sessionWithScope({ scopes: ['read', 'admin'] });
+    expect(resolveModel(ctx, 'alpha').id).toBe('alpha');
+    expect(resolveModel(ctx, 'beta').id).toBe('beta');
+    const res = await call('model_list', {});
+    const out = res.structuredContent as { count: number; models: Array<{ id: string }> };
+    expect(out.models.map((m) => m.id).sort()).toEqual(['alpha', 'beta']);
+    expect(out.count).toBe(2);
+  });
+});
+
+describe('resolveModel without an explicit model_id', () => {
+  it('demands a model_id as soon as a second model is loaded', async () => {
+    await sessionWithScope({ scopes: ['read'] });
+    expect(ctx.registry.count()).toBe(2);
+    try {
+      resolveModel(ctx);
+      expect.unreachable('resolveModel should have demanded a model_id');
+    } catch (err) {
+      const e = err as ToolExecutionError;
+      expect(e.code).toBe(ToolErrorCode.MODEL_REQUIRED);
+      expect((e.details as { available: string[] }).available.sort()).toEqual(['alpha', 'beta']);
+    }
+  });
+
+  it('picks the only model when exactly one is loaded', async () => {
+    await sessionWithScope({ scopes: ['read'] });
+    ctx.registry.remove('beta');
+    expect(ctx.registry.count()).toBe(1);
+    expect(resolveModel(ctx).id).toBe('alpha');
+  });
+
+  it('reports MODEL_NOT_FOUND when nothing is loaded', async () => {
+    await sessionWithScope({ scopes: ['read'] });
+    ctx.registry.remove('alpha');
+    ctx.registry.remove('beta');
+    try {
+      resolveModel(ctx);
+      expect.unreachable('resolveModel should have thrown with an empty registry');
+    } catch (err) {
+      expect((err as ToolExecutionError).code).toBe(ToolErrorCode.MODEL_NOT_FOUND);
+    }
+  });
+});

--- a/packages/mcp/src/tools/util.test.ts
+++ b/packages/mcp/src/tools/util.test.ts
@@ -19,6 +19,29 @@ describe('tool utilities', () => {
     expect(out.truncated).toBe(false);
   });
 
+  it('does not flag truncation on a page that lands exactly on the end', () => {
+    // The boundary the two tests above straddle without touching: the previous
+    // pair used offset+limit=3 against total 5 (truncated) and offset+limit=5
+    // against total 3 (not truncated), so `<` could become `<=` untouched. An
+    // agent paginating a result set whose size is a multiple of its page size
+    // would then be told there is more and ask for an empty next page forever.
+    const exact = paginate([1, 2, 3, 4], 2, 2);
+    expect(exact.items).toEqual([3, 4]);
+    expect(exact.truncated).toBe(false);
+    expect(exact.total).toBe(4);
+
+    // And one item short of the end still is truncated, so the assertion above
+    // is about the boundary and not about truncation never being reported.
+    const short = paginate([1, 2, 3, 4, 5], 2, 2);
+    expect(short.items).toEqual([3, 4]);
+    expect(short.truncated).toBe(true);
+  });
+
+  it('defaults offset to 0', () => {
+    expect(paginate([1, 2, 3], 2).items).toEqual([1, 2]);
+    expect(paginate([1, 2, 3], 2).truncated).toBe(true);
+  });
+
   it('formats count', () => {
     expect(fmtCount(1, 'door')).toBe('1 door');
     expect(fmtCount(3, 'door')).toBe('3 doors');

--- a/packages/mcp/src/tools/validation.test.ts
+++ b/packages/mcp/src/tools/validation.test.ts
@@ -1,0 +1,273 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The numbers `model_audit` and `ids_validate` report.
+ *
+ * `read-after-write.test.ts` covers which *issues* the audit raises over a
+ * mutation overlay, but nothing covered the arithmetic that turns those issues
+ * into the Lighthouse-style scores an agent actually reads and reports onward —
+ * `scoreFromIssues` could stop weighting warnings entirely and the suite stayed
+ * green. Nor did anything cover `summarizeIdsReport`'s empty-specification rule,
+ * where `specPassed = ents.length > 0` could become `= true` and a rule that
+ * matched no entity at all would be counted as passed. Both failures are silent
+ * in the worst way: the tool still returns a confident, plausible score.
+ */
+
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { CallToolResult } from '../protocol/index.js';
+import type { ToolContext } from '../context.js';
+import { DEFAULT_CONFIG, InMemoryModelRegistry, NOOP_PROGRESS, SILENT_LOGGER } from '../context.js';
+import { fullScope } from '../auth/scope.js';
+import { loadIfcModel } from '../loader.js';
+import { validationTools } from './validation.js';
+
+function guid(mnemonic: string): string {
+  return (mnemonic + '0'.repeat(22)).slice(0, 22);
+}
+
+const PREAMBLE = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('m','2026',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#20= IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#21,$);
+#21= IFCAXIS2PLACEMENT3D(#22,$,$);
+#22= IFCCARTESIANPOINT((0.,0.,0.));
+#30= IFCUNITASSIGNMENT((#31));
+#31= IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#40= IFCLOCALPLACEMENT($,#21);
+`;
+
+const TAIL = `ENDSEC;
+END-ISO-10303-21;
+`;
+
+/**
+ * Project + Site + Building, every required entity present, one named wall.
+ * The only structural finding is the missing IfcBuildingStorey, which is a
+ * *warning* — which is exactly what makes this fixture able to discriminate
+ * the warning weight from the error weight.
+ */
+const WARNING_ONLY = PREAMBLE + `#1= IFCPROJECT('${guid('PROJ')}',$,'Proj',$,$,$,$,(#20),#30);
+#2= IFCSITE('${guid('SITE')}',$,'Site',$,$,#40,$,$,.ELEMENT.,$,$,$,$,$);
+#3= IFCBUILDING('${guid('BLDG')}',$,'B',$,$,#40,$,$,.ELEMENT.,$,$,$);
+#72= IFCWALL('${guid('WALA')}',$,'Wall A',$,$,#40,$,'tagA',$);
+` + TAIL;
+
+/** Same, but with a storey present and the Site missing — one *error*, no warning. */
+const ERROR_ONLY = PREAMBLE + `#1= IFCPROJECT('${guid('PROJ')}',$,'Proj',$,$,$,$,(#20),#30);
+#3= IFCBUILDING('${guid('BLDG')}',$,'B',$,$,#40,$,$,.ELEMENT.,$,$,$);
+#4= IFCBUILDINGSTOREY('${guid('STOR')}',$,'L01',$,$,#40,$,$,.ELEMENT.,0.);
+#72= IFCWALL('${guid('WALA')}',$,'Wall A',$,$,#40,$,'tagA',$);
+` + TAIL;
+
+/** Everything present, but one of two walls carries no Name. */
+const UNNAMED = PREAMBLE + `#1= IFCPROJECT('${guid('PROJ')}',$,'Proj',$,$,$,$,(#20),#30);
+#2= IFCSITE('${guid('SITE')}',$,'Site',$,$,#40,$,$,.ELEMENT.,$,$,$,$,$);
+#3= IFCBUILDING('${guid('BLDG')}',$,'B',$,$,#40,$,$,.ELEMENT.,$,$,$);
+#4= IFCBUILDINGSTOREY('${guid('STOR')}',$,'L01',$,$,#40,$,$,.ELEMENT.,0.);
+#72= IFCWALL('${guid('WALA')}',$,'Wall A',$,$,#40,$,'tagA',$);
+#73= IFCWALL('${guid('WALB')}',$,$,$,$,#40,$,'tagB',$);
+` + TAIL;
+
+interface AuditShape {
+  overall: number;
+  scores: { structure: number; identity: number; dataQuality: number };
+  issues: Array<{ severity: string; category: string; rule: string; message: string }>;
+  totals: { products: number; unnamed: number; duplicateGlobalIds: number };
+}
+
+interface IdsShape {
+  summary: {
+    totalSpecifications: number;
+    passedSpecifications: number;
+    failedSpecifications: number;
+    totalEntities: number;
+    passedEntities: number;
+    failedEntities: number;
+  };
+}
+
+function tool(name: string) {
+  const found = validationTools.find((t) => t.name === name);
+  if (!found) throw new Error(`${name} not registered`);
+  return found;
+}
+
+let tmp: string;
+
+async function auditOf(file: string): Promise<AuditShape> {
+  return (await run(file, 'model_audit', {})).structuredContent as unknown as AuditShape;
+}
+
+async function run(file: string, name: string, input: Record<string, unknown>): Promise<CallToolResult> {
+  const ctx: ToolContext = {
+    registry: new InMemoryModelRegistry(),
+    scope: fullScope(),
+    progress: NOOP_PROGRESS,
+    log: SILENT_LOGGER,
+    signal: new AbortController().signal,
+    config: { ...DEFAULT_CONFIG, allowedPaths: [tmp] },
+  };
+  ctx.registry.add(await loadIfcModel(join(tmp, file), { modelId: 'm' }));
+  return tool(name).handler(input, ctx);
+}
+
+beforeAll(async () => {
+  tmp = await mkdtemp(join(tmpdir(), 'ifc-lite-mcp-validation-'));
+  await writeFile(join(tmp, 'warning-only.ifc'), WARNING_ONLY, 'utf-8');
+  await writeFile(join(tmp, 'error-only.ifc'), ERROR_ONLY, 'utf-8');
+  await writeFile(join(tmp, 'unnamed.ifc'), UNNAMED, 'utf-8');
+});
+
+afterAll(async () => {
+  await rm(tmp, { recursive: true, force: true });
+});
+
+describe('model_audit scoring', () => {
+  it('docks a structural warning 10 points, distinctly from an error', async () => {
+    const warned = await auditOf('warning-only.ifc');
+    // Exactly one structural finding, and it is a warning — so the score below
+    // is attributable to the warning weight and nothing else.
+    expect(warned.issues.filter((i) => i.category === 'structure')).toEqual([
+      expect.objectContaining({ severity: 'warning', rule: 'has-storeys' }),
+    ]);
+    expect(warned.scores.structure).toBe(90);
+  });
+
+  it('docks a structural error 25 points', async () => {
+    const errored = await auditOf('error-only.ifc');
+    expect(errored.issues.filter((i) => i.category === 'structure')).toEqual([
+      expect.objectContaining({ severity: 'error', rule: 'required-entity' }),
+    ]);
+    // 25 ≠ 10, so the two weights cannot be collapsed into one and still
+    // satisfy both tests.
+    expect(errored.scores.structure).toBe(75);
+  });
+
+  it('scores dataQuality on the share of *named* products', async () => {
+    const audit = await auditOf('unnamed.ifc');
+    // Four products (project, site, building, storey are spatial; the two walls
+    // and the spatial containers that `isProductType` accepts make up the
+    // denominator) — pinned, because a denominator that silently grew to
+    // include geometry primitives is the #2003-class defect this score had.
+    expect(audit.totals.unnamed).toBe(1);
+    expect(audit.totals.products).toBe(6);
+    expect(audit.scores.dataQuality).toBe(83);
+    expect(audit.issues.map((i) => i.rule)).toContain('has-name');
+  });
+
+  it('scores a clean identity at 100 and averages the three categories', async () => {
+    const audit = await auditOf('warning-only.ifc');
+    expect(audit.totals.duplicateGlobalIds).toBe(0);
+    expect(audit.scores.identity).toBe(100);
+    expect(audit.overall).toBe(
+      Math.round((audit.scores.structure + audit.scores.identity + audit.scores.dataQuality) / 3),
+    );
+  });
+});
+
+const IDS_MATCHING_NOTHING = `<?xml version="1.0" encoding="utf-8"?>
+<ids xmlns="http://standards.buildingsmart.org/IDS"
+     xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <info><title>Unmatched</title></info>
+  <specifications>
+    <specification name="Furniture must be named" ifcVersion="IFC4">
+      <applicability>
+        <entity><name><simpleValue>IFCFURNITURE</simpleValue></name></entity>
+      </applicability>
+      <requirements>
+        <attribute><name><simpleValue>Name</simpleValue></name></attribute>
+      </requirements>
+    </specification>
+  </specifications>
+</ids>`;
+
+const IDS_MATCHING_WALLS = `<?xml version="1.0" encoding="utf-8"?>
+<ids xmlns="http://standards.buildingsmart.org/IDS"
+     xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <info><title>Walls</title></info>
+  <specifications>
+    <specification name="Walls must be named" ifcVersion="IFC4">
+      <applicability>
+        <entity><name><simpleValue>IFCWALL</simpleValue></name></entity>
+      </applicability>
+      <requirements>
+        <attribute><name><simpleValue>Name</simpleValue></name></attribute>
+      </requirements>
+    </specification>
+  </specifications>
+</ids>`;
+
+describe('ids_validate summary', () => {
+  it('does not count a specification that matched no entity as passed', async () => {
+    // The vacuous-pass rule. A spec whose applicability selects nothing has an
+    // empty `entityResults`; counting it as passed is how an IDS typo turns
+    // into a green report, which is the single most misleading thing this tool
+    // can tell an agent.
+    const out = (await run('warning-only.ifc', 'ids_validate', {
+      ids_xml: IDS_MATCHING_NOTHING,
+    })).structuredContent as unknown as IdsShape;
+    expect(out.summary.totalSpecifications).toBe(1);
+    expect(out.summary.totalEntities).toBe(0);
+    expect(out.summary.passedSpecifications).toBe(0);
+    expect(out.summary.failedSpecifications).toBe(1);
+  });
+
+  it('counts a specification whose matched entities all pass', async () => {
+    // Counter-example: with the same requirement against a spec that *does*
+    // match, the pass is real — so the failure above is about emptiness, not
+    // about `passedSpecifications` being stuck at zero.
+    const out = (await run('warning-only.ifc', 'ids_validate', {
+      ids_xml: IDS_MATCHING_WALLS,
+    })).structuredContent as unknown as IdsShape;
+    expect(out.summary.totalEntities).toBeGreaterThan(0);
+    expect(out.summary.failedEntities).toBe(0);
+    expect(out.summary.passedSpecifications).toBe(1);
+    expect(out.summary.failedSpecifications).toBe(0);
+  });
+
+  it('reports failures when a matched entity does not satisfy the requirement', async () => {
+    const out = (await run('unnamed.ifc', 'ids_validate', {
+      ids_xml: IDS_MATCHING_WALLS,
+    })).structuredContent as unknown as IdsShape;
+    expect(out.summary.totalEntities).toBe(2);
+    expect(out.summary.failedEntities).toBe(1);
+    expect(out.summary.passedEntities).toBe(1);
+    expect(out.summary.passedSpecifications).toBe(0);
+  });
+});
+
+describe('ids source resolution', () => {
+  it('rejects a call that supplies neither ids_xml nor ids_path', async () => {
+    await expect(run('warning-only.ifc', 'ids_validate', {})).rejects.toThrow(/ids_xml or ids_path/);
+    await expect(run('warning-only.ifc', 'ids_explain', {})).rejects.toThrow(/ids_xml or ids_path/);
+  });
+
+  it('applies the allowedPaths guard to ids_explain, not only to ids_validate', async () => {
+    // Both tools share `loadIdsXml` so both enforce the allowlist; a path
+    // outside it must be refused rather than read.
+    await expect(run('warning-only.ifc', 'ids_explain', { ids_path: '/etc/hosts' }))
+      .rejects.toThrow(/outside allowed roots|sensitive home entry/i);
+  });
+
+  it('errors when the named specification is not in the document', async () => {
+    await expect(run('warning-only.ifc', 'ids_explain', {
+      ids_xml: IDS_MATCHING_WALLS, spec_name: 'No such spec',
+    })).rejects.toThrow(/not found in IDS document/);
+  });
+});
+
+describe('gherkin_check', () => {
+  it('reports UNSUPPORTED_OPERATION rather than silently passing', async () => {
+    await expect(run('warning-only.ifc', 'gherkin_check', {}))
+      .rejects.toThrow(/gherkin_check is planned/);
+  });
+});

--- a/packages/mcp/src/transport/http.test.ts
+++ b/packages/mcp/src/transport/http.test.ts
@@ -21,6 +21,15 @@ const VERSION = '0.0.0-test';
 
 const ALICE: AuthScope = { scopes: ['read', 'mutate'], user: 'alice' };
 const MALLORY: AuthScope = { scopes: ['read', 'mutate'], user: 'mallory' };
+// Same principal, same permissions — narrowed to *different* models. The only
+// thing telling these two sessions apart is `modelIds`, which is what makes
+// them the fixture for that arm of the identity check.
+const ALICE_ALPHA: AuthScope = { scopes: ['read', 'mutate'], user: 'alice', modelIds: ['alpha'] };
+const ALICE_BETA: AuthScope = { scopes: ['read', 'mutate'], user: 'alice', modelIds: ['beta'] };
+// Same principal, same narrowing, but a wider permission set.
+const ALICE_ADMIN: AuthScope = { scopes: ['read', 'mutate', 'admin'], user: 'alice' };
+// Same permissions in a different order — must still compare equal.
+const ALICE_REORDERED: AuthScope = { scopes: ['mutate', 'read'], user: 'alice' };
 
 function makeTransport(factory?: SessionFactory): HttpTransport {
   return new HttpTransport({
@@ -29,6 +38,10 @@ function makeTransport(factory?: SessionFactory): HttpTransport {
     authenticator: new BearerTokenAuth(new Map([
       ['alice-token', ALICE],
       ['mallory-token', MALLORY],
+      ['alice-alpha-token', ALICE_ALPHA],
+      ['alice-beta-token', ALICE_BETA],
+      ['alice-admin-token', ALICE_ADMIN],
+      ['alice-reordered-token', ALICE_REORDERED],
     ])),
     sessionFactory: factory ?? {
       build: (scope, sessionId) => createMCPServer({ version: VERSION, scope, sessionId }),
@@ -121,6 +134,64 @@ describe('HttpTransport session identity', () => {
       body: JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'ping' }),
     });
     expect(denied.status).toBe(403);
+  });
+
+  // The three tests above all differ by `user`, which `sameScope` rejects on
+  // its very first comparison — so every later arm of the check (the scope-set
+  // comparison, the `modelIds` comparison) was unreachable and could be
+  // deleted. A token narrowed to one model could then take over a session
+  // opened by a token narrowed to another, and inherit its drafts.
+  it('a token narrowed to a different model cannot reuse the session', async () => {
+    const sid = await initSession(port, 'alice-alpha-token');
+    const denied = await request(port, 'alice-beta-token', {
+      method: 'POST',
+      sessionId: sid,
+      body: JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'ping' }),
+    });
+    expect(denied.status).toBe(403);
+
+    // Counter-example: the identical token does reuse it, so the rejection is
+    // about the narrowing and not about session reuse being broken outright.
+    const ok = await request(port, 'alice-alpha-token', {
+      method: 'POST',
+      sessionId: sid,
+      body: JSON.stringify({ jsonrpc: '2.0', id: 3, method: 'ping' }),
+    });
+    expect(ok.status).toBe(200);
+  });
+
+  it('an unnarrowed token cannot reuse a narrowed session, or the reverse', async () => {
+    const narrowed = await initSession(port, 'alice-alpha-token');
+    expect((await request(port, 'alice-token', {
+      method: 'POST', sessionId: narrowed,
+      body: JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'ping' }),
+    })).status).toBe(403);
+
+    const wide = await initSession(port, 'alice-token');
+    expect((await request(port, 'alice-alpha-token', {
+      method: 'POST', sessionId: wide,
+      body: JSON.stringify({ jsonrpc: '2.0', id: 3, method: 'ping' }),
+    })).status).toBe(403);
+  });
+
+  it('a wider permission set cannot reuse a narrower session', async () => {
+    const sid = await initSession(port, 'alice-token');
+    const denied = await request(port, 'alice-admin-token', {
+      method: 'POST', sessionId: sid,
+      body: JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'ping' }),
+    });
+    expect(denied.status).toBe(403);
+  });
+
+  it('the same permission set in a different order still reuses the session', async () => {
+    // The sort in `sameScope` exists for this; without it a client that emitted
+    // its scopes in another order would be locked out of its own session.
+    const sid = await initSession(port, 'alice-token');
+    const ok = await request(port, 'alice-reordered-token', {
+      method: 'POST', sessionId: sid,
+      body: JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'ping' }),
+    });
+    expect(ok.status).toBe(200);
   });
 });
 


### PR DESCRIPTION
Mutation sweep of `packages/mcp` — the last package not yet swept. Twelve mutations against the load-bearing logic; **ten survived**, each now killed by a RED-verified test.

The largest hole was scope gating. Every fixture in the package built its context with `fullScope()` or `readOnlyScope()`, neither of which sets `modelIds`, so the entire per-model access-control feature was vacuous: `modelAllowed` could be replaced by `return true` and all 184 tests stayed green. A token narrowed to one model could read, query and unload every other model in the process, and `model_list` would enumerate them all.

## Mutation results

Every mutation was applied by exact-substring replacement asserting a replacement count of exactly 1, the mutated region re-read to confirm the text changed, and restored from a saved backup.

| # | Location | Mutation | n | Result |
|---|---|---|---|---|
| M1 | `auth/scope.ts` `scopeAllows` | drop `\|\| includes('admin')` | 1 | SURVIVED |
| M2 | `auth/scope.ts` `modelAllowed` | `return true` unconditionally | 1 | SURVIVED |
| M3 | `tools/validation.ts` `scoreFromIssues` | drop `- warns * 10` | 1 | SURVIVED |
| M4 | `tools/validation.ts` `summarizeIdsReport` | `ents.length > 0` → `true` | 1 | SURVIVED |
| M5 | `transport/http.ts` `sameScope` | drop the `modelIds` comparison | 1 | SURVIVED |
| M6 | `tools/util.ts` `paginate` | `offset + limit < total` → `<=` | 1 | SURVIVED |
| M7 | `tools/util.ts` `resolveModel` | `count() > 1` → `> 2` | 1 | SURVIVED |
| M8 | `tools/layer-store.ts` `resolveBase` | `kind: 'layer'` → `kind: 'stack'` | 1 | SURVIVED |
| M9 | `safe-path.ts` `ensureWithinRoots` | drop `absolute === root` | 1 | SURVIVED |
| M10 | `safe-path.ts` `rejectIfSensitiveHome` | disable the guard | 1 | **KILLED** (4 tests) |
| M11 | `tools/discovery.ts` `model_list` | drop the `modelAllowed` filter | 1 | SURVIVED |
| M12 | `tools/validation.ts` `model_audit` | `count > 1` → `> 2` | 1 | **KILLED** (1 test) |

M10 and M12 are the controls: they prove the suite was genuinely running against the mutated source, so the ten survivors are real gaps rather than an unrun suite. M12 in particular proves `model_audit` is reachable from the existing tests, so M3's survival is a scoring gap and not dead code.

No survivor is an equivalent mutant — each changes an observable answer, listed below.

## Gaps closed

**M2 / M11 — per-model access control (`auth/scope.ts`, `tools/util.ts`, `tools/discovery.ts`).** `AuthScope.modelIds` narrows a token to a subset of loaded models, enforced at `resolveModel`/`assertModelAccess`, `model_list` and `model_unload`. None of it had a test. New `src/tools/model-scope.test.ts` loads two models under a scope narrowed to one and asserts the denial is `PERMISSION_DENIED` (not `MODEL_NOT_FOUND`, which would tell the agent to load a model that is already loaded), that `model_list` shows one row **and** a count of 1, that `model_unload` and `query_entities` refuse the other model, and that the `MODEL_NOT_FOUND` `available` list does not leak out-of-scope ids. Nine tests fail under M2.

**M1 — `scopeAllows` admin escalation.** `fullScope()` short-circuits on the first `includes` for all five scopes, so `|| includes('admin')` was unreachable. An operator minting an admin-only token would find every read tool denied. New `src/auth/scope.test.ts` uses a `{ scopes: ['admin'] }` token, with `{ scopes: ['export'] }` → `'mutate'` as the counter-example so the test asserts admin-specific escalation rather than "any scope implies the rest".

**M5 — HTTP session identity (`transport/http.ts`).** The three existing tests all differ by `user`, which `sameScope` rejects on its very first comparison, leaving the scope-set and `modelIds` arms unreachable. A token narrowed to model A could take over a session opened by one narrowed to model B and inherit its layer drafts. Added four tests using tokens that share `user` and permissions and differ only in narrowing, each with an identical-token counter-example that must still get a 200 — plus a reordered-scopes token that must still reuse its session, covering the sort.

**M7 — `resolveModel`.** With exactly two models loaded and no `model_id`, the caller would silently get one of them instead of `MODEL_REQUIRED`.

**M6 — `paginate`.** The two existing tests use offset+limit=3 against total 5 and offset+limit=5 against total 3, straddling the boundary without touching it. A page landing exactly on the end would report `truncated: true`, so an agent paginating a result set whose size is a multiple of its page size would request empty pages forever. New test pins the exact boundary with a one-short case as the counter-example.

**M8 — `resolveBase` provenance kind (`tools/layer-store.ts`).** Only `seedDraftDoc` had tests. `resolveAncestorFiles` dispatches on `ProvenanceBase.kind` — a `'stack'` base is matched against a stack hash, a `'layer'` base against a layer id — so a mislabelled base resolves to an empty ancestor set: the draft is silently rebased onto nothing and the merge planner gets the wrong baseline. The new test asserts the `kind` and, directly, the property that makes it observable (`resolveAncestorFiles` with a `'stack'` base carrying a layer id returns `[]`). Also covers `refLayerFiles`' dangling-layer and unknown-ref errors.

**M3 / M4 — audit and IDS scoring (`tools/validation.ts`).** `validation.ts` had no test file; `read-after-write.test.ts` covers which *issues* the audit raises but never the arithmetic that turns them into the scores an agent reads and reports onward. New `src/tools/validation.test.ts` uses two fixtures that discriminate the weights — one whose only structural finding is a warning (90) and one whose only finding is an error (75) — so the two weights cannot be collapsed and still satisfy both. For IDS, a specification whose applicability matches nothing must count as **failed**: counting it passed is how an applicability typo becomes a green report, the most misleading thing this tool can say. Two counter-examples (a spec that matches and passes, one that matches and fails) ensure the assertion is about emptiness, not about `passedSpecifications` being stuck at zero.

**M9 — `ensureWithinRoots`.** Every other test passes a path strictly inside a root, so the equality arm was never exercised. An operator who passed `--allow <dir>` and then named that directory would be told their own allowed root is outside allowed roots. The root's parent is asserted still refused, so the test is about the boundary and not about the guard being off.

## Pre-existing failure fixed

`export-usd.test.ts` failed on macOS before any change: the fixture compared against an uncanonicalised `tmpdir()` path while the tool correctly returns the realpath (`tmpdir()` is `/var`, a symlink to `/private/var`, and every tool path goes through `resolveSafePath`). The production path was right; the expectation was not. Same fix and same reason `safe-path.test.ts` already documents.

## Baseline

`packages/mcp`: 20 files / 184 tests, 1 pre-existing failure → **23 files / 231 tests, all passing**. `pnpm typecheck` green at the repo root. Test-only changes; no changeset (test files are excluded from `dist` by `tsconfig.json` and by `package.json` `files`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)