### PR TITLE
test(merge): pin the author-kind literal in the human-approval gate

### DIFF
--- a/packages/merge/src/ref-flow-policy-ancestor.test.ts
+++ b/packages/merge/src/ref-flow-policy-ancestor.test.ts
@@ -85,6 +85,17 @@ function manifestLess(data: IfcxNode[]): IfcxFile {
   return withId(bare(data));
 }
 
+/** A publishable layer carrying a provenance manifest with an agent author. */
+function agentAuthored(data: IfcxNode[], intent: string, base: ProvenanceBase | null): IfcxFile {
+  const manifest = createProvenanceManifest({
+    author: { kind: 'agent', principal: 'bot' },
+    intent,
+    base,
+    created: '2026-08-04T00:00:00Z',
+  });
+  return withId(setProvenance(bare(data), manifest));
+}
+
 describe('checkRefPolicy fails closed on a manifest-less candidate', () => {
   /**
    * A candidate with no manifest could be an agent layer with the manifest
@@ -145,6 +156,53 @@ describe('checkRefPolicy fails closed on a manifest-less candidate', () => {
       created: '2026-08-04T01:00:00Z',
     });
     expect(outcome.status).toBe('merged');
+  });
+
+  /**
+   * `checkRefPolicy`'s gate is `manifest === undefined || manifest.author.kind
+   * === 'agent'`. Every test above the manifest-less side only; this fixture
+   * is the agent-with-manifest side, which had NO coverage anywhere in the
+   * repo — a mutation swapping the literal to `'human'` (still fail-closed on
+   * the manifest-less branch, so every other test here keeps passing) made
+   * `pnpm test` fully green. That is exactly the shape the approval gate
+   * exists to stop: an agent-authored, manifest-carrying candidate walking
+   * onto a `requireHumanApproval` ref unattended.
+   */
+  it('refuses an agent-authored candidate WITH a manifest on a requireHumanApproval ref', () => {
+    const store = new MemoryStore();
+    const base = publishable(
+      [{ path: 'wall-1', attributes: { 'bsi::ifc::class': { code: 'IfcWall', uri: 'u' }, [FIRE]: 'REI30' } }],
+      'Base',
+      null,
+    );
+    store.storeLayer(base);
+    store.setRef('protected', {
+      layers: [base.header.id],
+      policy: { requireHumanApproval: true },
+    });
+    const candidate = agentAuthored(
+      [{ path: 'wall-2', attributes: { 'bsi::ifc::class': { code: 'IfcWall', uri: 'u' }, [FIRE]: 'REI90' } }],
+      'Agent draft',
+      null,
+    );
+    store.storeLayer(candidate);
+
+    const refused = mergeIntoRef(store, { candidateId: candidate.header.id, into: 'protected' });
+    expect(refused.status).toBe('policy-failure');
+    if (refused.status !== 'policy-failure') return;
+    expect(refused.reason).toMatch(/human approval/i);
+    expect(store.getRef('protected')?.layers).toEqual([base.header.id]);
+
+    // Control: the same candidate merges once a human approves it — proves
+    // the gate is reachable and not permanently closed.
+    const approved = mergeIntoRef(store, {
+      candidateId: candidate.header.id,
+      into: 'protected',
+      approvedBy: 'bob',
+      principal: 'bob',
+      created: '2026-08-04T01:00:00Z',
+    });
+    expect(approved.status).toBe('merged');
   });
 });
 


### PR DESCRIPTION
`checkRefPolicy`'s fail-closed gate refuses an agent-authored or manifest-less candidate on a ref that requires human approval. **Its author-kind literal was unpinned.**

Flipping `manifest.author.kind === 'agent'` to `'human'` left the entire suite green.

That flip would let an agent-authored candidate carrying a manifest merge onto a protected ref **unattended**, while blocking human-authored ones — precisely inverting the gate this code exists to enforce.

## Why it looked covered

Only one disjunct was ever exercised. `ref-flow-policy-ancestor.test.ts` covered the `manifest === undefined` branch — a manifest-less candidate — and nothing anywhere constructed an **agent-authored candidate with a manifest** against such a ref. `grep -rn "kind: 'agent'" packages/merge/src/*.test.ts` returned zero hits.

So the security-relevant half of the condition was never evaluated, while the gate as a whole appeared tested.

## Severity: coverage gap

The shipped literal is `'agent'`, matching the doc comment's stated intent — behaviour is correct today. What was missing is the guard against it silently inverting.

## The same shape elsewhere is already handled

Worth recording rather than leaving for someone to re-derive: `collab-server/src/layer-registry-route.ts:538-540` notes this exact weakness in a comment — the author kind is *self-asserted*, so an agent claiming to be human would skip the gate — and mitigates it with defence in depth, requiring approval for every candidate on a protected ref regardless of author kind.

So the gap is isolated to the shared `ref-flow.ts` / CLI path and is not duplicated on the server side.

## Verification

Checked both directions by hand rather than taking the run at face value:

- literal flipped + **old** tests → **79/79 pass** (the gate was genuinely unguarded)
- literal flipped + **new** test → fails with `expected 'merged' to be 'policy-failure'`
- restored → 80 passing / 4 skipped across 8 files

Three control mutations died as expected in the same pass, confirming the harness reaches these files: `diff`'s `duplicated`/`deduplicated` group kind (4 tests), `merge`'s three-way `oChanged && !tChanged` guard (15 tests), and `inverse.ts`'s before/after argument order (3 tests — the revert-invariant tests catch it).

`tsc --noEmit` clean. `packages/diff` audited in the same pass — **no findings**, unchanged at 287 passing across 14 files.

Test-only; no changeset.
