### PR TITLE
fix(viewer): reject a positional script op after a cross-batch replaceAll

### DIFF
--- a/apps/viewer/src/lib/llm/script-edit-ops.test.ts
+++ b/apps/viewer/src/lib/llm/script-edit-ops.test.ts
@@ -397,3 +397,104 @@ test('applyScriptEditOperations rejects grouped structural repair ops without sh
   assert.equal(applied.status, 'semantic_error');
   assert.match(applied.error ?? '', /must declare `targetRootCause`/);
 });
+
+
+/**
+ * A `replaceAll` in one streaming fence followed by an `insert` in the next.
+ *
+ * The intra-batch invariant ("replaceAll must be the only op") is enforced as
+ * `operations.length > 1`, but the batch is the STREAMING DELTA, not the whole
+ * response: ChatPanel re-parses on every chunk and `filterUnappliedScriptOps`
+ * strips already-applied ops, so the two arrive as two batches of ONE each and
+ * that guard never fires.
+ *
+ * `buildBaseMutations` returns [] for `replaceAll` (its `default` arm), so the
+ * later `insert` rebased through an EMPTY mutation list and applied a
+ * base-snapshot offset to the post-replaceAll text -- landing at an arbitrary
+ * point, or clamped to EOF, with `ok: true` and no diagnostic.
+ *
+ * `replaceSelection` already had this protection via `priorAcceptedOps`;
+ * `replaceAll` did not, though it invalidates positional offsets just as
+ * thoroughly.
+ */
+test('an insert cannot follow a replaceAll accepted in an earlier streaming batch', () => {
+  const baseContent = 'AAA';
+
+  const first = applyScriptEditOperations({
+    content: baseContent,
+    selection: { from: 0, to: 0 },
+    revision: 1,
+    baseContentSnapshot: baseContent,
+    operations: [
+      { opId: 'rewrite', type: 'replaceAll', baseRevision: 1, text: 'ZZZZZZZZZZ' },
+    ],
+  });
+  assert.equal(first.ok, true);
+  assert.equal(first.content, 'ZZZZZZZZZZ');
+
+  const second = applyScriptEditOperations({
+    content: first.content,
+    selection: first.selection,
+    revision: first.revision,
+    priorAcceptedOps: [
+      { opId: 'rewrite', type: 'replaceAll', baseRevision: 1, text: 'ZZZZZZZZZZ' },
+    ],
+    acceptedBaseRevision: 1,
+    baseContentSnapshot: baseContent,
+    operations: [
+      { opId: 'late-insert', type: 'insert', baseRevision: 1, at: 1, text: 'X' },
+    ],
+  });
+
+  assert.equal(second.ok, false, 'a positional op after a replaceAll must be rejected');
+  // Assert the REASON, not just the rejection: an unrelated failure (a revision
+  // conflict, a range error) would satisfy `ok === false` while leaving the
+  // actual gap open.
+  assert.match(
+    JSON.stringify(second),
+    /cannot follow a whole-content edit/,
+    'must be rejected for following a whole-content edit, not for some other reason',
+  );
+  // And the content must be untouched by the rejected batch.
+  assert.equal(second.content, 'ZZZZZZZZZZ');
+});
+
+test('a replaceRange is rejected the same way after a cross-batch replaceAll', () => {
+  const baseContent = 'AAA';
+  const result = applyScriptEditOperations({
+    content: 'ZZZZZZZZZZ',
+    selection: { from: 0, to: 0 },
+    revision: 2,
+    priorAcceptedOps: [
+      { opId: 'rewrite', type: 'replaceAll', baseRevision: 1, text: 'ZZZZZZZZZZ' },
+    ],
+    acceptedBaseRevision: 1,
+    baseContentSnapshot: baseContent,
+    operations: [
+      { opId: 'late-range', type: 'replaceRange', baseRevision: 1, from: 0, to: 2, text: 'Q' },
+    ],
+  });
+  assert.equal(result.ok, false);
+  assert.match(JSON.stringify(result), /cannot follow a whole-content edit/);
+});
+
+test('an append after a cross-batch replaceAll is still allowed', () => {
+  // Control: `append` keys off `content.length`, not a base-snapshot offset,
+  // so it is unaffected by the rewrite and must NOT be swept up by the guard.
+  const baseContent = 'AAA';
+  const result = applyScriptEditOperations({
+    content: 'ZZZZZZZZZZ',
+    selection: { from: 0, to: 0 },
+    revision: 2,
+    priorAcceptedOps: [
+      { opId: 'rewrite', type: 'replaceAll', baseRevision: 1, text: 'ZZZZZZZZZZ' },
+    ],
+    acceptedBaseRevision: 1,
+    baseContentSnapshot: baseContent,
+    operations: [
+      { opId: 'tail', type: 'append', baseRevision: 1, text: '!' },
+    ],
+  });
+  assert.equal(result.ok, true, 'append is offset-free and must remain permitted');
+  assert.equal(result.content, 'ZZZZZZZZZZ!');
+});

--- a/apps/viewer/src/lib/llm/script-edit-ops.ts
+++ b/apps/viewer/src/lib/llm/script-edit-ops.ts
@@ -450,7 +450,21 @@ export function applyScriptEditOperations(params: {
   const appliedOpIds: string[] = [];
   const changes: ScriptEditorTextChange[] = [];
   const baseMutations = buildBaseMutations(params.priorAcceptedOps ?? [], baseContent.length);
-  let selectionMutationSeen = (params.priorAcceptedOps ?? []).some((op) => op.type === 'replaceSelection');
+  // Both `replaceSelection` and `replaceAll` invalidate every positional
+  // offset taken from the base snapshot, and `buildBaseMutations` returns []
+  // for BOTH (they hit its `default` arm) -- so a later positional op rebases
+  // through an empty mutation list and lands at a stale offset.
+  //
+  // `replaceSelection` was already carried across calls here; `replaceAll` was
+  // not. The intra-batch invariant is enforced separately below
+  // (`operations.length > 1 && ... 'replaceAll'`), but the batch is the
+  // STREAMING DELTA, not the whole response: ChatPanel re-parses per chunk and
+  // `filterUnappliedScriptOps` strips already-applied ops, so a `replaceAll`
+  // in one fence and an `insert` in the next arrive as two batches of ONE
+  // each -- and that guard never fires.
+  let contentReplacedSeen = (params.priorAcceptedOps ?? []).some(
+    (op) => op.type === 'replaceSelection' || op.type === 'replaceAll',
+  );
 
   if (operations.length === 0) {
     return { ok: true, content, selection, revision, appliedOpIds, changes, status: 'ok' };
@@ -613,15 +627,15 @@ export function applyScriptEditOperations(params: {
       changes.push({ from: selection.from, to: selection.to, insert: op.text });
       selection = { from: cursor, to: cursor };
       appliedOpIds.push(op.opId);
-      selectionMutationSeen = true;
+      contentReplacedSeen = true;
       continue;
     }
 
     if (op.type === 'insert') {
-      if (selectionMutationSeen) {
+      if (contentReplacedSeen) {
         const diagnostic = createPatchDiagnostic(
           'patch_semantic_error',
-          `insert op "${op.opId}" cannot follow a selection-based edit in the same patch set.`,
+          `insert op "${op.opId}" cannot follow a whole-content edit (replaceSelection or replaceAll) in the same patch set.`,
           'error',
           {
             opId: op.opId,
@@ -699,10 +713,10 @@ export function applyScriptEditOperations(params: {
       continue;
     }
 
-    if (selectionMutationSeen) {
+    if (contentReplacedSeen) {
       const diagnostic = createPatchDiagnostic(
         'patch_semantic_error',
-        `replaceRange op "${op.opId}" cannot follow a selection-based edit in the same patch set.`,
+        `replaceRange op "${op.opId}" cannot follow a whole-content edit (replaceSelection or replaceAll) in the same patch set.`,
         'error',
         {
           opId: op.opId,


### PR DESCRIPTION
`replaceSelection` and `replaceAll` both invalidate every positional offset taken from the base snapshot, and `buildBaseMutations` returns `[]` for **both** — they share its `default` arm. So a later `insert` or `replaceRange` rebases through an empty mutation list and applies a base-snapshot offset to already-rewritten text.

`replaceSelection` was carried across calls via `priorAcceptedOps`. **`replaceAll` was not.**

## Why the existing guard doesn't catch it

The intra-batch invariant *is* enforced:

```ts
if (operations.length > 1 && operations.some((op) => op.type === 'replaceAll')) { … }
```

But the batch is the **streaming delta**, not the response. `ChatPanel` re-parses on every chunk and `filterUnappliedScriptOps` strips already-applied ops — so a `replaceAll` in one fence and an `insert` in the next arrive as **two batches of one each**, and that guard never fires. `extractScriptEditOps` accumulates across fences, so a single assistant turn can emit both.

Result before this change: `ok: true`, no diagnostic, and the insert landed at an arbitrary offset in the rewritten text — or clamped to EOF when the rewrite was shorter than `op.at`. Silent corruption of the user's script.

**Severity: LIVE.** Restricted to `create` / `explicit_rewrite` intents; `repair` is blocked upstream two separate ways.

## The fix

One line at the initialiser — include `replaceAll` alongside `replaceSelection`, reusing the guard that already exists for exactly this hazard.

Renamed to `contentReplacedSeen`, and both diagnostics now read *"whole-content edit (replaceSelection or replaceAll)"*. "Selection-based edit" would be wrong for half the cases it now covers, and these strings are read by **the model** deciding how to repair — an inaccurate message there is a functional defect, not a cosmetic one.

## `append` is deliberately still permitted

It keys off `content.length`, not a base-snapshot offset, so a rewrite does not invalidate it. Pinned by a control test — a guard that swept `append` up would look exactly as green as a correct one.

## What the tests assert

The rejection tests check the **reason**, not just `ok === false`. An unrelated failure — a revision conflict, a range error — would satisfy a bare falsy check while leaving the actual gap open. That is the failure mode I have been finding all day in tests that only assert an outcome.

**RED verified:** dropping `replaceAll` from the initialiser fails exactly the two rejection tests and leaves the `append` control passing.

## Verification

**3086 passing / 0 failing / 2 pre-existing skips across 672 suites.** `tsc --noEmit` exit 0.

One note: my first draft of the tests passed `selection: null`, which typechecks as an error against `ScriptEditorSelection`. The suite ran green before `tsc` caught it — a reminder that a passing `tsx --test` run is not a typecheck.

`apps/viewer` is `private: true`, so no changeset.

## Provenance

Last of the four candidates from the `apps/viewer/src/lib` read-only audit. The other three shipped as #2302, #2303 and #2304; a fifth was **refuted** rather than patched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented positional edits from being applied after a whole-content replacement, including replacements received across streamed batches.
  - Preserved document content when conflicting edits are rejected.
  - Continued allowing offset-free append operations after a whole-content replacement.

- **Tests**
  - Added regression coverage for cross-batch replacement and subsequent edit behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->