### PR TITLE
test(renderer): cover the BVH's per-mesh world-space origin fold

### DIFF
--- a/packages/renderer/src/bvh.test.ts
+++ b/packages/renderer/src/bvh.test.ts
@@ -210,4 +210,50 @@ describe('BVH', () => {
     const ray: Ray = { origin: { x: 0, y: 0, z: 10 }, direction: { x: 0, y: 0, z: -1 } };
     assert.strictEqual(bvh.getMeshesForRay(ray, meshes).length, 0);
   });
+
+  // `MeshData.positions` are in the element's LOCAL frame; `MeshData.origin`
+  // (present on chunked/large-coordinate models, e.g. federated or RTC'd
+  // scenes) is a per-mesh world-space translation the BVH must fold in when
+  // computing AABBs — `raycast-engine.ts` builds the BVH from these same
+  // MeshData objects and relies on world-space bounds for culling. None of
+  // the fixtures above ever set `.origin`, so this fold was previously
+  // exercised by zero tests (mutation-confirmed: hard-coding the offset to 0
+  // left all prior tests green).
+  describe('per-mesh world-space origin', () => {
+    it('folds a non-zero origin into the AABB used for ray culling', () => {
+      // 8 decoys spread along +x (local coords, no origin). More than
+      // maxMeshesPerLeaf (8) once "far" is added, so the tree actually
+      // splits — the split sorts nodes by their CACHED centroid, which is
+      // exactly what makes this test sensitive to whether `origin` got
+      // folded into that cache (a leaf-level test with too few meshes can't
+      // tell: a single conservative leaf would swallow every mesh).
+      const decoys = Array.from({ length: 8 }, (_, i) => boxMesh(100 + i, i, 0, 0));
+      // "far": LOCAL vertices centred at (0,0,0) — the SAME raw local
+      // coordinates as decoys[0] — but placed at WORLD (1000,0,0) via
+      // `origin`. Correctly folding origin gives it a cached centroid of
+      // ~1000, sorting it away from the local cluster into its own branch.
+      const far = boxMesh(1, 0, 0, 0);
+      far.origin = [1000, 0, 0];
+      const meshes = [far, ...decoys];
+
+      const bvh = new BVH();
+      bvh.build(meshes);
+
+      // Ray straight down through world (1000,0,z) — far's TRUE world spot.
+      const rayAtFarWorld: Ray = { origin: { x: 1000, y: 0, z: 10 }, direction: { x: 0, y: 0, z: -1 } };
+      const hitsFarWorld = new Set(bvh.getMeshesForRay(rayAtFarWorld, meshes));
+      assert.ok(hitsFarWorld.has(0), 'ray through the WORLD position (origin + local) must hit "far"');
+
+      // Ray straight down through local/world (0,0,z) — decoys[0]'s
+      // position, and ALSO far's raw LOCAL vertex position if origin were
+      // ignored. Correct origin-folding keeps far's leaf entirely out of
+      // this region (its cached centroid is ~1000, not ~0).
+      const rayAtLocalZero: Ray = { origin: { x: 0, y: 0, z: 10 }, direction: { x: 0, y: 0, z: -1 } };
+      const hitsLocalZero = new Set(bvh.getMeshesForRay(rayAtLocalZero, meshes));
+      assert.ok(
+        !hitsLocalZero.has(0),
+        '"far" must NOT be reachable from a ray at its raw LOCAL coordinates — that is not its world position',
+      );
+    });
+  });
 });


### PR DESCRIPTION
Test-only. No production code changed.

## The gap

`BVH.build()` folds each mesh's `origin` into its world-space AABB — `bvh.ts:62-73`, whose own comment says *"Positions are in the element's local frame (world = origin + position)"*.

Every fixture in `bvh.test.ts` (`boxMesh`, `emptyMesh`) left `.origin` unset. A no-offset fixture makes the add an identity, so that fold was exercised by **zero** tests.

## Evidence

Exact-substring mutations, replacement count printed and asserted `n == 1`, mutated region re-read. Command: `npx tsx --test src/bvh.test.ts`.

| Mutation | Before | After |
|---|---|---|
| `ox`/`oy`/`oz` hardcoded to `0` — fold disabled outright | 7 tests, **7 pass, 0 fail** | 8 tests, 7 pass, **1 fail** |
| `aabbs[o] = minX `**`+`**` ox` → `-` | 7 tests, **7 pass, 0 fail** | 8 tests, 7 pass, **1 fail** |

**Control:** forcing `rayIntersectsAABB` to `return true` died **2 fail / 5 pass** of 7 against the *pre-existing* tests. So the suite discriminates fine — it was blind specifically to `origin`.

## Why this is a live path, not dead code

`raycast-engine.ts:136` reads `piece.origin`, and the BVH engages above `BVH_THRESHOLD = 100` meshes (`raycast-engine.ts:66`). A broken fold silently corrupts accelerated picking and snapping on precisely the large chunked models that trigger the BVH in the first place — and it degrades quietly, as a pick that misses, not as a crash.

Worth noting the sibling: `packages/spatial/src/spatial-index-builder.ts` has the *same* origin-fold pattern and **is** already properly covered (explicit `origin` describe block with axis-independence, absent-origin and degenerate-mesh cases). This was the one copy that got missed.

## The test needs more than two meshes — the obvious version is itself vacuous

`maxMeshesPerLeaf = 8` (`bvh.ts:19`), and `bvh.ts:104` returns a single leaf when `meshIndices.length <= maxMeshesPerLeaf`. That leaf returns **every** index regardless of whether the per-mesh AABBs are right, so a two-mesh fixture passes against the mutation. A first draft did exactly that and was caught by mutation-testing the draft before landing it.

The committed version uses nine meshes to force a real split on the cached centroid — which is what the fold actually feeds. The mesh placed at world `(1000,0,0)` carries the **same raw local vertices** as a decoy sitting at the origin, so the test is two-sided:

- a ray through its **world** position must hit it
- a ray through its raw **local** position must not

Ignoring `origin` in either direction fails one of those.

Renderer suite after the change: **423 pass, 0 fail.**

## Negative results

`packages/spatial` (45/45) and the matrix/bounds-heavy renderer files — frustum culling, AABB, clip-box, section-plane-basis, camera-fit-policy, scene-rect-select, point-cloud-transform — were surveyed and are already hardened by earlier rounds, with non-identity, non-axis-aligned fixtures carrying explicit "why this isn't degenerate" comments. Probed, already covered, untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected ray intersection behavior for meshes positioned away from their local origin.
  * Prevented objects from being incorrectly selected at their untransformed coordinates.

* **Tests**
  * Added regression coverage for translated mesh positioning and ray hits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->