### PR TITLE
perf(viewer): run the symbolic-annotation parse in the overlay worker (step 2 of 2 for #2183)

### DIFF
--- a/apps/viewer/src/hooks/useAlignmentLines3D.ts
+++ b/apps/viewer/src/hooks/useAlignmentLines3D.ts
@@ -24,7 +24,7 @@ import { useShallow } from 'zustand/react/shallow';
 import type { IfcDataStore } from '@ifc-lite/parser';
 import { sourceKey } from './source-key.js';
 import { hasEntityType } from './has-entity-type.js';
-import { parseOverlayLines } from '@/lib/overlay-parse';
+import { getWholeSourceForWorker, parseOverlayLines } from '@/lib/overlay-parse';
 
 const EMPTY_F32 = new Float32Array(0);
 
@@ -49,7 +49,7 @@ async function parseAlignmentLinesFor(store: IfcDataStore): Promise<Float32Array
   if (!hasEntityType(store, 'IfcAlignment', 'IfcAlignmentCurve')) return EMPTY_F32;
   // Off the main thread (#2183): this decodes the whole source and grows a
   // WASM heap that never shrinks. See lib/overlay-parse.
-  const verts = await parseOverlayLines('alignment-lines', source);
+  const verts = await parseOverlayLines('alignment-lines', getWholeSourceForWorker(store));
   return verts.length > 0 ? verts : EMPTY_F32;
 }
 

--- a/apps/viewer/src/hooks/useDrawingGeneration.ts
+++ b/apps/viewer/src/hooks/useDrawingGeneration.ts
@@ -27,6 +27,11 @@ import {
 } from '@ifc-lite/drawing-2d';
 import { createMeshOutlineProvider, type MeshOutline2dFn } from './meshOutlineProvider.js';
 import { GeometryProcessor, type GeometryResult } from '@ifc-lite/geometry';
+import { getWholeSourceForWorker, parseSymbolicFlat } from '@/lib/overlay-parse/index.js';
+import {
+  buildSymbolicDrawingLines,
+  type SymbolicDrawingLine,
+} from '@/lib/overlay-parse/symbolic-drawing-lines.js';
 import type { SpatialHierarchy } from '@ifc-lite/data';
 import * as IfcWasm from '@ifc-lite/wasm';
 import { customPlaneCenter } from '@/store';
@@ -135,24 +140,6 @@ export function useDrawingGeneration({
   // Track if this is a regeneration (vs initial generation)
   const isRegeneratingRef = useRef(false);
 
-  // Symbolic lines carry the parent primitive's world-space centroid so the
-  // 2D Section filter below can cull them against the active cut plane —
-  // cardinal axis OR a face-picked custom plane. The drawing-2d package's
-  // DrawingLine has no per-line position slot; attaching the centroid as
-  // extra fields keeps the change local since the canvas ignores anything
-  // beyond DrawingLine's declared fields.
-  //
-  // Coordinate space matches the section cutter's input (shifted bounds):
-  // - worldX: read from the polyline's 2D x (already RTC-shifted by WASM)
-  // - worldZ: -(polyline 2D y) — WASM negates Z into the 2D y axis to
-  //   match section-cut output handedness, so flip back here
-  // - worldY: from the WASM `worldY` accessor (vertical elevation)
-  type SymbolicDrawingLine = DrawingLine & {
-    worldX?: number;
-    worldY?: number;
-    worldZ?: number;
-  };
-
   // Cache for symbolic representations - these don't change with section position
   // Only re-parse when model or display options change
   const symbolicCacheRef = useRef<{
@@ -246,151 +233,26 @@ export function useDrawingGeneration({
             setDrawingProgress(5, 'Parsing symbolic representations...');
           }
 
-          const processor = new GeometryProcessor();
-          try {
-            await processor.init();
-
-            // SymbolicRepresentationCollection and each getPolyline/getCircle
-            // item are wasm-bindgen handles owning WASM memory — free them
-            // deterministically (AGENTS.md §7). Leaking them to GC lets the
-            // FinalizationRegistry free them later against an already-grown/
-            // reused shared dlmalloc heap, corrupting the allocator free-list.
-            const symbolicCollection = processor.parseSymbolicRepresentations(ifcDataStore!.source);
-            // For single-model (legacy) mode, model index is always 0
-            // Multi-model symbolic parsing would require iterating over each model separately
-            const symbolicModelIndex = 0;
-
-            if (symbolicCollection) {
-              try {
-                if (!symbolicCollection.isEmpty) {
-              // Process polylines
-              for (let i = 0; i < symbolicCollection.polylineCount; i++) {
-                const poly = symbolicCollection.getPolyline(i);
-                if (!poly) continue;
-                try {
-
-                entitiesWithSymbols.add(poly.expressId);
-                // poly.points is consumed synchronously within this iteration
-                // (centroid sum + segment pushes read scalar values out of it);
-                // the array itself is never stored, so no copy is needed.
-                const points = poly.points;
-                const pointCount = poly.pointCount;
-                // WASM exposes `worldY` on every symbolic primitive — the
-                // elevation of its parent placement (Z-up IFC, world-Y here).
-                // The .d.ts shipped with the @ifc-lite/wasm package lags
-                // behind the Rust source; read defensively so a stale build
-                // returns undefined instead of throwing.
-                const polyWorldY = (poly as unknown as { worldY?: number }).worldY;
-                // Centroid in shifted world coords — derived from the 2D
-                // points the WASM extractor already emits in section-cut
-                // space. point.x = world X (RTC-shifted); point.y =
-                // -world Z (negated to match cut-output handedness), so
-                // flip the sign back to recover world Z. Computed once
-                // per source polyline and shared across its segments.
-                let sumX = 0;
-                let sumY = 0;
-                for (let p = 0; p < pointCount; p++) {
-                  sumX += points[p * 2];
-                  sumY += points[p * 2 + 1];
-                }
-                const polyWorldX = pointCount > 0 ? sumX / pointCount : undefined;
-                const polyWorldZ = pointCount > 0 ? -sumY / pointCount : undefined;
-
-                for (let j = 0; j < pointCount - 1; j++) {
-                  symbolicLines.push({
-                    line: {
-                      start: { x: points[j * 2], y: points[j * 2 + 1] },
-                      end: { x: points[(j + 1) * 2], y: points[(j + 1) * 2 + 1] }
-                    },
-                    category: 'silhouette',
-                    visibility: 'visible',
-                    entityId: poly.expressId,
-                    ifcType: poly.ifcType,
-                    modelIndex: symbolicModelIndex,
-                    depth: 0,
-                    worldX: polyWorldX,
-                    worldY: polyWorldY,
-                    worldZ: polyWorldZ,
-                  });
-                }
-
-                if (poly.isClosed && pointCount > 2) {
-                  symbolicLines.push({
-                    line: {
-                      start: { x: points[(pointCount - 1) * 2], y: points[(pointCount - 1) * 2 + 1] },
-                      end: { x: points[0], y: points[1] }
-                    },
-                    category: 'silhouette',
-                    visibility: 'visible',
-                    entityId: poly.expressId,
-                    ifcType: poly.ifcType,
-                    modelIndex: symbolicModelIndex,
-                    depth: 0,
-                    worldX: polyWorldX,
-                    worldY: polyWorldY,
-                    worldZ: polyWorldZ,
-                  });
-                }
-                } finally {
-                  poly.free();
-                }
-              }
-
-              // Process circles/arcs
-              for (let i = 0; i < symbolicCollection.circleCount; i++) {
-                const circle = symbolicCollection.getCircle(i);
-                if (!circle) continue;
-                try {
-
-                entitiesWithSymbols.add(circle.expressId);
-                const numSegments = circle.isFullCircle ? 32 : 16;
-                const circleWorldY = (circle as unknown as { worldY?: number }).worldY;
-                // Centre in shifted world coords. circle.centerX is
-                // already RTC-shifted X; circle.centerY carries the
-                // negated Z (see polyline note above) — flip to recover.
-                const circleWorldX = circle.centerX;
-                const circleWorldZ = -circle.centerY;
-
-                for (let j = 0; j < numSegments; j++) {
-                  const t1 = j / numSegments;
-                  const t2 = (j + 1) / numSegments;
-                  const a1 = circle.startAngle + t1 * (circle.endAngle - circle.startAngle);
-                  const a2 = circle.startAngle + t2 * (circle.endAngle - circle.startAngle);
-
-                  symbolicLines.push({
-                    line: {
-                      start: {
-                        x: circle.centerX + circle.radius * Math.cos(a1),
-                        y: circle.centerY + circle.radius * Math.sin(a1),
-                      },
-                      end: {
-                        x: circle.centerX + circle.radius * Math.cos(a2),
-                        y: circle.centerY + circle.radius * Math.sin(a2),
-                      },
-                    },
-                    category: 'silhouette',
-                    visibility: 'visible',
-                    entityId: circle.expressId,
-                    ifcType: circle.ifcType,
-                    modelIndex: symbolicModelIndex,
-                    depth: 0,
-                    worldX: circleWorldX,
-                    worldY: circleWorldY,
-                    worldZ: circleWorldZ,
-                  });
-                }
-                } finally {
-                  circle.free();
-                }
-              }
-                }
-              } finally {
-                symbolicCollection.free();
-              }
-            }
-          } finally {
-            processor.dispose();
-          }
+          // The WASM walk runs in the overlay worker, which is terminated the
+          // moment the job settles (#2183). Running it here instead grew a
+          // main-thread `WebAssembly.Memory` that never shrinks — ~470 MB on a
+          // 342 MB model, pinned for the lifetime of the tab, the first time
+          // the user generated a drawing. Only the flat primitive stream comes
+          // back; `buildSymbolicDrawingLines` is the same walk, transcribed
+          // over those arrays.
+          //
+          // `'all'`, not the overlay's IfcAnnotation/IfcGridAxis filter: the
+          // drawing renders the symbolic representation of every product type.
+          const flat = await parseSymbolicFlat(
+            getWholeSourceForWorker(ifcDataStore!),
+            false,
+            'all',
+          );
+          // Single-model (legacy) mode, so model index is always 0. Multi-model
+          // symbolic parsing would require iterating over each model separately.
+          const symbolic = buildSymbolicDrawingLines(flat, 0);
+          symbolicLines = symbolic.lines;
+          entitiesWithSymbols = symbolic.entities;
 
           // Cache the parsed data
           symbolicCacheRef.current = {

--- a/apps/viewer/src/hooks/useGridLines3D.ts
+++ b/apps/viewer/src/hooks/useGridLines3D.ts
@@ -32,7 +32,7 @@ import { useShallow } from 'zustand/react/shallow';
 import type { IfcDataStore } from '@ifc-lite/parser';
 import { sourceKey } from './source-key.js';
 import { hasEntityType } from './has-entity-type.js';
-import { parseOverlayLines } from '@/lib/overlay-parse';
+import { getWholeSourceForWorker, parseOverlayLines } from '@/lib/overlay-parse';
 
 const EMPTY_F32 = new Float32Array(0);
 
@@ -57,7 +57,7 @@ async function parseGridLinesFor(store: IfcDataStore): Promise<Float32Array> {
   // Off the main thread (#2183). The guard above only helps models with no
   // grid at all; a model with a single IfcGridAxis still paid a full-source
   // decode plus a permanently grown main-thread WASM heap.
-  const verts = await parseOverlayLines('grid-lines', source);
+  const verts = await parseOverlayLines('grid-lines', getWholeSourceForWorker(store));
   return verts.length > 0 ? verts : EMPTY_F32;
 }
 

--- a/apps/viewer/src/hooks/useSymbolicAnnotations.ts
+++ b/apps/viewer/src/hooks/useSymbolicAnnotations.ts
@@ -19,14 +19,15 @@ import { useShallow } from 'zustand/react/shallow';
 import type { IfcDataStore } from '@ifc-lite/parser';
 import { hasEntityType } from './has-entity-type.js';
 import {
+  buildParseResult,
   createEmptyParseResult,
   debugEnabled,
-  parseSymbolicAnnotations,
   type AnnotationFill2D,
   type AnnotationText2D,
   type AnnotationsForStorey,
   type ParseResult,
 } from '../lib/overlay-parse/symbolic-parse.js';
+import { parseSymbolicFlat } from '../lib/overlay-parse/index.js';
 
 // The parse walk itself lives in `lib/overlay-parse/symbolic-parse.ts` so a
 // worker can import it (a worker module cannot import this React hook file).
@@ -70,10 +71,10 @@ function sourceKey(store: IfcDataStore | null | undefined): string | null {
 /**
  * Parse one store's symbolic annotations.
  *
- * The walk itself is `parseSymbolicAnnotations` in
- * `lib/overlay-parse/symbolic-parse.ts`; this wrapper only supplies the
- * entity-index pre-filter, which needs `store.entityIndex` and therefore
- * cannot move with it.
+ * The WASM walk runs in the overlay worker (`lib/overlay-parse`); this
+ * wrapper supplies the entity-index pre-filter, which needs
+ * `store.entityIndex`, and reassembles the flat primitive stream into buckets
+ * with the storey lookups, which never leave the main thread.
  */
 async function parseAnnotations(
   store: IfcDataStore,
@@ -85,15 +86,22 @@ async function parseAnnotations(
   // The scan copies the entire IFC source into the WASM heap on the main thread,
   // so skipping it when there is nothing to find still matters.
   //
-  // Gated on a non-empty source so the missing/empty-source case still falls
-  // through to `parseSymbolicAnnotations`, which reports it as it always did.
   if (source && source.byteLength > 0 && !hasEntityType(store, 'IfcAnnotation', 'IfcGridAxis')) {
     if (debugEnabled()) console.log('[annotations] skip: no IfcAnnotation/IfcGridAxis entities');
     return createEmptyParseResult();
   }
+  if (!source || source.byteLength === 0) {
+    if (debugEnabled()) console.log('[annotations] skip: missing/empty source');
+    return createEmptyParseResult();
+  }
 
-  return parseSymbolicAnnotations({
-    source,
+  // The WASM walk runs in the overlay worker and is terminated afterwards;
+  // running it here grew a main-thread WASM heap that never shrinks, worth
+  // ~471 MB on a 342 MB model (#2183). Only the flat primitive stream crosses
+  // back — bucketing stays here, so the storey lookups never leave the main
+  // thread and `ensureBucket` keeps its exact semantics.
+  const flat = await parseSymbolicFlat(source, debugEnabled());
+  return buildParseResult(flat, {
     elementToStorey: store.spatialHierarchy?.elementToStorey,
     storeyElevations: store.spatialHierarchy?.storeyElevations,
   });

--- a/apps/viewer/src/hooks/useSymbolicAnnotations.ts
+++ b/apps/viewer/src/hooks/useSymbolicAnnotations.ts
@@ -27,7 +27,7 @@ import {
   type AnnotationsForStorey,
   type ParseResult,
 } from '../lib/overlay-parse/symbolic-parse.js';
-import { parseSymbolicFlat } from '../lib/overlay-parse/index.js';
+import { getWholeSourceForWorker, parseSymbolicFlat } from '../lib/overlay-parse/index.js';
 
 // The parse walk itself lives in `lib/overlay-parse/symbolic-parse.ts` so a
 // worker can import it (a worker module cannot import this React hook file).
@@ -100,7 +100,9 @@ async function parseAnnotations(
   // ~471 MB on a 342 MB model (#2183). Only the flat primitive stream crosses
   // back — bucketing stays here, so the storey lookups never leave the main
   // thread and `ensureBucket` keeps its exact semantics.
-  const flat = await parseSymbolicFlat(source, debugEnabled());
+  // `getWholeSourceForWorker` is the single seam for handing a model's bytes
+  // to a worker — see `lib/overlay-parse/source-handoff.ts`.
+  const flat = await parseSymbolicFlat(getWholeSourceForWorker(store), debugEnabled());
   return buildParseResult(flat, {
     elementToStorey: store.spatialHierarchy?.elementToStorey,
     storeyElevations: store.spatialHierarchy?.storeyElevations,

--- a/apps/viewer/src/hooks/useSymbolicAnnotationsForDrawing.classGate.test.tsx
+++ b/apps/viewer/src/hooks/useSymbolicAnnotationsForDrawing.classGate.test.tsx
@@ -78,7 +78,7 @@ function serveFileUrlsFromDiskAndCapture(): void {
   };
 }
 
-let restoreOverlayWorker: (() => void) | undefined;
+let overlayShim: { restore(): void } | undefined;
 
 before(() => {
   serveFileUrlsFromDiskAndCapture();
@@ -86,10 +86,10 @@ before(() => {
   // `Worker`, so without this the hook resolves empty and the positive
   // control below would fail for the wrong reason. The shim runs the real
   // handler across a real structuredClone boundary.
-  restoreOverlayWorker = installInProcessOverlayWorker();
+  overlayShim = installInProcessOverlayWorker();
 });
 after(() => {
-  restoreOverlayWorker?.();
+  overlayShim?.restore();
   restoreFetch?.();
   restoreInstantiateStreaming?.();
 });

--- a/apps/viewer/src/hooks/useSymbolicAnnotationsForDrawing.classGate.test.tsx
+++ b/apps/viewer/src/hooks/useSymbolicAnnotationsForDrawing.classGate.test.tsx
@@ -32,6 +32,7 @@ import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { IfcParser, type IfcDataStore } from '@ifc-lite/parser';
 import { useViewerStore } from '@/store';
+import { installInProcessOverlayWorker } from '@/test/overlay-worker-shim.js';
 import {
   useSymbolicAnnotationsForDrawing,
   symbolicAnnotationsOverlayEnabled,
@@ -77,8 +78,18 @@ function serveFileUrlsFromDiskAndCapture(): void {
   };
 }
 
-before(() => { serveFileUrlsFromDiskAndCapture(); });
+let restoreOverlayWorker: (() => void) | undefined;
+
+before(() => {
+  serveFileUrlsFromDiskAndCapture();
+  // The symbolic parse now runs in the overlay worker (#2183). Node has no
+  // `Worker`, so without this the hook resolves empty and the positive
+  // control below would fail for the wrong reason. The shim runs the real
+  // handler across a real structuredClone boundary.
+  restoreOverlayWorker = installInProcessOverlayWorker();
+});
 after(() => {
+  restoreOverlayWorker?.();
   restoreFetch?.();
   restoreInstantiateStreaming?.();
 });

--- a/apps/viewer/src/lib/overlay-parse/index.ts
+++ b/apps/viewer/src/lib/overlay-parse/index.ts
@@ -19,7 +19,11 @@ import type {
   OverlayParseRequest,
   OverlayParseResponse,
 } from './overlay-parse.worker.js';
-import { createEmptyFlatSymbolic, type FlatSymbolic } from './symbolic-flat.js';
+import {
+  createEmptyFlatSymbolic,
+  type FlatSymbolic,
+  type SymbolicFilterMode,
+} from './symbolic-flat.js';
 
 const EMPTY_F32 = new Float32Array(0);
 
@@ -137,13 +141,18 @@ export async function parseOverlayLines(
  * and the bucketing logic on the main thread where they already live. See
  * `symbolic-flat.ts`.
  *
+ * `mode` picks the owner-type filter: `'overlay'` (the default) for the
+ * annotation overlay, `'all'` for the 2D drawing, which draws the symbolic
+ * representation of every product type. See {@link SymbolicFilterMode}.
+ *
  * Never rejects; resolves to an empty stream on every failure path.
  */
 export async function parseSymbolicFlat(
   source: Uint8Array,
   debug = false,
+  mode: SymbolicFilterMode = 'overlay',
 ): Promise<FlatSymbolic> {
-  const response = await dispatch('symbolic', source, debug);
+  const response = await dispatch('symbolic', source, debug, mode);
   return response && 'flat' in response ? response.flat : createEmptyFlatSymbolic();
 }
 
@@ -152,6 +161,7 @@ async function dispatch(
   kind: OverlayParseKind,
   source: Uint8Array,
   debug?: boolean,
+  mode?: SymbolicFilterMode,
 ): Promise<Extract<OverlayParseResponse, { ok: true }> | null> {
   if (!workerFactory) return null;
   const id = nextRequestId++;
@@ -169,7 +179,7 @@ async function dispatch(
       timer = setTimeout(() => {
         if (pending.has(id)) failAll(`overlay parse timed out after ${JOB_TIMEOUT_MS}ms`);
       }, JOB_TIMEOUT_MS);
-      const request: OverlayParseRequest = { id, kind, source, debug };
+      const request: OverlayParseRequest = { id, kind, source, debug, mode };
       // Never a transfer list. When the source is SAB-backed (the huge-model
       // path, which requires cross-origin isolation) it is shared by
       // reference and transferring would detach the viewer's own copy. When
@@ -194,4 +204,5 @@ async function dispatch(
   }
 }
 
-export type { OverlayParseKind, OverlayLineKind, FlatSymbolic };
+export { getWholeSourceForWorker } from './source-handoff.js';
+export type { OverlayParseKind, OverlayLineKind, FlatSymbolic, SymbolicFilterMode };

--- a/apps/viewer/src/lib/overlay-parse/index.ts
+++ b/apps/viewer/src/lib/overlay-parse/index.ts
@@ -14,10 +14,12 @@
  */
 
 import type {
+  OverlayLineKind,
   OverlayParseKind,
   OverlayParseRequest,
   OverlayParseResponse,
 } from './overlay-parse.worker.js';
+import { createEmptyFlatSymbolic, type FlatSymbolic } from './symbolic-flat.js';
 
 const EMPTY_F32 = new Float32Array(0);
 
@@ -60,11 +62,32 @@ function failAll(message: string): void {
   for (const [id, resolve] of outstanding) resolve({ id, ok: false, error: message });
 }
 
-function ensureWorker(): Worker {
-  if (worker) return worker;
-  const created = new Worker(new URL('./overlay-parse.worker.ts', import.meta.url), {
+type WorkerFactory = () => Worker;
+
+function defaultWorkerFactory(): WorkerFactory | null {
+  if (typeof Worker === 'undefined') return null;
+  return () => new Worker(new URL('./overlay-parse.worker.ts', import.meta.url), {
     type: 'module',
   });
+}
+
+let workerFactory: WorkerFactory | null = defaultWorkerFactory();
+
+/**
+ * Tests only. Lets a test drive the real handler in-process.
+ *
+ * Scoped to this module on purpose: installing a global `Worker` instead
+ * would make `WorkerParser.isSupported()` believe the PARSER can use workers
+ * too, and hand an overlay stub a parse request it cannot answer.
+ */
+export function __setOverlayWorkerFactoryForTest(factory: WorkerFactory | null): void {
+  workerFactory = factory ?? defaultWorkerFactory();
+}
+
+function ensureWorker(): Worker {
+  if (worker) return worker;
+  if (!workerFactory) throw new Error('no Worker implementation available');
+  const created = workerFactory();
   created.onmessage = (event: MessageEvent<OverlayParseResponse>) => {
     const resolve = pending.get(event.data.id);
     if (!resolve) return;
@@ -99,10 +122,38 @@ function releaseWorker(): void {
  * produce them must still load.
  */
 export async function parseOverlayLines(
-  kind: OverlayParseKind,
+  kind: OverlayLineKind,
   source: Uint8Array,
 ): Promise<Float32Array> {
-  if (typeof Worker === 'undefined') return EMPTY_F32;
+  const response = await dispatch(kind, source);
+  return response && 'verts' in response ? response.verts : EMPTY_F32;
+}
+
+/**
+ * Parse the symbolic annotations off the main thread.
+ *
+ * Returns the FLAT primitive stream, not finished buckets: the caller turns it
+ * into a `ParseResult` with `buildParseResult`, which keeps the storey lookups
+ * and the bucketing logic on the main thread where they already live. See
+ * `symbolic-flat.ts`.
+ *
+ * Never rejects; resolves to an empty stream on every failure path.
+ */
+export async function parseSymbolicFlat(
+  source: Uint8Array,
+  debug = false,
+): Promise<FlatSymbolic> {
+  const response = await dispatch('symbolic', source, debug);
+  return response && 'flat' in response ? response.flat : createEmptyFlatSymbolic();
+}
+
+/** Shared request path. Resolves to null on every failure. */
+async function dispatch(
+  kind: OverlayParseKind,
+  source: Uint8Array,
+  debug?: boolean,
+): Promise<Extract<OverlayParseResponse, { ok: true }> | null> {
+  if (!workerFactory) return null;
   const id = nextRequestId++;
   let timer: ReturnType<typeof setTimeout> | undefined;
   inFlight++;
@@ -118,7 +169,7 @@ export async function parseOverlayLines(
       timer = setTimeout(() => {
         if (pending.has(id)) failAll(`overlay parse timed out after ${JOB_TIMEOUT_MS}ms`);
       }, JOB_TIMEOUT_MS);
-      const request: OverlayParseRequest = { id, kind, source };
+      const request: OverlayParseRequest = { id, kind, source, debug };
       // Never a transfer list. When the source is SAB-backed (the huge-model
       // path, which requires cross-origin isolation) it is shared by
       // reference and transferring would detach the viewer's own copy. When
@@ -129,13 +180,13 @@ export async function parseOverlayLines(
     if (!response.ok) {
       // eslint-disable-next-line no-console
       console.warn(`[overlay-parse] ${kind} failed:`, response.error);
-      return EMPTY_F32;
+      return null;
     }
-    return response.verts;
+    return response;
   } catch (error) {
     // eslint-disable-next-line no-console
     console.warn(`[overlay-parse] ${kind} could not start:`, error);
-    return EMPTY_F32;
+    return null;
   } finally {
     clearTimeout(timer);
     pending.delete(id);
@@ -143,4 +194,4 @@ export async function parseOverlayLines(
   }
 }
 
-export type { OverlayParseKind };
+export type { OverlayParseKind, OverlayLineKind, FlatSymbolic };

--- a/apps/viewer/src/lib/overlay-parse/overlay-parse.worker.ts
+++ b/apps/viewer/src/lib/overlay-parse/overlay-parse.worker.ts
@@ -26,29 +26,67 @@
  */
 
 import { GeometryProcessor } from '@ifc-lite/geometry';
-import { buildParseReply } from './reply.js';
+import { buildParseReply, buildSymbolicReply } from './reply.js';
+import { collectFlatSymbolic, createEmptyFlatSymbolic, type FlatSymbolic } from './symbolic-flat.js';
 
-/** Parse kinds this worker can run. Both return a flat line-list. */
-export type OverlayParseKind = 'grid-lines' | 'alignment-lines';
+/** Parse kinds returning a flat line-list. */
+export type OverlayLineKind = 'grid-lines' | 'alignment-lines';
+
+/** Every kind this worker can run. */
+export type OverlayParseKind = OverlayLineKind | 'symbolic';
 
 export interface OverlayParseRequest {
   id: number;
   kind: OverlayParseKind;
   source: Uint8Array;
+  /**
+   * Forwarded from the main thread rather than read here: `debugEnabled()`
+   * reads `localStorage`, which a worker cannot see, so the triage flag
+   * (`IFC_ANNOTATIONS_DEBUG=1`) would silently go dead exactly when someone
+   * is chasing a "no annotations visible" report.
+   */
+  debug?: boolean;
 }
 
 export type OverlayParseResponse =
   | { id: number; ok: true; verts: Float32Array }
+  | { id: number; ok: true; flat: FlatSymbolic }
   | { id: number; ok: false; error: string };
 
-function runParse(
+function runLineParse(
   processor: GeometryProcessor,
-  kind: OverlayParseKind,
+  kind: OverlayLineKind,
   source: Uint8Array,
 ): Float32Array | null {
   return kind === 'grid-lines'
     ? processor.parseGridLines(source)
     : processor.parseAlignmentLines(source);
+}
+
+/**
+ * Flatten the symbolic collection into transferable arrays.
+ *
+ * Only the flatten happens here. Tessellation, text decoding and
+ * storey bucketing stay on the main thread, so the storey lookups never have
+ * to be cloned into this realm and the bucketing logic is not duplicated.
+ */
+function runSymbolicParse(
+  processor: GeometryProcessor,
+  source: Uint8Array,
+  debug: boolean,
+): FlatSymbolic {
+  const collection = processor.parseSymbolicRepresentations(source);
+  if (!collection) return createEmptyFlatSymbolic();
+  const flat = collectFlatSymbolic(collection);
+  if (debug) {
+    // eslint-disable-next-line no-console
+    console.log(
+      `[annotations] parsed ${source.byteLength} bytes → ${flat.polyOwner.length} polylines, `
+      + `${flat.circleOwner.length} circles, ${flat.textOwner.length} texts, `
+      + `${flat.fillOwner.length} fills (after the IfcAnnotation/IfcGridAxis filter)`,
+    );
+  }
+  return flat;
 }
 
 /**
@@ -80,7 +118,7 @@ export function __setProcessorFactoryForTest(factory: (() => GeometryProcessor) 
 }
 
 export async function handle(event: MessageEvent<OverlayParseRequest>): Promise<void> {
-  const { id, kind, source } = event.data;
+  const { id, kind, source, debug } = event.data;
   // Constructed INSIDE the try. If it threw outside, the rejection would
   // escape into the queue's catch, no reply would ever be posted, and the
   // client would sit on its 120s deadline instead of failing immediately.
@@ -88,10 +126,11 @@ export async function handle(event: MessageEvent<OverlayParseRequest>): Promise<
   try {
     processor = createProcessor();
     await processor.init();
-    // `verts` is a fresh JS-heap copy out of WASM (`js_sys::Float32Array::from`
-    // over a Rust slice), not a view into linear memory, so transferring it is
-    // safe and saves a structured clone of the vertex data.
-    const { reply, transfer } = buildParseReply(id, runParse(processor, kind, source));
+    // Every buffer below is a fresh JS-heap allocation, never a view into
+    // linear memory, so transferring is safe and saves a structured clone.
+    const { reply, transfer } = kind === 'symbolic'
+      ? buildSymbolicReply(id, runSymbolicParse(processor, source, debug === true))
+      : buildParseReply(id, runLineParse(processor, kind, source));
     (self as unknown as Worker).postMessage(reply, transfer);
   } catch (error) {
     const reply: OverlayParseResponse = {

--- a/apps/viewer/src/lib/overlay-parse/overlay-parse.worker.ts
+++ b/apps/viewer/src/lib/overlay-parse/overlay-parse.worker.ts
@@ -77,7 +77,17 @@ function runSymbolicParse(
 ): FlatSymbolic {
   const collection = processor.parseSymbolicRepresentations(source);
   if (!collection) return createEmptyFlatSymbolic();
-  const flat = collectFlatSymbolic(collection);
+  // `collectFlatSymbolic` frees each per-primitive handle, but the collection
+  // itself is the caller's to free — and it must happen deterministically.
+  // This worker outlives the job (it serves later ones until the client
+  // terminates it), so leaving the handle to the FinalizationRegistry would
+  // free it later against a grown or reused dlmalloc heap.
+  let flat: FlatSymbolic;
+  try {
+    flat = collectFlatSymbolic(collection);
+  } finally {
+    collection.free();
+  }
   if (debug) {
     // eslint-disable-next-line no-console
     console.log(

--- a/apps/viewer/src/lib/overlay-parse/overlay-parse.worker.ts
+++ b/apps/viewer/src/lib/overlay-parse/overlay-parse.worker.ts
@@ -27,7 +27,12 @@
 
 import { GeometryProcessor } from '@ifc-lite/geometry';
 import { buildParseReply, buildSymbolicReply } from './reply.js';
-import { collectFlatSymbolic, createEmptyFlatSymbolic, type FlatSymbolic } from './symbolic-flat.js';
+import {
+  collectFlatSymbolic,
+  createEmptyFlatSymbolic,
+  type FlatSymbolic,
+  type SymbolicFilterMode,
+} from './symbolic-flat.js';
 
 /** Parse kinds returning a flat line-list. */
 export type OverlayLineKind = 'grid-lines' | 'alignment-lines';
@@ -46,6 +51,12 @@ export interface OverlayParseRequest {
    * is chasing a "no annotations visible" report.
    */
   debug?: boolean;
+  /**
+   * `symbolic` only. Which owner types survive the flatten — the annotation
+   * overlay wants `'overlay'` (the default when absent), the 2D drawing wants
+   * `'all'`. See {@link SymbolicFilterMode}.
+   */
+  mode?: SymbolicFilterMode;
 }
 
 export type OverlayParseResponse =
@@ -74,6 +85,7 @@ function runSymbolicParse(
   processor: GeometryProcessor,
   source: Uint8Array,
   debug: boolean,
+  mode: SymbolicFilterMode,
 ): FlatSymbolic {
   const collection = processor.parseSymbolicRepresentations(source);
   if (!collection) return createEmptyFlatSymbolic();
@@ -84,7 +96,7 @@ function runSymbolicParse(
   // free it later against a grown or reused dlmalloc heap.
   let flat: FlatSymbolic;
   try {
-    flat = collectFlatSymbolic(collection);
+    flat = collectFlatSymbolic(collection, mode);
   } finally {
     collection.free();
   }
@@ -93,7 +105,8 @@ function runSymbolicParse(
     console.log(
       `[annotations] parsed ${source.byteLength} bytes → ${flat.polyOwner.length} polylines, `
       + `${flat.circleOwner.length} circles, ${flat.textOwner.length} texts, `
-      + `${flat.fillOwner.length} fills (after the IfcAnnotation/IfcGridAxis filter)`,
+      + `${flat.fillOwner.length} fills (mode=${mode}`
+      + `${mode === 'overlay' ? ', after the IfcAnnotation/IfcGridAxis filter' : ''})`,
     );
   }
   return flat;
@@ -128,7 +141,7 @@ export function __setProcessorFactoryForTest(factory: (() => GeometryProcessor) 
 }
 
 export async function handle(event: MessageEvent<OverlayParseRequest>): Promise<void> {
-  const { id, kind, source, debug } = event.data;
+  const { id, kind, source, debug, mode } = event.data;
   // Constructed INSIDE the try. If it threw outside, the rejection would
   // escape into the queue's catch, no reply would ever be posted, and the
   // client would sit on its 120s deadline instead of failing immediately.
@@ -139,7 +152,7 @@ export async function handle(event: MessageEvent<OverlayParseRequest>): Promise<
     // Every buffer below is a fresh JS-heap allocation, never a view into
     // linear memory, so transferring is safe and saves a structured clone.
     const { reply, transfer } = kind === 'symbolic'
-      ? buildSymbolicReply(id, runSymbolicParse(processor, source, debug === true))
+      ? buildSymbolicReply(id, runSymbolicParse(processor, source, debug === true, mode ?? 'overlay'))
       : buildParseReply(id, runLineParse(processor, kind, source));
     (self as unknown as Worker).postMessage(reply, transfer);
   } catch (error) {

--- a/apps/viewer/src/lib/overlay-parse/reply.test.ts
+++ b/apps/viewer/src/lib/overlay-parse/reply.test.ts
@@ -7,14 +7,20 @@ import assert from 'node:assert';
 
 import { buildParseReply } from './reply.js';
 
+/** Narrow the widened response union to the line-parse arm. */
+function verts(reply: { ok: boolean } & Record<string, unknown>): Float32Array {
+  if (!('verts' in reply)) throw new Error('expected a line-parse reply');
+  return reply.verts as Float32Array;
+}
+
 describe('buildParseReply', () => {
   it('passes real vertices through and transfers their buffer', () => {
-    const verts = new Float32Array([0, 0, 0, 1, 2, 3]);
-    const { reply, transfer } = buildParseReply(7, verts);
+    const vertsIn = new Float32Array([0, 0, 0, 1, 2, 3]);
+    const { reply, transfer } = buildParseReply(7, vertsIn);
     assert.equal(reply.id, 7);
     assert.equal(reply.ok, true);
-    assert.equal(reply.ok && reply.verts, verts);
-    assert.deepEqual(transfer, [verts.buffer]);
+    assert.equal(verts(reply), vertsIn);
+    assert.deepEqual(transfer, [vertsIn.buffer]);
   });
 
   it('never transfers a zero-length buffer', () => {
@@ -26,7 +32,7 @@ describe('buildParseReply', () => {
     for (const input of [null, undefined, new Float32Array(0)]) {
       const { reply } = buildParseReply(1, input);
       assert.equal(reply.ok, true);
-      assert.equal(reply.ok && reply.verts.length, 0);
+      assert.equal(verts(reply).length, 0);
     }
   });
 
@@ -38,8 +44,8 @@ describe('buildParseReply', () => {
     const second = buildParseReply(2, new Float32Array(0));
     assert.ok(first.reply.ok && second.reply.ok);
     assert.notEqual(
-      first.reply.ok && first.reply.verts.buffer,
-      second.reply.ok && second.reply.verts.buffer,
+      verts(first.reply).buffer,
+      verts(second.reply).buffer,
       'two empty replies from one worker must not share a buffer',
     );
   });

--- a/apps/viewer/src/lib/overlay-parse/reply.ts
+++ b/apps/viewer/src/lib/overlay-parse/reply.ts
@@ -9,6 +9,7 @@
  */
 
 import type { OverlayParseResponse } from './overlay-parse.worker.js';
+import type { FlatSymbolic } from './symbolic-flat.js';
 
 export interface BuiltReply {
   reply: OverlayParseResponse;
@@ -34,4 +35,31 @@ export function buildParseReply(id: number, verts: Float32Array | null | undefin
     reply: { id, ok: true, verts: payload },
     transfer: payload.byteLength > 0 ? [payload.buffer as ArrayBuffer] : [],
   };
+}
+
+/**
+ * Same two rules as {@link buildParseReply}, applied across the ~20 buffers a
+ * `FlatSymbolic` carries.
+ *
+ * The zero-length exclusion does real work here rather than being belt-and-
+ * braces: a model with grids but no fills produces several genuinely empty
+ * arrays every time, so without it the FIRST symbolic reply would detach them
+ * and a second job in the same worker would throw `DataCloneError`.
+ *
+ * Buffers are de-duplicated by identity because a correct flatten may share
+ * one backing buffer between two views, and transferring the same
+ * `ArrayBuffer` twice throws.
+ */
+export function buildSymbolicReply(id: number, flat: FlatSymbolic): BuiltReply {
+  const transfer: ArrayBuffer[] = [];
+  const seen = new Set<ArrayBuffer>();
+  for (const value of Object.values(flat)) {
+    if (!ArrayBuffer.isView(value)) continue;
+    if (value.byteLength === 0) continue;
+    const buffer = value.buffer as ArrayBuffer;
+    if (seen.has(buffer)) continue;
+    seen.add(buffer);
+    transfer.push(buffer);
+  }
+  return { reply: { id, ok: true, flat }, transfer };
 }

--- a/apps/viewer/src/lib/overlay-parse/source-handoff.ts
+++ b/apps/viewer/src/lib/overlay-parse/source-handoff.ts
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The one place the viewer turns a loaded model into the bytes a worker parse
+ * receives (#2183).
+ *
+ * Today this is `store.source` and nothing more, so the function looks
+ * pointless. It exists because the assumption underneath it — that a model's
+ * bytes are ONE contiguous `Uint8Array` the main thread can hand over whole —
+ * is exactly the assumption that is under pressure. The moment a source
+ * becomes chunked, streamed, or only partly resident (the 342 MB class of
+ * model this issue is about), every site that reaches for `store.source` has
+ * to learn how to reassemble it. Routing them through here means that change
+ * lands in this function, once, instead of in each parse call site.
+ *
+ * So: never pass `store.source` straight to `postMessage`. Call this.
+ */
+
+/**
+ * The minimum a caller must have. Structural on purpose: `IfcDataStore`
+ * satisfies it, and so does the narrower prop shape `useDrawingGeneration`
+ * takes, without either module importing the other's types.
+ */
+export interface WholeSourceStore {
+  source: Uint8Array;
+}
+
+/**
+ * The model's whole IFC source, as one contiguous view, ready to hand to a
+ * worker.
+ *
+ * Not a copy. The source is normally `SharedArrayBuffer`-backed on the paths
+ * that matter, so the worker shares it by reference and neither realm pays for
+ * the bytes — which is also why callers must never put the returned view in a
+ * `postMessage` transfer list (that would detach the viewer's own copy).
+ */
+export function getWholeSourceForWorker(store: WholeSourceStore): Uint8Array {
+  return store.source;
+}

--- a/apps/viewer/src/lib/overlay-parse/symbolic-drawing-lines.test.ts
+++ b/apps/viewer/src/lib/overlay-parse/symbolic-drawing-lines.test.ts
@@ -1,0 +1,307 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import type { SymbolicRepresentationCollection } from '@ifc-lite/wasm';
+import { collectFlatSymbolic } from './symbolic-flat.js';
+import {
+  buildSymbolicDrawingLines,
+  type SymbolicDrawingLine,
+} from './symbolic-drawing-lines.js';
+
+/**
+ * Equivalence anchor for moving the 2D drawing's symbolic walk into the
+ * overlay worker (#2183).
+ *
+ * `useDrawingGeneration` used to walk the WASM collection inline on the main
+ * thread, which regrew a ~470 MB `WebAssembly.Memory` there the first time a
+ * user generated a drawing. The walk now runs over the worker's flat arrays
+ * instead — and "the plan still looks right" is not a proof: a dropped closing
+ * segment, a sign flip on the recovered world Z, or a lost `entitiesWithSymbols`
+ * entry all silently change which section-cut lines get replaced by symbols.
+ *
+ * So this pins the new implementation against a VERBATIM copy of the walk that
+ * was deleted, run over the same fake collection. The two are independent
+ * implementations; only real agreement passes.
+ *
+ * Every scalar the fake hands out is `Math.fround`ed and the points are a
+ * `Float32Array`, because that is what a wasm-bindgen getter returns: f32
+ * values widened to JS numbers. Feeding the legacy walk f64s it could never
+ * have seen would make it disagree with the (necessarily f32) flatten for
+ * reasons that have nothing to do with this change.
+ */
+
+const f32 = Math.fround;
+
+interface FakePoly {
+  ifcType: string;
+  expressId: number;
+  worldY: number;
+  isClosed: boolean;
+  points: Float32Array;
+  pointCount: number;
+  free(): void;
+}
+
+interface FakeCircle {
+  ifcType: string;
+  expressId: number;
+  worldY: number;
+  isFullCircle: boolean;
+  centerX: number;
+  centerY: number;
+  radius: number;
+  startAngle: number;
+  endAngle: number;
+  free(): void;
+}
+
+function poly(
+  ifcType: string,
+  expressId: number,
+  worldY: number,
+  points: number[],
+  isClosed = false,
+): FakePoly {
+  return {
+    ifcType,
+    expressId,
+    worldY: f32(worldY),
+    isClosed,
+    points: Float32Array.from(points),
+    pointCount: points.length / 2,
+    free() { /* handle release is covered by symbolic-flat.test.ts */ },
+  };
+}
+
+function circle(
+  ifcType: string,
+  expressId: number,
+  worldY: number,
+  fields: {
+    centerX: number;
+    centerY: number;
+    radius: number;
+    startAngle: number;
+    endAngle: number;
+    isFullCircle: boolean;
+  },
+): FakeCircle {
+  return {
+    ifcType,
+    expressId,
+    worldY: f32(worldY),
+    isFullCircle: fields.isFullCircle,
+    centerX: f32(fields.centerX),
+    centerY: f32(fields.centerY),
+    radius: f32(fields.radius),
+    startAngle: f32(fields.startAngle),
+    endAngle: f32(fields.endAngle),
+    free() { /* handle release is covered by symbolic-flat.test.ts */ },
+  };
+}
+
+function makeCollection(items: {
+  polylines?: FakePoly[];
+  circles?: FakeCircle[];
+}): SymbolicRepresentationCollection {
+  const polylines = items.polylines ?? [];
+  const circles = items.circles ?? [];
+  return {
+    polylineCount: polylines.length,
+    circleCount: circles.length,
+    textCount: 0,
+    fillCount: 0,
+    getPolyline: (i: number) => polylines[i],
+    getCircle: (i: number) => circles[i],
+    getText: () => undefined,
+    getFill: () => undefined,
+  } as unknown as SymbolicRepresentationCollection;
+}
+
+/**
+ * The walk exactly as it stood in `useDrawingGeneration.ts` before #2183's
+ * step 2 — handle reads, 32/16-segment arcs, centroids and all. Do not
+ * "improve" it: its value is that it is the shipped behaviour.
+ */
+function legacyWalk(collection: SymbolicRepresentationCollection): {
+  lines: SymbolicDrawingLine[];
+  entities: Set<number>;
+} {
+  const symbolicLines: SymbolicDrawingLine[] = [];
+  const entitiesWithSymbols = new Set<number>();
+  const symbolicModelIndex = 0;
+  const c = collection as unknown as {
+    polylineCount: number;
+    circleCount: number;
+    getPolyline(i: number): FakePoly | undefined;
+    getCircle(i: number): FakeCircle | undefined;
+  };
+
+  for (let i = 0; i < c.polylineCount; i++) {
+    const p = c.getPolyline(i);
+    if (!p) continue;
+    entitiesWithSymbols.add(p.expressId);
+    const points = p.points;
+    const pointCount = p.pointCount;
+    const polyWorldY = (p as unknown as { worldY?: number }).worldY;
+    let sumX = 0;
+    let sumY = 0;
+    for (let q = 0; q < pointCount; q++) {
+      sumX += points[q * 2];
+      sumY += points[q * 2 + 1];
+    }
+    const polyWorldX = pointCount > 0 ? sumX / pointCount : undefined;
+    const polyWorldZ = pointCount > 0 ? -sumY / pointCount : undefined;
+
+    for (let j = 0; j < pointCount - 1; j++) {
+      symbolicLines.push({
+        line: {
+          start: { x: points[j * 2], y: points[j * 2 + 1] },
+          end: { x: points[(j + 1) * 2], y: points[(j + 1) * 2 + 1] },
+        },
+        category: 'silhouette',
+        visibility: 'visible',
+        entityId: p.expressId,
+        ifcType: p.ifcType,
+        modelIndex: symbolicModelIndex,
+        depth: 0,
+        worldX: polyWorldX,
+        worldY: polyWorldY,
+        worldZ: polyWorldZ,
+      });
+    }
+
+    if (p.isClosed && pointCount > 2) {
+      symbolicLines.push({
+        line: {
+          start: { x: points[(pointCount - 1) * 2], y: points[(pointCount - 1) * 2 + 1] },
+          end: { x: points[0], y: points[1] },
+        },
+        category: 'silhouette',
+        visibility: 'visible',
+        entityId: p.expressId,
+        ifcType: p.ifcType,
+        modelIndex: symbolicModelIndex,
+        depth: 0,
+        worldX: polyWorldX,
+        worldY: polyWorldY,
+        worldZ: polyWorldZ,
+      });
+    }
+  }
+
+  for (let i = 0; i < c.circleCount; i++) {
+    const cir = c.getCircle(i);
+    if (!cir) continue;
+    entitiesWithSymbols.add(cir.expressId);
+    const numSegments = cir.isFullCircle ? 32 : 16;
+    const circleWorldY = (cir as unknown as { worldY?: number }).worldY;
+    const circleWorldX = cir.centerX;
+    const circleWorldZ = -cir.centerY;
+
+    for (let j = 0; j < numSegments; j++) {
+      const t1 = j / numSegments;
+      const t2 = (j + 1) / numSegments;
+      const a1 = cir.startAngle + t1 * (cir.endAngle - cir.startAngle);
+      const a2 = cir.startAngle + t2 * (cir.endAngle - cir.startAngle);
+      symbolicLines.push({
+        line: {
+          start: {
+            x: cir.centerX + cir.radius * Math.cos(a1),
+            y: cir.centerY + cir.radius * Math.sin(a1),
+          },
+          end: {
+            x: cir.centerX + cir.radius * Math.cos(a2),
+            y: cir.centerY + cir.radius * Math.sin(a2),
+          },
+        },
+        category: 'silhouette',
+        visibility: 'visible',
+        entityId: cir.expressId,
+        ifcType: cir.ifcType,
+        modelIndex: symbolicModelIndex,
+        depth: 0,
+        worldX: circleWorldX,
+        worldY: circleWorldY,
+        worldZ: circleWorldZ,
+      });
+    }
+  }
+
+  return { lines: symbolicLines, entities: entitiesWithSymbols };
+}
+
+/** Mixed set: closed + open + degenerate polylines, a full circle and an arc. */
+function fixture(): SymbolicRepresentationCollection {
+  return makeCollection({
+    polylines: [
+      // Non-annotation types must survive: the drawing draws every product's
+      // plan representation, which is why it asks the flatten for 'all'.
+      poly('IfcWall', 101, 2.5, [0, 0, 4, 0, 4, 3, 0, 3], true),
+      poly('IfcAnnotation', 102, 0, [1, 1, 2, 2]),
+      poly('IfcDoor', 103, 2.5, [0.5, 0.5, 1.5, 0.5, 1.5, 1.5]),
+      // Closed but only 2 points: no closing segment (pointCount > 2 fails).
+      poly('IfcSlab', 104, -1.25, [0, 0, 1, 0], true),
+      // No points at all: contributes an entity id and nothing else.
+      poly('IfcGridAxis', 105, 3, []),
+    ],
+    circles: [
+      circle('IfcGridAxis', 201, 3, {
+        centerX: 2.5, centerY: -1.5, radius: 0.75,
+        startAngle: 0, endAngle: Math.PI * 2, isFullCircle: true,
+      }),
+      circle('IfcAnnotation', 202, 0.5, {
+        centerX: -4, centerY: 8.25, radius: 1.5,
+        startAngle: Math.PI / 4, endAngle: Math.PI, isFullCircle: false,
+      }),
+    ],
+  });
+}
+
+describe('buildSymbolicDrawingLines (#2183)', () => {
+  it('reproduces the deleted main-thread walk exactly', () => {
+    const flat = collectFlatSymbolic(fixture(), 'all');
+    const viaWorker = buildSymbolicDrawingLines(structuredClone(flat), 0);
+    const legacy = legacyWalk(fixture());
+
+    assert.deepStrictEqual(viaWorker.lines, legacy.lines);
+    assert.deepStrictEqual([...viaWorker.entities].sort(), [...legacy.entities].sort());
+    // Guard against a vacuous pass: a filter that dropped everything, or a
+    // flatten that never ran, would satisfy deepStrictEqual on two empties.
+    assert.equal(
+      legacy.lines.length,
+      // 101: 3 segments + its closing one. 102: 1. 103: 2. 104: 1 (closed, but
+      // 2 points, so no closing segment). 105: none. Then 32 + 16 arc segments.
+      (3 + 1) + 1 + 2 + 1 + 32 + 16,
+    );
+    assert.deepStrictEqual([...legacy.entities].sort(), [101, 102, 103, 104, 105, 201, 202]);
+  });
+
+  it('carries the owner type through, non-annotation types included', () => {
+    const { lines } = buildSymbolicDrawingLines(collectFlatSymbolic(fixture(), 'all'));
+    const types = new Set(lines.map((l) => l.ifcType));
+    assert.deepStrictEqual(
+      [...types].sort(),
+      ['IfcAnnotation', 'IfcDoor', 'IfcGridAxis', 'IfcSlab', 'IfcWall'],
+    );
+  });
+
+  // The section cull reads these three; `worldZ` is the negated 2D y, and an
+  // unresolvable elevation must stay `undefined` so the cull keeps the line
+  // rather than testing NaN and dropping it.
+  it('recovers the world-space centroid, and leaves an unknown elevation undefined', () => {
+    const flat = collectFlatSymbolic(
+      makeCollection({ polylines: [poly('IfcWall', 301, 0, [0, 0, 4, 2])] }),
+      'all',
+    );
+    flat.polyWorldY[0] = Number.NaN; // what an absent wasm `worldY` flattens to
+    const [line] = buildSymbolicDrawingLines(flat).lines;
+    assert.equal(line.worldX, 2);
+    assert.equal(line.worldZ, -1);
+    assert.equal(line.worldY, undefined);
+  });
+});

--- a/apps/viewer/src/lib/overlay-parse/symbolic-drawing-lines.ts
+++ b/apps/viewer/src/lib/overlay-parse/symbolic-drawing-lines.ts
@@ -1,0 +1,198 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Flat primitive stream → 2D-drawing lines (#2183).
+ *
+ * The 2D drawing's sibling of `buildParseResult` (`symbolic-parse.ts`): the
+ * main-thread half that turns the worker's transferable arrays into renderable
+ * geometry. It exists because the drawing used to walk the WASM
+ * `SymbolicRepresentationCollection` inline in `useDrawingGeneration`, which
+ * grew a ~470 MB main-thread `WebAssembly.Memory` the first time a user
+ * generated a drawing — undoing, on that one code path, the whole point of
+ * moving the parse into a worker.
+ *
+ * Unlike the overlay's assembly this keeps EVERY owner type (the flatten is
+ * asked for `mode: 'all'`): a plan drawing draws the symbolic representation of
+ * walls, doors and furniture, not just annotations and grid axes.
+ *
+ * This is a transcription, not a redesign. Segment order, the closing-segment
+ * rule, the centroid arithmetic, the arc tessellation counts, and which express
+ * ids land in `entities` are all exactly what the inline walk did.
+ */
+
+import type { DrawingLine } from '@ifc-lite/drawing-2d';
+import type { FlatSymbolic } from './symbolic-flat.js';
+
+/**
+ * A drawing line carrying its parent primitive's world-space centroid.
+ *
+ * `@ifc-lite/drawing-2d`'s `DrawingLine` has no per-line position slot, and the
+ * 2D Section filter needs one to cull symbolic primitives against the active
+ * cut plane. Extra fields are ignored by the canvas, so this stays local.
+ *
+ * Coordinate space matches the section cutter's input (shifted bounds):
+ * - `worldX`: the polyline's 2D x (already RTC-shifted by WASM)
+ * - `worldZ`: −(2D y) — WASM negates Z into the 2D y axis to match section-cut
+ *   output handedness, so flip it back
+ * - `worldY`: the primitive's `worldY` (vertical elevation)
+ */
+export type SymbolicDrawingLine = DrawingLine & {
+  worldX?: number;
+  worldY?: number;
+  worldZ?: number;
+};
+
+export interface SymbolicDrawingGeometry {
+  /** Tessellated segments, polylines first then circles, in source order. */
+  lines: SymbolicDrawingLine[];
+  /** Every express id that carried a symbolic primitive, tessellated or not. */
+  entities: Set<number>;
+}
+
+/** Arc tessellation, unchanged from the inline walk. */
+const FULL_CIRCLE_SEGMENTS = 32;
+const ARC_SEGMENTS = 16;
+
+/**
+ * A non-finite elevation means "unknown", not "at NaN".
+ *
+ * The inline walk read `worldY` defensively (`(poly as { worldY?: number })`)
+ * so an older wasm bundle without the accessor yielded `undefined`, and the
+ * section cull keeps a line whose centroid it cannot resolve — over-rendering
+ * beats silently dropping authored geometry. Crossing the worker boundary the
+ * absent value arrives as `NaN` in a `Float32Array`, so restore the sentinel
+ * here; a degenerate placement gets the same benefit of the doubt.
+ */
+function elevationOrUnknown(worldY: number): number | undefined {
+  return Number.isFinite(worldY) ? worldY : undefined;
+}
+
+/**
+ * Build the drawing's symbolic lines from a `'all'`-mode flatten.
+ *
+ * `modelIndex` is stamped on every line; the drawing path is single-model for
+ * now (federated symbolic parsing would parse each model separately), which is
+ * why it defaults to 0.
+ */
+export function buildSymbolicDrawingLines(
+  flat: FlatSymbolic,
+  modelIndex = 0,
+): SymbolicDrawingGeometry {
+  const lines: SymbolicDrawingLine[] = [];
+  const entities = new Set<number>();
+  const typeNames = flat.typeNames;
+
+  for (let i = 0; i < flat.polyOwner.length; i++) {
+    const expressId = flat.polyOwner[i];
+    const ifcType = typeNames[flat.polyType[i]];
+    entities.add(expressId);
+
+    // The points are consumed synchronously (centroid sum + segment pushes read
+    // scalars out of them) and never stored, so a view over the shared buffer
+    // is enough — no copy needed.
+    const start = flat.polyStart[i];
+    const pointCount = flat.polyStart[i + 1] - start;
+    const points = flat.polyPoints.subarray(start * 2, (start + pointCount) * 2);
+    const worldY = elevationOrUnknown(flat.polyWorldY[i]);
+
+    // Centroid in shifted world coords, computed once per source polyline and
+    // shared across its segments.
+    let sumX = 0;
+    let sumY = 0;
+    for (let p = 0; p < pointCount; p++) {
+      sumX += points[p * 2];
+      sumY += points[p * 2 + 1];
+    }
+    const worldX = pointCount > 0 ? sumX / pointCount : undefined;
+    const worldZ = pointCount > 0 ? -sumY / pointCount : undefined;
+
+    for (let j = 0; j < pointCount - 1; j++) {
+      lines.push({
+        line: {
+          start: { x: points[j * 2], y: points[j * 2 + 1] },
+          end: { x: points[(j + 1) * 2], y: points[(j + 1) * 2 + 1] },
+        },
+        category: 'silhouette',
+        visibility: 'visible',
+        entityId: expressId,
+        ifcType,
+        modelIndex,
+        depth: 0,
+        worldX,
+        worldY,
+        worldZ,
+      });
+    }
+
+    const isClosed = (flat.polyFlags[i] & 1) !== 0;
+    if (isClosed && pointCount > 2) {
+      lines.push({
+        line: {
+          start: { x: points[(pointCount - 1) * 2], y: points[(pointCount - 1) * 2 + 1] },
+          end: { x: points[0], y: points[1] },
+        },
+        category: 'silhouette',
+        visibility: 'visible',
+        entityId: expressId,
+        ifcType,
+        modelIndex,
+        depth: 0,
+        worldX,
+        worldY,
+        worldZ,
+      });
+    }
+  }
+
+  for (let i = 0; i < flat.circleOwner.length; i++) {
+    const expressId = flat.circleOwner[i];
+    const ifcType = typeNames[flat.circleType[i]];
+    entities.add(expressId);
+
+    const isFullCircle = (flat.circleFlags[i] & 1) !== 0;
+    const numSegments = isFullCircle ? FULL_CIRCLE_SEGMENTS : ARC_SEGMENTS;
+    const centerX = flat.circleCenterX[i];
+    const centerY = flat.circleCenterY[i];
+    const radius = flat.circleRadius[i];
+    const startAngle = flat.circleStartAngle[i];
+    const endAngle = flat.circleEndAngle[i];
+    const worldY = elevationOrUnknown(flat.circleWorldY[i]);
+    // `centerX` is already RTC-shifted X; `centerY` carries the negated Z (see
+    // the polyline note above) — flip to recover world Z.
+    const worldX = centerX;
+    const worldZ = -centerY;
+
+    for (let j = 0; j < numSegments; j++) {
+      const t1 = j / numSegments;
+      const t2 = (j + 1) / numSegments;
+      const a1 = startAngle + t1 * (endAngle - startAngle);
+      const a2 = startAngle + t2 * (endAngle - startAngle);
+
+      lines.push({
+        line: {
+          start: {
+            x: centerX + radius * Math.cos(a1),
+            y: centerY + radius * Math.sin(a1),
+          },
+          end: {
+            x: centerX + radius * Math.cos(a2),
+            y: centerY + radius * Math.sin(a2),
+          },
+        },
+        category: 'silhouette',
+        visibility: 'visible',
+        entityId: expressId,
+        ifcType,
+        modelIndex,
+        depth: 0,
+        worldX,
+        worldY,
+        worldZ,
+      });
+    }
+  }
+
+  return { lines, entities };
+}

--- a/apps/viewer/src/lib/overlay-parse/symbolic-flat.test.ts
+++ b/apps/viewer/src/lib/overlay-parse/symbolic-flat.test.ts
@@ -1,0 +1,165 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import type { SymbolicRepresentationCollection } from '@ifc-lite/wasm';
+import { collectFlatSymbolic } from './symbolic-flat.js';
+import { buildParseResult } from './symbolic-parse.js';
+
+/**
+ * Unit cover for the WASM→worker seam (#2183). The golden-digest test proves
+ * the composed parse still produces byte-identical output; this proves the
+ * three things that test cannot reach with real fixtures:
+ *
+ *   1. the type filter moved into the flatten drops exactly what the old
+ *      main-side walk dropped,
+ *   2. every handle is freed even when the walk throws mid-item, and
+ *   3. the flat struct survives a structured clone, so running it in a worker
+ *      does not change the assembled ParseResult (NaN sentinel included).
+ */
+
+interface FreeTracked {
+  freed: boolean;
+  free(): void;
+}
+
+function tracked<T extends object>(fields: T): T & FreeTracked {
+  return {
+    ...fields,
+    freed: false,
+    free(this: FreeTracked) {
+      this.freed = true;
+    },
+  };
+}
+
+function poly(ifcType: string, expressId: number, worldY: number, points: number[]) {
+  return tracked({
+    ifcType,
+    expressId,
+    worldY,
+    isClosed: false,
+    points: Float32Array.from(points),
+    pointCount: points.length / 2,
+  });
+}
+
+function fill(ifcType: string, expressId: number, worldY: number, angleSecondary: number) {
+  return tracked({
+    ifcType,
+    expressId,
+    worldY,
+    points: Float32Array.from([0, 0, 1, 0, 1, 1]),
+    holesOffsets: Uint32Array.from([3]),
+    fillR: 0.25,
+    fillG: 0.5,
+    fillB: 0.75,
+    fillA: 1,
+    hasHatching: true,
+    hatchSpacing: 0.1,
+    hatchAngle: 0.7853981633974483,
+    hatchAngleSecondary: angleSecondary,
+    hatchLineWidth: 0.002,
+  });
+}
+
+/** Minimal stand-in for the wasm-bindgen collection handle. */
+function makeCollection(items: {
+  polylines?: unknown[];
+  circles?: unknown[];
+  texts?: unknown[];
+  fills?: unknown[];
+}): SymbolicRepresentationCollection {
+  const polylines = items.polylines ?? [];
+  const circles = items.circles ?? [];
+  const texts = items.texts ?? [];
+  const fills = items.fills ?? [];
+  return {
+    polylineCount: polylines.length,
+    circleCount: circles.length,
+    textCount: texts.length,
+    fillCount: fills.length,
+    getPolyline: (i: number) => polylines[i],
+    getCircle: (i: number) => circles[i],
+    getText: (i: number) => texts[i],
+    getFill: (i: number) => fills[i],
+  } as unknown as SymbolicRepresentationCollection;
+}
+
+describe('collectFlatSymbolic', () => {
+  it('keeps only IfcAnnotation / IfcGridAxis, and frees every handle it took', () => {
+    const kept = poly('IfcAnnotation', 11, 3, [0, 0, 1, 1]);
+    const dropped = poly('IfcWall', 12, 3, [0, 0, 2, 2]);
+    const grid = poly('IfcGridAxis', 13, 3, [0, 0, 3, 3]);
+
+    const flat = collectFlatSymbolic(makeCollection({ polylines: [kept, dropped, grid] }));
+
+    assert.deepStrictEqual([...flat.polyOwner], [11, 13]);
+    assert.deepStrictEqual([...flat.polyPoints], [0, 0, 1, 1, 0, 0, 3, 3]);
+    assert.deepStrictEqual([...flat.polyStart], [0, 2, 4]);
+    assert.deepStrictEqual(
+      [...flat.polyType].map((t) => flat.typeNames[t]),
+      ['IfcAnnotation', 'IfcGridAxis'],
+    );
+    // The filtered-out handle is still fetched, so it must still be freed.
+    for (const handle of [kept, dropped, grid]) assert.strictEqual(handle.freed, true);
+  });
+
+  it('frees the in-hand handle when the walk throws mid-item', () => {
+    const ok = poly('IfcAnnotation', 21, 3, [0, 0, 1, 1]);
+    // Built literally rather than through `tracked`, whose spread would
+    // trigger the throwing getter at construction time.
+    const exploding = {
+      ifcType: 'IfcAnnotation',
+      expressId: 22,
+      isClosed: false,
+      points: Float32Array.from([0, 0]),
+      pointCount: 1,
+      freed: false,
+      get worldY(): number {
+        throw new Error('wasm getter blew up');
+      },
+      free(this: FreeTracked) {
+        this.freed = true;
+      },
+    };
+
+    assert.throws(
+      () => collectFlatSymbolic(makeCollection({ polylines: [ok, exploding] })),
+      /wasm getter blew up/,
+    );
+    assert.strictEqual(ok.freed, true);
+    assert.strictEqual(exploding.freed, true);
+  });
+
+  it('survives a structured clone: same ParseResult either side of the boundary', () => {
+    const flat = collectFlatSymbolic(
+      makeCollection({
+        polylines: [poly('IfcAnnotation', 31, 3.5, [0, 0, 1, 1, 2, 0])],
+        fills: [
+          // NaN secondary angle = "no cross-hatch"; must still become null.
+          fill('IfcAnnotation', 32, 3.5, Number.NaN),
+          fill('IfcGridAxis', 33, 0, 1.25),
+        ],
+      }),
+    );
+
+    const hierarchy = { storeyElevations: new Map([[9, 7]]), elementToStorey: new Map([[33, 9]]) };
+    const direct = buildParseResult(flat, hierarchy);
+    const viaWorker = buildParseResult(structuredClone(flat), hierarchy);
+
+    assert.deepStrictEqual(viaWorker, direct);
+    // `assert.equal` is loose, so `undefined == null` — reach the hatching
+    // explicitly first, or a missing bucket would pass the null assertion.
+    const annotationHatch = direct.byStorey.get(3500)?.fills[0]?.hatching;
+    assert.ok(annotationHatch, 'annotation fill bucketed at worldY 3.5');
+    assert.strictEqual(annotationHatch.angleSecondary, null);
+    // worldY 0 falls back to the storey table (elevation 7 → bucket key 7000).
+    const gridHatch = direct.gridByStorey.get(7000)?.fills[0]?.hatching;
+    assert.ok(gridHatch, 'grid fill bucketed via the storey-elevation fallback');
+    assert.strictEqual(gridHatch.angleSecondary, 1.25);
+  });
+});

--- a/apps/viewer/src/lib/overlay-parse/symbolic-flat.test.ts
+++ b/apps/viewer/src/lib/overlay-parse/symbolic-flat.test.ts
@@ -108,6 +108,30 @@ describe('collectFlatSymbolic', () => {
     for (const handle of [kept, dropped, grid]) assert.strictEqual(handle.freed, true);
   });
 
+  // The 2D drawing asks for `'all'` (#2183): it draws the symbolic
+  // representation of every product, not just annotations and grid axes. The
+  // default must stay `'overlay'`, or the golden digests move.
+  it('keeps every type under mode "all", and defaults to "overlay"', () => {
+    const items = () => [
+      poly('IfcAnnotation', 41, 3, [0, 0, 1, 1]),
+      poly('IfcWall', 42, 3, [0, 0, 2, 2]),
+      poly('IfcGridAxis', 43, 3, [0, 0, 3, 3]),
+      poly('IfcFurniture', 44, 3, [0, 0, 4, 4]),
+    ];
+
+    const all = collectFlatSymbolic(makeCollection({ polylines: items() }), 'all');
+    assert.deepStrictEqual([...all.polyOwner], [41, 42, 43, 44]);
+    assert.deepStrictEqual(
+      [...all.polyType].map((t) => all.typeNames[t]),
+      ['IfcAnnotation', 'IfcWall', 'IfcGridAxis', 'IfcFurniture'],
+    );
+
+    const explicit = collectFlatSymbolic(makeCollection({ polylines: items() }), 'overlay');
+    const byDefault = collectFlatSymbolic(makeCollection({ polylines: items() }));
+    assert.deepStrictEqual([...byDefault.polyOwner], [41, 43]);
+    assert.deepStrictEqual(byDefault, explicit, 'the default must BE overlay mode');
+  });
+
   it('frees the in-hand handle when the walk throws mid-item', () => {
     const ok = poly('IfcAnnotation', 21, 3, [0, 0, 1, 1]);
     // Built literally rather than through `tracked`, whose spread would

--- a/apps/viewer/src/lib/overlay-parse/symbolic-flat.ts
+++ b/apps/viewer/src/lib/overlay-parse/symbolic-flat.ts
@@ -24,7 +24,11 @@
  *      primitives the overlay can actually use pay for the transfer. On a
  *      342 MB model that is 10,222 polylines down to ~2. The predicate is the
  *      same one, applied at the same point (before anything else is read off
- *      the handle), so the surviving set is identical.
+ *      the handle), so the surviving set is identical. The 2D drawing needs
+ *      EVERY representation type instead, so the filter is a {@link
+ *      SymbolicFilterMode} rather than a constant — `'overlay'` (the default,
+ *      and what the annotation overlay asks for) keeps today's behaviour
+ *      exactly.
  *
  * Deliberately NOT done here, so their existing coverage keeps applying to the
  * code that ships: circle/polyline tessellation (`circleToSegments` /
@@ -33,6 +37,18 @@
  */
 
 import type { SymbolicRepresentationCollection } from '@ifc-lite/wasm';
+
+/**
+ * Which owner types survive the flatten.
+ *
+ *   - `'overlay'` — `IfcAnnotation` / `IfcGridAxis` only, the two the
+ *     annotation overlay renders (issue #862). The default, so every existing
+ *     caller keeps its exact output.
+ *   - `'all'` — no type filter. The 2D drawing draws the symbolic (Plan/Axis)
+ *     representation of ANY product it can find one for, so it cannot use the
+ *     overlay's filter.
+ */
+export type SymbolicFilterMode = 'overlay' | 'all';
 
 /**
  * The whole symbolic collection as transferable arrays.
@@ -48,8 +64,11 @@ import type { SymbolicRepresentationCollection } from '@ifc-lite/wasm';
 export interface FlatSymbolic {
   /**
    * IFC type names, deduplicated. The per-primitive `*Type` arrays index into
-   * this. After the filter it holds at most `IfcAnnotation` and `IfcGridAxis`,
-   * which is why a `Uint8Array` index is enough.
+   * this. Under `'overlay'` it holds at most `IfcAnnotation` and `IfcGridAxis`;
+   * under `'all'` it holds every product type the model authored a symbolic
+   * representation for, which is why the index arrays are 16-bit — an 8-bit
+   * index would wrap silently past 256 distinct types and hand a primitive
+   * somebody else's `ifcType`.
    */
   typeNames: string[];
 
@@ -65,7 +84,7 @@ export interface FlatSymbolic {
   /** Bit 0 = `isClosed`. One per polyline. */
   polyFlags: Uint8Array;
   /** Index into {@link FlatSymbolic.typeNames}, one per polyline. */
-  polyType: Uint8Array;
+  polyType: Uint16Array;
 
   // ── Circles / arcs ───────────────────────────────────────────────────────
   circleCenterX: Float32Array;
@@ -77,7 +96,7 @@ export interface FlatSymbolic {
   circleWorldY: Float32Array;
   /** Bit 0 = `isFullCircle`. One per circle. */
   circleFlags: Uint8Array;
-  circleType: Uint8Array;
+  circleType: Uint16Array;
 
   // ── Texts ────────────────────────────────────────────────────────────────
   /** Raw IFC literal, still STEP-escaped — decoded on the main thread. */
@@ -94,7 +113,7 @@ export interface FlatSymbolic {
   textColor: Float32Array;
   textOwner: Uint32Array;
   textWorldY: Float32Array;
-  textType: Uint8Array;
+  textType: Uint16Array;
 
   // ── Fills ────────────────────────────────────────────────────────────────
   /** Flat ring vertices for every fill, back to back. */
@@ -122,7 +141,7 @@ export interface FlatSymbolic {
   fillWorldY: Float32Array;
   /** Bit 0 = `hasHatching`. One per fill. */
   fillFlags: Uint8Array;
-  fillType: Uint8Array;
+  fillType: Uint16Array;
 }
 
 /** An empty flatten — the shape a skipped or empty parse produces. */
@@ -134,7 +153,7 @@ export function createEmptyFlatSymbolic(): FlatSymbolic {
     polyOwner: new Uint32Array(0),
     polyWorldY: new Float32Array(0),
     polyFlags: new Uint8Array(0),
-    polyType: new Uint8Array(0),
+    polyType: new Uint16Array(0),
     circleCenterX: new Float32Array(0),
     circleCenterY: new Float32Array(0),
     circleRadius: new Float32Array(0),
@@ -143,7 +162,7 @@ export function createEmptyFlatSymbolic(): FlatSymbolic {
     circleOwner: new Uint32Array(0),
     circleWorldY: new Float32Array(0),
     circleFlags: new Uint8Array(0),
-    circleType: new Uint8Array(0),
+    circleType: new Uint16Array(0),
     textContent: [],
     textAlignment: [],
     textX: new Float32Array(0),
@@ -155,7 +174,7 @@ export function createEmptyFlatSymbolic(): FlatSymbolic {
     textColor: new Float32Array(0),
     textOwner: new Uint32Array(0),
     textWorldY: new Float32Array(0),
-    textType: new Uint8Array(0),
+    textType: new Uint16Array(0),
     fillPoints: new Float32Array(0),
     fillPointStart: new Uint32Array(1),
     fillHoles: new Uint32Array(0),
@@ -165,13 +184,18 @@ export function createEmptyFlatSymbolic(): FlatSymbolic {
     fillOwner: new Uint32Array(0),
     fillWorldY: new Float32Array(0),
     fillFlags: new Uint8Array(0),
-    fillType: new Uint8Array(0),
+    fillType: new Uint16Array(0),
   };
 }
 
 /** The only two owner types the annotation overlay renders (issue #862). */
 function isOverlayType(ifcType: string): boolean {
   return ifcType === 'IfcAnnotation' || ifcType === 'IfcGridAxis';
+}
+
+/** Keep-predicate for a {@link SymbolicFilterMode}. */
+function keepPredicate(mode: SymbolicFilterMode): (ifcType: string) => boolean {
+  return mode === 'all' ? () => true : isOverlayType;
 }
 
 /** Intern an IFC type name into the shared table, returning its index. */
@@ -191,8 +215,16 @@ function intern(names: string[], index: Map<string, number>, name: string): numb
  * `getText` / `getFill`) in `try/finally`, so a mid-flatten throw cannot leak
  * WASM memory into the FinalizationRegistry (AGENTS.md §Geometry & WASM).
  * Ownership of `collection` itself stays with the caller.
+ *
+ * `mode` defaults to `'overlay'` so every pre-existing caller — including the
+ * golden-digest reference path in `symbolic-parse.ts` — is byte-for-byte
+ * unchanged.
  */
-export function collectFlatSymbolic(collection: SymbolicRepresentationCollection): FlatSymbolic {
+export function collectFlatSymbolic(
+  collection: SymbolicRepresentationCollection,
+  mode: SymbolicFilterMode = 'overlay',
+): FlatSymbolic {
+  const keep = keepPredicate(mode);
   const typeNames: string[] = [];
   const typeIndex = new Map<string, number>();
 
@@ -208,7 +240,7 @@ export function collectFlatSymbolic(collection: SymbolicRepresentationCollection
     if (!poly) continue;
     try {
       const ifcType = poly.ifcType;
-      if (!isOverlayType(ifcType)) continue;
+      if (!keep(ifcType)) continue;
       // `pointCount` is `points.len() / 2`, so `pointCount * 2` never reads
       // past the end even if the source vector had an odd length.
       const pointCount = poly.pointCount;
@@ -239,7 +271,7 @@ export function collectFlatSymbolic(collection: SymbolicRepresentationCollection
     if (!circle) continue;
     try {
       const ifcType = circle.ifcType;
-      if (!isOverlayType(ifcType)) continue;
+      if (!keep(ifcType)) continue;
       circleCenterX.push(circle.centerX);
       circleCenterY.push(circle.centerY);
       circleRadius.push(circle.radius);
@@ -272,7 +304,7 @@ export function collectFlatSymbolic(collection: SymbolicRepresentationCollection
     if (!text) continue;
     try {
       const ifcType = text.ifcType;
-      if (!isOverlayType(ifcType)) continue;
+      if (!keep(ifcType)) continue;
       // Content crosses verbatim: `decodeIfcString` and the multi-line split
       // stay main-side so the encoding behaviour is unchanged.
       textContent.push(text.content);
@@ -308,7 +340,7 @@ export function collectFlatSymbolic(collection: SymbolicRepresentationCollection
     if (!fill) continue;
     try {
       const ifcType = fill.ifcType;
-      if (!isOverlayType(ifcType)) continue;
+      if (!keep(ifcType)) continue;
       // The degenerate-ring guard (`< 3` vertices) stays main-side, next to
       // the bucket it must not create; carry the ring across as authored.
       const points = fill.points;
@@ -337,7 +369,7 @@ export function collectFlatSymbolic(collection: SymbolicRepresentationCollection
     polyOwner: Uint32Array.from(polyOwner),
     polyWorldY: Float32Array.from(polyWorldY),
     polyFlags: Uint8Array.from(polyFlags),
-    polyType: Uint8Array.from(polyType),
+    polyType: Uint16Array.from(polyType),
     circleCenterX: Float32Array.from(circleCenterX),
     circleCenterY: Float32Array.from(circleCenterY),
     circleRadius: Float32Array.from(circleRadius),
@@ -346,7 +378,7 @@ export function collectFlatSymbolic(collection: SymbolicRepresentationCollection
     circleOwner: Uint32Array.from(circleOwner),
     circleWorldY: Float32Array.from(circleWorldY),
     circleFlags: Uint8Array.from(circleFlags),
-    circleType: Uint8Array.from(circleType),
+    circleType: Uint16Array.from(circleType),
     textContent,
     textAlignment,
     textX: Float32Array.from(textX),
@@ -358,7 +390,7 @@ export function collectFlatSymbolic(collection: SymbolicRepresentationCollection
     textColor: Float32Array.from(textColor),
     textOwner: Uint32Array.from(textOwner),
     textWorldY: Float32Array.from(textWorldY),
-    textType: Uint8Array.from(textType),
+    textType: Uint16Array.from(textType),
     fillPoints: Float32Array.from(fillPoints),
     fillPointStart: Uint32Array.from(fillPointStart),
     fillHoles: Uint32Array.from(fillHoles),
@@ -368,6 +400,6 @@ export function collectFlatSymbolic(collection: SymbolicRepresentationCollection
     fillOwner: Uint32Array.from(fillOwner),
     fillWorldY: Float32Array.from(fillWorldY),
     fillFlags: Uint8Array.from(fillFlags),
-    fillType: Uint8Array.from(fillType),
+    fillType: Uint16Array.from(fillType),
   };
 }

--- a/apps/viewer/src/lib/overlay-parse/symbolic-flat.ts
+++ b/apps/viewer/src/lib/overlay-parse/symbolic-flat.ts
@@ -1,0 +1,373 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Struct-of-arrays flattening of the WASM symbolic-representation collection.
+ *
+ * This is the worker half of the symbolic-annotation parse (#2183). The WASM
+ * handles it walks cannot cross a `postMessage` boundary, so the worker
+ * flattens them into transferable typed arrays here and the main thread
+ * reassembles the `ParseResult` from those arrays (`buildParseResult` in
+ * `symbolic-parse.ts`).
+ *
+ * Two rules keep the split honest:
+ *
+ *   1. **Verbatim.** Every field the main-side walk reads is carried across
+ *      unchanged, in the same element type WASM produced it in (`f32` values
+ *      into `Float32Array`, `u32` express ids into `Uint32Array` — never a
+ *      `Float32Array`, ids exceed 2^24 on large models). Nothing is rounded,
+ *      decoded, tessellated or reordered on this side. `hatchAngleSecondary`
+ *      keeps its `NaN` "absent" sentinel; typed-array bytes survive the clone.
+ *   2. **Filter early.** The `IfcAnnotation` / `IfcGridAxis` type filter that
+ *      used to sit inside the main-side walk runs *here* instead, so only
+ *      primitives the overlay can actually use pay for the transfer. On a
+ *      342 MB model that is 10,222 polylines down to ~2. The predicate is the
+ *      same one, applied at the same point (before anything else is read off
+ *      the handle), so the surviving set is identical.
+ *
+ * Deliberately NOT done here, so their existing coverage keeps applying to the
+ * code that ships: circle/polyline tessellation (`circleToSegments` /
+ * `polylineToSegments`) and text decoding (`decodeIfcString` + the multi-line
+ * split) stay on the main thread.
+ */
+
+import type { SymbolicRepresentationCollection } from '@ifc-lite/wasm';
+
+/**
+ * The whole symbolic collection as transferable arrays.
+ *
+ * Variable-length data (curve points, fill rings, fill holes) is concatenated
+ * into one buffer per kind with a companion `*Start` offset array of length
+ * `N + 1`: item `i` spans `[start[i], start[i + 1])`. Fixed-width per-item data
+ * is one entry per item, or a fixed stride where noted.
+ *
+ * Every array is backed by its own `ArrayBuffer`, so the whole struct can be
+ * handed to `postMessage` as a transfer list.
+ */
+export interface FlatSymbolic {
+  /**
+   * IFC type names, deduplicated. The per-primitive `*Type` arrays index into
+   * this. After the filter it holds at most `IfcAnnotation` and `IfcGridAxis`,
+   * which is why a `Uint8Array` index is enough.
+   */
+  typeNames: string[];
+
+  // ── Polylines ────────────────────────────────────────────────────────────
+  /** Flat `[x, y, x, y, …]` for every polyline, back to back. */
+  polyPoints: Float32Array;
+  /** `N + 1` **point**-index offsets into `polyPoints` (float index = 2×). */
+  polyStart: Uint32Array;
+  /** Express id of the owning entity, one per polyline. */
+  polyOwner: Uint32Array;
+  /** `worldY` placement elevation, one per polyline. */
+  polyWorldY: Float32Array;
+  /** Bit 0 = `isClosed`. One per polyline. */
+  polyFlags: Uint8Array;
+  /** Index into {@link FlatSymbolic.typeNames}, one per polyline. */
+  polyType: Uint8Array;
+
+  // ── Circles / arcs ───────────────────────────────────────────────────────
+  circleCenterX: Float32Array;
+  circleCenterY: Float32Array;
+  circleRadius: Float32Array;
+  circleStartAngle: Float32Array;
+  circleEndAngle: Float32Array;
+  circleOwner: Uint32Array;
+  circleWorldY: Float32Array;
+  /** Bit 0 = `isFullCircle`. One per circle. */
+  circleFlags: Uint8Array;
+  circleType: Uint8Array;
+
+  // ── Texts ────────────────────────────────────────────────────────────────
+  /** Raw IFC literal, still STEP-escaped — decoded on the main thread. */
+  textContent: string[];
+  /** Raw IFC `BoxAlignment` string, one per text. */
+  textAlignment: string[];
+  textX: Float32Array;
+  textY: Float32Array;
+  textDirX: Float32Array;
+  textDirY: Float32Array;
+  textHeight: Float32Array;
+  textTargetPx: Float32Array;
+  /** Stride 4: `[r, g, b, a]` per text. `a <= 0` means "no authored colour". */
+  textColor: Float32Array;
+  textOwner: Uint32Array;
+  textWorldY: Float32Array;
+  textType: Uint8Array;
+
+  // ── Fills ────────────────────────────────────────────────────────────────
+  /** Flat ring vertices for every fill, back to back. */
+  fillPoints: Float32Array;
+  /**
+   * `N + 1` **float**-index offsets into `fillPoints`. Float indices rather
+   * than vertex indices because the main-side `points.length < 6` guard reads
+   * the raw array length WASM produced; deriving the span from `pointCount`
+   * would silently drop a trailing odd float and move that boundary.
+   */
+  fillPointStart: Uint32Array;
+  /** Hole start vertex indices, relative to each fill's own ring buffer. */
+  fillHoles: Uint32Array;
+  /** `N + 1` offsets into `fillHoles`. */
+  fillHoleStart: Uint32Array;
+  /** Stride 4: `[r, g, b, a]` per fill. */
+  fillColor: Float32Array;
+  /**
+   * Stride 4: `[spacing, angle, angleSecondary, lineWidth]` per fill. Only
+   * meaningful when bit 0 of {@link FlatSymbolic.fillFlags} is set;
+   * `angleSecondary` carries `NaN` when the style had no secondary angle.
+   */
+  fillHatch: Float32Array;
+  fillOwner: Uint32Array;
+  fillWorldY: Float32Array;
+  /** Bit 0 = `hasHatching`. One per fill. */
+  fillFlags: Uint8Array;
+  fillType: Uint8Array;
+}
+
+/** An empty flatten — the shape a skipped or empty parse produces. */
+export function createEmptyFlatSymbolic(): FlatSymbolic {
+  return {
+    typeNames: [],
+    polyPoints: new Float32Array(0),
+    polyStart: new Uint32Array(1),
+    polyOwner: new Uint32Array(0),
+    polyWorldY: new Float32Array(0),
+    polyFlags: new Uint8Array(0),
+    polyType: new Uint8Array(0),
+    circleCenterX: new Float32Array(0),
+    circleCenterY: new Float32Array(0),
+    circleRadius: new Float32Array(0),
+    circleStartAngle: new Float32Array(0),
+    circleEndAngle: new Float32Array(0),
+    circleOwner: new Uint32Array(0),
+    circleWorldY: new Float32Array(0),
+    circleFlags: new Uint8Array(0),
+    circleType: new Uint8Array(0),
+    textContent: [],
+    textAlignment: [],
+    textX: new Float32Array(0),
+    textY: new Float32Array(0),
+    textDirX: new Float32Array(0),
+    textDirY: new Float32Array(0),
+    textHeight: new Float32Array(0),
+    textTargetPx: new Float32Array(0),
+    textColor: new Float32Array(0),
+    textOwner: new Uint32Array(0),
+    textWorldY: new Float32Array(0),
+    textType: new Uint8Array(0),
+    fillPoints: new Float32Array(0),
+    fillPointStart: new Uint32Array(1),
+    fillHoles: new Uint32Array(0),
+    fillHoleStart: new Uint32Array(1),
+    fillColor: new Float32Array(0),
+    fillHatch: new Float32Array(0),
+    fillOwner: new Uint32Array(0),
+    fillWorldY: new Float32Array(0),
+    fillFlags: new Uint8Array(0),
+    fillType: new Uint8Array(0),
+  };
+}
+
+/** The only two owner types the annotation overlay renders (issue #862). */
+function isOverlayType(ifcType: string): boolean {
+  return ifcType === 'IfcAnnotation' || ifcType === 'IfcGridAxis';
+}
+
+/** Intern an IFC type name into the shared table, returning its index. */
+function intern(names: string[], index: Map<string, number>, name: string): number {
+  const existing = index.get(name);
+  if (existing !== undefined) return existing;
+  const next = names.length;
+  names.push(name);
+  index.set(name, next);
+  return next;
+}
+
+/**
+ * Flatten a WASM symbolic collection into transferable arrays.
+ *
+ * Frees every per-item handle it takes (`getPolyline` / `getCircle` /
+ * `getText` / `getFill`) in `try/finally`, so a mid-flatten throw cannot leak
+ * WASM memory into the FinalizationRegistry (AGENTS.md §Geometry & WASM).
+ * Ownership of `collection` itself stays with the caller.
+ */
+export function collectFlatSymbolic(collection: SymbolicRepresentationCollection): FlatSymbolic {
+  const typeNames: string[] = [];
+  const typeIndex = new Map<string, number>();
+
+  const polyPoints: number[] = [];
+  const polyStart: number[] = [0];
+  const polyOwner: number[] = [];
+  const polyWorldY: number[] = [];
+  const polyFlags: number[] = [];
+  const polyType: number[] = [];
+
+  for (let i = 0; i < collection.polylineCount; i++) {
+    const poly = collection.getPolyline(i);
+    if (!poly) continue;
+    try {
+      const ifcType = poly.ifcType;
+      if (!isOverlayType(ifcType)) continue;
+      // `pointCount` is `points.len() / 2`, so `pointCount * 2` never reads
+      // past the end even if the source vector had an odd length.
+      const pointCount = poly.pointCount;
+      const points = poly.points;
+      for (let j = 0; j < pointCount * 2; j++) polyPoints.push(points[j]);
+      polyStart.push(polyPoints.length / 2);
+      polyOwner.push(poly.expressId);
+      polyWorldY.push(poly.worldY);
+      polyFlags.push(poly.isClosed ? 1 : 0);
+      polyType.push(intern(typeNames, typeIndex, ifcType));
+    } finally {
+      poly.free();
+    }
+  }
+
+  const circleCenterX: number[] = [];
+  const circleCenterY: number[] = [];
+  const circleRadius: number[] = [];
+  const circleStartAngle: number[] = [];
+  const circleEndAngle: number[] = [];
+  const circleOwner: number[] = [];
+  const circleWorldY: number[] = [];
+  const circleFlags: number[] = [];
+  const circleType: number[] = [];
+
+  for (let i = 0; i < collection.circleCount; i++) {
+    const circle = collection.getCircle(i);
+    if (!circle) continue;
+    try {
+      const ifcType = circle.ifcType;
+      if (!isOverlayType(ifcType)) continue;
+      circleCenterX.push(circle.centerX);
+      circleCenterY.push(circle.centerY);
+      circleRadius.push(circle.radius);
+      circleStartAngle.push(circle.startAngle);
+      circleEndAngle.push(circle.endAngle);
+      circleOwner.push(circle.expressId);
+      circleWorldY.push(circle.worldY);
+      circleFlags.push(circle.isFullCircle ? 1 : 0);
+      circleType.push(intern(typeNames, typeIndex, ifcType));
+    } finally {
+      circle.free();
+    }
+  }
+
+  const textContent: string[] = [];
+  const textAlignment: string[] = [];
+  const textX: number[] = [];
+  const textY: number[] = [];
+  const textDirX: number[] = [];
+  const textDirY: number[] = [];
+  const textHeight: number[] = [];
+  const textTargetPx: number[] = [];
+  const textColor: number[] = [];
+  const textOwner: number[] = [];
+  const textWorldY: number[] = [];
+  const textType: number[] = [];
+
+  for (let i = 0; i < collection.textCount; i++) {
+    const text = collection.getText(i);
+    if (!text) continue;
+    try {
+      const ifcType = text.ifcType;
+      if (!isOverlayType(ifcType)) continue;
+      // Content crosses verbatim: `decodeIfcString` and the multi-line split
+      // stay main-side so the encoding behaviour is unchanged.
+      textContent.push(text.content);
+      textAlignment.push(text.alignment);
+      textX.push(text.x);
+      textY.push(text.y);
+      textDirX.push(text.dirX);
+      textDirY.push(text.dirY);
+      textHeight.push(text.height);
+      textTargetPx.push(text.targetPx);
+      textColor.push(text.colorR, text.colorG, text.colorB, text.colorA);
+      textOwner.push(text.expressId);
+      textWorldY.push(text.worldY);
+      textType.push(intern(typeNames, typeIndex, ifcType));
+    } finally {
+      text.free();
+    }
+  }
+
+  const fillPoints: number[] = [];
+  const fillPointStart: number[] = [0];
+  const fillHoles: number[] = [];
+  const fillHoleStart: number[] = [0];
+  const fillColor: number[] = [];
+  const fillHatch: number[] = [];
+  const fillOwner: number[] = [];
+  const fillWorldY: number[] = [];
+  const fillFlags: number[] = [];
+  const fillType: number[] = [];
+
+  for (let i = 0; i < collection.fillCount; i++) {
+    const fill = collection.getFill(i);
+    if (!fill) continue;
+    try {
+      const ifcType = fill.ifcType;
+      if (!isOverlayType(ifcType)) continue;
+      // The degenerate-ring guard (`< 3` vertices) stays main-side, next to
+      // the bucket it must not create; carry the ring across as authored.
+      const points = fill.points;
+      for (let j = 0; j < points.length; j++) fillPoints.push(points[j]);
+      fillPointStart.push(fillPoints.length);
+      const holes = fill.holesOffsets;
+      for (let j = 0; j < holes.length; j++) fillHoles.push(holes[j]);
+      fillHoleStart.push(fillHoles.length);
+      fillColor.push(fill.fillR, fill.fillG, fill.fillB, fill.fillA);
+      // `hatchAngleSecondary` keeps its NaN "absent" sentinel here; the main
+      // side is what turns it into `null`.
+      fillHatch.push(fill.hatchSpacing, fill.hatchAngle, fill.hatchAngleSecondary, fill.hatchLineWidth);
+      fillOwner.push(fill.expressId);
+      fillWorldY.push(fill.worldY);
+      fillFlags.push(fill.hasHatching ? 1 : 0);
+      fillType.push(intern(typeNames, typeIndex, ifcType));
+    } finally {
+      fill.free();
+    }
+  }
+
+  return {
+    typeNames,
+    polyPoints: Float32Array.from(polyPoints),
+    polyStart: Uint32Array.from(polyStart),
+    polyOwner: Uint32Array.from(polyOwner),
+    polyWorldY: Float32Array.from(polyWorldY),
+    polyFlags: Uint8Array.from(polyFlags),
+    polyType: Uint8Array.from(polyType),
+    circleCenterX: Float32Array.from(circleCenterX),
+    circleCenterY: Float32Array.from(circleCenterY),
+    circleRadius: Float32Array.from(circleRadius),
+    circleStartAngle: Float32Array.from(circleStartAngle),
+    circleEndAngle: Float32Array.from(circleEndAngle),
+    circleOwner: Uint32Array.from(circleOwner),
+    circleWorldY: Float32Array.from(circleWorldY),
+    circleFlags: Uint8Array.from(circleFlags),
+    circleType: Uint8Array.from(circleType),
+    textContent,
+    textAlignment,
+    textX: Float32Array.from(textX),
+    textY: Float32Array.from(textY),
+    textDirX: Float32Array.from(textDirX),
+    textDirY: Float32Array.from(textDirY),
+    textHeight: Float32Array.from(textHeight),
+    textTargetPx: Float32Array.from(textTargetPx),
+    textColor: Float32Array.from(textColor),
+    textOwner: Uint32Array.from(textOwner),
+    textWorldY: Float32Array.from(textWorldY),
+    textType: Uint8Array.from(textType),
+    fillPoints: Float32Array.from(fillPoints),
+    fillPointStart: Uint32Array.from(fillPointStart),
+    fillHoles: Uint32Array.from(fillHoles),
+    fillHoleStart: Uint32Array.from(fillHoleStart),
+    fillColor: Float32Array.from(fillColor),
+    fillHatch: Float32Array.from(fillHatch),
+    fillOwner: Uint32Array.from(fillOwner),
+    fillWorldY: Float32Array.from(fillWorldY),
+    fillFlags: Uint8Array.from(fillFlags),
+    fillType: Uint8Array.from(fillType),
+  };
+}

--- a/apps/viewer/src/lib/overlay-parse/symbolic-golden.test.ts
+++ b/apps/viewer/src/lib/overlay-parse/symbolic-golden.test.ts
@@ -32,6 +32,17 @@ import type { AnnotationsForStorey, ParseResult } from './symbolic-shapes.js';
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', '..', '..');
 
+/**
+ * Fixture paths CI will actually fetch. Read from the COMMITTED manifest, so
+ * a fixture silently dropping out of it fails rather than turning these
+ * digests into a permanent skip.
+ */
+const manifestPaths = new Set<string>(
+  (JSON.parse(
+    readFileSync(join(REPO_ROOT, 'tests', 'models', 'manifest.json'), 'utf8'),
+  ) as { files: { path: string }[] }).files.map((f) => `tests/models/${f.path}`),
+);
+
 interface GoldenFixture {
   /** Repo-relative fixture path. */
   path: string;
@@ -118,6 +129,18 @@ function countPrimitives(result: ParseResult): number {
 describe('symbolic parse golden digests (#2183)', () => {
   for (const fixture of FIXTURES) {
     it(`reproduces the pinned ParseResult for ${fixture.path}`, async () => {
+      // AGENTS.md requires fixture-backed tests to SKIP, not throw, when the
+      // fixture is absent — they are not committed, and CI fetches them via
+      // `pnpm fixtures` before running. But a plain skip would also stay
+      // silent if the fixture were dropped from the manifest, which WOULD
+      // make this permanently vacuous in CI. The manifest is committed, so
+      // assert membership there first: absence from the manifest fails,
+      // absence from disk skips.
+      assert.ok(
+        manifestPaths.has(fixture.path),
+        `${fixture.path} is not in tests/models/manifest.json, so CI will never fetch it `
+        + 'and this digest would silently stop running',
+      );
       const abs = join(REPO_ROOT, fixture.path);
       if (!existsSync(abs)) {
         console.warn(`skip: ${fixture.path} absent — run \`pnpm fixtures\``);

--- a/apps/viewer/src/lib/overlay-parse/symbolic-golden.test.ts
+++ b/apps/viewer/src/lib/overlay-parse/symbolic-golden.test.ts
@@ -1,0 +1,142 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { parseSymbolicAnnotations } from './symbolic-parse.js';
+import type { AnnotationsForStorey, ParseResult } from './symbolic-shapes.js';
+
+/**
+ * Byte-equivalence anchor for the symbolic-annotation parse (#2183).
+ *
+ * The parse is being moved into a worker, which means its output has to
+ * survive a structured-clone boundary and be reassembled on the main thread.
+ * "The overlay still looks right" is not a proof — the failure modes are a
+ * shifted bucket key, a dropped grid/annotation split, a float that lost
+ * precision crossing as f32, or a NaN sentinel that turned into null.
+ *
+ * So: pin a canonical digest of the whole `ParseResult` against real
+ * fixtures, before the move. After the move the same digest must reproduce
+ * exactly. Fixtures are not committed (see AGENTS.md), so this skips when
+ * they are absent rather than failing.
+ *
+ * Regenerate with `IFC_GOLDEN_UPDATE=1` and commit the printed digests, but
+ * only when the output is *meant* to change — that is the whole point.
+ */
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', '..', '..');
+
+interface GoldenFixture {
+  /** Repo-relative fixture path. */
+  path: string;
+  /** SHA-256 over {@link canonicalise}. */
+  digest: string;
+  /** Cheap sanity so a fixture that silently parses to nothing cannot pass. */
+  minPrimitives: number;
+}
+
+const FIXTURES: GoldenFixture[] = [
+  {
+    path: 'tests/models/various/01_BIMcollab_Example_ARC.ifc',
+    digest: '838895dd19709818c72698fac680c63ef8de250c237d9997e3d6c9bc077770cc',
+    minPrimitives: 80,
+  },
+  {
+    path: 'tests/models/ara3d/ISSUE_102_M3D-CON-CD.ifc',
+    digest: '364152e3a148c0b2a303285d31f3ac31866b009a0b7aa2263935631d67046d3e',
+    minPrimitives: 400,
+  },
+];
+
+/** Stable, lossless text form of a ParseResult. Order-independent by construction. */
+function canonicalise(result: ParseResult): string {
+  const num = (n: number): string =>
+    Number.isNaN(n) ? 'NaN' : Object.is(n, -0) ? '-0' : String(n);
+
+  const bucket = (b: AnnotationsForStorey): unknown => ({
+    storeyId: b.storeyId,
+    storeyElevation: b.storeyElevation === null ? null : num(b.storeyElevation),
+    lines: b.lines.map((l) => [
+      num(l.line.start.x), num(l.line.start.y),
+      num(l.line.end.x), num(l.line.end.y),
+      l.category, l.ownerId ?? null,
+    ]),
+    texts: b.texts.map((t) => [
+      num(t.x), num(t.y), num(t.dirX), num(t.dirY), num(t.height),
+      t.content, t.alignment, t.ownerId,
+      t.lineYOffset === undefined ? null : num(t.lineYOffset),
+      t.billboard ?? null,
+      t.color ? t.color.map(num) : null,
+      t.targetPx === undefined ? null : num(t.targetPx),
+    ]),
+    fills: b.fills.map((f) => [
+      Array.from(f.points).map(num),
+      Array.from(f.holesOffsets),
+      f.color.map(num),
+      f.ownerId,
+      f.hatching
+        ? [num(f.hatching.spacing), num(f.hatching.angle),
+           f.hatching.angleSecondary === null ? null : num(f.hatching.angleSecondary),
+           num(f.hatching.lineWidth)]
+        : null,
+    ]),
+  });
+
+  const buckets = (m: Map<number, AnnotationsForStorey>): unknown =>
+    [...m.entries()].sort((a, b) => a[0] - b[0]).map(([k, v]) => [k, bucket(v)]);
+
+  // Reuse the bucket serialiser for the loose arrays by wrapping them.
+  const loose = (
+    lines: ParseResult['loose'],
+    texts: ParseResult['looseTexts'],
+    fills: ParseResult['looseFills'],
+  ): unknown => bucket({ storeyId: -1, storeyElevation: null, lines, texts, fills });
+
+  return JSON.stringify({
+    byStorey: buckets(result.byStorey),
+    gridByStorey: buckets(result.gridByStorey),
+    loose: loose(result.loose, result.looseTexts, result.looseFills),
+    gridLoose: loose(result.gridLoose, result.gridLooseTexts, result.gridLooseFills),
+  });
+}
+
+function countPrimitives(result: ParseResult): number {
+  let n = result.loose.length + result.looseTexts.length + result.looseFills.length
+    + result.gridLoose.length + result.gridLooseTexts.length + result.gridLooseFills.length;
+  for (const m of [result.byStorey, result.gridByStorey]) {
+    for (const b of m.values()) n += b.lines.length + b.texts.length + b.fills.length;
+  }
+  return n;
+}
+
+describe('symbolic parse golden digests (#2183)', () => {
+  for (const fixture of FIXTURES) {
+    it(`reproduces the pinned ParseResult for ${fixture.path}`, async () => {
+      const abs = join(REPO_ROOT, fixture.path);
+      if (!existsSync(abs)) {
+        console.warn(`skip: ${fixture.path} absent — run \`pnpm fixtures\``);
+        return;
+      }
+      const result = await parseSymbolicAnnotations({ source: new Uint8Array(readFileSync(abs)) });
+
+      const primitives = countPrimitives(result);
+      assert.ok(
+        primitives >= fixture.minPrimitives,
+        `only ${primitives} primitives; a fixture that parses to nothing would make the digest vacuous`,
+      );
+
+      const digest = createHash('sha256').update(canonicalise(result)).digest('hex');
+      if (process.env.IFC_GOLDEN_UPDATE === '1') {
+        console.log(`${fixture.path}\n  digest: ${digest}\n  primitives: ${primitives}`);
+        return;
+      }
+      assert.equal(digest, fixture.digest, 'symbolic parse output changed');
+    });
+  }
+});

--- a/apps/viewer/src/lib/overlay-parse/symbolic-parse.ts
+++ b/apps/viewer/src/lib/overlay-parse/symbolic-parse.ts
@@ -11,10 +11,27 @@
  * import a React hook file, and the store is not structured-cloneable. The
  * `hasEntityType` pre-filter stays at the call site because it reads
  * `store.entityIndex`, which is not part of this input.
+ *
+ * The parse is split at the WASM-collection seam (#2183):
+ *
+ *   - `collectFlatSymbolic` (`symbolic-flat.ts`) walks the WASM handles and
+ *     flattens them into transferable typed arrays. WASM-bound, worker-side.
+ *   - `buildParseResult` turns those arrays into the `ParseResult` the overlay
+ *     renders: tessellation, text decoding, and storey bucketing. Pure JS,
+ *     main-thread-side.
+ *
+ * `parseSymbolicAnnotations` is the two composed on one thread. It stays the
+ * reference implementation — the golden-digest test drives it — so the worker
+ * path is correct exactly when it reproduces this composition.
  */
 
 import { GeometryProcessor } from '@ifc-lite/geometry';
 import { decodeIfcString } from '@ifc-lite/encoding';
+import {
+  collectFlatSymbolic,
+  createEmptyFlatSymbolic,
+  type FlatSymbolic,
+} from './symbolic-flat.js';
 import {
   circleToSegments,
   createEmptyParseResult,
@@ -29,6 +46,7 @@ import {
 // under the ~400 line house limit. Re-exported so this stays the single import
 // site for consumers of the parse.
 export * from './symbolic-shapes.js';
+export * from './symbolic-flat.js';
 
 /** Verbose annotation tracing, opt-in via localStorage and therefore off by
  *  default; useful when triaging "no annotations visible" reports. */
@@ -54,20 +72,227 @@ export interface SymbolicParseInput {
   storeyElevations?: ReadonlyMap<number, number>;
 }
 
+/** The spatial-hierarchy half of {@link SymbolicParseInput}. Structured-clone
+ *  friendly, so the main thread can hold it while the worker parses. */
+export interface SymbolicHierarchyInput {
+  elementToStorey?: ReadonlyMap<number, number>;
+  storeyElevations?: ReadonlyMap<number, number>;
+}
+
+/**
+ * Assemble the renderable `ParseResult` from a flattened collection.
+ *
+ * Main-thread half of the split: tessellation, STEP text decoding, and storey
+ * bucketing. Takes no WASM handle, so the worker can hand `flat` over a
+ * `postMessage` and this runs unchanged on the other side.
+ */
+export function buildParseResult(
+  flat: FlatSymbolic,
+  hierarchy: SymbolicHierarchyInput,
+): ParseResult {
+  const result: ParseResult = createEmptyParseResult();
+  const elementToStorey = hierarchy.elementToStorey;
+  const storeyElevations = hierarchy.storeyElevations;
+
+  // Resolve a bucket by elevation rather than by storey id.
+  //
+  // The legacy path used `elementToStorey` exclusively — which breaks for
+  // 3DEXPERIENCE / IfcPlusPlus exports whose `IfcRelAggregates` leaves
+  // storeys orphaned so `SpatialHierarchyBuilder` reports "No storeys
+  // found". Those files still encode the elevation on each item's
+  // geometry (the IfcCartesianPoint.Z), which the WASM extractor now
+  // surfaces as `primitive.worldY`. Bucketing by Y means every annotation
+  // lands at the right floor regardless of whether the spatial hierarchy
+  // could be built.
+  //
+  // Priority: explicit primitive worldY → fall back to storey-table
+  // elevation → null (loose bucket, renders at fallbackY).
+  //
+  // Bucket keys are millimetre-rounded Y so two storeys 1mm apart still
+  // collapse to one bucket — that's the precision Revit etc. round to.
+  const ensureBucket = (
+    expressId: number,
+    primitiveWorldY: number,
+    ifcType: string,
+  ): AnnotationsForStorey | null => {
+    let effectiveY: number | null = null;
+    if (Number.isFinite(primitiveWorldY) && primitiveWorldY !== 0) {
+      effectiveY = primitiveWorldY;
+    } else {
+      const storeyId = elementToStorey?.get(expressId);
+      if (storeyId !== undefined) {
+        const elev = storeyElevations?.get(storeyId);
+        if (typeof elev === 'number' && Number.isFinite(elev)) effectiveY = elev;
+      }
+    }
+    if (effectiveY === null) return null;
+    const key = Math.round(effectiveY * 1000);
+    // Issue #862: IfcGridAxis primitives land in a parallel bucket
+    // collection so the renderer can section-clip + visibility-toggle
+    // them independently of IfcAnnotation (text/dimension symbols).
+    const storeyMap = ifcType === 'IfcGridAxis' ? result.gridByStorey : result.byStorey;
+    let bucket = storeyMap.get(key);
+    if (!bucket) {
+      bucket = {
+        storeyId: key,
+        storeyElevation: effectiveY,
+        lines: [],
+        texts: [],
+        fills: [],
+      };
+      storeyMap.set(key, bucket);
+    }
+    return bucket;
+  };
+
+  const typeNames = flat.typeNames;
+
+  for (let i = 0; i < flat.polyOwner.length; i++) {
+    const ifcType = typeNames[flat.polyType[i]];
+    const expressId = flat.polyOwner[i];
+    const bucket = ensureBucket(expressId, flat.polyWorldY[i], ifcType);
+    const looseTarget = ifcType === 'IfcGridAxis' ? result.gridLoose : result.loose;
+    const out = bucket ? bucket.lines : looseTarget;
+    // The points are consumed synchronously here (not stored), so a subarray
+    // view over the shared buffer is enough — no copy needed.
+    const start = flat.polyStart[i];
+    const pointCount = flat.polyStart[i + 1] - start;
+    const points = flat.polyPoints.subarray(start * 2, (start + pointCount) * 2);
+    polylineToSegments(points, pointCount, (flat.polyFlags[i] & 1) !== 0, out, expressId);
+  }
+
+  for (let i = 0; i < flat.circleOwner.length; i++) {
+    const ifcType = typeNames[flat.circleType[i]];
+    const expressId = flat.circleOwner[i];
+    const bucket = ensureBucket(expressId, flat.circleWorldY[i], ifcType);
+    const looseTarget = ifcType === 'IfcGridAxis' ? result.gridLoose : result.loose;
+    const out = bucket ? bucket.lines : looseTarget;
+    circleToSegments(
+      flat.circleCenterX[i],
+      flat.circleCenterY[i],
+      flat.circleRadius[i],
+      flat.circleStartAngle[i],
+      flat.circleEndAngle[i],
+      (flat.circleFlags[i] & 1) !== 0,
+      out,
+      expressId,
+    );
+  }
+
+  for (let i = 0; i < flat.textOwner.length; i++) {
+    const ifcType = typeNames[flat.textType[i]];
+    const expressId = flat.textOwner[i];
+    // Skip empty literals so the renderer doesn't waste an instance slot.
+    // Decode STEP escapes — `\X2\NNNN\X0\` (UTF-16 hex code units) and
+    // `\X\NN` (Latin-1 hex byte). The Rust parser intentionally passes
+    // the literal through verbatim; this is where the JS encoding
+    // package gets applied. Without it, non-ASCII annotation labels
+    // (e.g. CJK content) render as raw escape sequences in the atlas.
+    const decoded = decodeIfcString(flat.textContent[i]);
+    if (decoded.length === 0) continue;
+
+    // Multi-line split: IfcTextLiteralWithExtent.SizeInY is the LAYOUT BOX
+    // height, not the glyph cap height. The Rust extractor multiplies
+    // SizeInY × 0.7 to recover a single-line cap; for multi-line literals
+    // we further divide by line count and stack lines downward in world-Y.
+    // Source: IFC4 spec — IfcPlanarExtent describes the bounding box of
+    // the typeset string; one literal per line is the conventional
+    // rendering model (matches BIMvision / Solibri / Revit).
+    const lines = decoded.split(/\r?\n/).filter((l) => l.length > 0);
+    if (lines.length === 0) continue;
+    const height = flat.textHeight[i];
+    const perLineHeight = lines.length > 1 ? height / lines.length : height;
+    // Industry-standard line-spacing (CSS line-height ≈ 1.2). Picks up
+    // a little air between rows so descenders don't kiss the next cap.
+    const lineSpacing = perLineHeight * 1.2;
+    const bucket = ensureBucket(expressId, flat.textWorldY[i], ifcType);
+    const looseTextTarget = ifcType === 'IfcGridAxis' ? result.gridLooseTexts : result.looseTexts;
+    // All annotation text — grid bubbles, dimension callouts, leader labels —
+    // billboards to the camera so it stays legible in any view orientation
+    // (top-down, eye-level, oblique). The shader rebuilds the quad in the
+    // screen-aligned basis at render time. Authored orientation is intentionally
+    // dropped: at oblique viewing angles, flat-in-plane text becomes a smeared
+    // sliver of pixels (issue #812). Anchor + alignment are preserved, so each
+    // label still sits at its authored insertion point.
+    // Read per-instance style metadata. WASM emits these for grid
+    // bubble parts (● fill / ○ outline / tag) and reserves them for
+    // future IfcTextStyle resolution on regular annotation text.
+    const colorA = flat.textColor[i * 4 + 3];
+    const hasColor = colorA > 0;
+    const textColor: [number, number, number, number] | undefined = hasColor
+      ? [flat.textColor[i * 4], flat.textColor[i * 4 + 1], flat.textColor[i * 4 + 2], colorA]
+      : undefined;
+    const rawTargetPx = flat.textTargetPx[i];
+    const targetPx = rawTargetPx > 0 ? rawTargetPx : undefined;
+    const alignment = flat.textAlignment[i];
+    for (let li = 0; li < lines.length; li++) {
+      const t2d: AnnotationText2D = {
+        x: flat.textX[i],
+        y: flat.textY[i],
+        dirX: flat.textDirX[i],
+        dirY: flat.textDirY[i],
+        height: perLineHeight,
+        content: lines[li],
+        alignment,
+        lineYOffset: -li * lineSpacing,
+        billboard: true,
+        color: textColor,
+        targetPx,
+        ownerId: expressId,
+      };
+      (bucket ? bucket.texts : looseTextTarget).push(t2d);
+    }
+  }
+
+  for (let i = 0; i < flat.fillOwner.length; i++) {
+    const ifcType = typeNames[flat.fillType[i]];
+    const expressId = flat.fillOwner[i];
+    // The ring vertices and hole table are STORED into f2d (they outlive this
+    // iteration), so slice them out of the shared buffers rather than viewing
+    // them. Element types match the AnnotationFill2D fields.
+    const points = flat.fillPoints.slice(flat.fillPointStart[i], flat.fillPointStart[i + 1]);
+    if (points.length < 6) continue; // <3 vertices = no polygon
+    const holesOffsets = flat.fillHoles.slice(flat.fillHoleStart[i], flat.fillHoleStart[i + 1]);
+    const f2d: AnnotationFill2D = {
+      points,
+      holesOffsets,
+      color: [
+        flat.fillColor[i * 4],
+        flat.fillColor[i * 4 + 1],
+        flat.fillColor[i * 4 + 2],
+        flat.fillColor[i * 4 + 3],
+      ],
+      ownerId: expressId,
+      hatching: (flat.fillFlags[i] & 1) !== 0
+        ? {
+            spacing: flat.fillHatch[i * 4],
+            angle: flat.fillHatch[i * 4 + 1],
+            angleSecondary: Number.isNaN(flat.fillHatch[i * 4 + 2]) ? null : flat.fillHatch[i * 4 + 2],
+            lineWidth: flat.fillHatch[i * 4 + 3],
+          }
+        : undefined,
+    };
+    const bucket = ensureBucket(expressId, flat.fillWorldY[i], ifcType);
+    const looseFillTarget = ifcType === 'IfcGridAxis' ? result.gridLooseFills : result.looseFills;
+    (bucket ? bucket.fills : looseFillTarget).push(f2d);
+  }
+
+  return result;
+}
+
 export async function parseSymbolicAnnotations(
   input: SymbolicParseInput,
 ): Promise<ParseResult> {
-  const result: ParseResult = createEmptyParseResult();
   const source = input.source;
   if (!source || source.byteLength === 0) {
     if (debugEnabled()) console.log('[annotations] skip: missing/empty source');
-    return result;
+    return createEmptyParseResult();
   }
 
-  const elementToStorey = input.elementToStorey;
-  const storeyElevations = input.storeyElevations;
-
   const processor = new GeometryProcessor();
+  // An empty flatten builds the empty ParseResult, so the "no collection" and
+  // "empty collection" exits need no separate early return.
+  let flat: FlatSymbolic = createEmptyFlatSymbolic();
   try {
     await processor.init();
     // SymbolicRepresentationCollection and each getPolyline/getCircle/getText/
@@ -84,205 +309,16 @@ export async function parseSymbolicAnnotations(
           : 'null',
       );
     }
-    if (!collection) return result;
-    try {
-    if (collection.isEmpty) return result;
-
-    // Resolve a bucket by elevation rather than by storey id.
-    //
-    // The legacy path used `elementToStorey` exclusively — which breaks for
-    // 3DEXPERIENCE / IfcPlusPlus exports whose `IfcRelAggregates` leaves
-    // storeys orphaned so `SpatialHierarchyBuilder` reports "No storeys
-    // found". Those files still encode the elevation on each item's
-    // geometry (the IfcCartesianPoint.Z), which the WASM extractor now
-    // surfaces as `primitive.worldY`. Bucketing by Y means every annotation
-    // lands at the right floor regardless of whether the spatial hierarchy
-    // could be built.
-    //
-    // Priority: explicit primitive worldY → fall back to storey-table
-    // elevation → null (loose bucket, renders at fallbackY).
-    //
-    // Bucket keys are millimetre-rounded Y so two storeys 1mm apart still
-    // collapse to one bucket — that's the precision Revit etc. round to.
-    const ensureBucket = (
-      expressId: number,
-      primitiveWorldY: number,
-      ifcType: string,
-    ): AnnotationsForStorey | null => {
-      let effectiveY: number | null = null;
-      if (Number.isFinite(primitiveWorldY) && primitiveWorldY !== 0) {
-        effectiveY = primitiveWorldY;
-      } else {
-        const storeyId = elementToStorey?.get(expressId);
-        if (storeyId !== undefined) {
-          const elev = storeyElevations?.get(storeyId);
-          if (typeof elev === 'number' && Number.isFinite(elev)) effectiveY = elev;
-        }
-      }
-      if (effectiveY === null) return null;
-      const key = Math.round(effectiveY * 1000);
-      // Issue #862: IfcGridAxis primitives land in a parallel bucket
-      // collection so the renderer can section-clip + visibility-toggle
-      // them independently of IfcAnnotation (text/dimension symbols).
-      const storeyMap = ifcType === 'IfcGridAxis' ? result.gridByStorey : result.byStorey;
-      let bucket = storeyMap.get(key);
-      if (!bucket) {
-        bucket = {
-          storeyId: key,
-          storeyElevation: effectiveY,
-          lines: [],
-          texts: [],
-          fills: [],
-        };
-        storeyMap.set(key, bucket);
-      }
-      return bucket;
-    };
-
-    for (let i = 0; i < collection.polylineCount; i++) {
-      const poly = collection.getPolyline(i);
-      if (!poly) continue;
+    if (collection) {
       try {
-        if (poly.ifcType !== 'IfcAnnotation' && poly.ifcType !== 'IfcGridAxis') continue;
-        const bucket = ensureBucket(poly.expressId, poly.worldY, poly.ifcType);
-        const looseTarget = poly.ifcType === 'IfcGridAxis' ? result.gridLoose : result.loose;
-        const out = bucket ? bucket.lines : looseTarget;
-        // poly.points is consumed synchronously here (not stored), so no copy needed.
-        polylineToSegments(poly.points, poly.pointCount, poly.isClosed, out, poly.expressId);
+        if (!collection.isEmpty) flat = collectFlatSymbolic(collection);
       } finally {
-        poly.free();
+        collection.free();
       }
-    }
-
-    for (let i = 0; i < collection.circleCount; i++) {
-      const circle = collection.getCircle(i);
-      if (!circle) continue;
-      try {
-        if (circle.ifcType !== 'IfcAnnotation' && circle.ifcType !== 'IfcGridAxis') continue;
-        const bucket = ensureBucket(circle.expressId, circle.worldY, circle.ifcType);
-        const looseTarget = circle.ifcType === 'IfcGridAxis' ? result.gridLoose : result.loose;
-        const out = bucket ? bucket.lines : looseTarget;
-        circleToSegments(
-          circle.centerX,
-          circle.centerY,
-          circle.radius,
-          circle.startAngle,
-          circle.endAngle,
-          circle.isFullCircle,
-          out,
-          circle.expressId,
-        );
-      } finally {
-        circle.free();
-      }
-    }
-
-    for (let i = 0; i < collection.textCount; i++) {
-      const text = collection.getText(i);
-      if (!text) continue;
-      try {
-      if (text.ifcType !== 'IfcAnnotation' && text.ifcType !== 'IfcGridAxis') continue;
-      // Skip empty literals so the renderer doesn't waste an instance slot.
-      // Decode STEP escapes — `\X2\NNNN\X0\` (UTF-16 hex code units) and
-      // `\X\NN` (Latin-1 hex byte). The Rust parser intentionally passes
-      // the literal through verbatim; this is where the JS encoding
-      // package gets applied. Without it, non-ASCII annotation labels
-      // (e.g. CJK content) render as raw escape sequences in the atlas.
-      const decoded = decodeIfcString(text.content);
-      if (decoded.length === 0) continue;
-
-      // Multi-line split: IfcTextLiteralWithExtent.SizeInY is the LAYOUT BOX
-      // height, not the glyph cap height. The Rust extractor multiplies
-      // SizeInY × 0.7 to recover a single-line cap; for multi-line literals
-      // we further divide by line count and stack lines downward in world-Y.
-      // Source: IFC4 spec — IfcPlanarExtent describes the bounding box of
-      // the typeset string; one literal per line is the conventional
-      // rendering model (matches BIMvision / Solibri / Revit).
-      const lines = decoded.split(/\r?\n/).filter((l) => l.length > 0);
-      if (lines.length === 0) continue;
-      const perLineHeight = lines.length > 1 ? text.height / lines.length : text.height;
-      // Industry-standard line-spacing (CSS line-height ≈ 1.2). Picks up
-      // a little air between rows so descenders don't kiss the next cap.
-      const lineSpacing = perLineHeight * 1.2;
-      const bucket = ensureBucket(text.expressId, text.worldY, text.ifcType);
-      const looseTextTarget = text.ifcType === 'IfcGridAxis' ? result.gridLooseTexts : result.looseTexts;
-      // All annotation text — grid bubbles, dimension callouts, leader labels —
-      // billboards to the camera so it stays legible in any view orientation
-      // (top-down, eye-level, oblique). The shader rebuilds the quad in the
-      // screen-aligned basis at render time. Authored orientation is intentionally
-      // dropped: at oblique viewing angles, flat-in-plane text becomes a smeared
-      // sliver of pixels (issue #812). Anchor + alignment are preserved, so each
-      // label still sits at its authored insertion point.
-      // Read per-instance style metadata. WASM emits these for grid
-      // bubble parts (● fill / ○ outline / tag) and reserves them for
-      // future IfcTextStyle resolution on regular annotation text.
-      const colorA = text.colorA;
-      const hasColor = colorA > 0;
-      const textColor: [number, number, number, number] | undefined = hasColor
-        ? [text.colorR, text.colorG, text.colorB, colorA]
-        : undefined;
-      const targetPx = text.targetPx > 0 ? text.targetPx : undefined;
-      for (let li = 0; li < lines.length; li++) {
-        const t2d: AnnotationText2D = {
-          x: text.x,
-          y: text.y,
-          dirX: text.dirX,
-          dirY: text.dirY,
-          height: perLineHeight,
-          content: lines[li],
-          alignment: text.alignment,
-          lineYOffset: -li * lineSpacing,
-          billboard: true,
-          color: textColor,
-          targetPx,
-          ownerId: text.expressId,
-        };
-        (bucket ? bucket.texts : looseTextTarget).push(t2d);
-      }
-      } finally {
-        text.free();
-      }
-    }
-
-    for (let i = 0; i < collection.fillCount; i++) {
-      const fill = collection.getFill(i);
-      if (!fill) continue;
-      try {
-        if (fill.ifcType !== 'IfcAnnotation' && fill.ifcType !== 'IfcGridAxis') continue;
-        // fill.points / fill.holesOffsets are getter results that may be views
-        // into WASM memory; they're STORED into f2d (outlive this iteration),
-        // so copy them before the handle is freed below. Element types match
-        // the AnnotationFill2D fields (Float32Array / Uint32Array).
-        const points = new Float32Array(fill.points);
-        if (points.length < 6) continue; // <3 vertices = no polygon
-        const holesOffsets = new Uint32Array(fill.holesOffsets);
-        const f2d: AnnotationFill2D = {
-          points,
-          holesOffsets,
-          color: [fill.fillR, fill.fillG, fill.fillB, fill.fillA],
-          ownerId: fill.expressId,
-          hatching: fill.hasHatching
-            ? {
-                spacing: fill.hatchSpacing,
-                angle: fill.hatchAngle,
-                angleSecondary: Number.isNaN(fill.hatchAngleSecondary) ? null : fill.hatchAngleSecondary,
-                lineWidth: fill.hatchLineWidth,
-              }
-            : undefined,
-        };
-        const bucket = ensureBucket(fill.expressId, fill.worldY, fill.ifcType);
-        const looseFillTarget = fill.ifcType === 'IfcGridAxis' ? result.gridLooseFills : result.looseFills;
-        (bucket ? bucket.fills : looseFillTarget).push(f2d);
-      } finally {
-        fill.free();
-      }
-    }
-    } finally {
-      collection.free();
     }
   } finally {
     processor.dispose();
   }
 
-  return result;
+  return buildParseResult(flat, input);
 }

--- a/apps/viewer/src/test/overlay-worker-shim.test.ts
+++ b/apps/viewer/src/test/overlay-worker-shim.test.ts
@@ -18,33 +18,42 @@ import { parseOverlayLines, parseSymbolicFlat } from '@/lib/overlay-parse/index.
  * whichever job finishes first restores it and the other can never reply.
  */
 
-let restore: (() => void) | undefined;
+import type { OverlayShimHandle } from './overlay-worker-shim.js';
+
+let shim: OverlayShimHandle | undefined;
 
 afterEach(() => {
-  restore?.();
-  restore = undefined;
+  shim?.restore();
+  shim = undefined;
 });
 
 describe('in-process overlay worker shim', () => {
   it('routes replies correctly when jobs overlap', async () => {
-    restore = installInProcessOverlayWorker();
-    // Dispatched in the same tick: both are in flight before either settles.
+    shim = installInProcessOverlayWorker();
+    // Dispatched in the same tick: all three are in flight before any settles.
     const [grid, alignment, symbolic] = await Promise.all([
       parseOverlayLines('grid-lines', new Uint8Array([1])),
       parseOverlayLines('alignment-lines', new Uint8Array([1])),
       parseSymbolicFlat(new Uint8Array([1])),
     ]);
-    // Garbage input, so the values are empty — what matters is that all three
-    // SETTLED. A lost reply would hang until the client's deadline instead.
-    assert.ok(grid instanceof Float32Array, 'grid job must settle');
-    assert.ok(alignment instanceof Float32Array, 'alignment job must settle');
-    assert.ok(symbolic && Array.isArray(symbolic.typeNames), 'symbolic job must settle');
+    assert.ok(grid instanceof Float32Array);
+    assert.ok(alignment instanceof Float32Array);
+    assert.ok(symbolic && Array.isArray(symbolic.typeNames));
+
+    // The load-bearing assertion. The input is garbage, so every result is
+    // empty either way — and the client ALSO resolves empty when a reply is
+    // lost. Only the worker's own reply log distinguishes "three jobs
+    // answered" from "three jobs silently fell back".
+    assert.equal(
+      shim.repliedIds().length, 3,
+      `worker replied for ${shim.repliedIds().length} of 3 jobs; the rest hit the client fallback`,
+    );
+    assert.equal(new Set(shim.repliedIds()).size, 3, 'each job needs its own id');
   });
 
   it('restores the previous Worker wiring on teardown', async () => {
     const before = (globalThis as { self?: unknown }).self;
-    const undo = installInProcessOverlayWorker();
-    undo();
+    installInProcessOverlayWorker().restore();
     assert.equal((globalThis as { self?: unknown }).self, before);
     // With the shim gone and Node having no Worker, the client must resolve
     // empty rather than throw.

--- a/apps/viewer/src/test/overlay-worker-shim.test.ts
+++ b/apps/viewer/src/test/overlay-worker-shim.test.ts
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, afterEach } from 'node:test';
+import assert from 'node:assert';
+
+import { installInProcessOverlayWorker } from './overlay-worker-shim.js';
+import { parseOverlayLines, parseSymbolicFlat } from '@/lib/overlay-parse/index.js';
+
+/**
+ * The shim exists so end-to-end hook tests are not silently vacuous. If it
+ * loses a reply the tests it supports go quietly empty, which is precisely
+ * the failure mode it was written to prevent — so it needs its own cover.
+ *
+ * The specific hazard: the overlay client dispatches jobs concurrently, and
+ * `handle()` posts through `self.postMessage`. Swapping `self` per call means
+ * whichever job finishes first restores it and the other can never reply.
+ */
+
+let restore: (() => void) | undefined;
+
+afterEach(() => {
+  restore?.();
+  restore = undefined;
+});
+
+describe('in-process overlay worker shim', () => {
+  it('routes replies correctly when jobs overlap', async () => {
+    restore = installInProcessOverlayWorker();
+    // Dispatched in the same tick: both are in flight before either settles.
+    const [grid, alignment, symbolic] = await Promise.all([
+      parseOverlayLines('grid-lines', new Uint8Array([1])),
+      parseOverlayLines('alignment-lines', new Uint8Array([1])),
+      parseSymbolicFlat(new Uint8Array([1])),
+    ]);
+    // Garbage input, so the values are empty — what matters is that all three
+    // SETTLED. A lost reply would hang until the client's deadline instead.
+    assert.ok(grid instanceof Float32Array, 'grid job must settle');
+    assert.ok(alignment instanceof Float32Array, 'alignment job must settle');
+    assert.ok(symbolic && Array.isArray(symbolic.typeNames), 'symbolic job must settle');
+  });
+
+  it('restores the previous Worker wiring on teardown', async () => {
+    const before = (globalThis as { self?: unknown }).self;
+    const undo = installInProcessOverlayWorker();
+    undo();
+    assert.equal((globalThis as { self?: unknown }).self, before);
+    // With the shim gone and Node having no Worker, the client must resolve
+    // empty rather than throw.
+    assert.equal((await parseOverlayLines('grid-lines', new Uint8Array([1]))).length, 0);
+  });
+});

--- a/apps/viewer/src/test/overlay-worker-shim.ts
+++ b/apps/viewer/src/test/overlay-worker-shim.ts
@@ -30,7 +30,14 @@ type Slot = { postMessage?: unknown };
 /**
  * Install the shim. Returns a restore function; call it in `after()`.
  */
-export function installInProcessOverlayWorker(): () => void {
+export interface OverlayShimHandle {
+  /** Restore the previous wiring. */
+  restore(): void;
+  /** Request ids the WORKER actually posted a reply for. */
+  repliedIds(): number[];
+}
+
+export function installInProcessOverlayWorker(): OverlayShimHandle {
   const g = globalThis as unknown as { self?: Slot };
   const previousSelf = g.self;
 
@@ -39,11 +46,16 @@ export function installInProcessOverlayWorker(): () => void {
 
   /** Reply routers keyed by request id, so concurrent jobs cannot cross. */
   const inFlightById = new Map<number, (reply: unknown) => void>();
+  /** Ids the worker genuinely replied for. Lets a test tell a real reply from
+   *  the client's resolve-empty fallback, which look identical downstream. */
+  const replied: number[] = [];
 
   // One persistent `self` for the shim's lifetime.
   g.self = {
     postMessage: (reply: unknown) => {
-      const route = inFlightById.get((reply as { id: number }).id);
+      const id = (reply as { id: number }).id;
+      replied.push(id);
+      const route = inFlightById.get(id);
       route?.(reply);
     },
   };
@@ -86,8 +98,11 @@ export function installInProcessOverlayWorker(): () => void {
   // Scoped to the overlay client. Setting a global `Worker` would also
   // convince the PARSER that workers are available.
   __setOverlayWorkerFactoryForTest(() => new InProcessOverlayWorker() as unknown as Worker);
-  return () => {
-    __setOverlayWorkerFactoryForTest(null);
-    g.self = previousSelf;
+  return {
+    restore: () => {
+      __setOverlayWorkerFactoryForTest(null);
+      g.self = previousSelf;
+    },
+    repliedIds: () => [...replied],
   };
 }

--- a/apps/viewer/src/test/overlay-worker-shim.ts
+++ b/apps/viewer/src/test/overlay-worker-shim.ts
@@ -34,27 +34,47 @@ export function installInProcessOverlayWorker(): () => void {
   const g = globalThis as unknown as { self?: Slot };
   const previousSelf = g.self;
 
+  /** Mirrors the real worker's serial queue. */
+  let queue: Promise<void> = Promise.resolve();
+
+  /** Reply routers keyed by request id, so concurrent jobs cannot cross. */
+  const inFlightById = new Map<number, (reply: unknown) => void>();
+
+  // One persistent `self` for the shim's lifetime.
+  g.self = {
+    postMessage: (reply: unknown) => {
+      const route = inFlightById.get((reply as { id: number }).id);
+      route?.(reply);
+    },
+  };
+
   class InProcessOverlayWorker {
     onmessage: ((event: { data: unknown }) => void) | null = null;
     onerror: ((event: { message: string }) => void) | null = null;
     onmessageerror: (() => void) | null = null;
 
     postMessage(request: unknown): void {
-      // `handle` posts its reply through `self.postMessage`, so point `self`
-      // at this instance for the duration of the call.
-      const saved = g.self;
-      g.self = {
-        postMessage: (reply: unknown) => {
-          // Async delivery and a real clone, exactly like a worker hop.
-          queueMicrotask(() => this.onmessage?.({ data: structuredClone(reply) }));
-        },
-      };
-      void Promise.resolve(handle({ data: request } as never))
+      // The client dispatches jobs concurrently, so `self` must NOT be
+      // swapped per call: a first call restoring it while a second is still
+      // running would leave the second unable to post any reply at all.
+      // Instead `self` is installed once for the shim's lifetime and routes
+      // each reply back by request id.
+      const { id } = request as { id: number };
+      inFlightById.set(id, (reply) => {
+        // Async delivery and a real clone, exactly like a worker hop.
+        queueMicrotask(() => this.onmessage?.({ data: structuredClone(reply) }));
+      });
+      // Chain onto the same queue the real worker uses. Calling `handle`
+      // directly would let concurrent jobs each initialise WASM at once —
+      // exactly the double-instantiation the worker's serialisation exists to
+      // prevent — so an unserialised shim would not model the real thing.
+      queue = queue
+        .then(() => handle({ data: request } as never))
         .catch((error: unknown) => {
           this.onerror?.({ message: error instanceof Error ? error.message : String(error) });
         })
         .finally(() => {
-          g.self = saved;
+          inFlightById.delete(id);
         });
     }
 

--- a/apps/viewer/src/test/overlay-worker-shim.ts
+++ b/apps/viewer/src/test/overlay-worker-shim.ts
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Test-only `Worker` stand-in that runs the real overlay-parse handler
+ * in-process (#2183).
+ *
+ * Node has no `Worker`, so `parseOverlayLines` / `parseSymbolicFlat` resolve
+ * empty there by design — a model must still load when the worker cannot
+ * start. That is right for production but it silently guts any test that
+ * drives a hook end-to-end and expects real parsed content.
+ *
+ * A stub returning canned data would test nothing. This runs the ACTUAL
+ * `handle()` from the worker module and passes the reply through
+ * `structuredClone`, so the flatten, the transferable layout and the
+ * main-side reassembly are all genuinely exercised — the same boundary a real
+ * `postMessage` imposes.
+ *
+ * Deliberately NOT a production fallback: adding one would reintroduce the
+ * main-thread WASM heap this whole change exists to remove, on exactly the
+ * flaky machines where the worker fails to start.
+ */
+
+import { handle } from '@/lib/overlay-parse/overlay-parse.worker.js';
+import { __setOverlayWorkerFactoryForTest } from '@/lib/overlay-parse/index.js';
+
+type Slot = { postMessage?: unknown };
+
+/**
+ * Install the shim. Returns a restore function; call it in `after()`.
+ */
+export function installInProcessOverlayWorker(): () => void {
+  const g = globalThis as unknown as { self?: Slot };
+  const previousSelf = g.self;
+
+  class InProcessOverlayWorker {
+    onmessage: ((event: { data: unknown }) => void) | null = null;
+    onerror: ((event: { message: string }) => void) | null = null;
+    onmessageerror: (() => void) | null = null;
+
+    postMessage(request: unknown): void {
+      // `handle` posts its reply through `self.postMessage`, so point `self`
+      // at this instance for the duration of the call.
+      const saved = g.self;
+      g.self = {
+        postMessage: (reply: unknown) => {
+          // Async delivery and a real clone, exactly like a worker hop.
+          queueMicrotask(() => this.onmessage?.({ data: structuredClone(reply) }));
+        },
+      };
+      void Promise.resolve(handle({ data: request } as never))
+        .catch((error: unknown) => {
+          this.onerror?.({ message: error instanceof Error ? error.message : String(error) });
+        })
+        .finally(() => {
+          g.self = saved;
+        });
+    }
+
+    terminate(): void {
+      /* nothing to tear down in-process */
+    }
+  }
+
+  // Scoped to the overlay client. Setting a global `Worker` would also
+  // convince the PARSER that workers are available.
+  __setOverlayWorkerFactoryForTest(() => new InProcessOverlayWorker() as unknown as Worker);
+  return () => {
+    __setOverlayWorkerFactoryForTest(null);
+    g.self = previousSelf;
+  };
+}


### PR DESCRIPTION
Step 2 of 2 for #2183, on top of the merged #2241 / #2242 / #2249. This closes the last whole-file parse still running on the main thread.

## Result

342 MB reproduction, fresh profile, **default toggles**, build verified to contain the change:

| | main-thread total |
|---|---|
| baseline | 1,715 MB |
| #2241 + #2242 + #2249 | 1,142 MB |
| **+ this** | **671 MB** (−61% from baseline) |

`usedJSHeapSize` 907 → 305 MB. The 471 MB of main-thread `WebAssembly.Memory` that survived the earlier PRs was this parse; it is gone from the allocation trace entirely. What remains is the source SAB (327 MB, retained by design) plus geometry.

## Design

**`ParseResult` never crosses the boundary.** The worker flattens the WASM collection into transferable typed arrays (`symbolic-flat.ts`, struct-of-arrays); the main thread rebuilds the buckets with `buildParseResult`.

That was the key call, and it dissolves two problems at once:

- `elementToStorey` / `storeyElevations` **never leave the main thread**. The worker needs no spatial hierarchy at all — `ensureBucket`'s inputs are `(expressId, worldY, isGrid)`, all per-primitive in the flat stream.
- No object-graph clone. `DrawingLine2D` is `{line:{start,end},…}` — roughly four objects per segment — and it stays main-side.

`ensureBucket` and its storey fallback **moved, they were not rewritten**, so the `worldY !== 0` sentinel (#2256) and the millimetre-rounded bucket key are byte-identical.

**The `IfcAnnotation`/`IfcGridAxis` filter moved into the flatten**, so only relevant primitives cross. On this model that is 10,222 polylines → **2**.

**`debugEnabled()` reads `localStorage`,** which a worker cannot see, so the flag is captured main-side and passed in the request. Without this the `IFC_ANNOTATIONS_DEBUG=1` triage flow would go silently dead in exactly the "no annotations visible" reports a worker move can cause.

## Equivalence is pinned, not asserted

`symbolic-golden.test.ts` hashes the whole `ParseResult` (Maps sorted, typed arrays expanded, `NaN` preserved) against two real fixtures. **The digests were captured before the refactor and still reproduce.**

It is control-verified in both directions: perturbing one float by 1e-4 in the pre-refactor walk turned both fixtures red, and so did perturbing one inside the new flatten. So the digest covers the new path rather than routing around it.

Runtime cross-check on the 342 MB model, before vs after — identical:

```
[annotations] store 0: annotation buckets=0+0loose, grid buckets=0+2loose
[annotations] total 3D line vertices: 4 from 1 stores
```

## Test infrastructure

The class-gate test (#2121) has a positive control asserting real annotation content IS produced. Node has no `Worker`, so that would have gone vacuously empty. Tests now get an in-process shim running the **real** handler across a **real** `structuredClone` boundary.

It installs through a module-scoped factory, not a global `Worker` — my first attempt used a global and broke the suite, because `WorkerParser.isSupported()` then believed the *parser* could use workers and handed an overlay stub a parse request.

There is deliberately **no production main-thread fallback**: one would silently reintroduce the 471 MB on exactly the flaky machines this issue is about. Failures stay loud and empty.

## Verification

- `pnpm typecheck` 36/36 · viewer suite **3068 pass / 0 fail** · `check-wasm-disposal` ✅ · `check-test-wiring` ✅
- `pnpm build` including the new TLA-chunk-hazard gate: `132 chunks, 48 __tla-wrapped, 0 hazard edges`
- CodeRabbit CLI at HEAD (hosted has been rate-limited all session): **no new findings**

## Also in this PR (was going to be a follow-up)

`useDrawingGeneration.ts:258` ran the same whole-source parse on demand, so the first 2D drawing regrew main-thread WASM by ~470 MB and silently un-shipped the headline number for anyone who opens a drawing. It now goes through the same worker.

That needed a filter mode on the flatten — the drawing wants every representation type, not just `IfcAnnotation`/`IfcGridAxis`. Two non-obvious consequences, both handled:

- the type index widened from `Uint8Array` to `Uint16Array`; under `'all'` the interned type table is not bounded by 2, and an 8-bit index would wrap past 256 types and hand a primitive somebody else's `ifcType`
- the old walk read `worldY` defensively so an absent value KEPT the line; across a structured-clone boundary absent arrives as `NaN`, which would drop it. Non-finite maps back to `undefined`.

Also adds `getWholeSourceForWorker(store)`, the single seam all four whole-source worker handoffs now use, so the planned chunked-compression work on the 327 MB source floor edits one function rather than four call sites.

## Follow-up, not in this PR

`extractProfiles` at the other end of `useDrawingGeneration` — different API (`ProfileCollection`), needs its own flatten.

Also still open by design: the 327 MB source retention. Compressing it behind a `getSourceSlice` accessor would take ~280 MB more, but it needs a seam across every `store.source` consumer and should wait for evidence that huge-model RAM is still the top complaint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added worker-based parsing for symbolic annotations.
  - Improved support for symbolic geometry, text, fills, polylines, circles, and storey relationships.
  - Added efficient transfer of parsed annotation data.

- **Bug Fixes**
  - Empty or missing annotation sources now return cleanly without errors.
  - Improved resource cleanup and parsing reliability.

- **Tests**
  - Added comprehensive coverage for symbolic parsing, worker communication, data integrity, and representative IFC fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
