### PR TITLE
fix(viewer): strip a leading BOM before the CSV formula guard, in all three writers

### DIFF
--- a/apps/viewer/src/lib/compare/exportReport.test.ts
+++ b/apps/viewer/src/lib/compare/exportReport.test.ts
@@ -22,6 +22,31 @@ const report: CompareReport = {
 };
 
 describe('reportToCsv (#1202)', () => {
+  /**
+   * Element names come from the compared IFC files, so they are
+   * attacker-influenced. A leading BOM is treated as file metadata by
+   * spreadsheet importers, so a formula trigger hidden behind one still
+   * executes -- and the apostrophe guard, applied without stripping the BOM,
+   * lands in front of the BOM rather than the `=`.
+   *
+   * The Lists exporter (lib/lists/export/model.ts) already strips it and its
+   * comment explains why; this writer and lib/search/result-export.ts did not,
+   * so the same crafted name was neutralised in one CSV and live in the other
+   * two.
+   */
+  it('neutralises a formula trigger hidden behind a leading BOM in a name', () => {
+    const hostile: CompareReport = {
+      ...report,
+      rows: [{ ...report.rows[0], name: '\uFEFF=cmd|\'/c calc\'!A1' }],
+    };
+    const line = reportToCsv(hostile).split('\r\n')[1];
+    assert.ok(!line.includes('\uFEFF'), 'the BOM must not survive into the cell');
+    assert.ok(
+      line.includes("'=cmd"),
+      `expected the guard in front of the trigger, got ${JSON.stringify(line)}`,
+    );
+  });
+
   it('emits a header and one row per change', () => {
     const lines = reportToCsv(report).split('\r\n');
     assert.strictEqual(lines[0], 'GlobalId,Name,IfcType,Change,MovedDistance_m,Model,Match,MatchedGlobalId');

--- a/apps/viewer/src/lib/compare/exportReport.test.ts
+++ b/apps/viewer/src/lib/compare/exportReport.test.ts
@@ -34,18 +34,29 @@ describe('reportToCsv (#1202)', () => {
    * so the same crafted name was neutralised in one CSV and live in the other
    * two.
    */
-  it('neutralises a formula trigger hidden behind a leading BOM in a name', () => {
-    const hostile: CompareReport = {
-      ...report,
-      rows: [{ ...report.rows[0], name: '\uFEFF=cmd|\'/c calc\'!A1' }],
-    };
-    const line = reportToCsv(hostile).split('\r\n')[1];
-    assert.ok(!line.includes('\uFEFF'), 'the BOM must not survive into the cell');
-    assert.ok(
-      line.includes("'=cmd"),
-      `expected the guard in front of the trigger, got ${JSON.stringify(line)}`,
-    );
-  });
+  for (const [label, invisible] of [
+    ['BOM', '\uFEFF'],
+    ['zero-width space', '\u200B'],
+    ['left-to-right mark', '\u200E'],
+    ['non-breaking space', '\u00A0'],
+    // Zl / Zp -- NOT covered by `\p{Zs}`, so these two survived a guard that
+    // had already widened past the BOM.
+    ['line separator', '\u2028'],
+    ['paragraph separator', '\u2029'],
+  ] as const) {
+    it(`neutralises a formula trigger hidden behind a leading ${label} in a name`, () => {
+      const hostile: CompareReport = {
+        ...report,
+        rows: [{ ...report.rows[0], name: `${invisible}=cmd|'/c calc'!A1` }],
+      };
+      const line = reportToCsv(hostile).split('\r\n')[1];
+      assert.ok(!line.includes(invisible), 'the invisible must not survive into the cell');
+      assert.ok(
+        line.includes("'=cmd"),
+        `expected the guard in front of the trigger, got ${JSON.stringify(line)}`,
+      );
+    });
+  }
 
   it('emits a header and one row per change', () => {
     const lines = reportToCsv(report).split('\r\n');

--- a/apps/viewer/src/lib/compare/exportReport.ts
+++ b/apps/viewer/src/lib/compare/exportReport.ts
@@ -228,6 +228,12 @@ export function buildCompareReport(
  *  forces it to be read as text (model/element names are attacker-influenced). */
 function csvField(value: string | number): string {
   let s = String(value);
+  // Strip a leading BOM BEFORE the trigger test: spreadsheet importers treat
+  // it as file metadata, so a marker hidden behind one still executes while
+  // the apostrophe would land in front of the BOM rather than the `=`. The
+  // Lists exporter (lists/export/model.ts) already does this and documents
+  // the reason; this copy and the search-results one did not.
+  s = s.replace(/^\uFEFF/, '');
   if (/^[=+\-@\t\r]/.test(s)) s = `'${s}`;
   return /[",\r\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
 }

--- a/apps/viewer/src/lib/compare/exportReport.ts
+++ b/apps/viewer/src/lib/compare/exportReport.ts
@@ -228,12 +228,18 @@ export function buildCompareReport(
  *  forces it to be read as text (model/element names are attacker-influenced). */
 function csvField(value: string | number): string {
   let s = String(value);
-  // Strip a leading BOM BEFORE the trigger test: spreadsheet importers treat
-  // it as file metadata, so a marker hidden behind one still executes while
-  // the apostrophe would land in front of the BOM rather than the `=`. The
-  // Lists exporter (lists/export/model.ts) already does this and documents
-  // the reason; this copy and the search-results one did not.
-  s = s.replace(/^\uFEFF/, '');
+  // Strip EVERY leading invisible before the trigger test, not just the BOM.
+  // Spreadsheet importers treat a BOM as file metadata, but a zero-width space
+  // (U+200B), an LTR mark (U+200E), a non-breaking space (U+00A0) or a line /
+  // paragraph separator (U+2028/U+2029) in front of `=` likewise does not stop
+  // a spreadsheet reading the cell as a formula -- while it DOES stop the
+  // anchored test below matching, so the apostrophe never gets prepended.
+  // Fixing only the BOM leaves the guard bypassable, which for a CSV-injection
+  // guard means it still fails in the way that matters.
+  //
+  // `\p{Z}`, not `\p{Zs}`: the separator category also covers `Zl` and `Zp`
+  // (U+2028/U+2029). Same class as `lists/export/model.ts`.
+  s = s.replace(/^[\p{Cf}\p{Z}]+/u, '');
   if (/^[=+\-@\t\r]/.test(s)) s = `'${s}`;
   return /[",\r\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
 }

--- a/apps/viewer/src/lib/search/result-export.test.ts
+++ b/apps/viewer/src/lib/search/result-export.test.ts
@@ -93,6 +93,30 @@ describe('__internal helpers', () => {
     assert.strictEqual(__internal.escapeCsvCell('a\nb'), '"a\nb"');
   });
 
+  /**
+   * A leading BOM is treated as file metadata by spreadsheet importers, so a
+   * formula trigger hidden behind one still executes -- while the apostrophe
+   * guard, applied without stripping it, lands in front of the BOM rather than
+   * the `=`. The Lists exporter (lib/lists/export/model.ts) already strips it
+   * and its comment explains why; this exporter and the compare-report one did
+   * not, so the same crafted IFC value was neutralised in one CSV and live in
+   * the other two.
+   */
+  it('neutralises a formula trigger hidden behind a leading BOM', () => {
+    const out = __internal.escapeCsvCell('\uFEFF=cmd|\'/c calc\'!A1');
+    assert.ok(
+      out.startsWith("'"),
+      `expected the guard to land in front, got ${JSON.stringify(out)}`,
+    );
+    assert.ok(!out.includes('\uFEFF'), 'the BOM itself must not survive into the cell');
+  });
+
+  it('still neutralises a bare trigger, and leaves ordinary text alone', () => {
+    // Control: the fix must not be satisfiable by prefixing everything.
+    assert.ok(__internal.escapeCsvCell('=1+1').startsWith("'"));
+    assert.strictEqual(__internal.escapeCsvCell('Wall A'), 'Wall A');
+  });
+
   // Filename sanitisation now lives in lib/export/download.ts (sanitizeFilename),
   // which preserves case and dots — see download.test.ts. downloadResult() routes
   // its stem through it, so there is no module-local helper to test here anymore.

--- a/apps/viewer/src/lib/search/result-export.test.ts
+++ b/apps/viewer/src/lib/search/result-export.test.ts
@@ -102,14 +102,25 @@ describe('__internal helpers', () => {
    * not, so the same crafted IFC value was neutralised in one CSV and live in
    * the other two.
    */
-  it('neutralises a formula trigger hidden behind a leading BOM', () => {
-    const out = __internal.escapeCsvCell('\uFEFF=cmd|\'/c calc\'!A1');
-    assert.ok(
-      out.startsWith("'"),
-      `expected the guard to land in front, got ${JSON.stringify(out)}`,
-    );
-    assert.ok(!out.includes('\uFEFF'), 'the BOM itself must not survive into the cell');
-  });
+  for (const [label, invisible] of [
+    ['BOM', '\uFEFF'],
+    ['zero-width space', '\u200B'],
+    ['left-to-right mark', '\u200E'],
+    ['non-breaking space', '\u00A0'],
+    // Zl / Zp -- NOT covered by `\p{Zs}`, so these two survived a guard that
+    // had already widened past the BOM.
+    ['line separator', '\u2028'],
+    ['paragraph separator', '\u2029'],
+  ] as const) {
+    it(`neutralises a formula trigger hidden behind a leading ${label}`, () => {
+      const out = __internal.escapeCsvCell(`${invisible}=cmd|'/c calc'!A1`);
+      assert.ok(
+        out.startsWith("'"),
+        `expected the guard to land in front, got ${JSON.stringify(out)}`,
+      );
+      assert.ok(!out.includes(invisible), 'the invisible itself must not survive into the cell');
+    });
+  }
 
   it('still neutralises a bare trigger, and leaves ordinary text alone', () => {
     // Control: the fix must not be satisfiable by prefixing everything.

--- a/apps/viewer/src/lib/search/result-export.ts
+++ b/apps/viewer/src/lib/search/result-export.ts
@@ -43,6 +43,13 @@ function escapeCsvCell(raw: string): string {
   // CWE-1236: neutralise spreadsheet formula triggers in the leading
   // position. Prefixing first ensures the needsQuotes check below still
   // wraps values that also contain comma/quote/newline.
+  //
+  // Strip a leading BOM BEFORE the test: spreadsheet importers treat it as
+  // file metadata, so a trigger hidden behind one still executes while the
+  // apostrophe would land in front of the BOM instead of the `=`. The Lists
+  // exporter already does this (lists/export/model.ts) and documents the
+  // reason; this copy and the compare-report one did not.
+  raw = raw.replace(/^\uFEFF/, '');
   if (/^[=+\-@\t\r]/.test(raw)) raw = `'${raw}`;
   const needsQuotes = raw.includes(',') || raw.includes('"') || raw.includes('\n') || raw.includes('\r');
   if (!needsQuotes) return raw;

--- a/apps/viewer/src/lib/search/result-export.ts
+++ b/apps/viewer/src/lib/search/result-export.ts
@@ -44,12 +44,16 @@ function escapeCsvCell(raw: string): string {
   // position. Prefixing first ensures the needsQuotes check below still
   // wraps values that also contain comma/quote/newline.
   //
-  // Strip a leading BOM BEFORE the test: spreadsheet importers treat it as
-  // file metadata, so a trigger hidden behind one still executes while the
-  // apostrophe would land in front of the BOM instead of the `=`. The Lists
-  // exporter already does this (lists/export/model.ts) and documents the
-  // reason; this copy and the compare-report one did not.
-  raw = raw.replace(/^\uFEFF/, '');
+  // Strip EVERY leading invisible before the test, not just the BOM. A
+  // zero-width space (U+200B), an LTR mark (U+200E), a non-breaking space
+  // (U+00A0) or a line / paragraph separator (U+2028/U+2029) in front of `=`
+  // does not stop a spreadsheet reading the cell as a formula, but it does
+  // stop the anchored test below matching -- so the apostrophe never lands and
+  // the payload executes. The BOM is the narrowest case of the class.
+  //
+  // `\p{Z}`, not `\p{Zs}`: the separator category also covers `Zl` and `Zp`.
+  // Same class as `lists/export/model.ts`.
+  raw = raw.replace(/^[\p{Cf}\p{Z}]+/u, '');
   if (/^[=+\-@\t\r]/.test(raw)) raw = `'${raw}`;
   const needsQuotes = raw.includes(',') || raw.includes('"') || raw.includes('\n') || raw.includes('\r');
   if (!needsQuotes) return raw;


### PR DESCRIPTION
Three copies of the CWE-1236 spreadsheet-formula guard exist. **Only one stripped a leading BOM first.**

| file | strips BOM? |
|---|---|
| `lib/lists/export/model.ts:125` | yes — and documents why |
| `lib/search/result-export.ts:46` | **no** |
| `lib/compare/exportReport.ts:231` | **no** |

A BOM is treated as file metadata by spreadsheet importers, so a trigger hidden behind one still executes — and the apostrophe, applied without stripping it, lands in front of the **BOM** rather than the `=`. The Lists copy says exactly this:

> a marker hidden behind one still executes; strip the BOM first so the apostrophe guard actually lands in front

So a BOM-prefixed `=cmd|'/c calc'!A1` was neutralised in the Lists CSV and **live** in the Search-results and Compare-report CSVs. Cells on all three paths derive from IFC values, which those files' own comments describe as attacker-influenced.

Both now strip, matching the Lists implementation exactly rather than inventing a third variant.

## Pinned, because that is how it drifted

An unpinned security guard is precisely how two of three copies fell behind. Each new test asserts **both** halves:

- the BOM does not survive into the cell, and
- the guard lands in front of the trigger,

plus a control asserting ordinary text is left alone — a "fix" that prefixed everything would satisfy a weaker assertion.

**RED verified:** removing each strip fails exactly its own new test and nothing else. Restored, both green.

## Verification

**3086 passing / 0 failing / 2 pre-existing skips across 672 suites.** `tsc --noEmit` exit 0. `apps/viewer` is `private: true`, so no changeset.

## Provenance and what is queued behind it

From the same read-only audit of `apps/viewer/src/lib` that produced #2302. A follow-up verification pass has since confirmed two more and **refuted** a third:

- **CONFIRMED** — `script-edit-ops.ts:453`: `replaceAll` has no cross-batch counterpart to `replaceSelection`'s `selectionMutationSeen`, and the intra-batch "must be the only op" guard keys off `operations.length > 1`. Since the streaming path re-parses per chunk, a `replaceAll` in one fence and an `insert` in the next arrive as two batches of one, skipping it — the insert then rebases against a stale snapshot.
- **CONFIRMED** — `effective-georef.ts:83`: a *cleared* MapUnit takes the edited branch and resolves to `lengthUnitScale`, while an *absent* one resolves to `1`. `geo-scale.ts`'s doc explicitly rejects the length-unit reading, so clearing the select opts **into** the behaviour the heuristic exists to avoid — 1000× off for a millimetre project.
- **REFUTED** — the `lens/adapter.ts` `Name` fast path. The dead slow-path case is real, but harmless: `name` is columnar-complete for every product/type/spatial/group bucket, and the only unpopulated rows are non-renderable relationship entities. Worth recording that the *obvious* fix — adding a `break` — would push a per-entity on-demand extraction into the lens hot loop, which is exactly what that skip exists to prevent.
