### PR TITLE
test(mcp,sdk): pin the schema validator's rejections and the forward relation helpers

### DIFF
--- a/packages/mcp/src/validate.test.ts
+++ b/packages/mcp/src/validate.test.ts
@@ -57,4 +57,50 @@ describe('validateInput', () => {
     expect(r.valid).toBe(false);
     expect(r.errors[0].path).toBe('$.ids[1]');
   });
+
+  // Kills a mutation of `schema.additionalProperties === false` to `=== true`
+  // (or a dropped check). Every hand-authored MCP tool schema sets
+  // `additionalProperties: false` to reject unrecognised fields from the
+  // LLM caller; without this test that guard had zero assertions and the
+  // whole suite stayed green even with the check disabled.
+  it('rejects unexpected properties when additionalProperties is false', () => {
+    const r = validateInput({
+      type: 'object',
+      properties: { name: { type: 'string' } },
+      additionalProperties: false,
+    }, { name: 'a', extra: 'nope' });
+    expect(r.valid).toBe(false);
+    expect(r.errors[0].path).toBe('$.extra');
+    expect(r.errors[0].message).toMatch(/Unexpected property/);
+  });
+
+  it('allows unexpected properties when additionalProperties is not false', () => {
+    const r = validateInput({
+      type: 'object',
+      properties: { name: { type: 'string' } },
+    }, { name: 'a', extra: 'ok' });
+    expect(r.valid).toBe(true);
+  });
+
+  // Kills a mutation of `input.length < schema.minLength` to `<=` (previously
+  // untested): a string exactly at the minimum length must still be valid.
+  // No existing test exercised this boundary, so an off-by-one that rejects
+  // the exact-minimum case stayed green.
+  it('accepts a string exactly at minLength and rejects one below it', () => {
+    const schema = { type: 'object' as const, properties: { s: { type: 'string' as const, minLength: 3 } } };
+    expect(validateInput(schema, { s: 'abc' }).valid).toBe(true);
+    const r = validateInput(schema, { s: 'ab' });
+    expect(r.valid).toBe(false);
+    expect(r.errors[0].message).toMatch(/shorter than 3/);
+  });
+
+  // Kills a mutation of `input.length > schema.maxLength` to `>=` (previously
+  // untested): a string exactly at the maximum length must still be valid.
+  it('accepts a string exactly at maxLength and rejects one above it', () => {
+    const schema = { type: 'object' as const, properties: { s: { type: 'string' as const, maxLength: 3 } } };
+    expect(validateInput(schema, { s: 'abc' }).valid).toBe(true);
+    const r = validateInput(schema, { s: 'abcd' });
+    expect(r.valid).toBe(false);
+    expect(r.errors[0].message).toMatch(/longer than 3/);
+  });
 });

--- a/packages/sdk/src/context.test.ts
+++ b/packages/sdk/src/context.test.ts
@@ -359,6 +359,56 @@ describe('QueryNamespace helpers', () => {
     expect(path.map((entity) => entity.type)).toEqual(['IfcProject', 'IfcBuilding', 'IfcBuildingStorey', 'IfcWall']);
   });
 
+  // Kills a mutation of contains()'s hard-coded rel type from
+  // 'IfcRelContainedInSpatialStructure' to 'IfcRelAggregates' (or any other
+  // relType/direction swap). Neither `bim.contains()` nor `bim.decomposes()`
+  // had any direct test before this — only their inverse siblings
+  // (containedIn/decomposedBy) were exercised indirectly via path().
+  it('contains() queries the forward containment relationship', () => {
+    const { backend, query } = createMockBackend();
+    const bim = createBimContext({ backend });
+
+    bim.contains({ modelId: 'model-1', expressId: 1 });
+
+    expect(query.related).toHaveBeenCalledWith(
+      { modelId: 'model-1', expressId: 1 },
+      'IfcRelContainedInSpatialStructure',
+      'forward',
+    );
+  });
+
+  // Kills a mutation of decomposes()'s hard-coded rel type from
+  // 'IfcRelAggregates' to 'IfcRelContainedInSpatialStructure' (or a
+  // direction swap) — previously unasserted.
+  it('decomposes() queries the forward aggregation relationship', () => {
+    const { backend, query } = createMockBackend();
+    const bim = createBimContext({ backend });
+
+    bim.decomposes({ modelId: 'model-1', expressId: 1 });
+
+    expect(query.related).toHaveBeenCalledWith(
+      { modelId: 'model-1', expressId: 1 },
+      'IfcRelAggregates',
+      'forward',
+    );
+  });
+
+  // Kills a mutation that swaps relType and direction in BimContext.related()
+  // (the top-level delegate) — previously exercised only via path()/storey(),
+  // which happen to route through containedIn/decomposedBy instead.
+  it('related() forwards relType and direction unmodified to the backend', () => {
+    const { backend, query } = createMockBackend();
+    const bim = createBimContext({ backend });
+
+    bim.related({ modelId: 'model-1', expressId: 1 }, 'IfcRelVoidsElement', 'inverse');
+
+    expect(query.related).toHaveBeenCalledWith(
+      { modelId: 'model-1', expressId: 1 },
+      'IfcRelVoidsElement',
+      'inverse',
+    );
+  });
+
   it('storeys() returns building storeys', () => {
     const { backend, query } = createMockBackend();
     query.entities.mockReturnValue([


### PR DESCRIPTION
Four surviving mutations. **Tests only** — no production code changed.

## 1. The validator's unexpected-property rejection was unasserted

`packages/mcp/src/validate.ts:68`

```diff
-if (schema.additionalProperties === false) {
+if (schema.additionalProperties === true) {
```

1 replacement (asserted), suite still **green**. That flip disables unexpected-property rejection entirely. Every hand-authored MCP tool schema sets `additionalProperties: false`, so this branch runs on real traffic — nothing asserted it in either direction.

## 2. Both string-length guards were tested away from their thresholds

Same file, `:102` and `:105`. `minLength`'s `<` → `<=` and `maxLength`'s `>` → `>=` each survived independently. Now pinned at the exact boundary in both directions: a string of exactly `minLength`/`maxLength` must pass, one character over the line must fail.

## 3. `contains()` and `decomposes()` had zero test callers

`packages/sdk/src/namespaces/query.ts:228-230` (and the `context.ts` delegates)

Neither helper was imported or called by any test file repo-wide — only their inverse siblings (`containedIn`, `decomposedBy`) were reached, indirectly, through `path()`.

```diff
-return this.related(ref, 'IfcRelContainedInSpatialStructure', 'forward');
+return this.related(ref, 'IfcRelAggregates', 'forward');
```

Survived. The new tests assert the exact relation type *and* direction each helper forwards to the backend, so a swap between the two relation kinds now fails.

## Severity

All four are **COVERAGE GAPs**, not live defects. The production code is correct today; nothing failed when it was deliberately broken.

## Verification

- 1 replacement per mutation, count asserted, mutated line re-read before each run.
- **Control mutation** (`QueryBuilder.count()` returning `0`) died as expected, confirming the harness reaches these files.
- All four were re-run after rebasing onto `main` **with the new tests stripped out**, to confirm they still survive against `main`'s current suite rather than being killed by tests landed since. They do — 231/231 mcp and 69/69 sdk stay green under each mutation. With the new tests: 235 and 72, and each mutation dies.
- `tsc --noEmit` clean in both packages, full output read.
- Restores were done by file copy throughout; the working tree carries no stray lockfile or build-output changes.

## One finding deliberately not included

This round also found the MCP scope enforcement (`modelAllowed`, `scopeAllows`) completely untested — gutting `modelAllowed` to `return true`, which disables the per-token model allowlist, passed the entire suite. Before this branch was rebased, `main` landed an equivalent and slightly broader `packages/mcp/src/auth/scope.test.ts` covering the same ground plus the allowlist-vs-admin orthogonality case. So it is already fixed upstream and nothing for it is included here — recording it only because it is worth knowing that path was unguarded until recently.

## Reproduction note

`packages/mcp` currently needs `pnpm install` plus a build of the new `@ifc-lite/diff` package before its suite will collect. Without that, 8 of 23 test files fail to load and the run reports 129 tests instead of 235 — while still printing a green "Tests passed" line. Worth watching for, since it looks like a pass.