### PR TITLE
fix(viewer): tell the user to reload when the script sandbox has aborted

### DIFF
--- a/apps/viewer/src/hooks/useSandbox.ts
+++ b/apps/viewer/src/hooks/useSandbox.ts
@@ -20,6 +20,7 @@ import {
   formatDiagnosticsForDisplay,
   type RuntimeScriptDiagnostic,
 } from '../lib/llm/script-diagnostics.js';
+import { describeSandboxAbort } from '../lib/sandboxAbort.js';
 
 /**
  * Tear a sandbox down without letting a teardown failure escape.
@@ -181,7 +182,17 @@ export function useSandbox(config?: SandboxConfig) {
     let sandbox: Sandbox | null = null;
     try {
       // Create a fresh sandbox for every execution — full isolation
-      const { createSandbox } = await import('@ifc-lite/sandbox');
+      const { createSandbox, isSandboxRuntimeAborted } = await import('@ifc-lite/sandbox');
+
+      // The shared QuickJS WASM module is dead for the rest of the document
+      // once a teardown abort has latched (#1922) — fail fast instead of
+      // creating a sandbox that cannot tear down cleanly either.
+      const abortedBeforeAttempt = describeSandboxAbort(isSandboxRuntimeAborted());
+      if (abortedBeforeAttempt) {
+        setError(abortedBeforeAttempt);
+        return null;
+      }
+
       sandbox = await createSandbox(bim, {
         permissions: { model: true, query: true, viewer: true, mutate: true, store: true, lens: true, export: true, files: true, ...config?.permissions },
         limits: { timeoutMs: 30_000, ...config?.limits },
@@ -200,6 +211,16 @@ export function useSandbox(config?: SandboxConfig) {
       useViewerStore.getState().bumpScriptRunSeq();
       return result;
     } catch (err: unknown) {
+      // A dispose() thrown from a prior run's teardown latches the runtime as
+      // aborted (#1922); a SandboxAbortError surfacing here means this very
+      // attempt hit it. Either way the fix is "reload", not the generic
+      // script-error diagnostics below.
+      const abortMessage = describeSandboxAbort(false, err);
+      if (abortMessage) {
+        setError(abortMessage);
+        return null;
+      }
+
       const runtime = augmentScriptError(err instanceof Error ? err.message : String(err), code);
 
       // If the error is a ScriptError with captured logs, preserve them.

--- a/apps/viewer/src/lib/sandboxAbort.test.ts
+++ b/apps/viewer/src/lib/sandboxAbort.test.ts
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Reactive half of #1922 containment: the app must actually read the latch
+ * (`isSandboxRuntimeAborted()`) and a caught `SandboxAbortError`, and turn
+ * either into the "reload the page" message — not a generic script error.
+ *
+ * `describeSandboxAbort` takes the aborted flag as a plain boolean rather
+ * than reading `isSandboxRuntimeAborted()` itself, so these tests set the
+ * latched state up directly instead of reproducing the upstream OOM.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { SandboxAbortError } from '@ifc-lite/sandbox';
+import { describeSandboxAbort, SANDBOX_ABORT_RELOAD_MESSAGE } from './sandboxAbort.js';
+
+describe('describeSandboxAbort', () => {
+  it('returns the reload message when the runtime is already latched aborted, before any attempt', () => {
+    assert.equal(describeSandboxAbort(true), SANDBOX_ABORT_RELOAD_MESSAGE);
+  });
+
+  it('returns the reload message for a SandboxAbortError caught mid-attempt, even if not latched going in', () => {
+    const err = new SandboxAbortError(new Error('Aborted(Assertion failed: list_empty(&rt->gc_obj_list))'));
+    assert.equal(describeSandboxAbort(false, err), SANDBOX_ABORT_RELOAD_MESSAGE);
+  });
+
+  it('leaves an ordinary script error alone on a healthy runtime', () => {
+    assert.equal(
+      describeSandboxAbort(false, new Error("'foo' is not defined")),
+      null,
+    );
+  });
+});

--- a/apps/viewer/src/lib/sandboxAbort.ts
+++ b/apps/viewer/src/lib/sandboxAbort.ts
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Turns the process-wide QuickJS teardown abort (`@ifc-lite/sandbox`'s
+ * `isSandboxRuntimeAborted()` / `SandboxAbortError`, ifc-lite#1922) into a
+ * user-facing message.
+ *
+ * Containment in `@ifc-lite/sandbox` names the failure and latches it so it
+ * is observable after the first occurrence, but nothing that latch is
+ * connected to anything: every sandbox call site (`useSandbox.ts`, the
+ * extension host's `sandbox-factory.ts`) either attempted an eval that could
+ * not succeed, or reported the crash as a generic script error with no
+ * mention that a reload is the only way out. This is the piece that reads
+ * the flag.
+ *
+ * `aborted` is a plain boolean, not read from `isSandboxRuntimeAborted()` in
+ * here, so callers set it up directly (real latch or a fabricated `true`)
+ * without needing to reproduce the upstream OOM to exercise this logic.
+ */
+
+import { SandboxAbortError } from '@ifc-lite/sandbox';
+
+export const SANDBOX_ABORT_RELOAD_MESSAGE =
+  'The script sandbox has crashed and can no longer run scripts (quickjs-emscripten ' +
+  'teardown abort, ifc-lite#1922). Reload the page to restore it.';
+
+/**
+ * Decide whether a sandbox failure — or an attempt about to be made — should
+ * be reported as "reload the page" rather than as an ordinary script error.
+ *
+ * @param aborted Whether the shared QuickJS runtime is already known to be
+ *   aborted, checked *before* attempting the operation so a doomed attempt
+ *   is never made.
+ * @param err The error caught from the attempt, if any. Recognised even when
+ *   `aborted` was false going in, since `dispose()` throws `SandboxAbortError`
+ *   at the moment the abort is discovered.
+ * @returns The reload message, or `null` if this is an ordinary failure.
+ */
+export function describeSandboxAbort(aborted: boolean, err?: unknown): string | null {
+  if (aborted || err instanceof SandboxAbortError) {
+    return SANDBOX_ABORT_RELOAD_MESSAGE;
+  }
+  return null;
+}

--- a/apps/viewer/src/services/extensions/sandbox-factory.test.ts
+++ b/apps/viewer/src/services/extensions/sandbox-factory.test.ts
@@ -1,0 +1,62 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The extension host's sandbox handle must read #1922 containment too — see
+ * `../../lib/sandboxAbort.test.ts` for the pure decision logic. This pins the
+ * wiring: `run()` turns a caught `SandboxAbortError` into the reload
+ * message instead of passing the raw teardown-abort text through.
+ *
+ * `sandbox.eval` is faked to throw directly — no WASM, no real OOM — so this
+ * is about how `BimSandboxHandle.run()` reacts to the latched failure, not
+ * about reproducing the upstream abort.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import type { Sandbox } from '@ifc-lite/sandbox';
+import { SandboxAbortError } from '@ifc-lite/sandbox';
+import { SANDBOX_ABORT_RELOAD_MESSAGE } from '../../lib/sandboxAbort.js';
+import { BimSandboxHandle } from './sandbox-factory.js';
+
+function fakeSandbox(evalImpl: () => Promise<never>): Sandbox {
+  return {
+    eval: evalImpl,
+    dispose: () => {},
+  } as unknown as Sandbox;
+}
+
+describe('BimSandboxHandle.run', () => {
+  it('reports the reload message when eval() throws SandboxAbortError, not the raw teardown text', async () => {
+    const sandbox = fakeSandbox(async () => {
+      throw new SandboxAbortError(new Error('Aborted(Assertion failed: list_empty(&rt->gc_obj_list))'));
+    });
+    const handle = new BimSandboxHandle(sandbox);
+
+    await assert.rejects(
+      () => handle.run('1 + 1'),
+      (err: unknown) => {
+        assert.ok(err instanceof Error);
+        assert.equal(err.message, SANDBOX_ABORT_RELOAD_MESSAGE);
+        return true;
+      },
+    );
+  });
+
+  it('leaves an ordinary eval failure untouched', async () => {
+    const sandbox = fakeSandbox(async () => {
+      throw new Error("'foo' is not defined");
+    });
+    const handle = new BimSandboxHandle(sandbox);
+
+    await assert.rejects(
+      () => handle.run('foo'),
+      (err: unknown) => {
+        assert.ok(err instanceof Error);
+        assert.equal(err.message, "'foo' is not defined");
+        return true;
+      },
+    );
+  });
+});

--- a/apps/viewer/src/services/extensions/sandbox-factory.ts
+++ b/apps/viewer/src/services/extensions/sandbox-factory.ts
@@ -34,8 +34,9 @@ import {
   type RuntimeSandboxFactory,
   type RuntimeSandboxHandle,
 } from '@ifc-lite/extensions';
-import { createSandbox, type Sandbox } from '@ifc-lite/sandbox';
+import { createSandbox, isSandboxRuntimeAborted, type Sandbox } from '@ifc-lite/sandbox';
 import type { BimContext } from '@ifc-lite/sdk';
+import { describeSandboxAbort } from '../../lib/sandboxAbort.js';
 
 export interface SandboxFactoryOptions {
   sdk: BimContext;
@@ -117,7 +118,8 @@ function wrapWithCapabilityGate(
   }) as unknown as BimContext;
 }
 
-class BimSandboxHandle implements RuntimeSandboxHandle {
+/** Exported for tests — production callers only reach it via `create()`. */
+export class BimSandboxHandle implements RuntimeSandboxHandle {
   /**
    * Globals pre-defined for the next `run`, keyed by name so re-setting
    * a global REPLACES its assignment instead of appending a duplicate.
@@ -159,12 +161,29 @@ class BimSandboxHandle implements RuntimeSandboxHandle {
 
   async run(source: string, _opts?: RuntimeRunOptions): Promise<RuntimeRunResult> {
     if (this.disposed) throw new Error('Sandbox disposed.');
+
+    // The shared QuickJS WASM module is dead for the rest of the document
+    // once a teardown abort has latched (#1922) — fail fast instead of
+    // running an extension against a module that cannot tear down cleanly.
+    const abortedBeforeAttempt = describeSandboxAbort(isSandboxRuntimeAborted());
+    if (abortedBeforeAttempt) {
+      throw new Error(abortedBeforeAttempt);
+    }
+
     const prelude = [...this.globals.values()].join('\n');
     const wrapped = prelude ? `${prelude}\n${source}` : source;
     let result;
     try {
       result = await this.sandbox.eval(wrapped, { typescript: false });
     } catch (err) {
+      // A SandboxAbortError here means this attempt hit the #1922 teardown
+      // abort (or a prior run's dispose() already latched it). Reload is the
+      // only remedy, so say that instead of the generic passthrough below.
+      const abortMessage = describeSandboxAbort(false, err);
+      if (abortMessage) {
+        throw new Error(abortMessage);
+      }
+
       // QuickJS throws "Lifetime not alive" (QuickJSUseAfterFree) when
       // a handle is touched after its underlying realm was disposed —
       // typically because a prior run / flavor switch tore down this


### PR DESCRIPTION
Refs #1922 — the second loose end you named:

> `SandboxAbortError` and `isSandboxRuntimeAborted` are exported and in `api-surface.json`, but **nothing in `apps/viewer` or the extension host reads the flag** to prompt a reload. So the user-visible symptom in this issue — the sandbox is unusable until reload — is unchanged; only the error message improved.

This does not touch the upstream defect, which is still live and still not ours. It closes the gap between the containment that landed in #2062/#2170 and anything actually consuming it.

## What was happening

Once the teardown abort fires, the shared QuickJS WASM module is dead for the rest of the document — so a reload is the only remedy. Neither entry point said so:

- **`useSandbox.ts`** — `disposeSandbox()` caught dispose failures and only `console.error`'d them, so a `SandboxAbortError` raised from teardown never reached the UI at all. Subsequent runs then failed with whatever generic error a doomed `eval()`/`createSandbox()` produced, routed through `augmentScriptError()`, which had no case for it.
- **`sandbox-factory.ts`** — `BimSandboxHandle.run()` special-cased only `"Lifetime not alive"` (an unrelated failure). A `SandboxAbortError` fell straight through as raw emscripten teardown text.

## What changed

Both sites now read the latch in two places:

1. **Before attempting** — `isSandboxRuntimeAborted()` is checked up front, so no eval is started against a module that cannot succeed.
2. **In the catch** — a `SandboxAbortError` is recognised on the run that first discovers the abort.

The message goes through the **existing** `scriptLastError` store (`scriptSlice.ts`), already rendered inline by `ScriptPanel.tsx` and `ChatPanel.tsx` / `ExecutableCodeBlock.tsx` for every other script failure. No new UI primitive, no `alert`/`confirm`. The extension host throws with the same actionable message, matching how its existing error paths behave.

## The test design deliberately mirrors yours

You flagged that the existing tests assert **containment, never absence** — `oom-job-dispose.test.ts:64-95` wraps its assertion in `if (caught !== undefined)` precisely so an upstream fix would not fail the file.

I kept that property. The decision is a pure helper that takes `aborted` as a plain boolean rather than reading the latch itself:

```ts
export function describeSandboxAbort(aborted: boolean, err?: unknown): string | null {
  if (aborted || err instanceof SandboxAbortError) return SANDBOX_ABORT_RELOAD_MESSAGE;
  return null;
}
```

So the tests set the condition up directly and never reproduce the upstream OOM. If quickjs-emscripten ever fixes the abort, nothing here breaks — the wiring simply stops being reached.

## Verification

RED-first, and re-confirmed by hand rather than taken from the agent's report: removing the catch-block wiring fails the new test with the raw `"QuickJS aborted while freeing the sandbox runtime…"` text where the reload message was expected. 1 replacement, count asserted; restoring returns it to green (1 pass / 1 fail → 2 / 0).

- `apps/viewer`: **3038 passing / 2 skipped**, 0 failing. `packages/sandbox`: 121 across 20 files.
- `tsc --noEmit` clean, full output read.
- `check-api-surface.mjs`: 4043 exports, matches snapshot. No published package touched — `apps/viewer` is private, so no changeset.
- `BimSandboxHandle` gained an `export` so the test can construct it; noted in a comment, and it does not reach a package entry.

## Deliberately not included

Surfacing the message on the very run whose **own** teardown latches the flag. That run's `eval()` has already resolved successfully by the time `dispose()` throws in `finally`, so covering it means reworking the success/error sequencing rather than just reading the flag. Out of scope for "read the flag, tell the user" — raising it rather than quietly widening.

## Still open on the issue

The upstream filing against quickjs-emscripten. There is still no linked issue, and that remains the actual fix path — this PR only stops the failure being silent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of sandbox runtime failures.
  * Displays clear reload guidance when the sandbox has been aborted or encounters an abort-related error.
  * Preserves specific error messages for ordinary script failures and invalid sandbox usage.
* **Tests**
  * Added coverage for aborted runtimes, abort-related errors, and standard script errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->