### PR TITLE
fix(data): cap the safeUtf8Decode scratch so one giant decode cannot pin memory (#2183)

### DIFF
--- a/.changeset/olive-donkeys-tap.md
+++ b/.changeset/olive-donkeys-tap.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/data": patch
+---
+
+Cap the `safeUtf8Decode` scratch buffer so a one-off whole-file decode can no longer pin memory for the lifetime of the realm.
+
+The scratch grew by doubling to the largest subarray ever decoded and was never released. That is the right trade for the 50-500 byte per-entity reads the helper was written for, but a single whole-source decode pushed it to the next power of two above the file size and kept it there: a 342 MB model pinned 512 MB, measured as 30% of the viewer's main-thread heap (#2183).
+
+Decodes at or under 4 MiB keep the existing reused buffer unchanged. Larger ones now get a throwaway buffer, since reuse only pays off for a buffer that is hit repeatedly and a one-off giant decode never is.

--- a/.changeset/olive-donkeys-tap.md
+++ b/.changeset/olive-donkeys-tap.md
@@ -2,7 +2,7 @@
 "@ifc-lite/data": patch
 ---
 
-Cap the `safeUtf8Decode` scratch buffer so a one-off whole-file decode can no longer pin memory for the lifetime of the realm.
+Cap the `safeUtf8Decode` scratch buffer so an oversized one-off decode no longer retains its full allocation for the lifetime of the realm.
 
 The scratch grew by doubling to the largest subarray ever decoded and was never released. That is the right trade for the 50-500 byte per-entity reads the helper was written for, but a single whole-source decode pushed it to the next power of two above the file size and kept it there: a 342 MB model pinned 512 MB, measured as 30% of the viewer's main-thread heap (#2183).
 

--- a/apps/viewer/src/hooks/useIfcFederation.ts
+++ b/apps/viewer/src/hooks/useIfcFederation.ts
@@ -539,8 +539,10 @@ export function useIfcFederation(
 
     // Check that all files are IFCX format and read buffers.
     // IFCX is JSON; SAB streaming would force a SAB→scratch copy in
-    // safeUtf8Decode + retain the scratch (net worse peak than ArrayBuffer).
-    // Keep on file.arrayBuffer().
+    // safeUtf8Decode on top of the JSON string (net worse peak than
+    // ArrayBuffer). Keep on file.arrayBuffer(). The copy is no longer
+    // *retained* since #2183 capped the scratch, but it is still a
+    // full-file transient the ArrayBuffer path does not pay.
     const buffers: Array<{ buffer: ArrayBuffer; name: string }> = [];
     for (const file of files) {
       const buffer = await file.arrayBuffer();
@@ -596,8 +598,10 @@ export function useIfcFederation(
 
     // Read new overlay buffers.
     // IFCX is JSON; SAB streaming would force a SAB→scratch copy in
-    // safeUtf8Decode + retain the scratch (net worse peak than ArrayBuffer).
-    // Keep on file.arrayBuffer().
+    // safeUtf8Decode on top of the JSON string (net worse peak than
+    // ArrayBuffer). Keep on file.arrayBuffer(). The copy is no longer
+    // *retained* since #2183 capped the scratch, but it is still a
+    // full-file transient the ArrayBuffer path does not pay.
     const newBuffers: Array<{ buffer: ArrayBuffer; name: string }> = [];
     for (const file of files) {
       const buffer = await file.arrayBuffer();

--- a/apps/viewer/src/utils/acquireFileBuffer.test.ts
+++ b/apps/viewer/src/utils/acquireFileBuffer.test.ts
@@ -157,9 +157,13 @@ describe('acquireFileBuffer', () => {
     //   parseFederatedIfcx → safeUtf8Decode(new Uint8Array(buffer)) → JSON.parse
     // safeUtf8Decode must copy SAB-backed views into a scratch buffer in
     // Chromium/Firefox (cross-thread JS string decoding cannot read SAB
-    // directly) and retains that scratch. Net peak with SAB streaming:
+    // directly). Net peak with SAB streaming:
     //   SAB (file.size) + scratch copy (file.size) + JSON string (~file.size)
-    //   + retained scratch — strictly worse than the plain ArrayBuffer path.
+    //   — strictly worse than the plain ArrayBuffer path.
+    // Since #2183 that copy is a throwaway rather than a retained buffer
+    // (any IFCX big enough to stream to SAB is far above the 4 MiB retention
+    // cap), so the peak is lower than it was — but still worse than not
+    // copying at all, which is why this guard stands.
     //
     // This is a source-level guard: it ensures the two IFCX entry points in
     // useIfcFederation.ts (loadFederatedIfcx + addIfcxOverlays) stay on

--- a/packages/data/src/utf8-decode.test.ts
+++ b/packages/data/src/utf8-decode.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest';
 import {
   __resetSabDecodeCache,
   __resetScratchBuffer,
+  __retainedScratchAllocations,
   __retainedScratchBytes,
   safeUtf8Decode,
   textDecoderAcceptsSab,
@@ -140,6 +141,9 @@ describe('safeUtf8Decode scratch retention', () => {
       const oversized = MAX_RETAINED_SCRATCH_BYTES + 1;
       const view = sabOfSize(oversized);
       expect(safeUtf8Decode(view).length).toBe(oversized);
+      // Without this the assertion below also passes when the copy path was
+      // never taken at all, i.e. when the SAB-rejection mock failed to engage.
+      expect(textDecoderAcceptsSab()).toBe(false);
       expect(__retainedScratchBytes()).toBe(0);
     } finally {
       restore();
@@ -171,10 +175,36 @@ describe('safeUtf8Decode scratch retention', () => {
     const restore = forceScratchCopyPath();
     try {
       expect(safeUtf8Decode(sabOfSize(8)).length).toBe(8);
+      expect(textDecoderAcceptsSab()).toBe(false);
       const before = __retainedScratchBytes();
+      const allocsBefore = __retainedScratchAllocations();
       expect(safeUtf8Decode(sabOfSize(MAX_RETAINED_SCRATCH_BYTES + 1)).length)
         .toBe(MAX_RETAINED_SCRATCH_BYTES + 1);
       expect(__retainedScratchBytes()).toBe(before);
+      expect(__retainedScratchAllocations()).toBe(allocsBefore);
+    } finally {
+      restore();
+    }
+  });
+
+  // The retained path exists so the millions of 50-500 byte per-entity decodes
+  // share one buffer. Size alone cannot tell reuse from "allocate a
+  // correctly-sized buffer every call", so assert the allocation count.
+  it('reuses a single buffer across repeated small decodes', () => {
+    if (typeof SharedArrayBuffer === 'undefined') return;
+    const restore = forceScratchCopyPath();
+    try {
+      expect(safeUtf8Decode(sabOfSize(512)).length).toBe(512);
+      expect(textDecoderAcceptsSab()).toBe(false);
+      expect(__retainedScratchAllocations()).toBe(1);
+      for (const size of [256, 512, 128, 1024, 64]) {
+        expect(safeUtf8Decode(sabOfSize(size)).length).toBe(size);
+      }
+      expect(__retainedScratchAllocations()).toBe(1, 'every decode fits the first buffer');
+      // Growing past it costs exactly one more allocation, not one per call.
+      expect(safeUtf8Decode(sabOfSize(9000)).length).toBe(9000);
+      expect(safeUtf8Decode(sabOfSize(9000)).length).toBe(9000);
+      expect(__retainedScratchAllocations()).toBe(2);
     } finally {
       restore();
     }

--- a/packages/data/src/utf8-decode.test.ts
+++ b/packages/data/src/utf8-decode.test.ts
@@ -5,9 +5,50 @@
 import { describe, expect, it } from 'vitest';
 import {
   __resetSabDecodeCache,
+  __resetScratchBuffer,
+  __retainedScratchBytes,
   safeUtf8Decode,
   textDecoderAcceptsSab,
 } from './utf8-decode.js';
+
+/** Mirrors `MAX_RETAINED_SCRATCH_BYTES` in the module under test. */
+const MAX_RETAINED_SCRATCH_BYTES = 4 * 1024 * 1024;
+
+/**
+ * Force the SAB-copy path by making `TextDecoder.decode` reject the first
+ * SAB-backed view it sees, which poisons the acceptance cache. Returns a
+ * cleanup that restores the real decoder and both caches.
+ */
+function forceScratchCopyPath(): () => void {
+  __resetSabDecodeCache();
+  __resetScratchBuffer();
+  const realDecode = TextDecoder.prototype.decode;
+  let rejectedOnce = false;
+  TextDecoder.prototype.decode = function (
+    this: TextDecoder,
+    input?: BufferSource,
+    ...rest: unknown[]
+  ): string {
+    const buf = (input as { buffer?: ArrayBufferLike } | undefined)?.buffer ?? input;
+    if (!rejectedOnce && buf instanceof SharedArrayBuffer) {
+      rejectedOnce = true;
+      throw new TypeError('TextDecoder.decode: cannot decode SharedArrayBuffer');
+    }
+    return realDecode.apply(this, [input as BufferSource, ...(rest as never[])]);
+  } as typeof realDecode;
+  return () => {
+    TextDecoder.prototype.decode = realDecode;
+    __resetSabDecodeCache();
+    __resetScratchBuffer();
+  };
+}
+
+/** A SAB-backed view of `size` bytes filled with a repeating ASCII pattern. */
+function sabOfSize(size: number): Uint8Array {
+  const view = new Uint8Array(new SharedArrayBuffer(size));
+  for (let i = 0; i < size; i++) view[i] = 97 + (i % 26);
+  return view;
+}
 
 function asciiBytes(text: string): Uint8Array {
   const out = new Uint8Array(text.length);
@@ -82,5 +123,60 @@ describe('safeUtf8Decode', () => {
     const first = textDecoderAcceptsSab();
     const second = textDecoderAcceptsSab();
     expect(first).toBe(second);
+  });
+});
+
+// Regression: #2183. A single whole-file decode used to grow the retained
+// scratch to the next power of two above the file size and never release
+// it (342 MB source -> 512 MB pinned for the lifetime of the realm).
+describe('safeUtf8Decode scratch retention', () => {
+  it('does not retain a scratch buffer for a decode above the cap', () => {
+    if (typeof SharedArrayBuffer === 'undefined') {
+      console.warn('skip: SharedArrayBuffer unavailable in this runtime');
+      return;
+    }
+    const restore = forceScratchCopyPath();
+    try {
+      const oversized = MAX_RETAINED_SCRATCH_BYTES + 1;
+      const view = sabOfSize(oversized);
+      expect(safeUtf8Decode(view).length).toBe(oversized);
+      expect(__retainedScratchBytes()).toBe(0);
+    } finally {
+      restore();
+    }
+  });
+
+  it('still reuses one retained buffer for decodes at or under the cap', () => {
+    if (typeof SharedArrayBuffer === 'undefined') return;
+    const restore = forceScratchCopyPath();
+    try {
+      // Poison the acceptance cache with a small decode first.
+      expect(safeUtf8Decode(sabOfSize(8)).length).toBe(8);
+      const afterSmall = __retainedScratchBytes();
+      expect(afterSmall).toBeGreaterThan(0);
+      expect(afterSmall).toBeLessThanOrEqual(MAX_RETAINED_SCRATCH_BYTES);
+
+      // A larger but still-eligible decode grows the same retained buffer,
+      // and never past the cap.
+      expect(safeUtf8Decode(sabOfSize(MAX_RETAINED_SCRATCH_BYTES)).length)
+        .toBe(MAX_RETAINED_SCRATCH_BYTES);
+      expect(__retainedScratchBytes()).toBe(MAX_RETAINED_SCRATCH_BYTES);
+    } finally {
+      restore();
+    }
+  });
+
+  it('leaves the retained buffer untouched when an oversized decode follows a small one', () => {
+    if (typeof SharedArrayBuffer === 'undefined') return;
+    const restore = forceScratchCopyPath();
+    try {
+      expect(safeUtf8Decode(sabOfSize(8)).length).toBe(8);
+      const before = __retainedScratchBytes();
+      expect(safeUtf8Decode(sabOfSize(MAX_RETAINED_SCRATCH_BYTES + 1)).length)
+        .toBe(MAX_RETAINED_SCRATCH_BYTES + 1);
+      expect(__retainedScratchBytes()).toBe(before);
+    } finally {
+      restore();
+    }
   });
 });

--- a/packages/data/src/utf8-decode.test.ts
+++ b/packages/data/src/utf8-decode.test.ts
@@ -8,12 +8,15 @@ import {
   __resetScratchBuffer,
   __retainedScratchAllocations,
   __retainedScratchBytes,
+  MAX_RETAINED_SCRATCH_BYTES,
   safeUtf8Decode,
   textDecoderAcceptsSab,
 } from './utf8-decode.js';
 
-/** Mirrors `MAX_RETAINED_SCRATCH_BYTES` in the module under test. */
-const MAX_RETAINED_SCRATCH_BYTES = 4 * 1024 * 1024;
+// Imported, never re-declared. Every boundary case below is anchored to the
+// production constant: a hand-copied mirror would keep passing after the real
+// value changed, and "oversized" would quietly become an under-cap request
+// exercising the retained path the test is named against.
 
 /**
  * Force the SAB-copy path by making `TextDecoder.decode` reject the first

--- a/packages/data/src/utf8-decode.test.ts
+++ b/packages/data/src/utf8-decode.test.ts
@@ -203,7 +203,8 @@ describe('safeUtf8Decode scratch retention', () => {
       for (const size of [256, 512, 128, 1024, 64]) {
         expect(safeUtf8Decode(sabOfSize(size)).length).toBe(size);
       }
-      expect(__retainedScratchAllocations()).toBe(1, 'every decode fits the first buffer');
+      // Still one allocation: every size above fits inside the first buffer.
+      expect(__retainedScratchAllocations()).toBe(1);
       // Growing past it costs exactly one more allocation, not one per call.
       expect(safeUtf8Decode(sabOfSize(9000)).length).toBe(9000);
       expect(safeUtf8Decode(sabOfSize(9000)).length).toBe(9000);

--- a/packages/data/src/utf8-decode.test.ts
+++ b/packages/data/src/utf8-decode.test.ts
@@ -10,6 +10,7 @@ import {
   __retainedScratchBytes,
   MAX_RETAINED_SCRATCH_BYTES,
   safeUtf8Decode,
+  SCRATCH_BASE_BYTES,
   textDecoderAcceptsSab,
 } from './utf8-decode.js';
 
@@ -133,6 +134,33 @@ describe('safeUtf8Decode', () => {
 // Regression: #2183. A single whole-file decode used to grow the retained
 // scratch to the next power of two above the file size and never release
 // it (342 MB source -> 512 MB pinned for the lifetime of the realm).
+describe('scratch cap invariant', () => {
+  // `scratchFor` doubles from SCRATCH_BASE_BYTES and only stops once cap >=
+  // request. It can therefore only land EXACTLY on the cap — never overshoot
+  // it for an at-cap request — while the cap is a power-of-two multiple of the
+  // base. That requirement is stated in prose above the constant and is
+  // load-bearing: at 5 MiB, an at-cap request would overshoot to 8 MiB and
+  // retain double the intended ceiling, with nothing going red.
+  it('keeps the cap a power-of-two multiple of the base', () => {
+    const ratio = MAX_RETAINED_SCRATCH_BYTES / SCRATCH_BASE_BYTES;
+    expect(Number.isInteger(ratio)).toBe(true);
+    expect(Number.isInteger(Math.log2(ratio))).toBe(true);
+  });
+
+  it('never retains more than the cap for an at-cap request', () => {
+    if (typeof SharedArrayBuffer === 'undefined') return;
+    const restore = forceScratchCopyPath();
+    try {
+      expect(safeUtf8Decode(sabOfSize(MAX_RETAINED_SCRATCH_BYTES)).length)
+        .toBe(MAX_RETAINED_SCRATCH_BYTES);
+      expect(textDecoderAcceptsSab()).toBe(false);
+      expect(__retainedScratchBytes()).toBe(MAX_RETAINED_SCRATCH_BYTES);
+    } finally {
+      restore();
+    }
+  });
+});
+
 describe('safeUtf8Decode scratch retention', () => {
   it('does not retain a scratch buffer for a decode above the cap', () => {
     if (typeof SharedArrayBuffer === 'undefined') {

--- a/packages/data/src/utf8-decode.ts
+++ b/packages/data/src/utf8-decode.ts
@@ -27,6 +27,19 @@
  * (`columnar-parser-attributes.ts`) already routes through scratch
  * buffers, so only the per-entity attribute reads + schema detection +
  * tokenizer fallback go through this helper.
+ *
+ * Why the scratch is capped (#2183): "grows to the largest seen subarray"
+ * is the right trade for the 50–500 byte reads this helper was written
+ * for, but it makes a *single* whole-file decode permanent. A caller that
+ * hands the entire source in (the viewer's grid / alignment / symbolic
+ * overlay parses did exactly that) pushes the doubling scratch to the
+ * next power of two above the file size and it is never released: a
+ * 342 MB model pinned 512 MB for the lifetime of the realm, measured as
+ * 30% of the whole main-thread heap. Reuse only pays off when a buffer is
+ * hit repeatedly, which a one-off giant decode never is, so above
+ * `MAX_RETAINED_SCRATCH_BYTES` we allocate a throwaway and let the GC
+ * have it. The cap is far above every decode on the hot path, so those
+ * callers keep the exact same reused buffer they had before.
  */
 
 const sharedDecoder = new TextDecoder();
@@ -67,17 +80,52 @@ export function __resetSabDecodeCache(): void {
 
 let scratchBuffer: Uint8Array | null = null;
 
+/** Base capacity, and the unit every retained scratch size is a multiple of. */
+const SCRATCH_BASE_BYTES = 4096;
+
 /**
- * Ensure the realm-local scratch buffer can hold `byteLength` bytes,
- * doubling on growth to amortise reallocation cost.
+ * Largest scratch buffer kept alive between calls, in bytes.
+ *
+ * Must stay a power-of-two multiple of {@link SCRATCH_BASE_BYTES} so the
+ * doubling loop below lands exactly on it and can never overshoot for a
+ * request at or under the cap.
+ *
+ * 4 MiB is ~4 orders of magnitude above the 50–500 byte per-entity reads
+ * this helper serves, so nothing on the hot path is pushed off the
+ * retained buffer.
  */
-function ensureScratch(byteLength: number): Uint8Array {
+const MAX_RETAINED_SCRATCH_BYTES = 4 * 1024 * 1024;
+
+/**
+ * Return a scratch `Uint8Array` of at least `byteLength` bytes.
+ *
+ * At or under {@link MAX_RETAINED_SCRATCH_BYTES} the realm-local buffer is
+ * grown by doubling and reused. Above it the request is a one-off (see the
+ * module header), so it gets a throwaway buffer that is not retained.
+ */
+function scratchFor(byteLength: number): Uint8Array {
+  if (byteLength > MAX_RETAINED_SCRATCH_BYTES) {
+    return new Uint8Array(byteLength);
+  }
   if (scratchBuffer === null || scratchBuffer.length < byteLength) {
-    let cap = scratchBuffer?.length ?? 4096;
+    let cap = scratchBuffer?.length ?? SCRATCH_BASE_BYTES;
     while (cap < byteLength) cap *= 2;
     scratchBuffer = new Uint8Array(cap);
   }
   return scratchBuffer;
+}
+
+/**
+ * Bytes currently pinned by the retained scratch buffer. Tests only.
+ * Deliberately not re-exported from the package index.
+ */
+export function __retainedScratchBytes(): number {
+  return scratchBuffer?.length ?? 0;
+}
+
+/** Drop the retained scratch buffer. Tests only. */
+export function __resetScratchBuffer(): void {
+  scratchBuffer = null;
 }
 
 /**
@@ -102,7 +150,7 @@ export function safeUtf8Decode(view: Uint8Array, start?: number, end?: number): 
   // ArrayBuffer-backed view with the same bytes.
   const len = sub.length;
   if (len === 0) return '';
-  const scratch = ensureScratch(len);
+  const scratch = scratchFor(len);
   scratch.set(sub);
   return sharedDecoder.decode(scratch.subarray(0, len));
 }

--- a/packages/data/src/utf8-decode.ts
+++ b/packages/data/src/utf8-decode.ts
@@ -98,7 +98,7 @@ const SCRATCH_BASE_BYTES = 4096;
  * this helper serves, so nothing on the hot path is pushed off the
  * retained buffer.
  */
-const MAX_RETAINED_SCRATCH_BYTES = 4 * 1024 * 1024;
+export const MAX_RETAINED_SCRATCH_BYTES = 4 * 1024 * 1024;
 
 /**
  * Return a scratch `Uint8Array` of at least `byteLength` bytes.

--- a/packages/data/src/utf8-decode.ts
+++ b/packages/data/src/utf8-decode.ts
@@ -85,7 +85,7 @@ let scratchBuffer: Uint8Array | null = null;
 let scratchAllocations = 0;
 
 /** Base capacity, and the unit every retained scratch size is a multiple of. */
-const SCRATCH_BASE_BYTES = 4096;
+export const SCRATCH_BASE_BYTES = 4096;
 
 /**
  * Largest scratch buffer kept alive between calls, in bytes.

--- a/packages/data/src/utf8-decode.ts
+++ b/packages/data/src/utf8-decode.ts
@@ -19,8 +19,10 @@
  *      (zero-copy, ~10 ns per call).
  *   3. When it rejects, copy the requested subarray into a thread-local
  *      scratch `Uint8Array` first, then decode. The scratch buffer grows
- *      to the largest seen subarray and is reused, so the GC pressure is
- *      bounded even for million-entity files.
+ *      to the largest seen subarray *up to* `MAX_RETAINED_SCRATCH_BYTES`
+ *      and is reused, so the GC pressure is bounded even for
+ *      million-entity files. Anything larger gets a throwaway buffer and
+ *      nothing is retained (see below).
  *
  * Performance: the typical IFC entity decode is 50–500 bytes, so the copy
  * path is microseconds per call. The hot batch decode path
@@ -79,6 +81,8 @@ export function __resetSabDecodeCache(): void {
 }
 
 let scratchBuffer: Uint8Array | null = null;
+/** Count of retained-scratch allocations. Tests only — proves reuse still happens. */
+let scratchAllocations = 0;
 
 /** Base capacity, and the unit every retained scratch size is a multiple of. */
 const SCRATCH_BASE_BYTES = 4096;
@@ -111,6 +115,7 @@ function scratchFor(byteLength: number): Uint8Array {
     let cap = scratchBuffer?.length ?? SCRATCH_BASE_BYTES;
     while (cap < byteLength) cap *= 2;
     scratchBuffer = new Uint8Array(cap);
+    scratchAllocations++;
   }
   return scratchBuffer;
 }
@@ -123,9 +128,21 @@ export function __retainedScratchBytes(): number {
   return scratchBuffer?.length ?? 0;
 }
 
+/**
+ * How many times the retained scratch has been (re)allocated. Tests only.
+ *
+ * Size alone cannot distinguish "reused one buffer" from "allocated a
+ * correctly-sized new one every call", and reuse is the entire reason the
+ * retained path exists for the millions of 50-500 byte per-entity decodes.
+ */
+export function __retainedScratchAllocations(): number {
+  return scratchAllocations;
+}
+
 /** Drop the retained scratch buffer. Tests only. */
 export function __resetScratchBuffer(): void {
   scratchBuffer = null;
+  scratchAllocations = 0;
 }
 
 /**


### PR DESCRIPTION
Part 1 of 2 for #2183. Independent of part 2, and worth landing on its own.

## The defect

`safeUtf8Decode`'s scratch buffer grows by doubling to the largest subarray ever decoded, and is never released. That is the right trade for the 50-500 byte per-entity reads the helper was written for. It is the wrong trade for a single whole-file decode: the scratch lands on the next power of two above the file size and stays there for the lifetime of the realm.

Measured in the viewer on a 342 MB model: **512 MB pinned** (exactly 2^29), which was 30% of the entire main-thread JS heap. Confirmed by heap snapshot, with the sole retainer being this module-level `scratchBuffer`, and by a captured allocation stack.

## The change

Above 4 MiB, hand out a throwaway buffer instead of retaining it. Reuse only pays off for a buffer that is hit repeatedly, and a one-off giant decode never is.

Everything on the hot path is orders of magnitude below the cap, so those callers keep the exact same reused buffer they had before. `MAX_RETAINED_SCRATCH_BYTES` is a power-of-two multiple of the 4096 base, so the doubling loop lands exactly on it and can never overshoot for a request at or under the cap.

## Verification

- 3 new tests, all against the SAB-copy path.
- Mutation-checked: restoring the old unbounded growth fails 2 of the 3 (retained 8,388,608 bytes instead of 0).
- `pnpm typecheck` and `pnpm test` green.

Changeset: patch on `@ifc-lite/data`. No export change, so no api-surface update. The two test-only helpers are deliberately not re-exported from the package index.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UTF-8 decoding memory management by reusing buffers for smaller requests and avoiding retention of oversized allocations.
  * Reduced the risk of excessive memory growth during large file and IFCX processing.

* **Tests**
  * Added regression coverage for buffer reuse, allocation limits, oversized decodes, and memory preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->