### PR TITLE
test(processing): pin the shard-class lookup table and dominant()'s majority rule

### DIFF
--- a/rust/processing/src/shard_classes.rs
+++ b/rust/processing/src/shard_classes.rs
@@ -191,4 +191,51 @@ mod tests {
              flag must stay clear even though the name ends in STYLE"
         );
     }
+
+    /// Pins every named-arm keyword to its own distinct class code. The two
+    /// tests above cover only the TYPE/STYLE suffix flag; nothing asserted
+    /// the named-arm lookup table itself, so this is a textbook lookup-table
+    /// vacuity: any two of the 12 named arms could be swapped
+    /// (e.g. `IFCRELVOIDSELEMENT` ↔ `IFCRELFILLSELEMENT`) and the full suite
+    /// stayed green. A wrong class here means the sharded pre-pass hands the
+    /// browser host the wrong span list for a record (voids treated as
+    /// fills, materials treated as aggregates, etc.), silently diverging
+    /// from the serial pre-pass it must reproduce byte-for-byte.
+    #[test]
+    fn classify_type_name_pins_every_named_arm_to_a_distinct_code() {
+        let cases = [
+            ("IFCPROJECT", PREPASS_CLASS_PROJECT),
+            ("IFCSITE", PREPASS_CLASS_SITE),
+            ("IFCSTYLEDITEM", PREPASS_CLASS_STYLED_ITEM),
+            ("IFCINDEXEDCOLOURMAP", PREPASS_CLASS_INDEXED_COLOUR_MAP),
+            ("IFCMATERIALDEFINITIONREPRESENTATION", PREPASS_CLASS_MATERIAL_DEF_REPR),
+            ("IFCRELASSOCIATESMATERIAL", PREPASS_CLASS_REL_ASSOCIATES_MATERIAL),
+            ("IFCRELVOIDSELEMENT", PREPASS_CLASS_REL_VOIDS),
+            ("IFCRELFILLSELEMENT", PREPASS_CLASS_REL_FILLS),
+            ("IFCRELAGGREGATES", PREPASS_CLASS_REL_AGGREGATES),
+            ("IFCMAPPEDITEM", PREPASS_CLASS_MAPPED_ITEM),
+            ("IFCRELDEFINESBYTYPE", PREPASS_CLASS_REL_DEFINES_BY_TYPE),
+            ("IFCMATERIALLAYERSET", PREPASS_CLASS_MATERIAL_LAYER_SET),
+            ("IFCMATERIALLAYERSETUSAGE", PREPASS_CLASS_MATERIAL_LAYER_SET),
+        ];
+        for (keyword, expected) in cases {
+            assert_eq!(
+                classify_type_name(keyword),
+                expected,
+                "{keyword} classified as {} not {expected}",
+                classify_type_name(keyword)
+            );
+        }
+
+        // Golden totals: every expected code above (except the two that
+        // intentionally share MATERIAL_LAYER_SET) is pairwise distinct, so a
+        // swap between any two arms is caught by the per-case assertion —
+        // not just an aggregate that a swap could still satisfy.
+        let distinct_codes: std::collections::HashSet<u8> =
+            cases.iter().map(|(_, c)| *c).collect();
+        assert_eq!(distinct_codes.len(), 12, "expected 12 distinct codes across 13 keywords (2 share MATERIAL_LAYER_SET)");
+
+        // An unrecognised keyword with no geometry/type-candidate signal is NONE.
+        assert_eq!(classify_type_name("IFCUNKNOWNTHING"), PREPASS_CLASS_NONE);
+    }
 }

--- a/rust/processing/src/style/indexed_colour.rs
+++ b/rust/processing/src/style/indexed_colour.rs
@@ -257,4 +257,29 @@ mod tests {
             "the out-of-range triangle must be dropped, not partially emitted"
         );
     }
+
+    /// `dominant()` must pick the colour referenced by the MOST triangles, not
+    /// the fewest. Every fixture elsewhere in this crate either has a single
+    /// palette entry (so any selection rule trivially "wins") or an exactly
+    /// balanced split (6 vs. 6), so a `max_by_key` → `min_by_key` flip
+    /// (picking the least-referenced colour instead) previously passed the
+    /// full suite untouched — a real gap, since `resolve_prepass_with_style_seeds`
+    /// always calls `dominant()` to seed the element style index even when the
+    /// mesh is later split, and falls back to it whole when triangle counts
+    /// don't line up with the palette (CSG/void cutting changed the topology).
+    #[test]
+    fn dominant_picks_the_majority_colour_not_the_minority() {
+        let map = FullIndexedColourMap {
+            geometry_id: 1,
+            colours: vec![Rgba::new(1.0, 0.0, 0.0, 1.0), Rgba::new(0.0, 1.0, 0.0, 1.0)],
+            // Palette entry 0 (red) referenced once, entry 1 (green) referenced
+            // three times — green is unambiguously the majority colour.
+            triangle_palette: vec![0, 1, 1, 1],
+        };
+        assert_eq!(
+            map.dominant(),
+            Rgba::new(0.0, 1.0, 0.0, 1.0),
+            "dominant() must return the majority-referenced colour (green), not the minority (red)"
+        );
+    }
 }


### PR DESCRIPTION
Two surviving mutations in `rust/processing`. **Tests only** — no production code changed.

## 1. The shard-class lookup table had nothing asserting it

`rust/processing/src/shard_classes.rs`

`main` recently gained two tests for `classify_type_name`, but both cover only the TYPE/STYLE **suffix flag**. Nothing asserted the named-arm lookup table itself.

```diff
-"IFCRELVOIDSELEMENT" => PREPASS_CLASS_REL_VOIDS,
-"IFCRELFILLSELEMENT" => PREPASS_CLASS_REL_FILLS,
+"IFCRELVOIDSELEMENT" => PREPASS_CLASS_REL_FILLS,
+"IFCRELFILLSELEMENT" => PREPASS_CLASS_REL_VOIDS,
```

1 replacement (asserted). **Zero test failures across the entire crate.** This is the classic lookup-table vacuity — any two of the 12 named arms could trade places silently.

It matters because the sharded pre-pass must reproduce the serial pre-pass exactly. A wrong class hands the host the wrong span list for a record — voids treated as fills, materials as aggregates — and diverges quietly rather than failing.

The new test pins all 13 keywords to their codes (two legitimately share `MATERIAL_LAYER_SET`) plus the unrecognised-keyword case, asserting per-case so a swap fails on the specific keyword rather than on an aggregate a swap could still satisfy.

## 2. `dominant()` could pick the minority colour

`rust/processing/src/style/indexed_colour.rs:57` — `.max_by_key(|(_, c)| *c)` → `.min_by_key(...)` survived.

Every existing fixture was either a single-entry palette (where any selection rule trivially wins) or an exactly balanced 6-vs-6 split — and a balanced split goes through `split_mesh_by_indexed_colour`, not `dominant()` at all. So the majority rule was never exercised.

`dominant()` is not a corner case: it seeds the element style index on every call to `resolve_prepass_with_style_seeds`, and it is the sole fallback whenever CSG or void cutting changes triangle topology so the split cannot apply. The new test uses an unbalanced 1-vs-3 palette split.

## Severity

Both are **COVERAGE GAPs**, not live defects. The production code is correct today; nothing failed when it was deliberately broken.

## Verification

- 1 replacement per mutation, count asserted, mutated line re-read before each run.
- **Control mutation** (reversing the `flat_voids` host sort in `prepass.rs`) died as expected, confirming the harness reaches these files.
- Both mutations were re-run after rebasing onto `main` and still die there. The shard-class swap was **additionally re-checked with the new test stripped out**, specifically to confirm it still survives against `main`'s newer suffix-flag tests rather than being killed by them — it does, with 0 failures.
- Suite **60 → 62**, all green. Module-size ratchet 4/4.
- `cargo clippy -p ifc-lite-processing --all-targets --no-deps -- -D warnings` (with `Checking ifc-lite-processing` confirmed present, so not a cached pass) reports only pre-existing errors in `simplify_session.rs`, `simplify_math.rs`, `processor/`, `geometry_export.rs` and `symbolic/color.rs` — none cite either file touched here.
- Restores were done by file copy throughout.