### PR TITLE
fix(data,cache): stop sumByType silently ignoring its elementType filter

### DIFF
--- a/.changeset/quantity-sumbytype-elementtype.md
+++ b/.changeset/quantity-sumbytype-elementtype.md
@@ -1,0 +1,12 @@
+---
+"@ifc-lite/data": patch
+"@ifc-lite/cache": patch
+---
+
+Stop `QuantityTable.sumByType` from silently ignoring its declared `elementType` filter.
+
+`sumByType(quantityName, elementType?)` declares an optional element-type filter, but two of the three implementations were arity-1 closures that dropped it: the columnar table in `@ifc-lite/data` and the cache-restored table in `@ifc-lite/cache`. The third — the server-backed table in `apps/viewer` — honours it for real, resolving ids through `entities.getByType`. So three implementations of one interface disagreed, and a caller holding the interface type had no way to tell which behaviour it would get.
+
+The failure mode mattered more than the type-level inaccuracy: a dropped filter returns a total over *every* element rather than an error, and in a quantity context a plausible wrong number is worse than a loud failure. No caller passes the second argument today, so nothing changes for existing code.
+
+Neither implementation can honour the filter as written — both see only `entityId` per row, with the entity-type mapping living in `EntityTable`. Rather than leave the contract lying, both now throw when `elementType` is passed, naming the supported route (resolve ids via `entities.getByType(elementType)` and total the matching rows). The interface doc records why.

--- a/packages/cache/src/sections/quantities.test.ts
+++ b/packages/cache/src/sections/quantities.test.ts
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `QuantityTable.sumByType` declares an optional `elementType` parameter,
+ * but neither this cache-restored implementation nor the columnar one in
+ * `@ifc-lite/data` has per-row entity-type data to honor it. Before this
+ * test existed, both silently dropped `elementType` and returned the
+ * unfiltered total — a caller who trusted the type signature would get a
+ * wrong-but-plausible number instead of an error. They now throw instead.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { StringTable, QuantityTableBuilder, quantityTableToColumns } from '@ifc-lite/data';
+import { QuantityType } from '@ifc-lite/data';
+import { BufferWriter, BufferReader } from '../utils/buffer-utils.js';
+import { writeQuantities, readQuantities } from './quantities.js';
+
+function buildFixture() {
+  const strings = new StringTable();
+  const builder = new QuantityTableBuilder(strings);
+  // Two entities, same quantity name, deliberately different values so a
+  // filtered vs. unfiltered sum cannot accidentally coincide.
+  builder.add({ entityId: 1, qsetName: 'Qto_WallBaseQuantities', quantityName: 'NetArea', quantityType: QuantityType.Area, value: 10 });
+  builder.add({ entityId: 2, qsetName: 'Qto_DoorBaseQuantities', quantityName: 'NetArea', quantityType: QuantityType.Area, value: 100 });
+  return { strings, table: builder.build() };
+}
+
+function roundTrip(strings: StringTable, table: ReturnType<typeof buildFixture>['table']) {
+  const writer = new BufferWriter();
+  writeQuantities(writer, table);
+  return readQuantities(new BufferReader(writer.build()), strings);
+}
+
+describe('cache QuantityTable.sumByType', () => {
+  it('sums across entities when no elementType is given (unfiltered)', () => {
+    const { strings, table } = buildFixture();
+    const restored = roundTrip(strings, table);
+    // Fixture property: both rows are included, so the sum is neither row's
+    // value alone — this pins down that "unfiltered" really means "all rows".
+    expect(restored.sumByType('NetArea')).toBeCloseTo(110);
+  });
+
+  it('throws when elementType is passed, instead of silently ignoring it', () => {
+    const { strings, table } = buildFixture();
+    const restored = roundTrip(strings, table);
+    expect(() => restored.sumByType('NetArea', 42)).toThrow(/elementType/);
+  });
+});

--- a/packages/cache/src/sections/quantities.ts
+++ b/packages/cache/src/sections/quantities.ts
@@ -130,7 +130,18 @@ export function readQuantities(reader: BufferReader, strings: StringTable): Quan
       return results;
     },
 
-    sumByType: (quantName) => {
+    // See `QuantityTable.sumByType`'s doc in `@ifc-lite/data`'s
+    // `quantity-table.ts`: a cache-restored table has no per-row entity-type
+    // data either, so `elementType` throws rather than being silently
+    // dropped (it used to return the unfiltered total).
+    sumByType: (quantName, elementType) => {
+      if (elementType !== undefined) {
+        throw new Error(
+          'QuantityTable.sumByType: elementType filtering is not supported by a ' +
+            'cache-restored table — it has no per-row entity-type data. Resolve entity ids ' +
+            'via entities.getByType(elementType) and sum the matching rows yourself.',
+        );
+      }
       const quantIdx = strings.indexOf(quantName);
       if (quantIdx < 0) return 0;
 

--- a/packages/data/src/property-table.test.ts
+++ b/packages/data/src/property-table.test.ts
@@ -121,6 +121,32 @@ describe('QuantityTable round-trip', () => {
   });
 });
 
+describe('QuantityTable.sumByType elementType', () => {
+  // The interface declares an optional `elementType` filter, but the
+  // columnar table only stores `entityId` per row — no entity-type data —
+  // so it cannot honor a filtered sum. It must fail loudly rather than
+  // silently return the unfiltered total (issue: declared-but-ignored param).
+  function buildFixture() {
+    const strings = new StringTable();
+    const builder = new QuantityTableBuilder(strings);
+    // Two entities, deliberately different values, so an accidental
+    // unfiltered-vs-filtered coincidence can't mask the bug.
+    builder.add({ entityId: 1, qsetName: 'Qto_WallBaseQuantities', quantityName: 'NetArea', quantityType: QuantityType.Area, value: 10 });
+    builder.add({ entityId: 2, qsetName: 'Qto_DoorBaseQuantities', quantityName: 'NetArea', quantityType: QuantityType.Area, value: 100 });
+    return builder.build();
+  }
+
+  it('sums every row when elementType is omitted', () => {
+    const table = buildFixture();
+    expect(table.sumByType('NetArea')).toBeCloseTo(110);
+  });
+
+  it('throws when elementType is passed instead of silently ignoring it', () => {
+    const table = buildFixture();
+    expect(() => table.sumByType('NetArea', 42)).toThrow(/elementType/);
+  });
+});
+
 describe('QuantityTable.findByQuantity', () => {
   // `EntityQuery.whereProperty('Qto_...', 'NetArea', '>', 10)` is documented but
   // quantities are not property rows, so the filter needs a quantity-side index

--- a/packages/data/src/quantity-table.ts
+++ b/packages/data/src/quantity-table.ts
@@ -60,6 +60,19 @@ export interface QuantityTable {
     value: PropertyValue,
     qsetName?: string,
   ): number[];
+  /**
+   * Sum every `quantityName` row, optionally restricted to entities of
+   * `elementType` (an `IfcTypeEnum` value).
+   *
+   * The columnar implementation here and the cache-restored implementation in
+   * `@ifc-lite/cache`'s `readQuantities` only ever see `entityId` per row —
+   * neither has the entity-type data needed to honor `elementType`, so both
+   * THROW when it is passed rather than silently returning the unfiltered
+   * total. A store that wants type-filtered sums must resolve entity ids via
+   * `entities.getByType(elementType)` itself and total the matching rows (see
+   * `apps/viewer`'s server-backed `QuantityTable`, which does have that data
+   * in scope and implements the filter for real).
+   */
   sumByType(quantityName: string, elementType?: number): number;
 }
 
@@ -191,7 +204,14 @@ export function quantityTableFromColumns(columns: QuantityTableColumns, strings:
       return results;
     },
 
-    sumByType: (quantName) => {
+    sumByType: (quantName, elementType) => {
+      if (elementType !== undefined) {
+        throw new Error(
+          'QuantityTable.sumByType: elementType filtering is not supported by this ' +
+            'columnar table — it has no per-row entity-type data. Resolve entity ids via ' +
+            'entities.getByType(elementType) and sum the matching rows yourself.',
+        );
+      }
       const quantIdx = strings.indexOf(quantName);
       if (quantIdx < 0) return 0;
       const rowIndices = quantityIndex.get(quantIdx) || [];


### PR DESCRIPTION
@louistrue — this one changes behaviour on two published packages, and the remedy is a judgement call rather than a forced move. Details and alternatives below; happy to switch to whichever you prefer.

## The defect

`QuantityTable.sumByType(quantityName, elementType?: number)` declares an optional element-type filter. **Two of the three implementations silently drop it**, because they are arity-1 closures:

| implementation | honours `elementType`? |
|---|---|
| `packages/data/src/quantity-table.ts:204` | no — `(quantName) => {...}` |
| `packages/cache/src/sections/quantities.ts:133` | no — `(quantName) => {...}` |
| `apps/viewer/src/utils/serverDataModel.ts:750` | **yes** — builds a valid-id set from `entities.getByType(elementType)` |

Three implementations of one interface, disagreeing, with no way for a caller holding the interface type to tell which one it has.

## Not currently live — a landmine, not an active bug

I grepped every `sumByType` reference in the repo. The only call site is `tests/integration.test.ts:158`, and it passes a single argument. **Nothing returns a wrong total today.** I'd rather say that plainly than dress this up as a live bug.

What makes it worth fixing anyway is the failure mode. A dropped filter doesn't error — it returns a total over *every* element. In a quantity context that is a plausible-looking wrong number, which is the worst thing to produce silently.

## Why not just implement it

Neither implementation has the data. Both see only `entityId` per row; the entity-type mapping lives in `EntityTable`, assembled in `packages/parser`. Honouring the filter would mean either threading that through or bumping the cache binary format — a materially bigger change than this defect justifies, and one I didn't want to make unilaterally.

## What this PR does

Both implementations now **throw** when `elementType` is passed, naming the supported route (resolve ids via `entities.getByType(elementType)`, total the matching rows). Zero-argument calls are untouched. The interface doc records the reasoning so the next reader doesn't re-derive it.

## The alternatives, since this is your call

1. **Throw** (this PR) — fails loud. Cost: a runtime error on a call TypeScript permits.
2. **Remove `elementType` from the interface** — best developer experience, a compile error instead of a runtime one. Cost: the one implementation that *does* support filtering loses it for interface-typed callers.
3. **Implement it for real** — correct, but needs entity-type data plumbed into both tables and likely a cache format bump.

I went with 1 because it is the smallest change that stops a silently wrong quantity, and it leaves 2 and 3 open. Say the word if you'd rather have either.

## Verification

RED-GREEN both ways, by reverting each implementation to its arity-1 form (exact-substring, replacement count asserted `n == 1`):

- `packages/data`: **1 failed of 14** — `AssertionError: expected [Function] to throw an error`. Restored: **83 pass**.
- `packages/cache`: **1 failed of 2**, same assertion. Restored: **50 pass**.

Control (`sum += value[idx]` → `* 2` in the same function) dies as expected, so the surrounding suite isn't vacuous either.

Fixtures use two entities with deliberately different values (10 and 100), so the unfiltered total (110) can't coincide with a filtered one.

## Negative results

Reviewed `relationship-graph.ts`, `entity-table.ts`, `property-table.ts`, `storey-elevation.ts` and the `entities`/`properties`/`relationships` cache sections for the same shape. Their optional parameters (`type?`, `psetName?`, `relType?`) are all correctly threaded through to their closures — no further arity mismatches. `geometry.ts`, `instanced-shards.ts`, `header.ts`, `entity-index.ts` and `epsg-index.ts` were not reached and remain unexamined.