### PR TITLE
fix(export): apply overlay deletions to the parquet geometry tables

### DIFF
--- a/.changeset/parquet-geometry-overlay-deletion.md
+++ b/.changeset/parquet-geometry-overlay-deletion.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/export": patch
+---
+
+Fix `ParquetExporter` emitting geometry for an overlay-deleted entity into the `.bos` archive. When a `MutablePropertyView` is supplied, `Entities`, `Properties`, `Quantities`, `Relationships` and `SpatialHierarchy` already dropped a tombstoned entity's rows, but `VertexBuffer.parquet`, `IndexBuffer.parquet` and `Meshes.parquet` never checked the overlay at all — a deleted entity's mesh still exported, so `Meshes.ExpressId` (and the vertices/triangles it indexes) could name an entity `Entities.parquet` had no row for. The three geometry writers now apply the same `isDeleted` filter as the other tables.

--- a/packages/export/src/parquet-exporter.test.ts
+++ b/packages/export/src/parquet-exporter.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect } from 'vitest';
 import { ParquetExporter } from './parquet-exporter.js';
 import type { IfcDataStore } from '@ifc-lite/parser';
+import type { GeometryResult, MeshData } from '@ifc-lite/geometry';
 import { MutablePropertyView as LiveMutablePropertyView } from '@ifc-lite/mutations';
 import {
   StringTable,
@@ -14,6 +15,7 @@ import {
   QuantityTableBuilder,
   PropertyValueType,
   RelationshipType,
+  QuantityType,
 } from '@ifc-lite/data';
 import { tableFromIPC } from 'apache-arrow';
 import { readParquet } from 'parquet-wasm';
@@ -153,5 +155,195 @@ describe('ParquetExporter overlay deletions (#2046)', () => {
     const names = rows.map((r) => r.Name);
     expect(names).toContain('Wall1');
     expect(names).toContain('Wall2 (deleted)');
+  });
+
+  it('omits quantities belonging to an overlay-deleted entity from Quantities.parquet', async () => {
+    // writeQuantities computes its own `keep` from `effective.isDeleted`, same
+    // shape as writeProperties above, but nothing previously exercised it —
+    // an entity-level filter with zero coverage on this table specifically.
+    const dataStore = buildDataStore();
+    const quantityBuilder = new QuantityTableBuilder(dataStore.strings);
+    quantityBuilder.add({
+      entityId: 1,
+      qsetName: 'Qto_WallBaseQuantities',
+      quantityName: 'NetSideArea',
+      quantityType: QuantityType.Area,
+      value: 10,
+      formula: '',
+    });
+    quantityBuilder.add({
+      entityId: 2,
+      qsetName: 'Qto_WallBaseQuantities',
+      quantityName: 'NetSideArea',
+      quantityType: QuantityType.Area,
+      value: 20,
+      formula: '',
+    });
+    dataStore.quantities = quantityBuilder.build();
+
+    const view = new LiveMutablePropertyView(null, 'm1');
+    view.deleteEntity(2);
+
+    const exporter = new ParquetExporter(dataStore, undefined, view);
+    const rows = decodeParquet(await exporter.exportTable('quantities'));
+
+    const entityIds = rows.map((r) => r.EntityId);
+    expect(entityIds).toContain(1);
+    expect(entityIds).not.toContain(2);
+  });
+});
+
+function mesh(partial: Partial<MeshData> & { expressId: number }): MeshData {
+  return {
+    positions: new Float32Array(),
+    normals: new Float32Array(),
+    indices: new Uint32Array(),
+    color: [1, 1, 1, 1],
+    ...partial,
+  } as MeshData;
+}
+
+function geometry(meshes: MeshData[]): GeometryResult {
+  const totalVertices = meshes.reduce((n, m) => n + m.positions.length / 3, 0);
+  const totalTriangles = meshes.reduce((n, m) => n + m.indices.length / 3, 0);
+  return {
+    meshes,
+    totalVertices,
+    totalTriangles,
+    coordinateInfo: {
+      originShift: [0, 0, 0],
+      originalBounds: { min: [0, 0, 0], max: [0, 0, 0] },
+      shiftedBounds: { min: [0, 0, 0], max: [0, 0, 0] },
+      hasLargeCoordinates: false,
+    },
+  } as unknown as GeometryResult;
+}
+
+describe('ParquetExporter overlay deletions reach the geometry tables', () => {
+  // writeVertexBuffer/writeIndexBuffer/writeMeshes never called getEffective()
+  // at all: Entities/Properties/Quantities/Relationships/SpatialHierarchy all
+  // drop a tombstoned entity's rows, but VertexBuffer.parquet, IndexBuffer.parquet
+  // and Meshes.parquet kept emitting its geometry unfiltered. The resulting
+  // .bos archive is internally inconsistent — Meshes.ExpressId (and the
+  // vertices/indices it points into) names an entity Entities.parquet no
+  // longer has a row for.
+  function buildStoreAndGeometry() {
+    const dataStore = buildDataStore();
+    const meshes: MeshData[] = [
+      mesh({
+        expressId: 1,
+        positions: new Float32Array([0, 0, 0, 1, 0, 0, 1, 1, 0]),
+        normals: new Float32Array(9),
+        indices: new Uint32Array([0, 1, 2]),
+      }),
+      mesh({
+        expressId: 2,
+        positions: new Float32Array([5, 5, 5, 6, 5, 5, 6, 6, 5]),
+        normals: new Float32Array(9),
+        indices: new Uint32Array([0, 1, 2]),
+      }),
+    ];
+    return { dataStore, geo: geometry(meshes) };
+  }
+
+  it('omits a deleted entity from Meshes.parquet', async () => {
+    const { dataStore, geo } = buildStoreAndGeometry();
+    const view = new LiveMutablePropertyView(null, 'm1');
+    view.deleteEntity(2);
+
+    const exporter = new ParquetExporter(dataStore, geo, view);
+    const entityIds = decodeParquet(await exporter.exportTable('entities')).map((r) => r.ExpressId);
+    const meshIds = decodeParquet(await exporter.exportTable('meshes')).map((r) => r.ExpressId);
+
+    expect(entityIds).toEqual([1]);
+    // Every id Meshes.parquet names must have a row in Entities.parquet.
+    expect(meshIds.every((id) => entityIds.includes(id))).toBe(true);
+  });
+
+  it('drops the deleted entity\'s vertices from VertexBuffer.parquet', async () => {
+    const { dataStore, geo } = buildStoreAndGeometry();
+    const view = new LiveMutablePropertyView(null, 'm1');
+    view.deleteEntity(2);
+
+    const exporter = new ParquetExporter(dataStore, geo, view);
+    const vertexRows = decodeParquet(await exporter.exportTable('vertices'));
+
+    // Mesh 2's vertices are all at X=5/6 — surviving mesh 1 only touches X=0/1.
+    expect(vertexRows.some((r) => Number(r.X) >= 5)).toBe(false);
+    expect(vertexRows).toHaveLength(3);
+  });
+
+  it('drops the deleted entity\'s triangles from IndexBuffer.parquet', async () => {
+    const { dataStore, geo } = buildStoreAndGeometry();
+    const view = new LiveMutablePropertyView(null, 'm1');
+    view.deleteEntity(2);
+
+    const exporter = new ParquetExporter(dataStore, geo, view);
+    const indexRows = decodeParquet(await exporter.exportTable('indices'));
+
+    expect(indexRows).toHaveLength(1);
+  });
+
+  it('still exports all geometry when no mutation view is supplied (back-compat)', async () => {
+    const { dataStore, geo } = buildStoreAndGeometry();
+    const exporter = new ParquetExporter(dataStore, geo);
+
+    const meshIds = decodeParquet(await exporter.exportTable('meshes')).map((r) => r.ExpressId);
+    expect(meshIds).toEqual([1, 2]);
+  });
+
+  /**
+   * Deleting the LAST mesh cannot expose a misaligned offset — nothing
+   * follows it. The regression this fix is exposed to is a mesh dropped in
+   * the MIDDLE: `writeMeshes` reports the `VertexStart`/`IndexStart` that
+   * `writeVertexBuffer`/`writeIndexBuffer` accumulate, so if the three
+   * loops ever stop skipping the same set, every later mesh points at
+   * another mesh's vertices. That reads as geometry silently attached to
+   * the wrong element, which no count would reveal.
+   *
+   * Three meshes, delete the middle one, and assert the survivor's start
+   * offsets closed the gap rather than preserving it.
+   */
+  it('keeps VertexStart/IndexStart aligned when a MIDDLE mesh is deleted', async () => {
+    const dataStore = buildDataStore();
+    const meshes: MeshData[] = [
+      mesh({
+        expressId: 1,
+        positions: new Float32Array([0, 0, 0, 1, 0, 0, 1, 1, 0]),
+        normals: new Float32Array(9),
+        indices: new Uint32Array([0, 1, 2]),
+      }),
+      mesh({
+        expressId: 2,
+        positions: new Float32Array([5, 5, 5, 6, 5, 5, 6, 6, 5]),
+        normals: new Float32Array(9),
+        indices: new Uint32Array([0, 1, 2]),
+      }),
+      mesh({
+        expressId: 3,
+        positions: new Float32Array([9, 9, 9, 8, 9, 9, 8, 8, 9]),
+        normals: new Float32Array(9),
+        indices: new Uint32Array([0, 1, 2]),
+      }),
+    ];
+    const geo = geometry(meshes);
+    const view = new LiveMutablePropertyView(null, 'm1');
+    view.deleteEntity(2);
+
+    const exporter = new ParquetExporter(dataStore, geo, view);
+    const meshRows = decodeParquet(await exporter.exportTable('meshes'));
+    const vertexRows = decodeParquet(await exporter.exportTable('vertices'));
+
+    expect(meshRows.map((r) => r.ExpressId)).toEqual([1, 3]);
+    // Mesh 3 must start immediately after mesh 1's three vertices — NOT at 6,
+    // which is where it would sit if the deleted mesh's span were still
+    // counted.
+    expect(Number(meshRows[1].VertexStart)).toBe(3);
+    expect(Number(meshRows[1].IndexStart)).toBe(3);
+    expect(vertexRows).toHaveLength(6);
+    // And the offset must actually land on mesh 3's own data (X = 9), not
+    // mesh 2's (X = 5) — an aligned-looking number pointing at the wrong
+    // vertices is the failure this guards.
+    expect(Number(vertexRows[Number(meshRows[1].VertexStart)].X)).toBe(9);
   });
 });

--- a/packages/export/src/parquet-exporter.ts
+++ b/packages/export/src/parquet-exporter.ts
@@ -32,12 +32,16 @@ export class ParquetExporter {
      *
      * When supplied, entities the overlay tombstoned via
      * `MutablePropertyView.deleteEntity()` — and every row that references
-     * one — are dropped from `Entities`, `Properties`, `Quantities` and
-     * `Relationships` (#2046). Unlike `StepExporter`/`Ifc5Exporter`, this is
-     * deletion-only: unlike those two, the writers below column-copy typed
-     * arrays out of the store in one shot rather than looping per entity, so
-     * they cannot also apply the overlay's pset/quantity/attribute edits the
-     * way a per-entity emission pass can. That is a known, separate gap.
+     * one — are dropped from `Entities`, `Properties`, `Quantities`,
+     * `Relationships`, `SpatialHierarchy` and the geometry tables
+     * (`VertexBuffer`, `IndexBuffer`, `Meshes`) (#2046; geometry tables
+     * joined the set after they were found still emitting a deleted
+     * entity's mesh into an otherwise-filtered archive). Unlike
+     * `StepExporter`/`Ifc5Exporter`, this is deletion-only: unlike those
+     * two, the writers below column-copy typed arrays out of the store in
+     * one shot rather than looping per entity, so they cannot also apply
+     * the overlay's pset/quantity/attribute edits the way a per-entity
+     * emission pass can. That is a known, separate gap.
      */
     constructor(store: IfcDataStore, geometryResult?: GeometryResult, mutationView?: MutablePropertyView) {
         this.store = store;
@@ -235,11 +239,19 @@ export class ParquetExporter {
             throw new Error('Geometry result not available');
         }
 
+        const effective = this.getEffective();
+
         // Collect all positions and normals from meshes
         const allPositions: number[] = [];
         const allNormals: number[] = [];
 
         for (const mesh of this.geometryResult.meshes) {
+            // Same predicate as writeEntities/writeMeshes: a tombstoned
+            // entity's geometry is not a row in Entities.parquet either, so
+            // leaving its vertices here would let VertexBuffer.parquet name
+            // (via Meshes.VertexStart/VertexCount) an entity no other table
+            // has.
+            if (effective?.isDeleted(mesh.expressId)) continue;
             // Positions are in the element's local frame (world = origin + position).
             // The BOS columnar layout has no transform column, so bake the per-mesh
             // origin into the world vertices. Normals are origin-invariant. No-op
@@ -290,9 +302,12 @@ export class ParquetExporter {
             throw new Error('Geometry result not available');
         }
 
+        const effective = this.getEffective();
+
         // Collect all indices from meshes
         const allIndices: number[] = [];
         for (const mesh of this.geometryResult.meshes) {
+            if (effective?.isDeleted(mesh.expressId)) continue;
             allIndices.push(...Array.from(mesh.indices));
         }
 
@@ -317,6 +332,7 @@ export class ParquetExporter {
         }
 
         const meshes = this.geometryResult.meshes;
+        const effective = this.getEffective();
         const expressIds: number[] = [];
         const vertexStarts: number[] = [];
         const vertexCounts: number[] = [];
@@ -327,6 +343,11 @@ export class ParquetExporter {
         let indexOffset = 0;
 
         for (const mesh of meshes) {
+            // Must match writeVertexBuffer/writeIndexBuffer's skip exactly —
+            // those two accumulate the offsets this loop reports, so a mesh
+            // dropped there but kept here (or vice versa) would misalign
+            // every subsequent VertexStart/IndexStart.
+            if (effective?.isDeleted(mesh.expressId)) continue;
             expressIds.push(mesh.expressId);
             vertexStarts.push(vertexOffset);
             vertexCounts.push(mesh.positions.length / 3);


### PR DESCRIPTION
A deleted entity's geometry still exports into the `.bos` archive.

`writeEntities`, `writeProperties`, `writeQuantities`, `writeRelationships` and `writeSpatialHierarchy` all consult the overlay. `writeVertexBuffer`, `writeIndexBuffer` and `writeMeshes` never called `getEffective()` **at all**.

Observed before the fix — 2 entities, 2 meshes, entity 2 deleted via `MutablePropertyView`, then exported:

```
Entities.parquet ExpressIds: [1]
Meshes.parquet   ExpressIds: [1, 2]
Orphaned mesh ExpressIds:    [2]
```

The archive is internally inconsistent: `Meshes.ExpressId` — and the vertices and triangles it indexes — names an entity `Entities.parquet` has no row for. Any geometry-derived total disagrees with the entity table after an edit-then-export.

**Severity: LIVE.**

## The fix, and the part that actually needed testing

The three writers now apply the same `isDeleted` predicate, with the skip placed **before** the offset bookkeeping so `VertexStart`/`IndexStart` still describe the buffers actually written.

That alignment is the fragile part, and the tests as first written could not see it — they delete the **last** mesh, and nothing follows a last mesh to be misaligned.

So I added a three-mesh case that deletes the **middle** one and asserts two things:

- the survivor's `VertexStart` closed the gap (**3**, not 6), and
- the offset lands on its **own** data (`X = 9`, not the deleted mesh's `X = 5`).

The second assertion is the point. An aligned-*looking* number pointing at the wrong vertices is the real failure mode here, and no row count would reveal it — it reads as geometry silently attached to the wrong element.

## That test earns its place — demonstrated, not asserted

Mutating the skip to advance the offsets before continuing — the shape of a plausible "preserve the bookkeeping across the skip" refactor — fails **only** the middle-deletion test:

```
× keeps VertexStart/IndexStart aligned when a MIDDLE mesh is deleted
  Tests  1 failed | 10 passed (11)
```

All ten others pass, including both existing deletion tests. The shipped result would be mesh 3's row silently naming mesh 2's vertices.

## Also closed

`writeQuantities`'s overlay filter had zero coverage. Now pinned — it was already correct, so that one is a coverage gap, not a bug.

## Controls

Each applied singly with an asserted replacement count and restored by file copy:

| mutation | result |
|---|---|
| Y/Z swap in `writeVertexBuffer` | died — 3 failures |
| `Index1`/`Index2` swap | died |
| `VertexCount`/`IndexCount` swap in `writeMeshes` | died |
| remove the new `writeMeshes` skip | died — exactly the new test |

## Counts

**456 passing / 29 skipped, 0 failing.**

Worth flagging: `src/lod1-generator.test.ts` fails to **load** — not fail — unless `@ifc-lite/wasm` is built first (`Failed to resolve entry for package "@ifc-lite/wasm"`). That is the partial-build trap, environmental and unrelated to this change. I built wasm to clear it rather than waive it, which is how the 0-failing figure above was obtained.

`tsc --noEmit` clean. Patch changeset included.
