### PR TITLE
test(wasm): pin the instancing threshold at its exact boundary

### DIFF
--- a/rust/wasm-bindings/src/api/gpu_meshes/instancing.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/instancing.rs
@@ -146,3 +146,85 @@ fn recover_flat(
         );
     }
 }
+
+#[cfg(test)]
+mod resolve_batch_occurrences_tests {
+    //! Pins the `(occs.len() + 1) >= min_occurrences` instancing-threshold gate at
+    //! its exact boundary. `occs` holds only the don't-bake PLACEHOLDER occurrences
+    //! for a rep group — the batch-local template itself is a separate materialized
+    //! mesh, counted once elsewhere (`batch.rs`'s `counts` accumulation: 1 per
+    //! candidate template + 1 per kept shard occurrence, see lines ~826-850). So the
+    //! `+ 1` here reproduces that template's count so this gate agrees with the
+    //! batch's own tally instead of undercounting by one. A group is kept (routed to
+    //! the instanced shard) exactly when template + placeholders clears
+    //! `min_occurrences`; otherwise every placeholder recovers flat.
+    //!
+    //! With no source registered in `mapped_item_cache`, `recover_flat` no-ops
+    //! (`Some(source)` fails) and contributes nothing to `shard` either way, so
+    //! `shard.len()` alone distinguishes kept (== occs.len()) from not-kept (== 0)
+    //! without needing real bakeable geometry.
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    const MIN_OCCURRENCES: usize = 4;
+    const REP: u128 = 42;
+
+    fn make_occ(express_id: u32) -> RawInstanceOccurrence {
+        RawInstanceOccurrence {
+            express_id,
+            ifc_type: "IfcFlowFitting".to_string(),
+            global_id: None,
+            name: None,
+            presentation_layer: None,
+            color: [1.0, 1.0, 1.0, 1.0],
+            rep_identity: REP,
+            world_transform: [
+                1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+            ],
+        }
+    }
+
+    fn empty_cache() -> SharedMappedItemCache {
+        Arc::new(Mutex::new(FxHashMap::default()))
+    }
+
+    /// Runs `resolve_batch_occurrences` with a single shard-eligible rep group of
+    /// `occ_count` placeholder occurrences and returns the resulting shard length —
+    /// `occ_count` when the group is kept, `0` when it is recovered flat instead.
+    fn shard_len_for(occ_count: u32) -> usize {
+        let raw: Vec<RawInstanceOccurrence> = (0..occ_count).map(make_occ).collect();
+        let mut template_by_rep = FxHashMap::default();
+        template_by_rep.insert(REP, TemplateInfo { eligible: true });
+        let mut recovered_flats = Vec::new();
+        let shard = resolve_batch_occurrences(
+            raw,
+            &template_by_rep,
+            &empty_cache(),
+            [0.0, 0.0, 0.0],
+            MIN_OCCURRENCES,
+            &mut recovered_flats,
+        );
+        shard.len()
+    }
+
+    #[test]
+    fn one_below_threshold_recovers_flat_not_shard() {
+        // occs.len() + 1 == MIN_OCCURRENCES - 1: must NOT be kept.
+        let occ_count = (MIN_OCCURRENCES - 2) as u32;
+        assert_eq!(shard_len_for(occ_count), 0);
+    }
+
+    #[test]
+    fn exactly_at_threshold_is_kept() {
+        // occs.len() + 1 == MIN_OCCURRENCES: the `>=` boundary, must be kept.
+        let occ_count = (MIN_OCCURRENCES - 1) as u32;
+        assert_eq!(shard_len_for(occ_count), occ_count as usize);
+    }
+
+    #[test]
+    fn one_above_threshold_is_kept() {
+        // occs.len() + 1 == MIN_OCCURRENCES + 1: comfortably kept.
+        let occ_count = MIN_OCCURRENCES as u32;
+        assert_eq!(shard_len_for(occ_count), occ_count as usize);
+    }
+}


### PR DESCRIPTION
`resolve_batch_occurrences` decides whether a group of repeated geometry is worth emitting as an instanced template, via `(occs.len() + 1) >= min_occurrences`. **The file had no tests at all**, and both plausible off-by-ones survived:

| mutation | before | after |
|---|---|---|
| drop the `+ 1` → `(occs.len()) >= min_occurrences` | survived 30/30 | dies |
| weaken `>=` → `>` | survived 30/30 | dies |

Either would silently change routing. Too strict and geometry that should be instanced falls back to flat meshes — a performance regression no test would notice. Too loose and a group too small to be worth it gets a template.

## The `+ 1` was verified, not assumed

The obvious reading is that `+ 1` is an off-by-one. It isn't, and the reason is worth recording:

- `all_occurrences`, passed in as `raw`, holds only the **don't-bake placeholder** occurrences. The batch-local template is a separately materialised `MeshData` living in `candidates`/`outputs` — it is not in `occs`.
- `batch.rs`'s authoritative `counts` tally (the one driving the final instance/flat decision at `batch.rs:856`) adds one per materialised candidate mesh — **the template included** — plus one per kept shard occurrence.
- So the template contributes exactly 1 to that tally, independent of `occs.len()`. The gate here reproduces that same arithmetic so the two agree, which is what `batch.rs:844-847`'s comment means by "this only confirms it".

**Severity: coverage gap.** Behaviour is correct today.

## Three tests, at the boundary

A test placed away from a threshold pins nothing, so these sit at it exactly, with `MIN_OCCURRENCES = 4`: group of 3 (below, not kept), 4 (at, kept), 5 (above, kept). The at-threshold case is what catches both mutations.

The signal avoids needing real bakeable geometry: with an empty `mapped_item_cache`, `recover_flat` no-ops on the missing source and never touches `shard`, so `shard.len()` alone separates kept (`== occs.len()`) from not-kept (`== 0`).

## This corrects an assumption from the previous round

The prior pass suspected files in this crate might not be reachable from native `cargo test`. For this one that is **wrong**: `resolve_batch_occurrences` and its `recover_flat` helper touch no `js_sys` or `web-sys` types — only `ifc_lite_processing::{MeshData, RawInstanceOccurrence}` and `ifc_lite_geometry::SharedMappedItemCache`, all plain Rust. The crate's `crate-type = ["cdylib", "rlib"]` builds a native rlib, and sibling files in the same directory (`void_index.rs`, `prepass_discovery.rs`) already carry working `#[cfg(test)]` units.

The genuinely unreachable ones are narrower than stated: specifically those whose `#[wasm_bindgen]` entry points construct `js_sys` typed arrays inline with the logic (`prepass_sharded.rs`, `batch.rs`, `batch_from_source.rs`). Those need a wasm32 or browser harness — a tooling gap, not a coverage one.

## Verification

Both mutations applied with an asserted replacement count and **re-run by hand** before pushing; each fails `exactly_at_threshold_is_kept` and restoring returns the suite green.

- `ifc-lite-wasm` lib **30 → 33** passing.
- Module-size ratchet 4/4 — file grew to 231 lines, inside budget, no split needed.
- Clippy `--all-targets --no-deps -D warnings`, confirmed a fresh run rather than cached: 13 pre-existing lint locations, **none in this file**, zero new.

Test-only; no changeset.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage validating instancing threshold behavior.
  * Confirmed smaller groups avoid shard routing, while groups meeting or exceeding the threshold are retained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->