### PR TITLE
test(parser): close 21 mutation-verified gaps in the tokenizer, header reader, and index builder

### DIFF
--- a/packages/parser/test/attribute-helpers.test.ts
+++ b/packages/parser/test/attribute-helpers.test.ts
@@ -1,0 +1,139 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Direct coverage for the shared attribute coercions used by the material,
+ * georef, and classification extractors.
+ *
+ * Only `getReference`'s `#`-prefixed form was reachable from an existing test.
+ * The STEP logical sentinels (`.T.` / `.F.`) and the non-string coercion in
+ * `getString` both survived mutation across the whole monorepo.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  getBoolean,
+  getNumber,
+  getReference,
+  getReferences,
+  getString,
+  getStringList,
+} from '../src/attribute-helpers.js';
+
+describe('getString', () => {
+  it('passes a string through unchanged', () => {
+    expect(getString('wall')).toBe('wall');
+    expect(getString('')).toBe('');
+  });
+
+  it('coerces a non-string scalar to its string form', () => {
+    // IFC numeric/boolean attributes reach the extractors untyped; returning
+    // undefined here would silently blank out a name or an identifier.
+    expect(getString(42)).toBe('42');
+    expect(getString(0)).toBe('0');
+    expect(getString(true)).toBe('true');
+  });
+
+  it('returns undefined only for null and undefined', () => {
+    expect(getString(null)).toBeUndefined();
+    expect(getString(undefined)).toBeUndefined();
+  });
+});
+
+describe('getNumber', () => {
+  it('passes a number through, including zero', () => {
+    expect(getNumber(1.5)).toBe(1.5);
+    expect(getNumber(0)).toBe(0);
+  });
+
+  it('parses a numeric string', () => {
+    expect(getNumber('2.5')).toBe(2.5);
+    expect(getNumber('-3')).toBe(-3);
+  });
+
+  it('returns undefined for a non-numeric string and for non-scalars', () => {
+    expect(getNumber('abc')).toBeUndefined();
+    expect(getNumber(null)).toBeUndefined();
+    expect(getNumber(undefined)).toBeUndefined();
+    expect(getNumber(true)).toBeUndefined();
+    expect(getNumber([1])).toBeUndefined();
+  });
+});
+
+describe('getBoolean', () => {
+  it('maps the STEP `.T.` logical to true', () => {
+    expect(getBoolean('.T.')).toBe(true);
+    expect(getBoolean('T')).toBe(true);
+    expect(getBoolean('true')).toBe(true);
+  });
+
+  it('maps the STEP `.F.` logical to false', () => {
+    // `.F.` must resolve to `false`, not to `undefined`. Callers treat
+    // undefined as "not stated" and fall back to a default, so losing `.F.`
+    // turns an explicit "no" into whatever the default happens to be.
+    expect(getBoolean('.F.')).toBe(false);
+    expect(getBoolean('F')).toBe(false);
+    expect(getBoolean('false')).toBe(false);
+  });
+
+  it('passes a real boolean through', () => {
+    expect(getBoolean(true)).toBe(true);
+    expect(getBoolean(false)).toBe(false);
+  });
+
+  it('returns undefined for the unset/unknown third state', () => {
+    // `$` (unset) and `.U.` (logical unknown) are neither true nor false.
+    expect(getBoolean(null)).toBeUndefined();
+    expect(getBoolean(undefined)).toBeUndefined();
+    expect(getBoolean('.U.')).toBeUndefined();
+    expect(getBoolean('$')).toBeUndefined();
+  });
+});
+
+describe('getReference', () => {
+  it('passes a numeric reference through', () => {
+    expect(getReference(12)).toBe(12);
+  });
+
+  it('strips the `#` prefix from a string reference', () => {
+    expect(getReference('#12')).toBe(12);
+  });
+
+  it('returns undefined for a string without the `#` marker', () => {
+    expect(getReference('12')).toBeUndefined();
+    expect(getReference('#')).toBeUndefined();
+    expect(getReference('#abc')).toBeUndefined();
+  });
+
+  it('returns undefined for null, undefined and non-scalars', () => {
+    expect(getReference(null)).toBeUndefined();
+    expect(getReference(undefined)).toBeUndefined();
+    expect(getReference({})).toBeUndefined();
+  });
+});
+
+describe('getReferences', () => {
+  it('collects the resolvable references and drops the rest', () => {
+    expect(getReferences([1, '#2', null, 'nope', '#3'])).toEqual([1, 2, 3]);
+  });
+
+  it('returns undefined for a non-array (an absent aggregate, not an empty one)', () => {
+    expect(getReferences('#1')).toBeUndefined();
+    expect(getReferences(null)).toBeUndefined();
+  });
+
+  it('returns an empty array for an empty aggregate', () => {
+    expect(getReferences([])).toEqual([]);
+  });
+});
+
+describe('getStringList', () => {
+  it('coerces every entry and drops only null/undefined', () => {
+    expect(getStringList(['a', 1, null, undefined, 'b'])).toEqual(['a', '1', 'b']);
+  });
+
+  it('returns undefined for a non-array', () => {
+    expect(getStringList('a')).toBeUndefined();
+  });
+});

--- a/packages/parser/test/entity-refs-from-index.test.ts
+++ b/packages/parser/test/entity-refs-from-index.test.ts
@@ -58,12 +58,20 @@ describe('buildEntityRefsFromIndex', () => {
     expect(seen).toEqual([...seen].sort((a, b) => a - b));
   });
 
-  it('interns one string per distinct type name', () => {
+  // NOT "interns one string per distinct type name". Interning is not
+  // observable from JS: `expect(a).toBe(b)` is `Object.is`, which compares
+  // string PRIMITIVES by value, so two independently-built equal strings
+  // satisfy it. Verified — replacing the intern lookup with
+  // `(' ' + key).slice(1)`, and separately with `Array.from(key).join('')`,
+  // both left this file green. The intern Map is a memory optimisation with
+  // no behavioural contract; what IS falsifiable is that every occurrence of
+  // a repeated type resolves to the same NAME, which is what this asserts.
+  it('resolves the same type name for every occurrence of a repeated type', () => {
     const { ids, starts, lengths } = cols(spans);
     const refs = buildEntityRefsFromIndex(src, ids, starts, lengths);
     const walls = refs.filter((r) => r.type === 'IFCWALL');
     expect(walls).toHaveLength(2);
-    expect(walls[0].type).toBe(walls[1].type);
+    expect(walls.map((r) => r.type)).toEqual(['IFCWALL', 'IFCWALL']);
   });
 
   it('tolerates whitespace between `=` and the type token', () => {

--- a/packages/parser/test/entity-refs-from-index.test.ts
+++ b/packages/parser/test/entity-refs-from-index.test.ts
@@ -1,0 +1,129 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Direct coverage for {@link buildEntityRefsFromIndex}.
+ *
+ * This is the fast path the parser worker takes when the streaming geometry
+ * pre-pass has already scanned the file: the whole entity index is synthesised
+ * from three SharedArrayBuffer columns without re-reading the source. Its two
+ * corruption guards (column-length mismatch, out-of-bounds span) both survived
+ * mutation because no test ever fed it a corrupt triple.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { buildEntityRefsFromIndex } from '../src/entity-refs-from-index.js';
+
+const SOURCE = ["#10=IFCWALL('a',$);", '#2=IFCSLAB($);', '#7=IFCWALL($);'].join('\n');
+const src = new TextEncoder().encode(SOURCE);
+
+/** Byte spans of the three records above, in file order. */
+const spans = (() => {
+  const out: Array<{ id: number; start: number; len: number }> = [];
+  let at = 0;
+  for (const line of SOURCE.split('\n')) {
+    out.push({ id: Number(line.slice(1, line.indexOf('='))), start: at, len: line.length });
+    at += line.length + 1;
+  }
+  return out;
+})();
+
+const cols = (rows: typeof spans) => ({
+  ids: Uint32Array.from(rows.map((r) => r.id)),
+  starts: Uint32Array.from(rows.map((r) => r.start)),
+  lengths: Uint32Array.from(rows.map((r) => r.len)),
+});
+
+describe('buildEntityRefsFromIndex', () => {
+  it('extracts the type token and byte span for each column entry', () => {
+    const { ids, starts, lengths } = cols(spans);
+    const refs = buildEntityRefsFromIndex(src, ids, starts, lengths);
+    expect(refs.map((r) => r.expressId)).toEqual([2, 7, 10]);
+    expect(refs.map((r) => r.type)).toEqual(['IFCSLAB', 'IFCWALL', 'IFCWALL']);
+    for (const ref of refs) {
+      const span = spans.find((s) => s.id === ref.expressId)!;
+      expect(ref.byteOffset).toBe(span.start);
+      expect(ref.byteLength).toBe(span.len);
+    }
+  });
+
+  it('emits refs in ascending expressId order regardless of column order', () => {
+    // The downstream compact index only skips its O(N log N) object sort when
+    // the refs already ascend; descending output would be a silent slowdown
+    // and, for consumers that assume order, a wrong answer.
+    const { ids, starts, lengths } = cols(spans);
+    const refs = buildEntityRefsFromIndex(src, ids, starts, lengths);
+    const seen = refs.map((r) => r.expressId);
+    expect(seen).toEqual([...seen].sort((a, b) => a - b));
+  });
+
+  it('interns one string per distinct type name', () => {
+    const { ids, starts, lengths } = cols(spans);
+    const refs = buildEntityRefsFromIndex(src, ids, starts, lengths);
+    const walls = refs.filter((r) => r.type === 'IFCWALL');
+    expect(walls).toHaveLength(2);
+    expect(walls[0].type).toBe(walls[1].type);
+  });
+
+  it('tolerates whitespace between `=` and the type token', () => {
+    const padded = new TextEncoder().encode('#1=  IFCWALL($);');
+    const refs = buildEntityRefsFromIndex(
+      padded,
+      Uint32Array.of(1),
+      Uint32Array.of(0),
+      Uint32Array.of(padded.length),
+    );
+    expect(refs[0].type).toBe('IFCWALL');
+  });
+
+  it('throws when the `lengths` column is shorter than the `ids` column', () => {
+    // Each column is checked independently; a guard that only validates
+    // `starts` lets a truncated `lengths` column through as undefined spans.
+    expect(() =>
+      buildEntityRefsFromIndex(src, Uint32Array.of(2, 7), Uint32Array.of(0, 19), Uint32Array.of(13)),
+    ).toThrow(/column-length mismatch/);
+  });
+
+  it('throws when the `starts` column is shorter than the `ids` column', () => {
+    expect(() =>
+      buildEntityRefsFromIndex(src, Uint32Array.of(2, 7), Uint32Array.of(0), Uint32Array.of(13, 13)),
+    ).toThrow(/column-length mismatch/);
+  });
+
+  it('throws when a span ends past the end of the source', () => {
+    // The start is in range but start+len walks off the buffer. Clamping would
+    // silently emit a truncated record with an empty type name.
+    expect(() =>
+      buildEntityRefsFromIndex(
+        src,
+        Uint32Array.of(2),
+        Uint32Array.of(0),
+        Uint32Array.of(src.length + 1),
+      ),
+    ).toThrow(/out-of-bounds span/);
+  });
+
+  it('throws when a span starts past the end of the source', () => {
+    expect(() =>
+      buildEntityRefsFromIndex(src, Uint32Array.of(2), Uint32Array.of(src.length + 1), Uint32Array.of(0)),
+    ).toThrow(/out-of-bounds span/);
+  });
+
+  it('accepts a span that ends exactly at the end of the source', () => {
+    const last = spans[spans.length - 1];
+    const refs = buildEntityRefsFromIndex(
+      src,
+      Uint32Array.of(last.id),
+      Uint32Array.of(last.start),
+      Uint32Array.of(last.len),
+    );
+    expect(refs[0].byteOffset + refs[0].byteLength).toBe(src.length);
+  });
+
+  it('returns an empty array for empty columns', () => {
+    expect(
+      buildEntityRefsFromIndex(src, new Uint32Array(0), new Uint32Array(0), new Uint32Array(0)),
+    ).toEqual([]);
+  });
+});

--- a/packages/parser/test/source-header.test.ts
+++ b/packages/parser/test/source-header.test.ts
@@ -1,0 +1,236 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Direct coverage for {@link parseSourceHeader}.
+ *
+ * The header is read on every parse (`columnar-parser`) and written back out on
+ * every STEP export (`step-exporter`), so a decoding error here silently
+ * rewrites a file's authorship and provenance. The only prior coverage was
+ * `packages/export/src/source-header-roundtrip.test.ts`, whose fixtures contain
+ * no STEP escape of any kind (`''`, `\X2\`, `\X4\`, `\S\`, `\P?\`), no `$`/`*`
+ * sentinel, no quoted delimiter, and no non-default `implementation_level` —
+ * so eight independent mutations to this module survived the whole monorepo.
+ *
+ * All fixtures here are synthetic and carry no real-world identifiers.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { parseSourceHeader } from '../src/source-header.js';
+
+const enc = (s: string): Uint8Array => new TextEncoder().encode(s);
+
+/** Wrap HEADER records in a minimal, well-formed STEP envelope. */
+function header(records: string, data = "#1=IFCWALL('a',$);"): Uint8Array {
+  return enc(
+    ['ISO-10303-21;', 'HEADER;', records, 'ENDSEC;', 'DATA;', data, 'ENDSEC;', 'END-ISO-10303-21;'].join(
+      '\n',
+    ),
+  );
+}
+
+const FILE_NAME_ALL = (fields: string) => `FILE_NAME(${fields});`;
+
+describe('parseSourceHeader', () => {
+  it('returns undefined for input with no recognisable header records', () => {
+    expect(parseSourceHeader(enc('not a step file at all'))).toBeUndefined();
+  });
+
+  it('reads the declared implementation_level rather than falling back to the default', () => {
+    // Every pre-existing fixture used '2;1', which is byte-identical to the
+    // hard-coded fallback in the parser — so an assertion of `'2;1'` held
+    // whether or not the field was parsed at all. Use a value that cannot be
+    // produced by the default.
+    const h = parseSourceHeader(header("FILE_DESCRIPTION(('ViewDefinition [X]'),'3;7');"));
+    expect(h?.implementationLevel).toBe('3;7');
+  });
+
+  it('falls back to 2;1 only when implementation_level is genuinely absent', () => {
+    const h = parseSourceHeader(header("FILE_DESCRIPTION(('ViewDefinition [X]'));"));
+    expect(h?.implementationLevel).toBe('2;1');
+  });
+
+  describe('sentinels', () => {
+    it('maps the `*` derived sentinel to undefined, not to a literal asterisk', () => {
+      const h = parseSourceHeader(
+        header(FILE_NAME_ALL("'n.ifc','2026-01-01T00:00:00',('A'),('O'),'P','S',*")),
+      );
+      expect(h?.authorization).toBeUndefined();
+      expect(h?.name).toBe('n.ifc');
+    });
+
+    it('maps the `$` unset sentinel to undefined', () => {
+      const h = parseSourceHeader(
+        header(FILE_NAME_ALL("'n.ifc','2026-01-01T00:00:00',('A'),('O'),$,'S','auth'")),
+      );
+      expect(h?.preprocessorVersion).toBeUndefined();
+      expect(h?.originatingSystem).toBe('S');
+    });
+
+    it('drops `$` and `*` entries from a list field instead of emitting them as text', () => {
+      const h = parseSourceHeader(
+        header(FILE_NAME_ALL("'n.ifc','2026-01-01T00:00:00',('A',$,'B',*),('O'),'P','S','auth'")),
+      );
+      expect(h?.author).toEqual(['A', 'B']);
+    });
+
+    it('yields an empty list for a `$` list field', () => {
+      const h = parseSourceHeader(
+        header(FILE_NAME_ALL("'n.ifc','2026-01-01T00:00:00',$,('O'),'P','S','auth'")),
+      );
+      expect(h?.author).toEqual([]);
+    });
+  });
+
+  describe('field positions', () => {
+    it('maps every FILE_NAME slot to its own field', () => {
+      // Guards against an off-by-one in the positional read: each value is
+      // distinct so a shifted index cannot land on a matching string.
+      const h = parseSourceHeader(
+        header(
+          FILE_NAME_ALL(
+            "'the-name','the-stamp',('the-author'),('the-org'),'the-preproc','the-origsys','the-authorization'",
+          ),
+        ),
+      );
+      expect(h?.name).toBe('the-name');
+      expect(h?.timeStamp).toBe('the-stamp');
+      expect(h?.author).toEqual(['the-author']);
+      expect(h?.organization).toEqual(['the-org']);
+      expect(h?.preprocessorVersion).toBe('the-preproc');
+      expect(h?.originatingSystem).toBe('the-origsys');
+      expect(h?.authorization).toBe('the-authorization');
+    });
+  });
+
+  describe('quote and nesting awareness', () => {
+    it('does not split a list item at a comma inside a quoted string', () => {
+      const h = parseSourceHeader(
+        header("FILE_DESCRIPTION(('Coords [Base: Survey, Site: Origin]','Second'),'2;1');"),
+      );
+      expect(h?.description).toEqual(['Coords [Base: Survey, Site: Origin]', 'Second']);
+    });
+
+    it('does not split a list item at a comma inside nested parentheses', () => {
+      const h = parseSourceHeader(header("FILE_DESCRIPTION(('a (x, y) b','Second'),'2;1');"));
+      expect(h?.description).toEqual(['a (x, y) b', 'Second']);
+    });
+
+    it('does not end the record at a closing parenthesis inside a quoted string', () => {
+      // `extractRecordArgs` walks to the matching `)`. If it ignores quote
+      // state, this record ends inside the name and every later field is lost.
+      const h = parseSourceHeader(
+        header(
+          FILE_NAME_ALL("'name) with paren','2026-01-01T00:00:00',('A'),('O'),'P','S','the-auth'"),
+        ),
+      );
+      expect(h?.name).toBe('name) with paren');
+      expect(h?.authorization).toBe('the-auth');
+    });
+  });
+
+  describe('string escapes', () => {
+    it("collapses the `''` doubled-quote escape to a single apostrophe", () => {
+      const h = parseSourceHeader(
+        header(FILE_NAME_ALL("'it''s a name','2026-01-01T00:00:00',$,$,$,$,$")),
+      );
+      expect(h?.name).toBe("it's a name");
+    });
+
+    it('decodes a \\X2\\ UTF-16 directive to real Unicode', () => {
+      const h = parseSourceHeader(
+        header(FILE_NAME_ALL("'Tr\\X2\\00FC\\X0\\mpler','2026-01-01T00:00:00',$,$,$,$,$")),
+      );
+      expect(h?.name).toBe('Trümpler');
+    });
+
+    it('decodes a \\X4\\ UTF-32 directive to real Unicode', () => {
+      const h = parseSourceHeader(
+        header(FILE_NAME_ALL("'e\\X4\\0001F600\\X0\\nd','2026-01-01T00:00:00',$,$,$,$,$")),
+      );
+      expect(h?.name).toBe('e\u{1F600}nd');
+    });
+
+    it('decodes an \\S\\ high-bit directive to real Unicode', () => {
+      // \S\d => code point of 'd' + 0x80 = 0xE4 = 'ä'.
+      const h = parseSourceHeader(
+        header(FILE_NAME_ALL("'\\S\\dpfel','2026-01-01T00:00:00',$,$,$,$,$")),
+      );
+      expect(h?.name).toBe('äpfel');
+    });
+
+    it('decodes an \\X\\ single-byte directive to real Unicode', () => {
+      const h = parseSourceHeader(
+        header(FILE_NAME_ALL("'\\X\\C4pfel','2026-01-01T00:00:00',$,$,$,$,$")),
+      );
+      expect(h?.name).toBe('Äpfel');
+    });
+
+    it('resolves `\\\\` to one literal backslash without eating a following directive', () => {
+      const h = parseSourceHeader(
+        header(FILE_NAME_ALL("'C:\\\\temp\\\\Tr\\X2\\00FC\\X0\\m','2026-01-01T00:00:00',$,$,$,$,$")),
+      );
+      expect(h?.name).toBe('C:\\temp\\Trüm');
+    });
+
+    it('keeps a \\X2\\ directive intact when an escaped backslash immediately follows it', () => {
+      // `\X2\00FC\X0\` + `\\` ends in three consecutive backslashes; a naive
+      // split at every doubled backslash consumes the directive terminator.
+      const h = parseSourceHeader(
+        header(FILE_NAME_ALL("'Tr\\X2\\00FC\\X0\\\\\\m','2026-01-01T00:00:00',$,$,$,$,$")),
+      );
+      expect(h?.name).toBe('Trü\\m');
+    });
+
+    it('keeps a \\X4\\ directive intact when an escaped backslash immediately follows it', () => {
+      // Same trap as the \X2\ case above, on the UTF-32 directive: the \X4\
+      // span must be consumed whole before the `\\` pair escape is considered,
+      // or the terminator is eaten and the directive never decodes.
+      const h = parseSourceHeader(
+        header(FILE_NAME_ALL("'e\\X4\\0001F600\\X0\\\\\\nd','2026-01-01T00:00:00',$,$,$,$,$")),
+      );
+      expect(h?.name).toBe('e\u{1F600}\\nd');
+    });
+
+    it('treats a backslash as a valid \\S\\ operand rather than a pair escape', () => {
+      // `\S\` takes exactly one operand character, and that character may
+      // itself be a backslash (code point 0x5C + 0x80 = 0xDC). If the operand
+      // is not consumed with the directive, the `\\` pair escape claims it and
+      // the directive is left unterminated.
+      const h = parseSourceHeader(
+        header(FILE_NAME_ALL("'\\S\\\\end','2026-01-01T00:00:00',$,$,$,$,$")),
+      );
+      expect(h?.name).toBe('Üend');
+    });
+  });
+
+  describe('tolerant shapes', () => {
+    it('accepts a bare value where a list was expected', () => {
+      // Some writers emit `FILE_SCHEMA('IFC4')` without the inner list.
+      const h = parseSourceHeader(header("FILE_SCHEMA('IFC4');"));
+      expect(h?.schemaIdentifiers).toEqual(['IFC4']);
+    });
+
+    it('reads the schema token verbatim from a well-formed list', () => {
+      const h = parseSourceHeader(header("FILE_SCHEMA(('IFC4X3_ADD2'));"));
+      expect(h?.schemaIdentifiers).toEqual(['IFC4X3_ADD2']);
+    });
+  });
+
+  describe('scan bounds', () => {
+    it('stops at the first ENDSEC so DATA-section text is never read as a header', () => {
+      // A quoted attribute in the DATA section can contain the literal text
+      // `FILE_NAME(...)`. Without the ENDSEC cut it is parsed as the header.
+      const src = header(
+        "FILE_DESCRIPTION(('ViewDefinition [X]'),'2;1');",
+        "#1=IFCWALL('FILE_NAME(''body-name'',''body-stamp'',$,$,$,$,$);',$);",
+      );
+      const h = parseSourceHeader(src);
+      expect(h?.description).toEqual(['ViewDefinition [X]']);
+      // No FILE_NAME record exists in the HEADER section, so these stay unset.
+      expect(h?.name).toBeUndefined();
+      expect(h?.timeStamp).toBeUndefined();
+    });
+  });
+});

--- a/packages/parser/test/tokenizer.test.ts
+++ b/packages/parser/test/tokenizer.test.ts
@@ -87,9 +87,16 @@ describe('StepTokenizer.scanEntitiesFast', () => {
     expect(refs.map((r) => r.type)).toEqual(['DHMWK', 'LILQAGG', 'DHMWK']);
   });
 
-  it('reuses one interned string for a repeated type name', () => {
+  // NOT "reuses one interned string": the cache is a memory optimisation and
+  // is not observable from JS. `expect(a).toBe(b)` is `Object.is`, which
+  // compares string PRIMITIVES by value, so a decoded-fresh name satisfies it
+  // exactly as an interned one does — deleting the `typeCache.set(...)` call
+  // outright left this file green. The two collision tests above carry the
+  // real, falsifiable property (the byte-for-byte verification of a cache
+  // hit); this one only pins that a plain repeat reads back correctly.
+  it('reads a repeated type name back identically on the cache-hit path', () => {
     const refs = scanFast('#1=IFCWALL(1);\n#2=IFCWALL(1);');
-    expect(refs[0].type).toBe(refs[1].type);
+    expect(refs.map((r) => r.type)).toEqual(['IFCWALL', 'IFCWALL']);
   });
 });
 

--- a/packages/parser/test/tokenizer.test.ts
+++ b/packages/parser/test/tokenizer.test.ts
@@ -1,0 +1,147 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Direct coverage for {@link StepTokenizer}, the byte-level STEP scanner every
+ * model in the product passes through.
+ *
+ * Before this file the tokenizer had no test of its own: it was only ever
+ * exercised transitively through `IfcParser`, whose fixtures never contain a
+ * malformed record, a multi-line entity whose line number is asserted, or two
+ * type names that collide in the fast scanner's type cache. Mutation testing
+ * confirmed the gap — nine independent mutations to `tokenizer.ts` (including
+ * making the whole `scanEntities()` generator yield nothing) left the entire
+ * monorepo green.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { StepTokenizer } from '../src/tokenizer.js';
+
+const bytes = (s: string): Uint8Array => new TextEncoder().encode(s);
+
+const scanFast = (s: string) => [...new StepTokenizer(bytes(s)).scanEntitiesFast()];
+const scanSlow = (s: string) => [...new StepTokenizer(bytes(s)).scanEntities()];
+
+describe('StepTokenizer.scanEntitiesFast', () => {
+  it('reports a byte length that spans the record up to and including the terminating semicolon', () => {
+    const src = "#1=IFCWALL('a');";
+    const [ref] = scanFast(src);
+    expect(ref).toBeDefined();
+    // The whole record, semicolon included — downstream slices `source` with
+    // this length, so an off-by-one drops the record terminator.
+    expect(ref.length).toBe(src.length);
+    expect(src.slice(ref.offset, ref.offset + ref.length)).toBe(src);
+    expect(src[ref.offset + ref.length - 1]).toBe(';');
+  });
+
+  it('rejects a type token that does not start with an uppercase letter', () => {
+    // STEP entity keywords are uppercase. A lowercase token after `=` is not a
+    // type name; accepting it invents entities out of malformed input.
+    expect(scanFast('#1=ifcwall(1);')).toEqual([]);
+    expect(scanFast('#1=_priv(1);')).toEqual([]);
+    // ...but a legitimately uppercase-initial name is still accepted.
+    expect(scanFast('#1=IFCWALL(1);').map((r) => r.type)).toEqual(['IFCWALL']);
+  });
+
+  it('counts newlines inside a multi-line record so later entities keep true line numbers', () => {
+    const src = ['#1=IFCWALL(', "  'name',", '  $', ');', '#2=IFCSLAB($);'].join('\n');
+    const refs = scanFast(src);
+    expect(refs.map((r) => r.expressId)).toEqual([1, 2]);
+    expect(refs[0].line).toBe(1);
+    // #2 sits on the 5th line; the three newlines inside #1's body must count.
+    expect(refs[1].line).toBe(5);
+  });
+
+  it('treats a quoted semicolon as string content, not as the end of the record', () => {
+    const src = "#1=IFCWALL('has ; semicolon');\n#2=IFCSLAB($);";
+    const refs = scanFast(src);
+    expect(refs.map((r) => r.expressId)).toEqual([1, 2]);
+    expect(refs[0].length).toBe("#1=IFCWALL('has ; semicolon');".length);
+  });
+
+  it('closes the string at a doubled-quote escape rather than staying inside it', () => {
+    // `''` is the STEP escape for a literal apostrophe. The scanner must
+    // consume both quotes without flipping out of string state, and must then
+    // still recognise the closing quote and the record terminator.
+    const src = "#1=IFCWALL('it''s here');\n#2=IFCSLAB($);";
+    const refs = scanFast(src);
+    expect(refs.map((r) => r.expressId)).toEqual([1, 2]);
+    expect(refs[0].length).toBe("#1=IFCWALL('it''s here');".length);
+  });
+
+  it('does not alias two type names that collide in the type-name cache', () => {
+    // The fast scanner caches decoded type names under a `length:hash` key to
+    // avoid millions of allocations. `Aa` and `BB` are the same length and
+    // produce the same 32-bit rolling hash, so the cache key alone cannot tell
+    // them apart — only the byte-for-byte verification of a cache hit can.
+    // Without it a hostile or corrupt file has one type silently read as
+    // another (a door reported as a wall).
+    const refs = scanFast('#1=Aa(1);\n#2=BB(1);\n#3=Aa(1);');
+    expect(refs.map((r) => r.type)).toEqual(['Aa', 'BB', 'Aa']);
+  });
+
+  it('keeps colliding type names distinct even when their lengths differ', () => {
+    // `DHMWK` and `LILQAGG` share a rolling hash but not a length.
+    const refs = scanFast('#1=DHMWK(1);\n#2=LILQAGG(1);\n#3=DHMWK(1);');
+    expect(refs.map((r) => r.type)).toEqual(['DHMWK', 'LILQAGG', 'DHMWK']);
+  });
+
+  it('reuses one interned string for a repeated type name', () => {
+    const refs = scanFast('#1=IFCWALL(1);\n#2=IFCWALL(1);');
+    expect(refs[0].type).toBe(refs[1].type);
+  });
+});
+
+describe('StepTokenizer.scanEntities (paren-matching scan)', () => {
+  it('yields each entity with the byte span its matching close paren defines', () => {
+    const src = "#1=IFCWALL('a',#2);\n#2=IFCSLAB($);";
+    const refs = scanSlow(src);
+    expect(refs.map((r) => r.expressId)).toEqual([1, 2]);
+    expect(refs.map((r) => r.type)).toEqual(['IFCWALL', 'IFCSLAB']);
+    expect(refs[0].line).toBe(1);
+    expect(refs[1].line).toBe(2);
+    // Length runs from `#` to the matching `)` (the semicolon is not included
+    // on this path — the close paren terminates the record).
+    expect(src.slice(refs[0].offset, refs[0].offset + refs[0].length))
+      .toBe("#1=IFCWALL('a',#2)");
+  });
+
+  it('tracks nested parentheses so a nested list does not close the record early', () => {
+    const src = '#1=IFCPOLYLOOP(((0.,0.),(1.,1.)),$);';
+    const [ref] = scanSlow(src);
+    expect(ref).toBeDefined();
+    expect(src.slice(ref.offset, ref.offset + ref.length))
+      .toBe('#1=IFCPOLYLOOP(((0.,0.),(1.,1.)),$)');
+  });
+
+  it('ignores parentheses that appear inside a quoted string', () => {
+    // A `)` inside a string must not decrement the nesting depth; if it does,
+    // the record is truncated mid-string and every downstream attribute read
+    // sees a malformed record.
+    const src = "#1=IFCWALL('closing ) paren',$);";
+    const [ref] = scanSlow(src);
+    expect(ref).toBeDefined();
+    expect(src.slice(ref.offset, ref.offset + ref.length))
+      .toBe("#1=IFCWALL('closing ) paren',$)");
+  });
+
+  it('ignores an unbalanced open paren inside a quoted string', () => {
+    const src = "#1=IFCWALL('opening ( paren',$);\n#2=IFCSLAB($);";
+    const refs = scanSlow(src);
+    expect(refs.map((r) => r.expressId)).toEqual([1, 2]);
+    expect(src.slice(refs[0].offset, refs[0].offset + refs[0].length))
+      .toBe("#1=IFCWALL('opening ( paren',$)");
+  });
+
+  it('yields nothing for a `#` that carries no express id', () => {
+    // `readExpressId` must reject a digitless `#`; accepting it would mint an
+    // entity with expressId 0 that collides with every other malformed marker.
+    expect(scanSlow('#=IFCWALL(1);')).toEqual([]);
+    expect(scanFast('#=IFCWALL(1);')).toEqual([]);
+  });
+
+  it('yields nothing when the record never closes its parenthesis', () => {
+    expect(scanSlow("#1=IFCWALL('a',$")).toEqual([]);
+  });
+});


### PR DESCRIPTION
Second, deeper mutation sweep of `packages/parser`. Test-only — **no production code changed**.

## Method

28 mutations against load-bearing logic. Each was applied by exact-substring replacement with an asserted replacement count of 1, the mutated region was re-read and confirmed changed, and every survivor was re-run against **all three suites that alias `@ifc-lite/parser` to source** — `packages/parser`, `packages/export`, `packages/query` — before being called a survivor.

**Controls** (mutations expected to die, run before believing any survivor):

| Control | Mutation | Result |
|---|---|---|
| A | `tokenizer.ts` — express-id accumulation `id*10 + (c-0x30)` → `id*10` | KILLED, 46 tests |
| B | `unit-extractor.ts` — `'MILLI': 1e-3` → `1e-2` | KILLED, 7 tests |

**Kill ratio: 6/28 (21%) before, 27/28 (96%) after.** Flagged **TARGETED** — the mutations deliberately aimed at the four modules that had no test file of their own.

## Modules with no direct coverage

| Module | LOC | Mutations | Survived before |
|---|---|---|---|
| `src/tokenizer.ts` | 359 | 10 | 9 |
| `src/source-header.ts` | 269 | 11 | 8 |
| `src/entity-refs-from-index.ts` | 126 | 3 | 2 |
| `src/attribute-helpers.ts` | 56 | 3 | 2 |
| `src/compact-entity-index.ts` | 480 | 1 | 0 |

## Gaps closed

Each row: the surviving mutation that proved the gap, and the test that now kills it.

### `src/tokenizer.ts` — the STEP scanner every model in the product passes through

| Surviving mutation | What a user would see | Killing test |
|---|---|---|
| Type-cache hit no longer verified byte-for-byte | A hostile or corrupt file gets one entity type silently read as another — a door reported as a wall. The verification exists specifically to defeat this; nothing tested it. | `does not alias two type names that collide in the type-name cache` (`Aa`/`BB` — same length, same 32-bit rolling hash) |
| Entity byte length excludes the terminating `;` | Every record slice is one byte short. | `reports a byte length that spans the record up to and including the terminating semicolon` |
| Type token no longer required to start `A-Z` | Malformed input mints entities out of lowercase tokens. | `rejects a type token that does not start with an uppercase letter` |
| Newlines inside a record body not counted | Every entity after a multi-line record reports a wrong line number in diagnostics. | `counts newlines inside a multi-line record so later entities keep true line numbers` |
| `findEntityLength` ignores string state | A `(` or `)` inside a quoted attribute changes the nesting depth; the record is truncated mid-string. | `ignores parentheses that appear inside a quoted string`, `ignores an unbalanced open paren inside a quoted string` |
| **`scanEntities()` yields nothing at all** | The entire paren-matching generator was dead to tests. It is exported public API (`StepTokenizer` via `index.ts`), so SDK consumers can call it. | four tests under `StepTokenizer.scanEntities` |
| `readExpressId` accepts a digitless `#` | A bare `#` mints an entity with `expressId` 0 that collides with every other malformed marker. | ``yields nothing for a `#` that carries no express id`` |

### `src/source-header.ts` — read on every parse, written back on every STEP export

A decoding error here silently rewrites a file's authorship and provenance on export.

| Surviving mutation | What a user would see | Killing test |
|---|---|---|
| `*` (derived) sentinel no longer maps to `undefined` | A literal `*` is written into the exported header field. | ``maps the `*` derived sentinel to undefined, not to a literal asterisk`` |
| `''` doubled-quote escape not collapsed | `it''s a name` stays doubled on read and re-doubles on every export round-trip. | ``collapses the `''` doubled-quote escape to a single apostrophe`` |
| `\X4\` span not consumed atomically | A UTF-32 directive immediately followed by an escaped backslash loses its terminator and never decodes. | `keeps a \X4\ directive intact when an escaped backslash immediately follows it` |
| `\S\` span not consumed atomically | A `\S\` whose operand is itself a backslash is claimed by the `\\` pair escape, leaving the directive unterminated. | `treats a backslash as a valid \S\ operand rather than a pair escape` |
| ENDSEC truncation removed | A quoted DATA-section attribute containing the literal text `FILE_NAME(...)` is parsed as the file's header. | `stops at the first ENDSEC so DATA-section text is never read as a header` |
| Bare-value list tolerance dropped | Writers that emit `FILE_SCHEMA('IFC4')` without the inner list lose the schema token. | `accepts a bare value where a list was expected` |
| Quote-awareness dropped in `extractRecordArgs` | A `)` inside a quoted filename ends the record early; every later FILE_NAME field is lost. | `does not end the record at a closing parenthesis inside a quoted string` |
| FILE_NAME positional read shifted by one | Authorization reads the originating-system slot. | `maps every FILE_NAME slot to its own field` (all seven values distinct, so a shifted index cannot land on a match) |

### `src/entity-refs-from-index.ts` — the parser worker's fast path

| Surviving mutation | What a user would see | Killing test |
|---|---|---|
| Column-length mismatch guard only checks `starts` | A truncated `lengths` column passes through as undefined spans instead of failing loudly. | ``throws when the `lengths` column is shorter than the `ids` column`` |
| Out-of-bounds span end check dropped | A span that walks off the buffer yields a truncated record with an empty type name rather than surfacing the corruption. | `throws when a span ends past the end of the source` |

### `src/attribute-helpers.ts`

| Surviving mutation | What a user would see | Killing test |
|---|---|---|
| `.F.` no longer maps to `false` | Callers treat `undefined` as "not stated" and fall back to a default, so an explicit STEP "no" becomes whatever the default happens to be. | ``maps the STEP `.F.` logical to false`` |
| `getString` non-string coercion removed | A numeric IFC attribute (name, identifier) blanks out entirely. | `coerces a non-string scalar to its string form` |

## Weak-shaped existing test found

`packages/export/src/source-header-roundtrip.test.ts` is the only pre-existing test that touched the header reader, and it carries three of the shapes this campaign keeps hitting:

1. **An expected value equal to the same constant the implementation uses.** Every fixture declares `implementation_level` as `'2;1'` — byte-identical to the parser's hard-coded fallback `let implementationLevel = '2;1'`. A probe mutation that stops parsing the field *entirely* (`if (false) implementationLevel = ...`) leaves `expect(sh!.implementationLevel).toBe('2;1')` **passing**. The new `reads the declared implementation_level rather than falling back to the default` uses `3;7`, and a separate test pins the fallback.
2. **Fixture constants that make the bug cancel.** No fixture contains a STEP escape of any kind (`''`, `\X2\`, `\X4\`, `\S\`, `\X\`, `\P?\`), a `$`/`*` sentinel, or a quoted delimiter — which is why eight independent mutations to `source-header.ts` survived.
3. **Expectations derived from the code under test.** Its `exportedHeader()` helper re-parses the exported bytes with `parseSourceHeader`, the function under test, so a symmetric read/write escaping bug cancels on both sides.

That test is left in place and still passes; the new parser-side tests assert against literal expected values instead of a round trip.

## Survivors classified

Two mutations still survive. Both are **EQUIVALENT**, proven:

- **`cacheKey` drops the length component** (`` `${typeLen}:${typeHash}` `` → `` `${typeHash}` ``). The cache-hit path already re-derives correctness independently: it checks `type.length === typeLen` and then compares every byte. Dropping `typeLen` from the key can therefore only cause an extra recompute-and-overwrite on a cross-length collision, never a wrong type. Correctness-equivalent; a pure (and negligible) cache-thrash regression. A test is included anyway (`keeps colliding type names distinct even when their lengths differ`, using `DHMWK`/`LILQAGG`) as a regression guard should the verification ever be refactored away.
- **`findEntityLength`'s doubled-quote skip disabled.** With the skip, both quotes are consumed and `inString` is unchanged (`true`). Without it, the first quote sets `inString = false` and the second sets it back to `true` — both quotes consumed, same end state, and there is no character between them for the transient state to affect. Byte-for-byte identical behaviour on every input.

No genuine gap is left unclosed, and nothing is padded.

## Verification

- Baseline `packages/parser`: **47 files / 382 tests**. Final: **51 files / 448 tests** (+4 files, +66 tests).
- `packages/export` 363 passed / 29 skipped and `packages/query` 153 passed are unchanged.
- Dependencies built with `pnpm turbo build --filter=@ifc-lite/parser^...` before every run; no suite silently skipped.
- No pre-existing failures found.

## Typecheck

`pnpm typecheck` covers only `apps/viewer` and `apps/viewer-embed`, and the root tsconfig excludes `**/*.test.ts`, so it does not check this work. Typechecked separately against `packages/parser/tsconfig.json` with `test/**/*` added to `include`: **exit 0, zero errors** — including every pre-existing parser test file, so there are no pre-existing errors to report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)