### PR TITLE
test(viewer-core): close the coverage gap on the viewer HTTP server, SSE and HTML escaping

### DIFF
--- a/packages/viewer/test/helpers/http.ts
+++ b/packages/viewer/test/helpers/http.ts
@@ -1,0 +1,141 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Minimal HTTP client helpers for the viewer server tests.
+ *
+ * Every socket these helpers open is registered in a module-level set and
+ * every request carries its own deadline. That matters here: the server
+ * under test holds SSE responses open forever, so a single leaked socket
+ * keeps the `node:http` server handle alive and `server.close()` never
+ * completes — the test run would hang instead of failing. `destroyAllSockets`
+ * is the belt-and-braces cleanup that runs from an `after` hook even when an
+ * assertion has already thrown.
+ */
+
+import { request as httpRequest, type IncomingMessage, type ClientRequest } from 'node:http';
+
+/** Per-request deadline. Long enough for a slow CI box, short enough to fail fast. */
+export const REQUEST_TIMEOUT_MS = 10_000;
+
+/** Deadline handed to `it(...)` for anything that touches a socket. */
+export const TEST_TIMEOUT = { timeout: 30_000 } as const;
+
+const openRequests = new Set<ClientRequest>();
+
+export interface Res {
+  status: number;
+  headers: NodeJS.Dict<string | string[]>;
+  body: Buffer;
+}
+
+export interface ReqOptions {
+  method?: string;
+  headers?: Record<string, string>;
+  body?: string;
+}
+
+/**
+ * Issue one request on its own socket (`agent: false`), so closing the
+ * server actually releases the port instead of waiting on a pooled
+ * keep-alive connection.
+ */
+export function req(port: number, path: string, opts: ReqOptions = {}): Promise<Res> {
+  return new Promise((resolvePromise, reject) => {
+    const r = httpRequest(
+      {
+        host: '127.0.0.1',
+        port,
+        path,
+        method: opts.method ?? 'GET',
+        headers: opts.headers,
+        agent: false,
+      },
+      (resp: IncomingMessage) => {
+        const chunks: Buffer[] = [];
+        resp.on('data', (c: Buffer) => chunks.push(c));
+        resp.on('end', () => {
+          openRequests.delete(r);
+          resolvePromise({
+            status: resp.statusCode ?? 0,
+            headers: resp.headers,
+            body: Buffer.concat(chunks),
+          });
+        });
+        resp.on('error', (e) => {
+          openRequests.delete(r);
+          reject(e);
+        });
+      },
+    );
+    openRequests.add(r);
+    r.setTimeout(REQUEST_TIMEOUT_MS, () => {
+      r.destroy(new Error(`request to ${path} timed out after ${REQUEST_TIMEOUT_MS}ms`));
+    });
+    r.on('error', (e) => {
+      openRequests.delete(r);
+      reject(e);
+    });
+    if (opts.body !== undefined) r.write(opts.body);
+    r.end();
+  });
+}
+
+/** `req` plus a JSON-parsed body. */
+export async function json(
+  port: number,
+  path: string,
+  opts?: ReqOptions,
+): Promise<{ status: number; headers: NodeJS.Dict<string | string[]>; json: any }> {
+  const res = await req(port, path, opts);
+  return { status: res.status, headers: res.headers, json: JSON.parse(res.body.toString()) };
+}
+
+/**
+ * Open a streaming request (SSE) and resolve once the response head arrives.
+ * The returned `close` MUST be called from a `finally` — see the module note.
+ */
+export function openStream(
+  port: number,
+  path: string,
+): Promise<{ res: IncomingMessage; close: () => void }> {
+  return new Promise((resolvePromise, reject) => {
+    const r = httpRequest({ host: '127.0.0.1', port, path, agent: false }, (resp) => {
+      resolvePromise({
+        res: resp,
+        close: () => {
+          openRequests.delete(r);
+          r.destroy();
+          resp.destroy();
+        },
+      });
+    });
+    openRequests.add(r);
+    r.setTimeout(REQUEST_TIMEOUT_MS, () => {
+      r.destroy(new Error(`stream ${path} produced no response head in ${REQUEST_TIMEOUT_MS}ms`));
+    });
+    r.on('error', (e) => {
+      openRequests.delete(r);
+      reject(e);
+    });
+    r.end();
+  });
+}
+
+/** Tear down anything still open. Safe to call more than once. */
+export function destroyAllSockets(): void {
+  for (const r of openRequests) r.destroy();
+  openRequests.clear();
+}
+
+/** Poll `predicate` up to `ms`, then give up. Never throws. */
+export async function poll(predicate: () => boolean, ms = 3000): Promise<void> {
+  const deadline = Date.now() + ms;
+  while (!predicate() && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+export const sleep = (ms: number): Promise<void> =>
+  new Promise((r) => setTimeout(r, ms));

--- a/packages/viewer/test/server-routes.test.ts
+++ b/packages/viewer/test/server-routes.test.ts
@@ -1,0 +1,693 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * End-to-end route tests for the viewer HTTP server.
+ *
+ * These drive a REAL `node:http` server over a REAL socket on port 0 —
+ * nothing about the request path is mocked. Every request gets its own
+ * socket and its own deadline (see ./helpers/http.ts); the SSE suite closes
+ * its stream from a `finally` so a failed assertion cannot leave the server
+ * handle open and hang the run.
+ */
+
+import assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  startViewerServer,
+  VALID_ACTIONS,
+  type CreateResult,
+  type ViewerServer,
+  type ViewerServerOptions,
+} from '../src/server.js';
+import {
+  destroyAllSockets,
+  json,
+  openStream,
+  poll,
+  req,
+  sleep,
+  TEST_TIMEOUT,
+} from './helpers/http.js';
+
+const HOOK_TIMEOUT = { timeout: 30_000 };
+
+/** Every server booted by a test, so the final teardown can close them all. */
+const booted: ViewerServer[] = [];
+
+async function boot(
+  opts: Partial<ViewerServerOptions> = {},
+): Promise<{ server: ViewerServer; port: number }> {
+  let port = 0;
+  const server = await startViewerServer({
+    filePath: null,
+    fileName: 'model.ifc',
+    port: 0,
+    ...opts,
+    onReady: (p, u) => {
+      port = p;
+      opts.onReady?.(p, u);
+    },
+  });
+  booted.push(server);
+  assert.ok(port > 0, 'onReady must report the bound ephemeral port');
+  return { server, port };
+}
+
+/**
+ * Last line of defence. Runs after every suite in this file, including when
+ * an assertion threw: kill any client socket first (an open SSE socket keeps
+ * the server handle referenced), then close every server we started.
+ */
+after(() => {
+  destroyAllSockets();
+  for (const s of booted) s.close();
+}, HOOK_TIMEOUT);
+
+describe('viewer server — static routes and CORS', () => {
+  let server: ViewerServer;
+  let port: number;
+  let dir: string;
+  let ifcPath: string;
+  const IFC = 'ISO-10303-21;\nHEADER;\nENDSEC;\nDATA;\nENDSEC;\nEND-ISO-10303-21;\n';
+
+  before(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'ifclite-viewer-'));
+    ifcPath = join(dir, 'house.ifc');
+    await writeFile(ifcPath, IFC);
+    ({ server, port } = await boot({ filePath: ifcPath, fileName: 'house.ifc' }));
+  }, HOOK_TIMEOUT);
+
+  after(async () => {
+    server?.close();
+    if (dir) await rm(dir, { recursive: true, force: true });
+  }, HOOK_TIMEOUT);
+
+  // Both directions of the CORS decision, one `it` per origin so a kill is
+  // attributed to the exact origin that discriminates. The allowlist regex is
+  // anchored; unanchored, it would echo the origin back to any host that
+  // merely *contains* "localhost", handing a hostile page read access to the
+  // model and the command API.
+  for (const origin of [
+    'http://localhost',
+    'http://localhost:5173',
+    'https://localhost:8443',
+    'http://127.0.0.1',
+    'http://127.0.0.1:3000',
+  ]) {
+    it(`echoes Access-Control-Allow-Origin for ${origin}`, TEST_TIMEOUT, async () => {
+      const res = await req(port, '/api/status', { headers: { origin } });
+      assert.equal(res.headers['access-control-allow-origin'], origin);
+    });
+  }
+
+  for (const origin of [
+    'http://localhost.evil.com',
+    'http://evil.com',
+    'https://evil.com/?next=http://localhost',
+    'http://127.0.0.1.evil.com',
+    'http://localhosts',
+    'http://alocalhost',
+    'ftp://localhost',
+    'http://localhost:notaport',
+  ]) {
+    it(`withholds Access-Control-Allow-Origin for ${origin}`, TEST_TIMEOUT, async () => {
+      const res = await req(port, '/api/status', { headers: { origin } });
+      assert.equal(res.headers['access-control-allow-origin'], undefined);
+    });
+  }
+
+  it('omits the allow-origin header entirely when no Origin is sent', TEST_TIMEOUT, async () => {
+    const res = await req(port, '/api/status');
+    assert.equal(res.headers['access-control-allow-origin'], undefined);
+    // The non-origin CORS headers are unconditional.
+    assert.equal(res.headers['access-control-allow-methods'], 'GET, POST, OPTIONS');
+    assert.equal(res.headers['access-control-allow-headers'], 'Content-Type');
+  });
+
+  it('answers the preflight with 204 and no body', TEST_TIMEOUT, async () => {
+    const res = await req(port, '/api/command', {
+      method: 'OPTIONS',
+      headers: { origin: 'http://localhost:5173' },
+    });
+    assert.equal(res.status, 204);
+    assert.equal(res.body.byteLength, 0);
+    assert.equal(res.headers['access-control-allow-origin'], 'http://localhost:5173');
+  });
+
+  it('short-circuits OPTIONS even on a route that exists', TEST_TIMEOUT, async () => {
+    // The OPTIONS guard sits ahead of route dispatch. Without it, an OPTIONS
+    // /api/status would fall through to the 404 tail and the browser would
+    // refuse the preflight.
+    const res = await req(port, '/api/status', { method: 'OPTIONS' });
+    assert.equal(res.status, 204);
+    assert.equal(res.body.byteLength, 0);
+  });
+
+  it('serves the viewer HTML at /', TEST_TIMEOUT, async () => {
+    const res = await req(port, '/');
+    assert.equal(res.status, 200);
+    assert.equal(res.headers['content-type'], 'text/html; charset=utf-8');
+    assert.match(res.body.toString(), /<title>house\.ifc — ifc-lite 3D<\/title>/);
+  });
+
+  it('does not serve the viewer HTML for POST /', TEST_TIMEOUT, async () => {
+    const res = await req(port, '/', { method: 'POST', body: '' });
+    assert.equal(res.status, 404);
+  });
+
+  it('ignores the query string when matching a route', TEST_TIMEOUT, async () => {
+    // Dispatch is on `url.pathname`, not on the raw `req.url`. Matching the
+    // raw URL would 404 every cache-busted request the browser makes.
+    const res = await req(port, '/?v=12345');
+    assert.equal(res.status, 200);
+    assert.equal(res.headers['content-type'], 'text/html; charset=utf-8');
+  });
+
+  it('streams the model with a Content-Length matching the file exactly', TEST_TIMEOUT, async () => {
+    const res = await req(port, '/model.ifc');
+    assert.equal(res.status, 200);
+    assert.equal(res.headers['content-type'], 'application/octet-stream');
+    assert.equal(res.headers['content-length'], String(Buffer.byteLength(IFC)));
+    assert.equal(res.body.toString(), IFC);
+  });
+
+  it('re-stats the model per request so a rewritten file is not truncated', TEST_TIMEOUT, async () => {
+    const bigger = IFC + '/* appended after server start */\n';
+    await writeFile(ifcPath, bigger);
+    try {
+      const res = await req(port, '/model.ifc');
+      assert.equal(res.headers['content-length'], String(Buffer.byteLength(bigger)));
+      assert.equal(res.body.toString(), bigger);
+    } finally {
+      await writeFile(ifcPath, IFC);
+    }
+  });
+
+  it('rewrites the wasm glue to load the binary from the server origin', TEST_TIMEOUT, async () => {
+    const res = await req(port, '/wasm/ifc-lite.js');
+    assert.equal(res.status, 200);
+    assert.equal(res.headers['content-type'], 'application/javascript; charset=utf-8');
+    const js = res.body.toString();
+    assert.match(js, /new URL\('\/wasm\/ifc-lite_bg\.wasm', location\.origin\)/);
+    assert.doesNotMatch(js, /new URL\('ifc-lite_bg\.wasm', import\.meta\.url\)/);
+  });
+
+  it('serves the wasm binary with the wasm MIME type and exact length', TEST_TIMEOUT, async () => {
+    const res = await req(port, '/wasm/ifc-lite_bg.wasm');
+    assert.equal(res.status, 200);
+    assert.equal(res.headers['content-type'], 'application/wasm');
+    assert.equal(res.headers['content-length'], String(res.body.byteLength));
+    // Absolute check against the WebAssembly spec's magic number.
+    assert.deepEqual([...res.body.subarray(0, 4)], [0x00, 0x61, 0x73, 0x6d]);
+  });
+
+  it('404s a snippet asset that does not exist', TEST_TIMEOUT, async () => {
+    const res = await req(port, '/wasm/snippets/nope-1234/missing.js');
+    assert.equal(res.status, 404);
+    assert.equal(res.headers['content-type'], 'text/plain');
+    assert.equal(res.body.toString(), 'Not Found');
+  });
+
+  it('404s a traversal attempt under /wasm/snippets/', TEST_TIMEOUT, async () => {
+    // The traversal guard is unit-tested on `resolveWasmAssetPath`; this pins
+    // that the route actually consults it rather than reading the path raw.
+    const res = await req(port, '/wasm/snippets/../../../../../../etc/passwd');
+    assert.equal(res.status, 404);
+    assert.equal(res.body.toString(), 'Not Found');
+  });
+
+  it('404s an unknown route', TEST_TIMEOUT, async () => {
+    const res = await req(port, '/definitely-not-a-route');
+    assert.equal(res.status, 404);
+    assert.equal(res.headers['content-type'], 'text/plain');
+    assert.equal(res.body.toString(), 'Not Found');
+  });
+
+  it('404s a /wasm/ path that is not one of the three wasm routes', TEST_TIMEOUT, async () => {
+    // `/wasm/` is only special for the two named files and the snippets
+    // prefix — it is not a general static root over the package directory.
+    const res = await req(port, '/wasm/package.json');
+    assert.equal(res.status, 404);
+  });
+});
+
+describe('viewer server — empty mode (no file, no create handler)', () => {
+  let server: ViewerServer;
+  let port: number;
+
+  before(async () => {
+    ({ server, port } = await boot({ filePath: null, fileName: 'untitled.ifc' }));
+  }, HOOK_TIMEOUT);
+  after(() => server?.close(), HOOK_TIMEOUT);
+
+  it('answers /model.ifc with 204 and an empty body, not 404', TEST_TIMEOUT, async () => {
+    // 204 is what the browser loader treats as "start empty"; a 404 would
+    // surface as a load error in the viewer.
+    const res = await req(port, '/model.ifc');
+    assert.equal(res.status, 204);
+    assert.equal(res.body.byteLength, 0);
+  });
+
+  it('reports 501 Not Implemented for /api/create without a handler', TEST_TIMEOUT, async () => {
+    const res = await json(port, '/api/create', {
+      method: 'POST',
+      body: JSON.stringify({ type: 'wall' }),
+    });
+    assert.equal(res.status, 501);
+    assert.equal(res.headers['content-type'], 'application/json; charset=utf-8');
+    assert.deepEqual(res.json, { ok: false, error: 'Create handler not configured' });
+  });
+
+  it('reports ok:false when nothing has been created yet', TEST_TIMEOUT, async () => {
+    const res = await json(port, '/api/export');
+    assert.equal(res.status, 200);
+    assert.equal(res.headers['content-type'], 'application/json; charset=utf-8');
+    assert.deepEqual(res.json, { ok: false, error: 'No geometry has been created yet' });
+  });
+});
+
+describe('viewer server — /api/command allowlist', () => {
+  let server: ViewerServer;
+  let port: number;
+
+  before(async () => {
+    ({ server, port } = await boot());
+  }, HOOK_TIMEOUT);
+  after(() => server?.close(), HOOK_TIMEOUT);
+
+  // One `it` per action, so removing any single action from the allowlist is
+  // killed by a named test rather than by one lucky case inside a loop.
+  for (const action of [
+    'colorize', 'isolate', 'xray', 'flyto', 'highlight',
+    'colorizeEntities', 'isolateEntities', 'hideEntities', 'showEntities', 'resetColorEntities',
+    'section', 'clearSection', 'colorByStorey', 'addGeometry',
+    'showall', 'reset', 'picked', 'setView', 'removeCreated', 'camera',
+  ]) {
+    it(`accepts the "${action}" action`, TEST_TIMEOUT, async () => {
+      assert.ok(VALID_ACTIONS.has(action), `${action} must be exported in VALID_ACTIONS`);
+      const res = await json(port, '/api/command', {
+        method: 'POST',
+        body: JSON.stringify({ action }),
+      });
+      assert.equal(res.status, 200);
+      assert.deepEqual(res.json, { ok: true, action, clients: 0 });
+    });
+  }
+
+  it('exports exactly the twenty actions the viewer implements', () => {
+    // Pins the size in both directions: the per-action tests above catch a
+    // removal, this catches a silent addition.
+    assert.equal(VALID_ACTIONS.size, 20);
+  });
+
+  it('rejects an action outside the allowlist and lists the valid ones', TEST_TIMEOUT, async () => {
+    const res = await json(port, '/api/command', {
+      method: 'POST',
+      body: JSON.stringify({ action: 'rm -rf' }),
+    });
+    assert.equal(res.status, 400);
+    assert.equal(res.json.ok, false);
+    assert.equal(res.json.error, 'Unknown action: rm -rf');
+    assert.deepEqual(res.json.validActions, [...VALID_ACTIONS]);
+  });
+
+  it('rejects a command with no action at all', TEST_TIMEOUT, async () => {
+    const res = await json(port, '/api/command', { method: 'POST', body: JSON.stringify({}) });
+    assert.equal(res.status, 400);
+    assert.equal(res.json.error, 'Unknown action: (none)');
+  });
+
+  it('rejects a malformed JSON body with 400 rather than crashing', TEST_TIMEOUT, async () => {
+    const res = await json(port, '/api/command', { method: 'POST', body: '{not json' });
+    assert.equal(res.status, 400);
+    assert.equal(res.json.ok, false);
+    assert.equal(typeof res.json.error, 'string');
+  });
+
+  it('reads the whole request body, not just the first chunk', TEST_TIMEOUT, async () => {
+    // A >64 KiB body arrives in several `data` events. Resolving on the first
+    // one would truncate the JSON and turn every large command into a 400.
+    const ids = Array.from({ length: 40_000 }, (_, i) => i);
+    const res = await json(port, '/api/command', {
+      method: 'POST',
+      body: JSON.stringify({ action: 'flyto', ids }),
+    });
+    assert.ok(JSON.stringify({ action: 'flyto', ids }).length > 65_536);
+    assert.equal(res.status, 200);
+    assert.deepEqual(res.json, { ok: true, action: 'flyto', clients: 0 });
+  });
+
+  it('does not treat GET /api/command as a command', TEST_TIMEOUT, async () => {
+    const res = await req(port, '/api/command');
+    assert.equal(res.status, 404);
+  });
+
+  it('does not treat POST /api/status as a status request', TEST_TIMEOUT, async () => {
+    const res = await req(port, '/api/status', { method: 'POST', body: '' });
+    assert.equal(res.status, 404);
+  });
+});
+
+describe('viewer server — SSE broadcast', () => {
+  let server: ViewerServer;
+  let port: number;
+
+  before(async () => {
+    ({ server, port } = await boot());
+  }, HOOK_TIMEOUT);
+  after(() => server?.close(), HOOK_TIMEOUT);
+
+  it('greets a subscriber, counts it, and forwards accepted commands', TEST_TIMEOUT, async () => {
+    const events: string[] = [];
+    const stream = await openStream(port, '/events');
+
+    // `finally`: an open SSE socket keeps `server.close()` pending forever,
+    // so a failed assertion must not leak the stream out of this test.
+    try {
+      assert.equal(stream.res.statusCode, 200);
+      assert.equal(stream.res.headers['content-type'], 'text/event-stream');
+      assert.equal(stream.res.headers['cache-control'], 'no-cache');
+      stream.res.on('data', (c: Buffer) => events.push(c.toString()));
+
+      const waitFor = async (n: number) => {
+        await poll(() => events.length >= n);
+        assert.ok(events.length >= n, `expected ${n} SSE frames, got ${events.length}`);
+      };
+
+      await waitFor(1);
+      // The greeting is a complete SSE frame: `data: ` prefix, JSON payload,
+      // blank-line terminator. Drop either newline and no browser EventSource
+      // ever dispatches the event.
+      assert.equal(events[0], 'data: {"action":"connected"}\n\n');
+      await poll(() => server.clientCount() === 1);
+      assert.equal(server.clientCount(), 1);
+
+      const accepted = await json(port, '/api/command', {
+        method: 'POST',
+        body: JSON.stringify({ action: 'flyto', ids: [7, 9] }),
+      });
+      assert.equal(accepted.json.clients, 1);
+      await waitFor(2);
+      assert.equal(events[1], 'data: {"action":"flyto","ids":[7,9]}\n\n');
+
+      // A rejected command must NOT reach subscribers.
+      await json(port, '/api/command', {
+        method: 'POST',
+        body: JSON.stringify({ action: 'nope' }),
+      });
+      await sleep(100);
+      assert.equal(events.length, 2);
+    } finally {
+      stream.close();
+    }
+
+    await poll(() => server.clientCount() === 0);
+    assert.equal(server.clientCount(), 0, 'disconnecting must drop the SSE client');
+  });
+
+  it('broadcasts to every subscriber, not only the first', TEST_TIMEOUT, async () => {
+    const a = await openStream(port, '/events');
+    const b = await openStream(port, '/events');
+    const seenA: string[] = [];
+    const seenB: string[] = [];
+    try {
+      a.res.on('data', (c: Buffer) => seenA.push(c.toString()));
+      b.res.on('data', (c: Buffer) => seenB.push(c.toString()));
+      await poll(() => server.clientCount() === 2);
+      assert.equal(server.clientCount(), 2);
+
+      server.broadcast({ action: 'showall' });
+      await poll(() => seenA.length >= 2 && seenB.length >= 2);
+      assert.deepEqual(seenA.at(-1), 'data: {"action":"showall"}\n\n');
+      assert.deepEqual(seenB.at(-1), 'data: {"action":"showall"}\n\n');
+    } finally {
+      a.close();
+      b.close();
+    }
+    await poll(() => server.clientCount() === 0);
+    assert.equal(server.clientCount(), 0);
+  });
+
+  it('/api/status reports the live subscriber count, not a constant', TEST_TIMEOUT, async () => {
+    const before = await json(port, '/api/status');
+    assert.equal(before.json.clients, 0);
+
+    const stream = await openStream(port, '/events');
+    try {
+      await poll(() => server.clientCount() === 1);
+      const during = await json(port, '/api/status');
+      assert.equal(during.json.clients, 1);
+    } finally {
+      stream.close();
+    }
+    await poll(() => server.clientCount() === 0);
+    const afterwards = await json(port, '/api/status');
+    assert.equal(afterwards.json.clients, 0);
+  });
+
+  it('does not open an SSE stream for POST /events', TEST_TIMEOUT, async () => {
+    const res = await req(port, '/events', { method: 'POST', body: '' });
+    assert.equal(res.status, 404);
+    assert.equal(server.clientCount(), 0);
+  });
+});
+
+describe('viewer server — create / export / clear lifecycle', () => {
+  let server: ViewerServer;
+  let port: number;
+  const seen: unknown[][] = [];
+  let nextContent = '';
+
+  before(async () => {
+    ({ server, port } = await boot({
+      fileName: 'house.ifc',
+      createHandler: async (elements): Promise<CreateResult> => {
+        seen.push(elements);
+        return {
+          content: nextContent,
+          entities: elements.map((e, i) => ({ type: e.type, expressId: 100 + i })),
+          stats: { fileSize: nextContent.length },
+        };
+      },
+    }));
+  }, HOOK_TIMEOUT);
+  after(() => server?.close(), HOOK_TIMEOUT);
+
+  it('wraps a single (non-array) element body into a one-element array', TEST_TIMEOUT, async () => {
+    // server.ts: `Array.isArray(parsed) ? parsed : [parsed]`. Without the
+    // wrap the handler receives a bare object, `elements.length` is
+    // `undefined` and `POST {"type":"IfcWall"}` — the documented single-element
+    // form — stops working.
+    nextContent = 'SEG_A';
+    const res = await json(port, '/api/create', {
+      method: 'POST',
+      body: JSON.stringify({ type: 'IfcWall', params: { length: 3 } }),
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.json.ok, true);
+    assert.equal(res.json.count, 1);
+    assert.equal(res.json.ifcSize, 5);
+    assert.deepEqual(res.json.entities, [{ type: 'IfcWall', expressId: 100 }]);
+    assert.deepEqual(seen.at(-1), [{ type: 'IfcWall', params: { length: 3 } }]);
+  });
+
+  it('passes an array body straight through and counts every element', TEST_TIMEOUT, async () => {
+    // The other direction of the same branch: an array must NOT be nested
+    // inside another array, which would give count 1 and a handler argument
+    // of `[[…]]`.
+    nextContent = 'SEG_B';
+    const res = await json(port, '/api/create', {
+      method: 'POST',
+      body: JSON.stringify([{ type: 'IfcSlab' }, { type: 'IfcColumn' }]),
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.json.count, 2);
+    assert.deepEqual(seen.at(-1), [{ type: 'IfcSlab' }, { type: 'IfcColumn' }]);
+    assert.deepEqual(res.json.entities, [
+      { type: 'IfcSlab', expressId: 100 },
+      { type: 'IfcColumn', expressId: 101 },
+    ]);
+  });
+
+  it('rejects an element without a "type" field', TEST_TIMEOUT, async () => {
+    const before = seen.length;
+    const res = await json(port, '/api/create', {
+      method: 'POST',
+      body: JSON.stringify([{ params: { length: 3 } }]),
+    });
+    assert.equal(res.status, 400);
+    assert.deepEqual(res.json, { ok: false, error: 'Missing "type" field' });
+    assert.equal(seen.length, before, 'the create handler must not run');
+  });
+
+  it('rejects an empty element array', TEST_TIMEOUT, async () => {
+    const before = seen.length;
+    const res = await json(port, '/api/create', { method: 'POST', body: '[]' });
+    assert.equal(res.status, 400);
+    assert.deepEqual(res.json, { ok: false, error: 'Missing "type" field' });
+    assert.equal(seen.length, before, 'the create handler must not run');
+  });
+
+  it('rejects a null element without crashing the request', TEST_TIMEOUT, async () => {
+    // `[null]` reaches `elements[0].type` on a null. Whatever the message,
+    // the contract is a 400 with ok:false — never a hung socket or a 500.
+    const before = seen.length;
+    const res = await json(port, '/api/create', { method: 'POST', body: '[null]' });
+    assert.equal(res.status, 400);
+    assert.equal(res.json.ok, false);
+    assert.equal(typeof res.json.error, 'string');
+    assert.equal(seen.length, before, 'the create handler must not run');
+  });
+
+  it('rejects a malformed create body with 400', TEST_TIMEOUT, async () => {
+    const res = await json(port, '/api/create', { method: 'POST', body: '{' });
+    assert.equal(res.status, 400);
+    assert.equal(res.json.ok, false);
+  });
+
+  it('does not treat GET /api/create as a create', TEST_TIMEOUT, async () => {
+    const res = await req(port, '/api/create');
+    assert.equal(res.status, 404);
+  });
+
+  it('reports the accumulated segment count in /api/status', TEST_TIMEOUT, async () => {
+    const res = await json(port, '/api/status');
+    assert.equal(res.status, 200);
+    assert.equal(res.headers['content-type'], 'application/json; charset=utf-8');
+    assert.deepEqual(res.json, {
+      ok: true,
+      model: 'house.ifc',
+      clients: 0,
+      createdSegments: 2,
+    });
+    assert.deepEqual(server.createdSegments, ['SEG_A', 'SEG_B']);
+  });
+
+  it('exports the segments newline-separated as an IFC attachment', TEST_TIMEOUT, async () => {
+    const res = await req(port, '/api/export');
+    assert.equal(res.status, 200);
+    assert.equal(res.headers['content-type'], 'application/octet-stream');
+    assert.equal(res.headers['content-disposition'], 'attachment; filename="created-house.ifc"');
+    assert.equal(res.body.toString(), 'SEG_A\nSEG_B');
+    assert.equal(res.headers['content-length'], String(Buffer.byteLength('SEG_A\nSEG_B')));
+  });
+
+  it('clears the segments and reports how many were dropped', TEST_TIMEOUT, async () => {
+    const res = await json(port, '/api/clear-created', { method: 'POST' });
+    assert.equal(res.status, 200);
+    assert.deepEqual(res.json, { ok: true, cleared: 2 });
+    assert.deepEqual(server.createdSegments, []);
+
+    const status = await json(port, '/api/status');
+    assert.equal(status.json.createdSegments, 0);
+
+    // Clearing again is a no-op that reports zero.
+    const again = await json(port, '/api/clear-created', { method: 'POST' });
+    assert.deepEqual(again.json, { ok: true, cleared: 0 });
+
+    const exported = await json(port, '/api/export');
+    assert.deepEqual(exported.json, { ok: false, error: 'No geometry has been created yet' });
+  });
+
+  it('surfaces a create-handler failure as 400 with the handler message', TEST_TIMEOUT, async () => {
+    const failing = await boot({
+      createHandler: async () => {
+        throw new Error('unsupported element');
+      },
+    });
+    try {
+      const res = await json(failing.port, '/api/create', {
+        method: 'POST',
+        body: JSON.stringify({ type: 'IfcNope' }),
+      });
+      assert.equal(res.status, 400);
+      assert.deepEqual(res.json, { ok: false, error: 'unsupported element' });
+      assert.deepEqual(failing.server.createdSegments, [], 'a failed create records no segment');
+    } finally {
+      failing.server.close();
+    }
+  });
+
+  it('broadcasts addGeometry with the created IFC content', TEST_TIMEOUT, async () => {
+    const live = await boot({
+      createHandler: async () => ({
+        content: 'CREATED_IFC',
+        entities: [{ expressId: 1 }],
+        stats: { fileSize: 11 },
+      }),
+    });
+    const stream = await openStream(live.port, '/events');
+    const events: string[] = [];
+    try {
+      stream.res.on('data', (c: Buffer) => events.push(c.toString()));
+      await poll(() => events.length >= 1);
+      await json(live.port, '/api/create', {
+        method: 'POST',
+        body: JSON.stringify({ type: 'IfcWall' }),
+      });
+      await poll(() => events.length >= 2);
+      assert.equal(
+        events[1],
+        'data: {"action":"addGeometry","ifcContent":"CREATED_IFC"}\n\n',
+      );
+
+      // …and clearing broadcasts the paired removeCreated.
+      await json(live.port, '/api/clear-created', { method: 'POST' });
+      await poll(() => events.length >= 3);
+      assert.equal(events[2], 'data: {"action":"removeCreated"}\n\n');
+    } finally {
+      stream.close();
+      live.server.close();
+    }
+  });
+});
+
+describe('viewer server — startup contract', () => {
+  it('rejects when the model file does not exist', TEST_TIMEOUT, async () => {
+    // If the pre-flight `stat` is ever dropped, this resolves instead of
+    // rejecting — and the server it just bound would keep the process alive
+    // forever. `leaked` + `finally` turns that into a clean failure rather
+    // than a hung run.
+    let leaked: ViewerServer | undefined;
+    try {
+      await assert.rejects(
+        async () => {
+          leaked = await startViewerServer({
+            filePath: join(tmpdir(), 'ifclite-does-not-exist-42.ifc'),
+            fileName: 'x.ifc',
+            port: 0,
+          });
+        },
+        /ENOENT/,
+      );
+    } finally {
+      leaked?.close();
+    }
+  });
+
+  it('reports the bound port and URL through onReady', TEST_TIMEOUT, async () => {
+    let seenPort = -1;
+    let seenUrl = '';
+    const { server, port } = await boot({
+      fileName: 'm.ifc',
+      onReady: (p, u) => {
+        seenPort = p;
+        seenUrl = u;
+      },
+    });
+    try {
+      assert.ok(seenPort > 0);
+      assert.equal(seenPort, port);
+      assert.equal(seenUrl, `http://localhost:${seenPort}`);
+      const res = await req(seenPort, '/api/status');
+      assert.equal(res.status, 200);
+    } finally {
+      server.close();
+    }
+  });
+});

--- a/packages/viewer/test/server-routes.test.ts
+++ b/packages/viewer/test/server-routes.test.ts
@@ -14,10 +14,11 @@
 
 import assert from 'node:assert/strict';
 import { after, before, describe, it } from 'node:test';
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { access, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
+  resolvePackageDirFromModuleUrl,
   startViewerServer,
   VALID_ACTIONS,
   type CreateResult,
@@ -35,6 +36,33 @@ import {
 } from './helpers/http.js';
 
 const HOOK_TIMEOUT = { timeout: 30_000 };
+
+/**
+ * Fail fast, and say what to do about it.
+ *
+ * `startViewerServer` reads the wasm glue at boot, so EVERY suite in this file
+ * needs `@ifc-lite/wasm`'s runtime — and that runtime is gitignored
+ * (`packages/wasm/pkg/.gitignore` is `*`), built by CI before the test job and
+ * by `bash scripts/build-wasm.sh` locally. Without it all six `before` hooks
+ * die on a bare `ENOENT … node_modules/@ifc-lite/wasm/pkg/ifc-lite.js`, which
+ * reads like a broken install rather than a missing build step.
+ *
+ * This throws instead of skipping on purpose: if a CI wasm build ever silently
+ * fails, these tests must go red, not quietly stop covering the wasm routes.
+ */
+before(async () => {
+  const wasmDir = resolvePackageDirFromModuleUrl(import.meta.resolve('@ifc-lite/wasm'));
+  const pkgDir = join(wasmDir, 'pkg');
+  for (const name of ['ifc-lite.js', 'ifc-lite_bg.wasm']) {
+    await access(join(pkgDir, name)).catch(() => {
+      throw new Error(
+        `Missing wasm runtime ${join(pkgDir, name)}. These tests serve the real ` +
+          `@ifc-lite/wasm artifacts over HTTP, and the runtime is gitignored. ` +
+          `Build it first: bash scripts/build-wasm.sh`,
+      );
+    });
+  }
+}, HOOK_TIMEOUT);
 
 /** Every server booted by a test, so the final teardown can close them all. */
 const booted: ViewerServer[] = [];
@@ -214,11 +242,35 @@ describe('viewer server — static routes and CORS', () => {
   });
 
   it('404s a traversal attempt under /wasm/snippets/', TEST_TIMEOUT, async () => {
-    // The traversal guard is unit-tested on `resolveWasmAssetPath`; this pins
-    // that the route actually consults it rather than reading the path raw.
-    const res = await req(port, '/wasm/snippets/../../../../../../etc/passwd');
-    assert.equal(res.status, 404);
-    assert.equal(res.body.toString(), 'Not Found');
+    // Two layers, and it matters which one answers.
+    //
+    // `server.ts` parses the request line with `new URL(...)` (server.ts:164)
+    // and routes on `url.pathname`, and the WHATWG parser removes double-dot
+    // path segments — including their percent-encoded spellings `%2e%2e` and
+    // `.%2e`. So a LITERAL `..` traversal never even reaches the
+    // `/wasm/snippets/` branch (server.ts:220): by the time routing happens the
+    // pathname is plain `/etc/passwd` and it falls through to the unknown-route
+    // 404. That is a real defence, so it is asserted — but it is normalisation,
+    // not `resolveWasmAssetPath`.
+    const normalised = await req(port, '/wasm/snippets/../../../../../../etc/passwd');
+    assert.equal(normalised.status, 404);
+    assert.equal(normalised.body.toString(), 'Not Found');
+
+    // The encoded form survives normalisation (`%2f` is not a segment
+    // separator, so `%2e%2e%2f…` is one opaque segment), so THIS one really
+    // does enter the `/wasm/snippets/` branch and reach
+    // `resolveWasmAssetPath`. Target: `pkg/../package.json`, a file that
+    // genuinely exists one level outside the served root — so if the route ever
+    // decoded the escapes back into separators AND the guard were gone, this
+    // would answer 200 with that file's bytes instead of 404.
+    const encoded = await req(port, '/wasm/snippets/%2e%2e%2f%2e%2e%2fpackage.json');
+    assert.equal(encoded.status, 404, 'an encoded traversal must not escape pkg/');
+    assert.equal(encoded.body.toString(), 'Not Found');
+
+    // `resolveWasmAssetPath` returning `null` for an escaping path is pinned
+    // directly in ./server.test.ts — it is unreachable from this route, since
+    // `url.pathname` always starts `/wasm/snippets/` here and can never carry a
+    // surviving `..` segment for `resolve()` to act on.
   });
 
   it('404s an unknown route', TEST_TIMEOUT, async () => {
@@ -478,6 +530,30 @@ describe('viewer server — create / export / clear lifecycle', () => {
   }, HOOK_TIMEOUT);
   after(() => server?.close(), HOOK_TIMEOUT);
 
+  /**
+   * Put the server's created-segment list into an exactly-known state.
+   *
+   * The suite shares one server, so without this the status/export/clear tests
+   * would be reading whatever the create tests above happened to leave behind —
+   * they would pass in file order and fail run in isolation or reordered.
+   * Clearing first also means the count each of them asserts is the count this
+   * helper just produced, not an accumulation of the whole file.
+   */
+  async function seedSegments(...contents: string[]): Promise<void> {
+    const cleared = await json(port, '/api/clear-created', { method: 'POST' });
+    assert.equal(cleared.status, 200, 'seed: clear must succeed');
+    assert.deepEqual(server.createdSegments, [], 'seed: must start from empty');
+    for (const content of contents) {
+      nextContent = content;
+      const res = await json(port, '/api/create', {
+        method: 'POST',
+        body: JSON.stringify({ type: 'IfcWall' }),
+      });
+      assert.equal(res.status, 200, `seed: creating ${content} must succeed`);
+    }
+    assert.deepEqual(server.createdSegments, contents, 'seed: state must match the request');
+  }
+
   it('wraps a single (non-array) element body into a one-element array', TEST_TIMEOUT, async () => {
     // server.ts: `Array.isArray(parsed) ? parsed : [parsed]`. Without the
     // wrap the handler receives a bare object, `elements.length` is
@@ -556,6 +632,9 @@ describe('viewer server — create / export / clear lifecycle', () => {
   });
 
   it('reports the accumulated segment count in /api/status', TEST_TIMEOUT, async () => {
+    // Two separate creates, so "accumulated" is what is actually being pinned:
+    // a status route that reported 1 (or the last segment only) would fail.
+    await seedSegments('SEG_A', 'SEG_B');
     const res = await json(port, '/api/status');
     assert.equal(res.status, 200);
     assert.equal(res.headers['content-type'], 'application/json; charset=utf-8');
@@ -569,6 +648,7 @@ describe('viewer server — create / export / clear lifecycle', () => {
   });
 
   it('exports the segments newline-separated as an IFC attachment', TEST_TIMEOUT, async () => {
+    await seedSegments('SEG_A', 'SEG_B');
     const res = await req(port, '/api/export');
     assert.equal(res.status, 200);
     assert.equal(res.headers['content-type'], 'application/octet-stream');
@@ -578,6 +658,9 @@ describe('viewer server — create / export / clear lifecycle', () => {
   });
 
   it('clears the segments and reports how many were dropped', TEST_TIMEOUT, async () => {
+    // `cleared` must be the number actually dropped, so seed a known 2 — a
+    // route that returned a constant, or 1, or the post-clear length, fails.
+    await seedSegments('SEG_A', 'SEG_B');
     const res = await json(port, '/api/clear-created', { method: 'POST' });
     assert.equal(res.status, 200);
     assert.deepEqual(res.json, { ok: true, cleared: 2 });

--- a/packages/viewer/test/server.test.ts
+++ b/packages/viewer/test/server.test.ts
@@ -48,4 +48,44 @@ describe('resolveWasmAssetPath', () => {
 
     assert.equal(assetPath, null);
   });
+
+  // The `/wasm/` prefix check is the function's own contract, not just an
+  // echo of the caller's route guard: it is what makes the `slice` below it
+  // safe. Without it, `'/other/x'.slice(6)` yields a different, unintended
+  // suffix that still resolves inside pkg/ and passes the traversal check.
+  for (const requestPath of ['/other/x.js', '/wasm', 'wasm/x.js', '/', '']) {
+    it(`returns null for a path outside /wasm/: ${JSON.stringify(requestPath)}`, () => {
+      assert.equal(
+        resolveWasmAssetPath('/Users/test/node_modules/@ifc-lite/wasm', requestPath),
+        null,
+      );
+    });
+  }
+
+  it('returns null for a bare /wasm/ with no asset name', () => {
+    // Boundary: the prefix matches but the remainder is empty, which would
+    // otherwise resolve to the pkg directory itself.
+    assert.equal(
+      resolveWasmAssetPath('/Users/test/node_modules/@ifc-lite/wasm', '/wasm/'),
+      null,
+    );
+  });
+
+  it('resolves a single-segment asset directly under pkg/', () => {
+    // The other direction of the same boundary.
+    assert.equal(
+      resolveWasmAssetPath('/Users/test/node_modules/@ifc-lite/wasm', '/wasm/x.js'),
+      '/Users/test/node_modules/@ifc-lite/wasm/pkg/x.js',
+    );
+  });
+
+  it('rejects a traversal that lands on a sibling of pkg/ with a shared prefix', () => {
+    // `relative()` returns "..", so the `startsWith('..')` check must fire —
+    // a naive `assetPath.startsWith(pkgDir)` string test would let this
+    // through because "/…/wasm/pkg-evil" starts with "/…/wasm/pkg".
+    assert.equal(
+      resolveWasmAssetPath('/Users/test/node_modules/@ifc-lite/wasm', '/wasm/../pkg-evil/x.js'),
+      null,
+    );
+  });
 });

--- a/packages/viewer/test/streaming-viewer.test.ts
+++ b/packages/viewer/test/streaming-viewer.test.ts
@@ -1,0 +1,256 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The streaming adapters POST to a running viewer over real HTTP, so these
+ * tests stand up a real capture server on port 0 and read what actually
+ * arrived on the wire. Nothing about `fetch` or the transport is stubbed.
+ *
+ * The capture server tracks its own sockets and destroys them in `after`, so
+ * a failed assertion can never leave a connection holding the server handle
+ * open — that is the difference between a failing run and a hanging one.
+ */
+
+import assert from 'node:assert/strict';
+import { after, before, beforeEach, describe, it } from 'node:test';
+import { createServer, type Server } from 'node:http';
+import type { Socket } from 'node:net';
+import type { EntityRef } from '@ifc-lite/sdk';
+import {
+  createStreamingViewerAdapter,
+  createStreamingVisibilityAdapter,
+} from '../src/streaming-viewer.js';
+
+const TO = { timeout: 30_000 } as const;
+
+let server: Server;
+let port: number;
+let received: Array<Record<string, unknown>>;
+let paths: string[];
+let methods: Array<string | undefined>;
+let contentTypes: Array<string | undefined>;
+const sockets = new Set<Socket>();
+
+const ref = (expressId: number): EntityRef => ({ modelId: 'arch', expressId });
+
+/** Wait until exactly `n` commands have landed, or fail. */
+async function waitFor(n: number): Promise<void> {
+  const deadline = Date.now() + 5000;
+  while (received.length < n && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 10));
+  }
+  assert.equal(received.length, n, `expected exactly ${n} commands on the wire`);
+}
+
+/** Assert no further command arrives (used to pin the negative direction). */
+async function expectNoMore(n: number): Promise<void> {
+  await new Promise((r) => setTimeout(r, 100));
+  assert.equal(received.length, n);
+}
+
+before(async () => {
+  server = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (c: Buffer) => chunks.push(c));
+    req.on('end', () => {
+      paths.push(req.url ?? '');
+      methods.push(req.method);
+      contentTypes.push(req.headers['content-type']);
+      received.push(JSON.parse(Buffer.concat(chunks).toString()));
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end('{"ok":true}');
+    });
+  });
+  server.on('connection', (s) => {
+    sockets.add(s);
+    s.on('close', () => sockets.delete(s));
+  });
+  await new Promise<void>((r) => server.listen(0, '127.0.0.1', r));
+  const addr = server.address();
+  assert.ok(addr && typeof addr === 'object');
+  port = addr.port;
+}, TO);
+
+after(() => {
+  for (const s of sockets) s.destroy();
+  sockets.clear();
+  server?.close();
+}, TO);
+
+beforeEach(() => {
+  received = [];
+  paths = [];
+  methods = [];
+  contentTypes = [];
+});
+
+describe('createStreamingViewerAdapter', () => {
+  it('POSTs JSON to /api/command on the given port', TO, async () => {
+    createStreamingViewerAdapter(port).flyTo([ref(1)]);
+    await waitFor(1);
+    assert.equal(paths[0], '/api/command');
+    assert.equal(methods[0], 'POST');
+    assert.equal(contentTypes[0], 'application/json');
+    assert.deepEqual(received[0], { action: 'flyto', ids: [1] });
+  });
+
+  it('colorize sends the express ids and colour verbatim', TO, async () => {
+    createStreamingViewerAdapter(port).colorize([ref(4), ref(9)], [1, 0.5, 0, 1]);
+    await waitFor(1);
+    assert.deepEqual(received[0], {
+      action: 'colorizeEntities',
+      ids: [4, 9],
+      color: [1, 0.5, 0, 1],
+    });
+  });
+
+  it('sends only the expressId, dropping the modelId', TO, async () => {
+    // The viewer indexes by express id alone; leaking `{modelId, expressId}`
+    // objects onto the wire would make every id fail to match.
+    createStreamingViewerAdapter(port).flyTo([ref(42)]);
+    await waitFor(1);
+    assert.deepEqual(received[0].ids, [42]);
+  });
+
+  it('colorizeAll sends one command per batch, not just the first', TO, async () => {
+    createStreamingViewerAdapter(port).colorizeAll([
+      { refs: [ref(1)], color: [1, 0, 0, 1] },
+      { refs: [ref(2), ref(3)], color: [0, 1, 0, 1] },
+      { refs: [ref(4)], color: [0, 0, 1, 1] },
+    ]);
+    await waitFor(3);
+    const byColor = new Map(received.map((c) => [JSON.stringify(c.color), c.ids]));
+    assert.deepEqual(byColor.get('[1,0,0,1]'), [1]);
+    assert.deepEqual(byColor.get('[0,1,0,1]'), [2, 3]);
+    assert.deepEqual(byColor.get('[0,0,1,1]'), [4]);
+    for (const c of received) assert.equal(c.action, 'colorizeEntities');
+  });
+
+  it('colorizeAll with no batches sends nothing', TO, async () => {
+    createStreamingViewerAdapter(port).colorizeAll([]);
+    await expectNoMore(0);
+  });
+
+  // Both directions of the resetColors branch. A scoped reset must target
+  // the given entities; an unscoped reset must fall back to the global
+  // "showall", or the user's other overrides would silently survive.
+  it('resetColors with refs sends a scoped reset', TO, async () => {
+    createStreamingViewerAdapter(port).resetColors([ref(7)]);
+    await waitFor(1);
+    assert.deepEqual(received[0], { action: 'resetColorEntities', ids: [7] });
+  });
+
+  it('resetColors with no argument sends the global showall', TO, async () => {
+    createStreamingViewerAdapter(port).resetColors();
+    await waitFor(1);
+    assert.deepEqual(received[0], { action: 'showall' });
+  });
+
+  it('resetColors with an EMPTY array also sends the global showall', TO, async () => {
+    // Boundary: [] is falsy-adjacent but truthy in JS. Treating it as a
+    // scoped reset would send `resetColorEntities` with an empty id list —
+    // a no-op, so the viewer would keep every colour override.
+    createStreamingViewerAdapter(port).resetColors([]);
+    await waitFor(1);
+    assert.deepEqual(received[0], { action: 'showall' });
+  });
+
+  it('setSection and setCamera forward their payloads under the right action', TO, async () => {
+    const adapter = createStreamingViewerAdapter(port);
+    const plane = { axis: 'z' as const, position: 2.5, enabled: true, flipped: false };
+    adapter.setSection(plane);
+    await waitFor(1);
+    assert.deepEqual(received[0], { action: 'section', section: plane });
+
+    received = [];
+    adapter.setCamera({ mode: 'orthographic', target: [0, 0, 0] });
+    await waitFor(1);
+    assert.deepEqual(received[0], {
+      action: 'camera',
+      state: { mode: 'orthographic', target: [0, 0, 0] },
+    });
+  });
+
+  it('the getters are write-only stubs and never touch the wire', TO, async () => {
+    const adapter = createStreamingViewerAdapter(port);
+    assert.equal(adapter.getSection(), null);
+    assert.deepEqual(adapter.getCamera(), { mode: 'perspective' });
+    await expectNoMore(0);
+  });
+
+  it('targets the port it was constructed with', TO, async () => {
+    // A hard-coded or off-by-one port would silently send every command into
+    // the void — the adapter swallows transport errors by design, so nothing
+    // else in the suite would notice.
+    const second: Array<Record<string, unknown>> = [];
+    const other = createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (c: Buffer) => chunks.push(c));
+      req.on('end', () => {
+        second.push(JSON.parse(Buffer.concat(chunks).toString()));
+        res.writeHead(200).end('{}');
+      });
+    });
+    other.on('connection', (s) => {
+      sockets.add(s);
+      s.on('close', () => sockets.delete(s));
+    });
+    try {
+      await new Promise<void>((r) => other.listen(0, '127.0.0.1', r));
+      const addr = other.address();
+      assert.ok(addr && typeof addr === 'object');
+
+      createStreamingViewerAdapter(addr.port).flyTo([ref(11)]);
+      const deadline = Date.now() + 5000;
+      while (second.length < 1 && Date.now() < deadline) {
+        await new Promise((r) => setTimeout(r, 10));
+      }
+      assert.deepEqual(second, [{ action: 'flyto', ids: [11] }]);
+      // …and nothing reached the other server.
+      await expectNoMore(0);
+    } finally {
+      other.close();
+    }
+  });
+
+  it('swallows a transport failure instead of rejecting the caller', TO, async () => {
+    // Fire-and-forget: a closed viewer must not take the SDK call down.
+    const dead = createStreamingViewerAdapter(1);
+    assert.doesNotThrow(() => dead.flyTo([ref(1)]));
+    await new Promise((r) => setTimeout(r, 200));
+  });
+});
+
+describe('createStreamingVisibilityAdapter', () => {
+  it('hide, show and isolate each map to their own distinct action', TO, async () => {
+    const adapter = createStreamingVisibilityAdapter(port);
+
+    adapter.hide([ref(1), ref(2)]);
+    await waitFor(1);
+    assert.deepEqual(received[0], { action: 'hideEntities', ids: [1, 2] });
+
+    received = [];
+    adapter.show([ref(3)]);
+    await waitFor(1);
+    assert.deepEqual(received[0], { action: 'showEntities', ids: [3] });
+
+    received = [];
+    adapter.isolate([ref(4)]);
+    await waitFor(1);
+    assert.deepEqual(received[0], { action: 'isolateEntities', ids: [4] });
+  });
+
+  it('reset sends the global showall with no id list', TO, async () => {
+    createStreamingVisibilityAdapter(port).reset();
+    await waitFor(1);
+    assert.deepEqual(received[0], { action: 'showall' });
+    assert.ok(!('ids' in received[0]));
+  });
+
+  it('an empty ref list still sends the command with an empty id array', TO, async () => {
+    createStreamingVisibilityAdapter(port).hide([]);
+    await waitFor(1);
+    assert.deepEqual(received[0], { action: 'hideEntities', ids: [] });
+  });
+});

--- a/packages/viewer/test/viewer-html.test.ts
+++ b/packages/viewer/test/viewer-html.test.ts
@@ -1,0 +1,104 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { getViewerHtml } from '../src/viewer-html.js';
+
+/** Extract the document title, which is where the model name is interpolated. */
+function titleOf(html: string): string {
+  const m = html.match(/<title>([\s\S]*?)<\/title>/);
+  assert.ok(m, 'viewer HTML must contain a <title>');
+  return m[1];
+}
+
+describe('getViewerHtml — model name escaping', () => {
+  it('escapes every HTML-significant character in the model name', () => {
+    // Absolute expectation derived from the HTML spec's five named
+    // references, not from the implementation's own output.
+    const title = titleOf(getViewerHtml(`&<>"'`));
+    assert.equal(title, `&amp;&lt;&gt;&quot;&#39; — ifc-lite 3D`);
+  });
+
+  // One case per character, so a kill names the character whose escape was
+  // dropped instead of hiding behind a single combined string.
+  for (const [raw, escaped] of [
+    ['&', '&amp;'],
+    ['<', '&lt;'],
+    ['>', '&gt;'],
+    ['"', '&quot;'],
+    ["'", '&#39;'],
+  ] as const) {
+    it(`escapes ${JSON.stringify(raw)} as ${escaped}`, () => {
+      assert.equal(titleOf(getViewerHtml(`a${raw}b`)), `a${escaped}b — ifc-lite 3D`);
+    });
+  }
+
+  it('escapes every occurrence, not just the first', () => {
+    // The replacements use /g. Without it only the leading character is
+    // escaped and the rest of the name still reaches the parser raw.
+    assert.equal(titleOf(getViewerHtml('<<<')), '&lt;&lt;&lt; — ifc-lite 3D');
+    assert.equal(titleOf(getViewerHtml('a&b&c')), 'a&amp;b&amp;c — ifc-lite 3D');
+  });
+
+  it('escapes the ampersand FIRST so escapes are not double-encoded', () => {
+    // If `&` were escaped after `<`, "&lt;" would become "&amp;lt;" and the
+    // browser would render the literal text "&lt;" instead of "<".
+    const title = titleOf(getViewerHtml('a<b'));
+    assert.equal(title, 'a&lt;b — ifc-lite 3D');
+    assert.doesNotMatch(title, /&amp;lt;/);
+  });
+
+  it('neutralises a script-injecting model name', () => {
+    const html = getViewerHtml('</title><script>alert(1)</script>');
+    assert.doesNotMatch(html, /<script>alert\(1\)<\/script>/);
+    assert.match(titleOf(html), /&lt;script&gt;alert\(1\)&lt;\/script&gt;/);
+  });
+
+  it('neutralises an attribute-breaking model name', () => {
+    // Both quote styles must go: a bare " or ' would escape any attribute
+    // context the name is later interpolated into.
+    const title = titleOf(getViewerHtml(`x" onload="evil()`));
+    assert.equal(title, `x&quot; onload=&quot;evil() — ifc-lite 3D`);
+    assert.doesNotMatch(title, /x" onload/);
+  });
+
+  it('escapes the name at every interpolation site, not only the title', () => {
+    // The name is also written into the loading screen and the info panel.
+    // A raw copy anywhere is a live injection point.
+    const html = getViewerHtml('<img src=x onerror=alert(1)>');
+    assert.doesNotMatch(html, /<img src=x onerror=alert\(1\)>/);
+    assert.equal(
+      html.split('&lt;img src=x onerror=alert(1)&gt;').length - 1,
+      3,
+      'the escaped name must appear at all three interpolation sites',
+    );
+  });
+
+  it('leaves a name with no special characters byte-for-byte intact', () => {
+    // The other direction of the binary signal: escaping must not fire on
+    // ordinary names, including non-ASCII ones.
+    const title = titleOf(getViewerHtml('Büro-Gebäude_v2 (final).ifc'));
+    assert.equal(title, 'Büro-Gebäude_v2 (final).ifc — ifc-lite 3D');
+  });
+
+  it('accepts an empty model name', () => {
+    assert.equal(titleOf(getViewerHtml('')), ' — ifc-lite 3D');
+  });
+
+  it('produces a complete standalone HTML document', () => {
+    const html = getViewerHtml('m.ifc');
+    assert.match(html, /^<!DOCTYPE html>/);
+    assert.match(html, /<\/html>\s*$/);
+    assert.match(html, /<meta charset="utf-8"\/>/);
+  });
+
+  it('references only same-origin assets', () => {
+    // The viewer must run offline behind `ifc-lite view`; a CDN <script> or
+    // remote <link> would make it fail with no network.
+    const html = getViewerHtml('m.ifc');
+    assert.doesNotMatch(html, /<script[^>]+src=["']https?:/i);
+    assert.doesNotMatch(html, /<link[^>]+href=["']https?:/i);
+  });
+});


### PR DESCRIPTION
`@ifc-lite/viewer-core` ships an HTTP server, an SSE broadcast channel, a REST command API and the generated viewer HTML — behind **4 unit tests** that only touched two pure path helpers. Every route, status code, MIME type, SSE frame and the model-name escaping were unverified.

**4 tests / 2 suites → 117 tests / 11 suites**, ~0.9 s. Test-only; no production code changed.

## How the coverage was proven

Every assertion here was verified by mutation, not by inspection. 67 mutations against load-bearing logic in `server.ts`, `viewer-html.ts` and `streaming-viewer.ts`; each applied by exact-substring replacement asserting a replacement count of exactly 1, re-read from disk to confirm the text changed, run under a hard wall-clock timeout, and restored from a saved backup.

**65 / 67 killed (97%).** Two deliberate controls (corrupt the 404 body; corrupt the SSE greeting) were run first and both died, before any survivor was believed.

That ratio is **targeted, not a uniform sweep** — the mutations were aimed at the logic these tests were written for, against a 4-test baseline. It is not comparable to a whole-package mutation score.

Representative kills:

| Mutation | Killed by |
|---|---|
| drop the `Array.isArray(parsed) ? parsed : [parsed]` wrap | `wraps a single (non-array) element body…` (+5) |
| invert that ternary | `passes an array body straight through…` (+6) |
| unanchor the CORS origin regex | 5 of the 8 rejected-origin cases |
| CORS regex → `if (true)` | all 8 rejected-origin cases |
| require a port in the CORS regex | `…for http://localhost`, `…for http://127.0.0.1` |
| drop `127.0.0.1` from the allowlist | the two `127.0.0.1` cases |
| `https?` → `http` | `…for https://localhost:8443` |
| SSE frame `\n\n` → `\n` | 3 SSE tests |
| `break` after the first SSE client | `broadcasts to every subscriber, not only the first` |
| broadcast before validating the action | `greets a subscriber, counts it, and forwards…` |
| never delete the client on close | 4 tests |
| dispatch on `req.url` instead of `url.pathname` | `ignores the query string when matching a route` |
| each route's method check removed | the matching `does not treat <VERB> …` test |
| `readBody` resolving on the first chunk | `reads the whole request body, not just the first chunk` |
| 501 → 400, 204 → 404, 204 → 200, 400 → 200 | the matching status-code test |
| `.wasm`/`.html`/`.js` MIME swaps | the matching route test |
| `Content-Length` off by one | 2 model-streaming tests |
| drop each of the 5 HTML escapes | one named per-character test each |
| escape `&` last instead of first | 6 escaping tests |
| `/g` → non-global on `<` | `escapes every occurrence, not just the first` |
| drop `stat` validation at startup | `rejects when the model file does not exist` |
| drop the `/wasm/` prefix guard | `returns null for a path outside /wasm/` |
| remove one action from `VALID_ACTIONS` | `accepts the \"camera\" action` + the size test |
| adapters: swap an action, keep the ref object, POST → GET, first batch only | the matching adapter test |

Per-case discrimination was **measured, not assumed**, for both loops: `M64` (drop one action) fails exactly the `accepts the \"camera\" action` case; `M65`/`M66`/`M67` each fail a *different* subset of the accepted-origin cases. The loops are not carried by one lucky case.

## Survivors

- **`elements.length === 0 || !elements[0].type` → `!elements[0]?.type`** — equivalent for every array-shaped input. The only observable difference is the error *string* for a `null` element: today a raw `TypeError` message leaks out, the mutant would return the domain message. Both are `400 {ok:false}`. Deliberately not pinned — asserting on a JS internal error text would be a worse test than none. A test does pin that `[null]` yields a 400 with `ok:false` rather than a 500 or a hung socket.
- **the `/wasm/snippets/` 200 path's MIME fallback** — genuine gap, but not reachable hermetically: it needs a real file under `packages/wasm/pkg/snippets/`, which is generated `wasm-pack` output that a test must not create or depend on. The 404 branch of that route *is* covered, including a traversal attempt.

## Hang safety

The server holds SSE responses open forever, so one leaked socket keeps the `node:http` handle referenced and `server.close()` never completes — a failed assertion becomes a run that never exits rather than a run that fails. This was not hypothetical: dropping the startup `stat` made `startViewerServer` resolve instead of reject, and the test leaked the server it had just bound. That mutation **hung the suite** on the first pass. Fixed in the test, and the mutation now dies cleanly in 1 s.

The safeguards:
- Every socket the helpers open is registered and destroyed from an `after` hook that runs even when an assertion throws.
- Every request carries its own 10 s deadline; every socket-touching test carries a 30 s timeout.
- SSE streams are closed from `finally`, never from the happy path.
- The startup-contract test captures and closes the server it would otherwise leak.

## Notes

- CI already runs this package: root `pnpm test` → `turbo test` picks up the package's `test` script. No workflow change needed.
- `pnpm typecheck` excludes test files, so the new tests were typechecked separately against the package's own `tsconfig.json` with `include` extended to `test/**/*` — clean. That caught a wrong `SectionPlane` shape in the draft.
- No changeset: test-only, no published API surface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end coverage for viewer server routes, including CORS, static assets, commands, SSE, exports, and error handling.
  * Added integration tests for streaming updates, visibility actions, resets, routing, and transport failures.
  * Added security and edge-case tests for asset paths and HTML escaping.
  * Added reusable HTTP testing utilities for requests, streams, polling, timeouts, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->