### PR TITLE
fix(ifcx): resolve exported child references against real node paths

### DIFF
--- a/.changeset/ifcx-writer-dangling-child-refs.md
+++ b/.changeset/ifcx-writer-dangling-child-refs.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/ifcx": patch
+---
+
+Fix `IfcxWriter` emitting dangling child references in the spatial hierarchy on every plain STEP-IFC → IFCX export.
+
+`collectNodes()` synthesized each entity's own node path via `idToPath?.get(expressId) ?? generatePath(expressId, typeEnum)` (e.g. `ifc:IfcWall.42`), while `getChildrenForEntity()` synthesized the *reference* to that same entity as a child independently, via `idToPath?.get(childId) || 'element:' + childId` (e.g. `element:42`). Whenever `idToPath` was not supplied — which is the normal case; it is only populated on IFCX → IFCX round-trips — the two never agreed, and every emitted `children` entry pointed at a path no node in the file actually had.
+
+The writer now builds a single expressId → path map once while iterating entities in `collectNodes()`, seeded from `idToPath` first (so a child referenced only by id, with no entity row of its own in this file, can still resolve if the caller already knows its path) and filled in with `generatePath()` for every entity. `getChildrenForEntity()` resolves child paths from that same map instead of re-deriving them. A child id with neither an entity row nor an `idToPath` entry is now omitted from `children` rather than emitted as an unresolvable `element:${id}` reference.

--- a/packages/ifcx/src/writer.test.ts
+++ b/packages/ifcx/src/writer.test.ts
@@ -386,12 +386,16 @@ describe('IfcxWriter — node attributes and paths', () => {
 });
 
 describe('IfcxWriter — spatial children', () => {
-  it('resolves containment from each of the four spatial maps', () => {
+  it('resolves containment from each of the four spatial maps, using each child\'s own generated path', () => {
     const { entities, strings } = makeEntities([
       { expressId: 1, typeEnum: TYPE_STOREY },
       { expressId: 2, typeEnum: TYPE_STOREY },
       { expressId: 3, typeEnum: TYPE_STOREY },
       { expressId: 4, typeEnum: TYPE_STOREY },
+      { expressId: 101, typeEnum: TYPE_WALL },
+      { expressId: 102, typeEnum: TYPE_WALL },
+      { expressId: 103, typeEnum: TYPE_WALL },
+      { expressId: 104, typeEnum: TYPE_WALL },
     ]);
     const spatialHierarchy = makeSpatialHierarchy({
       byStorey: new Map([[1, [101]]]),
@@ -402,14 +406,17 @@ describe('IfcxWriter — spatial children', () => {
     const file = parse(new IfcxWriter({ entities, strings, spatialHierarchy }).export().content);
 
     // Each map is consulted in turn; a lookup that stops early silently drops
-    // every element contained by a building, a site or a space.
-    assert.deepStrictEqual(file.data[0].children, { element_101: 'element:101' });
-    assert.deepStrictEqual(file.data[1].children, { element_102: 'element:102' });
-    assert.deepStrictEqual(file.data[2].children, { element_103: 'element:103' });
-    assert.deepStrictEqual(file.data[3].children, { element_104: 'element:104' });
+    // every element contained by a building, a site or a space. The child
+    // path must match the *same* path that child's own node was given
+    // (bug: it used to be synthesized independently as `element:${id}` and
+    // never matched any real node path).
+    assert.deepStrictEqual(file.data[0].children, { element_101: 'ifc:IfcWall.101' });
+    assert.deepStrictEqual(file.data[1].children, { element_102: 'ifc:IfcWall.102' });
+    assert.deepStrictEqual(file.data[2].children, { element_103: 'ifc:IfcWall.103' });
+    assert.deepStrictEqual(file.data[3].children, { element_104: 'ifc:IfcWall.104' });
   });
 
-  it('maps child ids through idToPath when available', () => {
+  it('maps child ids through idToPath when available, and omits a child with neither an entity row nor an idToPath entry', () => {
     const { entities, strings } = makeEntities([{ expressId: 1, typeEnum: TYPE_STOREY }]);
     const spatialHierarchy = makeSpatialHierarchy({ byStorey: new Map([[1, [101, 102]]]) });
     const idToPath = new Map([[102, 'known/child/path']]);
@@ -417,10 +424,35 @@ describe('IfcxWriter — spatial children', () => {
       new IfcxWriter({ entities, strings, spatialHierarchy, idToPath }).export().content
     );
 
+    // 101 has no entity row and no idToPath entry: emitting `element:101`
+    // would be a dangling reference (no node in the file has that path), so
+    // it must be omitted rather than fabricated.
     assert.deepStrictEqual(file.data[0].children, {
-      element_101: 'element:101',
       element_102: 'known/child/path',
     });
+  });
+
+  it('every emitted child reference resolves to an actual node path in the same file (no idToPath supplied)', () => {
+    // This is the STEP-IFC -> IFCX export path: idToPath is normally absent,
+    // and every child must still resolve within the exported file.
+    const { entities, strings } = makeEntities([
+      { expressId: 10, typeEnum: TYPE_STOREY },
+      { expressId: 42, typeEnum: TYPE_WALL },
+    ]);
+    const spatialHierarchy = makeSpatialHierarchy({ byStorey: new Map([[10, [42]]]) });
+    const file = parse(new IfcxWriter({ entities, strings, spatialHierarchy }).export().content);
+
+    const allPaths = new Set(file.data.map((n) => n.path));
+    for (const node of file.data) {
+      for (const childPath of Object.values(node.children ?? {})) {
+        assert.ok(
+          childPath === null || allPaths.has(childPath as string),
+          `dangling child reference: ${childPath} does not match any node path in ${JSON.stringify([...allPaths])}`
+        );
+      }
+    }
+    // Sanity: the containment link was actually exercised.
+    assert.deepStrictEqual(file.data[0].children, { element_42: 'ifc:IfcWall.42' });
   });
 
   it('omits children when there is no spatial hierarchy or no contained elements', () => {
@@ -497,7 +529,7 @@ describe('IfcxWriter.export', () => {
     const file = JSON.parse(result.content);
 
     const wallNode = file.data.find((n: { path: string }) => n.path.includes('101'));
-    assert.deepStrictEqual(wallNode.children, { element_102: 'element:102' });
+    assert.deepStrictEqual(wallNode.children, { element_102: 'ifc:IfcDoor.102' });
   });
 
   it('falls back to bySite when the id is absent from byStorey and byBuilding', () => {
@@ -510,7 +542,7 @@ describe('IfcxWriter.export', () => {
     const file = JSON.parse(result.content);
 
     const wallNode = file.data.find((n: { path: string }) => n.path.includes('101'));
-    assert.deepStrictEqual(wallNode.children, { element_102: 'element:102' });
+    assert.deepStrictEqual(wallNode.children, { element_102: 'ifc:IfcDoor.102' });
   });
 
   it('requests the IFC prop schema import only for bsi::ifc::prop:: keys, not presentation keys', () => {

--- a/packages/ifcx/src/writer.ts
+++ b/packages/ifcx/src/writer.ts
@@ -138,13 +138,35 @@ export class IfcxWriter {
     const nodes: IfcxNode[] = [];
     const { entities, spatialHierarchy, mutationView, idToPath } = this.data;
 
+    // Single source of truth for expressId -> path, built once up front so that
+    // an entity's own path and any *reference* to that entity as a child
+    // (see getChildrenForEntity) can never diverge. Previously the child-ref
+    // path was synthesized independently as `element:${childId}`, which does
+    // not match `ifc:${typeName}.${expressId}` produced by generatePath() and
+    // left every exported child reference dangling whenever idToPath was not
+    // supplied (i.e. every plain STEP-IFC -> IFCX export).
+    //
+    // Seed from idToPath first: on a round-trip it may know the authoritative
+    // path of an id that has no row in this file's entity table at all (e.g.
+    // a node referenced only as someone else's child). Those entries must
+    // survive even though the entity loop below never visits that id.
+    const resolvedPaths = new Map<number, string>(idToPath ?? []);
+    for (let i = 0; i < entities.count; i++) {
+      const expressId = entities.expressId[i];
+      const typeEnum = entities.typeEnum[i];
+      resolvedPaths.set(
+        expressId,
+        idToPath?.get(expressId) ?? this.generatePath(expressId, typeEnum)
+      );
+    }
+
     // Process entities from table
     for (let i = 0; i < entities.count; i++) {
       const expressId = entities.expressId[i];
       const typeEnum = entities.typeEnum[i];
 
       // Get or generate path
-      const path = idToPath?.get(expressId) || this.generatePath(expressId, typeEnum);
+      const path = resolvedPaths.get(expressId) ?? this.generatePath(expressId, typeEnum);
 
       // Get entity name
       const name = this.getString(entities.name[i]);
@@ -186,7 +208,7 @@ export class IfcxWriter {
       };
 
       // Add children based on spatial hierarchy
-      const children = this.getChildrenForEntity(expressId, spatialHierarchy, idToPath);
+      const children = this.getChildrenForEntity(expressId, spatialHierarchy, resolvedPaths);
       if (Object.keys(children).length > 0) {
         node.children = children;
       }
@@ -236,7 +258,7 @@ export class IfcxWriter {
   private getChildrenForEntity(
     entityId: number,
     spatialHierarchy: SpatialHierarchy | undefined,
-    idToPath: Map<number, string> | undefined
+    resolvedPaths: Map<number, string>
   ): Record<string, string | null> {
     const children: Record<string, string | null> = {};
 
@@ -250,7 +272,13 @@ export class IfcxWriter {
 
     if (containedElements) {
       for (const childId of containedElements) {
-        const childPath = idToPath?.get(childId) || `element:${childId}`;
+        // Resolve from the same expressId -> path map used to assign the
+        // child's own node path, so a child reference can never point at a
+        // path no node in this file actually has. If the child id has no
+        // corresponding entity row (e.g. a dangling relationship in the
+        // source data), skip it rather than emit an unresolvable reference.
+        const childPath = resolvedPaths.get(childId);
+        if (childPath === undefined) continue;
         // key = relationship/child name, value = child path
         // (IFCX children = Record<name, path>; null is reserved for removals)
         children[`element_${childId}`] = childPath;


### PR DESCRIPTION
**Every plain STEP-IFC → IFCX export emits a spatial hierarchy in which none of the child references resolve.** Found by mutation-testing the ifcx writer/reader pair; proven by running the writer, not by reading it.

## The defect

`writer.ts` synthesizes paths for the same entity in two independent places, and they disagree:

| | expression | result |
|---|---|---|
| entity's own path (`collectNodes`) | `idToPath?.get(expressId) ?? generatePath(expressId, typeEnum)` | `ifc:IfcWall.42` |
| reference to it as a child (`getChildrenForEntity`) | `idToPath?.get(childId) \|\| 'element:' + childId` | `element:42` |

`idToPath` is only populated on **ifcx → ifcx round-trips**. On every other export — including the primary STEP-IFC → IFCX conversion path — both fall back, and the fallbacks do not match.

Observed by running the writer directly with a single storey containing a single wall:

```
entity paths: ["ifc:IfcElement.10","ifc:IfcElement.42"]
child ref element_42 -> element:42 :: resolves = false
```

**Severity: LIVE.** Consumers reading the exported containment hierarchy find nothing at the referenced paths.

## Why it survived

Two existing tests asserted the broken value *directly*:

```js
assert.deepStrictEqual(file.data[0].children, { element_101: 'element:101' });
```

The dangling path was pinned as expected behaviour, so the bug was load-bearing on its own tests. Both are updated to the resolved path. The new test asserts the **invariant** instead of a literal — every emitted child path must match some node path in the same file — which is what makes it robust to a future change of path format. Against the old code it fails with:

```
dangling child reference: element:42 does not match any node path in
["ifc:IfcBuildingStorey.10","ifc:IfcWall.42"]
```

## The fix

Root cause of the divergence: `getChildrenForEntity` **cannot** call `generatePath` itself, because it does not know the child's `typeEnum` — so it invented a second format. The fix removes the second synthesis point rather than duplicating the first. `collectNodes` builds one `expressId → path` map up front and both readers resolve from it.

Seeded from `idToPath` first, so a child referenced only by id — with no entity row in this file — still resolves when the caller already knows its path. A child with **neither** an entity row nor an `idToPath` entry is now omitted from `children` rather than emitted as an unresolvable reference: no node for it exists in the output, so nothing can legitimately point at it. Silently emitting a broken reference is what this PR fixes; dropping it is the honest alternative, and it is documented at the call site.

## Verification

- old code + new tests → **5 failures** (RED)
- fixed → **110/110** (GREEN)
- reintroducing the `element:${childId}` fallback via exact-substring replace (asserted replacement count 1) → kills exactly the new omission test, 109/110

Restores were done by file copy, never `git checkout`/`restore`/`stash`.

109 → 110 tests across 11 files. `tsc --noEmit` clean. Patch changeset included.

## Separate live defect in the same file — deliberately NOT fixed here

`writer.ts:151` reads the IFC GlobalId into a variable that is never used again:

```js
const globalId = this.getString(entities.globalId[i]);
```

`bsi::ifc::globalId` used to be written, but was removed in `b9929a4ae` as a non-standard IFC5 key — and the removal left the read dead rather than resolving what should replace it. On re-import `entity-extractor.ts:96` uses `node.path` **as** the GlobalId, so a synthesized id silently replaces the authoritative one. Proven the same way: exporting an entity whose GlobalId is `ABC123REALIFCGUID0001` gives `GUID present in output: false`.

`writer.test.ts` populates `globalId` in its row builder (line 66) but never asserts on it anywhere in 557 lines.

@louistrue this one is your call, which is why it is not in this PR. Re-adding the attribute would reverse your deliberate removal, and the obvious alternative — using the GlobalId as the node path when `idToPath` has no entry — changes the exported path format. Both are design decisions rather than bug fixes. Happy to implement whichever you prefer.

Related, unverified: `hierarchy-builder.ts` reads storey `Elevation`/`LongName` from `bsi::ifc::prop::`, but the writer never emits either, even though `SpatialHierarchy` is a writer input. Same shape, flagged for follow-up rather than claimed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed IFCX exports to use correct paths for spatially contained child elements.
  * Preserved provided element paths and generated valid paths when needed.
  * Omitted child references that cannot be resolved, preventing dangling references.
  * Improved containment handling when multiple spatial relationships are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->