### PR TITLE
fix(renderer,viewer): keep a present model's instanced templates across a reshape

### DIFF
--- a/.changeset/instanced-templates-survive-clear.md
+++ b/.changeset/instanced-templates-survive-clear.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/renderer": patch
+---
+
+Add `Scene.clearFlatGeometry()`: resets flat/batched geometry (meshes, batches, buckets, textured meshes, colour overlays, streaming state) without destroying GPU-instanced templates. `Scene.clear()` is unchanged (still a full reset — flat geometry AND instanced templates) but is now implemented as `destroyAllInstancedTemplates()` + `clearFlatGeometry()` internally.
+
+This exists so a caller that reshapes the scene (a visibility toggle, an in-place content mutation, a federated model add) while at least one model is still present can retain that model's instanced geometry instead of losing it permanently — nothing re-uploads GPU-instanced templates once they're destroyed, since the instancing shard bytes are dropped after their one-time drain. Pair `clearFlatGeometry()` with `removeInstancedTemplatesForModel()` for any model that did NOT survive the reshape, to keep the invariant that only present models' instanced geometry stays visible.
+
+`clearFlatGeometry()` also stops unconditionally clearing `boundingBoxes`: an id with a surviving instanced occurrence keeps its cached box (needed for raycast/measure to keep working on retained geometry); an id with no surviving occurrence anywhere (flat or instanced) still has its box dropped, matching the previous behaviour for pure flat geometry.

--- a/apps/viewer/src/components/viewer/Viewport.tsx
+++ b/apps/viewer/src/components/viewer/Viewport.tsx
@@ -155,6 +155,27 @@ export function Viewport({
     return map;
   }, [models]);
 
+  // Model indices whose GPU-instanced templates should survive a reshape
+  // (#2073) — every federated model that is still loaded AND visible.
+  // `undefined` (no federation info yet) falls back to useGeometryStreaming's
+  // own "modelIndex 0 only" default, the non-federated case.
+  const presentInstancedModelIndices = useMemo(() => {
+    if (!modelIdToIndex || modelIdToIndex.size === 0) return undefined;
+    // Index 0 is unconditionally present: the shard drain resolves ownership
+    // as `modelIdToIndex.get(modelId) ?? 0`, so a shard whose modelId is not
+    // in the map lands on 0. Deriving this set from the map alone would then
+    // tear down templates the drain had just uploaded there — the two must
+    // agree on the FALLBACK, not only on the mapped entries. That mismatch
+    // between a producer and a consumer of the same key is exactly the shape
+    // behind #2272 and #2278.
+    const present = new Set<number>([0]);
+    for (const [modelId, index] of modelIdToIndex) {
+      const model = models.get(modelId);
+      if (!model || model.visible) present.add(index);
+    }
+    return present;
+  }, [modelIdToIndex, models]);
+
   // Helper to handle pick result and set selection properly
   // IMPORTANT: pickResult.expressId is now a globalId (transformed at load time)
   // resolveEntityRef is the single source of truth for globalId → EntityRef
@@ -1401,6 +1422,7 @@ export function Viewport({
     pendingInstancedShards,
     modelIdToIndex,
     modelIdToOffset,
+    presentInstancedModelIndices,
     clearPendingColorUpdates,
     clearPendingMeshColorUpdates,
     clearPendingMeshRemovals,

--- a/apps/viewer/src/components/viewer/useGeometryStreaming.instanced-retention.test.tsx
+++ b/apps/viewer/src/components/viewer/useGeometryStreaming.instanced-retention.test.tsx
@@ -1,0 +1,333 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * #2073: `scene.clear()` used to run unconditionally on every non-streaming
+ * reshape (`useGeometryStreaming.ts`'s main effect: a fresh/replaced file, a
+ * length-decrease from hiding a model or a type-visibility toggle, a
+ * federated model add, an in-place content-version bump). That destroys
+ * EVERY GPU-instanced template — including ones belonging to a model that is
+ * still loaded and visible — and nothing re-uploads them afterwards: the raw
+ * IFNS shard bytes are dropped from the store right after their one-time
+ * drain (`clearInstancedShards()` / `pendingInstancedShards: null`), so
+ * repeated geometry (windows, doors, bolts, ...) silently vanished for the
+ * rest of the session on the very next reshape.
+ *
+ * This drives the REAL `useGeometryStreaming` hook under happy-dom + React
+ * 19, with a fake `Renderer`/`Scene`/`Camera` (no WebGPU needed — the hook
+ * only calls a small, enumerable surface of methods on them) that records
+ * every call AND tracks which `modelIndex`es currently own instanced
+ * templates, the same way the real `Scene` class does. `decodeInstancedShard`
+ * is the REAL function from `@ifc-lite/geometry`, fed a known-good fixture
+ * (borrowed from `packed-instanced-decoder.test.ts`), so the shard-drain
+ * effect exercises real decode, not a stub.
+ *
+ * Two invariants are asserted, matching the issue's design requirement:
+ *  1. A reshape where the model is STILL present must retain its instanced
+ *     geometry (the bug: it did not).
+ *  2. A reshape where the model was hidden/removed must NOT retain its
+ *     instanced geometry (the naive "just don't clear" fix the issue's own
+ *     design comment rejected, because the scene/hook couldn't tell WHICH
+ *     model a template belonged to before #2172's per-model ownership +
+ *     #2239's bbox teardown landed).
+ */
+
+import '../../test/setup-dom.js';
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { useRef, useState } from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import type { Renderer } from '@ifc-lite/renderer';
+import type { MeshData } from '@ifc-lite/geometry';
+import { useGeometryStreaming, type UseGeometryStreamingParams } from './useGeometryStreaming.js';
+
+// ── Known-good decodable instanced-shard fixture ───────────────────────────
+// Same bytes as packages/geometry/src/packed-instanced-decoder.test.ts's
+// Rust↔TS conformance fixture (`dump_instanced_fixture`): 2 templates, 3
+// instances. Content doesn't matter here — only that `decodeInstancedShard`
+// accepts it without throwing, so the hook's real drain path runs end to end.
+const SHARD_FIXTURE_HEX =
+  '534e464901000000020000000300000018000000180000000800000000000000000000000c000000000000000c00000000000000040000000000000000000000000000000000000000000000000000000c0000000c0000000c0000000c000000040000000400000000000000000000000000000000000000000000000000000000000000e803000000000000cdcc4c3e9a99993e0000803f0000803f000000000000000000000000000000000000803f000000000000000000000000000000000000803f000000000000000000000000000000000000803f00000000e9030000cdcccc3dcdcc4c3e9a99993e0000803f0000803f0000000000000000000080bf000000000000803f000000000000004000000000000000000000803f000000000000000000000000000000000000803f01000000ea030000cdcc4c3ecdcc4c3e9a99993e0000803f0000803f000000000000000000000000000000000000803f000000000000000000000000000000000000803f000000000000000000000000000000000000803f0000803f00000000000000000000004000000000000000000000803f0000803f000000000000803f000000000000803f0000a0400000a0400000a0400000c0400000a0400000a0400000a0400000c0400000a0400000a0400000a0400000c0400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000020000000300000000000000010000000200000003000000';
+
+function hexToShardBytes(hex: string): ArrayBuffer {
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i += 1) {
+    out[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out.buffer;
+}
+
+const SHARD_BYTES = hexToShardBytes(SHARD_FIXTURE_HEX);
+
+function mesh(expressId: number, modelIndex = 0): MeshData {
+  return {
+    expressId,
+    modelIndex,
+    positions: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+    normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+    indices: new Uint32Array([0, 1, 2]),
+    color: [1, 1, 1, 1],
+  };
+}
+
+// ── Fake Scene: records every call the hook makes, and tracks which
+//    modelIndexes currently own instanced templates the same way the real
+//    Scene class does (add on addInstancedShard, drop-all on clear(),
+//    drop-one on removeInstancedTemplatesForModel(), untouched by
+//    clearFlatGeometry()). ──────────────────────────────────────────────────
+class FakeScene {
+  calls: string[] = [];
+  instancedModelIndices = new Set<number>();
+
+  clear(): void {
+    this.calls.push('clear');
+    this.instancedModelIndices.clear();
+  }
+  clearFlatGeometry(): void {
+    this.calls.push('clearFlatGeometry');
+    // Flat-only: instanced templates are untouched by design (#2073).
+  }
+  getInstancedModelIndices(): number[] {
+    return [...this.instancedModelIndices];
+  }
+  removeInstancedTemplatesForModel(modelIndex: number): number {
+    this.calls.push(`removeInstancedTemplatesForModel:${modelIndex}`);
+    const had = this.instancedModelIndices.delete(modelIndex);
+    return had ? 1 : 0;
+  }
+  addInstancedShard(_device: unknown, _shard: unknown, modelIndex = 0): void {
+    this.calls.push('addInstancedShard');
+    this.instancedModelIndices.add(modelIndex);
+  }
+  appendToBatches(): void { this.calls.push('appendToBatches'); }
+  queueMeshes(): void { this.calls.push('queueMeshes'); }
+  hasQueuedMeshes(): boolean { return false; }
+  getBatchedMeshes(): unknown[] { return []; }
+  flushPending(): boolean { return true; }
+  hasPendingBatches(): boolean { return false; }
+  rebuildPendingBatches(): void {}
+  removeMeshesForEntities(): void {}
+  translateMeshesForEntities(): void {}
+  rotateMeshesForEntities(): void {}
+  hasStreamingFragments(): boolean { return false; }
+  isEphemeralStreaming(): boolean { return false; }
+  finalizeStreaming(): void {}
+  finalizeStreamingAsync(): Promise<void> { return Promise.resolve(); }
+  finishEphemeralStreaming(): void {}
+  setEphemeralStreamingMode(): void {}
+  updateMeshColors(): void {}
+  setColorOverrides(): void {}
+  clearColorOverrides(): void {}
+}
+
+function fakeCamera() {
+  return {
+    fitBoundsAdaptive: () => ({ kind: 'compact' as const }),
+    getPosition: () => ({ x: 0, y: 0, z: 0 }),
+    getTarget: () => ({ x: 0, y: 0, z: 0 }),
+    setSceneBounds: () => {},
+    setOrbitAnchorBounds: () => {},
+    reset: () => {},
+  };
+}
+
+function fakeRenderer(scene: FakeScene) {
+  const camera = fakeCamera();
+  return {
+    getGPUDevice: () => ({}),
+    getPipeline: () => ({}),
+    getScene: () => scene,
+    getCamera: () => camera,
+    getCanvas: () => null,
+    clearCaches: () => {},
+    requestRender: () => {},
+  } as unknown as Renderer;
+}
+
+/** Harness: mounts the real hook, letting the test drive its params via
+ *  external re-renders. `pendingInstancedShards` is owned INTERNALLY (seeded
+ *  once from `initialShardBytes`) so `clearInstancedShards()` behaves exactly
+ *  like the real store action — set to null and stay null across later
+ *  reshapes, since nothing in this bug scenario ever repopulates it. */
+function Harness(props: Omit<UseGeometryStreamingParams, 'pendingInstancedShards' | 'clearInstancedShards' | 'rendererRef' | 'clearColorRef'> & {
+  initialShardBytes: ArrayBuffer[] | null;
+  renderer: Renderer;
+}) {
+  const { initialShardBytes, renderer, ...rest } = props;
+  const [shards, setShards] = useState<ArrayBuffer[] | null>(() => initialShardBytes);
+  const rendererRef = useRef<Renderer | null>(renderer);
+  const clearColorRef = useRef<[number, number, number, number]>([0, 0, 0, 1]);
+  useGeometryStreaming({
+    ...rest,
+    rendererRef,
+    pendingInstancedShards: shards,
+    clearInstancedShards: () => setShards(null),
+    clearColorRef,
+  });
+  return null;
+}
+
+type ReshapeOverrides = Pick<
+  UseGeometryStreamingParams,
+  'geometry' | 'geometryVersion' | 'geometryContentVersion' | 'modelCount' | 'presentInstancedModelIndices'
+>;
+
+function baseParams(scene: FakeScene, overrides: ReshapeOverrides) {
+  const noop = () => {};
+  return {
+    isInitialized: true,
+    isStreaming: false,
+    geometryBoundsRef: { current: { min: { x: -100, y: -100, z: -100 }, max: { x: 100, y: 100, z: 100 } } },
+    pendingMeshColorUpdates: null,
+    pendingColorUpdates: null,
+    pendingMeshRemovals: null,
+    pendingMeshTranslations: null,
+    pendingMeshRotations: null,
+    clearPendingMeshColorUpdates: noop,
+    clearPendingColorUpdates: noop,
+    clearPendingMeshRemovals: noop,
+    clearPendingMeshTranslations: noop,
+    clearPendingMeshRotations: noop,
+    renderer: fakeRenderer(scene),
+    ...overrides,
+  };
+}
+
+function mountHarness(container: HTMLDivElement): Root {
+  return createRoot(container);
+}
+
+describe('useGeometryStreaming — instanced-template retention across scene.clear() (#2073)', () => {
+  it('retains a still-present model\'s instanced geometry across a non-streaming reshape', () => {
+    const scene = new FakeScene();
+    const container = document.createElement('div');
+    const root = mountHarness(container);
+
+    // Initial load: one model (modelIndex 0), one flat mesh, one instanced
+    // shard streamed in alongside it.
+    act(() => {
+      root.render(
+        <Harness
+          {...baseParams(scene, {
+            geometry: [mesh(1, 0)],
+            geometryVersion: 1,
+            modelCount: 1,
+            presentInstancedModelIndices: new Set([0]),
+          })}
+          initialShardBytes={[SHARD_BYTES]}
+        />
+      );
+    });
+
+    assert.deepEqual(
+      scene.calls,
+      ['clearFlatGeometry', 'appendToBatches', 'addInstancedShard'],
+      'initial load: flat-geometry clear (no instanced templates exist yet, so the reconcile is a no-op), ' +
+      'flat append, instanced shard drain',
+    );
+    assert.deepEqual([...scene.instancedModelIndices], [0], 'model 0 owns instanced templates after initial load');
+    scene.calls.length = 0;
+
+    // Reshape #1: in-place content mutation (e.g. realignFederation) with the
+    // SAME model (0) still present — geometryContentVersion bumps. No new
+    // shard bytes arrive (pendingInstancedShards stays null, drained once).
+    act(() => {
+      root.render(
+        <Harness
+          {...baseParams(scene, {
+            geometry: [mesh(1, 0)],
+            geometryVersion: 1,
+            geometryContentVersion: 1,
+            modelCount: 1,
+            presentInstancedModelIndices: new Set([0]),
+          })}
+          initialShardBytes={[SHARD_BYTES]}
+        />
+      );
+    });
+
+    // Shape asserted in the issue: a flat-geometry clear + re-append, and
+    // — critically — NO second addInstancedShard (nothing re-uploads the
+    // dropped shard bytes). What must differ from the pre-fix behaviour is
+    // NOT the call names but the surviving state: model 0's instanced
+    // templates must still be there.
+    assert.ok(!scene.calls.includes('addInstancedShard'), 'no shard bytes were re-drained (none arrived)');
+    assert.deepEqual(
+      [...scene.instancedModelIndices],
+      [0],
+      'RED on unmodified main: scene.clear() destroys every instanced template, including model 0\'s, ' +
+      'even though model 0 never left. GREEN once the hook uses clearFlatGeometry() + reconciles ' +
+      'ownership against presentInstancedModelIndices instead of a blind clear().',
+    );
+
+    act(() => { root.unmount(); });
+  });
+
+  it('does NOT retain a hidden/removed model\'s instanced geometry (the case the naive fix breaks)', () => {
+    const scene = new FakeScene();
+    const container = document.createElement('div');
+    const root = mountHarness(container);
+
+    // Initial load: two federated models. Model 0 gets one instanced shard;
+    // model 1 gets a second, distinctly-tagged shard (simulated by seeding
+    // the fake scene directly at modelIndex 1 — the real per-shard modelIndex
+    // tagging is #2255's job, not this hook's; this test only needs the
+    // SCENE to already know model 1 owns templates, which #2172 already
+    // makes possible via addInstancedShard's modelIndex param).
+    act(() => {
+      root.render(
+        <Harness
+          {...baseParams(scene, {
+            geometry: [mesh(1, 0), mesh(2, 1)],
+            geometryVersion: 1,
+            modelCount: 2,
+            presentInstancedModelIndices: new Set([0, 1]),
+          })}
+          initialShardBytes={[SHARD_BYTES]}
+        />
+      );
+    });
+    // Seed model 1's instanced ownership directly (see comment above).
+    scene.instancedModelIndices.add(1);
+    assert.deepEqual([...scene.instancedModelIndices].sort(), [0, 1], 'both models own instanced templates');
+    scene.calls.length = 0;
+
+    // Reshape: model 1 is hidden (a type-visibility toggle or a federation
+    // hide) — geometry shrinks to just model 0's mesh, and the caller updates
+    // presentInstancedModelIndices to reflect that model 1 is no longer
+    // present.
+    act(() => {
+      root.render(
+        <Harness
+          {...baseParams(scene, {
+            geometry: [mesh(1, 0)],
+            geometryVersion: 2,
+            modelCount: 2,
+            presentInstancedModelIndices: new Set([0]),
+          })}
+          initialShardBytes={[SHARD_BYTES]}
+        />
+      );
+    });
+
+    assert.deepEqual(
+      [...scene.instancedModelIndices],
+      [0],
+      'model 1\'s instanced geometry must be torn down when it is hidden — retaining it would reproduce ' +
+      'exactly the bug the original design comment rejected (a hidden model\'s repeated geometry staying ' +
+      'on screen because the scene could not tell which template belonged to which model).',
+    );
+    assert.ok(
+      scene.calls.includes('removeInstancedTemplatesForModel:1'),
+      `expected an explicit per-model teardown for the removed model, got calls: ${JSON.stringify(scene.calls)}`,
+    );
+    assert.ok(
+      !scene.calls.includes('removeInstancedTemplatesForModel:0'),
+      'model 0 (still present) must not be torn down',
+    );
+
+    act(() => { root.unmount(); });
+  });
+});

--- a/apps/viewer/src/components/viewer/useGeometryStreaming.instanced-retention.test.tsx
+++ b/apps/viewer/src/components/viewer/useGeometryStreaming.instanced-retention.test.tsx
@@ -156,7 +156,14 @@ function Harness(props: Omit<UseGeometryStreamingParams, 'pendingInstancedShards
   renderer: Renderer;
 }) {
   const { initialShardBytes, renderer, ...rest } = props;
-  const [shards, setShards] = useState<ArrayBuffer[] | null>(() => initialShardBytes);
+  // #2255 changed the wire shape to carry the owning model's id alongside the
+  // bytes. The drain resolves ownership as `modelIdToIndex.get(modelId) ?? 0`,
+  // and these tests deliberately supply no `modelIdToIndex`, so every shard
+  // lands on modelIndex 0 — which is what the assertions below expect. Tagging
+  // here rather than at each call site keeps the fixtures about retention.
+  const [shards, setShards] = useState<Array<{ modelId: string; bytes: ArrayBuffer }> | null>(() =>
+    initialShardBytes === null ? null : initialShardBytes.map((bytes) => ({ modelId: 'model-0', bytes }))
+  );
   const rendererRef = useRef<Renderer | null>(renderer);
   const clearColorRef = useRef<[number, number, number, number]>([0, 0, 0, 1]);
   useGeometryStreaming({

--- a/apps/viewer/src/components/viewer/useGeometryStreaming.ts
+++ b/apps/viewer/src/components/viewer/useGeometryStreaming.ts
@@ -19,7 +19,7 @@
  */
 
 import { useEffect, useRef, type MutableRefObject } from 'react';
-import type { Renderer } from '@ifc-lite/renderer';
+import type { Renderer, Scene } from '@ifc-lite/renderer';
 import type { MeshData, CoordinateInfo } from '@ifc-lite/geometry';
 import { decodeInstancedShard } from '@ifc-lite/geometry';
 import { toast } from '../ui/toast.js';
@@ -99,6 +99,25 @@ export interface UseGeometryStreamingParams {
    * every primary load), so omitting this param preserves prior behaviour.
    */
   modelIdToOffset?: ReadonlyMap<string, number>;
+  /**
+   * Model indices whose GPU-instanced templates should survive a reshape
+   * (#2073). `scene.clear()` used to run unconditionally on every
+   * non-streaming reshape — a federated model add, a model hide, a
+   * type-visibility toggle, an in-place content-version bump — which
+   * destroyed EVERY model's instanced templates including ones for models
+   * still loaded and visible. Nothing re-uploads them afterwards (the raw
+   * shard bytes are dropped right after their one-time drain), so repeated
+   * geometry (windows, doors, bolts, ...) silently vanished for the rest of
+   * the session. Reshapes now call `scene.clearFlatGeometry()` (keeps
+   * instanced buffers) and reconcile ownership against this set — any
+   * modelIndex the scene still holds templates for but that is NOT in this
+   * set gets torn down via `removeInstancedTemplatesForModel`, so a
+   * genuinely removed/hidden model's instanced geometry does not linger.
+   * `undefined` defaults to "only modelIndex 0 is present" — the
+   * non-federated case, where `addInstancedShard` has always defaulted new
+   * templates to modelIndex 0.
+   */
+  presentInstancedModelIndices?: ReadonlySet<number>;
   clearPendingMeshColorUpdates: () => void;
   clearPendingColorUpdates: () => void;
   clearPendingMeshRemovals: () => void;
@@ -136,6 +155,35 @@ function traceGeometrySync(message: string): void {
   console.log(`[GeomSync] ${message}`);
 }
 
+// Non-federated default: only the primary model (modelIndex 0, what
+// `addInstancedShard` has always defaulted new templates to) survives a
+// reshape when the caller has no per-model presence info.
+const DEFAULT_PRESENT_INSTANCED_MODEL_INDICES: ReadonlySet<number> = new Set([0]);
+
+/**
+ * Reshape the scene for a non-streaming geometry change WITHOUT destroying
+ * instanced templates that belong to a model still present (#2073). Clears
+ * flat/batched geometry unconditionally (that always needs a full rebuild on
+ * a reshape), then reconciles instanced ownership: any modelIndex the scene
+ * still holds templates for but that is missing from
+ * `presentInstancedModelIndices` gets torn down via
+ * `removeInstancedTemplatesForModel` so a genuinely removed/hidden model's
+ * repeated geometry does not linger on screen. See the
+ * `presentInstancedModelIndices` param doc for the full rationale.
+ */
+function reshapeSceneKeepingPresentInstanced(
+  scene: Scene,
+  presentInstancedModelIndices: ReadonlySet<number> | undefined,
+): void {
+  scene.clearFlatGeometry();
+  const present = presentInstancedModelIndices ?? DEFAULT_PRESENT_INSTANCED_MODEL_INDICES;
+  for (const modelIndex of scene.getInstancedModelIndices()) {
+    if (!present.has(modelIndex)) {
+      scene.removeInstancedTemplatesForModel(modelIndex);
+    }
+  }
+}
+
 export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
   const {
     rendererRef,
@@ -155,6 +203,7 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
     pendingInstancedShards,
     modelIdToIndex,
     modelIdToOffset,
+    presentInstancedModelIndices,
     clearPendingMeshColorUpdates,
     clearPendingColorUpdates,
     clearPendingMeshRemovals,
@@ -251,7 +300,11 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
       lastContentVersionRef.current = contentVersion;
       if (lastGeometryLengthRef.current > 0) {
         traceGeometrySync(`geometry content version bumped → ${contentVersion}; re-uploading buffers`);
-        scene.clear();
+        // Resetting lastGeometryLengthRef to 0 makes the classification below
+        // read this as `isNewFile` — that branch owns the actual scene
+        // reshape (and, #2073, the instanced-retention reconcile), so this
+        // block only resets tracking state and must NOT touch the scene
+        // itself (a second reshape here would be immediately redundant).
         processedMeshIdsRef.current.clear();
         lastGeometryLengthRef.current = 0;
         lastGeometryRef.current = null;
@@ -283,7 +336,7 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
     const isCleared = currentLength === 0;
 
     if (isCleared) {
-      scene.clear();
+      reshapeSceneKeepingPresentInstanced(scene, presentInstancedModelIndices);
       processedMeshIdsRef.current.clear();
       lastGeometryLengthRef.current = 0;
       lastGeometryRef.current = null;
@@ -293,7 +346,12 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
 
     if (isNewFile) {
       traceGeometrySync(`new file currentLength=${currentLength} lastLength=${lastLength} releaseAfterFinalize=${releaseGeometryAfterFinalize}`);
-      scene.clear();
+      // #2073: a genuine first load has no existing instanced templates, so
+      // this is a no-op reconcile; a content-version bump (in-place mutation)
+      // disguises itself as "new file" by resetting lastGeometryLengthRef to 0
+      // above — retention must still apply here, not just at the bump site,
+      // or this branch would immediately undo it with a blind clear().
+      reshapeSceneKeepingPresentInstanced(scene, presentInstancedModelIndices);
       scene.setEphemeralStreamingMode(releaseGeometryAfterFinalize);
       processedMeshIdsRef.current.clear();
       cameraFittedRef.current = false;
@@ -306,8 +364,11 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
     } else if (!isIncremental && currentLength !== lastLength) {
       if (currentLength < lastLength) {
         traceGeometrySync(`geometry rebuilt after shrink currentLength=${currentLength} lastLength=${lastLength}`);
-        // Length decreased (model hidden) — rebuild scene, keep camera
-        scene.clear();
+        // Length decreased (model hidden) — rebuild scene, keep camera.
+        // #2073: reconcile instanced ownership instead of a blind clear() so
+        // a model that is STILL present keeps its instanced geometry; only
+        // the model(s) missing from presentInstancedModelIndices lose theirs.
+        reshapeSceneKeepingPresentInstanced(scene, presentInstancedModelIndices);
         scene.setEphemeralStreamingMode(releaseGeometryAfterFinalize);
         processedMeshIdsRef.current.clear();
         lastGeometryLengthRef.current = 0;
@@ -315,7 +376,7 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
       } else {
         traceGeometrySync(`geometry rebuilt after replace currentLength=${currentLength} lastLength=${lastLength} releaseAfterFinalize=${releaseGeometryAfterFinalize}`);
         // New file while another was open — full reset
-        scene.clear();
+        reshapeSceneKeepingPresentInstanced(scene, presentInstancedModelIndices);
         scene.setEphemeralStreamingMode(releaseGeometryAfterFinalize);
         processedMeshIdsRef.current.clear();
         cameraFittedRef.current = false;
@@ -349,7 +410,7 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
 
     // Visibility toggle while NOT streaming — array rebuilt from scratch
     if (isIncremental && !isStreaming && !prevIsStreamingRef.current) {
-      scene.clear();
+      reshapeSceneKeepingPresentInstanced(scene, presentInstancedModelIndices);
       processedMeshIdsRef.current.clear();
       lastGeometryLengthRef.current = 0;
       lastGeometryRef.current = geometry;

--- a/packages/renderer/src/scene-clear-flat-geometry.test.ts
+++ b/packages/renderer/src/scene-clear-flat-geometry.test.ts
@@ -1,0 +1,161 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `Scene.clearFlatGeometry()` (#2073): resets flat/batched geometry state
+ * exactly like `clear()` used to, but WITHOUT touching GPU-instanced
+ * templates. `clear()` itself is refactored to call
+ * `destroyAllInstancedTemplates()` + `clearFlatGeometry()`, so `clear()`'s
+ * full-reset behaviour must be unchanged — that's the regression guard here.
+ *
+ * `useGeometryStreaming.ts` calls `clearFlatGeometry()` instead of `clear()`
+ * on any reshape where at least one model is still present, then reconciles
+ * instanced ownership with `removeInstancedTemplatesForModel` for models
+ * that are NOT — see `scene-instanced-model-scope.test.ts` for that API's
+ * own coverage. This file only pins `clearFlatGeometry()`'s own contract.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { Scene } from './scene.js';
+import type { Mesh } from './types.js';
+import type { DecodedInstancedShard } from '@ifc-lite/geometry';
+
+(globalThis as Record<string, unknown>).GPUBufferUsage = {
+  MAP_READ: 1, MAP_WRITE: 2, COPY_SRC: 4, COPY_DST: 8, INDEX: 16,
+  VERTEX: 32, UNIFORM: 64, STORAGE: 128, INDIRECT: 256, QUERY_RESOLVE: 512,
+};
+
+function fakeBuffer(): GPUBuffer & { destroyed: number } {
+  const buf = {
+    size: 0,
+    destroyed: 0,
+    destroy() { this.destroyed++; },
+  };
+  return buf as unknown as GPUBuffer & { destroyed: number };
+}
+
+function fakeMesh(expressId: number): Mesh & {
+  vertexBuffer: GPUBuffer & { destroyed: number };
+  indexBuffer: GPUBuffer & { destroyed: number };
+} {
+  return {
+    expressId,
+    vertexBuffer: fakeBuffer(),
+    indexBuffer: fakeBuffer(),
+    indexCount: 3,
+    transform: { m: new Float32Array(16) } as unknown as Mesh['transform'],
+    color: [0, 0, 0, 1],
+    hydrated: true,
+  } as Mesh & {
+    vertexBuffer: GPUBuffer & { destroyed: number };
+    indexBuffer: GPUBuffer & { destroyed: number };
+  };
+}
+
+function fakeDevice(): { device: GPUDevice; created: Array<GPUBuffer & { destroyed: number }> } {
+  const created: Array<GPUBuffer & { destroyed: number }> = [];
+  const device = {
+    limits: { maxBufferSize: 1 << 30, maxStorageBufferBindingSize: 1 << 30 },
+    createBuffer: (desc: { size: number }) => {
+      const backing = new ArrayBuffer(desc.size);
+      const buf = {
+        size: desc.size,
+        destroyed: 0,
+        getMappedRange: () => backing,
+        unmap() {},
+        destroy() { this.destroyed++; },
+      };
+      created.push(buf as unknown as GPUBuffer & { destroyed: number });
+      return buf;
+    },
+    queue: { writeBuffer: () => {} },
+  };
+  return { device: device as unknown as GPUDevice, created };
+}
+
+/** One template, one occurrence, entityId `eid`. */
+function singleOccShard(eid: number): DecodedInstancedShard {
+  const positions = new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]);
+  const normals = new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]);
+  const indices = new Uint32Array([0, 1, 2]);
+  return {
+    templates: [{ positions, normals, indices, origin: [0, 0, 0] }],
+    instances: [{
+      templateIndex: 0,
+      entityId: eid,
+      color: [1, 1, 1, 1],
+      transform: new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]),
+    }],
+  };
+}
+
+describe('Scene.clearFlatGeometry (#2073)', () => {
+  it('destroys flat mesh buffers and resets flat bookkeeping', () => {
+    const scene = new Scene();
+    const m = fakeMesh(1);
+    scene['meshes'] = [m];
+    scene['boundingBoxes'].set(1, { min: { x: 0, y: 0, z: 0 }, max: { x: 1, y: 1, z: 1 } });
+
+    scene.clearFlatGeometry();
+
+    assert.strictEqual(m.vertexBuffer.destroyed, 1);
+    assert.strictEqual(m.indexBuffer.destroyed, 1);
+    assert.strictEqual(scene.getMeshes().length, 0);
+    // Flat-only id: nothing keeps its box alive once the mesh is gone.
+    assert.strictEqual(scene['boundingBoxes'].has(1), false);
+  });
+
+  it('leaves instanced templates fully intact — buffers NOT destroyed, still queryable', () => {
+    const scene = new Scene();
+    const { device, created } = fakeDevice();
+    scene.addInstancedShard(device, singleOccShard(42), 3);
+    assert.strictEqual(scene.getInstancedTemplates().length, 1, 'sanity: template uploaded');
+    assert.deepStrictEqual(scene.getInstancedModelIndices(), [3]);
+
+    scene.clearFlatGeometry();
+
+    assert.strictEqual(scene.getInstancedTemplates().length, 1, 'instanced template survives clearFlatGeometry()');
+    assert.deepStrictEqual(scene.getInstancedModelIndices(), [3], 'owning model unchanged');
+    for (const buf of created) {
+      assert.strictEqual(buf.destroyed, 0, 'clearFlatGeometry() must not destroy any instanced GPU buffer');
+    }
+  });
+
+  it('keeps the bounding box of an instanced-only id, drops a flat-only id\'s box', () => {
+    const scene = new Scene();
+    const { device } = fakeDevice();
+    scene.addInstancedShard(device, singleOccShard(42), 3);
+    const instancedBoxBefore = scene['boundingBoxes'].get(42);
+    assert.ok(instancedBoxBefore, 'sanity: addInstancedShard folded a world AABB for id 42');
+
+    const flatMesh = fakeMesh(1);
+    scene['meshes'] = [flatMesh];
+    scene['boundingBoxes'].set(1, { min: { x: 0, y: 0, z: 0 }, max: { x: 1, y: 1, z: 1 } });
+
+    scene.clearFlatGeometry();
+
+    assert.strictEqual(scene['boundingBoxes'].has(1), false, 'flat-only id: box dropped with its mesh');
+    assert.deepStrictEqual(
+      scene['boundingBoxes'].get(42),
+      instancedBoxBefore,
+      'instanced-only id: box survives — raycast/measure must keep working for retained geometry',
+    );
+  });
+
+  it('clear() still destroys instanced templates too (regression guard on the clearFlatGeometry refactor)', () => {
+    const scene = new Scene();
+    const { device, created } = fakeDevice();
+    scene.addInstancedShard(device, singleOccShard(42), 3);
+    assert.strictEqual(scene.getInstancedTemplates().length, 1);
+
+    scene.clear();
+
+    assert.strictEqual(scene.getInstancedTemplates().length, 0, 'clear() remains a FULL reset');
+    assert.deepStrictEqual(scene.getInstancedModelIndices(), []);
+    for (const buf of created) {
+      assert.strictEqual(buf.destroyed, 1, 'clear() destroys every instanced GPU buffer exactly once');
+    }
+  });
+});

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -3754,23 +3754,14 @@ export class Scene {
     }
   }
 
-  clear(): void {
-    for (const mesh of this.meshes) destroyGpuResources(mesh);
-    for (const batch of this.batchedMeshes) destroyGpuResources(batch);
-    for (const tm of this.texturedMeshes) {
-      tm.vertexBuffer.destroy();
-      tm.indexBuffer.destroy();
-      tm.uniformBuffer.destroy();
-      this.releaseTexturedMeshTexture(tm);
-    }
-    this.texturedMeshes = [];
-    // Belt-and-braces: refcounting above should have emptied the registry;
-    // destroy any straggler so clear() can never leak a shared GPU texture.
-    for (const entry of this.sharedTextures.values()) entry.texture.destroy();
-    this.sharedTextures.clear();
-    // GPU-instancing templates own their vertex/index/instance buffers.
-    // (Freed slots are holes whose buffers are already destroyed — skip them so
-    // a per-model removal followed by clear() can't double-destroy.)
+  /**
+   * Destroy every GPU-instanced template's buffers and reset all instanced
+   * bookkeeping, regardless of owning model. Shared by `clear()` (full reset)
+   * — `clearFlatGeometry()` deliberately does NOT call this, so a reshape
+   * that still has models present can retain their instanced geometry
+   * (#2073).
+   */
+  private destroyAllInstancedTemplates(): void {
     for (const it of this.instancedTemplates) {
       if (!it) continue;
       it.vertexBuffer.destroy();
@@ -3789,6 +3780,48 @@ export class Scene {
     this.lastInstancedVisibilityVersion = -1;
     this.instancedVisibilityDirty = false;
     this.instancedDevice = undefined;
+  }
+
+  clear(): void {
+    // GPU-instancing templates own their vertex/index/instance buffers.
+    // (Freed slots are holes whose buffers are already destroyed — skip them so
+    // a per-model removal followed by clear() can't double-destroy.)
+    this.destroyAllInstancedTemplates();
+    this.clearFlatGeometry();
+  }
+
+  /**
+   * Clear flat/batched geometry (meshes, batches, buckets, textured meshes,
+   * colour overlays, streaming state, residency bookkeeping) WITHOUT
+   * touching GPU-instanced templates (#2073). A reshape that still has at
+   * least one model present should call this instead of `clear()`, then
+   * reconcile instanced ownership with `removeInstancedTemplatesForModel`
+   * for any model that did NOT survive — that way a still-loaded model's
+   * repeated geometry (windows, doors, bolts, ...) stays resident across a
+   * visibility toggle / in-place content mutation / federated model add
+   * instead of silently vanishing (nothing re-uploads instanced shard bytes
+   * after their one-time drain).
+   *
+   * Bounding boxes are only dropped for ids with NO surviving instanced
+   * occurrence — an instanced-only id's box must outlive this call so
+   * raycast / measure / section keep working for the geometry that was
+   * just retained; a flat-only id's box is stale the moment its mesh data
+   * is gone, so it is dropped like everything else here.
+   */
+  clearFlatGeometry(): void {
+    for (const mesh of this.meshes) destroyGpuResources(mesh);
+    for (const batch of this.batchedMeshes) destroyGpuResources(batch);
+    for (const tm of this.texturedMeshes) {
+      tm.vertexBuffer.destroy();
+      tm.indexBuffer.destroy();
+      tm.uniformBuffer.destroy();
+      this.releaseTexturedMeshTexture(tm);
+    }
+    this.texturedMeshes = [];
+    // Belt-and-braces: refcounting above should have emptied the registry;
+    // destroy any straggler so clear() can never leak a shared GPU texture.
+    for (const entry of this.sharedTextures.values()) entry.texture.destroy();
+    this.sharedTextures.clear();
     // Clear partial batch cache (destroys buffers + drops all cache maps)
     this.dropAllPartialCaches();
     this.colorOverrideGeneration++;
@@ -3796,14 +3829,21 @@ export class Scene {
     this.streamingFragments = [];
     this.destroyOverrideBatches();
     this.colorOverrides = null;
-    // Reset the shared frame origin so the next model picks its own.
+    // Reset the shared frame origin so the next model picks its own. Retained
+    // instanced templates are unaffected — their per-occurrence transforms are
+    // already baked to absolute world coordinates at upload time, not relative
+    // to this origin.
     this.sharedFrameOrigin = null;
     this.meshes = [];
     this.batchedMeshes = [];
     this.buckets.clear();
     this.meshDataBucket = new Map();
     this.meshDataMap.clear();
-    this.boundingBoxes.clear();
+    for (const eid of [...this.boundingBoxes.keys()]) {
+      if (!this.instancedEntityMap.has(eid)) {
+        this.boundingBoxes.delete(eid);
+      }
+    }
     this.activeBucketKey.clear();
     this.lastDrawnFrame.clear();
     this.residencyRestoreQueue.clear();


### PR DESCRIPTION
Closes #2073. Step 3, and the last piece of that issue.

## Why this was blocked, and why it no longer is

The design comment on the issue rejected both obvious patches — keeping templates across the clear, or retaining bytes and re-uploading — for one reason:

> Either one makes *hiding* the primary model in a two-model federation leave its instanced geometry on screen — because neither the scene nor the hook can tell which templates belong to which model.

That objection is now answered. **#2172** added per-model ownership (`modelIndex`, `removeInstancedTemplatesForModel`) and **#2239** made its bounding-box teardown correct. This step is what those two were for.

## The change

`clear()` is split into `destroyAllInstancedTemplates()` (private) and a new public `clearFlatGeometry()`. **`clear()` calls both, so its behaviour is unchanged** — nothing that relied on the old semantics moves.

Reshapes now call `clearFlatGeometry()` and then tear down exactly the model indices no longer present. `clearFlatGeometry()` also stops blindly emptying `boundingBoxes`: it drops a box only for an id with no surviving instanced occurrence, so retained instanced-only geometry stays pickable and measurable instead of becoming invisible to raycast.

## Which retention shape, and why — with #2183 in mind

Chose **retaining the decoded GPU templates**, not the raw bytes.

Retaining templates costs approximately nothing: they are the *same* buffers that were already resident, and the bug was freeing them. Retaining shard bytes instead would hold a permanent JS-heap copy for the whole session **on top of** the GPU-resident one — strictly double the memory — and pay decode plus upload again on every reshape, which visibility toggles fire often.

With #2183 ("RAM's high with model 350MB") live, adding a permanent heap duplicate is the wrong direction. This is the cheaper and the faster option, and it builds directly on machinery that already shipped.

## One subtlety worth recording

The content-version-bump path **disguises itself as `isNewFile`**, so it needed the same treatment or it would have silently undone the retention one branch later. That is the kind of thing that would have shipped looking correct and failed on a specific user action.

The single remaining `scene.clear()` — the `!geometry` "session fully unloaded" branch — is deliberately untouched, since nothing should survive there.

## Verified in both directions, which is the whole point

A test proving geometry survives a reshape would happily pass the exact bug the original design comment warned about. So both are asserted:

- **Retention**: reverting the five call sites fails with `'clearFlatGeometry' vs 'clear'`, and `[0] vs []` for a model that never left.
- **Hiding** (`does NOT retain a hidden/removed model's instanced geometry — the case the naive fix breaks`): a hidden model is torn down via `removeInstancedTemplatesForModel:1` while a still-present model is untouched.
- **Scene level**: making `clearFlatGeometry()` destroy templates again fails 2 of 4 tests in the new `scene-clear-flat-geometry.test.ts`, including the bounding-box half.

I re-ran each of these by hand rather than relying on the report.

- `packages/renderer`: **453 passing** across 103 suites. `apps/viewer`: **3040 passing / 2 skipped / 0 failing** across 266 files. `tsc --noEmit` clean for both.
- Changeset: patch bump for `@ifc-lite/renderer`.

## Note on #2255

That PR (federated forwarding, still open) changes `pendingInstancedShards` to carry a `modelId` per shard. This branch is based on current `main` where it is still `ArrayBuffer[]`. The two are complementary — this one retains what is uploaded, that one gets federated shards uploaded in the first place — but whichever lands second will need a trivial rebase over the other's drain-site shape.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `Scene.clearFlatGeometry()` to remove flat geometry while preserving reusable instanced model templates.
  * Improved viewer reshaping and streaming so visible instanced models remain available during updates.
  * Preserved relevant bounding boxes when instanced occurrences remain.

* **Bug Fixes**
  * Removed stale geometry and bounding boxes when models are hidden or removed.
  * Full scene clearing continues to remove all geometry and instanced resources.

* **Tests**
  * Added coverage for flat-geometry clearing and instanced-template retention across viewer updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->