### PR TITLE
test(sdk): pin dispatchToBackend against prototype-chain reach

### DIFF
--- a/packages/sdk/src/dispatch-security.test.ts
+++ b/packages/sdk/src/dispatch-security.test.ts
@@ -1,0 +1,78 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `dispatchToBackend` takes `namespace` and `method` straight off the wire, so
+ * its own doc comment requires own-property lookups: an attacker must not be
+ * able to reach `__proto__`, `constructor`, `toString` or anything inherited
+ * from a host class.
+ *
+ * Nothing exercised that. Replacing both `Object.prototype.hasOwnProperty.call`
+ * guards with plain `in` — which walks the prototype chain, exactly the reach
+ * the comment warns about — left the suite green at 51/51.
+ *
+ * This is a PUBLISHED surface, not internal wiring: `dispatchToBackend` and
+ * `BimHost` both appear in `scripts/api-surface.json`, so third-party code
+ * calls it directly.
+ *
+ * The assertions check the specific rejection message rather than "it threw".
+ * A dispatcher that rejected everything would satisfy a bare `throws`, so each
+ * case is paired with a positive control proving a legitimate call on the same
+ * backend still dispatches.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { dispatchToBackend } from './types.js';
+import type { BimBackend } from './types.js';
+
+function backendWithOneNamespace() {
+  return {
+    model: {
+      list: vi.fn(() => ['ok']),
+    },
+  } as unknown as BimBackend;
+}
+
+describe('dispatchToBackend — prototype-chain reach', () => {
+  it('dispatches a legitimate own-property namespace and method (positive control)', () => {
+    const backend = backendWithOneNamespace();
+    expect(dispatchToBackend(backend, 'model', 'list', [])).toEqual(['ok']);
+  });
+
+  it.each([['__proto__'], ['constructor'], ['toString']])(
+    'refuses %s as a namespace',
+    (namespace) => {
+      const backend = backendWithOneNamespace();
+      expect(() => dispatchToBackend(backend, namespace, 'list', [])).toThrow(
+        /Unknown namespace/
+      );
+    }
+  );
+
+  it.each([['__proto__'], ['constructor'], ['toString'], ['hasOwnProperty']])(
+    'refuses %s as a method on a real namespace',
+    (method) => {
+      const backend = backendWithOneNamespace();
+      expect(() => dispatchToBackend(backend, 'model', method, [])).toThrow(
+        /Unknown method/
+      );
+    }
+  );
+
+  it('refuses a method inherited from a host class rather than declared on the namespace', () => {
+    // The other half of the doc comment: a namespace implemented as a class
+    // instance exposes its methods on the PROTOTYPE, not as own properties.
+    // An `in` lookup would happily dispatch to them.
+    class HostNamespace {
+      allowed(): string {
+        return 'allowed';
+      }
+    }
+    const backend = { model: new HostNamespace() } as unknown as BimBackend;
+
+    expect(() => dispatchToBackend(backend, 'model', 'allowed', [])).toThrow(
+      /Unknown method/
+    );
+  });
+});


### PR DESCRIPTION
`dispatchToBackend` takes `namespace` and `method` **straight off the wire**. Its own doc comment states the requirement:

> Security: namespace/method come straight off the wire. Use `Object.hasOwn` lookups so an attacker can't reach prototype members (`__proto__`, `constructor`, `toString`, …) or methods inherited from a host class.

Nothing exercised that. Swapping both `Object.prototype.hasOwnProperty.call` guards for plain `in` — which walks the prototype chain, exactly the reach the comment warns about — left the suite green at **51/51**.

This is a **published surface**, not internal plumbing: `dispatchToBackend` and `BimHost` both appear in `scripts/api-surface.json`, so third-party code calls it directly.

## A detail that changes what each guard is worth

Found while writing the tests, and worth recording because the obvious reading is wrong:

With `in` substituted, **only `__proto__` gets through as a namespace**. `constructor` and `toString` resolve to *functions*, so the existing `!ns || typeof ns !== 'object'` check rejects them regardless.

So the namespace guard is largely backstopped and independently observable only via `__proto__`. The **method** guard has no backstop at all — that is where the real protection sits. Both are pinned, but a future reader shouldn't conclude the two carry equal weight.

That's the third instance today of a guard whose apparent coverage came from an unrelated check downstream of it.

## What the tests assert

- The **specific rejection message**, not "it threw" — a dispatcher that rejected everything would satisfy a bare `throws`.
- Each case paired with a **positive control** dispatching a legitimate call on the same backend.
- A **host-class case**: a namespace implemented as a class instance exposes its methods on the prototype rather than as own properties, so an `in` lookup would dispatch to them happily. That is the half of the doc comment a `__proto__` test alone does not cover.

## Verification

- guards → `in` + **old** tests → **51/51 pass** (the gap was real)
- guards → `in` + **new** tests → **5 of 9 fail**, positive control still passes, so the failure is specific rather than broad
- restored → **60 passing across 5 files**

Bounded by a control: mutating `QueryNamespace.property()` to return `null` **dies** against two existing tests, so the harness reaches this package and the survival above is a genuine gap rather than a broken run.

**Severity: coverage gap.** The shipped guards are correct; `git diff` on `types.ts` is empty.

## Two things found and deliberately not bundled in

**`api-surface.json` is genuinely enforced**, which I checked rather than assumed given how many "green that means nothing" cases turned up today: `scripts/check-api-surface.mjs` snapshots every non-private package's exported names and kinds using the real TS checker, and CI runs it as a "Check API surface" step after `pnpm build`. It is a name/kind diff, so it would not catch an implemented-but-broken method — but as an accidental-removal guard it is live.

**`packages/embed-protocol` has no version guard at all** — not merely an untested one. `PROTOCOL_VERSION` is defined and sent on every message, but `isEmbedMessage()` only checks `source === EMBED_SOURCE` and never compares `version`. That is a design gap on a different published surface rather than a missing test, so it belongs to @louistrue as a decision rather than in this PR.

Also noted: `ModelNamespace.active()` / `bim.model.active()` are not exercised by `context.test.ts` — a milder gap noticed while calibrating the control.

Test-only; no changeset.
