### PR TITLE
fix(mutations): resolve setQuantity's oldValue from the base quantity

### DIFF
--- a/.changeset/mutations-setquantity-oldvalue.md
+++ b/.changeset/mutations-setquantity-oldvalue.md
@@ -1,0 +1,11 @@
+---
+"@ifc-lite/mutations": patch
+---
+
+Fix `MutablePropertyView.setQuantity()` reporting a wrong `oldValue`/mutation type on the first edit of an already-existing base quantity.
+
+Before this fix, `oldValue` was resolved only from a prior overlay mutation for the same key (`this.quantityMutations.get(key)?.value`), never from the base quantity's own value — unlike `setProperty()`, which resolves `oldValue` via `getPropertyValue()` (overlay-or-base). So editing a base quantity for the first time produced `{ type: 'UPDATE_QUANTITY', oldValue: null }` even though a real prior value existed. Consumers that gate reverting a quantity edit on `oldValue` being non-null (e.g. `apps/viewer`'s undo handler) silently did nothing on undo — the same "reports success, reverts nothing" shape as #2297, but for quantities, and in `@ifc-lite/mutations` rather than `@ifc-lite/mcp`.
+
+A second, related defect: adding a *new* quantity name to an already-existing quantity set was classified as `UPDATE_QUANTITY` (since `qsetExistsInBase` was checked instead of the specific quantity), so undo of that create also tried to restore a nonexistent prior value instead of removing the mutation.
+
+`setQuantity()` now resolves `oldValue`/the CREATE-vs-UPDATE classification from the overlay mutation when present, falling back to the specific base quantity's value (existence keyed on quantity name, not just qset name) — mirroring `setProperty()`'s existing resolution order.

--- a/packages/mutations/src/mutable-property-view.ts
+++ b/packages/mutations/src/mutable-property-view.ts
@@ -872,10 +872,27 @@ export class MutablePropertyView {
       }
     }
 
-    // Get old value for undo and to determine CREATE vs UPDATE
+    // Get old value for undo and to determine CREATE vs UPDATE. An overlay
+    // mutation (a prior edit this session) wins; otherwise fall back to the
+    // base quantity's own value — `qsetExistsInBase` alone is not enough,
+    // since a *new* quantity name can be added to an already-existing qset.
+    // Without the base-value fallback, the first edit of an existing base
+    // quantity reported `oldValue: null` (UPDATE_QUANTITY with nothing to
+    // restore), which is exactly the null the viewer's undo handler treats
+    // as "nothing to revert to" — undo silently did nothing (#2297 shape).
     const existingMutation = this.quantityMutations.get(key);
-    const oldValue = existingMutation?.value ?? null;
-    const isUpdate = existingMutation != null || qsetExistsInBase;
+    let oldValue: number | null;
+    let isUpdate: boolean;
+    if (existingMutation) {
+      oldValue = existingMutation.value ?? null;
+      isUpdate = true;
+    } else {
+      const baseQuantity = baseQsets
+        .find(q => q.name === qsetName)
+        ?.quantities.find(q => q.name === quantName);
+      oldValue = baseQuantity ? baseQuantity.value : null;
+      isUpdate = baseQuantity !== undefined;
+    }
 
     this.setQuantityMutation(entityId, key, {
       operation: 'SET',

--- a/packages/mutations/test/mutable-property-view.test.ts
+++ b/packages/mutations/test/mutable-property-view.test.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { describe, expect, it } from 'vitest';
-import { PropertyValueType } from '@ifc-lite/data';
+import { PropertyValueType, QuantityType } from '@ifc-lite/data';
 import { BulkQueryEngine, MutablePropertyView } from '../src/index.js';
 
 describe('MutablePropertyView', () => {
@@ -71,6 +71,61 @@ describe('MutablePropertyView', () => {
     fresh.setProperty(9, 'Pset_WallCommon', 'Combustible', null, PropertyValueType.Boolean);
     expect(fresh.deleteProperty(9, 'Pset_WallCommon', 'Combustible')).not.toBeNull();
     expect(fresh.getForEntity(9)).toEqual([]);
+  });
+
+  describe('setQuantity oldValue/type on a base quantity (undo correctness, #2297 shape)', () => {
+    it('carries the base value as oldValue on the first edit of an existing quantity', () => {
+      // `apps/viewer`'s undo handler only replays `mutation.oldValue` for
+      // UPDATE_QUANTITY when it is non-null (`mutationSlice.ts`): if the
+      // first edit of an already-existing base quantity reports
+      // `oldValue: null` instead of the true prior value, undo silently
+      // does nothing — the mutation stays applied. Unlike `setProperty`,
+      // which resolves `oldValue` via `getPropertyValue()` (base data +
+      // overlay), `setQuantity` must resolve the same way rather than only
+      // consulting an existing overlay mutation.
+      const view = new MutablePropertyView(null, 'model-1');
+      view.setQuantityExtractor((entityId) => entityId === 11 ? [{
+        name: 'Qto_Base',
+        quantities: [{ name: 'Area', type: QuantityType.Area, value: 10 }],
+      }] : []);
+
+      const mutation = view.setQuantity(11, 'Qto_Base', 'Area', 99, QuantityType.Area);
+
+      expect(mutation.type).toBe('UPDATE_QUANTITY');
+      expect(mutation.oldValue).toBe(10);
+    });
+
+    it('classifies a brand-new quantity added to an existing base qset as CREATE, not UPDATE', () => {
+      // `qsetExistsInBase` alone doesn't mean THIS quantity existed — adding
+      // a never-before-seen quantity name to an existing qset must report
+      // CREATE_QUANTITY (undo removes the mutation outright) rather than
+      // UPDATE_QUANTITY with a null oldValue (undo would try, and fail, to
+      // restore a "prior" value that never existed).
+      const view = new MutablePropertyView(null, 'model-1');
+      view.setQuantityExtractor((entityId) => entityId === 11 ? [{
+        name: 'Qto_Base',
+        quantities: [{ name: 'Area', type: QuantityType.Area, value: 10 }],
+      }] : []);
+
+      const mutation = view.setQuantity(11, 'Qto_Base', 'Volume', 42, QuantityType.Volume);
+
+      expect(mutation.type).toBe('CREATE_QUANTITY');
+      expect(mutation.oldValue).toBeNull();
+    });
+
+    it('still reports UPDATE with the overlay value on a second edit (control)', () => {
+      const view = new MutablePropertyView(null, 'model-1');
+      view.setQuantityExtractor((entityId) => entityId === 11 ? [{
+        name: 'Qto_Base',
+        quantities: [{ name: 'Area', type: QuantityType.Area, value: 10 }],
+      }] : []);
+
+      view.setQuantity(11, 'Qto_Base', 'Area', 99, QuantityType.Area);
+      const second = view.setQuantity(11, 'Qto_Base', 'Area', 123, QuantityType.Area);
+
+      expect(second.type).toBe('UPDATE_QUANTITY');
+      expect(second.oldValue).toBe(99);
+    });
   });
 
   describe('entity aliases (duplicate flow)', () => {


### PR DESCRIPTION
`setQuantity()` resolved `oldValue` only from a prior overlay mutation for the same key, never from the base quantity's own value — unlike `setProperty()`, which resolves it through `getPropertyValue()` (overlay-or-base). So the **first** edit of an already-existing base quantity produced `{ type: 'UPDATE_QUANTITY', oldValue: null }` even though a real prior value existed.

Two paths computing the same thing and disagreeing, with the divergence sitting in the **fallback**: `setProperty` (line 425) falls back to base, `setQuantity` (line 877) fell back to `null`.

## Severity: LIVE — it reaches the user as an undo that does nothing

`apps/viewer/src/store/slices/mutationSlice.ts:2701` gates the `UPDATE_QUANTITY` undo branch on `oldValue !== undefined && oldValue !== null`. A null `oldValue` skips the revert entirely and leaves the edit applied.

Probed against the unfixed code, base quantity `Area=10` edited to `99`:

```json
{ "type": "UPDATE_QUANTITY", "oldValue": null, "newValue": 99 }
```

This is the same *"reports success, reverts nothing"* shape as #2297, but a **distinct occurrence** — #2297 fixes `revertMutation` dispatch in `@ifc-lite/mcp`, which doesn't handle quantity mutation types at all. Neither fixes the other.

## A second defect in the same three lines

`isUpdate` was decided by `qsetExistsInBase` alone, so adding a **brand-new quantity name to an existing qset** was classified `UPDATE_QUANTITY` rather than `CREATE_QUANTITY`. Undo of that create then tried to restore a nonexistent prior value instead of removing the mutation.

The viewer already has a correct `CREATE_QUANTITY` undo branch (`mutationSlice.ts:2697`, calling `removeQuantityMutation`) that this misclassification routed around. I checked the path being displaced: the redo handler at line 2891 accepts both types, so the reclassification restores the intended branch without breaking anything that worked.

Existence is now keyed on the **quantity name** within the qset, not just the qset's presence — that is what distinguishes the two cases.

## Verification

**163 → 166 passing / 10 skipped across 9 files.** `tsc -p .` exit 0.

RED-verified against unfixed production code: exactly the two bug-proving tests fail (2 failed / 164 passed), and they pass after the fix.

The third new test is a deliberate **control**: a *second* edit of the same quantity must still report the first edit's value. It passes on the unfixed code too — it pins the overlay-wins ordering rather than the bug, so the suite can't be satisfied by a rule that just always reads from base.

The finding was also bounded before the fix was written: with the fix in place but the fallback forced back to `null`, only the new base-value test fails (`expected null to be 10`) while its siblings pass — so the test pins this specific resolution and isn't vacuous.

## Reviewed and found clean

- `change-set.ts` — already thoroughly covered, including merge ordering with an explicitly non-timestamp-sorted fixture.
- `change-set-to-ops.ts` — heavily hardened, with comments citing #2263 and #2044 for exactly the "empty qset materializes but members don't follow" and forward-pass ordering shapes. Every mutation type is handled or explicitly routed to `skipped`.
- The deletion/tombstone/restore paths (`deleteEntity`, `restoreFromTombstone`, `restoreNewEntity`, `stashAndPurgeEntityOverlay`) — each carries "why" comments referencing #1915, #1957, #1967 and the `hasChanges`/`hasPendingChanges`/`getModifiedEntityCount` agreement they maintain.
- `setAttribute()` takes `oldValue` as a caller-supplied parameter by design, so it is a different contract rather than the same bug shape — the caller-correctness question lives in `apps/viewer`, not this package.
