### PR TITLE
fix(renderer): drop stale instanced bounds when a model's templates are freed

### DIFF
--- a/.changeset/instanced-templates-bbox-teardown.md
+++ b/.changeset/instanced-templates-bbox-teardown.md
@@ -1,0 +1,11 @@
+---
+"@ifc-lite/renderer": patch
+---
+
+Fix `Scene.removeInstancedTemplatesForModel` leaving stale cached bounding boxes behind (#2073).
+
+The method already freed a model's GPU-instanced templates and pruned `instancedEntityMap`, but never touched the `boundingBoxes` cache it also feeds. For an id whose occurrences were entirely in the removed model (instanced-only), the cached world AABB lingered after the geometry was gone, so `getEntityBoundingBox()` kept returning a box for nothing and the released-geometry bounding-box raycast could still pick an element with no remaining mesh. For an id shared across models (occurrences in more than one), the cached box is a union built at upload time, so pruning only the removed model's occurrences left the box sized for occurrences that no longer exist.
+
+An id that also owns flat (non-instanced) geometry is unaffected: that mixed case is owned by `removeMeshesForEntity`'s flat-removal path, which already clears the cache on its own schedule.
+
+`removeInstancedTemplatesForModel` has no caller yet (step 1 of the #2073/#1912 fix); this closes the gap before step 2 wires it up.

--- a/packages/renderer/src/scene-instanced-model-scope.test.ts
+++ b/packages/renderer/src/scene-instanced-model-scope.test.ts
@@ -382,3 +382,100 @@ describe('Scene.removeInstancedTemplatesForModel — entity bookkeeping', () => 
     assert.strictEqual(survivor.selectedCount, 1, 'model 7 still owns a selected occurrence');
   });
 });
+
+/**
+ * A single-occurrence shard with an explicit world translation, for tests that
+ * need distinguishable, non-overlapping world AABBs (the `shard()` helper above
+ * always starts each shard's template 0 at local translation (0,0,0), so two
+ * shards built with it collide in world space).
+ */
+function singleOccShard(entityId: number, tx: number): DecodedInstancedShard {
+  return {
+    templates: [{
+      positions: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+      normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+      indices: new Uint32Array([0, 1, 2]),
+      origin: [0, 0, 0] as [number, number, number],
+    }],
+    instances: [{
+      templateIndex: 0,
+      entityId,
+      color: [1, 1, 1, 1] as [number, number, number, number],
+      transform: rowMajorTranslation(tx, 0, 0),
+    }],
+  };
+}
+
+describe('Scene.removeInstancedTemplatesForModel — bounding-box teardown (#2073)', () => {
+  it('drops the cached world AABB for an instanced-only id once its last occurrence is freed', () => {
+    const { scene } = twoModelScene();
+    assert.ok(scene.getEntityBoundingBox(10), 'sanity: bbox is cached at upload time');
+
+    scene.removeInstancedTemplatesForModel(3);
+
+    assert.strictEqual(
+      scene.getEntityBoundingBox(10), null,
+      'id 10 has no geometry left anywhere (instanced-only, its model was freed); a stale bbox must not linger',
+    );
+  });
+
+  it('keeps the cached world AABB for a MIXED id (also owns flat geometry) — the flat-removal path owns that cache', () => {
+    const { scene } = twoModelScene();
+    // Simulate id 10 also owning dedicated flat geometry (a mixed id), without
+    // going through the full flat-mesh ingestion pipeline — only `meshDataMap`
+    // membership is what the mixed/instanced-only discriminator reads.
+    (scene as unknown as { meshDataMap: Map<number, unknown[]> }).meshDataMap.set(10, [{}]);
+    const before = scene.getEntityBoundingBox(10);
+    assert.ok(before);
+
+    scene.removeInstancedTemplatesForModel(3);
+
+    assert.strictEqual(
+      scene.getEntityBoundingBox(10), before,
+      'mixed id keeps its cached bbox after template teardown; removeMeshesForEntity owns clearing it',
+    );
+  });
+
+  it('recomputes a SHARED id\'s bounds from its surviving occurrences instead of leaving a stale union', () => {
+    const scene = new Scene();
+    const { device } = fakeDevice();
+    // Same express id, two models, non-overlapping world boxes so the stale
+    // union is trivially distinguishable from the recomputed (post-removal) box.
+    scene.addInstancedShard(device, singleOccShard(42, 0), 3);   // world x in [0, 1]
+    scene.addInstancedShard(device, singleOccShard(42, 10), 7);  // world x in [10, 11]
+    const unioned = scene.getEntityBoundingBox(42)!;
+    assert.strictEqual(unioned.min.x, 0, 'sanity: the union spans both occurrences');
+    assert.strictEqual(unioned.max.x, 11);
+
+    scene.removeInstancedTemplatesForModel(3);
+
+    const after = scene.getEntityBoundingBox(42);
+    assert.ok(after, 'id 42 is still instanced via model 7');
+    assert.strictEqual(after!.min.x, 10, 'bounds must shrink to the surviving occurrence, not keep model 3\'s stale extent');
+    assert.strictEqual(after!.max.x, 11);
+  });
+
+  it('an instanced-only id whose model was removed is not selectable via the released-geometry bbox raycast', () => {
+    const scene = new Scene();
+    const { device } = fakeDevice();
+    scene.addInstancedShard(device, singleOccShard(10, 0), 3);    // world x in [0, 1]
+    scene.addInstancedShard(device, singleOccShard(20, 100), 7);  // world x in [100, 101], well clear
+
+    // Sanity: before removal, the ray finds id 10. `addInstancedShard` folds the
+    // authored Z-up triangle into the Y-up render frame, so the triangle ends up
+    // flat in the y=0 plane, spanning x in [0,1] and z in [-1,0] — the ray must
+    // approach along y (not z) to cross that plane, landing at a point strictly
+    // inside the triangle (not on an edge, which the intersection test need not
+    // resolve).
+    const before = scene.raycast({ x: 0.3, y: 5, z: -0.3 }, { x: 0, y: -1, z: 0 });
+    assert.strictEqual(before?.expressId, 10);
+
+    scene.removeInstancedTemplatesForModel(3);
+    // Post-release, CPU raycast is bbox-only (`raycastBoundingBoxes`), reading
+    // straight from `boundingBoxes` — no GPU device needed for this path.
+    scene.releaseGeometryData();
+
+    const after = scene.raycast({ x: 0.3, y: 5, z: -0.3 }, { x: 0, y: -1, z: 0 });
+    assert.strictEqual(after, null, 'id 10 had geometry only in the removed model; no box should remain to hit');
+  });
+});

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -3002,9 +3002,18 @@ export class Scene {
    * with another model — the federated case before id offsetting — keep the
    * surviving model's occurrences.
    *
+   * `boundingBoxes` bookkeeping (#2073): an id that ALSO owns flat geometry is
+   * a mixed id — `removeMeshesForEntity` owns that cache, so it is left alone
+   * here even when the id's last instanced occurrence is pruned. An
+   * instanced-only id that loses its last occurrence has nothing left to keep
+   * a cached box for, so its entry is dropped — otherwise bbox-raycast and
+   * `getBounds()` (post geometry-release) keep finding/sizing an element that
+   * no longer has geometry. An id that keeps SOME occurrences (the shared,
+   * federated case) has its box recomputed from just the survivors, not left
+   * as the stale union that also covered the freed model's occurrences.
+   *
    * Returns the number of templates removed (0 for an unknown model, which is a
-   * no-op). Mirrors `removeInstancedEntity` in leaving `boundingBoxes` alone:
-   * an id can also own flat geometry, and the flat removal path owns that cache.
+   * no-op).
    */
   removeInstancedTemplatesForModel(modelIndex: number): number {
     const freed = new Set<number>();
@@ -3025,6 +3034,10 @@ export class Scene {
       if (kept.length === occurrences.length) continue;
       if (kept.length > 0) {
         this.instancedEntityMap.set(eid, kept);
+        // Shared id: some occurrences survive in another model. The cached box
+        // is a union that also covered the freed occurrences — recompute it
+        // from exactly the survivors rather than leave it oversized.
+        this.recomputeInstancedWorldAabb(eid, kept);
         continue;
       }
       // Last occurrence gone: the id is no longer instanced at all.
@@ -3032,6 +3045,12 @@ export class Scene {
       this.instancedSelected.delete(eid);
       this.instancedHidden.delete(eid);
       this.instancedOverridden.delete(eid);
+      // Only drop the cached box when the id has no flat geometry either — a
+      // mixed id's box is owned by the flat-removal path (removeMeshesForEntity),
+      // which clears it on its own schedule.
+      if (!this.meshDataMap.has(eid)) {
+        this.boundingBoxes.delete(eid);
+      }
     }
 
     this.refreshLiveInstancedTemplates();
@@ -3040,6 +3059,48 @@ export class Scene {
     this.lastInstancedVisibilityVersion = -1;
     this.instancedVisibilityDirty = true;
     return freed.size;
+  }
+
+  /**
+   * Recompute `boundingBoxes[eid]` from exactly `occurrences` (REPLACING any
+   * existing entry rather than unioning into it), reading each occurrence's
+   * template-local AABB + packed instance matrix the same way
+   * `unionInstancedWorldAabb` does at upload time. Used when a model-level
+   * template removal (`removeInstancedTemplatesForModel`) prunes some but not
+   * all of a shared id's occurrences — a plain union only ever grows, so it
+   * cannot shrink to reflect occurrences that no longer exist. Deletes the
+   * entry outright if no surviving occurrence has a finite local box (#2073).
+   */
+  private recomputeInstancedWorldAabb(eid: number, occurrences: InstancedOccurrence[]): void {
+    let minX = Infinity, minY = Infinity, minZ = Infinity;
+    let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
+    let any = false;
+    for (const occ of occurrences) {
+      const cpu = this.instancedTemplateCpu[occ.templateIndex];
+      if (!cpu || !Number.isFinite(cpu.localMin[0])) continue;
+      const dv = new DataView(cpu.instanceData);
+      const [lmnx, lmny, lmnz] = cpu.localMin;
+      const [lmxx, lmxy, lmxz] = cpu.localMax;
+      const b = occ.byteOffset;
+      const m0 = dv.getFloat32(b + 0, true), m1 = dv.getFloat32(b + 4, true), m2 = dv.getFloat32(b + 8, true);
+      const m4 = dv.getFloat32(b + 16, true), m5 = dv.getFloat32(b + 20, true), m6 = dv.getFloat32(b + 24, true);
+      const m8 = dv.getFloat32(b + 32, true), m9 = dv.getFloat32(b + 36, true), m10 = dv.getFloat32(b + 40, true);
+      const m12 = dv.getFloat32(b + 48, true), m13 = dv.getFloat32(b + 52, true), m14 = dv.getFloat32(b + 56, true);
+      for (let c = 0; c < 8; c++) {
+        const x = (c & 1) ? lmxx : lmnx, y = (c & 2) ? lmxy : lmny, z = (c & 4) ? lmxz : lmnz;
+        const wx = m0 * x + m4 * y + m8 * z + m12;
+        const wy = m1 * x + m5 * y + m9 * z + m13;
+        const wz = m2 * x + m6 * y + m10 * z + m14;
+        if (wx < minX) minX = wx; if (wy < minY) minY = wy; if (wz < minZ) minZ = wz;
+        if (wx > maxX) maxX = wx; if (wy > maxY) maxY = wy; if (wz > maxZ) maxZ = wz;
+      }
+      any = true;
+    }
+    if (any) {
+      this.boundingBoxes.set(eid, { min: { x: minX, y: minY, z: minZ }, max: { x: maxX, y: maxY, z: maxZ } });
+    } else {
+      this.boundingBoxes.delete(eid);
+    }
   }
 
   /**


### PR DESCRIPTION
Refs #2073 — the pre-step-2 pinning you asked for:

> Today this is unreachable (nothing calls the function), which is exactly why it needs pinning before step 2 wires it up.

## What was wrong

`removeInstancedTemplatesForModel` freed a model's buffers and pruned its occurrences but left `boundingBoxes` untouched. Right for one case, wrong for two:

| id kind | before | now |
|---|---|---|
| **mixed** (also owns flat geometry) | left alone | left alone — the flat path owns that cache |
| **instanced-only**, last occurrence gone | kept a stale world AABB | entry dropped |
| **shared**, occurrences survive elsewhere | kept bounds covering the freed model | recomputed from survivors |

The instanced-only case is the one you named: `raycastBoundingBoxes` could still pick an element with no geometry left anywhere, and `getBounds()` kept sizing for it after geometry release.

The shared case matters for the same reason and could not fix itself: `boundingBoxes` for instanced ids is a running union built at upload time by `unionInstancedWorldAabb` (`scene.ts:3216-3248`) that **only ever grows**. After a partial prune it is provably oversized, generating false hits in the space the freed model vacated.

## The discriminator

There was no existing way to tell instanced-only from mixed. The only available signal is `meshDataMap.has(eid)` — true means the id also owns flat geometry. That is what gates the delete. Flagging it explicitly because inventing a wrong discriminator here was the main risk.

`getBounds()` (`scene.ts:3762-3822`) derives the union on demand from `boundingBoxes` rather than caching it separately, so pruning the map is sufficient — there is no second cache to invalidate.

## One correction to the premise

The old doc comment — and your note — said this *"mirrors `removeInstancedEntity` in leaving `boundingBoxes` alone"*. It doesn't: `removeInstancedEntity` **does** `boundingBoxes.delete(expressId)` at `scene.ts:1367`.

It's harmless there only because both of its call sites (`:1267`, `:1336`) sit inside `removeMeshesForEntity`, which already deleted the entry itself at `:1263` — so that delete is *redundant, not absent*. Your actual point stands entirely; only the comparison was off. Comment corrected rather than implemented around.

## Verification

RED first, against unmodified `main` — three of the four new tests fail, and the fourth (the mixed-id case) passes because it was already correct:

```
not ok 1 - drops the cached world AABB for an instanced-only id once its last occurrence is freed
          actual: { min: {x:0,y:0,z:-1}, max: {x:1,y:0,z:0} }  expected: null
not ok 3 - recomputes a SHARED id's bounds from its surviving occurrences instead of leaving a stale union
          0 !== 10
not ok 4 - an instanced-only id whose model was removed is not selectable via the released-geometry bbox raycast
          actual: { expressId: 10, distance: 5 }  expected: null
```

I re-ran this by hand after the agent's run rather than relying on the report: reverting both hunks gives 21 pass / 3 fail, restoring gives 24 / 0.

The raycast consequence you named **is** testable headlessly — `raycastBoundingBoxes` (`scene-raycaster.ts:318`) is a pure function over the map, reached via `scene.raycast()` once `releaseGeometryData()` puts it on the bbox-only path. No GPU device needed.

- Renderer suite: **449 passing across 39 files**, `tsc --noEmit` clean.
- `getResidentGpuBytes()` exactness unchanged — still covered by the existing GPU-byte-accounting suite.
- Changeset: patch bump for `@ifc-lite/renderer`.

## Still step 2's job

This is only the first of the two things you listed. The federated path still drops instanced-only shards — `addInstancedShard` takes an owning `modelIndex`, but finalization does not forward secondary models' shards — which remains the substance of step 2 and #1912.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stale bounding boxes after removing instanced model templates.
  * Updated bounds for shared entities that still have active instances.
  * Prevented released instanced-only entities from appearing in bounding-box raycasts.
  * Preserved correct bounds for entities containing both flat and instanced geometry.

* **Tests**
  * Added coverage for bounding-box cleanup, recomputation, preservation, and raycast behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->