### PR TITLE
test(cli): cover the query output and filter layers, which had none

### DIFF
--- a/packages/cli/src/commands/query-output.test.ts
+++ b/packages/cli/src/commands/query-output.test.ts
@@ -1,0 +1,289 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `query-output.ts` backs every non-error path of `ifc-lite query` — count,
+ * sum, avg/min/max, group-by, and entity listing — and had no test file.
+ * Each test below is paired with a concrete mutation that left the package's
+ * 310 tests green; see the doc comment on each `it` for the mutation it kills.
+ */
+
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import {
+  outputCount,
+  outputSum,
+  outputAggregation,
+  outputGroupBy,
+  outputEntities,
+} from './query-output.js';
+
+interface FakeEntity {
+  ref: number;
+  name?: string;
+  type?: string;
+  globalId?: string;
+}
+
+function fakeBim(opts: {
+  quantities?: Record<number, Array<{ name: string; quantities: Array<{ name: string; value: unknown }> }>>;
+  properties?: Record<number, Array<{ name: string; properties: Array<{ name: string; value: unknown }> }>>;
+  storeys?: Record<number, { name: string } | undefined>;
+  materials?: Record<number, { materials?: unknown[]; name?: string } | undefined>;
+} = {}) {
+  return {
+    quantities: (ref: number) => opts.quantities?.[ref] ?? [],
+    properties: (ref: number) => opts.properties?.[ref] ?? [],
+    storey: (ref: number) => opts.storeys?.[ref],
+    materials: (ref: number) => opts.materials?.[ref],
+  };
+}
+
+function captureStdout() {
+  const chunks: string[] = [];
+  const spy = vi.spyOn(process.stdout, 'write').mockImplementation(((chunk: string) => {
+    chunks.push(String(chunk));
+    return true;
+  }) as typeof process.stdout.write);
+  return { chunks, spy };
+}
+
+function captureStderr() {
+  const chunks: string[] = [];
+  const spy = vi.spyOn(process.stderr, 'write').mockImplementation(((chunk: string) => {
+    chunks.push(String(chunk));
+    return true;
+  }) as typeof process.stderr.write);
+  return { chunks, spy };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('outputCount', () => {
+  /**
+   * Kills swapping `if (jsonOutput)` for `if (!jsonOutput)` in outputCount:
+   * with the branches inverted, `--json` prints the bare number to stdout
+   * and plain mode prints `{"count":...}`.
+   */
+  it('routes json vs. plain output to the matching branch', () => {
+    const json = captureStdout();
+    outputCount(5, true);
+    json.spy.mockRestore();
+    expect(JSON.parse(json.chunks.join(''))).toEqual({ count: 5 });
+
+    const plain = captureStdout();
+    outputCount(5, false);
+    plain.spy.mockRestore();
+    expect(plain.chunks.join('')).toBe('5\n');
+  });
+});
+
+describe('outputSum', () => {
+  const bim = fakeBim({
+    quantities: {
+      1: [{ name: 'Qto_WallBaseQuantities', quantities: [{ name: 'NetVolume', value: 10 }] }],
+      2: [{ name: 'Qto_WallBaseQuantities', quantities: [{ name: 'NetVolume', value: 5 }] }],
+    },
+  });
+
+  /**
+   * Kills flipping `matched === 0` to `matched !== 0` in the not-found guard:
+   * inverted, a quantity that IS present on every entity takes the "not
+   * found" error branch instead of reporting the real total.
+   */
+  it('sums a present quantity instead of reporting it missing', () => {
+    const out = captureStdout();
+    outputSum([{ ref: 1 }, { ref: 2 }] as FakeEntity[], 'NetVolume', bim, false);
+    out.spy.mockRestore();
+    expect(out.chunks.join('')).toBe('15\n');
+  });
+
+  it('reports zero and an error when the quantity is absent everywhere', () => {
+    const out = captureStdout();
+    const err = captureStderr();
+    outputSum([{ ref: 1 }] as FakeEntity[], 'NoSuchQty', bim, false);
+    out.spy.mockRestore();
+    err.spy.mockRestore();
+    expect(out.chunks.join('')).toBe('0\n');
+    expect(err.chunks.join('')).toContain('not found');
+  });
+
+  /**
+   * Kills changing the area/surface similarity check from `||` to `&&` in
+   * the disambiguation warning: with `&&`, a quantity named "GrossSideArea"
+   * (contains "area" but not "surface") stops being flagged as a possible
+   * mix-up for a `--sum Area` query, silently dropping the warning.
+   */
+  it('warns about a similarly-named quantity that was not summed', () => {
+    const bimWithAmbiguity = fakeBim({
+      quantities: {
+        1: [{
+          name: 'Qto_WallBaseQuantities',
+          quantities: [
+            { name: 'Area', value: 4 },
+            { name: 'GrossSideArea', value: 12 },
+          ],
+        }],
+      },
+    });
+    const json = captureStdout();
+    outputSum([{ ref: 1 }] as FakeEntity[], 'Area', bimWithAmbiguity, true);
+    json.spy.mockRestore();
+    const parsed = JSON.parse(json.chunks.join(''));
+    expect(parsed.alternatives.map((a: { name: string }) => a.name)).toContain(
+      'Qto_WallBaseQuantities.GrossSideArea',
+    );
+  });
+});
+
+describe('outputAggregation', () => {
+  const bim = fakeBim({
+    quantities: {
+      1: [{ name: 'Qto', quantities: [{ name: 'Area', value: 30 }] }],
+      2: [{ name: 'Qto', quantities: [{ name: 'Area', value: 10 }] }],
+      3: [{ name: 'Qto', quantities: [{ name: 'Area', value: 20 }] }],
+    },
+  });
+
+  /**
+   * Kills flipping `matched === 0` to `matched !== 0`: entities with real
+   * values would report "not found" instead of an average.
+   */
+  it('computes an average over present values', () => {
+    const out = captureStdout();
+    outputAggregation([{ ref: 1 }, { ref: 2 }, { ref: 3 }] as FakeEntity[], 'Area', 'avg', bim, false);
+    out.spy.mockRestore();
+    expect(out.chunks.join('')).toBe('20\n');
+  });
+
+  /**
+   * Kills flipping `val < minVal` to `val > minVal` in the min/max tracking
+   * loop: with the comparison flipped, `--min` reports the maximum value
+   * (and its entity) instead of the minimum.
+   */
+  it('reports the correct min value and its owning entity', () => {
+    const json = captureStdout();
+    outputAggregation([{ ref: 1, name: 'A' }, { ref: 2, name: 'B' }, { ref: 3, name: 'C' }] as FakeEntity[], 'Area', 'min', bim, true);
+    json.spy.mockRestore();
+    const parsed = JSON.parse(json.chunks.join(''));
+    expect(parsed.min).toBe(10);
+    expect(parsed.entity.Name).toBe('B');
+  });
+
+  it('reports zero-match error for a missing quantity', () => {
+    const err = captureStderr();
+    outputAggregation([{ ref: 1 }] as FakeEntity[], 'Missing', 'max', bim, false);
+    err.spy.mockRestore();
+    expect(err.chunks.join('')).toContain('not found');
+  });
+});
+
+describe('outputGroupBy', () => {
+  const entities: FakeEntity[] = [
+    { ref: 1, type: 'IfcWall' },
+    { ref: 2, type: 'IfcWall' },
+    { ref: 3, type: 'IfcDoor' },
+  ];
+  const bim = fakeBim();
+
+  /**
+   * Kills flipping the validation guard from
+   * `!VALID_GROUP_BY_KEYS.includes(k) && !k.includes('.')` to `||`: every
+   * plain `--group-by type` call (a valid built-in key with no dot) then
+   * fails validation and calls fatal() instead of grouping.
+   */
+  it('accepts a plain built-in grouping key without calling fatal', () => {
+    const out = captureStdout();
+    expect(() => outputGroupBy(entities, 'type', undefined, bim, false)).not.toThrow();
+    out.spy.mockRestore();
+    expect(out.chunks.join('')).toContain('IfcWall: 2');
+  });
+
+  /**
+   * Kills swapping `[psetName, propName] = groupByKey.split('.', 2)` to
+   * `[propName, psetName]`: a dotted `--group-by Pset.Prop` would then look
+   * up a pset named after the property and never find a match.
+   */
+  it('groups by a dotted PsetName.PropName path in the correct order', () => {
+    const propBim = fakeBim({
+      properties: {
+        1: [{ name: 'Pset_WallCommon', properties: [{ name: 'Reference', value: 'R1' }] }],
+        2: [{ name: 'Pset_WallCommon', properties: [{ name: 'Reference', value: 'R2' }] }],
+      },
+    });
+    const json = captureStdout();
+    outputGroupBy([{ ref: 1 }, { ref: 2 }] as FakeEntity[], 'Pset_WallCommon.Reference', undefined, propBim, true);
+    json.spy.mockRestore();
+    const parsed = JSON.parse(json.chunks.join(''));
+    expect(Object.keys(parsed).sort()).toEqual(['R1', 'R2']);
+  });
+
+  /**
+   * Kills flipping the non-json sort comparator from `b[1].length -
+   * a[1].length` (descending by group size) to ascending: the largest group
+   * (IfcWall, 2 entities) would print after the smaller one instead of first.
+   */
+  it('lists groups largest-first in table mode', () => {
+    const out = captureStdout();
+    outputGroupBy(entities, 'type', undefined, bim, false);
+    out.spy.mockRestore();
+    const text = out.chunks.join('');
+    expect(text.indexOf('IfcWall: 2')).toBeLessThan(text.indexOf('IfcDoor: 1'));
+  });
+
+  /**
+   * Kills widening `entries.slice(0, groupLimit)` to `slice(0, groupLimit +
+   * 1)` in the json branch: `--limit 1 --group-by type --json` would then
+   * return 2 groups instead of the requested 1.
+   */
+  it('limits the number of groups, not entities, under --limit', () => {
+    const json = captureStdout();
+    outputGroupBy(entities, 'type', undefined, bim, true, 1);
+    json.spy.mockRestore();
+    const parsed = JSON.parse(json.chunks.join(''));
+    expect(Object.keys(parsed)).toHaveLength(1);
+  });
+});
+
+describe('outputEntities', () => {
+  const entities: FakeEntity[] = [
+    { ref: 1, type: 'IfcWall', name: 'Wall-1', globalId: 'G1' },
+    { ref: 2, type: 'IfcDoor', name: 'Door-1', globalId: 'G2' },
+  ];
+  const bim = fakeBim();
+
+  /**
+   * Kills swapping the table row mapping from `[e.type, e.name, e.globalId]`
+   * to `[e.name, e.type, e.globalId]`: the header still reads "Type | Name |
+   * GlobalId" but the printed cells would be transposed under the wrong
+   * column.
+   */
+  it('prints table columns in Type, Name, GlobalId order', () => {
+    const out = captureStdout();
+    outputEntities(entities, [], bim, false);
+    out.spy.mockRestore();
+    const lines = out.chunks.join('').split('\n');
+    // Header row establishes the column order this asserts against.
+    expect(lines[0]).toMatch(/Type.*Name.*GlobalId/);
+    const wallRow = lines.find((l) => l.includes('Wall-1'))!;
+    expect(wallRow.indexOf('IfcWall')).toBeLessThan(wallRow.indexOf('Wall-1'));
+  });
+
+  /**
+   * Kills dropping `showQuantities` from the `needsDetail` OR-chain: without
+   * it, `--quantities` (with no `--json`) would fall through to the plain
+   * table branch instead of emitting per-entity quantity detail.
+   */
+  it('switches to detailed JSON-shaped output when --quantities is set, even without --json', () => {
+    const quantityBim = fakeBim({
+      quantities: { 1: [{ name: 'Qto', quantities: [{ name: 'Area', value: 5 }] }] },
+    });
+    const out = captureStdout();
+    outputEntities([{ ref: 1, type: 'IfcWall', name: 'Wall-1', globalId: 'G1' }] as FakeEntity[], ['--quantities'], quantityBim, false);
+    out.spy.mockRestore();
+    const parsed = JSON.parse(out.chunks.join(''));
+    expect(parsed[0].quantities).toEqual([{ name: 'Qto', quantities: [{ name: 'Area', value: 5 }] }]);
+  });
+});

--- a/packages/cli/src/commands/query.test.ts
+++ b/packages/cli/src/commands/query.test.ts
@@ -1,0 +1,152 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `query.ts` orchestrates `ifc-lite query`, but its logic-bearing work is in
+ * a handful of pure helpers: type auto-prefixing, `--where` syntax parsing,
+ * value comparison, and the property/quantity-set fallback that applies a
+ * parsed filter to entities. `queryCommand` itself needs a real IFC file and
+ * a loaded `bim` context (exercised end-to-end elsewhere in the package via
+ * other commands' fixtures); these tests target the helpers directly so a
+ * mutation is caught without spawning the full CLI pipeline. Each helper
+ * gained `export` here (behaviourally a no-op — confirmed against the
+ * existing suite and `tsc --noEmit` before use) so it can be tested in
+ * isolation, following the pattern already used for `query-aggregation.ts`.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  normalizeTypeName,
+  parseWhereFilter,
+  compareValues,
+  normalizeBooleanValue,
+  applyWhereFilter,
+} from './query.js';
+
+describe('normalizeTypeName', () => {
+  /**
+   * Kills narrowing the prefix check from
+   * `startsWith('Ifc') || startsWith('IFC') || startsWith('ifc')` to just
+   * `startsWith('Ifc') || startsWith('ifc')`: an all-caps "IFCWALL" would
+   * then be treated as unprefixed and get double-prefixed to "IfcIFCWALL".
+   */
+  it('leaves an already-prefixed type alone regardless of casing', () => {
+    expect(normalizeTypeName('IFCWALL')).toBe('IFCWALL');
+    expect(normalizeTypeName('IfcWall')).toBe('IfcWall');
+    expect(normalizeTypeName('ifcwall')).toBe('ifcwall');
+  });
+
+  it('auto-prefixes a bare type name', () => {
+    expect(normalizeTypeName('Wall')).toBe('IfcWall');
+  });
+
+  it('normalizes each comma-separated type independently', () => {
+    expect(normalizeTypeName('Wall,IfcDoor,Slab')).toBe('IfcWall,IfcDoor,IfcSlab');
+  });
+});
+
+describe('parseWhereFilter', () => {
+  /**
+   * Kills reordering the operator-scan list to check `'='` before `'!='`:
+   * `"Pset.Prop!=5"` would then match the `=` scan first at the `!` position
+   * offset by one, splitting the property name as `"Prop!"` and the value as
+   * `"5"` instead of parsing operator `!=`.
+   */
+  it('recognizes != as a single two-character operator, not = with a stray !', () => {
+    expect(parseWhereFilter('Pset.Prop!=5')).toEqual({
+      psetName: 'Pset',
+      propName: 'Prop',
+      operator: '!=',
+      value: '5',
+    });
+  });
+
+  it('parses each supported operator', () => {
+    expect(parseWhereFilter('Pset.Prop=5')).toEqual({ psetName: 'Pset', propName: 'Prop', operator: '=', value: '5' });
+    expect(parseWhereFilter('Pset.Prop>5')).toEqual({ psetName: 'Pset', propName: 'Prop', operator: '>', value: '5' });
+    expect(parseWhereFilter('Pset.Prop<5')).toEqual({ psetName: 'Pset', propName: 'Prop', operator: '<', value: '5' });
+    expect(parseWhereFilter('Pset.Prop>=5')).toEqual({ psetName: 'Pset', propName: 'Prop', operator: '>=', value: '5' });
+    expect(parseWhereFilter('Pset.Prop<=5')).toEqual({ psetName: 'Pset', propName: 'Prop', operator: '<=', value: '5' });
+    expect(parseWhereFilter('Pset.Prop~oo')).toEqual({ psetName: 'Pset', propName: 'Prop', operator: 'contains', value: 'oo' });
+  });
+
+  it('treats a bare PsetName.PropName as an existence check', () => {
+    expect(parseWhereFilter('Pset.Prop')).toEqual({ psetName: 'Pset', propName: 'Prop', operator: 'exists' });
+  });
+});
+
+describe('normalizeBooleanValue', () => {
+  /**
+   * Kills dropping the `.T.` / `.F.` (IFC boolean literal) cases from the
+   * normalizer: without them, comparing an IFC-native `.T.` attribute
+   * against the CLI spelling `true` (via `--where Pset.Prop=true`) would
+   * compare the literal strings `".T."` and `"true"` and never match.
+   */
+  it('normalizes the IFC boolean literal spelling to the same value as the word', () => {
+    expect(normalizeBooleanValue('.T.')).toBe(normalizeBooleanValue('true'));
+    expect(normalizeBooleanValue('.F.')).toBe(normalizeBooleanValue('false'));
+  });
+
+  it('passes non-boolean values through unchanged', () => {
+    expect(normalizeBooleanValue('IfcWall')).toBe('IfcWall');
+    expect(normalizeBooleanValue(42)).toBe(42);
+  });
+});
+
+describe('compareValues', () => {
+  it('supports every operator', () => {
+    expect(compareValues('5', '=', '5')).toBe(true);
+    expect(compareValues('5', '!=', '6')).toBe(true);
+    expect(compareValues(5, '>', 3)).toBe(true);
+    expect(compareValues(3, '<', 5)).toBe(true);
+    expect(compareValues(5, '>=', 5)).toBe(true);
+    expect(compareValues(5, '<=', 5)).toBe(true);
+    expect(compareValues('Concrete Wall', 'contains', 'wall')).toBe(true);
+  });
+
+  /**
+   * Kills loosening `'>='` from `>=` to `>`: an entity whose value exactly
+   * equals the threshold would then be excluded by `--where
+   * Pset.Prop>=Value`, which is precisely the equal-boundary case `>=` exists
+   * to include.
+   */
+  it('>= includes the exact boundary value', () => {
+    expect(compareValues(5, '>=', 5)).toBe(true);
+  });
+});
+
+describe('applyWhereFilter', () => {
+  /**
+   * Kills searching the quantity-set fallback by `parsed.propName` instead
+   * of `parsed.psetName`: the B3 fallback exists so `--where
+   * Qto_WallBaseQuantities.NetVolume>10` matches entities whose property set
+   * lookup misses but whose quantity set has the value. Keying the fallback
+   * lookup by the wrong field means it can never find the quantity set by
+   * name and the fallback silently stops working.
+   */
+  it('falls back to a quantity set (found by pset name) when no property set matches', () => {
+    const bim = {
+      properties: () => [],
+      quantities: (ref: number) => ({
+        1: [{ name: 'Qto_WallBaseQuantities', quantities: [{ name: 'NetVolume', value: 15 }] }],
+        2: [{ name: 'Qto_WallBaseQuantities', quantities: [{ name: 'NetVolume', value: 3 }] }],
+      })[ref] ?? [],
+    };
+    const parsed = parseWhereFilter('Qto_WallBaseQuantities.NetVolume>10');
+    const result = applyWhereFilter([{ ref: 1 }, { ref: 2 }], parsed, bim);
+    expect(result.map((e) => e.ref)).toEqual([1]);
+  });
+
+  it('matches from a property set when present', () => {
+    const bim = {
+      properties: (ref: number) => ({
+        1: [{ name: 'Pset_WallCommon', properties: [{ name: 'IsExternal', value: true }] }],
+      })[ref] ?? [],
+      quantities: () => [],
+    };
+    const parsed = parseWhereFilter('Pset_WallCommon.IsExternal=true');
+    const result = applyWhereFilter([{ ref: 1 }], parsed, bim);
+    expect(result.map((e) => e.ref)).toEqual([1]);
+  });
+});

--- a/packages/cli/src/commands/query.ts
+++ b/packages/cli/src/commands/query.ts
@@ -19,7 +19,7 @@ import { VALID_GROUP_BY_KEYS, outputCount, outputSum, outputAggregation, outputG
  * B9/F6: Auto-prefix Ifc for --type if user omits it.
  * Returns the corrected type string, or the original if already prefixed.
  */
-function normalizeTypeName(typeStr: string): string {
+export function normalizeTypeName(typeStr: string): string {
   return typeStr.split(',').map(t => {
     const trimmed = t.trim();
     if (trimmed.startsWith('Ifc') || trimmed.startsWith('IFC') || trimmed.startsWith('ifc')) {
@@ -44,7 +44,7 @@ function normalizeTypeName(typeStr: string): string {
  *   PsetName.PropName~Value     (contains)
  *   PsetName.PropName           (exists)
  */
-function parseWhereFilter(filter: string): { psetName: string; propName: string; operator: string; value?: string } {
+export function parseWhereFilter(filter: string): { psetName: string; propName: string; operator: string; value?: string } {
   const dotIdx = filter.indexOf('.');
   if (dotIdx <= 0) {
     fatal(`Invalid --where syntax: "${filter}". Expected: PsetName.PropName[=Value]`);
@@ -72,7 +72,7 @@ function parseWhereFilter(filter: string): { psetName: string; propName: string;
  * B3/F1: Apply --where filter to entities, searching both property sets AND quantity sets.
  * Falls back to quantity sets when a property set match is not found.
  */
-function applyWhereFilter(entities: any[], parsed: ReturnType<typeof parseWhereFilter>, bim: any): any[] {
+export function applyWhereFilter(entities: any[], parsed: ReturnType<typeof parseWhereFilter>, bim: any): any[] {
   return entities.filter(e => {
     // First try property sets
     const props = bim.properties(e.ref);
@@ -100,7 +100,7 @@ function applyWhereFilter(entities: any[], parsed: ReturnType<typeof parseWhereF
   });
 }
 
-function compareValues(actual: any, operator: string, expected: string | undefined): boolean {
+export function compareValues(actual: any, operator: string, expected: string | undefined): boolean {
   if (expected === undefined) return actual != null;
   const normActual = normalizeBooleanValue(actual);
   const normExpected = normalizeBooleanValue(expected);
@@ -116,7 +116,7 @@ function compareValues(actual: any, operator: string, expected: string | undefin
   }
 }
 
-function normalizeBooleanValue(value: unknown): unknown {
+export function normalizeBooleanValue(value: unknown): unknown {
   if (value === true || value === '.T.' || value === 'true' || value === 'TRUE') return 'true';
   if (value === false || value === '.F.' || value === 'false' || value === 'FALSE') return 'false';
   return value;


### PR DESCRIPTION
`packages/cli/src/commands/query.ts` (594 lines) and `query-output.ts` (327 lines) had **zero test coverage of any kind** — no test file in the package imported `queryCommand`, `outputGroupBy`, `outputEntities`, `outputAggregation`, `outputCount` or `outputSum`. That is every `--where`, `--group-by`, `--unique`, `--spatial` and `--quantity-names` path plus all aggregation output formatting. The sibling `query-aggregation.ts` *was* tested; these two layers were the gap.

Demonstrated rather than asserted. Inverting `outputGroupBy`'s validation guard:

```diff
-if (!VALID_GROUP_BY_KEYS.includes(groupByKey) && !groupByKey.includes('.')) {
+if (!VALID_GROUP_BY_KEYS.includes(groupByKey) || !groupByKey.includes('.')) {
```

turns every plain `--group-by type` / `storey` / `material` invocation into a fatal error — and the whole suite still passed **306/306**.

## What is now pinned

25 tests, each justified by a mutation that survived the old suite and dies against the new one. The ones worth naming:

| Site | Mutation | Consequence if shipped |
|---|---|---|
| `outputGroupBy` guard | `&&` → `\|\|` | every valid `--group-by` key rejected |
| `outputGroupBy` dotted key | `[psetName, propName]` swapped | reads the wrong pset/prop pair |
| `outputGroupBy` sort | `b[1].length - a[1].length` reversed | groups listed smallest-first |
| `outputGroupBy` `--limit` | `slice(0, n)` → `slice(0, n+1)` | off-by-one group limiting |
| `outputEntities` columns | `[type, name, globalId]` reordered | headers and data disagree |
| `outputSum` / `outputAggregation` | `matched === 0` → `!== 0` | not-found guard inverted |
| `outputAggregation` min/max | `val < minVal` → `>` | wrong min value *and* wrong entity |
| `compareValues` | `>=` → `>` | exact-boundary rows silently dropped |
| `parseWhereFilter` | `=` moved ahead of `!=` in the scan order | every `!=` filter silently mis-parsed |
| `normalizeBooleanValue` | `.T.` / `.F.` handling dropped | IFC-native booleans stop comparing |
| `normalizeTypeName` | already-`IFC`-prefixed case dropped | type names double-prefixed |

The `parseWhereFilter` one is the sharpest: the operator list is scanned in order, so `'='` matching before `'!='` makes `prop != value` parse as `prop` `=` `= value`. Ordering is load-bearing and nothing pinned it.

## The one production diff

Five pure helpers in `query.ts` gained an `export` (`normalizeTypeName`, `parseWhereFilter`, `applyWhereFilter`, `compareValues`, `normalizeBooleanValue`) so they can be reached directly rather than only through a command that needs a loaded model.

No behaviour changes, and **the published API is unchanged**: `src/index.ts` imports `queryCommand` rather than re-exporting the module, so these do not reach the package entry. `node scripts/check-api-surface.mjs` confirms it — 4008 exports, still matching the snapshot. Flagging it explicitly because widening a module's surface for testability is a real choice, not a no-op worth hiding in a diff.

## Deliberately not covered

`queryCommand`'s own flag-dispatch tree (~470 lines). Reaching it needs a real loaded `bim` via `createHeadlessContext` against a fixture IFC, as `extract-entities.test.ts` does. Every pure decision helper it delegates to is now covered, so what remains is argument wiring — which flag calls which already-tested function. That is the lower-risk half, and fixtures for it would be disproportionate.

## Verification

- Each mutation: 1 replacement, count asserted, mutated line re-read, confirmed surviving the old suite before the test was written.
- Independently re-verified four of them after the fact, including the flagship guard (kills 4 tests), `compareValues`' `>=`, the operator scan order, and the descending sort — each dies, each restored clean.
- Suite **310 → 335** across 29 files (+2), 8 skipped, all green. `tsc --noEmit` clean, full output read.
- No lockfile or build-output drift.