### PR TITLE
refactor(sources): split SourceBrowser and useSourceCatalogSync along their seams

### DIFF
--- a/apps/viewer/src/components/sources/SourceBrowser.tsx
+++ b/apps/viewer/src/components/sources/SourceBrowser.tsx
@@ -10,19 +10,16 @@ import type {
   SourceContainer,
   SourceFile,
 } from '@ifc-lite/plugin-api';
-import { useIfc } from '@/hooks/useIfc';
-import { syncSourceModel } from '@/lib/sources/syncSourceModel';
-import { toast } from '@/components/ui/toast';
 import { loadDownloadedSourceFileRecords } from '@/lib/sources/persistence';
-import { useSourceHost } from '@/services/sources/SourceHostProvider';
-import { useViewerStore } from '@/store';
 import { useSourceCatalogSync } from './useSourceCatalogSync';
+import { useSourceFileSearch } from './useSourceFileSearch';
+import { useLoadedSourceModels } from './useLoadedSourceModels';
 import { usePagedList } from './usePagedList';
-import { SourceEntityList, LoadMoreRow } from './SourceEntityList';
 import { SourceProjectsStep } from './SourceProjectsStep';
+import { SourceFileAreasStep } from './SourceFileAreasStep';
 import { SourceFolderStep } from './SourceFolderStep';
 import { SourceBrowserHeader } from './SourceBrowserHeader';
-import { FolderOpen, AlertCircle } from 'lucide-react';
+import { AlertCircle } from 'lucide-react';
 
 interface SourceBrowserProps {
   provider: FileSourceProvider;
@@ -36,9 +33,6 @@ interface SourceBrowserProps {
 type Step = 'projects' | 'file-areas' | 'folders';
 
 export function SourceBrowser({ provider, ctx, onDownload, onBack, busy = false }: SourceBrowserProps) {
-  const sourceHost = useSourceHost();
-  const { models, addModel, removeModel } = useIfc();
-  const sourceTags = useViewerStore((s) => s.sourceTags);
   const capabilities = provider.manifest.capabilities;
   const [step, setStep] = useState<Step>('projects');
   const [selectedProject, setSelectedProject] = useState<SourceProject | null>(null);
@@ -48,13 +42,7 @@ export function SourceBrowser({ provider, ctx, onDownload, onBack, busy = false 
   // from several folders can be loaded together as one federated model.
   const [selectedFiles, setSelectedFiles] = useState<Map<string, SourceFile>>(new Map());
   const [downloadedRecords, setDownloadedRecords] = useState(() => loadDownloadedSourceFileRecords());
-  const [syncingFileIds, setSyncingFileIds] = useState<Set<string>>(new Set());
   const [error, setError] = useState<string | null>(null);
-
-  // Server-side file search (capabilities.search only).
-  const [searchQuery, setSearchQuery] = useState('');
-  const [searchActive, setSearchActive] = useState(false);
-  const searchQueryRef = useRef('');
 
   const refreshDownloadedRecords = useCallback(() => {
     setDownloadedRecords(loadDownloadedSourceFileRecords());
@@ -84,24 +72,13 @@ export function SourceBrowser({ provider, ctx, onDownload, onBack, busy = false 
     setError,
   );
 
-  const searchPaged = usePagedList<SourceFile>(
-    useCallback(
-      (cursor, signal) => {
-        const projectId = projectIdRef.current;
-        const query = searchQueryRef.current.trim();
-        if (!projectId || !query || !provider.searchFiles) return Promise.resolve({ items: [] });
-        return provider.searchFiles(
-          ctx,
-          projectId,
-          query,
-          { namePatterns: ['*.ifc', '*.ifcx', '*.ifc5'] },
-          { cursor, limit: 200, signal },
-        );
-      },
-      [provider, ctx],
-    ),
-    setError,
-  );
+  const search = useSourceFileSearch({ provider, ctx, projectIdRef, setError });
+
+  const loadedModels = useLoadedSourceModels({
+    providerName: provider.manifest.name,
+    projectId: selectedProject?.id ?? null,
+    onSynced: refreshDownloadedRecords,
+  });
 
   const sortedFolders = useMemo(
     () => [...folders].sort((left, right) => left.name.localeCompare(right.name, undefined, { sensitivity: 'base' })),
@@ -109,12 +86,12 @@ export function SourceBrowser({ provider, ctx, onDownload, onBack, busy = false 
   );
 
   const visibleFiles = useMemo(() => {
-    if (searchActive) return searchPaged.items;
+    if (search.active) return search.items;
     const targetId = selectedContainer?.id ?? selectedFileArea?.id;
     if (!targetId || !selectedFileArea) return [];
     if (capabilities.listFilesIsRecursive && targetId === selectedFileArea.id) return allFiles;
     return allFiles.filter((file) => file.containerId === targetId);
-  }, [allFiles, capabilities.listFilesIsRecursive, searchActive, searchPaged.items, selectedContainer, selectedFileArea]);
+  }, [allFiles, capabilities.listFilesIsRecursive, search.active, search.items, selectedContainer, selectedFileArea]);
 
   const sortedFiles = useMemo(
     () => [...visibleFiles].sort((left, right) => left.name.localeCompare(right.name, undefined, {
@@ -124,59 +101,11 @@ export function SourceBrowser({ provider, ctx, onDownload, onBack, busy = false 
     [visibleFiles],
   );
 
-  const loadedModelIdsByFileId = useMemo(() => {
-    const next = new Map<string, string[]>();
-    if (!selectedProject) return next;
-
-    for (const [modelId, tag] of sourceTags) {
-      if (tag.provider !== provider.manifest.name || tag.projectId !== selectedProject.id) {
-        continue;
-      }
-      const current = next.get(tag.fileId);
-      if (current) {
-        current.push(modelId);
-      } else {
-        next.set(tag.fileId, [modelId]);
-      }
-    }
-
-    return next;
-  }, [provider.manifest.name, selectedProject, sourceTags]);
-  const loadedModelNamesByFileId = useMemo(() => {
-    const next = new Map<string, string[]>();
-    for (const [fileId, modelIds] of loadedModelIdsByFileId) {
-      next.set(
-        fileId,
-        modelIds.map((modelId) => models.get(modelId)?.name).filter((name): name is string => Boolean(name)),
-      );
-    }
-    return next;
-  }, [loadedModelIdsByFileId, models]);
-
   useEffect(() => {
     refreshDownloadedRecords();
   }, [refreshDownloadedRecords, selectedFileArea?.id]);
 
-  const clearSearch = useCallback(() => {
-    setSearchActive(false);
-    setSearchQuery('');
-    searchQueryRef.current = '';
-    searchPaged.reset();
-  }, [searchPaged]);
-
-  const submitSearch = useCallback(() => {
-    const query = searchQuery.trim();
-    if (!query) {
-      clearSearch();
-      return;
-    }
-    // A retry after a failed search must not render results under the stale
-    // red banner — clear it up front, like handleSync/selectContainer do.
-    setError(null);
-    searchQueryRef.current = query;
-    setSearchActive(true);
-    searchPaged.start();
-  }, [clearSearch, searchPaged, searchQuery]);
+  const clearSearch = search.clear;
 
   const selectContainer = useCallback((c: SourceContainer) => {
     setError(null);
@@ -243,56 +172,6 @@ export function SourceBrowser({ provider, ctx, onDownload, onBack, busy = false 
     void catalog.syncFileArea(selectedProject.id, selectedFileArea.id, { announce: true });
   }, [capabilities, catalog, selectedFileArea, selectedProject]);
 
-  const handleSyncLoadedFile = useCallback(async (file: SourceFile) => {
-    const loadedModelIds = loadedModelIdsByFileId.get(file.id);
-    if (!loadedModelIds || loadedModelIds.length === 0) return;
-
-    setSyncingFileIds((previous) => new Set(previous).add(file.id));
-    try {
-      let synced = 0;
-      let lastLatestFileName: string | undefined;
-      let lastProviderTitle: string | undefined;
-      for (const modelId of loadedModelIds) {
-        const tag = sourceTags.get(modelId);
-        if (!tag) continue;
-
-        const { latestFile } = await syncSourceModel({
-          modelId,
-          tag,
-          sourceHost,
-          addModel,
-          removeModel,
-        });
-        synced += 1;
-        lastLatestFileName = latestFile.name;
-        lastProviderTitle = sourceHost.get(tag.provider)?.manifest.title ?? tag.provider;
-      }
-      refreshDownloadedRecords();
-      if (synced > 0 && lastLatestFileName && lastProviderTitle) {
-        toast.success(
-          synced === 1
-            ? `Synced ${lastLatestFileName} from ${lastProviderTitle}`
-            : `Synced ${synced} models from ${lastProviderTitle}`,
-        );
-      }
-    } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Failed to sync source model');
-    } finally {
-      setSyncingFileIds((previous) => {
-        const next = new Set(previous);
-        next.delete(file.id);
-        return next;
-      });
-    }
-  }, [
-    addModel,
-    loadedModelIdsByFileId,
-    refreshDownloadedRecords,
-    removeModel,
-    sourceHost,
-    sourceTags,
-  ]);
-
   const goBack = useCallback(() => {
     // A failed listing must never leave a dead-end screen: navigating always
     // clears the error and re-renders the previous step's list.
@@ -317,12 +196,12 @@ export function SourceBrowser({ provider, ctx, onDownload, onBack, busy = false 
   // Keep selected files fresh as listings update; files that vanished from
   // the source drop out of the selection.
   useEffect(() => {
-    // Files selected while a search is active come from `searchPaged.items`,
+    // Files selected while a search is active come from the search results,
     // not `allFiles` — reconciling against `allFiles` alone would drop a
     // search-origin selection the moment the catalog changes underneath it
     // (e.g. "Load more files" or a manual sync), with no message to the user.
     const byId = new Map(
-      [...allFiles, ...searchPaged.items].map((file) => [file.id, file] as const),
+      [...allFiles, ...search.items].map((file) => [file.id, file] as const),
     );
     setSelectedFiles((previous) => {
       let changed = false;
@@ -338,7 +217,7 @@ export function SourceBrowser({ provider, ctx, onDownload, onBack, busy = false 
       }
       return changed ? next : previous;
     });
-  }, [allFiles, searchPaged.items]);
+  }, [allFiles, search.items]);
 
   const selectedContainerId = selectedContainer?.id ?? null;
 
@@ -373,24 +252,17 @@ export function SourceBrowser({ provider, ctx, onDownload, onBack, busy = false 
       )}
 
       {step === 'file-areas' && (
-        <div className="flex-1 overflow-y-auto">
-          <SourceEntityList
-            items={fileAreasPaged.items}
-            loading={fileAreasPaged.loading}
-            icon={FolderOpen}
-            emptyLabel="No file areas found"
-            onSelect={openFileArea}
-          />
-          <LoadMoreRow
-            hasMore={fileAreasPaged.hasMore}
-            loading={fileAreasPaged.loadingMore}
-            onLoadMore={() => {
-              setError(null);
-              fileAreasPaged.loadMore();
-            }}
-            label="Load more"
-          />
-        </div>
+        <SourceFileAreasStep
+          fileAreas={fileAreasPaged.items}
+          loading={fileAreasPaged.loading}
+          hasMore={fileAreasPaged.hasMore}
+          loadingMore={fileAreasPaged.loadingMore}
+          onSelect={openFileArea}
+          onLoadMore={() => {
+            setError(null);
+            fileAreasPaged.loadMore();
+          }}
+        />
       )}
 
       {step === 'folders' && selectedFileArea && (
@@ -408,14 +280,14 @@ export function SourceBrowser({ provider, ctx, onDownload, onBack, busy = false 
             catalog.catalogComplete
           }
           loadingFolders={catalog.loadingFolders}
-          loadingFiles={searchActive ? searchPaged.loading : catalog.loadingFiles}
+          loadingFiles={search.active ? search.loading : catalog.loadingFiles}
           sortedFiles={sortedFiles}
           selectedFiles={selectedFiles}
           onToggleFile={toggleFile}
           downloadedRecords={downloadedRecords}
-          loadedModelNamesByFileId={loadedModelNamesByFileId}
-          syncingFileIds={syncingFileIds}
-          onSyncLoadedFile={(file) => void handleSyncLoadedFile(file)}
+          loadedModelNamesByFileId={loadedModels.loadedModelNamesByFileId}
+          syncingFileIds={loadedModels.syncingFileIds}
+          onSyncLoadedFile={(file) => void loadedModels.syncLoadedFile(file)}
           busy={busy}
           onLoad={handleLoad}
           foldersHaveMore={catalog.hasMoreFolders(selectedContainerId)}
@@ -424,20 +296,20 @@ export function SourceBrowser({ provider, ctx, onDownload, onBack, busy = false 
             catalog.loadMoreFolders(selectedContainerId);
           }}
           filesHaveMore={
-            searchActive ? searchPaged.hasMore : catalog.hasMoreFiles(selectedContainerId)
+            search.active ? search.hasMore : catalog.hasMoreFiles(selectedContainerId)
           }
           onLoadMoreFiles={() => {
             setError(null);
-            if (searchActive) searchPaged.loadMore();
+            if (search.active) search.loadMore();
             else catalog.loadMoreFiles(selectedContainerId);
           }}
-          loadingMore={catalog.loadingMore || searchPaged.loadingMore}
+          loadingMore={catalog.loadingMore || search.loadingMore}
           searchEnabled={capabilities.search && provider.searchFiles !== undefined}
-          searchQuery={searchQuery}
-          searchActive={searchActive}
-          onSearchQueryChange={setSearchQuery}
-          onSearchSubmit={submitSearch}
-          onSearchClear={clearSearch}
+          searchQuery={search.query}
+          searchActive={search.active}
+          onSearchQueryChange={search.setQuery}
+          onSearchSubmit={search.submit}
+          onSearchClear={search.clear}
         />
       )}
     </div>

--- a/apps/viewer/src/components/sources/SourceFileAreasStep.tsx
+++ b/apps/viewer/src/components/sources/SourceFileAreasStep.tsx
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { SourceContainer } from '@ifc-lite/plugin-api';
+import { SourceEntityList, LoadMoreRow } from './SourceEntityList';
+import { FolderOpen } from 'lucide-react';
+
+interface SourceFileAreasStepProps {
+  fileAreas: readonly SourceContainer[];
+  loading: boolean;
+  hasMore: boolean;
+  loadingMore: boolean;
+  onSelect: (fileArea: SourceContainer) => void;
+  onLoadMore: () => void;
+}
+
+/**
+ * Paged list of a project's top-level containers ("file areas").
+ *
+ * Presentational only: the listing state lives in `SourceBrowser` so it
+ * survives stepping into a file area and back out again, which must not
+ * re-fetch.
+ */
+export function SourceFileAreasStep({
+  fileAreas,
+  loading,
+  hasMore,
+  loadingMore,
+  onSelect,
+  onLoadMore,
+}: SourceFileAreasStepProps) {
+  return (
+    <div className="flex-1 overflow-y-auto">
+      <SourceEntityList
+        items={fileAreas}
+        loading={loading}
+        icon={FolderOpen}
+        emptyLabel="No file areas found"
+        onSelect={onSelect}
+      />
+      <LoadMoreRow hasMore={hasMore} loading={loadingMore} onLoadMore={onLoadMore} label="Load more" />
+    </div>
+  );
+}

--- a/apps/viewer/src/components/sources/sourceCatalogCache.ts
+++ b/apps/viewer/src/components/sources/sourceCatalogCache.ts
@@ -1,0 +1,70 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { ProviderCapabilities, SourceContainer, SourceFile } from '@ifc-lite/plugin-api';
+import { loadSourceCatalogCache, saveSourceCatalogCache } from '@/lib/sources/persistence';
+import type { PagedItems } from './sourceCatalogPaging';
+
+/** Identifies the one file area a cache entry belongs to. */
+export interface CatalogCacheScope {
+  readonly providerName: string;
+  readonly projectId: string;
+  readonly fileAreaId: string;
+}
+
+/**
+ * Only providers that return a whole file area in one listing can be cached:
+ * their catalog is either complete or visibly partial. Per-folder providers
+ * accumulate the area folder by folder, so what is in memory is never known to
+ * be the whole area and must not be written back as if it were.
+ */
+export function isCatalogCacheable(capabilities: ProviderCapabilities): boolean {
+  return capabilities.containerListing === 'flat-subtree' && capabilities.listFilesIsRecursive;
+}
+
+/**
+ * Persists the catalog when (and only when) it is completely fetched — partial
+ * pages must not masquerade as the whole area next session.
+ *
+ * @returns the entry's `updatedAt`, or `null` when nothing was written.
+ */
+export function persistCompleteCatalog(
+  scope: CatalogCacheScope,
+  containers: ReadonlyMap<string, PagedItems<SourceContainer>>,
+  files: ReadonlyMap<string, PagedItems<SourceFile>>,
+): number | null {
+  const containerPage = containers.get(scope.fileAreaId);
+  const filePage = files.get(scope.fileAreaId);
+  if (!containerPage || !filePage) return null;
+  if (containerPage.cursor !== undefined || filePage.cursor !== undefined) return null;
+  const entry = saveSourceCatalogCache(
+    scope.providerName,
+    scope.projectId,
+    scope.fileAreaId,
+    containerPage.items,
+    filePage.items,
+  );
+  return entry.updatedAt;
+}
+
+export interface CachedCatalog {
+  readonly containersByParent: Map<string, PagedItems<SourceContainer>>;
+  readonly filesByContainer: Map<string, PagedItems<SourceFile>>;
+  readonly updatedAt: number;
+}
+
+/**
+ * Reads a cached catalog back as the two page maps the hook holds in state.
+ * Cached pages carry no cursor: a cache entry only ever exists for a fully
+ * fetched area.
+ */
+export function readCachedCatalog(scope: CatalogCacheScope): CachedCatalog | null {
+  const cached = loadSourceCatalogCache(scope.providerName, scope.projectId, scope.fileAreaId);
+  if (!cached) return null;
+  return {
+    containersByParent: new Map([[scope.fileAreaId, { items: [...cached.folders] }]]),
+    filesByContainer: new Map([[scope.fileAreaId, { items: [...cached.files] }]]),
+    updatedAt: cached.updatedAt,
+  };
+}

--- a/apps/viewer/src/components/sources/sourceCatalogPaging.ts
+++ b/apps/viewer/src/components/sources/sourceCatalogPaging.ts
@@ -1,0 +1,58 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { FileSourceProvider, PluginContext, SourceContainer, SourceFile } from '@ifc-lite/plugin-api';
+
+export const IFC_NAME_PATTERNS = ['*.ifc', '*.ifcx', '*.ifc5'];
+export const LIST_PAGE_LIMIT = 200;
+
+/** One cursor-paged slice of a listing. `cursor === undefined` means "no more". */
+export interface PagedItems<T> {
+  readonly items: readonly T[];
+  readonly cursor?: string;
+}
+
+export async function fetchContainerPage(
+  provider: FileSourceProvider,
+  ctx: PluginContext,
+  projectId: string,
+  parentKey: string,
+  cursor: string | undefined,
+  signal: AbortSignal,
+): Promise<PagedItems<SourceContainer>> {
+  const page = await provider.listContainers(ctx, projectId, parentKey, {
+    cursor,
+    limit: LIST_PAGE_LIMIT,
+    signal,
+  });
+  // Providers may omit `parentId` on direct children; normalise so the
+  // client-side tree always has a link back to the queried parent.
+  const items = page.items.map((container) =>
+    container.parentId === undefined ? { ...container, parentId: parentKey } : container,
+  );
+  return { items, cursor: page.cursor } satisfies PagedItems<SourceContainer>;
+}
+
+export async function fetchFilePage(
+  provider: FileSourceProvider,
+  ctx: PluginContext,
+  projectId: string,
+  containerId: string,
+  cursor: string | undefined,
+  signal: AbortSignal,
+): Promise<PagedItems<SourceFile>> {
+  const page = await provider.listFiles(
+    ctx,
+    projectId,
+    containerId,
+    { namePatterns: IFC_NAME_PATTERNS },
+    { cursor, limit: LIST_PAGE_LIMIT, signal },
+  );
+  return { items: [...page.items], cursor: page.cursor } satisfies PagedItems<SourceFile>;
+}
+
+/** Appends a freshly fetched page to the pages already held for the same key. */
+export function appendPage<T>(current: PagedItems<T>, page: PagedItems<T>): PagedItems<T> {
+  return { items: [...current.items, ...page.items], cursor: page.cursor };
+}

--- a/apps/viewer/src/components/sources/sourceCatalogSelectors.test.ts
+++ b/apps/viewer/src/components/sources/sourceCatalogSelectors.test.ts
@@ -1,0 +1,76 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import type { PagedItems } from './sourceCatalogPaging';
+import {
+  collectUniqueById,
+  isCatalogComplete,
+  pageHasMore,
+  resolveCatalogKey,
+} from './sourceCatalogSelectors';
+
+const area = { projectId: 'p1', fileAreaId: 'fa1' };
+
+function page<T>(items: readonly T[], cursor?: string): PagedItems<T> {
+  return { items, cursor };
+}
+
+describe('sourceCatalogSelectors', () => {
+  it('keys area-wide listings by the file area and per-container ones by the selection', () => {
+    // Area-keyed (flat-subtree folders, recursive files): the selected folder
+    // must not become the key, or "Load more" would page a listing that was
+    // never fetched under that key.
+    assert.equal(resolveCatalogKey(area, 'folder-a', true), 'fa1');
+    assert.equal(resolveCatalogKey(area, null, true), 'fa1');
+
+    // Per-container: the selection is the key, falling back to the area root.
+    assert.equal(resolveCatalogKey(area, 'folder-a', false), 'folder-a');
+    assert.equal(resolveCatalogKey(area, null, false), 'fa1');
+
+    // No area open yet — nothing is keyed.
+    assert.equal(resolveCatalogKey(null, 'folder-a', false), null);
+  });
+
+  it('treats an empty catalog as incomplete and any outstanding cursor as incomplete', () => {
+    const empty = new Map<string, PagedItems<unknown>>();
+
+    // Nothing fetched yet must NOT read as complete: the folder-is-empty UI
+    // gate would otherwise fire before the first listing lands.
+    assert.equal(isCatalogComplete(empty, empty), false);
+
+    assert.equal(isCatalogComplete(new Map([['fa1', page([{ id: 'a' }])]]), empty), true);
+    assert.equal(isCatalogComplete(empty, new Map([['fa1', page([{ id: 'f' }])]])), true);
+
+    // A cursor on either side means more is outstanding.
+    assert.equal(isCatalogComplete(new Map([['fa1', page([], 'next')]]), empty), false);
+    assert.equal(
+      isCatalogComplete(new Map([['fa1', page([])]]), new Map([['fa1', page([], 'next')]])),
+      false,
+    );
+  });
+
+  it('dedupes entities reached through more than one page, last write winning', () => {
+    const pages = [
+      page([{ id: 'a', name: 'stale' }, { id: 'b', name: 'b' }]),
+      page([{ id: 'a', name: 'fresh' }]),
+    ];
+
+    assert.deepEqual(collectUniqueById(pages), [{ id: 'a', name: 'fresh' }, { id: 'b', name: 'b' }]);
+  });
+
+  it('reports more pages only for a fetched key with an outstanding cursor', () => {
+    const pages = new Map<string, PagedItems<unknown>>([
+      ['fa1', page([], 'next')],
+      ['folder-a', page([])],
+    ]);
+
+    assert.equal(pageHasMore(pages, 'fa1'), true);
+    assert.equal(pageHasMore(pages, 'folder-a'), false);
+    assert.equal(pageHasMore(pages, 'never-fetched'), false);
+    assert.equal(pageHasMore(pages, null), false);
+  });
+});

--- a/apps/viewer/src/components/sources/sourceCatalogSelectors.ts
+++ b/apps/viewer/src/components/sources/sourceCatalogSelectors.ts
@@ -1,0 +1,62 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { PagedItems } from './sourceCatalogPaging';
+
+/** The file area a catalog's pages were fetched for. */
+export interface CatalogArea {
+  readonly projectId: string;
+  readonly fileAreaId: string;
+}
+
+/**
+ * Flattens every page into one list, last write wins per id. Pages from
+ * different parents can repeat an entity (a folder reached two ways), so the
+ * flattening must dedupe rather than concatenate.
+ */
+export function collectUniqueById<T extends { id: string }>(pages: Iterable<PagedItems<T>>): T[] {
+  const byId = new Map<string, T>();
+  for (const page of pages) {
+    for (const item of page.items) byId.set(item.id, item);
+  }
+  return [...byId.values()];
+}
+
+/**
+ * True when every fetched listing is complete (no cursor outstanding). Only
+ * then can "folder X has no files" be asserted for UI gating.
+ */
+export function isCatalogComplete(
+  containersByParent: ReadonlyMap<string, PagedItems<unknown>>,
+  filesByContainer: ReadonlyMap<string, PagedItems<unknown>>,
+): boolean {
+  for (const page of containersByParent.values()) if (page.cursor !== undefined) return false;
+  for (const page of filesByContainer.values()) if (page.cursor !== undefined) return false;
+  return containersByParent.size > 0 || filesByContainer.size > 0;
+}
+
+/**
+ * The map key holding the current selection's entities.
+ *
+ * `keyedByArea` reflects the provider capability that decides the layout of the
+ * map: one entry per file area (`flat-subtree` folders, recursive files) versus
+ * one entry per browsed container. Area-keyed maps ignore the selection; the
+ * per-container ones fall back to the area root when nothing is selected.
+ */
+export function resolveCatalogKey(
+  area: CatalogArea | null,
+  selectedContainerId: string | null,
+  keyedByArea: boolean,
+): string | null {
+  if (!area) return null;
+  return keyedByArea ? area.fileAreaId : (selectedContainerId ?? area.fileAreaId);
+}
+
+/** True when the page at `key` has an outstanding cursor, i.e. "Load more" applies. */
+export function pageHasMore(
+  pages: ReadonlyMap<string, PagedItems<unknown>>,
+  key: string | null,
+): boolean {
+  return key !== null && pages.get(key)?.cursor !== undefined;
+}

--- a/apps/viewer/src/components/sources/useLoadedSourceModels.ts
+++ b/apps/viewer/src/components/sources/useLoadedSourceModels.ts
@@ -1,0 +1,118 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { useCallback, useMemo, useState } from 'react';
+import type { SourceFile } from '@ifc-lite/plugin-api';
+import { useIfc } from '@/hooks/useIfc';
+import { toast } from '@/components/ui/toast';
+import { syncSourceModel } from '@/lib/sources/syncSourceModel';
+import { useSourceHost } from '@/services/sources/SourceHostProvider';
+import { useViewerStore } from '@/store';
+
+interface UseLoadedSourceModelsOptions {
+  /** Manifest name of the provider being browsed. */
+  providerName: string;
+  /** Project being browsed, or `null` before one is chosen. */
+  projectId: string | null;
+  /** Called after a successful re-sync so download records can be refreshed. */
+  onSynced: () => void;
+}
+
+/**
+ * Bridges the browser's file listing to the models already loaded in the
+ * viewer: which listed files are open (and under what model names), and
+ * re-syncing those models against the source's latest revision.
+ *
+ * Keeping this out of `SourceBrowser` is what lets the browser stay a pure
+ * listing UI — the viewer store, the model registry and the source host are
+ * reached only from here.
+ */
+export function useLoadedSourceModels({ providerName, projectId, onSynced }: UseLoadedSourceModelsOptions) {
+  const sourceHost = useSourceHost();
+  const { models, addModel, removeModel } = useIfc();
+  const sourceTags = useViewerStore((s) => s.sourceTags);
+  const [syncingFileIds, setSyncingFileIds] = useState<Set<string>>(new Set());
+
+  const loadedModelIdsByFileId = useMemo(() => {
+    const next = new Map<string, string[]>();
+    if (!projectId) return next;
+
+    for (const [modelId, tag] of sourceTags) {
+      if (tag.provider !== providerName || tag.projectId !== projectId) {
+        continue;
+      }
+      const current = next.get(tag.fileId);
+      if (current) {
+        current.push(modelId);
+      } else {
+        next.set(tag.fileId, [modelId]);
+      }
+    }
+
+    return next;
+  }, [projectId, providerName, sourceTags]);
+
+  const loadedModelNamesByFileId = useMemo(() => {
+    const next = new Map<string, string[]>();
+    for (const [fileId, modelIds] of loadedModelIdsByFileId) {
+      next.set(
+        fileId,
+        modelIds.map((modelId) => models.get(modelId)?.name).filter((name): name is string => Boolean(name)),
+      );
+    }
+    return next;
+  }, [loadedModelIdsByFileId, models]);
+
+  const syncLoadedFile = useCallback(async (file: SourceFile) => {
+    const loadedModelIds = loadedModelIdsByFileId.get(file.id);
+    if (!loadedModelIds || loadedModelIds.length === 0) return;
+
+    setSyncingFileIds((previous) => new Set(previous).add(file.id));
+    try {
+      let synced = 0;
+      let lastLatestFileName: string | undefined;
+      let lastProviderTitle: string | undefined;
+      for (const modelId of loadedModelIds) {
+        const tag = sourceTags.get(modelId);
+        if (!tag) continue;
+
+        const { latestFile } = await syncSourceModel({
+          modelId,
+          tag,
+          sourceHost,
+          addModel,
+          removeModel,
+        });
+        synced += 1;
+        lastLatestFileName = latestFile.name;
+        lastProviderTitle = sourceHost.get(tag.provider)?.manifest.title ?? tag.provider;
+      }
+      onSynced();
+      if (synced > 0 && lastLatestFileName && lastProviderTitle) {
+        toast.success(
+          synced === 1
+            ? `Synced ${lastLatestFileName} from ${lastProviderTitle}`
+            : `Synced ${synced} models from ${lastProviderTitle}`,
+        );
+      }
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to sync source model');
+    } finally {
+      setSyncingFileIds((previous) => {
+        const next = new Set(previous);
+        next.delete(file.id);
+        return next;
+      });
+    }
+  }, [
+    addModel,
+    loadedModelIdsByFileId,
+    onSynced,
+    removeModel,
+    sourceHost,
+    sourceTags,
+  ]);
+
+  return { loadedModelNamesByFileId, syncingFileIds, syncLoadedFile };
+}

--- a/apps/viewer/src/components/sources/useSourceCatalogSync.ts
+++ b/apps/viewer/src/components/sources/useSourceCatalogSync.ts
@@ -5,15 +5,15 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { FileSourceProvider, PluginContext, SourceContainer, SourceFile } from '@ifc-lite/plugin-api';
 import { toast } from '@/components/ui/toast';
-import { loadSourceCatalogCache, saveSourceCatalogCache } from '@/lib/sources/persistence';
-
-const IFC_NAME_PATTERNS = ['*.ifc', '*.ifcx', '*.ifc5'];
-const LIST_PAGE_LIMIT = 200;
-
-interface PagedItems<T> {
-  readonly items: readonly T[];
-  readonly cursor?: string;
-}
+import { isCatalogCacheable, persistCompleteCatalog, readCachedCatalog } from './sourceCatalogCache';
+import { appendPage, fetchContainerPage, fetchFilePage, type PagedItems } from './sourceCatalogPaging';
+import {
+  collectUniqueById,
+  isCatalogComplete,
+  pageHasMore,
+  resolveCatalogKey,
+  type CatalogArea,
+} from './sourceCatalogSelectors';
 
 interface UseSourceCatalogSyncOptions {
   provider: FileSourceProvider;
@@ -37,10 +37,16 @@ interface UseSourceCatalogSyncOptions {
  * demand via `loadMore*` (never an eager drain, never a silent truncation).
  * Fully-fetched flat-subtree catalogs are cached in localStorage; partial or
  * per-folder catalogs stay in memory only.
+ *
+ * Page fetching lives in `sourceCatalogPaging`, cache read/write in
+ * `sourceCatalogCache`, and the derived views in `sourceCatalogSelectors`;
+ * what remains here is the request lifecycle (generations, aborts, flags).
  */
 export function useSourceCatalogSync({ provider, ctx, setError, onSynced }: UseSourceCatalogSyncOptions) {
   const { containerListing, listFilesIsRecursive } = provider.manifest.capabilities;
   const flatSubtree = containerListing === 'flat-subtree';
+  const cacheable = isCatalogCacheable(provider.manifest.capabilities);
+  const providerName = provider.manifest.name;
 
   // Guards against a slow, stale fetch overwriting a newer one if the user
   // backs out and re-enters a file area quickly. Bumping it also orphans any
@@ -48,7 +54,7 @@ export function useSourceCatalogSync({ provider, ctx, setError, onSynced }: UseS
   const requestGenRef = useRef(0);
   const abortRef = useRef<AbortController | null>(null);
 
-  const areaRef = useRef<{ projectId: string; fileAreaId: string } | null>(null);
+  const areaRef = useRef<CatalogArea | null>(null);
   // Container ids with an on-demand fetch already running (direct-children /
   // per-folder files), so rapid re-selection cannot double-fetch.
   const openingContainersRef = useRef(new Set<string>());
@@ -66,29 +72,12 @@ export function useSourceCatalogSync({ provider, ctx, setError, onSynced }: UseS
   const [syncing, setSyncing] = useState(false);
   const [catalogUpdatedAt, setCatalogUpdatedAt] = useState<number | null>(null);
 
-  const folders = useMemo(() => {
-    const byId = new Map<string, SourceContainer>();
-    for (const page of containersByParent.values()) {
-      for (const container of page.items) byId.set(container.id, container);
-    }
-    return [...byId.values()];
-  }, [containersByParent]);
-
-  const allFiles = useMemo(() => {
-    const byId = new Map<string, SourceFile>();
-    for (const page of filesByContainer.values()) {
-      for (const file of page.items) byId.set(file.id, file);
-    }
-    return [...byId.values()];
-  }, [filesByContainer]);
-
-  /** True when every fetched listing is complete (no cursor outstanding). Only
-   *  then can "folder X has no files" be asserted for UI gating. */
-  const catalogComplete = useMemo(() => {
-    for (const page of containersByParent.values()) if (page.cursor !== undefined) return false;
-    for (const page of filesByContainer.values()) if (page.cursor !== undefined) return false;
-    return containersByParent.size > 0 || filesByContainer.size > 0;
-  }, [containersByParent, filesByContainer]);
+  const folders = useMemo(() => collectUniqueById(containersByParent.values()), [containersByParent]);
+  const allFiles = useMemo(() => collectUniqueById(filesByContainer.values()), [filesByContainer]);
+  const catalogComplete = useMemo(
+    () => isCatalogComplete(containersByParent, filesByContainer),
+    [containersByParent, filesByContainer],
+  );
 
   const beginGeneration = useCallback((): { gen: number; signal: AbortSignal } => {
     abortRef.current?.abort();
@@ -103,39 +92,17 @@ export function useSourceCatalogSync({ provider, ctx, setError, onSynced }: UseS
   }, []);
 
   const fetchContainers = useCallback(
-    async (projectId: string, parentKey: string, cursor: string | undefined, signal: AbortSignal) => {
-      const page = await provider.listContainers(ctx, projectId, parentKey, {
-        cursor,
-        limit: LIST_PAGE_LIMIT,
-        signal,
-      });
-      // Providers may omit `parentId` on direct children; normalise so the
-      // client-side tree always has a link back to the queried parent.
-      const items = page.items.map((container) =>
-        container.parentId === undefined ? { ...container, parentId: parentKey } : container,
-      );
-      return { items, cursor: page.cursor } satisfies PagedItems<SourceContainer>;
-    },
+    (projectId: string, parentKey: string, cursor: string | undefined, signal: AbortSignal) =>
+      fetchContainerPage(provider, ctx, projectId, parentKey, cursor, signal),
     [ctx, provider],
   );
 
   const fetchFiles = useCallback(
-    async (projectId: string, containerId: string, cursor: string | undefined, signal: AbortSignal) => {
-      const page = await provider.listFiles(
-        ctx,
-        projectId,
-        containerId,
-        { namePatterns: IFC_NAME_PATTERNS },
-        { cursor, limit: LIST_PAGE_LIMIT, signal },
-      );
-      return { items: [...page.items], cursor: page.cursor } satisfies PagedItems<SourceFile>;
-    },
+    (projectId: string, containerId: string, cursor: string | undefined, signal: AbortSignal) =>
+      fetchFilePage(provider, ctx, projectId, containerId, cursor, signal),
     [ctx, provider],
   );
 
-  /** Persist the catalog when (and only when) it is completely fetched and the
-   *  provider uses one listing per area — partial pages must not masquerade as
-   *  the whole area next session. */
   const maybePersist = useCallback(
     (
       projectId: string,
@@ -143,35 +110,25 @@ export function useSourceCatalogSync({ provider, ctx, setError, onSynced }: UseS
       containers: ReadonlyMap<string, PagedItems<SourceContainer>>,
       files: ReadonlyMap<string, PagedItems<SourceFile>>,
     ) => {
-      if (!flatSubtree || !listFilesIsRecursive) return;
-      const containerPage = containers.get(fileAreaId);
-      const filePage = files.get(fileAreaId);
-      if (!containerPage || !filePage) return;
-      if (containerPage.cursor !== undefined || filePage.cursor !== undefined) return;
-      const entry = saveSourceCatalogCache(
-        provider.manifest.name,
-        projectId,
-        fileAreaId,
-        containerPage.items,
-        filePage.items,
-      );
-      setCatalogUpdatedAt(entry.updatedAt);
+      if (!cacheable) return;
+      const updatedAt = persistCompleteCatalog({ providerName, projectId, fileAreaId }, containers, files);
+      if (updatedAt !== null) setCatalogUpdatedAt(updatedAt);
     },
-    [flatSubtree, listFilesIsRecursive, provider.manifest.name],
+    [cacheable, providerName],
   );
 
   const applyCachedCatalog = useCallback(
     (projectId: string, fileAreaId: string): boolean => {
-      if (!flatSubtree || !listFilesIsRecursive) return false;
-      const cached = loadSourceCatalogCache(provider.manifest.name, projectId, fileAreaId);
+      if (!cacheable) return false;
+      const cached = readCachedCatalog({ providerName, projectId, fileAreaId });
       if (!cached) return false;
 
-      setContainersByParent(new Map([[fileAreaId, { items: [...cached.folders] }]]));
-      setFilesByContainer(new Map([[fileAreaId, { items: [...cached.files] }]]));
+      setContainersByParent(cached.containersByParent);
+      setFilesByContainer(cached.filesByContainer);
       setCatalogUpdatedAt(cached.updatedAt);
       return true;
     },
-    [flatSubtree, listFilesIsRecursive, provider.manifest.name],
+    [cacheable, providerName],
   );
 
   const syncFileArea = useCallback(
@@ -309,37 +266,25 @@ export function useSourceCatalogSync({ provider, ctx, setError, onSynced }: UseS
 
   /** The map key holding folders for the current selection. */
   const folderKeyFor = useCallback(
-    (selectedContainerId: string | null) => {
-      const area = areaRef.current;
-      if (!area) return null;
-      return flatSubtree ? area.fileAreaId : (selectedContainerId ?? area.fileAreaId);
-    },
+    (selectedContainerId: string | null) =>
+      resolveCatalogKey(areaRef.current, selectedContainerId, flatSubtree),
     [flatSubtree],
   );
 
   /** The map key holding files for the current selection. */
   const fileKeyFor = useCallback(
-    (selectedContainerId: string | null) => {
-      const area = areaRef.current;
-      if (!area) return null;
-      return listFilesIsRecursive ? area.fileAreaId : (selectedContainerId ?? area.fileAreaId);
-    },
+    (selectedContainerId: string | null) =>
+      resolveCatalogKey(areaRef.current, selectedContainerId, listFilesIsRecursive),
     [listFilesIsRecursive],
   );
 
   const hasMoreFolders = useCallback(
-    (selectedContainerId: string | null) => {
-      const key = folderKeyFor(selectedContainerId);
-      return key !== null && containersByParent.get(key)?.cursor !== undefined;
-    },
+    (selectedContainerId: string | null) => pageHasMore(containersByParent, folderKeyFor(selectedContainerId)),
     [containersByParent, folderKeyFor],
   );
 
   const hasMoreFiles = useCallback(
-    (selectedContainerId: string | null) => {
-      const key = fileKeyFor(selectedContainerId);
-      return key !== null && filesByContainer.get(key)?.cursor !== undefined;
-    },
+    (selectedContainerId: string | null) => pageHasMore(filesByContainer, fileKeyFor(selectedContainerId)),
     [fileKeyFor, filesByContainer],
   );
 
@@ -358,11 +303,7 @@ export function useSourceCatalogSync({ provider, ctx, setError, onSynced }: UseS
         try {
           const page = await fetchContainers(area.projectId, key, current.cursor, signal);
           if (requestGenRef.current !== gen) return;
-          const merged: PagedItems<SourceContainer> = {
-            items: [...current.items, ...page.items],
-            cursor: page.cursor,
-          };
-          const next = new Map(containersByParent).set(key, merged);
+          const next = new Map(containersByParent).set(key, appendPage(current, page));
           setContainersByParent(next);
           maybePersist(area.projectId, area.fileAreaId, next, filesByContainer);
         } catch (err) {
@@ -392,11 +333,7 @@ export function useSourceCatalogSync({ provider, ctx, setError, onSynced }: UseS
         try {
           const page = await fetchFiles(area.projectId, key, current.cursor, signal);
           if (requestGenRef.current !== gen) return;
-          const merged: PagedItems<SourceFile> = {
-            items: [...current.items, ...page.items],
-            cursor: page.cursor,
-          };
-          const next = new Map(filesByContainer).set(key, merged);
+          const next = new Map(filesByContainer).set(key, appendPage(current, page));
           setFilesByContainer(next);
           maybePersist(area.projectId, area.fileAreaId, containersByParent, next);
           onSynced?.();

--- a/apps/viewer/src/components/sources/useSourceFileSearch.ts
+++ b/apps/viewer/src/components/sources/useSourceFileSearch.ts
@@ -1,0 +1,86 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { useCallback, useRef, useState } from 'react';
+import type { FileSourceProvider, PluginContext, SourceFile } from '@ifc-lite/plugin-api';
+import { usePagedList } from './usePagedList';
+import { IFC_NAME_PATTERNS, LIST_PAGE_LIMIT } from './sourceCatalogPaging';
+
+interface UseSourceFileSearchOptions {
+  provider: FileSourceProvider;
+  ctx: PluginContext;
+  /** Project to search within, read at fetch time so a change needs no restart. */
+  projectIdRef: { readonly current: string | null };
+  /** Report a search error, or clear the current one with `null`. */
+  setError: (message: string | null) => void;
+}
+
+/**
+ * Server-side file search (`capabilities.search` providers only), kept as its
+ * own state machine: the query box, whether results are currently displacing
+ * the folder listing, and the paged result list.
+ *
+ * `active` is what the browser switches on — while it is true the file pane
+ * renders `items` instead of the catalog, so clearing must reset both.
+ */
+export function useSourceFileSearch({ provider, ctx, projectIdRef, setError }: UseSourceFileSearchOptions) {
+  const [query, setQuery] = useState('');
+  const [active, setActive] = useState(false);
+  // The fetcher reads the submitted query from a ref so a new search only
+  // needs a `start()`, not a rebuilt hook.
+  const queryRef = useRef('');
+
+  const paged = usePagedList<SourceFile>(
+    useCallback(
+      (cursor, signal) => {
+        const projectId = projectIdRef.current;
+        const submitted = queryRef.current.trim();
+        if (!projectId || !submitted || !provider.searchFiles) return Promise.resolve({ items: [] });
+        return provider.searchFiles(
+          ctx,
+          projectId,
+          submitted,
+          { namePatterns: IFC_NAME_PATTERNS },
+          { cursor, limit: LIST_PAGE_LIMIT, signal },
+        );
+      },
+      [provider, ctx, projectIdRef],
+    ),
+    setError,
+  );
+
+  const clear = useCallback(() => {
+    setActive(false);
+    setQuery('');
+    queryRef.current = '';
+    paged.reset();
+  }, [paged]);
+
+  const submit = useCallback(() => {
+    const trimmed = query.trim();
+    if (!trimmed) {
+      clear();
+      return;
+    }
+    // A retry after a failed search must not render results under the stale
+    // red banner — clear it up front, like handleSync/selectContainer do.
+    setError(null);
+    queryRef.current = trimmed;
+    setActive(true);
+    paged.start();
+  }, [clear, paged, query, setError]);
+
+  return {
+    query,
+    active,
+    items: paged.items,
+    loading: paged.loading,
+    loadingMore: paged.loadingMore,
+    hasMore: paged.hasMore,
+    setQuery,
+    submit,
+    clear,
+    loadMore: paged.loadMore,
+  };
+}


### PR DESCRIPTION
Offered to take or leave — this targets `feat/source-plugin-api-v2-host` and does **not** touch your branch directly. It closes the last two outstanding review threads on #1976, the two `chatgpt-codex-connector` module-size findings. Nothing is posted on #1976 itself.

It also does not touch the three files #2157 changes (`SourceProviderRow.tsx`, `SourceSettingsDialog.tsx`, `syncSourceModel.ts`), so the two can land in either order.

## First: the guidance is advisory, not CI-gated

Worth saying plainly before anyone treats these as blockers. `AGENTS.md:17` lists "split modules over ~400 non-generated lines" under **"House rules (review conventions, not linted, so self-police)"**, and names the real gates: typecheck, tests, test-wiring, wasm-type-sync, API-surface. Nothing in `.github/workflows` or `scripts/` measures TS module size. The Rust ratchet at `rust/processing/tests/module_size_ratchet.rs` is a genuine gate but references no `.ts`/`.tsx` file.

So the case for this PR is readability, not compliance. We think it stands on that alone — the seams below were already there, they just weren't file boundaries — but an "it reads fine as it is" is a perfectly good answer and nothing breaks if this sits.

We held it back earlier only because splitting these files while other #1976 fixes were still in flight would have collided with every one of them. Those fixes are now isolated in #2157, so the split can land cleanly.

## Seams

Cut along responsibility, not at line 400.

### `useSourceCatalogSync.ts` — 452 → 389

The hook was doing four jobs. Three of them are pure functions of their inputs and lift out whole:

| New module | Lines | What it owns |
|---|---|---|
| `sourceCatalogPaging.ts` | 58 | The two provider listing calls, the page constants, the `parentId` normalisation for direct children, and page appending. |
| `sourceCatalogCache.ts` | 70 | localStorage read/write, plus `isCatalogCacheable` — the capability predicate deciding whether an area's catalog can *ever* be cached. That rule was previously an inline `!flatSubtree \|\| !listFilesIsRecursive` duplicated across two callbacks; it now lives with the persistence code it constrains. |
| `sourceCatalogSelectors.ts` | 62 | The derived views: dedupe-by-id across pages, catalog completeness, map-key resolution, cursor checks. |

`folderKeyFor` and `fileKeyFor` were the same expression twice over different capability flags; they collapse into one `resolveCatalogKey(area, selected, keyedByArea)`. Same for `hasMoreFolders`/`hasMoreFiles` → `pageHasMore`, the two `folders`/`allFiles` memos → `collectUniqueById`, and the two identical `loadMore*` merge blocks → `appendPage`.

What remains in the hook is the one thing that genuinely needs to be a hook: the request lifecycle — generation counters, abort controllers, and the loading flags. The two `useCallback` fetch wrappers stay so every dependency array is unchanged.

### `SourceBrowser.tsx` — 445 → 317

The container's data wiring versus everything hanging off it:

| New module | Lines | What it owns |
|---|---|---|
| `useSourceFileSearch.ts` | 86 | The server-side search state machine: query box, whether results are displacing the folder listing, and the paged result list. Cohesive — every piece of it was only ever touched by the other pieces. |
| `useLoadedSourceModels.ts` | 118 | The bridge to models already open in the viewer: which listed files are loaded, under what names, and re-syncing them. |
| `SourceFileAreasStep.tsx` | 45 | The file-areas list. |

`useLoadedSourceModels` is the seam that pays for itself: it was the *only* reason `SourceBrowser` imported `useIfc`, `useViewerStore`, `useSourceHost`, `syncSourceModel` and `toast`. With it gone the browser is a listing UI and nothing more — it no longer reaches into the viewer's model state at all.

`SourceFileAreasStep` is smaller but fixes an asymmetry: `SourceProjectsStep` and `SourceFolderStep` were already components while the file-areas step was inline JSX, so the three sibling steps now read the same way. Deliberately kept **presentational** — its `usePagedList` state stays in the container, because moving it into the component would make it unmount on entering a file area and re-fetch the listing on the way back out. That would have been a behaviour change.

## Proof behaviour is unchanged

No existing test was modified — that was the constraint, on the reasoning that a test needing a change is evidence the split changed something.

Full `apps/viewer` suite, same machine, packages built in both runs:

| | tests | suites | pass | fail | skipped |
|---|---|---|---|---|---|
| base (`5efb03d6`) | 2244 | 507 | 2242 | 0 | 2 |
| after | 2248 | 508 | 2246 | 0 | 2 |

The delta is exactly the one new test file. The two suites covering this code (`useSourceCatalogSync.test.tsx`, `SourceFolderTree.test.ts`) run 5/5 unchanged.

`pnpm typecheck` passes (34/34 tasks) and `pnpm check:test-wiring` passes. Note that `apps/viewer` test files *are* typechecked: the root `tsconfig.json:123` excludes `**/*.test.ts`, but `apps/viewer/tsconfig.json` overrides `exclude` with only `src/lib/scripts/templates` — `tsc --showConfig` resolves 205 `.test.*` files into the viewer program.

## The one new test

`sourceCatalogSelectors.test.ts` (4 tests). The split made these functions reachable, and two of them encode rules worth pinning:

- `resolveCatalogKey` decides which listing "Load more" paginates. Swapping its two branches (`keyedByArea ? area.fileAreaId : (selected ?? area.fileAreaId)` → the reverse) — **1 replacement, test fails.**
- `isCatalogComplete` returning `size > 0 || size > 0` is what stops the "this folder has no files" empty state firing before the first listing lands. Replacing that line with `return true` — **1 replacement, test fails.**

Both mutations reverted from a backup taken before either was applied.