### PR TITLE
test(pointcloud,collab): close four survivors from the round-2 self-audit

### DIFF
--- a/packages/collab/test/from-ifcx-reset.test.ts
+++ b/packages/collab/test/from-ifcx-reset.test.ts
@@ -68,6 +68,39 @@ describe('seedFromIfcx reset contract', () => {
     expect(entitiesMap(doc).has('new-wall')).toBe(true);
   });
 
+  // The two cases above only ever pass `reset` EXPLICITLY. The default —
+  // `opts.reset` absent — is a third arm, and it is the one production uses
+  // most: `apps/viewer` seeds an already-live session doc with
+  // `seedFromIfcx(session.doc, bytes)` (collabSlice.ts) and
+  // `snapshot/worker.ts` calls `seedFromIfcx(doc, file)`. Widening the guard
+  // to `if (opts.reset !== false)` makes that call wipe the doc it was asked
+  // to seed into — silent data loss that converges across every peer — and
+  // it survived the whole collab suite before this test existed.
+  it('defaults to reset OFF: seeding with no options is additive, not destructive', () => {
+    const doc = createCollabDoc();
+    doc.transact(() => {
+      createEntity(doc, 'old-wall', { ifcClass: 'IfcWall' });
+      createRelationship(doc, 'old-rel', { ifcClass: 'IfcRelAggregates', source: 'old-wall' });
+      createGeometry(doc, 'old-geom', { type: 'parametric', source: 'extruded-area-solid' });
+    });
+
+    // No third argument at all — the shape both production call sites use.
+    seedFromIfcx(doc, minimalIfcx(['new-wall']));
+
+    expect(entitiesMap(doc).has('old-wall')).toBe(true);
+    expect(relationshipsMap(doc).has('old-rel')).toBe(true);
+    expect(geometryMap(doc).has('old-geom')).toBe(true);
+    expect(entitiesMap(doc).has('new-wall')).toBe(true);
+
+    // An explicitly empty options object must behave identically — the
+    // default lives in the `opts.reset` read, not in the `= {}` parameter
+    // default, so both routes to "absent" need pinning.
+    seedFromIfcx(doc, minimalIfcx(['newer-wall']), {});
+    expect(entitiesMap(doc).has('old-wall')).toBe(true);
+    expect(entitiesMap(doc).has('new-wall')).toBe(true);
+    expect(entitiesMap(doc).has('newer-wall')).toBe(true);
+  });
+
   it('mergeBranch("layer") does not reset the parent — content added to the parent after the fork survives', async () => {
     const parent = await createCollabSession({
       roomId: 'parent-reset-check',

--- a/packages/pointcloud/src/formats/las.test.ts
+++ b/packages/pointcloud/src/formats/las.test.ts
@@ -48,7 +48,15 @@ function buildHeader(overrides: Partial<{
   return { header: new Uint8Array(buf), total: 227 };
 }
 
-function buildFormat0Records(rows: Array<{ x: number; y: number; z: number; intensity?: number; classification?: number }>): Uint8Array {
+function buildFormat0Records(rows: Array<{
+  x: number; y: number; z: number; intensity?: number; classification?: number;
+  /**
+   * High 3 bits of byte 15 in formats 0–5: synthetic (0x20), key-point
+   * (0x40), withheld (0x80). Real producers set these on ordinary points,
+   * so the decoder has to mask them off the classification.
+   */
+  classFlags?: number;
+}>): Uint8Array {
   const buf = new ArrayBuffer(rows.length * 20);
   const view = new DataView(buf);
   for (let i = 0; i < rows.length; i++) {
@@ -57,8 +65,33 @@ function buildFormat0Records(rows: Array<{ x: number; y: number; z: number; inte
     view.setInt32(off + 4, rows[i].y, true);
     view.setInt32(off + 8, rows[i].z, true);
     view.setUint16(off + 12, rows[i].intensity ?? 0, true);
-    view.setUint8(off + 15, rows[i].classification ?? 0);
+    view.setUint8(off + 15, (rows[i].classification ?? 0) | (rows[i].classFlags ?? 0));
     // bytes 13, 14, 16, 17, 18, 19 = bit flags / scan angle / user data — leave 0
+  }
+  return new Uint8Array(buf);
+}
+
+/**
+ * Format-6 records (LAS 1.4 extended base record, 30 bytes). Two things
+ * differ from formats 0–5 and both are load-bearing in `decodeLasPoints`:
+ * classification moves from byte 15 to byte 16, and it is NOT masked (the
+ * flag bits got their own byte). `flagsByte15` writes whatever the producer
+ * left in the old slot so a decoder that still reads byte 15 is visible.
+ */
+function buildFormat6Records(rows: Array<{
+  x: number; y: number; z: number;
+  intensity?: number; classification: number; flagsByte15?: number;
+}>): Uint8Array {
+  const buf = new ArrayBuffer(rows.length * 30);
+  const view = new DataView(buf);
+  for (let i = 0; i < rows.length; i++) {
+    const off = i * 30;
+    view.setInt32(off, rows[i].x, true);
+    view.setInt32(off + 4, rows[i].y, true);
+    view.setInt32(off + 8, rows[i].z, true);
+    view.setUint16(off + 12, rows[i].intensity ?? 0, true);
+    view.setUint8(off + 15, rows[i].flagsByte15 ?? 0);
+    view.setUint8(off + 16, rows[i].classification);
   }
   return new Uint8Array(buf);
 }
@@ -247,6 +280,68 @@ describe('decodeLasPoints', () => {
     expect(withOffset.bbox.min[2]).toBeCloseTo(4.321, 6);
   });
 
+  // Every existing fixture stores a classification below 32 with the high
+  // three bits of byte 15 left at zero, which makes `& 0x1f` an identity on
+  // all of them — deleting the mask survived the whole pointcloud suite.
+  // Real producers DO set those flags (a withheld ground point is byte 15 =
+  // 0x82), and without the mask it decodes as class 130: every
+  // classification-based colour ramp and filter misses it.
+  it('masks the synthetic/key-point/withheld flag bits out of the legacy classification byte', () => {
+    const { header } = buildHeader({
+      pointDataFormatId: 0,
+      pointRecordLength: 20,
+      pointCount: 4,
+      scale: [1, 1, 1],
+    });
+    const h = parseLasHeader(header);
+    const records = buildFormat0Records([
+      { x: 0, y: 0, z: 0, classification: 2, classFlags: 0x80 },  // withheld ground
+      { x: 0, y: 0, z: 0, classification: 6, classFlags: 0x40 },  // key-point building
+      { x: 0, y: 0, z: 0, classification: 1, classFlags: 0x20 },  // synthetic unclassified
+      { x: 0, y: 0, z: 0, classification: 31, classFlags: 0xe0 }, // all three flags, max class
+    ]);
+    const chunk = decodeLasPoints(records, h, 4, 20);
+    // Each case is checked individually: a mask that dropped only some of
+    // the flag bits would still satisfy a whole-array comparison against a
+    // single wrong value, but not four different flag combinations.
+    expect(chunk.classifications![0]).toBe(2);
+    expect(chunk.classifications![1]).toBe(6);
+    expect(chunk.classifications![2]).toBe(1);
+    // Opposite direction: the mask must keep all five class bits, not
+    // narrow the field further.
+    expect(chunk.classifications![3]).toBe(31);
+  });
+
+  // Formats 6–10 are the LAS 1.4 extended records: classification moves to
+  // byte 16 and is a full unmasked byte (classes 0..255 are legal there).
+  // Nothing exercised a format >= 6 record, so both `classOffset` and the
+  // "don't mask" arm were invisible — collapsing `classOffset` to a constant
+  // 15 survived the whole suite.
+  it('reads format-6+ classification from byte 16, unmasked', () => {
+    const { header } = buildHeader({
+      pointDataFormatId: 6,
+      pointRecordLength: 30,
+      pointCount: 2,
+      scale: [1, 1, 1],
+    });
+    const h = parseLasHeader(header);
+    expect(h.hasGpsTime).toBe(true);
+    expect(h.hasRgb).toBe(false);
+    const records = buildFormat6Records([
+      // Byte 15 holds return/scan flags in format 6; a decoder still reading
+      // it would report 7, not 200.
+      { x: 0, y: 0, z: 0, classification: 200, flagsByte15: 7 },
+      // A value that WOULD survive `& 0x1f` unchanged if it were masked, to
+      // keep the first case from being the only discriminating one.
+      { x: 1, y: 2, z: 3, classification: 40, flagsByte15: 0 },
+    ]);
+    const chunk = decodeLasPoints(records, h, 2, 30);
+    // 200 is above the 5-bit legacy field: masking would give 8.
+    expect(chunk.classifications![0]).toBe(200);
+    // 40 & 0x1f === 8, so this too separates "masked" from "not masked".
+    expect(chunk.classifications![1]).toBe(40);
+  });
+
   it('decodes format-3 RGB points', () => {
     const { header } = buildHeader({
       pointDataFormatId: 3,
@@ -282,6 +377,65 @@ describe('decodeLasPoints', () => {
     const chunk = decodeLasPoints(records, h, 1, 34, 65535 / 255);
     expect(chunk.colors![0]).toBeCloseTo(1.0, 2);
     expect(chunk.colors![1]).toBeCloseTo(128 / 255, 2);
+  });
+});
+
+describe('sampleMaxRgbChannel', () => {
+  // The existing 8-bit-detection test puts the maximum in RED (r=255,
+  // g=128, b=64), so deleting the green and blue comparisons from the
+  // sampler's inner loop survives it — and the whole pointcloud suite. A
+  // sampler that only watches red under-reports the max on any file whose
+  // brightest channel is green or blue, the auto-detect concludes "already
+  // 16-bit", and an 8-bit file renders ~257x too dark.
+  const rgbHeader = () => {
+    const { header } = buildHeader({
+      pointDataFormatId: 3,
+      pointRecordLength: 34,
+      pointCount: 1,
+      scale: [1, 1, 1],
+    });
+    return parseLasHeader(header);
+  };
+
+  it('takes the max over ALL THREE channels, not just red', () => {
+    const h = rgbHeader();
+    // Max in green.
+    expect(
+      sampleMaxRgbChannel(buildFormat3Records([{ x: 0, y: 0, z: 0, r: 10, g: 255, b: 20 }]), h),
+    ).toBe(255);
+    // Max in blue.
+    expect(
+      sampleMaxRgbChannel(buildFormat3Records([{ x: 0, y: 0, z: 0, r: 10, g: 20, b: 255 }]), h),
+    ).toBe(255);
+    // Max in red (the direction the original fixture covered).
+    expect(
+      sampleMaxRgbChannel(buildFormat3Records([{ x: 0, y: 0, z: 0, r: 255, g: 20, b: 10 }]), h),
+    ).toBe(255);
+  });
+
+  it('scans every sampled record, not only the first', () => {
+    // The 16-bit value is on the LAST record: a sampler that stopped early
+    // (or only looked at record 0) would report 200 and mis-classify the
+    // file as 8-bit.
+    const { header } = buildHeader({
+      pointDataFormatId: 3,
+      pointRecordLength: 34,
+      pointCount: 3,
+      scale: [1, 1, 1],
+    });
+    const h = parseLasHeader(header);
+    const records = buildFormat3Records([
+      { x: 0, y: 0, z: 0, r: 100, g: 100, b: 100 },
+      { x: 0, y: 0, z: 0, r: 200, g: 200, b: 200 },
+      { x: 0, y: 0, z: 0, r: 0, g: 40000, b: 0 },
+    ]);
+    expect(sampleMaxRgbChannel(records, h)).toBe(40000);
+  });
+
+  it('returns 0 for a format with no RGB rather than reading past the record', () => {
+    const { header } = buildHeader({ pointDataFormatId: 0, pointRecordLength: 20, pointCount: 1 });
+    const h = parseLasHeader(header);
+    expect(sampleMaxRgbChannel(buildFormat0Records([{ x: 0, y: 0, z: 0 }]), h)).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Summary

Round 2 of the self-audit of our own merged `test(...)` PRs. Six PRs sampled (none overlapping round 1): **#2151** (renderer), **#2150** (codegen), **#2145** (query/lens), **#2139** (cache/encoding/sdk/server-client), **#2135** (parser), **#2141** (collab/pointcloud).

**23 mutations applied, 19 killed, 4 survived.** All four survivors sit in files #2141 swept, and no production defect was found. Test files only — no production code changed, no changeset.

## Discrimination table

| PR | Test / property | Mutation | Result |
|---|---|---|---|
| #2151 | `projectedAabbRadiusPx` "uses view DEPTH, not Euclidean distance" | dot product → `Math.sqrt(cx²+cy²+cz²)` | KILLED (3 tests) |
| #2151 | "fails open at exactly depth === radius" | `depth <= radius` → `depth < radius` | KILLED |
| #2151 | "picks the nearest corner on EVERY axis" | `nx = viewDir.x >= 0 ? min : max` → `nx = unionMin[0]` | KILLED |
| #2151 | "ortho: Infinity (not NaN) on poisoned radius" | drop `!Number.isFinite(maxOccRadius)` guard | KILLED |
| #2151 | `selectEvictions` "stops the moment the excess is exactly met" | `excess <= 0` → `excess < 0` | KILLED |
| #2151 | `selectEvictions` min-age rule | `>= minAgeFrames` → `> minAgeFrames` | KILLED (2 tests) |
| #2150 | crc32 spec vectors (independent bit-at-a-time reference) | poly `0xedb88320` → `0xedb88321` | KILLED (5 tests) |
| #2150 | crc32 case-insensitivity contract | drop `str.toUpperCase()` | KILLED (5 tests) |
| #2150 | `findCollisions` "detects a deliberately-colliding pair" | `nameList.length > 1` → `> 2` | KILLED |
| #2135 | `detectSchemaVersion` ladder ORDER | swap the IFC4X3 and IFC4 lines | KILLED |
| #2135 | default fallback arm | `return 'IFC4'` → `return 'IFC2X3'` | KILLED |
| #2135 | header scan window | `Math.min(len, 2000)` → `Math.min(len, 60)` | KILLED (3 tests) |
| #2145 | `discoverDataSources` "budgets each type separately" | per-type counter → store-wide `sampleIds.length` | KILLED |
| #2145 | sampling cap boundary | `count < SAMPLE_SIZE` → `count <= SAMPLE_SIZE` | KILLED |
| #2145 | "prefers `getMaterialNames()` over `getMaterialName()`" (#1366) | invert the preference | KILLED |
| #2139 | parse-stream tail-buffer terminal check | drop `\|\| tail.type === 'error'` | KILLED |
| #2139 | "throws when the stream ends before a terminal event" | remove the `if (!terminated) throw` | KILLED (2 tests) |
| #2141 | LAS 1.4 exact-version count | `versionMinor >= 4` → `> 4` | KILLED |
| #2141 | `seedFromIfcx` reset clears entities | drop `ents.clear()` | KILLED |
| #2141 | `seedFromIfcx` **default** reset arm | `if (opts.reset)` → `if (opts.reset !== false)` | **SURVIVED** |
| #2141 | legacy classification masking | drop `& 0x1f` | **SURVIVED** |
| #2141 | format 6–10 classification offset | `formatId >= 6 ? 16 : 15` → `15` | **SURVIVED** |
| #2141 | `sampleMaxRgbChannel` "detects 8-bit-in-low-byte RGB" | delete the green and blue comparisons | **SURVIVED** |

Every "SURVIVED" row was re-checked against the whole package suite (`packages/pointcloud`: 16 files / 134 passed; `packages/collab`: 41 files / 173 passed), not just the one test file.

## The four survivors

### 1. `seedFromIfcx` — the default arm was never exercised

`from-ifcx-reset.test.ts` pins `reset: true` and `reset: false`, both passed **explicitly**. `opts.reset` absent is a third arm and it was unpinned, so widening the guard to `if (opts.reset !== false)` survives all 41 collab test files.

That arm is the one production uses. `apps/viewer/src/store/slices/collabSlice.ts:597` seeds an **already-live** session doc with `seedFromIfcx(session.doc, bytes)`, and `packages/collab/src/snapshot/worker.ts:92` calls `seedFromIfcx(doc, file)`. Under the mutant both wipe the doc they were asked to seed into — silent data loss that every peer converges on.

New test drives both routes to "absent": no third argument at all, and an explicitly empty `{}` (the default lives in the `opts.reset` read, not in the `= {}` parameter default).

### 2. `& 0x1f` on the legacy classification byte

Every fixture in `las.test.ts` stored a classification below 32 with the high three bits of byte 15 at zero, which makes the mask an **identity on every input the suite feeds it**. Deleting it survived the whole package.

Formats 0–5 pack synthetic (0x20) / key-point (0x40) / withheld (0x80) into those bits, and real producers set them. A withheld ground point is byte 15 = `0x82` and decodes as class **130** without the mask — every classification colour ramp and filter misses it.

New test uses four flag/class combinations and asserts each individually (a mask that dropped only some of the flag bits would still satisfy a whole-array comparison against one wrong value), including class 31 with all three flags set to pin the mask from the other side — it must keep all five class bits, not narrow the field further.

### 3. Formats 6–10 were never decoded

No fixture ever built a format ≥ 6 record, so `classOffset = formatId >= 6 ? 16 : 15` collapsed to a constant `15` survives, and so does always applying `& 0x1f` (LAS 1.4 extended classification is a full unmasked byte, classes 0..255 are legal). New `buildFormat6Records` helper plus a test that reads class 200 out of byte 16 while byte 15 holds a decoy value of 7, and a second row using class 40 — `40 & 0x1f === 8`, so it separates "masked" from "not masked" independently of the first row.

### 4. `sampleMaxRgbChannel` only had its red channel pinned

The existing 8-bit-detection test uses `r=255, g=128, b=64` — the maximum is in **red**, so deleting the green and blue comparisons from the sampler's inner loop survives it, and the whole suite. A red-only sampler under-reports the max on any file whose brightest channel is green or blue; the auto-detect then concludes "already 16-bit" and an 8-bit file renders ~257x too dark.

New tests put the max in green, in blue, and in red; put a 16-bit value on the **last** record (so a sampler that stops early is visible); and pin the no-RGB early return.

## Method

Per mutation: `python3` exact-substring replacement with the replacement count asserted `== 1`, the mutated region re-read and confirmed changed before believing any result, then restored by copying back a backup taken **before** the file's first mutation (never `git checkout --`). Each new test was confirmed RED under its stated mutation and GREEN after restore.

## Test plan

- [x] `packages/pointcloud`: 16 files / 134 passed → 16 files / **139 passed**
- [x] `packages/collab`: 41 files / 173 passed → 41 files / **174 passed**
- [x] Each of the 4 survivors' mutations re-applied against the new tests and confirmed to fail; restored by file copy; green again
- [x] `turbo typecheck --filter=@ifc-lite/pointcloud --filter=@ifc-lite/collab`
- [x] No production code changed — test files only, no changeset

🤖 Generated with [Claude Code](https://claude.com/claude-code)
