### PR TITLE
fix(viewer-core): fold the per-element origin so `ifc-lite view` places elements correctly (#2261)

### DIFF
--- a/.changeset/viewer-fold-mesh-origin.md
+++ b/.changeset/viewer-fold-mesh-origin.md
@@ -1,0 +1,11 @@
+---
+"@ifc-lite/viewer-core": patch
+---
+
+Fix `ifc-lite view` rendering every element stacked at the scene origin.
+
+The wasm mesh contract hands back a per-element local frame: the world position of vertex `i` is `origin + positions[3i..3i+3]`. The standalone viewer blob buffered `positions` raw and never read `origin`, so each element was drawn around 0,0,0 with only its own local extents — a whole building collapsed into one overlapping pile. On the reporter's file all 119 meshes carry a non-zero origin (an `IfcColumn` at `(0.05, 12.20, -43.18)` with vertices within a metre of local zero), and the scene bounds came out 25.0 x 25.5 x 12.0 m instead of the model's real 29.9 x 27.4 x 46.4 m.
+
+`addMeshBatch` now folds the origin into the vertices once, up front, so rendering, camera fit, picking bounds, zoom/isolate, section planes and storey binning all read world space — they all consume what that one function stores. Both batch mappings (`loadModel` and the `addGeometry` command) forward `origin` through to it.
+
+Origins are already RTC-relative (`processGeometryBatch` subtracts the pre-pass `rtcOffset`), so folding into the f32 vertex buffer cannot reintroduce georeferencing jitter. The main web viewer at ifclite.dev already folded the origin, which is why it rendered the same files correctly.

--- a/packages/viewer/src/viewer-html.ts
+++ b/packages/viewer/src/viewer-html.ts
@@ -399,18 +399,39 @@ function computeEntityBounds(posArr, startVert, vertCount) {
   return { min: bMin, max: bMax };
 }
 
+// The wasm mesh contract is a per-element local frame: the world position of
+// vertex i is origin + positions[3i..3i+3]. Every world-space consumer has to
+// fold the origin in or the whole model collapses onto 0,0,0 (issue #2261).
+// Folding in place is safe: the MeshDataJs positions getter hands back a fresh
+// JS-owned Float32Array (see the comment in parseMeshesViaPrePass).
+function foldMeshOrigin(positions, origin) {
+  if (!origin) return positions;
+  const ox = origin[0] || 0, oy = origin[1] || 0, oz = origin[2] || 0;
+  if (ox === 0 && oy === 0 && oz === 0) return positions;
+  for (let i = 0; i < positions.length; i += 3) {
+    positions[i] += ox;
+    positions[i+1] += oy;
+    positions[i+2] += oz;
+  }
+  return positions;
+}
+
 function addMeshBatch(meshes) {
   const prevVerts = totalVertices;
   const prevIndices = totalIndices;
   for (const mesh of meshes) {
+    // World-space vertices, once, up front: rendering, camera fit, picking
+    // bounds, zoom/isolate, section planes and storey binning all read from
+    // what this function stores, so one fold here fixes every one of them.
+    const pos = foldMeshOrigin(mesh.positions, mesh.origin);
     const vStart = totalVertices;
-    const vCount = mesh.positions.length / 3;
+    const vCount = pos.length / 3;
     const iStart = totalIndices;
     const iCount = mesh.indices.length;
     const ifcType = mesh.ifcType || 'Unknown';
 
     // Entity bounds from this mesh
-    const meshBounds = computeEntityBounds(mesh.positions, 0, vCount);
+    const meshBounds = computeEntityBounds(pos, 0, vCount);
 
     // Track entity
     const existing = entityMap.get(mesh.expressId);
@@ -446,7 +467,7 @@ function addMeshBatch(meshes) {
 
     typeCounts.set(ifcType, (typeCounts.get(ifcType) || 0) + 1);
 
-    positions.push(mesh.positions);
+    positions.push(pos);
     normals.push(mesh.normals);
 
     // Offset indices
@@ -472,7 +493,7 @@ function addMeshBatch(meshes) {
     }
     pickColors.push(pc);
 
-    updateBounds(mesh.positions);
+    updateBounds(pos);
     totalVertices += vCount;
     totalIndices += iCount;
     totalTriangles += iCount / 3;
@@ -1120,6 +1141,7 @@ function handleCommand(cmd) {
             positions: m.positions,
             normals: m.normals,
             indices: m.indices,
+            origin: m.origin,
             color: [m.color[0], m.color[1], m.color[2], m.color[3] ?? 1],
           }));
           addMeshBatch(batch);
@@ -1391,6 +1413,7 @@ async function loadModel() {
             positions: m.positions,
             normals: m.normals,
             indices: m.indices,
+            origin: m.origin,
             color: [m.color[0], m.color[1], m.color[2], m.color[3] ?? 1],
           }));
           addMeshBatch(batch);

--- a/packages/viewer/test/viewer-html-runtime.test.ts
+++ b/packages/viewer/test/viewer-html-runtime.test.ts
@@ -1102,3 +1102,86 @@ describe('viewer blob — handleCommand: lifecycle and unknown actions', () => {
     assert.deepEqual(v.ctx.colorOverrides.get(100001), [0.2, 0.9, 0.4, 1]);
   });
 });
+
+// ── Per-element local-frame origin (issue #2261) ────────────────────────────
+
+/**
+ * The wasm mesh contract is a per-element local frame: the world position of
+ * vertex i is `origin + positions[3i..3i+3]`. The CLI viewer buffered
+ * `positions` raw and never read `origin`, so every element rendered at the
+ * scene origin. These tests pin both halves of the fix: the arithmetic, and
+ * the wiring that makes the arithmetic reachable — an `origin` the parser
+ * mapping never forwards is arithmetically irrelevant.
+ */
+describe('mesh origin folding', () => {
+  it('is browser-free', () => {
+    assertBrowserFree('foldMeshOrigin');
+  });
+
+  it('adds the origin to every vertex triple', () => {
+    const { foldMeshOrigin } = loadDecls(['foldMeshOrigin']);
+    const positions = new Float32Array([1, 2, 3, -1, 0, 0]);
+    const out = foldMeshOrigin(positions, new Float64Array([10, 5, -43]));
+    assert.deepEqual([...out], [11, 7, -40, 9, 5, -43]);
+    assert.equal(out, positions, 'the fold is in place, on the JS-owned copy');
+  });
+
+  it('leaves vertices untouched for an all-zero origin', () => {
+    const { foldMeshOrigin } = loadDecls(['foldMeshOrigin']);
+    const positions = new Float32Array([1, 2, 3, -1, 0, 0]);
+    foldMeshOrigin(positions, new Float64Array([0, 0, 0]));
+    assert.deepEqual([...positions], [1, 2, 3, -1, 0, 0]);
+  });
+
+  it('leaves vertices untouched when the mesh carries no origin', () => {
+    const { foldMeshOrigin } = loadDecls(['foldMeshOrigin']);
+    const positions = new Float32Array([1, 2, 3, -1, 0, 0]);
+    assert.deepEqual([...foldMeshOrigin(positions, undefined)], [1, 2, 3, -1, 0, 0]);
+    assert.deepEqual([...foldMeshOrigin(positions, null)], [1, 2, 3, -1, 0, 0]);
+  });
+
+  it('addMeshBatch folds before it buffers, bounds or measures', () => {
+    const src = extractDecl('addMeshBatch');
+    assert.match(src, /const pos = foldMeshOrigin\(mesh\.positions, mesh\.origin\);/);
+    // Everything downstream must read the folded copy: `mesh.positions` may
+    // appear exactly once, as the argument to the fold above.
+    const raw = src.match(/mesh\.positions/g) ?? [];
+    assert.equal(
+      raw.length,
+      1,
+      'addMeshBatch still reads the unfolded mesh.positions somewhere downstream',
+    );
+    assert.match(src, /computeEntityBounds\(pos, 0, vCount\)/);
+    assert.match(src, /positions\.push\(pos\)/);
+    assert.match(src, /updateBounds\(pos\)/);
+  });
+
+  it('the loadModel batch mapping forwards the origin to addMeshBatch', () => {
+    // loadModel is DOM/fetch-bound, so this is asserted on its shipped source
+    // text; extractDecl throws if the declaration is gone, so it cannot pass
+    // vacuously.
+    assert.match(extractDecl('loadModel'), /origin: m\.origin,/);
+  });
+
+  it('the addGeometry batch mapping forwards the origin to addMeshBatch', () => {
+    assert.match(extractDecl('handleCommand'), /origin: m\.origin,/);
+  });
+
+  it('addGeometry hands a real mesh origin through to addMeshBatch', () => {
+    const v = makeViewer();
+    v.ctx.wasmApi = {};
+    v.run({ action: 'addGeometry', ifcContent: 'a' });
+    v.parseCalls[0].opts.onBatch([
+      {
+        expressId: 1,
+        positions: new Float32Array([0, 0, 0]),
+        normals: new Float32Array(3),
+        indices: new Uint32Array([0]),
+        origin: new Float64Array([3, -4, 5]),
+        color: [1, 1, 1, 1],
+      },
+    ]);
+    const batch: any = v.addedBatches[0];
+    assert.deepEqual([...batch[0].origin], [3, -4, 5], 'the local frame must survive the mapping');
+  });
+});


### PR DESCRIPTION
Fixes #2261 (reported by @tibicen).

## The defect

`ifc-lite view` renders **every element at 0,0,0**. The standalone viewer blob never folds the per-element local-frame origin that the wasm mesh contract requires world-space consumers to apply (`world = origin + positions`).

Both batch mappings — `loadModel`'s `onBatch` and `addGeometry`'s `onBatch` — copied positions/normals/indices/color but **not** `m.origin`, and `addMeshBatch` buffered `mesh.positions` raw into the merged f32 buffer.

The main web viewer folds origin (`apps/viewer/src/utils/viewportUtils.ts:123`), which is exactly why ifclite.dev renders the reporter's file correctly and the CLI does not. Regressed in #874, when the standalone viewer moved onto the unified local-frame prepass path.

Measured end-to-end against the reporter's own `testsample.ifc`: **119 meshes / 93 entities, all 119 carrying non-zero origins.** Raw span 24.99 × 25.5 × 11.98 versus folded 29.9 × 27.35 × 46.35 — the model collapses onto itself without the fold.

## The fix

A `foldMeshOrigin(positions, origin)` helper applied in `addMeshBatch`, plus `origin: m.origin` forwarded through both batch mappings. One fold covers everything, because `addMeshBatch` is the single ingestion point: render buffer, camera fit, section planes (via boundsMin/Max), zoom/isolate/storey binning (via entityMap bounds) and GPU picking all derive from its output.

Precision is safe: origins are already RTC-relative, so folding into f32 cannot reintroduce georef jitter.

## Verification

Reviewed independently before this PR was opened, against three failure modes specific to this fix:

- **Partial fold** — would look right on screen while misplacing picking and section planes. Ruled out: single ingestion point, all consumers downstream of it.
- **In-place mutation safety** — verified against the Rust binding rather than the code comment: `rust/wasm-bindings/src/zero_copy/mesh.rs:82` returns `js_sys::Float32Array::from(...)`, a fresh JS-owned copy, never a view onto wasm memory.
- **Double-fold** — would silently double the offset. Ruled out: two call sites, each on fresh getter copies from a fresh parse; nothing re-batches.

**8 mutations, all killed** — the 5 canonical ones plus 3 the implementer did not try (bypass the fold at the call site, drop the z component, revert `computeEntityBounds`). Each applied with exactly 1 replacement asserted. Notably, dropping `origin` from the `addGeometry` mapping kills **both** the text-wiring assert and the behavioural test, so the wiring coverage is real rather than decorative.

Gates green uncached in a fresh worktree: build 43/43, `turbo test --force` 86/86, `turbo typecheck --force` 36/36.

## Release note

Carries a patch changeset for `@ifc-lite/viewer-core`. **That matters here**: the reporter installs from npm, so without a release the fix never reaches them — the CLI picks it up via `workspace:^` on the next `@ifc-lite/cli` publish.