### PR TITLE
fix(viewer): keep Radix primitives in one chunk so the app boots (#2243)

### DIFF
--- a/apps/viewer/vite.config.ts
+++ b/apps/viewer/vite.config.ts
@@ -344,6 +344,14 @@ export default defineConfig({
       },
       output: {
         manualChunks(id) {
+          // Radix primitives must stay in ONE chunk. They call each other at
+          // MODULE SCOPE (`createContextScope('Tooltip', [createPopperScope])`
+          // then `createPopperScope()`), so splitting them across chunks lets a
+          // top-level call reach a binding whose chunk has not initialised yet
+          // — the viewer then dies with `C is not a function` during module
+          // evaluation, before React mounts, and the whole app white-screens
+          // (#2243).
+          if (id.includes('/node_modules/@radix-ui/')) return 'radix';
           if (id.includes('/packages/sandbox/')) return 'sandbox';
           if (id.includes('/packages/export/')) return 'exporters';
           if (id.includes('/packages/server-client/')) return 'server-client';


### PR DESCRIPTION
Fixes #2243. **ifclite.com is white-screening on current `main`** — production is only up because of an instant rollback.

## The failure

The bundle throws during module evaluation, before React mounts:

```
TypeError: C is not a function. (In 'C()', 'C' is undefined)
	Module Code (pending-CytPVxJ4.js:1:555)
```

`C` is `createPopperScope`, imported from a sibling chunk. Radix calls across its own primitives **at module scope**:

```js
const [createTooltipContext, createTooltipScope] =
  createContextScope('Tooltip', [createPopperScope]);
const usePopperScope = createPopperScope();   // <- top-level call, char 555
```

Rolldown had split Tooltip and Popper into different chunks, so that top-level call reached a binding whose chunk had not initialised yet. There is no import cycle — it is an initialisation-order problem across a chunk boundary.

The throw escapes before any error boundary exists, so `#root` stays empty. **Every other symptom follows from that one fault:**

- `Viewer E2E smoke` — times out on `input[type="file"]`, which only renders inside the component tree that never mounted
- `Viewer benchmark (advisory)` — same selector, same cause
- `Build + WASM + Rust + Node` — a rollup; it is red only because `viewer-e2e` is

## The fix

Pin every `@radix-ui/*` module to one chunk, so the call is intra-chunk and ordering cannot break it.

## Verification

Production build served by `vite preview`, probed with Playwright, with a negative control:

| | before | after |
|---|---|---|
| `input[type="file"]` attaches | ❌ no | ✅ yes |
| `#root` innerHTML | **0 bytes** | 118,124 bytes |
| page errors | `C is not a function` | none |

## Note on blame

The sources stack (#1976…#2155) did **not** introduce this. It changed the module graph enough to move where the automatic splitter drew the boundary. Any future import shift could redraw it again — which is why the chunk is now pinned rather than left to the splitter.

Worth a separate look: `Viewer E2E smoke` caught a real production outage and did not block a single merge, and the benchmark is labelled "advisory". That is why this reached users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved application loading by grouping Radix UI components into a dedicated bundle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->