### PR TITLE
fix(ids): match a partOf parent's raw PredefinedType, not its custom name

### DIFF
--- a/.changeset/ids-partof-predefinedtype-userdefined.md
+++ b/.changeset/ids-partof-predefinedtype-userdefined.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/ids": patch
+---
+
+Fix a false FAIL on `partOf` requirements whose nested `entity.predefinedType` constraint asks for the literal `USERDEFINED` token against a parent that also carries a custom name.
+
+`getAncestors` sourced `ParentInfo.predefinedType` from `getObjectType`, which collapses a `USERDEFINED` raw enum to the accompanying user-defined name (e.g. `ObjectType`/`ElementType`). A spec requiring predefinedType `USERDEFINED` on the parent then compared that literal against the custom name instead of the raw token, and failed — even though `entity-facet.ts`'s direct entity check accepts exactly this case via its raw-token-first, user-name-fallback match.
+
+`ParentInfo` now carries the raw `PredefinedType` token separately from the user-defined name (`objectType`), and `partof-facet.ts`'s predefinedType match mirrors `entity-facet.ts`'s two-branch logic: raw token first, falling back to the user-defined name only when the raw token is `USERDEFINED`.

--- a/packages/ids/src/bridge/data-accessor.ts
+++ b/packages/ids/src/bridge/data-accessor.ts
@@ -253,7 +253,15 @@ export function createDataAccessor(store: IfcDataStore): IFCDataAccessor {
             out.push({
               expressId: parentId,
               entityType: accessor.getEntityType(parentId) || 'Unknown',
-              predefinedType: accessor.getObjectType(parentId),
+              // Raw enum token first (BEAM, USERDEFINED, …) — NOT
+              // getObjectType. getObjectType collapses USERDEFINED to the
+              // accompanying user-defined name, which loses the literal
+              // "USERDEFINED" token a spec may legitimately ask for (the
+              // same case entity-facet.ts's rawType branch accepts for a
+              // direct entity check). The user-defined name is carried
+              // separately in `objectType` as a fallback for partof-facet.
+              predefinedType: accessor.getPredefinedTypeRaw?.(parentId),
+              objectType: accessor.getObjectType(parentId),
             });
             queue.push(parentId);
           }

--- a/packages/ids/src/bridge/partof-predefined-type.test.ts
+++ b/packages/ids/src/bridge/partof-predefined-type.test.ts
@@ -1,0 +1,80 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * IDS partOf facet's nested `predefinedType` constraint, checked against a
+ * REAL parsed store (not the mock accessor `facets.test.ts` uses — that
+ * mock hands `ParentInfo.predefinedType` to the checker directly, so it
+ * cannot see a bug in how the bridge POPULATES that field).
+ *
+ * `getAncestors` sourced `ParentInfo.predefinedType` from
+ * `accessor.getObjectType(parentId)` instead of
+ * `accessor.getPredefinedTypeRaw(parentId)`. For a parent whose raw
+ * `PredefinedType` is `USERDEFINED` with an accompanying user-defined name
+ * (e.g. `ObjectType = 'CustomWallType'`), `getObjectType` returns the name,
+ * not the literal token `USERDEFINED` — so an IDS spec asking for the
+ * literal enum token `USERDEFINED` (a value `checkEntityFacet`/
+ * `entityFacetPasses` both accept for the very same entity, see
+ * `entity-facet.ts`'s two-branch match) silently FAILED for `partOf`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { StepTokenizer, ColumnarParser } from '@ifc-lite/parser';
+import type { EntityRef } from '@ifc-lite/parser';
+import { createDataAccessor } from './data-accessor.js';
+import { checkPartOfFacet } from '../facets/partof-facet.js';
+import type { IDSPartOfFacet, IDSSimpleValue } from '../types.js';
+
+const sv = (value: string): IDSSimpleValue => ({ type: 'simpleValue', value });
+
+async function parse(ifc: string) {
+  const source = new TextEncoder().encode(ifc);
+  const tokenizer = new StepTokenizer(source);
+  const entityRefs: EntityRef[] = [];
+  for (const ref of tokenizer.scanEntitiesFast()) {
+    entityRefs.push({
+      expressId: ref.expressId,
+      type: ref.type,
+      byteOffset: ref.offset,
+      byteLength: ref.length,
+      lineNumber: ref.line,
+    });
+  }
+  const parser = new ColumnarParser();
+  return parser.parseLite(source.buffer.slice(0) as ArrayBuffer, entityRefs, {});
+}
+
+// Child wall #100 aggregated into parent wall #200. Parent's raw
+// PredefinedType is USERDEFINED with a custom name in ObjectType — the
+// same shape `entity-facet.ts` handles with its rawType/userDefinedType
+// two-branch match.
+const IFC = `#100=IFCWALL('0Wall00000000000000001',$,'Child',$,$,$,$,$,$);
+#200=IFCWALL('0Wall00000000000000002',$,'Parent',$,'CustomWallType',$,$,$,.USERDEFINED.);
+#300=IFCRELAGGREGATES('0RelAgg000000000000001',$,$,$,#200,(#100));`;
+
+describe('IDS partOf predefinedType — sourced from the raw enum, not ObjectType', () => {
+  it('matches the literal USERDEFINED token against a parent whose raw PredefinedType is USERDEFINED (even though it also carries a custom name)', async () => {
+    const store = await parse(IFC);
+    const accessor = createDataAccessor(store);
+    const facet: IDSPartOfFacet = {
+      type: 'partOf',
+      relation: 'IfcRelAggregates',
+      entity: { type: 'entity', name: sv('IFCWALL'), predefinedType: sv('USERDEFINED') },
+    };
+    const result = checkPartOfFacet(facet, 100, accessor);
+    expect(result.passed).toBe(true);
+  });
+
+  it('still matches the user-defined name as a fallback for the same parent', async () => {
+    const store = await parse(IFC);
+    const accessor = createDataAccessor(store);
+    const facet: IDSPartOfFacet = {
+      type: 'partOf',
+      relation: 'IfcRelAggregates',
+      entity: { type: 'entity', name: sv('IFCWALL'), predefinedType: sv('CustomWallType') },
+    };
+    const result = checkPartOfFacet(facet, 100, accessor);
+    expect(result.passed).toBe(true);
+  });
+});

--- a/packages/ids/src/facets/partof-facet.ts
+++ b/packages/ids/src/facets/partof-facet.ts
@@ -127,9 +127,20 @@ function checkAncestorAgainstFacet(
     };
   }
 
-  // Check parent predefined type if specified
+  // Check parent predefined type if specified.
+  //
+  // Mirrors entity-facet.ts's two-branch match: compare the raw enum
+  // token first (BEAM, USERDEFINED, …), and only when the raw token is
+  // USERDEFINED fall back to the parent's user-defined name. A single
+  // combined value can't reproduce this — a parent whose raw
+  // PredefinedType is literally USERDEFINED but that also carries a
+  // custom name (ObjectType) must still match a facet asking for the
+  // literal "USERDEFINED" token, not just the custom name.
   if (facet.entity.predefinedType) {
-    if (!parent.predefinedType) {
+    const rawType = parent.predefinedType;
+    const userDefinedType = parent.objectType;
+
+    if (!rawType && !userDefinedType) {
       return {
         passed: false,
         actualValue: `${parent.entityType} (no predefinedType)`,
@@ -146,15 +157,34 @@ function checkAncestorAgainstFacet(
       };
     }
 
-    if (!matchConstraint(facet.entity.predefinedType, parent.predefinedType, IFC_CASE_INSENSITIVE)) {
+    let matched = false;
+    if (rawType && matchConstraint(facet.entity.predefinedType, rawType, IFC_CASE_INSENSITIVE)) {
+      matched = true;
+    } else if (
+      rawType === 'USERDEFINED' &&
+      userDefinedType &&
+      userDefinedType !== rawType &&
+      matchConstraint(facet.entity.predefinedType, userDefinedType, IFC_CASE_INSENSITIVE)
+    ) {
+      matched = true;
+    } else if (
+      !rawType &&
+      userDefinedType &&
+      matchConstraint(facet.entity.predefinedType, userDefinedType, IFC_CASE_INSENSITIVE)
+    ) {
+      matched = true;
+    }
+
+    if (!matched) {
+      const display = userDefinedType || rawType || '(none)';
       return {
         passed: false,
-        actualValue: `${parent.entityType}[${parent.predefinedType}]`,
+        actualValue: `${parent.entityType}[${display}]`,
         expectedValue: `${formatConstraint(facet.entity.name)}[${formatConstraint(facet.entity.predefinedType)}]`,
         failure: {
           type: 'PARTOF_PREDEFINED_TYPE_MISMATCH',
           field: 'predefinedType',
-          actual: parent.predefinedType,
+          actual: display,
           expected: formatConstraint(facet.entity.predefinedType),
           context: {
             relation: facet.relation,

--- a/packages/ids/src/facets/test-helpers.ts
+++ b/packages/ids/src/facets/test-helpers.ts
@@ -33,7 +33,13 @@ interface MockEntity {
   }>;
   classifications?: Array<{ system?: string; value?: string }>;
   materials?: Array<{ name: string; category?: string }>;
-  parent?: { expressId?: number; type: string; relation: string; predefinedType?: string };
+  parent?: {
+    expressId?: number;
+    type: string;
+    relation: string;
+    predefinedType?: string;
+    objectType?: string;
+  };
   attributes?: Record<string, string | number | boolean>;
   /**
    * Optional per-attribute XSD-type metadata, mirroring the schema
@@ -135,6 +141,7 @@ export function createMockAccessor(entities: MockEntity[]): IFCDataAccessor {
         expressId: entity.parent.expressId,
         entityType: entity.parent.type,
         predefinedType: entity.parent.predefinedType,
+        objectType: entity.parent.objectType,
       };
     },
     getAttribute(

--- a/packages/ids/src/types.ts
+++ b/packages/ids/src/types.ts
@@ -584,8 +584,20 @@ export interface ParentInfo {
   expressId: number;
   /** Parent entity type */
   entityType: string;
-  /** Parent predefined type (if available) */
+  /**
+   * Parent's raw `PredefinedType` enum token (`BEAM`, `USERDEFINED`,
+   * `NOTDEFINED`, …), if available. Mirrors `IFCDataAccessor.getPredefinedTypeRaw`.
+   */
   predefinedType?: string;
+  /**
+   * Parent's user-defined name (`ObjectType`/`ElementType`/`ProcessType`) —
+   * only meaningful as a fallback when `predefinedType` is `USERDEFINED`.
+   * Mirrors `IFCDataAccessor.getObjectType`. Kept distinct from
+   * `predefinedType` so partOf's predefinedType match can reproduce the
+   * same two-branch (raw-token-first, user-name-fallback) semantics
+   * `entity-facet.ts` uses for a direct entity check.
+   */
+  objectType?: string;
 }
 
 // ============================================================================


### PR DESCRIPTION
A `partOf` requirement whose nested `entity.predefinedType` asks for the literal `USERDEFINED` token wrongly **FAILED** against a compliant model — whenever the parent's raw `PredefinedType` is `USERDEFINED` *and* it also carries a custom name (`ObjectType`/`ElementType`).

## Root cause

`getAncestors` sourced `ParentInfo.predefinedType` from `accessor.getObjectType`, which **collapses** a `USERDEFINED` raw enum to the accompanying user-defined name. The literal `USERDEFINED` a spec asked for was then compared against the custom name and never matched. `partof-facet.ts` had no way to see the raw token at all.

`entity-facet.ts` accepts exactly this case for a **direct** entity check, via a documented two-branch match: raw token first, user-defined name only as a fallback when the raw token is `USERDEFINED`. Its comment even spells out why the order matters. The sibling `partOf` path was never given the same treatment — the same guard hardened in one copy but not the other.

## Severity: LIVE, and a false FAIL

The worse direction for a validator. A false PASS hides a problem; a **false FAIL marks a compliant model non-compliant**, which is a claim the tool makes about someone else's data.

Probed against the unfixed code using a **real parsed IFC** — not the mock accessor, which bypasses the bridge and cannot express this bug at all — `checkPartOfFacet` returned `passed: false` for a parent wall with `PredefinedType = .USERDEFINED.` and `ObjectType = 'CustomWallType'`:

```
AssertionError: expected false to be true
```

## The fix

`ParentInfo` now carries the raw token in `predefinedType` and the user-defined name separately in `objectType`; `partof-facet.ts`'s predefinedType match mirrors `entity-facet.ts`'s branches. A single combined value cannot reproduce the semantics, which is why the type gains a field rather than the call site just swapping accessors.

## Bounding control

The 10 existing `partOf` tests in `facets.test.ts` all run against the mock accessor and pass **unchanged** before and after. That confirms the facet-matching contract is unaltered and only the real bridge path changes — and it also explains why this survived: the existing partOf coverage physically could not see it.

## Left alone deliberately — your call

The two paths still **disagree on case sensitivity**. `entity-facet.ts` matches predefinedType case-*sensitively* (its comment cites the spec: enum tokens must be uppercase and the IDS literal must match exactly), while `partof-facet.ts` passes `IFC_CASE_INSENSITIVE` on every branch.

That divergence predates this change. I left it exactly as it was rather than altering matching semantics under cover of a bug fix — happy to align them in a follow-up if you want partOf to be case-sensitive too, but that changes verdicts for existing specs and seemed like your decision rather than mine.

## Verification

**300 → 302 passing across 16 files.** `tsc --noEmit` exit 0.

RED-verified: the new test fails against unfixed production code (1 failed / 301 passed) and passes after. Patch changeset included.

## Not duplicated

PR #2282 (open) covers a *different* shape in the same area — `checkRequirement`'s optional-arm allowlist omitting `PREDEFINED_TYPE_MISSING`/`PARTOF_PREDEFINED_TYPE_MISSING`. That one is about an **absent** value under an optional requirement; this one is about a **present** value read from the wrong accessor. They don't overlap and neither fixes the other.

## Reviewed and found clean

`property-facet.ts`, `attribute-facet.ts`, `classification-facet.ts`, `material-facet.ts`, and `entity-facet.ts`'s own logic — absent-vs-empty handling, case sensitivity, vacuous-match semantics, and `checkFacet`/`facetPasses` dual-path parity all read as deliberately hardened, with comments citing the earlier fixes that produced them. `constraints/index.ts` bounds/pattern/enumeration handling and its fail-closed `default: return false` for an unsupported constraint kind likewise.
