### PR TITLE
test(server): pin resolved_tessellation_quality's default and error variant

### DIFF
--- a/apps/server/src/routes/parse/mod.rs
+++ b/apps/server/src/routes/parse/mod.rs
@@ -231,3 +231,74 @@ mod extract_file_tests;
 
 #[cfg(test)]
 mod ifczip_tests;
+
+#[cfg(test)]
+mod resolved_tessellation_quality_tests {
+    use super::*;
+    use crate::error::ApiError;
+
+    /// Omitting the query parameter must resolve to the documented default
+    /// (`Medium`, byte-identical to pre-enum behavior) — not silently to some
+    /// other level. Coverage gap found via mutation testing: swapping this arm
+    /// to `TessellationQuality::Highest` survived the full `ifc-lite-server`
+    /// suite (83/83 passed) with zero test hitting this code path.
+    #[test]
+    fn none_resolves_to_medium_default() {
+        let query = ParseQuery {
+            tessellation_quality: None,
+            ..Default::default()
+        };
+        assert_eq!(
+            query.resolved_tessellation_quality().unwrap(),
+            TessellationQuality::Medium
+        );
+    }
+
+    /// Every documented label round-trips through `resolved_tessellation_quality`,
+    /// case-insensitively.
+    #[test]
+    fn every_documented_label_parses() {
+        let cases = [
+            ("lowest", TessellationQuality::Lowest),
+            ("Low", TessellationQuality::Low),
+            ("MEDIUM", TessellationQuality::Medium),
+            ("high", TessellationQuality::High),
+            ("Highest", TessellationQuality::Highest),
+        ];
+        for (label, expected) in cases {
+            let query = ParseQuery {
+                tessellation_quality: Some(label.to_string()),
+                ..Default::default()
+            };
+            assert_eq!(
+                query.resolved_tessellation_quality().unwrap(),
+                expected,
+                "label {label:?} should resolve to {expected:?}"
+            );
+        }
+    }
+
+    /// An unknown level must be rejected as a client error (`400 BadRequest`),
+    /// not swallowed or reported as a server-side `Internal` error — the two
+    /// map to different HTTP statuses and log at different severities.
+    /// Coverage gap found via mutation testing: replacing `ApiError::BadRequest`
+    /// with `ApiError::Internal` on this arm survived the full suite (83/83
+    /// passed) — no test asserted the error path at all, let alone which variant.
+    #[test]
+    fn unknown_label_is_bad_request_not_internal() {
+        let query = ParseQuery {
+            tessellation_quality: Some("ultra".to_string()),
+            ..Default::default()
+        };
+        let err = query.resolved_tessellation_quality().unwrap_err();
+        match err {
+            ApiError::BadRequest(msg) => {
+                assert!(
+                    msg.contains("ultra"),
+                    "error message should name the rejected value, got: {msg}"
+                );
+            }
+            other => panic!("expected ApiError::BadRequest, got {other:?}"),
+        }
+    }
+}


### PR DESCRIPTION
Test-only. Production code unchanged. **83 → 86** tests.

`ParseQuery::resolved_tessellation_quality` is called by every parse and fetch handler — `check_cache`, `get_cached_geometry`, `parse_parquet`, `parse_parquet_stream`, `json.rs` — and had **zero coverage anywhere in the crate**. Both of its arms were unpinned, each surviving **83/83**:

| arm | mutation | effect |
|---|---|---|
| `None => Ok(TessellationQuality::default())` | → `::Highest` | the documented default drifts silently |
| `ApiError::BadRequest(...)` | → `ApiError::Internal(...)` | a client-supplied bad value answers **500 instead of 400** |

The default one is the subtler gap: every existing test *omits* the query parameter, so the code path runs constantly — and none of them asserts what it resolves to. `Medium` is documented as byte-identical to pre-enum output, so a drift there changes geometry for every caller who doesn't pass the parameter, which is most of them.

The error-variant one is the same swap-two-codes shape found five times in this campaign. 400 and 500 map to different HTTP statuses and log at different severities, and nothing asserted the error path at all, let alone which variant it produced.

Both are **coverage gaps** — the code is correct today.

## One test that is not a kill

`every_documented_label_parses` covers all five labels as insurance and is **not tied to a surviving mutation** — I did not separately mutation-test each label arm. Stating that rather than letting a five-case loop imply five verified kills.

## Checks

Ratchet **4/4**. `clippy --no-deps`: 0 hits in the touched file.

## Not reached

`cached_replay.rs`, `parquet.rs`, `parquet_stream.rs` and `json.rs` were read but not mutation-tested — out of budget, so not claimed clean.

Worth flagging for a later round: `fetch.rs`'s `get_cached_geometry`, `get_data_model` and `check_cache` are **un-hit by any test in the crate** (no test references `/api/v1/cache/geometry`, `/api/v1/cache/check`, or `/api/v1/parse/data-model`). `get_cached_geometry` only succeeds on `(Some(parquet), Some(metadata))` and falls to `NotFound` for any partial cache state — an untested branch where a half-populated cache decides what a client gets back.