### PR TITLE
fix(ifcx,collab): a null child mask, and a promotion that dropped data

### DIFF
--- a/.changeset/collab-promote-entity-type-existing-target.md
+++ b/.changeset/collab-promote-entity-type-existing-target.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/collab": patch
+---
+
+Fix `promoteEntityType` silently discarding data when its target path already exists. `createEntity` is documented as idempotent — a pre-existing path is a no-op that returns the existing entity unchanged — but `promoteEntityType` deletes the source path unconditionally before calling it. If the target already existed (e.g. seeded by a concurrent peer, or a prior promotion that landed on the same path), the call reported success with a truthy `Y.Map` while the source entity's carried attributes, children and meta were permanently lost and the target kept its stale data. `promoteEntityType` now throws before deleting the source when the target path is already occupied, matching this file's existing convention of throwing on precondition violations (`setAttribute`, `setChild`, etc.) instead of silently discarding data.

--- a/.changeset/ifcx-composition-child-removal-mask.md
+++ b/.changeset/ifcx-composition-child-removal-mask.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/ifcx": patch
+---
+
+Fix `composeIfcx` and `composeFederated` dropping a `children: { name: null }` removal opinion when the same node also has an `inherits` reference that defines a child of the same name. Attribute removals already survived flattening as a mask so they shadow an inherited value (#1031); the identical `children` removal was deleted at flatten/merge time instead of preserved, so the inherited child silently reappeared in the composed tree. Children now use the same mask-and-resolve pattern as attributes in both composers, so an explicit `null` removes an inherited child too, and a later non-null opinion still resurrects it.

--- a/packages/collab/src/doc/entity.ts
+++ b/packages/collab/src/doc/entity.ts
@@ -179,6 +179,15 @@ export function promoteEntityType(
 ): Y.Map<unknown> | undefined {
   const old = getEntity(doc, oldPath);
   if (!old) return undefined;
+  // createEntity is idempotent — a pre-existing target silently no-ops and
+  // returns the existing entity unmodified. Without this check that no-op
+  // would surface here as "success" (a truthy Y.Map) while oldPath has
+  // already been deleted below, permanently losing its carried state.
+  if (hasEntity(doc, newPath)) {
+    throw new Error(
+      `@ifc-lite/collab: promoteEntityType target "${newPath}" already exists`,
+    );
+  }
 
   const oldAttrs = old.get(ENTITY_KEY.ATTRIBUTES) as Y.Map<unknown> | undefined;
   const oldChildren = old.get(ENTITY_KEY.CHILDREN) as Y.Map<string> | undefined;

--- a/packages/collab/test/schema.test.ts
+++ b/packages/collab/test/schema.test.ts
@@ -111,6 +111,30 @@ describe('entity ops', () => {
     expect(newJson.children).toEqual({ Body: 'body-1' });
   });
 
+  it('promoteEntityType does not silently drop data when the target path already exists', () => {
+    // createEntity is documented as idempotent: a pre-existing target is a
+    // no-op. promoteEntityType builds its "carried" attributes/children/meta
+    // and hands them to createEntity — if it silently no-oped instead of
+    // throwing here, `old` would already be deleted (see below) while
+    // `new`'s stale data survived untouched: a promotion that reports
+    // success (a truthy Y.Map) but permanently loses `old`'s state.
+    const doc = createCollabDoc();
+    createEntity(doc, 'old', {
+      ifcClass: 'IfcWall',
+      attributes: { Name: 'Wall-1' },
+    });
+    // `new` already exists — e.g. seeded by another concurrent operation.
+    createEntity(doc, 'new', { ifcClass: 'IfcSlab' });
+
+    expect(() => promoteEntityType(doc, 'old', 'new', 'IfcCurtainWall')).toThrow(
+      /already exists/,
+    );
+    // Failing loudly must not have deleted `old` on the way: the caller
+    // can retry against a different target path without data loss.
+    expect(entitiesMap(doc).has('old')).toBe(true);
+    expect(entityToJSON(entitiesMap(doc).get('new')!).meta.ifcClass).toBe('IfcSlab');
+  });
+
   it('deleteEntity removes the entity', () => {
     const doc = createCollabDoc();
     createEntity(doc, 'gone');

--- a/packages/ifcx/src/composition.ts
+++ b/packages/ifcx/src/composition.ts
@@ -70,14 +70,12 @@ function flattenNodes(path: string, nodes: IfcxNode[]): PreComposedNode {
   // Later nodes override earlier (layer semantics)
   for (const node of nodes) {
     if (node.children) {
-      for (const [key, value] of Object.entries(node.children)) {
-        if (value === null) {
-          // null means remove this child
-          delete result.children[key];
-        } else {
-          result.children[key] = value;
-        }
-      }
+      // Later wins, INCLUDING null: a null is a removal opinion and must
+      // survive flattening as a mask — composeNode resolves it after
+      // inheritance so a removed child also shadows an inherited child of
+      // the same name, mirroring the attribute mask (#1031). A later
+      // non-null opinion overwrites the mask (resurrect).
+      Object.assign(result.children, node.children);
     }
     if (node.inherits) {
       for (const [key, value] of Object.entries(node.inherits)) {
@@ -163,9 +161,12 @@ function composeNode(
     }
   }
 
-  // Resolve children
+  // Resolve children. A null opinion is a removal mask: it deletes the
+  // (possibly inherited) child and never appears in composed output.
   for (const [name, childPath] of Object.entries(pre.children)) {
-    if (childPath) {
+    if (childPath === null) {
+      node.children.delete(name);
+    } else if (childPath) {
       const child = composeNode(childPath, preComposed, composed, new Set(visited));
       node.children.set(name, child);
     }

--- a/packages/ifcx/src/federated-composition.ts
+++ b/packages/ifcx/src/federated-composition.ts
@@ -215,16 +215,14 @@ function mergeNodesForPath(path: string, layers: IfcxLayer[]): PreComposedNode {
 
     // Process all nodes for this path in this layer
     for (const node of nodes) {
-      // Merge children
+      // Merge children. Null opinions are removal masks that must stay in
+      // pre.children: resolveInheritance only copies inherited children for
+      // ABSENT keys, so the mask shadows an inherited child of the same
+      // name too (mirrors the attribute mask, #1031); composeNode drops
+      // masks from the final output. A later non-null opinion overwrites
+      // the mask (resurrect).
       if (node.children) {
-        for (const [key, value] of Object.entries(node.children)) {
-          if (value === null) {
-            // null removes the child
-            delete result.children[key];
-          } else {
-            result.children[key] = value;
-          }
-        }
+        Object.assign(result.children, node.children);
       }
 
       // Merge inherits

--- a/packages/ifcx/src/tombstones.test.ts
+++ b/packages/ifcx/src/tombstones.test.ts
@@ -228,6 +228,56 @@ describe('null attribute opinions compose as removals (#1031)', () => {
     assert.ok(fedWall);
     assert.strictEqual(fedWall.attributes.has('bsi::ifc::prop::FireRating'), false, 'composeFederated');
   });
+
+  it('null removals mask INHERITED children too (both composers)', () => {
+    // Mirrors the attribute case above: a null child opinion is a removal
+    // that must shadow a child of the same name coming from `inherits`,
+    // not just one defined directly on the node.
+    const inheritedChildRemoval: IfcxNode[] = [
+      { path: 'base-type', children: { Opening: 'opening-1' }, attributes: {} },
+      { path: 'opening-1', attributes: { 'bsi::ifc::class': { code: 'IfcOpeningElement', uri: 'u' } } },
+      {
+        path: 'wall-9',
+        inherits: { Type: 'base-type' },
+        children: { Opening: null },
+        attributes: { 'bsi::ifc::prop::Name': 'W9' },
+      },
+    ];
+
+    const composed = composeIfcx(makeFile(inheritedChildRemoval, 'inherit-child-removal'));
+    const wall = composed.get('wall-9');
+    assert.ok(wall);
+    assert.strictEqual(wall.children.has('Opening'), false, 'composeIfcx');
+    assert.strictEqual(wall.attributes.get('bsi::ifc::prop::Name'), 'W9');
+
+    const stack = createLayerStack();
+    stack.addLayerAt(
+      makeFile(inheritedChildRemoval, 'inherit-child-removal'),
+      new ArrayBuffer(0),
+      'layer-0',
+      0,
+      { type: 'buffer', name: 'layer-0' }
+    );
+    const federated = composeFederated(stack);
+    const fedWall = federated.composed.get('wall-9');
+    assert.ok(fedWall);
+    assert.strictEqual(fedWall.children.has('Opening'), false, 'composeFederated');
+  });
+
+  it('a later non-null child opinion resurrects a removed child', () => {
+    const resurrectChild: IfcxNode[] = [
+      { path: 'base-type', children: { Opening: 'opening-1' }, attributes: {} },
+      { path: 'opening-1', attributes: {} },
+      { path: 'opening-2', attributes: {} },
+      { path: 'wall-9', inherits: { Type: 'base-type' }, children: { Opening: null }, attributes: {} },
+      { path: 'wall-9', children: { Opening: 'opening-2' }, attributes: {} },
+    ];
+
+    const composed = composeIfcx(makeFile(resurrectChild, 'resurrect-child'));
+    const wall = composed.get('wall-9');
+    assert.ok(wall);
+    assert.strictEqual(wall.children.get('Opening')?.path, 'opening-2');
+  });
 });
 
 describe('bakeLayers (tombstone-free materialization)', () => {


### PR DESCRIPTION
Two packages, two live defects, both found by comparing a guard against its own sibling.

## 1. `packages/ifcx` — a null child mask is dropped, so a removed child comes back

`composition.ts` and `federated-composition.ts` dropped a `children: { name: null }` removal opinion during flatten/merge. So a child **removed** on a node that also `inherits` from a node defining that child **reappeared** in the composed tree.

This is the **#1031 shape exactly**: a `null` must survive flattening as a *mask*, so it shadows an **inherited** value and not merely an own one. That fix was applied to `attributes` — and never to `children`, in either composer.

Probed against the unfixed code, with `Base.children.Foo = 'foo-1'`, `Wall.inherits.typeRef = 'Base'`, `Wall.children.Foo = null`:

```
wall.children.has('Foo')  ->  true      (should be false)
```

**Sibling control**, the identical scenario for attributes (`FireRating: null` masking an inherited value): correctly `false`. So this is a proven asymmetry between the two, not a general masking failure.

**Blast radius, traced rather than assumed:** no producer in this repo emits `children: {x: null}` together with `inherits` on the same node — checked collab's snapshot writers, `from-step`, and the MCP tools. So it's a real defect in the shipped `composeIfcx`/`composeFederated` public API, reachable today by hand-authored IFCX or direct SDK use, but not currently triggered by any in-repo pipeline.

## 2. `packages/collab` — a promotion that reports success and loses the data

`promoteEntityType` deleted `oldPath` and then called `createEntity(newPath, …)` — which is **documented as idempotent**: an existing path is a silent no-op that returns the existing entity.

So when `newPath` already existed — a concurrent peer created it, or an earlier promotion already landed — the function returned a truthy `Y.Map` that looks like success, the promotion never happened, and `oldPath`'s state was already gone. Success reported, data lost.

It now throws **before deleting anything**, matching this file's own convention: `setAttribute`, `setChild` and `setInherit` all throw on a precondition violation rather than no-op. The test asserts `old` **survives** the failed call, so a partial deletion would fail it.

**Blast radius:** `promoteEntityType` has no callers anywhere in `packages/` or `apps/` — a dormant public API, presumably for a future type-promotion UI. Zero impact today; it would corrupt the first real caller's data on the first path collision.

## Verification

**ifcx 117 → 119 passing. collab 216 → 217 passing / 2 skipped.** `tsc --noEmit` exit 0 for both. Two patch changesets. Both fixes RED-verified against unfixed code.

## Coverage gaps found while in there — reported, not filled

- `packages/ifcx`'s `provenance.ts` has no direct *or* indirect unit coverage in-package, despite being consumed by collab's `publish-layer.ts` and by `collab-server`.
- `packages/collab`'s three provider adapters (`indexeddb`, `webrtc`, `websocket`) are untested, though they're thin wrappers over their upstream `y-*` libraries.

## Not reached — so not to be read as clean

collab's `awareness/`, `security/`, `federation/`, `sync/`, `privacy.ts`, `undo.ts`, `viewer-bridge.ts`, `conflicts/detector.ts` and `mutations/bind.ts`.

## Verified clean

`structured-attrs.ts` (the #1031/#2279 territory) is already deliberately hardened, with comments citing the exact edge cases — vacuous `.every()` on `[]`, legacy flat migration values. `entity.ts`'s `deletePropertyValue`/`deleteQuantityValue` cleanup is genuinely symmetric, as its comment claims. And `test/convergence-property.test.ts` already runs a seeded 3-peer/30-round trace applying ops in different sync orders and asserting deep-equal snapshots — that's precisely the CRDT convergence property worth having, so I didn't duplicate it.
