### PR TITLE
test(server): isolate the .ifcZIP declared-size guard from its backstop

### DIFF
--- a/apps/server/src/routes/parse/ifczip_tests.rs
+++ b/apps/server/src/routes/parse/ifczip_tests.rs
@@ -73,6 +73,62 @@ fn rejects_an_entry_over_the_size_ceiling() {
     assert!(matches!(err, ApiError::FileTooLarge { max_mb: 1 }));
 }
 
+/// Patch the 4-byte little-endian "uncompressed size" field in both the
+/// local file header (offset 22 from `PK\x03\x04`) and the central directory
+/// record (offset 24 from `PK\x01\x02`) of a single-entry Stored archive, so
+/// the archive's DECLARED size disagrees with the ACTUAL bytes on disk. Real
+/// callers do not need this — it exists to isolate the two independent
+/// guards in `unwrap_ifczip`: the up-front reject on `entry.size()` (the
+/// declared, central-directory value, checked before any decompression) and
+/// the belt-and-braces reject on the actual decompressed byte count.
+fn lie_about_uncompressed_size(mut zip: Vec<u8>, declared_size: u32) -> Vec<u8> {
+    let local_sig = [0x50, 0x4b, 0x03, 0x04];
+    let central_sig = [0x50, 0x4b, 0x01, 0x02];
+    let local_pos = zip
+        .windows(4)
+        .position(|w| w == local_sig)
+        .expect("local file header signature");
+    let central_pos = zip
+        .windows(4)
+        .position(|w| w == central_sig)
+        .expect("central directory signature");
+    zip[local_pos + 22..local_pos + 26].copy_from_slice(&declared_size.to_le_bytes());
+    zip[central_pos + 24..central_pos + 28].copy_from_slice(&declared_size.to_le_bytes());
+    zip
+}
+
+/// The declared-size guard (`entry.size() > max_bytes`, before decompressing)
+/// and the belt-and-braces post-decompression guard are two INDEPENDENT
+/// checks — `rejects_an_entry_over_the_size_ceiling` above cannot tell them
+/// apart because a well-formed archive's declared and actual sizes always
+/// agree, so either guard alone rejects it. This isolates the declared-size
+/// guard: the header LIES that the entry is huge while the actual Stored
+/// bytes are tiny, so only the declared-size check can catch it — the
+/// post-decompression guard sees a small `model.len()` and would admit it.
+///
+/// Coverage gap found via mutation testing: disabling the `entry.size() >
+/// max_bytes` check (replacing its condition with `false`) left the entire
+/// `ifczip_tests` module green (7/7 passed) because every other test's
+/// declared and actual sizes coincide.
+#[test]
+fn declared_size_guard_fires_even_when_actual_bytes_are_small() {
+    let content = "tiny"; // 4 actual bytes
+    let zip = make_zip(&[("model.ifc", content)]);
+    let lying_zip = lie_about_uncompressed_size(zip, 5_000_000);
+
+    // Sanity: the lie took — an ordinary archive of this content is nowhere
+    // near the ceiling used below, so a pass here would mean the guard never
+    // engaged at all rather than the lie failing to apply.
+    let honest_zip = make_zip(&[("model.ifc", content)]);
+    unwrap_ifczip(&honest_zip, 1_000, 1).expect("an honest 4-byte entry is admitted");
+
+    let err = unwrap_ifczip(&lying_zip, 1_000, 1).unwrap_err();
+    assert!(
+        matches!(err, ApiError::FileTooLarge { max_mb: 1 }),
+        "the declared (lying) size must be rejected before decompression, got {err:?}"
+    );
+}
+
 #[test]
 fn extracts_a_deflate_compressed_model_entry() {
     // Real buildingSMART .ifcZIP containers are DEFLATE-compressed, not


### PR DESCRIPTION
`unwrap_ifczip` rejects an entry on the uncompressed size declared in the central directory **before decompressing anything**, then bounds the actual read as belt-and-braces. Replacing the declared-size condition with `false` left the whole ifczip module green at **7/7**.

## Why it looked covered

Every existing fixture's declared size and actual size agree, so the post-decompression check catches the oversize case either way.

That includes the test named **`rejects_an_entry_over_the_size_ceiling`** — it passes whether or not the guard it is named for exists, because the backstop fires first. A test named for a guard it never reaches is worse than no test: it stops anyone from looking.

This is the same shape found in `collab-server` earlier this week, where a "named reviewers" test was actually satisfied by an unrelated self-approval check.

## The only fixture that separates the two guards

The new test patches the local-header and central-directory *uncompressed size* fields to claim 5,000,000 bytes while the entry actually holds 4 — by **byte-offset patch**, not through the `zip` API, which will not emit a header that disagrees with its own payload.

That asymmetry is the point: the backstop measures **actual** bytes and correctly does not fire, so with the declared-size check removed the request is admitted.

## Severity: coverage gap, not a live bug

The shipped guard is present and correct. Worth being precise about what it buys, since the obvious reading overstates it:

- it rejects a **lying header before any decompression begins**;
- the actual-byte bound behind it means removing it does **not** widen the size limit for a well-formed archive.

That second point is exactly why no existing test could see it go, and why this is a coverage gap rather than a vulnerability.

## Verification

- guard disabled + **old** tests → **7/7 pass** (the gap was real)
- guard disabled + **new** test → fails
- restored → **194 passing / 0 failing** for the crate (was 193)

Mutation applied by exact-substring replacement with an asserted replacement count of 1, mutated line re-read, restored by file copy. Re-run by hand before pushing.

Clippy clean, and clean on the same measurement with the test file reverted — `Checking ifc-lite-server` present in both runs, so neither was a cached no-op.

## The rest of the surface came back clean

Reported plainly rather than padded — these were checked and found genuinely covered:

- `middleware/auth.rs` bearer-token gate: missing header, wrong token, length mismatch, wrong scheme and wrong status are all driven by `auth_tests.rs`.
- `admission.rs` CPU/mem/RSS breakers: queue-full, mem-budget timeout, RSS shed, the exact `>=` boundary, per-reason counters and `Retry-After` doubling all covered.
- `error.rs` `ApiError → HTTP` mapping: exhaustive table test plus an independent sweep; every variant's status, code and `Retry-After` pinned.
- gzip-bomb and zero-ceiling paths in `extract_file` — the zero-ceiling fix is already in open PR #2233, so it was skipped rather than redone.

Test-only, and `apps/server` is not a published package, so no changeset.
