### PR TITLE
test(diff,provenance): close three mutation-verified coverage gaps

### DIFF
--- a/packages/diff/src/content-match.test.ts
+++ b/packages/diff/src/content-match.test.ts
@@ -312,6 +312,34 @@ describe('diffModels — content matching does not trust the data hash alone', (
     expect(diff.contentMatches ?? []).toEqual([]);
   });
 
+  it('reads a component map as a SET: the key insertion order does not decide the verdict', () => {
+    // `componentSignature` canonicalizes by sorting the keys, and the sort is
+    // the only thing that makes the documented "order-independent" contract
+    // true. `componentsAgree` is a one-way guard — a disagreement PROVES a
+    // collision — so an insertion-order signature would turn a difference in
+    // how two fingerprinting runs happened to enumerate psets into proof that
+    // two identical elements are unrelated. The user-visible result of that
+    // is a re-GUIDed element reported as added + deleted instead of renamed.
+    const components = buildComponentFingerprints(PSET_A);
+    const reversed = Object.fromEntries(Object.entries(components).reverse());
+
+    // Fixture guard: the two maps must be the same set in a DIFFERENT order,
+    // or this test would pass for the wrong reason (a one-key map, or a map
+    // whose reversal is itself).
+    expect(reversed).toEqual(components);
+    expect(Object.keys(reversed)).not.toEqual(Object.keys(components));
+
+    const base = [fp('a-guid', { ifcType: 'IfcWall', dataHash: COLLIDING, components })];
+    const head = [
+      fp('b-guid', { ifcType: 'IfcWall', dataHash: COLLIDING, components: reversed }),
+    ];
+
+    const diff = diffModels(base, head, { matchUnpairedByContent: true });
+
+    expect(diff.counts).toEqual({ added: 0, modified: 0, deleted: 0, unchanged: 0 });
+    expect(diff.contentMatches?.map((match) => match.kind)).toEqual(['renamed']);
+  });
+
   it('pairs the same colliding entities when no components are supplied (the guard needs them)', () => {
     const base = [fp('a-guid', { ifcType: 'IfcWall', dataHash: COLLIDING })];
     const head = [fp('b-guid', { ifcType: 'IfcWall', dataHash: COLLIDING })];

--- a/packages/diff/src/split-merge.test.ts
+++ b/packages/diff/src/split-merge.test.ts
@@ -13,7 +13,8 @@
 import { describe, expect, it } from 'vitest';
 import { diffModels } from './diff.js';
 import { identityMapFromContentMatches } from './identity-map.js';
-import type { EntityAabb, EntityFingerprint, ModelDiff } from './types.js';
+import { detectSplitMerge } from './split-merge.js';
+import type { DiffEntry, EntityAabb, EntityFingerprint, ModelDiff } from './types.js';
 
 type Ref = number;
 
@@ -638,5 +639,46 @@ describe('split/merge — the knobs', () => {
     expect(reversed.map((c) => c.pieces.map((p) => p.key))).toEqual(
       forward.map((c) => c.pieces.map((p) => p.key)),
     );
+  });
+
+  it('orders pieces that REPEAT a GlobalId by data hash, not by arrival order', () => {
+    // `sortPieces`'s SECOND key, which the test above cannot reach: with all
+    // keys distinct the first key already decides every comparison, so the
+    // tiebreak is free to be missing. A file that repeats a GlobalId still has
+    // two distinct entities, and without the tiebreak their relative order in
+    // the claim is whatever order the caller enumerated them in — two runs
+    // over the same model emit two different claims.
+    //
+    // Driven through `detectSplitMerge` directly because `diffModels` cannot
+    // reach it: `indexByKey` keeps only the first occurrence of a repeated
+    // key, so the second entity never becomes a candidate.
+    const whole = wholeWall();
+    const piece = (index: number, key: string, dataHash: string): EntityFingerprint<Ref> => ({
+      ...segment(index, 1.2),
+      key,
+      dataHash,
+    });
+    // Arrival order deliberately violates the required order on the tiebreak.
+    const pieces = [
+      piece(0, 'dup', 'h-zzz'),
+      piece(1, 'dup', 'h-aaa'),
+      piece(2, 'other', 'h-mmm'),
+    ];
+    const entries: DiffEntry<Ref>[] = [
+      { key: whole.key, state: 'deleted', changeKinds: [], base: whole },
+      ...pieces.map(
+        (p): DiffEntry<Ref> => ({ key: p.key, state: 'added', changeKinds: [], head: p }),
+      ),
+    ];
+
+    const found = detectSplitMerge(entries, true, {});
+
+    expect(found).toHaveLength(1);
+    expect(found?.[0].confidence).toBe('verified');
+    expect(found?.[0].pieces.map((p) => [p.key, p.dataHash])).toEqual([
+      ['dup', 'h-aaa'],
+      ['dup', 'h-zzz'],
+      ['other', 'h-mmm'],
+    ]);
   });
 });

--- a/packages/provenance/src/footprint.test.ts
+++ b/packages/provenance/src/footprint.test.ts
@@ -194,6 +194,71 @@ describe('conflictPredicate: structural conflicts', () => {
     expect(conflictPredicate(fpA, fpB).structural).toBe(false);
   });
 
+  it('STOPS at a container ancestor — a non-container ABOVE one is not reached', async () => {
+    // The crux rule has two halves, and the fixed DAG above can only exercise
+    // one of them: its containers (storeyRel, root) have nothing but more
+    // container above them, so "excluded from writtenNodes" and "not walked
+    // past" are indistinguishable there.
+    //
+    // This DAG separates them. `ElementPayload`'s documented component
+    // vocabulary includes `relationship:<RelType>`, so an element sitting
+    // ABOVE a relationship is a legal node-hash-v0 shape — the
+    // `IfcRelVoidsElement` one, a host element whose components include the
+    // voids relationship over its opening. Walking PAST the relationship
+    // would pull the host into the opening's writtenNodes, and every edit
+    // anywhere below the voids relationship would then structurally conflict
+    // with every edit on the host: exactly the false-conflict blowup the crux
+    // rule exists to prevent (the M4 kill criterion).
+    const dag = new ProvenanceDag();
+    const specs: NodeSpec[] = [
+      { id: 'openMesh', kind: 'geometry-mesh', payload: mesh(400) },
+      { id: 'hostMesh', kind: 'geometry-mesh', payload: mesh(500) },
+      {
+        id: 'opening',
+        kind: 'element',
+        children: ['openMesh'],
+        buildPayload: (h): ElementPayload => ({
+          key: 'opening-1',
+          ifcType: 'IfcOpeningElement',
+          components: [{ componentKey: 'geometry-mesh', hash: h.get('openMesh')! }],
+        }),
+      },
+      {
+        id: 'voidsRel',
+        kind: 'relationship',
+        children: ['opening'],
+        buildPayload: (h): RelationshipPayload => ({
+          relType: 'IfcRelVoidsElement',
+          roles: [{ roleName: 'RelatedOpeningElement', refs: [h.get('opening')!] }],
+        }),
+      },
+      {
+        id: 'host',
+        kind: 'element',
+        children: ['hostMesh', 'voidsRel'],
+        buildPayload: (h): ElementPayload => ({
+          key: 'host-1',
+          ifcType: 'IfcWall',
+          components: [
+            { componentKey: 'geometry-mesh', hash: h.get('hostMesh')! },
+            { componentKey: 'relationship:IfcRelVoidsElement', hash: h.get('voidsRel')! },
+          ],
+        }),
+      },
+    ];
+    for (const spec of specs) dag.addNode(spec);
+    await dag.build();
+
+    const opening = computeFootprint(dag, propertyEdit('opOpening', ['openMesh']));
+    // Not just "voidsRel is absent" — `host`, which lives above it, is absent too.
+    expect(opening.writtenNodes).toEqual(new Set(['openMesh', 'opening']));
+
+    // ...and the consequence the rule is actually for.
+    const hostEdit = computeFootprint(dag, propertyEdit('opHost', ['hostMesh']));
+    expect(hostEdit.writtenNodes).toEqual(new Set(['hostMesh', 'host']));
+    expect(conflictPredicate(opening, hostEdit).structural).toBe(false);
+  });
+
   it('computeFootprint throws on an unknown target node id', async () => {
     const dag = buildFixedDag();
     await dag.build();


### PR DESCRIPTION
Mutation sweep of `packages/diff` and `packages/provenance` — the two packages the repo-wide vacuous-test sweep had not reached. Both are in very good shape: **39 mutations applied, 36 killed**. Three survivors were genuine gaps; two more are proven equivalent mutants and were deliberately left alone.

Every mutation was applied with an exact-substring replacement asserting a replacement count of 1, the mutated region was re-read to confirm the text actually changed, and the file was restored from a saved backup (never `git checkout --`). Two controls (`diff.ts` `changeKinds.length > 0` → `>= 0`; `resolveUseGeometry` → `return considerGeometry`) were included specifically to prove the harness ran against mutated source — both killed, 9 tests between them.

Baseline: diff 14 files / 284 tests, provenance 11 files / 265 tests, all green. Final: 286 and 266.

## Gap 1 — a component map's key ORDER decided whether two elements matched

`content-tiers.ts`'s `componentSignature` documents an "order-independent canonical form" and gets it from a `.sort()` on the keys. No fixture ever built two maps with the same entries in a different insertion order, so:

```
for (const key of Object.keys(components).sort())  ->  for (const key of Object.keys(components))
```

left all 284 tests green.

`componentsAgree` is a **one-way** guard: it never rejects a real match, so a disagreement is treated as PROOF that the shared `dataHash` was a collision, and the pair is refused. With an insertion-order signature, a difference in how two fingerprinting runs happened to enumerate psets becomes that proof. What a user sees: a re-GUIDed element that content matching should have retired as `renamed` stays in the diff as added + deleted.

**Killing test** — `content-match.test.ts`, *"reads a component map as a SET: the key insertion order does not decide the verdict"*. It carries a fixture guard (`expect(Object.keys(reversed)).not.toEqual(Object.keys(components))` alongside `expect(reversed).toEqual(components)`) so it cannot pass for the wrong reason on a one-key map.

## Gap 2 — the piece-order tiebreak for a repeated GlobalId

`split-merge-lanes.ts`'s `sortPieces` sorts by `key`, then by `dataHash` "for the pathological case of a model repeating a GlobalId". The existing *"is order-independent"* test uses distinct keys throughout, so the first key already decides every comparison and the second is free to be missing:

```
if (ad !== bd) return ad < bd ? -1 : 1;  ->  if (false && ad !== bd) ...
```

survived. `Array.prototype.sort` is stable, so without the tiebreak two pieces sharing a key come back in **arrival order** — two runs over the same model emit two different claims for the same split.

`diffModels` cannot reach this: `indexByKey` keeps only the first occurrence of a repeated key, so the second entity never becomes a candidate. The new test therefore drives `detectSplitMerge` directly, with an arrival order that deliberately violates the required one.

**Killing test** — `split-merge.test.ts`, *"orders pieces that REPEAT a GlobalId by data hash, not by arrival order"*.

## Gap 3 — the crux ancestor rule's second half (footprint / M4 conflicts)

`footprint.ts`'s rule has two halves: a `relationship`/`layer` ancestor is excluded from `writtenNodes`, **and** the walk does not continue past it ("everything above an aggregator is more aggregation"). The fixed DAG in the tests has nothing but more container above its containers (`storeyRel` → `root`, both container kinds), so the two halves are indistinguishable there. Replacing the container `continue` with `stack.push(parentId); continue;` — excluded, but walked past — left all 265 tests green.

`ElementPayload`'s documented component vocabulary includes `relationship:<RelType>`, so an **element above a relationship** is a legal node-hash-v0 shape: the `IfcRelVoidsElement` one, a host element whose components include the voids relationship over its opening. On that DAG the mutant pulls the host element into every opening-side footprint, so every edit anywhere below the voids relationship structurally conflicts with every edit on the host — precisely the false-conflict blowup the crux rule exists to prevent, and the M4 kill criterion (`docs/vision/moonshots-execution-plan.md` §5).

**Killing test** — `footprint.test.ts`, *"STOPS at a container ancestor — a non-container ABOVE one is not reached"*. It pins the exact `writtenNodes` set (so it discriminates "walked past" from "merely excluded") **and** the `conflictPredicate.structural` consequence, which is the thing that actually matters.

## Survivors classified as equivalent (no test added)

- **`content-match.ts` `retire()` counter swap** (`removedAdded` ↔ `removedDeleted`). Every call site passes equal-length groups — tier 1 requires `bases.length === group.heads.length`, and the residue-1-1 and positional paths pass `[base], [head]` — so the two counters are always equal and the swap cannot be observed.
- **`content-match.ts` residue-emptiness `||` → `&&`.** The early `continue` is subsumed by the identical check on the position pass's leftovers 36 lines later: `pairByPosition` returns no pairs and preserves emptiness when either side is empty, so `leftoverBase.length === 0 || leftoverHead.length === 0` catches exactly the same cases.
- **`split-merge-lanes.ts` refuted-path `if (!verdict.complete) return undefined;`.** Reachable (partial refutation), but downstream is total: an incomplete set makes `usableVolume(...)!` yield `undefined`, so `findSingleInterloper`'s `sum`/`overshoot` are `NaN`, `NaN <= band` is false, and the `Math.abs(...) > band` filter never `continue`s — the second index always trips the "two explanations is no explanation" return. `undefined` either way.

## Everything else held

Killed outright: the mutual-nearest tie abstention, its `maxDistance` cap and its deterministic pair ordering, all three `componentsAgree` guard sites, the `ifcType` half of the bucket key, the tier-1 sub-bucket count equality, `MAX_POSITION_MATCH_GROUP`'s boundary, the size-before-move precedence in `classifyGeometryChange`, both directions of the lane-2 uniqueness rule, lane 1's precedence over lane 2, `sortPieces`' primary key, the conflict pass's evidence rank and its tie-memory refinement, `extentCoverage`'s gap check, `sortedExtents`' sort, `clusterByProximity`'s query-dominates-predicate factor — and on the provenance side the NFC sort/encode agreement, `AmbiguousSetKeyError`, `verifyNodeRef`'s hash comparison, `aabbFromMesh`'s origin fold, `inflateAabb`'s mm→m conversion, `invalidate`'s ancestor cascade and `recompute`'s dependency ordering.

Test-only; no production code changed. `pnpm typecheck` green at the repo root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)