### PR TITLE
fix(cache,export): reject a non-numeric glTF accessor count in both readers

### DIFF
--- a/.changeset/cache-glb-accessor-count-nan-guard.md
+++ b/.changeset/cache-glb-accessor-count-nan-guard.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/cache": patch
+---
+
+Fix `parseGLBToMeshData`'s existing accessor bounds guard being silently bypassed by a missing/non-numeric `accessor.count` in a GLB's JSON chunk.
+
+The guard (`bufferOffset + neededBytes > bin.byteLength`) is a bare comparison, and `accessor.count` — REQUIRED by the glTF spec but never runtime-checked — flows unvalidated from `JSON.parse` into it. A missing `count` makes it `undefined`, and `undefined * elementSize` is `NaN`; every arithmetic comparison against `NaN` (`< 0`, `> bin.byteLength`) evaluates `false`, so the guard added for the accessor-overrun case (see the "malformed accessor bounds" tests) did not catch this. Control fell through to a typed-array constructor built from the same `NaN`, which coerces to an element count of 0 — producing a mesh with an empty `positions` array, reported as a successfully imported model, instead of throwing. `readAccessorData` now validates `accessor.count` is a non-negative integer before doing any arithmetic on it; a valid `count`, including the boundary value `0`, is unaffected.

--- a/.changeset/export-glb-accessor-count-nan-guard.md
+++ b/.changeset/export-glb-accessor-count-nan-guard.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/export": patch
+---
+
+Fix the export package's own (parallel, `@ifc-lite/cache`-independent) GLB reader silently decoding an empty mesh instead of erroring when an accessor's `count` is present but non-numeric.
+
+`readAccessor` computed `count` as `Number(acc.count || 0)`: the `|| 0` only substitutes a default for a *missing* count — a present-but-bogus value (a corrupted JSON chunk with `"count":"abc"`) survives it and becomes `NaN`. The bounds check right below it (`byteOffset + byteLen > bin.byteLength`) is a bare comparison, so `NaN > bin.byteLength` evaluated `false` and the guard was bypassed; `bin.subarray(offset, NaN)` then silently returned an empty view, and the accessor decoded as a mesh with zero vertices/indices rather than a diagnosable error. `count` is now validated as a non-negative integer before use; a valid `count` (including `0`) is unaffected.

--- a/packages/cache/src/glb.test.ts
+++ b/packages/cache/src/glb.test.ts
@@ -276,6 +276,68 @@ describe('parseGLBToMeshData — malformed accessor bounds (issue #2230 hunt)', 
 
     expect(() => parseGLBToMeshData(doc, bin)).toThrow(/accessor 0 reads bytes/);
   });
+
+  /**
+   * The bounds guard above is a bare arithmetic comparison (`< 0`, `>
+   * bin.byteLength`), which is provably false whenever any operand is NaN.
+   * `accessor.count` is REQUIRED by the glTF spec but nothing enforced that
+   * at runtime: a missing/non-numeric `count` in the untrusted JSON chunk
+   * makes `accessor.count * elementSize` NaN, and `NaN > bin.byteLength` is
+   * `false` — the guard added for the overrun case above does not catch
+   * this. Before the `Number.isInteger` check, this silently produced an
+   * EMPTY positions array (typed-array length ToIndex(NaN) === 0) reported
+   * as a successfully imported mesh, instead of throwing.
+   */
+  it('throws instead of silently returning an empty mesh when accessor.count is missing/non-numeric', () => {
+    const doc = {
+      asset: { version: '2.0' },
+      scenes: [{ nodes: [0] }],
+      nodes: [{ mesh: 0 }],
+      meshes: [
+        {
+          primitives: [
+            { attributes: { POSITION: 0 } },
+          ],
+        },
+      ],
+      accessors: [
+        // `count` omitted entirely -- required by the glTF spec, not runtime-checked.
+        { bufferView: 0, byteOffset: 0, componentType: 5126, type: 'VEC3' },
+      ],
+      bufferViews: [
+        { buffer: 0, byteOffset: 0, byteLength: 36, byteStride: 12, target: 34962 },
+      ],
+      buffers: [{ byteLength: 36 }],
+    };
+    const bin = new Uint8Array(36).fill(1);
+
+    expect(() => parseGLBToMeshData(doc as any, bin)).toThrow(/invalid count/);
+  });
+
+  it('still decodes a valid accessor.count = 0 (bounding control: an empty-but-declared accessor is not an error)', () => {
+    const doc = {
+      asset: { version: '2.0' },
+      scenes: [{ nodes: [0] }],
+      nodes: [{ mesh: 0 }],
+      meshes: [
+        {
+          primitives: [
+            { attributes: { POSITION: 0 } },
+          ],
+        },
+      ],
+      accessors: [
+        { bufferView: 0, byteOffset: 0, componentType: 5126, count: 0, type: 'VEC3' },
+      ],
+      bufferViews: [
+        { buffer: 0, byteOffset: 0, byteLength: 0, byteStride: 12, target: 34962 },
+      ],
+      buffers: [{ byteLength: 0 }],
+    };
+    const bin = new Uint8Array(0);
+
+    expect(() => parseGLBToMeshData(doc, bin)).not.toThrow();
+  });
 });
 
 describe('parseGLB — SharedArrayBuffer-backed input', () => {

--- a/packages/cache/src/glb.ts
+++ b/packages/cache/src/glb.ts
@@ -284,6 +284,19 @@ function readAccessorData(
 
   const bufferOffset = (bufferView.byteOffset ?? 0) + (accessor.byteOffset ?? 0);
 
+  // `accessor.count` comes straight from the (untrusted) GLB JSON chunk and
+  // is REQUIRED by the glTF spec, but nothing here enforced that at runtime:
+  // a missing/non-numeric `count` makes it `undefined`/NaN, and `NaN * x` is
+  // NaN. Every arithmetic bounds comparison below (`< 0`, `> bin.byteLength`)
+  // is false against NaN, so the bounds check was silently bypassed rather
+  // than rejecting the malformed accessor. Control then fell through to a
+  // typed-array constructor built from that same NaN count, which coerces to
+  // an element count of 0 (ToIndex(NaN) === 0) — producing a silently EMPTY
+  // mesh reported as a successful import instead of throwing.
+  if (!Number.isInteger(accessor.count) || accessor.count < 0) {
+    throw new Error(`GLB: accessor ${accessorIdx} has an invalid count: ${accessor.count}`);
+  }
+
   // Bounds-check the full byte range this accessor claims against the actual
   // BIN chunk BEFORE slicing/constructing anything. `accessor.count` /
   // `byteOffset` come straight from the (untrusted) GLB JSON chunk; without

--- a/packages/export/src/glb-mesh.test.ts
+++ b/packages/export/src/glb-mesh.test.ts
@@ -173,6 +173,73 @@ describe('parseGLBToMeshData', () => {
     const glb = buildGlb({ asset: { version: '2.0' }, meshes: [] }, new Uint8Array(4));
     expect(parseGLBToMeshData(glb)).toEqual([]);
   });
+
+  /**
+   * `readAccessor`'s bounds check (`byteOffset + byteLen > bin.byteLength`)
+   * is a bare comparison. `count` used to be computed as
+   * `Number(acc.count || 0)`, which only substitutes 0 for a MISSING count —
+   * a present-but-non-numeric count (a corrupted JSON chunk with
+   * `"count":"abc"`) survives `|| 0` and becomes NaN. `NaN > bin.byteLength`
+   * is `false`, so the guard was silently bypassed and `bin.subarray(offset,
+   * NaN)` returned an EMPTY view: the mesh decoded with zero
+   * vertices/indices instead of the read failing loudly.
+   */
+  it('rejects a non-numeric accessor.count instead of silently decoding an empty mesh', () => {
+    // Same shape as buildMeshGlb, but the POSITION accessor's `count` is a
+    // non-empty, non-numeric string. `Number(acc.count || 0)` only
+    // substitutes a default for a MISSING count -- a present-but-bogus
+    // count like this survives `|| 0` and becomes NaN.
+    const { bin, bvOffset, accOffsets } = buildBin();
+    const json = {
+      asset: { version: '2.0' },
+      nodes: [{ mesh: 0, extras: { expressId: 42 } }],
+      meshes: [{ primitives: [{ attributes: { POSITION: 0, NORMAL: 1 }, indices: 2 }] }],
+      accessors: [
+        { bufferView: 0, byteOffset: accOffsets[0], componentType: FLOAT, count: 'abc', type: 'VEC3' },
+        { bufferView: 0, byteOffset: accOffsets[1], componentType: FLOAT, count: 3, type: 'VEC3' },
+        { bufferView: 0, byteOffset: accOffsets[2], componentType: UNSIGNED_INT, count: 3, type: 'SCALAR' },
+      ],
+      bufferViews: [{ buffer: 0, byteOffset: bvOffset, byteLength: bin.length - bvOffset }],
+      buffers: [{ byteLength: bin.length }],
+    };
+    const glb = buildGlb(json, bin);
+    expect(() => parseGLBToMeshData(glb)).toThrow(/invalid count/);
+  });
+
+  it('still decodes a valid accessor.count (bounding control: the untampered GLB still works)', () => {
+    const meshes = parseGLBToMeshData(buildMeshGlb({ expressId: 42 }));
+    expect(meshes).toHaveLength(1);
+    expect(Array.from(meshes[0].positions)).toEqual(POSITIONS);
+  });
+
+  /**
+   * `Number.isInteger(count) && count >= 0` must accept the boundary value
+   * `0`, not just positive counts -- a legitimately empty accessor (all
+   * three of POSITION/NORMAL/indices declaring zero elements) is not a
+   * malformed GLB and must decode to a mesh with empty typed arrays rather
+   * than being rejected by the new guard.
+   */
+  it('still decodes a valid accessor.count = 0 (bounding control: an empty-but-declared accessor is not an error)', () => {
+    const bin = new Uint8Array(0);
+    const json = {
+      asset: { version: '2.0' },
+      nodes: [{ mesh: 0, extras: { expressId: 42 } }],
+      meshes: [{ primitives: [{ attributes: { POSITION: 0, NORMAL: 1 }, indices: 2 }] }],
+      accessors: [
+        { bufferView: 0, byteOffset: 0, componentType: FLOAT, count: 0, type: 'VEC3' },
+        { bufferView: 0, byteOffset: 0, componentType: FLOAT, count: 0, type: 'VEC3' },
+        { bufferView: 0, byteOffset: 0, componentType: UNSIGNED_INT, count: 0, type: 'SCALAR' },
+      ],
+      bufferViews: [{ buffer: 0, byteOffset: 0, byteLength: 0 }],
+      buffers: [{ byteLength: 0 }],
+    };
+    const glb = buildGlb(json, bin);
+    const meshes = parseGLBToMeshData(glb);
+    expect(meshes).toHaveLength(1);
+    expect(meshes[0].positions).toHaveLength(0);
+    expect(meshes[0].normals).toHaveLength(0);
+    expect(meshes[0].indices).toHaveLength(0);
+  });
 });
 
 describe('parseGLB header validation', () => {

--- a/packages/export/src/glb.ts
+++ b/packages/export/src/glb.ts
@@ -130,6 +130,18 @@ export function parseGLBToMeshData(glb: Uint8Array): MeshData[] {
     const bv = bufferViews[acc.bufferView];
     const byteOffset = (bv.byteOffset || 0) + (acc.byteOffset || 0);
     const count = Number(acc.count || 0);
+    // `Number(acc.count || 0)` only catches a MISSING count (falsy ->
+    // defaults to 0); a present-but-non-numeric count (e.g. a corrupted
+    // JSON chunk with `"count":"abc"`) survives `|| 0` and becomes NaN
+    // here. `byteLen` then propagates NaN, and `NaN > bin.byteLength` below
+    // is `false` -- the exact same "bare comparison is bypassed by NaN"
+    // shape as the sibling `@ifc-lite/cache` GLB reader. Without this
+    // check, `bin.subarray(offset, NaN)` silently returns an EMPTY view and
+    // this accessor decodes as a mesh with zero vertices/indices instead of
+    // throwing.
+    if (!Number.isInteger(count) || count < 0) {
+      throw new Error(`GLB accessor has an invalid count: ${acc.count}`);
+    }
     const comps = typeComponents(String(acc.type));
     const cSize = componentTypeSize(Number(acc.componentType));
     const byteLen = count * comps * cSize;


### PR DESCRIPTION
`accessor.count` is required by the glTF spec but arrives from `JSON.parse` of the GLB's embedded JSON chunk — so it is producer-controlled and need not be a number. **Two independent readers** each mishandled it, in slightly different ways.

## `packages/cache/src/glb.ts` — the guard is bypassed

`readAccessorData` feeds `count` into the bounds check `bufferOffset + neededBytes > bin.byteLength`. With `count` missing or NaN that comparison is **false** — every NaN comparison is — so the guard passes and the reader returns an **empty mesh with no error**.

Probed on the unfixed code:

```
valid accessor.count = 3      -> meshes: 1, positions len: 9
malformed count = undefined   -> meshes: 1, positions: Float32Array(0), len: 0
```

## `packages/export/src/glb.ts` — the `|| 0` doesn't cover it

`readAccessor` does `count = Number(acc.count || 0)`. The `|| 0` substitutes only for a **missing** count; a present-but-non-numeric one survives it and becomes NaN:

```
count = "abc"  -> meshes: 1, positions len: 0, indices len: 0
count = 3      -> meshes: 1, positions.length: 9
```

Both now require `Number.isInteger(count) && count >= 0` before any arithmetic. I checked the two guards are the **same predicate**, not merely similar — these are parallel implementations, and this defect exists precisely because they drifted.

## Reachability

`apps/viewer/src/hooks/ingest/viewerModelIngest.ts` calls `loadGLBToMeshData` on model ingest.

## What the throw displaces — checked, not assumed

Both readers previously returned empty data and now **throw**, so the question is whether that crashes ingest where it previously degraded.

It doesn't. `parseGlbViewerModel` has no local try/catch, but its only caller (`useIfcLoader.ts:880`) wraps it:

```js
} catch (err: unknown) {
  console.error('[useIfc] GLB parsing failed:', err);
  updateModel(modelId, { loadState: 'error', loadError: message });
  setError(`GLB parsing failed: ${message}`);
  setLoading(false);
```

So the throw surfaces as a user-visible error and a clean error state — no crash, no unhandled rejection, and strictly better than a silent empty-mesh "success" that looks like a model with no geometry. `@ifc-lite/export`'s reader has no other production call site in the repo.

## Bounding controls

Both pass on the **unfixed** code, so neither guard can be satisfied by rejecting everything:

- A valid count still decodes.
- `count: 0` is still accepted as a legitimately empty accessor.

The `count: 0` control was **missing** on the export side; it's been added.

## Verification

**cache 66 → 68, export 450 → 453.** `tsc --noEmit` exit 0 for both. Two patch changesets.

## Provenance

Found by a repo-wide sweep for one shape — a validation guard written as a bare comparison, which NaN silently bypasses. The same sweep produced the CLI half of #2298 and the MCP fix in #2328.
