### PR TITLE
fix(viewer): role-gate quantity edits in a shared collab session

### DIFF
--- a/apps/viewer/src/store/slices/mutationSlice.collab-gate.test.ts
+++ b/apps/viewer/src/store/slices/mutationSlice.collab-gate.test.ts
@@ -28,6 +28,8 @@ function makeViewSpy() {
       deleteProperty: (..._a: unknown[]) => { calls.push('deleteProperty'); return mutation; },
       setAttribute: (..._a: unknown[]) => { calls.push('setAttribute'); return mutation; },
       createPropertySet: (..._a: unknown[]) => { calls.push('createPropertySet'); return mutation; },
+      setQuantity: (..._a: unknown[]) => { calls.push('setQuantity'); return mutation; },
+      createQuantitySet: (..._a: unknown[]) => { calls.push('createQuantitySet'); return mutation; },
     },
   };
 }
@@ -89,5 +91,56 @@ describe('mutationSlice — collab role gate on property mutations', () => {
     assert.notStrictEqual(s.setAttribute('m1', 1, 'Name', 'x'), null);
     assert.deepStrictEqual(spy.calls, ['setProperty', 'setAttribute']);
     assert.ok((state() as unknown as { dirtyModels: Set<string> }).dirtyModels.has('m1'));
+  });
+});
+
+/**
+ * `setQuantity` / `createQuantitySet` carried NEITHER the `canCollabEdit()`
+ * gate NOR a `mirror*` call, unlike every other mutation kind above.
+ *
+ * The gate half is fixed: they now reject a viewer-role writer like their
+ * siblings. `setProperty`'s own comment gives the reason -- a viewer-role user
+ * must not accumulate local-only edits that silently never reach the room.
+ *
+ * The MIRROR half is NOT fixed and is pinned as a known gap. There is no
+ * `mirrorQuantityEdit` in this codebase at all, and `attachRemoteApply`'s
+ * inbound observer has no branch for the CRDT's `quantities` map key (only
+ * `attributes` and `psets`), even though `packages/collab`'s schema defines
+ * `ENTITY_KEY.QUANTITIES` with working `setQuantityValue`/`deleteQuantityValue`
+ * accessors. So an EDITOR's quantity edit still reaches no peer: no error, no
+ * warning, nothing observable short of comparing Qtos across peers by hand.
+ *
+ * Wiring that is a multi-file feature (bridge `CollabDocApi` +
+ * `RemoteApplyHandlers` + `attachRemoteApply` + `collabSlice` + this slice),
+ * so it is documented here rather than half-built. The second test pins the
+ * current no-mirror behaviour so closing the gap is a visible, deliberate
+ * diff against this file.
+ */
+describe('mutationSlice -- quantity mutations are role-gated; mirroring is a known gap', () => {
+  it('viewer role: quantity writes are rejected, like every other mutation kind', () => {
+    const { spy, state } = buildSlice(false);
+    const s = state();
+    assert.strictEqual(
+      s.setQuantity('m1', 1, 'Qto_WallBaseQuantities', 'Length', 3),
+      null,
+      'a viewer role must not commit a quantity edit',
+    );
+    assert.strictEqual(
+      s.createQuantitySet('m1', 1, 'Qto_New', [{ name: 'Length', value: 3, quantityType: 0 }]),
+      null,
+    );
+    // The underlying view must never be touched: returning null while still
+    // having written locally would be the same divergence, just hidden.
+    assert.deepStrictEqual(spy.calls, []);
+  });
+
+  it('editor role: quantity writes commit locally but still mirror nothing (known gap)', () => {
+    const { spy, state } = buildSlice(true);
+    const s = state();
+    assert.notStrictEqual(s.setQuantity('m1', 1, 'Qto_WallBaseQuantities', 'Length', 3), null);
+    assert.deepStrictEqual(spy.calls, ['setQuantity'], 'local view IS written');
+    // No `mirror*` action exists for quantities to call, so there is nothing
+    // to assert was invoked. That absence IS the gap: a remote peer never
+    // sees this edit.
   });
 });

--- a/apps/viewer/src/store/slices/mutationSlice.ts
+++ b/apps/viewer/src/store/slices/mutationSlice.ts
@@ -1320,6 +1320,19 @@ export const createMutationSlice: StateCreator<
 
   // Quantity Mutations
   setQuantity: (modelId, entityId, qsetName, quantName, value, quantityType = QuantityType.Count, unit) => {
+    // Same gate as setProperty/setAttribute/createPropertySet, for the reason
+    // spelled out there: a viewer-role user must not accumulate local-only
+    // edits that silently never reach the room. This was missing here, so a
+    // read-only participant's quantity edits committed locally, marked the
+    // model dirty and entered their undo stack.
+    //
+    // NOTE the sync half of that comment is NOT yet true for quantities even
+    // for an editor: there is no `mirrorQuantityEdit`, and `attachRemoteApply`
+    // has no `quantities` arm, so a quantity edit still reaches no peer. That
+    // is a separate, larger gap — see the tests below and the PR discussion.
+    // Gating here at least stops an unauthorised writer, and stops the local
+    // state diverging further than it already does.
+    if (!get().canCollabEdit()) return null;
     const view = get().mutationViews.get(modelId);
     if (!view) return null;
 
@@ -1348,6 +1361,8 @@ export const createMutationSlice: StateCreator<
   },
 
   createQuantitySet: (modelId, entityId, qsetName, quantities) => {
+    // See setQuantity above — same omission, same reason.
+    if (!get().canCollabEdit()) return null;
     const view = get().mutationViews.get(modelId);
     if (!view) return null;
 


### PR DESCRIPTION
`setQuantity` and `createQuantitySet` were the **only** mutation kinds with no `canCollabEdit()` gate. `setProperty`, `deleteProperty`, `setAttribute` and `createPropertySet` all have one, and `setProperty`'s own comment states why:

> a viewer-role user must not build up local-only edits that silently never reach the room

That is exactly what quantities did. A read-only participant's quantity edit committed to the local view, marked the model dirty, and entered their undo stack — while their role means it could never sync.

**Severity: LIVE.** Both now gate, and the test asserts the underlying view is not touched either — returning `null` while still writing locally would be the same divergence, just hidden.

## Deliberately NOT fixed, and pinned instead

**Quantity edits reach no peer even for an editor.**

There is no `mirrorQuantityEdit` anywhere in the codebase, and `attachRemoteApply`'s inbound observer branches only on `attributes` and `psets` — it has no arm for the CRDT's `quantities` key, despite `packages/collab`'s schema defining `ENTITY_KEY.QUANTITIES` with working `setQuantityValue` / `deleteQuantityValue` accessors.

So in a shared room an editor changes a Length or Area, sees it locally, and **no peer ever does** — no error, no warning, nothing observable short of comparing Qtos by hand.

Closing that is a multi-file feature: the bridge's `CollabDocApi` and `RemoteApplyHandlers`, `attachRemoteApply`, `collabSlice` and this slice. Half-building it would be worse than documenting it, so the second test pins the current no-mirror behaviour and closing the gap shows up as a deliberate diff against this file.

@louistrue — flagging the split explicitly: the gate is a one-line omission with unambiguous precedent, so I fixed it. The mirror is a feature with a design surface, so it is yours to scope.

## The op-kind inventory this came from

Every kind `attachRemoteApply` can receive, and whether it produces output or is recorded as skipped:

| kind | output? | recorded when skipped? |
|---|---|---|
| `entities` root delete | yes → `onEntityDelete` | — |
| `attributes` write | yes → `onAttribute` / `onPlacement` | — |
| **`attributes` delete** | **no** — `continue`, no handler exists | **no** |
| `psets` property write / delete | yes | — |
| `psets` wholesale add / delete | yes | — |
| **`quantities`** (any) | **no arm at all** | **no** |
| unresolved `entityForPath` | no-op | no |

The two "no/no" rows are the same match-but-yield-nothing shape as #2263, #2277 and #2278.

**The attribute-delete row is reported but not claimed as live**, because I checked whether anything can produce it: `deleteAttribute` has no caller that writes to a live room — the bridge's `CollabDocApi` does not expose it, and the only other caller (`packages/mcp`'s layer-store) operates on offline in-memory draft docs with no websocket wiring. Reachable if a writer is ever added; not today.

## Also checked, came back clean

- `step-seed.ts` drops null/undefined property values from the seed — a structural consequence of the flat-attribute encoding, consistent with the rest of this pipeline.
- `geometry-sync.ts` counts empty meshes explicitly (`skippedEmpty`) and warns — empty vs absent correctly distinguished, each with its own counter.
- `onPsetDelete`'s empty-vs-absent case is already handled and documented in-line: Yjs detaches the map before the delete event, so property names are genuinely unrecoverable and it correctly drops the whole set rather than guessing.
- `pathForEntity` / `entityForPath` share one `entityMaps(store)` cache — no paired-key divergence.

## Verification

- Reverting the `setQuantity` gate fails **exactly** the new viewer-role test.
- Two sibling controls in the bridge died as expected — the `txn.local` guard and the unresolved-path guard — confirming the harness reaches these files and the survivals above are genuine gaps.
- **3085 passing / 0 failing / 2 pre-existing skips across 673 suites.** `tsc --noEmit` clean.

`apps/viewer` is `private: true`, so no changeset.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Restricted quantity updates to users with editing permissions.
  - Prevented unauthorized quantity changes from modifying local viewer state.
  - Confirmed authorized quantity edits continue to apply locally without unintended collaboration mirroring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->