### PR TITLE
test(spatial,mcp): self-audit follow-up — three merged tests our own mutation sweep could not kill

### DIFF
--- a/.changeset/mcp-scope-constructor-array-copy.md
+++ b/.changeset/mcp-scope-constructor-array-copy.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/mcp": patch
+---
+
+`fullScope()` and `readOnlyScope()` now copy the `scopes` array as well as the
+wrapper object. The shallow spread handed every caller the same array instance
+as the exported `FULL_ACCESS` / `READ_ONLY` constants, so an in-place mutation
+(`readOnlyScope().scopes.push('mutate')`) widened the constant itself and every
+token minted afterwards in the same process carried the extra scope.

--- a/packages/mcp/src/auth/scope.test.ts
+++ b/packages/mcp/src/auth/scope.test.ts
@@ -75,14 +75,37 @@ describe('modelAllowed', () => {
 
 describe('scope constructors', () => {
   it('hand back copies, so a caller mutating one does not widen the next', () => {
+    // Assert against a LITERAL, not against `FULL_ACCESS.scopes`: comparing
+    // `fullScope()` to the very constant a leak would have corrupted is a
+    // self-comparison that holds however badly the constructor leaks (with
+    // `fullScope()` returning `FULL_ACCESS` itself, this test passed in
+    // isolation — measured; the only failure came from a later test in the
+    // file, i.e. from cross-test leakage, not from this assertion).
     const a = fullScope();
     a.scopes = ['read'];
-    expect(fullScope().scopes).toEqual(FULL_ACCESS.scopes);
+    expect(fullScope().scopes).toEqual(['read', 'validate', 'mutate', 'export', 'admin']);
+    expect(FULL_ACCESS.scopes).toEqual(['read', 'validate', 'mutate', 'export', 'admin']);
 
     const b = readOnlyScope();
     b.modelIds = ['only-this-one'];
     expect(readOnlyScope().modelIds).toBeUndefined();
     expect(READ_ONLY.scopes).not.toContain('mutate');
+  });
+
+  it('are copies against IN-PLACE mutation too, not just reassignment', () => {
+    // Reassigning `.scopes` is the one mutation a shallow `{ ...CONST }` copy
+    // survives, so the assertion above cannot see the aliasing that matters:
+    // a caller that PUSHES onto the array it was handed writes straight into
+    // the exported constant, and every token minted afterwards in the process
+    // carries the extra scope — a read-only token silently gaining `mutate`.
+    readOnlyScope().scopes.push('mutate');
+    expect(READ_ONLY.scopes).not.toContain('mutate');
+    expect(readOnlyScope().scopes).toEqual(['read', 'validate', 'export']);
+    expect(scopeAllows(readOnlyScope(), 'mutate')).toBe(false);
+
+    fullScope().scopes.length = 0;
+    expect(FULL_ACCESS.scopes).toHaveLength(5);
+    expect(scopeAllows(fullScope(), 'read')).toBe(true);
   });
 
   it('read-only really is read-only', () => {

--- a/packages/mcp/src/auth/scope.ts
+++ b/packages/mcp/src/auth/scope.ts
@@ -40,10 +40,14 @@ export function modelAllowed(scope: AuthScope, modelId: string): boolean {
   return scope.modelIds.includes(modelId);
 }
 
+/* The `scopes` array is copied too, not just the wrapper object: a spread
+ * alone hands every caller the SAME array instance as the exported constant,
+ * so `readOnlyScope().scopes.push('mutate')` widens `READ_ONLY` itself and
+ * every token minted afterwards in the process gets the extra scope. */
 export function readOnlyScope(): AuthScope {
-  return { ...READ_ONLY };
+  return { ...READ_ONLY, scopes: [...READ_ONLY.scopes] };
 }
 
 export function fullScope(): AuthScope {
-  return { ...FULL_ACCESS };
+  return { ...FULL_ACCESS, scopes: [...FULL_ACCESS.scopes] };
 }

--- a/packages/spatial/src/bvh.test.ts
+++ b/packages/spatial/src/bvh.test.ts
@@ -31,6 +31,24 @@ function row(n: number, axis: 0 | 1 | 2 = 0): MeshWithBounds[] {
   });
 }
 
+/**
+ * Rotation matrix about `axis` (normalized here) by `angle`, Rodrigues form,
+ * as `R[row][col]`. Used to build a view-projection whose upper 3x3 has no
+ * zero entry.
+ */
+function rotationAboutAxis(axis: [number, number, number], angle: number): number[][] {
+  const n = Math.hypot(axis[0], axis[1], axis[2]);
+  const [x, y, z] = [axis[0] / n, axis[1] / n, axis[2] / n];
+  const c = Math.cos(angle);
+  const s = Math.sin(angle);
+  const t = 1 - c;
+  return [
+    [t * x * x + c, t * x * y - s * z, t * x * z + s * y],
+    [t * x * y + s * z, t * y * y + c, t * y * z - s * x],
+    [t * x * z - s * y, t * y * z + s * x, t * z * z + c],
+  ];
+}
+
 describe('BVH.build', () => {
   it('returns an empty index for no meshes without throwing', () => {
     const bvh = BVH.build([]);
@@ -269,6 +287,71 @@ describe('FrustumUtils', () => {
     expect(FrustumUtils.isAABBVisible(f, cell(12, 0, 10))).toBe(false); // right
     expect(FrustumUtils.isAABBVisible(f, cell(0, -12, 10))).toBe(false); // bottom
     expect(FrustumUtils.isAABBVisible(f, cell(0, 12, 10))).toBe(false); // top
+    expect(FrustumUtils.isAABBVisible(f, cell(0, 0, -2))).toBe(false); // near
+    expect(FrustumUtils.isAABBVisible(f, cell(0, 0, 22))).toBe(false); // far
+  });
+
+  it('extracts the six planes under a dense rotation, where no matrix entry is zero', () => {
+    // The axis-aligned fixture above pins each plane's CONSTANT, but not which
+    // matrix entry every normal COMPONENT comes from: it is diagonal, so
+    // m[1], m[2], m[4], m[6], m[8] and m[9] are all zero and swapping one for
+    // another is an identity. Measured on that fixture alone: the bottom plane
+    // reading `m[2]` instead of `m[1]`, and the near plane reading `m[6]`
+    // instead of `m[2]`, both SURVIVE. A rotated view leaves no zero entry in
+    // the upper 3x3, so a component read from the wrong row is observable.
+    const rot = rotationAboutAxis([1, 2, 3], 0.7); // rot[r][c], world -> view
+    for (const r of rot) for (const v of r) expect(Math.abs(v)).toBeGreaterThan(0.05);
+
+    // View volume: x ∈ [-10, 10], y ∈ [-5, 5], z ∈ [0, 20]. Deliberately
+    // different extents per axis, so a swap between two planes is not masked
+    // by a symmetric volume. m = P · rot, column-major.
+    const scale = [0.1, 0.2, 0.05];
+    const m = [
+      ...[0, 1, 2].flatMap((c) => [
+        scale[0] * rot[0][c], scale[1] * rot[1][c], scale[2] * rot[2][c], 0,
+      ]),
+      0, 0, 0, 1,
+    ];
+    const f = FrustumUtils.fromViewProjMatrix(m);
+
+    // A view-space point mapped back to world by the inverse rotation (the
+    // transpose): the expectations are derived from the fixture rotation, not
+    // from `fromViewProjMatrix`.
+    const cell = (vx: number, vy: number, vz: number): AABB => {
+      const wx = rot[0][0] * vx + rot[1][0] * vy + rot[2][0] * vz;
+      const wy = rot[0][1] * vx + rot[1][1] * vy + rot[2][1] * vz;
+      const wz = rot[0][2] * vx + rot[1][2] * vy + rot[2][2] * vz;
+      return box(wx - 0.5, wy - 0.5, wz - 0.5, wx + 0.5, wy + 0.5, wz + 0.5);
+    };
+
+    // Inside on every axis, then just inside each face.
+    expect(FrustumUtils.isAABBVisible(f, cell(0, 0, 10))).toBe(true);
+    expect(FrustumUtils.isAABBVisible(f, cell(-9, 0, 10))).toBe(true);
+    expect(FrustumUtils.isAABBVisible(f, cell(9, 0, 10))).toBe(true);
+    expect(FrustumUtils.isAABBVisible(f, cell(0, -4, 10))).toBe(true);
+    expect(FrustumUtils.isAABBVisible(f, cell(0, 4, 10))).toBe(true);
+    expect(FrustumUtils.isAABBVisible(f, cell(0, 0, 2))).toBe(true);
+    expect(FrustumUtils.isAABBVisible(f, cell(0, 0, 18))).toBe(true);
+    // Every corner of the volume, all still inside. Probing each plane only
+    // along its OWN axis is not enough: a normal component read from the wrong
+    // row can leave the sign of that one dot product unchanged (measured — the
+    // near plane taking its x from `m[6]` instead of `m[2]` survives the
+    // face-centre probes above). A corner loads every component at once, so a
+    // mis-wired one tilts the plane into the volume and clips the corner off.
+    for (const vx of [-9, 9]) {
+      for (const vy of [-4, 4]) {
+        for (const vz of [1, 19]) {
+          expect(FrustumUtils.isAABBVisible(f, cell(vx, vy, vz))).toBe(true);
+        }
+      }
+    }
+    // Well outside each face, one assertion per plane. The cells are cubes in
+    // WORLD space, so their half-diagonal (0.87 m) is the slack a plane test
+    // sees; 2 m outside clears it and the -0.5 m margin both.
+    expect(FrustumUtils.isAABBVisible(f, cell(-12, 0, 10))).toBe(false); // left
+    expect(FrustumUtils.isAABBVisible(f, cell(12, 0, 10))).toBe(false); // right
+    expect(FrustumUtils.isAABBVisible(f, cell(0, -7, 10))).toBe(false); // bottom
+    expect(FrustumUtils.isAABBVisible(f, cell(0, 7, 10))).toBe(false); // top
     expect(FrustumUtils.isAABBVisible(f, cell(0, 0, -2))).toBe(false); // near
     expect(FrustumUtils.isAABBVisible(f, cell(0, 0, 22))).toBe(false); // far
   });

--- a/packages/spatial/src/bvh.test.ts
+++ b/packages/spatial/src/bvh.test.ts
@@ -70,8 +70,13 @@ describe('BVH.queryAABB', () => {
   });
 
   it('does not miss meshes when the extent is longest on y or z', () => {
-    // The split-axis choice picks the longest extent; a scene laid out on x
-    // only would never exercise the y/z branches.
+    // A scene laid out on x only never queries against a y- or z-dominant
+    // hierarchy. Note what this does NOT pin: the split-axis choice itself is
+    // a performance decision, invisible in the results (forcing `axis = 0` for
+    // every node leaves the whole suite green — measured), so the value here
+    // is the per-axis query geometry, and each iteration does discriminate on
+    // its own axis (widening only the y slab fails the axis-1 iteration,
+    // widening only z fails the axis-2 one).
     for (const axis of [1, 2] as const) {
       const meshes = row(9, axis);
       const bvh = BVH.build(meshes);
@@ -149,6 +154,20 @@ describe('BVH.raycast', () => {
     const unit = bvh.raycast([0, 0, 0], [1, 0, 0]).sort((a, b) => a - b);
     const long = bvh.raycast([0, 0, 0], [1000, 0, 0]).sort((a, b) => a - b);
     expect(long).toEqual(unit);
+    // The magnitude-invariance above is NOT evidence that the normalization
+    // runs: the slab test scales every `t` by the same positive factor, so the
+    // hit SET is invariant under any positive scaling and deleting the
+    // normalization outright leaves both assertions green (measured). The
+    // degenerate direction is the one input where the normalization is
+    // observable: it divides by a zero length, every component becomes NaN,
+    // and the slab test rejects — a zero-length ray hits nothing. Skip the
+    // normalization and the same call takes the parallel-slab branch on all
+    // three axes instead and reports every mesh containing the origin, so a
+    // viewer picking with a degenerate direction would select the element the
+    // camera sits inside.
+    const inside = BVH.build([cube(1, [0, 0, 0], 5)]);
+    expect(inside.raycast([0, 0, 0], [1, 0, 0])).toEqual([1]);
+    expect(inside.raycast([0, 0, 0], [0, 0, 0])).toEqual([]);
   });
 });
 
@@ -197,7 +216,9 @@ describe('BVH.queryFrustum', () => {
 describe('FrustumUtils', () => {
   it('normalizes planes extracted from a view-projection matrix', () => {
     // Simple orthographic-ish matrix; the only invariant asserted here is that
-    // every extracted plane normal is unit length after normalization.
+    // every extracted plane normal is unit length after normalization. On its
+    // own that is weak — it says nothing about the plane CONSTANTS or about
+    // which matrix rows each plane comes from; the test below covers both.
     const m = [
       2, 0, 0, 0,
       0, 2, 0, 0,
@@ -210,6 +231,46 @@ describe('FrustumUtils', () => {
       const len = Math.hypot(p.normal[0], p.normal[1], p.normal[2]);
       expect(len).toBeCloseTo(1, 10);
     }
+  });
+
+  it('extracts the six planes of a known orthographic volume, in world units', () => {
+    // Column-major orthographic view-proj for x,y ∈ [-10, 10], z ∈ [0, 20]
+    // (WebGPU clip space, z ∈ [0, 1] — matching the near-plane extraction,
+    // which uses row 2 alone rather than w + row 2).
+    const m = [
+      0.1, 0, 0, 0,
+      0, 0.1, 0, 0,
+      0, 0, 0.05, 0,
+      0, 0, 0, 1,
+    ];
+    const f = FrustumUtils.fromViewProjMatrix(m);
+
+    // Culling decisions are taken in WORLD units against the -0.5 m margin, so
+    // they only come out right if the plane constant was divided by the normal
+    // length too. Skipping `plane.distance /= len` leaves every normal unit
+    // length — the assertion above still passes — while the left plane moves
+    // from x = -10 to x = -15, and this box (5 m outside, 2 m outside the
+    // margin) is then wrongly kept.
+    const cell = (cx: number, cy: number, cz: number): AABB =>
+      box(cx - 0.5, cy - 0.5, cz - 0.5, cx + 0.5, cy + 0.5, cz + 0.5);
+
+    // Inside the volume on every axis.
+    expect(FrustumUtils.isAABBVisible(f, cell(0, 0, 10))).toBe(true);
+    // Just inside each face (within the volume, so kept with or without margin).
+    expect(FrustumUtils.isAABBVisible(f, cell(-9, 0, 10))).toBe(true);
+    expect(FrustumUtils.isAABBVisible(f, cell(9, 0, 10))).toBe(true);
+    expect(FrustumUtils.isAABBVisible(f, cell(0, -9, 10))).toBe(true);
+    expect(FrustumUtils.isAABBVisible(f, cell(0, 9, 10))).toBe(true);
+    expect(FrustumUtils.isAABBVisible(f, cell(0, 0, 1))).toBe(true);
+    expect(FrustumUtils.isAABBVisible(f, cell(0, 0, 19))).toBe(true);
+    // Well outside each face — one assertion per plane, so a single mis-wired
+    // plane cannot hide behind the other five.
+    expect(FrustumUtils.isAABBVisible(f, cell(-12, 0, 10))).toBe(false); // left
+    expect(FrustumUtils.isAABBVisible(f, cell(12, 0, 10))).toBe(false); // right
+    expect(FrustumUtils.isAABBVisible(f, cell(0, -12, 10))).toBe(false); // bottom
+    expect(FrustumUtils.isAABBVisible(f, cell(0, 12, 10))).toBe(false); // top
+    expect(FrustumUtils.isAABBVisible(f, cell(0, 0, -2))).toBe(false); // near
+    expect(FrustumUtils.isAABBVisible(f, cell(0, 0, 22))).toBe(false); // far
   });
 
   it('leaves a degenerate zero-length plane normal untouched instead of producing NaN', () => {


### PR DESCRIPTION
## Why

23 test-coverage PRs merged into `main` in the last day. Review already caught real vacuity in three of them at or after merge — #2145 (a dedup test pinning only one direction), #2151 (a loop where 5 of 8 cases asserted nothing), #2148 (round-trips built from paired production functions). This is a self-audit for the same shapes in the rest of that work, done the way those defects were found: apply the minimal mutation each test claims to catch, plus a neighbouring one it arguably should, and record KILLED / SURVIVED — per case for loops, not just "the loop failed".

Sampled six PRs, biased to the failing shapes: **#2147** (spatial/clash — loops over axes, `[]` and `Infinity` sink assertions), **#2144** (mcp auth — two-valued signals, copy semantics), **#2136** (rust georef — a cross-check between two paired production functions, the #2148 shape), **#2140** (a zero-valued fixture), **#2146** (a 3x3 region-combination loop), plus the clash box-kernel symmetry tests (self-paired assertions). 24 mutations. Three survivors.

## Measurement

Every mutation was an exact-substring replacement asserting a replacement count of 1, with the mutated region re-read before the run and restored from a backup taken before the first mutation.

| PR | Test | Claimed property | Discriminates | Evidence |
|---|---|---|---|---|
| #2147 | `BVH.raycast` "normalizes the direction" | direction is normalized | **no** | deleting the normalization entirely → SURVIVED (hit set is invariant under any positive scaling) |
| #2147 | `FrustumUtils` "normalizes planes extracted from a view-projection matrix" | planes are normalized | **partial** | `plane.distance /= len` → `/= 1` → SURVIVED; left-plane `m[3] + m[0]` → `m[3] - m[0]` → SURVIVED; `if (len > 0)` → `if (len > 1e12)` → KILLED |
| #2147 | "does not miss meshes when the extent is longest on y or z" | y/z query geometry | **yes** (per case) | y slab widened by 100 → KILLED at axis 1; z slab widened → KILLED at axis 2; but forcing `axis = 0` for every split → SURVIVED, so the split-axis rationale in the comment is not what the test pins |
| #2147 | "grazes a slab plane exactly" | parallel-slab guard | **yes** | guard removed → KILLED (3 tests); `<`/`>` → `<=`/`>=` → KILLED |
| #2147 | "does NOT report meshes behind the ray origin" | `tmax >= 0` | **yes** | `return tmax >= 0` → `return true` → KILLED |
| #2147 | "keeps a batch just outside the frustum edge" | the -0.5 m anti-flicker margin | **yes** | `PLANE_EPSILON = -0.5` → `0` → KILLED (2 tests) |
| #2147 | clash `intersects` "is symmetric" | symmetry | **yes** | `a.max[0] >= b.min[0]` → `>` (asymmetric) → KILLED; `return true` → SURVIVED here, KILLED by the separation test in the same file |
| #2144 | "hand back copies, so a caller mutating one does not widen the next" | constructors return copies | **no** | `fullScope()` → `return FULL_ACCESS` → SURVIVED in isolation (the assertion compares `fullScope()` to the constant a leak corrupts); the whole-file failure came from a later test, i.e. cross-test leakage. And the named property does not hold of the code at all: the spread was shallow |
| #2144 | "lets `admin` stand in for a scope the token does not list" | the escalation arm | **yes** | `|| scope.scopes.includes('admin')` removed → KILLED |
| #2144 | `modelAllowed` allowlist | per-model gating | **yes** | `return scope.modelIds.includes(modelId)` → `return true` → KILLED (2 tests) |
| #2136 | `to_matrix` column pinning + `local_to_map` cross-check | rotation / scale / translation | **yes** | col-1 sign flip → KILLED; `local_to_map` sign flip alone → KILLED by the cross-check; **both flipped together** (the symmetric error a cross-check cannot see) → KILLED by the pinned columns; z scale `s` → `1.0` → KILLED |
| #2140 | "falls back to the metre default instead of accepting a zero scale" | the `s > 0` guard | **yes** | guard dropped → KILLED; `s > 0` → `s >= 0` → KILLED; fallback `1.0` → `2.0` → KILLED |
| #2146 | soundness invariant, 3x3 region combinations | structural intersection always conflicts | **partial** | `structural || spatial` → `structural && spatial` → KILLED in 7 of 9 cases; the 2 survivors are the combinations where both regions overlap, so `spatial` is true anyway |

## What this changes

**1. `BVH.raycast` normalization (#2147).** Deleting the normalization survived: the slab test scales every `t` by the same positive factor, so the hit set is invariant under any positive scaling and the assertion is a tautology. The degenerate direction is the one observable input — it divides by a zero length and the NaN components make the slab test reject, so a zero-length ray hits nothing; without the normalization the call takes the parallel-slab branch on all three axes and reports every mesh containing the origin (a viewer pick with a degenerate direction would select the element the camera sits inside). Pinned; the mutation is now KILLED.

**2. `fromViewProjMatrix` (#2147).** The only assertion was that the six normals are unit length, which says nothing about the plane constants or about which matrix rows each plane comes from. A new test extracts a known orthographic volume (x, y in [-10, 10], z in [0, 20]) and asserts one inside and one outside box per plane, in world units. Dropped distance normalization, flipped left plane and swapped near-plane constant are now all KILLED.

**3. `readOnlyScope()` / `fullScope()` (#2144).** The test compared `fullScope().scopes` against `FULL_ACCESS.scopes` — the very constant a leak corrupts — so it held however badly the constructor leaked. Now asserted against a literal. Measuring it also showed the property the test names is not one the code had: the spread was shallow, so `readOnlyScope().scopes.push('mutate')` wrote into `READ_ONLY` itself and every token minted afterwards in the process carried the extra scope. `scopes` is now copied too, with the in-place mutation pinned (patch changeset included).

Plus a corrected comment on the y/z BVH loop, which claimed to exercise a split-axis choice that is invisible in the results.

The other sampled tests held, including the one built in the #2148 shape: the georef matrix pins its columns, so even a sign error applied symmetrically to both `to_matrix` and `local_to_map` is caught.

## Verification

- `packages/spatial`: 46 tests pass (45 before); each new assertion RED-verified against the mutation it exists to catch.
- `packages/mcp`: 232 tests pass with dependencies built.
- `pnpm turbo typecheck --force` clean for both packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
