### PR TITLE
fix(ids): let an optional requirement pass when predefinedType is absent

### DIFF
--- a/.changeset/ids-optional-predefinedtype-missing.md
+++ b/.changeset/ids-optional-predefinedtype-missing.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/ids": patch
+---
+
+Fix `optional` requirements incorrectly failing when a nested `predefinedType` constraint is checked against an entity (or, for `partOf`, a related entity) that has no predefined type at all.
+
+Per IDS semantics, `optional` means "if present, must satisfy" — a wholly absent attribute passes, same as `ATTRIBUTE_MISSING`/`PROPERTY_MISSING`/etc. already do. `PREDEFINED_TYPE_MISSING` and `PARTOF_PREDEFINED_TYPE_MISSING` were left out of that "wholly absent" allow-list, so an `optional` entity or `partOf` requirement with a `predefinedType` sub-constraint reported `fail` instead of `pass` whenever the target had no predefined type data — the opposite of what `optional` promises.

--- a/packages/ids/src/validation/validator.test.ts
+++ b/packages/ids/src/validation/validator.test.ts
@@ -192,6 +192,70 @@ describe('validateIDS — optionality', () => {
     const reqResult = report.specificationResults[0].entityResults[0].requirementResults[0];
     expect(reqResult.status).toBe('pass');
   });
+
+  it('optional entity requirement passes when predefinedType is wholly absent', async () => {
+    // PREDEFINED_TYPE_MISSING means "this entity has no PredefinedType
+    // and no fallback ObjectType at all" — the same "wholly absent"
+    // shape as ATTRIBUTE_MISSING, so `optional` must give it a pass
+    // rather than treating it as bad data.
+    const accessor = createMockAccessor([
+      { expressId: 1, type: 'IfcWall' }, // no objectType, no predefinedType
+    ]);
+
+    const spec = makeSpec({
+      requirements: [
+        {
+          id: 'req-0',
+          facet: { type: 'entity', name: sv('IFCWALL'), predefinedType: sv('SOLIDWALL') },
+          optionality: 'optional',
+        },
+      ],
+    });
+
+    const report = await validateIDS(makeDoc([spec]), accessor, modelInfo);
+    const reqResult = report.specificationResults[0].entityResults[0].requirementResults[0];
+    expect(reqResult.failure?.type).toBe('PREDEFINED_TYPE_MISSING');
+    expect(reqResult.status).toBe('pass');
+    expect(report.specificationResults[0].status).toBe('pass');
+  });
+
+  it('optional partOf requirement passes when parent predefinedType is wholly absent', async () => {
+    // Same "wholly absent" shape as above, one level removed: the
+    // relation exists (a parent was found) but the parent's own
+    // PredefinedType attribute is unset.
+    const accessor = createMockAccessor([
+      {
+        expressId: 1,
+        type: 'IfcWall',
+        parent: {
+          expressId: 2,
+          type: 'IfcBuildingStorey',
+          relation: 'IfcRelContainedInSpatialStructure',
+          // predefinedType intentionally omitted
+        },
+      },
+    ]);
+
+    const spec = makeSpec({
+      requirements: [
+        {
+          id: 'req-0',
+          facet: {
+            type: 'partOf',
+            relation: 'IfcRelContainedInSpatialStructure',
+            entity: { name: sv('IFCBUILDINGSTOREY'), predefinedType: sv('BASEMENT') },
+          },
+          optionality: 'optional',
+        },
+      ],
+    });
+
+    const report = await validateIDS(makeDoc([spec]), accessor, modelInfo);
+    const reqResult = report.specificationResults[0].entityResults[0].requirementResults[0];
+    expect(reqResult.failure?.type).toBe('PARTOF_PREDEFINED_TYPE_MISSING');
+    expect(reqResult.status).toBe('pass');
+    expect(report.specificationResults[0].status).toBe('pass');
+  });
 });
 
 // ============================================================================

--- a/packages/ids/src/validation/validator.ts
+++ b/packages/ids/src/validation/validator.ts
@@ -549,6 +549,13 @@ function checkRequirement(
           'CLASSIFICATION_MISSING',
           'MATERIAL_MISSING',
           'PARTOF_RELATION_MISSING',
+          // The nested predefinedType sub-constraint on an entity /
+          // partOf facet is itself an "attribute" of the target entity —
+          // when it's wholly unset (no PredefinedType, no fallback
+          // ObjectType/parent predefinedType at all) that's the same
+          // "wholly absent" shape as ATTRIBUTE_MISSING, not "bad data".
+          'PREDEFINED_TYPE_MISSING',
+          'PARTOF_PREDEFINED_TYPE_MISSING',
         ]);
         if (
           facetResult.failure?.type &&


### PR DESCRIPTION
An `optional` requirement carrying a `predefinedType` sub-constraint reports **FAIL** against an entity that has no predefined type at all — so a compliant model is wrongly marked non-compliant.

## The defect

`checkRequirement`'s `optional` arm allow-lists the failure types meaning "wholly absent", per the rule its own comment states:

> Pass when the facet matches. Pass when the facet is wholly absent. **Fail** when the facet is present but its value/datatype is wrong — `optional` does not give a free pass to bad data.

The list covered `ATTRIBUTE_MISSING`, `PROPERTY_MISSING`, `PSET_MISSING`, `CLASSIFICATION_MISSING`, `MATERIAL_MISSING` and `PARTOF_RELATION_MISSING` — but omitted `PREDEFINED_TYPE_MISSING` and `PARTOF_PREDEFINED_TYPE_MISSING`, which are structurally the same "this is entirely unset" case.

Observed before the fix, through `validateIDS` rather than by inspection:

```
optional entity facet {name: IFCWALL, predefinedType: SOLIDWALL}
against an IfcWall with no PredefinedType and no ObjectType
  -> status: "fail", failure.type: "PREDEFINED_TYPE_MISSING"
```

Same shape for an `optional` `partOf` facet against a parent with no `predefinedType`.

**Severity: LIVE.**

## Why this can't create a false PASS — checked at the emission sites, not assumed

This is the part that mattered most, because for a conformance checker a false **PASS** is far worse than the false FAIL being fixed: someone acts on it. Widening the "absent" allow-list is exactly the kind of change that could do that, so I verified the distinction is real before accepting it.

- `entity-facet.ts:94` emits `PREDEFINED_TYPE_MISSING` **only** under `!rawType && !userDefinedType` — genuinely unset — and emits a separate `PREDEFINED_TYPE_MISMATCH` at `:138` when a value is present but doesn't match.
- `partof-facet.ts` splits the same way: `:138` MISSING for `!parent.predefinedType`, `:155` MISMATCH otherwise.

Only the MISSING variants are added. The MISMATCH variants stay out, so `optional` still fails on bad data exactly as documented.

## The rest of the surface was inventoried and is sound

Reported plainly rather than padded — the audit's main hypothesis (a recognised-but-unevaluated constraint reading as "satisfied") did **not** hold:

- All six facet types — `entity`, `attribute`, `property`, `classification`, `material`, `partOf` — reach a matcher arm, with a `default` that **fails closed**.
- Every constraint kind is actually evaluated: `simpleValue`, `pattern`, `enumeration`, and `bounds` (covering `length`/`minLength`/`maxLength`/`min|maxInclusive`/`min|maxExclusive`). Mutating the `bounds` arm to `return true` — the false-PASS shape — kills 7 tests across 2 files, so it is genuinely exercised rather than vacuously covered.
- The `checkFacet` / `facetPasses` dual path (full diagnostics vs boolean fast path) is the classic "two implementations that must agree" risk, and it already has an explicit differential parity test across every facet × entity combination.

## Verification

- **RED**: with the fix reverted and the new tests in place, both new tests fail and the other **300 pass** — so the bug was untested, not previously failing.
- **GREEN**: restored → **302 passing across 15 files**.
- Restores by file copy throughout; never `git checkout`/`restore`/`stash`.
- `tsc --noEmit` clean. Patch changeset included.
