### PR TITLE
test(lists): pin toScheduleRows' leaf-level fallback for hand-built groups

### DIFF
--- a/packages/lists/src/engine.test.ts
+++ b/packages/lists/src/engine.test.ts
@@ -972,6 +972,22 @@ describe('toScheduleRows', () => {
     const rows = toScheduleRows([{ key: 'k', label: 'Solo', count: 4, sums: {}, level: 0 }], 1);
     expect(rows).toEqual([{ key: 'k', path: ['Solo'], count: 4, sums: {} }]);
   });
+
+  it('a hand-built group with `level` omitted derives it from `path.length - 1`, not `path.length`', () => {
+    // `level` is optional on the public ListGroup type; `summariseListRows`
+    // always fills it, but a caller assembling groups by hand (the
+    // documented "hand-built multi-level set" case) may only supply `path`.
+    // For a 3-level tuple ['A','B','C'], the leaf level is 2 (path.length -
+    // 1), matching `levelCount=3`'s `leafLevel = levelCount - 1 = 2`. Using
+    // `path.length` (3) instead would never equal `leafLevel`, so every
+    // hand-built leaf group would be filtered out and the schedule would
+    // come back empty.
+    const rows = toScheduleRows(
+      [{ key: groupPathKey(['A', 'B', 'C']), label: 'C', count: 2, sums: {}, path: ['A', 'B', 'C'] }],
+      3,
+    );
+    expect(rows).toEqual([{ key: groupPathKey(['A', 'B', 'C']), path: ['A', 'B', 'C'], count: 2, sums: {} }]);
+  });
 });
 
 describe('listResultToCSV', () => {


### PR DESCRIPTION
`toScheduleRows` filters groups to the leaf level with `g.level ?? (g.path ? g.path.length - 1 : 0)`. Changing that fallback to `g.path.length` — off by one, so nothing matches the leaf and the pivot returns empty — **survived all 151 tests**.

Every existing test supplies an explicit `level`, so `??` short-circuits and the fallback arithmetic was never evaluated.

## Why pin a branch nothing internal reaches

Because of who *does* reach it. `toScheduleRows` is exported from the package index, and the code's own comment says exactly why the fallback is there:

> a hand-built multi-level set (the public API allows one — `summariseListRows` always fills `level` in) would match no leaf at all and pivot to nothing

So the branch is defensive for callers outside this repo. Its being unreachable from our own producer is not grounds to leave it unpinned — the same reasoning as the `parseV5aKey` guard in #2264.

The converse also came up in this round and I want to be clear I applied it: a genuinely unreachable-by-construction branch is *not* worth a test. In #2264 I skipped one for exactly that reason. The distinction is whether anything outside our own writers can get there.

## Severity: coverage gap

`summariseListRows` is the only in-repo producer of `ListGroup` and always fills `level`, so shipped behaviour is correct today. Nothing here changes production code.

## Bounded, not assumed

The sibling `g.path ?? [g.label]` fallback on the very next line **does** die under its own mutation, so the harness genuinely reaches `engine.ts`. This branch specifically was unpinned, rather than the file being dead to the suite.

## Verification

- One test: a hand-built 3-level `ListGroup` carrying `path` and no `level`, asserting the leaf row is produced.
- Re-ran the mutation by hand: it fails the new test with `expected [] to deeply equal [...]`; restoring returns the suite green.
- `packages/lists` **151 → 152** across 7 files; `tsc --noEmit` clean.
- `packages/data` audited in the same pass — **no findings**, unchanged at 127 passing across 11 files. Its quantity/property/relationship/storey-elevation tables already carry pins for the asymmetric read/write pairs, tie-breaks and null handling from earlier rounds.

Test-only; no changeset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression coverage to verify schedule rows are generated correctly for groups without an explicit level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->