### PR TITLE
test(source-fixture): stop four paging checks from passing vacuously

### DIFF
--- a/packages/source-fixture/src/conformance/download.ts
+++ b/packages/source-fixture/src/conformance/download.ts
@@ -57,13 +57,19 @@ export function describeDownloadConformance(
 
       const controller = new AbortController();
       controller.abort();
-      await expect(
-        provider.download(
+      try {
+        await provider.download(
           ctx,
           { projectId: fixtures.projectId, containerId: file.containerId, fileId: file.id },
           { signal: controller.signal },
-        ),
-      ).rejects.toBeTruthy();
+        );
+        expect.fail('download() resolved instead of rejecting on an already-aborted signal');
+      } catch (error) {
+        expect(
+          (error as { name?: unknown } | undefined)?.name,
+          `download() rejected on an already-aborted signal, but not with an abort-specific error: ${String(error)}`,
+        ).toBe('AbortError');
+      }
     });
   });
 }

--- a/packages/source-fixture/src/conformance/paging.ts
+++ b/packages/source-fixture/src/conformance/paging.ts
@@ -36,6 +36,62 @@ export function describePagingConformance(
       assertSameIdSet(paged, bulk, label);
     }
 
+    // Shared tail for the "a real page boundary forces cursor-following to
+    // work" companion checks below: given a `bulk` result already known to
+    // have 2+ items, proves smallPageLimit actually forces more than one
+    // request and that the paged result still reconstructs `bulk` exactly.
+    // Factored out so the four categories below reuse the same assertions
+    // `listProjects` already had instead of four near-identical copies —
+    // duplication is exactly what let this check drift onto only one branch
+    // in the first place.
+    async function assertPagingCrossesBoundary<T extends { id: string }>(
+      label: string,
+      fetchPage: (request: { cursor?: string; limit?: number }) => Promise<Page<T>>,
+      bulk: readonly T[],
+    ): Promise<void> {
+      // Having 2+ items is necessary but NOT sufficient: if the page limit
+      // can hold them all, one response still satisfies the id-set assertion
+      // below and no boundary is ever crossed.
+      expect(
+        smallPageLimit,
+        `smallPageLimit (${smallPageLimit}) must be smaller than the ${bulk.length} ${label} items ` +
+          `available, or a single response satisfies this check and paging is never exercised`,
+      ).toBeLessThan(bulk.length);
+
+      // And the inequality alone is still not enough — a provider that
+      // ignores `limit` returns everything in one response regardless. Count
+      // the requests: crossing a real page boundary means more than one.
+      let requestCount = 0;
+      const paged = await collectAllPages((request) => {
+        requestCount += 1;
+        return fetchPage(request);
+      }, smallPageLimit);
+      expect(
+        requestCount,
+        `${label} answered in a single response despite a page limit smaller than the result ` +
+          "set — its `limit`/cursor handling is not being exercised",
+      ).toBeGreaterThan(1);
+
+      assertNoDuplicateIds(paged, `${label} (multi-page)`);
+      assertSameIdSet(paged, bulk, `${label} (multi-page)`);
+    }
+
+    // Companion to `checkPagingProperty` above: fetches the bulk result,
+    // requires it to actually have 2+ items (the gap `checkPagingProperty`
+    // alone doesn't cover — see `ConformanceFixtures` doc comment), then
+    // forces and verifies a real page boundary via `assertPagingCrossesBoundary`.
+    async function checkPagingForcesBoundary<T extends { id: string }>(
+      label: string,
+      fetchPage: (request: { cursor?: string; limit?: number }) => Promise<Page<T>>,
+    ): Promise<void> {
+      const bulk = await collectAllPages(fetchPage, 10_000);
+      expect(
+        bulk.length,
+        `${label}: fixture must supply at least 2 items to force a real page boundary`,
+      ).toBeGreaterThanOrEqual(2);
+      await assertPagingCrossesBoundary(label, fetchPage, bulk);
+    }
+
     it('listProjects: terminates, dedups, and reconstructs the bulk result', async () => {
       const ctx = createContext();
       await checkPagingProperty('listProjects', (request) => provider.listProjects(ctx, request));
@@ -61,31 +117,7 @@ export function describePagingConformance(
           bulk.some((project) => project.id === fixtures.secondProjectId),
           `secondProjectId ${fixtures.secondProjectId} did not appear in listProjects' results`,
         ).toBe(true);
-        // Having two projects is necessary but NOT sufficient: if the page
-        // limit can hold them all, one response still satisfies the id-set
-        // assertion below and no boundary is ever crossed.
-        expect(
-          smallPageLimit,
-          `smallPageLimit (${smallPageLimit}) must be smaller than the ${bulk.length} projects ` +
-            `available, or a single response satisfies this check and paging is never exercised`,
-        ).toBeLessThan(bulk.length);
-
-        // And the inequality alone is still not enough — a provider that
-        // ignores `limit` returns everything in one response regardless. Count
-        // the requests: crossing a real page boundary means more than one.
-        let requestCount = 0;
-        const paged = await collectAllPages((request) => {
-          requestCount += 1;
-          return provider.listProjects(ctx, request);
-        }, smallPageLimit);
-        expect(
-          requestCount,
-          'listProjects answered in a single response despite a page limit smaller than the ' +
-            'result set — its `limit`/cursor handling is not being exercised',
-        ).toBeGreaterThan(1);
-
-        assertNoDuplicateIds(paged, 'listProjects (multi-page)');
-        assertSameIdSet(paged, bulk, 'listProjects (multi-page)');
+        await assertPagingCrossesBoundary('listProjects', (request) => provider.listProjects(ctx, request), bulk);
       },
     );
 
@@ -96,9 +128,28 @@ export function describePagingConformance(
       );
     });
 
+    // Companion to the check above — see the `checkPagingForcesBoundary` doc
+    // comment and the `listProjects` companion test earlier in this file:
+    // without this, a fixture world with exactly one container at this level
+    // would pass the check above vacuously, never exercising cursor-following
+    // at all.
+    it('listContainers: a real page boundary forces cursor-following to work', async () => {
+      const ctx = createContext();
+      await checkPagingForcesBoundary('listContainers', (request) =>
+        provider.listContainers(ctx, fixtures.projectId, undefined, request),
+      );
+    });
+
     it('listFiles: terminates, dedups, and reconstructs the bulk result', async () => {
       const ctx = createContext();
       await checkPagingProperty('listFiles', (request) =>
+        provider.listFiles(ctx, fixtures.projectId, fixtures.containerWithFilesId, undefined, request),
+      );
+    });
+
+    it('listFiles: a real page boundary forces cursor-following to work', async () => {
+      const ctx = createContext();
+      await checkPagingForcesBoundary('listFiles', (request) =>
         provider.listFiles(ctx, fixtures.projectId, fixtures.containerWithFilesId, undefined, request),
       );
     });
@@ -113,12 +164,31 @@ export function describePagingConformance(
       },
     );
 
+    it.runIf(provider.manifest.capabilities.search && fixtures.searchQuery !== undefined)(
+      'searchFiles: a real page boundary forces cursor-following to work',
+      async () => {
+        const ctx = createContext();
+        await checkPagingForcesBoundary('searchFiles', (request) =>
+          provider.searchFiles!(ctx, fixtures.projectId, fixtures.searchQuery!, undefined, request),
+        );
+      },
+    );
+
     it.runIf(provider.manifest.capabilities.revisionHistory && fixtures.fileWithRevisions !== undefined)(
       'listRevisions: terminates, dedups, and reconstructs the bulk result',
       async () => {
         const ctx = createContext();
         const ref = { projectId: fixtures.projectId, ...fixtures.fileWithRevisions! };
         await checkPagingProperty('listRevisions', (request) => provider.listRevisions!(ctx, ref, request));
+      },
+    );
+
+    it.runIf(provider.manifest.capabilities.revisionHistory && fixtures.fileWithRevisions !== undefined)(
+      'listRevisions: a real page boundary forces cursor-following to work',
+      async () => {
+        const ctx = createContext();
+        const ref = { projectId: fixtures.projectId, ...fixtures.fileWithRevisions! };
+        await checkPagingForcesBoundary('listRevisions', (request) => provider.listRevisions!(ctx, ref, request));
       },
     );
   });


### PR DESCRIPTION
#2281 added a companion check so the `listProjects` paging test cannot pass against a provider that never paginates — asserting `bulk.length >= 2`, `smallPageLimit < bulk.length`, and `requestCount > 1`.

The generic `checkPagingProperty` used for `listContainers`, `listFiles`, `searchFiles` and `listRevisions` **never got the same companion**. Each of those could pass **vacuously** whenever the caller's fixtures happened to supply a single item at that level.

The same rule applied to one branch and never to its four structural twins — the shape behind six live bugs in this repo today.

## Latent, not live — and measured rather than assumed

Today's fixture world supplies ≥ 2 items for every category, so the suite is **not** currently vacuous. Breaking `paginate()` so it never returns a cursor fails **51 of 158**, including all five companion checks.

The exposure is a future adopter of this **reusable** kit whose fixtures are sparser — which is precisely what a conformance kit is for.

## One helper, not four copies

Implemented by extracting the shared tail of #2281's check into `assertPagingCrossesBoundary`, wrapped by `checkPagingForcesBoundary` which adds the `bulk.length >= 2` assertion.

Deliberately **one** helper rather than four near-identical blocks — a duplicated check is exactly what drifted here in the first place. `listProjects` keeps its own inline bulk fetch and `secondProjectId` membership assertion, which are unique to it; its assertions, messages and order are unchanged in effect.

## Two mutation classes, because they're different failures

"Pagination is broken" and "the check is vacuous" are not the same thing, so both were proven:

| Mutation | Result |
|---|---|
| `paginate()` returns no cursor | **51 failed / 107 passed** |
| fixture supplies only 1 revision | **11 failed / 147 passed** |

The second is the one that matters:

```
AssertionError: listRevisions: fixture must supply at least 2 items to force
a real page boundary: expected 1 to be greater than or equal to 2
```

That's the silent pass this exists to prevent, and it's the assertion that would not have existed otherwise.

## Also tightened

`conformance/download.ts`'s already-aborted-signal check used `.rejects.toBeTruthy()` — satisfied by **any** thrown error, verifying neither that the rejection is abort-specific nor that it is prompt. Same un-failable-assertion class you flagged on #2313. It now asserts `error.name === 'AbortError'` and fails explicitly if the call resolves.

**It was not masking anything.** `provider.ts`'s `guard()` checks `signal?.aborted` unconditionally first, ahead of sign-in and failure injection, so no other error could masquerade as an abort. I confirmed the tightened form is meaningful anyway by making `toAbortError` return a plain `Error` without the `AbortError` name — the test then fails in all five suite runs.

## Verification

**138 → 158 passing across 3 files.** `tsc --noEmit` exit 0. Conformance-kit and tests only, no provider production code touched, so no changeset.

## Not touched

`source-dalux`'s `fetchPage` rejecting a complete single-page listing as truncated is already covered by your draft #2253 — found it, confirmed the overlap, left it alone.
