### PR TITLE
fix(mcp): make mutation_undo actually revert the overlay

### DIFF
--- a/.changeset/mcp-mutation-undo-actually-undoes.md
+++ b/.changeset/mcp-mutation-undo-actually-undoes.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/mcp": patch
+---
+
+Fix `mutation_undo` reporting mutations as reverted while leaving the overlay untouched. It only trimmed `MutablePropertyView`'s append-only mutation-history array (documented in `@ifc-lite/mutations` as *not* poppable for undo) and never reverted the actual property/attribute/entity overlay state, so a caller that undid an edit and then read the entity back still saw the edited value — the tool claimed success on an operation that did nothing. `mutation_undo` now applies the inverse of each reverted mutation (property set/create/delete, attribute set, entity create/delete) to the live overlay, mirroring the viewer's undo-stack dispatch.
+
+Also fixes `entity_set_attribute` never recording the attribute's prior value in its mutation record, so any consumer of `Mutation.oldValue` (including the undo above) restored to an empty value instead of the true original.

--- a/packages/mcp/src/read-after-write.test.ts
+++ b/packages/mcp/src/read-after-write.test.ts
@@ -381,6 +381,88 @@ describe('model_info and count_entities after an edit', () => {
   }, 30_000);
 });
 
+describe('mutation_undo', () => {
+  it('reverts the value a read-back sees, not just the history count', async () => {
+    await session();
+    await call('entity_set_attribute', {
+      global_id: guid('WALA'), attribute: 'Name', value: 'Wall A renamed',
+    });
+    const edited = await structured<EntityShape>('get_entity', { global_id: guid('WALA') });
+    expect(edited.name).toBe('Wall A renamed');
+
+    const undone = await structured<{ undone: number }>('mutation_undo', { n: 1 });
+    expect(undone.undone).toBe(1);
+
+    // The tool reported the mutation undone; a caller relying on that has to
+    // see the overlay actually revert, not just a shorter history list.
+    const restored = await structured<EntityShape>('get_entity', { global_id: guid('WALA') });
+    expect(restored.name).toBe('Wall A');
+  }, 30_000);
+
+  it('reverts an UPDATE_PROPERTY edit to the value it overwrote', async () => {
+    await session();
+    await call('entity_set_property', {
+      global_id: guid('WALA'), pset: 'Pset_WallCommon', name: 'IsExternal', value: false,
+    });
+    await call('mutation_undo', { n: 1 });
+    const entity = await structured<EntityShape>('get_entity', {
+      global_id: guid('WALA'), include: ['properties'],
+    });
+    expect(propertyValue(entity, 'Pset_WallCommon', 'IsExternal')).toBe(true);
+  }, 30_000);
+
+  it('reverts a brand-new property (CREATE_PROPERTY) by removing it, not blanking it', async () => {
+    await session();
+    await call('entity_set_property', {
+      global_id: guid('WALA'), pset: 'Pset_Custom', name: 'Rating', value: 'A',
+    });
+    let entity = await structured<EntityShape>('get_entity', {
+      global_id: guid('WALA'), include: ['properties'],
+    });
+    expect(propertyValue(entity, 'Pset_Custom', 'Rating')).toBe('A');
+
+    await call('mutation_undo', { n: 1 });
+    entity = await structured<EntityShape>('get_entity', {
+      global_id: guid('WALA'), include: ['properties'],
+    });
+    expect(entity.properties?.find((p) => p.name === 'Pset_Custom')).toBeUndefined();
+  }, 30_000);
+
+  it('reverts a CREATE_ENTITY by making the entity unreachable again', async () => {
+    await session();
+    const created = await structured<{ expressId: number }>('entity_create', {
+      type: 'IfcWall',
+      attributes: [`'${guid('WALD')}'`, null, "'Wall D'"],
+    });
+    await call('mutation_undo', { n: 1 });
+    await expect(async () => tool('get_entity').handler({ express_id: created.expressId }, ctx))
+      .rejects.toThrow();
+  }, 30_000);
+
+  it('reverts a DELETE_ENTITY by making the base entity reachable again', async () => {
+    await session();
+    await call('entity_delete', { global_id: guid('WALB') });
+    await expect(async () => tool('get_entity').handler({ global_id: guid('WALB') }, ctx))
+      .rejects.toThrow();
+
+    await call('mutation_undo', { n: 1 });
+    const restored = await structured<EntityShape>('get_entity', { global_id: guid('WALB') });
+    expect(restored.name).toBe('Wall B');
+  }, 30_000);
+
+  it('undoes N mutations most-recent-first, unwinding a double edit to the original value', async () => {
+    await session();
+    await call('entity_set_attribute', { global_id: guid('WALA'), attribute: 'Name', value: 'First edit' });
+    await call('entity_set_attribute', { global_id: guid('WALA'), attribute: 'Name', value: 'Second edit' });
+
+    const undone = await structured<{ undone: number }>('mutation_undo', { n: 2 });
+    expect(undone.undone).toBe(2);
+
+    const restored = await structured<EntityShape>('get_entity', { global_id: guid('WALA') });
+    expect(restored.name).toBe('Wall A');
+  }, 30_000);
+});
+
 describe('addressing a created entity in the same session', () => {
   it('lets a batch create an entity and then set a property on it by GlobalId', async () => {
     await session();

--- a/packages/mcp/src/tools/mutate.ts
+++ b/packages/mcp/src/tools/mutate.ts
@@ -158,7 +158,16 @@ const entitySetAttribute: Tool = {
     const view = backend.getMutationView();
     if (!view) throw new Error('Mutation view not available');
     const expressId = resolveExpressId(m, input);
-    view.setAttribute(expressId, input.attribute as string, input.value as string);
+    const attribute = input.attribute as string;
+    // Capture the value as it stood right before this write so the mutation
+    // record's `oldValue` is the true prior value — `mutation_undo` (and any
+    // other reader of `Mutation.oldValue`) restores from this field, and
+    // `setAttribute` does not derive it itself (unlike `setProperty`).
+    const before = m.bim.attributes({ modelId: m.id, expressId }).find((a) => a.name === attribute);
+    const oldValue = before !== undefined && before.value !== undefined && before.value !== null
+      ? String(before.value)
+      : undefined;
+    view.setAttribute(expressId, attribute, input.value as string, oldValue);
     return okResult(`Set ${input.attribute} on #${expressId}.`, { expressId, attribute: input.attribute, value: input.value });
   },
 };
@@ -300,9 +309,69 @@ const mutationDiff: Tool = {
   },
 };
 
+type MutationView = NonNullable<ReturnType<HeadlessLikeBackend['getMutationView']>>;
+
+/**
+ * Apply the inverse of one mutation-history entry to the live overlay.
+ *
+ * `MutablePropertyView.mutationHistory` is deliberately append-only (see the
+ * package's own docs on `getMutations()` / `hasChanges()`) — popping it, on
+ * its own, reverts nothing. This mirrors the inverse-mutation dispatch the
+ * viewer's undo stack applies (`apps/viewer/src/store/slices/mutationSlice.ts`),
+ * scoped to the mutation types this package's own tools can produce.
+ * `skipHistory: true` throughout so reverting a mutation does not itself
+ * grow the history mutation_undo just trimmed it from.
+ */
+function revertMutation(view: MutationView, mutation: Mutation): void {
+  switch (mutation.type) {
+    case 'CREATE_PROPERTY':
+      if (mutation.psetName && mutation.propName) {
+        view.deleteProperty(mutation.entityId, mutation.psetName, mutation.propName, true);
+      }
+      return;
+    case 'UPDATE_PROPERTY':
+    case 'DELETE_PROPERTY':
+      if (mutation.psetName && mutation.propName && mutation.oldValue !== undefined) {
+        view.setProperty(
+          mutation.entityId,
+          mutation.psetName,
+          mutation.propName,
+          mutation.oldValue,
+          mutation.valueType,
+          undefined,
+          true,
+        );
+      }
+      return;
+    case 'UPDATE_ATTRIBUTE':
+      if (mutation.attributeName) {
+        if (mutation.oldValue !== undefined && mutation.oldValue !== null) {
+          view.setAttribute(mutation.entityId, mutation.attributeName, String(mutation.oldValue), undefined, true);
+        } else {
+          view.removeAttributeMutation(mutation.entityId, mutation.attributeName);
+        }
+      }
+      return;
+    case 'CREATE_ENTITY':
+      view.deleteEntity(mutation.entityId);
+      return;
+    case 'DELETE_ENTITY':
+      view.restoreFromTombstone(mutation.entityId);
+      return;
+    default:
+      // Types this package's tools never emit (quantities, positional attrs,
+      // retype) — surfaced rather than silently dropped, so a future tool
+      // that starts emitting one of these does not get a no-op undo.
+      throw new ToolExecutionError({
+        code: ToolErrorCode.INVALID_INPUT,
+        message: `mutation_undo: '${mutation.type}' mutations are not revertible by this tool.`,
+      });
+  }
+}
+
 const mutationUndo: Tool = {
   name: 'mutation_undo',
-  description: 'Revert the last N pending mutations on this session. v0.1: best-effort; rebuilds the mutation view when N exceeds history length.',
+  description: 'Revert the last N pending mutations on this session, restoring the overlay to what it held before them — not just trimming the mutation log.',
   scope: 'mutate',
   inputSchema: {
     type: 'object',
@@ -320,6 +389,13 @@ const mutationUndo: Tool = {
     const n = (input.n as number | undefined) ?? 1;
     const history = (view as unknown as { mutationHistory?: Mutation[] }).mutationHistory ?? [];
     const undone = Math.min(n, history.length);
+    const toUndo = history.slice(history.length - undone);
+    // Reverse chronological order — most recent mutation reverts first, same
+    // as an undo stack, so an entity edited twice unwinds to its
+    // second-to-last state before its first.
+    for (let i = toUndo.length - 1; i >= 0; i -= 1) {
+      revertMutation(view, toUndo[i]);
+    }
     history.splice(history.length - undone, undone);
     return okResult(`Undone ${undone} mutation(s).`, { undone });
   },


### PR DESCRIPTION
`mutation_undo` returned `{undone: N}` while changing nothing.

It only spliced entries off `MutablePropertyView.mutationHistory` — which `@ifc-lite/mutations` documents as **append-only**, *"undo does not pop history"* (`mutable-property-view.ts:1551`) — and never reverted the property/attribute/entity overlay. A caller that undid an edit and read the entity back still saw the edited value.

Observed against **committed** code, not an injected mutation:

```
FAIL  mutation_undo > reverts the value a read-back sees, not just the history count
AssertionError: expected 'Wall A renamed' to be 'Wall A'
```

**Severity: LIVE.**

This is the match-but-yield-nothing shape behind #2263, #2277, #2278 and #2296 — and it is worse on an MCP tool than in library code: the caller is a model, it receives an explicit success, and it acts on it. There is no human reading a diff to notice the edit never reverted.

## The fix

`revertMutation` applies the inverse per type — `CREATE_PROPERTY`, `UPDATE_PROPERTY`, `DELETE_PROPERTY`, `UPDATE_ATTRIBUTE`, `CREATE_ENTITY`, `DELETE_ENTITY` — mirroring the dispatch the viewer's undo stack already ships rather than inventing a second convention.

- Reverts run **most-recent-first**, so an entity edited twice unwinds in order.
- Every revert passes `skipHistory: true`, so reverting does not re-grow the history it was just trimmed from.
- Any type **outside** that set throws `INVALID_INPUT` instead of returning success. A future tool that starts emitting quantities or retypes gets a loud error rather than the same silent no-op this PR fixes — the failure mode should not be reintroducible by adding a tool.

## A second defect on the same path

`entity_set_attribute` called `view.setAttribute(expressId, attr, value)` **without `oldValue`**, so every `UPDATE_ATTRIBUTE` recorded `oldValue: null`. Even a correct undo would have restored attributes to *empty* rather than their prior value — and `mutation_diff`'s `previousValue` was wrong for attributes for the same reason. It now reads the current value via `m.bim.attributes(...)` before writing.

Worth noting the two defects would have masked each other: fixing undo alone would have produced confidently-wrong restores instead of no-ops.

## Signatures verified, not assumed

Three of these calls end in positional booleans, which is exactly where a plausible-looking fix goes wrong silently. Checked against `mutable-property-view.ts`:

| call | signature |
|---|---|
| `deleteProperty` | 4th arg is `skipHistory` |
| `setProperty` | 7th is `skipHistory` (6th is `unit`, passed `undefined`) |
| `setAttribute` | 4th is `oldValue`, 5th is `skipHistory` |

All three land where intended.

## Tests

Six new tests, one per revertible type plus a two-step unwind — including that `CREATE_PROPERTY` reverts by **removing** the property rather than blanking it, which a weaker assertion would miss. **All six fail against the committed code.**

`@ifc-lite/mcp` 236 → **242 passing across 23 files**. `tsc --noEmit` clean. Patch changeset included.

## Also reviewed, found sound

`layer.ts` (`draft_apply_ops`' switch is exhaustive against its own enum, all four cases wired), `layer-ops.ts`, `layer-store.ts`, `layer-access.ts`, `layer-review.ts` (`add_review_feedback`'s empty `decisions` is schema-blocked by `minItems: 1`), and `validate.ts`. One genuinely untested empty-argument path noted rather than fixed: `mutation_batch`'s empty `operations` array is blocked by schema, so it is unreachable through the tool interface.
