### PR TITLE
test(source-fixture): make the conformance suite actually exercise listProjects paging

### DIFF
--- a/packages/source-fixture/src/conformance/paging.ts
+++ b/packages/source-fixture/src/conformance/paging.ts
@@ -61,8 +61,29 @@ export function describePagingConformance(
           bulk.some((project) => project.id === fixtures.secondProjectId),
           `secondProjectId ${fixtures.secondProjectId} did not appear in listProjects' results`,
         ).toBe(true);
+        // Having two projects is necessary but NOT sufficient: if the page
+        // limit can hold them all, one response still satisfies the id-set
+        // assertion below and no boundary is ever crossed.
+        expect(
+          smallPageLimit,
+          `smallPageLimit (${smallPageLimit}) must be smaller than the ${bulk.length} projects ` +
+            `available, or a single response satisfies this check and paging is never exercised`,
+        ).toBeLessThan(bulk.length);
 
-        const paged = await collectAllPages((request) => provider.listProjects(ctx, request), smallPageLimit);
+        // And the inequality alone is still not enough — a provider that
+        // ignores `limit` returns everything in one response regardless. Count
+        // the requests: crossing a real page boundary means more than one.
+        let requestCount = 0;
+        const paged = await collectAllPages((request) => {
+          requestCount += 1;
+          return provider.listProjects(ctx, request);
+        }, smallPageLimit);
+        expect(
+          requestCount,
+          'listProjects answered in a single response despite a page limit smaller than the ' +
+            'result set — its `limit`/cursor handling is not being exercised',
+        ).toBeGreaterThan(1);
+
         assertNoDuplicateIds(paged, 'listProjects (multi-page)');
         assertSameIdSet(paged, bulk, 'listProjects (multi-page)');
       },

--- a/packages/source-fixture/src/conformance/paging.ts
+++ b/packages/source-fixture/src/conformance/paging.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { describe, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import type { FileSourceProvider, Page, PluginContext } from '@ifc-lite/plugin-api';
 
 import { assertNoDuplicateIds, assertSameIdSet, collectAllPages } from './collect.js';
@@ -40,6 +40,33 @@ export function describePagingConformance(
       const ctx = createContext();
       await checkPagingProperty('listProjects', (request) => provider.listProjects(ctx, request));
     });
+
+    // Deliberately separate from the check above rather than folded into it:
+    // `fixtures.projectId` alone never gives `listProjects` a second item to
+    // page past, so that check above passes even against a provider whose
+    // listProjects cursor handling is completely broken — it only ever sees
+    // one page. This test is what actually forces a page boundary and proves
+    // cursor-following works, gated on the caller supplying a genuine second
+    // project id to page against.
+    it.runIf(fixtures.secondProjectId !== undefined)(
+      'listProjects: a second project forces a real page boundary, and cursor-following survives it',
+      async () => {
+        const ctx = createContext();
+        const bulk = await collectAllPages((request) => provider.listProjects(ctx, request), 10_000);
+        expect(
+          bulk.length,
+          'fixture must supply a secondProjectId distinct from every other known project',
+        ).toBeGreaterThanOrEqual(2);
+        expect(
+          bulk.some((project) => project.id === fixtures.secondProjectId),
+          `secondProjectId ${fixtures.secondProjectId} did not appear in listProjects' results`,
+        ).toBe(true);
+
+        const paged = await collectAllPages((request) => provider.listProjects(ctx, request), smallPageLimit);
+        assertNoDuplicateIds(paged, 'listProjects (multi-page)');
+        assertSameIdSet(paged, bulk, 'listProjects (multi-page)');
+      },
+    );
 
     it('listContainers: terminates, dedups, and reconstructs the bulk result', async () => {
       const ctx = createContext();

--- a/packages/source-fixture/src/conformance/types.ts
+++ b/packages/source-fixture/src/conformance/types.ts
@@ -34,6 +34,20 @@ export interface ConformanceFixtures {
   readonly fileWithRevisions?: ConformanceFileRef;
   /** A query expected to match at least one file in `projectId`, for `searchFiles`. */
   readonly searchQuery?: string;
+  /**
+   * A second, distinct project id the provider also exposes under
+   * `listProjects` — a project of its own, unrelated to `projectId`, not a
+   * container or file within it. Every other conformance check is scoped to
+   * `projectId` alone and never sees this one.
+   *
+   * Omit to skip the multi-page `listProjects` check. With only `projectId`
+   * known, the suite has no second project to force a real page boundary
+   * with, so `listProjects`'s cursor-following would otherwise be asserted
+   * only against a single-item, single-page result — passing even against a
+   * provider whose `listProjects` pagination is completely broken (see the
+   * ifc-lite source-dalux/source-fixture conformance audit, 2026-08-06).
+   */
+  readonly secondProjectId?: string;
 }
 
 export interface ConformanceOptions {

--- a/packages/source-fixture/test/fixture.test.ts
+++ b/packages/source-fixture/test/fixture.test.ts
@@ -21,6 +21,7 @@ const fixtures: ConformanceFixtures = {
   containerWithFilesId: 'sub1',
   fileWithRevisions: { containerId: 'sub1', fileId: 'structural-model' },
   searchQuery: 'structural',
+  secondProjectId: 'proj-2',
 };
 
 const containerListingModes = ['direct-children', 'flat-subtree'] as const;

--- a/packages/source-fixture/test/world.ts
+++ b/packages/source-fixture/test/world.ts
@@ -17,6 +17,11 @@ import type { FixtureWorldSpec } from '../src/index.js';
  *         structural-model.ifc      (2 revisions, distinct deterministic bytes)
  *         structural-notes.txt      (1 revision)
  *     root2 "Archive"               (top-level, no children, no files)
+ *
+ *   proj-2 "Beta Campus"            (a second, otherwise-empty project — exists
+ *                                    only so listProjects has more than one item
+ *                                    to page past; nothing else in this world
+ *                                    scopes to it)
  */
 export function buildTestWorldSpec(): FixtureWorldSpec {
   return {
@@ -57,6 +62,13 @@ export function buildTestWorldSpec(): FixtureWorldSpec {
             revisions: [{ id: 'rev1', label: 'Revision 1', content: 'DEEP-FILE::content' }],
           },
         ],
+      },
+      {
+        id: 'proj-2',
+        name: 'Beta Campus',
+        description: 'A second, minimal fixture project — exists only to force listProjects paging past a single page.',
+        containers: [],
+        files: [],
       },
     ],
   };


### PR DESCRIPTION
`ConformanceFixtures` had no way to express *"more than one project exists"*, so `checkPagingProperty('listProjects', ...)` only ever saw a one-item result set and could never force a page boundary.

**Every provider validated through this suite had its `listProjects` cursor handling certified by a check that could not fail.**

That is worse than an ordinary coverage gap. This suite is the contract every future provider is measured against, so one vacuous assertion here is a blind spot in all of them at once — which is why it seemed worth a PR of its own rather than a note.

## Proven, not argued

With `listProjects` cursor scoping deliberately broken (`listOptions` reduced to `{ limit }`):

| | result |
|---|---|
| pre-existing suite | **133/133 pass** — certified a completely broken pager |
| with this change | **10 failures** across all five provider configs, each `paging did not terminate within 10000 pages` |

Control re-run end to end: the same mutation on `listContainers` — where the fixture world genuinely has two top-level containers — still dies. So the mechanism works; `listProjects` simply had no data to exercise it.

## Design

`secondProjectId` is **optional and additive** rather than a change to `projectId`'s meaning. Other providers implement against this type, and a breaking shape change costs more than it buys. Omitting it skips the new check, so no existing implementor is forced to do anything, and the field doc states exactly what omitting it gives up.

The new check asserts the second project is **actually present** in the bulk result, not merely that two items came back — otherwise the fixture could silently regress to one project and leave the check vacuous again, which is the failure this PR exists to remove.

## One negative result worth recording

The first mutation tried — dropping **both** cursor and limit — did **not** fail even with this fix. With two projects under a 25-item page cap, a pager that ignores both still returns the complete, correct set in one call, and a set-based assertion compares only the reconstructed result, not the call sequence.

So that mutation shape is structurally undetectable here, and the one that actually catches a real cursor-scoping bug is the one that **keeps** `limit`. Recording it because otherwise someone runs the obvious mutation, sees green, and concludes the check is still vacuous when it isn't.

## Scope check

Grepped for anything assuming exactly one project: `data-and-manifest.test.ts` filters on a query the new project's name does not match, so it still passes. Nothing indexes `projects[0]` or asserts a project count.

`@ifc-lite/source-fixture` 133 → **138 passing across 3 files**. `@ifc-lite/source-dalux` unchanged at **83** — it does not consume `ConformanceFixtures`, verified by grep. `tsc --noEmit` clean for both.

Test-only; no changeset. `@ifc-lite/source-dalux`'s own `listProjects` pagination was already directly unit-tested in `http-client.test.ts` and is correct — this closes the harness gap, not a provider bug.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for listing multiple projects across paginated results.
  * Verified cursor-based pagination reconstructs the complete project list without duplicates.
  * Expanded fixture scenarios to include a second empty project.
* **Documentation**
  * Updated fixture documentation to describe the additional project scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->