### PR TITLE
test(extensions): actually exercise the bundle path-traversal guard

### DIFF
--- a/packages/extensions/src/bundle/iflx.test.ts
+++ b/packages/extensions/src/bundle/iflx.test.ts
@@ -158,6 +158,32 @@ describe('unpackBundle — invalid inputs', () => {
     expect(r.ok).toBe(false);
   });
 
+  it('rejects an absolute Windows path (drive-letter branch)', async () => {
+    // `isSafeBundlePath` rejects drive letters in a clause of its own,
+    // separate from the leading-slash check the test above covers. A bundle
+    // is a portable artefact: one built on any OS may be unpacked on Windows,
+    // so a `C:\` key must be refused regardless of where unpacking happens.
+    const original = await loadGood();
+    const packed = packBundle(original);
+    const unpacked = unpackBundle(packed);
+    if (!unpacked.ok) throw new Error('expected good bundle to unpack');
+    const files: Record<string, string> = {};
+    for (const [path, file] of unpacked.value.files) {
+      files[path] = Buffer.from(file.bytes).toString('base64');
+    }
+    files['C:\\Windows\\System32\\evil.dll'] = Buffer.from('evil').toString('base64');
+    const env = gzipSync(new TextEncoder().encode(JSON.stringify({
+      format: 'iflx',
+      version: 1,
+      files,
+    })));
+    const r = unpackBundle(env);
+    expect(r.ok).toBe(false);
+    // Assert the reason, not just the outcome: a bundle can also fail
+    // manifest validation, which would pass this test for the wrong reason.
+    if (!r.ok) expect(r.errors[0].code).toBe('invalid_format');
+  });
+
   it('rejects a path containing control characters', () => {
     // Defence-in-depth: control chars (incl. the old 0x1f/0x1e signing
     // separators) must never appear in a bundle path.

--- a/packages/extensions/src/bundle/iflx.test.ts
+++ b/packages/extensions/src/bundle/iflx.test.ts
@@ -108,6 +108,56 @@ describe('unpackBundle — invalid inputs', () => {
     expect(r.ok).toBe(false);
   });
 
+  it('rejects a bundle file path that escapes the bundle root via ".."', async () => {
+    // Mutation: `isSafeBundlePath` returning `true` unconditionally (i.e.
+    // deleting the whole check) survived the full suite untouched,
+    // including the neighbouring "control characters" test above — that
+    // test only passes today because its accompanying manifest.json is
+    // itself invalid ("{}"), so `unpackBundle` still rejects the bundle
+    // for an unrelated reason and never actually exercises the path
+    // check. Build the envelope around a manifest that DOES validate, so
+    // rejection can only come from the path-traversal check in
+    // `isSafeBundlePath`. Without it, a malicious bundle could smuggle a
+    // "../../etc/whatever" file key past validation and into any host
+    // adapter that later writes the file map to disk (see the comment on
+    // `isSafeBundlePath`).
+    const original = await loadGood();
+    const packed = packBundle(original);
+    const unpacked = unpackBundle(packed);
+    if (!unpacked.ok) throw new Error('expected good bundle to unpack');
+    const files: Record<string, string> = {};
+    for (const [path, file] of unpacked.value.files) {
+      files[path] = Buffer.from(file.bytes).toString('base64');
+    }
+    files['../escape.js'] = Buffer.from('evil').toString('base64');
+    const env = gzipSync(new TextEncoder().encode(JSON.stringify({
+      format: 'iflx',
+      version: 1,
+      files,
+    })));
+    const r = unpackBundle(env);
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects an absolute bundle file path', async () => {
+    const original = await loadGood();
+    const packed = packBundle(original);
+    const unpacked = unpackBundle(packed);
+    if (!unpacked.ok) throw new Error('expected good bundle to unpack');
+    const files: Record<string, string> = {};
+    for (const [path, file] of unpacked.value.files) {
+      files[path] = Buffer.from(file.bytes).toString('base64');
+    }
+    files['/etc/passwd'] = Buffer.from('evil').toString('base64');
+    const env = gzipSync(new TextEncoder().encode(JSON.stringify({
+      format: 'iflx',
+      version: 1,
+      files,
+    })));
+    const r = unpackBundle(env);
+    expect(r.ok).toBe(false);
+  });
+
   it('rejects a path containing control characters', () => {
     // Defence-in-depth: control chars (incl. the old 0x1f/0x1e signing
     // separators) must never appear in a bundle path.


### PR DESCRIPTION
`isSafeBundlePath` (`packages/extensions/src/bundle/iflx.ts:256`) is the zip-slip guard for `.iflx` unpacking. It exists so a malicious bundle cannot smuggle a `../../` or absolute file key past `unpackBundle` into a host adapter that later writes the file map to disk.

**Nothing exercised it.** Replacing its body with `return true` — bypassing the traversal, absolute-path, Windows-drive-letter and control-character checks all at once — left the entire 773-test suite green.

## Why the file looked covered

There *is* a test named `rejects a path containing control characters`. But its envelope carries `{}` as the manifest, so `unpackBundle` rejected it during **manifest validation** and never reached the path check at all.

So the guard had a test pointing at it that could not fail for the reason its name implies. That is the same shape as the other near-misses in this area lately: a check that passes for the wrong reason is indistinguishable from a check that works.

## Bounded, not just asserted

A survivor is consistent with two very different things — the guard is unpinned, or nothing in the file is reached at all. So I mutated the neighbouring `envelope.format !== IFLX_MAGIC` check as a control: it broke **3 files / 12 tests** immediately.

The harness reaches `iflx.ts` fine. It was this guard specifically that was unpinned.

## The tests

Two, both built around the loader's own **valid** fixture bundle plus one extra unsafe-keyed file — so a valid manifest cannot confound the result and the assertion isolates `isSafeBundlePath` rather than re-testing manifest validation:

- rejects a bundle file path that escapes the bundle root via `..`
- rejects an absolute bundle file path

## Severity: coverage gap, not a live defect

The guard is correct today. I read it under unmutated code: it rejects `..`, empty and `.` segments, absolute POSIX (`/…`) and Windows (`C:\…`) paths, and control characters. Nothing here is exploitable as it stands.

What was missing is the guard against it *silently becoming* wrong — which for a path-traversal check on third-party bundle content is worth having.

## Verification

Checked both directions by hand rather than taking the run at face value:

- guard bypassed + **old** tests → **10/10 pass** (the gap, demonstrated)
- guard bypassed + **new** tests → **2 fail of 12**
- restored → 59 files / **775 tests** passing, `tsc --noEmit` clean

Test-only; no changeset.

## Also checked, no findings

`capability/match.ts`, `parse.ts`, `scope-claim.ts`, `diff.ts`, `risk.ts`, `host/check.ts`, `host/permissions.ts`, `host/runtime.ts`, `signing/verify.ts`, `bundle/loader.ts`, `when/eval.ts` — all already carry allow-and-deny pins from earlier hardening rounds, several titled `Regression: …`. No further survivors worth reporting.

`packages/plugin-api` is a dependency-free type surface with no runtime logic beyond `version.ts`; there was nothing meaningful to mutate.
