### PR TITLE
test(parser): pin the attribute nesting-depth guard

### DIFF
--- a/packages/parser/src/entity-extractor.test.ts
+++ b/packages/parser/src/entity-extractor.test.ts
@@ -43,3 +43,51 @@ describe('EntityExtractor typed-value unwrapping', () => {
     expect(ent?.attributes[2]).toEqual(['IFCREAL', 1.5]);
   });
 });
+
+describe('EntityExtractor MAX_PARSE_DEPTH guard', () => {
+  // parseAttributeValue recurses once per nesting level of a parenthesised
+  // list/typed-value attribute. Unguarded, a hostile or corrupted file can
+  // nest deep enough to blow the JS call stack — verified directly: with the
+  // depth check disabled, a ~200k-deep nested attribute throws
+  // "RangeError: Maximum call stack size exceeded" from inside
+  // parseAttributeValue, which propagates up and is caught by extractEntity's
+  // try/catch — losing the ENTIRE entity (all attributes, including
+  // unrelated sibling values) rather than just the one malformed attribute.
+  // The MAX_PARSE_DEPTH=100 guard localizes the failure: only the
+  // over-nested attribute value is truncated to null; sibling attributes on
+  // the same entity are unaffected.
+
+  /** Build a STEP record whose middle attribute is nested `depth` levels deep: `(((...(#1)...)))`. */
+  function nestedRecord(depth: number): string {
+    const nested = '('.repeat(depth) + '#1' + ')'.repeat(depth);
+    return `#1=IFCPROPERTYSINGLEVALUE('Head',${nested},'Tail');`;
+  }
+
+  /** Descend through nested single-element arrays to the innermost value. */
+  function innermost(value: unknown): unknown {
+    let v = value;
+    while (Array.isArray(v) && v.length === 1) v = v[0];
+    return v;
+  }
+
+  it('parses a 100-level-deep nested attribute fully (at the guard boundary)', () => {
+    const ent = extract(nestedRecord(100));
+    expect(ent).not.toBeNull();
+    expect(ent?.attributes[0]).toBe('Head');
+    expect(ent?.attributes[2]).toBe('Tail');
+    // At exactly MAX_PARSE_DEPTH the innermost #1 reference is still resolved.
+    expect(innermost(ent?.attributes[1])).toBe(1);
+  });
+
+  it('truncates a 101-level-deep nested attribute to null but preserves sibling attributes', () => {
+    const ent = extract(nestedRecord(101));
+    expect(ent).not.toBeNull();
+    // The guard must localize the failure: attributes before/after the
+    // over-nested one are untouched, not lost along with the whole entity.
+    expect(ent?.attributes[0]).toBe('Head');
+    expect(ent?.attributes[2]).toBe('Tail');
+    // One level past the guard, the innermost value is null (truncated),
+    // not the resolved reference `1`.
+    expect(innermost(ent?.attributes[1])).toBeNull();
+  });
+});


### PR DESCRIPTION
`parseAttributeValue` recurses once per nesting level of a parenthesised attribute, guarded at `depth > MAX_PARSE_DEPTH` (100). **Nothing exercised depth at all** — raising the threshold to `MAX_PARSE_DEPTH * 1000` left the suite green at **451/451**.

## What the guard actually buys

Worth stating precisely rather than as "prevents a DoS", because the real answer is narrower and more interesting.

`extractEntity` already wraps extraction in `try/catch` and returns `null` on throw. So an unguarded stack overflow does **not** take the parser down. What it does is lose the **entire entity** — every attribute, including unrelated siblings that parsed perfectly well — because the `RangeError` propagates out of `parseAttributes` and is swallowed at entity level.

The guard downgrades that from whole-entity loss to truncating just the over-nested value to `null`, keeping the rest of the entity intact. That is the behaviour the tests pin: the 101-level case asserts both the truncation **and** that a sibling attribute on the same entity survives.

## Pinned from both sides

A second test asserts a 100-level attribute still resolves fully, so the truncation assertion cannot be satisfied by a guard that fires too eagerly. That test is what makes the first one meaningful — and it is not a duplicate: it **passes** under the weakened mutation, so the two are independent.

## Severity: coverage gap

The shipped guard is correct. `.ifc` input is third-party, so this reject path exists for files we did not write — "no writer in this repo emits 101 levels of nesting" is not a reason to leave it unpinned.

## Verification

- weakened guard + **old** tests → **451/451 pass** (the gap was real)
- weakened guard + **new** tests → fails on the 101-level case (`expected 1 to be null`), and only that one — 452/453
- restored → **453/453**

Mutation applied by exact-substring replacement with an asserted replacement count of 1, mutated line re-read, restored by file copy. Re-run by hand before pushing rather than taken from the run.

451 → 453 tests across 52 files. `tsc --noEmit` clean. Test-only; no changeset.

## Scope note

This package was already swept in #2181 (tokenizer type-cache collision, source-header field swap, `guid.ts` boundary, `ifc-string.ts` `\S\` advance, property-value regex flag, cache section-reader truncation). This is a distinct guard not covered there. `entity-refs-from-index.ts`, `ifczip.ts`'s zip-bomb and image-budget guards, and `decodeIfcString`'s malformed/unterminated/odd-length/non-hex escape handling were all reviewed in the same pass and are **already well covered** — no findings, reported plainly rather than padded.
