### PR TITLE
fix(deps): bump brace-expansion override to ^5.0.9 (GHSA-rgw5-rvv9-x895)

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
       "@babel/core": "^7.29.6",
       "js-yaml@4": "^4.3.0",
       "read-yaml-file": "^2.1.0",
-      "brace-expansion": "^5.0.8",
+      "brace-expansion": "^5.0.9",
       "minimatch": "^10.2.5"
     },
     "patchedDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,7 +27,7 @@ overrides:
   '@babel/core': ^7.29.6
   js-yaml@4: ^4.3.0
   read-yaml-file: ^2.1.0
-  brace-expansion: ^5.0.8
+  brace-expansion: ^5.0.9
   minimatch: ^10.2.5
 
 patchedDependencies:
@@ -3513,8 +3513,8 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -7520,7 +7520,7 @@ snapshots:
 
   boolbase@1.0.0: {}
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -8783,7 +8783,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
Closes the open **high**-severity Dependabot alert on the default branch.

`brace-expansion` `>= 4.0.0 < 5.0.9` — DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation. Patched in **5.0.9**.

We already pin it via `pnpm.overrides`, but at `^5.0.8`, so the lockfile resolved exactly 5.0.8 — one patch short of the fix. Transitive only (glob/minimatch chain), no source change needed. One character in `package.json`, plus the lockfile.

## Verification

- `pnpm-lock.yaml` now resolves `brace-expansion@5.0.9` at both sites (was 5.0.8)
- `pnpm build` 43/43
- `pnpm turbo test --force` 86/86
- `pnpm turbo typecheck --force` 36/36

## One thing found along the way

The first full run failed on `@ifc-lite/export` → `parquet-geometry.test.ts` → *"bakes the per-mesh origin into world vertices on all three axes"*. It is **a flake, not this change**: that test passes on clean `main` (450/450), and passes twice more with this bump applied (450/450, 450/450), and `brace-expansion` is a glob utility that cannot reach parquet geometry. Filed separately so it does not get rediscovered as a mystery red.