### PR TITLE
test(sandbox): cover three bridge namespaces that had no behavioural tests

### DIFF
--- a/packages/sandbox/src/bridge-export.test.ts
+++ b/packages/sandbox/src/bridge-export.test.ts
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `bim.export` had zero behavioural coverage. `csv`, `json`, and `ifc` are
+ * pure passthroughs to `sdk.export.*` with no independent logic — not
+ * tested here beyond what `download`'s default shares with them, since a
+ * passthrough test would only assert "a call happened," which this
+ * project's calibration explicitly treats as padding.
+ *
+ * `download` has one real branch: `mimeType` defaults to `'text/plain'`
+ * when falsy. That default is pinned here, including that it also fires
+ * for an explicit empty string (the fallback is `||`, not `??`).
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type { BimContext } from '@ifc-lite/sdk';
+import { buildExportNamespace } from './bridge-export.js';
+
+function findMethod(name: string) {
+  const method = buildExportNamespace().methods.find((m) => m.name === name);
+  if (!method) throw new Error(`no such method: ${name}`);
+  return method;
+}
+
+function mockSdk() {
+  return {
+    export: {
+      csv: vi.fn(),
+      json: vi.fn(),
+      ifc: vi.fn(),
+      download: vi.fn(),
+    },
+  } as unknown as BimContext;
+}
+
+describe('bim.export.download — mimeType default', () => {
+  it('passes an explicit mimeType through unchanged', () => {
+    const sdk = mockSdk();
+    findMethod('download').call(sdk, ['hello', 'a.txt', 'application/json']);
+    expect(sdk.export.download).toHaveBeenCalledWith('hello', 'a.txt', 'application/json');
+  });
+
+  it('defaults to text/plain when mimeType is undefined', () => {
+    const sdk = mockSdk();
+    findMethod('download').call(sdk, ['hello', 'a.txt', undefined]);
+    expect(sdk.export.download).toHaveBeenCalledWith('hello', 'a.txt', 'text/plain');
+  });
+
+  it('also defaults to text/plain for an explicit empty string (|| , not ??)', () => {
+    const sdk = mockSdk();
+    findMethod('download').call(sdk, ['hello', 'a.txt', '']);
+    expect(sdk.export.download).toHaveBeenCalledWith('hello', 'a.txt', 'text/plain');
+  });
+});

--- a/packages/sandbox/src/bridge-query.test.ts
+++ b/packages/sandbox/src/bridge-query.test.ts
@@ -1,0 +1,286 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `bim.query` had zero behavioural coverage: `bridge-permissions.test.ts`
+ * only checks `typeof bim.query`, never invoking a `call:` handler.
+ *
+ * Every method that accepts an entity ref guards it through `toRef` and
+ * falls back to either `[]` (array-typed returns) or `null`/an empty
+ * composite (single-value / non-nullable composite returns) when the ref is
+ * unusable. That fallback shape is the one place these 17 near-identical
+ * methods could silently diverge from their own declared `tsReturn` type —
+ * this file pins each fallback against an invalid ref, and pins that a
+ * valid ref reaches the underlying SDK call unmodified.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type { BimContext, EntityData, EntityRef } from '@ifc-lite/sdk';
+import { buildQueryNamespace } from './bridge-query.js';
+
+function findMethod(name: string) {
+  const method = buildQueryNamespace().methods.find((m) => m.name === name);
+  if (!method) throw new Error(`no such method: ${name}`);
+  return method;
+}
+
+const REF: EntityRef = { modelId: 'm1', expressId: 7 };
+const DUMPED_ENTITY = { ref: REF, name: 'Wall' };
+const ENTITY: EntityData = {
+  ref: REF,
+  globalId: 'g1',
+  name: 'Basic Wall',
+  type: 'IfcWall',
+  description: '',
+  objectType: '',
+};
+
+function mockSdk(overrides: Partial<BimContext> = {}): BimContext {
+  return {
+    query: vi.fn(),
+    matchingActiveFilter: vi.fn(),
+    entity: vi.fn(),
+    attributes: vi.fn(),
+    properties: vi.fn(),
+    quantities: vi.fn(),
+    property: vi.fn(),
+    classifications: vi.fn(),
+    materials: vi.fn(),
+    typeProperties: vi.fn(),
+    documents: vi.fn(),
+    relationships: vi.fn(),
+    quantity: vi.fn(),
+    related: vi.fn(),
+    containedIn: vi.fn(),
+    contains: vi.fn(),
+    decomposedBy: vi.fn(),
+    decomposes: vi.fn(),
+    storey: vi.fn(),
+    path: vi.fn(),
+    storeys: vi.fn(),
+    viewer: { getSelection: vi.fn(() => []) },
+    ...overrides,
+  } as unknown as BimContext;
+}
+
+describe('bim.query — invalid-ref fallback shape', () => {
+  // Array-returning methods must fall back to [], matching their `T[]`
+  // tsReturn — a `null` fallback here would violate the declared type for
+  // any script that does `.map()` on the result without a null check.
+  it.each([
+    'attributes',
+    'properties',
+    'quantities',
+    'classifications',
+    'documents',
+    'related',
+    'contains',
+    'decomposes',
+    'path',
+  ])('%s returns [] for an invalid ref, without calling the SDK', (name) => {
+    const sdk = mockSdk();
+    const method = findMethod(name);
+    const args = name === 'related' ? [{}, 'IfcRelAggregates', 'forward'] : [{}];
+    const result = method.call(sdk, args);
+    expect(result).toEqual([]);
+  });
+
+  // Single-value-returning methods must fall back to null, matching their
+  // `T | null` tsReturn.
+  it.each([
+    'property',
+    'materials',
+    'typeProperties',
+    'quantity',
+    'containedIn',
+    'decomposedBy',
+    'storey',
+  ])('%s returns null for an invalid ref, without calling the SDK', (name) => {
+    const sdk = mockSdk();
+    const method = findMethod(name);
+    const args = name === 'property' || name === 'quantity' ? [{}, 'Pset', 'Prop'] : [{}];
+    const result = method.call(sdk, args);
+    expect(result).toBeNull();
+  });
+
+  // `relationships`' tsReturn is the one non-nullable composite in the
+  // family (`BimRelationships`, not `BimRelationships | null`), so its
+  // fallback is a struct of empty arrays rather than null or []. Assert the
+  // exact shape — a bare `{}` or a missing key would still be "falsy-ish"
+  // under a looser assertion but would break a script reading `.voids`.
+  it('relationships returns an all-empty struct for an invalid ref, without calling the SDK', () => {
+    const sdk = mockSdk();
+    const method = findMethod('relationships');
+    const result = method.call(sdk, [{}]);
+    expect(result).toEqual({ voids: [], fills: [], groups: [], connections: [] });
+    expect(sdk.relationships).not.toHaveBeenCalled();
+  });
+
+  it('none of the array/null fallback methods call the underlying SDK method on an invalid ref', () => {
+    const sdk = mockSdk();
+    for (const name of [
+      'attributes', 'properties', 'quantities', 'classifications', 'documents',
+      'related', 'contains', 'decomposes', 'path',
+      'property', 'materials', 'typeProperties', 'quantity', 'containedIn',
+      'decomposedBy', 'storey',
+    ]) {
+      const method = findMethod(name);
+      const args = name === 'related'
+        ? [{}, 'IfcRelAggregates', 'forward']
+        : name === 'property' || name === 'quantity'
+          ? [{}, 'Pset', 'Prop']
+          : [{}];
+      method.call(sdk, args);
+    }
+    expect(sdk.attributes).not.toHaveBeenCalled();
+    expect(sdk.properties).not.toHaveBeenCalled();
+    expect(sdk.quantities).not.toHaveBeenCalled();
+    expect(sdk.classifications).not.toHaveBeenCalled();
+    expect(sdk.documents).not.toHaveBeenCalled();
+    expect(sdk.related).not.toHaveBeenCalled();
+    expect(sdk.contains).not.toHaveBeenCalled();
+    expect(sdk.decomposes).not.toHaveBeenCalled();
+    expect(sdk.path).not.toHaveBeenCalled();
+    expect(sdk.property).not.toHaveBeenCalled();
+    expect(sdk.materials).not.toHaveBeenCalled();
+    expect(sdk.typeProperties).not.toHaveBeenCalled();
+    expect(sdk.quantity).not.toHaveBeenCalled();
+    expect(sdk.containedIn).not.toHaveBeenCalled();
+    expect(sdk.decomposedBy).not.toHaveBeenCalled();
+    expect(sdk.storey).not.toHaveBeenCalled();
+  });
+});
+
+describe('bim.query — valid ref reaches the SDK', () => {
+  it('attributes forwards the resolved ref to sdk.attributes', () => {
+    const sdk = mockSdk({ attributes: vi.fn(() => [{ name: 'Tag', value: 'x' }]) as any });
+    const result = findMethod('attributes').call(sdk, [DUMPED_ENTITY]);
+    expect(sdk.attributes).toHaveBeenCalledWith(REF);
+    expect(result).toEqual([{ name: 'Tag', value: 'x' }]);
+  });
+
+  it('storey unwraps ref, calls sdk.storey, and re-aliases a non-null result', () => {
+    const sdk = mockSdk({ storey: vi.fn(() => ENTITY) as any });
+    const result = findMethod('storey').call(sdk, [DUMPED_ENTITY]) as Record<string, unknown>;
+    expect(sdk.storey).toHaveBeenCalledWith(REF);
+    expect(result.name).toBe('Basic Wall');
+    expect(result.Name).toBe('Basic Wall');
+  });
+});
+
+describe('bim.query.properties / bim.query.quantities — named-property mapping', () => {
+  it('maps every property set through mapNamedProperties and dual name/Name, globalId/GlobalId keys', () => {
+    const sdk = mockSdk({
+      properties: vi.fn(() => [
+        {
+          name: 'Pset_WallCommon',
+          globalId: 'gp1',
+          properties: [{ name: 'IsExternal', value: true, type: 'IfcBoolean' }],
+        },
+      ]) as any,
+    });
+    const result = findMethod('properties').call(sdk, [DUMPED_ENTITY]) as any[];
+    expect(result).toEqual([
+      {
+        name: 'Pset_WallCommon',
+        Name: 'Pset_WallCommon',
+        globalId: 'gp1',
+        GlobalId: 'gp1',
+        properties: [
+          { name: 'IsExternal', Name: 'IsExternal', value: true, Value: true, NominalValue: true, type: 'IfcBoolean', Type: 'IfcBoolean' },
+        ],
+        Properties: [
+          { name: 'IsExternal', Name: 'IsExternal', value: true, Value: true, NominalValue: true, type: 'IfcBoolean', Type: 'IfcBoolean' },
+        ],
+      },
+    ]);
+  });
+
+  it('maps every quantity set through mapNamedProperties and dual name/Name keys', () => {
+    const sdk = mockSdk({
+      quantities: vi.fn(() => [
+        { name: 'Qto_WallBaseQuantities', quantities: [{ name: 'Length', value: 3.2, type: 'IfcLengthMeasure' }] },
+      ]) as any,
+    });
+    const result = findMethod('quantities').call(sdk, [DUMPED_ENTITY]) as any[];
+    expect(result).toEqual([
+      {
+        name: 'Qto_WallBaseQuantities',
+        Name: 'Qto_WallBaseQuantities',
+        quantities: [
+          { name: 'Length', Name: 'Length', value: 3.2, Value: 3.2, NominalValue: 3.2, type: 'IfcLengthMeasure', Type: 'IfcLengthMeasure' },
+        ],
+        Quantities: [
+          { name: 'Length', Name: 'Length', value: 3.2, Value: 3.2, NominalValue: 3.2, type: 'IfcLengthMeasure', Type: 'IfcLengthMeasure' },
+        ],
+      },
+    ]);
+  });
+});
+
+describe('bim.query.byType', () => {
+  it('applies the type filter when types are given', () => {
+    const byType = vi.fn().mockReturnThis();
+    const toArray = vi.fn(() => [ENTITY]);
+    const builder = { byType, toArray };
+    const sdk = mockSdk({ query: vi.fn(() => builder) as any });
+    const result = findMethod('byType').call(sdk, [['IfcWall']]);
+    expect(byType).toHaveBeenCalledWith('IfcWall');
+    expect((result as any[]).map((e) => e.name)).toEqual(['Basic Wall']);
+  });
+
+  it('skips the filter call entirely (returns everything unfiltered) when given zero types', () => {
+    // Documented as "Filter by IFC type" but with an empty type list it is a
+    // no-op passthrough to toArray() — worth pinning explicitly since it is
+    // easy to mistake for "return []".
+    const byType = vi.fn();
+    const toArray = vi.fn(() => [ENTITY]);
+    const builder = { byType, toArray };
+    const sdk = mockSdk({ query: vi.fn(() => builder) as any });
+    const result = findMethod('byType').call(sdk, [[]]);
+    expect(byType).not.toHaveBeenCalled();
+    expect((result as any[]).length).toBe(1);
+  });
+});
+
+describe('bim.query.selection', () => {
+  it('drops selection refs that no longer resolve to an entity', () => {
+    const staleRef: EntityRef = { modelId: 'm1', expressId: 999 };
+    const sdk = mockSdk({
+      viewer: { getSelection: vi.fn(() => [REF, staleRef]) } as any,
+      entity: vi.fn((ref: EntityRef) => (ref.expressId === 7 ? ENTITY : null)) as any,
+    });
+    const result = findMethod('selection').call(sdk, []) as any[];
+    expect(result).toHaveLength(1);
+    expect(result[0].ref).toEqual(REF);
+  });
+
+  it('returns [] when nothing is selected', () => {
+    const sdk = mockSdk({ viewer: { getSelection: vi.fn(() => []) } as any });
+    const result = findMethod('selection').call(sdk, []);
+    expect(result).toEqual([]);
+  });
+});
+
+describe('bim.query.matchingActiveFilter', () => {
+  it('returns null when no filter is active (matches the sdk value, not [])', () => {
+    const sdk = mockSdk({ matchingActiveFilter: vi.fn(() => null) as any });
+    expect(findMethod('matchingActiveFilter').call(sdk, [])).toBeNull();
+  });
+
+  it('re-aliases entities when a filter is active', () => {
+    const sdk = mockSdk({ matchingActiveFilter: vi.fn(() => [ENTITY]) as any });
+    const result = findMethod('matchingActiveFilter').call(sdk, []) as any[];
+    expect(result[0].Name).toBe('Basic Wall');
+  });
+});
+
+describe('bim.query.entity', () => {
+  it('returns null for an unresolved (modelId, expressId) pair without ref validation', () => {
+    const sdk = mockSdk({ entity: vi.fn(() => null) as any });
+    const result = findMethod('entity').call(sdk, ['m1', 999]);
+    expect(sdk.entity).toHaveBeenCalledWith({ modelId: 'm1', expressId: 999 });
+    expect(result).toBeNull();
+  });
+});

--- a/packages/sandbox/src/bridge-viewer.test.ts
+++ b/packages/sandbox/src/bridge-viewer.test.ts
@@ -1,0 +1,88 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `bim.viewer` had zero behavioural coverage. Most methods are thin
+ * passthroughs (`colorize`, `hide`, `show`, `isolate`, `select`, `flyTo`,
+ * `resetColors`, `resetVisibility`) with no independent logic — the
+ * `entityRefs` arg type (unmarshalled in bridge-schema.ts, out of scope
+ * here) already extracts `.ref` before the `call:` handler ever runs, so
+ * there is nothing for a unit test at this layer to catch beyond "the SDK
+ * method was called with the args it was given."
+ *
+ * `colorizeAll` is the one method with real logic in this file: unlike its
+ * siblings it declares its arg as `'dump'` (not `'entityRefs'`), so it does
+ * its own `.ref ?? e` extraction and reshapes `{ entities, color }[]` into
+ * `{ refs, color }[]`. That reshape is pinned here, including the
+ * `.ref ?? e` fallback for bare (unwrapped) entity refs.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type { BimContext, EntityRef } from '@ifc-lite/sdk';
+import { buildViewerNamespace } from './bridge-viewer.js';
+
+function findMethod(name: string) {
+  const method = buildViewerNamespace().methods.find((m) => m.name === name);
+  if (!method) throw new Error(`no such method: ${name}`);
+  return method;
+}
+
+function mockSdk() {
+  return {
+    viewer: {
+      colorize: vi.fn(),
+      colorizeAll: vi.fn(),
+      hide: vi.fn(),
+      show: vi.fn(),
+      isolate: vi.fn(),
+      select: vi.fn(),
+      flyTo: vi.fn(),
+      resetColors: vi.fn(),
+      resetVisibility: vi.fn(),
+    },
+  } as unknown as BimContext;
+}
+
+describe('bim.viewer.colorizeAll — batch reshape', () => {
+  it('extracts .ref from wrapped entities and pairs it with the batch color', () => {
+    const sdk = mockSdk();
+    const refA: EntityRef = { modelId: 'm1', expressId: 1 };
+    const refB: EntityRef = { modelId: 'm1', expressId: 2 };
+    findMethod('colorizeAll').call(sdk, [
+      [
+        { entities: [{ ref: refA, name: 'Wall A' }], color: '#ff0000' },
+        { entities: [{ ref: refB, name: 'Wall B' }], color: '#00ff00' },
+      ],
+    ]);
+    expect(sdk.viewer.colorizeAll).toHaveBeenCalledWith([
+      { refs: [refA], color: '#ff0000' },
+      { refs: [refB], color: '#00ff00' },
+    ]);
+  });
+
+  it('falls back to the bare entity object when .ref is absent, matching the framework entityRefs unmarshal', () => {
+    const sdk = mockSdk();
+    const bareRef = { modelId: 'm1', expressId: 3 };
+    findMethod('colorizeAll').call(sdk, [
+      [{ entities: [bareRef], color: '#0000ff' }],
+    ]);
+    expect(sdk.viewer.colorizeAll).toHaveBeenCalledWith([
+      { refs: [bareRef], color: '#0000ff' },
+    ]);
+  });
+
+  it('maps every entity within every batch, not just the first of each', () => {
+    const sdk = mockSdk();
+    const refs: EntityRef[] = [
+      { modelId: 'm1', expressId: 1 },
+      { modelId: 'm1', expressId: 2 },
+      { modelId: 'm1', expressId: 3 },
+    ];
+    findMethod('colorizeAll').call(sdk, [
+      [{ entities: refs.map((ref) => ({ ref })), color: '#fff' }],
+    ]);
+    const call = (sdk.viewer.colorizeAll as any).mock.calls[0][0];
+    expect(call[0].refs).toEqual(refs);
+  });
+});


### PR DESCRIPTION
`bridge-query.ts`, `bridge-viewer.ts` and `bridge-export.ts` had **no behavioural coverage**. `bridge-permissions.test.ts` only asserts `typeof bim.<ns>` and never invokes a `call:` handler.

Confirmed by mutation before writing anything, rather than inferred from a grep: disabling `byType`'s filter guard left the suite **green at 121/121**, while a control mutation in the already-covered `bridge-helpers.ts` went red — proving the harness reaches this package and the gap is real rather than a broken runner.

## No live defect — and that took checking

The specific thing hunted was a guard differing from its siblings, the shape behind #2334's `addBeam` bug. **It is absent here.**

All 17 ref-taking methods in `bridge-query.ts` call the shared `toRef` and guard `if (!ref)`, and each fallback matches its own declared return type:

- array returns → `[]`
- nullable single values → `null`
- `relationships` (non-nullable) → `{voids:[],fills:[],groups:[],connections:[]}`

Those field names were traced against `sdk/src/types.ts:189` rather than eyeballed. Seventeen near-identical call sites, all correctly aligned — the opposite of `addBeam`.

## What the tests pin, all mutation-verified

- The `[]` vs `null` vs empty-struct fallback split across all 17 methods, and that an invalid ref never reaches the SDK.
- `properties`/`quantities`' `mapNamedProperties` dual-key mapping.
- `byType`'s filtered vs unfiltered paths.
- `selection`'s stale-ref filtering.
- `colorizeAll`'s `{entities,color}[]` → `{refs,color}[]` reshape, including the `.ref ?? e` fallback.
- `download`'s `||` mimeType default — including the empty-string case, which is exactly where `??` would behave differently and is documented as intentional.

Each test was checked by mutating the line it covers and confirming RED. For example, changing the `relationships` fallback fails precisely one test (`relationships returns an all-empty struct for an invalid ref, without calling the SDK`) and nothing else.

## Deliberately not tested

Flagged rather than padded: the seven pure passthrough methods in `bridge-viewer.ts`, `csv`/`json`/`ifc` in `bridge-export.ts`, and **all** of `bridge-files.ts` — one-line forwards to `sdk.*` with no independent logic. A test there would assert only that a call happened, which is noise dressed as coverage.

## Also ruled out with evidence

- None of these modules bypasses `bridge-schema.ts`'s marshal path, so no raw host object reaches sandboxed script.
- `colorizeAll`'s hand-rolled `e.ref ?? e` was compared against the framework's `entityRefs` unmarshal and is **identical** logic — not a divergent guard.

## Verification

**121 → 156 passing across 23 files.** `tsc --noEmit` exit 0. Test-only, so no changeset.
