### PR TITLE
perf(viewer): move extractProfiles into the overlay worker (#2183)

### DIFF
--- a/apps/viewer/src/hooks/useDrawingGeneration.projection.test.tsx
+++ b/apps/viewer/src/hooks/useDrawingGeneration.projection.test.tsx
@@ -27,7 +27,7 @@
  */
 
 import '@/test/setup-dom.js';
-import { describe, it, before } from 'node:test';
+import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
@@ -37,6 +37,7 @@ import type { Drawing2D } from '@ifc-lite/drawing-2d';
 import type { GeometryResult, MeshData } from '@ifc-lite/geometry';
 import { IfcTypeEnum, type SpatialHierarchy, type SpatialNode } from '@ifc-lite/data';
 import type { TypeVisibilityGate } from '@/store/typeVisibilityFilter';
+import { installInProcessOverlayWorker } from '@/test/overlay-worker-shim.js';
 import { useDrawingGeneration } from './useDrawingGeneration.js';
 
 // ─── Real wasm under happy-dom ───────────────────────────────────────────
@@ -75,7 +76,18 @@ function serveFileUrlsFromDisk(): void {
   Reflect.deleteProperty(WebAssembly, 'instantiateStreaming');
 }
 
-before(() => { serveFileUrlsFromDisk(); });
+let overlayShim: { restore(): void } | undefined;
+
+before(() => {
+  serveFileUrlsFromDisk();
+  // The profile extraction now runs in the overlay worker (#2183). Node has no
+  // `Worker`, so without this the hook resolves to zero profiles and every
+  // assertion below would pass VACUOUSLY — the exact failure mode the
+  // "class is visible" canary exists to catch. The shim runs the real handler
+  // across a real structuredClone boundary.
+  overlayShim = installInProcessOverlayWorker();
+});
+after(() => { overlayShim?.restore(); });
 
 // ─── Fixture helpers ─────────────────────────────────────────────────────
 

--- a/apps/viewer/src/hooks/useDrawingGeneration.ts
+++ b/apps/viewer/src/hooks/useDrawingGeneration.ts
@@ -26,8 +26,13 @@ import {
   type ProfileEntry,
 } from '@ifc-lite/drawing-2d';
 import { createMeshOutlineProvider, type MeshOutline2dFn } from './meshOutlineProvider.js';
-import { GeometryProcessor, type GeometryResult } from '@ifc-lite/geometry';
-import { getWholeSourceForWorker, parseSymbolicFlat } from '@/lib/overlay-parse/index.js';
+import { type GeometryResult } from '@ifc-lite/geometry';
+import {
+  getWholeSourceForWorker,
+  parseProfilesFlat,
+  parseSymbolicFlat,
+} from '@/lib/overlay-parse/index.js';
+import { buildProfileEntries } from '@/lib/overlay-parse/profile-entries.js';
 import {
   buildSymbolicDrawingLines,
   type SymbolicDrawingLine,
@@ -151,10 +156,10 @@ export function useDrawingGeneration({
 
   // Cache for extracted extruded-solid profiles (issue #979 construction
   // projection). Like symbolic reps these are section-position-independent, so
-  // they're parsed once per model and reused across section moves. Every typed
-  // array is copied off the WASM heap (`.slice()`) and the WASM handles freed
-  // deterministically before caching — caching a live view would dangle once
-  // the shared dlmalloc heap grows/reuses (AGENTS.md §7).
+  // they're parsed once per model and reused across section moves. The
+  // extraction and its WASM handle freeing now live in the overlay worker
+  // (#2183); what is cached here is `buildProfileEntries` output, whose typed
+  // arrays are plain JS-heap copies with no view into any WASM heap.
   const profileCacheRef = useRef<{
     profiles: ProfileEntry[];
     sourceId: string | null;
@@ -303,62 +308,33 @@ export function useDrawingGeneration({
           setDrawingProgress(10, 'Extracting profiles...');
         }
         try {
-          const processor = new GeometryProcessor();
-          try {
-            await processor.init();
-            // ProfileCollection + each ProfileEntryJs are WASM-bindgen handles
-            // owning WASM memory. Copy every typed array off the heap with
-            // `.slice()` and free each handle deterministically before caching
-            // (AGENTS.md §7 — leaking to GC corrupts the shared dlmalloc heap).
-            const collection = processor.extractProfiles(ifcDataStore.source, 0);
-            if (collection) {
-              try {
-                // Profiles come back in UNSHIFTED WebGL world space, but the
-                // meshes and the section position live in the render frame
-                // (issue #945 RTC / large-coordinate shift). Subtract the same
-                // shift so projection lines land on the cut geometry for
-                // georeferenced models — a no-op for small-coordinate models
-                // (AC20). The WASM mesh path subtracts the RTC offset in IFC
-                // Z-up then converts to Y-up via (x,y,z)→(x,z,−y), so the Y-up
-                // shift is (rtc.x, rtc.z, −rtc.y); the TS path instead
-                // subtracts `originShift`, already in Y-up.
-                const ci = geometryResult.coordinateInfo;
-                const rtc = ci.wasmRtcOffset;
-                const shift = rtc
-                  ? { x: rtc.x, y: rtc.z, z: -rtc.y }
-                  : ci.originShift;
-                const len = collection.length;
-                for (let i = 0; i < len; i++) {
-                  const entry = collection.get(i);
-                  if (!entry) continue;
-                  try {
-                    const transform = entry.transform.slice();
-                    transform[12] -= shift.x;
-                    transform[13] -= shift.y;
-                    transform[14] -= shift.z;
-                    profiles.push({
-                      expressId: entry.expressId,
-                      ifcType: entry.ifcType,
-                      outerPoints: entry.outerPoints.slice(),
-                      holeCounts: entry.holeCounts.slice(),
-                      holePoints: entry.holePoints.slice(),
-                      transform,
-                      extrusionDir: entry.extrusionDir.slice(),
-                      extrusionDepth: entry.extrusionDepth,
-                      modelIndex: 0,
-                    });
-                  } finally {
-                    entry.free();
-                  }
-                }
-              } finally {
-                collection.free();
-              }
-            }
-            profileCacheRef.current = { profiles, sourceId: modelCacheKey };
-          } finally {
-            processor.dispose();
-          }
+          // The WASM extraction runs in the overlay worker, which is terminated
+          // the moment the job settles (#2183). Running it here instead grew a
+          // main-thread `WebAssembly.Memory` that never shrinks — ~470 MB on a
+          // 342 MB model, pinned for the lifetime of the tab, the first time
+          // the user enabled construction projection. Only the flat entry
+          // stream comes back; `buildProfileEntries` is the same walk,
+          // transcribed over those arrays.
+          const flat = await parseProfilesFlat(getWholeSourceForWorker(ifcDataStore));
+
+          // Profiles come back in UNSHIFTED WebGL world space, but the meshes
+          // and the section position live in the render frame (issue #945 RTC /
+          // large-coordinate shift). Subtract the same shift so projection lines
+          // land on the cut geometry for georeferenced models — a no-op for
+          // small-coordinate models (AC20). The WASM mesh path subtracts the RTC
+          // offset in IFC Z-up then converts to Y-up via (x,y,z)→(x,z,−y), so
+          // the Y-up shift is (rtc.x, rtc.z, −rtc.y); the TS path instead
+          // subtracts `originShift`, already in Y-up. It stays main-side because
+          // `coordinateInfo` is main-thread state the worker cannot see.
+          const ci = geometryResult.coordinateInfo;
+          const rtc = ci.wasmRtcOffset;
+          const shift = rtc
+            ? { x: rtc.x, y: rtc.z, z: -rtc.y }
+            : ci.originShift;
+          // Single-model (legacy) mode, so model index is always 0. Multi-model
+          // profile extraction would require iterating over each model separately.
+          profiles = buildProfileEntries(flat, shift, 0);
+          profileCacheRef.current = { profiles, sourceId: modelCacheKey };
         } catch (error) {
           // Degrade gracefully: the drawing still renders without projection.
           console.warn('Profile extraction failed:', error);

--- a/apps/viewer/src/lib/overlay-parse/index.ts
+++ b/apps/viewer/src/lib/overlay-parse/index.ts
@@ -19,6 +19,7 @@ import type {
   OverlayParseRequest,
   OverlayParseResponse,
 } from './overlay-parse.worker.js';
+import { createEmptyFlatProfiles, type FlatProfiles } from './profiles-flat.js';
 import {
   createEmptyFlatSymbolic,
   type FlatSymbolic,
@@ -84,8 +85,14 @@ let workerFactory: WorkerFactory | null = defaultWorkerFactory();
  * would make `WorkerParser.isSupported()` believe the PARSER can use workers
  * too, and hand an overlay stub a parse request it cannot answer.
  */
-export function __setOverlayWorkerFactoryForTest(factory: WorkerFactory | null): void {
+export function __setOverlayWorkerFactoryForTest(
+  factory: WorkerFactory | null,
+): WorkerFactory | null {
+  const previous = workerFactory;
   workerFactory = factory ?? defaultWorkerFactory();
+  // Returned so a caller can restore whatever was installed before it, rather
+  // than resetting to the default and silently disabling an outer shim.
+  return previous;
 }
 
 function ensureWorker(): Worker {
@@ -156,6 +163,21 @@ export async function parseSymbolicFlat(
   return response && 'flat' in response ? response.flat : createEmptyFlatSymbolic();
 }
 
+/**
+ * Extract the construction-projection profiles off the main thread.
+ *
+ * Returns the FLAT entry stream, not finished `ProfileEntry` objects: the
+ * caller rebuilds them with `buildProfileEntries`, which keeps the RTC /
+ * `originShift` correction on the main thread where `coordinateInfo` lives.
+ * See `profiles-flat.ts`.
+ *
+ * Never rejects; resolves to an empty stream on every failure path.
+ */
+export async function parseProfilesFlat(source: Uint8Array): Promise<FlatProfiles> {
+  const response = await dispatch('profiles', source);
+  return response && 'profiles' in response ? response.profiles : createEmptyFlatProfiles();
+}
+
 /** Shared request path. Resolves to null on every failure. */
 async function dispatch(
   kind: OverlayParseKind,
@@ -205,4 +227,10 @@ async function dispatch(
 }
 
 export { getWholeSourceForWorker } from './source-handoff.js';
-export type { OverlayParseKind, OverlayLineKind, FlatSymbolic, SymbolicFilterMode };
+export type {
+  OverlayParseKind,
+  OverlayLineKind,
+  FlatProfiles,
+  FlatSymbolic,
+  SymbolicFilterMode,
+};

--- a/apps/viewer/src/lib/overlay-parse/overlay-parse.test.ts
+++ b/apps/viewer/src/lib/overlay-parse/overlay-parse.test.ts
@@ -242,9 +242,23 @@ describe('parseProfilesFlat', () => {
     assert.equal(worker.posted[0].kind, 'profiles');
     assert.equal(worker.posted[0].source, source, 'source passed by reference');
 
-    const profiles = { typeNames: ['IfcWall'], expressId: new Uint32Array([42]) };
+    // Assert the FIELDS survive, not that the same object came back: object
+    // identity would hold even if the client dropped or reshaped the payload.
+    const profiles = {
+      typeNames: ['IfcWall'],
+      typeIndex: new Uint16Array([0]),
+      expressId: new Uint32Array([42]),
+      outerPoints: new Float32Array([1, 2, 3, 4]),
+      outerStart: new Uint32Array([0, 4]),
+      extrusionDepth: new Float32Array([2.5]),
+    };
     worker.reply({ id: worker.posted[0].id, ok: true, profiles });
-    assert.equal(await promise, profiles);
+    const got = await promise;
+    assert.deepEqual(got.typeNames, ['IfcWall']);
+    assert.deepEqual([...got.expressId], [42]);
+    assert.deepEqual([...got.outerPoints], [1, 2, 3, 4]);
+    assert.deepEqual([...got.outerStart], [0, 4]);
+    assert.deepEqual([...got.extrusionDepth], [2.5]);
     assert.equal(worker.terminated, 1, 'terminate is what frees the WASM pages');
   });
 

--- a/apps/viewer/src/lib/overlay-parse/overlay-parse.test.ts
+++ b/apps/viewer/src/lib/overlay-parse/overlay-parse.test.ts
@@ -52,6 +52,7 @@ class FakeWorker {
 }
 
 let parseOverlayLines: typeof import('./index.js').parseOverlayLines;
+let parseProfilesFlat: typeof import('./index.js').parseProfilesFlat;
 let JOB_TIMEOUT_MS: number;
 
 beforeEach(async () => {
@@ -64,6 +65,7 @@ beforeEach(async () => {
   // are module-level singletons.
   const mod = await import(`./index.js?t=${Date.now()}${Math.random()}`);
   parseOverlayLines = mod.parseOverlayLines;
+  parseProfilesFlat = mod.parseProfilesFlat;
   JOB_TIMEOUT_MS = mod.JOB_TIMEOUT_MS;
 });
 
@@ -229,5 +231,59 @@ describe('parseOverlayLines', () => {
     const mod = await import(`./index.js?nw=${Date.now()}${Math.random()}`);
     assert.equal((await mod.parseOverlayLines('grid-lines', new Uint8Array(1))).length, 0);
     assert.equal(instances.length, 0);
+  });
+});
+
+describe('parseProfilesFlat', () => {
+  it('asks for the profiles kind and returns the flatten the worker sends', async () => {
+    const source = new Uint8Array([1, 2, 3]);
+    const promise = parseProfilesFlat(source);
+    const worker = instances[0];
+    assert.equal(worker.posted[0].kind, 'profiles');
+    assert.equal(worker.posted[0].source, source, 'source passed by reference');
+
+    const profiles = { typeNames: ['IfcWall'], expressId: new Uint32Array([42]) };
+    worker.reply({ id: worker.posted[0].id, ok: true, profiles });
+    assert.equal(await promise, profiles);
+    assert.equal(worker.terminated, 1, 'terminate is what frees the WASM pages');
+  });
+
+  // Construction projection is decoration too: a model that cannot produce
+  // profiles must still draw, so every failure resolves to an empty flatten
+  // rather than rejecting or handing back undefined.
+  it('resolves to an EMPTY flatten on a parse error, not a rejection', async () => {
+    const promise = parseProfilesFlat(new Uint8Array(1));
+    const worker = instances[0];
+    worker.reply({ id: worker.posted[0].id, ok: false, error: 'boom' });
+    const flat = await promise;
+    assert.equal(flat.expressId.length, 0);
+    assert.deepEqual(flat.typeNames, []);
+    // The `N + 1` offset arrays must still have their leading zero, or the
+    // rebuild would read `undefined` bounds instead of producing nothing.
+    assert.equal(flat.outerStart.length, 1);
+    assert.equal(flat.holeCountStart.length, 1);
+    assert.equal(flat.holePointStart.length, 1);
+    assert.equal(worker.terminated, 1, 'a failed job must still free the worker');
+  });
+
+  it('resolves to an empty flatten when the worker dies silently', async () => {
+    const promise = parseProfilesFlat(new Uint8Array(1));
+    mock.timers.tick(JOB_TIMEOUT_MS + 1);
+    assert.equal((await promise).expressId.length, 0);
+    assert.equal(instances[0].terminated, 1);
+  });
+
+  // Each empty resolution must own its buffers: a shared module-level constant
+  // would be handed to two callers, and one mutating it would corrupt the other.
+  it('gives each empty resolution its own arrays', async () => {
+    const a = parseProfilesFlat(new Uint8Array(1));
+    const b = parseProfilesFlat(new Uint8Array(1));
+    const worker = instances[0];
+    worker.reply({ id: worker.posted[0].id, ok: false, error: 'boom' });
+    worker.reply({ id: worker.posted[1].id, ok: false, error: 'boom' });
+    const [first, second] = await Promise.all([a, b]);
+    assert.notEqual(first, second);
+    assert.notEqual(first.outerStart.buffer, second.outerStart.buffer);
+    assert.notEqual(first.typeNames, second.typeNames);
   });
 });

--- a/apps/viewer/src/lib/overlay-parse/overlay-parse.worker.ts
+++ b/apps/viewer/src/lib/overlay-parse/overlay-parse.worker.ts
@@ -26,7 +26,12 @@
  */
 
 import { GeometryProcessor } from '@ifc-lite/geometry';
-import { buildParseReply, buildSymbolicReply } from './reply.js';
+import { buildParseReply, buildProfilesReply, buildSymbolicReply } from './reply.js';
+import {
+  collectFlatProfiles,
+  createEmptyFlatProfiles,
+  type FlatProfiles,
+} from './profiles-flat.js';
 import {
   collectFlatSymbolic,
   createEmptyFlatSymbolic,
@@ -38,7 +43,7 @@ import {
 export type OverlayLineKind = 'grid-lines' | 'alignment-lines';
 
 /** Every kind this worker can run. */
-export type OverlayParseKind = OverlayLineKind | 'symbolic';
+export type OverlayParseKind = OverlayLineKind | 'symbolic' | 'profiles';
 
 export interface OverlayParseRequest {
   id: number;
@@ -62,6 +67,7 @@ export interface OverlayParseRequest {
 export type OverlayParseResponse =
   | { id: number; ok: true; verts: Float32Array }
   | { id: number; ok: true; flat: FlatSymbolic }
+  | { id: number; ok: true; profiles: FlatProfiles }
   | { id: number; ok: false; error: string };
 
 function runLineParse(
@@ -113,6 +119,29 @@ function runSymbolicParse(
 }
 
 /**
+ * Flatten the extruded-solid profile collection into transferable arrays.
+ *
+ * Only the flatten happens here. The RTC/`originShift` correction and the
+ * `ProfileEntry[]` rebuild stay on the main thread (`profile-entries.ts`),
+ * because the shift is derived from `geometryResult.coordinateInfo` — state
+ * this realm has no view of.
+ */
+function runProfilesParse(processor: GeometryProcessor, source: Uint8Array): FlatProfiles {
+  const collection = processor.extractProfiles(source, 0);
+  if (!collection) return createEmptyFlatProfiles();
+  // `collectFlatProfiles` frees each per-entry handle, but the collection
+  // itself is the caller's to free — and it must happen deterministically.
+  // This worker outlives the job (it serves later ones until the client
+  // terminates it), so leaving the handle to the FinalizationRegistry would
+  // free it later against a grown or reused dlmalloc heap.
+  try {
+    return collectFlatProfiles(collection);
+  } finally {
+    collection.free();
+  }
+}
+
+/**
  * Serialises message handling.
  *
  * Two jobs arriving in the same tick (a model with both grids and alignments)
@@ -153,7 +182,9 @@ export async function handle(event: MessageEvent<OverlayParseRequest>): Promise<
     // linear memory, so transferring is safe and saves a structured clone.
     const { reply, transfer } = kind === 'symbolic'
       ? buildSymbolicReply(id, runSymbolicParse(processor, source, debug === true, mode ?? 'overlay'))
-      : buildParseReply(id, runLineParse(processor, kind, source));
+      : kind === 'profiles'
+        ? buildProfilesReply(id, runProfilesParse(processor, source))
+        : buildParseReply(id, runLineParse(processor, kind, source));
     (self as unknown as Worker).postMessage(reply, transfer);
   } catch (error) {
     const reply: OverlayParseResponse = {

--- a/apps/viewer/src/lib/overlay-parse/profile-entries.test.ts
+++ b/apps/viewer/src/lib/overlay-parse/profile-entries.test.ts
@@ -1,0 +1,285 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import type { ProfileCollection } from '@ifc-lite/wasm';
+import type { ProfileEntry } from '@ifc-lite/drawing-2d';
+import { collectFlatProfiles } from './profiles-flat.js';
+import { buildProfileEntries } from './profile-entries.js';
+
+/**
+ * Equivalence anchor for moving the construction-projection extraction into
+ * the overlay worker (#2183).
+ *
+ * `useDrawingGeneration` used to call `extractProfiles` on the whole source on
+ * the main thread and walk the collection inline, which regrew a ~470 MB
+ * main-thread `WebAssembly.Memory` the first time a user enabled construction
+ * projection. The walk now runs over the worker's flat arrays instead — and
+ * "the projection still looks right" is not a proof: a hole ring sliced at the
+ * wrong offset, a wrapped type index, or a transform read off a mis-strided
+ * buffer all silently change which footprints get drawn where.
+ *
+ * So this pins the new implementation against a VERBATIM copy of the walk that
+ * was deleted, run over the same fake collection. The two are independent
+ * implementations; only real agreement passes.
+ *
+ * Every scalar the fake hands out is `Math.fround`ed and the arrays are typed,
+ * because that is what a wasm-bindgen getter returns: f32 values widened to JS
+ * numbers. Feeding the legacy walk f64s it could never have seen would make it
+ * disagree with the (necessarily f32) flatten for reasons that have nothing to
+ * do with this change.
+ */
+
+const f32 = Math.fround;
+
+interface FakeEntry {
+  expressId: number;
+  ifcType: string;
+  outerPoints: Float32Array;
+  holeCounts: Uint32Array;
+  holePoints: Float32Array;
+  transform: Float32Array;
+  extrusionDir: Float32Array;
+  extrusionDepth: number;
+  free(): void;
+}
+
+/** A 4×4 column-major transform with a recognisable translation column. */
+function transformAt(tx: number, ty: number, tz: number): number[] {
+  return [
+    1, 0, 0, 0,
+    0, 1, 0, 0,
+    0, 0, 1, 0,
+    tx, ty, tz, 1,
+  ];
+}
+
+function entry(fields: {
+  expressId: number;
+  ifcType: string;
+  outerPoints: number[];
+  holeCounts?: number[];
+  holePoints?: number[];
+  transform: number[];
+  extrusionDir: number[];
+  extrusionDepth: number;
+}): FakeEntry {
+  return {
+    expressId: fields.expressId,
+    ifcType: fields.ifcType,
+    outerPoints: Float32Array.from(fields.outerPoints),
+    holeCounts: Uint32Array.from(fields.holeCounts ?? []),
+    holePoints: Float32Array.from(fields.holePoints ?? []),
+    transform: Float32Array.from(fields.transform),
+    extrusionDir: Float32Array.from(fields.extrusionDir),
+    extrusionDepth: f32(fields.extrusionDepth),
+    free() { /* handle release is asserted separately below */ },
+  };
+}
+
+function makeCollection(entries: (FakeEntry | undefined)[]): ProfileCollection {
+  return {
+    length: entries.length,
+    get: (i: number) => entries[i],
+  } as unknown as ProfileCollection;
+}
+
+/**
+ * The walk exactly as it stood in `useDrawingGeneration.ts` before #2183's
+ * step 3 — `.slice()` copies, RTC subtraction, handle frees and all. Do not
+ * "improve" it: its value is that it is the shipped behaviour.
+ */
+function legacyWalk(
+  collection: ProfileCollection,
+  shift: { x: number; y: number; z: number },
+): ProfileEntry[] {
+  const profiles: ProfileEntry[] = [];
+  const c = collection as unknown as {
+    length: number;
+    get(i: number): FakeEntry | undefined;
+  };
+  const len = c.length;
+  for (let i = 0; i < len; i++) {
+    const e = c.get(i);
+    if (!e) continue;
+    try {
+      const transform = e.transform.slice();
+      transform[12] -= shift.x;
+      transform[13] -= shift.y;
+      transform[14] -= shift.z;
+      profiles.push({
+        expressId: e.expressId,
+        ifcType: e.ifcType,
+        outerPoints: e.outerPoints.slice(),
+        holeCounts: e.holeCounts.slice(),
+        holePoints: e.holePoints.slice(),
+        transform,
+        extrusionDir: e.extrusionDir.slice(),
+        extrusionDepth: e.extrusionDepth,
+        modelIndex: 0,
+      });
+    } finally {
+      e.free();
+    }
+  }
+  return profiles;
+}
+
+/**
+ * Mixed set: a ringed profile with two holes, one with none, a gap in the
+ * collection, and an express id past 2^24 (which a `Float32Array` id column
+ * could not hold exactly).
+ */
+function fixture(): (FakeEntry | undefined)[] {
+  return [
+    entry({
+      expressId: 101,
+      ifcType: 'IfcWallStandardCase',
+      outerPoints: [0, 0, 4, 0, 4, 3, 0, 3],
+      holeCounts: [4, 3],
+      holePoints: [1, 1, 2, 1, 2, 2, 1, 2, 3, 0.5, 3.5, 0.5, 3.25, 1],
+      transform: transformAt(1200.5, 30.25, -800.125),
+      extrusionDir: [0, 1, 0],
+      extrusionDepth: 2.75,
+    }),
+    entry({
+      expressId: 102,
+      ifcType: 'IfcSlab',
+      outerPoints: [0, 0, 10, 0, 10, 8, 0, 8],
+      transform: transformAt(0, 0, 0),
+      extrusionDir: [0, -1, 0],
+      extrusionDepth: 0.2,
+    }),
+    // A gap: `ProfileCollection.get` returns undefined out of bounds, and the
+    // walk must skip rather than emit a hole in the output.
+    undefined,
+    entry({
+      expressId: 33_554_433, // 2^25 + 1: not representable exactly as f32
+      ifcType: 'IfcBeam',
+      outerPoints: [-0.1, -0.2, 0.1, -0.2, 0.1, 0.2, -0.1, 0.2],
+      transform: transformAt(-5.5, 12.125, 7.75),
+      extrusionDir: [1, 0, 0],
+      extrusionDepth: 6,
+    }),
+  ];
+}
+
+const SHIFT = { x: 1200, y: 30, z: -800 };
+
+describe('buildProfileEntries (#2183)', () => {
+  it('reproduces the deleted main-thread walk exactly', () => {
+    const flat = collectFlatProfiles(makeCollection(fixture()));
+    // `structuredClone` stands in for the `postMessage` hop.
+    const viaWorker = buildProfileEntries(structuredClone(flat), SHIFT, 0);
+    const legacy = legacyWalk(makeCollection(fixture()), SHIFT);
+
+    assert.deepStrictEqual(viaWorker, legacy);
+    // Guard against a vacuous pass: two empty arrays satisfy deepStrictEqual.
+    assert.equal(legacy.length, 3);
+    assert.deepStrictEqual(legacy.map((p) => p.expressId), [101, 102, 33_554_433]);
+  });
+
+  it('subtracts the render-frame shift from the translation column only', () => {
+    const flat = collectFlatProfiles(makeCollection(fixture()));
+    const [first] = buildProfileEntries(flat, SHIFT, 0);
+    assert.equal(first.transform[12], f32(1200.5) - 1200);
+    assert.equal(first.transform[13], f32(30.25) - 30);
+    assert.equal(first.transform[14], f32(-800.125) + 800);
+    // The rotation/scale block is untouched.
+    assert.deepStrictEqual(
+      Array.from(first.transform.subarray(0, 12)),
+      [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0],
+    );
+  });
+
+  it('gives each entry its own copies, not views into the shared buffers', () => {
+    const flat = collectFlatProfiles(makeCollection(fixture()));
+    const profiles = buildProfileEntries(flat, SHIFT, 0);
+    for (const p of profiles) {
+      for (const view of [p.outerPoints, p.holeCounts, p.holePoints, p.transform, p.extrusionDir]) {
+        assert.notEqual(
+          view.buffer,
+          flat.outerPoints.buffer,
+          'a cached entry must not alias the concatenated flatten',
+        );
+        assert.equal(view.byteOffset, 0);
+      }
+    }
+    // Mutating a rebuilt entry must not reach back into the flatten.
+    profiles[0].outerPoints[0] = 999;
+    assert.equal(flat.outerPoints[0], 0);
+  });
+
+  it('stamps the model index it is given', () => {
+    const profiles = buildProfileEntries(
+      collectFlatProfiles(makeCollection(fixture())),
+      SHIFT,
+      3,
+    );
+    assert.deepStrictEqual(profiles.map((p) => p.modelIndex), [3, 3, 3]);
+  });
+
+  // The bug this shape has already produced once (symbolic flatten review): an
+  // 8-bit type index wraps past 256 distinct types and hands an entry somebody
+  // else's `ifcType`. The profile type table is unbounded — every product with
+  // an extruded body contributes — so this is reachable, not theoretical.
+  it('keeps ifcType correct past 256 distinct types', () => {
+    const entries = Array.from({ length: 300 }, (_, i) =>
+      entry({
+        expressId: 1000 + i,
+        ifcType: `IfcType${i}`,
+        outerPoints: [0, 0, 1, 0, 1, 1],
+        transform: transformAt(0, 0, 0),
+        extrusionDir: [0, 1, 0],
+        extrusionDepth: 1,
+      }));
+    const profiles = buildProfileEntries(
+      collectFlatProfiles(makeCollection(entries)),
+      { x: 0, y: 0, z: 0 },
+      0,
+    );
+    assert.equal(profiles.length, 300);
+    assert.equal(profiles[299].ifcType, 'IfcType299');
+    assert.equal(new Set(profiles.map((p) => p.ifcType)).size, 300);
+  });
+
+  it('frees every entry handle, including when the flatten throws', () => {
+    const freed: number[] = [];
+    const track = (e: FakeEntry): FakeEntry => ({
+      ...e,
+      free() { freed.push(e.expressId); },
+    });
+    const good = track(entry({
+      expressId: 1,
+      ifcType: 'IfcSlab',
+      outerPoints: [0, 0, 1, 0, 1, 1],
+      transform: transformAt(0, 0, 0),
+      extrusionDir: [0, 1, 0],
+      extrusionDepth: 1,
+    }));
+    const bad = track(entry({
+      expressId: 2,
+      ifcType: 'IfcSlab',
+      outerPoints: [0, 0, 1, 0, 1, 1],
+      transform: transformAt(0, 0, 0),
+      extrusionDir: [0, 1, 0],
+      extrusionDepth: 1,
+    }));
+    // A getter that throws mid-entry: the handle must still be released, or it
+    // is left to the FinalizationRegistry and freed against a grown heap.
+    Object.defineProperty(bad, 'outerPoints', {
+      get() { throw new Error('wasm getter blew up'); },
+    });
+
+    assert.throws(() => collectFlatProfiles(makeCollection([good, bad])), /wasm getter blew up/);
+    assert.deepStrictEqual(freed, [1, 2]);
+  });
+
+  it('rebuilds nothing from an empty flatten', () => {
+    const flat = collectFlatProfiles(makeCollection([]));
+    assert.deepStrictEqual(buildProfileEntries(flat, SHIFT, 0), []);
+  });
+});

--- a/apps/viewer/src/lib/overlay-parse/profile-entries.test.ts
+++ b/apps/viewer/src/lib/overlay-parse/profile-entries.test.ts
@@ -199,10 +199,20 @@ describe('buildProfileEntries (#2183)', () => {
     const flat = collectFlatProfiles(makeCollection(fixture()));
     const profiles = buildProfileEntries(flat, SHIFT, 0);
     for (const p of profiles) {
-      for (const view of [p.outerPoints, p.holeCounts, p.holePoints, p.transform, p.extrusionDir]) {
+      // Each view must be checked against ITS OWN source array. Comparing all
+      // five against flat.outerPoints made four of the five assertions pass
+      // trivially, since a holePoints view could never share that buffer.
+      const pairs: [Uint8Array | Uint32Array | Float32Array, Uint8Array | Uint32Array | Float32Array][] = [
+        [p.outerPoints, flat.outerPoints],
+        [p.holeCounts, flat.holeCounts],
+        [p.holePoints, flat.holePoints],
+        [p.transform, flat.transform],
+        [p.extrusionDir, flat.extrusionDir],
+      ];
+      for (const [view, origin] of pairs) {
         assert.notEqual(
           view.buffer,
-          flat.outerPoints.buffer,
+          origin.buffer,
           'a cached entry must not alias the concatenated flatten',
         );
         assert.equal(view.byteOffset, 0);

--- a/apps/viewer/src/lib/overlay-parse/profile-entries.ts
+++ b/apps/viewer/src/lib/overlay-parse/profile-entries.ts
@@ -1,0 +1,87 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Flat profile arrays → `ProfileEntry[]` (#2183).
+ *
+ * The construction-projection sibling of `buildSymbolicDrawingLines`: the
+ * main-thread half that turns the worker's transferable arrays back into the
+ * entries `ProfileProjector` consumes. It exists because `useDrawingGeneration`
+ * used to call `extractProfiles` on the whole source on the main thread, which
+ * regrew a `WebAssembly.Memory` there — ~470 MB on a 342 MB model — the first
+ * time a user enabled construction projection, and that memory never shrinks.
+ *
+ * This is a transcription, not a redesign: field order, the `.slice()` copies,
+ * and the RTC correction are exactly what the inline walk did.
+ *
+ * The RTC/`originShift` correction stays HERE rather than in the flatten
+ * because it reads `geometryResult.coordinateInfo` — main-thread state the
+ * worker has no view of.
+ */
+
+import type { ProfileEntry } from '@ifc-lite/drawing-2d';
+import {
+  EXTRUSION_DIR_STRIDE,
+  TRANSFORM_STRIDE,
+  type FlatProfiles,
+} from './profiles-flat.js';
+
+/**
+ * The render-frame shift to subtract from each profile's world translation.
+ *
+ * Profiles come back in UNSHIFTED WebGL world space, but the meshes and the
+ * section position live in the render frame (issue #945 RTC / large-coordinate
+ * shift), so without this the projection lines miss the cut geometry on
+ * georeferenced models. See the call site for how it is derived from
+ * `coordinateInfo` — the derivation is main-thread-only, which is why this
+ * arrives as a plain vector.
+ */
+export interface ProfileOriginShift {
+  x: number;
+  y: number;
+  z: number;
+}
+
+/**
+ * Rebuild the drawing's profile entries from a flatten.
+ *
+ * `modelIndex` is stamped on every entry; the projection path is single-model
+ * for now (federated extraction would extract each model separately), which is
+ * why it defaults to 0 — mirroring the symbolic path's federation limit.
+ */
+export function buildProfileEntries(
+  flat: FlatProfiles,
+  shift: ProfileOriginShift,
+  modelIndex = 0,
+): ProfileEntry[] {
+  const profiles: ProfileEntry[] = [];
+  const typeNames = flat.typeNames;
+
+  for (let i = 0; i < flat.expressId.length; i++) {
+    // Every array below is `slice`d, not viewed: the entries outlive this loop
+    // (they are cached across section moves), and a view would keep the whole
+    // concatenated buffer alive and alias its neighbours.
+    const transform = flat.transform.slice(i * TRANSFORM_STRIDE, (i + 1) * TRANSFORM_STRIDE);
+    transform[12] -= shift.x;
+    transform[13] -= shift.y;
+    transform[14] -= shift.z;
+
+    profiles.push({
+      expressId: flat.expressId[i],
+      ifcType: typeNames[flat.typeIndex[i]],
+      outerPoints: flat.outerPoints.slice(flat.outerStart[i], flat.outerStart[i + 1]),
+      holeCounts: flat.holeCounts.slice(flat.holeCountStart[i], flat.holeCountStart[i + 1]),
+      holePoints: flat.holePoints.slice(flat.holePointStart[i], flat.holePointStart[i + 1]),
+      transform,
+      extrusionDir: flat.extrusionDir.slice(
+        i * EXTRUSION_DIR_STRIDE,
+        (i + 1) * EXTRUSION_DIR_STRIDE,
+      ),
+      extrusionDepth: flat.extrusionDepth[i],
+      modelIndex,
+    });
+  }
+
+  return profiles;
+}

--- a/apps/viewer/src/lib/overlay-parse/profiles-flat.ts
+++ b/apps/viewer/src/lib/overlay-parse/profiles-flat.ts
@@ -1,0 +1,189 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Struct-of-arrays flattening of the WASM extruded-solid profile collection.
+ *
+ * The profile sibling of `symbolic-flat.ts`, and the same contract: the WASM
+ * handles this walks cannot cross a `postMessage` boundary, so the worker
+ * flattens them into transferable typed arrays here and the main thread
+ * reassembles the `ProfileEntry[]` from those arrays (`buildProfileEntries` in
+ * `profile-entries.ts`).
+ *
+ * Verbatim: every field the main-side walk read off a `ProfileEntryJs` is
+ * carried across unchanged, in the element type WASM produced it in — `f32`
+ * coordinates into `Float32Array`, `u32` express ids and hole counts into
+ * `Uint32Array` (never a `Float32Array`; express ids exceed 2^24 on large
+ * models). Nothing is rounded, reordered, or filtered on this side, and no
+ * profile is dropped: the projector's own guards stay where they are.
+ *
+ * The RTC/`originShift` correction is deliberately NOT applied here. It reads
+ * `geometryResult.coordinateInfo`, which is main-thread state, so it stays with
+ * the rebuild (see `profile-entries.ts`).
+ */
+
+import type { ProfileCollection } from '@ifc-lite/wasm';
+
+/**
+ * A whole profile collection as transferable arrays.
+ *
+ * Variable-length data (outer ring vertices, hole counts, hole vertices) is
+ * concatenated into one buffer per kind with a companion `*Start` offset array
+ * of length `N + 1`: entry `i` spans `[start[i], start[i + 1])`. Offsets are
+ * **element** indices into the array they describe, so a ring with an odd float
+ * count survives verbatim rather than being reconstructed from a vertex count.
+ * Fixed-width data uses a fixed stride, which the Rust types guarantee
+ * (`transform: [f32; 16]`, `extrusion_dir: [f32; 3]`).
+ *
+ * Every array is backed by its own `ArrayBuffer`, so the whole struct can be
+ * handed to `postMessage` as a transfer list.
+ */
+export interface FlatProfiles {
+  /**
+   * IFC type names, deduplicated. {@link FlatProfiles.typeIndex} indexes into
+   * this. The table is unbounded — a profile is extracted for every product
+   * with an extruded-area-solid body, not a filtered subset — which is why the
+   * index array is 16-bit. An 8-bit index would wrap silently past 256 distinct
+   * types and hand an entry somebody else's `ifcType`.
+   */
+  typeNames: string[];
+  /** Index into {@link FlatProfiles.typeNames}, one per entry. */
+  typeIndex: Uint16Array;
+  /** Express id of the owning element, one per entry. */
+  expressId: Uint32Array;
+
+  /** Flat `[x, y, x, y, …]` outer rings for every entry, back to back. */
+  outerPoints: Float32Array;
+  /** `N + 1` **float**-index offsets into {@link FlatProfiles.outerPoints}. */
+  outerStart: Uint32Array;
+
+  /** Per-hole vertex counts for every entry, back to back. */
+  holeCounts: Uint32Array;
+  /** `N + 1` offsets into {@link FlatProfiles.holeCounts}. */
+  holeCountStart: Uint32Array;
+
+  /** Flat `[x, y, x, y, …]` hole rings for every entry, back to back. */
+  holePoints: Float32Array;
+  /** `N + 1` **float**-index offsets into {@link FlatProfiles.holePoints}. */
+  holePointStart: Uint32Array;
+
+  /** Stride 16: the column-major 4×4 world transform, per entry. */
+  transform: Float32Array;
+  /** Stride 3: `[dx, dy, dz]` extrusion direction, per entry. */
+  extrusionDir: Float32Array;
+  /** Extrusion depth in metres, one per entry. */
+  extrusionDepth: Float32Array;
+}
+
+/** Floats per entry in {@link FlatProfiles.transform}. */
+export const TRANSFORM_STRIDE = 16;
+/** Floats per entry in {@link FlatProfiles.extrusionDir}. */
+export const EXTRUSION_DIR_STRIDE = 3;
+
+/** An empty flatten — the shape a skipped or failed parse produces. */
+export function createEmptyFlatProfiles(): FlatProfiles {
+  return {
+    typeNames: [],
+    typeIndex: new Uint16Array(0),
+    expressId: new Uint32Array(0),
+    outerPoints: new Float32Array(0),
+    outerStart: new Uint32Array(1),
+    holeCounts: new Uint32Array(0),
+    holeCountStart: new Uint32Array(1),
+    holePoints: new Float32Array(0),
+    holePointStart: new Uint32Array(1),
+    transform: new Float32Array(0),
+    extrusionDir: new Float32Array(0),
+    extrusionDepth: new Float32Array(0),
+  };
+}
+
+/** Intern an IFC type name into the shared table, returning its index. */
+function intern(names: string[], index: Map<string, number>, name: string): number {
+  const existing = index.get(name);
+  if (existing !== undefined) return existing;
+  const next = names.length;
+  names.push(name);
+  index.set(name, next);
+  return next;
+}
+
+/**
+ * Copy `count` floats out of a WASM-backed view, zero-filling any shortfall.
+ *
+ * The Rust getters return fixed-size arrays, so the shortfall branch is
+ * unreachable today; it exists so an older wasm bundle cannot make the stride
+ * arithmetic read into the NEXT entry's slot.
+ */
+function pushFixed(out: number[], values: Float32Array, count: number): void {
+  for (let i = 0; i < count; i++) out.push(i < values.length ? values[i] : 0);
+}
+
+/**
+ * Flatten a WASM profile collection into transferable arrays.
+ *
+ * Frees every per-entry handle (`collection.get(i)`) in `try/finally`, exactly
+ * as the main-thread walk did, so a mid-flatten throw cannot leak WASM memory
+ * into the FinalizationRegistry (AGENTS.md §Geometry & WASM). Ownership of
+ * `collection` itself stays with the caller.
+ */
+export function collectFlatProfiles(collection: ProfileCollection): FlatProfiles {
+  const typeNames: string[] = [];
+  const typeTable = new Map<string, number>();
+
+  const typeIndex: number[] = [];
+  const expressId: number[] = [];
+  const outerPoints: number[] = [];
+  const outerStart: number[] = [0];
+  const holeCounts: number[] = [];
+  const holeCountStart: number[] = [0];
+  const holePoints: number[] = [];
+  const holePointStart: number[] = [0];
+  const transform: number[] = [];
+  const extrusionDir: number[] = [];
+  const extrusionDepth: number[] = [];
+
+  const len = collection.length;
+  for (let i = 0; i < len; i++) {
+    const entry = collection.get(i);
+    if (!entry) continue;
+    try {
+      typeIndex.push(intern(typeNames, typeTable, entry.ifcType));
+      expressId.push(entry.expressId);
+
+      const outer = entry.outerPoints;
+      for (let j = 0; j < outer.length; j++) outerPoints.push(outer[j]);
+      outerStart.push(outerPoints.length);
+
+      const counts = entry.holeCounts;
+      for (let j = 0; j < counts.length; j++) holeCounts.push(counts[j]);
+      holeCountStart.push(holeCounts.length);
+
+      const holes = entry.holePoints;
+      for (let j = 0; j < holes.length; j++) holePoints.push(holes[j]);
+      holePointStart.push(holePoints.length);
+
+      pushFixed(transform, entry.transform, TRANSFORM_STRIDE);
+      pushFixed(extrusionDir, entry.extrusionDir, EXTRUSION_DIR_STRIDE);
+      extrusionDepth.push(entry.extrusionDepth);
+    } finally {
+      entry.free();
+    }
+  }
+
+  return {
+    typeNames,
+    typeIndex: Uint16Array.from(typeIndex),
+    expressId: Uint32Array.from(expressId),
+    outerPoints: Float32Array.from(outerPoints),
+    outerStart: Uint32Array.from(outerStart),
+    holeCounts: Uint32Array.from(holeCounts),
+    holeCountStart: Uint32Array.from(holeCountStart),
+    holePoints: Float32Array.from(holePoints),
+    holePointStart: Uint32Array.from(holePointStart),
+    transform: Float32Array.from(transform),
+    extrusionDir: Float32Array.from(extrusionDir),
+    extrusionDepth: Float32Array.from(extrusionDepth),
+  };
+}

--- a/apps/viewer/src/lib/overlay-parse/profiles-golden.test.ts
+++ b/apps/viewer/src/lib/overlay-parse/profiles-golden.test.ts
@@ -1,0 +1,171 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { GeometryProcessor } from '@ifc-lite/geometry';
+import type { ProfileEntry } from '@ifc-lite/drawing-2d';
+import { collectFlatProfiles } from './profiles-flat.js';
+import { buildProfileEntries } from './profile-entries.js';
+
+/**
+ * Byte-equivalence anchor for the construction-projection profile extraction
+ * (#2183), the sibling of `symbolic-golden.test.ts`.
+ *
+ * The extraction moved off the main thread into the overlay worker, which means
+ * its output now survives a structured-clone boundary and is reassembled from
+ * flat arrays. "Projection still looks right" is not a proof — the failure
+ * modes are a hole ring sliced at the wrong offset, an entry handed a
+ * neighbour's `ifcType` through a wrapped type index, a transform read off a
+ * mis-strided buffer, or the RTC subtraction applied twice or not at all.
+ *
+ * So: pin a canonical digest of the whole `ProfileEntry[]` against real
+ * fixtures. The digests below were captured from the PRE-MOVE code path (the
+ * inline `extractProfiles` walk in `useDrawingGeneration`, run verbatim over
+ * the same fixtures with the same `SHIFT`), so reproducing them is evidence the
+ * move changed nothing. If they drift, the move broke something — fix it,
+ * do not regenerate.
+ *
+ * Fixture choice differs from `symbolic-golden.test.ts` on purpose. Its two
+ * models (`01_BIMcollab_Example_ARC`, `ISSUE_102_M3D-CON-CD`) extract exactly
+ * ZERO profiles — neither authors `IfcExtrudedAreaSolid` bodies, which is all
+ * `extract_profiles` collects — so they would pin the digest of an empty array
+ * forever. These two do: 14 entries with holes and mapped items, and 365
+ * across ten IFC types.
+ *
+ * Regenerate with `IFC_GOLDEN_UPDATE=1` and commit the printed digests, but
+ * only when the output is *meant* to change — that is the whole point.
+ */
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', '..', '..');
+
+/**
+ * Fixture paths CI will actually fetch. Read from the COMMITTED manifest, so
+ * a fixture silently dropping out of it fails rather than turning these
+ * digests into a permanent skip.
+ */
+const manifestPaths = new Set<string>(
+  (JSON.parse(
+    readFileSync(join(REPO_ROOT, 'tests', 'models', 'manifest.json'), 'utf8'),
+  ) as { files: { path: string }[] }).files.map((f) => `tests/models/${f.path}`),
+);
+
+/**
+ * A deliberately non-zero, non-symmetric render-frame shift.
+ *
+ * The RTC correction is the one piece of arithmetic that stays main-side, so a
+ * zero shift would make the digests blind to it being dropped, doubled, or
+ * applied to the wrong three slots.
+ */
+const SHIFT = { x: 1.5, y: -2.25, z: 0.75 };
+
+interface GoldenFixture {
+  /** Repo-relative fixture path. */
+  path: string;
+  /** SHA-256 over {@link canonicalise}. */
+  digest: string;
+  /** Cheap sanity so a fixture that silently extracts nothing cannot pass. */
+  minEntries: number;
+}
+
+const FIXTURES: GoldenFixture[] = [
+  {
+    path: 'tests/models/ara3d/AC20-FZK-Haus.ifc',
+    digest: 'fdcc561d74f579dbd8ad59c30efd1005b1d8619113284c55785fa03f742a2011',
+    minEntries: 14,
+  },
+  {
+    path: 'tests/models/ara3d/duplex.ifc',
+    digest: '508e095171d22ba4152e8f4433dada9775ce26a3f4e421931e6b619d4000c786',
+    minEntries: 300,
+  },
+];
+
+/** Stable, lossless text form of the extracted profiles, in source order. */
+function canonicalise(profiles: ProfileEntry[]): string {
+  const num = (n: number): string =>
+    Number.isNaN(n) ? 'NaN' : Object.is(n, -0) ? '-0' : String(n);
+  return JSON.stringify(
+    profiles.map((p) => [
+      p.expressId,
+      p.ifcType,
+      Array.from(p.outerPoints).map(num),
+      Array.from(p.holeCounts),
+      Array.from(p.holePoints).map(num),
+      Array.from(p.transform).map(num),
+      Array.from(p.extrusionDir).map(num),
+      num(p.extrusionDepth),
+      p.modelIndex,
+    ]),
+  );
+}
+
+/**
+ * The shipping composition, on one thread: WASM walk → flatten → rebuild.
+ *
+ * `structuredClone` stands in for the `postMessage` hop. It is not decoration:
+ * it is what proves the flatten carries nothing that fails to clone and nothing
+ * that is a live view into WASM linear memory.
+ */
+async function extractProfileEntries(source: Uint8Array): Promise<ProfileEntry[]> {
+  const processor = new GeometryProcessor();
+  try {
+    await processor.init();
+    const collection = processor.extractProfiles(source, 0);
+    if (!collection) return [];
+    // `collectFlatProfiles` frees each per-entry handle; the collection itself
+    // is the caller's to free, deterministically (AGENTS.md §Geometry & WASM).
+    try {
+      return buildProfileEntries(structuredClone(collectFlatProfiles(collection)), SHIFT, 0);
+    } finally {
+      collection.free();
+    }
+  } finally {
+    processor.dispose();
+  }
+}
+
+describe('profile extraction golden digests (#2183)', () => {
+  for (const fixture of FIXTURES) {
+    it(`reproduces the pinned ProfileEntry[] for ${fixture.path}`, async () => {
+      // AGENTS.md requires fixture-backed tests to SKIP, not throw, when the
+      // fixture is absent — they are not committed, and CI fetches them via
+      // `pnpm fixtures` before running. But a plain skip would also stay
+      // silent if the fixture were dropped from the manifest, which WOULD
+      // make this permanently vacuous in CI. The manifest is committed, so
+      // assert membership there first: absence from the manifest fails,
+      // absence from disk skips.
+      assert.ok(
+        manifestPaths.has(fixture.path),
+        `${fixture.path} is not in tests/models/manifest.json, so CI will never fetch it `
+        + 'and this digest would silently stop running',
+      );
+      const abs = join(REPO_ROOT, fixture.path);
+      if (!existsSync(abs)) {
+        console.warn(`skip: ${fixture.path} absent — run \`pnpm fixtures\``);
+        return;
+      }
+
+      const profiles = await extractProfileEntries(new Uint8Array(readFileSync(abs)));
+
+      assert.ok(
+        profiles.length >= fixture.minEntries,
+        `only ${profiles.length} profiles; a fixture that extracts nothing would make the `
+        + 'digest vacuous',
+      );
+
+      const digest = createHash('sha256').update(canonicalise(profiles)).digest('hex');
+      if (process.env.IFC_GOLDEN_UPDATE === '1') {
+        console.log(`${fixture.path}\n  digest: ${digest}\n  entries: ${profiles.length}`);
+        return;
+      }
+      assert.equal(digest, fixture.digest, 'profile extraction output changed');
+    });
+  }
+});

--- a/apps/viewer/src/lib/overlay-parse/profiles-golden.test.ts
+++ b/apps/viewer/src/lib/overlay-parse/profiles-golden.test.ts
@@ -133,7 +133,7 @@ async function extractProfileEntries(source: Uint8Array): Promise<ProfileEntry[]
 
 describe('profile extraction golden digests (#2183)', () => {
   for (const fixture of FIXTURES) {
-    it(`reproduces the pinned ProfileEntry[] for ${fixture.path}`, async () => {
+    it(`reproduces the pinned ProfileEntry[] for ${fixture.path}`, async (t) => {
       // AGENTS.md requires fixture-backed tests to SKIP, not throw, when the
       // fixture is absent — they are not committed, and CI fetches them via
       // `pnpm fixtures` before running. But a plain skip would also stay
@@ -148,7 +148,10 @@ describe('profile extraction golden digests (#2183)', () => {
       );
       const abs = join(REPO_ROOT, fixture.path);
       if (!existsSync(abs)) {
-        console.warn(`skip: ${fixture.path} absent — run \`pnpm fixtures\``);
+        // t.skip() records a SKIP; a bare `return` records a PASS, which is
+        // how a fixture-less run silently looks green. It does not stop
+        // execution on its own, so the `return` stays.
+        t.skip(`${fixture.path} absent — run \`pnpm fixtures\``);
         return;
       }
 

--- a/apps/viewer/src/lib/overlay-parse/reply.test.ts
+++ b/apps/viewer/src/lib/overlay-parse/reply.test.ts
@@ -5,7 +5,8 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 
-import { buildParseReply } from './reply.js';
+import { buildParseReply, buildProfilesReply } from './reply.js';
+import { createEmptyFlatProfiles } from './profiles-flat.js';
 
 /** Narrow the widened response union to the line-parse arm. */
 function verts(reply: { ok: boolean } & Record<string, unknown>): Float32Array {
@@ -48,5 +49,46 @@ describe('buildParseReply', () => {
       verts(second.reply).buffer,
       'two empty replies from one worker must not share a buffer',
     );
+  });
+});
+
+describe('buildProfilesReply', () => {
+  it('transfers every non-empty buffer exactly once', () => {
+    const flat = createEmptyFlatProfiles();
+    flat.expressId = new Uint32Array([7, 8]);
+    flat.outerPoints = new Float32Array([0, 0, 1, 1]);
+    // Two views over ONE buffer: transferring it twice throws, so the reply
+    // builder must de-duplicate by buffer identity.
+    const shared = new Float32Array([1, 2, 3, 4, 5, 6]);
+    flat.transform = shared.subarray(0, 3);
+    flat.extrusionDir = shared.subarray(3, 6);
+
+    const { reply, transfer } = buildProfilesReply(3, flat);
+    assert.equal(reply.id, 3);
+    assert.equal(reply.ok, true);
+    assert.equal(new Set(transfer).size, transfer.length, 'no buffer may appear twice');
+    assert.ok(transfer.includes(flat.expressId.buffer as ArrayBuffer));
+    assert.ok(transfer.includes(shared.buffer as ArrayBuffer));
+    // expressId, outerPoints, the one shared transform/extrusionDir buffer, and
+    // the three `N + 1` offset arrays (each holds its leading zero, so each is
+    // non-empty). Everything else on an empty flatten is zero-length.
+    assert.equal(transfer.length, 6);
+  });
+
+  // A model with no openings genuinely produces empty hole arrays every time.
+  // Transferring one detaches it, and the next reply from the same worker
+  // throws DataCloneError, surfacing as a parse failure.
+  it('never transfers a zero-length buffer, and skips the string table', () => {
+    const flat = createEmptyFlatProfiles();
+    flat.typeNames = ['IfcWall'];
+    const { transfer } = buildProfilesReply(1, flat);
+    assert.deepEqual(
+      transfer.filter((b) => b.byteLength === 0),
+      [],
+      'nothing to move, and moving it invites detachment',
+    );
+    // `createEmptyFlatProfiles` is all-empty apart from the `N + 1` offset
+    // arrays, which each hold one leading zero.
+    assert.equal(transfer.length, 3, 'the three offset arrays, and nothing else');
   });
 });

--- a/apps/viewer/src/lib/overlay-parse/reply.ts
+++ b/apps/viewer/src/lib/overlay-parse/reply.ts
@@ -9,6 +9,7 @@
  */
 
 import type { OverlayParseResponse } from './overlay-parse.worker.js';
+import type { FlatProfiles } from './profiles-flat.js';
 import type { FlatSymbolic } from './symbolic-flat.js';
 
 export interface BuiltReply {
@@ -38,19 +39,20 @@ export function buildParseReply(id: number, verts: Float32Array | null | undefin
 }
 
 /**
- * Same two rules as {@link buildParseReply}, applied across the ~20 buffers a
- * `FlatSymbolic` carries.
+ * The transfer list for a struct-of-arrays payload: every non-empty typed-array
+ * buffer it holds, each listed once.
  *
  * The zero-length exclusion does real work here rather than being belt-and-
- * braces: a model with grids but no fills produces several genuinely empty
- * arrays every time, so without it the FIRST symbolic reply would detach them
- * and a second job in the same worker would throw `DataCloneError`.
+ * braces: a model with grids but no fills, or with profiles but no holes,
+ * produces several genuinely empty arrays every time, so without it the FIRST
+ * reply would detach them and a second job in the same worker would throw
+ * `DataCloneError`.
  *
  * Buffers are de-duplicated by identity because a correct flatten may share
  * one backing buffer between two views, and transferring the same
  * `ArrayBuffer` twice throws.
  */
-export function buildSymbolicReply(id: number, flat: FlatSymbolic): BuiltReply {
+function transferablesOf(flat: object): ArrayBuffer[] {
   const transfer: ArrayBuffer[] = [];
   const seen = new Set<ArrayBuffer>();
   for (const value of Object.values(flat)) {
@@ -61,5 +63,24 @@ export function buildSymbolicReply(id: number, flat: FlatSymbolic): BuiltReply {
     seen.add(buffer);
     transfer.push(buffer);
   }
-  return { reply: { id, ok: true, flat }, transfer };
+  return transfer;
+}
+
+/**
+ * Same two rules as {@link buildParseReply}, applied across the ~20 buffers a
+ * `FlatSymbolic` carries. See {@link transferablesOf}.
+ */
+export function buildSymbolicReply(id: number, flat: FlatSymbolic): BuiltReply {
+  return { reply: { id, ok: true, flat }, transfer: transferablesOf(flat) };
+}
+
+/**
+ * The profile arm of the same contract. See {@link transferablesOf}.
+ *
+ * A model whose extruded solids have no openings carries three empty arrays
+ * (`holeCounts`, `holePoints`, and — for a model with no profiles at all —
+ * every buffer), which is exactly the case the zero-length rule protects.
+ */
+export function buildProfilesReply(id: number, profiles: FlatProfiles): BuiltReply {
+  return { reply: { id, ok: true, profiles }, transfer: transferablesOf(profiles) };
 }

--- a/apps/viewer/src/lib/overlay-parse/symbolic-golden.test.ts
+++ b/apps/viewer/src/lib/overlay-parse/symbolic-golden.test.ts
@@ -128,7 +128,7 @@ function countPrimitives(result: ParseResult): number {
 
 describe('symbolic parse golden digests (#2183)', () => {
   for (const fixture of FIXTURES) {
-    it(`reproduces the pinned ParseResult for ${fixture.path}`, async () => {
+    it(`reproduces the pinned ParseResult for ${fixture.path}`, async (t) => {
       // AGENTS.md requires fixture-backed tests to SKIP, not throw, when the
       // fixture is absent — they are not committed, and CI fetches them via
       // `pnpm fixtures` before running. But a plain skip would also stay
@@ -143,7 +143,10 @@ describe('symbolic parse golden digests (#2183)', () => {
       );
       const abs = join(REPO_ROOT, fixture.path);
       if (!existsSync(abs)) {
-        console.warn(`skip: ${fixture.path} absent — run \`pnpm fixtures\``);
+        // t.skip() records a SKIP; a bare `return` records a PASS, which is
+        // how a fixture-less run silently looks green. It does not stop
+        // execution on its own, so the `return` stays.
+        t.skip(`${fixture.path} absent — run \`pnpm fixtures\``);
         return;
       }
       const result = await parseSymbolicAnnotations({ source: new Uint8Array(readFileSync(abs)) });

--- a/apps/viewer/src/test/overlay-worker-shim.test.ts
+++ b/apps/viewer/src/test/overlay-worker-shim.test.ts
@@ -61,17 +61,22 @@ describe('in-process overlay worker shim', () => {
   // nested install silently disabled the outer shim on teardown.
   it('restores the OUTER shim, not the default, when nested', async () => {
     const outer = installInProcessOverlayWorker();
-    const inner = installInProcessOverlayWorker();
-    inner.restore();
+    try {
+      const inner = installInProcessOverlayWorker();
+      inner.restore();
     // The outer shim must still be serving: with it disabled, Node has no
     // Worker and this would resolve empty without the worker ever replying.
-    const before = outer.repliedIds().length;
-    await parseOverlayLines('grid-lines', new Uint8Array([1]));
-    assert.ok(
-      outer.repliedIds().length > before,
-      'the outer shim stopped serving, so restore() reset to the default',
-    );
-    outer.restore();
+      const before = outer.repliedIds().length;
+      await parseOverlayLines('grid-lines', new Uint8Array([1]));
+      assert.ok(
+        outer.repliedIds().length > before,
+        'the outer shim stopped serving, so restore() reset to the default',
+      );
+    } finally {
+      // A failed assertion above must not leave the outer shim installed for
+      // every later test in this file.
+      outer.restore();
+    }
   });
 
   it('restores the previous Worker wiring on teardown', async () => {

--- a/apps/viewer/src/test/overlay-worker-shim.test.ts
+++ b/apps/viewer/src/test/overlay-worker-shim.test.ts
@@ -6,7 +6,11 @@ import { describe, it, afterEach } from 'node:test';
 import assert from 'node:assert';
 
 import { installInProcessOverlayWorker } from './overlay-worker-shim.js';
-import { parseOverlayLines, parseSymbolicFlat } from '@/lib/overlay-parse/index.js';
+import {
+  parseOverlayLines,
+  parseProfilesFlat,
+  parseSymbolicFlat,
+} from '@/lib/overlay-parse/index.js';
 
 /**
  * The shim exists so end-to-end hook tests are not silently vacuous. If it
@@ -30,25 +34,44 @@ afterEach(() => {
 describe('in-process overlay worker shim', () => {
   it('routes replies correctly when jobs overlap', async () => {
     shim = installInProcessOverlayWorker();
-    // Dispatched in the same tick: all three are in flight before any settles.
-    const [grid, alignment, symbolic] = await Promise.all([
+    // Dispatched in the same tick: all four are in flight before any settles.
+    const [grid, alignment, symbolic, profiles] = await Promise.all([
       parseOverlayLines('grid-lines', new Uint8Array([1])),
       parseOverlayLines('alignment-lines', new Uint8Array([1])),
       parseSymbolicFlat(new Uint8Array([1])),
+      parseProfilesFlat(new Uint8Array([1])),
     ]);
     assert.ok(grid instanceof Float32Array);
     assert.ok(alignment instanceof Float32Array);
     assert.ok(symbolic && Array.isArray(symbolic.typeNames));
+    assert.ok(profiles && profiles.expressId instanceof Uint32Array);
 
     // The load-bearing assertion. The input is garbage, so every result is
     // empty either way — and the client ALSO resolves empty when a reply is
-    // lost. Only the worker's own reply log distinguishes "three jobs
-    // answered" from "three jobs silently fell back".
+    // lost. Only the worker's own reply log distinguishes "four jobs
+    // answered" from "four jobs silently fell back".
     assert.equal(
-      shim.repliedIds().length, 3,
-      `worker replied for ${shim.repliedIds().length} of 3 jobs; the rest hit the client fallback`,
+      shim.repliedIds().length, 4,
+      `worker replied for ${shim.repliedIds().length} of 4 jobs; the rest hit the client fallback`,
     );
-    assert.equal(new Set(shim.repliedIds()).size, 3, 'each job needs its own id');
+    assert.equal(new Set(shim.repliedIds()).size, 4, 'each job needs its own id');
+  });
+
+  // Reported in review: restore() used to reset to the default factory, so a
+  // nested install silently disabled the outer shim on teardown.
+  it('restores the OUTER shim, not the default, when nested', async () => {
+    const outer = installInProcessOverlayWorker();
+    const inner = installInProcessOverlayWorker();
+    inner.restore();
+    // The outer shim must still be serving: with it disabled, Node has no
+    // Worker and this would resolve empty without the worker ever replying.
+    const before = outer.repliedIds().length;
+    await parseOverlayLines('grid-lines', new Uint8Array([1]));
+    assert.ok(
+      outer.repliedIds().length > before,
+      'the outer shim stopped serving, so restore() reset to the default',
+    );
+    outer.restore();
   });
 
   it('restores the previous Worker wiring on teardown', async () => {

--- a/apps/viewer/src/test/overlay-worker-shim.ts
+++ b/apps/viewer/src/test/overlay-worker-shim.ts
@@ -6,8 +6,9 @@
  * Test-only `Worker` stand-in that runs the real overlay-parse handler
  * in-process (#2183).
  *
- * Node has no `Worker`, so `parseOverlayLines` / `parseSymbolicFlat` resolve
- * empty there by design — a model must still load when the worker cannot
+ * Node has no `Worker`, so `parseOverlayLines` / `parseSymbolicFlat` /
+ * `parseProfilesFlat` resolve empty there by design — a model must still load
+ * (and still draw, without projection) when the worker cannot
  * start. That is right for production but it silently guts any test that
  * drives a hook end-to-end and expects real parsed content.
  *
@@ -97,10 +98,14 @@ export function installInProcessOverlayWorker(): OverlayShimHandle {
 
   // Scoped to the overlay client. Setting a global `Worker` would also
   // convince the PARSER that workers are available.
-  __setOverlayWorkerFactoryForTest(() => new InProcessOverlayWorker() as unknown as Worker);
+  const previousFactory = __setOverlayWorkerFactoryForTest(
+    () => new InProcessOverlayWorker() as unknown as Worker,
+  );
   return {
     restore: () => {
-      __setOverlayWorkerFactoryForTest(null);
+      // Restore what was installed BEFORE this shim, not the default: nested
+      // installs would otherwise disable the outer one.
+      __setOverlayWorkerFactoryForTest(previousFactory);
       g.self = previousSelf;
     },
     repliedIds: () => [...replied],


### PR DESCRIPTION
Follows #2274 (merged). This is the **last whole-source parse still running on the main thread**, and it is a prerequisite for the compressed-source work.

## Why

`useDrawingGeneration` called `extractProfiles(store.source, 0)` directly, so the first time a user enables construction projection it regrew a main-thread `WebAssembly.Memory` by ~470 MB — memory that never shrinks.

It also **blocked** the planned compressed source: under that scheme this call becomes a full 342 MB main-thread `materialize()` the moment projection is switched on, i.e. a regression introduced by the change meant to save memory.

## What

Same shape as the symbolic move in #2274. The worker flattens `ProfileCollection` into transferable struct-of-arrays (`profiles-flat.ts`); the main thread rebuilds entries with `buildProfileEntries`.

The RTC / `originShift` correction **stays main-side** — it reads `geometryResult.coordinateInfo`, which is main-thread state — and it was moved, not rewritten.

`typeIndex` is `Uint16Array`, not `Uint8Array`: the profile type table is unbounded, and an 8-bit index would wrap past 256 types and hand an entry somebody else's `ifcType`. Same trap that was caught in the symbolic flatten.

## Equivalence

Digests captured from the **pre-move** path and reproduced unchanged after it. Control-verified: perturbing `extrusionDepth` by `0.001` in the flatten turns both fixtures red.

**The fixtures deliberately differ from `symbolic-golden.test.ts`.** Neither `01_BIMcollab_Example_ARC` nor `ISSUE_102_M3D-CON-CD` authors `IfcExtrudedAreaSolid` bodies, so both extract **zero** profiles — pinning them would have pinned the digest of an empty array forever, which is precisely the vacuity the `minEntries` guard exists to prevent. `AC20-FZK-Haus` (14 entries) and `duplex` (365) are used instead, both in the committed manifest so CI fetches them. The golden fixture shift is non-zero and non-symmetric, so a dropped or doubled RTC correction shows up in the digest.

`buildProfileEntries` is additionally pinned against a verbatim copy of the deleted walk over the same fake collection.

## Review finding fixed here

From the CLI review of #2274: the test shim's `restore()` reset the worker factory to the **default** rather than to whatever was installed before it, so a nested install silently disabled the outer shim on teardown. It now returns and restores the previous factory, with a nested-install test. Mutation-checked — reverting to `null` fails it.

## Not fixed here (pre-existing on main)

`symbolic-parse.ts` sets `lineYOffset: -li * lineSpacing`, which is `-0` for single-line literals where the interface documents `undefined`. It is **byte-identical to main** and behaviourally inert (adding `-0` to Y is a no-op), so correcting the doc/code mismatch belongs in its own PR with a multi-line fixture rather than inside a move.

## Verification

`pnpm typecheck` 36/36 · overlay-parse suite **49 pass / 0 fail** · viewer **3112 pass / 0 fail** · `check-wasm-disposal` ✅ (27 sites) · `check-test-wiring` ✅ · both golden digest sets unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added worker-based profile extraction for improved viewer processing.
  * Preserved profile geometry, transforms, model indices, and coordinate shifts during reconstruction.
  * Added support for concurrent profile parsing and reliable data transfer.

* **Bug Fixes**
  * Improved cleanup and handling of parsing failures, worker timeouts, empty results, and unavailable workers.

* **Tests**
  * Expanded coverage for profile extraction, reconstruction, concurrency, cleanup, and rendering accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->