### PR TITLE
fix(sandbox): route addBeam's storey guard through the shared helper

### DIFF
--- a/.changeset/sandbox-store-addbeam-storeyid-guard.md
+++ b/.changeset/sandbox-store-addbeam-storeyid-guard.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/sandbox": patch
+---
+
+Fix `bim.store.addBeam` accepting `storeyExpressId: 0` in a sandboxed script. Every other `bim.store.addX` method (`addColumn`, `addWall`, `addSlab`, `addDoor`, `addWindow`, `addSpace`, `addRoof`, `addPlate`, `addMember`) shares `requireStoreyId`, which rejects `storeyExpressId <= 0` since EXPRESS ids are 1-based and `#0` is never a valid reference. `addBeam` alone duplicated the check inline and only rejected negative values, letting `0` through with a less specific downstream error (`resolveSpatialAnchor: storey #0 has no resolvable IfcLocalPlacement` instead of the bridge's own "storeyExpressId must be a positive integer" message). No entity was ever created either way — `resolveSpatialAnchor` throws before any STEP records are emitted — so this was an error-message inconsistency, not silent data corruption. `addBeam` now uses the same shared `requireStoreyId` helper as its siblings.

--- a/packages/sandbox/src/bridge-store.test.ts
+++ b/packages/sandbox/src/bridge-store.test.ts
@@ -1,0 +1,68 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `bim.store` had zero behavioural coverage — bridge-permissions.test.ts
+ * only checks that `typeof bim.store` is gated correctly, never calls a
+ * method's `call:` handler. These tests exercise the handlers directly
+ * against a minimal mock SDK, without spinning up QuickJS.
+ *
+ * `requireStoreyId` (shared by addColumn/addWall/addSlab/addDoor/addWindow/
+ * addSpace/addRoof/addPlate/addMember) rejects `storeyExpressId <= 0` —
+ * EXPRESS ids are 1-based, so `#0` is never a valid reference (see the
+ * comment on `requireStoreyId` in bridge-store.ts). `addBeam` alone
+ * duplicates this guard inline and only rejects `< 0`, letting `0` through
+ * to `sdk.store.addBeam`.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type { BimContext } from '@ifc-lite/sdk';
+import { buildStoreNamespace } from './bridge-store.js';
+
+function findMethod(name: string) {
+  const ns = buildStoreNamespace();
+  const method = ns.methods.find((m) => m.name === name);
+  if (!method) throw new Error(`no such method: ${name}`);
+  return method;
+}
+
+/** Minimal mock SDK — only `store.addX` needs to exist; call() should throw
+ * on invalid input before ever reaching these mocks. */
+function mockSdk() {
+  return {
+    store: {
+      addColumn: vi.fn(() => ({ modelId: 'm', expressId: 99 })),
+      addBeam: vi.fn(() => ({ modelId: 'm', expressId: 99 })),
+    },
+  } as unknown as BimContext;
+}
+
+describe('bim.store storeyExpressId guard — addBeam vs. its siblings', () => {
+  it('addColumn rejects storeyExpressId 0 (EXPRESS ids are 1-based)', () => {
+    const sdk = mockSdk();
+    const call = findMethod('addColumn').call;
+    expect(() =>
+      call(sdk, ['model', 0, { Position: [0, 0, 0], Width: 1, Depth: 1, Height: 1 }]),
+    ).toThrow(/storeyExpressId must be a positive integer/);
+    expect((sdk as unknown as { store: { addColumn: ReturnType<typeof vi.fn> } }).store.addColumn).not.toHaveBeenCalled();
+  });
+
+  it('addBeam also rejects storeyExpressId 0, matching addColumn', () => {
+    const sdk = mockSdk();
+    const call = findMethod('addBeam').call;
+    expect(() =>
+      call(sdk, ['model', 0, { Start: [0, 0, 0], End: [1, 0, 0], Width: 1, Height: 1 }]),
+    ).toThrow();
+    expect((sdk as unknown as { store: { addBeam: ReturnType<typeof vi.fn> } }).store.addBeam).not.toHaveBeenCalled();
+  });
+
+  it('addBeam still rejects negative storeyExpressId (bounding control)', () => {
+    const sdk = mockSdk();
+    const call = findMethod('addBeam').call;
+    expect(() =>
+      call(sdk, ['model', -1, { Start: [0, 0, 0], End: [1, 0, 0], Width: 1, Height: 1 }]),
+    ).toThrow();
+    expect((sdk as unknown as { store: { addBeam: ReturnType<typeof vi.fn> } }).store.addBeam).not.toHaveBeenCalled();
+  });
+});

--- a/packages/sandbox/src/bridge-store.ts
+++ b/packages/sandbox/src/bridge-store.ts
@@ -157,10 +157,7 @@ export function buildStoreNamespace(): NamespaceSchema {
         ],
         tsReturn: '{ modelId: string; expressId: number }',
         call: (sdk, args) => {
-          const storeyExpressId = args[1] as number;
-          if (!Number.isInteger(storeyExpressId) || storeyExpressId < 0) {
-            throw new Error(`bim.store.addBeam: storeyExpressId must be a non-negative integer, got ${storeyExpressId}`);
-          }
+          const storeyExpressId = requireStoreyId(args[1] as number, 'addBeam');
           const params = args[2] as Parameters<typeof sdk.store.addBeam>[2];
           if (
             !params


### PR DESCRIPTION
Nine sibling `addX` methods in `bridge-store.ts` — `addColumn`, `addWall`, `addSlab`, `addDoor`, `addWindow`, `addSpace`, `addRoof`, `addPlate`, `addMember` — all validate through the shared `requireStoreyId`, which rejects `storeyExpressId <= 0`. EXPRESS ids are 1-based, so `#0` never exists.

`addBeam` alone duplicated the check inline and rejected only `< 0`, letting `0` through. The same guard hardened in nine copies and not the tenth.

Fixed by reusing the existing helper — no new throw semantics, and no second copy left to drift.

## Severity: consistency defect, not live corruption

Downgraded after tracing it rather than assuming from the shape, since "guard missing in one sibling" usually *is* live.

With `storeyExpressId = 0`, `sdk.store.addBeam` reaches `resolveSpatialAnchor(store, 0)`, whose `findStoreyPlacementId` looks up `entityIndex.byId.get(0)` — always `undefined`, since EXPRESS ids start at 1 — and throws **before** any `editor.addEntity`. So no malformed entity was ever emitted. The script just got a less specific error than its nine siblings would have produced.

## The coverage finding is arguably the bigger one

While in there, the audit established that **`bridge-query.ts`, `bridge-store.ts`, `bridge-viewer.ts`, `bridge-export.ts` and `bridge-files.ts` had no behavioural tests at all.** `bridge-permissions.test.ts` only asserts `typeof bim.<ns>` and never invokes a `call:` handler.

This PR adds the first behavioural coverage for one of those five. The other four remain uncovered — flagging that rather than padding this PR with tests for code I haven't audited.

## Bounding control

`addBeam(model, -1, …)` must still throw, and does both before and after — so the fix cannot be "reject more broadly", and it confirms the negative-rejection path was already reachable.

## Ruled out with evidence, not left as suspicions

- **No raw host object reaches script.** Every return value goes through `bridge-schema.ts`'s `marshalValue`, which rebuilds values as fresh QuickJS handles in the separate WASM heap — a copy, not a live reference — and none of these five modules bypasses that path.
- **`colorizeAll`'s manual `e.ref ?? e` extraction** is identical in permissiveness to the schema's `'entityRefs'` unmarshal. No divergence.
- **The NaN limit/offset shape from #2298 and #2328 does not apply here.** `bridge-query.ts` has no limit/offset parameters at all — `all`, `byType` and the relationship accessors return unbounded results by contract. Inapplicable, rather than silently broken.

## Verification

**121 → 124 passing across 21 files.** `tsc --noEmit` exit 0. Patch changeset.

RED-verified: `addBeam(model, 0, …)` does not throw against the unfixed code (1 failed / 2 passed).
