### PR TITLE
test(extensions,sdk): close 42 mutation-verified gaps on the capability boundary and the published SDK surface

### DIFF
--- a/packages/extensions/src/capability/catalogue.test.ts
+++ b/packages/extensions/src/capability/catalogue.test.ts
@@ -1,0 +1,119 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The capability catalogue is the public-facing list the review screen
+ * and the authoring prompt render — adding to it is a SemVer-relevant
+ * API change. Before this file `isKnownCapability` had exactly two
+ * repo-wide occurrences (its definition and the barrel re-export):
+ * published, and never called by a test. Replacing its body with
+ * `return true` left all 603 tests green, which is precisely the
+ * "unknown capability is red" story `risk.ts` leans on.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  findCatalogueEntry,
+  isKnownCapability,
+  listCapabilityCatalogue,
+} from './catalogue.js';
+import { parseCapability } from './parse.js';
+import type { Capability, CapabilityScope } from '../types.js';
+
+function cap(raw: string): Capability {
+  const r = parseCapability(raw);
+  if (!r.ok) throw new Error(`fixture "${raw}" does not parse: ${r.errors[0]?.message}`);
+  return r.value;
+}
+
+describe('listCapabilityCatalogue', () => {
+  it('returns entries and every one is well-formed', () => {
+    const entries = listCapabilityCatalogue();
+    expect(entries.length).toBeGreaterThan(0);
+    for (const e of entries) {
+      expect(typeof e.scope).toBe('string');
+      expect(e.action.length).toBeGreaterThan(0);
+      expect(e.description.length).toBeGreaterThan(0);
+      expect(['green', 'yellow', 'red']).toContain(e.baseRisk);
+      expect(typeof e.requiresTarget).toBe('boolean');
+    }
+  });
+
+  it('has no duplicate scope.action keys', () => {
+    const keys = listCapabilityCatalogue().map((e) => `${e.scope}.${e.action}`);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+});
+
+describe('isKnownCapability', () => {
+  // Measured per case, not as one "some entry matches" assertion: a
+  // single lucky row would otherwise carry the whole list.
+  it.each([
+    'model.read', 'model.mutate:Pset_*', 'model.create', 'model.delete',
+    'viewer.read', 'viewer.colorize', 'viewer.isolate', 'viewer.fly', 'viewer.section',
+    'export.create:csv', 'storage.local', 'network.fetch:example.invalid',
+    'command.invoke:ext.*', 'ui.dock', 'ui.toolbar', 'ui.contextMenu', 'ui.statusBar',
+  ])('recognises the catalogued capability "%s"', (raw) => {
+    expect(isKnownCapability(cap(raw))).toBe(true);
+  });
+
+  it.each([
+    ['model', 'destroy'],
+    ['viewer', 'mutate'],
+    ['export', 'read'],
+    ['storage', 'remote'],
+    ['network', 'listen'],
+    ['command', 'define'],
+    ['ui', 'overlay'],
+  ])('rejects the uncatalogued capability "%s.%s"', (scope, action) => {
+    expect(isKnownCapability({ raw: `${scope}.${action}`, scope: scope as CapabilityScope, action })).toBe(false);
+  });
+
+  it('does not resolve keys inherited from Object.prototype', () => {
+    // The lookup key is built from caller-controlled strings; a plain
+    // object lookup would resolve `constructor` / `toString`.
+    expect(isKnownCapability({ raw: 'model.constructor', scope: 'model', action: 'constructor' })).toBe(false);
+    expect(isKnownCapability({ raw: 'model.toString', scope: 'model', action: 'toString' })).toBe(false);
+  });
+});
+
+describe('findCatalogueEntry', () => {
+  it('returns the entry matching scope + action, ignoring the target', () => {
+    const entry = findCatalogueEntry(cap('model.mutate:Pset_WallCommon.FireRating'));
+    expect(entry).toBeDefined();
+    expect(entry?.scope).toBe('model');
+    expect(entry?.action).toBe('mutate');
+    expect(entry?.requiresTarget).toBe(true);
+  });
+
+  it('returns undefined for a capability outside the catalogue', () => {
+    expect(findCatalogueEntry({ raw: 'model.destroy', scope: 'model', action: 'destroy' })).toBeUndefined();
+  });
+
+  it('agrees with isKnownCapability on every catalogued entry', () => {
+    for (const e of listCapabilityCatalogue()) {
+      const c = { raw: `${e.scope}.${e.action}`, scope: e.scope, action: e.action };
+      expect(isKnownCapability(c)).toBe(true);
+      expect(findCatalogueEntry(c)).toBe(e);
+    }
+  });
+
+  it('marks exactly the target-taking capabilities as requiresTarget', () => {
+    const required = listCapabilityCatalogue()
+      .filter((e) => e.requiresTarget)
+      .map((e) => `${e.scope}.${e.action}`)
+      .sort();
+    expect(required).toEqual([
+      'command.invoke',
+      'export.create',
+      'model.mutate',
+      'network.fetch',
+    ]);
+  });
+
+  it('keeps model.delete and network.fetch at the red base risk', () => {
+    expect(findCatalogueEntry(cap('model.delete'))?.baseRisk).toBe('red');
+    expect(findCatalogueEntry(cap('network.fetch:example.invalid'))?.baseRisk).toBe('red');
+  });
+});

--- a/packages/extensions/src/host/sdk-version.test.ts
+++ b/packages/extensions/src/host/sdk-version.test.ts
@@ -52,6 +52,23 @@ describe('sdk-version', () => {
     expect(evaluateCompatibility('x', '>=2.0.0 <3.0.0', '3.0.0').status).toBe('outdated');
   });
 
+  // VERSION_PARSE_RE only tolerates a suffix that starts with "." or "-";
+  // junk glued straight onto a number is a typo and must fall through to
+  // `permissive` so the user is asked to confirm, rather than having a
+  // bogus range silently evaluated as if it parsed. Nothing pinned that:
+  // relaxing the suffix group from `(?:[.-].*)?` to `(?:.*)?` left the
+  // whole suite green while making "2abc" parse as 2.0.0.
+  it('does not parse a version with junk glued onto a numeric segment', () => {
+    expect(evaluateCompatibility('x', '>=2abc', '2.5.0').status).toBe('permissive');
+    expect(evaluateCompatibility('x', '>=2.0.0', '2abc').status).toBe('permissive');
+  });
+
+  it('still accepts the shorthand and prerelease forms the parser documents', () => {
+    expect(evaluateCompatibility('x', '>=2', '2.5.0').status).toBe('compatible');
+    expect(evaluateCompatibility('x', '>=2.1', '2.5.0').status).toBe('compatible');
+    expect(evaluateCompatibility('x', '>=2.1.0-rc.1', '2.5.0').status).toBe('compatible');
+  });
+
   it('findAffected returns one result per installed entry', () => {
     const results = findAffected(
       [

--- a/packages/extensions/src/manifest/contributions.test.ts
+++ b/packages/extensions/src/manifest/contributions.test.ts
@@ -1,0 +1,236 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Per-contribution-kind field requirements.
+ *
+ * The fixture suite covered exactly two contribution rules (a bad slot
+ * and a malformed `when`). Every required-field check — commands.title,
+ * keybindings.key, exporters.mimeType, statusBar.text, and the rest —
+ * could be deleted with the whole suite still green. A missing
+ * `exporters.mimeType` reaching the host means an export contribution
+ * that produces a file the browser cannot type.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { validateManifest } from './validate.js';
+
+function withContributes(contributes: unknown, entry: unknown = {}): Record<string, unknown> {
+  return {
+    manifestVersion: 1,
+    id: 'com.example.contrib',
+    name: 'Contrib',
+    description: 'Contribution fixture.',
+    version: '1.0.0',
+    engines: { ifcLiteSdk: '>=2.0.0' },
+    capabilities: ['model.read'],
+    activation: ['onStartup'],
+    contributes,
+    entry,
+  };
+}
+
+function pathsFor(contributes: unknown, entry: unknown = {}): string[] {
+  const r = validateManifest(withContributes(contributes, entry));
+  return r.ok ? [] : r.errors.map((e) => e.path);
+}
+
+const CMD = { id: 'ext.example.cmd', title: 'Run' };
+
+describe('contributes.commands', () => {
+  it('requires id and title on every command', () => {
+    const paths = pathsFor({ commands: [{ id: 'ext.example.cmd' }] });
+    expect(paths).toContain('contributes.commands[0].title');
+  });
+
+  it('rejects a blank title', () => {
+    const paths = pathsFor({ commands: [{ id: 'ext.example.cmd', title: '  ' }] });
+    expect(paths).toContain('contributes.commands[0].title');
+  });
+
+  it('rejects a non-array commands value', () => {
+    const paths = pathsFor({ commands: {} });
+    expect(paths).toContain('contributes.commands');
+  });
+
+  it('accepts a well-formed command', () => {
+    expect(validateManifest(withContributes({ commands: [CMD] })).ok).toBe(true);
+  });
+});
+
+describe('contributes.toolbar', () => {
+  it('requires command', () => {
+    const paths = pathsFor({ commands: [CMD], toolbar: [{ slot: 'toolbar.right' }] });
+    expect(paths).toContain('contributes.toolbar[0].command');
+  });
+
+  // The valid fixtures only ever use toolbar.left / toolbar.right, so
+  // dropping 'toolbar.center' from the allow-list went unnoticed.
+  it.each(['toolbar.left', 'toolbar.right', 'toolbar.center'])(
+    'accepts the documented slot "%s"',
+    (slot) => {
+      const r = validateManifest(withContributes({
+        commands: [CMD],
+        toolbar: [{ command: CMD.id, slot }],
+      }));
+      if (!r.ok) console.error(slot, r.errors);
+      expect(r.ok).toBe(true);
+    },
+  );
+
+  it('rejects an unknown toolbar slot', () => {
+    const paths = pathsFor({ commands: [CMD], toolbar: [{ command: CMD.id, slot: 'toolbar.middle' }] });
+    expect(paths).toContain('contributes.toolbar[0].slot');
+  });
+
+  it('rejects a missing slot outright', () => {
+    const paths = pathsFor({ commands: [CMD], toolbar: [{ command: CMD.id }] });
+    expect(paths).toContain('contributes.toolbar[0].slot');
+  });
+});
+
+describe('contributes.dock', () => {
+  it('requires id, title and widget', () => {
+    const paths = pathsFor({ dock: [{ slot: 'dock.left' }] });
+    expect(paths).toContain('contributes.dock[0].id');
+    expect(paths).toContain('contributes.dock[0].title');
+    expect(paths).toContain('contributes.dock[0].widget');
+  });
+
+  it.each(['dock.left', 'dock.right', 'dock.bottom'])('accepts the documented slot "%s"', (slot) => {
+    const r = validateManifest(withContributes({
+      dock: [{ id: 'panel', title: 'Panel', widget: 'ui/panel.json', slot }],
+    }));
+    if (!r.ok) console.error(slot, r.errors);
+    expect(r.ok).toBe(true);
+  });
+
+  it('rejects a toolbar slot used on a dock contribution', () => {
+    const paths = pathsFor({
+      dock: [{ id: 'panel', title: 'Panel', widget: 'ui/panel.json', slot: 'toolbar.left' }],
+    });
+    expect(paths).toContain('contributes.dock[0].slot');
+  });
+});
+
+describe('contributes.contextMenu', () => {
+  it.each(['contextMenu.entity', 'contextMenu.canvas', 'contextMenu.tree'])(
+    'accepts the documented slot "%s"',
+    (slot) => {
+      const r = validateManifest(withContributes({
+        commands: [CMD],
+        contextMenu: [{ command: CMD.id, slot }],
+      }));
+      if (!r.ok) console.error(slot, r.errors);
+      expect(r.ok).toBe(true);
+    },
+  );
+
+  it('requires command', () => {
+    const paths = pathsFor({ contextMenu: [{ slot: 'contextMenu.entity' }] });
+    expect(paths).toContain('contributes.contextMenu[0].command');
+  });
+});
+
+describe('contributes.keybindings', () => {
+  // Without `key` the host has nothing to bind — the contribution is
+  // silently inert.
+  it('requires the key stroke', () => {
+    const paths = pathsFor({ commands: [CMD], keybindings: [{ command: CMD.id }] });
+    expect(paths).toContain('contributes.keybindings[0].key');
+  });
+
+  it('requires the command', () => {
+    const paths = pathsFor({ keybindings: [{ key: 'ctrl+k' }] });
+    expect(paths).toContain('contributes.keybindings[0].command');
+  });
+
+  it('accepts a well-formed keybinding', () => {
+    const r = validateManifest(withContributes({
+      commands: [CMD],
+      keybindings: [{ command: CMD.id, key: 'ctrl+k' }],
+    }));
+    if (!r.ok) console.error(r.errors);
+    expect(r.ok).toBe(true);
+  });
+});
+
+describe('contributes.lenses', () => {
+  it.each(['id', 'name', 'evaluator'])('requires "%s"', (field) => {
+    const item: Record<string, string> = { id: 'l1', name: 'Lens', evaluator: 'src/l.js' };
+    delete item[field];
+    expect(pathsFor({ lenses: [item] })).toContain(`contributes.lenses[0].${field}`);
+  });
+});
+
+describe('contributes.exporters', () => {
+  it.each(['id', 'name', 'mimeType', 'extension', 'handler'])('requires "%s"', (field) => {
+    const item: Record<string, string> = {
+      id: 'e1', name: 'Exp', mimeType: 'text/csv', extension: 'csv', handler: 'src/e.js',
+    };
+    delete item[field];
+    expect(pathsFor({ exporters: [item] })).toContain(`contributes.exporters[0].${field}`);
+  });
+
+  it('accepts a fully-specified exporter', () => {
+    const r = validateManifest(withContributes({
+      exporters: [{ id: 'e1', name: 'Exp', mimeType: 'text/csv', extension: 'csv', handler: 'src/e.js' }],
+    }));
+    if (!r.ok) console.error(r.errors);
+    expect(r.ok).toBe(true);
+  });
+});
+
+describe('contributes.idsValidators', () => {
+  it.each(['id', 'name', 'handler'])('requires "%s"', (field) => {
+    const item: Record<string, string> = { id: 'v1', name: 'V', handler: 'src/v.js' };
+    delete item[field];
+    expect(pathsFor({ idsValidators: [item] })).toContain(`contributes.idsValidators[0].${field}`);
+  });
+});
+
+describe('contributes.statusBar', () => {
+  it.each(['id', 'text'])('requires "%s"', (field) => {
+    const item: Record<string, string> = { id: 'sb1', text: 'Ready', slot: 'statusBar.left' };
+    delete item[field];
+    expect(pathsFor({ statusBar: [item] })).toContain(`contributes.statusBar[0].${field}`);
+  });
+
+  it.each(['statusBar.left', 'statusBar.right'])('accepts the documented slot "%s"', (slot) => {
+    const r = validateManifest(withContributes({ statusBar: [{ id: 'sb1', text: 'Ready', slot }] }));
+    if (!r.ok) console.error(slot, r.errors);
+    expect(r.ok).toBe(true);
+  });
+
+  it('rejects an unknown statusBar slot', () => {
+    const paths = pathsFor({ statusBar: [{ id: 'sb1', text: 'Ready', slot: 'statusBar.middle' }] });
+    expect(paths).toContain('contributes.statusBar[0].slot');
+  });
+});
+
+describe('contributes — shape guards', () => {
+  it('rejects a non-object contributes', () => {
+    const paths = pathsFor(['nope']);
+    expect(paths).toContain('contributes');
+  });
+
+  it('rejects a non-object array item', () => {
+    const paths = pathsFor({ commands: ['nope'] });
+    expect(paths).toContain('contributes.commands[0]');
+  });
+
+  it('rejects a non-string when clause', () => {
+    const paths = pathsFor({ commands: [CMD], toolbar: [{ command: CMD.id, slot: 'toolbar.left', when: 3 }] });
+    expect(paths).toContain('contributes.toolbar[0].when');
+  });
+
+  it('accepts a well-formed when clause', () => {
+    const r = validateManifest(withContributes({
+      commands: [CMD],
+      toolbar: [{ command: CMD.id, slot: 'toolbar.left', when: 'model.loaded' }],
+    }));
+    if (!r.ok) console.error(r.errors);
+    expect(r.ok).toBe(true);
+  });
+});

--- a/packages/extensions/src/manifest/cross-ref.test.ts
+++ b/packages/extensions/src/manifest/cross-ref.test.ts
@@ -1,0 +1,111 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Command cross-reference coverage.
+ *
+ * Only the *negative* direction was pinned before (a toolbar entry
+ * pointing at a command nobody declares). Both positive directions were
+ * unpinned: deleting the `entry.commands` branch, or dropping the
+ * `if (sb.command)` guard on statusBar entries, left the whole suite
+ * green while turning valid manifests into rejected ones.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { validateManifest } from './validate.js';
+
+function base(contributes: unknown, entry: unknown): Record<string, unknown> {
+  return {
+    manifestVersion: 1,
+    id: 'com.example.xref',
+    name: 'XRef',
+    description: 'Cross-reference fixture.',
+    version: '1.0.0',
+    engines: { ifcLiteSdk: '>=2.0.0' },
+    capabilities: ['model.read'],
+    activation: ['onStartup'],
+    contributes,
+    entry,
+  };
+}
+
+describe('crossReferenceCommands — declaration sources', () => {
+  it('accepts a reference satisfied by contributes.commands', () => {
+    const r = validateManifest(base(
+      {
+        commands: [{ id: 'ext.example.cmd', title: 'Run' }],
+        toolbar: [{ command: 'ext.example.cmd', slot: 'toolbar.right' }],
+      },
+      {},
+    ));
+    if (!r.ok) console.error(r.errors);
+    expect(r.ok).toBe(true);
+  });
+
+  // The `entry.commands` branch is a second, independent declaration
+  // source: a manifest may point a toolbar button at a command whose
+  // only declaration is the id → script-path map under `entry`.
+  it('accepts a reference satisfied only by entry.commands', () => {
+    const r = validateManifest(base(
+      { toolbar: [{ command: 'ext.example.only-entry', slot: 'toolbar.right' }] },
+      { commands: { 'ext.example.only-entry': 'src/cmd.js' } },
+    ));
+    if (!r.ok) console.error(r.errors);
+    expect(r.ok).toBe(true);
+  });
+
+  it('still rejects a reference declared in neither place', () => {
+    const r = validateManifest(base(
+      { toolbar: [{ command: 'ext.example.ghost', slot: 'toolbar.right' }] },
+      { commands: { 'ext.example.other': 'src/cmd.js' } },
+    ));
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.errors.some((e) => e.code === 'invalid_reference')).toBe(true);
+    }
+  });
+});
+
+describe('crossReferenceCommands — every referencing contribution kind', () => {
+  it.each([
+    ['toolbar', { command: 'ext.example.ghost', slot: 'toolbar.right' }],
+    ['contextMenu', { command: 'ext.example.ghost', slot: 'contextMenu.entity' }],
+    ['keybindings', { command: 'ext.example.ghost', key: 'ctrl+k' }],
+    ['statusBar', { id: 'sb1', text: 'Hi', slot: 'statusBar.left', command: 'ext.example.ghost' }],
+  ])('flags a dangling command referenced from contributes.%s', (kind, item) => {
+    const r = validateManifest(base({ [kind]: [item] }, {}));
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.errors.some(
+        (e) => e.code === 'invalid_reference' && e.path === `contributes.${kind}`,
+      )).toBe(true);
+    }
+  });
+});
+
+describe('crossReferenceCommands — optional statusBar command', () => {
+  // `command` is optional on a statusBar item (a plain text indicator).
+  // Dropping the `if (sb.command)` guard would push `undefined` into the
+  // reference list and reject this perfectly valid manifest.
+  it('accepts a statusBar item with no command at all', () => {
+    const r = validateManifest(base(
+      { statusBar: [{ id: 'sb1', text: 'Ready', slot: 'statusBar.left' }] },
+      {},
+    ));
+    if (!r.ok) console.error(r.errors);
+    expect(r.ok).toBe(true);
+  });
+
+  it('accepts a statusBar item whose command is declared', () => {
+    const r = validateManifest(base(
+      {
+        commands: [{ id: 'ext.example.cmd', title: 'Run' }],
+        statusBar: [{ id: 'sb1', text: 'Ready', slot: 'statusBar.left', command: 'ext.example.cmd' }],
+      },
+      {},
+    ));
+    if (!r.ok) console.error(r.errors);
+    expect(r.ok).toBe(true);
+  });
+});

--- a/packages/extensions/src/manifest/validate.test.ts
+++ b/packages/extensions/src/manifest/validate.test.ts
@@ -1,0 +1,241 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Direct unit coverage for `validateManifest` and the primitives it
+ * builds on.
+ *
+ * The pre-existing `manifest.test.ts` drives the validator through
+ * fixture files and asserts only `result.ok`. That shape is satisfied by
+ * *any* error, so it pins almost none of the individual field rules:
+ * mutation testing showed the id-casing rule, the engine-range rule, the
+ * blank-string rule, the `l10n` / `tests` / `author` / `entry` type rules
+ * and both `optionalString` call sites could all be disabled with the
+ * whole suite still green. Each test below asserts a specific error
+ * `code` at a specific `path`, so it fails when its own rule goes away.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { validateManifest } from './validate.js';
+import type { ValidationError } from '../types.js';
+
+/** Smallest manifest the validator accepts; spread + override per test. */
+function baseManifest(): Record<string, unknown> {
+  return {
+    manifestVersion: 1,
+    id: 'com.example.base',
+    name: 'Base',
+    description: 'A base manifest.',
+    version: '1.0.0',
+    engines: { ifcLiteSdk: '>=2.0.0' },
+    capabilities: ['model.read'],
+    activation: ['onStartup'],
+    entry: {},
+  };
+}
+
+function errorsOf(input: unknown): ValidationError[] {
+  const r = validateManifest(input);
+  return r.ok ? [] : r.errors;
+}
+
+function hasError(input: unknown, path: string, code: string): boolean {
+  return errorsOf(input).some((e) => e.path === path && e.code === code);
+}
+
+describe('validateManifest — the baseline really is valid', () => {
+  it('accepts the base manifest used by every test below', () => {
+    const r = validateManifest(baseManifest());
+    if (!r.ok) console.error(r.errors);
+    expect(r.ok).toBe(true);
+  });
+});
+
+describe('validateManifest — id', () => {
+  // The ID_RE comment states the canonical id is lowercase and that an
+  // earlier `/i` flag was a bug. The only invalid-id fixture contains
+  // spaces, so it is rejected either way — nothing pinned the casing
+  // rule until now.
+  it('rejects an id with uppercase letters, which the fixtures never covered', () => {
+    expect(hasError({ ...baseManifest(), id: 'com.Example.Widget' }, 'id', 'invalid_id')).toBe(true);
+  });
+
+  it('accepts lowercase reverse-DNS ids with hyphens and underscores', () => {
+    expect(validateManifest({ ...baseManifest(), id: 'com.example.fire-rating_v2' }).ok).toBe(true);
+  });
+
+  it('rejects an id with a leading separator', () => {
+    expect(hasError({ ...baseManifest(), id: '.com.example' }, 'id', 'invalid_id')).toBe(true);
+  });
+});
+
+describe('validateManifest — version', () => {
+  it('rejects a two-segment version', () => {
+    expect(hasError({ ...baseManifest(), version: '1.0' }, 'version', 'invalid_semver')).toBe(true);
+  });
+
+  it('accepts a prerelease + build version', () => {
+    expect(validateManifest({ ...baseManifest(), version: '1.2.3-rc.1+build.5' }).ok).toBe(true);
+  });
+});
+
+describe('validateManifest — engines', () => {
+  it('rejects a range string that is only whitespace', () => {
+    const input = { ...baseManifest(), engines: { ifcLiteSdk: '   ' } };
+    expect(hasError(input, 'engines.ifcLiteSdk', 'required')).toBe(true);
+  });
+
+  // ENGINE_RANGE_RE is the only thing standing between a typo'd range
+  // and the host loader's SemVer comparison, and no fixture exercised it.
+  it('rejects a range containing characters no SemVer range can contain', () => {
+    const input = { ...baseManifest(), engines: { ifcLiteSdk: 'latest' } };
+    expect(hasError(input, 'engines.ifcLiteSdk', 'invalid_engine_range')).toBe(true);
+  });
+
+  it('accepts the documented range forms', () => {
+    for (const range of ['>=2.4.0 <3.0.0', '^2.4.0', '2.x', '~2.4']) {
+      const r = validateManifest({ ...baseManifest(), engines: { ifcLiteSdk: range } });
+      if (!r.ok) console.error(range, r.errors);
+      expect(r.ok).toBe(true);
+    }
+  });
+});
+
+describe('validateManifest — required strings must not be blank', () => {
+  // `requireString`'s trim() check: without it a manifest whose name is
+  // "   " validates and installs with an invisible display name.
+  it.each(['name', 'description', 'id', 'version'])(
+    'rejects a whitespace-only "%s"',
+    (field) => {
+      const input = { ...baseManifest(), [field]: '   ' };
+      const codes = errorsOf(input).filter((e) => e.path === field).map((e) => e.code);
+      expect(codes).toContain('invalid_value');
+    },
+  );
+
+  it('reports type_mismatch (not invalid_value) for a non-string name', () => {
+    expect(hasError({ ...baseManifest(), name: 42 }, 'name', 'type_mismatch')).toBe(true);
+  });
+});
+
+describe('validateManifest — optional strings', () => {
+  // Both `optionalString` call sites (license, readme) were unpinned.
+  it.each(['license', 'readme'])('rejects a non-string "%s"', (field) => {
+    expect(hasError({ ...baseManifest(), [field]: 7 }, field, 'type_mismatch')).toBe(true);
+  });
+
+  it.each(['license', 'readme'])('accepts an absent "%s"', (field) => {
+    const input = baseManifest();
+    delete input[field];
+    expect(validateManifest(input).ok).toBe(true);
+  });
+});
+
+describe('validateManifest — author', () => {
+  it('rejects a non-object author', () => {
+    expect(hasError({ ...baseManifest(), author: 'Jane' }, 'author', 'type_mismatch')).toBe(true);
+  });
+
+  it('requires a non-blank author.name', () => {
+    const input = { ...baseManifest(), author: { name: '  ' } };
+    expect(hasError(input, 'author.name', 'required')).toBe(true);
+  });
+
+  it('rejects a non-string author.url', () => {
+    const input = { ...baseManifest(), author: { name: 'Jane', url: 42 } };
+    expect(hasError(input, 'author.url', 'type_mismatch')).toBe(true);
+  });
+
+  it('rejects a non-string author.email', () => {
+    const input = { ...baseManifest(), author: { name: 'Jane', email: [] } };
+    expect(hasError(input, 'author.email', 'type_mismatch')).toBe(true);
+  });
+
+  it('accepts a fully-populated author', () => {
+    const input = {
+      ...baseManifest(),
+      author: { name: 'Jane', url: 'https://example.invalid', email: 'jane@example.invalid' },
+    };
+    expect(validateManifest(input).ok).toBe(true);
+  });
+});
+
+describe('validateManifest — entry', () => {
+  it('rejects a non-string entry.activate', () => {
+    const input = { ...baseManifest(), entry: { activate: 42 } };
+    expect(hasError(input, 'entry.activate', 'type_mismatch')).toBe(true);
+  });
+
+  it('rejects a non-string entry.deactivate', () => {
+    const input = { ...baseManifest(), entry: { deactivate: {} } };
+    expect(hasError(input, 'entry.deactivate', 'type_mismatch')).toBe(true);
+  });
+
+  it('rejects a non-object entry.commands map', () => {
+    const input = { ...baseManifest(), entry: { commands: ['a'] } };
+    expect(hasError(input, 'entry.commands', 'type_mismatch')).toBe(true);
+  });
+
+  it('rejects a non-string value inside entry.triggers', () => {
+    const input = { ...baseManifest(), entry: { triggers: { 'ext.a': 3 } } };
+    expect(hasError(input, 'entry.triggers.ext.a', 'type_mismatch')).toBe(true);
+  });
+});
+
+describe('validateManifest — tests', () => {
+  it('rejects a blank test name / command / fixture', () => {
+    const input = {
+      ...baseManifest(),
+      tests: [{ name: ' ', command: '', fixture: '  ', expect: {} }],
+    };
+    const paths = errorsOf(input).map((e) => e.path);
+    expect(paths).toContain('tests[0].name');
+    expect(paths).toContain('tests[0].command');
+    expect(paths).toContain('tests[0].fixture');
+  });
+
+  it('requires test.expect to be an object', () => {
+    const input = {
+      ...baseManifest(),
+      tests: [{ name: 'n', command: 'c', fixture: 'f' }],
+    };
+    expect(hasError(input, 'tests[0].expect', 'required')).toBe(true);
+  });
+
+  it('accepts a well-formed test entry', () => {
+    const input = {
+      ...baseManifest(),
+      tests: [{ name: 'n', command: 'ext.example.cmd', fixture: 'f.ifc', expect: { ok: true } }],
+    };
+    expect(validateManifest(input).ok).toBe(true);
+  });
+});
+
+describe('validateManifest — l10n', () => {
+  it('rejects a non-object locale bag', () => {
+    const input = { ...baseManifest(), l10n: { de: 'nope' } };
+    expect(hasError(input, 'l10n.de', 'type_mismatch')).toBe(true);
+  });
+
+  it('rejects a non-string translation value', () => {
+    const input = { ...baseManifest(), l10n: { de: { title: 42 } } };
+    expect(hasError(input, 'l10n.de.title', 'type_mismatch')).toBe(true);
+  });
+
+  it('accepts a well-formed l10n bag', () => {
+    const input = { ...baseManifest(), l10n: { de: { title: 'Titel' } } };
+    expect(validateManifest(input).ok).toBe(true);
+  });
+});
+
+describe('validateManifest — capabilities and activation', () => {
+  it('rejects a non-string capability entry with an indexed path', () => {
+    const input = { ...baseManifest(), capabilities: [42] };
+    expect(hasError(input, 'capabilities[0]', 'type_mismatch')).toBe(true);
+  });
+
+  it('rejects a non-array activation list', () => {
+    expect(hasError({ ...baseManifest(), activation: 'onStartup' }, 'activation', 'required')).toBe(true);
+  });
+});

--- a/packages/extensions/src/migrations/migrations.test.ts
+++ b/packages/extensions/src/migrations/migrations.test.ts
@@ -11,14 +11,39 @@
  * `rawVersion < 1` left the whole suite green, and a manifest declaring
  * `manifestVersion: 0` or `1.5` would then be waved through as
  * already-current.
+ *
+ * The code alone is NOT a discriminator here. `migrateManifest` emits
+ * `invalid_manifest_version` at path `manifestVersion` from *three*
+ * independent places: the shape guard, the "newer than supported"
+ * branch, and the "no migration available" branch at the bottom of the
+ * chain loop. So `0` still errors with deleting `rawVersion < 1` (it
+ * falls through to "no migration available from v0"), and `1.5` still
+ * errors with `!Number.isInteger` deleted (`1.5 > 1` hits the
+ * newer-than-supported branch). Both mutations survive a code-only
+ * assertion. Each case below therefore asserts the guard's own
+ * *message*, which is what actually distinguishes the three rules.
  */
 
 import { describe, expect, it } from 'vitest';
 import { CURRENT_MANIFEST_VERSION, migrateManifest, migrateV1 } from './index.js';
 
+/** The shape guard's own message — distinct from the other two rules'. */
+const SHAPE_GUARD_MESSAGE = 'manifestVersion is required and must be a positive integer.';
+
 function errorCodes(input: Record<string, unknown>): string[] {
   const r = migrateManifest(input);
   return r.ok ? [] : r.errors.map((e) => e.code);
+}
+
+/** Assert the *shape guard* rejected it, not one of its two look-alikes. */
+function expectShapeGuardRejection(v: unknown): void {
+  const r = migrateManifest({ manifestVersion: v as number });
+  expect(r.ok).toBe(false);
+  if (r.ok) return;
+  expect(r.errors).toHaveLength(1);
+  expect(r.errors[0].path).toBe('manifestVersion');
+  expect(r.errors[0].code).toBe('invalid_manifest_version');
+  expect(r.errors[0].message).toBe(SHAPE_GUARD_MESSAGE);
 }
 
 describe('migrateManifest — version guard', () => {
@@ -29,18 +54,18 @@ describe('migrateManifest — version guard', () => {
     if (r.ok) expect(r.value).toBe(input);
   });
 
-  it.each([0, -1, -42])('rejects the non-positive version %s', (v) => {
-    expect(errorCodes({ manifestVersion: v })).toContain('invalid_manifest_version');
+  it.each([0, -1, -42])('rejects the non-positive version %s at the shape guard', (v) => {
+    expectShapeGuardRejection(v);
   });
 
-  it.each([1.5, 0.5, 2.0001])('rejects the non-integer version %s', (v) => {
-    expect(errorCodes({ manifestVersion: v })).toContain('invalid_manifest_version');
+  it.each([1.5, 0.5, 2.0001])('rejects the non-integer version %s at the shape guard', (v) => {
+    expectShapeGuardRejection(v);
   });
 
   it.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
-    'rejects the non-finite version %s',
+    'rejects the non-finite version %s at the shape guard',
     (v) => {
-      expect(errorCodes({ manifestVersion: v })).toContain('invalid_manifest_version');
+      expectShapeGuardRejection(v);
     },
   );
 

--- a/packages/extensions/src/migrations/migrations.test.ts
+++ b/packages/extensions/src/migrations/migrations.test.ts
@@ -1,0 +1,82 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `migrateManifest` version-guard coverage.
+ *
+ * `manifest.test.ts` pins the "newer than we support" and the
+ * "non-numeric" cases. It does not pin the integrality / positivity
+ * half of the same guard: deleting `!Number.isInteger(rawVersion)` and
+ * `rawVersion < 1` left the whole suite green, and a manifest declaring
+ * `manifestVersion: 0` or `1.5` would then be waved through as
+ * already-current.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { CURRENT_MANIFEST_VERSION, migrateManifest, migrateV1 } from './index.js';
+
+function errorCodes(input: Record<string, unknown>): string[] {
+  const r = migrateManifest(input);
+  return r.ok ? [] : r.errors.map((e) => e.code);
+}
+
+describe('migrateManifest — version guard', () => {
+  it('accepts the current version and returns the input identity', () => {
+    const input = { manifestVersion: CURRENT_MANIFEST_VERSION, id: 'com.example.a' };
+    const r = migrateManifest(input);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value).toBe(input);
+  });
+
+  it.each([0, -1, -42])('rejects the non-positive version %s', (v) => {
+    expect(errorCodes({ manifestVersion: v })).toContain('invalid_manifest_version');
+  });
+
+  it.each([1.5, 0.5, 2.0001])('rejects the non-integer version %s', (v) => {
+    expect(errorCodes({ manifestVersion: v })).toContain('invalid_manifest_version');
+  });
+
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
+    'rejects the non-finite version %s',
+    (v) => {
+      expect(errorCodes({ manifestVersion: v })).toContain('invalid_manifest_version');
+    },
+  );
+
+  it.each([undefined, null, 'one', true, [], {}])(
+    'rejects the non-numeric version %s',
+    (v) => {
+      expect(errorCodes({ manifestVersion: v as unknown as number })).toContain(
+        'invalid_manifest_version',
+      );
+    },
+  );
+
+  it('rejects a future version and names it in the message', () => {
+    const r = migrateManifest({ manifestVersion: CURRENT_MANIFEST_VERSION + 1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.errors[0].path).toBe('manifestVersion');
+      expect(r.errors[0].message).toContain(String(CURRENT_MANIFEST_VERSION + 1));
+    }
+  });
+
+  it('points every rejection at the manifestVersion path', () => {
+    for (const v of [0, 1.5, 'one', CURRENT_MANIFEST_VERSION + 1]) {
+      const r = migrateManifest({ manifestVersion: v as unknown as number });
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.errors[0].path).toBe('manifestVersion');
+    }
+  });
+});
+
+describe('migrateV1', () => {
+  it('is re-exported from the migrations barrel and passes v1 through', () => {
+    expect(typeof migrateV1).toBe('function');
+    const input = { manifestVersion: 1, id: 'com.example.a' };
+    const r = migrateV1(input);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value).toEqual(input);
+  });
+});

--- a/packages/extensions/src/signing/signing.test.ts
+++ b/packages/extensions/src/signing/signing.test.ts
@@ -188,6 +188,54 @@ describe('canonicalContentHash', () => {
     two.set('b.txt', { path: 'b.txt', bytes: enc.encode('y') });
     expect(await canonicalContentHash(one)).not.toBe(await canonicalContentHash(two));
   });
+
+  // The test above proves the *old* 0x1f/0x1e separator scheme is gone,
+  // but it does not prove the replacement length prefixes carry a
+  // length: zeroing every prefix byte keeps those two inputs distinct
+  // (they have different segment counts) and left the whole suite green.
+  //
+  // This pair is the case that needs the actual length. Both maps hold
+  // one file and the same trailing bytes; they differ only in *where*
+  // the path ends and the content begins:
+  //
+  //   one: path "a"          content PAD + "b"
+  //   two: path "a" + PAD    content "b"
+  //
+  // With a real prefix the two serialisations start `len=1` vs `len=9`
+  // and diverge immediately. With a constant prefix they are the same
+  // byte string, so the hash collides and two different bundles would
+  // share a signature.
+  it('is injective when the path/content boundary shifts (length prefix carries the length)', async () => {
+    const enc = new TextEncoder();
+    // Eight bytes matching what a *constant* prefix would emit. The
+    // serialisation is `prefix(len(path)) || path || prefix(len(bytes)) || bytes`,
+    // so these two maps produce the identical byte string the moment the
+    // prefix stops depending on the length:
+    //
+    //   one: path "a"          bytes NUL*8 + "b"   ->  C a C C b
+    //   two: path "a" + NUL*8  bytes "b"           ->  C a C C b
+    //
+    // With a real prefix the first length is 1 vs 9 and they diverge at
+    // byte 7. Without it two different bundles share a content hash, and
+    // therefore a signature. `changes when path changes` above does not
+    // reach this: those inputs differ in segment *count*, so even a
+    // constant prefix keeps them apart.
+    const NUL8 = String.fromCharCode(0).repeat(8);
+
+    const one = new Map<string, { path: string; bytes: Uint8Array }>();
+    one.set('a', { path: 'a', bytes: enc.encode(`${NUL8}b`) });
+
+    const two = new Map<string, { path: string; bytes: Uint8Array }>();
+    two.set(`a${NUL8}`, { path: `a${NUL8}`, bytes: enc.encode('b') });
+
+    expect(await canonicalContentHash(one)).not.toBe(await canonicalContentHash(two));
+  });
+
+  it('changes when a file is added, even with identical existing entries', async () => {
+    const a = makeBundle({ 'manifest.json': '{}' });
+    const b = makeBundle({ 'manifest.json': '{}', 'empty.txt': '' });
+    expect(await canonicalContentHash(a.files)).not.toBe(await canonicalContentHash(b.files));
+  });
 });
 
 describe('sign + verify — happy path', () => {

--- a/packages/extensions/src/validate/code.test.ts
+++ b/packages/extensions/src/validate/code.test.ts
@@ -39,6 +39,31 @@ describe('validateCode — banned globals', () => {
     const r = validateCode(`document.body.innerHTML = '';`);
     expect(r.ok).toBe(false);
   });
+
+  // `self` is the one worker-realm alias of the global object, and it was
+  // the only entry in BANNED_GLOBALS with no test: removing it from the
+  // set left the whole suite green while re-opening the exact escape the
+  // other four close.
+  it('rejects self, the worker-realm alias of the global object', () => {
+    const r = validateCode(`self.postMessage('x');`);
+    expect(r.ok).toBe(false);
+    expect(r.errors[0].message).toContain('self');
+  });
+
+  // Guards the whole set at once, per name, so a future edit that drops
+  // any single entry fails here rather than silently widening the gate.
+  it.each(['globalThis', 'window', 'process', 'document', 'self'])(
+    'names "%s" in the banned-global diagnostic',
+    (name) => {
+      const r = validateCode(`const x = ${name};`);
+      expect(r.ok).toBe(false);
+      expect(r.errors.some((e) => e.message.includes(`"${name}"`))).toBe(true);
+    },
+  );
+
+  it('leaves an unrelated identifier alone', () => {
+    expect(validateCode(`const x = ctx.bim;`).ok).toBe(true);
+  });
 });
 
 describe('validateCode — banned calls', () => {

--- a/packages/extensions/src/when/eval.test.ts
+++ b/packages/extensions/src/when/eval.test.ts
@@ -1,0 +1,179 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `when` evaluator — the guards the existing `when.test.ts` does not pin.
+ *
+ * `when` clauses come out of an extension manifest, i.e. third-party
+ * text, and decide whether a contribution is shown. The two lookup
+ * guards in `evaluate()` — the v1 allow-list and the own-property check
+ * — are the whole reason a host that accidentally puts extra state on
+ * the context object cannot leak it to an extension, and neither was
+ * exercised: deleting either left all 603 tests green. So did making
+ * the empty string truthy and letting booleans through the ordering
+ * comparisons.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { EMPTY_WHEN_CONTEXT, WHEN_CONTEXT_KEYS, evaluateWhen } from './eval.js';
+import { parseWhen } from './parse.js';
+import type { WhenContext } from '../types.js';
+
+function parse(src: string) {
+  const r = parseWhen(src);
+  if (!r.ok) throw new Error(`fixture "${src}" does not parse: ${r.errors[0].message}`);
+  return r.value;
+}
+
+function evalCtx(src: string, ctx: WhenContext): boolean {
+  return evaluateWhen(parse(src), ctx);
+}
+
+describe('EMPTY_WHEN_CONTEXT', () => {
+  it('covers exactly the v1 key vocabulary', () => {
+    expect(Object.keys(EMPTY_WHEN_CONTEXT).sort()).toEqual([...WHEN_CONTEXT_KEYS].sort());
+  });
+
+  it('makes every key evaluate falsy', () => {
+    for (const key of WHEN_CONTEXT_KEYS) {
+      expect(evalCtx(key, EMPTY_WHEN_CONTEXT)).toBe(false);
+    }
+  });
+
+  it('is frozen so a host cannot mutate the shared default', () => {
+    expect(Object.isFrozen(EMPTY_WHEN_CONTEXT)).toBe(true);
+  });
+});
+
+describe('identifier lookup — v1 allow-list', () => {
+  // Without the allow-list gate, an identifier a *host* happens to put on
+  // the context object becomes readable from third-party manifest text.
+  it('ignores a context key outside the v1 vocabulary even when present', () => {
+    const leaky = {
+      ...EMPTY_WHEN_CONTEXT,
+      'internal.licenseKey': true,
+    } as unknown as WhenContext;
+
+    expect(evalCtx('internal.licenseKey', leaky)).toBe(false);
+  });
+
+  it('still reads an allow-listed key from the same object', () => {
+    const leaky = {
+      ...EMPTY_WHEN_CONTEXT,
+      'internal.licenseKey': true,
+      'model.loaded': true,
+    } as unknown as WhenContext;
+
+    expect(evalCtx('model.loaded', leaky)).toBe(true);
+  });
+
+  it('treats an allow-listed key the context omits as undefined, not inherited', () => {
+    const partial = { 'model.loaded': true } as unknown as WhenContext;
+    expect(evalCtx('model.loaded', partial)).toBe(true);
+    expect(evalCtx('viewer.open', partial)).toBe(false);
+  });
+});
+
+describe('identifier lookup — own-property gate', () => {
+  // `expr.name in ctx` would walk the prototype chain. None of the v1
+  // key names collide with Object.prototype, so the gate only bites for
+  // a context whose *prototype* carries an allow-listed key — exactly
+  // what a `Object.create(defaults)` host would produce, and it must not
+  // resolve.
+  it('does not resolve an allow-listed key inherited from the prototype', () => {
+    const proto = { 'model.loaded': true };
+    const ctx = Object.create(proto) as WhenContext;
+
+    expect('model.loaded' in (ctx as object)).toBe(true);
+    expect(evalCtx('model.loaded', ctx)).toBe(false);
+  });
+
+  it('resolves the same key once it is an own property', () => {
+    const proto = { 'model.loaded': true };
+    const ctx = Object.create(proto) as WhenContext;
+    (ctx as Record<string, unknown>)['model.loaded'] = true;
+
+    expect(evalCtx('model.loaded', ctx)).toBe(true);
+  });
+});
+
+describe('truthiness coercion', () => {
+  it('treats the empty string as false and a non-empty string as true', () => {
+    const empty = { ...EMPTY_WHEN_CONTEXT, 'selection.type': '' } as WhenContext;
+    const set = { ...EMPTY_WHEN_CONTEXT, 'selection.type': 'IfcWall' } as WhenContext;
+
+    expect(evalCtx('selection.type', empty)).toBe(false);
+    expect(evalCtx('selection.type', set)).toBe(true);
+  });
+
+  it('treats 0 as false and a non-zero number as true', () => {
+    expect(evalCtx('selection.count', { ...EMPTY_WHEN_CONTEXT, 'selection.count': 0 })).toBe(false);
+    expect(evalCtx('selection.count', { ...EMPTY_WHEN_CONTEXT, 'selection.count': 3 })).toBe(true);
+  });
+
+  it('negation follows the same coercion', () => {
+    const empty = { ...EMPTY_WHEN_CONTEXT, 'selection.type': '' } as WhenContext;
+    expect(evalCtx('!selection.type', empty)).toBe(true);
+  });
+});
+
+describe('ordering comparisons', () => {
+  // JS would happily evaluate `true > false`. The evaluator refuses, so
+  // a boolean context value can never satisfy an ordering clause.
+  //
+  // Mixed boolean/number is caught by the *later* `typeof left !== typeof
+  // right` check as well, so it does not pin this guard. Two booleans do:
+  // they pass the typeof check and only the explicit boolean rejection
+  // stands between them and JS's numeric coercion.
+  it('returns false when both sides of an ordering are booleans', () => {
+    const ctx = { ...EMPTY_WHEN_CONTEXT, 'model.loaded': true, 'viewer.open': false } as WhenContext;
+
+    expect(evalCtx('model.loaded > viewer.open', ctx)).toBe(false);
+    expect(evalCtx('model.loaded >= viewer.open', ctx)).toBe(false);
+    expect(evalCtx('viewer.open < model.loaded', ctx)).toBe(false);
+    expect(evalCtx('viewer.open <= model.loaded', ctx)).toBe(false);
+  });
+
+  it('returns false when only one side of an ordering is a boolean', () => {
+    const ctx = { ...EMPTY_WHEN_CONTEXT, 'model.loaded': true } as WhenContext;
+
+    expect(evalCtx('model.loaded > 0', ctx)).toBe(false);
+    expect(evalCtx('model.loaded <= 2', ctx)).toBe(false);
+  });
+
+  it('still orders numbers on both strict and inclusive operators', () => {
+    const ctx = { ...EMPTY_WHEN_CONTEXT, 'selection.count': 2 } as WhenContext;
+
+    expect(evalCtx('selection.count > 1', ctx)).toBe(true);
+    expect(evalCtx('selection.count > 2', ctx)).toBe(false);
+    expect(evalCtx('selection.count >= 2', ctx)).toBe(true);
+    expect(evalCtx('selection.count < 3', ctx)).toBe(true);
+    expect(evalCtx('selection.count <= 1', ctx)).toBe(false);
+  });
+
+  it('orders strings lexically', () => {
+    const ctx = { ...EMPTY_WHEN_CONTEXT, 'selection.type': 'IfcWall' } as WhenContext;
+    expect(evalCtx("selection.type > 'IfcSlab'", ctx)).toBe(true);
+    expect(evalCtx("selection.type < 'IfcSlab'", ctx)).toBe(false);
+  });
+
+  it('returns false when an ordering side is undefined', () => {
+    expect(evalCtx('selection.type > 1', EMPTY_WHEN_CONTEXT)).toBe(false);
+  });
+});
+
+describe('equality', () => {
+  it('is strict about type — booleans do not equal numbers', () => {
+    const ctx = { ...EMPTY_WHEN_CONTEXT, 'model.loaded': true } as WhenContext;
+    expect(evalCtx('model.loaded == 1', ctx)).toBe(false);
+    expect(evalCtx('model.loaded != 1', ctx)).toBe(true);
+    expect(evalCtx('model.loaded == true', ctx)).toBe(true);
+  });
+
+  it('treats two undefined sides as equal and one as unequal', () => {
+    expect(evalCtx('selection.type == model.schema', EMPTY_WHEN_CONTEXT)).toBe(true);
+    expect(evalCtx("selection.type == 'IfcWall'", EMPTY_WHEN_CONTEXT)).toBe(false);
+    expect(evalCtx("selection.type != 'IfcWall'", EMPTY_WHEN_CONTEXT)).toBe(true);
+  });
+});

--- a/packages/sdk/src/namespaces/namespaces.test.ts
+++ b/packages/sdk/src/namespaces/namespaces.test.ts
@@ -171,6 +171,14 @@ describe('EventsNamespace', () => {
     expect(unsubs[0]).toHaveBeenCalledTimes(1);
   });
 
+  // The bookkeeping key is `${event}-${nextId++}`, and the counter is
+  // the whole point: two subscriptions to the *same* event must occupy
+  // two map slots. The `offA()` half of this test does not reach that —
+  // each unsubscribe closes over its own `unsub`, so it holds with a
+  // constant key too. The `removeAll()` half is what discriminates:
+  // with a per-event key the second `on()` overwrites the first slot,
+  // `offA()` deletes that single slot, and B's unsubscribe is never
+  // called — a listener leaked past `removeAll()`.
   it('gives each subscription its own unsubscribe, even for the same event', () => {
     const { ns, unsubs } = setup();
     const offA = ns.on('selection:changed', vi.fn());
@@ -179,6 +187,22 @@ describe('EventsNamespace', () => {
     offA();
     expect(unsubs[0]).toHaveBeenCalledTimes(1);
     expect(unsubs[1]).not.toHaveBeenCalled();
+
+    ns.removeAll();
+    expect(unsubs[0]).toHaveBeenCalledTimes(1); // not re-run
+    expect(unsubs[1]).toHaveBeenCalledTimes(1); // released, not leaked
+  });
+
+  it('removeAll() releases every subscription to one and the same event', () => {
+    const { ns, unsubs } = setup();
+    ns.on('selection:changed', vi.fn());
+    ns.on('selection:changed', vi.fn());
+    ns.on('selection:changed', vi.fn());
+
+    ns.removeAll();
+
+    expect(unsubs).toHaveLength(3);
+    for (const u of unsubs) expect(u).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/sdk/src/namespaces/namespaces.test.ts
+++ b/packages/sdk/src/namespaces/namespaces.test.ts
@@ -1,0 +1,439 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Namespace-level coverage for the `bim.*` surfaces `context.test.ts`
+ * does not reach.
+ *
+ * `ModelNamespace`, `EventsNamespace`, `ScheduleNamespace` and
+ * `SpacesNamespace` are all exported from the package root and wired
+ * into `BimContext`, so external consumers call them — but each had
+ * only three repo-wide occurrences (definition, context wiring, barrel
+ * re-export) and no test. Mutation testing confirmed it: dropping
+ * `ModelNamespace.active()`'s null guard, dropping the unsubscribe
+ * bookkeeping in `EventsNamespace`, routing `schedule.tasks()` at
+ * `schedule.sequences()`, and disabling the "no spaces backend" guard
+ * all left the SDK suite green.
+ *
+ * The `QueryBuilder` / `QueryNamespace` cases below are the ones the
+ * existing chain tests miss: descriptor restoration after `first()`,
+ * the default comparison operator, first-vs-last relationship pick, and
+ * the 3-arg qset-name filter in `quantity()`.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { ModelNamespace } from './model.js';
+import { EventsNamespace } from './events.js';
+import { ScheduleNamespace } from './schedule.js';
+import { SpacesNamespace } from './spaces.js';
+import { QueryNamespace } from './query.js';
+import type {
+  BimBackend,
+  EntityData,
+  EntityRef,
+  ModelInfo,
+  QuantitySetData,
+  QueryDescriptor,
+} from '../types.js';
+
+function modelInfo(id: string): ModelInfo {
+  return {
+    id,
+    name: `${id}.ifc`,
+    schema: 'IFC4',
+    schemaVersion: 'IFC4',
+    entityCount: 1,
+    fileSize: 1,
+    loadedAt: 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// ModelNamespace
+// ---------------------------------------------------------------------------
+
+describe('ModelNamespace', () => {
+  function setup(activeId: string | null, models: ModelInfo[]) {
+    const model = {
+      list: vi.fn(() => models),
+      activeId: vi.fn(() => activeId),
+      loadIfc: vi.fn(),
+    };
+    return { ns: new ModelNamespace({ model } as unknown as BimBackend), model };
+  }
+
+  it('list() passes the backend list straight through', () => {
+    const models = [modelInfo('arch')];
+    const { ns } = setup('arch', models);
+    expect(ns.list()).toBe(models);
+  });
+
+  it('active() resolves the active model', () => {
+    const { ns } = setup('arch', [modelInfo('mep'), modelInfo('arch')]);
+    expect(ns.active()?.id).toBe('arch');
+  });
+
+  // Without the `if (!id) return null` guard, `list().find(m => m.id === null)`
+  // returns undefined → `?? null`, so the *return value* is the same. The
+  // observable difference is that the backend list is queried at all — and,
+  // more importantly, that a model whose id is the empty string would match.
+  it('active() returns null when no model is active, without consulting the list', () => {
+    const { ns, model } = setup(null, [modelInfo('arch')]);
+    expect(ns.active()).toBeNull();
+    expect(model.list).not.toHaveBeenCalled();
+  });
+
+  it('active() returns null for an active id that is not in the list', () => {
+    const { ns } = setup('ghost', [modelInfo('arch')]);
+    expect(ns.active()).toBeNull();
+  });
+
+  it('get() returns the matching model or null', () => {
+    const { ns } = setup('arch', [modelInfo('arch'), modelInfo('mep')]);
+    expect(ns.get('mep')?.id).toBe('mep');
+    expect(ns.get('nope')).toBeNull();
+  });
+
+  it('loadIfc() defaults the filename to created.ifc', () => {
+    const { ns, model } = setup('arch', []);
+    ns.loadIfc('ISO-10303-21;');
+    expect(model.loadIfc).toHaveBeenCalledWith('ISO-10303-21;', 'created.ifc');
+  });
+
+  it('loadIfc() forwards an explicit filename', () => {
+    const { ns, model } = setup('arch', []);
+    ns.loadIfc('ISO-10303-21;', 'tower.ifc');
+    expect(model.loadIfc).toHaveBeenCalledWith('ISO-10303-21;', 'tower.ifc');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EventsNamespace
+// ---------------------------------------------------------------------------
+
+describe('EventsNamespace', () => {
+  function setup() {
+    const unsubs: Array<() => void> = [];
+    const subscribe = vi.fn((_event: string, _handler: (d: unknown) => void) => {
+      const unsub = vi.fn();
+      unsubs.push(unsub);
+      return unsub;
+    });
+    return { ns: new EventsNamespace({ subscribe } as unknown as BimBackend), subscribe, unsubs };
+  }
+
+  it('on() subscribes on the backend and hands back the unsubscribe', () => {
+    const { ns, subscribe, unsubs } = setup();
+    const handler = vi.fn();
+
+    const off = ns.on('selection:changed', handler);
+    expect(subscribe).toHaveBeenCalledWith('selection:changed', handler);
+
+    off();
+    expect(unsubs[0]).toHaveBeenCalledTimes(1);
+  });
+
+  it('removeAll() calls every outstanding unsubscribe', () => {
+    const { ns, unsubs } = setup();
+    ns.on('selection:changed', vi.fn());
+    ns.on('model:loaded', vi.fn());
+
+    ns.removeAll();
+
+    expect(unsubs).toHaveLength(2);
+    for (const u of unsubs) expect(u).toHaveBeenCalledTimes(1);
+  });
+
+  // The per-subscription `unsubscribers.delete(id)` is the bookkeeping
+  // that stops `removeAll()` from calling an already-released
+  // unsubscribe a second time. Without it the backend sees a double
+  // unsubscribe for every handler the caller released itself.
+  it('does not re-run an unsubscribe that the caller already invoked', () => {
+    const { ns, unsubs } = setup();
+    const off = ns.on('selection:changed', vi.fn());
+    ns.on('model:loaded', vi.fn());
+
+    off();
+    ns.removeAll();
+
+    expect(unsubs[0]).toHaveBeenCalledTimes(1);
+    expect(unsubs[1]).toHaveBeenCalledTimes(1);
+  });
+
+  it('removeAll() is idempotent', () => {
+    const { ns, unsubs } = setup();
+    ns.on('selection:changed', vi.fn());
+
+    ns.removeAll();
+    ns.removeAll();
+
+    expect(unsubs[0]).toHaveBeenCalledTimes(1);
+  });
+
+  it('gives each subscription its own unsubscribe, even for the same event', () => {
+    const { ns, unsubs } = setup();
+    const offA = ns.on('selection:changed', vi.fn());
+    ns.on('selection:changed', vi.fn());
+
+    offA();
+    expect(unsubs[0]).toHaveBeenCalledTimes(1);
+    expect(unsubs[1]).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ScheduleNamespace
+// ---------------------------------------------------------------------------
+
+describe('ScheduleNamespace', () => {
+  function setup() {
+    const schedule = {
+      data: vi.fn(() => ({ kind: 'data' })),
+      tasks: vi.fn(() => [{ kind: 'task' }]),
+      workSchedules: vi.fn(() => [{ kind: 'workSchedule' }]),
+      sequences: vi.fn(() => [{ kind: 'sequence' }]),
+    };
+    return { ns: new ScheduleNamespace({ schedule } as unknown as BimBackend), schedule };
+  }
+
+  // Each accessor must reach its *own* backend method — the four have
+  // identical signatures, so a mis-wired one is invisible without a
+  // per-method assertion.
+  it('routes each accessor to the matching backend method', () => {
+    const { ns, schedule } = setup();
+
+    expect(ns.data('arch')).toEqual({ kind: 'data' });
+    expect(ns.tasks('arch')).toEqual([{ kind: 'task' }]);
+    expect(ns.workSchedules('arch')).toEqual([{ kind: 'workSchedule' }]);
+    expect(ns.sequences('arch')).toEqual([{ kind: 'sequence' }]);
+
+    expect(schedule.data).toHaveBeenCalledWith('arch');
+    expect(schedule.tasks).toHaveBeenCalledWith('arch');
+    expect(schedule.workSchedules).toHaveBeenCalledWith('arch');
+    expect(schedule.sequences).toHaveBeenCalledWith('arch');
+  });
+
+  it('forwards an omitted modelId as undefined so the backend picks the active model', () => {
+    const { ns, schedule } = setup();
+    ns.tasks();
+    expect(schedule.tasks).toHaveBeenCalledWith(undefined);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SpacesNamespace
+// ---------------------------------------------------------------------------
+
+describe('SpacesNamespace', () => {
+  it('delegates to the backend when space derivation is available', () => {
+    const spaces = {
+      listStoreys: vi.fn(() => [{ expressId: 1, name: 'EG', elevation: 0 }]),
+      generate: vi.fn(() => ({ created: 3 })),
+    };
+    const ns = new SpacesNamespace({ spaces } as unknown as BimBackend);
+
+    expect(ns.storeys()).toEqual([{ expressId: 1, name: 'EG', elevation: 0 }]);
+    ns.generate({ height: 'auto' } as never);
+    expect(spaces.generate).toHaveBeenCalledWith({ height: 'auto' });
+  });
+
+  // `backend.spaces` is optional: remote/transport-backed contexts leave
+  // it undefined because the store lives server-side. Without the guard
+  // the caller gets an opaque "cannot read properties of undefined"
+  // instead of the actionable message.
+  it('throws an explanatory error when the backend has no spaces support', () => {
+    const ns = new SpacesNamespace({} as unknown as BimBackend);
+
+    expect(() => ns.storeys()).toThrow(/spaces: not available on this backend/);
+    expect(() => ns.generate()).toThrow(/spaces: not available on this backend/);
+  });
+
+  it('names the remedy in the error so a script author can act on it', () => {
+    const ns = new SpacesNamespace({} as unknown as BimBackend);
+    expect(() => ns.storeys()).toThrow(/headless\/local context/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// QueryBuilder / QueryNamespace
+// ---------------------------------------------------------------------------
+
+function entity(modelId: string, expressId: number, type = 'IfcWall'): EntityData {
+  return {
+    ref: { modelId, expressId },
+    globalId: `g${expressId}`,
+    name: `e${expressId}`,
+    type,
+    description: '',
+    objectType: '',
+  };
+}
+
+describe('QueryBuilder', () => {
+  function setup(results: EntityData[]) {
+    const seen: QueryDescriptor[] = [];
+    const entities = vi.fn((d: QueryDescriptor) => {
+      seen.push(structuredClone(d));
+      return results;
+    });
+    const backend = { query: { entities } } as unknown as BimBackend;
+    return { ns: new QueryNamespace(backend), seen };
+  }
+
+  it('defaults the comparison operator to "exists" when none is given', () => {
+    const { ns, seen } = setup([]);
+    ns.create().where('Pset_WallCommon', 'IsExternal').toArray();
+    expect(seen[0].filters).toEqual([
+      { psetName: 'Pset_WallCommon', propName: 'IsExternal', operator: 'exists', value: undefined },
+    ]);
+  });
+
+  it('keeps an explicit operator and value', () => {
+    const { ns, seen } = setup([]);
+    ns.create().where('Pset_WallCommon', 'IsExternal', '=', true).toArray();
+    expect(seen[0].filters?.[0].operator).toBe('=');
+    expect(seen[0].filters?.[0].value).toBe(true);
+  });
+
+  it('accumulates types and filters across chained calls', () => {
+    const { ns, seen } = setup([]);
+    ns.create().byType('IfcWall').byType('IfcSlab', 'IfcRoof').model('arch').limit(5).offset(2).toArray();
+    expect(seen[0]).toEqual({
+      types: ['IfcWall', 'IfcSlab', 'IfcRoof'],
+      modelId: 'arch',
+      limit: 5,
+      offset: 2,
+    });
+  });
+
+  // `first()` sets limit=1 for one call and must put the caller's limit
+  // back. Without the restore, a builder reused after `first()` silently
+  // returns one row.
+  it('first() restores the caller-supplied limit afterwards', () => {
+    const { ns, seen } = setup([entity('arch', 1), entity('arch', 2)]);
+    const builder = ns.create().limit(10);
+
+    expect(builder.first()?.ref.expressId).toBe(1);
+    builder.toArray();
+
+    expect(seen[0].limit).toBe(1);
+    expect(seen[1].limit).toBe(10);
+  });
+
+  it('first() restores an absent limit as absent, not as 1', () => {
+    const { ns, seen } = setup([entity('arch', 1)]);
+    const builder = ns.create();
+
+    builder.first();
+    builder.toArray();
+
+    expect(seen[0].limit).toBe(1);
+    expect(seen[1].limit).toBeUndefined();
+  });
+
+  it('first() returns null on an empty result', () => {
+    const { ns } = setup([]);
+    expect(ns.create().first()).toBeNull();
+  });
+
+  it('count() and refs() read the same descriptor', () => {
+    const { ns } = setup([entity('arch', 1), entity('arch', 2)]);
+    expect(ns.create().count()).toBe(2);
+    expect(ns.create().refs()).toEqual([
+      { modelId: 'arch', expressId: 1 },
+      { modelId: 'arch', expressId: 2 },
+    ]);
+  });
+});
+
+describe('QueryNamespace — relationship navigation', () => {
+  function setup(related: EntityRef[], data: Record<number, EntityData>) {
+    const backend = {
+      query: {
+        related: vi.fn(() => related),
+        entityData: vi.fn((r: EntityRef) => data[r.expressId] ?? null),
+      },
+    } as unknown as BimBackend;
+    return new QueryNamespace(backend);
+  }
+
+  // Both `containedIn` and `decomposedBy` document "the" parent, and the
+  // backend returns them in relationship order. Picking any element other
+  // than the first would change which storey a script reports.
+  it('containedIn() resolves the first related ref, not the last', () => {
+    const ns = setup(
+      [{ modelId: 'arch', expressId: 10 }, { modelId: 'arch', expressId: 20 }],
+      { 10: entity('arch', 10, 'IfcBuildingStorey'), 20: entity('arch', 20, 'IfcBuilding') },
+    );
+    expect(ns.containedIn({ modelId: 'arch', expressId: 1 })?.ref.expressId).toBe(10);
+  });
+
+  it('decomposedBy() resolves the first related ref, not the last', () => {
+    const ns = setup(
+      [{ modelId: 'arch', expressId: 10 }, { modelId: 'arch', expressId: 20 }],
+      { 10: entity('arch', 10, 'IfcBuilding'), 20: entity('arch', 20, 'IfcSite') },
+    );
+    expect(ns.decomposedBy({ modelId: 'arch', expressId: 1 })?.ref.expressId).toBe(10);
+  });
+
+  it('containedIn() and decomposedBy() return null with no relations', () => {
+    const ns = setup([], {});
+    expect(ns.containedIn({ modelId: 'arch', expressId: 1 })).toBeNull();
+    expect(ns.decomposedBy({ modelId: 'arch', expressId: 1 })).toBeNull();
+  });
+
+  it('related() drops refs the backend cannot resolve', () => {
+    const ns = setup(
+      [{ modelId: 'arch', expressId: 10 }, { modelId: 'arch', expressId: 99 }],
+      { 10: entity('arch', 10) },
+    );
+    const out = ns.related({ modelId: 'arch', expressId: 1 }, 'IfcRelAggregates', 'forward');
+    expect(out.map((e) => e.ref.expressId)).toEqual([10]);
+  });
+});
+
+describe('QueryNamespace — quantity()', () => {
+  function setup(qsets: QuantitySetData[]) {
+    const backend = {
+      query: { quantities: vi.fn(() => qsets) },
+    } as unknown as BimBackend;
+    return new QueryNamespace(backend);
+  }
+
+  const REF: EntityRef = { modelId: 'arch', expressId: 1 };
+
+  const QSETS: QuantitySetData[] = [
+    { name: 'Qto_WallBaseQuantities', quantities: [{ name: 'NetVolume', type: 0, value: 1 }] },
+    { name: 'Custom_Quantities', quantities: [{ name: 'NetVolume', type: 0, value: 99 }] },
+  ];
+
+  // The 3-arg form exists specifically to scope the lookup to a qset.
+  // Without the `matchSet` filter it degenerates into the 2-arg form and
+  // returns whichever set happens to come first.
+  it('3-arg form honours the qset name', () => {
+    const ns = setup(QSETS);
+    expect(ns.quantity(REF, 'Custom_Quantities', 'NetVolume')).toBe(99);
+    expect(ns.quantity(REF, 'Qto_WallBaseQuantities', 'NetVolume')).toBe(1);
+  });
+
+  it('3-arg form returns null when no qset name matches', () => {
+    const ns = setup(QSETS);
+    expect(ns.quantity(REF, 'Qto_SlabBaseQuantities', 'NetVolume')).toBeNull();
+  });
+
+  it('3-arg form accepts a /regex/ qset pattern', () => {
+    const ns = setup(QSETS);
+    expect(ns.quantity(REF, '/Qto_.*BaseQuantities/', 'NetVolume')).toBe(1);
+  });
+
+  it('2-arg form searches every qset and returns the first match', () => {
+    const ns = setup(QSETS);
+    expect(ns.quantity(REF, 'NetVolume')).toBe(1);
+  });
+
+  it('returns null for an unknown quantity name', () => {
+    const ns = setup(QSETS);
+    expect(ns.quantity(REF, 'GrossVolume')).toBeNull();
+  });
+});

--- a/packages/sdk/src/transport/transport.test.ts
+++ b/packages/sdk/src/transport/transport.test.ts
@@ -1,0 +1,340 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Transport layer coverage.
+ *
+ * `BroadcastTransport`, `MessagePortTransport` and `RemoteBackend` are
+ * all exported from the package root — `BroadcastTransport` is the one
+ * the package README tells external tools to use for cross-tab access —
+ * and none of the three had a test. Mutation testing showed the request
+ * timeout default, the close-time rejection of in-flight requests, the
+ * response-vs-event discrimination (which decides whether an *error*
+ * reply resolves a caller or is silently handed to event subscribers),
+ * and `RemoteBackend`'s event-type filter were all free to change.
+ *
+ * `BroadcastChannel` and `MessagePort` are stubbed rather than mocked
+ * out of the module, so the real constructor / `postMessage` /
+ * `onmessage` wiring is exercised.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BroadcastTransport } from './broadcast.js';
+import { MessagePortTransport } from './message-port.js';
+import { RemoteBackend } from './remote-backend.js';
+import type { SdkEvent, SdkRequest, SdkResponse, Transport } from '../types.js';
+
+// ---------------------------------------------------------------------------
+// Stubs
+// ---------------------------------------------------------------------------
+
+/** Minimal BroadcastChannel / MessagePort stand-in with the same surface. */
+class FakeChannel {
+  onmessage: ((e: { data: unknown }) => void) | null = null;
+  posted: unknown[] = [];
+  closed = false;
+
+  postMessage(data: unknown): void {
+    this.posted.push(data);
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+
+  /** Simulate an inbound message from the other side. */
+  deliver(data: unknown): void {
+    this.onmessage?.({ data });
+  }
+
+  start(): void { /* MessagePort API parity */ }
+}
+
+const channels: FakeChannel[] = [];
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  channels.length = 0;
+  vi.stubGlobal('BroadcastChannel', class {
+    constructor(readonly name: string) {
+      const ch = new FakeChannel();
+      channels.push(ch);
+      // Delegate onto the fake so the transport's assignments land on it.
+      return ch as unknown as BroadcastChannel;
+    }
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+function request(id: string): SdkRequest {
+  return { id, namespace: 'query', method: 'entities', args: [] };
+}
+
+// ---------------------------------------------------------------------------
+// BroadcastTransport
+// ---------------------------------------------------------------------------
+
+describe('BroadcastTransport', () => {
+  it('posts the request on the named channel', async () => {
+    const t = new BroadcastTransport('ifc-lite');
+    const p = t.send(request('r1'));
+
+    expect(channels[0].posted).toEqual([request('r1')]);
+
+    channels[0].deliver({ id: 'r1', result: ['a'] } satisfies SdkResponse);
+    await expect(p).resolves.toEqual({ id: 'r1', result: ['a'] });
+  });
+
+  it('resolves the matching pending request and leaves others in flight', async () => {
+    const t = new BroadcastTransport('ifc-lite');
+    const p1 = t.send(request('r1'));
+    const p2 = t.send(request('r2'));
+
+    channels[0].deliver({ id: 'r2', result: 2 } satisfies SdkResponse);
+    await expect(p2).resolves.toEqual({ id: 'r2', result: 2 });
+
+    channels[0].deliver({ id: 'r1', result: 1 } satisfies SdkResponse);
+    await expect(p1).resolves.toEqual({ id: 'r1', result: 1 });
+  });
+
+  // An error reply carries `error` and no `result`. It must still resolve
+  // the caller's promise; treating it as an event would leave the caller
+  // hanging until the timeout.
+  it('resolves a pending request from an error-only response', async () => {
+    const t = new BroadcastTransport('ifc-lite');
+    const p = t.send(request('r1'));
+
+    channels[0].deliver({ id: 'r1', error: { message: 'boom' } } satisfies SdkResponse);
+    await expect(p).resolves.toEqual({ id: 'r1', error: { message: 'boom' } });
+  });
+
+  it('ignores a response for an id it never sent', async () => {
+    const t = new BroadcastTransport('ifc-lite');
+    const p = t.send(request('r1'));
+
+    channels[0].deliver({ id: 'ghost', result: 1 } satisfies SdkResponse);
+    // Still pending: the only way to observe that is to satisfy it after.
+    channels[0].deliver({ id: 'r1', result: 1 } satisfies SdkResponse);
+    await expect(p).resolves.toEqual({ id: 'r1', result: 1 });
+  });
+
+  it('delivers host events to every subscriber and stops on unsubscribe', () => {
+    const t = new BroadcastTransport('ifc-lite');
+    const a = vi.fn();
+    const b = vi.fn();
+    const offA = t.subscribe(a);
+    t.subscribe(b);
+
+    const ev: SdkEvent = { type: 'selection:changed', data: [1] };
+    channels[0].deliver(ev);
+    expect(a).toHaveBeenCalledWith(ev);
+    expect(b).toHaveBeenCalledWith(ev);
+
+    offA();
+    channels[0].deliver(ev);
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not hand a response to event subscribers', () => {
+    const t = new BroadcastTransport('ifc-lite');
+    const handler = vi.fn();
+    t.subscribe(handler);
+    void t.send(request('r1'));
+
+    channels[0].deliver({ id: 'r1', result: 1 } satisfies SdkResponse);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  // 30s, not "some timeout": a caller that supplies no options must not
+  // have its request abandoned early, and must not wait forever either.
+  it('times out an unanswered request after the 30s default', async () => {
+    const t = new BroadcastTransport('ifc-lite');
+    const p = t.send(request('r1'));
+    const assertion = expect(p).rejects.toThrow(/timed out after 30000ms/);
+
+    await vi.advanceTimersByTimeAsync(29_999);
+    await vi.advanceTimersByTimeAsync(2);
+    await assertion;
+  });
+
+  it('honours an explicit timeoutMs', async () => {
+    const t = new BroadcastTransport('ifc-lite', { timeoutMs: 50 });
+    const p = t.send(request('r1'));
+    const assertion = expect(p).rejects.toThrow(/timed out after 50ms/);
+
+    await vi.advanceTimersByTimeAsync(51);
+    await assertion;
+  });
+
+  it('does not time out a request that was already answered', async () => {
+    const t = new BroadcastTransport('ifc-lite', { timeoutMs: 50 });
+    const p = t.send(request('r1'));
+    channels[0].deliver({ id: 'r1', result: 1 } satisfies SdkResponse);
+
+    await expect(p).resolves.toEqual({ id: 'r1', result: 1 });
+    await vi.advanceTimersByTimeAsync(1_000); // must not throw an unhandled rejection
+  });
+
+  // Without the close-time rejection an in-flight request hangs for the
+  // full timeout after the channel is already gone — and if the timer is
+  // also cleared, forever.
+  it('rejects in-flight requests when the transport is closed', async () => {
+    const t = new BroadcastTransport('ifc-lite');
+    const p = t.send(request('r1'));
+    const assertion = expect(p).rejects.toThrow(/Transport closed/);
+
+    t.close();
+    await assertion;
+  });
+
+  it('closes the underlying channel and drops subscribers', () => {
+    const t = new BroadcastTransport('ifc-lite');
+    const handler = vi.fn();
+    t.subscribe(handler);
+
+    t.close();
+
+    expect(channels[0].closed).toBe(true);
+    channels[0].deliver({ type: 'model:loaded', data: null } satisfies SdkEvent);
+    expect(handler).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MessagePortTransport
+// ---------------------------------------------------------------------------
+
+describe('MessagePortTransport', () => {
+  function setup(options?: { timeoutMs?: number }) {
+    const port = new FakeChannel();
+    const t = new MessagePortTransport(port as unknown as MessagePort, options);
+    return { t, port };
+  }
+
+  it('posts on the port and resolves the matching response', async () => {
+    const { t, port } = setup();
+    const p = t.send(request('r1'));
+
+    expect(port.posted).toEqual([request('r1')]);
+    port.deliver({ id: 'r1', result: 'ok' } satisfies SdkResponse);
+    await expect(p).resolves.toEqual({ id: 'r1', result: 'ok' });
+  });
+
+  it('resolves a pending request from an error-only response', async () => {
+    const { t, port } = setup();
+    const p = t.send(request('r1'));
+
+    port.deliver({ id: 'r1', error: { message: 'boom' } } satisfies SdkResponse);
+    await expect(p).resolves.toEqual({ id: 'r1', error: { message: 'boom' } });
+  });
+
+  it('routes events to subscribers, not to pending requests', () => {
+    const { t, port } = setup();
+    const handler = vi.fn();
+    t.subscribe(handler);
+
+    const ev: SdkEvent = { type: 'lens:changed', data: { id: 'l1' } };
+    port.deliver(ev);
+    expect(handler).toHaveBeenCalledWith(ev);
+  });
+
+  it('times out after the 30s default', async () => {
+    const { t } = setup();
+    const p = t.send(request('r1'));
+    const assertion = expect(p).rejects.toThrow(/timed out after 30000ms/);
+
+    await vi.advanceTimersByTimeAsync(30_001);
+    await assertion;
+  });
+
+  it('rejects in-flight requests and closes the port on close()', async () => {
+    const { t, port } = setup();
+    const p = t.send(request('r1'));
+    const assertion = expect(p).rejects.toThrow(/Transport closed/);
+
+    t.close();
+    await assertion;
+    expect(port.closed).toBe(true);
+  });
+
+  it('ignores non-object and null messages', () => {
+    const { t, port } = setup();
+    const handler = vi.fn();
+    t.subscribe(handler);
+
+    port.deliver(null);
+    port.deliver('hello');
+    port.deliver(42);
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RemoteBackend
+// ---------------------------------------------------------------------------
+
+describe('RemoteBackend', () => {
+  function fakeTransport() {
+    const handlers = new Set<(e: SdkEvent) => void>();
+    const transport: Transport = {
+      send: vi.fn(async () => ({ id: 'x', result: null })),
+      subscribe: (h) => {
+        handlers.add(h);
+        return () => handlers.delete(h);
+      },
+      close: vi.fn(),
+    };
+    return { transport, emit: (e: SdkEvent) => handlers.forEach((h) => h(e)) };
+  }
+
+  // Every namespace is a throwing proxy: the failure mode must be a
+  // clear synchronous error naming the namespace and method, not an
+  // undefined-is-not-a-function further down the call stack.
+  it.each([
+    'model', 'query', 'selection', 'visibility', 'viewer',
+    'mutate', 'store', 'spatial', 'export', 'lens', 'files', 'schedule',
+  ] as const)('throws a named error for any %s method', (ns) => {
+    const { transport } = fakeTransport();
+    const backend = new RemoteBackend(transport);
+    const fn = (backend as unknown as Record<string, Record<string, () => unknown>>)[ns].anything;
+
+    expect(() => fn()).toThrow(new RegExp(`Cannot call ${ns}\\.anything\\(\\) synchronously`));
+  });
+
+  // The subscribe filter is the whole contract of `BimBackend.subscribe`:
+  // a handler registered for one event type must not see another.
+  it('delivers only the subscribed event type', () => {
+    const { transport, emit } = fakeTransport();
+    const backend = new RemoteBackend(transport);
+    const onSelection = vi.fn();
+
+    backend.subscribe('selection:changed', onSelection);
+
+    emit({ type: 'model:loaded', data: { id: 'arch' } });
+    expect(onSelection).not.toHaveBeenCalled();
+
+    emit({ type: 'selection:changed', data: [1, 2] });
+    expect(onSelection).toHaveBeenCalledTimes(1);
+    expect(onSelection).toHaveBeenCalledWith([1, 2]);
+  });
+
+  it('hands back an unsubscribe that stops delivery', () => {
+    const { transport, emit } = fakeTransport();
+    const backend = new RemoteBackend(transport);
+    const handler = vi.fn();
+
+    const off = backend.subscribe('model:loaded', handler);
+    emit({ type: 'model:loaded', data: 1 });
+    off();
+    emit({ type: 'model:loaded', data: 2 });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/sdk/src/transport/transport.test.ts
+++ b/packages/sdk/src/transport/transport.test.ts
@@ -172,10 +172,18 @@ describe('BroadcastTransport', () => {
     await assertion;
   });
 
-  it('does not time out a request that was already answered', async () => {
+  // Advancing the clock past an answered request proves nothing on its
+  // own: rejecting an already-resolved promise is a no-op, so deleting
+  // `clearTimeout(entry.timer)` leaves this green. The timer *count* is
+  // the observable — without the clear, every answered request leaves a
+  // live timer holding its reject closure for the full timeout.
+  it('does not time out a request that was already answered, and clears its timer', async () => {
     const t = new BroadcastTransport('ifc-lite', { timeoutMs: 50 });
     const p = t.send(request('r1'));
+    expect(vi.getTimerCount()).toBe(1);
+
     channels[0].deliver({ id: 'r1', result: 1 } satisfies SdkResponse);
+    expect(vi.getTimerCount()).toBe(0);
 
     await expect(p).resolves.toEqual({ id: 'r1', result: 1 });
     await vi.advanceTimersByTimeAsync(1_000); // must not throw an unhandled rejection
@@ -232,6 +240,19 @@ describe('MessagePortTransport', () => {
 
     port.deliver({ id: 'r1', error: { message: 'boom' } } satisfies SdkResponse);
     await expect(p).resolves.toEqual({ id: 'r1', error: { message: 'boom' } });
+  });
+
+  // Same gap as the BroadcastTransport case above: the timer count is
+  // the only observable that `clearTimeout(entry.timer)` still runs.
+  it('clears the request timer once the response arrives', async () => {
+    const { t, port } = setup({ timeoutMs: 50 });
+    const p = t.send(request('r1'));
+    expect(vi.getTimerCount()).toBe(1);
+
+    port.deliver({ id: 'r1', result: 'ok' } satisfies SdkResponse);
+    expect(vi.getTimerCount()).toBe(0);
+
+    await expect(p).resolves.toEqual({ id: 'r1', result: 'ok' });
   });
 
   it('routes events to subscribers, not to pending requests', () => {

--- a/packages/sdk/src/types.test.ts
+++ b/packages/sdk/src/types.test.ts
@@ -1,0 +1,86 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `EntityRef` ⇄ `EntityRefString` codec.
+ *
+ * Both functions are exported from the package root and documented as
+ * the transport encoding external tools use — and neither had a single
+ * test in this package: swapping the two halves of `entityRefToString`,
+ * or dropping the empty-modelId and negative-expressId guards in
+ * `stringToEntityRef`, left the whole SDK suite green. (`apps/viewer`
+ * has a same-named pair under `src/store/types.ts`; that is the
+ * viewer's own copy and does not exercise this one.)
+ */
+
+import { describe, expect, it } from 'vitest';
+import { entityRefToString, stringToEntityRef } from './types.js';
+import type { EntityRef } from './types.js';
+
+describe('entityRefToString', () => {
+  it('emits modelId first and expressId second', () => {
+    expect(entityRefToString({ modelId: 'arch', expressId: 42 })).toBe('arch:42');
+  });
+
+  it('is not symmetric — a numeric-looking modelId still comes first', () => {
+    // Pins the field order independently of the round-trip test below,
+    // which a swapped implementation would still satisfy.
+    expect(entityRefToString({ modelId: '7', expressId: 42 })).toBe('7:42');
+  });
+
+  it('encodes expressId 0', () => {
+    expect(entityRefToString({ modelId: 'm', expressId: 0 })).toBe('m:0');
+  });
+});
+
+describe('stringToEntityRef', () => {
+  it('decodes a plain reference', () => {
+    expect(stringToEntityRef('arch:42')).toEqual({ modelId: 'arch', expressId: 42 });
+  });
+
+  it('accepts expressId 0', () => {
+    expect(stringToEntityRef('m:0')).toEqual({ modelId: 'm', expressId: 0 });
+  });
+
+  // `idx < 1` (not `idx < 0`): a leading colon means an empty modelId,
+  // which is not a usable reference in a federated model set. Relaxing
+  // the guard produced `{ modelId: '', expressId: 42 }` silently.
+  it('rejects an empty modelId', () => {
+    expect(() => stringToEntityRef(':42')).toThrow(/Invalid EntityRefString/);
+  });
+
+  it('rejects a string with no separator', () => {
+    expect(() => stringToEntityRef('arch')).toThrow(/Invalid EntityRefString/);
+  });
+
+  it('rejects the empty string', () => {
+    expect(() => stringToEntityRef('')).toThrow(/Invalid EntityRefString/);
+  });
+
+  it('rejects a non-numeric expressId', () => {
+    expect(() => stringToEntityRef('arch:abc')).toThrow(/Invalid expressId/);
+  });
+
+  // The `expressId < 0` half of the guard: express IDs are STEP line
+  // numbers and are never negative. Without it "arch:-1" decoded to a
+  // ref no backend can resolve.
+  it('rejects a negative expressId', () => {
+    expect(() => stringToEntityRef('arch:-1')).toThrow(/Invalid expressId/);
+  });
+
+  it('rejects a non-finite expressId', () => {
+    expect(() => stringToEntityRef('arch:Infinity')).toThrow(/Invalid expressId/);
+    expect(() => stringToEntityRef('arch:NaN')).toThrow(/Invalid expressId/);
+  });
+});
+
+describe('EntityRef round trip', () => {
+  it.each<EntityRef>([
+    { modelId: 'arch', expressId: 42 },
+    { modelId: 'm', expressId: 0 },
+    { modelId: '7', expressId: 9 },
+  ])('round-trips %o', (ref) => {
+    expect(stringToEntityRef(entityRefToString(ref))).toEqual(ref);
+  });
+});


### PR DESCRIPTION
Second, deeper mutation sweep of `packages/extensions` (the capability/permission boundary) and `packages/sdk` (the published API surface). **Test-only — no production code changed.**

## Measurement

| | baseline | final |
|---|---|---|
| `packages/extensions` | 53 files / 603 tests | 59 files / 770 tests |
| `packages/sdk` | 6 files / 69 tests | 9 files / 147 tests |

Clean before and after; no pre-existing failures, no skips (fixture-gated or otherwise) in either package.

**67 probative mutations. 23 KILLED, 44 SURVIVED — kill ratio 34%.** TARGETED: the mutations were aimed at modules with no test file or a test file far thinner than the source. Two controls (`matchCapability`'s scope check, `dispatchToBackend`'s own-property method gate) died as expected before any survivor was believed.

Every survivor was re-confirmed with `dist` rebuilt and the mutations applied, against `packages/cli` (25 files / 271 tests), `packages/mcp` (23 / 231), `packages/sandbox` (12 / 71) and `apps/viewer` (703 files / 2748 tests) — all still green, so none was a false survivor.

## `packages/extensions`

### The manifest validator was the largest hole

`manifest.test.ts` drives `validateManifest` through fixture files and asserts only `result.ok`. That shape is satisfied by *any* error, so a fixture testing "bad id" is equally satisfied by an unrelated one — it pins almost none of the individual field rules. Twelve independent rules could be disabled with all 603 tests green:

| # | Surviving mutation | What a user would see | Killing test |
|---|---|---|---|
| M1 | `ID_RE` → case-insensitive | An uppercase id installs, breaking the lowercase canonical-id guarantee the message and the RFC both promise. The only bad-id fixture is `"BAD ID WITH SPACES"`, rejected either way. | `validate.test.ts` › rejects an id with uppercase letters |
| M2 | `ENGINE_RANGE_RE` gate → `false` | `"engines": { "ifcLiteSdk": "latest" }` passes validation and reaches the host's SemVer comparison. | › rejects a range containing characters no SemVer range can contain |
| M3 | blank engine-range check dropped | A whitespace-only range validates. | › rejects a range string that is only whitespace |
| M6 | `requireString`'s `trim()` check → `false` | A manifest whose `name` is `"   "` installs with an invisible display name. | › rejects a whitespace-only "name"/"description"/"id"/"version" |
| M7 | `optionalString` type gate → `false` | Both call sites (`license`, `readme`) unguarded. | › rejects a non-string "license"/"readme" |
| M8 | `tests[].name/command/fixture` blank check dropped | | › rejects a blank test name / command / fixture |
| M9 | `l10n` value type check → `false` | | › rejects a non-string translation value |
| M10 | `author.url`/`email` type checks → `false` | | › rejects a non-string author.url / author.email |
| M11 | `entry.activate`/`deactivate` type check → `false` | | › rejects a non-string entry.activate / entry.deactivate |
| M4 | cross-ref ignores `entry.commands` | A valid manifest whose toolbar button points at a command declared only in `entry.commands` is **rejected**. Only the negative direction was pinned. | `cross-ref.test.ts` › accepts a reference satisfied only by entry.commands |
| M5 | statusBar `if (sb.command)` guard dropped | A statusBar item with no command (a plain text indicator, which is valid) is **rejected** as a dangling reference. | › accepts a statusBar item with no command at all |
| M12 | `isKnownCapability` → `return true` | Two repo-wide occurrences — definition plus barrel re-export. Published, never called by a test. Every uncatalogued capability reads as known, which is exactly the "unknown capability is red" story `risk.ts` leans on. | `catalogue.test.ts` › rejects the uncatalogued capability "…" (7 cases, measured per case) |

### Contribution field requirements

Only two contribution rules were covered by fixtures (a bad slot and a malformed `when`). These survived:

| # | Surviving mutation | Killing test |
|---|---|---|
| E35 | `keybindings[].key` requirement removed — the host has nothing to bind, the contribution is silently inert | `contributions.test.ts` › requires the key stroke |
| E36 | `exporters[].mimeType` requirement removed — an export contribution produces a file the browser cannot type | › requires "mimeType" |
| E37 | `statusBar[].text` requirement removed | › requires "text" |
| E38 | `commands[].title` requirement removed | › requires id and title on every command |
| E44 | `toolbar.center` dropped from the slot allow-list — the valid fixtures only ever use `toolbar.left`/`right`, so a documented slot silently stopped being accepted | › accepts the documented slot "toolbar.center" |

### `when` evaluator — the guards a third-party clause runs against

`when` clauses come out of an extension manifest and decide whether a contribution is shown.

| # | Surviving mutation | Killing test |
|---|---|---|
| E16 | v1 context allow-list gate → `false` | `when/eval.test.ts` › ignores a context key outside the v1 vocabulary even when present |
| E17 | `hasOwnProperty(ctx, name)` → `name in ctx` — a `Object.create(defaults)` context would resolve inherited keys | › does not resolve an allow-listed key inherited from the prototype |
| E18 | empty string coerces to `true` | › treats the empty string as false and a non-empty string as true |
| E19 | boolean ordering rejection dropped — `true > false` becomes satisfiable. Mixed boolean/number is caught by the later `typeof left !== typeof right` check, so only **two booleans** pin this guard; the first version of this test was non-probative and was narrowed. | › returns false when both sides of an ordering are booleans |

### Signing, code validation, SDK-version matching

| # | Surviving mutation | Killing test |
|---|---|---|
| E13 | `self` removed from `BANNED_GLOBALS` — the one worker-realm alias of the global object, and the only entry in the set with no test | `code.test.ts` › rejects self, the worker-realm alias… (+ a per-name case for all five) |
| E43 | `writeLengthPrefix` writes constant bytes — the serialisation stops being injective, so two different bundles can share a content hash and therefore a signature. The existing "old separator bytes" test does not reach this: its inputs differ in segment *count*, so a constant prefix still separates them. | `signing.test.ts` › is injective when the path/content boundary shifts |
| E24 | version suffix group `(?:[.-].*)?` → `(?:.*)?` — `">=2abc"` parses as `2.0.0` instead of falling through to `permissive` for the user to confirm | `sdk-version.test.ts` › does not parse a version with junk glued onto a numeric segment |

Signing and SDK-version matching were otherwise **well covered**: 12 of 20 mutations in that batch died, including every `verifyBundle` gate, the base64 strict-format check, the canonical sort, and the caret/tilde/wildcard range rules.

## `packages/sdk`

Six test files covered thirty source files. `context.test.ts` reaches query/export/files/viewer/mutate/lens/spatial/store; everything else was unexercised. **18 of 21 mutations survived.**

| # | Surviving mutation | What an external consumer would see | Killing test |
|---|---|---|---|
| S3 | `entityRefToString` emits `expressId:modelId` | The documented transport encoding is silently reversed. (`apps/viewer` has its own same-named pair under `src/store/types.ts`; it does not exercise this one.) | `types.test.ts` › emits modelId first and expressId second |
| S1 | `stringToEntityRef` `idx < 1` → `idx < 0` | `":42"` decodes to `{ modelId: '', expressId: 42 }` | › rejects an empty modelId |
| S2 | negative-expressId guard dropped | `"arch:-1"` decodes to a ref no backend resolves | › rejects a negative expressId |
| S4 | `ModelNamespace.active()` null guard → `false` | | `namespaces.test.ts` › active() returns null when no model is active, without consulting the list |
| S5 | `loadIfc` filename default `'created.ifc'` → `''` | | › loadIfc() defaults the filename to created.ifc |
| S6 | `QueryBuilder.first()` does not restore the caller's limit | A builder reused after `first()` silently returns one row | › first() restores the caller-supplied limit afterwards |
| S7 | `where()` default operator `'exists'` → `'='` | A two-arg `where()` changes meaning | › defaults the comparison operator to "exists" |
| S9 | `containedIn()` picks the last related ref, not the first | A script reports a different storey | › containedIn() resolves the first related ref, not the last |
| S10 | 3-arg `quantity()` ignores the qset name | The 3-arg form degenerates into the 2-arg form and returns whichever set comes first | › 3-arg form honours the qset name |
| S12 | `EventsNamespace.on` unsubscribe leaves its map entry | The backend sees a double unsubscribe for every handler the caller released itself | › does not re-run an unsubscribe that the caller already invoked |
| S13 | `removeAll()` clears the map without calling the unsubscribes | Every listener leaks | › removeAll() calls every outstanding unsubscribe |
| S14 | `SpacesNamespace` missing-backend gate → `false` | A transport-backed context gets "cannot read properties of undefined" instead of the actionable message | › throws an explanatory error when the backend has no spaces support |
| S15 | `schedule.tasks()` routed at `schedule.sequences()` | The four accessors have identical signatures, so a mis-wired one is invisible without a per-method assertion | › routes each accessor to the matching backend method |
| S16 | `BroadcastTransport` default timeout `30_000` → `1` | | `transport.test.ts` › times out an unanswered request after the 30s default |
| S17 | `close()` no longer rejects in-flight requests | A pending `send()` hangs for the full timeout after the channel is gone | › rejects in-flight requests when the transport is closed |
| S18 | `MessagePortTransport` response discrimination drops `'error' in data` | An **error reply** stops resolving the caller and is handed to event subscribers instead; the caller hangs until timeout | › resolves a pending request from an error-only response |
| S21 | `RemoteBackend.subscribe` drops the event-type filter | A handler registered for `selection:changed` receives every event | › delivers only the subscribed event type |

`BroadcastTransport`, `MessagePortTransport` and `RemoteBackend` are stubbed at the `BroadcastChannel`/`MessagePort` level rather than module-mocked, so the real constructor / `postMessage` / `onmessage` wiring is exercised.

## Survivors not closed

- **S20** — `ListNamespace.execute()`'s `modelId ?? 'default'`. `list.ts` loads `@ifc-lite/lists` through a dynamic `import()` with a variable specifier, which `vi.mock` cannot intercept; closing it needs a module-loading harness this PR does not introduce. Genuine gap, left open.
- **E29** — `canonicalContentHash` dropping the *path* length-prefix write. This desynchronises the write offsets rather than expressing a single property, so it is only detectable by pinning a golden hash vector (none exists, deliberately). The injectivity property it aims at is now covered by E43's test. Reported, not closed.
- **E31 / E31b** — `migrateManifest` dropping `!Number.isInteger(rawVersion)` and/or `rawVersion < 1`. **EQUIVALENT, and proven**: with `CURRENT_MANIFEST_VERSION === 1`, any non-integer above 1 is rejected by the future-version check, and anything below 1 falls into the migration loop, finds no chain entry and is rejected with the same `invalid_manifest_version` code. It stops being equivalent the moment a v2 lands, so `migrations.test.ts` asserts the error *code and path* — properties that hold either way — rather than the specific branch.

## Weak-shaped existing tests found

- `manifest.test.ts`'s two fixture loops assert only `result.ok`. The invalid-fixture loop is the "property that holds whether or not the code does the thing" shape: an unrelated error satisfies a fixture named for a specific rule. This is what let all twelve validator rules go unpinned. Left in place; the new files sit alongside and assert a specific `code` at a specific `path`.
- `canonicalContentHash`'s injectivity test targets a scheme that no longer exists (the `0x1f`/`0x1e` separators), and its fixtures differ in segment count — so it does not exercise the length prefix that replaced them.

## Production issues found — reported, not fixed

None were changed, and no new test asserts either side of them.

1. **`stringToEntityRef('arch:')` decodes to `{ modelId: 'arch', expressId: 0 }`.** `Number('')` is `0`, which clears both `Number.isFinite` and `>= 0`. A trailing-colon reference silently resolves to entity #0 rather than being rejected. (`packages/sdk/src/types.ts:40`)
2. **The `EntityRef` codec is lossy for a `modelId` containing `:`.** `entityRefToString` emits `arch:v2:1` without escaping; `stringToEntityRef` splits on the *first* colon and then throws `Invalid expressId`. Encode and decode disagree. (`packages/sdk/src/types.ts:29`, `:36`)
3. **`VERSION_PARSE_RE`'s comment contradicts its behaviour.** It reads "Reject 4+ dotted segments outright — silent truncation of `1.2.3.4` to `1.2.3` would hide manifest typos", but the trailing `(?:[.-].*)?` group swallows the extra segments: `1.2.3.4` parses as `1.2.3`, and `>=2.0.0nope` backtracks into a match and evaluates as `>=2.0.0`. Either the comment or the regex is wrong. (`packages/extensions/src/host/sdk-version.ts:61`)

## Pre-existing typecheck errors

`pnpm typecheck` covers 2 of 40 packages and the root tsconfig excludes `**/*.test.ts`, so each package was typechecked separately against its own options with the exclusion lifted, and `--listFiles` verified the test files entered the program (58 of them for extensions, 9 for sdk — not vacuous).

- `packages/extensions` — 1 error, pre-existing: `src/flavor/switcher.test.ts:17` (`FlavorExtension` literal missing `source`, `bundleHash`, `enabled`).
- `packages/sdk` — 31 errors, all pre-existing: 28 in `src/context.test.ts` (mock backend missing `loadIfc` / `entitiesMatchingActiveFilter`, partial `Transport`, `never[]` inference), 3 in `src/sandbox.test.ts`.

All twelve files in this PR typecheck clean. Nothing pre-existing was fixed.
