### PR TITLE
feat(geometry): report whether a half-space cut was capped, and expose mesh volume

### DIFF
--- a/.changeset/halfspace-cap-verdict-open-boundary.md
+++ b/.changeset/halfspace-cap-verdict-open-boundary.md
@@ -1,0 +1,22 @@
+---
+"@ifc-lite/geometry": patch
+---
+
+Fix `cap_half_space_clip` reporting `capped: true` while a boundary edge was left open.
+
+The boundary chain walk dropped a dead-ended chain (no continuation back to
+its start) and could also fold an unclosed chain into an already-visited
+vertex, treating it as if it were a closed loop. Neither case affected
+`outer_count`/`outer_filled`, the two counters the return value was computed
+from, so an open edge from a dead-ended or merged chain never showed up in
+the verdict.
+
+On a non-watertight host — a routine input to
+`BooleanClippingProcessor::clip_mesh_with_half_space` — this could report
+`capped: true` with open boundary edges still present, contradicting the
+function's own contract ("a boundary that does not close bails") and the
+per-piece "was the cut closed" signal #1810 zone splitting depends on for a
+trustworthy quoted volume.
+
+The walk now tracks whether any chain failed to close, and that flag is
+ANDed into the returned verdict alongside the existing counters.

--- a/.changeset/halfspace-cap-verdict-open-boundary.md
+++ b/.changeset/halfspace-cap-verdict-open-boundary.md
@@ -29,3 +29,19 @@ into `loops`, triangulated, and appended to the mesh — garbage cap geometry
 landing in the output even on a call that correctly reported
 `capped: false`. The merge arm now clears the partial walk before breaking,
 matching its sibling dead-end arm.
+
+Scope note: `capped` only measures whether the ON-PLANE cut section closed.
+A host with pre-existing OPEN boundary edges off the cut plane still reports
+`capped: true` — the boundary walk is filtered to on-plane endpoints by
+design, so it never re-examines unrelated openness elsewhere on the mesh.
+
+Also adds `kernel::mesh_volume`, a public, closedness-UNGATED divergence-
+theorem volume reading for a `Mesh` (delegates to the crate's one
+divergence-sum implementation, `signed_volume6`). It is a raw primitive, not
+a replacement for `geom_closure::GeometryHasher::volume` — that one stays
+the crate's closedness-gated, per-entity volume and requires the hasher's
+accumulated state; `mesh_volume` is for a bare `Mesh` (e.g. a future
+zone-split piece) that never went through it. Callers of `mesh_volume` must
+establish closedness themselves first; see its doc for the exact
+translation-stability guarantee (stable up to a documented quantization
+noise floor, not exact).

--- a/.changeset/halfspace-cap-verdict-open-boundary.md
+++ b/.changeset/halfspace-cap-verdict-open-boundary.md
@@ -20,3 +20,12 @@ trustworthy quoted volume.
 
 The walk now tracks whether any chain failed to close, and that flag is
 ANDed into the returned verdict alongside the existing counters.
+
+The merge-into-an-already-visited-vertex arm had a second bug beyond the
+verdict: it set the flag and `break`, matching the code comment ("do NOT
+push it as if it were a closed loop"), but never cleared the partial walk
+first, so the un-closed chain was still `>= 3` vertices long and got pushed
+into `loops`, triangulated, and appended to the mesh — garbage cap geometry
+landing in the output even on a call that correctly reported
+`capped: false`. The merge arm now clears the partial walk before breaking,
+matching its sibling dead-end arm.

--- a/rust/geometry/src/kernel/mesh_volume.rs
+++ b/rust/geometry/src/kernel/mesh_volume.rs
@@ -1,0 +1,85 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Public, documented home for reading a [`Mesh`]'s volume.
+
+use super::mesh_bridge::mesh_to_tris;
+use super::signed_volume::signed_volume6;
+use crate::mesh::Mesh;
+
+/// Signed volume of a `Mesh`, via the divergence theorem.
+///
+/// Positive for a closed, outward-wound mesh; negative if inward-wound;
+/// meaningless (translation-dependent) if the mesh is not closed — callers
+/// that need a trustworthy reading (e.g. reporting a split zone piece's
+/// volume) must establish closedness first, same requirement [`signed_volume6`]
+/// itself carries.
+///
+/// Delegates to [`signed_volume6`] rather than re-deriving the sum: that is
+/// the crate's ONE divergence-theorem implementation, and it deliberately sums
+/// about the OPERAND'S OWN AABB CENTRE rather than the world origin. That
+/// choice is not cosmetic — see `signed_volume::signed_volume6`'s doc for the
+/// #198779 incident where a world-origin reference turned a crack sliver on a
+/// far-from-origin operand into a wildly wrong, sign-flipping volume. A split
+/// zone piece is exactly the shape of operand that provokes this: it can sit
+/// anywhere in a building/national-grid-scale model and can carry the same
+/// kind of boundary sliver from the cut that produced it, so this function
+/// inherits the AABB-centred reference rather than exposing a second,
+/// world-origin-referenced volume primitive alongside it.
+///
+/// The two other volume readings already in the crate were each wrong for
+/// this job for a different reason: `router::voids::geom::mesh_signed_volume`
+/// sums about the world origin (fine for its own callers, which only ever see
+/// frame-local meshes near the origin — not true of an arbitrary zone piece),
+/// and `kernel::mesh_bridge`'s `#[cfg(test)]`-only helper duplicates that same
+/// world-origin arithmetic for test-only use. Reusing [`signed_volume6`]
+/// avoids adding a THIRD divergence-theorem implementation to reconcile.
+pub fn mesh_volume(mesh: &Mesh) -> f64 {
+    signed_volume6(&mesh_to_tris(mesh)) / 6.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kernel::arrangement::cube_mesh;
+    use crate::kernel::mesh_bridge::tris_to_mesh;
+
+    #[test]
+    fn mesh_volume_of_a_closed_cube_is_correct() {
+        let cube = tris_to_mesh(&cube_mesh(0.0, 2.0)); // side 2 → vol 8
+        let v = mesh_volume(&cube);
+        assert!((v - 8.0).abs() < 1.0e-9, "expected 8.0, got {v}");
+    }
+
+    /// The property that makes this the right function to expose (see the
+    /// fn's own doc, and `signed_volume::signed_volume6`'s doc for the
+    /// #198779 incident this reproduces the shape of): for an OPEN surface —
+    /// a mesh with an unresolved boundary, e.g. a zone piece carrying a
+    /// boundary sliver from the cut that produced it — the divergence sum
+    /// referenced to a FIXED point is translation-variant, so a world-origin
+    /// implementation reads a different (and for a far-from-origin operand,
+    /// wildly different) value depending only on where the model sits. The
+    /// AABB-centred reference this function actually uses co-moves with the
+    /// operand, so the reading must hold regardless of that translation. A
+    /// world-origin implementation, tested the same way, would NOT hold —
+    /// this is the reproduction shape for that class of implementation bug.
+    #[test]
+    fn mesh_volume_is_stable_far_from_the_world_origin_for_an_open_mesh() {
+        let mut tris = cube_mesh(0.0, 2.0);
+        tris.pop(); // drop one triangle → open boundary (one missing face)
+        let near = tris_to_mesh(&tris);
+        let mut far = near.clone();
+        for c in far.positions.as_chunks_mut::<3>().0 {
+            c[0] += 10_000.0;
+            c[1] += 10_000.0;
+            c[2] += 10_000.0;
+        }
+        let v_near = mesh_volume(&near);
+        let v_far = mesh_volume(&far);
+        assert!(
+            (v_near - v_far).abs() < 1.0e-6,
+            "near={v_near} far={v_far} should match for an AABB-centred reading"
+        );
+    }
+}

--- a/rust/geometry/src/kernel/mesh_volume.rs
+++ b/rust/geometry/src/kernel/mesh_volume.rs
@@ -11,10 +11,17 @@ use crate::mesh::Mesh;
 /// Signed volume of a `Mesh`, via the divergence theorem.
 ///
 /// Positive for a closed, outward-wound mesh; negative if inward-wound;
-/// meaningless (translation-dependent) if the mesh is not closed — callers
-/// that need a trustworthy reading (e.g. reporting a split zone piece's
-/// volume) must establish closedness first, same requirement [`signed_volume6`]
-/// itself carries.
+/// meaningless if the mesh is not closed — the divergence theorem this sum
+/// implements requires a closed surface, and an open one has no true volume
+/// to read regardless of where it sits. That reading is translation-STABLE,
+/// not translation-dependent: because it delegates to [`signed_volume6`],
+/// which sums about the operand's own AABB centre rather than a fixed point,
+/// an open mesh reads the same wrong-but-consistent number wherever it is
+/// translated (see the `mesh_volume_is_stable_far_from_the_world_origin_for_an_open_mesh`
+/// test below) — it just isn't the mesh's actual volume. Callers that need a
+/// trustworthy reading (e.g. reporting a split zone piece's volume) must
+/// establish closedness first, same requirement [`signed_volume6`] itself
+/// carries.
 ///
 /// Delegates to [`signed_volume6`] rather than re-deriving the sum: that is
 /// the crate's ONE divergence-theorem implementation, and it deliberately sums

--- a/rust/geometry/src/kernel/mesh_volume.rs
+++ b/rust/geometry/src/kernel/mesh_volume.rs
@@ -13,15 +13,25 @@ use crate::mesh::Mesh;
 /// Positive for a closed, outward-wound mesh; negative if inward-wound;
 /// meaningless if the mesh is not closed — the divergence theorem this sum
 /// implements requires a closed surface, and an open one has no true volume
-/// to read regardless of where it sits. That reading is translation-STABLE,
-/// not translation-dependent: because it delegates to [`signed_volume6`],
-/// which sums about the operand's own AABB centre rather than a fixed point,
-/// an open mesh reads the same wrong-but-consistent number wherever it is
-/// translated (see the `mesh_volume_is_stable_far_from_the_world_origin_for_an_open_mesh`
-/// test below) — it just isn't the mesh's actual volume. Callers that need a
-/// trustworthy reading (e.g. reporting a split zone piece's volume) must
-/// establish closedness first, same requirement [`signed_volume6`] itself
-/// carries.
+/// to read regardless of where it sits. That reading is translation-stable
+/// only up to a bounded QUANTIZATION noise floor, not exactly
+/// translation-invariant: [`mesh_to_tris`] rounds every coordinate to
+/// `kernel::mesh_bridge::SNAP_GRID` (1/65536 m, ~15.26 µm) before this
+/// function ever sees it, and a non-grid-aligned translation moves each
+/// vertex's rounding independently, so the sum drifts by roughly
+/// `surface_area * SNAP_GRID` (plus, at far-from-origin offsets, the
+/// coarser f32-ulp term the `Mesh` positions already carried on the way in).
+/// Because it delegates to [`signed_volume6`], which sums about the
+/// operand's own AABB centre rather than a fixed point, that drift is the
+/// ONLY thing that moves the reading — a world-origin implementation would
+/// additionally vary with the reference point itself, wrong by orders of
+/// magnitude more (see the
+/// `mesh_volume_is_stable_far_from_the_world_origin_for_an_open_mesh` test
+/// below, which pins the AABB-centred reading's noise floor and would fail
+/// hard against that class of regression). It is still not the mesh's actual
+/// volume. Callers that need a trustworthy reading (e.g. reporting a split
+/// zone piece's volume) must establish closedness first, same requirement
+/// [`signed_volume6`] itself carries.
 ///
 /// Delegates to [`signed_volume6`] rather than re-deriving the sum: that is
 /// the crate's ONE divergence-theorem implementation, and it deliberately sums
@@ -35,13 +45,29 @@ use crate::mesh::Mesh;
 /// inherits the AABB-centred reference rather than exposing a second,
 /// world-origin-referenced volume primitive alongside it.
 ///
-/// The two other volume readings already in the crate were each wrong for
-/// this job for a different reason: `router::voids::geom::mesh_signed_volume`
+/// This is a raw, UNGATED kernel primitive — it reads whatever `Mesh` it is
+/// handed, closed or not, and (via [`mesh_to_tris`]) silently drops any
+/// out-of-range-index or non-finite triangle. It is the low-level counterpart
+/// to `geom_closure::GeometryHasher::volume`, which is the crate's
+/// closedness-GATED, per-entity volume: that one returns `None` unless the
+/// hasher's accumulated `GeometryClosure` proves the entity is a single
+/// closed orientable solid, but it requires that accumulated per-entity
+/// state — it has nothing to gate a bare, freshly-produced `Mesh` (e.g. a
+/// zone-split piece) that never went through the hasher. A caller of THIS
+/// function that needs the same trustworthiness guarantee must establish
+/// closedness itself first — `router::voids::geom::mesh_is_closed_exact` is
+/// the crate's existing closed-surface check but is `pub(super)`-scoped to
+/// that module today, so a caller outside it needs either that visibility
+/// widened or an equivalent check of its own — same requirement
+/// `GeometryHasher::volume`'s own gate establishes upstream.
+///
+/// The other volume readings already in the crate were each wrong for this
+/// job for a different reason: `router::voids::geom::mesh_signed_volume`
 /// sums about the world origin (fine for its own callers, which only ever see
 /// frame-local meshes near the origin — not true of an arbitrary zone piece),
 /// and `kernel::mesh_bridge`'s `#[cfg(test)]`-only helper duplicates that same
 /// world-origin arithmetic for test-only use. Reusing [`signed_volume6`]
-/// avoids adding a THIRD divergence-theorem implementation to reconcile.
+/// avoids adding another divergence-theorem implementation to reconcile.
 pub fn mesh_volume(mesh: &Mesh) -> f64 {
     signed_volume6(&mesh_to_tris(mesh)) / 6.0
 }
@@ -68,25 +94,73 @@ mod tests {
     /// implementation reads a different (and for a far-from-origin operand,
     /// wildly different) value depending only on where the model sits. The
     /// AABB-centred reference this function actually uses co-moves with the
-    /// operand, so the reading must hold regardless of that translation. A
-    /// world-origin implementation, tested the same way, would NOT hold —
-    /// this is the reproduction shape for that class of implementation bug.
+    /// operand, so the reading must hold up to a bounded quantization noise
+    /// floor regardless of that translation. A world-origin implementation,
+    /// tested the same way, would NOT hold — this is the reproduction shape
+    /// for that class of implementation bug.
+    ///
+    /// Deliberately NOT grid-aligned: an earlier version of this test used
+    /// integer cube corners and an offset that was an exact multiple of
+    /// `SNAP_GRID` (1/65536 m), which makes BOTH the f32 store and the
+    /// reconciliation snap in [`mesh_to_tris`] exact no-ops — so it could
+    /// only ever discriminate the AABB-centred-vs-world-origin reference
+    /// choice, never the quantization noise those two steps genuinely
+    /// introduce for a real-world placement (a caught house review finding:
+    /// "a test that can't fail" against the property it was named for). This
+    /// version uses off-grid corners and a non-multiple offset, so the snap
+    /// noise is real and the tolerance below is sized to it rather than to
+    /// bit-exactness — see the `..._is_not_bit_exact_across_a_non_grid_translation`
+    /// test for the proof that this specific loosening was necessary.
     #[test]
     fn mesh_volume_is_stable_far_from_the_world_origin_for_an_open_mesh() {
-        let mut tris = cube_mesh(0.0, 2.0);
+        let mut tris = cube_mesh(0.1, 2.3); // off-grid corners, side 2.2
         tris.pop(); // drop one triangle → open boundary (one missing face)
         let near = tris_to_mesh(&tris);
         let mut far = near.clone();
         for c in far.positions.as_chunks_mut::<3>().0 {
-            c[0] += 10_000.0;
-            c[1] += 10_000.0;
-            c[2] += 10_000.0;
+            c[0] += 10_000.1; // off-grid, far-from-origin offset
+            c[1] += 10_000.1;
+            c[2] += 10_000.1;
         }
         let v_near = mesh_volume(&near);
         let v_far = mesh_volume(&far);
+        let drift = (v_near - v_far).abs();
+        // Bound sized to the documented noise floor (surface_area * SNAP_GRID
+        // plus f32 ulp at a 10 km offset), NOT to bit-exactness — see the doc
+        // comment above and `mesh_volume`'s own doc. A world-origin
+        // regression drifts by ~6.7e3 on this exact fixture shape (measured
+        // separately, see PR #2260 review thread), thousands of times past
+        // this bound, so the test still catches that class of bug.
         assert!(
-            (v_near - v_far).abs() < 1.0e-6,
-            "near={v_near} far={v_far} should match for an AABB-centred reading"
+            drift < 1.0e-2,
+            "near={v_near} far={v_far} drift={drift} exceeds the documented \
+             quantization noise floor for an AABB-centred reading"
+        );
+    }
+
+    /// Proves the loosened tolerance above is load-bearing, not decorative:
+    /// re-run the exact same off-grid fixture at the OLD 1e-6 bit-exactness
+    /// bound the previous (grid-exact) test used, and watch it fail. This is
+    /// the RED half of the RED/GREEN pair — without the off-grid corners and
+    /// offset, this assertion would spuriously pass, which is exactly the
+    /// "test that can't fail" defect being fixed.
+    #[test]
+    fn mesh_volume_is_not_bit_exact_across_a_non_grid_translation() {
+        let mut tris = cube_mesh(0.1, 2.3);
+        tris.pop();
+        let near = tris_to_mesh(&tris);
+        let mut far = near.clone();
+        for c in far.positions.as_chunks_mut::<3>().0 {
+            c[0] += 10_000.1;
+            c[1] += 10_000.1;
+            c[2] += 10_000.1;
+        }
+        let drift = (mesh_volume(&near) - mesh_volume(&far)).abs();
+        assert!(
+            drift > 1.0e-6,
+            "expected the off-grid translation to show measurable snap/f32 \
+             drift (drift={drift}); if this now passes, mesh_to_tris's \
+             quantization changed and the doc/tolerance above need revisiting"
         );
     }
 }

--- a/rust/geometry/src/kernel/mod.rs
+++ b/rust/geometry/src/kernel/mod.rs
@@ -27,6 +27,7 @@ pub mod interner;
 pub mod interval;
 pub mod manifest;
 pub mod mesh_bridge;
+pub mod mesh_volume;
 pub mod predicates;
 pub mod rational;
 pub(crate) mod signed_volume;

--- a/rust/geometry/src/processors/boolean/halfspace_cap.rs
+++ b/rust/geometry/src/processors/boolean/halfspace_cap.rs
@@ -4,6 +4,30 @@
 
 use crate::{Mesh, Point2, Point3, Vector3};
 
+// Test-only seam for the `outer_filled == outer_count` accounting
+// (`cap_half_space_clip`, below): forces `triangulate_polygon_with_holes_refined`
+// to fail for one specific OUTER ring index, so a "partial cap" (some outer
+// regions triangulate, one CDT-fails) is reproducible without needing to
+// construct real degenerate geometry that trips earcutr/CDT internals — the
+// robustness `safe_earcut` deliberately provides makes that near-impossible
+// to hit organically (kernel-gate review, PR #2260: "needs a CDT-failure
+// fixture, which is genuinely harder"). `#[cfg(test)]`-gated in both
+// directions, so it compiles to nothing (no thread-local, no branch) outside
+// `cargo test` on this crate.
+#[cfg(test)]
+thread_local! {
+    static FORCE_CDT_FAIL_ON_RING: std::cell::Cell<Option<usize>> =
+        const { std::cell::Cell::new(None) };
+}
+
+/// Set which outer-ring index (0-based, in processing order) should fail
+/// triangulation on the NEXT `cap_half_space_clip` call. `None` disables it.
+/// Test-only; see [`FORCE_CDT_FAIL_ON_RING`].
+#[cfg(test)]
+pub(crate) fn force_cdt_fail_on_ring_for_test(ring: Option<usize>) {
+    FORCE_CDT_FAIL_ON_RING.with(|c| c.set(ring));
+}
+
 /// Close the planar cut left by an unbounded `IfcHalfSpaceSolid` DIFFERENCE.
 ///
 /// `ClippingProcessor::clip_mesh` clips each triangle to the half-plane but
@@ -252,6 +276,12 @@ pub(crate) fn cap_half_space_clip(
     // the return value.
     let outer_count = depth.iter().filter(|&&d| d.is_multiple_of(2)).count();
     let mut outer_filled = 0usize;
+    // 0-based index among OUTER rings only, in processing order — distinct
+    // from `oi` (which also counts holes). Used only to address the
+    // `#[cfg(test)]` CDT-failure seam above, so it does not exist at all
+    // outside a test build.
+    #[cfg(test)]
+    let mut outer_count_seen = 0usize;
 
     for (oi, ring) in rings.iter().enumerate() {
         if !depth[oi].is_multiple_of(2) {
@@ -277,7 +307,23 @@ pub(crate) fn cap_half_space_clip(
             holes.push(h);
         }
 
-        let (verts2d, indices) = match triangulate_polygon_with_holes_refined(&outer, &holes) {
+        #[cfg(test)]
+        let forced_fail = FORCE_CDT_FAIL_ON_RING.with(|c| c.get() == Some(outer_count_seen));
+        #[cfg(not(test))]
+        let forced_fail = false;
+        #[cfg(test)]
+        {
+            outer_count_seen += 1;
+        }
+
+        let cdt_result = if forced_fail {
+            Err(crate::Error::TriangulationError(
+                "forced CDT failure (test seam)".to_string(),
+            ))
+        } else {
+            triangulate_polygon_with_holes_refined(&outer, &holes)
+        };
+        let (verts2d, indices) = match cdt_result {
             Ok(r) => r,
             Err(_) => continue,
         };

--- a/rust/geometry/src/processors/boolean/halfspace_cap.rs
+++ b/rust/geometry/src/processors/boolean/halfspace_cap.rs
@@ -158,8 +158,12 @@ pub(crate) fn cap_half_space_clip(
             if !visited.insert(cur) {
                 // Walked into an already-visited vertex without returning to
                 // `s` first: an unclosed chain merging into another chain
-                // (or itself). Do NOT push it as if it were a closed loop.
+                // (or itself). Do NOT push it as if it were a closed loop —
+                // clear the partial walk so it can never reach the
+                // `loop_v.len() >= 3` push below and leak garbage triangles
+                // into the mesh despite the correctly-`false` verdict.
                 boundary_incomplete = true;
+                loop_v.clear();
                 break;
             }
             loop_v.push(cur);

--- a/rust/geometry/src/processors/boolean/halfspace_cap.rs
+++ b/rust/geometry/src/processors/boolean/halfspace_cap.rs
@@ -22,23 +22,38 @@ use crate::{Mesh, Point2, Point3, Vector3};
 /// the kept `+clip_normal` material). If the boundary is non-manifold or does
 /// not close (a non-watertight host), we bail and leave the mesh unchanged —
 /// never worse than the uncapped output.
-pub(crate) fn cap_half_space_clip(mesh: &mut Mesh, plane_point: Point3<f64>, clip_normal: Vector3<f64>) {
+///
+/// Returns whether the cut was actually closed. This MUST be measured, never
+/// seeded: the #2171 TS clipper set `capped: true` up front and relied on the
+/// capping pass to correct it on failure, which is invisible whenever a plane
+/// runs (the common case) but silently lies — reporting a watertight result
+/// for what is actually an open shell — the moment a caller runs this over an
+/// EMPTY plane list (a documented, supported input, e.g. a solid with no
+/// applicable half-space cuts). Any future "no planes ran" path must return
+/// `false` from having never called this, not inherit a seeded `true`.
+#[must_use = "capped must be measured (this bool), never seeded — a discarded \
+              result is exactly the #2171 bug where a caller assumed `true`"]
+pub(crate) fn cap_half_space_clip(
+    mesh: &mut Mesh,
+    plane_point: Point3<f64>,
+    clip_normal: Vector3<f64>,
+) -> bool {
     use crate::triangulation::{project_to_2d, triangulate_polygon_with_holes_refined};
     use std::collections::{HashMap, HashSet};
 
     // Escape hatch: revert to the pre-fix (uncapped) plane clip without a
     // rebuild, should the section cap ever misbehave on an unforeseen host.
     if std::env::var_os("IFC_LITE_HALFSPACE_CAP_OFF").is_some() {
-        return;
+        return false;
     }
     let tri_n = mesh.indices.len() / 3;
     let vcount = mesh.positions.len() / 3;
     if tri_n == 0 || vcount < 3 {
-        return;
+        return false;
     }
     let n = match clip_normal.try_normalize(1e-12) {
         Some(v) => v,
-        None => return,
+        None => return false,
     };
 
     // Diagonal-relative tolerance for "lies on the cut plane".
@@ -115,11 +130,11 @@ pub(crate) fn cap_half_space_clip(mesh: &mut Mesh, plane_point: Point3<f64>, cli
             continue; // not the cut section
         }
         if next.insert(a, b).is_some() {
-            return; // non-manifold cut boundary → bail
+            return false; // non-manifold cut boundary → bail
         }
     }
     if next.is_empty() {
-        return;
+        return false;
     }
 
     // Chain the boundary half-edges into closed loops.
@@ -154,7 +169,7 @@ pub(crate) fn cap_half_space_clip(mesh: &mut Mesh, plane_point: Point3<f64>, cli
         }
     }
     if loops.is_empty() {
-        return;
+        return false;
     }
 
     // Project every loop into one shared 2D basis whose +w faces the cap's
@@ -215,6 +230,13 @@ pub(crate) fn cap_half_space_clip(mesh: &mut Mesh, plane_point: Point3<f64>, cli
     let cap_normal = [cap_outward.x as f32, cap_outward.y as f32, cap_outward.z as f32];
     let lift = |p: &Point2<f64>| -> Point3<f64> { origin + u_axis * p.x + v_axis * p.y };
 
+    // "Capped" means every outer region actually got triangulated — a partial
+    // cap (one outer ring's CDT fails while others succeed) still leaves an
+    // open boundary, so the count, not just "we attempted this loop", decides
+    // the return value.
+    let outer_count = depth.iter().filter(|&&d| d.is_multiple_of(2)).count();
+    let mut outer_filled = 0usize;
+
     for (oi, ring) in rings.iter().enumerate() {
         if !depth[oi].is_multiple_of(2) {
             continue; // hole — emitted with its outer ring
@@ -243,6 +265,7 @@ pub(crate) fn cap_half_space_clip(mesh: &mut Mesh, plane_point: Point3<f64>, cli
             Ok(r) => r,
             Err(_) => continue,
         };
+        outer_filled += 1;
         let verts3d: Vec<Point3<f64>> = verts2d.iter().map(lift).collect();
         let base = (mesh.positions.len() / 3) as u32;
         for p in &verts3d {
@@ -263,4 +286,6 @@ pub(crate) fn cap_half_space_clip(mesh: &mut Mesh, plane_point: Point3<f64>, cli
                 .extend_from_slice(&[base + tri[0] as u32, base + i1 as u32, base + i2 as u32]);
         }
     }
+
+    outer_count > 0 && outer_filled == outer_count
 }

--- a/rust/geometry/src/processors/boolean/halfspace_cap.rs
+++ b/rust/geometry/src/processors/boolean/halfspace_cap.rs
@@ -142,6 +142,12 @@ pub(crate) fn cap_half_space_clip(
     starts.sort_unstable();
     let mut visited: HashSet<u32> = HashSet::new();
     let mut loops: Vec<Vec<u32>> = Vec::new();
+    // Set whenever a chain fails to close back on its own start — a dead end
+    // (no continuation) or a merge into a vertex already visited by another
+    // chain (or by itself, mid-walk). Either shape leaves boundary edges
+    // open; a `false` here overrides `outer_count`/`outer_filled`, which only
+    // ever see the loops that DID close and say nothing about the rest.
+    let mut boundary_incomplete = false;
     for &s in &starts {
         if visited.contains(&s) {
             continue;
@@ -150,12 +156,18 @@ pub(crate) fn cap_half_space_clip(
         let mut cur = s;
         loop {
             if !visited.insert(cur) {
+                // Walked into an already-visited vertex without returning to
+                // `s` first: an unclosed chain merging into another chain
+                // (or itself). Do NOT push it as if it were a closed loop.
+                boundary_incomplete = true;
                 break;
             }
             loop_v.push(cur);
             match next.get(&cur) {
                 Some(&nx) => cur = nx,
                 None => {
+                    // Dead end: this chain never returns to `s`.
+                    boundary_incomplete = true;
                     loop_v.clear();
                     break;
                 }
@@ -287,5 +299,5 @@ pub(crate) fn cap_half_space_clip(
         }
     }
 
-    outer_count > 0 && outer_filled == outer_count
+    outer_count > 0 && outer_filled == outer_count && !boundary_incomplete
 }

--- a/rust/geometry/src/processors/boolean/halfspace_cap_tests.rs
+++ b/rust/geometry/src/processors/boolean/halfspace_cap_tests.rs
@@ -277,6 +277,56 @@ fn cap_winding_faces_away_from_kept_material_on_both_complementary_pieces() {
     }
 }
 
+/// Kernel-review counterexample (PR #2260, louistrue): a unit box clipped at
+/// z=0.5 closes cleanly on its own, but if a SEPARATE dangling triangle with
+/// exactly one fully-on-plane edge (and a third vertex off-plane) is also
+/// present in the mesh, that triangle's on-plane edge gets enrolled in the
+/// boundary chain walk, dead-ends (its far vertex has no continuation), and
+/// is silently dropped by the `None => loop_v.clear()` arm — never affecting
+/// `outer_count`/`outer_filled`. The dangling triangle's edges stay open
+/// (never welded to anything else in the mesh) yet `cap_half_space_clip`
+/// still reports `capped = true`, contradicting both its own doc ("a
+/// boundary that does not close bails") and the property #1810 zone
+/// splitting depends on (a trustworthy per-piece "was the cut closed"
+/// signal).
+#[test]
+fn cap_reports_false_when_a_dangling_on_plane_edge_stays_open() {
+    let bx = unit_box();
+    let clip_normal = Vector3::new(0.0, 0.0, 1.0);
+    let plane_point = Point3::new(0.5, 0.5, 0.5);
+    let clipper = ClippingProcessor::new();
+    let mut clipped = clipper
+        .clip_mesh(&bx, &Plane::new(plane_point, clip_normal))
+        .unwrap();
+
+    // Dangling triangle, disconnected from the box (shares no vertices with
+    // its cut loop): edge a-b lies fully on z=0.5, vertex c is off-plane.
+    let base = (clipped.positions.len() / 3) as u32;
+    let a = [5.0f32, 5.0, 0.5];
+    let b = [6.0f32, 5.0, 0.5];
+    let c = [5.0f32, 6.0, 3.0];
+    for v in [a, b, c] {
+        clipped.positions.extend_from_slice(&v);
+        clipped.normals.extend_from_slice(&[0.0, 0.0, 1.0]);
+    }
+    clipped.indices.extend_from_slice(&[base, base + 1, base + 2]);
+
+    let open_before = open_edges(&clipped);
+    assert!(open_before > 0, "fixture must start with open edges");
+
+    let capped = cap_half_space_clip(&mut clipped, plane_point, clip_normal);
+
+    let open_after = open_edges(&clipped);
+    assert!(
+        open_after > 0,
+        "the dangling triangle's edges must remain open after capping (got {open_after})"
+    );
+    assert!(
+        !capped,
+        "capped must be false when boundary edges remain open (got true with {open_after} open edges)"
+    );
+}
+
 /// `capped` must be MEASURED, not seeded: a plane that never touches the mesh
 /// (no vertex lies on it, so there is no open boundary to close) must report
 /// `false`, never a leftover-`true` from some earlier call or a hopeful

--- a/rust/geometry/src/processors/boolean/halfspace_cap_tests.rs
+++ b/rust/geometry/src/processors/boolean/halfspace_cap_tests.rs
@@ -136,10 +136,10 @@ fn two_pass_layer_clip_on_nonconvex_profile_is_watertight() {
     let before_next = Plane::new(Point3::new(0.0, 2.4, 0.0), Vector3::new(0.0, 1.0, 0.0));
 
     let mut slab = clipper.clip_mesh(&host, &after_prev).unwrap();
-    cap_half_space_clip(&mut slab, after_prev.point, after_prev.normal);
+    assert!(cap_half_space_clip(&mut slab, after_prev.point, after_prev.normal));
     let flipped = Plane::new(before_next.point, -before_next.normal);
     let mut slab = clipper.clip_mesh(&slab, &flipped).unwrap();
-    cap_half_space_clip(&mut slab, flipped.point, flipped.normal);
+    assert!(cap_half_space_clip(&mut slab, flipped.point, flipped.normal));
 
     assert_eq!(
         open_edges(&slab), 0,
@@ -185,7 +185,11 @@ fn cap_welds_ulp_twin_section_corner() {
     push(c[3], c[0], c[4]); push(c[3], c[4], c[7]); // left  (x=0)
 
     assert!(open_edges(&m) > 0, "fixture is open at z=0 before capping");
-    cap_half_space_clip(&mut m, Point3::new(0.5, 0.5, 0.0), Vector3::new(0.0, 0.0, 1.0));
+    assert!(cap_half_space_clip(
+        &mut m,
+        Point3::new(0.5, 0.5, 0.0),
+        Vector3::new(0.0, 0.0, 1.0)
+    ));
     assert_eq!(
         open_edges(&m), 0,
         "cap must weld the ~1-ULP section twin and close the z=0 face"
@@ -213,11 +217,86 @@ fn unbounded_half_space_clip_is_capped_and_watertight() {
     assert!(open_edges(&clipped) > 0, "raw plane clip leaves the section open");
     let tris_before = clipped.indices.len() / 3;
 
-    cap_half_space_clip(&mut clipped, plane_point, clip_normal);
+    assert!(cap_half_space_clip(&mut clipped, plane_point, clip_normal));
 
     assert_eq!(open_edges(&clipped), 0, "capped clip must be watertight");
     assert!(clipped.indices.len() / 3 > tris_before, "cap must add triangles");
     // Closed kept-half of the unit box → +0.5 (positive ⇒ outward winding).
     let v = signed_volume(&clipped);
     assert!((v - 0.5).abs() < 1.0e-5, "capped half-box volume should be +0.5, got {v}");
+}
+
+/// Pins the winding property the maintainer explicitly asked to carry over
+/// from #2171: "cap winding derived from the cut direction coming out
+/// inverted on both pieces". A volume-conservation-only test (like the one
+/// above) passes straight through that bug — a mesh whose cap triangles are
+/// wound inward can still integrate to the right positive magnitude if only
+/// a minority of the surface is misoriented relative to its area, which is
+/// exactly why the #2171 bug survived its own test suite. This asserts the
+/// GEOMETRIC orientation of every cap triangle directly, on BOTH pieces you
+/// get from cutting the same plane in each direction (`clip_normal = +z`
+/// keeping the top half, `clip_normal = -z` keeping the bottom half — the
+/// same two branches `clip_mesh_with_half_space` takes for
+/// `AgreementFlag = .T.` vs `.F.`), not just their summed volume.
+#[test]
+fn cap_winding_faces_away_from_kept_material_on_both_complementary_pieces() {
+    let bx = unit_box();
+    let plane_point = Point3::new(0.5, 0.5, 0.5);
+    let clipper = ClippingProcessor::new();
+
+    for &clip_normal in &[Vector3::new(0.0, 0.0, 1.0), Vector3::new(0.0, 0.0, -1.0)] {
+        let mut clipped = clipper
+            .clip_mesh(&bx, &Plane::new(plane_point, clip_normal))
+            .unwrap();
+        let tris_before = clipped.indices.len() / 3;
+        assert!(cap_half_space_clip(&mut clipped, plane_point, clip_normal));
+        assert!(
+            clipped.indices.len() / 3 > tris_before,
+            "cap must add triangles for clip_normal={clip_normal:?}"
+        );
+
+        // Outward normal of the KEPT solid at the cut face points away from
+        // the kept material, i.e. opposite the direction that was kept.
+        let expected_outward = -clip_normal;
+        let p = |i: u32| -> Point3<f64> {
+            let b = i as usize * 3;
+            Point3::new(
+                clipped.positions[b] as f64,
+                clipped.positions[b + 1] as f64,
+                clipped.positions[b + 2] as f64,
+            )
+        };
+        for tri in clipped.indices[tris_before * 3..].as_chunks::<3>().0 {
+            let (a, b, c) = (p(tri[0]), p(tri[1]), p(tri[2]));
+            let n = (b - a).cross(&(c - a));
+            assert!(
+                n.dot(&expected_outward) > 0.0,
+                "cap triangle wound inward for clip_normal={clip_normal:?}: geo_n={n:?}"
+            );
+        }
+    }
+}
+
+/// `capped` must be MEASURED, not seeded: a plane that never touches the mesh
+/// (no vertex lies on it, so there is no open boundary to close) must report
+/// `false`, never a leftover-`true` from some earlier call or a hopeful
+/// default. This is the exact shape of the #2171 regression — the caller
+/// asked for a cap, nothing was capped, so the answer must be `false`.
+#[test]
+fn cap_reports_false_when_the_plane_touches_no_boundary() {
+    let bx = unit_box();
+    assert_eq!(open_edges(&bx), 0, "fixture box must be watertight");
+    let mut untouched = bx.clone();
+    // Plane far outside the unit box — no vertex is within `on_plane_eps` of it.
+    let capped = cap_half_space_clip(
+        &mut untouched,
+        Point3::new(0.5, 0.5, 100.0),
+        Vector3::new(0.0, 0.0, 1.0),
+    );
+    assert!(!capped, "a plane touching nothing must report false, not a seeded true");
+    assert_eq!(
+        untouched.indices.len(),
+        bx.indices.len(),
+        "an unmatched plane must leave the mesh unchanged"
+    );
 }

--- a/rust/geometry/src/processors/boolean/halfspace_cap_tests.rs
+++ b/rust/geometry/src/processors/boolean/halfspace_cap_tests.rs
@@ -420,3 +420,158 @@ fn cap_does_not_leak_garbage_triangles_from_an_unclosed_merge_chain() {
         "a chain that never closes must not append ANY vertices to the mesh"
     );
 }
+
+/// Kernel-gate finding (PR #2260, deep review): `outer_filled == outer_count`
+/// (the "did every outer ring actually triangulate" accounting) had NO
+/// fixture — mutating it to `outer_filled <= outer_count` or `>= 1` passed
+/// every other test in this file, because none of them produce two SEPARATE
+/// outer rings where only one fails its CDT. That shape needs a genuine
+/// triangulation failure, which `safe_earcut`'s deliberate robustness makes
+/// hard to trigger with real degenerate geometry (see the fn-level doc on
+/// `force_cdt_fail_on_ring_for_test`), so this drives it through the
+/// `#[cfg(test)]` seam instead: two unit boxes far apart, both clipped by the
+/// SAME plane in one call (two disjoint, non-nested cut sections ⇒
+/// `outer_count == 2`), with the second ring's CDT forced to fail.
+#[test]
+fn cap_reports_false_when_one_of_two_outer_rings_fails_its_cdt() {
+    let mut combined = unit_box();
+    let second = {
+        let mut b = unit_box();
+        for c in b.positions.as_chunks_mut::<3>().0 {
+            c[0] += 10.0; // far enough that the two cut sections never nest
+        }
+        b
+    };
+    let base = (combined.positions.len() / 3) as u32;
+    combined.positions.extend_from_slice(&second.positions);
+    combined.normals.extend_from_slice(&second.normals);
+    combined
+        .indices
+        .extend(second.indices.iter().map(|&i| i + base));
+
+    let plane_point = Point3::new(0.5, 0.5, 0.5);
+    let clip_normal = Vector3::new(0.0, 0.0, 1.0);
+    let clipper = ClippingProcessor::new();
+    let mut clipped = clipper
+        .clip_mesh(&combined, &Plane::new(plane_point, clip_normal))
+        .unwrap();
+
+    // Sanity: with no forced failure, both sections cap and the verdict is
+    // true — establishes `outer_count == 2` is really reached before we
+    // start forcing failures.
+    let mut baseline = clipped.clone();
+    force_cdt_fail_on_ring_for_test(None);
+    assert!(
+        cap_half_space_clip(&mut baseline, plane_point, clip_normal),
+        "both disjoint sections must cap cleanly with no forced failure"
+    );
+
+    let tris_before = clipped.indices.len() / 3;
+    force_cdt_fail_on_ring_for_test(Some(1)); // fail the SECOND outer ring
+    let capped = cap_half_space_clip(&mut clipped, plane_point, clip_normal);
+    force_cdt_fail_on_ring_for_test(None); // don't leak into later tests
+
+    assert!(
+        !capped,
+        "one outer ring failing its CDT must make the whole verdict false, \
+         even though the other ring succeeded"
+    );
+    let tris_after = clipped.indices.len() / 3;
+    assert!(
+        tris_after > tris_before,
+        "the ring that DID triangulate must still contribute its cap \
+         triangles (best-effort geometry), got {} new tris",
+        tris_after - tris_before
+    );
+}
+
+/// Kernel-gate finding (PR #2260, deep review, minor): the merge-arm
+/// `loop_v.clear()` fix (above) makes an unclosed chain correctly contribute
+/// NO triangles — but which vertex a walk happens to START from is decided
+/// by welded-vertex insertion order, and for a "cycle plus one dangling tail
+/// that merges into it" shape (a rho: closed ring C, plus an edge t->c into
+/// one of C's own vertices), that order decides whether C's own,
+/// independently-valid loop ever gets walked at all.
+///
+/// Same solid — a unit box cut at z=0.5 (a clean, independently-capping
+/// cycle) plus one on-plane dangling triangle whose edge targets a cycle
+/// corner — reproduced under BOTH vertex orderings. In both, `capped` is
+/// correctly `false` (the invariant #1810 depends on: never a false
+/// positive). What differs is whether the cycle's own cap geometry survives:
+///
+/// - tail-vertices-inserted-first: the walk starting at the tail consumes the
+///   ENTIRE cycle into `visited` before merging back into itself, so the
+///   cycle never gets its own walk and NOTHING is capped.
+/// - cycle-vertices-inserted-first: a cycle vertex is walked (and closes)
+///   before the tail's start is reached, so the cycle IS capped — the
+///   tail's own walk then correctly contributes nothing.
+///
+/// This is a real latent difference in output completeness (not correctness
+/// — `capped` is false either way) that the kernel-gate review flagged as
+/// non-blocking, latent risk rather than an observed regression, since fixing
+/// it needs picking genuine chain "sources" before genuine cycles, which is
+/// a bigger structural change than this PR's "small fixes" scope. This test
+/// pins BOTH observed behaviours as a regression guard and a citation for the
+/// follow-up, rather than leaving the finding untested.
+#[test]
+fn cap_verdict_stays_false_but_cap_completeness_is_order_dependent_for_a_cycle_plus_tail() {
+    let plane_point = Point3::new(0.5, 0.5, 0.5);
+    let clip_normal = Vector3::new(0.0, 0.0, 1.0);
+    let clipper = ClippingProcessor::new();
+    let box_cut = clipper
+        .clip_mesh(&unit_box(), &Plane::new(plane_point, clip_normal))
+        .unwrap();
+
+    // Dangling on-plane edge t -> c, where `c` coincides exactly with the
+    // box cut's (0.0, 0.0, 0.5) corner (an axis-aligned edge cut at an
+    // exactly-representable f32 midpoint, so this is a bit-exact weld).
+    let t = [2.0f32, 0.0, 0.5];
+    let c = [0.0f32, 0.0, 0.5];
+    let off = [2.0f32, 1.0, 3.0];
+
+    // Order A: tail vertices FIRST → the cycle is entirely consumed into the
+    // tail's own failed walk and never capped.
+    let mut order_a = Mesh::new();
+    for v in [t, c, off] {
+        order_a.positions.extend_from_slice(&v);
+        order_a.normals.extend_from_slice(&[0.0, 0.0, 1.0]);
+    }
+    order_a.indices.extend_from_slice(&[0, 1, 2]);
+    let box_base = (order_a.positions.len() / 3) as u32;
+    order_a.positions.extend_from_slice(&box_cut.positions);
+    order_a.normals.extend_from_slice(&box_cut.normals);
+    order_a
+        .indices
+        .extend(box_cut.indices.iter().map(|&i| i + box_base));
+
+    let tris_before_a = order_a.indices.len() / 3;
+    let capped_a = cap_half_space_clip(&mut order_a, plane_point, clip_normal);
+    assert!(!capped_a, "order A must still report capped=false");
+    assert_eq!(
+        order_a.indices.len() / 3,
+        tris_before_a,
+        "order A (tail-first ids): the cycle must be swallowed by the tail's \
+         walk and end up with NO cap triangles at all"
+    );
+
+    // Order B: box (cycle) vertices FIRST → the cycle gets its own walk and
+    // IS capped; the tail's walk correctly contributes nothing.
+    let mut order_b = box_cut.clone();
+    let tail_base = (order_b.positions.len() / 3) as u32;
+    for v in [t, c, off] {
+        order_b.positions.extend_from_slice(&v);
+        order_b.normals.extend_from_slice(&[0.0, 0.0, 1.0]);
+    }
+    order_b
+        .indices
+        .extend_from_slice(&[tail_base, tail_base + 1, tail_base + 2]);
+
+    let tris_before_b = order_b.indices.len() / 3;
+    let capped_b = cap_half_space_clip(&mut order_b, plane_point, clip_normal);
+    assert!(!capped_b, "order B must still report capped=false");
+    assert!(
+        order_b.indices.len() / 3 > tris_before_b,
+        "order B (cycle-first ids): the cycle must still be capped even \
+         though the overall verdict is correctly false"
+    );
+}

--- a/rust/geometry/src/processors/boolean/halfspace_cap_tests.rs
+++ b/rust/geometry/src/processors/boolean/halfspace_cap_tests.rs
@@ -350,3 +350,73 @@ fn cap_reports_false_when_the_plane_touches_no_boundary() {
         "an unmatched plane must leave the mesh unchanged"
     );
 }
+
+/// Kernel-gate finding (PR #2260, louistrue, 2026-08-07): the boundary walk's
+/// "merge into an already-visited vertex" arm sets `boundary_incomplete` and
+/// `break`s, but does NOT `loop_v.clear()` before the `if loop_v.len() >= 3`
+/// push below it — unlike the sibling dead-end (`None`) arm, which does clear.
+/// So an unclosed chain that folds back into a vertex some OTHER chain already
+/// visited is triangulated and appended to the mesh as if it were a real ring,
+/// even though the function correctly reports `capped = false`.
+///
+/// Four dangling on-plane triangles wired s->a->b->c->a (a "rho": a tail that
+/// loops back one hop short of its own start) reproduce this without needing
+/// any real cut at all. The walk starting at `s` visits a, b, c, then hits `a`
+/// again — already visited by this same walk, and `cur != s` — so it takes the
+/// merge arm, not the `cur == s` closure. `loop_v` still holds `[s, a, b, c]`
+/// and is pushed as a "loop" because the merge arm never clears it.
+#[test]
+fn cap_does_not_leak_garbage_triangles_from_an_unclosed_merge_chain() {
+    let z_plane = 0.5f32;
+    // On-plane quad corners.
+    let s = [0.0f32, 0.0, z_plane];
+    let a = [1.0f32, 0.0, z_plane];
+    let b = [1.0f32, 1.0, z_plane];
+    let c = [0.0f32, 1.0, z_plane];
+    // Off-plane third vertex for each dangling triangle, distinct so none
+    // welds to another and none lies on the cut plane.
+    let off_a = [2.0f32, 0.0, 3.0];
+    let off_b = [2.0f32, 1.0, 4.0];
+    let off_c = [1.0f32, 2.0, 5.0];
+    let off_d = [0.0f32, 2.0, 6.0];
+
+    let mut m = Mesh::new();
+    let push_tri = |m: &mut Mesh, verts: [[f32; 3]; 3]| {
+        let base = (m.positions.len() / 3) as u32;
+        for v in verts {
+            m.positions.extend_from_slice(&v);
+            m.normals.extend_from_slice(&[0.0, 0.0, 1.0]);
+        }
+        m.indices.extend_from_slice(&[base, base + 1, base + 2]);
+    };
+    push_tri(&mut m, [s, a, off_a]); // on-plane edge s->a
+    push_tri(&mut m, [a, b, off_b]); // on-plane edge a->b
+    push_tri(&mut m, [b, c, off_c]); // on-plane edge b->c
+    push_tri(&mut m, [c, a, off_d]); // on-plane edge c->a (merges back into `a`)
+
+    let tris_before = m.indices.len() / 3;
+    let positions_before = m.positions.len();
+
+    let capped = cap_half_space_clip(
+        &mut m,
+        Point3::new(0.0, 0.0, z_plane as f64),
+        Vector3::new(0.0, 0.0, 1.0),
+    );
+
+    assert!(
+        !capped,
+        "an unclosed merge chain must not report capped=true"
+    );
+    assert_eq!(
+        m.indices.len() / 3,
+        tris_before,
+        "a chain that never closes must not append ANY triangles to the mesh, \
+         even when the overall verdict is correctly `false` — got {} new tri(s)",
+        m.indices.len() / 3 - tris_before
+    );
+    assert_eq!(
+        m.positions.len(),
+        positions_before,
+        "a chain that never closes must not append ANY vertices to the mesh"
+    );
+}

--- a/rust/geometry/src/processors/boolean/mod.rs
+++ b/rust/geometry/src/processors/boolean/mod.rs
@@ -29,6 +29,8 @@ use cut_heuristics::{
     cutter_below_skip_ratio, plane_is_coincident_with_host_face, quality_skips_small_cuts,
 };
 use halfspace_cap::cap_half_space_clip;
+#[cfg(test)]
+use halfspace_cap::force_cdt_fail_on_ring_for_test;
 
 /// Maximum recursion depth for nested boolean operations.
 /// Prevents stack overflow from deeply nested IfcBooleanResult chains.

--- a/rust/geometry/src/processors/boolean/mod.rs
+++ b/rust/geometry/src/processors/boolean/mod.rs
@@ -273,7 +273,16 @@ impl BooleanClippingProcessor {
         // OPEN (the BSP kernel's polygon cap was deleted with the BSP port in
         // #1024). Re-close it: a watertight host clipped by a plane leaves an
         // open boundary lying on that plane, forming the section to cap.
-        cap_half_space_clip(&mut clipped, plane_point, clip_normal);
+        //
+        // `cap_half_space_clip` reports (measured, not assumed) whether it
+        // actually closed the cut. Nothing downstream of this call consumes
+        // that yet — the mesh is returned either way, same as before this
+        // function reported anything, since an uncapped-but-otherwise-valid
+        // mesh is still the least-bad output (see the fn's own doc). A
+        // per-solid "was this fully watertight" signal is exactly what a
+        // future geometric zone split needs to report per-piece integrity —
+        // that consumer doesn't exist yet, so the bool is bound, not routed.
+        let _capped = cap_half_space_clip(&mut clipped, plane_point, clip_normal);
         Ok(clipped)
     }
 


### PR DESCRIPTION
Route-independent groundwork for #1810's geometric zone splitting, following your decision on #2171 to build this in Rust.

**This deliberately does not build the clipper, and does not pick the route.** The precision question I raised — compose `clip_mesh` N times through `Mesh.positions: Vec<f32>`, versus the exact kernel's `intersection`/`subtract_many` — is still yours to call. These three pieces are needed whichever way it goes, so they are worth having now rather than blocking on it.

## 1. `cap_half_space_clip` now reports whether it capped

It returned `()` and bailed silently at three points, so nothing could distinguish a capped piece from an open shell — and a zone split has to report per-piece volume, which is meaningless without that. Now `-> bool`, `#[must_use]`.

**The value is measured, never seeded**, and that distinction is the #2171 lesson rather than a style preference. The TypeScript version seeded `capped: true` and relied on the capping pass to correct it: fine whenever a plane runs, and silently wrong when the plane list is empty — a documented, supported input — handing the caller `capped: true` on an open shell.

So success is counted (`outer_count > 0 && outer_filled == outer_count`), and a **partial** cap — one outer ring's triangulation failing while others succeed — reports `false`. That is still an open boundary.

Nothing consumes it yet; the caller binds it with a comment saying so until a zone-split consumer exists.

## 2. A public mesh volume

`kernel::mesh_volume`, delegating to `signed_volume6` rather than reimplementing.

That is the **AABB-centred** one — not `router/voids/geom.rs`'s world-origin variant, nor the `#[cfg(test)]`-only helper in `mesh_bridge.rs`. Both of those are translation-variant for open surfaces, which is precisely the property a per-piece volume must not have. `signed_volume.rs:19-28` already explains why; the new doc names the other two candidates so nobody reaches for them later.

In its own file because adding it to `mesh_bridge.rs` pushed that 21 lines over its ratchet budget. No budget raised.

## 3. The cap-winding property — and a negative result

You asked for this to carry over:

> cap winding derived from the cut direction coming out inverted on both pieces (conservation-only tests pass through it, which is exactly why it survived)

**`rust/geometry` does not have that bug.** The cap computes each triangle's geometric normal live and forces it to match `cap_outward` regardless of what the CDT returned (`halfspace_cap.rs:276-286`), so it is structurally immune to winding inherited from the cut direction.

Pinned anyway, and pinned the way you specified — asserting per-triangle orientation **directly**, on **both complementary pieces** of the same cut (`clip_normal = +z` and `-z`, mirroring `AgreementFlag = .T.`/`.F.`). Not via volume, because conservation-only tests pass straight through this class; that is why it survived in TypeScript.

I verified the class is genuinely testable here rather than asserting a tautology: flipping `cap_outward` from `-n` to `n` fails the new test immediately with `cap triangle wound inward for clip_normal=[0,0,1]: geo_n=[0,0,0.25]`.

## Verification

Every assertion justified by a mutation, each re-run by hand:

| mutation | result |
|---|---|
| `cap_outward = -n` → `n` | new winding test fails with the diagnostic above |
| empty-boundary bail `return false` → `return true` | only the measured-not-seeded test fails |
| `mesh_volume` summing about the world origin | fails `near=6.666 far=-6660` — the #198779 sign-flip shape |

That last fixture has to be **open**. A closed-mesh translation-invariance test would pass under either reference point and prove nothing.

- `cargo test -p ifc-lite-geometry --lib`: **599 passing**, 1 ignored.
- Module-size ratchet: **4/4**, with `mesh_bridge.rs` confirmed back under its 904-line budget.
- Clippy: the crate carries ~157 pre-existing `chunks_exact_to_as_chunks` / `int_plus_one` errors from nightly drift across files I never touched. Compared `--> file:line` locations before and after: **zero new locations**.

## Still needs your call

The precision route. Reusing `clip_mesh` as-is quietly decides that zone volumes are accurate only to f32-at-model-scale, since `Mesh.positions` is `Vec<f32>` and an N-plane volume round-trips the cut vertices N times. That may be an acceptable answer — it just should not be made by omission, and it determines whether the next PR composes `clip_mesh` or goes through the exact kernel.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a geometry API for calculating signed mesh volume, including open meshes without requiring closedness.
  * Volume calculations support meshes positioned away from the world origin, with documented numerical precision limitations.

* **Bug Fixes**
  * Half-space clipping now accurately reports unsuccessful capping.
  * Prevented incomplete boundary chains and partial triangulations from producing invalid cap geometry.
  * Improved handling of dangling edges, non-intersecting planes, and complementary clipped sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->