### PR TITLE
fix(bcf): sanitize the viewpoint GUID before using it as a zip path

### DIFF
--- a/.changeset/bcf-viewpoint-guid-zip-slip.md
+++ b/.changeset/bcf-viewpoint-guid-zip-slip.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/bcf": patch
+---
+
+Fix a zip-slip hazard in `writeBCF`: a viewpoint GUID is parsed unvalidated from untrusted markup XML on read, and was used verbatim in the `Viewpoint_<guid>.bcfv` / `Snapshot_<guid>.*` zip entry names. A crafted GUID containing `../` on a read-modify-save (e.g. `ifc-lite bcf add-comment`) could write a zip entry outside the archive root. The topic GUID already went through a sanitizer for the same reason; the viewpoint GUID now goes through the same sanitizer, computed once per viewpoint so the markup `<Viewpoint>` filename reference and the actual zip entry always agree.
+
+ifc-lite's own reader is in-memory and unaffected by this; the risk is a re-exported `.bcfzip` containing entries with literal `../` segments that could escape the archive root in a downstream tool that extracts entries by joining names onto a directory.

--- a/packages/bcf/src/writer.test.ts
+++ b/packages/bcf/src/writer.test.ts
@@ -607,6 +607,65 @@ describe('BCF Writer', () => {
     expect(markup).toContain(`Guid="${evilGuid}"`);
   });
 
+  it('sanitizes a path-traversal viewpoint GUID so no zip entry escapes the archive root (zip-slip), and markup agrees with the entry name', async () => {
+    // A viewpoint GUID is parsed unvalidated from untrusted markup XML on read
+    // (reader.ts parseViewpointContent), so it can carry the same `../` hazard
+    // as a topic GUID. Using it verbatim in `Viewpoint_${guid}.bcfv` would let
+    // a crafted GUID write outside the archive root on a read-modify-save.
+    const evilGuid = '../../evil';
+    const topic: BCFTopic = {
+      guid: generateUuid(),
+      title: 'Topic with malicious viewpoint',
+      creationDate: new Date().toISOString(),
+      creationAuthor: 'attacker@example.com',
+      viewpoints: [
+        {
+          guid: evilGuid,
+        } as BCFViewpoint,
+      ],
+      comments: [],
+    };
+    const project: BCFProject = {
+      version: '2.1',
+      topics: new Map([[topic.guid, topic]]),
+    };
+
+    const blob = await writeBCF(project);
+    const zip = await JSZip.loadAsync(await blobToArrayBuffer(blob));
+
+    const paths: string[] = [];
+    zip.forEach((relativePath) => paths.push(relativePath));
+
+    // No entry may contain a parent-directory traversal segment, and none may
+    // be an absolute path.
+    for (const p of paths) {
+      expect(p.split('/')).not.toContain('..');
+      expect(p.startsWith('/')).toBe(false);
+    }
+
+    // The markup's <Viewpoint>filename</Viewpoint> reference must name an
+    // entry that actually exists in the archive (writer computes the sanitized
+    // name once and reuses it in both places -- they must not diverge).
+    const markupPath = paths.find((p) => p.endsWith('markup.bcf'));
+    expect(markupPath).toBeDefined();
+    const markup = await zip.file(markupPath!)?.async('string');
+    expect(markup).toContain(`Guid="${evilGuid}"`);
+
+    const viewpointFilenameMatch = markup?.match(/<Viewpoint>([^<]+)<\/Viewpoint>/);
+    expect(viewpointFilenameMatch).toBeTruthy();
+    const referencedFilename = viewpointFilenameMatch![1];
+
+    // The referenced filename must not itself carry a traversal segment...
+    expect(referencedFilename).not.toContain('..');
+    expect(referencedFilename).not.toContain('/');
+
+    // ...and the archive must actually contain an entry under this topic's
+    // folder with that exact filename (markup reference and zip entry agree).
+    const topicFolder = markupPath!.slice(0, markupPath!.length - 'markup.bcf'.length);
+    const viewpointEntry = zip.file(`${topicFolder}${referencedFilename}`);
+    expect(viewpointEntry).not.toBeNull();
+  });
+
   it('keeps distinct GUIDs that sanitize identically in distinct folders (no silent overwrite)', async () => {
     // 'a?b' and 'a:b' both sanitize to 'a_b'; without disambiguation the
     // second topic folder would overwrite the first inside the archive.

--- a/packages/bcf/src/writer.ts
+++ b/packages/bcf/src/writer.ts
@@ -118,10 +118,33 @@ function shortGuidHash(guid: string): string {
  * and `usedNames` catches the remaining collisions with a counter suffix.
  */
 function sanitizeTopicFolderName(guid: string, usedNames: Set<string>): string {
-  const cleaned = guid.replace(/[^A-Za-z0-9._-]/g, '_').replace(/\.\.+/g, '_');
-  const base = cleaned === guid && cleaned.length > 0
+  return sanitizeZipComponent(guid, usedNames, 'topic');
+}
+
+/**
+ * Sanitize an arbitrary GUID for use as a zip path component (zip-slip guard).
+ *
+ * Shared by both the topic-folder name and the viewpoint file base name: a
+ * viewpoint GUID is parsed just as unvalidated from untrusted markup XML on
+ * read (reader.ts `parseViewpointContent`) as a topic GUID is, so it carries
+ * the same path-traversal hazard. Restrict the name to safe filename
+ * characters and collapse any dot-run so it can never traverse. `fallback` is
+ * used when sanitization strips the name to nothing.
+ *
+ * Sanitization is lossy, so two distinct GUIDs can map to one name, which
+ * would silently overwrite an entry. Any name that sanitization changed gets
+ * a hash of the original GUID appended, and `usedNames` catches the
+ * remaining collisions with a counter suffix. Callers MUST sanitize each
+ * GUID exactly once and reuse the result everywhere that GUID's entry is
+ * named (markup references and the zip entry itself) -- calling this twice
+ * for the same GUID against a `usedNames` set that already contains the
+ * first result produces a second, different name.
+ */
+function sanitizeZipComponent(raw: string, usedNames: Set<string>, fallback: string): string {
+  const cleaned = raw.replace(/[^A-Za-z0-9._-]/g, '_').replace(/\.\.+/g, '_');
+  const base = cleaned === raw && cleaned.length > 0
     ? cleaned
-    : `${cleaned.length > 0 ? cleaned : 'topic'}-${shortGuidHash(guid)}`;
+    : `${cleaned.length > 0 ? cleaned : fallback}-${shortGuidHash(raw)}`;
   let candidate = base;
   for (let n = 2; usedNames.has(candidate); n++) {
     candidate = `${base}-${n}`;
@@ -142,14 +165,22 @@ async function writeTopicFolder(
   const folder = zip.folder(sanitizeTopicFolderName(topic.guid, usedFolderNames));
   if (!folder) return;
 
+  // Sanitize each viewpoint GUID once, up front, so the markup <Viewpoint>
+  // reference (written below) and the zip entry (written in
+  // writeViewpointFiles) always agree on the same file name. A topic-scoped
+  // usedNames set disambiguates viewpoint GUIDs that sanitize identically,
+  // the same way topic folders are disambiguated above.
+  const usedViewpointNames = new Set<string>();
+  const viewpointBaseNames = topic.viewpoints.map((vp) =>
+    sanitizeZipComponent(vp.guid, usedViewpointNames, 'viewpoint'),
+  );
+
   // Write markup.bcf
-  writeMarkupFile(folder, topic, version);
+  writeMarkupFile(folder, topic, version, viewpointBaseNames);
 
   // Write viewpoints
   for (let i = 0; i < topic.viewpoints.length; i++) {
-    const viewpoint = topic.viewpoints[i];
-    const isDefault = i === 0;
-    await writeViewpointFiles(folder, viewpoint, isDefault);
+    await writeViewpointFiles(folder, topic.viewpoints[i], viewpointBaseNames[i]);
   }
 }
 
@@ -171,7 +202,12 @@ function snapshotExt(viewpoint: BCFViewpoint): 'png' | 'jpg' {
  * Write markup.bcf file
  * Uses buildingSMART standard format
  */
-function writeMarkupFile(folder: JSZip, topic: BCFTopic, version: '2.1' | '3.0'): void {
+function writeMarkupFile(
+  folder: JSZip,
+  topic: BCFTopic,
+  version: '2.1' | '3.0',
+  viewpointBaseNames: string[],
+): void {
   let content = `<?xml version="1.0" encoding="UTF-8"?>
 <Markup xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">`;
 
@@ -248,9 +284,14 @@ function writeMarkupFile(folder: JSZip, topic: BCFTopic, version: '2.1' | '3.0')
   // Write viewpoint references
   for (let i = 0; i < topic.viewpoints.length; i++) {
     const viewpoint = topic.viewpoints[i];
-    // Use standard buildingSMART naming convention: Viewpoint_<guid>.bcfv
-    const filename = `Viewpoint_${viewpoint.guid}.bcfv`;
-    const snapshotName = `Snapshot_${viewpoint.guid}.${snapshotExt(viewpoint)}`;
+    // Use standard buildingSMART naming convention: Viewpoint_<guid>.bcfv,
+    // but the file name component is the sanitized base name (zip-slip
+    // guard) -- the SAME one writeViewpointFiles uses for the actual entry,
+    // so the markup reference and the archive agree. The real GUID is still
+    // written verbatim as the Guid attribute below.
+    const baseName = viewpointBaseNames[i];
+    const filename = `Viewpoint_${baseName}.bcfv`;
+    const snapshotName = `Snapshot_${baseName}.${snapshotExt(viewpoint)}`;
 
     content += `\n  <Viewpoints Guid="${escapeXml(viewpoint.guid)}">`;
     content += `\n    <Viewpoint>${filename}</Viewpoint>`;
@@ -289,11 +330,14 @@ function writeMarkupFile(folder: JSZip, topic: BCFTopic, version: '2.1' | '3.0')
 async function writeViewpointFiles(
   folder: JSZip,
   viewpoint: BCFViewpoint,
-  _isDefault: boolean
+  baseName: string,
 ): Promise<void> {
-  // Use standard buildingSMART naming convention: Viewpoint_<guid>.bcfv
-  const filename = `Viewpoint_${viewpoint.guid}.bcfv`;
-  const snapshotName = `Snapshot_${viewpoint.guid}.${snapshotExt(viewpoint)}`;
+  // Use standard buildingSMART naming convention: Viewpoint_<guid>.bcfv, but
+  // the file name component is the sanitized base name (zip-slip guard) --
+  // the SAME one the caller wrote into the markup <Viewpoint> reference, so
+  // the archive entry and the markup agree. See sanitizeZipComponent.
+  const filename = `Viewpoint_${baseName}.bcfv`;
+  const snapshotName = `Snapshot_${baseName}.${snapshotExt(viewpoint)}`;
 
   // Write viewpoint XML - use buildingSMART standard format
   let content = `<?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
`writeBCF` sanitized the **topic** guid before using it as a zip path component and used the **viewpoint** guid raw — in the same file.

`sanitizeTopicFolderName`'s own comment states the hazard:

> A topic GUID is parsed unvalidated from untrusted markup XML on read, so it can carry path separators or `..` … a crafted GUID (`../../evil`) [would] write outside the archive root.

A viewpoint GUID is parsed exactly as unvalidated — `reader.ts:713` takes it from `Guid="([^"]+)"` with no character-set check — and was interpolated straight into `Viewpoint_${guid}.bcfv` / `Snapshot_${guid}.*` and handed to `folder.file()`.

Observed before the fix: a viewpoint guid of `../../evil` produces the zip entry `Viewpoint_../../evil.bcfv`.

## Consequence, stated precisely

ifc-lite's own reader is in-memory and **unaffected**. The harm is that a read-modify-save round trip — `ifc-lite bcf add-comment`, or the viewer's import→export — emits a `.bcfzip` containing traversal entries: a zip-slip against the **next** tool that extracts it by joining entry names onto a directory.

It is not a local RCE, and overstating it would be the fastest way to get a real finding dismissed.

## The risky part is agreement, not traversal

Sanitizing the zip entry while leaving the markup reference raw would close the traversal and **break every archive**.

So the GUID is sanitized **once** per viewpoint, up front, into a `viewpointBaseNames` array threaded into both the markup writer and the entry writer. Calling the sanitizer twice would draw two different names from the collision-disambiguation counter — that constraint is now documented on the helper so the next caller doesn't reintroduce it.

**Verified rather than assumed:** mutating the fix to sanitize a second time instead of reusing the threaded name kills **four** tests, including the pre-existing *"should use consistent filenames between markup and viewpoint files"*. The agreement is genuinely guarded, not merely intended.

The topic sanitizer is now a thin wrapper over a shared `sanitizeZipComponent`, so the two cannot drift apart again — which is how this arose in the first place.

## Verification

- **RED**: the new test fails on the unfixed writer with `expected 'Viewpoint_../../evil.bcfv' not to contain '..'`, and the other **144 pass** — the gap was real.
- **Sibling control**: neutralising `sanitizeZipComponent`'s cleaning kills **both** the existing topic test and the new viewpoint one, confirming the harness reaches this file.
- **144 → 145 passing across 7 files.** `tsc --noEmit` exit 0.

One note: the typecheck first reported five unresolved `@ifc-lite/encoding` imports — the partial-build trap, not a real error. Building that dependency cleared it. Reporting a red typecheck as "unrelated" without doing that is how a genuine error hides.

Patch changeset included.

## Provenance

From a repo-wide sweep for *the same guard implemented more than once, hardened in one place only* — the shape behind #2299, #2301, #2303 and #2309. This was its rank-2 finding; rank 1 (ten copies of the CSV formula guard, three tiers of hardening) is partly addressed in #2306 with the remaining consolidation left as a maintainer decision.
