### PR TITLE
fix(pointcloud): reject a truncated LAS under stride>1 instead of faking points

### DIFF
--- a/.changeset/las-strided-truncation-guard.md
+++ b/.changeset/las-strided-truncation-guard.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/pointcloud": patch
+---
+
+Fix `LasStreamingSource` silently emitting fabricated zero-valued points instead of erroring when a LAS file's header declares more points than the body actually backs (truncated download, corrupt/lying producer) and downsampling (`stride > 1`) is active.
+
+The strided-read branch of `next()` always allocated its scratch buffer at the full requested size and copied into it via `subarray`/`set`; `subarray` silently saturates instead of throwing when the source slab is short, so the missing tail landed as zero bytes rather than raising an error, and those zero-derived points were reported as real decoded data. The `stride === 1` branch was already safe because it hands the (possibly short) slab straight to `decodeLasPoints`, whose own length check catches it. The strided branch now checks the read slab's length against what the requested strided window needs and throws a clear "file truncated?" error instead of fabricating points.

--- a/packages/pointcloud/src/streaming/las-source.test.ts
+++ b/packages/pointcloud/src/streaming/las-source.test.ts
@@ -147,6 +147,40 @@ describe('LasStreamingSource', () => {
     expect(xs).toEqual([0, 3, 6, 9]);
   });
 
+  it('rejects a truncated file under stride>1 downsampling instead of silently zero-filling missing points', async () => {
+    // The header declares 10 points, but the body backs only 3 of them —
+    // simulating a truncated download or a corrupt/lying producer.
+    // `BlobByteSource.read` clamps silently to the available bytes (no
+    // error), and the strided-read branch of `next()` always allocates its
+    // `compact` scratch buffer at the FULL requested size before copying
+    // into it via `subarray`/`set` — `subarray` saturates instead of
+    // throwing near the end of a short slab, so the missing tail lands in
+    // `compact` as zero bytes rather than raising an error. Those
+    // zero-derived "points" then decode and get reported as real data.
+    const rows: Array<{ x: number; y: number; z: number }> = [];
+    for (let i = 0; i < 10; i++) rows.push({ x: i + 1, y: 0, z: 0 });
+    const full = buildLasFile(rows);
+    const fullBuf = await full.arrayBuffer();
+    const headerSize = 227;
+    const recordLen = 20;
+    const truncated = fullBuf.slice(0, headerSize + 3 * recordLen);
+    const blob = new Blob([truncated], { type: 'application/octet-stream' });
+    const src = new LasStreamingSource(blob, { downsample: { stride: 2 } });
+    await src.open();
+    await expect(src.next(100)).rejects.toThrow(/truncated/);
+  });
+
+  it('control: an untruncated file still decodes correctly under stride>1 (guard does not reject valid input)', async () => {
+    const rows: Array<{ x: number; y: number; z: number }> = [];
+    for (let i = 0; i < 10; i++) rows.push({ x: i + 1, y: 0, z: 0 });
+    const src = new LasStreamingSource(buildLasFile(rows), { downsample: { stride: 2 } });
+    await src.open();
+    const chunk = await src.next(100);
+    expect(chunk?.pointCount).toBe(5);
+    const xs = Array.from({ length: chunk!.pointCount }, (_, i) => chunk!.positions[i * 3]);
+    expect(xs).toEqual([1, 3, 5, 7, 9]);
+  });
+
   it('aborts cleanly between chunks', async () => {
     const blob = buildLasFile([{ x: 1, y: 2, z: 3 }]);
     const src = new LasStreamingSource(blob);

--- a/packages/pointcloud/src/streaming/las-source.ts
+++ b/packages/pointcloud/src/streaming/las-source.ts
@@ -129,6 +129,28 @@ export class LasStreamingSource implements StreamingPointSource {
     const endByte = startByte + sourceTake * this.header.pointRecordLength;
     const slab = await this.bytes.read(startByte, endByte);
     abortIfAborted(signal);
+    // `BlobByteSource.read` silently clamps to the blob's actual size — a
+    // file whose header declares more points than the body backs (a
+    // truncated download, a corrupt producer) returns a SHORT slab with no
+    // error. Unlike the stride===1 branch above (where `decodeLasPoints`'s
+    // own `bytes.length < count * stride` check catches this because the
+    // short `slab` is handed to it directly), this branch always allocates
+    // `compact` at the FULL expected size and copies into it via
+    // `subarray`/`set` — `subarray` silently saturates to the available
+    // length near the end of a short `slab`, so the tail of `compact` is
+    // left at its zero-initialised default instead of raising an error.
+    // `decodeLasPoints` then sees a `compact` buffer that already matches
+    // `decodedCount * stride` exactly and has nothing left to catch this
+    // with — it decodes the zero-filled tail as real records, emitting
+    // points at the header's own scale/offset origin and counting them in
+    // `pointCount`. Fabricated data, reported as a successful read.
+    const expectedSlabLen = sourceTake * this.header.pointRecordLength;
+    if (slab.length < expectedSlabLen) {
+      throw new Error(
+        `LAS: decode expects ${expectedSlabLen} bytes for ${sourceTake} strided source records, ` +
+        `got ${slab.length} — file truncated?`,
+      );
+    }
 
     // Build a compacted slab that contains only the records we want, then
     // hand it to decodeLasPoints with stride === recordLen.


### PR DESCRIPTION
A LAS file whose header declares more points than its body backs — a truncated download, or a producer that lies about `pointCount` — read through `LasStreamingSource` **with downsampling** silently returned fabricated zero-derived points and reported them as a successful read.

## Three things line up to hide it

1. `BlobByteSource.read` **clamps** to the blob's actual size and returns a short slab with no error.
2. The strided branch allocates `compact` at the **full expected size** and fills it via `slab.subarray(srcOff, srcOff + recordLen)` — `subarray` saturates rather than throwing, so the tail stays at its zero-initialised default.
3. `decodeLasPoints` is then handed a buffer that already matches `decodedCount * stride` **exactly**, so its own `bytes.length < count * stride` check has nothing left to catch.

The `stride === 1` branch is safe precisely because it skips step 2: the short slab goes straight to `decodeLasPoints` and the existing check fires. So the guard is effectively present in one branch and absent from its sibling — with the twist that the sibling *neutralises* the shared downstream check rather than merely lacking one.

## Severity: LIVE

Probed against the unfixed code — header declares 10 points (x = 1..10), body truncated to 3 records, stride 2:

```
PROBE did NOT throw. chunk: {"pointCount":5,"xs":[1,3,0,0,0]}
```

Three of the five reported points never existed in the file. They aren't obviously wrong either — they decode at the header's own scale/offset origin, so they look like real points sitting at the model origin.

## What the throw displaces

Throwing is the **established** failure mode here, not a new one: `decodeLasPoints` already throws for exactly this condition on the unstrided path, and the new message mirrors its wording. Nothing that previously succeeded now fails — only reads that were previously returning fabricated data.

## Bounding control

In the same file: the **same fixture at the same stride but not truncated** must still decode — `pointCount: 5`, `xs: [1,3,5,7,9]`. It passes before and after, so the guard cannot be satisfied by rejecting all strided reads.

## How it was found

By grepping for a buffer slice whose end is computed from a declared length — the same `subarray`-saturation shape fixed in `packages/geometry` earlier today, where a malformed offset silently absorbed a neighbouring mesh's vertices. Worth noting the pattern generalises: `subarray` saturating instead of throwing has now produced two independent live bugs in this codebase.

## Verification

**145 → 148 passing / 2 skipped across 16 files.** `tsc --noEmit` exit 0.

`las-source.test.ts` had **no truncation coverage at all** before this.

(Skip counts vary by environment — three fixture-gated tests run here that are skipped where fixtures are absent. The 150 total is stable.)

## Not a duplicate

#2293 covers the E57 bytestream-overrun guard and the LAZ origin frame — different files, different guard. I reviewed its diff to confirm before writing anything.

## Reviewed and found clean

- `formats/las.ts` — header parsing, classification bit-masking (0x1f low-5-bits pre-1.4, dedicated byte for 1.4+), RGB offset table.
- `formats/e57-*.ts` — packet bounds, bytestream length-table bounds, recordCount-vs-body guard, ScaledInteger bit-width cap, XML recordCount NaN/negative rejection.
- `streaming/e57-source.ts` — shares `decodeE57Packet` with the whole-file decoder, so there's no duplicated-logic drift risk of the kind found here.
- `formats/ply.ts`, `pcd.ts`, `lzf.ts`, `ascii-points.ts`, `ifcx-points.ts` — all carry explicit declared-count-vs-available-bytes guards; `decompressLZF` has per-opcode bounds checks.
- `streaming/laz-source.ts` — point retrieval goes through `laz-perf`'s wasm `getPoint()` rather than a raw byte slice, so this shape doesn't apply the same way. Deliberately **not** chased: fabricating a truncated compressed stream would be testing `laz-perf` internals, not this package's code.
