### PR TITLE
fix(repo): repair the vitest peer entry that breaks every release

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1215,7 +1215,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@26.1.2)(happy-dom@20.11.1)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@26.1.2)(happy-dom@20.11.1)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/pointcloud:
     dependencies:
@@ -1406,7 +1406,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@26.1.2)(happy-dom@20.11.1)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@26.1.2)(happy-dom@20.11.1)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/source-fixture:
     dependencies:
@@ -1419,7 +1419,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@26.1.2)(happy-dom@20.11.1)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@26.1.2)(happy-dom@20.11.1)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/spatial:
     dependencies:


### PR DESCRIPTION
## The failure

`Release` has failed on **every commit since #1976** (`c8f771ca`) — five consecutive runs. Last success was `d1ebcbe0` at 04:54Z today.

The failing step is `Install Dependencies`:

```
ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY  Broken lockfile: no entry for
'vitest@4.1.10(@edge-runtime/vm@3.2.0)(@types/node@26.1.2)(happy-dom@20.11.1)(vite@8.1.5(...))'
in pnpm-lock.yaml
```

(The `NODE_AUTH_TOKEN` line above it in the log is a `WARN` and a red herring — the install fails on the lockfile, not on auth.)

## The cause

Three importers record their `vitest` dev dependency against **`vite@8.1.5`**, while the lockfile's own `vitest` package entry is keyed on **`vite@8.2.0`**:

- `packages/plugin-api`
- `packages/source-dalux`
- `packages/source-fixture`

All three arrived with the recent sources work. A peer-keyed entry naming a version the lockfile does not contain resolves to nothing, so a frozen install cannot satisfy it. That is exactly the "badly resolved merge conflict" the error message guesses at.

## The fix

`pnpm install --no-frozen-lockfile`, which is what the error message itself prescribes. It comes to **three lines**: only the peer hash was wrong, no dependency actually moves.

## Why CI stayed green while releases burned

The test lanes install *without* `--frozen-lockfile`, so they silently repaired the entry in memory and never surfaced it. `Release` installs frozen, as a release should, and is the only lane that can see the problem.

Verified: `pnpm install --frozen-lockfile` completes cleanly on this branch and fails on `main`.