### PR TITLE
test(collab-server): pin the blob write gate and the named-reviewers gate

### DIFF
--- a/packages/collab-server/test/blob-route.test.ts
+++ b/packages/collab-server/test/blob-route.test.ts
@@ -87,4 +87,55 @@ describe('blob route', () => {
     expect(res.status).toBe(413);
     await handle.stop();
   });
+
+  // Mutation-testing gap: no existing test ever supplies a real
+  // `authenticate` hook and hits `/blobs`, so `makeBlobAuthorizer`'s
+  // `canWrite` gate (viewer/commenter must not PUT or DELETE — only
+  // editor/admin) had zero coverage. Replacing `canWrite(principal)` with
+  // `true` in that branch left the full suite green. Every other check in
+  // this route (401 unauthenticated, 400 malformed hash, 413 oversize) was
+  // already asserted; only this role gate's deny path was not.
+  it('gates PUT/DELETE on editor/admin; viewer reads but cannot write', async () => {
+    const roleForToken = new Map<string, 'viewer' | 'editor'>([
+      ['viewer-token', 'viewer'],
+      ['editor-token', 'editor'],
+    ]);
+    const handle = await startCollabServer({
+      port: 0,
+      authenticate: (token) => {
+        const role = token ? roleForToken.get(token) : undefined;
+        return role ? { userId: token!, role } : null;
+      },
+    });
+    const port = (handle.httpServer.address() as { port: number }).port;
+    const base = `http://127.0.0.1:${port}`;
+    const data = new TextEncoder().encode('viewer cannot write this');
+    const hash = fnv128(data);
+    const asViewer: RequestInit = { headers: { authorization: 'Bearer viewer-token' } };
+    const asEditor: RequestInit = { headers: { authorization: 'Bearer editor-token' } };
+
+    try {
+      // Viewer: PUT is refused before it ever reaches storage.
+      let res = await fetch(`${base}/blobs/${hash}`, { ...asViewer, method: 'PUT', body: data });
+      expect(res.status).toBe(401);
+      // Viewer: reads still work (list gate is read-only, not write-gated).
+      res = await fetch(`${base}/blobs`, asViewer);
+      expect(res.status).toBe(200);
+
+      // Editor: PUT succeeds, then a viewer's DELETE is refused.
+      res = await fetch(`${base}/blobs/${hash}`, { ...asEditor, method: 'PUT', body: data });
+      expect(res.status).toBe(201);
+      res = await fetch(`${base}/blobs/${hash}`, { ...asViewer, method: 'DELETE' });
+      expect(res.status).toBe(401);
+      // The blob is still there — the refused DELETE had no effect.
+      res = await fetch(`${base}/blobs/${hash}`, asViewer);
+      expect(res.status).toBe(200);
+
+      // Editor's DELETE is honored.
+      res = await fetch(`${base}/blobs/${hash}`, { ...asEditor, method: 'DELETE' });
+      expect(res.status).toBe(204);
+    } finally {
+      await handle.stop();
+    }
+  });
 });

--- a/packages/collab-server/test/layer-registry.test.ts
+++ b/packages/collab-server/test/layer-registry.test.ts
@@ -311,6 +311,44 @@ describe('layer registry route', () => {
     }
   });
 
+  it('blocks an outsider posting feedback for the named-reviewers reason, not by accident', async () => {
+    // The test above ('enforces named reviewers...') asserts 403 for a
+    // restricted review too, but its caller IS the layer author — so if the
+    // named-reviewers gate on POST /reviews/:id/feedback were deleted
+    // entirely, that assertion would still pass 403, just from the
+    // self-approval check a few lines later ("layer author ... cannot
+    // approve their own review"). That means the reviewers gate itself had
+    // no test proving it is what's firing. Here the actor ('anonymous', the
+    // default when no `authenticate` hook is wired — see `beforeAll` above)
+    // is a different principal than the layer's author ('alice', the
+    // `publishable` default), so self-approval can never produce a 403: if
+    // this 403 fires, it can only be the reviewers gate.
+    const layer = publishable(
+      [{ path: 'wall-1', attributes: { [CLASS]: { code: 'IfcWall', uri: 'u' } } }],
+      'Outsider-gate probe',
+      null
+    );
+    await push(layer);
+    await fetch(`${api}/refs/outsider-probe`, {
+      method: 'PUT',
+      body: JSON.stringify({ layers: [layer.header.id] }),
+    });
+    const opened = await fetch(`${api}/reviews`, {
+      method: 'POST',
+      body: JSON.stringify({ layer_id: layer.header.id, into: 'outsider-probe', reviewers: ['bob'] }),
+    });
+    const { id } = (await opened.json()) as { id: string };
+    const rejected = await fetch(`${api}/reviews/${id}/feedback`, {
+      method: 'POST',
+      body: JSON.stringify({
+        decisions: [{ entity: 'wall-1', decision: 'accept' }],
+        status: 'approved',
+      }),
+    });
+    expect(rejected.status).toBe(403);
+    expect(((await rejected.json()) as { error: string }).error).toContain('named reviewers');
+  });
+
   it('rejects malformed ref bodies: non-string layers and invalid policy shapes', async () => {
     const badLayers = await fetch(`${api}/refs/bad`, {
       method: 'PUT',


### PR DESCRIPTION
A mutation pass over `collab-server`'s authorization surface — `layer-registry.ts`, `layer-registry-route.ts`, `blob-route.ts` and their wiring in `server.ts`. Roughly a dozen mutations across the ref-policy guards, the manifest-author binding, self-approval, `requireHumanApproval` and the first-write-wins content-conflict guard **all died cleanly**, so that harness is genuinely load-bearing. Two gaps did not.

**No cross-tenant reach found.** Both findings are coverage gaps; production logic is correct today and untouched.

## 1. The blob write-role gate had zero coverage

`server.ts:560` — `if (method === 'PUT' || method === 'DELETE') return canWrite(principal);`

Replacing it with `return true` — opening blob writes to **every** authenticated principal, viewers and commenters included — left the suite fully green at **143/143**. No test anywhere supplied a real `authenticate` hook and hit `/blobs`.

Bounding control, so the survivor is interpretable: the *registry*'s structurally identical write gate at `server.ts:542` was mutated the same way and **was** killed by `registry-room-token.test.ts`. So the harness catches this exact class when a test exists — the blob route simply had none.

New `test/blob-route.test.ts` drives viewer and editor tokens through a per-token `authenticate` mock: viewer reads, viewer cannot write, editor can.

## 2. The named-reviewers gate on `POST /reviews/:id/feedback` passed its only test for the wrong reason

`layer-registry-route.ts:731`. Replacing the condition with `false` — deleting the gate, so **any** principal can post approving feedback on a review that names specific reviewers — also left the suite green at 143/143.

The test that appears to cover it is `layer-registry.test.ts:256`, "enforces named reviewers and blocks self-approval". Its caller is `bot-7`, who is *also the layer's author*. With the reviewers gate deleted the request still returns 403 — but from the **self-approval** check a few lines further down:

```
STATUS 403 {"error":"layer author bot-7 cannot approve their own review"}
```

The assertion is `expect(rejected.status).toBe(403)` with no message check, so the two rejection reasons are indistinguishable to it. The gate was never actually exercised. Notably the same test's self-approval half *does* assert on the message — the reviewers half is the one that doesn't.

Again bounded: the equivalent gate on `POST /reviews/:id/topics` (`:678`) was mutated identically and **was** killed by `layer-registry-topics.test.ts`. So this is specific to the feedback endpoint's test, not a systemic blind spot.

The new test uses the suite's default anonymous actor against a layer authored by a *different* principal, so self-approval can never fire, and asserts the 403 body contains `named reviewers` — pinning the reason, not just the status.

## Verification

Every mutation applied by exact-substring replacement with an asserted replacement count of 1, the mutated line re-read, and restored by file copy. Each re-run by hand before pushing rather than taken from the run:

| | old tests | new tests |
|---|---|---|
| blob gate → `return true` | **143/143 pass** | fails (`201` where `401` expected) |
| reviewers gate → `false` | **143/143 pass** | fails (`200` where `403` expected) |

**145 passing across 31 files** restored (was 143). `tsc --noEmit` clean. `git diff --stat` confirms test-only: two files, +89 lines, no source touched.

Test-only; no changeset.
