### PR TITLE
fix(data): restore the four entity names missing from IFC_ENTITY_NAMES

### DIFF
--- a/.changeset/ifc-entity-names-proxy-stratum-gap.md
+++ b/.changeset/ifc-entity-names-proxy-stratum-gap.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/data": patch
+---
+
+Add the four entities missing from `IFC_ENTITY_NAMES` — `IfcProxy`, `IfcSolidStratum`, `IfcVoidStratum`, `IfcWaterStratum`. All four are representable in `IfcTypeEnum`/`IfcTypeEnumToString`, but were absent from the UPPERCASE→PascalCase table, so any direct `IFC_ENTITY_NAMES[upper] ?? upper` lookup fell through to the raw UPPERCASE STEP keyword instead of the PascalCase name. That affects `@ifc-lite/mcp`'s `query`/`diff`/`validation`/`discovery` tools and `@ifc-lite/cli`'s `info`/`diff` commands whenever a model contains one of these types — and `IFCPROXY` in particular is minted by `schema-converter.ts` itself when downgrading IFC4X3 entities to IFC4, so it is not an exotic case.
+
+The file's header claimed it was auto-generated and must not be edited by hand, naming `scripts/generate-entity-names.ts` as the way to regenerate it. That script does not exist anywhere in the repository and is referenced nowhere else, so the table is in practice maintained by hand and no regeneration path was available to fix the drift. The header now says so, rather than directing the next maintainer to a command that cannot be run.
+
+A completeness test (`ifc-entity-names.test.ts`) now pins every `IfcTypeEnum` member with a known PascalCase spelling against `IFC_ENTITY_NAMES`, so future drift — including a regeneration that drops entries again — fails loudly instead of silently degrading display names.

--- a/packages/data/src/ifc-entity-names.test.ts
+++ b/packages/data/src/ifc-entity-names.test.ts
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect } from 'vitest';
+import { IFC_ENTITY_NAMES } from './ifc-entity-names.js';
+import { IfcTypeEnum, IfcTypeEnumToString } from './types.js';
+
+describe('IFC_ENTITY_NAMES', () => {
+  // These four were confirmed missing (issue tracked in PR #2318, which
+  // works around the gap in the parquet export layer rather than fixing
+  // it at source). All four ARE representable in IfcTypeEnum /
+  // IfcTypeEnumToString, so leaving them out of this table is a genuine
+  // asymmetry: any direct `IFC_ENTITY_NAMES[upper] ?? upper` lookup (used
+  // by packages/mcp's query/diff/validation/discovery tools and
+  // packages/cli's info/diff commands) silently displays the raw
+  // UPPERCASE STEP keyword instead of the PascalCase entity name for
+  // these types.
+  it('covers IfcProxy', () => {
+    expect(IFC_ENTITY_NAMES['IFCPROXY']).toBe('IfcProxy');
+  });
+
+  it('covers IfcSolidStratum', () => {
+    expect(IFC_ENTITY_NAMES['IFCSOLIDSTRATUM']).toBe('IfcSolidStratum');
+  });
+
+  it('covers IfcVoidStratum', () => {
+    expect(IFC_ENTITY_NAMES['IFCVOIDSTRATUM']).toBe('IfcVoidStratum');
+  });
+
+  it('covers IfcWaterStratum', () => {
+    expect(IFC_ENTITY_NAMES['IFCWATERSTRATUM']).toBe('IfcWaterStratum');
+  });
+
+  /**
+   * Completeness control: every non-Unknown IfcTypeEnum member that has a
+   * known PascalCase spelling via IfcTypeEnumToString must also be
+   * reachable from IFC_ENTITY_NAMES under its UPPERCASE STEP keyword.
+   * This is the general shape of the four bugs above — it fails loudly if
+   * a future codegen run drops entries again, instead of relying on
+   * someone noticing four missing dictionary keys by eye.
+   */
+  it('has an entry for every representable IfcTypeEnum member', () => {
+    const missing: string[] = [];
+    for (const key of Object.keys(IfcTypeEnum)) {
+      if (/^\d+$/.test(key) || key === 'Unknown') continue; // numeric reverse-map keys
+      const enumValue = (IfcTypeEnum as unknown as Record<string, number>)[key];
+      const pascal = IfcTypeEnumToString(enumValue);
+      if (pascal === 'Unknown') continue; // not representable either direction
+      const upper = key.toUpperCase();
+      if (IFC_ENTITY_NAMES[upper] !== pascal) {
+        missing.push(`${upper} -> expected ${pascal}, got ${IFC_ENTITY_NAMES[upper]}`);
+      }
+    }
+    expect(missing).toEqual([]);
+  });
+});

--- a/packages/data/src/ifc-entity-names.ts
+++ b/packages/data/src/ifc-entity-names.ts
@@ -4,9 +4,20 @@
 
 /**
  * UPPERCASE → PascalCase entity name map
- * Auto-generated from @ifc-lite/codegen schema registry (IFC4X3)
+ * Originally generated from the @ifc-lite/codegen schema registry (IFC4X3).
  *
- * DO NOT EDIT MANUALLY - regenerate with: node scripts/generate-entity-names.ts
+ * NOTE: `scripts/generate-entity-names.ts`, named by the original header here
+ * as the way to regenerate this file, is NOT present in the repository - it is
+ * referenced nowhere else. This table is therefore maintained BY HAND, and a
+ * "just regenerate it" fix is not available. Four entries (IFCPROXY,
+ * IFCSOLIDSTRATUM, IFCVOIDSTRATUM, IFCWATERSTRATUM) were absent while being
+ * representable in `IfcTypeEnum`/`IfcTypeEnumToString` (types.ts), so every
+ * caller doing `IFC_ENTITY_NAMES[upper] ?? upper` fell through to the raw
+ * UPPERCASE string for them; they are added below and marked.
+ *
+ * `ifc-entity-names.test.ts` pins the two tables against each other, so any
+ * future drift - including a regeneration that drops entries again - fails
+ * loudly instead of silently degrading display names.
  */
 export const IFC_ENTITY_NAMES: Record<string, string> = {
   'IFCACTIONREQUEST': 'IfcActionRequest',
@@ -557,6 +568,8 @@ export const IFC_ENTITY_NAMES: Record<string, string> = {
   'IFCPROTECTIVEDEVICETRIPPINGUNIT': 'IfcProtectiveDeviceTrippingUnit',
   'IFCPROTECTIVEDEVICETRIPPINGUNITTYPE': 'IfcProtectiveDeviceTrippingUnitType',
   'IFCPROTECTIVEDEVICETYPE': 'IfcProtectiveDeviceType',
+  // Added by hand - see the header note on the four missing entries.
+  'IFCPROXY': 'IfcProxy',
   'IFCPUMP': 'IfcPump',
   'IFCPUMPTYPE': 'IfcPumpType',
   'IFCQUANTITYAREA': 'IfcQuantityArea',
@@ -704,6 +717,8 @@ export const IFC_ENTITY_NAMES: Record<string, string> = {
   'IFCSLIPPAGECONNECTIONCONDITION': 'IfcSlippageConnectionCondition',
   'IFCSOLARDEVICE': 'IfcSolarDevice',
   'IFCSOLARDEVICETYPE': 'IfcSolarDeviceType',
+  // Added by hand - see the header note on the four missing entries.
+  'IFCSOLIDSTRATUM': 'IfcSolidStratum',
   'IFCSOLIDMODEL': 'IfcSolidModel',
   'IFCSPACE': 'IfcSpace',
   'IFCSPACEHEATER': 'IfcSpaceHeater',
@@ -868,11 +883,15 @@ export const IFC_ENTITY_NAMES: Record<string, string> = {
   'IFCVIRTUALELEMENT': 'IfcVirtualElement',
   'IFCVIRTUALGRIDINTERSECTION': 'IfcVirtualGridIntersection',
   'IFCVOIDINGFEATURE': 'IfcVoidingFeature',
+  // Added by hand - see the header note on the four missing entries.
+  'IFCVOIDSTRATUM': 'IfcVoidStratum',
   'IFCWALL': 'IfcWall',
   'IFCWALLSTANDARDCASE': 'IfcWallStandardCase',
   'IFCWALLTYPE': 'IfcWallType',
   'IFCWASTETERMINAL': 'IfcWasteTerminal',
   'IFCWASTETERMINALTYPE': 'IfcWasteTerminalType',
+  // Added by hand - see the header note on the four missing entries.
+  'IFCWATERSTRATUM': 'IfcWaterStratum',
   'IFCWELLKNOWNTEXT': 'IfcWellKnownText',
   'IFCWINDOW': 'IfcWindow',
   'IFCWINDOWLININGPROPERTIES': 'IfcWindowLiningProperties',


### PR DESCRIPTION
`IFCPROXY`, `IFCSOLIDSTRATUM`, `IFCVOIDSTRATUM` and `IFCWATERSTRATUM` are all representable in `IfcTypeEnum`/`IfcTypeEnumToString`, but were **absent** from the UPPERCASE→PascalCase table. Every caller doing `IFC_ENTITY_NAMES[upper] ?? upper` fell through to the raw UPPERCASE STEP keyword for them.

## Where it shows

Six call sites display that value directly to a user:

| File | Line |
|---|---|
| `packages/mcp/src/tools/query.ts` | 204 |
| `packages/mcp/src/tools/diff.ts` | 218 |
| `packages/mcp/src/tools/validation.ts` | 184 |
| `packages/mcp/src/tools/discovery.ts` | 74 |
| `packages/cli/src/commands/info.ts` | 29 |
| `packages/cli/src/commands/diff.ts` | 106 |

`IFCPROXY` is not an exotic case. `packages/export/src/schema-converter.ts` **mints proxies itself** when downgrading IFC4X3 entities to IFC4 — `IFCREFERENT`, `IFCPOSITIONINGELEMENT` and `IFCLINEARPOSITIONINGELEMENT` all map to `IFCPROXY`. So a file this repo produced can be read back and displayed with the wrong casing.

## Measured, not assumed

All 125 non-`Unknown` enum members were enumerated and round-tripped through `IfcTypeEnumToString` then `IFC_ENTITY_NAMES`. Exactly these four fail.

`types.ts`'s own `IfcTypeEnum` / `TYPE_STRING_TO_ENUM` / `TYPE_ENUM_TO_STRING` triangle is complete in both directions — the drift is only in this separate table.

## The header was lying, which is why this persisted

The file claimed it was auto-generated and must not be edited by hand, naming `scripts/generate-entity-names.ts` as the way to regenerate it.

**That script does not exist.** The only reference to it in the entire repository is that comment. So the table is maintained by hand in practice, no "just regenerate it" fix was available, and the header was actively steering the next maintainer toward a command that cannot be run. It now says so instead.

That seemed worth correcting rather than leaving — the note is the reason a hand-fix looks illegitimate here, and it would have made this drift look unfixable to the next person who found it. Happy to drop that part if you'd rather keep the header as-is and restore the generator separately.

## Nothing relied on the old passthrough

Every other in-repo use of these four uppercase strings — `schema-converter`'s downgrade map, `reference-collector`'s set, `attribute-slot-types` — treats them as **internal identifiers** and never routes them through `IFC_ENTITY_NAMES`. No test pins the uppercase form as a display value.

## Verification

**128 → 133 passing across 12 files.** `tsc --noEmit` exit 0.

RED-verified: the four direct tests plus a completeness control all fail against the unfixed table (`expected undefined to be 'IfcProxy'`, and the control diffing exactly those four keys). The completeness control is the durable part — it pins the two tables against each other, so future drift fails loudly rather than silently degrading display names.

## Relationship to #2318

Complementary, not duplicate. #2318 documents this gap and works around it *inside the parquet exporter* by never routing untouched rows through the table; this fixes the table itself so the other six consumers stop displaying uppercase. Neither depends on the other.

## Reviewed and found clean

`types.ts`'s enum triangle (125/125 both directions). `entity-table.ts`'s `getTypeName()` checks the enum path first, so it was unaffected. `StringTable`'s null-index guard is load-bearing and already pinned.

One thing noted but **not** claimed as a finding: `property-table.ts`'s `add()` switch has no `case PropertyValueType.Reference`, so such a row would store nothing in any value column. The parser does not appear to emit `Reference` rows today, and unreachability wasn't proven with a bounding control — so it is flagged for a follow-up rather than reported as a bug.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored missing IFC entity-name mappings for proxy, solid stratum, void stratum, and water stratum entities.
  * Improved coverage to ensure all supported IFC type entries resolve to their expected names.

* **Tests**
  * Added validation for the restored mappings and complete entity-name coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->