### PR TITLE
test(collab-server): pin canWrite's role set and PathLock's exemptRoles bypass

### DIFF
--- a/packages/collab-server/test/auth.test.ts
+++ b/packages/collab-server/test/auth.test.ts
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, it } from 'vitest';
+import { canWrite, type Role } from '../src/auth.js';
+
+describe('canWrite', () => {
+  // Pins the exact role → write-capability mapping. Only `editor` and
+  // `admin` may mutate the doc; `viewer` was already exercised end-to-end
+  // in audit-rate.test.ts, but `commenter` had no coverage at all — a
+  // mutation adding `principal.role === 'commenter'` to the `canWrite`
+  // disjunction survived the full suite (138/138 still green) before this
+  // test existed, because no test ever asked whether a commenter can write.
+  it.each<[Role, boolean]>([
+    ['viewer', false],
+    ['commenter', false],
+    ['editor', true],
+    ['admin', true],
+  ])('role=%s → canWrite=%s', (role, expected) => {
+    expect(canWrite({ userId: 'u', role })).toBe(expected);
+  });
+});

--- a/packages/collab-server/test/path-locks.test.ts
+++ b/packages/collab-server/test/path-locks.test.ts
@@ -55,6 +55,23 @@ describe('path-locks', () => {
     expect(reg.matches('entities/storey-1/wall', { userId: 'bob', role: 'editor' })).toBeNull();
   });
 
+  // `exemptRoles` had no coverage at all: a mutation turning the
+  // `lock.exemptRoles?.has(principal.role)` check into a no-op (so the
+  // exemption is silently ignored) survived the full suite unchanged
+  // (142/142 still green), because no existing test ever set
+  // `exemptRoles` on a lock. This pins the "the locking admin can still
+  // edit" behaviour documented in the module header.
+  it('registry matches respects exemptRoles', () => {
+    const reg = createPathLockRegistry();
+    const lock = reg.add({
+      prefix: 'entities/storey-1/',
+      label: 'mep-review',
+      exemptRoles: new Set(['admin']),
+    });
+    expect(reg.matches('entities/storey-1/wall', { userId: 'bob', role: 'editor' })).toBe(lock);
+    expect(reg.matches('entities/storey-1/wall', { userId: 'alice', role: 'admin' })).toBeNull();
+  });
+
   it('rejects writes to locked prefixes via verifyAgainstPathLocks', async () => {
     const reg = createPathLockRegistry();
     reg.add({ prefix: 'entities/locked', label: 'frozen' });


### PR DESCRIPTION
Two surviving mutations, both in security-adjacent code. **Tests only** — no production change.

## 1. `canWrite` had no deny-side coverage

`packages/collab-server/src/auth.ts:42`

```diff
-return principal.role === 'editor' || principal.role === 'admin';
+return principal.role === 'editor' || principal.role === 'admin' || principal.role === 'commenter';
```

1 replacement (asserted), suite still **green**. Granting `commenter` write access changed nothing that any test could see.

**Bounded with a control**, because "a mutation survived" is otherwise consistent with the function never being called: removing `editor` from the same check **kills 35 tests across 11 files**. So `canWrite` is heavily exercised — what was missing is specifically the *deny* side. Every test asserted that editor and admin are allowed; none asserted that anyone is refused.

The new test walks all four roles, so widening the set fails on the specific role rather than passing silently.

## 2. `PathLock.exemptRoles` had no test at all

`packages/collab-server/src/path-locks.ts:80` — this is the documented "the locking admin can still edit" bypass, a role-based exemption from a write lock.

```diff
-if (lock.exemptRoles?.has(principal.role)) continue;
+if (false) continue;
```

Survived. Every existing test configured `exemptUserIds`; **not one ever set `exemptRoles`**, so the entire role-exemption path was dead to the suite. Had the real check been inverted or dropped, nothing would have caught it.

## Severity

Both are **COVERAGE GAPs**, not live defects. `commenter` is correctly denied write today and the exemption is correctly applied — nothing failed when either was deliberately broken. Flagging them as security-*adjacent* rather than security bugs, deliberately: the code is right, the guard against it silently becoming wrong was missing.

## Verification

- 1 replacement per mutation, count asserted, mutated line re-read before each run.
- **Re-verified after rebasing onto current `main`** (16 commits behind at the time) — both still die there. Worth doing explicitly here, because a merge can drain an assertion without touching a test file, and `main` moved by ~45 PRs today.
- Suite **138 → 143** across 31 files (+1), `tsc --noEmit` clean, full output read.
- Restores by file copy throughout; the production diff is empty (`git diff -- packages/collab-server/src` shows nothing).

## Not covered

`layer-registry.ts`, `blob-route.ts` and `layer-registry-route.ts` (~1440 lines combined) were read but not mutation-tested — out of budget for this round, and worth a dedicated pass.

`room-manager.ts` got a structural review rather than mutation testing: connections are keyed per-`Room` instance and broadcasts are scoped to `this.conns`, so no cross-room leakage was found — but that is a read, not a proof, and I would not want it recorded as verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming that editing permissions are correctly enforced by role.
  * Added coverage verifying that administrators can bypass applicable path locks while editors remain restricted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->