### PR TITLE
test(viewer): pin the map-conversion rotation cross terms (identity-fixture vacuity)

### DIFF
--- a/apps/viewer/src/lib/geo/cesium-placement.test.ts
+++ b/apps/viewer/src/lib/geo/cesium-placement.test.ts
@@ -110,6 +110,13 @@ describe('cesium placement helpers', () => {
   });
 
   it('computes OrthogonalHeight from target base altitude with shift and RTC', () => {
+    // storeyElevations picks the clamp anchor (ground-floor storey) that
+    // targetBaseAltitude gets measured from — see findClampAnchorY. A
+    // storey at elevation 0 makes that term vanish from the subtraction,
+    // silently passing even if the anchor-Y term were dropped entirely.
+    // Use a genuinely non-zero elevation so the anchor term is load-bearing.
+    const storeyElevations = new Map([[1, 5]]);
+    assert.notStrictEqual(storeyElevations.get(1), 0, 'fixture must use a non-zero storey elevation');
     const orthogonalHeight = computeOrthogonalHeightForBaseAltitude({
       coordinateInfo: {
         originShift: { x: 0, y: 2, z: 0 },
@@ -126,11 +133,12 @@ describe('cesium placement helpers', () => {
       },
       projectedCRS: { mapUnitScale: 0.3048 },
       lengthUnitScale: 1,
-      storeyElevations: new Map([[1, 0]]),
+      storeyElevations,
       targetBaseAltitude: 245,
     });
 
-    assert.strictEqual(orthogonalHeight, 787.4);
+    // 245 - shiftY(2) - rtcYupY(3) - anchorY(5) = 235 meters; /0.3048 mapUnitScale.
+    assert.strictEqual(orthogonalHeight, 771);
   });
 
   it('computes the IFC origin height from OrthogonalHeight and model center', () => {

--- a/apps/viewer/src/lib/geo/cesium-placement.test.ts
+++ b/apps/viewer/src/lib/geo/cesium-placement.test.ts
@@ -179,6 +179,42 @@ describe('cesium placement helpers', () => {
     assert.deepStrictEqual(viewer, { x: 2, z: -1 });
   });
 
+  it('rotates viewer XY drag deltas by a genuine (non-identity) grid rotation', () => {
+    // A no-rotation fixture (xAxisAbscissa: 1, xAxisOrdinate: 0) zeroes the
+    // cross terms of the rotation matrix (`ordinate * deltaZ` in eastMeters,
+    // `abscissa * deltaZ` cancelling with a zero ordinate elsewhere), so a
+    // sign error in those terms is invisible to it. Use a real rotation
+    // (cos/sin of a 3-4-5 angle) with both delta components nonzero so every
+    // term of the 2x2 rotation actually contributes to the result.
+    const rotation = { xAxisAbscissa: 0.6, xAxisOrdinate: 0.8, scale: 1 };
+    // Decay-proofing: the fixture itself must stay a genuine rotation — both
+    // axes nonzero and distinct — or this test silently degrades back to the
+    // identity case it was written to replace.
+    assert.notStrictEqual(rotation.xAxisAbscissa, 0);
+    assert.notStrictEqual(rotation.xAxisOrdinate, 0);
+    assert.notStrictEqual(rotation.xAxisAbscissa, rotation.xAxisOrdinate);
+
+    const projected = viewerDeltaToProjectedDelta(1, 2, rotation, { mapUnitScale: 1 }, 1);
+
+    // eastMeters = 0.6*1 + 0.8*2 = 2.2; northMeters = 0.8*1 - 0.6*2 = -0.4.
+    assert.ok(Math.abs(projected.eastings - 2.2) < 1e-9, `eastings = ${projected.eastings}`);
+    assert.ok(Math.abs(projected.northings - -0.4) < 1e-9, `northings = ${projected.northings}`);
+  });
+
+  it('rotates projected map deltas back to viewer deltas by a genuine (non-identity) grid rotation', () => {
+    const rotation = { xAxisAbscissa: 0.6, xAxisOrdinate: 0.8, scale: 1 };
+    assert.notStrictEqual(rotation.xAxisAbscissa, 0);
+    assert.notStrictEqual(rotation.xAxisOrdinate, 0);
+    assert.notStrictEqual(rotation.xAxisAbscissa, rotation.xAxisOrdinate);
+
+    // Inverse of the forward-rotation case above: (2.2, -0.4) must round-trip
+    // back to the original (1, 2) viewer delta.
+    const viewer = projectedDeltaToViewerDelta(2.2, -0.4, rotation, { mapUnitScale: 1 }, 1);
+
+    assert.ok(Math.abs(viewer.x - 1) < 1e-9, `x = ${viewer.x}`);
+    assert.ok(Math.abs(viewer.z - 2) < 1e-9, `z = ${viewer.z}`);
+  });
+
   it('intersects a downward ray with a horizontal plane at the expected point', () => {
     const hit = intersectRayWithHorizontalPlane(
       { origin: { x: 5, y: 10, z: -3 }, direction: { x: 0, y: -1, z: 0 } },

--- a/apps/viewer/src/lib/geo/ifc-origin.test.ts
+++ b/apps/viewer/src/lib/geo/ifc-origin.test.ts
@@ -103,6 +103,52 @@ describe('computeIfcOriginViewerPosition', () => {
     assert.ok(Math.abs(out!.viewer.z - -50) < 1e-9, `viewer.z = ${out!.viewer.z}`);
   });
 
+  it('inverts a non-identity anchor rotation+scale correctly (mutation-testing round 6)', async () => {
+    // Every other same-CRS test in this file uses makeConversion's fixed
+    // xAxisAbscissa: 1, xAxisOrdinate: 0, scale: 1 for BOTH models — an
+    // identity rotation with no scaling. Mutation testing found that lets a
+    // sign flip on either rotation cross-term, a dropped ordinate term in
+    // anchorDenom, or the anchor's effective-scale computation being
+    // hardcoded to 1 all survive undetected, because the (1, 0)/scale=1
+    // fixture makes each of those terms either zero or a no-op. This test
+    // gives the ANCHOR a genuine rotation (36.87 deg: abscissa 0.6,
+    // ordinate 0.8) and a non-unit scale, and pins the exact expected
+    // viewer position via an independent hand-derivation (see comments).
+    const anchorConv: MapConversion = {
+      id: 100, sourceCRS: 10, targetCRS: 1,
+      eastings: 124000, northings: 477000, orthogonalHeight: 0,
+      xAxisAbscissa: 0.6, xAxisOrdinate: 0.8, scale: 2,
+    };
+    assert.notStrictEqual(anchorConv.xAxisOrdinate, 0, 'fixture must use a non-zero rotation ordinate');
+    assert.notStrictEqual(anchorConv.scale, 1, 'fixture must use a non-unit scale');
+    const anchor: ModelGeorefInput = {
+      coordinateInfo: emptyCoordinateInfo(),
+      mapConversion: anchorConv,
+      projectedCRS: rdCrs(),
+      lengthUnitScale: 1,
+    };
+    const otherConv = makeConversion(124100, 477050);
+    const other: ModelGeorefInput = {
+      coordinateInfo: emptyCoordinateInfo(),
+      mapConversion: otherConv,
+      projectedCRS: rdCrs(),
+      lengthUnitScale: 1,
+    };
+    const out = await computeIfcOriginViewerPosition(other, anchor);
+    assert.ok(out);
+    assert.strictEqual(out!.source, 'anchor');
+    // dE = 100, dN = 50. anchorScale = 2 (Scale=2, mapUnitScale=lengthUnitScale=1,
+    // so the IFC-schema unit-bridge heuristic doesn't override it).
+    // anchorDenom = anchorScale * (absc^2 + ord^2) = 2 * (0.36 + 0.64) = 2.
+    // invDenom = 0.5.
+    // ifcX = invDenom * (absc*dE + ord*dN) = 0.5 * (0.6*100 + 0.8*50) = 50.
+    // ifcY = invDenom * (-ord*dE + absc*dN) = 0.5 * (-0.8*100 + 0.6*50) = -25.
+    // viewer = { x: ifcX, y: ifcZ(=0), z: -ifcY } (anchor's own shift/RTC are 0).
+    assert.ok(Math.abs(out!.viewer.x - 50) < 1e-9, `viewer.x = ${out!.viewer.x}`);
+    assert.ok(Math.abs(out!.viewer.y - 0) < 1e-9, `viewer.y = ${out!.viewer.y}`);
+    assert.ok(Math.abs(out!.viewer.z - 25) < 1e-9, `viewer.z = ${out!.viewer.z}`);
+  });
+
   it('accounts for orthogonalHeight differences (vertical offset)', async () => {
     const anchor: ModelGeorefInput = {
       coordinateInfo: emptyCoordinateInfo(),

--- a/apps/viewer/src/lib/geo/reproject.test.ts
+++ b/apps/viewer/src/lib/geo/reproject.test.ts
@@ -19,6 +19,9 @@ import {
 import type { CoordinateInfo } from '@ifc-lite/geometry';
 import type { MapConversion, ProjectedCRS } from '@ifc-lite/parser';
 
+const close = (a: number, b: number, eps = 1e-6) =>
+  assert.ok(Math.abs(a - b) < eps, `expected ${a} to be close to ${b}`);
+
 function makeCoordinateInfo(): CoordinateInfo {
   return {
     originShift: { x: 1000, y: 5, z: 2000 },
@@ -135,6 +138,47 @@ describe('reproject helpers', () => {
     assert.ok(roundTrip);
     assert.ok(Math.abs(roundTrip!.easting - conversion.eastings) < 0.01);
     assert.ok(Math.abs(roundTrip!.northing - conversion.northings) < 0.01);
+  });
+
+  it('round-trips with a non-identity rotation AND a non-zero geometry center (mutation-testing round 6)', async () => {
+    // Every other round-trip test in this file uses BOTH xAxisOrdinate: 0
+    // (no rotation) AND an omitted/default coordinateInfo (geometry center
+    // ifcX = ifcY = 0). Mutation testing found that combination makes the
+    // rotation cross-term (ordinate * ifcX/ifcY) in computeProjectedCenter
+    // and reprojectFromLatLon's inverse vanish for EITHER reason alone, so a
+    // sign flip in either function's rotation term survives undetected. This
+    // fixture uses a non-trivial rotation AND a non-zero model-center offset
+    // so the cross-term is load-bearing in both directions.
+    const crs: ProjectedCRS = { id: 1, name: 'EPSG:28992', mapUnit: 'METRE', mapUnitScale: 1 };
+    const conversion: MapConversion = {
+      id: 2,
+      sourceCRS: 10,
+      targetCRS: 1,
+      eastings: 121687.331,
+      northings: 487326.994,
+      orthogonalHeight: 0,
+      xAxisAbscissa: 0.6,
+      xAxisOrdinate: 0.8,
+      scale: 1,
+    };
+    const coordinateInfo = makeCoordinateInfo();
+    const { ifcX, ifcY } = computeModelCenterInIfcMeters(coordinateInfo);
+    assert.notStrictEqual(conversion.xAxisOrdinate, 0, 'fixture must use a non-zero rotation ordinate');
+    assert.notStrictEqual(ifcX, 0, 'fixture must use a non-zero geometry-center ifcX');
+    assert.notStrictEqual(ifcY, 0, 'fixture must use a non-zero geometry-center ifcY');
+
+    const latLon = await reprojectToLatLon(conversion, crs, coordinateInfo);
+    assert.ok(latLon);
+    const roundTrip = await reprojectFromLatLon(latLon!, crs, conversion, coordinateInfo);
+    assert.ok(roundTrip);
+    assert.ok(
+      Math.abs(roundTrip!.easting - conversion.eastings) < 0.01,
+      `easting round-trip: ${roundTrip!.easting} vs ${conversion.eastings}`,
+    );
+    assert.ok(
+      Math.abs(roundTrip!.northing - conversion.northings) < 0.01,
+      `northing round-trip: ${roundTrip!.northing} vs ${conversion.northings}`,
+    );
   });
 
   it('resolves Dutch RD New from a non-EPSG name via WELL_KNOWN_CRS', async () => {
@@ -274,6 +318,80 @@ describe('reproject helpers', () => {
     assert.ok(footprint);
     assert.strictEqual(footprint!.length, 5);
     assert.deepStrictEqual(footprint![0], footprint![4]);
+  });
+
+  it('places each footprint corner at the position an independent rotation+shift+RTC calculation predicts (mutation-testing round 6)', async () => {
+    // The "preserves corner count" test above only checks length===5 and
+    // ring[0]===ring[4] (closure) — mutation testing found it does NOT pin
+    // the actual corner positions: dropping the RTC offset, dropping the
+    // origin shift, flipping the rotation sign, negating the Y-up->Z-up
+    // ifcY flip, or reordering the four corners all left it green. This
+    // test recomputes each corner independently (same documented formula,
+    // written separately from computeFootprintGeoJSON's implementation) and
+    // asserts the real function's output matches within a tight tolerance.
+    const crs: ProjectedCRS = { id: 1, name: 'EPSG:32632', mapUnit: 'METRE', mapUnitScale: 1 };
+    const conversion: MapConversion = {
+      id: 2,
+      sourceCRS: 1,
+      targetCRS: 1,
+      eastings: 500_000,
+      northings: 5_000_000,
+      orthogonalHeight: 0,
+      // Non-identity rotation (unit vector, NOT the (1, 0) no-rotation case)
+      // so a sign flip on either axis actually moves the projected point.
+      xAxisAbscissa: 0.6,
+      xAxisOrdinate: 0.8,
+      scale: 1,
+    };
+    const coordinateInfo: CoordinateInfo = {
+      // Non-zero shift and RTC so dropping either term is detectable.
+      originShift: { x: 100, y: 5, z: -50 },
+      originalBounds: { min: { x: -10, y: -1, z: -20 }, max: { x: 10, y: 11, z: 20 } },
+      shiftedBounds: { min: { x: -10, y: -1, z: -20 }, max: { x: 10, y: 11, z: 20 } },
+      hasLargeCoordinates: false,
+      wasmRtcOffset: { x: 7, y: 3, z: 11 },
+    };
+    // Fixture sanity: these are the exact properties whose absence made the
+    // count/closure-only test above vacuous. If any of these decay back to
+    // the identity/zero case, this test stops discriminating the mutations
+    // it was written to catch.
+    assert.notStrictEqual(conversion.xAxisOrdinate, 0, 'fixture must use a non-zero rotation ordinate');
+    assert.notStrictEqual(coordinateInfo.originShift.x, 0, 'fixture must use a non-zero origin shift');
+    assert.notStrictEqual(coordinateInfo.wasmRtcOffset!.x, 0, 'fixture must use a non-zero RTC offset');
+
+    const footprint = await computeFootprintGeoJSON(conversion, crs, coordinateInfo, 1);
+    assert.ok(footprint);
+    assert.strictEqual(footprint!.length, 5);
+
+    const projDef = await resolveProjection(crs);
+    assert.ok(projDef);
+    const proj4mod = (await import('proj4')).default;
+
+    const { abscissa, ordinate } = { abscissa: conversion.xAxisAbscissa!, ordinate: conversion.xAxisOrdinate! };
+    const rtc = coordinateInfo.wasmRtcOffset!;
+    const shift = coordinateInfo.originShift;
+    const rtcYup = { x: rtc.x, z: -rtc.y };
+    const bounds = coordinateInfo.shiftedBounds;
+    const expectedCorners = [
+      { x: bounds.min.x, z: bounds.min.z },
+      { x: bounds.max.x, z: bounds.min.z },
+      { x: bounds.max.x, z: bounds.max.z },
+      { x: bounds.min.x, z: bounds.max.z },
+    ].map((c) => {
+      const worldX = c.x + shift.x + rtcYup.x;
+      const worldZ = c.z + shift.z + rtcYup.z;
+      const ifcX = worldX;
+      const ifcY = -worldZ;
+      const easting = conversion.eastings + (abscissa * ifcX - ordinate * ifcY);
+      const northing = conversion.northings + (ordinate * ifcX + abscissa * ifcY);
+      const [lon, lat] = proj4mod(projDef!, 'WGS84', [easting, northing]);
+      return [lon, lat] as [number, number];
+    });
+
+    for (let i = 0; i < 4; i++) {
+      close(footprint![i][0], expectedCorners[i][0], 1e-6);
+      close(footprint![i][1], expectedCorners[i][1], 1e-6);
+    }
   });
 });
 


### PR DESCRIPTION
Test-only. No production code changed.

## The gap

`viewerDeltaToProjectedDelta` and `projectedDeltaToViewerDelta` (`apps/viewer/src/lib/geo/cesium-placement.ts`) apply the IfcMapConversion 2×2 grid rotation. Their only direct unit tests used the **identity fixture** `{ xAxisAbscissa: 1, xAxisOrdinate: 0 }`, which zeroes every `ordinate * …` cross term.

`pick-to-geo.test.ts` *does* exercise a real 60° rotation — but only through `viewerPointToProjected` with `deltaZ = 0`, which independently zeroes the *other* cross term. So across both files, no test ever had a non-zero rotation ordinate **and** a non-zero second delta component at the same time. The rotation was covered on paper and uncovered in fact.

## Evidence

Exact-substring mutations, replacement count printed and asserted `n == 1`, mutated line re-read. Command: `npx tsx --test src/lib/geo/cesium-placement.test.ts src/lib/geo/pick-to-geo.test.ts`.

| # | Mutation | Before | After |
|---|---|---|---|
| 1 | `eastMeters = hScale * (abscissa * deltaX `**`+`**` ordinate * deltaZ)` → `-` | 29 tests, **29 pass, 0 fail** (survivor) | 31 tests, 30 pass, **1 fail** |
| 2 | `z: (`**`ordinate`**` * eastMeters - abscissa * northMeters)` → `-ordinate` | 29 tests, **29 pass, 0 fail** (survivor) | 31 tests, 30 pass, **1 fail** |

**Control** — flipped the already-covered `- abscissa * deltaZ` term in `northMeters`: died immediately, 26 pass / **3 fail** of 29. So the suite discriminates fine; it was blind specifically to the cross terms.

**The production code is correct.** This is a coverage defect, not a behaviour defect — but an unpinned rotation is exactly where a future refactor lands a silent sign error, and a sign error here mis-places every dragged element on a rotated site grid.

## The fix, made decay-proof

Two cases using a genuine oblique rotation `(0.6, 0.8)` — a real unit vector, 3-4-5 angle — with both delta components non-zero, so every term of the matrix contributes:

- forward: `east = 0.6·1 + 0.8·2 = 2.2`, `north = 0.8·1 − 0.6·2 = −0.4`
- inverse: `(2.2, −0.4)` round-trips back to `(1, 2)`

Each asserts on the **fixture itself** — both axes non-zero and mutually distinct — so it cannot quietly decay back into the identity case it was written to replace.

One detail worth keeping: these use tolerance comparisons rather than `deepStrictEqual`, because `0.8*1 - 0.6*2` lands on `-0.3999999999999999`. An exact-equality assertion on non-dyadic fixtures is a flake waiting to happen.

Full geo suite after the change: **207 pass, 0 fail**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression coverage for rotated grids, non-zero elevations, and scaled model anchors.
  * Improved validation of forward and inverse coordinate transformations.
  * Added round-trip reprojection and footprint checks, including projected GeoJSON coordinates and polygon closure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->