### PR TITLE
fix(geometry): bounds-check packed mesh pool ranges before slicing

### DIFF
--- a/.changeset/packed-geometry-pool-bounds-guard.md
+++ b/.changeset/packed-geometry-pool-bounds-guard.md
@@ -1,0 +1,13 @@
+---
+"@ifc-lite/geometry": patch
+---
+
+Bounds-check each mesh's declared positions/normals/indices range against the shared data pool when decoding packed geometry batches, so a malformed or corrupted offset/length pair throws a diagnosable error instead of being silently accepted.
+
+`decodePackedGeometryCacheShard` (the binary `packed-cache-shard` reader used by the desktop native cache path) and `convertPackedNativeBatch` (the Tauri-native packed-mesh-array conversion) both sliced each mesh's vertex/normal/index data out of a shared pool via `TypedArray.subarray(offset, offset + length)` with no check that `offset + length` stayed inside the pool. `subarray` saturates rather than throwing on an out-of-range end, so a mesh whose declared length ran past its pool silently received truncated data — or, when the overrun reached into a neighbouring mesh's range, silently absorbed that mesh's vertices instead. Either way the result renders as plausible-looking geometry with no error anywhere on the read path. The sibling instanced-shard decoder (`packed-instanced-decoder.ts`) already carried this exact guard; these two were missing it.
+
+`decodePackedGeometryCacheShard` also now rejects a payload truncated below the header size or inside the data section, matching the truncation check the instanced decoder already had.
+
+`convertPackedNativeBatch` additionally requires each offset and length to be a non-negative integer, which the binary decoder gets for free: its values come from `getUint32`, while these arrive as plain JS numbers on an IPC payload. An upper-bound comparison alone does not cover that — `NaN + length > poolLength` is false, so a NaN offset would pass and `subarray(NaN, NaN)` returns an empty view, reporting a successfully converted mesh that carries no geometry at all; a negative offset likewise passes and makes `subarray` count from the end of the pool.
+
+No change to well-formed input; all of these are purely defensive checks on malformed/truncated/corrupted data.

--- a/packages/geometry/src/native-bridge-conversion.test.ts
+++ b/packages/geometry/src/native-bridge-conversion.test.ts
@@ -1,0 +1,200 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Type conversion functions for the native Tauri bridge.
+ *
+ * `convertPackedNativeBatch` shares its offset/length pool-table shape with
+ * the binary packed-cache-shard decoder (`packed-geometry-decoder.ts`), which
+ * validates each mesh's declared range against its shared pool before
+ * slicing. This file had no coverage at all before, and the pool-bounds
+ * check was missing here too: a malformed offset/length pair would silently
+ * clip (`subarray` saturates) into truncated-or-borrowed geometry instead of
+ * throwing.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  convertNativeMesh,
+  convertPackedNativeBatch,
+  convertNativeBatchTelemetry,
+  convertNativeCoordinateInfo,
+  type NativePackedGeometryBatch,
+} from './native-bridge-conversion.js';
+
+describe('convertNativeMesh', () => {
+  it('converts plain number arrays into typed arrays', () => {
+    const out = convertNativeMesh({
+      expressId: 7,
+      ifcType: 'IfcWall',
+      positions: [1, 2, 3],
+      normals: [0, 1, 0],
+      indices: [0, 1, 2],
+      color: [1, 0, 0, 1],
+    });
+    expect(out.positions).toBeInstanceOf(Float32Array);
+    expect(Array.from(out.positions)).toEqual([1, 2, 3]);
+    expect(out.normals).toBeInstanceOf(Float32Array);
+    expect(out.indices).toBeInstanceOf(Uint32Array);
+    expect(out.expressId).toBe(7);
+    expect(out.ifcType).toBe('IfcWall');
+  });
+});
+
+describe('convertPackedNativeBatch', () => {
+  const baseNative: NativePackedGeometryBatch = {
+    meshes: [
+      { expressId: 101, positionsOffset: 0, positionsLen: 6, normalsOffset: 0, normalsLen: 6, indicesOffset: 0, indicesLen: 3, color: [1, 1, 1, 1] },
+      { expressId: 202, positionsOffset: 6, positionsLen: 3, normalsOffset: 6, normalsLen: 3, indicesOffset: 3, indicesLen: 3, color: [0, 1, 0, 1] },
+    ],
+    positions: [1, 2, 3, 4, 5, 6, 100, 200, 300],
+    normals: [0, 0, 1, 0, 1, 0, 1, 0, 0],
+    indices: [0, 1, 0, 0, 1, 2],
+    progress: { processed: 1, total: 2, currentType: 'mesh' },
+  };
+
+  it('splits the shared pools at each mesh offset/length', () => {
+    const out = convertPackedNativeBatch(baseNative);
+    expect(out).toHaveLength(2);
+    expect(Array.from(out[0].positions)).toEqual([1, 2, 3, 4, 5, 6]);
+    expect(Array.from(out[1].positions)).toEqual([100, 200, 300]);
+  });
+
+  // Mesh 0 declares a positions length far beyond the 9-float shared pool.
+  // `subarray` saturates instead of throwing, so without a guard mesh 0
+  // silently absorbs mesh 1's vertices with no error anywhere.
+  it('rejects a mesh whose positions range runs past the positions pool', () => {
+    const bad: NativePackedGeometryBatch = {
+      ...baseNative,
+      meshes: [
+        { ...baseNative.meshes[0], positionsLen: 999 },
+        baseNative.meshes[1],
+      ],
+    };
+    expect(() => convertPackedNativeBatch(bad)).toThrow(/mesh 0 pool offset out of bounds/);
+  });
+
+  it('rejects a mesh whose normals range runs past the normals pool', () => {
+    const bad: NativePackedGeometryBatch = {
+      ...baseNative,
+      meshes: [
+        { ...baseNative.meshes[0], normalsLen: 999 },
+        baseNative.meshes[1],
+      ],
+    };
+    expect(() => convertPackedNativeBatch(bad)).toThrow(/mesh 0 pool offset out of bounds/);
+  });
+
+  it('rejects a mesh whose indices range runs past the indices pool', () => {
+    const bad: NativePackedGeometryBatch = {
+      ...baseNative,
+      meshes: [
+        { ...baseNative.meshes[0], indicesLen: 999 },
+        baseNative.meshes[1],
+      ],
+    };
+    expect(() => convertPackedNativeBatch(bad)).toThrow(/mesh 0 pool offset out of bounds/);
+  });
+
+  // Control: an out-of-range SECOND mesh must not be masked by the first
+  // mesh's valid range — proves the guard runs per-mesh.
+  it('rejects an out-of-bounds second mesh even when the first mesh is valid', () => {
+    const bad: NativePackedGeometryBatch = {
+      ...baseNative,
+      meshes: [
+        baseNative.meshes[0],
+        { ...baseNative.meshes[1], positionsLen: 999 },
+      ],
+    };
+    expect(() => convertPackedNativeBatch(bad)).toThrow(/mesh 1 pool offset out of bounds/);
+  });
+
+  // Unlike the binary decoder, whose offsets come from `getUint32` and are
+  // therefore non-negative integers by construction, these arrive as plain
+  // JS numbers on an IPC payload. An upper-bound check alone does not cover
+  // that: `NaN + len > length` is FALSE, so NaN slips through and
+  // `subarray(NaN, NaN)` yields an EMPTY view — a mesh reported as
+  // successfully converted while carrying no geometry at all. A negative
+  // offset likewise passes the upper bound and makes `subarray` count from
+  // the END of the pool, silently borrowing another mesh's vertices.
+  it('rejects a NaN offset instead of silently producing an empty mesh', () => {
+    const bad: NativePackedGeometryBatch = {
+      ...baseNative,
+      meshes: [{ ...baseNative.meshes[0], positionsOffset: Number.NaN }],
+    };
+    expect(() => convertPackedNativeBatch(bad)).toThrow(/mesh 0 pool offset out of bounds/);
+  });
+
+  it('rejects a negative offset instead of slicing from the end of the pool', () => {
+    const bad: NativePackedGeometryBatch = {
+      ...baseNative,
+      meshes: [{ ...baseNative.meshes[0], positionsOffset: -3, positionsLen: 3 }],
+    };
+    expect(() => convertPackedNativeBatch(bad)).toThrow(/mesh 0 pool offset out of bounds/);
+  });
+
+  // Control: a mesh range that exactly reaches the end of its pool must
+  // still decode — proves the guard doesn't over-reject valid data.
+  it('accepts a mesh range that exactly reaches the end of its pool', () => {
+    const ok: NativePackedGeometryBatch = {
+      ...baseNative,
+      meshes: [baseNative.meshes[0]],
+      positions: [1, 2, 3, 4, 5, 6],
+      normals: [0, 0, 1, 0, 1, 0],
+      indices: [0, 1, 0],
+    };
+    const out = convertPackedNativeBatch(ok);
+    expect(Array.from(out[0].positions)).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+});
+
+describe('convertNativeBatchTelemetry', () => {
+  it('returns undefined when telemetry is absent', () => {
+    expect(convertNativeBatchTelemetry(undefined, 123)).toBeUndefined();
+  });
+
+  it('attaches jsReceivedTimeMs to the converted telemetry', () => {
+    const out = convertNativeBatchTelemetry(
+      {
+        batchSequence: 3,
+        payloadKind: 'mesh-array',
+        meshCount: 5,
+        positionsLen: 10,
+        normalsLen: 10,
+        indicesLen: 6,
+        chunkReadyTimeMs: 1,
+        packTimeMs: 2,
+        emitTimeMs: 3,
+        emittedTimeMs: 4,
+      },
+      42
+    );
+    expect(out).toEqual({
+      batchSequence: 3,
+      payloadKind: 'mesh-array',
+      meshCount: 5,
+      positionsLen: 10,
+      normalsLen: 10,
+      indicesLen: 6,
+      chunkReadyTimeMs: 1,
+      packTimeMs: 2,
+      emitTimeMs: 3,
+      emittedTimeMs: 4,
+      jsReceivedTimeMs: 42,
+    });
+  });
+});
+
+describe('convertNativeCoordinateInfo', () => {
+  it('copies bounds and shift fields through unchanged', () => {
+    const native = {
+      originShift: { x: 1, y: 2, z: 3 },
+      originalBounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 10, y: 10, z: 10 } },
+      shiftedBounds: { min: { x: -1, y: -2, z: -3 }, max: { x: 9, y: 8, z: 7 } },
+      hasLargeCoordinates: true,
+    };
+    expect(convertNativeCoordinateInfo(native)).toEqual(native);
+  });
+});

--- a/packages/geometry/src/native-bridge-conversion.ts
+++ b/packages/geometry/src/native-bridge-conversion.ts
@@ -85,6 +85,22 @@ export function convertNativeMesh(native: NativeMeshData): MeshData {
   };
 }
 
+/**
+ * Whether `[offset, offset + length)` is a real range inside a pool of
+ * `poolLength` elements. Both bounds must be non-negative integers: a NaN or
+ * negative value would pass a bare `offset + length > poolLength` comparison
+ * and then be silently reinterpreted by `subarray`.
+ */
+function isPoolRange(offset: number, length: number, poolLength: number): boolean {
+  return (
+    Number.isInteger(offset) &&
+    Number.isInteger(length) &&
+    offset >= 0 &&
+    length >= 0 &&
+    offset + length <= poolLength
+  );
+}
+
 export function convertPackedNativeBatch(native: NativePackedGeometryBatch): MeshData[] {
   // Copy each packed numeric array once, then hand meshes cheap subarray views
   // instead of slicing and copying per mesh.
@@ -92,14 +108,37 @@ export function convertPackedNativeBatch(native: NativePackedGeometryBatch): Mes
   const normals = Float32Array.from(native.normals);
   const indices = Uint32Array.from(native.indices);
 
-  return native.meshes.map((mesh) => ({
-    expressId: mesh.expressId,
-    ifcType: mesh.ifcType,
-    positions: positions.subarray(mesh.positionsOffset, mesh.positionsOffset + mesh.positionsLen),
-    normals: normals.subarray(mesh.normalsOffset, mesh.normalsOffset + mesh.normalsLen),
-    indices: indices.subarray(mesh.indicesOffset, mesh.indicesOffset + mesh.indicesLen),
-    color: mesh.color,
-  }));
+  return native.meshes.map((mesh, meshIndex) => {
+    // Validate each mesh's pool ranges before subarray — a malformed offset
+    // would otherwise silently clip (subarray saturates), yielding
+    // truncated-or-borrowed geometry indistinguishable from a real mesh.
+    // Mirrors the guard on the binary packed-cache-shard decoder
+    // (packed-geometry-decoder.ts) for the same offset/length table shape.
+    //
+    // An upper-bound check alone is NOT enough here. The binary decoder's
+    // offsets come from `getUint32`, so they are non-negative integers by
+    // construction; these arrive as plain JS numbers on an IPC payload.
+    // `NaN + len > length` is false, so NaN would pass and
+    // `subarray(NaN, NaN)` returns an EMPTY view — a mesh reported as
+    // converted while carrying no geometry. A negative offset also passes,
+    // and makes `subarray` count from the END of the pool. Require a
+    // non-negative integer for each before comparing.
+    if (
+      !isPoolRange(mesh.positionsOffset, mesh.positionsLen, positions.length) ||
+      !isPoolRange(mesh.normalsOffset, mesh.normalsLen, normals.length) ||
+      !isPoolRange(mesh.indicesOffset, mesh.indicesLen, indices.length)
+    ) {
+      throw new Error(`Native packed geometry batch mesh ${meshIndex} pool offset out of bounds`);
+    }
+    return {
+      expressId: mesh.expressId,
+      ifcType: mesh.ifcType,
+      positions: positions.subarray(mesh.positionsOffset, mesh.positionsOffset + mesh.positionsLen),
+      normals: normals.subarray(mesh.normalsOffset, mesh.normalsOffset + mesh.normalsLen),
+      indices: indices.subarray(mesh.indicesOffset, mesh.indicesOffset + mesh.indicesLen),
+      color: mesh.color,
+    };
+  });
 }
 
 export function convertNativeBatchTelemetry(

--- a/packages/geometry/src/packed-geometry-decoder.test.ts
+++ b/packages/geometry/src/packed-geometry-decoder.test.ts
@@ -242,4 +242,105 @@ describe('decodePackedGeometryCacheShard', () => {
       /Unsupported packed geometry cache shard version: 2/
     );
   });
+
+  it('rejects a payload truncated below the header size', () => {
+    const truncated = FIXTURE.slice(0, 4);
+
+    expect(() => decodePackedGeometryCacheShard(truncated, 0, 0)).toThrow(
+      /too small for header/
+    );
+  });
+
+  it('rejects a payload truncated inside the data section', () => {
+    const truncated = FIXTURE.slice(0, FIXTURE.byteLength - 4);
+
+    expect(() => decodePackedGeometryCacheShard(truncated, 0, 0)).toThrow(
+      /Packed geometry cache shard truncated/
+    );
+  });
+
+  // A mesh whose declared pool length runs past the end of the shared
+  // positions/normals/indices pool must be rejected, not silently clipped.
+  // `subarray` saturates rather than throwing, so an unvalidated offset would
+  // hand back truncated geometry (or, worse, a neighbouring mesh's vertices)
+  // with no error anywhere on the read path.
+  it('rejects a mesh whose positions range runs past the positions pool', () => {
+    const bad = encodeShard({
+      meshes: [
+        { expressId: 101, posOff: 0, posLen: 999, nrmOff: 0, nrmLen: 6, idxOff: 0, idxLen: 3, color: [1, 1, 1, 1] },
+      ],
+      positions: POSITIONS.slice(0, 6),
+      normals: NORMALS.slice(0, 6),
+      indices: INDICES.slice(0, 3),
+    });
+
+    expect(() => decodePackedGeometryCacheShard(bad, 0, 0)).toThrow(
+      /mesh 0 pool offset out of bounds/
+    );
+  });
+
+  it('rejects a mesh whose normals range runs past the normals pool', () => {
+    const bad = encodeShard({
+      meshes: [
+        { expressId: 101, posOff: 0, posLen: 6, nrmOff: 0, nrmLen: 999, idxOff: 0, idxLen: 3, color: [1, 1, 1, 1] },
+      ],
+      positions: POSITIONS.slice(0, 6),
+      normals: NORMALS.slice(0, 6),
+      indices: INDICES.slice(0, 3),
+    });
+
+    expect(() => decodePackedGeometryCacheShard(bad, 0, 0)).toThrow(
+      /mesh 0 pool offset out of bounds/
+    );
+  });
+
+  it('rejects a mesh whose indices range runs past the indices pool', () => {
+    const bad = encodeShard({
+      meshes: [
+        { expressId: 101, posOff: 0, posLen: 6, nrmOff: 0, nrmLen: 6, idxOff: 0, idxLen: 999, color: [1, 1, 1, 1] },
+      ],
+      positions: POSITIONS.slice(0, 6),
+      normals: NORMALS.slice(0, 6),
+      indices: INDICES.slice(0, 3),
+    });
+
+    expect(() => decodePackedGeometryCacheShard(bad, 0, 0)).toThrow(
+      /mesh 0 pool offset out of bounds/
+    );
+  });
+
+  // Control: an out-of-range SECOND mesh must not be masked by the first
+  // mesh's valid range — proves the guard runs per-mesh, not once for the
+  // whole table.
+  it('rejects an out-of-bounds second mesh even when the first mesh is valid', () => {
+    const bad = encodeShard({
+      meshes: [
+        { expressId: 101, posOff: 0, posLen: 6, nrmOff: 0, nrmLen: 6, idxOff: 0, idxLen: 3, color: [1, 1, 1, 1] },
+        { expressId: 202, posOff: 6, posLen: 999, nrmOff: 6, nrmLen: 6, idxOff: 3, idxLen: 3, color: [0, 1, 0, 1] },
+      ],
+      positions: POSITIONS,
+      normals: NORMALS,
+      indices: INDICES,
+    });
+
+    expect(() => decodePackedGeometryCacheShard(bad, 0, 0)).toThrow(
+      /mesh 1 pool offset out of bounds/
+    );
+  });
+
+  // Control: an in-bounds mesh at the exact edge of the pool must still
+  // decode — proves the guard doesn't over-reject valid data.
+  it('accepts a mesh range that exactly reaches the end of its pool', () => {
+    const ok = encodeShard({
+      meshes: [
+        { expressId: 101, posOff: 0, posLen: 6, nrmOff: 0, nrmLen: 6, idxOff: 0, idxLen: 3, color: [1, 1, 1, 1] },
+      ],
+      positions: POSITIONS.slice(0, 6),
+      normals: NORMALS.slice(0, 6),
+      indices: INDICES.slice(0, 3),
+    });
+
+    const batch = decodePackedGeometryCacheShard(ok, 0, 0);
+    expect(Array.from(batch.meshes[0].positions)).toEqual([1, 2, 3, 4, 5, 6]);
+  });
 });

--- a/packages/geometry/src/packed-geometry-decoder.ts
+++ b/packages/geometry/src/packed-geometry-decoder.ts
@@ -53,6 +53,10 @@ export function decodePackedGeometryCacheShard(
   batchSequence: number
 ): GeometryBatch {
   const buffer = toArrayBuffer(payload);
+  const headerBytes = 8 * Uint32Array.BYTES_PER_ELEMENT;
+  if (buffer.byteLength < headerBytes) {
+    throw new Error('Packed geometry cache shard too small for header');
+  }
   const header = new Uint32Array(buffer, 0, 8);
   const [magic, version, meshCount, positionsLen, normalsLen, indicesLen, processed, total] = header;
   if (magic !== 0x49464342) {
@@ -72,6 +76,12 @@ export function decodePackedGeometryCacheShard(
   const positionsOffset = dataByteOffset;
   const normalsOffset = positionsOffset + positionsByteLength;
   const indicesOffset = normalsOffset + normalsByteLength;
+  const expectedBytes = indicesOffset + indicesByteLength;
+  if (buffer.byteLength < expectedBytes) {
+    throw new Error(
+      `Packed geometry cache shard truncated: have ${buffer.byteLength}, need ${expectedBytes}`
+    );
+  }
 
   const positions = new Float32Array(buffer, positionsOffset, positionsLen);
   const normals = new Float32Array(buffer, normalsOffset, normalsLen);
@@ -98,6 +108,17 @@ export function decodePackedGeometryCacheShard(
       meshView.getFloat32(base + 36, true),
       meshView.getFloat32(base + 40, true),
     ];
+    // Validate each mesh's pool ranges before subarray — a malformed/wrapped
+    // offset would otherwise silently clip (subarray saturates), yielding
+    // truncated-or-borrowed geometry indistinguishable from a real mesh
+    // (mirrors the same guard in packed-instanced-decoder.ts).
+    if (
+      positionsOffsetWords + positionsLengthWords > positionsLen ||
+      normalsOffsetWords + normalsLengthWords > normalsLen ||
+      indicesOffsetWords + indicesLengthWords > indicesLen
+    ) {
+      throw new Error(`Packed geometry cache shard mesh ${meshIndex} pool offset out of bounds`);
+    }
     meshes.push({
       expressId,
       positions: positions.subarray(positionsOffsetWords, positionsOffsetWords + positionsLengthWords),


### PR DESCRIPTION
`decodePackedGeometryCacheShard` (binary packed-cache-shard reader) and `convertPackedNativeBatch` (Tauri native packed-mesh conversion) both sliced each mesh's positions/normals/indices out of a **shared pool** with `subarray(offset, offset + length)` and no check that the range stayed inside it.

`subarray` saturates instead of throwing, so a malformed range silently yielded truncated geometry — or, when it overran into the next mesh's region, silently absorbed **that mesh's** vertices.

Probed against the unfixed code:

```
mesh A (expressId 101) declared posLen=999
actual positions: [1, 2, 3, 4, 5, 6, 100, 200, 300]
-> mesh A absorbed mesh B's vertices [100,200,300], no error raised
```

The sibling decoder for the same format family, `packed-instanced-decoder.ts:135`, **already carries this exact guard**, with a comment explaining why: *"a malformed/wrapped offset would otherwise silently clip… indistinguishable from a real occurrence."* These two never got it.

## What the new throw displaces

Worth stating explicitly, since turning silent-wrong-data into an exception is a real behaviour change: throwing is the **established** failure mode on this path, not a new one. The sibling already throws for this exact condition, and the surrounding `native-bridge.ts` functions already throw for a missing cache manifest. Nothing that previously succeeded now fails — only input that was previously producing wrong geometry.

## The native path needed more than the sibling's guard

This is the part I'd most like a second opinion on.

The binary decoder's offsets come from `getUint32` — non-negative integers by construction, so an upper-bound comparison is a complete check there. `convertPackedNativeBatch`'s arrive as **plain JS numbers on an IPC payload**, and an upper-bound check alone does not cover them:

- `NaN + len > poolLength` is **false**, so a NaN offset passes the bound, and `subarray(NaN, NaN)` returns an **empty view** — a mesh reported as successfully converted while carrying no geometry at all.
- A **negative** offset also passes, and makes `subarray` count from the *end* of the pool — borrowing another mesh's vertices again.

Both were verified to slip through the upper-bound-only form (`expected [Function] to throw an error`, twice), so each offset and length must be a non-negative integer before the range is compared.

## Bounding controls

- A mesh range that **exactly** reaches the end of its pool still decodes — proves the guard doesn't over-reject valid data.
- An out-of-bounds **second** mesh is rejected while the first is valid — proves the check runs per mesh, not once per table.

Both pass before and after the fix, so neither is satisfied by "reject everything" or "accept everything".

## Also fixed

`decodePackedGeometryCacheShard` now rejects a payload truncated below the header size or inside the data section, matching the truncation check the instanced decoder already had.

## Verification

**300 → 319 passing across 27 files.** `tsc --noEmit` exit 0.

`native-bridge-conversion.ts` had **no test file at all** before this. All new tests were RED-verified against the unfixed code.

## Scope

Per your open #2260, I deliberately did not touch the half-space cut capping / open-boundary area.

`coordinate-handler.ts`'s bounds/origin-folding logic was reviewed and found clean — in particular the raw-position small-coordinate heuristic is intentionally origin-unaware (it asks whether WASM already emitted per-element local frames, which is a different question from world-bounds computation), so it is not an instance of the two-paths-disagree shape despite looking like one.
