### PR TITLE
fix(viewer): purge the removed model's selection state in removeModel

### DIFF
--- a/apps/viewer/src/store/removeModel-selection-purge.test.ts
+++ b/apps/viewer/src/store/removeModel-selection-purge.test.ts
@@ -1,0 +1,84 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `removeModel` must drop selection state that keys off the removed model,
+ * and must NOT touch a federated sibling's.
+ *
+ * Selection is keyed by `modelId`, so after a removal `models.get(...)`
+ * returns undefined for the stale ref: `PropertiesPanel` renders nothing
+ * rather than re-resolving, and `activeStorey` stays pinned to a storey in a
+ * model that no longer exists (Solo level display, floorplan). Nothing
+ * re-resolves it until the user clicks elsewhere.
+ *
+ * `syncSourceModel`'s `purgeStaleReferences` already does this for the
+ * same-modelId resync path; full removal never got the same treatment.
+ *
+ * These run against the REAL combined store rather than the slice harness in
+ * `modelSlice.test.ts`, which stubs `set`/`get` and only wires the
+ * mutation/IDS/source-tag cross-slice calls `removeModel` already made — it
+ * could not observe selection state at all.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { useViewerStore } from './index.js';
+import type { FederatedModel } from './types.js';
+
+function model(id: string, idOffset: number): FederatedModel {
+  return { id, name: id, visible: true, idOffset } as unknown as FederatedModel;
+}
+
+function seedTwoModelsWithSelection(): void {
+  useViewerStore.setState({
+    models: new Map([
+      ['A', model('A', 0)],
+      ['B', model('B', 100000)],
+    ]),
+    activeModelId: 'A',
+    selectedEntity: { modelId: 'A', expressId: 42 },
+    activeStorey: { modelId: 'A', expressId: 7 },
+    selectedEntities: [
+      { modelId: 'A', expressId: 42 },
+      { modelId: 'B', expressId: 99 },
+    ],
+    selectedEntitiesSet: new Set(['A:42', 'B:99']),
+    selectedModelId: 'A',
+  });
+}
+
+describe('removeModel purges selection state for the removed model', () => {
+  it('clears refs pointing at the removed model', () => {
+    seedTwoModelsWithSelection();
+    useViewerStore.getState().removeModel('A');
+    const s = useViewerStore.getState();
+
+    assert.strictEqual(s.selectedEntity, null, 'selectedEntity must not survive its model');
+    assert.strictEqual(s.activeStorey, null, 'activeStorey must not survive its model');
+    assert.strictEqual(s.selectedModelId, null);
+  });
+
+  it('preserves a federated sibling\'s selection', () => {
+    seedTwoModelsWithSelection();
+    useViewerStore.getState().removeModel('A');
+    const s = useViewerStore.getState();
+
+    // The half that makes this a purge rather than a reset: clearing
+    // wholesale would be just as green against the assertions above while
+    // silently dropping every other loaded model's selection.
+    assert.deepStrictEqual(s.selectedEntities, [{ modelId: 'B', expressId: 99 }]);
+    assert.deepStrictEqual([...s.selectedEntitiesSet], ['B:99']);
+  });
+
+  it('leaves selection untouched when an unrelated model is removed', () => {
+    seedTwoModelsWithSelection();
+    useViewerStore.getState().removeModel('B');
+    const s = useViewerStore.getState();
+
+    assert.deepStrictEqual(s.selectedEntity, { modelId: 'A', expressId: 42 });
+    assert.deepStrictEqual(s.activeStorey, { modelId: 'A', expressId: 7 });
+    assert.deepStrictEqual([...s.selectedEntitiesSet], ['A:42']);
+    assert.strictEqual(s.selectedModelId, 'A');
+  });
+});

--- a/apps/viewer/src/store/slices/modelSlice.ts
+++ b/apps/viewer/src/store/slices/modelSlice.ts
@@ -12,7 +12,8 @@
  */
 
 import type { StateCreator } from 'zustand';
-import type { FederatedModel } from '../types.js';
+import type { EntityRef, FederatedModel } from '../types.js';
+import { stringToEntityRef } from '../types.js';
 import type { IfcDataStore } from '@ifc-lite/parser';
 import type { GeometryResult } from '@ifc-lite/geometry';
 import { federationRegistry, type GlobalIdLookup } from '@ifc-lite/renderer';
@@ -207,11 +208,65 @@ export const createModelSlice: StateCreator<ModelSlice & ModelCrossSliceState, [
 
       const activeModel = newActiveId ? newModels.get(newActiveId) : null;
 
+      // Selection state keys off modelId, so anything pointing at the removed
+      // model is now dangling: `models.get(selectedEntity.modelId)` returns
+      // undefined and the properties panel silently renders nothing rather
+      // than re-resolving, leaving a ghost selection until the user clicks
+      // elsewhere. `activeStorey` likewise stays pinned to a storey in a model
+      // that no longer exists, which the Solo level display and floorplan read.
+      //
+      // `syncSourceModel`'s purgeStaleReferences already does exactly this for
+      // the same-modelId resync path; full removal needed the same treatment
+      // and never got it. Entries belonging to OTHER models are preserved —
+      // clearing wholesale would drop a federated sibling's live selection.
+      // Selection lives on selectionSlice; reached through a narrow cast the
+      // same way the mutation/IDS/source-tag actions above are reached via
+      // `cross`, since a slice's own StateCreator is typed to its own fields.
+      // Every field is optional here, not just cast: `modelSlice.test.ts`
+      // drives this action through a harness that stubs `set`/`get` with the
+      // model slice alone, so selection fields are genuinely absent there. A
+      // slice reaching across must tolerate that rather than assume the
+      // combined store.
+      const sel = state as unknown as Partial<{
+        selectedEntity: EntityRef | null;
+        activeStorey: EntityRef | null;
+        selectedEntities: EntityRef[];
+        selectedEntitiesSet: Set<string>;
+        selectedModelId: string | null;
+      }>;
+      const priorEntities = sel.selectedEntities ?? [];
+      const priorSet = sel.selectedEntitiesSet ?? new Set<string>();
+      const keptEntities = priorEntities.filter((e) => e.modelId !== modelId);
+      const selectionTouchedRemoved =
+        sel.selectedEntity?.modelId === modelId ||
+        sel.activeStorey?.modelId === modelId ||
+        keptEntities.length !== priorEntities.length;
+
       return {
         models: newModels,
         activeModelId: newActiveId,
         ifcDataStore: activeModel?.ifcDataStore ?? null,
         geometryResult: activeModel?.geometryResult ?? null,
+        ...(selectionTouchedRemoved
+          ? {
+              selectedEntity:
+                sel.selectedEntity?.modelId === modelId ? null : sel.selectedEntity,
+              activeStorey: sel.activeStorey?.modelId === modelId ? null : sel.activeStorey,
+              selectedEntities: keptEntities,
+              // Parsed with the shared helper rather than a `${modelId}:`
+              // prefix test: `stringToEntityRef` splits on the FIRST colon, so
+              // a prefix match would also strip a sibling model whose id
+              // merely starts with this one's id plus a colon. Using the same
+              // parse every other consumer uses keeps this filter from
+              // becoming a third, subtly different reading of the same key.
+              selectedEntitiesSet: new Set(
+                [...priorSet].filter(
+                  (k) => stringToEntityRef(k).modelId !== modelId
+                )
+              ),
+              selectedModelId: sel.selectedModelId === modelId ? null : (sel.selectedModelId ?? null),
+            }
+          : {}),
       };
     });
   },


### PR DESCRIPTION
`removeModel` clears the removed model's mutation footprint, source tag and IDS report — but leaves **every selection field** pointing at it.

Observed against the real combined store, before the fix:

```
BEFORE selectedEntity: {"modelId":"A","expressId":42}
AFTER  selectedEntity: {"modelId":"A","expressId":42}
AFTER  selectedEntitiesSet: ["A:42"]
AFTER  selectedModelId: "A"
AFTER  activeStorey: {"modelId":"A","expressId":7}
```

`models.get(selectedEntity.modelId)` now returns `undefined`, so `PropertiesPanel` renders nothing rather than re-resolving — a ghost selection that nothing clears until the user clicks elsewhere. `activeStorey` stays pinned to a storey in a model that is gone, which the Solo level display and floorplan read.

**Severity: LIVE.** `selectedEntity` / `setSelectedEntity` / `addEntityToSelection` are wired into `Viewport`, `HierarchyPanel`, `PropertiesPanel`, `SearchModal` and `SearchInline`, so this is reachable from ordinary use: select an entity, remove its model.

`syncSourceModel`'s `purgeStaleReferences` already does exactly this for the same-modelId resync path — the maintainers established the invariant; full removal is the same class of staleness and never got the same treatment.

## It is a purge, not a reset

Entries belonging to other federated models are preserved. Clearing wholesale would satisfy the obvious assertions while silently dropping a sibling model's live selection — so that half has its own test, and a third test pins that removing an *unrelated* model leaves the current selection alone.

## Two details worth recording

**The set filter parses rather than prefix-matches.** `entityRefToString` produces `${modelId}:${expressId}`, so `startsWith(`${modelId}:`)` looks sufficient — but `stringToEntityRef` splits on the **first** colon, so a prefix test would also strip a sibling whose id begins with this one's id plus a colon. Using the shared helper keeps this from becoming a third, subtly different reading of the same key, which is precisely the shape behind #2272 and #2278.

**The cross-slice fields are read as `Partial` and defaulted, and that is not padding.** `modelSlice.test.ts` drives `removeModel` through a harness that stubs `set`/`get` with the model slice alone, so those fields are genuinely absent there. My first version assumed the combined store and **broke 6 existing tests** — worth stating, because it is exactly the assumption a reviewer would otherwise have to catch.

## Verification

- Reproduced by observation against the real store (output above), not inferred from reading.
- RED: with the purge disabled all three new tests fail, including the sibling case — without it, the removed model's key lingers in the set regardless of which model was removed.
- GREEN: **3086 passing / 0 failing / 2 pre-existing skips across 673 suites**; `modelSlice.test.ts` back to 37/37.
- `tsc --noEmit` clean.

The regression tests deliberately run against the real combined store. The existing slice harness could not have caught this — it only stubs the mutation/IDS/source-tag calls `removeModel` already made, and never had selection state to observe.

## Adjacent, reported but not fixed

`hiddenEntitiesByModel` / `isolatedEntitiesByModel` also survive `removeModel` unpurged — but a grep across `apps/viewer/src` finds **zero production call sites** for any of their writers, `isolatedEntitiesByModel` has no writer anywhere, and the SDK visibility adapter carries a comment saying it deliberately uses the legacy `hiddenEntities` set instead. Their cleanup action `clearModelVisibility` is likewise never called from production. That is orphaned API surface, not a reachable defect, so it is a maintainer note rather than part of this fix.

`apps/viewer` is `private: true`, so no changeset.
