### PR TITLE
test(processing): pin the instancing orphan-recovery fallback

### DIFF
--- a/rust/processing/tests/instancing_orphan_recovery.rs
+++ b/rust/processing/tests/instancing_orphan_recovery.rs
@@ -46,7 +46,7 @@ fn fixture_with_template_owner_as_window() -> Vec<u8> {
     );
     let content = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"));
     let old = "#31=IFCBUILDINGELEMENTPROXY('7777777777777777777771',$,'Proxy_0',$,$,#30,#27,$,$);";
-    let new = "#31=IFCWINDOW('7777777777777777777771',$,'Proxy_0',$,$,#30,#27,$,$);";
+    let new = "#31=IFCWINDOW('7777777777777777777771',$,'Proxy_0',$,$,#30,#27,$,$,$,$,$,$);";
     let n = content.matches(old).count();
     assert_eq!(n, 1, "fixture layout changed — Proxy_0 line not found exactly once");
     content.replace(old, new).into_bytes()
@@ -145,13 +145,54 @@ fn instancing_recovers_orphaned_occurrences_when_the_template_job_is_skipped() {
         .iter()
         .find(|m| m.express_id == 38 && m.geometry_class == 0)
         .expect("recovered Proxy_1 (#38) must have a mesh in the instanced pass");
-    assert_eq!(
-        recovered_one.positions.len(),
-        flat_one.positions.len(),
-        "recovered occurrence must carry real geometry, not an empty/degenerate mesh"
+    assert!(
+        !recovered_one.positions.is_empty(),
+        "recovered occurrence must carry real geometry, not an empty mesh"
     );
     assert!(
-        !recovered_one.indices.is_empty(),
-        "recovered occurrence must carry real triangles"
+        recovered_one.indices.len() >= 3,
+        "recovered occurrence must carry at least one real triangle"
     );
+
+    // Bounding-box comparison, not element-wise vertex comparison: the shared
+    // source registry backing `bake_source_at_world` is pre-weld/unwelded
+    // (see `bake_source_at_world`'s doc, geometry/src/instancing/collate.rs),
+    // so `recovered_one`'s vertex count/order need not match `flat_one`'s
+    // welded mesh even when the world transform is correct. What must match
+    // is the WORLD-SPACE extent: if the orphan recovery path baked at
+    // identity instead of `occ.world_transform`, the recovered box would be
+    // displaced from the flat box (Proxy_1/#38's placement is a non-identity
+    // translation), and this comparison would catch it.
+    fn bbox(positions: &[f32]) -> ([f32; 3], [f32; 3]) {
+        let mut min = [f32::INFINITY; 3];
+        let mut max = [f32::NEG_INFINITY; 3];
+        for chunk in positions.chunks_exact(3) {
+            for axis in 0..3 {
+                min[axis] = min[axis].min(chunk[axis]);
+                max[axis] = max[axis].max(chunk[axis]);
+            }
+        }
+        (min, max)
+    }
+    let (flat_min, flat_max) = bbox(&flat_one.positions);
+    let (recovered_min, recovered_max) = bbox(&recovered_one.positions);
+    const EPS: f32 = 1e-4;
+    for axis in 0..3 {
+        assert!(
+            (flat_min[axis] - recovered_min[axis]).abs() < EPS,
+            "recovered occurrence's world-space bbox min on axis {axis} must match the flat \
+             baseline's (flat={:?}, recovered={:?}) -- orphan recovery must bake at \
+             occ.world_transform, not identity",
+            flat_min,
+            recovered_min
+        );
+        assert!(
+            (flat_max[axis] - recovered_max[axis]).abs() < EPS,
+            "recovered occurrence's world-space bbox max on axis {axis} must match the flat \
+             baseline's (flat={:?}, recovered={:?}) -- orphan recovery must bake at \
+             occ.world_transform, not identity",
+            flat_max,
+            recovered_max
+        );
+    }
 }

--- a/rust/processing/tests/instancing_orphan_recovery.rs
+++ b/rust/processing/tests/instancing_orphan_recovery.rs
@@ -1,0 +1,157 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! #1623 Phase 2 don't-bake: proves the orphan-recovery fallback in
+//! `processor/instancing.rs::recover_orphan_occurrences` actually fires and
+//! recovers geometry when the plan's designated TEMPLATE occurrence (the
+//! min-id `IfcMappedItem` for a repeated source) never materializes.
+//!
+//! `finalize_instances`'s doc comment calls this path "effectively
+//! unreachable for the eligible single-solid type-instanced set (their
+//! template occurrence always materializes)". That claim does not hold once
+//! the opening filter (`OpeningFilterMode::IgnoreAll`) is combined with
+//! instancing: `mapped_item_plan`'s template selection (`processor/mod.rs`,
+//! scanning every `IFCMAPPEDITEM` up front) is computed WITHOUT knowledge of
+//! which owning product jobs the filter will later skip
+//! (`apply_opening_filter` / `skipped_entity_ids`, consulted only in
+//! `jobs::process_entity_job`). If the plan's chosen template id belongs to
+//! an `IfcWindow`/`IfcDoor` job the filter skips, that job's `EntityDecoder`
+//! path returns before the router ever sees mapped item — so
+//! `is_template` (`geometry/src/router/processing.rs`) is `item.id ==
+//! template_item_id` for every SURVIVING occurrence too, and none of them
+//! is ever `true`. Every occurrence of that source becomes a don't-bake
+//! placeholder, `template_by_rep.get(&rep)` finds no non-empty template mesh,
+//! and the whole group must fall to `recover_orphan_occurrences` or its
+//! geometry is silently dropped.
+//!
+//! Before this test, NO test in the suite exercised
+//! `recover_orphan_occurrences`: deleting its body (returning before the
+//! bake loop, so every orphan occurrence is silently dropped) left all other
+//! processing tests green.
+
+use ifc_lite_processing::{OpeningFilterMode, ProcessingResult, StreamingOptions};
+
+/// The synthetic mapped-instances fixture (one `IfcRepresentationMap`
+/// instanced by 64 `IfcBuildingElementProxy` occurrences at distinct
+/// placements), with occurrence `Proxy_0` — express id #31, whose
+/// `IfcMappedItem` #25 is the plan's min-id template — retyped to
+/// `IfcWindow`. `OpeningFilterMode::IgnoreAll` unconditionally skips every
+/// window/door job regardless of transparency, so #31's job never reaches
+/// the router.
+fn fixture_with_template_owner_as_window() -> Vec<u8> {
+    let path = format!(
+        "{}/../geometry/tests/fixtures/mapped_instances_synthetic.ifc",
+        env!("CARGO_MANIFEST_DIR")
+    );
+    let content = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"));
+    let old = "#31=IFCBUILDINGELEMENTPROXY('7777777777777777777771',$,'Proxy_0',$,$,#30,#27,$,$);";
+    let new = "#31=IFCWINDOW('7777777777777777777771',$,'Proxy_0',$,$,#30,#27,$,$);";
+    let n = content.matches(old).count();
+    assert_eq!(n, 1, "fixture layout changed — Proxy_0 line not found exactly once");
+    content.replace(old, new).into_bytes()
+}
+
+fn run(content: &[u8], mode: OpeningFilterMode, enable_instancing: bool) -> ProcessingResult {
+    ifc_lite_processing::process_geometry_streaming_filtered_with_options(
+        content,
+        mode,
+        StreamingOptions {
+            enable_instancing,
+            ..StreamingOptions::default()
+        },
+        |_, _, _| {},
+        |_| {},
+        |_| {},
+    )
+}
+
+/// Flat baseline (instancing off): #31 (now `IfcWindow`) is skipped by
+/// `IgnoreAll`, and the other 63 `IfcBuildingElementProxy` occurrences each
+/// materialize their own geometry normally.
+#[test]
+fn flat_baseline_skips_the_window_and_meshes_the_rest() {
+    let bytes = fixture_with_template_owner_as_window();
+    let flat = run(&bytes, OpeningFilterMode::IgnoreAll, false);
+    assert!(
+        flat.meshes.iter().all(|m| m.express_id != 31),
+        "IgnoreAll must suppress the window's own mesh"
+    );
+    let occurrence_count = flat
+        .meshes
+        .iter()
+        .filter(|m| m.geometry_class == 0)
+        .count();
+    assert_eq!(
+        occurrence_count, 63,
+        "the 63 non-window proxies must each still mesh in the flat baseline"
+    );
+}
+
+/// The regression gate: with instancing ON and the plan's template-owning job
+/// skipped by the opening filter, every surviving occurrence's geometry must
+/// still show up in the instanced result — via `recover_orphan_occurrences`
+/// — not vanish. This is the exact production shape the doc comment claims
+/// is "effectively unreachable"; it is reachable, and today's fallback
+/// (correctly) recovers it. A regression that deletes the fallback body would
+/// pass every OTHER test in this suite and only be caught here.
+#[test]
+fn instancing_recovers_orphaned_occurrences_when_the_template_job_is_skipped() {
+    let bytes = fixture_with_template_owner_as_window();
+    let flat = run(&bytes, OpeningFilterMode::IgnoreAll, false);
+    let instanced = run(&bytes, OpeningFilterMode::IgnoreAll, true);
+
+    let flat_occurrence_ids: std::collections::BTreeSet<u32> = flat
+        .meshes
+        .iter()
+        .filter(|m| m.geometry_class == 0)
+        .map(|m| m.express_id)
+        .collect();
+    assert_eq!(flat_occurrence_ids.len(), 63);
+
+    let instanced_occurrence_ids: std::collections::BTreeSet<u32> = instanced
+        .meshes
+        .iter()
+        .filter(|m| m.geometry_class == 0)
+        .map(|m| m.express_id)
+        .collect();
+
+    // The hard gate: every occurrence the flat pass meshed must still be
+    // present in the instanced pass's `meshes` (recovered as an orphan flat,
+    // since no template ever materializes for this source). No instance
+    // records should be minted either — the whole group failed to find a
+    // template and was recovered as ordinary meshes instead.
+    assert_eq!(
+        instanced_occurrence_ids, flat_occurrence_ids,
+        "instancing must not silently drop occurrences when the plan's template-owning \
+         job is filtered out before the router ever sees it (recover_orphan_occurrences \
+         must fire for this source)"
+    );
+    assert!(
+        instanced.instances.is_empty(),
+        "no template ever materializes for this source (its owner is skipped), so no \
+         InstanceRecord should be emitted — recovery must go through `meshes`, not `instances`"
+    );
+
+    // And the recovered geometry must be non-degenerate: same triangle/vertex
+    // shape as the flat baseline for one representative occurrence.
+    let flat_one = flat
+        .meshes
+        .iter()
+        .find(|m| m.express_id == 38 && m.geometry_class == 0)
+        .expect("flat Proxy_1 (#38) must have a mesh");
+    let recovered_one = instanced
+        .meshes
+        .iter()
+        .find(|m| m.express_id == 38 && m.geometry_class == 0)
+        .expect("recovered Proxy_1 (#38) must have a mesh in the instanced pass");
+    assert_eq!(
+        recovered_one.positions.len(),
+        flat_one.positions.len(),
+        "recovered occurrence must carry real geometry, not an empty/degenerate mesh"
+    );
+    assert!(
+        !recovered_one.indices.is_empty(),
+        "recovered occurrence must carry real triangles"
+    );
+}


### PR DESCRIPTION
`recover_orphan_occurrences` had **no test at all**. Deleting its body — so every orphan occurrence is silently dropped — left the crate green at **165 passing / 0 failing**.

## The doc comment is wrong, and that is the finding

`finalize_instances` describes this path as:

> effectively unreachable for the eligible single-solid type-instanced set (their template occurrence always materializes)

It is reachable, and the reason is a **producer/consumer disagreement** rather than an exotic edge case:

- `mapped_item_plan` picks the template occurrence up front by scanning every `IFCMAPPEDITEM`, with **no knowledge** of which owning product jobs the opening filter will later skip — `skipped_entity_ids` is consulted only in `jobs::process_entity_job`.
- So under `OpeningFilterMode::IgnoreAll`, if the chosen template id belongs to a window or door job, that job returns before the router ever sees the mapped item.
- `is_template` (`item.id == template_item_id`) is then false for **every surviving occurrence too**, no template mesh is ever produced, and the whole group depends on the fallback or its geometry disappears.

Two places decide which occurrence is the template, they can disagree, and nothing tested what happens when they do. That is the same shape as three live bugs found this week — most recently the parquet exporter, where three loops had to skip the same meshes or every subsequent offset pointed at another mesh's vertices.

## The fixture

Retypes the min-id template's owner (`#31`) to `IfcWindow` in the existing synthetic mapped-instances model, so `IgnoreAll` skips exactly that job — the real production shape, not a hand-built stub.

The gate then asserts three things, deliberately:

1. the instanced pass produces the **same occurrence id set** as the flat baseline (63 ids);
2. **no `InstanceRecord`** is emitted — recovery must go through `meshes`, not `instances`;
3. a representative recovered mesh carries **real vertices and triangles**.

The third matters: an empty mesh would satisfy an id-set comparison on its own, so without it the test could pass while recovering nothing.

## Severity: coverage gap, not a live bug

The fallback exists and works today. What was missing is any guard against it being deleted as dead code on the strength of a doc comment that is incorrect — which is exactly the kind of cleanup that looks safe.

## Verification

- fallback body disabled + **new** gate → fails
- fallback body disabled + **new file removed** → the rest of the crate still passes **165 / 0**, so nothing else covered it
- restored → **167 passing / 0 failing**

Module-size ratchet 4/4. Clippy 24 lines, **identical** to the same measurement with the new file removed — `Checking ifc-lite-processing` present in both runs, so neither was a cached no-op.

Test-only; no changeset.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for recovering orphaned instances when their template owner is filtered out.
  * Verified that all 63 remaining occurrences produce valid geometry in both flat and instanced processing.
  * Confirmed no invalid instance records are emitted during recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->