### PR TITLE
test(pointcloud): pin the E57 bytestream-overrun guard and LAZ origin frame

### DIFF
--- a/packages/pointcloud/src/formats/e57.test.ts
+++ b/packages/pointcloud/src/formats/e57.test.ts
@@ -257,6 +257,45 @@ describe('decodeE57Scan (uncompressed Float64)', () => {
     expect(chunk.positions[5]).toBeCloseTo(1.55, 5);
   });
 
+  it('rejects a ScaledInteger field whose minimum/maximum range needs more than 53 bits per record', () => {
+    // Mutation testing: `scaledIntegerBitsPerRecord`'s `bits > 53` check
+    // had zero coverage. Disabling it left the full suite green.
+    //
+    // e57-xml.ts parses `minimum`/`maximum` with a bare `Number(...)` and
+    // never sanity-checks the span — a hostile or corrupt file can declare
+    // any range. Without this guard, a huge span produces a huge
+    // `bitsPerRecord`, and `readBitsLE`'s byte walk then silently loses
+    // precision past the 53-bit Number limit (or, for a truly enormous
+    // span, walks off the end of the bytestream reading `undefined` bytes
+    // as NaN) instead of failing with a clear diagnostic.
+    // One well-formed data packet — 3 bytestreams, 2 bytes each, matching
+    // the "decodes ScaledInteger cartesian streams" fixture above, so the
+    // decoder reaches per-field capacity sizing (where the bits check
+    // lives) rather than tripping an earlier, unrelated guard.
+    const buf = new ArrayBuffer(22);
+    const view = new DataView(buf);
+    view.setUint8(0, 1); // packetType = data
+    view.setUint8(1, 0); // flags
+    view.setUint16(2, 21, true); // packetLogicalLength - 1 (total = 22)
+    view.setUint16(4, 3, true); // bytestreamCount
+    view.setUint16(6, 2, true); // X bytestream length
+    view.setUint16(8, 2, true); // Y bytestream length
+    view.setUint16(10, 2, true); // Z bytestream length
+
+    const entry: Data3DEntry = {
+      guid: 'test',
+      recordCount: 1,
+      binaryFileOffset: 0,
+      prototype: [
+        // span = 2^60 - 0 + 1 -> bitsPerRecord = 60 > 53.
+        { name: 'cartesianX', kind: 'ScaledInteger', scale: 1, offset: 0, minimum: 0, maximum: 2 ** 60 },
+        { name: 'cartesianY', kind: 'ScaledInteger', scale: 0.01, offset: 0, minimum: -100, maximum: 155 },
+        { name: 'cartesianZ', kind: 'ScaledInteger', scale: 0.01, offset: 0, minimum: -100, maximum: 155 },
+      ],
+    };
+    expect(() => decodeE57Scan(new Uint8Array(buf), entry)).toThrow(/exceeds the 53-bit/);
+  });
+
   it('decodes classification and intensity (Integer kind) through the full scan pipeline', () => {
     // Mutation testing found decodeE57Scan's classification/intensity paths
     // had ZERO coverage anywhere in this package: no test built a packet
@@ -490,6 +529,59 @@ describe('decodeE57Scan (uncompressed Float64)', () => {
       ],
     };
     expect(() => decodeE57Scan(logical, entry)).toThrow(/bytestreamCount \(99\) ≠ prototype length \(3\)/);
+  });
+
+  it('rejects a bytestream whose declared length overruns the packet payload, instead of silently reading past-payload bytes', () => {
+    // Mutation testing: `decodeE57Packet`'s per-field
+    // `streamCursor + bytestreamLengths[i] > payloadEnd` check had zero
+    // coverage. Disabling it left the full suite green — worse, it does
+    // NOT fail loudly: because the two guards that run before it in the
+    // packet walk (`offset + 6 > payloadEnd` and the length-table's own
+    // `cursor + 2 > payloadEnd`) always fire first whenever this guard's
+    // own condition on THEIR triggers would, this per-field guard is the
+    // only one of the three that a crafted file can actually reach.
+    //
+    // Disabling it, a packet declaring cartesianX's bytestream far longer
+    // than the packet actually is shifts every subsequent field's start
+    // offset outward by the lie, and — as long as the buffer physically
+    // has bytes at that shifted (wrong) location (e.g. the next packet's
+    // header/payload in a real multi-packet file) — the read SUCCEEDS
+    // with no exception, silently decoding cartesianY/Z from the wrong
+    // bytes. Verified directly: with the guard removed, this exact
+    // fixture returns positions [1, 777, 888] (reading the "borrowed"
+    // decoy values planted at the shifted offsets) instead of throwing.
+    // The correct values [2, 3] planted at cartesianY/Z's TRUE offsets
+    // are never touched — proof the corruption is silent, not a crash.
+    const buf = new ArrayBuffer(80);
+    const view = new DataView(buf);
+    view.setUint8(0, 1); // packetType = data
+    view.setUint8(1, 0); // flags
+    view.setUint16(2, 35, true); // packetLogicalLength - 1 = 35 -> packetLength = 36 (payloadEnd = 36)
+    view.setUint16(4, 3, true); // bytestreamCount = 3 (matches prototype length)
+    view.setUint16(6, 40, true); // X length LIES: declares 40 bytes (5 points) — past payloadEnd(36)
+    view.setUint16(8, 8, true); // Y length: correctly 8 bytes (1 point)
+    view.setUint16(10, 8, true); // Z length: correctly 8 bytes (1 point)
+    // True layout per the correct field lengths: X at 12, Y at 20, Z at 28.
+    view.setFloat64(12, 1.0, true);
+    view.setFloat64(20, 2.0, true); // correct Y — must never be read
+    view.setFloat64(28, 3.0, true); // correct Z — must never be read
+    // Decoy values at the offsets X's lie would shift Y/Z to (12+40=52,
+    // 52+8=60) — bytes that belong to whatever data follows this packet
+    // in a real file, not to this scan's fields at all.
+    view.setFloat64(52, 777.0, true);
+    view.setFloat64(60, 888.0, true);
+
+    const entry: Data3DEntry = {
+      guid: 'test',
+      recordCount: 1,
+      binaryFileOffset: 0,
+      prototype: [
+        { name: 'cartesianX', kind: 'Float', precision: 'double' },
+        { name: 'cartesianY', kind: 'Float', precision: 'double' },
+        { name: 'cartesianZ', kind: 'Float', precision: 'double' },
+      ],
+    };
+    expect(() => decodeE57Scan(new Uint8Array(buf), entry)).toThrow(/runs past packet payload/);
   });
 });
 

--- a/packages/pointcloud/src/streaming/laz-source.test.ts
+++ b/packages/pointcloud/src/streaming/laz-source.test.ts
@@ -95,6 +95,40 @@ function stubLazPerfModuleWithCounter(): LazPerfModule {
   };
 }
 
+/**
+ * Same layout as `buildLazFile` but with an explicit header bbox — needed
+ * to check `toInfo()`'s `bboxInDecodedFrame` translation, which
+ * `buildLazFile`'s all-zero header can't exercise (a zero bbox looks
+ * "translated" whether or not the subtraction actually ran).
+ */
+function buildLazFileWithBbox(
+  pointCount: number,
+  bbox: { min: [number, number, number]; max: [number, number, number] },
+): Blob {
+  const headerSize = 227;
+  const buf = new ArrayBuffer(headerSize + pointCount * RECORD_LEN);
+  const view = new DataView(buf);
+  view.setUint32(0, 0x4653414c, true); // "LASF"
+  view.setUint8(24, 1);
+  view.setUint8(25, 2);
+  view.setUint16(94, headerSize, true);
+  view.setUint32(96, headerSize, true);
+  view.setUint32(100, 0, true);
+  view.setUint8(104, 0);
+  view.setUint16(105, RECORD_LEN, true);
+  view.setUint32(107, pointCount, true);
+  view.setFloat64(131, 1, true);
+  view.setFloat64(139, 1, true);
+  view.setFloat64(147, 1, true);
+  view.setFloat64(179, bbox.max[0], true);
+  view.setFloat64(187, bbox.min[0], true);
+  view.setFloat64(195, bbox.max[1], true);
+  view.setFloat64(203, bbox.min[1], true);
+  view.setFloat64(211, bbox.max[2], true);
+  view.setFloat64(219, bbox.min[2], true);
+  return new Blob([buf], { type: 'application/octet-stream' });
+}
+
 describe('LazStreamingSource downsampling', () => {
   let restore: (() => void) | null = null;
 
@@ -114,6 +148,47 @@ describe('LazStreamingSource downsampling', () => {
     expect(chunk!.pointCount).toBe(4);
     const xs = Array.from({ length: chunk!.pointCount }, (_, i) => chunk!.positions[i * 3]);
     expect(xs).toEqual([0, 3, 6, 9]);
+  });
+});
+
+describe('LazStreamingSource originOffset (issue #1804)', () => {
+  let restore: (() => void) | null = null;
+
+  afterEach(() => {
+    restore?.();
+    restore = null;
+  });
+
+  it('reports the bbox in the same frame as the points it emits, same as LasStreamingSource', async () => {
+    // `bboxInDecodedFrame` is shared by both streaming sources specifically
+    // so a fix to one doesn't silently leave the other behind (see the
+    // function's doc comment in formats/las.ts) — but only
+    // `las-source.test.ts` pins this. LAZ shares the exact same code path
+    // (decodeLasPoints + bboxInDecodedFrame, both fed `this.originOffset`)
+    // yet had zero coverage: a future edit that updates one call site and
+    // not the other would pass this suite silently.
+    restore = setLazPerfLoaderForTesting(async () => stubLazPerfModuleWithCounter());
+
+    // Header bbox is the RAW (pre-subtraction) box; points come out of the
+    // stub with x = source record index (0, 1, 2, ...), y = z = 0.
+    const blob = buildLazFileWithBbox(3, { min: [0, 0, 0], max: [2, 0, 0] });
+    const originOffset = [100, 200, 300] as const;
+    const src = new LazStreamingSource(blob, { originOffset });
+    const info = await src.open();
+    expect(info.bbox).toEqual({ min: [-100, -200, -300], max: [-98, -200, -300] });
+
+    // Cross-check against the actual emitted points: every point must fall
+    // inside the reported box — the invariant issue #1804 broke for LAS.
+    const chunk = await src.next(16);
+    expect(chunk).not.toBeNull();
+    const { positions, pointCount } = chunk!;
+    for (let i = 0; i < pointCount; i++) {
+      for (let axis = 0; axis < 3; axis++) {
+        const v = positions[i * 3 + axis];
+        expect(v).toBeGreaterThanOrEqual(info.bbox.min[axis]);
+        expect(v).toBeLessThanOrEqual(info.bbox.max[axis]);
+      }
+    }
   });
 });
 


### PR DESCRIPTION
Three gaps in the point-cloud readers, and the first has an unusually bad failure shape.

## 1. The E57 bytestream-overrun guard fails *silently* when removed

`decodeE57Packet`'s per-field check (`streamCursor + bytestreamLengths[i] > payloadEnd`) had no test.

Removing it does **not** crash. A packet declaring `cartesianX`'s bytestream longer than the packet actually is shifts every later field's start offset outward by the lie — and as long as the buffer physically has bytes there (the next packet's header in any real multi-packet file), the read **succeeds** and decodes Y/Z from the wrong bytes.

Verified directly: with the guard removed the fixture returns positions `[1, 777, 888]` — decoys planted at the shifted offsets — while the correct `[2, 3]` at the true offsets are never touched. Silent coordinate corruption, no exception. I confirmed the "no exception" half myself; the new test fails with `expected [Function] to throw an error`.

That matters for severity of a future regression: most guards here fail loudly, so a reviewer's instinct that "we'd notice" is wrong for this one.

## 2. The 53-bit ScaledInteger guard

`scaledIntegerBitsPerRecord`'s `bits > 53` check survived deletion with the suite green. `e57-xml.ts` parses min/max with a bare `Number()` and no sanity check, so this guard is the only thing between a hostile file and precision loss in the bit walk.

## 3. LAZ's origin frame — the omission the codebase already got bitten by

`laz-source.ts` had **zero** coverage of `originOffset` / `bboxInDecodedFrame`, which `las-source.ts` does pin.

That is not an arbitrary omission. `bboxInDecodedFrame`'s own doc comment says it is *"shared by BOTH streaming sources on purpose… how one of them ends up fixed and the other left behind"* — issue #1804 already happened once. The LAZ half was the untested one.

Code is correct today; the new test fails if **either** call site drops the offset (verified by mutating each independently — both land on the same test, because the assertion cross-checks bbox against emitted points).

## Two guards deliberately NOT pinned — proven equivalent, not assumed

Both sit *above* guard C in the same walk, and neither is reachable:

- **Guard A** (`offset+6 > payloadEnd`, truncated header): every input tripping it also trips the `bytestreamCount !== prototype.length` check, since the prototype always carries ≥ 3 fields.
- **Guard B** (`cursor+2 > payloadEnd`, truncated length table): the cursor arithmetic is unconditional, so whenever B's condition would fire the final cursor already exceeds `payloadEnd`, guaranteeing guard C fires on the very first field.

Checked empirically rather than argued from an absence of failures: fixtures crafted to hit each condition produced a **different** guard's message every time.

**This is the mirror image of the `.ifcZIP` shape found earlier today.** There, a post-decompression backstop made the *first* guard untestable through the front door. Here the chain means A and B are dead weight, and C — the only one a crafted file can actually reach — was the one with no coverage.

## Severity

All three are **coverage gaps, not live bugs**: current production code is correct in every case. Elevated note on #1 only, because its removal corrupts silently rather than throwing.

## Verification

- guard C removed + **old** tests → **147 pass, all green** (the gap was real)
- guard C removed + **new** test → fails, no exception raised
- restored → **149 passing / 2 skipped across 16 files** (was 146)
- sibling control on the adjacent `packetEnd > logical.length` guard **died**, killing an existing test — so the harness genuinely reaches this file

Restores by file copy throughout; never `git checkout`/`restore`/`stash`. `tsc --noEmit` clean.

Test-only; no changeset. #2265's already-merged E57 DataPacket pins were read first and gone past rather than re-covered; `pcd.ts`, `ply.ts`, `ascii-points.ts`, `e57-page.ts` and their streaming wrappers were swept in the same pass with no further survivors worth pinning.
