### PR TITLE
fix(viewer): stop modelMinZMeters double-counting the origin shift

### DIFF
--- a/apps/viewer/src/lib/geo/kmz-altitude-hint.test.ts
+++ b/apps/viewer/src/lib/geo/kmz-altitude-hint.test.ts
@@ -70,12 +70,17 @@ describe('modelMinZMeters', () => {
     assert.strictEqual(modelMinZMeters(info), 512.25);
   });
 
-  it('folds the origin shift back in', () => {
+  it('does not double-count the origin shift (originalBounds is already world-frame)', () => {
+    // Producer contract (localParsingUtils.ts createCoordinateInfo):
+    // shiftedBounds = originalBounds - originShift. So a real CoordinateInfo
+    // with this originalBounds/originShift pair has this exact shiftedBounds -
+    // it is not a free variable.
     const info = coordInfo({
       originalBounds: { min: { x: 0, y: 12.25, z: 0 }, max: { x: 5, y: 30, z: 5 } },
+      shiftedBounds: { min: { x: -100, y: -487.75, z: 20 }, max: { x: -95, y: -470, z: 25 } },
       originShift: { x: 100, y: 500, z: -20 },
     });
-    assert.strictEqual(modelMinZMeters(info), 512.25);
+    assert.strictEqual(modelMinZMeters(info), 12.25);
   });
 
   it('folds the wasm RTC offset back in (Z-up z is the vertical component)', () => {

--- a/apps/viewer/src/lib/geo/kmz-altitude-hint.ts
+++ b/apps/viewer/src/lib/geo/kmz-altitude-hint.ts
@@ -41,17 +41,21 @@ export const NEAR_ZERO_ORTHOGONAL_HEIGHT_METERS = 1;
  * Lowest geometry Z of the model in metres, in the IFC world frame.
  *
  * `coordinateInfo.originalBounds` is in the renderer's Y-up frame (vertical =
- * `y`) and has the origin shift and the wasm RTC offset subtracted, so both
- * are folded back in - the exact reconstruction `computeModelCenterInIfcMeters`
- * (reproject.ts) uses for the KMZ placement itself. The RTC offset is stored
- * in IFC Z-up, so its `z` component is the vertical one.
+ * `y`) and is ALREADY in the world frame - the producer
+ * (`createCoordinateInfo`, utils/localParsingUtils.ts) clones the raw mesh
+ * bounds into it and derives `shiftedBounds = originalBounds - originShift`
+ * from it, not the other way round. So only the wasm RTC offset needs to be
+ * folded back in here; adding the origin shift on top of `originalBounds`
+ * would double-count it. This mirrors `computeModelCenterInIfcMeters`
+ * (reproject.ts), where the shift is added to `shiftedBounds` and net cancels
+ * against `originalBounds`. The RTC offset is stored in IFC Z-up, so its `z`
+ * component is the vertical one.
  */
 export function modelMinZMeters(coordinateInfo: CoordinateInfo | undefined): number | null {
   const minY = coordinateInfo?.originalBounds?.min?.y;
   if (minY === undefined || !Number.isFinite(minY)) return null;
-  const shiftY = coordinateInfo?.originShift?.y ?? 0;
   const rtcYupY = coordinateInfo?.wasmRtcOffset?.z ?? 0;
-  const minZ = minY + shiftY + rtcYupY;
+  const minZ = minY + rtcYupY;
   return Number.isFinite(minZ) ? minZ : null;
 }
 


### PR DESCRIPTION
`modelMinZMeters` added `originShift.y` on top of `originalBounds` — but `originalBounds` is **already in the world frame**. The producer (`createCoordinateInfo`, `utils/localParsingUtils.ts`) clones the raw mesh bounds into it and **derives** `shiftedBounds = originalBounds - originShift` from it, not the other way round. Adding the shift back double-counts it.

This is the identical bug **#2302** fixed in `reproject.ts`'s `computeModelCenterInIfcMeters` — in a sibling that was missed. The other two readers of this field, `cesium-placement.ts` and `cesium-bridge.ts`, already read `originalBounds` with no shift addition. One branch of four disagreed.

Probed with a fixture obeying the producer's contract:

```
originalBounds.min.y = 12.25, originShift = { 100, 500, -20 }
modelMinZMeters -> 512.25        (expected 12.25)
```

## The test was pinning the bug

`kmz-altitude-hint.test.ts`'s *"folds the origin shift back in"* asserted `512.25` and **passed** — because its `coordInfo` helper defaulted `shiftedBounds` to an identity box unrelated to `originalBounds`. That's a `CoordinateInfo` the producer cannot emit, since the two fields are defined in terms of each other.

So this PR changes an existing assertion's expected value, which is normally re-baselining a test to match broken code. Three measurements distinguish the two, and all three were run:

| | result |
|---|---|
| old fixture + **unfixed** code | 15 pass / 0 fail — *the test was vacuous* |
| **repaired** fixture + **unfixed** code | 14 pass / **1 fail** — *the repair catches it* |
| repaired fixture + **fixed** code | 15 pass / 0 fail |

The middle row is the one that matters. **The fixture repair, not the expectation change, is what makes the test able to fail** — the corrected expectation then follows from the producer's contract rather than from the new code's output.

Renamed to *"does not double-count the origin shift (originalBounds is already world-frame)"*, since it now asserts the opposite of what its old name claimed. The sibling RTC test is untouched — the RTC offset genuinely **is** subtracted from `originalBounds` and does need folding back, which is why that one was correct all along.

## Blast radius

`modelMinZMeters` → `suggestAbsoluteAltitudeForKmz` → `kmzSuggestsAbsoluteAltitude` → the KMZ export dialog's *"recommend True elevation (MSL)"* hint. A wrong number feeding a boolean threshold, so the dialog could recommend `clampToGround` where `absolute` is correct, or the reverse.

It only bites when `originShift` is nonzero — the large-coordinate precision-recentering path — which is exactly the georeferenced-site population this hint exists for. Not data corruption; a wrong recommendation.

## Verification

**15/15 passing.** `apps/viewer` is `"private": true`, so no changeset.

## Scope

Only `kmz-altitude-hint.ts` and its test. `reproject.ts`, `effective-georef.ts`, `cesium-placement.ts` and `cesium-bridge.ts` are untouched.

Also confirmed while in this area, and deliberately **not** touched: `overlay-parse/symbolic-parse.ts:117`'s `primitiveWorldY !== 0` still treats a legitimate zero elevation as absent — that's issue #2256, sequenced behind #2274.
