### PR TITLE
fix(mcp): reject a non-numeric query limit/offset instead of ignoring it

### DIFF
--- a/.changeset/mcp-backend-query-limit-offset-guard.md
+++ b/.changeset/mcp-backend-query-limit-offset-guard.md
@@ -1,0 +1,11 @@
+---
+"@ifc-lite/mcp": patch
+---
+
+Fix `descriptor.limit` / `descriptor.offset` in the read backend (`backend-query.ts`) silently ignoring a non-numeric, negative, or `Infinity` value instead of rejecting it. `descriptor.offset && descriptor.offset > 0` (and the equivalent for `limit`) is falsy for `NaN` — every comparison with `NaN` is false — so a caller that computed a bad value from e.g. `Number(userInput)` got back every matching row instead of an error, silently returning more than it asked for. The same falsy-zero shape made `limit: 0` ("no rows") a no-op instead, silently returning every row.
+
+No built-in MCP tool reaches this today: `query_entities` validates `limit`/`offset` as JSON-Schema integers before its handler runs and paginates separately via its own `paginate()` helper rather than the query builder's `.limit()/.offset()`. The live path is the public SDK surface — `HeadlessLikeBackend` is exported from both `./index.js` and `./browser.js` for embedders, and driving it through `@ifc-lite/sdk`'s fluent `QueryBuilder` (`bim.query().limit(n).offset(m).toArray()`) reaches `descriptor.limit`/`descriptor.offset` directly, unguarded by any tool schema.
+
+`entities()` now throws on a non-finite or negative `limit`/`offset` instead of quietly serving the wrong slice. `limit: 0` is now a deliberate empty result rather than being silently ignored — a behaviour change, not just a bugfix, and nothing in this package uses `0` as an "unlimited" sentinel.
+
+Same defect shape as the CLI's `headless-backend.ts` fix (#2298); `packages/mcp` has its own parallel implementation of this adapter (not a shared import), with its own tests and release cadence, so it needed its own fix.

--- a/packages/mcp/src/backend-query-limit-offset.test.ts
+++ b/packages/mcp/src/backend-query-limit-offset.test.ts
@@ -1,0 +1,124 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `descriptor.limit` / `descriptor.offset` guards in `entities()`
+ * (backend-query.ts), exercised through the public SDK path
+ * `bim.query().limit(n).offset(n).toArray()`.
+ *
+ * No built-in MCP tool reaches this: `query_entities` (tools/query.ts)
+ * schema-validates `limit`/`offset` as JSON-Schema integers before its
+ * handler runs, and does its own pagination via `paginate()` in
+ * tools/util.ts rather than chaining `.limit()/.offset()` on the query
+ * builder. But `HeadlessLikeBackend` is exported from both `./index.js`
+ * and `./browser.js` for programmatic/embedder use, and an embedder
+ * driving it through `@ifc-lite/sdk`'s fluent `QueryBuilder` (exactly
+ * the shape `namespaces.test.ts` in packages/sdk exercises) reaches
+ * `descriptor.limit`/`descriptor.offset` directly with whatever value
+ * it computed -- unguarded by any tool-schema layer. This mirrors the
+ * CLI's `headless-backend.ts`, fixed for the same shape in #2298; mcp
+ * has its own parallel implementation with its own tests.
+ */
+
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { loadIfcModel } from './loader.js';
+import type { LoadedModel } from './context.js';
+
+/** A 22-character IFC GlobalId from a short mnemonic. */
+function guid(mnemonic: string): string {
+  return (mnemonic + '0'.repeat(22)).slice(0, 22);
+}
+
+const MODEL = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('m','2026',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1= IFCPROJECT('${guid('PROJ')}',$,'Proj',$,$,$,$,(#20),#30);
+#20= IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#21,$);
+#21= IFCAXIS2PLACEMENT3D(#22,$,$);
+#22= IFCCARTESIANPOINT((0.,0.,0.));
+#30= IFCUNITASSIGNMENT((#31));
+#31= IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#40= IFCLOCALPLACEMENT($,#21);
+#41= IFCBUILDINGSTOREY('${guid('STOR')}',$,'L01',$,$,#40,$,$,.ELEMENT.,0.);
+#42= IFCBUILDING('${guid('BLDG')}',$,'B',$,$,#40,$,$,.ELEMENT.,$,$,$);
+#43= IFCRELAGGREGATES('${guid('AGG1')}',$,$,$,#1,(#42));
+#44= IFCRELAGGREGATES('${guid('AGG2')}',$,$,$,#42,(#41));
+#45= IFCRELCONTAINEDINSPATIALSTRUCTURE('${guid('RELC')}',$,$,$,(#72,#73,#74),#41);
+#72= IFCWALL('${guid('WALA')}',$,'Wall A',$,$,#40,$,'tagA',$);
+#73= IFCWALL('${guid('WALB')}',$,'Wall B',$,$,#40,$,'tagB',$);
+#74= IFCWALL('${guid('WALC')}',$,'Wall C',$,$,#40,$,'tagC',$);
+ENDSEC;
+END-ISO-10303-21;
+`;
+
+let tmp: string;
+let model: LoadedModel;
+
+beforeAll(async () => {
+  tmp = await mkdtemp(join(tmpdir(), 'ifc-lite-mcp-limit-offset-'));
+  await writeFile(join(tmp, 'm.ifc'), MODEL, 'utf-8');
+  model = await loadIfcModel(join(tmp, 'm.ifc'), { modelId: 'm' });
+});
+
+afterAll(async () => {
+  await rm(tmp, { recursive: true, force: true });
+});
+
+function wallNames(): string[] {
+  return model.bim.query().byType('IfcWall').toArray().map((e) => e.name ?? '');
+}
+
+describe('descriptor.limit / descriptor.offset — bounding controls (must pass before and after the fix)', () => {
+  it('an absent limit/offset returns everything', () => {
+    expect(model.bim.query().byType('IfcWall').toArray()).toHaveLength(3);
+  });
+
+  it('a valid limit still limits', () => {
+    expect(model.bim.query().byType('IfcWall').limit(1).toArray()).toHaveLength(1);
+  });
+
+  it('a valid offset still skips', () => {
+    const all = wallNames();
+    const skipped = model.bim.query().byType('IfcWall').offset(1).toArray().map((e) => e.name);
+    expect(skipped).toEqual(all.slice(1));
+  });
+});
+
+describe('descriptor.limit / descriptor.offset — the defect (RED against unfixed code)', () => {
+  it('NaN limit does not silently return every row', () => {
+    // A caller that computed limit via e.g. `Number(userInput)` on a
+    // non-numeric string gets NaN. Every comparison with NaN is false, so
+    // the unfixed `descriptor.limit && descriptor.limit > 0` guard is
+    // falsy and the limit is silently dropped -- the query returns all 3
+    // rows instead of failing loudly. This must throw, not return 3.
+    expect(() => model.bim.query().byType('IfcWall').limit(Number.NaN).toArray()).toThrow();
+  });
+
+  it('NaN offset does not silently return every row', () => {
+    expect(() => model.bim.query().byType('IfcWall').offset(Number.NaN).toArray()).toThrow();
+  });
+
+  it('a negative limit does not silently return every row', () => {
+    expect(() => model.bim.query().byType('IfcWall').limit(-1).toArray()).toThrow();
+  });
+
+  it('a negative offset does not silently return every row', () => {
+    expect(() => model.bim.query().byType('IfcWall').offset(-1).toArray()).toThrow();
+  });
+
+  it('Infinity limit does not silently return every row', () => {
+    expect(() => model.bim.query().byType('IfcWall').limit(Number.POSITIVE_INFINITY).toArray()).toThrow();
+  });
+
+  it('limit: 0 is a deliberate empty result, not "unlimited" (behaviour change, called out here and in the changeset)', () => {
+    expect(model.bim.query().byType('IfcWall').limit(0).toArray()).toHaveLength(0);
+  });
+});

--- a/packages/mcp/src/backend-query.ts
+++ b/packages/mcp/src/backend-query.ts
@@ -383,8 +383,41 @@ export function createQueryAdapter(
           });
         }
       }
-      if (descriptor.offset && descriptor.offset > 0) filtered = filtered.slice(descriptor.offset);
-      if (descriptor.limit && descriptor.limit > 0) filtered = filtered.slice(0, descriptor.limit);
+      // `&&` alone lets a NaN offset/limit through silently: every NaN
+      // comparison is false, so `descriptor.offset > 0` was falsy and the
+      // guard did nothing -- a caller that computed a bad value (e.g.
+      // `Number(userInput)` on a non-numeric string) got back MORE rows
+      // than asked for, with no error. The same falsy-zero shape made
+      // `limit: 0` ("no rows") silently mean "every row" instead. Fail
+      // loudly on a non-finite or negative value instead of quietly
+      // serving the wrong slice, matching the misconfigured-caller
+      // convention this adapter already uses elsewhere (see the `add*`
+      // stubs in headless-backend.ts). `limit: 0` is now a deliberate
+      // empty result.
+      //
+      // No built-in MCP tool reaches this today: `query_entities`
+      // (tools/query.ts) validates `limit`/`offset` as JSON-Schema
+      // integers before its handler runs and does its own pagination via
+      // `paginate()` rather than chaining `.limit()/.offset()` on the
+      // query builder. This guards the public SDK path instead --
+      // `HeadlessLikeBackend` is exported from `./index.js` and
+      // `./browser.js` for programmatic use, and an embedder driving it
+      // through `@ifc-lite/sdk`'s fluent `QueryBuilder` reaches
+      // `descriptor.limit`/`descriptor.offset` directly. Same shape as
+      // the CLI's `headless-backend.ts` (#2298) -- a parallel
+      // implementation, not a shared import, so it needed its own fix.
+      if (descriptor.offset != null) {
+        if (!Number.isFinite(descriptor.offset) || descriptor.offset < 0) {
+          throw new Error(`Invalid offset: ${descriptor.offset} (must be a non-negative finite number)`);
+        }
+        if (descriptor.offset > 0) filtered = filtered.slice(descriptor.offset);
+      }
+      if (descriptor.limit != null) {
+        if (!Number.isFinite(descriptor.limit) || descriptor.limit < 0) {
+          throw new Error(`Invalid limit: ${descriptor.limit} (must be a non-negative finite number)`);
+        }
+        filtered = filtered.slice(0, descriptor.limit);
+      }
       return filtered;
     },
     // Headless contexts have no interactive viewer filter, so there is never an


### PR DESCRIPTION
`descriptor.offset && descriptor.offset > 0` and the matching `limit` line let a `NaN` through silently: **every comparison with NaN is false**, so the guard did nothing and the caller got back *more* rows than asked for, with no error. The same falsy-zero shape made `limit: 0` ("no rows") mean "every row".

This is the parallel copy of what **#2298** fixes on the CLI side. That PR deliberately left this one alone — different package, own tests and release cadence — and its comment now names this file as still unfixed rather than implying MCP was covered.

## Severity, stated at what was measured

**No built-in MCP tool reaches this path.** `query_entities` declares `limit`/`offset` as JSON-Schema integers with bounds, `server.ts` runs `validateInput()` before the handler, and the handler paginates itself via `paginate()` rather than chaining `.limit()`. Verified by grep: there is no `.limit(` or `.offset(` call in any `tools/*.ts`.

The live surface is the **exported** one. `HeadlessLikeBackend` is exported from both `index.ts` and `browser.ts` for embedders, and an embedder driving it through the SDK's fluent `bim.query().limit(n).offset(m).toArray()` reaches this descriptor unguarded — the same shape `packages/sdk`'s own contract test exercises. That's the "external usage IS the contract" standard from the #2111 review.

So: real, but reachable through the published surface rather than through a tool call today. I'd rather say that plainly than let the diff imply a live tool bug.

## Deliberately different from the CLI fix

The CLI's version throws `TypeError`. This one throws a plain `Error`, because that is **this adapter's own convention** for a misconfigured caller (see the `add*` stubs, commented "Stubs throw so a misconfigured caller fails loudly"), and a plain `Error` is what `server.ts`'s handler catch turns into `INTERNAL_ERROR` if it ever did surface through a tool call.

Matching a sibling is a good default, not an obligation — copying `TypeError` here would have imported the CLI's convention into a package that doesn't use it.

## One deliberate behaviour change

`limit: 0` now returns **no rows** instead of every row. It has its own test and is called out in the changeset.

I checked this before making it: nothing in `sdk`, `mcp` or `cli` treats `0` as an "unlimited" sentinel, and `query_entities`'s schema sets `minimum: 1`, so `0` was never a valid tool input in the first place.

## Verification

RED against unfixed production: **6 of 9 new tests fail** — NaN, negative and Infinity for both `limit` and `offset`, plus `limit: 0` — while the other **3 pass as bounding controls**: a valid `limit` still limits, a valid `offset` still skips, and an absent one still returns everything. So the guard cannot pass by rejecting everything.

**236 → 245 passing across 24 files.** `tsc --noEmit` exit 0.

## Provenance

Found by a repo-wide sweep for one shape — a validation guard written as a bare comparison, which `NaN` silently bypasses. The same sweep produced the CLI half of #2298.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved entity query pagination validation.
  * Invalid, negative, or non-finite `limit` and `offset` values now return clear errors.
  * `limit: 0` now correctly returns an empty result.
  * `offset: 0` is handled consistently without altering results.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->