### PR TITLE
test(cache): pin the two corruption guards on the binary cache read path

### DIFF
--- a/packages/cache/src/sections/entity-index.test.ts
+++ b/packages/cache/src/sections/entity-index.test.ts
@@ -1,0 +1,69 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * entity-index.ts had no dedicated unit test: readEntityIndex's downstream
+ * lookups (`typeNames[typeIndices[i]]`) silently yield `undefined` for a
+ * corrupt typeIndex, so the function guards against that with an explicit
+ * throw. Mutation testing showed that guard's reject path was asserted
+ * nowhere — deleting it left the full cache suite (including cache.test.ts's
+ * happy-path entity-index round-trip) green, because every existing test
+ * only ever writes valid, in-range typeIndex values.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { writeEntityIndex, readEntityIndex } from './entity-index.js';
+import { BufferWriter, BufferReader } from '../utils/buffer-utils.js';
+import type { CacheEntityIndex } from '../types.js';
+
+function roundTrip(index: CacheEntityIndex) {
+  const writer = new BufferWriter();
+  writeEntityIndex(writer, index);
+  return readEntityIndex(new BufferReader(writer.build()));
+}
+
+describe('EntityIndex section round-trip', () => {
+  it('round-trips ids, byte ranges and type names for valid input', () => {
+    const byId = new Map<number, { expressId: number; type: string; byteOffset: number; byteLength: number; lineNumber: number }>([
+      [1, { expressId: 1, type: 'IFCWALL', byteOffset: 10, byteLength: 20, lineNumber: 0 }],
+      [2, { expressId: 2, type: 'IFCSLAB', byteOffset: 30, byteLength: 15, lineNumber: 0 }],
+    ]);
+    const restored = roundTrip({ byId });
+
+    expect(Array.from(restored.ids)).toEqual([1, 2]);
+    expect(Array.from(restored.byteOffsets)).toEqual([10, 30]);
+    expect(Array.from(restored.byteLengths)).toEqual([20, 15]);
+    expect(restored.typeNames[restored.typeIndices[0]]).toBe('IFCWALL');
+    expect(restored.typeNames[restored.typeIndices[1]]).toBe('IFCSLAB');
+  });
+
+  it('rejects a typeIndex that points outside the typeNames table (corrupt/truncated cache)', () => {
+    // Write a valid, single-type-name section, then corrupt the on-disk
+    // typeIndices column so it addresses a type name that doesn't exist —
+    // simulating truncation/corruption between the typeNames block and the
+    // columnar arrays without hand-building the whole binary layout.
+    const byId = new Map<number, { expressId: number; type: string; byteOffset: number; byteLength: number; lineNumber: number }>([
+      [1, { expressId: 1, type: 'IFCWALL', byteOffset: 0, byteLength: 1, lineNumber: 0 }],
+    ]);
+    const writer = new BufferWriter();
+    writeEntityIndex(writer, { byId });
+    const bytes = new Uint8Array(writer.build());
+
+    // Layout: count(u32) typeNameCount(u32) [typeName strings] ids[] byteOffsets[]
+    // byteLengths[] typeIndices[u16]. With one entity and one type name, the
+    // typeIndices column is the last 2 bytes of the buffer.
+    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    const corruptTypeIndex = 0xffff; // guaranteed out of range for a 1-entry typeNames table
+    view.setUint16(bytes.byteLength - 2, corruptTypeIndex, true);
+
+    expect(() => readEntityIndex(new BufferReader(bytes.buffer))).toThrow(
+      /Corrupt cache entity-index: typeIndex \d+ at row \d+ exceeds typeNames length \d+/,
+    );
+
+    // Control: the untouched (truthful) buffer still reads cleanly — the
+    // throw above is caused by the corruption, not the fixture itself.
+    const clean = new Uint8Array(writer.build());
+    expect(() => readEntityIndex(new BufferReader(clean.buffer))).not.toThrow();
+  });
+});

--- a/packages/cache/src/sections/geometry-chunks.test.ts
+++ b/packages/cache/src/sections/geometry-chunks.test.ts
@@ -11,8 +11,9 @@ import {
   groupMeshesIntoChunks,
   deflateRaw,
   inflateRaw,
+  decodeGeometryChunk,
 } from './geometry-chunks.js';
-import { GeometryChunkFlags } from '../types.js';
+import { GeometryChunkFlags, type GeometryChunkInfo } from '../types.js';
 
 const coordInfo = (overrides: Partial<CoordinateInfo> = {}): CoordinateInfo => ({
   originShift: { x: 1.5, y: -2.5, z: 1e6 },
@@ -163,5 +164,35 @@ describe('v13 geometry section round-trip', () => {
     const result = await readGeometryV13(section, 0, 13);
     expect(result.meshes).toEqual([]);
     expect(result.totalVertices).toBe(0);
+  });
+});
+
+describe('decodeGeometryChunk length verification', () => {
+  // Mutation testing showed this guard's reject path was asserted nowhere:
+  // deleting the `raw.byteLength !== info.uncompressedLength` check in
+  // decodeGeometryChunk left the full suite green. A directory entry that
+  // lies about a chunk's decoded length (truncation, corruption, or a
+  // writer/reader offset drift) must fail loudly instead of silently
+  // handing the decoder a short/long mesh-record stream it would then
+  // mis-parse into garbage vertex/index data.
+  it('throws when the stored bytes decode to a length that disagrees with the directory', async () => {
+    const meshes = [mesh(1, [0, 0, 0])];
+    const section = await buildGeometrySectionV13(meshes, coordInfo(), { compress: false });
+    const open = openGeometryChunksV13(section, 0, 13);
+    const realInfo = open.chunks[0];
+    expect(realInfo.flags & GeometryChunkFlags.DeflateRaw).toBe(0); // uncompressed: raw === stored
+
+    const bytes = new Uint8Array(section);
+    const stored = bytes.subarray(realInfo.byteOffset, realInfo.byteOffset + realInfo.byteLength);
+
+    // Directory claims one more byte than the record actually decodes to.
+    const lyingInfo: GeometryChunkInfo = { ...realInfo, uncompressedLength: realInfo.uncompressedLength + 1 };
+    await expect(decodeGeometryChunk(stored, lyingInfo, 13)).rejects.toThrow(
+      /Invalid cache: chunk decoded to \d+ bytes, directory says \d+/,
+    );
+
+    // Control: the real (truthful) info round-trips fine — the throw above is
+    // caused by the lie, not some unrelated failure in the fixture.
+    await expect(decodeGeometryChunk(stored, realInfo, 13)).resolves.toBeTruthy();
   });
 });

--- a/packages/cache/src/sections/geometry-chunks.test.ts
+++ b/packages/cache/src/sections/geometry-chunks.test.ts
@@ -192,7 +192,11 @@ describe('decodeGeometryChunk length verification', () => {
     );
 
     // Control: the real (truthful) info round-trips fine — the throw above is
-    // caused by the lie, not some unrelated failure in the fixture.
-    await expect(decodeGeometryChunk(stored, realInfo, 13)).resolves.toBeTruthy();
+    // caused by the lie, not some unrelated failure in the fixture. Assert
+    // the decoded content itself (mesh count + expressId), not mere
+    // truthiness: an empty array is also truthy and would satisfy a
+    // `resolves.toBeTruthy()` check whether or not any mesh actually decoded.
+    const decoded = await decodeGeometryChunk(stored, realInfo, 13);
+    expectMeshesEqual(decoded, meshes);
   });
 });


### PR DESCRIPTION
Two guards on the binary cache read path had their reject path asserted nowhere. Both exist in production and are **correct** — but deleting either left the whole suite green, so nothing was holding them there.

## The two gaps

**`geometry-chunks.ts` — `decodeGeometryChunk` length verification.** The check that a decoded chunk's byte length matches the directory's declared `uncompressedLength`. Replacing the condition with `false` kept **66/66 green**.

This is the only defense against a directory that lies about a chunk's true size — truncation, corruption, or a writer/reader offset drift on the chunked path. Without it the decoder receives a short or long mesh-record stream and mis-parses it into garbage vertex and index data instead of failing loudly. A wrong mesh is much harder to trace back than a rejected cache.

**`entity-index.ts` — `readEntityIndex` typeIndex range check.** The check that every `typeIndex` addresses a real `typeNames` entry. Also **66/66 green** when neutralised.

There was no `entity-index.test.ts` at all. The section was exercised only through `cache.test.ts`'s happy-path round trip, which by construction never writes an out-of-range index. Without the guard, downstream `typeNames[typeIndices[i]]` lookups silently yield `undefined` type names.

## Severity

Both are **COVERAGE GAPS, not live bugs.** The shipped comparisons are correct today. A throw from either is handled by `BinaryCacheReader.read()`'s caller as a cache miss and re-parse, which matches how the other validation throws in this package behave — so the guards are the right design, they were just unpinned.

## How the tests are bounded

Each new test carries a **control** asserting the truthful input still resolves, so neither can pass by way of a fixture that is simply broken — a test that throws for an unrelated reason would fail the control.

The entity-index corruption test writes a valid section through the real writer and then flips the on-disk `typeIndices` column to `0xffff`, rather than hand-building the binary layout. That keeps it honest if the layout changes: it corrupts a real buffer instead of asserting against a hand-copied one that could silently drift from the format.

## Checked and found already covered — not reported as findings

- `DIRECTORY_ENTRY_BYTES`: mutating 44 → 40 already fails 9 tests.
- Instanced-shard truncation guards: already pinned in `instanced-shards.test.ts`.
- Header and version negotiation: `header.test.ts` already pins the magic bytes as literals, the section-table field offsets, and future-version rejection.
- `BufferReader`'s `ensureAvailable` bounds checking, which is systemic and covers short reads for every primitive.
- The `headLength` field in the v13 head is written but read by nothing in-repo (explicitly `void`-ed with a comment reserving it for a future range reader) — no gap, since nothing trusts it today.

## Verification

**66 → 69 passing across 10 files.** `tsc --noEmit` exit 0.

Each guard was mutated to `if (false)` independently, with an asserted replacement count of 1 and the mutated line re-read; in both cases **exactly one test failed — the new one** — so all 66 pre-existing tests pass under the mutation, which is the gap itself. Restores were done by file copy from a backup, and the production sources are byte-identical to `main`: this PR changes tests only.

The typecheck needs `@ifc-lite/geometry` built first, otherwise an unrelated module-resolution error masks the real result.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for reading entity indexes, including valid round trips and corrupted on-disk data.
  * Added validation ensuring geometry chunks are rejected when declared uncompressed lengths are incorrect.
  * Confirmed valid geometry metadata continues to decode successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->