### PR TITLE
test(wasm): pin the Z-up to Y-up conversion on origin, bounds and placement

### DIFF
--- a/rust/wasm-bindings/src/zero_copy/mesh_tests.rs
+++ b/rust/wasm-bindings/src/zero_copy/mesh_tests.rs
@@ -155,3 +155,53 @@ fn new_converts_zup_to_yup_for_positions_and_normals() {
     assert_eq!(md.positions, vec![1.0, 3.0, -2.0]);
     assert_eq!(md.normals, vec![0.0, 0.0, -1.0]);
 }
+
+/// `MeshDataJs::new` must apply the SAME IFC Z-up -> WebGL Y-up swap to
+/// `origin`, `local_bounds` and `local_to_world` as it does to `positions`
+/// (issue #1474). Nothing previously pinned this: a mutation dropping any of
+/// the three swaps (origin left un-swapped, local_bounds passed through
+/// unconverted, local_to_world left un-conjugated) survived the full suite —
+/// `world = origin + position` would then mix axes and every consumer of
+/// `localBounds`/`localToWorld` would receive IFC-frame data in a Y-up scene
+/// (mirrored / displaced local-frame geometry).
+#[test]
+fn new_converts_origin_local_bounds_and_local_to_world_to_yup() {
+    let mut mesh = Mesh::new();
+    mesh.positions = vec![0.0, 0.0, 0.0];
+    mesh.normals = vec![0.0, 0.0, 1.0];
+    mesh.indices = vec![0, 0, 0];
+    // origin: IFC (x,y,z) -> Y-up (x,z,-y)
+    mesh.origin = [10.0, 20.0, 30.0];
+    // local_bounds: [minx,miny,minz,maxx,maxy,maxz], IFC frame
+    mesh.local_bounds = Some([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    // local_to_world: identity except a translation, so the swap is easy to
+    // verify by hand: the translation column (row-major, col 3) is the same
+    // per-component (x,z,-y) swap as `origin`.
+    #[rustfmt::skip]
+    let m = [
+        1.0, 0.0, 0.0, 100.0,
+        0.0, 1.0, 0.0, 200.0,
+        0.0, 0.0, 1.0, 300.0,
+        0.0, 0.0, 0.0, 1.0,
+    ];
+    mesh.local_to_world = Some(m);
+
+    let md = MeshDataJs::new(1, "IfcWall".to_string(), mesh, [1.0, 1.0, 1.0, 1.0]);
+
+    // origin: (10, 20, 30) -> (10, 30, -20)
+    assert_eq!(md.origin, [10.0, 30.0, -20.0]);
+
+    // local_bounds: min_y/max_y swap-and-negate onto the new Z, per
+    // `swap_zup_to_yup_aabb` (NOT a plain per-component swap).
+    assert_eq!(
+        md.local_bounds,
+        Some([1.0, 3.0, -5.0, 4.0, 6.0, -2.0]),
+        "local_bounds must go through the AABB-corner swap, not a per-component one"
+    );
+
+    // local_to_world translation column: (100, 200, 300) -> (100, 300, -200),
+    // the same swap as a plain point, confirming M' = S*M*S^T carries the
+    // translation through correctly for this diagonal-plus-translation case.
+    let ltw = md.local_to_world.expect("local_to_world set");
+    assert_eq!([ltw[3], ltw[7], ltw[11]], [100.0, 300.0, -200.0]);
+}

--- a/rust/wasm-bindings/src/zero_copy/mesh_tests.rs
+++ b/rust/wasm-bindings/src/zero_copy/mesh_tests.rs
@@ -174,15 +174,25 @@ fn new_converts_origin_local_bounds_and_local_to_world_to_yup() {
     mesh.origin = [10.0, 20.0, 30.0];
     // local_bounds: [minx,miny,minz,maxx,maxy,maxz], IFC frame
     mesh.local_bounds = Some([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
-    // local_to_world: identity except a translation, so the swap is easy to
-    // verify by hand: the translation column (row-major, col 3) is the same
-    // per-component (x,z,-y) swap as `origin`.
+    // local_to_world: a 90° rotation about Z plus a translation.
+    //
+    // The rotation block must be NON-IDENTITY and NON-SYMMETRIC, and both
+    // properties are load-bearing:
+    //
+    //   * identity rotation makes `S·M·Sᵀ` and `S·M` produce the SAME
+    //     translation column, so a translation-only assertion cannot tell
+    //     them apart — dropping the right factor leaves every rotated
+    //     placement wrong by a factor of `Sᵀ` while the test stays green;
+    //   * a SYMMETRIC rotation makes `S·M·Sᵀ` and `Sᵀ·M·S` identical, which
+    //     would trade one blind spot for another.
+    //
+    // 90° about Z is the smallest fixture with neither property.
     #[rustfmt::skip]
     let m = [
-        1.0, 0.0, 0.0, 100.0,
-        0.0, 1.0, 0.0, 200.0,
-        0.0, 0.0, 1.0, 300.0,
-        0.0, 0.0, 0.0, 1.0,
+        0.0, -1.0, 0.0, 100.0,
+        1.0,  0.0, 0.0, 200.0,
+        0.0,  0.0, 1.0, 300.0,
+        0.0,  0.0, 0.0, 1.0,
     ];
     mesh.local_to_world = Some(m);
 
@@ -199,9 +209,23 @@ fn new_converts_origin_local_bounds_and_local_to_world_to_yup() {
         "local_bounds must go through the AABB-corner swap, not a per-component one"
     );
 
-    // local_to_world translation column: (100, 200, 300) -> (100, 300, -200),
-    // the same swap as a plain point, confirming M' = S*M*S^T carries the
-    // translation through correctly for this diagonal-plus-translation case.
+    // All 16 elements, not just the translation column. Derived by hand from
+    // `M' = S·M·Sᵀ` with S: (x,y,z) -> (x,z,-y):
+    //
+    //   S·R  = [[0,-1,0],[0,0,1],[-1,0,0]]
+    //   S·R·Sᵀ = [[0,0,1],[0,1,0],[-1,0,0]]
+    //   S·t  = (100, 300, -200)
+    //
+    // Each of the four plausible wrong forms produces a DIFFERENT rotation
+    // block against this fixture: `M` unconjugated, `S·M`, `M·Sᵀ`, and the
+    // reversed `Sᵀ·M·S`. That is what the identity fixture could not do.
     let ltw = md.local_to_world.expect("local_to_world set");
-    assert_eq!([ltw[3], ltw[7], ltw[11]], [100.0, 300.0, -200.0]);
+    #[rustfmt::skip]
+    let expected = [
+         0.0, 0.0, 1.0,  100.0,
+         0.0, 1.0, 0.0,  300.0,
+        -1.0, 0.0, 0.0, -200.0,
+         0.0, 0.0, 0.0,    1.0,
+    ];
+    assert_eq!(ltw, expected, "local_to_world must be conjugated as S*M*S^T, not merely translated");
 }


### PR DESCRIPTION
`MeshDataJs::new` converts four things from the IFC Z-up frame to the WebGL Y-up frame: positions, the per-element `origin`, the local AABB, and the placement matrix. **Only positions and normals were pinned.**

Dropping the conversion on each of the other three survived all 30 tests:

| field | mutation | result |
|---|---|---|
| `origin` | reduced to a straight copy | survived |
| `local_bounds` | passed through without `swap_zup_to_yup_aabb` | survived |
| `local_to_world` | passed through without the `swap_zup_to_yup_mat4` conjugation | survived |

## Why each one matters for where geometry lands

- **`origin`** — `world = origin + position`. Swap only one side and the frames mix, so the element renders displaced or mirrored.
- **`local_bounds`** — an AABB cannot be swapped component-wise: negating an axis flips which corner is min and which is max. The code already knows this (`swap_zup_to_yup_aabb` exists precisely for it), but nothing checked that it was still being called.
- **`local_to_world`** — needs conjugating, `M' = S·M·Sᵀ`, not copying, because it is expressed in the frame the positions were in *before* conversion.

## Bounded, not assumed

The existing `new_converts_zup_to_yup_for_positions_and_normals` test already kills a sibling mutation on this same constructor, so the module is genuinely reached. These three fields specifically were unpinned, rather than the function being dead to the suite.

## Severity: coverage gap

The arithmetic is correct today. I checked it by hand against the convention used elsewhere in the file:

```
origin  (10,20,30)        -> (10,30,-20)
AABB    [1,2,3,4,5,6]     -> [1,3,-5,4,6,-2]   (corner swap, not per-component)
matrix  translation col   (100,200,300) -> (100,300,-200)
```

## Verification

- Each mutation applied with an asserted replacement count and **re-run by hand**: dropping the `origin` swap and dropping the matrix conjugation each fail the new test independently; restoring returns 31/31.
- `ifc-lite-wasm` lib **30 → 31** passing. `ifc-lite-clash` unchanged at 40 plus 1 doctest — audited in the same pass, no findings.
- Module-size ratchet 4/4. Clippy adds no new lint locations over the crate's pre-existing 13-error nightly baseline (none in the touched file).

Test-only; no changeset.

## Two things found and deliberately not bundled in

**A second gap, flagged rather than fixed.** `api/gpu_meshes/instancing.rs::resolve_batch_occurrences` has a `(occs.len() + 1) >= min_occurrences` threshold with **no tests in the file at all**, and it survives mutation. I cross-checked the `+1` against the `counts` accumulation in `batch.rs` — it matches that convention, so it is correct. Worth its own pass rather than riding along here.

**A structural limit worth recording.** `prepass_sharded.rs`, `batch.rs` and `batch_from_source.rs` are large and untested, but their `#[wasm_bindgen]` entry points call `js_sys` typed-array constructors inline with the logic, so they cannot be invoked from native `cargo test` at all — there is no JS host. Pinning them needs a wasm32 or browser harness, not more mutation work. That is a tooling gap, not a coverage one, and no amount of effort in this method will close it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression coverage for converting mesh origins, bounds, and transforms between IFC Z-up and WebGL Y-up coordinate systems.
  * Validates axis-aligned bounding box corners and non-symmetric transformation matrices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->