### PR TITLE
test(diff): pin changedComponents' both-sides-required guard

### DIFF
--- a/packages/diff/src/component-fingerprint.test.ts
+++ b/packages/diff/src/component-fingerprint.test.ts
@@ -165,7 +165,13 @@ describe('diffModels with component sub-hashes', () => {
       ref: null,
     };
     const diff = diffModels([bare], [bare]);
-    expect(diff.byKey.get('w')?.changedComponents).toBeUndefined();
+    // Assert the ENTRY, not just the field: `undefined?.changedComponents` is
+    // also `undefined`, so a bare `expect(get('w')?.changedComponents)
+    // .toBeUndefined()` passes just as well when diffModels drops the entity
+    // entirely — a different, worse bug than the one being pinned.
+    const entry = diff.byKey.get('w');
+    expect(entry).toMatchObject({ key: 'w', state: 'unchanged' });
+    expect(entry?.changedComponents).toBeUndefined();
   });
 
   it('omits changedComponents when only ONE side carries sub-hashes, not both', () => {
@@ -187,7 +193,12 @@ describe('diffModels with component sub-hashes', () => {
     };
     const head = fp('w', wall);
     const diff = diffModels([base], [head]);
-    expect(diff.byKey.get('w')?.changedComponents).toBeUndefined();
+    // Same reason as the test above: pin that the entity is PRESENT and
+    // unchanged, then that the field is absent. Optional chaining alone would
+    // let "the entity vanished from the diff" satisfy this assertion.
+    const entry = diff.byKey.get('w');
+    expect(entry).toMatchObject({ key: 'w', state: 'unchanged' });
+    expect(entry?.changedComponents).toBeUndefined();
   });
 
   it('sorts changedComponents when multiple keys differ, regardless of object insertion order', () => {

--- a/packages/diff/src/component-fingerprint.test.ts
+++ b/packages/diff/src/component-fingerprint.test.ts
@@ -168,6 +168,28 @@ describe('diffModels with component sub-hashes', () => {
     expect(diff.byKey.get('w')?.changedComponents).toBeUndefined();
   });
 
+  it('omits changedComponents when only ONE side carries sub-hashes, not both', () => {
+    // `components` is opt-in per-fingerprint (docs on `DiffEntry.changedComponents`:
+    // "Present only when both fingerprints carry `components`"). A caller that
+    // supplies sub-hashes for the head revision only — a partial rollout of the
+    // sub-hash adapter, or a base fingerprint computed before this field existed —
+    // must not have the missing side read as an EMPTY component map: that would
+    // report every one of the present side's component keys as "changed" when
+    // there is no evidence either way, contradicting the documented contract and
+    // the identical abstention `componentsAgree` (content-match pass) already
+    // takes for exactly this asymmetry.
+    const base: EntityFingerprint<null> = {
+      key: 'w',
+      ifcType: 'IfcWall',
+      dataHash: buildDataFingerprint(wall),
+      // no `components` on this side
+      ref: null,
+    };
+    const head = fp('w', wall);
+    const diff = diffModels([base], [head]);
+    expect(diff.byKey.get('w')?.changedComponents).toBeUndefined();
+  });
+
   it('sorts changedComponents when multiple keys differ, regardless of object insertion order', () => {
     // Object key insertion order here is deliberately the REVERSE of alphabetical
     // ('pset:Z...' before 'pset:A...'), so a build that returns the union in


### PR DESCRIPTION
`DiffEntry.changedComponents` is documented as present **only when both** fingerprints carry `components` (`types.ts:166-168`), enforced by the `&&` at `diff.ts:188`. Every existing test had both sides present or both absent — never one side with sub-hashes and the other without — so that branch was unasserted.

Flipping the guard to `||`, with a missing side defaulted to `{}` — the plausible bug shape, treating *"no evidence"* as *"empty"* — left the suite green at **287/287**.

That mutation would report every component key present on the one side as **spuriously changed**: a diff inventing modifications that never happened. The abstention is the correct contract, and it matches `componentsAgree`'s identical abstention in the content-match pass — with sub-hashes on only one side there is nothing to compare, so the honest answer is to say nothing rather than guess.

**Severity: coverage gap.** Shipped behaviour is right.

## Two things checked and deliberately not changed

Recorded so the next pass over this package doesn't spend its run rediscovering them:

**The hash short-circuit is real and is intended.** `diff.ts:173` and `geometry-compare.ts`'s `geometryEqual` both classify "unchanged" from hash equality with no value fallback, and it is reachable on every diff run. That is the content-hashing design, with the `ifcType` / `componentsAgree` collision guards behind it — not a defect.

**The paired-computation search came back clean.** `fingerprint.ts` already centralises `coreAttributes` for both `buildDataFingerprint` and `buildComponentFingerprints`, with a comment naming that exact failure mode, and there is no second undocumented pair of independently computed keys. Given three live bugs this week were two places computing one value and disagreeing, a clean result there is worth stating.

## A correction to my own briefing

I sent this audit off believing `stableHash` was 32-bit and collision-prone. **It isn't, and hasn't been since #1987** (`ed63063c9`), which widened it to 64-bit FNV-1a precisely because 32-bit collisions were enumerable. Verified in the source: `BigInt.asUintN(64, ...)`, `padStart(16, '0')`. The current doc comments already describe it correctly.

Noting it because that stale fact was steering the audit toward a collision hunt that no longer has a target.

## Verification

- guard flipped + **old** tests → **287/287 pass** (the gap was real)
- guard flipped + **new** test → fails, and the other 11 tests in that file still pass, so the failure is specific rather than broad breakage
- restored → **288/288 across 14 files**

Mutation applied by exact-substring replacement with an asserted replacement count of 1, restored by file copy, re-run by hand before pushing. `tsc --noEmit` clean.

Test-only; no changeset.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected change reporting so component-level differences are omitted when the base version lacks component fingerprint data.

* **Tests**
  * Added regression coverage for fingerprints with component sub-hashes present only in the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->