### PR TITLE
fix(viewer): strip every leading invisible before the Lists formula guard

### DIFF
--- a/apps/viewer/src/lib/lists/export/injection.test.ts
+++ b/apps/viewer/src/lib/lists/export/injection.test.ts
@@ -17,6 +17,38 @@ import { buildExportModel, neutralizeSpreadsheetFormula } from './model';
 import { toCsv } from './csv';
 import { toXlsx } from './xlsx';
 
+describe('neutralizeSpreadsheetFormula — parity with the sibling guards', () => {
+  /**
+   * `packages/sdk/src/namespaces/export.ts` looks for the trigger PAST any
+   * leading invisible (#1944): a BOM, zero-width space, LRM or NBSP does not
+   * stop a spreadsheet reading the cell as a formula, but it does stop an
+   * anchored regex matching. This copy stripped U+FEFF only, so ZWSP and
+   * friends were bypasses.
+   *
+   * Reachable: `packages/encoding/src/ifc-string.ts` decodes \\X2\\200B\\X0\\
+   * to a literal U+200B, so an IFC Name can carry one.
+   */
+  for (const [label, invisible] of [
+    ['BOM', '\uFEFF'],
+    ['zero-width space', '\u200B'],
+    ['left-to-right mark', '\u200E'],
+    ['non-breaking space', '\u00A0'],
+  ] as const) {
+    it(`guards a trigger hidden behind a leading ${label}`, () => {
+      const out = neutralizeSpreadsheetFormula(`${invisible}=HYPERLINK("http://example.invalid","x")`);
+      assert.ok(
+        out.startsWith("'"),
+        `expected the guard in front, got ${JSON.stringify(out)}`,
+      );
+      assert.ok(!out.includes(invisible), 'the invisible must not survive into the cell');
+    });
+  }
+
+  it('leaves ordinary text alone', () => {
+    assert.strictEqual(neutralizeSpreadsheetFormula('Wall A'), 'Wall A');
+  });
+});
+
 describe('neutralizeSpreadsheetFormula (#1790 review, CWE-1236)', () => {
   it('prefixes an apostrophe to every formula-trigger lead char', () => {
     for (const s of ['=1+1', '+1', '-1', '@SUM(A1)', '\tx', '\rx']) {

--- a/apps/viewer/src/lib/lists/export/injection.test.ts
+++ b/apps/viewer/src/lib/lists/export/injection.test.ts
@@ -33,6 +33,10 @@ describe('neutralizeSpreadsheetFormula — parity with the sibling guards', () =
     ['zero-width space', '\u200B'],
     ['left-to-right mark', '\u200E'],
     ['non-breaking space', '\u00A0'],
+    // Zl / Zp. `\p{Zs}` does NOT cover these, so they stayed viable prefixes
+    // until the class widened to `\p{Z}`.
+    ['line separator', '\u2028'],
+    ['paragraph separator', '\u2029'],
   ] as const) {
     it(`guards a trigger hidden behind a leading ${label}`, () => {
       const out = neutralizeSpreadsheetFormula(`${invisible}=HYPERLINK("http://example.invalid","x")`);

--- a/apps/viewer/src/lib/lists/export/model.ts
+++ b/apps/viewer/src/lib/lists/export/model.ts
@@ -129,7 +129,11 @@ export function neutralizeSpreadsheetFormula(s: string): string {
   // regex matching, so stripping only the BOM left the others as bypasses.
   // `packages/sdk/src/namespaces/export.ts` matches past this same class
   // (#1944); this copy handled the BOM alone.
-  s = s.replace(/^[\p{Cf}\p{Zs}]+/u, '');
+  //
+  // `\p{Z}`, not `\p{Zs}`: the separator category also covers `Zl` and `Zp`,
+  // so U+2028 (LINE SEPARATOR) and U+2029 (PARAGRAPH SEPARATOR) would
+  // otherwise remain viable prefixes for hiding a formula trigger.
+  s = s.replace(/^[\p{Cf}\p{Z}]+/u, '');
   // NOTE a deliberate, unresolved divergence from `packages/lists/src/engine.ts`:
   // that copy EXEMPTS a genuine number from the `-`/`+` trigger (#1772, comment:
   // "`-0.35` exported as `'-0.35` and broke Excel SUM()"), whereas this copy

--- a/apps/viewer/src/lib/lists/export/model.ts
+++ b/apps/viewer/src/lib/lists/export/model.ts
@@ -123,7 +123,22 @@ export function displayCell(value: CellValue): string {
  * writers so both honour the guideline identically.
  */
 export function neutralizeSpreadsheetFormula(s: string): string {
-  s = s.replace(/^\uFEFF/, '');
+  // Strip ALL leading invisibles, not just U+FEFF. A zero-width space,
+  // left-to-right mark or non-breaking space in front of `=` does not stop a
+  // spreadsheet reading the cell as a formula, but it does stop an anchored
+  // regex matching, so stripping only the BOM left the others as bypasses.
+  // `packages/sdk/src/namespaces/export.ts` matches past this same class
+  // (#1944); this copy handled the BOM alone.
+  s = s.replace(/^[\p{Cf}\p{Zs}]+/u, '');
+  // NOTE a deliberate, unresolved divergence from `packages/lists/src/engine.ts`:
+  // that copy EXEMPTS a genuine number from the `-`/`+` trigger (#1772, comment:
+  // "`-0.35` exported as `'-0.35` and broke Excel SUM()"), whereas this copy
+  // guards it -- and `injection.test.ts` pins `'+1'` as guarded on purpose. So
+  // the viewer's Lists CSV ships every negative measure as text while the
+  // library's does not. Both behaviours are deliberately tested, so they cannot
+  // both be right; picking one is a product decision (broken SUM() vs a cell
+  // that a spreadsheet could re-read as a formula) and is NOT bundled into this
+  // hardening change.
   return /^[=+\-@\t\r]/.test(s) ? `'${s}` : s;
 }
 


### PR DESCRIPTION
The Lists export guard stripped a leading **BOM only**. A zero-width space, left-to-right mark or non-breaking space in front of `=` does not stop a spreadsheet reading the cell as a formula, but it **does** stop an anchored regex matching — so those three were bypasses where the BOM was not.

Reachable, not theoretical: `packages/encoding/src/ifc-string.ts` decodes an `\X2\200B\X0\` escape via `String.fromCharCode`, so an IFC `Name` can carry a literal U+200B ahead of `=HYPERLINK(...)`.

`packages/sdk/src/namespaces/export.ts` already matches past this whole class (#1944). This copy is now brought up to it. **Stripping** rather than merely looking past keeps the existing contract that the invisible does not survive into the cell.

**RED verified:** reverting to the BOM-only strip fails exactly the three non-BOM invisible cases and leaves the BOM case passing.

## Deliberately NOT changed — and this is the important part

`packages/lists/src/engine.ts:699` **exempts a genuine number** from the `-`/`+` trigger (#1772), with a comment naming the breakage:

> `-0.35` exported as `'-0.35` and broke Excel SUM()

This copy **guards** it — and `injection.test.ts` pins `'+1'` as guarded **on purpose**. So the viewer's Lists CSV ships every negative measure as text while the library's does not. Same feature, two exporters, opposite behaviour, each with a deliberate test.

I started to unify them and stopped when the existing test failed. They cannot both be right, and choosing costs a behaviour change either way:

- adopt the exemption → a cell like `-0.35` is no longer prefixed, which is correct for numbers but widens what an attacker-influenced value can look like;
- keep the guard → `SUM()` over any column containing negatives stays broken in the viewer's CSV.

That is a product call about a security/usability trade-off, not a hardening detail to slip into this commit, so it is noted at the call site instead — so the next reader does not "fix" one copy into the other by accident. @louistrue, this one is yours.

## The wider picture this came from

A repo-wide sweep for *the same guard implemented more than once, hardened in one place only* — the shape behind #2303, #2299 and #2301. It found **ten copies** of this CWE-1236 guard in three tiers:

| tier | where | guard |
|---|---|---|
| strongest | `packages/sdk/src/namespaces/export.ts:223` | matches past **all** leading invisibles |
| middle | `apps/viewer/src/lib/lists/export/model.ts` | stripped `^BOM` only *(this PR)* |
| bare | 7 more, incl. `packages/cli`, `packages/mcp`, `apps/viewer/src/sdk`, `rust/export/src/csv.rs` | bare trigger test |

Three hardenings landed on three different dates in three different files, none propagated. `AGENTS.md:91` states the rule repo-wide **and explicitly claims BOM coverage** — a guarantee only one copy provided.

The real fix is one shared helper called by all ten (plus the Rust port), which also means reconciling the numeric exemption above. That is a cross-package refactor touching a published SDK surface and an AGENTS.md rule, so it wants a maintainer decision rather than my unilateral consolidation. This PR closes the one gap that is unambiguously a gap.

## Verification

**3088 passing / 0 failing / 2 pre-existing skips across 673 suites.** `tsc --noEmit` exit 0. `apps/viewer` is `private: true`, so no changeset.
