### PR TITLE
fix(viewer): stop stackless DOMExceptions reaching PostHog with zero frames

### DIFF
--- a/apps/viewer/src/lib/analytics.test.ts
+++ b/apps/viewer/src/lib/analytics.test.ts
@@ -5,7 +5,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { scrubEvent } from './analytics-scrub.js';
-import { beforeSend } from './analytics.js';
+import { beforeSend, ensureCapturableStack } from './analytics.js';
 import { __setChunkReloadPendingForTests } from './chunk-version-skew.js';
 
 // `scrubEvent` is the single `before_send` gate every captured event passes
@@ -640,5 +640,80 @@ describe('beforeSend - chunk-skew gate wiring', () => {
     } finally {
       __setChunkReloadPendingForTests(null);
     }
+  });
+});
+
+// #2229/#2230: PostHog's own DOMExceptionCoercer (@posthog/core,
+// error-tracking/coercers/dom-exception-coercer.js) does:
+//
+//   const hasStack = isString(err.stack);
+//   return { ..., stack: hasStack ? err.stack : undefined, ... };
+//
+// So a captured DOMException with no `.stack` reaches PostHog with ZERO
+// frames — read directly from node_modules to pin this down rather than
+// assumed. And a JS-constructed `new DOMException(msg, name)` genuinely has
+// no `.stack` in real engines: confirmed by probing both WebKit 26.5 (the
+// exact Safari version in #2229/#2230's report) and Chromium via Playwright
+// — `'stack' in err` is `false` in both, despite `err instanceof Error` being
+// `true`. `ensureCapturableStack` (./analytics.ts) is the fix: it recognises
+// this shape at the `captureException` boundary and synthesizes a real,
+// string `.stack` before the value ever reaches posthog-js's coercer.
+describe('ensureCapturableStack — #2229/#2230 stackless-DOMException fix', () => {
+  // Stand-in for a real browser DOMException constructed by our own code
+  // (e.g. gpu-upload-guard.ts's caught GPU failures): instanceof Error, real
+  // name/message, but no `.stack` — reproducing what Playwright observed in
+  // both WebKit 26.5 and Chromium for `new DOMException(...)`.
+  class StacklessDOMException extends Error {
+    constructor(message: string, name: string) {
+      super(message);
+      this.name = name;
+      // Deliberately reproducing the browser shape, where `new
+      // DOMException()` never gets an own `.stack` at all.
+      delete (this as { stack?: string }).stack;
+    }
+  }
+
+  it('RED: a stackless DOMException has no usable .stack (the bug as observed)', () => {
+    const err = new StacklessDOMException('createBuffer failed', 'InvalidStateError');
+    assert.equal('stack' in err, false);
+    // This is exactly what PostHog's DOMExceptionCoercer checks — reproduced
+    // here directly against the same predicate it uses (`isString(err.stack)`)
+    // rather than trusting a paraphrase of it.
+    assert.equal(typeof (err as { stack?: unknown }).stack, 'undefined');
+  });
+
+  it('GREEN: ensureCapturableStack gives it a real, string .stack', () => {
+    const err = new StacklessDOMException('createBuffer failed', 'InvalidStateError');
+    const fixed = ensureCapturableStack(err);
+    assert.ok(fixed instanceof Error);
+    assert.equal(typeof (fixed as Error).stack, 'string');
+    assert.ok(((fixed as Error).stack as string).length > 0);
+  });
+
+  it('preserves name and message so error_type / grouping stay correct', () => {
+    const err = new StacklessDOMException('createBuffer failed', 'InvalidStateError');
+    const fixed = ensureCapturableStack(err) as Error;
+    assert.equal(fixed.name, 'InvalidStateError');
+    assert.equal(fixed.message, 'createBuffer failed');
+  });
+
+  it('leaves an Error that already has a real stack untouched (identity)', () => {
+    const err = new TypeError('already fine');
+    const result = ensureCapturableStack(err);
+    assert.equal(result, err); // same object, not a copy
+  });
+
+  it('passes through non-Error values unchanged (string, number, null)', () => {
+    assert.equal(ensureCapturableStack('bare string'), 'bare string');
+    assert.equal(ensureCapturableStack(42), 42);
+    assert.equal(ensureCapturableStack(null), null);
+    assert.equal(ensureCapturableStack(undefined), undefined);
+  });
+
+  it('treats an empty-string .stack the same as a missing one', () => {
+    const err = new StacklessDOMException('x', 'AbortError');
+    (err as { stack?: string }).stack = '';
+    const fixed = ensureCapturableStack(err) as Error;
+    assert.ok(fixed.stack && fixed.stack.length > 0);
   });
 });

--- a/apps/viewer/src/lib/analytics.ts
+++ b/apps/viewer/src/lib/analytics.ts
@@ -28,6 +28,55 @@ export const beforeSend = <
   return scrubEvent(event);
 };
 
+// PostHog's own `DOMExceptionCoercer` (posthog-js -> @posthog/core) does
+// exactly this before an exception ever leaves the browser:
+//
+//   const hasStack = isString(err.stack);
+//   return { ..., stack: hasStack ? err.stack : undefined, ... };
+//
+// — verified by reading @posthog/core's dom-exception-coercer.js. So any
+// DOMException reaching `captureException` with no `.stack` is symbolicated
+// as zero frames, full stop; no amount of sourcemap upload changes that,
+// because there is nothing for PostHog to resolve.
+//
+// And a JS-constructed `DOMException` commonly HAS no `.stack`: confirmed by
+// probing real engines with Playwright (both WebKit 26.5 and Chromium) —
+// `new DOMException(msg, name)` is `instanceof Error` but `'stack' in err` is
+// false in both. Contrast a DOMException the browser itself throws as part of
+// a native binding failure (e.g. `structuredClone`'s `DataCloneError`), which
+// DOES get a stack in both engines. Which path `GPUDevice.createTexture`'s
+// `InvalidStateError` takes isn't independently verifiable without a live
+// WebGPU device, but the fix below is correct either way: it only touches
+// errors that already have no usable stack, so it can only add frames PostHog
+// would otherwise have dropped, never disturb a real one.
+//
+// This is the root cause behind issues #2229/#2230 ("payload carries no
+// stacktrace") for any call site whose caught value is a DOMException (GPU
+// upload failures, WebGL context loss, AbortError-shaped cancellations, …).
+//
+// The fix: at the capture boundary, if the value handed to `captureException`
+// is an `Error` (DOMException included — it's `instanceof Error`) with no
+// usable `.stack`, synthesize one by throwing/catching fresh right here. That
+// can't recover the original throw site, but every call site that reaches
+// this (gpu-upload-guard.ts, useIfcLoader.ts, LocationMap.tsx, …) reports
+// synchronously from inside its own catch block, so the synthesized frames
+// are the same call chain minus the innermost native frame — real,
+// sourcemap-resolvable file/line/column instead of the zero frames PostHog's
+// coercer would otherwise emit. See ./analytics.test.ts for the RED/GREEN
+// pair pinning this against posthog-js's actual coercer behavior.
+export function ensureCapturableStack(err: unknown): unknown {
+  if (!(err instanceof Error)) return err;
+  if (typeof err.stack === 'string' && err.stack.length > 0) return err;
+  const withStack = new Error(err.message);
+  withStack.name = err.name;
+  // V8 only: drops this function's own frame so the top of the synthesized
+  // stack is the real caller. A no-op (and harmless) everywhere else — those
+  // engines already excluded native-call frames from `new Error()`'s capture.
+  const capture = (Error as unknown as { captureStackTrace?: (target: object, ctor: unknown) => void }).captureStackTrace;
+  if (typeof capture === 'function') capture(withStack, ensureCapturableStack);
+  return withStack;
+}
+
 // `import.meta.env` is undefined under the Node test runner (no Vite define
 // plugin), and this module is loaded transitively by most viewer tests. The
 // optional chaining keeps the module-top-level read safe there — do NOT drop
@@ -73,7 +122,13 @@ if (enabled) {
       app_version: typeof __APP_VERSION__ === 'string' ? __APP_VERSION__ : 'dev',
       app_build_sha: typeof __BUILD_SHA__ === 'string' ? __BUILD_SHA__ : 'dev',
     });
-    client = posthogClient;
+    client = {
+      capture: posthogClient.capture.bind(posthogClient),
+      // Normalize away the DOMException-with-no-.stack case (see
+      // ensureCapturableStack above) before it reaches posthog-js's coercer.
+      captureException: (err, additionalProperties) =>
+        posthogClient.captureException(ensureCapturableStack(err), additionalProperties),
+    };
   } catch (err) {
     console.warn('[analytics] PostHog init failed; analytics disabled', err);
   }


### PR DESCRIPTION
Refs #2229, #2230 — your triage note:

> What would make it actionable is a stack frame — the payload carries no `stacktrace`, so the minified frames are not being symbolicated for these two. Worth fixing that before chasing the WebGPU path itself.

Agreed on the priority. But the cause turned out not to be sourcemaps, and that matters, because fixing sourcemaps would not have produced a single extra frame.

## The sourcemap pipeline is already correct

Checked all of it rather than assuming it was the gap:

- `apps/viewer/vite.config.ts:325` — `sourcemap: process.env.VITE_SOURCEMAP === '1'`, opt-in rather than off
- `scripts/vercel-build.sh` already runs `posthog-cli sourcemap process --release-version <12-char sha> --delete-after`, with `scripts/add-sourcemap-refs.mjs` injecting the `//# sourceMappingURL=` comments first because rolldown-vite's chunks lack them
- the `app_build_sha` "decode route" you mentioned is not a script — it is the super-property registered in `analytics.ts` matched against `RELEASE_VERSION` in `vercel-build.sh`, both truncating the sha to 12 chars

All of that landed in #1862, well before these two reports. **Proven working end to end**: built with `VITE_SOURCEMAP=1` (106 `.map` files), ran the ref injector, and resolved a real minified frame — same chunk-name shape as #2243's `pending-CytPVxJ4.js:1:555` — back to `src/components/ui/tooltip.tsx:23:8` with inline source content.

## The actual cause is upstream of symbolication

`@posthog/core`'s `dom-exception-coercer.js:35,39`:

```js
const hasStack = isString(err.stack);
return { ..., stack: hasStack ? err.stack : undefined, ... };
```

An exception with no `.stack` is emitted with **zero frames**. No amount of sourcemap upload changes that — there is nothing to resolve.

**And a JS-constructed `DOMException` has no stack.** Probed both engines with Playwright rather than reasoning about it:

| | `instanceof Error` | `'stack' in err` |
|---|---|---|
| `new DOMException(msg, name)` — Chromium | true | **false** |
| `new DOMException(msg, name)` — WebKit | true | **false** |
| `new RangeError(...)` — both | true | true |
| natively-thrown DOMException (`structuredClone` DataCloneError) — both | true | true |

**#2229 is a `DOMException`** (`InvalidStateError` from `GPUDevice.createTexture`). So it would arrive frameless whatever the sourcemap configuration.

## The fix

`ensureCapturableStack` at the capture boundary synthesizes a stack **only** when an `Error` arrives without a usable one, using `Error.captureStackTrace` where available to drop its own frame. Non-`Error` values pass through untouched; anything with a real stack is returned as-is. So it can only add frames PostHog would otherwise have dropped — it can never disturb a genuine one.

It cannot recover the original throw site, and the code says so. But every call site that reaches it — `gpu-upload-guard.ts`, `useIfcLoader.ts`, `LocationMap.tsx`, `ChunkErrorBoundary.tsx` — reports synchronously from inside its own `catch`, so the synthesized frames are that call chain minus the innermost native frame. Real, sourcemap-resolvable file/line/column instead of nothing.

One honest limit: whether `GPUDevice.createTexture`'s `InvalidStateError` is constructed or engine-thrown is not verifiable without a live WebGPU device. The fix is correct either way — it only touches errors that already have no usable stack.

## Hypothesis that was wrong, checked anyway

"`captureException` is being handed a bare string" — no. All seven call sites (`useIfcLoader.ts:350/1798/1906`, `gpu-upload-guard.ts:70`, `ChunkErrorBoundary.tsx:77`, `LocationMap.tsx:295`, plus `useClash`/`useIDS`) pass the caught value.

## Verification

- RED-first: neutering `ensureCapturableStack` fails 2 of its 6 tests; restoring returns them green. Mutation applied with an asserted replacement count, restored by file copy.
- I re-ran the browser probe myself rather than taking the agent's word — the table above is my own run.
- `apps/viewer`: **3044 passing / 2 skipped / 0 failing**. `tsc --noEmit` clean.
- No changeset — `apps/viewer` is private.

## Still needs you, and I did not attempt it

`POSTHOG_CLI_API_KEY` and `POSTHOG_CLI_ENV_ID` must be set in the Vercel project env for the upload step to actually run in production (the condition is already in `vercel-build.sh`). The in-repo half is complete and demonstrated; whether those two secrets are currently set is not checkable from here, and I did not try to touch the dashboard.

Worth confirming, because with this fix frames will now *exist* — and they will still render as minified chunk offsets unless the upload is live.
