### PR TITLE
test(renderer,ifcx): pin three boundary and precedence gaps

### DIFF
--- a/packages/ifcx/src/property-extractor.test.ts
+++ b/packages/ifcx/src/property-extractor.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { StringTable } from '@ifc-lite/data';
+import { StringTable, QuantityType } from '@ifc-lite/data';
 import { parseIfcx } from './index.js';
 import { extractProperties } from './property-extractor.js';
 import type { ComposedNode, IfcxFile } from './types.js';
@@ -140,6 +140,11 @@ describe('extractProperties — typed records and internal carriers (#1031)', ()
     const co2 = co2Set.quantities.find((q) => q.name === 'EmbodiedCO2');
     assert.ok(co2, 'raw custom quantity reaches the quantity table');
     assert.strictEqual(co2.value, 412.5);
+    assert.strictEqual(
+      co2.type,
+      QuantityType.Count,
+      'unrecognized numeric in a non-Qto custom set must not fabricate a Length unit'
+    );
     assert.ok(
       !qsets.some((qset) => qset.quantities.some((q) => q.name === 'Length')),
       'typed Length not double-claimed as quantity'

--- a/packages/ifcx/src/tombstones.test.ts
+++ b/packages/ifcx/src/tombstones.test.ts
@@ -77,6 +77,25 @@ describe('tombstone composition (single document, later wins)', () => {
     const composed = composeIfcx(makeFile(baseNodes));
     assert.strictEqual(composed.size, 4);
   });
+
+  it('subtree shadowing beats a child\'s own resurrect opinion (parent tombstone wins)', () => {
+    // opening-1 explicitly resurrects itself, but wall-1 (its parent) is
+    // tombstoned. Per the documented semantics, entity tombstones shadow
+    // the whole subtree regardless of a child's own opinion.
+    const file = makeFile([
+      ...baseNodes,
+      { path: 'opening-1', attributes: { [IFCLITE_ATTR.DELETED]: false } },
+      { path: 'wall-1', attributes: { [IFCLITE_ATTR.DELETED]: true } },
+    ]);
+    const composed = composeIfcx(file);
+
+    assert.strictEqual(composed.has('wall-1'), false);
+    assert.strictEqual(
+      composed.has('opening-1'),
+      false,
+      "child's own resurrect must not override parent subtree shadowing"
+    );
+  });
 });
 
 describe('tombstone composition (federated layer stack, strength wins)', () => {

--- a/packages/renderer/src/picking-manager.test.ts
+++ b/packages/renderer/src/picking-manager.test.ts
@@ -284,6 +284,30 @@ describe('PickingManager', () => {
       assert.equal(h.createdMeshes.length, 0, 'must not hydrate when over budget');
     });
 
+    // Pins the exact MAX_PICK_MESH_CREATION (500) boundary: `toCreate > 500`
+    // must stay a strict inequality, not `>=`. A budget of exactly 500 pieces
+    // is still affordable and must hydrate on the GPU path, not fall back.
+    it('hydrates on the GPU path at exactly the pick-mesh budget (500)', async () => {
+      const exactlyBudget = Array.from({ length: 500 }, () => ({ expressId: WALL }));
+      // Only WALL needs pieces here; SLAB contributes nothing so toCreate === 500 exactly.
+      const h = harness({ pieces: (id) => (id === WALL ? exactlyBudget : undefined) });
+
+      await h.manager.pickRect(0, 0, 100, 100);
+
+      assert.equal(h.selectRectCalls, 0, 'exactly-500 must stay under budget and use the GPU path');
+      assert.equal(h.createdMeshes.length, 500, 'all 500 pieces must be hydrated');
+    });
+
+    it('falls back to Scene.selectRect one piece past the pick-mesh budget (501)', async () => {
+      const overBudget = Array.from({ length: 501 }, () => ({ expressId: WALL }));
+      const h = harness({ pieces: (id) => (id === WALL ? overBudget : undefined) });
+
+      await h.manager.pickRect(0, 0, 100, 100);
+
+      assert.equal(h.selectRectCalls, 1, '501 pieces must exceed the budget and take the CPU path');
+      assert.equal(h.createdMeshes.length, 0, 'must not hydrate when one piece over budget');
+    });
+
     it('honours isolation when falling back to the CPU path', async () => {
       const h = harness({ released: true });
 


### PR DESCRIPTION
Test-only. Three mutation-verified gaps.

## Picking flips to CPU at a boundary nothing tested

`renderer/src/picking-manager.ts:130` — `toCreate > MAX_PICK_MESH_CREATION` (500) chooses GPU versus CPU picking. The existing test used **600**, well past the line, so `>` → `>=` survived **422/422**.

Bounded by a control: `ordinal < baselineExisting` → `<=` dies **2/422**, so this function is genuinely exercised — only the threshold was blind. Now pinned at exactly 500 (GPU) and 501 (CPU fallback).

## Subtree shadowing was documented but unenforced

`ifcx/src/tombstones.ts` documents that an entity tombstone shadows its whole subtree *regardless of a child's own opinion*. Nothing checked it: letting a child's explicit `deleted: false` override its tombstoned parent survived **49/49**.

Now a tombstoned wall containing an explicitly-resurrected opening asserts **both** stay absent from the composed output.

Worth noting how this one was verified, because my first two attempts were wrong: an initial mutation referenced an undefined symbol (compile error — not a survivor), and a second used the wrong attribute accessor and was a silent no-op that "passed". The replacement-count assertion caught the second. Only the third — reading the child's attributes through `composed.get(child.path)` the way the code itself would — actually inverted the behaviour, and that one dies 1/14.

## Two quantity-type codes were interchangeable

`ifcx/src/index.ts:358` — `return qtoSet ? 0 : 3;` is the Length-versus-Count fallback for an unrecognised quantity name. Swapping the two survived, because the custom-Qto-set test asserted the value and the name but never `.type`.

That is the same swap-two-codes shape found twice elsewhere today (two refusal reason strings, fully interchangeable). Now asserts `QuantityType.Count`.

**renderer 424 pass** (was 422), **ifcx 50** (was 49).

## Negative results

`scene.ts`'s `instancedTemplateCpu` / `instancedTemplates` alignment — the shape that produced a real defect in this package earlier — was re-examined, and every remaining read site is properly guarded. `clip-box.ts`, `point-cloud-node.ts`'s `transformAabb`, ifcx's `canonical.ts`, `system-membership.ts`, `path-resolver.ts` and `entity-extractor.ts` were checked with no gaps found.

Three things flagged rather than claimed clean:

- `ifcx/src/writer.ts` has **zero test coverage** and is unreachable except through its own re-export.
- `hierarchy-builder.test.ts` is **unconditionally skipped** here for a missing on-disk fixture (`Hello_Wall_hello-wall.ifcx`), so that file has no executable coverage in this environment at all.
- In the renderer, `deviation-shader.wgsl.ts`, `point-cloud-renderer.ts`, `point-shader.wgsl.ts` and `triangle-bvh.ts` are exercised by no test — the `src/*.test.ts` glob doesn't reach subdirectories and nothing imports them.

`packages/pointcloud`, `packages/drawing-2d` and `packages/lists` were not reached.