### PR TITLE
fix(viewer): keep radix/floating-ui out of the store's top-level-await taint

### DIFF
--- a/apps/viewer/vite.config.ts
+++ b/apps/viewer/vite.config.ts
@@ -355,6 +355,23 @@ export default defineConfig({
           if (id.includes('/node_modules/apache-arrow/')) return 'arrow';
           if (id.includes('/node_modules/parquet-wasm/')) return 'parquet';
           if (id.includes('/node_modules/cesium/')) return 'cesium';
+          // @radix-ui/@floating-ui run synchronous, top-level module-init
+          // code (e.g. react-tooltip's `createPopperScope()` at module
+          // scope). The default chunker otherwise merges them into whatever
+          // chunk also touches @/store, and the store transitively pulls in
+          // WASM modules that use real top-level await — vite-plugin-top-level-await
+          // then wraps that WHOLE merged chunk's body in a deferred
+          // `.then()`, so the synchronous radix init runs late. A sibling
+          // chunk that imports the same merged chunk but has no async taint
+          // of its own evaluates synchronously and calls into the
+          // not-yet-populated binding — "C is not a function" at module
+          // scope (issue #2243). Keep radix/floating-ui in their own chunk,
+          // clear of the store's async taint, so their module-init always
+          // finishes before anything can import from them.
+          if (
+            id.includes('/node_modules/@radix-ui/') ||
+            id.includes('/node_modules/@floating-ui/')
+          ) return 'radix-ui';
           // three.js + addons — only the /mcp landing imports them, keep
           // the main viewer / pages off the hook.
           if (


### PR DESCRIPTION
Fixes #2243 — the viewer does not boot in the production build.

```
TypeError: C is not a function. (In 'C()', 'C' is undefined)
  Module Code (pending-CytPVxJ4.js:1:555)
```

**This also explains the repo-wide `Viewer E2E smoke` failure.** Both failing smoke tests die waiting for `input[type="file"]` — that is the same non-boot — and it reproduces on Linux/Chromium, so it was never Safari-specific. One bug, two symptoms.

## It is not a circular import

That was my first hypothesis and it is wrong. `pending.ts` is imported one way by `ActivityBar.tsx:41` and `LayerDraftSection.tsx:21`, and imports `@/store` one way. Nothing imports back. No source-level cycle exists.

The real cause is a chunking + top-level-await interaction, traced through the sourcemap (`char 553` → `M=C()`):

1. The `pending-*` chunk also bundles **`@radix-ui/react-tooltip`**, which runs `var usePopperScope = createPopperScope()` at **module scope** (`react-tooltip/dist/index.mjs:25`).
2. `createPopperScope` comes from an auto-generated chunk that statically imports `@/store`, which transitively pulls in WASM modules using **real top-level `await`**.
3. `vite-plugin-top-level-await` propagates that taint by wrapping the **entire chunk body** — including the wholly unrelated, synchronous `createContextScope('Popper')` init — in `Promise.all([__tla_0..__tla_3]).then(async () => { ... })`.
4. The `pending-*` chunk has **no async taint of its own**, so its top-level code runs synchronously and calls `createPopperScope()` *before* that deferred callback has populated the binding.

Hence `C is undefined` at module scope. The minified name and the chunk name are both incidental — this is a hazard of which modules land together, not of any one file.

## The fix

`manualChunks` already buckets `sandbox`, `export`, `server-client`, `bcf`, `ids`, `lens`, `drawing-2d`, `cesium` and `three`. Nothing kept `@radix-ui` / `@floating-ui` — pure synchronous UI-init code — out of whatever chunk also touches the store, so the default chunker merged them and they inherited its taint.

```js
if (
  id.includes('/node_modules/@radix-ui/') ||
  id.includes('/node_modules/@floating-ui/')
) return 'radix-ui';
```

Their module init now always completes before any importer evaluates.

## Why it never showed up in dev

The dev server serves unbundled ESM with a different evaluation order, and the app boots clean there — verified, not assumed: I ran the identical headless check against `vite` dev and got zero console errors. It only manifests in the bundled build, which is exactly why CI's E2E (which builds) caught it while local dev did not.

## Verification — built and loaded, both directions

Done by hand in headless Chromium against a served `dist/`, not inferred:

| | result |
|---|---|
| **without the fix** | `BOOT FAILED` — `TypeError: C is not a function` at `assets/pending-D_t-TAWB.js:1:553` |
| **with the fix** | `BOOTED OK`, zero `pageerror`, `radix-ui-*.js` (153.79 kB / 47.64 kB gzip) emitted as its own chunk |

Remaining console output on the good build is benign: a 404 for the Vercel analytics script and "No available adapters" (no WebGPU in headless).

## The PostHog error in the report is incidental

`Cannot load blob:… due to access control checks` from `posthog-recorder.js` is Safari refusing a blob-URL worker for session replay, in PostHog's own bundle. Not causal — the `TypeError` reproduces in headless Chrome with no blob involved at all. It should stay a separate concern.

## Worth considering separately

This class of bug is invisible to every check we run except a real browser load of the built app. `tsc`, unit tests and lint all pass on the broken build — CI only caught it because the E2E boots the bundle. Whatever makes that signal louder (or fails faster than a 30s `waitForSelector` timeout) would have turned hours into minutes here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved application loading by grouping Radix UI and Floating UI components into a dedicated bundle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->