### PR TITLE
test(viewer): pin seven placement and wall-edit refusal branches

### DIFF
--- a/apps/viewer/src/lib/placement-edit.test.ts
+++ b/apps/viewer/src/lib/placement-edit.test.ts
@@ -434,6 +434,159 @@ describe('placement-edit', () => {
     assert.strictEqual(projectOntoWallAxis(chain, [-3, 0, 0]), 0);
   });
 
+  it('resizeRectangleWall rejects a sloped resize (dz != 0)', () => {
+    const fx = makeWallFixture();
+    const editor = new StubStoreEditor(fx.entities) as unknown as Parameters<typeof resizeRectangleWall>[2];
+    const view = new StubView() as unknown as Parameters<typeof resizeRectangleWall>[1];
+    // dz = 1 is far larger than the tolerance (max(1e-6*length, 1e-9)),
+    // so this must be refused rather than silently sloping the wall.
+    const result = resizeRectangleWall(dataStoreStub, view, editor, fx.ids.wall, [0, 0, 0], [3, 4, 1]);
+    assert.strictEqual(result.ok, false);
+    if (!result.ok) {
+      assert.strictEqual(result.reason, 'Start and end must lie on the same storey plane');
+    }
+  });
+
+  it('resizeRectangleWall refuses when the wall-edit chain does not resolve', () => {
+    // makeFixture() is a plain column with no representation chain
+    // (Representation attr is null) — resolveWallEditChain must
+    // return null, and resizeRectangleWall must surface the
+    // dedicated "no simple representation" refusal rather than
+    // crashing or reusing an unrelated message.
+    const { point, axis, local, column } = makeFixture();
+    const editor = new StubStoreEditor([point, axis, local, column]) as unknown as Parameters<typeof resizeRectangleWall>[2];
+    const view = new StubView() as unknown as Parameters<typeof resizeRectangleWall>[1];
+    const result = resizeRectangleWall(dataStoreStub, view, editor, 100, [0, 0, 0], [1, 0, 0]);
+    assert.strictEqual(result.ok, false);
+    if (!result.ok) {
+      assert.strictEqual(
+        result.reason,
+        'Wall does not have a simple IfcRectangleProfileDef → IfcExtrudedAreaSolid representation',
+      );
+    }
+  });
+
+  it('computeWallSplitGeometry rejects a non-finite split distance', () => {
+    const fx = makeWallFixture();
+    const editor = new StubStoreEditor(fx.entities) as unknown as Parameters<typeof resolveWallEditChain>[2];
+    const view = new StubView() as unknown as Parameters<typeof resolveWallEditChain>[1];
+    const chain = resolveWallEditChain(dataStoreStub, view, editor, fx.ids.wall);
+    assert.ok(chain);
+    const result = computeWallSplitGeometry(chain, NaN, 3);
+    assert.strictEqual(result.ok, false);
+    if (!result.ok) {
+      assert.strictEqual(result.reason, 'Split distance must be a finite number');
+    }
+  });
+
+  it('computeWallSplitGeometry rejects an unreadable extrusion height', () => {
+    const fx = makeWallFixture();
+    const editor = new StubStoreEditor(fx.entities) as unknown as Parameters<typeof resolveWallEditChain>[2];
+    const view = new StubView() as unknown as Parameters<typeof resolveWallEditChain>[1];
+    const chain = resolveWallEditChain(dataStoreStub, view, editor, fx.ids.wall);
+    assert.ok(chain);
+    // NaN height (e.g. non-numeric Depth slot on the extrusion).
+    const nanResult = computeWallSplitGeometry(chain, 2, NaN);
+    assert.strictEqual(nanResult.ok, false);
+    if (!nanResult.ok) {
+      assert.strictEqual(nanResult.reason, 'Wall has no readable extrusion height');
+    }
+    // Zero/negative height must also be refused (sourceHeight <= 0).
+    const zeroResult = computeWallSplitGeometry(chain, 2, 0);
+    assert.strictEqual(zeroResult.ok, false);
+    if (!zeroResult.ok) {
+      assert.strictEqual(zeroResult.reason, 'Wall has no readable extrusion height');
+    }
+  });
+
+  it('computeWallSplitGeometry pins the MIN_WALL_SEGMENT_LENGTH boundary exactly', () => {
+    const fx = makeWallFixture();
+    const editor = new StubStoreEditor(fx.entities) as unknown as Parameters<typeof resolveWallEditChain>[2];
+    const view = new StubView() as unknown as Parameters<typeof resolveWallEditChain>[1];
+    const chain = resolveWallEditChain(dataStoreStub, view, editor, fx.ids.wall);
+    assert.ok(chain);
+    const len = chain.wallLength; // 5
+    const eps = 1e-6;
+
+    // Start side: distance === MIN exactly must be rejected (the
+    // guard is `<=`). One epsilon past it must be accepted — this
+    // is what discriminates `<=` from `<`.
+    const atStart = computeWallSplitGeometry(chain, MIN_WALL_SEGMENT_LENGTH, 3);
+    assert.strictEqual(atStart.ok, false);
+    const justInsideStart = computeWallSplitGeometry(chain, MIN_WALL_SEGMENT_LENGTH + eps, 3);
+    assert.strictEqual(justInsideStart.ok, true);
+
+    // End side: distance === len - MIN exactly must be rejected (the
+    // guard is `>=`). One epsilon short of it must be accepted —
+    // this is what discriminates `>=` from `>`.
+    const atEnd = computeWallSplitGeometry(chain, len - MIN_WALL_SEGMENT_LENGTH, 3);
+    assert.strictEqual(atEnd.ok, false);
+    const justInsideEnd = computeWallSplitGeometry(chain, len - MIN_WALL_SEGMENT_LENGTH - eps, 3);
+    assert.strictEqual(justInsideEnd.ok, true);
+  });
+
+  it('rotateProductYaw reports the chain-resolution reason when the placement does not resolve', () => {
+    const { point, axis, local } = makeFixture();
+    const broken: OverlayEntity = {
+      expressId: 200,
+      type: 'IFCCOLUMN',
+      attributes: ['guid', null, 'Broken', null, null, null, null, null], // no placement
+    };
+    const editor = new StubStoreEditor([point, axis, local, broken]) as unknown as Parameters<typeof rotateProductYaw>[2];
+    const view = new StubView() as unknown as Parameters<typeof rotateProductYaw>[1];
+    const result = rotateProductYaw(dataStoreStub, view, editor, 200, Math.PI / 4);
+    assert.strictEqual(result.ok, false);
+    if (!result.ok) {
+      assert.strictEqual(
+        result.reason,
+        'Entity placement is not a simple IfcLocalPlacement → IfcAxis2Placement3D chain',
+      );
+    }
+  });
+
+  it('rotateProductYaw reports the implicit-RefDirection reason distinctly from the chain-resolution reason', () => {
+    const { point, axis, local, column } = makeFixture();
+    const editor = new StubStoreEditor([point, axis, local, column]) as unknown as Parameters<typeof rotateProductYaw>[2];
+    const view = new StubView() as unknown as Parameters<typeof rotateProductYaw>[1];
+    const result = rotateProductYaw(dataStoreStub, view, editor, 100, Math.PI / 4);
+    assert.strictEqual(result.ok, false);
+    if (!result.ok) {
+      assert.strictEqual(
+        result.reason,
+        'Entity has an implicit reference direction; rotation requires an explicit IfcDirection on its axis placement.',
+      );
+    }
+  });
+
+  it('translateProduct and setProductPosition report the chain-resolution reason', () => {
+    const { point, axis, local } = makeFixture();
+    const broken: OverlayEntity = {
+      expressId: 200,
+      type: 'IFCCOLUMN',
+      attributes: ['guid', null, 'Broken', null, null, null, null, null], // no placement
+    };
+    const editor = new StubStoreEditor([point, axis, local, broken]) as unknown as Parameters<typeof translateProduct>[2];
+    const view = new StubView() as unknown as Parameters<typeof translateProduct>[1];
+
+    const translateResult = translateProduct(dataStoreStub, view, editor, 200, [1, 0, 0]);
+    assert.strictEqual(translateResult.ok, false);
+    if (!translateResult.ok) {
+      assert.strictEqual(
+        translateResult.reason,
+        'Entity placement is not a simple IfcLocalPlacement → IfcAxis2Placement3D → IfcCartesianPoint chain',
+      );
+    }
+
+    const setResult = setProductPosition(dataStoreStub, view, editor, 200, [1, 0, 0]);
+    assert.strictEqual(setResult.ok, false);
+    if (!setResult.ok) {
+      assert.strictEqual(
+        setResult.reason,
+        'Entity placement is not a simple IfcLocalPlacement → IfcAxis2Placement3D → IfcCartesianPoint chain',
+      );
+    }
+  });
+
   it('treats 2D coordinates as having Z=0', () => {
     const point: OverlayEntity = {
       expressId: 50,


### PR DESCRIPTION
Test-only. `wall-edit.ts` and `placement-core.ts` both verified byte-identical to base — neither has a test file of its own; both are reached only through the `placement-edit` barrel.

## The headline is a vacuous assertion, not a missing test

`rotateProductYaw` has two refusal branches with distinct, user-facing reasons:

- `state === null` → *"Entity placement is not a simple IfcLocalPlacement → IfcAxis2Placement3D chain"*
- `state.refDirectionId === null` → *"Entity has an implicit reference direction; rotation requires an explicit IfcDirection on its axis placement."*

The one existing refusal test asserted `result.ok === false` and nothing else. **Swapping the two reason strings between the branches was completely invisible — 18/18 pass.**

That matters because the reason is the whole product here. A user told their wall has an *implicit reference direction* would act on that; if the code were actually hitting the unrelated chain-resolution branch, the message would send them down the wrong path entirely, and no test could tell. The `state === null` branch also had no test at all.

Both branches now assert the exact reason. The swap dies **2 of 26** — symmetric, because swapping breaks both directions at once.

## The boundary tested everywhere except at the boundary

`computeWallSplitGeometry` rejects splits within `MIN_WALL_SEGMENT_LENGTH` of either end. Two tests already covered "too close to start" and "too close to end" — both splitting at `MIN/2`, deep inside the rejection region, where the operator makes no difference. So `<=` → `<` and `>=` → `>` both survived **18/18**.

Now pinned exactly AT the threshold on both ends, plus one epsilon inside. Each operator dies independently, **1 of 26** — verified separately rather than only as a combined mutation, since a combined one can be killed by either half.

## Five untested refusal guards

Each verified to survive deletion before, and to die after:

| guard | reason |
|---|---|
| sloped resize (`dz != 0`) | *Start and end must lie on the same storey plane* |
| chain does not resolve | *Wall does not have a simple IfcRectangleProfileDef → IfcExtrudedAreaSolid representation* |
| unreadable extrusion height | *Wall has no readable extrusion height* |
| non-finite split distance | *Split distance must be a finite number* |
| `translateProduct` + `setProductPosition` chain refusal | shared reason string |

The sloped-wall guard is the one with real geometric consequence: without it a resize can tilt a wall off its storey plane, inconsistent with the rest of the IFC geometry.

## Method note

`translateProduct` and `setProductPosition` share one reason string, so an exact-substring anchor matches twice. Rather than force it, each was mutated **by line number**. That is the third time today an ambiguous anchor was correctly refused by the replacement-count assertion — twice for a sibling call site, once for a doc comment quoting the string. Without that assertion each would have been a silent no-op reporting a false pass.

**18 → 26 pass.** All seven gaps were reachable with fixtures; none needed a production change or was left open.

## Not examined

Large parts of `apps/viewer/src/lib/` and `src/hooks/` have no test file at all — the `tours/` subtree (`anchor-resolver`, `controller`, `storage`, `telemetry`, `tour-store`), `lib/scripts/`, `lib/collab/` (`annotation-sync`, `blob-store`, `mesh-codec`, `share-link`), `lib/lists/`, `lib/llm/`, and most `use*.ts` hooks including `useIfcLoader` and `useIfc`. Listing rather than claiming clean.

`space-snap.ts` was read closely — its 11 tests assert exact `pt`/`kind` values rather than truthiness — but was not mutation-tested, so it is inconclusive, not verified.