### PR TITLE
test(parser,encoding,cache): pin six unguarded boundaries

### DIFF
--- a/packages/cache/src/sections/instanced-shards.test.ts
+++ b/packages/cache/src/sections/instanced-shards.test.ts
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, it } from 'vitest';
+import { BufferReader, BufferWriter } from '../utils/buffer-utils.js';
+import { readInstancedShards, writeInstancedShards } from './instanced-shards.js';
+
+describe('readInstancedShards', () => {
+  it('round-trips shards through write/read', () => {
+    const shardA = new Uint8Array([1, 2, 3, 4]).buffer;
+    const shardB = new Uint8Array([5, 6]).buffer;
+    const writer = new BufferWriter();
+    writeInstancedShards(writer, [shardA, shardB]);
+    const reader = new BufferReader(writer.build());
+    const out = readInstancedShards(reader);
+    expect(out.length).toBe(2);
+    expect(Array.from(new Uint8Array(out[0]))).toEqual([1, 2, 3, 4]);
+    expect(Array.from(new Uint8Array(out[1]))).toEqual([5, 6]);
+  });
+
+  it('throws the specific "missing length" error when the buffer is truncated to exactly 3 bytes before a shard length prefix (#1238 boundary)', () => {
+    // Build a valid section (count=1, one 4-byte shard) then cut the buffer
+    // 1 byte short of the length prefix: 4 bytes for the count, plus exactly
+    // 3 of the 4 length-prefix bytes, and nothing else. This is the precise
+    // boundary the guard exists for: `remaining < 4` must catch it before
+    // readUint32() is ever called on an incomplete length field. A guard of
+    // `remaining < 3` would let this case fall through to readUint32(),
+    // which throws an unrelated RangeError instead of the intended,
+    // diagnosable "Truncated InstancedShards" error.
+    const shard = new Uint8Array([9, 9, 9, 9]).buffer;
+    const writer = new BufferWriter();
+    writeInstancedShards(writer, [shard]);
+    const full = new Uint8Array(writer.build());
+
+    // full layout: [count:4][len:4][shard bytes:4] = 12 bytes total.
+    expect(full.length).toBe(12);
+    const truncated = full.slice(0, 4 + 3); // count intact, length prefix cut to 3 bytes
+    expect(truncated.length).toBe(7);
+
+    const reader = new BufferReader(truncated.buffer);
+    expect(() => readInstancedShards(reader)).toThrow(
+      'Truncated InstancedShards: missing length for shard 0/1',
+    );
+  });
+});

--- a/packages/encoding/src/guid.test.ts
+++ b/packages/encoding/src/guid.test.ts
@@ -67,6 +67,25 @@ describe('guid', () => {
     expect(generateUuid(() => 0)).toBe('00000000-0000-4000-8000-000000000000');
   });
 
+  it('rejects an IFC GUID whose first character encodes a value above 3', () => {
+    // An IfcGloballyUniqueId packs a 128-bit UUID into 22 base64-like
+    // characters (22 * 6 = 132 bits), so the first character only carries
+    // the UUID's top 2 bits and must be restricted to values 0-3 (chars
+    // '0'..'3' in IFC_GUID_CHARS). '4' is the char at index 4, one past the
+    // valid range, so a well-formed-looking 22-char string starting with
+    // '4' must still be rejected.
+    const guid = `4${'0'.repeat(21)}`;
+    expect(guid).toHaveLength(22);
+    expect(isValidIfcGuid(guid)).toBe(false);
+  });
+
+  it('accepts every legal first character (0-3) and rejects the next value (4)', () => {
+    for (const validFirst of ['0', '1', '2', '3']) {
+      expect(isValidIfcGuid(`${validFirst}${'A'.repeat(21)}`)).toBe(true);
+    }
+    expect(isValidIfcGuid(`4${'A'.repeat(21)}`)).toBe(false);
+  });
+
   it('keeps the default path valid and non-repeating', () => {
     // Assert the CONTRACT (well-formed, distinct across a run) rather than a
     // single inequality: two draws colliding is astronomically unlikely but is

--- a/packages/encoding/src/ifc-string.test.ts
+++ b/packages/encoding/src/ifc-string.test.ts
@@ -86,6 +86,25 @@ describe('decodeIfcString', () => {
     expect(decodeIfcString('\\S\\D')).toBe('Ä');
   });
 
+  it('advances exactly one code unit past \\S\\ for a BMP codepoint at the 0xFFFF boundary', () => {
+    // \S\X reads X as a whole code point so it can skip a surrogate pair when
+    // X is astral, but U+FFFF itself is a single UTF-16 code unit (not a
+    // surrogate) and must NOT be treated as a 2-unit pair. Trailing 'Y'
+    // proves the offset: if the decoder over-advances by one unit here, 'Y'
+    // is silently swallowed instead of appended.
+    const input = `\\S\\${'￿'}Y`;
+    const expected = `${String.fromCodePoint(0xFFFF + 128)}Y`;
+    expect(decodeIfcString(input)).toBe(expected);
+  });
+
+  it('advances two code units past \\S\\ for an astral (non-BMP) codepoint', () => {
+    // X = U+1D11E (𝄞, a surrogate pair): the decoder must skip both UTF-16
+    // units of X, then continue with the trailing 'Y' marker.
+    const input = `\\S\\${'\u{1D11E}'}Y`;
+    const expected = `${String.fromCodePoint(0x1D11E + 128)}Y`;
+    expect(decodeIfcString(input)).toBe(expected);
+  });
+
   it('supports explicit \\PA\\ code page directive before \\S\\', () => {
     expect(decodeIfcString('\\PA\\\\S\\D')).toBe('Ä');
   });

--- a/packages/encoding/src/property-value.test.ts
+++ b/packages/encoding/src/property-value.test.ts
@@ -35,6 +35,12 @@ describe('parsePropertyValue', () => {
     expect(result.ifcType).toBe('Label');
   });
 
+  it('resolves "IFCTYPE,value" case-insensitively (the regex carries an /i flag)', () => {
+    const result = parsePropertyValue('ifclabel,Concrete');
+    expect(result.displayValue).toBe('Concrete');
+    expect(result.ifcType).toBe('Label');
+  });
+
   it('resolves "IFCTYPE,.T." string pattern as boolean', () => {
     const result = parsePropertyValue('IFCBOOLEAN,.T.');
     expect(result.displayValue).toBe('True');

--- a/packages/export/src/source-header-roundtrip.test.ts
+++ b/packages/export/src/source-header-roundtrip.test.ts
@@ -99,6 +99,35 @@ describe('parseSourceHeader', () => {
   it('returns undefined for non-STEP input', () => {
     expect(parseSourceHeader(new TextEncoder().encode('not an ifc file'))).toBeUndefined();
   });
+
+  it('assigns FILE_NAME fields to the correct positions, not swapped with a neighbour', () => {
+    // Regression net for a positional-argument swap: `name` (parts[0]) and
+    // `timeStamp` (parts[1]) were parsed but never asserted anywhere in this
+    // suite, so `parts[0]`<->`parts[1]` (or any other adjacent FILE_NAME
+    // field) could swap silently. Every field below is given a DISTINCT,
+    // self-describing value so a swap of any two adjacent fields changes the
+    // assertion that fails, pinning each argument to its exact slot:
+    // name, timeStamp, author, organization, preprocessorVersion,
+    // originatingSystem, authorization.
+    const model = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('slot0-name.ifc','slot1-timestamp',('slot2-author'),('slot3-org'),'slot4-preproc','slot5-origsystem','slot6-auth');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+ENDSEC;
+END-ISO-10303-21;`;
+    const parsed = parseSourceHeader(new TextEncoder().encode(model));
+    expect(parsed).toBeDefined();
+    expect(parsed!.name).toBe('slot0-name.ifc');
+    expect(parsed!.timeStamp).toBe('slot1-timestamp');
+    expect(parsed!.author).toEqual(['slot2-author']);
+    expect(parsed!.organization).toEqual(['slot3-org']);
+    expect(parsed!.preprocessorVersion).toBe('slot4-preproc');
+    expect(parsed!.originatingSystem).toBe('slot5-origsystem');
+    expect(parsed!.authorization).toBe('slot6-auth');
+  });
 });
 
 describe('StepExporter header round-trip (no mutations)', () => {

--- a/packages/parser/src/tokenizer.test.ts
+++ b/packages/parser/src/tokenizer.test.ts
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, it } from 'vitest';
+import { StepTokenizer } from './tokenizer.js';
+
+describe('StepTokenizer.scanEntitiesFast', () => {
+  it('finds entities and reports correct expressId/type/line', () => {
+    const text = [
+      "#1=IFCPROJECT('0000000000000000000001',$,'P',$,$,$,$,$,$);",
+      "#2=IFCWALL('0000000000000000000002',$,$,$,$,$,$,$,$);",
+    ].join('\n');
+    const buffer = new TextEncoder().encode(text);
+    const tokenizer = new StepTokenizer(buffer);
+    const refs = Array.from(tokenizer.scanEntitiesFast());
+    expect(refs).toHaveLength(2);
+    expect(refs[0]).toMatchObject({ expressId: 1, type: 'IFCPROJECT', line: 1 });
+    expect(refs[1]).toMatchObject({ expressId: 2, type: 'IFCWALL', line: 2 });
+  });
+
+  it('does not alias two distinct type names that share a 31-multiplicative hash (type-name cache collision guard)', () => {
+    // 'I0OAAA' and 'I10AAA' are two distinct, valid IFC-style type names of
+    // the same length that collide under the tokenizer's rolling hash
+    // (typeHash = typeLen; typeHash = (typeHash*31+byte)|0 per byte, cache
+    // key `${typeLen}:${typeHash}`), found by brute-force search over the
+    // exact algorithm. Without the byte-for-byte cache verification in
+    // scanEntitiesFast, the second entity's type would be silently misread
+    // as the first entity's cached string once the first name populates the
+    // cache under the shared key.
+    const first = 'I0OAAA';
+    const second = 'I10AAA';
+    expect(first).toHaveLength(second.length);
+    expect(first).not.toBe(second);
+
+    const text = [
+      `#1=${first}($);`,
+      `#2=${second}($);`,
+    ].join('\n');
+    const buffer = new TextEncoder().encode(text);
+    const tokenizer = new StepTokenizer(buffer);
+    const refs = Array.from(tokenizer.scanEntitiesFast());
+    expect(refs).toHaveLength(2);
+    expect(refs[0].type).toBe(first);
+    expect(refs[1].type).toBe(second);
+  });
+});


### PR DESCRIPTION
Test-only. No production code changed. None of these is a live defect — every one is a coverage gap where the code is correct and the tests couldn't tell.

## 1. The type-name cache collision guard is unpinned — the strongest of the six

`parser/src/tokenizer.ts` caches type names under `${typeLen}:${typeHash}` using a 31-multiplicative rolling hash, then **verifies the cached string byte-for-byte** before reusing it. Deleting that verification:

```diff
-        if (type === undefined || !cacheHitMatches) {
+        if (type === undefined) {
```
1 replacement, asserted. Result: **382 passed, 0 failed** — the entire parser suite. `tokenizer.ts` had no test file at all.

The guard is load-bearing because collisions are real, not theoretical. `I0OAAA` and `I10AAA` are distinct, valid 6-character IFC-style type names that both hash to `-1128237441`, sharing cache key `6:-1128237441`. I recomputed that hash independently, outside the codebase, rather than trusting the claim:

```
I0OAAA: len=6 hash=-1128237441
I10AAA: len=6 hash=-1128237441   -> same cache key
```

The divergence happens after three bytes (`6·31+73 → 259`, then `259·31+48 = 8077·31+79` versus `259·31+49 = 8078·31+48`, both landing on `250466`) and the identical `AAA` suffix carries it home. With the verification removed, the second entity's type is silently reported as the first — the new test fails with `expected 'I0OAAA' to be 'I10AAA'`.

## 2. FILE_NAME slots could swap silently

`parseSourceHeader` assigns seven positional fields from `splitTopLevel`, but `name` (`parts[0]`) and `timeStamp` (`parts[1]`) were parsed and never asserted anywhere. Swapping them survives **17/17**.

The new fixture gives all seven fields distinct, self-describing values (`slot0-name.ifc`, `slot1-timestamp`, …) so a swap of *any* adjacent pair changes which assertion fails — it pins each argument to its slot rather than just catching the one swap I tested.

## 3–5. Three encoding boundaries

| file | mutation | before | after |
|---|---|---|---|
| `guid.ts` | `firstCharValue > 3` → `> 4` | **51/51 pass** | 2 fail of 56 |
| `ifc-string.ts` | `i += 3 + (cp > 0xFFFF ? 2 : 1)` → `i += 3 + 2` | **51/51 pass** | 1 fail of 56 |
| `property-value.ts` | drop the `/i` flag from the typed-value regex | **55/55 pass** | 1 fail of 56 |

The GUID one matters because an `IfcGloballyUniqueId` packs 128 bits into 22 base64-ish characters (22 × 6 = 132), so the first character carries only the UUID's top 2 bits and must be `0`–`3`.

The `\S\` one is a two-sided boundary: the decoder reads `X` as a whole code point so it can skip a surrogate pair, which means it must advance **1** unit for BMP and **2** for astral. The BMP case is pinned at U+FFFF — the boundary value that is *not* a surrogate — with a trailing marker character that gets swallowed if the decoder over-advances.

## 6. Closes the survivor left open by #2180

`instanced-shards.ts`'s defensive `reader.remaining < 4` guard (the "missing length prefix" throw for a corrupt cache) mutated to `< 3` survived **48/48**. The new test truncates a serialized section to exactly 7 bytes — count intact, length prefix cut to 3 — the precise boundary the guard exists for. Below it, `readUint32()` throws an unrelated `RangeError` instead of the diagnosable error.

## Totals

cache **50** pass, parser **384**, encoding **56**, export **364**.

## Process note

The agent producing this work died mid-run on an API error, before its own verification step. Rather than ship it on trust or discard it, I re-derived every finding from scratch: each mutation re-applied with an asserted replacement count, each run both with and without the new test, and the hash collision recomputed independently. The numbers above are all mine.