### PR TITLE
test(data,cache): pin xxhash64's stripe loop and the full relationship-name table

### DIFF
--- a/packages/cache/src/cache.test.ts
+++ b/packages/cache/src/cache.test.ts
@@ -34,6 +34,22 @@ describe('xxhash64', () => {
     expect(hash1).toBe(hash2);
   });
 
+  // All the tests above only ever compare xxhash64's output against
+  // itself (same call twice, or two short inputs), so any internally
+  // consistent but algorithmically wrong implementation still passes
+  // them -- e.g. swapping which 8-byte lane feeds the v2/v3 accumulator
+  // in the >=32-byte stripe loop produces a deterministic, input-sensitive,
+  // but *wrong* hash and none of the other cases here catch it. This
+  // pins a golden value from an independent xxHash64 (seed 0) implementation
+  // (xxhash-wasm) for a 55-byte input, so the >=32-byte code path is
+  // checked against the real algorithm, not just against itself.
+  it('matches the reference xxHash64 (seed 0) value for a >=32-byte input', () => {
+    const data = new TextEncoder().encode('The quick brown fox jumps over the lazy dog. 1234567890');
+    expect(data.length).toBeGreaterThanOrEqual(32);
+    const hash = xxhash64(data);
+    expect(hash.toString(16).padStart(16, '0')).toBe('d9cbd36f4605dc8f');
+  });
+
   it('should produce different hashes for different data', () => {
     const data1 = new TextEncoder().encode('Hello');
     const data2 = new TextEncoder().encode('World');

--- a/packages/data/src/relationship-graph.test.ts
+++ b/packages/data/src/relationship-graph.test.ts
@@ -46,6 +46,43 @@ describe('RelationshipGraph', () => {
     expect(rels[0].type).toBe(RelationshipType.ContainsElements);
     expect(rels[0].typeName).toBe('IfcRelContainedInSpatialStructure');
   });
+
+  // The suite above only ever exercises one `RelationshipType` -> IFC entity
+  // name mapping (ContainsElements), so a swap between two other entries in
+  // the internal `RelationshipTypeToString` lookup table (e.g. AssignsToGroup
+  // <-> AssignsToProduct, which are adjacent numeric values 60/61) is
+  // invisible to every existing test. This pins every type -> name pair so
+  // such a swap fails here.
+  it('maps every RelationshipType to its correct IFC entity name', () => {
+    const expected: Record<RelationshipType, string> = {
+      [RelationshipType.ContainsElements]: 'IfcRelContainedInSpatialStructure',
+      [RelationshipType.Aggregates]: 'IfcRelAggregates',
+      [RelationshipType.DefinesByProperties]: 'IfcRelDefinesByProperties',
+      [RelationshipType.DefinesByType]: 'IfcRelDefinesByType',
+      [RelationshipType.AssociatesMaterial]: 'IfcRelAssociatesMaterial',
+      [RelationshipType.AssociatesClassification]: 'IfcRelAssociatesClassification',
+      [RelationshipType.AssociatesDocument]: 'IfcRelAssociatesDocument',
+      [RelationshipType.VoidsElement]: 'IfcRelVoidsElement',
+      [RelationshipType.FillsElement]: 'IfcRelFillsElement',
+      [RelationshipType.ConnectsPathElements]: 'IfcRelConnectsPathElements',
+      [RelationshipType.ConnectsElements]: 'IfcRelConnectsElements',
+      [RelationshipType.SpaceBoundary]: 'IfcRelSpaceBoundary',
+      [RelationshipType.AssignsToGroup]: 'IfcRelAssignsToGroup',
+      [RelationshipType.AssignsToProduct]: 'IfcRelAssignsToProduct',
+      [RelationshipType.ReferencedInSpatialStructure]: 'IfcRelReferencedInSpatialStructure',
+    };
+
+    let relId = 1000;
+    for (const [typeStr, typeName] of Object.entries(expected)) {
+      const type = Number(typeStr) as RelationshipType;
+      const builder = new RelationshipGraphBuilder();
+      builder.addEdge(1, 2, type, relId++);
+      const g = builder.build();
+      const rels = g.getRelationshipsBetween(1, 2);
+      expect(rels).toHaveLength(1);
+      expect(rels[0].typeName).toBe(typeName);
+    }
+  });
 });
 
 describe('relationshipGraphToColumns / relationshipGraphFromColumns round-trip', () => {


### PR DESCRIPTION
Two surviving mutations. **Tests only** — no production code changed.

## 1. `xxhash64` had no value-correctness test at all

`packages/cache/src/utils/hash.ts`

Every existing test compared the function's output *against itself* — the same call twice, or two arbitrary short inputs asserted merely to differ. A deterministic-but-wrong hash passes all of them, so the `>= 32`-byte stripe loop was entirely unconstrained.

Mutation — swap which 8-byte lane feeds accumulators `v2` and `v3`:

```diff
-v2 = round64(v2, view.getBigUint64(offset + 8, true));
-v3 = round64(v3, view.getBigUint64(offset + 16, true));
+v2 = round64(v2, view.getBigUint64(offset + 16, true));
+v3 = round64(v3, view.getBigUint64(offset + 8, true));
```

1 replacement (asserted), suite still **green**. A wrong hash here is a silent cache-correctness bug — entries collide, or never hit.

The new test pins a golden digest for a 55-byte input. **The implementation is correct as it stands**: the expected value was cross-checked against an independent from-spec XXH64 that also reproduces the canonical vectors for the empty string (`ef46db3751d8e999`) and `"a"` (`d24ec4f1a98c6e5b`). The mutation now kills 2 tests.

## 2. 14 of 15 relationship type-name mappings were unchecked

`packages/data/src/relationship-graph.ts`

The only `typeName` assertion in the suite covered `ContainsElements`. Swapping the IFC names for `AssignsToGroup` and `AssignsToProduct` survived — a swap between any two of the other 14 entries was invisible.

The new test walks all 15 enum values and asserts each resulting `typeName`, so any two entries swapped now fails on the name rather than passing silently.

## Severity

Both are **COVERAGE GAPs**, not live defects. The production values are correct today; nothing failed when they were deliberately broken.

## Verification

- 1 replacement per mutation, count asserted, mutated line re-read before each run.
- Both mutations were **re-run after rebasing onto `main`** and still die there — a rebase can drain assertions without touching a test file.
- Control mutation (`readUint32`'s little-endian flag flipped) died as expected across 23 tests, confirming the harness actually exercises these files.
- Suite: **129 → 131**, all green. `tsc --noEmit` clean for both packages.
- Restores were done by file copy throughout; `git status` shows only the two test files modified.

One aside, not addressed here: `QuantityTable.sumByType` declares an `elementType?: number` parameter the implementation never reads (`packages/data/src/quantity-table.ts:43` vs `:160`). That is the subject of a separate open PR awaiting an API decision, so it is untouched here.