### PR TITLE
feat(export): expose spatial and type relationships

### DIFF
--- a/rust/export/src/ifc5.rs
+++ b/rust/export/src/ifc5.rs
@@ -7,7 +7,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use ifc_lite_core::{build_entity_index, EntityDecoder, EntityScanner};
+use ifc_lite_core::{build_entity_index, EntityDecoder};
 use serde_json::{json, Map, Value};
 
 use crate::json::typed_value;
@@ -67,51 +67,14 @@ fn prim_name(name: &str, fallback_type: &str, id: u32) -> String {
     format!("{out}_{id}")
 }
 
-/// Spatial parent→children edges from IfcRelAggregates + IfcRelContainedInSpatialStructure.
-/// Returns the edge map and the first `IfcProject` id. Shared with the CSV spatial export.
+/// Spatial parent→children edges plus the first `IfcProject`.
+///
+/// A shim over [`crate::relationships`], which resolves these in the same pass
+/// as the type edges. Kept because the three in-crate callers want only this
+/// pair. Shared with the CSV and USD spatial exports.
 pub(crate) fn spatial_children(content: &[u8]) -> (HashMap<u32, Vec<u32>>, Option<u32>) {
-    // Parallel on native (byte-identical to `build_entity_index`), serial on wasm.
-    let index = ifc_lite_processing::build_entity_index_parallel(content);
-    let mut decoder = EntityDecoder::with_index(content, index);
-    let mut children: HashMap<u32, Vec<u32>> = HashMap::new();
-    let mut project: Option<u32> = None;
-
-    let mut scanner = EntityScanner::new(content);
-    while let Some((id, type_name, start, end)) = scanner.next_entity() {
-        match type_name {
-            "IFCPROJECT" => project = project.or(Some(id)),
-            // IfcRelAggregates: RelatingObject(4), RelatedObjects(5, list)
-            "IFCRELAGGREGATES" => {
-                if let Ok(rel) = decoder.decode_at_with_id(id, start, end) {
-                    if let Some(parent) = rel.get(4).and_then(|a| a.as_entity_ref()) {
-                        if let Some(list) = rel.get(5).and_then(|a| a.as_list()) {
-                            for c in list {
-                                if let Some(cid) = c.as_entity_ref() {
-                                    children.entry(parent).or_default().push(cid);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            // IfcRelContainedInSpatialStructure: RelatedElements(4, list), RelatingStructure(5)
-            "IFCRELCONTAINEDINSPATIALSTRUCTURE" => {
-                if let Ok(rel) = decoder.decode_at_with_id(id, start, end) {
-                    if let Some(parent) = rel.get(5).and_then(|a| a.as_entity_ref()) {
-                        if let Some(list) = rel.get(4).and_then(|a| a.as_list()) {
-                            for c in list {
-                                if let Some(cid) = c.as_entity_ref() {
-                                    children.entry(parent).or_default().push(cid);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            _ => {}
-        }
-    }
-    (children, project)
+    let r = crate::relationships::relationships(content);
+    (r.spatial_children, r.project)
 }
 
 /// Decode the IfcProject node (id, name) — it is not an IfcProduct so the export

--- a/rust/export/src/lib.rs
+++ b/rust/export/src/lib.rs
@@ -23,6 +23,7 @@ mod kmz;
 mod merged;
 mod model;
 mod obj;
+mod relationships;
 mod openings;
 #[cfg(feature = "parquet-bos")]
 mod parquet_bos;
@@ -61,6 +62,9 @@ pub use ifc_lite_core::{AttributeValue, DecodedEntity, IfcType};
 // geometry exporters' output, which is normalised to metres.
 pub use ifc_lite_processing::prepass::UnitScales;
 pub use ifc5::{export_ifc5, Ifc5Options};
+// Spatial and type relationships, which `EntityRow` cannot carry because IFC
+// models them as separate entities that are not products.
+pub use relationships::{relationships, Relationships};
 pub use json::{export_json, JsonOptions};
 pub use jsonld::{export_jsonld, JsonLdOptions};
 pub use kmz::{

--- a/rust/export/src/relationships.rs
+++ b/rust/export/src/relationships.rs
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: MPL-2.0
+//! Connections IFC keeps in relationship entities rather than on the products.
+//!
+//! [`EntityRow`](crate::EntityRow) describes one product on its own: its class,
+//! identity, name, and the property and quantity sets attached to it. What it
+//! cannot describe is how products relate to each other, because IFC models
+//! those as separate objectified relationships (`IfcRelAggregates`,
+//! `IfcRelContainedInSpatialStructure`, `IfcRelDefinesByType`). Those are not
+//! products, so they never appear in the row stream, and a consumer that wants
+//! the spatial tree or an occurrence's type has nowhere to get it.
+//!
+//! This resolves all three in one scan. A caller that wants only the spatial
+//! half pays for the type half as well, which is one extra match arm over the
+//! same pass and cheaper than a second traversal.
+
+use std::collections::HashMap;
+
+use ifc_lite_core::{EntityDecoder, EntityScanner};
+
+/// Relationships resolved from one pass over the file.
+#[derive(Debug, Clone, Default)]
+pub struct Relationships {
+    /// Spatial parent to its children, from `IfcRelAggregates` and
+    /// `IfcRelContainedInSpatialStructure` together.
+    ///
+    /// Both are edges in the same tree: aggregation composes the spatial
+    /// structure (project to site to building to storey), containment attaches
+    /// elements to the storey that holds them. A consumer walking a hierarchy
+    /// wants them merged, which is why they are not reported separately.
+    pub spatial_children: HashMap<u32, Vec<u32>>,
+    /// The first `IfcProject`, which is the root of that tree. `None` for a file
+    /// that declares none, which is malformed but occurs.
+    pub project: Option<u32>,
+    /// An occurrence to the type object it is defined by, from
+    /// `IfcRelDefinesByType`.
+    ///
+    /// One type defines many occurrences, so the map is keyed by occurrence: it
+    /// answers "what is this?" for a product in hand, which is the direction a
+    /// consumer asks in.
+    pub type_of: HashMap<u32, u32>,
+}
+
+/// Resolve the relationships in `content`.
+///
+/// Malformed relationships are skipped rather than failing the scan: a file with
+/// one dangling reference still has a usable tree, and the alternative is
+/// returning nothing for a defect the caller cannot act on.
+pub fn relationships(content: &[u8]) -> Relationships {
+    // Parallel on native (byte-identical to `build_entity_index`), serial on wasm.
+    let index = ifc_lite_processing::build_entity_index_parallel(content);
+    let mut decoder = EntityDecoder::with_index(content, index);
+    let mut out = Relationships::default();
+
+    let mut scanner = EntityScanner::new(content);
+    while let Some((id, type_name, start, end)) = scanner.next_entity() {
+        match type_name {
+            "IFCPROJECT" => out.project = out.project.or(Some(id)),
+            // IfcRelAggregates: RelatingObject(4), RelatedObjects(5, list)
+            "IFCRELAGGREGATES" => {
+                if let Ok(rel) = decoder.decode_at_with_id(id, start, end) {
+                    if let Some(parent) = rel.get(4).and_then(|a| a.as_entity_ref()) {
+                        if let Some(list) = rel.get(5).and_then(|a| a.as_list()) {
+                            for c in list {
+                                if let Some(cid) = c.as_entity_ref() {
+                                    out.spatial_children.entry(parent).or_default().push(cid);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            // IfcRelContainedInSpatialStructure: RelatedElements(4, list), RelatingStructure(5)
+            "IFCRELCONTAINEDINSPATIALSTRUCTURE" => {
+                if let Ok(rel) = decoder.decode_at_with_id(id, start, end) {
+                    if let Some(parent) = rel.get(5).and_then(|a| a.as_entity_ref()) {
+                        if let Some(list) = rel.get(4).and_then(|a| a.as_list()) {
+                            for c in list {
+                                if let Some(cid) = c.as_entity_ref() {
+                                    out.spatial_children.entry(parent).or_default().push(cid);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            // IfcRelDefinesByType: RelatedObjects(4, list), RelatingType(5)
+            "IFCRELDEFINESBYTYPE" => {
+                if let Ok(rel) = decoder.decode_at_with_id(id, start, end) {
+                    if let Some(ty) = rel.get(5).and_then(|a| a.as_entity_ref()) {
+                        if let Some(list) = rel.get(4).and_then(|a| a.as_list()) {
+                            for o in list {
+                                if let Some(oid) = o.as_entity_ref() {
+                                    out.type_of.insert(oid, ty);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A project, a storey aggregated under it, a wall contained in the storey,
+    /// and a wall type defining that wall.
+    const FILE: &[u8] = br#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('rel.ifc','2026-01-01T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('p',$,'P',$,$,$,$,$,$);
+#2=IFCBUILDINGSTOREY('s',$,'S',$,$,$,$,$,.ELEMENT.,0.);
+#3=IFCWALL('w',$,'W',$,$,$,$,$,.STANDARD.);
+#4=IFCWALLTYPE('t',$,'T',$,$,$,$,$,$,.STANDARD.);
+#10=IFCRELAGGREGATES('a',$,$,$,#1,(#2));
+#11=IFCRELCONTAINEDINSPATIALSTRUCTURE('c',$,$,$,(#3),#2);
+#12=IFCRELDEFINESBYTYPE('d',$,$,$,(#3),#4);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+    #[test]
+    fn aggregation_and_containment_land_in_one_tree() {
+        let r = relationships(FILE);
+        assert_eq!(r.project, Some(1));
+        assert_eq!(r.spatial_children.get(&1).map(Vec::as_slice), Some(&[2u32][..]));
+        assert_eq!(r.spatial_children.get(&2).map(Vec::as_slice), Some(&[3u32][..]));
+    }
+
+    #[test]
+    fn an_occurrence_finds_its_type() {
+        let r = relationships(FILE);
+        assert_eq!(r.type_of.get(&3), Some(&4));
+        assert_eq!(
+            r.type_of.get(&4),
+            None,
+            "the map is keyed by occurrence, not by type"
+        );
+    }
+
+    /// A file with no relationships is empty, not a failure. Plenty of real
+    /// files carry only geometry.
+    #[test]
+    fn a_file_without_relationships_yields_nothing() {
+        let bare = br#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('b.ifc','2026-01-01T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCWALL('w',$,'W',$,$,$,$,$,.STANDARD.);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+        let r = relationships(bare);
+        assert!(r.spatial_children.is_empty());
+        assert!(r.type_of.is_empty());
+        assert_eq!(r.project, None);
+    }
+
+    /// A dangling reference must not take the rest of the tree with it.
+    #[test]
+    fn a_dangling_relationship_does_not_lose_the_others() {
+        let mut broken = String::from_utf8(FILE.to_vec()).expect("ascii");
+        // Point the containment at a storey that does not exist.
+        broken = broken.replace(
+            "#11=IFCRELCONTAINEDINSPATIALSTRUCTURE('c',$,$,$,(#3),#2);",
+            "#11=IFCRELCONTAINEDINSPATIALSTRUCTURE('c',$,$,$,(#3),#999);",
+        );
+        let r = relationships(broken.as_bytes());
+        assert_eq!(
+            r.spatial_children.get(&1).map(Vec::as_slice),
+            Some(&[2u32][..]),
+            "the aggregation edge is independent of the broken containment"
+        );
+        assert_eq!(r.type_of.get(&3), Some(&4));
+    }
+}


### PR DESCRIPTION
## Why

`EntityRow` describes one product on its own: class, identity, name, property and quantity sets. What it cannot describe is how products relate to each other, because IFC models those as objectified relationships (`IfcRelAggregates`, `IfcRelContainedInSpatialStructure`, `IfcRelDefinesByType`) which are not products and so never appear in the row stream.

A consumer wanting the spatial tree, or an occurrence's type object, had nowhere to get either.

## What

`relationships()` resolves all three in one pass:

- **`spatial_children`** merges `IfcRelAggregates` and `IfcRelContainedInSpatialStructure`. Both are edges in the same tree — aggregation composes project → site → building → storey, containment attaches elements to the storey holding them — and a caller walking a hierarchy wants them together, so they are not reported separately.
- **`project`**, the root of that tree.
- **`type_of`**, keyed by *occurrence* rather than by type, because that is the direction a consumer with a product in hand asks in.

## Not new code so much as promoted code

The spatial half already existed as a crate-private scan behind the IFC5, CSV and USD exports. It moves into the new module unchanged, and those three keep their shape through a thin shim, so there is one implementation rather than two.

The type half is one additional match arm over the same scan — cheaper than the second full traversal a separate entry point would cost. A caller wanting only the spatial half pays for the type half, which is the trade I took deliberately.

## Behaviour on malformed input

Malformed relationships are skipped rather than failing the scan. A file with one dangling reference still has a usable tree, and returning nothing hands the caller a defect it cannot act on. A test pins that a dangling containment does not take the aggregation edge with it.

## Verification

- `cargo clippy --workspace --exclude ifc-lite-wasm --all-targets -- -D warnings` clean
- `cargo test -p ifc-lite-export` — 159 passed
- Four new tests: merged tree, occurrence-to-type direction, a file with no relationships at all, and the dangling-reference case
- 187 lines, under the module-size ratchet
- No perf-sensitive path touched (`rust/export` is not in that list); the shared scan replaces an identical one, so the spatial callers do the same work as before