### PR TITLE
fix(sources): close the icon-URL bypass, render real preference controls, test syncSourceModel

### DIFF
--- a/apps/viewer/src/components/sources/SourceProviderRow.test.tsx
+++ b/apps/viewer/src/components/sources/SourceProviderRow.test.tsx
@@ -1,0 +1,144 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `safeIconUrl` — the provider-manifest icon is third-party data landing in an
+ * `img src`, so the host decides what it is allowed to point at.
+ *
+ * Two properties are pinned here, both of which the pre-fix string-prefix
+ * implementation got wrong:
+ *
+ * 1. **The `/\` bypass.** `/\evil.example/beacon.gif` passes a
+ *    `raw.startsWith('/')` "same-origin relative" check, but the WHATWG URL
+ *    parser (and therefore every browser) treats `\` as `/` for special
+ *    schemes, so the byte stream the browser actually requests is
+ *    `//evil.example/beacon.gif` — a cross-origin beacon. Resolution has to go
+ *    through `new URL()` and the check has to be on the RESOLVED origin.
+ *
+ * 2. **The allowlist gate.** An absolute icon URL is allowed only when its host
+ *    is in `permissions.network` — the same allowlist the host's fetch wrapper
+ *    already enforces, so a plugin can point its icon exactly where it has
+ *    already declared it talks. A same-origin relative icon (`/icons/acme.svg`)
+ *    stays allowed independently of that list, so a provider with no network
+ *    permissions at all can still ship an icon.
+ *
+ * The empty-allowlist case is tested in BOTH directions on purpose: "empty"
+ * reads as "allow nothing" or "allow everything" depending on how the check is
+ * written, and only asserting one side leaves the other free.
+ */
+
+import '@/test/setup-dom.js';
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { safeIconUrl } from './SourceProviderRow.js';
+
+/** The origin `setup-dom` registers happy-dom with. */
+const ORIGIN = 'http://localhost';
+
+describe('safeIconUrl — same-origin relative icons', () => {
+  it('allows a same-origin absolute path even when permissions.network is empty', () => {
+    assert.equal(safeIconUrl('/icons/acme.svg', []), `${ORIGIN}/icons/acme.svg`);
+  });
+
+  it('allows a same-origin ./ relative icon when permissions.network is empty', () => {
+    assert.equal(safeIconUrl('./icons/acme.svg', []), `${ORIGIN}/icons/acme.svg`);
+  });
+
+  it('allows a same-origin absolute URL spelled out in full', () => {
+    assert.equal(
+      safeIconUrl(`${ORIGIN}/icons/acme.svg`, []),
+      `${ORIGIN}/icons/acme.svg`,
+    );
+  });
+});
+
+describe('safeIconUrl — the backslash bypass', () => {
+  // Every one of these starts with `/`, so a `raw.startsWith('/')` check reads
+  // them as same-origin. The URL parser resolves each to `//evil.example`.
+  for (const raw of [
+    '/\\evil.example/beacon.gif',
+    '/\\/evil.example',
+    '/\\\\evil.example/beacon.gif',
+    '\\\\evil.example/beacon.gif',
+  ]) {
+    it(`rejects ${JSON.stringify(raw)}`, () => {
+      // Guard the premise: if the parser ever stopped folding `\` into `/`,
+      // these inputs would be harmless and the test would be vacuous.
+      const resolvedOrigin = new URL(raw, `${ORIGIN}/`).origin;
+      assert.equal(
+        resolvedOrigin,
+        'http://evil.example',
+        'premise: the URL parser must resolve this off-origin',
+      );
+      assert.equal(safeIconUrl(raw, []), undefined);
+      assert.equal(
+        safeIconUrl(raw, ['evil.example']),
+        undefined,
+        'plain http stays rejected even for an allowlisted host',
+      );
+    });
+  }
+});
+
+describe('safeIconUrl — schemes that are never icons', () => {
+  it('rejects a protocol-relative URL', () => {
+    assert.equal(safeIconUrl('//evil.example/x.png', []), undefined);
+  });
+
+  it('rejects data:', () => {
+    assert.equal(safeIconUrl('data:image/svg+xml,<svg/>', []), undefined);
+  });
+
+  it('rejects javascript:', () => {
+    assert.equal(safeIconUrl('javascript:alert(1)', []), undefined);
+  });
+
+  it('rejects plain http even for an allowlisted host', () => {
+    assert.equal(safeIconUrl('http://icons.example/i.png', ['icons.example']), undefined);
+  });
+
+  it('rejects an unparseable value', () => {
+    assert.equal(safeIconUrl('https://', []), undefined);
+  });
+
+  it('passes an absent iconUrl through', () => {
+    assert.equal(safeIconUrl(undefined, ['icons.example']), undefined);
+    assert.equal(safeIconUrl('', ['icons.example']), undefined);
+  });
+});
+
+describe('safeIconUrl — the permissions.network gate', () => {
+  it('allows an https icon on an allowlisted host', () => {
+    assert.equal(
+      safeIconUrl('https://icons.example/i.png', ['icons.example']),
+      'https://icons.example/i.png',
+    );
+  });
+
+  it('rejects an https icon on a host that is NOT allowlisted', () => {
+    assert.equal(safeIconUrl('https://other.example/i.png', ['icons.example']), undefined);
+  });
+
+  // Both directions of the empty-allowlist case. "Empty" must mean "no
+  // cross-origin icon", not "every cross-origin icon".
+  it('rejects EVERY cross-origin https icon when permissions.network is empty', () => {
+    assert.equal(safeIconUrl('https://icons.example/i.png', []), undefined);
+    assert.equal(safeIconUrl('https://cdn.example/i.png', []), undefined);
+  });
+
+  it('still allows a same-origin relative icon when permissions.network is empty', () => {
+    assert.notEqual(safeIconUrl('/icons/acme.svg', []), undefined);
+  });
+
+  it('honours the wildcard form the host fetch wrapper uses', () => {
+    assert.equal(
+      safeIconUrl('https://cdn.icons.example/i.png', ['*.icons.example']),
+      'https://cdn.icons.example/i.png',
+    );
+    assert.equal(
+      safeIconUrl('https://cdn.icons.example.evil/i.png', ['*.icons.example']),
+      undefined,
+    );
+  });
+});

--- a/apps/viewer/src/components/sources/SourceProviderRow.tsx
+++ b/apps/viewer/src/components/sources/SourceProviderRow.tsx
@@ -5,6 +5,7 @@
 import type { FileSourceProvider } from '@ifc-lite/plugin-api';
 import type { SourceHost } from '@/services/sources/source-host';
 import { loadResolvedSourcePrefs } from '@/lib/sources/preferences';
+import { isAllowedHost, isHttpsUrl } from '@/services/sources/host-fetch';
 import { useSourceAuth } from './useSourceAuth';
 import { Button } from '@/components/ui/button';
 import { Cloud, Loader2, LogIn, LogOut, Settings } from 'lucide-react';
@@ -19,21 +20,48 @@ interface SourceProviderRowProps {
 }
 
 /**
- * A provider manifest is third-party data, and `iconUrl` lands in an `img src`.
- * Allow only https: and same-origin relative paths — `javascript:` is inert in
- * `src` but `data:`/protocol-relative URLs are a real exfiltration and
- * mixed-content surface, and a plugin has no business pointing the tag anywhere
- * else. Anything unparseable or off-scheme falls back to the generic icon.
+ * A provider manifest is third-party data, and `iconUrl` lands in an `img src`,
+ * which fires an uncredentialed cross-origin GET the moment it renders — a
+ * beacon. So the host, not the plugin, decides where that tag may point.
+ *
+ * Two rules, both checked on the RESOLVED URL rather than on the raw string:
+ *
+ * - **Same-origin is always allowed**, whatever `permissions.network` says. A
+ *   provider that talks to nothing still gets to ship `/icons/acme.svg`; an
+ *   empty allowlist means "no cross-origin icon", never "no icon at all".
+ * - **Cross-origin must be https AND in `permissions.network`** — the same
+ *   allowlist (wildcards included) the host's fetch wrapper already enforces,
+ *   so a plugin can point its icon exactly where it has already declared it
+ *   talks, and nowhere else. That rejects `data:`, `javascript:`, plaintext
+ *   `http:`, and protocol-relative URLs as a side effect of the same check.
+ *
+ * String-prefixing the raw value is NOT good enough, which is why this resolves
+ * through `new URL()` first: `/\evil.example/beacon.gif` passes a leading-slash
+ * "same-origin" test, but the URL parser folds `\` into `/` for special
+ * schemes, so the browser requests `//evil.example/beacon.gif`. Anything
+ * unparseable or disallowed falls back to the generic icon.
  */
-function safeIconUrl(raw: string | undefined): string | undefined {
+export function safeIconUrl(
+  raw: string | undefined,
+  allowedHosts: readonly string[],
+): string | undefined {
   if (!raw) return undefined;
-  if (raw.startsWith('//')) return undefined; // protocol-relative
-  if (raw.startsWith('/') || raw.startsWith('./')) return raw; // same-origin
+
+  let resolved: URL;
   try {
-    return new URL(raw).protocol === 'https:' ? raw : undefined;
+    // Resolving against the document base is what the browser would do with
+    // this string anyway; doing it here means the origin we check is the
+    // origin that will actually be requested.
+    resolved = new URL(raw, window.location.href);
   } catch {
     return undefined;
   }
+
+  // Normalized, so whatever escaping trick produced the string is gone by the
+  // time it reaches the tag.
+  if (resolved.origin === window.location.origin) return resolved.href;
+  if (!isHttpsUrl(resolved)) return undefined;
+  return isAllowedHost(allowedHosts, resolved.hostname) ? resolved.href : undefined;
 }
 
 export function SourceProviderRow({
@@ -44,6 +72,7 @@ export function SourceProviderRow({
   onBrowse,
 }: SourceProviderRowProps) {
   const { manifest } = provider;
+  const iconUrl = safeIconUrl(manifest.iconUrl, manifest.permissions.network);
   const auth = useSourceAuth(provider, sourceHost);
   const interactive = auth.status !== 'not-interactive';
 
@@ -79,9 +108,9 @@ export function SourceProviderRow({
           truncated real provider titles ("SharePoint / OneDrive" became
           "SharePo…") at the panel's default docked width. */}
       <div className="flex items-center gap-2">
-        {safeIconUrl(manifest.iconUrl) ? (
+        {iconUrl ? (
           <img
-            src={safeIconUrl(manifest.iconUrl)}
+            src={iconUrl}
             alt=""
             className="h-4 w-4 shrink-0 rounded-sm object-contain"
           />

--- a/apps/viewer/src/components/sources/SourceSettingsDialog.test.tsx
+++ b/apps/viewer/src/components/sources/SourceSettingsDialog.test.tsx
@@ -1,0 +1,233 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `PluginPreferenceType` declares four kinds — `textfield`, `password`,
+ * `checkbox`, `dropdown` — and the host renders the settings form from the
+ * manifest, so a provider has no other way to get a control on screen.
+ * `PreferenceField` used to render `<Input type={password ? 'password' :
+ * 'text'}>` for all four, which means a declared `dropdown` came out as a
+ * free-text box: no option list shown, and any string at all typeable into a
+ * field whose whole point is that only the declared values are legal. A
+ * `checkbox` came out the same way, with the user expected to type the word
+ * "true".
+ *
+ * These tests pin the rendered control per declared type, in both directions
+ * where the type is a binary (a checkbox reads AND writes `"true"`/`"false"`;
+ * a dropdown offers exactly the declared options and reports the option's
+ * VALUE, not its label).
+ */
+
+import '@/test/setup-dom.js';
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import type { PluginManifest, PluginPreference } from '@ifc-lite/plugin-api';
+import { SourceSettingsDialog } from './SourceSettingsDialog.js';
+
+function makeManifest(preferences: readonly PluginPreference[]): PluginManifest {
+  return {
+    name: 'test-provider',
+    title: 'Test Provider',
+    api: '^2.0.0',
+    permissions: { network: [] },
+    auth: 'preferences',
+    preferences,
+    capabilities: {
+      containerListing: 'direct-children',
+      listFilesIsRecursive: false,
+      revisionHistory: false,
+      downloadHistoricalRevisions: false,
+      changeDetection: false,
+      search: false,
+    },
+    contributes: { fileSources: [] },
+  };
+}
+
+const mounted: Array<{ root: Root; container: HTMLElement }> = [];
+
+function renderDialog(
+  preferences: readonly PluginPreference[],
+  initialValues: Record<string, string> = {},
+): { saved: Array<Record<string, string>> } {
+  const saved: Array<Record<string, string>> = [];
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(
+      <SourceSettingsDialog
+        manifest={makeManifest(preferences)}
+        open
+        onOpenChange={() => {}}
+        onSave={(values) => saved.push(values)}
+        initialValues={initialValues}
+      />,
+    );
+  });
+  mounted.push({ root, container });
+  return { saved };
+}
+
+/** The dialog content is portaled, so everything is looked up from `body`. */
+function field(name: string): HTMLElement {
+  const el = document.body.querySelector(`#pref-${name}`);
+  assert.ok(el, `a control for preference "${name}" must render`);
+  return el as HTMLElement;
+}
+
+function clickSave(): void {
+  const save = [...document.body.querySelectorAll('button')].find(
+    (b) => b.textContent?.trim() === 'Save',
+  );
+  assert.ok(save, 'the Save button must render');
+  act(() => {
+    save.click();
+  });
+}
+
+beforeEach(() => {
+  for (const { root, container } of mounted.splice(0)) {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  }
+  document.body.innerHTML = '';
+});
+
+describe('SourceSettingsDialog — text and password preferences keep their control', () => {
+  it('renders a text input for textfield', () => {
+    renderDialog([
+      { name: 'region', title: 'Region', type: 'textfield', required: false },
+    ]);
+    const el = field('region');
+    assert.equal(el.tagName, 'INPUT');
+    assert.equal(el.getAttribute('type'), 'text');
+  });
+
+  it('renders a masked input for password', () => {
+    renderDialog([
+      { name: 'apiKey', title: 'API key', type: 'password', required: false },
+    ]);
+    const el = field('apiKey');
+    assert.equal(el.tagName, 'INPUT');
+    assert.equal(el.getAttribute('type'), 'password');
+  });
+});
+
+describe('SourceSettingsDialog — checkbox preferences', () => {
+  const pref: PluginPreference = {
+    name: 'useProxy',
+    title: 'Route through the proxy',
+    type: 'checkbox',
+    required: false,
+    default: 'false',
+  };
+
+  it('does NOT render a free-text box for a checkbox', () => {
+    renderDialog([pref]);
+    const el = field('useProxy');
+    assert.notEqual(
+      el.tagName,
+      'INPUT',
+      'a checkbox preference must not be a typed-in text field',
+    );
+  });
+
+  it('renders unchecked for the stored value "false"', () => {
+    renderDialog([pref], { useProxy: 'false' });
+    assert.equal(field('useProxy').getAttribute('aria-checked'), 'false');
+  });
+
+  it('renders checked for the stored value "true"', () => {
+    renderDialog([pref], { useProxy: 'true' });
+    assert.equal(field('useProxy').getAttribute('aria-checked'), 'true');
+  });
+
+  it('saves "true" after the user turns it on', () => {
+    const { saved } = renderDialog([pref], { useProxy: 'false' });
+    act(() => {
+      field('useProxy').click();
+    });
+    clickSave();
+    assert.deepEqual(saved, [{ useProxy: 'true' }]);
+  });
+
+  it('saves "false" after the user turns it off', () => {
+    const { saved } = renderDialog([pref], { useProxy: 'true' });
+    act(() => {
+      field('useProxy').click();
+    });
+    clickSave();
+    assert.deepEqual(saved, [{ useProxy: 'false' }]);
+  });
+});
+
+describe('SourceSettingsDialog — dropdown preferences', () => {
+  const pref: PluginPreference = {
+    name: 'environment',
+    title: 'Environment',
+    type: 'dropdown',
+    required: false,
+    default: 'prod',
+    options: [
+      { label: 'Production', value: 'prod' },
+      { label: 'Staging', value: 'stage' },
+    ],
+  };
+
+  /** Radix's Select opens on ArrowDown; the listbox is portaled to `body`. */
+  function openDropdown(): HTMLElement[] {
+    act(() => {
+      field('environment').dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, cancelable: true }),
+      );
+    });
+    return [...document.body.querySelectorAll('[role="option"]')] as HTMLElement[];
+  }
+
+  it('does NOT render a free-text box for a dropdown', () => {
+    renderDialog([pref]);
+    const el = field('environment');
+    assert.notEqual(
+      el.tagName,
+      'INPUT',
+      'a dropdown preference must not accept arbitrary typed values',
+    );
+  });
+
+  it('shows the label of the currently stored value', () => {
+    renderDialog([pref], { environment: 'stage' });
+    assert.match(field('environment').textContent ?? '', /Staging/);
+  });
+
+  it('offers exactly the declared options, by label', () => {
+    renderDialog([pref]);
+    assert.deepEqual(
+      openDropdown().map((o) => o.textContent),
+      ['Production', 'Staging'],
+    );
+  });
+
+  it('saves the option VALUE, not its label, when one is chosen', () => {
+    const { saved } = renderDialog([pref], { environment: 'prod' });
+    const staging = openDropdown().find((o) => o.textContent === 'Staging');
+    assert.ok(staging, 'the Staging option must be offered');
+    act(() => {
+      staging.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }),
+      );
+    });
+    clickSave();
+    assert.deepEqual(saved, [{ environment: 'stage' }]);
+  });
+
+  it('renders no options for a dropdown that declares none, rather than crashing', () => {
+    renderDialog([{ ...pref, options: undefined, default: undefined }], {});
+    assert.deepEqual(openDropdown(), []);
+  });
+});

--- a/apps/viewer/src/components/sources/SourceSettingsDialog.tsx
+++ b/apps/viewer/src/components/sources/SourceSettingsDialog.tsx
@@ -14,6 +14,14 @@ import {
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { CheckCircle2, XCircle, Loader2, Trash2 } from 'lucide-react';
 
 interface SourceSettingsDialogProps {
@@ -164,6 +172,18 @@ export function SourceSettingsDialog({
   );
 }
 
+/**
+ * Renders one manifest-declared preference. `PluginPreferenceType` has four
+ * members and each gets its own control: rendering a `dropdown` or a `checkbox`
+ * as a text box let the user type any string at all into a field whose declared
+ * point is that only certain values are legal — and showed no option list, so
+ * there was nothing to tell them what those values were.
+ *
+ * Values stay strings end to end, because that is what the manifest's `default`
+ * and the host's preference storage are: a checkbox round-trips `"true"` /
+ * `"false"` (exactly as `PluginPreference.default` documents), a dropdown
+ * round-trips the chosen option's `value`.
+ */
 function PreferenceField({
   pref,
   value,
@@ -173,22 +193,55 @@ function PreferenceField({
   value: string;
   onChange: (value: string) => void;
 }) {
+  const id = `pref-${pref.name}`;
+  const labelId = `${id}-label`;
+
   return (
     <div className="flex flex-col gap-1.5">
-      <Label htmlFor={`pref-${pref.name}`}>
+      {/* `htmlFor` only associates with a labelable element, which the Radix
+          switch/select triggers (buttons) are not — those carry
+          `aria-labelledby` pointing back here instead. */}
+      <Label id={labelId} htmlFor={pref.type === 'checkbox' || pref.type === 'dropdown' ? undefined : id}>
         {pref.title}
         {pref.required && <span className="ml-1 text-red-500">*</span>}
       </Label>
       {pref.description && (
         <p className="text-xs text-muted-foreground">{pref.description}</p>
       )}
-      <Input
-        id={`pref-${pref.name}`}
-        type={pref.type === 'password' ? 'password' : 'text'}
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        placeholder={pref.type === 'password' ? '••••••••' : undefined}
-      />
+      {pref.type === 'checkbox' ? (
+        <Switch
+          id={id}
+          aria-labelledby={labelId}
+          checked={value === 'true'}
+          onCheckedChange={(checked) => onChange(checked ? 'true' : 'false')}
+        />
+      ) : pref.type === 'dropdown' ? (
+        <Select
+          // Radix treats `''` as "no value" and rejects it as an item value, so
+          // an unset dropdown shows the placeholder rather than a blank row.
+          value={value === '' ? undefined : value}
+          onValueChange={onChange}
+        >
+          <SelectTrigger id={id} aria-labelledby={labelId}>
+            <SelectValue placeholder="Select…" />
+          </SelectTrigger>
+          <SelectContent>
+            {(pref.options ?? []).map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      ) : (
+        <Input
+          id={id}
+          type={pref.type === 'password' ? 'password' : 'text'}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={pref.type === 'password' ? '••••••••' : undefined}
+        />
+      )}
     </div>
   );
 }

--- a/apps/viewer/src/lib/sources/syncSourceModel.test.ts
+++ b/apps/viewer/src/lib/sources/syncSourceModel.test.ts
@@ -1,0 +1,477 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `syncSourceModel` re-downloads a cloud-source model in place. Unlike its
+ * siblings in this directory (`loadQueue`, `persistence`) it shipped without
+ * tests, and the properties below are the ones whose failure modes are
+ * destructive rather than merely annoying:
+ *
+ * - **A failed fetch must not cost the user their model.** The function loads
+ *   the replacement FIRST and only removes the old model on success; if
+ *   `download` (or `addModel`) fails, the original must still be in the store
+ *   afterwards. Reordering those two steps deletes a loaded model on any
+ *   network blip.
+ * - **A provider that no longer lists the file must say so**, rather than
+ *   silently succeeding, downloading nothing, or walking a cursor chain
+ *   forever.
+ * - **The provider-supplied filename is sanitized** before it becomes a `File`
+ *   — it is third-party data and reaches a download/export path — while the
+ *   user's own model label survives the sync untouched.
+ * - **The new revision id is carried onto the replacement model's source tag**,
+ *   because that tag is what the next revision check compares against: leave
+ *   the old id there and the model reports itself out of date forever.
+ */
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import type {
+  FileSourceProvider,
+  ListOptions,
+  Page,
+  PluginContext,
+  PluginManifest,
+  SourceFile,
+  SourceTag,
+} from '@ifc-lite/plugin-api';
+
+class MemoryStorage implements Storage {
+  private readonly map = new Map<string, string>();
+  get length(): number { return this.map.size; }
+  clear(): void { this.map.clear(); }
+  getItem(key: string): string | null { return this.map.get(key) ?? null; }
+  key(index: number): string | null { return [...this.map.keys()][index] ?? null; }
+  removeItem(key: string): void { this.map.delete(key); }
+  setItem(key: string, value: string): void { this.map.set(key, value); }
+}
+
+const localStorageMock = new MemoryStorage();
+Object.defineProperty(globalThis, 'localStorage', {
+  value: localStorageMock,
+  configurable: true,
+});
+
+const { useViewerStore } = await import('@/store/index.js');
+const { syncSourceModel, isSourceModelSyncing } = await import('./syncSourceModel.js');
+type FederatedModel = import('@/store/types.js').FederatedModel;
+type SourceHost = import('@/services/sources/source-host.js').SourceHost;
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const MODEL_ID = 'model-1';
+
+function makeModel(overrides: Partial<FederatedModel> = {}): FederatedModel {
+  return {
+    id: MODEL_ID,
+    // Deliberately NOT the source file's name: this is the user's own label,
+    // which a sync must preserve.
+    name: 'My renamed tower',
+    ifcDataStore: null,
+    geometryResult: null,
+    visible: true,
+    collapsed: false,
+    schemaVersion: 'IFC4',
+    loadedAt: 42,
+    fileSize: 3,
+    sourceFile: new File([new Uint8Array([1, 2, 3])], 'tower.ifc'),
+    idOffset: 0,
+    maxExpressId: 0,
+    ...overrides,
+  } as FederatedModel;
+}
+
+function makeFile(overrides: Partial<SourceFile> = {}): SourceFile {
+  return {
+    id: 'file-1',
+    name: 'tower.ifc',
+    containerId: 'container-1',
+    currentRevisionId: 'rev-2',
+    ...overrides,
+  };
+}
+
+function makeTag(overrides: Partial<SourceTag> = {}): SourceTag {
+  return {
+    provider: 'test-provider',
+    projectId: 'project-1',
+    containerId: 'container-1',
+    fileId: 'file-1',
+    revisionId: 'rev-1',
+    loadedAt: 1,
+    ...overrides,
+  };
+}
+
+const manifest = {
+  name: 'test-provider',
+  title: 'Test Provider',
+  api: '^2.0.0',
+  permissions: { network: [] },
+  auth: 'preferences',
+  preferences: [],
+  capabilities: {
+    containerListing: 'direct-children',
+    listFilesIsRecursive: false,
+    revisionHistory: false,
+    downloadHistoricalRevisions: false,
+    changeDetection: false,
+    search: false,
+  },
+  contributes: { fileSources: [] },
+} as PluginManifest;
+
+interface ProviderStub {
+  readonly pages?: ReadonlyArray<Page<SourceFile>>;
+  readonly download?: () => Promise<ArrayBuffer>;
+}
+
+interface Harness {
+  readonly sourceHost: SourceHost;
+  readonly listCalls: Array<ListOptions | undefined>;
+  readonly addModelCalls: Array<{ file: File; name?: string }>;
+  readonly removed: string[];
+  readonly addModel: (file: File, options?: { name?: string; modelId?: string }) => Promise<string | null>;
+  readonly removeModel: (id: string) => void;
+}
+
+function makeHarness(stub: ProviderStub = {}, addModelImpl?: (file: File, options?: { modelId?: string }) => Promise<string | null>): Harness {
+  const listCalls: Array<ListOptions | undefined> = [];
+  const addModelCalls: Array<{ file: File; name?: string }> = [];
+  const removed: string[] = [];
+  const pages = stub.pages ?? [{ items: [makeFile()] }];
+
+  const provider = {
+    manifest,
+    async listFiles(
+      _ctx: PluginContext,
+      _projectId: string,
+      _containerId: string,
+      _filter: unknown,
+      options?: ListOptions,
+    ): Promise<Page<SourceFile>> {
+      listCalls.push(options);
+      return pages[Math.min(listCalls.length - 1, pages.length - 1)];
+    },
+    download: stub.download ?? (async () => new Uint8Array([1, 2, 3]).buffer),
+  } as unknown as FileSourceProvider;
+
+  const sourceHost = {
+    get: (name: string) => (name === manifest.name ? provider : undefined),
+    createContext: () => ({}) as PluginContext,
+    createSourceTag: (
+      providerName: string,
+      projectId: string,
+      containerId: string,
+      fileId: string,
+      revisionId: string,
+    ): SourceTag => ({
+      provider: providerName,
+      projectId,
+      containerId,
+      fileId,
+      revisionId,
+      loadedAt: 999,
+    }),
+  } as unknown as SourceHost;
+
+  const addModel = async (file: File, options?: { name?: string; modelId?: string }) => {
+    addModelCalls.push({ file, name: options?.name });
+    if (addModelImpl) return addModelImpl(file, options);
+    // Stand in for the real loader: register the replacement under the id the
+    // caller allocated, which is what the post-add store check looks for.
+    const id = options?.modelId ?? 'replacement';
+    useViewerStore.setState((state) => {
+      const models = new Map(state.models);
+      models.set(id, makeModel({ id, name: options?.name ?? 'replacement' }));
+      return { models };
+    });
+    return id;
+  };
+
+  const removeModel = (id: string) => {
+    removed.push(id);
+    useViewerStore.setState((state) => {
+      const models = new Map(state.models);
+      models.delete(id);
+      return { models };
+    });
+  };
+
+  return { sourceHost, listCalls, addModelCalls, removed, addModel, removeModel };
+}
+
+function seedStore(model = makeModel()): void {
+  useViewerStore.setState({
+    models: new Map([[model.id, model]]),
+    activeModelId: model.id,
+    sourceTags: new Map(),
+    mutationViews: new Map(),
+    selectedEntityIds: new Set(),
+    selectedStoreys: new Set(),
+    hiddenEntities: new Set(),
+    isolatedEntities: null,
+    ghostExceptEntities: null,
+    classFilter: null,
+    selectedEntities: [],
+    selectedEntitiesSet: new Set(),
+    selectedEntity: null,
+    selectedEntityId: null,
+    activeStorey: null,
+    selectedModelId: null,
+    hiddenEntitiesByModel: new Map(),
+    isolatedEntitiesByModel: new Map(),
+  });
+}
+
+beforeEach(() => {
+  localStorageMock.clear();
+  seedStore();
+});
+
+// ---------------------------------------------------------------------------
+
+describe('syncSourceModel — a failed fetch never costs the user their model', () => {
+  it('rejects with the provider error and leaves the original model loaded', async () => {
+    const h = makeHarness({
+      download: async () => {
+        throw new Error('network is down');
+      },
+    });
+
+    await assert.rejects(
+      syncSourceModel({
+        modelId: MODEL_ID,
+        tag: makeTag(),
+        sourceHost: h.sourceHost,
+        addModel: h.addModel,
+        removeModel: h.removeModel,
+      }),
+      /network is down/,
+    );
+
+    assert.ok(
+      useViewerStore.getState().models.has(MODEL_ID),
+      'the original model must survive a failed download',
+    );
+    assert.deepEqual(h.removed, [], 'nothing may be removed when the download fails');
+    assert.deepEqual(h.addModelCalls, [], 'no replacement is loaded when the download fails');
+  });
+
+  it('rejects and keeps the original when the reload itself fails', async () => {
+    const h = makeHarness({}, async () => null);
+
+    await assert.rejects(
+      syncSourceModel({
+        modelId: MODEL_ID,
+        tag: makeTag(),
+        sourceHost: h.sourceHost,
+        addModel: h.addModel,
+        removeModel: h.removeModel,
+      }),
+      /Failed to reload tower\.ifc/,
+    );
+
+    assert.ok(
+      useViewerStore.getState().models.has(MODEL_ID),
+      'a failed reload must not delete the model it was replacing',
+    );
+    assert.deepEqual(h.removed, []);
+  });
+
+  it('clears the in-flight entry after a failure, so a retry is possible', async () => {
+    const h = makeHarness({
+      download: async () => {
+        throw new Error('network is down');
+      },
+    });
+    const promise = syncSourceModel({
+      modelId: MODEL_ID,
+      tag: makeTag(),
+      sourceHost: h.sourceHost,
+      addModel: h.addModel,
+      removeModel: h.removeModel,
+    });
+    assert.equal(isSourceModelSyncing(MODEL_ID), true, 'a running sync must report as in flight');
+    await assert.rejects(promise);
+    assert.equal(isSourceModelSyncing(MODEL_ID), false);
+  });
+});
+
+describe('syncSourceModel — the provider no longer offers the file', () => {
+  it('reports the file as gone when the listing comes back empty', async () => {
+    const h = makeHarness({ pages: [{ items: [] }] });
+
+    await assert.rejects(
+      syncSourceModel({
+        modelId: MODEL_ID,
+        tag: makeTag(),
+        sourceHost: h.sourceHost,
+        addModel: h.addModel,
+        removeModel: h.removeModel,
+      }),
+      /no longer available in its original folder/,
+    );
+    assert.ok(useViewerStore.getState().models.has(MODEL_ID));
+  });
+
+  it('reports the file as gone when the listing has files but not this one', async () => {
+    const h = makeHarness({ pages: [{ items: [makeFile({ id: 'some-other-file' })] }] });
+
+    await assert.rejects(
+      syncSourceModel({
+        modelId: MODEL_ID,
+        tag: makeTag(),
+        sourceHost: h.sourceHost,
+        addModel: h.addModel,
+        removeModel: h.removeModel,
+      }),
+      /no longer available in its original folder/,
+    );
+  });
+
+  it('follows the cursor across pages to find the file', async () => {
+    const h = makeHarness({
+      pages: [
+        { items: [makeFile({ id: 'other' })], cursor: 'page-2' },
+        { items: [makeFile()] },
+      ],
+    });
+
+    const result = await syncSourceModel({
+      modelId: MODEL_ID,
+      tag: makeTag(),
+      sourceHost: h.sourceHost,
+      addModel: h.addModel,
+      removeModel: h.removeModel,
+    });
+
+    assert.equal(result.latestFile.id, 'file-1');
+    assert.equal(h.listCalls.length, 2);
+    assert.equal(h.listCalls[0]?.cursor, undefined, 'the first page is requested without a cursor');
+    assert.equal(h.listCalls[1]?.cursor, 'page-2', 'the second page uses the cursor the first returned');
+  });
+
+  it('stops instead of looping when a provider repeats the same cursor forever', async () => {
+    const h = makeHarness({
+      // Same cursor every time and never the wanted file: the shape a buggy or
+      // hostile provider produces.
+      pages: [{ items: [makeFile({ id: 'other' })], cursor: 'stuck' }],
+    });
+
+    await assert.rejects(
+      syncSourceModel({
+        modelId: MODEL_ID,
+        tag: makeTag(),
+        sourceHost: h.sourceHost,
+        addModel: h.addModel,
+        removeModel: h.removeModel,
+      }),
+      /no longer available in its original folder/,
+    );
+    assert.equal(
+      h.listCalls.length,
+      2,
+      'a repeated cursor must be caught on the second page, not after 100',
+    );
+  });
+});
+
+describe('syncSourceModel — filename handling', () => {
+  it('sanitizes the provider-supplied filename before it becomes a File', async () => {
+    const h = makeHarness({
+      pages: [{ items: [makeFile({ name: '../../etc/pas swd.ifc' })] }],
+    });
+
+    await syncSourceModel({
+      modelId: MODEL_ID,
+      tag: makeTag(),
+      sourceHost: h.sourceHost,
+      addModel: h.addModel,
+      removeModel: h.removeModel,
+    });
+
+    const loaded = h.addModelCalls[0]?.file;
+    assert.ok(loaded, 'a replacement File must be loaded');
+    assert.doesNotMatch(loaded.name, /[/\\]/, 'no path separator may survive into the File name');
+    assert.equal(loaded.name, 'etc-pas swd.ifc');
+  });
+
+  it('falls back to "model" when the provider name sanitizes away to nothing', async () => {
+    const h = makeHarness({ pages: [{ items: [makeFile({ name: '///' })] }] });
+
+    await syncSourceModel({
+      modelId: MODEL_ID,
+      tag: makeTag(),
+      sourceHost: h.sourceHost,
+      addModel: h.addModel,
+      removeModel: h.removeModel,
+    });
+
+    assert.equal(h.addModelCalls[0]?.file.name, 'model');
+  });
+
+  it("keeps the user's model label rather than overwriting it with the source name", async () => {
+    const h = makeHarness({ pages: [{ items: [makeFile({ name: 'tower-rev3.ifc' })] }] });
+
+    await syncSourceModel({
+      modelId: MODEL_ID,
+      tag: makeTag(),
+      sourceHost: h.sourceHost,
+      addModel: h.addModel,
+      removeModel: h.removeModel,
+    });
+
+    assert.equal(h.addModelCalls[0]?.name, 'My renamed tower');
+  });
+});
+
+describe('syncSourceModel — the revision id lands on the replacement model', () => {
+  it("writes the downloaded file's current revision id onto the new source tag", async () => {
+    const h = makeHarness({
+      pages: [{ items: [makeFile({ currentRevisionId: 'rev-7', containerId: 'moved-container' })] }],
+    });
+
+    const result = await syncSourceModel({
+      modelId: MODEL_ID,
+      tag: makeTag({ revisionId: 'rev-1' }),
+      sourceHost: h.sourceHost,
+      addModel: h.addModel,
+      removeModel: h.removeModel,
+    });
+
+    assert.equal(result.sourceTag.revisionId, 'rev-7');
+    // A file the provider reports in a different container must be tracked
+    // there, not at the stale location the old tag recorded.
+    assert.equal(result.sourceTag.containerId, 'moved-container');
+
+    const stored = useViewerStore.getState().sourceTags.get(result.reloadedModelId);
+    assert.ok(stored, 'the replacement model must carry a source tag');
+    assert.equal(stored.revisionId, 'rev-7');
+    assert.notEqual(
+      result.reloadedModelId,
+      MODEL_ID,
+      'the replacement is loaded under a fresh id',
+    );
+  });
+
+  it('swaps the old model out and makes the replacement active', async () => {
+    const h = makeHarness();
+
+    const result = await syncSourceModel({
+      modelId: MODEL_ID,
+      tag: makeTag(),
+      sourceHost: h.sourceHost,
+      addModel: h.addModel,
+      removeModel: h.removeModel,
+    });
+
+    const state = useViewerStore.getState();
+    assert.deepEqual(h.removed, [MODEL_ID], 'the old model is removed exactly once, after the load');
+    assert.equal(state.models.has(MODEL_ID), false);
+    assert.equal(state.models.has(result.reloadedModelId), true);
+    assert.equal(state.activeModelId, result.reloadedModelId);
+  });
+});


### PR DESCRIPTION
Offered to **take or leave**. This does not touch `feat/source-plugin-api-v2-host` directly — it targets it, so you can merge, cherry-pick, or ignore it. Same shape as #2155 for #2023. Nothing has been posted on #1976.

Three of the open review threads. The two module splits (`SourceBrowser.tsx`, `useSourceCatalogSync.ts`) are deliberately **not** here: they touch the same files as everything else and would collide with every other fix in flight.

Test counts for `apps/viewer/src/**/sources/**`: **50 tests / 15 suites** before, **92 tests / 26 suites** after, 0 failures either way.

---

## 1. `safeIconUrl` — the `/\` bypass, and the `permissions.network` gate

`SourceProviderRow.tsx`. The old check string-prefixed the raw manifest value:

```ts
if (raw.startsWith('//')) return undefined;
if (raw.startsWith('/') || raw.startsWith('./')) return raw; // "same-origin"
```

`/\evil.example/beacon.gif` passes `raw.startsWith('/')` and is returned as same-origin. The WHATWG URL parser folds `\` into `/` for special schemes, so what the browser actually requests is `//evil.example/beacon.gif` — a cross-origin beacon fired by an `img src`, from third-party manifest data.

Now it resolves through `new URL(raw, window.location.href)` and checks the **resolved** origin:

- same-origin → allowed, returned normalized, **independent of the allowlist**;
- otherwise https **and** hostname in `permissions.network` → allowed;
- everything else → `undefined` (generic icon). `data:`, `javascript:`, plaintext `http:` and protocol-relative all fall out of that one check rather than needing their own special cases.

The allowlist match reuses `isAllowedHost` from `services/sources/host-fetch.ts` — the same function `ctx.fetch` enforces — so `*.example.com` behaves identically in both places and there is no second copy of the matching rule to drift.

**Empty allowlist is pinned in both directions**, since that is the case that reads as "allow nothing" or "allow everything" depending on how the check is written: `permissions.network: []` rejects *every* cross-origin https icon, and still allows `/icons/acme.svg`.

### RED

Exporting the old implementation unchanged and running the new test file: **9 of 18 failed**, including all three backslash variants and every allowlist assertion. After the fix: **18/18**.

### Mutations (each applied by exact-substring replacement, replacement count asserted `== 1`, mutated region re-read from disk before believing the result, restored from a saved copy)

| # | Mutation | count | Result |
|---|---|---|---|
| A | reinstate `if (raw.startsWith('/')) return raw;` | 1 | 5 fail — all four backslash variants + protocol-relative |
| B | `isAllowedHost(...) ? resolved.href : undefined` → `resolved.href` | 1 | 3 fail — non-allowlisted host, empty allowlist, wildcard negative |
| C | `origin === location.origin` → `&& allowedHosts.length > 0` | 1 | 4 fail — every same-origin-with-empty-allowlist case |
| D | disable the https check | 1 | 5 fail — backslash variants + "http on an allowlisted host" |

A test that only checked "allowed host passes" would survive B and C. Both are killed.

## 2. Checkbox and dropdown preferences rendered as text inputs

`SourceSettingsDialog.tsx`. `PreferenceField` rendered `<Input type={pref.type === 'password' ? 'password' : 'text'}>` for all four `PluginPreferenceType` members and never read `pref.options`. A provider declaring a `dropdown` got a free-text box: no option list shown, any string typeable into a field whose entire point is that only the declared values are legal. A `checkbox` expected the user to type the word `true`.

Now `checkbox` renders a `Switch` and `dropdown` a `Select` populated from `pref.options`. Both come from the app's existing `@/components/ui` set (`@radix-ui/react-switch` / `@radix-ui/react-select`, already dependencies) — **no new UI dependency**. `password` and `text` are untouched. Values stay strings end to end, because that is what `PluginPreference.default` and the host's preference storage are: a checkbox round-trips `"true"` / `"false"` exactly as the type documents, a dropdown round-trips the option's `value`.

One accessibility detail: `htmlFor` only associates with a labelable element, which the Radix triggers (buttons) are not, so those carry `aria-labelledby` back to the label instead.

### RED

New test file against the current implementation: **9 of 12 failed** — every checkbox and dropdown assertion. Only the `textfield` / `password` cases passed. After the fix: **12/12**.

### Mutations

| # | Mutation | count | Killed |
|---|---|---|---|
| E | `checked={value === 'true'}` → `checked={false}` | 1 | "renders checked for `"true"`", "saves `"false"` after turning off" |
| F | `onChange(checked ? 'true' : 'false')` → inverted | 1 | both save-direction tests |
| G | `SelectItem` body `{option.label}` → `{option.value}` | 1 | "shows the label of the stored value", "offers exactly the declared options", "saves the VALUE not the label" |
| H | `SelectItem value={option.value}` → `value={option.label}` | 1 | "shows the label of the stored value", "saves the VALUE not the label" |

## 3. `syncSourceModel.ts` had no tests

12 tests, in `syncSourceModel.test.ts`, aimed at the contract rather than at "it calls the thing":

- **a failed fetch must not cost the user their model** — the module deliberately loads the replacement first and removes the old model only on success; a failed `download`, and separately a failed `addModel`, must both reject *and* leave the original in the store, with nothing removed;
- **a provider that no longer lists the file must say so** — empty page, page with other files, cursor followed across pages, and a provider repeating the same cursor forever caught on page 2 rather than after 100;
- **filename sanitisation** — a provider-supplied `../../etc/pas swd.ifc` reaches the `File` with no path separator, a name that sanitises away to nothing falls back to `model`, and the user's own renamed model label survives instead of being overwritten by the source filename;
- **the revision id lands on the replacement** — the new tag carries `latestFile.currentRevisionId` (and the file's *current* container, not the stale tagged one) and is stored against the fresh model id; leave the old id there and the model reports itself out of date forever.

These are characterization tests on existing behaviour, so there is no RED step to show — their value is entirely in whether they have teeth. **13 mutations, every one killed, no survivors**, and every one of the 12 tests is killed by at least one:

| # | Mutation | count | Killed |
|---|---|---|---|
| N1 | `removeModel(modelId)` moved before the download | 1 | 8 — incl. "leaves the original model loaded" |
| N2 | `if (!addedId && !registered)` → never fires | 1 | 1 — "keeps the original when the reload fails" |
| N3 | `items.find(f => f.id === tag.fileId)` → `items[0]` | 1 | 3 — wrong-file, cursor walk, stuck cursor |
| N4 | drop the repeated-cursor guard | 1 | 1 — stuck cursor (2 pages, not 100) |
| N5 | stop passing `cursor` to the next page | 1 | 1 — cursor walk |
| N6 | skip `sanitizeFilename` | 1 | 2 — both filename tests |
| N7 | `fallback: 'model'` → `'file'` | 1 | 1 — the fallback test |
| N8 | `name: model.name` → `name: safeFileName` | 1 | 1 — user's label preserved |
| N9 | new tag gets `tag.revisionId` instead of `latestFile.currentRevisionId` | 1 | 1 — revision id |
| N10 | new tag keeps `tag.containerId` | 1 | 1 — revision id / moved container |
| N11 | never `setActiveModel(replacementId)` | 1 | 1 — swap + activate |
| N12 | leak the `inFlightSyncs` entry | 1 | 11 — incl. "a retry is possible" |
| N13 | `if (!latestFile)` never throws | 1 | 3 — both "file is gone" cases |

Each mutation was applied by exact-substring replacement asserting a replacement count of exactly 1, the mutated region re-read from disk to confirm the text actually changed, and restored by copying back a saved backup. The harness refuses to start unless the target file is pristine — an earlier run had a mutation leak into its own backup and produced uniformly cascading failures, which is what that guard now prevents.

---

## Checks

- `pnpm typecheck` at root: **pass**.
- Test files **are** covered by it: `apps/viewer/tsconfig.json` overrides the root `exclude` (`**/*.test.ts`) with its own `["src/lib/scripts/templates"]`, so `src/**/*` pulls the tests in. Verified rather than assumed — a deliberate `const x: number = "s"` was appended to both a new `.test.ts` and a new `.test.tsx`, `tsc --noEmit` flagged both, and removing them returned a clean run.
- No changeset: the branch already carries `cloud-source-plugin-architecture.md` and `plugin-api-v2-contract.md`, and this is a fix to unreleased work under them.
- Nothing outside `apps/viewer/src/**/sources/**` is touched. `packages/plugin-api` needed no change — `PluginPreferenceType` and `DropdownOption` already declared everything the UI now honours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
