### PR TITLE
test(embed): pin that the embed protocol has no version guard today

### DIFF
--- a/apps/viewer-embed/src/bridge/handler.test.ts
+++ b/apps/viewer-embed/src/bridge/handler.test.ts
@@ -803,3 +803,37 @@ describe('read commands', () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// Protocol version — observed current behaviour (no guard exists)
+// ---------------------------------------------------------------------------
+
+describe('protocol version mismatch', () => {
+  // isEmbedMessage() (packages/embed-protocol) only checks `source`, never
+  // `version`. The bridge inherits that: a command whose `version` disagrees
+  // with PROTOCOL_VERSION — or omits it — is dispatched exactly like a
+  // same-version command. This is a DESIGN GAP (documented for the
+  // maintainer to decide reject/warn/negotiate), not a live bug: today's
+  // single protocol version means no real host has ever sent a mismatch.
+  it('dispatches a command with an OLDER version exactly like a matching one', async () => {
+    initBridge(makeCtx(state));
+    await send(fw, { source: EMBED_SOURCE, version: '0.1', type: 'SHOW_ALL', requestId: 'r1' }, PARENT);
+    expect(called(state, 'showAllInAllModels')).toBe(true);
+    expect(fw.posted.at(-1)!.msg.responseId).toBe('r1');
+    expect(fw.posted.at(-1)!.msg.error).toBeUndefined();
+  });
+
+  it('dispatches a command with a NEWER version exactly like a matching one', async () => {
+    initBridge(makeCtx(state));
+    await send(fw, { source: EMBED_SOURCE, version: '99.0', type: 'SHOW_ALL', requestId: 'r1' }, PARENT);
+    expect(called(state, 'showAllInAllModels')).toBe(true);
+    expect(fw.posted.at(-1)!.msg.error).toBeUndefined();
+  });
+
+  it('dispatches a command with the version field missing entirely', async () => {
+    initBridge(makeCtx(state));
+    await send(fw, { source: EMBED_SOURCE, type: 'SHOW_ALL', requestId: 'r1' }, PARENT);
+    expect(called(state, 'showAllInAllModels')).toBe(true);
+    expect(fw.posted.at(-1)!.msg.error).toBeUndefined();
+  });
+});

--- a/packages/embed-protocol/test/protocol.test.ts
+++ b/packages/embed-protocol/test/protocol.test.ts
@@ -150,4 +150,23 @@ describe('isEmbedMessage', () => {
     if (!isEmbedMessage(data)) throw new Error('expected an embed message');
     expect(data.type).toBe('READY');
   });
+
+  // PROTOCOL_VERSION is stamped on every envelope (see createEvent/createResponse/
+  // createCommand above) but isEmbedMessage never reads it — only `source` gates
+  // acceptance. There is no version-compatibility guard anywhere on this boundary
+  // today: an older host talking to a newer viewer (or vice versa) is accepted
+  // exactly like a same-version message and dispatched as normal. This is a
+  // documented DESIGN GAP, not a bug fix here — the decision to reject/warn/
+  // negotiate on mismatch belongs to the maintainer. These tests pin today's
+  // behaviour so a future guard is an intentional, visible change.
+  it('accepts a mismatched version — no version guard exists today', () => {
+    expect(isEmbedMessage({ source: EMBED_SOURCE, version: '0.1', type: 'READY' })).toBe(true);
+    expect(isEmbedMessage({ source: EMBED_SOURCE, version: '99.0', type: 'READY' })).toBe(true);
+    expect(isEmbedMessage({ source: EMBED_SOURCE, version: 'not-a-version', type: 'READY' })).toBe(true);
+  });
+
+  it('accepts a missing version field entirely — no version guard exists today', () => {
+    const { version: _version, ...withoutVersion } = createEvent('READY', { version: '1.0' });
+    expect(isEmbedMessage(withoutVersion)).toBe(true);
+  });
 });

--- a/packages/embed-sdk/test/message-filtering.test.ts
+++ b/packages/embed-sdk/test/message-filtering.test.ts
@@ -104,6 +104,23 @@ describe('envelope filtering', () => {
     h.inbound({ source: EMBED_SOURCE, version: PROTOCOL_VERSION, type: 'ENTITY_SELECTED', data: { id: 7 } });
     expect(seen).toEqual([{ id: 7 }]);
   });
+
+  // isEmbedMessage() (packages/embed-protocol) checks only `source`, never
+  // `version`, and the SDK's onMessage does not add its own check. A message
+  // whose `version` disagrees with PROTOCOL_VERSION — or omits it — passes the
+  // filter and fires the listener exactly like a same-version message. This is
+  // a DESIGN GAP for the maintainer to resolve (reject/warn/negotiate), not a
+  // live bug today: pinned here so a future guard is a deliberate, visible change.
+  it('accepts a mismatched or missing version — no version guard exists today', async () => {
+    h = mount({});
+    const seen: unknown[] = [];
+    const embed = await h.handshake();
+    embed.on('entity-selected', (d) => seen.push(d));
+    h.inbound({ source: EMBED_SOURCE, version: '0.1', type: 'ENTITY_SELECTED', data: { id: 1 } });
+    h.inbound({ source: EMBED_SOURCE, version: '99.0', type: 'ENTITY_SELECTED', data: { id: 2 } });
+    h.inbound({ source: EMBED_SOURCE, type: 'ENTITY_SELECTED', data: { id: 3 } });
+    expect(seen).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }]);
+  });
 });
 
 describe('outbound targetOrigin', () => {


### PR DESCRIPTION
`isEmbedMessage` filters solely on `source === EMBED_SOURCE`. It **never reads `version`** — despite `PROTOCOL_VERSION` being defined and stamped on every message — and it is the only envelope filter both consumers use: `embed-sdk`'s `onMessage` and `viewer-embed`'s bridge handler.

## Established by observation, not by reading

Commands sent with `version: '0.1'`, `version: '99.0'`, and **no `version` at all** were each dispatched through the real bridge and the real SDK filter exactly like a matching-version message: `showAllInAllModels` ran, a normal `RESPONSE` went back with no error, and the SDK listener fired with the payload.

Full acceptance — not a silent no-op, not a malformed-payload crash. That distinction matters for deciding what to do about it, which is why it was worth measuring rather than assuming.

## Severity: design gap — not a live bug, and not a coverage gap

Only `PROTOCOL_VERSION = '1.0'` has ever shipped, so no real host/viewer pair has disagreed yet. **Nothing incorrect is running today.** What is absent is any protection if that changes, on a cross-origin boundary where messages arrive from a page we do not control.

## No policy invented here

Whether a mismatch should reject, warn, or negotiate is @louistrue's call. This PR pins the **current** behaviour at all three call sites so that decision can be made against facts, and so whichever policy is chosen starts from tests that fail loudly rather than silently.

### One measurement worth having before deciding

Adding `version === PROTOCOL_VERSION` to the guard breaks **two pre-existing tests** as well as the three new ones:

```
× accepts a bare object whose only field is the discriminator
× accepts a source inherited from the prototype chain
```

Both construct envelopes with no `version`. So a strict check is **not purely additive** — it tightens what counts as a well-formed envelope, and those two fixtures would need revisiting. Better to know that up front than to discover it mid-implementation.

## The rest of the boundary is genuinely well covered

Checked rather than assumed, and reported plainly since a clean result on a trust boundary is worth as much as a finding:

- origin allowlist — fail-open default, **exact match** not prefix/suffix, non-latching on reject
- envelope shape rejection — null, string, number, missing source, foreign source
- unknown command → `UNKNOWN_COMMAND` for request/response, silent drop for fire-and-forget
- `GET_SCREENSHOT` explicitly `NOT_IMPLEMENTED` rather than a silently-succeeding stub — exactly the "matches but yields nothing" shape that produced four live bugs elsewhere this week, and here it is handled correctly
- INIT token guard tested in both directions

Every reject path there is already asserted. The version guard was the only gap.

## Verification

Three sibling mutations, one per call site, each applied by exact-substring replacement with an asserted replacement count of 1 and restored by file copy:

| call site | new tests die? | others |
|---|---|---|
| `embed-protocol` `isEmbedMessage` | yes (2) | 18 pass |
| `viewer-embed` bridge handler | yes (3) | 115 pass |
| `embed-sdk` `onMessage` | yes (1) | 68 pass |

All three died as predicted, so the new tests genuinely exercise `isEmbedMessage` through each consumer rather than being satisfied by something downstream.

**embed-protocol 20 → 22, embed-sdk 68 → 69, viewer-embed 115 → 118**, all passing. `git diff` on `packages/embed-protocol/src/index.ts` is empty — source untouched.

Test-only; no changeset.

*(Note: `viewer-embed`'s typecheck fails in a clean worktree with cascading `TS2307: Cannot find module '@ifc-lite/extensions'` across `apps/viewer/src/**` because that package isn't built there. Pre-existing and unrelated — none of the errors touch `bridge/handler.ts`.)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage documenting current handling of messages with older, newer, or missing protocol versions.
  * Confirmed validly sourced commands continue to execute and reach listeners despite version differences.
  * Expanded validation tests to verify source-based message acceptance behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->