### PR TITLE
fix(viewer): treat a cleared MapUnit as absent, not as unparseable

### DIFF
--- a/apps/viewer/src/lib/geo/effective-georef.test.ts
+++ b/apps/viewer/src/lib/geo/effective-georef.test.ts
@@ -15,6 +15,7 @@ import {
   resolveEpsetMapUnitScale,
   supportsStandardGeoreferencing,
 } from './effective-georef.js';
+import { resolveMapUnitToMetreScale } from './geo-scale.js';
 import type { MapConversion, ProjectedCRS } from '@ifc-lite/parser';
 
 describe('effective georeferencing', () => {
@@ -44,6 +45,55 @@ describe('effective georeferencing', () => {
 
     assert.strictEqual(merged?.description, 'Edited CRS');
     assert.strictEqual(merged?.mapUnitScale, 2.5);
+  });
+
+  /**
+   * The MapUnit editor is a `<select>` whose first option has an empty value,
+   * and `commitEdit` deliberately permits an empty commit for selects, so `''`
+   * reaches `mergeProjectedCRS` as an edit.
+   *
+   * `''` is not `undefined`, so it took the EDITED branch and
+   * `inferMapUnitScale('', lengthUnitScale)` returned the length-unit
+   * fallback. That is exactly the reading `resolveMapUnitToMetreScale`'s doc
+   * rejects -- "when no explicit MapUnit is set, treat the offsets as metres"
+   * -- so clearing the field opted INTO the failure the heuristic exists to
+   * avoid. For a millimetre project that is a 1000x under-scale of the CRS
+   * offsets, which flings the model outside the CRS's valid range.
+   */
+  it('treats a CLEARED MapUnit as absent (metres), not as unparseable', () => {
+    const original: ProjectedCRS = {
+      id: 1,
+      name: 'EPSG:28992',
+      mapUnit: 'METRE',
+      mapUnitScale: 1,
+    };
+
+    // lengthUnitScale 0.001 = a millimetre project, the case that hurts.
+    const merged = mergeProjectedCRS(original, { mapUnit: '' }, 0.001);
+
+    assert.strictEqual(merged?.mapUnit, '');
+    // `undefined`, NOT the length-unit scale: an absent MapUnit leaves the
+    // scale unresolved here and `resolveMapUnitToMetreScale` supplies the
+    // metres default downstream. Asserting `1` here would be wrong -- that
+    // number is produced one layer later, and pinning it in the wrong place
+    // would pass for the wrong reason.
+    assert.strictEqual(
+      merged?.mapUnitScale,
+      undefined,
+      'a cleared MapUnit must be treated as absent, not as an unparseable unit',
+    );
+    // And the downstream resolution is the metres heuristic, which is the
+    // behaviour the user actually gets.
+    assert.strictEqual(resolveMapUnitToMetreScale(merged?.mapUnitScale, 0.001), 1);
+  });
+
+  it('still falls back to the length unit for a NON-EMPTY unparseable MapUnit', () => {
+    // Control: the fix must not turn every edited MapUnit into 1, only the
+    // cleared one. 'WIBBLE' matches no known unit, so the documented
+    // length-unit fallback still applies.
+    const original: ProjectedCRS = { id: 1, name: 'EPSG:28992', mapUnit: 'METRE', mapUnitScale: 1 };
+    const merged = mergeProjectedCRS(original, { mapUnit: 'WIBBLE' }, 0.001);
+    assert.strictEqual(merged?.mapUnitScale, 0.001);
   });
 
   it('treats IFC2X3 files with IfcMapConversion and IfcProjectedCRS as standard georeferencing', () => {

--- a/apps/viewer/src/lib/geo/effective-georef.ts
+++ b/apps/viewer/src/lib/geo/effective-georef.ts
@@ -117,8 +117,27 @@ export function mergeProjectedCRS(
 ): ProjectedCRS | undefined {
   if (!original && !mutations) return undefined;
   const mapUnit = mutations?.mapUnit ?? original?.mapUnit;
+  // A CLEARED MapUnit is an ABSENT MapUnit, not an unparseable one.
+  //
+  // The panel's MapUnit editor is a `<select>` whose first option has an empty
+  // value, and `commitEdit` deliberately permits an empty commit for selects
+  // (`if (!trimmed && !hint.isSelect) return;`). So `''` reaches here as an
+  // edit. `''` is not `undefined`, so it took the edited branch, and
+  // `inferMapUnitScale('', lengthUnitScale)` returns the FALLBACK — the
+  // project's length-unit scale.
+  //
+  // That is precisely the reading `resolveMapUnitToMetreScale` exists to
+  // reject: its doc says "when no explicit MapUnit is set, treat the offsets
+  // as metres", because surveying pipelines emit metre offsets regardless of
+  // the project unit. So clearing the field opted the user INTO the failure
+  // the heuristic was written to avoid — for a millimetre project, a 1000×
+  // under-scale that flings the model outside the CRS's valid range.
+  //
+  // Passing `undefined` as the fallback for an empty string routes it to the
+  // absent path (scale 1). A non-empty but unparseable MapUnit keeps today's
+  // length-unit fallback.
   const mapUnitScale = mutations?.mapUnit !== undefined
-    ? inferMapUnitScale(mapUnit, lengthUnitScale)
+    ? inferMapUnitScale(mapUnit, mapUnit ? lengthUnitScale : undefined)
     : original?.mapUnitScale ?? inferMapUnitScale(mapUnit, undefined);
   return {
     id: original?.id ?? 0,


### PR DESCRIPTION
`mergeProjectedCRS` branches on `mutations?.mapUnit !== undefined`. An empty string is not `undefined`, so **clearing** the MapUnit took the *edited* branch, and `inferMapUnitScale('', lengthUnitScale)` returned the fallback — the project's length-unit scale.

That is precisely the reading `resolveMapUnitToMetreScale`'s doc rejects:

> **Heuristic: when no explicit MapUnit is set, treat the offsets as metres.** Files that genuinely use non-metre offsets can set MapUnit explicitly (e.g. `IfcProjectedCRS.MapUnit = MILLIMETRE`) to opt out.

So clearing the field opted the user **into** the behaviour the heuristic exists to avoid. For a millimetre project that is a **1000× under-scale** of the CRS offsets — the failure the same doc describes as landing an RD easting "in the South Pacific instead of the Netherlands".

**Severity: LIVE**, and reachable through ordinary UI, not a crafted input: the MapUnit editor is a `<select>` whose first option has an empty value, and `commitEdit` deliberately permits an empty commit for selects (`if (!trimmed && !hint.isSelect) return;`). Opening the editor and confirming without choosing is enough.

## The fix

An empty string routes to the absent path. A **non-empty** unparseable MapUnit keeps today's length-unit fallback — pinned by a control test, so the fix cannot be satisfied by collapsing every edited value to `1`.

## A correction worth recording

My first assertion expected `mapUnitScale === 1` and **failed against my own fix**.

The merge returns `undefined`; the metres default is supplied one layer later by `resolveMapUnitToMetreScale`. Asserting `1` at the merge would have pinned the right number in the wrong place and passed for the wrong reason — the exact failure mode I have spent the day finding in other tests. The test now asserts `undefined` at the merge **and** checks the downstream resolution separately, so both layers are pinned where they actually live.

## Verification

- **RED**: reverting the fix fails exactly the cleared-MapUnit test, nothing else.
- **GREEN**: **3085 passing / 0 failing / 2 pre-existing skips across 672 suites**.
- `tsc --noEmit` exit 0.

`apps/viewer` is `private: true`, so no changeset.

## Provenance

Third confirmed finding from the `apps/viewer/src/lib` read-only audit, after #2302 (double-counted `originShift`) and #2303 (BOM before the CSV formula guard). A dedicated verification pass confirmed this one and #2302's sibling, and **refuted** a fourth candidate — the `lens/adapter.ts` `Name` fast path, where the dead code is real but the consequence is not, and the obvious patch would have pushed a per-entity extraction into the lens hot loop.

One candidate remains open: `script-edit-ops.ts:453`, where `replaceAll` has no cross-batch counterpart to `replaceSelection`'s `selectionMutationSeen` guard.
