### PR TITLE
test(cli,viewer): pin five parser and codec boundaries

### DIFF
--- a/apps/viewer/src/store/types.test.ts
+++ b/apps/viewer/src/store/types.test.ts
@@ -68,6 +68,37 @@ describe('EntityRef utilities', () => {
       // "with:colons:123" parsed as Number results in NaN, which is converted to -1
       assert.strictEqual(result.expressId, -1, 'expressId should be -1 when parsing invalid number');
     });
+
+    it('should return the sentinel {modelId: "", expressId: -1} when the string has no colon at all', () => {
+      // This is the colonIndex === -1 branch specifically (as opposed to the
+      // NaN-after-parsing branch exercised above by 'model:with:colons:123',
+      // which always has a colon). Nothing previously in this suite passed a
+      // string with zero colons.
+      const result = stringToEntityRef('no-colon-here');
+      assert.strictEqual(result.modelId, '');
+      assert.strictEqual(result.expressId, -1);
+    });
+
+    it('should stop at trailing non-digit garbage rather than yielding NaN (parseInt prefix tolerance)', () => {
+      // parseInt('12abc', 10) === 12, not NaN — a value like 'model:12abc'
+      // silently parses to expressId 12 instead of hitting the NaN -> -1
+      // sentinel path. Pin the actual (perhaps surprising) behavior so a
+      // change here is a deliberate decision, not an accident.
+      const result = stringToEntityRef('model:12abc');
+      assert.strictEqual(result.modelId, 'model');
+      assert.strictEqual(result.expressId, 12);
+    });
+
+    it('should parse a leading "0x..." expressId as decimal 0, not hex (radix 10 is explicit)', () => {
+      // parseInt('0x1A', 10) === 0 (stops at the non-digit 'x' after the
+      // leading '0'), whereas parseInt('0x1A') with no radix argument
+      // auto-detects the hex prefix and returns 26. This is the one input
+      // shape that actually distinguishes "radix 10 passed" from "radix
+      // omitted" — a plain 'model:12abc' behaves identically either way.
+      const result = stringToEntityRef('model:0x1A');
+      assert.strictEqual(result.modelId, 'model');
+      assert.strictEqual(result.expressId, 0);
+    });
   });
 
   describe('entityRefToString and stringToEntityRef roundtrip', () => {

--- a/packages/cli/src/commands/mutate.test.ts
+++ b/packages/cli/src/commands/mutate.test.ts
@@ -45,6 +45,15 @@ describe('parseWhereFilter', () => {
     const result = parseWhereFilter('Pset.Prop=');
     expect(result.value).toBe('');
   });
+
+  it('treats an operator at the very start of the prop segment as no match (empty propName is not a valid filter)', () => {
+    // rest = "=value": the '=' sits at index 0, which the opIdx > 0 guard
+    // deliberately excludes so filters can't resolve to an empty propName.
+    // It falls through to the exists-only shape instead of matching '='.
+    const result = parseWhereFilter('Pset.=value');
+    expect(result.operator).toBe('exists');
+    expect(result.propName).toBe('=value');
+  });
 });
 
 describe('parseSetArg', () => {
@@ -107,6 +116,18 @@ describe('parseSetArg', () => {
     expect(result.psetName).toBe('Pset');
     expect(result.propName).toBe('Prop');
     expect(result.value).toBe('a=b');
+  });
+
+  it('treats a leading dot (dotIdx === 0) as attribute mutation, same as no dot at all', () => {
+    // dotIdx <= 0 covers both "no dot" (-1) and "dot at position 0". A
+    // leading dot with nothing before it can't be a real pset name, so this
+    // is parsed as an attribute mutation named ".Name" rather than a
+    // pset.prop split with an empty psetName.
+    const result = parseSetArg('.Name=value');
+    expect(result.isAttribute).toBe(true);
+    expect(result.psetName).toBeNull();
+    expect(result.propName).toBe('.Name');
+    expect(result.value).toBe('value');
   });
 });
 

--- a/packages/cli/src/headless-backend.test.ts
+++ b/packages/cli/src/headless-backend.test.ts
@@ -69,6 +69,22 @@ describe('isProductType', () => {
     expect(isProductType('IFCWALLTYPE')).toBe(false);
     expect(isProductType('IFCSLABTYPE')).toBe(false);
   });
+
+  it('returns false for unknown/unrecognized type names', () => {
+    expect(isProductType('NOT_A_REAL_IFC_TYPE')).toBe(false);
+  });
+
+  it('returns true for real building-element product types', () => {
+    // This is the load-bearing default path: query.entities() with no
+    // --type filter walks store.entityIndex.byType and keeps only entries
+    // where isProductType(typeName) is true. Every prior case in this
+    // describe block only exercises a false-returning branch, so a mutant
+    // that hard-codes `return false` at the end of the function was not
+    // caught by any of them.
+    expect(isProductType('IFCWALL')).toBe(true);
+    expect(isProductType('IFCSLAB')).toBe(true);
+    expect(isProductType('IFCDOOR')).toBe(true);
+  });
 });
 
 describe('normalizeBooleanValue', () => {


### PR DESCRIPTION
Test-only. No production code changed. Five coverage gaps — the behaviour is correct in each case; nothing could see a regression.

## `isProductType`'s positive branch was never asserted

`cli/src/headless-backend.ts:121-131`. Every test in its describe block checks a case that returns **false** — rel types, property types, quantity types, the `*TYPE` suffix. None confirms it returns **true** for an actual product type.

`return true` → `return false`: **66/66 pass.**

It gates the default (no `--type`) path of `query.entities()`, reached from `analyze`, `ask`, `export` and `eval`, so the function that decides what a query returns by default had its whole affirmative case unpinned.

## Two off-by-one boundaries in the `--set` / `--where` parsers

`cli/src/commands/mutate.ts`, each surviving **66/66**:

| function | mutation | what it changes |
|---|---|---|
| `parseSetArg` | `dotIdx <= 0` → `< 0` | `.Name=v` becomes an empty pset name instead of an attribute |
| `parseWhereFilter` | `opIdx > 0` → `>= 0` | `Pset.=v` becomes an empty prop name instead of an exists check |

Both are the zero-index case specifically. Bounded by a control: `dotIdx > eqIdx` → `< eqIdx` dies **4 of 50**, so the conditional genuinely is exercised — it was only the `<= 0` vs `< 0` split that was blind. I checked the actual divergence rather than assuming it: `.Name=value` gives `{isAttribute: true, propName: '.Name'}` correct versus `{isAttribute: false, psetName: ''}` mutated.

## Two gaps in the viewer's EntityRef codec

`apps/viewer/src/store/types.ts:477-489` — the **second** implementation of the codec, the one with a sentinel contract rather than the SDK's throw (see #2185, where the divergence is flagged for your call).

- The `colonIndex === -1` branch — no colon at all — was **never reached**. Every existing test that lands on the sentinel gets there through NaN parsing instead, so the no-colon path was dead. Mutating the sentinel `modelId` survived **17/17**.
- `parseInt(..., 10)`'s radix was unpinned; dropping it survived **17/17**.

Control for this function: `substring(0, colonIndex)` → `substring(1, colonIndex)` dies **6 of 17**, so modelId extraction is well covered — these two branches specifically were not.

**The contract is deliberately unchanged.** Whether this copy should throw like the SDK one is your decision, flagged on #2185. These tests pin what it does *today*, so that decision gets made deliberately rather than by drift.

## One method note worth keeping

The obvious radix fixture is vacuous. `parseInt('12abc')` is `12` **with or without** radix 10 — non-`0x` strings decimal-parse identically either way, so a test using `'model:12abc'` passes against the mutation it was written to kill. It takes `'0x1A'` — `0` with radix 10, `26` with auto-detect — to discriminate. That was caught by mutation-testing the new test itself before trusting it, which is the only reason it isn't in this PR as a decorative assertion.

## Totals

cli **276 pass**, viewer `types.test.ts` **20** (was 17).

## Negative results

`matchesFilter` / `coerceValue` / `splitStepArgs` in `mutate.ts`: a probed boundary (`!isNaN(num) && value.trim() !== ''` → `||`) died immediately, 1 of 50 — coverage there looks solid, not pursued further.

`applyAttributeMutations` (the STEP text post-processing, with its `ATTRIBUTE_INDEX` / `OBJECTTYPE_TYPES` validation) is not exported and has no direct unit test — reachable only through a full `mutateCommand` integration that would need a real IFC fixture. Flagged as unexamined, **not** as clean.

`apps/viewer/src/store/slices/` (selection, pinboard, basket) was not reached this round.