### PR TITLE
test(geometry): pin three prism_cut boundaries, incl. a shared constant

### DIFF
--- a/rust/geometry/src/router/voids/prism_cut_tests.rs
+++ b/rust/geometry/src/router/voids/prism_cut_tests.rs
@@ -662,3 +662,99 @@ fn hairline_true_collinear_cover_still_accepted() {
         "a near-collinear fully-covered hairline must remain accepted"
     );
 }
+
+/// `PrismFrame::contains` is documented as a "Strict interior test (open
+/// solid)": points exactly on the depth boundaries `d0`/`d1` must be
+/// classified as OUTSIDE, not inside. Every call site in this file only ever
+/// probes triangle/piece centroids, which are essentially never bit-exact on
+/// a slab plane, so this boundary is otherwise never exercised. Pin it
+/// directly against a hand-built axis-aligned frame.
+#[test]
+fn prism_frame_contains_excludes_depth_boundary_points() {
+    let pf = PrismFrame {
+        u: [1.0, 0.0, 0.0],
+        v: [0.0, 1.0, 0.0],
+        d: [0.0, 0.0, 1.0],
+        planes: vec![0.0, 10.0],
+        profiles: vec![vec![[0.0, 0.0], [10.0, 0.0], [10.0, 10.0], [0.0, 10.0]]],
+        slab_area: vec![100.0],
+        slab_interior: vec![[5.0, 5.0]],
+        bb: ([0.0, 0.0], [10.0, 10.0]),
+    };
+
+    // Strictly interior in all three axes: inside.
+    assert!(pf.contains([5.0, 5.0, 5.0]));
+
+    // Exactly on the d0 plane: must be OUTSIDE (open solid), not inside.
+    assert!(
+        !pf.contains([5.0, 5.0, 0.0]),
+        "a point exactly on the d0 boundary must be excluded by the strict interior test"
+    );
+    // Exactly on the d1 plane: must be OUTSIDE (open solid), not inside.
+    assert!(
+        !pf.contains([5.0, 5.0, 10.0]),
+        "a point exactly on the d1 boundary must be excluded by the strict interior test"
+    );
+
+    // Just outside on either side: outside.
+    assert!(!pf.contains([5.0, 5.0, -0.001]));
+    assert!(!pf.contains([5.0, 5.0, 10.001]));
+}
+
+/// `rings_equal` is documented as "Cyclic CCW-ring equality WITHIN `tol`" —
+/// an inclusive bound. A per-coordinate difference of exactly `tol` must
+/// still count as equal; only strictly-greater differences must reject the
+/// match. `try_merge_prisms`'s only caller of this function (the wall-leaf
+/// half-void merge) never happens to land a fixture exactly on this
+/// boundary, so pin the `>` vs `>=` distinction directly.
+#[test]
+fn rings_equal_treats_exact_tolerance_as_equal() {
+    let tol = 0.25;
+    let a = vec![[0.0, 0.0], [4.0, 0.0], [4.0, 4.0], [0.0, 4.0]];
+    let mut b = a.clone();
+    // First vertex shifted by exactly `tol` in x: still within tolerance.
+    b[0] = [0.25, 0.0];
+    assert!(
+        rings_equal(&a, &b, tol),
+        "a difference exactly at tol must count as equal (inclusive boundary)"
+    );
+
+    // Shifted by one ULP past tol: must now be unequal.
+    b[0] = [0.25 + 1.0e-9, 0.0];
+    assert!(
+        !rings_equal(&a, &b, tol),
+        "a difference just past tol must be rejected"
+    );
+}
+
+/// `basis_from_depth` is documented to use "the same seed convention as
+/// `OpeningFrame::from_depth`" — both pick seed `+Z` when `|d.z| < 0.9`, else
+/// `+Y`. `prepare_prism` builds its frame via `OpeningFrame`/the void-context
+/// path while `detect_prism` (mesh-driven) calls `basis_from_depth` directly;
+/// if the two thresholds ever drift apart, a depth vector with `|d.z|` in the
+/// gap gets a DIFFERENT (u, v) basis from each path, silently corrupting any
+/// coordinate exchanged between them (e.g. `try_merge_prisms`'s BASIS_TOL
+/// check, which assumes a shared convention). Every existing fixture's depth
+/// vectors are axis-aligned or steeply diagonal, so `|d.z|` never actually
+/// lands in the band between the two candidate thresholds — pin the
+/// cross-function agreement directly for a depth vector that does.
+#[test]
+fn basis_from_depth_matches_opening_frame_seed_convention() {
+    // |z| ~= 0.640, inside (0.09, 0.9): distinguishes a drifted threshold
+    // without landing exactly on either candidate boundary.
+    let d3 = crate::Vector3::new(0.6, 0.0, 0.5).normalize();
+    let d: V3 = [d3.x, d3.y, d3.z];
+
+    let want = super::super::OpeningFrame::from_depth(d3).expect("normalizable depth");
+    let (u, v) = basis_from_depth(d).expect("normalizable depth");
+
+    let close = |a: V3, b: [f64; 3]| (0..3).all(|k| (a[k] - b[k]).abs() < 1.0e-12);
+    assert!(
+        close([want.cross_a.x, want.cross_a.y, want.cross_a.z], u),
+        "basis_from_depth's u must match OpeningFrame::from_depth's cross_a for the same seed convention"
+    );
+    assert!(
+        close([want.cross_b.x, want.cross_b.y, want.cross_b.z], v),
+        "basis_from_depth's v must match OpeningFrame::from_depth's cross_b for the same seed convention"
+    );
+}


### PR DESCRIPTION
Test-only. `prism_cut.rs` is byte-identical to base — only its test file grew. **577 → 580** lib tests.

## The interesting one: a magic constant duplicated across two functions

`basis_from_depth` (`prism_cut.rs:568`) picks its seed with `d[2].abs() < 0.9`, and its doc comment says it uses *"the same seed convention as `OpeningFrame::from_depth`"*. That function carries the identical `0.9` at `router/voids/mod.rs:80` — I checked rather than took the comment's word for it.

**Nothing tied the two together.** Shifting one threshold to `0.09` survived **579/579**, because every fixture's depth vector is axis-aligned or steeply diagonal and none lands in the `[0.09, 0.9)` band where the two would disagree.

That matters more than a normal boundary gap: two functions sharing a magic constant, linked only by a doc comment, is drift waiting to happen. If they diverge, `detect_prism`'s mesh-driven basis and `prepare_prism`'s `OpeningFrame`-driven basis silently disagree for the same depth vector, corrupting anything that exchanges `(u,v)` between them — `try_merge_prisms`' `BASIS_TOL` check among them. The new test asserts the two agree for a depth vector inside that band, so a future edit to either function is caught.

## Two guards documented as inclusive/strict that nothing held to it

`PrismFrame::contains` (`:453`) is documented *"Strict interior test (open solid)"*, but `<=`/`>=` → `<`/`>` survived **577/577**. The reason it was unreachable is specific: both call sites (`:1896`, `:2138`) pass triangle and piece **centroids**, which are never bit-exact on a slab plane. Now pinned exactly on `d0` and `d1`.

`rings_equal` (`:1121`) is documented as equality **within** `tol` — inclusive — but `>` → `>=` survived **578/578**. Pinned at exactly `tol` and one ULP past it.

All three are **coverage gaps**: the code is correct today, nothing pinned it.

## Control

`cap_xor`'s `in_prev != in_next` → `==` kills **4 tests immediately** (`box_cutter_through_wall_watertight_and_volume_exact`, `deterministic_output`, `mixed_eligible_and_ineligible_returns_residual`, `rotated_prism_cutter_fires_and_reconciles`). So this file's harness discriminates well — these three boundaries specifically were blind, rather than `prism_cut.rs` being under-tested generally.

## Checks

Ratchet **4/4** — `prism_cut_tests.rs` grew to ~760 lines, still within budget, no split needed.

`clippy -D warnings` reports 4 errors, all pre-existing in `rust/core` (`georef.rs:287/680/703`, `parser/scanner.rs:107`) and none in the touched file. I verified the same 4 are present on an unmodified tree rather than assuming — that check caught a real problem of mine on #2190, where an unused import from a file split passed `cargo test` and failed CI.

## Not reached

`bool2d_path.rs`, `synthesis.rs`, `probe.rs`, `sweep.rs`, `geom.rs`, and non-void placement/profile code — the round's budget went entirely to `prism_cut.rs` (2958 lines). Flagged as unfinished, not clean.

Two specific follow-up targets spotted but not mutated: the volume self-check tolerances at `prism_cut.rs:1946-1955` (the `Err(8)` gates) and `try_merge_prisms`' `BASIS_TOL`/weld constants at `:1146-1160`.