### PR TITLE
test(export): pay the parquet-wasm import tax in a hook, not in the first test

### DIFF
--- a/packages/export/src/parquet-geometry.test.ts
+++ b/packages/export/src/parquet-geometry.test.ts
@@ -16,7 +16,7 @@
  * discovers days later. This file pins the writers row by row.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
 import { ParquetExporter } from './parquet-exporter.js';
 import type { IfcDataStore } from '@ifc-lite/parser';
 import type { GeometryResult, MeshData } from '@ifc-lite/geometry';
@@ -143,6 +143,32 @@ function buildTypedStore(): IfcDataStore {
     relationships: new RelationshipGraphBuilder().build(),
   } as unknown as IfcDataStore;
 }
+
+/**
+ * `toParquet()` (and this file's own `readArrowTable`) dynamically import
+ * `apache-arrow` and `parquet-wasm` on first use. `parquet-wasm`'s Node
+ * build instantiates its WebAssembly module synchronously as an import side
+ * effect (`node_modules/parquet-wasm/node/parquet_wasm.js`: `readFileSync` +
+ * `new WebAssembly.Instance(...)` at module scope), so the first call in
+ * this worker pays real module-resolution + WASM-compile latency — under
+ * light load, comfortably inside vitest's 5s default `testTimeout`; under
+ * CI-scale contention (many packages' test suites racing for CPU in the
+ * same `turbo test` run), it can push PAST it (#2248 — reproduced as
+ * `Error: Test timed out in 5000ms` on whichever test happened to run
+ * first, 3/6 concurrent local runs, plus one CI run at 5025ms with the very
+ * next test at 4974ms — one tick from also timing out).
+ *
+ * That is a fixed one-time tax that has nothing to do with any single
+ * test's assertions, so it does not belong inside any single test's
+ * timing budget. Pay it once here, in a hook with its own (generous, and
+ * import-latency-appropriate) timeout, so every `it()` below — including
+ * whichever one the test runner happens to schedule first — starts from a
+ * warm module cache and reflects only its own (fast) work.
+ */
+beforeAll(async () => {
+  await import('apache-arrow');
+  await import('parquet-wasm');
+}, 30_000);
 
 describe('ParquetExporter VertexBuffer.parquet', () => {
   it('bakes the per-mesh origin into world vertices on all three axes', async () => {


### PR DESCRIPTION
Fixes #2248.

**Not floating point, not shared state, not iteration order** — the three candidates your steer named. It is a fixed one-time cost landing inside a per-test timeout by accident of execution order.

## The cause

`toParquet()` and this file's own `readArrowTable` dynamically import `apache-arrow` and `parquet-wasm` on first use. parquet-wasm's Node build instantiates its WebAssembly module **synchronously, as an import side effect**:

```js
// node_modules/parquet-wasm/node/parquet_wasm.js:2981-2983
const wasmBytes  = require('fs').readFileSync(wasmPath);
const wasmModule = new WebAssembly.Module(wasmBytes);
const wasm = exports.__wasm = new WebAssembly.Instance(wasmModule, imports).exports;
```

So whichever test runs first pays module resolution plus a WASM compile inside its own 5000ms vitest budget. That cost is CPU-bound, so under `turbo test` contention across 43 packages it can cross the line.

That explains both halves of the puzzle in your report: it is always the **first** `it()` in the file, and `--filter @ifc-lite/export` never reproduced it, because a single-package run has no contention to inflate the tax.

Your own evidence already pointed here and I think it is the most convincing detail: the failing run had this test at **5025ms** and its neighbour at **4974ms** — one tick from also timing out — while every later test in the file ran in single-digit to low-hundreds ms. That is not a test that computes something slowly; that is two tests sharing a starting-gun delay.

## The fix

A `beforeAll` warms both imports once, with its own 30s budget, so no single test's timing includes a fixed tax that has nothing to do with its assertions.

**No epsilon widened, no retry added**, per your steer. The origin-fold arithmetic is exact integer work (`1+10`, `2+20`, `3+30`) and was never in question — I swept `export`, `data`, `geometry`, `parser`, `encoding` and `mutations` for module-level mutable state reachable from `writeVertexBuffer` and found none, so there was nothing to loosen even if that had been tempting.

## Verification

- **Reproduced first**, since a flake you cannot reproduce cannot be verified fixed. Isolated loops (60 runs), whole-file repeats (60), and the export suite alone (40 × 29 files) gave **0/100 failures** — matching your `--filter` result. The repro needed cross-package contention: full `pnpm turbo run test` hit it on the first attempt, and a 6-way concurrent harness reproduced it at **3/48**, every one the same `Test timed out in 5000ms` on the same test.
- **After the fix: 48/48** on the same harness at the same iteration count, and under a full `turbo test` the test completes in **833ms** where it had timed out at 5025ms.
- I re-confirmed the mechanism by hand rather than taking it on trust: the synchronous instantiation is at the lines quoted above, and stripping the `beforeAll` moves the first test from **22ms → 67ms** on an idle machine. Small in isolation — which is precisely why this only ever bit under load, and worth stating plainly rather than implying the fix is dramatic locally.
- `packages/export`: 450/450 across 27 files. `tsc --noEmit` clean.

## No changeset

Test-file only; test files are not part of the published surface and no shipped behaviour changes. Matches the precedent in `a9000b352` (the collab-server flaky access-control fix), which also shipped without one.

## Worth noting beyond this test

Any other test file whose **first** test triggers a lazy WASM or heavy dynamic import has the same latent shape — the tax is invisible until something else on the machine competes for CPU. If this recurs elsewhere, that is the pattern to look for rather than the assertions.
