### PR TITLE
test(viewer): repair five CoordinateInfo fixtures that cannot exist

### DIFF
--- a/apps/viewer/src/hooks/ingest/federationRealign.test.ts
+++ b/apps/viewer/src/hooks/ingest/federationRealign.test.ts
@@ -209,7 +209,14 @@ function federation(): { models: Map<string, TestModel>; x: TestModel; a: TestMo
   );
   const a = model(
     [boxMesh(21, [7, 0, -3], [-1, 0, 4])],
-    coordinateInfo({ originShift: { x: 20, y: 0, z: -5 } }),
+    // shiftedBounds = originalBounds - originShift (createCoordinateInfo's
+    // invariant); realignFederationModels only round-trips this field
+    // opaquely (never reads it), but a fixture no producer could emit is
+    // still worth avoiding.
+    coordinateInfo({
+      originShift: { x: 20, y: 0, z: -5 },
+      shiftedBounds: { min: { x: -20, y: 0, z: 5 }, max: { x: -19, y: 1, z: 6 } },
+    }),
     georef({ eastings: 0, northings: 800 }),
   );
   const models = new Map<string, TestModel>([['X', x], ['A', a]]);

--- a/apps/viewer/src/hooks/ingest/pointCloudAlignment.test.ts
+++ b/apps/viewer/src/hooks/ingest/pointCloudAlignment.test.ts
@@ -199,8 +199,12 @@ describe('computePointCloudAlignment (issue #1804)', () => {
     const georef = makeGeoref({
       coordinateInfo: {
         originShift: { x: 3, y: 0, z: -4 },
+        // shiftedBounds = originalBounds - originShift (createCoordinateInfo's
+        // invariant); computePointCloudAlignment never reads either bounds
+        // field (only originShift/wasmRtcOffset), but a fixture no producer
+        // could emit is still worth avoiding.
         originalBounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 0, y: 0, z: 0 } },
-        shiftedBounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 0, y: 0, z: 0 } },
+        shiftedBounds: { min: { x: -3, y: 0, z: 4 }, max: { x: -3, y: 0, z: 4 } },
         hasLargeCoordinates: false,
         wasmRtcOffset: { x: 120, y: -75, z: 6 },
       },

--- a/apps/viewer/src/lib/geo/ifc-origin.test.ts
+++ b/apps/viewer/src/lib/geo/ifc-origin.test.ts
@@ -46,6 +46,11 @@ describe('computeIfcOriginViewerPosition', () => {
       coordinateInfo: {
         ...emptyCoordinateInfo(),
         originShift: { x: 50, y: 3, z: -20 },
+        // shiftedBounds = originalBounds - originShift (createCoordinateInfo's
+        // invariant); computeIfcOriginViewerPosition never reads either
+        // bounds field, but a fixture no producer could emit is still worth
+        // avoiding.
+        shiftedBounds: { min: { x: -50, y: -3, z: 20 }, max: { x: -50, y: -3, z: 20 } },
         wasmRtcOffset: { x: 10, y: 7, z: -4 },
       },
     };
@@ -61,7 +66,13 @@ describe('computeIfcOriginViewerPosition', () => {
   it('treats the anchor model as its own frame even with georef present', async () => {
     const conversion = makeConversion(155000, 463000);
     const model: ModelGeorefInput = {
-      coordinateInfo: { ...emptyCoordinateInfo(), originShift: { x: 1, y: 2, z: 3 } },
+      coordinateInfo: {
+        ...emptyCoordinateInfo(),
+        originShift: { x: 1, y: 2, z: 3 },
+        // shiftedBounds = originalBounds - originShift; unused by this path
+        // but kept consistent with the producer's invariant.
+        shiftedBounds: { min: { x: -1, y: -2, z: -3 }, max: { x: -1, y: -2, z: -3 } },
+      },
       mapConversion: conversion,
       projectedCRS: rdCrs(),
       lengthUnitScale: 1,
@@ -205,7 +216,13 @@ describe('computeIfcOriginViewerPosition', () => {
 
   it('falls back to the model own frame when the anchor lacks georef', async () => {
     const model: ModelGeorefInput = {
-      coordinateInfo: { ...emptyCoordinateInfo(), originShift: { x: 99, y: 1, z: 2 } },
+      coordinateInfo: {
+        ...emptyCoordinateInfo(),
+        originShift: { x: 99, y: 1, z: 2 },
+        // shiftedBounds = originalBounds - originShift; unused by this path
+        // but kept consistent with the producer's invariant.
+        shiftedBounds: { min: { x: -99, y: -1, z: -2 }, max: { x: -99, y: -1, z: -2 } },
+      },
       mapConversion: makeConversion(1, 2),
       projectedCRS: rdCrs(),
       lengthUnitScale: 1,

--- a/apps/viewer/src/lib/geo/reproject.test.ts
+++ b/apps/viewer/src/lib/geo/reproject.test.ts
@@ -355,9 +355,13 @@ describe('reproject helpers', () => {
     };
     const coordinateInfo: CoordinateInfo = {
       // Non-zero shift and RTC so dropping either term is detectable.
+      // shiftedBounds = originalBounds - originShift (createCoordinateInfo's
+      // invariant): identical bound sets here would have made this test
+      // unable to tell computeFootprintGeoJSON reading `shiftedBounds` apart
+      // from an accidental `originalBounds` read (see the module doc above).
       originShift: { x: 100, y: 5, z: -50 },
       originalBounds: { min: { x: -10, y: -1, z: -20 }, max: { x: 10, y: 11, z: 20 } },
-      shiftedBounds: { min: { x: -10, y: -1, z: -20 }, max: { x: 10, y: 11, z: 20 } },
+      shiftedBounds: { min: { x: -110, y: -6, z: 30 }, max: { x: -90, y: 6, z: 70 } },
       hasLargeCoordinates: false,
       wasmRtcOffset: { x: 7, y: 3, z: 11 },
     };

--- a/apps/viewer/src/lib/wall-rects-from-meshes.test.ts
+++ b/apps/viewer/src/lib/wall-rects-from-meshes.test.ts
@@ -119,8 +119,11 @@ describe('wallRectsFromMeshes', () => {
       originShift: shift,
       wasmRtcOffset: rtc,
       hasLargeCoordinates: true,
+      // shiftedBounds = originalBounds - originShift (createCoordinateInfo's
+      // invariant); wallRectsFromMeshes never reads either bounds field, but
+      // a fixture no producer could emit is still worth avoiding.
       originalBounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 0, y: 0, z: 0 } },
-      shiftedBounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 0, y: 0, z: 0 } },
+      shiftedBounds: { min: { x: -100, y: -5, z: -20 }, max: { x: -100, y: -5, z: -20 } },
     } as unknown as CoordinateInfo;
 
     // Wall render box: renderX[0..4], renderZ[0..0.8], renderY[0..3].
@@ -153,8 +156,11 @@ describe('wallRectsFromMeshes', () => {
       originShift: { x: 100, y: 5, z: 20 },
       wasmRtcOffset: { x: 1000, y: 2000, z: 3000 },
       hasLargeCoordinates: true,
+      // shiftedBounds = originalBounds - originShift (createCoordinateInfo's
+      // invariant); wallRectsFromMeshes never reads either bounds field, but
+      // a fixture no producer could emit is still worth avoiding.
       originalBounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 0, y: 0, z: 0 } },
-      shiftedBounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 0, y: 0, z: 0 } },
+      shiftedBounds: { min: { x: -100, y: -5, z: -20 }, max: { x: -100, y: -5, z: -20 } },
     } as unknown as CoordinateInfo;
     // Wall ifcZ ∈ [3005, 3008]; a band at ifcZ [0, 3] does NOT overlap it.
     const rects = wallRectsFromMeshes([wallBox(1, 0, 4, 0, 0.8, 0, 3)], coord, 0, 3);


### PR DESCRIPTION
`createCoordinateInfo` (`utils/localParsingUtils.ts`) enforces:

```
shiftedBounds = originalBounds - originShift
```

A fixture that breaks that invariant doesn't merely fail to catch a bug — it **certifies** one, and the test's name then documents the wrong behaviour as intended.

That isn't hypothetical. **Three production bugs today were each pinned by exactly such a fixture**: #2302 (`reproject`), #2343 (`kmz-altitude-hint`) and #2344 (`cesium-placement`, whose correct sibling sat 37 lines above it). So this sweeps the invariant across the repo rather than waiting for a fourth.

## Inventory

**30 `CoordinateInfo` fixture sites** across `apps/**` and `packages/**`:

| Verdict | Count |
|---|---|
| IMPOSSIBLE | 9 |
| CONSISTENT | 2 |
| N/A | 19 |

N/A means either `originShift = {0,0,0}` — trivially consistent, and unable to certify this bug — or the fixture never sets both bound sets, so there's nothing to contradict.

## What this commit repairs

The **five** impossible fixtures that do not collide with open PRs. All five are provably harmless today — the field they violated is never read by the code under test — so no assertion changed and no production bug was hiding behind them.

They're repaired anyway, because a fixture that cannot exist is a **latent certifier**: the next person to extend one of these tests inherits an input the producer can never emit.

### The telling one

`reproject.test.ts:356` set `shiftedBounds` **equal to** `originalBounds` with `originShift = {100, 5, -50}` — the exact #2302 shape, in a test added *after* #2302 fixed that file, **in the same file**.

`computeFootprintGeoJSON` genuinely reads `shiftedBounds`, so with identical bound sets the test could not tell a correct `shiftedBounds` read apart from an accidental `originalBounds` one. It still passes after the repair, because the test's own oracle reads the same field so both sides moved together — but the discrimination it was written to provide didn't exist until now.

## Verification

**67 passing across the five files.** No production code touched. `apps/viewer` is `"private": true`, so no changeset.

## Deferred, not forgotten

Three more impossible fixtures collide with my own open PRs and would revert work already in review:

| Fixture | Overlaps |
|---|---|
| `kmz-altitude-hint.test.ts` | #2343 |
| `cesium-placement.test.ts` | #2344 |
| `cache/sections/geometry-chunks.test.ts` | #2313, #2326 |

**One of those is load-bearing and worth stating now.** `cesium-placement.test.ts`'s *"computes the IFC origin height"* fixture has `shiftedBounds === originalBounds` with `originShift.y = 3`, and a hard-coded expected value of `14`. Repairing the fixture yields `11`.

`computeIfcOriginHeight` is **correct** — verified independently against reproject's own consistent fixture — so this is not a production bug. It's a wrong expected number that only an impossible input could produce. I'll send that repair once #2344 merges rather than conflicting with it now.

## Not reached

Phase 1b of the sweep — declared-count vs actual array length (`accessor.count`, `meshCount`, chunk `byteLength`), `min <= max` bounds, derived hash/id fields, containment links — was **not** surveyed. Those invariants remain unswept, so absence of findings there means nothing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated coordinate fixtures across federation, point-cloud alignment, IFC origin, reprojection, and wall-rectangle tests.
  * Ensured shifted bounds consistently match configured origin shifts.
  * Preserved existing test behavior and assertions while improving coverage of coordinate transformations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->