### PR TITLE
fix(build): propagate the TLA wrapper to importers, and gate the class (#2246)

### DIFF
--- a/apps/viewer/package.json
+++ b/apps/viewer/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build && node ../../scripts/check-tla-chunk-hazards.mjs dist/assets",
     "typecheck": "tsc --noEmit",
     "preview": "vite preview",
     "test": "tsx --test --test-concurrency=1 $(find src -type f \\( -name '*.test.ts' -o -name '*.test.tsx' \\) | sort)",

--- a/patches/vite-plugin-top-level-await@1.6.0.patch
+++ b/patches/vite-plugin-top-level-await@1.6.0.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/bundle-info.js b/dist/bundle-info.js
-index fec6ef5417214d2b612f685790279253daf7bdf0..5939733f87c1f7e6bfe7c35398beef2a318d05c3 100644
+index fec6ef5417214d2b612f685790279253daf7bdf0..d0666ebf6202f749ba0246b51ec8739df63c0c82 100644
 --- a/dist/bundle-info.js
 +++ b/dist/bundle-info.js
 @@ -43,7 +43,8 @@ async function parseBundleAsts(bundleChunks) {
@@ -12,3 +12,17 @@ index fec6ef5417214d2b612f685790279253daf7bdf0..5939733f87c1f7e6bfe7c35398beef2a
          })
      ])));
  }
+@@ -86,7 +87,12 @@ async function parseBundleInfo(bundleAsts) {
+     }
+     // Pass 2: transfer each modules's "top-level await usage" property to all successors in reverse graph
+     const q = Object.entries(bundleInfo)
+-        .filter(([, module]) => module.withTopLevelAwait)
++        // Seed from transformNeeded, not withTopLevelAwait. transformModule defers
++        // the exports of ANY chunk with transformNeeded (which includes chunks
++        // flagged solely for containing dynamic imports), so a static importer of
++        // such a chunk must be wrapped too - otherwise it evaluates synchronously
++        // and reads a binding that is still unassigned. See ifc-lite#2246/#2243.
++        .filter(([, module]) => module.transformNeeded)
+         .map(([moduleName]) => moduleName);
+     while (q.length > 0) {
+         const moduleName = q.shift();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,7 +35,7 @@ patchedDependencies:
     hash: f503a4ec701f193ef8db43cf396349b5ef3d39508fa6469bf0f36ab31f549c24
     path: patches/@swc__core@1.15.8.patch
   vite-plugin-top-level-await@1.6.0:
-    hash: 250521d8ad2a8063f42539e889cf813250ca05aae49cf24dd6ab40c320784958
+    hash: c5871d895df86faf93e04c1734912fa9da6682a225fe719c3187e5ea00ff9bcd
     path: patches/vite-plugin-top-level-await@1.6.0.patch
 
 importers:
@@ -370,7 +370,7 @@ importers:
         version: 4.1.1(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       vite-plugin-top-level-await:
         specifier: ^1.6.0
-        version: 1.6.0(patch_hash=250521d8ad2a8063f42539e889cf813250ca05aae49cf24dd6ab40c320784958)(@swc/helpers@0.5.21)(rollup@4.62.2)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 1.6.0(patch_hash=c5871d895df86faf93e04c1734912fa9da6682a225fe719c3187e5ea00ff9bcd)(@swc/helpers@0.5.21)(rollup@4.62.2)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       vite-plugin-wasm:
         specifier: ^3.6.0
         version: 3.6.0(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
@@ -494,7 +494,7 @@ importers:
         version: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
       vite-plugin-top-level-await:
         specifier: ^1.6.0
-        version: 1.6.0(patch_hash=250521d8ad2a8063f42539e889cf813250ca05aae49cf24dd6ab40c320784958)(@swc/helpers@0.5.21)(rollup@4.62.2)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 1.6.0(patch_hash=c5871d895df86faf93e04c1734912fa9da6682a225fe719c3187e5ea00ff9bcd)(@swc/helpers@0.5.21)(rollup@4.62.2)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       vite-plugin-wasm:
         specifier: ^3.6.0
         version: 3.6.0(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
@@ -541,7 +541,7 @@ importers:
         version: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
       vite-plugin-top-level-await:
         specifier: ^1.6.0
-        version: 1.6.0(patch_hash=250521d8ad2a8063f42539e889cf813250ca05aae49cf24dd6ab40c320784958)(@swc/helpers@0.5.21)(rollup@4.62.2)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 1.6.0(patch_hash=c5871d895df86faf93e04c1734912fa9da6682a225fe719c3187e5ea00ff9bcd)(@swc/helpers@0.5.21)(rollup@4.62.2)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       vite-plugin-wasm:
         specifier: ^3.6.0
         version: 3.6.0(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
@@ -569,7 +569,7 @@ importers:
         version: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
       vite-plugin-top-level-await:
         specifier: ^1.5.0
-        version: 1.6.0(patch_hash=250521d8ad2a8063f42539e889cf813250ca05aae49cf24dd6ab40c320784958)(@swc/helpers@0.5.21)(rollup@4.62.2)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 1.6.0(patch_hash=c5871d895df86faf93e04c1734912fa9da6682a225fe719c3187e5ea00ff9bcd)(@swc/helpers@0.5.21)(rollup@4.62.2)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       vite-plugin-wasm:
         specifier: ^3.6.0
         version: 3.6.0(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
@@ -9605,7 +9605,7 @@ snapshots:
       tinyglobby: 0.2.17
       vite: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
 
-  vite-plugin-top-level-await@1.6.0(patch_hash=250521d8ad2a8063f42539e889cf813250ca05aae49cf24dd6ab40c320784958)(@swc/helpers@0.5.21)(rollup@4.62.2)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)):
+  vite-plugin-top-level-await@1.6.0(patch_hash=c5871d895df86faf93e04c1734912fa9da6682a225fe719c3187e5ea00ff9bcd)(@swc/helpers@0.5.21)(rollup@4.62.2)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       '@rollup/plugin-virtual': 3.0.2(rollup@4.62.2)
       '@swc/core': 1.15.8(patch_hash=f503a4ec701f193ef8db43cf396349b5ef3d39508fa6469bf0f36ab31f549c24)(@swc/helpers@0.5.21)

--- a/scripts/check-tla-chunk-hazards.mjs
+++ b/scripts/check-tla-chunk-hazards.mjs
@@ -42,9 +42,29 @@ if (files.length === 0) {
   process.exit(2);
 }
 
-/** Static `from "./chunk.js"` specifiers. Dynamic import() is irrelevant here:
- *  it is awaited by construction, so it can never observe an unassigned binding. */
-const STATIC_IMPORT = /from\s*"\.\/([A-Za-z0-9_.\-]+\.js)"/g;
+/**
+ * Static import specifiers, in both forms rolldown emits:
+ *
+ *   import { a as b } from "./chunk.js"     <- binding import
+ *   import "./chunk.js"                      <- side-effect import (no `from`)
+ *
+ * Both are matched. A side-effect import binds nothing, so on its own it
+ * cannot produce the "read an unassigned binding" crash — but it still means
+ * the importer's body runs without awaiting the target, so any side-effect
+ * ordering it relies on is equally unsound. Cheaper to flag both than to
+ * argue about which is fatal this week.
+ *
+ * Dynamic `import()` is deliberately NOT matched: it is awaited by
+ * construction, so it can never observe an unassigned binding.
+ *
+ * Verified against the emitted bundle rather than assumed: rolldown emits
+ * double-quoted specifiers only (0 single-quoted across 129 chunks), and every
+ * `__tla` occurrence is a real identifier, not string or comment text — which
+ * is why a regex is sufficient here and a full parse is not worth the build
+ * cost. If either ever stops holding, this check gets noisy in the SAFE
+ * direction (a spurious failure), never the silent one.
+ */
+const STATIC_IMPORT = /(?:from|import)\s*"\.\/([A-Za-z0-9_.\-]+\.js)"/g;
 
 const chunks = new Map();
 for (const name of files) {

--- a/scripts/check-tla-chunk-hazards.mjs
+++ b/scripts/check-tla-chunk-hazards.mjs
@@ -1,0 +1,81 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Fails the build when an emitted chunk that is NOT wrapped by
+ * vite-plugin-top-level-await statically imports from one that IS.
+ *
+ * Why this exists (#2243 / #2246): the plugin rewrites a chunk that needs
+ * transforming into an async body and assigns its exports inside a deferred
+ * `__tla` promise. An importer that is not itself wrapped evaluates
+ * synchronously and can read one of those bindings before it is assigned. If
+ * it reads it at MODULE SCOPE the result is `TypeError: <x> is not a
+ * function` during module evaluation — before any React error boundary
+ * exists, so #root stays empty and the whole app white-screens. That is
+ * exactly how ifclite.com went down: 24 such edges existed, one of them had a
+ * module-scope consumer (Radix Tooltip calling createPopperScope), and a
+ * routine chunk reshuffle moved it onto the entry's synchronous path.
+ *
+ * The check is deliberately on the EDGE, not on "is the binding used at
+ * module scope". Whether a given edge is fatal depends on how the importer
+ * happens to use the binding today, which is precisely the accident that let
+ * this sit latent. An edge is the thing that is structurally wrong.
+ *
+ * Run after `vite build` for apps/viewer.
+ */
+
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const assetsDir = process.argv[2] ?? 'apps/viewer/dist/assets';
+
+if (!existsSync(assetsDir)) {
+  console.error(`[tla-hazards] No such directory: ${assetsDir}`);
+  console.error('[tla-hazards] Build apps/viewer first, or pass the assets dir as argv[2].');
+  process.exit(2);
+}
+
+const files = readdirSync(assetsDir).filter((f) => f.endsWith('.js'));
+if (files.length === 0) {
+  console.error(`[tla-hazards] No .js chunks in ${assetsDir} — refusing to report success.`);
+  process.exit(2);
+}
+
+/** Static `from "./chunk.js"` specifiers. Dynamic import() is irrelevant here:
+ *  it is awaited by construction, so it can never observe an unassigned binding. */
+const STATIC_IMPORT = /from\s*"\.\/([A-Za-z0-9_.\-]+\.js)"/g;
+
+const chunks = new Map();
+for (const name of files) {
+  const text = readFileSync(join(assetsDir, name), 'utf8');
+  chunks.set(name, {
+    wrapped: text.includes('__tla'),
+    imports: new Set([...text.matchAll(STATIC_IMPORT)].map((m) => m[1])),
+  });
+}
+
+const hazards = [];
+for (const [name, chunk] of chunks) {
+  if (chunk.wrapped) continue; // it awaits its own deps; safe by construction
+  for (const target of chunk.imports) {
+    if (chunks.get(target)?.wrapped) hazards.push([name, target]);
+  }
+}
+
+const wrapped = [...chunks.values()].filter((c) => c.wrapped).length;
+console.log(`[tla-hazards] ${chunks.size} chunks, ${wrapped} __tla-wrapped, ${hazards.length} hazard edges`);
+
+if (hazards.length > 0) {
+  console.error('');
+  console.error('[tla-hazards] FAIL — an unwrapped chunk statically imports a __tla-wrapped chunk.');
+  console.error('[tla-hazards] Any module-scope read of such a binding throws before React mounts (#2243).');
+  console.error('');
+  for (const [from, to] of hazards) console.error(`    ${from}  ->  ${to}`);
+  console.error('');
+  console.error('[tla-hazards] Usual cause: vite-plugin-top-level-await did not propagate the wrap to');
+  console.error('[tla-hazards] this importer. See patches/vite-plugin-top-level-await@1.6.0.patch and #2246.');
+  process.exit(1);
+}
+
+console.log('[tla-hazards] OK — every importer of a deferred chunk is itself deferred.');


### PR DESCRIPTION
Closes #2246.

#2244 pinned Radix into one chunk so its module-scope call could not cross a chunk boundary. That fixed **the instance**. This fixes **the class**, and adds a build-time gate so it cannot come back.

## The defect

`vite-plugin-top-level-await` marks a chunk `transformNeeded` when it contains top-level await **or a dynamic import**, and `transformModule` defers **all** exports of any `transformNeeded` chunk. But Pass 2 of `parseBundleInfo` seeds its propagation queue only from `withTopLevelAwait`:

```js
const q = Object.entries(bundleInfo)
    .filter(([, module]) => module.withTopLevelAwait)   // <- misses dynamic-import-only chunks
    .map(([moduleName]) => moduleName);
```

So a chunk flagged *solely* for containing dynamic imports has its exports deferred while its static importers are never marked. Those importers evaluate synchronously and read bindings that are still unassigned — `TypeError: C is not a function` during module evaluation, before React mounts, so `#root` stays empty (#2243).

Seeding from `transformNeeded` makes every importer of a deferred chunk deferred too.

## Proven independently of #2244

With the radix/floating-ui pin **removed** and only this patch applied, a production build boots:

```
BOOTED=true
ROOT_LEN=118124
PAGE_ERRORS=0
```

So the patch alone is sufficient. The pin is kept anyway — it also trims the initial payload by ~8KB gzip.

## The class is closed, measured on the emitted bundle

| build | hazard edges |
|---|---|
| broken (`9c684df4c`) | **24** |
| #2244 pin only | 22 |
| this patch | **0** (129 chunks, 46 wrapped) |

A hazard edge is an unwrapped chunk statically importing a `__tla`-wrapped one. The 22 that survived #2244 were latent only because none of those bindings happened to be read at module scope.

## The gate

`scripts/check-tla-chunk-hazards.mjs` turns this from a production white-screen into a build failure, wired into `apps/viewer`'s build so it runs locally, in CI **and on Vercel**.

Negative control — run against the first-bad commit's build:

```
[tla-hazards] 186 chunks, 61 __tla-wrapped, 24 hazard edges
exit=1
```

It would have caught the outage before deploy. On this branch: `0 hazard edges`, exit 0.

The check is deliberately on the **edge**, not on "is the binding read at module scope" — whether an edge is fatal depends on how the importer happens to use it today, which is exactly the accident that let this sit latent through 24 edges.

## Gate

build 43/43 · `turbo test --force` 86/86 · `turbo typecheck --force` 36/36

## Follow-up worth considering separately

`build.target` is `esnext` and every browser this app supports executes native top-level await, where the ES spec makes dependents wait. Dropping `vite-plugin-top-level-await` entirely would remove the need for both the patch and the gate — but it needs its own verification pass (worker builds, the Safari floor, `vite-plugin-wasm`'s pairing with it), so it is not this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of dynamically imported modules and deferred exports during builds.
  * Added safeguards to detect unsafe JavaScript chunk dependencies that could affect application loading.

* **Build Improvements**
  * Builds now automatically validate generated assets and report potential top-level await chunk hazards.
  * Enhanced compatibility with modern ECMAScript resource-management syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->