### PR TITLE
fix(deps): repair the lockfile the sources stack left broken on main

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1215,7 +1215,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@26.1.2)(happy-dom@20.11.1)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@26.1.2)(happy-dom@20.11.1)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/pointcloud:
     dependencies:
@@ -1406,7 +1406,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@26.1.2)(happy-dom@20.11.1)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@26.1.2)(happy-dom@20.11.1)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/source-fixture:
     dependencies:
@@ -1419,7 +1419,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@26.1.2)(happy-dom@20.11.1)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@26.1.2)(happy-dom@20.11.1)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/spatial:
     dependencies:


### PR DESCRIPTION
`pnpm install --frozen-lockfile` currently fails on `main`:

```
ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY  Broken lockfile: no entry for
'vitest@4.1.10(@edge-runtime/vm@3.2.0)(@types/node@26.1.2)(happy-dom@20.11.1)(vite@8.1.5(...))'
in pnpm-lock.yaml
```

CI and the Vercel deploys both run frozen installs, so this breaks both until it lands.

## Cause

`packages/plugin-api`, `packages/source-dalux` and `packages/source-fixture` were authored before the `vite@8.1.5 -> 8.2.0` bump reached main, so their lockfile importer entries pin `vitest` against the old vite. Squash-merging #1976 and #2023 brought those three stale entries onto a main that resolves 8.2.0, and pnpm has no entry for that combination. Three lines, one per new package — the diff is literally `8.1.5` to `8.2.0` three times.

This is the failure mode where the individual PRs are each fine and the *combination* is not: each branch's lockfile was self-consistent against its own base.

## Verification

- `pnpm install --frozen-lockfile` passes (it is the thing that was failing).
- `pnpm build` 43/43.
- `pnpm turbo test --force` 86/86 — forced, because a cached task would not prove the install works.
- `pnpm turbo typecheck --force` 36/36.

Caught by gating the five sources PRs as one integration branch before merging: the union failed the frozen install while every PR was individually green. The union warned about it; the sequential squash merges reproduced it on main.