### PR TITLE
fix(viewer): stop computeModelCenterInIfcMeters double-counting originShift

### DIFF
--- a/apps/viewer/src/lib/geo/reproject.test.ts
+++ b/apps/viewer/src/lib/geo/reproject.test.ts
@@ -22,12 +22,22 @@ import type { MapConversion, ProjectedCRS } from '@ifc-lite/parser';
 const close = (a: number, b: number, eps = 1e-6) =>
   assert.ok(Math.abs(a - b) < eps, `expected ${a} to be close to ${b}`);
 
+/**
+ * The producer's invariant is `shiftedBounds = originalBounds - originShift`
+ * (utils/localParsingUtils.ts). The previous fixture set a non-zero
+ * `originShift` while making the two bound sets IDENTICAL — a shape no
+ * producer can emit — so any consumer reading the wrong one of the pair
+ * produced the same numbers and the suite could not tell them apart. That is
+ * why the double-shift in `computeModelCenterInIfcMeters` survived.
+ *
+ * These bounds satisfy the invariant, so the two are now distinguishable.
+ */
 function makeCoordinateInfo(): CoordinateInfo {
   return {
     originShift: { x: 1000, y: 5, z: 2000 },
     originalBounds: {
-      min: { x: -10, y: -1, z: -20 },
-      max: { x: 10, y: 11, z: 20 },
+      min: { x: 990, y: 4, z: 1980 },
+      max: { x: 1010, y: 16, z: 2020 },
     },
     shiftedBounds: {
       min: { x: -10, y: -1, z: -20 },

--- a/apps/viewer/src/lib/geo/reproject.ts
+++ b/apps/viewer/src/lib/geo/reproject.ts
@@ -551,7 +551,15 @@ export function computeModelCenterInIfcMeters(
 ): { ifcX: number; ifcY: number; ifcZ: number } {
   if (!coordinateInfo) return { ifcX: 0, ifcY: 0, ifcZ: 0 };
 
-  const bounds = coordinateInfo.originalBounds;
+  // `shiftedBounds`, NOT `originalBounds`. The producer defines
+  // `shiftedBounds = originalBounds - originShift`
+  // (utils/localParsingUtils.ts), so `originalBounds` is ALREADY in the world
+  // frame — adding `shift` to it below would count the shift twice and put the
+  // model centre `originShift` away from where the footprint polygon
+  // (computeFootprintGeoJSON, which reads `shiftedBounds`) places the very same
+  // box. This matches the rule stated in this module's own pipeline doc above:
+  // `world_yup = bounds_center + originShift`, from the VIEWER bounds.
+  const bounds = coordinateInfo.shiftedBounds;
   const shift = coordinateInfo.originShift;
   const rtc = coordinateInfo.wasmRtcOffset;
 


### PR DESCRIPTION
`computeModelCenterInIfcMeters` read `originalBounds` and then added `originShift`. The producer defines

```
shiftedBounds = originalBounds − originShift     (utils/localParsingUtils.ts:155-167)
```

so `originalBounds` is **already** in the world frame — the shift was counted twice.

`computeFootprintGeoJSON`, in the same module, reads `shiftedBounds` and adds the shift, which is correct. So the two disagreed about where the **same bounding box** sits: the Cesium globe anchor (`cesium-bridge.ts` consumes this centre for easting/northing/height) landed `originShift` away from the footprint polygon drawn for the same model.

The module's own pipeline doc states the rule, and the fixed line now matches it:

> `world_yup = bounds_center + originShift + wasmRtcOffset_as_yup` — from the **viewer** bounds.

**Severity: LIVE**, but scoped: it only bites when `originShift ≠ 0`. The trusted-native streaming path forces it to zero, which is why it does not show on ordinary desktop loads.

## Why it survived — the fixture could not fail

`makeCoordinateInfo` set `originShift: {1000, 5, 2000}` while making `originalBounds` and `shiftedBounds` **identical** — a shape no producer can emit, since one is defined as the other minus the shift. Reading either one produced the same numbers, so the suite was structurally blind to the swap.

Measured rather than asserted:

| | result |
|---|---|
| old fixture + buggy code | **22/22 pass** |
| new fixture + buggy code | **1 fails** |
| new fixture + fix | 22/22 pass |

The expected values in the assertion were **correct all along** (`{ifcX: 1003, ifcY: -1993, ifcZ: 21}`) — they encode the `shiftedBounds` semantics. Only the inputs were degenerate. So this is a fixture repair, not a re-baselining: **no expected value moved**, which is the distinction between fixing a test and bending one.

That is the same class as the `.ifcZIP` and named-reviewers cases found earlier this week — a test whose inputs cannot distinguish the behaviour it names — and it is the reason this bug outlived a suite that appeared to cover it.

## Verification

- **3083 passing / 0 failing / 2 pre-existing skips across 672 suites.**
- `tsc --noEmit` exit 0.
- The swap was applied and reverted by exact-substring replacement with an asserted replacement count of 1, and every run above was executed rather than reasoned about.

`apps/viewer` is `private: true`, so no changeset.

## Provenance

Found by a read-only audit of `apps/viewer/src/lib` run under disk exhaustion — no builds, no test runs, source reading only. It produced ten ranked candidates with reachability analysis; this was #1. The others (a `replaceAll` edit-op with no cross-batch counterpart, a `Name` attribute arm that returns instead of falling through to its own slow path, a cleared-vs-absent MapUnit, and a CSV-injection guard that strips a BOM in one of three copies) are queued behind it.
