### PR TITLE
test(server,data): work through the #2224 review follow-ups

### DIFF
--- a/.changeset/entity-table-retype-override-casing.md
+++ b/.changeset/entity-table-retype-override-casing.md
@@ -1,0 +1,10 @@
+---
+"@ifc-lite/data": patch
+"@ifc-lite/cache": patch
+---
+
+Fix `EntityTable.setTypeOverride` storing a UI retype's class name in whatever casing the caller passed instead of canonicalising it.
+
+A "change class" retype hands `setTypeOverride` a raw UPPERCASE IFC class token (e.g. `IFCBUILDINGSTOREY`), and `getTypeName` echoed the override straight back unchanged. `isSpatialStructureTypeName` — and any other case-sensitive `*Name` predicate built off `IfcTypeEnumToString`'s PascalCase output — matches against the PascalCase form only, so a retyped entity's new class silently stopped being recognised as part of the spatial tree, even though the case-insensitive `isStoreyLikeSpatialTypeName` correctly saw it. `setTypeOverride` now canonicalises the incoming name to PascalCase before storing it, so `getTypeName` and every name-based predicate agree regardless of the casing a caller passes in.
+
+`EntityTable` has three independent implementations — the columnar table in `@ifc-lite/data`, the cache-restored table in `@ifc-lite/cache`, and the server-backed table in `apps/viewer` — and all three stored the override verbatim. Fixing only one would have left the same retype behaving differently depending on whether the model came from a fresh parse, a cache restore, or the server, which is harder to diagnose than the original bug. All three now canonicalise identically.

--- a/apps/server/src/admission_tests.rs
+++ b/apps/server/src/admission_tests.rs
@@ -314,14 +314,18 @@ async fn breaker_is_inert_when_rss_budget_or_pct_is_zero() {
     no_pct.acquire(1).await.expect("shed_pct 0 ⇒ no breaker");
 }
 
-/// `set_resident_bytes` / `resident_bytes` round-trip, and the gauge is what
-/// `metrics_text` publishes. Without this the sampler could write to a field
-/// nothing reads.
+/// `set_resident_bytes` feeds the gauge that `metrics_text` publishes.
+/// Without this the sampler could write to a field nothing reads.
+///
+/// Pins only the observable contract (the metrics body), not the
+/// `resident_bytes()` getter round-trip: the body assertion below already
+/// requires `set_resident_bytes` to have taken effect, so a separate
+/// `assert_eq!(a.resident_bytes(), 4_096)` added nothing a broken
+/// `metrics_text` implementation could hide behind.
 #[tokio::test]
 async fn resident_gauge_round_trips_into_the_metrics_body() {
     let a = Arc::new(Admission::new(cfg_shed(2, 100, 2, 85)));
     a.set_resident_bytes(4_096);
-    assert_eq!(a.resident_bytes(), 4_096);
     assert!(a.metrics_text().contains("ifc_server_resident_bytes 4096"));
     // The budget gauge reports bytes, not MB.
     assert!(a

--- a/apps/server/src/cors_tests.rs
+++ b/apps/server/src/cors_tests.rs
@@ -133,6 +133,14 @@ async fn near_miss_wildcards_do_not_enable_permissive_cors() {
 /// The default `CORS_ORIGINS` (nothing configured) is a localhost allow-list,
 /// never permissive — a wildcard default would expose every self-hosted
 /// deployment that never sets the variable.
+///
+/// Pins that the header is EMPTY for an untrusted origin, not merely "not the
+/// literal `*`". A layer that reflected the request's `Origin` back
+/// (`AllowOrigin::mirror_request()`) would pass the old `assert_ne!(.., "*")`
+/// version of this test while still granting `https://attacker.example`
+/// cross-origin access — the response header would read
+/// `https://attacker.example`, never the string `"*"`. Asserting emptiness is
+/// the only way this test can catch that.
 #[tokio::test]
 async fn the_shipped_default_is_not_permissive() {
     let defaults = shipped_default_config().cors_origins;
@@ -141,9 +149,10 @@ async fn the_shipped_default_is_not_permissive() {
         &defaults.iter().map(String::as_str).collect::<Vec<_>>(),
     )
     .await;
-    assert_ne!(
+    assert_eq!(
         allow_origin_for(state, "https://attacker.example").await,
-        "*",
-        "the default CORS configuration must not be permissive: {defaults:?}"
+        "",
+        "the default CORS configuration must not grant an untrusted origin any \
+         Access-Control-Allow-Origin header (reflected or wildcard): {defaults:?}"
     );
 }

--- a/apps/server/src/cors_tests.rs
+++ b/apps/server/src/cors_tests.rs
@@ -61,8 +61,15 @@ async fn state_with_origins(label: &str, origins: &[&str]) -> AppState {
 }
 
 /// `GET /api/v1/health` with an `Origin`, returning the
-/// `Access-Control-Allow-Origin` response header (empty string when absent).
-async fn allow_origin_for(state: AppState, origin: &str) -> String {
+/// `Access-Control-Allow-Origin` response header value.
+///
+/// `None` means the header was genuinely absent from the response — the
+/// no-CORS-access contract. This is deliberately NOT collapsed to `""`:
+/// a `Some("".to_string())` (an explicit, empty header value) would be a
+/// different and stranger bug than a missing header, and callers that only
+/// care about "was access granted" must still be able to tell the two
+/// apart from "was the header present at all".
+async fn allow_origin_for(state: AppState, origin: &str) -> Option<String> {
     let request = Request::builder()
         .method("GET")
         .uri("/api/v1/health")
@@ -75,7 +82,6 @@ async fn allow_origin_for(state: AppState, origin: &str) -> String {
         .headers()
         .get(header::ACCESS_CONTROL_ALLOW_ORIGIN)
         .map(|v| v.to_str().unwrap().to_string())
-        .unwrap_or_default()
 }
 
 /// A `"*"` entry anywhere in `CORS_ORIGINS` puts the layer in permissive mode.
@@ -84,11 +90,11 @@ async fn allow_origin_for(state: AppState, origin: &str) -> String {
 #[tokio::test]
 async fn a_wildcard_entry_enables_permissive_cors() {
     let state = state_with_origins("wildcard", &["*"]).await;
-    assert_eq!(allow_origin_for(state, OTHER).await, "*");
+    assert_eq!(allow_origin_for(state, OTHER).await.as_deref(), Some("*"));
 
     // The wildcard is honoured even when it is not the first entry.
     let state = state_with_origins("wildcard-tail", &[ALLOWED, "*"]).await;
-    assert_eq!(allow_origin_for(state, OTHER).await, "*");
+    assert_eq!(allow_origin_for(state, OTHER).await.as_deref(), Some("*"));
 }
 
 /// The other direction, and the security-relevant one: with an explicit
@@ -98,18 +104,19 @@ async fn a_wildcard_entry_enables_permissive_cors() {
 #[tokio::test]
 async fn an_explicit_allow_list_reflects_only_listed_origins() {
     let state = state_with_origins("allowlist-hit", &[ALLOWED]).await;
-    assert_eq!(allow_origin_for(state, ALLOWED).await, ALLOWED);
+    assert_eq!(allow_origin_for(state, ALLOWED).await.as_deref(), Some(ALLOWED));
 
     let state = state_with_origins("allowlist-miss", &[ALLOWED]).await;
     assert_eq!(
         allow_origin_for(state, OTHER).await,
-        "",
-        "an unlisted origin must NOT be granted access"
+        None,
+        "an unlisted origin must NOT be granted access — the header must be \
+         absent, not merely non-matching"
     );
 
     // ...and must never be answered with a blanket wildcard.
     let state = state_with_origins("allowlist-nowild", &[ALLOWED]).await;
-    assert_ne!(allow_origin_for(state, OTHER).await, "*");
+    assert_ne!(allow_origin_for(state, OTHER).await.as_deref(), Some("*"));
 }
 
 /// A near-miss on the wildcard literal (`"**"`, `" * "`, an empty list) must
@@ -121,26 +128,29 @@ async fn near_miss_wildcards_do_not_enable_permissive_cors() {
         let state = state_with_origins("near-miss", &[spelling]).await;
         let allow = allow_origin_for(state, OTHER).await;
         assert_ne!(
-            allow, "*",
+            allow.as_deref(),
+            Some("*"),
             "{spelling:?} must not be treated as the permissive wildcard"
         );
     }
-    // An empty list allows nothing.
+    // An empty list allows nothing — the header must be absent entirely.
     let state = state_with_origins("empty", &[]).await;
-    assert_eq!(allow_origin_for(state, OTHER).await, "");
+    assert_eq!(allow_origin_for(state, OTHER).await, None);
 }
 
 /// The default `CORS_ORIGINS` (nothing configured) is a localhost allow-list,
 /// never permissive — a wildcard default would expose every self-hosted
 /// deployment that never sets the variable.
 ///
-/// Pins that the header is EMPTY for an untrusted origin, not merely "not the
-/// literal `*`". A layer that reflected the request's `Origin` back
-/// (`AllowOrigin::mirror_request()`) would pass the old `assert_ne!(.., "*")`
-/// version of this test while still granting `https://attacker.example`
-/// cross-origin access — the response header would read
-/// `https://attacker.example`, never the string `"*"`. Asserting emptiness is
-/// the only way this test can catch that.
+/// Pins that the header is ABSENT for an untrusted origin, not merely "not
+/// the literal `*`" and not merely "an empty string". A layer that reflected
+/// the request's `Origin` back (`AllowOrigin::mirror_request()`) would pass
+/// the old `assert_ne!(.., "*")` version of this test while still granting
+/// `https://attacker.example` cross-origin access — the response header
+/// would read `https://attacker.example`, never the string `"*"`. Asserting
+/// `None` is the only way this test can catch that AND distinguish a
+/// genuinely missing header from a header present with an empty value,
+/// which `allow_origin_for`'s old `String` return type collapsed together.
 #[tokio::test]
 async fn the_shipped_default_is_not_permissive() {
     let defaults = shipped_default_config().cors_origins;
@@ -151,7 +161,7 @@ async fn the_shipped_default_is_not_permissive() {
     .await;
     assert_eq!(
         allow_origin_for(state, "https://attacker.example").await,
-        "",
+        None,
         "the default CORS configuration must not grant an untrusted origin any \
          Access-Control-Allow-Origin header (reflected or wildcard): {defaults:?}"
     );

--- a/apps/server/src/routes/parse/extract_file_tests.rs
+++ b/apps/server/src/routes/parse/extract_file_tests.rs
@@ -162,8 +162,20 @@ async fn a_file_of_exactly_the_ceiling_is_accepted() {
 
 /// A `max_file_size_mb` of 0 admits nothing but an empty body — the degenerate
 /// configuration must not wrap around into "unlimited".
+///
+/// Pins BOTH sides of the boundary. Previously only the one-byte rejection
+/// was asserted, so a mutant that rejected every upload unconditionally
+/// (including a genuinely empty one, which a `max_bytes == 0` ceiling must
+/// still admit) survived: it still rejected the one byte this test sent.
+/// The empty-body admission below is what catches that mutant.
 #[tokio::test]
 async fn a_zero_ceiling_rejects_any_payload() {
+    let mut multipart = multipart_of(b"").await;
+    let bytes = extract_file(&mut multipart, 0)
+        .await
+        .expect("an empty body must be admitted even under a zero ceiling");
+    assert!(bytes.is_empty());
+
     let mut multipart = multipart_of(b"x").await;
     let err = extract_file(&mut multipart, 0).await.unwrap_err();
     assert!(matches!(err, ApiError::FileTooLarge { max_mb: 0 }));

--- a/apps/viewer/src/utils/serverDataModel.ts
+++ b/apps/viewer/src/utils/serverDataModel.ts
@@ -30,6 +30,7 @@ import {
   QuantityType,
   isBuildingLikeSpatialType,
   isStoreyLikeSpatialType,
+  IFC_ENTITY_NAMES,
   type SpatialHierarchy,
   type SpatialNode,
   type EntityTable,
@@ -401,7 +402,13 @@ function buildEntityTable(
     },
     setTypeOverride: (id, typeName) => {
       if (typeName === null) typeOverrides.delete(id);
-      else typeOverrides.set(id, typeName);
+      // Canonicalise on the way in, matching `entityTableFromColumns`
+      // (packages/data/src/entity-table.ts) and the cache-restored table.
+      // `getTypeName` echoes the override back verbatim and consumers like
+      // `isSpatialStructureTypeName` match the PascalCase form, so storing
+      // the caller's raw UPPERCASE token makes a retyped entity invisible to
+      // them. All three EntityTable implementations must agree here.
+      else typeOverrides.set(id, IFC_ENTITY_NAMES[typeName.toUpperCase()] ?? typeName.toUpperCase());
     },
     getExpressIdByGlobalId: (gid) => {
       return globalIdToExpressId.get(gid) ?? -1;

--- a/packages/cache/src/cache.test.ts
+++ b/packages/cache/src/cache.test.ts
@@ -16,6 +16,7 @@ import {
   PropertyValueType,
   QuantityType,
   RelationshipType,
+  isSpatialStructureTypeName,
 } from '@ifc-lite/data';
 import { BinaryCacheWriter, BinaryCacheReader, xxhash64, SchemaVersion, FORMAT_VERSION } from './index.js';
 import type { CacheDataStore } from './types.js';
@@ -459,6 +460,28 @@ describe('BinaryCacheWriter and BinaryCacheReader', () => {
     expect(entities.getName(1)).toBe('Test Project');
     expect(entities.getName(4)).toBe('Wall 1');
     expect(entities.getTypeName(4)).toBe('IfcWall');
+  });
+
+  // Regression test for the cache-restored `EntityTable` (the one that ships
+  // to users through the persisted cache): `setTypeOverride` must canonicalise
+  // the caller's raw UPPERCASE token to PascalCase, matching
+  // `entityTableFromColumns` (packages/data/src/entity-table.ts), so a
+  // retyped entity is still recognised by consumers like
+  // `isSpatialStructureTypeName` after a cache round-trip.
+  it('canonicalises a type override to PascalCase across a cache round-trip', async () => {
+    const writer = new BinaryCacheWriter();
+    const cacheBuffer = await writer.write(dataStore, undefined, sourceBuffer, {
+      includeGeometry: false,
+    });
+
+    const reader = new BinaryCacheReader();
+    const result = await reader.read(cacheBuffer);
+
+    const { entities } = result.dataStore;
+    entities.setTypeOverride(4, 'IFCBUILDINGSTOREY');
+
+    expect(entities.getTypeName(4)).toBe('IfcBuildingStorey');
+    expect(isSpatialStructureTypeName(entities.getTypeName(4))).toBe(true);
   });
 
   it('should preserve property data through round-trip', async () => {

--- a/packages/cache/src/sections/entities.ts
+++ b/packages/cache/src/sections/entities.ts
@@ -7,7 +7,7 @@
  */
 
 import type { EntityTable, StringTable } from '@ifc-lite/data';
-import { IfcTypeEnum, IfcTypeEnumToString, IfcTypeEnumFromString } from '@ifc-lite/data';
+import { IfcTypeEnum, IfcTypeEnumToString, IfcTypeEnumFromString, IFC_ENTITY_NAMES } from '@ifc-lite/data';
 import { BufferWriter, BufferReader } from '../utils/buffer-utils.js';
 
 /**
@@ -181,7 +181,13 @@ export function readEntities(reader: BufferReader, strings: StringTable): Entity
     },
     setTypeOverride: (id, typeName) => {
       if (typeName === null) typeOverrides.delete(id);
-      else typeOverrides.set(id, typeName);
+      // Canonicalise on the way in, matching `entityTableFromColumns`
+      // (packages/data/src/entity-table.ts). `getTypeName` echoes the
+      // override back verbatim and consumers like
+      // `isSpatialStructureTypeName` match the PascalCase form, so storing
+      // the caller's raw UPPERCASE token makes a retyped entity invisible to
+      // them. All three EntityTable implementations must agree here.
+      else typeOverrides.set(id, IFC_ENTITY_NAMES[typeName.toUpperCase()] ?? typeName.toUpperCase());
     },
     getExpressIdByGlobalId: (gid) => {
       return globalIdToExpressId.get(gid) ?? -1;

--- a/packages/data/src/entity-table.ts
+++ b/packages/data/src/entity-table.ts
@@ -340,7 +340,13 @@ export function entityTableFromColumns(
 
     setTypeOverride: (id, typeName) => {
       if (typeName === null) typeOverrides.delete(id);
-      else typeOverrides.set(id, typeName);
+      // Canonicalise to PascalCase on the way in: callers (a UI "change
+      // class" action) hand this a raw UPPERCASE IFC class token, but
+      // `getTypeName` echoes the override straight back, and consumers
+      // (e.g. `isSpatialStructureTypeName`) match against the PascalCase
+      // form. Storing the raw casing made every retyped entity invisible
+      // to those case-sensitive name predicates.
+      else typeOverrides.set(id, normalizeIfcUpperCase(typeName.toUpperCase()));
     },
 
     getExpressIdByGlobalId: (gid) => globalIdToExpressId.get(gid) ?? -1,

--- a/packages/data/src/spatial-types.test.ts
+++ b/packages/data/src/spatial-types.test.ts
@@ -15,6 +15,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
+import { EntityTableBuilder } from './entity-table.js';
 import {
   BUILDING_LIKE_SPATIAL_TYPE_ENUMS,
   SPACE_LIKE_SPATIAL_TYPE_ENUMS,
@@ -28,6 +29,7 @@ import {
   isStoreyLikeSpatialType,
   isStoreyLikeSpatialTypeName,
 } from './spatial-types.js';
+import { StringTable } from './string-table.js';
 import { IfcTypeEnum } from './types.js';
 
 describe('SPATIAL_STRUCTURE_TYPE_ENUMS membership', () => {
@@ -157,5 +159,30 @@ describe('name-based predicates', () => {
     expect(isStoreyLikeSpatialTypeName('IFCBUILDINGSTOREY')).toBe(true);
     expect(isSpaceLikeSpatialTypeName('IFCSPACE')).toBe(true);
     expect(isSpaceLikeSpatialTypeName('ifcspace')).toBe(true);
+  });
+});
+
+describe('retype override interop with isSpatialStructureTypeName', () => {
+  // `EntityTable.setTypeOverride` (entity-table.ts) is how a UI "change
+  // class" action re-labels an entity. Its `typeName` argument comes from a
+  // dropdown of raw IFC class tokens, which are UPPERCASE
+  // (`IFCBUILDINGSTOREY`, not `IfcBuildingStorey`) — the same casing
+  // `IFC_ENTITY_NAMES` and the rest of the raw-type-name plumbing use
+  // elsewhere in this file. `getTypeName` echoed that override back verbatim,
+  // so any caller that re-classifies an entity and then asks
+  // `isSpatialStructureTypeName(table.getTypeName(id))` whether it belongs in
+  // the spatial tree got a silent `false` for every retyped entity — even
+  // though `isStoreyLikeSpatialTypeName` (case-insensitive) correctly said
+  // `true`. Pins that the override is canonicalised to PascalCase on the way
+  // in, so `getTypeName` and the case-sensitive name predicate agree.
+  it('canonicalises an UPPERCASE retype so isSpatialStructureTypeName recognises it', () => {
+    const strings = new StringTable();
+    const builder = new EntityTableBuilder(1, strings);
+    builder.add(501, 'IFCWALL', '4aaCT2_$X3_xJG3rzD8L_8', 'Wall-Retyped', '', '', true, false);
+    const table = builder.build();
+
+    table.setTypeOverride(501, 'IFCBUILDINGSTOREY');
+
+    expect(isSpatialStructureTypeName(table.getTypeName(501))).toBe(true);
   });
 });


### PR DESCRIPTION
Closes #2224. All four items, plus one that turned out wider than described.

For the two tests that pass while permitting the bug they are named for, I proved the weakness before fixing it rather than assuming the review was right.

## 1. `cors_tests.rs` — the security test now means what its name says

`the_shipped_default_is_not_permissive` only asserted the allow-origin header was not the literal `*`.

Swapping the layer to `AllowOrigin::mirror_request()`, which reflects any origin back, left the OLD assertion **passing** — because the reflected value is `https://attacker.example`, which is indeed not `*`. A config granting an attacker cross-origin access sailed through a test promising it could not.

It now asserts the header is **empty** for an untrusted origin. Under the same mutation: `left: "https://attacker.example"`, `right: ""` — fails.

Still a weak test rather than a live hole, since the shipped default is a localhost allow-list. But as you said, it is a security test and should mean what it says.

## 2. `extract_file_tests.rs` — the zero-ceiling boundary

`a_zero_ceiling_rejects_any_payload` only asserted the reject half. Making `extract_file` return `FileTooLarge` on entering the field — rejecting everything — left the old test passing. It now also asserts an empty body is *admitted* under a zero ceiling, and that mutation fails on it.

## 3. `admission_tests.rs` — dropped the subsumed half

Removed the setter/getter round trip; the metrics body is the observable contract. Confirmed the remaining assertion still bites rather than deleting one and assuming: making `metrics_text` emit `0` instead of the real gauge fails it.

## 4. The retype casing — wider than the issue described

Root cause is as you diagnosed, and the fix belongs in `setTypeOverride`, not `isSpatialStructureTypeName` — the latter's case-sensitivity is deliberate and has its own test pinning it.

But `EntityTable` has **three independent implementations**, and all three stored the override verbatim: the columnar table (`packages/data/src/entity-table.ts:341`), the cache-restored table (`packages/cache/src/sections/entities.ts:182`), and the server-backed table (`apps/viewer/src/utils/serverDataModel.ts:402`).

Fixing only the first would have left the same retype behaving differently depending on whether the model came from a fresh parse, a cache restore, or the server — harder to diagnose than the uniform bug it replaced. All three now canonicalise identically, using the already-exported `IFC_ENTITY_NAMES`, so no new API is added. The changeset covers `@ifc-lite/data` **and** `@ifc-lite/cache` since both changed behaviour; `apps/viewer` is private.

RED-first here too: the new interop test fails `expected false to be true` against unmodified code.

## Verification

- `cargo test -p ifc-lite-server`: **193 passing**. Clippy clean with `--no-deps`, `Checking ifc-lite-server` confirmed present so it is not a cached pass.
- `@ifc-lite/data` 122 tests / 11 files; `@ifc-lite/cache` 58 / 8. Both green.
- `tsc --noEmit` clean for `packages/data`, `packages/cache` and `apps/viewer`.
- Every mutation applied with an asserted replacement count and the mutated line re-read; restores by file copy throughout.

## On the trigger for this issue

Worth recording: the hosted bot reported "Review limit reached" on most of that batch, which renders as a **green check with no review having happened**. That is the fourth distinct way a green signal has misled in this area lately — alongside running the wrong test runner (which prints nothing at all), a partial build making whole test files fail to load, and a stale workspace dep silently under-collecting a suite. A green check is evidence a job ran, not evidence it checked anything.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Retyped IFC entities now consistently recognize canonical PascalCase names across parsed, cached, server-backed, and viewer models.
  * Spatial structure checks correctly identify retyped entities regardless of the casing supplied.
  * Removing a type override continues to behave as expected.
  * Zero-byte files are accepted, while one-byte files are correctly rejected according to the configured limit.

* **Tests**
  * Expanded coverage for type override casing, metrics behavior, CORS security, and file-size boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->