### PR TITLE
test(server): close 15 mutation-verified coverage gaps in apps/server

### DIFF
--- a/apps/server/src/admission.rs
+++ b/apps/server/src/admission.rs
@@ -388,3 +388,7 @@ mod tests {
         assert!(text.contains("reason=\"rss_shed\"} 0"));
     }
 }
+
+#[cfg(test)]
+#[path = "admission_tests.rs"]
+mod admission_tests;

--- a/apps/server/src/admission_tests.rs
+++ b/apps/server/src/admission_tests.rs
@@ -1,0 +1,232 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Second test module for `admission`: the parts the in-file `tests` module
+//! left vacuous.
+//!
+//! The in-file tests assert only `matches!(err, ApiError::Overloaded { .. })`,
+//! so the `retry_after_secs` each rejection path advertises was unpinned; they
+//! also never touch the exact RSS watermark, so `>=` could be relaxed to `>`
+//! with the suite green; and they never read a rejection counter, so all three
+//! reasons could be attributed to the same bucket.
+
+use super::*;
+
+fn cfg(max_parses: usize, budget_mb: u64, queue_depth: usize, shed_pct: u8) -> AdmissionCfg {
+    AdmissionCfg {
+        max_concurrent_parses: max_parses,
+        mem_budget_bytes: budget_mb * 1024 * 1024,
+        queue_depth,
+        queue_timeout: std::time::Duration::from_millis(50),
+        shed_pct,
+    }
+}
+
+/// Pull one `ifc_server_admission_rejected_total{reason="…"}` sample out of the
+/// Prometheus text body.
+fn rejected(a: &Admission, reason: &str) -> u64 {
+    let needle = format!("ifc_server_admission_rejected_total{{reason=\"{reason}\"}} ");
+    let text = a.metrics_text();
+    let line = text
+        .lines()
+        .find(|l| l.starts_with(&needle))
+        .unwrap_or_else(|| panic!("no sample for reason={reason:?} in:\n{text}"));
+    line[needle.len()..].trim().parse().expect("counter value")
+}
+
+/// Every rejection is attributed to its OWN reason. Swapping any two of these
+/// increments left the whole suite green, and an operator debugging a 503 storm
+/// reads exactly these three counters to tell "the box is out of memory" from
+/// "the box is out of CPU" from "the queue is saturated" — three different
+/// remediations.
+#[tokio::test]
+async fn each_rejection_reason_increments_its_own_counter() {
+    // rss_shed: breaker open, nothing else touched.
+    let shed = Arc::new(Admission::new(cfg(4, 100, 4, 85)));
+    shed.set_resident_bytes(90 * 1024 * 1024);
+    shed.acquire(1).await.expect_err("breaker sheds");
+    assert_eq!(rejected(&shed, "rss_shed"), 1);
+    assert_eq!(rejected(&shed, "queue_full"), 0);
+    assert_eq!(rejected(&shed, "overloaded"), 0);
+
+    // queue_full: CPU busy and no queue slot ⇒ immediate reject.
+    let full = Arc::new(Admission::new(cfg(1, 0, 0, 0)));
+    let _held = full.acquire(1).await.expect("takes the only slot");
+    full.acquire(1).await.expect_err("queue full");
+    assert_eq!(rejected(&full, "queue_full"), 1);
+    assert_eq!(rejected(&full, "rss_shed"), 0);
+    assert_eq!(rejected(&full, "overloaded"), 0);
+
+    // overloaded: a queue slot exists, so the request WAITS and then times out.
+    let slow = Arc::new(Admission::new(cfg(1, 0, 4, 0)));
+    let _held = slow.acquire(1).await.expect("takes the only slot");
+    slow.acquire(1).await.expect_err("waits then times out");
+    assert_eq!(rejected(&slow, "overloaded"), 1);
+    assert_eq!(rejected(&slow, "rss_shed"), 0);
+    assert_eq!(rejected(&slow, "queue_full"), 0);
+}
+
+/// The memory-budget timeout is its own path (CPU permit acquired, memory
+/// permits unavailable) and must be counted as `overloaded`.
+#[tokio::test]
+async fn memory_budget_timeout_counts_as_overloaded() {
+    let a = Arc::new(Admission::new(cfg(8, 100, 4, 0)));
+    let _g1 = a.acquire(40 * 1024 * 1024).await.expect("40MB #1");
+    let _g2 = a.acquire(40 * 1024 * 1024).await.expect("40MB #2");
+    a.acquire(40 * 1024 * 1024).await.expect_err("over budget");
+    assert_eq!(rejected(&a, "overloaded"), 1);
+    assert_eq!(rejected(&a, "queue_full"), 0);
+    assert_eq!(rejected(&a, "rss_shed"), 0);
+}
+
+/// `Retry-After` is DOUBLED on the RSS-breaker path and single on every other
+/// path. That is the whole point of the breaker: RSS does not fall the instant
+/// a slot frees, so a client that retries after the plain queue timeout just
+/// bounces off a still-open breaker. Halving the shed value survived the suite
+/// because no test read the number.
+#[tokio::test]
+async fn shed_advertises_double_the_retry_after_of_the_other_paths() {
+    // queue_timeout 50 ms ⇒ `.as_secs()` is 0 ⇒ `.max(1)` ⇒ 1 s baseline.
+    let queue_full = Arc::new(Admission::new(cfg(1, 0, 0, 0)));
+    let _held = queue_full.acquire(1).await.expect("takes the slot");
+    let ApiError::Overloaded { retry_after_secs: queue_secs } =
+        queue_full.acquire(1).await.expect_err("queue full")
+    else {
+        panic!("expected Overloaded");
+    };
+    assert_eq!(queue_secs, 1, "queue rejection advertises the bare timeout");
+
+    let shedding = Arc::new(Admission::new(cfg(4, 100, 4, 85)));
+    shedding.set_resident_bytes(90 * 1024 * 1024);
+    let ApiError::Overloaded { retry_after_secs: shed_secs } =
+        shedding.acquire(1).await.expect_err("breaker sheds")
+    else {
+        panic!("expected Overloaded");
+    };
+    assert_eq!(shed_secs, 2, "the RSS breaker backs clients off twice as long");
+    assert_eq!(shed_secs, queue_secs * 2);
+}
+
+/// The retry hint scales with the configured timeout rather than being a
+/// hard-coded constant, and never advertises `0` (a client would hot-loop).
+#[tokio::test]
+async fn retry_after_tracks_the_configured_timeout_and_is_never_zero() {
+    let mut c = cfg(1, 0, 0, 0);
+    c.queue_timeout = std::time::Duration::from_secs(7);
+    let a = Arc::new(Admission::new(c));
+    let _held = a.acquire(1).await.expect("takes the slot");
+    let ApiError::Overloaded { retry_after_secs } = a.acquire(1).await.expect_err("queue full")
+    else {
+        panic!("expected Overloaded");
+    };
+    assert_eq!(retry_after_secs, 7);
+
+    let mut z = cfg(1, 0, 0, 0);
+    z.queue_timeout = std::time::Duration::ZERO;
+    let a = Arc::new(Admission::new(z));
+    let _held = a.acquire(1).await.expect("takes the slot");
+    let ApiError::Overloaded { retry_after_secs } = a.acquire(1).await.expect_err("queue full")
+    else {
+        panic!("expected Overloaded");
+    };
+    assert_eq!(retry_after_secs, 1, "a sub-second timeout still backs the client off 1s");
+}
+
+/// The RSS watermark comparison is `>=`, and it is exercised AT the exact
+/// boundary in both directions — the existing test sits 5 MB clear of it, so
+/// relaxing `>=` to `>` changed nothing observable.
+///
+/// `watermark = mem_budget_bytes / 100 * shed_pct`; with a 100 MiB budget and
+/// 85% that is exactly `1_048_576 * 85 = 89_128_960` bytes (the integer
+/// division is exact here, so the boundary is not an artifact of rounding).
+#[tokio::test]
+async fn rss_breaker_fires_exactly_at_the_watermark() {
+    const BUDGET: u64 = 100 * 1024 * 1024;
+    let watermark = BUDGET / 100 * 85;
+    assert_eq!(watermark, 89_128_960, "boundary arithmetic is exact");
+
+    let a = Arc::new(Admission::new(cfg(4, 100, 4, 85)));
+
+    // One byte below: admits, and readiness says not shedding.
+    a.set_resident_bytes(watermark - 1);
+    assert!(!a.is_shedding(), "below the watermark the instance stays ready");
+    let g = a.acquire(1).await.expect("admits one byte below the watermark");
+    drop(g);
+
+    // Exactly at the watermark: sheds. This is the case `>` would miss.
+    a.set_resident_bytes(watermark);
+    assert!(a.is_shedding(), "AT the watermark the breaker is open");
+    a.acquire(1).await.expect_err("sheds at exactly the watermark");
+    assert_eq!(rejected(&a, "rss_shed"), 1);
+
+    // One byte above: still sheds.
+    a.set_resident_bytes(watermark + 1);
+    assert!(a.is_shedding());
+    a.acquire(1).await.expect_err("sheds above the watermark");
+}
+
+/// The breaker is inert when either input is 0 — an unsampled RSS (`0`, e.g.
+/// every non-Linux target), a disabled memory budget, or `shed_pct = 0`. Any of
+/// those turning the breaker ON would make the readiness probe report 503
+/// forever on a dev machine and drain a healthy instance in production.
+#[tokio::test]
+async fn breaker_is_inert_when_rss_budget_or_pct_is_zero() {
+    // RSS never sampled.
+    let unsampled = Arc::new(Admission::new(cfg(4, 100, 4, 85)));
+    assert_eq!(unsampled.resident_bytes(), 0);
+    assert!(!unsampled.is_shedding());
+    unsampled.acquire(1).await.expect("an unsampled RSS must not shed");
+
+    // Memory gate disabled entirely.
+    let no_budget = Arc::new(Admission::new(cfg(4, 0, 4, 85)));
+    no_budget.set_resident_bytes(u64::MAX);
+    assert!(!no_budget.is_shedding());
+    no_budget.acquire(1).await.expect("no budget ⇒ no breaker");
+
+    // Breaker explicitly disabled.
+    let no_pct = Arc::new(Admission::new(cfg(4, 100, 4, 0)));
+    no_pct.set_resident_bytes(u64::MAX);
+    assert!(!no_pct.is_shedding());
+    no_pct.acquire(1).await.expect("shed_pct 0 ⇒ no breaker");
+}
+
+/// `set_resident_bytes` / `resident_bytes` round-trip, and the gauge is what
+/// `metrics_text` publishes. Without this the sampler could write to a field
+/// nothing reads.
+#[tokio::test]
+async fn resident_gauge_round_trips_into_the_metrics_body() {
+    let a = Arc::new(Admission::new(cfg(2, 100, 2, 85)));
+    a.set_resident_bytes(4_096);
+    assert_eq!(a.resident_bytes(), 4_096);
+    assert!(a.metrics_text().contains("ifc_server_resident_bytes 4096"));
+    // The budget gauge reports bytes, not MB.
+    assert!(a
+        .metrics_text()
+        .contains(&format!("ifc_server_mem_budget_bytes {}", 100 * 1024 * 1024)));
+}
+
+/// `in_flight` rises on admit and falls on drop (the `AdmissionGuard::drop`
+/// impl), and `queued` is back to 0 once a rejected waiter has given up — a
+/// leaked queue slot would permanently shrink the effective queue depth.
+#[tokio::test]
+async fn in_flight_and_queued_gauges_return_to_zero() {
+    let a = Arc::new(Admission::new(cfg(1, 0, 2, 0)));
+    let g = a.acquire(1).await.expect("admit");
+    assert!(a.metrics_text().contains("ifc_server_admission_in_flight 1"));
+    // A second request queues, times out, and must not leak its queue slot.
+    a.acquire(1).await.expect_err("times out waiting");
+    assert!(a.metrics_text().contains("ifc_server_admission_queued 0"));
+    drop(g);
+    assert!(a.metrics_text().contains("ifc_server_admission_in_flight 0"));
+}
+
+/// A `0`-byte reservation still consumes a permit (`.max(1)`), so a flood of
+/// zero-length uploads cannot slip past the byte budget unbounded.
+#[tokio::test]
+async fn a_zero_byte_reservation_still_costs_one_permit() {
+    // 1 MB budget ⇒ exactly one permit.
+    let a = Arc::new(Admission::new(cfg(8, 1, 4, 0)));
+    let _g = a.acquire(0).await.expect("first zero-byte admit");
+    a.acquire(0).await.expect_err("the single permit is taken");
+}

--- a/apps/server/src/config.rs
+++ b/apps/server/src/config.rs
@@ -96,7 +96,11 @@ impl Config {
     /// (`parity_tests::test_state`), so a test that set `IFC_SERVER_API_TOKEN`
     /// globally would silently switch those tests to an authenticated server.
     /// Behavior is unchanged: `from_env` passes the real `std::env::var`.
-    fn from_lookup(get: impl Fn(&str) -> Option<String>) -> Self {
+    ///
+    /// `pub(crate)` so tests outside this module (`cors_tests`) can build a
+    /// config that is pinned to the shipped defaults rather than to whatever
+    /// the CI runner happens to export.
+    pub(crate) fn from_lookup(get: impl Fn(&str) -> Option<String>) -> Self {
         let worker_threads: usize = get("WORKER_THREADS")
             .unwrap_or_else(|| num_cpus::get().to_string())
             .parse()

--- a/apps/server/src/config.rs
+++ b/apps/server/src/config.rs
@@ -85,16 +85,28 @@ impl std::fmt::Debug for Config {
 impl Config {
     /// Load configuration from environment variables.
     pub fn from_env() -> Self {
-        let worker_threads: usize = std::env::var("WORKER_THREADS")
-            .unwrap_or_else(|_| num_cpus::get().to_string())
+        Self::from_lookup(|key| std::env::var(key).ok())
+    }
+
+    /// The actual parsing, over an injected variable lookup.
+    ///
+    /// Split out from [`Self::from_env`] purely so the defaults and the
+    /// parse/clamp rules are unit-testable without mutating the process
+    /// environment — `from_env` is called from other tests in this binary
+    /// (`parity_tests::test_state`), so a test that set `IFC_SERVER_API_TOKEN`
+    /// globally would silently switch those tests to an authenticated server.
+    /// Behavior is unchanged: `from_env` passes the real `std::env::var`.
+    fn from_lookup(get: impl Fn(&str) -> Option<String>) -> Self {
+        let worker_threads: usize = get("WORKER_THREADS")
+            .unwrap_or_else(|| num_cpus::get().to_string())
             .parse()
             .unwrap_or_else(|_| num_cpus::get());
         Self {
-            port: std::env::var("PORT")
-                .unwrap_or_else(|_| "8080".into())
+            port: get("PORT")
+                .unwrap_or_else(|| "8080".into())
                 .parse()
                 .unwrap_or(8080),
-            cache_dir: std::env::var("CACHE_DIR").unwrap_or_else(|_| {
+            cache_dir: get("CACHE_DIR").unwrap_or_else(|| {
                 // Auto-detect environment:
                 // - Docker: use /app/cache (created in Dockerfile)
                 // - Local dev: use ./.cache relative to server directory
@@ -108,17 +120,16 @@ impl Config {
                         .unwrap_or_else(|| "./.cache".into())
                 }
             }),
-            max_file_size_mb: std::env::var("MAX_FILE_SIZE_MB")
-                .unwrap_or_else(|_| "500".into())
+            max_file_size_mb: get("MAX_FILE_SIZE_MB")
+                .unwrap_or_else(|| "500".into())
                 .parse()
                 .unwrap_or(500),
-            request_timeout_secs: std::env::var("REQUEST_TIMEOUT_SECS")
-                .unwrap_or_else(|_| "300".into())
+            request_timeout_secs: get("REQUEST_TIMEOUT_SECS")
+                .unwrap_or_else(|| "300".into())
                 .parse()
                 .unwrap_or(300),
             worker_threads,
-            max_concurrent_parses: std::env::var("IFC_MAX_CONCURRENT_PARSES")
-                .ok()
+            max_concurrent_parses: get("IFC_MAX_CONCURRENT_PARSES")
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(worker_threads)
                 .max(1),
@@ -127,42 +138,37 @@ impl Config {
             // `=0` is an opt-out. Only 0 when no ceiling is readable, which
             // main() warns about (memory admission then falls back to OFF).
             mem_budget_mb: crate::mem_policy::resolve_mem_budget_mb(
-                std::env::var("IFC_MEM_BUDGET_MB")
-                    .ok()
-                    .and_then(|v| v.parse().ok()),
+                get("IFC_MEM_BUDGET_MB").and_then(|v| v.parse().ok()),
                 crate::mem_policy::cgroup_memory_limit_bytes(),
                 crate::mem_policy::total_physical_memory_bytes(),
             ),
-            admission_queue_depth: std::env::var("IFC_ADMISSION_QUEUE_DEPTH")
-                .ok()
+            admission_queue_depth: get("IFC_ADMISSION_QUEUE_DEPTH")
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(worker_threads * 2),
-            admission_queue_timeout_secs: std::env::var("IFC_ADMISSION_QUEUE_TIMEOUT_SECS")
-                .ok()
+            admission_queue_timeout_secs: get("IFC_ADMISSION_QUEUE_TIMEOUT_SECS")
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(5),
-            mem_shed_pct: std::env::var("IFC_MEM_SHED_PCT")
-                .ok()
+            mem_shed_pct: get("IFC_MEM_SHED_PCT")
                 .and_then(|v| v.parse::<u8>().ok())
                 .unwrap_or(85)
                 .min(100),
-            metrics_enabled: std::env::var("IFC_METRICS_ENABLED")
+            metrics_enabled: get("IFC_METRICS_ENABLED")
                 .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
                 .unwrap_or(false),
-            initial_batch_size: std::env::var("INITIAL_BATCH_SIZE")
-                .unwrap_or_else(|_| "100".into())
+            initial_batch_size: get("INITIAL_BATCH_SIZE")
+                .unwrap_or_else(|| "100".into())
                 .parse()
                 .unwrap_or(100),
-            max_batch_size: std::env::var("MAX_BATCH_SIZE")
-                .unwrap_or_else(|_| "1000".into())
+            max_batch_size: get("MAX_BATCH_SIZE")
+                .unwrap_or_else(|| "1000".into())
                 .parse()
                 .unwrap_or(1000),
-            cache_max_age_days: std::env::var("CACHE_MAX_AGE_DAYS")
-                .unwrap_or_else(|_| "7".into())
+            cache_max_age_days: get("CACHE_MAX_AGE_DAYS")
+                .unwrap_or_else(|| "7".into())
                 .parse()
                 .unwrap_or(7),
-            cors_origins: std::env::var("CORS_ORIGINS")
-                .unwrap_or_else(|_| {
+            cors_origins: get("CORS_ORIGINS")
+                .unwrap_or_else(|| {
                     // Default: allow common development origins
                     "http://localhost:3000,http://localhost:5173,http://127.0.0.1:3000,http://127.0.0.1:5173".into()
                 })
@@ -170,9 +176,8 @@ impl Config {
                 .map(|s| s.trim().to_string())
                 .filter(|s| !s.is_empty())
                 .collect(),
-            api_token: std::env::var("IFC_SERVER_API_TOKEN")
-                .or_else(|_| std::env::var("API_TOKEN"))
-                .ok()
+            api_token: get("IFC_SERVER_API_TOKEN")
+                .or_else(|| get("API_TOKEN"))
                 .map(|s| s.trim().to_string())
                 .filter(|s| !s.is_empty()),
         }
@@ -184,3 +189,7 @@ impl Default for Config {
         Self::from_env()
     }
 }
+
+#[cfg(test)]
+#[path = "config_tests.rs"]
+mod config_tests;

--- a/apps/server/src/config_tests.rs
+++ b/apps/server/src/config_tests.rs
@@ -1,0 +1,234 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Tests for `Config` parsing, defaults and clamps.
+//!
+//! `config.rs` had NO tests. Mutating the listen port default, deleting the
+//! empty-token filter (so `IFC_SERVER_API_TOKEN=""` would ENABLE auth against
+//! an empty secret), deleting the `IFC_MEM_SHED_PCT` clamp, and dropping the
+//! `IFC_METRICS_ENABLED=1` spelling all left the suite green.
+//!
+//! Everything is driven through `Config::from_lookup`, so no test here reads or
+//! writes the real process environment — `parity_tests` calls `from_env()` on
+//! other threads and would be silently reconfigured by a global `set_var`.
+
+use super::*;
+use std::collections::HashMap;
+
+/// A lookup over an explicit map — anything not listed is "unset".
+fn cfg(vars: &[(&str, &str)]) -> Config {
+    let map: HashMap<String, String> = vars
+        .iter()
+        .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+        .collect();
+    Config::from_lookup(|key| map.get(key).cloned())
+}
+
+/// Every var unset: the shipped defaults. These are the values a bare
+/// `docker run` gets, so each one is a deployment contract.
+#[test]
+fn defaults_apply_when_nothing_is_set() {
+    let c = cfg(&[]);
+    assert_eq!(c.port, 8080, "the container/Railway port contract");
+    assert_eq!(c.max_file_size_mb, 500);
+    assert_eq!(c.request_timeout_secs, 300);
+    assert_eq!(c.initial_batch_size, 100);
+    assert_eq!(c.max_batch_size, 1000);
+    assert_eq!(c.cache_max_age_days, 7);
+    assert_eq!(c.admission_queue_timeout_secs, 5);
+    assert_eq!(c.mem_shed_pct, 85);
+    assert!(!c.metrics_enabled, "metrics are opt-in, never on by default");
+    assert!(c.api_token.is_none(), "auth is off by default");
+    // Derived from worker_threads, which defaults to the CPU count.
+    assert_eq!(c.max_concurrent_parses, c.worker_threads.max(1));
+    assert_eq!(c.admission_queue_depth, c.worker_threads * 2);
+}
+
+/// Both directions of every scalar override: a valid value is honoured, and an
+/// unparseable one falls back to the default rather than panicking at startup.
+#[test]
+fn scalar_overrides_are_honoured_and_garbage_falls_back() {
+    let c = cfg(&[
+        ("PORT", "9443"),
+        ("MAX_FILE_SIZE_MB", "42"),
+        ("REQUEST_TIMEOUT_SECS", "17"),
+        ("INITIAL_BATCH_SIZE", "7"),
+        ("MAX_BATCH_SIZE", "77"),
+        ("CACHE_MAX_AGE_DAYS", "1"),
+        ("IFC_ADMISSION_QUEUE_TIMEOUT_SECS", "9"),
+    ]);
+    assert_eq!(c.port, 9443);
+    assert_eq!(c.max_file_size_mb, 42);
+    assert_eq!(c.request_timeout_secs, 17);
+    assert_eq!(c.initial_batch_size, 7);
+    assert_eq!(c.max_batch_size, 77);
+    assert_eq!(c.cache_max_age_days, 1);
+    assert_eq!(c.admission_queue_timeout_secs, 9);
+
+    let bad = cfg(&[
+        ("PORT", "not-a-port"),
+        ("MAX_FILE_SIZE_MB", "-1"),
+        ("REQUEST_TIMEOUT_SECS", ""),
+        ("INITIAL_BATCH_SIZE", "1e6"),
+        ("MAX_BATCH_SIZE", "∞"),
+        ("CACHE_MAX_AGE_DAYS", "seven"),
+        ("IFC_ADMISSION_QUEUE_TIMEOUT_SECS", "5s"),
+    ]);
+    assert_eq!(bad.port, 8080);
+    assert_eq!(bad.max_file_size_mb, 500);
+    assert_eq!(bad.request_timeout_secs, 300);
+    assert_eq!(bad.initial_batch_size, 100);
+    assert_eq!(bad.max_batch_size, 1000);
+    assert_eq!(bad.cache_max_age_days, 7);
+    assert_eq!(bad.admission_queue_timeout_secs, 5);
+}
+
+/// `IFC_MAX_CONCURRENT_PARSES` feeds the admission CPU semaphore. `0` must be
+/// clamped up to 1 — a zero-permit semaphore would wedge every parse request
+/// until the queue timeout and then 503 forever.
+#[test]
+fn concurrency_is_clamped_to_at_least_one() {
+    assert_eq!(cfg(&[("IFC_MAX_CONCURRENT_PARSES", "0")]).max_concurrent_parses, 1);
+    assert_eq!(cfg(&[("IFC_MAX_CONCURRENT_PARSES", "3")]).max_concurrent_parses, 3);
+    // Unparseable ⇒ worker_threads, still clamped.
+    let c = cfg(&[("WORKER_THREADS", "0"), ("IFC_MAX_CONCURRENT_PARSES", "x")]);
+    assert_eq!(c.worker_threads, 0);
+    assert_eq!(c.max_concurrent_parses, 1);
+}
+
+/// `IFC_MEM_SHED_PCT` is a percentage of the memory budget. Values above 100
+/// are clamped: an unclamped 200 would put the RSS watermark at twice the
+/// budget, so the circuit breaker would never fire and the container would be
+/// OOM-killed instead of shedding. Pinned at the boundary in both directions.
+#[test]
+fn shed_pct_is_clamped_to_100() {
+    assert_eq!(cfg(&[("IFC_MEM_SHED_PCT", "100")]).mem_shed_pct, 100);
+    assert_eq!(cfg(&[("IFC_MEM_SHED_PCT", "101")]).mem_shed_pct, 100);
+    assert_eq!(cfg(&[("IFC_MEM_SHED_PCT", "255")]).mem_shed_pct, 100);
+    assert_eq!(cfg(&[("IFC_MEM_SHED_PCT", "99")]).mem_shed_pct, 99);
+    assert_eq!(cfg(&[("IFC_MEM_SHED_PCT", "0")]).mem_shed_pct, 0, "0 disables the breaker");
+    // A value beyond u8 does not parse ⇒ the default, not a wrapped number.
+    assert_eq!(cfg(&[("IFC_MEM_SHED_PCT", "256")]).mem_shed_pct, 85);
+}
+
+/// `IFC_METRICS_ENABLED` accepts `1` and any casing of `true`, and NOTHING
+/// else. Dropping the `"1"` arm survived the suite: an operator following the
+/// usual `=1` convention would silently get a 404 on the metrics route.
+#[test]
+fn metrics_flag_accepts_one_and_true_only() {
+    for on in ["1", "true", "TRUE", "True"] {
+        assert!(
+            cfg(&[("IFC_METRICS_ENABLED", on)]).metrics_enabled,
+            "{on:?} must enable metrics"
+        );
+    }
+    for off in ["0", "false", "yes", "on", "", "2", "truthy"] {
+        assert!(
+            !cfg(&[("IFC_METRICS_ENABLED", off)]).metrics_enabled,
+            "{off:?} must NOT enable metrics"
+        );
+    }
+}
+
+/// The bearer token: `IFC_SERVER_API_TOKEN` wins over `API_TOKEN`, the value is
+/// trimmed, and a blank value stays `None`.
+///
+/// The blank case is the load-bearing one. Without the `!is_empty()` filter,
+/// `IFC_SERVER_API_TOKEN=""` (a very common way to "unset" a variable in a
+/// compose file or CI secret) would flip `api_token` to `Some("")`, and the
+/// server would start REQUIRING an `Authorization: Bearer ` header whose secret
+/// is the empty string — every real client 401s while anyone sending the empty
+/// credential is admitted. The mutation deleting that filter left the suite
+/// green.
+#[test]
+fn api_token_precedence_trimming_and_blank_handling() {
+    assert_eq!(
+        cfg(&[("IFC_SERVER_API_TOKEN", "primary"), ("API_TOKEN", "legacy")]).api_token,
+        Some("primary".to_string()),
+        "IFC_SERVER_API_TOKEN takes precedence"
+    );
+    assert_eq!(
+        cfg(&[("API_TOKEN", "legacy")]).api_token,
+        Some("legacy".to_string()),
+        "API_TOKEN is the documented fallback"
+    );
+    assert_eq!(
+        cfg(&[("IFC_SERVER_API_TOKEN", "  padded  ")]).api_token,
+        Some("padded".to_string()),
+        "surrounding whitespace is stripped"
+    );
+    for blank in ["", "   ", "\n", "\t "] {
+        assert_eq!(
+            cfg(&[("IFC_SERVER_API_TOKEN", blank)]).api_token,
+            None,
+            "a blank token ({blank:?}) must leave auth OFF, not enable it with an empty secret"
+        );
+    }
+    assert_eq!(cfg(&[]).api_token, None);
+}
+
+/// A set-but-blank `IFC_SERVER_API_TOKEN` must not shadow a real `API_TOKEN`
+/// into oblivion silently... it does, and that is the documented precedence
+/// (first var wins if present). Pinned so the behavior is a decision, not an
+/// accident: the fallback is `or_else` on presence, not on emptiness.
+#[test]
+fn blank_primary_token_shadows_the_fallback_and_leaves_auth_off() {
+    let c = cfg(&[("IFC_SERVER_API_TOKEN", ""), ("API_TOKEN", "legacy")]);
+    assert_eq!(c.api_token, None);
+}
+
+/// CORS origins: comma-split, trimmed, empty segments dropped. A trailing
+/// comma or padded list must not produce an empty origin, which would later be
+/// an unparseable `HeaderValue` silently dropped from the allow-list.
+#[test]
+fn cors_origins_are_split_trimmed_and_compacted() {
+    let c = cfg(&[(
+        "CORS_ORIGINS",
+        " https://a.example , ,https://b.example,,  ",
+    )]);
+    assert_eq!(
+        c.cors_origins,
+        vec!["https://a.example".to_string(), "https://b.example".to_string()]
+    );
+    assert_eq!(cfg(&[("CORS_ORIGINS", "*")]).cors_origins, vec!["*".to_string()]);
+    // The default list is localhost-only — never a wildcard.
+    let d = cfg(&[]);
+    assert!(!d.cors_origins.is_empty());
+    assert!(
+        !d.cors_origins.iter().any(|o| o == "*"),
+        "the default CORS list must not be permissive: {:?}",
+        d.cors_origins
+    );
+    assert!(d.cors_origins.iter().all(|o| o.contains("localhost") || o.contains("127.0.0.1")));
+}
+
+/// `Debug` must never print the token. Derived `Debug` (or a stray field
+/// rename) would leak the secret into logs and panic reports.
+#[test]
+fn debug_redacts_the_api_token() {
+    let c = cfg(&[("IFC_SERVER_API_TOKEN", "sup3r-s3cret-value")]);
+    let rendered = format!("{c:?}");
+    assert!(
+        !rendered.contains("sup3r-s3cret-value"),
+        "the bearer token leaked into Debug output: {rendered}"
+    );
+    assert!(rendered.contains("<redacted>"));
+    // A sanity check that Debug prints anything at all (so the assertion above
+    // is not vacuously satisfied by an empty string).
+    assert!(rendered.contains("port"));
+}
+
+/// `IFC_MEM_BUDGET_MB` is forwarded to the resolver, including the explicit
+/// `0` opt-out; a garbage value is treated as unset (auto-detect).
+#[test]
+fn mem_budget_env_reaches_the_resolver() {
+    assert_eq!(cfg(&[("IFC_MEM_BUDGET_MB", "2048")]).mem_budget_mb, 2048);
+    assert_eq!(cfg(&[("IFC_MEM_BUDGET_MB", "0")]).mem_budget_mb, 0);
+    // Unparseable ⇒ auto-detection, i.e. whatever the host's ceilings resolve
+    // to; it must equal the no-explicit-value result, not the parsed garbage.
+    assert_eq!(
+        cfg(&[("IFC_MEM_BUDGET_MB", "lots")]).mem_budget_mb,
+        cfg(&[]).mem_budget_mb
+    );
+}

--- a/apps/server/src/cors_tests.rs
+++ b/apps/server/src/cors_tests.rs
@@ -19,6 +19,20 @@ use tower::ServiceExt;
 const ALLOWED: &str = "https://allowed.example";
 const OTHER: &str = "https://other.example";
 
+/// The shipped defaults, with NO environment read at all.
+///
+/// `Config::from_env()` would import the runner's environment into these
+/// tests: a CI job that exports `CORS_ORIGINS=*` would turn
+/// [`the_shipped_default_is_not_permissive`] into an assertion about the
+/// runner's override, and it would fail loudly for the wrong reason instead of
+/// pinning the default we actually ship. `from_lookup(|_| None)` is the same
+/// parser with every variable unset, so this fixture is the shipped default by
+/// construction. Environment *parsing* coverage lives in `config_tests.rs`,
+/// where the lookup is injected per case.
+fn shipped_default_config() -> Config {
+    Config::from_lookup(|_| None)
+}
+
 async fn state_with_origins(label: &str, origins: &[&str]) -> AppState {
     let dir = std::env::temp_dir().join(format!(
         "ifc-lite-server-cors-{}-{}",
@@ -27,7 +41,7 @@ async fn state_with_origins(label: &str, origins: &[&str]) -> AppState {
     ));
     let _ = std::fs::remove_dir_all(&dir);
     let cache = Arc::new(DiskCache::new(dir.to_str().unwrap()).await);
-    let mut config = Config::from_env();
+    let mut config = shipped_default_config();
     config.cors_origins = origins.iter().map(|o| (*o).to_string()).collect();
     // Auth must stay off here, or a 401 would mask the CORS assertions.
     config.api_token = None;
@@ -121,7 +135,7 @@ async fn near_miss_wildcards_do_not_enable_permissive_cors() {
 /// deployment that never sets the variable.
 #[tokio::test]
 async fn the_shipped_default_is_not_permissive() {
-    let defaults = Config::from_env().cors_origins;
+    let defaults = shipped_default_config().cors_origins;
     let state = state_with_origins(
         "defaults",
         &defaults.iter().map(String::as_str).collect::<Vec<_>>(),

--- a/apps/server/src/cors_tests.rs
+++ b/apps/server/src/cors_tests.rs
@@ -1,0 +1,135 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Tests for `build_cors_layer` as it is actually mounted on the router.
+//!
+//! Nothing tested it. Breaking the wildcard detection (`o == "*"`) left the
+//! suite green in the direction that matters least — but the same blind spot
+//! covers the direction that matters most: if the ALLOW-LIST branch ever
+//! degraded into a permissive one, every deployment with an explicit
+//! `CORS_ORIGINS` would start serving any origin on the internet, and no test
+//! would notice.
+
+use super::*;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+
+const ALLOWED: &str = "https://allowed.example";
+const OTHER: &str = "https://other.example";
+
+async fn state_with_origins(label: &str, origins: &[&str]) -> AppState {
+    let dir = std::env::temp_dir().join(format!(
+        "ifc-lite-server-cors-{}-{}",
+        std::process::id(),
+        label
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    let cache = Arc::new(DiskCache::new(dir.to_str().unwrap()).await);
+    let mut config = Config::from_env();
+    config.cors_origins = origins.iter().map(|o| (*o).to_string()).collect();
+    // Auth must stay off here, or a 401 would mask the CORS assertions.
+    config.api_token = None;
+    AppState {
+        cache,
+        config: Arc::new(config),
+        admission: Arc::new(crate::admission::Admission::new(
+            crate::admission::AdmissionCfg {
+                max_concurrent_parses: 2,
+                mem_budget_bytes: 0,
+                queue_depth: 2,
+                queue_timeout: std::time::Duration::from_millis(50),
+                shed_pct: 0,
+            },
+        )),
+    }
+}
+
+/// `GET /api/v1/health` with an `Origin`, returning the
+/// `Access-Control-Allow-Origin` response header (empty string when absent).
+async fn allow_origin_for(state: AppState, origin: &str) -> String {
+    let request = Request::builder()
+        .method("GET")
+        .uri("/api/v1/health")
+        .header(header::ORIGIN, origin)
+        .body(Body::empty())
+        .unwrap();
+    let response = build_router(state).oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    response
+        .headers()
+        .get(header::ACCESS_CONTROL_ALLOW_ORIGIN)
+        .map(|v| v.to_str().unwrap().to_string())
+        .unwrap_or_default()
+}
+
+/// A `"*"` entry anywhere in `CORS_ORIGINS` puts the layer in permissive mode.
+/// This is the documented development escape hatch, so it must keep working —
+/// and it must be reachable ONLY through that exact literal.
+#[tokio::test]
+async fn a_wildcard_entry_enables_permissive_cors() {
+    let state = state_with_origins("wildcard", &["*"]).await;
+    assert_eq!(allow_origin_for(state, OTHER).await, "*");
+
+    // The wildcard is honoured even when it is not the first entry.
+    let state = state_with_origins("wildcard-tail", &[ALLOWED, "*"]).await;
+    assert_eq!(allow_origin_for(state, OTHER).await, "*");
+}
+
+/// The other direction, and the security-relevant one: with an explicit
+/// allow-list, an origin that is NOT on it gets no
+/// `Access-Control-Allow-Origin` header at all, so a browser blocks the
+/// cross-origin read. A listed origin is reflected back.
+#[tokio::test]
+async fn an_explicit_allow_list_reflects_only_listed_origins() {
+    let state = state_with_origins("allowlist-hit", &[ALLOWED]).await;
+    assert_eq!(allow_origin_for(state, ALLOWED).await, ALLOWED);
+
+    let state = state_with_origins("allowlist-miss", &[ALLOWED]).await;
+    assert_eq!(
+        allow_origin_for(state, OTHER).await,
+        "",
+        "an unlisted origin must NOT be granted access"
+    );
+
+    // ...and must never be answered with a blanket wildcard.
+    let state = state_with_origins("allowlist-nowild", &[ALLOWED]).await;
+    assert_ne!(allow_origin_for(state, OTHER).await, "*");
+}
+
+/// A near-miss on the wildcard literal (`"**"`, `" * "`, an empty list) must
+/// fall into the allow-list branch, not the permissive one. This is what pins
+/// the `o == "*"` comparison itself rather than merely "some entry exists".
+#[tokio::test]
+async fn near_miss_wildcards_do_not_enable_permissive_cors() {
+    for spelling in ["**", "*.example.com", "all"] {
+        let state = state_with_origins("near-miss", &[spelling]).await;
+        let allow = allow_origin_for(state, OTHER).await;
+        assert_ne!(
+            allow, "*",
+            "{spelling:?} must not be treated as the permissive wildcard"
+        );
+    }
+    // An empty list allows nothing.
+    let state = state_with_origins("empty", &[]).await;
+    assert_eq!(allow_origin_for(state, OTHER).await, "");
+}
+
+/// The default `CORS_ORIGINS` (nothing configured) is a localhost allow-list,
+/// never permissive — a wildcard default would expose every self-hosted
+/// deployment that never sets the variable.
+#[tokio::test]
+async fn the_shipped_default_is_not_permissive() {
+    let defaults = Config::from_env().cors_origins;
+    let state = state_with_origins(
+        "defaults",
+        &defaults.iter().map(String::as_str).collect::<Vec<_>>(),
+    )
+    .await;
+    assert_ne!(
+        allow_origin_for(state, "https://attacker.example").await,
+        "*",
+        "the default CORS configuration must not be permissive: {defaults:?}"
+    );
+}

--- a/apps/server/src/error.rs
+++ b/apps/server/src/error.rs
@@ -131,3 +131,7 @@ impl From<crate::services::parquet_data_model::DataModelParquetError> for ApiErr
         ApiError::Parquet(err.to_string())
     }
 }
+
+#[cfg(test)]
+#[path = "error_tests.rs"]
+mod error_tests;

--- a/apps/server/src/error_tests.rs
+++ b/apps/server/src/error_tests.rs
@@ -1,0 +1,173 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Tests for the error → HTTP status/code mapping.
+//!
+//! `error.rs` had no tests. The whole `match` in `IntoResponse` was unpinned
+//! except for `Overloaded` (incidentally, via `parity_tests`): remapping
+//! `FileTooLarge` from `413` to `400` left the suite green, even though the
+//! streaming size guard exists specifically so a client sees a clean `413`
+//! rather than a generic multipart error.
+
+use super::*;
+use axum::body::to_bytes;
+
+/// `(status, code)` for one error, plus the JSON body it serialises to.
+async fn parts(err: ApiError) -> (StatusCode, String, serde_json::Value) {
+    let response = err.into_response();
+    let status = response.status();
+    let retry_after = response
+        .headers()
+        .get(axum::http::header::RETRY_AFTER)
+        .map(|v| v.to_str().unwrap().to_string())
+        .unwrap_or_default();
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body: serde_json::Value = serde_json::from_slice(&bytes).expect("JSON error body");
+    (status, retry_after, body)
+}
+
+/// The full mapping table, one row per variant. Each row is checked
+/// independently, so a mutation to any single arm fails on that arm rather
+/// than being masked by the rest of the loop.
+#[tokio::test]
+async fn every_variant_maps_to_its_documented_status_and_code() {
+    let cases: Vec<(ApiError, StatusCode, &str)> = vec![
+        (
+            ApiError::BadRequest("nope".into()),
+            StatusCode::BAD_REQUEST,
+            "BAD_REQUEST",
+        ),
+        (ApiError::MissingFile, StatusCode::BAD_REQUEST, "MISSING_FILE"),
+        (
+            ApiError::FileTooLarge { max_mb: 500 },
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "FILE_TOO_LARGE",
+        ),
+        (
+            ApiError::Processing("boom".into()),
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "PROCESSING_ERROR",
+        ),
+        (
+            ApiError::Cache("boom".into()),
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "CACHE_ERROR",
+        ),
+        (ApiError::NotFound("key".into()), StatusCode::NOT_FOUND, "NOT_FOUND"),
+        (
+            ApiError::Internal("boom".into()),
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "INTERNAL_ERROR",
+        ),
+        (
+            ApiError::Parquet("boom".into()),
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "PARQUET_ERROR",
+        ),
+        (
+            ApiError::Overloaded { retry_after_secs: 3 },
+            StatusCode::SERVICE_UNAVAILABLE,
+            "OVERLOADED",
+        ),
+    ];
+
+    for (err, expected_status, expected_code) in cases {
+        let label = err.to_string();
+        let (status, _, body) = parts(err).await;
+        assert_eq!(status, expected_status, "status for {label:?}");
+        assert_eq!(body["code"], expected_code, "code for {label:?}");
+        assert_eq!(
+            body["error"], label,
+            "the body message must be the Display text for {label:?}"
+        );
+    }
+}
+
+/// An oversized upload is a `413`, not a `400`. The distinction is what lets a
+/// client tell "your file is too big, split it" from "your request was
+/// malformed", and the message must carry the actual ceiling.
+#[tokio::test]
+async fn file_too_large_is_413_and_names_the_limit() {
+    let (status, _, body) = parts(ApiError::FileTooLarge { max_mb: 500 }).await;
+    assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE);
+    assert_ne!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(body["code"], "FILE_TOO_LARGE");
+    assert_eq!(body["error"], "File too large: maximum size is 500 MB");
+    // The limit is interpolated, not hard-coded.
+    let (_, _, body) = parts(ApiError::FileTooLarge { max_mb: 42 }).await;
+    assert_eq!(body["error"], "File too large: maximum size is 42 MB");
+}
+
+/// `Retry-After` is emitted for `Overloaded` and for NOTHING else — both
+/// directions of the header signal, and the value is the one carried in the
+/// variant rather than a constant.
+#[tokio::test]
+async fn retry_after_header_is_overloaded_only() {
+    let (status, retry_after, _) = parts(ApiError::Overloaded { retry_after_secs: 7 }).await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(retry_after, "7");
+
+    let (_, retry_after, _) = parts(ApiError::Overloaded { retry_after_secs: 12 }).await;
+    assert_eq!(retry_after, "12", "the header echoes the variant's value");
+
+    for other in [
+        ApiError::BadRequest("x".into()),
+        ApiError::MissingFile,
+        ApiError::FileTooLarge { max_mb: 1 },
+        ApiError::NotFound("x".into()),
+        ApiError::Internal("x".into()),
+    ] {
+        let label = other.to_string();
+        let (_, retry_after, _) = parts(other).await;
+        assert!(
+            retry_after.is_empty(),
+            "{label:?} must not advertise Retry-After, got {retry_after:?}"
+        );
+    }
+}
+
+/// Domain errors from the workspace crates become `PROCESSING_ERROR` (500) and
+/// carry the underlying message, so a malformed-IFC failure is diagnosable from
+/// the response alone.
+#[tokio::test]
+async fn core_and_geometry_errors_become_processing_errors() {
+    let core: ApiError = ifc_lite_core::Error::ParseError {
+        position: 42,
+        message: "bad STEP header".into(),
+    }
+    .into();
+    assert!(matches!(core, ApiError::Processing(_)));
+    let (status, _, body) = parts(core).await;
+    assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(body["code"], "PROCESSING_ERROR");
+    assert!(
+        body["error"].as_str().unwrap().contains("bad STEP header"),
+        "the underlying message must survive the conversion: {body}"
+    );
+}
+
+/// A JSON (de)serialisation failure is an INTERNAL error, not a client error:
+/// the client did not send the JSON that failed, the server produced it.
+#[tokio::test]
+async fn serde_json_errors_become_internal_errors() {
+    let err = serde_json::from_str::<serde_json::Value>("{not json").unwrap_err();
+    let api: ApiError = err.into();
+    assert!(matches!(api, ApiError::Internal(_)));
+    let (status, _, body) = parts(api).await;
+    assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(body["code"], "INTERNAL_ERROR");
+    assert!(body["error"].as_str().unwrap().starts_with("Internal server error: JSON error:"));
+}
+
+/// The body is always a two-field object; a client parses `code`
+/// programmatically and shows `error` to a human.
+#[tokio::test]
+async fn the_error_body_shape_is_stable() {
+    let (_, _, body) = parts(ApiError::NotFound("cache key abc".into())).await;
+    let obj = body.as_object().expect("object body");
+    assert_eq!(obj.len(), 2, "exactly `error` and `code`: {body}");
+    assert!(obj.contains_key("error"));
+    assert!(obj.contains_key("code"));
+    assert_eq!(body["error"], "Not found: cache key abc");
+}

--- a/apps/server/src/error_tests.rs
+++ b/apps/server/src/error_tests.rs
@@ -11,7 +11,63 @@
 //! rather than a generic multipart error.
 
 use super::*;
-use axum::body::to_bytes;
+use axum::body::{to_bytes, Body};
+use axum::extract::{multipart::MultipartError, FromRequest, Multipart};
+use axum::http::{header, Request};
+
+/// A real [`MultipartError`], since it has no public constructor: drive the
+/// extractor over a body whose content-type promises a `--X` boundary that the
+/// payload never contains.
+async fn a_multipart_error() -> MultipartError {
+    let request = Request::builder()
+        .method("POST")
+        .header(header::CONTENT_TYPE, "multipart/form-data; boundary=X")
+        .body(Body::from("this is not a multipart payload"))
+        .unwrap();
+    let mut multipart = Multipart::from_request(request, &())
+        .await
+        .expect("the content-type is well-formed, so extraction itself succeeds");
+    multipart
+        .next_field()
+        .await
+        .expect_err("the body is malformed, so the first field must fail")
+}
+
+/// A real [`tokio::task::JoinError`], likewise unconstructible by hand: let a
+/// spawned task panic and take the error off the handle. The panic is caught
+/// by the runtime, not by this test.
+async fn a_join_error() -> tokio::task::JoinError {
+    tokio::spawn(async { panic!("deliberate panic to produce a JoinError") })
+        .await
+        .expect_err("a panicking task must yield a JoinError")
+}
+
+/// Exhaustiveness by construction: this `match` has no wildcard arm, so adding
+/// a variant to [`ApiError`] is a COMPILE error here, which forces whoever
+/// adds it to also add its row to the table below. (The table itself cannot be
+/// generated from the type — each row needs a constructed value — so this
+/// guard is what keeps the "one row per variant" claim honest.)
+///
+/// `VARIANT_COUNT` must equal the number of arms below; the table test asserts
+/// it saw that many distinct variants, so a new arm added without a new row
+/// fails at runtime.
+const VARIANT_COUNT: usize = 11;
+
+fn variant_name(err: &ApiError) -> &'static str {
+    match err {
+        ApiError::BadRequest(_) => "BadRequest",
+        ApiError::MissingFile => "MissingFile",
+        ApiError::FileTooLarge { .. } => "FileTooLarge",
+        ApiError::Multipart(_) => "Multipart",
+        ApiError::Processing(_) => "Processing",
+        ApiError::Cache(_) => "Cache",
+        ApiError::NotFound(_) => "NotFound",
+        ApiError::Internal(_) => "Internal",
+        ApiError::Join(_) => "Join",
+        ApiError::Parquet(_) => "Parquet",
+        ApiError::Overloaded { .. } => "Overloaded",
+    }
+}
 
 /// `(status, code)` for one error, plus the JSON body it serialises to.
 async fn parts(err: ApiError) -> (StatusCode, String, serde_json::Value) {
@@ -27,7 +83,8 @@ async fn parts(err: ApiError) -> (StatusCode, String, serde_json::Value) {
     (status, retry_after, body)
 }
 
-/// The full mapping table, one row per variant. Each row is checked
+/// The full mapping table, one row per variant — all
+/// [`VARIANT_COUNT`] of them, asserted at the end. Each row is checked
 /// independently, so a mutation to any single arm fails on that arm rather
 /// than being masked by the rest of the loop.
 #[tokio::test]
@@ -70,10 +127,28 @@ async fn every_variant_maps_to_its_documented_status_and_code() {
             StatusCode::SERVICE_UNAVAILABLE,
             "OVERLOADED",
         ),
+        // Neither of these two has a public constructor, so both are produced
+        // by actually provoking the failure they represent.
+        (
+            ApiError::Multipart(a_multipart_error().await),
+            StatusCode::BAD_REQUEST,
+            "MULTIPART_ERROR",
+        ),
+        (
+            ApiError::Join(a_join_error().await),
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "TASK_ERROR",
+        ),
     ];
 
+    let mut covered = std::collections::BTreeSet::new();
     for (err, expected_status, expected_code) in cases {
         let label = err.to_string();
+        assert!(
+            covered.insert(variant_name(&err)),
+            "duplicate row for {:?} — every row must pin a different variant",
+            variant_name(&err)
+        );
         let (status, _, body) = parts(err).await;
         assert_eq!(status, expected_status, "status for {label:?}");
         assert_eq!(body["code"], expected_code, "code for {label:?}");
@@ -82,6 +157,11 @@ async fn every_variant_maps_to_its_documented_status_and_code() {
             "the body message must be the Display text for {label:?}"
         );
     }
+    assert_eq!(
+        covered.len(),
+        VARIANT_COUNT,
+        "the table must have one row per ApiError variant; covered: {covered:?}"
+    );
 }
 
 /// An oversized upload is a `413`, not a `400`. The distinction is what lets a

--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -64,6 +64,10 @@ const BODY_LIMIT_SLACK_MB: usize = 16;
 #[cfg(test)]
 mod parity_tests;
 
+#[cfg(test)]
+#[path = "cors_tests.rs"]
+mod cors_tests;
+
 use config::Config;
 use services::cache::DiskCache;
 

--- a/apps/server/src/middleware/auth.rs
+++ b/apps/server/src/middleware/auth.rs
@@ -68,3 +68,9 @@ fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
     }
     diff == 0
 }
+
+// Tests live in a sibling file so this module stays a production-sized unit;
+// as a child module they keep `use super::*` access to `constant_time_eq`.
+#[cfg(test)]
+#[path = "auth_tests.rs"]
+mod auth_tests;

--- a/apps/server/src/middleware/auth_tests.rs
+++ b/apps/server/src/middleware/auth_tests.rs
@@ -1,0 +1,167 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Tests for the optional bearer-token layer.
+//!
+//! Before these, `middleware/auth.rs` had NO tests at all: a mutation making
+//! `constant_time_eq` always return `true` — i.e. every request authenticated
+//! with ANY token, or none — left the whole 83-test suite green. The only
+//! direction the suite pinned was "no token configured ⇒ pass through", which
+//! the parity tests exercise incidentally. Everything below pins the OTHER
+//! direction, the one that actually protects the compute routes.
+
+use super::*;
+use axum::{body::Body, http::Request, routing::get, Router};
+use tower::ServiceExt;
+
+/// A `Config` with everything at a fixed, irrelevant value except the token —
+/// built as a literal (not `from_env`) so these tests never read, and never
+/// race on, the process environment.
+fn config_with_token(token: Option<&str>) -> Arc<Config> {
+    Arc::new(Config {
+        port: 8080,
+        cache_dir: String::from("/tmp/ifc-lite-auth-tests"),
+        max_file_size_mb: 500,
+        request_timeout_secs: 300,
+        worker_threads: 1,
+        initial_batch_size: 100,
+        max_batch_size: 1000,
+        cache_max_age_days: 7,
+        cors_origins: vec![],
+        max_concurrent_parses: 1,
+        mem_budget_mb: 0,
+        admission_queue_depth: 2,
+        admission_queue_timeout_secs: 5,
+        mem_shed_pct: 85,
+        metrics_enabled: false,
+        api_token: token.map(str::to_string),
+    })
+}
+
+/// One protected route behind the real middleware, driven in-process.
+fn app(token: Option<&str>) -> Router {
+    let config = config_with_token(token);
+    Router::new()
+        .route("/protected", get(|| async { "reached the handler" }))
+        .layer(axum::middleware::from_fn_with_state(
+            config,
+            require_bearer_token,
+        ))
+}
+
+/// Issue the request, returning the status.
+async fn status(token: Option<&str>, authorization: Option<&str>) -> StatusCode {
+    let mut builder = Request::builder().method("GET").uri("/protected");
+    if let Some(value) = authorization {
+        builder = builder.header(header::AUTHORIZATION, value);
+    }
+    app(token)
+        .oneshot(builder.body(Body::empty()).unwrap())
+        .await
+        .unwrap()
+        .status()
+}
+
+/// BOTH directions of the configured-token signal, at the same call site.
+/// The negative half is what a mutation to `constant_time_eq`'s return value
+/// (or to the match guard) breaks; without it an operator who sets
+/// `IFC_SERVER_API_TOKEN` gets an unprotected server that still logs
+/// "auth ENABLED" at startup.
+#[tokio::test]
+async fn configured_token_admits_the_match_and_rejects_everything_else() {
+    assert_eq!(
+        status(Some("s3cret"), Some("Bearer s3cret")).await,
+        StatusCode::OK,
+        "the exact token must be admitted"
+    );
+    assert_eq!(
+        status(Some("s3cret"), Some("Bearer wrong!")).await,
+        StatusCode::UNAUTHORIZED,
+        "a same-length non-matching token must be rejected"
+    );
+    assert_eq!(
+        status(Some("s3cret"), None).await,
+        StatusCode::UNAUTHORIZED,
+        "a missing Authorization header must be rejected"
+    );
+}
+
+/// `constant_time_eq` returns `false` on a length mismatch BEFORE folding
+/// bytes. Inverting that early return (`return true`) authenticates every
+/// token whose length differs from the secret — including the empty one —
+/// and left the suite green. Both a shorter and a longer presented token,
+/// plus a prefix of the real secret, pin it.
+#[tokio::test]
+async fn length_mismatch_is_rejected_not_short_circuited_to_success() {
+    for presented in ["", "s3cr", "s3cretx", "s3crets3cret"] {
+        assert_eq!(
+            status(Some("s3cret"), Some(&format!("Bearer {presented}"))).await,
+            StatusCode::UNAUTHORIZED,
+            "token {presented:?} differs in length from the secret and must be rejected"
+        );
+    }
+}
+
+/// The unit under the middleware, exercised directly so a length-mismatch
+/// regression is attributable to the comparator rather than to routing.
+#[test]
+fn constant_time_eq_pins_both_outcomes() {
+    assert!(constant_time_eq(b"abc", b"abc"));
+    assert!(constant_time_eq(b"", b""));
+    // Equal length, differing bytes — the folding path must still say no.
+    assert!(!constant_time_eq(b"abc", b"abd"));
+    assert!(!constant_time_eq(b"abc", b"cba"));
+    // Length mismatch — the early return must be `false`.
+    assert!(!constant_time_eq(b"abc", b"ab"));
+    assert!(!constant_time_eq(b"ab", b"abc"));
+    assert!(!constant_time_eq(b"abc", b""));
+}
+
+/// The scheme prefix is matched case-sensitively as `"Bearer "`. Mutating it
+/// to `"bearer "` (or dropping the strip entirely) survived the suite: the
+/// server would then reject every correctly-formed client while accepting a
+/// differently-cased one. Pin the accepted spelling and the rejected ones.
+#[tokio::test]
+async fn only_the_bearer_scheme_prefix_is_accepted() {
+    assert_eq!(
+        status(Some("s3cret"), Some("Bearer s3cret")).await,
+        StatusCode::OK
+    );
+    for bad in ["bearer s3cret", "BEARER s3cret", "Basic s3cret", "s3cret"] {
+        assert_eq!(
+            status(Some("s3cret"), Some(bad)).await,
+            StatusCode::UNAUTHORIZED,
+            "{bad:?} does not carry the `Bearer ` scheme and must be rejected"
+        );
+    }
+}
+
+/// Surrounding whitespace inside the credential is trimmed (`.map(str::trim)`),
+/// so a client that pads the value still authenticates.
+#[tokio::test]
+async fn credential_whitespace_is_trimmed() {
+    assert_eq!(
+        status(Some("s3cret"), Some("Bearer   s3cret  ")).await,
+        StatusCode::OK
+    );
+}
+
+/// The rejection status is specifically `401 Unauthorized`, not `403`: a
+/// client distinguishes "authenticate" from "you may never do this", and the
+/// mutation swapping them survived. Asserted against the concrete code, and
+/// against the pass-through case so both branches of the layer are pinned.
+#[tokio::test]
+async fn rejection_is_401_and_no_token_configured_passes_through() {
+    assert_eq!(
+        status(Some("s3cret"), Some("Bearer nope!!")).await,
+        StatusCode::UNAUTHORIZED
+    );
+    assert_ne!(
+        status(Some("s3cret"), Some("Bearer nope!!")).await,
+        StatusCode::FORBIDDEN
+    );
+    // Auth off (the default): the layer is transparent.
+    assert_eq!(status(None, None).await, StatusCode::OK);
+    assert_eq!(status(None, Some("Bearer anything")).await, StatusCode::OK);
+}

--- a/apps/server/src/routes/parse/cache_keys.rs
+++ b/apps/server/src/routes/parse/cache_keys.rs
@@ -224,6 +224,100 @@ mod tests {
         assert_eq!(key, "abc-default-symbolic-v1");
     }
 
+    /// `request_cache_key` is the seed for EVERY other key (parquet, parquet
+    /// metadata, JSON response, symbolic sidecar) and the identifier handed
+    /// back to the client. Nothing tested it: dropping the quality segment
+    /// from it left the suite green, even though that makes a
+    /// `?tessellation_quality=high` request read back the entry a previous
+    /// `medium` request wrote — the client silently gets a coarser mesh than
+    /// it asked for, and no cache bust ever fixes it.
+    #[test]
+    fn request_cache_key_separates_content_filter_and_quality() {
+        let data = b"ISO-10303-21;";
+        let hash = DiskCache::generate_key(data);
+        let default_query = ParseQuery::default();
+
+        // The default level keeps the LEGACY (unsuffixed) shape.
+        assert_eq!(
+            request_cache_key(data, &default_query, TessellationQuality::default()),
+            format!("{hash}-default")
+        );
+        // A non-default level gets its own distinct entry.
+        assert_eq!(
+            request_cache_key(data, &default_query, TessellationQuality::High),
+            format!("{hash}-default-qhigh")
+        );
+
+        // Every (filter, quality) pair is distinct from every other — measured
+        // pairwise, so this cannot pass on one discriminating case.
+        let mut seen = std::collections::HashSet::new();
+        for mode in [
+            OpeningFilterMode::Default,
+            OpeningFilterMode::IgnoreAll,
+            OpeningFilterMode::IgnoreOpaque,
+        ] {
+            for quality in [
+                TessellationQuality::Lowest,
+                TessellationQuality::Low,
+                TessellationQuality::Medium,
+                TessellationQuality::High,
+                TessellationQuality::Highest,
+            ] {
+                let query = ParseQuery { opening_filter: mode, tessellation_quality: None };
+                let key = request_cache_key(data, &query, quality);
+                assert!(key.starts_with(&hash), "the file hash must lead the key: {key}");
+                assert!(
+                    seen.insert(key.clone()),
+                    "collision: {mode:?}/{quality:?} reuses an existing key {key}"
+                );
+            }
+        }
+        assert_eq!(seen.len(), 15);
+
+        // Different CONTENT under identical options must never collide.
+        let other = request_cache_key(b"different bytes", &default_query, TessellationQuality::default());
+        assert_ne!(other, request_cache_key(data, &default_query, TessellationQuality::default()));
+    }
+
+    /// The derived keys are all distinct namespaces over the same seed, so a
+    /// parquet blob can never be served where symbolic JSON or a typed
+    /// `ParseResponse` is expected.
+    #[test]
+    fn derived_keys_never_collide_with_each_other() {
+        let seed = "0ab20f4e4014-default";
+        let derived = [
+            seed.to_string(),
+            json_response_cache_key(seed),
+            symbolic_cache_key(seed),
+            parquet_cache_key("0ab20f4e4014", OpeningFilterMode::Default, TessellationQuality::Medium),
+            parquet_metadata_cache_key("0ab20f4e4014", OpeningFilterMode::Default, TessellationQuality::Medium),
+        ];
+        let unique: std::collections::HashSet<&String> = derived.iter().collect();
+        assert_eq!(unique.len(), derived.len(), "derived keys collide: {derived:?}");
+    }
+
+    /// The quality suffix uses the level LABEL, so two adjacent levels can
+    /// never share an entry, and the default level alone stays unsuffixed.
+    #[test]
+    fn quality_suffix_is_empty_only_for_the_default_level() {
+        assert_eq!(quality_cache_suffix(TessellationQuality::default()), "");
+        let mut suffixes = std::collections::HashSet::new();
+        for quality in [
+            TessellationQuality::Lowest,
+            TessellationQuality::Low,
+            TessellationQuality::Medium,
+            TessellationQuality::High,
+            TessellationQuality::Highest,
+        ] {
+            let suffix = quality_cache_suffix(quality);
+            if quality != TessellationQuality::default() {
+                assert_eq!(suffix, format!("-q{}", quality.label()));
+                assert!(!suffix.is_empty(), "{quality:?} must not reuse the default entry");
+            }
+            assert!(suffixes.insert(suffix), "two levels share a cache suffix");
+        }
+    }
+
     #[test]
     fn schema_detection_uses_file_schema_declaration_only() {
         let content = b"ISO-10303-21;

--- a/apps/server/src/routes/parse/extract_file_tests.rs
+++ b/apps/server/src/routes/parse/extract_file_tests.rs
@@ -137,3 +137,107 @@ async fn accepts_a_file_within_the_ceiling() {
     let bytes = extract_file(&mut multipart, 1).await.unwrap();
     assert_eq!(bytes.len(), content.len());
 }
+
+/// The size guard is `>`, not `>=`: a file of EXACTLY `max_file_size_mb` must
+/// be accepted. The pre-existing tests sat 512 KB under a 1 MB ceiling and
+/// 512 KB over it, so tightening the comparison to `>=` — which rejects every
+/// upload landing exactly on the advertised limit with a `413` naming that very
+/// limit — left the whole suite green.
+#[tokio::test]
+async fn a_file_of_exactly_the_ceiling_is_accepted() {
+    const MAX_MB: usize = 1;
+    let exactly = vec![0u8; MAX_MB * 1024 * 1024];
+    let mut multipart = multipart_of(&exactly).await;
+    let bytes = extract_file(&mut multipart, MAX_MB)
+        .await
+        .expect("a file of exactly max_file_size_mb must be accepted");
+    assert_eq!(bytes.len(), exactly.len());
+
+    // ...and one byte over is rejected. Both sides of the boundary.
+    let one_over = vec![0u8; MAX_MB * 1024 * 1024 + 1];
+    let mut multipart = multipart_of(&one_over).await;
+    let err = extract_file(&mut multipart, MAX_MB).await.unwrap_err();
+    assert!(matches!(err, ApiError::FileTooLarge { max_mb: MAX_MB }));
+}
+
+/// A `max_file_size_mb` of 0 admits nothing but an empty body — the degenerate
+/// configuration must not wrap around into "unlimited".
+#[tokio::test]
+async fn a_zero_ceiling_rejects_any_payload() {
+    let mut multipart = multipart_of(b"x").await;
+    let err = extract_file(&mut multipart, 0).await.unwrap_err();
+    assert!(matches!(err, ApiError::FileTooLarge { max_mb: 0 }));
+}
+
+/// Build a gzip stream whose DECOMPRESSED size is `len` but whose compressed
+/// form is tiny — the classic decompression bomb.
+fn gzip_bomb(len: usize) -> Vec<u8> {
+    use flate2::write::GzEncoder;
+    use std::io::Write;
+    let mut encoder = GzEncoder::new(Vec::new(), flate2::Compression::best());
+    encoder.write_all(&vec![b'A'; len]).unwrap();
+    encoder.finish().unwrap()
+}
+
+/// The gzip path must bound the DECOMPRESSED size, not just the uploaded
+/// bytes. Disabling that check survived the suite: a ~2 KB upload expanding to
+/// hundreds of megabytes would be buffered in full, which is exactly the
+/// single-request OOM the admission byte budget exists to prevent — and the
+/// budget reserves against the COMPRESSED size, so it cannot catch this.
+#[tokio::test]
+async fn a_gzip_bomb_is_rejected_on_its_decompressed_size() {
+    const MAX_MB: usize = 1;
+    let bomb = gzip_bomb(4 * 1024 * 1024); // 4 MB out of a 1 MB ceiling
+    assert!(
+        bomb.len() < MAX_MB * 1024 * 1024,
+        "the compressed payload must itself be within the ceiling ({} bytes), \
+         otherwise the raw read guard would catch it and this proves nothing",
+        bomb.len()
+    );
+    assert_eq!(&bomb[..2], &[0x1f, 0x8b], "gzip magic, so the gzip branch runs");
+
+    let mut multipart = multipart_of(&bomb).await;
+    let err = extract_file(&mut multipart, MAX_MB).await.unwrap_err();
+    assert!(
+        matches!(err, ApiError::FileTooLarge { max_mb: MAX_MB }),
+        "expected FileTooLarge on the decompressed size, got {err:?}"
+    );
+}
+
+/// The other direction: a gzip payload that decompresses to within the ceiling
+/// is accepted and yields the ORIGINAL bytes, so the bomb guard above is not
+/// simply rejecting everything gzipped.
+#[tokio::test]
+async fn a_gzip_payload_within_the_ceiling_round_trips() {
+    const MAX_MB: usize = 1;
+    let plain = vec![b'A'; 256 * 1024];
+    let mut multipart = multipart_of(&gzip_bomb(plain.len())).await;
+    let bytes = extract_file(&mut multipart, MAX_MB)
+        .await
+        .expect("a small gzip payload must decompress and be accepted");
+    assert_eq!(bytes.len(), plain.len());
+    assert_eq!(bytes.as_ref(), plain.as_slice());
+}
+
+/// A multipart body with no `file` field is a `MissingFile` (400), not a
+/// silently-empty parse.
+#[tokio::test]
+async fn a_body_without_a_file_field_is_missing_file() {
+    let mut body = Vec::new();
+    body.extend_from_slice(
+        format!("--{BOUNDARY}\r\nContent-Disposition: form-data; name=\"notfile\"\r\n\r\nx\r\n--{BOUNDARY}--\r\n")
+            .as_bytes(),
+    );
+    let request = Request::builder()
+        .method("POST")
+        .uri("/")
+        .header(
+            header::CONTENT_TYPE,
+            format!("multipart/form-data; boundary={BOUNDARY}"),
+        )
+        .body(Body::from(body))
+        .unwrap();
+    let mut multipart = Multipart::from_request(request, &()).await.unwrap();
+    let err = extract_file(&mut multipart, 1).await.unwrap_err();
+    assert!(matches!(err, ApiError::MissingFile), "got {err:?}");
+}


### PR DESCRIPTION
## Why

`apps/server` is the binary `packages/server-bin` downloads, verifies and executes — the actual server users run — and it had never been mutation-swept, unlike the TypeScript packages and the `rust/core`, `rust/wasm-bindings`, `rust/processing` and `rust/geometry` crates.

## Method

Toolchain: the root pin, `nightly-2025-11-15` (rustc 1.93.0-nightly). Baseline `cargo test -p ifc-lite-server`: **83 passed, 0 failed, 0 ignored**.

20 mutations, each applied by exact-substring replacement with an asserted replacement count of 1 and the mutated region re-read before any result was believed, then restored from a saved backup copy (never `git checkout --`). **Two deliberate controls, run first, both KILLED** — so the suite was known to be live before any survivor was trusted.

**Kill ratio: 5/20 (25%). TARGETED** — mutations were aimed at the weakest-looking areas (auth, config, threshold boundaries, error mapping), not sampled uniformly, so this ratio is not an estimate of crate-wide coverage.

| # | File | Mutation | Result |
|---|---|---|---|
| C1 | `mem_policy.rs` | `BUDGET_PCT_OF_CEILING` 70 → 80 | **KILLED** (control) — `uses_tightest_readable_ceiling`, `physical_ram_bounds_a_bare_vm_with_no_cgroup` |
| C2 | `admission.rs` | CPU semaphore permits `+ 1` | **KILLED** (control) — `rejects_with_overloaded_when_cpu_saturated` + 2 |
| M1 | `middleware/auth.rs` | match guard `\|\| true` (any token authenticates) | SURVIVED |
| M2 | `middleware/auth.rs` | `constant_time_eq` length mismatch `return true` | SURVIVED |
| M3 | `middleware/auth.rs` | `strip_prefix("Bearer ")` → `"bearer "` | SURVIVED |
| M4 | `middleware/auth.rs` | `UNAUTHORIZED` → `FORBIDDEN` | SURVIVED |
| M5 | `middleware/auth.rs` | auth-disabled pass-through → 401 | KILLED — 8 `parity_tests` |
| M6 | `config.rs` | port default 8080 → 9090 | SURVIVED |
| M7 | `config.rs` | drop `filter(\|s\| !s.is_empty())` on `api_token` | SURVIVED |
| M8 | `config.rs` | drop the `IFC_METRICS_ENABLED=1` spelling | SURVIVED |
| M9 | `config.rs` | drop `.min(100)` on `IFC_MEM_SHED_PCT` | SURVIVED |
| M10 | `admission.rs` | shed `Retry-After` `* 2` → `* 1` | SURVIVED |
| M11 | `admission.rs` | `acquire`: `rss >= watermark` → `>` | SURVIVED |
| M12 | `admission.rs` | `rejected_shed` → `rejected_overload` | SURVIVED |
| M13 | `admission.rs` | `is_shedding`: `>=` → `>` | SURVIVED |
| M14 | `error.rs` | `FileTooLarge` 413 → 400 | SURVIVED |
| M15 | `routes/parse/mod.rs` | upload guard `>` → `>=` | SURVIVED |
| M16 | `routes/parse/mod.rs` | disable the gzip decompressed-size guard | SURVIVED |
| M17 | `main.rs` | `memory_admission_log_level` `Some(0)` Info → Warn | KILLED — `explicit_zero_is_opt_out_info` |
| M18 | `main.rs` | CORS `o == "*"` → `o == "**"` | SURVIVED |
| M19 | `routes/parse/cache_keys.rs` | `request_cache_key` drops the quality segment | SURVIVED |
| M20 | `error.rs` | `Overloaded` 503 → 500 | KILLED — `saturated_admission_returns_503_with_retry_after` |

Every one of the 15 survivors was **replayed against the new suite and confirmed KILLED** (killing tests listed below).

## Gaps closed

### `middleware/auth.rs` — no tests at all (M1–M4)

The optional bearer-token layer that protects every compute/parse/cache route had zero coverage. Making `constant_time_eq` unconditionally true left all 83 tests green: an operator who sets `IFC_SERVER_API_TOKEN`, sees the startup log say auth is ENABLED, and believes the compute routes are protected would in fact be serving them to anyone. The only direction the suite pinned was "no token configured ⇒ pass through" (M5, killed incidentally by `parity_tests`) — precisely the direction that protects nothing.

New `middleware/auth_tests.rs` drives the real middleware in-process and pins both directions of the configured-token signal, the length-mismatch early return (M2 — inverting it authenticates every token of a *different* length, including the empty one), the case-sensitive scheme prefix (M3), credential trimming, and 401-not-403 (M4).

Killed by: `configured_token_admits_the_match_and_rejects_everything_else`, `length_mismatch_is_rejected_not_short_circuited_to_success`, `constant_time_eq_pins_both_outcomes`, `only_the_bearer_scheme_prefix_is_accepted`, `rejection_is_401_and_no_token_configured_passes_through`.

### `config.rs` — no tests at all (M6–M9)

Notably **M7**: without the `!is_empty()` filter, `IFC_SERVER_API_TOKEN=""` — a common way to "unset" a variable in a compose file or a CI secret — flips `api_token` to `Some("")`, so the server starts *requiring* an `Authorization: Bearer ` header whose secret is the empty string. Every real client 401s; anyone sending the empty credential is admitted. And **M9**: an unclamped `IFC_MEM_SHED_PCT=200` puts the RSS watermark at twice the budget, so the circuit breaker never fires and the container is OOM-killed instead of shedding.

New `config_tests.rs` covers the shipped defaults, every scalar override plus its garbage-fallback, the concurrency `max(1)` clamp, the shed-pct clamp at the 100 boundary in both directions, the metrics flag's accepted *and* rejected spellings, token precedence/trimming/blank handling, CORS splitting, `Debug` redaction of the token, and the mem-budget passthrough.

Killed by: `defaults_apply_when_nothing_is_set`, `scalar_overrides_are_honoured_and_garbage_falls_back`, `api_token_precedence_trimming_and_blank_handling`, `blank_primary_token_shadows_the_fallback_and_leaves_auth_off`, `metrics_flag_accepts_one_and_true_only`, `shed_pct_is_clamped_to_100`.

### `admission.rs` — thresholds and observability (M10–M13)

The existing tests assert only `matches!(err, ApiError::Overloaded { .. })`, so the `Retry-After` each path advertises was unpinned, and they sit 5 MB clear of the RSS watermark, so `>=` could be relaxed to `>` with the suite green. No test read a rejection counter, so all three reasons could be attributed to one bucket — and those counters are exactly what an operator reads to tell a memory 503 from a CPU one from a queue one, three different remediations.

New `admission_tests.rs` pins per-reason counter attribution, the doubled shed `Retry-After` against the single-length one (and that it tracks the configured timeout and is never 0), and the watermark at `watermark - 1` / `watermark` / `watermark + 1` — 89 128 960 bytes exactly, so the boundary is not a rounding artifact. Also the inert-breaker cases (unsampled RSS, no budget, `shed_pct = 0`), gauge round-tripping, and that a queued-then-rejected waiter does not leak its queue slot.

Killed by: `each_rejection_reason_increments_its_own_counter`, `shed_advertises_double_the_retry_after_of_the_other_paths`, `rss_breaker_fires_exactly_at_the_watermark`.

### `error.rs` — the status mapping (M14)

Only `Overloaded` was pinned, incidentally. Remapping an oversized upload from `413` to `400` was invisible — even though the streaming size guard exists specifically so a client sees a clean `413` rather than a generic multipart `400`. New `error_tests.rs` walks the whole variant table (status, code and body message per row), pins `Retry-After` as `Overloaded`-only in both directions, and covers the `From` conversions.

Killed by: `every_variant_maps_to_its_documented_status_and_code`, `file_too_large_is_413_and_names_the_limit`.

### `extract_file` — boundary and gzip bomb (M15, M16)

The existing tests sat 512 KB under a 1 MB ceiling and 512 KB over it, so tightening `>` to `>=` — which rejects every upload landing exactly on the advertised limit, with a 413 naming that very limit — survived. And nothing exercised the gzip branch at all: disabling the decompressed-size bound lets a ~4 KB upload expand to hundreds of MB, which the admission byte budget cannot catch because it reserves against the *compressed* size.

Killed by: `a_file_of_exactly_the_ceiling_is_accepted`, `a_gzip_bomb_is_rejected_on_its_decompressed_size`. Also added: the within-ceiling gzip round-trip (so the bomb guard is not just rejecting everything gzipped), a zero ceiling, and the missing-`file`-field case.

### CORS (M18)

`build_cors_layer` had no tests. The mutation broke the wildcard in its least dangerous direction, but the same blind spot covers the dangerous one: if the allow-list branch ever degraded into a permissive one, every deployment with an explicit `CORS_ORIGINS` would start serving any origin, unnoticed. New `cors_tests.rs` drives the real router and asserts an unlisted origin gets *no* `Access-Control-Allow-Origin` header, near-miss spellings (`**`, `*.example.com`) are not treated as the wildcard, and the shipped default is not permissive.

Killed by: `a_wildcard_entry_enables_permissive_cors`, `near_miss_wildcards_do_not_enable_permissive_cors`.

### `request_cache_key` (M19)

The seed for every other key (parquet, parquet metadata, JSON response, symbolic sidecar) and the identifier handed to the client — and it had no test. Dropping its quality segment left the suite green, which would make a `?tessellation_quality=high` request read back the entry a previous `medium` request wrote: the client silently gets a coarser mesh than it asked for, and no cache bust ever fixes it. The new test checks all 15 (filter × quality) pairs for **pairwise** distinctness rather than inferring discrimination from a loop.

Killed by: `request_cache_key_separates_content_filter_and_quality`.

## Production change

One, behaviour-preserving: `Config::from_env` now delegates to a private `from_lookup(get: impl Fn(&str) -> Option<String>)`, and `from_env` passes the real `std::env::var`. This is required because `parity_tests::test_state` calls `from_env()` concurrently in the same test binary — a config test that set `IFC_SERVER_API_TOKEN` via `set_var` would silently switch those tests to an authenticated server. No default, clamp or precedence rule changed.

## Notes

- New tests live in sibling `*_tests.rs` files (the established `#[path]` pattern, as in `services/parquet.rs`) so no production module crosses the 400-line ratchet. `cargo test -p ifc-lite-processing --test module_size_ratchet` is green.
- `mem_policy::physical_memory_is_readable_on_linux` is `#[cfg(target_os = "linux")]`, so it silently does not exist on a macOS dev box. Not a failure — it does run in CI — but worth knowing that a local green is 1 test lighter than CI's.
- `cargo fmt --check` reports diffs across ~22 files in this crate at baseline, including files this PR does not touch, so the crate is not rustfmt-clean upstream and nothing here was reformatted.

## Verification

- Baseline: `cargo test -p ifc-lite-server` → 83 passed, 0 failed, 0 ignored.
- Final: **126 passed, 0 failed, 0 ignored**.
- `cargo clippy -p ifc-lite-server --all-targets`: clean on the pinned toolchain.
- All 15 survivors replayed post-fix: each fails, with the named test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for admission control, configuration parsing, CORS behavior, authentication, API errors, cache-key isolation, and file-upload limits.
  * Verified boundary conditions including memory budgets, retry timing, authorization failures, decompression limits, missing files, and safe CORS defaults.
  * Confirmed stable error responses, metrics behavior, queue cleanup, and backward-compatible cache keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->