### PR TITLE
test(sandbox,cli): close 20 mutation-verified gaps in the sandbox capability boundary and CLI surface

### DIFF
--- a/packages/cli/src/commands/ext-signing.test.ts
+++ b/packages/cli/src/commands/ext-signing.test.ts
@@ -46,6 +46,12 @@ class ExitCalled extends Error {
  * `verifyBundle`, which then emits a second document. That second write cannot
  * happen in production — it is an artifact of making the exit observable — so
  * the assertions read the document the command actually decided to print.
+ *
+ * The same artifact hides the exit *code*, which is why `verify()` below reads
+ * the FIRST recorded exit rather than the one that escapes: the catch-all also
+ * calls `process.exit(2)`, so reading the escaping code made "exit 2" hold for
+ * a mismatch branch that exited 0. Verified: changing the mismatch branch to
+ * `process.exit(0)` left this file green until the change below.
  */
 function firstJsonDoc(out: string): unknown {
   const [first] = out.split(/\n(?=\{)/);
@@ -56,11 +62,14 @@ describe('ifc-lite ext verify', () => {
   let dir: string;
   let stdout: string;
   let stderr: string;
+  /** Every process.exit() code, in call order. Index 0 is the deciding branch. */
+  const exitCodes: number[] = [];
   const dirs: string[] = [];
 
   beforeEach(async () => {
     stdout = '';
     stderr = '';
+    exitCodes.length = 0;
     dir = await mkdtemp(join(tmpdir(), 'ifc-lite-ext-sign-'));
     dirs.push(dir);
     vi.spyOn(process.stdout, 'write').mockImplementation(((chunk: string) => {
@@ -72,6 +81,7 @@ describe('ifc-lite ext verify', () => {
       return true;
     }) as typeof process.stderr.write);
     vi.spyOn(process, 'exit').mockImplementation((((code?: string | number | null) => {
+      exitCodes.push(typeof code === 'number' ? code : 0);
       throw new ExitCalled(typeof code === 'number' ? code : undefined);
     }) as unknown) as typeof process.exit);
   });
@@ -99,13 +109,15 @@ describe('ifc-lite ext verify', () => {
   async function verify(args: string[]): Promise<{ code: number; stdout: string; stderr: string }> {
     stdout = '';
     stderr = '';
+    exitCodes.length = 0;
     try {
       await extVerifyCommand(args);
-      return { code: 0, stdout, stderr };
     } catch (err) {
-      if (err instanceof ExitCalled) return { code: err.code ?? 0, stdout, stderr };
-      throw err;
+      if (!(err instanceof ExitCalled)) throw err;
     }
+    // exitCodes[0], not the escaping ExitCalled: the mismatch branch's exit is
+    // re-raised by the catch-all around verifyBundle, which masks its code.
+    return { code: exitCodes[0] ?? 0, stdout, stderr };
   }
 
   it('accepts a bundle signed by the key the caller expects', async () => {

--- a/packages/cli/src/commands/ext-signing.test.ts
+++ b/packages/cli/src/commands/ext-signing.test.ts
@@ -1,0 +1,206 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `ifc-lite ext verify` is a gate: a CI pipeline runs it and reads the exit
+ * code. `ext-signing.ts` had no test file, and three mutations left the
+ * package's 271 tests green — all of them turning a refusal into an
+ * acceptance:
+ *
+ *   - the signer check (`expected.fingerprint !== info.fingerprint`) deleted,
+ *     so a bundle signed by ANY key passed `--key trusted.iflk` with exit 0;
+ *   - the unsigned-but-`--key`-given refusal downgraded from exit 2 to exit 0;
+ *   - `getArg` accepting a following flag as its value, so
+ *     `--key --json` silently verified against no key at all.
+ *
+ * The suite drives the real commands end to end — keygen, pack, sign, verify —
+ * because the exit code and the stdout document ARE the contract, and a unit
+ * test of the comparison would not have caught the third one.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { extCommand } from './ext.js';
+import {
+  extKeygenCommand,
+  extPackCommand,
+  extSignCommand,
+  extVerifyCommand,
+} from './ext-signing.js';
+
+/** Thrown in place of a real process.exit so the code is observable. */
+class ExitCalled extends Error {
+  constructor(public readonly code: number | undefined) {
+    super(`process.exit(${code})`);
+  }
+}
+
+/**
+ * The FIRST JSON document on stdout.
+ *
+ * A real `process.exit()` ends the process; the stub throws instead, and on the
+ * fingerprint-mismatch path that throw is caught by the `try` around
+ * `verifyBundle`, which then emits a second document. That second write cannot
+ * happen in production — it is an artifact of making the exit observable — so
+ * the assertions read the document the command actually decided to print.
+ */
+function firstJsonDoc(out: string): unknown {
+  const [first] = out.split(/\n(?=\{)/);
+  return JSON.parse(first);
+}
+
+describe('ifc-lite ext verify', () => {
+  let dir: string;
+  let stdout: string;
+  let stderr: string;
+  const dirs: string[] = [];
+
+  beforeEach(async () => {
+    stdout = '';
+    stderr = '';
+    dir = await mkdtemp(join(tmpdir(), 'ifc-lite-ext-sign-'));
+    dirs.push(dir);
+    vi.spyOn(process.stdout, 'write').mockImplementation(((chunk: string) => {
+      stdout += String(chunk);
+      return true;
+    }) as typeof process.stdout.write);
+    vi.spyOn(process.stderr, 'write').mockImplementation(((chunk: string) => {
+      stderr += String(chunk);
+      return true;
+    }) as typeof process.stderr.write);
+    vi.spyOn(process, 'exit').mockImplementation((((code?: string | number | null) => {
+      throw new ExitCalled(typeof code === 'number' ? code : undefined);
+    }) as unknown) as typeof process.exit);
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    for (const d of dirs.splice(0)) await rm(d, { recursive: true, force: true });
+  });
+
+  /** Scaffold a bundle directory and return its path. */
+  async function scaffold(name = 'demo'): Promise<string> {
+    const path = join(dir, name);
+    await extCommand(['init', path, '--id', `ext.${name}`]);
+    return path;
+  }
+
+  /** Generate a keypair, returning both file paths. */
+  async function keypair(prefix: string): Promise<{ pub: string; priv: string }> {
+    const base = join(dir, prefix);
+    await extKeygenCommand(['--out', base]);
+    return { pub: `${base}.public.iflk`, priv: `${base}.private.iflk` };
+  }
+
+  /** Run verify and report how it exited. */
+  async function verify(args: string[]): Promise<{ code: number; stdout: string; stderr: string }> {
+    stdout = '';
+    stderr = '';
+    try {
+      await extVerifyCommand(args);
+      return { code: 0, stdout, stderr };
+    } catch (err) {
+      if (err instanceof ExitCalled) return { code: err.code ?? 0, stdout, stderr };
+      throw err;
+    }
+  }
+
+  it('accepts a bundle signed by the key the caller expects', async () => {
+    const src = await scaffold();
+    const key = await keypair('alice');
+    const out = join(dir, 'signed.iflx');
+    await extPackCommand([src, '--out', out, '--sign', '--key', key.priv]);
+
+    const result = await verify([out, '--key', key.pub, '--json']);
+    expect(result.code).toBe(0);
+    const doc = firstJsonDoc(result.stdout);
+    expect(doc).toMatchObject({ ok: true, signed: true });
+  });
+
+  it('REFUSES a bundle signed by a different key, with exit 2', async () => {
+    const src = await scaffold();
+    const alice = await keypair('alice');
+    const mallory = await keypair('mallory');
+    const out = join(dir, 'signed-by-mallory.iflx');
+    // Validly signed — just not by the signer the caller pinned.
+    await extPackCommand([src, '--out', out, '--sign', '--key', mallory.priv]);
+
+    const result = await verify([out, '--key', alice.pub, '--json']);
+    expect(result.code).toBe(2);
+    const doc = firstJsonDoc(result.stdout) as Record<string, unknown>;
+    expect(doc.ok).toBe(false);
+    expect(doc.error).toBe('fingerprint_mismatch');
+    expect(doc.expectedFingerprint).not.toBe(doc.actualFingerprint);
+  });
+
+  it('reports the mismatch on stderr, not stdout, without --json', async () => {
+    const src = await scaffold();
+    const alice = await keypair('alice');
+    const mallory = await keypair('mallory');
+    const out = join(dir, 'signed-by-mallory2.iflx');
+    await extPackCommand([src, '--out', out, '--sign', '--key', mallory.priv]);
+
+    const result = await verify([out, '--key', alice.pub]);
+    expect(result.code).toBe(2);
+    expect(result.stderr).toContain('does not match the expected key');
+    expect(result.stdout).toBe('');
+  });
+
+  it('REFUSES an unsigned bundle when --key was given, with exit 2', async () => {
+    const src = await scaffold();
+    const key = await keypair('alice');
+    const out = join(dir, 'unsigned.iflx');
+    await extPackCommand([src, '--out', out]);
+
+    const result = await verify([out, '--key', key.pub, '--json']);
+    expect(result.code).toBe(2);
+    expect(firstJsonDoc(result.stdout)).toMatchObject({
+      ok: false,
+      signed: false,
+      error: 'unsigned_with_expected_key',
+    });
+  });
+
+  it('inspects an unsigned bundle successfully when no --key is given', async () => {
+    // The counter-case that keeps the refusal above about --key rather than
+    // about being unsigned.
+    const src = await scaffold();
+    const out = join(dir, 'unsigned2.iflx');
+    await extPackCommand([src, '--out', out]);
+
+    const result = await verify([out, '--json']);
+    expect(result.code).toBe(0);
+    expect(firstJsonDoc(result.stdout)).toMatchObject({ ok: true, signed: false });
+  });
+
+  it('does not read the flag after --key as a key path', async () => {
+    // `--key --json` means "no key, JSON output". Treating `--json` as the key
+    // path would make the run verify against a key file that does not exist —
+    // or, on the unsigned path here, quietly assert a signer that was never
+    // supplied.
+    const src = await scaffold();
+    const out = join(dir, 'unsigned3.iflx');
+    await extPackCommand([src, '--out', out]);
+
+    const result = await verify([out, '--key', '--json']);
+    expect(result.code).toBe(0);
+    expect(firstJsonDoc(result.stdout)).toMatchObject({ ok: true, signed: false });
+  });
+
+  it('still verifies a bundle signed after the fact by `ext sign`', async () => {
+    const src = await scaffold();
+    const key = await keypair('alice');
+    const packed = join(dir, 'plain.iflx');
+    await extPackCommand([src, '--out', packed]);
+    const signed = join(dir, 'after.iflx');
+    await extSignCommand([src, '--key', key.priv, '--out', signed]);
+
+    expect((await verify([packed, '--json'])).code).toBe(0);
+    const result = await verify([signed, '--key', key.pub, '--json']);
+    expect(result.code).toBe(0);
+    expect(firstJsonDoc(result.stdout)).toMatchObject({ ok: true, signed: true });
+  });
+});

--- a/packages/cli/src/commands/query-aggregation.test.ts
+++ b/packages/cli/src/commands/query-aggregation.test.ts
@@ -1,0 +1,232 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `query-aggregation.ts` backs `ifc-lite query --sort` and had no test file.
+ * Four separate mutations left the package's 271 tests green:
+ *
+ *   - inverting the quantity sort direction (`--desc` returned ascending),
+ *   - dropping the camelCase attribute-key mapping (`--sort globalid` and
+ *     `--sort objecttype` sorted every row by `undefined`, i.e. not at all),
+ *   - swapping pset and property in a dotted `--sort Pset.Prop`, and
+ *   - dropping the `|| 0` that turns an unparseable quantity into a number.
+ *
+ * Each branch of `sortEntities` is measured per-case: a two-element fixture
+ * would be carried by one lucky comparison, so the fixtures below are ordered
+ * so that *every* adjacent pair has to compare correctly.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { getQuantityValue, sortEntities, STANDARD_QTO_MAP } from './query-aggregation.js';
+
+interface FakeEntity {
+  ref: number;
+  name?: string;
+  type?: string;
+  globalId?: string;
+  objectType?: string;
+}
+
+/** Minimal stand-in for the SDK surface `sortEntities` actually touches. */
+function fakeBim(
+  quantities: Record<number, Array<{ name: string; quantities: Array<{ name: string; value: unknown }> }>> = {},
+  properties: Record<number, Array<{ name: string; properties: Array<{ name: string; value: unknown }> }>> = {},
+) {
+  return {
+    quantities: (ref: number) => quantities[ref] ?? [],
+    properties: (ref: number) => properties[ref] ?? [],
+  };
+}
+
+describe('getQuantityValue', () => {
+  const bim = fakeBim({
+    1: [
+      { name: 'Qto_WallBaseQuantities', quantities: [{ name: 'Length', value: 4.5 }] },
+      { name: 'Qto_Custom', quantities: [{ name: 'Height', value: '3' }] },
+    ],
+    2: [{ name: 'Qto_WallBaseQuantities', quantities: [{ name: 'Length', value: 'not a number' }] }],
+  });
+
+  it('finds a quantity in the first qset', () => {
+    expect(getQuantityValue(bim, 1, 'Length')).toBe(4.5);
+  });
+
+  it('keeps searching past the first qset', () => {
+    expect(getQuantityValue(bim, 1, 'Height')).toBe(3);
+  });
+
+  it('answers null — not 0 — when the quantity is absent', () => {
+    // The distinction is load-bearing: `--sum` and `--sort` treat a missing
+    // quantity differently from a present zero.
+    expect(getQuantityValue(bim, 1, 'Volume')).toBeNull();
+    expect(getQuantityValue(bim, 99, 'Length')).toBeNull();
+  });
+
+  it('answers 0, not NaN, for a present-but-unparseable value', () => {
+    // Without the `|| 0`, this leaks NaN into `--sum` totals (NaN poisons the
+    // whole sum) and into `--sort` comparisons (NaN comparisons are all false,
+    // so the order silently becomes input order).
+    const value = getQuantityValue(bim, 2, 'Length');
+    expect(value).toBe(0);
+    expect(Number.isNaN(value)).toBe(false);
+  });
+});
+
+describe('sortEntities — quantity sort', () => {
+  const entities: FakeEntity[] = [
+    { ref: 3, name: 'C' },
+    { ref: 1, name: 'A' },
+    { ref: 4, name: 'D' },
+    { ref: 2, name: 'B' },
+  ];
+  const bim = fakeBim({
+    1: [{ name: 'Qto', quantities: [{ name: 'Area', value: 10 }] }],
+    2: [{ name: 'Qto', quantities: [{ name: 'Area', value: 20 }] }],
+    3: [{ name: 'Qto', quantities: [{ name: 'Area', value: 30 }] }],
+    4: [{ name: 'Qto', quantities: [{ name: 'Area', value: 40 }] }],
+  });
+
+  it('sorts ascending by default', () => {
+    expect(sortEntities(entities, 'Area', false, bim).map((e) => e.ref)).toEqual([1, 2, 3, 4]);
+  });
+
+  it('sorts descending when asked', () => {
+    expect(sortEntities(entities, 'Area', true, bim).map((e) => e.ref)).toEqual([4, 3, 2, 1]);
+  });
+
+  it('treats a missing quantity as 0 rather than dropping the row', () => {
+    const withMissing = [...entities, { ref: 9, name: 'Z' }];
+    expect(sortEntities(withMissing, 'Area', false, bim).map((e) => e.ref)).toEqual([9, 1, 2, 3, 4]);
+  });
+
+  it('does not mutate the caller\'s array', () => {
+    const input = [...entities];
+    sortEntities(input, 'Area', true, bim);
+    expect(input.map((e) => e.ref)).toEqual([3, 1, 4, 2]);
+  });
+});
+
+describe('sortEntities — attribute sort', () => {
+  const entities: FakeEntity[] = [
+    { ref: 3, name: 'Charlie', type: 'IfcSlab', globalId: 'G3', objectType: 'OT-3' },
+    { ref: 1, name: 'Alpha', type: 'IfcColumn', globalId: 'G1', objectType: 'OT-1' },
+    { ref: 4, name: 'Delta', type: 'IfcWall', globalId: 'G4', objectType: 'OT-4' },
+    { ref: 2, name: 'Bravo', type: 'IfcDoor', globalId: 'G2', objectType: 'OT-2' },
+  ];
+  const bim = fakeBim();
+
+  it('sorts by name', () => {
+    expect(sortEntities(entities, 'name', false, bim).map((e) => e.ref)).toEqual([1, 2, 3, 4]);
+    expect(sortEntities(entities, 'name', true, bim).map((e) => e.ref)).toEqual([4, 3, 2, 1]);
+  });
+
+  it('sorts by type', () => {
+    // IfcColumn < IfcDoor < IfcSlab < IfcWall
+    expect(sortEntities(entities, 'type', false, bim).map((e) => e.ref)).toEqual([1, 2, 3, 4]);
+  });
+
+  it('maps the lowercase spelling back to the camelCase entity key', () => {
+    // `globalid` and `objecttype` are accepted spellings, but the entity field
+    // is `globalId` / `objectType`. Without the mapping every row reads
+    // `undefined`, every comparison is 0, and the "sort" is a no-op that
+    // silently returns input order.
+    for (const spelling of ['globalId', 'globalid', 'GlobalId']) {
+      expect(
+        sortEntities(entities, spelling, false, bim).map((e) => e.ref),
+        `--sort ${spelling}`,
+      ).toEqual([1, 2, 3, 4]);
+    }
+    for (const spelling of ['objectType', 'objecttype', 'ObjectType']) {
+      expect(
+        sortEntities(entities, spelling, true, bim).map((e) => e.ref),
+        `--sort ${spelling} --desc`,
+      ).toEqual([4, 3, 2, 1]);
+    }
+  });
+
+  it('puts entities missing the attribute first, ascending', () => {
+    const withMissing = [...entities, { ref: 9 }];
+    expect(sortEntities(withMissing, 'name', false, bim).map((e) => e.ref)).toEqual([9, 1, 2, 3, 4]);
+  });
+});
+
+describe('sortEntities — dotted Pset.Prop sort', () => {
+  const entities: FakeEntity[] = [
+    { ref: 3 },
+    { ref: 1 },
+    { ref: 4 },
+    { ref: 2 },
+  ];
+  // `Pset_WallCommon.Rating` and `Rating.Pset_WallCommon` must not be
+  // interchangeable: the second name is looked up INSIDE the first.
+  const properties = {
+    1: [{ name: 'Pset_WallCommon', properties: [{ name: 'Rating', value: 10 }] }],
+    2: [{ name: 'Pset_WallCommon', properties: [{ name: 'Rating', value: 20 }] }],
+    3: [{ name: 'Pset_WallCommon', properties: [{ name: 'Rating', value: 30 }] }],
+    4: [{ name: 'Pset_WallCommon', properties: [{ name: 'Rating', value: 40 }] }],
+  };
+  const bim = fakeBim({}, properties);
+
+  it('reads the property from the named pset, in that order', () => {
+    expect(sortEntities(entities, 'Pset_WallCommon.Rating', false, bim).map((e) => e.ref)).toEqual([
+      1, 2, 3, 4,
+    ]);
+    expect(sortEntities(entities, 'Pset_WallCommon.Rating', true, bim).map((e) => e.ref)).toEqual([
+      4, 3, 2, 1,
+    ]);
+  });
+
+  it('finds nothing when pset and property are given the wrong way round', () => {
+    // The counter-example that pins the order: a reversed lookup finds no
+    // values at all, so the comparison is flat and input order survives.
+    expect(sortEntities(entities, 'Rating.Pset_WallCommon', false, bim).map((e) => e.ref)).toEqual([
+      3, 1, 4, 2,
+    ]);
+  });
+
+  it('falls back to quantity sets when the pset has no such property', () => {
+    const qtoBim = fakeBim(
+      {
+        1: [{ name: 'Qto_WallBaseQuantities', quantities: [{ name: 'Length', value: 5 }] }],
+        2: [{ name: 'Qto_WallBaseQuantities', quantities: [{ name: 'Length', value: 1 }] }],
+      },
+      {},
+    );
+    expect(
+      sortEntities([{ ref: 1 }, { ref: 2 }], 'Qto_WallBaseQuantities.Length', false, qtoBim).map(
+        (e) => e.ref,
+      ),
+    ).toEqual([2, 1]);
+  });
+
+  it('compares non-numeric property values as text', () => {
+    const textBim = fakeBim({}, {
+      1: [{ name: 'Pset', properties: [{ name: 'Grade', value: 'C30' }] }],
+      2: [{ name: 'Pset', properties: [{ name: 'Grade', value: 'A10' }] }],
+      3: [{ name: 'Pset', properties: [{ name: 'Grade', value: 'B20' }] }],
+    });
+    expect(
+      sortEntities([{ ref: 1 }, { ref: 2 }, { ref: 3 }], 'Pset.Grade', false, textBim).map(
+        (e) => e.ref,
+      ),
+    ).toEqual([2, 3, 1]);
+  });
+});
+
+describe('STANDARD_QTO_MAP', () => {
+  it('names each type\'s standard quantity set with its real IFC spelling', () => {
+    expect(Object.keys(STANDARD_QTO_MAP.IfcWall)).toEqual(['Qto_WallBaseQuantities']);
+    expect(STANDARD_QTO_MAP.IfcWall.Qto_WallBaseQuantities).toContain('GrossSideArea');
+    expect(STANDARD_QTO_MAP.IfcSpace.Qto_SpaceBaseQuantities).toContain('NetFloorArea');
+  });
+
+  it('lists exactly one standard qset per covered type', () => {
+    for (const [type, sets] of Object.entries(STANDARD_QTO_MAP)) {
+      expect(Object.keys(sets), type).toHaveLength(1);
+      const [setName] = Object.keys(sets);
+      expect(setName, type).toMatch(/^Qto_\w+BaseQuantities$/);
+      expect(sets[setName].length, `${type}.${setName}`).toBeGreaterThanOrEqual(1);
+    }
+  });
+});

--- a/packages/cli/src/logger.test.ts
+++ b/packages/cli/src/logger.test.ts
@@ -41,6 +41,29 @@ describe('parseVerbosity', () => {
     spy.mockRestore();
   });
 
+  it('does not swallow the NEXT FLAG as an invalid --log-level value', () => {
+    // Three states, not two: the value after `--log-level` is either valid, or
+    // an invalid word (consumed, so it cannot be mistaken for the file path),
+    // or another flag (must NOT be consumed). Only the first two were pinned,
+    // so `--log-level --json` silently ate `--json` and the command produced
+    // human output where a script expected JSON.
+    const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const v = parseVerbosity(['query', 'm.ifc', '--log-level', '--json']);
+    expect(v.level).toBe('info');
+    expect(v.rest).toEqual(['query', 'm.ifc', '--json']);
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('tolerates --log-level as the very last argument', () => {
+    const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const v = parseVerbosity(['info', 'm.ifc', '--log-level']);
+    expect(v.level).toBe('info');
+    expect(v.rest).toEqual(['info', 'm.ifc']);
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
   it('leaves command-local flags untouched', () => {
     const v = parseVerbosity(['generate-spaces', 'm.ifc', '--json', '--out', 'x.json']);
     expect(v.rest).toEqual(['generate-spaces', 'm.ifc', '--json', '--out', 'x.json']);

--- a/packages/cli/src/output.test.ts
+++ b/packages/cli/src/output.test.ts
@@ -2,14 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { mkdtemp, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   getFlag,
   getAllFlags,
   hasFlag,
   getPositionalArgs,
   formatTable,
+  printJson,
   validateViewerPort,
+  writeOutput,
 } from './output.js';
 
 describe('getFlag', () => {
@@ -171,4 +176,90 @@ describe('formatTable', () => {
     expect(lines[2]).toContain('x');
   });
 
+});
+
+/**
+ * `writeOutput` and `printJson` are what every command's payload goes through,
+ * and neither had a test. Two mutations left the package's 271 tests green:
+ * dropping the stdout trailing newline (which is what keeps `| jq` and shell
+ * prompts working, and is deliberately withheld from byte output so
+ * `--format step > out.ifc` matches the exporter bytes), and dropping
+ * `printJson`'s Map conversion (a Map serialises to `{}` without it, so
+ * `--json` reported empty objects where the data was).
+ */
+describe('writeOutput', () => {
+  const writes: Array<string | Uint8Array> = [];
+  afterEach(() => {
+    writes.length = 0;
+    vi.restoreAllMocks();
+  });
+
+  function captureStdout() {
+    vi.spyOn(process.stdout, 'write').mockImplementation(((chunk: string | Uint8Array) => {
+      writes.push(chunk);
+      return true;
+    }) as typeof process.stdout.write);
+  }
+
+  it('appends a trailing newline to string output that lacks one', async () => {
+    captureStdout();
+    await writeOutput('hello');
+    expect(writes).toEqual(['hello', '\n']);
+  });
+
+  it('does not double the newline when the string already ends in one', async () => {
+    captureStdout();
+    await writeOutput('hello\n');
+    expect(writes).toEqual(['hello\n']);
+  });
+
+  it('writes bytes verbatim — no trailing newline', async () => {
+    // The IFC/GLB case: an appended newline corrupts the file.
+    captureStdout();
+    const bytes = new Uint8Array([0x49, 0x53, 0x4f]);
+    await writeOutput(bytes);
+    expect(writes).toEqual([bytes]);
+  });
+
+  it('writes to the file instead of stdout when --out is given', async () => {
+    captureStdout();
+    const dir = await mkdtemp(join(tmpdir(), 'ifc-lite-output-'));
+    const path = join(dir, 'payload.txt');
+    await writeOutput('no newline here', path);
+    // Written verbatim to disk, and nothing went to stdout.
+    expect(await readFile(path, 'utf-8')).toBe('no newline here');
+    expect(writes).toEqual([]);
+  });
+});
+
+describe('printJson', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function captured(data: unknown): string {
+    let out = '';
+    vi.spyOn(process.stdout, 'write').mockImplementation(((chunk: string) => {
+      out += chunk;
+      return true;
+    }) as typeof process.stdout.write);
+    printJson(data);
+    return out;
+  }
+
+  it('converts a Map to a plain object rather than emitting {}', () => {
+    const out = captured({ counts: new Map([['IfcWall', 12], ['IfcDoor', 3]]) });
+    expect(JSON.parse(out)).toEqual({ counts: { IfcWall: 12, IfcDoor: 3 } });
+  });
+
+  it('converts a nested Map too', () => {
+    const out = captured(new Map([['byStorey', new Map([['L1', 4]])]]));
+    expect(JSON.parse(out)).toEqual({ byStorey: { L1: 4 } });
+  });
+
+  it('leaves ordinary values alone and ends with a newline', () => {
+    const out = captured({ ok: true, items: [1, 2] });
+    expect(out.endsWith('\n')).toBe(true);
+    expect(JSON.parse(out)).toEqual({ ok: true, items: [1, 2] });
+  });
 });

--- a/packages/sandbox/src/bridge-helpers.test.ts
+++ b/packages/sandbox/src/bridge-helpers.test.ts
@@ -1,0 +1,153 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The shared bridge helpers had no test file. `toRef` has 30+ call sites
+ * across the bridge namespaces and is the only thing standing between a
+ * script-supplied object and an EntityRef the SDK will act on; `withAliases`
+ * exists solely so scripts can write `e.GlobalId` as well as `e.globalId`.
+ *
+ * Dropping `toRef`'s shape validation, and dropping an alias from
+ * `withAliases`, both left the package suite green.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { EntityData } from '@ifc-lite/sdk';
+import { mapNamedProperties, toRef, withAliases } from './bridge-helpers.js';
+
+describe('toRef', () => {
+  it('accepts a wrapped ref', () => {
+    expect(toRef({ ref: { modelId: 'm1', expressId: 42 }, name: 'Wall' })).toEqual({
+      modelId: 'm1',
+      expressId: 42,
+    });
+  });
+
+  it('accepts a bare ref', () => {
+    expect(toRef({ modelId: 'm1', expressId: 42 })).toEqual({ modelId: 'm1', expressId: 42 });
+  });
+
+  it('rejects a wrapped ref whose fields have the wrong types', () => {
+    // A script can hand any shape across the boundary. Each of these has a
+    // `ref` object, so a validation-free version would return it and let the
+    // SDK act on a ref with no usable expressId.
+    expect(toRef({ ref: { modelId: 'm1', expressId: '42' } })).toBeNull();
+    expect(toRef({ ref: { modelId: 1, expressId: 42 } })).toBeNull();
+    expect(toRef({ ref: { modelId: 'm1' } })).toBeNull();
+    expect(toRef({ ref: { expressId: 42 } })).toBeNull();
+    expect(toRef({ ref: {} })).toBeNull();
+  });
+
+  it('rejects a bare object whose fields have the wrong types', () => {
+    expect(toRef({ modelId: 'm1', expressId: '42' })).toBeNull();
+    expect(toRef({ modelId: 42, expressId: 42 })).toBeNull();
+    expect(toRef({ name: 'Wall' })).toBeNull();
+  });
+
+  it('rejects nullish and non-object input', () => {
+    expect(toRef(null)).toBeNull();
+    expect(toRef(undefined)).toBeNull();
+    expect(toRef(0)).toBeNull();
+    expect(toRef('')).toBeNull();
+  });
+
+  it('prefers the wrapped ref over sibling fields when both are present', () => {
+    expect(
+      toRef({ ref: { modelId: 'inner', expressId: 1 }, modelId: 'outer', expressId: 2 }),
+    ).toEqual({ modelId: 'inner', expressId: 1 });
+  });
+
+  it('falls back to the bare fields when the wrapped ref is unusable', () => {
+    // The fallback returns the OUTER object itself (extra keys and all), not a
+    // freshly built ref — so assert the identifying fields rather than an
+    // exact shape.
+    expect(toRef({ ref: { modelId: 'inner' }, modelId: 'outer', expressId: 2 })).toMatchObject({
+      modelId: 'outer',
+      expressId: 2,
+    });
+  });
+});
+
+describe('withAliases', () => {
+  const entity = {
+    ref: { modelId: 'm1', expressId: 7 },
+    globalId: '0YvCT2_$X3_xJG3rzD8L_8',
+    name: 'Basic Wall',
+    type: 'IfcWall',
+    description: 'exterior',
+    objectType: 'Wall:Basic',
+  } as unknown as EntityData;
+
+  it('exposes every field under BOTH the camelCase and PascalCase spelling', () => {
+    const aliased = withAliases(entity);
+    // Enumerated as an exact shape: a missing alias is the whole failure mode,
+    // and spot-checking one pair would not catch a different one going away.
+    expect(aliased).toEqual({
+      ref: { modelId: 'm1', expressId: 7 },
+      globalId: '0YvCT2_$X3_xJG3rzD8L_8',
+      GlobalId: '0YvCT2_$X3_xJG3rzD8L_8',
+      name: 'Basic Wall',
+      Name: 'Basic Wall',
+      type: 'IfcWall',
+      Type: 'IfcWall',
+      description: 'exterior',
+      Description: 'exterior',
+      objectType: 'Wall:Basic',
+      ObjectType: 'Wall:Basic',
+    });
+  });
+
+  it('carries an absent field through as undefined under both spellings', () => {
+    const sparse = { ref: { modelId: 'm1', expressId: 7 }, name: 'Wall' } as unknown as EntityData;
+    const aliased = withAliases(sparse);
+    expect(Object.keys(aliased).sort()).toEqual(
+      [
+        'Description',
+        'GlobalId',
+        'Name',
+        'ObjectType',
+        'Type',
+        'description',
+        'globalId',
+        'name',
+        'objectType',
+        'ref',
+        'type',
+      ].sort(),
+    );
+    expect(aliased.GlobalId).toBeUndefined();
+    expect(aliased.Name).toBe('Wall');
+  });
+});
+
+describe('mapNamedProperties', () => {
+  it('exposes each property under every spelling the schema promises', () => {
+    expect(
+      mapNamedProperties([{ name: 'IsExternal', value: true, type: 'IfcBoolean' }]),
+    ).toEqual([
+      {
+        name: 'IsExternal',
+        Name: 'IsExternal',
+        value: true,
+        Value: true,
+        NominalValue: true,
+        type: 'IfcBoolean',
+        Type: 'IfcBoolean',
+      },
+    ]);
+  });
+
+  it('maps every entry, not just the first', () => {
+    const mapped = mapNamedProperties([
+      { name: 'A', value: 1, type: 'IfcInteger' },
+      { name: 'B', value: 2, type: 'IfcInteger' },
+    ]);
+    expect(mapped.map((p) => p.Name)).toEqual(['A', 'B']);
+    expect(mapped.map((p) => p.NominalValue)).toEqual([1, 2]);
+  });
+
+  it('returns an empty list for no properties', () => {
+    expect(mapNamedProperties([])).toEqual([]);
+  });
+});

--- a/packages/sandbox/src/bridge-marshal.test.ts
+++ b/packages/sandbox/src/bridge-marshal.test.ts
@@ -1,0 +1,172 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Value marshalling across the QuickJS boundary — the three conversions every
+ * `bim.*` call goes through, none of which had a test.
+ *
+ * 1. `entityRefs` unmarshalling. The schema documents it as "array of
+ *    entities, map to .ref", and that mapping is what lets a script pass
+ *    `bim.query.byType(...)` results straight into `bim.viewer.colorize(...)`.
+ *    Dropping the `?? r` unwrap left the suite green.
+ * 2. `returns: 'string'` marshalling, which answers `null` — not a coerced
+ *    string — when the SDK hands back a non-string.
+ * 3. The `marshalValue` cycle guard, which is scoped to the *ancestor chain*.
+ *    Removing objects from the guard on exit is the difference between an
+ *    acyclic graph that shares a sub-object across siblings serialising in
+ *    full and its second occurrence silently becoming `null`. Making the
+ *    guard permanent (never deleting on exit) left the suite green.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { BimContext, EntityRef } from '@ifc-lite/sdk';
+import { createSandbox } from './sandbox.js';
+
+/** Permissions for a sandbox that only needs `bim.export`. */
+const EXPORT_ONLY = {
+  model: false,
+  query: false,
+  viewer: false,
+  mutate: false,
+  store: false,
+  lens: false,
+  export: true,
+  files: false,
+} as const;
+
+/** Build a stub BimContext whose `export` namespace records and answers. */
+function stubSdk(overrides: {
+  csv?: (refs: EntityRef[], options: unknown) => unknown;
+  json?: (refs: EntityRef[], columns: unknown) => unknown;
+}): { sdk: BimContext; calls: { csvRefs: EntityRef[][] } } {
+  const calls = { csvRefs: [] as EntityRef[][] };
+  const sdk = {
+    export: {
+      csv: (refs: EntityRef[], options: unknown) => {
+        calls.csvRefs.push(refs);
+        return overrides.csv ? overrides.csv(refs, options) : '';
+      },
+      json: (refs: EntityRef[], columns: unknown) =>
+        overrides.json ? overrides.json(refs, columns) : [],
+    },
+  } as unknown as BimContext;
+  return { sdk, calls };
+}
+
+async function withSandbox<T>(
+  sdk: BimContext,
+  fn: (evalCode: (code: string) => Promise<unknown>) => Promise<T>,
+): Promise<T> {
+  const sandbox = await createSandbox(sdk, { permissions: EXPORT_ONLY });
+  try {
+    return await fn(async (code) => (await sandbox.eval(code, { typescript: false })).value);
+  } finally {
+    sandbox.dispose();
+  }
+}
+
+describe('entityRefs argument unmarshalling', () => {
+  it('unwraps the .ref of each entity before the SDK sees it', async () => {
+    const { sdk, calls } = stubSdk({});
+    await withSandbox(sdk, async (run) => {
+      await run(`bim.export.csv(
+        [
+          { ref: { modelId: 'm1', expressId: 7 }, name: 'Wall A', type: 'IfcWall' },
+          { ref: { modelId: 'm1', expressId: 9 }, name: 'Wall B', type: 'IfcWall' },
+        ],
+        { columns: ['Name'] },
+      )`);
+    });
+
+    expect(calls.csvRefs).toHaveLength(1);
+    // The SDK must receive bare EntityRefs — NOT the wrapper objects. The
+    // `name`/`type` fields above exist so a mutant that forwards the entity
+    // unchanged is visibly different rather than accidentally equal.
+    expect(calls.csvRefs[0]).toEqual([
+      { modelId: 'm1', expressId: 7 },
+      { modelId: 'm1', expressId: 9 },
+    ]);
+  });
+
+  it('passes an already-bare ref through untouched', async () => {
+    const { sdk, calls } = stubSdk({});
+    await withSandbox(sdk, async (run) => {
+      await run(`bim.export.csv([{ modelId: 'm2', expressId: 3 }], { columns: [] })`);
+    });
+    expect(calls.csvRefs[0]).toEqual([{ modelId: 'm2', expressId: 3 }]);
+  });
+
+  it('answers an empty list when the argument is omitted', async () => {
+    const { sdk, calls } = stubSdk({});
+    await withSandbox(sdk, async (run) => {
+      await run(`bim.export.csv()`);
+    });
+    expect(calls.csvRefs[0]).toEqual([]);
+  });
+});
+
+describe("returns: 'string' marshalling", () => {
+  it('hands a string back as a string', async () => {
+    const { sdk } = stubSdk({ csv: () => 'Name\nWall A\n' });
+    const value = await withSandbox(sdk, (run) =>
+      run(`bim.export.csv([], { columns: ['Name'] })`),
+    );
+    expect(value).toBe('Name\nWall A\n');
+  });
+
+  it('answers null for a non-string, rather than coercing it', async () => {
+    // A coercing marshaller would hand the script "[object Object]" / "42" and
+    // let a broken SDK return read as real CSV text.
+    for (const [returned, label] of [
+      [{ rows: 1 }, 'object'],
+      [42, 'number'],
+      [undefined, 'undefined'],
+    ] as const) {
+      const { sdk } = stubSdk({ csv: () => returned });
+      const value = await withSandbox(sdk, (run) =>
+        run(`bim.export.csv([], { columns: [] })`),
+      );
+      expect(value, `non-string return of type ${label}`).toBeNull();
+    }
+  });
+});
+
+describe('marshalValue cycle guard', () => {
+  it('serialises a sub-object shared between siblings in full, both times', async () => {
+    // Acyclic: `shared` appears twice, but never inside itself. Both
+    // occurrences must survive — a guard that never releases an object on the
+    // way out would null the second one.
+    const shared = { unit: 'm', factor: 0.001 };
+    const { sdk } = stubSdk({ json: () => ({ a: shared, b: shared }) });
+    const value = await withSandbox(sdk, (run) => run(`bim.export.json([], [])`));
+    expect(value).toEqual({
+      a: { unit: 'm', factor: 0.001 },
+      b: { unit: 'm', factor: 0.001 },
+    });
+  });
+
+  it('serialises the same object repeated down a sibling list', async () => {
+    const shared = { id: 1 };
+    const { sdk } = stubSdk({ json: () => [shared, shared, shared] });
+    const value = await withSandbox(sdk, (run) => run(`bim.export.json([], [])`));
+    expect(value).toEqual([{ id: 1 }, { id: 1 }, { id: 1 }]);
+  });
+
+  it('still cuts a genuine cycle rather than recursing forever', async () => {
+    const cyclic: Record<string, unknown> = { name: 'root' };
+    cyclic.self = cyclic;
+    const { sdk } = stubSdk({ json: () => cyclic });
+    const value = await withSandbox(sdk, (run) => run(`bim.export.json([], [])`));
+    expect(value).toEqual({ name: 'root', self: null });
+  });
+
+  it('cuts a cycle that closes through an intermediate object', async () => {
+    const root: Record<string, unknown> = { level: 0 };
+    const child: Record<string, unknown> = { level: 1, back: root };
+    root.child = child;
+    const { sdk } = stubSdk({ json: () => root });
+    const value = await withSandbox(sdk, (run) => run(`bim.export.json([], [])`));
+    expect(value).toEqual({ level: 0, child: { level: 1, back: null } });
+  });
+});

--- a/packages/sandbox/src/bridge-permissions.test.ts
+++ b/packages/sandbox/src/bridge-permissions.test.ts
@@ -1,0 +1,147 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The permission gate is the sandbox's whole capability boundary: a namespace
+ * whose permission is false is never built onto `bim`, so a script cannot
+ * reach it at all. Nothing pinned that. Deleting the gate in
+ * `buildSchemaNamespaces` — every namespace built regardless of permissions —
+ * left the package's 71 tests green, as did flipping the read-only
+ * `DEFAULT_PERMISSIONS` for `mutate` and `store` to true.
+ *
+ * Both directions matter and are checked separately, so a regression in one
+ * cannot hide behind the other:
+ *   - the gate honours an explicitly-false permission, and
+ *   - the *defaults* it reads are read-only for the two write capabilities.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { BimContext } from '@ifc-lite/sdk';
+import { createSandbox } from './sandbox.js';
+import { DEFAULT_PERMISSIONS, type SandboxPermissions } from './types.js';
+
+/** `typeof bim.<ns>` inside the sandbox: 'object' when built, 'undefined' when gated out. */
+async function namespaceTypes(
+  permissions: SandboxPermissions | undefined,
+): Promise<Record<string, string>> {
+  const sandbox = await createSandbox({} as BimContext, { permissions });
+  try {
+    const result = await sandbox.eval(
+      `({
+        model: typeof bim.model,
+        query: typeof bim.query,
+        viewer: typeof bim.viewer,
+        mutate: typeof bim.mutate,
+        store: typeof bim.store,
+        lens: typeof bim.lens,
+        create: typeof bim.create,
+        files: typeof bim.files,
+        export: typeof bim.export,
+      })`,
+      { typescript: false },
+    );
+    return result.value as Record<string, string>;
+  } finally {
+    sandbox.dispose();
+  }
+}
+
+describe('sandbox permission gate', () => {
+  it('does not build a namespace whose permission is explicitly false', async () => {
+    const types = await namespaceTypes({
+      model: false,
+      query: false,
+      viewer: false,
+      mutate: false,
+      store: false,
+      lens: false,
+      export: false,
+      files: false,
+    });
+
+    // Every gate off: the `bim` object carries no namespace at all.
+    expect(types).toEqual({
+      model: 'undefined',
+      query: 'undefined',
+      viewer: 'undefined',
+      mutate: 'undefined',
+      store: 'undefined',
+      lens: 'undefined',
+      create: 'undefined',
+      files: 'undefined',
+      export: 'undefined',
+    });
+  });
+
+  it('builds exactly the namespaces whose permission is true', async () => {
+    const types = await namespaceTypes({
+      model: false,
+      query: true,
+      viewer: false,
+      mutate: true,
+      store: false,
+      lens: false,
+      export: false,
+      files: false,
+    });
+
+    expect(types.query).toBe('object');
+    expect(types.mutate).toBe('object');
+    // Everything else stays out — a gate that lets one namespace through must
+    // not let the rest through with it.
+    expect(types.model).toBe('undefined');
+    expect(types.viewer).toBe('undefined');
+    expect(types.store).toBe('undefined');
+    expect(types.lens).toBe('undefined');
+    expect(types.export).toBe('undefined');
+    expect(types.files).toBe('undefined');
+    // `bim.create` reuses the `export` permission, so it follows export, not
+    // its own name.
+    expect(types.create).toBe('undefined');
+  });
+
+  it('gates bim.create on the export permission it declares', async () => {
+    const types = await namespaceTypes({
+      model: false,
+      query: false,
+      viewer: false,
+      mutate: false,
+      store: false,
+      lens: false,
+      export: true,
+      files: false,
+    });
+    expect(types.create).toBe('object');
+    expect(types.export).toBe('object');
+  });
+
+  it('keeps the two write capabilities off by default', () => {
+    // Asserted on the constant as well as through a sandbox below: this is the
+    // published default for every caller that passes no permissions at all.
+    expect(DEFAULT_PERMISSIONS.mutate).toBe(false);
+    expect(DEFAULT_PERMISSIONS.store).toBe(false);
+    // The read capabilities are on by default — a default of "nothing works"
+    // would pass the two assertions above while breaking every caller.
+    expect(DEFAULT_PERMISSIONS.model).toBe(true);
+    expect(DEFAULT_PERMISSIONS.query).toBe(true);
+    expect(DEFAULT_PERMISSIONS.viewer).toBe(true);
+    expect(DEFAULT_PERMISSIONS.lens).toBe(true);
+    expect(DEFAULT_PERMISSIONS.export).toBe(true);
+    expect(DEFAULT_PERMISSIONS.files).toBe(true);
+  });
+
+  it('a default sandbox exposes the read API but neither write namespace', async () => {
+    const types = await namespaceTypes(undefined);
+
+    expect(types.mutate).toBe('undefined');
+    expect(types.store).toBe('undefined');
+    expect(types.query).toBe('object');
+    expect(types.model).toBe('object');
+    expect(types.viewer).toBe('object');
+    expect(types.lens).toBe('object');
+    expect(types.export).toBe('object');
+    expect(types.files).toBe('object');
+    expect(types.create).toBe('object');
+  });
+});

--- a/packages/sandbox/src/creator-registry.test.ts
+++ b/packages/sandbox/src/creator-registry.test.ts
@@ -1,0 +1,148 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The session-scoped IfcCreator registry, which had no test of its own.
+ * Cross-session isolation was covered (bridge-schema.test.ts); the handle
+ * lifecycle inside one session was not:
+ *
+ *   - the per-session counter must ADVANCE, or a script that calls
+ *     `bim.create.project()` twice gets handle 1 both times and the second
+ *     creator silently replaces the first — the user's first model is gone
+ *     with no error anywhere;
+ *   - `removeSession` — the sandbox's own teardown path, via
+ *     `disposeSchemaNamespaceSession` — must actually drop the creators, or a
+ *     disposed sandbox keeps whole IfcCreator models alive for the life of the
+ *     process.
+ *
+ * Both survived mutation with the package suite green.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { IfcCreator } from '@ifc-lite/sdk';
+import { creatorRegistry } from './creator-registry.js';
+
+/** A fresh session id per test — the registry is a module-level singleton. */
+let nextSession = 0;
+const session = (): string => `test-session-${++nextSession}`;
+
+describe('creatorRegistry handle allocation', () => {
+  it('gives every creator in a session a distinct handle', () => {
+    const s = session();
+    const first = new IfcCreator({ Name: 'First' });
+    const second = new IfcCreator({ Name: 'Second' });
+    const third = new IfcCreator({ Name: 'Third' });
+
+    const h1 = creatorRegistry.registerForSession(s, first);
+    const h2 = creatorRegistry.registerForSession(s, second);
+    const h3 = creatorRegistry.registerForSession(s, third);
+
+    expect(new Set([h1, h2, h3]).size).toBe(3);
+    // Each handle still resolves to the creator it was issued for — a counter
+    // that does not advance would make all three answer the last creator.
+    expect(creatorRegistry.getForSession(s, h1)).toBe(first);
+    expect(creatorRegistry.getForSession(s, h2)).toBe(second);
+    expect(creatorRegistry.getForSession(s, h3)).toBe(third);
+
+    creatorRegistry.removeSession(s);
+  });
+
+  it('keeps advancing while any creator in the session is still live', () => {
+    const s = session();
+    const keep = new IfcCreator({ Name: 'Keep' });
+    const drop = new IfcCreator({ Name: 'Drop' });
+    const hKeep = creatorRegistry.registerForSession(s, keep);
+    const hDrop = creatorRegistry.registerForSession(s, drop);
+
+    creatorRegistry.removeForSession(s, hDrop);
+    const hNext = creatorRegistry.registerForSession(s, new IfcCreator({ Name: 'Next' }));
+
+    // The session is not empty (hKeep is live), so the counter is intact and
+    // the freed handle is NOT handed out again while a stale script reference
+    // to it could still exist.
+    expect(hNext).not.toBe(hKeep);
+    expect(hNext).not.toBe(hDrop);
+    expect(creatorRegistry.getForSession(s, hKeep)).toBe(keep);
+    expect(() => creatorRegistry.getForSession(s, hDrop)).toThrow(/Invalid creator handle/);
+
+    creatorRegistry.removeSession(s);
+  });
+
+  it('numbers each session from its own counter', () => {
+    const a = session();
+    const b = session();
+    const creatorA1 = new IfcCreator({ Name: 'A1' });
+    const creatorA2 = new IfcCreator({ Name: 'A2' });
+    const creatorB1 = new IfcCreator({ Name: 'B1' });
+
+    const ha1 = creatorRegistry.registerForSession(a, creatorA1);
+    const ha2 = creatorRegistry.registerForSession(a, creatorA2);
+    const hb1 = creatorRegistry.registerForSession(b, creatorB1);
+
+    // Session b starts its own numbering rather than continuing a's, so a's
+    // second handle and b's first are different numbers...
+    expect(ha2).not.toBe(hb1);
+    // ...and each session resolves its own handles to its own creators.
+    expect(creatorRegistry.getForSession(a, ha1)).toBe(creatorA1);
+    expect(creatorRegistry.getForSession(a, ha2)).toBe(creatorA2);
+    expect(creatorRegistry.getForSession(b, hb1)).toBe(creatorB1);
+    // Session a's second handle does not exist in b at all.
+    expect(() => creatorRegistry.getForSession(b, ha2)).toThrow(/Invalid creator handle/);
+
+    creatorRegistry.removeSession(a);
+    creatorRegistry.removeSession(b);
+  });
+});
+
+describe('creatorRegistry teardown', () => {
+  it('removeSession drops every creator the session held', () => {
+    const s = session();
+    const handles = [
+      creatorRegistry.registerForSession(s, new IfcCreator({ Name: 'One' })),
+      creatorRegistry.registerForSession(s, new IfcCreator({ Name: 'Two' })),
+    ];
+
+    creatorRegistry.removeSession(s);
+
+    // Not just "the counter was cleared": every handle must be gone, which is
+    // the observable half of not leaking the creators.
+    for (const handle of handles) {
+      expect(() => creatorRegistry.getForSession(s, handle)).toThrow(/Invalid creator handle/);
+    }
+  });
+
+  it('removeForSession drops only the handle asked for', () => {
+    const s = session();
+    const keep = new IfcCreator({ Name: 'Keep' });
+    const drop = new IfcCreator({ Name: 'Drop' });
+    const hKeep = creatorRegistry.registerForSession(s, keep);
+    const hDrop = creatorRegistry.registerForSession(s, drop);
+
+    creatorRegistry.removeForSession(s, hDrop);
+
+    expect(creatorRegistry.getForSession(s, hKeep)).toBe(keep);
+    expect(() => creatorRegistry.getForSession(s, hDrop)).toThrow(/Invalid creator handle/);
+
+    creatorRegistry.removeSession(s);
+  });
+
+  it('restarts numbering once the session holds no creators at all', () => {
+    // Documented rather than asserted as desirable: emptying a session drops
+    // its counter along with its map, so the next handle starts over at 1.
+    // Harmless today because the only way to empty a session is to remove
+    // every creator in it, which invalidates every handle a script could hold.
+    // Pinned so a change to that coupling is a deliberate one.
+    const s = session();
+    const first = creatorRegistry.registerForSession(s, new IfcCreator({ Name: 'First' }));
+    creatorRegistry.removeForSession(s, first);
+    const afterEmpty = creatorRegistry.registerForSession(s, new IfcCreator({ Name: 'Second' }));
+    expect(afterEmpty).toBe(first);
+    creatorRegistry.removeSession(s);
+  });
+
+  it('removeForSession on an unknown session is a no-op, not a throw', () => {
+    expect(() => creatorRegistry.removeForSession('never-registered', 1)).not.toThrow();
+    expect(() => creatorRegistry.removeSession('never-registered')).not.toThrow();
+  });
+});

--- a/packages/sandbox/src/stack-limit.test.ts
+++ b/packages/sandbox/src/stack-limit.test.ts
@@ -1,0 +1,70 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `SandboxLimits.maxStackBytes` — the one resource ceiling besides the CPU
+ * timeout that a script can actually be stopped by, and it had no test.
+ * Removing the `runtime.setMaxStackSize(...)` call left the package suite
+ * green, so nothing noticed that a configured stack ceiling was never applied.
+ *
+ * The recursion depth is chosen to sit BETWEEN the two states: it completes
+ * under the default 512KB stack and overflows under the 8KB one. A depth that
+ * overflowed in both would pass whether or not the limit is applied.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { BimContext } from '@ifc-lite/sdk';
+import { createSandbox } from './sandbox.js';
+import { DEFAULT_LIMITS } from './types.js';
+
+/** Recurses `n` deep and returns `n`. */
+const RECURSE = (n: number) => `function f(k){ return k <= 0 ? 0 : 1 + f(k - 1); } f(${n});`;
+
+/** Deep enough to exhaust an 8KB stack, shallow enough for the 512KB default. */
+const DEPTH = 400;
+
+async function evalWith(
+  limits: { maxStackBytes?: number },
+  code: string,
+): Promise<{ ok: true; value: unknown } | { ok: false; message: string }> {
+  const sandbox = await createSandbox({} as BimContext, { limits });
+  try {
+    const result = await sandbox.eval(code, { typescript: false });
+    return { ok: true, value: result.value };
+  } catch (err) {
+    return { ok: false, message: err instanceof Error ? err.message : String(err) };
+  } finally {
+    sandbox.dispose();
+  }
+}
+
+describe('sandbox stack ceiling', () => {
+  it('applies a configured maxStackBytes — recursion past it is stopped', async () => {
+    const result = await evalWith({ maxStackBytes: 8 * 1024 }, RECURSE(DEPTH));
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.message).toMatch(/stack overflow/i);
+  });
+
+  it('lets the SAME recursion through under the default ceiling', async () => {
+    // The other half of the pair: without this, the assertion above would hold
+    // just as well for a sandbox that refuses all recursion.
+    const result = await evalWith({}, RECURSE(DEPTH));
+    expect(result).toEqual({ ok: true, value: DEPTH });
+  });
+
+  it('applies an explicitly-passed ceiling equal to the default', async () => {
+    const result = await evalWith({ maxStackBytes: DEFAULT_LIMITS.maxStackBytes }, RECURSE(DEPTH));
+    expect(result).toEqual({ ok: true, value: DEPTH });
+  });
+
+  // NOT tested here: runaway recursion under the default ceiling. It does stop,
+  // but the overflow leaves QuickJS holding objects with leaked refcounts and
+  // the subsequent `runtime.dispose()` throws out of teardown — issue #1922,
+  // upstream, with no in-repo lever. A test asserting it would be asserting the
+  // bug's blast radius rather than the ceiling.
+
+  it('publishes a 512KB default stack', () => {
+    expect(DEFAULT_LIMITS.maxStackBytes).toBe(512 * 1024);
+  });
+});


### PR DESCRIPTION
Second, deeper mutation pass over `packages/sandbox` and `packages/cli`. Both had a shallow first pass; this one targeted the modules with **no test file at all**, which is where the survivors were.

**26 mutations + 3 deliberate controls; 5 killed, 21 survived — 19% kill ratio.** That number is **TARGETED**, not a uniform sample: mutations were aimed at the untested modules on purpose, so it measures where the suites do not reach, not overall suite quality. Everything aimed at the *tested* paths died — console capture budgets, the CPU timeout, disposal ordering, rejected promises, `diff-scope` classification.

**Test-only. No production code changed.**

| | files | tests | after |
|---|---|---|---|
| `packages/sandbox` | 12 | 71 | **17 / 108** |
| `packages/cli` | 25 | 271 passing (9 skipped) | **27 / 305 (9 skipped)** |

The 9 skips are fixture-gated, not unconditional: `clash.test.ts` needs a built CLI entry plus the wasm runtime, `gym.test.ts` needs the AB22.ifc fixture.

## Method

Each mutation was a verified single-occurrence substring replacement; the mutated region was **re-read from disk** and asserted to contain the new text and not the old before any result was believed; the source was restored from a backup taken before that file's first mutation (never `git checkout --`).

Every survivor was re-run against the downstream suites that consume `@ifc-lite/sandbox` — `packages/cli`'s three `schema` tests and `apps/viewer`'s `system-prompt` / `script-preflight` tests, both resolving through the built `dist`, with the package rebuilt for each mutation. **No false survivors.**

**Controls** (expected to die, all did): shrinking `MAX_LOG_ENTRIES` 1000 → 10; dropping the `interrupted` flag from the CPU interrupt handler; an off-by-one in the CLI log-level gate.

## Gaps closed — `packages/sandbox`

The capability boundary was almost entirely unpinned.

| Surviving mutation | What a user would see | Killing test |
|---|---|---|
| `if (!permissions[schema.permission]) continue` → `if (false) continue` | every namespace built regardless of permissions — a read-only script reaches `bim.mutate.*` and `bim.store.*` | `bridge-permissions.test.ts` |
| `DEFAULT_PERMISSIONS.mutate/store` `false` → `true` | every caller that passes no permissions silently gets write access | `bridge-permissions.test.ts` |
| `raw.map(r => r.ref ?? r)` → `raw.map(r => r)` | `bim.query.byType(...)` results no longer usable as `bim.viewer.colorize(...)` arguments | `bridge-marshal.test.ts` |
| `typeof value === 'string' ? … : vm.null` → `String(value)` | a broken SDK return reads as real CSV text (`"[object Object]"`) instead of `null` | `bridge-marshal.test.ts` |
| `stack.delete(obj)` on exit → no-op | `{ a: shared, b: shared }` returns `b: null` — an acyclic graph reported as cyclic | `bridge-marshal.test.ts` |
| `nextHandleBySession.set(sessionId, handle + 1)` → `handle` | a second `bim.create.project()` silently replaces the first model, no error anywhere | `creator-registry.test.ts` |
| `removeSession` stops dropping creators | every disposed sandbox leaks its `IfcCreator` models for the process lifetime | `creator-registry.test.ts` |
| `toRef` shape validation removed | a malformed script-supplied ref reaches the SDK with no usable `expressId` | `bridge-helpers.test.ts` |
| `withAliases` drops `GlobalId` | `e.GlobalId` — the whole point of the helper — is `undefined` | `bridge-helpers.test.ts` |
| `runtime.setMaxStackSize(...)` never called | a configured `maxStackBytes` is silently ignored | `stack-limit.test.ts` |

The stack test brackets the ceiling in **both** directions: the same 400-deep recursion completes under the default 512KB and overflows under an 8KB one, so it cannot pass for a sandbox that simply refuses all recursion.

## Gaps closed — `packages/cli`

| Surviving mutation | What a user would see | Killing test |
|---|---|---|
| `--log-level` value check drops `!value.startsWith('-')` | `--log-level --json` swallows `--json`; a script gets human output | `logger.test.ts` |
| `--sort` direction inverted | `--desc` returns **ascending** | `query-aggregation.test.ts` |
| attribute-key camelCase mapping dropped | `--sort globalid` / `--sort objecttype` silently a no-op (input order) | `query-aggregation.test.ts` |
| dotted sort swaps pset/prop | `--sort Pset_WallCommon.Rating` finds nothing, sorts nothing | `query-aggregation.test.ts` |
| `Number(q.value) \|\| 0` → `Number(q.value)` | NaN poisons `--sum` totals and flattens `--sort` | `query-aggregation.test.ts` |
| `writeOutput` trailing newline dropped | stdout payloads run into the shell prompt; byte output must stay verbatim | `output.test.ts` |
| `printJson` Map conversion dropped | `--json` reports `{}` where the data was | `output.test.ts` |
| `expected.fingerprint !== info.fingerprint` → `if (false)` | **a bundle signed by ANY key passes `ext verify --key trusted.iflk` with exit 0** | `ext-signing.test.ts` |
| unsigned-with-`--key` `exit(2)` → `exit(0)` | a CI gate accepts an unsigned bundle | `ext-signing.test.ts` |
| `getArg` accepts a following flag as its value | `--key --json` verifies against no key at all | `ext-signing.test.ts` |

`query-aggregation.ts` and `ext-signing.ts` both had **no test file**. Sort fixtures are four elements ordered so every adjacent pair has to compare correctly, rather than two elements one lucky comparison would carry.

## Reported, not fixed

**1. `runtime.setMemoryLimit(...)` is an observable no-op.** Removing the call changes nothing — and neither does the limit. A script allocated **50,000,000 characters under a declared 1MB `memoryBytes` ceiling** and succeeded. Reproduced against `quickjs-emscripten` directly, no ifc-lite code in the path, with the limit set both before and after `newContext()`: the call site is correct, this is upstream behaviour. The consequence is that the published **64MB `memoryBytes` default does not currently bound a script's memory use**; only the CPU timeout and the stack ceiling actually stop a runaway script. Classified EQUIVALENT for the shapes probed (strings and arrays up to 50MB against a 1MB declared limit) — **not** proven equivalent for all shapes. Flagging for a maintainer decision rather than changing sandbox behaviour.

**2. #1922.** Runaway recursion under the default stack ceiling does stop, but the overflow leaves QuickJS holding leaked refcounts and the following `runtime.dispose()` throws out of teardown. Upstream, no in-repo lever. A test would assert the bug's blast radius rather than the ceiling, so `stack-limit.test.ts` documents the omission instead.

**Also pinned rather than changed:** emptying a session drops its handle counter with its map, so the next handle restarts at 1. Harmless today — the only way to empty a session is to remove every creator in it, which invalidates every handle a script could hold — but the coupling is now explicit so a change to it is deliberate.

Nothing here touches **#2110**: every new sandbox test runs one eval at a time on its own sandbox instance.

## Typecheck

Test files were typechecked against each package's own compiler options with the `src`-only `include` lifted (the root `pnpm typecheck` excludes `**/*.test.ts`); `--listFiles` confirmed all 12 sandbox and 25 cli test files entered the program. Pre-existing errors left alone: **2** in `sandbox/src/transpile-wasm-url.test.ts` (the package has no `@types/node`, which only its tests need) and **16** across 6 existing cli test files (all the `process.exit` mock signature). The new files add none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
