### PR TITLE
fix(query): correct three EntityNode helpers that traversed relationships backwards

### DIFF
--- a/.changeset/entity-node-traversal-directions.md
+++ b/.changeset/entity-node-traversal-directions.md
@@ -1,0 +1,14 @@
+---
+"@ifc-lite/query": patch
+---
+
+Fix three `EntityNode` relationship helpers that traversed the graph in the wrong direction.
+
+The parser builds every edge as `addEdge(relatingObject, relatedObject)` (`columnar-parser.ts:476`), so `forward` always means relating → related. Three helpers were oriented against that:
+
+- `filledBy()` used `inverse`. `IfcRelFillsElement` is `(RelatingOpeningElement, RelatedBuildingElement)`, so the opening is the source and the filler the target — reaching the filler from the opening is a forward traversal. As written the method returned an empty array for every opening, which is indistinguishable from "this opening has no filler".
+- `definingType()` used `forward` and `instances()` used `inverse`. `IfcRelDefinesByType` has the type as its relating object, so the type is the source and each occurrence the target; both helpers were the wrong way round. The element → type lookups in `on-demand-extractors.ts` already used `inverse` for this, so the two disagreed.
+
+`filledBy()` is the one with an observable consequence today: `@ifc-lite/clash` calls `opening.filledBy()` to exclude a host element from clashing with the door or window filling its own opening (`adapters/step.ts:172`). Because the call always returned nothing, that exclusion never fired and every door and window could report a false-positive clash against the opening it legitimately fills. `definingType()` and `instances()` have no in-repo callers, so their fix is latent — but they are public API.
+
+The gap survived because the unit-test fixture encoded the reverse orientation for `IfcRelDefinesByType`, so the mock and the reversed code agreed with each other. The fixture is corrected to match the parser, and `IfcRelFillsElement` — previously absent from it entirely — is now covered.

--- a/packages/lists/src/engine.test.ts
+++ b/packages/lists/src/engine.test.ts
@@ -606,6 +606,33 @@ describe('executeList', () => {
     expect(result.rows[0].values[0]).toBe('Wall-02');
     expect(result.rows[1].values[0]).toBe('Wall-01');
   });
+
+  // Mutation: compareCellValues() special-cases null so it always sorts
+  // first regardless of direction (`a === null` -> -1). Swapping the two
+  // returned constants (null sorting last instead) left the whole suite
+  // green, because the only existing sortBy tests compare two non-null
+  // values. Wall-02 has no PredefinedType (resolves to null); pin that it
+  // sorts ahead of Wall-01's 'SOLIDWALL' under an ascending sort.
+  it('sorts null values first, ahead of non-null values', () => {
+    const provider = createMockProvider();
+    const def: ListDefinition = {
+      id: 'test-null-sort',
+      name: 'Test',
+      createdAt: 0,
+      updatedAt: 0,
+      entityTypes: [IfcTypeEnum.IfcWall],
+      conditions: [],
+      columns: [
+        { id: 'name', source: 'attribute', propertyName: 'Name' },
+        { id: 'predef', source: 'attribute', propertyName: 'PredefinedType' },
+      ],
+      sortBy: { columnId: 'predef', direction: 'asc' },
+    };
+
+    const result = executeList(def, provider);
+    expect(result.rows[0].values[0]).toBe('Wall-02'); // null PredefinedType
+    expect(result.rows[1].values[0]).toBe('Wall-01'); // 'SOLIDWALL'
+  });
 });
 
 describe('grouping & summary', () => {
@@ -1045,6 +1072,27 @@ describe('discoverColumns', () => {
     expect(result.properties.has('Pset_WallCommon')).toBe(true);
     expect(result.quantities.has('Qto_WallBaseQuantities')).toBe(true);
     expect(result.quantities.has('Qto_SlabBaseQuantities')).toBe(true);
+  });
+
+  // Mutation: discovery.ts sorts property/quantity names before returning
+  // them ("for stable UI"), but every prior assertion here used toContain(),
+  // which is order-insensitive. Dropping the .sort() call in discoverColumns
+  // left the whole suite green. Pin the exact alphabetical order using
+  // fixture data whose insertion order differs from sorted order (entity 1's
+  // Pset_WallCommon is inserted IsExternal/FireRating/LoadBearing/..., and
+  // its Qto_WallBaseQuantities is inserted Length/Height/Width/NetVolume).
+  it('sorts property and quantity names alphabetically, independent of insertion order', () => {
+    const provider = createMockProvider();
+    const result = discoverColumns(provider, [IfcTypeEnum.IfcWall]);
+
+    expect(result.properties.get('Pset_WallCommon')).toEqual([
+      'FireRating',
+      'IsExternal',
+      'LoadBearing',
+      'ThermalTransmittance',
+    ]);
+
+    expect(result.quantities.get('Qto_WallBaseQuantities')).toEqual(['Height', 'Length', 'NetVolume', 'Width']);
   });
 });
 

--- a/packages/query/src/entity-node.ts
+++ b/packages/query/src/entity-node.ts
@@ -154,13 +154,23 @@ export class EntityNode {
   }
   
   // Types
+  /**
+   * The type object defining this occurrence.
+   *
+   * `IfcRelDefinesByType` has the type as its relating object, and the parser
+   * stores edges relating -> related, so the type is the source and each
+   * occurrence the target. Reaching the type from an occurrence is therefore
+   * an inverse traversal — matching the element -> type lookups in
+   * `on-demand-extractors.ts`.
+   */
   definingType(): EntityNode | null {
-    const nodes = this.getRelated(RelationshipType.DefinesByType, 'forward');
+    const nodes = this.getRelated(RelationshipType.DefinesByType, 'inverse');
     return nodes[0] ?? null;
   }
   
+  /** The occurrences defined by this type — forward, from the type source. */
   instances(): EntityNode[] {
-    return this.getRelated(RelationshipType.DefinesByType, 'inverse');
+    return this.getRelated(RelationshipType.DefinesByType, 'forward');
   }
   
   // Openings
@@ -168,8 +178,16 @@ export class EntityNode {
     return this.getRelated(RelationshipType.VoidsElement, 'forward');
   }
   
+  /**
+   * The elements filling this opening (doors, windows).
+   *
+   * `IfcRelFillsElement` is (RelatingOpeningElement, RelatedBuildingElement),
+   * so the opening is the relating object and the filler the related one —
+   * reaching the filler from the opening is a forward traversal, the same
+   * orientation `voids()` uses to reach the opening from its host.
+   */
   filledBy(): EntityNode[] {
-    return this.getRelated(RelationshipType.FillsElement, 'inverse');
+    return this.getRelated(RelationshipType.FillsElement, 'forward');
   }
 
   // Multi-hop traversal

--- a/packages/query/test/entity-node.test.ts
+++ b/packages/query/test/entity-node.test.ts
@@ -50,8 +50,15 @@ function buildSpatialStore() {
       { source: 4, target: 11, type: RelationshipType.ContainsElements, relId: 201 },
       // Wall voids opening
       { source: 10, target: 20, type: RelationshipType.VoidsElement, relId: 300 },
-      // Wall defined by type (forward = instance -> type; inverse = type -> instances)
-      { source: 10, target: 30, type: RelationshipType.DefinesByType, relId: 400 },
+      // Opening filled by door. IfcRelFillsElement is
+      // (RelatingOpeningElement, RelatedBuildingElement), so the opening is
+      // the source and the filler is the target — the same relating -> related
+      // orientation VoidsElement uses above.
+      { source: 20, target: 11, type: RelationshipType.FillsElement, relId: 301 },
+      // Type defines wall. The parser calls addEdge(relatingObject, related),
+      // and for IfcRelDefinesByType the relating object is the TYPE, so the
+      // type is the source and the instance the target.
+      { source: 30, target: 10, type: RelationshipType.DefinesByType, relId: 400 },
     ],
   });
 }
@@ -206,6 +213,19 @@ describe('EntityNode', () => {
       const openings = wall.voids();
       expect(openings).toHaveLength(1);
       expect(openings[0].expressId).toBe(20);
+    });
+
+    it('filledBy() should return the element filling the opening', () => {
+      // `filledBy()` had zero callers in any test file. IfcRelFillsElement
+      // stores the opening as the relating object and the filler as the
+      // related one, so reaching the filler from the opening is a forward
+      // traversal — the same direction `voids()` uses to reach the opening
+      // from its host. Traversing inverse from the opening finds nothing and
+      // silently returns [], which is indistinguishable from "no filler".
+      const store = buildSpatialStore();
+      const opening = new EntityNode(store, 20);
+      const fillers = opening.filledBy();
+      expect(fillers.map((f) => f.expressId)).toEqual([11]);
     });
 
     it('voids() should return empty for element with no openings', () => {


### PR DESCRIPTION
Three `EntityNode` helpers walk the relationship graph in the wrong direction. One of them silently disables a clash-detection exclusion today.

## The rule they break

The parser builds every edge as `addEdge(rel.relatingObject, targetId, ...)` (`packages/parser/src/columnar-parser.ts:476`). So `forward` always means **relating → related**, uniformly, for every relationship type.

## `filledBy()` — returns `[]` for every opening

`IfcRelFillsElement` is `(RelatingOpeningElement, RelatedBuildingElement)`: the opening is the source, the filler is the target. Reaching the filler from the opening is therefore a **forward** traversal — the same orientation `voids()` already uses to reach the opening from its host.

It used `inverse`, so it found nothing. Not "sometimes wrong" — an empty array for every opening, every time, which is indistinguishable from "this opening has no filler".

This one has an observable consequence today. `@ifc-lite/clash` calls it to exclude a host element from clashing with the door or window filling its own opening:

```ts
// packages/clash/src/adapters/step.ts:172
for (const filler of opening.filledBy()) {
  ...pairs.push([ek, qualifiedKey(fillerElement.model, fillerElement.key)]);
}
```

Because the loop body never ran, that exclusion never fired — so every door and window could report a false-positive clash against the opening it legitimately fills.

## `definingType()` and `instances()` — both reversed

`IfcRelDefinesByType` has the **type** as its relating object, so the type is the source and each occurrence the target. `definingType()` (occurrence → type) needs `inverse`; `instances()` (type → occurrences) needs `forward`. Both were the other way round.

`on-demand-extractors.ts` already gets this right — it uses `inverse` for element → type in three places, with the comment `// Find type entity via DefinesByType relationship (inverse: element → type)`. So the two modules disagreed about the same traversal.

These two have no in-repo callers, so the fix is latent — but they are public API surface.

## Why the tests did not catch it

`IfcRelFillsElement` was absent from the unit-test fixture entirely, and `filledBy()` had zero callers in any test file repo-wide.

`IfcRelDefinesByType` was worse than absent: the fixture encoded the **reverse** orientation —

```ts
// forward = instance -> type; inverse = type -> instances
{ source: 10 /* wall */, target: 30 /* type */, type: RelationshipType.DefinesByType }
```

— so the mock and the reversed production code agreed with each other and the tests passed. Correcting the fixture to match the parser (`source: 30, target: 10`) immediately fails both helpers. That is the actual root cause here: a fixture that documents the wrong invariant makes the bug untestable.

## Verification

- RED first: with `IfcRelFillsElement` added to the fixture, the new test fails `expected [] to deeply equal [ 11 ]` against unmodified production code.
- With the corrected fixture, `definingType()` and `instances()` both fail before the fix.
- Each of the three fixes was mutation-verified by reverting it to the old direction: 1 replacement each (count asserted), each kills exactly one test, each restored.
- No regressions, with **every workspace package built first** so no test file silently fails to load: query 154/154 (11 files), clash 176/176 (19), sdk 69/69 (6), lists 121/121 (6), mcp 231/231 (23). Before the full build, clash reported a green "153 passed" while 2 of its 19 files had failed to load — worth knowing, because that reads exactly like a pass.
- `tsc --noEmit` clean.

## Also included

Two unrelated coverage gaps found in the same sweep of `packages/lists`, both COVERAGE GAPs (code correct, tests did not pin it):

- `discoverColumns` — removing the `.sort()` on property names survived; every assertion used order-insensitive `toContain`.
- `compareCellValues` — swapping the null-first ordering to null-last survived; no existing sort test had a null cell.

A control mutation (`return a - b` → `b - a` in the numeric compare branch) died immediately, confirming the harness reaches that file.