### PR TITLE
test(merge,drawing-2d): cover eleven unpinned predicates

### DIFF
--- a/packages/drawing-2d/src/object-styles.test.ts
+++ b/packages/drawing-2d/src/object-styles.test.ts
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, it } from 'vitest';
+import { isIfcTypeVisible, getHiddenIfcTypes } from './object-styles.js';
+
+describe('isIfcTypeVisible', () => {
+  it('IfcWall is visible by default', () => {
+    expect(isIfcTypeVisible('IfcWall')).toBe(true);
+  });
+
+  it('IfcOpeningElement is hidden by default', () => {
+    expect(isIfcTypeVisible('IfcOpeningElement')).toBe(false);
+  });
+
+  it('a user override can hide a normally-visible type', () => {
+    expect(isIfcTypeVisible('IfcWall', { IfcWall: { visible: false } })).toBe(false);
+  });
+});
+
+describe('getHiddenIfcTypes', () => {
+  it('includes types that are hidden by default and excludes visible ones', () => {
+    const hidden = getHiddenIfcTypes();
+    expect(hidden).toContain('IfcOpeningElement');
+    expect(hidden).not.toContain('IfcWall');
+  });
+
+  it('reflects user overrides that hide/show types', () => {
+    const hidden = getHiddenIfcTypes({
+      IfcWall: { visible: false },
+      IfcOpeningElement: { visible: true },
+    });
+    expect(hidden).toContain('IfcWall');
+    expect(hidden).not.toContain('IfcOpeningElement');
+  });
+});

--- a/packages/drawing-2d/src/openings/opening-relationship-builder.test.ts
+++ b/packages/drawing-2d/src/openings/opening-relationship-builder.test.ts
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, it } from 'vitest';
+import { OpeningRelationshipBuilder } from './opening-relationship-builder.js';
+import type { EntityMetadata } from '../types.js';
+
+describe('OpeningRelationshipBuilder', () => {
+  it('computes width from the x-extent and height from the z-extent of bounds', () => {
+    const entityMetadata = new Map<number, EntityMetadata>([
+      [
+        10,
+        {
+          ifcType: 'IfcOpeningElement',
+          bounds: {
+            min: { x: 0, y: 0, z: 0 },
+            // x-extent (width) = 3, z-extent (height) = 2 -- deliberately
+            // different so a width/height axis swap is detectable.
+            max: { x: 3, y: 0.2, z: 2 },
+          },
+        },
+      ],
+    ]);
+
+    const relationships = new OpeningRelationshipBuilder(entityMetadata)
+      .addVoidRelationships([{ hostId: 1, openingId: 10 }])
+      .build(0);
+
+    const info = relationships.openingInfo.get(10);
+    expect(info).toBeDefined();
+    expect(info!.width).toBe(3);
+    expect(info!.height).toBe(2);
+  });
+
+  it('assigns doorOperation only for door-type openings', () => {
+    const entityMetadata = new Map<number, EntityMetadata>([
+      [
+        10,
+        {
+          ifcType: 'IfcOpeningElement',
+          bounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 1, y: 1, z: 2 } },
+        },
+      ],
+      [
+        20,
+        {
+          ifcType: 'IfcDoor',
+          properties: { OperationType: 'DOUBLE_DOOR_SINGLE_SWING' },
+        },
+      ],
+    ]);
+
+    const relationships = new OpeningRelationshipBuilder(entityMetadata)
+      .addVoidRelationships([{ hostId: 1, openingId: 10 }])
+      .addFillRelationships([{ openingId: 10, elementId: 20 }])
+      .build(0);
+
+    const info = relationships.openingInfo.get(10);
+    expect(info?.type).toBe('door');
+    expect(info?.doorOperation).toBe('DOUBLE_DOOR_SINGLE_SWING');
+  });
+});

--- a/packages/drawing-2d/src/openings/opening-utils.test.ts
+++ b/packages/drawing-2d/src/openings/opening-utils.test.ts
@@ -1,0 +1,72 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, it } from 'vitest';
+import {
+  isHostElement,
+  isOpeningElement,
+  isDoorOrWindow,
+  filterOutOpeningElements,
+  getHostEntityIds,
+} from './opening-utils.js';
+import type { OpeningRelationships } from '../types.js';
+
+describe('isHostElement', () => {
+  it('returns true for wall/slab/roof/floor types', () => {
+    expect(isHostElement('IfcWall')).toBe(true);
+    expect(isHostElement('IfcWallStandardCase')).toBe(true);
+    expect(isHostElement('IfcSlab')).toBe(true);
+    expect(isHostElement('IfcRoof')).toBe(true);
+    expect(isHostElement('IfcFloor')).toBe(true);
+  });
+
+  it('returns false for non-host types like doors and windows', () => {
+    expect(isHostElement('IfcDoor')).toBe(false);
+    expect(isHostElement('IfcWindow')).toBe(false);
+    expect(isHostElement('IfcFurniture')).toBe(false);
+  });
+});
+
+describe('isOpeningElement / isDoorOrWindow', () => {
+  it('identifies opening element types', () => {
+    expect(isOpeningElement('IfcOpeningElement')).toBe(true);
+    expect(isOpeningElement('IfcWall')).toBe(false);
+  });
+
+  it('identifies door/window types', () => {
+    expect(isDoorOrWindow('IfcDoor')).toBe(true);
+    expect(isDoorOrWindow('IfcWindow')).toBe(true);
+    expect(isDoorOrWindow('IfcWall')).toBe(false);
+  });
+});
+
+describe('filterOutOpeningElements', () => {
+  it('excludes ids that are openings or filling elements', () => {
+    const relationships: OpeningRelationships = {
+      voidedBy: new Map([[1, [10]]]),
+      filledBy: new Map([[10, 20]]),
+      openingInfo: new Map(),
+    };
+    const result = filterOutOpeningElements([1, 10, 20, 30], relationships);
+    expect(result).toEqual([1, 30]);
+  });
+});
+
+describe('getHostEntityIds', () => {
+  it('excludes opening and door/window entities, keeps hosts', () => {
+    const relationships: OpeningRelationships = {
+      voidedBy: new Map(),
+      filledBy: new Map(),
+      openingInfo: new Map(),
+    };
+    const ifcTypes = new Map<number, string>([
+      [1, 'IfcWall'],
+      [2, 'IfcOpeningElement'],
+      [3, 'IfcDoor'],
+      [4, 'IfcSlab'],
+    ]);
+    const result = getHostEntityIds([1, 2, 3, 4], relationships, ifcTypes);
+    expect(result).toEqual([1, 4]);
+  });
+});

--- a/packages/drawing-2d/src/styling/layer-mapping.test.ts
+++ b/packages/drawing-2d/src/styling/layer-mapping.test.ts
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, it } from 'vitest';
+import { LayerMapper } from './layer-mapping.js';
+import type { ArchitecturalLine } from '../types.js';
+
+function line(overrides: Partial<ArchitecturalLine>): ArchitecturalLine {
+  return {
+    line: { start: { x: 0, y: 0 }, end: { x: 1, y: 0 } },
+    category: 'cut',
+    entityId: 1,
+    ifcType: 'IfcWall',
+    modelIndex: 0,
+    depth: 0,
+    semanticType: 'wall-cut',
+    lineWeight: 'heavy',
+    lineStyle: 'solid',
+    visibility: 'visible',
+    ...overrides,
+  } as ArchitecturalLine;
+}
+
+describe('LayerMapper.getLayerForLine', () => {
+  const mapper = new LayerMapper();
+
+  it('routes a hidden-visibility line to the hidden layer even when solid', () => {
+    const l = line({ visibility: 'hidden', lineStyle: 'solid' });
+    const layer = mapper.getLayerForLine(l);
+    expect(layer.aiaCode).toBe('A-HIDN');
+  });
+
+  it('routes a dashed line to the hidden layer even when visibility is visible', () => {
+    const l = line({ visibility: 'visible', lineStyle: 'dashed' });
+    const layer = mapper.getLayerForLine(l);
+    expect(layer.aiaCode).toBe('A-HIDN');
+  });
+
+  it('does not route a visible solid wall-cut line to the hidden layer', () => {
+    const l = line({ visibility: 'visible', lineStyle: 'solid' });
+    const layer = mapper.getLayerForLine(l);
+    expect(layer.aiaCode).not.toBe('A-HIDN');
+    expect(layer.aiaCode).toBe('A-WALL');
+  });
+});

--- a/packages/drawing-2d/src/styling/line-styles.test.ts
+++ b/packages/drawing-2d/src/styling/line-styles.test.ts
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, it } from 'vitest';
+import { LineStyler } from './line-styles.js';
+import type { ArchitecturalLine } from '../types.js';
+
+function line(overrides: Partial<ArchitecturalLine>): ArchitecturalLine {
+  return {
+    line: { start: { x: 0, y: 0 }, end: { x: 1, y: 0 } },
+    category: 'cut',
+    entityId: 1,
+    ifcType: 'IfcWall',
+    modelIndex: 0,
+    depth: 0,
+    semanticType: 'wall-cut',
+    lineWeight: 'heavy',
+    lineStyle: 'solid',
+    visibility: 'visible',
+    ...overrides,
+  } as ArchitecturalLine;
+}
+
+describe('LineStyler.getCSSClass', () => {
+  const styler = new LineStyler();
+
+  it('appends "hidden-line" for a hidden-visibility line', () => {
+    const classes = styler.getCSSClass(line({ visibility: 'hidden' }));
+    expect(classes).toContain('hidden-line');
+  });
+
+  it('does not append "hidden-line" for a visible line', () => {
+    const classes = styler.getCSSClass(line({ visibility: 'visible' }));
+    expect(classes).not.toContain('hidden-line');
+  });
+});

--- a/packages/drawing-2d/src/styling/line-weights.test.ts
+++ b/packages/drawing-2d/src/styling/line-weights.test.ts
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, it } from 'vitest';
+import { LineWeightAssigner } from './line-weights.js';
+import type { DrawingLine } from '../types.js';
+
+function drawingLine(overrides: Partial<DrawingLine>): DrawingLine {
+  return {
+    line: { start: { x: 0, y: 0 }, end: { x: 1, y: 0 } },
+    category: 'projection',
+    visibility: 'visible',
+    entityId: 1,
+    ifcType: 'IfcFurniture',
+    modelIndex: 0,
+    depth: 0,
+    ...overrides,
+  } as DrawingLine;
+}
+
+describe('LineWeightAssigner.assignWeight', () => {
+  const assigner = new LineWeightAssigner();
+
+  it('assigns hairline weight to a hidden-visibility projection line', () => {
+    // visibility is 'hidden' but category is 'projection' (not 'hidden') -
+    // the doc comment says "Hidden lines are always hairline", which should
+    // trigger on visibility alone, not require category === 'hidden' too.
+    const l = drawingLine({ visibility: 'hidden', category: 'projection' });
+    const result = assigner.assignWeight(l);
+    expect(result.lineWeight).toBe('hairline');
+  });
+
+  it('assigns hairline weight to a hidden-category line', () => {
+    const l = drawingLine({ visibility: 'visible', category: 'hidden' });
+    const result = assigner.assignWeight(l);
+    expect(result.lineWeight).toBe('hairline');
+  });
+
+  it('does not force hairline for a visible projection line', () => {
+    const l = drawingLine({ visibility: 'visible', category: 'projection' });
+    const result = assigner.assignWeight(l);
+    expect(result.lineWeight).not.toBe('hairline');
+    expect(result.lineWeight).toBe('light');
+  });
+});

--- a/packages/drawing-2d/src/symbols/door-symbol.test.ts
+++ b/packages/drawing-2d/src/symbols/door-symbol.test.ts
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, it } from 'vitest';
+import { DoorSymbolGenerator } from './door-symbol.js';
+import type { DoorSwingParameters } from '../types.js';
+
+describe('DoorSymbolGenerator.generateSymbol (single swing)', () => {
+  const generator = new DoorSymbolGenerator();
+  const center = { x: 10, y: 0 };
+  const width = 2;
+  const wallDir = { x: 1, y: 0 };
+  const swingDir = { x: 0, y: 1 };
+
+  it('places the hinge on the -wallDir side of center for a left-hinged door', () => {
+    const result = generator.generateSymbol(center, width, 'SINGLE_SWING_LEFT', wallDir, swingDir);
+    const params = result.symbol.parameters as DoorSwingParameters;
+    // hingeOffset = -halfWidth along wallDir => hinge x < center.x
+    expect(params.hingePoint.x).toBeLessThan(center.x);
+  });
+
+  it('places the hinge on the +wallDir side of center for a right-hinged door', () => {
+    const result = generator.generateSymbol(center, width, 'SINGLE_SWING_RIGHT', wallDir, swingDir);
+    const params = result.symbol.parameters as DoorSwingParameters;
+    expect(params.hingePoint.x).toBeGreaterThan(center.x);
+  });
+});

--- a/packages/drawing-2d/src/symbols/symbol-utils.test.ts
+++ b/packages/drawing-2d/src/symbols/symbol-utils.test.ts
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, it } from 'vitest';
+import { inferWallDirection } from './symbol-utils.js';
+import type { Bounds2D } from '../types.js';
+
+describe('inferWallDirection', () => {
+  it('returns horizontal direction when width exceeds height', () => {
+    const bounds: Bounds2D = { min: { x: 0, y: 0 }, max: { x: 4, y: 1 } };
+    expect(inferWallDirection(bounds)).toEqual({ x: 1, y: 0 });
+  });
+
+  it('returns vertical direction when height exceeds width', () => {
+    const bounds: Bounds2D = { min: { x: 0, y: 0 }, max: { x: 1, y: 4 } };
+    expect(inferWallDirection(bounds)).toEqual({ x: 0, y: 1 });
+  });
+
+  it('returns vertical direction for a square opening (width === height boundary)', () => {
+    const bounds: Bounds2D = { min: { x: 0, y: 0 }, max: { x: 2, y: 2 } };
+    expect(inferWallDirection(bounds)).toEqual({ x: 0, y: 1 });
+  });
+});

--- a/packages/merge/src/ref-flow-policy-ancestor.test.ts
+++ b/packages/merge/src/ref-flow-policy-ancestor.test.ts
@@ -23,7 +23,7 @@ import { describe, expect, it } from 'vitest';
 import { computeLayerId, computeStackHash, createProvenanceManifest, setProvenance } from '@ifc-lite/ifcx';
 import type { IfcxFile, IfcxNode, ProvenanceBase } from '@ifc-lite/ifcx';
 import { extractStackState } from './component-state.js';
-import { mergeIntoRef, resolveAncestor } from './ref-flow.js';
+import { checkRefPolicy, mergeIntoRef, resolveAncestor } from './ref-flow.js';
 import type { LayerRefStore, RefEntry } from './ref-flow.js';
 
 const FIRE = 'bsi::ifc::v5a::Pset_FireSafety::FireRating';
@@ -244,5 +244,65 @@ describe('resolveAncestor: layer base includes the named layer itself', () => {
     if (outcome.status !== 'preview') return;
     expect(outcome.ancestorMatched).toBe(true);
     expect(outcome.plan.conflicts).toEqual([]);
+  });
+});
+
+describe('checkRefPolicy: requiredChecks enforcement', () => {
+  const entry: RefEntry = { layers: [], policy: { requiredChecks: ['spec-a'] } };
+
+  it('refuses when the required check has no passing evidence and is not waived', () => {
+    const manifest = createProvenanceManifest({
+      author: { kind: 'human', principal: 'alice' },
+      intent: 'x',
+      base: null,
+      checks: [],
+    });
+    const reason = checkRefPolicy(entry, manifest, [], undefined);
+    expect(reason).toMatch(/spec-a/);
+  });
+
+  it('does not accept a passing check for a DIFFERENT spec as satisfying the required one', () => {
+    // A predicate that ORs spec-match with pass-result (instead of ANDing
+    // them) would let an unrelated passing check satisfy any required spec.
+    const manifest = createProvenanceManifest({
+      author: { kind: 'human', principal: 'alice' },
+      intent: 'x',
+      base: null,
+      checks: [{ tool: 't', spec: 'spec-b', result: 'pass' }],
+    });
+    const reason = checkRefPolicy(entry, manifest, [], undefined);
+    expect(reason).toMatch(/spec-a/);
+  });
+
+  it('admits once the manifest carries a passing check for that exact spec', () => {
+    const manifest = createProvenanceManifest({
+      author: { kind: 'human', principal: 'alice' },
+      intent: 'x',
+      base: null,
+      checks: [{ tool: 't', spec: 'spec-a', result: 'pass' }],
+    });
+    expect(checkRefPolicy(entry, manifest, [], undefined)).toBeUndefined();
+  });
+
+  it('admits a missing/failing required check once it is explicitly waived', () => {
+    const manifest = createProvenanceManifest({
+      author: { kind: 'human', principal: 'alice' },
+      intent: 'x',
+      base: null,
+      checks: [],
+    });
+    const reason = checkRefPolicy(entry, manifest, [{ spec: 'spec-a', reason: 'known flaky' }], undefined);
+    expect(reason).toBeUndefined();
+  });
+
+  it('still refuses an UNwaived required check when a different spec is waived', () => {
+    const manifest = createProvenanceManifest({
+      author: { kind: 'human', principal: 'alice' },
+      intent: 'x',
+      base: null,
+      checks: [],
+    });
+    const reason = checkRefPolicy(entry, manifest, [{ spec: 'spec-other', reason: 'unrelated' }], undefined);
+    expect(reason).toMatch(/spec-a/);
   });
 });

--- a/packages/merge/src/three-way.test.ts
+++ b/packages/merge/src/three-way.test.ts
@@ -293,6 +293,31 @@ describe('three-way decision matrix', () => {
     const plan = planThreeWayMerge({ ancestor: [base], ours: [base], theirs: [base, candidate] });
     expect(plan.conflicts).toEqual([]);
   });
+
+  it('theirs adds an entity ours already tombstoned (unseen by the ancestor) → resurrect, not a silent no-op', () => {
+    // The ancestor never mentions 'wall-new' at all: only ours' own layer
+    // creates a (tombstoned) node for it. That still means the TARGET
+    // stack carries a real tombstone that must be resurrected — gating the
+    // resurrect on "ours OR ancestor recorded a tombstone" is required;
+    // gating on "ours AND ancestor" misses this because the ancestor-side
+    // entity is simply undefined, not a recorded non-tombstone.
+    const oursTombstone = layer([{ path: 'wall-new', attributes: { [IFCLITE_ATTR.DELETED]: true } }], 'ours-tomb');
+    const theirsAdd = layer(
+      [{ path: 'wall-new', attributes: { 'bsi::ifc::class': { code: 'IfcWall', uri: 'u' }, [FIRE]: 'REI90' } }],
+      'theirs-add'
+    );
+    const plan = planThreeWayMerge({
+      ancestor: [base],
+      ours: [base, oursTombstone],
+      theirs: [base, theirsAdd],
+    });
+    expect(plan.conflicts).toEqual([]);
+    expect(plan.autoOps).toContainEqual({ op: 'resurrect-entity', path: 'wall-new' });
+    const merged = stateAfterMerge([base, oursTombstone], plan.autoOps);
+    const wallNew = merged.get('wall-new');
+    expect(wallNew?.deleted).toBe(false);
+    expect(wallNew?.components.get('pset:Pset_FireSafety')?.[FIRE]).toBe('REI90');
+  });
 });
 
 describe('partition fuzz: random op partitions never lose ops', () => {


### PR DESCRIPTION
Test-only. No production file modified. **merge 71 → 78**, **drawing-2d 153 → 179** across 12 → 20 test files.

## `packages/merge` had never been audited

Three predicates in the publish/merge gate were unpinned, each surviving **71/71**:

| location | mutation | effect |
|---|---|---|
| `ref-flow.ts:110` | invert the waiver-skip guard | waived specs enforced, unwaived ones skipped |
| `ref-flow.ts:111` | `c.spec === spec && c.result === 'pass'` → `\|\|` | **any** unrelated passing check satisfies a required spec |
| `three-way.ts:352` | resurrect gate `\|\|` → `&&` | drops resurrect ops when ours tombstoned a path the ancestor never mentioned |

The second is the one I'd want covered: it turns a policy gate into a rubber stamp, since a single passing check of any kind would satisfy every required spec.

**The negative result here is as useful as the findings.** The hypothesis going in was an ours/theirs precedence bug — three-way merge is precedence-sensitive and the fixtures looked thin. Four precedence and conflict-kind mutations (`rebase.ts` ours/theirs swap, conflict-kind swaps in `three-way.ts` and `merge-layer.ts`, an op-name swap in `inverse.ts`) **all died immediately**. The merge algebra is well covered; it was the gate predicates around it that were blind.

One survivor at `ref-flow.ts:175` was proved structurally equivalent and excluded rather than reported.

## `packages/drawing-2d`: eight files with no test at all

Confirmed by import-graph BFS — no sibling test, no reference from any test file. Each of these predicates could be inverted with the suite green: door hinge sides, opening width/height axes, `inferWallDirection` at `width === height`, the hidden-types filter negation, and the hidden/dashed routing in `layer-mapping`, `line-weights`, `line-styles`.

Two controls (`svg-exporter.ts`, `polygon-builder.ts`) died as expected, so the package's harness discriminates — these files were simply outside it.

## A correction to this round's own severity labels

The round reported the door-symbol and opening-builder findings as **live defects**. They are not. I read both: the code is correct. The opening builder takes `width` from the X extent and `height` from Z, which is right for a Z-up frame. A mutation surviving tells you the *tests* don't constrain the code — not that the code is wrong, and the distinction matters when the claim is "doors are drawn backwards".

What *is* true, and is the reason these are worth having: the path is public. `generateDoorSymbol` is exposed through `packages/sdk` (`namespaces/drawing.ts:241`), documented in `docs/guide/drawing-2d.md`, and listed in `scripts/api-surface.json`. So SDK consumers reach code that no test constrained, and `opening.width` feeds door-symbol sizing downstream.

Everything here is a **coverage gap**.

## One genuinely dead export

`openings/opening-utils.ts`'s `isHostElement` is not re-exported, not called anywhere, and duplicated inline elsewhere. Tested anyway since it's cheap, but flagging it — it looks like a deletion candidate rather than something to maintain.