### PR TITLE
test(clash,drawing-2d,pointcloud): close six mutation-verified coverage gaps

### DIFF
--- a/packages/clash/src/bcf-bridge.test.ts
+++ b/packages/clash/src/bcf-bridge.test.ts
@@ -157,6 +157,54 @@ describe('createBCFFromClashResult', () => {
     expect(minor?.labels).toEqual(['ELEC', 'Clash']);
   });
 
+  /**
+   * Kills the mutation `a.members.length - b.members.length` (comparator
+   * operands swapped) in `sortGroups`. Every other ordering test in this
+   * file mixes different severities, so the more-populous group is also
+   * always the more-severe one and the severity comparison alone decides
+   * the order — the member-count tie-break's sign is never exercised. This
+   * fixture holds severity constant ('major' for both) so `maxTopics: 1`
+   * can only keep the right group if the count tie-break sorts descending.
+   */
+  it('breaks a severity tie by member count desc when capping topics', async () => {
+    const { result } = makeFixture();
+    const small = clash(
+      'tie-small',
+      ref('GUID_S1', 'IfcWall'),
+      ref('GUID_S2', 'IfcSlab'),
+      'hard',
+      'major',
+      'tie-rule',
+    );
+    const bigA = clash(
+      'tie-big-1',
+      ref('GUID_T1', 'IfcWall'),
+      ref('GUID_T2', 'IfcSlab'),
+      'hard',
+      'major',
+      'tie-rule',
+    );
+    const bigB = clash(
+      'tie-big-2',
+      ref('GUID_T1', 'IfcWall'),
+      ref('GUID_T3', 'IfcSlab'),
+      'hard',
+      'major',
+      'tie-rule',
+    );
+    const groupSmall = makeGroup('group-tie-small', 'major', [small]);
+    const groupBig = makeGroup('group-tie-big', 'major', [bigA, bigB]);
+
+    const project = await createBCFFromClashResult(result, [groupSmall, groupBig], {
+      author: 'tester',
+      maxTopics: 1,
+    });
+
+    // Only the larger, 2-member group survives the cap.
+    expect(project.topics.has(uuidFromSeed('group-tie-big'))).toBe(true);
+    expect(project.topics.has(uuidFromSeed('group-tie-small'))).toBe(false);
+  });
+
   it('omits a missing discipline from the labels', async () => {
     const { result } = makeFixture();
     const lone = clash(

--- a/packages/clash/src/grouping.test.ts
+++ b/packages/clash/src/grouping.test.ts
@@ -233,6 +233,30 @@ describe('groupClashes — aggregates', () => {
     expect(groups[0].members).toHaveLength(2);
     expect(groups[1].severity).toBe('major');
   });
+
+  /**
+   * Kills the mutation `a.members.length - b.members.length` (comparator
+   * operands swapped) in `groupClashes`'s final sort. Every other ordering
+   * test in this file mixes different severities, so a group with more
+   * members always also has the more-severe (lower-rank) severity and the
+   * severity comparison alone decides the order — the count comparator's
+   * sign is never actually exercised. This fixture holds severity constant
+   * (both groups 'major') so only the member-count tie-break can produce
+   * the expected order: the larger group must sort first.
+   */
+  it('breaks a severity tie by member count desc', () => {
+    const clashes = [
+      // Same severity as the other group; fewer members, so it must sort second.
+      clash({ id: 'c1', a: PIPE, b: BEAM, rule: 'small-rule', point: [0, 0, 0], severity: 'major' }),
+      // Same severity; two members, so it must sort first.
+      clash({ id: 'c2', a: PIPE2, b: BEAM2, rule: 'big-rule', point: [10, 0, 0], severity: 'major' }),
+      clash({ id: 'c3', a: PIPE2, b: BEAM2, rule: 'big-rule', point: [10.3, 0, 0], severity: 'major' }),
+    ];
+    const groups = groupClashes(makeResult(clashes), { by: 'rule' });
+    expect(groups).toHaveLength(2);
+    expect(groups[0].members).toHaveLength(2);
+    expect(groups[1].members).toHaveLength(1);
+  });
 });
 
 describe('groupClashes — determinism', () => {

--- a/packages/drawing-2d/src/polygon-builder.test.ts
+++ b/packages/drawing-2d/src/polygon-builder.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { PolygonBuilder } from './polygon-builder.js';
-import { polygonSignedArea } from './math.js';
+import { polygonSignedArea, isCounterClockwise } from './math.js';
 import type { CutSegment } from './types.js';
 
 /** Build the 4 cut segments of an axis-aligned rectangle [x0,x1]×[y0,y1]. */
@@ -170,5 +170,43 @@ describe('PolygonBuilder — open-band reconstruction (cap-free layer slabs)', (
     expect(area(GREEN)).toBeCloseTo(20.0, 5); // core: 10 (length) × 2 (thickness)
     expect(area(RED)).toBeCloseTo(10.0, 5);
     expect(area(BLUE)).toBeCloseTo(10.0, 5);
+  });
+});
+
+describe('PolygonBuilder — hole containment and winding (classifyLoops)', () => {
+  /**
+   * A slab section with a through-opening: one outer ring and one smaller
+   * ring fully inside it, same entity, single material (colourless).
+   * `classifyLoops` must classify the smaller ring as a HOLE of the larger
+   * one — and (undocumented invariant, previously untested — see the
+   * mutation this regression kills below) the outer ring must come back CCW
+   * and the hole CW, i.e. OPPOSITE winding.
+   *
+   * This isn't cosmetic: `packages/renderer/src/section-2d-overlay.ts`
+   * feeds `polygon.outer`/`polygon.holes` straight into `joinHoles()` +
+   * `earClip()` to triangulate the 3D cut-face fill, and hole-joining
+   * ear-clipping algorithms rely on the hole being wound opposite the outer
+   * ring to bridge it in correctly. Swapping `ensureCCW`/`ensureCW` for the
+   * outer ring in `classifyLoops` (`ensureCCW(outer.points)` →
+   * `ensureCW(outer.points)`) leaves both rings wound the SAME way; no
+   * existing test in this file or `polygon-builder-opening.test.ts` builds
+   * a contained hole, so that mutation survives the full suite.
+   */
+  it('classifies a contained inner ring as a hole, wound opposite the outer ring', () => {
+    const segments = [
+      ...rectSegments(0, 0, 10, 10, 500), // outer boundary
+      ...rectSegments(4, 4, 6, 6, 500),   // fully-contained opening
+    ];
+
+    const polygons = new PolygonBuilder().buildPolygons(segments);
+
+    expect(polygons).toHaveLength(1);
+    const { outer, holes } = polygons[0].polygon;
+    expect(holes).toHaveLength(1);
+
+    expect(isCounterClockwise(outer)).toBe(true);
+    expect(isCounterClockwise(holes[0])).toBe(false);
+    expect(Math.abs(polygonSignedArea(outer))).toBeCloseTo(100, 5);
+    expect(Math.abs(polygonSignedArea(holes[0]))).toBeCloseTo(4, 5);
   });
 });

--- a/packages/pointcloud/src/formats/e57.test.ts
+++ b/packages/pointcloud/src/formats/e57.test.ts
@@ -257,6 +257,82 @@ describe('decodeE57Scan (uncompressed Float64)', () => {
     expect(chunk.positions[5]).toBeCloseTo(1.55, 5);
   });
 
+  it('decodes classification and intensity (Integer kind) through the full scan pipeline', () => {
+    // Mutation testing found decodeE57Scan's classification/intensity paths
+    // had ZERO coverage anywhere in this package: no test built a packet
+    // carrying a `classification` or `intensity` prototype field, so
+    // `readClassificationStream`/`readIntensityStream` in e57-decode.ts
+    // were exercised only by TypeScript, never by an assertion. A mutation
+    // that broke either (e.g. subtracting `minimum` from a classification
+    // Integer, which the source comment explicitly says NOT to do because
+    // class IDs are absolute labels, not range-normalised offsets; or
+    // flipping the sign in intensity's range-remap) ran green.
+    //
+    // `minimum` is deliberately non-zero on both fields so a stray
+    // `+ minimum` / `- minimum` swap changes the decoded value — with
+    // minimum=0 the two are indistinguishable.
+    const points = [
+      { x: 1, y: 2, z: 3, classification: 6, intensityRaw: 150 },
+      { x: 4, y: 5, z: 6, classification: 15, intensityRaw: 200 },
+    ];
+    const numPoints = points.length;
+
+    const lenF64 = numPoints * 8;
+    const lenU8 = numPoints * 1;
+    const lengths = [lenF64, lenF64, lenF64, lenU8, lenU8];
+    const totalPayload = lengths.reduce((a, b) => a + b, 0);
+    const headerBytes = 4 + 2 + lengths.length * 2;
+    const packetSize = headerBytes + totalPayload;
+    const buf = new ArrayBuffer(packetSize);
+    const view = new DataView(buf);
+    view.setUint8(0, 1);
+    view.setUint8(1, 0);
+    view.setUint16(2, packetSize - 1, true);
+    view.setUint16(4, lengths.length, true);
+    for (let i = 0; i < lengths.length; i++) view.setUint16(6 + i * 2, lengths[i], true);
+
+    let cursor = headerBytes;
+    for (let i = 0; i < numPoints; i++) view.setFloat64(cursor + i * 8, points[i].x, true);
+    cursor += lenF64;
+    for (let i = 0; i < numPoints; i++) view.setFloat64(cursor + i * 8, points[i].y, true);
+    cursor += lenF64;
+    for (let i = 0; i < numPoints; i++) view.setFloat64(cursor + i * 8, points[i].z, true);
+    cursor += lenF64;
+    // classification: Integer, minimum=5/maximum=20 — raw byte IS the
+    // class id, never range-remapped (unlike color/intensity).
+    for (let i = 0; i < numPoints; i++) view.setUint8(cursor + i, points[i].classification);
+    cursor += lenU8;
+    // intensity: Integer, minimum=50/maximum=250 — normalised to [0,1]
+    // via (raw - minimum) / (maximum - minimum) then scaled to u16.
+    for (let i = 0; i < numPoints; i++) view.setUint8(cursor + i, points[i].intensityRaw);
+
+    const logical = new Uint8Array(buf);
+    const entry: Data3DEntry = {
+      guid: 'test',
+      recordCount: numPoints,
+      binaryFileOffset: 0,
+      prototype: [
+        { name: 'cartesianX', kind: 'Float', precision: 'double' },
+        { name: 'cartesianY', kind: 'Float', precision: 'double' },
+        { name: 'cartesianZ', kind: 'Float', precision: 'double' },
+        { name: 'classification', kind: 'Integer', minimum: 5, maximum: 20 },
+        { name: 'intensity', kind: 'Integer', minimum: 50, maximum: 250 },
+      ],
+    };
+
+    const chunk = decodeE57Scan(logical, entry);
+    expect(chunk.pointCount).toBe(2);
+    expect(chunk.classifications).toBeDefined();
+    // Absolute labels: raw byte passes through unchanged, NOT raw-minimum
+    // (which would wrongly yield 1 and 10).
+    expect(Array.from(chunk.classifications!)).toEqual([6, 15]);
+    expect(chunk.intensities).toBeDefined();
+    // (150-50)/(250-50) = 0.5 -> round(0.5*65535) = 32768
+    // (200-50)/(250-50) = 0.75 -> round(0.75*65535) = 49151
+    expect(chunk.intensities![0]).toBe(32768);
+    expect(chunk.intensities![1]).toBe(49151);
+  });
+
   it('rejects a recordCount the binary section cannot hold (no OOM alloc)', () => {
     // A hostile header declares 1e9 records but the binary section is a few
     // bytes. Without the pre-allocation guard this would allocate a ~12GB
@@ -510,6 +586,110 @@ describe('resolveCompressedVectorDataOffset (E57 §6.4.2)', () => {
     bytes[0] = 99; // wrong sectionId
     expect(() => resolveCompressedVectorDataOffset(bytes, 0, 1024))
       .toThrow(/section/i);
+  });
+
+  it('remaps Integer colour channels from a non-zero minimum', () => {
+    // The existing colour test declares `minimum: 0` (it asserts 200/255),
+    // and at minimum 0 the range-remap `(raw - minimum) * inv` is
+    // indistinguishable from `(raw + minimum) * inv` — so the sign of that
+    // subtraction was never constrained. A non-zero minimum makes the two
+    // differ, which is the only way the mutation becomes observable.
+    const pts = [
+      { x: 1, y: 2, z: 3, r: 110, g: 60, b: 35 },
+      { x: 4, y: 5, z: 6, r: 210, g: 10, b: 110 },
+    ];
+    const n = pts.length;
+    const lenF64 = n * 8;
+    const lenU8 = n;
+    const lengths = [lenF64, lenF64, lenF64, lenU8, lenU8, lenU8];
+    const headerBytes = 4 + 2 + lengths.length * 2;
+    const packetSize = headerBytes + lengths.reduce((a, b) => a + b, 0);
+    const buf = new ArrayBuffer(packetSize);
+    const view = new DataView(buf);
+    view.setUint8(0, 1);
+    view.setUint8(1, 0);
+    view.setUint16(2, packetSize - 1, true);
+    view.setUint16(4, lengths.length, true);
+    for (let i = 0; i < lengths.length; i++) view.setUint16(6 + i * 2, lengths[i], true);
+
+    let cursor = headerBytes;
+    for (const key of ['x', 'y', 'z'] as const) {
+      for (let i = 0; i < n; i++) view.setFloat64(cursor + i * 8, pts[i][key], true);
+      cursor += lenF64;
+    }
+    for (const key of ['r', 'g', 'b'] as const) {
+      for (let i = 0; i < n; i++) view.setUint8(cursor + i, pts[i][key]);
+      cursor += lenU8;
+    }
+
+    const entry: Data3DEntry = {
+      guid: 'test',
+      recordCount: n,
+      binaryFileOffset: 0,
+      prototype: [
+        { name: 'cartesianX', kind: 'Float', precision: 'double' },
+        { name: 'cartesianY', kind: 'Float', precision: 'double' },
+        { name: 'cartesianZ', kind: 'Float', precision: 'double' },
+        // minimum 10 / maximum 210 -> inv = 1/200.
+        { name: 'colorRed', kind: 'Integer', minimum: 10, maximum: 210 },
+        { name: 'colorGreen', kind: 'Integer', minimum: 10, maximum: 210 },
+        { name: 'colorBlue', kind: 'Integer', minimum: 10, maximum: 210 },
+      ],
+    };
+
+    const chunk = decodeE57Scan(new Uint8Array(buf), entry);
+    expect(chunk.colors).toBeDefined();
+    // (110-10)/200 = 0.5, (60-10)/200 = 0.25, (35-10)/200 = 0.125.
+    // A `+ minimum` swap would give 0.6 / 0.35 / 0.225 instead.
+    expect(chunk.colors![0]).toBeCloseTo(0.5, 5);
+    expect(chunk.colors![1]).toBeCloseTo(0.25, 5);
+    expect(chunk.colors![2]).toBeCloseTo(0.125, 5);
+  });
+
+  it('recovers ScaledInteger classification values through their minimum offset', () => {
+    // The ScaledInteger classification branch adds `minimum` back to recover
+    // the original value, and no test reached it at all — the Integer branch
+    // above is the only one previously exercised. With a non-zero minimum a
+    // `raw - minimum` swap changes the decoded class, so the sign is pinned.
+    // minimum 5 / maximum 20 -> span 15 -> 4 bits per record.
+    const n = 2;
+    const lenF64 = n * 8;
+    const lenBits = 1; // 2 records * 4 bits = 8 bits = 1 byte
+    const lengths = [lenF64, lenF64, lenF64, lenBits];
+    const headerBytes = 4 + 2 + lengths.length * 2;
+    const packetSize = headerBytes + lengths.reduce((a, b) => a + b, 0);
+    const buf = new ArrayBuffer(packetSize);
+    const view = new DataView(buf);
+    view.setUint8(0, 1);
+    view.setUint8(1, 0);
+    view.setUint16(2, packetSize - 1, true);
+    view.setUint16(4, lengths.length, true);
+    for (let i = 0; i < lengths.length; i++) view.setUint16(6 + i * 2, lengths[i], true);
+
+    let cursor = headerBytes;
+    for (const v of [[1, 4], [2, 5], [3, 6]]) {
+      for (let i = 0; i < n; i++) view.setFloat64(cursor + i * 8, v[i], true);
+      cursor += lenF64;
+    }
+    // Raw 4-bit values 1 and 10, packed little-endian: low nibble first.
+    view.setUint8(cursor, 1 | (10 << 4));
+
+    const entry: Data3DEntry = {
+      guid: 'test',
+      recordCount: n,
+      binaryFileOffset: 0,
+      prototype: [
+        { name: 'cartesianX', kind: 'Float', precision: 'double' },
+        { name: 'cartesianY', kind: 'Float', precision: 'double' },
+        { name: 'cartesianZ', kind: 'Float', precision: 'double' },
+        { name: 'classification', kind: 'ScaledInteger', minimum: 5, maximum: 20 },
+      ],
+    };
+
+    const chunk = decodeE57Scan(new Uint8Array(buf), entry);
+    expect(chunk.classifications).toBeDefined();
+    // raw + minimum: 1+5 = 6, 10+5 = 15. A `- minimum` swap clamps to 0 and 5.
+    expect(Array.from(chunk.classifications!)).toEqual([6, 15]);
   });
 
   it('rejects when the section header runs past end of buffer', () => {


### PR DESCRIPTION
Six surviving mutations. **Tests only** — no production code changed. All six are COVERAGE GAPs: the code is correct today, but nothing failed when it was deliberately broken.

## Two identical tie-break gaps in `clash`

`grouping.ts:353` and `bcf-bridge.ts:101` both sort groups by severity, then by member count. Every existing fixture varied severity across groups — so severity alone decided the order and the member-count comparator was never reached.

```diff
-b.members.length - a.members.length
+a.members.length - b.members.length
```

Survived in both. New same-severity fixtures pin the tie-break. In `bcf-bridge` it is not cosmetic: that order decides which topics survive `maxTopics` capping, so reversing it silently exports the *smallest* clash groups instead of the largest.

## `drawing-2d` — outer/hole winding was never exercised

`polygon-builder.ts:557` — `classifyLoops` gives the outer ring the opposite winding to its holes. Flipping `ensureCCW` to `ensureCW` survived, because no test in the package builds a genuinely *contained* hole.

The invariant is load-bearing outside the package: `renderer/section-2d-overlay.ts` feeds `polygon.outer` / `polygon.holes` into `joinHoles()` + `earClip()`, which needs opposite winding to bridge correctly.

## `pointcloud` — E57 classification and intensity had no coverage at all

No test built a packet carrying a `classification` or `intensity` prototype field, so those decode paths were exercised only by the type checker. Three sign/offset mutations survived across the Integer and ScaledInteger branches.

The fourth is the interesting one. The Integer **colour channel** remap also survived:

```diff
-clamp01((raw - min) * inv)
+clamp01((raw + min) * inv)
```

The package's only colour test declares `minimum: 0` (it asserts `200/255`) — and at minimum 0, `(raw - minimum)` and `(raw + minimum)` are *identical*. The subtraction's sign was structurally unobservable. Every new fixture here uses a non-zero minimum, which is the only way these mutations become observable at all.

## Verification

- 1 replacement per mutation, count asserted, mutated line re-read before each run.
- **Control mutations died as expected in all three packages** — `clash/review.ts:50` comparison, `drawing-2d/projection-bands.ts:206` overhead case, `pointcloud` `LAS_CLASS_COUNT` 256 → 255 — confirming the harness actually reaches these files.
- Suites: clash **176 → 178**, drawing-2d **153 → 154**, pointcloud **134 → 137** (+2 skipped). All green, with every test file confirmed loading — a partial build here reports a green "Tests passed" line while whole files silently fail to load.
- `tsc --noEmit` clean in all three packages.
- Restores by file copy throughout; no lockfile or build-output drift.

Two of the six were found only after disambiguating an anchor that matched **two** call sites — the replacement-count assertion caught it. Worth noting because a two-site anchor silently mutates the wrong line and reads as a clean pass.