### PR TITLE
fix(viewer,merge): stop two silent drops on the layer-publish path

### DIFF
--- a/.changeset/custom-pset-componentkey-shape.md
+++ b/.changeset/custom-pset-componentkey-shape.md
@@ -1,0 +1,11 @@
+---
+"@ifc-lite/merge": patch
+---
+
+Fix `componentKeyForAttribute` silently misclassifying a custom-named (not `Pset_`/`Qto_`-prefixed) property or quantity set, breaking whole-set tombstone lookups for it.
+
+`componentKeyForAttribute` bucketed a `bsi::ifc::v5a::<Set>::<Member>` attribute as `pset:<Set>`/`qset:<Set>` only when `<Set>` matched a literal `Pset_`/`Qto_` prefix, falling back to a one-off-per-attribute `attr:<key>` bucket for any other name. `packages/mutations/src/change-set-to-ops.ts` builds `pset:<name>`/`qset:<name>` component keys unconditionally from the mutation type, for any author-chosen name, and `@ifc-lite/collab`'s structured-attribute inflation already disambiguates a custom set name by value shape (typed record -> pset, plain finite number -> quantity) — its own doc comment describes that as a convention "the merge engine's `pset:`/`qset:` component keys... already share", which this package didn't actually hold up.
+
+The observable break: `apps/viewer/src/lib/layers/publish.ts`'s `buildDeltaNodes` resolves a whole-component tombstone (`DELETE_PROPERTY_SET`/`DELETE_QUANTITY_SET`) by looking up the base state's members under `pset:<name>`/`qset:<name>`. For a custom-named set, that lookup found nothing (the members lived under `attr:<key>` instead), so zero attributes were nulled — deleting a custom-named property set silently did nothing at all, no error, no diagnostic.
+
+`componentKeyForAttribute` now takes the attribute's value and disambiguates a custom set name by the same shape rule `@ifc-lite/collab` uses. A `null` value (an in-flight single-member deletion, as opposed to a whole-component tombstone) still carries no shape to go on, so that path is unchanged.

--- a/.changeset/custom-pset-componentkey-shape.md
+++ b/.changeset/custom-pset-componentkey-shape.md
@@ -2,7 +2,7 @@
 "@ifc-lite/merge": patch
 ---
 
-Fix `componentKeyForAttribute` silently misclassifying a custom-named (not `Pset_`/`Qto_`-prefixed) property or quantity set, breaking whole-set tombstone lookups for it.
+Fix `componentKeyForAttribute` silently misclassifying a custom-named (not `Pset_`/`Qto_`-prefixed) property or quantity set, breaking whole-set tombstone lookups for it, and fix a member deletion on such a set being routed to a different component than the value it targets — so the member survived the delete.
 
 `componentKeyForAttribute` bucketed a `bsi::ifc::v5a::<Set>::<Member>` attribute as `pset:<Set>`/`qset:<Set>` only when `<Set>` matched a literal `Pset_`/`Qto_` prefix, falling back to a one-off-per-attribute `attr:<key>` bucket for any other name. `packages/mutations/src/change-set-to-ops.ts` builds `pset:<name>`/`qset:<name>` component keys unconditionally from the mutation type, for any author-chosen name, and `@ifc-lite/collab`'s structured-attribute inflation already disambiguates a custom set name by value shape (typed record -> pset, plain finite number -> quantity) — its own doc comment describes that as a convention "the merge engine's `pset:`/`qset:` component keys... already share", which this package didn't actually hold up.
 

--- a/apps/viewer/src/lib/layers/publish.test.ts
+++ b/apps/viewer/src/lib/layers/publish.test.ts
@@ -221,6 +221,63 @@ describe('publishViewerDraft (#1717 V2)', () => {
     assert.strictEqual(state.get('wall-guid-1')?.components.get('pset:Pset_FireSafety'), undefined);
   });
 
+  it('a whole-pset deletion on a CUSTOM-named set (not Pset_-prefixed) still tombstones its members', async () => {
+    // `@ifc-lite/merge`'s `componentKeyForAttribute` used to classify
+    // `bsi::ifc::v5a::<Set>::<Member>` by matching a literal "Pset_"/
+    // "Qto_" substring in the key, not by looking at the value shape the
+    // way `changeSetToOps` and `@ifc-lite/collab`'s inflation both do.
+    // A set named anything else fell through to a one-off `attr:<key>`
+    // bucket per member, so `buildDeltaNodes`'s `tombstone-component`
+    // lookup (`baseState.get(entity).components.get('pset:<name>')`)
+    // found nothing under that bucket and nulled zero attributes — a
+    // "delete this property set" edit on a custom-named set silently did
+    // nothing at all.
+    const CUSTOM = 'bsi::ifc::v5a::CompanyDataSet::Owner';
+    const store = await BrowserLayerStore.open();
+    const base: IfcxFile = {
+      ...makeBase(),
+      data: [
+        {
+          path: 'wall-guid-1',
+          attributes: {
+            'bsi::ifc::class': { code: 'IfcWall', uri: 'u' },
+            [CUSTOM]: { type: 'IfcLabel', value: 'Acme Co' },
+          },
+        },
+      ],
+    };
+    const result = publishViewerDraft({
+      store,
+      stackFiles: [base],
+      mutations: [
+        mutation({ id: 'm1', type: 'DELETE_PROPERTY_SET', psetName: 'CompanyDataSet' }),
+        mutation({ id: 'm2', type: 'UPDATE_ATTRIBUTE', attributeName: 'Name', newValue: 'Wall W1' }),
+      ],
+      pathOf: (id) => (id === 7 ? 'wall-guid-1' : undefined),
+      intent: 'Delete the whole custom data set',
+      authorPrincipal: 'louis',
+      refName: 'local',
+      created: '2026-07-11T12:00:00Z',
+    });
+    const node = result.file.data.find((n) => n.path === 'wall-guid-1');
+    // The proven fix: the delta actually carries a null opinion for the
+    // custom-named set's member, on the wire, instead of nothing at all.
+    // Real IFCX composition (what the viewer renders) is per-attribute
+    // LWW and doesn't consult `componentKeyForAttribute` at all, so this
+    // null opinion alone is enough to make the property disappear for
+    // the user.
+    assert.strictEqual(node?.attributes?.[CUSTOM], null);
+    // NOT yet fixed, and deliberately not asserted here: a `null` value
+    // carries no type-shape to disambiguate a custom set name by, so
+    // `@ifc-lite/merge`'s OWN semantic re-read of [base, delta] together
+    // still buckets this null under `attr:<full key>` rather than
+    // `pset:CompanyDataSet` (the docstring on `componentKeyForAttribute`
+    // says so explicitly). That's a narrower, second-order gap in the
+    // merge engine's conflict-detection model — worth a follow-up, but
+    // out of scope here: the member-shape ambiguity is unresolvable
+    // without carrying per-key bucket memory across the fold.
+  });
+
   it('quantity op values wrap in a typed record unless they are plain finite numbers', () => {
     // Exercises buildDeltaNodes directly rather than through
     // publishViewerDraft: a non-finite quantity can never survive the
@@ -338,6 +395,50 @@ describe('publishViewerDraft retype + skipped reporting (#1717 geometry pass)', 
     });
     assert.strictEqual(result.skippedCount, 1);
     assert.strictEqual(result.opCount, 1);
+  });
+
+  it('reports an empty-pset creation as unrepresented instead of silently vanishing from the layer', async () => {
+    // `changeSetToOps` materializes a whole-pset creation with no members
+    // yet (`StoreEditor.addPropertySet(id, name, [])`, or any future
+    // producer path that ends the same way) as `set-component` with
+    // `values: {}` — see #2277's "materialize the (possibly empty) set"
+    // fix on the producer side. The IFCX wire dialect has no attribute
+    // that means "this pset exists with zero members", so `buildDeltaNodes`
+    // cannot represent it; the regression is dropping it AND counting it
+    // as published (`opCount`) with no diagnostic. Mixed with an unrelated
+    // resolvable edit on a different entity so the batch isn't rejected
+    // outright by the "every edit failed / was empty" guard.
+    const store = await BrowserLayerStore.open();
+    const result = publishViewerDraft({
+      store,
+      stackFiles: [makeBase()],
+      mutations: [
+        mutation({
+          id: 'm-empty-pset',
+          type: 'CREATE_PROPERTY_SET',
+          entityId: 42,
+          psetName: 'Pset_Empty',
+          newValue: [],
+        }),
+        mutation({ id: 'm-real', entityId: 7, psetName: 'Pset_FireSafety', propName: 'FireRating', newValue: 'REI90' }),
+      ],
+      pathOf: (id) => (id === 7 ? 'wall-guid-1' : id === 42 ? 'wall-guid-empty' : undefined),
+      intent: 'Create an empty pset alongside a real edit',
+      authorPrincipal: 'alice',
+      refName: 'local',
+    });
+    // The empty-pset op has no wire representation: it must be reported,
+    // not silently folded into a successful opCount.
+    assert.strictEqual(result.skippedCount, 1);
+    // The entity that only carried the empty-pset op must not appear in
+    // the published layer at all — there is nothing to compose there.
+    assert.strictEqual(
+      result.file.data.find((n) => n.path === 'wall-guid-empty'),
+      undefined,
+    );
+    // The unrelated real edit on the other entity must still publish.
+    const realNode = result.file.data.find((n) => n.path === 'wall-guid-1');
+    assert.deepStrictEqual(realNode?.attributes?.[FIRE], { type: 'IfcLabel', value: 'REI90' });
   });
 });
 

--- a/apps/viewer/src/lib/layers/publish.ts
+++ b/apps/viewer/src/lib/layers/publish.ts
@@ -82,7 +82,22 @@ function wireEntry(
  * is per-attribute LWW, so anything not explicitly nulled shines
  * through.
  */
-export function buildDeltaNodes(ops: readonly ChangeSetOp[], baseFiles: readonly IfcxFile[]): IfcxNode[] {
+export function buildDeltaNodes(
+  ops: readonly ChangeSetOp[],
+  baseFiles: readonly IfcxFile[],
+  /**
+   * Optional sink for `set-component` ops that resolved to zero wire
+   * attributes (e.g. `values: {}` from an empty-pset creation) — the
+   * IFCX dialect has no way to represent "component exists, no
+   * members", so these ops leave no trace on `data`. Without this,
+   * `changeSetToOps`'s own #2277 fix (materializing an empty pset as
+   * `values: {}` rather than dropping the mutation) gets silently
+   * undone one layer downstream: the op survives the producer, then
+   * vanishes here with no diagnostic and no error, while the caller's
+   * `opCount` still counts it as published.
+   */
+  unrepresentedOps?: ChangeSetOp[],
+): IfcxNode[] {
   const baseState = ops.some((op) => op.op === 'tombstone-component')
     ? extractStackState(baseFiles)
     : null;
@@ -100,10 +115,15 @@ export function buildDeltaNodes(ops: readonly ChangeSetOp[], baseFiles: readonly
     const node = nodeFor(op.entity);
     switch (op.op) {
       case 'set-component': {
+        let wrote = false;
         for (const [member, value] of Object.entries(op.values)) {
           const entry = wireEntry(op.componentKey, member, value);
-          if (entry) node.attributes = { ...node.attributes, [entry.key]: entry.value };
+          if (entry) {
+            node.attributes = { ...node.attributes, [entry.key]: entry.value };
+            wrote = true;
+          }
         }
+        if (!wrote) unrepresentedOps?.push(op);
         break;
       }
       case 'tombstone-component': {
@@ -170,7 +190,8 @@ export function publishViewerDraft(init: PublishDraftInit): PublishDraftResult {
   const { ops, identityMap, unresolved, skipped } = changeSetToOps(changeSet, {
     globalIdOf: (expressId) => init.pathOf(expressId),
   });
-  const data = buildDeltaNodes(ops, init.stackFiles);
+  const unrepresentedOps: ChangeSetOp[] = [];
+  const data = buildDeltaNodes(ops, init.stackFiles, unrepresentedOps);
   if (data.length === 0) {
     throw new Error('No publishable changes: every pending edit failed identity resolution or was empty.');
   }
@@ -203,7 +224,12 @@ export function publishViewerDraft(init: PublishDraftInit): PublishDraftResult {
   const existing = init.store.getRef(init.refName);
   init.store.setRef(init.refName, { layers: [...(existing?.layers ?? []), layerId] });
 
-  return { layerId, file, opCount: ops.length, unresolved, skippedCount: skipped.length };
+  // `unrepresentedOps` carries ops the wire dialect cannot express (e.g. an
+  // empty-pset creation, `values: {}`) — same "no layer representation"
+  // outcome as a `skipped` mutation, just discovered one layer later, so
+  // it folds into the same count rather than passing silently as part of
+  // `opCount`.
+  return { layerId, file, opCount: ops.length, unresolved, skippedCount: skipped.length + unrepresentedOps.length };
 }
 
 export interface CollabPublishInit {

--- a/packages/merge/src/component-state.test.ts
+++ b/packages/merge/src/component-state.test.ts
@@ -47,6 +47,15 @@ describe('componentKeyForAttribute', () => {
   });
 });
 
+function layerWith(attributes: Record<string, unknown>): IfcxFile {
+  return {
+    header: { id: 'l', ifcxVersion: 'ifcx_alpha', dataVersion: '1.0.0', author: 't', timestamp: 't' },
+    imports: [],
+    schemas: {},
+    data: [{ path: 'wall-guid-1', attributes }],
+  } as unknown as IfcxFile;
+}
+
 describe('extractStackState + a whole-pset tombstone lookup on a custom-named set (the buildDeltaNodes path)', () => {
   it('finds the custom-named pset members under pset:<name>, not a one-off attr:<key> bucket', () => {
     const base: IfcxFile = {
@@ -72,5 +81,36 @@ describe('extractStackState + a whole-pset tombstone lookup on a custom-named se
     expect(entity?.components.get('pset:MyCustomSet')).toEqual({
       'bsi::ifc::v5a::MyCustomSet::FireRating': { type: 'IfcLabel', value: 'REI60' },
     });
+  });
+
+  /**
+   * A `null` member deletion carries no value shape, so classifying it by
+   * shape sent the delete to a DIFFERENT component than the live value it
+   * was meant to remove — and the member survived:
+   *
+   *   live   (CarbonMetrics::CO2, 42)   -> qset:CarbonMetrics
+   *   delete (CarbonMetrics::CO2, null) -> attr:bsi::ifc::v5a::CarbonMetrics::CO2
+   *   components after delete: {"qset:CarbonMetrics":{"...::CO2":42}}
+   *
+   * The fold is weakest-first, so the value is already present when the
+   * deletion is seen; the resolver looks up which component actually holds
+   * the key rather than guessing from a shape that isn't there.
+   */
+  it.each([
+    ['custom quantity set', 'bsi::ifc::v5a::CarbonMetrics::CO2', 42 as unknown],
+    ['custom property set', 'bsi::ifc::v5a::MyCustomSet::FireRating', { type: 'IfcLabel', value: 'F30' }],
+    // Controls: the standard prefixes always routed correctly. They must
+    // still behave identically, or the fix has changed more than intended.
+    ['standard Pset_', 'bsi::ifc::v5a::Pset_WallCommon::IsExternal', { type: 'IfcBoolean', value: true }],
+    ['standard Qto_', 'bsi::ifc::v5a::Qto_WallBaseQuantities::NetArea', 12.5 as unknown],
+  ])('a null deletion removes the member it targets (%s)', (_label, key, value) => {
+    const live = layerWith({ [key]: value });
+    const deletion = layerWith({ [key]: null });
+    const state = extractStackState([live, deletion]);
+    const entity = state.get('wall-guid-1');
+    // The member is gone from every component, not merely absent from the
+    // one the deletion happened to be classified into.
+    const surviving = [...(entity?.components.values() ?? [])].filter((attrs) => key in attrs);
+    expect(surviving).toEqual([]);
   });
 });

--- a/packages/merge/src/component-state.test.ts
+++ b/packages/merge/src/component-state.test.ts
@@ -1,0 +1,76 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `componentKeyForAttribute` must agree with the producer side of the
+ * pipe: `packages/mutations/src/change-set-to-ops.ts` builds
+ * `pset:<name>` / `qset:<name>` component keys unconditionally from the
+ * mutation type, for ANY author-chosen set name — not only names
+ * starting with `Pset_`/`Qto_`. `@ifc-lite/collab`'s structured-attribute
+ * inflation (packages/collab/src/snapshot/structured-attrs.ts) already
+ * disambiguates a custom v5a set name by value shape (typed record →
+ * pset, plain finite number → quantity) and documents that convention as
+ * "already shared" by the merge engine's componentKey vocabulary — this
+ * pins that this package actually holds up its end.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { IfcxFile } from '@ifc-lite/ifcx';
+import { componentKeyForAttribute, extractStackState } from './component-state.js';
+
+describe('componentKeyForAttribute', () => {
+  it('buckets a custom (non-Pset_) set name as pset:<name> when the value is a typed property record', () => {
+    const key = componentKeyForAttribute('bsi::ifc::v5a::MyCustomSet::FireRating', {
+      type: 'IfcLabel',
+      value: 'REI60',
+    });
+    expect(key).toBe('pset:MyCustomSet');
+  });
+
+  it('buckets a custom (non-Qto_) set name as qset:<name> when the value is a plain finite number', () => {
+    const key = componentKeyForAttribute('bsi::ifc::v5a::MyMetrics::Height', 3.2);
+    expect(key).toBe('qset:MyMetrics');
+  });
+
+  it('still buckets the standard Pset_/Qto_ prefixes the same as before, value or no value', () => {
+    expect(componentKeyForAttribute('bsi::ifc::v5a::Pset_FireSafety::FireRating', { type: 'IfcLabel', value: 'REI60' })).toBe(
+      'pset:Pset_FireSafety',
+    );
+    expect(componentKeyForAttribute('bsi::ifc::v5a::Pset_FireSafety::FireRating', null)).toBe('pset:Pset_FireSafety');
+    expect(componentKeyForAttribute('bsi::ifc::v5a::Qto_WallBaseQuantities::Height', 3)).toBe(
+      'qset:Qto_WallBaseQuantities',
+    );
+    expect(componentKeyForAttribute('bsi::ifc::v5a::Qto_WallBaseQuantities::Height', null)).toBe(
+      'qset:Qto_WallBaseQuantities',
+    );
+  });
+});
+
+describe('extractStackState + a whole-pset tombstone lookup on a custom-named set (the buildDeltaNodes path)', () => {
+  it('finds the custom-named pset members under pset:<name>, not a one-off attr:<key> bucket', () => {
+    const base: IfcxFile = {
+      header: { id: 'base', ifcxVersion: 'ifcx_alpha', dataVersion: '1.0.0', author: 't', timestamp: 't' },
+      imports: [],
+      schemas: {},
+      data: [
+        {
+          path: 'wall-guid-1',
+          attributes: {
+            'bsi::ifc::v5a::MyCustomSet::FireRating': { type: 'IfcLabel', value: 'REI60' },
+          },
+        },
+      ],
+    };
+    const state = extractStackState([base]);
+    const entity = state.get('wall-guid-1');
+    // Before the fix this component simply didn't exist under
+    // `pset:MyCustomSet` — every member fell into its own
+    // `attr:<full key>` bucket instead, so a whole-component tombstone
+    // lookup (`buildDeltaNodes`'s `tombstone-component` case) found
+    // nothing to null and silently deleted zero attributes.
+    expect(entity?.components.get('pset:MyCustomSet')).toEqual({
+      'bsi::ifc::v5a::MyCustomSet::FireRating': { type: 'IfcLabel', value: 'REI60' },
+    });
+  });
+});

--- a/packages/merge/src/component-state.ts
+++ b/packages/merge/src/component-state.ts
@@ -76,9 +76,12 @@ const QSET_ANYWHERE_RE = /(?:^|::)(Qto_[A-Za-z0-9_]+)(?:::|$)/;
  * custom-named set silently did nothing.
  *
  * A `null` value (an in-flight member deletion, not a whole-component
- * tombstone) carries no shape to disambiguate from, so it keeps the
- * old literal-prefix-only classification — the same shape this
- * function has always had for that case, no behavior change there.
+ * tombstone) carries no shape to disambiguate from, so it keeps the old
+ * literal-prefix-only classification here. That is NOT sufficient on its
+ * own — for a custom set name it would route the delete to a different
+ * component than the live value sits in — so callers folding a stack must
+ * go through `resolveComponentKey`, which resolves a deletion against the
+ * components already present instead of guessing. See its docstring.
  */
 export function componentKeyForAttribute(attribute: string, value?: unknown): ComponentKey {
   if (attribute === ATTR.CLASS) return 'attr:class';
@@ -119,6 +122,34 @@ export function componentKeyForAttribute(attribute: string, value?: unknown): Co
     return `geometry:${tier}`;
   }
   return `attr:${attribute}`;
+}
+
+/**
+ * Resolve the component a key belongs to, for one fold step.
+ *
+ * A `null` value is a member DELETION and carries no shape, so
+ * `componentKeyForAttribute` cannot disambiguate a custom set name from
+ * it and falls back to the literal-prefix convention. That put the
+ * delete in a different bucket than the live value it was meant to
+ * remove: the member survived the delete entirely.
+ *
+ *   live edit (CarbonMetrics::CO2, 42)   -> qset:CarbonMetrics
+ *   delete    (CarbonMetrics::CO2, null) -> attr:bsi::ifc::v5a::CarbonMetrics::CO2
+ *
+ * The stack is folded weakest-first, so by the time a deletion is seen
+ * the value it deletes is already present. Looking up which component
+ * actually holds the key answers precisely what the value shape cannot,
+ * and is exact rather than heuristic. Falls back to the shape-based
+ * classification when no component holds the key -- a delete of
+ * something that was never set, where the bucket does not matter.
+ */
+function resolveComponentKey(entity: EntityState, key: string, value: unknown): ComponentKey {
+  if (value === null) {
+    for (const [componentKey, attrs] of entity.components) {
+      if (key in attrs) return componentKey;
+    }
+  }
+  return componentKeyForAttribute(key, value);
 }
 
 /**
@@ -209,7 +240,7 @@ function applyNode(entity: EntityState, node: IfcxNode): void {
       continue;
     }
     if (key.startsWith(IFCLITE_ATTR.DERIVED)) continue;
-    const componentKey = componentKeyForAttribute(key, value);
+    const componentKey = resolveComponentKey(entity, key, value);
     const component = entity.components.get(componentKey) ?? {};
     if (value === null) {
       delete component[key];
@@ -369,7 +400,7 @@ function applyNodeCow(entity: EntityState, node: IfcxNode): void {
   if (!node.attributes) return;
   for (const [key, value] of Object.entries(node.attributes)) {
     if (key.startsWith(IFCLITE_ATTR.DERIVED)) continue;
-    const componentKey = componentKeyForAttribute(key, value);
+    const componentKey = resolveComponentKey(entity, key, value);
     const component: ComponentAttributes = { ...(entity.components.get(componentKey) ?? {}) };
     if (value === null) {
       delete component[key];

--- a/packages/merge/src/component-state.ts
+++ b/packages/merge/src/component-state.ts
@@ -12,7 +12,7 @@
  */
 
 import type { IfcxFile, IfcxNode } from '@ifc-lite/ifcx';
-import { ATTR, IFCLITE_ATTR, canonicalStringify } from '@ifc-lite/ifcx';
+import { ATTR, IFCLITE_ATTR, canonicalStringify, isTypedPropertyValue, parseV5aKey } from '@ifc-lite/ifcx';
 import { stableHash } from '@ifc-lite/diff';
 import type { ComponentAttributes, ComponentKey, ComponentSnapshot } from './types.js';
 
@@ -42,19 +42,74 @@ export interface EntityState {
 
 export type StackState = Map<string, EntityState>;
 
-const PSET_RE = /(?:^|::)(Pset_[A-Za-z0-9_]+)(?:::|$)/;
-const QSET_RE = /(?:^|::)(Qto_[A-Za-z0-9_]+)(?:::|$)/;
+/** `Qto_*` set names always route to quantities (same rule as `@ifc-lite/collab`'s inflation). */
+const QTO_SET_RE = /^Qto_/;
+/** Numbers under `Pset_*` sets stay flat/legacy rather than quantities — mirrors the collab rule. */
+const PSET_SET_RE = /^Pset_/;
+/**
+ * The original name-anywhere patterns, kept for NON-v5a keys so this
+ * change stays strictly additive. Only the `bsi::ifc::v5a::` branch above
+ * gains new behaviour.
+ */
+const PSET_ANYWHERE_RE = /(?:^|::)(Pset_[A-Za-z0-9_]+)(?:::|$)/;
+const QSET_ANYWHERE_RE = /(?:^|::)(Qto_[A-Za-z0-9_]+)(?:::|$)/;
 
 /**
- * Map an IFCX attribute key onto the layer-op componentKey vocabulary.
- * Diff keys and op keys are deliberately the same words (02 §2.2).
+ * Map an IFCX attribute key (+ its value, when known) onto the layer-op
+ * componentKey vocabulary. Diff keys and op keys are deliberately the
+ * same words (02 §2.2).
+ *
+ * `bsi::ifc::v5a::<Set>::<Member>` keys carry an author-chosen set name
+ * that is NOT required to start with `Pset_`/`Qto_` — `changeSetToOps`
+ * builds `pset:<name>`/`qset:<name>` unconditionally from the mutation
+ * type, for any name, and `@ifc-lite/collab`'s structured-attribute
+ * inflation already disambiguates custom set names by VALUE SHAPE
+ * (typed-record → pset, plain finite number → quantity) rather than by
+ * matching the set name against those two prefixes. This used a
+ * name-only regex instead, so any pset/qset whose author-chosen name
+ * didn't start with `Pset_`/`Qto_` silently fell through to a
+ * one-off-per-attribute `attr:<key>` bucket instead of `pset:<name>` /
+ * `qset:<name>` — e.g. a whole-pset tombstone
+ * (`buildDeltaNodes`'s `tombstone-component` case) looks up the base
+ * state's members by `pset:<name>`, found nothing under that bucket,
+ * and nulled zero attributes: a "delete this property set" edit on a
+ * custom-named set silently did nothing.
+ *
+ * A `null` value (an in-flight member deletion, not a whole-component
+ * tombstone) carries no shape to disambiguate from, so it keeps the
+ * old literal-prefix-only classification — the same shape this
+ * function has always had for that case, no behavior change there.
  */
-export function componentKeyForAttribute(attribute: string): ComponentKey {
+export function componentKeyForAttribute(attribute: string, value?: unknown): ComponentKey {
   if (attribute === ATTR.CLASS) return 'attr:class';
   if (attribute === ATTR.TRANSFORM) return 'placement';
-  const pset = PSET_RE.exec(attribute);
+  const v5a = parseV5aKey(attribute);
+  if (v5a) {
+    const { setName } = v5a;
+    if (value !== null && value !== undefined) {
+      if (QTO_SET_RE.test(setName)) {
+        const candidate = isTypedPropertyValue(value) ? value.value : value;
+        if (typeof candidate === 'number' && Number.isFinite(candidate)) return `qset:${setName}`;
+      }
+      if (isTypedPropertyValue(value)) return `pset:${setName}`;
+      if (typeof value === 'number' && Number.isFinite(value) && !PSET_SET_RE.test(setName)) {
+        return `qset:${setName}`;
+      }
+    }
+    // No value (or a `null` deletion) to disambiguate a custom set name by
+    // shape: fall back to the literal-prefix convention.
+    if (PSET_SET_RE.test(setName)) return `pset:${setName}`;
+    if (QTO_SET_RE.test(setName)) return `qset:${setName}`;
+  }
+  // Non-v5a keys keep the original name-anywhere classification verbatim.
+  // The v5a branch above is the only behaviour this function changes; the
+  // shapes below (a bare `Pset_X::Y`, or a `Pset_`-named member under
+  // `bsi::ifc::prop::`) are not what the custom-set bug is about, and
+  // silently rebucketing them would move members between components in a
+  // merge that never asked for it.
+  const pset = PSET_ANYWHERE_RE.exec(attribute);
   if (pset) return `pset:${pset[1]}`;
-  const qset = QSET_RE.exec(attribute);
+  const qset = QSET_ANYWHERE_RE.exec(attribute);
   if (qset) return `qset:${qset[1]}`;
   if (attribute.startsWith(ATTR.PROP_PREFIX)) {
     return `attr:prop:${attribute.slice(ATTR.PROP_PREFIX.length)}`;
@@ -154,7 +209,7 @@ function applyNode(entity: EntityState, node: IfcxNode): void {
       continue;
     }
     if (key.startsWith(IFCLITE_ATTR.DERIVED)) continue;
-    const componentKey = componentKeyForAttribute(key);
+    const componentKey = componentKeyForAttribute(key, value);
     const component = entity.components.get(componentKey) ?? {};
     if (value === null) {
       delete component[key];
@@ -314,7 +369,7 @@ function applyNodeCow(entity: EntityState, node: IfcxNode): void {
   if (!node.attributes) return;
   for (const [key, value] of Object.entries(node.attributes)) {
     if (key.startsWith(IFCLITE_ATTR.DERIVED)) continue;
-    const componentKey = componentKeyForAttribute(key);
+    const componentKey = componentKeyForAttribute(key, value);
     const component: ComponentAttributes = { ...(entity.components.get(componentKey) ?? {}) };
     if (value === null) {
       delete component[key];


### PR DESCRIPTION
Two live bugs at the **consumer** end of the layer-ops pipeline, both silent. Found by auditing the other end of the pipe that produced #2263 and #2277 — on the theory that if the producer dropped data twice, the consumer was worth the same suspicion.

## 1. An empty component vanishes on publish — and takes its entity with it

`buildDeltaNodes` only writes `node.attributes` inside the `Object.entries(op.values)` loop. A `set-component` with `values: {}` runs it zero times, never gains an `attributes` key, and is removed by the trailing `.filter(node => node.attributes !== undefined)`. Meanwhile `opCount` still reports it as published.

```
EMPTY-ONLY nodes: []
MIXED node paths: ["wall-guid-normal"]
```

The second line is the worse one — mixed with a real op, the empty-pset entity **disappears from the layer entirely**.

This is the #2263/#2277 shape one layer downstream. #2277 had just changed `changeSetToOps` to materialise `values: {}` rather than drop the mutation — **and this silently undid it.**

The wire dialect genuinely cannot express "component exists, no members", so the fix reports rather than pretends: ops resolving to zero wire attributes go to an `unrepresentedOps` sink and fold into `skippedCount` — the same "had no layer representation" bucket the UI already warns on via `LayerDraftSection.tsx`. No UI change needed.

## 2. Deleting a custom-named property set silently does nothing

`componentKeyForAttribute` bucketed a v5a key as `pset:<Set>`/`qset:<Set>` only when the set name literally began `Pset_`/`Qto_`. But `changeSetToOps` builds `pset:<name>` unconditionally for **any** author-chosen name, and `@ifc-lite/collab` disambiguates custom names by **value shape** (typed record → pset, plain finite number → quantity) — its doc comment even claims merge "already shares" that convention, which was not true.

So a whole-set tombstone on `CompanyDataSet` looked up members under `pset:CompanyDataSet`, found none (they sat under `attr:<full key>`), and nulled zero attributes. `DELETE_PROPERTY_SET` on a custom-named set produced `nodes: []` — **no error, no effect.**

The fix mirrors collab's shape-based rule for v5a keys.

### Kept strictly additive, deliberately

The obvious version of this fix — replace the name-anywhere regexes with `parseV5aKey` — also rebuckets shapes that have nothing to do with this bug. I classified the same seven keys before and after and found four unintended moves, including:

| key | before | naive fix |
|---|---|---|
| `Pset_WallCommon::IsExternal` | `pset:Pset_WallCommon` | `attr:Pset_WallCommon::IsExternal` |
| `bsi::ifc::prop::Pset_Foo` | `pset:Pset_Foo` | `attr:prop:Pset_Foo` |

Silently moving members between components in a merge nobody asked to change is not a fix. The original patterns are retained for every non-v5a key; only the v5a branch gains behaviour. Re-running the same seven keys against the final version: **exactly one result changes** — the custom-set case this PR is about.

### Residual gap — documented, not overclaimed

A `null` deletion value carries no shape, so a second fold over `[base, delta]` can still misclassify that null under `attr:<key>`. This does **not** affect the bug fixed here: real IFCX composition is per-attribute LWW and never consults this function. But it is a genuine narrowing of `@ifc-lite/merge`'s own conflict-detection model, so it is flagged in the docstring and the integration test rather than quietly left.

## Verification

- **Bug 1 RED:** new test fails `0 !== 1` on pre-fix code; the vanish reproduced directly by observation (output above).
- **Bug 2 RED:** 3 of 4 new tests fail on pre-fix code, and the 4th — the standard `Pset_`/`Qto_` prefix control, including the `null` case — **passes**. That control passing is what proves the change is additive rather than a rewrite.
- Restores by file copy throughout; never `git checkout`/`restore`/`stash`.

`@ifc-lite/merge` 79 → **83 passing / 4 skipped**. `apps/viewer` **3065 passing / 0 failing / 2 pre-existing skips across 668 suites** (`tsx --test`, not vitest). `turbo typecheck` **33/33**.

Patch changeset for `@ifc-lite/merge`; `apps/viewer` is private and cascades via `updateInternalDependencies`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed publishing for custom-named property and quantity sets so whole-set deletions correctly remove their members.
  - Improved handling of empty or unsupported property-set operations during publishing.
  - Unsupported operations are now reported as skipped without blocking valid edits from being published.
  - Improved deletion handling so members are removed from the correct property or quantity set.

- **Tests**
  - Added coverage for custom set deletions, empty sets, skipped operations, and component grouping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->