### PR TITLE
test(clash): pin the sort-and-sweep eviction boundary

### DIFF
--- a/packages/clash/src/duplicates.test.ts
+++ b/packages/clash/src/duplicates.test.ts
@@ -74,6 +74,22 @@ describe('findDuplicates', () => {
     expect(findDuplicates([flatA, flatB]).clashes).toHaveLength(1);
   });
 
+  it('does not evict a same-position candidate at the exact sweep boundary', () => {
+    // Two zero-volume (point) elements at the identical location: bounds.min ===
+    // bounds.max on every axis, so the sweep's own max[axis] EQUALS the next
+    // candidate's min[axis] exactly. The sweep must keep (not evict) a candidate
+    // whose max sits exactly at the new element's min — an `<=` eviction there
+    // would drop the pair before `consider()` ever sees it, silently losing a
+    // genuine coincident-element duplicate.
+    const p: ClashElement = {
+      key: 'pa', ref: nextRef++, model: 'm', tag: 'IfcColumn',
+      bounds: { min: [3, 3, 3], max: [3, 3, 3] },
+      positions: new Float32Array(0), indices: new Uint32Array(6),
+    };
+    const q: ClashElement = { ...p, key: 'pb', ref: nextRef++ };
+    expect(findDuplicates([p, q]).clashes).toHaveLength(1);
+  });
+
   it('reports a pair whose IoU is EXACTLY the threshold', () => {
     // A = [0,1]³, B = [0,1]²×[0,2]: intersection 1, union 1 + 2 − 1 = 2, so the
     // IoU is exactly 0.5 — no rounding involved. `sim < threshold` rejects means


### PR DESCRIPTION
`duplicates.ts`'s sort-and-sweep evicts an active candidate once its box ends before the new candidate starts. Relaxing `<` to `<=` left the suite green at **178/178**.

That mutation evicts a candidate whose box touches the new one's start **exactly**. For two zero-volume elements at the same location — `max[axis] === minA` — the earlier one leaves `active` before `consider()` ever runs on the pair, so a genuine coincident duplicate is **silently not reported**. Point and planar elements are precisely the degenerate case a duplicate check exists to catch.

**Severity: coverage gap.** `<` is correct and ships.

Bounded by a control rather than assumed: the adjacent IoU threshold (`sim < iouThreshold` → `<=`) **dies** against the existing *"IoU is EXACTLY the threshold"* test. So boundaries in this file are caught when a test exists — the sweep boundary simply had none.

## The question this round set out to answer

**Can the broad phase cull a pair the narrow phase would have reported?** No — and the reasoning is worth keeping, because a false negative here is invisible while a false positive is merely noise:

- TS `ts-kernel.ts:47` and `narrow.ts:40` compute the same `max(tolerance, clearance ?? 0)` margin, so the broad-phase margin is always **≥** the narrow-phase tolerance.
- `packages/spatial`'s AABB and BVH use inclusive `<=`/`>=` throughout, so an exact touch at a bbox edge is kept, not dropped.

## A real TS/Rust divergence — recorded, not "fixed"

The two engines **do** disagree on how the margin is built: Rust (`session.rs:165`) gates `clearance` behind `mode == 1`, while TS folds `rule.clearance` in unconditionally.

That is exactly the two-places-compute-the-same-value shape behind four live bugs this week, so I checked whether it is exploitable rather than filing it on the strength of the pattern. **It isn't:** the margin stays ≥ `tolerance` in both engines, and `clearance` is only consulted for classification when `mode === 'clearance'` on both sides (`narrow.ts:234`, `narrow.rs:294`). So TS merely searches a superset of triangle candidates for a hard-mode rule carrying a leftover `clearance` — extra work, never a missed clash.

No mutation was run against it because TS is the permissive side: there is nothing to assert that would fail today. Reporting it so the next person doesn't re-derive it, and so it's on record if the gating ever changes.

## Two duplications noted, neither a defect today

- `buildSummary` is byte-identical in `orchestrator.ts:155` and `duplicates.ts:115` — no drift now, but a future edit to one copy would introduce it.
- `src/contact/*` (aabb / bvh / tri-tri / narrow-phase) has **no importer outside itself** — the live pipeline runs through `engine-ts/broad.ts` + `engine-ts/narrow.ts`. Flagging as apparently-dead code rather than auditing it as if it shipped.

## Verification

- boundary relaxed + **old** tests → **178/178 pass** (the gap was real)
- boundary relaxed + **new** test → fails, `expected [] to have length 1`
- restored → **179 passing across 19 files**

Mutation applied by exact-substring replacement with an asserted replacement count of 1, restored by file copy, re-run by hand before pushing. `tsc --noEmit` clean.

Test-only; no changeset.

Prior mutation sweeps (#2219, #2174, #2147, #2190) had already pinned `grouping.ts`'s tie-break, several boundary/truncation gaps and the Rust `map_to_local` — those were skipped rather than re-covered.
