### PR TITLE
fix(viewer): clear the legacy selectedEntityIds set when a model is selected

### DIFF
--- a/apps/viewer/src/store/slices/selectionSlice.test.ts
+++ b/apps/viewer/src/store/slices/selectionSlice.test.ts
@@ -395,21 +395,20 @@ describe('SelectionSlice', () => {
       assert.strictEqual(state.selectedEntityId, null);
     });
 
-    it('setSelectedModelId does NOT clear the legacy selectedEntityIds set', () => {
-      // Pinning the CURRENT behaviour, not endorsing it. `setSelectedModelId`
-      // (selectionSlice.ts:292) clears `selectedEntity`, `selectedEntities`
-      // and `selectedEntityId`, but leaves the legacy global-id set standing,
-      // even though its comment reads "Clear other selection when selecting a
-      // model". The survivors are user-visible: MainToolbar.tsx:352 and
-      // ElementsTab.tsx:44 keep reporting the stale count, and
-      // useAnimationLoop.ts:244 keeps painting the stale highlight, while the
-      // properties panel has already switched to the model.
-      // If that asymmetry is ever fixed, THIS test is the one to flip.
+    it('setSelectedModelId clears the legacy selectedEntityIds set', () => {
+      // `setSelectedModelId` (selectionSlice.ts:292) clears `selectedEntity`,
+      // `selectedEntities` and `selectedEntityId`, and must also clear the
+      // legacy global-id set, matching its own comment: "Clear other
+      // selection when selecting a model". Otherwise the set survives and
+      // MainToolbar.tsx:352 and ElementsTab.tsx:44 keep reporting the stale
+      // count, and useAnimationLoop.ts:244 keeps painting the stale
+      // highlight, while the properties panel has already switched to the
+      // model.
       state.setSelectedEntityIds([7, 8]);
 
       state.setSelectedModelId('model-1');
 
-      assert.deepStrictEqual([...state.selectedEntityIds].sort((a, b) => a - b), [7, 8]);
+      assert.deepStrictEqual([...state.selectedEntityIds], []);
     });
 
     it('setSelectedEntities makes the FIRST ref primary and clears the model selection', () => {

--- a/apps/viewer/src/store/slices/selectionSlice.ts
+++ b/apps/viewer/src/store/slices/selectionSlice.ts
@@ -295,5 +295,6 @@ export const createSelectionSlice: StateCreator<SelectionSlice, [], [], Selectio
     selectedEntity: null,
     selectedEntities: [],
     selectedEntityId: null,
+    selectedEntityIds: new Set(),
   }),
 });


### PR DESCRIPTION
Closes #2223.

`setSelectedModelId` cleared `selectedEntity`, `selectedEntities` and `selectedEntityId` but left the legacy `selectedEntityIds` set standing — despite its own comment reading *"Clear other selection when selecting a model"*.

Click a model in the hierarchy while elements are selected and the UI disagrees with itself: `MainToolbar.tsx:352` and `ElementsTab.tsx:44` keep reporting the stale count, `useAnimationLoop.ts:244` keeps painting the stale highlight, and the properties panel has already switched to the model.

```diff
 selectedEntityId: null,
+selectedEntityIds: new Set(),
```

A fresh `Set()`, matching `clearSelection` and `setSelectedEntityIds` rather than mutating a shared reference.

## The test that pinned this is flipped, as the issue asked

It was added in #2162 recording the asymmetry rather than endorsing it, and said so in its own comment: *"If that asymmetry is ever fixed, THIS test is the one to flip."* Done — renamed, comment rewritten to describe the contract it now enforces, assertion inverted.

Worth noting how this got here, since it is a small vindication of the process: CodeRabbit originally proposed adding `assert.strictEqual(state.selectedEntityIds.size, 0)` to a *different* test on #2162. That would have failed, because the store genuinely did not clear the set. The right response was to refute the suggestion, record the real behaviour with a test, and name the honest fix as a behaviour change for the maintainer to call. That is exactly the route this took.

## What I checked before changing shared state

Clearing a set that ~25 files read is the one way this could do harm, so I did not take it on faith:

- **Every reader of `selectedEntityIds`** — `Viewport.tsx`, `HierarchyPanel.tsx`, `CommandPalette.tsx`, `BCFPanel.tsx`, `useGanttSelection3DHighlight.ts`, `ListResultsTable.tsx`, `PresenceBroadcaster.tsx`, `useKeyboardShortcuts.ts`, `useClash.ts`, `lib/tours/snapshot.ts`, `basketSave.ts` and the rest. All display, highlight, or take explicit snapshots (clash, tours) that do not route through this action. None depends on the set surviving a model selection.
- **All nine call sites of `setSelectedModelId`** — the hierarchy panel's "click a model row" (the bug scenario) plus eight export / data-connector dialogs that call it once to default-select the first model when nothing is selected yet. None relies on the set persisting.

## Verification

- **RED first**: with the added line reverted, the flipped test fails with `+ [ 7, 8 ] - []`. 1 replacement, count asserted; restoring returns it to green. I re-ran this myself after the agent's run rather than relying on the report — 45 pass / 1 fail mutated, 46 / 0 restored.
- Full `apps/viewer` suite: **2878 passing / 2 skipped / 0 failing** across 252 files.
- `tsc --noEmit` clean, full output read.
- No changeset: `apps/viewer` is `private: true` and no published package changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Selecting a model now clears previously selected legacy entity IDs, preventing outdated selections from persisting.
* **Tests**
  * Updated selection behavior coverage to verify that legacy entity selections are cleared when a model is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->