### PR TITLE
fix(viewer): run the whole-source overlay parses in a disposable worker (#2183)

### DIFF
--- a/apps/viewer/src/hooks/useAlignmentLines3D.ts
+++ b/apps/viewer/src/hooks/useAlignmentLines3D.ts
@@ -19,12 +19,12 @@
  */
 
 import { useEffect, useMemo, useState } from 'react';
-import { GeometryProcessor } from '@ifc-lite/geometry';
 import { useViewerStore } from '@/store';
 import { useShallow } from 'zustand/react/shallow';
 import type { IfcDataStore } from '@ifc-lite/parser';
 import { sourceKey } from './source-key.js';
 import { hasEntityType } from './has-entity-type.js';
+import { parseOverlayLines } from '@/lib/overlay-parse';
 
 const EMPTY_F32 = new Float32Array(0);
 
@@ -47,14 +47,10 @@ async function parseAlignmentLinesFor(store: IfcDataStore): Promise<Float32Array
   // scan — it copies the entire IFC source into the WASM heap on the main thread
   // just to find none (~0.5s on a 170MB file).
   if (!hasEntityType(store, 'IfcAlignment', 'IfcAlignmentCurve')) return EMPTY_F32;
-  const processor = new GeometryProcessor();
-  try {
-    await processor.init();
-    const verts = processor.parseAlignmentLines(source);
-    return verts && verts.length > 0 ? verts : EMPTY_F32;
-  } finally {
-    processor.dispose();
-  }
+  // Off the main thread (#2183): this decodes the whole source and grows a
+  // WASM heap that never shrinks. See lib/overlay-parse.
+  const verts = await parseOverlayLines('alignment-lines', source);
+  return verts.length > 0 ? verts : EMPTY_F32;
 }
 
 function ensureParseFor(stores: IfcDataStore[]): void {

--- a/apps/viewer/src/hooks/useGridLines3D.ts
+++ b/apps/viewer/src/hooks/useGridLines3D.ts
@@ -15,8 +15,10 @@
  *
  * Unlike alignment (always-on), grids are gated by the `ifcGrid` type-visibility
  * toggle — but the parse itself is unconditional and cached; the Viewport only
- * uploads/clears based on the toggle. Gating the parse on the toggle would not
- * save anything: `ifcGrid` defaults to true (`store/constants.ts`).
+ * uploads/clears based on the toggle. Gating the parse on the toggle was
+ * considered and rejected: `ifcGrid` defaults to true (`store/constants.ts`),
+ * so it would only help users who have explicitly turned grids off, and it
+ * would trade that for a visible delay the first time they turn them on.
  *
  * The parse runs in a disposable worker (`lib/overlay-parse`), never on the
  * main thread — it decodes the entire source and grows a WASM heap that never
@@ -54,8 +56,7 @@ async function parseGridLinesFor(store: IfcDataStore): Promise<Float32Array> {
   if (!hasEntityType(store, 'IfcGridAxis', 'IfcGrid')) return EMPTY_F32;
   // Off the main thread (#2183). The guard above only helps models with no
   // grid at all; a model with a single IfcGridAxis still paid a full-source
-  // decode plus a permanently grown main-thread WASM heap. Note that making
-  // this lazy would not help: `typeVisibility.ifcGrid` defaults to true.
+  // decode plus a permanently grown main-thread WASM heap.
   const verts = await parseOverlayLines('grid-lines', source);
   return verts.length > 0 ? verts : EMPTY_F32;
 }

--- a/apps/viewer/src/hooks/useGridLines3D.ts
+++ b/apps/viewer/src/hooks/useGridLines3D.ts
@@ -15,16 +15,22 @@
  *
  * Unlike alignment (always-on), grids are gated by the `ifcGrid` type-visibility
  * toggle — but the parse itself is unconditional and cached; the Viewport only
- * uploads/clears based on the toggle.
+ * uploads/clears based on the toggle. Gating the parse on the toggle would not
+ * save anything: `ifcGrid` defaults to true (`store/constants.ts`).
+ *
+ * The parse runs in a disposable worker (`lib/overlay-parse`), never on the
+ * main thread — it decodes the entire source and grows a WASM heap that never
+ * shrinks, which cost ~950 MB of permanent main-thread memory on a 342 MB
+ * model with a single grid axis (#2183).
  */
 
 import { useEffect, useMemo, useState } from 'react';
-import { GeometryProcessor } from '@ifc-lite/geometry';
 import { useViewerStore } from '@/store';
 import { useShallow } from 'zustand/react/shallow';
 import type { IfcDataStore } from '@ifc-lite/parser';
 import { sourceKey } from './source-key.js';
 import { hasEntityType } from './has-entity-type.js';
+import { parseOverlayLines } from '@/lib/overlay-parse';
 
 const EMPTY_F32 = new Float32Array(0);
 
@@ -46,14 +52,12 @@ async function parseGridLinesFor(store: IfcDataStore): Promise<Float32Array> {
   // Skip the full-source WASM scan when the model has no grid — it copies the
   // entire IFC source into the WASM heap on the main thread just to find none.
   if (!hasEntityType(store, 'IfcGridAxis', 'IfcGrid')) return EMPTY_F32;
-  const processor = new GeometryProcessor();
-  try {
-    await processor.init();
-    const verts = processor.parseGridLines(source);
-    return verts && verts.length > 0 ? verts : EMPTY_F32;
-  } finally {
-    processor.dispose();
-  }
+  // Off the main thread (#2183). The guard above only helps models with no
+  // grid at all; a model with a single IfcGridAxis still paid a full-source
+  // decode plus a permanently grown main-thread WASM heap. Note that making
+  // this lazy would not help: `typeVisibility.ifcGrid` defaults to true.
+  const verts = await parseOverlayLines('grid-lines', source);
+  return verts.length > 0 ? verts : EMPTY_F32;
 }
 
 function ensureParseFor(stores: IfcDataStore[]): void {

--- a/apps/viewer/src/lib/overlay-parse/index.ts
+++ b/apps/viewer/src/lib/overlay-parse/index.ts
@@ -1,0 +1,93 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Client for {@link ./overlay-parse.worker.ts}. See that file for why these
+ * parses must not run on the main thread (#2183).
+ *
+ * Lifecycle: one worker is shared by every in-flight job so a load that
+ * needs both grid and alignment lines pays a single WASM compile, and it is
+ * terminated the moment the last job settles. Terminating is the whole
+ * point — it is what returns the decode scratch and the never-shrinking
+ * `WebAssembly.Memory` to the OS.
+ */
+
+import type {
+  OverlayParseKind,
+  OverlayParseRequest,
+  OverlayParseResponse,
+} from './overlay-parse.worker.js';
+
+const EMPTY_F32 = new Float32Array(0);
+
+let worker: Worker | null = null;
+let nextRequestId = 1;
+let inFlight = 0;
+const pending = new Map<number, (response: OverlayParseResponse) => void>();
+
+function ensureWorker(): Worker {
+  if (worker) return worker;
+  const created = new Worker(new URL('./overlay-parse.worker.ts', import.meta.url), {
+    type: 'module',
+  });
+  created.onmessage = (event: MessageEvent<OverlayParseResponse>) => {
+    const resolve = pending.get(event.data.id);
+    if (!resolve) return;
+    pending.delete(event.data.id);
+    resolve(event.data);
+  };
+  created.onerror = (event) => {
+    // A worker-level failure never resolves the per-job listener, so settle
+    // every outstanding job rather than hanging the overlay parse forever.
+    const message = event.message || 'overlay parse worker failed';
+    for (const [id, resolve] of pending) resolve({ id, ok: false, error: message });
+    pending.clear();
+  };
+  worker = created;
+  return created;
+}
+
+function releaseWorker(): void {
+  inFlight--;
+  if (inFlight > 0 || !worker) return;
+  worker.terminate();
+  worker = null;
+  pending.clear();
+}
+
+/**
+ * Parse a whole-source overlay line set off the main thread.
+ *
+ * Resolves to an empty array on any failure: these overlays are decoration,
+ * and a model that cannot produce them must still load.
+ */
+export async function parseOverlayLines(
+  kind: OverlayParseKind,
+  source: Uint8Array,
+): Promise<Float32Array> {
+  if (typeof Worker === 'undefined') return EMPTY_F32;
+  const id = nextRequestId++;
+  inFlight++;
+  try {
+    const active = ensureWorker();
+    const response = await new Promise<OverlayParseResponse>((resolve) => {
+      pending.set(id, resolve);
+      const request: OverlayParseRequest = { id, kind, source };
+      // No transfer list: `source` is SAB-backed, so it is shared by
+      // reference. Transferring would detach the viewer's own copy.
+      active.postMessage(request);
+    });
+    if (!response.ok) {
+      // eslint-disable-next-line no-console
+      console.warn(`[overlay-parse] ${kind} failed:`, response.error);
+      return EMPTY_F32;
+    }
+    return response.verts;
+  } finally {
+    pending.delete(id);
+    releaseWorker();
+  }
+}
+
+export type { OverlayParseKind };

--- a/apps/viewer/src/lib/overlay-parse/index.ts
+++ b/apps/viewer/src/lib/overlay-parse/index.ts
@@ -21,10 +21,44 @@ import type {
 
 const EMPTY_F32 = new Float32Array(0);
 
+/**
+ * Ceiling on a single parse. Generous on purpose: the parse itself is ~1s for
+ * a 342 MB source, so anything near this means the worker is gone rather than
+ * slow. It exists because a worker killed by the OS (renderer/worker OOM,
+ * the most likely failure mode for exactly the huge-model case this module
+ * serves) fires NEITHER `message` nor `error`. Without a deadline that job
+ * never settles, `inFlight` never returns to zero, the dead handle is handed
+ * to every later job, and overlays stay broken for the rest of the session
+ * with nothing in the console.
+ */
+export const JOB_TIMEOUT_MS = 120_000;
+
 let worker: Worker | null = null;
 let nextRequestId = 1;
 let inFlight = 0;
 const pending = new Map<number, (response: OverlayParseResponse) => void>();
+
+/**
+ * Tear the pool down and settle every outstanding job as failed.
+ *
+ * Terminating here (rather than leaving the worker up) is deliberate. A
+ * worker `error` event is not necessarily fatal, so a surviving worker would
+ * go on to deliver the real replies for jobs we have already settled empty,
+ * and those replies would be silently dropped by `onmessage`. Killing the
+ * realm makes the failure unambiguous and gives the next job a clean one.
+ *
+ * `inFlight` is NOT reset here: each settled job still runs its own `finally`,
+ * which decrements it exactly once.
+ */
+function failAll(message: string): void {
+  const outstanding = [...pending];
+  pending.clear();
+  if (worker) {
+    worker.terminate();
+    worker = null;
+  }
+  for (const [id, resolve] of outstanding) resolve({ id, ok: false, error: message });
+}
 
 function ensureWorker(): Worker {
   if (worker) return worker;
@@ -38,11 +72,11 @@ function ensureWorker(): Worker {
     resolve(event.data);
   };
   created.onerror = (event) => {
-    // A worker-level failure never resolves the per-job listener, so settle
-    // every outstanding job rather than hanging the overlay parse forever.
-    const message = event.message || 'overlay parse worker failed';
-    for (const [id, resolve] of pending) resolve({ id, ok: false, error: message });
-    pending.clear();
+    failAll(event.message || 'overlay parse worker failed');
+  };
+  // A reply that cannot be deserialized would otherwise hang its job forever.
+  created.onmessageerror = () => {
+    failAll('overlay parse worker sent an undeserializable reply');
   };
   worker = created;
   return created;
@@ -59,8 +93,10 @@ function releaseWorker(): void {
 /**
  * Parse a whole-source overlay line set off the main thread.
  *
- * Resolves to an empty array on any failure: these overlays are decoration,
- * and a model that cannot produce them must still load.
+ * Never rejects. Resolves to an empty array on every failure path — worker
+ * construction, `postMessage`, a parse error inside the worker, or the worker
+ * dying — because these overlays are decoration and a model that cannot
+ * produce them must still load.
  */
 export async function parseOverlayLines(
   kind: OverlayParseKind,
@@ -68,14 +104,26 @@ export async function parseOverlayLines(
 ): Promise<Float32Array> {
   if (typeof Worker === 'undefined') return EMPTY_F32;
   const id = nextRequestId++;
+  let timer: ReturnType<typeof setTimeout> | undefined;
   inFlight++;
   try {
-    const active = ensureWorker();
+    // `new Worker(...)` and `postMessage` can both throw synchronously (a
+    // blocked worker URL, a CSP refusal, a payload the structured-clone
+    // algorithm rejects). Those must resolve empty like every other failure
+    // here, not reject: callers treat these overlays as decoration and a
+    // rejection would surface as an unhandled error during load.
     const response = await new Promise<OverlayParseResponse>((resolve) => {
+      const active = ensureWorker();
       pending.set(id, resolve);
+      timer = setTimeout(() => {
+        if (pending.has(id)) failAll(`overlay parse timed out after ${JOB_TIMEOUT_MS}ms`);
+      }, JOB_TIMEOUT_MS);
       const request: OverlayParseRequest = { id, kind, source };
-      // No transfer list: `source` is SAB-backed, so it is shared by
-      // reference. Transferring would detach the viewer's own copy.
+      // Never a transfer list. When the source is SAB-backed (the huge-model
+      // path, which requires cross-origin isolation) it is shared by
+      // reference and transferring would detach the viewer's own copy. When
+      // it is a plain ArrayBuffer (no COI) structured clone copies it into
+      // the worker, which is correct but not free.
       active.postMessage(request);
     });
     if (!response.ok) {
@@ -84,7 +132,12 @@ export async function parseOverlayLines(
       return EMPTY_F32;
     }
     return response.verts;
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.warn(`[overlay-parse] ${kind} could not start:`, error);
+    return EMPTY_F32;
   } finally {
+    clearTimeout(timer);
     pending.delete(id);
     releaseWorker();
   }

--- a/apps/viewer/src/lib/overlay-parse/overlay-parse.test.ts
+++ b/apps/viewer/src/lib/overlay-parse/overlay-parse.test.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { describe, it, beforeEach, afterEach } from 'node:test';
+import { describe, it, beforeEach, afterEach, mock } from 'node:test';
 import assert from 'node:assert';
 
 /**
@@ -28,6 +28,7 @@ class FakeWorker {
   static failNextConstruct = false;
   onmessage: ((event: { data: unknown }) => void) | null = null;
   onerror: ((event: { message: string }) => void) | null = null;
+  onmessageerror: (() => void) | null = null;
   readonly posted: PostedMessage[] = [];
   terminated = 0;
 
@@ -51,17 +52,23 @@ class FakeWorker {
 }
 
 let parseOverlayLines: typeof import('./index.js').parseOverlayLines;
+let JOB_TIMEOUT_MS: number;
 
 beforeEach(async () => {
   instances.length = 0;
   (globalThis as { Worker?: unknown }).Worker = FakeWorker;
+  // Deterministic deadline test, and it keeps every other test from leaving a
+  // 2-minute timer behind that would hold the process open.
+  mock.timers.enable({ apis: ['setTimeout'] });
   // Fresh module state per test: the worker handle and the in-flight count
   // are module-level singletons.
   const mod = await import(`./index.js?t=${Date.now()}${Math.random()}`);
   parseOverlayLines = mod.parseOverlayLines;
+  JOB_TIMEOUT_MS = mod.JOB_TIMEOUT_MS;
 });
 
 afterEach(() => {
+  mock.timers.reset();
   delete (globalThis as { Worker?: unknown }).Worker;
 });
 
@@ -131,6 +138,90 @@ describe('parseOverlayLines', () => {
     worker.onerror?.({ message: 'worker died' });
     assert.equal((await promise).length, 0, 'must not hang forever');
     assert.equal(worker.terminated, 1);
+  });
+
+  // An `error` event is not necessarily fatal: the worker can keep running and
+  // deliver the real reply for a job we already settled. If it is left alive,
+  // that reply is silently dropped and the next job gets the same sick realm.
+  it('kills the worker on error so a late real reply cannot be silently dropped', async () => {
+    const a = parseOverlayLines('grid-lines', new Uint8Array(1));
+    const b = parseOverlayLines('alignment-lines', new Uint8Array(1));
+    const worker = instances[0];
+    worker.onerror?.({ message: 'one task threw' });
+
+    // Start the next job SYNCHRONOUSLY, before a and b's `finally` microtasks
+    // run. This is the window that matters: if `failAll` did not terminate and
+    // null the worker, `inFlight` is still 2 here, so the sick realm would be
+    // handed straight to job c and its late replies would be dropped.
+    assert.equal(worker.terminated, 1, 'failAll must kill the realm, not wait for refcounting');
+    const c = parseOverlayLines('grid-lines', new Uint8Array(1));
+    assert.equal(instances.length, 2, 'job c must get a FRESH worker, not the sick one');
+
+    assert.equal((await a).length, 0);
+    assert.equal((await b).length, 0);
+    instances[1].reply({ id: instances[1].posted[0].id, ok: true, verts: new Float32Array([9]) });
+    assert.deepEqual(await c, new Float32Array([9]));
+  });
+
+  it('settles on an undeserializable reply (messageerror)', async () => {
+    const promise = parseOverlayLines('grid-lines', new Uint8Array(1));
+    const worker = instances[0];
+    assert.equal(typeof worker.onmessageerror, 'function', 'messageerror must be handled');
+    worker.onmessageerror?.();
+    assert.equal((await promise).length, 0);
+    assert.equal(worker.terminated, 1);
+  });
+
+  // The failure mode with no recovery: a worker killed by the OS (OOM on a
+  // huge model) fires neither `message` nor `error`.
+  it('does not wedge the module when a worker dies silently', async () => {
+    const promise = parseOverlayLines('grid-lines', new Uint8Array(1));
+    const worker = instances[0];
+    mock.timers.tick(JOB_TIMEOUT_MS + 1);
+    assert.equal((await promise).length, 0, 'a silent death must still settle');
+    assert.equal(worker.terminated, 1, 'the dead worker holds the WASM heap we came to reclaim');
+
+    // And the pool must still be usable afterwards.
+    const next = parseOverlayLines('grid-lines', new Uint8Array(1));
+    assert.equal(instances.length, 2, 'a wedged inFlight would reuse the dead handle');
+    instances[1].reply({ id: instances[1].posted[0].id, ok: true, verts: new Float32Array([1]) });
+    assert.deepEqual(await next, new Float32Array([1]));
+  });
+
+  it('resolves empty when the Worker constructor throws', async () => {
+    (globalThis as { Worker?: unknown }).Worker = function () {
+      throw new Error('blocked by CSP');
+    };
+    const mod = await import(`./index.js?ct=${Date.now()}${Math.random()}`);
+    assert.equal((await mod.parseOverlayLines('grid-lines', new Uint8Array(1))).length, 0);
+  });
+
+  it('resolves empty when postMessage throws synchronously', async () => {
+    class ThrowingWorker extends FakeWorker {
+      override postMessage(): void {
+        throw new DOMException('could not be cloned', 'DataCloneError');
+      }
+    }
+    (globalThis as { Worker?: unknown }).Worker = ThrowingWorker;
+    const mod = await import(`./index.js?pm=${Date.now()}${Math.random()}`);
+    assert.equal((await mod.parseOverlayLines('grid-lines', new Uint8Array(1))).length, 0);
+    // The worker was constructed, so it must still be freed.
+    assert.equal(instances[0].terminated, 1);
+  });
+
+  it('a failed start does not strand the in-flight count', async () => {
+    (globalThis as { Worker?: unknown }).Worker = function () {
+      throw new Error('boom');
+    };
+    const mod = await import(`./index.js?if=${Date.now()}${Math.random()}`);
+    await mod.parseOverlayLines('grid-lines', new Uint8Array(1));
+    // If inFlight leaked, the next successful job would never terminate.
+    (globalThis as { Worker?: unknown }).Worker = FakeWorker;
+    const promise = mod.parseOverlayLines('grid-lines', new Uint8Array(1));
+    const worker = instances[instances.length - 1];
+    worker.reply({ id: worker.posted[0].id, ok: true, verts: new Float32Array(0) });
+    await promise;
+    assert.equal(worker.terminated, 1, 'inFlight must be balanced after a failed start');
   });
 
   it('returns empty without spawning anything when Worker is unavailable', async () => {

--- a/apps/viewer/src/lib/overlay-parse/overlay-parse.test.ts
+++ b/apps/viewer/src/lib/overlay-parse/overlay-parse.test.ts
@@ -1,0 +1,142 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+
+/**
+ * Contract tests for the overlay-parse worker client (#2183).
+ *
+ * The whole point of this module is that the worker is TERMINATED once the
+ * last job settles: terminating is what returns the decode scratch and the
+ * never-shrinking `WebAssembly.Memory` to the OS. A client that keeps the
+ * worker alive would re-introduce the bug in a different realm, so the
+ * termination assertions below are the load-bearing ones.
+ */
+
+interface PostedMessage {
+  id: number;
+  kind: string;
+  source: Uint8Array;
+}
+
+const instances: FakeWorker[] = [];
+
+/** Records posts and lets each test drive replies by hand. */
+class FakeWorker {
+  static failNextConstruct = false;
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+  onerror: ((event: { message: string }) => void) | null = null;
+  readonly posted: PostedMessage[] = [];
+  terminated = 0;
+
+  constructor(public url: unknown, public options: unknown) {
+    instances.push(this);
+  }
+
+  postMessage(message: PostedMessage, transfer?: unknown[]): void {
+    this.posted.push(message);
+    // A transfer list here would detach the viewer's own SAB-backed source.
+    assert.equal(transfer, undefined, 'source must be shared, never transferred');
+  }
+
+  terminate(): void {
+    this.terminated++;
+  }
+
+  reply(data: unknown): void {
+    this.onmessage?.({ data });
+  }
+}
+
+let parseOverlayLines: typeof import('./index.js').parseOverlayLines;
+
+beforeEach(async () => {
+  instances.length = 0;
+  (globalThis as { Worker?: unknown }).Worker = FakeWorker;
+  // Fresh module state per test: the worker handle and the in-flight count
+  // are module-level singletons.
+  const mod = await import(`./index.js?t=${Date.now()}${Math.random()}`);
+  parseOverlayLines = mod.parseOverlayLines;
+});
+
+afterEach(() => {
+  delete (globalThis as { Worker?: unknown }).Worker;
+});
+
+describe('parseOverlayLines', () => {
+  it('returns the vertices the worker sends back', async () => {
+    const source = new Uint8Array([1, 2, 3]);
+    const promise = parseOverlayLines('grid-lines', source);
+    const worker = instances[0];
+    assert.equal(worker.posted.length, 1);
+    assert.equal(worker.posted[0].kind, 'grid-lines');
+    assert.equal(worker.posted[0].source, source, 'source passed by reference');
+
+    const verts = new Float32Array([0, 0, 0, 1, 2, 3]);
+    worker.reply({ id: worker.posted[0].id, ok: true, verts });
+    assert.deepEqual(await promise, verts);
+  });
+
+  it('terminates the worker once the last job settles', async () => {
+    const promise = parseOverlayLines('grid-lines', new Uint8Array(1));
+    const worker = instances[0];
+    assert.equal(worker.terminated, 0, 'still running while the job is in flight');
+    worker.reply({ id: worker.posted[0].id, ok: true, verts: new Float32Array(0) });
+    await promise;
+    assert.equal(worker.terminated, 1, 'terminate is what frees the WASM pages');
+  });
+
+  it('shares one worker across concurrent jobs and terminates it once', async () => {
+    const a = parseOverlayLines('grid-lines', new Uint8Array(1));
+    const b = parseOverlayLines('alignment-lines', new Uint8Array(1));
+    assert.equal(instances.length, 1, 'one WASM compile, not two');
+    const worker = instances[0];
+    assert.equal(worker.posted.length, 2);
+    assert.notEqual(worker.posted[0].id, worker.posted[1].id, 'ids must be distinct to route replies');
+
+    worker.reply({ id: worker.posted[0].id, ok: true, verts: new Float32Array([1]) });
+    await a;
+    assert.equal(worker.terminated, 0, 'second job still in flight');
+
+    worker.reply({ id: worker.posted[1].id, ok: true, verts: new Float32Array([2]) });
+    await b;
+    assert.equal(worker.terminated, 1);
+  });
+
+  it('spawns a fresh worker for a later job after the pool went idle', async () => {
+    const first = parseOverlayLines('grid-lines', new Uint8Array(1));
+    instances[0].reply({ id: instances[0].posted[0].id, ok: true, verts: new Float32Array(0) });
+    await first;
+
+    const second = parseOverlayLines('grid-lines', new Uint8Array(1));
+    assert.equal(instances.length, 2, 'terminated worker cannot be reused');
+    instances[1].reply({ id: instances[1].posted[0].id, ok: true, verts: new Float32Array(0) });
+    await second;
+    assert.equal(instances[1].terminated, 1);
+  });
+
+  it('resolves empty on a parse error rather than rejecting', async () => {
+    const promise = parseOverlayLines('grid-lines', new Uint8Array(1));
+    const worker = instances[0];
+    worker.reply({ id: worker.posted[0].id, ok: false, error: 'boom' });
+    assert.equal((await promise).length, 0, 'overlays are decoration; the model must still load');
+    assert.equal(worker.terminated, 1, 'a failed job must still free the worker');
+  });
+
+  it('settles outstanding jobs when the worker itself errors', async () => {
+    const promise = parseOverlayLines('grid-lines', new Uint8Array(1));
+    const worker = instances[0];
+    worker.onerror?.({ message: 'worker died' });
+    assert.equal((await promise).length, 0, 'must not hang forever');
+    assert.equal(worker.terminated, 1);
+  });
+
+  it('returns empty without spawning anything when Worker is unavailable', async () => {
+    delete (globalThis as { Worker?: unknown }).Worker;
+    const mod = await import(`./index.js?nw=${Date.now()}${Math.random()}`);
+    assert.equal((await mod.parseOverlayLines('grid-lines', new Uint8Array(1))).length, 0);
+    assert.equal(instances.length, 0);
+  });
+});

--- a/apps/viewer/src/lib/overlay-parse/overlay-parse.worker.test.ts
+++ b/apps/viewer/src/lib/overlay-parse/overlay-parse.worker.test.ts
@@ -1,0 +1,77 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+
+/**
+ * The worker's contract with its client is: ALWAYS post exactly one reply,
+ * and never reject.
+ *
+ * Silence is the one outcome the client cannot recover from cheaply — it has
+ * to sit on the full 120s deadline before giving up. Before #2183's follow-up
+ * the `GeometryProcessor` was constructed OUTSIDE the try, so a construction
+ * failure escaped into the queue's `.catch()` and posted nothing at all.
+ *
+ * Under Node there is no WASM runtime, so the processor fails to come up on
+ * its own. That is not a contrived stub — it is exactly the class of early
+ * failure (asset unavailable, instantiate rejected) this contract exists for,
+ * and it reaches the same path.
+ */
+
+const posted: unknown[] = [];
+let handle: typeof import('./overlay-parse.worker.js').handle;
+let setFactory: typeof import('./overlay-parse.worker.js').__setProcessorFactoryForTest;
+
+beforeEach(async () => {
+  posted.length = 0;
+  // The module guards its `self.onmessage` registration on being in a real
+  // worker scope, which is what makes it importable here at all.
+  (globalThis as { self?: unknown }).self = {
+    postMessage: (msg: unknown) => { posted.push(msg); },
+  };
+  const mod = await import(`./overlay-parse.worker.js?t=${Date.now()}${Math.random()}`);
+  handle = mod.handle;
+  setFactory = mod.__setProcessorFactoryForTest;
+});
+
+afterEach(() => {
+  setFactory?.(null);
+  delete (globalThis as { self?: unknown }).self;
+});
+
+function event(kind: 'grid-lines' | 'alignment-lines' = 'grid-lines'): MessageEvent<never> {
+  return { data: { id: 7, kind, source: new Uint8Array([1]) } } as unknown as MessageEvent<never>;
+}
+
+describe('overlay-parse worker handle', () => {
+  it('is importable outside a worker scope (registration is guarded)', () => {
+    assert.equal(typeof handle, 'function');
+  });
+
+  // THE regression: the processor used to be constructed outside the try, so
+  // a construction failure escaped into the queue's catch and posted nothing.
+  it('posts an error reply when the processor cannot be CONSTRUCTED', async () => {
+    setFactory(() => { throw new Error('wasm asset unavailable'); });
+    await handle(event());
+    assert.equal(posted.length, 1, 'silence costs the client its full 120s deadline');
+    const reply = posted[0] as { id: number; ok: boolean; error: string };
+    assert.equal(reply.id, 7, 'the reply must carry the id so the client can route it');
+    assert.equal(reply.ok, false);
+    assert.match(reply.error, /wasm asset unavailable/);
+  });
+
+  it('never rejects on a construction failure, so the queue is not poisoned', async () => {
+    setFactory(() => { throw new Error('boom'); });
+    await assert.doesNotReject(() => handle(event()));
+    await assert.doesNotReject(() => handle(event('alignment-lines')));
+    assert.equal(posted.length, 2, 'a second job still gets its own reply');
+  });
+
+  it('posts exactly one reply on the real path', async () => {
+    await handle(event());
+    assert.equal(posted.length, 1);
+    assert.equal((posted[0] as { id: number }).id, 7);
+  });
+});

--- a/apps/viewer/src/lib/overlay-parse/overlay-parse.worker.ts
+++ b/apps/viewer/src/lib/overlay-parse/overlay-parse.worker.ts
@@ -26,6 +26,7 @@
  */
 
 import { GeometryProcessor } from '@ifc-lite/geometry';
+import { buildParseReply } from './reply.js';
 
 /** Parse kinds this worker can run. Both return a flat line-list. */
 export type OverlayParseKind = 'grid-lines' | 'alignment-lines';
@@ -40,25 +41,42 @@ export type OverlayParseResponse =
   | { id: number; ok: true; verts: Float32Array }
   | { id: number; ok: false; error: string };
 
-const EMPTY = new Float32Array(0);
-
-function runParse(processor: GeometryProcessor, kind: OverlayParseKind, source: Uint8Array): Float32Array {
-  const verts = kind === 'grid-lines'
+function runParse(
+  processor: GeometryProcessor,
+  kind: OverlayParseKind,
+  source: Uint8Array,
+): Float32Array | null {
+  return kind === 'grid-lines'
     ? processor.parseGridLines(source)
     : processor.parseAlignmentLines(source);
-  return verts && verts.length > 0 ? verts : EMPTY;
 }
 
-self.onmessage = async (event: MessageEvent<OverlayParseRequest>) => {
+/**
+ * Serialises message handling.
+ *
+ * Two jobs arriving in the same tick (a model with both grids and alignments)
+ * would otherwise both `await processor.init()` concurrently. `IfcLiteBridge`
+ * guards on a PER-INSTANCE flag and wasm-bindgen's `__wbg_init` guards on a
+ * module-level `wasm` binding that is only assigned AFTER its await, so both
+ * pass both guards and the ~3.9 MB module is instantiated twice — two
+ * `WebAssembly.Memory`s in a worker whose entire purpose is to bound memory.
+ * In the worker the module is always cold, so this is the normal path.
+ *
+ * `runParse` is fully synchronous, so serialising costs nothing: the only
+ * concurrency ever available here was the init overlap.
+ */
+let queue: Promise<void> = Promise.resolve();
+
+async function handle(event: MessageEvent<OverlayParseRequest>): Promise<void> {
   const { id, kind, source } = event.data;
   const processor = new GeometryProcessor();
   try {
     await processor.init();
-    const verts = runParse(processor, kind, source);
-    const reply: OverlayParseResponse = { id, ok: true, verts };
-    // `verts` is a fresh copy out of WASM, so transferring it is safe and
-    // saves a structured clone of the vertex data.
-    (self as unknown as Worker).postMessage(reply, [verts.buffer as ArrayBuffer]);
+    // `verts` is a fresh JS-heap copy out of WASM (`js_sys::Float32Array::from`
+    // over a Rust slice), not a view into linear memory, so transferring it is
+    // safe and saves a structured clone of the vertex data.
+    const { reply, transfer } = buildParseReply(id, runParse(processor, kind, source));
+    (self as unknown as Worker).postMessage(reply, transfer);
   } catch (error) {
     const reply: OverlayParseResponse = {
       id,
@@ -72,4 +90,10 @@ self.onmessage = async (event: MessageEvent<OverlayParseRequest>) => {
     // as soon as the last in-flight job settles.
     processor.dispose();
   }
+}
+
+self.onmessage = (event: MessageEvent<OverlayParseRequest>) => {
+  // `handle` never rejects (it posts an error reply instead), but chain
+  // defensively so one bad job cannot poison the queue for later ones.
+  queue = queue.then(() => handle(event)).catch(() => undefined);
 };

--- a/apps/viewer/src/lib/overlay-parse/overlay-parse.worker.ts
+++ b/apps/viewer/src/lib/overlay-parse/overlay-parse.worker.ts
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Worker host for the always-on overlay parses that need the WHOLE IFC
+ * source (issue #2183).
+ *
+ * `parseGridLines` / `parseAlignmentLines` take the entire file, decode it
+ * to a JS string, and hand that string to WASM. Two costs of that are
+ * permanent in whichever realm runs it:
+ *
+ *   1. `safeUtf8Decode`'s scratch buffer, when the runtime rejects
+ *      SAB-backed views (every cross-origin-isolated browser). Capped
+ *      since #2183, but still a full-size transient.
+ *   2. `WebAssembly.Memory`, which only ever grows. `dispose()` frees the
+ *      wasm-bindgen handle, not the pages.
+ *
+ * Run on the main thread that is ~950 MB pinned for a 342 MB model, for
+ * the lifetime of the tab, to draw some overlay lines. Both costs are
+ * realm-local, so hosting the parse in a worker that is terminated
+ * afterwards returns all of it to the OS.
+ *
+ * The source is a `SharedArrayBuffer`-backed view, so handing it over is
+ * zero-copy: it is shared, never cloned or transferred.
+ */
+
+import { GeometryProcessor } from '@ifc-lite/geometry';
+
+/** Parse kinds this worker can run. Both return a flat line-list. */
+export type OverlayParseKind = 'grid-lines' | 'alignment-lines';
+
+export interface OverlayParseRequest {
+  id: number;
+  kind: OverlayParseKind;
+  source: Uint8Array;
+}
+
+export type OverlayParseResponse =
+  | { id: number; ok: true; verts: Float32Array }
+  | { id: number; ok: false; error: string };
+
+const EMPTY = new Float32Array(0);
+
+function runParse(processor: GeometryProcessor, kind: OverlayParseKind, source: Uint8Array): Float32Array {
+  const verts = kind === 'grid-lines'
+    ? processor.parseGridLines(source)
+    : processor.parseAlignmentLines(source);
+  return verts && verts.length > 0 ? verts : EMPTY;
+}
+
+self.onmessage = async (event: MessageEvent<OverlayParseRequest>) => {
+  const { id, kind, source } = event.data;
+  const processor = new GeometryProcessor();
+  try {
+    await processor.init();
+    const verts = runParse(processor, kind, source);
+    const reply: OverlayParseResponse = { id, ok: true, verts };
+    // `verts` is a fresh copy out of WASM, so transferring it is safe and
+    // saves a structured clone of the vertex data.
+    (self as unknown as Worker).postMessage(reply, [verts.buffer as ArrayBuffer]);
+  } catch (error) {
+    const reply: OverlayParseResponse = {
+      id,
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+    (self as unknown as Worker).postMessage(reply);
+  } finally {
+    // Frees the wasm-bindgen handle. The linear memory itself only goes
+    // back to the OS when this worker is terminated, which the client does
+    // as soon as the last in-flight job settles.
+    processor.dispose();
+  }
+};

--- a/apps/viewer/src/lib/overlay-parse/overlay-parse.worker.ts
+++ b/apps/viewer/src/lib/overlay-parse/overlay-parse.worker.ts
@@ -67,10 +67,26 @@ function runParse(
  */
 let queue: Promise<void> = Promise.resolve();
 
-async function handle(event: MessageEvent<OverlayParseRequest>): Promise<void> {
+/**
+ * Indirection purely so a test can force the one failure the client cannot
+ * recover from cheaply: the processor failing to be constructed at all.
+ * Production always uses the default.
+ */
+let createProcessor = (): GeometryProcessor => new GeometryProcessor();
+
+/** Tests only. Pass null to restore the real factory. */
+export function __setProcessorFactoryForTest(factory: (() => GeometryProcessor) | null): void {
+  createProcessor = factory ?? ((): GeometryProcessor => new GeometryProcessor());
+}
+
+export async function handle(event: MessageEvent<OverlayParseRequest>): Promise<void> {
   const { id, kind, source } = event.data;
-  const processor = new GeometryProcessor();
+  // Constructed INSIDE the try. If it threw outside, the rejection would
+  // escape into the queue's catch, no reply would ever be posted, and the
+  // client would sit on its 120s deadline instead of failing immediately.
+  let processor: GeometryProcessor | undefined;
   try {
+    processor = createProcessor();
     await processor.init();
     // `verts` is a fresh JS-heap copy out of WASM (`js_sys::Float32Array::from`
     // over a Rust slice), not a view into linear memory, so transferring it is
@@ -87,13 +103,26 @@ async function handle(event: MessageEvent<OverlayParseRequest>): Promise<void> {
   } finally {
     // Frees the wasm-bindgen handle. The linear memory itself only goes
     // back to the OS when this worker is terminated, which the client does
-    // as soon as the last in-flight job settles.
-    processor.dispose();
+    // as soon as the last in-flight job settles. Optional call: construction
+    // itself can fail, and then there is nothing to dispose.
+    processor?.dispose();
   }
 }
 
-self.onmessage = (event: MessageEvent<OverlayParseRequest>) => {
-  // `handle` never rejects (it posts an error reply instead), but chain
-  // defensively so one bad job cannot poison the queue for later ones.
-  queue = queue.then(() => handle(event)).catch(() => undefined);
-};
+/**
+ * True only in a real dedicated-worker scope. Guarding the registration keeps
+ * this module importable from a test (Node has no `self`) and off `window` if
+ * it is ever pulled into a main-thread chunk.
+ */
+const isWorkerScope =
+  typeof self !== 'undefined' &&
+  typeof (globalThis as { window?: unknown }).window === 'undefined' &&
+  typeof (self as unknown as Worker).postMessage === 'function';
+
+if (isWorkerScope) {
+  self.onmessage = (event: MessageEvent<OverlayParseRequest>) => {
+    // `handle` never rejects (it posts an error reply instead), but chain
+    // defensively so one bad job cannot poison the queue for later ones.
+    queue = queue.then(() => handle(event)).catch(() => undefined);
+  };
+}

--- a/apps/viewer/src/lib/overlay-parse/reply.test.ts
+++ b/apps/viewer/src/lib/overlay-parse/reply.test.ts
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import { buildParseReply } from './reply.js';
+
+describe('buildParseReply', () => {
+  it('passes real vertices through and transfers their buffer', () => {
+    const verts = new Float32Array([0, 0, 0, 1, 2, 3]);
+    const { reply, transfer } = buildParseReply(7, verts);
+    assert.equal(reply.id, 7);
+    assert.equal(reply.ok, true);
+    assert.equal(reply.ok && reply.verts, verts);
+    assert.deepEqual(transfer, [verts.buffer]);
+  });
+
+  it('never transfers a zero-length buffer', () => {
+    const { transfer } = buildParseReply(1, new Float32Array(0));
+    assert.deepEqual(transfer, [], 'nothing to move, and transferring it invites detachment');
+  });
+
+  it('normalises null and empty results to a fresh array', () => {
+    for (const input of [null, undefined, new Float32Array(0)]) {
+      const { reply } = buildParseReply(1, input);
+      assert.equal(reply.ok, true);
+      assert.equal(reply.ok && reply.verts.length, 0);
+    }
+  });
+
+  // The bug: a shared module-level empty array, transferred once, is detached
+  // for every later reply from the same worker, which then throws
+  // DataCloneError and surfaces as a parse failure.
+  it('gives each no-result reply a DISTINCT buffer', () => {
+    const first = buildParseReply(1, null);
+    const second = buildParseReply(2, new Float32Array(0));
+    assert.ok(first.reply.ok && second.reply.ok);
+    assert.notEqual(
+      first.reply.ok && first.reply.verts.buffer,
+      second.reply.ok && second.reply.verts.buffer,
+      'two empty replies from one worker must not share a buffer',
+    );
+  });
+});

--- a/apps/viewer/src/lib/overlay-parse/reply.ts
+++ b/apps/viewer/src/lib/overlay-parse/reply.ts
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Reply construction for the overlay-parse worker, split out from the worker
+ * itself so it is unit-testable (importing the worker module would run its
+ * `self.onmessage` registration).
+ */
+
+import type { OverlayParseResponse } from './overlay-parse.worker.js';
+
+export interface BuiltReply {
+  reply: OverlayParseResponse;
+  transfer: ArrayBuffer[];
+}
+
+/**
+ * Wrap parse output in a reply plus its transfer list.
+ *
+ * Two rules, both of which exist because one worker serves several concurrent
+ * jobs (grid + alignment) before it is terminated:
+ *
+ *   1. A no-result parse gets a FRESH array, never a shared module-level
+ *      constant. Transferring a shared empty array detaches it, and the next
+ *      empty reply from the same worker would then throw `DataCloneError` and
+ *      be surfaced as a parse failure.
+ *   2. A zero-length buffer is never put in the transfer list. There is
+ *      nothing to move, and it keeps rule 1 from being load-bearing.
+ */
+export function buildParseReply(id: number, verts: Float32Array | null | undefined): BuiltReply {
+  const payload = verts && verts.length > 0 ? verts : new Float32Array(0);
+  return {
+    reply: { id, ok: true, verts: payload },
+    transfer: payload.byteLength > 0 ? [payload.buffer as ArrayBuffer] : [],
+  };
+}


### PR DESCRIPTION
Part 2 of 2 for #2183. Independent of #2241 — the two touch disjoint files and neither needs the other. (Originally stacked; unstacked because `test.yml` is `pull_request: branches: [main]`, so a non-main base silently skipped the entire Test workflow and CodeRabbit.)

## What #2183 actually is

Fourth memory report from the same reporter (#294, #515, #600, now #2183), and the first with enough detail to reproduce without his model, which he cannot share. His numbers: 314 MB IFC4, 1,938,526 entities, only 21,341 with geometry, DevTools Main VM 3,642 MB.

Reproduced on `tests/models/various/O-S1-BWK...` (342 MB, 4.41M entities, ~16.7K with geometry, property-dominated). Production build, Chrome, cross-origin isolated.

Steady state after load, main thread:

| measure | before |
|---|---|
| `usedJSHeapSize` | 907 MB |
| `measureUserAgentSpecificMemory()` | 1,715 MB |
| heap snapshot, total shallow | 1,717 MB |
| of which `system / JSArrayBufferData` | 1,494 MB (87%) |

Three buffers were 85.6% of the whole heap: **512 MB** (the decode scratch, fixed in #2241), **439.3 MB** (exactly 7,028 wasm pages, the one main-thread `WebAssembly.Memory`), and **326.8 MB** (`ifcDataStore.source`, retained by design).

It is not geometry: `geom=87.2MB`, mesh arrays 137 MB.

## Root cause

`useGridLines3D` hands the **whole file** to `parseGridLines`, which `safeUtf8Decode`s all 342 MB into a JS string and pushes that string into main-thread WASM. `dispose()` frees the wasm-bindgen handle, not the pages, so the heap stays grown for the tab's lifetime.

The hook already had a guard whose own comment names this cost. The guard works. It just does not help when the model *has* a grid, and this model has **exactly one `IfcGrid` and one `IfcGridAxis`**. Roughly 950 MB of permanent main-thread memory to draw a single grid axis.

## The change

Both costs are realm-local, so host the parse in a worker and terminate it. One worker is shared by concurrent jobs so a load needing both grid and alignment lines pays a single WASM compile; it is terminated as soon as the last job settles. The source is SAB-backed, so it is shared with the worker by reference, never cloned or transferred.

## Result, same model, same build

| | before | after (this PR + #2241) |
|---|---|---|
| `measureUserAgentSpecificMemory()` | 1,715 MB | **1,142 MB** |
| `usedJSHeapSize` | 907 MB | 304 MB |
| 512 MB doubling scratch | present | gone (a 326.8 MB throwaway, collected) |
| main-thread `WebAssembly.Memory` | 439 MB | **471 MB, still present** |

**Corrected.** An earlier revision of this PR claimed 772 MB and said the symbolic-annotation parse "did not fire on this model". Both were wrong. That measurement was taken in a browser profile where `typeVisibility.ifcGrid` was persisted **false**, and the symbolic parse is gated on `ifcAnnotations || effectiveGridEnabled` — so it was suppressed. With default toggles it does fire, on any model carrying an `IfcGridAxis`, and it regrows the main-thread WASM heap this PR reclaims for grids and alignments.

The numbers above are a fresh profile, default toggles, on a build verified to contain the change (the first attempt measured a stale `@ifc-lite/data` served from the turbo cache).

So this PR plus #2241 removes the 512 MB scratch and keeps grid/alignment off the main thread. The remaining 471 MB goes when #2249's step 2 moves the symbolic parse into this same worker, projecting roughly 670 MB. **#2183 should stay open until then.**

Control (independent of the fix): a 218 MB model with zero grids and **more** geometry (3.5M tris vs 1.8M) sat at 736 MB on the old build, i.e. the cost tracked grids, not model size.

## Verification

- Functional: `ISSUE_102_M3D-CON-CD.ifc` (494 grid axes). Grid toggle off gives a clean model, on gives the full grid mass. The overlay geometry genuinely comes back through the worker.
- 7 new tests on the client contract. Mutation-checked: dropping the `terminate()` call fails 5 of 7.
- `pnpm typecheck`, `pnpm test` (80/80 tasks, viewer 2,933 pass / 0 fail), `pnpm knip` clean for the new module.

## Deliberately not in this PR

- **Lazy grid parse.** Considered and rejected: `typeVisibility.ifcGrid` defaults to true, so it would only help users who explicitly turned grids off, in exchange for a visible delay when they turn them back on.
- **`useSymbolicAnnotations`.** Same whole-source parse shape, and it DOES fire here — its guard is `hasEntityType(store, 'IfcAnnotation', 'IfcGridAxis')`, so any model with a grid trips it. Its WASM walk is ~200 lines inside a 1102-line hook, so it moves in #2249 (step 1 landed, step 2 wires it to this worker). It accounts for the 471 MB still on the main thread above.
- **`store.source` retention (327 MB).** Deliberate, and it is what makes property reads instant without a second copy. Separate discussion.
- **Bytes-based wasm entry points.** Would remove the JS string entirely, but after this PR it buys no further main-thread reduction, only lower transient worker cost. Follow-up at best.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added background processing for grid and alignment overlay lines.
  * Overlay parsing now keeps the viewer responsive during large-file processing.
  * Added reliable handling for unavailable workers and parsing errors.
* **Bug Fixes**
  * Prevented source data from being modified during overlay parsing.
  * Improved resource cleanup, reuse, and recovery after processing failures.
* **Tests**
  * Added coverage for successful parsing, concurrent requests, timeouts, failures, and worker recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Known costs, stated rather than buried

- **Fresh WASM compile per parse session.** Terminating is what reclaims the memory, so each load refetches and recompiles `ifc-lite_bg.wasm` in the worker. On a cold cache or flaky connection that fetch can fail; the client resolves empty and the hook caches empty for that source, so the overlay is missing until reload. Decoration-only, console-warned, but real.
- **Non-cross-origin-isolated contexts** (no SAB, e.g. Firefox under COEP `credentialless`) structured-clone the whole source into the worker per job, which raises transient peak on exactly the memory-constrained machines this issue is about.
