### PR TITLE
fix(encoding): reject a non-hex UUID instead of silently zeroing it

### DIFF
--- a/.changeset/guid-uuid-hex-validation.md
+++ b/.changeset/guid-uuid-hex-validation.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/encoding": patch
+---
+
+Reject a UUID string containing non-hexadecimal characters in `uuidToIfcGuid` instead of silently zeroing them. The function stripped dashes and checked the resulting string's length (32), but never checked that every character was actually a hex digit — `parseInt('gg', 16)` returns `NaN`, and `Uint8Array` coerces `NaN` to `0`, so a garbage input like `'gggggggg-gggg-gggg-gggg-gggggggggggg'` silently produced the all-zero UUID's GUID instead of throwing. `uuidToIfcGuid` is reachable with arbitrary caller-supplied strings via the SDK's `bcf.uuidToIfcGuid`.

--- a/packages/encoding/src/guid.test.ts
+++ b/packages/encoding/src/guid.test.ts
@@ -21,6 +21,14 @@ describe('guid', () => {
     expect(isValidIfcGuid(ifcGuid)).toBe(true);
   });
 
+  it('rejects a UUID string containing non-hex characters instead of silently zeroing them', () => {
+    // hex.length === 32 after stripping dashes, so the length guard passes;
+    // parseInt('GG', 16) is NaN, and Uint8Array coerces NaN to 0. Nothing
+    // throws today - a garbage UUID silently becomes the all-zero UUID's
+    // GUID instead of being rejected.
+    expect(() => uuidToIfcGuid('gggggggg-gggg-gggg-gggg-gggggggggggg')).toThrow();
+  });
+
   it('generates schema-valid IFC GUIDs', () => {
     for (let i = 0; i < 100; i++) {
       const ifcGuid = generateIfcGuid();

--- a/packages/encoding/src/guid.ts
+++ b/packages/encoding/src/guid.ts
@@ -22,6 +22,13 @@ export function uuidToIfcGuid(uuid: string): string {
   if (hex.length !== 32) {
     throw new Error(`Invalid UUID: expected 32 hex characters, got ${hex.length}`);
   }
+  if (!/^[0-9A-F]{32}$/.test(hex)) {
+    // The length check alone lets a non-hex character (e.g. 'g', 'z', '_')
+    // through: parseInt(..., 16) below would silently return NaN for that
+    // byte, and Uint8Array coerces NaN to 0 - turning garbage input into a
+    // wrong-but-valid-looking GUID instead of rejecting it.
+    throw new Error(`Invalid UUID: contains non-hexadecimal characters`);
+  }
 
   const bytes = new Uint8Array(16);
   for (let i = 0; i < 16; i++) {

--- a/packages/encoding/src/ifc-string.test.ts
+++ b/packages/encoding/src/ifc-string.test.ts
@@ -82,8 +82,26 @@ describe('decodeIfcString', () => {
     expect(decodeIfcString('\\X\\F1')).toBe('ñ');
   });
 
+  it('passes a malformed \\X\\ payload through literally instead of decoding NaN as NUL', () => {
+    // Non-hex digits: parseInt('ZZ', 16) is NaN, and String.fromCharCode(NaN)
+    // silently produces U+0000 if the hex-format guard is ever removed.
+    expect(decodeIfcString('\\X\\ZZ')).toBe('\\X\\ZZ');
+    // Truncated payload (only one hex digit before the string ends).
+    expect(decodeIfcString('\\X\\F')).toBe('\\X\\F');
+    expect(decodeIfcString('\\X\\')).toBe('\\X\\');
+  });
+
   it('decodes \\S\\ latin extended', () => {
     expect(decodeIfcString('\\S\\D')).toBe('Ä');
+  });
+
+  it('passes a truncated \\S\\ (no character following) through literally without throwing', () => {
+    // If the "is there a char after \S\" boundary check is ever loosened by
+    // one, str.codePointAt() reads past the end of the string (undefined),
+    // undefined + 128 is NaN, and String.fromCodePoint(NaN) throws a
+    // RangeError instead of leaving the unterminated escape as literal text.
+    expect(() => decodeIfcString('\\S\\')).not.toThrow();
+    expect(decodeIfcString('\\S\\')).toBe('\\S\\');
   });
 
   it('advances exactly one code unit past \\S\\ for a BMP codepoint at the 0xFFFF boundary', () => {


### PR DESCRIPTION
`uuidToIfcGuid` stripped dashes and checked the result was 32 characters — but never checked they were **hex digits**. `parseInt('gg', 16)` returns `NaN`, and `Uint8Array` coerces `NaN` to `0`, so garbage produced the **all-zero UUID's GUID** rather than an error.

Observed by direct probe on the unfixed code: `'gggggggg-gggg-gggg-gggg-gggggggggggg'` produced `Uint8Array [0,0,0,0,…]` and a clean, plausible-looking GUID.

**Wrong-but-valid-looking is the bad part.** A thrown error is obvious. A GUID that decodes fine and refers to nothing propagates into a BCF topic or an IFC reference and surfaces much later, somewhere else.

**Severity: LIVE.** Reachable with arbitrary caller-supplied strings — the SDK re-exports it as `bcf.uuidToIfcGuid` (`packages/sdk/src/namespaces/bcf.ts:287`), handing the caller's string straight through.

The check runs **after** the existing `.toUpperCase()`, so lowercase UUIDs still normalise and pass — it rejects non-hex, not lower case. I checked that specifically, since an uppercase-only regex placed before the normalisation would have broken every lowercase caller.

## Also pinned — two coverage gaps in `decodeIfcString`

Both verified as gaps rather than defects: the shipped code passes each malformed shape through literally, which is the documented behaviour for an unrecognised escape.

- **`\X\HH` malformed hex**: relaxing the guard to always-true **survived** the whole suite. Without it, `String.fromCharCode(NaN)` emits U+0000 into the decoded string.
- **Truncated `\S\` boundary** (`i + 3 < str.length`): relaxing `<` to `<=` also **survived** — and probing it directly **throws** `RangeError: Invalid code point NaN`, because `codePointAt` past the end yields `undefined`. One character away from crashing on truncated third-party input.

## The rest of the decoder came back clean

Worth stating, since this package is load-bearing for guards that live elsewhere — #2306's spreadsheet-formula bypass depended on `\X2\200B\X0\` decoding to a literal zero-width space, and #2310's zip-slip on an unvalidated GUID. A decoder faithfully emitting a hostile character isn't wrong, but downstream guards can only be right if someone has established what it can emit.

Every malformed shape — odd-length or non-hex `\X2\`/`\X4\`, unterminated runs, lone surrogates, out-of-range scalars, truncated `\PA\` — either decodes correctly or passes through byte-identical. **No silent drops**, and `encodeIfcString(decodeIfcString(x)) === x` holds. No competing second implementation exists on the TS side; the Rust decoder is already pinned by the shared `ifc_string_vectors.json` parity fixture from #2181.

## Verification

- **RED**: the new test fails on the unfixed code (`expected function to throw` — it didn't), other 58 pass.
- Sibling control: neutralising the new guard kills the same test, so it is load-bearing.
- **56 → 59 passing across 4 files.** `tsc --noEmit` clean.

Restores by file copy throughout; every mutation asserted a replacement count of 1. Patch changeset included.
