### PR TITLE
fix(cache): bounds-check binary reads so truncated input fails diagnosably

### DIFF
--- a/.changeset/binary-cache-bounds-guard.md
+++ b/.changeset/binary-cache-bounds-guard.md
@@ -1,0 +1,11 @@
+---
+"@ifc-lite/cache": patch
+---
+
+Harden binary parsing against truncated/corrupt input so it fails with a diagnosable error instead of a raw engine `RangeError` ("Invalid typed array length" / offset-and-length-out-of-bounds).
+
+`BufferReader` (used by every `.ifc-lite` cache section reader — strings, entities, properties, quantities, relationships, entity index) now bounds-checks each read against the bytes actually remaining before touching the buffer. Previously `readBytes()` silently clamped via `Uint8Array.slice()` on a short buffer, and callers like `readUint32Array()` then constructed a typed array at the originally-requested element count against that shorter (copied) buffer — throwing a raw `RangeError` deep inside the engine instead of a message naming what ran short. This mirrors the guard `readInstancedShards` already hand-rolled for the same bug shape (#1238), generalized to every read.
+
+`parseGLBToMeshData`'s `readAccessorData` (GLB/binary-glTF import) now validates an accessor's declared byte range against the actual BIN chunk length before slicing/constructing typed arrays, for both the tightly-packed and strided read paths — a malformed or truncated `.glb` with an inflated `accessor.count` previously hit the same raw `RangeError` shape instead of a clear "accessor N reads bytes [...) but the BIN chunk is only M bytes" error.
+
+No change to well-formed input; both are purely defensive bounds checks on malformed/truncated data.

--- a/packages/cache/src/glb.test.ts
+++ b/packages/cache/src/glb.test.ts
@@ -212,6 +212,72 @@ describe('parseGLBToMeshData / loadGLBToMeshData — material colour round-trip'
   });
 });
 
+describe('parseGLBToMeshData — malformed accessor bounds (issue #2230 hunt)', () => {
+  /**
+   * Pins the `readAccessorData` bounds guard. `accessor.count` comes
+   * straight from the untrusted GLB JSON chunk; a hostile or truncated
+   * `.glb` can declare a POSITION accessor far larger than the actual BIN
+   * chunk. Before the guard, `bin.slice()` silently CLAMPED to the short
+   * buffer and the typed-array constructor that followed still requested
+   * the originally-declared element count against it — a raw
+   * `RangeError: Invalid typed array length` (the exact "range consisting
+   * of offset and length are out of bounds" crash shape) instead of a
+   * diagnosable error naming the accessor and the overrun.
+   */
+  it('throws a diagnosable error when a tightly-packed accessor.count overruns the BIN chunk', () => {
+    const doc = {
+      asset: { version: '2.0' },
+      scenes: [{ nodes: [0] }],
+      nodes: [{ mesh: 0 }],
+      meshes: [
+        {
+          primitives: [
+            { attributes: { POSITION: 0 } },
+          ],
+        },
+      ],
+      accessors: [
+        // Declares 10,000 VEC3 float verts (120,000 bytes) backed by a
+        // bufferView/BIN chunk that only actually holds 12 bytes (1 vert).
+        { bufferView: 0, byteOffset: 0, componentType: 5126, count: 10_000, type: 'VEC3' },
+      ],
+      bufferViews: [
+        { buffer: 0, byteOffset: 0, byteLength: 12, byteStride: 12, target: 34962 },
+      ],
+      buffers: [{ byteLength: 12 }],
+    };
+    const bin = new Uint8Array(12);
+
+    expect(() => parseGLBToMeshData(doc, bin)).toThrow(/accessor 0 reads bytes/);
+  });
+
+  it('throws a diagnosable error when a strided accessor.count overruns the BIN chunk', () => {
+    const doc = {
+      asset: { version: '2.0' },
+      scenes: [{ nodes: [0] }],
+      nodes: [{ mesh: 0 }],
+      meshes: [
+        {
+          primitives: [
+            { attributes: { POSITION: 0 } },
+          ],
+        },
+      ],
+      accessors: [
+        { bufferView: 0, byteOffset: 0, componentType: 5126, count: 10_000, type: 'VEC3' },
+      ],
+      bufferViews: [
+        // byteStride (16) != elementSize (12) forces the strided read path.
+        { buffer: 0, byteOffset: 0, byteLength: 16, byteStride: 16, target: 34962 },
+      ],
+      buffers: [{ byteLength: 16 }],
+    };
+    const bin = new Uint8Array(16);
+
+    expect(() => parseGLBToMeshData(doc, bin)).toThrow(/accessor 0 reads bytes/);
+  });
+});
+
 describe('parseGLB — SharedArrayBuffer-backed input', () => {
   // The viewer streams large imports (>= 256 MB) into a SharedArrayBuffer
   // (acquireFileBuffer). In a browser, `TextDecoder.decode` rejects any

--- a/packages/cache/src/glb.ts
+++ b/packages/cache/src/glb.ts
@@ -284,6 +284,27 @@ function readAccessorData(
 
   const bufferOffset = (bufferView.byteOffset ?? 0) + (accessor.byteOffset ?? 0);
 
+  // Bounds-check the full byte range this accessor claims against the actual
+  // BIN chunk BEFORE slicing/constructing anything. `accessor.count` /
+  // `byteOffset` come straight from the (untrusted) GLB JSON chunk; without
+  // this, `bin.slice()` below silently CLAMPS on a truncated/malformed BIN
+  // (fewer bytes than asked), and the typed-array constructor that follows
+  // still requests the ORIGINALLY declared element count against that
+  // shorter buffer — a raw `RangeError: Invalid typed array length` (or
+  // "range consisting of offset and length are out of bounds", depending on
+  // engine) escapes instead of a diagnosable domain error.
+  const neededBytes = byteStride === elementSize
+    ? accessor.count * elementSize
+    : accessor.count > 0
+      ? (accessor.count - 1) * byteStride + elementSize
+      : 0;
+  if (bufferOffset < 0 || neededBytes < 0 || bufferOffset + neededBytes > bin.byteLength) {
+    throw new Error(
+      `GLB: accessor ${accessorIdx} reads bytes [${bufferOffset}, ${bufferOffset + neededBytes}) ` +
+      `but the BIN chunk is only ${bin.byteLength} bytes`,
+    );
+  }
+
   // If data is tightly packed, we can use a view directly
   if (byteStride === elementSize) {
     const byteLength = accessor.count * elementSize;

--- a/packages/cache/src/utils/buffer-utils.test.ts
+++ b/packages/cache/src/utils/buffer-utils.test.ts
@@ -1,0 +1,68 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Pins `BufferReader`'s bounds guard (issue #2230 hunt): every scalar/array
+ * read must fail with a diagnosable `Error` when a truncated or corrupt
+ * buffer can't satisfy the requested length, rather than letting a raw
+ * engine `RangeError` ("Range consisting of offset and length are out of
+ * bounds" / "Invalid typed array length") escape from deep inside a typed
+ * array constructor. That raw-engine shape is exactly what happens when
+ * `readBytes` clamps via `Uint8Array.slice()` on a short buffer and a caller
+ * (e.g. `readUint32Array`) then constructs a typed array at the ORIGINALLY
+ * requested element count against the clamped (shorter) result buffer.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { BufferReader, BufferWriter } from './buffer-utils.js';
+
+describe('BufferReader bounds guard', () => {
+  it('readBytes throws a diagnosable error instead of silently clamping on a truncated buffer', () => {
+    const reader = new BufferReader(new Uint8Array([1, 2, 3]).buffer);
+    expect(() => reader.readBytes(10)).toThrow(/read past end of buffer/);
+  });
+
+  it('readUint32Array throws instead of hitting a raw "Invalid typed array length" RangeError', () => {
+    // 3 bytes available; asking for 10 uint32s (40 bytes) used to clamp
+    // readBytes(40) down to a 3-byte slice, then blow up constructing
+    // `new Uint32Array(slice.buffer, slice.byteOffset, 10)` against that
+    // 3-byte buffer with a raw engine RangeError.
+    const reader = new BufferReader(new Uint8Array([1, 2, 3]).buffer);
+    let threw: unknown;
+    try {
+      reader.readUint32Array(10);
+    } catch (e) {
+      threw = e;
+    }
+    expect(threw).toBeInstanceOf(Error);
+    expect((threw as Error).message).toMatch(/read past end of buffer/);
+    // Specifically NOT the raw engine message this bug used to produce.
+    expect((threw as Error).message).not.toMatch(/Invalid typed array length/);
+  });
+
+  it('readString throws cleanly when the declared length runs past the buffer', () => {
+    const writer = new BufferWriter();
+    writer.writeUint32(1000); // declared string byte length
+    writer.writeBytes(new Uint8Array([104, 105])); // only 2 bytes actually present
+    const reader = new BufferReader(writer.build());
+    expect(() => reader.readString()).toThrow(/read past end of buffer/);
+  });
+
+  it('readUint16/readUint32/readInt32/readBigUint64/readFloat32/readFloat64 all bounds-check', () => {
+    const empty = () => new BufferReader(new ArrayBuffer(0));
+    expect(() => empty().readUint16()).toThrow(/read past end of buffer/);
+    expect(() => empty().readUint32()).toThrow(/read past end of buffer/);
+    expect(() => empty().readInt32()).toThrow(/read past end of buffer/);
+    expect(() => empty().readBigUint64()).toThrow(/read past end of buffer/);
+    expect(() => empty().readFloat32()).toThrow(/read past end of buffer/);
+    expect(() => empty().readFloat64()).toThrow(/read past end of buffer/);
+  });
+
+  it('reads succeed normally when the buffer has enough bytes', () => {
+    const writer = new BufferWriter();
+    writer.writeUint32(0xdeadbeef);
+    const reader = new BufferReader(writer.build());
+    expect(reader.readUint32()).toBe(0xdeadbeef);
+  });
+});

--- a/packages/cache/src/utils/buffer-utils.ts
+++ b/packages/cache/src/utils/buffer-utils.ts
@@ -150,47 +150,78 @@ export class BufferReader {
     return this.bytes.length - this.offset;
   }
 
+  /**
+   * Bounds-check a read of `count` bytes at the current offset BEFORE it
+   * happens, and throw a diagnosable domain error instead of letting a
+   * truncated/corrupt buffer reach the engine.
+   *
+   * Without this, e.g. `readBytes(length)` on a truncated buffer silently
+   * clamps via `Uint8Array.slice()` (returning fewer bytes than asked), and
+   * a caller that then constructs a typed array of the ORIGINALLY requested
+   * element count (`readUint32Array` etc.) hits a raw
+   * `RangeError: Invalid typed array length` deep in the engine — the exact
+   * "range consisting of offset and length are out of bounds" crash shape.
+   * `readInstancedShards` (#1238) hand-rolled this same guard at one call
+   * site; every `BufferReader` read now gets it for free.
+   */
+  private ensureAvailable(count: number): void {
+    if (count > this.remaining) {
+      throw new Error(
+        `BufferReader: read past end of buffer (need ${count} bytes at offset ${this.offset}, ` +
+        `only ${this.remaining} remain)`,
+      );
+    }
+  }
+
   readUint8(): number {
+    this.ensureAvailable(1);
     return this.bytes[this.offset++];
   }
 
   readUint16(): number {
+    this.ensureAvailable(2);
     const value = this.view.getUint16(this.offset, true);
     this.offset += 2;
     return value;
   }
 
   readUint32(): number {
+    this.ensureAvailable(4);
     const value = this.view.getUint32(this.offset, true);
     this.offset += 4;
     return value;
   }
 
   readInt32(): number {
+    this.ensureAvailable(4);
     const value = this.view.getInt32(this.offset, true);
     this.offset += 4;
     return value;
   }
 
   readBigUint64(): bigint {
+    this.ensureAvailable(8);
     const value = this.view.getBigUint64(this.offset, true);
     this.offset += 8;
     return value;
   }
 
   readFloat32(): number {
+    this.ensureAvailable(4);
     const value = this.view.getFloat32(this.offset, true);
     this.offset += 4;
     return value;
   }
 
   readFloat64(): number {
+    this.ensureAvailable(8);
     const value = this.view.getFloat64(this.offset, true);
     this.offset += 8;
     return value;
   }
 
   readBytes(length: number): Uint8Array {
+    this.ensureAvailable(length);
     const slice = this.bytes.slice(this.offset, this.offset + length);
     this.offset += length;
     return slice;


### PR DESCRIPTION
Refs #2230.

**This does not claim to fix #2230.** That report is stackless, has no repro and no model, so the origin site is unprovable. What it does is close the two places where its exact shape — a length read *out of the data*, then used to construct an `ArrayBuffer` view — could escape as a raw engine error instead of something diagnosable.

## 1. `BufferReader` — every cache section reader

`packages/cache/src/utils/buffer-utils.ts`

`BufferReader` backs every `.ifc-lite` section reader: strings, entities, properties, quantities, relationships, entity index. `readBytes()` silently **clamped** via `Uint8Array.slice()` on a short buffer, and a caller like `readUint32Array(count)` then constructed a typed array at the *originally requested* element count against that shorter copy.

Observed on unmodified code:

```
readUint32Array(10) on a 3-byte buffer  → RangeError: Invalid typed array length: 10
readString(), declared length 1000 over 2 actual bytes → no throw at all, silent truncation
readUint16() on an empty buffer        → RangeError: Offset is outside the bounds of the DataView
```

Every read now bounds-checks first and throws `BufferReader: read past end of buffer (need N bytes at offset M, only R remain)`.

Worth noting: `readInstancedShards` already hand-rolled exactly this guard for #1238. The shape was known and fixed at one call site; it is now general.

## 2. `readAccessorData` — the GLB importer, reachable from a user action

`packages/cache/src/glb.ts`

`accessor.count` and `accessor.byteOffset` come straight from the untrusted GLB JSON chunk and were used with no check against the actual BIN length. Observed on unmodified code:

```
tightly-packed, count=10,000 VEC3 vs a 12-byte BIN → RangeError: Invalid typed array length: 30000
strided,        count=10,000 VEC3 vs a 16-byte BIN → RangeError: Offset is outside the bounds of the DataView
```

This one is reachable from an ordinary user action — opening a `.glb` in the viewer (`useIfcLoader.ts:850`) — where a truncated file put the raw engine message in front of the user *and* into `captureException`. Which is relevant to #2230: a **guarded-but-uninformative** failure still reaches PostHog through that hook's outer catch, so a report of this shape does not imply an unguarded site.

One upfront range check now covers both the tightly-packed and strided paths, using `(count - 1) * byteStride + elementSize` for the strided case so the last element's extent is accounted for rather than assuming `count * stride`.

## This makes corrupt input louder, not more fatal

Turning silent truncation into a throw is only an improvement if the caller handles it. `apps/viewer/src/hooks/useIfcCache.ts:416` already catches on the cache path and **deletes the corrupted entry**, so a truncated cache now degrades to a clean cache miss plus eviction, where before it produced a raw `RangeError`.

## Verification

- RED-first for both, and re-confirmed by hand rather than taken from the agent's report: removing the GLB guard makes the new tests fail with `Invalid typed array length: 30000` — the raw engine error — and restoring returns them to green.
- `packages/cache`: **65 passing / 9 files**. `apps/viewer`: **2926 passing / 2 skipped** across 633 suites (correct runner is `tsx --test`, not vitest). `tsc --noEmit` clean for both.
- Changeset: patch bump for `@ifc-lite/cache`.

## Audited and found already sound

Not everything needed fixing, and it is worth recording what did not: E57 page/packet decoding, LAS header and point decoding, the LAS streaming source (`Blob.slice` clamps rather than throwing), PCD binary and binary_compressed (which already has truncation *and* ratio guards), and the `.ifcZIP` unwrap (explicit uncompressed-size ceiling read from the central directory). Several of those carry comments referencing real prior user-file bugs — the guards are deliberate and already tested.

## Flagged, deliberately not fixed

`packages/geometry/src/packed-geometry-decoder.ts` and `packed-instanced-decoder.ts` have the identical unguarded shape, confirmed live in Node on a truncated payload. Both call sites (`native-bridge.ts:557,672`) wrap in try/catch routing to `onError`, and the path is Tauri-desktop only — not reachable from a browser file open. Raising it rather than widening this PR into a surface it cannot claim to have exercised.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of truncated or corrupt binary and GLB data.
  - Replaced low-level range errors with clear diagnostic messages identifying invalid reads or accessor bounds.
  - Preserved existing behavior for valid input.

- **Tests**
  - Added coverage for malformed accessor data and truncated scalar, array, byte, and string reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->