### PR TITLE
test(pointcloud): pin the two E57 DataPacket header guards

### DIFF
--- a/packages/pointcloud/src/formats/e57.test.ts
+++ b/packages/pointcloud/src/formats/e57.test.ts
@@ -426,6 +426,71 @@ describe('decodeE57Scan (uncompressed Float64)', () => {
     expect(chunk.positions[4]).toBe(0x3);
     expect(chunk.positions[5]).toBe(0x5);
   });
+
+  it('rejects a DataPacket whose declared length runs past the logical buffer', () => {
+    // Mutation testing: `decodeE57Packet`'s `packetEnd > logical.length`
+    // check (e57-decode.ts) had zero coverage — every existing packet
+    // fixture in this file declares a packetLength that matches its own
+    // buffer size exactly, so the guard was never exercised in either
+    // direction. Disabling the guard left the full suite green.
+    //
+    // A corrupt/hostile file can set the packetLength field (u16 LE at
+    // offset 2-3) to any value up to 65536 regardless of how much data
+    // actually follows. Without this guard, the bytestream-length-table
+    // walk uses that inflated `payloadEnd` as its bound instead of the
+    // real buffer end, so a short bytestream length can slip through the
+    // per-field bounds check and the packet is treated as valid — either
+    // silently truncating output or surfacing as an unrelated RangeError
+    // deep in the decode loop instead of this clear diagnostic.
+    const logical = new Uint8Array(20);
+    const view = new DataView(logical.buffer);
+    view.setUint8(0, 1); // packetType = data
+    view.setUint8(1, 0); // flags
+    view.setUint16(2, 199, true); // packetLogicalLength - 1 => declared length 200
+    view.setUint16(4, 3, true); // bytestreamCount (matches prototype length)
+
+    const entry: Data3DEntry = {
+      guid: 'test',
+      recordCount: 1,
+      binaryFileOffset: 0,
+      prototype: [
+        { name: 'cartesianX', kind: 'Float', precision: 'double' },
+        { name: 'cartesianY', kind: 'Float', precision: 'double' },
+        { name: 'cartesianZ', kind: 'Float', precision: 'double' },
+      ],
+    };
+    expect(() => decodeE57Scan(logical, entry)).toThrow(/runs past end of logical/i);
+  });
+
+  it('rejects a DataPacket whose bytestreamCount does not match the prototype length', () => {
+    // Mutation testing: `decodeE57Packet`'s `bytestreamCount !==
+    // prototype.length` check had zero coverage — the only fixture that
+    // mentions "bytestreamCount" is a doc comment describing the packet
+    // layout, not an assertion. Disabling the guard left the full suite
+    // green.
+    //
+    // Without this guard a corrupt bytestreamCount field makes the
+    // length-table walk read the wrong number of u16 entries, misaligning
+    // every subsequent bytestream offset against the actual field layout.
+    const logical = new Uint8Array(6);
+    const view = new DataView(logical.buffer);
+    view.setUint8(0, 1); // packetType = data
+    view.setUint8(1, 0); // flags
+    view.setUint16(2, 5, true); // packetLogicalLength - 1 => declared length 6 (matches buffer)
+    view.setUint16(4, 99, true); // bytestreamCount — does not match prototype.length (3)
+
+    const entry: Data3DEntry = {
+      guid: 'test',
+      recordCount: 1,
+      binaryFileOffset: 0,
+      prototype: [
+        { name: 'cartesianX', kind: 'Float', precision: 'double' },
+        { name: 'cartesianY', kind: 'Float', precision: 'double' },
+        { name: 'cartesianZ', kind: 'Float', precision: 'double' },
+      ],
+    };
+    expect(() => decodeE57Scan(logical, entry)).toThrow(/bytestreamCount \(99\) ≠ prototype length \(3\)/);
+  });
 });
 
 describe('parseE57Xml (worker-safe; no DOMParser dependency)', () => {


### PR DESCRIPTION
`decodeE57Packet` validates two things a hostile or corrupt E57 file can lie about in its packet header. **Neither was exercised.**

| guard | disabled → |
|---|---|
| `packetEnd > logical.length` — declared `packetLength` running past the buffer | suite stayed green (144 passed) |
| `bytestreamCount !== prototype.length` — packet claiming a different bytestream count than its prototype | suite stayed green |

No fixture ever built a packet that lied in either direction, so both guards were dead to the suite.

## Bounded, not assumed

A survivor is consistent with "this guard is unpinned" *or* "nothing in this file is reached". So I disabled the sibling `availableBytes <= 0 || entry.recordCount > availableBytes * 8` guard as a control: it killed 2 existing tests immediately. The harness reaches this file fine — these two specifically were unpinned.

## Severity: coverage gap, and the distinction was traced rather than guessed

It would be easy to call a disabled bounds check on untrusted binary a security issue. It is not, and the reason is worth stating: **JS TypedArrays and DataViews bounds-check every read**, so a disabled guard cannot produce out-of-bounds access. The realistic worst case is a *less informative* error — `truncated bytestream length table` instead of the specific diagnostic — or, near EOF, a silent trim indistinguishable from the already-supported "file under-reports records" fallback.

I could not make any decoded output observably wrong, so there is **no source change here** — only the tests that stop these guards silently disappearing.

## One false-coverage signal worth recording

Grepping for `bytestreamCount` *looked* like the second guard was already covered. The hit was a **doc comment** describing the packet byte layout, not an assertion. Reading the match context is what settled it — the same shape as the `.iflx` control-char test in #2262 that pointed at a guard it never reached.

## Verification

- Each mutation applied with an asserted replacement count and re-run by hand: each kills exactly one of the two new tests, and restoring returns the suite to green.
- `packages/pointcloud`: **144 → 146** passing (2 skipped unchanged) across 16 files. `tsc --noEmit` clean.
- `packages/encoding` audited in the same pass — unchanged at 56 passing, no findings.

Test-only; no changeset.

## Also audited, no findings

Every file in `packages/pointcloud/src/formats/` (las, pcd, ply, ascii-points, e57-page, e57-xml) and the streaming sources (las-source, laz-source, e57-source, blob-source), plus `packages/encoding/src/ifc-string.ts`. PCD and PLY in particular had **zero** surviving mutations on every length and count guard tried — they already carry explicit attacker-scenario comments and OOM-guard tests from earlier rounds.

Grepped `packetLength|packetEnd|bytestreamCount` across the package: they appear only in the three E57 files already reviewed, so this shape is not repeated elsewhere.