### PR TITLE
test(merge): pin mergeIntoRef's fast-forward-on-ref-tip branch

### DIFF
--- a/packages/merge/src/ref-flow-policy-ancestor.test.ts
+++ b/packages/merge/src/ref-flow-policy-ancestor.test.ts
@@ -364,3 +364,80 @@ describe('checkRefPolicy: requiredChecks enforcement', () => {
     expect(reason).toMatch(/spec-a/);
   });
 });
+
+/**
+ * `mergeIntoRef`'s "candidate authored against the ref's current stack"
+ * fast-forward branch (the common push-with-no-conflicts case) was never
+ * exercised by any test in `merge`, `cli`, or `collab-server` — every
+ * existing `fast-forward` assertion instead went through the EARLIER
+ * "candidate already on the ref" branch. That left `waiversConsumed`'s
+ * effect on this specific branch unpinned: a merge that only succeeds
+ * because a required check was waived must fall through to the three-way
+ * path so the waiver lands in a durable `manifest.merge.waived_checks`
+ * record, rather than fast-forwarding (which appends no merge layer, so
+ * the waiver is never recorded). Verified BEFORE writing these tests, by
+ * mutating the `if (!waiversConsumed(...))` guard at ref-flow.ts to
+ * `if (true)`: the full unmodified suite (88 tests) stayed green, and so
+ * did a second mutation on the same branch's `refLayers` construction —
+ * proving the branch was entirely unreached. Production itself is
+ * correct; this closes the gap.
+ */
+describe('mergeIntoRef: fast-forward branch for a candidate built on the ref tip', () => {
+  const store = () => new MemoryStore();
+
+  function seedRef(policy?: RefEntry['policy']) {
+    const s = store();
+    const baseLayer = publishable([{ path: 'wall-1', attributes: {} }], 'Base', null);
+    s.storeLayer(baseLayer);
+    s.setRef('protected', { layers: [baseLayer.header.id], ...(policy ? { policy } : {}) });
+    const stackId = computeStackHash([baseLayer.header.id]);
+    return { store: s, baseLayer, stackId };
+  }
+
+  it('fast-forwards a plain candidate with no ref policy', () => {
+    const { store: s, stackId } = seedRef();
+    const candidate = publishable(
+      [{ path: 'wall-1', attributes: { [FIRE]: 'REI180' } }],
+      'Edit',
+      { kind: 'stack', id: stackId },
+    );
+    s.storeLayer(candidate);
+    const outcome = mergeIntoRef(s, { candidateId: candidate.header.id, into: 'protected' });
+    expect(outcome.status).toBe('fast-forward');
+    if (outcome.status !== 'fast-forward') return;
+    expect(outcome.refLayers).toEqual(expect.arrayContaining([candidate.header.id]));
+  });
+
+  it('does NOT fast-forward when completion relies on a waived required check — it must record the waiver on a merge layer', () => {
+    const { store: s, stackId } = seedRef({ requiredChecks: ['spec-a'] });
+    const candidate = publishable(
+      [{ path: 'wall-1', attributes: { [FIRE]: 'REI180' } }],
+      'Edit',
+      { kind: 'stack', id: stackId },
+    );
+    s.storeLayer(candidate);
+    const outcome = mergeIntoRef(s, {
+      candidateId: candidate.header.id,
+      into: 'protected',
+      waivers: [{ spec: 'spec-a', reason: 'known flaky, waived' }],
+    });
+    expect(outcome.status).toBe('merged');
+  });
+
+  it('fast-forwards when the required check genuinely passes (no waiver consumed)', () => {
+    const { store: s, stackId } = seedRef({ requiredChecks: ['spec-a'] });
+    const manifest = createProvenanceManifest({
+      author: { kind: 'human', principal: 'alice' },
+      intent: 'Edit',
+      base: { kind: 'stack', id: stackId },
+      created: '2026-08-04T00:00:00Z',
+      checks: [{ tool: 't', spec: 'spec-a', result: 'pass' }],
+    });
+    const candidate = withId(
+      setProvenance(bare([{ path: 'wall-1', attributes: { [FIRE]: 'REI180' } }]), manifest),
+    );
+    s.storeLayer(candidate);
+    const outcome = mergeIntoRef(s, { candidateId: candidate.header.id, into: 'protected' });
+    expect(outcome.status).toBe('fast-forward');
+  });
+});

--- a/packages/merge/src/ref-flow-policy-ancestor.test.ts
+++ b/packages/merge/src/ref-flow-policy-ancestor.test.ts
@@ -20,7 +20,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { computeLayerId, computeStackHash, createProvenanceManifest, setProvenance } from '@ifc-lite/ifcx';
+import { computeLayerId, computeStackHash, createProvenanceManifest, getProvenance, setProvenance } from '@ifc-lite/ifcx';
 import type { IfcxFile, IfcxNode, ProvenanceBase } from '@ifc-lite/ifcx';
 import { extractStackState } from './component-state.js';
 import { checkRefPolicy, mergeIntoRef, resolveAncestor } from './ref-flow.js';
@@ -395,7 +395,7 @@ describe('mergeIntoRef: fast-forward branch for a candidate built on the ref tip
   }
 
   it('fast-forwards a plain candidate with no ref policy', () => {
-    const { store: s, stackId } = seedRef();
+    const { store: s, baseLayer, stackId } = seedRef();
     const candidate = publishable(
       [{ path: 'wall-1', attributes: { [FIRE]: 'REI180' } }],
       'Edit',
@@ -405,7 +405,11 @@ describe('mergeIntoRef: fast-forward branch for a candidate built on the ref tip
     const outcome = mergeIntoRef(s, { candidateId: candidate.header.id, into: 'protected' });
     expect(outcome.status).toBe('fast-forward');
     if (outcome.status !== 'fast-forward') return;
-    expect(outcome.refLayers).toEqual(expect.arrayContaining([candidate.header.id]));
+    // ORDER is the contract this branch implements: the base layer stays
+    // first and the candidate is appended after it. `arrayContaining` (or
+    // asserting `status` alone) passes for a fast-forward that produced the
+    // wrong layer order, which is exactly the failure worth catching.
+    expect(outcome.refLayers).toEqual([baseLayer.header.id, candidate.header.id]);
   });
 
   it('does NOT fast-forward when completion relies on a waived required check — it must record the waiver on a merge layer', () => {
@@ -422,10 +426,21 @@ describe('mergeIntoRef: fast-forward branch for a candidate built on the ref tip
       waivers: [{ spec: 'spec-a', reason: 'known flaky, waived' }],
     });
     expect(outcome.status).toBe('merged');
+    if (outcome.status !== 'merged') return;
+
+    // The POINT of falling through to the three-way path is that the waiver
+    // becomes durable, not merely that the fast path was skipped. Asserting
+    // `status` alone passes for an implementation that waives the check and
+    // records NOTHING -- which would leave the ref indistinguishable from one
+    // whose required check genuinely passed.
+    const mergeLayer = s.loadLayer(outcome.mergeLayerId);
+    expect(getProvenance(mergeLayer)?.merge?.waived_checks).toEqual([
+      expect.objectContaining({ spec: 'spec-a', reason: 'known flaky, waived' }),
+    ]);
   });
 
   it('fast-forwards when the required check genuinely passes (no waiver consumed)', () => {
-    const { store: s, stackId } = seedRef({ requiredChecks: ['spec-a'] });
+    const { store: s, baseLayer, stackId } = seedRef({ requiredChecks: ['spec-a'] });
     const manifest = createProvenanceManifest({
       author: { kind: 'human', principal: 'alice' },
       intent: 'Edit',
@@ -439,5 +454,7 @@ describe('mergeIntoRef: fast-forward branch for a candidate built on the ref tip
     s.storeLayer(candidate);
     const outcome = mergeIntoRef(s, { candidateId: candidate.header.id, into: 'protected' });
     expect(outcome.status).toBe('fast-forward');
+    if (outcome.status !== 'fast-forward') return;
+    expect(outcome.refLayers).toEqual([baseLayer.header.id, candidate.header.id]);
   });
 });


### PR DESCRIPTION
`mergeIntoRef`'s "candidate authored against the ref's current stack" fast-forward path — the common push-with-no-conflicts case — was **entirely unreached** by the test suite. Every existing `fast-forward` assertion goes through the *earlier* "candidate already on the ref" branch instead.

## What was unpinned

That left the branch's waiver gate untested. A merge that only completes because a required check was **waived** must fall through to the three-way path, so the waiver is durably recorded in `manifest.merge.waived_checks` on an actual merge layer.

A fast-forward appends no layer at all. So a waiver taken on this path would leave no trace on the ref — a required check would read as *satisfied* rather than *waived*, which is precisely the distinction the waiver mechanism exists to preserve.

## Bounding control — "unpinned" vs "never called"

A surviving mutation means either the guard is unpinned or the code is never called. Both were measured:

- Mutating `if (!waiversConsumed(entry, manifest, waivers))` → `if (true)`: **all 88 tests green.**
- A second, blatant mutation on the same branch — dropping `candidateId` from `refLayers`, i.e. fast-forwarding the ref *without* the candidate's layer, straightforward data loss: **also green.**

The second is what makes the first meaningful. The branch was invisible to the suite, not merely under-asserted. Both mutations are killed by the new tests.

## Severity

**COVERAGE GAP, not a live bug.** The shipped guard is correct. Probed directly against unmutated code, a waiver-consuming candidate returns `merged`; the same probe against the mutated guard returns `fast-forward`.

## Why three tests

So the waiver case cannot pass for the wrong reason:

1. A plain candidate with no policy fast-forwards — pins that the branch is reached and the candidate layer is appended.
2. A waiver-consuming candidate must come back `merged`.
3. A candidate whose required check **genuinely passes** still fast-forwards.

Without the third, the second would also pass if *any* policy at all defeated the fast path — which would pin the wrong thing entirely.

## Reviewed and found clean — not reported

- `three-way.ts`'s alive-state flip detection: mutation killed by 14 tests across the subtree-shadow and resurrect suites.
- `inverse.ts`'s re-tombstone-on-add/resurrect branch: killed by 2 tests, despite having no dedicated test file — covered transitively.
- `state-diff.ts` add/delete/modify classification: killed cleanly.
- `component-state.ts`'s fast-path tombstone guard: `applyNodeCow` has no `IFCLITE_ATTR.DELETED` handling, but the touched-path scan rejects any stack carrying a tombstone before it ever runs, and `fast-path-differential.test.ts` exists to fuzz that equivalence. Not a gap.

## Verification

**88 → 91 passing / 4 skipped across 9 files.** `tsc --noEmit` exit 0.

Production code is byte-identical to `main` — this PR changes tests only. Every mutation asserted a replacement count of 1 with the mutated line re-read, and restores were done by file copy from a backup.

The typecheck needs the workspace deps built first, otherwise an unresolved `@ifc-lite/diff` masks the real result.
