### PR TITLE
fix(mutations): stop whole-pset/qset creations being silently dropped

### DIFF
--- a/.changeset/quiet-quantities-vanish.md
+++ b/.changeset/quiet-quantities-vanish.md
@@ -1,0 +1,12 @@
+---
+"@ifc-lite/mutations": patch
+---
+
+Fix silent data loss for whole-property-set and whole-quantity-set creations (`StoreEditor.addPropertySet` / `addQuantitySet`, or the underlying `MutablePropertyView.createPropertySet` / `createQuantitySet`) in two downstream consumers of `Mutation` records.
+
+`createPropertySet()` and `createQuantitySet()` each record a single `CREATE_PROPERTY_SET` / `CREATE_QUANTITY` mutation for the whole set, carrying the full member array on `newValue` — unlike `setProperty()` / `setQuantity()`, which always record `psetName` **and** `propName` together for one member at a time.
+
+- `changeSetToOps()` (the layer-publish bridge in `change-set-to-ops.ts`) treated `CREATE_PROPERTY_SET` as "materialize an empty component; members follow" — but for this whole-set form nothing else in the change set ever populated the values, so the published op carried `values: {}` and every property the user entered was dropped from the layer. The `CREATE_QUANTITY`/`UPDATE_QUANTITY` case required `propName`, so the whole-set form matched the case and produced nothing at all — not even a `skipped` entry, so the loss was invisible.
+- `MutablePropertyView.applyMutations()` (backing `exportMutations()` → `importMutations()`) had the same `psetName && propName` gap for `CREATE_QUANTITY`, so a `createQuantitySet()` batch silently vanished on round trip through a fresh view.
+
+Both paths now read the member array off `newValue` for the whole-set form, mirroring the per-member fold. No change to the per-member (`setProperty`/`setQuantity`) mutation shapes.

--- a/packages/mutations/src/change-set-to-ops.test.ts
+++ b/packages/mutations/src/change-set-to-ops.test.ts
@@ -145,6 +145,76 @@ describe('changeSetToOps', () => {
     expect(add).toMatchObject({ ifcType: 'IfcWall' });
   });
 
+  it('carries the properties of a whole-pset CREATE_PROPERTY_SET into the published component', () => {
+    // `MutablePropertyView.createPropertySet()` (used by `StoreEditor.addPropertySet`)
+    // records ONE CREATE_PROPERTY_SET mutation for the whole set, with `newValue`
+    // holding the full properties array — it does NOT also push a separate
+    // CREATE_PROPERTY mutation per member the way `setProperty()` does. The old
+    // "members follow" comment on this branch assumed such follow-up mutations
+    // always existed; for this path nothing ever populated `values`, so the
+    // published op silently carried `values: {}` — every property the user
+    // entered was dropped from the layer at publish time. Mutation: gut the
+    // `Array.isArray(mutation.newValue)` loop back to just materializing `{}`.
+    const result = changeSetToOps(
+      changeSet([
+        mutation('CREATE_PROPERTY_SET', 42, {
+          psetName: 'Pset_Foo',
+          newValue: [
+            { name: 'Bar', value: 42 },
+            { name: 'Baz', value: 'hello' },
+          ] as unknown as PropertyValue,
+        }),
+      ]),
+      resolver
+    );
+    expect(result.ops).toContainEqual({
+      op: 'set-component',
+      entity: '3fAx$GlobalId42',
+      componentKey: 'pset:Pset_Foo',
+      values: { Bar: 42, Baz: 'hello' },
+    });
+  });
+
+  it('still materializes an empty component for a CREATE_PROPERTY_SET with no properties (control)', () => {
+    const result = changeSetToOps(
+      changeSet([mutation('CREATE_PROPERTY_SET', 42, { psetName: 'Pset_Empty', newValue: [] as unknown as PropertyValue })]),
+      resolver
+    );
+    expect(result.ops).toContainEqual({
+      op: 'set-component',
+      entity: '3fAx$GlobalId42',
+      componentKey: 'pset:Pset_Empty',
+      values: {},
+    });
+  });
+
+  it('carries the quantities of a whole-qset CREATE_QUANTITY (createQuantitySet, no propName) instead of dropping it (#2251 finding)', () => {
+    // `MutablePropertyView.createQuantitySet()` (used by `StoreEditor.addQuantitySet`)
+    // records a CREATE_QUANTITY mutation with NO `propName` — the previous
+    // `mutation.psetName && mutation.propName` guard was false for this record,
+    // so it fell all the way through the switch's CREATE_QUANTITY/UPDATE_QUANTITY
+    // case with nothing emitted. Worse than the pset case above: because the
+    // mutation still matched a known `case`, it never reached the `default`
+    // branch either, so it wasn't even reported via `skipped` — a freshly
+    // created quantity set vanished from the published layer with zero trace.
+    const result = changeSetToOps(
+      changeSet([
+        mutation('CREATE_QUANTITY', 42, {
+          psetName: 'Qto_Foo',
+          newValue: [{ name: 'NetVolume', value: 1.5 }] as unknown as PropertyValue,
+        }),
+      ]),
+      resolver
+    );
+    expect(result.skipped).toEqual([]);
+    expect(result.ops).toContainEqual({
+      op: 'set-component',
+      entity: '3fAx$GlobalId42',
+      componentKey: 'qset:Qto_Foo',
+      values: { NetVolume: 1.5 },
+    });
+  });
+
   it('serializes a retype as a class opinion and rides PredefinedType on the core channel', () => {
     const result = changeSetToOps(
       changeSet([

--- a/packages/mutations/src/change-set-to-ops.ts
+++ b/packages/mutations/src/change-set-to-ops.ts
@@ -203,6 +203,21 @@ function applyMutation(
     case 'UPDATE_QUANTITY':
       if (mutation.psetName && mutation.propName) {
         setMember(entity, `qset:${mutation.psetName}`, mutation.propName, mutation.newValue ?? null);
+      } else if (mutation.type === 'CREATE_QUANTITY' && mutation.psetName && Array.isArray(mutation.newValue)) {
+        // `MutablePropertyView.createQuantitySet()` (whole-qset creation, e.g.
+        // `StoreEditor.addQuantitySet`) records ONE CREATE_QUANTITY mutation for
+        // the whole set — no `propName`, `newValue` is the full quantities array
+        // — unlike `setQuantity()`'s per-quantity CREATE_QUANTITY, which always
+        // carries both. Without this branch the `psetName && propName` check
+        // above is false and the mutation fell through with nothing published:
+        // not even into `skipped` (it matches this case, so the default branch
+        // never runs), so a freshly-created quantity set vanished from the
+        // layer with zero trace.
+        for (const q of mutation.newValue as Array<{ name?: string; value?: PropertyValue }>) {
+          if (q && typeof q.name === 'string') {
+            setMember(entity, `qset:${mutation.psetName}`, q.name, q.value ?? null);
+          }
+        }
       }
       break;
     case 'DELETE_QUANTITY':
@@ -212,8 +227,24 @@ function applyMutation(
       break;
     case 'CREATE_PROPERTY_SET':
       if (mutation.psetName) {
-        // Materialize the (possibly empty) set; members follow.
-        componentFor(entity, `pset:${mutation.psetName}`).set(`pset:${mutation.psetName}`, {});
+        const componentKey = `pset:${mutation.psetName}`;
+        // Materialize the (possibly empty) set.
+        componentFor(entity, componentKey).set(componentKey, {});
+        // `MutablePropertyView.createPropertySet()` (whole-pset creation, e.g.
+        // `StoreEditor.addPropertySet`) records ONE CREATE_PROPERTY_SET mutation
+        // for the whole set — `newValue` is the full properties array — and does
+        // NOT also push a separate CREATE_PROPERTY mutation per member into
+        // `mutationHistory`. "members follow" was therefore never true for this
+        // path: nothing else in the change set ever populated `values`, so the
+        // published set-component op carried `values: {}` and every property the
+        // user entered was silently dropped from the layer.
+        if (Array.isArray(mutation.newValue)) {
+          for (const prop of mutation.newValue as Array<{ name?: string; value?: PropertyValue }>) {
+            if (prop && typeof prop.name === 'string') {
+              setMember(entity, componentKey, prop.name, prop.value ?? null);
+            }
+          }
+        }
       }
       break;
     case 'DELETE_PROPERTY_SET':

--- a/packages/mutations/src/mutable-property-view.ts
+++ b/packages/mutations/src/mutable-property-view.ts
@@ -1818,6 +1818,27 @@ export class MutablePropertyView {
               (mutation.quantityType as QuantityType) ?? QuantityType.Count,
               mutation.unit,
             );
+          } else if (
+            mutation.type === 'CREATE_QUANTITY' &&
+            mutation.psetName &&
+            Array.isArray(mutation.newValue)
+          ) {
+            // `createQuantitySet()` (whole-qset creation, e.g.
+            // `StoreEditor.addQuantitySet`) records ONE CREATE_QUANTITY mutation
+            // for the whole set — no `propName`, `newValue` is the full
+            // quantities array — unlike `setQuantity()`'s per-quantity
+            // CREATE_QUANTITY, which always carries both. Mirrors the
+            // CREATE_PROPERTY_SET handling below. Without this branch the
+            // `psetName && propName` check above is false and the record
+            // matched this `case` with nothing done — never falling through to
+            // the "unhandled mutation type" warning either — so a freshly
+            // created quantity set silently vanished on
+            // exportMutations()/importMutations() round trip.
+            this.createQuantitySet(
+              mutation.entityId,
+              mutation.psetName,
+              mutation.newValue as unknown as Array<{ name: string; value: number; quantityType: QuantityType; unit?: string }>,
+            );
           }
           break;
 

--- a/packages/mutations/test/retype.test.ts
+++ b/packages/mutations/test/retype.test.ts
@@ -12,7 +12,7 @@ import {
   type MutationEntityRef,
   type MutationStoreShape,
 } from '../src/index.js';
-import { PropertyValueType } from '@ifc-lite/data';
+import { PropertyValueType, QuantityType } from '@ifc-lite/data';
 
 function makeStore(maxId: number, type = 'IFCBUILDINGELEMENTPROXY'): MutationStoreShape {
   const byId = new Map<number, MutationEntityRef>();
@@ -303,6 +303,53 @@ describe('MutablePropertyView.importMutations — skipped CREATE_ENTITY (#2044)'
     } finally {
       warnSpy.mockRestore();
     }
+  });
+});
+
+describe('MutablePropertyView.importMutations — whole-set CREATE_QUANTITY (mutation-testing finding)', () => {
+  it('replays a createQuantitySet() batch through exportMutations -> importMutations', () => {
+    // `createQuantitySet()` (used by `StoreEditor.addQuantitySet`) records a
+    // SINGLE CREATE_QUANTITY mutation for the whole set — no `propName`,
+    // `newValue` is the full quantities array — unlike `setQuantity()`'s
+    // per-quantity CREATE_QUANTITY, which always carries both. The replay
+    // switch in `applyMutations` used to require `psetName && propName` for
+    // every CREATE_QUANTITY/UPDATE_QUANTITY record, so this whole-set form
+    // matched the case and then did nothing: it never fell through to the
+    // "unhandled mutation type" warning either, so the quantity set silently
+    // vanished on round trip. Mirrors the identical gap this session found
+    // in `change-set-to-ops.ts`'s CREATE_PROPERTY_SET/CREATE_QUANTITY
+    // handling for the layer-publish path.
+    const a = new MutablePropertyView(null, 'm1');
+    a.createQuantitySet(42, 'Qto_WallBaseQuantities', [
+      { name: 'NetVolume', value: 1.5, quantityType: QuantityType.Volume },
+      { name: 'GrossArea', value: 12, quantityType: QuantityType.Area },
+    ]);
+
+    const json = a.exportMutations();
+    const b = new MutablePropertyView(null, 'm1');
+    b.importMutations(json);
+
+    expect(b.getQuantitiesForEntity(42)).toEqual(a.getQuantitiesForEntity(42));
+    expect(b.getQuantitiesForEntity(42)).toMatchObject([
+      {
+        name: 'Qto_WallBaseQuantities',
+        quantities: expect.arrayContaining([
+          expect.objectContaining({ name: 'NetVolume', value: 1.5 }),
+          expect.objectContaining({ name: 'GrossArea', value: 12 }),
+        ]),
+      },
+    ]);
+  });
+
+  it('still replays a per-quantity setQuantity() update on an existing set (control)', () => {
+    const a = new MutablePropertyView(null, 'm1');
+    a.setQuantity(42, 'Qto_WallBaseQuantities', 'NetVolume', 3, QuantityType.Volume);
+    const json = a.exportMutations();
+
+    const b = new MutablePropertyView(null, 'm1');
+    b.importMutations(json);
+
+    expect(b.getQuantitiesForEntity(42)).toEqual(a.getQuantitiesForEntity(42));
   });
 });
 


### PR DESCRIPTION
**LIVE data loss.** Create a property set or quantity set via `StoreEditor.addPropertySet` / `addQuantitySet`, then either publish that change set through the layer bridge or round-trip it through the public `exportMutations()` / `importMutations()`, and every value the user entered is gone. Silently — no error, no warning, and in one case not even a `skipped` entry.

## Why two independent consumers got it wrong the same way

`createPropertySet()` / `createQuantitySet()` record **one** mutation for the whole set, with the member array on `newValue`. That is a different shape from `setProperty()` / `setQuantity()`, which always carry `psetName` **and** `propName` for a single member. Both consumers were written against the per-member shape.

**`change-set-to-ops.ts:213`** materialised the pset component with `values: {}` under the comment *"members follow"*. They do not — `createPropertySet` emits a single record and no per-member `CREATE_PROPERTY`, so nothing downstream ever populated it.

**`change-set-to-ops.ts:202`** is the worse half. The `CREATE_QUANTITY` arm required `propName`; the whole-set form has none, so it **matched the `case`, produced nothing, and never reached the default branch** that records unrepresentable mutations. The file documents that it reports what it cannot represent; this defeated that contract, which is why the loss is completely traceless rather than merely wrong.

**`mutable-property-view.ts:1810`** had the identical `psetName && propName` gap in `applyMutations`, so a `createQuantitySet` batch vanished on export/import. Its `CREATE_PROPERTY_SET` replay was already correct — that is what the fix mirrors, rather than inventing a new convention.

## Observed before fixing

```
pset publish     → values: {}          (expected { Bar: 42, Baz: 'hello' })
qset publish     → ops: [], skipped: [] (total silence)
qset round trip  → getQuantitiesForEntity(42) === []   against a populated source
```

## Verification

- Each fix reverted **in isolation** and re-run, to confirm it is the thing under test rather than something else covering for it. I repeated both by hand: reverting the publish fix fails 2 of 15 with `expected [] to deep equally contain {...}` — the empty-ops case — and reverting the round-trip fix fails 1 of 21.
- I also confirmed the premise directly rather than trusting the diagnosis: `createPropertySet` emits exactly **one** mutation record, so "members follow" was never true for this path.
- **Control siblings** cover the empty-set and per-member paths, so the fix cannot pass by breaking those instead.
- `packages/mutations` **157 → 162** passing (10 skipped unchanged); `tsc --noEmit` clean.
- Changeset: patch bump for `@ifc-lite/mutations`.

## Audited in the same pass, no findings

`packages/collab` — `undo.ts` (thin `Y.UndoManager` wrapper), `conflicts/detector.ts` (advisory only), `mutations/bind.ts`, `federation/resolver.ts`, `branch/history.ts`, and `mutable-property-view.ts`'s deleteEntity/restoreNewEntity stash-and-purge pairing, already hardened by #1967 / #2012 / #2036 / #2044 / #2048. Untouched.

One thing noted and deliberately **not** fixed: `geometry/gc.ts`'s `sweepBlobs()` computes a `freed` count and then discards it, returning `decision.reclaimBytes` unconditionally — a metric-accuracy discrepancy with its own doc comment. No in-repo caller and no data-corruption consequence, so it is a coverage gap rather than something to change here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed creation of complete property sets so all properties are preserved.
  * Fixed creation and replay of complete quantity sets so all quantities are retained.
  * Preserved existing behavior for individual property and quantity updates.
  * Empty property sets now remain correctly represented.

* **Tests**
  * Added coverage for property-set and quantity-set creation, mutation round trips, and individual quantity updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->