### PR TITLE
test(drawing-2d,data): close 20 mutation-verified coverage gaps

### DIFF
--- a/packages/data/src/entity-table.test.ts
+++ b/packages/data/src/entity-table.test.ts
@@ -108,3 +108,91 @@ describe('entityTableToColumns / entityTableFromColumns round-trip', () => {
     expect(rebuilt.expressId.buffer).toBe(table.expressId.buffer);
   });
 });
+
+describe('EntityTable GlobalId index', () => {
+  // The sample table's entity 401 carries an EMPTY GlobalId (the IFC file
+  // omitted it, or the row is a non-rooted entity). Without the emptiness
+  // guard on the index build, '' maps to a real expressId and every BCF
+  // lookup of a missing GUID resolves to whatever entity happened to be
+  // last with a blank GlobalId.
+  it('never indexes the empty GlobalId', () => {
+    const { table } = buildSampleTable();
+    expect(table.getExpressIdByGlobalId('')).toBe(-1);
+  });
+
+  it('still indexes every non-empty GlobalId', () => {
+    const { table } = buildSampleTable();
+    expect(table.getExpressIdByGlobalId('0YvCT2_$X3_xJG3rzD8L_8')).toBe(101);
+    expect(table.getExpressIdByGlobalId('3qqCT2_$X3_xJG3rzD8L_8')).toBe(301);
+  });
+
+  it('keeps the empty GlobalId unindexed through the columns round-trip', () => {
+    const { strings, table } = buildSampleTable();
+    const rebuilt = entityTableFromColumns(entityTableToColumns(table), strings);
+    expect(rebuilt.getExpressIdByGlobalId('')).toBe(-1);
+    expect(rebuilt.getExpressIdByGlobalId('1abCT2_$X3_xJG3rzD8L_8')).toBe(102);
+  });
+});
+
+describe('EntityTable typeRanges derived from interleaved columns', () => {
+  // `entityTableFromColumns` derives typeRanges only when the caller omits
+  // them (worker-transport rebuild). IFC streams interleave types freely,
+  // and the range for a type is [firstRow, lastRow+1] — NOT the number of
+  // rows of that type, which only coincides when each type is contiguous
+  // and starts at row 0. The sample table above is fully contiguous, so it
+  // cannot tell the two apart; this fixture interleaves deliberately.
+  function interleaved() {
+    const strings = new StringTable();
+    const builder = new EntityTableBuilder(8, strings);
+    builder.add(1, 'IFCWALL', 'gid-1', 'W1', '', '', false, false); // row 0
+    builder.add(2, 'IFCSPACE', 'gid-2', 'S1', '', '', false, false); // row 1
+    builder.add(3, 'IFCWALL', 'gid-3', 'W2', '', '', false, false); // row 2
+    builder.add(4, 'IFCSPACE', 'gid-4', 'S2', '', '', false, false); // row 3
+    builder.add(5, 'IFCWALL', 'gid-5', 'W3', '', '', false, false); // row 4
+    return { strings, table: builder.build() };
+  }
+
+  it('spans first row to last row + 1 for an interleaved type', () => {
+    const { strings, table } = interleaved();
+    const columns = entityTableToColumns(table);
+    delete (columns as { typeRanges?: unknown }).typeRanges;
+    const rebuilt = entityTableFromColumns(columns, strings);
+
+    // IfcWall occupies rows 0, 2, 4 -> [0, 5); IfcSpace rows 1, 3 -> [1, 4).
+    expect(rebuilt.typeRanges.get(IfcTypeEnum.IfcWall)).toEqual({ start: 0, end: 5 });
+    expect(rebuilt.typeRanges.get(IfcTypeEnum.IfcSpace)).toEqual({ start: 1, end: 4 });
+  });
+
+  it('produces a range that contains every row of that type', () => {
+    const { strings, table } = interleaved();
+    const columns = entityTableToColumns(table);
+    delete (columns as { typeRanges?: unknown }).typeRanges;
+    const rebuilt = entityTableFromColumns(columns, strings);
+
+    for (const [type, range] of rebuilt.typeRanges) {
+      for (let row = 0; row < rebuilt.count; row++) {
+        if (rebuilt.typeEnum[row] === type) {
+          expect(row).toBeGreaterThanOrEqual(range.start);
+          expect(row).toBeLessThan(range.end);
+        }
+      }
+    }
+  });
+
+  it('prefers supplied typeRanges over the derived ones', () => {
+    const { strings, table } = interleaved();
+    const columns = entityTableToColumns(table);
+    columns.typeRanges = new Map([[IfcTypeEnum.IfcWall, { start: 7, end: 9 }]]);
+    const rebuilt = entityTableFromColumns(columns, strings);
+    expect(rebuilt.typeRanges.get(IfcTypeEnum.IfcWall)).toEqual({ start: 7, end: 9 });
+  });
+
+  it('getByType stays exact for interleaved types (index, not range, decides)', () => {
+    const { strings, table } = interleaved();
+    const columns = entityTableToColumns(table);
+    delete (columns as { typeRanges?: unknown }).typeRanges;
+    const rebuilt = entityTableFromColumns(columns, strings);
+    expect(rebuilt.getByType(IfcTypeEnum.IfcWall)).toEqual([1, 3, 5]);
+    expect(rebuilt.getByType(IfcTypeEnum.IfcSpace)).toEqual([2, 4]);
+  });
+});

--- a/packages/data/src/property-table.test.ts
+++ b/packages/data/src/property-table.test.ts
@@ -32,6 +32,26 @@ describe('PropertyTable round-trip', () => {
     expect(rebuilt.getPropertyValue(100, 'Custom', 'Length')).toBeCloseTo(3.5);
   });
 
+  it('getPropertyValue reads the NAMED pset when both carry the same property', () => {
+    // Every other fixture gives each pset distinct property names, so the
+    // `psetName[idx] === psetIdx` half of the row match is an identity on
+    // them: dropping it and matching on the property name alone survives
+    // the whole package (measured, round-four self-audit). The same-named
+    // property in two sets is the real case — Pset_WallCommon.Reference vs
+    // a vendor set's Reference — and picking the first row for the entity
+    // shows the wrong value in the property panel.
+    const strings = new StringTable();
+    const builder = new PropertyTableBuilder(strings);
+    builder.add({ entityId: 100, psetName: 'Pset_WallCommon', psetGlobalId: 'gid-1', propName: 'Reference', propType: PropertyValueType.String, value: 'WALL-STD' });
+    builder.add({ entityId: 100, psetName: 'Vendor_Custom', psetGlobalId: 'gid-2', propName: 'Reference', propType: PropertyValueType.String, value: 'VND-042' });
+    const table = builder.build();
+
+    expect(table.getPropertyValue(100, 'Pset_WallCommon', 'Reference')).toBe('WALL-STD');
+    expect(table.getPropertyValue(100, 'Vendor_Custom', 'Reference')).toBe('VND-042');
+    // A pset the entity does not carry must not fall through to either row.
+    expect(table.getPropertyValue(100, 'Pset_SlabCommon', 'Reference')).toBe(null);
+  });
+
   it('handles empty tables (lite-mode default)', () => {
     const strings = new StringTable();
     const empty = new PropertyTableBuilder(strings).build();

--- a/packages/data/src/property-table.test.ts
+++ b/packages/data/src/property-table.test.ts
@@ -157,3 +157,46 @@ describe('QuantityTable.findByQuantity', () => {
     expect(table.findByQuantity!('NetArea', '=', '12.5')).toEqual([]);
   });
 });
+
+describe('QuantityTable.getQuantityValue qset scoping', () => {
+  // The round-trip fixture above uses a single quantity set, which makes the
+  // `qsetName[idx] === qsetIdx` half of the lookup an identity: any row
+  // matching the quantity name is also in the only qset. IFC routinely puts
+  // the same quantity name (NetArea, GrossVolume, ...) in several Qto_ sets
+  // on one element, so the qset half decides which number is reported.
+  function twoQsetTable() {
+    const strings = new StringTable();
+    const builder = new QuantityTableBuilder(strings);
+    builder.add({ entityId: 100, qsetName: 'Qto_WallBaseQuantities', quantityName: 'NetArea', quantityType: QuantityType.Area, value: 5 });
+    builder.add({ entityId: 100, qsetName: 'Qto_CustomQuantities', quantityName: 'NetArea', quantityType: QuantityType.Area, value: 42 });
+    return builder.build();
+  }
+
+  it('returns the value from the NAMED quantity set, not the first row for the entity', () => {
+    const table = twoQsetTable();
+    expect(table.getQuantityValue(100, 'Qto_WallBaseQuantities', 'NetArea')).toBe(5);
+    expect(table.getQuantityValue(100, 'Qto_CustomQuantities', 'NetArea')).toBe(42);
+  });
+
+  it('returns null for a quantity set the entity does not carry', () => {
+    expect(twoQsetTable().getQuantityValue(100, 'Qto_SlabBaseQuantities', 'NetArea')).toBeNull();
+  });
+
+  it('returns null for an unknown quantity name and for an unknown entity', () => {
+    const table = twoQsetTable();
+    expect(table.getQuantityValue(100, 'Qto_WallBaseQuantities', 'NoSuchQuantity')).toBeNull();
+    expect(table.getQuantityValue(999, 'Qto_WallBaseQuantities', 'NetArea')).toBeNull();
+  });
+
+  it('getForEntity keeps the two same-named quantities in separate sets', () => {
+    const sets = twoQsetTable().getForEntity(100);
+    expect(sets.map((s) => s.name).sort()).toEqual([
+      'Qto_CustomQuantities',
+      'Qto_WallBaseQuantities',
+    ]);
+    for (const s of sets) {
+      expect(s.quantities).toHaveLength(1);
+      expect(s.quantities[0].name).toBe('NetArea');
+    }
+  });
+});

--- a/packages/data/src/relationship-graph.test.ts
+++ b/packages/data/src/relationship-graph.test.ts
@@ -84,3 +84,77 @@ describe('relationshipGraphToColumns / relationshipGraphFromColumns round-trip',
     expect(rebuilt.forward.edgeTargets.length).toBe(0);
   });
 });
+
+describe('buildCSR determinism and edge presence', () => {
+  // The sample fixture above adds edges in already-ascending source order
+  // (100, 200, 200, 400, 400), which makes the `uniqueKeys.sort()` in
+  // buildCSR an identity — and every assertion in it calls `.sort()` on the
+  // result, so CSR ordering could not be observed either way. These build
+  // the graph in DESCENDING key order and read the raw CSR columns.
+  function descendingGraph() {
+    const builder = new RelationshipGraphBuilder();
+    builder.addEdge(400, 41, RelationshipType.Aggregates, 1);
+    builder.addEdge(200, 21, RelationshipType.Aggregates, 2);
+    builder.addEdge(300, 31, RelationshipType.Aggregates, 3);
+    builder.addEdge(200, 22, RelationshipType.Aggregates, 4);
+    builder.addEdge(100, 11, RelationshipType.Aggregates, 5);
+    return builder.build();
+  }
+
+  it('lays edges out in ascending key order regardless of insertion order', () => {
+    const g = descendingGraph();
+    // Offsets must be assigned by ascending key, not by first-seen order.
+    expect([...g.forward.offsets.entries()].sort((a, b) => a[0] - b[0])).toEqual([
+      [100, 0],
+      [200, 1],
+      [300, 3],
+      [400, 4],
+    ]);
+    // ... and the scattered edge column follows that layout.
+    expect([...g.forward.edgeTargets]).toEqual([11, 21, 22, 31, 41]);
+  });
+
+  it('produces byte-identical CSR columns for two different insertion orders', () => {
+    const ascending = new RelationshipGraphBuilder();
+    ascending.addEdge(100, 11, RelationshipType.Aggregates, 5);
+    ascending.addEdge(200, 21, RelationshipType.Aggregates, 2);
+    ascending.addEdge(200, 22, RelationshipType.Aggregates, 4);
+    ascending.addEdge(300, 31, RelationshipType.Aggregates, 3);
+    ascending.addEdge(400, 41, RelationshipType.Aggregates, 1);
+    const a = ascending.build();
+    const d = descendingGraph();
+    expect([...d.forward.edgeTargets]).toEqual([...a.forward.edgeTargets]);
+    expect([...d.forward.edgeRelIds]).toEqual([...a.forward.edgeRelIds]);
+    expect([...d.forward.offsets.entries()].sort((x, y) => x[0] - y[0])).toEqual(
+      [...a.forward.offsets.entries()].sort((x, y) => x[0] - y[0]),
+    );
+  });
+
+  it('records the per-key edge count', () => {
+    const g = descendingGraph();
+    expect(g.forward.counts.get(200)).toBe(2);
+    expect(g.forward.counts.get(100)).toBe(1);
+    expect(g.forward.counts.get(999)).toBeUndefined();
+  });
+
+  it('hasAnyEdges distinguishes entities with edges from those without', () => {
+    const g = buildSampleGraph();
+    expect(g.forward.hasAnyEdges(200)).toBe(true); // storey has children
+    expect(g.forward.hasAnyEdges(301)).toBe(false); // leaf wall: no forward edges
+    expect(g.inverse.hasAnyEdges(301)).toBe(true); // ... but it has parents
+    expect(g.forward.hasAnyEdges(999)).toBe(false); // unknown entity
+  });
+
+  it('hasAnyEdges is false for every entity in an empty graph', () => {
+    const empty = new RelationshipGraphBuilder().build();
+    expect(empty.forward.hasAnyEdges(1)).toBe(false);
+    expect(empty.inverse.hasAnyEdges(1)).toBe(false);
+  });
+
+  it('getTargets returns just the target ids, filtered by type', () => {
+    const g = buildSampleGraph();
+    expect(g.forward.getTargets(200, RelationshipType.ContainsElements).sort()).toEqual([301, 302]);
+    expect(g.forward.getTargets(200, RelationshipType.Aggregates)).toEqual([]);
+    expect(g.forward.getTargets(200).sort()).toEqual([301, 302]);
+  });
+});

--- a/packages/data/src/spatial-types.test.ts
+++ b/packages/data/src/spatial-types.test.ts
@@ -1,0 +1,150 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `spatial-types.ts` had no test file. It is the single source of truth for
+ * "is this entity part of the spatial tree, and at which level" — consumed
+ * by `parser/spatial-hierarchy-builder.ts`, the viewer's hierarchy tree,
+ * `basketVisibleSet`, `visibility-adapter` and `PropertiesPanel`.
+ *
+ * A membership mistake here is silent in the worst way: an entity dropped
+ * from `SPATIAL_STRUCTURE_TYPE_ENUMS` simply stops appearing in the model
+ * tree, and a `*Name` predicate wired to the wrong set answers plausibly
+ * for the majority of inputs.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  BUILDING_LIKE_SPATIAL_TYPE_ENUMS,
+  SPACE_LIKE_SPATIAL_TYPE_ENUMS,
+  SPATIAL_STRUCTURE_TYPE_ENUMS,
+  STOREY_LIKE_SPATIAL_TYPE_ENUMS,
+  isBuildingLikeSpatialType,
+  isSpaceLikeSpatialType,
+  isSpaceLikeSpatialTypeName,
+  isSpatialStructureType,
+  isSpatialStructureTypeName,
+  isStoreyLikeSpatialType,
+  isStoreyLikeSpatialTypeName,
+} from './spatial-types.js';
+import { IfcTypeEnum } from './types.js';
+
+describe('SPATIAL_STRUCTURE_TYPE_ENUMS membership', () => {
+  it('contains every level of the IFC spatial tree', () => {
+    for (const t of [
+      IfcTypeEnum.IfcProject,
+      IfcTypeEnum.IfcSite,
+      IfcTypeEnum.IfcBuilding,
+      IfcTypeEnum.IfcBuildingStorey,
+      IfcTypeEnum.IfcSpace,
+      IfcTypeEnum.IfcSpatialZone,
+    ]) {
+      expect(isSpatialStructureType(t)).toBe(true);
+    }
+  });
+
+  it('contains the IFC4X3 infrastructure facilities and their parts', () => {
+    for (const t of [
+      IfcTypeEnum.IfcFacility,
+      IfcTypeEnum.IfcFacilityPart,
+      IfcTypeEnum.IfcBridge,
+      IfcTypeEnum.IfcBridgePart,
+      IfcTypeEnum.IfcRoad,
+      IfcTypeEnum.IfcRoadPart,
+      IfcTypeEnum.IfcRailway,
+      IfcTypeEnum.IfcRailwayPart,
+      IfcTypeEnum.IfcMarineFacility,
+    ]) {
+      expect(isSpatialStructureType(t)).toBe(true);
+    }
+  });
+
+  it('excludes ordinary products', () => {
+    for (const t of [
+      IfcTypeEnum.IfcWall,
+      IfcTypeEnum.IfcSlab,
+      IfcTypeEnum.IfcDoor,
+      IfcTypeEnum.Unknown,
+    ]) {
+      expect(isSpatialStructureType(t)).toBe(false);
+    }
+  });
+
+  it('is the union of the three level sets, plus project/site/parts', () => {
+    // Every building-like, storey-like and space-like type must also be a
+    // spatial-structure type — the sub-sets cannot drift out of the parent.
+    for (const t of [
+      ...BUILDING_LIKE_SPATIAL_TYPE_ENUMS,
+      ...STOREY_LIKE_SPATIAL_TYPE_ENUMS,
+      ...SPACE_LIKE_SPATIAL_TYPE_ENUMS,
+    ]) {
+      expect(SPATIAL_STRUCTURE_TYPE_ENUMS).toContain(t);
+    }
+  });
+});
+
+describe('level predicates are mutually exclusive', () => {
+  // Each of the three levels must answer for its own types and reject the
+  // other two; a predicate wired to a neighbouring set passes any test that
+  // only checks positives.
+  const cases: Array<[IfcTypeEnum, 'building' | 'storey' | 'space']> = [
+    [IfcTypeEnum.IfcBuilding, 'building'],
+    [IfcTypeEnum.IfcFacility, 'building'],
+    [IfcTypeEnum.IfcBridge, 'building'],
+    [IfcTypeEnum.IfcBuildingStorey, 'storey'],
+    [IfcTypeEnum.IfcSpace, 'space'],
+    [IfcTypeEnum.IfcSpatialZone, 'space'],
+  ];
+
+  for (const [type, level] of cases) {
+    it(`${IfcTypeEnum[type] ?? type} is ${level}-like and nothing else`, () => {
+      expect(isBuildingLikeSpatialType(type)).toBe(level === 'building');
+      expect(isStoreyLikeSpatialType(type)).toBe(level === 'storey');
+      expect(isSpaceLikeSpatialType(type)).toBe(level === 'space');
+    });
+  }
+
+  it('rejects a non-spatial type at every level', () => {
+    expect(isBuildingLikeSpatialType(IfcTypeEnum.IfcWall)).toBe(false);
+    expect(isStoreyLikeSpatialType(IfcTypeEnum.IfcWall)).toBe(false);
+    expect(isSpaceLikeSpatialType(IfcTypeEnum.IfcWall)).toBe(false);
+  });
+});
+
+describe('name-based predicates', () => {
+  it('agree with their enum counterparts on PascalCase IFC names', () => {
+    expect(isStoreyLikeSpatialTypeName('IfcBuildingStorey')).toBe(true);
+    expect(isSpaceLikeSpatialTypeName('IfcSpace')).toBe(true);
+    expect(isSpaceLikeSpatialTypeName('IfcSpatialZone')).toBe(true);
+    expect(isSpatialStructureTypeName('IfcBuilding')).toBe(true);
+  });
+
+  // Cross-level negatives: these are what separate `isSpaceLikeSpatialTypeName`
+  // from a delegation to the storey-like set (and vice versa).
+  it('do not answer for a neighbouring level', () => {
+    expect(isSpaceLikeSpatialTypeName('IfcBuildingStorey')).toBe(false);
+    expect(isStoreyLikeSpatialTypeName('IfcSpace')).toBe(false);
+    expect(isStoreyLikeSpatialTypeName('IfcSpatialZone')).toBe(false);
+    expect(isSpaceLikeSpatialTypeName('IfcBuilding')).toBe(false);
+  });
+
+  it('reject non-spatial and unknown names', () => {
+    expect(isSpatialStructureTypeName('IfcWall')).toBe(false);
+    expect(isStoreyLikeSpatialTypeName('NotAnIfcType')).toBe(false);
+    expect(isSpaceLikeSpatialTypeName('NotAnIfcType')).toBe(false);
+  });
+
+  it('reject null, undefined and the empty string', () => {
+    for (const bad of [null, undefined, '']) {
+      expect(isSpatialStructureTypeName(bad)).toBe(false);
+      expect(isStoreyLikeSpatialTypeName(bad)).toBe(false);
+      expect(isSpaceLikeSpatialTypeName(bad)).toBe(false);
+    }
+  });
+
+  it('are case-sensitive on the PascalCase spelling', () => {
+    // The name set is built from IfcTypeEnumToString, which emits PascalCase.
+    expect(isSpatialStructureTypeName('IFCBUILDINGSTOREY')).toBe(false);
+  });
+});

--- a/packages/data/src/spatial-types.test.ts
+++ b/packages/data/src/spatial-types.test.ts
@@ -143,8 +143,19 @@ describe('name-based predicates', () => {
     }
   });
 
-  it('are case-sensitive on the PascalCase spelling', () => {
-    // The name set is built from IfcTypeEnumToString, which emits PascalCase.
+  it('do NOT agree on case: only isSpatialStructureTypeName is case-sensitive', () => {
+    // The three name predicates are built two different ways and behave
+    // differently on a STEP-cased name, which the one-sided assertion this
+    // replaces could not show. `isSpatialStructureTypeName` matches against a
+    // Set of `IfcTypeEnumToString` output, so it is PascalCase-only;
+    // `isStoreyLike…` / `isSpaceLike…` route through `IfcTypeEnumFromString`,
+    // which upper-cases its argument and therefore accepts any casing. STEP
+    // type names are stored UPPERCASE in this codebase, so a caller handing a
+    // raw type name to all three gets inconsistent answers.
     expect(isSpatialStructureTypeName('IFCBUILDINGSTOREY')).toBe(false);
+    expect(isSpatialStructureTypeName('IFCSPACE')).toBe(false);
+    expect(isStoreyLikeSpatialTypeName('IFCBUILDINGSTOREY')).toBe(true);
+    expect(isSpaceLikeSpatialTypeName('IFCSPACE')).toBe(true);
+    expect(isSpaceLikeSpatialTypeName('ifcspace')).toBe(true);
   });
 });

--- a/packages/data/src/string-table.test.ts
+++ b/packages/data/src/string-table.test.ts
@@ -109,3 +109,29 @@ describe('StringTable', () => {
     });
   });
 });
+
+describe('StringTable.fromArray duplicate handling', () => {
+  // The comment on fromArray promises "first occurrence wins" so a duplicate
+  // (possible after manual concatenation of two tables) does not shadow the
+  // canonical index. Nothing exercised it: every fixture was duplicate-free,
+  // which makes last-wins and first-wins indistinguishable.
+  it('keeps the FIRST index for a duplicated string', () => {
+    const table = StringTable.fromArray(['', 'wall', 'slab', 'wall']);
+    expect(table.indexOf('wall')).toBe(1);
+    expect(table.get(1)).toBe('wall');
+    expect(table.get(3)).toBe('wall'); // the duplicate slot survives verbatim
+    expect(table.count).toBe(4);
+  });
+
+  it('does not re-append a duplicated string on intern', () => {
+    const table = StringTable.fromArray(['', 'wall', 'slab', 'wall']);
+    expect(table.intern('wall')).toBe(1);
+    expect(table.count).toBe(4);
+  });
+
+  it('keeps index 0 pointing at the empty sentinel even if it repeats', () => {
+    const table = StringTable.fromArray(['', 'wall', '']);
+    expect(table.indexOf('')).toBe(0);
+    expect(table.intern('')).toBe(0);
+  });
+});

--- a/packages/drawing-2d/src/line-merger.test.ts
+++ b/packages/drawing-2d/src/line-merger.test.ts
@@ -62,6 +62,30 @@ describe('mergeCollinearLines', () => {
     expect(merged).toHaveLength(2);
   });
 
+  // A truly parallel offset segment is rejected TWICE over — its start and
+  // its end are both off the reference line — so either half of the
+  // same-line test alone satisfies the case above: deleting the start-point
+  // check and replacing the end-point check with `return true` each survive
+  // it (measured, round-four self-audit). The two fixtures below are
+  // slightly convergent instead: both sit inside the same angle bucket
+  // (bucketSize = 2 * angleTolerance = 0.02 rad) as the tilted reference
+  // line, and each is on the wrong side of exactly ONE of the two checks.
+  // Fusing either would weld a nearly-parallel neighbour onto the reference
+  // line and lengthen it.
+  it('rejects a near-parallel segment whose START lies on the reference line', () => {
+    const reference = seg(0, 0, 10, 0.1); // angle 0.01 rad
+    // Start offset 0.0005 (inside distanceTolerance 0.001), end offset 0.0995.
+    const converging = seg(0, 0.0005, 10, 0.0005);
+    expect(mergeCollinearLines([reference, converging])).toHaveLength(2);
+  });
+
+  it('rejects a near-parallel segment whose END lies on the reference line', () => {
+    const reference = seg(0, 0, 10, 0.1);
+    // Mirror image: start offset 0.0995, end offset 0.0005.
+    const converging = seg(0, 0.0995, 10, 0.0995);
+    expect(mergeCollinearLines([reference, converging])).toHaveLength(2);
+  });
+
   it('keeps segments of different direction apart', () => {
     const merged = mergeCollinearLines([seg(0, 0, 1, 0), seg(0, 0, 0, 1)]);
     expect(merged).toHaveLength(2);

--- a/packages/drawing-2d/src/line-merger.test.ts
+++ b/packages/drawing-2d/src/line-merger.test.ts
@@ -1,0 +1,243 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `line-merger.ts` had no test file. `mergeDrawingLines` runs on every
+ * generated drawing (`drawing-generator.ts`), and `mergeCollinearLines`,
+ * `deduplicateLines` and `splitLineAtParams` are all published from the
+ * package barrel with no in-repo caller at all — definition plus re-export
+ * were their only two occurrences in the repository.
+ *
+ * The failure mode is quiet: a merge that is too eager fuses lines that
+ * belong to different categories (a cut line swallowing a hidden line
+ * changes its weight and dash pattern), and one that is too timid leaves
+ * the SVG/DXF full of hairline seams. Neither throws.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  deduplicateLines,
+  mergeCollinearLines,
+  mergeDrawingLines,
+  splitLineAtParams,
+} from './line-merger.js';
+import type { DrawingLine, Line2D } from './types.js';
+
+const seg = (x0: number, y0: number, x1: number, y1: number): Line2D => ({
+  start: { x: x0, y: y0 },
+  end: { x: x1, y: y1 },
+});
+
+const drawingLine = (line: Line2D, over: Partial<DrawingLine> = {}): DrawingLine => ({
+  line,
+  category: 'cut',
+  visibility: 'visible',
+  entityId: 1,
+  ifcType: 'IfcWall',
+  modelIndex: 0,
+  depth: 0,
+  ...over,
+});
+
+const lengthOf = (l: Line2D) =>
+  Math.hypot(l.end.x - l.start.x, l.end.y - l.start.y);
+
+describe('mergeCollinearLines', () => {
+  it('fuses two touching collinear segments into one', () => {
+    const merged = mergeCollinearLines([seg(0, 0, 1, 0), seg(1, 0, 2, 0)]);
+    expect(merged).toHaveLength(1);
+    expect(lengthOf(merged[0])).toBeCloseTo(2, 9);
+  });
+
+  it('fuses overlapping segments without double-counting the overlap', () => {
+    const merged = mergeCollinearLines([seg(0, 0, 3, 0), seg(1, 0, 2, 0)]);
+    expect(merged).toHaveLength(1);
+    expect(lengthOf(merged[0])).toBeCloseTo(3, 9);
+  });
+
+  it('keeps parallel segments on DIFFERENT lines apart', () => {
+    // Same direction, offset by 1 in Y — far beyond distanceTolerance.
+    const merged = mergeCollinearLines([seg(0, 0, 1, 0), seg(0, 1, 1, 1)]);
+    expect(merged).toHaveLength(2);
+  });
+
+  it('keeps segments of different direction apart', () => {
+    const merged = mergeCollinearLines([seg(0, 0, 1, 0), seg(0, 0, 0, 1)]);
+    expect(merged).toHaveLength(2);
+  });
+
+  it('returns single-element and empty inputs unchanged', () => {
+    expect(mergeCollinearLines([])).toEqual([]);
+    const one = [seg(0, 0, 1, 0)];
+    expect(mergeCollinearLines(one)).toEqual(one);
+  });
+
+  describe('gapTolerance', () => {
+    // A collinear gap SMALLER than gapTolerance is bridged; a larger one is
+    // not. Both sides are needed: with the tolerance term deleted the first
+    // case silently produces two hairline segments instead of one line.
+    it('bridges a gap strictly inside the tolerance', () => {
+      const merged = mergeCollinearLines(
+        [seg(0, 0, 1, 0), seg(1.005, 0, 2, 0)],
+        { gapTolerance: 0.01 },
+      );
+      expect(merged).toHaveLength(1);
+      expect(lengthOf(merged[0])).toBeCloseTo(2, 9);
+    });
+
+    it('does NOT bridge a gap outside the tolerance', () => {
+      const merged = mergeCollinearLines(
+        [seg(0, 0, 1, 0), seg(1.005, 0, 2, 0)],
+        { gapTolerance: 0.001 },
+      );
+      expect(merged).toHaveLength(2);
+    });
+
+    it('applies the DEFAULT gapTolerance when options are omitted entirely', () => {
+      // The default (0.01) is what production passes: `drawing-generator`
+      // calls `mergeDrawingLines(allLines)` with no options object, so the
+      // absent-argument path is the one that ships.
+      const bridged = mergeCollinearLines([seg(0, 0, 1, 0), seg(1.005, 0, 2, 0)]);
+      expect(bridged).toHaveLength(1);
+      const notBridged = mergeCollinearLines([seg(0, 0, 1, 0), seg(1.5, 0, 2, 0)]);
+      expect(notBridged).toHaveLength(2);
+    });
+  });
+});
+
+describe('mergeDrawingLines grouping', () => {
+  const a = seg(0, 0, 1, 0);
+  const b = seg(1, 0, 2, 0);
+
+  it('merges collinear lines that share entity, category and visibility', () => {
+    const merged = mergeDrawingLines([drawingLine(a), drawingLine(b)]);
+    expect(merged).toHaveLength(1);
+    expect(lengthOf(merged[0].line)).toBeCloseTo(2, 9);
+  });
+
+  it('does NOT merge across line categories', () => {
+    // A cut line and a projection line render at different weights; fusing
+    // them would relabel one of them.
+    const merged = mergeDrawingLines([
+      drawingLine(a, { category: 'cut' }),
+      drawingLine(b, { category: 'projection' }),
+    ]);
+    expect(merged).toHaveLength(2);
+    expect(merged.map((l) => l.category).sort()).toEqual(['cut', 'projection']);
+  });
+
+  it('does NOT merge across visibility states', () => {
+    // Hidden lines are dashed; merging a hidden run into a visible one
+    // would draw the occluded part solid.
+    const merged = mergeDrawingLines([
+      drawingLine(a, { visibility: 'visible' }),
+      drawingLine(b, { visibility: 'hidden' }),
+    ]);
+    expect(merged).toHaveLength(2);
+  });
+
+  it('does NOT merge across entities', () => {
+    const merged = mergeDrawingLines([
+      drawingLine(a, { entityId: 1 }),
+      drawingLine(b, { entityId: 2 }),
+    ]);
+    expect(merged).toHaveLength(2);
+  });
+
+  it('does NOT merge across federated models', () => {
+    const merged = mergeDrawingLines([
+      drawingLine(a, { modelIndex: 0 }),
+      drawingLine(b, { modelIndex: 1 }),
+    ]);
+    expect(merged).toHaveLength(2);
+  });
+
+  it('carries the group metadata onto the merged line', () => {
+    const merged = mergeDrawingLines([
+      drawingLine(a, { entityId: 42, ifcType: 'IfcSlab', category: 'hidden' }),
+      drawingLine(b, { entityId: 42, ifcType: 'IfcSlab', category: 'hidden' }),
+    ]);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].entityId).toBe(42);
+    expect(merged[0].ifcType).toBe('IfcSlab');
+    expect(merged[0].category).toBe('hidden');
+  });
+});
+
+describe('deduplicateLines', () => {
+  it('drops an exact duplicate', () => {
+    expect(deduplicateLines([seg(0, 0, 1, 1), seg(0, 0, 1, 1)])).toHaveLength(1);
+  });
+
+  // Section cutting emits the shared edge of two adjacent faces twice, once
+  // from each face and in opposite order. Without the reverse-direction
+  // match every such edge is drawn twice.
+  it('drops a duplicate written in the OPPOSITE direction', () => {
+    const kept = deduplicateLines([seg(0, 0, 1, 1), seg(1, 1, 0, 0)]);
+    expect(kept).toHaveLength(1);
+    expect(kept[0]).toEqual(seg(0, 0, 1, 1)); // first occurrence wins
+  });
+
+  it('keeps genuinely distinct lines', () => {
+    expect(deduplicateLines([seg(0, 0, 1, 1), seg(0, 0, 1, 2)])).toHaveLength(2);
+  });
+
+  it('honours the tolerance in both directions', () => {
+    const near = [seg(0, 0, 1, 1), seg(1.0005, 1.0005, 0, 0)];
+    expect(deduplicateLines(near, 0.01)).toHaveLength(1);
+    expect(deduplicateLines(near, 0.0001)).toHaveLength(2);
+  });
+
+  it('returns an empty array for empty input', () => {
+    expect(deduplicateLines([])).toEqual([]);
+  });
+});
+
+describe('splitLineAtParams', () => {
+  const line = seg(0, 0, 10, 0);
+
+  it('returns the whole line when there is nothing to split at', () => {
+    const parts = splitLineAtParams(line, []);
+    expect(parts).toHaveLength(1);
+    expect(parts[0].start).toEqual({ x: 0, y: 0 });
+    expect(parts[0].end).toEqual({ x: 10, y: 0 });
+  });
+
+  it('splits at an interior parameter and covers the line exactly', () => {
+    const parts = splitLineAtParams(line, [0.25]);
+    expect(parts).toHaveLength(2);
+    expect(parts[0].end.x).toBeCloseTo(2.5, 9);
+    expect(parts[1].start.x).toBeCloseTo(2.5, 9);
+    expect(parts.reduce((s, p) => s + lengthOf(p), 0)).toBeCloseTo(10, 9);
+  });
+
+  it('sorts unordered parameters', () => {
+    const parts = splitLineAtParams(line, [0.75, 0.25]);
+    expect(parts.map((p) => p.start.x)).toEqual([0, 2.5, 7.5]);
+  });
+
+  // Hidden-line removal feeds raw intersection parameters in here; those can
+  // fall outside [0, 1] when the occluder extends past the segment. Keeping
+  // them would emit segments that run off the end of the line.
+  it('discards parameters outside the open interval (0, 1)', () => {
+    const parts = splitLineAtParams(line, [-0.5, 0.5, 1.5]);
+    expect(parts).toHaveLength(2);
+    expect(parts[0].start.x).toBeCloseTo(0, 9);
+    expect(parts[parts.length - 1].end.x).toBeCloseTo(10, 9);
+    for (const p of parts) {
+      for (const x of [p.start.x, p.end.x]) {
+        expect(x).toBeGreaterThanOrEqual(0);
+        expect(x).toBeLessThanOrEqual(10);
+      }
+    }
+  });
+
+  it('never emits a zero-length segment for a duplicated or endpoint parameter', () => {
+    for (const params of [[0.5, 0.5], [0], [1], [0, 1]]) {
+      for (const p of splitLineAtParams(line, params)) {
+        expect(lengthOf(p)).toBeGreaterThan(0);
+      }
+    }
+  });
+});

--- a/packages/drawing-2d/src/math.test.ts
+++ b/packages/drawing-2d/src/math.test.ts
@@ -170,6 +170,15 @@ describe('polygon winding', () => {
   it('classifies winding by the sign of the signed area', () => {
     expect(isCounterClockwise(ccw)).toBe(true);
     expect(isCounterClockwise(cw)).toBe(false);
+    // A degenerate ring has zero area and no winding, so the comparison has
+    // to be strict: with `>= 0` it reads as counter-clockwise, `ensureCW`
+    // then reverses a polygon that has no orientation to fix, and the two
+    // fixtures above cannot see it (measured, round-four self-audit).
+    expect(isCounterClockwise([
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+      { x: 2, y: 0 },
+    ])).toBe(false);
   });
 
   // polygon-builder uses ensureCCW for outer rings and ensureCW for holes.

--- a/packages/drawing-2d/src/math.test.ts
+++ b/packages/drawing-2d/src/math.test.ts
@@ -1,0 +1,202 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `math.ts` had no test file. Everything the 2D drawing pipeline puts on
+ * paper goes through the plane/projection/polygon helpers below, so a wrong
+ * answer here is silent: the SVG/PDF/DXF still renders, just mirrored,
+ * rotated, or with inverted hole winding.
+ *
+ * The projection cases (`getProjectionAxes` / `projectTo2D`) were only ever
+ * pinned from `apps/viewer/src/hooks/scanSectionMath.test.ts`, i.e. from a
+ * consumer two packages downstream — publishing `@ifc-lite/drawing-2d` on
+ * its own carried no check at all. `getAxisNormal`'s `flipped: true` branch
+ * had no in-repo caller (every call site passes `false` literally) and no
+ * test anywhere.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  boundsEmpty,
+  boundsValid,
+  ensureCCW,
+  ensureCW,
+  getAxisNormal,
+  getProjectionAxes,
+  isCounterClockwise,
+  polygonSignedArea,
+  projectPointOnLine,
+  projectTo2D,
+} from './math.js';
+import type { Point2D } from './types.js';
+
+describe('getProjectionAxes', () => {
+  // The Rust `projection_outline::project` mirrors this mapping (see the
+  // JSDoc on getProjectionAxes); swapping u/v here silently transposes
+  // every elevation and plan.
+  it('maps each section axis to a distinct, ordered in-plane pair', () => {
+    expect(getProjectionAxes('x')).toEqual({ u: 'z', v: 'y' });
+    expect(getProjectionAxes('y')).toEqual({ u: 'x', v: 'z' });
+    expect(getProjectionAxes('z')).toEqual({ u: 'x', v: 'y' });
+  });
+
+  it('never maps the section axis onto itself', () => {
+    for (const axis of ['x', 'y', 'z'] as const) {
+      const { u, v } = getProjectionAxes(axis);
+      expect(u).not.toBe(axis);
+      expect(v).not.toBe(axis);
+      expect(u).not.toBe(v);
+    }
+  });
+});
+
+describe('projectTo2D', () => {
+  const p = { x: 2, y: 3, z: 5 };
+
+  it('takes (u, v) from getProjectionAxes for every axis, unflipped', () => {
+    expect(projectTo2D(p, 'x', false)).toEqual({ x: 5, y: 3 }); // (z, y)
+    expect(projectTo2D(p, 'y', false)).toEqual({ x: 2, y: 5 }); // (x, z)
+    expect(projectTo2D(p, 'z', false)).toEqual({ x: 2, y: 3 }); // (x, y)
+  });
+
+  it('mirrors ONLY the U axis when the section is flipped', () => {
+    // The V component must be untouched — the drawing is mirrored
+    // left-to-right, never turned upside down.
+    for (const axis of ['x', 'y', 'z'] as const) {
+      const straight = projectTo2D(p, axis, false);
+      const flipped = projectTo2D(p, axis, true);
+      expect(flipped.x).toBe(-straight.x);
+      expect(flipped.y).toBe(straight.y);
+    }
+  });
+
+  it('is not the identity in the flipped case (a non-zero U is required to show it)', () => {
+    // Guards the fixture itself: a point on the U=0 line would make the
+    // flip unobservable and the assertion above vacuous.
+    expect(projectTo2D(p, 'z', false).x).not.toBe(0);
+  });
+});
+
+describe('getAxisNormal', () => {
+  it('returns the positive unit axis when not flipped', () => {
+    expect(getAxisNormal('x', false)).toEqual({ x: 1, y: 0, z: 0 });
+    expect(getAxisNormal('y', false)).toEqual({ x: 0, y: 1, z: 0 });
+    expect(getAxisNormal('z', false)).toEqual({ x: 0, y: 0, z: 1 });
+  });
+
+  // Every in-repo call site passes `flipped: false` literally, so this
+  // branch is reachable only through the published API.
+  it('negates the unit axis when flipped', () => {
+    expect(getAxisNormal('x', true)).toEqual({ x: -1, y: 0, z: 0 });
+    expect(getAxisNormal('y', true)).toEqual({ x: 0, y: -1, z: 0 });
+    expect(getAxisNormal('z', true)).toEqual({ x: 0, y: 0, z: -1 });
+  });
+});
+
+describe('projectPointOnLine', () => {
+  // t is a NORMALISED parameter (0 at start, 1 at end), not a raw dot
+  // product. `line-merger.groupByLine` compares these against a distance
+  // tolerance, so an un-normalised t silently scales with line length.
+  it('returns 0 at the start and 1 at the end regardless of line length', () => {
+    const short = { start: { x: 0, y: 0 }, end: { x: 1, y: 0 } };
+    const long = { start: { x: 0, y: 0 }, end: { x: 40, y: 0 } };
+    expect(projectPointOnLine({ x: 0, y: 0 }, short)).toBeCloseTo(0, 12);
+    expect(projectPointOnLine({ x: 1, y: 0 }, short)).toBeCloseTo(1, 12);
+    expect(projectPointOnLine({ x: 0, y: 0 }, long)).toBeCloseTo(0, 12);
+    expect(projectPointOnLine({ x: 40, y: 0 }, long)).toBeCloseTo(1, 12);
+  });
+
+  it('is invariant to line length for the same fractional position', () => {
+    const short = { start: { x: 0, y: 0 }, end: { x: 2, y: 0 } };
+    const long = { start: { x: 0, y: 0 }, end: { x: 10, y: 0 } };
+    expect(projectPointOnLine({ x: 0.5, y: 7 }, short)).toBeCloseTo(0.25, 12);
+    expect(projectPointOnLine({ x: 2.5, y: 7 }, long)).toBeCloseTo(0.25, 12);
+  });
+
+  it('extrapolates past the endpoints rather than clamping', () => {
+    const line = { start: { x: 0, y: 0 }, end: { x: 4, y: 0 } };
+    expect(projectPointOnLine({ x: -2, y: 0 }, line)).toBeCloseTo(-0.5, 12);
+    expect(projectPointOnLine({ x: 6, y: 0 }, line)).toBeCloseTo(1.5, 12);
+  });
+
+  it('returns 0 for a degenerate (zero-length) line', () => {
+    const dot = { start: { x: 3, y: 3 }, end: { x: 3, y: 3 } };
+    expect(projectPointOnLine({ x: 9, y: 9 }, dot)).toBe(0);
+  });
+});
+
+describe('boundsValid', () => {
+  it('rejects the empty sentinel produced by boundsEmpty()', () => {
+    expect(boundsValid(boundsEmpty())).toBe(false);
+  });
+
+  it('accepts a well-ordered finite box, including a degenerate point box', () => {
+    expect(boundsValid({ min: { x: 0, y: 0 }, max: { x: 1, y: 1 } })).toBe(true);
+    expect(boundsValid({ min: { x: 2, y: 2 }, max: { x: 2, y: 2 } })).toBe(true);
+  });
+
+  it('rejects inverted bounds on either axis', () => {
+    expect(boundsValid({ min: { x: 1, y: 0 }, max: { x: 0, y: 1 } })).toBe(false);
+    expect(boundsValid({ min: { x: 0, y: 1 }, max: { x: 1, y: 0 } })).toBe(false);
+  });
+
+  // Ordered-but-infinite bounds pass the min<=max test, so each isFinite
+  // guard has to be exercised on its own coordinate.
+  it('rejects an infinite extent on any single coordinate', () => {
+    const finite = { min: { x: 0, y: 0 }, max: { x: 1, y: 1 } };
+    expect(boundsValid({ ...finite, min: { x: -Infinity, y: 0 } })).toBe(false);
+    expect(boundsValid({ ...finite, max: { x: Infinity, y: 1 } })).toBe(false);
+    expect(boundsValid({ ...finite, min: { x: 0, y: -Infinity } })).toBe(false);
+    expect(boundsValid({ ...finite, max: { x: 1, y: Infinity } })).toBe(false);
+  });
+});
+
+describe('polygon winding', () => {
+  // CCW unit square, and its CW reverse.
+  const ccw: Point2D[] = [
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+    { x: 1, y: 1 },
+    { x: 0, y: 1 },
+  ];
+  const cw: Point2D[] = [...ccw].reverse();
+
+  it('reports the true signed area (half the shoelace sum), not twice it', () => {
+    expect(polygonSignedArea(ccw)).toBeCloseTo(1, 12);
+    expect(polygonSignedArea(cw)).toBeCloseTo(-1, 12);
+  });
+
+  it('classifies winding by the sign of the signed area', () => {
+    expect(isCounterClockwise(ccw)).toBe(true);
+    expect(isCounterClockwise(cw)).toBe(false);
+  });
+
+  // polygon-builder uses ensureCCW for outer rings and ensureCW for holes.
+  // Swapping the two branches of ensureCW makes every hole wind the same
+  // way as its outer ring, which fills the hole in in the SVG.
+  it('ensureCCW yields counter-clockwise output from BOTH inputs', () => {
+    expect(isCounterClockwise(ensureCCW(ccw))).toBe(true);
+    expect(isCounterClockwise(ensureCCW(cw))).toBe(true);
+  });
+
+  it('ensureCW yields clockwise output from BOTH inputs', () => {
+    expect(isCounterClockwise(ensureCW(ccw))).toBe(false);
+    expect(isCounterClockwise(ensureCW(cw))).toBe(false);
+  });
+
+  it('ensureCCW and ensureCW disagree on every input', () => {
+    for (const poly of [ccw, cw]) {
+      expect(isCounterClockwise(ensureCCW(poly))).not.toBe(
+        isCounterClockwise(ensureCW(poly)),
+      );
+    }
+  });
+
+  it('leaves the input array untouched', () => {
+    const original = [...ccw];
+    ensureCW(ccw);
+    ensureCCW(ccw);
+    expect(ccw).toEqual(original);
+  });
+});

--- a/packages/drawing-2d/src/sheet/sheet-types.test.ts
+++ b/packages/drawing-2d/src/sheet/sheet-types.test.ts
@@ -22,8 +22,12 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { calculateDrawingTransform } from './sheet-types.js';
+import { calculateDrawingTransform, calculateViewportBounds } from './sheet-types.js';
 import { COMMON_SCALES } from '../styles.js';
+import type { PaperSizeDefinition } from './paper-sizes.js';
+import type { DrawingFrame } from './frame-types.js';
+import { createTitleBlock } from './title-block-types.js';
+import type { TitleBlockConfig, TitleBlockPosition } from './title-block-types.js';
 
 const scale100 = COMMON_SCALES.find((s) => s.factor === 100)!;
 
@@ -92,5 +96,116 @@ describe('calculateDrawingTransform', () => {
       scale1
     );
     expect(scaleFactor).toBeCloseTo(1000, 6);
+  });
+});
+
+/**
+ * `calculateViewportBounds` had no test at all, despite being the function
+ * that decides where drawing content lands on the sheet — `sheetSlice.ts`
+ * in the viewer calls it at five separate sites (sheet creation, paper
+ * change, frame change, title-block change, scale change).
+ *
+ * Its `right-strip` branch is additionally unreachable from every shipped
+ * preset: all four entries of `TITLE_BLOCK_PRESETS` use `bottom-right` or
+ * `bottom-full`, so only a hand-built config exercises it.
+ */
+describe('calculateViewportBounds', () => {
+  const paper: PaperSizeDefinition = {
+    id: 'TEST',
+    name: 'Test',
+    category: 'custom',
+    widthMm: 400,
+    heightMm: 300,
+    orientation: 'landscape',
+    defaultMarginMm: 10,
+  };
+
+  // Deliberately asymmetric: every margin, the binding margin and the
+  // border gap are distinct, so dropping any one term moves the result.
+  const frame: DrawingFrame = {
+    style: 'custom',
+    margins: { top: 7, right: 11, bottom: 13, left: 17, bindingMargin: 3 },
+    border: {
+      outerLineWeight: 0.7,
+      innerLineWeight: 0.35,
+      borderGap: 2,
+      showFoldMarks: false,
+      showTrimMarks: false,
+    },
+    showZoneReferences: false,
+    horizontalZones: 0,
+    verticalZones: 0,
+    zoneFontSize: 3,
+  };
+
+  const titleBlock = (
+    position: TitleBlockPosition,
+    widthMm: number,
+    heightMm: number
+  ): TitleBlockConfig => ({
+    ...createTitleBlock('standard'),
+    position,
+    widthMm,
+    heightMm,
+  });
+
+  // frameInnerLeft   = 17 + 3 + 2 = 22
+  // frameInnerRight  = 400 - 11 - 2 = 387
+  // frameInnerTop    =  7 + 2 =  9
+  // frameInnerBottom = 300 - 13 - 2 = 285
+  const INNER_LEFT = 22;
+  const INNER_RIGHT = 387;
+  const INNER_TOP = 9;
+  const INNER_BOTTOM = 285;
+  const PADDING = 5;
+
+  it('insets the origin by left margin + binding margin + border gap', () => {
+    // The binding margin is the hole-punch allowance; folding it out shifts
+    // every drawing 3mm left, straight into the punched edge.
+    const v = calculateViewportBounds(paper, frame, titleBlock('bottom-right', 180, 55));
+    expect(v.x).toBe(INNER_LEFT);
+    expect(v.y).toBe(INNER_TOP);
+  });
+
+  it('reserves title-block height (plus padding) for a bottom-right block', () => {
+    const v = calculateViewportBounds(paper, frame, titleBlock('bottom-right', 180, 55));
+    expect(v.width).toBe(INNER_RIGHT - INNER_LEFT);
+    expect(v.height).toBe(INNER_BOTTOM - INNER_TOP - 55 - PADDING);
+  });
+
+  it('reserves title-block height (plus padding) for a bottom-full block', () => {
+    const v = calculateViewportBounds(paper, frame, titleBlock('bottom-full', 0, 70));
+    expect(v.width).toBe(INNER_RIGHT - INNER_LEFT);
+    expect(v.height).toBe(INNER_BOTTOM - INNER_TOP - 70 - PADDING);
+  });
+
+  it('reserves title-block WIDTH (plus padding) for a right-strip block, leaving height full', () => {
+    const v = calculateViewportBounds(paper, frame, titleBlock('right-strip', 60, 200));
+    expect(v.width).toBe(INNER_RIGHT - INNER_LEFT - 60 - PADDING);
+    expect(v.height).toBe(INNER_BOTTOM - INNER_TOP);
+  });
+
+  it('reserves along exactly one axis per position — never both, never neither', () => {
+    const full = {
+      width: INNER_RIGHT - INNER_LEFT,
+      height: INNER_BOTTOM - INNER_TOP,
+    };
+    const bottom = calculateViewportBounds(paper, frame, titleBlock('bottom-right', 60, 55));
+    expect(bottom.width).toBe(full.width);
+    expect(bottom.height).toBeLessThan(full.height);
+
+    const strip = calculateViewportBounds(paper, frame, titleBlock('right-strip', 60, 55));
+    expect(strip.width).toBeLessThan(full.width);
+    expect(strip.height).toBe(full.height);
+  });
+
+  it('shrinks the reserved axis as the title block grows', () => {
+    const small = calculateViewportBounds(paper, frame, titleBlock('bottom-right', 180, 20));
+    const large = calculateViewportBounds(paper, frame, titleBlock('bottom-right', 180, 80));
+    expect(small.height - large.height).toBe(60);
+
+    const narrow = calculateViewportBounds(paper, frame, titleBlock('right-strip', 40, 55));
+    const wide = calculateViewportBounds(paper, frame, titleBlock('right-strip', 90, 55));
+    expect(narrow.width - wide.width).toBe(50);
   });
 });


### PR DESCRIPTION
Mutation sweep of `packages/drawing-2d` and `packages/data` — both had only shallow coverage work earlier in this campaign.

**Method.** 30 probative mutations against load-bearing logic (coordinate transforms and flips, page/viewport fitting, path construction, colour/stroke resolution, index construction and lookup, id mapping, set arithmetic, empty/single-element cases). Each was a single exact-substring replacement with the replacement count asserted at 1 and the mutated region re-read before any result was believed. Two deliberate control mutations were run first and both died. Every survivor was re-run against `parser`, `cache`, `sdk`, `query`, `lists`, `ids`, `export` and the full `apps/viewer` suite with `dist` rebuilt.

**Baseline → final.** `drawing-2d` 12 files / 153 tests → 14 / 204. `data` 10 / 81 → 11 / 117. Both suites reproduced clean before and after; no skips in either package. Test-only — no production code changed.

**Kill ratio: 12/30 (40%)**, flagged **TARGETED** (aimed at modules with no test file and at exports whose only two repo-wide occurrences were definition + barrel).

---

## Gaps closed

Each row: the surviving mutation, and the test that now kills it.

### `packages/drawing-2d/src/math.ts` — no test file existed

`math.ts` is where every number that reaches the SVG/PDF/DXF is computed. A wrong answer is silent: the drawing still renders, just mirrored, rotated, or with holes filled in.

| Mutation | Was |
|---|---|
| `getProjectionAxes('y')` → `{u:'z', v:'x'}` (transposed) | survived `drawing-2d`; caught only by `apps/viewer/src/hooks/scanSectionMath.test.ts`, two packages downstream |
| `projectTo2D`: `flipped ? -u : u` → `u` (flip deleted) | same — only the viewer noticed |
| `getAxisNormal`: `flipped ? -1 : 1` → `1` | **survived every suite in the repo.** Every in-repo call site passes the literal `false` (`section-cutter.ts:68`, `gpu-section-cutter.ts:481`, `scanSectionMath.ts:235`), so the `flipped: true` branch is reachable only through the published API and had no test anywhere |
| `ensureCW` branches swapped | survived. `polygon-builder` uses `ensureCCW` for outer rings and `ensureCW` for holes; inverted, every hole winds with its ring and fills in |
| `projectPointOnLine`: `/ lenSq` deleted | survived. `t` stops being normalised and starts scaling with line length, which `line-merger` then compares against a fixed tolerance |
| `boundsValid`: one `isFinite` guard → `true` | survived. `boundsEmpty()` fails the `min <= max` test on its own, so the isFinite guards need ordered-but-infinite bounds to show |

Closed by a new `src/math.test.ts` (21 tests): the axis mapping is pinned for all three axes plus the invariant that neither in-plane axis is the section axis; the flip is pinned as *U-only* (`flipped.x === -straight.x && flipped.y === straight.y`) for all three axes, with an explicit guard that the fixture's U is non-zero so the assertion is not vacuous; `getAxisNormal` is pinned in both flip states; `projectPointOnLine` is pinned as length-invariant; `boundsValid` gets one case per isFinite guard; and `ensureCCW`/`ensureCW` are each asserted to produce their winding *from both inputs*.

### `packages/drawing-2d/src/line-merger.ts` — no test file existed

`mergeDrawingLines` runs on every generated drawing (`drawing-generator.ts:347`). `mergeCollinearLines`, `deduplicateLines` and `splitLineAtParams` occur exactly **twice** in the repository — definition plus barrel re-export — i.e. published and never exercised.

| Mutation | User-visible effect if real |
|---|---|
| group key `modelIndex:entityId:category:visibility` → `modelIndex:entityId` | a cut line absorbs a hidden line: the occluded run is drawn solid at cut weight |
| `linesEqual` reverse-direction branch deleted | section cutting emits each shared face edge twice, once per face and in opposite order — every one is now drawn twice |
| `splitLineAtParams`: `params.filter(t => t > 0 && t < 1)` deleted | hidden-line intersection parameters outside `[0,1]` emit segments running off the end of the line |
| `next.t0 <= current.t1 + gapTolerance` → `next.t0 <= current.t1` | collinear segments separated by a sub-tolerance seam are never fused; the drawing keeps hairline breaks |

Closed by a new `src/line-merger.test.ts` (24 tests). The grouping tests assert non-merging across category, visibility, entity and `modelIndex` separately. `gapTolerance` is pinned on both sides *and* with the options argument omitted entirely — the absent-default path is what `drawing-generator` actually calls.

### `packages/drawing-2d/src/sheet/sheet-types.ts` — `calculateViewportBounds` untested

`sheetSlice.ts` calls it at five sites (sheet creation, paper change, frame change, title-block change, scale change). Its sibling `calculateDrawingTransform` was well covered; this one had nothing.

| Mutation | Was |
|---|---|
| `frame.margins.left + frame.margins.bindingMargin + borderGap` → binding margin dropped | survived. Every drawing shifts left into the hole-punch allowance |
| `right-strip`: `- titleBlock.widthMm` dropped | survived. Content runs under the title block |

Closed by 6 tests appended to `sheet/sheet-types.test.ts`, using a paper/frame fixture where every margin, the binding margin and the border gap are distinct values, so no term can be dropped without moving the result. Note the `right-strip` branch is unreachable from all four `TITLE_BLOCK_PRESETS` entries (they are all `bottom-right` or `bottom-full`) — it ships only via a hand-built config.

### `packages/data/src/spatial-types.ts` — no test file existed

The single source of truth for "is this in the spatial tree, and at which level", read by `parser/spatial-hierarchy-builder.ts`, the viewer hierarchy, `basketVisibleSet`, `visibility-adapter` and `PropertiesPanel`.

| Mutation | Was |
|---|---|
| `isSpaceLikeSpatialTypeName` delegates to `isStoreyLikeSpatialType` | survived `data` entirely, and survived every downstream suite |
| `IfcSpace` removed from `SPATIAL_STRUCTURE_TYPE_ENUMS` | survived `data`; caught only by `packages/parser` |

Closed by a new `src/spatial-types.test.ts` (16 tests). The level predicates are asserted **mutually exclusive** per type (a predicate wired to a neighbouring set passes any positives-only test), and a structural invariant pins that every building-/storey-/space-like type is also in the parent structure set, so the sub-sets cannot drift out of it.

### `packages/data/src/relationship-graph.ts`

`buildCSR`'s `uniqueKeys.sort((a,b) => a-b)` was **unkillable from the existing fixture**: edges were added in already-ascending source order (100, 200, 200, 400, 400), and every assertion called `.sort()` on the result, so CSR layout could not be observed either way. `hasAnyEdges` and `getTargets` had no test at all — replacing `hasAnyEdges` with `return true` survived.

Closed by 6 tests: a descending-insertion fixture that reads the raw `offsets`/`edgeTargets` columns, a cross-check that two insertion orders produce byte-identical CSR columns, `counts` per key, `hasAnyEdges` in forward *and* inverse direction (a leaf wall has parents but no children), and `getTargets` with and without a type filter.

### `packages/data/src/quantity-table.ts`

The existing `QuantityTable` round-trip fixture used a single quantity set, which makes the `qsetName[idx] === qsetIdx` half of `getQuantityValue` an identity — deleting it survived. IFC routinely puts the same quantity name in several `Qto_` sets on one element, so that half decides which number is reported.

Closed by 4 tests on a two-qset fixture where the same `NetArea` holds `5` and `42`.

### `packages/data/src/entity-table.ts`

| Mutation | Was |
|---|---|
| `if (gidString)` → `if (true)` when building the GlobalId index | survived. Entities with an empty GlobalId get indexed under `''`, so `getExpressIdByGlobalId('')` returns a real entity instead of `-1` — every BCF lookup of a missing GUID resolves to whatever entity was last with a blank GlobalId |
| derived `typeRanges`: `end: lastRow + 1` → `end: indices.length` | survived. The existing fixture stores each type contiguously starting at row 0, where the two expressions coincide; IFC streams interleave types freely |

Closed by 8 tests. The GlobalId ones reuse the existing fixture's entity `401` (which already carries an empty GlobalId) and re-check after the columns round-trip; the `typeRanges` ones use a deliberately interleaved fixture (wall, space, wall, space, wall) with `typeRanges` deleted from the columns to force the derive branch, plus a containment invariant and a check that supplied ranges win over derived ones.

### `packages/data/src/string-table.ts`

`fromArray` carries a comment promising "first occurrence wins" so a duplicate does not shadow the canonical index. Collapsing it to unconditional `set` survived — no fixture contained a duplicate. Closed by 3 tests.

---

## Controls

| Control | Expected | Result |
|---|---|---|
| `sheet-types.ts`: `paddingFactor = 0.95` → `0.5` | die | KILLED (`calculateDrawingTransform` suite) |
| `string-table.ts`: `indexOf` `?? -1` → `?? 0` | die | KILLED (2 tests) |

Neither control survived, so no survivor was believed on an unverified harness.

---

## Also found, not changed

- **`QuantityTable.sumByType(quantityName, elementType?)` ignores `elementType`.** The interface declares the parameter; `quantityTableFromColumns` implements it as `(quantName) => ...`. A caller passing an element-type filter silently gets the unfiltered sum — a wrong number with no error. Reported rather than fixed; the new tests assert only properties that hold either way, so they do not enshrine it.
- **`apps/viewer/src/hooks/useDrawingGeneration.projection.test.tsx` is order-dependent.** `drops a hidden class from the projection profiles` fails when the file is run alone and passes inside the full `pnpm test` run. Pre-existing on a clean checkout; not touched here.
- **`resolveObjectStyle`'s hatch deep-merge base cannot be mutated away** — dropping `...(typeDefault.hatch ?? ...)` is a `tsc` error (TS2322), so the compiler already guards it. Recorded as non-probative rather than counted as a survivor.
- **Uncalled published API** (definition + barrel re-export only, no consumer anywhere in the repo): `mergeCollinearLines`, `deduplicateLines`, `splitLineAtParams`, `boundsValid`, `parseEntityKey`, `getHiddenIfcTypes`, `LINE_PATTERN_DASH_ARRAYS`, `lookupProj4`. A further group is exported from its own module but not re-exported at all, so it is unreachable even by consumers: all of `openings/opening-utils.ts` (`getDoorOpenings`, `getWindowOpenings`, `getOpeningInfo`, `getHostEntityIds`, `getHostsWithOpenings`, `isHostElement`, `filterOutOpeningElements`) and most of `symbols/symbol-utils.ts` (`generateNorthArrow`, `generateSectionMark`, `generateLevelMark`, `generateOpeningSymbols`, `generateDoorSymbolAt`, `generateWindowSymbolAt`).

## Pre-existing typecheck errors

Typechecked against each package's own options with `**/*.test.ts` un-excluded, and confirmed via `--listFiles` that all 14 `drawing-2d` and 11 `data` test files entered the program. Pre-existing, not fixed, none from the new files:

- `drawing-2d`: 3 × TS2741 — `dxf-exporter.test.ts:18`, `svg-exporter.test.ts:16` and `:116` spread `DEFAULT_SECTION_CONFIG` into a `SectionConfig`, which is missing `plane`.
- `data`: 1 × TS2345 — `utf8-decode.test.ts:61`, spread into `TextDecoder.decode`'s 2-tuple parameter.

Root `pnpm typecheck` (34 tasks), `pnpm turbo test` for both packages, `scripts/check-test-wiring.mjs` and `scripts/check-api-surface.mjs` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for data indexing, quantity retrieval, relationship graphs, spatial classification, and string deduplication.
  * Added comprehensive validation for 2D line merging, projections, geometry winding, and viewport bounds.
  * Verified edge cases including empty values, duplicate entries, missing data, tolerance limits, resizing, and insertion-order independence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->