### PR TITLE
refactor(viewer): lift the symbolic-annotation walk out of the hook (step 1 of 2 for #2183)

### DIFF
--- a/apps/viewer/src/hooks/useSymbolicAnnotations.ts
+++ b/apps/viewer/src/hooks/useSymbolicAnnotations.ts
@@ -13,182 +13,26 @@
  */
 
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { GeometryProcessor } from '@ifc-lite/geometry';
 import type { DrawingLine2D } from '@ifc-lite/renderer';
-import { decodeIfcString } from '@ifc-lite/encoding';
 import { useViewerStore } from '@/store';
 import { useShallow } from 'zustand/react/shallow';
 import type { IfcDataStore } from '@ifc-lite/parser';
 import { hasEntityType } from './has-entity-type.js';
+import {
+  createEmptyParseResult,
+  debugEnabled,
+  parseSymbolicAnnotations,
+  type AnnotationFill2D,
+  type AnnotationText2D,
+  type AnnotationsForStorey,
+  type ParseResult,
+} from '../lib/overlay-parse/symbolic-parse.js';
 
-/** Lines belonging to a single storey, ready to feed into the section overlay. */
-export interface AnnotationsForStorey {
-  storeyId: number;
-  /** Authored `IfcBuildingStorey.Elevation`. `null` means the storey carried
-   *  no elevation in the parsed metadata — distinguishing that from a real
-   *  ground-floor at 0.0 matters because `resolveBucketY` only wants to swap
-   *  in the fallback in the missing case, not for legitimate ground floors. */
-  storeyElevation: number | null;
-  lines: DrawingLine2D[];
-  texts: AnnotationText2D[];
-  fills: AnnotationFill2D[];
-}
-
-/**
- * A single text label in renderer 2D space (XZ on the section plane).
- *
- * `dirX / dirY` encodes the baseline direction (already mirrored to match the
- * Y-negated 2D coord system that lines and circles use). `height` is in world
- * units. `alignment` is the raw IFC `BoxAlignment` string ("bottom-left",
- * "center", …) — the renderer interprets it.
- */
-export interface AnnotationText2D {
-  x: number;
-  y: number;
-  dirX: number;
-  dirY: number;
-  height: number;
-  content: string;
-  alignment: string;
-  /** Express ID of the owning IfcAnnotation / IfcGridAxis entity (per-entity hide). */
-  ownerId: number;
-  /**
-   * For multi-line text literals (e.g. CJK descriptions with `\X\0A`
-   * newlines), one IfcTextLiteralWithExtent expands into one AnnotationText2D
-   * per line. `lineYOffset` is added to the storey-elevation world-Y at 3D
-   * conversion so successive lines stack downward (negative Y) below the
-   * shared anchor. Optional — single-line literals leave it undefined.
-   */
-  lineYOffset?: number;
-  /**
-   * When true, the renderer rebuilds the glyph quad in screen-aligned
-   * (cameraRight, cameraUp) basis so the text always faces the camera.
-   * Set for every annotation literal (grid bubbles, dimension callouts,
-   * leader labels) so they stay legible in any view — flat-in-plane text
-   * collapses to a sliver at oblique angles (issue #812). Defaults to false.
-   */
-  billboard?: boolean;
-  /** sRGB straight-alpha tint (0..1). Defaults to renderer near-black. */
-  color?: [number, number, number, number];
-  /** Per-instance target cap height in screen pixels. 0/undef = renderer default. */
-  targetPx?: number;
-}
-
-/**
- * A single filled region in renderer 2D space. Outer ring + holes flattened
- * into one `points` array; `holesOffsets` marks where each hole starts (in
- * vertex indices, not floats). Empty `holesOffsets` = simple polygon.
- *
- * `hatching` is present when the IFC style chain resolved to an
- * IfcFillAreaStyleHatching. When absent the fill is solid (color only).
- */
-export interface AnnotationFill2D {
-  points: Float32Array;
-  holesOffsets: Uint32Array;
-  color: [number, number, number, number];
-  /** Express ID of the owning IfcAnnotation / IfcGridAxis entity (per-entity hide). */
-  ownerId: number;
-  hatching?: {
-    spacing: number;
-    angle: number;
-    angleSecondary: number | null;
-    lineWidth: number;
-  };
-}
-
-/** Cached parse result keyed by source identity.
- *
- * IfcAnnotation and IfcGridAxis primitives are stored in PARALLEL bucket
- * collections (issue #862). They share the same parse pass and the same
- * storey-resolution logic, but the renderer treats them differently:
- *
- *   - Annotation buckets always lift every storey (memory
- *     `feedback_3d_annotation_overlay_no_section_filter.md`: the user
- *     expects every storey's dimensions to be visible in 3D).
- *   - Grid buckets get optional section-plane filtering and an
- *     independent visibility toggle, so dense-grid models can hide
- *     grids per storey without losing dimensions.
- */
-interface ParseResult {
-  // IfcAnnotation buckets
-  byStorey: Map<number, AnnotationsForStorey>;
-  loose: DrawingLine2D[];
-  looseTexts: AnnotationText2D[];
-  looseFills: AnnotationFill2D[];
-
-  // IfcGridAxis buckets (issue #862)
-  gridByStorey: Map<number, AnnotationsForStorey>;
-  gridLoose: DrawingLine2D[];
-  gridLooseTexts: AnnotationText2D[];
-  gridLooseFills: AnnotationFill2D[];
-}
-
-const CIRCLE_SEGMENTS_FULL = 32;
-const CIRCLE_SEGMENTS_ARC = 16;
-
-/**
- * Convert a polyline (Float32Array of [x,y,x,y,…]) into start/end segments.
- * Exported for unit testing.
- */
-export function polylineToSegments(
-  points: Float32Array,
-  pointCount: number,
-  isClosed: boolean,
-  out: DrawingLine2D[],
-  ownerId = 0,
-): void {
-  for (let j = 0; j < pointCount - 1; j++) {
-    out.push({
-      line: {
-        start: { x: points[j * 2], y: points[j * 2 + 1] },
-        end:   { x: points[(j + 1) * 2], y: points[(j + 1) * 2 + 1] },
-      },
-      category: 'annotation',
-      ownerId,
-    });
-  }
-  if (isClosed && pointCount > 2) {
-    out.push({
-      line: {
-        start: { x: points[(pointCount - 1) * 2], y: points[(pointCount - 1) * 2 + 1] },
-        end:   { x: points[0], y: points[1] },
-      },
-      category: 'annotation',
-      ownerId,
-    });
-  }
-}
-
-/**
- * Tessellate a circle/arc into chord segments.
- * Exported for unit testing.
- */
-export function circleToSegments(
-  centerX: number,
-  centerY: number,
-  radius: number,
-  startAngle: number,
-  endAngle: number,
-  isFullCircle: boolean,
-  out: DrawingLine2D[],
-  ownerId = 0,
-): void {
-  const numSegments = isFullCircle ? CIRCLE_SEGMENTS_FULL : CIRCLE_SEGMENTS_ARC;
-  for (let j = 0; j < numSegments; j++) {
-    const t1 = j / numSegments;
-    const t2 = (j + 1) / numSegments;
-    const a1 = startAngle + t1 * (endAngle - startAngle);
-    const a2 = startAngle + t2 * (endAngle - startAngle);
-    out.push({
-      line: {
-        start: { x: centerX + radius * Math.cos(a1), y: centerY + radius * Math.sin(a1) },
-        end:   { x: centerX + radius * Math.cos(a2), y: centerY + radius * Math.sin(a2) },
-      },
-      category: 'annotation',
-      ownerId,
-    });
-  }
-}
+// The parse walk itself lives in `lib/overlay-parse/symbolic-parse.ts` so a
+// worker can import it (a worker module cannot import this React hook file).
+// Re-exported here so existing consumers keep their import paths.
+export type { AnnotationsForStorey, AnnotationText2D, AnnotationFill2D };
+export { polylineToSegments, circleToSegments } from '../lib/overlay-parse/symbolic-parse.js';
 
 /** Make a stable cache key for one parsed source.
  *
@@ -223,265 +67,36 @@ function sourceKey(store: IfcDataStore | null | undefined): string | null {
   return `b${len}-${hashOne(head)}-${hashOne(mid)}-${hashOne(tail)}`;
 }
 
-/** Set `localStorage.IFC_ANNOTATIONS_DEBUG = '1'` in the browser to log
- *  per-store parse counts + lift vertex counts to the console. Off by
- *  default; useful when triaging "no annotations visible" reports. */
-const debugEnabled = (): boolean => {
-  if (typeof window === 'undefined') return false;
-  try { return window.localStorage?.getItem('IFC_ANNOTATIONS_DEBUG') === '1'; }
-  catch { return false; }
-};
-
+/**
+ * Parse one store's symbolic annotations.
+ *
+ * The walk itself is `parseSymbolicAnnotations` in
+ * `lib/overlay-parse/symbolic-parse.ts`; this wrapper only supplies the
+ * entity-index pre-filter, which needs `store.entityIndex` and therefore
+ * cannot move with it.
+ */
 async function parseAnnotations(
   store: IfcDataStore,
 ): Promise<ParseResult> {
-  const result: ParseResult = {
-    byStorey: new Map(),
-    loose: [],
-    looseTexts: [],
-    looseFills: [],
-    gridByStorey: new Map(),
-    gridLoose: [],
-    gridLooseTexts: [],
-    gridLooseFills: [],
-  };
   const source = store.source;
-  if (!source || source.byteLength === 0) {
-    if (debugEnabled()) console.log('[annotations] skip: missing/empty source');
-    return result;
-  }
   // Skip the full-source WASM scan only when the model has neither IfcAnnotation
   // nor IfcGridAxis — this parse path ALSO feeds the grid buckets (gridByStorey /
   // gridLoose*), so gating on IfcAnnotation alone would drop grid-only models.
   // The scan copies the entire IFC source into the WASM heap on the main thread,
   // so skipping it when there is nothing to find still matters.
-  if (!hasEntityType(store, 'IfcAnnotation', 'IfcGridAxis')) {
+  //
+  // Gated on a non-empty source so the missing/empty-source case still falls
+  // through to `parseSymbolicAnnotations`, which reports it as it always did.
+  if (source && source.byteLength > 0 && !hasEntityType(store, 'IfcAnnotation', 'IfcGridAxis')) {
     if (debugEnabled()) console.log('[annotations] skip: no IfcAnnotation/IfcGridAxis entities');
-    return result;
+    return createEmptyParseResult();
   }
 
-  const hierarchy = store.spatialHierarchy;
-  const elementToStorey = hierarchy?.elementToStorey;
-  const storeyElevations = hierarchy?.storeyElevations;
-
-  const processor = new GeometryProcessor();
-  try {
-    await processor.init();
-    // SymbolicRepresentationCollection and each getPolyline/getCircle/getText/
-    // getFill item are wasm-bindgen handles owning WASM memory — free them
-    // deterministically (AGENTS.md §7). Leaking them to GC lets the
-    // FinalizationRegistry free them later against an already-grown/reused
-    // shared dlmalloc heap, corrupting the allocator free-list.
-    const collection = processor.parseSymbolicRepresentations(source);
-    if (debugEnabled()) {
-      console.log(
-        `[annotations] parsed ${source.byteLength} bytes →`,
-        collection
-          ? `${collection.polylineCount} polylines, ${collection.circleCount} circles, ${collection.textCount} texts, ${collection.fillCount} fills`
-          : 'null',
-      );
-    }
-    if (!collection) return result;
-    try {
-    if (collection.isEmpty) return result;
-
-    // Resolve a bucket by elevation rather than by storey id.
-    //
-    // The legacy path used `elementToStorey` exclusively — which breaks for
-    // 3DEXPERIENCE / IfcPlusPlus exports whose `IfcRelAggregates` leaves
-    // storeys orphaned so `SpatialHierarchyBuilder` reports "No storeys
-    // found". Those files still encode the elevation on each item's
-    // geometry (the IfcCartesianPoint.Z), which the WASM extractor now
-    // surfaces as `primitive.worldY`. Bucketing by Y means every annotation
-    // lands at the right floor regardless of whether the spatial hierarchy
-    // could be built.
-    //
-    // Priority: explicit primitive worldY → fall back to storey-table
-    // elevation → null (loose bucket, renders at fallbackY).
-    //
-    // Bucket keys are millimetre-rounded Y so two storeys 1mm apart still
-    // collapse to one bucket — that's the precision Revit etc. round to.
-    const ensureBucket = (
-      expressId: number,
-      primitiveWorldY: number,
-      ifcType: string,
-    ): AnnotationsForStorey | null => {
-      let effectiveY: number | null = null;
-      if (Number.isFinite(primitiveWorldY) && primitiveWorldY !== 0) {
-        effectiveY = primitiveWorldY;
-      } else {
-        const storeyId = elementToStorey?.get(expressId);
-        if (storeyId !== undefined) {
-          const elev = storeyElevations?.get(storeyId);
-          if (typeof elev === 'number' && Number.isFinite(elev)) effectiveY = elev;
-        }
-      }
-      if (effectiveY === null) return null;
-      const key = Math.round(effectiveY * 1000);
-      // Issue #862: IfcGridAxis primitives land in a parallel bucket
-      // collection so the renderer can section-clip + visibility-toggle
-      // them independently of IfcAnnotation (text/dimension symbols).
-      const storeyMap = ifcType === 'IfcGridAxis' ? result.gridByStorey : result.byStorey;
-      let bucket = storeyMap.get(key);
-      if (!bucket) {
-        bucket = {
-          storeyId: key,
-          storeyElevation: effectiveY,
-          lines: [],
-          texts: [],
-          fills: [],
-        };
-        storeyMap.set(key, bucket);
-      }
-      return bucket;
-    };
-
-    for (let i = 0; i < collection.polylineCount; i++) {
-      const poly = collection.getPolyline(i);
-      if (!poly) continue;
-      try {
-        if (poly.ifcType !== 'IfcAnnotation' && poly.ifcType !== 'IfcGridAxis') continue;
-        const bucket = ensureBucket(poly.expressId, poly.worldY, poly.ifcType);
-        const looseTarget = poly.ifcType === 'IfcGridAxis' ? result.gridLoose : result.loose;
-        const out = bucket ? bucket.lines : looseTarget;
-        // poly.points is consumed synchronously here (not stored), so no copy needed.
-        polylineToSegments(poly.points, poly.pointCount, poly.isClosed, out, poly.expressId);
-      } finally {
-        poly.free();
-      }
-    }
-
-    for (let i = 0; i < collection.circleCount; i++) {
-      const circle = collection.getCircle(i);
-      if (!circle) continue;
-      try {
-        if (circle.ifcType !== 'IfcAnnotation' && circle.ifcType !== 'IfcGridAxis') continue;
-        const bucket = ensureBucket(circle.expressId, circle.worldY, circle.ifcType);
-        const looseTarget = circle.ifcType === 'IfcGridAxis' ? result.gridLoose : result.loose;
-        const out = bucket ? bucket.lines : looseTarget;
-        circleToSegments(
-          circle.centerX,
-          circle.centerY,
-          circle.radius,
-          circle.startAngle,
-          circle.endAngle,
-          circle.isFullCircle,
-          out,
-          circle.expressId,
-        );
-      } finally {
-        circle.free();
-      }
-    }
-
-    for (let i = 0; i < collection.textCount; i++) {
-      const text = collection.getText(i);
-      if (!text) continue;
-      try {
-      if (text.ifcType !== 'IfcAnnotation' && text.ifcType !== 'IfcGridAxis') continue;
-      // Skip empty literals so the renderer doesn't waste an instance slot.
-      // Decode STEP escapes — `\X2\NNNN\X0\` (UTF-16 hex code units) and
-      // `\X\NN` (Latin-1 hex byte). The Rust parser intentionally passes
-      // the literal through verbatim; this is where the JS encoding
-      // package gets applied. Without it, non-ASCII annotation labels
-      // (e.g. CJK content) render as raw escape sequences in the atlas.
-      const decoded = decodeIfcString(text.content);
-      if (decoded.length === 0) continue;
-
-      // Multi-line split: IfcTextLiteralWithExtent.SizeInY is the LAYOUT BOX
-      // height, not the glyph cap height. The Rust extractor multiplies
-      // SizeInY × 0.7 to recover a single-line cap; for multi-line literals
-      // we further divide by line count and stack lines downward in world-Y.
-      // Source: IFC4 spec — IfcPlanarExtent describes the bounding box of
-      // the typeset string; one literal per line is the conventional
-      // rendering model (matches BIMvision / Solibri / Revit).
-      const lines = decoded.split(/\r?\n/).filter((l) => l.length > 0);
-      if (lines.length === 0) continue;
-      const perLineHeight = lines.length > 1 ? text.height / lines.length : text.height;
-      // Industry-standard line-spacing (CSS line-height ≈ 1.2). Picks up
-      // a little air between rows so descenders don't kiss the next cap.
-      const lineSpacing = perLineHeight * 1.2;
-      const bucket = ensureBucket(text.expressId, text.worldY, text.ifcType);
-      const looseTextTarget = text.ifcType === 'IfcGridAxis' ? result.gridLooseTexts : result.looseTexts;
-      // All annotation text — grid bubbles, dimension callouts, leader labels —
-      // billboards to the camera so it stays legible in any view orientation
-      // (top-down, eye-level, oblique). The shader rebuilds the quad in the
-      // screen-aligned basis at render time. Authored orientation is intentionally
-      // dropped: at oblique viewing angles, flat-in-plane text becomes a smeared
-      // sliver of pixels (issue #812). Anchor + alignment are preserved, so each
-      // label still sits at its authored insertion point.
-      // Read per-instance style metadata. WASM emits these for grid
-      // bubble parts (● fill / ○ outline / tag) and reserves them for
-      // future IfcTextStyle resolution on regular annotation text.
-      const colorA = text.colorA;
-      const hasColor = colorA > 0;
-      const textColor: [number, number, number, number] | undefined = hasColor
-        ? [text.colorR, text.colorG, text.colorB, colorA]
-        : undefined;
-      const targetPx = text.targetPx > 0 ? text.targetPx : undefined;
-      for (let li = 0; li < lines.length; li++) {
-        const t2d: AnnotationText2D = {
-          x: text.x,
-          y: text.y,
-          dirX: text.dirX,
-          dirY: text.dirY,
-          height: perLineHeight,
-          content: lines[li],
-          alignment: text.alignment,
-          lineYOffset: -li * lineSpacing,
-          billboard: true,
-          color: textColor,
-          targetPx,
-          ownerId: text.expressId,
-        };
-        (bucket ? bucket.texts : looseTextTarget).push(t2d);
-      }
-      } finally {
-        text.free();
-      }
-    }
-
-    for (let i = 0; i < collection.fillCount; i++) {
-      const fill = collection.getFill(i);
-      if (!fill) continue;
-      try {
-        if (fill.ifcType !== 'IfcAnnotation' && fill.ifcType !== 'IfcGridAxis') continue;
-        // fill.points / fill.holesOffsets are getter results that may be views
-        // into WASM memory; they're STORED into f2d (outlive this iteration),
-        // so copy them before the handle is freed below. Element types match
-        // the AnnotationFill2D fields (Float32Array / Uint32Array).
-        const points = new Float32Array(fill.points);
-        if (points.length < 6) continue; // <3 vertices = no polygon
-        const holesOffsets = new Uint32Array(fill.holesOffsets);
-        const f2d: AnnotationFill2D = {
-          points,
-          holesOffsets,
-          color: [fill.fillR, fill.fillG, fill.fillB, fill.fillA],
-          ownerId: fill.expressId,
-          hatching: fill.hasHatching
-            ? {
-                spacing: fill.hatchSpacing,
-                angle: fill.hatchAngle,
-                angleSecondary: Number.isNaN(fill.hatchAngleSecondary) ? null : fill.hatchAngleSecondary,
-                lineWidth: fill.hatchLineWidth,
-              }
-            : undefined,
-        };
-        const bucket = ensureBucket(fill.expressId, fill.worldY, fill.ifcType);
-        const looseFillTarget = fill.ifcType === 'IfcGridAxis' ? result.gridLooseFills : result.looseFills;
-        (bucket ? bucket.fills : looseFillTarget).push(f2d);
-      } finally {
-        fill.free();
-      }
-    }
-    } finally {
-      collection.free();
-    }
-  } finally {
-    processor.dispose();
-  }
-
-  return result;
+  return parseSymbolicAnnotations({
+    source,
+    elementToStorey: store.spatialHierarchy?.elementToStorey,
+    storeyElevations: store.spatialHierarchy?.storeyElevations,
+  });
 }
 
 /**

--- a/apps/viewer/src/lib/overlay-parse/symbolic-parse.ts
+++ b/apps/viewer/src/lib/overlay-parse/symbolic-parse.ts
@@ -14,200 +14,35 @@
  */
 
 import { GeometryProcessor } from '@ifc-lite/geometry';
-import type { DrawingLine2D } from '@ifc-lite/renderer';
 import { decodeIfcString } from '@ifc-lite/encoding';
+import {
+  circleToSegments,
+  createEmptyParseResult,
+  polylineToSegments,
+  type AnnotationFill2D,
+  type AnnotationsForStorey,
+  type AnnotationText2D,
+  type ParseResult,
+} from './symbolic-shapes.js';
 
-/** Lines belonging to a single storey, ready to feed into the section overlay. */
-export interface AnnotationsForStorey {
-  storeyId: number;
-  /** Authored `IfcBuildingStorey.Elevation`. `null` means the storey carried
-   *  no elevation in the parsed metadata — distinguishing that from a real
-   *  ground-floor at 0.0 matters because `resolveBucketY` only wants to swap
-   *  in the fallback in the missing case, not for legitimate ground floors. */
-  storeyElevation: number | null;
-  lines: DrawingLine2D[];
-  texts: AnnotationText2D[];
-  fills: AnnotationFill2D[];
-}
+// The result contracts and pure helpers live next door so both modules stay
+// under the ~400 line house limit. Re-exported so this stays the single import
+// site for consumers of the parse.
+export * from './symbolic-shapes.js';
 
-/**
- * A single text label in renderer 2D space (XZ on the section plane).
- *
- * `dirX / dirY` encodes the baseline direction (already mirrored to match the
- * Y-negated 2D coord system that lines and circles use). `height` is in world
- * units. `alignment` is the raw IFC `BoxAlignment` string ("bottom-left",
- * "center", …) — the renderer interprets it.
- */
-export interface AnnotationText2D {
-  x: number;
-  y: number;
-  dirX: number;
-  dirY: number;
-  height: number;
-  content: string;
-  alignment: string;
-  /** Express ID of the owning IfcAnnotation / IfcGridAxis entity (per-entity hide). */
-  ownerId: number;
-  /**
-   * For multi-line text literals (e.g. CJK descriptions with `\X\0A`
-   * newlines), one IfcTextLiteralWithExtent expands into one AnnotationText2D
-   * per line. `lineYOffset` is added to the storey-elevation world-Y at 3D
-   * conversion so successive lines stack downward (negative Y) below the
-   * shared anchor. Optional — single-line literals leave it undefined.
-   */
-  lineYOffset?: number;
-  /**
-   * When true, the renderer rebuilds the glyph quad in screen-aligned
-   * (cameraRight, cameraUp) basis so the text always faces the camera.
-   * Set for every annotation literal (grid bubbles, dimension callouts,
-   * leader labels) so they stay legible in any view — flat-in-plane text
-   * collapses to a sliver at oblique angles (issue #812). Defaults to false.
-   */
-  billboard?: boolean;
-  /** sRGB straight-alpha tint (0..1). Defaults to renderer near-black. */
-  color?: [number, number, number, number];
-  /** Per-instance target cap height in screen pixels. 0/undef = renderer default. */
-  targetPx?: number;
-}
-
-/**
- * A single filled region in renderer 2D space. Outer ring + holes flattened
- * into one `points` array; `holesOffsets` marks where each hole starts (in
- * vertex indices, not floats). Empty `holesOffsets` = simple polygon.
- *
- * `hatching` is present when the IFC style chain resolved to an
- * IfcFillAreaStyleHatching. When absent the fill is solid (color only).
- */
-export interface AnnotationFill2D {
-  points: Float32Array;
-  holesOffsets: Uint32Array;
-  color: [number, number, number, number];
-  /** Express ID of the owning IfcAnnotation / IfcGridAxis entity (per-entity hide). */
-  ownerId: number;
-  hatching?: {
-    spacing: number;
-    angle: number;
-    angleSecondary: number | null;
-    lineWidth: number;
-  };
-}
-
-/** Cached parse result keyed by source identity.
- *
- * IfcAnnotation and IfcGridAxis primitives are stored in PARALLEL bucket
- * collections (issue #862). They share the same parse pass and the same
- * storey-resolution logic, but the renderer treats them differently:
- *
- *   - Annotation buckets always lift every storey (memory
- *     `feedback_3d_annotation_overlay_no_section_filter.md`: the user
- *     expects every storey's dimensions to be visible in 3D).
- *   - Grid buckets get optional section-plane filtering and an
- *     independent visibility toggle, so dense-grid models can hide
- *     grids per storey without losing dimensions.
- */
-export interface ParseResult {
-  // IfcAnnotation buckets
-  byStorey: Map<number, AnnotationsForStorey>;
-  loose: DrawingLine2D[];
-  looseTexts: AnnotationText2D[];
-  looseFills: AnnotationFill2D[];
-
-  // IfcGridAxis buckets (issue #862)
-  gridByStorey: Map<number, AnnotationsForStorey>;
-  gridLoose: DrawingLine2D[];
-  gridLooseTexts: AnnotationText2D[];
-  gridLooseFills: AnnotationFill2D[];
-}
-
-/** The empty (nothing parsed) result. Also used by callers that short-circuit
- *  before the walk — e.g. the `hasEntityType` pre-filter in the hook. */
-export function createEmptyParseResult(): ParseResult {
-  return {
-    byStorey: new Map(),
-    loose: [],
-    looseTexts: [],
-    looseFills: [],
-    gridByStorey: new Map(),
-    gridLoose: [],
-    gridLooseTexts: [],
-    gridLooseFills: [],
-  };
-}
-
-const CIRCLE_SEGMENTS_FULL = 32;
-const CIRCLE_SEGMENTS_ARC = 16;
-
-/**
- * Convert a polyline (Float32Array of [x,y,x,y,…]) into start/end segments.
- * Exported for unit testing.
- */
-export function polylineToSegments(
-  points: Float32Array,
-  pointCount: number,
-  isClosed: boolean,
-  out: DrawingLine2D[],
-  ownerId = 0,
-): void {
-  for (let j = 0; j < pointCount - 1; j++) {
-    out.push({
-      line: {
-        start: { x: points[j * 2], y: points[j * 2 + 1] },
-        end:   { x: points[(j + 1) * 2], y: points[(j + 1) * 2 + 1] },
-      },
-      category: 'annotation',
-      ownerId,
-    });
-  }
-  if (isClosed && pointCount > 2) {
-    out.push({
-      line: {
-        start: { x: points[(pointCount - 1) * 2], y: points[(pointCount - 1) * 2 + 1] },
-        end:   { x: points[0], y: points[1] },
-      },
-      category: 'annotation',
-      ownerId,
-    });
-  }
-}
-
-/**
- * Tessellate a circle/arc into chord segments.
- * Exported for unit testing.
- */
-export function circleToSegments(
-  centerX: number,
-  centerY: number,
-  radius: number,
-  startAngle: number,
-  endAngle: number,
-  isFullCircle: boolean,
-  out: DrawingLine2D[],
-  ownerId = 0,
-): void {
-  const numSegments = isFullCircle ? CIRCLE_SEGMENTS_FULL : CIRCLE_SEGMENTS_ARC;
-  for (let j = 0; j < numSegments; j++) {
-    const t1 = j / numSegments;
-    const t2 = (j + 1) / numSegments;
-    const a1 = startAngle + t1 * (endAngle - startAngle);
-    const a2 = startAngle + t2 * (endAngle - startAngle);
-    out.push({
-      line: {
-        start: { x: centerX + radius * Math.cos(a1), y: centerY + radius * Math.sin(a1) },
-        end:   { x: centerX + radius * Math.cos(a2), y: centerY + radius * Math.sin(a2) },
-      },
-      category: 'annotation',
-      ownerId,
-    });
-  }
-}
-
-/** Set `localStorage.IFC_ANNOTATIONS_DEBUG = '1'` in the browser to log
- *  per-store parse counts + lift vertex counts to the console. Off by
+/** Verbose annotation tracing, opt-in via localStorage and therefore off by
  *  default; useful when triaging "no annotations visible" reports. */
 export const debugEnabled = (): boolean => {
   if (typeof window === 'undefined') return false;
-  try { return window.localStorage?.getItem('IFC_ANNOTATIONS_DEBUG') === '1'; }
-  catch { return false; }
+  try {
+    return window.localStorage?.getItem('IFC_ANNOTATIONS_DEBUG') === '1';
+  } catch (error) {
+    // Storage access throws in some privacy modes. A debug flag is never worth
+    // failing a parse over, but AGENTS.md forbids swallowing it silently.
+    // eslint-disable-next-line no-console
+    console.warn('[annotations] could not read the debug flag:', error);
+    return false;
+  }
 };
 
 /** Everything the symbolic-annotation walk needs off an `IfcDataStore`. */

--- a/apps/viewer/src/lib/overlay-parse/symbolic-parse.ts
+++ b/apps/viewer/src/lib/overlay-parse/symbolic-parse.ts
@@ -1,0 +1,453 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Symbolic-annotation (IfcAnnotation / IfcGridAxis) parse, extracted from
+ * `hooks/useSymbolicAnnotations.ts` so it can run off the React tree.
+ *
+ * The walk takes a plain `Uint8Array` source plus the two spatial-hierarchy
+ * lookups it needs, deliberately NOT an `IfcDataStore`: a worker module cannot
+ * import a React hook file, and the store is not structured-cloneable. The
+ * `hasEntityType` pre-filter stays at the call site because it reads
+ * `store.entityIndex`, which is not part of this input.
+ */
+
+import { GeometryProcessor } from '@ifc-lite/geometry';
+import type { DrawingLine2D } from '@ifc-lite/renderer';
+import { decodeIfcString } from '@ifc-lite/encoding';
+
+/** Lines belonging to a single storey, ready to feed into the section overlay. */
+export interface AnnotationsForStorey {
+  storeyId: number;
+  /** Authored `IfcBuildingStorey.Elevation`. `null` means the storey carried
+   *  no elevation in the parsed metadata — distinguishing that from a real
+   *  ground-floor at 0.0 matters because `resolveBucketY` only wants to swap
+   *  in the fallback in the missing case, not for legitimate ground floors. */
+  storeyElevation: number | null;
+  lines: DrawingLine2D[];
+  texts: AnnotationText2D[];
+  fills: AnnotationFill2D[];
+}
+
+/**
+ * A single text label in renderer 2D space (XZ on the section plane).
+ *
+ * `dirX / dirY` encodes the baseline direction (already mirrored to match the
+ * Y-negated 2D coord system that lines and circles use). `height` is in world
+ * units. `alignment` is the raw IFC `BoxAlignment` string ("bottom-left",
+ * "center", …) — the renderer interprets it.
+ */
+export interface AnnotationText2D {
+  x: number;
+  y: number;
+  dirX: number;
+  dirY: number;
+  height: number;
+  content: string;
+  alignment: string;
+  /** Express ID of the owning IfcAnnotation / IfcGridAxis entity (per-entity hide). */
+  ownerId: number;
+  /**
+   * For multi-line text literals (e.g. CJK descriptions with `\X\0A`
+   * newlines), one IfcTextLiteralWithExtent expands into one AnnotationText2D
+   * per line. `lineYOffset` is added to the storey-elevation world-Y at 3D
+   * conversion so successive lines stack downward (negative Y) below the
+   * shared anchor. Optional — single-line literals leave it undefined.
+   */
+  lineYOffset?: number;
+  /**
+   * When true, the renderer rebuilds the glyph quad in screen-aligned
+   * (cameraRight, cameraUp) basis so the text always faces the camera.
+   * Set for every annotation literal (grid bubbles, dimension callouts,
+   * leader labels) so they stay legible in any view — flat-in-plane text
+   * collapses to a sliver at oblique angles (issue #812). Defaults to false.
+   */
+  billboard?: boolean;
+  /** sRGB straight-alpha tint (0..1). Defaults to renderer near-black. */
+  color?: [number, number, number, number];
+  /** Per-instance target cap height in screen pixels. 0/undef = renderer default. */
+  targetPx?: number;
+}
+
+/**
+ * A single filled region in renderer 2D space. Outer ring + holes flattened
+ * into one `points` array; `holesOffsets` marks where each hole starts (in
+ * vertex indices, not floats). Empty `holesOffsets` = simple polygon.
+ *
+ * `hatching` is present when the IFC style chain resolved to an
+ * IfcFillAreaStyleHatching. When absent the fill is solid (color only).
+ */
+export interface AnnotationFill2D {
+  points: Float32Array;
+  holesOffsets: Uint32Array;
+  color: [number, number, number, number];
+  /** Express ID of the owning IfcAnnotation / IfcGridAxis entity (per-entity hide). */
+  ownerId: number;
+  hatching?: {
+    spacing: number;
+    angle: number;
+    angleSecondary: number | null;
+    lineWidth: number;
+  };
+}
+
+/** Cached parse result keyed by source identity.
+ *
+ * IfcAnnotation and IfcGridAxis primitives are stored in PARALLEL bucket
+ * collections (issue #862). They share the same parse pass and the same
+ * storey-resolution logic, but the renderer treats them differently:
+ *
+ *   - Annotation buckets always lift every storey (memory
+ *     `feedback_3d_annotation_overlay_no_section_filter.md`: the user
+ *     expects every storey's dimensions to be visible in 3D).
+ *   - Grid buckets get optional section-plane filtering and an
+ *     independent visibility toggle, so dense-grid models can hide
+ *     grids per storey without losing dimensions.
+ */
+export interface ParseResult {
+  // IfcAnnotation buckets
+  byStorey: Map<number, AnnotationsForStorey>;
+  loose: DrawingLine2D[];
+  looseTexts: AnnotationText2D[];
+  looseFills: AnnotationFill2D[];
+
+  // IfcGridAxis buckets (issue #862)
+  gridByStorey: Map<number, AnnotationsForStorey>;
+  gridLoose: DrawingLine2D[];
+  gridLooseTexts: AnnotationText2D[];
+  gridLooseFills: AnnotationFill2D[];
+}
+
+/** The empty (nothing parsed) result. Also used by callers that short-circuit
+ *  before the walk — e.g. the `hasEntityType` pre-filter in the hook. */
+export function createEmptyParseResult(): ParseResult {
+  return {
+    byStorey: new Map(),
+    loose: [],
+    looseTexts: [],
+    looseFills: [],
+    gridByStorey: new Map(),
+    gridLoose: [],
+    gridLooseTexts: [],
+    gridLooseFills: [],
+  };
+}
+
+const CIRCLE_SEGMENTS_FULL = 32;
+const CIRCLE_SEGMENTS_ARC = 16;
+
+/**
+ * Convert a polyline (Float32Array of [x,y,x,y,…]) into start/end segments.
+ * Exported for unit testing.
+ */
+export function polylineToSegments(
+  points: Float32Array,
+  pointCount: number,
+  isClosed: boolean,
+  out: DrawingLine2D[],
+  ownerId = 0,
+): void {
+  for (let j = 0; j < pointCount - 1; j++) {
+    out.push({
+      line: {
+        start: { x: points[j * 2], y: points[j * 2 + 1] },
+        end:   { x: points[(j + 1) * 2], y: points[(j + 1) * 2 + 1] },
+      },
+      category: 'annotation',
+      ownerId,
+    });
+  }
+  if (isClosed && pointCount > 2) {
+    out.push({
+      line: {
+        start: { x: points[(pointCount - 1) * 2], y: points[(pointCount - 1) * 2 + 1] },
+        end:   { x: points[0], y: points[1] },
+      },
+      category: 'annotation',
+      ownerId,
+    });
+  }
+}
+
+/**
+ * Tessellate a circle/arc into chord segments.
+ * Exported for unit testing.
+ */
+export function circleToSegments(
+  centerX: number,
+  centerY: number,
+  radius: number,
+  startAngle: number,
+  endAngle: number,
+  isFullCircle: boolean,
+  out: DrawingLine2D[],
+  ownerId = 0,
+): void {
+  const numSegments = isFullCircle ? CIRCLE_SEGMENTS_FULL : CIRCLE_SEGMENTS_ARC;
+  for (let j = 0; j < numSegments; j++) {
+    const t1 = j / numSegments;
+    const t2 = (j + 1) / numSegments;
+    const a1 = startAngle + t1 * (endAngle - startAngle);
+    const a2 = startAngle + t2 * (endAngle - startAngle);
+    out.push({
+      line: {
+        start: { x: centerX + radius * Math.cos(a1), y: centerY + radius * Math.sin(a1) },
+        end:   { x: centerX + radius * Math.cos(a2), y: centerY + radius * Math.sin(a2) },
+      },
+      category: 'annotation',
+      ownerId,
+    });
+  }
+}
+
+/** Set `localStorage.IFC_ANNOTATIONS_DEBUG = '1'` in the browser to log
+ *  per-store parse counts + lift vertex counts to the console. Off by
+ *  default; useful when triaging "no annotations visible" reports. */
+export const debugEnabled = (): boolean => {
+  if (typeof window === 'undefined') return false;
+  try { return window.localStorage?.getItem('IFC_ANNOTATIONS_DEBUG') === '1'; }
+  catch { return false; }
+};
+
+/** Everything the symbolic-annotation walk needs off an `IfcDataStore`. */
+export interface SymbolicParseInput {
+  source: Uint8Array;
+  /** store.spatialHierarchy?.elementToStorey */
+  elementToStorey?: ReadonlyMap<number, number>;
+  /** store.spatialHierarchy?.storeyElevations */
+  storeyElevations?: ReadonlyMap<number, number>;
+}
+
+export async function parseSymbolicAnnotations(
+  input: SymbolicParseInput,
+): Promise<ParseResult> {
+  const result: ParseResult = createEmptyParseResult();
+  const source = input.source;
+  if (!source || source.byteLength === 0) {
+    if (debugEnabled()) console.log('[annotations] skip: missing/empty source');
+    return result;
+  }
+
+  const elementToStorey = input.elementToStorey;
+  const storeyElevations = input.storeyElevations;
+
+  const processor = new GeometryProcessor();
+  try {
+    await processor.init();
+    // SymbolicRepresentationCollection and each getPolyline/getCircle/getText/
+    // getFill item are wasm-bindgen handles owning WASM memory — free them
+    // deterministically (AGENTS.md §7). Leaking them to GC lets the
+    // FinalizationRegistry free them later against an already-grown/reused
+    // shared dlmalloc heap, corrupting the allocator free-list.
+    const collection = processor.parseSymbolicRepresentations(source);
+    if (debugEnabled()) {
+      console.log(
+        `[annotations] parsed ${source.byteLength} bytes →`,
+        collection
+          ? `${collection.polylineCount} polylines, ${collection.circleCount} circles, ${collection.textCount} texts, ${collection.fillCount} fills`
+          : 'null',
+      );
+    }
+    if (!collection) return result;
+    try {
+    if (collection.isEmpty) return result;
+
+    // Resolve a bucket by elevation rather than by storey id.
+    //
+    // The legacy path used `elementToStorey` exclusively — which breaks for
+    // 3DEXPERIENCE / IfcPlusPlus exports whose `IfcRelAggregates` leaves
+    // storeys orphaned so `SpatialHierarchyBuilder` reports "No storeys
+    // found". Those files still encode the elevation on each item's
+    // geometry (the IfcCartesianPoint.Z), which the WASM extractor now
+    // surfaces as `primitive.worldY`. Bucketing by Y means every annotation
+    // lands at the right floor regardless of whether the spatial hierarchy
+    // could be built.
+    //
+    // Priority: explicit primitive worldY → fall back to storey-table
+    // elevation → null (loose bucket, renders at fallbackY).
+    //
+    // Bucket keys are millimetre-rounded Y so two storeys 1mm apart still
+    // collapse to one bucket — that's the precision Revit etc. round to.
+    const ensureBucket = (
+      expressId: number,
+      primitiveWorldY: number,
+      ifcType: string,
+    ): AnnotationsForStorey | null => {
+      let effectiveY: number | null = null;
+      if (Number.isFinite(primitiveWorldY) && primitiveWorldY !== 0) {
+        effectiveY = primitiveWorldY;
+      } else {
+        const storeyId = elementToStorey?.get(expressId);
+        if (storeyId !== undefined) {
+          const elev = storeyElevations?.get(storeyId);
+          if (typeof elev === 'number' && Number.isFinite(elev)) effectiveY = elev;
+        }
+      }
+      if (effectiveY === null) return null;
+      const key = Math.round(effectiveY * 1000);
+      // Issue #862: IfcGridAxis primitives land in a parallel bucket
+      // collection so the renderer can section-clip + visibility-toggle
+      // them independently of IfcAnnotation (text/dimension symbols).
+      const storeyMap = ifcType === 'IfcGridAxis' ? result.gridByStorey : result.byStorey;
+      let bucket = storeyMap.get(key);
+      if (!bucket) {
+        bucket = {
+          storeyId: key,
+          storeyElevation: effectiveY,
+          lines: [],
+          texts: [],
+          fills: [],
+        };
+        storeyMap.set(key, bucket);
+      }
+      return bucket;
+    };
+
+    for (let i = 0; i < collection.polylineCount; i++) {
+      const poly = collection.getPolyline(i);
+      if (!poly) continue;
+      try {
+        if (poly.ifcType !== 'IfcAnnotation' && poly.ifcType !== 'IfcGridAxis') continue;
+        const bucket = ensureBucket(poly.expressId, poly.worldY, poly.ifcType);
+        const looseTarget = poly.ifcType === 'IfcGridAxis' ? result.gridLoose : result.loose;
+        const out = bucket ? bucket.lines : looseTarget;
+        // poly.points is consumed synchronously here (not stored), so no copy needed.
+        polylineToSegments(poly.points, poly.pointCount, poly.isClosed, out, poly.expressId);
+      } finally {
+        poly.free();
+      }
+    }
+
+    for (let i = 0; i < collection.circleCount; i++) {
+      const circle = collection.getCircle(i);
+      if (!circle) continue;
+      try {
+        if (circle.ifcType !== 'IfcAnnotation' && circle.ifcType !== 'IfcGridAxis') continue;
+        const bucket = ensureBucket(circle.expressId, circle.worldY, circle.ifcType);
+        const looseTarget = circle.ifcType === 'IfcGridAxis' ? result.gridLoose : result.loose;
+        const out = bucket ? bucket.lines : looseTarget;
+        circleToSegments(
+          circle.centerX,
+          circle.centerY,
+          circle.radius,
+          circle.startAngle,
+          circle.endAngle,
+          circle.isFullCircle,
+          out,
+          circle.expressId,
+        );
+      } finally {
+        circle.free();
+      }
+    }
+
+    for (let i = 0; i < collection.textCount; i++) {
+      const text = collection.getText(i);
+      if (!text) continue;
+      try {
+      if (text.ifcType !== 'IfcAnnotation' && text.ifcType !== 'IfcGridAxis') continue;
+      // Skip empty literals so the renderer doesn't waste an instance slot.
+      // Decode STEP escapes — `\X2\NNNN\X0\` (UTF-16 hex code units) and
+      // `\X\NN` (Latin-1 hex byte). The Rust parser intentionally passes
+      // the literal through verbatim; this is where the JS encoding
+      // package gets applied. Without it, non-ASCII annotation labels
+      // (e.g. CJK content) render as raw escape sequences in the atlas.
+      const decoded = decodeIfcString(text.content);
+      if (decoded.length === 0) continue;
+
+      // Multi-line split: IfcTextLiteralWithExtent.SizeInY is the LAYOUT BOX
+      // height, not the glyph cap height. The Rust extractor multiplies
+      // SizeInY × 0.7 to recover a single-line cap; for multi-line literals
+      // we further divide by line count and stack lines downward in world-Y.
+      // Source: IFC4 spec — IfcPlanarExtent describes the bounding box of
+      // the typeset string; one literal per line is the conventional
+      // rendering model (matches BIMvision / Solibri / Revit).
+      const lines = decoded.split(/\r?\n/).filter((l) => l.length > 0);
+      if (lines.length === 0) continue;
+      const perLineHeight = lines.length > 1 ? text.height / lines.length : text.height;
+      // Industry-standard line-spacing (CSS line-height ≈ 1.2). Picks up
+      // a little air between rows so descenders don't kiss the next cap.
+      const lineSpacing = perLineHeight * 1.2;
+      const bucket = ensureBucket(text.expressId, text.worldY, text.ifcType);
+      const looseTextTarget = text.ifcType === 'IfcGridAxis' ? result.gridLooseTexts : result.looseTexts;
+      // All annotation text — grid bubbles, dimension callouts, leader labels —
+      // billboards to the camera so it stays legible in any view orientation
+      // (top-down, eye-level, oblique). The shader rebuilds the quad in the
+      // screen-aligned basis at render time. Authored orientation is intentionally
+      // dropped: at oblique viewing angles, flat-in-plane text becomes a smeared
+      // sliver of pixels (issue #812). Anchor + alignment are preserved, so each
+      // label still sits at its authored insertion point.
+      // Read per-instance style metadata. WASM emits these for grid
+      // bubble parts (● fill / ○ outline / tag) and reserves them for
+      // future IfcTextStyle resolution on regular annotation text.
+      const colorA = text.colorA;
+      const hasColor = colorA > 0;
+      const textColor: [number, number, number, number] | undefined = hasColor
+        ? [text.colorR, text.colorG, text.colorB, colorA]
+        : undefined;
+      const targetPx = text.targetPx > 0 ? text.targetPx : undefined;
+      for (let li = 0; li < lines.length; li++) {
+        const t2d: AnnotationText2D = {
+          x: text.x,
+          y: text.y,
+          dirX: text.dirX,
+          dirY: text.dirY,
+          height: perLineHeight,
+          content: lines[li],
+          alignment: text.alignment,
+          lineYOffset: -li * lineSpacing,
+          billboard: true,
+          color: textColor,
+          targetPx,
+          ownerId: text.expressId,
+        };
+        (bucket ? bucket.texts : looseTextTarget).push(t2d);
+      }
+      } finally {
+        text.free();
+      }
+    }
+
+    for (let i = 0; i < collection.fillCount; i++) {
+      const fill = collection.getFill(i);
+      if (!fill) continue;
+      try {
+        if (fill.ifcType !== 'IfcAnnotation' && fill.ifcType !== 'IfcGridAxis') continue;
+        // fill.points / fill.holesOffsets are getter results that may be views
+        // into WASM memory; they're STORED into f2d (outlive this iteration),
+        // so copy them before the handle is freed below. Element types match
+        // the AnnotationFill2D fields (Float32Array / Uint32Array).
+        const points = new Float32Array(fill.points);
+        if (points.length < 6) continue; // <3 vertices = no polygon
+        const holesOffsets = new Uint32Array(fill.holesOffsets);
+        const f2d: AnnotationFill2D = {
+          points,
+          holesOffsets,
+          color: [fill.fillR, fill.fillG, fill.fillB, fill.fillA],
+          ownerId: fill.expressId,
+          hatching: fill.hasHatching
+            ? {
+                spacing: fill.hatchSpacing,
+                angle: fill.hatchAngle,
+                angleSecondary: Number.isNaN(fill.hatchAngleSecondary) ? null : fill.hatchAngleSecondary,
+                lineWidth: fill.hatchLineWidth,
+              }
+            : undefined,
+        };
+        const bucket = ensureBucket(fill.expressId, fill.worldY, fill.ifcType);
+        const looseFillTarget = fill.ifcType === 'IfcGridAxis' ? result.gridLooseFills : result.looseFills;
+        (bucket ? bucket.fills : looseFillTarget).push(f2d);
+      } finally {
+        fill.free();
+      }
+    }
+    } finally {
+      collection.free();
+    }
+  } finally {
+    processor.dispose();
+  }
+
+  return result;
+}

--- a/apps/viewer/src/lib/overlay-parse/symbolic-shapes.test.ts
+++ b/apps/viewer/src/lib/overlay-parse/symbolic-shapes.test.ts
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import { createEmptyParseResult } from './symbolic-shapes.js';
+import type { ParseResult } from './symbolic-shapes.js';
+
+/**
+ * The extraction in #2183 introduced exactly one new behaviour:
+ * `createEmptyParseResult()`, which the hook now returns when the
+ * `hasEntityType` pre-filter skips a store. Everything else in this module is
+ * a byte-identical move and is already covered by
+ * `hooks/useSymbolicAnnotations.test.ts` through the re-exports.
+ *
+ * What matters here is that the empty result is STRUCTURALLY complete and
+ * FRESH per call. A missing bucket would throw at a consumer that iterates it;
+ * a shared instance would let one model's annotations leak into another's
+ * result, since callers push into these arrays.
+ */
+describe('createEmptyParseResult', () => {
+  const KEYS: (keyof ParseResult)[] = [
+    'byStorey', 'loose', 'looseTexts', 'looseFills',
+    'gridByStorey', 'gridLoose', 'gridLooseTexts', 'gridLooseFills',
+  ];
+
+  it('has every bucket the annotation and grid paths read', () => {
+    const result = createEmptyParseResult();
+    assert.deepEqual(Object.keys(result).sort(), [...KEYS].sort());
+  });
+
+  it('starts every bucket empty', () => {
+    const r = createEmptyParseResult();
+    assert.equal(r.byStorey.size, 0);
+    assert.equal(r.gridByStorey.size, 0);
+    for (const k of ['loose', 'looseTexts', 'looseFills', 'gridLoose', 'gridLooseTexts', 'gridLooseFills'] as const) {
+      assert.equal(r[k].length, 0, `${k} must start empty`);
+    }
+  });
+
+  it('returns a FRESH result each call, not a shared singleton', () => {
+    const a = createEmptyParseResult();
+    const b = createEmptyParseResult();
+    for (const k of KEYS) {
+      assert.notEqual(a[k], b[k], `${k} must not be shared between results`);
+    }
+    // Mutating one must not be visible in the other: callers push into these.
+    a.loose.push({} as never);
+    a.byStorey.set(1, {} as never);
+    assert.equal(b.loose.length, 0);
+    assert.equal(b.byStorey.size, 0);
+  });
+
+  it('keeps the annotation and grid buckets separate within one result', () => {
+    const r = createEmptyParseResult();
+    assert.notEqual(r.byStorey, r.gridByStorey, 'issue #862 keeps these parallel');
+    assert.notEqual(r.loose, r.gridLoose);
+    assert.notEqual(r.looseTexts, r.gridLooseTexts);
+    assert.notEqual(r.looseFills, r.gridLooseFills);
+  });
+});

--- a/apps/viewer/src/lib/overlay-parse/symbolic-shapes.ts
+++ b/apps/viewer/src/lib/overlay-parse/symbolic-shapes.ts
@@ -1,0 +1,198 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Result contracts and pure tessellation helpers for the symbolic-annotation
+ * parse. Split from `symbolic-parse.ts` to keep both modules under the ~400
+ * line house limit; that file owns the WASM walk, this one owns the shapes it
+ * produces and the geometry helpers it uses.
+ *
+ * Nothing here touches WASM or the DOM, so it is safe to import from a worker,
+ * the React tree, or a test.
+ */
+
+import type { DrawingLine2D } from '@ifc-lite/renderer';
+/** Lines belonging to a single storey, ready to feed into the section overlay. */
+export interface AnnotationsForStorey {
+  storeyId: number;
+  /** Authored `IfcBuildingStorey.Elevation`. `null` means the storey carried
+   *  no elevation in the parsed metadata — distinguishing that from a real
+   *  ground-floor at 0.0 matters because `resolveBucketY` only wants to swap
+   *  in the fallback in the missing case, not for legitimate ground floors. */
+  storeyElevation: number | null;
+  lines: DrawingLine2D[];
+  texts: AnnotationText2D[];
+  fills: AnnotationFill2D[];
+}
+
+/**
+ * A single text label in renderer 2D space (XZ on the section plane).
+ *
+ * `dirX / dirY` encodes the baseline direction (already mirrored to match the
+ * Y-negated 2D coord system that lines and circles use). `height` is in world
+ * units. `alignment` is the raw IFC `BoxAlignment` string ("bottom-left",
+ * "center", …) — the renderer interprets it.
+ */
+export interface AnnotationText2D {
+  x: number;
+  y: number;
+  dirX: number;
+  dirY: number;
+  height: number;
+  content: string;
+  alignment: string;
+  /** Express ID of the owning IfcAnnotation / IfcGridAxis entity (per-entity hide). */
+  ownerId: number;
+  /**
+   * For multi-line text literals (e.g. CJK descriptions with `\X\0A`
+   * newlines), one IfcTextLiteralWithExtent expands into one AnnotationText2D
+   * per line. `lineYOffset` is added to the storey-elevation world-Y at 3D
+   * conversion so successive lines stack downward (negative Y) below the
+   * shared anchor. Optional — single-line literals leave it undefined.
+   */
+  lineYOffset?: number;
+  /**
+   * When true, the renderer rebuilds the glyph quad in screen-aligned
+   * (cameraRight, cameraUp) basis so the text always faces the camera.
+   * Set for every annotation literal (grid bubbles, dimension callouts,
+   * leader labels) so they stay legible in any view — flat-in-plane text
+   * collapses to a sliver at oblique angles (issue #812). Defaults to false.
+   */
+  billboard?: boolean;
+  /** sRGB straight-alpha tint (0..1). Defaults to renderer near-black. */
+  color?: [number, number, number, number];
+  /** Per-instance target cap height in screen pixels. 0/undef = renderer default. */
+  targetPx?: number;
+}
+
+/**
+ * A single filled region in renderer 2D space. Outer ring + holes flattened
+ * into one `points` array; `holesOffsets` marks where each hole starts (in
+ * vertex indices, not floats). Empty `holesOffsets` = simple polygon.
+ *
+ * `hatching` is present when the IFC style chain resolved to an
+ * IfcFillAreaStyleHatching. When absent the fill is solid (color only).
+ */
+export interface AnnotationFill2D {
+  points: Float32Array;
+  holesOffsets: Uint32Array;
+  color: [number, number, number, number];
+  /** Express ID of the owning IfcAnnotation / IfcGridAxis entity (per-entity hide). */
+  ownerId: number;
+  hatching?: {
+    spacing: number;
+    angle: number;
+    angleSecondary: number | null;
+    lineWidth: number;
+  };
+}
+
+/** Cached parse result keyed by source identity.
+ *
+ * IfcAnnotation and IfcGridAxis primitives are stored in PARALLEL bucket
+ * collections (issue #862). They share the same parse pass and the same
+ * storey-resolution logic, but the renderer treats them differently:
+ *
+ *   - Annotation buckets always lift every storey (memory
+ *     `feedback_3d_annotation_overlay_no_section_filter.md`: the user
+ *     expects every storey's dimensions to be visible in 3D).
+ *   - Grid buckets get optional section-plane filtering and an
+ *     independent visibility toggle, so dense-grid models can hide
+ *     grids per storey without losing dimensions.
+ */
+export interface ParseResult {
+  // IfcAnnotation buckets
+  byStorey: Map<number, AnnotationsForStorey>;
+  loose: DrawingLine2D[];
+  looseTexts: AnnotationText2D[];
+  looseFills: AnnotationFill2D[];
+
+  // IfcGridAxis buckets (issue #862)
+  gridByStorey: Map<number, AnnotationsForStorey>;
+  gridLoose: DrawingLine2D[];
+  gridLooseTexts: AnnotationText2D[];
+  gridLooseFills: AnnotationFill2D[];
+}
+
+/** The empty (nothing parsed) result. Also used by callers that short-circuit
+ *  before the walk — e.g. the `hasEntityType` pre-filter in the hook. */
+export function createEmptyParseResult(): ParseResult {
+  return {
+    byStorey: new Map(),
+    loose: [],
+    looseTexts: [],
+    looseFills: [],
+    gridByStorey: new Map(),
+    gridLoose: [],
+    gridLooseTexts: [],
+    gridLooseFills: [],
+  };
+}
+
+const CIRCLE_SEGMENTS_FULL = 32;
+const CIRCLE_SEGMENTS_ARC = 16;
+
+/**
+ * Convert a polyline (Float32Array of [x,y,x,y,…]) into start/end segments.
+ * Exported for unit testing.
+ */
+export function polylineToSegments(
+  points: Float32Array,
+  pointCount: number,
+  isClosed: boolean,
+  out: DrawingLine2D[],
+  ownerId = 0,
+): void {
+  for (let j = 0; j < pointCount - 1; j++) {
+    out.push({
+      line: {
+        start: { x: points[j * 2], y: points[j * 2 + 1] },
+        end:   { x: points[(j + 1) * 2], y: points[(j + 1) * 2 + 1] },
+      },
+      category: 'annotation',
+      ownerId,
+    });
+  }
+  if (isClosed && pointCount > 2) {
+    out.push({
+      line: {
+        start: { x: points[(pointCount - 1) * 2], y: points[(pointCount - 1) * 2 + 1] },
+        end:   { x: points[0], y: points[1] },
+      },
+      category: 'annotation',
+      ownerId,
+    });
+  }
+}
+
+/**
+ * Tessellate a circle/arc into chord segments.
+ * Exported for unit testing.
+ */
+export function circleToSegments(
+  centerX: number,
+  centerY: number,
+  radius: number,
+  startAngle: number,
+  endAngle: number,
+  isFullCircle: boolean,
+  out: DrawingLine2D[],
+  ownerId = 0,
+): void {
+  const numSegments = isFullCircle ? CIRCLE_SEGMENTS_FULL : CIRCLE_SEGMENTS_ARC;
+  for (let j = 0; j < numSegments; j++) {
+    const t1 = j / numSegments;
+    const t2 = (j + 1) / numSegments;
+    const a1 = startAngle + t1 * (endAngle - startAngle);
+    const a2 = startAngle + t2 * (endAngle - startAngle);
+    out.push({
+      line: {
+        start: { x: centerX + radius * Math.cos(a1), y: centerY + radius * Math.sin(a1) },
+        end:   { x: centerX + radius * Math.cos(a2), y: centerY + radius * Math.sin(a2) },
+      },
+      category: 'annotation',
+      ownerId,
+    });
+  }
+}


### PR DESCRIPTION
Step 1 of 2 for #2183. Independent of #2241 and #2242.

**Scope of the "pure move" claim:** the parse walk itself is byte-identical (verified by `diff`, see below). Two deliberate deltas landed on top, both from review: the module was split into `symbolic-parse.ts` (the WASM walk) and `symbolic-shapes.ts` (result contracts + pure helpers) to stay under the ~400 line house limit, and `debugEnabled()` now `console.warn`s instead of silently swallowing a failed `localStorage` read. Neither changes parse output.

## Why

`useSymbolicAnnotations` does the same thing #2242 fixed for grids and alignments: hands the **entire** IFC source to `parseSymbolicRepresentations`, which decodes it to a JS string and pushes that into a main-thread `WebAssembly.Memory` that never shrinks.

Its guard is `hasEntityType(store, 'IfcAnnotation', 'IfcGridAxis')` — so **any model carrying a grid trips it too**. That is why fixing grids alone does not close the hole: on the 342 MB reproduction model, which has exactly one `IfcGridAxis`, this path is also eligible.

A worker module cannot import a React hook file, so the walk has to come out before it can be moved off-thread. This PR is that extraction and nothing else.

## What moved

`apps/viewer/src/hooks/useSymbolicAnnotations.ts` → `apps/viewer/src/lib/overlay-parse/symbolic-parse.ts` (the walk, 288 lines) and `symbolic-shapes.ts` (contracts + helpers, 198 lines):

- `AnnotationsForStorey`, `AnnotationText2D`, `AnnotationFill2D`, `ParseResult`
- `CIRCLE_SEGMENTS_FULL` / `CIRCLE_SEGMENTS_ARC`, `polylineToSegments`, `circleToSegments`, `debugEnabled`
- the walk itself, now `parseSymbolicAnnotations({ source, elementToStorey, storeyElevations })` instead of taking an `IfcDataStore`

Those three fields are everything it needed off the store. Types and helpers are re-exported from the hook, so `Drawing2DCanvas.tsx` and `useSymbolicAnnotations.test.ts` are untouched.

**The `hasEntityType` pre-filter could not move** — it needs `store.entityIndex`. It stays at the call site, ordered so an empty source still falls through and produces the original `skip: missing/empty source` log.

## Proof it is a pure move

```
$ diff <(git show HEAD~1:…/useSymbolicAnnotations.ts | sed -n '/const ensureBucket = (/,/^  return result;$/p') \
       <(sed -n '/const ensureBucket = (/,/^  return result;$/p' …/symbolic-parse.ts)
IDENTICAL          # 181 lines each
```

Every `.free()` keeps its `try/finally`. `node scripts/check-wasm-disposal.mjs` → `✅ All 29 WASM-handle construction(s) release deterministically`.

## Verification

- `pnpm typecheck` — 36/36
- `pnpm --filter @ifc-lite/viewer test` — 3035 tests, 3033 pass, 0 fail, 2 skipped
- `pnpm knip` — no new orphans (diffed against a clean-`HEAD` baseline; the only delta is `AnnotationsForStorey` moving line, a pre-existing unused export)

## One added export, called out rather than hidden

`createEmptyParseResult()`. Moving the guard to the call site means the hook needs an empty `ParseResult`; this factory replaces what would otherwise be a duplicated 8-field literal.

## Step 2

Wires `parseSymbolicAnnotations` into the `lib/overlay-parse` worker from #2242. It lands after #2242 merges rather than stacking on it, because `test.yml` is `pull_request: branches: [main]` — a non-main base silently skips the entire Test workflow and CodeRabbit, which is how #2242 originally shipped with zero test coverage.


## Measured: what step 2 is actually worth

On the 342 MB reproduction, fresh profile, **default toggles**, all three PRs merged:

| | baseline | #2241 + #2242 + this |
|---|---|---|
| `measureUserAgentSpecificMemory()` | 1,715 MB | 1,142 MB |
| main-thread `WebAssembly.Memory` | 439 MB | **471 MB, still present** |

That remaining 471 MB is this parse, still running on the main thread. Step 2 moves it into the `lib/overlay-parse` worker from #2242 and should land the model near ~670 MB.

This matters more than it looks: the guard is `hasEntityType(store, 'IfcAnnotation', 'IfcGridAxis')`, so **any model carrying a grid trips it**, and the trigger is `ifcAnnotations || effectiveGridEnabled` — both default to true. So for a default user this is the largest single remaining chunk, not a tidy-up.

## Step 2 is not a mechanical wrap

Adversarial review flagged three things the pure-move deliberately did not solve, which step 2 has to:

- `elementToStorey` is a Map over every spatially-contained element, structured-cloned per parse.
- `ParseResult` is a nested object graph (one object per segment); annotation-dense models pay a large clone back plus transient doubling.
- `debugEnabled()` reads `window.localStorage` and silently returns false in a worker, killing the triage flag for exactly the "no annotations visible" reports a worker-move regression would produce.

Expect `symbolic-shapes.ts` to churn again when the output is flattened to typed arrays.



## Review findings, and their disposition

A fresh CodeRabbit CLI pass at HEAD (the hosted review has been rate-limited all session) raised two, both against code this PR **moved rather than wrote**. Neither is implemented here, deliberately:

1. **"Add fixture-based parser tests."** The walk had no direct tests before this PR and has none after; that is unchanged, not newly introduced. Writing IFC fixtures that exercise lines, circles, text decoding, fills, `IfcGridAxis` routing and elevation bucketing is real work and belongs with step 2, when the output shape changes anyway. Adding them here would also make the byte-identity claim harder to check, since the diff would no longer be a move. What this PR does add is coverage for the one thing it genuinely introduced, `createEmptyParseResult`.

2. **`worldY === 0` treated as "no elevation."** Real, and CodeRabbit is right that `0` is a finite elevation. But changing it is a behaviour change inside a PR whose entire safety argument is that the walk is byte-identical, and it needs a fixture to prove the new bucketing is correct rather than merely different. Tracked in #2256.

Both are recorded here rather than resolved silently so the next reader does not have to rediscover them.

