### PR TITLE
test(collab,ifcx): pin three shape guards on the v5a inflation path

### DIFF
--- a/packages/collab/test/structured-attrs-gates.test.ts
+++ b/packages/collab/test/structured-attrs-gates.test.ts
@@ -192,6 +192,59 @@ describe('geometryRecordLookup', () => {
  * classifications/materials to `[]` has that clearing silently dropped
  * on a snapshot -> seed round trip.
  */
+/**
+ * Numeric-shape gates on the v5a set branches.
+ *
+ * Both `Number.isFinite` checks survived mutation: dropping either left
+ * the whole collab suite green. Neither is reachable through a JSON
+ * round-trip — `JSON.stringify(NaN) === null` — but an in-memory value
+ * computed without one (an op producing `0/0`, a unit conversion
+ * dividing by zero) reaches inflation directly, which is what these
+ * guards are for.
+ */
+describe('v5a numeric shape gates', () => {
+  const QTO = 'bsi::ifc::v5a::Qto_Lengths::Height';
+  const CUSTOM = 'bsi::ifc::v5a::CustomQuantities::Ratio';
+
+  it.each([
+    ['NaN', Number.NaN],
+    ['Infinity', Number.POSITIVE_INFINITY],
+  ])('does not admit a typed %s under a Qto_ set into quantities', (_label, n) => {
+    const out = inflateStructuredAttributes({ [QTO]: { type: 'IfcReal', value: n } });
+    // It does NOT stay flat: a rejected Qto_ candidate falls through to
+    // the property-shape check below it and lands in psets. Asserting
+    // only "not in quantities" would pass for the wrong reason if the
+    // value were dropped entirely, so pin where it actually goes.
+    expect(out.quantities).toEqual({});
+    expect(out.psets.Qto_Lengths?.Height).toEqual({ type: 'IfcReal', value: n });
+  });
+
+  it.each([
+    ['NaN', Number.NaN],
+    ['Infinity', Number.POSITIVE_INFINITY],
+  ])('leaves a raw %s under a custom set FLAT rather than making it a quantity', (_label, n) => {
+    const out = inflateStructuredAttributes({ [CUSTOM]: n });
+    expect(out.quantities).toEqual({});
+    // Present and unchanged, not merely absent from quantities.
+    expect(out.attributes[CUSTOM]).toBe(n);
+  });
+
+  /**
+   * `isTypedPropertyValue`'s extra-key rejection is unpinned across THREE
+   * packages — removing it leaves ifcx, collab and merge all green. A
+   * record carrying an unknown key is not the documented wire shape, and
+   * admitting it would re-emit a different value than arrived, breaking
+   * the same inverse property the gates above protect.
+   */
+  it('leaves a typed record carrying an extra key FLAT', () => {
+    const key = 'bsi::ifc::v5a::Pset_Foo::Bar';
+    const value = { type: 'IfcLabel', value: 'x', extraKey: 'unexpected' };
+    const out = inflateStructuredAttributes({ [key]: value });
+    expect(out.psets).toEqual({});
+    expect(out.attributes[key]).toEqual(value);
+  });
+});
+
 describe('structured-attrs empty-array gate (#1031 regression)', () => {
   it('round-trips an explicitly empty classifications array', () => {
     const inflated = inflateStructuredAttributes({

--- a/packages/ifcx/src/types.test.ts
+++ b/packages/ifcx/src/types.test.ts
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { isTypedPropertyValue } from './types.js';
+
+/**
+ * `isTypedPropertyValue` is the strict shape test that disambiguates a
+ * genuine typed property record (`{type, value, unit?, source?}`) from
+ * any other object. It is shared by three packages: ifcx's own
+ * property/quantity extraction, collab's `isPropertyValueShaped` (which
+ * decides whether an attribute inflates into the psets CRDT branch or
+ * stays flat), and merge's component-state handling of pset properties.
+ *
+ * The extra-key rejection loop at the end of the function is what makes
+ * the test strict rather than permissive: without it, any object that
+ * happens to carry `type` (string) and `value` (string | number |
+ * boolean | null) would pass — including one with unrelated additional
+ * keys — and every one of ifcx/collab/merge's suites stayed green when
+ * that loop was deleted, so nothing pinned it.
+ */
+describe('isTypedPropertyValue — extra-key strict rejection', () => {
+  it('accepts the canonical {type, value} shape', () => {
+    assert.equal(isTypedPropertyValue({ type: 'IfcText', value: 'hello' }), true);
+  });
+
+  it('accepts type/value plus the two documented optional keys', () => {
+    assert.equal(
+      isTypedPropertyValue({ type: 'IfcReal', value: 1.5, unit: 'm', source: 'import' }),
+      true
+    );
+  });
+
+  it('rejects a record with an extra, undocumented key', () => {
+    // Same {type, value} pair as the accepted case above, plus one
+    // foreign key. This is exactly the shape the loop exists to catch:
+    // a record that looks typed at a glance but isn't the exact wire
+    // contract, and must not be treated as one.
+    assert.equal(
+      isTypedPropertyValue({ type: 'IfcText', value: 'hello', extraKey: 'oops' }),
+      false
+    );
+  });
+
+  it('rejects a record with an extra key even when the base fields are well-formed numerics', () => {
+    assert.equal(
+      isTypedPropertyValue({ type: 'IfcReal', value: 42, extraKey: 'oops' }),
+      false
+    );
+  });
+});


### PR DESCRIPTION
Three shape guards on the v5a inflation path were unpinned — removing any one left the suites green.

| guard | mutation | before |
|---|---|---|
| `structured-attrs.ts` `Qto_` branch | drop `Number.isFinite(candidate)` | survived |
| same file, general numeric branch | drop `Number.isFinite(value)` | survived |
| `isTypedPropertyValue` extra-key loop | remove it | survived **in three packages** |

## The third one is the interesting one

Removing `isTypedPropertyValue`'s extra-key rejection — so a `{type, value, extraKey}` record inflates as a pset instead of being refused — left **ifcx 113/113, collab 211/211, and merge 80/80** all green. Three packages depend on that function and none of them pinned it.

It is bounded, so the survival means "unpinned" and not "never called": replacing the whole function with `return false` fails **6 tests in ifcx and 2 in collab**. The function is thoroughly exercised; this particular branch of it simply wasn't.

## Severity: coverage gaps, not live bugs

The guards behave correctly today. NaN/Infinity cannot arrive through a JSON round-trip — `JSON.stringify(NaN) === null` — but an in-memory value computed without one (an op producing `0/0`, a unit conversion dividing by zero) reaches inflation directly, so the guards have real defensive value. No user-facing impact is claimed.

## One correction worth recording

The `Qto_` rejection does **not** leave the value flat, which is what I first assumed. A rejected candidate falls through to the property-shape check below it and lands in **psets**.

That matters for the test, not just the comment: a test asserting only *"not in quantities"* would pass for the wrong reason if the value were dropped entirely. These pin where the value actually goes, and the two flat cases assert the value is still **present and unchanged**, not merely absent from the branch it was rejected from.

## Verification

Each mutation applied by exact-substring replacement with an asserted replacement count of 1, the mutated line re-read, restored by file copy. Each re-run by hand before pushing:

- `Qto_` finite guard removed → exactly the two typed-NaN/Infinity tests fail (19/21)
- general finite guard removed → exactly the two raw-NaN/Infinity tests fail (19/21)
- extra-key loop removed → the ifcx tests fail (115/117) and the collab extra-key test fails
- restored → all green

`@ifc-lite/collab` 211 → **216 passing / 2 skipped across 44 files**. `@ifc-lite/ifcx` 113 → **117 passing**. `@ifc-lite/merge` unchanged at **80 / 4 skipped**. `tsc --noEmit` clean for both touched packages.

Test-only; no changeset.

## Context

Found while auditing `inflateStructuredAttributes` as the reference implementation for the value-shape convention that #2278 adopts in `@ifc-lite/merge`. That audit found **no live bug** in the inflation path itself — every value shape handled with no silent drop, and `inflate(deflate(x)) === x` held for every shape including custom-named and empty sets. These three gaps are what it did turn up, kept separate from #2278 because they are unrelated to it.
