### PR TITLE
test(lens): pin the group auto-colour last-resort bucket key

### DIFF
--- a/packages/lens/src/engine.test.ts
+++ b/packages/lens/src/engine.test.ts
@@ -707,4 +707,15 @@ describe('evaluateAutoColorLens — By Zone', () => {
     expect(result.legend).toHaveLength(1);
     expect(result.colorMap.get(2)).toEqual(GHOST_COLOR);
   });
+
+  it('falls back to "Type #id" when a group has neither a name nor an ObjectType', () => {
+    // Last-resort bucket key so completely unnamed groups still get their own
+    // distinct legend entry instead of silently merging into another group.
+    const provider = createGroupProvider([
+      { id: 1, groups: [{ id: 500, type: 'IfcGroup' }] },
+    ]);
+    const result = evaluateAutoColorLens({ source: 'group' }, provider);
+    expect(result.legend).toHaveLength(1);
+    expect(result.legend[0].name).toBe('IfcGroup #500');
+  });
 });


### PR DESCRIPTION
One surviving mutation in `packages/lens/src/engine.ts`. **Tests only** — no production code changed.

`extractAutoColorValue`'s `group` arm ends with a last-resort key so a completely unnamed group still gets its own legend entry rather than merging into another bucket:

```ts
if (g.name && g.name.trim() !== '') return g.name;
if (g.objectType && g.objectType.trim() !== '') return `${g.type}: ${g.objectType}`;
return `${g.type} #${g.id}`;   // <- unreached by any test
```

Four tests already covered this arm — distinct named zones, the `IfcZone` preference among multiple memberships (#1075), the ObjectType fallback, and ghosting when there is no membership — so the arm looked well covered. None of them reached the final branch: every fixture group had a name or an ObjectType.

Rewriting that returned key survived all 97 tests.

## Severity

**COVERAGE GAP**, not a live defect. The fallback is correct today; nothing failed when it was changed.

## Verification

- 1 replacement (asserted), mutated line re-read before the run.
- Checked **against `main` with the new test absent**: the mutation leaves 97/97 green there. With the test in place it dies. So this is specifically the unreached branch, not the arm being untested — the other four tests keep passing throughout.
- Suite **97 → 98**, 4 files, all green.
- Restore by file copy throughout.

## Separately, a much larger gap found in the same sweep — not fixed here

`packages/cli/src/commands/query.ts` (594 lines) and `query-output.ts` (327 lines) have **zero test coverage of any kind**. No test file in the package imports `queryCommand`, `outputGroupBy`, `outputEntities`, `outputAggregation`, `outputCount` or `outputSum` — that is every `--where`, `--group-by`, `--unique`, `--spatial` and `--quantity-names` path plus all aggregation output formatting.

Demonstrated rather than asserted. Inverting `outputGroupBy`'s validation guard:

```diff
-if (!VALID_GROUP_BY_KEYS.includes(groupByKey) && !groupByKey.includes('.')) {
+if (!VALID_GROUP_BY_KEYS.includes(groupByKey) || !groupByKey.includes('.')) {
```

turns every plain `--group-by type` / `storey` / `material` invocation into a fatal error, and the full suite still passes 306/306 (8 skipped) — identical to baseline.

The sibling `query-aggregation.ts` *is* tested; the gap is specifically the output-formatting and command-orchestration layers. Left for a dedicated PR — 921 unexercised lines is more than should be backfilled unreviewed alongside a one-line test, and the guard itself is correct today (`&&`), so this is a coverage gap rather than a live bug.