### PR TITLE
fix(provenance): union a caller-supplied region, never substitute it

### DIFF
--- a/.changeset/provenance-region-override-union.md
+++ b/.changeset/provenance-region-override-union.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/provenance": patch
+---
+
+Fix `computeMergeOpFootprint` silently dropping the host/opening spatial coupling when a caller supplies its own `region` on an `entity-remove` or `geometry-replace` op.
+
+`entity-add`'s footprint already unions a caller-supplied `region` with the computed (host-aware) one ("union, never substitute" — a narrower override must never shrink the region below what the op actually touches). `entity-remove` and `geometry-replace` did not follow the same rule: any caller-supplied `region` replaced the computed region outright, discarding the hosted-openings/host-box coverage that makes the B4.2 spatial conflict rule catch the host-move-plus-opening-move pair that structurally looks disjoint but does not commute (recutHost reads live opening geometry under lazy cut semantics). A disjoint caller-supplied region on either op type let `conflictPredicate`/`findCrossConflicts` clear a pair that genuinely diverges.
+
+`createCommutationCertificate` was not compromised end-to-end by this — it always replays both op orders after the predicate passes and refuses on divergence — but `findCrossConflicts`/`conflictPredicate` used standalone (as `merge-battery.ts`'s own comments describe pairing with `attemptBothOrders` for ground truth) would return a false negative. Both op types now union the caller-supplied region with the computed one, matching `entity-add`.

--- a/packages/provenance/src/merge-model.ts
+++ b/packages/provenance/src/merge-model.ts
@@ -967,7 +967,15 @@ export function computeMergeOpFootprint(dag: ProvenanceDag, state: ModelState, o
         const box = regionOfMeshes(opening.meshes.values());
         if (box) boxes.push(box);
       }
-      const region = op.region ?? (boxes.length > 0 ? unionAabb(boxes) : undefined);
+      // `op.region` AUGMENTS the computed (own + hosted-openings) region, it
+      // does not replace it -- same rule as `entity-add` above ("union,
+      // never substitute"): the computed region is what makes this op's
+      // footprint necessarily meet a concurrent op on one of the removed
+      // entity's hosted openings or on the host itself; a disjoint override
+      // would silently drop that coverage.
+      const computed = boxes.length > 0 ? unionAabb(boxes) : undefined;
+      const region =
+        op.region === undefined ? computed : computed === undefined ? op.region : unionAabb([op.region, computed]);
       const editOp: EditOp = {
         opId: op.opId,
         kind: 'geometry-edit',
@@ -992,24 +1000,28 @@ export function computeMergeOpFootprint(dag: ProvenanceDag, state: ModelState, o
       // footprint have to say so.
       const openings = hostedOpenings(state, ownerId);
       const targetNodeIds = openings.length > 0 ? [...ownerEntity.meshes.keys()] : [op.meshNodeId];
-      let region = op.region;
-      if (!region) {
-        const boxes: Aabb[] = [
-          aabbFromMesh(ownerEntity.meshes.get(op.meshNodeId) as GeometryMeshPayload),
-          aabbFromMesh(op.payload),
-        ];
-        // ...and the bytes it writes are a function of EVERY opening in the
-        // host, which can sit anywhere inside the host's bounds -- not just
-        // inside the named mesh's. On a single-mesh host the two coincide (the
-        // named mesh IS the host), which is why this was invisible; on a host
-        // whose meshes are spatially separated, omitting the host box lets an
-        // op on a far-away opening look disjoint from the re-cut it changes.
-        if (openings.length > 0) {
-          const hostBox = baseAabbOfEntity(ownerEntity);
-          if (hostBox) boxes.push(hostBox);
-        }
-        region = unionAabb(boxes);
+      const boxes: Aabb[] = [
+        aabbFromMesh(ownerEntity.meshes.get(op.meshNodeId) as GeometryMeshPayload),
+        aabbFromMesh(op.payload),
+      ];
+      // ...and the bytes it writes are a function of EVERY opening in the
+      // host, which can sit anywhere inside the host's bounds -- not just
+      // inside the named mesh's. On a single-mesh host the two coincide (the
+      // named mesh IS the host), which is why this was invisible; on a host
+      // whose meshes are spatially separated, omitting the host box lets an
+      // op on a far-away opening look disjoint from the re-cut it changes.
+      if (openings.length > 0) {
+        const hostBox = baseAabbOfEntity(ownerEntity);
+        if (hostBox) boxes.push(hostBox);
       }
+      const computed = unionAabb(boxes);
+      // `op.region` AUGMENTS the computed region, it does not replace it --
+      // same "union, never substitute" rule as `entity-add`/`entity-remove`
+      // above. A caller-supplied region is a hint the footprint may widen
+      // with, never a narrower box it may shrink to: substituting it let a
+      // disjoint override hide the exact host/opening coupling this function
+      // exists to declare (the B4.2 headline non-commuting pair).
+      const region = op.region === undefined ? computed : unionAabb([op.region, computed]);
       const editOp: EditOp = { opId: op.opId, kind: 'geometry-edit', targetNodeIds, region };
       return computeFootprint(dag, editOp);
     }

--- a/packages/provenance/test/merge-model-hosting.test.ts
+++ b/packages/provenance/test/merge-model-hosting.test.ts
@@ -24,6 +24,7 @@ import { conflictPredicate } from '../src/footprint.js';
 import {
   attemptBothOrders,
   createCommutationCertificate,
+  findCrossConflicts,
   verifyCommutationCertificate,
 } from '../src/commutation.js';
 import type { GeometryMeshPayload } from '../src/node-hash.js';
@@ -235,6 +236,46 @@ describe('node-disjoint ops that genuinely do NOT commute (the B4.2 headline)', 
     const outcome = await createCommutationCertificate({ base, opsA: [hostOp], opsB: [openingOp] });
     expect(outcome.ok).toBe(false);
     expect(outcome.ok === false && outcome.reason).toBe('conflict');
+  });
+
+  it('REGRESSION PROBE: a caller-supplied region on the HOST op must not suppress the spatial catch', async () => {
+    // Exact same headline pair as above -- disjoint writtenNodes, genuinely
+    // divergent bytes -- except the host op carries its own (tiny, disjoint)
+    // `region` override, exactly like a real caller who already knows a
+    // cheap bounding box for the mesh it is replacing would supply. Per
+    // computeMergeOpFootprint's own module docstring (`entity-add`'s
+    // "op.region AUGMENTS the host-aware one, it does not replace it" /
+    // "union, never substitute"), the SAME rule must hold for
+    // `geometry-replace` and `entity-remove`, or this is exactly the
+    // headline non-commuting pair slipping through undetected.
+    const base = hostedState();
+    const farAwayBox = { min: [10, 10, 0] as const, max: [10.01, 10.01, 0] as const };
+    const hostOp: MergeOp = { ...moveHost('a0', 0.1, 0.1), region: farAwayBox };
+    const openingOp = moveOpening('b0', 0.5, 0.5);
+
+    // Ground truth is unchanged: the pair still genuinely does not commute.
+    expect(attemptBothOrders(base, [hostOp], [openingOp]).status).toBe('diverged');
+
+    const dag = buildStateDag(base);
+    const fpA = computeMergeOpFootprint(dag, base, hostOp);
+    const fpB = computeMergeOpFootprint(dag, base, openingOp);
+    const verdict = conflictPredicate(fpA, fpB);
+    // This must be caught by the spatial rule, exactly like the headline
+    // case with no override -- a caller-supplied region must AUGMENT the
+    // host-aware region, never replace it wholesale.
+    expect(verdict.spatial).toBe(true);
+    expect(verdict.conflict).toBe(true);
+
+    // `findCrossConflicts` is the standalone predicate scan `merge-battery.ts`
+    // treats as ground truth alongside `attemptBothOrders`; called alone (no
+    // replay) it inherits the same miss. `createCommutationCertificate` stays
+    // sound end-to-end regardless, because it ALWAYS replays both orders after
+    // the predicate passes (see its `attemptBothOrders` call) -- that defense
+    // in depth is what this second half pins, so a future removal of the
+    // replay step is caught here too.
+    expect(findCrossConflicts(base, [hostOp], [openingOp]).length).toBeGreaterThan(0);
+    const outcome = await createCommutationCertificate({ base, opsA: [hostOp], opsB: [openingOp] });
+    expect(outcome.ok).toBe(false);
   });
 
   it('order-dependent REJECTION: one order applies, the reverse order does not', () => {


### PR DESCRIPTION
`computeMergeOpFootprint`'s `entity-add` case unions a caller-supplied `op.region` with the computed host/opening-aware region, and its comment says why in as many words: **"union, never substitute"**.

The `entity-remove` and `geometry-replace` cases **substituted** it.

So a caller passing a disjoint region on either of those two silently dropped the host↔opening spatial coupling — the coupling that makes the B4.2 conflict rule catch the documented non-commuting pair (host move plus opening move under lazy cut semantics). The footprint came back narrower than the operation really touches, and a conflict that should have been reported was not.

The same guard hardened in one of three sibling cases — with the correct one carrying a comment explaining the rule the other two didn't follow.

## Severity: coverage gap / latent soundness asymmetry — not live

I'd rather give the reasoning than the label, because the label alone would overclaim in either direction:

- **No in-repo caller reaches it.** `merge-battery.ts` never sets `region:` on generated ops, so nothing today supplies the value that triggers the substitution.
- **The one caller that composes it has defence in depth.** `createCommutationCertificate`'s independent replay/divergence check (`attemptBothOrders`) still catches the pair. This was confirmed rather than assumed, by pairing the probe against `findCrossConflicts` alone — which *did* miss the conflict pre-fix — while the certificate stayed sound.
- **`packages/provenance` is `private: true`**, so the "external usage IS the contract" argument from the #2111 review doesn't apply here either.

What *is* wrong today is narrower, and worth fixing anyway: the exported API's soundness guarantee silently did not hold for two of its three op types, and held for the third only by an explicitly documented decision the other two didn't copy. For a package whose entire job is asserting that a merge is sound, a guarantee that quietly applies to one case in three is the kind of thing that should be true by construction rather than by which caller happens to reach it.

## Verification

RED against the unfixed code: the new probe fails at `expect(verdict.spatial).toBe(true)` — got `false`.

**266 → 267 passing across 11 files.** `tsc --noEmit` exit 0. Patch changeset.

Bounding control: `entity-add`'s already-correct path is unaffected and still passes, so the change can't be satisfied by unioning indiscriminately.

## Reviewed and found clean

`node-hash.ts` (FNV-1a64 + SHA-256 canonical encoding, NFC-normalisation ambiguity rejection), `certificate.ts` (create/verify, signature-shape validation, NaN/Infinity guards), `commutation.ts`, `dag-engine.ts` (incremental memoised DAG), `footprint.ts` (conflict predicate, container-kind ancestor exclusion).

This package carries unusually dense self-documentation of prior audit rounds — the SPEC FREEZE commit, the G2/G4 red-team references — and it shows in how little there was to find.

## On the `packages/sdk` half — partial, and I want to be precise about it

The same pass also looked at `packages/sdk`. Everything reviewed came back clean, including both areas I'd specifically targeted: `dispatchToBackend` (already hardened by #2294 against prototype-chain reach) and the `EntityRef` encode/decode round-trip (last-colon split, numeric regex, finite/non-negative check) — both confirmed intact and calibration-verified.

But the review was **broad, not exhaustive**. `namespaces/bcf.ts`, `drawing.ts`, `ids.ts`, `export.ts`, `clash.ts` and the whole `transport/` directory were **not read**. Absence of findings there should not be read as "reviewed and clean" — they simply weren't reached before the budget went into the provenance fix above. Worth a follow-up pass rather than assuming that ground is covered.
