### PR TITLE
fix(viewer): give clash settings the unreadable-entry guard its siblings have

### DIFF
--- a/apps/viewer/src/lib/clash/persistence.ts
+++ b/apps/viewer/src/lib/clash/persistence.ts
@@ -149,7 +149,7 @@ function readStoredPresets(): ClashPreset[] {
   try {
     unwritableKeys.delete(PRESETS_KEY);
     const raw = localStorage.getItem(PRESETS_KEY);
-    if (!raw) return [];
+    if (raw === null) return [];
     const parsed: unknown = JSON.parse(raw);
     const list = Array.isArray(parsed)
       ? parsed
@@ -265,7 +265,7 @@ export function loadSettings(): ClashGlobalSettings {
   try {
     unwritableKeys.delete(SETTINGS_KEY);
     const raw = localStorage.getItem(SETTINGS_KEY);
-    if (!raw) return { ...DEFAULT_CLASH_SETTINGS };
+    if (raw === null) return { ...DEFAULT_CLASH_SETTINGS };
     return normalizeSettings(JSON.parse(raw));
   } catch (err) {
     onReadFailure(SETTINGS_KEY, err);
@@ -309,7 +309,7 @@ export function loadReviews(): Map<string, ClashReview> {
   try {
     unwritableKeys.delete(REVIEWS_KEY);
     const raw = localStorage.getItem(REVIEWS_KEY);
-    if (!raw) return map;
+    if (raw === null) return map;
     const parsed: unknown = JSON.parse(raw);
     const reviews =
       parsed && typeof parsed === 'object' ? (parsed as { reviews?: unknown }).reviews : null;

--- a/apps/viewer/src/lib/clash/persistence.ts
+++ b/apps/viewer/src/lib/clash/persistence.ts
@@ -263,15 +263,18 @@ export function normalizeSettings(raw: unknown): ClashGlobalSettings {
 
 export function loadSettings(): ClashGlobalSettings {
   try {
+    unwritableKeys.delete(SETTINGS_KEY);
     const raw = localStorage.getItem(SETTINGS_KEY);
     if (!raw) return { ...DEFAULT_CLASH_SETTINGS };
     return normalizeSettings(JSON.parse(raw));
-  } catch {
+  } catch (err) {
+    onReadFailure(SETTINGS_KEY, err);
     return { ...DEFAULT_CLASH_SETTINGS };
   }
 }
 
 export function saveSettings(settings: ClashGlobalSettings): SaveResult {
+  if (unwritableKeys.has(SETTINGS_KEY)) return refuseOverwrite('clash settings');
   try {
     localStorage.setItem(SETTINGS_KEY, JSON.stringify({ schemaVersion: SCHEMA_VERSION, settings }));
     return { ok: true };

--- a/apps/viewer/src/lib/clash/persistence.unreadable.test.ts
+++ b/apps/viewer/src/lib/clash/persistence.unreadable.test.ts
@@ -112,6 +112,57 @@ describe('clash persistence: an unreadable entry is never overwritten', () => {
     assert.deepStrictEqual(saveSettings({ ...DEFAULT_CLASH_SETTINGS, tolerance: 0.01 }), { ok: true });
 
     assert.ok(survives(ls, CORRUPT_SETTINGS), 'the unreadable settings blob was destroyed by the save');
+
+    // The save reporting `ok: true` is not, on its own, proof that anything was
+    // written: read SETTINGS_KEY back and check it actually holds the edit, so a
+    // no-op save (or one that silently wrote something else) cannot pass this
+    // test the way it could when only the `SaveResult` and `survives()` were
+    // checked.
+    const persisted = JSON.parse(ls.getItem(SETTINGS_KEY)!) as { settings: typeof DEFAULT_CLASH_SETTINGS };
+    assert.strictEqual(persisted.settings.tolerance, 0.01, 'the recovery save did not actually write the new settings');
+  });
+
+  // An empty string is not "no entry" — it is the corrupt entry a truncated or
+  // interrupted write is most likely to leave behind. `!raw` treats it the same
+  // as a missing key (both are falsy), so it must be `raw === null` specifically,
+  // or an empty string never reaches `JSON.parse` and silently skips the whole
+  // preserve-and-quarantine path this suite otherwise exercises.
+  it('treats an empty stored string as a read failure, not "no entry"', () => {
+    ls.setItem(SETTINGS_KEY, '');
+
+    const loaded = loadSettings();
+    assert.deepStrictEqual(loaded, DEFAULT_CLASH_SETTINGS);
+
+    // The empty string must have gone through the same preserve-and-quarantine
+    // path as bad JSON — moved to a backup key — not silently skipped because
+    // it happened to also be falsy like a missing key.
+    assert.ok(
+      ls.store.has(`${SETTINGS_KEY}:unreadable`),
+      'an empty stored string must be preserved as an unreadable entry, not treated as if nothing was ever stored',
+    );
+
+    // Ordinary recovery, not a lockout: the very next save still succeeds and
+    // actually writes, since the empty value was successfully backed up.
+    assert.deepStrictEqual(saveSettings({ ...DEFAULT_CLASH_SETTINGS, tolerance: 0.01 }), { ok: true });
+    const persisted = JSON.parse(ls.getItem(SETTINGS_KEY)!) as { settings: typeof DEFAULT_CLASH_SETTINGS };
+    assert.strictEqual(persisted.settings.tolerance, 0.01);
+  });
+
+  // Bounding control: a genuinely absent key is not a read failure. Without
+  // this, a fix that widens the check too far (e.g. treating `undefined` or
+  // any falsy `raw` as corrupt) would misclassify a brand-new user's first run
+  // as data corruption.
+  it('a genuinely absent key still returns defaults without being treated as corrupt', () => {
+    // Nothing was ever set at SETTINGS_KEY (beforeEach starts from a fresh store).
+    assert.strictEqual(ls.getItem(SETTINGS_KEY), null);
+
+    const loaded = loadSettings();
+    assert.deepStrictEqual(loaded, DEFAULT_CLASH_SETTINGS);
+    assert.ok(!ls.store.has(`${SETTINGS_KEY}:unreadable`), 'a missing key must not be preserved as an unreadable entry');
+
+    assert.deepStrictEqual(saveSettings({ ...DEFAULT_CLASH_SETTINGS, tolerance: 0.03 }), { ok: true });
+    const persisted = JSON.parse(ls.getItem(SETTINGS_KEY)!) as { settings: typeof DEFAULT_CLASH_SETTINGS };
+    assert.strictEqual(persisted.settings.tolerance, 0.03);
   });
 
   // ── Negative cases: the guard must not turn into "never write again" ────────

--- a/apps/viewer/src/lib/clash/persistence.unreadable.test.ts
+++ b/apps/viewer/src/lib/clash/persistence.unreadable.test.ts
@@ -10,6 +10,9 @@ import {
   savePresets,
   loadReviews,
   saveReviews,
+  loadSettings,
+  saveSettings,
+  DEFAULT_CLASH_SETTINGS,
   type ClashPreset,
 } from './persistence.js';
 
@@ -23,10 +26,12 @@ class MemoryStorage {
 const g = globalThis as { localStorage?: unknown };
 const PRESETS_KEY = 'ifc-lite-clash-presets';
 const REVIEWS_KEY = 'ifc-lite-clash-reviews';
+const SETTINGS_KEY = 'ifc-lite-clash-settings';
 
 /** Truncated JSON — the shape a half-written or externally mangled entry has. */
 const CORRUPT_PRESETS = '{"schemaVersion":1,"presets":[{"id":"custom-1","name":"My rule"';
 const CORRUPT_REVIEWS = '{"schemaVersion":1,"reviews":{"rule-a G1 G2":{"status":"resol';
+const CORRUPT_SETTINGS = '{"schemaVersion":1,"settings":{"mode":"hard","tolerance":0.5';
 
 /** True when `raw` is still somewhere in storage (original key or a backup). */
 function survives(ls: MemoryStorage, raw: string): boolean {
@@ -52,6 +57,7 @@ describe('clash persistence: an unreadable entry is never overwritten', () => {
     // Clear the module-level "unwritable" flags via a clean read of empty storage.
     buildInitialPresets();
     loadReviews();
+    loadSettings();
   });
 
   after(() => {
@@ -68,6 +74,7 @@ describe('clash persistence: an unreadable entry is never overwritten', () => {
     g.localStorage = new MemoryStorage();
     buildInitialPresets();
     loadReviews();
+    loadSettings();
   });
 
   it('preserves unreadable presets across the save that follows the failed read', () => {
@@ -93,12 +100,35 @@ describe('clash persistence: an unreadable entry is never overwritten', () => {
     assert.ok(survives(ls, CORRUPT_REVIEWS), 'the unreadable reviews blob was destroyed by the save');
   });
 
+  it('preserves unreadable settings across the save that follows the failed read', () => {
+    ls.setItem(SETTINGS_KEY, CORRUPT_SETTINGS);
+
+    // The read degrades to defaults — the user's stored tolerance is not visible.
+    const loaded = loadSettings();
+    assert.deepStrictEqual(loaded, DEFAULT_CLASH_SETTINGS);
+
+    // ...and the very next edit persists that degraded (default) settings —
+    // but the original bytes must still be recoverable from a backup key.
+    assert.deepStrictEqual(saveSettings({ ...DEFAULT_CLASH_SETTINGS, tolerance: 0.01 }), { ok: true });
+
+    assert.ok(survives(ls, CORRUPT_SETTINGS), 'the unreadable settings blob was destroyed by the save');
+  });
+
   // ── Negative cases: the guard must not turn into "never write again" ────────
 
   it('still round-trips normally when the stored entry is readable', () => {
     assert.deepStrictEqual(savePresets([customPreset]), { ok: true });
     const reloaded = buildInitialPresets().filter((p) => !p.builtin);
     assert.deepStrictEqual(reloaded.map((p) => p.id), ['custom-new']);
+  });
+
+  // Bounding control: a non-corrupt settings entry must still load its stored
+  // values and still save successfully — otherwise "refuse everything" would
+  // pass this suite too.
+  it('still round-trips settings normally when the stored entry is readable', () => {
+    const settings = { ...DEFAULT_CLASH_SETTINGS, tolerance: 0.05, mode: 'clearance' as const };
+    assert.deepStrictEqual(saveSettings(settings), { ok: true });
+    assert.deepStrictEqual(loadSettings(), settings);
   });
 
   it('keeps saving after an unreadable read — the panel stays usable', () => {
@@ -144,10 +174,12 @@ describe('clash persistence: an unreadable entry is never overwritten', () => {
     })();
     full.setItem(PRESETS_KEY, CORRUPT_PRESETS);
     full.setItem(REVIEWS_KEY, CORRUPT_REVIEWS);
+    full.setItem(SETTINGS_KEY, CORRUPT_SETTINGS);
     g.localStorage = full;
 
     buildInitialPresets();
     loadReviews();
+    loadSettings();
 
     const presetResult = savePresets([customPreset]);
     assert.strictEqual(presetResult.ok === false && presetResult.reason, 'unreadable');
@@ -156,5 +188,9 @@ describe('clash persistence: an unreadable entry is never overwritten', () => {
     const reviewResult = saveReviews(new Map<string, ClashReview>([['k', { status: 'resolved' }]]));
     assert.strictEqual(reviewResult.ok === false && reviewResult.reason, 'unreadable');
     assert.strictEqual(full.getItem(REVIEWS_KEY), CORRUPT_REVIEWS);
+
+    const settingsResult = saveSettings({ ...DEFAULT_CLASH_SETTINGS, tolerance: 0.01 });
+    assert.strictEqual(settingsResult.ok === false && settingsResult.reason, 'unreadable');
+    assert.strictEqual(full.getItem(SETTINGS_KEY), CORRUPT_SETTINGS);
   });
 });


### PR DESCRIPTION
`persistence.ts` documents its own contract: a loader that fails to parse calls `onReadFailure(key, cause)`, which backs the corrupt bytes up or latches the key in `unwritableKeys`; every later save then checks that set and calls `refuseOverwrite` rather than clobbering data it never successfully read.

`savePresets` and `saveReviews` both honour it. **`saveSettings` did not**, and `loadSettings`'s catch swallowed the parse failure without ever calling `onReadFailure`. Two of three siblings, in one file, against the rule that file exists to enforce.

Probed against the unfixed module using the `MemoryStorage` harness the existing tests already use:

```
loaded (corrupt tolerance 0.5 lost) -> defaults
save result                          -> { ok: true }
corrupt bytes still present anywhere -> false
```

Silently gone, no backup, success reported.

**Downstream:** `clashSlice.ts:197` calls `loadSettings()` at boot, and `persistSettings()` — wired to every detection-setting change — plus `applyClashFlavorConfig` call `saveSettings` unconditionally. So a half-written entry read as defaults is permanently overwritten by the next settings edit, where the same corruption in presets or reviews is preserved and surfaced as `SaveResult.reason === 'unreadable'`.

## Displacement checked first

Making a save refuse can be worse than the bug it fixes, so this was resolved before writing anything. The concern: would refusing strand the user on defaults with an inert settings panel?

It doesn't.

- `persistSettings` (`clashSlice.ts:218-223`) **already checks `ok`** and reports failures once per session via `reportClashSettingsSaveFailure`.
- `settings-save-notice.ts` **is already wired to this exact path** — its own doc names `persistSettings` as its only caller — swapping in a toast while the dialog is mounted, else `console.warn`. No new plumbing needed.
- Zustand's `set()` commits the in-session value **before** `persistSettings` runs, and a refused write doesn't roll it back. The controls stay live and editable; a refusal only means that value hasn't reached `localStorage` — precisely what presets and reviews already do.

So the full sibling-matching fix is safe, and the smaller loader-only variant wasn't needed. Two lines: `unwritableKeys.delete(SETTINGS_KEY)` plus `onReadFailure(...)` in `loadSettings`, and the `unwritableKeys` check at the top of `saveSettings`.

## Verification

**RED** against unfixed code — 2 subtests fail: `preserves unreadable settings across the save that follows the failed read`, and the extended `refuses to save when the unreadable value could not even be backed up`, which got `ok: true` where it expected `reason: 'unreadable'`.

**Bounding control**, passing before *and* after: `still round-trips settings normally when the stored entry is readable` saves a **non-default** settings object and asserts `loadSettings()` returns exactly it — so the guard can't be satisfied by refusing everything.

**22 → 24 passing** across the clash tests. `clashSlice.ts` was read but **not modified** — its existing wiring already does the right thing once `saveSettings` returns a refusal. `apps/viewer` is `"private": true`, so no changeset.

## Noted, out of scope

`applyClashFlavorConfig` discards the `SaveResult` entirely, so a refusal there is silent. That's pre-existing, unchanged by this PR, and lives in the slice rather than this module — flagging rather than widening the diff.

## Severity

Live, but bounded: the data at risk is detection preferences (mode, tolerance, clearance, clusterEpsilon, reportTouch, groupBy), not user-authored content like custom rules or review triage. `DEFAULT_CLASH_SETTINGS` is a reasonable fallback — the defect is that the corruption was unrecoverable and unreported, not that the fallback was wrong.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of corrupted or unreadable saved settings.
  - Preserves unreadable settings during fallback saves instead of overwriting them.
  - Prevents saving when corrupted settings cannot be safely backed up.
  - Readable settings continue to load and save normally.

- **Tests**
  - Added coverage for corrupted settings, preservation during fallback saves, and unreadable storage failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->