### PR TITLE
fix(collab-server): stop one room's snapshot overwriting another's

### DIFF
--- a/.changeset/snapshot-worker-room-key-collision.md
+++ b/.changeset/snapshot-worker-room-key-collision.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/collab-server": patch
+---
+
+Fix `SnapshotWorker` overwriting one room's `.ifcx` snapshot with another's. The output filename was built with the lossy `[^a-zA-Z0-9._-] -> _` sanitizer, which maps distinct room ids (e.g. `proj/alpha` and `proj:alpha`) onto the same name; with the timestamp component at millisecond resolution, two such rooms snapshotted in the same tick wrote to one path and the second silently replaced the first — while `runOnce()` returned a successful `SnapshotResult` for both, each reporting its own `byteLength`. The path now uses `encodeURIComponent`, matching `FilePersistence.logPath` and `S3Persistence.safeRoom`, whose comments already document why the lossy map is unsafe for a durable key. Ids the old sanitizer left unchanged (UUIDs, room codes) encode identically, so existing snapshot filenames are unaffected.

--- a/packages/collab-server/src/snapshot-worker.ts
+++ b/packages/collab-server/src/snapshot-worker.ts
@@ -88,7 +88,14 @@ export class SnapshotWorker {
         const ifcx = snapshotToIfcx(room.doc);
         const content = serializeIfcx(ifcx, false);
         const stamp = new Date(this.now()).toISOString().replace(/[:.]/g, '-');
-        const safe = t.roomId.replace(/[^a-zA-Z0-9._-]/g, '_');
+        // Reversible and collision-free, matching `FilePersistence.logPath`
+        // and `S3Persistence.safeRoom`. A lossy `[^a-zA-Z0-9._-] -> _` replace
+        // maps distinct rooms (e.g. `a/b` and `a:b`) onto one snapshot path,
+        // so two rooms snapshotted in the same millisecond silently overwrite
+        // each other while `runOnce` reports both writes as successful. Safe
+        // ids (UUIDs, room codes) are unchanged, so existing files keep their
+        // names.
+        const safe = encodeURIComponent(t.roomId);
         const filePath = path.join(this.options.outputDir, `${safe}.${stamp}.ifcx`);
         await fs.promises.writeFile(filePath, content);
         results.push({

--- a/packages/collab-server/test/room-lifecycle.test.ts
+++ b/packages/collab-server/test/room-lifecycle.test.ts
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, it, vi } from 'vitest';
+import { MemoryPersistence, type Persistence } from '../src/persistence.js';
+import { RoomManager } from '../src/room-manager.js';
+
+/**
+ * Reject paths around room load / room cap. Both are the difference between
+ * "one room is broken" and "the process is broken", and neither was asserted
+ * anywhere before.
+ */
+describe('RoomManager reject paths', () => {
+  it('propagates a persistence load failure and evicts the poisoned room', async () => {
+    const failing = { fail: true };
+    const persistence: Persistence = {
+      async load(roomId: string) {
+        if (failing.fail) throw new Error(`corrupt log for ${roomId}`);
+        return null;
+      },
+      async append() {},
+      async compact() {},
+      async drop() {},
+    };
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const mgr = new RoomManager({ persistence });
+
+      // The caller must see the failure — a room whose durable log cannot be
+      // read must not come back as a silently empty doc that then compacts
+      // its emptiness over the real state.
+      await expect(mgr.getOrCreate('broken')).rejects.toThrow(/corrupt log/);
+
+      // ...and the poisoned entry must not stay cached, or the room is
+      // bricked for the process lifetime and keeps occupying a maxRooms slot.
+      expect(mgr.list()).not.toContain('broken');
+      expect(await mgr.stats()).toEqual([]);
+
+      // Once the underlying fault clears, the same id loads normally.
+      failing.fail = false;
+      const room = await mgr.getOrCreate('broken');
+      expect(room.id).toBe('broken');
+      expect(mgr.list()).toContain('broken');
+
+      await mgr.unloadAll();
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it('rejects a new room once maxRooms is reached, without evicting live rooms', async () => {
+    const mgr = new RoomManager({ persistence: new MemoryPersistence(), maxRooms: 2 });
+    await mgr.getOrCreate('a');
+    await mgr.getOrCreate('b');
+
+    await expect(mgr.getOrCreate('c')).rejects.toThrow(/room limit \(2\)/);
+    expect(mgr.list()).toEqual(['a', 'b']);
+
+    // An already-loaded room is still served after the cap is hit — the cap
+    // guards creation, not lookup.
+    const again = await mgr.getOrCreate('a');
+    expect(again.id).toBe('a');
+
+    await mgr.unloadAll();
+  });
+});

--- a/packages/collab-server/test/snapshot-worker.test.ts
+++ b/packages/collab-server/test/snapshot-worker.test.ts
@@ -78,4 +78,38 @@ describe('SnapshotWorker', () => {
     expect(results.length).toBe(1);
     await mgr.unloadAll();
   });
+
+  it('gives rooms that differ only in unsafe characters distinct snapshot files', async () => {
+    // `FilePersistence.logPath` deliberately encodes room ids rather than
+    // replacing unsafe characters, because a lossy `[^a-zA-Z0-9._-] -> _`
+    // map collapses distinct rooms onto one path (see persistence.ts).
+    // The snapshot worker writes to the same kind of durable per-room path,
+    // so it must not collapse them either: with a fixed clock (or two rooms
+    // snapshotted in the same millisecond) the second write would silently
+    // overwrite the first while `runOnce` reported both as successful.
+    const mgr = new RoomManager({ persistence: new MemoryPersistence() });
+    const a = await mgr.getOrCreate('proj/alpha');
+    const b = await mgr.getOrCreate('proj:alpha');
+    a.doc.transact(() => a.doc.getMap('meta').set('which', 'slash'));
+    b.doc.transact(() => b.doc.getMap('meta').set('which', 'colon'));
+
+    const worker = new SnapshotWorker({
+      roomManager: mgr,
+      outputDir: tmpDir,
+      intervalMs: 60_000,
+      includeIdle: true,
+      now: () => 1_700_000_000_000,
+    });
+    const results = await worker.runOnce();
+    expect(results.length).toBe(2);
+
+    const paths = new Set(results.map((r) => r.filePath));
+    expect(paths.size).toBe(2);
+    // Every reported path must still exist: a reported write that another
+    // room's write clobbered is a success report for work that is gone.
+    for (const r of results) expect(fs.existsSync(r.filePath)).toBe(true);
+    expect(fs.readdirSync(tmpDir).length).toBe(2);
+
+    await mgr.unloadAll();
+  });
 });


### PR DESCRIPTION
`SnapshotWorker` built its `.ifcx` output path with the lossy `[^a-zA-Z0-9._-] -> _` sanitizer. Distinct rooms map onto one name — `proj/alpha` and `proj:alpha` both become `proj_alpha` — and the timestamp component is millisecond-resolution, so two such rooms snapshotted in the same tick wrote to the same path.

The second `writeFile` silently replaced the first, while `runOnce()` returned a **successful** `SnapshotResult` for *both*, each reporting its own `byteLength`.

Observed on **unmutated production code**: two rooms in, two results out, one file on disk (`expected 1 to be 2`).

**Severity: LIVE**, and durable — this is not a rendering glitch, it is a snapshot that no longer exists.

## The codebase had already ruled on this

`FilePersistence.logPath` uses `encodeURIComponent`, with a comment stating the reason almost verbatim:

> A lossy `[^a-zA-Z0-9._-] -> _` replace would map distinct rooms (e.g. `a/b` and `a:b`) onto one log file and interleave their updates.

And `legacyLogPath` keeps the lossy variant explicitly for migration **reads** — *"never for new writes."*

PR #1501 hardened `persistence.ts`, `persistence-s3.ts` and `persistence-redis.ts` together and **did not touch `snapshot-worker.ts`** — the one remaining live use of the lossy map for a durable path, and the only one with no comment justifying it.

Now `encodeURIComponent`, matching both siblings. Ids the old sanitizer left unchanged (UUIDs, room codes) encode identically, so existing snapshot filenames do not churn — the same argument `persistence.ts` makes for its own migration.

This is three of the shapes found repeatedly today at once: a **result derived from the request rather than the work**, a **key built two ways in two places**, and a **guard hardened in one copy but not its sibling**.

## Also pinned — two reject paths asserted nowhere

From the same pass, in `RoomManager`:

- A failed persistence load **evicts the poisoned promise**, so the room id is not bricked and does not hold a `maxRooms` slot, and a retry after the fault clears succeeds. Neutralising that eviction left **31 files / 146 tests green** — which is what made it worth pinning.
- The `maxRooms` cap rejects creation while still serving already-loaded rooms; mutating `>=` to `>` lets one extra room through.

Both bounded by a control: mutating `persistence.ts`'s own `encodeURIComponent` back to the lossy map **dies** against two existing tests, so the harness genuinely reaches this area and the survivors above are real gaps.

## Checked and deliberately not reported

- `persistence-redis.ts` keys with a **raw** roomId plus `:snap`/`:log`. Inconsistent with its siblings, but **injective** — the suffixes differ, so no two rooms can collide. Not a defect.
- `Room.persistAndMaybeCompact` swallowing persistence errors is **documented intentional** (in-memory state stays consistent; the next append/compact catches up; `destroy()` does a final full-state compact). One genuine observation left unfixed: `metrics.ts` has no persistence-error counter, so a persistently failing backend is stderr-only.
- `server.ts:448`'s `decodeURIComponent` means `/a%2Fb` and `/a/b` alias — but to the *same* room, which is the y-websocket convention. No split-brain.
- An `S3Persistence.compact` multi-writer truncation hazard is **inferred only** and untestable without a multi-process harness; flagged, not claimed.

## Verification

**145 → 148 passing across 32 files.** `tsc --noEmit` clean. Patch changeset included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented snapshots from different rooms with similar IDs from overwriting one another.
  - Preserved existing snapshot filenames for IDs that require no encoding.
  - Ensured failed room loads are reported and can be retried.
  - Improved room-limit handling so existing rooms remain accessible when capacity is reached.

- **Tests**
  - Added coverage for snapshot filename collisions, room-load failures, retries, and room limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->