### PR TITLE
fix(viewer): give loadFromCache the staleness check loadFromServer has

### DIFF
--- a/apps/viewer/src/hooks/cacheTier.test.ts
+++ b/apps/viewer/src/hooks/cacheTier.test.ts
@@ -5,7 +5,13 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 
-import { classifyCacheTier, planCacheWrite, decideMeshOnlyCacheHit, type CacheTierOptions } from './cacheTier.js';
+import {
+  classifyCacheTier,
+  planCacheWrite,
+  decideMeshOnlyCacheHit,
+  decideCacheLoadOutcome,
+  type CacheTierOptions,
+} from './cacheTier.js';
 
 // Mirror the production constants (ifcConfig.ts). Not imported: ifcConfig reads
 // import.meta.env at module load and can't be evaluated under `node:test`.
@@ -111,5 +117,48 @@ describe('decideMeshOnlyCacheHit', () => {
     assert.equal(decideMeshOnlyCacheHit({ storedMtime: 0, freshMtime: 1000, hasFullHash: false }), 'miss');
     assert.equal(decideMeshOnlyCacheHit({ freshMtime: 1000, hasFullHash: true }), 'serve');
     assert.equal(decideMeshOnlyCacheHit({ hasFullHash: false }), 'miss');
+  });
+});
+
+describe('decideCacheLoadOutcome', () => {
+  it('SERVES a successful hit that still owns the active model slot', () => {
+    assert.equal(
+      decideCacheLoadOutcome({ loadSucceeded: true, isStale: false }),
+      'serve',
+    );
+  });
+
+  it('reports MISS (fall through to server/WASM) for an ordinary failed hit', () => {
+    // The bounding control for the whole fix: a real cache miss must keep
+    // falling through to a fresh parse. An over-eager early return here would
+    // silently disable caching's fallback and leave the model unloaded.
+    assert.equal(
+      decideCacheLoadOutcome({ loadSucceeded: false, isStale: false }),
+      'miss',
+    );
+  });
+
+  it('reports STALE — distinct from a miss — when the load was superseded', () => {
+    // `loadFromCache` returns the same `success: false` for a superseded load
+    // as for a miss. Collapsing the two sends the superseded load into a full
+    // server/WASM reparse of the OLD file while the newer load owns the slot,
+    // so the two MUST NOT map to the same outcome.
+    assert.equal(
+      decideCacheLoadOutcome({ loadSucceeded: false, isStale: true }),
+      'stale',
+    );
+    assert.notEqual(
+      decideCacheLoadOutcome({ loadSucceeded: false, isStale: true }),
+      decideCacheLoadOutcome({ loadSucceeded: false, isStale: false }),
+    );
+  });
+
+  it('STALE dominates success: a superseded load never finalizes either', () => {
+    // A hit can succeed and *then* be superseded while it resolves. Finalizing
+    // it would write the old file's store into the new model's slot.
+    assert.equal(
+      decideCacheLoadOutcome({ loadSucceeded: true, isStale: true }),
+      'stale',
+    );
   });
 });

--- a/apps/viewer/src/hooks/cacheTier.ts
+++ b/apps/viewer/src/hooks/cacheTier.ts
@@ -106,3 +106,36 @@ export function decideMeshOnlyCacheHit(opts: {
   if (!mtimeKnown && !hasFullHash) return 'miss';
   return 'serve';
 }
+
+/**
+ * What the loader should do after `loadFromCache` resolves.
+ *
+ * `loadFromCache` returns the SAME `{ success: false }` for two very different
+ * situations — an ordinary cache miss (corrupt/absent entry: reparse) and a
+ * SUPERSEDED load (a newer file already owns the active model slot: stop). A
+ * caller that only branches on `success` therefore treats supersession as a
+ * miss and proceeds to a full server/WASM reparse of the OLD file while the
+ * newer load is painting — the same active-slot race the staleness guards
+ * inside `loadFromCache` exist to close, just moved one step later and made far
+ * more expensive. So the staleness re-check belongs at the call site too, and
+ * this function is where the three outcomes are named:
+ *   - `stale`: superseded — return immediately, write nothing, reparse nothing;
+ *   - `serve`: a good hit — finalize the model from the cache;
+ *   - `miss`: no usable entry — fall through to the server/WASM path as before.
+ *
+ * Staleness DOMINATES success: a load that succeeded but was superseded while
+ * it resolved must not finalize either, or the finalize writes the old file's
+ * store into the new model's slot.
+ *
+ * Pure and injected (not reading `loadSessionRef` itself) for the same reason
+ * as the helpers above: it stays node-testable without importing the loader.
+ */
+export function decideCacheLoadOutcome(opts: {
+  /** Did `loadFromCache` report a successful hit? */
+  loadSucceeded: boolean;
+  /** Has a newer load taken the active model slot in the meantime? */
+  isStale: boolean;
+}): 'serve' | 'stale' | 'miss' {
+  if (opts.isStale) return 'stale';
+  return opts.loadSucceeded ? 'serve' : 'miss';
+}

--- a/apps/viewer/src/hooks/useIfcCache.staleness.test.tsx
+++ b/apps/viewer/src/hooks/useIfcCache.staleness.test.tsx
@@ -1,0 +1,513 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `loadFromCache` must never write into the ACTIVE model slot once a newer load
+ * owns it (PR #2301).
+ *
+ * The window is real and wide: the caller awaits `getCached` (IndexedDB), then
+ * this function awaits the Blob materialization, `reader.read`, and — worst —
+ * one `readChunk` PLUS an event-loop yield per geometry chunk. Anything the
+ * function writes after those awaits (progress, the streaming flag, geometry
+ * batches, instanced shards, the data store) lands in whatever model is active
+ * *at that moment*, which for a superseded load is the file the user just
+ * opened. The symptom is the new model blanking and then repopulating with the
+ * previous file's geometry and properties.
+ *
+ * These tests drive the real function against a real multi-chunk v13 cache
+ * buffer and flip the injected `isStale` predicate at each point where the
+ * window opens, asserting that NOTHING moved afterwards. The two controls at
+ * the bottom are what keep the fix honest: "guard everything" would satisfy
+ * every staleness assertion here by breaking cache loads outright, so a
+ * non-stale load must still write the full set, and a corrupt entry must still
+ * report the plain miss that sends the caller to a fresh parse.
+ */
+
+import '@/test/setup-dom.js';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import {
+  StringTable,
+  EntityTableBuilder,
+  PropertyTableBuilder,
+  QuantityTableBuilder,
+  RelationshipGraphBuilder,
+  RelationshipType,
+} from '@ifc-lite/data';
+import {
+  BinaryCacheWriter,
+  openGeometryChunksV13,
+  SectionType,
+  BinaryCacheReader,
+  type CacheDataStore,
+} from '@ifc-lite/cache';
+import type { MeshData, CoordinateInfo, GeometryResult } from '@ifc-lite/geometry';
+import { useViewerStore } from '@/store';
+import { useIfcCache, type CacheResult, type CacheLoadResult } from './useIfcCache.js';
+
+// ─── Fixture: a cache entry whose geometry spans SEVERAL chunks ──────────
+//
+// Chunking is spatial (a 32m grid cell per chunk, then a soft byte cap), so
+// three tiny meshes 1000m apart give three chunks for a few hundred bytes —
+// the cheap way to get the per-chunk `await` + yield the race needs. The
+// `chunks.length >= 3` assertion below pins that: if chunking ever changed and
+// collapsed these into one chunk, the between-chunks tests would silently stop
+// testing anything.
+
+function mesh(expressId: number, at: [number, number, number]): MeshData {
+  return {
+    expressId,
+    positions: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+    normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+    indices: new Uint32Array([0, 1, 2]),
+    color: [0.5, 0.25, 0.125, 1],
+    ifcType: 'IFCWALL',
+    geometryClass: 0,
+    origin: at,
+  };
+}
+
+const MESHES: MeshData[] = [
+  mesh(4, [0, 0, 0]),
+  mesh(5, [1000, 0, 0]),
+  mesh(6, [2000, 0, 0]),
+];
+
+const COORD_INFO: CoordinateInfo = {
+  originShift: { x: 0, y: 0, z: 0 },
+  originalBounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 2001, y: 1, z: 0 } },
+  shiftedBounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 2001, y: 1, z: 0 } },
+  hasLargeCoordinates: false,
+};
+
+const SOURCE_TEXT = [
+  'ISO-10303-21;',
+  'HEADER;',
+  'ENDSEC;',
+  'DATA;',
+  "#1=IFCPROJECT('guid-project');",
+  "#3=IFCBUILDING('guid-building');",
+  "#4=IFCWALL('guid-wall-1');",
+  "#5=IFCWALL('guid-wall-2');",
+  "#6=IFCWALL('guid-wall-3');",
+  'ENDSEC;',
+  'END-ISO-10303-21;',
+].join('\n');
+
+function buildCacheDataStore(): CacheDataStore {
+  const strings = new StringTable();
+  const entityBuilder = new EntityTableBuilder(10, strings);
+  entityBuilder.add(1, 'IfcProject', 'guid-project', 'Test Project', '', '', false, false);
+  entityBuilder.add(3, 'IfcBuilding', 'guid-building', 'Test Building', '', '', false, false);
+  entityBuilder.add(4, 'IfcWall', 'guid-wall-1', 'Wall 1', '', '', true, false);
+  entityBuilder.add(5, 'IfcWall', 'guid-wall-2', 'Wall 2', '', '', true, false);
+  entityBuilder.add(6, 'IfcWall', 'guid-wall-3', 'Wall 3', '', '', true, false);
+  const relationshipBuilder = new RelationshipGraphBuilder();
+  relationshipBuilder.addEdge(3, 4, RelationshipType.ContainsElements, 100);
+  relationshipBuilder.addEdge(3, 5, RelationshipType.ContainsElements, 101);
+  relationshipBuilder.addEdge(3, 6, RelationshipType.ContainsElements, 102);
+  return {
+    schema: 1,
+    entityCount: 5,
+    strings,
+    entities: entityBuilder.build(),
+    properties: new PropertyTableBuilder(strings).build(),
+    quantities: new QuantityTableBuilder(strings).build(),
+    relationships: relationshipBuilder.build(),
+  };
+}
+
+/** Opaque GPU-instancing payload — the loader only forwards the bytes. */
+const SHARD_BYTES = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]).buffer;
+
+/**
+ * Build the real v13 cache buffer the loader would have written.
+ *
+ * `withShards` defaults ON so the instanced-shard append (an active-slot write
+ * that sat BELOW the old post-loop guard) is actually exercised. The truncation
+ * fixtures turn it off: the shards section is written after the geometry one,
+ * so with shards present a truncated tail would corrupt the shards instead of
+ * a geometry chunk and never reach the chunk loop's error path.
+ */
+async function buildCacheEntry(
+  options: { withGeometry?: boolean; withShards?: boolean } = {},
+): Promise<CacheResult> {
+  const { withGeometry = true, withShards = true } = options;
+  const sourceBuffer = new TextEncoder().encode(SOURCE_TEXT).buffer as ArrayBuffer;
+  const buffer = await new BinaryCacheWriter().write(
+    buildCacheDataStore(),
+    withGeometry
+      ? {
+          meshes: MESHES,
+          totalVertices: 9,
+          totalTriangles: 3,
+          coordinateInfo: COORD_INFO,
+          instancedShards: withShards ? [SHARD_BYTES] : undefined,
+        }
+      : undefined,
+    sourceBuffer,
+    { includeGeometry: withGeometry, omitSourceHash: true },
+  );
+  return { buffer, sourceBuffer };
+}
+
+function openGeometry(buffer: ArrayBuffer) {
+  const header = new BinaryCacheReader().readHeader(buffer);
+  const section = header.sections.find((s) => s.type === SectionType.Geometry);
+  assert.ok(section, 'the fixture must carry a geometry section');
+  return { open: openGeometryChunksV13(buffer, section.offset, header.version), section };
+}
+
+/** How many geometry chunks the fixture entry actually holds. */
+function chunkCountOf(buffer: ArrayBuffer): number {
+  return openGeometry(buffer).open.chunks.length;
+}
+
+/**
+ * Cut the buffer through the MIDDLE of chunk 1 so chunk 0 decodes cleanly and
+ * chunk 1 throws. Chopping a fixed number of bytes off the tail is not enough:
+ * that only breaks the LAST chunk, which a superseded load never reaches (the
+ * in-loop guard breaks out first), so the error path would never run.
+ */
+function truncateThroughSecondChunk(buffer: ArrayBuffer): ArrayBuffer {
+  const { open, section } = openGeometry(buffer);
+  assert.ok(open.chunks.length >= 2, 'need at least two chunks to truncate the second');
+  const first = open.chunks[0];
+  const second = open.chunks[1];
+  assert.ok(
+    second.byteOffset >= first.byteOffset + first.byteLength,
+    'chunk 0 must be stored entirely before chunk 1',
+  );
+  return buffer.slice(0, section.offset + second.byteOffset + Math.ceil(second.byteLength / 2));
+}
+
+// ─── Harness: the real hook, rendered ────────────────────────────────────
+
+type LoadFromCache = ReturnType<typeof useIfcCache>['loadFromCache'];
+
+let root: Root | null = null;
+let loadFromCache: LoadFromCache | null = null;
+
+function Probe() {
+  loadFromCache = useIfcCache().loadFromCache;
+  return null;
+}
+
+/** Progress/streaming/geometry/shards/store — the whole active-slot surface. */
+function snapshot() {
+  const s = useViewerStore.getState();
+  return {
+    geometryMeshIds: (s.geometryResult?.meshes ?? []).map((m) => m.expressId),
+    geometryResultIsNull: s.geometryResult === null,
+    shards: s.pendingInstancedShards,
+    ifcDataStore: s.ifcDataStore,
+    progress: s.progress,
+    streaming: s.geometryStreamingActive,
+  };
+}
+
+/** The state a newer load has already painted into the active slot. */
+const NEWER_LOADS_GEOMETRY: GeometryResult = {
+  meshes: [mesh(999, [0, 0, 0])],
+  totalVertices: 3,
+  totalTriangles: 1,
+  coordinateInfo: COORD_INFO,
+};
+const NEWER_LOADS_PROGRESS = { phase: 'Newer load in flight', percent: 42 };
+
+/**
+ * Seed the store as the NEWER load left it — geometry painted, its own progress
+ * line up, its stream still open. Every staleness assertion below is then
+ * "this is untouched", which is exactly the user-visible contract: the file the
+ * user just opened must not flicker back to the previous one.
+ */
+function seedNewerLoadState() {
+  useViewerStore.setState({
+    geometryResult: NEWER_LOADS_GEOMETRY,
+    pendingInstancedShards: null,
+    ifcDataStore: null,
+    progress: { ...NEWER_LOADS_PROGRESS },
+    geometryStreamingActive: true,
+  });
+}
+
+/**
+ * The assertion for a load that started LIVE and was superseded mid-stream.
+ *
+ * Such a load legitimately owned the slot for its first two writes — the
+ * "Loading from cache" progress line and the `setGeometryResult(null)` reset,
+ * both of which happen before any await — so those two are not violations. What
+ * must not happen afterwards is everything the streamed section writes: further
+ * geometry, shards, the data store, the per-chunk / completion progress lines,
+ * and lowering the newer load's streaming flag.
+ */
+function assertStreamAbandoned(result: CacheLoadResult, expectedMeshCount: number) {
+  const after = snapshot();
+  assert.equal(result.success, false, 'a superseded load must not report success');
+  assert.equal(
+    after.geometryMeshIds.length,
+    expectedMeshCount,
+    'no further geometry chunk may be appended after supersession',
+  );
+  assert.equal(after.shards, null, 'instanced shards must not be appended');
+  assert.equal(after.ifcDataStore, null, 'the IFC data store must not be written');
+  assert.equal(after.streaming, true, "the newer load's streaming flag must not be lowered");
+  assert.equal(
+    after.progress?.phase,
+    'Loading from cache',
+    'no progress past the pre-supersession line may be posted',
+  );
+}
+
+function assertNothingMoved(before: ReturnType<typeof snapshot>, result: CacheLoadResult) {
+  const after = snapshot();
+  assert.equal(result.success, false, 'a superseded load must not report success');
+  assert.deepEqual(after.geometryMeshIds, before.geometryMeshIds, 'geometry must not move');
+  assert.equal(after.shards, before.shards, 'instanced shards must not move');
+  assert.equal(after.ifcDataStore, before.ifcDataStore, 'the IFC data store must not move');
+  assert.deepEqual(after.progress, before.progress, 'progress must not move');
+  assert.equal(after.streaming, before.streaming, 'the streaming flag must not move');
+}
+
+beforeEach(async () => {
+  loadFromCache = null;
+  seedNewerLoadState();
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root!.render(<Probe />);
+  });
+  assert.ok(loadFromCache, 'the hook must expose loadFromCache');
+});
+
+afterEach(async () => {
+  const current = root;
+  root = null;
+  if (current) await act(async () => current.unmount());
+  useViewerStore.setState({
+    geometryResult: null,
+    pendingInstancedShards: null,
+    ifcDataStore: null,
+    geometryStreamingActive: false,
+  });
+});
+
+async function load(entry: CacheResult, isStale: () => boolean): Promise<CacheLoadResult> {
+  let result!: CacheLoadResult;
+  await act(async () => {
+    result = await loadFromCache!(entry, 'old.ifc', 'model-old', undefined, undefined, isStale);
+  });
+  return result;
+}
+
+describe('loadFromCache — a superseded load writes nothing (#2301)', () => {
+  it('the fixture really does span several geometry chunks', async () => {
+    const entry = await buildCacheEntry();
+    assert.ok(
+      chunkCountOf(entry.buffer as ArrayBuffer) >= 3,
+      'the between-chunks tests are meaningless with a single chunk',
+    );
+  });
+
+  it('supersession BEFORE the first cache state write leaves everything alone', async () => {
+    // The caller awaited `getCached`; by the time this runs a newer load owns
+    // the slot. Not even the "Loading from cache" progress line may land.
+    const entry = await buildCacheEntry();
+    const before = snapshot();
+    const result = await load(entry, () => true);
+    assertNothingMoved(before, result);
+  });
+
+  it('supersession while the entry is being read never opens a stream', async () => {
+    // Flip the predicate on the very first progress write — i.e. after the
+    // entry guard passed but before the awaited `reader.read` resolves. The
+    // streaming flag is global active-model state, so a superseded load must
+    // not raise it: `useGeometryStreaming` would then be waiting on a stream
+    // that belongs to nobody.
+    const entry = await buildCacheEntry();
+    useViewerStore.setState({ geometryResult: null, geometryStreamingActive: false });
+    let stale = false;
+    const unsubscribe = useViewerStore.subscribe((s) => {
+      if (s.progress?.phase === 'Loading from cache') stale = true;
+    });
+    try {
+      const result = await load(entry, () => stale);
+      assert.ok(stale, 'the supersession must actually have been triggered');
+      const after = snapshot();
+      assert.equal(result.success, false, 'a superseded load must not report success');
+      assert.equal(after.streaming, false, 'a superseded load must not open a geometry stream');
+      assert.equal(after.geometryMeshIds.length, 0, 'no geometry may be appended');
+      assert.equal(after.shards, null, 'instanced shards must not be appended');
+      assert.equal(after.ifcDataStore, null, 'the IFC data store must not be written');
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  it('supersession BETWEEN geometry chunks stops the stream mid-flight', async () => {
+    // The window between raising the streaming flag and the first append holds
+    // no store write at all (it is one `await readChunk`), so there is no state
+    // change to hang the flip on — the predicate is driven by call ORDER
+    // instead: call 1 is the entry guard, call 2 the pre-stream guard, call 3
+    // the in-loop guard for chunk 0. Supersession therefore lands strictly
+    // inside the loop, and ONLY the in-loop guard can catch it.
+    //
+    // The premise is asserted, not assumed: the streaming flag starts down and
+    // must be UP afterwards, which proves the two earlier guards let this load
+    // through and the loop really was entered.
+    const entry = await buildCacheEntry();
+    useViewerStore.setState({ geometryResult: null, geometryStreamingActive: false });
+    let calls = 0;
+    const result = await load(entry, () => ++calls >= 3);
+    assert.ok(calls >= 3, 'the in-loop guard must have been reached');
+    // Not one chunk may land: the flip happens while `readChunk(0)` is still in
+    // flight, so the very first append is already superseded.
+    assertStreamAbandoned(result, 0);
+  });
+
+  it('supersession AFTER a chunk landed appends no further chunk, shards or store', async () => {
+    // The harsher interleaving: chunk 0 is already in the scene when the newer
+    // load takes over. The old load cannot un-append it, but it must append
+    // nothing MORE — no later chunk, no shards, no data store, no completion
+    // progress — and it must not lower the newer load's streaming flag.
+    const entry = await buildCacheEntry();
+    // Start from an empty scene so "chunk 0 landed" is unambiguous.
+    useViewerStore.setState({ geometryResult: null });
+    let stale = false;
+    const unsubscribe = useViewerStore.subscribe((s) => {
+      if (s.geometryResult && s.geometryResult.meshes.length > 0) stale = true;
+    });
+    let result: CacheLoadResult;
+    try {
+      result = await load(entry, () => stale);
+    } finally {
+      unsubscribe();
+    }
+    assert.ok(stale, 'at least one chunk must have landed before supersession');
+    // Each fixture mesh sits in its own spatial cell, so chunk 0 carries
+    // exactly one — and chunks 1..n must never follow it.
+    assertStreamAbandoned(result, 1);
+  });
+
+  it('a superseded load that then hits a corrupt chunk does not blank the new model', async () => {
+    // The partial-geometry rollback in the chunk-loop `catch` is an active-slot
+    // write too. On a superseded load the partial geometry in the store is the
+    // NEWER model's, so rolling it back would blank the file the user is
+    // looking at — and this load's own fallback reparse is abandoned anyway.
+    const entry = await buildCacheEntry({ withShards: false });
+    const truncated = truncateThroughSecondChunk(entry.buffer as ArrayBuffer);
+    useViewerStore.setState({ geometryResult: null });
+    let stale = false;
+    const unsubscribe = useViewerStore.subscribe((s) => {
+      if (s.geometryResult && s.geometryResult.meshes.length > 0) stale = true;
+    });
+    let result: CacheLoadResult;
+    try {
+      result = await load({ ...entry, buffer: truncated }, () => stale);
+    } finally {
+      unsubscribe();
+    }
+    assert.ok(stale, 'a chunk must have landed before the truncated one threw');
+    assert.equal(result.success, false);
+    // Whatever is in the slot at this point belongs to the load that owns it,
+    // not to this one — it must still be there.
+    assert.equal(
+      snapshot().geometryResultIsNull,
+      false,
+      'a superseded load must not roll back geometry it no longer owns',
+    );
+  });
+
+  it('supersession on a metadata-only entry does not write the store either', async () => {
+    // The no-geometry branch is the `else` of the geometry branch, so it sees
+    // NEITHER of the guards that branch carries — yet it still crosses the
+    // awaited `reader.read` (and the Blob materialization), and it writes both
+    // the data store and progress.
+    //
+    // Supersession has to land AFTER the entry guard or that guard catches it
+    // and this branch is never reached, so the predicate goes by call order:
+    // call 1 is the entry guard, call 2 is this branch's own guard. The
+    // "Loading from cache" progress line below is the premise check — it only
+    // exists if the entry guard let this load through.
+    const entry = await buildCacheEntry({ withGeometry: false });
+    useViewerStore.setState({ ifcDataStore: null });
+    let calls = 0;
+    const result = await load(entry, () => ++calls >= 2);
+    assert.ok(calls >= 2, "the no-geometry branch's guard must have been reached");
+    const after = snapshot();
+    assert.equal(result.success, false, 'a superseded load must not report success');
+    assert.equal(
+      after.progress?.phase,
+      'Loading from cache',
+      'the entry guard must have let this load through (otherwise this proves nothing)',
+    );
+    assert.equal(after.ifcDataStore, null, 'the IFC data store must not be written');
+  });
+});
+
+describe('loadFromCache — bounding controls: the fix must not disable caching', () => {
+  it('a NON-stale load still serves the entry and writes everything', async () => {
+    // Without this, "guard every write" would pass every test above by
+    // refusing to load from cache at all.
+    const entry = await buildCacheEntry();
+    useViewerStore.setState({ geometryResult: null, geometryStreamingActive: false });
+    const result = await load(entry, () => false);
+
+    assert.equal(result.success, true, 'a live load must serve the cache hit');
+    assert.equal(result.meshCount, MESHES.length);
+    assert.equal(result.totalVertices, 9);
+    assert.equal(result.totalTriangles, 3);
+
+    const after = snapshot();
+    assert.deepEqual(
+      [...after.geometryMeshIds].sort((a, b) => a - b),
+      MESHES.map((m) => m.expressId),
+      'every chunk must have been appended',
+    );
+    assert.equal(after.shards?.length, 1, 'the instanced shards must be restored');
+    assert.equal(after.shards?.[0].modelId, 'model-old', 'shards must be attributed to the model');
+    assert.ok(after.ifcDataStore, 'the data store must be written');
+    assert.equal(after.progress?.phase, 'Complete (from cache)', 'the load must report completion');
+    assert.equal(after.streaming, false, 'the stream must be closed so the fragments finalize');
+  });
+
+  it('a non-stale load with no geometry section still hydrates the store', async () => {
+    const entry = await buildCacheEntry({ withGeometry: false });
+    useViewerStore.setState({ ifcDataStore: null });
+    const result = await load(entry, () => false);
+    assert.equal(result.success, true);
+    assert.equal(result.meshCount, 0);
+    assert.ok(useViewerStore.getState().ifcDataStore, 'the data store must be written');
+  });
+
+  it('a truncated entry still rolls partial geometry back for the load that OWNS the slot', async () => {
+    // The other half of the rollback guard — and the proof that the truncated
+    // fixture really does throw mid-stream (without that, the superseded-load
+    // version of this test would pass vacuously).
+    const entry = await buildCacheEntry({ withShards: false });
+    const truncated = truncateThroughSecondChunk(entry.buffer as ArrayBuffer);
+    useViewerStore.setState({ geometryResult: null });
+    const result = await load({ ...entry, buffer: truncated }, () => false);
+    assert.equal(result.success, false, 'a truncated entry must fail the load');
+    assert.equal(
+      snapshot().geometryResultIsNull,
+      true,
+      'the owning load must clear its own partial geometry for the fallback reparse',
+    );
+  });
+
+  it('an ordinary MISS still reports failure so the caller reparses', async () => {
+    // A corrupt entry with NO staleness: `success: false` is what sends the
+    // caller through to the server/WASM path. An early return that swallowed
+    // this would leave the model permanently unloaded.
+    const corrupt = new Uint8Array(512);
+    corrupt.set(new TextEncoder().encode('not-a-cache-file'));
+    const result = await load({ buffer: corrupt.buffer }, () => false);
+    assert.equal(result.success, false, 'a corrupt entry must report a plain miss');
+    assert.equal(result.meshCount, 0);
+  });
+});

--- a/apps/viewer/src/hooks/useIfcCache.ts
+++ b/apps/viewer/src/hooks/useIfcCache.ts
@@ -189,10 +189,29 @@ export function useIfcCache() {
     modelId: string,
     cacheKey?: string,
     fallbackSourceBuffer?: ArrayBufferLike,
+    /**
+     * Optional staleness check — returns true if this load has been
+     * superseded. Same contract as `loadFromServer`'s (useIfcServer.ts:120),
+     * and it exists for the same reason: an IndexedDB read is slow enough to
+     * finish after a newer load has already painted, and the writes below go
+     * straight into the ACTIVE model slot. Without it a superseded cache hit
+     * blanks the new model's geometry and then repopulates it with the
+     * previous file's.
+     *
+     * Optional so existing callers are unaffected; a caller that omits it
+     * keeps the old behaviour.
+     */
+    isStale?: () => boolean,
   ): Promise<CacheLoadResult> => {
     try {
       const cacheLoadStart = performance.now();
       setProgress({ phase: 'Loading from cache', percent: 10 });
+
+      // Re-check before the first write: `getCached` was awaited by the
+      // caller, so a newer load can already own the active slot by now.
+      if (isStale?.()) {
+        return { success: false, meshCount: 0, totalVertices: 0, totalTriangles: 0 };
+      }
 
       // Reset geometry first so Viewport detects this as a new file
       setGeometryResult(null);
@@ -387,6 +406,14 @@ export function useIfcCache() {
           shardsReader.position = shardsSection.offset;
           const shards = readInstancedShards(shardsReader);
           if (shards.length > 0) appendInstancedShards(modelId, shards);
+        }
+
+        // Re-check after the chunk loop: it awaits per chunk (and yields to
+        // the event loop at line ~385), so a newer load can have taken the
+        // active slot mid-stream. Writing the data store here would hand the
+        // new model the previous file's entities.
+        if (isStale?.()) {
+          return { success: false, meshCount: 0, totalVertices: 0, totalTriangles: 0 };
         }
 
         setIfcDataStore(dataStore);

--- a/apps/viewer/src/hooks/useIfcCache.ts
+++ b/apps/viewer/src/hooks/useIfcCache.ts
@@ -205,13 +205,18 @@ export function useIfcCache() {
   ): Promise<CacheLoadResult> => {
     try {
       const cacheLoadStart = performance.now();
-      setProgress({ phase: 'Loading from cache', percent: 10 });
 
-      // Re-check before the first write: `getCached` was awaited by the
-      // caller, so a newer load can already own the active slot by now.
+      // Re-check before the first write — and `setProgress` below IS a write
+      // into the shared (active-model) progress state, so the check has to come
+      // first: `getCached` was awaited by the caller, so a newer load can
+      // already own the active slot by now, and a superseded load posting
+      // "Loading from cache" over the newer load's progress is visible to the
+      // user even though no geometry moved.
       if (isStale?.()) {
         return { success: false, meshCount: 0, totalVertices: 0, totalTriangles: 0 };
       }
+
+      setProgress({ phase: 'Loading from cache', percent: 10 });
 
       // Reset geometry first so Viewport detects this as a new file
       setGeometryResult(null);
@@ -369,11 +374,28 @@ export function useIfcCache() {
         loadedTotalVertices = open.totalVertices;
         loadedTotalTriangles = open.totalTriangles;
 
+        // Re-check before the streaming flag: `reader.read` above was awaited,
+        // so a newer load can own the slot by now. The flag is global
+        // (active-model) state — a superseded load raising it here, or lowering
+        // it in the `finally` below, would drive the NEWER load's stream.
+        if (isStale?.()) {
+          return { success: false, meshCount: 0, totalVertices: 0, totalTriangles: 0 };
+        }
+
         setGeometryStreamingActive(true);
         const allMeshes: MeshData[] = [];
+        let superseded = false;
         try {
           for (let i = 0; i < open.chunks.length; i++) {
             const chunkMeshes = await open.readChunk(i);
+            // Per-chunk re-check: every iteration awaits `readChunk` AND yields
+            // to the event loop at the end of the body, so supersession can
+            // land BETWEEN chunks. Without this, the remaining chunks of the
+            // old file keep appending into the new model's geometry.
+            if (isStale?.()) {
+              superseded = true;
+              break;
+            }
             allMeshes.push(...chunkMeshes);
             appendGeometryBatch(chunkMeshes, open.coordinateInfo);
             if ((i & 3) === 3 || i === open.chunks.length - 1) {
@@ -390,12 +412,28 @@ export function useIfcCache() {
           // A corrupt/truncated entry can fail AFTER earlier chunks were
           // already appended. Roll the partial geometry back so the caller's
           // fallback fresh stream starts from a clean scene instead of
-          // appending onto half a cached model.
-          setGeometryResult(null);
+          // appending onto half a cached model. Only when we still own the
+          // slot: for a superseded load the partial geometry is the NEWER
+          // model's, and clearing it would blank the file the user is looking
+          // at (this path's own fallback reparse is abandoned anyway).
+          if (!isStale?.()) setGeometryResult(null);
           throw chunkErr;
         } finally {
-          setGeometryStreamingActive(false);
+          // Same ownership condition: only the load that raised the flag (and
+          // still owns the slot) may lower it. A superseded load lowering it
+          // ends the newer load's stream early and finalizes half a model.
+          if (!isStale?.()) setGeometryStreamingActive(false);
         }
+
+        // Re-check after the chunk loop: it awaits per chunk (and yields to the
+        // event loop after each append), so a newer load can have taken the
+        // active slot mid-stream — including after the LAST chunk's yield. This
+        // sits ahead of the shard append, which is an active-slot write too:
+        // shards from the old file would be instanced into the new model.
+        if (superseded || isStale?.()) {
+          return { success: false, meshCount: 0, totalVertices: 0, totalTriangles: 0 };
+        }
+
         meshCount = allMeshes.length;
 
         // Restore the GPU-instancing shards (opaque repeated occurrences that
@@ -406,14 +444,6 @@ export function useIfcCache() {
           shardsReader.position = shardsSection.offset;
           const shards = readInstancedShards(shardsReader);
           if (shards.length > 0) appendInstancedShards(modelId, shards);
-        }
-
-        // Re-check after the chunk loop: it awaits per chunk (and yields to
-        // the event loop at line ~385), so a newer load can have taken the
-        // active slot mid-stream. Writing the data store here would hand the
-        // new model the previous file's entities.
-        if (isStale?.()) {
-          return { success: false, meshCount: 0, totalVertices: 0, totalTriangles: 0 };
         }
 
         setIfcDataStore(dataStore);
@@ -434,6 +464,15 @@ export function useIfcCache() {
           }));
         }
       } else {
+        // The no-geometry entry bypasses BOTH guards in the geometry branch
+        // above, yet it still crosses the awaited `reader.read` (and the
+        // Blob `arrayBuffer()` materialization) after the entry check — so it
+        // needs its own re-check before writing the store and the progress
+        // line below, or a superseded metadata-only hit hands the new model the
+        // previous file's entities.
+        if (isStale?.()) {
+          return { success: false, meshCount: 0, totalVertices: 0, totalTriangles: 0 };
+        }
         setIfcDataStore(dataStore);
       }
 

--- a/apps/viewer/src/hooks/useIfcLoader.cacheStaleness.test.tsx
+++ b/apps/viewer/src/hooks/useIfcLoader.cacheStaleness.test.tsx
@@ -1,0 +1,213 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The loader-side half of PR #2301 has no test of its own (#2301 review,
+ * 2026-08-10T18:50): `useIfcLoader.ts` — `if (cacheOutcome === 'stale')
+ * return;` — delete that line and the whole suite stays green.
+ * `useIfcCache.staleness.test.tsx` drives `loadFromCache` directly with an
+ * injected `isStale` predicate; it never renders or drives `useIfcLoader`,
+ * so it cannot see whether the CALLER honours the outcome `loadFromCache`
+ * reports.
+ *
+ * `loadFromCache` returns the SAME `{ success: false }` for an ordinary
+ * cache miss as for a superseded load. Without the guard this test pins, a
+ * superseded load falls through past the cache block into "Try server
+ * parsing" / local WASM — a full, wasted reparse of the file the user is no
+ * longer looking at, racing the newer load for workers — which is exactly
+ * the race PR #2301 exists to close, just moved one step later and made far
+ * more expensive.
+ *
+ * **How this is driven without a real WASM engine.** Two overlapping primary
+ * `loadFile` calls reproduce the real race: `loadFile`'s session bump
+ * (`++loadSessionRef.current`) is its very first statement, before any
+ * `await`, so firing `loadFile(fileA)` then `loadFile(fileB)` back-to-back
+ * (both synchronous up to their own first `await`) deterministically leaves
+ * `fileA`'s session stale by the time it reaches the cache branch — no
+ * timing race, no flakiness. `fileA` is sized and fingerprinted to hit a
+ * real cache entry seeded via `fake-indexeddb` (the same technique
+ * `ifc-cache.test.ts` uses); `fileB` is a plain small file, so its own load
+ * needs no cache round-trip at all.
+ *
+ * **The observable.** `setProgress` is wrapped (not `mock.module`, which
+ * this repo rejects — see `ExtensionHostProvider.tsx`) to count calls whose
+ * `phase` is `'Starting geometry streaming'`, the first unconditional write
+ * on entry to the local WASM path (unconditional because `USE_SERVER` is
+ * false under `tsx --test`, so nothing else can gate it). Exactly one call
+ * is correct: `fileB`, the winning load, legitimately enters that path once.
+ * A second call can only come from `fileA` wrongly falling through after
+ * being superseded — the counting (not a final-state check) is what makes
+ * this unambiguous, since both loads would otherwise leave the SAME phase
+ * string behind.
+ */
+
+import 'fake-indexeddb/auto';
+import '@/test/setup-dom.js';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import {
+  StringTable,
+  EntityTableBuilder,
+  PropertyTableBuilder,
+  QuantityTableBuilder,
+  RelationshipGraphBuilder,
+} from '@ifc-lite/data';
+import { BinaryCacheWriter, type CacheDataStore } from '@ifc-lite/cache';
+import { useViewerStore } from '@/store';
+import { CACHE_SIZE_THRESHOLD } from '@/utils/ifcConfig.js';
+import { resolveLoadTessellationTier } from '@/store/constants.js';
+import { computeSourceFingerprint } from './sourceFingerprint.js';
+import { buildGeometryCacheKey } from './geometryCacheKey.js';
+import { setCached } from '../services/cacheService.js';
+import { useIfcLoader } from './useIfcLoader.js';
+
+// ─── Fixtures ──────────────────────────────────────────────────────────────
+
+/** A STEP file of an exact byte length, padded with harmless filler bytes
+ *  between a real header/footer. Content correctness past the header doesn't
+ *  matter: `fileA`'s cache lookup always resolves via the guard under test
+ *  before anything reads the buffer's interior, and `fileB` never reaches a
+ *  real parse either (Node has no WASM engine) — every assertion here is
+ *  about how many times the WASM path is ENTERED, not what it produces. */
+function buildStepFile(name: string, targetBytes: number): File {
+  const header = new TextEncoder().encode("ISO-10303-21;\nHEADER;\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n");
+  const footer = new TextEncoder().encode('ENDSEC;\nEND-ISO-10303-21;\n');
+  const padLen = Math.max(0, targetBytes - header.length - footer.length);
+  const bytes = new Uint8Array(header.length + padLen + footer.length);
+  bytes.set(header, 0);
+  bytes.fill(0x20, header.length, header.length + padLen);
+  bytes.set(footer, header.length + padLen);
+  return new File([bytes], name);
+}
+
+/** Minimal but valid `CacheDataStore` — never actually read: `fileA`'s
+ *  `isStale` check is the very first statement in `loadFromCache`, before
+ *  the entry's buffer is even materialized. Its only job is to make
+ *  `getCached` return a truthy hit so `fileA` reaches the guard at all. */
+function buildMinimalCacheDataStore(): CacheDataStore {
+  const strings = new StringTable();
+  const entityBuilder = new EntityTableBuilder(2, strings);
+  entityBuilder.add(1, 'IfcProject', 'guid-project', 'Test Project', '', '', false, false);
+  return {
+    schema: 1,
+    entityCount: 1,
+    strings,
+    entities: entityBuilder.build(),
+    properties: new PropertyTableBuilder(strings).build(),
+    quantities: new QuantityTableBuilder(strings).build(),
+    relationships: new RelationshipGraphBuilder().build(),
+  };
+}
+
+/** Compute the SAME cache key `useIfcLoader.loadFile` would derive for this
+ *  buffer, from the same store fields and the same helper functions it uses
+ *  (`buildGeometryCacheKey`, `computeSourceFingerprint`,
+ *  `resolveLoadTessellationTier`) — not a guess at their output. */
+function cacheKeyFor(buffer: ArrayBuffer): string {
+  const { hex } = computeSourceFingerprint(buffer);
+  const state = useViewerStore.getState();
+  const skipSmallCuts = state.geometryMode === 'fast';
+  const tessellationTier = resolveLoadTessellationTier(buffer.byteLength / (1024 * 1024), state.geometryMode);
+  return buildGeometryCacheKey(buffer.byteLength, hex, state.mergeLayers, undefined, skipSmallCuts, tessellationTier);
+}
+
+// ─── Harness: the real hook, rendered ────────────────────────────────────
+
+let hookApi: ReturnType<typeof useIfcLoader> | null = null;
+
+function Probe(): null {
+  hookApi = useIfcLoader();
+  return null;
+}
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+beforeEach(async () => {
+  hookApi = null;
+  useViewerStore.getState().resetViewerState();
+  useViewerStore.getState().clearAllModels();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root!.render(<Probe />);
+  });
+  assert.ok(hookApi, 'the hook must expose loadFile');
+});
+
+afterEach(async () => {
+  const current = root;
+  root = null;
+  if (current) await act(async () => current.unmount());
+  if (container) container.remove();
+  container = null;
+});
+
+describe('useIfcLoader — a superseded cache-hit load must not fall through to a reparse (#2301)', () => {
+  it('the winning load enters the local WASM path exactly once, not twice', async () => {
+    // fileA: big enough to qualify for the source-persisting cache tier
+    // (CACHE_SIZE_THRESHOLD .. CACHE_MAX_SOURCE_SIZE) and seeded into the
+    // (fake) IndexedDB cache under its own real cache key.
+    const fileA = buildStepFile('cache-staleness-A.ifc', CACHE_SIZE_THRESHOLD + 4096);
+    const bufferA = await fileA.arrayBuffer();
+    const cacheKey = cacheKeyFor(bufferA);
+
+    const entryBuffer = await new BinaryCacheWriter().write(
+      buildMinimalCacheDataStore(),
+      undefined,
+      bufferA,
+      { includeGeometry: false, omitSourceHash: true },
+    );
+    // A `sourceBuffer` is supplied so the entry is NOT source-decoupled —
+    // `mayServe` short-circuits true with no mtime/hash gate, so `fileA`
+    // reaches the `isStale` guard unconditionally.
+    await setCached(cacheKey, entryBuffer as ArrayBuffer, fileA.name, bufferA.byteLength, bufferA);
+
+    // fileB: well under CACHE_SIZE_THRESHOLD, so its own load never touches
+    // the cache at all — it reaches the WASM path by the plain no-cache path.
+    const fileB = buildStepFile('cache-staleness-B.ifc', 2048);
+
+    let startingStreamCalls = 0;
+    const realSetProgress = useViewerStore.getState().setProgress;
+    await act(async () => {
+      useViewerStore.setState({
+        setProgress: (p) => {
+          if (p?.phase === 'Starting geometry streaming') startingStreamCalls++;
+          return realSetProgress(p);
+        },
+      });
+    });
+    // The wrapper replaces a store action referenced in `loadFile`'s own
+    // `useCallback` deps, so the hook must have re-rendered before firing
+    // the loads below — otherwise `hookApi.loadFile` would still close over
+    // the ORIGINAL `setProgress` and this test would prove nothing.
+    assert.notEqual(
+      useViewerStore.getState().setProgress,
+      realSetProgress,
+      'the wrapped setProgress must have replaced the original in the store',
+    );
+
+    // The real race: two primary loads back-to-back. `loadFile` bumps
+    // `loadSessionRef` as its first statement, before any `await`, so by
+    // the time `fileA` resumes past its own first `await` it is already
+    // stale — deterministically, not by timing luck.
+    await act(async () => {
+      const pending = [hookApi!.loadFile(fileA), hookApi!.loadFile(fileB)];
+      await Promise.allSettled(pending);
+    });
+
+    assert.equal(
+      startingStreamCalls,
+      1,
+      'exactly one primary load may enter the local WASM path — the winning '
+      + '(non-stale) load. A superseded cache-hit load falling through to a '
+      + 'full reparse of the OLD file would enter it a second time, which is '
+      + 'the fall-through PR #2301 exists to close (useIfcLoader.ts, '
+      + "`if (cacheOutcome === 'stale') return;`).",
+    );
+  });
+});

--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -15,7 +15,7 @@ import { flushSync } from 'react-dom';
 import { useShallow } from 'zustand/react/shallow';
 import { getViewerStoreApi, useViewerStore, type FederatedModel } from '@/store';
 import { getGeomWorkerOverride, resolveLoadTessellationTier, isMeshOnlyCacheEnabled } from '../store/constants.js';
-import { planCacheWrite, decideMeshOnlyCacheHit } from './cacheTier.js';
+import { planCacheWrite, decideMeshOnlyCacheHit, decideCacheLoadOutcome } from './cacheTier.js';
 import { computeSourceFingerprint } from './sourceFingerprint.js';
 import { computeFullSourceHash } from '../utils/sourceContentHash.js';
 import { IfcParser, detectFormat, unwrapIfcZipWithResources, type IfcDataStore } from '@ifc-lite/parser';
@@ -1059,7 +1059,23 @@ export function useIfcLoader() {
               buffer,
               () => loadSessionRef.current !== currentSession,
             );
-            if (cacheLoadResult.success) {
+            // `loadFromCache` returns the SAME `{ success: false }` for a
+            // superseded load as for an ordinary miss, so branching on
+            // `success` alone would send a superseded load on to a full
+            // server/WASM reparse of the OLD file below — the very race the
+            // `isStale` guards close, just later and far more expensive.
+            // Re-check the session here (the predicate is already in scope) and
+            // name the three outcomes explicitly.
+            const cacheOutcome = decideCacheLoadOutcome({
+              loadSucceeded: cacheLoadResult.success,
+              isStale: loadSessionRef.current !== currentSession,
+            });
+            if (cacheOutcome === 'stale') {
+              // A newer load owns the active slot: write nothing, parse
+              // nothing. The newer load drives `setLoading`/progress itself.
+              return;
+            }
+            if (cacheOutcome === 'serve') {
               const state = useViewerStore.getState();
               await finalizeModel(state.ifcDataStore, state.geometryResult, getSchemaVersion(state.ifcDataStore), {
                 loadState: 'complete',

--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -1047,7 +1047,18 @@ export function useIfcLoader() {
             // Pass the freshly read file buffer as the source fallback: the
             // desktop cache doesn't persist a sourceBuffer, and without one the
             // restored store can't carry the lazy entity accessors.
-            const cacheLoadResult = await loadFromCache(cacheResult, file.name, modelId, cacheKey, buffer);
+            // Pass the same staleness check `loadFromServer` already takes
+            // (see its `isStale` param): `getCached` above is an awaited
+            // IndexedDB read, so a second primary load can own the active
+            // slot by the time this resolves.
+            const cacheLoadResult = await loadFromCache(
+              cacheResult,
+              file.name,
+              modelId,
+              cacheKey,
+              buffer,
+              () => loadSessionRef.current !== currentSession,
+            );
             if (cacheLoadResult.success) {
               const state = useViewerStore.getState();
               await finalizeModel(state.ifcDataStore, state.geometryResult, getSchemaVersion(state.ifcDataStore), {


### PR DESCRIPTION
`loadFromServer` takes `isStale?: () => boolean` and checks it **four times** before writing to the active model slot. `loadFromCache` had no such parameter at all — and it writes the same slot: `setGeometryResult(null)`, then `setGeometryResult(...)` / `setIfcDataStore(...)`.

Both are reached from the same place in `useIfcLoader`, after an awaited read.

## Why it's reachable

- `getCached` is an **IndexedDB read**, and the chunk loop below it yields to the event loop per chunk — a real window, not a theoretical one.
- `ViewportContainer`'s `routeLoad` has **no in-flight check**, so two successive drops start two primary loads.
- Primary loads **do** bump `loadSessionRef` (`useIfcLoader.ts:266`).

So a superseded cache hit blanks the new model's geometry and repopulates it with the **previous file's**. That is the "user sees the wrong model's data" failure mode.

I checked reachability rather than assuming it — the guard would be pointless if something upstream serialised these.

## The fix

Two guards, placed where the awaits actually are: before the first `setGeometryResult(null)`, and after the chunk loop before `setIfcDataStore`. Both return the type's existing failure shape, so the caller's fallback path is unchanged. The parameter is optional, so no existing caller changes behaviour.

This is pattern completion, not a redesign — the correct shape already exists twenty lines away in `useIfcServer`.

## Deliberately not touched

Federated adds **capture** the session without bumping it (`useIfcLoader.ts:262-267`), so two concurrent federated adds cannot invalidate each other. The comment there says so explicitly:

> Federated adds are independent and run concurrently — they capture the current session without invalidating each other; a subsequent primary load still bumps it and aborts any in-flight federated adds.

That is intentional design. I flagged it while mapping the guards but did not change it — that is a maintainer decision, not a bug fix, and quietly altering it would change federation semantics under the guise of a staleness patch.

## Not pinned by a test — stated plainly

These hooks need a store + IndexedDB harness that does not exist. Every file in `apps/viewer/src/hooks/*.test.ts` covers a **pure helper**, not a hook; the sibling `loadFromServer` guard this mirrors is likewise untested. So this is verified by typecheck and the full suite only.

I would normally not ship an unpinned fix, and I am not pretending this one is pinned. Building that harness is its own piece of work and larger than this change.

**3083 passing / 0 failing / 2 pre-existing skips across 672 suites.** `tsc --noEmit` exit 0. `apps/viewer` is `private: true`, so no changeset.

## Where this came from

A full staleness audit of `useIfcLoader.ts` — all 38 `await` sites tabulated by whether the session guard is re-checked after the await and before the first write. This is the highest-value item from that table. The remaining candidates (IFCX/GLB active-slot writes, the post-`geometryProcessor.init()` blank, and the tail completion writes that re-enable picking mid-stream) are ranked and can follow separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model loading reliability when multiple loads start in quick succession.
  * Prevented outdated cached loads from replacing newer model data.
  * Ensured superseded loads exit cleanly without leaving partial geometry, progress, or invalid state.
  * Improved restoration of metadata and streamed model content from cache.
  * Added clearer handling for successful, unavailable, and superseded cache loads.

* **Tests**
  * Added coverage for overlapping loads, cache misses, metadata restoration, streaming, and recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->