### PR TITLE
test(export): pin the surface-boundary slot order and construction-by-face-type

### DIFF
--- a/rust/export/src/adjacency.rs
+++ b/rust/export/src/adjacency.rs
@@ -116,3 +116,66 @@ pub fn solve_adjacency(rooms: &mut [Room]) -> usize {
     }
     pairs.len() * 2
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hbjson::{Face, Face3D};
+
+    /// Two square wall faces, 0.5m apart, coplanar-facing (anti-parallel normals,
+    /// matching area, zero lateral offset) — the geometry `solve_adjacency` is
+    /// built to pair. Room/face identifiers are distinct on purpose so a swap
+    /// between "which room" and "which face" is observable in the output.
+    fn facing_rooms() -> Vec<Room> {
+        // Room A's wall: outward normal +x (winding gives Newell normal (1,0,0)).
+        let face_a = Face3D::new(vec![
+            [2.0, 0.0, 0.0],
+            [2.0, 2.0, 0.0],
+            [2.0, 2.0, 2.0],
+            [2.0, 0.0, 2.0],
+        ]);
+        // Room B's wall: outward normal -x, offset 0.5m, same footprint extents.
+        let face_b = Face3D::new(vec![
+            [2.5, 0.0, 0.0],
+            [2.5, 0.0, 2.0],
+            [2.5, 2.0, 2.0],
+            [2.5, 2.0, 0.0],
+        ]);
+        let room_a = Room::new(
+            "RoomA".to_string(),
+            vec![Face::new("FaceA".to_string(), face_a, "Wall", "Outdoors")],
+        );
+        let room_b = Room::new(
+            "RoomB".to_string(),
+            vec![Face::new("FaceB".to_string(), face_b, "Wall", "Outdoors")],
+        );
+        vec![room_a, room_b]
+    }
+
+    /// Mutation killed: swapping `vec![adjacent_face, adjacent_room]` to
+    /// `vec![adjacent_room, adjacent_face]` inside `BoundaryCondition::surface`
+    /// (hbjson.rs) survived the full suite — every existing assertion only checks
+    /// `boundary_condition_objects.len() == 2`, never which slot holds the face id
+    /// vs. the room id, and never that room A's face points at room B (not itself).
+    /// This test pins both the slot order and the cross-room identity.
+    #[test]
+    fn solve_adjacency_pairs_faces_with_correct_face_then_room_order() {
+        let mut rooms = facing_rooms();
+        let created = solve_adjacency(&mut rooms);
+        assert_eq!(created, 2, "expected exactly one matched pair (2 interior faces)");
+
+        let bc_a = &rooms[0].faces[0].boundary_condition;
+        let bc_b = &rooms[1].faces[0].boundary_condition;
+        assert_eq!(bc_a.ty, "Surface");
+        assert_eq!(bc_b.ty, "Surface");
+
+        // Room A's face must reference [FaceB, RoomB] — face id first, room id second —
+        // and NOT its own room.
+        let objs_a = bc_a.boundary_condition_objects.as_ref().expect("room A objects");
+        assert_eq!(objs_a.as_slice(), ["FaceB".to_string(), "RoomB".to_string()].as_slice());
+
+        // Room B's face must reference [FaceA, RoomA], the mirror image.
+        let objs_b = bc_b.boundary_condition_objects.as_ref().expect("room B objects");
+        assert_eq!(objs_b.as_slice(), ["FaceA".to_string(), "RoomA".to_string()].as_slice());
+    }
+}

--- a/rust/export/src/lib.rs
+++ b/rust/export/src/lib.rs
@@ -263,6 +263,45 @@ mod tests {
         }
     }
 
+    /// Mutation killed: swapping `constructions::build_constructions`'s returned
+    /// `Constructions { wall, floor, roof }` (e.g. `wall: slab_id.clone(), floor:
+    /// wall_id.clone(), roof: wall_id`) survived the full suite — every existing
+    /// assertion only checks `stats.constructions > 0` / that the energy library is
+    /// non-empty, never which construction id lands on which `face_type`. This test
+    /// pins wall faces to the wall build-up and floor/roof faces to the slab build-up.
+    #[test]
+    fn duplex_faces_get_construction_by_face_type_not_swapped() {
+        let Some(bytes) = fixture("ara3d/duplex.ifc") else {
+            return;
+        };
+        let (json, stats) = export_hbjson_with_stats(&bytes, &HbjsonOptions::default());
+        assert!(stats.constructions > 0, "expected constructions, got {}", stats.constructions);
+        let v: Value = serde_json::from_str(&json).expect("valid JSON");
+
+        let mut saw_wall_construction = false;
+        let mut saw_slab_construction = false;
+        for r in v["rooms"].as_array().unwrap() {
+            for f in r["faces"].as_array().unwrap() {
+                let Some(cons) = f["properties"]["energy"]["construction"].as_str() else {
+                    continue;
+                };
+                match f["face_type"].as_str().unwrap() {
+                    "Wall" => {
+                        assert_eq!(cons, "ifclite_wall", "wall face got {cons}");
+                        saw_wall_construction = true;
+                    }
+                    "Floor" | "RoofCeiling" => {
+                        assert_eq!(cons, "ifclite_slab", "{} face got {cons}", f["face_type"]);
+                        saw_slab_construction = true;
+                    }
+                    other => panic!("unexpected face_type {other}"),
+                }
+            }
+        }
+        assert!(saw_wall_construction, "expected at least one Wall face with a construction");
+        assert!(saw_slab_construction, "expected at least one Floor/RoofCeiling face with a construction");
+    }
+
     #[test]
     fn revit_georeferenced_model_does_not_collapse() {
         // rvt01 carries national-grid coordinates (~2.78e6); the origin-rebase must keep


### PR DESCRIPTION
Two surviving mutations in `rust/export`. **Tests only** — no production code changed.

## 1. The two `boundary_condition_objects` slots are interchangeable

`rust/export/src/hbjson.rs:39-41`

```diff
-Some(vec![adjacent_face, adjacent_room])
+Some(vec![adjacent_room, adjacent_face])
```

1 replacement (asserted), suite still **green**. Both entries are `String`, so the swap is type-correct and produces a well-formed model. The only existing check was `boundary_condition_objects.len() == 2` on the duplex fixture — true either way. Nothing asserted slot order or cross-room identity.

Getting this wrong hands a downstream energy tool the wrong adjacency pairing while still validating. The new test in `adjacency.rs` builds two synthetic facing wall faces and pins both slots by identity; under the mutation it fails with `left: ["RoomB","FaceB"] right: ["FaceB","RoomB"]`.

## 2. No test tied a construction id to a face type

`rust/export/src/constructions.rs:156-158`

```diff
-wall: wall_id, floor: slab_id.clone(), roof: slab_id,
+wall: slab_id.clone(), floor: wall_id.clone(), roof: wall_id,
```

1 replacement (asserted), suite still **green**. The suite asserted only `stats.constructions > 0` and that `energy.materials` / `energy.constructions` were non-empty — all of which survive assigning the slab build-up to walls and the wall build-up to floors and roofs. The new test asserts each face type receives its own build-up; under the mutation it fails with `"Floor" face got ifclite_wall`.

## Severity

Both are **COVERAGE GAPs**, not live defects. The production assignments are correct today; nothing failed when they were deliberately inverted.

## Verification

- 1 replacement per mutation, count asserted, mutated line re-read before each run.
- **Control mutation** (`units: "Meters"` → `"Feet"`) died as expected, confirming the harness actually reaches these files.
- Both mutations were **re-run after rebasing onto `main`** and still die there — a rebase can drain assertions without touching a test file.
- Suite: **122 → 124**, all green. Module-size ratchet 4/4.
- Restores were done by file copy throughout.

Note on clippy: `cargo clippy -p ifc-lite-export --all-targets --no-deps -- -D warnings` reports 29 errors locally, all `clippy::chunks_exact_to_as_chunks` (a recent nightly lint) in `gltf.rs`, `collada.rs`, `obj.rs`, `usd/emit.rs` and `frame.rs`. None cite the two files this PR touches, and they are present on `main` unchanged — this is local-toolchain drift, not something introduced here.