### PR TITLE
test(export): close 40 mutation-verified gaps in a second, deeper sweep

### DIFF
--- a/packages/export/src/demesh-writer.test.ts
+++ b/packages/export/src/demesh-writer.test.ts
@@ -395,3 +395,95 @@ ${FOOTER}`;
     expect(danglingRefs(out)).toEqual([]);
   });
 });
+
+/**
+ * Three prune behaviours that no fixture above reaches. A mutation sweep left
+ * the suite green on all three: deleting `IFCOWNERHISTORY` from
+ * `PROTECTED_TYPES`, counting EVERY tombstone into `strippedOpeningCount`
+ * (`toBeGreaterThan(0)` holds either way), and never pulling styled items into
+ * the closure.
+ */
+
+// FIXTURE_SINGLE, except the opening element carries an IfcOwnerHistory that
+// NOTHING else in the file references. When the opening falls, the history is
+// orphaned inside the closure and only PROTECTED_TYPES keeps it alive.
+const FIXTURE_ORPHANED_OWNER = `${HEADER}
+#95=IFCOWNERHISTORY($,$,$,.ADDED.,$,$,$,0);
+#10=IFCWALL('0wall10000000000000000',$,'A',$,$,$,#100,$,$);
+#100=IFCPRODUCTDEFINITIONSHAPE($,$,(#110));
+#110=IFCSHAPEREPRESENTATION(#8,'Body','SweptSolid',(#120));
+#120=IFCEXTRUDEDAREASOLID(#130,#131,#132,2.);
+#130=IFCRECTANGLEPROFILEDEF(.AREA.,$,$,1.,1.);
+#131=IFCAXIS2PLACEMENT3D(#5,$,$);
+#132=IFCDIRECTION((0.,0.,1.));
+#200=IFCOPENINGELEMENT('0open00000000000000000',#95,$,$,$,$,#210,$,$);
+#210=IFCPRODUCTDEFINITIONSHAPE($,$,(#211));
+#211=IFCSHAPEREPRESENTATION(#8,'Body','SweptSolid',(#212));
+#212=IFCEXTRUDEDAREASOLID(#213,#131,#132,1.);
+#213=IFCRECTANGLEPROFILEDEF(.AREA.,$,$,0.5,0.5);
+#220=IFCRELVOIDSELEMENT('0rvoid0000000000000000',$,$,$,#10,#200);
+${FOOTER}`;
+
+// FIXTURE_SINGLE with no opening at all, plus a style chain hanging OFF the
+// replaced solid (#120). IfcStyledItem points AT the geometry, so forward
+// reachability from the representation root never finds it.
+const FIXTURE_STYLED = `${HEADER}
+#10=IFCWALL('0wall10000000000000000',$,'A',$,$,$,#100,$,$);
+#100=IFCPRODUCTDEFINITIONSHAPE($,$,(#110));
+#110=IFCSHAPEREPRESENTATION(#8,'Body','SweptSolid',(#120));
+#120=IFCEXTRUDEDAREASOLID(#130,#131,#132,2.);
+#130=IFCRECTANGLEPROFILEDEF(.AREA.,$,$,1.,1.);
+#131=IFCAXIS2PLACEMENT3D(#5,$,$);
+#132=IFCDIRECTION((0.,0.,1.));
+#500=IFCSTYLEDITEM(#120,(#501),$);
+#501=IFCSURFACESTYLE('OldStyle',.BOTH.,(#502));
+#502=IFCSURFACESTYLESHADING(#503,0.);
+#503=IFCCOLOURRGB($,1.,0.,0.);
+${FOOTER}`;
+
+describe('applySimplifiedGeometry — prune edges', () => {
+  it('never tombstones shared infrastructure orphaned by the sweep (IfcOwnerHistory)', async () => {
+    const { store, view, editor } = await loadStore(FIXTURE_ORPHANED_OWNER);
+    const report = applySimplifiedGeometry(store, editor, [{ expressId: 10, ...TETRA }]);
+    expect(report.replaced).toEqual([10]);
+
+    const out = exportText(store, view);
+    // The opening that referenced it IS gone — so this is genuinely the
+    // orphaned case, not a history kept alive by a surviving referrer.
+    expect(out).not.toMatch(/IFCOPENINGELEMENT/);
+    expect(out).toMatch(/#95=IFCOWNERHISTORY/);
+    expect(danglingRefs(out)).toEqual([]);
+  });
+
+  it('counts ONLY openings into strippedOpeningCount', async () => {
+    const { store, view, editor } = await loadStore(FIXTURE_SINGLE);
+    const report = applySimplifiedGeometry(store, editor, [{ expressId: 10, ...TETRA }]);
+
+    // Exactly the IfcRelVoidsElement (#220) and the IfcOpeningElement (#200).
+    // `toBeGreaterThan(0)` is equally true of a counter that counts every
+    // tombstone, which is a strictly larger number here.
+    expect(report.strippedOpeningCount).toBe(2);
+    expect(report.prunedEntityCount).toBeGreaterThan(report.strippedOpeningCount);
+  });
+
+  it('reports zero stripped openings for a model that has none', async () => {
+    const { store, editor } = await loadStore(FIXTURE_STYLED);
+    const report = applySimplifiedGeometry(store, editor, [{ expressId: 10, ...TETRA }]);
+    expect(report.strippedOpeningCount).toBe(0);
+    expect(report.prunedEntityCount).toBeGreaterThan(0);
+  });
+
+  it('prunes the style chain that hangs off replaced geometry, leaving no dangling item', async () => {
+    const { store, view, editor } = await loadStore(FIXTURE_STYLED);
+    applySimplifiedGeometry(store, editor, [{ expressId: 10, ...TETRA }]);
+    const out = exportText(store, view);
+
+    // The old solid is gone...
+    expect(out).not.toMatch(/IFCEXTRUDEDAREASOLID/);
+    // ...and so is the styled item that pointed at it. Matched by its own id
+    // so the NEW style chain this export writes cannot satisfy the assertion.
+    expect(out).not.toMatch(/#500=IFCSTYLEDITEM/);
+    expect(out).not.toMatch(/'OldStyle'/);
+    expect(danglingRefs(out)).toEqual([]);
+  });
+});

--- a/packages/export/src/entity-iteration.test.ts
+++ b/packages/export/src/entity-iteration.test.ts
@@ -1,0 +1,127 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `entity-iteration.ts` had no test file. Its iteration half is well pinned
+ * indirectly — dropping `yield* deferred` fails four exporter tests — but its
+ * `size` is not: reporting only the primary index's size left the whole suite
+ * green, and `size` is what `StepExporter`/`MergedExporter` report as the
+ * export's entity total (`step-exporter.ts:1069`, `merged-exporter.ts:611`).
+ *
+ * A user with a `deferPropertyAtomIndex` parse sees an export summary that
+ * undercounts by every deferred property atom — thousands on a real file —
+ * while the file itself is complete.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { IfcDataStore } from '@ifc-lite/parser';
+import { getCompleteEntityIndex, getMaxExpressId, type ExportEntityRef } from './entity-iteration.js';
+
+const ref = (type: string, byteOffset: number): ExportEntityRef => ({ type, byteOffset, byteLength: 10 });
+
+/**
+ * `byId` and `deferredEntityIndex` are DISJOINT by construction and here have
+ * DIFFERENT sizes (2 vs 3) — equal sizes would let `byId.size + deferred.size`
+ * and `deferred.size * 2` agree, and either alone would be half the total.
+ */
+function storeWithDeferred(): IfcDataStore {
+  return {
+    entityIndex: {
+      byId: new Map([
+        [1, ref('IFCWALL', 0)],
+        [2, ref('IFCPROPERTYSET', 20)],
+      ]),
+    },
+    deferredEntityIndex: new Map([
+      [7, ref('IFCPROPERTYSINGLEVALUE', 40)],
+      [8, ref('IFCPROPERTYSINGLEVALUE', 60)],
+      [9, ref('IFCQUANTITYAREA', 80)],
+    ]),
+  } as unknown as IfcDataStore;
+}
+
+function storeWithoutDeferred(): IfcDataStore {
+  return {
+    entityIndex: {
+      byId: new Map([
+        [1, ref('IFCWALL', 0)],
+        [2, ref('IFCPROPERTYSET', 20)],
+      ]),
+    },
+  } as unknown as IfcDataStore;
+}
+
+describe('getCompleteEntityIndex', () => {
+  it('counts the deferred atoms in size, not just the primary index', () => {
+    expect(getCompleteEntityIndex(storeWithDeferred()).size).toBe(5);
+  });
+
+  it('resolves and reports membership across both indexes', () => {
+    const index = getCompleteEntityIndex(storeWithDeferred());
+    expect(index.get(1)?.type).toBe('IFCWALL');
+    expect(index.get(9)?.type).toBe('IFCQUANTITYAREA');
+    expect(index.get(999)).toBeUndefined();
+    expect(index.has(2)).toBe(true);
+    expect(index.has(8)).toBe(true);
+    expect(index.has(999)).toBe(false);
+  });
+
+  it('iterates every id from both indexes exactly once', () => {
+    const ids = [...getCompleteEntityIndex(storeWithDeferred())].map(([id]) => id);
+    expect(ids).toEqual([1, 2, 7, 8, 9]);
+  });
+
+  it('size stays consistent with what iteration yields', () => {
+    const index = getCompleteEntityIndex(storeWithDeferred());
+    expect([...index]).toHaveLength(index.size);
+  });
+
+  it('returns the primary index itself when nothing was deferred', () => {
+    const store = storeWithoutDeferred();
+    expect(getCompleteEntityIndex(store)).toBe(store.entityIndex.byId as never);
+  });
+
+  it('takes the fast path for an EMPTY deferred index too', () => {
+    // The third state alongside "absent" and "populated": present but empty.
+    const store = storeWithoutDeferred() as unknown as { deferredEntityIndex: Map<number, ExportEntityRef> };
+    store.deferredEntityIndex = new Map();
+    const index = getCompleteEntityIndex(store as unknown as IfcDataStore);
+    expect(index.size).toBe(2);
+    expect(index).toBe((store as unknown as IfcDataStore).entityIndex.byId as never);
+  });
+});
+
+describe('getMaxExpressId', () => {
+  it('returns the largest id present, including one that only the deferred index holds', () => {
+    expect(getMaxExpressId(getCompleteEntityIndex(storeWithDeferred()))).toBe(9);
+  });
+
+  it('returns the id itself, not its predecessor (the next free id is caller-side)', () => {
+    const index = getCompleteEntityIndex({
+      entityIndex: { byId: new Map([[42, ref('IFCWALL', 0)]]) },
+    } as unknown as IfcDataStore);
+    expect(getMaxExpressId(index)).toBe(42);
+  });
+
+  it('returns 0 for an empty index', () => {
+    const index = getCompleteEntityIndex({
+      entityIndex: { byId: new Map() },
+    } as unknown as IfcDataStore);
+    expect(getMaxExpressId(index)).toBe(0);
+  });
+
+  it('is order-independent — a descending index reports the same maximum', () => {
+    // A monotonically increasing fixture lets "return the LAST id" pass too.
+    const index = getCompleteEntityIndex({
+      entityIndex: {
+        byId: new Map([
+          [50, ref('IFCWALL', 0)],
+          [10, ref('IFCSLAB', 20)],
+          [30, ref('IFCBEAM', 40)],
+        ]),
+      },
+    } as unknown as IfcDataStore);
+    expect(getMaxExpressId(index)).toBe(50);
+  });
+});

--- a/packages/export/src/glb-mesh.test.ts
+++ b/packages/export/src/glb-mesh.test.ts
@@ -1,0 +1,193 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `glb.ts` exports four functions; `glb.test.ts` covered exactly one
+ * (`countGlbMeshes`) plus a one-line smoke of `parseGLB`. `extractGlbMapping`
+ * and `parseGLBToMeshData` — the two that actually read binary offsets — had
+ * no test of their own, and a mutation sweep confirmed it: swapping the node
+ * and mesh indices in the mapping, dropping the accessor `byteOffset` from the
+ * buffer-view base, forcing material alpha to 1, blackening the default colour,
+ * and deleting the GLB total-length check ALL left the suite green.
+ *
+ * A wrong accessor offset does not throw — it reads the neighbouring
+ * attribute's bytes and hands back a mesh whose normals are its positions.
+ * These are the tests that see it.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseGLB, extractGlbMapping, parseGLBToMeshData, countGlbMeshes } from './glb.js';
+
+const FLOAT = 5126;
+const UNSIGNED_INT = 5125;
+
+/** Assemble a GLB from a JSON chunk and a BIN chunk, as the Rust assembler does. */
+function buildGlb(json: unknown, bin: Uint8Array, declaredTotalLength?: number): Uint8Array {
+  const jsonBytes = new TextEncoder().encode(JSON.stringify(json));
+  const pad4 = (n: number) => (4 - (n % 4)) % 4;
+  const jsonChunkLen = jsonBytes.length + pad4(jsonBytes.length);
+  const binChunkLen = bin.length + pad4(bin.length);
+  const total = 12 + 8 + jsonChunkLen + 8 + binChunkLen;
+  const out = new Uint8Array(total);
+  const dv = new DataView(out.buffer);
+  let o = 0;
+  dv.setUint32(o, 0x46546c67, true); o += 4; // magic 'glTF'
+  dv.setUint32(o, 2, true); o += 4; // version
+  dv.setUint32(o, declaredTotalLength ?? total, true); o += 4;
+  dv.setUint32(o, jsonChunkLen, true); o += 4;
+  dv.setUint32(o, 0x4e4f534a, true); o += 4; // 'JSON'
+  out.set(jsonBytes, o); o += jsonBytes.length;
+  for (let i = 0; i < pad4(jsonBytes.length); i++) out[o++] = 0x20;
+  dv.setUint32(o, binChunkLen, true); o += 4;
+  dv.setUint32(o, 0x004e4942, true); o += 4; // 'BIN\0'
+  out.set(bin, o);
+  return out;
+}
+
+const POSITIONS = [0, 0, 0, 1, 0, 0, 1, 1, 0];
+/**
+ * Deliberately DIFFERENT from POSITIONS, and not a unit axis triple: if the
+ * accessor byteOffset were dropped, NORMAL would silently alias POSITION and a
+ * fixture whose normals happened to equal its positions would never notice.
+ */
+const NORMALS = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9];
+const INDICES = [0, 1, 2];
+
+/** BIN chunk: 16 bytes of lead-in (→ bufferView byteOffset 16), then the three
+ *  accessor ranges back to back at accessor byteOffsets 0 / 36 / 72. */
+function buildBin(): { bin: Uint8Array; bvOffset: number; accOffsets: [number, number, number] } {
+  const bvOffset = 16;
+  const posBytes = new Uint8Array(new Float32Array(POSITIONS).buffer);
+  const norBytes = new Uint8Array(new Float32Array(NORMALS).buffer);
+  const idxBytes = new Uint8Array(new Uint32Array(INDICES).buffer);
+  const bin = new Uint8Array(bvOffset + posBytes.length + norBytes.length + idxBytes.length);
+  bin.fill(0xff, 0, bvOffset); // lead-in is NOT zero, so aliasing it is visible
+  bin.set(posBytes, bvOffset);
+  bin.set(norBytes, bvOffset + posBytes.length);
+  bin.set(idxBytes, bvOffset + posBytes.length + norBytes.length);
+  return {
+    bin,
+    bvOffset,
+    accOffsets: [0, posBytes.length, posBytes.length + norBytes.length],
+  };
+}
+
+/**
+ * A GLB with TWO nodes but ONE mesh: node 0 carries no mesh at all, so the
+ * node index (1) and the mesh index (0) DIFFER. Equal indices would make
+ * `{ node, mesh }` a symmetric pair that a swap cannot be seen through.
+ */
+function buildMeshGlb(options: { material?: number; expressId?: number } = {}): Uint8Array {
+  const { bin, bvOffset, accOffsets } = buildBin();
+  const json: Record<string, unknown> = {
+    asset: { version: '2.0' },
+    nodes: [
+      { name: 'no-mesh-node' },
+      {
+        mesh: 0,
+        extras: options.expressId === undefined ? {} : { expressId: options.expressId },
+      },
+    ],
+    meshes: [
+      {
+        primitives: [
+          {
+            attributes: { POSITION: 0, NORMAL: 1 },
+            indices: 2,
+            ...(options.material === undefined ? {} : { material: options.material }),
+          },
+        ],
+      },
+    ],
+    accessors: [
+      { bufferView: 0, byteOffset: accOffsets[0], componentType: FLOAT, count: 3, type: 'VEC3' },
+      { bufferView: 0, byteOffset: accOffsets[1], componentType: FLOAT, count: 3, type: 'VEC3' },
+      { bufferView: 0, byteOffset: accOffsets[2], componentType: UNSIGNED_INT, count: 3, type: 'SCALAR' },
+    ],
+    bufferViews: [{ buffer: 0, byteOffset: bvOffset, byteLength: bin.length - bvOffset }],
+    materials: [
+      { pbrMetallicRoughness: { baseColorFactor: [0.2, 0.4, 0.6, 0.5] } },
+      { pbrMetallicRoughness: { baseColorFactor: [0.1, 0.3, 0.5] } }, // RGB only
+      { pbrMetallicRoughness: {} }, // no factor at all
+    ],
+    buffers: [{ byteLength: bin.length }],
+  };
+  return buildGlb(json, bin);
+}
+
+describe('extractGlbMapping', () => {
+  it('maps each express id to its own node index and its own mesh index', () => {
+    // node 1 → mesh 0: the two indices differ, so a swap is visible.
+    const mapping = extractGlbMapping(buildMeshGlb({ expressId: 42 }));
+    expect(mapping).toEqual({ '42': { node: 1, mesh: 0 } });
+  });
+
+  it('skips a node that has no mesh and a node that has no express id', () => {
+    const withoutId = extractGlbMapping(buildMeshGlb());
+    expect(withoutId).toEqual({});
+  });
+});
+
+describe('parseGLBToMeshData', () => {
+  it('reads each attribute from its own accessor byteOffset, not the buffer-view base', () => {
+    const meshes = parseGLBToMeshData(buildMeshGlb({ expressId: 42 }));
+    expect(meshes).toHaveLength(1);
+    expect(Array.from(meshes[0].positions)).toEqual(POSITIONS);
+    // If the accessor byteOffset were dropped, this would come back as
+    // POSITIONS (or as the 0xff lead-in bytes read as floats).
+    expect(Array.from(meshes[0].normals).map((v) => Number(v.toFixed(6)))).toEqual(NORMALS);
+    expect(Array.from(meshes[0].indices)).toEqual(INDICES);
+  });
+
+  it('carries the node expressId onto the mesh, defaulting to 0 when absent', () => {
+    expect(parseGLBToMeshData(buildMeshGlb({ expressId: 42 }))[0].expressId).toBe(42);
+    expect(parseGLBToMeshData(buildMeshGlb())[0].expressId).toBe(0);
+  });
+
+  it('resolves the material baseColorFactor including a non-1 alpha', () => {
+    // Alpha 0.5: an opaque fixture makes the alpha slot an identity against
+    // the hard-coded 1 fallback and cannot see it being dropped.
+    const meshes = parseGLBToMeshData(buildMeshGlb({ material: 0, expressId: 42 }));
+    expect(meshes[0].color).toEqual([0.2, 0.4, 0.6, 0.5]);
+  });
+
+  it('defaults alpha to 1 for an RGB-only baseColorFactor', () => {
+    const meshes = parseGLBToMeshData(buildMeshGlb({ material: 1, expressId: 42 }));
+    expect(meshes[0].color).toEqual([0.1, 0.3, 0.5, 1]);
+  });
+
+  it('falls back to the neutral grey default when the primitive names no material', () => {
+    // The third, untested state alongside "has a factor" and "has an RGB
+    // factor": no material index at all.
+    const meshes = parseGLBToMeshData(buildMeshGlb({ expressId: 42 }));
+    expect(meshes[0].color).toEqual([0.8, 0.8, 0.8, 1]);
+  });
+
+  it('falls back to the neutral grey default when the material carries no baseColorFactor', () => {
+    const meshes = parseGLBToMeshData(buildMeshGlb({ material: 2, expressId: 42 }));
+    expect(meshes[0].color).toEqual([0.8, 0.8, 0.8, 1]);
+  });
+
+  it('returns no meshes for a node-less GLB', () => {
+    const glb = buildGlb({ asset: { version: '2.0' }, meshes: [] }, new Uint8Array(4));
+    expect(parseGLBToMeshData(glb)).toEqual([]);
+  });
+});
+
+describe('parseGLB header validation', () => {
+  it('rejects a GLB whose declared total length exceeds the buffer it arrived in', () => {
+    // A truncated download: the chunks that DID arrive still parse, so without
+    // the length check the caller silently accepts a partial model.
+    const { bin } = buildBin();
+    const truncated = buildGlb({ asset: { version: '2.0' }, meshes: [{}] }, bin, 1_000_000);
+    expect(() => parseGLB(truncated)).toThrow(/Invalid GLB length/);
+    expect(countGlbMeshes(truncated)).toBe(0);
+  });
+
+  it('accepts the same GLB when the declared length matches', () => {
+    const { bin } = buildBin();
+    const intact = buildGlb({ asset: { version: '2.0' }, meshes: [{}] }, bin);
+    expect(countGlbMeshes(intact)).toBe(1);
+  });
+});

--- a/packages/export/src/lod-geometry-utils.test.ts
+++ b/packages/export/src/lod-geometry-utils.test.ts
@@ -118,10 +118,30 @@ describe('mat4 helpers', () => {
   });
 
   it('mat4Mul composes parent-then-child in that order', () => {
-    // Translate by (10,0,0), then by (0,20,0), applied to the origin.
-    const a = mat4FromBasisTranslation([1, 0, 0], [0, 1, 0], [0, 0, 1], [10, 0, 0]);
-    const b = mat4FromBasisTranslation([1, 0, 0], [0, 1, 0], [0, 0, 1], [0, 20, 0]);
-    expect(mat4TransformPoint(mat4Mul(a, b), vec3(0, 0, 0))).toEqual([10, 20, 0]);
+    // NOT two translations: translations COMMUTE, so `mat4Mul(a, b)` and
+    // `mat4Mul(b, a)` agree and the operand order — the only thing this test
+    // is named for — is invisible. A rotation and a translation do not
+    // commute, so the two orders land the origin in different places.
+    //
+    //   rot(90° yaw) ∘ translate(10,0,0) : origin -> (10,0,0) -> (0,10,0)
+    //   translate(10,0,0) ∘ rot(90° yaw) : origin -> (0,0,0)  -> (10,0,0)
+    const rot = mat4FromBasisTranslation([0, 1, 0], [-1, 0, 0], [0, 0, 1], [0, 0, 0]);
+    const move = mat4FromBasisTranslation([1, 0, 0], [0, 1, 0], [0, 0, 1], [10, 0, 0]);
+
+    expect(mat4TransformPoint(mat4Mul(rot, move), vec3(0, 0, 0))).toEqual([0, 10, 0]);
+    // The other order, spelled out, so a swap cannot pass as the same answer.
+    expect(mat4TransformPoint(mat4Mul(move, rot), vec3(0, 0, 0))).toEqual([10, 0, 0]);
+  });
+
+  it('mat4Mul is left-multiplication: mul(a, b) applies b first', () => {
+    // The composition rule itself, independent of the fixture above:
+    // (A·B)·p must equal A·(B·p).
+    const a = mat4FromBasisTranslation([0, 1, 0], [-1, 0, 0], [0, 0, 1], [1, 2, 3]);
+    const b = mat4FromBasisTranslation([0, 0, 1], [0, 1, 0], [-1, 0, 0], [4, 5, 6]);
+    const p = vec3(7, 8, 9);
+
+    expect(mat4TransformPoint(mat4Mul(a, b), p))
+      .toEqual(mat4TransformPoint(a, mat4TransformPoint(b, p)));
   });
 });
 

--- a/packages/export/src/lod-geometry-utils.test.ts
+++ b/packages/export/src/lod-geometry-utils.test.ts
@@ -1,0 +1,142 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `lod-geometry-utils.ts` had no test file. The LOD0/LOD1 generators exercise
+ * its matrix maths well enough that flipping the cross-product handedness or
+ * dropping the translation column both fail `lod0-generator.test.ts` — but the
+ * degenerate paths do not: the empty-point AABB fallback and the
+ * `toIfcArrayBuffer` view window were both mutable with the suite green.
+ *
+ * `toIfcArrayBuffer` is the FIRST thing both generators do to their input
+ * (`lod0-generator.ts:80`, `lod1-generator.ts:138`). Returning the whole
+ * backing buffer for a `Uint8Array` that is a WINDOW onto a larger one — the
+ * ordinary result of slicing bytes out of a container or a pooled read — hands
+ * the parser bytes that are not the model.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  toIfcArrayBuffer,
+  normalizeIfcTypeName,
+  aabbFromPoints,
+  vec3,
+  vec3Cross,
+  vec3Normalize,
+  mat4Identity,
+  mat4Mul,
+  mat4FromBasisTranslation,
+  mat4TransformPoint,
+} from './lod-geometry-utils.js';
+
+describe('toIfcArrayBuffer', () => {
+  it('honours the byteOffset/byteLength window of a partial view', () => {
+    // The mutation-visible case: a view that is NOT the whole buffer. The
+    // neighbouring bytes are deliberately non-zero so aliasing them shows up.
+    const backing = new Uint8Array([0xff, 0xff, 1, 2, 3, 4, 0xff, 0xff]);
+    const view = backing.subarray(2, 6);
+    const out = toIfcArrayBuffer(view);
+    expect(out.byteLength).toBe(4);
+    expect(Array.from(new Uint8Array(out))).toEqual([1, 2, 3, 4]);
+  });
+
+  it('passes an ArrayBuffer straight through', () => {
+    const buf = new Uint8Array([1, 2, 3]).buffer;
+    expect(toIfcArrayBuffer(buf)).toBe(buf);
+  });
+
+  it('avoids a copy for a full-coverage view', () => {
+    const full = new Uint8Array([1, 2, 3, 4]);
+    expect(toIfcArrayBuffer(full)).toBe(full.buffer);
+  });
+
+  it('handles a zero-length window without reaching past it', () => {
+    const backing = new Uint8Array([9, 9, 9, 9]);
+    expect(toIfcArrayBuffer(backing.subarray(2, 2)).byteLength).toBe(0);
+  });
+});
+
+describe('aabbFromPoints', () => {
+  it('brackets the points on every axis', () => {
+    const box = aabbFromPoints([vec3(-1, 5, 2), vec3(3, -4, 8), vec3(0, 0, 0)]);
+    expect(box.min).toEqual([-1, -4, 0]);
+    expect(box.max).toEqual([3, 5, 8]);
+  });
+
+  it('returns a degenerate box at the origin for no points, not a unit box', () => {
+    // The Infinity seeds must not leak into the export; the documented
+    // fallback is a zero-size box AT THE ORIGIN.
+    expect(aabbFromPoints([])).toEqual({ min: [0, 0, 0], max: [0, 0, 0] });
+  });
+
+  it('returns the point itself for a single point', () => {
+    expect(aabbFromPoints([vec3(2, 3, 4)])).toEqual({ min: [2, 3, 4], max: [2, 3, 4] });
+  });
+});
+
+describe('vec3Normalize', () => {
+  it('scales to unit length', () => {
+    expect(vec3Normalize(vec3(0, 0, 5), [1, 0, 0])).toEqual([0, 0, 1]);
+  });
+
+  it('returns the caller fallback for a degenerate or non-finite vector', () => {
+    expect(vec3Normalize(vec3(0, 0, 0), [1, 0, 0])).toEqual([1, 0, 0]);
+    expect(vec3Normalize(vec3(NaN, 0, 0), [0, 1, 0])).toEqual([0, 1, 0]);
+  });
+});
+
+describe('vec3Cross', () => {
+  it('is right-handed: X cross Y is +Z', () => {
+    expect(vec3Cross(vec3(1, 0, 0), vec3(0, 1, 0))).toEqual([0, 0, 1]);
+    expect(vec3Cross(vec3(0, 1, 0), vec3(1, 0, 0))).toEqual([0, 0, -1]);
+  });
+});
+
+describe('mat4 helpers', () => {
+  it('mat4Identity is the multiplicative identity on both sides', () => {
+    const m = mat4FromBasisTranslation([0, 1, 0], [-1, 0, 0], [0, 0, 1], [5, 6, 7]);
+    expect(Array.from(mat4Mul(mat4Identity(), m))).toEqual(Array.from(m));
+    expect(Array.from(mat4Mul(m, mat4Identity()))).toEqual(Array.from(m));
+  });
+
+  it('mat4FromBasisTranslation puts the basis in the columns and the translation last', () => {
+    const m = mat4FromBasisTranslation([1, 0, 0], [0, 1, 0], [0, 0, 1], [5, 6, 7]);
+    expect(Array.from(m)).toEqual([
+      1, 0, 0, 5,
+      0, 1, 0, 6,
+      0, 0, 1, 7,
+      0, 0, 0, 1,
+    ]);
+  });
+
+  it('mat4TransformPoint applies rotation AND translation', () => {
+    // A 90-degree yaw with a non-zero translation: an identity rotation would
+    // hide a dropped basis, and a zero translation would hide a dropped column.
+    const m = mat4FromBasisTranslation([0, 1, 0], [-1, 0, 0], [0, 0, 1], [5, 6, 7]);
+    expect(mat4TransformPoint(m, vec3(1, 0, 0))).toEqual([5, 7, 7]);
+  });
+
+  it('mat4Mul composes parent-then-child in that order', () => {
+    // Translate by (10,0,0), then by (0,20,0), applied to the origin.
+    const a = mat4FromBasisTranslation([1, 0, 0], [0, 1, 0], [0, 0, 1], [10, 0, 0]);
+    const b = mat4FromBasisTranslation([1, 0, 0], [0, 1, 0], [0, 0, 1], [0, 20, 0]);
+    expect(mat4TransformPoint(mat4Mul(a, b), vec3(0, 0, 0))).toEqual([10, 20, 0]);
+  });
+});
+
+describe('normalizeIfcTypeName', () => {
+  it('keeps an already-PascalCase name', () => {
+    expect(normalizeIfcTypeName('IfcWallStandardCase')).toBe('IfcWallStandardCase');
+  });
+
+  it('passes an uppercase STEP name through unchanged', () => {
+    expect(normalizeIfcTypeName('IFCWALL')).toBe('IFCWALL');
+  });
+
+  it('trims, and maps empty/undefined input to the empty string', () => {
+    expect(normalizeIfcTypeName('  IfcWall  ')).toBe('IfcWall');
+    expect(normalizeIfcTypeName('')).toBe('');
+    expect(normalizeIfcTypeName(undefined as unknown as string)).toBe('');
+  });
+});

--- a/packages/export/src/lod0-generator.test.ts
+++ b/packages/export/src/lod0-generator.test.ts
@@ -65,3 +65,78 @@ describe('generateLod0', () => {
     });
   });
 });
+
+/**
+ * Every fixture above is METRE-scaled with its bounding-box corner at the local
+ * origin — two constants that make the unit multiply and the corner offset
+ * IDENTITIES. A mutation sweep confirmed it: deleting `* unitScale` from the
+ * coordinate reader and from `IfcBoundingBox.XDim`, and discarding
+ * `IfcBoundingBox.Corner` entirely, all left the suite green, as did emitting
+ * the bbox min in place of the centroid, flipping the declared output unit to
+ * `mm`, and growing the no-representation fallback cube fivefold.
+ *
+ * A millimetre model with an off-origin corner is the ordinary case in the
+ * wild — Revit exports millimetres — and every one of those mutations puts an
+ * element in the wrong place, or at 1000x its size, in the LOD0 output another
+ * tool consumes.
+ */
+const IFC_MILLIMETRE = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [DesignTransferView]'),'2;1');
+FILE_NAME('lod0-mm.ifc','2026-05-27T00:00:00',$,$,'ifc-lite','ifc-lite',$);
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('project',$,'Project',$,$,$,$,$,#2);
+#2=IFCUNITASSIGNMENT((#3));
+#3=IFCSIUNIT(*,.LENGTHUNIT.,.MILLI.,.METRE.);
+#10=IFCLOCALPLACEMENT($,#11);
+#11=IFCAXIS2PLACEMENT3D(#12,$,$);
+#12=IFCCARTESIANPOINT((10000.,20000.,30000.));
+#20=IFCCARTESIANPOINT((1000.,2000.,3000.));
+#30=IFCPRODUCTDEFINITIONSHAPE($,$,(#31));
+#31=IFCSHAPEREPRESENTATION($,'Body','BoundingBox',(#32));
+#32=IFCBOUNDINGBOX(#20,2000.,3000.,4000.);
+#40=IFCWALL('wall-mm-guid',$,'MM Wall',$,$,#10,#30,$,.NOTDEFINED.);
+#50=IFCWALL('no-shape-guid',$,'No Shape',$,$,#10,$,$,.NOTDEFINED.);
+ENDSEC;
+END-ISO-10303-21;`;
+
+describe('generateLod0 — millimetre model with an off-origin bounding box', () => {
+  it('applies the length-unit scale to placements, corners and dimensions alike', async () => {
+    const lod0 = await generateLod0(new TextEncoder().encode(IFC_MILLIMETRE));
+    const wall = lod0.elements.find((e) => e.globalId === 'wall-mm-guid')!;
+
+    // placement (10,20,30) m + corner (1,2,3) m, dims (2,3,4) m.
+    // Distinct per axis so a scale dropped on one axis is visible; corner
+    // distinct from the placement so neither can stand in for the other.
+    expect(wall.bbox.min.map((v) => Number(v.toFixed(6)))).toEqual([11, 22, 33]);
+    expect(wall.bbox.max.map((v) => Number(v.toFixed(6)))).toEqual([13, 25, 37]);
+    expect(wall.bbox_source).toBe('shape');
+  });
+
+  it('reports the centroid as the bbox midpoint, not a corner', async () => {
+    const lod0 = await generateLod0(new TextEncoder().encode(IFC_MILLIMETRE));
+    const wall = lod0.elements.find((e) => e.globalId === 'wall-mm-guid')!;
+    // Asymmetric about the origin on every axis, so min/max/midpoint all differ.
+    expect(wall.centroid.map((v) => Number(v.toFixed(6)))).toEqual([12, 23.5, 35]);
+  });
+
+  it('declares metres regardless of the source file unit', async () => {
+    const lod0 = await generateLod0(new TextEncoder().encode(IFC_MILLIMETRE));
+    expect(lod0.units).toBe('m');
+    expect(lod0.lod).toBe(0);
+    expect(lod0.schema).toBe('ifc-lite-geometry');
+  });
+
+  it('falls back to a 0.2 m cube at the placement for an element with no representation', async () => {
+    // The untested third state: `Representation` is `$`, so there is no shape
+    // bbox to find and the fallback branch is the only thing that runs.
+    const lod0 = await generateLod0(new TextEncoder().encode(IFC_MILLIMETRE));
+    const bare = lod0.elements.find((e) => e.globalId === 'no-shape-guid')!;
+
+    expect(bare.bbox_source).toBe('fallback');
+    expect(bare.bbox.min.map((v) => Number(v.toFixed(6)))).toEqual([9.9, 19.9, 29.9]);
+    expect(bare.bbox.max.map((v) => Number(v.toFixed(6)))).toEqual([10.1, 20.1, 30.1]);
+  });
+});

--- a/packages/export/src/parquet-geometry.test.ts
+++ b/packages/export/src/parquet-geometry.test.ts
@@ -1,0 +1,401 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `ParquetExporter`'s geometry tables (`VertexBuffer` / `IndexBuffer` /
+ * `Meshes`), its column typing, and the metadata block had NO test at all —
+ * `parquet-exporter.test.ts` pins the overlay-deletion behaviour and nothing
+ * else. A mutation sweep confirmed it: dropping the per-mesh origin fold,
+ * swapping the Y and Z vertex columns, emitting `VertexCount` un-divided by 3,
+ * freezing `IndexStart` at 0, swapping `Index1`/`Index2`, and disabling the
+ * Float64 forcing for declared-REAL columns ALL left the suite green.
+ *
+ * Every one of those is a silently-wrong `.bos` archive: it opens fine and the
+ * numbers inside are wrong, which is exactly the failure another vendor's tool
+ * discovers days later. This file pins the writers row by row.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ParquetExporter } from './parquet-exporter.js';
+import type { IfcDataStore } from '@ifc-lite/parser';
+import type { GeometryResult, MeshData } from '@ifc-lite/geometry';
+import {
+  StringTable,
+  EntityTableBuilder,
+  PropertyTableBuilder,
+  QuantityTableBuilder,
+  RelationshipGraphBuilder,
+  PropertyValueType,
+  QuantityType,
+} from '@ifc-lite/data';
+
+/**
+ * `src/vendor-types.d.ts` declares deliberately NARROW ambient modules for
+ * apache-arrow and parquet-wasm covering only the write side the exporter
+ * uses, so a named import of the read side (`tableFromIPC` / `readParquet`)
+ * does not typecheck. Reach them through an explicitly typed dynamic import
+ * instead of widening the ambient declaration — the exporter's own contract
+ * is what that file describes.
+ */
+interface ArrowRow { toJSON(): Record<string, unknown> }
+interface ArrowTable {
+  toArray(): ArrowRow[];
+  schema: { fields: Array<{ name: string; type: unknown }> };
+}
+async function readArrowTable(bytes: Uint8Array): Promise<ArrowTable> {
+  const { readParquet } = (await import('parquet-wasm')) as unknown as {
+    readParquet(b: Uint8Array): { intoIPCStream(): ArrayBuffer };
+  };
+  const { tableFromIPC } = (await import('apache-arrow')) as unknown as {
+    tableFromIPC(ipc: ArrayBuffer): ArrowTable;
+  };
+  return tableFromIPC(readParquet(bytes).intoIPCStream());
+}
+
+/** Decode a Parquet buffer back to plain row objects for assertions. */
+async function decodeParquet(bytes: Uint8Array): Promise<Record<string, unknown>[]> {
+  return (await readArrowTable(bytes)).toArray().map((row) => row.toJSON());
+}
+
+/** Decode a Parquet buffer and report its Arrow schema field types by name. */
+async function decodeParquetSchema(bytes: Uint8Array): Promise<Record<string, string>> {
+  const table = await readArrowTable(bytes);
+  const out: Record<string, string> = {};
+  for (const field of table.schema.fields) out[field.name] = String(field.type);
+  return out;
+}
+
+function mesh(partial: Partial<MeshData> & { expressId: number }): MeshData {
+  return {
+    positions: new Float32Array(),
+    normals: new Float32Array(),
+    indices: new Uint32Array(),
+    color: [1, 1, 1, 1],
+    ...partial,
+  } as MeshData;
+}
+
+function geometry(meshes: MeshData[]): GeometryResult {
+  const totalVertices = meshes.reduce((n, m) => n + m.positions.length / 3, 0);
+  const totalTriangles = meshes.reduce((n, m) => n + m.indices.length / 3, 0);
+  return {
+    meshes,
+    totalVertices,
+    totalTriangles,
+    coordinateInfo: {
+      originShift: [0, 0, 0],
+      originalBounds: { min: [0, 0, 0], max: [0, 0, 0] },
+      shiftedBounds: { min: [0, 0, 0], max: [0, 0, 0] },
+      hasLargeCoordinates: false,
+    },
+  } as unknown as GeometryResult;
+}
+
+/**
+ * Store with ONE quantity and ONE property whose REAL value is a whole number.
+ * Whole-number reals are the case that exposes the Float64 forcing: content
+ * inference alone would type the column Int32 and the consumer would read an
+ * integer schema for a `IfcQuantityArea` value.
+ */
+function buildTypedStore(): IfcDataStore {
+  const strings = new StringTable();
+
+  // Flags deliberately ASYMMETRIC across the two rows: an entity that has
+  // geometry and is not a type, and an entity that is a type and has no
+  // geometry. Two rows agreeing on both flags cannot tell HAS_GEOMETRY from
+  // IS_TYPE — a swapped mask would read identically.
+  const entityBuilder = new EntityTableBuilder(2, strings);
+  entityBuilder.add(1, 'IFCWALL', 'wall-1-guid', 'Wall1', '', '', true, false);
+  entityBuilder.add(2, 'IFCWALLTYPE', 'wall-type-guid', 'WallTypeA', '', '', false, true);
+
+  const propertyBuilder = new PropertyTableBuilder(strings);
+  propertyBuilder.add({
+    entityId: 1,
+    psetName: 'Pset_WallCommon',
+    psetGlobalId: '',
+    propName: 'ThermalTransmittance',
+    value: 3, // a whole-number REAL
+    propType: PropertyValueType.Real,
+  });
+
+  const quantityBuilder = new QuantityTableBuilder(strings);
+  quantityBuilder.add({
+    entityId: 1,
+    qsetName: 'Qto_WallBaseQuantities',
+    quantityName: 'NetSideArea',
+    quantityType: QuantityType.Area,
+    value: 1200, // a whole-number REAL, and > 2^31 is the wrap risk
+    formula: '',
+  });
+
+  return {
+    fileSize: 123,
+    schemaVersion: 'IFC4',
+    entityCount: 2,
+    parseTime: 0,
+    source: new Uint8Array(0),
+    entityIndex: { byId: new Map(), byType: new Map() },
+    strings,
+    entities: entityBuilder.build(),
+    properties: propertyBuilder.build(),
+    quantities: quantityBuilder.build(),
+    relationships: new RelationshipGraphBuilder().build(),
+  } as unknown as IfcDataStore;
+}
+
+describe('ParquetExporter VertexBuffer.parquet', () => {
+  it('bakes the per-mesh origin into world vertices on all three axes', async () => {
+    // The BOS columnar layout has no transform column, so the ONLY place the
+    // origin can be applied is here. A fixture at origin (0,0,0) makes the fold
+    // an identity and cannot see this — every component is deliberately
+    // non-zero AND distinct so a fold dropped on any single axis shows up.
+    const m = mesh({
+      expressId: 1,
+      positions: new Float32Array([1, 2, 3]),
+      normals: new Float32Array([0, 0, 1]),
+      origin: [10, 20, 30],
+    } as Partial<MeshData> & { expressId: number });
+
+    const exporter = new ParquetExporter({} as IfcDataStore, geometry([m]));
+    const rows = await decodeParquet(await exporter.exportTable('vertices'));
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].X).toBeCloseTo(11, 5);
+    expect(rows[0].Y).toBeCloseTo(22, 5);
+    expect(rows[0].Z).toBeCloseTo(33, 5);
+  });
+
+  it('leaves normals origin-invariant', async () => {
+    const m = mesh({
+      expressId: 1,
+      positions: new Float32Array([1, 2, 3]),
+      normals: new Float32Array([0.25, 0.5, 0.75]),
+      origin: [10, 20, 30],
+    } as Partial<MeshData> & { expressId: number });
+
+    const exporter = new ParquetExporter({} as IfcDataStore, geometry([m]));
+    const rows = await decodeParquet(await exporter.exportTable('vertices'));
+
+    expect(rows[0].NormalX).toBeCloseTo(0.25, 5);
+    expect(rows[0].NormalY).toBeCloseTo(0.5, 5);
+    expect(rows[0].NormalZ).toBeCloseTo(0.75, 5);
+  });
+
+  it('keeps the X/Y/Z column split in axis order for a mesh with no origin', async () => {
+    // The no-origin branch is the OTHER side of the fold and is reached by a
+    // separate `push(...)` — it must produce the same column assignment.
+    const m = mesh({
+      expressId: 1,
+      positions: new Float32Array([4, 5, 6, 7, 8, 9]),
+      normals: new Float32Array([0, 0, 1, 0, 1, 0]),
+    });
+
+    const exporter = new ParquetExporter({} as IfcDataStore, geometry([m]));
+    const rows = await decodeParquet(await exporter.exportTable('vertices'));
+
+    expect(rows.map((r) => [r.X, r.Y, r.Z])).toEqual([
+      [4, 5, 6],
+      [7, 8, 9],
+    ]);
+  });
+
+  it('treats an explicit zero origin exactly like an absent one', async () => {
+    const zero = mesh({
+      expressId: 1,
+      positions: new Float32Array([4, 5, 6]),
+      normals: new Float32Array([0, 0, 1]),
+      origin: [0, 0, 0],
+    } as Partial<MeshData> & { expressId: number });
+    const absent = mesh({
+      expressId: 2,
+      positions: new Float32Array([4, 5, 6]),
+      normals: new Float32Array([0, 0, 1]),
+    });
+
+    const a = await decodeParquet(
+      await new ParquetExporter({} as IfcDataStore, geometry([zero])).exportTable('vertices'),
+    );
+    const b = await decodeParquet(
+      await new ParquetExporter({} as IfcDataStore, geometry([absent])).exportTable('vertices'),
+    );
+    expect(a).toEqual(b);
+    expect(a[0]).toMatchObject({ X: 4, Y: 5, Z: 6 });
+  });
+});
+
+describe('ParquetExporter IndexBuffer.parquet', () => {
+  it('splits the flat index stream into Index0/1/2 in the order it was given', async () => {
+    // Faithful copy, not a winding claim: `MeshData.indices` winding is
+    // documented as unreliable, but the exporter must not permute the corners
+    // it was handed — a consumer joining IndexBuffer to VertexBuffer would
+    // build different triangles.
+    const m = mesh({
+      expressId: 1,
+      positions: new Float32Array(18),
+      normals: new Float32Array(18),
+      indices: new Uint32Array([0, 1, 2, 3, 4, 5]),
+    });
+
+    const exporter = new ParquetExporter({} as IfcDataStore, geometry([m]));
+    const rows = await decodeParquet(await exporter.exportTable('indices'));
+
+    expect(rows).toEqual([
+      { Index0: 0, Index1: 1, Index2: 2 },
+      { Index0: 3, Index1: 4, Index2: 5 },
+    ]);
+  });
+});
+
+describe('ParquetExporter Meshes.parquet', () => {
+  it('emits vertex/index starts that accumulate across meshes, and counts in the right unit', async () => {
+    // TWO meshes with DIFFERENT sizes: a single mesh leaves every start at 0
+    // and cannot see a frozen accumulator, and equal sizes cannot tell a
+    // vertex stride from an index stride.
+    const a = mesh({
+      expressId: 11,
+      positions: new Float32Array(3 * 4), // 4 vertices
+      normals: new Float32Array(3 * 4),
+      indices: new Uint32Array([0, 1, 2, 0, 2, 3]), // 6 indices
+    });
+    const b = mesh({
+      expressId: 22,
+      positions: new Float32Array(3 * 3), // 3 vertices
+      normals: new Float32Array(3 * 3),
+      indices: new Uint32Array([0, 1, 2]), // 3 indices
+    });
+
+    const exporter = new ParquetExporter({} as IfcDataStore, geometry([a, b]));
+    const rows = await decodeParquet(await exporter.exportTable('meshes'));
+
+    expect(rows).toEqual([
+      { ExpressId: 11, VertexStart: 0, VertexCount: 4, IndexStart: 0, IndexCount: 6 },
+      { ExpressId: 22, VertexStart: 4, VertexCount: 3, IndexStart: 6, IndexCount: 3 },
+    ]);
+  });
+
+  it('has starts that index the VertexBuffer/IndexBuffer rows the same export wrote', async () => {
+    // The three geometry tables are only usable TOGETHER; this pins the join.
+    const a = mesh({
+      expressId: 11,
+      positions: new Float32Array([0, 0, 0, 1, 0, 0, 1, 1, 0]),
+      normals: new Float32Array(9),
+      indices: new Uint32Array([0, 1, 2]),
+    });
+    const b = mesh({
+      expressId: 22,
+      positions: new Float32Array([5, 5, 5, 6, 5, 5, 6, 6, 5, 5, 6, 5]),
+      normals: new Float32Array(12),
+      indices: new Uint32Array([0, 1, 2, 0, 2, 3]),
+    });
+
+    const exporter = new ParquetExporter({} as IfcDataStore, geometry([a, b]));
+    const meshRows = await decodeParquet(await exporter.exportTable('meshes'));
+    const vertexRows = await decodeParquet(await exporter.exportTable('vertices'));
+    const indexRows = await decodeParquet(await exporter.exportTable('indices'));
+
+    const second = meshRows[1];
+    expect(vertexRows).toHaveLength(3 + 4);
+    // VertexStart must land on mesh b's FIRST vertex, not mesh a's.
+    expect(vertexRows[Number(second.VertexStart)]).toMatchObject({ X: 5, Y: 5, Z: 5 });
+    // IndexStart is in indices, so it maps to triangle IndexStart/3.
+    expect(Number(second.IndexStart) % 3).toBe(0);
+    expect(indexRows).toHaveLength((3 + 6) / 3);
+    expect(Number(second.IndexStart) / 3).toBe(1);
+  });
+
+  it('writes no rows for an empty mesh set', async () => {
+    const exporter = new ParquetExporter({} as IfcDataStore, geometry([]));
+    expect(await decodeParquet(await exporter.exportTable('meshes'))).toEqual([]);
+    expect(await decodeParquet(await exporter.exportTable('vertices'))).toEqual([]);
+    expect(await decodeParquet(await exporter.exportTable('indices'))).toEqual([]);
+  });
+});
+
+describe('ParquetExporter column typing', () => {
+  it('keeps a whole-number REAL property value in a Float64 column', async () => {
+    const exporter = new ParquetExporter(buildTypedStore());
+    const bytes = await exporter.exportTable('properties');
+    expect((await decodeParquetSchema(bytes)).ValueReal).toMatch(/Float(64)?/i);
+    expect((await decodeParquet(bytes))[0].ValueReal).toBe(3);
+  });
+
+  it('keeps a whole-number quantity value in a Float64 column', async () => {
+    const exporter = new ParquetExporter(buildTypedStore());
+    const bytes = await exporter.exportTable('quantities');
+    expect((await decodeParquetSchema(bytes)).Value).toMatch(/Float(64)?/i);
+    expect((await decodeParquet(bytes))[0].Value).toBe(1200);
+  });
+
+  it('leaves an undeclared integer column as an integer (the forcing is opt-in, not blanket)', async () => {
+    // Counter-example: without this, "declare every numeric column Float64"
+    // would pass the two assertions above just as well.
+    const exporter = new ParquetExporter(buildTypedStore());
+    const schema = await decodeParquetSchema(await exporter.exportTable('entities'));
+    expect(schema.ExpressId).toMatch(/Int/i);
+  });
+});
+
+describe('ParquetExporter Entities.parquet flag columns', () => {
+  it('reads HasGeometry and IsType from their own flag bits', async () => {
+    const rows = await decodeParquet(await new ParquetExporter(buildTypedStore()).exportTable('entities'));
+    expect(rows.map((r) => [r.ExpressId, r.HasGeometry, r.IsType])).toEqual([
+      [1, true, false],
+      [2, false, true],
+    ]);
+  });
+});
+
+describe('ParquetExporter Properties.parquet', () => {
+  it('reports ValueBool as null for a non-boolean property (the 255 sentinel)', async () => {
+    // The stored sentinel is 255, which is neither 1 nor 0 — without the
+    // sentinel check every non-boolean property row would export `false`,
+    // i.e. a real value the source never carried.
+    const rows = await decodeParquet(await new ParquetExporter(buildTypedStore()).exportTable('properties'));
+    expect(rows[0].PropType).toBe('Real');
+    expect(rows[0].ValueBool).toBeNull();
+  });
+});
+
+describe('ParquetExporter Quantities.parquet', () => {
+  it('reports a quantity with no formula as null rather than string index 0', async () => {
+    const rows = await decodeParquet(await new ParquetExporter(buildTypedStore()).exportTable('quantities'));
+    expect(rows[0].Formula).toBeNull();
+  });
+});
+
+describe('ParquetExporter Metadata.json', () => {
+  it('reports the geometry statistics of the export it accompanies', async () => {
+    const a = mesh({
+      expressId: 11,
+      positions: new Float32Array(3 * 4),
+      normals: new Float32Array(3 * 4),
+      indices: new Uint32Array([0, 1, 2, 0, 2, 3]),
+    });
+    const exporter = new ParquetExporter(buildTypedStore(), geometry([a]));
+    const zipBytes = await exporter.exportBOS();
+
+    const JSZip = (await import('jszip')).default;
+    const zip = await JSZip.loadAsync(zipBytes);
+    const metadata = JSON.parse(await zip.file('Metadata.json')!.async('string'));
+
+    expect(metadata.statistics.meshCount).toBe(1);
+    expect(metadata.statistics.vertexCount).toBe(4);
+    expect(metadata.statistics.triangleCount).toBe(2);
+    expect(metadata.sourceFile).toMatchObject({ size: 123, schema: 'IFC4', entityCount: 2 });
+  });
+
+  it('reports zeroed geometry statistics when no geometry was supplied', async () => {
+    // The two-valued signal in both directions: the branch above must not be
+    // passing merely because the numbers happen to be non-zero.
+    const zipBytes = await new ParquetExporter(buildTypedStore()).exportBOS();
+    const JSZip = (await import('jszip')).default;
+    const zip = await JSZip.loadAsync(zipBytes);
+    const metadata = JSON.parse(await zip.file('Metadata.json')!.async('string'));
+
+    expect(metadata.statistics.meshCount).toBe(0);
+    expect(metadata.statistics.vertexCount).toBe(0);
+    expect(metadata.statistics.triangleCount).toBe(0);
+    expect(zip.file('VertexBuffer.parquet')).toBeNull();
+  });
+});

--- a/packages/export/src/select-qualification.test.ts
+++ b/packages/export/src/select-qualification.test.ts
@@ -1,0 +1,79 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `select-qualification.ts` had no test file. Its behaviour was reachable only
+ * through `step-exporter.test.ts`, which pins the AMBIGUOUS direction (the
+ * `{ typed }` marker escape hatch) — so a mutation sweep found that making
+ * `#`-references qualifiable and flipping the boolean preference from
+ * `IfcBoolean` to `IfcLogical` both left the suite green.
+ *
+ * Both write a non-conformant or wrong-typed token into the exported STEP file:
+ * `IFCDESCRIPTIVEMEASURE('#5')` where an entity reference belongs, and
+ * `IFCLOGICAL(.T.)` where a strict reader expects `IFCBOOLEAN(.T.)`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { serializeQualifiedSelectSlot } from './select-qualification.js';
+
+describe('serializeQualifiedSelectSlot — unambiguous members', () => {
+  it('qualifies a bare boolean as IfcBoolean, not IfcLogical', () => {
+    // IfcPropertySingleValue.NominalValue is IfcValue, whose defined-type
+    // leaves contain EXACTLY ONE BOOLEAN (IfcBoolean) and EXACTLY ONE LOGICAL
+    // (IfcLogical). Both resolve unambiguously, so only the declared
+    // preference order decides — which is precisely what must be pinned.
+    expect(serializeQualifiedSelectSlot('IFCPROPERTYSINGLEVALUE', 2, true)).toBe('IFCBOOLEAN(.T.)');
+    expect(serializeQualifiedSelectSlot('IFCPROPERTYSINGLEVALUE', 2, false)).toBe('IFCBOOLEAN(.F.)');
+  });
+
+  it('qualifies a string in a slot whose SELECT has exactly one STRING member', () => {
+    // IfcCurveStyle.CurveWidth is IfcSizeSelect: one STRING leaf
+    // (IfcDescriptiveMeasure), several REAL leaves.
+    expect(serializeQualifiedSelectSlot('IFCCURVESTYLE', 2, 'thick')).toBe(
+      "IFCDESCRIPTIVEMEASURE('thick')",
+    );
+  });
+
+  it('leaves an ambiguous REAL family to the caller marker', () => {
+    // Same slot, a number: IfcSizeSelect has FIVE REAL leaves, so there is no
+    // single right answer and the auto-qualifier must decline.
+    expect(serializeQualifiedSelectSlot('IFCCURVESTYLE', 2, 3)).toBeNull();
+  });
+});
+
+describe('serializeQualifiedSelectSlot — values that are never qualifiable', () => {
+  it('declines an entity reference even in a slot with one unambiguous STRING member', () => {
+    // `#5` is an ENTITY member of the SELECT and must serialize as a bare
+    // reference. Qualifying it would emit IFCDESCRIPTIVEMEASURE('#5') — a
+    // quoted string where the file needs a live link, so the reference is lost.
+    expect(serializeQualifiedSelectSlot('IFCCURVESTYLE', 2, '#5')).toBeNull();
+    expect(serializeQualifiedSelectSlot('IFCCURVESTYLE', 2, '  #1234  ')).toBeNull();
+  });
+
+  it('declines the null and derived markers and an enum token', () => {
+    expect(serializeQualifiedSelectSlot('IFCCURVESTYLE', 2, '$')).toBeNull();
+    expect(serializeQualifiedSelectSlot('IFCCURVESTYLE', 2, '*')).toBeNull();
+    expect(serializeQualifiedSelectSlot('IFCCURVESTYLE', 2, '.NOTDEFINED.')).toBeNull();
+  });
+
+  it('declines a non-finite number', () => {
+    expect(serializeQualifiedSelectSlot('IFCCURVESTYLE', 2, NaN)).toBeNull();
+    expect(serializeQualifiedSelectSlot('IFCCURVESTYLE', 2, Infinity)).toBeNull();
+  });
+});
+
+describe('serializeQualifiedSelectSlot — slots that are not SELECTs', () => {
+  it('declines a slot the schema does not type as a scalar SELECT', () => {
+    // IfcWall.Name is IfcLabel, a plain defined type — not this pass's business.
+    expect(serializeQualifiedSelectSlot('IFCWALL', 2, 'W-01')).toBeNull();
+  });
+
+  it('declines an entity the registry does not know', () => {
+    expect(serializeQualifiedSelectSlot('IFCNOTAREALENTITY', 0, true)).toBeNull();
+  });
+
+  it('declines an out-of-range slot index', () => {
+    expect(serializeQualifiedSelectSlot('IFCCURVESTYLE', 99, 'thick')).toBeNull();
+  });
+});

--- a/packages/export/src/type-owned-psets.test.ts
+++ b/packages/export/src/type-owned-psets.test.ts
@@ -1,0 +1,117 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `type-owned-psets.ts` had no test file of its own. Its main pass is well
+ * covered indirectly by `overlay-effective-model.test.ts`, but two edges were
+ * not: emitting `()` instead of `$` for an EMPTY `HasPropertySets` list, and
+ * treating an UNKNOWN class (`typeOf` returned `undefined`) as a type object.
+ * A mutation sweep left the suite green on both.
+ *
+ * `HasPropertySets` is `OPTIONAL SET [1:?]`, so `()` is schema-invalid — a
+ * strict validator rejects the file. And a class no bundled schema declares
+ * has no confirmed slot 5, so guessing "type object" writes a pset list into
+ * whatever attribute happens to sit there.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isTypeClass, hasPropertySetsToken, resolveTypeOwnedPsetIds, HAS_PROPERTY_SETS_SLOT } from './type-owned-psets.js';
+
+describe('hasPropertySetsToken', () => {
+  it('emits $ for an empty list, never an empty aggregate', () => {
+    // HasPropertySets is OPTIONAL SET [1:?] — `()` violates the lower bound.
+    expect(hasPropertySetsToken([])).toBe('$');
+  });
+
+  it('emits a reference aggregate in the given order', () => {
+    expect(hasPropertySetsToken([7])).toBe('(#7)');
+    expect(hasPropertySetsToken([7, 3, 11])).toBe('(#7,#3,#11)');
+  });
+});
+
+describe('isTypeClass', () => {
+  it('recognises a type object from its inheritance chain', () => {
+    expect(isTypeClass('IFCWALLTYPE')).toBe(true);
+  });
+
+  it('recognises an IFC2X3 style class that does not end in Type', () => {
+    expect(isTypeClass('IFCDOORSTYLE')).toBe(true);
+    expect(isTypeClass('IFCWINDOWSTYLE')).toBe(true);
+  });
+
+  it('does not call an occurrence or a relationship a type object', () => {
+    expect(isTypeClass('IFCWALL')).toBe(false);
+    // Ends in TYPE but is a relationship — the suffix test's other failure.
+    expect(isTypeClass('IFCRELDEFINESBYTYPE')).toBe(false);
+  });
+
+  it('treats an UNKNOWN class as an occurrence, the safe direction', () => {
+    expect(isTypeClass('IFCNOTAREALCLASS')).toBe(false);
+  });
+
+  it('treats an ABSENT class as an occurrence rather than guessing', () => {
+    // `effective.typeOf(id)` returns undefined for a record the exporter
+    // cannot resolve; slot 5 of an unconfirmed class must not be written.
+    expect(isTypeClass(undefined)).toBe(false);
+  });
+
+  it('pins the HasPropertySets slot index the routing writes into', () => {
+    expect(HAS_PROPERTY_SETS_SLOT).toBe(5);
+  });
+});
+
+describe('resolveTypeOwnedPsetIds', () => {
+  const nameOf = (map: Record<number, string>) => (id: number) => map[id] ?? null;
+
+  it('swaps an affected pset for its replacement in place', () => {
+    const out = resolveTypeOwnedPsetIds(
+      [10, 11],
+      new Set(['Pset_A']),
+      new Map([['Pset_A', 99]]),
+      nameOf({ 10: 'Pset_A', 11: 'Pset_B' }),
+    );
+    expect(out).toEqual([99, 11]);
+  });
+
+  it('drops an affected pset that has no replacement (a deletion)', () => {
+    const out = resolveTypeOwnedPsetIds(
+      [10, 11],
+      new Set(['Pset_A']),
+      new Map(),
+      nameOf({ 10: 'Pset_A', 11: 'Pset_B' }),
+    );
+    expect(out).toEqual([11]);
+  });
+
+  it('appends a replacement the original list never named', () => {
+    const out = resolveTypeOwnedPsetIds(
+      [11],
+      new Set(['Pset_New']),
+      new Map([['Pset_New', 99]]),
+      nameOf({ 11: 'Pset_B' }),
+    );
+    expect(out).toEqual([11, 99]);
+  });
+
+  it('appends without duplicating one that was already swapped in', () => {
+    // Both passes see Pset_A; only the first may emit it.
+    const out = resolveTypeOwnedPsetIds(
+      [10],
+      new Set(['Pset_A']),
+      new Map([['Pset_A', 99], ['Pset_New', 100]]),
+      nameOf({ 10: 'Pset_A' }),
+    );
+    expect(out).toEqual([99, 100]);
+  });
+
+  it('carries an unreadable pset id through untouched', () => {
+    // nameOf returns null for an overlay-created pset — never "affected".
+    const out = resolveTypeOwnedPsetIds([10], new Set(['Pset_A']), new Map([['Pset_A', 99]]), () => null);
+    expect(out).toEqual([10, 99]);
+  });
+
+  it('is the identity on an empty original list with no replacements', () => {
+    expect(resolveTypeOwnedPsetIds([], new Set(), new Map(), () => null)).toEqual([]);
+  });
+});


### PR DESCRIPTION
Test-only. **No production code changed** — `git diff --stat` is eight test files.

`packages/export` was swept at the very start of this campaign, when the method was least developed. This is a second, deeper pass. It starts from the modules with **no test file, or a test file far thinner than the source** — the place every deep pass has found its survivors.

## Result

| | |
|---|---|
| Mutations | 40 (+ 2 controls) |
| Killed by the existing suite | **9 (22.5%)** |
| Survivors | 31 — all closed here |
| Tests | 363 passed / 29 skipped → **448 passed / 29 skipped** |
| Test files | 21 → 27 (2 skipped unchanged) |

Kill ratio is **TARGETED**: the mutations were aimed at the thin and untested modules, not sampled uniformly across the package.

**Controls** (deliberate, expected to die, run before believing any survivor) — both died:

| | Mutation | Result |
|---|---|---|
| C1 | `filterColumns`: `if (!keep) return columns` → `if (true) return columns` | KILLED — 3 tests in `parquet-exporter.test.ts` |
| C2 | `countGlbMeshes`: `return json.meshes.length` → `return 0` | KILLED — `counts the meshes that are present` |

## Modules with no test file, or a test file far thinner than the source

| Module | src | own test | chosen |
|---|---|---|---|
| `parquet-exporter.ts` | 629 | 157 (deletions only) | yes |
| `glb.ts` | 182 | 65 (1 of 4 exports) | yes |
| `lod0-generator.ts` | 320 | 67 | yes |
| `demesh-prune.ts` | 188 | none | yes |
| `select-qualification.ts` | 153 | none | yes |
| `lod-geometry-utils.ts` | 114 | none | yes |
| `type-owned-psets.ts` | 108 | none | yes |
| `entity-iteration.ts` | 83 | none | yes |
| `attribute-real-slots.ts` | 134 | none directly | covered via `attribute-slot-types.test.ts` |
| `demesh-session.ts` | 338 | none directly | covered via `demesh-writer.test.ts` |
| `unit-normalize.ts` | 377 | 207 | measured, already strong |

`unit-normalize.ts` — the obvious unit-conversion target — was read and judged already well covered (its test pins the FP-noise rounding, the exponent form, the unit-override guard, the excluded unit-definition entities and both `IfcPropertyTableValue` directions). It was left alone.

## The gaps

### `parquet-exporter.ts` — the geometry writers, column typing and metadata had NO test

`parquet-exporter.test.ts` pins overlay deletions and nothing else. `.bos` is consumed by other vendors' tools, so every one of these is a file that opens fine and is wrong inside.

| # | Mutation | replacements | before | killed by |
|---|---|---|---|---|
| M1 | `writeVertexBuffer`: drop the per-mesh origin fold on X | 1 | SURVIVED | `bakes the per-mesh origin into world vertices on all three axes` |
| M2 | `writeVertexBuffer`: swap the Y and Z columns | 1 | SURVIVED | `keeps the X/Y/Z column split in axis order…` (+2) |
| M3 | `writeMeshes`: `VertexCount` un-divided by 3 | 1 | SURVIVED | `emits vertex/index starts that accumulate across meshes…` |
| M4 | `writeMeshes`: `IndexStart` never advances | 1 | SURVIVED | same, + `has starts that index the VertexBuffer/IndexBuffer rows…` |
| M5 | `writeIndexBuffer`: swap `Index1`/`Index2` | 1 | SURVIVED | `splits the flat index stream into Index0/1/2 in the order it was given` |
| M6 | `toParquet`: drop the Float64 forcing for declared-REAL columns | 1 | SURVIVED | `keeps a whole-number REAL property value in a Float64 column` (+1) |
| M7 | `writeProperties`: lose the 255 "null boolean" sentinel | 1 | SURVIVED | `reports ValueBool as null for a non-boolean property` |
| M8 | `writeQuantities`: Formula guard `i > 0` → `i >= 0` | 1 | SURVIVED | `reports a quantity with no formula as null rather than string index 0` |
| M9 | `writeMetadata`: `statistics.vertexCount` always 0 | 1 | SURVIVED | `reports the geometry statistics of the export it accompanies` |
| M10 | `writeEntities`: read `HasGeometry` off the `IS_TYPE` bit | 1 | SURVIVED | `reads HasGeometry and IsType from their own flag bits` |

M1 is the **identity-fixture** shape: with a mesh at origin `(0,0,0)` the fold is a no-op. The new fixture uses `[10, 20, 30]` — non-zero and distinct per axis, so a fold dropped on any single axis shows. M3/M4 needed **two meshes of different sizes**: one mesh leaves every start at 0, and equal sizes cannot tell a vertex stride from an index stride.

M6 needed a **whole-number** REAL (`3`, `1200`): content inference alone demotes those to Int32, losing the float schema. A counter-example test pins that `ExpressId` stays integer, so "declare every numeric column Float64" does not pass.

### `glb.ts` — 2 of 4 exports had no test

| # | Mutation | replacements | before | killed by |
|---|---|---|---|---|
| M11 | `extractGlbMapping`: swap node index and mesh index | 1 | SURVIVED | `maps each express id to its own node index and its own mesh index` |
| M12 | `parseGLBToMeshData`: drop the accessor `byteOffset` | 1 | SURVIVED | `reads each attribute from its own accessor byteOffset, not the buffer-view base` |
| M13 | material alpha always 1 | 1 | SURVIVED | `resolves the material baseColorFactor including a non-1 alpha` |
| M14 | `DEFAULT_COLOR` turns black | 1 | SURVIVED | `falls back to the neutral grey default…` (+1) |
| M15 | `parseGLB`: drop the total-length sanity check | 1 | SURVIVED | `rejects a GLB whose declared total length exceeds the buffer it arrived in` |

A wrong accessor offset does not throw — it reads the neighbouring attribute's bytes. The fixture's normals are deliberately unequal to its positions, and the BIN lead-in is `0xff` rather than zero, so aliasing either is visible. M13 is the identity shape again: an opaque fixture (alpha 1) cannot see the alpha slot being dropped, so the fixture uses `0.5`. Material resolution is exercised in all four states — RGBA factor, RGB-only factor, material with no factor, and primitive with no material.

### `lod0-generator.ts` — every fixture was metre-scaled with its corner at the origin

Two constants that make the unit multiply and the corner offset **identities**. Six mutations survived because of them.

| # | Mutation | replacements | before | killed by |
|---|---|---|---|---|
| M29 | `IfcBoundingBox.XDim` ignores the length-unit scale | 1 | SURVIVED | `applies the length-unit scale to placements, corners and dimensions alike` |
| M30 | cartesian point coordinates ignore the length-unit scale | 1 | SURVIVED | same (+2) |
| M31 | `IfcBoundingBox.Corner` discarded (always local origin) | 1 | SURVIVED | same (+1) |
| M32 | centroid is the bbox min, not the midpoint | 1 | SURVIVED | `reports the centroid as the bbox midpoint, not a corner` |
| M33 | declared output units flip to `mm` | 1 | SURVIVED | `declares metres regardless of the source file unit` |
| M34 | no-representation fallback cube grows 5× | 1 | SURVIVED | `falls back to a 0.2 m cube at the placement…` |

The new fixture is a **millimetre** model (the ordinary case in the wild) with an **off-origin** bounding-box corner, distinct per axis, plus an element whose `Representation` is `$` so the fallback branch is reached at all.

### `demesh-prune.ts` — no test file

| # | Mutation | replacements | before | killed by |
|---|---|---|---|---|
| M35 | `IFCOWNERHISTORY` loses its `PROTECTED_TYPES` entry | 1 | SURVIVED | `never tombstones shared infrastructure orphaned by the sweep (IfcOwnerHistory)` |
| M36 | presentation layers count as referrers | 1 | KILLED | `prunes geometry whose only surviving referrer is a presentation layer…` |
| M37 | an emptied presentation layer is left behind | 1 | KILLED | same |
| M38 | the detached product→old-rep edge stays in the reverse index | 1 | KILLED | 4 tests |
| M39 | `strippedOpeningCount` counts every tombstone | 1 | SURVIVED | `counts ONLY openings into strippedOpeningCount` (+1) |
| M40 | styled items never pulled into the closure | 1 | SURVIVED | `prunes the style chain that hangs off replaced geometry, leaving no dangling item` |

**Weak-shaped existing test.** M39 survived because `strippedOpeningCount` was asserted with `expect(...).toBeGreaterThan(0)` — equally true of a counter that counts *every* tombstone, which is a strictly larger number on that fixture. It is now pinned to the exact count (2), with `prunedEntityCount > strippedOpeningCount` and a zero-openings counter-example.

### Four smaller modules with no test file

| # | Module | Mutation | replacements | before | killed by |
|---|---|---|---|---|---|
| M16 | `entity-iteration.ts` | stop iterating the deferred index | 1 | KILLED | 4 exporter tests |
| M17 | `entity-iteration.ts` | `size` ignores deferred atoms | 1 | SURVIVED | `counts the deferred atoms in size…` (+1) |
| M18 | `entity-iteration.ts` | `getMaxExpressId` off by one | 1 | KILLED | 10 exporter tests |
| M19 | `type-owned-psets.ts` | `()` for an empty `HasPropertySets` | 1 | SURVIVED | `emits $ for an empty list, never an empty aggregate` |
| M20 | `type-owned-psets.ts` | drop the append-unnamed-replacements pass | 1 | KILLED | 5 tests |
| M21 | `type-owned-psets.ts` | an ABSENT class treated as a type object | 1 | SURVIVED | `treats an ABSENT class as an occurrence rather than guessing` |
| M22 | `lod-geometry-utils.ts` | empty-point AABB returns a unit box | 1 | SURVIVED | `returns a degenerate box at the origin for no points, not a unit box` |
| M23 | `lod-geometry-utils.ts` | negate the cross-product handedness | 1 | KILLED | `lod0-generator.test.ts` |
| M24 | `lod-geometry-utils.ts` | drop the translation column | 1 | KILLED | `lod0-generator.test.ts` |
| M25 | `lod-geometry-utils.ts` | `toIfcArrayBuffer` ignores the view window | 1 | SURVIVED | `honours the byteOffset/byteLength window of a partial view` (+1) |
| M26 | `select-qualification.ts` | ambiguous family no longer bails out | 1 | KILLED | `honours the { typed } marker…` |
| M27 | `select-qualification.ts` | entity refs (`#5`) become qualifiable | 1 | SURVIVED | `declines an entity reference even in a slot with one unambiguous STRING member` |
| M28 | `select-qualification.ts` | boolean prefers `IfcLogical` over `IfcBoolean` | 1 | SURVIVED | `qualifies a bare boolean as IfcBoolean, not IfcLogical` |

What each survivor means for a user:

- **M17** — `size` is what `StepExporter` (`step-exporter.ts:1069`) and `MergedExporter` (`merged-exporter.ts:611`) report as the export's entity total. A `deferPropertyAtomIndex` parse undercounts by every deferred property atom while the file itself is complete.
- **M19** — `HasPropertySets` is `OPTIONAL SET [1:?]`; `()` violates the lower bound and a strict validator rejects the file.
- **M21** — a class no bundled schema declares has no confirmed slot 5; guessing "type object" writes a pset list into whatever attribute happens to sit there.
- **M25** — `toIfcArrayBuffer` is the FIRST thing both LOD generators do to their input (`lod0-generator.ts:80`, `lod1-generator.ts:138`). Returning the whole backing buffer for a `Uint8Array` that is a *window* onto a larger one — the ordinary result of slicing bytes out of a container — hands the parser bytes that are not the model.
- **M27** — qualifying `#5` emits `IFCDESCRIPTIVEMEASURE('#5')`: a quoted string where the file needs a live link, so the reference is lost.
- **M28** — `IfcPropertySingleValue.NominalValue` is `IfcValue`, which has exactly one BOOLEAN leaf and exactly one LOGICAL leaf, so both resolve unambiguously and only the declared preference decides. The mutation writes `IFCLOGICAL(.T.)` where a strict reader expects `IFCBOOLEAN(.T.)`.

M23/M24 died against `lod0-generator.test.ts`, which is worth recording: the matrix maths *is* covered transitively even though the module has no test file. Only its degenerate paths were open.

## Fixture shapes deliberately avoided

Each of these is a shape that has beaten this campaign before:

- **Identity constants** — origin `(0,0,0)`, unit scale `1.0`, bbox corner at the local origin, opaque material alpha. Replaced with distinct non-zero, per-axis values and a millimetre model.
- **A property that holds either way** — `toBeGreaterThan(0)` on a counter (M39, fixed).
- **A loop carried by one lucky case** — two meshes of *different* sizes so a vertex stride cannot pass for an index stride; a descending id map so "return the last id" cannot pass for a maximum.
- **A two-valued signal with an untested third state** — material resolution in all four states; `deferredEntityIndex` absent / empty / populated; `Representation` present and `$`; metadata statistics with and without geometry.
- **Symmetric pairs** — the GLB fixture has two nodes and one mesh so node index (1) ≠ mesh index (0), and asymmetric entity flags so `HAS_GEOMETRY` cannot read as `IS_TYPE`.

## Typecheck

`pnpm typecheck` covers 2 of 40 packages and the root `tsconfig.json` excludes `**/*.test.ts`, so it does not check this work. I typechecked `packages/export/src/**/*` separately against the package's own `tsconfig.packages.json` options with the test exclusion lifted (29 test files in the program, verified via `--listFiles`). **All new and modified files are clean.**

**Pre-existing errors surfaced, not fixed here** (15, all invisible to CI because build and typecheck both exclude `**/*.test.ts`):

- `src/ifc5-exporter.test.ts` — 7 × `TS2345`, `null` passed where `MutablePropertyView | undefined` is declared.
- `src/parquet-exporter.test.ts` — 6, from `src/vendor-types.d.ts` declaring deliberately narrow ambient modules for `apache-arrow`/`parquet-wasm` that cover only the write side the exporter uses: `tableFromIPC` and `readParquet` are not declared, plus `TS7006` on the row callback and `TS2339` on `RelationshipType.Contains`.
- `src/merged-exporter.test.ts` — 2 × `TS2339`, `.set` on `EntityByIdIndex`.

The new `parquet-geometry.test.ts` reaches the Parquet read side through an explicitly typed dynamic import rather than widening `vendor-types.d.ts`, so it adds no new instance of that error and leaves the exporter's own ambient contract alone.

## Method notes

- Dependencies built first (`pnpm turbo build --filter=@ifc-lite/export^...`) before any run.
- Every mutation was an exact-substring replacement asserting `n == 1`, with the mutated region **re-read from disk** and confirmed changed before any result was believed.
- Every restore copied back a backup taken **before** that file's first mutation — never `git checkout --`, never a backup re-taken after a run.
- The full package suite was run for every mutation (not a subset), so a kill in another file could not be missed.
- Two parquet mutations were re-run after the async refactor of the decode helpers to confirm the tests still discriminate.
- Skipped suites are unchanged (2 files, 29 tests) and are all fixture-gated on models fetched by `pnpm fixtures`; no suite silently skips.
