### PR TITLE
test(renderer): close 8 mutation-verified coverage gaps

### DIFF
--- a/packages/renderer/src/contribution-cull.test.ts
+++ b/packages/renderer/src/contribution-cull.test.ts
@@ -44,6 +44,31 @@ describe('resolveContributionThresholdPx', () => {
     const opts = { pixelRadius: 2, interactingPixelRadius: 0.5 };
     assert.strictEqual(resolveContributionThresholdPx(opts, true), 2);
   });
+
+  // `pixelRadius <= 0` means DISABLED, and disabled must win over any motion
+  // boost: a viewer that opted out of contribution culling must not start
+  // dropping sub-pixel geometry the moment the user grabs the orbit control.
+  // Guards the `> 0` in the disable check (a `>= 0` there lets the motion
+  // branch resurrect culling from a pixelRadius of exactly 0).
+  it('stays disabled while interacting when pixelRadius is 0, even with a motion boost', () => {
+    assert.strictEqual(
+      resolveContributionThresholdPx({ pixelRadius: 0, interactingPixelRadius: 8 }, true),
+      0,
+    );
+    assert.strictEqual(
+      resolveContributionThresholdPx({ pixelRadius: -1, interactingPixelRadius: 8 }, true),
+      0,
+    );
+    // Both directions: the smallest positive radius is NOT disabled, and the
+    // motion boost applies to it normally.
+    assert.strictEqual(
+      resolveContributionThresholdPx(
+        { pixelRadius: Number.MIN_VALUE, interactingPixelRadius: 8 },
+        true,
+      ),
+      8,
+    );
+  });
 });
 
 describe('projectedAabbRadiusPx (perspective)', () => {
@@ -108,11 +133,37 @@ describe('projectedAabbRadiusPx (perspective)', () => {
     );
     assert.strictEqual(px, Infinity);
   });
+
+  // The tangency boundary itself: depth EXACTLY equal to the bounding-sphere
+  // radius means the sphere touches the camera plane, which the contract
+  // treats as "never cull". Pinned in both directions — one epsilon further
+  // out must produce a finite (cullable) projection, or the guard would be
+  // swallowing everything near the camera.
+  it('fails open at exactly depth === radius, and projects finitely just beyond it', () => {
+    // Box [-1,-1,-2]..[1,1,0] → half-diagonal radius = sqrt(4+4+4)/2 = sqrt(3).
+    const radius = Math.sqrt(3);
+    const cam = perspectiveCam();
+    // Centre at z = -radius → view depth (down -Z) is exactly `radius`.
+    const centreZ = -radius;
+    const atBoundary = projectedAabbRadiusPx(
+      [-1, -1, centreZ - 1],
+      [1, 1, centreZ + 1],
+      cam,
+    );
+    assert.strictEqual(atBoundary, Infinity, 'depth === radius must fail open');
+
+    // Push the same box far enough out that depth > radius: now cullable.
+    const farZ = -radius * 100;
+    const beyond = projectedAabbRadiusPx([-1, -1, farZ - 1], [1, 1, farZ + 1], cam);
+    assert.ok(Number.isFinite(beyond), `depth > radius must project finitely, got ${beyond}`);
+    assert.ok(beyond > 0, `expected a positive pixel radius, got ${beyond}`);
+  });
 });
 
 describe('projectedAabbRadiusPx (orthographic)', () => {
   const orthoCam = (orthoHalfHeight: number): CullCameraState => ({
     eye: { x: 0, y: 0, z: 0 },
+    viewDir: { x: 0, y: 0, z: -1 }, // unused in ortho, required by the interface
     mode: 'orthographic',
     fovYRadians: 0,
     orthoHalfHeight,
@@ -174,6 +225,51 @@ describe('projectedInstancedRadiusPx (instanced templates)', () => {
     assert.ok(Math.abs(px - (2 / 100) * 500) < 1e-9, `got ${px}`);
   });
 
+  // The test above only ever exercises the Z axis: with an axis-aligned
+  // viewDir the X and Y corner picks are multiplied by a zero direction
+  // component and cannot affect the result. A real orbit camera looks
+  // obliquely, so all three axes must be pinned independently — picking the
+  // FAR corner on any axis over-estimates the depth, under-estimates the
+  // projected size, and silently culls instanced templates (repeated bolts,
+  // windows, furniture) that are actually large on screen.
+  it('picks the nearest corner on EVERY axis under an oblique view direction', () => {
+    const inv = 1 / Math.sqrt(3);
+    for (const sx of [1, -1]) {
+      for (const sy of [1, -1]) {
+        for (const sz of [1, -1]) {
+          const cam = perspectiveCam({
+            viewDir: { x: sx * inv, y: sy * inv, z: sz * inv },
+          });
+          const min: [number, number, number] = [100, 200, 300];
+          const max: [number, number, number] = [140, 260, 380];
+          const px = projectedInstancedRadiusPx(min, max, 2, cam);
+
+          // Independent oracle: brute-force the minimum view depth over all
+          // eight corners of the union box, which is what the per-axis sign
+          // trick is a shortcut for.
+          let minDepth = Infinity;
+          for (const x of [min[0], max[0]]) {
+            for (const y of [min[1], max[1]]) {
+              for (const z of [min[2], max[2]]) {
+                const d = x * cam.viewDir.x + y * cam.viewDir.y + z * cam.viewDir.z;
+                if (d < minDepth) minDepth = d;
+              }
+            }
+          }
+          if (!(minDepth > 2)) {
+            assert.strictEqual(px, Infinity, `sx=${sx} sy=${sy} sz=${sz} must fail open`);
+            continue;
+          }
+          const expected = (2 / minDepth) * 500;
+          assert.ok(
+            Math.abs(px - expected) < 1e-9,
+            `sx=${sx} sy=${sy} sz=${sz}: got ${px}, expected ${expected}`,
+          );
+        }
+      }
+    }
+  });
+
   it('fails open when an occurrence could reach the camera plane (minDepth <= radius)', () => {
     const px = projectedInstancedRadiusPx([-10, -10, -10], [10, 10, -1], 5, perspectiveCam());
     assert.strictEqual(px, Infinity);
@@ -192,6 +288,36 @@ describe('projectedInstancedRadiusPx (instanced templates)', () => {
     assert.strictEqual(
       projectedInstancedRadiusPx([-1, -1, -101], [1, 1, -99], NaN, perspectiveCam()),
       Infinity,
+    );
+  });
+
+  // The perspective case above is masked: `!(minDepth > Infinity)` and
+  // `!(minDepth > NaN)` both already return Infinity, so the non-finite
+  // guard is invisible there. The ORTHOGRAPHIC branch has no such downstream
+  // check — without the guard, a NaN radius divides straight through and the
+  // function returns NaN, which every `radius < threshold` comparison reads
+  // as false. That happens to avoid culling, but it leaks NaN into the
+  // renderer's cull bookkeeping instead of the documented Infinity.
+  it('orthographic: fails open with Infinity (not NaN) on poisoned/NaN maxOccRadius', () => {
+    const orthoCam: CullCameraState = {
+      eye: { x: 0, y: 0, z: 0 },
+      viewDir: { x: 0, y: 0, z: -1 },
+      mode: 'orthographic',
+      fovYRadians: 0,
+      orthoHalfHeight: 100,
+      viewportHeightPx: 1000,
+    };
+    assert.strictEqual(
+      projectedInstancedRadiusPx([-1, -1, -101], [1, 1, -99], Infinity, orthoCam),
+      Infinity,
+    );
+    assert.strictEqual(
+      projectedInstancedRadiusPx([-1, -1, -101], [1, 1, -99], NaN, orthoCam),
+      Infinity,
+    );
+    // Opposite direction: a finite radius still projects finitely in ortho.
+    assert.ok(
+      Number.isFinite(projectedInstancedRadiusPx([-1, -1, -101], [1, 1, -99], 0.5, orthoCam)),
     );
   });
 
@@ -215,6 +341,7 @@ describe('projectedInstancedRadiusPx (instanced templates)', () => {
   it('orthographic: depth-independent, scales with zoom', () => {
     const cam: CullCameraState = {
       eye: { x: 0, y: 0, z: 0 },
+      viewDir: { x: 0, y: 0, z: -1 }, // unused in ortho, required by the interface
       mode: 'orthographic',
       fovYRadians: 0,
       orthoHalfHeight: 100,

--- a/packages/renderer/src/contribution-cull.test.ts
+++ b/packages/renderer/src/contribution-cull.test.ts
@@ -234,14 +234,33 @@ describe('projectedInstancedRadiusPx (instanced templates)', () => {
   // windows, furniture) that are actually large on screen.
   it('picks the nearest corner on EVERY axis under an oblique view direction', () => {
     const inv = 1 / Math.sqrt(3);
+    const min: [number, number, number] = [100, 200, 300];
+    const max: [number, number, number] = [140, 260, 380];
+    const centre: [number, number, number] = [
+      (min[0] + max[0]) / 2,
+      (min[1] + max[1]) / 2,
+      (min[2] + max[2]) / 2,
+    ];
     for (const sx of [1, -1]) {
       for (const sy of [1, -1]) {
         for (const sz of [1, -1]) {
+          const viewDir = { x: sx * inv, y: sy * inv, z: sz * inv };
+          // Orbit the eye 500 units BACK along its own view direction from the
+          // box centre, so the box is genuinely in front of the camera in all
+          // eight octants. With the eye pinned at the origin, five of the eight
+          // sign combinations put the box BEHIND the camera, where the nearest
+          // and the far corner both yield a non-positive depth and the function
+          // returns Infinity either way — those iterations assert nothing. A
+          // z-axis corner regression (`nz = unionMin[2]`, ignoring the sign)
+          // survives the origin-eye fixture untouched.
           const cam = perspectiveCam({
-            viewDir: { x: sx * inv, y: sy * inv, z: sz * inv },
+            viewDir,
+            eye: {
+              x: centre[0] - 500 * viewDir.x,
+              y: centre[1] - 500 * viewDir.y,
+              z: centre[2] - 500 * viewDir.z,
+            },
           });
-          const min: [number, number, number] = [100, 200, 300];
-          const max: [number, number, number] = [140, 260, 380];
           const px = projectedInstancedRadiusPx(min, max, 2, cam);
 
           // Independent oracle: brute-force the minimum view depth over all
@@ -251,15 +270,21 @@ describe('projectedInstancedRadiusPx (instanced templates)', () => {
           for (const x of [min[0], max[0]]) {
             for (const y of [min[1], max[1]]) {
               for (const z of [min[2], max[2]]) {
-                const d = x * cam.viewDir.x + y * cam.viewDir.y + z * cam.viewDir.z;
+                const d =
+                  (x - cam.eye.x) * cam.viewDir.x +
+                  (y - cam.eye.y) * cam.viewDir.y +
+                  (z - cam.eye.z) * cam.viewDir.z;
                 if (d < minDepth) minDepth = d;
               }
             }
           }
-          if (!(minDepth > 2)) {
-            assert.strictEqual(px, Infinity, `sx=${sx} sy=${sy} sz=${sz} must fail open`);
-            continue;
-          }
+          // Guard the fixture itself: every octant must stay in front of the
+          // camera, or the assertion below degenerates into Infinity ===
+          // Infinity and stops discriminating.
+          assert.ok(
+            minDepth > 2,
+            `sx=${sx} sy=${sy} sz=${sz}: fixture must sit in front of the camera (minDepth ${minDepth})`,
+          );
           const expected = (2 / minDepth) * 500;
           assert.ok(
             Math.abs(px - expected) < 1e-9,

--- a/packages/renderer/src/instanced-render.test.ts
+++ b/packages/renderer/src/instanced-render.test.ts
@@ -13,6 +13,7 @@ import {
   INSTANCE_FLAGS_OFFSET,
   INSTANCE_FLAG_SELECTED,
 } from './instanced-render.js';
+import { OPAQUE_ALPHA_CUTOFF } from './overlay-routing.js';
 
 // --- frame helpers (independent re-derivation of the expected world coord) ---
 
@@ -223,6 +224,78 @@ describe('prepareInstancedRender — grouping + buffer assembly', () => {
     assert.strictEqual(t0.instanceCount, 1, 'the transparent occurrence of template 0 is excluded');
     const dv = new DataView(t0.instanceBuffer);
     assert.strictEqual(dv.getUint32(64, true), 1, 'the kept instance is the opaque one (entityId 1)');
+  });
+
+  // The cutoff boundary itself. Alpha EXACTLY at OPAQUE_ALPHA_CUTOFF must be
+  // treated as opaque, because that is what the flat split does too
+  // (`alpha < OPAQUE_ALPHA_CUTOFF` in overlay-routing.ts and scene.ts). If the
+  // instanced path used `<=` instead, an occurrence at alpha 0.99 would be
+  // dropped from the instanced pass while the flat pass also considers it
+  // opaque — the geometry renders nowhere and the user sees repeated elements
+  // silently missing. Existing fixtures only use 0.3/0.5/1.0, so the boundary
+  // was free in both directions.
+  it('treats alpha EXACTLY at the opaque cutoff as opaque, one epsilon below as transparent', () => {
+    const origin: [number, number, number] = [0, 0, 0];
+    const tmpl = () => ({
+      positions: new Float32Array([0, 0, 0]),
+      normals: new Float32Array([0, 1, 0]),
+      indices: new Uint32Array([0]),
+      origin,
+    });
+    const inst = (entityId: number, alpha: number) => ({
+      templateIndex: 0,
+      entityId,
+      color: [1, 1, 1, alpha] as [number, number, number, number],
+      transform: rowMajorIdentity(),
+    });
+
+    // Exactly at the cutoff → opaque → kept by the instanced path.
+    const atCutoff = prepareInstancedRender({
+      templates: [tmpl()],
+      instances: [inst(1, OPAQUE_ALPHA_CUTOFF)],
+    });
+    assert.strictEqual(atCutoff.length, 1, 'alpha === cutoff must stay in the instanced path');
+    assert.strictEqual(atCutoff[0].instanceCount, 1);
+    assert.deepStrictEqual(Array.from(atCutoff[0].entityIds), [1]);
+
+    // One representable step below → transparent → excluded.
+    const belowCutoff = prepareInstancedRender({
+      templates: [tmpl()],
+      instances: [inst(2, OPAQUE_ALPHA_CUTOFF - Number.EPSILON)],
+    });
+    assert.strictEqual(belowCutoff.length, 0, 'just below the cutoff must route to the flat path');
+  });
+
+  // Documented defensive branch ("a corrupt templateIndex would otherwise
+  // throw; drop it loudly-safe") that no fixture ever reached. Without the
+  // guard an out-of-range or negative templateIndex in a decoded IFNS shard
+  // throws mid-upload, so the whole model fails to appear instead of losing
+  // one bad occurrence.
+  it('drops occurrences with an out-of-range templateIndex instead of throwing', () => {
+    const origin: [number, number, number] = [0, 0, 0];
+    const shard = {
+      templates: [
+        {
+          positions: new Float32Array([0, 0, 0]),
+          normals: new Float32Array([0, 1, 0]),
+          indices: new Uint32Array([0]),
+          origin,
+        },
+      ],
+      instances: [
+        { templateIndex: 0, entityId: 1, color: [1, 0, 0, 1] as [number, number, number, number], transform: rowMajorIdentity() },
+        { templateIndex: 5, entityId: 2, color: [1, 0, 0, 1] as [number, number, number, number], transform: rowMajorIdentity() },
+        { templateIndex: -1, entityId: 3, color: [1, 0, 0, 1] as [number, number, number, number], transform: rowMajorIdentity() },
+      ],
+    };
+
+    let out!: ReturnType<typeof prepareInstancedRender>;
+    assert.doesNotThrow(() => {
+      out = prepareInstancedRender(shard);
+    }, 'a corrupt templateIndex must not abort the whole shard');
+    assert.strictEqual(out.length, 1, 'the one valid template still uploads');
+    assert.strictEqual(out[0].instanceCount, 1, 'only the valid occurrence is kept');
+    assert.deepStrictEqual(Array.from(out[0].entityIds), [1]);
   });
 });
 

--- a/packages/renderer/src/render-stats.test.ts
+++ b/packages/renderer/src/render-stats.test.ts
@@ -36,6 +36,53 @@ describe('sumResidentGpuBytes', () => {
     assert.strictEqual(r.total, r.batches);
   });
 
+  // The LOD1 index buffer (#1682 phase 5) is a SECOND index buffer allocated
+  // alongside the batch. It is real GPU memory and the residency budget is
+  // what decides when to evict — under-counting it makes the renderer believe
+  // it is inside a budget it has actually blown, so eviction never fires and
+  // large models drift toward GPU OOM / driver-level allocation failures.
+  // No existing fixture sets `lod1IndexBuffer`, so its contribution was free.
+  it('counts the LOD1 index buffer when a batch has one built', () => {
+    const withoutLod = sumResidentGpuBytes({
+      batches: [{ vertexBuffer: buf(1000), indexBuffer: buf(400), uniformBuffer: buf(224) }],
+      partialBatches: [],
+      meshes: [],
+      textured: [],
+      instanced: [],
+    });
+    assert.strictEqual(withoutLod.batches, 1000 + 400 + 224);
+
+    const withLod = sumResidentGpuBytes({
+      batches: [
+        {
+          vertexBuffer: buf(1000),
+          indexBuffer: buf(400),
+          uniformBuffer: buf(224),
+          lod1IndexBuffer: buf(128),
+        },
+      ],
+      partialBatches: [],
+      meshes: [],
+      textured: [],
+      instanced: [],
+    });
+    assert.strictEqual(withLod.batches, 1000 + 400 + 224 + 128);
+    assert.strictEqual(withLod.total, withoutLod.total + 128);
+
+    // Same accounting on every collection that flows through `sumBatch`.
+    const viaMeshesAndPartials = sumResidentGpuBytes({
+      batches: [],
+      partialBatches: [
+        { vertexBuffer: buf(10), indexBuffer: buf(4), lod1IndexBuffer: buf(2) },
+      ],
+      meshes: [{ vertexBuffer: buf(10), indexBuffer: buf(4), lod1IndexBuffer: buf(6) }],
+      textured: [],
+      instanced: [],
+    });
+    assert.strictEqual(viaMeshesAndPartials.batches, 10 + 4 + 2);
+    assert.strictEqual(viaMeshesAndPartials.meshes, 10 + 4 + 6);
+  });
+
   it('estimates textures at 4 bytes per texel across array layers', () => {
     const r = sumResidentGpuBytes({
       batches: [],

--- a/packages/renderer/src/residency.test.ts
+++ b/packages/renderer/src/residency.test.ts
@@ -51,6 +51,30 @@ describe('selectEvictions (#1682 phase 3a)', () => {
     assert.deepStrictEqual(selectEvictions(shells, MB, 0, FRAME, 5), ['a']);
   });
 
+  // Exact-fit boundary. The existing cases all overshoot the budget (excess
+  // goes negative on the last eviction), so the loop's stop condition is only
+  // ever tested in its `< 0` form. When the evicted bytes land EXACTLY on the
+  // budget the loop must stop there: evicting one more batch destroys GPU
+  // buffers that were within budget, and the user sees that batch pop back in
+  // a frame or two after a needless re-upload.
+  it('stops the moment the excess is exactly met, not one batch later', () => {
+    const shells = [
+      shell('oldest', 10 * MB, 1),
+      shell('next', 10 * MB, 2),
+      shell('newest', 10 * MB, 3),
+    ];
+    // 30MB resident, 20MB budget → excess exactly 10MB = one batch.
+    assert.deepStrictEqual(selectEvictions(shells, 30 * MB, 20 * MB, FRAME), ['oldest']);
+    // Two batches' worth of excess, again landing exactly on zero.
+    assert.deepStrictEqual(selectEvictions(shells, 30 * MB, 10 * MB, FRAME), ['oldest', 'next']);
+    // Opposite direction: one byte more excess than an exact fit needs the
+    // next batch too.
+    assert.deepStrictEqual(selectEvictions(shells, 30 * MB + 1, 20 * MB, FRAME), [
+      'oldest',
+      'next',
+    ]);
+  });
+
   it('returns everything eligible when even full eviction cannot meet the budget', () => {
     const shells = [shell('a', MB, 0), shell('b', MB, 1)];
     assert.deepStrictEqual(selectEvictions(shells, 100 * MB, MB, FRAME), ['a', 'b']);


### PR DESCRIPTION
test(renderer): close 8 mutation-verified coverage gaps

A mutation sweep of `packages/renderer` (38 test files, 414 tests) — the
last unswept package, and one named in `scripts/check-test-wiring.mjs`'s
own docstring as having had 13 test files silently dark in CI for months.
The wiring is fixed and the suite genuinely runs; this establishes what
that suite is now worth.

18 mutations against GPU-free logic (culling maths, residency/eviction
policy, instancing bookkeeping, GPU-byte accounting). 2 were deliberate
controls run first to prove the harness was operating on mutated source;
both died. Of the 16 real mutations, 7 were already killed, 9 survived —
8 genuine untested gaps, 1 proven-equivalent mutant that is NOT counted
as a gap and for which no test was written.

The ratio is TARGETED, not uniform: mutations were aimed at boundary
conditions and documented-but-unexercised defensive branches, so it is
not comparable to a uniform sample.

contribution-cull (5 gaps)

1. `projectedInstancedRadiusPx` nearest-corner selection. The existing
   "picks the nearest corner per viewDir sign" test uses an axis-aligned
   viewDir, so the X and Y corner picks are multiplied by a zero
   direction component and cannot affect the result — only the Z axis
   was pinned. Flipping the X pick (and independently the Y pick) from
   near corner to far corner kept all 414 tests green. Picking the far
   corner over-estimates the view depth and under-estimates the
   projected size, so an oblique camera — i.e. any real orbit — silently
   culls instanced templates that are large on screen: repeated bolts,
   windows and furniture pop out of the model. Now pinned across all
   eight viewDir sign octants against a brute-force eight-corner oracle.

2. `resolveContributionThresholdPx` disable check. `pixelRadius > 0`
   relaxed to `>= 0` survived: with culling explicitly disabled
   (pixelRadius 0) but a motion boost configured, the mutant resumes
   culling the moment the user grabs the orbit control. Both directions
   pinned, including that the smallest positive radius is not disabled.

3. `projectedAabbRadiusPx` tangency boundary. `depth <= radius` relaxed
   to `depth < radius` survived — no fixture sat exactly on the
   boundary. Pinned in both directions: exactly at tangency fails open,
   just beyond it projects finitely.

4. `projectedInstancedRadiusPx` non-finite-radius guard, orthographic
   branch. The existing poison test only covers perspective, where the
   guard is masked (`!(minDepth > Infinity)` and `!(minDepth > NaN)`
   both already return Infinity). Ortho has no such downstream check:
   without the guard a NaN radius divides straight through and the
   function returns NaN instead of the documented Infinity, leaking NaN
   into the renderer's cull bookkeeping.

residency (1 gap)

5. `selectEvictions` exact-fit stop condition. Every existing case
   overshoots the budget, so the loop's `excess <= 0` break was only
   ever tested in its `< 0` form; relaxing it survived. When the evicted
   bytes land exactly on the budget the mutant destroys one more batch's
   GPU buffers than needed, and the user sees that batch pop back in
   after a needless re-upload. Both the exact-fit and the one-byte-over
   cases are now pinned.

render-stats (1 gap)

6. `sumResidentGpuBytes` LOD1 index buffer. No fixture set
   `lod1IndexBuffer`, so its whole contribution was free — dropping it
   survived. Under-counting it makes the residency budget believe it is
   inside a limit it has actually blown, so eviction never fires and
   large models drift toward GPU allocation failure. Pinned on batches,
   partial sub-batches and meshes.

instanced-render (2 gaps)

7. Opaque/transparent cutoff boundary. Existing fixtures use alpha 0.3,
   0.5 and 1.0, so `< OPAQUE_ALPHA_CUTOFF` relaxed to `<=` survived.
   Alpha exactly 0.99 must be opaque, matching the flat split in
   overlay-routing.ts and scene.ts; under the mutant such an occurrence
   is dropped from the instanced pass while the flat pass also treats it
   as opaque, so the geometry renders nowhere and repeated elements go
   silently missing. Boundary pinned in both directions.

8. Corrupt `templateIndex` guard. The documented defensive branch
   ("drop it loudly-safe") was never reached by a fixture; removing it
   survived. Without it an out-of-range or negative templateIndex in a
   decoded IFNS shard throws mid-upload, so the entire model fails to
   appear instead of losing one bad occurrence.

Not counted as a gap: the early `excess <= 0` return in
`selectEvictions` relaxed to `< 0` survives and is a proven-equivalent
mutant — the only differing input class is excess === 0, where the
loop's own `excess <= 0` break returns the same empty array on the first
candidate, and building the candidate list has no side effects. It still
survives after this change, deliberately; no test was manufactured for
it.

Test-only: no production code is changed. Every new test was
RED-verified under its mutation and GREEN with the mutation reverted,
each mutation applied via an exact-substring replacement asserting a
replacement count of exactly 1, and the mutated region re-read on disk
before any result was believed. Two pre-existing type errors in
contribution-cull.test.ts (orthographic camera literals missing the
required `viewDir`) are fixed in passing, since the package tsconfig
excludes `**/*.test.ts` and these files were typechecked separately with
that exclusion lifted.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded rendering coverage for contribution culling across interaction states, camera angles, tangencies, and orthographic projections.
  * Added instancing tests for alpha cutoff behavior and invalid template handling.
  * Added regression coverage for resident GPU memory calculations, including additional index-buffer memory.
  * Added eviction tests for exact-fit memory budgets and near-limit scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->