### PR TITLE
fix(drawing-2d): promote an island inside a hole to solid, not a second hole

### DIFF
--- a/.changeset/drawing2d-nested-hole-island.md
+++ b/.changeset/drawing2d-nested-hole-island.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/drawing-2d": patch
+---
+
+Fix `PolygonBuilder.classifyLoops` misclassifying an island (e.g. a mullion cross-section, or a column stub) nested inside a hole as a second hole of the outer boundary, instead of a solid polygon in its own right. Previously every ring's containment was tested only against the top-level outer boundary, so anything geometrically inside it — at any nesting depth — became a hole, silently turning the island into void in the rendered section drawing. Loops are now classified by nesting depth relative to their nearest containing ancestor: even depth is a solid outer boundary, odd depth is a hole of its immediate parent.

--- a/packages/drawing-2d/src/polygon-builder.test.ts
+++ b/packages/drawing-2d/src/polygon-builder.test.ts
@@ -209,4 +209,45 @@ describe('PolygonBuilder — hole containment and winding (classifyLoops)', () =
     expect(Math.abs(polygonSignedArea(outer))).toBeCloseTo(100, 5);
     expect(Math.abs(polygonSignedArea(holes[0]))).toBeCloseTo(4, 5);
   });
+
+  /**
+   * An island (e.g. a mullion cross-section, or a column stub) fully
+   * contained inside a hole (a window opening, or a shaft) must be promoted
+   * to its OWN solid outer polygon — not folded into the outer wall as a
+   * second hole. `classifyLoops` previously tested every ring's containment
+   * only against the top-level outer, so anything geometrically inside the
+   * outer boundary — at ANY nesting depth — was classified as a hole of it.
+   * That silently turned the island into void, i.e. the mullion/column
+   * would render as an empty gap in the drawing instead of solid material.
+   */
+  it('promotes an island nested inside a hole to its own solid polygon, not a second hole of the outer', () => {
+    const segments = [
+      ...rectSegments(0, 0, 10, 10, 500), // outer wall boundary
+      ...rectSegments(2, 2, 8, 8, 500),   // window opening (hole)
+      ...rectSegments(4, 4, 6, 6, 500),   // mullion cross-section (island) inside the opening
+    ];
+
+    const polygons = new PolygonBuilder().buildPolygons(segments);
+
+    expect(polygons).toHaveLength(2);
+
+    const outerPoly = polygons.find(
+      (p) => Math.abs(polygonSignedArea(p.polygon.outer)) > 50,
+    )!;
+    const islandPoly = polygons.find(
+      (p) => Math.abs(polygonSignedArea(p.polygon.outer)) < 50,
+    )!;
+
+    // The outer wall keeps exactly the window opening as its hole — the
+    // island must NOT appear as a second hole here.
+    expect(outerPoly.polygon.holes).toHaveLength(1);
+    expect(Math.abs(polygonSignedArea(outerPoly.polygon.outer))).toBeCloseTo(100, 5);
+    expect(Math.abs(polygonSignedArea(outerPoly.polygon.holes[0]))).toBeCloseTo(36, 5);
+
+    // The island is its own solid polygon (no holes), wound CCW like any
+    // other outer boundary.
+    expect(islandPoly.polygon.holes).toHaveLength(0);
+    expect(isCounterClockwise(islandPoly.polygon.outer)).toBe(true);
+    expect(Math.abs(polygonSignedArea(islandPoly.polygon.outer))).toBeCloseTo(4, 5);
+  });
 });

--- a/packages/drawing-2d/src/polygon-builder.ts
+++ b/packages/drawing-2d/src/polygon-builder.ts
@@ -536,43 +536,70 @@ export class PolygonBuilder {
   }
 
   /**
-   * Classify loops as outer boundaries or holes
-   * Uses containment testing and area sign
+   * Classify loops as outer boundaries or holes.
+   *
+   * Nesting can go more than one level deep — an island (e.g. a mullion
+   * cross-section, or a column stub) fully inside a hole (a window opening,
+   * a shaft) must become its OWN solid outer polygon, not a second hole of
+   * the outermost boundary. Each loop's classification is therefore relative
+   * to its NEAREST containing ancestor (the smallest-area loop that still
+   * contains it), not the top-level outer: walk the ancestor chain to get a
+   * nesting depth, then even depth (0, 2, 4, …) = solid outer boundary, odd
+   * depth (1, 3, …) = hole of its immediate (even-depth) parent.
    */
   private classifyLoops(loops: Loop[]): Array<{ outer: Point2D[]; holes: Point2D[][] }> {
     if (loops.length === 0) return [];
 
-    // Sort by absolute area (largest first)
+    // Sort by absolute area (largest first) — the nearest-ancestor search
+    // below relies on iterating candidates by area, not on this order.
     const sorted = [...loops].sort((a, b) => Math.abs(b.area) - Math.abs(a.area));
+    const n = sorted.length;
+
+    // Nearest containing ancestor: the smallest-area OTHER loop that
+    // contains this one. -1 = top-level (no containing loop).
+    const parent: number[] = new Array(n).fill(-1);
+    for (let i = 0; i < n; i++) {
+      let bestParent = -1;
+      let bestArea = Infinity;
+      for (let j = 0; j < n; j++) {
+        if (i === j) continue;
+        if (this.isLoopContainedIn(sorted[i].points, sorted[j].points)) {
+          const area = Math.abs(sorted[j].area);
+          if (area < bestArea) {
+            bestArea = area;
+            bestParent = j;
+          }
+        }
+      }
+      parent[i] = bestParent;
+    }
+
+    // Nesting depth = length of the ancestor chain to the top level.
+    const depth: number[] = new Array(n).fill(0);
+    for (let i = 0; i < n; i++) {
+      let d = 0;
+      let p = parent[i];
+      while (p !== -1) {
+        d++;
+        p = parent[p];
+      }
+      depth[i] = d;
+    }
 
     const result: Array<{ outer: Point2D[]; holes: Point2D[][] }> = [];
-    const assigned = new Set<number>();
 
-    for (let i = 0; i < sorted.length; i++) {
-      if (assigned.has(i)) continue;
+    for (let i = 0; i < n; i++) {
+      if (depth[i] % 2 !== 0) continue; // holes are emitted as part of their parent below
 
-      const outer = sorted[i];
-
-      // Ensure outer boundary is CCW
-      const outerPoints = ensureCCW(outer.points);
-
-      // Find holes (smaller loops contained within this one)
+      const outerPoints = ensureCCW(sorted[i].points);
       const holes: Point2D[][] = [];
 
-      for (let j = i + 1; j < sorted.length; j++) {
-        if (assigned.has(j)) continue;
-
-        const inner = sorted[j];
-
-        // Check if inner is contained in outer
-        if (this.isLoopContainedIn(inner.points, outerPoints)) {
-          // Ensure hole is CW (opposite winding)
-          holes.push(ensureCW(inner.points));
-          assigned.add(j);
+      for (let j = 0; j < n; j++) {
+        if (parent[j] === i && depth[j] % 2 === 1) {
+          holes.push(ensureCW(sorted[j].points));
         }
       }
 
-      assigned.add(i);
       result.push({ outer: outerPoints, holes });
     }
 

--- a/packages/drawing-2d/src/projection-bands.test.ts
+++ b/packages/drawing-2d/src/projection-bands.test.ts
@@ -50,6 +50,18 @@ describe('classifyDepthRange', () => {
     expect(classifyDepthRange(-0.5, -2, bands)).toBe('visible');
   });
 
+  it('keeps an element exactly at the below-band boundary as visible (band is closed at -below)', () => {
+    // dMax === -depths.below exactly — the documented `[-below, 0)` band is
+    // closed on this end, so this must NOT cull.
+    expect(classifyDepthRange(-5, -3, bands)).toBe('visible');
+  });
+
+  it('keeps an element exactly at the above-band boundary as overhead (band is closed at +above)', () => {
+    // dMin === depths.above exactly — the documented `(0, +above]` band is
+    // closed on this end, so this must NOT cull.
+    expect(classifyDepthRange(3, 5, bands)).toBe('overhead');
+  });
+
   it('zero-width bands cull a near-plane element; the 1mm floor keeps it (R1)', () => {
     const dNearBelow = -0.0005; // just below the cut
     expect(classifyDepthRange(dNearBelow, dNearBelow, { below: 0, above: 0 })).toBe('cull');


### PR DESCRIPTION
`PolygonBuilder.classifyLoops` tested every ring against the **top-level outer ring only**, so any loop geometrically inside the outer — regardless of nesting depth — was classified as a hole of it.

A real island inside an opening (a mullion, pier, or column stub caught by the same section cut) was therefore emitted as a **second hole** and drawn as void where the model has solid material.

Probed on the unfixed code with three nested rectangles — a 10×10 wall, a 6×6 opening, and a 2×2 mullion inside the opening:

```
num polygons: 1
outer:  (0,0),(10,0),(10,10),(0,10)
holes:  [(2,2)-(8,8)] , [(4,4)-(6,6)]   <- the mullion, wrongly a hole
```

Now classified by nesting **depth** against the nearest containing ancestor: even depth is a solid outer ring, odd depth is a hole of its immediate even-depth parent.

## Severity: LIVE — and it's a silently wrong drawing

Not a crash, not an error, not a blank output. The section renders cleanly and shows a **void where material exists**, which is the failure mode a reviewer is least likely to catch by eye and a user is most likely to trust.

Reachable from the package's core public entry point: `SectionCutter.cutMeshes` → `PolygonBuilder.buildPolygons` → `classifyLoops`, on any section through an opening containing a mullion or pier.

## Bounding controls

Both pass **before and after**, so the new depth-parity logic cannot be satisfied by simply reclassifying everything:

- The existing single-hole regression — `classifies a contained inner ring as a hole, wound opposite the outer ring`.
- The 3-way material-layer split, over non-nested side-by-side loops.

Only the 2-level nesting case changes behaviour.

## Also included — coverage gaps, not bugs

Two boundary tests for `classifyDepthRange` in `projection-bands.ts`. Mutating `hi >= -below` to `hi >` and `lo <= above` to `lo <` each **survived the whole suite**, because no test exercised the exact boundary value.

Production is already correct here — the documented semantics are closed at the outer edge and the code uses the inclusive operators — so these pin behaviour that was right but unasserted. Each mutant now fails exactly one test.

## Verification

**238 → 241 passing across 24 files.** `tsc --noEmit` exit 0. Patch changeset.

## Reviewed and found clean

`section-cutter.ts` (edge/plane intersection, degenerate-triangle and on-plane-edge handling), `hidden-line.ts` (depth-buffer rasterisation, barycentric degenerate guard, flip sign convention), `line-merger.ts` (collinear merge, dedup, gap tolerance — direction bucketing correctly handles reversed vectors), and `storey-bands.ts`, whose `<=` boundary in `currentFloorBands` **is** already pinned by an existing test (mutating it fails 1 of 12).

One thing noted and deliberately **not** chased: `hatch-generator.ts`'s `clipLineToRing` computes an `entering` flag that is never read. The even-odd toggle it looks intended for already alternates correctly from the sorted crossings, so it reads as vestigial rather than a functional bug — flagging it rather than deleting code under a fix PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected nested polygon handling so islands inside holes are rendered as separate solid polygons.
  * Preserved accurate hole assignments, polygon winding, and area calculations.
  * Fixed visibility classification for ranges exactly at depth-band boundaries.

* **Tests**
  * Added regression coverage for nested islands and depth-band boundary conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->