### PR TITLE
fix(viewer-core): fold the per-element origin in the CLI viewer (#2261)

### DIFF
--- a/.changeset/cli-view-local-frame-origin.md
+++ b/.changeset/cli-view-local-frame-origin.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/viewer-core": patch
+---
+
+Fix `ifc-lite view` rendering most elements collapsed near the world origin instead of at their real placement (#2261). wasm's mesh geometry is stored in a per-element local frame by default (world position = `mesh.origin` + `position`, added to keep f32 vertex storage precise at building/georef scale); the standalone CLI viewer's minimal WebGL renderer read `positions` directly without folding `origin` back in, so every element rendered near its own local frame instead of its true world placement. The main web viewer (`@ifc-lite/geometry` / `@ifc-lite/renderer`) already applied this fold and was unaffected.

--- a/packages/viewer/src/viewer-html.ts
+++ b/packages/viewer/src/viewer-html.ts
@@ -1117,7 +1117,7 @@ function handleCommand(cmd) {
           const batch = meshes.map(m => ({
             expressId: m.expressId + idOffset,
             ifcType: m.ifcType || 'Created',
-            positions: m.positions,
+            positions: foldOrigin(m.positions, m.origin),
             normals: m.normals,
             indices: m.indices,
             color: [m.color[0], m.color[1], m.color[2], m.color[3] ?? 1],
@@ -1299,6 +1299,28 @@ function connectSSE() {
 // Same callback contract: onBatch(meshes, { percent }) and onComplete().
 // meshes are MeshDataJs objects (.expressId/.ifcType/.positions/.normals/
 // .indices/.color), identical to what the old async API yielded.
+
+// wasm stores each mesh's positions relative to its own per-element local
+// frame, not absolute world coordinates -- world position = origin + position
+// (see MeshDataJs.origin; local-frame storage defaults ON for wasm so f32
+// vertices stay precise at building/georef scale). origin is [0,0,0] when
+// positions are already absolute, so this is a no-op in that case (#2261:
+// this fold was missing entirely, collapsing every element toward its own
+// AABB centre near the shared (0,0,0) origin).
+function foldOrigin(positions, origin) {
+  if (!origin || (origin[0] === 0 && origin[1] === 0 && origin[2] === 0)) {
+    return positions;
+  }
+  const ox = origin[0], oy = origin[1], oz = origin[2];
+  const out = new Float32Array(positions.length);
+  for (let i = 0; i < positions.length; i += 3) {
+    out[i] = positions[i] + ox;
+    out[i + 1] = positions[i + 1] + oy;
+    out[i + 2] = positions[i + 2] + oz;
+  }
+  return out;
+}
+
 async function parseMeshesViaPrePass(api, content, opts) {
   opts = opts || {};
   const batchSize = opts.batchSize || 50;
@@ -1388,7 +1410,12 @@ async function loadModel() {
           const batch = meshes.map(m => ({
             expressId: m.expressId,
             ifcType: m.ifcType || 'Unknown',
-            positions: m.positions,
+            // positions are stored in each mesh's own local frame -- world
+            // position = m.origin + positions[i] (see MeshDataJs.origin).
+            // wasm defaults local-frame storage ON, so skipping this fold
+            // collapses every element toward its own AABB centre, i.e. most
+            // elements render near the shared (0,0,0) origin (#2261).
+            positions: foldOrigin(m.positions, m.origin),
             normals: m.normals,
             indices: m.indices,
             color: [m.color[0], m.color[1], m.color[2], m.color[3] ?? 1],

--- a/packages/viewer/test/viewer-html-runtime.test.ts
+++ b/packages/viewer/test/viewer-html-runtime.test.ts
@@ -263,6 +263,49 @@ describe('viewer blob — typed-array merging', () => {
   });
 });
 
+describe('viewer blob — foldOrigin', () => {
+  it('is browser-free', () => assertBrowserFree('foldOrigin'));
+
+  const { foldOrigin } = loadDecls(['foldOrigin']);
+
+  it('adds the per-element local-frame origin onto every vertex (#2261)', () => {
+    // wasm's local-frame storage (default ON) stores positions relative to a
+    // per-mesh origin: world = origin + position. Two vertices of one mesh,
+    // offset by a non-zero origin (e.g. a column 42m from the model origin).
+    const positions = new Float32Array([0.4, -12.7, -0.4, -0.4, 12.7, 0.4]);
+    const origin = [-0.4, 42.78, -0.55];
+    const out = foldOrigin(positions, origin);
+    assert.deepEqual(Array.from(out).map(round), [0, 30.08, -0.95, -0.8, 55.48, -0.15]);
+  });
+
+  it('is a no-op when origin is [0,0,0] (positions already absolute)', () => {
+    const positions = new Float32Array([1, 2, 3]);
+    const out = foldOrigin(positions, [0, 0, 0]);
+    assert.equal(out, positions, 'must return the same array, not a needless copy');
+  });
+
+  it('is a no-op when origin is missing (older wasm bundle)', () => {
+    const positions = new Float32Array([1, 2, 3]);
+    const out = foldOrigin(positions, undefined);
+    assert.equal(out, positions);
+  });
+
+  it('does not mutate the input array', () => {
+    const positions = new Float32Array([1, 2, 3]);
+    foldOrigin(positions, [10, 20, 30]);
+    assert.deepEqual(Array.from(positions), [1, 2, 3]);
+  });
+
+  it('is applied at both mesh-ingestion call sites, not just one', () => {
+    // Regression guard: this bug's fix is easy to apply at the main load path
+    // and silently miss the /api/create (addGeometry) live-streaming path, or
+    // vice versa. Both onBatch callbacks must route positions through
+    // foldOrigin rather than reading m.positions directly.
+    const occurrences = SCRIPT.match(/positions:\s*foldOrigin\(m\.positions,\s*m\.origin\)/g) ?? [];
+    assert.equal(occurrences.length, 2, 'both onBatch callbacks must fold m.origin into m.positions');
+  });
+});
+
 describe('viewer blob — bounds', () => {
   it('is browser-free', () => {
     assertBrowserFree('computeEntityBounds');
@@ -576,6 +619,7 @@ function makeViewer(
       'getEntityBoundsForFilter',
       'STOREY_PALETTE',
       'ID_NAMESPACE_SIZE',
+      'foldOrigin',
       'handleCommand',
     ],
     scope,


### PR DESCRIPTION
Fixes #2261 — `ifc-lite view` rendered most elements collapsed onto the world origin.

## The lead was the reporter's own observation

They noted the hosted viewer parses the same file correctly. The parser and geometry kernel are shared, so a kernel bug would break both — which meant the difference had to be **downstream** of parsing, in what the CLI does differently. That narrowed the search from "IFC placement handling" to "what does the CLI's render path skip", and the answer was one fold.

## Root cause

wasm stores each mesh's vertices in a **per-element local frame** by default — `local_frame_enabled()` is on for `target_arch = "wasm32"` — so `world = mesh.origin + position`, where `origin` is that mesh's own AABB centre. It exists so f32 vertex storage stays precise at building and georeferenced scale, and the contract is stated on the wasm type surface itself.

Every real consumer folds it back in:

- `packages/geometry/src/geometry-coordinate.ts:85-114` carries `origin` through
- `packages/renderer/src/scene-geometry.ts:102-104` adds it before GPU upload

`packages/viewer/src/viewer-html.ts` — the bespoke minimal WebGL renderer used **only** by `ifc-lite view` — did not, at either of its two mesh-ingestion sites. It fed local-frame positions in as if they were world coordinates, so every element rendered relative to its own centre. That is exactly the reported symptom: everything piled near `0,0,0`.

The main web viewer was never affected, which is why the two paths disagreed.

## The fix

`foldOrigin(positions, origin)` applied at both ingestion sites. It returns the input unchanged when `origin` is absent or zero, so a build with absolute positions is a genuine no-op rather than a wasted copy.

## Verified end to end against the reporter's file, not simulated

Built wasm and the CLI locally, ran the real `ifc-lite view` server, and drove it with headless Chromium:

- **Before** — reproduced the reported screenshot exactly, down to the same `7,950 triangles, 93 entities` stat line.
- **After** — the same file renders as the regular column/beam/footing grid the reporter expected, **stat line unchanged**. Placement moved; geometry did not. That is the check that separates a real fix from one that quietly drops or rebuilds meshes.

Cross-checked numerically against `collectMeshesViaPrePass` calling the identical `buildPrePassOnce`/`processGeometryBatch` entry points — 119 meshes / 12,390 vertices both ways, confirming the two paths agree on geometry and differ only in the fold.

## Tests

Five new tests, one of which asserts the fold happens at **both** call sites. Reverting only one is the likely future regression, and a test checking a single site would not catch it.

- RED: reverting both sites (scripted exact-substring replace, count asserted at 2) fails exactly the new tests, old tests still green.
- GREEN: restored → **247/247 passing** in `@ifc-lite/viewer-core`, `tsc --noEmit` clean.

Patch changeset included for `@ifc-lite/viewer-core`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed viewer rendering so meshes appear in their correct world positions.
  - Applied consistent positioning when loading models and adding geometry dynamically.
  - Preserved behavior for meshes without an origin or with a zero origin.

- **Tests**
  - Added regression coverage for mesh positioning, unchanged input data, and both geometry-loading workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->