### PR TITLE
feat(viewer): show dX/dY/dZ and horizontal/vertical on distance measurements (#2199)

### DIFF
--- a/apps/viewer/src/components/viewer/tools/MeasurePanel.tsx
+++ b/apps/viewer/src/components/viewer/tools/MeasurePanel.tsx
@@ -12,6 +12,11 @@ import { Button } from '@/components/ui/button';
 import { useViewerStore, type Measurement } from '@/store';
 import { MeasurementOverlays } from './MeasurementVisuals';
 import { formatDistance } from './formatDistance';
+import {
+  distanceComponents,
+  formatAxisDeltas,
+  formatHorizontalVertical,
+} from './measure-modes/components';
 import { useDraggablePanel } from '@/hooks/useDraggablePanel';
 import { useAnchorGeoreference, type AnchorGeoreference } from '@/lib/geo/useAnchorGeoreference';
 import { viewerPointToProjected } from '@/lib/geo/pick-to-geo';
@@ -386,6 +391,8 @@ interface MeasurementItemProps {
 }
 
 function MeasurementItem({ measurement, index, onDelete, geoAnchor }: MeasurementItemProps) {
+  // Pure display: derived from the stored endpoints, nothing is persisted.
+  const components = distanceComponents(measurement.start, measurement.end);
   return (
     <div className="bg-muted/50 rounded px-2 py-0.5 text-xs">
       <div className="flex items-center justify-between">
@@ -399,6 +406,14 @@ function MeasurementItem({ measurement, index, onDelete, geoAnchor }: Measuremen
         >
           <X className="h-2.5 w-2.5" />
         </Button>
+      </div>
+      <div className="overflow-x-auto">
+        <div className="font-mono text-[10px] leading-tight text-muted-foreground whitespace-nowrap">
+          {formatAxisDeltas(components)}
+        </div>
+        <div className="font-mono text-[10px] leading-tight text-muted-foreground whitespace-nowrap">
+          {formatHorizontalVertical(components)}
+        </div>
       </div>
       {geoAnchor && (
         <div className="mt-0.5 overflow-x-auto">

--- a/apps/viewer/src/components/viewer/tools/MeasurementVisuals.tsx
+++ b/apps/viewer/src/components/viewer/tools/MeasurementVisuals.tsx
@@ -193,7 +193,13 @@ export const MeasurementOverlays = React.memo(function MeasurementOverlays({ mea
             }}
           >
             {formatDistance(activeMeasurement.distance)}
-            {/* Live axis breakdown, derived on render (see measure-modes/components). */}
+            {/* Live axis breakdown, derived on render (see measure-modes/components).
+                Mirrors the completed-measurement label: axis deltas first, then
+                horizontal/vertical — the drag is exactly when a setting-out user
+                wants dX/dY/dZ, so the live readout must not be the poorer one. */}
+            <div className="font-normal text-[10px] leading-tight opacity-80">
+              {formatAxisDeltas(distanceComponents(activeMeasurement.start, activeMeasurement.current))}
+            </div>
             <div className="font-normal text-[10px] leading-tight opacity-80">
               {formatHorizontalVertical(distanceComponents(activeMeasurement.start, activeMeasurement.current))}
             </div>
@@ -469,7 +475,20 @@ export const MeasurementOverlays = React.memo(function MeasurementOverlays({ mea
       )}
     </>
   );
-}, (prevProps, nextProps) => {
+}, measurementOverlaysPropsEqual);
+
+/**
+ * Props-equality for the `React.memo` above. Exported so it can be tested
+ * directly — the stale-readout bug it guards against is invisible in a render
+ * test, because the component renders correctly when it renders at all.
+ *
+ * World coordinates are compared as well as screen ones: the axis breakdown
+ * (`distanceComponents`) is derived from world x/y/z, so two different world
+ * positions that project to the SAME screen point — moving along the view ray,
+ * or snapping to a different depth under an unmoved cursor — must still
+ * re-render. Screen-only comparison would leave a stale dX/dY/dZ on screen.
+ */
+export function measurementOverlaysPropsEqual(prevProps: MeasurementOverlaysProps, nextProps: MeasurementOverlaysProps): boolean {
   // Custom comparison to prevent unnecessary re-renders
   // Return true if props are equal (skip re-render), false if different (re-render)
 
@@ -482,6 +501,9 @@ export const MeasurementOverlays = React.memo(function MeasurementOverlays({ mea
     // Check screen coordinates for zoom/camera changes
     if (prev.start.screenX !== next.start.screenX || prev.start.screenY !== next.start.screenY) return false;
     if (prev.end.screenX !== next.end.screenX || prev.end.screenY !== next.end.screenY) return false;
+    // World coords too — the axis breakdown is derived from them.
+    if (prev.start.x !== next.start.x || prev.start.y !== next.start.y || prev.start.z !== next.start.z) return false;
+    if (prev.end.x !== next.end.x || prev.end.y !== next.end.y || prev.end.z !== next.end.z) return false;
   }
 
   // Compare activeMeasurement - check if it exists and if position changed
@@ -491,7 +513,13 @@ export const MeasurementOverlays = React.memo(function MeasurementOverlays({ mea
       prevProps.activeMeasurement.current.screenX !== nextProps.activeMeasurement.current.screenX ||
       prevProps.activeMeasurement.current.screenY !== nextProps.activeMeasurement.current.screenY ||
       prevProps.activeMeasurement.start.screenX !== nextProps.activeMeasurement.start.screenX ||
-      prevProps.activeMeasurement.start.screenY !== nextProps.activeMeasurement.start.screenY
+      prevProps.activeMeasurement.start.screenY !== nextProps.activeMeasurement.start.screenY ||
+      prevProps.activeMeasurement.current.x !== nextProps.activeMeasurement.current.x ||
+      prevProps.activeMeasurement.current.y !== nextProps.activeMeasurement.current.y ||
+      prevProps.activeMeasurement.current.z !== nextProps.activeMeasurement.current.z ||
+      prevProps.activeMeasurement.start.x !== nextProps.activeMeasurement.start.x ||
+      prevProps.activeMeasurement.start.y !== nextProps.activeMeasurement.start.y ||
+      prevProps.activeMeasurement.start.z !== nextProps.activeMeasurement.start.z
     ) return false;
   }
 
@@ -569,7 +597,7 @@ export const MeasurementOverlays = React.memo(function MeasurementOverlays({ mea
   }
 
   return true; // All props are equal, skip re-render
-});
+}
 
 interface SnapIndicatorProps {
   screenX: number;

--- a/apps/viewer/src/components/viewer/tools/MeasurementVisuals.tsx
+++ b/apps/viewer/src/components/viewer/tools/MeasurementVisuals.tsx
@@ -11,11 +11,18 @@ import type { Measurement, SnapVisualization } from '@/store';
 import type { MeasurementConstraintEdge } from '@/store/types';
 import { SnapType, type SnapTarget } from '@ifc-lite/renderer';
 import { formatDistance } from './formatDistance';
+import {
+  distanceComponents,
+  formatAxisDeltas,
+  formatHorizontalVertical,
+} from './measure-modes/components';
 
 export interface MeasurementOverlaysProps {
   measurements: Measurement[];
   pending: { screenX: number; screenY: number } | null;
-  activeMeasurement: { start: { screenX: number; screenY: number; x: number; y: number; z: number }; current: { screenX: number; screenY: number }; distance: number } | null;
+  // `current` carries world x/y/z (the store's ActiveMeasurement uses a full
+  // MeasurePoint) so the live label can show the same axis breakdown.
+  activeMeasurement: { start: { screenX: number; screenY: number; x: number; y: number; z: number }; current: { screenX: number; screenY: number; x: number; y: number; z: number }; distance: number } | null;
   snapTarget: SnapTarget | null;
   snapVisualization: SnapVisualization | null;
   hoverPosition?: { x: number; y: number } | null;
@@ -75,7 +82,9 @@ export const MeasurementOverlays = React.memo(function MeasurementOverlays({ mea
       </svg>
 
       {/* Completed measurements */}
-      {measurements.map((m) => (
+      {measurements.map((m) => {
+        const components = distanceComponents(m.start, m.end);
+        return (
         <div key={m.id} className="pointer-events-none">
           {/* Line connecting start and end */}
           <svg
@@ -121,9 +130,17 @@ export const MeasurementOverlays = React.memo(function MeasurementOverlays({ mea
             }}
           >
             {formatDistance(m.distance)}
+            {/* Axis breakdown, derived on render (see measure-modes/components). */}
+            <div className="font-normal text-[10px] leading-tight opacity-80">
+              {formatAxisDeltas(components)}
+            </div>
+            <div className="font-normal text-[10px] leading-tight opacity-80">
+              {formatHorizontalVertical(components)}
+            </div>
           </div>
         </div>
-      ))}
+        );
+      })}
 
       {/* Active measurement (live preview while dragging) */}
       {activeMeasurement && (
@@ -176,6 +193,10 @@ export const MeasurementOverlays = React.memo(function MeasurementOverlays({ mea
             }}
           >
             {formatDistance(activeMeasurement.distance)}
+            {/* Live axis breakdown, derived on render (see measure-modes/components). */}
+            <div className="font-normal text-[10px] leading-tight opacity-80">
+              {formatHorizontalVertical(distanceComponents(activeMeasurement.start, activeMeasurement.current))}
+            </div>
           </div>
         </div>
       )}

--- a/apps/viewer/src/components/viewer/tools/measure-modes/components.test.ts
+++ b/apps/viewer/src/components/viewer/tools/measure-modes/components.test.ts
@@ -1,0 +1,89 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import {
+  distanceComponents,
+  formatSignedDistance,
+  formatAxisDeltas,
+  formatHorizontalVertical,
+} from './components.js';
+
+describe('distanceComponents', () => {
+  it('splits a (3, 12, 4) displacement with Y as the UP axis', () => {
+    // The whole risk of this slice: the viewer is Y-up, so the ground plane is
+    // X/Z. horizontal = hypot(3, 4) = 5, vertical = |12|.
+    // Swapping the two formulas gives 12 / 5; treating Z as up gives
+    // hypot(3, 12) = 12.369 / 4. Both are killed by these two numbers.
+    const c = distanceComponents({ x: 0, y: 0, z: 0 }, { x: 3, y: 12, z: 4 });
+    assert.strictEqual(c.horizontal, 5);
+    assert.strictEqual(c.vertical, 12);
+  });
+
+  it('keeps the same split when the displacement is offset from the origin', () => {
+    const c = distanceComponents({ x: 10, y: -4, z: -2 }, { x: 13, y: 8, z: 2 });
+    assert.strictEqual(c.dx, 3);
+    assert.strictEqual(c.dy, 12);
+    assert.strictEqual(c.dz, 4);
+    assert.strictEqual(c.horizontal, 5);
+    assert.strictEqual(c.vertical, 12);
+  });
+
+  it('returns signed deltas (end minus start), not magnitudes', () => {
+    const c = distanceComponents({ x: 3, y: 12, z: 4 }, { x: 0, y: 0, z: 0 });
+    assert.strictEqual(c.dx, -3);
+    assert.strictEqual(c.dy, -12);
+    assert.strictEqual(c.dz, -4);
+    // ...while horizontal / vertical stay non-negative regardless of direction.
+    assert.strictEqual(c.horizontal, 5);
+    assert.strictEqual(c.vertical, 12);
+  });
+
+  it('is purely vertical for a straight drop and purely horizontal for a level run', () => {
+    const drop = distanceComponents({ x: 1, y: 5, z: 2 }, { x: 1, y: 2, z: 2 });
+    assert.strictEqual(drop.horizontal, 0);
+    assert.strictEqual(drop.vertical, 3);
+
+    const run = distanceComponents({ x: 0, y: 7, z: 0 }, { x: 6, y: 7, z: 8 });
+    assert.strictEqual(run.horizontal, 10);
+    assert.strictEqual(run.vertical, 0);
+  });
+
+  it('agrees with the straight-line distance via Pythagoras', () => {
+    const start = { x: -2.5, y: 1.25, z: 0.75 };
+    const end = { x: 4.5, y: -3.25, z: 6.75 };
+    const c = distanceComponents(start, end);
+    const straight = Math.hypot(end.x - start.x, end.y - start.y, end.z - start.z);
+    assert.ok(Math.abs(Math.hypot(c.horizontal, c.vertical) - straight) < 1e-12);
+  });
+
+  it('is zero in every component for a degenerate measurement', () => {
+    const c = distanceComponents({ x: 2, y: 3, z: 4 }, { x: 2, y: 3, z: 4 });
+    assert.deepStrictEqual(c, { dx: 0, dy: 0, dz: 0, horizontal: 0, vertical: 0 });
+  });
+});
+
+describe('formatSignedDistance', () => {
+  it('keeps the minus sign in front of the unit-scaled magnitude', () => {
+    assert.strictEqual(formatSignedDistance(3), '3.000 m');
+    assert.strictEqual(formatSignedDistance(-3), '-3.000 m');
+    // Sub-metre values scale to cm/mm; the sign must survive that branch.
+    assert.strictEqual(formatSignedDistance(-0.25), '-25.0 cm');
+    assert.strictEqual(formatSignedDistance(-0.005), '-5.0 mm');
+    assert.strictEqual(formatSignedDistance(0), '0.0 mm');
+  });
+});
+
+describe('measurement readout lines', () => {
+  it('labels each axis delta with its own axis', () => {
+    const c = distanceComponents({ x: 0, y: 0, z: 0 }, { x: 3, y: 12, z: -4 });
+    assert.strictEqual(formatAxisDeltas(c), 'dX 3.000 m  dY 12.000 m  dZ -4.000 m');
+  });
+
+  it('labels horizontal H and vertical V', () => {
+    const c = distanceComponents({ x: 0, y: 0, z: 0 }, { x: 3, y: 12, z: 4 });
+    assert.strictEqual(formatHorizontalVertical(c), 'H 5.000 m  V 12.000 m');
+  });
+});

--- a/apps/viewer/src/components/viewer/tools/measure-modes/components.ts
+++ b/apps/viewer/src/components/viewer/tools/measure-modes/components.ts
@@ -1,0 +1,72 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Axis breakdown for a point-to-point measurement.
+ *
+ * Pure display maths: the stored Measurement shape is unchanged, these values
+ * are derived on render from its two endpoints.
+ *
+ * AXIS CONVENTION: viewer space is Y-UP. Geometry is converted from IFC Z-up
+ * to WebGL Y-up on import (see packages/renderer/src/camera.ts, `up: {x:0,y:1,z:0}`),
+ * so the vertical component is |dy| and the horizontal component is the length
+ * of the (dx, dz) ground-plane projection. Using dz as "up" here would be
+ * silently wrong for every model.
+ */
+
+import { formatDistance } from '../formatDistance';
+
+export interface Point3 {
+  x: number;
+  y: number;
+  z: number;
+}
+
+export interface DistanceComponents {
+  /** Signed delta along viewer X (east/west in the ground plane). */
+  dx: number;
+  /** Signed delta along viewer Y (the UP axis). */
+  dy: number;
+  /** Signed delta along viewer Z (the other ground-plane axis). */
+  dz: number;
+  /** Ground-plane (horizontal) distance: hypot(dx, dz). Never negative. */
+  horizontal: number;
+  /** Vertical rise/fall: |dy|. Never negative. */
+  vertical: number;
+}
+
+/**
+ * Break a point-to-point displacement into per-axis deltas plus the
+ * horizontal / vertical split. Deltas are signed (end minus start); the
+ * horizontal and vertical readouts are magnitudes.
+ */
+export function distanceComponents(start: Point3, end: Point3): DistanceComponents {
+  const dx = end.x - start.x;
+  const dy = end.y - start.y;
+  const dz = end.z - start.z;
+  return {
+    dx,
+    dy,
+    dz,
+    // Y is up: the ground plane is X/Z, the vertical axis is Y.
+    horizontal: Math.hypot(dx, dz),
+    vertical: Math.abs(dy),
+  };
+}
+
+/** Format a signed delta, keeping the sign in front of the unit-scaled magnitude. */
+export function formatSignedDistance(meters: number): string {
+  const magnitude = formatDistance(Math.abs(meters));
+  return meters < 0 ? `-${magnitude}` : magnitude;
+}
+
+/** One-line per-axis readout, e.g. `dX 3.000 m  dY 12.000 m  dZ 4.000 m`. */
+export function formatAxisDeltas(c: DistanceComponents): string {
+  return `dX ${formatSignedDistance(c.dx)}  dY ${formatSignedDistance(c.dy)}  dZ ${formatSignedDistance(c.dz)}`;
+}
+
+/** One-line horizontal/vertical readout, e.g. `H 5.000 m  V 12.000 m`. */
+export function formatHorizontalVertical(c: DistanceComponents): string {
+  return `H ${formatDistance(c.horizontal)}  V ${formatDistance(c.vertical)}`;
+}

--- a/apps/viewer/src/components/viewer/tools/measurementOverlaysPropsEqual.test.ts
+++ b/apps/viewer/src/components/viewer/tools/measurementOverlaysPropsEqual.test.ts
@@ -1,0 +1,130 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The memo comparator must react to WORLD coordinate changes, not only screen
+ * ones (#2199 review).
+ *
+ * `MeasurementOverlays` renders the axis breakdown from `distanceComponents`,
+ * which reads world x/y/z. The comparator originally compared `screenX`/
+ * `screenY` only — correct while the label showed a single projected distance,
+ * wrong the moment the label started deriving from world coords.
+ *
+ * The failure is reachable, not theoretical: two different world positions can
+ * project to the SAME screen point whenever the movement is along the view ray
+ * — dragging in depth, or snapping to a nearer/farther surface under a cursor
+ * that has not moved a pixel. React then skips the re-render and the readout
+ * keeps showing the previous dX/dY/dZ.
+ *
+ * A render test cannot catch this: the component renders correctly whenever it
+ * renders at all. The bug is that it is not asked to.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { measurementOverlaysPropsEqual, type MeasurementOverlaysProps } from './MeasurementVisuals.js';
+
+type Props = MeasurementOverlaysProps;
+
+/** A measurement point: same screen position unless overridden. */
+function pt(x: number, y: number, z: number, screenX = 100, screenY = 200) {
+  return { x, y, z, screenX, screenY };
+}
+
+function props(over: Partial<Props> = {}): Props {
+  return {
+    measurements: [],
+    pending: null,
+    activeMeasurement: null,
+    snapTarget: null,
+    snapVisualization: null,
+    hoverPosition: null,
+    projectToScreen: undefined,
+    constraintEdge: null,
+    ...over,
+  } as Props;
+}
+
+function completed(start: ReturnType<typeof pt>, end: ReturnType<typeof pt>) {
+  return props({
+    measurements: [{ id: 'm1', start, end, distance: 1 }] as unknown as Props['measurements'],
+  });
+}
+
+describe('measurementOverlaysPropsEqual', () => {
+  it('re-renders when a completed measurement moves in world space at the SAME screen position', () => {
+    const a = completed(pt(0, 0, 0), pt(1, 0, 0));
+    // Identical screen coords, different world Z — the depth-drag case.
+    const b = completed(pt(0, 0, 0), pt(1, 0, 5));
+
+    assert.equal(
+      measurementOverlaysPropsEqual(a, b),
+      false,
+      'a world-only change must invalidate the memo, or the axis readout goes stale',
+    );
+  });
+
+  // PER-AXIS, deliberately. A single case that moves one axis lets a mutation
+  // neutering a DIFFERENT axis's comparison survive — the comparator is six
+  // independent clauses for the active measurement, so each needs its own case
+  // or the suite pins presence rather than correctness.
+  for (const [axis, moved] of [
+    ['x', pt(9, 0, 0)],
+    ['y', pt(0, 9, 0)],
+    ['z', pt(0, 0, 9)],
+  ] as const) {
+    it(`re-renders when the ACTIVE measurement's current.${axis} moves at the same screen position`, () => {
+      const base = { start: pt(0, 0, 0), current: pt(0, 0, 0), distance: 1 };
+      const a = props({ activeMeasurement: base as Props['activeMeasurement'] });
+      const b = props({ activeMeasurement: { ...base, current: moved } as Props['activeMeasurement'] });
+
+      assert.equal(measurementOverlaysPropsEqual(a, b), false);
+    });
+
+    it(`re-renders when the ACTIVE measurement's start.${axis} moves at the same screen position`, () => {
+      const base = { start: pt(0, 0, 0), current: pt(1, 1, 1), distance: 1 };
+      const a = props({ activeMeasurement: base as Props['activeMeasurement'] });
+      const b = props({ activeMeasurement: { ...base, start: moved } as Props['activeMeasurement'] });
+
+      assert.equal(measurementOverlaysPropsEqual(a, b), false);
+    });
+  }
+
+  for (const [axis, moved] of [
+    ['x', pt(9, 0, 0)],
+    ['y', pt(0, 9, 0)],
+    ['z', pt(0, 0, 9)],
+  ] as const) {
+    it(`re-renders when a completed measurement's end.${axis} moves at the same screen position`, () => {
+      const a = completed(pt(0, 0, 0), pt(0, 0, 0));
+      const b = completed(pt(0, 0, 0), moved);
+
+      assert.equal(measurementOverlaysPropsEqual(a, b), false);
+    });
+
+    it(`re-renders when a completed measurement's start.${axis} moves at the same screen position`, () => {
+      const a = completed(pt(0, 0, 0), pt(1, 1, 1));
+      const b = completed(moved, pt(1, 1, 1));
+
+      assert.equal(measurementOverlaysPropsEqual(a, b), false);
+    });
+  }
+
+  it('still skips the re-render when nothing changed at all', () => {
+    // The negative control: if this returns false, the comparator has stopped
+    // discriminating and is just forcing every render, which would make the
+    // three assertions above pass for the wrong reason.
+    const a = completed(pt(0, 0, 0), pt(1, 2, 3));
+    const b = completed(pt(0, 0, 0), pt(1, 2, 3));
+
+    assert.equal(measurementOverlaysPropsEqual(a, b), true);
+  });
+
+  it('still re-renders on a screen-only change, as it always did', () => {
+    const a = completed(pt(0, 0, 0), pt(1, 2, 3));
+    const b = completed(pt(0, 0, 0), pt(1, 2, 3, 999, 999));
+
+    assert.equal(measurementOverlaysPropsEqual(a, b), false);
+  });
+});


### PR DESCRIPTION
First slice of #2199 (xyzbety's request to expand the measurement tools). **Display only** — no change to the `Measurement` data shape, no new modes, no interaction changes.

Today the 3D measure tool reports a single scalar. This adds the component breakdown people actually want for setting-out work: dX / dY / dZ, plus horizontal and vertical.

## The one real risk, and how it's pinned

The viewer is **Y-up** (`packages/renderer/src/camera.ts:28-33`, *"converted from IFC Z-up to WebGL Y-up during import"*), so `vertical = |dy|` and `horizontal = hypot(dx, dz)`. Getting that convention backwards is the entire failure mode of this slice, and it would look plausible on screen.

The canonical test uses a **(3, 12, 4)** displacement, which gives horizontal **5.0** and vertical **12.0** — two values that cannot be confused with each other or with the 13.0 total. Swapping the formulas kills 5 of 9 tests.

Existing code independently agrees on the convention: `measureHandlers.ts:224` labels world Y *"(vertical)"*, and `lib/geo/pick-to-geo.ts` derives height from `d.y`.

## Verification

Reviewed independently before this PR was opened, with every mutation re-run by the reviewer rather than taken on trust:

- swap horizontal/vertical → **5 of 9 tests die**
- plus the reviewer's own checks on the surrounding mechanism

They also verified two things the brief didn't ask for: that measurement points carry **fresh world coordinates** on every drag (`measurementSlice.ts:134-149` replaces the point wholesale, and the screen-only update path correctly leaves x/y/z alone on camera moves), so the live H/V readout can't drift from the displayed distance; and that the prop widening in `MeasurementVisuals.tsx` is safe because `MeasurePanel.tsx:371` is its only caller.

## Scope discipline

New logic lives in a new file, `tools/measure-modes/components.ts` — `MeasurementVisuals.tsx` (658 lines) and `useMouseControls.ts` (876) are already over the ~400-line house budget and were deliberately not grown.

`apps/viewer` is private, so no changeset.

Slices 2–5 (measurement modes, angle, area, volume) are **not** in this PR. Slice 2 is the architecture-proving one and deserves its own block of work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Measurement labels now show signed X, Y, and Z differences.
  * Added horizontal and vertical distance breakdowns for completed and in-progress measurements.
  * Distance values are formatted consistently with unit-aware and signed readouts.

* **Tests**
  * Added coverage for measurement calculations, formatting, offsets, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->