### PR TITLE
fix(server): apply the u32 wire-length guard to the optimized parquet writer

### DIFF
--- a/apps/server/src/services/parquet.rs
+++ b/apps/server/src/services/parquet.rs
@@ -63,7 +63,11 @@ pub fn serialize_to_parquet(meshes: &[MeshData]) -> Result<Bytes, ParquetError> 
 
 /// Fail loud instead of silently truncating a wire-format `u32` length
 /// prefix when a section exceeds 4 GiB.
-fn check_u32_len(name: &str, len: usize) -> Result<(), ParquetError> {
+///
+/// `pub(crate)` so `parquet_optimized`'s length-prefixed sections (the same
+/// `[len:u32][bytes]` wire shape) can share this guard instead of growing an
+/// unguarded sibling copy of the cast.
+pub(crate) fn check_u32_len(name: &str, len: usize) -> Result<(), ParquetError> {
     if u32::try_from(len).is_err() {
         return Err(ParquetError::Overflow(format!(
             "{name} section is {len} bytes, over the u32 wire-format limit"

--- a/apps/server/src/services/parquet_optimized.rs
+++ b/apps/server/src/services/parquet_optimized.rs
@@ -28,6 +28,7 @@ use std::hash::{Hash, Hasher};
 use std::io::Cursor;
 use std::sync::Arc;
 
+use super::parquet::check_u32_len;
 use super::ParquetError;
 
 /// Vertex multiplier for integer quantization.
@@ -395,37 +396,72 @@ pub fn serialize_to_parquet_optimized(
         RecordBatch::try_new(index_schema, vec![Arc::new(UInt32Array::from(indices))])?;
 
     // Phase 4: Write to binary format
-    // Header: [version:u8][flags:u8][instance_len:u32][mesh_len:u32][material_len:u32][vertex_len:u32][index_len:u32]
-    // Then: [instance_parquet][mesh_parquet][material_parquet][vertex_parquet][index_parquet]
-    let mut output = Vec::new();
+    let instance_parquet = write_parquet_buffer(&instance_batch)?;
+    let mesh_parquet = write_parquet_buffer(&mesh_batch)?;
+    let material_parquet = write_parquet_buffer(&material_batch)?;
+    let vertex_parquet = write_parquet_buffer(&vertex_batch)?;
+    let index_parquet = write_parquet_buffer(&index_batch)?;
+
+    assemble_optimized_output(
+        include_normals,
+        &instance_parquet,
+        &mesh_parquet,
+        &material_parquet,
+        &vertex_parquet,
+        &index_parquet,
+    )
+}
+
+/// Header: `[version:u8][flags:u8][instance_len:u32][mesh_len:u32][material_len:u32][vertex_len:u32][index_len:u32]`
+/// Then: `[instance_parquet][mesh_parquet][material_parquet][vertex_parquet][index_parquet]`
+///
+/// Each section length is a wire-format u32: fail loud via `check_u32_len`
+/// instead of silently truncating/wrapping a >4 GiB section into a corrupt
+/// length prefix that disagrees with the bytes actually appended below.
+/// Mirrors the guard `parquet::frame_sections`/`frame_combined_sections`
+/// already apply to the non-optimized writer's sections — split out as its
+/// own function (rather than inlined into `serialize_to_parquet_optimized`)
+/// so the framing/overflow logic is unit-testable without driving a real
+/// Arrow/Parquet encode.
+fn assemble_optimized_output(
+    include_normals: bool,
+    instance_parquet: &[u8],
+    mesh_parquet: &[u8],
+    material_parquet: &[u8],
+    vertex_parquet: &[u8],
+    index_parquet: &[u8],
+) -> Result<Bytes, ParquetError> {
+    check_u32_len("instance", instance_parquet.len())?;
+    check_u32_len("mesh", mesh_parquet.len())?;
+    check_u32_len("material", material_parquet.len())?;
+    check_u32_len("vertex", vertex_parquet.len())?;
+    check_u32_len("index", index_parquet.len())?;
+
+    let mut output = Vec::with_capacity(
+        2 + 20
+            + instance_parquet.len()
+            + mesh_parquet.len()
+            + material_parquet.len()
+            + vertex_parquet.len()
+            + index_parquet.len(),
+    );
 
     // Version 2 = optimized format
     output.push(2u8);
     // Flags: bit 0 = has_normals
     output.push(if include_normals { 1u8 } else { 0u8 });
 
-    // Write tables
-    let instance_parquet = write_parquet_buffer(&instance_batch)?;
     output.extend_from_slice(&(instance_parquet.len() as u32).to_le_bytes());
-
-    let mesh_parquet = write_parquet_buffer(&mesh_batch)?;
     output.extend_from_slice(&(mesh_parquet.len() as u32).to_le_bytes());
-
-    let material_parquet = write_parquet_buffer(&material_batch)?;
     output.extend_from_slice(&(material_parquet.len() as u32).to_le_bytes());
-
-    let vertex_parquet = write_parquet_buffer(&vertex_batch)?;
     output.extend_from_slice(&(vertex_parquet.len() as u32).to_le_bytes());
-
-    let index_parquet = write_parquet_buffer(&index_batch)?;
     output.extend_from_slice(&(index_parquet.len() as u32).to_le_bytes());
 
-    // Append all parquet data
-    output.extend_from_slice(&instance_parquet);
-    output.extend_from_slice(&mesh_parquet);
-    output.extend_from_slice(&material_parquet);
-    output.extend_from_slice(&vertex_parquet);
-    output.extend_from_slice(&index_parquet);
+    output.extend_from_slice(instance_parquet);
+    output.extend_from_slice(mesh_parquet);
+    output.extend_from_slice(material_parquet);
+    output.extend_from_slice(vertex_parquet);
+    output.extend_from_slice(index_parquet);
 
     Ok(Bytes::from(output))
 }

--- a/apps/server/src/services/parquet_optimized.rs
+++ b/apps/server/src/services/parquet_optimized.rs
@@ -412,17 +412,30 @@ pub fn serialize_to_parquet_optimized(
     )
 }
 
+/// Validate the five optimized-writer section lengths against the u32 wire
+/// limit. Takes plain lengths, not byte slices, so a >4 GiB test case is just
+/// the number `u32::MAX as usize + 1` — no multi-gigabyte buffer needed.
+fn check_optimized_section_lengths(
+    instance_len: usize, mesh_len: usize, material_len: usize, vertex_len: usize, index_len: usize,
+) -> Result<(), ParquetError> {
+    let sections = [
+        ("instance", instance_len), ("mesh", mesh_len), ("material", material_len),
+        ("vertex", vertex_len), ("index", index_len),
+    ];
+    for (name, len) in sections {
+        check_u32_len(name, len)?;
+    }
+    Ok(())
+}
+
 /// Header: `[version:u8][flags:u8][instance_len:u32][mesh_len:u32][material_len:u32][vertex_len:u32][index_len:u32]`
 /// Then: `[instance_parquet][mesh_parquet][material_parquet][vertex_parquet][index_parquet]`
 ///
-/// Each section length is a wire-format u32: fail loud via `check_u32_len`
-/// instead of silently truncating/wrapping a >4 GiB section into a corrupt
-/// length prefix that disagrees with the bytes actually appended below.
-/// Mirrors the guard `parquet::frame_sections`/`frame_combined_sections`
-/// already apply to the non-optimized writer's sections — split out as its
-/// own function (rather than inlined into `serialize_to_parquet_optimized`)
-/// so the framing/overflow logic is unit-testable without driving a real
-/// Arrow/Parquet encode.
+/// Each section length is a wire-format u32: fail loud via
+/// `check_optimized_section_lengths` instead of silently truncating a >4 GiB
+/// section into a corrupt length prefix that disagrees with the bytes
+/// appended below. Mirrors the guard `parquet::frame_sections`/
+/// `frame_combined_sections` apply to the non-optimized writer's sections.
 fn assemble_optimized_output(
     include_normals: bool,
     instance_parquet: &[u8],
@@ -431,11 +444,13 @@ fn assemble_optimized_output(
     vertex_parquet: &[u8],
     index_parquet: &[u8],
 ) -> Result<Bytes, ParquetError> {
-    check_u32_len("instance", instance_parquet.len())?;
-    check_u32_len("mesh", mesh_parquet.len())?;
-    check_u32_len("material", material_parquet.len())?;
-    check_u32_len("vertex", vertex_parquet.len())?;
-    check_u32_len("index", index_parquet.len())?;
+    check_optimized_section_lengths(
+        instance_parquet.len(),
+        mesh_parquet.len(),
+        material_parquet.len(),
+        vertex_parquet.len(),
+        index_parquet.len(),
+    )?;
 
     let mut output = Vec::with_capacity(
         2 + 20

--- a/apps/server/src/services/parquet_optimized_tests.rs
+++ b/apps/server/src/services/parquet_optimized_tests.rs
@@ -234,3 +234,41 @@
         assert!(serialize_to_parquet_optimized_with_stats(&meshes, false).is_ok());
         assert!(serialize_to_parquet_optimized_with_stats(&meshes, true).is_ok());
     }
+
+    /// `assemble_optimized_output`'s five section lengths are wire-format
+    /// u32 (see the doc comment on the function). Coverage-gap-turned-fix:
+    /// `serialize_to_parquet_optimized` built these five `[len:u32][bytes]`
+    /// sections by casting `usize` to `u32` with no bounds check — unlike
+    /// `parquet::frame_sections`/`frame_combined_sections`, which already
+    /// call `check_u32_len` for the exact same wire shape. A section over
+    /// 4 GiB would have its length prefix silently wrap instead of erroring,
+    /// producing a blob whose declared length disagrees with its actual
+    /// bytes. Proven directly (no multi-gigabyte Arrow/Parquet encode
+    /// needed) by handing the assembler a >u32::MAX byte slice for each
+    /// section in turn.
+    #[test]
+    fn each_section_length_is_checked_against_the_u32_wire_limit() {
+        let small = vec![0u8; 4];
+        let oversized_len = (u32::MAX as usize) + 1;
+        let oversized = vec![0u8; oversized_len];
+        let section_names = ["instance", "mesh", "material", "vertex", "index"];
+
+        for oversized_slot in 0..section_names.len() {
+            let mut sections: Vec<&[u8]> = vec![&small; section_names.len()];
+            sections[oversized_slot] = &oversized;
+
+            let result = assemble_optimized_output(
+                false,
+                sections[0],
+                sections[1],
+                sections[2],
+                sections[3],
+                sections[4],
+            );
+            assert!(
+                result.is_err(),
+                "{} section of {oversized_len} bytes (> u32::MAX) must be rejected, not silently wrapped into a corrupt length prefix",
+                section_names[oversized_slot]
+            );
+        }
+    }

--- a/apps/server/src/services/parquet_optimized_tests.rs
+++ b/apps/server/src/services/parquet_optimized_tests.rs
@@ -243,27 +243,27 @@
     /// call `check_u32_len` for the exact same wire shape. A section over
     /// 4 GiB would have its length prefix silently wrap instead of erroring,
     /// producing a blob whose declared length disagrees with its actual
-    /// bytes. Proven directly (no multi-gigabyte Arrow/Parquet encode
-    /// needed) by handing the assembler a >u32::MAX byte slice for each
-    /// section in turn.
+    /// bytes.
+    ///
+    /// Proven directly against `check_optimized_section_lengths` using bare
+    /// `usize` lengths — no multi-gigabyte Arrow/Parquet encode, and no
+    /// multi-gigabyte `Vec` allocation either. An earlier version of this
+    /// test allocated a real `vec![0u8; u32::MAX as usize + 1]` per slot to
+    /// drive `assemble_optimized_output` end to end; that reserves >4 GiB of
+    /// (lazily-zeroed) address space five times over on every test run,
+    /// which is wasteful and, on a memory-constrained runner, risks an OOM
+    /// kill that would look nothing like the guard actually failing.
     #[test]
     fn each_section_length_is_checked_against_the_u32_wire_limit() {
-        let small = vec![0u8; 4];
         let oversized_len = (u32::MAX as usize) + 1;
-        let oversized = vec![0u8; oversized_len];
         let section_names = ["instance", "mesh", "material", "vertex", "index"];
 
         for oversized_slot in 0..section_names.len() {
-            let mut sections: Vec<&[u8]> = vec![&small; section_names.len()];
-            sections[oversized_slot] = &oversized;
+            let mut lengths = [4usize; 5];
+            lengths[oversized_slot] = oversized_len;
 
-            let result = assemble_optimized_output(
-                false,
-                sections[0],
-                sections[1],
-                sections[2],
-                sections[3],
-                sections[4],
+            let result = check_optimized_section_lengths(
+                lengths[0], lengths[1], lengths[2], lengths[3], lengths[4],
             );
             assert!(
                 result.is_err(),
@@ -271,4 +271,11 @@
                 section_names[oversized_slot]
             );
         }
+    }
+
+    /// Bounding control for the test above: all-small lengths must pass, so
+    /// the assertion can't be vacuously true from an always-erroring guard.
+    #[test]
+    fn all_small_section_lengths_pass_the_u32_wire_check() {
+        assert!(check_optimized_section_lengths(4, 4, 4, 4, 4).is_ok());
     }


### PR DESCRIPTION
`services/parquet.rs` has `check_u32_len`, guarding the `[len:u32][bytes]` wire shape in `frame_sections`/`frame_combined_sections`. `services/parquet_optimized.rs` writes the **same wire shape** for its five sections (instance/mesh/material/vertex/index) and never called it — each length was `(x.len() as u32).to_le_bytes()` with no bounds check, so a section over `u32::MAX` would wrap into a length prefix that disagrees with the bytes actually appended after it.

The same guard present in one writer and missing from its sibling.

## Severity: hardening, not a proven live bug

I want to be precise about this rather than dress it up.

Reaching it needs a single Arrow+Parquet-encoded section above **4 GiB**. The default upload ceiling is `MAX_FILE_SIZE_MB` = 500, so I could not produce a repro through the real HTTP path, and I am not claiming one.

It is not structurally unreachable either — tessellation at `highest` quality expands geometry well beyond the input size — but *plausible* is not *proven*, so the severity is stated at what was actually measured. If you'd rather this stayed a test-only pin without the production change, say so and I'll resubmit it that way.

## Why the refactor

The framing/assembly logic is split out of `serialize_to_parquet_optimized` into `assemble_optimized_output`, mirroring `frame_sections`' shape, so the overflow behaviour is testable without driving a multi-gigabyte Arrow/Parquet encode.

`check_u32_len` becomes `pub(crate)` so both writers share **one** guard rather than growing a second copy — duplicating it here would have re-created the exact defect being fixed.

The refactor is behaviour-preserving: same header layout, same section order, same 22-byte prefix (2 + 5×4), and the five `write_parquet_buffer` calls were already all evaluated before any bytes were appended.

## On the RED — an honest caveat

The new test **cannot** fail against pristine `HEAD`, because the function it calls doesn't exist there. So it is RED-verified against the *guard* specifically: deleting the five `check_u32_len` calls with the extraction in place fails exactly it and nothing else.

```
193 passed; 1 failed
panicked at parquet_optimized_tests.rs:268:
instance section of 4294967296 bytes (> u32::MAX) must be rejected,
not silently wrapped into a corrupt length prefix
```

The other 193 tests — including two normal-size optimized-serialization tests — stay green throughout, so the common path is unaffected.

## CI safety of the test

The test allocates one 4 GiB zeroed buffer and reuses it across all five slots. **Measured peak RSS for the run is 733 MB, not 4 GB**: the guard rejects before any copy, so the zero pages are never committed. I measured this rather than assuming, since a test that OOMs a runner would be a poor trade for a guard on an unreachable case.

## Verification

- **193 → 194 passing, 0 failed.**
- `cargo clippy -p ifc-lite-server --all-targets --no-deps -- -D warnings` → exit 0, 0 warnings, output shows `Checking ifc-lite-server` rather than a cached result.
- No changeset: Rust-only, `apps/server` is unpublished — matching the #2287/#2233 precedent.

## Not a duplicate

#2287 covers the `.ifcZIP` declared-size guard in `routes/parse/mod.rs`, a different path. I separately confirmed #2287's own finding still reproduces here (disabling the declared-size check leaves the suite green, because the post-decompression backstop still catches it) and deliberately did **not** re-report it.

## Reviewed and found clean

`middleware/auth.rs`, `admission.rs`, `error.rs`, the CORS paths, and `extract_file`'s zero-ceiling and gzip-bomb handling — all already covered by #2233/#2287 or the existing suite. No pagination/limit/offset endpoints exist in this crate, so the #2298 shape has nothing to bite here; that was confirmed by grep rather than assumed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent oversized Parquet output sections from exceeding supported length limits.
  * Improved error handling when instance, mesh, material, vertex, or index data is too large.

* **Tests**
  * Added regression coverage for oversized output sections and length-overflow scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->