### PR TITLE
test(mcp,extensions,sandbox): pin four security-boundary gaps

### DIFF
--- a/packages/extensions/src/capability/scope-claim.test.ts
+++ b/packages/extensions/src/capability/scope-claim.test.ts
@@ -61,6 +61,22 @@ describe('scopeClaimCovers (claim within grant)', () => {
     expect(scopeClaimCovers(grant, claim('model.mutate:Pset_FireSafety*@IfcWall'))).toBe(false);
   });
 
+  it('requires EVERY grant constraint to match, not just the first', () => {
+    // Regression: the constraint check is a loop over multiple key=value
+    // pairs. A claim that satisfies the first constraint but fails a
+    // later one must still be denied — a loop that only inspects the
+    // first entry would wrongly grant coverage here.
+    const grant = claim('model.mutate:Pset_*@IfcWall&storey=EG&fireRating=required');
+    // Counterfactual: matching only the first constraint is NOT enough.
+    expect(
+      scopeClaimCovers(grant, claim('model.mutate:Pset_*@IfcWall&storey=EG&fireRating=optional')),
+    ).toBe(false);
+    // Both constraints must match for coverage to hold.
+    expect(
+      scopeClaimCovers(grant, claim('model.mutate:Pset_*@IfcWall&storey=EG&fireRating=required')),
+    ).toBe(true);
+  });
+
   it('matches IFC type prefix globs one-way', () => {
     const grant = claim('model.mutate:Pset_*@IfcWall*');
     expect(scopeClaimCovers(grant, claim('model.mutate:Pset_*@IfcWallStandardCase'))).toBe(true);
@@ -109,6 +125,29 @@ describe('opMatchesScopeClaim (write/publish-time enforcement)', () => {
         ifcType: 'IfcWall',
       }),
     ).toBe(false);
+  });
+
+  it('requires EVERY claim constraint to match an op tag, not just the first', () => {
+    // Regression: same multi-constraint loop as scopeClaimCovers, on the
+    // op-enforcement side. A single satisfied constraint must not be
+    // enough when the claim has more than one.
+    const twoConstraint = claim('model.mutate:Pset_FireSafety*@IfcWall&storey=EG&zone=A');
+    // Counterfactual: op satisfies "storey" but fails "zone" — must deny.
+    expect(
+      opMatchesScopeClaim(twoConstraint, {
+        capability: 'model.mutate:Pset_FireSafety',
+        ifcType: 'IfcWall',
+        tags: { storey: 'EG', zone: 'B' },
+      }),
+    ).toBe(false);
+    // Both constraints satisfied — must accept.
+    expect(
+      opMatchesScopeClaim(twoConstraint, {
+        capability: 'model.mutate:Pset_FireSafety',
+        ifcType: 'IfcWall',
+        tags: { storey: 'EG', zone: 'A' },
+      }),
+    ).toBe(true);
   });
 
   it('findCoveringClaim returns the matching claim or undefined', () => {

--- a/packages/extensions/src/host/activation.test.ts
+++ b/packages/extensions/src/host/activation.test.ts
@@ -116,6 +116,41 @@ describe('ActivationDispatcher — listener failure does not mark activated', ()
   });
 });
 
+describe('ActivationDispatcher — concurrent fire re-entrancy', () => {
+  it('does not double-dispatch an extension covered by two events fired concurrently', async () => {
+    // Regression: fire() marks `activating` synchronously before the
+    // first await so overlapping fire() calls can't both slip past the
+    // `entry.activated` check for the same extension. Without that
+    // guard, two events sharing an extension, fired concurrently, would
+    // both see `activated === false` and invoke listeners twice.
+    const d = new ActivationDispatcher();
+    let calls = 0;
+    let releaseFirst: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    d.onActivate(async (extId) => {
+      calls += 1;
+      if (extId === 'ext-a') await gate;
+    });
+    d.register('ext-a', ['onStartup', 'onOpen']);
+
+    const p1 = d.fire('onStartup');
+    const p2 = d.fire('onOpen');
+    releaseFirst();
+    await Promise.all([p1, p2]);
+
+    expect(calls).toBe(1);
+    // Counterfactual: an unrelated extension registered on only one
+    // event does get dispatched normally, so `calls === 1` above is
+    // attributable to the re-entrancy guard, not to the fixture being
+    // vacuous (e.g. one of the fires finding nothing to do).
+    d.register('ext-b', ['onStartup']);
+    await d.fire('onStartup');
+    expect(calls).toBe(2);
+  });
+});
+
 describe('ActivationDispatcher — reset', () => {
   it('resetActivation allows re-firing per-extension', async () => {
     const d = new ActivationDispatcher();

--- a/packages/mcp/src/tools/layer-session.test.ts
+++ b/packages/mcp/src/tools/layer-session.test.ts
@@ -197,6 +197,20 @@ describe('review ownership', () => {
     expect(denied.details).toEqual(unknown.details);
     expect(denied.details?.reviews).toEqual([]);
 
+    // Bob is a *listed reviewer* on this review, not a stranger. Denying
+    // mallory (above) alone cannot prove respond_to_review is owner-only,
+    // since mallory would be denied either way — she is neither owner nor
+    // reviewer. Bob is the boundary case: `requireOwnedReview` is called
+    // here without `{ allowReviewers: true }`, so a reviewer must be
+    // refused exactly like a stranger, not admitted the way
+    // add_review_feedback admits him below.
+    const deniedReviewer = await callErr('respond_to_review', { review_id: reviewId }, bob());
+    expect(deniedReviewer.code).toBe('ENTITY_NOT_FOUND');
+    // Unlike mallory, bob is a listed reviewer, so the review is visible to
+    // him (reads admit reviewers) — the id legitimately appears in his
+    // error details. What matters is the *action* is still refused.
+    expect(deniedReviewer.details?.reviews).toEqual([reviewId]);
+
     const response = await call('respond_to_review', { review_id: reviewId }, alice());
     expect(response.draft_id).toBeTypeOf('string');
   });

--- a/packages/sandbox/src/bridge-schema.test.ts
+++ b/packages/sandbox/src/bridge-schema.test.ts
@@ -35,6 +35,30 @@ describe('bim.create bridge schema', () => {
     expect(addIfcWallWindow?.paramNames).toEqual(['handle', 'wallId', 'params']);
   });
 
+  it('does not expose a namespace whose permission is disabled', async () => {
+    // Counterfactual, not just a boundary check: bim.mutate (disabled here)
+    // and bim.query (left enabled) are evaluated in the SAME session, so a
+    // passing assertion on bim.mutate cannot be explained by the sandbox
+    // being broken in general — bim.query proves the sandbox is otherwise
+    // functional. mutate:false is also DEFAULT_PERMISSIONS' own default, so
+    // this exercises the exact posture production code ships with.
+    const sandbox = await createSandbox({} as BimContext, {
+      permissions: { mutate: false, query: true },
+    });
+    try {
+      await expect(sandbox.eval('typeof bim.mutate', { typescript: false })).resolves.toMatchObject({
+        value: 'undefined',
+      });
+      await expect(sandbox.eval('bim.mutate.setName', { typescript: false })).rejects.toThrow();
+
+      await expect(sandbox.eval('typeof bim.query', { typescript: false })).resolves.toMatchObject({
+        value: 'object',
+      });
+    } finally {
+      sandbox.dispose();
+    }
+  });
+
   it('isolates creator handles per sandbox session', async () => {
     const sandboxA = await createSandbox({} as BimContext, {
       permissions: CREATE_ONLY_PERMISSIONS,


### PR DESCRIPTION
Test-only. No production code changed. All four are **coverage gaps** — the logic is correct in each case; the suites just couldn't see a regression. These sit on permission boundaries, so the failure mode of an undetected regression is a privilege leak rather than a wrong number.

## 1. `respond_to_review` owner-only rests on an untested absent default

`mcp/src/tools/layer-access.ts:100` keeps `respond_to_review` owner-only by relying on `allowReviewers` being **absent** (`undefined === true` → deny). Mutating `=== true` → `!== false`, which flips that absent default to *allow*, survived **231/231**.

The existing test denied a stranger — which can't prove owner-only, because a stranger is denied either way. The boundary case is a **listed reviewer**, someone `add_review_feedback` *does* admit. That's now asserted, with the distinction spelled out in the test: the reviewer can still *see* the review (reads admit reviewers, so the id legitimately appears in his error details) while the *action* is refused.

## 2. Two constraint loops were identities on single-constraint fixtures

`extensions/src/capability/scope-claim.ts:158` (`scopeClaimCovers`) and `:182` (`opMatchesScopeClaim`) both iterate `Object.entries(constraints)`. Every fixture had exactly one constraint, so `.slice(0, 1)` changed nothing — each survived **603/603**.

A capability granted for `{a: 1}` would then also match an op requiring `{a: 1, b: 2}`. Both callers (`layer-ops.ts`, `layer-publish.ts`) now have two-constraint fixtures.

## 3. The activation re-entrancy guard had no concurrent test

`extensions/src/host/activation.ts:105` — dropping `entry.activating` from `if (!entry || entry.activated || entry.activating) continue;` survived **603/603**.

Now pinned with a gated promise proving exactly-once dispatch under overlapping `fire()` calls, plus a counterfactual that a *separate* extension still dispatches normally — otherwise "only one activation happened" could just mean dispatch was broken.

Real callers exist in `apps/viewer/src/services/extensions/`, but I did not trace an actual concurrent call site, so this is plausible exposure rather than a confirmed defect, and I'd rather say that than imply a live bug.

## 4. The sandbox permission gate was never tested in the deny direction

`sandbox/src/bridge-schema.ts:209` — `if (!permissions[schema.permission]) continue;` decides which `bim.*` namespaces get wired into a sandboxed extension. Deleting the line entirely survived **71/71**: nothing checked that a *withheld* permission actually withholds anything.

Now asserts that `mutate: false` leaves `bim.mutate` undefined and throwing, while `bim.query` stays available in the same session — so the test pins the gate rather than the absence of a bridge.

## Deliberately not included

This round independently rediscovered the `readOnlyScope()` shallow-spread leak in `mcp/src/auth/scope.ts` — the `{ ...READ_ONLY }` that shares the same `scopes` array, so `readOnlyScope().scopes.push('mutate')` widens the process-wide constant.

**That is already fixed in our open #2158**, with a character-identical patch and a stronger test (it exercises `push` *and* `length = 0`, asserting against literals rather than against the constant a leak corrupts). It is absent from `main` only because #2158 hasn't merged. Shipping it again here would conflict with our own PR, so it is excluded.

Worth noting as a property of the review queue rather than of the code: a defect fixed in an unmerged PR is still present on `main`, so audits branched from `main` will keep rediscovering it.

## Totals

mcp **231**, extensions **606** (was 603), sandbox **72** (was 71).

## Negative results — mutation-tested, no survivors

`mcp/src/safe-path.ts` (post-canonicalisation re-check, root-boundary separator, sensitive-home guard), `layer-access.ts` visibility primitives, `layer-store.ts` session isolation; `extensions` `capability/match.ts`, `parse.ts`, `diff.ts`, `host/permissions.ts`, `host/check.ts` (both directions, multi-grant OR, fail-closed on an uncatalogued namespace), `signing/verify.ts` + `sign.ts` (tampered content, hash, signature and timestamp all rejected); `sandbox/src/sandbox.ts` dispose/timeout/abort re-checks and the budget suites.

`packages/plugin-api` does not exist in this repo. Not deep-mutated for time: `capability/risk.ts` (a UI badge tier, not a gate) and `host/sdk-revalidate.ts` (a repair workflow, not enforcement).