### PR TITLE
fix(core): resolve imperial length units in EntityDecoder::length_unit_scale

### DIFF
--- a/rust/core/src/decoder.rs
+++ b/rust/core/src/decoder.rs
@@ -348,7 +348,17 @@ impl<'a> EntityDecoder<'a> {
         }
 
         let scale = match project_id {
-            Some(pid) => crate::units::try_extract_length_unit_scale(self, pid).unwrap_or(1.0),
+            // The FULL extractor, matching `plane_angle_to_radians` ten lines
+            // above. `try_extract_length_unit_scale` returns None BY DESIGN for
+            // IFCCONVERSIONBASEDUNIT length units (imperial), deferring the
+            // deeper name + IFCMEASUREWITHUNIT walk to the full-index path --
+            // and its own doc says the caller "should retry against a complete
+            // index before trusting a metres default", because it exists for
+            // the streaming pre-pass and its PARTIAL index. This accessor is
+            // not that: it scans the whole content with EntityScanner and its
+            // callers hold a complete index. Collapsing that deferral to 1.0
+            // read a foot model as a metre one.
+            Some(pid) => crate::units::extract_length_unit_scale(self, pid).unwrap_or(1.0),
             None => 1.0,
         };
         self.length_unit_scale_cache = Some(scale);

--- a/rust/core/src/decoder.rs
+++ b/rust/core/src/decoder.rs
@@ -348,16 +348,6 @@ impl<'a> EntityDecoder<'a> {
         }
 
         let scale = match project_id {
-            // The FULL extractor, matching `plane_angle_to_radians` ten lines
-            // above. `try_extract_length_unit_scale` returns None BY DESIGN for
-            // IFCCONVERSIONBASEDUNIT length units (imperial), deferring the
-            // deeper name + IFCMEASUREWITHUNIT walk to the full-index path --
-            // and its own doc says the caller "should retry against a complete
-            // index before trusting a metres default", because it exists for
-            // the streaming pre-pass and its PARTIAL index. This accessor is
-            // not that: it scans the whole content with EntityScanner and its
-            // callers hold a complete index. Collapsing that deferral to 1.0
-            // read a foot model as a metre one.
             Some(pid) => crate::units::extract_length_unit_scale(self, pid).unwrap_or(1.0),
             None => 1.0,
         };

--- a/rust/core/src/decoder/decoder_tests.rs
+++ b/rust/core/src/decoder/decoder_tests.rs
@@ -304,3 +304,60 @@ fn clearing_the_entity_cache_keeps_the_placement_memo() {
         "clear_cache is documented as clearing all caches and must keep doing so"
     );
 }
+
+/// `length_unit_scale` must resolve an IMPERIAL length unit rather than
+/// silently reporting metres.
+///
+/// The accessor used to call `units::try_extract_length_unit_scale`, which
+/// returns `None` BY DESIGN for an `IFCCONVERSIONBASEDUNIT` length unit: it
+/// defers the deeper name + `IFCMEASUREWITHUNIT` walk to the full-index path,
+/// and its own doc tells the caller to retry "against a complete index before
+/// trusting a metres default". It exists for the streaming pre-pass and its
+/// PARTIAL index.
+///
+/// `length_unit_scale` is not that caller -- it scans the whole content with
+/// `EntityScanner`, and its callers hold a complete index. So `.unwrap_or(1.0)`
+/// collapsed that deliberate deferral into "metres" and read a foot-authored
+/// model as a metre one, putting every absolute tolerance derived from it out
+/// by 3.28x. It now calls the full `units::extract_length_unit_scale`, matching
+/// `plane_angle_to_radians` directly above it.
+#[test]
+fn length_unit_scale_resolves_an_imperial_conversion_based_unit() {
+    let content = r#"ISO-10303-21;
+DATA;
+#1=IFCPROJECT('guid',$,'Test',$,$,$,$,(#2),#3);
+#3=IFCUNITASSIGNMENT((#10));
+#5=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#9=IFCMEASUREWITHUNIT(IFCLENGTHMEASURE(0.3048),#5);
+#10=IFCCONVERSIONBASEDUNIT(#11,.LENGTHUNIT.,'FOOT',#9);
+#11=IFCDIMENSIONALEXPONENTS(1,0,0,0,0,0,0);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+    let mut decoder = EntityDecoder::new(content);
+    let scale = decoder.length_unit_scale();
+    assert!(
+        (scale - 0.3048).abs() < 1e-9,
+        "foot-authored file must report the foot scale 0.3048, got {scale}"
+    );
+}
+
+/// Bounding control for the test above: an SI metre file must STILL report
+/// 1.0. Without this, "always return 0.3048" would satisfy the imperial test.
+#[test]
+fn length_unit_scale_still_reports_metres_for_an_si_metre_file() {
+    let content = r#"ISO-10303-21;
+DATA;
+#1=IFCPROJECT('guid',$,'Test',$,$,$,$,(#2),#3);
+#3=IFCUNITASSIGNMENT((#5));
+#5=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+    let mut decoder = EntityDecoder::new(content);
+    let scale = decoder.length_unit_scale();
+    assert!(
+        (scale - 1.0).abs() < 1e-12,
+        "metre-authored file must still report 1.0, got {scale}"
+    );
+}


### PR DESCRIPTION
`EntityDecoder::length_unit_scale()` called `try_extract_length_unit_scale`, which returns `None` **by design** for an `IFCCONVERSIONBASEDUNIT` length unit — `units.rs:339-350` defers the deeper name + `IFCMEASUREWITHUNIT` walk to the full-index path rather than reimplement it:

```rust
// Imperial/conversion length units need a deeper chain
// (name + IFCMEASUREWITHUNIT). Defer to the full-index
// path rather than reimplement that walk here.
return None;
```

The accessor collapsed that deferral to `.unwrap_or(1.0)`, so a foot-unit file read as metres.

## Three things make this a clear miss rather than a judgement call

1. **The `try_` variant's own doc mandates the retry**: *"the caller should retry against a complete index before trusting a metres default"* — and says it exists for the streaming pre-pass and its **partial** index. This accessor is not that: it scans the whole content with `EntityScanner`, and its callers hold a complete index.
2. **`resolve_unit_scales` (`rust/processing/src/prepass.rs:332-338`), the actual pre-pass, does perform the documented retry.**
3. **`plane_angle_to_radians`, the sibling accessor ten lines above, already calls its FULL extractor.** Same file, same shape, opposite choice.

## Why it isn't masked everywhere

Geometry decoders are normally seeded with unit scales, so the accessor short-circuits. **`rust/export` seeds nowhere** — `build_constructions` (`export/src/constructions.rs:115-117`) builds its own decoder and calls this immediately.

On a foot-unit file its layer thicknesses came out ~3.28× too large, and the mm signature that buckets constructions — `(thickness * scale * 1000.0).round()` — mis-grouped build-ups.

## NOT verified by test — stated plainly

`cargo check -p ifc-lite-core` **passes**. I did **not** run the suite.

This machine is at 100% disk — 1.0 GiB free, down from 2.1 GiB during that single `cargo check` — and building the test binaries risks re-exhausting it. It *was* fully exhausted earlier today, and every command in the session failed until space was reclaimed. Trading a working session for one test run is not a good trade.

There is also **no imperial-unit fixture in the tree**, so a RED test has to be authored rather than just run. `try_extract_length_unit_scale`'s None-for-conversion-unit branch is what such a fixture would target: an `IFCPROJECT` whose `IFCUNITASSIGNMENT` carries `IFCCONVERSIONBASEDUNIT('FOOT', …)`, asserting `length_unit_scale()` returns `0.3048` rather than `1.0`.

@louistrue — please gate this one locally before merging. Given CI has been unreliable today and this is unverified beyond a type check, it deserves the local run more than most.

## From the same sweep, reported not fixed

A Rust-side sweep for the divergent-guard shape also surfaced:

- **Z-up→Y-up winding**: `export/src/frame.rs` and `wasm-bindings/.../mesh.rs` reverse triangle winding; `apps/server/src/services/axis.rs` does not. Currently masked — glTF and COLLADA both emit `double_sided`, and the server ships explicit normals — but it surfaces for any importer that back-face-culls. The swap matrix has determinant **+1**, so it preserves orientation on its own and *dropping* the reversal is the mathematically-motivated direction; `frame.rs`'s header explicitly documents matching the viewer, so this is a maintainer call.
- **`extract_face_indices_from_entity`** (`core/src/fast_parse.rs:193`) lacks the string-literal, comment-skip and structural validation its geometry twin has. Zero in-tree callers, but `pub`-exported — a latent trap rather than a live gap.
- The flagged **UV overflow** at `triangulated.rs:149` was **refuted as stated**: a bare `0` in `CoordIndex` routes to the saturating fast path and never produces `u32::MAX`. Reaching it needs a validator-rejecting character *and* a non-positive index in the same list; release behaviour is bounds-checked and the triangle is dropped anyway. Debug-build panic only — a fuzz hazard, not user-facing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected length-unit conversion handling for imperial units, ensuring they resolve to the proper scale factor.
  * Preserved existing metre-based SI unit behavior with a scale factor of `1.0`.

* **Tests**
  * Added regression coverage for imperial and SI length-unit conversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->