### PR TITLE
test(diff,merge): pin the two sort orders that nothing was asserting

### DIFF
--- a/packages/diff/src/component-fingerprint.test.ts
+++ b/packages/diff/src/component-fingerprint.test.ts
@@ -167,4 +167,27 @@ describe('diffModels with component sub-hashes', () => {
     const diff = diffModels([bare], [bare]);
     expect(diff.byKey.get('w')?.changedComponents).toBeUndefined();
   });
+
+  it('sorts changedComponents when multiple keys differ, regardless of object insertion order', () => {
+    // Object key insertion order here is deliberately the REVERSE of alphabetical
+    // ('pset:Z...' before 'pset:A...'), so a build that returns the union in
+    // encounter order (base keys first, then head-only keys) rather than
+    // `.sort()`-ed order would still pass every OTHER test in this file — every
+    // existing changedComponents assertion has exactly one entry, where
+    // encounter order and sorted order are indistinguishable. This pins the
+    // sorted contract with two entries whose natural order differs from sorted.
+    const before: EntityFingerprint<null> = {
+      key: 'w',
+      ifcType: 'IfcWall',
+      dataHash: 'd0',
+      components: { 'pset:Zeta': 'z1', 'pset:Alpha': 'a1' },
+      ref: null,
+    };
+    const after: EntityFingerprint<null> = {
+      ...before,
+      components: { 'pset:Zeta': 'z2', 'pset:Alpha': 'a2' },
+    };
+    const diff = diffModels([before], [after]);
+    expect(diff.byKey.get('w')?.changedComponents).toEqual(['pset:Alpha', 'pset:Zeta']);
+  });
 });

--- a/packages/merge/src/state-diff.test.ts
+++ b/packages/merge/src/state-diff.test.ts
@@ -12,7 +12,21 @@
 import { describe, expect, it } from 'vitest';
 import type { IfcxFile, IfcxNode } from '@ifc-lite/ifcx';
 import { IFCLITE_ATTR } from '@ifc-lite/ifcx';
-import { diffLayerStacks } from './state-diff.js';
+import { diffLayerStacks, diffStackStates } from './state-diff.js';
+import type { EntityState, StackState } from './component-state.js';
+
+/** Minimal alive (non-deleted) entity for path-ordering tests below —
+ *  no components, no children, so only presence/absence drives the diff. */
+function bareEntity(path: string): EntityState {
+  return {
+    path,
+    components: new Map(),
+    children: new Map(),
+    inherits: new Map(),
+    deleted: false,
+    explicitDeleted: false,
+  };
+}
 
 function makeLayer(data: IfcxNode[], id: string): IfcxFile {
   return {
@@ -71,5 +85,28 @@ describe('shared layer-diff JSON contract', () => {
     const dead = makeLayer([{ path: 'wall-b', attributes: { [IFCLITE_ATTR.DELETED]: true } }], 'dead');
     const diff = diffLayerStacks([base, dead], [base, dead]);
     expect(diff).toEqual({ added: [], deleted: [], modified: [] });
+  });
+
+  it('sorts added/deleted paths, not just modified components — insertion order alone would not', () => {
+    // `paths` is built from `[...from.keys(), ...to.keys()]`, so its natural
+    // (unsorted) order is Map insertion order. Insert 'zebra' before 'apple'
+    // on both sides: every OTHER test in this file only ever has a single
+    // added/deleted path, where insertion order and sorted order coincide by
+    // construction, so a build that dropped the `.sort()` on `paths` would
+    // still pass them all. This pins the documented "paths ... sorted"
+    // contract (see the file-level doc comment) with two paths whose
+    // insertion order is deliberately the reverse of alphabetical.
+    const from: StackState = new Map();
+    const to: StackState = new Map([
+      ['zebra', bareEntity('zebra')],
+      ['apple', bareEntity('apple')],
+    ]);
+    expect(diffStackStates(from, to).added).toEqual(['apple', 'zebra']);
+
+    const deletedFrom: StackState = new Map([
+      ['zebra', bareEntity('zebra')],
+      ['apple', bareEntity('apple')],
+    ]);
+    expect(diffStackStates(deletedFrom, new Map()).deleted).toEqual(['apple', 'zebra']);
   });
 });


### PR DESCRIPTION
Two surviving mutations. **Tests only** — no production code changed.

Both are the same vacuity shape: a fixture small enough that insertion order and sorted order coincide, making the sort unobservable.

## 1. `changedComponentKeys` — `packages/diff/src/diff.ts:65`

```diff
-return changed.sort();
+return changed;
```

1 replacement (asserted), suite still **green**. No existing case had more than one changed component, so the sort could never be observed.

## 2. `diffStackStates` — `packages/merge/src/state-diff.ts:41`

```diff
-const paths = [...new Set<string>([...from.keys(), ...to.keys()])].sort();
+const paths = [...new Set<string>([...from.keys(), ...to.keys()])];
```

1 replacement (asserted), suite still **green**. Every existing case had at most one added and one deleted path.

Worth noting: the file's own doc comment promises "paths and component keys sorted". The code delivers it and only the *inner* component ordering was pinned — the `paths` ordering the comment also promises was not.

Both new tests insert their keys in reverse-alphabetical order (`zebra` before `apple`, `pset:Zeta` before `pset:Alpha`), so the assertion fails on ordering rather than on membership.

## Severity

Both are **COVERAGE GAPs**, not live defects. The production code sorts correctly today; nothing failed when the sort was removed.

## Verification

- 1 replacement per mutation, count asserted, mutated line re-read before each run.
- **Control mutation** (flipping `scope === 'data' || scope === 'both'` to `&&` in `diff.ts`) failed 7 tests across 2 files, confirming the harness reaches these files.
- Both were re-run after rebasing onto `main` **with the new tests stripped out**, to confirm they still survive against `main`'s current suite rather than being killed by tests landed since. They do.
- Suites: diff **286 → 287** (14 files), merge **71 → 72** plus 4 skipped (8 files), all green. `tsc --noEmit` clean in both packages.
- Restores were done by file copy throughout; no lockfile or build-output drift.

## One finding deliberately not included

This round also flagged `stableHash` as pinned only for *shape* — "deterministic" and "distinguishes inputs" hold for any hash, including a deterministic-but-wrong one. `main` has since moved that function to FNV-1a-**64** and pinned the canonical 64-bit vectors, which covers it properly, so nothing for it is included here.