### PR TITLE
fix(collab-server): let retention recognise the snapshot files it ships

### DIFF
--- a/.changeset/retention-classify-real-snapshot-files.md
+++ b/.changeset/retention-classify-real-snapshot-files.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/collab-server": patch
+---
+
+Fix `planRetention`'s default classifier never matching a real `SnapshotWorker` output file, so `applyRetention` silently never reclaims any of it.
+
+`SnapshotWorker.runOnce` (`snapshot-worker.ts`) writes one `<safeRoomId>.<isoStamp>.ifcx` file per active room on every tick and never overwrites or deletes a previous one. `retention.ts`'s `defaultClassify` only recognized `<roomId>.log` (active) and `<roomId>.log.<stamp>` / `<roomId>.snap.<stamp>` (rotated/snapshot) — shapes nothing in this package's `FilePersistence` or `SnapshotWorker` actually produces. Every real `.ifcx` snapshot was therefore classified `unknown` and skipped regardless of age or configured policy: `planRetention` returned an empty `drop` list and `applyRetention` freed 0 bytes even under an aggressive 1-day policy, while snapshot files accumulated on disk forever with no error surfaced. `defaultClassify` now also matches `*.ifcx` as `snapshot`, so it is governed by `snapshotsDays` like the (aspirational) `.snap.<stamp>` shape.

--- a/packages/collab-server/src/retention.ts
+++ b/packages/collab-server/src/retention.ts
@@ -56,6 +56,10 @@ interface FileFact {
  *   - `<roomId>.log.<isoStamp>` ← rotated logs (auditable)
  *   - `<roomId>.snap.<isoStamp>` ← periodic snapshots (kept longer)
  *
+ * Plus `SnapshotWorker`'s real output, which is what actually lands on disk
+ * today (`FilePersistence` compacts its log in place and never rotates it):
+ *   - `<roomId>.<isoStamp>.ifcx` ← periodic snapshots, classified `snapshot`
+ *
  * Tools shipping their own naming convention can pass a custom matcher
  * via the `classify` option.
  */
@@ -132,10 +136,24 @@ export async function applyRetention(decision: RetentionDecision): Promise<numbe
   return freed;
 }
 
-/** Default classifier matching `FilePersistence` naming. */
+/**
+ * Default classifier matching `FilePersistence` naming, plus
+ * `SnapshotWorker`'s real on-disk output.
+ *
+ * `SnapshotWorker.runOnce` (snapshot-worker.ts) writes one
+ * `<safeRoomId>.<isoStamp>.ifcx` file per room on every tick and never
+ * overwrites or deletes a previous one -- `.log.<stamp>` / `.snap.<stamp>`
+ * are aspirational shapes nothing in this package currently produces. Without
+ * matching `.ifcx` here, a deployment running the shipped worker alongside
+ * this retention module (exactly as both modules document) would have every
+ * snapshot classified `unknown` and skipped regardless of age or policy --
+ * `planRetention`/`applyRetention` would report a clean run while real
+ * snapshot files accumulate on disk forever.
+ */
 function defaultClassify(name: string): 'active' | 'log' | 'snapshot' | 'unknown' {
   if (/\.log$/.test(name)) return 'active';
   if (/\.log\..+$/.test(name)) return 'log';
   if (/\.snap\..+$/.test(name)) return 'snapshot';
+  if (/\.ifcx$/.test(name)) return 'snapshot';
   return 'unknown';
 }

--- a/packages/collab-server/test/retention.test.ts
+++ b/packages/collab-server/test/retention.test.ts
@@ -51,4 +51,25 @@ describe('retention', () => {
       'a.log.2024-06-01',
     ]);
   });
+
+  it('drops SnapshotWorker\'s actual on-disk snapshot files once they age out', () => {
+    // `SnapshotWorker.runOnce` (src/snapshot-worker.ts) writes
+    // `<safeRoomId>.<isoStamp>.ifcx` on every tick -- never `.snap.<stamp>`,
+    // which is the only "snapshot" shape `defaultClassify` recognizes. A
+    // deployment running the shipped worker + this retention module together
+    // (exactly as documented) must still be able to reclaim those files.
+    touch('myroom.2024-01-01T00-00-00-000Z.ifcx', 2000); // ancient real snapshot
+    touch('myroom.2026-08-01T00-00-00-000Z.ifcx', 1); // fresh real snapshot -- control
+    touch('myroom.log', 0); // active log, never dropped
+
+    const decision = planRetention(tmpDir, { fullLogDays: 1, snapshotsDays: 30 });
+    expect(decision.drop.map((p) => path.basename(p))).toEqual([
+      'myroom.2024-01-01T00-00-00-000Z.ifcx',
+    ]);
+    // Bounding control: the fresh snapshot and the active log must survive --
+    // a classifier that just deletes every .ifcx unconditionally would also
+    // pass the assertion above without this.
+    expect(decision.drop).not.toContain(path.join(tmpDir, 'myroom.2026-08-01T00-00-00-000Z.ifcx'));
+    expect(decision.drop).not.toContain(path.join(tmpDir, 'myroom.log'));
+  });
 });


### PR DESCRIPTION
`SnapshotWorker.runOnce` writes `<safeRoomId>.<isoStamp>.ifcx` per active room on every tick and never overwrites or deletes a previous one. `retention.ts`'s `defaultClassify` matched only `<roomId>.log`, `<roomId>.log.<stamp>` and `<roomId>.snap.<stamp>` — so every real snapshot classified as `unknown` and was skipped regardless of age or policy.

Two modules shipped in the same package that don't compose, and the failure is **silent**: `planRetention` returns an empty `drop` list and `applyRetention` reports a clean run having freed nothing.

Probed against the unfixed code with a real-shaped snapshot file aged 2000 days plus an active `.log`:

```
defaults                             -> drop: [], reclaimBytes: 0
{ fullLogDays: 1, snapshotsDays: 1 } -> drop: [], reclaimBytes: 0
```

No policy could ever reclaim it.

There's a second half worth stating: the `.log.<stamp>` and `.snap.<stamp>` shapes the classifier was written against are **aspirational**. `FilePersistence` writes only `<safe>.log` and compacts it *in place*, never rotating to a dated file. So the classifier recognised two shapes nothing produces and missed the one thing that does.

## Severity — stated at what I measured

`planRetention`/`applyRetention` have **no in-repo caller**. They're exported for a deployment to wire from cron or a Lambda, which is exactly what the module doc describes, and `SnapshotWorker`'s `outputDir` is caller-configured. **So nothing running in this repo today leaks disk**, and I don't want to imply otherwise.

But both are public API of a published package, and pointing the shipped retention module at the shipped snapshot writer's directory is the obvious combination — the same "external usage IS the contract" standard the #2111 review applied to `ParquetExporter`.

## Why this can't delete anything it shouldn't

I treated this as the risk that matters, since the fix's whole effect is to make files *eligible for deletion*.

`.ifcx` is classified `snapshot` — the **longest-retained** class (`snapshotsDays`, 5 years by default), not `log`. So the change cannot delete anything sooner than the policy a caller already opted into by calling `applyRetention` on that directory at all. A caller with a different convention still has the documented `classify` hook.

The bounding control lives in the same test: a **fresh** `.ifcx` (1 day old, under the 30-day policy) and the active `.log` must **not** be dropped. Both asserted, so the fix cannot be a "delete every `.ifcx`" rule.

## Doc

`planRetention`'s doc comment listed only the three `FilePersistence` shapes. It now also records the `.ifcx` shape — that comment is what a caller reads before deciding whether they need a custom classifier, so leaving it describing only shapes that never appear would preserve half the bug.

## Verification

**145 → 146 passing across 31 files.** `tsc --noEmit` exit 0. RED-verified: `expected [] to deeply equal [ Array(1) ]` against the unfixed classifier.

## Not a duplicate

#2309 fixes the lossy room-id sanitiser **inside** `SnapshotWorker`; this is the **downstream** retention classifier. They don't overlap, and I deliberately left #2309's line alone.

## Reviewed and found clean

The lossy-key shape #2309 fixes does **not** recur elsewhere in this package, which was the main thing I went looking for:

- `persistence.ts` / `persistence-s3.ts` — room-id keys use `encodeURIComponent` (injective, traversal-safe); the legacy lossy sanitiser is a read-only migration fallback, documented as such.
- `persistence-redis.ts` — key is `prefix + roomId + fixedSuffix`, injective by construction.
- `blob-route.ts` — hash validated by `HASH_REGEX` before any filesystem use.
- `layer-registry-fs.ts` — layer ids, review ids and report digests are all regex-validated before becoming filenames.
- `access-control.ts` — role checks are consistent across the blob, registry, token, revoke and kick paths; the one relaxed check (blob PUT/DELETE has no room binding) carries an explicit comment marking it a deliberate tradeoff.
- `room-manager.ts` — the write-role gate, rate limit and payload-size checks run identically before both the sync-write and awareness paths. Confirmed live and tested by mutation (flipping the gate fails 5 tests across 4 files).
