### PR TITLE
test(cache): pin the quantity formula NULL sentinel across a cache round trip

### DIFF
--- a/packages/cache/src/sections/quantities.test.ts
+++ b/packages/cache/src/sections/quantities.test.ts
@@ -33,6 +33,45 @@ function roundTrip(strings: StringTable, table: ReturnType<typeof buildFixture>[
   return readQuantities(new BufferReader(writer.build()), strings);
 }
 
+describe('cache QuantityTable formula round-trip', () => {
+  // `formula` was written/read (writeQuantities/readQuantities) but no cache
+  // test ever asserted it survived the round-trip: a mutation changing the
+  // read-side "no formula" sentinel check from `> 0` to `>= 0` (which would
+  // make every row with no formula answer the *first* interned string instead
+  // of `undefined`, since the 0 slot is `formula`'s explicit "unset" value —
+  // see `@ifc-lite/data`'s `quantityTableFromColumns`) still passed the full
+  // suite. This pins both the present and absent cases.
+  it('preserves a present formula and answers undefined when none was set', () => {
+    const strings = new StringTable();
+    const builder = new QuantityTableBuilder(strings);
+    builder.add({
+      entityId: 1,
+      qsetName: 'Qto_WallBaseQuantities',
+      quantityName: 'NetArea',
+      quantityType: QuantityType.Area,
+      value: 10,
+      formula: 'Length * Height',
+    });
+    builder.add({
+      entityId: 2,
+      qsetName: 'Qto_WallBaseQuantities',
+      quantityName: 'GrossVolume',
+      quantityType: QuantityType.Volume,
+      value: 5,
+    });
+    const table = builder.build();
+    const restored = roundTrip(strings, table);
+
+    const qsets = restored.getForEntity(1);
+    const netArea = qsets[0].quantities.find((q) => q.name === 'NetArea');
+    expect(netArea?.formula).toBe('Length * Height');
+
+    const qsets2 = restored.getForEntity(2);
+    const grossVolume = qsets2[0].quantities.find((q) => q.name === 'GrossVolume');
+    expect(grossVolume?.formula).toBeUndefined();
+  });
+});
+
 describe('cache QuantityTable.sumByType', () => {
   it('sums across entities when no elementType is given (unfiltered)', () => {
     const { strings, table } = buildFixture();


### PR DESCRIPTION
`formula[idx] > 0 ? strings.get(...) : undefined` uses **0 as the "no formula" sentinel**. Relaxing it to `>= 0` — so an absent formula reads back as the empty string at index 0 instead of `undefined` — survived the whole suite.

Nothing exercised the field. Grepping `formula` across `quantities.test.ts` and `cache.test.ts` returned **no hits at all**, so the sentinel was never round-tripped in either direction.

One test, round-tripping a quantity that *has* a formula alongside one that does not, so both halves of the sentinel are pinned rather than only the present case.

**Severity: coverage gap.** The `> 0` convention is copied verbatim from `@ifc-lite/data`'s `quantityTableFromColumns` (`packages/data/src/quantity-table.ts:175`) and the cache matches it exactly, so shipped behaviour is correct today.

## The more useful result is the negative one

I picked this package because it is a **writer/reader pair by construction**, and every real data-loss bug found in this codebase today was a writer and a reader disagreeing about a shape — an empty-array gate read differently than written, a whole-set record read as if it were per-member, a length written but a different one trusted.

So the round did a full field inventory across `header`, `strings`, `entities`, `properties`, `quantities`, `relationships`, `entity-index`, `geometry` / `geometry-chunks`, `instanced-shards` and `glb`:

- Every field the writer emits has a matching reader field **in the same order**, including all the optional flag-gated ones — `wasmRtcOffset`, `buildingRotation`, per-mesh `origin`, `geometryClass`, `ifcType`, the GLB strided-accessor path, the instanced-shard truncation guards.
- Nothing written-but-never-read, nothing read-but-never-written.
- No count or length written without a matching reader check.

And it is not merely asserted. Four deliberate **field-order swaps** were run as controls and all died immediately:

| swap | result |
|---|---|
| relationships `edgeRelIds` / `edgeTypes` | died |
| entity-index `byteOffsets` / `byteLengths` | died |
| geometry-chunk directory `meshCount` / `uncompressedLength` | died — `chunk decoded to N bytes, directory says M` |
| properties `psetIndex` / `entityIndex` | died |

So the round-trip coverage there is real, not incidental.

One consistent no-op noted rather than flagged: `CacheEntityRef.lineNumber` is computed in `normalizeRef` and serialised by neither side — symmetric, so not a mismatch.

## Verification

- Mutation applied with an asserted replacement count and re-run by hand: it kills exactly the new test, and restoring returns the suite green.
- `packages/cache` **65 → 66** passing across 9 files. `tsc --noEmit` clean.

Test-only; no changeset.
