### PR TITLE
test(server-bin,create-ifc-lite): wire both packages into CI and close 32 mutation-verified gaps

### DIFF
--- a/packages/create-ifc-lite/package.json
+++ b/packages/create-ifc-lite/package.json
@@ -9,7 +9,8 @@
   "main": "./dist/index.js",
   "scripts": {
     "build": "pnpm exec tsc",
-    "dev": "pnpm exec tsc --watch"
+    "dev": "pnpm exec tsc --watch",
+    "test": "vitest run"
   },
   "files": [
     "dist"
@@ -36,7 +37,8 @@
   },
   "devDependencies": {
     "@types/node": "^26.1.2",
-    "typescript": "^5.3.0"
+    "typescript": "^5.3.0",
+    "vitest": "^4.1.10"
   },
   "homepage": "https://ifclite.dev/docs/",
   "bugs": "https://github.com/LTplus-AG/ifc-lite/issues"

--- a/packages/create-ifc-lite/test/cli.test.ts
+++ b/packages/create-ifc-lite/test/cli.test.ts
@@ -1,0 +1,251 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect, beforeEach, afterEach, beforeAll } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, existsSync, writeFileSync, chmodSync, readdirSync, realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { createRequire } from 'node:module';
+
+/**
+ * The scaffolder is a bin with no exports, so its argument parsing and its
+ * project-name guard can only be exercised by running it. Every run here uses a
+ * throwaway temp directory as cwd, and `npm` is shadowed by a stub that fails
+ * immediately, so no test ever reaches the network or writes outside the temp
+ * directory. Runs that get past validation are asserted on the banner the CLI
+ * prints BEFORE any template work begins.
+ */
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CLI = resolve(__dirname, '../src/index.ts');
+// Resolve tsx from THIS package, not from the spawned process's cwd (a temp dir
+// with no node_modules), otherwise `node --import tsx` cannot find the loader.
+const TSX_LOADER = createRequire(import.meta.url).resolve('tsx');
+
+let workDir: string;
+let stubBin: string;
+
+beforeAll(() => {
+  // A fake `npm` that exits non-zero at once, so template scaffolding cannot
+  // reach the real registry from a unit test.
+  stubBin = mkdtempSync(join(tmpdir(), 'ifclite-stubbin-'));
+  const npmStub = join(stubBin, 'npm');
+  writeFileSync(npmStub, '#!/bin/sh\necho "registry disabled in tests" >&2\nexit 1\n');
+  chmodSync(npmStub, 0o755);
+});
+
+beforeEach(() => {
+  // realpath: on macOS /var is a symlink to /private/var and the child's
+  // process.cwd() reports the resolved form.
+  workDir = realpathSync(mkdtempSync(join(tmpdir(), 'ifclite-create-')));
+});
+
+afterEach(() => {
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+function run(args: string[]) {
+  const result = spawnSync(process.execPath, ['--import', pathToFileURL(TSX_LOADER).href, CLI, ...args], {
+    cwd: workDir,
+    encoding: 'utf-8',
+    env: {
+      ...process.env,
+      PATH: `${stubBin}:${process.env.PATH ?? ''}`,
+      npm_config_registry: 'http://127.0.0.1:1/',
+    },
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  };
+}
+
+describe('project name validation', () => {
+  const rejected = [
+    ['../evil', 'parent traversal'],
+    ['../../etc', 'multi-level traversal'],
+    ['..', 'a bare parent reference'],
+    ['.', 'the current directory'],
+    ['foo/bar', 'a nested path'],
+    ['/tmp/absolute', 'an absolute path'],
+    ['a/../b', 'traversal in the middle'],
+    ['@scope/..', 'a scoped name whose last segment is a dot-segment'],
+    ['@scope/.', 'a scoped name ending in a single dot-segment'],
+    ['~/home', 'a tilde path'],
+    ['name with spaces', 'whitespace'],
+    ['proj;rm -rf /', 'shell metacharacters'],
+    ['name$(id)', 'command substitution'],
+    ['back\\slash', 'a backslash separator'],
+  ] as const;
+
+  for (const [name, why] of rejected) {
+    it(`rejects ${why}: ${JSON.stringify(name)}`, () => {
+      const { status, stderr } = run([name]);
+      expect(stderr).toContain('Invalid project name');
+      expect(status).toBe(1);
+    });
+  }
+
+  it('creates nothing anywhere when the name is rejected', () => {
+    const outside = join(workDir, 'outside');
+    mkdirSync(outside);
+    const inner = join(outside, 'inner');
+    mkdirSync(inner);
+    const before = readdirSync(outside);
+
+    const { status } = run(['../evil']);
+    expect(status).toBe(1);
+    expect(readdirSync(outside)).toEqual(before);
+    expect(existsSync(join(workDir, 'evil'))).toBe(false);
+    expect(existsSync(resolve(workDir, '../evil'))).toBe(false);
+    void inner;
+  });
+
+  const accepted = [
+    'my-ifc-app',
+    'my_app',
+    'app.v2',
+    'App123',
+    '@scope/pkg',
+    '@my.scope/my-pkg',
+  ];
+
+  for (const name of accepted) {
+    it(`accepts ${JSON.stringify(name)} and targets it under cwd`, () => {
+      const { stdout, stderr } = run([name]);
+      expect(stderr).not.toContain('Invalid project name');
+      expect(stdout).toContain(`Creating IFC-Lite project in ${join(workDir, name)}`);
+    });
+  }
+
+  it('defaults the project name to my-ifc-app when none is given', () => {
+    const { stdout } = run([]);
+    expect(stdout).toContain(`Creating IFC-Lite project in ${join(workDir, 'my-ifc-app')}`);
+  });
+});
+
+describe('existing directory protection', () => {
+  it('refuses to scaffold into an existing directory', () => {
+    mkdirSync(join(workDir, 'taken'));
+    const { status, stderr } = run(['taken']);
+    expect(stderr).toContain('Directory "taken" already exists.');
+    expect(status).toBe(1);
+  });
+
+  it('refuses even when the existing directory is empty', () => {
+    mkdirSync(join(workDir, 'empty-dir'));
+    expect(readdirSync(join(workDir, 'empty-dir'))).toEqual([]);
+    expect(run(['empty-dir']).status).toBe(1);
+  });
+
+  it('refuses when the name collides with an existing FILE', () => {
+    writeFileSync(join(workDir, 'afile'), 'x');
+    const { status, stderr } = run(['afile']);
+    expect(stderr).toContain('already exists');
+    expect(status).toBe(1);
+  });
+
+  it('does not touch the contents of the existing directory', () => {
+    const dir = join(workDir, 'taken');
+    mkdirSync(dir);
+    writeFileSync(join(dir, 'keep.txt'), 'precious');
+    run(['taken']);
+    expect(readdirSync(dir)).toEqual(['keep.txt']);
+  });
+
+  it('proceeds when the directory does not exist', () => {
+    const { stdout } = run(['fresh']);
+    expect(stdout).toContain('Creating IFC-Lite project in');
+  });
+});
+
+describe('template flag parsing', () => {
+  for (const template of ['basic', 'threejs', 'babylonjs', 'react', 'server', 'server-native']) {
+    it(`accepts --template ${template}`, () => {
+      const { stderr } = run(['proj', '--template', template]);
+      expect(stderr).not.toContain('Invalid template');
+    });
+  }
+
+  it('accepts the -t alias', () => {
+    const { stderr } = run(['proj', '-t', 'threejs']);
+    expect(stderr).not.toContain('Invalid template');
+  });
+
+  it('rejects an unknown template and names it', () => {
+    const { status, stderr } = run(['proj', '--template', 'svelte']);
+    expect(stderr).toContain('Invalid template: svelte');
+    expect(status).toBe(1);
+  });
+
+  it('rejects --template with no value', () => {
+    const { status, stderr } = run(['proj', '--template']);
+    expect(stderr).toContain('Invalid template');
+    expect(status).toBe(1);
+  });
+
+  // KNOWN DEFECT, pinned rather than fixed here (behaviour change is the
+  // maintainer's call): the guard is `t in TEMPLATES`, and `in` walks the
+  // prototype chain, so every Object.prototype key is accepted as a template
+  // name. None of the `if (template === ...)` branches then match, so the user
+  // silently gets the `basic` scaffold instead of an "Invalid template" error.
+  for (const protoKey of ['toString', 'constructor', 'valueOf', 'hasOwnProperty']) {
+    it(`KNOWN DEFECT: --template ${protoKey} is accepted and silently scaffolds basic`, () => {
+      const { stderr } = run(['proj', '--template', protoKey]);
+      expect(stderr).not.toContain('Invalid template');
+    });
+  }
+
+  it('consumes the template value so it is not mistaken for the project name', () => {
+    const { stdout } = run(['--template', 'threejs', 'named']);
+    expect(stdout).toContain(`Creating IFC-Lite project in ${join(workDir, 'named')}`);
+  });
+
+  it('does not treat the template value as the project name when the name is omitted', () => {
+    const { stdout } = run(['--template', 'react']);
+    expect(stdout).toContain(`Creating IFC-Lite project in ${join(workDir, 'my-ifc-app')}`);
+  });
+
+  it('never treats a flag-looking argument as the project name', () => {
+    const { stdout, stderr } = run(['--verbose']);
+    expect(stderr).not.toContain('Invalid project name');
+    expect(stdout).toContain(`Creating IFC-Lite project in ${join(workDir, 'my-ifc-app')}`);
+  });
+
+  it('lets a later positional argument win over an earlier one', () => {
+    const { stdout } = run(['first', 'second']);
+    expect(stdout).toContain(`Creating IFC-Lite project in ${join(workDir, 'second')}`);
+  });
+});
+
+describe('help', () => {
+  it('prints usage and exits 0 for --help', () => {
+    const { status, stdout } = run(['--help']);
+    expect(status).toBe(0);
+    expect(stdout).toContain('create-ifc-lite - Create IFC-Lite projects instantly');
+  });
+
+  it('prints usage and exits 0 for -h', () => {
+    const { status, stdout } = run(['-h']);
+    expect(status).toBe(0);
+    expect(stdout).toContain('Usage:');
+  });
+
+  it('lists every template in the help text', () => {
+    const { stdout } = run(['--help']);
+    for (const template of ['basic', 'threejs', 'babylonjs', 'react', 'server', 'server-native']) {
+      expect(stdout).toContain(template);
+    }
+  });
+
+  it('help wins over an otherwise-invalid project name and creates nothing', () => {
+    const { status, stdout } = run(['../evil', '--help']);
+    expect(status).toBe(0);
+    expect(stdout).toContain('Usage:');
+    expect(existsSync(resolve(workDir, '../evil'))).toBe(false);
+  });
+});

--- a/packages/create-ifc-lite/test/config-fixers.test.ts
+++ b/packages/create-ifc-lite/test/config-fixers.test.ts
@@ -1,0 +1,343 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+/**
+ * `config-fixers` shells out to `npm view` to resolve published versions. That
+ * is mocked here, so no test touches the registry; the filesystem work happens
+ * in a temp directory that is removed afterwards.
+ */
+
+const execFileSyncMock = vi.hoisted(() => vi.fn());
+
+vi.mock('child_process', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('child_process')>()),
+  execFileSync: execFileSyncMock,
+}));
+
+type Fixers = typeof import('../src/utils/config-fixers.js');
+
+let fixers: Fixers;
+let dir: string;
+
+/**
+ * Route `npm view <pkg> versions --json` and `npm view <pkg>@<v> dependencies
+ * --json` to fixture data. `versions` lists the published versions of a package
+ * (oldest first, as npm returns them); `deps` maps "<pkg>@<version>" to that
+ * version's dependency map.
+ */
+function stubRegistry(
+  versions: Record<string, string[]>,
+  deps: Record<string, Record<string, string>> = {}
+) {
+  execFileSyncMock.mockImplementation((_cmd: string, args: string[]) => {
+    const viewArgs = args[0] === '/d' ? args.slice(4) : args;
+    const [, spec, field] = viewArgs;
+    if (field === 'versions') {
+      return Buffer.from(JSON.stringify(versions[spec] ?? []));
+    }
+    if (field === 'dependencies') {
+      return Buffer.from(JSON.stringify(deps[spec] ?? {}));
+    }
+    throw new Error(`unexpected npm view field: ${field}`);
+  });
+}
+
+beforeEach(async () => {
+  vi.resetModules();
+  execFileSyncMock.mockReset();
+  dir = mkdtempSync(join(tmpdir(), 'ifclite-fixers-'));
+  fixers = await import('../src/utils/config-fixers.js');
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe('getPackageVersion', () => {
+  it('returns the newest installable version as a caret range', () => {
+    stubRegistry({ '@ifc-lite/parser': ['1.0.0', '1.1.0', '1.2.0'] });
+    expect(fixers.getPackageVersion('@ifc-lite/parser')).toBe('^1.2.0');
+  });
+
+  it('prefers the newest of the candidates, not the oldest', () => {
+    stubRegistry({ pkg: ['0.1.0', '9.9.9'] });
+    expect(fixers.getPackageVersion('pkg')).toBe('^9.9.9');
+  });
+
+  it('only considers the last 10 published versions', () => {
+    // 12 published; the two oldest must be out of reach even if everything
+    // newer were uninstallable.
+    const versions = Array.from({ length: 12 }, (_, i) => `1.0.${i}`);
+    const deps: Record<string, Record<string, string>> = {};
+    for (const v of versions.slice(2)) {
+      deps[`pkg@${v}`] = { '@ifc-lite/core': '^2.0.0' };
+    }
+    stubRegistry({ pkg: versions, '@ifc-lite/core': [] }, deps);
+    expect(() => fixers.getPackageVersion('pkg')).toThrow(/Failed to resolve the latest published version of pkg/);
+  });
+
+  it('reaches back through the candidate window to the newest installable version', () => {
+    stubRegistry(
+      { pkg: ['1.0.0', '1.0.1', '1.0.2'], '@ifc-lite/core': ['2.0.0'] },
+      {
+        'pkg@1.0.2': { '@ifc-lite/core': '^9.9.9' },
+        'pkg@1.0.1': { '@ifc-lite/core': '^2.0.0' },
+      }
+    );
+    expect(fixers.getPackageVersion('pkg')).toBe('^1.0.1');
+  });
+
+  it('skips a version whose @ifc-lite dependency was never published', () => {
+    stubRegistry(
+      { pkg: ['1.0.0', '2.0.0'], '@ifc-lite/core': ['1.0.0'] },
+      { 'pkg@2.0.0': { '@ifc-lite/core': '^7.7.7' }, 'pkg@1.0.0': { '@ifc-lite/core': '^1.0.0' } }
+    );
+    expect(fixers.getPackageVersion('pkg')).toBe('^1.0.0');
+  });
+
+  it('ignores non-@ifc-lite dependencies entirely when judging installability', () => {
+    stubRegistry({ pkg: ['1.0.0'] }, { 'pkg@1.0.0': { react: '^99.0.0', three: '^0.1.0' } });
+    expect(fixers.getPackageVersion('pkg')).toBe('^1.0.0');
+    // React's own published versions must never have been queried.
+    const queried = execFileSyncMock.mock.calls.map((c) => (c[1] as string[]).join(' '));
+    expect(queried.some((q) => q.includes('react'))).toBe(false);
+  });
+
+  it('ignores an @ifc-lite dependency range with no pinnable version', () => {
+    stubRegistry({ pkg: ['1.0.0'] }, { 'pkg@1.0.0': { '@ifc-lite/core': 'workspace:^' } });
+    expect(fixers.getPackageVersion('pkg')).toBe('^1.0.0');
+  });
+
+  it('extracts the pinned version out of a caret range', () => {
+    stubRegistry(
+      { pkg: ['1.0.0'], '@ifc-lite/core': ['3.4.5'] },
+      { 'pkg@1.0.0': { '@ifc-lite/core': '^3.4.5' } }
+    );
+    expect(fixers.getPackageVersion('pkg')).toBe('^1.0.0');
+  });
+
+  it('rejects when a pinned dependency version is absent from the registry', () => {
+    stubRegistry(
+      { pkg: ['1.0.0'], '@ifc-lite/core': ['3.4.4'] },
+      { 'pkg@1.0.0': { '@ifc-lite/core': '^3.4.5' } }
+    );
+    expect(() => fixers.getPackageVersion('pkg')).toThrow(/Failed to resolve/);
+  });
+
+  it('throws instead of emitting a placeholder when nothing is published', () => {
+    stubRegistry({ pkg: [] });
+    expect(() => fixers.getPackageVersion('pkg')).toThrow(/Failed to resolve the latest published version of pkg/);
+  });
+
+  it('throws with actionable text when the registry is unreachable', () => {
+    execFileSyncMock.mockImplementation(() => {
+      throw new Error('ENOTFOUND registry.npmjs.org');
+    });
+    expect(() => fixers.getPackageVersion('pkg')).toThrow(/Check your npm registry access/);
+  });
+
+  it('caches resolved versions so a second call makes no registry query', () => {
+    stubRegistry({ pkg: ['1.0.0'] });
+    expect(fixers.getPackageVersion('pkg')).toBe('^1.0.0');
+    const callsAfterFirst = execFileSyncMock.mock.calls.length;
+    expect(fixers.getPackageVersion('pkg')).toBe('^1.0.0');
+    expect(execFileSyncMock.mock.calls.length).toBe(callsAfterFirst);
+  });
+
+  it('caches published-version lists across packages that share a dependency', () => {
+    stubRegistry(
+      { a: ['1.0.0'], b: ['1.0.0'], '@ifc-lite/core': ['2.0.0'] },
+      { 'a@1.0.0': { '@ifc-lite/core': '^2.0.0' }, 'b@1.0.0': { '@ifc-lite/core': '^2.0.0' } }
+    );
+    fixers.getPackageVersion('a');
+    fixers.getPackageVersion('b');
+    const coreVersionQueries = execFileSyncMock.mock.calls.filter((c) => {
+      const args = c[1] as string[];
+      return args.includes('@ifc-lite/core') && args.includes('versions');
+    });
+    expect(coreVersionQueries.length).toBe(1);
+  });
+
+  it('refuses a package name that could smuggle npm flags or shell text', () => {
+    stubRegistry({});
+    for (const bad of ['--registry=http://evil', 'pkg; rm -rf /', 'pkg name', '../pkg', '@a/b/c']) {
+      expect(() => fixers.getPackageVersion(bad)).toThrow(/Failed to resolve/);
+    }
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  it('accepts scoped and unscoped well-formed names', () => {
+    stubRegistry({ '@ifc-lite/parser': ['1.0.0'], three: ['0.160.0'] });
+    expect(fixers.getPackageVersion('@ifc-lite/parser')).toBe('^1.0.0');
+    expect(fixers.getPackageVersion('three')).toBe('^0.160.0');
+  });
+
+  it('invokes npm directly (no shell) on non-Windows platforms', () => {
+    stubRegistry({ pkg: ['1.0.0'] });
+    fixers.getPackageVersion('pkg');
+    const [command, args] = execFileSyncMock.mock.calls[0];
+    if (process.platform !== 'win32') {
+      expect(command).toBe('npm');
+      expect(args).toEqual(['view', 'pkg', 'versions', '--json']);
+    } else {
+      expect(args.slice(0, 4)).toEqual(['/d', '/s', '/c', 'npm']);
+    }
+  });
+
+  it('bounds the registry call with a timeout', () => {
+    stubRegistry({ pkg: ['1.0.0'] });
+    fixers.getPackageVersion('pkg');
+    expect(execFileSyncMock.mock.calls[0][2]).toMatchObject({ stdio: 'pipe', timeout: 30000 });
+  });
+
+  it('tolerates npm returning a bare string instead of an array', () => {
+    execFileSyncMock.mockImplementation(() => Buffer.from(JSON.stringify('1.2.3')));
+    expect(fixers.getPackageVersion('pkg')).toBe('^1.2.3');
+  });
+});
+
+describe('fixPackageJson', () => {
+  function writePkg(content: unknown) {
+    writeFileSync(join(dir, 'package.json'), JSON.stringify(content, null, 2));
+  }
+  function readPkg() {
+    return JSON.parse(readFileSync(join(dir, 'package.json'), 'utf-8'));
+  }
+
+  it('does nothing when there is no package.json', () => {
+    stubRegistry({});
+    expect(() => fixers.fixPackageJson(dir, 'my-app')).not.toThrow();
+    expect(existsSync(join(dir, 'package.json'))).toBe(false);
+  });
+
+  it('sets the project name', () => {
+    stubRegistry({});
+    writePkg({ name: 'template-name', version: '0.0.0' });
+    fixers.fixPackageJson(dir, 'my-app');
+    expect(readPkg().name).toBe('my-app');
+  });
+
+  it('replaces workspace: ranges with the published version', () => {
+    stubRegistry({ '@ifc-lite/parser': ['1.5.0'] });
+    writePkg({ name: 'x', dependencies: { '@ifc-lite/parser': 'workspace:^' } });
+    fixers.fixPackageJson(dir, 'my-app');
+    expect(readPkg().dependencies['@ifc-lite/parser']).toBe('^1.5.0');
+  });
+
+  it('leaves non-workspace ranges untouched', () => {
+    stubRegistry({ '@ifc-lite/parser': ['1.5.0'] });
+    writePkg({ name: 'x', dependencies: { three: '^0.160.0', '@ifc-lite/parser': 'workspace:*' } });
+    fixers.fixPackageJson(dir, 'my-app');
+    expect(readPkg().dependencies.three).toBe('^0.160.0');
+  });
+
+  it('rewrites workspace ranges in every dependency field, not just dependencies', () => {
+    stubRegistry({ a: ['1.0.0'], b: ['2.0.0'], c: ['3.0.0'], d: ['4.0.0'] });
+    writePkg({
+      name: 'x',
+      dependencies: { a: 'workspace:^' },
+      devDependencies: { b: 'workspace:^' },
+      peerDependencies: { c: 'workspace:^' },
+      optionalDependencies: { d: 'workspace:^' },
+    });
+    fixers.fixPackageJson(dir, 'my-app');
+    const pkg = readPkg();
+    expect(pkg.dependencies.a).toBe('^1.0.0');
+    expect(pkg.devDependencies.b).toBe('^2.0.0');
+    expect(pkg.peerDependencies.c).toBe('^3.0.0');
+    expect(pkg.optionalDependencies.d).toBe('^4.0.0');
+  });
+
+  it('survives a package.json with no dependency fields at all', () => {
+    stubRegistry({});
+    writePkg({ name: 'x' });
+    expect(() => fixers.fixPackageJson(dir, 'my-app')).not.toThrow();
+  });
+
+  it('removes a .git directory carried over from the template', () => {
+    stubRegistry({});
+    writePkg({ name: 'x' });
+    mkdirSync(join(dir, '.git'));
+    writeFileSync(join(dir, '.git', 'HEAD'), 'ref: refs/heads/main');
+    fixers.fixPackageJson(dir, 'my-app');
+    expect(existsSync(join(dir, '.git'))).toBe(false);
+  });
+
+  it('keeps unrelated files when removing .git', () => {
+    stubRegistry({});
+    writePkg({ name: 'x' });
+    writeFileSync(join(dir, '.gitignore'), 'node_modules');
+    mkdirSync(join(dir, '.git'));
+    fixers.fixPackageJson(dir, 'my-app');
+    expect(existsSync(join(dir, '.gitignore'))).toBe(true);
+  });
+
+  it('writes the package.json back as 2-space indented JSON', () => {
+    stubRegistry({});
+    writePkg({ name: 'x', scripts: { dev: 'vite' } });
+    fixers.fixPackageJson(dir, 'my-app');
+    expect(readFileSync(join(dir, 'package.json'), 'utf-8')).toContain('\n  "scripts": {\n    "dev"');
+  });
+
+  it('propagates a resolution failure rather than writing a broken manifest', () => {
+    stubRegistry({ '@ifc-lite/parser': [] });
+    writePkg({ name: 'x', dependencies: { '@ifc-lite/parser': 'workspace:^' } });
+    expect(() => fixers.fixPackageJson(dir, 'my-app')).toThrow(/Failed to resolve/);
+    expect(readPkg().dependencies['@ifc-lite/parser']).toBe('workspace:^');
+  });
+});
+
+describe('fixTsConfig / fixViteConfig / fixViewerTemplate', () => {
+  it('writes a standalone tsconfig with no monorepo references', () => {
+    fixers.fixTsConfig(dir);
+    const tsconfig = JSON.parse(readFileSync(join(dir, 'tsconfig.json'), 'utf-8'));
+    expect(tsconfig.references).toBeUndefined();
+    expect(tsconfig.extends).toBeUndefined();
+    expect(tsconfig.compilerOptions.strict).toBe(true);
+    expect(tsconfig.compilerOptions.paths['@/*']).toEqual(['./src/*']);
+  });
+
+  it('overwrites an existing tsconfig that still had references', () => {
+    writeFileSync(join(dir, 'tsconfig.json'), JSON.stringify({ references: [{ path: '../parser' }] }));
+    fixers.fixTsConfig(dir);
+    expect(JSON.parse(readFileSync(join(dir, 'tsconfig.json'), 'utf-8')).references).toBeUndefined();
+  });
+
+  it('writes a vite config carrying the cross-origin isolation headers WASM needs', () => {
+    fixers.fixViteConfig(dir);
+    const config = readFileSync(join(dir, 'vite.config.ts'), 'utf-8');
+    expect(config).toContain("'Cross-Origin-Opener-Policy': 'same-origin'");
+    expect(config).toContain("'Cross-Origin-Embedder-Policy': 'credentialless'");
+  });
+
+  it('excludes the wasm packages from vite dependency pre-bundling', () => {
+    fixers.fixViteConfig(dir);
+    const config = readFileSync(join(dir, 'vite.config.ts'), 'utf-8');
+    for (const excluded of ['@ifc-lite/wasm', '@duckdb/duckdb-wasm', 'parquet-wasm', 'esbuild-wasm']) {
+      expect(config).toContain(excluded);
+    }
+  });
+
+  it('registers the wasm and top-level-await plugins for workers too', () => {
+    fixers.fixViteConfig(dir);
+    const config = readFileSync(join(dir, 'vite.config.ts'), 'utf-8');
+    expect(config).toContain('plugins: () => [wasm(), topLevelAwait()]');
+    expect(config).toContain("format: 'es'");
+  });
+
+  it('fixViewerTemplate applies all three fixups', () => {
+    stubRegistry({});
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'template' }));
+    fixers.fixViewerTemplate(dir, 'my-app');
+    expect(JSON.parse(readFileSync(join(dir, 'package.json'), 'utf-8')).name).toBe('my-app');
+    expect(existsSync(join(dir, 'tsconfig.json'))).toBe(true);
+    expect(existsSync(join(dir, 'vite.config.ts'))).toBe(true);
+  });
+});

--- a/packages/create-ifc-lite/vitest.config.ts
+++ b/packages/create-ifc-lite/vitest.config.ts
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    // The CLI tests spawn the real bin through tsx; give them room.
+    testTimeout: 30_000,
+  },
+});

--- a/packages/server-bin/package.json
+++ b/packages/server-bin/package.json
@@ -18,6 +18,7 @@
   "scripts": {
     "build": "pnpm exec tsc",
     "dev": "pnpm exec tsc --watch",
+    "test": "vitest run",
     "start": "node dist/cli.js",
     "postinstall": "node -e \"import('./dist/postinstall.js').catch(() => {})\" || true"
   },
@@ -30,7 +31,8 @@
   },
   "devDependencies": {
     "@types/node": "^26.1.2",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.10"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/server-bin/test/binary.test.ts
+++ b/packages/server-bin/test/binary.test.ts
@@ -1,0 +1,258 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { join } from 'node:path';
+
+/**
+ * `runBinary` shells out to a downloaded native server. These tests never
+ * download and never start a server: `child_process.spawn` is replaced with a
+ * fake child, and the cache probe is satisfied by stubbing the two `fs`
+ * predicates `isBinaryCached` consults, so nothing is written outside memory.
+ */
+
+const spawnMock = vi.hoisted(() => vi.fn());
+const existsSyncMock = vi.hoisted(() => vi.fn((_path: string) => true));
+const readFileMock = vi.hoisted(() => vi.fn());
+
+vi.mock('child_process', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('child_process')>()),
+  spawn: spawnMock,
+}));
+
+vi.mock('fs', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('fs')>()),
+  existsSync: existsSyncMock,
+}));
+
+vi.mock('fs/promises', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('fs/promises')>()),
+  readFile: readFileMock,
+}));
+
+import { runBinary, getBinaryPath, getBinaryInfo, isBinaryCached } from '../src/binary.js';
+
+const PKG_VERSION = '1.16.6';
+
+class FakeChild extends EventEmitter {
+  kill = vi.fn();
+}
+
+let child: FakeChild;
+
+/**
+ * `runBinary` awaits the cache probe before it spawns, so tests must wait for
+ * the spawn to actually happen before emitting child events - otherwise the
+ * event fires before any listener is attached and the assertion is vacuous.
+ */
+async function waitForSpawn(expectedCalls = 1): Promise<void> {
+  for (let i = 0; i < 100 && spawnMock.mock.calls.length < expectedCalls; i++) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  if (spawnMock.mock.calls.length < expectedCalls) {
+    throw new Error(`spawn was not called ${expectedCalls} time(s)`);
+  }
+}
+
+beforeEach(() => {
+  child = new FakeChild();
+  spawnMock.mockReset();
+  spawnMock.mockReturnValue(child);
+  existsSyncMock.mockReset();
+  existsSyncMock.mockReturnValue(true);
+  readFileMock.mockReset();
+  readFileMock.mockImplementation(async (path: string) =>
+    String(path).endsWith('package.json')
+      ? JSON.stringify({ version: PKG_VERSION })
+      : PKG_VERSION
+  );
+  vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('isBinaryCached', () => {
+  it('is true only when the binary, the version sidecar and a matching version all line up', async () => {
+    await expect(isBinaryCached()).resolves.toBe(true);
+  });
+
+  it('is false when the binary file is missing', async () => {
+    existsSyncMock.mockImplementation((p: string) => !String(p).includes('ifc-lite-server'));
+    await expect(isBinaryCached()).resolves.toBe(false);
+  });
+
+  it('is false when the version sidecar is missing', async () => {
+    existsSyncMock.mockImplementation((p: string) => !String(p).endsWith('version.txt'));
+    await expect(isBinaryCached()).resolves.toBe(false);
+  });
+
+  it('is false when the cached version differs from the package version', async () => {
+    readFileMock.mockImplementation(async (path: string) =>
+      String(path).endsWith('package.json') ? JSON.stringify({ version: PKG_VERSION }) : '0.0.1'
+    );
+    await expect(isBinaryCached()).resolves.toBe(false);
+  });
+
+  it('tolerates surrounding whitespace in the version sidecar', async () => {
+    readFileMock.mockImplementation(async (path: string) =>
+      String(path).endsWith('package.json') ? JSON.stringify({ version: PKG_VERSION }) : `  ${PKG_VERSION}\n`
+    );
+    await expect(isBinaryCached()).resolves.toBe(true);
+  });
+
+  it('is false (not a crash) when the version sidecar cannot be read', async () => {
+    readFileMock.mockImplementation(async (path: string) => {
+      if (String(path).endsWith('package.json')) return JSON.stringify({ version: PKG_VERSION });
+      throw new Error('EACCES');
+    });
+    await expect(isBinaryCached()).resolves.toBe(false);
+  });
+});
+
+describe('getBinaryPath / getBinaryInfo', () => {
+  it('places the binary inside the package cache directory', () => {
+    const info = getBinaryInfo();
+    expect(getBinaryPath()).toBe(join(info.cacheDir, info.platform.binaryName));
+    expect(info.cacheDir.endsWith('.cache')).toBe(true);
+    expect(info.binaryPath.startsWith(info.cacheDir)).toBe(true);
+  });
+
+  it('reports cached only when BOTH the binary and the version sidecar exist', () => {
+    expect(getBinaryInfo().isCached).toBe(true);
+
+    existsSyncMock.mockImplementation((p: string) => !String(p).endsWith('version.txt'));
+    expect(getBinaryInfo().isCached).toBe(false);
+
+    existsSyncMock.mockImplementation((p: string) => String(p).endsWith('version.txt'));
+    expect(getBinaryInfo().isCached).toBe(false);
+  });
+});
+
+describe('runBinary - exit code propagation', () => {
+  it('resolves with the child exit code', async () => {
+    const promise = runBinary([]);
+    await waitForSpawn();
+    child.emit('exit', 3, null);
+    await expect(promise).resolves.toBe(3);
+  });
+
+  it('maps a clean exit to 0', async () => {
+    const promise = runBinary([]);
+    await waitForSpawn();
+    child.emit('exit', 0, null);
+    await expect(promise).resolves.toBe(0);
+  });
+
+  it('maps a null exit code to 0', async () => {
+    const promise = runBinary([]);
+    await waitForSpawn();
+    child.emit('exit', null, null);
+    await expect(promise).resolves.toBe(0);
+  });
+
+  it('maps SIGINT to 130, SIGTERM to 143 and anything else to 129', async () => {
+    const cases = [
+      ['SIGINT', 130],
+      ['SIGTERM', 143],
+      ['SIGHUP', 129],
+      ['SIGKILL', 129],
+    ] as const;
+    for (const [index, [signal, expected]] of cases.entries()) {
+      const local = new FakeChild();
+      spawnMock.mockReturnValueOnce(local);
+      const promise = runBinary([]);
+      await waitForSpawn(index + 1);
+      local.emit('exit', null, signal);
+      await expect(promise).resolves.toBe(expected);
+    }
+  });
+
+  it('prefers the signal mapping over the numeric code when both are present', async () => {
+    const promise = runBinary([]);
+    await waitForSpawn();
+    child.emit('exit', 0, 'SIGTERM');
+    await expect(promise).resolves.toBe(143);
+  });
+
+  it('rejects with a spawn failure message when the child cannot start', async () => {
+    const promise = runBinary([]);
+    await waitForSpawn();
+    child.emit('error', new Error('ENOENT'));
+    await expect(promise).rejects.toThrow(/Failed to start server: ENOENT/);
+  });
+});
+
+describe('runBinary - argument and signal plumbing', () => {
+  it('passes the caller args straight through to the binary with inherited stdio', async () => {
+    const promise = runBinary(['--flag', 'value']);
+    await waitForSpawn();
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const [binaryPath, args, options] = spawnMock.mock.calls[0];
+    expect(binaryPath).toBe(getBinaryPath());
+    expect(args).toEqual(['--flag', 'value']);
+    expect(options.stdio).toBe('inherit');
+    expect(options.env).toBe(process.env);
+    child.emit('exit', 0, null);
+    await promise;
+  });
+
+  it('defaults to an empty argument list', async () => {
+    const promise = runBinary();
+    await waitForSpawn();
+    expect(spawnMock.mock.calls[0][1]).toEqual([]);
+    child.emit('exit', 0, null);
+    await promise;
+  });
+
+  it('forwards SIGINT, SIGTERM and SIGHUP to the child while it runs', async () => {
+    const promise = runBinary([]);
+    await waitForSpawn();
+    for (const sig of ['SIGINT', 'SIGTERM', 'SIGHUP'] as const) {
+      process.emit(sig as NodeJS.Signals);
+      expect(child.kill).toHaveBeenCalledWith(sig);
+    }
+    child.emit('exit', 0, null);
+    await promise;
+  });
+
+  it('removes its signal listeners once the child exits, so a later signal is not forwarded', async () => {
+    const before = (['SIGINT', 'SIGTERM', 'SIGHUP'] as const).map((s) => process.listenerCount(s));
+    const promise = runBinary([]);
+    await waitForSpawn();
+    child.emit('exit', 0, null);
+    await promise;
+
+    const after = (['SIGINT', 'SIGTERM', 'SIGHUP'] as const).map((s) => process.listenerCount(s));
+    expect(after).toEqual(before);
+
+    child.kill.mockClear();
+    process.emit('SIGINT');
+    expect(child.kill).not.toHaveBeenCalled();
+  });
+
+  it('removes its signal listeners when the child fails to start', async () => {
+    const before = process.listenerCount('SIGTERM');
+    const promise = runBinary([]);
+    await waitForSpawn();
+    child.emit('error', new Error('boom'));
+    await expect(promise).rejects.toThrow();
+    expect(process.listenerCount('SIGTERM')).toBe(before);
+  });
+
+  it('does not accumulate listeners across repeated runs', async () => {
+    const before = process.listenerCount('SIGINT');
+    for (let i = 0; i < 5; i++) {
+      const local = new FakeChild();
+      spawnMock.mockReturnValueOnce(local);
+      const promise = runBinary([]);
+      await waitForSpawn(i + 1);
+      local.emit('exit', 0, null);
+      await promise;
+    }
+    expect(process.listenerCount('SIGINT')).toBe(before);
+  });
+});

--- a/packages/server-bin/test/checksum.test.ts
+++ b/packages/server-bin/test/checksum.test.ts
@@ -1,0 +1,199 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+
+import { verifyArchiveChecksum } from '../src/checksum.js';
+
+const ASSET_URL =
+  'https://github.com/LTplus-AG/ifc-lite/releases/download/v1.2.3/ifc-lite-server-linux-x64.tar.gz';
+const ARCHIVE_NAME = 'ifc-lite-server-linux-x64.tar.gz';
+const CONTENT = 'pretend this is a release archive';
+const DIGEST = createHash('sha256').update(CONTENT).digest('hex');
+
+let dir: string;
+let archivePath: string;
+let fetchMock: ReturnType<typeof vi.fn>;
+
+/** Serve bodies keyed by URL; any URL not listed responds 404. */
+function serve(routes: Record<string, string>) {
+  fetchMock.mockImplementation(async (url: string) => {
+    if (url in routes) {
+      return { ok: true, text: async () => routes[url] } as unknown as Response;
+    }
+    return { ok: false, status: 404, statusText: 'Not Found' } as unknown as Response;
+  });
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'ifclite-checksum-'));
+  archivePath = join(dir, ARCHIVE_NAME);
+  writeFileSync(archivePath, CONTENT);
+  fetchMock = vi.fn();
+  vi.stubGlobal('fetch', fetchMock);
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('verifyArchiveChecksum - matching digest', () => {
+  it('accepts a bare single-digest sidecar and keeps the archive', async () => {
+    serve({ [`${ASSET_URL}.sha256`]: `${DIGEST}\n` });
+    await expect(verifyArchiveChecksum(archivePath, ASSET_URL, ARCHIVE_NAME)).resolves.toBeUndefined();
+    expect(existsSync(archivePath)).toBe(true);
+  });
+
+  it('accepts an uppercase digest (comparison is case-normalised)', async () => {
+    serve({ [`${ASSET_URL}.sha256`]: DIGEST.toUpperCase() });
+    await expect(verifyArchiveChecksum(archivePath, ASSET_URL, ARCHIVE_NAME)).resolves.toBeUndefined();
+  });
+
+  it('accepts a "<hex>  <name>" sidecar line', async () => {
+    serve({ [`${ASSET_URL}.sha256`]: `${DIGEST}  ${ARCHIVE_NAME}\n` });
+    await expect(verifyArchiveChecksum(archivePath, ASSET_URL, ARCHIVE_NAME)).resolves.toBeUndefined();
+  });
+
+  it('accepts the binary-mode "*name" marker', async () => {
+    serve({ [`${ASSET_URL}.sha256`]: `${DIGEST} *${ARCHIVE_NAME}` });
+    await expect(verifyArchiveChecksum(archivePath, ASSET_URL, ARCHIVE_NAME)).resolves.toBeUndefined();
+  });
+
+  it('does not warn when a checksum was found and matched', async () => {
+    serve({ [`${ASSET_URL}.sha256`]: DIGEST });
+    await verifyArchiveChecksum(archivePath, ASSET_URL, ARCHIVE_NAME);
+    expect(console.warn).not.toHaveBeenCalled();
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Checksum verified'));
+  });
+});
+
+describe('verifyArchiveChecksum - mismatching digest fails closed', () => {
+  const WRONG = 'a'.repeat(64);
+
+  it('throws and names both digests', async () => {
+    serve({ [`${ASSET_URL}.sha256`]: WRONG });
+    await expect(verifyArchiveChecksum(archivePath, ASSET_URL, ARCHIVE_NAME)).rejects.toThrow(
+      /Checksum verification failed/
+    );
+  });
+
+  it('deletes the archive so a tampered artifact can never be extracted or executed', async () => {
+    serve({ [`${ASSET_URL}.sha256`]: WRONG });
+    await expect(verifyArchiveChecksum(archivePath, ASSET_URL, ARCHIVE_NAME)).rejects.toThrow();
+    expect(existsSync(archivePath)).toBe(false);
+  });
+
+  it('reports the expected and the actual digest in the error', async () => {
+    serve({ [`${ASSET_URL}.sha256`]: WRONG });
+    await expect(verifyArchiveChecksum(archivePath, ASSET_URL, ARCHIVE_NAME)).rejects.toThrow(
+      new RegExp(`Expected: ${WRONG}[\\s\\S]*Actual:\\s+${DIGEST}`)
+    );
+  });
+
+  it('detects a one-byte change to the archive after the checksum was published', async () => {
+    serve({ [`${ASSET_URL}.sha256`]: DIGEST });
+    writeFileSync(archivePath, `${CONTENT}!`);
+    await expect(verifyArchiveChecksum(archivePath, ASSET_URL, ARCHIVE_NAME)).rejects.toThrow(
+      /Checksum verification failed/
+    );
+  });
+});
+
+describe('verifyArchiveChecksum - missing checksum fails open', () => {
+  it('warns and proceeds when neither the sidecar nor SHA256SUMS exists', async () => {
+    serve({});
+    await expect(verifyArchiveChecksum(archivePath, ASSET_URL, ARCHIVE_NAME)).resolves.toBeUndefined();
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('no SHA-256 checksum published'));
+    expect(existsSync(archivePath)).toBe(true);
+  });
+
+  it('names the archive in the fail-open warning', async () => {
+    serve({});
+    await verifyArchiveChecksum(archivePath, ASSET_URL, ARCHIVE_NAME);
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining(ARCHIVE_NAME));
+  });
+});
+
+describe('verifyArchiveChecksum - checksum source resolution', () => {
+  const SUMS_URL =
+    'https://github.com/LTplus-AG/ifc-lite/releases/download/v1.2.3/SHA256SUMS';
+
+  it('tries the per-asset sidecar before the release-wide SHA256SUMS', async () => {
+    serve({ [`${ASSET_URL}.sha256`]: DIGEST, [SUMS_URL]: 'b'.repeat(64) });
+    await expect(verifyArchiveChecksum(archivePath, ASSET_URL, ARCHIVE_NAME)).resolves.toBeUndefined();
+    expect(fetchMock.mock.calls[0][0]).toBe(`${ASSET_URL}.sha256`);
+  });
+
+  it('derives the SHA256SUMS url from the SAME release directory as the asset', async () => {
+    serve({ [SUMS_URL]: `${DIGEST}  ${ARCHIVE_NAME}` });
+    await expect(verifyArchiveChecksum(archivePath, ASSET_URL, ARCHIVE_NAME)).resolves.toBeUndefined();
+    expect(fetchMock.mock.calls.map((c) => c[0])).toEqual([`${ASSET_URL}.sha256`, SUMS_URL]);
+  });
+
+  it('falls through to SHA256SUMS when the sidecar fetch rejects outright', async () => {
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.endsWith('.sha256')) throw new Error('ECONNRESET');
+      return { ok: true, text: async () => `${DIGEST}  ${ARCHIVE_NAME}` } as unknown as Response;
+    });
+    await expect(verifyArchiveChecksum(archivePath, ASSET_URL, ARCHIVE_NAME)).resolves.toBeUndefined();
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('failed to fetch checksum'));
+  });
+
+  it('picks the SHA256SUMS line for this archive, not another asset in the same release', async () => {
+    const other = 'c'.repeat(64);
+    serve({
+      [SUMS_URL]: [
+        `${other}  ifc-lite-server-darwin-arm64.tar.gz`,
+        `${DIGEST}  ${ARCHIVE_NAME}`,
+        `${other}  ifc-lite-server-win32-x64.zip`,
+      ].join('\n'),
+    });
+    await expect(verifyArchiveChecksum(archivePath, ASSET_URL, ARCHIVE_NAME)).resolves.toBeUndefined();
+  });
+
+  it('fails closed when SHA256SUMS lists only OTHER assets and the first line is a valid digest', async () => {
+    const other = 'c'.repeat(64);
+    serve({ [SUMS_URL]: `${other}  ifc-lite-server-darwin-arm64.tar.gz` });
+    // The first line parses cleanly but names a different asset, so no checksum
+    // applies to ours: fail open, never silently adopt another asset's digest.
+    await verifyArchiveChecksum(archivePath, ASSET_URL, ARCHIVE_NAME);
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('no SHA-256 checksum published'));
+  });
+
+  it('accepts a path-qualified name ending in the archive name', async () => {
+    serve({ [SUMS_URL]: `${DIGEST}  dist/artifacts/${ARCHIVE_NAME}` });
+    await expect(verifyArchiveChecksum(archivePath, ASSET_URL, ARCHIVE_NAME)).resolves.toBeUndefined();
+  });
+
+  it('rejects a name that merely ends with the archive name without a path separator', async () => {
+    serve({ [SUMS_URL]: `${DIGEST}  evil-${ARCHIVE_NAME}` });
+    await verifyArchiveChecksum(archivePath, ASSET_URL, ARCHIVE_NAME);
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('no SHA-256 checksum published'));
+  });
+
+  it('ignores lines whose digest is not exactly 64 hex chars', async () => {
+    serve({ [SUMS_URL]: `${DIGEST.slice(0, 63)}  ${ARCHIVE_NAME}\n${DIGEST}xy  ${ARCHIVE_NAME}` });
+    await verifyArchiveChecksum(archivePath, ASSET_URL, ARCHIVE_NAME);
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('no SHA-256 checksum published'));
+  });
+
+  it('ignores blank lines and comment noise before the real entry', async () => {
+    serve({ [SUMS_URL]: `\n# generated by ci\n\n${DIGEST}  ${ARCHIVE_NAME}\n` });
+    await expect(verifyArchiveChecksum(archivePath, ASSET_URL, ARCHIVE_NAME)).resolves.toBeUndefined();
+  });
+
+  it('does not fetch a third url after SHA256SUMS misses', async () => {
+    serve({});
+    await verifyArchiveChecksum(archivePath, ASSET_URL, ARCHIVE_NAME);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/server-bin/test/platform.test.ts
+++ b/packages/server-bin/test/platform.test.ts
@@ -1,0 +1,184 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const execSyncMock = vi.hoisted(() => vi.fn((_cmd: string, _opts?: unknown) => 'ldd (GNU libc) 2.39'));
+
+vi.mock('child_process', () => ({
+  execSync: execSyncMock,
+}));
+
+import { getPlatformInfo, getPlatformDescription, type PlatformInfo } from '../src/platform.js';
+
+const realPlatform = process.platform;
+const realArch = process.arch;
+
+function setEnvironment(platform: string, arch: string) {
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+  Object.defineProperty(process, 'arch', { value: arch, configurable: true });
+}
+
+beforeEach(() => {
+  execSyncMock.mockReset();
+  execSyncMock.mockReturnValue('ldd (GNU libc) 2.39');
+});
+
+afterEach(() => {
+  Object.defineProperty(process, 'platform', { value: realPlatform, configurable: true });
+  Object.defineProperty(process, 'arch', { value: realArch, configurable: true });
+});
+
+describe('getPlatformInfo - supported targets', () => {
+  it('describes macOS arm64 as a tar.gz target with an extension-less binary', () => {
+    setEnvironment('darwin', 'arm64');
+    const info = getPlatformInfo();
+    expect(info.platform).toBe('darwin');
+    expect(info.arch).toBe('arm64');
+    expect(info.targetTriple).toBe('darwin-arm64');
+    expect(info.archiveType).toBe('tar.gz');
+    expect(info.archiveName).toBe('ifc-lite-server-darwin-arm64.tar.gz');
+    expect(info.binaryName).toBe('ifc-lite-server');
+    expect(info.isMusl).toBe(false);
+  });
+
+  it('describes macOS x64', () => {
+    setEnvironment('darwin', 'x64');
+    expect(getPlatformInfo().archiveName).toBe('ifc-lite-server-darwin-x64.tar.gz');
+  });
+
+  it('gives Windows a .exe binary name and a zip archive', () => {
+    setEnvironment('win32', 'x64');
+    const info = getPlatformInfo();
+    expect(info.binaryName).toBe('ifc-lite-server.exe');
+    expect(info.archiveType).toBe('zip');
+    expect(info.archiveName).toBe('ifc-lite-server-win32-x64.zip');
+  });
+
+  it('never appends .exe or zip on non-Windows platforms', () => {
+    for (const [platform, arch] of [['darwin', 'arm64'], ['linux', 'x64']] as const) {
+      setEnvironment(platform, arch);
+      const info = getPlatformInfo();
+      expect(info.binaryName).toBe('ifc-lite-server');
+      expect(info.binaryName.endsWith('.exe')).toBe(false);
+      expect(info.archiveType).toBe('tar.gz');
+    }
+  });
+
+  it('detects glibc Linux x64 as a non-musl target', () => {
+    setEnvironment('linux', 'x64');
+    const info = getPlatformInfo();
+    expect(info.isMusl).toBe(false);
+    expect(info.targetTriple).toBe('linux-x64');
+    expect(info.archiveName).toBe('ifc-lite-server-linux-x64.tar.gz');
+  });
+
+  it('detects musl Linux x64 and appends the -musl suffix to triple and archive', () => {
+    setEnvironment('linux', 'x64');
+    execSyncMock.mockReturnValue('musl libc (x86_64)\nVersion 1.2.5');
+    const info = getPlatformInfo();
+    expect(info.isMusl).toBe(true);
+    expect(info.targetTriple).toBe('linux-x64-musl');
+    expect(info.archiveName).toBe('ifc-lite-server-linux-x64-musl.tar.gz');
+  });
+
+  it('matches musl case-insensitively', () => {
+    setEnvironment('linux', 'x64');
+    execSyncMock.mockReturnValue('MUSL libc (x86_64)');
+    expect(getPlatformInfo().isMusl).toBe(true);
+  });
+
+  it('treats an unreadable ldd (throwing execSync) as glibc rather than failing', () => {
+    setEnvironment('linux', 'x64');
+    execSyncMock.mockImplementation(() => {
+      throw new Error('ldd: not found');
+    });
+    const info = getPlatformInfo();
+    expect(info.isMusl).toBe(false);
+    expect(info.targetTriple).toBe('linux-x64');
+  });
+
+  it('does not probe ldd at all on non-Linux platforms', () => {
+    setEnvironment('darwin', 'arm64');
+    getPlatformInfo();
+    expect(execSyncMock).not.toHaveBeenCalled();
+
+    setEnvironment('win32', 'x64');
+    getPlatformInfo();
+    expect(execSyncMock).not.toHaveBeenCalled();
+  });
+
+  it('probes ldd exactly once on Linux', () => {
+    setEnvironment('linux', 'arm64');
+    getPlatformInfo();
+    expect(execSyncMock).toHaveBeenCalledTimes(1);
+    expect(String(execSyncMock.mock.calls[0]?.[0])).toContain('ldd');
+  });
+});
+
+describe('getPlatformInfo - rejected targets', () => {
+  it('rejects an unsupported platform naming it', () => {
+    setEnvironment('freebsd', 'x64');
+    expect(() => getPlatformInfo()).toThrow(/Unsupported platform: freebsd/);
+  });
+
+  it('rejects an unsupported architecture naming it', () => {
+    setEnvironment('linux', 'ia32');
+    expect(() => getPlatformInfo()).toThrow(/Unsupported architecture: ia32/);
+  });
+
+  it('rejects a supported platform crossed with an unsupported arch before the triple check', () => {
+    setEnvironment('darwin', 'riscv64');
+    expect(() => getPlatformInfo()).toThrow(/Unsupported architecture/);
+  });
+
+  it('rejects Windows on arm64 - a valid platform and a valid arch, but no released target', () => {
+    setEnvironment('win32', 'arm64');
+    expect(() => getPlatformInfo()).toThrow(/Unsupported platform\/architecture combination: win32-arm64/);
+  });
+
+  it('rejects musl Linux on arm64 - no musl arm64 build is published', () => {
+    setEnvironment('linux', 'arm64');
+    execSyncMock.mockReturnValue('musl libc (aarch64)');
+    expect(() => getPlatformInfo()).toThrow(/Unsupported platform\/architecture combination: linux-arm64-musl/);
+  });
+
+  it('accepts glibc Linux arm64 - the non-musl counterpart of the rejected case', () => {
+    setEnvironment('linux', 'arm64');
+    expect(getPlatformInfo().targetTriple).toBe('linux-arm64');
+  });
+
+  it('lists the supported targets in the combination error', () => {
+    setEnvironment('win32', 'arm64');
+    expect(() => getPlatformInfo()).toThrow(/darwin-x64, darwin-arm64, linux-x64, linux-arm64, linux-x64-musl, win32-x64/);
+  });
+});
+
+describe('getPlatformDescription', () => {
+  const base: PlatformInfo = {
+    platform: 'linux',
+    arch: 'x64',
+    binaryName: 'ifc-lite-server',
+    archiveName: 'ifc-lite-server-linux-x64.tar.gz',
+    archiveType: 'tar.gz',
+    targetTriple: 'linux-x64',
+    isMusl: false,
+  };
+
+  it('renders human names per platform', () => {
+    expect(getPlatformDescription({ ...base, platform: 'darwin' })).toContain('macOS');
+    expect(getPlatformDescription({ ...base, platform: 'linux' })).toContain('Linux');
+    expect(getPlatformDescription({ ...base, platform: 'win32' })).toContain('Windows');
+  });
+
+  it('renders human names per architecture', () => {
+    expect(getPlatformDescription({ ...base, arch: 'x64' })).toContain('x64 (Intel/AMD)');
+    expect(getPlatformDescription({ ...base, arch: 'arm64' })).toContain('ARM64 (Apple Silicon/ARM)');
+  });
+
+  it('appends the musl suffix only when isMusl is true', () => {
+    expect(getPlatformDescription({ ...base, isMusl: true })).toBe('Linux x64 (Intel/AMD) (musl/Alpine)');
+    expect(getPlatformDescription({ ...base, isMusl: false })).toBe('Linux x64 (Intel/AMD)');
+  });
+});

--- a/packages/server-bin/vitest.config.ts
+++ b/packages/server-bin/vitest.config.ts
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -849,6 +849,9 @@ importers:
       typescript:
         specifier: ^5.3.0
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@26.1.2)(happy-dom@20.11.1)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/data:
     devDependencies:
@@ -1345,6 +1348,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@26.1.2)(happy-dom@20.11.1)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/server-client:
     dependencies:


### PR DESCRIPTION
test(server-bin,create-ifc-lite): wire both packages into CI and close 32 mutation-verified gaps

`packages/server-bin` and `create-ifc-lite` both had zero test files and no
`test` script, so `turbo test` skipped them entirely. Neither is a thin
wrapper:

- `server-bin` decides which release asset to download for the current
  platform (`platform.ts` — arch/platform validation, musl detection, target
  triple, archive naming), verifies the downloaded archive's SHA-256 before it
  is extracted, chmod'd and executed (`checksum.ts` — including the fail-open
  vs fail-closed decision and the SHA256SUMS line parser), and maps the child
  process's exit signal to a shell exit code (`binary.ts`).
- `create-ifc-lite` parses argv, validates the project name before it is used
  as a directory name (the guard that keeps `join(cwd, name)` under cwd),
  refuses to write into an existing directory, and rewrites `workspace:`
  ranges into published versions resolved from the registry.

Both packages now have a `test` script and a vitest devDependency — that is
the only reason the suites can run at all; `pnpm check:test-wiring` still
passes. Baseline 0 tests -> 61 in server-bin, 82 in create-ifc-lite.

Every gap was found by mutation. Each mutation was applied as a verified
single-occurrence substring replacement, the mutated region was re-read from
disk and asserted to contain the new text (and not the old) before any result
was believed, and the source was restored from a saved backup copy. 33
mutations + 3 deliberate controls; 35 killed, 1 survivor. Because the baseline
was zero tests, this near-100% ratio measures "the package had no tests", NOT
suite quality — it is not comparable to a uniform sweep of an already-tested
package.

Controls (expected to die, all did): rewriting the Windows `.exe` binary name
to the Unix one; turning the checksum comparison into `if (false)`; dropping
the `^` from the resolved version range.

Representative gaps closed:

- Deleting the archive on a checksum mismatch was invisible — a tampered
  artifact could be left on disk. Killed by "deletes the archive so a tampered
  artifact can never be extracted or executed".
- Turning the fail-open branch (`if (!expected)`) into a never-taken condition
  was invisible. Killed by "warns and proceeds when neither the sidecar nor
  SHA256SUMS exists".
- Loosening the SHA256SUMS filename match from `=== name || endsWith('/'+name)`
  to a bare `endsWith(name)` was invisible; that admits a `evil-<archive>.tar.gz`
  line from the same release. Killed by "rejects a name that merely ends with
  the archive name without a path separator".
- Loosening the 64-hex digest pattern to `{8,}` was invisible. Killed by
  "ignores lines whose digest is not exactly 64 hex chars".
- Deriving the SHA256SUMS URL by appending to the asset URL instead of
  replacing its last segment was invisible. Killed by "derives the SHA256SUMS
  url from the SAME release directory as the asset".
- Dropping the `-musl` suffix, inverting the zip/tar.gz choice, admitting
  `ia32`, and removing the supported-target check were all invisible. Killed by
  the platform matrix, including the two boundary cases `win32-arm64` and
  `linux-arm64-musl` (valid platform, valid arch, no published target).
- `runBinary` mapping SIGINT/SIGTERM/other to 130/143/129, and `code ?? 0`,
  were both unpinned. Killed by "maps SIGINT to 130, SIGTERM to 143 and
  anything else to 129" and "maps a null exit code to 0".
- Removing the `cleanup()` that unregisters the SIGINT/SIGTERM/SIGHUP handlers
  after the child exits was invisible — the leak this guards against is
  unbounded listener growth. Killed by "removes its signal listeners once the
  child exits" and "does not accumulate listeners across repeated runs".
- Neutralising the project-name guard (`hasDotSegment = false`, or unanchoring
  the name regex) was invisible. Killed by the rejection table, which covers
  `../evil`, `..`, `.`, `/tmp/absolute`, `a/../b`, `@scope/..` and shell
  metacharacters, plus "creates nothing anywhere when the name is rejected".
- Removing the existing-directory refusal was invisible. Killed by "refuses to
  scaffold into an existing directory" and "does not touch the contents of the
  existing directory".
- `args[++i]` not consuming the `--template` value was invisible. Killed by
  "consumes the template value so it is not mistaken for the project name".
- Dropping `.reverse()` from the version candidate list (picking the OLDEST
  installable version instead of the newest), narrowing `depFields` to
  `dependencies`, removing the npm package-name validation, and removing the
  `.git` cleanup were all invisible. Each now has a dedicated test.

The single survivor is EQUIVALENT: `const isMusl = platform === 'linux' &&
isMuslLinux()` (platform.ts:79) still returns false without the left operand,
because `isMuslLinux` itself returns early on `process.platform !== 'linux'`
(platform.ts:41-43), and `platform` is that same value read at platform.ts:59.
The redundant guard is worth keeping as documentation of intent.

One KNOWN DEFECT is documented by test rather than fixed, because fixing it
changes behaviour: `create-ifc-lite/src/index.ts:73` gates the template on
`t in TEMPLATES`, and `in` walks the prototype chain, so
`--template toString` (or `constructor`, `valueOf`, `hasOwnProperty`) is
accepted and silently scaffolds the `basic` template instead of printing
"Invalid template". The tests are named "KNOWN DEFECT: ..." so the fix is a
one-line change plus flipping those assertions.

Test-only; no production code changed. The test files were typechecked
separately against each package's own compiler options with the `src`-only
`include` lifted, since the root `pnpm typecheck` does not cover them.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
