### PR TITLE
test(ifcx): pin parseV5aKey's rejection of malformed third-party keys

### DIFF
--- a/packages/ifcx/src/property-extractor.test.ts
+++ b/packages/ifcx/src/property-extractor.test.ts
@@ -7,6 +7,7 @@ import assert from 'node:assert';
 import { StringTable, QuantityType } from '@ifc-lite/data';
 import { parseIfcx } from './index.js';
 import { extractProperties } from './property-extractor.js';
+import { parseV5aKey } from './types.js';
 import type { ComposedNode, IfcxFile } from './types.js';
 
 function createNode(path: string): ComposedNode {
@@ -183,5 +184,44 @@ describe('extractProperties — typed records and internal carriers (#1031)', ()
     const netArea = all.find((q) => q.name === 'NetArea');
     assert.ok(netArea, `NetArea present in quantity table (got ${JSON.stringify(qsets)})`);
     assert.strictEqual(netArea.value, 12.5);
+  });
+});
+
+describe('parseV5aKey — malformed keys from third-party ifcx files', () => {
+  /**
+   * `parseV5aKey` splits `bsi::ifc::v5a::<Set>::<Prop>`. Its `sep <= 0` guard
+   * rejects an EMPTY set name (`bsi::ifc::v5a::::Name`, where the separator
+   * sits at index 0). Relaxing that to `sep < 0` survived the whole 109-test
+   * suite -- nothing pinned the empty-set-name case.
+   *
+   * It matters because this parses attribute keys out of an .ifcx document,
+   * which may come from another tool: `property-extractor.ts:110`/`:232` and
+   * `index.ts:376` all feed it third-party content. No writer in THIS repo
+   * emits a doubled separator, but the guard exists for input we did not
+   * write -- without it a malformed key yields a property set named '' that
+   * then flows on into the property and quantity tables.
+   */
+  it('rejects a v5a key whose set name is empty', () => {
+    assert.strictEqual(parseV5aKey('bsi::ifc::v5a::::NetArea'), null);
+  });
+
+  /**
+   * Control: a well-formed key must still parse, so the guard above cannot be
+   * satisfied by rejecting everything.
+   */
+  it('still parses a well-formed v5a key', () => {
+    assert.deepStrictEqual(parseV5aKey('bsi::ifc::v5a::Qto_WallBaseQuantities::NetArea'), {
+      setName: 'Qto_WallBaseQuantities',
+      name: 'NetArea',
+    });
+  });
+
+  /**
+   * The trailing-separator form has an empty MEMBER name and is rejected by
+   * the same condition's upper bound. Pinned alongside so the two halves of
+   * that guard are not left leaning on each other.
+   */
+  it('rejects a v5a key whose member name is empty', () => {
+    assert.strictEqual(parseV5aKey('bsi::ifc::v5a::Qto_WallBaseQuantities::'), null);
   });
 });


### PR DESCRIPTION
`parseV5aKey` splits `bsi::ifc::v5a::<Set>::<Prop>` and guards with `sep <= 0 || sep >= rest.length - 2`. Relaxing that to `sep < 0` — accepting an **empty set name** from `bsi::ifc::v5a::::Name`, where the separator sits at index 0 — survived the whole 109-test suite.

## Why this one is worth pinning, when most unreachable branches are not

A mutation pass over this package flagged the branch and set it aside as *"requires a malformed key that no writer in this repo emits"*. That is true, and for a parser of third-party files it is the wrong reachability test.

This parses attribute keys out of an `.ifcx` document, which may have been written by another tool — `property-extractor.ts:110` and `:232`, and `index.ts:376`, all feed it content we did not produce. **The guard exists precisely for input our own writers never emit.** Without it, a malformed key yields a property set named `''` which then flows on into the property and quantity tables.

It is the same shape as the `.iflx` path-traversal guard in #2262: a defensive check on untrusted input, correct today, with nothing stopping it silently becoming wrong.

## The tests

- **empty set name** — the case the mutation exposed
- **trailing separator** (`...::Set::`, an empty *member* name) — caught by the same condition's upper bound, pinned alongside so the two halves of that guard are not left leaning on each other
- **a well-formed key**, as a control — otherwise the guard could be satisfied by rejecting everything

## Verification

- The `sep < 0` mutation now fails exactly `rejects a v5a key whose set name is empty` (1 replacement, count asserted, mutated line re-read); restoring returns the suite to green.
- **109 → 112** passing across 11 files. `tsc --noEmit` clean.
- Note `packages/ifcx` runs `tsx --test`, not vitest — running the wrong one here prints nothing at all and reads exactly like a pass.

Test-only; no changeset.

## Also audited, no findings

The rest of `packages/ifcx` and all of `packages/spatial`. The write/read pairs in `writer.ts`, `property-extractor.ts` (including the v5a routing between properties and quantities, and the custom-set typed-vs-raw split) and `geometry-extractor.ts` are already densely pinned, several with doc comments referencing real bugs from earlier rounds (#1031 typed-property round-trip, dedupe-key collapsing, homogeneous-w validation). That area reads as mature.

One other survivor was found and deliberately **not** shipped: swapping the `byBuilding`/`bySite` fallback order in `writer.ts:246`. The four spatial-hierarchy maps are populated by entity type, so an id can structurally key only one of them — a storey cannot also be a building. The ordering is genuinely unobservable with real data, so a test there would pin nothing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for parsing v5a property keys.
  * Verified malformed keys with empty set or member names are rejected.
  * Confirmed well-formed property keys continue to parse correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->