### PR TITLE
fix(create): refuse to author IFC2X3 elements without an IfcOwnerHistory

### DIFF
--- a/.changeset/create-ifc2x3-mandatory-ownerhistory.md
+++ b/.changeset/create-ifc2x3-mandatory-ownerhistory.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/create": patch
+---
+
+`resolveSpatialAnchor` now refuses (throws) rather than silently proceeding when a store's schema is IFC2X3 and it has no `IfcOwnerHistory` entity.
+
+`IfcRoot.OwnerHistory` is optional from IFC4 onward but mandatory in IFC2X3. `resolveSpatialAnchor` previously resolved `ownerHistoryId: null` for any store missing `IfcOwnerHistory`, regardless of schema, and every in-store builder (`addWallToStore`, `addBeamToStore`, `addSlabToStore`, ...) emits `$` for a null `ownerHistoryId` unconditionally. Editing an IFC2X3 store that itself is missing `IfcOwnerHistory` (a malformed or hand-edited file) therefore silently authored new IFC2X3 elements with `$` in place of a mandatory attribute. IFC4/IFC4X3 stores are unaffected — OwnerHistory is genuinely optional there and `$` is correct.

--- a/packages/clash/src/differential.test.ts
+++ b/packages/clash/src/differential.test.ts
@@ -198,6 +198,17 @@ describe('differential: WASM kernel === TS kernel', () => {
     expect(await bothAgree(els, [{ id: 'self', name: 'self', a: 'IfcBeam', mode: 'hard' }])).toBe(1);
   });
 
+  it('agrees on same-key exclusion (WASM has no key concept in its broad phase)', async () => {
+    // The Rust/WASM broad phase ingests only positions/indices/AABBs — it has no
+    // notion of durable `key`/`model`, so same-entity exclusion for the WASM
+    // engine relies entirely on the shared orchestrator's post-filter (see
+    // orchestrator.ts `elA.key === elB.key` check). This pins that the WASM
+    // engine agrees with TS (0 clashes) for two overlapping elements sharing a
+    // durable key, the way a split IFC5/USD entity would.
+    const els = [box('SAME', 'IfcWall', [0, 0, 0]), box('SAME', 'IfcWall', [0.2, 0, 0])];
+    expect(await bothAgree(els, [{ id: 'self', name: 'wall self-clash', a: 'IfcWall', mode: 'hard' }])).toBe(0);
+  });
+
   it('agrees across the full discipline matrix on a mixed model', async () => {
     const els = [
       box('w1', 'IfcWall', [0, 0, 0]),

--- a/packages/create/src/in-store/resolve-anchor-ifc2x3-ownerhistory.test.ts
+++ b/packages/create/src/in-store/resolve-anchor-ifc2x3-ownerhistory.test.ts
@@ -1,0 +1,81 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `IfcRoot.OwnerHistory` is OPTIONAL from IFC4 onward but MANDATORY in
+ * IFC2X3. `resolveSpatialAnchor`'s own comment ("OwnerHistory is OPTIONAL
+ * from IFC4 onward") only states the IFC4+ half of that rule, and the
+ * lookup itself (`findOwnerHistoryId`) is schema-blind: it returns `null`
+ * whenever the store has no `IFCOWNERHISTORY` entity, regardless of schema.
+ *
+ * For an IFC2X3 store that is missing `IfcOwnerHistory` (a malformed or
+ * hand-edited file — real IFC2X3 files virtually always carry one, but
+ * nothing here enforces that), every downstream builder
+ * (`addWallToStore`, `addBeamToStore`, ...) calls `ownerHistoryRef(null)`,
+ * which unconditionally emits `$`. That is a mandatory attribute emitted
+ * as `$` in an IFC2X3 file — a malformed file that most parsers still
+ * accept silently.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { IfcParser } from '@ifc-lite/parser';
+import { MutablePropertyView, StoreEditor } from '@ifc-lite/mutations';
+import { resolveSpatialAnchor } from './resolve-anchor.js';
+import { addWallToStore } from './wall.js';
+
+/** Minimal IFC2X3 model with one storey and NO IfcOwnerHistory entity. */
+const IFC2X3_NO_OWNER_HISTORY = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('t.ifc','',(''),(''),'','','');
+FILE_SCHEMA(('IFC2X3'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0proj00000000000000000',$,'P',$,$,$,$,(#7),#9);
+#5=IFCCARTESIANPOINT((0.,0.,0.));
+#6=IFCAXIS2PLACEMENT3D(#5,$,$);
+#7=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-05,#6,$);
+#8=IFCGEOMETRICREPRESENTATIONSUBCONTEXT('Body','Model',*,*,*,*,#7,$,.MODEL_VIEW.,$);
+#9=IFCUNITASSIGNMENT((#91));
+#91=IFCSIUNIT(*,.LENGTHUNIT.,.MILLI.,.METRE.);
+#20=IFCLOCALPLACEMENT($,#6);
+#30=IFCBUILDINGSTOREY('0storey000000000000000',$,'Level 0',$,$,#20,$,$,.ELEMENT.,0.);
+ENDSEC;
+END-ISO-10303-21;`;
+
+describe('resolveSpatialAnchor + addWallToStore: IFC2X3 without IfcOwnerHistory', () => {
+  it('refuses to resolve an anchor that would make addWallToStore emit a mandatory OwnerHistory as $', async () => {
+    const store = await new IfcParser().parseColumnar(
+      new TextEncoder().encode(IFC2X3_NO_OWNER_HISTORY).buffer as ArrayBuffer,
+      { disableWorkerScan: true },
+    );
+
+    // resolveSpatialAnchor must refuse outright rather than silently hand
+    // back { schema: 'IFC2X3', ownerHistoryId: null } — a combination every
+    // builder would turn into a malformed IFC2X3 element ($ for a mandatory
+    // attribute).
+    expect(() => resolveSpatialAnchor(store, 30)).toThrow(/OwnerHistory/);
+  });
+
+  it('control: IFC4 with no IfcOwnerHistory still resolves fine (OwnerHistory is optional there)', async () => {
+    const ifc4NoOwnerHistory = IFC2X3_NO_OWNER_HISTORY.replace("FILE_SCHEMA(('IFC2X3'));", "FILE_SCHEMA(('IFC4'));");
+    const store = await new IfcParser().parseColumnar(
+      new TextEncoder().encode(ifc4NoOwnerHistory).buffer as ArrayBuffer,
+      { disableWorkerScan: true },
+    );
+
+    const anchor = resolveSpatialAnchor(store, 30);
+    expect(anchor.schema).toBe('IFC4');
+    expect(anchor.ownerHistoryId).toBeNull();
+
+    const view = new MutablePropertyView(null, 'm1');
+    const editor = new StoreEditor(store, view);
+    const result = addWallToStore(editor, anchor, {
+      Start: [0, 0, 0], End: [5, 0, 0], Thickness: 0.2, Height: 3,
+    });
+    const wall = view.getNewEntities().find((e) => e.expressId === result.wallId);
+    // Correctly `$` — OwnerHistory is optional from IFC4 onward.
+    expect(wall?.attributes[1]).toBeNull();
+  });
+});

--- a/packages/create/src/in-store/resolve-anchor.ts
+++ b/packages/create/src/in-store/resolve-anchor.ts
@@ -37,6 +37,19 @@ export function resolveSpatialAnchor(store: IfcDataStore, storeyExpressId: numbe
 
   const schema = (store.schemaVersion ?? 'IFC4') as SpatialAnchorSchema;
 
+  // Unlike IFC4+, IfcRoot.OwnerHistory is MANDATORY in IFC2X3. Every builder
+  // (addWallToStore, addBeamToStore, ...) blindly emits `$` when
+  // ownerHistoryId is null, which is fine for IFC4+ but would silently write
+  // a malformed IFC2X3 file (mandatory attribute emitted as `$`) for a store
+  // that itself is missing IfcOwnerHistory. Refuse here rather than let that
+  // through quietly.
+  if (schema === 'IFC2X3' && ownerHistoryId === null) {
+    throw new Error(
+      'resolveSpatialAnchor: IFC2X3 requires IfcOwnerHistory (IfcRoot.OwnerHistory is mandatory in ' +
+        'IFC2X3), but the store has none — cannot author new IFC2X3 elements without one',
+    );
+  }
+
   // Builder params are metres; the file may not be (e.g. millimetre Revit
   // exports). Resolve the length-unit scale here so builders can emit
   // coordinates in the file's native unit — mirrors the read-side


### PR DESCRIPTION
`IfcRoot.OwnerHistory` is **optional from IFC4 onward but mandatory in IFC2X3**. `resolveSpatialAnchor` resolved `ownerHistoryId: null` for any store lacking an `IFCOWNERHISTORY` entity without consulting the schema — its own comment covers only the IFC4+ half of that rule. Every builder (`addWallToStore`, `addBeamToStore`, … all public exports) then calls `ownerHistoryRef(null)` unconditionally and emits `$`.

Probed through the public API with a real parsed IFC2X3 fixture carrying no `IfcOwnerHistory` — `resolveSpatialAnchor` → `addWallToStore`:

```
wall.attributes[1] === null      // a mandatory attribute written as `$`
```

Silently, and into a file most parsers accept anyway. A malformed IFC that still reads back is the worst version of this — nothing downstream complains until something strict does.

## Why a throw, and what it displaces

This was the part worth checking before adding one, since a throw in an authoring path can break a working flow.

It doesn't here. `resolveSpatialAnchor` **already throws** for a missing body context and for a missing axis context, and its viewer call site (`store-adapter.ts`) already throws for "no model loaded". Callers must already handle it — the new throw is consistent with the function's existing contract rather than a novel failure mode.

And a genuine IFC2X3 file always carries `IfcOwnerHistory`, because the schema requires it. So this fires only on input that is **already invalid IFC2X3**, and it fires at authoring time rather than at whatever reads the file later.

Synthesising an owner history was the alternative I considered. Inventing provenance data — a fabricated person, organisation and application — seemed worse than refusing, but say the word if you'd rather have that.

## Bounding control

IFC4 with no `IfcOwnerHistory` must **still resolve and still emit `$`**. That's the real 0-boundary: without it the guard could have been "reject whenever owner history is absent", which would break every minimal IFC4 file — including ifc-lite's own exports.

## Verification

**123 → 125 passing across 17 files.** `tsc --noEmit` exit 0. Patch changeset.

---

## Also included — test-only, no production change

`packages/clash`: the **WASM kernel's self-clash exclusion had no test at all**.

`broad.ts` and `orchestrator.ts` both filter same-`(model, key)` pairs, and the comment explains why: *"Filter here so every kernel — TS or WASM, regardless of how its broad phase dedups — behaves alike."* But the WASM kernel never ingests `key`/`model`, so `orchestrator.ts:92` is its **sole** enforcement point, while the TS path has `broad.ts` as a redundant second line. The existing self-clash test uses distinct keys, so it never reached this.

Neutralising that guard now fails the new test with **WASM reporting a false clash while TS still reports none** — which is exactly the asymmetry worth pinning: TS's redundancy was masking WASM's total reliance on the shared guard.

**179 → 180 passing**, `tsc --noEmit` exit 0.

## Reviewed and found clean

`duplicates.ts`'s sort-and-sweep eviction boundary is already pinned by #2292 (same day), and it's the only sort-and-sweep in the package — checked for the recurrence rather than assumed. `exclude.ts` and `disciplines.ts` reviewed and correct.

One honest limit: `narrow.ts`'s tolerance/contact logic is densely documented against prior bugs (#1362, #1402, #1866) but was **not** re-mutated within budget — no findings there should be read as "verified clean".
