### PR TITLE
fix(query): stop EntityQuery.first() permanently capping the query

### DIFF
--- a/.changeset/query-first-no-longer-caps-the-query.md
+++ b/.changeset/query-first-no-longer-caps-the-query.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/query": patch
+---
+
+Fix `EntityQuery.first()` permanently capping the query it was called on. `first()` narrowed the result set by calling `this.limit(1)` — which mutates the query object itself rather than a clone — so the cap outlived the call: every subsequent `execute()`, `ids()` or `first()` on the same query returned at most one row. A caller's own explicit `limit(n)` was overwritten too, silently collapsing to 1.
+
+Building a query, peeking at the first match, then iterating it in full is ordinary usage of a fluent query API, and `EntityQuery` is published surface — so "no in-repo caller does that" is not a defence here, the same reasoning applied to `ParquetExporter`'s un-memoised overlay index in the #2111 review.
+
+`first()` now narrows for the duration of the call only, restoring whatever limit was previously set rather than clearing it.

--- a/packages/query/src/entity-query.ts
+++ b/packages/query/src/entity-query.ts
@@ -119,8 +119,19 @@ export class EntityQuery {
   }
   
   async first(): Promise<QueryResultEntity | null> {
-    const results = this.limit(1).execute();
-    return results[0] ?? null;
+    // Narrow to one row for this call only. `this.limit(1)` mutates the query
+    // itself, so the cap outlived the call and every later
+    // execute()/ids()/first() on the same object returned at most one row --
+    // including one the caller had set a different limit on. Restore whatever
+    // was there before rather than clearing it, so an explicit limit survives.
+    const previousLimit = this.limitCount;
+    this.limitCount = 1;
+    try {
+      const results = this.execute();
+      return results[0] ?? null;
+    } finally {
+      this.limitCount = previousLimit;
+    }
   }
 
   // ═══════════════════════════════════════════════════════════════

--- a/packages/query/test/entity-query.test.ts
+++ b/packages/query/test/entity-query.test.ts
@@ -233,6 +233,38 @@ describe('EntityQuery', () => {
       const first = await query.first();
       expect(first).toBeNull();
     });
+
+    it('first() should not leave the query permanently capped at one result', async () => {
+      // `first()` narrowed the query by calling `this.limit(1)` on ITSELF
+      // rather than on a clone, so the cap outlived the call: every later
+      // execute()/ids()/first() on the same object returned at most one row.
+      // `EntityQuery` is published API (@ifc-lite/query), and building a
+      // query then calling first() before iterating it in full is ordinary
+      // usage — "no in-repo caller does that" is not a defence for a package
+      // whose consumers are external, the same reasoning applied to
+      // ParquetExporter's un-memoised overlay index in the #2111 review.
+      const store = makeStore();
+      const query = new EntityQuery(store as any, [IfcTypeEnum.IfcWall]);
+
+      // Control: the query really does match 2 walls to begin with, so a
+      // later assertion of 2 cannot pass by the fixture being empty.
+      expect(query.execute()).toHaveLength(2);
+
+      const first = await query.first();
+      expect(first!.expressId).toBe(1);
+
+      expect(query.execute()).toHaveLength(2);
+      expect(await query.ids()).toHaveLength(2);
+    });
+
+    it('first() should respect a limit the caller set explicitly', async () => {
+      // Control on the fix: restoring the previous limit must restore what
+      // the CALLER set, not clear it outright.
+      const store = makeStore();
+      const query = new EntityQuery(store as any, null).limit(3);
+      await query.first();
+      expect(query.execute()).toHaveLength(3);
+    });
   });
 
   // ── Empty store ───────────────────────────────────────────────

--- a/packages/query/test/entity-query.test.ts
+++ b/packages/query/test/entity-query.test.ts
@@ -244,7 +244,7 @@ describe('EntityQuery', () => {
       // whose consumers are external, the same reasoning applied to
       // ParquetExporter's un-memoised overlay index in the #2111 review.
       const store = makeStore();
-      const query = new EntityQuery(store as any, [IfcTypeEnum.IfcWall]);
+      const query = new EntityQuery(store, [IfcTypeEnum.IfcWall]);
 
       // Control: the query really does match 2 walls to begin with, so a
       // later assertion of 2 cannot pass by the fixture being empty.
@@ -261,7 +261,7 @@ describe('EntityQuery', () => {
       // Control on the fix: restoring the previous limit must restore what
       // the CALLER set, not clear it outright.
       const store = makeStore();
-      const query = new EntityQuery(store as any, null).limit(3);
+      const query = new EntityQuery(store, null).limit(3);
       await query.first();
       expect(query.execute()).toHaveLength(3);
     });


### PR DESCRIPTION
`first()` narrowed the result set with `this.limit(1)` — which mutates the query object rather than a clone — so the cap **outlived the call**. Every later `execute()`, `ids()` or `first()` on the same query returned at most one row, and a caller's own explicit `limit(n)` was overwritten, silently collapsing to 1.

Measured against the unfixed code, on a fixture matching two walls:

```
expected [ QueryResultEntity{…} ] to have a length of 2 but got 1
expected [ QueryResultEntity{…} ] to have a length of 3 but got 1
```

The second is from a query the caller had explicitly set `.limit(3)` on before calling `first()`.

`first()` now narrows for the duration of the call only, restoring the previous limit rather than clearing it — so an explicit limit survives.

## On severity — the part worth your judgement

`EntityQuery.first()` has **no in-repo caller** outside this package's own tests, so this is not observable from anything shipped in the monorepo today. I want that stated plainly rather than buried.

But `@ifc-lite/query` is **published** (v1.14.15, not private), and building a query, peeking at the first match, then iterating it in full is ordinary usage of a fluent API — it's the kind of thing the API's shape invites.

This repo has already ruled on exactly this reasoning. `parquet-exporter.ts` carries a comment recording the #2111 review's conclusion:

> `ParquetExporter` has no in-repo callers, so external usage IS the contract and "no caller does that" is not a defence.

I'm applying that same standard here. If you read the precedent differently for this package, I'm happy to drop it to a test-only pin instead.

## Why two tests

1. **The leak itself** — carries a control asserting the fixture really matches two rows *before* `first()` is called, so it cannot pass by the fixture being empty.
2. **The restore specifically** — a caller's `limit(3)` must still be 3 afterwards, not cleared. Without this, "restore" could be implemented as "reset to null" and still look correct on test 1.

## Verification

**154 → 156 passing across 11 files.** `tsc --noEmit` exit 0. Both new tests RED-verified against the unfixed code (output above).

## Provenance

Found while reviewing a mutation audit of `packages/query` that came back **otherwise clean** — the two highest-risk branches (the indexed-table vs STEP-fallback strategy selection in `whereProperty`) were mutation-tested and are correctly guarded and pinned by `where-property-parity.test.ts`. The auditor flagged this one as a latent footgun and set it aside precisely because it has no in-repo consumer; the published-API precedent above is why I'm shipping it rather than leaving it.

Two further observations from that pass, reported but **not** acted on, since neither is a proven defect:

- `IfcQuery`'s `hierarchy`/`project`/`storeys` getters are exported but unreached by any in-repo caller — the viewer reads `store.spatialHierarchy` directly and the CLI resolves through the SDK's own `QueryNamespace.storeys()`.
- `property-table.ts`/`entity-table.ts`/`fluent-api.ts` are an older parallel API surface, still exported and still tested, with no consumers anywhere in the monorepo outside their own tests.

Both are surface-area questions rather than bugs, so they're yours to call rather than something to change unasked.
