### PR TITLE
test(geometry): close 16 mutation-verified gaps in the coordinate and shard-decoder paths

### DIFF
--- a/packages/geometry/src/geometry-coordinate.test.ts
+++ b/packages/geometry/src/geometry-coordinate.test.ts
@@ -1,0 +1,384 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Streaming batch sizing + WASM MeshCollection → MeshData conversion.
+ *
+ * `convertMeshCollectionToBatch` is the single-threaded mesh-extraction path
+ * (`index.ts`); everything it drops on the floor — a per-element origin, a
+ * local box, a placement matrix, a texture — is lost silently, showing up only
+ * as geometry in the wrong place or shaded wrong.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+import {
+  getStreamingBatchSize,
+  convertMeshCollectionToBatch,
+  withBuildingRotation,
+} from './geometry-coordinate.js';
+import type { CoordinateInfo } from './types.js';
+
+describe('getStreamingBatchSize', () => {
+  const buffer = new Uint8Array(0);
+
+  it('returns a numeric config verbatim, ignoring the buffer', () => {
+    expect(getStreamingBatchSize(new Uint8Array(500 * 1024 * 1024), 7)).toBe(7);
+  });
+
+  // Every bracket asserted with a value on each side of its boundary — a
+  // single sample per bracket lets one lucky case carry the whole ladder.
+  it.each([
+    [0, 100],
+    [9.9, 100],
+    [10, 200],
+    [49.9, 200],
+    [50, 300],
+    [99.9, 300],
+    [100, 500],
+    [299.9, 500],
+    [300, 1500],
+    [499.9, 1500],
+    [500, 3000],
+    [5000, 3000],
+  ])('maps %s MB to a batch of %s', (fileSizeMB, expected) => {
+    expect(getStreamingBatchSize(buffer, { fileSizeMB })).toBe(expected);
+  });
+
+  it('derives the file size from the buffer when the config omits it', () => {
+    // 60 MB → the 50–100 MB bracket.
+    expect(getStreamingBatchSize(new Uint8Array(60 * 1024 * 1024), {})).toBe(300);
+  });
+
+  it('treats a zero fileSizeMB as absent and measures the buffer', () => {
+    // `fileSizeMB: 0` is falsy, so the buffer length decides: 200 MB → 500.
+    expect(
+      getStreamingBatchSize(new Uint8Array(200 * 1024 * 1024), { fileSizeMB: 0 })
+    ).toBe(500);
+  });
+});
+
+describe('withBuildingRotation', () => {
+  const base: CoordinateInfo = {
+    originShift: { x: 0, y: 0, z: 0 },
+    originalBounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 1, y: 1, z: 1 } },
+    shiftedBounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 1, y: 1, z: 1 } },
+    hasLargeCoordinates: false,
+  };
+
+  it('attaches the rotation without mutating the input', () => {
+    const out = withBuildingRotation(base, 1.25);
+
+    expect(out.buildingRotation).toBe(1.25);
+    expect(out).not.toBe(base);
+    expect(base).not.toHaveProperty('buildingRotation');
+  });
+
+  // Zero is a meaningful rotation (explicitly north-aligned) and is falsy;
+  // only `undefined` means "not resolved".
+  it('attaches a zero rotation', () => {
+    expect(withBuildingRotation(base, 0).buildingRotation).toBe(0);
+  });
+
+  it('returns the input untouched when the rotation is undefined', () => {
+    expect(withBuildingRotation(base, undefined)).toBe(base);
+  });
+});
+
+// ── convertMeshCollectionToBatch ──
+
+interface FakeMesh {
+  expressId: number;
+  ifcType: string;
+  positions: Float32Array;
+  normals: Float32Array;
+  indices: Uint32Array;
+  color: Float32Array;
+  free: () => void;
+  [k: string]: unknown;
+}
+
+function fakeMesh(overrides: Partial<FakeMesh> & { expressId: number }): FakeMesh {
+  return {
+    ifcType: 'IfcWall',
+    positions: new Float32Array([0, 0, 0]),
+    normals: new Float32Array([0, 0, 1]),
+    indices: new Uint32Array([0]),
+    color: new Float32Array([1, 1, 1, 1]),
+    free: vi.fn(),
+    ...overrides,
+  } as FakeMesh;
+}
+
+function fakeCollection(meshes: (FakeMesh | null)[], extra: Record<string, unknown> = {}) {
+  return {
+    length: meshes.length,
+    get: (i: number) => meshes[i],
+    free: vi.fn(),
+    ...extra,
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const asCollection = (c: unknown) => c as any;
+
+describe('convertMeshCollectionToBatch', () => {
+  it('frees every mesh and the collection itself', () => {
+    const meshes = [fakeMesh({ expressId: 1 }), fakeMesh({ expressId: 2 })];
+    const collection = fakeCollection(meshes);
+
+    convertMeshCollectionToBatch(asCollection(collection));
+
+    expect(meshes[0].free).toHaveBeenCalledTimes(1);
+    expect(meshes[1].free).toHaveBeenCalledTimes(1);
+    expect(collection.free).toHaveBeenCalledTimes(1);
+  });
+
+  it('frees the collection even when a mesh getter throws', () => {
+    const collection = fakeCollection([], {
+      length: 1,
+      get: () => {
+        throw new Error('boom');
+      },
+    });
+
+    expect(() => convertMeshCollectionToBatch(asCollection(collection))).toThrow('boom');
+    expect(collection.free).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips null mesh slots', () => {
+    const batch = convertMeshCollectionToBatch(
+      asCollection(fakeCollection([null, fakeMesh({ expressId: 9 })]))
+    );
+
+    expect(batch.map((m) => m.expressId)).toEqual([9]);
+  });
+
+  it('copies the colour out of the WASM view into a plain tuple', () => {
+    const color = new Float32Array([0.1, 0.2, 0.3, 0.4]);
+    const batch = convertMeshCollectionToBatch(
+      asCollection(fakeCollection([fakeMesh({ expressId: 1, color })]))
+    );
+
+    expect(batch[0].color).toEqual([
+      color[0], color[1], color[2], color[3],
+    ]);
+    expect(Array.isArray(batch[0].color)).toBe(true);
+  });
+
+  // The origin guard is `originArr[0] || originArr[1] || originArr[2]` — ANY
+  // non-zero component means the element has a local frame. Requiring all
+  // three (a plausible slip) drops every axis-aligned origin, and the geometry
+  // then renders at the world origin instead of its placement.
+  it.each([
+    [[0, 0, 5000], [0, 0, 5000]],
+    [[5000, 0, 0], [5000, 0, 0]],
+    [[0, 5000, 0], [0, 5000, 0]],
+    [[1, 2, 3], [1, 2, 3]],
+  ])('keeps a local origin with only some axes set: %j', (origin, expected) => {
+    const batch = convertMeshCollectionToBatch(
+      asCollection(fakeCollection([fakeMesh({ expressId: 1, origin })]))
+    );
+
+    expect(batch[0].origin).toEqual(expected);
+  });
+
+  it('omits an all-zero origin (absolute positions)', () => {
+    const batch = convertMeshCollectionToBatch(
+      asCollection(fakeCollection([fakeMesh({ expressId: 1, origin: [0, 0, 0] })]))
+    );
+
+    expect(batch[0].origin).toBeUndefined();
+  });
+
+  it('omits the origin when the getter is absent or the wrong arity', () => {
+    const batch = convertMeshCollectionToBatch(
+      asCollection(
+        fakeCollection([
+          fakeMesh({ expressId: 1 }),
+          fakeMesh({ expressId: 2, origin: [1, 2] }),
+        ])
+      )
+    );
+
+    expect(batch[0].origin).toBeUndefined();
+    expect(batch[1].origin).toBeUndefined();
+  });
+
+  it('carries the local bounds split at min/max, and only at full arity', () => {
+    const batch = convertMeshCollectionToBatch(
+      asCollection(
+        fakeCollection([
+          fakeMesh({ expressId: 1, localBounds: [-1, -2, -3, 4, 5, 6] }),
+          fakeMesh({ expressId: 2, localBounds: [-1, -2, -3, 4, 5] }),
+        ])
+      )
+    );
+
+    expect(batch[0].localBounds).toEqual({ min: [-1, -2, -3], max: [4, 5, 6] });
+    expect(batch[1].localBounds).toBeUndefined();
+  });
+
+  it('carries a 16-element placement matrix as a plain array, in order', () => {
+    const m = Array.from({ length: 16 }, (_, i) => i + 1);
+    const batch = convertMeshCollectionToBatch(
+      asCollection(
+        fakeCollection([
+          fakeMesh({ expressId: 1, localToWorld: new Float32Array(m) }),
+          fakeMesh({ expressId: 2, localToWorld: new Float32Array(15) }),
+        ])
+      )
+    );
+
+    expect(batch[0].localToWorld).toEqual(m);
+    expect(batch[1].localToWorld).toBeUndefined();
+  });
+
+  it('defaults the geometry class to 0 (Model) when the getter is absent', () => {
+    const batch = convertMeshCollectionToBatch(
+      asCollection(
+        fakeCollection([
+          fakeMesh({ expressId: 1 }),
+          fakeMesh({ expressId: 2, geometryClass: 1 }),
+        ])
+      )
+    );
+
+    expect(batch[0].geometryClass).toBe(0);
+    expect(batch[1].geometryClass).toBe(1);
+  });
+
+  it('carries a four-component shading colour, and drops a mis-sized one', () => {
+    const batch = convertMeshCollectionToBatch(
+      asCollection(
+        fakeCollection([
+          fakeMesh({ expressId: 1, shadingColor: [0.1, 0.2, 0.3, 0.4] }),
+          fakeMesh({ expressId: 2, shadingColor: [0.1, 0.2, 0.3] }),
+          fakeMesh({ expressId: 3 }),
+        ])
+      )
+    );
+
+    expect(batch[0].shadingColor).toEqual([0.1, 0.2, 0.3, 0.4]);
+    expect(batch[1].shadingColor).toBeUndefined();
+    expect(batch[2].shadingColor).toBeUndefined();
+  });
+
+  it('copies an embedded texture with its uvs and repeat factors', () => {
+    const uvs = new Float32Array([0, 0, 1, 1]);
+    const rgba = new Uint8Array([255, 0, 0, 255]);
+    const batch = convertMeshCollectionToBatch(
+      asCollection(
+        fakeCollection([
+          fakeMesh({
+            expressId: 1,
+            hasTexture: true,
+            uvs,
+            textureRgba: rgba,
+            textureWidth: 1,
+            textureHeight: 1,
+            textureRepeatS: 2,
+            textureRepeatT: 3,
+          }),
+        ])
+      )
+    );
+
+    expect(batch[0].uvs).toBe(uvs);
+    expect(batch[0].texture).toEqual({
+      rgba,
+      width: 1,
+      height: 1,
+      repeatS: 2,
+      repeatT: 3,
+    });
+    expect(batch[0].textureRef).toBeUndefined();
+  });
+
+  it('prefers the embedded texture over an external reference', () => {
+    const batch = convertMeshCollectionToBatch(
+      asCollection(
+        fakeCollection([
+          fakeMesh({
+            expressId: 1,
+            hasTexture: true,
+            uvs: new Float32Array([0, 0]),
+            textureRgba: new Uint8Array([1, 2, 3, 4]),
+            textureWidth: 1,
+            textureHeight: 1,
+            textureRepeatS: 1,
+            textureRepeatT: 1,
+            textureId: 5,
+            textureUrl: 'images/wall.png',
+          }),
+        ])
+      )
+    );
+
+    expect(batch[0].texture).toBeDefined();
+    expect(batch[0].textureRef).toBeUndefined();
+  });
+
+  it('carries an external texture reference when no pixels were decoded', () => {
+    const batch = convertMeshCollectionToBatch(
+      asCollection(
+        fakeCollection([
+          fakeMesh({
+            expressId: 1,
+            uvs: new Float32Array([0, 0]),
+            textureId: 5,
+            textureUrl: 'images/wall.png',
+            textureRepeatS: 4,
+            textureRepeatT: 5,
+          }),
+        ])
+      )
+    );
+
+    expect(batch[0].texture).toBeUndefined();
+    expect(batch[0].textureRef).toEqual({
+      textureId: 5,
+      url: 'images/wall.png',
+      repeatS: 4,
+      repeatT: 5,
+    });
+  });
+
+  it('attaches the per-entity fingerprint, box and volume by express id', () => {
+    const collection = fakeCollection(
+      [fakeMesh({ expressId: 11 }), fakeMesh({ expressId: 22 })],
+      {
+        geometryHashCount: 2,
+        // Deliberately NOT in mesh order, so a positional lookup would mis-attribute.
+        geometryHashIds: new Uint32Array([22, 11]),
+        geometryHashValues: new BigUint64Array([7n, 9n]),
+        geometryAabbValues: new Float64Array([
+          0, 0, 0, 1, 1, 1, // id 22
+          -5, -5, -5, 5, 5, 5, // id 11
+        ]),
+        geometryVolumeValues: new Float64Array([1, 1000]),
+      }
+    );
+
+    const batch = convertMeshCollectionToBatch(asCollection(collection));
+
+    expect(batch[0].expressId).toBe(11);
+    expect(batch[0].geometryHash).toBe(9n);
+    expect(batch[0].geometryAabb).toEqual({ min: [-5, -5, -5], max: [5, 5, 5] });
+    expect(batch[0].geometryVolume).toBe(1000);
+
+    expect(batch[1].geometryHash).toBe(7n);
+    expect(batch[1].geometryVolume).toBe(1);
+  });
+
+  it('leaves fingerprint fields absent when hashing was not enabled', () => {
+    const batch = convertMeshCollectionToBatch(
+      asCollection(fakeCollection([fakeMesh({ expressId: 1 })]))
+    );
+
+    expect(batch[0].geometryHash).toBeUndefined();
+    expect(batch[0].geometryAabb).toBeUndefined();
+    expect(batch[0].geometryVolume).toBeUndefined();
+  });
+});

--- a/packages/geometry/src/geometry-coordinate.test.ts
+++ b/packages/geometry/src/geometry-coordinate.test.ts
@@ -23,8 +23,12 @@ import type { CoordinateInfo } from './types.js';
 describe('getStreamingBatchSize', () => {
   const buffer = new Uint8Array(0);
 
+  // No buffer length can produce 7 — every measured bracket returns one of
+  // 100/200/300/500/1500/3000 — so the assertion, not the buffer's size,
+  // carries the "ignores the buffer" claim. Allocating a large buffer here
+  // would only add memory pressure in parallel workers.
   it('returns a numeric config verbatim, ignoring the buffer', () => {
-    expect(getStreamingBatchSize(new Uint8Array(500 * 1024 * 1024), 7)).toBe(7);
+    expect(getStreamingBatchSize(buffer, 7)).toBe(7);
   });
 
   // Every bracket asserted with a value on each side of its boundary — a
@@ -120,8 +124,9 @@ function fakeCollection(meshes: (FakeMesh | null)[], extra: Record<string, unkno
   };
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const asCollection = (c: unknown) => c as any;
+// The fakes are structural stand-ins for the WASM `MeshCollection`; cast to
+// the parameter's own type (not `any`) so the call site stays type-checked.
+const asCollection = (c: unknown) => c as Parameters<typeof convertMeshCollectionToBatch>[0];
 
 describe('convertMeshCollectionToBatch', () => {
   it('frees every mesh and the collection itself', () => {
@@ -135,7 +140,10 @@ describe('convertMeshCollectionToBatch', () => {
     expect(collection.free).toHaveBeenCalledTimes(1);
   });
 
-  it('frees the collection even when a mesh getter throws', () => {
+  // `collection.get` throws before any mesh exists, so only the outer
+  // `finally { collection.free() }` can run here — the per-mesh cleanup is
+  // covered by the next test.
+  it('frees the collection when the collection getter itself throws', () => {
     const collection = fakeCollection([], {
       length: 1,
       get: () => {
@@ -144,6 +152,26 @@ describe('convertMeshCollectionToBatch', () => {
     });
 
     expect(() => convertMeshCollectionToBatch(asCollection(collection))).toThrow('boom');
+    expect(collection.free).toHaveBeenCalledTimes(1);
+  });
+
+  // The mesh IS handed out and then throws mid-conversion: without the inner
+  // `finally { mesh.free() }` the WASM mesh leaks on every partial failure,
+  // and the collection-level free below would not catch it.
+  it('frees the mesh AND the collection when a mesh getter throws mid-conversion', () => {
+    const free = vi.fn();
+    const mesh = {
+      ...fakeMesh({ expressId: 1 }),
+      free,
+      // `color` is read after the mesh is in hand but before it is pushed.
+      get color(): Float32Array {
+        throw new Error('mesh boom');
+      },
+    };
+    const collection = fakeCollection([], { length: 1, get: () => mesh });
+
+    expect(() => convertMeshCollectionToBatch(asCollection(collection))).toThrow('mesh boom');
+    expect(free).toHaveBeenCalledTimes(1);
     expect(collection.free).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/geometry/src/geometry.test.ts
+++ b/packages/geometry/src/geometry.test.ts
@@ -154,6 +154,83 @@ describe('CoordinateHandler', () => {
       expect(bounds.max.y).toBe(10);
       expect(bounds.max.z).toBe(10);
     });
+
+    // Every other bounds fixture leaves `origin` absent, so the per-element
+    // local-frame fold (`world = origin + position`) is exercised by nothing:
+    // dropping `+ ox/oy/oz` leaves them all green. Without the fold, a model
+    // whose elements each carry their own origin collapses to a box around
+    // zero and the viewer fits the camera on the wrong volume.
+    it('folds each mesh origin into world bounds', () => {
+      const meshes = [
+        createTestMesh({
+          expressId: 1,
+          positions: new Float32Array([0, 0, 0, 1, 2, 3]),
+          origin: [100, 200, 300],
+        }),
+        createTestMesh({
+          expressId: 2,
+          positions: new Float32Array([0, 0, 0, 1, 1, 1]),
+          origin: [-40, -50, -60],
+        }),
+      ];
+
+      const bounds = handler.calculateBounds(meshes);
+
+      expect(bounds.min).toEqual({ x: -40, y: -50, z: -60 });
+      expect(bounds.max).toEqual({ x: 101, y: 202, z: 303 });
+    });
+
+    // Distinct per-axis origins: an implementation that folded ox into all
+    // three axes (or reused one component) still passes an isotropic fixture.
+    it('applies the origin components axis-by-axis', () => {
+      const meshes = [
+        createTestMesh({
+          expressId: 1,
+          positions: new Float32Array([0, 0, 0]),
+          origin: [7, 11, 13],
+        }),
+      ];
+
+      const bounds = handler.calculateBounds(meshes);
+
+      expect(bounds.min).toEqual({ x: 7, y: 11, z: 13 });
+      expect(bounds.max).toEqual({ x: 7, y: 11, z: 13 });
+    });
+  });
+
+  describe('shiftPositions', () => {
+    it('subtracts the shift per axis', () => {
+      const positions = new Float32Array([10, 20, 30, 40, 50, 60]);
+
+      handler.shiftPositions(positions, { x: 1, y: 2, z: 3 });
+
+      expect(Array.from(positions)).toEqual([9, 18, 27, 39, 48, 57]);
+    });
+
+    // The corrupted-vertex clamp: deleting the whole `else` branch (leaving
+    // garbage in place) passed the suite. A NaN or 1e30 vertex reaching the GPU
+    // buffer explodes the mesh's bounding box and can blank the whole model.
+    it('clamps non-finite and out-of-range vertices to the shifted origin', () => {
+      const positions = new Float32Array([
+        1, 2, 3, // valid
+        NaN, 0, 0, // non-finite
+        1e8, 1e8, 1e8, // beyond MAX_REASONABLE_COORD
+      ]);
+
+      handler.shiftPositions(positions, { x: 1, y: 1, z: 1 });
+
+      expect(Array.from(positions.subarray(0, 3))).toEqual([0, 1, 2]);
+      expect(Array.from(positions.subarray(3, 6))).toEqual([0, 0, 0]);
+      expect(Array.from(positions.subarray(6, 9))).toEqual([0, 0, 0]);
+    });
+
+    it('honours an explicit tighter threshold', () => {
+      const positions = new Float32Array([50000, 0, 0]);
+
+      handler.shiftPositions(positions, { x: 0, y: 0, z: 0 }, 10000);
+
+      expect(Array.from(positions)).toEqual([0, 0, 0]);
+    });
   });
 
   describe('needsShift', () => {
@@ -173,6 +250,33 @@ describe('CoordinateHandler', () => {
       };
 
       expect(handler.needsShift(bounds)).toBe(true);
+    });
+
+    // The comparison is strictly `>`; both existing cases sit far from the
+    // 10 km threshold, so `>` vs `>=` was indistinguishable.
+    it('treats exactly the 10km threshold as not needing a shift', () => {
+      expect(
+        handler.needsShift({
+          min: { x: 0, y: 0, z: 0 },
+          max: { x: 10000, y: 0, z: 0 },
+        })
+      ).toBe(false);
+
+      expect(
+        handler.needsShift({
+          min: { x: 0, y: 0, z: 0 },
+          max: { x: 10000.5, y: 0, z: 0 },
+        })
+      ).toBe(true);
+    });
+
+    it('considers the most negative extent, not just the maxima', () => {
+      expect(
+        handler.needsShift({
+          min: { x: 0, y: -50000, z: 0 },
+          max: { x: 1, y: 1, z: 1 },
+        })
+      ).toBe(true);
     });
   });
 
@@ -220,6 +324,24 @@ describe('CoordinateHandler', () => {
 
       expect(info.hasLargeCoordinates).toBe(false);
       expect(info.originShift.x).toBe(0);
+    });
+
+    // The no-shift branch still runs a zero-shift pass purely to scrub
+    // corrupted vertices. Nothing asserted that, so removing the scrub — the
+    // only thing that branch does — stayed green.
+    it('scrubs corrupted vertices even when no shift is needed', () => {
+      const meshes = [
+        createTestMesh({
+          expressId: 1,
+          positions: new Float32Array([1, 2, 3, NaN, 5, 6, 1e9, 0, 0]),
+        }),
+      ];
+
+      const info = handler.processMeshes(meshes);
+
+      expect(info.hasLargeCoordinates).toBe(false);
+      // Valid vertex untouched (zero shift), corrupted ones collapsed to 0.
+      expect(Array.from(meshes[0].positions)).toEqual([1, 2, 3, 0, 0, 0, 0, 0, 0]);
     });
   });
 
@@ -301,6 +423,139 @@ describe('CoordinateHandler', () => {
       expect(info.originShift).toEqual({ x: 0, y: 0, z: 0 });
       expect(info.originalBounds.min.x).toBe(-20);
       expect(info.originalBounds.max.z).toBe(310);
+    });
+
+    // The trusted path resets `originShift` to zero. Every existing trusted
+    // test starts from a fresh handler where the shift is ALREADY zero, so the
+    // reset was a no-op in the fixture and deleting the line stayed green.
+    // In production the trusted path can follow a shifted browser batch.
+    it('clears a shift established by an earlier non-trusted batch', () => {
+      handler.processMeshesIncremental([
+        createTestMesh({
+          expressId: 1,
+          positions: new Float32Array([500000, 5000000, 100, 500100, 5000100, 150]),
+        }),
+      ]);
+      // Precondition: the browser path did establish a non-zero shift.
+      expect(handler.getOriginShift()).not.toEqual({ x: 0, y: 0, z: 0 });
+
+      handler.processTrustedMeshesIncremental([
+        createTestMesh({
+          expressId: 2,
+          positions: new Float32Array([1, 2, 3, 4, 5, 6]),
+        }),
+      ]);
+
+      expect(handler.getOriginShift()).toEqual({ x: 0, y: 0, z: 0 });
+      expect(handler.getFinalCoordinateInfo().hasLargeCoordinates).toBe(false);
+    });
+
+    // The shift trigger is `distanceFromOrigin > 10km OR maxSize > 10km`.
+    // Every fixture was far from the origin, so the extent half of the OR was
+    // dead weight: a 40km-wide site straddling the origin never got shifted
+    // and keeps float precision loss across the whole model.
+    it('shifts a model that straddles the origin but spans more than 10km', () => {
+      handler.processMeshesIncremental([
+        createTestMesh({
+          expressId: 1,
+          positions: new Float32Array([-20000, -20000, 0, 21000, 21000, 10]),
+        }),
+      ]);
+
+      const shift = handler.getOriginShift();
+      expect(shift.x).toBeCloseTo(500, 6);
+      expect(shift.y).toBeCloseTo(500, 6);
+      expect(handler.getFinalCoordinateInfo().hasLargeCoordinates).toBe(true);
+    });
+
+    // WASM-RTC detection is "> 50% of meshes have a small first vertex".
+    // A 1-of-2 batch sits exactly ON the boundary: `>` must NOT fire, so the
+    // shift is still applied. `>=` there would silently suppress the shift.
+    it('does not claim WASM RTC on an exact 50/50 split', () => {
+      handler.processMeshesIncremental([
+        createTestMesh({
+          expressId: 1,
+          positions: new Float32Array([0, 0, 0, 1, 1, 1]), // small first vertex
+        }),
+        createTestMesh({
+          expressId: 2,
+          positions: new Float32Array([500000, 5000000, 0, 500010, 5000010, 5]),
+        }),
+      ]);
+
+      expect(handler.getOriginShift()).not.toEqual({ x: 0, y: 0, z: 0 });
+      expect(handler.getFinalCoordinateInfo().hasLargeCoordinates).toBe(true);
+    });
+
+    it('claims WASM RTC once a clear majority of meshes are small, and skips the shift', () => {
+      handler.processMeshesIncremental([
+        createTestMesh({ expressId: 1, positions: new Float32Array([0, 0, 0, 1, 1, 1]) }),
+        createTestMesh({ expressId: 2, positions: new Float32Array([2, 2, 2, 3, 3, 3]) }),
+        createTestMesh({
+          expressId: 3,
+          positions: new Float32Array([500000, 5000000, 0, 500010, 5000010, 5]),
+        }),
+      ]);
+
+      expect(handler.getOriginShift()).toEqual({ x: 0, y: 0, z: 0 });
+      // Bounds are recomputed at the 10km threshold, dropping the outlier.
+      expect(handler.getFinalCoordinateInfo().originalBounds.max.x).toBe(3);
+    });
+
+    // Once RTC is confirmed, later batches deliberately take the SAMPLED
+    // bounds path (first + last vertex only) — a documented ~150x speedup.
+    // Nothing pinned it, so replacing the guard with a full per-vertex scan
+    // stayed green while costing that speedup.
+    it('samples first and last vertex only once WASM RTC is confirmed', () => {
+      handler.processMeshesIncremental([
+        createTestMesh({ expressId: 1, positions: new Float32Array([0, 0, 0, 1, 1, 1]) }),
+      ]);
+
+      handler.processMeshesIncremental([
+        createTestMesh({
+          expressId: 2,
+          // Interior vertex is the extreme one; the sampled path must miss it.
+          positions: new Float32Array([2, 0, 0, 900, 0, 0, 4, 0, 0]),
+        }),
+      ]);
+
+      expect(handler.getFinalCoordinateInfo().originalBounds.max.x).toBe(4);
+    });
+  });
+
+  describe('trusted (native) bounds sampling', () => {
+    // calculateBoundsFast folds each mesh origin too; every trusted fixture
+    // left `origin` absent, so dropping the fold there was also invisible.
+    it('folds each mesh origin into the sampled bounds', () => {
+      handler.processTrustedMeshesIncremental([
+        createTestMesh({
+          expressId: 1,
+          positions: new Float32Array([0, 0, 0, 1, 2, 3]),
+          origin: [1000, 2000, 3000],
+        }),
+      ]);
+
+      const info = handler.getFinalCoordinateInfo();
+      expect(info.originalBounds.min).toEqual({ x: 1000, y: 2000, z: 3000 });
+      expect(info.originalBounds.max).toEqual({ x: 1001, y: 2002, z: 3003 });
+    });
+
+    it('skips meshes with fewer than three position components', () => {
+      handler.processTrustedMeshesIncremental([
+        createTestMesh({ expressId: 1, positions: new Float32Array([]) }),
+        createTestMesh({ expressId: 2, positions: new Float32Array([5, 6, 7]) }),
+      ]);
+
+      const info = handler.getFinalCoordinateInfo();
+      expect(info.originalBounds.min).toEqual({ x: 5, y: 6, z: 7 });
+    });
+
+    it('returns no info when a batch yields no valid bounds', () => {
+      handler.processTrustedMeshesIncremental([
+        createTestMesh({ expressId: 1, positions: new Float32Array([]) }),
+      ]);
+
+      expect(handler.getCurrentCoordinateInfo()).toBeNull();
     });
   });
 

--- a/packages/geometry/src/packed-geometry-decoder.test.ts
+++ b/packages/geometry/src/packed-geometry-decoder.test.ts
@@ -1,0 +1,245 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Packed geometry cache shard decoder.
+ *
+ * The shard is produced by the native Rust pipeline and consumed by
+ * `native-bridge.ts`; a stride or offset disagreement between the two ends is
+ * silent — the renderer just draws the wrong vertices onto the wrong element.
+ * The fixture below is written from the FORMAT SPEC (the layout documented on
+ * `decodePackedGeometryCacheShard`), not from the decoder, so the two are
+ * independent statements of the same contract.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  decodePackedGeometryCacheShard,
+  toArrayBuffer,
+} from './packed-geometry-decoder.js';
+
+const MAGIC = 0x49464342;
+const HEADER_WORDS = 8;
+const MESH_RECORD_WORDS = 11;
+
+interface MeshRecord {
+  expressId: number;
+  posOff: number;
+  posLen: number;
+  nrmOff: number;
+  nrmLen: number;
+  idxOff: number;
+  idxLen: number;
+  color: [number, number, number, number];
+}
+
+/** Independent encoder, written from the documented layout. */
+function encodeShard(opts: {
+  magic?: number;
+  version?: number;
+  processed?: number;
+  total?: number;
+  meshes: MeshRecord[];
+  positions: number[];
+  normals: number[];
+  indices: number[];
+}): Uint8Array {
+  const { meshes, positions, normals, indices } = opts;
+  const headerBytes = HEADER_WORDS * 4;
+  const tableBytes = meshes.length * MESH_RECORD_WORDS * 4;
+  const dataBytes = (positions.length + normals.length + indices.length) * 4;
+  const buf = new ArrayBuffer(headerBytes + tableBytes + dataBytes);
+  const view = new DataView(buf);
+
+  const header = [
+    opts.magic ?? MAGIC,
+    opts.version ?? 1,
+    meshes.length,
+    positions.length,
+    normals.length,
+    indices.length,
+    opts.processed ?? 0,
+    opts.total ?? 0,
+  ];
+  header.forEach((w, i) => view.setUint32(i * 4, w, true));
+
+  meshes.forEach((m, i) => {
+    const base = headerBytes + i * MESH_RECORD_WORDS * 4;
+    view.setUint32(base, m.expressId, true);
+    view.setUint32(base + 4, m.posOff, true);
+    view.setUint32(base + 8, m.posLen, true);
+    view.setUint32(base + 12, m.nrmOff, true);
+    view.setUint32(base + 16, m.nrmLen, true);
+    view.setUint32(base + 20, m.idxOff, true);
+    view.setUint32(base + 24, m.idxLen, true);
+    m.color.forEach((c, k) => view.setFloat32(base + 28 + k * 4, c, true));
+  });
+
+  let cursor = headerBytes + tableBytes;
+  positions.forEach((v) => {
+    view.setFloat32(cursor, v, true);
+    cursor += 4;
+  });
+  normals.forEach((v) => {
+    view.setFloat32(cursor, v, true);
+    cursor += 4;
+  });
+  indices.forEach((v) => {
+    view.setUint32(cursor, v, true);
+    cursor += 4;
+  });
+
+  return new Uint8Array(buf);
+}
+
+// Two meshes with DIFFERENT, non-zero pool offsets and DIFFERENT lengths, so
+// neither the mesh-table stride nor the positions/normals/indices section
+// offsets can be got right by accident. Values are distinguishable per slot.
+const POSITIONS = [
+  1, 2, 3, 4, 5, 6, // mesh A (2 verts)
+  10, 20, 30, 40, 50, 60, 70, 80, 90, // mesh B (3 verts)
+];
+const NORMALS = [
+  0, 0, 1, 0, 1, 0, // mesh A
+  1, 0, 0, 0, 0, -1, 0, -1, 0, // mesh B
+];
+const INDICES = [0, 1, 0, /* mesh A */ 0, 1, 2 /* mesh B */];
+
+const FIXTURE = encodeShard({
+  processed: 7,
+  total: 42,
+  meshes: [
+    {
+      expressId: 101,
+      posOff: 0,
+      posLen: 6,
+      nrmOff: 0,
+      nrmLen: 6,
+      idxOff: 0,
+      idxLen: 3,
+      color: [0.25, 0.5, 0.75, 1],
+    },
+    {
+      expressId: 202,
+      posOff: 6,
+      posLen: 9,
+      nrmOff: 6,
+      nrmLen: 9,
+      idxOff: 3,
+      idxLen: 3,
+      color: [1, 0, 0.5, 0.25],
+    },
+  ],
+  positions: POSITIONS,
+  normals: NORMALS,
+  indices: INDICES,
+});
+
+describe('toArrayBuffer', () => {
+  it('returns an ArrayBuffer payload unchanged', () => {
+    const ab = new ArrayBuffer(8);
+    expect(toArrayBuffer(ab)).toBe(ab);
+  });
+
+  it('unwraps a whole-buffer Uint8Array without copying', () => {
+    const u8 = new Uint8Array([1, 2, 3, 4]);
+    expect(toArrayBuffer(u8)).toBe(u8.buffer);
+  });
+
+  it('copies a Uint8Array that is only a window onto its buffer', () => {
+    const backing = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
+    const window = backing.subarray(2, 6);
+
+    const out = toArrayBuffer(window);
+
+    expect(out).not.toBe(backing.buffer);
+    expect(out.byteLength).toBe(4);
+    expect(Array.from(new Uint8Array(out))).toEqual([3, 4, 5, 6]);
+  });
+
+  it('accepts a plain number array', () => {
+    expect(Array.from(new Uint8Array(toArrayBuffer([9, 8, 7])))).toEqual([9, 8, 7]);
+  });
+
+  it('rejects an unsupported payload', () => {
+    expect(() => toArrayBuffer('nope')).toThrow(/Unsupported packed geometry shard payload/);
+  });
+});
+
+describe('decodePackedGeometryCacheShard', () => {
+  it('splits the pools at the documented mesh-table stride and section offsets', () => {
+    const batch = decodePackedGeometryCacheShard(FIXTURE, 1234, 5);
+
+    expect(batch.meshes).toHaveLength(2);
+
+    const [a, b] = batch.meshes;
+    expect(a.expressId).toBe(101);
+    expect(Array.from(a.positions)).toEqual([1, 2, 3, 4, 5, 6]);
+    expect(Array.from(a.normals)).toEqual([0, 0, 1, 0, 1, 0]);
+    expect(Array.from(a.indices)).toEqual([0, 1, 0]);
+    expect(a.color).toEqual([0.25, 0.5, 0.75, 1]);
+
+    // Mesh B reads from a non-zero offset in every pool AND has a different
+    // length from mesh A, so a wrong stride or a collapsed section offset
+    // cannot produce these values.
+    expect(b.expressId).toBe(202);
+    expect(Array.from(b.positions)).toEqual([10, 20, 30, 40, 50, 60, 70, 80, 90]);
+    expect(Array.from(b.normals)).toEqual([1, 0, 0, 0, 0, -1, 0, -1, 0]);
+    expect(Array.from(b.indices)).toEqual([0, 1, 2]);
+    expect(b.color).toEqual([1, 0, 0.5, 0.25]);
+  });
+
+  it('carries the progress counters and native telemetry', () => {
+    const batch = decodePackedGeometryCacheShard(FIXTURE, 1234, 5);
+
+    expect(batch.progress).toEqual({ processed: 7, total: 42, currentType: 'cached' });
+    expect(batch.nativeTelemetry).toMatchObject({
+      batchSequence: 5,
+      payloadKind: 'packed-cache-shard',
+      meshCount: 2,
+      positionsLen: POSITIONS.length,
+      normalsLen: NORMALS.length,
+      indicesLen: INDICES.length,
+      jsReceivedTimeMs: 1234,
+    });
+  });
+
+  it('decodes an empty shard', () => {
+    const empty = encodeShard({ meshes: [], positions: [], normals: [], indices: [] });
+
+    const batch = decodePackedGeometryCacheShard(empty, 0, 0);
+
+    expect(batch.meshes).toEqual([]);
+    expect(batch.progress.total).toBe(0);
+  });
+
+  it('rejects a payload whose magic is not the shard magic', () => {
+    const bad = encodeShard({
+      magic: 0xdeadbeef,
+      meshes: [],
+      positions: [],
+      normals: [],
+      indices: [],
+    });
+
+    expect(() => decodePackedGeometryCacheShard(bad, 0, 0)).toThrow(
+      /Invalid packed geometry cache shard magic/
+    );
+  });
+
+  it('rejects an unsupported format version', () => {
+    const bad = encodeShard({
+      version: 2,
+      meshes: [],
+      positions: [],
+      normals: [],
+      indices: [],
+    });
+
+    expect(() => decodePackedGeometryCacheShard(bad, 0, 0)).toThrow(
+      /Unsupported packed geometry cache shard version: 2/
+    );
+  });
+});

--- a/packages/geometry/src/packed-instanced-decoder.test.ts
+++ b/packages/geometry/src/packed-instanced-decoder.test.ts
@@ -96,3 +96,199 @@ describe('decodeInstancedShard (Rust↔TS conformance)', () => {
     expect(() => decodeInstancedShard(bytes.slice(0, 40))).toThrow(/truncated/);
   });
 });
+
+// ── Synthetic shards ──
+//
+// The Rust fixture above is a valid, well-formed shard whose template origins
+// are all (0,0,0). A zero origin makes the three f64 reads indistinguishable
+// from one another (swap X and Y and the suite stays green), and a valid shard
+// never exercises the two bounds guards. These build shards from the LAYOUT
+// documented on the decoder, so both statements of the format are independent.
+
+const HEADER_WORDS = 8;
+const TEMPLATE_RECORD_BYTES = 48;
+const INSTANCE_RECORD_BYTES = 88;
+
+interface SynthTemplate {
+  posOff: number;
+  posLen: number;
+  nrmOff: number;
+  nrmLen: number;
+  idxOff: number;
+  idxLen: number;
+  origin: [number, number, number];
+}
+
+interface SynthInstance {
+  templateIndex: number;
+  entityId: number;
+  color: [number, number, number, number];
+  transform: number[];
+}
+
+function encodeInstancedShard(opts: {
+  templates: SynthTemplate[];
+  instances: SynthInstance[];
+  positions: number[];
+  normals: number[];
+  indices: number[];
+}): Uint8Array {
+  const { templates, instances, positions, normals, indices } = opts;
+  const templateTableOffset = HEADER_WORDS * 4;
+  const instanceTableOffset = templateTableOffset + templates.length * TEMPLATE_RECORD_BYTES;
+  const dataOffset = instanceTableOffset + instances.length * INSTANCE_RECORD_BYTES;
+  const total = dataOffset + (positions.length + normals.length + indices.length) * 4;
+  const buf = new ArrayBuffer(total);
+  const view = new DataView(buf);
+
+  [
+    INSTANCED_SHARD_MAGIC,
+    1,
+    templates.length,
+    instances.length,
+    positions.length,
+    normals.length,
+    indices.length,
+    0,
+  ].forEach((w, i) => view.setUint32(i * 4, w, true));
+
+  templates.forEach((t, i) => {
+    const base = templateTableOffset + i * TEMPLATE_RECORD_BYTES;
+    [t.posOff, t.posLen, t.nrmOff, t.nrmLen, t.idxOff, t.idxLen].forEach((w, k) =>
+      view.setUint32(base + k * 4, w, true)
+    );
+    t.origin.forEach((v, k) => view.setFloat64(base + 24 + k * 8, v, true));
+  });
+
+  instances.forEach((inst, i) => {
+    const base = instanceTableOffset + i * INSTANCE_RECORD_BYTES;
+    view.setUint32(base, inst.templateIndex, true);
+    view.setUint32(base + 4, inst.entityId, true);
+    inst.color.forEach((c, k) => view.setFloat32(base + 8 + k * 4, c, true));
+    inst.transform.forEach((m, k) => view.setFloat32(base + 24 + k * 4, m, true));
+  });
+
+  let cursor = dataOffset;
+  positions.forEach((v) => {
+    view.setFloat32(cursor, v, true);
+    cursor += 4;
+  });
+  normals.forEach((v) => {
+    view.setFloat32(cursor, v, true);
+    cursor += 4;
+  });
+  indices.forEach((v) => {
+    view.setUint32(cursor, v, true);
+    cursor += 4;
+  });
+
+  return new Uint8Array(buf);
+}
+
+const IDENTITY = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+
+function synthShard(over: Partial<Parameters<typeof encodeInstancedShard>[0]> = {}) {
+  return encodeInstancedShard({
+    templates: [
+      { posOff: 0, posLen: 3, nrmOff: 0, nrmLen: 3, idxOff: 0, idxLen: 1, origin: [0, 0, 0] },
+    ],
+    instances: [
+      { templateIndex: 0, entityId: 1, color: [1, 1, 1, 1], transform: IDENTITY },
+    ],
+    positions: [0, 0, 0],
+    normals: [0, 0, 1],
+    indices: [0],
+    ...over,
+  });
+}
+
+describe('decodeInstancedShard (synthetic edge cases)', () => {
+  it('decodes a non-zero template origin axis-by-axis', () => {
+    const shard = decodeInstancedShard(
+      synthShard({
+        templates: [
+          {
+            posOff: 0,
+            posLen: 3,
+            nrmOff: 0,
+            nrmLen: 3,
+            idxOff: 0,
+            idxLen: 1,
+            // Three distinct values: swapping any pair of the f64 reads shows up.
+            origin: [12345.5, -6789.25, 42.125],
+          },
+        ],
+      })
+    );
+
+    expect(shard.templates[0].origin).toEqual([12345.5, -6789.25, 42.125]);
+  });
+
+  it('rejects a template whose pool range runs past the positions pool', () => {
+    expect(() =>
+      decodeInstancedShard(
+        synthShard({
+          templates: [
+            { posOff: 2, posLen: 3, nrmOff: 0, nrmLen: 3, idxOff: 0, idxLen: 1, origin: [0, 0, 0] },
+          ],
+        })
+      )
+    ).toThrow(/template 0 pool offset out of bounds/);
+  });
+
+  it('rejects a template whose normals range runs past the normals pool', () => {
+    expect(() =>
+      decodeInstancedShard(
+        synthShard({
+          templates: [
+            { posOff: 0, posLen: 3, nrmOff: 1, nrmLen: 3, idxOff: 0, idxLen: 1, origin: [0, 0, 0] },
+          ],
+        })
+      )
+    ).toThrow(/template 0 pool offset out of bounds/);
+  });
+
+  it('rejects a template whose index range runs past the indices pool', () => {
+    expect(() =>
+      decodeInstancedShard(
+        synthShard({
+          templates: [
+            { posOff: 0, posLen: 3, nrmOff: 0, nrmLen: 3, idxOff: 0, idxLen: 2, origin: [0, 0, 0] },
+          ],
+        })
+      )
+    ).toThrow(/template 0 pool offset out of bounds/);
+  });
+
+  it('rejects an instance that references a template the shard does not carry', () => {
+    expect(() =>
+      decodeInstancedShard(
+        synthShard({
+          instances: [
+            { templateIndex: 0, entityId: 1, color: [1, 1, 1, 1], transform: IDENTITY },
+            { templateIndex: 3, entityId: 2, color: [1, 1, 1, 1], transform: IDENTITY },
+          ],
+        })
+      )
+    ).toThrow(/instance 1 references missing template 3 \(have 1\)/);
+  });
+
+  it('accepts a template that exactly fills each pool', () => {
+    const shard = decodeInstancedShard(synthShard());
+
+    expect(shard.templates[0].positions).toHaveLength(3);
+    expect(shard.instances).toHaveLength(1);
+  });
+
+  it('reads the transform in the stored row order', () => {
+    // Asymmetric matrix: a transposed read yields a different array.
+    const m = Array.from({ length: 16 }, (_, i) => i + 1);
+    const shard = decodeInstancedShard(
+      synthShard({
+        instances: [{ templateIndex: 0, entityId: 1, color: [1, 1, 1, 1], transform: m }],
+      })
+    );
+
+    expect(Array.from(shard.instances[0].transform)).toEqual(m);
+  });
+});


### PR DESCRIPTION
Second, deeper mutation sweep over `packages/geometry`. The first pass (#2134, #2137) was shallow relative to what later passes found elsewhere, and geometry is where a wrong answer is silent — a wrong mesh or a wrong transform, not an exception — feeding the renderer, clash and export paths.

**Test-only. No production code changed.**

## Result

| | |
|---|---|
| Baseline | 24 files / 225 tests, all green |
| After | 26 files / 295 tests, all green |
| Mutations | 30 + 2 controls |
| Killed by the existing suite | 12 / 30 (**40%**, TARGETED — aimed at the untested modules) |
| Survivors | 18 |
| Survivors now killed | 16 |
| Survivors proved equivalent | 2 |

Controls (run before any survivor was believed, both died): interleaved-buffer stride `i * 6` → `i * 3`; centroid `(min.x + max.x) / 2` → `min.x`.

The survivors clustered almost perfectly in the three modules that had **no test file at all**: `coordinate-handler.ts`'s untested branches, `packed-geometry-decoder.ts`, and `geometry-coordinate.ts`.

## Gaps closed

Each row: the mutation that survived the old suite, and the test that now kills it. All replacement counts asserted `== 1`, each mutated region re-read and confirmed before the run.

### `coordinate-handler.ts`

| Mutation | What a user would see | Killing test |
|---|---|---|
| `positions[i] + ox` → `positions[i]` in `calculateBounds` | Every bounds fixture left `origin` absent, so the per-element local-frame fold (`world = origin + position`) was exercised by nothing. Without it a model whose elements each carry an origin collapses to a box around zero — the camera fits the wrong volume. | `folds each mesh origin into world bounds`, `applies the origin components axis-by-axis` |
| same fold dropped in `calculateBoundsFast` | Same, on the desktop-native streaming path. | `folds each mesh origin into the sampled bounds` |
| delete the corrupted-vertex clamp in `shiftPositions` | Nothing asserted the `else` branch. A `NaN` or `1e30` vertex reaches the GPU buffer, exploding the mesh's box and able to blank the model. | `clamps non-finite and out-of-range vertices to the shifted origin`, `scrubs corrupted vertices even when no shift is needed` |
| `maxCoord > THRESHOLD` → `>=` in `needsShift` | Both existing cases sat far from 10 km, so the boundary was free. | `treats exactly the 10km threshold as not needing a shift` |
| drop `\|\| maxSize > THRESHOLD` from the incremental shift trigger | Every fixture was *far from the origin*, so the extent half of the OR was dead weight. A 40 km site straddling the origin never gets shifted and keeps float precision loss across the whole model. | `shifts a model that straddles the origin but spans more than 10km` |
| `(small / total) > 0.5` → `>=` in WASM-RTC detection | No fixture sat on the boundary. `>=` there silently suppresses a shift the model needs. | `does not claim WASM RTC on an exact 50/50 split` (+ the clear-majority case) |
| delete `originShift = {0,0,0}` from `processTrustedMeshesIncremental` | **Zero-fixture cancellation:** every trusted test starts from a fresh handler where the shift is *already* zero, so the reset was a no-op in the fixture and the assertion `originShift).toEqual({x:0,y:0,z:0})` proved nothing. In production the trusted path can follow a shifted browser batch. | `clears a shift established by an earlier non-trusted batch` |
| disable the sampled-bounds fast path | The documented ~150x speedup (first + last vertex only) was pinned by nothing; a "fix" to a full scan would have been invisible. | `samples first and last vertex only once WASM RTC is confirmed` |

### `packed-geometry-decoder.ts` — no test file existed

| Mutation | Impact | Killing test |
|---|---|---|
| mesh-table stride `11` → `12` words | Renderer draws the wrong vertices onto the wrong element. Silent. | `splits the pools at the documented mesh-table stride and section offsets` |
| `normalsOffset = positionsOffset + positionsByteLength` → `positionsOffset` | Normals read from the positions pool — wrong shading, no error. | same |
| remove the magic check | A foreign payload is decoded as garbage geometry instead of throwing. | `rejects a payload whose magic is not the shard magic` |

New `packed-geometry-decoder.test.ts` builds its fixture from the **layout documented on the decoder**, not from the decoder itself, so the two are independent statements of the format. Two meshes at different non-zero pool offsets with different lengths, so neither the stride nor a section offset can come out right by accident. Also covers `toArrayBuffer`'s four payload shapes and the version guard.

### `geometry-coordinate.ts` — no test file existed

| Mutation | Impact | Killing test |
|---|---|---|
| first bracket of the streaming batch ladder `100` → `200` | Whole 10/50/100/300/500 MB ladder unpinned. | `maps %s MB to a batch of %s` (both sides of every bracket) |
| `origin[0] \|\| origin[1] \|\| origin[2]` → `&&` | Drops every axis-aligned local origin — e.g. `(0, 0, 5000)` — so the element renders at the world origin instead of its placement. | `keeps a local origin with only some axes set` |

New `geometry-coordinate.test.ts` also covers `convertMeshCollectionToBatch`'s free-on-throw contract, `localBounds`/`localToWorld` arity guards, embedded vs. external texture precedence, the `geometryClass` default, and by-express-id (not positional) fingerprint attribution.

### `packed-instanced-decoder.ts`

| Mutation | Impact | Killing test |
|---|---|---|
| swap the template origin's `getFloat64` reads | **Zero-fixture cancellation:** the Rust conformance fixture's origins are all `(0,0,0)`, so any permutation of the three reads is invisible. | `decodes a non-zero template origin axis-by-axis` |
| remove the template pool-bounds guard | A malformed offset silently clips (`subarray` saturates) into truncated geometry indistinguishable from a real occurrence — exactly what the guard's comment says it exists to prevent. | three `rejects a template whose … runs past the … pool` tests |
| remove the `templateIndex >= templates.length` guard | Instance references a template that does not exist. | `rejects an instance that references a template the shard does not carry` |

## Survivors that are equivalent, not gaps

- **`byteOffset === 0` conjunct in `toArrayBuffer`** — redundant: `byteOffset > 0` implies `byteLength ≤ buffer.byteLength − byteOffset < buffer.byteLength`, so the second conjunct already fails. Proven.
- **the `activeThreshold` ternary in `processMeshesIncremental`** — when `wasmRtcDetected` is true, `calculateBounds` discards the argument (it takes the sampling fast path), and the `shiftPositions` call site is unreachable because a non-zero `originShift` together with `wasmRtcDetected` cannot be produced through the public API: the detection branch never sets a shift, and `processTrustedMeshesIncremental` zeroes it. Proven by reachability over the only two read sites.

## Measured and holding — no changes needed

`geometry-fingerprints.ts` and `batch-sizing.ts` killed **8 of 8**: `AABB_STRIDE` 6→3, min/max order in `geometryAabbAt` **and** in its paired writer `writeGeometryAabbAt`, dropping the non-positive-volume refusal, `Math.min(ids, values)` → `Math.max`, and all three `resolveBatchSizing`/`nextAdaptiveBatchJobs` clamps. These two modules are genuinely well covered.

## Weak-shaped existing tests found

Reported whether or not changed:

1. **`should accumulate trusted native bounds without applying a shift`** — asserts `originShift` equals zero starting from a handler whose `originShift` is already zero. The assertion holds whether or not the code does the thing. Now backed by a test that establishes a non-zero shift first.
2. **`expand-to-flat` in `packed-instanced-decoder.test.ts`** — folds `tmpl.origin[0..2]` into the point before applying the transform, but the fixture's origins are all `(0,0,0)`, so the origin decode cancels entirely. Left in place (it is a genuine Rust↔TS conformance test); the axis-by-axis origin test now covers what it could not.
3. **Every `calculateBounds` / trusted-bounds fixture** omitted `origin`, making the fold in both bounds paths untestable — the same zero-fixture shape, across seven tests.

## Verification

- `pnpm turbo build --filter=@ifc-lite/geometry^...` before every run.
- `pnpm typecheck` does **not** cover this package, and the root tsconfig excludes `**/*.test.ts` — so the four test files were typechecked separately against the package's own options with the exclusion lifted (`tsc -p` with `exclude` reduced to `node_modules`/`dist`, `--listFiles` confirming all 49 test files were in the program). **Zero errors in the four files touched here.** 17 pre-existing errors in six other geometry test files (`geometry-native*`, `wasm-url-plumbing`, `prepass-class-spans`, `geometry-parallel-stream-end`, `diagnostics`) are untouched by this PR and predate it — they are invisible to CI for the same reason.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for geometry bounds, coordinate handling, rotations, mesh conversion, and resource cleanup.
  * Added validation for packed and instanced geometry decoding, including malformed, empty, and boundary-case data.
  * Added tests for textures, colors, transforms, origins, geometry fingerprints, volumes, and payload conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->