### PR TITLE
test(processing): pin the Y-up/Z-up conjugation order and a cofactor sign

### DIFF
--- a/rust/processing/src/simplify_session_tests.rs
+++ b/rust/processing/src/simplify_session_tests.rs
@@ -7,7 +7,9 @@
 //! `module_size_ratchet` budget; `_tests.rs` files are exempt from that
 //! ratchet (see `module_size_ratchet.rs`'s `is_exempt`).
 
-use crate::simplify_math::zup_to_yup;
+use crate::simplify_math::{
+    conjugate_yup_to_zup, invert_affine_row_major, matmul_row_major, zup_to_yup,
+};
 use crate::simplify_session::*;
 
 /// Indexed 12-tri box between min/max, IFC Z-up frame, zero normals.
@@ -154,6 +156,74 @@ fn yup_frame_round_trips_and_restores_winding() {
     assert!((rmax[1] - 4.0).abs() < 1e-5);
     assert!((rmin[2] - -3.0).abs() < 1e-5);
     assert!(rmax[2].abs() < 1e-5);
+}
+
+#[test]
+fn conjugate_yup_to_zup_recovers_a_non_identity_matrix() {
+    // `yup_frame_round_trips_and_restores_winding` only exercises
+    // `conjugate_yup_to_zup` through the identity matrix, where
+    // `S * I * S^T == S^T * I * S == I` for any orthogonal `S` — so a
+    // mutation swapping the multiplication order (`S * M' * S^T` instead
+    // of the documented `S^T * M' * S`) is invisible there. Pin it with a
+    // translation whose x/y/z are distinct, so the two orders diverge.
+    let m = [
+        1.0, 0.0, 0.0, 10.0, 0.0, 1.0, 0.0, 20.0, 0.0, 0.0, 1.0, 30.0, 0.0, 0.0, 0.0, 1.0,
+    ];
+    // Forward boundary conjugation `M' = S * M * S^T`
+    // (`zero_copy::mesh::swap_zup_to_yup_mat4`'s convention), built from
+    // the same S/S^T this module documents in `conjugate_yup_to_zup`.
+    #[rustfmt::skip]
+    let s: [f64; 16] = [
+        1.0, 0.0, 0.0, 0.0,
+        0.0, 0.0, 1.0, 0.0,
+        0.0, -1.0, 0.0, 0.0,
+        0.0, 0.0, 0.0, 1.0,
+    ];
+    #[rustfmt::skip]
+    let st: [f64; 16] = [
+        1.0, 0.0, 0.0, 0.0,
+        0.0, 0.0, -1.0, 0.0,
+        0.0, 1.0, 0.0, 0.0,
+        0.0, 0.0, 0.0, 1.0,
+    ];
+    let m_prime = matmul_row_major(&matmul_row_major(&s, &m), &st);
+    let recovered = conjugate_yup_to_zup(&m_prime);
+    for (i, (a, b)) in recovered.iter().zip(m.iter()).enumerate() {
+        assert!((a - b).abs() < 1e-9, "index {i}: {recovered:?} != {m:?}");
+    }
+}
+
+#[test]
+fn invert_affine_row_major_inverts_a_rotated_placement() {
+    // Every existing `local_to_world` fixture in this file uses an identity
+    // (diagonal) linear block, so the cofactor cross terms in
+    // `invert_affine_row_major`'s determinant (e.g. `a[3] * a[7] - a[4] *
+    // a[6]`) are always `0 * 0`, and a sign flip there is invisible —
+    // worse, even a pure axis-aligned 90-degree rotation keeps one row a
+    // unit vector and re-zeroes the same cross term. Use a fully generic
+    // invertible linear block (every entry nonzero and distinct) so the
+    // determinant's cofactor expansion is actually exercised, and check
+    // the round trip `M * M^-1 == I` directly rather than re-deriving the
+    // expected inverse by hand.
+    #[rustfmt::skip]
+    let m: [f64; 16] = [
+        2.0, 1.0, 3.0, 5.0,
+        4.0, 5.0, 1.0, 7.0,
+        2.0, 3.0, 6.0, 9.0,
+        0.0, 0.0, 0.0, 1.0,
+    ];
+    let inv = invert_affine_row_major(&m).expect("rotation matrix is non-singular");
+    let round_trip = matmul_row_major(&m, &inv);
+    #[rustfmt::skip]
+    let identity: [f64; 16] = [
+        1.0, 0.0, 0.0, 0.0,
+        0.0, 1.0, 0.0, 0.0,
+        0.0, 0.0, 1.0, 0.0,
+        0.0, 0.0, 0.0, 1.0,
+    ];
+    for (i, (a, b)) in round_trip.iter().zip(identity.iter()).enumerate() {
+        assert!((a - b).abs() < 1e-9, "index {i}: {round_trip:?} != identity");
+    }
 }
 
 #[test]


### PR DESCRIPTION
Test-only. `simplify_math.rs` unmodified. **60 → 62** lib tests. Both are **coverage gaps** — the code is correct; the fixtures couldn't see it.

## Two identity-fixture blind spots, each surviving 60/60

### `:42` — the conjugation order

`conjugate_yup_to_zup` computes `S^T * M * S`. Swapping it to `S * M * S^T` survives.

The only existing exerciser feeds it the **identity matrix**, and `S · I · Sᵀ == Sᵀ · I · S == I` for *any* orthogonal `S` — so the multiplication order is invisible by construction, not by accident. Now driven with a translation whose x/y/z are distinct, so the two orders diverge.

### `:74` — the determinant's third cofactor

`a[3]*a[7] - a[4]*a[6]` → `+` survives. Every `local_to_world` fixture in the suite uses a **diagonal** linear block, which zeroes `a[3]`, `a[6]` and `a[7]`.

The near-miss is the interesting part: a pure 90° rotation about Z **does not fix this**. It leaves the z-row a unit vector and re-zeroes the same cross term — so the obvious "add a rotated fixture" instinct would have produced a test that still passes against the mutation. It takes a fully generic invertible block with every entry non-zero and distinct. The test asserts `M · M⁻¹ == I` rather than re-deriving the expected inverse by hand.

This is the **same shape** as the Y-up/Z-up sign drop that mirrored an entire HBJSON export earlier in this campaign — found here in the sibling code that performs that very conversion.

## Controls

Flipping the sign in `yup_to_zup`, in `zup_to_yup`, or breaking `S`'s orthogonality each kills a test immediately. So the general conversion path *is* exercised — only the multiplication **order** and the cofactor **sign** were blind.

## Reported, not fixed

`invert_affine_row_major`'s `det.abs() < 1e-24` singular-placement branch, and the `SimplifySkip::SingularPlacement` path it feeds, have **zero coverage on either side**. Raising the threshold to `1e10` fails 6 tests, so the branch is reachable and load-bearing — but the `1e-24` cutoff itself is unpinned in both directions. No fixture produces a near-singular placement.

## `apps/server` is testable after all

Worth recording beyond this PR: `cargo test -p ifc-lite-server` passes **83/0** with a scratch `CARGO_TARGET_DIR`. The `E0152: duplicate lang item` that had that crate written off as environmentally untestable was never a property of the crate — it's a shared-target-dir artifact. It remains un-swept and is now a legitimate target.

## Checks

Ratchet **4/4**. Clippy run with `--no-deps` this time: 7 pre-existing hits in this test file, **identical count with and without** the additions, so none are new. That distinction matters — a plain `cargo clippy -p <crate>` aborts on another crate's pre-existing errors before reaching yours, which made a check I ran on #2198 look clean when it had never run at all.