### PR TITLE
test(viewer): close 25 mutation-verified gaps in the store's core state layer

### DIFF
--- a/apps/viewer/src/store/basketVisibleSet.test.ts
+++ b/apps/viewer/src/store/basketVisibleSet.test.ts
@@ -5,7 +5,10 @@
 import assert from 'node:assert/strict';
 import { afterEach, beforeEach, describe, it } from 'node:test';
 import { IfcTypeEnum, RelationshipType, type SpatialHierarchy, type SpatialNode } from '@ifc-lite/data';
+import type { GeometryResult, MeshData } from '@ifc-lite/geometry';
 import type { AggregationRelationships } from '../utils/aggregation.js';
+import type { FederatedModel } from './types.js';
+import type { ViewerState } from './index.js';
 import {
   collectSpatialSubtreeElementsWithIfcSpace,
   getSmartBasketInputFromStore,
@@ -16,6 +19,59 @@ import {
 } from './basketVisibleSet.js';
 import { useViewerStore } from './index.js';
 import { entityRefToString } from './types.js';
+
+/**
+ * The visible-set code reads exactly two things off geometry: `meshes.length`
+ * (the cache fingerprint, basketVisibleSet.ts:72 and :92) and each mesh's
+ * `expressId` / `ifcType` (basketVisibleSet.ts:372 and :384). Everything else
+ * on `MeshData` / `GeometryResult` is filled in here with empty-but-valid
+ * values so the fixtures satisfy the REAL contract. An `as any` would have
+ * been shorter, but it also silently survives the day one of those required
+ * fields starts mattering to the code under test.
+ */
+function createMesh(expressId: number, ifcType: string): MeshData {
+  return {
+    expressId,
+    ifcType,
+    positions: new Float32Array(0),
+    normals: new Float32Array(0),
+    indices: new Uint32Array(0),
+    color: [1, 1, 1, 1],
+  };
+}
+
+function createGeometry(meshes: MeshData[]): GeometryResult {
+  const zero = { x: 0, y: 0, z: 0 };
+  return {
+    meshes,
+    totalTriangles: 0,
+    totalVertices: 0,
+    coordinateInfo: {
+      originShift: zero,
+      originalBounds: { min: zero, max: zero },
+      shiftedBounds: { min: zero, max: zero },
+      hasLargeCoordinates: false,
+    },
+  };
+}
+
+/** A federated model with the federation fields the basket cares about. */
+function createFederatedModel(overrides: Partial<FederatedModel> = {}): FederatedModel {
+  return {
+    id: 'm1',
+    name: 'Model 1',
+    ifcDataStore: null,
+    geometryResult: null,
+    visible: true,
+    collapsed: false,
+    schemaVersion: 'IFC4',
+    loadedAt: 0,
+    fileSize: 0,
+    idOffset: 0,
+    maxExpressId: 0,
+    ...overrides,
+  };
+}
 
 function createNode(expressId: number, type: IfcTypeEnum, children: SpatialNode[] = [], elements: number[] = []): SpatialNode {
   return {
@@ -290,9 +346,9 @@ describe('basketVisibleSet', () => {
     // hid lands in the basket anyway.
     describe('the fingerprint reacts to every visibility channel it reads', () => {
       const meshes = [
-        { expressId: 1, ifcType: 'IfcWall' },
-        { expressId: 2, ifcType: 'IfcWall' },
-        { expressId: 3, ifcType: 'IfcWall' },
+        createMesh(1, 'IfcWall'),
+        createMesh(2, 'IfcWall'),
+        createMesh(3, 'IfcWall'),
       ];
 
       function seedThreeVisibleWalls() {
@@ -305,7 +361,7 @@ describe('basketVisibleSet', () => {
           hiddenEntities: new Set(),
           isolatedEntities: null,
           classFilter: null,
-          geometryResult: { meshes } as any,
+          geometryResult: createGeometry(meshes),
         });
         invalidateVisibleBasketCache();
         const seeded = getVisibleBasketEntityRefsFromStore().map(entityRefToString).sort();
@@ -368,7 +424,7 @@ describe('basketVisibleSet', () => {
         // PREVIOUS model's refs out of the cache.
         seedThreeVisibleWalls();
         useViewerStore.setState({
-          geometryResult: { meshes: [{ expressId: 1, ifcType: 'IfcWall' }] } as any,
+          geometryResult: createGeometry([createMesh(1, 'IfcWall')]),
         });
 
         assert.deepStrictEqual(
@@ -388,7 +444,7 @@ describe('basketVisibleSet', () => {
           isolatedEntities: null,
           classFilter: null,
           hiddenEntitiesByModel: new Map(),
-          models: new Map([['m1', { id: 'm1', visible: true, idOffset: 0, maxExpressId: 10, geometryResult: { meshes } } as any]]),
+          models: new Map([['m1', createFederatedModel({ maxExpressId: 10, geometryResult: createGeometry(meshes) })]]),
         });
         invalidateVisibleBasketCache();
         assert.strictEqual(getVisibleBasketEntityRefsFromStore().length, 3);
@@ -417,13 +473,11 @@ describe('basketVisibleSet', () => {
           hierarchyBasketSelection: new Set(),
           models: new Map(),
           hiddenEntities: new Set(),
-          geometryResult: {
-            meshes: [
-              { expressId: 1, ifcType: 'IfcWall' },
-              { expressId: 2, ifcType: 'IfcWall' },
-              { expressId: 3, ifcType: 'IfcWall' },
-            ],
-          } as any,
+          geometryResult: createGeometry([
+            createMesh(1, 'IfcWall'),
+            createMesh(2, 'IfcWall'),
+            createMesh(3, 'IfcWall'),
+          ]),
           classFilter: { ids: new Set([1, 2]), label: 'IfcWall' },
           isolatedEntities: new Set([2, 3]),
         });
@@ -445,7 +499,7 @@ describe('basketVisibleSet', () => {
       });
 
       /** One model at offset 1000 carrying global meshes 1001..1003. */
-      function seedOffsetModel(extra: Record<string, unknown> = {}) {
+      function seedOffsetModel(extra: Partial<ViewerState> = {}) {
         useViewerStore.setState({
           selectedEntitiesSet: new Set(),
           selectedEntity: null,
@@ -457,21 +511,17 @@ describe('basketVisibleSet', () => {
           classFilter: null,
           hiddenEntitiesByModel: new Map(),
           isolatedEntitiesByModel: new Map(),
-          models: new Map([['m1', {
-            id: 'm1',
-            visible: true,
+          models: new Map([['m1', createFederatedModel({
             idOffset: 1000,
             maxExpressId: 100,
-            geometryResult: {
-              meshes: [
-                { expressId: 1001, ifcType: 'IfcWall' },
-                { expressId: 1002, ifcType: 'IfcWall' },
-                { expressId: 1003, ifcType: 'IfcWall' },
-              ],
-            },
-          } as any]]),
+            geometryResult: createGeometry([
+              createMesh(1001, 'IfcWall'),
+              createMesh(1002, 'IfcWall'),
+              createMesh(1003, 'IfcWall'),
+            ]),
+          })]]),
           ...extra,
-        } as any);
+        });
         invalidateVisibleBasketCache();
       }
 
@@ -529,7 +579,13 @@ describe('basketVisibleSet', () => {
 
         seedOffsetModel();
         const models = new Map(useViewerStore.getState().models);
-        models.set('m1', { ...models.get('m1')!, ifcDataStore: { spatialHierarchy: hierarchy } as any });
+        // `IfcDataStore` is a class with a large surface; the basket only walks
+        // `spatialHierarchy`, so narrow through `unknown` rather than `any` —
+        // the store field keeps its declared type at every read below.
+        models.set('m1', {
+          ...models.get('m1')!,
+          ifcDataStore: { spatialHierarchy: hierarchy } as unknown as FederatedModel['ifcDataStore'],
+        });
         useViewerStore.setState({
           models,
           // 1004 = local storey 4 + the model's 1000 offset.

--- a/apps/viewer/src/store/basketVisibleSet.test.ts
+++ b/apps/viewer/src/store/basketVisibleSet.test.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import assert from 'node:assert/strict';
-import { beforeEach, describe, it } from 'node:test';
+import { afterEach, beforeEach, describe, it } from 'node:test';
 import { IfcTypeEnum, RelationshipType, type SpatialHierarchy, type SpatialNode } from '@ifc-lite/data';
 import type { AggregationRelationships } from '../utils/aggregation.js';
 import {
@@ -228,6 +228,33 @@ describe('basketVisibleSet', () => {
 
       assert.strictEqual(isBasketIsolationActiveFromStore(), false);
     });
+
+    it('returns false when the isolation is a strict SUPERSET of the basket', () => {
+      // The existing "size differs" case only covers isolation SMALLER than
+      // the basket, where the membership loop also fails — so the `!==`
+      // size check itself was never discriminated and could be weakened to
+      // `>` unnoticed. Here every basket id IS isolated but extra elements
+      // are isolated too, so only the size check can say "no". Getting this
+      // wrong lights up the basket's "isolation active" toggle when the
+      // viewport is showing more than the basket.
+      useViewerStore.setState({
+        pinboardEntities: new Set(['legacy:100']),
+        isolatedEntities: new Set([100, 200]),
+        models: new Map(),
+      });
+
+      assert.strictEqual(isBasketIsolationActiveFromStore(), false);
+    });
+
+    it('returns false when sizes match but membership does not', () => {
+      useViewerStore.setState({
+        pinboardEntities: new Set(['legacy:100', 'legacy:200']),
+        isolatedEntities: new Set([100, 999]),
+        models: new Map(),
+      });
+
+      assert.strictEqual(isBasketIsolationActiveFromStore(), false);
+    });
   });
 
   describe('visibility cache', () => {
@@ -252,6 +279,262 @@ describe('basketVisibleSet', () => {
       const b = getVisibleBasketEntityRefsFromStore();
 
       assert.deepStrictEqual(a, b);
+    });
+
+    // The two tests above hold whether or not the cache ever invalidates —
+    // `deepStrictEqual(first, second)` is exactly as true for a frozen cache
+    // as for a correct one. The fingerprint could drop `hiddenEntities`,
+    // `isolatedEntities` and `classFilter` outright with the whole
+    // apps/viewer suite (2750 tests) still green. What the user sees when it
+    // does: hide a wall, press "Add visible to basket", and the wall you just
+    // hid lands in the basket anyway.
+    describe('the fingerprint reacts to every visibility channel it reads', () => {
+      const meshes = [
+        { expressId: 1, ifcType: 'IfcWall' },
+        { expressId: 2, ifcType: 'IfcWall' },
+        { expressId: 3, ifcType: 'IfcWall' },
+      ];
+
+      function seedThreeVisibleWalls() {
+        useViewerStore.setState({
+          selectedEntitiesSet: new Set(),
+          selectedEntity: null,
+          selectedEntityIds: new Set(),
+          hierarchyBasketSelection: new Set(),
+          models: new Map(),
+          hiddenEntities: new Set(),
+          isolatedEntities: null,
+          classFilter: null,
+          geometryResult: { meshes } as any,
+        });
+        invalidateVisibleBasketCache();
+        const seeded = getVisibleBasketEntityRefsFromStore().map(entityRefToString).sort();
+        assert.deepStrictEqual(seeded, ['legacy:1', 'legacy:2', 'legacy:3']);
+      }
+
+      it('re-computes after hiddenEntities changes (no explicit invalidate)', () => {
+        seedThreeVisibleWalls();
+        // Deliberately NOT calling invalidateVisibleBasketCache() — the
+        // fingerprint alone has to notice.
+        useViewerStore.setState({ hiddenEntities: new Set([2]) });
+
+        assert.deepStrictEqual(
+          getVisibleBasketEntityRefsFromStore().map(entityRefToString).sort(),
+          ['legacy:1', 'legacy:3'],
+        );
+      });
+
+      it('re-computes after isolatedEntities changes (no explicit invalidate)', () => {
+        seedThreeVisibleWalls();
+        useViewerStore.setState({ isolatedEntities: new Set([3]) });
+
+        assert.deepStrictEqual(
+          getVisibleBasketEntityRefsFromStore().map(entityRefToString),
+          ['legacy:3'],
+        );
+      });
+
+      it('re-computes after the class filter changes (no explicit invalidate)', () => {
+        seedThreeVisibleWalls();
+        useViewerStore.setState({ classFilter: { ids: new Set([1]), label: 'IfcWall' } });
+
+        assert.deepStrictEqual(
+          getVisibleBasketEntityRefsFromStore().map(entityRefToString),
+          ['legacy:1'],
+        );
+      });
+
+      it('re-computes after per-model hidden entities change (no explicit invalidate)', () => {
+        useViewerStore.setState({
+          selectedEntitiesSet: new Set(),
+          selectedEntity: null,
+          selectedEntityIds: new Set(),
+          hierarchyBasketSelection: new Set(),
+          geometryResult: null,
+          hiddenEntities: new Set(),
+          isolatedEntities: null,
+          classFilter: null,
+          hiddenEntitiesByModel: new Map(),
+          models: new Map([['m1', { id: 'm1', visible: true, idOffset: 0, maxExpressId: 10, geometryResult: { meshes } } as any]]),
+        });
+        invalidateVisibleBasketCache();
+        assert.strictEqual(getVisibleBasketEntityRefsFromStore().length, 3);
+
+        useViewerStore.setState({ hiddenEntitiesByModel: new Map([['m1', new Set([2])]]) });
+        assert.deepStrictEqual(
+          getVisibleBasketEntityRefsFromStore().map((r) => r.expressId).sort((a, b) => a - b),
+          [1, 3],
+        );
+
+        useViewerStore.setState({ models: new Map(), hiddenEntitiesByModel: new Map() });
+        invalidateVisibleBasketCache();
+      });
+    });
+
+    describe('active filters INTERSECT — they do not union', () => {
+      it('keeps only the ids present in both the class filter and the isolation', () => {
+        // With `some` instead of `every` the two filters would union, so a
+        // "isolate these two" + "filter to this class" combination shows
+        // MORE than either filter alone — the opposite of what stacking
+        // filters means to the user.
+        useViewerStore.setState({
+          selectedEntitiesSet: new Set(),
+          selectedEntity: null,
+          selectedEntityIds: new Set(),
+          hierarchyBasketSelection: new Set(),
+          models: new Map(),
+          hiddenEntities: new Set(),
+          geometryResult: {
+            meshes: [
+              { expressId: 1, ifcType: 'IfcWall' },
+              { expressId: 2, ifcType: 'IfcWall' },
+              { expressId: 3, ifcType: 'IfcWall' },
+            ],
+          } as any,
+          classFilter: { ids: new Set([1, 2]), label: 'IfcWall' },
+          isolatedEntities: new Set([2, 3]),
+        });
+        invalidateVisibleBasketCache();
+
+        assert.deepStrictEqual(
+          getVisibleBasketEntityRefsFromStore().map(entityRefToString),
+          ['legacy:2'],
+        );
+      });
+    });
+
+    describe('federated per-model gates and offsets', () => {
+      // `resetViewerState()` does not clear the federation map, so drop the
+      // fixture model explicitly — otherwise it leaks into later suites.
+      afterEach(() => {
+        useViewerStore.setState({ models: new Map(), hiddenEntitiesByModel: new Map(), isolatedEntitiesByModel: new Map() });
+        invalidateVisibleBasketCache();
+      });
+
+      /** One model at offset 1000 carrying global meshes 1001..1003. */
+      function seedOffsetModel(extra: Record<string, unknown> = {}) {
+        useViewerStore.setState({
+          selectedEntitiesSet: new Set(),
+          selectedEntity: null,
+          selectedEntityIds: new Set(),
+          hierarchyBasketSelection: new Set(),
+          geometryResult: null,
+          hiddenEntities: new Set(),
+          isolatedEntities: null,
+          classFilter: null,
+          hiddenEntitiesByModel: new Map(),
+          isolatedEntitiesByModel: new Map(),
+          models: new Map([['m1', {
+            id: 'm1',
+            visible: true,
+            idOffset: 1000,
+            maxExpressId: 100,
+            geometryResult: {
+              meshes: [
+                { expressId: 1001, ifcType: 'IfcWall' },
+                { expressId: 1002, ifcType: 'IfcWall' },
+                { expressId: 1003, ifcType: 'IfcWall' },
+              ],
+            },
+          } as any]]),
+          ...extra,
+        } as any);
+        invalidateVisibleBasketCache();
+      }
+
+      it('maps mesh global ids back to LOCAL express ids through the model offset', () => {
+        seedOffsetModel();
+        const refs = getVisibleBasketEntityRefsFromStore();
+        assert.deepStrictEqual(
+          refs.map(entityRefToString).sort(),
+          ['m1:1', 'm1:2', 'm1:3'],
+        );
+      });
+
+      it('applies hiddenEntitiesByModel in the model LOCAL id space, not the global one', () => {
+        // The per-model sets are keyed by local expressId. If the candidate
+        // carried the global id instead, `hiddenEntitiesByModel` would never
+        // match and hiding an element in a federated model would do nothing.
+        seedOffsetModel({ hiddenEntitiesByModel: new Map([['m1', new Set([2])]]) });
+        assert.deepStrictEqual(
+          getVisibleBasketEntityRefsFromStore().map(entityRefToString).sort(),
+          ['m1:1', 'm1:3'],
+        );
+      });
+
+      it('applies isolatedEntitiesByModel in the model LOCAL id space', () => {
+        seedOffsetModel({ isolatedEntitiesByModel: new Map([['m1', new Set([3])]]) });
+        assert.deepStrictEqual(
+          getVisibleBasketEntityRefsFromStore().map(entityRefToString),
+          ['m1:3'],
+        );
+      });
+
+      it('resolves a GLOBAL selected-storey id back into the model local id space', () => {
+        // The hierarchy tree sends storey ids in the RENDERER (global) space,
+        // but `byStorey` is keyed by the model's local express ids. Dropping
+        // the `storeyId - offset` fallback makes storey isolation match
+        // nothing in any offset model: pick a storey in the second federated
+        // file and the viewport goes empty.
+        const storeyLocalId = 4;
+        const storeyNode = createNode(storeyLocalId, IfcTypeEnum.IfcBuildingStorey, [], [1, 2]);
+        const projectNode = createNode(1, IfcTypeEnum.IfcProject, [storeyNode], []);
+        const hierarchy: SpatialHierarchy = {
+          project: projectNode,
+          byStorey: new Map([[storeyLocalId, [1, 2]]]),
+          byBuilding: new Map(),
+          bySite: new Map(),
+          bySpace: new Map(),
+          storeyElevations: new Map(),
+          storeyHeights: new Map(),
+          elementToStorey: new Map(),
+          getStoreyElements: () => [],
+          getStoreyByElevation: () => null,
+          getContainingSpace: () => null,
+          getPath: () => [],
+        };
+
+        seedOffsetModel();
+        const models = new Map(useViewerStore.getState().models);
+        models.set('m1', { ...models.get('m1')!, ifcDataStore: { spatialHierarchy: hierarchy } as any });
+        useViewerStore.setState({
+          models,
+          // 1004 = local storey 4 + the model's 1000 offset.
+          selectedStoreys: new Set([1000 + storeyLocalId]),
+        });
+        invalidateVisibleBasketCache();
+
+        // Only the storey's own elements (local 1 and 2) survive isolation;
+        // local 3 is in the model but not in the storey.
+        assert.deepStrictEqual(
+          getVisibleBasketEntityRefsFromStore().map(entityRefToString).sort(),
+          ['m1:1', 'm1:2'],
+        );
+
+        // Opposite direction of the same ternary: a storey id that is ALREADY
+        // local must be used as-is. Subtracting the offset unconditionally
+        // would push it negative and match nothing, so the surfaces that
+        // still emit local storey ids would silently isolate to empty.
+        useViewerStore.setState({ selectedStoreys: new Set([storeyLocalId]) });
+        invalidateVisibleBasketCache();
+        assert.deepStrictEqual(
+          getVisibleBasketEntityRefsFromStore().map(entityRefToString).sort(),
+          ['m1:1', 'm1:2'],
+        );
+
+        useViewerStore.setState({ selectedStoreys: new Set() });
+      });
+
+      it('skips a model whose visible flag is off', () => {
+        seedOffsetModel();
+        assert.strictEqual(getVisibleBasketEntityRefsFromStore().length, 3);
+
+        const models = new Map(useViewerStore.getState().models);
+        models.set('m1', { ...models.get('m1')!, visible: false });
+        useViewerStore.setState({ models });
+
+        assert.strictEqual(getVisibleBasketEntityRefsFromStore().length, 0);
+      });
     });
   });
 

--- a/apps/viewer/src/store/basketVisibleSet.test.ts
+++ b/apps/viewer/src/store/basketVisibleSet.test.ts
@@ -344,6 +344,39 @@ describe('basketVisibleSet', () => {
         );
       });
 
+      it('applies lensHiddenIds, and re-computes when they change', () => {
+        // `lensHiddenIds` is folded into the hidden set alongside
+        // `hiddenEntities` and is its own fingerprint channel, but nothing
+        // exercised either half: turning the fold into a `delete` and blanking
+        // the channel in the fingerprint BOTH survived the whole store suite
+        // (round-four self-audit). On screen that is a lens whose hidden
+        // elements stay in the basket's visible set.
+        seedThreeVisibleWalls();
+        useViewerStore.setState({ lensHiddenIds: new Set([2]) });
+
+        assert.deepStrictEqual(
+          getVisibleBasketEntityRefsFromStore().map(entityRefToString).sort(),
+          ['legacy:1', 'legacy:3'],
+        );
+        useViewerStore.setState({ lensHiddenIds: new Set() });
+      });
+
+      it('re-computes after the legacy mesh set itself changes', () => {
+        // The `geometryResult.meshes.length` channel: reloading a model in
+        // single-model mode changes the candidate set without touching any
+        // hidden/isolated/filter state, so blanking that channel serves the
+        // PREVIOUS model's refs out of the cache.
+        seedThreeVisibleWalls();
+        useViewerStore.setState({
+          geometryResult: { meshes: [{ expressId: 1, ifcType: 'IfcWall' }] } as any,
+        });
+
+        assert.deepStrictEqual(
+          getVisibleBasketEntityRefsFromStore().map(entityRefToString),
+          ['legacy:1'],
+        );
+      });
+
       it('re-computes after per-model hidden entities change (no explicit invalidate)', () => {
         useViewerStore.setState({
           selectedEntitiesSet: new Set(),
@@ -522,7 +555,31 @@ describe('basketVisibleSet', () => {
           ['m1:1', 'm1:2'],
         );
 
+        // Clearing the storey selection must be seen by the CACHE too, with no
+        // explicit invalidate: `selectedStoreys` is its own fingerprint
+        // channel, and blanking it survived the suite (round-four self-audit)
+        // because every storey assertion above invalidates by hand. Leaving it
+        // stale means the viewport un-isolates while the basket does not.
         useViewerStore.setState({ selectedStoreys: new Set() });
+        assert.deepStrictEqual(
+          getVisibleBasketEntityRefsFromStore().map(entityRefToString).sort(),
+          ['m1:1', 'm1:2', 'm1:3'],
+        );
+      });
+
+      it('re-computes after per-model ISOLATED entities change (no explicit invalidate)', () => {
+        // `isolatedEntitiesByModel` is read by the fingerprint but was the one
+        // visibility channel with no cache test — dropping it from the
+        // fingerprint survived the whole store suite (round-four self-audit),
+        // because the per-model isolation test above invalidates by hand.
+        seedOffsetModel();
+        assert.strictEqual(getVisibleBasketEntityRefsFromStore().length, 3);
+
+        useViewerStore.setState({ isolatedEntitiesByModel: new Map([['m1', new Set([3])]]) });
+        assert.deepStrictEqual(
+          getVisibleBasketEntityRefsFromStore().map(entityRefToString),
+          ['m1:3'],
+        );
       });
 
       it('skips a model whose visible flag is off', () => {

--- a/apps/viewer/src/store/globalId.test.ts
+++ b/apps/viewer/src/store/globalId.test.ts
@@ -1,0 +1,140 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Federation ID-space arithmetic — `local expressId ↔ renderer globalId`.
+ *
+ * This module had no tests at all: a mutation sweep confirmed that deleting
+ * the offset entirely (`return expressId + (model.idOffset ?? 0)` →
+ * `return expressId`) left the WHOLE apps/viewer suite (2750 tests) green.
+ * On screen that mutation means clicking a wall in the second federated
+ * model highlights / selects an unrelated element from the first one.
+ *
+ * The boundary cases below matter because the offset window is CLOSED at
+ * both ends: `[idOffset, idOffset + maxExpressId]`. An off-by-one at either
+ * end silently reassigns a real element to the neighbouring model.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import type { FederatedModel } from './types.js';
+import {
+  toGlobalIdFromModels,
+  fromGlobalIdFromModels,
+  toGlobalIdForRef,
+  type ForwardModelMapLike,
+} from './globalId.js';
+
+type ReverseEntry = Pick<FederatedModel, 'idOffset' | 'maxExpressId'>;
+
+/** Two models: A owns global [0, 500], B owns global [1000, 1300]. */
+function twoModels(): Map<string, ReverseEntry> {
+  return new Map<string, ReverseEntry>([
+    ['model-a', { idOffset: 0, maxExpressId: 500 }],
+    ['model-b', { idOffset: 1000, maxExpressId: 300 }],
+  ]);
+}
+
+describe('toGlobalIdFromModels', () => {
+  it('adds the model offset for a federated model', () => {
+    const models: ForwardModelMapLike = new Map([['model-b', { idOffset: 1000 }]]);
+    assert.equal(toGlobalIdFromModels(models, 'model-b', 42), 1042);
+  });
+
+  it('is the identity for a model whose offset is 0', () => {
+    const models: ForwardModelMapLike = new Map([['model-a', { idOffset: 0 }]]);
+    assert.equal(toGlobalIdFromModels(models, 'model-a', 42), 42);
+  });
+
+  it('treats an offset-carrying model differently from the legacy sentinels', () => {
+    // Both directions pinned: the sentinel path must IGNORE an offset that
+    // the same map would otherwise apply. Without this pairing a mutation
+    // that drops either branch keeps one of the two assertions true.
+    const models: ForwardModelMapLike = new Map([
+      ['legacy', { idOffset: 1000 }],
+      ['default', { idOffset: 1000 }],
+      ['__legacy__', { idOffset: 1000 }],
+      ['real', { idOffset: 1000 }],
+    ]);
+    assert.equal(toGlobalIdFromModels(models, 'legacy', 7), 7);
+    assert.equal(toGlobalIdFromModels(models, 'default', 7), 7);
+    assert.equal(toGlobalIdFromModels(models, '__legacy__', 7), 7);
+    assert.equal(toGlobalIdFromModels(models, 'real', 7), 1007);
+  });
+
+  it('falls back to the raw expressId for an unknown model id', () => {
+    const models: ForwardModelMapLike = new Map([['model-b', { idOffset: 1000 }]]);
+    assert.equal(toGlobalIdFromModels(models, 'not-loaded', 42), 42);
+  });
+
+  it('treats a model entry with no idOffset as offset 0', () => {
+    const models: ForwardModelMapLike = new Map([['model-x', {}]]);
+    assert.equal(toGlobalIdFromModels(models, 'model-x', 42), 42);
+  });
+
+  it('toGlobalIdForRef forwards modelId + expressId to the same arithmetic', () => {
+    const models: ForwardModelMapLike = new Map([['model-b', { idOffset: 1000 }]]);
+    assert.equal(toGlobalIdForRef(models, { modelId: 'model-b', expressId: 42 }), 1042);
+  });
+});
+
+describe('fromGlobalIdFromModels', () => {
+  it('returns the legacy sentinel when no models are registered', () => {
+    assert.deepEqual(
+      fromGlobalIdFromModels(new Map(), 42),
+      { modelId: 'legacy', expressId: 42 },
+    );
+  });
+
+  it('routes an id to the model whose offset window contains it', () => {
+    const models = twoModels();
+    assert.deepEqual(fromGlobalIdFromModels(models, 42), { modelId: 'model-a', expressId: 42 });
+    assert.deepEqual(fromGlobalIdFromModels(models, 1042), { modelId: 'model-b', expressId: 42 });
+  });
+
+  it('includes the LOWER boundary: localId exactly 0 belongs to the model', () => {
+    const models = twoModels();
+    assert.deepEqual(fromGlobalIdFromModels(models, 0), { modelId: 'model-a', expressId: 0 });
+    assert.deepEqual(fromGlobalIdFromModels(models, 1000), { modelId: 'model-b', expressId: 0 });
+  });
+
+  it('includes the UPPER boundary: localId exactly maxExpressId belongs to the model', () => {
+    const models = twoModels();
+    assert.deepEqual(fromGlobalIdFromModels(models, 500), { modelId: 'model-a', expressId: 500 });
+    assert.deepEqual(fromGlobalIdFromModels(models, 1300), { modelId: 'model-b', expressId: 300 });
+  });
+
+  it('excludes an id one past the upper boundary (gap between models)', () => {
+    const models = twoModels();
+    // 501 is above model-a's max and below model-b's offset — owned by neither.
+    assert.equal(fromGlobalIdFromModels(models, 501), undefined);
+    // Past model-b's window entirely, with >1 model so no single-model rescue.
+    assert.equal(fromGlobalIdFromModels(models, 1301), undefined);
+  });
+
+  it('rescues an out-of-range id when exactly one model is loaded', () => {
+    // Overlay-allocated ids land above the parse-time maxExpressId; with a
+    // single model the offset-corrected id is still the right answer.
+    const single = new Map<string, ReverseEntry>([['only', { idOffset: 100, maxExpressId: 50 }]]);
+    assert.deepEqual(fromGlobalIdFromModels(single, 999), { modelId: 'only', expressId: 899 });
+  });
+
+  it('round-trips every model through toGlobalId → fromGlobalId', () => {
+    const reverse = twoModels();
+    const forward: ForwardModelMapLike = new Map([
+      ['model-a', { idOffset: 0 }],
+      ['model-b', { idOffset: 1000 }],
+    ]);
+    for (const [modelId, entry] of reverse) {
+      for (const expressId of [0, 1, entry.maxExpressId]) {
+        const global = toGlobalIdFromModels(forward, modelId, expressId);
+        assert.deepEqual(
+          fromGlobalIdFromModels(reverse, global),
+          { modelId, expressId },
+          `${modelId}#${expressId} must round-trip`,
+        );
+      }
+    }
+  });
+});

--- a/apps/viewer/src/store/slices/modelSlice.test.ts
+++ b/apps/viewer/src/store/slices/modelSlice.test.ts
@@ -220,6 +220,13 @@ describe('ModelSlice', () => {
       assert.strictEqual(state.models.size, 1);
       assert.ok(!state.models.has('does-not-exist'));
       assert.strictEqual(state.models.get('model-1')?.name, 'A');
+      // "No-op" has to mean the rest of the slice too, not just the map:
+      // an early return that still emits a state patch would point the
+      // active-model pointer (and the mirrored stores) at an id that does
+      // not exist. Asserting only the map cannot see that — measured.
+      assert.strictEqual(state.activeModelId, 'model-1');
+      assert.strictEqual(state.ifcDataStore, state.models.get('model-1')?.ifcDataStore ?? null);
+      assert.strictEqual(state.geometryResult, state.models.get('model-1')?.geometryResult ?? null);
     });
   });
 

--- a/apps/viewer/src/store/slices/modelSlice.test.ts
+++ b/apps/viewer/src/store/slices/modelSlice.test.ts
@@ -203,14 +203,27 @@ describe('ModelSlice', () => {
       // Opposite direction of the same branch: patching a background model
       // must not swap the active model's data out from under the UI.
       const activeStore = { tag: 'active' } as unknown as IfcDataStore;
-      state.addModel({ ...createMockModel('model-1', 'A'), ifcDataStore: activeStore });
+      const activeGeometry = { tag: 'active' } as unknown as GeometryResult;
+      state.addModel({
+        ...createMockModel('model-1', 'A'),
+        ifcDataStore: activeStore,
+        geometryResult: activeGeometry,
+      });
       state.addModel(createMockModel('model-2', 'B'));
       assert.strictEqual(state.activeModelId, 'model-1');
 
-      state.updateModel('model-2', { ifcDataStore: { tag: 'other' } as unknown as IfcDataStore });
+      const otherStore = { tag: 'other' } as unknown as IfcDataStore;
+      const otherGeometry = { tag: 'other' } as unknown as GeometryResult;
+      state.updateModel('model-2', { ifcDataStore: otherStore, geometryResult: otherGeometry });
 
+      // BOTH mirrors are gated on `activeModelId` (modelSlice.ts:112-113), so
+      // both directions need pinning. Patching only `ifcDataStore` here left
+      // the geometry gate free to be deleted outright without any test
+      // noticing — and the geometry mirror is what the viewport renders.
       assert.strictEqual(state.ifcDataStore, activeStore);
-      assert.strictEqual((state.models.get('model-2')?.ifcDataStore as unknown as { tag: string }).tag, 'other');
+      assert.strictEqual(state.geometryResult, activeGeometry);
+      assert.strictEqual(state.models.get('model-2')?.ifcDataStore, otherStore);
+      assert.strictEqual(state.models.get('model-2')?.geometryResult, otherGeometry);
     });
 
     it('is a no-op for an unknown model id', () => {

--- a/apps/viewer/src/store/slices/modelSlice.test.ts
+++ b/apps/viewer/src/store/slices/modelSlice.test.ts
@@ -148,6 +148,81 @@ describe('ModelSlice', () => {
     });
   });
 
+  describe('upsertModel', () => {
+    it('MERGES into an existing entry instead of replacing it', () => {
+      // The ingest pipeline upserts a model twice: a metadata-only stub
+      // first, then the parsed payload. A replacing (non-merging) upsert
+      // would drop whatever the second call omits — the model's name /
+      // georef / visibility silently reverting mid-load.
+      const original = { ...createMockModel('model-1', 'Original'), maxExpressId: 999 };
+      state.upsertModel(original);
+
+      const geometry = { tag: 'late' } as unknown as GeometryResult;
+      state.upsertModel({ id: 'model-1', geometryResult: geometry } as unknown as FederatedModel);
+
+      assert.strictEqual(state.models.get('model-1')?.name, 'Original');
+      assert.strictEqual(state.models.get('model-1')?.maxExpressId, 999);
+      assert.strictEqual(state.models.get('model-1')?.geometryResult, geometry);
+    });
+
+    it('adopts the first upserted model as active and mirrors its payload', () => {
+      const store = { tag: 'a' } as unknown as IfcDataStore;
+      const geometry = { tag: 'a' } as unknown as GeometryResult;
+      state.upsertModel({ ...createMockModel('model-1', 'A'), ifcDataStore: store, geometryResult: geometry });
+
+      assert.strictEqual(state.activeModelId, 'model-1');
+      assert.strictEqual(state.ifcDataStore, store);
+      assert.strictEqual(state.geometryResult, geometry);
+    });
+
+    it('does not steal the active slot from an already-active model', () => {
+      state.upsertModel(createMockModel('model-1', 'A'));
+      state.upsertModel(createMockModel('model-2', 'B'));
+      assert.strictEqual(state.activeModelId, 'model-1');
+    });
+  });
+
+  describe('updateModel', () => {
+    it('re-mirrors ifcDataStore / geometryResult when the ACTIVE model is patched', () => {
+      // This is how the loader attaches parsed data to a model that was
+      // registered earlier. If the mirror is not refreshed, the whole app
+      // (properties panel, exports, queries) keeps reading the pre-parse
+      // store while the model list shows the file as loaded.
+      state.addModel(createMockModel('model-1', 'A'));
+      const store = { tag: 'patched' } as unknown as IfcDataStore;
+      const geometry = { tag: 'patched' } as unknown as GeometryResult;
+
+      state.updateModel('model-1', { ifcDataStore: store, geometryResult: geometry });
+
+      assert.strictEqual(state.models.get('model-1')?.ifcDataStore, store);
+      assert.strictEqual(state.ifcDataStore, store);
+      assert.strictEqual(state.geometryResult, geometry);
+    });
+
+    it('leaves the active mirror alone when a NON-active model is patched', () => {
+      // Opposite direction of the same branch: patching a background model
+      // must not swap the active model's data out from under the UI.
+      const activeStore = { tag: 'active' } as unknown as IfcDataStore;
+      state.addModel({ ...createMockModel('model-1', 'A'), ifcDataStore: activeStore });
+      state.addModel(createMockModel('model-2', 'B'));
+      assert.strictEqual(state.activeModelId, 'model-1');
+
+      state.updateModel('model-2', { ifcDataStore: { tag: 'other' } as unknown as IfcDataStore });
+
+      assert.strictEqual(state.ifcDataStore, activeStore);
+      assert.strictEqual((state.models.get('model-2')?.ifcDataStore as unknown as { tag: string }).tag, 'other');
+    });
+
+    it('is a no-op for an unknown model id', () => {
+      state.addModel(createMockModel('model-1', 'A'));
+      state.updateModel('does-not-exist', { name: 'Ghost' });
+
+      assert.strictEqual(state.models.size, 1);
+      assert.ok(!state.models.has('does-not-exist'));
+      assert.strictEqual(state.models.get('model-1')?.name, 'A');
+    });
+  });
+
   describe('removeModel', () => {
     it('should remove a model from the map', () => {
       const model = createMockModel('model-1', 'Test Model');

--- a/apps/viewer/src/store/slices/selectionSlice.test.ts
+++ b/apps/viewer/src/store/slices/selectionSlice.test.ts
@@ -331,7 +331,7 @@ describe('SelectionSlice', () => {
       assert.strictEqual(state.selectedModelId, 'model-1');
     });
 
-    it('setSelectedModelId clears every entity-selection channel', () => {
+    it('setSelectedModelId clears the multi-model entity channels and the primary id', () => {
       state.setSelectedEntity({ modelId: 'model-1', expressId: 7 });
       state.setSelectedEntities([
         { modelId: 'model-1', expressId: 7 },
@@ -345,6 +345,23 @@ describe('SelectionSlice', () => {
       assert.strictEqual(state.selectedEntity, null);
       assert.deepStrictEqual(state.selectedEntities, []);
       assert.strictEqual(state.selectedEntityId, null);
+    });
+
+    it('setSelectedModelId does NOT clear the legacy selectedEntityIds set', () => {
+      // Pinning the CURRENT behaviour, not endorsing it. `setSelectedModelId`
+      // (selectionSlice.ts:292) clears `selectedEntity`, `selectedEntities`
+      // and `selectedEntityId`, but leaves the legacy global-id set standing,
+      // even though its comment reads "Clear other selection when selecting a
+      // model". The survivors are user-visible: MainToolbar.tsx:352 and
+      // ElementsTab.tsx:44 keep reporting the stale count, and
+      // useAnimationLoop.ts:244 keeps painting the stale highlight, while the
+      // properties panel has already switched to the model.
+      // If that asymmetry is ever fixed, THIS test is the one to flip.
+      state.setSelectedEntityIds([7, 8]);
+
+      state.setSelectedModelId('model-1');
+
+      assert.deepStrictEqual([...state.selectedEntityIds].sort((a, b) => a - b), [7, 8]);
     });
 
     it('setSelectedEntities makes the FIRST ref primary and clears the model selection', () => {

--- a/apps/viewer/src/store/slices/selectionSlice.test.ts
+++ b/apps/viewer/src/store/slices/selectionSlice.test.ts
@@ -255,6 +255,119 @@ describe('SelectionSlice', () => {
     });
   });
 
+  describe('legacy selection: primary-id bookkeeping', () => {
+    // `selectedEntityId` is the GLOBAL id the renderer highlights. Every
+    // legacy multi-select action has to keep it pointing at the MOST RECENT
+    // survivor of `selectedEntityIds`, otherwise the highlight box jumps to
+    // an element the user did not touch last (or lingers after the last
+    // element was deselected). None of that was pinned before.
+
+    it('addToSelection makes the added id primary', () => {
+      state.addToSelection(10);
+      state.addToSelection(20);
+      assert.deepStrictEqual([...state.selectedEntityIds].sort((a, b) => a - b), [10, 20]);
+      assert.strictEqual(state.selectedEntityId, 20);
+    });
+
+    it('removeFromSelection promotes the LAST remaining id, not the first', () => {
+      state.setSelectedEntityIds([10, 20, 30]);
+      state.removeFromSelection(30);
+
+      assert.deepStrictEqual([...state.selectedEntityIds].sort((a, b) => a - b), [10, 20]);
+      // Insertion order is preserved by Set, so the last survivor is 20.
+      assert.strictEqual(state.selectedEntityId, 20);
+    });
+
+    it('removeFromSelection clears the primary id when the set empties', () => {
+      state.setSelectedEntityIds([10]);
+      state.removeFromSelection(10);
+      assert.strictEqual(state.selectedEntityIds.size, 0);
+      assert.strictEqual(state.selectedEntityId, null);
+    });
+
+    it('toggleSelection adds then removes, keeping the primary id in step', () => {
+      state.setSelectedEntityIds([10]);
+      state.toggleSelection(20);
+      assert.strictEqual(state.selectedEntityId, 20);
+
+      state.toggleSelection(20);
+      assert.deepStrictEqual([...state.selectedEntityIds], [10]);
+      assert.strictEqual(state.selectedEntityId, 10);
+    });
+
+    it('setSelectedEntityIds makes the LAST id primary, and [] clears it', () => {
+      state.setSelectedEntityIds([10, 20, 30]);
+      assert.strictEqual(state.selectedEntityId, 30);
+
+      state.setSelectedEntityIds([]);
+      assert.strictEqual(state.selectedEntityIds.size, 0);
+      assert.strictEqual(state.selectedEntityId, null);
+    });
+
+    it('clearSelection empties the set and the primary id', () => {
+      state.setSelectedEntityIds([10, 20]);
+      state.clearSelection();
+      assert.strictEqual(state.selectedEntityIds.size, 0);
+      assert.strictEqual(state.selectedEntityId, null);
+    });
+  });
+
+  describe('entity vs model selection are mutually exclusive', () => {
+    it('setSelectedEntityId clears selectedModelId when an entity is picked', () => {
+      state.setSelectedModelId('model-1');
+      state.setSelectedEntityId(42);
+      // Otherwise the properties panel shows model metadata AND an element
+      // at the same time — the panel binds to whichever it checks first.
+      assert.strictEqual(state.selectedModelId, null);
+      assert.strictEqual(state.selectedEntityId, 42);
+    });
+
+    it('setSelectedEntityId(null) does NOT clear selectedModelId', () => {
+      // Opposite direction: clearing the entity highlight (e.g. an empty
+      // canvas click while a model row is selected in the hierarchy) must
+      // leave the model selection alone.
+      state.setSelectedModelId('model-1');
+      state.setSelectedEntityId(null);
+      assert.strictEqual(state.selectedModelId, 'model-1');
+    });
+
+    it('setSelectedModelId clears every entity-selection channel', () => {
+      state.setSelectedEntity({ modelId: 'model-1', expressId: 7 });
+      state.setSelectedEntities([
+        { modelId: 'model-1', expressId: 7 },
+        { modelId: 'model-1', expressId: 8 },
+      ]);
+      state.setSelectedEntityIds([7, 8]);
+
+      state.setSelectedModelId('model-1');
+
+      assert.strictEqual(state.selectedModelId, 'model-1');
+      assert.strictEqual(state.selectedEntity, null);
+      assert.deepStrictEqual(state.selectedEntities, []);
+      assert.strictEqual(state.selectedEntityId, null);
+    });
+
+    it('setSelectedEntities makes the FIRST ref primary and clears the model selection', () => {
+      const refs: EntityRef[] = [
+        { modelId: 'model-1', expressId: 7 },
+        { modelId: 'model-2', expressId: 8 },
+      ];
+      state.setSelectedModelId('model-1');
+      state.setSelectedEntities(refs);
+
+      assert.deepStrictEqual(state.selectedEntities, refs);
+      // Unified-storey display drives the property panel from the FIRST ref.
+      assert.deepStrictEqual(state.selectedEntity, refs[0]);
+      assert.strictEqual(state.selectedModelId, null);
+    });
+
+    it('setSelectedEntities([]) clears the primary entity', () => {
+      state.setSelectedEntity({ modelId: 'model-1', expressId: 7 });
+      state.setSelectedEntities([]);
+      assert.strictEqual(state.selectedEntity, null);
+    });
+  });
+
   describe('legacy selection: storey selection', () => {
     it('should toggle storey selection', () => {
       state.toggleStoreySelection(1);

--- a/apps/viewer/src/store/slices/visibilitySlice.test.ts
+++ b/apps/viewer/src/store/slices/visibilitySlice.test.ts
@@ -102,6 +102,29 @@ describe('VisibilitySlice', () => {
       assert.strictEqual(hidden?.size, 1);
       assert.ok(hidden?.has(300));
     });
+
+    it('drops the model key entirely once its last hidden entity is shown', () => {
+      // The singular `showEntityInModel` prunes an emptied model entry
+      // (test above); the plural must match. A lingering empty Set is a
+      // phantom entry in `hiddenEntitiesByModel` that every `.has(modelId)`
+      // consumer reads as "this model has hidden geometry" — and it feeds
+      // the basket's visible-set cache fingerprint via digestModelEntityMap.
+      state.hideEntitiesInModel('model-1', [100, 200]);
+      state.showEntitiesInModel('model-1', [100, 200]);
+
+      assert.ok(!state.hiddenEntitiesByModel.has('model-1'));
+      assert.strictEqual(state.hiddenEntitiesByModel.size, 0);
+    });
+
+    it('keeps the model key while any entity is still hidden', () => {
+      // Opposite direction of the pruning branch, so a mutation that
+      // ALWAYS deletes the key is caught too.
+      state.hideEntitiesInModel('model-1', [100, 200]);
+      state.showEntitiesInModel('model-1', [100]);
+
+      assert.ok(state.hiddenEntitiesByModel.has('model-1'));
+      assert.deepStrictEqual([...state.hiddenEntitiesByModel.get('model-1')!], [200]);
+    });
   });
 
   describe('multi-model visibility: toggleEntityVisibilityInModel', () => {
@@ -245,6 +268,187 @@ describe('VisibilitySlice', () => {
     });
   });
 
+  describe('legacy visibility: isolateEntities (multi-entity isolate)', () => {
+    it('isolates exactly the requested ids and unhides them', () => {
+      state.hideEntities([100, 300]);
+      state.isolateEntities([100, 200]);
+
+      assert.deepStrictEqual([...state.isolatedEntities!].sort((a, b) => a - b), [100, 200]);
+      // The isolated ids must be unhidden — otherwise "isolate" produces an
+      // empty viewport (isolated AND hidden = nothing on screen).
+      assert.ok(!state.hiddenEntities.has(100));
+      // Ids outside the isolation keep their hidden flag.
+      assert.ok(state.hiddenEntities.has(300));
+    });
+
+    it('toggles isolation off only when the SAME exact set is re-isolated', () => {
+      state.isolateEntities([100, 200]);
+      state.isolateEntities([100, 200]);
+      assert.strictEqual(state.isolatedEntities, null);
+    });
+
+    it('does NOT toggle off on a same-size set that merely overlaps', () => {
+      // The membership check is `ids.every(...)`, not `ids.some(...)`.
+      // With `some`, isolating {100,200} then {100,999} would CLEAR the
+      // isolation instead of switching to the new pair — the user clicks a
+      // different pair of elements and the whole model reappears.
+      state.isolateEntities([100, 200]);
+      state.isolateEntities([100, 999]);
+
+      assert.notStrictEqual(state.isolatedEntities, null);
+      assert.deepStrictEqual([...state.isolatedEntities!].sort((a, b) => a - b), [100, 999]);
+    });
+
+    it('does not toggle off when the new set is a different size', () => {
+      state.isolateEntities([100, 200]);
+      state.isolateEntities([100]);
+      assert.deepStrictEqual([...state.isolatedEntities!], [100]);
+    });
+  });
+
+  describe('visibility resets: showAll / clearAllFilters', () => {
+    /** Put every independent "something is hidden or dimmed" channel into a non-default state. */
+    function armAllFilters() {
+      state.hideEntity(123);
+      state.isolateEntity(456);
+      state.setClassFilter([1, 2, 3], 'IfcWall');
+      state.setGhostExceptEntities(new Set([7, 8]));
+      // setGhostExceptEntities clears isolation by design — re-arm it so
+      // the reset assertions below cover all four channels at once.
+      state.isolateEntities([456]);
+    }
+
+    it('showAll clears hidden, isolation, the class filter AND X-Ray ghosting', () => {
+      armAllFilters();
+      state.showAll();
+
+      assert.strictEqual(state.hiddenEntities.size, 0);
+      assert.strictEqual(state.isolatedEntities, null);
+      // A surviving classFilter keeps every non-matching element hidden
+      // after the user pressed "Show all" — geometry stays missing with no
+      // remaining UI affordance that explains why.
+      assert.strictEqual(state.classFilter, null);
+      // A surviving ghostExceptEntities leaves the model translucent.
+      assert.strictEqual(state.ghostExceptEntities, null);
+    });
+
+    it('clearAllFilters clears isolation, the class filter and ghosting but keeps hidden entities', () => {
+      armAllFilters();
+      state.clearAllFilters();
+
+      assert.strictEqual(state.isolatedEntities, null);
+      assert.strictEqual(state.classFilter, null);
+      assert.strictEqual(state.ghostExceptEntities, null);
+      // Both directions pinned: clearAllFilters is NOT showAll — manually
+      // hidden entities must survive it.
+      assert.ok(state.hiddenEntities.has(123));
+    });
+
+    it('setHiddenEntities replaces hidden and clears isolation, class filter and ghosting', () => {
+      armAllFilters();
+      state.setHiddenEntities(new Set([900]));
+
+      assert.deepStrictEqual([...state.hiddenEntities], [900]);
+      assert.strictEqual(state.isolatedEntities, null);
+      assert.strictEqual(state.classFilter, null);
+      assert.strictEqual(state.ghostExceptEntities, null);
+    });
+
+    it('setIsolatedEntities clears hidden entities and ghosting (mutually exclusive modes)', () => {
+      state.hideEntity(123);
+      state.setGhostExceptEntities(new Set([7]));
+      state.setIsolatedEntities(new Set([456]));
+
+      assert.deepStrictEqual([...state.isolatedEntities!], [456]);
+      // Leftover hidden ids would subtract from the isolated set, so a BCF
+      // viewpoint with defaultVisibility=false would show fewer elements
+      // than the viewpoint asked for.
+      assert.strictEqual(state.hiddenEntities.size, 0);
+      // Isolation hides the rest; ghosting shows it translucent. Both at
+      // once is contradictory, so isolation wins.
+      assert.strictEqual(state.ghostExceptEntities, null);
+    });
+
+    it('setIsolatedEntities(null) clears isolation', () => {
+      state.setIsolatedEntities(new Set([1]));
+      state.setIsolatedEntities(null);
+      assert.strictEqual(state.isolatedEntities, null);
+    });
+
+    it('setGhostExceptEntities clears isolation, and clearGhost undoes only the ghosting', () => {
+      state.isolateEntity(456);
+      state.setGhostExceptEntities(new Set([7, 8]));
+
+      assert.deepStrictEqual([...state.ghostExceptEntities!].sort((a, b) => a - b), [7, 8]);
+      assert.strictEqual(state.isolatedEntities, null);
+
+      state.clearGhost();
+      assert.strictEqual(state.ghostExceptEntities, null);
+    });
+
+    it('showAllInAllModels clears the class filter as well as the hidden/isolated sets', () => {
+      state.hideEntitiesInModel('model-1', [100, 200]);
+      state.hideEntity(500);
+      state.setClassFilter([1, 2], 'IfcWall');
+
+      state.showAllInAllModels();
+
+      assert.strictEqual(state.hiddenEntitiesByModel.size, 0);
+      assert.strictEqual(state.isolatedEntitiesByModel.size, 0);
+      assert.strictEqual(state.hiddenEntities.size, 0);
+      assert.strictEqual(state.isolatedEntities, null);
+      assert.strictEqual(state.classFilter, null);
+      // NOTE: `ghostExceptEntities` is deliberately NOT asserted here.
+      // Unlike `showAll` / `clearAllFilters` / `setHiddenEntities`, this
+      // action does not clear it today, so an X-Ray context survives
+      // "Home / show all" (see resetVisibilityForHomeFromStore in
+      // store/homeView.ts). That looks like an oversight rather than a
+      // decision, but changing it is a behaviour change and needs a
+      // maintainer ruling — so this test pins only what the action
+      // currently promises instead of enshrining the gap either way.
+    });
+  });
+
+  describe('legacy visibility: setClassFilter', () => {
+    it('stores the ids and label', () => {
+      state.setClassFilter([1, 2, 3], 'IfcWall');
+      assert.strictEqual(state.classFilter?.label, 'IfcWall');
+      assert.deepStrictEqual([...state.classFilter!.ids].sort((a, b) => a - b), [1, 2, 3]);
+    });
+
+    it('toggles off when the same id set is re-applied', () => {
+      state.setClassFilter([1, 2, 3], 'IfcWall');
+      state.setClassFilter([1, 2, 3], 'IfcWall');
+      assert.strictEqual(state.classFilter, null);
+    });
+
+    it('switches to a different class rather than toggling off', () => {
+      state.setClassFilter([1, 2, 3], 'IfcWall');
+      state.setClassFilter([4, 5, 6], 'IfcSlab');
+      assert.strictEqual(state.classFilter?.label, 'IfcSlab');
+    });
+
+    it('does NOT toggle off on a same-size class that merely overlaps', () => {
+      // Membership is `ids.every(...)`. With `some`, a second class whose id
+      // set happens to share one member (an element counted under both, or
+      // just an id collision across models) would CLEAR the filter instead
+      // of switching to it — the user clicks a class row and the filter
+      // silently turns off.
+      state.setClassFilter([1, 2, 3], 'IfcWall');
+      state.setClassFilter([1, 8, 9], 'IfcSlab');
+
+      assert.notStrictEqual(state.classFilter, null);
+      assert.strictEqual(state.classFilter?.label, 'IfcSlab');
+      assert.deepStrictEqual([...state.classFilter!.ids].sort((a, b) => a - b), [1, 8, 9]);
+    });
+
+    it('clearClassFilter removes it', () => {
+      state.setClassFilter([1], 'IfcWall');
+      state.clearClassFilter();
+      assert.strictEqual(state.classFilter, null);
+    });
+  });
+
   describe('legacy visibility: isEntityVisible', () => {
     it('should return true for visible entity', () => {
       assert.strictEqual(state.isEntityVisible(123), true);
@@ -259,6 +463,30 @@ describe('VisibilitySlice', () => {
       state.isolateEntity(100);
       assert.strictEqual(state.isEntityVisible(100), true);
       assert.strictEqual(state.isEntityVisible(200), false);
+    });
+
+    it('returns false for an entity outside an active class filter', () => {
+      // classFilter is a third, INDEPENDENT gate (Class tab type-group
+      // clicks). Without this test the whole `classFilter` branch of
+      // isEntityVisible can be deleted with every suite still green — and
+      // "hide everything except IfcWall" would stop hiding anything.
+      state.setClassFilter([100, 101], 'IfcWall');
+      assert.strictEqual(state.isEntityVisible(100), true);
+      assert.strictEqual(state.isEntityVisible(200), false);
+    });
+
+    it('requires an entity to pass EVERY gate, not just one', () => {
+      state.setClassFilter([100, 200], 'IfcWall');
+      state.isolateEntities([100, 300]);
+      // 100 is in both → visible. 200 passes the class filter but fails
+      // isolation; 300 the reverse. Neither may be visible.
+      assert.strictEqual(state.isEntityVisible(100), true);
+      assert.strictEqual(state.isEntityVisible(200), false);
+      assert.strictEqual(state.isEntityVisible(300), false);
+
+      // …and an explicit hide overrides passing both.
+      state.hideEntity(100);
+      assert.strictEqual(state.isEntityVisible(100), false);
     });
   });
 

--- a/apps/viewer/src/store/typeVisibilityFilter.test.ts
+++ b/apps/viewer/src/store/typeVisibilityFilter.test.ts
@@ -49,6 +49,43 @@ describe('isTypeVisible', () => {
     assert.equal(isTypeVisible('IfcSpace', { ...ALL_ON, site: false }), true);
     assert.equal(isTypeVisible('IfcAnnotation', { ...ALL_ON, ifcAnnotations: false }), false);
   });
+
+  it('measures EVERY class→toggle pair independently, in both directions', () => {
+    // Per-case measurement: the loop above only ever discriminated
+    // `spaces`, `site` and `ifcAnnotations`, so `IfcSpatialZone`,
+    // `IfcOpeningElement` and `IfcVirtualElement` could be remapped to each
+    // other's toggle with the whole suite still green. On screen that means
+    // the Openings switch hides virtual elements and leaves the openings
+    // visible (or vice versa).
+    const pairs: ReadonlyArray<readonly [string, keyof typeof ALL_ON]> = [
+      ['IfcSpace', 'spaces'],
+      ['IfcSpatialZone', 'spatialZones'],
+      ['IfcOpeningElement', 'openings'],
+      ['IfcVirtualElement', 'virtualElements'],
+      ['IfcSite', 'site'],
+      ['IfcGeographicElement', 'site'],
+      ['IfcAnnotation', 'ifcAnnotations'],
+    ];
+
+    for (const [ifcType, ownKey] of pairs) {
+      // Its own toggle off → hidden.
+      assert.equal(
+        isTypeVisible(ifcType, { ...ALL_ON, [ownKey]: false }),
+        false,
+        `${ifcType} must be hidden when ${ownKey} is off`,
+      );
+      // Every OTHER toggle off → still visible. This is the half that
+      // catches a swapped mapping.
+      for (const otherKey of Object.keys(ALL_ON) as (keyof typeof ALL_ON)[]) {
+        if (otherKey === ownKey) continue;
+        assert.equal(
+          isTypeVisible(ifcType, { ...ALL_ON, [otherKey]: false }),
+          true,
+          `${ifcType} must be unaffected by the ${otherKey} toggle`,
+        );
+      }
+    }
+  });
 });
 
 describe('buildHiddenIfcTypes', () => {
@@ -66,5 +103,39 @@ describe('buildHiddenIfcTypes', () => {
   it('drops IfcAnnotation when annotations are off', () => {
     const hidden = buildHiddenIfcTypes({ ...ALL_ON, ifcAnnotations: false });
     assert.deepEqual([...hidden], ['IfcAnnotation']);
+  });
+
+  it('drops exactly the classes owned by each toggle, one toggle at a time', () => {
+    // Mirrors the per-pair check above for the GLB-export gate, so the two
+    // consumers can never disagree about which class a toggle owns.
+    const expected: Record<keyof typeof ALL_ON, string[]> = {
+      spaces: ['IfcSpace'],
+      spatialZones: ['IfcSpatialZone'],
+      openings: ['IfcOpeningElement'],
+      virtualElements: ['IfcVirtualElement'],
+      site: ['IfcSite', 'IfcGeographicElement'],
+      ifcAnnotations: ['IfcAnnotation'],
+    };
+
+    for (const [key, classes] of Object.entries(expected) as [keyof typeof ALL_ON, string[]][]) {
+      const hidden = buildHiddenIfcTypes({ ...ALL_ON, [key]: false });
+      assert.deepEqual([...hidden].sort(), [...classes].sort(), `toggle ${key}`);
+    }
+  });
+
+  it('hides every mapped class when all toggles are off', () => {
+    const allOff = {
+      spaces: false, spatialZones: false, openings: false,
+      virtualElements: false, site: false, ifcAnnotations: false,
+    };
+    assert.deepEqual([...buildHiddenIfcTypes(allOff)].sort(), [
+      'IfcAnnotation',
+      'IfcGeographicElement',
+      'IfcOpeningElement',
+      'IfcSite',
+      'IfcSpace',
+      'IfcSpatialZone',
+      'IfcVirtualElement',
+    ]);
   });
 });


### PR DESCRIPTION
Mutation sweep of the viewer's **core state layer** — `apps/viewer/src/store/**`. Selection and visibility set arithmetic, isolate/show-all interactions, federated per-model id spaces, section plane state, and the model add/update/remove lifecycle.

**Test-only. No production file is modified** (`git diff` touches six `*.test.ts` files and nothing else).

## Measurement

| | |
|---|---|
| Mutations against load-bearing logic | 27 (+2 deliberate controls) |
| KILLED | 4 |
| SURVIVED | 23 |
| Kill ratio | **4/27 = 15%** — flagged **TARGETED**: I aimed at actions with no test at all |
| `apps/viewer` tests | 2750 → **2815** (0 fail; the same 2 pre-existing env-gated LLM/OpenRouter skips) |

Controls, run before believing any survivor, both died as expected:

| Control | Killed by |
|---|---|
| `isolateEntity`: `new Set([id])` → `new Set()` | `should isolate single entity` |
| `resolveGlobalIdFromModels`: `localId <= maxExpressId` → `<` | `resolves the highest parsed express id through the fast (first) pass` |

`sectionSlice.ts` was measured and is **genuinely well covered** — 3/3 mutations killed (position upper clamp, custom-plane clearing on axis change, the pick-preview arm guard). Nothing added there.

## Gaps closed

Each row: the surviving mutation that proved the gap, and what a user would see if the mutated code shipped.

### `store/globalId.ts` — no test file existed at all

| Surviving mutation | User-visible effect | Killing test |
|---|---|---|
| `return expressId + (model.idOffset ?? 0)` → `return expressId` | Clicking a wall in the second federated model selects an unrelated element from the first | `adds the model offset for a federated model`, `round-trips every model through toGlobalId → fromGlobalId` |
| `localExpressId >= 0 && <= maxExpressId` → `> 0 && < maxExpressId` | The element at express id 0 and the element at exactly `maxExpressId` resolve to the wrong model (or to nothing) | `includes the LOWER boundary…`, `includes the UPPER boundary…` |

This survivor was re-run against the **whole** `apps/viewer` suite (2750 tests), not just the store — still green. New file `globalId.test.ts` (13 tests) also pins the `legacy` / `default` / `__legacy__` sentinels against a map that *does* carry an offset, so neither branch can be deleted alone.

### `store/basketVisibleSet.ts` — stale cache and set arithmetic

| Surviving mutation | User-visible effect | Killing test |
|---|---|---|
| Fingerprint drops `hiddenEntities` + `isolatedEntities` + `classFilter` | Hide a wall, press "Add visible to basket", and the wall you just hid lands in the basket | `re-computes after hiddenEntities changes (no explicit invalidate)` (+2 siblings) |
| Fingerprint drops `hiddenEntitiesByModel` | Same, for per-model hiding in a federated scene | `re-computes after per-model hidden entities change…` |
| `sorted.every(...)` → `sorted.some(...)` | Stacking a class filter on top of an isolation shows **more** than either filter alone | `keeps only the ids present in both the class filter and the isolation` |
| Per-model `hiddenEntitiesByModel` / `isolatedEntitiesByModel` gates deleted | Hiding an element inside one federated model does nothing to the basket's visible set | `applies hiddenEntitiesByModel in the model LOCAL id space, not the global one` (+1) |
| `expressId: globalId - offset` → `globalId` | Per-model sets never match in an offset model — same silent no-op | same two tests |
| `byStorey.has(id) ? id : id - offset` → either side alone | Picking a storey in the second federated file isolates to nothing | `resolves a GLOBAL selected-storey id back into the model local id space` |
| `basketIds.size !== isolated.size` → `>` | The basket's "isolation active" toggle lights up while the viewport shows more than the basket | `returns false when the isolation is a strict SUPERSET of the basket` |

The two pre-existing cache tests are the *\"property that holds whether or not the code does the thing\"* shape — `assert.deepStrictEqual(first, second)` is exactly as true for a cache that never invalidates as for a correct one. The new tests mutate store state **without** calling `invalidateVisibleBasketCache()`, so only the fingerprint can save them.

Similarly, the pre-existing `returns false when isolated size differs from basket` case had the basket *larger* than the isolation, where the membership loop also returns false — so the size check itself was never discriminated. Both directions are now pinned separately.

### `store/slices/visibilitySlice.ts`

| Surviving mutation | User-visible effect | Killing test |
|---|---|---|
| `showAll` stops clearing `classFilter` + `ghostExceptEntities` | Press "Show all" and geometry stays hidden / translucent, with no UI affordance left to explain why | `showAll clears hidden, isolation, the class filter AND X-Ray ghosting` |
| `clearAllFilters` stops clearing them | same | `clearAllFilters clears isolation, the class filter and ghosting but keeps hidden entities` |
| `setIsolatedEntities` stops clearing `hiddenEntities` / ghosting | A BCF viewpoint with `defaultVisibility=false` shows fewer elements than the viewpoint asked for | `setIsolatedEntities clears hidden entities and ghosting (mutually exclusive modes)` |
| `isEntityVisible`'s whole `classFilter` branch deleted | "Show only IfcWall" stops hiding anything | `returns false for an entity outside an active class filter`, `requires an entity to pass EVERY gate, not just one` |
| `isolateEntities` toggle-off `every` → `some` | Isolate `{100,200}`, then isolate `{100,999}` → the whole model reappears instead of switching | `does NOT toggle off on a same-size set that merely overlaps` |
| `setClassFilter` toggle-off `every` → `some` | Clicking a second class row that shares one id turns the filter off instead of switching | `does NOT toggle off on a same-size class that merely overlaps` |
| `showEntitiesInModel` stops pruning the emptied model key | Phantom \"this model has hidden geometry\" entry that every `.has(modelId)` consumer and the basket fingerprint read | `drops the model key entirely once its last hidden entity is shown` (+ the opposite direction) |

`isolateEntities`, `setClassFilter`, `clearClassFilter`, `clearAllFilters`, `setHiddenEntities`, `setIsolatedEntities`, `setGhostExceptEntities` and `clearGhost` had no tests at all before this.

### `store/slices/selectionSlice.ts`

`selectedEntityId` is the **global** id the renderer highlights, so every legacy multi-select action must keep it on the most recent survivor of `selectedEntityIds`. None of that was pinned.

| Surviving mutation | User-visible effect | Killing test |
|---|---|---|
| `removeFromSelection`: `remaining[remaining.length-1]` → `remaining[0]` | Deselecting one element jumps the highlight box to the *oldest* selection | `removeFromSelection promotes the LAST remaining id, not the first` |
| `setSelectedEntityIds`: `ids[ids.length-1]` → `ids[0]` | same, for bulk "select all results" | `setSelectedEntityIds makes the LAST id primary, and [] clears it` |
| `addToSelection` drops `selectedEntityId: id` | Ctrl-click adds to the set but the highlight never moves | `addToSelection makes the added id primary` |
| `setSelectedEntityId` stops clearing `selectedModelId` | The properties panel shows model metadata *and* an element at once | `setSelectedEntityId clears selectedModelId when an entity is picked` |
| …and the opposite: always clearing it | Clicking empty canvas drops a hierarchy model-row selection | `setSelectedEntityId(null) does NOT clear selectedModelId` |
| `setSelectedModelId` stops clearing the entity channels | same collision, from the other side | `setSelectedModelId clears every entity-selection channel` |
| `setSelectedEntities`: primary `refs[0]` → last, and keeps `selectedModelId` | The unified-storey property panel binds to the wrong storey | `setSelectedEntities makes the FIRST ref primary and clears the model selection` |

### `store/slices/modelSlice.ts`

| Surviving mutation | User-visible effect | Killing test |
|---|---|---|
| `upsertModel`: drop the `{ ...existing, ...model }` merge | The ingest pipeline upserts a stub then the payload; a replacing upsert reverts the model's name / georef / visibility mid-load | `MERGES into an existing entry instead of replacing it` |
| `upsertModel`: `state.activeModelId ?? model.id` → `model.id` | Loading a second model steals the active slot | `does not steal the active slot from an already-active model` |
| `updateModel`: stop re-mirroring `ifcDataStore` / `geometryResult` | The loader attaches parsed data via `updateModel`; without the mirror the whole app keeps reading the pre-parse store while the model list shows the file as loaded | `re-mirrors ifcDataStore / geometryResult when the ACTIVE model is patched` |
| …and the opposite: always mirror | Patching a background model swaps the active model's data out from under the UI | `leaves the active mirror alone when a NON-active model is patched` |
| `updateModel`: remove the `if (!model) return {}` early return | Unknown model id inserts a `{ undefined }` entry into the federation map | `is a no-op for an unknown model id` |

### `store/typeVisibilityFilter.ts`

The existing loop only ever discriminated `spaces`, `site` and `ifcAnnotations`. Swapping `IfcOpeningElement` ↔ `IfcVirtualElement`, or remapping `IfcSpatialZone` onto `spaces`, survived — the Openings switch would hide virtual elements and leave openings visible. Now measured **per pair, in both directions** (own toggle off ⇒ hidden; every other toggle off ⇒ still visible), for `isTypeVisible` and for `buildHiddenIfcTypes` (the GLB-export gate) alike, so the two consumers can never disagree about which class a toggle owns.

## Finding for a maintainer — not fixed here

`showAllInAllModels` does **not** clear `ghostExceptEntities`, while `showAll`, `clearAllFilters` and `setHiddenEntities` all do. `showAllInAllModels` is what `resetVisibilityForHomeFromStore` (`store/homeView.ts`) calls for Home / "reset filters" — the same function that was extended in #1402 to drop focused-clash state. So: run a clash check in **Ghost** mode (`useClash.ts` → `setGhostExceptEntities`), press Home, and the model stays translucent with no clash selection left to explain it.

That looks like an oversight rather than a decision, but it is a behaviour change, so this PR does not make it. The `showAllInAllModels` test here pins only what the action currently promises and carries an inline note rather than enshrining the gap in either direction.

Nothing in this sweep touched the `scene.clear()` / instanced-template area of **#2073**, and nothing here depends on how that is resolved.

## Verification

- `pnpm --filter @ifc-lite/viewer test` — 2815 tests, 0 fail, 2 skipped (both pre-existing, env-gated: `IFC_LITE_VERIFY_OPENROUTER_MODELS` and the LLM env registry check).
- `pnpm --filter @ifc-lite/viewer typecheck` passes. Confirmed empirically that it **does** cover test files: it initially failed on three `setGhostExceptEntities([7, 8])` calls in the new tests (the action takes a `Set`), which is exactly the check working.
- Every new test was RED-checked against the mutation it targets and GREEN on clean `main`. Both directions of each binary signal are pinned; boundaries probed at `localId === 0`, `localId === maxExpressId`, `maxExpressId + 1`, empty selections, single-element sets, and the last model being removed.
- `node scripts/check-test-wiring.mjs` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for basket visibility, isolation, filtering, lens, geometry, and model-specific visibility.
  * Added federation global-ID conversion tests, including offsets, gaps, legacy values, and round trips.
  * Added tests for model updates, active-model state, selection behavior, and visibility resets.
  * Added comprehensive IFC type visibility tests covering class-specific toggles and combined filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->