### PR TITLE
test(data): pin the quantity formula sentinel in packages/data too

### DIFF
--- a/packages/data/src/property-table.test.ts
+++ b/packages/data/src/property-table.test.ts
@@ -141,6 +141,43 @@ describe('QuantityTable round-trip', () => {
   });
 });
 
+describe('QuantityTable formula sentinel', () => {
+  // `formula` uses 0 as the "unset" sentinel in the columnar array (built
+  // with `.fill(0)`), so `getForEntity`'s read side must compare `> 0`, not
+  // `>= 0` — index 0 is StringTable's own reserved empty-string slot, so an
+  // `>= 0` reader would resolve every unset formula to `''` instead of
+  // `undefined`. The mirror of this bug shape was pinned for the
+  // cache-restored table in `@ifc-lite/cache`'s `quantities.test.ts`; this
+  // pins it for the columnar table itself, which shares the exact
+  // `formula[idx] > 0 ? ... : undefined` line.
+  it('answers undefined for a row with no formula, not the empty string', () => {
+    const strings = new StringTable();
+    const builder = new QuantityTableBuilder(strings);
+    builder.add({
+      entityId: 1,
+      qsetName: 'Qto_WallBaseQuantities',
+      quantityName: 'NetArea',
+      quantityType: QuantityType.Area,
+      value: 10,
+      formula: 'Length * Height',
+    });
+    builder.add({
+      entityId: 2,
+      qsetName: 'Qto_WallBaseQuantities',
+      quantityName: 'GrossVolume',
+      quantityType: QuantityType.Volume,
+      value: 5,
+    });
+    const table = builder.build();
+
+    const withFormula = table.getForEntity(1)[0].quantities.find((q) => q.name === 'NetArea');
+    expect(withFormula?.formula).toBe('Length * Height');
+
+    const withoutFormula = table.getForEntity(2)[0].quantities.find((q) => q.name === 'GrossVolume');
+    expect(withoutFormula?.formula).toBeUndefined();
+  });
+});
+
 describe('QuantityTable.sumByType elementType', () => {
   // The interface declares an optional `elementType` filter, but the
   // columnar table only stores `entityId` per row — no entity-type data —


### PR DESCRIPTION
#2267 pinned `formula[idx] > 0` in `packages/cache`. **`packages/data` has the same line, the same sentinel, and had the same gap** — relaxing `> 0` to `>= 0` left the suite green at **127/127**.

This is the sibling of an already-found bug shape rather than a rediscovery of it: `packages/cache/src/sections/quantities.ts` and `packages/data/src/quantity-table.ts:175` are independent readers of the same column layout, and only one was covered.

## Why the sentinel matters

`0` is `StringTable`'s reserved empty string, so under the relaxed form an absent formula reads back as `''` instead of `undefined`. Callers distinguish those: `''` is a formula that renders blank, `undefined` is no formula at all.

Nothing exercised the field. There is no `quantity-table.test.ts`, and the `QuantityTable` round-trips embedded in `property-table.test.ts` never asserted `formula`.

## Pinned from both sides, and bounded

One round-trip covers a quantity that **has** a formula alongside one that does **not**, so the assertion cannot be satisfied by a reader returning `undefined` for everything.

The survivor is bounded by a control, so it is not "function never called": swapping the `qsetIndex`/`quantityIndex` population order in the same function dies with 4 failures.

## Severity: coverage gap

`> 0` is what ships and it is correct. The `packages/data` convention matches `quantityTableFromColumns` and the cache reader exactly.

## Verification

- relaxed sentinel + **old** tests → **127/127 pass**
- relaxed sentinel + **new** test → fails, `expected '' to be undefined`
- restored → **128/128**

Mutation applied by exact-substring replacement with an asserted replacement count of 1, the mutated line re-read, restored by file copy. Re-run by hand before pushing.

127 → 128 tests across 11 files. `tsc --noEmit` clean. Test-only; no changeset.

## One thing found and deliberately not bundled in

`unitId: Int32Array` is **written but never read**. Both `PropertyTable` and `QuantityTable` populate it (`property-table.ts:49,95,135-137`, `quantity-table.ts:35,99,109`), it survives `*ToColumns`/`*FromColumns`, and `packages/cache` persists it — but no reader anywhere consumes it. `getForEntity`/`getPropertyValue`/`getQuantityValue` never populate `Property.unit`/`Quantity.unit` from it, and no current parser call site supplies `row.unitId` when adding rows.

This looks like superseded infrastructure from #1573's unit-display work, which moved to a `dataType`-based resolution path. Since nothing depends on it, no mutation can prove it wrong — which is exactly why it is reported rather than tested. Flagging it as a removal-or-wire-up decision for @louistrue rather than guessing which.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for quantity table formula handling.
  * Verified formulas round-trip correctly and missing formulas return the expected empty value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->