### PR TITLE
test(geometry): cover five void-path gaps, incl. a zero-coverage branch

### DIFF
--- a/rust/geometry/src/router/voids/bool2d_path_tests.rs
+++ b/rust/geometry/src/router/voids/bool2d_path_tests.rs
@@ -101,6 +101,91 @@ fn near_parallel_oblique_opening_defers() {
 }
 
 #[test]
+fn slightly_oblique_short_opening_defers_on_parallelism_alone() {
+    // Isolates the parallelism gate (`host_axis.dot(op_axis).abs() < 1 -
+    // 1e-6`) from the zero-lateral-sweep gate, which normally dominates: a
+    // through-cut opening's depth is forced close to the host span, so its
+    // lateral drift (depth * sin(theta)) almost always breaches `lat_tol`
+    // before the parallelism threshold does. Here `z_tol` is deliberately
+    // large (span check made vacuous) so a very SHORT, 3°-tilted opening can
+    // satisfy the lateral-drift gate (drift = 0.005 * sin(3°) ≈ 2.6e-4 <
+    // lat_tol ≈ 4.0e-4) while still being far outside the parallelism
+    // threshold (cos(3°) ≈ 0.99863 < 1 - 1e-6). Only the parallelism gate can
+    // reject this input.
+    let theta = 3.0_f64.to_radians();
+    let axis = Vector3::new(theta.sin(), 0.0, theta.cos());
+    let op = opening((1.0, 1.0, 0.0), axis, 0.005, 1.0);
+    assert!(
+        opening_solid_footprint(&op, &hm_inv(), &host_axis(), HZ_MIN, HZ_MAX, 10.0).is_none(),
+        "a 3-degree tilt must be rejected by the parallelism gate even when \
+         the lateral-drift and through-cut-span gates are too loose to catch it"
+    );
+}
+
+#[test]
+fn degenerate_zero_area_footprint_defers() {
+    // A collinear (zero-area) footprint must be rejected — `area_abs` can
+    // never be negative (it is a `.abs()`), so the guard's only reachable
+    // branch is the exact `== 0.0` case; weakening `<= 0.0` to `< 0.0` turns
+    // it into dead code that never fires.
+    let z = Vector3::new(0.0, 0.0, 1.0);
+    let m = Matrix4::new_translation(&Vector3::new(1.0, 1.0, 0.0));
+    let profile = Profile2D::new(vec![
+        Point2::new(0.0, 0.0),
+        Point2::new(1.0, 0.0),
+        Point2::new(2.0, 0.0),
+    ]);
+    let op = ExtrudedSolidLike {
+        profile,
+        depth: HZ_MAX,
+        dir_sign: 1.0,
+        m: m * Matrix4::new_translation(&Vector3::new(0.0, 0.0, 0.0))
+            * Rotation3::rotation_between(&z, &host_axis())
+                .unwrap_or_else(Rotation3::identity)
+                .to_homogeneous(),
+    };
+    assert!(
+        opening_solid_footprint(&op, &hm_inv(), &host_axis(), HZ_MIN, HZ_MAX, 0.04).is_none(),
+        "a zero-area (collinear) footprint must defer to the exact kernel"
+    );
+}
+
+#[test]
+fn reconcile_solid_rejects_volume_ratio_outside_tolerance() {
+    // Host: unit square extruded to depth 1 -> volume 1, bounds [0,1]^3.
+    let host_profile = Profile2D::new(vec![
+        Point2::new(0.0, 0.0),
+        Point2::new(1.0, 0.0),
+        Point2::new(1.0, 1.0),
+        Point2::new(0.0, 1.0),
+    ]);
+    let host = extrude_profile(&host_profile, 1.0, None).expect("host extrude");
+
+    // Solid: same [0,1]^2 bounding box, but with a 0.5 x 0.1 notch cut into
+    // the top edge (not touching the corners), so the AABB is UNCHANGED while
+    // the volume drops to 0.95 (5% below the host) -> the ratio (0.95) lands
+    // outside the real 0.97..1.03 tolerance but inside a loosened one, so
+    // only the ratio check (not the bounds check) can reject it.
+    let notched_profile = Profile2D::new(vec![
+        Point2::new(0.0, 0.0),
+        Point2::new(1.0, 0.0),
+        Point2::new(1.0, 1.0),
+        Point2::new(0.7, 1.0),
+        Point2::new(0.7, 0.9),
+        Point2::new(0.2, 0.9),
+        Point2::new(0.2, 1.0),
+        Point2::new(0.0, 1.0),
+    ]);
+    let solid = extrude_profile(&notched_profile, 1.0, None).expect("solid extrude");
+
+    assert!(
+        !reconcile_solid(&host, &solid),
+        "a 5% volume-ratio discrepancy (0.95) must be rejected by the \
+         0.97..1.03 tolerance even though the AABB matches exactly"
+    );
+}
+
+#[test]
 fn annular_opening_defers() {
     // An opening whose own profile carries a hole can't reduce to one
     // subtracted footprint → defer.

--- a/rust/geometry/src/router/voids/reveal_tests.rs
+++ b/rust/geometry/src/router/voids/reveal_tests.rs
@@ -243,6 +243,100 @@
         );
     }
 
+    /// A "box" whose top face is beveled by ~20° at one corner (face-normal
+    /// dot with the true +Z axis ≈ 0.94). The axis-merge tolerance in
+    /// `is_rectangular_box_mesh` must stay tight (0.98, ≈11.5°) so this
+    /// bevel is recognised as a genuinely distinct 4th face-normal axis and
+    /// rejected — not silently folded into the top face's axis group. Both
+    /// triangles share the same first vertex, so the plane-offset check
+    /// (1 mm) cannot discriminate: only the merge-tolerance threshold can.
+    #[test]
+    fn test_rectangular_box_detector_rejects_beveled_corner() {
+        let t = 0.363_f64; // dot(tilted normal, +Z) ≈ 0.94: between 0.80 and 0.98
+        let n_up = Vector3::new(0.0, 0.0, 1.0);
+        let n_down = Vector3::new(0.0, 0.0, -1.0);
+        let mut m = Mesh::new();
+
+        // Top: one flat triangle establishing the true +Z axis, plus one
+        // beveled triangle sharing the same first vertex.
+        let b0 = Point3::new(0.0, 0.0, 1.0);
+        let b1 = Point3::new(1.0, 0.0, 1.0);
+        let b2 = Point3::new(1.0, 1.0, 1.0);
+        let b3 = Point3::new(0.0, 1.0, 1.0);
+        let e = Point3::new(1.0, 1.0, 1.0 + t);
+        let vb = m.vertex_count() as u32;
+        m.add_vertex(b0, n_up);
+        m.add_vertex(b1, n_up);
+        m.add_vertex(b2, n_up);
+        m.add_vertex(b3, n_up);
+        m.add_vertex(e, n_up);
+        m.add_triangle(vb, vb + 1, vb + 2); // flat: normal exactly +Z
+        m.add_triangle(vb, vb + 4, vb + 3); // beveled: normal ≈ 20° off +Z
+
+        // Bottom: flat, normal -Z.
+        let a0 = Point3::new(0.0, 0.0, 0.0);
+        let a1 = Point3::new(1.0, 0.0, 0.0);
+        let a2 = Point3::new(1.0, 1.0, 0.0);
+        let a3 = Point3::new(0.0, 1.0, 0.0);
+        let va = m.vertex_count() as u32;
+        m.add_vertex(a0, n_down);
+        m.add_vertex(a1, n_down);
+        m.add_vertex(a2, n_down);
+        m.add_vertex(a3, n_down);
+        m.add_triangle(va, va + 2, va + 1);
+        m.add_triangle(va, va + 3, va + 2);
+
+        // Four sides, each a flat quad (±X, ±Y).
+        let sides: [[Point3<f64>; 4]; 4] = [
+            [
+                Point3::new(0.0, 0.0, 0.0),
+                Point3::new(0.0, 1.0, 0.0),
+                Point3::new(0.0, 1.0, 1.0),
+                Point3::new(0.0, 0.0, 1.0),
+            ], // x = 0
+            [
+                Point3::new(1.0, 0.0, 0.0),
+                Point3::new(1.0, 1.0, 0.0),
+                Point3::new(1.0, 1.0, 1.0),
+                Point3::new(1.0, 0.0, 1.0),
+            ], // x = 1
+            [
+                Point3::new(0.0, 0.0, 0.0),
+                Point3::new(1.0, 0.0, 0.0),
+                Point3::new(1.0, 0.0, 1.0),
+                Point3::new(0.0, 0.0, 1.0),
+            ], // y = 0
+            [
+                Point3::new(0.0, 1.0, 0.0),
+                Point3::new(1.0, 1.0, 0.0),
+                Point3::new(1.0, 1.0, 1.0),
+                Point3::new(0.0, 1.0, 1.0),
+            ], // y = 1
+        ];
+        for quad in &sides {
+            let edge1 = quad[1] - quad[0];
+            let edge2 = quad[3] - quad[0];
+            let normal = edge1
+                .cross(&edge2)
+                .try_normalize(1e-10)
+                .unwrap_or(Vector3::new(1.0, 0.0, 0.0));
+            let vs = m.vertex_count() as u32;
+            m.add_vertex(quad[0], normal);
+            m.add_vertex(quad[1], normal);
+            m.add_vertex(quad[2], normal);
+            m.add_vertex(quad[3], normal);
+            m.add_triangle(vs, vs + 1, vs + 2);
+            m.add_triangle(vs, vs + 2, vs + 3);
+        }
+
+        assert!(
+            !is_rectangular_box_mesh(&m),
+            "a beveled corner (~20° face-normal tilt) must NOT merge into the \
+             top face's axis group — it is a genuinely distinct 4th axis, so \
+             the mesh is not a clean box"
+        );
+    }
+
     /// A box rotated 45° around Z should still be classified as a box: its
     /// three face-normal axes are mutually orthogonal even though none align
     /// with world axes. The diagonal cutter then handles the rotation.
@@ -461,6 +555,49 @@
 
         assert_eq!(new_min, open_min, "-X-poke-out: extension must not change min");
         assert_eq!(new_max, open_max, "-X-poke-out: extension must not change max");
+    }
+
+    #[test]
+    fn test_extend_opening_skipped_for_recess_pocket() {
+        // Regression coverage for issue #853's RECESS/POCKET pattern: the
+        // opening starts exactly on the wall's near face (y=0) but ends well
+        // short of the far face (y=0.1 of a 0.2 m-thick wall) — a partial-depth
+        // bite authored from one side, not a through-hole. Extending it would
+        // silently convert the pocket into a through-hole. This path
+        // (`is_recess`) had ZERO unit coverage before this test — neutering it
+        // entirely (`let is_recess = false;`) left the full suite green.
+        let router = crate::router::GeometryRouter::new();
+
+        let wall_min = Point3::new(0.0, 0.0, 0.0);
+        let wall_max = Point3::new(10.0, 0.2, 3.0);
+        // Flush with the near (min) face, ends at 0.1 -- well inside, not
+        // touching the far face at 0.2.
+        let open_min = Point3::new(4.0, 0.0, 1.0);
+        let open_max = Point3::new(6.0, 0.1, 2.5);
+        let dir = Vector3::new(0.0, 1.0, 0.0);
+
+        let (new_min, new_max) =
+            router.extend_opening_along_direction(open_min, open_max, wall_min, wall_max, dir);
+
+        assert_eq!(
+            new_min, open_min,
+            "a recess's authored min bound must be left unchanged"
+        );
+        assert_eq!(
+            new_max, open_max,
+            "a recess must NOT be extended to reach the wall's far face"
+        );
+
+        // Mirrored: flush with the FAR face, floats short of the near face.
+        let open_min = Point3::new(4.0, 0.1, 1.0);
+        let open_max = Point3::new(6.0, 0.2, 2.5);
+        let (new_min, new_max) =
+            router.extend_opening_along_direction(open_min, open_max, wall_min, wall_max, dir);
+        assert_eq!(
+            new_min, open_min,
+            "a far-flush recess must not be extended toward the near face"
+        );
+        assert_eq!(new_max, open_max, "a far-flush recess's max bound must be left unchanged");
     }
 
     /// DETERMINISM (CI-safe, no fixture): the parametric cut on a rotated, building-scale


### PR DESCRIPTION
Test-only. No production file modified. **577 → 582** lib tests. All five are **coverage gaps** — the code is correct; nothing constrained it.

## The sharpest: a branch with zero coverage guarding a known issue

`synthesis.rs:550`'s RECESS/POCKET detection can be **neutered entirely** — `let is_recess = false;` — and 577/577 still pass. I re-ran that myself.

It guards issue #853: a partial-depth pocket authored flush against one wall face. Without the check, that pocket gets silently extended into a **through-hole** — a visible, wrong hole through a wall. Cases 1–3 of the same function *are* covered by existing tests; case 4 never was.

The new test pins both orientations (flush against the near face, and mirrored against the far face), asserting the authored bounds come back unchanged.

## Four more

| location | mutation | result |
|---|---|---|
| `bool2d_path.rs:395` | `reconcile_solid`'s `(0.97..1.03)` → `(0.90..1.10)` | **577/577** — the function had no direct unit test at all |
| `bool2d_path.rs:361` | `area_abs(&fp) <= 0.0` → `< 0.0` | **survived** |
| `bool2d_path.rs:336` | opening-parallelism gate `1e-6` → `1e-2` | **survived** |
| `geom.rs:622` | `is_rectangular_box_mesh`'s `0.98` axis-merge → `0.80` | **survived** |

The `area_abs` one is neat: `area_abs` is an `.abs()`, so it can never be negative — weakening `<= 0.0` to `< 0.0` turns the guard's only reachable branch into dead code. No fixture had ever produced a degenerate footprint.

The `reconcile_solid` fixture isolates properly: it notches a host edge so volume drops 5% while the **AABB stays byte-identical**, so only the ratio check can reject it, not the bounds check.

The parallelism gate deserves its caveat stated plainly: it is **redundant** with the lateral-sweep gate for a full-depth through-cut, because lateral drift (`depth·sinθ`) dominates parallelism (`~θ²/2`) by roughly 14× at the boundary. It is separately reachable for a *short* opening decoupled via `z_tol`, and the new test builds exactly that case rather than pretending the redundancy isn't there.

## Left open, named rather than filled

- **`geom.rs:703`** — the paired `0.98` that `geom.rs:622`'s doc comment claims to match. It survives. This is the same duplicated-constant shape found at `basis_from_depth`/`OpeningFrame::from_depth` in #2194, but `infer_opening_frame` uses **weighted** axis merging rather than first-seen-wins, so the bevel technique doesn't transfer directly. Not fixed.
- **`synthesis.rs:545`** — `face_align_tol`'s `1e-5` survives being loosened **10,000×**. The new recess fixtures are exactly flush (`diff = 0`), so they pin the branch logic but not this tolerance's magnitude.
- **`probe.rs`, `sweep.rs`** — surveyed and constants listed (`probe.rs:225` `dot.abs() > 0.01`, `sweep.rs:41` volume-drift `1.0e-3`, `sweep.rs:270` `VERTEX_CLEARANCE`), but no mutations run. Unswept, not clean.

## Checks

Ratchet **4/4**. `clippy -D warnings` reports the 4 known pre-existing errors in `rust/core` (`georef.rs`, `parser/scanner.rs`); none points at either touched file.