### PR TITLE
fix(bcf): write and read BCF 3.0 BimSnippet and DocumentReference shapes

### DIFF
--- a/.changeset/bcf-30-snippet-and-document-shapes.md
+++ b/.changeset/bcf-30-snippet-and-document-shapes.md
@@ -1,0 +1,13 @@
+---
+"@ifc-lite/bcf": minor
+---
+
+Fix BCF 3.0 `BimSnippet` and `DocumentReference` being written and read in the BCF 2.1 shape, which made our 3.0 output schema-invalid and silently dropped or corrupted the equivalent fields when reading a spec-correct 3.0 file from another vendor's tool.
+
+Three divergences between the two schema versions were unhandled (all per `buildingSMART/BCF-XML` `markup.xsd`):
+
+- `BimSnippet`'s external flag is `isExternal` in 2.1 and `IsExternal` in 3.0. The reader only matched the lowercase spelling, so a spec-correct 3.0 file with `IsExternal="true"` read back as `isExternal: false` — a silent wrong value, not a parse failure. The writer emitted lowercase at version 3.0. The same rename is already handled for the `Header`/`<File>` attribute; this applies the identical treatment to `BimSnippet`.
+- `DocumentReference` replaced 2.1's `<ReferencedDocument>` plus `isExternal` with a choice of `<DocumentGuid>` (a reference into `project.bcfp`'s Documents) or `<Url>`, dropping `isExternal` entirely. The reader required `<ReferencedDocument>` to be present, so every reference in a 3.0 file was dropped; the writer emitted the 2.1 shape regardless of version.
+- 3.0 groups the entries under a single `<DocumentReferences>` container, while 2.1 repeats `<DocumentReference>` directly under `<Topic>`. The writer emitted the 2.1 containment at version 3.0.
+
+`BCFDocumentReference` gains optional `documentGuid` and `url`, and `isExternal`/`referencedDocument` become optional since 3.0 has no equivalent — hence a minor rather than a patch, as reading either field now requires a presence check.

--- a/packages/bcf/src/reader.ts
+++ b/packages/bcf/src/reader.ts
@@ -468,7 +468,10 @@ function extractBimSnippet(content: string): BCFBimSnippet | undefined {
   const match = content.match(/<BimSnippet\s+SnippetType="([^"]+)"[^>]*>([\s\S]*?)<\/BimSnippet>/);
   if (!match) return undefined;
 
-  const isExternalMatch = match[0].match(/isExternal="([^"]+)"/);
+  // BCF 2.1 spells this `isExternal`, 3.0 `IsExternal` (same rename as the
+  // Header `<File>` attribute in reader.ts's parseHeaderFiles); accept either
+  // casing so a spec-correct 3.0 file's flag isn't silently read as false.
+  const isExternalMatch = match[0].match(/\b[Ii]sExternal="([^"]+)"/);
   const reference = extractElement(match[2], 'Reference');
   const referenceSchema = extractElement(match[2], 'ReferenceSchema');
 
@@ -482,22 +485,37 @@ function extractBimSnippet(content: string): BCFBimSnippet | undefined {
 
 /**
  * Extract document references from topic content
+ *
+ * BCF 2.1's `<DocumentReference>` carries `<ReferencedDocument>` plus an
+ * `isExternal` flag; BCF 3.0 replaced that with `<DocumentGuid>` (internal,
+ * into project.bcfp's Documents) or `<Url>` (external), and dropped
+ * `isExternal` entirely (buildingSMART/BCF-XML markup.xsd). Parse whichever
+ * shape is present rather than assuming 2.1, so a 3.0 file's document
+ * references aren't silently dropped.
  */
 function extractDocumentReferences(content: string): BCFDocumentReference[] {
   const refs: BCFDocumentReference[] = [];
-  const matches = content.matchAll(/<DocumentReference[^>]*>([\s\S]*?)<\/DocumentReference>/g);
+  // `(?![A-Za-z])` keeps 3.0's <DocumentReferences> CONTAINER from matching as
+  // if it were an entry: without it the container's opening tag pairs with the
+  // first entry's closing tag, and the first reference is only parsed
+  // correctly by accident of that overlap.
+  const matches = content.matchAll(/<DocumentReference(?![A-Za-z])[^>]*>([\s\S]*?)<\/DocumentReference>/g);
 
   for (const match of matches) {
     const guidMatch = match[0].match(/Guid="([^"]+)"/);
-    const isExternalMatch = match[0].match(/isExternal="([^"]+)"/);
+    const isExternalMatch = match[0].match(/\bisExternal="([^"]+)"/);
     const referencedDoc = extractElement(match[1], 'ReferencedDocument');
+    const documentGuid = extractElement(match[1], 'DocumentGuid');
+    const url = extractElement(match[1], 'Url');
     const description = extractElement(match[1], 'Description');
 
-    if (referencedDoc) {
+    if (referencedDoc || documentGuid || url) {
       refs.push({
         guid: guidMatch?.[1],
-        isExternal: isExternalMatch?.[1] === 'true',
+        isExternal: isExternalMatch ? isExternalMatch[1] === 'true' : undefined,
         referencedDocument: referencedDoc,
+        documentGuid,
+        url,
         description,
       });
     }

--- a/packages/bcf/src/types.ts
+++ b/packages/bcf/src/types.ts
@@ -97,8 +97,18 @@ export interface BCFBimSnippet {
 
 export interface BCFDocumentReference {
   guid?: string;
-  isExternal: boolean;
-  referencedDocument: string;
+  /**
+   * BCF 2.1 only: whether `referencedDocument` is an external URL. Dropped
+   * entirely from the BCF 3.0 schema, which distinguishes `documentGuid`
+   * (internal, into project.bcfp's Documents) from `url` (external) instead.
+   */
+  isExternal?: boolean;
+  /** BCF 2.1 `<ReferencedDocument>`. */
+  referencedDocument?: string;
+  /** BCF 3.0 `<DocumentGuid>`: reference into project.bcfp's Documents. */
+  documentGuid?: string;
+  /** BCF 3.0 `<Url>`: external document link. */
+  url?: string;
   description?: string;
 }
 

--- a/packages/bcf/src/writer.test.ts
+++ b/packages/bcf/src/writer.test.ts
@@ -1007,6 +1007,12 @@ describe('BCF Writer', () => {
     expect(markup30).toContain('<Url>https://example.com/spec.pdf</Url>');
     expect(markup30).not.toContain('<ReferencedDocument>');
     expect(markup30).not.toContain('isExternal');
+    // Presence of both tags alone doesn't prove containment: a regression
+    // that emits <DocumentReference> as a sibling of an empty
+    // <DocumentReferences></DocumentReferences> would still satisfy plain
+    // toContain checks. Require the entry to appear NESTED inside the
+    // container, matching buildingSMART/BCF-XML markup.xsd for 3.0.
+    expect(markup30).toMatch(/<DocumentReferences>[\s\S]*<DocumentReference[\s\S]*<\/DocumentReferences>/);
 
     const project: BCFProject = { version: '3.0', topics: new Map([[topic.guid, topic]]) };
     const readTopic = (await readBCF(await (await writeBCF(project)).arrayBuffer()))
@@ -1031,11 +1037,13 @@ describe('BCF Writer', () => {
     <Title>Vendor topic</Title>
     <CreationDate>2026-01-01T00:00:00Z</CreationDate>
     <CreationAuthor>vendor@example.com</CreationAuthor>
-    <DocumentReference Guid="docref-1">
-      <DocumentGuid>doc-guid-1</DocumentGuid>
-      <Url>https://example.com/doc.pdf</Url>
-      <Description>Spec doc</Description>
-    </DocumentReference>
+    <DocumentReferences>
+      <DocumentReference Guid="docref-1">
+        <DocumentGuid>doc-guid-1</DocumentGuid>
+        <Url>https://example.com/doc.pdf</Url>
+        <Description>Spec doc</Description>
+      </DocumentReference>
+    </DocumentReferences>
   </Topic>
 </Markup>`,
     );
@@ -1068,6 +1076,15 @@ describe('BCF Writer', () => {
     const markup30 = await markupFor(topic, '3.0');
     expect(markup30).toContain('<DocumentReferences>');
     expect(markup30).toContain('</DocumentReferences>');
+    // toContain alone doesn't prove containment: a regression that emits both
+    // entries as siblings of an empty <DocumentReferences></DocumentReferences>
+    // would still satisfy the two checks above. Require both entries to sit
+    // between the container's open and close tags.
+    const containerMatch = markup30.match(/<DocumentReferences>([\s\S]*)<\/DocumentReferences>/);
+    expect(containerMatch).not.toBeNull();
+    const containerBody = containerMatch![1];
+    expect(containerBody).toContain('Guid="dr-1"');
+    expect(containerBody).toContain('Guid="dr-2"');
 
     // Control: 2.1 must NOT gain the wrapper, so this pins the version split
     // rather than just "the wrapper is always emitted".

--- a/packages/bcf/src/writer.test.ts
+++ b/packages/bcf/src/writer.test.ts
@@ -941,4 +941,153 @@ describe('BCF Writer', () => {
     };
     expect(await paths()).toEqual(await paths());
   });
+
+  it('writes BimSnippet IsExternal with BCF 3.0 casing, and round-trips it back to true', async () => {
+    // BCF 2.1 spells the attribute `isExternal`; 3.0 renamed it `IsExternal`
+    // (buildingSMART/BCF-XML markup.xsd). Writing lowercase at version 3.0
+    // produces schema-invalid markup, and a reader that only recognizes
+    // lowercase would silently read a spec-correct 3.0 file's flag as false.
+    const topic = baseTopic({
+      bimSnippet: {
+        snippetType: 'IFC',
+        isExternal: true,
+        reference: 'a.ifc',
+        referenceSchema: 'https://example.com/schema.xsd',
+      },
+    });
+
+    const markup30 = await markupFor(topic, '3.0');
+    expect(markup30).toContain('IsExternal="true"');
+    expect(markup30).not.toContain(' isExternal="true"');
+
+    const project: BCFProject = { version: '3.0', topics: new Map([[topic.guid, topic]]) };
+    const readTopic = (await readBCF(await (await writeBCF(project)).arrayBuffer()))
+      .topics.get(topic.guid)!;
+    expect(readTopic.bimSnippet?.isExternal).toBe(true);
+  });
+
+  it('reads a genuine BCF 3.0 BimSnippet (IsExternal, capital I) authored by a third-party tool', async () => {
+    // Not a round trip through our own writer: this is the shape a spec-correct
+    // external BCF 3.0 tool actually emits, straight into our reader.
+    const zip = new JSZip();
+    zip.file('bcf.version', '<?xml version="1.0" encoding="UTF-8"?>\n<Version VersionId="3.0"></Version>');
+    zip.folder('t1')!.file(
+      'markup.bcf',
+      `<?xml version="1.0" encoding="UTF-8"?>
+<Markup xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Topic Guid="t1">
+    <Title>Vendor topic</Title>
+    <CreationDate>2026-01-01T00:00:00Z</CreationDate>
+    <CreationAuthor>vendor@example.com</CreationAuthor>
+    <BimSnippet SnippetType="IFC" IsExternal="true">
+      <Reference>ref.ifc</Reference>
+      <ReferenceSchema>ifcXML</ReferenceSchema>
+    </BimSnippet>
+  </Topic>
+</Markup>`,
+    );
+    const bytes = await zip.generateAsync({ type: 'uint8array' });
+
+    const readProject = await readBCF(bytes);
+    expect(readProject.topics.get('t1')?.bimSnippet?.isExternal).toBe(true);
+  });
+
+  it('writes and round-trips a BCF 3.0 DocumentReference as DocumentGuid/Url, not the 2.1 shape', async () => {
+    // BCF 3.0 replaced <ReferencedDocument>+isExternal with <DocumentGuid> (an
+    // internal reference into project.bcfp's Documents) or <Url> (external),
+    // and dropped isExternal. Writing the 2.1 shape at version 3.0 is
+    // schema-invalid; a strict 3.0 consumer would reject the archive.
+    const topic = baseTopic({
+      documentReferences: [
+        { guid: generateUuid(), url: 'https://example.com/spec.pdf', description: 'Spec' },
+      ],
+    });
+
+    const markup30 = await markupFor(topic, '3.0');
+    expect(markup30).toContain('<Url>https://example.com/spec.pdf</Url>');
+    expect(markup30).not.toContain('<ReferencedDocument>');
+    expect(markup30).not.toContain('isExternal');
+
+    const project: BCFProject = { version: '3.0', topics: new Map([[topic.guid, topic]]) };
+    const readTopic = (await readBCF(await (await writeBCF(project)).arrayBuffer()))
+      .topics.get(topic.guid)!;
+    expect(readTopic.documentReferences?.[0]).toMatchObject({
+      url: 'https://example.com/spec.pdf',
+      description: 'Spec',
+    });
+  });
+
+  it('reads a genuine BCF 3.0 DocumentReference (DocumentGuid/Url) authored by a third-party tool', async () => {
+    // Not a round trip through our own writer: this is the shape a spec-correct
+    // external BCF 3.0 tool actually emits. The 2.1-only reader used to require
+    // <ReferencedDocument> to exist at all, so this whole reference was dropped.
+    const zip = new JSZip();
+    zip.file('bcf.version', '<?xml version="1.0" encoding="UTF-8"?>\n<Version VersionId="3.0"></Version>');
+    zip.folder('t1')!.file(
+      'markup.bcf',
+      `<?xml version="1.0" encoding="UTF-8"?>
+<Markup xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Topic Guid="t1">
+    <Title>Vendor topic</Title>
+    <CreationDate>2026-01-01T00:00:00Z</CreationDate>
+    <CreationAuthor>vendor@example.com</CreationAuthor>
+    <DocumentReference Guid="docref-1">
+      <DocumentGuid>doc-guid-1</DocumentGuid>
+      <Url>https://example.com/doc.pdf</Url>
+      <Description>Spec doc</Description>
+    </DocumentReference>
+  </Topic>
+</Markup>`,
+    );
+    const bytes = await zip.generateAsync({ type: 'uint8array' });
+
+    const readProject = await readBCF(bytes);
+    const refs = readProject.topics.get('t1')?.documentReferences;
+    expect(refs).toHaveLength(1);
+    expect(refs?.[0]).toMatchObject({
+      guid: 'docref-1',
+      documentGuid: 'doc-guid-1',
+      url: 'https://example.com/doc.pdf',
+      description: 'Spec doc',
+    });
+  });
+
+  it('groups BCF 3.0 DocumentReferences under the container element, and round-trips two of them', async () => {
+    // The two versions differ in CONTAINMENT as well as in each entry's shape:
+    // 3.0's <Topic> holds a single <DocumentReferences> element wrapping the
+    // entries, while 2.1 repeats <DocumentReference> directly under <Topic>
+    // (buildingSMART/BCF-XML markup.xsd, Topic). Emitting the 2.1 containment
+    // at version 3.0 stays schema-invalid even once each entry is correct.
+    const topic = baseTopic({
+      documentReferences: [
+        { guid: 'dr-1', documentGuid: 'doc-guid-1', description: 'internal' },
+        { guid: 'dr-2', url: 'https://example.com/spec.pdf', description: 'external' },
+      ],
+    });
+
+    const markup30 = await markupFor(topic, '3.0');
+    expect(markup30).toContain('<DocumentReferences>');
+    expect(markup30).toContain('</DocumentReferences>');
+
+    // Control: 2.1 must NOT gain the wrapper, so this pins the version split
+    // rather than just "the wrapper is always emitted".
+    const markup21 = await markupFor(topic, '2.1');
+    expect(markup21).not.toContain('<DocumentReferences>');
+
+    // Both entries must survive the wrapper on the way back in, with their own
+    // guids: a reader that treats the container as if it were an entry loses
+    // or misattributes the first one.
+    const project: BCFProject = { version: '3.0', topics: new Map([[topic.guid, topic]]) };
+    const readTopic = (await readBCF(await (await writeBCF(project)).arrayBuffer()))
+      .topics.get(topic.guid)!;
+    expect(readTopic.documentReferences).toHaveLength(2);
+    expect(readTopic.documentReferences?.[0]).toMatchObject({
+      guid: 'dr-1',
+      documentGuid: 'doc-guid-1',
+    });
+    expect(readTopic.documentReferences?.[1]).toMatchObject({
+      guid: 'dr-2',
+      url: 'https://example.com/spec.pdf',
+    });
+  });
 });

--- a/packages/bcf/src/writer.ts
+++ b/packages/bcf/src/writer.ts
@@ -264,13 +264,18 @@ function writeMarkupFile(
   // snippet when it is complete so we never write schema-invalid markup. (The
   // type marks referenceSchema optional, but a snippet without it is unusable.)
   if (topic.bimSnippet?.referenceSchema) {
-    content += writeBimSnippet(topic.bimSnippet);
+    content += writeBimSnippet(topic.bimSnippet, version);
   }
 
   if (topic.documentReferences && topic.documentReferences.length > 0) {
+    // Containment differs too: 3.0 groups the entries under a single
+    // <DocumentReferences> element, while 2.1 repeats <DocumentReference>
+    // directly under <Topic> (buildingSMART/BCF-XML markup.xsd, Topic).
+    if (version === '3.0') content += `\n    <DocumentReferences>`;
     for (const docRef of topic.documentReferences) {
-      content += writeDocumentReference(docRef);
+      content += writeDocumentReference(docRef, version);
     }
+    if (version === '3.0') content += `\n    </DocumentReferences>`;
   }
 
   if (topic.relatedTopics && topic.relatedTopics.length > 0) {
@@ -696,11 +701,16 @@ function writeHeaderFile(file: BCFHeaderFile, indent: string, version: '2.1' | '
 
 /**
  * Write BimSnippet XML
+ *
+ * BCF 2.1 spells the attribute `isExternal`; 3.0 renamed it `IsExternal`
+ * (buildingSMART/BCF-XML markup.xsd, BimSnippet's IsExternal attribute) —
+ * same rename as the Header `<File>` attribute in {@link writeHeaderFile}.
  */
-function writeBimSnippet(snippet: BCFBimSnippet): string {
+function writeBimSnippet(snippet: BCFBimSnippet, version: '2.1' | '3.0'): string {
   // Caller guarantees referenceSchema is present (see writeMarkupFile); both
   // Reference and ReferenceSchema are required by the BCF schema.
-  let content = `\n    <BimSnippet SnippetType="${escapeXml(snippet.snippetType)}" isExternal="${snippet.isExternal}">`;
+  const isExternalAttr = version === '3.0' ? 'IsExternal' : 'isExternal';
+  let content = `\n    <BimSnippet SnippetType="${escapeXml(snippet.snippetType)}" ${isExternalAttr}="${snippet.isExternal}">`;
   content += `\n      <Reference>${escapeXml(snippet.reference)}</Reference>`;
   content += `\n      <ReferenceSchema>${escapeXml(snippet.referenceSchema ?? '')}</ReferenceSchema>`;
   content += `\n    </BimSnippet>`;
@@ -709,11 +719,38 @@ function writeBimSnippet(snippet: BCFBimSnippet): string {
 
 /**
  * Write DocumentReference XML
+ *
+ * BCF 2.1 and 3.0 diverge structurally here, not just by attribute casing:
+ * 2.1 has `<ReferencedDocument>` (a string, plus an `isExternal` flag on
+ * whether it's a URL); 3.0 replaced both with `<DocumentGuid>` (a reference
+ * into project.bcfp's Documents) or `<Url>`, and dropped `isExternal`
+ * entirely (buildingSMART/BCF-XML markup.xsd, release_3_0 DocumentReference).
+ * `documentGuid`/`url` are preferred when present; `referencedDocument` is
+ * the 2.1-shaped fallback so 2.1-authored data written as 3.0 still emits
+ * something.
  */
-function writeDocumentReference(docRef: BCFDocumentReference): string {
+function writeDocumentReference(docRef: BCFDocumentReference, version: '2.1' | '3.0'): string {
   const guidAttr = docRef.guid ? ` Guid="${escapeXml(docRef.guid)}"` : '';
-  let content = `\n    <DocumentReference${guidAttr} isExternal="${docRef.isExternal}">`;
-  content += `\n      <ReferencedDocument>${escapeXml(docRef.referencedDocument)}</ReferencedDocument>`;
+
+  if (version === '3.0') {
+    let content = `\n    <DocumentReference${guidAttr}>`;
+    if (docRef.documentGuid) {
+      content += `\n      <DocumentGuid>${escapeXml(docRef.documentGuid)}</DocumentGuid>`;
+    } else {
+      const url = docRef.url ?? docRef.referencedDocument;
+      if (url) {
+        content += `\n      <Url>${escapeXml(url)}</Url>`;
+      }
+    }
+    if (docRef.description) {
+      content += `\n      <Description>${escapeXml(docRef.description)}</Description>`;
+    }
+    content += `\n    </DocumentReference>`;
+    return content;
+  }
+
+  let content = `\n    <DocumentReference${guidAttr} isExternal="${docRef.isExternal ?? false}">`;
+  content += `\n      <ReferencedDocument>${escapeXml(docRef.referencedDocument ?? docRef.url ?? '')}</ReferencedDocument>`;
   if (docRef.description) {
     content += `\n      <Description>${escapeXml(docRef.description)}</Description>`;
   }


### PR DESCRIPTION
Three divergences between the BCF 2.1 and 3.0 schemas were unhandled, so we emitted **schema-invalid 3.0 markup** and **silently mis-read a spec-correct 3.0 file** written by another vendor's tool.

All three were verified against `buildingSMART/BCF-XML` `markup.xsd`, `release_2_1` vs `release_3_0` — fetched and diffed, not recalled:

| | 2.1 | 3.0 |
|---|---|---|
| BimSnippet flag | `isExternal` | `IsExternal` |
| DocumentReference body | `<ReferencedDocument>` + `isExternal` | `<DocumentGuid>` \| `<Url>`, no `isExternal` |
| DocumentReference containment | repeated under `<Topic>` | wrapped in `<DocumentReferences>` |

## Severity: LIVE

Probed against the **unfixed** code with a spec-correct BCF 3.0 archive:

```json
{ "bimSnippet": { "snippetType": "IFC", "isExternal": false, ... } }
```

The input said `IsExternal="true"`. That is a **silent wrong value**, not a parse failure — the worst shape, because nothing signals it. And `documentReferences` was **absent entirely** for two well-formed references: both dropped.

After the fix, the same probe returns `isExternal: true` and both references with their own guids intact.

## The three fixes

- **BimSnippet casing.** The reader matched only the lowercase spelling; the writer emitted lowercase at version 3.0. The identical rename is *already handled* for the `Header`/`<File>` attribute, with a comment noting the change — the same treatment simply never reached `BimSnippet`. This is the "same guard hardened in one copy but not its siblings" shape.
- **DocumentReference body.** The reader required `<ReferencedDocument>` to exist, so a 3.0 reference matched nothing and was skipped; the writer emitted the 2.1 shape regardless of version.
- **DocumentReference containment.** The writer emitted 2.1 containment at 3.0, which stays schema-invalid even once each entry's own shape is correct.

## Types

`BCFDocumentReference` gains optional `documentGuid`/`url`, and `isExternal`/`referencedDocument` become optional since 3.0 has no equivalent. That is why the changeset is **minor** rather than patch: reading either field now requires a presence check. No consumer outside `packages/bcf` references them.

## Hardened, but explicitly not claimed as a fix

The reader's DocumentReference regex now excludes the `<DocumentReferences>` container via `(?![A-Za-z])`. Without it, the container's opening tag pairs with the *first entry's* closing tag, and the first reference parses correctly only by accident of that overlap.

**Measured: reverting just this leaves all 149 tests green.** It changes no observable behaviour on schema-valid input — it makes the parse deliberate rather than accidental. Flagging it as such rather than counting it as a third bug.

## Verification

**144 → 149 passing across 7 files.** `tsc --noEmit` exit 0.

The containment test is RED-verified: reverting only the wrapper emission fails it and nothing else (148/149). It also asserts 2.1 does **not** gain the wrapper, so it pins the version split rather than "the wrapper is always emitted", and it round-trips two references to confirm neither is lost or misattributed on the way back in.

## Not included

`writer.ts` interpolates the unsanitized viewpoint GUID into zip entry names — confirmed live here by direct probe (a `../../evil` guid produces a traversal entry), but that is already **PR #2310**, still open. Deliberately excluded rather than duplicated.

## Reviewed and found clean

Zip-bomb and resource-cap guards; `viewpoint.ts` camera math (perspective/orthogonal conversion, Y-up↔Z-up, FOV clamp, section-plane↔clipping-plane — forward and inverse transforms agree); `parseComments`/`parseVisibility`/`parseHeaderFiles`, which are already deliberately hardened against the same 2.1/3.0 wrapper differences.

One documentation-only inaccuracy noted and left alone: `writer.ts`'s comment near `writeVisibility` describes the `DefaultVisibility` default as `false`, while both writer and reader consistently use `true`. Happy to correct it here if you'd prefer it not linger.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added BCF 3.0 support for document references using `DocumentGuid` and `Url`.
  - Added compatibility with BCF 3.0 casing and document-reference container formats.
  - Preserved support for existing BCF 2.1 document-reference formats.

- **Bug Fixes**
  - Improved reading and writing of BCF snippets and document references across supported versions.
  - Made optional document-reference fields handle incomplete or version-specific data correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->