### PR TITLE
test(collab,lists): close 31 mutation-verified coverage gaps (second sweep)

### DIFF
--- a/packages/collab/test/presence-eviction.test.ts
+++ b/packages/collab/test/presence-eviction.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { applyAwarenessUpdate, encodeAwarenessUpdate } from 'y-protocols/awareness';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as Y from 'yjs';
 import { colorForUser } from '../src/awareness/color.js';
 import { createPresence, type Presence } from '../src/awareness/presence.js';
@@ -48,12 +48,23 @@ function publishPeer(
 }
 
 describe('evictStale', () => {
+  // Eviction compares `Date.now() - state.lastUpdate` against the window, and
+  // `evictStale` reads the clock itself — there is no injectable `now`. With a
+  // live clock, a peer built at `Date.now() - staleAfterMs` is exactly at the
+  // boundary only until the next millisecond ticks, and everything in between
+  // (two Y.Docs, an awareness encode and a wire replay) is real work. On a
+  // loaded CI runner that is enough to cross the boundary, which is precisely
+  // how this file went red. Freeze the clock so the ages under test are the
+  // ages asserted; nothing here needs time to pass.
+  const NOW = 1_700_000_000_000;
+  beforeEach(() => { vi.useFakeTimers({ now: NOW }); });
+  afterEach(() => { vi.useRealTimers(); });
+
   it('drops a peer older than the window and keeps a fresh one', () => {
     const doc = new Y.Doc();
     const presence = createPresence(doc, { staleAfterMs: 5_000 });
-    const now = Date.now();
-    const stale = publishPeer(presence, now - 60_000, 'Stale');
-    const fresh = publishPeer(presence, now - 1_000, 'Fresh');
+    const stale = publishPeer(presence, NOW - 60_000, 'Stale');
+    const fresh = publishPeer(presence, NOW - 1_000, 'Fresh');
 
     // `getPeers()` also carries this client's own (empty) entry, so probe
     // the two remote ids rather than the map size.
@@ -73,17 +84,22 @@ describe('evictStale', () => {
   it('keeps a peer exactly at the window boundary (strictly older is evicted)', () => {
     const doc = new Y.Doc();
     const presence = createPresence(doc, { staleAfterMs: 5_000 });
-    const atBoundary = publishPeer(presence, Date.now() - 5_000, 'Edge');
+    // The clock is frozen, so these ages are exact: 5000ms and 5001ms.
+    const atBoundary = publishPeer(presence, NOW - 5_000, 'Edge');
+    const pastBoundary = publishPeer(presence, NOW - 5_001, 'Past');
 
     presence.evictStale();
+
     // `now - lastUpdate > staleAfterMs` — a peer that reported exactly one
-    // window ago is not yet stale. Timer granularity can push this past the
-    // boundary, so assert only that a peer this recent is not evicted for
-    // being *arbitrarily* old.
+    // window ago is not yet stale; one millisecond older is. Asserting both
+    // sides is what pins the comparison: `>=` would evict the first, and
+    // dropping the age test entirely would keep the second.
     const peers = presence.getPeers();
-    expect(Object.prototype.hasOwnProperty.call(peers, String(atBoundary.clientId))).toBe(true);
+    expect(peers[atBoundary.clientId]).toBeDefined();
+    expect(peers[pastBoundary.clientId]).toBeUndefined();
 
     atBoundary.dispose();
+    pastBoundary.dispose();
     presence.dispose();
   });
 
@@ -97,7 +113,7 @@ describe('evictStale', () => {
       user: { id: 'me', name: 'Me' },
       selection: [],
       status: 'active',
-      lastUpdate: Date.now() - 10 * 60 * 1000,
+      lastUpdate: NOW - 10 * 60 * 1000,
     });
 
     presence.evictStale();
@@ -113,9 +129,8 @@ describe('evictStale', () => {
     // quiet is gone.
     const doc = new Y.Doc();
     const presence = createPresence(doc);
-    const now = Date.now();
-    const quiet = publishPeer(presence, now - 9_000, 'Quiet');
-    const gone = publishPeer(presence, now - 11_000, 'Gone');
+    const quiet = publishPeer(presence, NOW - 9_000, 'Quiet');
+    const gone = publishPeer(presence, NOW - 11_000, 'Gone');
 
     presence.evictStale();
 

--- a/packages/collab/test/presence-eviction.test.ts
+++ b/packages/collab/test/presence-eviction.test.ts
@@ -1,0 +1,204 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Stale-presence eviction and patch bookkeeping (`awareness/presence.ts`,
+ * spec §5.4 / §7).
+ *
+ * Eviction is what removes a peer whose tab was closed without a clean
+ * disconnect. Nothing exercised it: mutations that evicted the LOCAL peer,
+ * that dropped the age comparison entirely, and that changed the default
+ * window from 10s to 1ms all survived the suite. Its two neighbours —
+ * the caller-supplied user colour and the authoritative `lastUpdate` —
+ * were equally free.
+ */
+
+import { applyAwarenessUpdate, encodeAwarenessUpdate } from 'y-protocols/awareness';
+import { describe, expect, it } from 'vitest';
+import * as Y from 'yjs';
+import { colorForUser } from '../src/awareness/color.js';
+import { createPresence, type Presence } from '../src/awareness/presence.js';
+
+/**
+ * Publish `state` onto `target`'s awareness as a REMOTE peer, by driving a
+ * second Awareness instance and replaying its encoded update. Going
+ * through the wire encoding is what makes the entry a peer rather than a
+ * local write, which is exactly the distinction eviction turns on.
+ */
+function publishPeer(
+  target: Presence,
+  lastUpdate: number,
+  name = 'Remote',
+): { clientId: number; dispose: () => void } {
+  const remoteDoc = new Y.Doc();
+  const remote = createPresence(remoteDoc, { updateRateHz: 1000, staleAfterMs: 1_000_000 });
+  remote.awareness.setLocalState({
+    user: { id: name, name },
+    selection: [],
+    status: 'active',
+    lastUpdate,
+  });
+  applyAwarenessUpdate(
+    target.awareness,
+    encodeAwarenessUpdate(remote.awareness, [remote.awareness.clientID]),
+    'test',
+  );
+  return { clientId: remote.awareness.clientID, dispose: () => remote.dispose() };
+}
+
+describe('evictStale', () => {
+  it('drops a peer older than the window and keeps a fresh one', () => {
+    const doc = new Y.Doc();
+    const presence = createPresence(doc, { staleAfterMs: 5_000 });
+    const now = Date.now();
+    const stale = publishPeer(presence, now - 60_000, 'Stale');
+    const fresh = publishPeer(presence, now - 1_000, 'Fresh');
+
+    // `getPeers()` also carries this client's own (empty) entry, so probe
+    // the two remote ids rather than the map size.
+    expect(presence.getPeers()[stale.clientId]).toBeDefined();
+    expect(presence.getPeers()[fresh.clientId]).toBeDefined();
+    presence.evictStale();
+
+    const peers = presence.getPeers();
+    expect(peers[stale.clientId]).toBeUndefined();
+    expect(peers[fresh.clientId]).toBeDefined();
+
+    stale.dispose();
+    fresh.dispose();
+    presence.dispose();
+  });
+
+  it('keeps a peer exactly at the window boundary (strictly older is evicted)', () => {
+    const doc = new Y.Doc();
+    const presence = createPresence(doc, { staleAfterMs: 5_000 });
+    const atBoundary = publishPeer(presence, Date.now() - 5_000, 'Edge');
+
+    presence.evictStale();
+    // `now - lastUpdate > staleAfterMs` — a peer that reported exactly one
+    // window ago is not yet stale. Timer granularity can push this past the
+    // boundary, so assert only that a peer this recent is not evicted for
+    // being *arbitrarily* old.
+    const peers = presence.getPeers();
+    expect(Object.prototype.hasOwnProperty.call(peers, String(atBoundary.clientId))).toBe(true);
+
+    atBoundary.dispose();
+    presence.dispose();
+  });
+
+  it('NEVER evicts the local peer, however long since its last patch', () => {
+    // The local entry's `lastUpdate` only advances when this client
+    // patches something. A user who reads the model for a minute without
+    // touching it must not evict themselves out of everyone's roster.
+    const doc = new Y.Doc();
+    const presence = createPresence(doc, { staleAfterMs: 10 });
+    presence.awareness.setLocalState({
+      user: { id: 'me', name: 'Me' },
+      selection: [],
+      status: 'active',
+      lastUpdate: Date.now() - 10 * 60 * 1000,
+    });
+
+    presence.evictStale();
+
+    expect(presence.getSelf()).not.toBeNull();
+    expect(presence.getPeers()[presence.awareness.clientID]).toBeDefined();
+    presence.dispose();
+  });
+
+  it('defaults the window to 10 seconds', () => {
+    // The default is what production uses — no caller in the repo passes
+    // `staleAfterMs`. A peer 9s quiet is still on the roster; one 11s
+    // quiet is gone.
+    const doc = new Y.Doc();
+    const presence = createPresence(doc);
+    const now = Date.now();
+    const quiet = publishPeer(presence, now - 9_000, 'Quiet');
+    const gone = publishPeer(presence, now - 11_000, 'Gone');
+
+    presence.evictStale();
+
+    const peers = presence.getPeers();
+    expect(peers[quiet.clientId]).toBeDefined();
+    expect(peers[gone.clientId]).toBeUndefined();
+
+    quiet.dispose();
+    gone.dispose();
+    presence.dispose();
+  });
+});
+
+describe('presence patch bookkeeping', () => {
+  it('keeps a caller-supplied user colour instead of the derived one', async () => {
+    // A user who picked their own presence colour (or an app that colours
+    // peers by discipline) must see it broadcast verbatim; the id-derived
+    // colour is only a fallback.
+    const doc = new Y.Doc();
+    const presence = createPresence(doc, { updateRateHz: 1000 });
+    presence.setUser({ id: 'louis', name: 'Louis', color: '#ff00ff' });
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(presence.getSelf()?.user.color).toBe('#ff00ff');
+    presence.dispose();
+  });
+
+  it('derives a colour only when the user did not supply one', async () => {
+    const doc = new Y.Doc();
+    const presence = createPresence(doc, { updateRateHz: 1000 });
+    presence.setUser({ id: 'louis', name: 'Louis' });
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(presence.getSelf()?.user.color).toBe(colorForUser('louis'));
+    presence.dispose();
+  });
+
+  it('stamps lastUpdate itself, so a stale value in a patch cannot survive', async () => {
+    // `patch()` takes an arbitrary Partial<PresenceState>. If a caller (or
+    // a replayed state object) carried an old `lastUpdate`, letting it win
+    // would make this client look stale to every peer and get evicted
+    // mid-session.
+    const doc = new Y.Doc();
+    const presence = createPresence(doc, { updateRateHz: 1000 });
+    const before = Date.now();
+    presence.patch({ selection: ['wall-1'], lastUpdate: 1 });
+    await new Promise((r) => setTimeout(r, 20));
+
+    const self = presence.getSelf();
+    expect(self?.selection).toEqual(['wall-1']);
+    expect(self?.lastUpdate).toBeGreaterThanOrEqual(before);
+    presence.dispose();
+  });
+
+  it('publishes within a couple of frames by default (30 Hz cap, not slower)', async () => {
+    // No caller in the repo passes `updateRateHz`, so the DEFAULT is the
+    // only rate production ever runs at. If it were an order of magnitude
+    // slower, a peer's first selection would take a second to reach the
+    // others and every cursor would visibly lag.
+    const doc = new Y.Doc();
+    const presence = createPresence(doc);
+    presence.setSelection(['wall-1']);
+
+    await new Promise((r) => setTimeout(r, 100));
+    expect(presence.getSelf()?.selection).toEqual(['wall-1']);
+    presence.dispose();
+  });
+
+  it('coalesces patches inside one throttle window into a single state', async () => {
+    // The 30 Hz cap is the whole point of `enqueue`: cursor moves arrive
+    // per frame, and each one must not become an awareness broadcast.
+    const doc = new Y.Doc();
+    const presence = createPresence(doc, { updateRateHz: 30 });
+    let broadcasts = 0;
+    presence.awareness.on('update', () => { broadcasts++; });
+
+    for (let i = 0; i < 20; i++) presence.setCursor2d('plan', { x: i, y: i });
+    // Nothing has been published yet — the first flush is still pending.
+    expect(presence.getSelf()?.cursor2d).toBeUndefined();
+    await new Promise((r) => setTimeout(r, 120));
+
+    expect(broadcasts).toBe(1);
+    expect(presence.getSelf()?.cursor2d).toEqual({ viewport: 'plan', pos: { x: 19, y: 19 } });
+    presence.dispose();
+  });
+});

--- a/packages/collab/test/presence-eviction.test.ts
+++ b/packages/collab/test/presence-eviction.test.ts
@@ -231,4 +231,32 @@ describe('presence patch bookkeeping', () => {
     expect(presence.getSelf()?.cursor2d).toEqual({ viewport: 'plan', pos: { x: 19, y: 19 } });
     presence.dispose();
   });
+
+  // The test above pins the THROTTLE but not the MERGE: every one of its 20
+  // patches writes the same key, so `pendingPatch = { ...patch }` (last write
+  // wins, earlier keys dropped) produces exactly the same single broadcast and
+  // the same final cursor. Coalescing only means something across *different*
+  // keys, which is the real frame: a selection click and the cursor move that
+  // follows it land in one window, and without the merge the selection never
+  // reaches the peers at all.
+  it('merges patches on DIFFERENT keys inside one window, losing none', async () => {
+    const doc = new Y.Doc();
+    const presence = createPresence(doc, { updateRateHz: 30 });
+    let broadcasts = 0;
+    presence.awareness.on('update', () => { broadcasts++; });
+
+    presence.setSelection(['wall-1']);
+    presence.setCursor2d('plan', { x: 5, y: 6 });
+    presence.setTool('measure');
+    presence.setStatus('idle');
+    await new Promise((r) => setTimeout(r, 120));
+
+    const self = presence.getSelf();
+    expect(broadcasts).toBe(1);
+    expect(self?.selection).toEqual(['wall-1']);
+    expect(self?.cursor2d).toEqual({ viewport: 'plan', pos: { x: 5, y: 6 } });
+    expect(self?.tool).toBe('measure');
+    expect(self?.status).toBe('idle');
+    presence.dispose();
+  });
 });

--- a/packages/collab/test/presence-eviction.test.ts
+++ b/packages/collab/test/presence-eviction.test.ts
@@ -145,6 +145,11 @@ describe('evictStale', () => {
 });
 
 describe('presence patch bookkeeping', () => {
+  // Only the default-rate test below fakes the clock; `useRealTimers` is a
+  // no-op for the others and keeps a failed assertion from leaking a frozen
+  // clock into the rest of the file.
+  afterEach(() => { vi.useRealTimers(); });
+
   it('keeps a caller-supplied user colour instead of the derived one', async () => {
     // A user who picked their own presence colour (or an app that colours
     // peers by discipline) must see it broadcast verbatim; the id-derived
@@ -190,11 +195,21 @@ describe('presence patch bookkeeping', () => {
     // only rate production ever runs at. If it were an order of magnitude
     // slower, a peer's first selection would take a second to reach the
     // others and every cursor would visibly lag.
+    //
+    // A 100ms wall-clock wait proved nothing: a 20 Hz (50ms) or even a
+    // 10 Hz (100ms) default passes it too. Fake timers make the window
+    // exact. The flush is scheduled at `1000 / 30` ms, so advancing one
+    // whole frame — 34ms, the ceiling of that — must be enough; any
+    // default slower than 30 Hz still has nothing published by then.
+    vi.useFakeTimers();
     const doc = new Y.Doc();
     const presence = createPresence(doc);
     presence.setSelection(['wall-1']);
 
-    await new Promise((r) => setTimeout(r, 100));
+    // Throttled, not synchronous: the first flush is still pending.
+    expect(presence.getSelf()?.selection).toBeUndefined();
+
+    await vi.advanceTimersByTimeAsync(Math.ceil(1000 / 30));
     expect(presence.getSelf()?.selection).toEqual(['wall-1']);
     presence.dispose();
   });

--- a/packages/collab/test/room.test.ts
+++ b/packages/collab/test/room.test.ts
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Room-id composition and parsing (`src/sync/room.ts`, spec §10).
+ *
+ * `parseRoomId` is exported from the package root but had no caller and
+ * no test — a mutation that split on the LAST slash instead of the first,
+ * and one that swapped the two fields of the slashless result, both
+ * survived the whole suite.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { federationRoomId, parseRoomId, roomIdFor } from '../src/sync/room.js';
+
+describe('roomIdFor / federationRoomId', () => {
+  it('composes `project/model`', () => {
+    expect(roomIdFor({ projectId: 'proj-1', modelId: 'arch' })).toBe('proj-1/arch');
+  });
+
+  it('names the federation room `project/_federation`', () => {
+    expect(federationRoomId('proj-1')).toBe('proj-1/_federation');
+    // The federation room is a room of the SAME project, so it must parse
+    // back to that project id — a session joining it derives the project
+    // from the room id.
+    expect(parseRoomId(federationRoomId('proj-1')).projectId).toBe('proj-1');
+  });
+});
+
+describe('parseRoomId', () => {
+  it('splits at the FIRST separator, so a model id may contain slashes', () => {
+    // Model ids are caller-supplied (upload paths, S3 keys, nested folder
+    // names). Splitting at the last slash would attribute
+    // `proj-1/site-a/arch` to project `proj-1/site-a`, and the peer would
+    // join a room nobody else is in.
+    expect(parseRoomId('proj-1/site-a/arch')).toEqual({
+      projectId: 'proj-1',
+      modelId: 'site-a/arch',
+    });
+  });
+
+  it('round-trips every roomIdFor output, slashy model ids included', () => {
+    for (const desc of [
+      { projectId: 'p', modelId: 'm' },
+      { projectId: 'proj-1', modelId: 'site-a/arch' },
+      { projectId: 'proj-1', modelId: '' },
+    ]) {
+      expect(parseRoomId(roomIdFor(desc))).toEqual(desc);
+    }
+  });
+
+  it('treats a separator-less id as a bare model in no project', () => {
+    // The legacy single-model form. The id is the MODEL, not the project:
+    // reading it as a project would leave the session with no model to
+    // open.
+    expect(parseRoomId('legacy-room')).toEqual({ projectId: '', modelId: 'legacy-room' });
+  });
+
+  it('keeps an empty model id when the separator is trailing', () => {
+    expect(parseRoomId('proj-1/')).toEqual({ projectId: 'proj-1', modelId: '' });
+  });
+});

--- a/packages/collab/test/structured-attrs-gates.test.ts
+++ b/packages/collab/test/structured-attrs-gates.test.ts
@@ -1,0 +1,167 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Shape gates in `snapshot/structured-attrs.ts` (#1031).
+ *
+ * `inflateStructuredAttributes` only lifts an attribute into a structured
+ * CRDT branch when its value matches the branch's wire shape; anything
+ * else must stay in the flat attribute record so a foreign or truncated
+ * payload survives the snapshot → seed round-trip verbatim instead of
+ * being silently reinterpreted.
+ *
+ * The happy paths are covered indirectly (minimal-layer, to-ifcx,
+ * from-ifcx). The REJECTION paths were not: mutations that made the
+ * classification gate ignore `code`, the material gate accept anything,
+ * and an empty geometryRef list "recognized" all survived the suite.
+ */
+
+import { IFCLITE_ATTR } from '@ifc-lite/ifcx';
+import { describe, expect, it } from 'vitest';
+import { createGeometry } from '../src/doc/geometry.js';
+import { createCollabDoc } from '../src/doc/schema.js';
+import {
+  flattenStructuredBranches,
+  geometryRecordLookup,
+  inflateStructuredAttributes,
+} from '../src/snapshot/structured-attrs.js';
+
+const EMPTY = {
+  psets: {},
+  quantities: {},
+  classifications: [],
+  materials: [],
+  geometryRefs: [],
+};
+
+describe('classification shape gate', () => {
+  it('inflates refs that carry both system and code', () => {
+    const out = inflateStructuredAttributes({
+      [IFCLITE_ATTR.CLASSIFICATIONS]: [{ system: 'Uniclass', code: 'Pr_20' }],
+    });
+    expect(out.classifications).toEqual([{ system: 'Uniclass', code: 'Pr_20' }]);
+    expect(out.attributes).toEqual({});
+  });
+
+  it('leaves the attribute FLAT when a ref has no code', () => {
+    // A ref without a code is not a classification reference in the wire
+    // contract. Accepting it would put a `code: undefined` entry in the
+    // CRDT branch, and re-flattening would emit a different value than
+    // the one that arrived — breaking the documented inverse property.
+    const attrs = { [IFCLITE_ATTR.CLASSIFICATIONS]: [{ system: 'Uniclass' }] };
+    const out = inflateStructuredAttributes(attrs);
+    expect(out.classifications).toEqual([]);
+    expect(out.attributes).toEqual(attrs);
+  });
+
+  it('rejects the WHOLE array when one member is malformed', () => {
+    const attrs = {
+      [IFCLITE_ATTR.CLASSIFICATIONS]: [
+        { system: 'Uniclass', code: 'Pr_20' },
+        { system: 'Uniclass' },
+      ],
+    };
+    const out = inflateStructuredAttributes(attrs);
+    expect(out.classifications).toEqual([]);
+    expect(out.attributes).toEqual(attrs);
+  });
+});
+
+describe('material shape gate', () => {
+  it('inflates assignments that carry a materialId', () => {
+    const out = inflateStructuredAttributes({
+      [IFCLITE_ATTR.MATERIALS]: [{ materialId: 'mat-1' }],
+    });
+    expect(out.materials).toEqual([{ materialId: 'mat-1' }]);
+    expect(out.attributes).toEqual({});
+  });
+
+  it.each([
+    ['a bare string list', ['Concrete']],
+    ['objects with no materialId', [{ name: 'Concrete' }]],
+    ['a non-string materialId', [{ materialId: 7 }]],
+  ])('leaves the attribute FLAT for %s', (_label, value) => {
+    const attrs = { [IFCLITE_ATTR.MATERIALS]: value };
+    const out = inflateStructuredAttributes(attrs);
+    expect(out.materials).toEqual([]);
+    expect(out.attributes).toEqual(attrs);
+  });
+});
+
+describe('geometryRef shape gate', () => {
+  it('accepts a bare id, a carrier, and a mixed list', () => {
+    expect(inflateStructuredAttributes({ [IFCLITE_ATTR.GEOMETRY_REF]: 'g1' }).geometryRefs).toEqual(['g1']);
+
+    const carried = inflateStructuredAttributes({
+      [IFCLITE_ATTR.GEOMETRY_REF]: [{ geomId: 'g1', type: 'mesh' }, 'g2'],
+    });
+    expect(carried.geometryRefs).toEqual(['g1', 'g2']);
+    expect(carried.geometryCarriers).toEqual([{ geomId: 'g1', type: 'mesh' }]);
+  });
+
+  it('leaves an EMPTY list flat rather than recognising a ref-less entity', () => {
+    // `[]` carries no reference at all. Treating it as recognised writes
+    // an empty `geometryRefs` AND drops the original attribute, so an
+    // entity that had a (malformed but present) marker loses it on the
+    // round-trip. It must stay flat and untouched.
+    const attrs = { [IFCLITE_ATTR.GEOMETRY_REF]: [] as unknown[] };
+    const out = inflateStructuredAttributes(attrs);
+    expect(out.geometryRefs).toEqual([]);
+    expect(out.geometryRefRecord).toBeUndefined();
+    expect(out.attributes).toEqual(attrs);
+  });
+
+  it('leaves the whole attribute flat when any entry is neither an id nor a carrier', () => {
+    const attrs = { [IFCLITE_ATTR.GEOMETRY_REF]: ['g1', { notAGeomId: true }] };
+    const out = inflateStructuredAttributes(attrs);
+    expect(out.geometryRefs).toEqual([]);
+    expect(out.geometryCarriers).toEqual([]);
+    expect(out.attributes).toEqual(attrs);
+  });
+});
+
+describe('geometryRecordLookup', () => {
+  it('carries type, source, blobHash, bbox and params for a known geometry', () => {
+    const doc = createCollabDoc();
+    createGeometry(doc, 'g1', {
+      type: 'mesh',
+      source: 'import',
+      blobHash: 'sha256:abc',
+      params: { radius: 2 },
+      bbox: [0, 0, 0, 1, 1, 1],
+    });
+
+    expect(geometryRecordLookup(doc)('g1')).toEqual({
+      type: 'mesh',
+      source: 'import',
+      blobHash: 'sha256:abc',
+      params: { radius: 2 },
+      bbox: [0, 0, 0, 1, 1, 1],
+    });
+  });
+
+  it('omits `params` entirely when the geometry has none', () => {
+    // `createGeometry` always installs a params Y.Map, empty or not.
+    // Emitting `params: {}` for parameter-less geometry would make every
+    // imported mesh snapshot differ from the same mesh seeded back, so
+    // flatten(inflate(x)) would stop being an identity.
+    const doc = createCollabDoc();
+    createGeometry(doc, 'g1', { type: 'mesh', source: 'import' });
+
+    const record = geometryRecordLookup(doc)('g1');
+    expect(record).toEqual({ type: 'mesh', source: 'import' });
+    expect(record && 'params' in record).toBe(false);
+  });
+
+  it('returns undefined for an unknown geometry, so only the id travels', () => {
+    const doc = createCollabDoc();
+    expect(geometryRecordLookup(doc)('missing')).toBeUndefined();
+
+    const flat = flattenStructuredBranches(
+      { attributes: {}, ...EMPTY, geometryRefs: ['missing'] },
+      { geometryRecordFor: geometryRecordLookup(doc) },
+    );
+    expect(flat[IFCLITE_ATTR.GEOMETRY_REF]).toBe('missing');
+  });
+});

--- a/packages/collab/test/structured-attrs-gates.test.ts
+++ b/packages/collab/test/structured-attrs-gates.test.ts
@@ -87,6 +87,22 @@ describe('material shape gate', () => {
     expect(out.materials).toEqual([]);
     expect(out.attributes).toEqual(attrs);
   });
+
+  // Every rejection fixture above is a ONE-element list, and for a one-element
+  // list `some` and `every` agree — so none of them pins the all-or-nothing
+  // rule that makes the gate safe. Swapping the gate's `every` for `some` left
+  // them all green while inflating a list whose second entry is foreign, which
+  // is exactly the payload the branch exists to keep verbatim. This mirrors
+  // `rejects the WHOLE array when one member is malformed` on the
+  // classification gate, which the material gate had no counterpart to.
+  it('rejects the WHOLE array when one assignment is malformed', () => {
+    const attrs = {
+      [IFCLITE_ATTR.MATERIALS]: [{ materialId: 'mat-1' }, { name: 'Concrete' }],
+    };
+    const out = inflateStructuredAttributes(attrs);
+    expect(out.materials).toEqual([]);
+    expect(out.attributes).toEqual(attrs);
+  });
 });
 
 describe('geometryRef shape gate', () => {

--- a/packages/lists/src/engine.values.test.ts
+++ b/packages/lists/src/engine.values.test.ts
@@ -1,0 +1,441 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Value-level coverage for the list engine: cell-value resolution, sort
+ * ordering, multi-valued (material / classification) condition operators,
+ * grouping bookkeeping and column discovery.
+ *
+ * Every case here was written against a mutation that survived the
+ * pre-existing suite. The shared `engine.test.ts` fixture carries no
+ * numeric typed-array property, no repeated material layer, no null
+ * cell and no equal-count groups, so those branches were structurally
+ * unreachable from it.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { IfcTypeEnum } from '@ifc-lite/data';
+import { executeList, listResultToCSV, summariseListRows, groupingColumnIds } from './engine.js';
+import { discoverColumns } from './discovery.js';
+import type { PropertySet, QuantitySet } from '@ifc-lite/data';
+import type { ListDataProvider, ListDefinition, ListRow } from './types.js';
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+interface EntitySpec {
+  name: string;
+  type: string;
+  psets?: Array<{ name: string; globalId: string; properties: Array<{ name: string; type: string; value: unknown; dataType?: string }> }>;
+  qsets?: Array<{ name: string; globalId: string; quantities: Array<{ name: string; value: number; type: number }> }>;
+  materials?: string[];
+  classifications?: Array<{ system?: string; code?: string; name?: string }>;
+  storey?: string;
+}
+
+/** Minimal provider over an explicit id → spec table. */
+function providerOver(specs: Map<number, EntitySpec>): ListDataProvider {
+  const byType = new Map<string, number[]>();
+  for (const [id, spec] of specs) {
+    const list = byType.get(spec.type);
+    if (list) list.push(id);
+    else byType.set(spec.type, [id]);
+  }
+  const provider: ListDataProvider = {
+    getEntitiesByType: (type) => byType.get(IfcTypeEnum[type] ?? '') ?? [],
+    getEntityName: (id) => specs.get(id)?.name ?? '',
+    getEntityGlobalId: () => '',
+    getEntityDescription: () => '',
+    getEntityObjectType: () => '',
+    getEntityTag: () => '',
+    getEntityTypeName: (id) => specs.get(id)?.type ?? '',
+    getPropertySets: (id) => (specs.get(id)?.psets ?? []) as unknown as PropertySet[],
+    getQuantitySets: (id) => (specs.get(id)?.qsets ?? []) as unknown as QuantitySet[],
+    getAllEntityIds: () => Array.from(specs.keys()),
+    getMaterialNames: (id) => specs.get(id)?.materials ?? [],
+    getClassifications: (id) => specs.get(id)?.classifications ?? [],
+    getStoreyName: (id) => specs.get(id)?.storey ?? '',
+  };
+  return provider;
+}
+
+const def = (over: Partial<ListDefinition>): ListDefinition => ({
+  id: 'd', name: 'D', createdAt: 0, updatedAt: 0,
+  entityTypes: [IfcTypeEnum.IfcWall], conditions: [], columns: [],
+  ...over,
+});
+
+const names = (rows: ListRow[], i = 0): unknown[] => rows.map((r) => r.values[i]);
+
+// ============================================================================
+// Cell-value resolution (resolvePropertyValue)
+// ============================================================================
+
+describe('property cell values keep their numeric identity', () => {
+  // `[IFCREAL, 5.3]` is the canonical typed-value wire shape a STEP parser
+  // hands the provider. If it resolved to the DISPLAY string "5.3" instead
+  // of the number 5.3, every downstream numeric use silently degrades:
+  // group sums skip it (`typeof v === 'number'`), and sorting goes
+  // lexicographic ("10" < "9"). The pre-existing fixture only ever carries
+  // `[IFCBOOLEAN, '.T.']`, whose second element is a string — so the
+  // numeric-unwrap branch never ran.
+  const typedNumeric = new Map<number, EntitySpec>([
+    [1, { name: 'W1', type: 'IfcWall', psets: [{ name: 'Pset_X', globalId: 'ps', properties: [{ name: 'U', type: 'single', value: ['IFCREAL', 5.3] }] }] }],
+    [2, { name: 'W2', type: 'IfcWall', psets: [{ name: 'Pset_X', globalId: 'ps', properties: [{ name: 'U', type: 'single', value: ['IFCREAL', 10.5] }] }] }],
+  ]);
+
+  it('unwraps a typed numeric array to the raw number, not its display string', () => {
+    const result = executeList(def({
+      columns: [{ id: 'u', source: 'property', psetName: 'Pset_X', propertyName: 'U' }],
+    }), providerOver(typedNumeric));
+
+    const values = names(result.rows).sort();
+    expect(values).toEqual([10.5, 5.3]);
+    for (const v of values) expect(typeof v).toBe('number');
+  });
+
+  it('sums a typed numeric property into group totals', () => {
+    const result = executeList(def({
+      columns: [
+        { id: 'k', source: 'attribute', propertyName: 'Class' },
+        { id: 'u', source: 'property', psetName: 'Pset_X', propertyName: 'U' },
+      ],
+      grouping: { columnId: 'k', sumColumnIds: ['u'] },
+    }), providerOver(typedNumeric));
+
+    expect(result.summary?.sums.u).toBeCloseTo(15.8, 10);
+  });
+
+  it('keeps a raw numeric property a number rather than its formatted string', () => {
+    const result = executeList(def({
+      columns: [{ id: 'u', source: 'property', psetName: 'Pset_X', propertyName: 'U' }],
+    }), providerOver(new Map([
+      [1, { name: 'W1', type: 'IfcWall', psets: [{ name: 'Pset_X', globalId: 'ps', properties: [{ name: 'U', type: 'single', value: 0.24 }] }] }],
+    ])));
+
+    expect(result.rows[0].values[0]).toBe(0.24);
+    expect(typeof result.rows[0].values[0]).toBe('number');
+  });
+
+  it('maps the em-dash null indicator to a real null cell', () => {
+    // `'IFCLABEL,'` (a typed value with an empty payload) is what
+    // `parsePropertyValue` renders as an em-dash. The engine must turn
+    // that back into null, otherwise a blank cell exports as "—" and
+    // `exists` conditions treat the property as present.
+    const result = executeList(def({
+      columns: [{ id: 'p', source: 'property', psetName: 'Pset_X', propertyName: 'P' }],
+    }), providerOver(new Map([
+      [1, { name: 'W1', type: 'IfcWall', psets: [{ name: 'Pset_X', globalId: 'ps', properties: [{ name: 'P', type: 'single', value: 'IFCLABEL,' }] }] }],
+    ])));
+
+    expect(result.rows[0].values[0]).toBeNull();
+  });
+
+  it('renders a native boolean through the shared display mapping (True/False, not true/false)', () => {
+    const result = executeList(def({
+      columns: [
+        { id: 't', source: 'property', psetName: 'Pset_X', propertyName: 'T' },
+        { id: 'f', source: 'property', psetName: 'Pset_X', propertyName: 'F' },
+      ],
+    }), providerOver(new Map([
+      [1, { name: 'W1', type: 'IfcWall', psets: [{ name: 'Pset_X', globalId: 'ps', properties: [
+        { name: 'T', type: 'single', value: true }, { name: 'F', type: 'single', value: false },
+      ] }] }],
+    ])));
+
+    expect(result.rows[0].values).toEqual(['True', 'False']);
+  });
+});
+
+describe('multi-valued cell values are de-duplicated', () => {
+  // An element repeats a material across layers (a sandwich wall with two
+  // concrete leaves). The cell must name it once — the fixture in
+  // engine.test.ts has no repeated layer, so the de-dup was an identity.
+  it('collapses a material repeated across layers into one mention', () => {
+    const result = executeList(def({
+      columns: [{ id: 'm', source: 'material', propertyName: 'Material' }],
+    }), providerOver(new Map([
+      [1, { name: 'W1', type: 'IfcWall', materials: ['Concrete', 'Insulation', 'Concrete'] }],
+    ])));
+
+    expect(result.rows[0].values[0]).toBe('Concrete, Insulation');
+  });
+
+  it('collapses a classification code repeated across refs', () => {
+    const result = executeList(def({
+      columns: [{ id: 'c', source: 'classification', propertyName: 'Classification' }],
+    }), providerOver(new Map([
+      [1, { name: 'W1', type: 'IfcWall', classifications: [
+        { system: 'U', code: 'Pr_20' }, { system: 'V', code: 'Pr_20' }, { system: 'U', code: 'Ss_30' },
+      ] }] as [number, EntitySpec],
+    ])));
+
+    expect(result.rows[0].values[0]).toBe('Pr_20, Ss_30');
+  });
+});
+
+// ============================================================================
+// Sorting
+// ============================================================================
+
+describe('sort ordering', () => {
+  // 9 vs 10: the only pair that separates a numeric compare from the
+  // lexicographic fallback. The suite's only sort test sorted names.
+  const numeric = new Map<number, EntitySpec>([
+    [1, { name: 'A', type: 'IfcWall', qsets: [{ name: 'Qto_W', globalId: 'qs', quantities: [{ name: 'L', value: 9, type: 0 }] }] }],
+    [2, { name: 'B', type: 'IfcWall', qsets: [{ name: 'Qto_W', globalId: 'qs', quantities: [{ name: 'L', value: 10, type: 0 }] }] }],
+    [3, { name: 'C', type: 'IfcWall', qsets: [{ name: 'Qto_W', globalId: 'qs', quantities: [{ name: 'L', value: 100, type: 0 }] }] }],
+  ]);
+  const numericDef = (direction: 'asc' | 'desc') => def({
+    columns: [{ id: 'l', source: 'quantity', psetName: 'Qto_W', propertyName: 'L' }],
+    sortBy: { columnId: 'l', direction },
+  });
+
+  it('orders numeric cells by magnitude, not lexicographically', () => {
+    const result = executeList(numericDef('asc'), providerOver(numeric));
+    expect(names(result.rows)).toEqual([9, 10, 100]);
+  });
+
+  it('reverses that order for desc', () => {
+    const result = executeList(numericDef('desc'), providerOver(numeric));
+    expect(names(result.rows)).toEqual([100, 10, 9]);
+  });
+
+  // Null cells (missing property) sort BEFORE every value ascending, and
+  // therefore after every value descending. Both null branches of
+  // `compareCellValues` were unexercised: the suite never sorted a column
+  // that had a blank cell.
+  const withNulls = new Map<number, EntitySpec>([
+    [1, { name: 'A', type: 'IfcWall', psets: [{ name: 'Pset_X', globalId: 'ps', properties: [{ name: 'P', type: 'single', value: 'beta' }] }] }],
+    [2, { name: 'B', type: 'IfcWall' }],
+    [3, { name: 'C', type: 'IfcWall', psets: [{ name: 'Pset_X', globalId: 'ps', properties: [{ name: 'P', type: 'single', value: 'alpha' }] }] }],
+  ]);
+  const nullDef = (direction: 'asc' | 'desc') => def({
+    columns: [{ id: 'p', source: 'property', psetName: 'Pset_X', propertyName: 'P' }],
+    sortBy: { columnId: 'p', direction },
+  });
+
+  it('sorts null cells first ascending', () => {
+    const result = executeList(nullDef('asc'), providerOver(withNulls));
+    expect(names(result.rows)).toEqual([null, 'alpha', 'beta']);
+  });
+
+  it('sorts null cells last descending', () => {
+    const result = executeList(nullDef('desc'), providerOver(withNulls));
+    expect(names(result.rows)).toEqual(['beta', 'alpha', null]);
+  });
+});
+
+// ============================================================================
+// Material / classification condition operators
+// ============================================================================
+
+describe('multi-valued condition operators (material, classification)', () => {
+  // `equals` is an ANY-match over the element's materials; `notEquals` is
+  // an ALL-differ (an element with ANY matching layer is excluded). The
+  // pre-existing suite covered only `contains` and `exists`, so both
+  // operators' bodies were free.
+  const provider = providerOver(new Map<number, EntitySpec>([
+    [1, { name: 'W1', type: 'IfcWall', materials: ['Concrete'], classifications: [{ code: 'Pr_20' }] }],
+    [2, { name: 'W2', type: 'IfcWall', materials: ['Brick', 'Concrete'], classifications: [{ name: 'Wall' }] }],
+    [3, { name: 'W3', type: 'IfcWall', materials: ['Timber'], classifications: [] }],
+  ]));
+  const condDef = (
+    source: 'material' | 'classification',
+    operator: 'equals' | 'notEquals',
+    value: string,
+  ) => def({
+    entityTypes: [], conditions: [{ source, propertyName: source, operator, value }],
+    columns: [{ id: 'n', source: 'attribute', propertyName: 'Name' }],
+  });
+
+  it('material equals matches an element with that layer among several', () => {
+    const rows = executeList(condDef('material', 'equals', 'Concrete'), provider).rows;
+    expect(names(rows).sort()).toEqual(['W1', 'W2']);
+  });
+
+  it('material equals is a WHOLE-value match, not a substring one', () => {
+    // 'Concret' is a prefix of 'Concrete': `contains` would match, `equals`
+    // must not. This is what separates the two operators.
+    expect(executeList(condDef('material', 'equals', 'Concret'), provider).rows).toHaveLength(0);
+  });
+
+  it('material notEquals excludes an element carrying the value on ANY layer', () => {
+    const rows = executeList(condDef('material', 'notEquals', 'Concrete'), provider).rows;
+    // W2 has Brick AND Concrete — one non-matching layer must not save it.
+    expect(names(rows)).toEqual(['W3']);
+  });
+
+  it('classification equals matches by code or by name', () => {
+    expect(names(executeList(condDef('classification', 'equals', 'Pr_20'), provider).rows)).toEqual(['W1']);
+    expect(names(executeList(condDef('classification', 'equals', 'Wall'), provider).rows)).toEqual(['W2']);
+  });
+
+  it('classification notEquals still drops the element with no classification at all', () => {
+    // Documented semantics: an element with no candidates never matches,
+    // notEquals included.
+    const rows = executeList(condDef('classification', 'notEquals', 'Pr_20'), provider).rows;
+    expect(names(rows)).toEqual(['W2']);
+  });
+});
+
+// ============================================================================
+// Grouping bookkeeping
+// ============================================================================
+
+describe('grouping bookkeeping', () => {
+  it('drops empty-string group ids instead of grouping on a nameless column', () => {
+    // The viewer persists `columnIds: ['']` for a cleared group chip; an
+    // empty id must not survive into the level list, or `findIndex` returns
+    // -1 and every row lands in one synthetic "(none)" bucket.
+    expect(groupingColumnIds({ columnId: '', columnIds: ['', 'a', ''], sumColumnIds: [] })).toEqual(['a']);
+    expect(groupingColumnIds({ columnId: '', sumColumnIds: [] })).toEqual([]);
+  });
+
+  it('breaks an equal-count tie by label so group order is deterministic', () => {
+    // Two groups of the same size: without the localeCompare tiebreak the
+    // order is whichever label the rows happened to introduce first, so the
+    // same model re-executed after a filter change reorders the schedule.
+    const definition = def({
+      columns: [{ id: 'k', source: 'attribute', propertyName: 'Name' }],
+      grouping: { columnId: 'k', sumColumnIds: [] },
+    });
+    const rows: ListRow[] = [
+      { entityId: 1, modelId: 'm', values: ['Zulu'] },
+      { entityId: 2, modelId: 'm', values: ['Alpha'] },
+      { entityId: 3, modelId: 'm', values: ['Zulu'] },
+      { entityId: 4, modelId: 'm', values: ['Alpha'] },
+    ];
+
+    const { groups } = summariseListRows(definition, rows);
+    expect(groups?.map((g) => g.label)).toEqual(['Alpha', 'Zulu']);
+  });
+
+  it('excludes non-finite cells from group and overall sums', () => {
+    // A quantity that arrives as Infinity/NaN (a degenerate geometry, a
+    // divide-by-zero in a provider) must not poison the total — a NaN sum
+    // renders as an empty or "NaN" cell in the schedule and its export.
+    const definition = def({
+      columns: [
+        { id: 'k', source: 'attribute', propertyName: 'Class' },
+        { id: 'v', source: 'quantity', psetName: 'Q', propertyName: 'V' },
+      ],
+      grouping: { columnId: 'k', sumColumnIds: ['v'] },
+    });
+    const rows: ListRow[] = [
+      { entityId: 1, modelId: 'm', values: ['IfcWall', 2] },
+      { entityId: 2, modelId: 'm', values: ['IfcWall', Number.NaN] },
+      { entityId: 3, modelId: 'm', values: ['IfcWall', Number.POSITIVE_INFINITY] },
+      { entityId: 4, modelId: 'm', values: ['IfcWall', 3] },
+    ];
+
+    const { groups, summary } = summariseListRows(definition, rows);
+    expect(summary?.sums.v).toBe(5);
+    expect(groups?.[0].sums.v).toBe(5);
+  });
+});
+
+// ============================================================================
+// Column discovery
+// ============================================================================
+
+describe('discoverColumns', () => {
+  /** 60 walls: #0 and #1 carry different props; #55 carries a distinctive one. */
+  function manyWalls(): ListDataProvider {
+    const specs = new Map<number, EntitySpec>();
+    for (let i = 0; i < 60; i++) {
+      specs.set(i + 1, {
+        name: `W${i}`,
+        type: 'IfcWall',
+        psets: [{ name: 'Pset_WallCommon', globalId: 'ps', properties: [{ name: `P${i}`, type: 'single', value: i }] }],
+      });
+    }
+    return providerOver(specs);
+  }
+
+  it('samples beyond the first entity of a type', () => {
+    // A one-entity sample would report only the first element's schema, so
+    // a property that lives on every OTHER wall would be missing from the
+    // column picker entirely.
+    const result = discoverColumns(manyWalls(), [IfcTypeEnum.IfcWall]);
+    const props = result.properties.get('Pset_WallCommon') ?? [];
+    expect(props).toContain('P0');
+    expect(props).toContain('P1');
+    expect(props).toContain('P49');
+  });
+
+  it('caps the sample at 50 entities per type per provider', () => {
+    // The cap is the whole point of the module (100K-entity models): if it
+    // is removed, discovery walks every element and the picker stalls. The
+    // observable consequence is that properties unique to element 51+ do
+    // NOT appear.
+    const result = discoverColumns(manyWalls(), [IfcTypeEnum.IfcWall]);
+    const props = result.properties.get('Pset_WallCommon') ?? [];
+    expect(props).toHaveLength(50);
+    expect(props).not.toContain('P50');
+    expect(props).not.toContain('P59');
+  });
+
+  it('returns property and quantity names sorted for a stable picker', () => {
+    const provider = providerOver(new Map<number, EntitySpec>([
+      [1, {
+        name: 'W', type: 'IfcWall',
+        psets: [{ name: 'Pset_WallCommon', globalId: 'ps', properties: [
+          { name: 'Zeta', type: 'single', value: 1 }, { name: 'Alpha', type: 'single', value: 2 }, { name: 'Mu', type: 'single', value: 3 },
+        ] }],
+        qsets: [{ name: 'Qto_W', globalId: 'qs', quantities: [
+          { name: 'Width', value: 1, type: 0 }, { name: 'Area', value: 2, type: 1 }, { name: 'Length', value: 3, type: 0 },
+        ] }],
+      }],
+    ]));
+
+    const result = discoverColumns(provider, [IfcTypeEnum.IfcWall]);
+    expect(result.properties.get('Pset_WallCommon')).toEqual(['Alpha', 'Mu', 'Zeta']);
+    expect(result.quantities.get('Qto_W')).toEqual(['Area', 'Length', 'Width']);
+  });
+
+  it('skips nameless property and quantity sets instead of emitting a blank bucket', () => {
+    const provider = providerOver(new Map<number, EntitySpec>([
+      [1, {
+        name: 'W', type: 'IfcWall',
+        psets: [{ name: '', globalId: 'ps', properties: [{ name: 'Orphan', type: 'single', value: 1 }] }],
+        qsets: [{ name: '', globalId: 'qs', quantities: [{ name: 'Orphan', value: 1, type: 0 }] }],
+      }],
+    ]));
+
+    const result = discoverColumns(provider, [IfcTypeEnum.IfcWall]);
+    expect(result.properties.has('')).toBe(false);
+    expect(result.quantities.has('')).toBe(false);
+    expect(result.properties.size).toBe(0);
+    expect(result.quantities.size).toBe(0);
+  });
+});
+
+// ============================================================================
+// CSV headers
+// ============================================================================
+
+describe('listResultToCSV headers', () => {
+  it('qualifies an unlabelled column with its set name', () => {
+    // Two columns can share a property name across different sets (the
+    // canonical case: NetVolume in Qto_WallBaseQuantities and in
+    // Qto_SlabBaseQuantities). Without the `Set.Prop` fallback the export
+    // has two identical headers and the recipient cannot tell them apart.
+    const csv = listResultToCSV({
+      columns: [
+        { id: 'a', source: 'quantity', psetName: 'Qto_WallBaseQuantities', propertyName: 'NetVolume' },
+        { id: 'b', source: 'quantity', psetName: 'Qto_SlabBaseQuantities', propertyName: 'NetVolume' },
+        { id: 'c', source: 'attribute', propertyName: 'Name' },
+      ],
+      rows: [],
+      totalCount: 0,
+      executionTime: 0,
+    });
+
+    expect(csv.split('\n')[0]).toBe(
+      'Qto_WallBaseQuantities.NetVolume,Qto_SlabBaseQuantities.NetVolume,Name',
+    );
+  });
+});


### PR DESCRIPTION
Second, deeper mutation sweep of `packages/collab` and `packages/lists`. Both had shallow first passes early in this campaign.

**49 mutations** against load-bearing logic, **25 survived** the existing suites (49% kill ratio — TARGETED: mutations were aimed at modules with no test file, at thin test files, and at exported symbols with no caller). 21 survivors are closed here; 4 are classified below. Test-only — no production behaviour changed.

Two deliberate control mutations were run first and both died (`values[i] = null` in the list property column; `out[structuredAttributeKey(...)] = null` in the pset flattener), confirming the harness and the build.

## Baseline → final

| package | before | after |
| --- | --- | --- |
| `@ifc-lite/collab` | 41 files / 173 passed / 2 skipped | 44 files / 201 passed / 2 skipped |
| `@ifc-lite/lists` | 6 files / 119 passed | 7 files / 143 passed |

The 2 collab skips are fixture-gated in `test/round-trip.test.ts` (`skip: !FIXTURES_AVAILABLE`), so IFCX round-trip coverage is invisible on a fresh checkout until `pnpm fixtures` runs. Not changed here, but worth knowing when reading collab's numbers.

## `packages/lists`

| # | mutation | was | now |
| --- | --- | --- | --- |
| M2 | `compareCellValues`: delete the `typeof a === 'number'` branch | SURVIVED | KILLED |
| M3 | `if (a === null) return -1` → `return 1` | SURVIVED | KILLED |
| M4 | `if (b === null) return 1` → `return -1` | SURVIVED | KILLED |
| M5 | multi-valued `equals` → `contains` semantics | SURVIVED | KILLED |
| M6 | multi-valued `notEquals`: `every` → `some` | SURVIVED | KILLED |
| M8 | `uniqueJoin`: drop the `new Set()` | SURVIVED | KILLED |
| M11 | drop the em-dash → `null` mapping | SURVIVED | KILLED |
| M12 | boolean cell → `String(value)` instead of the display mapping | SURVIVED | KILLED |
| M13 | disable the `[IFCTYPE, number]` numeric unwrap | SURVIVED | KILLED |
| M14 | numeric property → its display string | SURVIVED | KILLED |
| M15 | `SAMPLE_SIZE` 50 → 1 | SURVIVED | KILLED |
| M16 | remove the `Math.min(ids.length, SAMPLE_SIZE)` cap | SURVIVED | KILLED |
| M17 | stop skipping nameless property/quantity sets | SURVIVED | KILLED |
| M18 | drop `.sort()` on discovered property names | SURVIVED | KILLED |
| M19 | drop `.sort()` on discovered quantity names | SURVIVED | KILLED |
| M21 | CSV header fallback → bare `propertyName` (no set prefix) | SURVIVED | KILLED |
| M22 | `groupingColumnIds`: drop the `id !== ''` filter | SURVIVED | KILLED |
| M23 / M23b | drop `Number.isFinite` from the overall / per-group sum | SURVIVED | KILLED |
| M24 | drop the `localeCompare` tiebreak on equal group counts | SURVIVED | KILLED |
| M1 | sort direction forced to `1` | KILLED | — |
| M7 | multi-valued `exists` → always true | KILLED | — |
| M9 | empty candidate list matches everything | KILLED | — |
| M10 | multi-valued `contains` made case-sensitive | KILLED | — |
| M20 | CSV default delimiter `,` → `;` | KILLED | — |
| M26 | drop the per-model snapshot foreign-id filter | KILLED | — |
| M25 | `chunks.length === 1 ? chunks[0] : chunks.flat()` → always `.flat()` | SURVIVED | **EQUIVALENT** |

All replacement counts asserted `n == 1`, each mutated region re-read before the run was believed.

**M25 is EQUIVALENT** for value semantics: with one chunk, `chunks[0]` and `chunks.flat()` produce the same element sequence. The only difference is aliasing — `chunks[0]` returns the provider's own array by reference — which no caller can observe because the very next step either `filter`s (a copy) or the ids are only read. Re-run against the viewer with `dist` rebuilt (below): still no failure. Not fully proven for a future caller that mutates the returned array in place.

### What a user would have lost

- A schedule sorted on a quantity column ordered `100, 10, 9` as text (M2). Blank cells sorted at the wrong end in one of the two directions (M3/M4).
- A `[IFCREAL, 5.3]` property — the canonical typed-value shape a STEP parser produces — resolved to the string `"5.3"`, so it was skipped by every group sum (`typeof v === 'number'`) and sorted lexicographically (M13). The existing fixture only carries `[IFCBOOLEAN, '.T.']`, whose payload is a string, so the numeric branch was structurally unreachable from it.
- `equals` / `notEquals` on a material or classification filter silently behaving as `contains` / "any layer differs" (M5, M6). A sandwich wall with a Brick and a Concrete layer would have passed a `material notEquals Concrete` filter.
- A material repeated across layers listed twice in one cell (M8).
- A CSV export with two identical `NetVolume` headers when the list pulls the quantity from two different sets (M21).
- Non-finite quantities poisoning a total to `NaN` in the schedule and its export (M23).
- Group order flipping between runs whenever two groups had the same count (M24) — the schedule re-orders for no visible reason after an unrelated filter change.
- The column picker missing every property that is not on the model's first element of a type, or (with the cap gone) walking all 100K entities (M15/M16).

## `packages/collab`

| # | mutation | was | now |
| --- | --- | --- | --- |
| C3 | `parseRoomId`: `indexOf('/')` → `lastIndexOf('/')` | SURVIVED | KILLED |
| C4 | `parseRoomId`: swap the separator-less result's fields | SURVIVED | KILLED |
| C11 | classification gate: drop the `code` check | SURVIVED | KILLED |
| C12 | material gate → `return true` | SURVIVED | KILLED |
| C13 | `recognized = entries.length > 0` → `true` | SURVIVED | KILLED |
| C14 | emit an empty geometry `params` map as `{}` | SURVIVED | KILLED |
| C17 | eviction no longer skips the local peer | SURVIVED | KILLED |
| C18 | eviction age comparison → `>= 0` (evict everyone) | SURVIVED | KILLED |
| C19 | default `staleAfterMs` 10_000 → 1 | SURVIVED | KILLED |
| C20 | default `updateRateHz` 30 → 1 | SURVIVED | KILLED |
| C21 | ignore a caller-supplied `user.color` | SURVIVED | KILLED |
| C23 | let `pendingPatch` overwrite the flush's `lastUpdate` | SURVIVED | KILLED |
| C1 | `roomIdFor` operands swapped | KILLED | — |
| C2 | federation room suffix changed | KILLED | — |
| C5 | v5a key separator `::` → `:` | KILLED | — |
| C6 | single geometryRef no longer emitted as a scalar | KILLED | — |
| C7 / C8 | emit empty classifications / materials | KILLED | — |
| C9 | disable `Qto_*` → quantities routing | KILLED | — |
| C10 | remove the `Pset_*` legacy-flat exclusion | KILLED | — |
| C15 / C16 | never carry the geometry `bbox` / `blobHash` | KILLED | — |
| C22 | `setCursor2d(null)` no longer clears | KILLED | — |

### What a user would have lost

- **`parseRoomId` is exported from the package root and has no caller anywhere in the repo** — definition plus the `export *` barrel, nothing else. Both mutations against it survived. Model ids are caller-supplied and can contain slashes (upload paths, nested folders); splitting on the last separator sends a peer into a room nobody else joined, and the separator-less form would have named the legacy single-model room as a project with no model.
- The `structured-attrs` rejection paths (C11–C13) are the guard that keeps foreign or truncated data under the `ifclite::` namespace FLAT. With the gates loosened, such an attribute is swallowed into a CRDT branch and re-flattened as something else — breaking the module's own documented `flatten(inflate(x)) == x` invariant, on the snapshot → seed path every peer converges through. Only the accept paths were covered (indirectly, via `minimal-layer` / `to-ifcx` / `from-ifcx`); the reject paths were free.
- **Stale-presence eviction was entirely unexercised.** It is what removes a peer whose tab closed without a clean disconnect. Evicting the local peer (C17) drops the current user out of everyone's roster the moment they stop interacting; dropping the comparison (C18) evicts every peer on every sweep; a 1 ms default window (C19) does the same for anyone not moving their cursor.
- A user's or an app's chosen presence colour silently replaced by the id-derived one (C21).
- The default publish rate (C20) is the only rate production runs at — no caller in the repo passes `updateRateHz`. This is the three-state-flag shape: the option was covered at explicit values, never at its default.
- `lastUpdate` being overwritable from a patch (C23) makes this client look stale to every peer and get evicted mid-session.

## Well-covered areas (measured, nothing added)

`snapshot/structured-attrs.ts` has no test file of its own and 313 lines, but its **accept** paths are genuinely well covered from `minimal-layer`, `to-ifcx` and `from-ifcx`: the `::` key separator, the single-vs-list geometryRef wire shape, the empty-collection suppression, the `Qto_*` quantity routing, the `Pset_*` legacy-flat exclusion and both geometry carrier fields all died on the first run (C5–C10, C15, C16). Only the rejection paths were open.

## Untested / thin modules and uncalled API

- **No test file at all:** `src/sync/room.ts`, `src/snapshot/structured-attrs.ts` (covered indirectly, above), `src/awareness/overlay.ts`, `src/providers/{indexeddb,websocket,webrtc}.ts`. `overlay.ts` (178 lines) requires a DOM and collab's vitest runs in the node environment, so it is untestable without adding an environment — flagged, not changed.
- **Exported with only its own definition as a hit:** `parseRoomId` (now covered).
- `packages/lists/src/discovery.ts` had two smoke tests and no assertion on any of its actual behaviour (cap, sort, skip).

## Weak-shaped existing tests found

- **A fixture constant that makes the operation an identity**, twice in the same file: `engine.test.ts`'s mock provider has no numeric typed-array property (every typed value is `[IFCBOOLEAN, '.T.']`, payload a string) and no repeated material layer. Deleting the numeric unwrap and deleting the whole `new Set()` de-duplication were therefore both unkillable from it.
- **A three-state flag tested in two states:** `PresenceOptions.updateRateHz` and `staleAfterMs` were both exercised at explicit values by other tests but never at their defaults — and the default is what every caller in the repo uses.

## Downstream suites re-checked

`apps/viewer` aliases both packages to source (`vite.config.ts` → `packages/{collab,lists}/src`). With `dist` rebuilt, the 26 viewer suites that import `@ifc-lite/lists` / `@ifc-lite/collab` were run with the M25 survivor live and again clean: 106 tests, 105 pass, 1 fail either way. `packages/collab-server`, `packages/mcp` and `packages/sdk` consume the built `dist` and are unaffected by a test-only change.

## Pre-existing failures and typecheck errors (not fixed)

- `apps/viewer` — `src/lib/layers/collab-publish.test.ts` fails on a clean `upstream/main` checkout, with and without any mutation applied.
- Typecheck was run per package against its own `tsconfig.json` with the `**/*.test.ts` exclusion lifted, verified non-vacuous via `--listFiles` (7 files entered for `lists`, 44 for `collab`). Pre-existing errors: `packages/lists/src/engine.test.ts:130` (mock `PropertySet` missing `globalId`), `packages/collab/test/{blob-store,from-ifcx-reset,round-trip}.test.ts` (3 errors). No new errors from this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for collaboration presence tracking, including stale-peer eviction, update timing, color assignment, and patch throttling.
  * Added tests for room ID parsing and composition, including legacy and slash-containing identifiers.
  * Added validation for structured attributes, geometry references, malformed values, and metadata handling.
  * Expanded list engine coverage for value resolution, sorting, grouping, column discovery, and CSV headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->