### PR TITLE
fix(collab): flag quantity conflicts, and redact annotation authors

### DIFF
--- a/.changeset/collab-quantity-conflict-and-annotation-redaction.md
+++ b/.changeset/collab-quantity-conflict-and-annotation-redaction.md
@@ -1,0 +1,8 @@
+---
+"@ifc-lite/collab": patch
+---
+
+Fix two gaps found while auditing files with no direct test coverage:
+
+- `createConflictDetector` classified concurrent writes to a Pset property as a `pset-property` conflict but had no matching case for the structurally identical Qset (quantity) shape — concurrent quantity writes from two peers landed silently with no conflict event, a false negative. `classify()` now handles `ENTITY_KEY.QUANTITIES` the same way it handles `ENTITY_KEY.PSETS`, emitting a new `quantity` `ConflictKind`.
+- `redactAuthorMeta` (the "anonymise this project" GDPR helper) blanked `createdBy`/`lastEditedBy` on every entity but never touched the `annotations` map, so a markup pin's `authorId`/`authorName` (real display name) survived redaction untouched. It now blanks both fields on every annotation alongside the existing entity-meta redaction; annotation `note` text and position are left as-is.

--- a/packages/collab/src/conflicts/detector.ts
+++ b/packages/collab/src/conflicts/detector.ts
@@ -35,6 +35,7 @@ import {
 export type ConflictKind =
   | 'attribute'
   | 'pset-property'
+  | 'quantity'
   | 'hierarchy'
   | 'geometry-blob'
   | 'geometry-param'
@@ -239,6 +240,10 @@ function classify(
           // the pset name as the field — useful when two peers seed the
           // same Pset concurrently.
           return key ? { kind: 'pset-property', path: entityPath, field: key } : null;
+        case ENTITY_KEY.QUANTITIES:
+          // Mirrors PSETS above: a new (or replaced) Qset Y.Map at the
+          // entity level, keyed by qset name.
+          return key ? { kind: 'quantity', path: entityPath, field: key } : null;
         default:
           return null;
       }
@@ -247,6 +252,12 @@ function classify(
       const psetName = path[2];
       return key
         ? { kind: 'pset-property', path: entityPath, field: `${psetName}.${key}` }
+        : null;
+    }
+    if (path.length === 3 && subMap === ENTITY_KEY.QUANTITIES) {
+      const qsetName = path[2];
+      return key
+        ? { kind: 'quantity', path: entityPath, field: `${qsetName}.${key}` }
         : null;
     }
     return null;

--- a/packages/collab/src/privacy.ts
+++ b/packages/collab/src/privacy.ts
@@ -21,6 +21,7 @@
 import type { IfcxFile } from '@ifc-lite/ifcx';
 import type { CollabSession } from './session.js';
 import { snapshotToIfcx, type SnapshotOptions } from './snapshot/to-ifcx.js';
+import { TOP } from './doc/schema.js';
 
 export interface ExportAndLeaveOptions {
   /** Forwarded to `snapshotToIfcx`. */
@@ -73,16 +74,19 @@ export async function exportAndLeave(
 
 /**
  * Strip user-attributable metadata from a Y.Doc: per-entity `meta` keys
- * `createdBy` / `lastEditedBy` are blanked. Useful for "anonymise this
- * project" exports. Returns the number of entities touched.
+ * `createdBy` / `lastEditedBy`, and per-annotation `authorId` / `authorName`,
+ * are blanked. Useful for "anonymise this project" exports. Returns the
+ * number of entities + annotations touched.
  *
  * Note: this does NOT touch the underlying CRDT struct authorship
  * (clientID is intrinsic to Yjs's merge semantics and removing it
  * would corrupt the doc). For a proper anonymised export, snapshot
- * to IFCX first — the IFCX serialiser drops clientIDs by design.
+ * to IFCX first — the IFCX serialiser drops clientIDs by design (and
+ * doesn't carry annotations at all — markup ≠ BIM, see doc/annotation.ts).
  */
 export function redactAuthorMeta(session: CollabSession): number {
   const ents = session.doc.getMap('entities');
+  const annotations = session.doc.getMap(TOP.ANNOTATIONS);
   let touched = 0;
   session.doc.transact(() => {
     ents.forEach((entUntyped) => {
@@ -96,6 +100,19 @@ export function redactAuthorMeta(session: CollabSession): number {
       }
       if (meta.has('lastEditedBy')) {
         meta.set('lastEditedBy', null);
+        changed = true;
+      }
+      if (changed) touched += 1;
+    });
+    annotations.forEach((annUntyped) => {
+      const ann = annUntyped as import('yjs').Map<unknown>;
+      let changed = false;
+      if (ann.has('authorId') && ann.get('authorId') !== '') {
+        ann.set('authorId', '');
+        changed = true;
+      }
+      if (ann.has('authorName') && ann.get('authorName') !== '') {
+        ann.set('authorName', '');
         changed = true;
       }
       if (changed) touched += 1;

--- a/packages/collab/test/conflict-scenarios.test.ts
+++ b/packages/collab/test/conflict-scenarios.test.ts
@@ -23,6 +23,7 @@ import {
   setAttribute,
   setChild,
   setPropertyValue,
+  setQuantityValue,
 } from '../src/doc/entity.js';
 import { createGeometry, setGeometryBlobHash, setGeometryParam } from '../src/doc/geometry.js';
 import { addTarget, createRelationship, removeTarget } from '../src/doc/relationship.js';
@@ -130,6 +131,50 @@ describe('conflict scenarios', () => {
             e.kind === 'pset-property' &&
             e.path === 'wall' &&
             e.field === 'Pset_WallCommon',
+        ),
+      ).toBe(true);
+    }
+  });
+
+  it('quantity: concurrent quantity writes inside an existing Qset', () => {
+    const h = harness();
+    shareEntity(h, 'wall');
+    // Seed the Qset on A first so both peers share the same Qset Y.Map.
+    h.a.transact(() => setQuantityValue(h.a, 'wall', 'Qto_WallBaseQuantities', 'GrossArea', 10));
+    h.sync();
+
+    h.a.transact(() => setQuantityValue(h.a, 'wall', 'Qto_WallBaseQuantities', 'GrossArea', 20));
+    h.b.transact(() => setQuantityValue(h.b, 'wall', 'Qto_WallBaseQuantities', 'GrossArea', 30));
+    h.sync();
+
+    for (const events of [h.aEvents, h.bEvents]) {
+      expect(
+        events.some(
+          (e) =>
+            e.kind === 'quantity' &&
+            e.path === 'wall' &&
+            e.field === 'Qto_WallBaseQuantities.GrossArea',
+        ),
+      ).toBe(true);
+    }
+  });
+
+  it('quantity: concurrent Qset creation surfaces at the Qset name', () => {
+    const h = harness();
+    shareEntity(h, 'wall');
+
+    // Both peers seed the same Qset name without a prior shared Y.Map.
+    h.a.transact(() => setQuantityValue(h.a, 'wall', 'Qto_WallBaseQuantities', 'GrossArea', 10));
+    h.b.transact(() => setQuantityValue(h.b, 'wall', 'Qto_WallBaseQuantities', 'GrossArea', 20));
+    h.sync();
+
+    for (const events of [h.aEvents, h.bEvents]) {
+      expect(
+        events.some(
+          (e) =>
+            e.kind === 'quantity' &&
+            e.path === 'wall' &&
+            e.field === 'Qto_WallBaseQuantities',
         ),
       ).toBe(true);
     }

--- a/packages/collab/test/mutations-bind.test.ts
+++ b/packages/collab/test/mutations-bind.test.ts
@@ -84,4 +84,30 @@ describe('bindMutationsToCollab', () => {
 
     session.dispose();
   });
+
+  it('onlyWhenConnected: memory provider skips the mirror, local view still updates', async () => {
+    const session = await createCollabSession({
+      roomId: 'r4',
+      user: { id: 'u', name: 'U' },
+      provider: 'memory',
+    });
+    session.transact(() => createEntity(session.doc, 'w', { ifcClass: 'IfcWall' }));
+
+    const view = new MutablePropertyView(null, 'model-1');
+    view.setOnDemandExtractor(() => []);
+
+    const bound = bindMutationsToCollab(view, session, {
+      resolveEntity: () => 'w',
+      onlyWhenConnected: true,
+    });
+
+    bound.setProperty(1, 'P', 'X', 'v', PropertyValueType.Label);
+
+    // Local (legacy) view always updates regardless of mirror gating.
+    expect(view.getPropertyValue(1, 'P', 'X')).toBe('v');
+    // Y.Doc mirror is skipped: provider is 'memory', not connected.
+    expect(getPropertyValue(session.doc, 'w', 'P', 'X')).toBeUndefined();
+
+    session.dispose();
+  });
 });

--- a/packages/collab/test/privacy.test.ts
+++ b/packages/collab/test/privacy.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { createCollabSession } from '../src/session.js';
 import { createEntity, setAttribute, entityToJSON } from '../src/doc/entity.js';
 import { entitiesMap } from '../src/doc/schema.js';
+import { createAnnotation, getAnnotation } from '../src/doc/annotation.js';
 import { exportAndLeave, redactAuthorMeta } from '../src/privacy.js';
 
 describe('privacy / GDPR helpers', () => {
@@ -72,6 +73,34 @@ describe('privacy / GDPR helpers', () => {
     const a = entityToJSON(entitiesMap(session.doc).get('a')!);
     expect(a.meta.createdBy).toBeNull();
     expect(a.meta.lastEditedBy).toBeNull();
+    session.dispose();
+  });
+
+  it('redactAuthorMeta also blanks annotation authorId / authorName, leaving the note body intact', async () => {
+    const session = await createCollabSession({
+      roomId: 'r5',
+      user: { id: 'sven', name: 'Sven' },
+      provider: 'memory',
+    });
+    session.transact(() => {
+      createAnnotation(session.doc, 'pin-1', {
+        position: { x: 0, y: 0, z: 0 },
+        note: 'leaky pipe here',
+        authorId: 'sven',
+        authorName: 'Sven Realname',
+        authorColor: '#fff',
+        createdAt: 1,
+        updatedAt: 1,
+      });
+    });
+    const touched = redactAuthorMeta(session);
+    expect(touched).toBe(1);
+    const ann = getAnnotation(session.doc, 'pin-1')!;
+    expect(ann.authorId).toBe('');
+    expect(ann.authorName).toBe('');
+    // Only authorship is redacted — the pin content and position survive.
+    expect(ann.note).toBe('leaky pipe here');
+    expect(ann.position).toEqual({ x: 0, y: 0, z: 0 });
     session.dispose();
   });
 });

--- a/packages/collab/test/viewer-bridge.test.ts
+++ b/packages/collab/test/viewer-bridge.test.ts
@@ -173,4 +173,50 @@ describe('mountPresenceInViewer', () => {
     expect(container.children.length).toBe(0);
     session.dispose();
   });
+
+  it('raycastToWorld: publishes cursor3d on hit, keeps last value on miss, clears on mouseleave', async () => {
+    const session = await createCollabSession({
+      roomId: 'r-ray',
+      user: { id: 'u', name: 'U' },
+      provider: 'memory',
+      presence: { updateRateHz: 1000 },
+    });
+
+    const container = (
+      globalThis as unknown as { document: { createElement: (t: string) => unknown } }
+    ).document.createElement('div') as {
+      appendChild: (c: unknown) => void;
+      dispatchEvent: (e: unknown) => boolean;
+      querySelector: (s: string) => unknown;
+      children: unknown[];
+    };
+
+    let nextHit: { x: number; y: number; z: number } | null = { x: 1, y: 2, z: 3 };
+    const teardown = mountPresenceInViewer({
+      session,
+      container: container as unknown as HTMLElement,
+      viewport: 'plan',
+      raycastToWorld: () => nextHit,
+    });
+
+    const M = (globalThis as unknown as { MouseEvent: new (t: string, i?: object) => unknown }).MouseEvent;
+    container.dispatchEvent(new M('mousemove', { clientX: 10, clientY: 20 }));
+    await new Promise((r) => setTimeout(r, 30));
+    expect(session.presence.getSelf()?.cursor3d).toEqual({ x: 1, y: 2, z: 3 });
+    // cursor2d must NOT be published in raycast mode.
+    expect(session.presence.getSelf()?.cursor2d).toBeUndefined();
+
+    // A ray miss must leave the previously-published cursor3d in place.
+    nextHit = null;
+    container.dispatchEvent(new M('mousemove', { clientX: 11, clientY: 21 }));
+    await new Promise((r) => setTimeout(r, 30));
+    expect(session.presence.getSelf()?.cursor3d).toEqual({ x: 1, y: 2, z: 3 });
+
+    container.dispatchEvent(new M('mouseleave'));
+    await new Promise((r) => setTimeout(r, 30));
+    expect(session.presence.getSelf()?.cursor3d).toBeUndefined();
+
+    teardown();
+    session.dispose();
+  });
 });


### PR DESCRIPTION
Two live defects, both the same shape: a rule applied to one branch of a pair and never to its structural twin.

## 1. `conflicts/detector.ts` — quantity conflicts were never flagged

`classify()` handled `ENTITY_KEY.PSETS` at both the entity level and the `psetName.propName` level, emitting a `pset-property` conflict. `ENTITY_KEY.QUANTITIES` has the **identical nesting** (`qsetName → qtyName → number`, written by `setQuantityValue` in `doc/entity.ts`) and had **no case at all** — it fell through to `default: return null`.

Probed on the unfixed code, two peers concurrently writing the same `Qto_WallBaseQuantities.GrossArea`:

```
aEvents: []
```

A false negative — which this file's own comments call out as the worse failure mode for a conflict detector, since a missed conflict is invisible while a spurious one is merely noise.

**Blast radius: advisory only.** The CRDT still converges correctly; what was wrong is the audit trail — two people editing quantities concurrently got no conflict badge. Added a `quantity` `ConflictKind` mirroring `PSETS` at both nesting depths.

## 2. `privacy.ts` — the anonymiser left real names behind

`redactAuthorMeta()`, the GDPR "anonymise this project" helper, walked only `doc.getMap('entities')` and blanked `meta.createdBy`/`meta.lastEditedBy`. It never touched the separate top-level `annotations` map, whose records carry `authorId` and `authorName` — a real display name.

Probed on the unfixed code, **after** calling `redactAuthorMeta`:

```json
"authorId":"sven","authorName":"Sven Realname"
```

A redaction helper that leaves the name it exists to remove. Now blanks both on every annotation in the same transaction, leaving `note` and `position` untouched.

## Verification

Both RED-verified: **3 failures against unfixed production** (2 quantity, 1 annotation), 0 after. **216 → 221 passing / 2 skipped across 44 files.** `tsc --noEmit` exit 0. Patch changeset.

## Also included — coverage only, no production change

Both mutation-checked so the assertions can actually fail:

- `mutations/bind.ts`'s `onlyWhenConnected`/`shouldMirror` had no tests. Mutating the `provider !== 'memory'` check to `return true` fails the new one.
- `viewer-bridge.ts`'s `raycastToWorld` path (publish on hit, keep-last on miss, clear on mouseleave) had no tests — only the `cursor2d` fallback did. Removing the `if (hit)` guard fails the new one.

## Reported and deliberately NOT fixed — your call

`packages/ifcx/src/provenance.ts`'s `validateProvenance` checks `merge.resolutions` and `merge.waived_checks` only with `Array.isArray`, never per entry — unlike `identity_map` and `checks` **in the same function**, which are deep-validated, and unlike the strict body parser in `collab-server/src/layer-registry-route.ts`. It accepts this with zero errors:

```js
[{ notEntity: true, choice: 'nuke' }, 42, null]
```

Traced before deciding: `assertPushableLayer` is the only consumer treating this as an untrusted-input gate, nothing in-repo constructs a `merge` record yet (the feature isn't wired end to end), and the viewer's provenance panel only reads `.length`/`.into`/`.resolver`. So I left it as a reported gap rather than shipping a third production change I couldn't tie to a live consumer — happy to add the deep validation if you'd rather have it now, since it's consistent with what the same function already does for `identity_map`.

Separately: **`provenance.ts` has no direct or indirect unit coverage in-package**, confirmed by mutation — breaking its version check leaves all 117 ifcx tests green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection and reporting for conflicts involving quantity updates and concurrent quantity-set creation.
  * Annotation privacy redaction now removes author IDs and names while preserving notes and positions.

* **Bug Fixes**
  * Disconnected mutations marked as connection-dependent no longer mirror to shared documents.
  * Viewer cursor presence now correctly handles 3D raycast hits, misses, and mouse-leave events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->