### PR TITLE
test(spatial): pin the ray exit-face and frustum margin boundaries

### DIFF
--- a/packages/spatial/src/bvh.test.ts
+++ b/packages/spatial/src/bvh.test.ts
@@ -162,6 +162,19 @@ describe('BVH.raycast', () => {
     expect(bvh.raycast([-0.5001, 0, 0], [0, 0, 1])).toEqual([]);
   });
 
+  it('reports a hit when the ray origin sits exactly on the exit face, pointing away', () => {
+    // Cube spans -0.5..0.5 on every axis. Origin at x=0.5 (the +x face),
+    // direction +x (away from the cube). The slab math resolves tmax to
+    // exactly 0 here (not the parallel-axis case covered above — direction
+    // is non-zero on the axis that produces the boundary). AABBUtils.intersects
+    // and the BVH itself are both inclusive at an exact touch (`<=`/`>=`);
+    // `tmax >= 0` is what keeps this consistent for the ray case. `tmax > 0`
+    // also passes every other test in this file, so only this exact-touch
+    // origin distinguishes the two.
+    const bvh = BVH.build([cube(1, [0, 0, 0])]);
+    expect(bvh.raycast([0.5, 0, 0], [1, 0, 0])).toEqual([1]);
+  });
+
   it('reports a hit when the ray starts inside a mesh', () => {
     const bvh = BVH.build([cube(1, [0, 0, 0], 5)]);
     expect(bvh.raycast([0, 0, 0], [1, 0, 0])).toEqual([1]);
@@ -383,6 +396,20 @@ describe('FrustumUtils', () => {
     expect(FrustumUtils.isAABBVisible({ planes: [{ normal: [1, 0, 0], distance: -1.4 }] }, b)).toBe(true);
     // Plane at x = 1.6 → 0.6 m behind: past the margin, culled.
     expect(FrustumUtils.isAABBVisible({ planes: [{ normal: [1, 0, 0], distance: -1.6 }] }, b)).toBe(false);
+  });
+
+  it('keeps an AABB exactly at the margin boundary, and culls a hair past it', () => {
+    // Positive vertex on +x is 1. Plane at x = 1.5 puts it exactly 0.5 m
+    // behind the plane — precisely PLANE_EPSILON. `distance < EPSILON` keeps
+    // this (distance === EPSILON does not satisfy strict '<'); `distance <=
+    // EPSILON` would wrongly cull it, and every other test in this file
+    // (which all use a 0.1 m margin either side of the boundary) still
+    // passes under that mutant.
+    const b = box(-1, -1, -1, 1, 1, 1);
+    expect(FrustumUtils.isAABBVisible({ planes: [{ normal: [1, 0, 0], distance: -1.5 }] }, b)).toBe(true);
+    // A hair past the boundary is culled either way — distinguishes "exact
+    // boundary" from "always keep".
+    expect(FrustumUtils.isAABBVisible({ planes: [{ normal: [1, 0, 0], distance: -1.500001 }] }, b)).toBe(false);
   });
 
   it('applies the same positive-vertex rule for a negative-facing normal', () => {


### PR DESCRIPTION
Two boundaries in the BVH were one character from wrong and untested.

| guard | mutation | before |
|---|---|---|
| `rayIntersectsAABB`: `return tmax >= 0` | → `> 0` | survived |
| `isAABBVisible`: `distance < PLANE_EPSILON` | → `<=` | survived |

**The ray one matters for consistency, not just correctness.** A ray whose origin sits exactly on a non-parallel exit face (`tmax === 0`) would stop reporting a hit — and the inclusive form is what keeps this agreeing with `AABBUtils`' own `<=`/`>=` face-touch convention. The two would have silently disagreed about a shared surface, which is the paired-value shape behind several of this week's live bugs.

**The frustum one is a constant whose defining boundary was never probed.** `PLANE_EPSILON` is `-0.5`, a deliberate anti-flicker margin, and the existing tests only sample 0.1 m either side of it.

Both are **coverage gaps, not live bugs** — the shipped comparisons are correct at both boundaries.

## What the tests assert

Each pins the boundary **and** the far side of it — *"keeps at the margin, culls a hair past it"* — so neither can be satisfied by a predicate that accepts everything or rejects everything.

## One mutation deliberately not reported as a finding

`Math.floor` → `Math.ceil` on the split midpoint also survives. But both children are always recursed, so split direction changes tree *shape*, not query results — an equivalent mutant. The file's existing test comments already record the same conclusion for the split-axis choice, so reporting it would have been noise.

## Verification

- Both mutations applied and re-run **by hand** before pushing; each fails exactly its own new test, 48/49.
- Bounding control: deleting the right-child recursion in `queryNode` kills **7** tests — the harness genuinely reaches this file, so the two survivors are real gaps rather than dead code.
- **47 → 49 passing across 3 files.** `tsc --noEmit` exit 0.

Test-only; no changeset.

One process note: this worktree had no `node_modules`, so the agent's reported test run could not have happened as described. I installed dependencies and re-ran everything — baseline, both REDs, and the control — before trusting any of it. The tests themselves turned out sound; the evidence for them did not exist until I produced it.

Also worth flagging: the typecheck initially failed on an unresolved `@ifc-lite/geometry` import — the partial-build trap, not a real error. Building that dependency cleared it.
