### PR TITLE
feat(renderer): model-tagged instanced-template storage (step 1 of 2 for #1912 / #2073)

### DIFF
--- a/.changeset/model-tagged-instanced-templates.md
+++ b/.changeset/model-tagged-instanced-templates.md
@@ -1,0 +1,9 @@
+---
+'@ifc-lite/renderer': minor
+---
+
+Model-tagged instanced-template storage in `Scene`. `InstancedTemplateGPU` now carries a `modelIndex`, `addInstancedShard(device, shard, modelIndex = 0)` takes the owning model, and the new `removeInstancedTemplatesForModel(modelIndex)` frees exactly that model's GPU buffers and occurrences. Template slots are stable — a removal blanks its slots instead of splicing, so no other model's `templateIndex` shifts — and `getInstancedModelIndices()` reports which models hold templates. `getResidentGpuBytes()` counts live templates only.
+
+Also fixes a latent slot misalignment: after `releaseGeometryData()` a subsequently uploaded shard's CPU template landed at CPU index 0 instead of its GPU slot, so CPU consumers (raycast / measure / section / export) could read a different template's triangles than the occurrence named.
+
+Behaviour is unchanged for existing callers (`modelIndex` defaults to 0 and the single `addInstancedShard` call site does not pass one).

--- a/packages/renderer/src/scene-instanced-model-scope.test.ts
+++ b/packages/renderer/src/scene-instanced-model-scope.test.ts
@@ -159,6 +159,22 @@ describe('Scene instanced templates are model-tagged', () => {
     scene.removeInstancedTemplatesForModel(3);
     assert.deepStrictEqual([...scene.getInstancedModelIndices()], [7]);
   });
+
+  it('reports ownership even while the instanced pass is hidden (Types view)', () => {
+    // The documented difference from `getInstancedTemplates()`: hiding the
+    // pass must not change who OWNS templates, or a Types-view toggle would
+    // make a per-model teardown think the model holds nothing. Adding the
+    // `instancedVisible` early-return to `getInstancedModelIndices` survived
+    // the suite before this assertion existed (measured).
+    const { scene } = twoModelScene();
+    scene.setInstancedVisible(false);
+    assert.strictEqual(scene.getInstancedTemplates().length, 0, 'the pass is hidden');
+    assert.deepStrictEqual(
+      [...scene.getInstancedModelIndices()].sort((a, b) => a - b), [3, 7]);
+    // …and a removal taken while hidden is still model-scoped.
+    assert.strictEqual(scene.removeInstancedTemplatesForModel(3), 2);
+    assert.deepStrictEqual([...scene.getInstancedModelIndices()], [7]);
+  });
 });
 
 describe('Scene.removeInstancedTemplatesForModel — index stability', () => {
@@ -324,6 +340,33 @@ describe('Scene.removeInstancedTemplatesForModel — entity bookkeeping', () => 
 
     scene.removeInstancedTemplatesForModel(3);
     assert.deepStrictEqual([...(scene['instancedSelected'] as Set<number>)], [42]);
+  });
+
+  it('drops the HIDDEN and OVERRIDE bookkeeping too, not just the selection', () => {
+    // Selection is one of three sibling sets pruned on the same lines. With
+    // only `instancedSelected` asserted, deleting the `instancedHidden` /
+    // `instancedOverridden` lines survives the suite (measured) — and a stale
+    // entry there means a re-loaded model's occurrence of the same express id
+    // comes back invisible or wearing a dead lens colour.
+    const scene = new Scene();
+    const { device } = fakeDevice();
+    scene.addInstancedShard(device, shard(2, [42, 11]), 3);
+    scene.addInstancedShard(device, shard(3, [42, 21, 22]), 7);
+
+    // 11 exists only in model 3; 42 is shared, so it must survive all three.
+    scene.setInstancedVisibility(new Set([11, 42]), null);
+    scene.setInstancedColorOverrides(new Map<number, readonly [number, number, number, number]>([
+      [11, [1, 0, 0, 1]],
+      [42, [0, 1, 0, 1]],
+    ]));
+    assert.deepStrictEqual(
+      [...(scene['instancedHidden'] as Set<number>)].sort((a, b) => a - b), [11, 42]);
+    assert.deepStrictEqual(
+      [...(scene['instancedOverridden'] as Set<number>)].sort((a, b) => a - b), [11, 42]);
+
+    scene.removeInstancedTemplatesForModel(3);
+    assert.deepStrictEqual([...(scene['instancedHidden'] as Set<number>)], [42]);
+    assert.deepStrictEqual([...(scene['instancedOverridden'] as Set<number>)], [42]);
   });
 
   it('decrements the surviving templates\' selectedCount only for pruned occurrences', () => {

--- a/packages/renderer/src/scene-instanced-model-scope.test.ts
+++ b/packages/renderer/src/scene-instanced-model-scope.test.ts
@@ -1,0 +1,341 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { Scene } from './scene.js';
+import type { DecodedInstancedShard } from '@ifc-lite/geometry';
+
+/**
+ * Model-scoped instanced-template storage (Refs #1912, #2073).
+ *
+ * A template is identified by `(modelIndex, templateIndex)`, where
+ * `templateIndex` is a STABLE slot in the scene's template array rather than a
+ * position in a densely-packed list. The properties pinned here are the ones a
+ * federated load and a per-model teardown both depend on:
+ *
+ *  - adding or removing one model's templates never shifts another model's
+ *    `templateIndex` values (occurrences hold those by value);
+ *  - removing a model frees exactly its own GPU handles and no others;
+ *  - `getResidentGpuBytes()` stays exact across add/remove;
+ *  - a shared express id (two models, same id — the federated case) loses only
+ *    the removed model's occurrences.
+ *
+ * Every structural test uses TWO models with DIFFERENT template counts, so a
+ * model tag can never be mistaken for a global array position.
+ *
+ * The buffer allocation itself needs no real GPU: `addInstancedShard` only asks
+ * the device for sized, mapped buffers, so a recording stub exercises the real
+ * interleave / bounds-fold / entity-map code and lets us assert on the exact
+ * handles destroyed. The draw + pick passes need a real context and stay in the
+ * browser/E2E lanes.
+ */
+
+// WebGPU enum globals used by Scene buffer creation (not defined in node) —
+// same stub the other renderer tests install.
+(globalThis as Record<string, unknown>).GPUBufferUsage = {
+  MAP_READ: 1, MAP_WRITE: 2, COPY_SRC: 4, COPY_DST: 8, INDEX: 16,
+  VERTEX: 32, UNIFORM: 64, STORAGE: 128, INDIRECT: 256, QUERY_RESOLVE: 512,
+};
+
+interface FakeBuffer {
+  size: number;
+  destroyed: number;
+  getMappedRange(): ArrayBuffer;
+  unmap(): void;
+  destroy(): void;
+}
+
+function fakeDevice(): { device: GPUDevice; created: FakeBuffer[] } {
+  const created: FakeBuffer[] = [];
+  const device = {
+    limits: { maxBufferSize: 1 << 30, maxStorageBufferBindingSize: 1 << 30 },
+    createBuffer: (desc: { size: number }) => {
+      const backing = new ArrayBuffer(desc.size);
+      const buf: FakeBuffer = {
+        size: desc.size,
+        destroyed: 0,
+        getMappedRange: () => backing,
+        unmap() {},
+        destroy() { this.destroyed++; },
+      };
+      created.push(buf);
+      return buf;
+    },
+    queue: { writeBuffer: () => {} },
+  };
+  return { device: device as unknown as GPUDevice, created };
+}
+
+/** Row-major translation mat4 (the `DecodedInstance.transform` convention). */
+function rowMajorTranslation(x: number, y: number, z: number): Float32Array {
+  return new Float32Array([
+    1, 0, 0, x,
+    0, 1, 0, y,
+    0, 0, 1, z,
+    0, 0, 0, 1,
+  ]);
+}
+
+/**
+ * A shard with `templateCount` distinct unit triangles, one opaque occurrence
+ * each, entity ids taken from `entityIds` (occurrence i belongs to template i).
+ * Template i gets i+1 triangles so the templates differ in buffer size — a
+ * uniform size would let a byte-accounting bug pass by coincidence.
+ */
+function shard(templateCount: number, entityIds: number[]): DecodedInstancedShard {
+  const templates = [];
+  const instances = [];
+  for (let t = 0; t < templateCount; t++) {
+    const tris = t + 1;
+    const positions = new Float32Array(tris * 9);
+    const normals = new Float32Array(tris * 9);
+    const indices = new Uint32Array(tris * 3);
+    for (let k = 0; k < tris; k++) {
+      positions.set([0, 0, 0, 1, 0, 0, 0, 1, 0], k * 9);
+      normals.set([0, 0, 1, 0, 0, 1, 0, 0, 1], k * 9);
+      indices.set([k * 3, k * 3 + 1, k * 3 + 2], k * 3);
+    }
+    templates.push({ positions, normals, indices, origin: [0, 0, 0] as [number, number, number] });
+    instances.push({
+      templateIndex: t,
+      entityId: entityIds[t],
+      color: [1, 1, 1, 1] as [number, number, number, number],
+      transform: rowMajorTranslation(t, 0, 0),
+    });
+  }
+  return { templates, instances };
+}
+
+/** The `(modelIndex, slot)` pairs of every live template, in slot order. */
+function liveTags(scene: Scene): Array<[number, number]> {
+  const slots = scene['instancedTemplates'] as ReadonlyArray<{ modelIndex: number } | undefined>;
+  const out: Array<[number, number]> = [];
+  for (let i = 0; i < slots.length; i++) {
+    const t = slots[i];
+    if (t) out.push([t.modelIndex, i]);
+  }
+  return out;
+}
+
+/** Occurrence slots recorded for `expressId`, in insertion order. */
+function occSlots(scene: Scene, expressId: number): number[] {
+  const map = scene['instancedEntityMap'] as Map<number, Array<{ templateIndex: number }>>;
+  return (map.get(expressId) ?? []).map((o) => o.templateIndex);
+}
+
+/** Two models: model 3 has 2 templates (ids 10, 11), model 7 has 3 (ids 20, 21, 22). */
+function twoModelScene() {
+  const scene = new Scene();
+  const { device, created } = fakeDevice();
+  scene.addInstancedShard(device, shard(2, [10, 11]), 3);
+  const afterFirst = created.length;
+  scene.addInstancedShard(device, shard(3, [20, 21, 22]), 7);
+  return { scene, device, created, modelA: created.slice(0, afterFirst), modelB: created.slice(afterFirst) };
+}
+
+describe('Scene instanced templates are model-tagged', () => {
+  it('tags each uploaded template with its owning model and keeps both models resident', () => {
+    const { scene } = twoModelScene();
+    assert.deepStrictEqual(liveTags(scene), [[3, 0], [3, 1], [7, 2], [7, 3], [7, 4]]);
+    assert.strictEqual(scene.getInstancedTemplates().length, 5);
+    assert.deepStrictEqual(
+      scene.getInstancedTemplates().map((t) => t.modelIndex),
+      [3, 3, 7, 7, 7],
+    );
+  });
+
+  it('defaults the model tag to 0 when the caller does not pass one', () => {
+    const scene = new Scene();
+    const { device } = fakeDevice();
+    scene.addInstancedShard(device, shard(2, [1, 2]));
+    assert.deepStrictEqual(scene.getInstancedTemplates().map((t) => t.modelIndex), [0, 0]);
+  });
+
+  it('reports the model indices that currently hold templates', () => {
+    const { scene } = twoModelScene();
+    assert.deepStrictEqual([...scene.getInstancedModelIndices()].sort((a, b) => a - b), [3, 7]);
+    scene.removeInstancedTemplatesForModel(3);
+    assert.deepStrictEqual([...scene.getInstancedModelIndices()], [7]);
+  });
+});
+
+describe('Scene.removeInstancedTemplatesForModel — index stability', () => {
+  it('does not shift the surviving model\'s template slots', () => {
+    const { scene } = twoModelScene();
+    const before = scene.getInstancedTemplates().filter((t) => t.modelIndex === 7);
+    const slotsBefore = [occSlots(scene, 20), occSlots(scene, 21), occSlots(scene, 22)];
+    assert.deepStrictEqual(slotsBefore, [[2], [3], [4]]);
+
+    assert.strictEqual(scene.removeInstancedTemplatesForModel(3), 2);
+
+    // Occurrence records hold slots BY VALUE; they must still name the same
+    // templates, by identity, not merely by index.
+    assert.deepStrictEqual([occSlots(scene, 20), occSlots(scene, 21), occSlots(scene, 22)], slotsBefore);
+    const slots = scene['instancedTemplates'] as ReadonlyArray<unknown>;
+    assert.strictEqual(slots[2], before[0]);
+    assert.strictEqual(slots[3], before[1]);
+    assert.strictEqual(slots[4], before[2]);
+    assert.deepStrictEqual(liveTags(scene), [[7, 2], [7, 3], [7, 4]]);
+  });
+
+  it('does not shift existing slots when a further model is added after a removal', () => {
+    const { scene, device } = twoModelScene();
+    scene.removeInstancedTemplatesForModel(3);
+    scene.addInstancedShard(device, shard(1, [30]), 9);
+
+    assert.deepStrictEqual([occSlots(scene, 20), occSlots(scene, 21), occSlots(scene, 22)], [[2], [3], [4]]);
+    // The new model takes a fresh slot — a freed slot is never recycled, so a
+    // stale occurrence reference can never resolve to a different model's template.
+    assert.deepStrictEqual(occSlots(scene, 30), [5]);
+    assert.deepStrictEqual(liveTags(scene), [[7, 2], [7, 3], [7, 4], [9, 5]]);
+  });
+
+  it('keeps the CPU template array aligned with the GPU slots after a removal', () => {
+    const { scene } = twoModelScene();
+    scene.removeInstancedTemplatesForModel(3);
+    const cpu = scene['instancedTemplateCpu'] as ReadonlyArray<{ indices: Uint32Array } | undefined>;
+    assert.strictEqual(cpu[0], undefined);
+    assert.strictEqual(cpu[1], undefined);
+    // Model 7's templates carry 1, 2 and 3 triangles at slots 2, 3, 4.
+    assert.deepStrictEqual([cpu[2]?.indices.length, cpu[3]?.indices.length, cpu[4]?.indices.length], [3, 6, 9]);
+  });
+
+  it('keeps CPU templates slot-aligned after releaseGeometryData() drops them', () => {
+    // releaseGeometryData() empties the CPU template array while the GPU slots
+    // live on. A shard uploaded afterwards must land on its GPU slot, not at
+    // CPU index 0 — otherwise every CPU consumer (raycast / measure / section /
+    // export) reads a different template's triangles than the occurrence names.
+    const { scene, device } = twoModelScene();
+    scene.releaseGeometryData();
+    scene.addInstancedShard(device, shard(1, [30]), 9);
+
+    assert.deepStrictEqual(occSlots(scene, 30), [5]);
+    const cpu = scene['instancedTemplateCpu'] as ReadonlyArray<{ indices: Uint32Array } | undefined>;
+    assert.strictEqual(cpu[0], undefined, 'the new template must not squat on a released slot');
+    assert.strictEqual(cpu[5]?.indices.length, 3);
+    assert.strictEqual(scene.getInstancedMeshDataPieces(30)?.length, 1);
+  });
+});
+
+describe('Scene.removeInstancedTemplatesForModel — disposal', () => {
+  it('destroys exactly the removed model\'s GPU handles, once each', () => {
+    const { scene, modelA, modelB } = twoModelScene();
+    assert.strictEqual(modelA.length, 6, '2 templates x (vertex, index, instance)');
+    assert.strictEqual(modelB.length, 9, '3 templates x (vertex, index, instance)');
+
+    scene.removeInstancedTemplatesForModel(3);
+
+    assert.deepStrictEqual(modelA.map((b) => b.destroyed), [1, 1, 1, 1, 1, 1]);
+    assert.deepStrictEqual(modelB.map((b) => b.destroyed), [0, 0, 0, 0, 0, 0, 0, 0, 0]);
+  });
+
+  it('does not re-destroy an already-removed model\'s handles on clear()', () => {
+    const { scene, modelA, modelB } = twoModelScene();
+    scene.removeInstancedTemplatesForModel(3);
+    scene.clear();
+    assert.deepStrictEqual(modelA.map((b) => b.destroyed), [1, 1, 1, 1, 1, 1]);
+    assert.deepStrictEqual(modelB.map((b) => b.destroyed), [1, 1, 1, 1, 1, 1, 1, 1, 1]);
+    assert.strictEqual(scene.getInstancedTemplates().length, 0);
+  });
+
+  it('is a no-op for a model that holds no templates', () => {
+    const { scene, modelA, modelB } = twoModelScene();
+    assert.strictEqual(scene.removeInstancedTemplatesForModel(99), 0);
+    assert.deepStrictEqual(modelA.map((b) => b.destroyed), [0, 0, 0, 0, 0, 0]);
+    assert.deepStrictEqual(modelB.map((b) => b.destroyed), [0, 0, 0, 0, 0, 0, 0, 0, 0]);
+    assert.deepStrictEqual(liveTags(scene), [[3, 0], [3, 1], [7, 2], [7, 3], [7, 4]]);
+  });
+
+  it('is a no-op on an empty scene', () => {
+    const scene = new Scene();
+    assert.strictEqual(scene.removeInstancedTemplatesForModel(0), 0);
+    assert.strictEqual(scene.getInstancedTemplates().length, 0);
+  });
+
+  it('leaves no live templates once the last model is removed', () => {
+    const { scene, modelA, modelB } = twoModelScene();
+    assert.strictEqual(scene.removeInstancedTemplatesForModel(3), 2);
+    assert.strictEqual(scene.removeInstancedTemplatesForModel(7), 3);
+    assert.strictEqual(scene.getInstancedTemplates().length, 0);
+    assert.deepStrictEqual([...scene.getInstancedModelIndices()], []);
+    assert.deepStrictEqual(modelA.concat(modelB).map((b) => b.destroyed), new Array(15).fill(1));
+    assert.strictEqual(scene.getResidentGpuBytes().instanced, 0);
+  });
+});
+
+describe('Scene.removeInstancedTemplatesForModel — GPU byte accounting', () => {
+  it('subtracts exactly the removed model\'s bytes and no others', () => {
+    const { scene, modelA, modelB } = twoModelScene();
+    const bytesA = modelA.reduce((n, b) => n + b.size, 0);
+    const bytesB = modelB.reduce((n, b) => n + b.size, 0);
+    assert.ok(bytesA > 0 && bytesB > 0 && bytesA !== bytesB, 'the two models must differ in size');
+    assert.strictEqual(scene.getResidentGpuBytes().instanced, bytesA + bytesB);
+
+    scene.removeInstancedTemplatesForModel(3);
+    assert.strictEqual(scene.getResidentGpuBytes().instanced, bytesB);
+
+    scene.removeInstancedTemplatesForModel(7);
+    assert.strictEqual(scene.getResidentGpuBytes().instanced, 0);
+  });
+
+  it('counts a model added after a removal without counting the freed slots', () => {
+    const { scene, device, modelB, created } = twoModelScene();
+    scene.removeInstancedTemplatesForModel(3);
+    const beforeAdd = created.length;
+    scene.addInstancedShard(device, shard(1, [30]), 9);
+    const bytesB = modelB.reduce((n, b) => n + b.size, 0);
+    const bytesC = created.slice(beforeAdd).reduce((n, b) => n + b.size, 0);
+    assert.strictEqual(scene.getResidentGpuBytes().instanced, bytesB + bytesC);
+  });
+});
+
+describe('Scene.removeInstancedTemplatesForModel — entity bookkeeping', () => {
+  it('drops the removed model\'s express ids and keeps the survivor\'s', () => {
+    const { scene } = twoModelScene();
+    scene.removeInstancedTemplatesForModel(3);
+    assert.strictEqual(scene.isInstancedEntity(10), false);
+    assert.strictEqual(scene.isInstancedEntity(11), false);
+    assert.strictEqual(scene.isInstancedEntity(20), true);
+    assert.strictEqual(scene.getInstancedEntityCount(), 3);
+  });
+
+  it('keeps a shared express id alive when only one model\'s occurrence is removed', () => {
+    const scene = new Scene();
+    const { device } = fakeDevice();
+    // The federated case before id offsetting: both models use express id 42.
+    scene.addInstancedShard(device, shard(2, [42, 11]), 3);
+    scene.addInstancedShard(device, shard(3, [42, 21, 22]), 7);
+    assert.deepStrictEqual(occSlots(scene, 42), [0, 2]);
+
+    scene.removeInstancedTemplatesForModel(3);
+    assert.strictEqual(scene.isInstancedEntity(42), true);
+    assert.deepStrictEqual(occSlots(scene, 42), [2], 'only model 3\'s occurrence is pruned');
+  });
+
+  it('drops selection/hidden/override bookkeeping only for ids that lost every occurrence', () => {
+    const scene = new Scene();
+    const { device } = fakeDevice();
+    scene.addInstancedShard(device, shard(2, [42, 11]), 3);
+    scene.addInstancedShard(device, shard(3, [42, 21, 22]), 7);
+    scene.setInstancedSelection(new Set([42, 11]));
+    assert.deepStrictEqual([...(scene['instancedSelected'] as Set<number>)].sort((a, b) => a - b), [11, 42]);
+
+    scene.removeInstancedTemplatesForModel(3);
+    assert.deepStrictEqual([...(scene['instancedSelected'] as Set<number>)], [42]);
+  });
+
+  it('decrements the surviving templates\' selectedCount only for pruned occurrences', () => {
+    const scene = new Scene();
+    const { device } = fakeDevice();
+    scene.addInstancedShard(device, shard(2, [42, 11]), 3);
+    scene.addInstancedShard(device, shard(3, [42, 21, 22]), 7);
+    scene.setInstancedSelection(new Set([42]));
+    const survivor = scene.getInstancedTemplates().find((t) => t.modelIndex === 7)!;
+    assert.strictEqual(survivor.selectedCount, 1);
+
+    scene.removeInstancedTemplatesForModel(3);
+    assert.strictEqual(survivor.selectedCount, 1, 'model 7 still owns a selected occurrence');
+  });
+});

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -110,6 +110,11 @@ function destroyGpuResources(
  * `drawIndexed(indexCount, instanceCount)`. Buffers are Scene-owned, freed in clear().
  */
 export interface InstancedTemplateGPU {
+  /** Owning model (federation index). Templates are identified by
+   *  `(modelIndex, slot)`, so one model's templates can be freed without
+   *  disturbing another's — see `removeInstancedTemplatesForModel`. Defaults to
+   *  0, the single-model / primary case. */
+  modelIndex: number;
   vertexBuffer: GPUBuffer;
   indexBuffer: GPUBuffer;
   indexCount: number;
@@ -135,6 +140,9 @@ const EMPTY_INSTANCED_TEMPLATES: readonly InstancedTemplateGPU[] = [];
 /** One occurrence's location in the instanced buffers, for per-instance selection
  *  + colour-override patching. originalColor restores after a lens/IDS overlay clears. */
 interface InstancedOccurrence {
+  /** STABLE slot in `instancedTemplates` / `instancedTemplateCpu` — never
+   *  reused after the slot is freed, so a stale reference resolves to a hole
+   *  rather than to another model's template. */
   templateIndex: number;
   byteOffset: number;
   originalColor: [number, number, number, number];
@@ -168,10 +176,23 @@ export class Scene {
    *  Refcounted: entries die when the last referencing mesh is removed / on clear(). */
   private sharedTextures = new Map<number, { texture: GPUTexture; refs: number }>();
   private texturedDevice?: GPUDevice;                               // #961: cached for textured-mesh re-upload on translate
-  private instancedTemplates: InstancedTemplateGPU[] = [];          // GPU-instancing: unique templates + per-occurrence buffers (fed by addInstancedShard)
+  /** GPU-instancing: unique templates + per-occurrence buffers (fed by
+   *  addInstancedShard). SLOT-STABLE and therefore SPARSE: a per-model removal
+   *  (`removeInstancedTemplatesForModel`) leaves `undefined` holes instead of
+   *  splicing, because `InstancedOccurrence.templateIndex` holds the slot by
+   *  value and a splice would silently repoint every later occurrence at the
+   *  wrong template. New templates always append at `length`; freed slots are
+   *  never recycled. Iterate `getInstancedTemplates()` (compacted, cached) for
+   *  the draw/pick/accounting walks — never this array directly. */
+  private instancedTemplates: (InstancedTemplateGPU | undefined)[] = [];
+  /** Compacted live view of `instancedTemplates`, rebuilt on mutation. */
+  private liveInstancedTemplates: InstancedTemplateGPU[] = [];
   private instancedVisible = true;                                  // GPU-instancing: hidden in Types view mode (instanced geometry is class-0 occurrences)
   private instancedEntityMap: Map<number, InstancedOccurrence[]> = new Map(); // express_id -> occurrences, for per-instance selection/overlay patching
-  private instancedTemplateCpu: InstancedTemplateCpu[] = [];        // compact CPU geometry per template (index-aligned with instancedTemplates) for CPU consumers
+  /** Compact CPU geometry per template, slot-aligned with `instancedTemplates`
+   *  (so equally sparse) for CPU consumers. Also emptied wholesale on geometry
+   *  release — every reader already tolerates a missing entry. */
+  private instancedTemplateCpu: (InstancedTemplateCpu | undefined)[] = [];
   private instancedDevice?: GPUDevice;                              // cached for per-instance flag/colour writeBuffer updates
   private instancedSelected: Set<number> = new Set();              // currently flag-selected instanced express_ids
   private instancedHidden: Set<number> = new Set();               // currently hidden instanced express_ids (hide/isolate)
@@ -2930,7 +2951,8 @@ export class Scene {
       partialBatches: this.partialBatchCache.values(),
       meshes: this.meshes,
       textured: this.texturedMeshes,
-      instanced: this.instancedTemplates,
+      // Live templates only — freed slots are holes with destroyed buffers.
+      instanced: this.liveInstancedTemplates,
     });
   }
 
@@ -2948,7 +2970,76 @@ export class Scene {
    *  hidden (Types view mode) so the draw loop skips it. */
   getInstancedTemplates(): readonly InstancedTemplateGPU[] {
     if (!this.instancedVisible) return EMPTY_INSTANCED_TEMPLATES;
-    return this.instancedTemplates;
+    return this.liveInstancedTemplates;
+  }
+
+  /** Rebuild the compacted live-template view after a slot add/remove. */
+  private refreshLiveInstancedTemplates(): void {
+    const live: InstancedTemplateGPU[] = [];
+    for (const t of this.instancedTemplates) {
+      if (t) live.push(t);
+    }
+    this.liveInstancedTemplates = live;
+  }
+
+  /** Model indices that currently own at least one instanced template. Unlike
+   *  `getInstancedTemplates()` this ignores the Types-view visibility toggle —
+   *  hiding the pass does not change who owns what. */
+  getInstancedModelIndices(): number[] {
+    const seen = new Set<number>();
+    for (const t of this.instancedTemplates) {
+      if (t) seen.add(t.modelIndex);
+    }
+    return [...seen];
+  }
+
+  /**
+   * Free every instanced template owned by `modelIndex`: destroy exactly its
+   * own vertex/index/instance buffers, blank its slots (leaving holes, so no
+   * other model's `templateIndex` shifts), prune its occurrences from
+   * `instancedEntityMap`, and drop the per-id selection/hidden/override
+   * bookkeeping for ids that lost their LAST occurrence. Express ids shared
+   * with another model — the federated case before id offsetting — keep the
+   * surviving model's occurrences.
+   *
+   * Returns the number of templates removed (0 for an unknown model, which is a
+   * no-op). Mirrors `removeInstancedEntity` in leaving `boundingBoxes` alone:
+   * an id can also own flat geometry, and the flat removal path owns that cache.
+   */
+  removeInstancedTemplatesForModel(modelIndex: number): number {
+    const freed = new Set<number>();
+    for (let i = 0; i < this.instancedTemplates.length; i++) {
+      const t = this.instancedTemplates[i];
+      if (!t || t.modelIndex !== modelIndex) continue;
+      t.vertexBuffer.destroy();
+      t.indexBuffer.destroy();
+      t.instanceBuffer.destroy();
+      this.instancedTemplates[i] = undefined;
+      this.instancedTemplateCpu[i] = undefined;
+      freed.add(i);
+    }
+    if (freed.size === 0) return 0;
+
+    for (const [eid, occurrences] of this.instancedEntityMap) {
+      const kept = occurrences.filter((o) => !freed.has(o.templateIndex));
+      if (kept.length === occurrences.length) continue;
+      if (kept.length > 0) {
+        this.instancedEntityMap.set(eid, kept);
+        continue;
+      }
+      // Last occurrence gone: the id is no longer instanced at all.
+      this.instancedEntityMap.delete(eid);
+      this.instancedSelected.delete(eid);
+      this.instancedHidden.delete(eid);
+      this.instancedOverridden.delete(eid);
+    }
+
+    this.refreshLiveInstancedTemplates();
+    // Occurrence population changed → force the next visibility pass to
+    // recompute rather than early-return on an unchanged id set.
+    this.lastInstancedVisibilityVersion = -1;
+    this.instancedVisibilityDirty = true;
+    return freed.size;
   }
 
   /**
@@ -2967,7 +3058,7 @@ export class Scene {
    * type-only dependency on @ifc-lite/geometry and the Scene stays focused on
    * GPU upload.
    */
-  addInstancedShard(device: GPUDevice, shard: DecodedInstancedShard): void {
+  addInstancedShard(device: GPUDevice, shard: DecodedInstancedShard, modelIndex = 0): void {
     this.instancedDevice = device; // cached for per-instance selection/overlay writeBuffer
     const prepared = prepareInstancedRender(shard);
     // Selected ids whose occurrences arrived in THIS shard (selection recorded
@@ -3023,8 +3114,10 @@ export class Scene {
       );
       instanceBuffer.unmap();
 
+      // Always append: slots are stable identities, never recycled.
       const templateIndex = this.instancedTemplates.length;
       const template: InstancedTemplateGPU = {
+        modelIndex,
         vertexBuffer,
         indexBuffer,
         indexCount: t.indices.length,
@@ -3034,7 +3127,7 @@ export class Scene {
         maxOccRadius: 0,
         selectedCount: 0,
       };
-      this.instancedTemplates.push(template);
+      this.instancedTemplates[templateIndex] = template;
 
       // Template-local AABB (used to derive per-occurrence world AABBs cheaply).
       let lmnx = Infinity, lmny = Infinity, lmnz = Infinity;
@@ -3047,14 +3140,16 @@ export class Scene {
       // Retain the compact CPU geometry + the packed instance records (mat4 per
       // occurrence) so CPU consumers can reach instanced geometry without a full
       // per-occurrence MeshData each. These are references into the decoded shard.
-      this.instancedTemplateCpu.push({
+      // Slot-assigned, not pushed: the CPU array is emptied on geometry release
+      // while the GPU slots live on, so `push` would silently misalign the two.
+      this.instancedTemplateCpu[templateIndex] = {
         positions: t.positions,
         normals: t.normals,
         indices: t.indices,
         instanceData: t.instanceBuffer,
         localMin: [lmnx, lmny, lmnz],
         localMax: [lmxx, lmxy, lmxz],
-      });
+      };
 
       // Map each occurrence's express_id -> (template, byte offset, original
       // colour) so selection (flag byte) + lens/IDS overlays (colour bytes) can
@@ -3101,6 +3196,7 @@ export class Scene {
         }
       }
     }
+    this.refreshLiveInstancedTemplates();
     // Write the selected flag for ids whose occurrences arrived after the
     // selection was recorded (idempotent for their pre-existing occurrences),
     // so the highlight shows on late-streamed geometry too.
@@ -3612,12 +3708,16 @@ export class Scene {
     for (const entry of this.sharedTextures.values()) entry.texture.destroy();
     this.sharedTextures.clear();
     // GPU-instancing templates own their vertex/index/instance buffers.
+    // (Freed slots are holes whose buffers are already destroyed — skip them so
+    // a per-model removal followed by clear() can't double-destroy.)
     for (const it of this.instancedTemplates) {
+      if (!it) continue;
       it.vertexBuffer.destroy();
       it.indexBuffer.destroy();
       it.instanceBuffer.destroy();
     }
     this.instancedTemplates = [];
+    this.liveInstancedTemplates = [];
     this.instancedTemplateCpu = [];
     this.instancedEntityMap.clear();
     this.instancedSelected.clear();


### PR DESCRIPTION
## Step one of two

Instanced templates lived in a single flat, globally-positional array with no notion of which model owned them. That missing primitive is what **both** #1912 and #2073 bottom out on:

- **#1912** — `useIfcLoader.ts` sets `enableInstancing: target.kind === 'primary'`, and the comment above it says why: a federated load must keep geometry flat, "else its opaque repeated occurrences would be partitioned into shards the federated path doesn't consume and silently dropped." Nothing could say "these templates belong to model N".
- **#2073** — `scene.clear()` destroys every template and nothing re-uploads them. The two obvious patches (keep templates across clears, or retain-and-re-upload) both make *hiding* a model leave its instanced geometry on screen — again because nothing can tell which templates belong to it.

This PR lands only the primitive. **It does not flip `enableInstancing` on for federated loads and does not change `scene.clear()`'s behaviour.** See "Step two" below.

## What now exists

A template is identified by `(modelIndex, slot)` rather than a bare global position:

- `InstancedTemplateGPU.modelIndex` records the owning model. `addInstancedShard(device, shard, modelIndex = 0)` stamps it.
- `removeInstancedTemplatesForModel(modelIndex)` — the per-model teardown `scene.ts` was missing entirely. Destroys exactly that model's vertex/index/instance buffers, blanks its slots, prunes its occurrences from `instancedEntityMap`, and drops per-id selection/hidden/override bookkeeping **only** for ids that lost their last occurrence. An express id shared by two models (the federated case before id offsetting) keeps the surviving model's occurrences.
- `getInstancedModelIndices()` reports which models hold templates.
- `getInstancedTemplates()` returns a cached compacted view; `getResidentGpuBytes()` counts live templates only.

### Design note: stable slots, not a reindex

The earlier design comment on #2073 proposed a filtered clear that splices and then reindexes every surviving `InstancedOccurrence.templateIndex`, and flagged that reindex as "the place most likely to hide an off-by-one". **This PR removes the reindex entirely rather than writing it.** Removal blanks slots instead of splicing, so no surviving index ever moves; freed slots are never recycled, so a stale reference resolves to a hole and never to another model's template. Every existing reader of `instancedTemplates[i]` / `instancedTemplateCpu[i]` already guards with `?.` or `if (!x) continue` (they had to — `releaseGeometryData()` already empties the CPU array), so sparseness needed no consumer changes.

### Latent bug fixed on the way

`releaseGeometryData()` empties `instancedTemplateCpu` while the GPU slots live on. A shard uploaded afterwards `push`ed its CPU template at index 0 instead of its GPU slot, so every CPU consumer — raycast, measure, section-face, export — would read a *different* template's triangles than the occurrence named. CPU templates are now slot-assigned. Pinned by `keeps CPU templates slot-aligned after releaseGeometryData() drops them`.

## Correctness

Renderer tests: **422 → 440** (18 new), all green. `packages/renderer` runs `tsx --test`, not vitest.

Properties pinned, each with at least two models holding *different* template counts so a model tag can never be mistaken for a global array position:

- **Index stability** — removing model A leaves model B's occurrence slots unchanged, and asserted by *object identity* on the templates they resolve to, not just by index. Also holds when a third model is added after the removal.
- **Disposal exactness** — asserts on the exact GPU handles: all 6 of model A's buffers destroyed exactly once, all 9 of model B's destroyed zero times. A later `clear()` must not double-destroy the already-freed ones.
- **`getResidentGpuBytes()` accounting** — exact across add → remove → add. Templates are deliberately built at *different* sizes so a byte bug can't pass by coincidence.
- **Shared express id** — removing one model prunes only its occurrence; the id stays instanced.
- **Edge cases** — empty scene, removing a model with zero templates, removing the last model, no explicit `modelIndex` (defaults to 0).

Every new test is mutation-verified: 14 mutations (drop the model tag, splice instead of tombstone, ignore the model filter, walk the sparse array for byte accounting, delete the whole id instead of pruning occurrences, don't skip holes in `clear()`, don't free the buffers, don't refresh the live view on add / on remove, don't prune selection state, push the CPU template instead of slot-assigning, leave the CPU slot populated, …) — **all 14 killed**, each by the test intended to catch it.

The buffer allocation path needs no real GPU (`addInstancedShard` only asks the device for sized, mapped buffers), so a recording stub exercises the real interleave / bounds-fold / entity-map code and lets the tests assert on exact destroyed handles. The draw and pick passes do need a real context and stay in the browser/E2E lanes — not mocked here.

## Compatibility

Additive. `modelIndex` defaults to 0 and the repo's single `addInstancedShard` call site (`useGeometryStreaming.ts:724`) does not pass one, so today's behaviour is bit-identical. `@ifc-lite/viewer` typechecks unchanged.

## Step two (deliberately not in this PR)

Enabling federated instancing wants a maintainer's sign-off and a benchmark, so it is separate:

1. Thread the real `modelIndex` through `useGeometryStreaming`'s drain effect from `ViewportContainer`'s `modelIdToIndex` map, instead of the constant 0.
2. Apply the federated `idOffset` to instanced shard entity ids at `useIfcLoader.ts` alongside the flat-mesh offsetting, so `instancedEntityMap` stays in one id space.
3. Flip `enableInstancing` for federated targets and un-gate the render-push block — with a benchmark, since no instancing performance claim has been measured in this harness.
4. Resolve `modelIndex` for instanced picks CPU-side off the occurrence's template (`picker.ts` currently returns `modelIndex: undefined`), spending no pick-encoding bits.
5. Only then decide `scene.clear()`'s scoped variant / decoded-shard retention for #2073, including the realign-delta re-bake for the anchor-moved case (`federationRealign.ts`). `removeInstancedTemplatesForModel` is the teardown half that work needed; the retention half is a viewer-layer decision this PR does not pre-empt.

Refs #1912
Refs #2073

🤖 Generated with [Claude Code](https://claude.com/claude-code)
