### PR TITLE
feat(viewer): deliver GPU instancing to federated models

### DIFF
--- a/apps/viewer/src/components/viewer/Viewport.tsx
+++ b/apps/viewer/src/components/viewer/Viewport.tsx
@@ -143,6 +143,18 @@ export function Viewport({
     ? modelIdToIndex.get(selectedEntity.modelId) ?? undefined
     : undefined;
 
+  // modelId → express-id offset, for re-homing a federated model's instanced
+  // shard occurrences onto the ids `finalizeModel` assigned its flat meshes
+  // (#1912). Derived from the same `models` map ViewportContainer's
+  // `modelIdToIndex` comes from, so the two agree on every model in scope.
+  const modelIdToOffset = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const [modelId, model] of models) {
+      map.set(modelId, model.idOffset ?? 0);
+    }
+    return map;
+  }, [models]);
+
   // Helper to handle pick result and set selection properly
   // IMPORTANT: pickResult.expressId is now a globalId (transformed at load time)
   // resolveEntityRef is the single source of truth for globalId → EntityRef
@@ -1387,6 +1399,8 @@ export function Viewport({
     pendingMeshTranslations,
     pendingMeshRotations,
     pendingInstancedShards,
+    modelIdToIndex,
+    modelIdToOffset,
     clearPendingColorUpdates,
     clearPendingMeshColorUpdates,
     clearPendingMeshRemovals,

--- a/apps/viewer/src/components/viewer/useGeometryStreaming.instancedShards.test.tsx
+++ b/apps/viewer/src/components/viewer/useGeometryStreaming.instancedShards.test.tsx
@@ -1,0 +1,182 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Federated instanced-shard delivery (#1912 step 2).
+ *
+ * `addInstancedShard` (packages/renderer) has taken an owning `modelIndex`
+ * since #2172, but the ONE call site — this hook's drain effect — never
+ * forwarded it, and the loader only ever pushed the PRIMARY model's shard
+ * bytes into `pendingInstancedShards` in the first place. A secondary
+ * (federated) model's repeated opaque occurrences therefore never reached
+ * the scene: no instanced geometry rendered for anything but the primary.
+ *
+ * This test drives the hook directly (`useGeometryStreaming` mounted under a
+ * bare harness, no real GPU / renderer) with a shard tagged for a SECOND
+ * model and asserts:
+ *   1. `scene.addInstancedShard` is actually called for it (not silently
+ *      dropped), and
+ *   2. it is called with that model's `modelIndex`, and
+ *   3. the occurrence's entity id has been re-homed by that model's
+ *      `idOffset` — the offset `finalizeModel` applies to the model's flat
+ *      meshes at finalize (apps/viewer/src/hooks/useIfcLoader.ts) — so the
+ *      instanced occurrence's id matches the one selection/highlighting use
+ *      for the same entity everywhere else.
+ */
+
+import '@/test/setup-dom.js';
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { useRef } from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import type { Renderer } from '@ifc-lite/renderer';
+import type { DecodedInstancedShard } from '@ifc-lite/geometry';
+import { useGeometryStreaming, type UseGeometryStreamingParams } from './useGeometryStreaming.js';
+
+/** One template (a single triangle), one instance — hand-built IFNS bytes
+ *  (see packed-instanced-decoder.ts's documented layout) so the test needs
+ *  no WASM / Rust fixture. */
+function buildShardBytes(entityId: number): ArrayBuffer {
+  const HEADER_WORDS = 8;
+  const TEMPLATE_BYTES = 48;
+  const INSTANCE_BYTES = 88;
+  const posLen = 9, nrmLen = 9, idxLen = 3;
+
+  const templateTableOff = HEADER_WORDS * 4;
+  const instanceTableOff = templateTableOff + TEMPLATE_BYTES;
+  const dataOff = instanceTableOff + INSTANCE_BYTES;
+  const posOff = dataOff;
+  const nrmOff = posOff + posLen * 4;
+  const idxOff = nrmOff + nrmLen * 4;
+  const total = idxOff + idxLen * 4;
+
+  const buf = new ArrayBuffer(total);
+  const dv = new DataView(buf);
+  let o = 0;
+  dv.setUint32(o, 0x4946_4e53, true); o += 4; // magic "IFNS"
+  dv.setUint32(o, 1, true); o += 4;           // version
+  dv.setUint32(o, 1, true); o += 4;           // templateCount
+  dv.setUint32(o, 1, true); o += 4;           // instanceCount
+  dv.setUint32(o, posLen, true); o += 4;
+  dv.setUint32(o, nrmLen, true); o += 4;
+  dv.setUint32(o, idxLen, true); o += 4;
+  dv.setUint32(o, 0, true); o += 4;           // reserved
+
+  // Template record: posOff,posLen,nrmOff,nrmLen,idxOff,idxLen (element counts) + origin f64x3
+  o = templateTableOff;
+  dv.setUint32(o, 0, true); o += 4;   // posOff (element index)
+  dv.setUint32(o, posLen, true); o += 4;
+  dv.setUint32(o, 0, true); o += 4;   // nrmOff
+  dv.setUint32(o, nrmLen, true); o += 4;
+  dv.setUint32(o, 0, true); o += 4;   // idxOff
+  dv.setUint32(o, idxLen, true); o += 4;
+  dv.setFloat64(o, 0, true); o += 8;  // originX
+  dv.setFloat64(o, 0, true); o += 8;  // originY
+  dv.setFloat64(o, 0, true); o += 8;  // originZ
+
+  // Instance record: templateIndex, entityId, color(4xf32), transform(16xf32 identity)
+  o = instanceTableOff;
+  dv.setUint32(o, 0, true); o += 4;
+  dv.setUint32(o, entityId, true); o += 4;
+  dv.setFloat32(o, 1, true); o += 4;
+  dv.setFloat32(o, 1, true); o += 4;
+  dv.setFloat32(o, 1, true); o += 4;
+  dv.setFloat32(o, 1, true); o += 4;
+  const identity = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+  for (const v of identity) { dv.setFloat32(o, v, true); o += 4; }
+
+  // Data: positions/normals (a degenerate but well-formed triangle), indices.
+  const positions = new Float32Array(buf, posOff, posLen);
+  positions.set([0, 0, 0, 1, 0, 0, 0, 1, 0]);
+  const normals = new Float32Array(buf, nrmOff, nrmLen);
+  normals.set([0, 0, 1, 0, 0, 1, 0, 0, 1]);
+  const indices = new Uint32Array(buf, idxOff, idxLen);
+  indices.set([0, 1, 2]);
+
+  return buf;
+}
+
+interface RecordedCall {
+  modelIndex: number | undefined;
+  entityIds: number[];
+}
+
+function fakeRenderer(calls: RecordedCall[]): Renderer {
+  const scene = {
+    addInstancedShard: (_device: unknown, shard: DecodedInstancedShard, modelIndex?: number) => {
+      calls.push({ modelIndex, entityIds: shard.instances.map((i) => i.entityId) });
+    },
+  };
+  return {
+    getGPUDevice: () => ({}) as unknown,
+    getScene: () => scene,
+    requestRender: () => {},
+  } as unknown as Renderer;
+}
+
+function baseParams(overrides: Partial<UseGeometryStreamingParams>): UseGeometryStreamingParams {
+  return {
+    rendererRef: { current: null },
+    isInitialized: true,
+    geometry: null,
+    isStreaming: false,
+    geometryBoundsRef: { current: { min: { x: 0, y: 0, z: 0 }, max: { x: 0, y: 0, z: 0 } } },
+    pendingMeshColorUpdates: null,
+    pendingColorUpdates: null,
+    pendingMeshRemovals: null,
+    pendingMeshTranslations: null,
+    pendingMeshRotations: null,
+    pendingInstancedShards: null,
+    clearPendingMeshColorUpdates: () => {},
+    clearPendingColorUpdates: () => {},
+    clearPendingMeshRemovals: () => {},
+    clearPendingMeshTranslations: () => {},
+    clearPendingMeshRotations: () => {},
+    clearInstancedShards: () => {},
+    clearColorRef: { current: [1, 1, 1, 1] },
+    ...overrides,
+  };
+}
+
+function Harness({ params }: { params: UseGeometryStreamingParams }) {
+  const rendererRef = useRef(params.rendererRef.current);
+  useGeometryStreaming({ ...params, rendererRef });
+  return null;
+}
+
+const mounted: Array<{ root: Root; container: HTMLElement }> = [];
+
+describe('useGeometryStreaming — federated instanced-shard forwarding (#1912)', () => {
+  it('forwards a secondary model\'s shard under its own modelIndex with its id-offset applied', async () => {
+    const calls: RecordedCall[] = [];
+    const renderer = fakeRenderer(calls);
+
+    const RAW_ENTITY_ID = 42;
+    const ID_OFFSET = 5000;
+    const params = baseParams({
+      rendererRef: { current: renderer },
+      pendingInstancedShards: [{ modelId: 'model-b', bytes: buildShardBytes(RAW_ENTITY_ID) }],
+      modelIdToIndex: new Map([['model-a', 0], ['model-b', 1]]),
+      modelIdToOffset: new Map([['model-a', 0], ['model-b', ID_OFFSET]]),
+    });
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    mounted.push({ root, container });
+
+    await act(async () => {
+      root.render(<Harness params={params} />);
+    });
+
+    assert.equal(calls.length, 1, 'scene.addInstancedShard must be called for the secondary model\'s shard');
+    assert.equal(calls[0].modelIndex, 1, 'must upload under the secondary model\'s modelIndex, not the primary\'s (0)');
+    assert.deepEqual(
+      calls[0].entityIds,
+      [RAW_ENTITY_ID + ID_OFFSET],
+      'the occurrence\'s entity id must carry the model\'s id-offset, matching the id finalizeModel assigned to its flat meshes',
+    );
+  });
+});

--- a/apps/viewer/src/components/viewer/useGeometryStreaming.ts
+++ b/apps/viewer/src/components/viewer/useGeometryStreaming.ts
@@ -76,11 +76,29 @@ export interface UseGeometryStreamingParams {
   pendingMeshRotations: Map<number, { angle: number; pivot: [number, number, number] }> | null;
   /**
    * Emit-both GPU-instancing: raw IFNS shard bytes from the geometry worker,
-   * drained here via `scene.addInstancedShard` (decode + upload as instanced
-   * templates). Cleared after each drain. Inert until the wasm exposes
+   * tagged with the owning model's id, drained here via
+   * `scene.addInstancedShard` (decode + upload as instanced templates).
+   * Cleared after each drain. Inert until the wasm exposes
    * processGeometryBatchInstanced.
    */
-  pendingInstancedShards: ArrayBuffer[] | null;
+  pendingInstancedShards: Array<{ modelId: string; bytes: ArrayBuffer }> | null;
+  /**
+   * modelId → renderer modelIndex (same map ViewportContainer stamps onto
+   * flat meshes / point clouds — reused here rather than re-derived, so a
+   * shard and its model's flat geometry always agree on ownership). Missing
+   * entry (legacy single-model path, no federation) falls back to 0.
+   */
+  modelIdToIndex?: ReadonlyMap<string, number>;
+  /**
+   * modelId → express-id offset (`FederatedModel.idOffset`). A federated
+   * shard's occurrences carry the RAW ids the worker parsed with — the same
+   * offset applied to that model's flat meshes at finalize must be applied
+   * here too, or an instanced occurrence's id would never match the one
+   * selection/highlighting/props use for the same entity (#1912). A primary
+   * model's offset is always 0 (the federation registry is cleared before
+   * every primary load), so omitting this param preserves prior behaviour.
+   */
+  modelIdToOffset?: ReadonlyMap<string, number>;
   clearPendingMeshColorUpdates: () => void;
   clearPendingColorUpdates: () => void;
   clearPendingMeshRemovals: () => void;
@@ -135,6 +153,8 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
     pendingMeshTranslations,
     pendingMeshRotations,
     pendingInstancedShards,
+    modelIdToIndex,
+    modelIdToOffset,
     clearPendingMeshColorUpdates,
     clearPendingColorUpdates,
     clearPendingMeshRemovals,
@@ -699,9 +719,11 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
 
   // ─── GPU-instancing shards ───────────────────────────────────────────
   // The geometry worker collates each batch into an IFNS shard; the loader
-  // pushes the raw bytes into pendingInstancedShards. Drain here: decode +
-  // upload each as instanced templates (repeated opaque occurrences render
-  // ONLY via these). Runs on the default path now.
+  // pushes the raw bytes into pendingInstancedShards, tagged with the owning
+  // model's id. Drain here: decode, re-home each occurrence's id onto that
+  // model's express-id space, and upload under that model's modelIndex
+  // (#1912 — a federated model's shards used to be dropped before ever
+  // reaching this drain, since the loader only forwarded the primary's).
   useEffect(() => {
     if (pendingInstancedShards === null || !isInitialized) return;
     const renderer = rendererRef.current;
@@ -711,7 +733,7 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
     if (!device) return;
 
     if (pendingInstancedShards.length > 0) {
-      for (const bytes of pendingInstancedShards) {
+      for (const { modelId, bytes } of pendingInstancedShards) {
         // CRITICAL: never let a shard decode/upload throw OUT of this effect.
         // addInstancedShard creates GPU buffers (mappedAtCreation); on a degraded
         // backend whose device is being lost (e.g. CI's SwiftShader), createBuffer
@@ -721,7 +743,15 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
         // still renders.
         try {
           const shard = decodeInstancedShard(new Uint8Array(bytes));
-          if (shard) scene.addInstancedShard(device, shard);
+          if (!shard) continue;
+          const idOffset = modelIdToOffset?.get(modelId) ?? 0;
+          if (idOffset > 0) {
+            for (const instance of shard.instances) {
+              instance.entityId += idOffset;
+            }
+          }
+          const modelIndex = modelIdToIndex?.get(modelId) ?? 0;
+          scene.addInstancedShard(device, shard, modelIndex);
         } catch (err) {
           console.warn('[useGeometryStreaming] instanced shard upload failed (device lost?), skipping:', err);
         }
@@ -729,7 +759,7 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
       renderer.requestRender();
     }
     clearInstancedShards();
-  }, [pendingInstancedShards, isInitialized, clearInstancedShards]);
+  }, [pendingInstancedShards, modelIdToIndex, modelIdToOffset, isInitialized, clearInstancedShards]);
 
   // ─── Mesh translations (move / gizmo drag / numeric move) ────────────
   // Drain the pending-translation map onto the renderer. Same

--- a/apps/viewer/src/hooks/useIfcCache.ts
+++ b/apps/viewer/src/hooks/useIfcCache.ts
@@ -180,6 +180,11 @@ export function useIfcCache() {
   const loadFromCache = useCallback(async (
     cacheResult: CacheResult,
     fileName: string,
+    // Owning model id for the restored instanced shards (#1912) — this path
+    // is PRIMARY-only (a federated add never caches), so its id-offset is
+    // always 0 and the modelId only needs to match the model useIfcLoader.ts
+    // registers via `upsertModel` for the same load.
+    modelId: string,
     cacheKey?: string,
     fallbackSourceBuffer?: ArrayBufferLike,
   ): Promise<CacheLoadResult> => {
@@ -379,7 +384,7 @@ export function useIfcCache() {
           const shardsReader = new BufferReader(cacheBuffer);
           shardsReader.position = shardsSection.offset;
           const shards = readInstancedShards(shardsReader);
-          if (shards.length > 0) appendInstancedShards(shards);
+          if (shards.length > 0) appendInstancedShards(modelId, shards);
         }
 
         setIfcDataStore(dataStore);

--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -526,6 +526,27 @@ export function useIfcLoader() {
               }
             }
             for (const asset of geometryResult.pointClouds ?? []) asset.expressId = asset.expressId + idOffset;
+            // #924/#1912: instanced-ONLY entities (no flat mesh, so the loop
+            // above never touches them) carry the same RAW ids the worker
+            // parsed with — re-home them too, or compare's
+            // `buildEntityFingerprints` (which subtracts idOffset from every
+            // key expecting it to already be global) would derive the wrong
+            // localId for every one of them.
+            if (geometryResult.instancedGeometryHashes) {
+              geometryResult.instancedGeometryHashes = new Map(
+                Array.from(geometryResult.instancedGeometryHashes, ([id, v]) => [id + idOffset, v]),
+              );
+            }
+            if (geometryResult.instancedGeometryAabbs) {
+              geometryResult.instancedGeometryAabbs = new Map(
+                Array.from(geometryResult.instancedGeometryAabbs, ([id, v]) => [id + idOffset, v]),
+              );
+            }
+            if (geometryResult.instancedGeometryVolumes) {
+              geometryResult.instancedGeometryVolumes = new Map(
+                Array.from(geometryResult.instancedGeometryVolumes, ([id, v]) => [id + idOffset, v]),
+              );
+            }
           }
           if (idOffset > 0 && patch?.pointCloudHandleId !== undefined) {
             const renderer = getGlobalRenderer();
@@ -555,6 +576,16 @@ export function useIfcLoader() {
           // Spatial index AFTER id offset + alignment (final ids + world positions)
           // and AFTER addModel so it attaches to THIS model, not the active slot.
           buildSpatialIndexForModel(geometryResult.meshes, modelId, dataStore);
+          // GPU-instancing (#1912): forward this model's shards now — NOT during
+          // streaming — because `useGeometryStreaming`'s drain re-homes each
+          // occurrence's raw entity id by `idOffset`, which is only known now
+          // (registerModelOffset ran a few lines up). AFTER addModel, so the
+          // renderer-side modelId → modelIndex / idOffset lookups
+          // (Viewport.tsx's `modelIdToIndex` / `modelIdToOffset`) already see
+          // this model when the drain effect runs.
+          if (allInstancedShards.length > 0) {
+            appendInstancedShards(modelId, allInstancedShards);
+          }
           return;
         }
 
@@ -966,7 +997,7 @@ export function useIfcLoader() {
             // Pass the freshly read file buffer as the source fallback: the
             // desktop cache doesn't persist a sourceBuffer, and without one the
             // restored store can't carry the lazy entity accessors.
-            const cacheLoadResult = await loadFromCache(cacheResult, file.name, cacheKey, buffer);
+            const cacheLoadResult = await loadFromCache(cacheResult, file.name, modelId, cacheKey, buffer);
             if (cacheLoadResult.success) {
               const state = useViewerStore.getState();
               await finalizeModel(state.ifcDataStore, state.geometryResult, getSchemaVersion(state.ifcDataStore), {
@@ -1074,11 +1105,16 @@ export function useIfcLoader() {
         // Issue #540: snapshot at load time so the WASM bridge applies
         // the flag before the first parseMeshes* call.
         mergeLayers: mergeLayersAtLoad,
-        // GPU instancing is primary-model only (single global scene, primary id
-        // space). A federated load must keep all geometry flat, else its opaque
-        // repeated occurrences would be partitioned into shards the federated path
-        // doesn't consume and silently dropped.
-        enableInstancing: target.kind === 'primary',
+        // GPU instancing (#1912 step 2): enabled for every load, primary and
+        // federated. It used to be primary-only — the scene's instanced
+        // templates were untagged, so a federated model's opaque repeated
+        // occurrences would land in shards the federated path never consumed
+        // and silently dropped. `addInstancedShard` now takes an owning
+        // `modelIndex` (#2172) and the federated finalize branch below
+        // forwards its collected shards with that model's index + its
+        // express-id offset, so the shards this produces have somewhere to
+        // go.
+        enableInstancing: true,
       });
       // Armed BEFORE init() so an engine-init failure still frees whatever the
       // partially-initialised bridge allocated (dispose() is a no-op when it
@@ -1511,18 +1547,27 @@ export function useIfcLoader() {
               totalMeshes = event.totalSoFar;
               lastTotalMeshes = event.totalSoFar;
 
+              // GPU-instancing: retain the raw IFNS shard bytes for BOTH target
+              // kinds — a primary load also writes them into the cache (the
+              // decode/upload only reads them, never detaches), and a federated
+              // load forwards them once at finalize (#1912), once its
+              // express-id offset is known (see the `target.kind === 'federated'`
+              // branch of `finalizeModel` below). Empty for non-instanced
+              // models / older wasm.
+              if (event.instancedShards && event.instancedShards.length > 0) {
+                for (let i = 0; i < event.instancedShards.length; i++) {
+                  allInstancedShards.push(event.instancedShards[i]);
+                }
+              }
+
               if (target.kind === 'primary') {
-                // GPU-instancing: hand the batch's IFNS shards to the store so
-                // useGeometryStreaming decodes + uploads them via the instanced path.
-                // Also retain the raw bytes so they're written into the cache (the
-                // decode/upload only reads them, never detaches) — otherwise a cache
-                // reload would drop every instanced occurrence. Empty for non-
-                // instanced models / older wasm.
+                // Live GPU-instancing: hand the batch's IFNS shards to the store
+                // so useGeometryStreaming decodes + uploads them via the
+                // instanced path AS THEY STREAM IN. Primary-only: its id-offset
+                // is always 0 (the federation registry is cleared before every
+                // primary load), so there is nothing to wait on.
                 if (event.instancedShards && event.instancedShards.length > 0) {
-                  appendInstancedShards(event.instancedShards);
-                  for (let i = 0; i < event.instancedShards.length; i++) {
-                    allInstancedShards.push(event.instancedShards[i]);
-                  }
+                  appendInstancedShards(modelId, event.instancedShards);
                 }
                 // Accumulate meshes for batched rendering
                 for (let i = 0; i < event.meshes.length; i++) pendingMeshes.push(event.meshes[i]);
@@ -1660,8 +1705,9 @@ export function useIfcLoader() {
                     totalVertices: allMeshes.reduce((sum, m) => sum + m.positions.length / 3, 0),
                     totalTriangles: allMeshes.reduce((sum, m) => sum + m.indices.length / 3, 0),
                     coordinateInfo: finalCoordinateInfo ?? createCoordinateInfo(calculateMeshBounds(allMeshes).bounds),
-                    // Empty for federated (instancing is primary-only) but kept for
-                    // shape consistency / future-proofing. (#924 compare parity)
+                    // Populated for federated too now that instancing runs for both
+                    // target kinds (#1912); empty only for older wasm / models with
+                    // no instanced-only entities. (#924 compare parity)
                     ...(allInstancedGeometryHashes.size > 0
                       ? { instancedGeometryHashes: allInstancedGeometryHashes }
                       : {}),

--- a/apps/viewer/src/lib/compare/buildFingerprints.ts
+++ b/apps/viewer/src/lib/compare/buildFingerprints.ts
@@ -82,9 +82,10 @@ export interface BuildFingerprintsModel {
    * Geometry-diff hashes for instanced-ONLY entities (#924) — repeated opaque
    * geometry that GPU-instancing took off the flat `meshes` array, so it carries
    * no per-mesh `geometryHash`. Keyed by express id (same convention as
-   * `meshes`). Without this, compare would silently miss geometry changes on
-   * instanced elements. Instancing is primary-model only, so these ids have
-   * `idOffset === 0`.
+   * `meshes` — i.e. federation-global, `local + idOffset`; the loader applies
+   * that shift to a federated model's instanced-only ids at finalize just like
+   * it does for `meshes`, #1912). Without this, compare would silently miss
+   * geometry changes on instanced elements.
    */
   instancedGeometryHashes?: ReadonlyMap<number, bigint>;
   /**

--- a/apps/viewer/src/store/slices/dataSlice.ts
+++ b/apps/viewer/src/store/slices/dataSlice.ts
@@ -71,12 +71,19 @@ export interface DataSlice {
   clearPendingMeshRemovals: () => void;
   /**
    * Emit-both GPU-instancing: raw IFNS shard bytes (transferable ArrayBuffers)
-   * collated per geometry batch by the worker. `useGeometryStreaming` drains
-   * them each frame via `scene.addInstancedShard` (decode + upload as instanced
-   * templates). Additive overlay on the flat geometry; null when none pending.
+   * collated per geometry batch by the worker, tagged with the owning model's
+   * id. `useGeometryStreaming` drains them each frame via
+   * `scene.addInstancedShard` (decode + upload as instanced templates),
+   * resolving `modelId` to the renderer's `modelIndex` and to that model's
+   * express-id offset so occurrences land under the right owner and match
+   * the ids used everywhere else for that model (#1912). Additive overlay on
+   * the flat geometry; null when none pending. A primary load's `modelId`
+   * always carries idOffset 0 (the federation registry is cleared before
+   * every primary load), so the primary path behaves exactly as before this
+   * tagging was added.
    */
-  pendingInstancedShards: ArrayBuffer[] | null;
-  appendInstancedShards: (shards: ArrayBuffer[]) => void;
+  pendingInstancedShards: Array<{ modelId: string; bytes: ArrayBuffer }> | null;
+  appendInstancedShards: (modelId: string, shards: ArrayBuffer[]) => void;
   clearInstancedShards: () => void;
   /**
    * Pending per-entity translations for the renderer. Authoring
@@ -314,9 +321,12 @@ export const createDataSlice: StateCreator<DataSlice & DataCrossSliceState, [], 
 
   clearPendingMeshRemovals: () => set({ pendingMeshRemovals: null }),
 
-  appendInstancedShards: (shards) => set((state) => ({
+  appendInstancedShards: (modelId, shards) => set((state) => ({
     // Accumulate across batches — useGeometryStreaming drains once per frame.
-    pendingInstancedShards: [...(state.pendingInstancedShards ?? []), ...shards],
+    pendingInstancedShards: [
+      ...(state.pendingInstancedShards ?? []),
+      ...shards.map((bytes) => ({ modelId, bytes })),
+    ],
   })),
 
   clearInstancedShards: () => set({ pendingInstancedShards: null }),


### PR DESCRIPTION
Closes #1912. Step 2 of the work #2172 began.

## What was missing

Step 1 gave the scene per-model ownership — `modelIndex` on templates, `addInstancedShard(device, shard, modelIndex)`, `removeInstancedTemplatesForModel` — and you noted at the time that tagging alone would not deliver instancing to federated loads. That was right, and it was worse than "not forwarded":

- `useIfcLoader.ts` set `enableInstancing: target.kind === 'primary'`, so the WASM engine never *produced* instanced shards for a federated load
- `event.instancedShards` was collected only under `if (target.kind === 'primary')`

So there was nothing to forward. Federated models' repeated geometry rendered through nothing at all.

## Forwarding alone is not sufficient — the part the issue does not mention

A federated model gets `idOffset > 0`. The federation registry is cleared before every primary load, so any *second* model always has a nonzero offset. But a shard's occurrence `entityId`s are the **raw** ids the worker parsed with.

Uploading those unchanged would give instanced occurrences ids that never match the ones selection, highlighting and the properties panel use for the same entity — geometry on screen that cannot be picked, or picks the wrong element. The offset is now applied at drain time, matching exactly what `finalizeModel` already does to that model's flat meshes.

The same latent bug sat in the **#924 compare hash/aabb/volume maps**, also keyed on raw ids. It was unreachable while instancing was primary-only and became live the moment federated shards started flowing. Fixed alongside rather than left as a trap for whoever hit it first.

## Identity: reused, not reinvented

Ownership resolves through the existing `modelIdToIndex` — the same map `ViewportContainer.tsx:150-157` already stamps onto flat meshes and point clouds — threaded into `useGeometryStreaming` rather than derived a second time. A missing entry falls back to `0`, so the legacy single-model path is byte-identical.

This mattered: a second identity scheme for "which model is this" is exactly the shape that has produced four separate defects here recently (`sumByType`, the `EntityRef` codec, `setTypeOverride` across three implementations, `EntityTable`). I did have to add a `modelIdToOffset` map, since no existing mapping carried `FederatedModel.idOffset` to the shard path — it derives from the same source `finalizeModel` uses.

## Scope — this closes #1912, not #2073

Stating it plainly rather than letting the issue link imply more.

`scene.clear()` is still called on every non-streaming reshape (`useGeometryStreaming.ts:266`, `:276`, `:290`, `:298`, `:332`) and nothing re-uploads afterwards. Tracing the effect ordering: a shard pushed in the same commit as its owning model's `addModel` **survives**, because the drain effect runs after the clear effect in commit order. But any *already-uploaded* model's instancing — the primary's, or an earlier federated model's — is wiped by a later clear and never comes back.

So #2073's retention gap is real, unchanged, and now equally exposed on the federated path. Full retention across `scene.clear()` is materially larger (it needs the shard bytes kept, or the templates preserved across the clear) and is step 3, not attempted here.

## Verification

- **RED first**, re-confirmed by hand rather than taken from a report: reverting the ownership and offset logic fails the new test with `expected: 1, actual: 0` (no `addInstancedShard` call for the secondary model), and restoring returns it to green.
- Every edit mutation-checked with an asserted replacement count; restores by file copy throughout.
- `apps/viewer`: **3039 passing / 2 skipped / 0 failing** across 266 files. `tsc --noEmit` clean, full output read.
- `packages/renderer` unchanged and still 449/449 — step 1's primitives already covered ownership.
- No changeset: `apps/viewer` is private, and no published package changed.
