### PR TITLE
test(embed): wire embed-protocol and embed-sdk into CI, 23 mutation-verified gaps

### DIFF
--- a/packages/embed-protocol/package.json
+++ b/packages/embed-protocol/package.json
@@ -14,10 +14,12 @@
   },
   "scripts": {
     "build": "pnpm exec tsc",
-    "dev": "pnpm exec tsc --watch"
+    "dev": "pnpm exec tsc --watch",
+    "test": "vitest run"
   },
   "devDependencies": {
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.10"
   },
   "license": "MPL-2.0",
   "repository": {

--- a/packages/embed-protocol/test/protocol.test.ts
+++ b/packages/embed-protocol/test/protocol.test.ts
@@ -1,0 +1,153 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect } from 'vitest';
+import {
+  EMBED_SOURCE,
+  PROTOCOL_VERSION,
+  createEvent,
+  createResponse,
+  createCommand,
+  isEmbedMessage,
+} from '../src/index.js';
+
+describe('protocol constants', () => {
+  // These two strings are the wire contract between the embed viewer and every
+  // published SDK version. Changing either silently breaks every deployed embed,
+  // so pin the literal values, not just their types.
+  it('pins the message discriminator', () => {
+    expect(EMBED_SOURCE).toBe('ifc-lite-embed');
+  });
+
+  it('pins the protocol version', () => {
+    expect(PROTOCOL_VERSION).toBe('1.0');
+  });
+});
+
+describe('createEvent', () => {
+  it('stamps source, version, type and data', () => {
+    const msg = createEvent('MODEL_LOADING', { progress: 0.5, phase: 'geometry' });
+    expect(msg).toEqual({
+      source: 'ifc-lite-embed',
+      version: '1.0',
+      type: 'MODEL_LOADING',
+      data: { progress: 0.5, phase: 'geometry' },
+    });
+  });
+
+  it('carries the exact type string it was given', () => {
+    expect(createEvent('READY', { version: '1.0' }).type).toBe('READY');
+    expect(createEvent('SECTION_CHANGED', { axis: 'down', position: 1, enabled: true }).type)
+      .toBe('SECTION_CHANGED');
+  });
+
+  it('leaves data undefined when omitted, and sets no requestId/responseId', () => {
+    const msg = createEvent('INIT_ACK');
+    expect(msg.data).toBeUndefined();
+    expect(msg.requestId).toBeUndefined();
+    expect(msg.responseId).toBeUndefined();
+  });
+
+  it('preserves the payload object identity (no cloning)', () => {
+    const data = { azimuth: 1, elevation: 2 };
+    expect(createEvent('CAMERA_CHANGED', data).data).toBe(data);
+  });
+});
+
+describe('createResponse', () => {
+  it('uses the RESPONSE type and echoes the responseId', () => {
+    const msg = createResponse('req-42', { dataUrl: 'data:,' });
+    expect(msg.type).toBe('RESPONSE');
+    expect(msg.responseId).toBe('req-42');
+    expect(msg.data).toEqual({ dataUrl: 'data:,' });
+    expect(msg.error).toBeUndefined();
+    // A response must never be mistaken for a request by the correlation logic.
+    expect(msg.requestId).toBeUndefined();
+  });
+
+  it('carries an error payload through unchanged', () => {
+    const err = { code: 'LOAD_FAILED', message: 'boom' };
+    const msg = createResponse('req-1', undefined, err);
+    expect(msg.error).toEqual(err);
+    expect(msg.data).toBeUndefined();
+  });
+
+  it('stamps source and version like every other envelope', () => {
+    const msg = createResponse('req-1');
+    expect(msg.source).toBe(EMBED_SOURCE);
+    expect(msg.version).toBe(PROTOCOL_VERSION);
+  });
+});
+
+describe('createCommand', () => {
+  it('stamps type, data and requestId', () => {
+    const msg = createCommand('LOAD_MODEL', { url: 'https://example.test/a.ifc' }, 'req-7');
+    expect(msg).toEqual({
+      source: 'ifc-lite-embed',
+      version: '1.0',
+      type: 'LOAD_MODEL',
+      requestId: 'req-7',
+      data: { url: 'https://example.test/a.ifc' },
+    });
+  });
+
+  it('omits requestId for fire-and-forget commands, and never sets responseId', () => {
+    const msg = createCommand('SHOW_ALL');
+    expect(msg.requestId).toBeUndefined();
+    expect(msg.responseId).toBeUndefined();
+    expect(msg.type).toBe('SHOW_ALL');
+  });
+});
+
+describe('isEmbedMessage', () => {
+  it('accepts an envelope carrying the embed discriminator', () => {
+    expect(isEmbedMessage({ source: EMBED_SOURCE, version: '1.0', type: 'READY' })).toBe(true);
+  });
+
+  it('accepts a bare object whose only field is the discriminator', () => {
+    expect(isEmbedMessage({ source: 'ifc-lite-embed' })).toBe(true);
+  });
+
+  it('rejects null and undefined', () => {
+    expect(isEmbedMessage(null)).toBe(false);
+    expect(isEmbedMessage(undefined)).toBe(false);
+  });
+
+  it('rejects non-objects', () => {
+    expect(isEmbedMessage('ifc-lite-embed')).toBe(false);
+    expect(isEmbedMessage(42)).toBe(false);
+    expect(isEmbedMessage(true)).toBe(false);
+  });
+
+  it('rejects an object with no source field', () => {
+    expect(isEmbedMessage({ type: 'READY' })).toBe(false);
+    expect(isEmbedMessage({})).toBe(false);
+  });
+
+  it('rejects a foreign source, including near-misses', () => {
+    expect(isEmbedMessage({ source: 'react-devtools-bridge' })).toBe(false);
+    expect(isEmbedMessage({ source: 'ifc-lite-embed-evil' })).toBe(false);
+    expect(isEmbedMessage({ source: 'IFC-LITE-EMBED' })).toBe(false);
+    expect(isEmbedMessage({ source: '' })).toBe(false);
+    expect(isEmbedMessage({ source: undefined })).toBe(false);
+  });
+
+  it('rejects an array, which is an object but never a valid envelope', () => {
+    expect(isEmbedMessage([])).toBe(false);
+    expect(isEmbedMessage(['ifc-lite-embed'])).toBe(false);
+  });
+
+  it('accepts a source inherited from the prototype chain', () => {
+    // `in` walks the prototype chain; this documents the current behaviour so a
+    // switch to a hasOwnProperty check is a deliberate, visible change.
+    const proto = { source: EMBED_SOURCE };
+    expect(isEmbedMessage(Object.create(proto))).toBe(true);
+  });
+
+  it('narrows the type so envelope fields are readable', () => {
+    const data: unknown = createEvent('READY', { version: '1.0' });
+    if (!isEmbedMessage(data)) throw new Error('expected an embed message');
+    expect(data.type).toBe('READY');
+  });
+});

--- a/packages/embed-protocol/vitest.config.ts
+++ b/packages/embed-protocol/vitest.config.ts
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+  },
+});

--- a/packages/embed-sdk/package.json
+++ b/packages/embed-sdk/package.json
@@ -14,13 +14,16 @@
   },
   "scripts": {
     "build": "pnpm exec tsc",
-    "dev": "pnpm exec tsc --watch"
+    "dev": "pnpm exec tsc --watch",
+    "test": "vitest run"
   },
   "dependencies": {
     "@ifc-lite/embed-protocol": "workspace:^"
   },
   "devDependencies": {
-    "typescript": "^6.0.3"
+    "happy-dom": "^20.11.1",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.10"
   },
   "license": "MPL-2.0",
   "repository": {

--- a/packages/embed-sdk/test/events-lifecycle.test.ts
+++ b/packages/embed-sdk/test/events-lifecycle.test.ts
@@ -1,0 +1,173 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { mount, type Harness } from './harness.js';
+import type { IFCLiteEmbed } from '../src/index.js';
+
+let h: Harness | undefined;
+afterEach(() => {
+  h?.cleanup();
+  h = undefined;
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+async function ready(): Promise<{ embed: IFCLiteEmbed; h: Harness }> {
+  const harness = mount({});
+  h = harness;
+  const embed = await harness.handshake();
+  harness.posted.length = 0;
+  return { embed, h: harness };
+}
+
+describe('event name mapping', () => {
+  it('maps SCREAMING_SNAKE event types to kebab-case', async () => {
+    const { embed, h: harness } = await ready();
+    const cases: Array<[string, string]> = [
+      ['MODEL_LOADING', 'model-loading'],
+      ['MODEL_LOADED', 'model-loaded'],
+      ['MODEL_ERROR', 'model-error'],
+      ['ENTITY_SELECTED', 'entity-selected'],
+      ['ENTITY_DESELECTED', 'entity-deselected'],
+      ['ENTITY_HOVERED', 'entity-hovered'],
+      ['CAMERA_CHANGED', 'camera-changed'],
+      ['SECTION_CHANGED', 'section-changed'],
+    ];
+    for (const [wire, subscribed] of cases) {
+      const seen: unknown[] = [];
+      const off = embed.on(subscribed as never, (d) => seen.push(d));
+      harness.emit(wire, { tag: wire });
+      expect(seen, `${wire} did not reach '${subscribed}'`).toEqual([{ tag: wire }]);
+      off();
+    }
+  });
+
+  it('maps a single-word type by lower-casing it', async () => {
+    const { embed, h: harness } = await ready();
+    const seen: unknown[] = [];
+    embed.on('ready', (d) => seen.push(d));
+    harness.emit('READY', { version: '1.0' });
+    expect(seen).toEqual([{ version: '1.0' }]);
+  });
+
+  it('replaces every underscore, not just the first', async () => {
+    const { embed, h: harness } = await ready();
+    const seen: unknown[] = [];
+    embed.on('a-b-c' as never, (d) => seen.push(d));
+    harness.emit('A_B_C', { ok: true });
+    expect(seen).toEqual([{ ok: true }]);
+  });
+
+  it('does not deliver a wire type to the un-mapped listener name', async () => {
+    const { embed, h: harness } = await ready();
+    const seen: unknown[] = [];
+    embed.on('ENTITY_SELECTED' as never, (d) => seen.push(d));
+    harness.emit('ENTITY_SELECTED', { id: 1 });
+    expect(seen).toEqual([]);
+  });
+});
+
+describe('listener registry', () => {
+  it('fans out to every listener on the same event', async () => {
+    const { embed, h: harness } = await ready();
+    const a: unknown[] = [];
+    const b: unknown[] = [];
+    embed.on('entity-hovered', (d) => a.push(d));
+    embed.on('entity-hovered', (d) => b.push(d));
+    harness.emit('ENTITY_HOVERED', { id: 3 });
+    expect(a).toEqual([{ id: 3 }]);
+    expect(b).toEqual([{ id: 3 }]);
+  });
+
+  it('unsubscribes exactly the callback returned by on()', async () => {
+    const { embed, h: harness } = await ready();
+    const a: unknown[] = [];
+    const b: unknown[] = [];
+    const offA = embed.on('entity-hovered', (d) => a.push(d));
+    embed.on('entity-hovered', (d) => b.push(d));
+    offA();
+    harness.emit('ENTITY_HOVERED', { id: 3 });
+    expect(a).toEqual([]);
+    expect(b).toEqual([{ id: 3 }]);
+  });
+
+  it('survives a throwing listener and still runs the next one', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { embed, h: harness } = await ready();
+    const seen: unknown[] = [];
+    embed.on('camera-changed', () => { throw new Error('listener blew up'); });
+    embed.on('camera-changed', (d) => seen.push(d));
+    expect(() => harness.emit('CAMERA_CHANGED', { azimuth: 1, elevation: 2 })).not.toThrow();
+    expect(seen).toEqual([{ azimuth: 1, elevation: 2 }]);
+    expect(errSpy).toHaveBeenCalled();
+  });
+
+  it('delivers the envelope data, not the envelope itself', async () => {
+    const { embed, h: harness } = await ready();
+    const seen: unknown[] = [];
+    embed.on('model-loaded', (d) => seen.push(d));
+    harness.emit('MODEL_LOADED', { entities: 1, triangles: 2, vertices: 3 });
+    expect(seen).toEqual([{ entities: 1, triangles: 2, vertices: 3 }]);
+  });
+});
+
+describe('destroy', () => {
+  it('rejects every in-flight request', async () => {
+    const { embed, h: harness } = await ready();
+    const a = embed.getModelInfo();
+    const b = embed.getScreenshot();
+    void harness;
+    embed.destroy();
+    await expect(a).rejects.toThrow('Embed destroyed');
+    await expect(b).rejects.toThrow('Embed destroyed');
+  });
+
+  it('rejects new requests instead of posting them', async () => {
+    const { embed, h: harness } = await ready();
+    embed.destroy();
+    await expect(embed.getModelInfo()).rejects.toThrow('Embed destroyed');
+    expect(harness.posted).toEqual([]);
+  });
+
+  it('removes the iframe from the DOM', async () => {
+    const { embed, h: harness } = await ready();
+    expect(harness.container.querySelector('iframe')).toBe(harness.iframe);
+    embed.destroy();
+    expect(harness.container.querySelector('iframe')).toBeNull();
+  });
+
+  it('stops delivering events after destroy', async () => {
+    const { embed, h: harness } = await ready();
+    const seen: unknown[] = [];
+    embed.on('entity-selected', (d) => seen.push(d));
+    harness.emit('ENTITY_SELECTED', { id: 1 });
+    expect(seen).toHaveLength(1);
+    embed.destroy();
+    harness.emit('ENTITY_SELECTED', { id: 2 });
+    expect(seen).toHaveLength(1);
+  });
+
+  it('does not leave a pending-request timer that fires after destroy', async () => {
+    vi.useFakeTimers();
+    const harness = mount({});
+    h = harness;
+    harness.emit('READY', { version: '1.0' });
+    harness.emit('INIT_ACK');
+    const embed = await harness.created;
+    const p = embed.getModelInfo();
+    const assertion = expect(p).rejects.toThrow('Embed destroyed');
+    embed.destroy();
+    await assertion;
+    // If the 30s timer had survived, this would produce a second rejection.
+    await vi.advanceTimersByTimeAsync(60_000);
+    await expect(p).rejects.toThrow('Embed destroyed');
+  });
+
+  it('is idempotent', async () => {
+    const { embed } = await ready();
+    embed.destroy();
+    expect(() => embed.destroy()).not.toThrow();
+  });
+});

--- a/packages/embed-sdk/test/handshake.test.ts
+++ b/packages/embed-sdk/test/handshake.test.ts
@@ -1,0 +1,119 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { EMBED_SOURCE, PROTOCOL_VERSION } from '@ifc-lite/embed-protocol';
+import { mount, type Harness } from './harness.js';
+
+let h: Harness | undefined;
+afterEach(() => {
+  h?.cleanup();
+  h = undefined;
+  vi.useRealTimers();
+});
+
+describe('READY → INIT → INIT_ACK handshake', () => {
+  it('sends nothing before READY arrives', () => {
+    h = mount({});
+    expect(h.posted).toEqual([]);
+  });
+
+  it('sends INIT in response to READY, stamped with source and version', () => {
+    h = mount({ token: 'tok-123' });
+    h.emit('READY', { version: PROTOCOL_VERSION });
+    expect(h.posted).toHaveLength(1);
+    expect(h.last().msg).toEqual({
+      source: EMBED_SOURCE,
+      version: PROTOCOL_VERSION,
+      type: 'INIT',
+      data: { token: 'tok-123' },
+    });
+  });
+
+  it('sends the token via postMessage with an undefined token when none is configured', () => {
+    h = mount({});
+    h.emit('READY', { version: PROTOCOL_VERSION });
+    expect((h.last().msg as { data: { token?: string } }).data.token).toBeUndefined();
+  });
+
+  it('does not resolve create() on READY alone', async () => {
+    h = mount({});
+    h.emit('READY', { version: PROTOCOL_VERSION });
+    const settled = await Promise.race([
+      h.created.then(() => 'resolved'),
+      Promise.resolve('pending'),
+    ]);
+    expect(settled).toBe('pending');
+  });
+
+  it('resolves create() once INIT_ACK arrives', async () => {
+    h = mount({});
+    h.emit('READY', { version: PROTOCOL_VERSION });
+    h.emit('INIT_ACK');
+    await expect(h.created).resolves.toBeDefined();
+  });
+
+  it('resolves on INIT_ACK even if READY was never seen', async () => {
+    // The viewer may have emitted READY before the host listener attached.
+    h = mount({});
+    h.emit('INIT_ACK');
+    await expect(h.created).resolves.toBeDefined();
+    expect(h.posted).toEqual([]);
+  });
+
+  it('sends INIT only once even if READY is repeated', () => {
+    h = mount({});
+    h.emit('READY', { version: PROTOCOL_VERSION });
+    h.emit('READY', { version: PROTOCOL_VERSION });
+    h.emit('READY', { version: PROTOCOL_VERSION });
+    expect(h.posted.filter(p => p.msg.type === 'INIT')).toHaveLength(1);
+  });
+
+  it('ignores a READY that fails the origin check', () => {
+    h = mount({});
+    h.emit('READY', { version: PROTOCOL_VERSION }, {}, { origin: 'https://evil.example.test' });
+    expect(h.posted).toEqual([]);
+  });
+});
+
+describe('handshake timeout', () => {
+  it('rejects after the default 15s when the viewer never answers', async () => {
+    vi.useFakeTimers();
+    h = mount({});
+    const assertion = expect(h.created).rejects.toThrow(/handshake timed out/);
+    await vi.advanceTimersByTimeAsync(15_000);
+    await assertion;
+  });
+
+  it('does not reject one tick before the deadline', async () => {
+    vi.useFakeTimers();
+    h = mount({});
+    await vi.advanceTimersByTimeAsync(14_999);
+    const settled = await Promise.race([
+      h.created.then(() => 'resolved', () => 'rejected'),
+      Promise.resolve('pending'),
+    ]);
+    expect(settled).toBe('pending');
+  });
+
+  it('honours a custom timeout', async () => {
+    vi.useFakeTimers();
+    h = mount({ timeout: 500 });
+    const assertion = expect(h.created).rejects.toThrow(/handshake timed out/);
+    await vi.advanceTimersByTimeAsync(500);
+    await assertion;
+  });
+
+  it('does not reject after INIT_ACK once the deadline passes', async () => {
+    vi.useFakeTimers();
+    h = mount({});
+    h.emit('READY', { version: PROTOCOL_VERSION });
+    h.emit('INIT_ACK');
+    await expect(h.created).resolves.toBeDefined();
+    // The timer must have been cleared; advancing past the deadline must not
+    // turn an already-resolved handshake into an unhandled rejection.
+    await vi.advanceTimersByTimeAsync(60_000);
+    await expect(h.created).resolves.toBeDefined();
+  });
+});

--- a/packages/embed-sdk/test/harness.ts
+++ b/packages/embed-sdk/test/harness.ts
@@ -1,0 +1,118 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Test harness for the embed SDK.
+ *
+ * The SDK talks to a real cross-origin iframe. Under happy-dom the iframe never
+ * navigates (see vitest.config.ts), so we install our own `contentWindow` whose
+ * `postMessage` records everything the SDK sends, and we synthesise inbound
+ * `MessageEvent`s with full control over `origin` and `source`.
+ */
+
+import { EMBED_SOURCE, PROTOCOL_VERSION } from '@ifc-lite/embed-protocol';
+import { IFCLiteEmbed, type EmbedOptions } from '../src/index.js';
+
+export const DEFAULT_ORIGIN = 'https://embed.ifclite.com';
+
+export interface PostedMessage {
+  msg: Record<string, unknown>;
+  targetOrigin: string;
+  transfer: unknown;
+}
+
+export interface InboundOptions {
+  origin?: string;
+  /** Pass `null` to simulate a message from a window that is not our iframe. */
+  source?: unknown;
+}
+
+export interface Harness {
+  container: HTMLDivElement;
+  iframe: HTMLIFrameElement;
+  /** Everything the SDK has posted into the iframe, oldest first. */
+  posted: PostedMessage[];
+  /** The fake `contentWindow` the SDK posts into. */
+  frameWindow: unknown;
+  /** Promise returned by `IFCLiteEmbed.create` — resolves after the handshake. */
+  created: Promise<IFCLiteEmbed>;
+  /** Dispatch an inbound message event at the host window. */
+  inbound(data: unknown, opts?: InboundOptions): void;
+  /** Dispatch a well-formed embed envelope. */
+  emit(type: string, data?: unknown, extra?: Record<string, unknown>, opts?: InboundOptions): void;
+  /** Drive READY → INIT → INIT_ACK and return the ready instance. */
+  handshake(): Promise<IFCLiteEmbed>;
+  /** The most recently posted message. */
+  last(): PostedMessage;
+  cleanup(): void;
+}
+
+export function mount(opts: Partial<EmbedOptions> = {}): Harness {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+
+  // `create` is async but runs the constructor synchronously before its first
+  // await, so the iframe exists as soon as the call returns.
+  const created = IFCLiteEmbed.create({ container, ...opts } as EmbedOptions);
+  // Swallow the rejection here so a deliberately-timed-out handshake does not
+  // surface as an unhandled rejection; tests still assert on `created`.
+  created.catch(() => {});
+
+  // The caller may have overridden `container` (e.g. with a CSS selector), so
+  // look the iframe up in whichever element the SDK actually mounted into.
+  const mountedInto = typeof opts.container === 'string'
+    ? document.querySelector(opts.container)
+    : (opts.container ?? container);
+  const iframe = mountedInto?.querySelector('iframe');
+  if (!iframe) throw new Error('harness: SDK did not create an iframe');
+
+  const posted: PostedMessage[] = [];
+  const frameWindow = {
+    postMessage(msg: Record<string, unknown>, targetOrigin: string, transfer: unknown) {
+      posted.push({ msg, targetOrigin, transfer });
+    },
+  };
+  Object.defineProperty(iframe, 'contentWindow', { value: frameWindow, configurable: true });
+
+  const expectedOrigin = new URL(opts.origin ?? DEFAULT_ORIGIN).origin;
+
+  const inbound = (data: unknown, o: InboundOptions = {}) => {
+    window.dispatchEvent(new MessageEvent('message', {
+      data,
+      origin: o.origin ?? expectedOrigin,
+      source: ('source' in o ? o.source : frameWindow) as MessageEventSource,
+    }));
+  };
+
+  const emit = (
+    type: string,
+    data?: unknown,
+    extra: Record<string, unknown> = {},
+    o: InboundOptions = {},
+  ) => {
+    inbound({ source: EMBED_SOURCE, version: PROTOCOL_VERSION, type, data, ...extra }, o);
+  };
+
+  return {
+    container,
+    iframe,
+    posted,
+    frameWindow,
+    created,
+    inbound,
+    emit,
+    last: () => {
+      if (posted.length === 0) throw new Error('harness: nothing has been posted');
+      return posted[posted.length - 1]!;
+    },
+    async handshake() {
+      emit('READY', { version: PROTOCOL_VERSION });
+      emit('INIT_ACK');
+      return created;
+    },
+    cleanup() {
+      container.remove();
+    },
+  };
+}

--- a/packages/embed-sdk/test/iframe-url.test.ts
+++ b/packages/embed-sdk/test/iframe-url.test.ts
@@ -1,0 +1,117 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { IFCLiteEmbed } from '../src/index.js';
+import { mount, DEFAULT_ORIGIN, type Harness } from './harness.js';
+
+let h: Harness | undefined;
+afterEach(() => { h?.cleanup(); h = undefined; });
+
+function urlOf(opts: Parameters<typeof mount>[0]): URL {
+  h = mount(opts);
+  return new URL(h.iframe.src);
+}
+
+describe('iframe URL construction', () => {
+  it('defaults to the production embed origin and the /v1 path', () => {
+    const url = urlOf({});
+    expect(url.origin).toBe(DEFAULT_ORIGIN);
+    expect(url.pathname).toBe('/v1');
+  });
+
+  it('honours a custom origin', () => {
+    const url = urlOf({ origin: 'https://embed.example.test' });
+    expect(url.origin).toBe('https://embed.example.test');
+    expect(url.pathname).toBe('/v1');
+  });
+
+  it('emits no query params when no options are given', () => {
+    expect([...urlOf({}).searchParams.keys()]).toEqual([]);
+  });
+
+  it('passes through the scalar params verbatim', () => {
+    const p = urlOf({
+      modelUrl: 'https://cdn.example.test/a.ifc',
+      theme: 'dark',
+      bg: 'ff0000',
+      controls: 'orbit',
+      view: 'top',
+    }).searchParams;
+    expect(p.get('modelUrl')).toBe('https://cdn.example.test/a.ifc');
+    expect(p.get('theme')).toBe('dark');
+    expect(p.get('bg')).toBe('ff0000');
+    expect(p.get('controls')).toBe('orbit');
+    expect(p.get('view')).toBe('top');
+  });
+
+  it('encodes the boolean flags as the string "true" when set', () => {
+    const p = urlOf({ hideAxis: true, hideScale: true }).searchParams;
+    expect(p.get('hideAxis')).toBe('true');
+    expect(p.get('hideScale')).toBe('true');
+  });
+
+  it('omits the boolean flags entirely when false (not "false")', () => {
+    // Both directions: a viewer that parses `hideAxis` by presence would hide
+    // the axis for every consumer who explicitly asked for it to stay.
+    const p = urlOf({ hideAxis: false, hideScale: false }).searchParams;
+    expect(p.has('hideAxis')).toBe(false);
+    expect(p.has('hideScale')).toBe(false);
+  });
+
+  it('joins hideTypes with commas', () => {
+    const p = urlOf({ hideTypes: ['IFCSPACE', 'IFCOPENINGELEMENT'] }).searchParams;
+    expect(p.get('hideTypes')).toBe('IFCSPACE,IFCOPENINGELEMENT');
+  });
+
+  it('omits hideTypes for an empty array', () => {
+    expect(urlOf({ hideTypes: [] }).searchParams.has('hideTypes')).toBe(false);
+  });
+
+  it('serialises camera as azimuth,elevation when zoom is absent', () => {
+    const p = urlOf({ camera: { azimuth: 45, elevation: 30 } }).searchParams;
+    expect(p.get('camera')).toBe('45,30');
+  });
+
+  it('appends zoom as a third camera component when present', () => {
+    const p = urlOf({ camera: { azimuth: 45, elevation: 30, zoom: 2.5 } }).searchParams;
+    expect(p.get('camera')).toBe('45,30,2.5');
+  });
+
+  it('keeps a zoom of 0, which is falsy but meaningful', () => {
+    const p = urlOf({ camera: { azimuth: 0, elevation: 0, zoom: 0 } }).searchParams;
+    expect(p.get('camera')).toBe('0,0,0');
+  });
+
+  it('never puts the auth token in the URL', () => {
+    const url = urlOf({ token: 'secret-token-value' });
+    expect(url.href).not.toContain('secret-token-value');
+    expect(url.searchParams.has('token')).toBe(false);
+  });
+
+  it('mounts the iframe into the container with the expected attributes', () => {
+    h = mount({});
+    expect(h.iframe.parentElement).toBe(h.container);
+    expect(h.iframe.getAttribute('allow')).toBe('cross-origin-isolated');
+    expect(h.iframe.getAttribute('loading')).toBe('eager');
+    expect(h.iframe.style.cssText).toContain('border: none');
+  });
+
+  it('resolves a string container via querySelector', () => {
+    const target = document.createElement('div');
+    target.id = 'embed-host-under-test';
+    document.body.appendChild(target);
+    try {
+      h = mount({ container: '#embed-host-under-test' });
+      expect(target.querySelector('iframe')).toBe(h.iframe);
+    } finally {
+      target.remove();
+    }
+  });
+
+  it('rejects with a named error when the container selector matches nothing', async () => {
+    await expect(IFCLiteEmbed.create({ container: '#no-such-container' }))
+      .rejects.toThrow(/Container not found: #no-such-container/);
+  });
+});

--- a/packages/embed-sdk/test/message-filtering.test.ts
+++ b/packages/embed-sdk/test/message-filtering.test.ts
@@ -1,0 +1,127 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The inbound-message filter is the SDK's trust boundary: anything that gets
+ * past it can resolve a pending request or fire a consumer event callback.
+ * Every rejection reason is pinned in both directions.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { EMBED_SOURCE, PROTOCOL_VERSION } from '@ifc-lite/embed-protocol';
+import { mount, DEFAULT_ORIGIN, type Harness } from './harness.js';
+
+let h: Harness | undefined;
+afterEach(() => { h?.cleanup(); h = undefined; });
+
+describe('event.origin filtering', () => {
+  it('accepts a message from the expected origin', async () => {
+    h = mount({});
+    const seen: unknown[] = [];
+    const embed = await h.handshake();
+    embed.on('entity-selected', (d) => seen.push(d));
+    h.emit('ENTITY_SELECTED', { id: 7 });
+    expect(seen).toEqual([{ id: 7 }]);
+  });
+
+  it('drops a message from a different origin', async () => {
+    h = mount({});
+    const seen: unknown[] = [];
+    const embed = await h.handshake();
+    embed.on('entity-selected', (d) => seen.push(d));
+    h.emit('ENTITY_SELECTED', { id: 7 }, {}, { origin: 'https://evil.example.test' });
+    expect(seen).toEqual([]);
+  });
+
+  it('drops a message from an origin that merely prefixes the expected one', async () => {
+    h = mount({ origin: 'https://embed.ifclite.com' });
+    const seen: unknown[] = [];
+    const embed = await h.handshake();
+    embed.on('entity-selected', (d) => seen.push(d));
+    // A substring/startsWith comparison would let all of these through.
+    for (const origin of [
+      'https://embed.ifclite.com.evil.test',
+      'https://evil.test/https://embed.ifclite.com',
+      'http://embed.ifclite.com',
+      'https://embed.ifclite.com:8443',
+      'null',
+    ]) {
+      h.emit('ENTITY_SELECTED', { id: 7 }, {}, { origin });
+    }
+    expect(seen).toEqual([]);
+  });
+
+  it('normalises a consumer-supplied origin with a trailing slash or path', async () => {
+    h = mount({ origin: 'https://embed.example.test/viewer/' });
+    const seen: unknown[] = [];
+    // The handshake itself only works if the canonical origin is accepted.
+    const embed = await h.handshake();
+    embed.on('entity-selected', (d) => seen.push(d));
+    h.emit('ENTITY_SELECTED', { id: 1 }, {}, { origin: 'https://embed.example.test' });
+    expect(seen).toEqual([{ id: 1 }]);
+  });
+});
+
+describe('event.source filtering', () => {
+  it('drops a message whose source is not our iframe window', async () => {
+    h = mount({});
+    const seen: unknown[] = [];
+    const embed = await h.handshake();
+    embed.on('entity-selected', (d) => seen.push(d));
+    h.emit('ENTITY_SELECTED', { id: 7 }, {}, { source: { postMessage() {} } });
+    expect(seen).toEqual([]);
+  });
+
+  it('drops a same-origin message with no source window at all', async () => {
+    h = mount({});
+    const seen: unknown[] = [];
+    const embed = await h.handshake();
+    embed.on('entity-selected', (d) => seen.push(d));
+    h.emit('ENTITY_SELECTED', { id: 7 }, {}, { source: null });
+    expect(seen).toEqual([]);
+  });
+});
+
+describe('envelope filtering', () => {
+  it('ignores traffic that lacks the embed discriminator', async () => {
+    h = mount({});
+    const seen: unknown[] = [];
+    const embed = await h.handshake();
+    embed.on('entity-selected', (d) => seen.push(d));
+    h.inbound({ type: 'ENTITY_SELECTED', data: { id: 7 } });
+    h.inbound({ source: 'some-other-widget', type: 'ENTITY_SELECTED', data: { id: 7 } });
+    h.inbound(null);
+    h.inbound('ENTITY_SELECTED');
+    expect(seen).toEqual([]);
+  });
+
+  it('accepts the same payload once the discriminator is present', async () => {
+    h = mount({});
+    const seen: unknown[] = [];
+    const embed = await h.handshake();
+    embed.on('entity-selected', (d) => seen.push(d));
+    h.inbound({ source: EMBED_SOURCE, version: PROTOCOL_VERSION, type: 'ENTITY_SELECTED', data: { id: 7 } });
+    expect(seen).toEqual([{ id: 7 }]);
+  });
+});
+
+describe('outbound targetOrigin', () => {
+  it('never posts to the "*" wildcard', async () => {
+    h = mount({});
+    const embed = await h.handshake();
+    void embed.select([1, 2]);
+    expect(h.posted.length).toBeGreaterThan(0);
+    for (const p of h.posted) {
+      expect(p.targetOrigin).not.toBe('*');
+      expect(p.targetOrigin).toBe(DEFAULT_ORIGIN);
+    }
+  });
+
+  it('targets the configured origin, not the default one', async () => {
+    h = mount({ origin: 'https://embed.example.test' });
+    const embed = await h.handshake();
+    void embed.showAll();
+    expect(h.last().targetOrigin).toBe('https://embed.example.test');
+  });
+});

--- a/packages/embed-sdk/test/request-response.test.ts
+++ b/packages/embed-sdk/test/request-response.test.ts
@@ -1,0 +1,259 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { EMBED_SOURCE, PROTOCOL_VERSION } from '@ifc-lite/embed-protocol';
+import { mount, type Harness } from './harness.js';
+import type { IFCLiteEmbed } from '../src/index.js';
+
+let h: Harness | undefined;
+afterEach(() => {
+  h?.cleanup();
+  h = undefined;
+  vi.useRealTimers();
+});
+
+async function ready(opts: Parameters<typeof mount>[0] = {}): Promise<{ embed: IFCLiteEmbed; h: Harness }> {
+  const harness = mount(opts);
+  h = harness;
+  const embed = await harness.handshake();
+  harness.posted.length = 0; // drop the INIT so `last()` is the command under test
+  return { embed, h: harness };
+}
+
+/** Reply to the most recent outbound command. */
+function reply(harness: Harness, data?: unknown, error?: { code: string; message: string }) {
+  const requestId = harness.last().msg.requestId as string;
+  harness.inbound({
+    source: EMBED_SOURCE,
+    version: PROTOCOL_VERSION,
+    type: 'RESPONSE',
+    responseId: requestId,
+    data,
+    error,
+  });
+}
+
+describe('request correlation', () => {
+  it('stamps a unique requestId on every command', async () => {
+    const { embed, h: harness } = await ready();
+    void embed.showAll();
+    void embed.showAll();
+    const ids = harness.posted.map(p => p.msg.requestId);
+    expect(ids).toHaveLength(2);
+    expect(ids[0]).toBeTypeOf('string');
+    expect(ids[0]).not.toBe(ids[1]);
+  });
+
+  it('resolves the matching promise with the response data', async () => {
+    const { embed, h: harness } = await ready();
+    const p = embed.getModelInfo();
+    reply(harness, { models: [], totalEntities: 3, totalTriangles: 9 });
+    await expect(p).resolves.toEqual({ models: [], totalEntities: 3, totalTriangles: 9 });
+  });
+
+  it('rejects with "code: message" when the response carries an error', async () => {
+    const { embed, h: harness } = await ready();
+    const p = embed.loadModel('https://cdn.example.test/a.ifc');
+    reply(harness, undefined, { code: 'LOAD_FAILED', message: 'bad IFC' });
+    await expect(p).rejects.toThrow('LOAD_FAILED: bad IFC');
+  });
+
+  it('prefers the error branch even when data is also present', async () => {
+    const { embed, h: harness } = await ready();
+    const p = embed.getModelInfo();
+    reply(harness, { models: [] }, { code: 'E', message: 'm' });
+    await expect(p).rejects.toThrow('E: m');
+  });
+
+  it('resolves only the request whose id matches, leaving the others pending', async () => {
+    const { embed, h: harness } = await ready();
+    const first = embed.getModelInfo();
+    const firstId = harness.last().msg.requestId;
+    const second = embed.getModelInfo();
+    reply(harness, { tag: 'second' });
+
+    await expect(second).resolves.toEqual({ tag: 'second' });
+    const firstSettled = await Promise.race([
+      first.then(() => 'settled', () => 'settled'),
+      Promise.resolve('pending'),
+    ]);
+    expect(firstSettled).toBe('pending');
+    expect(firstId).not.toBe(harness.last().msg.requestId);
+  });
+
+  it('ignores a response whose responseId matches nothing', async () => {
+    const { embed, h: harness } = await ready();
+    const p = embed.getModelInfo();
+    harness.inbound({
+      source: EMBED_SOURCE,
+      version: PROTOCOL_VERSION,
+      type: 'RESPONSE',
+      responseId: 'not-a-real-request-id',
+      data: { models: [] },
+    });
+    const settled = await Promise.race([
+      p.then(() => 'settled', () => 'settled'),
+      Promise.resolve('pending'),
+    ]);
+    expect(settled).toBe('pending');
+  });
+
+  it('does not resolve a request twice from a duplicated response', async () => {
+    const { embed, h: harness } = await ready();
+    const p = embed.getModelInfo();
+    const seen: string[] = [];
+    embed.on('ready', () => seen.push('ready-listener-fired'));
+    reply(harness, { models: [] });
+    await expect(p).resolves.toEqual({ models: [] });
+    // Replaying the same envelope must not re-enter the pending path; it now
+    // falls through to the event broadcast, which has no 'response' listener.
+    reply(harness, { models: [] });
+    expect(seen).toEqual([]);
+  });
+
+  it('clears the per-request timer when the response arrives', async () => {
+    // Resolving without clearing leaves a live 30s timer per answered request:
+    // invisible to the promise (it is already settled) but a real leak in a
+    // long-lived page, and it keeps the Node event loop alive under test.
+    vi.useFakeTimers();
+    const harness = mount({});
+    h = harness;
+    harness.emit('READY', { version: PROTOCOL_VERSION });
+    harness.emit('INIT_ACK');
+    const embed = await harness.created;
+    harness.posted.length = 0;
+
+    const before = vi.getTimerCount();
+    const p = embed.getModelInfo();
+    expect(vi.getTimerCount()).toBe(before + 1);
+    reply(harness, { models: [] });
+    await expect(p).resolves.toEqual({ models: [] });
+    expect(vi.getTimerCount()).toBe(before);
+  });
+
+  it('clears the per-request timer when the response is an error', async () => {
+    vi.useFakeTimers();
+    const harness = mount({});
+    h = harness;
+    harness.emit('READY', { version: PROTOCOL_VERSION });
+    harness.emit('INIT_ACK');
+    const embed = await harness.created;
+    harness.posted.length = 0;
+
+    const before = vi.getTimerCount();
+    const p = embed.getModelInfo();
+    expect(vi.getTimerCount()).toBe(before + 1);
+    reply(harness, undefined, { code: 'E', message: 'm' });
+    await expect(p).rejects.toThrow('E: m');
+    expect(vi.getTimerCount()).toBe(before);
+  });
+
+  it('does not also broadcast a matched response as a public event', async () => {
+    const { embed, h: harness } = await ready();
+    const seen: unknown[] = [];
+    embed.on('response' as never, (d) => seen.push(d));
+    const p = embed.getModelInfo();
+    reply(harness, { models: [] });
+    await expect(p).resolves.toEqual({ models: [] });
+    expect(seen).toEqual([]);
+  });
+
+  it('rejects with a per-command timeout message after 30s', async () => {
+    vi.useFakeTimers();
+    const harness = mount({});
+    h = harness;
+    harness.emit('READY', { version: PROTOCOL_VERSION });
+    harness.emit('INIT_ACK');
+    const embed = await harness.created;
+    const p = embed.getScreenshot();
+    const assertion = expect(p).rejects.toThrow('GET_SCREENSHOT timed out (30s)');
+    await vi.advanceTimersByTimeAsync(30_000);
+    await assertion;
+  });
+
+  it('does not time out a request that was already answered', async () => {
+    vi.useFakeTimers();
+    const harness = mount({});
+    h = harness;
+    harness.emit('READY', { version: PROTOCOL_VERSION });
+    harness.emit('INIT_ACK');
+    const embed = await harness.created;
+    harness.posted.length = 0;
+    const p = embed.getModelInfo();
+    reply(harness, { models: [] });
+    await expect(p).resolves.toEqual({ models: [] });
+    await vi.advanceTimersByTimeAsync(120_000);
+    await expect(p).resolves.toEqual({ models: [] });
+  });
+});
+
+describe('command payloads', () => {
+  it('sends the documented type and payload for each command', async () => {
+    const { embed, h: harness } = await ready();
+    const cases: Array<[() => unknown, string, unknown]> = [
+      [() => embed.loadModel('u'), 'LOAD_MODEL', { url: 'u' }],
+      [() => embed.addModel('u', 'n'), 'ADD_MODEL', { url: 'u', name: 'n' }],
+      [() => embed.removeModel('m1'), 'REMOVE_MODEL', { modelId: 'm1' }],
+      [() => embed.select([1, 2]), 'SELECT', { ids: [1, 2] }],
+      [() => embed.selectByGuid(['g']), 'SELECT_BY_GUID', { guids: ['g'] }],
+      [() => embed.clearSelection(), 'CLEAR_SELECTION', undefined],
+      [() => embed.isolate([3]), 'ISOLATE', { ids: [3] }],
+      [() => embed.hide([4]), 'HIDE', { ids: [4] }],
+      [() => embed.show([5]), 'SHOW', { ids: [5] }],
+      [() => embed.showAll(), 'SHOW_ALL', undefined],
+      [() => embed.resetColors(), 'RESET_COLORS', undefined],
+      [() => embed.fitToView([6]), 'FIT_TO_VIEW', { ids: [6] }],
+      [() => embed.setCamera(1, 2, 3), 'SET_CAMERA', { azimuth: 1, elevation: 2, zoom: 3 }],
+      [() => embed.setView('left'), 'SET_VIEW', { preset: 'left' }],
+      [() => embed.setSection({ axis: 'down', enabled: true }), 'SET_SECTION', { axis: 'down', enabled: true }],
+      [() => embed.setTheme('dark', '000000'), 'SET_THEME', { theme: 'dark', bg: '000000' }],
+      [() => embed.setTypeVisibility({ spaces: false }), 'SET_TYPE_VISIBILITY', { spaces: false }],
+      [() => embed.getProperties(9), 'GET_PROPERTIES', { id: 9 }],
+      [() => embed.getScreenshot(800, 600), 'GET_SCREENSHOT', { width: 800, height: 600 }],
+      [() => embed.getModelInfo(), 'GET_MODEL_INFO', undefined],
+    ];
+    for (const [call, type, data] of cases) {
+      const before = harness.posted.length;
+      void (call() as Promise<unknown>).catch(() => {});
+      expect(harness.posted.length, `${type} posted nothing`).toBe(before + 1);
+      const sent = harness.last().msg;
+      expect(sent.type, `${type} sent the wrong type`).toBe(type);
+      expect(sent.data, `${type} sent the wrong payload`).toEqual(data);
+      expect(sent.source).toBe(EMBED_SOURCE);
+      expect(sent.version).toBe(PROTOCOL_VERSION);
+    }
+  });
+
+  it('stringifies numeric colour-map keys', async () => {
+    const { embed, h: harness } = await ready();
+    void embed.setColors({ 12: [1, 0, 0, 1], 7: [0, 1, 0, 0.5] });
+    const data = harness.last().msg.data as { colorMap: Record<string, number[]> };
+    expect(Object.keys(data.colorMap).sort()).toEqual(['12', '7']);
+    expect(data.colorMap['12']).toEqual([1, 0, 0, 1]);
+    expect(data.colorMap['7']).toEqual([0, 1, 0, 0.5]);
+  });
+
+  it('sends an empty colour map rather than dropping the command', async () => {
+    const { embed, h: harness } = await ready();
+    void embed.setColors({});
+    expect(harness.last().msg.type).toBe('SET_COLORS');
+    expect(harness.last().msg.data).toEqual({ colorMap: {} });
+  });
+
+  it('transfers the ArrayBuffer for LOAD_MODEL_BUFFER', async () => {
+    const { embed, h: harness } = await ready();
+    const buf = new ArrayBuffer(8);
+    void embed.loadModelBuffer(buf);
+    expect(harness.last().msg.type).toBe('LOAD_MODEL_BUFFER');
+    expect(harness.last().msg.data).toBe(buf);
+    expect(harness.last().transfer).toEqual([buf]);
+  });
+
+  it('sends an empty transfer list for ordinary commands', async () => {
+    const { embed, h: harness } = await ready();
+    void embed.showAll();
+    expect(harness.last().transfer).toEqual([]);
+  });
+});

--- a/packages/embed-sdk/vitest.config.ts
+++ b/packages/embed-sdk/vitest.config.ts
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@ifc-lite/embed-protocol': path.resolve(__dirname, '../embed-protocol/src/index.ts'),
+    },
+  },
+  test: {
+    environment: 'happy-dom',
+    // The SDK points the iframe at a real https origin; without this happy-dom
+    // would try to fetch it over the network and the suite would be flaky/offline-broken.
+    environmentOptions: {
+      happyDOM: { settings: { navigation: { disableChildFrameNavigation: true } } },
+    },
+    globals: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -895,6 +895,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@26.1.2)(happy-dom@20.11.1)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/embed-sdk:
     dependencies:
@@ -902,9 +905,15 @@ importers:
         specifier: workspace:^
         version: link:../embed-protocol
     devDependencies:
+      happy-dom:
+        specifier: ^20.11.1
+        version: 20.11.1
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@26.1.2)(happy-dom@20.11.1)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/encoding:
     devDependencies:


### PR DESCRIPTION
## Why

`packages/embed-protocol` and `packages/embed-sdk` both had **zero test files and no `test` script**, so `turbo test` skipped them entirely — the same shape that recently turned up in other packages.

I checked whether that was legitimate before writing anything:

- **`embed-protocol` — not types-only.** It is mostly type declarations, but `src/index.ts:228-279` ships four executable functions: `createEvent`, `createResponse`, `createCommand`, and the `isEmbedMessage` type guard. Both sides of the iframe boundary run every message through them, and `isEmbedMessage` (`src/index.ts:272`) is the discriminator check the SDK relies on. Small surface, but load-bearing.
- **`embed-sdk` — definitively real logic.** `src/index.ts` builds the iframe URL (`:128-145`), normalises the expected origin (`:125`), runs the READY → INIT → INIT_ACK handshake (`:160-179`), correlates requests to responses by id (`:332-342`), and enforces the entire inbound trust boundary (`:323-327`). None of it ran in CI.

Both packages now have a `test` script and a vitest devDependency — that is the only reason the suites can run at all. `pnpm check:test-wiring` still passes (verified).

## Method

Every gap below was found by mutation. Each mutation was applied as a single-occurrence exact-substring replacement whose replacement count was asserted `== 1`, the mutated region was **re-read from disk** and confirmed changed before any result was believed, and the source was restored by copying back a saved backup (never `git checkout --`).

**23 mutations, 23 killed.** Three (C1–C3) were deliberate controls, run to prove the harness operates on mutated source. Because the baseline was zero tests, **all 23 were live gaps before this PR** — this is a targeted sweep of previously untested code, not a uniform sample of a covered package, so the ratio is not comparable to a sweep of an already-tested package.

Baseline → final: embed-protocol 0 → 20 tests; embed-sdk 0 → 68 tests.

## Security-relevant findings

The embed path was audited specifically for `postMessage` target-origin handling, `event.origin` validation, and wildcard `'*'` use. **The production code is correct** — no `'*'` on either the send or the receive side of the SDK, and no behaviour was changed. What was missing was any test holding it there:

| Mutation | Before |
|---|---|
| `postMessage(..., this.origin, ...)` → `'*'` | **survived** — the SDK could have been changed to broadcast every command, including the auth token in `INIT`, to any ancestor origin, with the suite green |
| delete `if (event.origin !== this.expectedOrigin) return;` | **survived** — the SDK would have accepted viewer events from any origin |
| `new URL(this.origin).origin` → raw `this.origin` | **survived** — a consumer-supplied origin with a trailing slash would have silently stopped matching, breaking the handshake |
| delete `if (event.source !== this.iframe.contentWindow) return;` | **survived** |
| delete `if (!isEmbedMessage(event.data)) return;` | **survived** |

All five are now killed. The origin test also pins the near-misses a substring or `startsWith` comparison would admit: a suffix-extended host, the expected origin embedded in an attacker path, a scheme downgrade, a port change, and the literal `"null"`.

## Other gaps closed

Each line names the surviving mutation and the killing test lives in the file shown.

- **`isEmbedMessage`** (`embed-protocol/test/protocol.test.ts`) — dropping the `data !== null` guard, and relaxing `source === EMBED_SOURCE` to `source !== undefined`, both survived. Now covered for `null`/`undefined`/primitives/arrays, a missing `source`, and near-miss discriminators (case-flipped, suffix-extended, empty).
- **`createCommand`** — dropping `requestId` from the envelope survived; response correlation depends on it.
- **URL building** (`embed-sdk/test/iframe-url.test.ts`) — `if (opts.hideAxis)` → `!== undefined` and `hideTypes?.length` → `hideTypes` both survived: nothing pinned that an explicit `false` or an empty array must *not* appear in the URL. `camera.zoom !== undefined` → truthiness survived, so a zoom of `0` was silently dropped with no test noticing.
- **Event fan-out** (`embed-sdk/test/events-lifecycle.test.ts`) — `msg.type.toLowerCase()` and `.replace(/_/g, '-')` could each be weakened with no failure. Every wire event type is now mapped to its documented kebab-case name, and the un-mapped name is asserted *not* to fire.
- **Response correlation** (`embed-sdk/test/request-response.test.ts`) — dropping the `pending.has()` precondition, and dropping the `return` that stops a matched response from also being broadcast as a public event, both survived.
- **Timeouts** — the 15s handshake default and the 30s per-request deadline could both be doubled with no failure. Both directions are pinned, including "does not fire one tick early".
- **`destroy()`** — removing the loop that rejects in-flight requests, and removing the `destroyed` short-circuit in `request()`, both survived.
- **`clearTimeout(req.timeout)` on a matched response** survived the first round. The promise is already settled, so nothing observable changes *through the promise* — but it is still a real leak (one live 30s timer per answered request in a long-lived page), so it is now pinned via `vi.getTimerCount()` on both the resolve and the reject path. This is the one survivor from round one; it is closed, not classified away.

## Notes

- Test-only. **No production code changed.**
- Both directions of every binary signal are pinned, and boundaries are probed (zoom `0`, empty `hideTypes`, explicit `false` flags, one tick before the timeout deadline).
- `embed-sdk` tests run under happy-dom with child-frame navigation disabled, so the suite never touches the network; the harness installs its own `contentWindow` to capture what the SDK posts and synthesises inbound `MessageEvent`s with full control over `origin` and `source`.
- The root `pnpm typecheck` excludes `**/*.test.ts`, so the new test files were typechecked **separately** against each package's own compiler options with that exclusion (and `rootDir`) lifted. Both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)