### PR TITLE
test(codegen): close eight mutation-verified coverage gaps

### DIFF
--- a/packages/codegen/test/crc32.test.ts
+++ b/packages/codegen/test/crc32.test.ts
@@ -7,9 +7,16 @@
  *
  * This hash is a compatibility contract: it must match the pre-computed
  * IDs baked into the generated schema (packages/parser/src/generated/type-ids.ts)
- * and the web-ifc algorithm it mirrors. We pin known values from that
- * generated file (single source of truth for the codegen CLI's output)
- * rather than duplicating web-ifc's table here.
+ * and the web-ifc algorithm it mirrors.
+ *
+ * Two layers of assertion, doing different jobs:
+ *  - `crc32 specification vectors` pins crc32() to CRC-32/ISO-HDLC using
+ *    values that come from outside this repository. Nothing else in this file
+ *    can catch an algorithmic error, because everything else compares crc32()
+ *    against output crc32() produced.
+ *  - the remaining suites pin the *generator* to those hashes via the real
+ *    generated file (packages/parser/src/generated/type-ids.ts), the single
+ *    source of truth for the codegen CLI's output.
  */
 
 import { readFileSync } from 'node:fs';
@@ -45,6 +52,110 @@ function loadGeneratedTypeIds(): Map<string, number> {
   }
   return ids;
 }
+
+/**
+ * Independent, bit-at-a-time reference implementation of CRC-32/ISO-HDLC,
+ * written straight from the algorithm's parameters rather than from
+ * src/crc32.ts:
+ *
+ *   width=32  poly=0x04C11DB7  init=0xFFFFFFFF
+ *   refin=true  refout=true  xorout=0xFFFFFFFF  check=0xCBF43926
+ *
+ * This shares no code and no constants with the implementation under test:
+ * src/crc32.ts is table-driven and uses the *reflected* polynomial
+ * 0xEDB88320 with right shifts; this one is table-free and uses the
+ * *unreflected* polynomial 0x04C11DB7 with left shifts, reflecting each
+ * input byte on the way in and the register on the way out. Two independent
+ * routes to the same specification, so agreement between them is evidence
+ * about the specification and not a tautology.
+ */
+function reflect(value: number, width: number): number {
+  let out = 0;
+  for (let i = 0; i < width; i++) {
+    if ((value >>> i) & 1) out |= 1 << (width - 1 - i);
+  }
+  return out >>> 0;
+}
+
+function crc32Reference(input: string): number {
+  let reg = 0xffffffff;
+  for (let i = 0; i < input.length; i++) {
+    const byte = input.charCodeAt(i);
+    if (byte > 0xff) {
+      throw new Error(`crc32Reference: non-byte input at ${i}: ${byte}`);
+    }
+    reg = (reg ^ (reflect(byte, 8) << 24)) >>> 0;
+    for (let bit = 0; bit < 8; bit++) {
+      reg =
+        (reg & 0x80000000) !== 0
+          ? ((reg << 1) ^ 0x04c11db7) >>> 0
+          : (reg << 1) >>> 0;
+    }
+  }
+  return (reflect(reg, 32) ^ 0xffffffff) >>> 0;
+}
+
+describe('crc32 specification vectors', () => {
+  // Without these, every other assertion in this file compares crc32() with
+  // itself (directly, or via generated/type-ids.ts which crc32() produced).
+  // A wrong-but-self-consistent hash would pass all of them. These are the
+  // only assertions here whose expected values come from outside our code.
+  //
+  // These IDs cross a language boundary: rust/core/src/generated/schema.rs
+  // hashes unknown type names with its own CRC32 and the TS table is shipped
+  // by @ifc-lite/parser. Two internally coherent tables that disagree with
+  // each other is exactly the failure a self-check cannot see, so the same
+  // vectors are pinned on the Rust side in
+  // rust/core/tests/crc32_spec_vectors.rs.
+
+  it('matches the standard CRC-32/ISO-HDLC check value', () => {
+    // "check" is defined by the algorithm's specification as the CRC of the
+    // nine ASCII bytes "123456789". crc32() uppercases its input first, but
+    // digits are unaffected by case, so the vector applies unchanged.
+    expect(crc32('123456789')).toBe(0xcbf43926);
+  });
+
+  it('hashes the empty string to the specified xorout identity', () => {
+    // With no input the register never leaves init=0xFFFFFFFF, so the result
+    // is init ^ xorout = 0xFFFFFFFF ^ 0xFFFFFFFF = 0.
+    expect(crc32('')).toBe(0x00000000);
+  });
+
+  it('agrees with an independent bit-at-a-time reference implementation', () => {
+    // Anchor the reference itself to the published check value before
+    // trusting it as an oracle.
+    expect(crc32Reference('123456789')).toBe(0xcbf43926);
+    expect(crc32Reference('')).toBe(0x00000000);
+
+    // crc32() uppercases; feed the reference the already-uppercased form so
+    // the comparison is about the hash, not about the case folding (which
+    // has its own test below).
+    const names = [
+      'IFCWALL',
+      'IFCWINDOW',
+      'IFCDOOR',
+      'IFCPROJECT',
+      'IFCBUILDINGSTOREY',
+      'IFCEXTRUDEDAREASOLID',
+      'IFCTRIANGULATEDFACESET',
+      'IFCNOTATYPE',
+      'A',
+      'AB',
+      'ABC',
+    ];
+    for (const name of names) {
+      expect(crc32(name)).toBe(crc32Reference(name));
+    }
+  });
+
+  it('agrees with the reference across the full generated IFC entity set', () => {
+    const generated = loadGeneratedTypeIds();
+    expect(generated.size).toBeGreaterThan(500);
+    for (const name of generated.keys()) {
+      expect(crc32(name)).toBe(crc32Reference(name.toUpperCase()));
+    }
+  });
+});
 
 describe('crc32', () => {
   it('matches the pre-computed IfcWall hash from generated/type-ids.ts', () => {

--- a/packages/codegen/test/express-parser.test.ts
+++ b/packages/codegen/test/express-parser.test.ts
@@ -328,6 +328,40 @@ describe('EXPRESS Parser', () => {
     });
   });
 
+  describe('Attribute section boundary', () => {
+    /**
+     * The attributes section ends at the FIRST of WHERE / DERIVE / INVERSE /
+     * UNIQUE. Every existing fixture had at most one of those keywords, so
+     * "first" and "last" were the same index and the choice was untestable —
+     * picking the last one instead swallows the INVERSE/DERIVE block and turns
+     * its lines into bogus attributes.
+     */
+    it('stops at the FIRST section keyword when several are present', () => {
+      const schema = parseExpressSchema(`
+        SCHEMA TEST;
+
+        ENTITY IfcTest
+          SUBTYPE OF (IfcRoot);
+          RealAttr : IfcLabel;
+         DERIVE
+          DerivedAttr : IfcLabel := 'x';
+         INVERSE
+          InverseAttr : SET [0:?] OF IfcRelAssigns FOR RelatedObjects;
+         WHERE
+          WR1 : EXISTS(RealAttr);
+        END_ENTITY;
+
+        END_SCHEMA;
+      `);
+
+      const test = schema.entities[0];
+      expect(test.attributes.map(a => a.name)).toEqual(['RealAttr']);
+      // Both directions: the derived and inverse names must not leak in.
+      expect(test.attributes.map(a => a.name)).not.toContain('DerivedAttr');
+      expect(test.attributes.map(a => a.name)).not.toContain('InverseAttr');
+    });
+  });
+
   describe('Real IFC schema parsing', () => {
     it('should parse IfcWall from real schema', () => {
       const schema = parseExpressSchema(`

--- a/packages/codegen/test/rust-generator.test.ts
+++ b/packages/codegen/test/rust-generator.test.ts
@@ -1,0 +1,145 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Tests for the Rust generator (packages/codegen/src/rust-generator.ts).
+ *
+ * This emitter produces `rust/core/src/generated/type_ids.rs` and
+ * `rust/core/src/generated/schema.rs` — the Rust core's entire notion of what
+ * an IFC type IS. Before these tests the whole 700-line module had no test at
+ * all: a mutation that emitted `pub const IfcWall` instead of `pub const
+ * IFCWALL`, or that lower-cased the `from_str` match arms, produced a green
+ * `pnpm test` in this package and only exploded (or, worse, silently
+ * mis-classified every entity) the next time someone regenerated the Rust.
+ *
+ * The identifier CASING rules are the load-bearing part and are pinned in both
+ * directions here:
+ *   - `type_ids.rs` constants are SCREAMING_CASE (`IFCWALL`), Rust's const
+ *     convention.
+ *   - `IfcType` enum variants keep the schema's PascalCase (`IfcWall`).
+ *   - `from_str` matches on the UPPERCASED name, because it is called with
+ *     `s.to_uppercase()`.
+ *   - `as_str()` returns the UPPERCASE STEP spelling; `name()` returns the
+ *     PascalCase display spelling. These two must not collapse into each other.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseExpressSchema } from '../src/express-parser.js';
+import { generateRust } from '../src/rust-generator.js';
+import { crc32 } from '../src/crc32.js';
+
+const SCHEMA_SRC = `
+  SCHEMA TEST_RUST;
+
+  ENTITY IfcRoot
+    ABSTRACT;
+    GlobalId : IfcGloballyUniqueId;
+  END_ENTITY;
+
+  ENTITY IfcWall
+    SUBTYPE OF (IfcRoot);
+    PredefinedType : OPTIONAL IfcWallTypeEnum;
+  END_ENTITY;
+
+  ENTITY IfcRelAggregates
+    SUBTYPE OF (IfcRoot);
+    RelatingObject : IfcObjectDefinition;
+  END_ENTITY;
+
+  END_SCHEMA;
+`;
+
+const schema = parseExpressSchema(SCHEMA_SRC);
+const rust = generateRust(schema);
+
+describe('generateRust — type_ids.rs', () => {
+  it('emits SCREAMING_CASE constants, not the PascalCase entity name', () => {
+    expect(rust.typeIds).toContain(`pub const IFCWALL: u32 = ${crc32('IfcWall')};`);
+    // Both directions: the PascalCase spelling must NOT be emitted as a const.
+    expect(rust.typeIds).not.toContain('pub const IfcWall:');
+  });
+
+  it('emits the CRC32 of the entity name, not of some other spelling', () => {
+    // crc32() upcases internally, so IfcWall and IFCWALL hash identically; the
+    // value pinned here is the real one shipped in the generated Rust.
+    expect(crc32('IfcWall')).toBe(2391406946);
+    expect(rust.typeIds).toContain('pub const IFCWALL: u32 = 2391406946;');
+  });
+
+  it('covers every entity in the schema exactly once', () => {
+    for (const entity of schema.entities) {
+      const line = `pub const ${entity.name.toUpperCase()}: u32 = ${crc32(entity.name)};\n`;
+      expect(rust.typeIds.split(line).length - 1, entity.name).toBe(1);
+    }
+  });
+
+  it('stamps the schema name into the module banner', () => {
+    expect(rust.typeIds).toContain('Generated from EXPRESS schema: TEST_RUST');
+  });
+});
+
+describe('generateRust — schema.rs IfcType enum', () => {
+  it('declares variants in PascalCase, not SCREAMING_CASE', () => {
+    expect(rust.schema).toContain('    IfcWall,\n');
+    expect(rust.schema).not.toContain('    IFCWALL,\n');
+  });
+
+  it('matches from_str on the UPPERCASE spelling (it is fed s.to_uppercase())', () => {
+    expect(rust.schema).toContain('let upper = s.to_uppercase();');
+    expect(rust.schema).toContain('"IFCWALL" => Self::IfcWall,');
+    // Both directions: a PascalCase match arm would be dead code.
+    expect(rust.schema).not.toContain('"IfcWall" => Self::IfcWall,');
+  });
+
+  it('maps from_id on the CRC32 id', () => {
+    expect(rust.schema).toContain(`${crc32('IfcWall')} => Self::IfcWall,`);
+    expect(rust.schema).toContain('_ => Self::Unknown(id),');
+  });
+
+  it('id() round-trips the same constant that type_ids.rs exports', () => {
+    expect(rust.schema).toContain(`Self::IfcWall => ${crc32('IfcWall')},`);
+  });
+
+  it('keeps as_str() UPPERCASE and name() PascalCase (they must not collapse)', () => {
+    expect(rust.schema).toContain('Self::IfcWall => "IFCWALL",');
+    expect(rust.schema).toContain('Self::IfcWall => "IfcWall",');
+  });
+
+  it('emits a parent() arm only for entities that declare SUBTYPE OF', () => {
+    expect(rust.schema).toContain('Self::IfcWall => Some(Self::IfcRoot),');
+    // IfcRoot is the root: no supertype, so no arm — it falls through to None.
+    expect(rust.schema).not.toContain('Self::IfcRoot => Some(');
+  });
+
+  it('emits is_abstract() arms only for ABSTRACT entities', () => {
+    expect(rust.schema).toContain('Self::IfcRoot => true,');
+    expect(rust.schema).not.toContain('Self::IfcWall => true,');
+  });
+
+  it('records the entity count in the doc comment', () => {
+    expect(rust.schema).toContain(`All ${schema.entities.length} entity types`);
+  });
+});
+
+describe('generateRust — entity categorisation', () => {
+  it('routes IfcRel* entities to the Relationships section', () => {
+    const relIdx = rust.typeIds.indexOf('// Relationships');
+    expect(relIdx).toBeGreaterThanOrEqual(0);
+    const section = rust.typeIds.slice(relIdx);
+    expect(section).toContain('pub const IFCRELAGGREGATES:');
+  });
+
+  it('drops categories that ended up empty', () => {
+    // Nothing in this schema is MEP, so that header must not be emitted.
+    expect(rust.typeIds).not.toContain('// MEP');
+    expect(rust.schema).not.toContain('// MEP');
+  });
+
+  it('assigns every entity to exactly one category', () => {
+    for (const entity of schema.entities) {
+      const variant = `    ${entity.name},\n`;
+      expect(rust.schema.split(variant).length - 1, entity.name).toBe(1);
+    }
+  });
+});

--- a/packages/codegen/test/type-ids-generator.test.ts
+++ b/packages/codegen/test/type-ids-generator.test.ts
@@ -1,0 +1,141 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Tests for the type-ids generator (packages/codegen/src/type-ids-generator.ts).
+ *
+ * This module emits `type-ids.ts` — the `TYPE_IDS` (name -> CRC32) and
+ * `TYPE_NAMES` (CRC32 -> name) maps every consumer of a generated schema
+ * bundle uses for O(1) type lookup. The whole module had no test: inverting
+ * the reverse map (`  IfcWall: 2391406946,` instead of `  2391406946:
+ * 'IfcWall',`) still produced syntactically valid TypeScript and a green
+ * suite, while `getTypeName(id)` would return `undefined` for every id at
+ * runtime.
+ *
+ * The emitted file also ships executable helpers (`getTypeId`, `getTypeName`,
+ * `isValidTypeId`, `normalizeTypeName`, `crc32Hash`). Because they are emitted
+ * as TEXT, nothing in this package ever ran them. Here we transpile the
+ * emitted module and execute it, so the helper semantics — not just their
+ * presence as substrings — are pinned.
+ */
+
+import { describe, it, expect } from 'vitest';
+import ts from 'typescript';
+import { parseExpressSchema } from '../src/express-parser.js';
+import { generateTypeIds } from '../src/type-ids-generator.js';
+import { crc32 } from '../src/crc32.js';
+
+const schema = parseExpressSchema(`
+  SCHEMA TEST_TYPE_IDS;
+
+  ENTITY IfcWall;
+    GlobalId : IfcGloballyUniqueId;
+  END_ENTITY;
+
+  ENTITY IfcWallStandardCase
+    SUBTYPE OF (IfcWall);
+  END_ENTITY;
+
+  ENTITY IfcDoor;
+    GlobalId : IfcGloballyUniqueId;
+  END_ENTITY;
+
+  END_SCHEMA;
+`);
+
+const source = generateTypeIds(schema);
+
+/** The runtime surface the emitted `type-ids.ts` ships to consumers. */
+interface EmittedTypeIds {
+  TYPE_IDS: Record<string, number>;
+  TYPE_NAMES: Record<number, string>;
+  getTypeId(name: string): number | undefined;
+  getTypeName(id: number): string | undefined;
+  isValidTypeId(id: number): boolean;
+  crc32Hash(str: string): number;
+}
+
+/**
+ * Transpile the emitted `type-ids.ts` and evaluate it, returning its exports.
+ * The emitted module is self-contained (no imports), so a plain transpile +
+ * dynamic import of a data: URL is enough — and it is the only way to test the
+ * runtime helpers the generator ships to consumers.
+ */
+async function loadEmittedModule(code: string): Promise<EmittedTypeIds> {
+  const js = ts.transpileModule(code, {
+    compilerOptions: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.ESNext },
+  }).outputText;
+  return await import(`data:text/javascript;base64,${Buffer.from(js).toString('base64')}`);
+}
+
+describe('generateTypeIds — emitted source shape', () => {
+  it('emits the forward map as name -> id', () => {
+    expect(source).toContain(`  IfcWall: ${crc32('IfcWall')},\n`);
+  });
+
+  it('emits the reverse map as id -> name, not a second forward map', () => {
+    expect(source).toContain(`  ${crc32('IfcWall')}: 'IfcWall',\n`);
+    // Both directions: TYPE_NAMES must not be a duplicate of TYPE_IDS.
+    const reverseBlock = source.slice(source.indexOf('export const TYPE_NAMES'));
+    expect(reverseBlock).not.toContain(`  IfcWall: ${crc32('IfcWall')},`);
+  });
+
+  it('stamps the schema name into the banner', () => {
+    expect(source).toContain('Generated from EXPRESS schema: TEST_TYPE_IDS');
+  });
+
+  it('covers every entity in both maps exactly once', () => {
+    for (const entity of schema.entities) {
+      const id = crc32(entity.name);
+      expect(source.split(`  ${entity.name}: ${id},\n`).length - 1, entity.name).toBe(1);
+      expect(source.split(`  ${id}: '${entity.name}',\n`).length - 1, entity.name).toBe(1);
+    }
+  });
+});
+
+describe('generateTypeIds — emitted runtime helpers (executed)', () => {
+  it('TYPE_IDS and TYPE_NAMES round-trip', async () => {
+    const mod = await loadEmittedModule(source);
+    expect(mod.TYPE_IDS.IfcWall).toBe(crc32('IfcWall'));
+    expect(mod.TYPE_NAMES[crc32('IfcWall')]).toBe('IfcWall');
+  });
+
+  it('getTypeId resolves the PascalCase name', async () => {
+    const mod = await loadEmittedModule(source);
+    expect(mod.getTypeId('IfcWall')).toBe(crc32('IfcWall'));
+  });
+
+  it('getTypeId normalises the UPPERCASE STEP spelling', async () => {
+    const mod = await loadEmittedModule(source);
+    expect(mod.getTypeId('IFCWALL')).toBe(crc32('IfcWall'));
+    expect(mod.getTypeId('IFCWALLSTANDARDCASE')).toBe(crc32('IfcWallStandardCase'));
+  });
+
+  it('getTypeId returns undefined for an unknown name (negative direction)', async () => {
+    const mod = await loadEmittedModule(source);
+    expect(mod.getTypeId('IFCNOTATHING')).toBeUndefined();
+    expect(mod.getTypeId('CompletelyUnrelated')).toBeUndefined();
+  });
+
+  it('getTypeName and isValidTypeId agree, in both directions', async () => {
+    const mod = await loadEmittedModule(source);
+    const id = crc32('IfcDoor');
+    expect(mod.getTypeName(id)).toBe('IfcDoor');
+    expect(mod.isValidTypeId(id)).toBe(true);
+
+    expect(mod.getTypeName(1)).toBeUndefined();
+    expect(mod.isValidTypeId(1)).toBe(false);
+  });
+
+  it('the emitted crc32Hash matches the generator crc32 (case-insensitive)', async () => {
+    const mod = await loadEmittedModule(source);
+    expect(mod.crc32Hash('IfcWall')).toBe(crc32('IfcWall'));
+    expect(mod.crc32Hash('IFCWALL')).toBe(crc32('IfcWall'));
+    // Sanity: not degenerate.
+    expect(mod.crc32Hash('IfcWall')).not.toBe(mod.crc32Hash('IfcDoor'));
+    // And it agrees on a name that is NOT in the schema, which is the whole
+    // point of shipping the hash function alongside the tables.
+    expect(mod.crc32Hash('IfcNotInThisSchema')).toBe(crc32('IfcNotInThisSchema'));
+  });
+});

--- a/packages/codegen/test/typescript-generator-mapping.test.ts
+++ b/packages/codegen/test/typescript-generator-mapping.test.ts
@@ -1,0 +1,309 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Type-mapping, escaping, ordering and emitted-runtime coverage for the
+ * TypeScript generator.
+ *
+ * The existing typescript-generator tests only exercise REAL/INTEGER/BOOLEAN/
+ * STRING and all-uppercase enum fixtures, so several load-bearing rules were
+ * free to change without a single failing test:
+ *
+ *  - `LOGICAL -> 'boolean | null'` (three-valued) could become `'boolean'`.
+ *  - `BINARY -> 'string'` could become anything.
+ *  - `STRING(22)` / `BINARY(32)` bounded forms could stop mapping to `string`.
+ *  - the `endsWith('Measure') -> number` rule could become `startsWith`.
+ *  - the union parenthesisation that makes `LIST OF LOGICAL` emit
+ *    `(boolean | null)[]` instead of the precedence-misparsed
+ *    `boolean | null[]` could be deleted — this one has an explaining comment
+ *    in the source but no guard.
+ *  - enum MEMBER names could stop being upper-cased (every fixture value was
+ *    already uppercase, so the call was untestable).
+ *  - the single-quote / newline escaping in SCHEMA_REGISTRY could be dropped,
+ *    emitting a generated file that does not parse.
+ *  - topologicalSort could stop visiting parents first.
+ *  - the runtime helpers the generator emits as TEXT (getEntityMetadata,
+ *    normalizeTypeName, getAllAttributesForEntity, ...) were never executed
+ *    anywhere in this package — only substring-matched by name.
+ */
+
+import { describe, it, expect } from 'vitest';
+import ts from 'typescript';
+import { parseExpressSchema, type ExpressSchema } from '../src/express-parser.js';
+import { generateTypeScript } from '../src/typescript-generator.js';
+
+/** The runtime surface the emitted `schema-registry.ts` ships to consumers. */
+interface EmittedAttributeMetadata {
+  name: string;
+  type: string;
+  optional: boolean;
+}
+
+interface EmittedEntityMetadata {
+  name: string;
+  isAbstract: boolean;
+  parent?: string;
+  attributes: EmittedAttributeMetadata[];
+  allAttributes?: EmittedAttributeMetadata[];
+  inheritanceChain?: string[];
+}
+
+interface EmittedSchemaRegistry {
+  SCHEMA_REGISTRY: {
+    name: string;
+    entities: Record<string, EmittedEntityMetadata>;
+    types: Record<string, string>;
+    enums: Record<string, string[]>;
+    selects: Record<string, string[]>;
+  };
+  getEntityMetadata(typeName: string): EmittedEntityMetadata | undefined;
+  getAllAttributesForEntity(typeName: string): EmittedAttributeMetadata[];
+  getInheritanceChainForEntity(typeName: string): string[];
+  isKnownEntity(typeName: string): boolean;
+}
+
+/**
+ * Transpile an emitted, self-contained generated module and evaluate it.
+ * This is what turns "the generator printed the right characters" into "the
+ * code the generator ships actually behaves".
+ */
+async function evalEmitted(code: string): Promise<EmittedSchemaRegistry> {
+  const js = ts.transpileModule(code, {
+    compilerOptions: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.ESNext },
+  }).outputText;
+  return await import(`data:text/javascript;base64,${Buffer.from(js).toString('base64')}`);
+}
+
+describe('EXPRESS -> TypeScript type mapping', () => {
+  const code = generateTypeScript(
+    parseExpressSchema(`
+      SCHEMA TEST_MAPPING;
+
+      ENTITY IfcTest;
+        Flag : LOGICAL;
+        Blob : BINARY;
+        Bounded : BINARY(32);
+        Guid : STRING(22);
+        Len : IfcLengthMeasure;
+        Label : IfcLabel;
+        Custom : SomeUnmappedType;
+      END_ENTITY;
+
+      END_SCHEMA;
+    `),
+  );
+
+  it('maps LOGICAL to the three-valued `boolean | null`, not `boolean`', () => {
+    expect(code.entities).toContain('\n  Flag: boolean | null;\n');
+    expect(code.entities).not.toContain('\n  Flag: boolean;\n');
+  });
+
+  it('maps BINARY and bounded BINARY(N) to string', () => {
+    // Anchored on the newline + indent: an unanchored 'Blob: string;' would
+    // also match inside another attribute whose name ENDS in Blob.
+    expect(code.entities).toContain('\n  Blob: string;\n');
+    expect(code.entities).toContain('\n  Bounded: string;\n');
+  });
+
+  it('maps bounded STRING(N) to string', () => {
+    expect(code.entities).toContain('\n  Guid: string;\n');
+  });
+
+  it('maps *Measure defined types to number by SUFFIX, not prefix', () => {
+    expect(code.entities).toContain('\n  Len: number;\n');
+    // Both directions: an Ifc name that does NOT end in Measure passes through
+    // unchanged, so the rule cannot be a blanket "starts with Ifc -> number".
+    expect(code.entities).toContain('\n  Label: IfcLabel;\n');
+  });
+
+  it('passes unknown/custom types through unchanged', () => {
+    expect(code.entities).toContain('\n  Custom: SomeUnmappedType;\n');
+  });
+});
+
+describe('collection element types are parenthesised when they are unions', () => {
+  const code = generateTypeScript(
+    parseExpressSchema(`
+      SCHEMA TEST_COLLECTIONS;
+
+      TYPE IfcLogicalList = LIST [1:?] OF LOGICAL;
+      END_TYPE;
+
+      ENTITY IfcTest;
+        Flags : LIST [1:?] OF LOGICAL;
+        Points : LIST [1:?] OF IfcCartesianPoint;
+      END_ENTITY;
+
+      END_SCHEMA;
+    `),
+  );
+
+  it('wraps a union element type on the attribute path: (boolean | null)[]', () => {
+    expect(code.entities).toContain('\n  Flags: (boolean | null)[];\n');
+    // The misparse this guards against: `boolean | null[]` is
+    // `boolean | (null[])`, a completely different type.
+    expect(code.entities).not.toContain('\n  Flags: boolean | null[];\n');
+  });
+
+  it('does NOT parenthesise a non-union element type', () => {
+    expect(code.entities).toContain('\n  Points: IfcCartesianPoint[];\n');
+    expect(code.entities).not.toContain('\n  Points: (IfcCartesianPoint)[];\n');
+  });
+
+  it('wraps a union element type on the type-alias path too', () => {
+    expect(code.types).toContain('export type IfcLogicalList = (boolean | null)[];');
+  });
+});
+
+describe('enum member naming', () => {
+  const code = generateTypeScript(
+    parseExpressSchema(`
+      SCHEMA TEST_ENUM_CASE;
+
+      TYPE IfcCaseEnum = ENUMERATION OF
+        (lowercase
+        ,MixedCase
+        ,ALREADYUPPER);
+      END_TYPE;
+
+      END_SCHEMA;
+    `),
+  );
+
+  it('upper-cases the member NAME while preserving the literal VALUE', () => {
+    expect(code.enums).toContain("  LOWERCASE = 'lowercase',");
+    expect(code.enums).toContain("  MIXEDCASE = 'MixedCase',");
+    expect(code.enums).toContain("  ALREADYUPPER = 'ALREADYUPPER',");
+  });
+
+  it('never emits the un-upper-cased member name', () => {
+    expect(code.enums).not.toContain("  lowercase = ");
+    expect(code.enums).not.toContain("  MixedCase = ");
+  });
+});
+
+describe('SCHEMA_REGISTRY escapes values that would break the generated file', () => {
+  // Built directly rather than parsed: the point is that whatever a schema
+  // manages to put in these strings, the emitted module must still parse.
+  const schema: ExpressSchema = {
+    name: 'TEST_ESCAPING',
+    entities: [],
+    types: [{ name: 'IfcQuoted', underlyingType: "STRING\nWITH 'quote'" }],
+    enums: [{ name: 'IfcQuotedEnum', values: ["IT'S"] }],
+    selects: [{ name: 'IfcQuotedSelect', types: ["A'B"] }],
+  };
+  const code = generateTypeScript(schema);
+
+  it('escapes quotes and flattens newlines in the emitted source', () => {
+    expect(code.schemaRegistry).toContain("IfcQuoted: 'STRING WITH \\'quote\\''");
+    expect(code.schemaRegistry).toContain("IfcQuotedEnum: ['IT\\'S']");
+    expect(code.schemaRegistry).toContain("IfcQuotedSelect: ['A\\'B']");
+  });
+
+  it('produces a registry that still parses and carries the original values', async () => {
+    const mod = await evalEmitted(code.schemaRegistry);
+    expect(mod.SCHEMA_REGISTRY.types.IfcQuoted).toBe("STRING WITH 'quote'");
+    expect(mod.SCHEMA_REGISTRY.enums.IfcQuotedEnum).toEqual(["IT'S"]);
+    expect(mod.SCHEMA_REGISTRY.selects.IfcQuotedSelect).toEqual(["A'B"]);
+  });
+});
+
+describe('entity interfaces are emitted parents-first', () => {
+  it('sorts a child declared before its parent behind that parent', () => {
+    const code = generateTypeScript(
+      parseExpressSchema(`
+        SCHEMA TEST_ORDER;
+
+        ENTITY IfcChild
+          SUBTYPE OF (IfcParent);
+          ChildAttr : IfcLabel;
+        END_ENTITY;
+
+        ENTITY IfcParent;
+          ParentAttr : IfcLabel;
+        END_ENTITY;
+
+        END_SCHEMA;
+      `),
+    );
+
+    const parentAt = code.entities.indexOf('export interface IfcParent');
+    const childAt = code.entities.indexOf('export interface IfcChild extends IfcParent');
+    expect(parentAt).toBeGreaterThanOrEqual(0);
+    expect(childAt).toBeGreaterThanOrEqual(0);
+    expect(parentAt).toBeLessThan(childAt);
+  });
+});
+
+describe('emitted SCHEMA_REGISTRY runtime helpers (executed, not substring-matched)', () => {
+  const code = generateTypeScript(
+    parseExpressSchema(`
+      SCHEMA TEST_RUNTIME;
+
+      ENTITY IfcRoot
+        ABSTRACT;
+        GlobalId : IfcGloballyUniqueId;
+      END_ENTITY;
+
+      ENTITY IfcWall
+        SUBTYPE OF (IfcRoot);
+        PredefinedType : OPTIONAL IfcWallTypeEnum;
+      END_ENTITY;
+
+      END_SCHEMA;
+    `),
+  );
+
+  it('getEntityMetadata resolves the PascalCase name', async () => {
+    const mod = await evalEmitted(code.schemaRegistry);
+    expect(mod.getEntityMetadata('IfcWall')?.name).toBe('IfcWall');
+  });
+
+  it('getEntityMetadata normalises the UPPERCASE STEP spelling', async () => {
+    const mod = await evalEmitted(code.schemaRegistry);
+    expect(mod.getEntityMetadata('IFCWALL')?.name).toBe('IfcWall');
+  });
+
+  it('getEntityMetadata returns undefined for an unknown type (negative direction)', async () => {
+    const mod = await evalEmitted(code.schemaRegistry);
+    expect(mod.getEntityMetadata('IFCNOTATHING')).toBeUndefined();
+  });
+
+  it('getAllAttributesForEntity includes INHERITED attributes, parent-first', async () => {
+    const mod = await evalEmitted(code.schemaRegistry);
+    expect(mod.getAllAttributesForEntity('IfcWall').map((a) => a.name)).toEqual([
+      'GlobalId',
+      'PredefinedType',
+    ]);
+    // Both directions: the own-attributes list must NOT include the parent's.
+    expect(mod.getEntityMetadata('IfcWall')?.attributes.map((a) => a.name)).toEqual([
+      'PredefinedType',
+    ]);
+  });
+
+  it('getAllAttributesForEntity returns [] for an unknown type', async () => {
+    const mod = await evalEmitted(code.schemaRegistry);
+    expect(mod.getAllAttributesForEntity('IFCNOTATHING')).toEqual([]);
+  });
+
+  it('getInheritanceChainForEntity runs root -> leaf, and [] when unknown', async () => {
+    const mod = await evalEmitted(code.schemaRegistry);
+    expect(mod.getInheritanceChainForEntity('IfcWall')).toEqual(['IfcRoot', 'IfcWall']);
+    expect(mod.getInheritanceChainForEntity('IFCNOTATHING')).toEqual([]);
+  });
+
+  it('isKnownEntity answers both directions', async () => {
+    const mod = await evalEmitted(code.schemaRegistry);
+    expect(mod.isKnownEntity('IfcWall')).toBe(true);
+    expect(mod.isKnownEntity('IFCWALL')).toBe(true);
+    expect(mod.isKnownEntity('IFCNOTATHING')).toBe(false);
+  });
+
+  it('carries isAbstract through to the runtime metadata, both values', async () => {
+    const mod = await evalEmitted(code.schemaRegistry);
+    expect(mod.getEntityMetadata('IfcRoot')?.isAbstract).toBe(true);
+    expect(mod.getEntityMetadata('IfcWall')?.isAbstract).toBe(false);
+    expect(mod.getEntityMetadata('IfcWall')?.parent).toBe('IfcRoot');
+  });
+});

--- a/rust/core/tests/crc32_spec_vectors.rs
+++ b/rust/core/tests/crc32_spec_vectors.rs
@@ -1,0 +1,119 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Pins the Rust CRC32 type-ID hash to the CRC-32/ISO-HDLC specification.
+//!
+//! `crc32_hash` lives in the generated `rust/core/src/generated/schema.rs` and
+//! is private, so it is pinned here *indirectly* through the public API that
+//! is its only caller: `IfcType::from_str` returns `Unknown(crc32_hash(&upper))`
+//! for any name that is not a known entity. Hashing an unknown name therefore
+//! exercises the same function without touching generated code.
+//!
+//! Why this matters: these IDs cross a language boundary. The TypeScript table
+//! in `packages/parser/src/generated/type-ids.ts` is produced by
+//! `packages/codegen/src/crc32.ts`, and Rust re-derives the hash here for names
+//! outside the table. A wrong-but-self-consistent CRC32 on either side yields
+//! two internally coherent tables that disagree with each other, and neither
+//! suite notices, because each validates against itself. The same vectors are
+//! pinned on the TypeScript side in `packages/codegen/test/crc32.test.ts`.
+
+use ifc_lite_core::IfcType;
+
+/// Hash `name` with the generated `crc32_hash`, via the only public route to it.
+fn unknown_hash(name: &str) -> u32 {
+    match IfcType::from_str(name) {
+        IfcType::Unknown(hash) => hash,
+        known => panic!(
+            "{name:?} was expected to be an unknown type (so that it reaches \
+             crc32_hash), but it parsed as {known:?}"
+        ),
+    }
+}
+
+/// Independent, bit-at-a-time reference implementation of CRC-32/ISO-HDLC,
+/// written from the algorithm's parameters rather than from the generated code:
+///
+/// ```text
+/// width=32  poly=0x04C11DB7  init=0xFFFFFFFF
+/// refin=true  refout=true  xorout=0xFFFFFFFF  check=0xCBF43926
+/// ```
+///
+/// It shares no code and no constants with the implementation under test: the
+/// generated `crc32_hash` is table-driven over the *reflected* polynomial
+/// 0xEDB88320 with right shifts, while this one is table-free over the
+/// *unreflected* polynomial 0x04C11DB7 with left shifts, reflecting each input
+/// byte on the way in and the register on the way out.
+fn crc32_reference(input: &str) -> u32 {
+    let mut reg: u32 = 0xFFFF_FFFF;
+    for byte in input.as_bytes() {
+        reg ^= u32::from(byte.reverse_bits()) << 24;
+        for _ in 0..8 {
+            reg = if reg & 0x8000_0000 != 0 {
+                (reg << 1) ^ 0x04C1_1DB7
+            } else {
+                reg << 1
+            };
+        }
+    }
+    reg.reverse_bits() ^ 0xFFFF_FFFF
+}
+
+#[test]
+fn crc32_hash_matches_the_standard_check_value() {
+    // "check" is defined by the CRC-32/ISO-HDLC specification as the CRC of the
+    // nine ASCII bytes "123456789". `from_str` uppercases its input first, but
+    // digits are unaffected by case, so the vector applies unchanged.
+    assert_eq!(
+        unknown_hash("123456789"),
+        0xCBF4_3926,
+        "Rust crc32_hash is not CRC-32/ISO-HDLC; the type IDs it derives will \
+         disagree with the TypeScript table"
+    );
+}
+
+#[test]
+fn crc32_hash_of_the_empty_string_is_the_xorout_identity() {
+    // With no input the register never leaves init=0xFFFFFFFF, so the result is
+    // init ^ xorout = 0xFFFFFFFF ^ 0xFFFFFFFF = 0.
+    assert_eq!(unknown_hash(""), 0x0000_0000);
+}
+
+#[test]
+fn reference_implementation_is_anchored_to_the_specification() {
+    // Anchor the oracle to the published check value before trusting it below.
+    assert_eq!(crc32_reference("123456789"), 0xCBF4_3926);
+    assert_eq!(crc32_reference(""), 0x0000_0000);
+}
+
+#[test]
+fn crc32_hash_agrees_with_the_independent_reference() {
+    // Names deliberately absent from the IFC entity set so that `from_str`
+    // falls through to `Unknown(crc32_hash(..))`.
+    let names = [
+        "IFCNOTATYPE",
+        "IFCWALLISH",
+        "IFCDEFINITELYNOTANENTITY",
+        "A",
+        "AB",
+        "ABC",
+        "123456789",
+        "SOME_VENDOR_EXTENSION",
+    ];
+    for name in names {
+        assert_eq!(
+            unknown_hash(name),
+            crc32_reference(&name.to_uppercase()),
+            "crc32_hash disagrees with the CRC-32/ISO-HDLC reference for {name:?}"
+        );
+    }
+}
+
+/// The cross-language pin: the exact same spec vectors are asserted in
+/// `packages/codegen/test/crc32.test.ts`, so the two implementations cannot
+/// drift into two self-consistent but mutually incompatible tables.
+#[test]
+fn spec_vectors_are_the_same_ones_pinned_in_typescript() {
+    assert_eq!(unknown_hash("123456789"), 0xCBF4_3926);
+    assert_eq!(unknown_hash(""), 0x0000_0000);
+}


### PR DESCRIPTION
Mutation sweep of `packages/codegen` and `packages/wasm` — the two packages the repo-wide sweep had not reached.

**19 mutations, 4 already killed** (21%). Aimed **deliberately at weak areas**, not sampled uniformly, so this ratio is not comparable to a uniform one. Two of the four kills are deliberate controls, run before any survivor was believed.

Every mutation was applied by an exact-substring `python3` replacement that printed its replacement count and asserted `n == 1`, the mutated region was re-read and confirmed changed before any result was believed, and each was restored by copying back a saved backup — never `git checkout --`.

## `packages/wasm`: nothing to close

The package has **no JavaScript source at all** — only wasm-pack output under `pkg/` (of which just `ifc-lite.d.ts` is tracked) plus five `node --test` suites that drive the Rust-built binary. Every mutation with observable behaviour lands in Rust and needs a wasm rebuild to take effect, so it is not meaningfully mutable from the JS suite. Nothing is changed for it here.

One environmental note, not a change in this PR: `test/package.test.mjs` asserts the packed tarball contains `pkg/ifc-lite.js` and `pkg/ifc-lite_bg.wasm`, and hard-fails (rather than skipping, as the other four suites do) in a tree where the wasm has not been built.

## `packages/codegen`: eight gaps closed

### Two emitters had no test file at all

**`rust-generator.ts`** (714 lines) produces `rust/core/src/generated/{type_ids.rs,schema.rs}` — the Rust core's entire notion of what an IFC type is.

| mutation | result |
|---|---|
| `pub const ${entity.name.toUpperCase()}` → `${entity.name}` | SURVIVED |
| `from_str` arm `"${name.toUpperCase()}"` → `.toLowerCase()` | SURVIVED |

The second one makes every `from_str` arm dead code against the `s.to_uppercase()` it is fed, so every IFC type parses as `Unknown`. Killed by `test/rust-generator.test.ts`, which pins the casing contract in both directions: SCREAMING_CASE constants, PascalCase enum variants, UPPERCASE `from_str` arms and `as_str()`, PascalCase `name()`, and `parent()` / `is_abstract()` arms present only for the entities that earn them.

**`type-ids-generator.ts`** produces `type-ids.ts`.

| mutation | result |
|---|---|
| reverse map `${id}: '${name}',` → `'${name}': ${id},` | SURVIVED |

Still valid TypeScript, still green — and `getTypeName(id)` returns `undefined` for every id at runtime. Killed by `test/type-ids-generator.test.ts`.

### The emitted runtime helpers were never executed

The generated bundles ship `getTypeId`, `getTypeName`, `isValidTypeId`, `crc32Hash`, `getEntityMetadata`, `getAllAttributesForEntity`, `getInheritanceChainForEntity` and `isKnownEntity`. Because the generator emits them as **text**, nothing in this package ever ran them — they were only substring-matched by name.

| mutation | result |
|---|---|
| emitted `return metadata?.allAttributes \|\| []` → `metadata?.attributes` | SURVIVED |

That drops every inherited attribute from every consumer of the generated bundle. The new tests transpile the emitted module (`ts.transpileModule`, already a devDependency) and import it, so the helper *semantics* are pinned, not their presence as substrings.

### Six more survivors in `typescript-generator.ts` / `express-parser.ts`

| mutation | result |
|---|---|
| `LOGICAL: 'boolean \| null'` → `'boolean'` | SURVIVED |
| `BINARY: 'string'` → `'number'` | SURVIVED |
| bounded `STRING(N)` → `'number'` | SURVIVED |
| `expressType.endsWith('Measure')` → `startsWith` | SURVIVED |
| attribute union parenthesisation `(${t})[]` → `${t}[]` | SURVIVED |
| `const memberName = value.toUpperCase()` → `value` | SURVIVED |
| registry `.replace(/'/g, "\\'")` on enum values → dropped | SURVIVED |
| registry `.replace(/'/g,…).replace(/\n/g,' ')` on types → dropped | SURVIVED |
| `topologicalSort` parent visit → `if (false)` | SURVIVED |
| `Math.min(...sectionMatches)` → `Math.max` | SURVIVED |

- Only REAL/INTEGER/BOOLEAN/STRING had fixtures, so the three-valued `LOGICAL → boolean | null` mapping, `BINARY → string`, and the bounded `STRING(N)` / `BINARY(N)` forms were all free.
- The union parenthesisation that makes `LIST OF LOGICAL` emit `(boolean | null)[]` rather than the precedence-misparsed `boolean | null[]` (which is `boolean | (null[])`, a different type) carries an explaining comment in the source but had no guard.
- Enum MEMBER names are upper-cased, but every fixture value was already uppercase, so the call was untestable. Now pinned with a lowercase and a mixed-case value, asserting the NAME is upper-cased while the literal VALUE is preserved.
- Dropping the SCHEMA_REGISTRY quote/newline escaping emits a registry that does not parse; now checked by evaluating the emitted module, not just matching characters.
- Every fixture already declared parents before children, so disabling `topologicalSort`'s parent visit changed nothing.
- The attributes section ends at the FIRST of WHERE / DERIVE / INVERSE / UNIQUE. Every fixture had at most one of those keywords, so "first" and "last" were the same index; taking the last swallows the DERIVE/INVERSE block and turns its lines into bogus attributes.

## Controls and existing kills

Run **before** any survivor was believed, both expected to die, both did:

| control | killed by |
|---|---|
| CRC32 polynomial `0xedb88320` → `0xedb88321` | `crc32.test.ts` |
| `chain.unshift(current.name)` → `chain.push(...)` | `express-parser.test.ts` "should get inheritance chain" |

Two further mutations died against the pre-existing suite: joining SELECT members with `&` instead of `\|`, and making EXPRESS comment stripping greedy (`[\s\S]*?` → `[\s\S]*`).

## Survivor left alone

The `name[3] >= 'A' && name[3] <= 'Z'` fast path in the emitted `normalizeTypeName` is an **equivalent mutant** for the exported surface: it is a pure shortcut, and every input it accepts resolves to the same registry key through the case-insensitive fallback loop directly below it, while every input it rejects resolves to a non-key either way. Left unchanged.

## Notes

- One of my own new assertions was initially vacuous — `toContain('Blob: string;')` also matched inside `FixedBlob: string;`, so the `BINARY` mutation still survived the test meant to kill it. All entity-attribute assertions are now newline-and-indent anchored, and every survivor above was re-run against the finished suite to confirm it now dies.
- `pnpm typecheck` at the root does not cover test files (the package tsconfig excludes `test`), so the new files were typechecked separately against `packages/codegen/tsconfig.json` with `rootDir: "."` and the exclusion lifted — clean.
- No `as any` / `@ts-ignore`; the evaluated modules are typed by declared interfaces.
- Test-only; no production code changed. **codegen 55 → 102 tests, 5 → 8 test files.** No `packages/wasm/pkg/` file is touched. `scripts/check-test-wiring.mjs` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)