### PR TITLE
fix(mutations): stop an empty whole-qset creation vanishing silently

### DIFF
--- a/.changeset/qset-empty-whole-set-vanishes.md
+++ b/.changeset/qset-empty-whole-set-vanishes.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/mutations": patch
+---
+
+Fix `changeSetToOps` silently dropping a whole quantity set created with zero quantities (`createQuantitySet(entity, name, [])`, e.g. `StoreEditor.addQuantitySet` called before any quantity is added).
+
+The whole-qset `CREATE_QUANTITY` branch (added in #2263 for the non-empty case) looped over `newValue` to populate the published component's `values`, but never first materialized the component the way the sibling `CREATE_PROPERTY_SET` branch does. An empty `newValue` array meant the loop ran zero times, so the component was never added to the fold at all — the mutation matched the `CREATE_QUANTITY` case (so it never reached the `default` branch that records unrepresentable mutations either), and the set vanished from the published layer with `ops: []` and `skipped: []`: no diagnostic, no trace. Same failure shape as #2263, in the one corner (empty array) that fix's test coverage didn't reach.

--- a/packages/mutations/src/change-set-to-ops.test.ts
+++ b/packages/mutations/src/change-set-to-ops.test.ts
@@ -215,6 +215,27 @@ describe('changeSetToOps', () => {
     });
   });
 
+  it('still materializes an empty component for a whole-qset CREATE_QUANTITY with no quantities (control)', () => {
+    // Mirrors the CREATE_PROPERTY_SET empty-array control above. `createQuantitySet(entity,
+    // name, [])` is a legal call (an empty set, to be populated later) — the whole-qset
+    // branch looped over `newValue` to populate `values` but never first materialized the
+    // (possibly empty) component the way the CREATE_PROPERTY_SET branch does, so an empty
+    // array meant the loop ran zero times and the component was never added to `components`
+    // at all: `ops: []`, `skipped: []`, the whole set vanished with zero trace — the #2263
+    // shape surviving in the one corner its original fix didn't cover.
+    const result = changeSetToOps(
+      changeSet([mutation('CREATE_QUANTITY', 42, { psetName: 'Qto_Empty', newValue: [] as unknown as PropertyValue })]),
+      resolver
+    );
+    expect(result.skipped).toEqual([]);
+    expect(result.ops).toContainEqual({
+      op: 'set-component',
+      entity: '3fAx$GlobalId42',
+      componentKey: 'qset:Qto_Empty',
+      values: {},
+    });
+  });
+
   it('serializes a retype as a class opinion and rides PredefinedType on the core channel', () => {
     const result = changeSetToOps(
       changeSet([

--- a/packages/mutations/src/change-set-to-ops.ts
+++ b/packages/mutations/src/change-set-to-ops.ts
@@ -213,9 +213,18 @@ function applyMutation(
         // not even into `skipped` (it matches this case, so the default branch
         // never runs), so a freshly-created quantity set vanished from the
         // layer with zero trace.
+        const qsetComponentKey = `qset:${mutation.psetName}`;
+        // Materialize the (possibly empty) set — mirrors CREATE_PROPERTY_SET
+        // below. `createQuantitySet(entity, name, [])` is a legal call (a set
+        // created with zero quantities, to be populated later); without this
+        // line the loop below runs zero times and never touches `components`,
+        // so the whole set still vanished with zero trace for exactly the
+        // empty-array case — the same #2263 shape surviving in a corner the
+        // original fix didn't cover.
+        componentFor(entity, qsetComponentKey).set(qsetComponentKey, {});
         for (const q of mutation.newValue as Array<{ name?: string; value?: PropertyValue }>) {
           if (q && typeof q.name === 'string') {
-            setMember(entity, `qset:${mutation.psetName}`, q.name, q.value ?? null);
+            setMember(entity, qsetComponentKey, q.name, q.value ?? null);
           }
         }
       }


### PR DESCRIPTION
**#2263 fixed whole-set creations being dropped by `changeSetToOps`. The same shape survived in the one corner that fix's own tests did not reach: an empty one.**

`createQuantitySet(entity, name, [])` is a legal call — a set created with zero quantities and populated later. `StoreEditor.addQuantitySet` does exactly this.

## The defect

The whole-qset `CREATE_QUANTITY` branch loops over `newValue` to fill the component's members but — unlike the sibling `CREATE_PROPERTY_SET` branch — never materialises the component first. With an empty array the loop runs zero times and nothing is ever written to `components`.

And because the mutation still **matches** the `CREATE_QUANTITY` case, it never falls through to the `default` branch that records unrepresentable mutations. Observed on the unfixed code:

```
input:  CREATE_QUANTITY, psetName: 'Qto_WallBaseQuantities', newValue: []
RESULT: {"ops":[],"identityMap":[],"unresolved":[],"skipped":[]}
```

`ops` empty **and** `skipped` empty — the exact #2263 signature. The set vanishes from the published layer with no diagnostic and no trace.

With the fix, the same input yields:

```
{"op":"set-component","entity":"GUID_42","componentKey":"qset:Qto_WallBaseQuantities","values":{}}
```

**Severity: LIVE.**

## The asymmetry was visible in the tests, too

`CREATE_PROPERTY_SET` has an explicit *"still materializes an empty component … (control)"* test. `CREATE_QUANTITY` had no equivalent. The pset branch materialises unconditionally at `change-set-to-ops.ts:241`; the qset branch didn't. That control now exists for both, which is what stops the two branches drifting apart again.

## The rest of the switch was walked, not assumed

Every other arm was checked for the same "matches but yields nothing, no skip" shape. They guard on producer-supplied fields (`psetName`/`propName`/`entityType`) that every in-repo producer sets unconditionally — `MutablePropertyView.setProperty`/`setEntityType` and friends — so those guard-failures are unreachable rather than unpinned. `UPDATE_ENTITY_TYPE`'s `if (mutation.entityType)` is the closest look-alike, but `setEntityType` throws on a missing type, so it cannot be reached from a real edit. Tracking only an *unknown mutation type* in `skipped` is the deliberate design.

Also checked and clean:

- `applyMutations` in `mutable-property-view.ts` has the same whole-set branches but defers to `createQuantitySet`/`createPropertySet`, which materialise `newQsets`/`newPsets` unconditionally — never affected.
- `collectEffectiveChanges` reports `qset-added`/`pset-added` from map keys regardless of member count — correct.
- No `DELETE_QUANTITY_SET` mutation type exists, so there is no delete-side analogue to check.
- `bulk-query-engine.ts`'s `SET_ATTRIBUTE` returning `null` is an explicit, commented "not yet implemented", not a silent drop.

## Verification

- RED: new test fails on the unfixed code with `expected [] to deep equally contain {…}`, and the 15 sibling tests in the same file still pass — so the failure is specific, not broad breakage.
- GREEN: 16/16 in that file; **163 passing / 10 skipped across 9 files** for the package.
- `tsc --noEmit` clean. Patch changeset included.

One note on the suite: `test/mutations.test.ts` fails to LOAD with 0 tests unless `@ifc-lite/data`, `@ifc-lite/encoding`, `@ifc-lite/ifcx` and `@ifc-lite/parser` are built first — a stale-workspace-dep trap unrelated to this change, but worth knowing, since it under-collects silently rather than failing.
