### PR TITLE
test(viewer): cover the layer registry client, which had none

### DIFF
--- a/apps/viewer/src/lib/layers/registry-client.test.ts
+++ b/apps/viewer/src/lib/layers/registry-client.test.ts
@@ -1,0 +1,143 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { LayerRegistryClient, RegistryError } from './registry-client.js';
+
+type FetchImpl = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+function withMockFetch<T>(impl: FetchImpl, fn: () => Promise<T>): Promise<T> {
+  const original = globalThis.fetch;
+  globalThis.fetch = impl as typeof globalThis.fetch;
+  return fn().finally(() => {
+    globalThis.fetch = original;
+  });
+}
+
+const BASE = 'http://registry.example';
+
+test('a plain non-2xx (no `status` field) rejects with a RegistryError carrying the body error and HTTP status', async () => {
+  await withMockFetch(
+    async () => new Response(JSON.stringify({ error: 'layer not found' }), { status: 404 }),
+    async () => {
+      const client = new LayerRegistryClient(BASE);
+      await assert.rejects(
+        () => client.pullLayer('missing-layer'),
+        (err: unknown) => {
+          assert.ok(err instanceof RegistryError, 'expected a RegistryError');
+          assert.equal((err as RegistryError).status, 404);
+          assert.equal((err as RegistryError).message, 'layer not found');
+          return true;
+        },
+      );
+    },
+  );
+});
+
+test('a non-2xx body carrying a `status` field resolves as data instead of throwing (merge outcome pass-through)', async () => {
+  const outcomeBody = {
+    status: 'conflicts',
+    conflicts: [{ componentKey: 'pset:Pset_FireSafety' }],
+  };
+  await withMockFetch(
+    async () => new Response(JSON.stringify(outcomeBody), { status: 409 }),
+    async () => {
+      const client = new LayerRegistryClient(BASE);
+      const result = await client.mergeRef('main', { candidate: 'blake3:x' });
+      assert.deepEqual(result, outcomeBody);
+    },
+  );
+});
+
+test('path segments are encodeURIComponent-encoded before reaching fetch', async () => {
+  const id = 'a/b#c d';
+  const captured: string[] = [];
+  await withMockFetch(
+    async (input) => {
+      captured.push(String(input));
+      return new Response(JSON.stringify({ header: { id } }), { status: 200 });
+    },
+    async () => {
+      const client = new LayerRegistryClient(BASE);
+      await client.pullLayer(id);
+    },
+  );
+  assert.equal(captured.length, 1);
+  assert.equal(captured[0], `${BASE}/api/v1/layers/a%2Fb%23c%20d`);
+});
+
+test('a non-JSON error body degrades to `{ error: text }`, surfaced as the RegistryError message', async () => {
+  await withMockFetch(
+    async () => new Response('Internal Server Error', { status: 500 }),
+    async () => {
+      const client = new LayerRegistryClient(BASE);
+      await assert.rejects(
+        () => client.listLayers(),
+        (err: unknown) => {
+          assert.ok(err instanceof RegistryError);
+          assert.equal((err as RegistryError).message, 'Internal Server Error');
+          assert.equal((err as RegistryError).status, 500);
+          return true;
+        },
+      );
+    },
+  );
+});
+
+test('an empty success body resolves to `{}`', async () => {
+  await withMockFetch(
+    async () => new Response('', { status: 200 }),
+    async () => {
+      const client = new LayerRegistryClient(BASE);
+      const result = await client.listLayers();
+      assert.deepEqual(result, {});
+    },
+  );
+});
+
+test('getReport bypasses the JSON envelope and returns the raw text body unparsed', async () => {
+  // Deliberately has whitespace a JSON.parse/stringify round-trip would
+  // strip, so a regression to JSON-parsing this body is caught by content,
+  // not just by type.
+  const raw = '{"looks": "like json but must come back as a raw string,  unparsed"}';
+  await withMockFetch(
+    async () => new Response(raw, { status: 200 }),
+    async () => {
+      const client = new LayerRegistryClient(BASE);
+      const result = await client.getReport('deadbeef');
+      assert.equal(result, raw);
+      assert.equal(typeof result, 'string');
+    },
+  );
+});
+
+test('getReport returns null on 404 instead of throwing', async () => {
+  await withMockFetch(
+    async () => new Response('not found', { status: 404 }),
+    async () => {
+      const client = new LayerRegistryClient(BASE);
+      const result = await client.getReport('missing-digest');
+      assert.equal(result, null);
+    },
+  );
+});
+
+test('getReport throws RegistryError on a non-404 failure', async () => {
+  await withMockFetch(
+    async () => new Response('boom', { status: 503 }),
+    async () => {
+      const client = new LayerRegistryClient(BASE);
+      await assert.rejects(
+        () => client.getReport('some-digest'),
+        (err: unknown) => {
+          assert.ok(err instanceof RegistryError);
+          assert.equal((err as RegistryError).status, 503);
+          assert.equal((err as RegistryError).message, 'evidence fetch failed (503)');
+          return true;
+        },
+      );
+    },
+  );
+});


### PR DESCRIPTION
`LayerRegistryClient` had **zero** live coverage. `merge.test.ts` imports only `RegistryError` and the types, and uses a hand-written stand-in — the real class was never constructed by any test.

Proven before writing anything, rather than assumed: neutralising `request()`'s non-2xx guard so **every error response is treated as success** left all 45 tests across the layers surface green. A remote client where a fail-open regression is invisible.

## Eight tests, each proven able to fail

| # | Pins | Mutation that makes it RED |
|---|---|---|
| 1 | plain non-2xx (no `status`) → `RegistryError` | guard → `if (false)` |
| 2 | non-2xx **with** `status` → resolves as data | guard → `if (!res.ok)` |
| 3 | path segments encoded | drop `encodeURIComponent` |
| 4 | non-JSON error body → `{ error: text }` | catch → `parsed = {}` |
| 5 | empty success body → `{}` | drop the `text ?` ternary |
| 6 | `getReport` returns **raw** text | `return` → `JSON.stringify(await res.json())` |
| 7 | `getReport` 404 → `null` | `404` → `405` |
| 8 | `getReport` other failure → throws | guard → `if (false)` |

**Pair 1 and 2 are the point.** A non-2xx carrying a `status` field is *data*, not an error: `collab-server`'s `layer-registry-route.ts` emits `status` **only** on merge outcomes — `conflicts`, `policy-failure`, `unrelated-base` — riding a 409/403/422, while every other error path uses `{ error: … }` with no `status`. Testing one direction alone would let the other rot; the pair *is* the contract.

Test 3 uses an id of `'a/b#c d'` and asserts the exact URL `.../layers/a%2Fb%23c%20d` reaches `fetch`. Asserting merely "a request happened" wouldn't catch a lossy sanitiser — the shape that was a live bug in `collab-server` today.

## One test was rewritten mid-flight

Worth recording, because it's exactly why this protocol exists. Test 6's first fixture used a whitespace-free JSON body, so the `JSON.stringify(JSON.parse(x))` mutation was **absorbed** — the assertion could not fail. It was rewritten with internal whitespace that a round trip strips, then re-proven RED.

A coverage PR whose tests can't fail is worse than no PR, and that one nearly shipped.

## No production seam was added

`request()` and `getReport()` call global `fetch` directly; there's no constructor or module injection point. I did **not** add one — `globalThis.fetch` is stubbed per test and restored in `finally`, matching the pattern already used by `stream-direct.test.ts`, `stream-client.test.ts` and `source-host.test.ts`.

Reshaping production code to suit a test would be the wrong trade for coverage of behaviour that is already correct.

## Verification

**No bugs found.** `registry-client.ts` is unchanged; this pins behaviour that was right but unasserted.

8 new tests; **34 passing** across `registry-client` + `merge` + `publish`. `apps/viewer` is `"private": true`, so no changeset.

## Not covered, and why

Header assembly (`content-type` / `authorization`) — lower risk than the four contract items above. `fromCollabConfig` — a thin wrapper over `collabServerUrl()` behind `import.meta.env`, needing env and localStorage stubs for marginal value.
