### PR TITLE
fix(viewer): stop the terrain-height button double-counting the origin shift

### DIFF
--- a/apps/viewer/src/lib/geo/cesium-placement.test.ts
+++ b/apps/viewer/src/lib/geo/cesium-placement.test.ts
@@ -117,6 +117,9 @@ describe('cesium placement helpers', () => {
     // Use a genuinely non-zero elevation so the anchor term is load-bearing.
     const storeyElevations = new Map([[1, 5]]);
     assert.notStrictEqual(storeyElevations.get(1), 0, 'fixture must use a non-zero storey elevation');
+    // Producer contract (localParsingUtils.ts createCoordinateInfo):
+    // shiftedBounds = originalBounds - originShift. originalBounds is ALREADY
+    // world-frame, so shiftedBounds is not a free variable here.
     const orthogonalHeight = computeOrthogonalHeightForBaseAltitude({
       coordinateInfo: {
         originShift: { x: 0, y: 2, z: 0 },
@@ -125,8 +128,8 @@ describe('cesium placement helpers', () => {
           max: { x: 10, y: 11, z: 10 },
         },
         shiftedBounds: {
-          min: { x: 0, y: -1, z: 0 },
-          max: { x: 10, y: 11, z: 10 },
+          min: { x: 0, y: -3, z: 0 },
+          max: { x: 10, y: 9, z: 10 },
         },
         hasLargeCoordinates: false,
         wasmRtcOffset: { x: 0, y: 0, z: 3 },
@@ -137,8 +140,11 @@ describe('cesium placement helpers', () => {
       targetBaseAltitude: 245,
     });
 
-    // 245 - shiftY(2) - rtcYupY(3) - anchorY(5) = 235 meters; /0.3048 mapUnitScale.
-    assert.strictEqual(orthogonalHeight, 771);
+    // anchorY comes from originalBounds (already world-frame, per
+    // findClampAnchorY/cesium-placement.ts control reads) so originShift
+    // must NOT be subtracted again here — only the RTC offset still needs
+    // folding in: 245 - rtcYupY(3) - anchorY(5) = 237 meters; /0.3048 mapUnitScale.
+    assert.strictEqual(orthogonalHeight, 777.56);
   });
 
   it('computes the IFC origin height from OrthogonalHeight and model center', () => {

--- a/apps/viewer/src/lib/geo/cesium-placement.ts
+++ b/apps/viewer/src/lib/geo/cesium-placement.ts
@@ -147,12 +147,19 @@ export function computeOrthogonalHeightForBaseAltitude({
   storeyElevations,
   targetBaseAltitude,
 }: OrthogonalHeightForBaseAltitudeInput): number {
+  // `originalBounds` is ALREADY in the world frame (see the producer contract
+  // note on `computeModelCenterInIfcMeters` in reproject.ts), so `anchorY`
+  // below is already world-frame. Subtracting `originShift` again here would
+  // double-count it: this mirrors `ifcOriginHeight = orthogonalHeight*scale +
+  // computeModelCenterInIfcMeters(coordinateInfo).ifcZ`, whose `ifcZ` already
+  // folds the shift back into `shiftedBounds` (which cancels against this
+  // function's `originalBounds` read) plus the RTC offset — so only the RTC
+  // offset still needs folding in here, not the shift a second time.
   const bounds = coordinateInfo?.originalBounds;
   const anchorY = findClampAnchorY(bounds, storeyElevations);
-  const shiftY = coordinateInfo?.originShift?.y ?? 0;
   // RTC offset is stored in IFC Z-up; viewer-Y aligns to its Z component.
   const rtcYupY = coordinateInfo?.wasmRtcOffset?.z ?? 0;
-  const orthogonalHeightMeters = targetBaseAltitude - shiftY - rtcYupY - anchorY;
+  const orthogonalHeightMeters = targetBaseAltitude - rtcYupY - anchorY;
 
   return Math.round(
     metersToMapUnits(orthogonalHeightMeters, projectedCRS, lengthUnitScale) * 100,


### PR DESCRIPTION
`computeOrthogonalHeightForBaseAltitude` derived `anchorY` from `originalBounds` — already world-frame — and then subtracted `originShift.y` **again**, double-counting it.

This is the **fourth instance of one arithmetic error**, and the most pointed: the correct sibling is **37 lines up in the same file**. `computeCesiumPlacement` (line 113) reads `originalBounds` with no shift, and was one of the controls I used to diagnose the earlier two.

The first three: `reproject.ts`'s `computeModelCenterInIfcMeters` (#2302), `kmz-altitude-hint.ts`'s `modelMinZMeters` (#2343), and this one — found by a **repo-wide sweep for the shape** rather than by waiting for a fourth report.

## The probe

With a fixture obeying the producer contract (`shiftedBounds = originalBounds - originShift`, `originShift.y = 2`, `wasmRtcOffset.z = 3`), round-tripping the computed height back through `computeIfcOriginHeight` → `computeCesiumPlacement`:

```
anchor lands at 242.999…     (target was 245)
```

Off by exactly `originShift.y`. After the fix it lands at `244.999264` — that residual is the function's own `Math.round(x * 100) / 100`, not a shift error.

## The test pinned the bug — three for three

`cesium-placement.test.ts`'s fixture set `shiftedBounds` **equal to** `originalBounds` while `originShift.y = 2`. The contract requires `min.y = -3, max.y = 9`. A `CoordinateInfo` the producer cannot emit.

Identical trap to #2302 and #2343. In all three cases the test didn't merely fail to catch the bug — it **certified** it, and named it as intended behaviour.

So, the three-way measurement again, since changing an expected value is otherwise indistinguishable from re-baselining:

| | result |
|---|---|
| old fixture + **unfixed** code | 21 pass / 0 fail — *test was vacuous* |
| **repaired** fixture + **unfixed** code | 20 pass / **1 fail**, `771 !== 777.56` |
| repaired fixture + **fixed** code | 21 pass / 0 fail |

## Blast radius — this one *writes*

Unlike #2343's export hint, this changes authored data. `computeOrthogonalHeightForBaseAltitude` is called from `GeoreferencingPanel.tsx:409`, behind the **"set OrthogonalHeight to Cesium terrain elevation"** button.

On any model that triggered the large-coordinate origin shift — real-world-sited georeferenced IFC, precisely the population this feature exists for — that button wrote an `OrthogonalHeight` off by `originShift.y` metres, moving the model's **authored vertical position**. Models with `originShift = {0,0,0}` are unaffected.

## Verification

**21/21 passing** in the touched file. `apps/viewer` is `"private": true`, so no changeset.

## The sweep result, for the record

Roughly **30 non-producer read sites** of `originalBounds`/`shiftedBounds` across `apps/**` and `packages/**` were inventoried and classified. Every other one is correct — `originalBounds` with no shift, `shiftedBounds` with the shift added back, `shiftedBounds` alone in scene-local contexts (camera fit, section cuts, BCF viewpoints), or producer/pass-through code.

The Rust side has no matching reader: its `origin_shift` is a separate, narrower field on `ProcessingResult.metadata` with no reader analog.

So this is now *"we checked them all"* rather than *"we fixed four"* — which was the point of running the sweep instead of fixing #2343 and moving on.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected orthogonal height calculations so placements use accurate world-coordinate values.
  * Fixed altitude results that could be incorrectly offset when an origin shift was already applied.
  * Updated validation coverage to reflect the corrected calculation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->