### PR TITLE
test(pointcloud,drawing-2d,lists): close nine mutation-verified gaps

### DIFF
--- a/packages/drawing-2d/src/dxf/dxf.test.ts
+++ b/packages/drawing-2d/src/dxf/dxf.test.ts
@@ -528,4 +528,9 @@ describe('text decoding', () => {
   it('strips MTEXT formatting while preserving escaped backslashes', () => {
     expect(stripMtextFormatting('{\\fArial|b1;Bold} \\\\server\\share \\Pnext')).toBe('Bold \\server\\share \nnext');
   });
+
+  it('collapses a stacked fraction into "numerator/denominator"', () => {
+    expect(stripMtextFormatting('\\S1^2;')).toBe('1/2');
+    expect(stripMtextFormatting('Width: \\S3^4; m')).toBe('Width: 3/4 m');
+  });
 });

--- a/packages/drawing-2d/src/hidden-line.test.ts
+++ b/packages/drawing-2d/src/hidden-line.test.ts
@@ -1,0 +1,60 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect } from 'vitest';
+import type { MeshData } from '@ifc-lite/geometry';
+import { HiddenLineClassifier } from './hidden-line.js';
+import type { DrawingLine } from './types.js';
+
+/**
+ * A flat quad occluder at z=5, spanning x/y in [0, 10], viewed along the
+ * z axis. `sampleVisibility` (hidden-line.ts) compares a candidate line's
+ * depth against this rasterized depth buffer.
+ */
+function occluderMesh(): MeshData {
+  return {
+    expressId: 1,
+    positions: new Float32Array([
+      0, 0, 5,
+      10, 0, 5,
+      10, 10, 5,
+      0, 10, 5,
+    ]),
+    normals: new Float32Array(12),
+    indices: new Uint32Array([0, 1, 2, 0, 2, 3]),
+    color: [1, 1, 1, 1],
+  };
+}
+
+function makeLine(depth: number): DrawingLine {
+  return {
+    line: { start: { x: 2, y: 2 }, end: { x: 8, y: 8 } },
+    category: 'projection',
+    visibility: 'visible',
+    entityId: 1,
+    ifcType: 'IfcWall',
+    modelIndex: 0,
+    depth,
+  };
+}
+
+describe('HiddenLineClassifier depth test (sampleVisibility)', () => {
+  it('classifies a line nearer than the occluder as visible', () => {
+    const classifier = new HiddenLineClassifier({ resolution: 64 });
+    classifier.buildDepthBuffer([occluderMesh()], 'z', 0, 10, false);
+
+    // Occluder sits at depth 5; a line at depth 3 is in front of it.
+    const [result] = classifier.classifyLines([makeLine(3)]);
+    expect(result.overallVisibility).toBe('visible');
+  });
+
+  it('classifies a line farther than the occluder as hidden', () => {
+    const classifier = new HiddenLineClassifier({ resolution: 64 });
+    classifier.buildDepthBuffer([occluderMesh()], 'z', 0, 10, false);
+
+    // A line at depth 7 sits behind the depth-5 occluder.
+    const [result] = classifier.classifyLines([makeLine(7)]);
+    expect(result.overallVisibility).toBe('hidden');
+  });
+});

--- a/packages/drawing-2d/src/openings/opening-filter.test.ts
+++ b/packages/drawing-2d/src/openings/opening-filter.test.ts
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect } from 'vitest';
+import { OpeningFilter } from './opening-filter.js';
+import type { CutSegment, OpeningInfo, OpeningRelationships } from '../types.js';
+
+const HOST_ID = 10;
+const OPENING_ID = 20;
+
+function makeRelationships(): OpeningRelationships {
+  const openingInfo: OpeningInfo = {
+    type: 'opening',
+    openingId: OPENING_ID,
+    hostElementId: HOST_ID,
+    width: 2,
+    height: 2,
+    // Axis 'z', not flipped -> 2D x/y maps directly to 3D x/y.
+    bounds3D: {
+      min: { x: 0, y: 0, z: 0 },
+      max: { x: 4, y: 4, z: 1 },
+    },
+    modelIndex: 0,
+  };
+  return {
+    voidedBy: new Map([[HOST_ID, [OPENING_ID]]]),
+    filledBy: new Map(),
+    openingInfo: new Map([[OPENING_ID, openingInfo]]),
+  };
+}
+
+function makeSegment(p0: { x: number; y: number }, p1: { x: number; y: number }): CutSegment {
+  return {
+    p0: { x: p0.x, y: p0.y, z: 0 },
+    p1: { x: p1.x, y: p1.y, z: 0 },
+    p0_2d: p0,
+    p1_2d: p1,
+    entityId: HOST_ID,
+    ifcType: 'IfcWall',
+    modelIndex: 0,
+  };
+}
+
+describe('OpeningFilter.filterSegment (void removal)', () => {
+  it('removes a cut segment that lies entirely inside an opening void', () => {
+    const filter = new OpeningFilter(makeRelationships());
+    filter.projectOpenings({ axis: 'z', position: 0, flipped: false });
+
+    // Fully inside the [0,0]-[4,4] opening bounds.
+    const segment = makeSegment({ x: 1, y: 1 }, { x: 3, y: 3 });
+    const result = filter.filterSegmentsForHost([segment], HOST_ID);
+
+    expect(result).toEqual([]);
+  });
+
+  it('keeps a cut segment entirely outside the opening void', () => {
+    const filter = new OpeningFilter(makeRelationships());
+    filter.projectOpenings({ axis: 'z', position: 0, flipped: false });
+
+    // Well clear of the [0,0]-[4,4] opening bounds.
+    const segment = makeSegment({ x: 10, y: 10 }, { x: 12, y: 12 });
+    const result = filter.filterSegmentsForHost([segment], HOST_ID);
+
+    expect(result).toEqual([segment]);
+  });
+});

--- a/packages/lists/src/engine.test.ts
+++ b/packages/lists/src/engine.test.ts
@@ -400,6 +400,15 @@ describe('executeList', () => {
     { source: 'attribute', propertyName: 'Class', operator: 'equals', value: 'IfcWall', expected: ['Wall-01', 'Wall-02'] },
     // Only Wall-02 has an insulation layer (multi-valued, any-match).
     { source: 'material', propertyName: 'Material', operator: 'contains', value: 'insulation', expected: ['Wall-02'] },
+    // Multi-valued equals: Wall-02's material list is ['Brick', 'Rigid
+    // Insulation'] — equals must match on ANY candidate ('some'), not
+    // require ALL of them to equal the target ('every' would drop it).
+    { source: 'material', propertyName: 'Material', operator: 'equals', value: 'Brick', expected: ['Wall-02'] },
+    // Multi-valued notEquals: must exclude an entity when ANY candidate
+    // equals the target ('every' semantics) — 'some' would wrongly keep
+    // Wall-02 because its OTHER material ('Rigid Insulation') still
+    // differs from 'Brick'.
+    { source: 'material', propertyName: 'Material', operator: 'notEquals', value: 'Brick', expected: ['Slab-01', 'Wall-01'] },
     // Classification matches by code or by name.
     { source: 'classification', propertyName: 'Classification', operator: 'contains', value: 'Pr_20', expected: ['Wall-01'] },
     { source: 'classification', propertyName: 'Classification', operator: 'contains', value: 'slab', expected: ['Slab-01'] },
@@ -440,6 +449,12 @@ describe('executeList', () => {
     { source: 'quantity', psetName: 'Qto_WallBaseQuantities', propertyName: 'Length', operator: 'lt', value: 4, expected: ['Wall-02'] },
     { source: 'quantity', psetName: 'Qto_WallBaseQuantities', propertyName: 'Length', operator: 'gte', value: 5.0, expected: ['Wall-01'] },
     { source: 'quantity', psetName: 'Qto_WallBaseQuantities', propertyName: 'Length', operator: 'lte', value: 3.5, expected: ['Wall-02'] },
+    // Boundary pin for gt/lt (strict): value exactly equal to a wall's own
+    // Length must NOT match — `>`/`<` mutated to `>=`/`<=` would wrongly
+    // include it. gte/lte at the same values (above) already cover the
+    // inclusive side, so this isolates strictness specifically.
+    { source: 'quantity', psetName: 'Qto_WallBaseQuantities', propertyName: 'Length', operator: 'gt', value: 5.0, expected: [] },
+    { source: 'quantity', psetName: 'Qto_WallBaseQuantities', propertyName: 'Length', operator: 'lt', value: 3.5, expected: [] },
     // FireRating: Wall-01='REI 90', Wall-02='EI 30', Slab-01 has no
     // Pset_WallCommon at all (null actualValue is excluded, not a match).
     { source: 'property', psetName: 'Pset_WallCommon', propertyName: 'FireRating', operator: 'notEquals', value: 'EI 30', expected: ['Wall-01'] },
@@ -1035,6 +1050,23 @@ describe('discoverColumns', () => {
 
     expect(result.quantities.has('Qto_WallBaseQuantities')).toBe(true);
     expect(result.quantities.get('Qto_WallBaseQuantities')).toContain('Length');
+  });
+
+  it('returns property/quantity names sorted alphabetically, not in discovery order', () => {
+    // Discovery-order for Pset_WallCommon (entity 1's properties, in
+    // fixture order) is IsExternal, FireRating, LoadBearing,
+    // ThermalTransmittance — alphabetically it's FireRating, IsExternal,
+    // LoadBearing, ThermalTransmittance. An order-blind `toContain`
+    // assertion can't tell these apart; `toEqual` pins the exact order.
+    const provider = createMockProvider();
+    const result = discoverColumns(provider, [IfcTypeEnum.IfcWall]);
+
+    expect(result.properties.get('Pset_WallCommon')).toEqual([
+      'FireRating',
+      'IsExternal',
+      'LoadBearing',
+      'ThermalTransmittance',
+    ]);
   });
 
   it('aggregates discovery across multiple providers and multiple types', () => {

--- a/packages/lists/src/engine.zone.test.ts
+++ b/packages/lists/src/engine.zone.test.ts
@@ -21,7 +21,7 @@ type Assignment = { zoneName: string | null; straddles: boolean; touchedZoneName
 
 function createProvider(assignments: Map<number, Assignment>): ListDataProvider {
   return {
-    getEntitiesByType: (t) => (t === IfcTypeEnum.IfcWall ? [1, 2, 3] : []),
+    getEntitiesByType: (t) => (t === IfcTypeEnum.IfcWall ? [1, 2, 3, 4] : []),
     getEntityName: (id) => `Wall-${id}`,
     getEntityGlobalId: (id) => `guid-${id}`,
     getEntityDescription: () => '',
@@ -44,6 +44,10 @@ describe('zone column/condition (#1810)', () => {
     [1, { zoneName: 'Section A', straddles: false, touchedZoneNames: [] }],
     [2, { zoneName: null, straddles: true, touchedZoneNames: ['Section A', 'Section B'] }],
     [3, { zoneName: null, straddles: false, touchedZoneNames: [] }], // unassigned
+    // straddles=true but touchedZoneNames is empty (e.g. the viewer-side
+    // zone math flagged a boundary crossing without resolving named
+    // zones) — must fall back to zoneName, not join an empty list.
+    [4, { zoneName: 'Section C (fallback)', straddles: true, touchedZoneNames: [] }],
   ]);
 
   it('resolves the zone name for a cleanly-assigned element', () => {
@@ -70,12 +74,20 @@ describe('zone column/condition (#1810)', () => {
     expect(result.rows.find(r => r.entityId === 3)!.values[0]).toBe(null);
   });
 
+  it('falls back to zoneName when straddles is true but touchedZoneNames is empty', () => {
+    const result = executeList(
+      walls([{ id: 'z', source: 'zone', psetName: 'sections', propertyName: 'Zone' }]),
+      createProvider(assignments),
+    );
+    expect(result.rows.find(r => r.entityId === 4)!.values[0]).toBe('Section C (fallback)');
+  });
+
   it('resolves the Straddles boolean column independent of the Zone column', () => {
     const result = executeList(
       walls([{ id: 's', source: 'zone', psetName: 'sections', propertyName: 'Straddles' }]),
       createProvider(assignments),
     );
-    expect(result.rows.map(r => r.values[0])).toEqual([false, true, false]);
+    expect(result.rows.map(r => r.values[0])).toEqual([false, true, false, true]);
   });
 
   it('an unknown zone-set id resolves to null (provider has no data for it)', () => {

--- a/packages/pointcloud/src/classification.test.ts
+++ b/packages/pointcloud/src/classification.test.ts
@@ -89,6 +89,19 @@ describe('classification count aggregation (#1783)', () => {
     expect(counts.reduce((a, b) => a + b, 0)).toBe(3);
   });
 
+  it('stops at pointCount when the buffer is longer than the chunk claims', () => {
+    // Buffer holds 5 codes but the chunk says only 2 points are valid —
+    // the extra 3 slots are stale/uninitialised and must not be counted.
+    const counts = createClassificationCounts();
+    accumulateClassificationCounts(counts, {
+      classifications: new Uint8Array([2, 2, 9, 9, 9]),
+      pointCount: 2,
+    });
+    expect(counts[2]).toBe(2);
+    expect(counts[9]).toBe(0);
+    expect(counts.reduce((a, b) => a + b, 0)).toBe(2);
+  });
+
   it('lists only non-zero entries, ascending by code', () => {
     const counts = createClassificationCounts();
     accumulateClassificationCounts(counts, {

--- a/packages/pointcloud/src/streaming/host.test.ts
+++ b/packages/pointcloud/src/streaming/host.test.ts
@@ -153,6 +153,47 @@ describe('streamPointCloud (in-process source)', () => {
     expect(counts.reduce((a, b) => a + b, 0)).toBe(12);
   });
 
+  it('aggregates the bbox across 3+ chunks with each axis extreme in a different chunk', async () => {
+    // Chunk 1 (rows 0-3): widest X range, mid Y/Z.
+    // Chunk 2 (rows 4-7): widest Y range, X min tightens here.
+    // Chunk 3 (rows 8-11): widest Z range (both the global min and max).
+    // No single chunk holds every axis extreme, so a swapped min/max
+    // comparison in the aggregation (host.ts) would report a bbox that
+    // doesn't match any chunk's own box, or would fail to widen at all.
+    const rows = [
+      { x: 0, y: 10, z: 100 },
+      { x: 1, y: 10, z: 100 },
+      { x: 2, y: 10, z: 100 },
+      { x: 3, y: 10, z: 100 }, // global x max = 3
+      { x: -5, y: 20, z: 100 },
+      { x: -5, y: 21, z: 100 },
+      { x: -5, y: 22, z: 100 },
+      { x: -5, y: 23, z: 100 }, // global y max = 23; global x min = -5
+      { x: -5, y: 10, z: 5 }, // global z min = 5
+      { x: -5, y: 10, z: 200 }, // global z max = 200
+      { x: -5, y: 10, z: 100 },
+      { x: -5, y: 10, z: 100 },
+    ];
+
+    let bbox: { min: readonly number[]; max: readonly number[] } | null = null;
+    const handle = streamPointCloud({
+      format: 'las',
+      blob: buildLasFile(rows),
+      chunkSize: 4,
+      onChunk: () => {},
+      onComplete: (b) => { bbox = b; },
+      createSource: ({ blob, stride }) => new LasStreamingSource(blob, {
+        downsample: { stride },
+      }),
+    });
+
+    await handle.done;
+    expect(bbox).not.toBeNull();
+    const b = bbox as unknown as { min: readonly number[]; max: readonly number[] };
+    expect(b.min).toEqual([-5, 10, 5]);
+    expect(b.max).toEqual([3, 23, 200]);
+  });
+
   it('rejects files larger than maxFileSize', async () => {
     const blob = buildLasFile([{ x: 0, y: 0, z: 0 }]);
     let errored: Error | null = null;


### PR DESCRIPTION
Test-only — no production file is modified (verified with `git diff` over non-test sources, not just `git status`).

## Three of these are full survivors

`drawing-2d` had **no test file at all** for either `hidden-line.ts` or `opening-filter.ts`. Each of these leaves the entire package suite green with the behaviour inverted:

| file | mutation | result |
|---|---|---|
| `hidden-line.ts:458` | `lineDepth <= bufferDepth + depthBias` → `>` | **153/153 pass** |
| `openings/opening-filter.ts:118` | `return []` → `return [segment]` | **153/153 pass** |
| `dxf/parser.ts` | delete the stacked-fraction regex | **153/153 pass** |

The first flips visible and hidden for the **whole** hidden-line-removal algorithm — the output would be inside-out, and nothing noticed. The second makes opening-void removal a complete no-op, so voids are never cut from the drawing.

I re-verified both myself: with the new tests, the depth inversion fails 2/158 and the opening no-op fails 1/158.

## pointcloud

**`classification.ts:83`** — `Math.min(classes.length, chunk.pointCount)` → `Math.max` survived. The reason is worth recording: the existing fixture's buffer was *shorter* than `pointCount`, and JS typed arrays silently no-op past their own bounds, so the swap had nothing to reveal. The new fixture inverts that relationship.

**`streaming/host.ts:154`** — the aggregated bbox handed to `onComplete` was **never read by any test**, so swapping the X/Y min comparisons survived. That bbox feeds viewer scene framing, culling and colour-ramp range, so an axis-swapping refactor would ship silently today. Verified: the swap now fails 1/138.

## lists

- `gt`/`lt` were tested at value 4 against walls at 5.0 and 3.5 — far from the line, where `>` and `>=` agree. **Bounded by a control**: `gte`/`lte` die immediately on the same fixtures, so the gap was specific to the strict operators rather than the comparison path being untested. Verified: `>` → `>=` now fails 1/125.
- Multi-valued `equals`/`notEquals` (material, classification) had **no cases at all** — `some` ↔ `every` survived in both directions.
- `getZoneValue`'s straddles + empty `touchedZoneNames` fallback was unreachable from any fixture.
- `discoverColumns`' sort was asserted with order-blind `toContain`, so dropping `.sort()` survived.

## Totals

pointcloud **133** (was 131), drawing-2d **158** (was 153), lists **125** (was 119).

## Provenance note

An earlier attempt at this work was completed and then destroyed — the agent ran `git checkout --` on its own finished tests to leave a clean working tree, and the report didn't carry the test bodies. This is the re-done version, built from the surviving diagnosis. Worth stating because the measured baselines differ slightly from that first report (pointcloud was 131 passed / 5 skipped, not 134 / 2), and these are the numbers that were actually observed here.