### PR TITLE
test(plugin-api): cover the version gate that decides plugin registration

### DIFF
--- a/packages/plugin-api/test/version.test.ts
+++ b/packages/plugin-api/test/version.test.ts
@@ -1,0 +1,100 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `satisfiesCaretRange` is the runtime gate `apps/viewer/src/services/sources/
+ * source-host.ts` uses to decide whether a provider manifest is allowed to
+ * register against this host (`satisfiesCaretRange(PLUGIN_API_VERSION,
+ * manifest.api)`). Before this file, neither it nor `matchesGlob` had any
+ * behavioural coverage in this package — a broken major-version check (e.g.
+ * always returning true) passed the full test suite unchanged.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { satisfiesCaretRange, matchesGlob, PLUGIN_API_VERSION } from '../src/version.js';
+
+describe('satisfiesCaretRange', () => {
+  it('accepts an exact match', () => {
+    expect(satisfiesCaretRange('2.0.0', '^2.0.0')).toBe(true);
+  });
+
+  it('accepts a host with a higher patch', () => {
+    expect(satisfiesCaretRange('2.0.5', '^2.0.0')).toBe(true);
+  });
+
+  it('rejects a host with a lower patch', () => {
+    expect(satisfiesCaretRange('2.0.0', '^2.0.5')).toBe(false);
+  });
+
+  it('accepts a host with a higher minor, regardless of patch', () => {
+    expect(satisfiesCaretRange('2.5.0', '^2.1.9')).toBe(true);
+  });
+
+  it('rejects a host with a lower minor', () => {
+    expect(satisfiesCaretRange('2.0.9', '^2.1.0')).toBe(false);
+  });
+
+  it('rejects a lower major, even with a much higher minor/patch', () => {
+    expect(satisfiesCaretRange('1.99.99', '^2.0.0')).toBe(false);
+  });
+
+  it('rejects a higher major (caret ranges do not span majors)', () => {
+    expect(satisfiesCaretRange('3.0.0', '^2.0.0')).toBe(false);
+  });
+
+  it('accepts the range without a leading caret', () => {
+    expect(satisfiesCaretRange('2.0.0', '2.0.0')).toBe(true);
+  });
+
+  it('rejects a malformed required range', () => {
+    expect(satisfiesCaretRange('2.0.0', '^2.x')).toBe(false);
+    expect(satisfiesCaretRange('2.0.0', '')).toBe(false);
+    expect(satisfiesCaretRange('2.0.0', '>=2.0.0')).toBe(false);
+  });
+
+  it('rejects a malformed host version', () => {
+    expect(satisfiesCaretRange('not-a-version', '^2.0.0')).toBe(false);
+    expect(satisfiesCaretRange('', '^2.0.0')).toBe(false);
+  });
+
+  it('gates the package version constant against itself, as source-host.ts does', () => {
+    expect(satisfiesCaretRange(PLUGIN_API_VERSION, `^${PLUGIN_API_VERSION}`)).toBe(true);
+    expect(satisfiesCaretRange(PLUGIN_API_VERSION, '^99.0.0')).toBe(false);
+  });
+});
+
+describe('matchesGlob', () => {
+  it('matches a literal name with no wildcards', () => {
+    expect(matchesGlob('model.ifc', 'model.ifc')).toBe(true);
+    expect(matchesGlob('model.ifc', 'other.ifc')).toBe(false);
+  });
+
+  it('is case-insensitive', () => {
+    expect(matchesGlob('MODEL.IFC', 'model.ifc')).toBe(true);
+  });
+
+  it('expands * to match any run of characters', () => {
+    expect(matchesGlob('model.ifc', '*.ifc')).toBe(true);
+    expect(matchesGlob('model.ifczip', '*.ifc')).toBe(false);
+    expect(matchesGlob('a/b/model.ifc', '*.ifc')).toBe(true);
+  });
+
+  it('expands ? to match exactly one character', () => {
+    expect(matchesGlob('a.ifc', '?.ifc')).toBe(true);
+    expect(matchesGlob('ab.ifc', '?.ifc')).toBe(false);
+    expect(matchesGlob('.ifc', '?.ifc')).toBe(false);
+  });
+
+  it('escapes regex metacharacters in the pattern so they behave as literals', () => {
+    expect(matchesGlob('plan(1).ifc', 'plan(1).ifc')).toBe(true);
+    expect(matchesGlob('plan1.ifc', 'plan(1).ifc')).toBe(false);
+    expect(matchesGlob('a+b.ifc', 'a+b.ifc')).toBe(true);
+    expect(matchesGlob('aXb.ifc', 'a+b.ifc')).toBe(false);
+  });
+
+  it('anchors the match to the full name, not a substring', () => {
+    expect(matchesGlob('prefix-model.ifc', 'model.ifc')).toBe(false);
+    expect(matchesGlob('model.ifc-suffix', 'model.ifc')).toBe(false);
+  });
+});


### PR DESCRIPTION
`version.ts` is the **only runtime logic** in `packages/plugin-api` — `index.ts` is a pure re-export and `types.ts` is declarations only — and it had **zero behavioural coverage**. The package's single test file is entirely `expectTypeOf`, which is erased at runtime.

## Proven, not inferred

Flipping `satisfiesCaretRange`'s major-version rejection from `return false` to `return true` left the suite **green at 10/10**.

Because no covered file existed *inside the package* to calibrate against, the harness itself was separately proven to run — by breaking an `expectTypeOf` assertion in `types.test.ts` and confirming RED. So "green" here meant *untested*, not *no runner*. That distinction has produced phantom results before, so it was worth establishing.

## Why this particular function matters

`apps/viewer/src/services/sources/source-host.ts:91`:

```ts
if (!satisfiesCaretRange(PLUGIN_API_VERSION, manifest.api)) {
```

That is the live gate deciding whether a source plugin may register against the host — a capability boundary with no test behind it.

## What was added

23 tests covering `satisfiesCaretRange`'s major/minor/patch boundaries and malformed input — including the exact self-check shape `source-host.ts` performs — plus `matchesGlob`'s wildcard, anchoring, escaping and case-insensitivity behaviour.

Both mutations now bite:

- The major-gate flip fails **3** tests, including `gates the package version constant against itself, as source-host.ts does`.
- Dropping `matchesGlob`'s wildcard expansion fails **2**.

Restored by file copy each time, `diff` byte-identical.

**Severity: coverage gap, not a live bug.** The logic is correct as written; this pins it.

## Verification

**10 → 44 passing across 4 files.** `tsc --noEmit` exit 0. No changeset — test-only, matching the precedent set by #2279.

## Also audited in the same pass — genuinely clean, no changes

- **`packages/embed-protocol`** — 20/20. Calibration mutation on `isEmbedMessage`'s discriminator failed 1 test (`rejects a foreign source, including near-misses`). The absent version guard is the known #2295 finding and was deliberately not duplicated.
- **`packages/embed-sdk`** — 68/68, and the best-tested of the three. Calibration mutation swapping the response correlation from `responseId` to `requestId` — a sibling-confusion shape, the pattern that produced six live bugs today — failed **9** tests. It already pins origin/source filtering, requestId correlation, timeouts **rejecting** rather than resolving, and destroy-idempotency with timer cleanup. Checked specifically for a retry that could double-apply: there is no retry logic at all.
- `plugin-api`'s `index.ts` and `types.ts` — no runtime logic, so no tests added rather than padding with assertions that a re-export re-exports.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for plugin API version compatibility checks.
  * Verified caret-range matching across version boundaries and malformed inputs.
  * Added tests for glob matching, including wildcards, case-insensitivity, escaped characters, and full-name matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->