### PR TITLE
test(spatial,clash): mutation sweep — spatial had zero tests, clash had 11 unpinned boundaries

### DIFF
--- a/.changeset/spatial-clash-boundary-coverage.md
+++ b/.changeset/spatial-clash-boundary-coverage.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/spatial": patch
+---
+
+Wire `@ifc-lite/spatial` into the test runner. The package shipped four modules of load-bearing geometry — `AABBUtils`, the `BVH` (AABB query, raycast, frustum query), `FrustumUtils` and the spatial index builder — with no test files and no `test` script, so `turbo test` skipped it entirely and none of it ran in CI. Adds a `test` script plus 45 tests covering the touching/containment boundaries, ray-slab behaviour behind the origin and along a grazed axis, the frustum plane margin, the per-mesh world-space origin lift, and the time-sliced async builder. No behaviour change.

--- a/packages/clash/src/analysis.test.ts
+++ b/packages/clash/src/analysis.test.ts
@@ -50,6 +50,22 @@ describe('isTouching', () => {
   it('always flags touch-status clashes', () => {
     expect(isTouching(clash('a', 0.001, 'info', 'touch'))).toBe(true);
   });
+
+  it('includes a depth sitting EXACTLY on the epsilon, and excludes the next value up', () => {
+    // The band is inclusive at its edge. An exclusive `<` re-labels a coincident
+    // face reported at precisely the band edge as a genuine overlap — the
+    // false-positive class #1273 removed — and nothing else in the suite pins it.
+    expect(isTouching(clash('a', -TOUCHING_EPSILON, 'info'))).toBe(true);
+    expect(isTouching(clash('a', -TOUCHING_EPSILON * 1.000001, 'info'))).toBe(false);
+  });
+
+  it('honours a caller-supplied epsilon at its own boundary', () => {
+    const c = clash('a', -0.5, 'info');
+    expect(isTouching(c, 0.5)).toBe(true);
+    expect(isTouching(c, 0.25)).toBe(false);
+    // Default band would reject it — proves the argument, not the default, wins.
+    expect(isTouching(c)).toBe(false);
+  });
 });
 
 describe('sortClashes', () => {

--- a/packages/clash/src/duplicates.test.ts
+++ b/packages/clash/src/duplicates.test.ts
@@ -74,6 +74,26 @@ describe('findDuplicates', () => {
     expect(findDuplicates([flatA, flatB]).clashes).toHaveLength(1);
   });
 
+  it('reports a pair whose IoU is EXACTLY the threshold', () => {
+    // A = [0,1]³, B = [0,1]²×[0,2]: intersection 1, union 1 + 2 − 1 = 2, so the
+    // IoU is exactly 0.5 — no rounding involved. `sim < threshold` rejects means
+    // the threshold itself qualifies; an exclusive `<=` silently drops the pair
+    // that sits precisely on the value the caller configured.
+    const a: ClashElement = {
+      key: 'a', ref: nextRef++, model: 'm', tag: 'IfcWall',
+      bounds: { min: [0, 0, 0], max: [1, 1, 1] },
+      positions: new Float32Array(0), indices: new Uint32Array(36),
+    };
+    const b: ClashElement = {
+      ...a, key: 'b', ref: nextRef++,
+      bounds: { min: [0, 0, 0], max: [1, 1, 2] },
+    };
+    expect(findDuplicates([a, b], { iouThreshold: 0.5 }).clashes).toHaveLength(1);
+    // Just above the exact IoU it is correctly rejected, so the assertion above
+    // is a boundary decision and not "this pair always overlaps".
+    expect(findDuplicates([a, b], { iouThreshold: 0.5000001 }).clashes).toHaveLength(0);
+  });
+
   it('produces a coherent summary', () => {
     const res = findDuplicates([
       box('a', [0, 0, 0], 0.5, 12),

--- a/packages/clash/src/engine-ts/boundaries.test.ts
+++ b/packages/clash/src/engine-ts/boundaries.test.ts
@@ -1,0 +1,262 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Two-valued / boundary contracts of the clash pipeline.
+ *
+ * Everything here is a case where a wrong answer is silent: a violation that is
+ * exactly ON the limit, an overlap exactly equal to tolerance, a depth measured
+ * in only one direction, and a run that stopped early. None of them throw —
+ * they just report a number nobody checks.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { createClashEngine } from '../engine.js';
+import { fromPositions } from '../math/aabb.js';
+import type { ClashElement, Vec3 } from '../types.js';
+
+const BOX_INDICES = new Uint32Array([
+  0, 1, 2, 0, 2, 3, 4, 6, 5, 4, 7, 6, 0, 4, 5, 0, 5, 1,
+  1, 5, 6, 1, 6, 2, 2, 6, 7, 2, 7, 3, 3, 7, 4, 3, 4, 0,
+]);
+
+let nextRef = 1;
+
+/** Axis-aligned box, 12 triangles, with independent per-axis half-extents. */
+function boxElement(key: string, tag: string, c: Vec3, half: Vec3): ClashElement {
+  const [cx, cy, cz] = c;
+  const [hx, hy, hz] = half;
+  const positions = new Float32Array([
+    cx - hx, cy - hy, cz - hz,
+    cx + hx, cy - hy, cz - hz,
+    cx + hx, cy + hy, cz - hz,
+    cx - hx, cy + hy, cz - hz,
+    cx - hx, cy - hy, cz + hz,
+    cx + hx, cy - hy, cz + hz,
+    cx + hx, cy + hy, cz + hz,
+    cx - hx, cy + hy, cz + hz,
+  ]);
+  return {
+    key, ref: nextRef++, model: 'm', tag, positions, indices: BOX_INDICES,
+    bounds: fromPositions(positions),
+  };
+}
+
+/**
+ * Closed box whose six faces are each fanned from a face-centre vertex:
+ * 14 vertices, 24 triangles. Geometrically identical to `boxElement`, but with
+ * MORE triangles — which is what decides the small/large role in the narrow
+ * phase, and therefore which direction the contained-pair depth is measured in.
+ */
+function fanBoxElement(key: string, tag: string, c: Vec3, half: Vec3): ClashElement {
+  const [cx, cy, cz] = c;
+  const [hx, hy, hz] = half;
+  const positions = new Float32Array([
+    cx - hx, cy - hy, cz - hz,
+    cx + hx, cy - hy, cz - hz,
+    cx + hx, cy + hy, cz - hz,
+    cx - hx, cy + hy, cz - hz,
+    cx - hx, cy - hy, cz + hz,
+    cx + hx, cy - hy, cz + hz,
+    cx + hx, cy + hy, cz + hz,
+    cx - hx, cy + hy, cz + hz,
+    cx, cy, cz - hz, // 8  -z face centre
+    cx, cy, cz + hz, // 9  +z
+    cx, cy - hy, cz, // 10 -y
+    cx, cy + hy, cz, // 11 +y
+    cx - hx, cy, cz, // 12 -x
+    cx + hx, cy, cz, // 13 +x
+  ]);
+  const indices = new Uint32Array([
+    0, 1, 8, 1, 2, 8, 2, 3, 8, 3, 0, 8,
+    4, 5, 9, 5, 6, 9, 6, 7, 9, 7, 4, 9,
+    0, 1, 10, 1, 5, 10, 5, 4, 10, 4, 0, 10,
+    3, 2, 11, 2, 6, 11, 6, 7, 11, 7, 3, 11,
+    0, 3, 12, 3, 7, 12, 7, 4, 12, 4, 0, 12,
+    1, 2, 13, 2, 6, 13, 6, 5, 13, 5, 1, 13,
+  ]);
+  return { key, ref: nextRef++, model: 'm', tag, positions, indices, bounds: fromPositions(positions) };
+}
+
+const L_PRISM_INDICES = new Uint32Array([
+  0, 2, 1, 0, 3, 2, 0, 4, 3, 0, 5, 4,
+  6, 7, 8, 6, 8, 9, 6, 9, 10, 6, 10, 11,
+  0, 1, 7, 0, 7, 6, 1, 2, 8, 1, 8, 7, 2, 3, 9, 2, 9, 8,
+  3, 4, 10, 3, 10, 9, 4, 5, 11, 4, 11, 10, 5, 0, 6, 5, 6, 11,
+]);
+
+/**
+ * Closed, CONCAVE L-shaped prism, 20 triangles: footprint
+ * (0,0)-(2,0)-(2,1)-(1,1)-(1,2)-(0,2) extruded z = 0..1. The square
+ * [1,2]×[1,2] is a notch — inside the AABB but OUTSIDE the solid — so a box
+ * placed across the notch wall is AABB-contained while genuinely crossing the
+ * surface.
+ */
+function lPrismElement(key: string, tag: string): ClashElement {
+  const positions = new Float32Array([
+    0, 0, 0, 2, 0, 0, 2, 1, 0, 1, 1, 0, 1, 2, 0, 0, 2, 0,
+    0, 0, 1, 2, 0, 1, 2, 1, 1, 1, 1, 1, 1, 2, 1, 0, 2, 1,
+  ]);
+  return { key, ref: nextRef++, model: 'm', tag, positions, indices: L_PRISM_INDICES, bounds: fromPositions(positions) };
+}
+
+describe('clearance rule: the limit itself is a violation', () => {
+  it('reports a gap EXACTLY equal to the required clearance', async () => {
+    // A spans x ∈ [-0.5, 0.5], B spans x ∈ [1.0, 2.0] → gap exactly 0.5, which
+    // is also the required clearance. Every value is exact in f32, so this is a
+    // true `==` boundary, not a near-miss. `<=` is the documented contract and
+    // is what the Rust kernel implements (rust/clash/src/narrow.rs); a `<` here
+    // silently passes a duct that sits precisely on the minimum separation.
+    const elements = [
+      boxElement('A', 'IfcWall', [0, 0, 0], [0.5, 0.5, 0.5]),
+      boxElement('B', 'IfcDuctSegment', [1.5, 0, 0], [0.5, 0.5, 0.5]),
+    ];
+    const engine = createClashEngine({ backend: 'ts' });
+    const result = await engine.run(elements, [
+      { id: 'r', name: 'r', a: 'IfcWall', b: 'IfcDuct*', mode: 'clearance', clearance: 0.5 },
+    ]);
+    expect(result.summary.total).toBe(1);
+    expect(result.clashes[0].status).toBe('clearance');
+    expect(result.clashes[0].distance).toBeCloseTo(0.5, 6);
+  });
+
+  it('does NOT report a gap just beyond the required clearance', async () => {
+    // Same fixture pushed 1/16 m further apart. Without this the test above
+    // would also pass for an engine that reports every candidate pair.
+    const elements = [
+      boxElement('A', 'IfcWall', [0, 0, 0], [0.5, 0.5, 0.5]),
+      boxElement('B', 'IfcDuctSegment', [1.5625, 0, 0], [0.5, 0.5, 0.5]),
+    ];
+    const engine = createClashEngine({ backend: 'ts' });
+    const result = await engine.run(elements, [
+      { id: 'r', name: 'r', a: 'IfcWall', b: 'IfcDuct*', mode: 'clearance', clearance: 0.5 },
+    ]);
+    expect(result.summary.total).toBe(0);
+  });
+});
+
+describe('hard rule: an overlap exactly equal to tolerance is contact, not a clash', () => {
+  it('suppresses two boxes whose AABBs penetrate by exactly the tolerance', async () => {
+    // Overlap on x is exactly 1/16 = the tolerance, so the AABB signed gap is
+    // exactly -tolerance. The gate is `gap < -tolerance` (strict, mirroring the
+    // Rust kernel): an overlap that merely REACHES tolerance is the touching
+    // band, not a hard clash. A `<=` here turns every element that sits exactly
+    // on the modelling tolerance into a reported collision.
+    const t = 0.0625;
+    const elements = [
+      boxElement('A', 'IfcWall', [0, 0, 0], [0.5, 0.5, 0.5]),
+      boxElement('B', 'IfcSlab', [1 - t, 0, 0], [0.5, 0.5, 0.5]),
+    ];
+    const engine = createClashEngine({ backend: 'ts' });
+    const result = await engine.run(
+      elements,
+      [{ id: 'r', name: 'r', a: 'IfcWall', b: 'IfcSlab', mode: 'hard' }],
+      { tolerance: t },
+    );
+    expect(result.summary.total).toBe(0);
+  });
+
+  it('DOES report the pair once the overlap goes past the tolerance', async () => {
+    // Recall guard: proves the suppression above is a boundary decision, not a
+    // blanket "axis-aligned boxes never clash".
+    const t = 0.0625;
+    const elements = [
+      boxElement('A', 'IfcWall', [0, 0, 0], [0.5, 0.5, 0.5]),
+      boxElement('B', 'IfcSlab', [1 - 4 * t, 0, 0], [0.5, 0.5, 0.5]),
+    ];
+    const engine = createClashEngine({ backend: 'ts' });
+    const result = await engine.run(
+      elements,
+      [{ id: 'r', name: 'r', a: 'IfcWall', b: 'IfcSlab', mode: 'hard' }],
+      { tolerance: t },
+    );
+    expect(result.summary.total).toBe(1);
+    expect(result.clashes[0].status).toBe('hard');
+  });
+});
+
+describe('contained pair: penetration depth is measured in BOTH directions (#1866)', () => {
+  it('uses the deeper of the two mesh-level measurements, not just the smaller mesh', async () => {
+    // Concave L-prism (20 triangles) vs a fanned box (24 triangles) laid across
+    // the notch wall at x = 1. The box's AABB is inside the prism's, so this is
+    // the contained-pair branch.
+    //
+    // The narrow phase iterates the mesh with FEWER triangles, so here "small"
+    // is the L-prism. Measuring only small→large gives 0: the prism's crossing
+    // triangles are the notch wall, whose corners all sit outside the box. The
+    // real depth is large→small — the box's crossing-triangle vertices buried in
+    // the prism, deepest at its z = 0.2 / z = 0.8 corners, 0.2 m from the
+    // prism's z faces. Drop that term and the engine silently falls back to the
+    // AABB estimate of 0.6 m: it TRIPLES the reported penetration depth, which
+    // is exactly the over-report #1866 was filed for.
+    const prism = lPrismElement('L', 'IfcSlab');
+    const bar = fanBoxElement('BAR', 'IfcBeam', [0.9, 1.5, 0.5], [0.5, 0.3, 0.3]);
+    const engine = createClashEngine({ backend: 'ts' });
+    const result = await engine.run([prism, bar], [
+      { id: 'r', name: 'r', a: 'IfcSlab', b: 'IfcBeam', mode: 'hard' },
+    ]);
+
+    expect(result.summary.total).toBe(1);
+    const c = result.clashes[0];
+    expect(c.status).toBe('hard');
+    // Real mesh depth: 0.2 m (the deepest crossing-triangle vertex inside the
+    // prism), NOT the 0.6 m AABB proxy (the box's own shortest extent).
+    expect(c.distance).toBeCloseTo(-0.2, 3);
+    expect(c.distance).not.toBeCloseTo(-0.6, 3);
+  });
+});
+
+describe('maxCandidatePairs: the cap is honoured and the truncation is reported', () => {
+  /** Six candidate pairs: four mutually overlapping walls, self-clash. */
+  function fourOverlappingWalls(): ClashElement[] {
+    return [
+      boxElement('W1', 'IfcWall', [0, 0, 0], [0.5, 0.5, 0.5]),
+      boxElement('W2', 'IfcWall', [0.1, 0, 0], [0.5, 0.5, 0.5]),
+      boxElement('W3', 'IfcWall', [0.2, 0, 0], [0.5, 0.5, 0.5]),
+      boxElement('W4', 'IfcWall', [0.3, 0, 0], [0.5, 0.5, 0.5]),
+    ];
+  }
+  const RULE = { id: 'self', name: 'walls', a: 'IfcWall', mode: 'hard' as const };
+
+  it('reports no truncation and all 6 pairs when the cap is not set', async () => {
+    const engine = createClashEngine({ backend: 'ts' });
+    const result = await engine.run(fourOverlappingWalls(), [RULE]);
+    expect(result.summary.total).toBe(6);
+    expect(result.truncated).toBeUndefined();
+  });
+
+  it('processes exactly `maxCandidatePairs` pairs and reports the dropped remainder', async () => {
+    // The budget is checked BEFORE each pair (`processed >= maxPairs`), so a cap
+    // of 2 must yield exactly 2 clashes and 4 dropped. An off-by-one runs a
+    // third pair — the cap is then not the cap the caller asked for, and the
+    // reported `droppedPairs` no longer adds up to the candidate total.
+    const engine = createClashEngine({ backend: 'ts' });
+    const result = await engine.run(fourOverlappingWalls(), [RULE], { maxCandidatePairs: 2 });
+    expect(result.summary.total).toBe(2);
+    expect(result.truncated).toEqual({ reason: 'maxCandidatePairs', droppedPairs: 4 });
+  });
+
+  it('flags truncation even when the cap bites on the very first pair', async () => {
+    // Zero budget: nothing is examined, and the caller MUST be told — otherwise
+    // an empty clash list reads as "the model is clean".
+    const engine = createClashEngine({ backend: 'ts' });
+    const result = await engine.run(fourOverlappingWalls(), [RULE], { maxCandidatePairs: 0 });
+    expect(result.summary.total).toBe(0);
+    expect(result.truncated?.droppedPairs).toBe(6);
+  });
+
+  it('spends ONE global budget across rules, not one per rule', async () => {
+    // Two rules over the same six pairs with a cap of 8: the first rule spends
+    // 6, leaving 2 for the second, which then drops 4.
+    const engine = createClashEngine({ backend: 'ts' });
+    const result = await engine.run(
+      fourOverlappingWalls(),
+      [RULE, { ...RULE, id: 'self2' }],
+      { maxCandidatePairs: 8 },
+    );
+    expect(result.truncated?.droppedPairs).toBe(4);
+    expect(result.summary.byRule.self).toBe(6);
+    expect(result.summary.byRule.self2).toBe(2);
+  });
+});

--- a/packages/clash/src/math/aabb.test.ts
+++ b/packages/clash/src/math/aabb.test.ts
@@ -1,0 +1,197 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Boundary contract for the box kernel behind the clash narrow phase.
+ *
+ * These wrappers bind the Plato-generated single-source math (generated/plato.g.ts)
+ * that is ALSO transpiled to Rust (rust/clash/src/generated/plato.rs). The two
+ * kernels must agree exactly at the touching point, so the `<=` / `>=` choices
+ * are a cross-language contract, not an implementation detail.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  aabbContains,
+  boundsOfPoints,
+  center,
+  fromPositions,
+  inflate,
+  intersects,
+  overlapBounds,
+  signedGap,
+} from './aabb.js';
+import type { AABB, Mat4, Vec3 } from '../types.js';
+
+function box(
+  minX: number, minY: number, minZ: number,
+  maxX: number, maxY: number, maxZ: number,
+): AABB {
+  return { min: [minX, minY, minZ], max: [maxX, maxY, maxZ] };
+}
+
+const UNIT = box(0, 0, 0, 1, 1, 1);
+
+describe('intersects', () => {
+  it('counts an exact face touch as intersecting, on every axis and both signs', () => {
+    expect(intersects(UNIT, box(1, 0, 0, 2, 1, 1))).toBe(true);
+    expect(intersects(UNIT, box(-1, 0, 0, 0, 1, 1))).toBe(true);
+    expect(intersects(UNIT, box(0, 1, 0, 1, 2, 1))).toBe(true);
+    expect(intersects(UNIT, box(0, -1, 0, 1, 0, 1))).toBe(true);
+    expect(intersects(UNIT, box(0, 0, 1, 1, 1, 2))).toBe(true);
+    expect(intersects(UNIT, box(0, 0, -1, 1, 1, 0))).toBe(true);
+  });
+
+  it('separates on a single axis while the other two still overlap', () => {
+    expect(intersects(UNIT, box(1.0001, 0, 0, 2, 1, 1))).toBe(false);
+    expect(intersects(UNIT, box(0, 1.0001, 0, 1, 2, 1))).toBe(false);
+    expect(intersects(UNIT, box(0, 0, 1.0001, 1, 1, 2))).toBe(false);
+  });
+
+  it('is symmetric', () => {
+    const cases: Array<[AABB, AABB]> = [
+      [UNIT, box(1, 0, 0, 2, 1, 1)],
+      [UNIT, box(0.5, 0.5, 0.5, 4, 4, 4)],
+      [UNIT, box(9, 9, 9, 10, 10, 10)],
+      [box(-9, -9, -9, -8, -8, -8), box(-8, -9, -9, -7, -8, -8)],
+    ];
+    for (const [a, b] of cases) expect(intersects(a, b)).toBe(intersects(b, a));
+  });
+});
+
+describe('aabbContains', () => {
+  it('counts a shared face as contained (documented `<=` / `>=` contract)', () => {
+    expect(aabbContains(UNIT, UNIT)).toBe(true);
+    expect(aabbContains(UNIT, box(0, 0, 0, 0.5, 1, 1))).toBe(true); // shares min-x face
+    expect(aabbContains(UNIT, box(0.5, 0, 0, 1, 1, 1))).toBe(true); // shares max-x face
+  });
+
+  it('rejects an inner box poking out on any single axis', () => {
+    expect(aabbContains(UNIT, box(-0.0001, 0, 0, 1, 1, 1))).toBe(false);
+    expect(aabbContains(UNIT, box(0, 0, 0, 1.0001, 1, 1))).toBe(false);
+    expect(aabbContains(UNIT, box(0, -0.0001, 0, 1, 1, 1))).toBe(false);
+    expect(aabbContains(UNIT, box(0, 0, 0, 1, 1.0001, 1))).toBe(false);
+    expect(aabbContains(UNIT, box(0, 0, -0.0001, 1, 1, 1))).toBe(false);
+    expect(aabbContains(UNIT, box(0, 0, 0, 1, 1, 1.0001))).toBe(false);
+  });
+
+  it('is NOT symmetric — argument order decides outer vs inner', () => {
+    const inner = box(0.25, 0.25, 0.25, 0.75, 0.75, 0.75);
+    expect(aabbContains(UNIT, inner)).toBe(true);
+    expect(aabbContains(inner, UNIT)).toBe(false);
+  });
+
+  it('handles negative coordinates', () => {
+    const outer = box(-10, -10, -10, -1, -1, -1);
+    expect(aabbContains(outer, box(-9, -9, -9, -2, -2, -2))).toBe(true);
+    expect(aabbContains(outer, box(-11, -9, -9, -2, -2, -2))).toBe(false);
+  });
+});
+
+describe('signedGap', () => {
+  it('is zero for boxes that exactly touch', () => {
+    // `-0` (the negated zero overlap) — compare numerically, not with Object.is.
+    expect(signedGap(UNIT, box(1, 0, 0, 2, 1, 1))).toBeCloseTo(0, 12);
+  });
+
+  it('is the Euclidean separation when the boxes are apart on one axis', () => {
+    expect(signedGap(UNIT, box(3, 0, 0, 4, 1, 1))).toBeCloseTo(2, 12);
+  });
+
+  it('is the diagonal distance when the boxes are apart on several axes', () => {
+    // Corner-to-corner: 3 on x, 4 on y -> 5.
+    expect(signedGap(UNIT, box(4, 5, 0, 5, 6, 1))).toBeCloseTo(5, 12);
+  });
+
+  it('is the negative of the MINIMUM-axis overlap when the boxes penetrate', () => {
+    // Overlaps 0.9 on x but only 0.1 on y — the shallow axis wins.
+    expect(signedGap(UNIT, box(0.1, 0.9, 0, 2, 2, 1))).toBeCloseTo(-0.1, 12);
+  });
+
+  it('is symmetric', () => {
+    const b = box(0.1, 0.9, 0, 2, 2, 1);
+    expect(signedGap(UNIT, b)).toBeCloseTo(signedGap(b, UNIT), 12);
+    const far = box(4, 5, 0, 5, 6, 1);
+    expect(signedGap(UNIT, far)).toBeCloseTo(signedGap(far, UNIT), 12);
+  });
+});
+
+describe('overlapBounds', () => {
+  it('returns the intersection box for overlapping boxes', () => {
+    expect(overlapBounds(UNIT, box(0.5, 0.25, -1, 3, 0.75, 2))).toEqual(
+      box(0.5, 0.25, 0, 1, 0.75, 1),
+    );
+  });
+
+  it('degenerates a touching axis to the shared plane, not an inverted box', () => {
+    const r = overlapBounds(UNIT, box(1, 0, 0, 2, 1, 1));
+    expect(r.min[0]).toBe(1);
+    expect(r.max[0]).toBe(1);
+  });
+
+  it('never produces an inverted (min > max) box for disjoint inputs', () => {
+    const r = overlapBounds(UNIT, box(5, 5, 5, 6, 6, 6));
+    for (let i = 0; i < 3; i += 1) expect(r.min[i]).toBeLessThanOrEqual(r.max[i]);
+  });
+});
+
+describe('inflate / center / boundsOfPoints', () => {
+  it('grows the box by the margin on every side', () => {
+    expect(inflate(UNIT, 0.5)).toEqual(box(-0.5, -0.5, -0.5, 1.5, 1.5, 1.5));
+  });
+
+  it('shrinks on a negative margin', () => {
+    expect(inflate(UNIT, -0.25)).toEqual(box(0.25, 0.25, 0.25, 0.75, 0.75, 0.75));
+  });
+
+  it('computes the centre of an asymmetric, partly negative box', () => {
+    expect(center(box(-4, 0, 2, -2, 4, 8))).toEqual([-3, 2, 5]);
+  });
+
+  it('encloses two points regardless of their order', () => {
+    const a: Vec3 = [3, -1, 7];
+    const b: Vec3 = [-2, 5, 0];
+    expect(boundsOfPoints(a, b)).toEqual(box(-2, -1, 0, 3, 5, 7));
+    expect(boundsOfPoints(b, a)).toEqual(boundsOfPoints(a, b));
+  });
+});
+
+describe('fromPositions', () => {
+  it('bounds a packed position buffer', () => {
+    const p = new Float32Array([0, 0, 0, 2, -1, 5, -3, 4, 1]);
+    expect(fromPositions(p)).toEqual(box(-3, -1, 0, 2, 4, 5));
+  });
+
+  it('returns a degenerate origin box for an empty buffer, not ±Infinity', () => {
+    expect(fromPositions(new Float32Array(0))).toEqual(box(0, 0, 0, 0, 0, 0));
+    // A buffer too short for a single vertex is treated the same way.
+    expect(fromPositions(new Float32Array([1, 2]))).toEqual(box(0, 0, 0, 0, 0, 0));
+  });
+
+  it('ignores a trailing partial vertex instead of poisoning the box with NaN', () => {
+    const p = new Float32Array([0, 0, 0, 1, 1, 1, 9, 9]); // 8 floats: last vertex is short
+    const r = fromPositions(p);
+    expect(r).toEqual(box(0, 0, 0, 1, 1, 1));
+    expect(r.min.every(Number.isFinite)).toBe(true);
+    expect(r.max.every(Number.isFinite)).toBe(true);
+  });
+
+  it('applies a column-major transform to every vertex', () => {
+    // Translate by (10, 20, 30).
+    const t: Mat4 = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 10, 20, 30, 1];
+    const p = new Float32Array([0, 0, 0, 1, 2, 3]);
+    expect(fromPositions(p, t)).toEqual(box(10, 20, 30, 11, 22, 33));
+  });
+
+  it('reads the transform column-major — a rotation is not confused with its transpose', () => {
+    // 90° about +z, column-major: maps (1,0,0) -> (0,1,0). The transpose would
+    // map it to (0,-1,0), so this fixture cannot pass under both conventions.
+    const t: Mat4 = [0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+    const p = new Float32Array([0, 0, 0, 1, 0, 0]);
+    const r = fromPositions(p, t);
+    expect(r.min[1]).toBeCloseTo(0, 6);
+    expect(r.max[1]).toBeCloseTo(1, 6);
+    expect(r.max[0]).toBeCloseTo(0, 6);
+  });
+});

--- a/packages/spatial/package.json
+++ b/packages/spatial/package.json
@@ -14,13 +14,15 @@
   },
   "scripts": {
     "build": "pnpm exec tsc",
-    "dev": "pnpm exec tsc --watch"
+    "dev": "pnpm exec tsc --watch",
+    "test": "vitest run"
   },
   "dependencies": {
     "@ifc-lite/geometry": "workspace:^"
   },
   "devDependencies": {
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.10"
   },
   "license": "MPL-2.0",
   "author": "Louis True",

--- a/packages/spatial/src/aabb.test.ts
+++ b/packages/spatial/src/aabb.test.ts
@@ -1,0 +1,124 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, it } from 'vitest';
+import { AABBUtils, type AABB } from './aabb.js';
+
+function box(
+  minX: number, minY: number, minZ: number,
+  maxX: number, maxY: number, maxZ: number,
+): AABB {
+  return { min: [minX, minY, minZ], max: [maxX, maxY, maxZ] };
+}
+
+describe('AABBUtils.intersects', () => {
+  it('is inclusive at an exact face touch on EVERY axis', () => {
+    const unit = box(0, 0, 0, 1, 1, 1);
+    // One neighbour per axis, sharing exactly one face plane. Each is asserted
+    // separately so a single-axis regression cannot hide behind the others.
+    expect(AABBUtils.intersects(unit, box(1, 0, 0, 2, 1, 1))).toBe(true); // +x
+    expect(AABBUtils.intersects(unit, box(-1, 0, 0, 0, 1, 1))).toBe(true); // -x
+    expect(AABBUtils.intersects(unit, box(0, 1, 0, 1, 2, 1))).toBe(true); // +y
+    expect(AABBUtils.intersects(unit, box(0, -1, 0, 1, 0, 1))).toBe(true); // -y
+    expect(AABBUtils.intersects(unit, box(0, 0, 1, 1, 1, 2))).toBe(true); // +z
+    expect(AABBUtils.intersects(unit, box(0, 0, -1, 1, 1, 0))).toBe(true); // -z
+  });
+
+  it('separates on any single axis even when the other two overlap', () => {
+    const unit = box(0, 0, 0, 1, 1, 1);
+    // A hair past the touching plane on exactly one axis.
+    expect(AABBUtils.intersects(unit, box(1.0001, 0, 0, 2, 1, 1))).toBe(false);
+    expect(AABBUtils.intersects(unit, box(0, 1.0001, 0, 1, 2, 1))).toBe(false);
+    expect(AABBUtils.intersects(unit, box(0, 0, 1.0001, 1, 1, 2))).toBe(false);
+  });
+
+  it('is symmetric — a∩b and b∩a agree for touching, overlapping and disjoint', () => {
+    const cases: Array<[AABB, AABB]> = [
+      [box(0, 0, 0, 1, 1, 1), box(1, 0, 0, 2, 1, 1)],
+      [box(0, 0, 0, 1, 1, 1), box(0.5, 0.5, 0.5, 3, 3, 3)],
+      [box(0, 0, 0, 1, 1, 1), box(5, 5, 5, 6, 6, 6)],
+      [box(-4, -4, -4, -3, -3, -3), box(-3, -4, -4, -2, -3, -3)],
+    ];
+    for (const [a, b] of cases) {
+      expect(AABBUtils.intersects(a, b)).toBe(AABBUtils.intersects(b, a));
+    }
+  });
+
+  it('handles fully negative coordinates', () => {
+    expect(AABBUtils.intersects(box(-10, -10, -10, -5, -5, -5), box(-6, -6, -6, -1, -1, -1))).toBe(true);
+    expect(AABBUtils.intersects(box(-10, -10, -10, -5, -5, -5), box(-4, -4, -4, -1, -1, -1))).toBe(false);
+  });
+
+  it('treats a zero-volume (degenerate) box as intersecting when it lies on the surface', () => {
+    const unit = box(0, 0, 0, 1, 1, 1);
+    const plane = box(1, 0, 0, 1, 1, 1); // zero extent on x, sitting on the +x face
+    expect(AABBUtils.intersects(unit, plane)).toBe(true);
+    const point = box(0.5, 0.5, 0.5, 0.5, 0.5, 0.5);
+    expect(AABBUtils.intersects(unit, point)).toBe(true);
+  });
+});
+
+describe('AABBUtils.contains (point in box)', () => {
+  it('is inclusive on both the min and the max face of every axis', () => {
+    const unit = box(0, 0, 0, 1, 1, 1);
+    expect(AABBUtils.contains(unit, [0, 0.5, 0.5])).toBe(true);
+    expect(AABBUtils.contains(unit, [1, 0.5, 0.5])).toBe(true);
+    expect(AABBUtils.contains(unit, [0.5, 0, 0.5])).toBe(true);
+    expect(AABBUtils.contains(unit, [0.5, 1, 0.5])).toBe(true);
+    expect(AABBUtils.contains(unit, [0.5, 0.5, 0])).toBe(true);
+    expect(AABBUtils.contains(unit, [0.5, 0.5, 1])).toBe(true);
+    // Corners are in.
+    expect(AABBUtils.contains(unit, [0, 0, 0])).toBe(true);
+    expect(AABBUtils.contains(unit, [1, 1, 1])).toBe(true);
+  });
+
+  it('rejects a point just outside on each axis', () => {
+    const unit = box(0, 0, 0, 1, 1, 1);
+    expect(AABBUtils.contains(unit, [-0.0001, 0.5, 0.5])).toBe(false);
+    expect(AABBUtils.contains(unit, [1.0001, 0.5, 0.5])).toBe(false);
+    expect(AABBUtils.contains(unit, [0.5, -0.0001, 0.5])).toBe(false);
+    expect(AABBUtils.contains(unit, [0.5, 1.0001, 0.5])).toBe(false);
+    expect(AABBUtils.contains(unit, [0.5, 0.5, -0.0001])).toBe(false);
+    expect(AABBUtils.contains(unit, [0.5, 0.5, 1.0001])).toBe(false);
+  });
+
+  it('works with negative coordinates', () => {
+    const b = box(-3, -3, -3, -1, -1, -1);
+    expect(AABBUtils.contains(b, [-2, -2, -2])).toBe(true);
+    expect(AABBUtils.contains(b, [0, -2, -2])).toBe(false);
+  });
+});
+
+describe('AABBUtils.union / center / size / surfaceArea', () => {
+  it('unions disjoint boxes into the enclosing box', () => {
+    expect(AABBUtils.union(box(0, 0, 0, 1, 1, 1), box(4, -2, 3, 5, -1, 7))).toEqual(
+      box(0, -2, 0, 5, 1, 7),
+    );
+  });
+
+  it('union is idempotent and absorbs a contained box', () => {
+    const outer = box(-1, -1, -1, 4, 4, 4);
+    expect(AABBUtils.union(outer, outer)).toEqual(outer);
+    expect(AABBUtils.union(outer, box(0, 0, 0, 1, 1, 1))).toEqual(outer);
+  });
+
+  it('computes the centre for asymmetric and negative boxes', () => {
+    expect(AABBUtils.center(box(0, 0, 0, 2, 4, 6))).toEqual([1, 2, 3]);
+    expect(AABBUtils.center(box(-4, -4, -4, -2, 0, 4))).toEqual([-3, -2, 0]);
+  });
+
+  it('computes per-axis size, distinguishing the axes', () => {
+    // Deliberately unequal extents: a cube would pass even with axes swapped.
+    expect(AABBUtils.size(box(0, 0, 0, 2, 5, 11))).toEqual([2, 5, 11]);
+  });
+
+  it('computes surface area of a non-cubic box', () => {
+    // 2*(w*h + w*d + h*d) = 2*(2*3 + 2*4 + 3*4) = 2*26 = 52
+    expect(AABBUtils.surfaceArea(box(0, 0, 0, 2, 3, 4))).toBe(52);
+    // A flat (zero-thickness) box still has two faces of area w*h.
+    expect(AABBUtils.surfaceArea(box(0, 0, 0, 2, 3, 0))).toBe(12);
+    // A degenerate point has zero area.
+    expect(AABBUtils.surfaceArea(box(1, 1, 1, 1, 1, 1))).toBe(0);
+  });
+});

--- a/packages/spatial/src/bvh.test.ts
+++ b/packages/spatial/src/bvh.test.ts
@@ -1,0 +1,251 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, it } from 'vitest';
+import { BVH, type MeshWithBounds } from './bvh.js';
+import type { AABB } from './aabb.js';
+import { FrustumUtils, type Frustum } from './frustum.js';
+
+function box(
+  minX: number, minY: number, minZ: number,
+  maxX: number, maxY: number, maxZ: number,
+): AABB {
+  return { min: [minX, minY, minZ], max: [maxX, maxY, maxZ] };
+}
+
+/** Unit cube centred on `c`, tagged with `expressId`. */
+function cube(expressId: number, c: [number, number, number], half = 0.5): MeshWithBounds {
+  return {
+    expressId,
+    bounds: box(c[0] - half, c[1] - half, c[2] - half, c[0] + half, c[1] + half, c[2] + half),
+  };
+}
+
+/** A row of `n` unit cubes marching along +x, one per integer step. */
+function row(n: number, axis: 0 | 1 | 2 = 0): MeshWithBounds[] {
+  return Array.from({ length: n }, (_, i) => {
+    const c: [number, number, number] = [0, 0, 0];
+    c[axis] = i * 10;
+    return cube(100 + i, c);
+  });
+}
+
+describe('BVH.build', () => {
+  it('returns an empty index for no meshes without throwing', () => {
+    const bvh = BVH.build([]);
+    expect(bvh.queryAABB(box(-1e6, -1e6, -1e6, 1e6, 1e6, 1e6))).toEqual([]);
+    expect(bvh.raycast([0, 0, 0], [1, 0, 0])).toEqual([]);
+    expect(bvh.queryFrustum({ planes: [] })).toEqual([]);
+  });
+
+  it('indexes a single mesh (the leaf-only path)', () => {
+    const bvh = BVH.build([cube(7, [0, 0, 0])]);
+    expect(bvh.queryAABB(box(-1, -1, -1, 1, 1, 1))).toEqual([7]);
+    expect(bvh.queryAABB(box(50, 50, 50, 51, 51, 51))).toEqual([]);
+  });
+});
+
+describe('BVH.queryAABB', () => {
+  it('returns only the meshes actually overlapping the query box', () => {
+    // 20 cubes spread along x at 0,10,20,... — deep enough to force several
+    // levels of internal nodes, so the recursion (not just the leaf scan) runs.
+    const bvh = BVH.build(row(20));
+    // Covers the cubes centred at 30 and 40 only.
+    const hits = bvh.queryAABB(box(29, -1, -1, 41, 1, 1)).sort((a, b) => a - b);
+    expect(hits).toEqual([103, 104]);
+  });
+
+  it('is inclusive at an exact face touch', () => {
+    const bvh = BVH.build([cube(1, [0, 0, 0])]); // spans -0.5..0.5
+    expect(bvh.queryAABB(box(0.5, 0, 0, 1, 0, 0))).toEqual([1]);
+    expect(bvh.queryAABB(box(0.5001, 0, 0, 1, 0, 0))).toEqual([]);
+  });
+
+  it('finds every mesh when the query box covers the whole scene', () => {
+    const meshes = row(20);
+    const bvh = BVH.build(meshes);
+    const hits = bvh.queryAABB(box(-100, -100, -100, 1000, 100, 100)).sort((a, b) => a - b);
+    expect(hits).toEqual(meshes.map((m) => m.expressId).sort((a, b) => a - b));
+  });
+
+  it('does not miss meshes when the extent is longest on y or z', () => {
+    // The split-axis choice picks the longest extent; a scene laid out on x
+    // only would never exercise the y/z branches.
+    for (const axis of [1, 2] as const) {
+      const meshes = row(9, axis);
+      const bvh = BVH.build(meshes);
+      const q: AABB = box(-1, -1, -1, 1, 1, 1);
+      q.min[axis] = 29;
+      q.max[axis] = 41;
+      expect(bvh.queryAABB(q).sort((a, b) => a - b)).toEqual([103, 104]);
+    }
+  });
+
+  it('handles a scene entirely in negative space', () => {
+    const meshes = [cube(1, [-100, -100, -100]), cube(2, [-90, -100, -100]), cube(3, [-80, -100, -100])];
+    const bvh = BVH.build(meshes);
+    expect(bvh.queryAABB(box(-91, -101, -101, -89, -99, -99))).toEqual([2]);
+  });
+
+  it('reports every mesh at a coincident location (duplicate bounds)', () => {
+    const meshes = [cube(1, [0, 0, 0]), cube(2, [0, 0, 0]), cube(3, [0, 0, 0])];
+    const bvh = BVH.build(meshes);
+    expect(bvh.queryAABB(box(0, 0, 0, 0, 0, 0)).sort((a, b) => a - b)).toEqual([1, 2, 3]);
+  });
+});
+
+describe('BVH.raycast', () => {
+  it('hits meshes along the ray and skips the ones off-axis', () => {
+    const bvh = BVH.build([cube(1, [10, 0, 0]), cube(2, [20, 0, 0]), cube(3, [30, 50, 0])]);
+    expect(bvh.raycast([0, 0, 0], [1, 0, 0]).sort((a, b) => a - b)).toEqual([1, 2]);
+  });
+
+  it('does NOT report meshes behind the ray origin', () => {
+    // Cube at x = -10, ray fired towards +x from the origin. The slab test's
+    // `tmax >= 0` is the only thing that rejects it; without it every mesh on
+    // the infinite LINE would be reported and viewer picking would select an
+    // element behind the camera.
+    const bvh = BVH.build([cube(1, [-10, 0, 0]), cube(2, [10, 0, 0])]);
+    expect(bvh.raycast([0, 0, 0], [1, 0, 0])).toEqual([2]);
+    // Reversing the direction swaps which one is visible.
+    expect(bvh.raycast([0, 0, 0], [-1, 0, 0])).toEqual([1]);
+  });
+
+  it('handles an axis-parallel ray without NaN poisoning the slab test', () => {
+    // direction has two exact zeros: the parallel-slab guard must reject on the
+    // axes the ray does not advance along, instead of computing 0 * Infinity.
+    const bvh = BVH.build([cube(1, [0, 0, 30]), cube(2, [0, 40, 30])]);
+    // Ray along +z through x=0,y=0 — hits cube 1, misses cube 2 (y=40).
+    expect(bvh.raycast([0, 0, 0], [0, 0, 1])).toEqual([1]);
+    // Same ray offset in y so it misses everything.
+    expect(bvh.raycast([0, 20, 0], [0, 0, 1])).toEqual([]);
+  });
+
+  it('grazes a slab plane exactly, on an axis the ray does not advance along', () => {
+    // Cube 1 spans x,y ∈ [-0.5, 0.5]. The ray runs along +z with direction
+    // x = y = 0 and its origin sits EXACTLY on the x = -0.5 face plane. Without
+    // the parallel-slab guard the slab math evaluates (min.x - origin.x) * (1/0)
+    // = 0 * Infinity = NaN, every subsequent comparison is false, and the hit is
+    // silently DROPPED — a viewer click that grazes an element edge selects
+    // nothing. Both faces of both grazed axes are checked.
+    const bvh = BVH.build([cube(1, [0, 0, 30])]);
+    expect(bvh.raycast([-0.5, 0, 0], [0, 0, 1])).toEqual([1]);
+    expect(bvh.raycast([0.5, 0, 0], [0, 0, 1])).toEqual([1]);
+    expect(bvh.raycast([0, -0.5, 0], [0, 0, 1])).toEqual([1]);
+    expect(bvh.raycast([0, 0.5, 0], [0, 0, 1])).toEqual([1]);
+    // A hair outside the same face is still correctly a miss, so the test above
+    // cannot be satisfied by simply accepting every parallel ray.
+    expect(bvh.raycast([-0.5001, 0, 0], [0, 0, 1])).toEqual([]);
+  });
+
+  it('reports a hit when the ray starts inside a mesh', () => {
+    const bvh = BVH.build([cube(1, [0, 0, 0], 5)]);
+    expect(bvh.raycast([0, 0, 0], [1, 0, 0])).toEqual([1]);
+  });
+
+  it('normalizes the direction — magnitude does not change the hit set', () => {
+    const bvh = BVH.build([cube(1, [10, 0, 0]), cube(2, [20, 0, 0])]);
+    const unit = bvh.raycast([0, 0, 0], [1, 0, 0]).sort((a, b) => a - b);
+    const long = bvh.raycast([0, 0, 0], [1000, 0, 0]).sort((a, b) => a - b);
+    expect(long).toEqual(unit);
+  });
+});
+
+describe('BVH.queryFrustum', () => {
+  /** Axis-aligned "box frustum": six inward-facing planes bounding a cuboid. */
+  function boxFrustum(b: AABB): Frustum {
+    return {
+      planes: [
+        { normal: [1, 0, 0], distance: -b.min[0] },
+        { normal: [-1, 0, 0], distance: b.max[0] },
+        { normal: [0, 1, 0], distance: -b.min[1] },
+        { normal: [0, -1, 0], distance: b.max[1] },
+        { normal: [0, 0, 1], distance: -b.min[2] },
+        { normal: [0, 0, -1], distance: b.max[2] },
+      ],
+    };
+  }
+
+  it('returns only meshes inside the frustum volume', () => {
+    const bvh = BVH.build(row(20));
+    // Wide enough that the -0.5 m plane epsilon cannot reach the neighbours,
+    // which sit 10 m away.
+    const hits = bvh.queryFrustum(boxFrustum(box(25, -5, -5, 45, 5, 5))).sort((a, b) => a - b);
+    expect(hits).toEqual([103, 104]);
+  });
+
+  it('culls everything when the frustum is far from the scene', () => {
+    const bvh = BVH.build(row(20));
+    expect(bvh.queryFrustum(boxFrustum(box(1000, 1000, 1000, 1100, 1100, 1100)))).toEqual([]);
+  });
+
+  it('keeps a batch just outside the frustum edge (the anti-flicker margin)', () => {
+    // Cube spans -0.5..0.5, so its positive vertex on +x is 0.5. The frustum's
+    // left plane cuts at x = 0.7, putting that vertex 0.2 m BEHIND the plane —
+    // strictly outside. FrustumUtils tolerates up to 0.5 m of overshoot so a
+    // batch grazing the edge does not pop in and out while orbiting; with a
+    // zero margin this batch would be culled and flicker.
+    const bvh = BVH.build([cube(1, [0, 0, 0])]);
+    expect(bvh.queryFrustum(boxFrustum(box(0.7, -5, -5, 10, 5, 5)))).toEqual([1]);
+    // Beyond the margin it IS culled — so the assertion above is not satisfied
+    // by a "keep everything" frustum test.
+    expect(bvh.queryFrustum(boxFrustum(box(1.1, -5, -5, 10, 5, 5)))).toEqual([]);
+  });
+});
+
+describe('FrustumUtils', () => {
+  it('normalizes planes extracted from a view-projection matrix', () => {
+    // Simple orthographic-ish matrix; the only invariant asserted here is that
+    // every extracted plane normal is unit length after normalization.
+    const m = [
+      2, 0, 0, 0,
+      0, 2, 0, 0,
+      0, 0, 1, 0,
+      0, 0, 0, 1,
+    ];
+    const f = FrustumUtils.fromViewProjMatrix(m);
+    expect(f.planes).toHaveLength(6);
+    for (const p of f.planes) {
+      const len = Math.hypot(p.normal[0], p.normal[1], p.normal[2]);
+      expect(len).toBeCloseTo(1, 10);
+    }
+  });
+
+  it('leaves a degenerate zero-length plane normal untouched instead of producing NaN', () => {
+    const m = new Array(16).fill(0);
+    const f = FrustumUtils.fromViewProjMatrix(m);
+    for (const p of f.planes) {
+      expect(p.normal.every(Number.isFinite)).toBe(true);
+      expect(Number.isFinite(p.distance)).toBe(true);
+    }
+  });
+
+  it('uses the positive vertex — a box is kept while ANY corner is inside', () => {
+    const b = box(-1, -1, -1, 1, 1, 1);
+    // Plane facing +x, cutting at x = 0.9: the box's +x corner (x = 1) is in
+    // front of it, so the box must survive. Testing the min corner instead
+    // (or the centre) would wrongly cull it.
+    const f: Frustum = { planes: [{ normal: [1, 0, 0], distance: -0.9 }] };
+    expect(FrustumUtils.isAABBVisible(f, b)).toBe(true);
+    // Move the plane past the far corner by more than the 0.5 m margin.
+    const far: Frustum = { planes: [{ normal: [1, 0, 0], distance: -1.6 }] };
+    expect(FrustumUtils.isAABBVisible(far, b)).toBe(false);
+  });
+
+  it('keeps an AABB up to half a metre behind the plane, and no further', () => {
+    const b = box(-1, -1, -1, 1, 1, 1); // positive vertex on +x is 1
+    // Plane at x = 1.4 → positive vertex 0.4 m behind it: within the margin.
+    expect(FrustumUtils.isAABBVisible({ planes: [{ normal: [1, 0, 0], distance: -1.4 }] }, b)).toBe(true);
+    // Plane at x = 1.6 → 0.6 m behind: past the margin, culled.
+    expect(FrustumUtils.isAABBVisible({ planes: [{ normal: [1, 0, 0], distance: -1.6 }] }, b)).toBe(false);
+  });
+
+  it('applies the same positive-vertex rule for a negative-facing normal', () => {
+    const b = box(-1, -1, -1, 1, 1, 1);
+    const f: Frustum = { planes: [{ normal: [-1, 0, 0], distance: -0.9 }] };
+    expect(FrustumUtils.isAABBVisible(f, b)).toBe(true);
+    const far: Frustum = { planes: [{ normal: [-1, 0, 0], distance: -1.6 }] };
+    expect(FrustumUtils.isAABBVisible(far, b)).toBe(false);
+  });
+});

--- a/packages/spatial/src/spatial-index-builder.test.ts
+++ b/packages/spatial/src/spatial-index-builder.test.ts
@@ -1,0 +1,126 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, it } from 'vitest';
+import type { MeshData } from '@ifc-lite/geometry';
+import { buildSpatialIndex, buildSpatialIndexAsync } from './spatial-index-builder.js';
+import type { AABB } from './aabb.js';
+
+function box(
+  minX: number, minY: number, minZ: number,
+  maxX: number, maxY: number, maxZ: number,
+): AABB {
+  return { min: [minX, minY, minZ], max: [maxX, maxY, maxZ] };
+}
+
+/** Minimal MeshData: an axis-aligned cube of `size` around `center`, local frame. */
+function mesh(
+  expressId: number,
+  center: [number, number, number],
+  size = 1,
+  origin?: [number, number, number],
+): MeshData {
+  const h = size / 2;
+  const [cx, cy, cz] = center;
+  const positions = new Float32Array([
+    cx - h, cy - h, cz - h,
+    cx + h, cy - h, cz - h,
+    cx + h, cy + h, cz + h,
+    cx - h, cy + h, cz + h,
+  ]);
+  const m: MeshData = {
+    expressId,
+    positions,
+    normals: new Float32Array(positions.length),
+    indices: new Uint32Array([0, 1, 2, 0, 2, 3]),
+    color: [1, 1, 1, 1],
+  };
+  if (origin) m.origin = origin;
+  return m;
+}
+
+describe('buildSpatialIndex', () => {
+  it('indexes meshes by their world-space bounds', () => {
+    const bvh = buildSpatialIndex([mesh(1, [0, 0, 0]), mesh(2, [10, 0, 0])]);
+    expect(bvh.queryAABB(box(-1, -1, -1, 1, 1, 1))).toEqual([1]);
+    expect(bvh.queryAABB(box(9, -1, -1, 11, 1, 1))).toEqual([2]);
+  });
+
+  it('lifts local positions by the per-mesh origin into world space', () => {
+    // Positions are LOCAL (centred on 0); the element actually sits at
+    // (100, 0, 0). Without the origin lift the index answers queries about the
+    // model origin instead of where the element is — every clash broad-phase
+    // candidate and every viewer pick on an origin-offset model is then wrong.
+    const bvh = buildSpatialIndex([mesh(42, [0, 0, 0], 2, [100, 0, 0])]);
+    expect(bvh.queryAABB(box(99, -1, -1, 101, 1, 1))).toEqual([42]);
+    expect(bvh.queryAABB(box(-1, -1, -1, 1, 1, 1))).toEqual([]);
+  });
+
+  it('applies the origin lift per axis, not just on x', () => {
+    const bvh = buildSpatialIndex([mesh(7, [0, 0, 0], 2, [0, -50, 25])]);
+    expect(bvh.queryAABB(box(-1, -51, 24, 1, -49, 26))).toEqual([7]);
+    // A query at the mirrored offsets must NOT hit: proves y and z are lifted
+    // with the right sign, not merely by the same magnitude.
+    expect(bvh.queryAABB(box(-1, 49, -26, 1, 51, -24))).toEqual([]);
+  });
+
+  it('treats an absent origin as no offset', () => {
+    const bvh = buildSpatialIndex([mesh(3, [5, 5, 5], 2)]);
+    expect(bvh.queryAABB(box(4, 4, 4, 6, 6, 6))).toEqual([3]);
+  });
+
+  it('gives an empty mesh a degenerate box at the model origin, not Infinity', () => {
+    const empty: MeshData = {
+      expressId: 9,
+      positions: new Float32Array(0),
+      normals: new Float32Array(0),
+      indices: new Uint32Array(0),
+      color: [1, 1, 1, 1],
+    };
+    const bvh = buildSpatialIndex([empty]);
+    // A degenerate [0,0,0] box: found at the origin, and — crucially — NOT
+    // found everywhere, which is what an un-initialised ±Infinity box does.
+    expect(bvh.queryAABB(box(0, 0, 0, 0, 0, 0))).toEqual([9]);
+    expect(bvh.queryAABB(box(1000, 1000, 1000, 1001, 1001, 1001))).toEqual([]);
+  });
+
+  it('returns a queryable empty index for no meshes', () => {
+    expect(buildSpatialIndex([]).queryAABB(box(-1e9, -1e9, -1e9, 1e9, 1e9, 1e9))).toEqual([]);
+  });
+});
+
+describe('buildSpatialIndexAsync', () => {
+  it('produces the same index as the synchronous builder', async () => {
+    const meshes = Array.from({ length: 40 }, (_, i) => mesh(i + 1, [i * 5, 0, 0], 1));
+    const sync = buildSpatialIndex(meshes);
+    const async_ = await buildSpatialIndexAsync(meshes);
+    const q = box(-1, -1, -1, 21, 1, 1);
+    expect(async_.queryAABB(q).sort((a, b) => a - b)).toEqual(sync.queryAABB(q).sort((a, b) => a - b));
+  });
+
+  it('indexes EVERY mesh when the workload spans several time slices', async () => {
+    // budgetMs = 0 forces a yield at every 500-mesh checkpoint, exercising the
+    // chunk-resume path. A resume bug (restarting or skipping a chunk) shows up
+    // as a missing or duplicated expressId.
+    const meshes = Array.from({ length: 1200 }, (_, i) => mesh(i + 1, [i, 0, 0], 0.5));
+    const bvh = await buildSpatialIndexAsync(meshes, 0);
+    const all = bvh.queryAABB(box(-10, -10, -10, 2000, 10, 10));
+    expect(all).toHaveLength(1200);
+    expect(new Set(all).size).toBe(1200);
+    // Spot-check the boundaries of the 500-mesh chunks.
+    expect(bvh.queryAABB(box(499.6, -1, -1, 500.4, 1, 1))).toEqual([501]);
+    expect(bvh.queryAABB(box(999.6, -1, -1, 1000.4, 1, 1))).toEqual([1001]);
+  });
+
+  it('carries the origin lift through the async path too', async () => {
+    const bvh = await buildSpatialIndexAsync([mesh(42, [0, 0, 0], 2, [100, 0, 0])], 0);
+    expect(bvh.queryAABB(box(99, -1, -1, 101, 1, 1))).toEqual([42]);
+    expect(bvh.queryAABB(box(-1, -1, -1, 1, 1, 1))).toEqual([]);
+  });
+
+  it('returns a queryable empty index for no meshes', async () => {
+    const bvh = await buildSpatialIndexAsync([]);
+    expect(bvh.queryAABB(box(-1e9, -1e9, -1e9, 1e9, 1e9, 1e9))).toEqual([]);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1371,6 +1371,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@26.1.2)(happy-dom@20.11.1)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/viewer:
     dependencies:


### PR DESCRIPTION
## Why

A repo-wide vacuous-coverage sweep has now covered ~28 packages plus the Rust crates. `packages/clash` and `packages/spatial` had not been swept. Both are geometry/maths-heavy, where a wrong answer is silent and confident rather than an error — a missed clash or a wrong containment looks exactly like a correct empty result.

**20 mutations were applied across the two packages; 6 were already killed by the existing suites, 11 survived as genuine gaps, and 3 are provable equivalent mutants.** Every mutation was applied by exact-substring replacement asserting a replacement count of 1, and the mutated region was re-read before the result was believed. Two controls (below) prove the harness ran against mutated source.

## Baseline

| package | before | after |
|---|---|---|
| `@ifc-lite/clash` | 17 files / 140 tests | 19 files / **176 tests** |
| `@ifc-lite/spatial` | **0 files / 0 tests / no `test` script** | 3 files / **45 tests** |

No pre-existing failures.

### `@ifc-lite/spatial` was not in CI at all

The package has no test files and no `test` script, so `turbo test` skipped it. Four modules of load-bearing geometry — `AABBUtils`, `BVH` (AABB query, raycast, frustum query), `FrustumUtils`, and the spatial index builder — ran unverified. It is consumed by `@ifc-lite/clash` (broad phase, per-element triangle BVH), `@ifc-lite/renderer`, `@ifc-lite/query` and the viewer.

## Mutation table

Controls are marked ✱ — both were expected to be killed and were, proving the suite genuinely ran against mutated source (including the Plato-generated file, which is otherwise easy to mutate into nothing).

| # | file | mutation | n | result |
|---|---|---|---|---|
| M1 ✱ | `clash/engine-ts/broad.ts` | `inflate(b.bounds, margin)` → `inflate(b.bounds, 0)` | 1 | **KILLED** — `engine.test.ts › finds a clearance violation within the gap` |
| M2 | `clash/engine-ts/broad.ts` | `if (j <= i) continue` → `j < i` | 1 | SURVIVED — **equivalent** |
| M3 | `clash/engine-ts/broad.ts` | drop same-entity skip in the group-pair branch | 1 | SURVIVED — **equivalent** |
| M4 | `clash/engine-ts/narrow.ts` | touch band `minDist <= tolerance` → `<` | 1 | **KILLED** — `regression.test.ts › catches an exact touch when tolerance is 0` |
| M5 | `clash/engine-ts/narrow.ts` | `minDist <= rule.clearance` → `<` | 1 | SURVIVED — **gap** |
| M6 | `clash/engine-ts/narrow.ts` | `gap < -tolerance` → `<=` | 1 | SURVIVED — **gap** |
| M7 | `clash/engine-ts/narrow.ts` | drop the reciprocal `large.maxPenetrationInto(small, …)` term | 1 | SURVIVED — **gap** |
| M8 | `clash/engine-ts/narrow.ts` | drop the `Math.max(0, …)` penetration clamp | 1 | SURVIVED — **equivalent** |
| M9 | `clash/engine-ts/ts-kernel.ts` | `processed >= maxPairs` → `>` | 1 | SURVIVED — **gap** |
| M10 | `clash/engine-ts/ts-kernel.ts` | `candidatesDropped = total - processed` → `= 0` | 1 | SURVIVED — **gap** |
| M11 ✱ | `clash/math/generated/plato.g.ts` | `aabbContains` → always `false` | 1 | **KILLED** — 6 tests (`#1866` pair + differential) |
| M12 | `clash/math/generated/plato.g.ts` | `intersects` `a.min[0] <= b.max[0]` → `<` | 1 | SURVIVED — **gap** |
| M13 | `clash/math/generated/plato.g.ts` | `aabbContains` `outer.min[0] <= inner.min[0]` → `<` | 1 | SURVIVED — **gap** |
| M14 | `clash/analysis.ts` | `isTouching` `penetrationDepth(c) <= eps` → `<` | 1 | SURVIVED — **gap** |
| M15 | `clash/duplicates.ts` | `sim < iouThreshold` → `<=` | 1 | SURVIVED — **gap** |
| M16 | `spatial/aabb.ts` | `intersects` `a.min[0] <= b.max[0]` → `<` | 1 | KILLED *incidentally* by `clash/regression.test.ts` (cross-package, via `dist`); spatial's own suite did not exist |
| M17 | `spatial/aabb.ts` | `contains` `point[0] >= aabb.min[0]` → `>` | 1 | SURVIVED — **gap** |
| M18 | `spatial/frustum.ts` | `PLANE_EPSILON = -0.5` → `0` | 1 | SURVIVED — **gap** |
| M19 | `spatial/bvh.ts` | `return tmax >= 0` → `return true` | 1 | SURVIVED — **gap** |
| M20 | `spatial/bvh.ts` | remove the `direction[i] === 0` parallel-slab guard | 1 | SURVIVED — **gap** |
| M21 | `spatial/spatial-index-builder.ts` | drop the per-mesh `origin` lift | 1 | SURVIVED — **gap** |

(21 rows: M16 is listed separately from the clash-side kill it produced. **Kill ratio before this PR: 6 / 20 mutations killed, 3 of the 14 survivors provably equivalent → 11 genuine gaps.** All 11 are killed by this PR.)

Spatial mutations were rebuilt (`pnpm exec tsc`) and re-run against the clash suite before the spatial suite existed, so "SURVIVED" there means *no suite in the repo caught it*, not merely "spatial has no tests".

## Survivors → what a user would have seen

**Clearance limit is exclusive (M5).** A `clearance` rule with a gap *exactly* equal to the requirement reported no violation. `<=` is the documented contract and is what `rust/clash/src/narrow.rs:294` implements, so this is also a TS↔WASM differential contract with nothing pinning it.
→ `boundaries.test.ts › reports a gap EXACTLY equal to the required clearance` (fixture chosen so the gap is exact in f32), plus a just-beyond-the-limit negative so the test cannot pass by over-reporting.

**Overlap exactly equal to tolerance (M6).** Two elements overlapping by precisely the modelling tolerance were promoted from contact to a hard clash. Mirrors `narrow.rs:268`.
→ `boundaries.test.ts › suppresses two boxes whose AABBs penetrate by exactly the tolerance`, with a recall companion that the pair *is* reported once the overlap passes tolerance.

**Contained-pair depth measured one way only (M7).** `#1866`'s fix takes the max of both mesh-into-mesh depths; only one direction was exercised. The fixture (concave L-prism, 20 tris, vs a face-fanned box, 24 tris — the triangle counts decide which mesh is "small") makes the small→large term 0 and the large→small term the real answer. Dropping the reciprocal falls back to the AABB proxy and **triples** the reported depth (0.6 m vs the true 0.2 m) — exactly the over-report `#1866` was filed for.
→ `boundaries.test.ts › uses the deeper of the two mesh-level measurements`.

**`maxCandidatePairs` had no coverage at all (M9, M10).** With `candidatesDropped` forced to 0 the whole suite stayed green: a run that stopped early reports `truncated: undefined`, so a partial clash list reads to the caller as *"the model is clean."* This is the highest-severity survivor here. The off-by-one (M9) separately means the cap is not the cap the caller asked for.
→ Four tests: no cap → no truncation; cap 2 → exactly 2 clashes and `{ reason: 'maxCandidatePairs', droppedPairs: 4 }`; cap 0 → truncation still flagged; and the documented *global* (not per-rule) budget across two rules.

**Box-kernel touching boundaries (M12, M13).** The Plato-generated `intersects` / `aabbContains` are the single source transpiled to `rust/clash/src/generated/plato.rs`; their `<=`/`>=` choices are a cross-language contract. `aabbContains`'s boundary was only reachable through end-to-end fixtures.
→ New `clash/src/math/aabb.test.ts`: per-axis touching, single-axis separation, symmetry of `intersects`/`signedGap`, *asymmetry* of `aabbContains`, `signedGap` as min-axis overlap, non-inverted `overlapBounds`, and `fromPositions` on empty / ragged buffers and under a column-major transform (with a rotation fixture that fails under the transpose).

**`isTouching` at exactly the band edge (M14).** A coincident face reported at precisely `TOUCHING_EPSILON` was re-labelled a genuine overlap — the false-positive class `#1273` removed.
→ two tests appended to the existing `analysis.test.ts`.

**Duplicate IoU at exactly the threshold (M15).** A pair whose IoU is exactly the configured `iouThreshold` was dropped. Fixture uses `[0,1]³` vs `[0,1]²×[0,2]` → IoU exactly 0.5, no rounding.
→ test appended to `duplicates.test.ts`, with a just-above-threshold negative.

**Spatial, all five (M17, M18, M19, M20, M21):**
- `AABBUtils.contains` was inclusive-by-accident on the min faces — a point on an element's boundary.
- `PLANE_EPSILON = -0.5` is the anti-flicker margin; without it batches grazing the frustum edge pop in and out while orbiting.
- `return tmax >= 0` is the only thing rejecting geometry **behind** the ray origin — without it viewer picking selects an element behind the camera.
- The `direction[i] === 0` guard: a ray whose origin sits exactly on a slab plane computes `0 * Infinity = NaN`, every comparison goes false, and the hit is **silently dropped** — a click grazing an element edge selects nothing. (My first attempt at this test passed under the mutant; the fixture now places the origin exactly on the face plane, which is the only way to reach the NaN.)
- The per-mesh `origin` lift is what makes the index world-space. Drop it and every query on an origin-offset model — clash broad phase and viewer picking alike — answers about the model origin instead.

→ `spatial/src/aabb.test.ts`, `bvh.test.ts`, `spatial-index-builder.test.ts` (45 tests), each with a negative companion so it cannot pass for the wrong reason.

## Equivalent mutants (proved, not assumed)

- **M2** `j <= i` → `j < i`: the only newly-admitted case is `j === i`, where `other === a`, so the immediately following `a.key === other.key && a.model === other.model` guard skips it unconditionally.
- **M3** dropping the same-entity skip in the group-pair branch: `orchestrator.ts` re-applies the identical filter (`if (elA.key === elB.key && elA.model === elB.model) continue`) on every kernel's records, deliberately, so all backends behave alike. The broad-phase guard is a redundant early-out; removing it costs a wasted narrow-phase test and changes no output.
- **M8** dropping `Math.max(0, …)`: reached only when `intersects` is true, i.e. some triangle pair shares a point `p`. `p` lies in both meshes, and each element's `bounds` encloses its own mesh, so both AABBs contain `p` ⇒ `signedGap ≤ 0` ⇒ `penetration ≥ 0`. The clamp is dead under the package's own bounds invariant.

## Notes

- **Plato clash-math freshness lane:** `packages/clash/src/math/generated/plato.g.ts` was mutated during the sweep (M11–M13) and restored from a byte-for-byte backup copy — never `git checkout --`. **It is unmodified in this PR** (`git diff` touches no generated file and no `.plato` source), so the lane's `changes` filter should not even fire.
- Production code is unchanged except `packages/spatial/package.json` (`test` script + `vitest` devDependency), without which the spatial suite cannot run. `pnpm check:test-wiring` passes.
- `pnpm typecheck` passes at the repo root (34/34).
