### PR TITLE
fix(viewer): stop "Color by this column" silently falling back to IFC type

### DIFF
--- a/apps/viewer/src/lib/ifc-class-reassign.test.ts
+++ b/apps/viewer/src/lib/ifc-class-reassign.test.ts
@@ -1,0 +1,121 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import {
+  resolveReassignSchema,
+  getReassignTargets,
+  isKnownReassignTarget,
+  isReassignableElement,
+  getPredefinedTypes,
+  COMMON_REASSIGN_TARGETS,
+} from './ifc-class-reassign.js';
+
+describe('resolveReassignSchema', () => {
+  it('maps a 2X3 spelling (any case) to IFC2X3', () => {
+    assert.strictEqual(resolveReassignSchema('IFC2X3'), 'IFC2X3');
+    assert.strictEqual(resolveReassignSchema('ifc2x3'), 'IFC2X3');
+  });
+
+  it('maps a 4X3 spelling to IFC4X3', () => {
+    assert.strictEqual(resolveReassignSchema('IFC4X3_ADD2'), 'IFC4X3');
+  });
+
+  it('defaults to IFC4 for a plain IFC4 spelling, null, or unknown input', () => {
+    assert.strictEqual(resolveReassignSchema('IFC4'), 'IFC4');
+    assert.strictEqual(resolveReassignSchema(null), 'IFC4');
+    assert.strictEqual(resolveReassignSchema(undefined), 'IFC4');
+    assert.strictEqual(resolveReassignSchema('nonsense'), 'IFC4');
+  });
+});
+
+describe('getReassignTargets', () => {
+  it('includes concrete IfcElement subtypes and excludes abstract supertypes', () => {
+    const targets = getReassignTargets('IFC4');
+    assert.ok(targets.includes('IfcWall'));
+    assert.ok(targets.includes('IfcColumn'));
+    // IfcBuildingElement and IfcElement are abstract — never offered directly.
+    assert.ok(!targets.includes('IfcBuildingElement'));
+    assert.ok(!targets.includes('IfcElement'));
+  });
+
+  it('excludes non-IfcElement products such as IfcSpace', () => {
+    const targets = getReassignTargets('IFC4');
+    assert.ok(!targets.includes('IfcSpace'));
+  });
+
+  it('excludes type entities such as IfcWallType (they are not IfcElement subtypes)', () => {
+    const targets = getReassignTargets('IFC4');
+    assert.ok(!targets.includes('IfcWallType'));
+  });
+
+  it('sorts the result A→Z', () => {
+    const targets = getReassignTargets('IFC4');
+    const sorted = [...targets].sort((a, b) => a.localeCompare(b));
+    assert.deepStrictEqual(targets, sorted);
+  });
+
+  it('is stable across repeated calls (exercises the cache path)', () => {
+    const first = getReassignTargets('IFC4');
+    const second = getReassignTargets('IFC4');
+    assert.deepStrictEqual(first, second);
+  });
+});
+
+describe('isKnownReassignTarget', () => {
+  it('is true for a concrete class regardless of casing/whitespace', () => {
+    assert.strictEqual(isKnownReassignTarget('IFC4', '  ifcwall  '), true);
+  });
+
+  it('is false for an abstract class', () => {
+    assert.strictEqual(isKnownReassignTarget('IFC4', 'IfcBuildingElement'), false);
+  });
+
+  it('is false for an unknown class name', () => {
+    assert.strictEqual(isKnownReassignTarget('IFC4', 'IfcTotallyMadeUp'), false);
+  });
+});
+
+describe('isReassignableElement', () => {
+  it('is true for a concrete IfcElement subtype', () => {
+    assert.strictEqual(isReassignableElement('IFC4', 'IfcWall'), true);
+  });
+
+  it('is false for a concrete non-IfcElement product (IfcSpace)', () => {
+    assert.strictEqual(isReassignableElement('IFC4', 'IfcSpace'), false);
+  });
+
+  it('is false for an abstract class', () => {
+    assert.strictEqual(isReassignableElement('IFC4', 'IfcBuildingElement'), false);
+  });
+
+  it('is false for an unknown class name', () => {
+    assert.strictEqual(isReassignableElement('IFC4', 'IfcNotARealClass'), false);
+  });
+});
+
+describe('getPredefinedTypes', () => {
+  it('returns a non-empty enum domain for a class known to have one (IfcWall)', () => {
+    const types = getPredefinedTypes('IFC4', 'IfcWall');
+    assert.ok(types.length > 0);
+    assert.ok(types.includes('NOTDEFINED'));
+  });
+
+  it('returns [] for an unknown class', () => {
+    assert.deepStrictEqual(getPredefinedTypes('IFC4', 'IfcNotARealClass'), []);
+  });
+});
+
+describe('COMMON_REASSIGN_TARGETS', () => {
+  it('every quick-pick chip is a valid, reassignable IFC4 element', () => {
+    for (const name of COMMON_REASSIGN_TARGETS) {
+      assert.strictEqual(
+        isReassignableElement('IFC4', name),
+        true,
+        `${name} should be a reassignable IfcElement subtype`,
+      );
+    }
+  });
+});

--- a/apps/viewer/src/lib/length-unit-scale.test.ts
+++ b/apps/viewer/src/lib/length-unit-scale.test.ts
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import type { IfcDataStore } from '@ifc-lite/parser';
+import { getModelLengthUnitScale } from './length-unit-scale.js';
+
+/**
+ * Build a stub IfcDataStore with just the fields
+ * `getModelLengthUnitScale` reads. Other fields are typed as `unknown` so
+ * the cast doesn't pollute production code with test shims (mirrors the
+ * pattern in `level-offsets.test.ts`).
+ */
+function makeStore(fields: {
+  lengthUnitScale?: number;
+  source?: Uint8Array;
+  entityIndex?: { byId: { get(id: number): unknown }; byType: Map<string, number[]> };
+}): IfcDataStore {
+  return fields as unknown as IfcDataStore;
+}
+
+// entityIndex with no IFCPROJECT entries — `extractLengthUnitScale` returns
+// its documented default of 1.0 without needing a real STEP buffer.
+const emptyEntityIndex = { byId: { get: () => undefined }, byType: new Map<string, number[]>() };
+
+describe('getModelLengthUnitScale', () => {
+  it('returns 1 for a null/undefined data store', () => {
+    assert.strictEqual(getModelLengthUnitScale(null), 1);
+    assert.strictEqual(getModelLengthUnitScale(undefined), 1);
+  });
+
+  it('uses dataStore.lengthUnitScale directly when it is a positive finite number', () => {
+    const store = makeStore({ lengthUnitScale: 0.001 });
+    assert.strictEqual(getModelLengthUnitScale(store), 0.001);
+  });
+
+  it('falls back to 1 when lengthUnitScale is invalid and there is no source buffer to extract from', () => {
+    const store = makeStore({ lengthUnitScale: NaN });
+    assert.strictEqual(getModelLengthUnitScale(store), 1);
+  });
+
+  it('treats a non-positive lengthUnitScale as invalid (boundary: 0 and negative both reject)', () => {
+    assert.strictEqual(getModelLengthUnitScale(makeStore({ lengthUnitScale: 0 })), 1);
+    assert.strictEqual(getModelLengthUnitScale(makeStore({ lengthUnitScale: -5 })), 1);
+  });
+
+  it('falls back to extraction (and its 1.0 default with no IFCPROJECT) when lengthUnitScale is missing', () => {
+    const store = makeStore({
+      source: new Uint8Array([1, 2, 3]),
+      entityIndex: emptyEntityIndex,
+    });
+    assert.strictEqual(getModelLengthUnitScale(store), 1);
+  });
+
+  it('memoises per data store — a later mutation of lengthUnitScale is not re-read', () => {
+    const store = makeStore({ lengthUnitScale: 0.01 });
+    assert.strictEqual(getModelLengthUnitScale(store), 0.01);
+    // Mutate after the first (cached) read.
+    (store as unknown as { lengthUnitScale: number }).lengthUnitScale = 1000;
+    assert.strictEqual(getModelLengthUnitScale(store), 0.01, 'expected the cached value, not the mutated one');
+  });
+
+  it('caches per-instance — a second, distinct store with the same shape is read independently', () => {
+    const storeA = makeStore({ lengthUnitScale: 0.001 });
+    const storeB = makeStore({ lengthUnitScale: 1 });
+    assert.strictEqual(getModelLengthUnitScale(storeA), 0.001);
+    assert.strictEqual(getModelLengthUnitScale(storeB), 1);
+  });
+});

--- a/apps/viewer/src/lib/lists/columnToAutoColor.test.ts
+++ b/apps/viewer/src/lib/lists/columnToAutoColor.test.ts
@@ -1,0 +1,90 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import type { ColumnDefinition } from '@ifc-lite/lists';
+import { columnToAutoColor } from './columnToAutoColor.js';
+
+function col(partial: Partial<ColumnDefinition> & Pick<ColumnDefinition, 'source' | 'propertyName'>): ColumnDefinition {
+  return { id: 'c1', ...partial };
+}
+
+describe('columnToAutoColor', () => {
+  it('maps an ordinary attribute column straight through', () => {
+    assert.deepStrictEqual(
+      columnToAutoColor(col({ source: 'attribute', propertyName: 'Name' })),
+      { source: 'attribute', propertyName: 'Name' },
+    );
+  });
+
+  it('routes the "Class" attribute column to ifcType (dedicated fast path)', () => {
+    assert.deepStrictEqual(
+      columnToAutoColor(col({ source: 'attribute', propertyName: 'Class' })),
+      { source: 'ifcType' },
+    );
+  });
+
+  it('maps a property column with its pset/property name', () => {
+    assert.deepStrictEqual(
+      columnToAutoColor(col({ source: 'property', psetName: 'Pset_WallCommon', propertyName: 'FireRating' })),
+      { source: 'property', psetName: 'Pset_WallCommon', propertyName: 'FireRating' },
+    );
+  });
+
+  it('maps a quantity column with its qset/quantity name', () => {
+    assert.deepStrictEqual(
+      columnToAutoColor(col({ source: 'quantity', psetName: 'Qto_WallBaseQuantities', propertyName: 'Length' })),
+      { source: 'quantity', psetName: 'Qto_WallBaseQuantities', propertyName: 'Length' },
+    );
+  });
+
+  /**
+   * Regression for a coverage gap that hid a live bug: `columnToAutoColor`
+   * had no case for `source: 'material'`, so it fell through to the
+   * `default: return { source: 'ifcType' }` branch. Clicking "Color by this
+   * column" on a Material list column silently colored the 3D view by IFC
+   * type instead of by material — no error, just the wrong grouping. Proven
+   * against unmodified `columnToAutoColor.ts` by direct invocation before
+   * this test existed: `columnToAutoColor({ source: 'material', ... })`
+   * returned `{ source: 'ifcType' }`.
+   */
+  it('preserves the material source rather than silently degrading to ifcType', () => {
+    assert.deepStrictEqual(
+      columnToAutoColor(col({ source: 'material', propertyName: 'Material' })),
+      { source: 'material' },
+    );
+  });
+
+  /**
+   * Same gap, classification column. AutoColorSpec.psetName doubles as a
+   * classification-system filter (see engine.ts `selectClassificationRef`),
+   * so it must be carried through, not dropped.
+   */
+  it('preserves the classification source and its system filter', () => {
+    assert.deepStrictEqual(
+      columnToAutoColor(col({ source: 'classification', psetName: 'Uniclass', propertyName: 'System' })),
+      { source: 'classification', psetName: 'Uniclass' },
+    );
+  });
+
+  /** Same gap, model column — AutoColorSpec supports `source: 'model'` directly. */
+  it('preserves the model source rather than silently degrading to ifcType', () => {
+    assert.deepStrictEqual(
+      columnToAutoColor(col({ source: 'model', propertyName: 'Model' })),
+      { source: 'model' },
+    );
+  });
+
+  it('falls back to ifcType for spatial and zone columns (no AutoColorSpec equivalent)', () => {
+    assert.deepStrictEqual(
+      columnToAutoColor(col({ source: 'spatial', propertyName: 'Storey' })),
+      { source: 'ifcType' },
+    );
+    assert.deepStrictEqual(
+      columnToAutoColor(col({ source: 'zone', propertyName: 'Zone' })),
+      { source: 'ifcType' },
+    );
+  });
+});

--- a/apps/viewer/src/lib/lists/columnToAutoColor.ts
+++ b/apps/viewer/src/lib/lists/columnToAutoColor.ts
@@ -27,6 +27,17 @@ export function columnToAutoColor(col: ColumnDefinition): AutoColorSpec {
       return { source: 'property', psetName: col.psetName, propertyName: col.propertyName };
     case 'quantity':
       return { source: 'quantity', psetName: col.psetName, propertyName: col.propertyName };
+    case 'material':
+      return { source: 'material' };
+    case 'classification':
+      // psetName doubles as a classification-system filter on both sides of
+      // the bridge (see ColumnDefinition.psetName and AutoColorSpec.psetName).
+      return { source: 'classification', psetName: col.psetName };
+    case 'model':
+      return { source: 'model' };
+    // 'spatial' and 'zone' columns have no AutoColorSpec equivalent — fall
+    // back to ifcType rather than silently mis-coloring by a container/zone
+    // value the lens engine can't actually group by.
     default:
       return { source: 'ifcType' };
   }

--- a/apps/viewer/src/lib/zones/colors.test.ts
+++ b/apps/viewer/src/lib/zones/colors.test.ts
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { zoneColorForIndex } from './colors.js';
+
+function assertClose(actual: number, expected: number, tol = 1e-6) {
+  assert.ok(
+    Math.abs(actual - expected) <= tol,
+    `expected ${actual} to be within ${tol} of ${expected}`,
+  );
+}
+
+describe('zoneColorForIndex', () => {
+  it('returns a valid RGB triple in [0, 1] for every channel', () => {
+    for (let i = 0; i < 20; i++) {
+      const [r, g, b] = zoneColorForIndex(i);
+      for (const c of [r, g, b]) {
+        assert.ok(c >= 0 && c <= 1, `channel ${c} out of [0,1] at index ${i}`);
+      }
+    }
+  });
+
+  it('is deterministic — same index always yields the same colour', () => {
+    assert.deepStrictEqual(zoneColorForIndex(3), zoneColorForIndex(3));
+  });
+
+  it('wraps the 8-colour palette (index 8 matches index 0)', () => {
+    assert.deepStrictEqual(zoneColorForIndex(0), zoneColorForIndex(8));
+    assert.deepStrictEqual(zoneColorForIndex(1), zoneColorForIndex(9));
+  });
+
+  it('assigns visibly distinct colours to adjacent zones (hue actually varies)', () => {
+    // Palette hues are 210, 25, 140, 280, ... — indices 0 and 1 must differ
+    // by more than a rounding epsilon in at least one channel. This pins the
+    // hue-lookup wiring: a mutation that always used hue index 0 would make
+    // every zone the same colour and only this assertion would catch it.
+    const c0 = zoneColorForIndex(0);
+    const c1 = zoneColorForIndex(1);
+    const maxDiff = Math.max(...c0.map((v, idx) => Math.abs(v - c1[idx])));
+    assert.ok(maxDiff > 0.05, `expected index 0 and 1 to differ, got ${c0} vs ${c1}`);
+  });
+
+  it('matches the known RGB for hue 210 (index 0) at s=0.65, l=0.55', () => {
+    // Hand-computed reference for HSL(210, 0.65, 0.55) -> RGB.
+    // c = (1 - |2*0.55-1|) * 0.65 = 0.9 * 0.65 = 0.585
+    // hp = 210/60 = 3.5 -> branch [0, x, c], x = c*(1-|3.5%2 - 1|) = c*(1-0.5)=0.2925
+    // m = l - c/2 = 0.55 - 0.2925 = 0.2575
+    // r = 0 + m = 0.2575, g = x + m = 0.55, b = c + m = 0.8425
+    const [r, g, b] = zoneColorForIndex(0);
+    assertClose(r, 0.2575, 1e-4);
+    assertClose(g, 0.55, 1e-4);
+    assertClose(b, 0.8425, 1e-4);
+  });
+});


### PR DESCRIPTION
"Color by this column" on a **Material**, **Classification** or **Model** list column silently coloured the viewport by IFC type instead. No error — just a quietly wrong grouping in the 3D view and the legend.

## The bug

`columnToAutoColor` bridges a list `ColumnDefinition.source` to a lens `AutoColorSpec.source`. It handled only `attribute` / `property` / `quantity`; everything else fell through to:

```ts
default:
  return { source: 'ifcType' };
```

But `AutoColorSpec.source` supports `classification`, `material` and `model` directly (`packages/lens/src/types.ts:204`). Three cases were simply missing.

`ListResultsTable.tsx:228` calls this **unconditionally** for whatever column the user picked, and nothing in `ColumnHeaderMenu.tsx` gates the action by source — so the fallback was reachable from ordinary UI, not a corner case.

```diff
+case 'material':
+  return { source: 'material' };
+case 'classification':
+  return { source: 'classification', psetName: col.psetName };
+case 'model':
+  return { source: 'model' };
```

Classification passes `psetName` through as the classification-system filter — that field's documented dual role on both sides of the bridge (`types.ts:207-208`).

## What is deliberately *not* fixed

`spatial` and `zone` keep the `ifcType` fallback, and the code now says why.

`AutoColorSpec` has no spatial source. It does have `group` — but that resolves **IFC `IfcZone`/`IfcGroup` relationship membership** (`packages/lens/src/engine.ts:350-362`), whereas a lists `zone` column is the viewer's own **user-defined zone sets** (#1810, with `Zone`/`Straddles` modes). Different concepts. Mapping one onto the other would trade a visible fallback for an invisible mismatch, which is worse.

Worth flagging separately: those two sources still silently fall back rather than being disabled in the menu. Gating the action by source is a UI decision, so I have left it alone.

## Verification

- **RED first**, against `main`'s unmodified source with the new tests in place: 3 of the 8 subtests fail — material, classification and model each returning `{ source: 'ifcType' }`. All 8 pass with the fix.
- Grepped every other consumer of `AutoColorSpec` / `ColumnDefinition['source']` — `LensPanel.tsx`, `lens-editor-utils.ts`, `ListBuilder.tsx`, `lensSlice.ts`. No other source-to-source bridge exists; this was the only site.
- Full suite: **2750 → 2788** tests across **251** files (+4), 2786 pass, 2 skipped, **0 fail**. `tsc --noEmit` clean, full output read.
- No changeset: `apps/viewer` is `private: true` and no shared package changed.

## Also included

Coverage for three `apps/viewer/src/lib` modules that had **none**, found in the same sweep:

- `ifc-class-reassign.ts` — abstract filter, subtype parent-walk, predefined-type lookup. Three mutations killed by the new tests. A fourth (schema priority order, `2X3` vs `4X3`) is an **equivalent mutant** — no real IFC schema string matches both substrings — so it is labelled, not counted.
- `zones/colors.ts` — deterministic per-zone HSL palette, including a hand-computed HSL→RGB reference rather than comparing the function against itself.
- `length-unit-scale.ts` — per-store memoized length scale. One guard mutation survived but is an equivalent mutant: a redundant normalisation two lines later forces the same result. Its control (`return 1` → `return 2` on the null-store path) died, confirming the harness reaches the file.

Note for anyone reproducing: `apps/viewer` runs `tsx --test`, **not** vitest — invoking vitest against these paths silently produces no output at all, which reads like a clean pass.