### PR TITLE
fix(source-dalux): four review follow-ups for #2023 (first-poll baseline, transient-failure deletions, folder parent paging, package index)

### DIFF
--- a/docs/api/typescript.md
+++ b/docs/api/typescript.md
@@ -47,6 +47,7 @@ ifc-lite ships 36 public npm packages: 35 scoped `@ifc-lite/*` packages plus the
 | [`create-ifc-lite`](#create-ifc-lite) | Create IFC-Lite projects with one command |
 | [`@ifc-lite/merge`](https://www.npmjs.com/package/@ifc-lite/merge) | Three-way merge engine for IFCX layers — MergePlan with auto-merged ops and explicit conflict records, merge-layer emission, rebase, and revert. |
 | [`@ifc-lite/plugin-api`](https://www.npmjs.com/package/@ifc-lite/plugin-api) | Dependency-free type surface for ifc-lite file-source plugins |
+| [`@ifc-lite/source-dalux`](https://www.npmjs.com/package/@ifc-lite/source-dalux) | Dalux Build (Box) file-source provider for ifc-lite |
 <!-- END GENERATED: package-index -->
 
 ---

--- a/packages/source-dalux/src/http-client.ts
+++ b/packages/source-dalux/src/http-client.ts
@@ -277,10 +277,12 @@ export async function fetchPage(
 
 /**
  * Follows every page of a Dalux bookmark-paginated endpoint and returns the
- * combined items. For internal callers that genuinely need a whole listing
- * in one shot — currently only `watchRevisions`'s one-sweep-per-file-area
- * poll. The public `FileSourceProvider` listing methods must NOT use this;
- * they call {@link fetchPage} once and return that page to the host.
+ * combined items. For callers that genuinely need a whole listing in one
+ * shot: `watchRevisions`'s one-sweep-per-file-area poll, and the folder
+ * listing in `listContainers` (whose parent-id resolution is only correct
+ * against the complete folder set). `listProjects`/`listFiles` must NOT use
+ * this — they call {@link fetchPage} once and return that page to the host,
+ * so a large tenant or file area is never loaded eagerly.
  *
  * Bounded by `MAX_SWEEP_PAGES` (a server minting endlessly fresh bookmarks
  * can't loop forever) and tracks every bookmark seen across the whole

--- a/packages/source-dalux/src/provider.ts
+++ b/packages/source-dalux/src/provider.ts
@@ -103,28 +103,35 @@ export class DaluxBuildProvider implements FileSourceProvider {
     // 'flat-subtree'); the host nests the flattened result client-side via
     // each folder's `parentId`.
     const fileAreaId = decodeContainerId(parentId).fileAreaId;
-    const page = await fetchPage(
+    // Deliberately the one listing path that sweeps every page before
+    // returning. Nesting is only decidable against the *complete* folder set:
+    // a folder's parent can land on any page, and the host appends later
+    // pages to what it already has (`useSourceCatalogSync` merges
+    // `[...current.items, ...page.items]`) without ever re-resolving earlier
+    // ones — so a parent id resolved against a single page is resolved
+    // permanently, and wrongly. The sweep is bounded by `MAX_SWEEP_PAGES` and
+    // covers folders only; files (the volume) stay paged one call at a time.
+    const rawFolders = await fetchAllPages(
       client,
       `/5.1/projects/${enc(projectId)}/file_areas/${enc(fileAreaId)}/folders`,
       {},
-      options?.cursor,
       options?.signal,
     );
-    const folders = convertListLenient<DaluxFolder>(ctx, page.items, decodeFolder, 'Folder');
-    const folderIdsThisPage = new Set(folders.map((folder) => folder.folderId));
+    const folders = convertListLenient<DaluxFolder>(ctx, rawFolders, decodeFolder, 'Folder');
+    const folderIds = new Set(folders.map((folder) => folder.folderId));
 
     const containers: SourceContainer[] = folders.map((folder) => {
       const parentFolderId = nonEmptyString(folder.parentFolderId);
-      // A folder whose parent isn't the file area itself and isn't another
-      // folder on this page is reattached to the file area root rather than
-      // left dangling: Dalux sometimes reports folders whose parent is
-      // never itself surfaced as a folder. Known limitation of paging one
-      // Dalux bookmark page at a time (required so a large area doesn't
-      // force one giant eager fetch): if a folder's true parent lands on a
-      // *later* page, it's reattached to the root here too, and re-nests
-      // correctly once the host has walked that later page and revisits it.
+      // A folder whose parent is neither the file area itself nor any folder
+      // in the area is reattached to the file area root rather than left
+      // dangling: Dalux sometimes reports folders whose parent is never
+      // itself surfaced as a folder, and a container pointing at a parent id
+      // that never arrives is dropped from the host's tree entirely
+      // (`buildContainerTree`). Because `folderIds` is built from the whole
+      // area, "not in the area" now genuinely means unreachable rather than
+      // merely "not on this page".
       const resolvedParentId =
-        !parentFolderId || parentFolderId === fileAreaId || folderIdsThisPage.has(parentFolderId)
+        !parentFolderId || parentFolderId === fileAreaId || folderIds.has(parentFolderId)
           ? (parentFolderId ?? fileAreaId)
           : fileAreaId;
 
@@ -139,7 +146,10 @@ export class DaluxBuildProvider implements FileSourceProvider {
       };
     });
 
-    return { items: containers, cursor: page.cursor };
+    // The whole area is in `containers`, so there is no page left to hand
+    // back — the host's "load more folders" affordance stays inert and the
+    // catalog counts as completely fetched.
+    return { items: containers, cursor: undefined };
   }
 
   async listFiles(
@@ -235,8 +245,11 @@ export class DaluxBuildProvider implements FileSourceProvider {
    * 1. One area's sweep failing (a deleted file area 404ing, or a pagination
    *    error) must not abort the whole call — that would discard the
    *    already-detected events from every *other*, healthy area too. So each
-   *    area's sweep is caught individually; a failed area's refs are
-   *    reported (with a warning) rather than the call rejecting outright.
+   *    area's sweep is caught individually and warned about rather than the
+   *    call rejecting outright. Only a definitive not-found (HTTP 404) turns
+   *    into `deleted: true` events; any other failure leaves that area's refs
+   *    without an event this poll, because "the request failed" is not
+   *    evidence that "the file is gone upstream".
    * 2. `ctx.storage.set`/`delete` for every area are buffered and only
    *    committed once the whole sweep is done, never per-area as each area
    *    finishes. Advancing a cache immediately and *then* discovering a
@@ -279,20 +292,32 @@ export class DaluxBuildProvider implements FileSourceProvider {
         const daluxFiles = convertListLenient<DaluxFile>(ctx, rawItems, decodeFile, 'File');
         filesById = new Map(daluxFiles.filter((file) => !file.deleted).map((file) => [file.fileId, file] as const));
       } catch (err) {
-        // This area's sweep failed outright (area deleted upstream -> 404,
-        // a Dalux pagination error, ...). Report its refs as deleted/skipped
-        // rather than letting the failure propagate and take every other
-        // area's already-detected events down with it. Crucially: don't
-        // touch this area's caches below, so a transient failure gets
-        // retried against the same baseline next poll instead of silently
-        // losing whatever change caused it.
-        ctx.log.warn('Dalux: file-area sweep failed during watchRevisions, skipping its refs this poll', {
-          projectId,
-          fileAreaId,
-          error: err instanceof Error ? err.message : String(err),
-        });
-        for (const ref of areaRefs) {
-          events.push({ fileId: ref.fileId, latestRevisionId: LATEST_REVISION, deleted: true });
+        // This area's sweep failed outright. Never let the failure propagate
+        // and take every other area's already-detected events down with it —
+        // and never touch this area's caches below, so the next poll compares
+        // against the same baseline instead of silently losing whatever
+        // change caused the failure.
+        //
+        // `deleted: true` is contractually "the file is gone upstream", and
+        // the host surfaces it to the user as exactly that. Only a definitive
+        // not-found says that: a 500, a timeout, an aborted relay or a
+        // pagination error say nothing at all about whether the files still
+        // exist, so those refs are simply skipped this poll.
+        const gone = err instanceof DaluxHttpError && err.status === 404;
+        ctx.log.warn(
+          gone
+            ? 'Dalux: file area not found during watchRevisions, reporting its refs as deleted'
+            : 'Dalux: file-area sweep failed during watchRevisions, skipping its refs this poll',
+          {
+            projectId,
+            fileAreaId,
+            error: err instanceof Error ? err.message : String(err),
+          },
+        );
+        if (gone) {
+          for (const ref of areaRefs) {
+            events.push({ fileId: ref.fileId, latestRevisionId: LATEST_REVISION, deleted: true });
+          }
         }
         continue;
       }
@@ -308,9 +333,16 @@ export class DaluxBuildProvider implements FileSourceProvider {
         }
 
         const latestRevisionId = currentRevisionId(match);
-        const cached = await ctx.storage.get(cacheKey);
-        if (cached && cached !== latestRevisionId) {
-          events.push({ fileId: ref.fileId, latestRevisionId, previousRevisionId: cached });
+        // Before the first successful poll there is no cache entry. Falling
+        // back to the ref's own `revisionId` — the revision the host is
+        // currently holding for this file, produced by `currentRevisionId`
+        // too, so directly comparable — is what stops a change made between
+        // the file being tracked and the first poll from being swallowed
+        // forever: with no baseline, that poll would emit nothing and then
+        // cache the newer revision as if it had always been the known one.
+        const baseline = (await ctx.storage.get(cacheKey)) ?? nonEmptyString(ref.revisionId);
+        if (baseline && baseline !== latestRevisionId) {
+          events.push({ fileId: ref.fileId, latestRevisionId, previousRevisionId: baseline });
         }
         pendingSets.set(cacheKey, latestRevisionId);
       }

--- a/packages/source-dalux/test/provider.test.ts
+++ b/packages/source-dalux/test/provider.test.ts
@@ -276,6 +276,52 @@ describe('DaluxBuildProvider', () => {
         },
       ]);
     });
+
+    it('keeps a folder nested under a parent that only appears on a later Dalux page', async () => {
+      // Dalux hands back folders one bookmark page at a time, and a child can
+      // land on an earlier page than its parent. Rewriting such a child to the
+      // file-area root is permanent: the host appends later pages to the list
+      // it already has (`useSourceCatalogSync` merges `[...current.items,
+      // ...page.items]`) and never re-asks the provider to re-resolve them.
+      const mockFetch = vi.fn().mockImplementation((url: string) => {
+        if (url.includes('/5.1/projects/proj1/file_areas/fa1/folders')) {
+          const isSecondPage = url.includes('bookmark=page-2');
+          if (!isSecondPage) {
+            return Promise.resolve(
+              mockResponse({
+                json: () =>
+                  Promise.resolve({
+                    items: [
+                      { data: { folderId: 'child-folder', folderName: 'Child Folder', parentFolderId: 'late-parent' } },
+                    ],
+                    links: [
+                      {
+                        rel: 'nextPage',
+                        href: 'https://node1.field.dalux.com/service/api/5.1/projects/proj1/file_areas/fa1/folders?bookmark=page-2',
+                      },
+                    ],
+                  }),
+              }),
+            );
+          }
+          return Promise.resolve(
+            mockResponse({
+              json: () =>
+                Promise.resolve({ items: [{ data: { folderId: 'late-parent', folderName: 'Late Parent' } }] }),
+            }),
+          );
+        }
+        return Promise.resolve(mockResponse({ json: () => Promise.resolve([]) }));
+      });
+
+      const ctx = createMockCtx(mockFetch as unknown as typeof fetch);
+      const page = await provider.listContainers(ctx, 'proj1', fileAreaContainerId('fa1'));
+
+      const childId = folderContainerId('fa1', 'child-folder');
+      const parentId = folderContainerId('fa1', 'late-parent');
+      expect(page.items.map((c) => c.id).sort()).toEqual([childId, parentId].sort());
+      expect(page.items.find((c) => c.id === childId)?.parentId).toBe(parentId);
+    });
   });
 
   describe('listFiles', () => {
@@ -543,6 +589,100 @@ describe('DaluxBuildProvider', () => {
       ]);
 
       expect(result.events).toEqual([]);
+    });
+
+    it('emits an event on the very first poll when upstream has moved past the ref revision (empty cache)', async () => {
+      // Before the first successful poll there is no cache entry for the file.
+      // Comparing against "nothing" and then storing the new value would swallow
+      // that change permanently: the ref's own revisionId is the baseline the
+      // host is currently holding, so it is what upstream must be compared to.
+      const mockFetch = vi.fn().mockResolvedValue(
+        mockResponse({
+          json: () =>
+            Promise.resolve({
+              items: [
+                { data: { fileId: 'f1', fileName: 'a.ifc', fileAreaId: 'fa1', fileRevisionId: 'rev-2', deleted: false } },
+              ],
+            }),
+        }),
+      );
+      const ctx = createMockCtx(mockFetch as unknown as typeof fetch);
+      expect(await ctx.storage.get('rev:proj1:fa1:f1')).toBeUndefined();
+
+      const result = await provider.watchRevisions(ctx, [
+        { projectId: 'proj1', containerId: fileAreaContainerId('fa1'), fileId: 'f1', revisionId: 'rev-1' },
+      ]);
+
+      expect(result.events).toEqual([{ fileId: 'f1', latestRevisionId: 'rev-2', previousRevisionId: 'rev-1' }]);
+      expect(await ctx.storage.get('rev:proj1:fa1:f1')).toBe('rev-2');
+    });
+
+    it('stays silent on the first poll when upstream still matches the ref revision', async () => {
+      const mockFetch = vi.fn().mockResolvedValue(
+        mockResponse({
+          json: () =>
+            Promise.resolve({
+              items: [
+                { data: { fileId: 'f1', fileName: 'a.ifc', fileAreaId: 'fa1', fileRevisionId: 'rev-1', deleted: false } },
+              ],
+            }),
+        }),
+      );
+      const ctx = createMockCtx(mockFetch as unknown as typeof fetch);
+
+      const result = await provider.watchRevisions(ctx, [
+        { projectId: 'proj1', containerId: fileAreaContainerId('fa1'), fileId: 'f1', revisionId: 'rev-1' },
+      ]);
+
+      expect(result.events).toEqual([]);
+      expect(await ctx.storage.get('rev:proj1:fa1:f1')).toBe('rev-1');
+    });
+
+    it('reports deleted for a definitive 404 on the file-area sweep', async () => {
+      const mockFetch = vi.fn().mockResolvedValue(
+        mockResponse({ ok: false, status: 404, statusText: 'Not Found', text: () => Promise.resolve('file area deleted') }),
+      );
+      const ctx = createMockCtx(mockFetch as unknown as typeof fetch);
+      await ctx.storage.set('rev:proj1:fa-gone:f1', 'rev-1');
+
+      const result = await provider.watchRevisions(ctx, [
+        { projectId: 'proj1', containerId: fileAreaContainerId('fa-gone'), fileId: 'f1' },
+      ]);
+
+      expect(result.events).toEqual([{ fileId: 'f1', latestRevisionId: LATEST_REVISION, deleted: true }]);
+    });
+
+    it('does NOT report deletion when an area sweep fails transiently (500), leaving the baseline intact', async () => {
+      // `deleted: true` is contractually "the file is gone upstream" and the
+      // host surfaces it as "N source files are gone upstream". A 500, a
+      // timeout or an aborted relay says nothing about the file existing, so
+      // the area's refs are skipped for this poll instead.
+      const mockFetch = vi.fn().mockResolvedValue(
+        mockResponse({ ok: false, status: 500, statusText: 'Internal Server Error', text: () => Promise.resolve('upstream boom') }),
+      );
+      const ctx = createMockCtx(mockFetch as unknown as typeof fetch);
+      await ctx.storage.set('rev:proj1:fa1:f1', 'rev-1');
+
+      const result = await provider.watchRevisions(ctx, [
+        { projectId: 'proj1', containerId: fileAreaContainerId('fa1'), fileId: 'f1' },
+      ]);
+
+      expect(result.events).toEqual([]);
+      expect(ctx.log.warn).toHaveBeenCalled();
+      expect(await ctx.storage.get('rev:proj1:fa1:f1')).toBe('rev-1');
+    });
+
+    it('does NOT report deletion when the sweep fails for a non-HTTP reason (aborted/network)', async () => {
+      const mockFetch = vi.fn().mockRejectedValue(new Error('network down'));
+      const ctx = createMockCtx(mockFetch as unknown as typeof fetch);
+      await ctx.storage.set('rev:proj1:fa1:f1', 'rev-1');
+
+      const result = await provider.watchRevisions(ctx, [
+        { projectId: 'proj1', containerId: fileAreaContainerId('fa1'), fileId: 'f1' },
+      ]);
+
+      expect(result.events).toEqual([]);
+      expect(await ctx.storage.get('rev:proj1:fa1:f1')).toBe('rev-1');
     });
 
     it('isolates a failed area sweep: other areas still report events instead of the whole call rejecting', async () => {


### PR DESCRIPTION
Four of the unresolved review threads on #2023, implemented against that PR's head (`cf2d816`) and targeting `feat/source-dalux-provider`, not `main`.

**Offered for you to take or leave.** It deliberately does not touch your branch, does not resolve any of your threads, and nothing was posted on #2023. If you'd rather fix any of these differently, ignore the corresponding commit hunk — the four fixes are independent.

Everything stays inside `packages/source-dalux` plus the generated docs region. Where a fix looked like it wanted a host change, I stopped and wrote down why instead (see #4).

Baseline `packages/source-dalux`: **77 tests**. After: **83 tests** (5 new + 1 that was already green as a guard). `pnpm typecheck`, `pnpm lint`, `pnpm check:test-wiring`, `pnpm docs:check-readmes` all pass. Test files aren't covered by the root typecheck (`include: ["src/**/*"]`), so they were typechecked separately against the package's own tsconfig with that exclusion lifted — clean.

---

### 1. Stale published-package index

`pnpm docs:check-generated` exited **1** on this branch and **0** on its base, so the staleness originates here: `docs/api/typescript.md`'s `package-index` region has no `@ifc-lite/source-dalux` row. Ran `pnpm docs:generate`; only the generated region is committed (one added table row), nothing hand-edited. `pnpm docs:check-generated` now exits **0**.

### 2. First poll compared against nothing (`provider.ts`, `watchRevisions`)

The upstream revision was compared only against the provider cache. Before the first successful poll there is no cache entry, so `cached && cached !== latest` is false, **no event is emitted**, and the newer revision is then written to the cache — the update is suppressed permanently, not just delayed. Every existing test seeded the cache first, which is exactly why this was invisible.

`ref.revisionId` is the revision the host is currently holding, produced by the same `currentRevisionId()` and forwarded by `revisionWatch.ts`, so it is directly comparable. It is now the baseline when the cache is empty.

- RED: `emits an event on the very first poll when upstream has moved past the ref revision (empty cache)` — failed on current code (`expected [] to deeply equal [ { fileId: 'f1', … } ]`).
- Mutation (teeth): `const baseline = (await ctx.storage.get(cacheKey)) ?? nonEmptyString(ref.revisionId);` → `const baseline = await ctx.storage.get(cacheKey);` (1 replacement) → that test fails, the companion guard test still passes.
- Mutation for the guard test: `if (baseline && baseline !== latestRevisionId)` → `if (baseline)` (1 replacement) → `stays silent on the first poll when upstream still matches the ref revision` fails, along with the two pre-existing "must not falsely emit" tests.

### 3. A transient failure was reported as deletion (`provider.ts`, `watchRevisions`)

The `try` covers `fetchAllPages` plus decode, so a 500, a timeout, an aborted relay and a pagination error all land in the same `catch` as a 404 — and the catch emitted `deleted: true` for every tracked ref in that area. `RevisionEvent.deleted` is documented as "the file is gone upstream" and the host surfaces it as "N source files are gone upstream", so this is a contract violation rather than a UX wart.

Only a definitive not-found (`DaluxHttpError` with status 404) now produces deletions; anything else skips that area's refs for this poll — which is what the catch's own comment already said it did. Cache handling is untouched (`continue` still buffers nothing), so the change is confined to the event kind. The class doc comment above `watchRevisions` was updated to match.

- RED: `does NOT report deletion when an area sweep fails transiently (500)…` and `…when the sweep fails for a non-HTTP reason (aborted/network)` — both failed on current code with the spurious `deleted: true` event.
- Both directions covered: `reports deleted for a definitive 404 on the file-area sweep` (green before and after — the 404 path must not regress) and the two transient tests.
- Mutations: `const gone = err instanceof DaluxHttpError && err.status === 404;` → `const gone = false;` (1 replacement) → only the 404 test fails. → `const gone = true;` (1 replacement, i.e. the pre-fix behaviour) → only the two transient tests fail.

### 4. Parent ids were resolved against one page (`provider.ts`, `listContainers`)

`folderIdsThisPage` was built from a single Dalux page, so a folder whose parent lands on a different page was rewritten to the file-area root. The comment claimed the host "re-nests correctly once the host has walked that later page and revisits it" — it does not: `useSourceCatalogSync.ts` merges `items: [...current.items, ...page.items]` on both load-more paths, a pure append with no re-resolution, and the result persists via `maybePersist`. So the misplacement is permanent. That comment is gone.

**On the shape of the fix.** Literally preserving the reported parent id and leaving it dangling would make those folders *disappear* rather than be misplaced: `buildContainerTree` does `byId.get(c.parentId)?.children.push(node)`, so a container whose parent id never arrives is dropped from the tree entirely, and `SourceFolderStep` filters by exact `parentId` too. Making dangling parents fall back to the root is a host change, which I was asked not to make on your branch — and the provider also genuinely needs the root fallback for the case your comment describes (Dalux reporting a parent that is never itself surfaced as a folder; covered by your existing test, still green).

So instead the folder listing resolves against the **complete** folder set: it sweeps every page via `fetchAllPages` and returns one complete page with no cursor. Parent ids are then preserved for every real parent, and "parent not in the area" now genuinely means unreachable instead of "not on this page".

This does reverse your explicit "one giant eager fetch" note, so it is the hunk most worth disagreeing with. The argument for it: nesting is not decidable from a single page, the endpoint already returns every folder in the area regardless of nesting (`containerListing: 'flat-subtree'`), folders are the small dimension while files — the volume — stay paged one call at a time, the sweep is bounded by `MAX_SWEEP_PAGES`, and a complete folder page is what lets `maybePersist` treat the catalog as fully fetched. The `fetchAllPages` doc comment was updated so its stated invariant still matches reality. If you'd rather keep folder paging, this is the one to drop.

- RED: `keeps a folder nested under a parent that only appears on a later Dalux page` — failed on current code (child rewritten to the file-area root, second page never fetched).
- Mutation: the `fetchAllPages(...)` call reverted to the previous single `fetchPage(...)` (1 replacement) → only that test fails.

Every mutation was applied as an exact-substring replacement asserting exactly one occurrence, the mutated region re-read to confirm the text changed, and reverted by restoring a saved copy of the file.

No changeset: the package is unreleased and `.changeset/source-dalux-initial.md` already covers this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
