### PR TITLE
build(export): take XXH3 from twox-hash (MIT) instead of xxhash-rust (BSL-1.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1516,7 +1516,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
- "xxhash-rust",
+ "twox-hash",
  "zip",
 ]
 

--- a/rust/export/Cargo.toml
+++ b/rust/export/Cargo.toml
@@ -16,7 +16,16 @@ rustc-hash = "2.1"
 # Bulk little-endian reinterpret of f32/u32 slices to bytes (glTF vertex encoding)
 # and a single-pass 128-bit content hash for mesh dedup; both pure-Rust + wasm-safe.
 bytemuck = "1.25"
-xxhash-rust = { version = "0.8", features = ["xxh3"] }
+# XXH3-128 for the mesh-dedup key. `twox-hash` rather than `xxhash-rust`: both
+# implement the same algorithm, but twox-hash is MIT where xxhash-rust is
+# BSL-1.0, and a downstream consumer of this crate ships under a licence
+# allowlist that BSL-1.0 sits outside of. The digest only gates key equality and
+# never reaches the output, so the choice of implementation is free here — which
+# makes staying inside the common permissive set the obvious call.
+# `default-features = false` deliberately: the default set pulls `rand` (for
+# randomly-seeded hashers), which this use has no need of and which would widen
+# the dependency graph for nothing. `alloc` is what the streaming hasher needs.
+twox-hash = { version = "2.1", default-features = false, features = ["xxhash3_128", "alloc"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/rust/export/src/gltf.rs
+++ b/rust/export/src/gltf.rs
@@ -365,21 +365,25 @@ fn make_material(color: [f32; 4], lit: bool, emissive: bool) -> Material {
 /// EQUALITY (dedup grouping) and never appears in the output, so bit-identical meshes
 /// still collapse together and the emitted GLB is byte-for-byte unchanged; the win is
 /// ~20-50x less hashing on large models (xxh3 bulk vs element-wise SipHash-1-3).
+///
+/// Because the digest never leaves this function, the IMPLEMENTATION is free: any
+/// sound 128-bit hash groups the same meshes. That is what makes `twox-hash` (MIT)
+/// substitutable for `xxhash-rust` (BSL-1.0) without touching a single output byte.
 fn geom_color_key(positions: &[f32], normals: &[f32], indices: &[u32], color: [f32; 4]) -> u128 {
-    use xxhash_rust::xxh3::Xxh3;
-    let mut h = Xxh3::new();
-    h.update(&(positions.len() as u64).to_le_bytes());
-    h.update(bytemuck::cast_slice::<f32, u8>(positions));
-    h.update(&(normals.len() as u64).to_le_bytes());
-    h.update(bytemuck::cast_slice::<f32, u8>(normals));
-    h.update(&(indices.len() as u64).to_le_bytes());
-    h.update(bytemuck::cast_slice::<u32, u8>(indices));
+    use twox_hash::XxHash3_128;
+    let mut h = XxHash3_128::new();
+    h.write(&(positions.len() as u64).to_le_bytes());
+    h.write(bytemuck::cast_slice::<f32, u8>(positions));
+    h.write(&(normals.len() as u64).to_le_bytes());
+    h.write(bytemuck::cast_slice::<f32, u8>(normals));
+    h.write(&(indices.len() as u64).to_le_bytes());
+    h.write(bytemuck::cast_slice::<u32, u8>(indices));
     let (r, g, b, a) = color_key(color);
-    h.update(&r.to_le_bytes());
-    h.update(&g.to_le_bytes());
-    h.update(&b.to_le_bytes());
-    h.update(&a.to_le_bytes());
-    h.digest128()
+    h.write(&r.to_le_bytes());
+    h.write(&g.to_le_bytes());
+    h.write(&b.to_le_bytes());
+    h.write(&a.to_le_bytes());
+    h.finish_128()
 }
 
 /// Streams geometry into one or more glTF buffers. Each buffer holds three bufferViews


### PR DESCRIPTION
## What and why

The mesh-dedup key added in #2153 brought `xxhash-rust` into this crate's graph, and with it **BSL-1.0**.

Boost is a perfectly good permissive licence — OSI-approved, FSF Free/Libre, and lighter on binary distribution than MIT. **The problem is not the licence.** It is that a downstream consumer of `ifc-lite-export` ships under a fixed, contractually approved licence allowlist, and BSL-1.0 sits outside it. Widening that set is a client conversation with a written-approval step — a lot of process to absorb for a hash function, when the same algorithm is available from a crate already inside the common permissive set.

`twox-hash` is **MIT** and implements XXH3-128.

## Why this is substitutable at all

Because of a property the existing doc comment already states: the digest **gates key equality for dedup grouping and never reaches the output.** Any sound 128-bit hash groups exactly the same meshes, so the implementation is free.

The doc now says that explicitly rather than leaving it implied — it is the reason the swap is safe, not an incidental detail, and the next person to touch this should know the constraint is "sound 128-bit hash" and not "this specific crate".

## How it was verified

**Byte-identical, measured not assumed.** Across a 17-model corpus (2 KB → 27 MB, IFC2X3 through IFC4X3_ADD2), every column matches the pre-swap output on every model:

| | result |
|---|---|
| geometry hash | identical on all 17 |
| byte length | identical on all 17 |
| mesh count | identical on all 17 |
| vertex count | identical on all 17 |
| triangle count | identical on all 17 |

Run by pinning the downstream importer at `37eedd24`, capturing output, then re-running the identical binary with `--config 'patch."…ifc-lite".ifc-lite-export.path=…'` against this branch. `diff` is empty.

- [x] `cargo test` — **471 passed, 0 failed** across `ifc-lite-core`, `ifc-lite-export`, `ifc-lite-processing`, including the pinned `mesh_determinism` manifest
- [x] `cargo clippy -p ifc-lite-export --all-targets -- -D warnings` — clean
- [ ] Geometry/WASM change — no `rust/wasm-bindings` change, and no geometry output change to re-pin (see table)

## Dependency footprint

`default-features = false` is deliberate: the default set pulls `rand` for randomly-seeded hashers, which a content-addressed dedup key has no use for and which would widen the graph for nothing. Only `xxhash3_128` and `alloc` (what the streaming hasher needs) are enabled — **a smaller footprint than the crate it replaces.**

## Checklist

- [x] Behavior asserted through the existing determinism manifest plus the corpus comparison above
- [x] Published `packages/*` — none touched, so no changeset
- [x] No geometry output changed
- [x] House rules: no repo-wide `cargo fmt`, no module pushed past its budget
- [x] No client or project identifiers

---
_Generated by [Claude Code](https://claude.ai/code/session_01FE2CUm5rWNypVDeK6nuzbT)_