### PR TITLE
fix(viewer): stop a failed georef reload leaving a half-rebuilt federation

### DIFF
--- a/apps/viewer/src/components/viewer/properties/GeoreferencingPanel.tsx
+++ b/apps/viewer/src/components/viewer/properties/GeoreferencingPanel.tsx
@@ -443,6 +443,7 @@ export function GeoreferencingPanel({ georef, modelId, enableEditing, schemaVers
 
     try {
       clearAllModels();
+      const failed: string[] = [];
       for (const model of snapshot) {
         const sourceFile = model.sourceFile;
         if (!sourceFile) continue;
@@ -454,14 +455,30 @@ export function GeoreferencingPanel({ georef, modelId, enableEditing, schemaVers
           collapsed: model.collapsed,
         });
         if (!reloadedModelId) {
-          throw new Error(`Failed to reload ${model.name}`);
+          // Do NOT throw: `clearAllModels()` has already run, so an early exit
+          // leaves the federation half-rebuilt — every model after this one is
+          // simply gone, and the only feedback is a "reload failed" toast that
+          // says nothing about how many survived. The sibling rebuild in
+          // `useFileCommands.tsx:317-320` avoids this by validating every read
+          // BEFORE clearing and refusing the whole refresh; that is not
+          // available here, because a model's failure is only observable once
+          // `addModel` has tried to load it. So keep going, reload everything
+          // that can be reloaded, and name what could not.
+          failed.push(model.name);
+          continue;
         }
         if (model.visible === false) {
           useViewerStore.getState().setModelVisibility(model.id, false);
         }
       }
       setShowReloadPrompt(false);
-      toast.success('Reloaded models for edited georeferencing');
+      if (failed.length > 0) {
+        toast.error(
+          `Reloaded ${snapshot.length - failed.length} of ${snapshot.length} models. Could not reload: ${failed.join(', ')}.`,
+        );
+      } else {
+        toast.success('Reloaded models for edited georeferencing');
+      }
     } catch (error) {
       toast.error(error instanceof Error ? error.message : 'Reload failed');
     }


### PR DESCRIPTION
`reloadModelsForAlignment` calls `clearAllModels()` and then re-adds each model in a loop. A failed `addModel` **threw out of that loop**, so every model *after* the failure was simply gone — the federation silently shrank, and the only feedback was a `Failed to reload <name>` toast that said nothing about how many survived.

**Severity: LIVE**, user-visible. Reload 5 models, have the third fail, and you are left with 2 — with a message that reads like a single-model problem.

## The sibling path does not have this bug, and the difference is instructive

`useFileCommands.tsx`'s federation refresh validates **every re-read before** calling `clearAllModels()`, and refuses the whole refresh if any failed:

```ts
// A federation rebuild starts with clearAllModels(), so a partial read
// would silently drop every failed model from the scene. Refuse instead:
// the user keeps the loaded (stale) federation and gets told why.
if (targets.length > 1 && failedNames.length > 0) { … return; }
```

The authors clearly hit this hazard once and hardened that path. The georeferencing path never got the same treatment — the same *one-path-hardened, its-sibling-not* shape as #2073 and #2258, which is why it was worth reading the two rebuild paths side by side rather than either alone.

**That fix is not portable here.** `useFileCommands` can pre-validate because re-reading bytes either works or doesn't, before anything is cleared. Here a model's failure is only observable once `addModel` has already tried to load it — by which point `clearAllModels()` has run. So pre-validation isn't an option and the loop has to degrade gracefully instead.

## The fix

Continue rather than throw. Everything that can be reloaded is, and the toast names both the count and the casualties:

> Reloaded 3 of 5 models. Could not reload: X, Y.

rather than a bare failure that hides the shrinkage. The `catch` is kept for genuinely unexpected throws.

## Verification

**3083 passing / 0 failing / 2 pre-existing skips across 672 suites.** `tsc --noEmit` exit 0.

One note worth recording: the typecheck initially reported `Cannot find module '@ifc-lite/solar'` — the partial-build trap, not a real error. Building that dependency first cleared it. Reporting a red typecheck as "unrelated" without doing that would have been the wrong call, since it is exactly how a genuine error hides.

`apps/viewer` is `private: true`, so no changeset.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Model alignment reloads now continue even when individual models fail.
  * Added error notifications summarizing successful and unsuccessful reloads, including affected model names.
  * Successfully reloaded models remain visible, with a success notification shown when all reloads complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->