### PR TITLE
fix(viewer): two promises that could never settle

### DIFF
--- a/.changeset/server-onready-throw-hang.md
+++ b/.changeset/server-onready-throw-hang.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/viewer-core": patch
+---
+
+Fix `startViewerServer` hanging forever if the caller's `onReady` callback threw. The executor for the returned promise only took a `resolve` parameter; `onReady` runs inside the `server.listen` callback, outside any try/catch the caller can see, so a throw there silently skipped `promiseResolve` and the returned promise never settled. It now rejects with the thrown error, and closes the already-bound server first so the rejection doesn't leak a listening socket.

--- a/.changeset/server-onready-throw-hang.md
+++ b/.changeset/server-onready-throw-hang.md
@@ -3,3 +3,5 @@
 ---
 
 Fix `startViewerServer` hanging forever if the caller's `onReady` callback threw. The executor for the returned promise only took a `resolve` parameter; `onReady` runs inside the `server.listen` callback, outside any try/catch the caller can see, so a throw there silently skipped `promiseResolve` and the returned promise never settled. It now rejects with the thrown error, and closes the already-bound server first so the rejection doesn't leak a listening socket.
+
+Also fix the same class of hang on a `server.listen()` bind failure (e.g. `EADDRINUSE`): a bind failure emits `error` and never runs the `listen` callback, so the returned promise hung forever with no way to observe the failure. It now rejects with the underlying error; since the server never bound on this path there is no listening socket to close.

--- a/apps/viewer/src/lib/layers/browser-store.test.ts
+++ b/apps/viewer/src/lib/layers/browser-store.test.ts
@@ -138,4 +138,44 @@ describe('BrowserLayerStore / readAll — IndexedDB transaction abort handling',
     store?.storeLayer(fresh);
     assert.equal(store?.hasLayer(fresh.header.id), true);
   });
+
+  it('a degraded (memory-only) store never issues IndexedDB writes from storeLayer/setRef', async () => {
+    failNextCursorContinue();
+    const degraded = await BrowserLayerStore.open();
+
+    // Spy on IDBObjectStore.prototype.put: the persistence primitive every
+    // write path (storeLayer, setRef) funnels through. If open()'s catch
+    // path truly degrades to memory-only, put() must never fire for this
+    // store's mutations — not merely "the call resolved".
+    const proto = IDBObjectStore.prototype as unknown as Record<string, (...args: unknown[]) => unknown>;
+    const originalPut = proto.put;
+    let putCalls = 0;
+    proto.put = function (this: IDBObjectStore, ...args: unknown[]) {
+      putCalls++;
+      return originalPut.apply(this, args);
+    };
+    const layer = publishable(
+      [{ path: 'wall-4', attributes: { 'bsi::ifc::class': { code: 'IfcWall', uri: 'u' } } }],
+      'browser-store.test degraded-store no-write',
+      null,
+    );
+    try {
+      degraded.storeLayer(layer);
+      degraded.setRef('degraded-ref', { layers: [layer.header.id] });
+      // persist() is fire-and-forget; give any stray IDB write a turn.
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      assert.equal(putCalls, 0, 'a degraded store must not call IDBObjectStore.put at all');
+    } finally {
+      proto.put = originalPut;
+    }
+
+    // Corroborate via a fresh, real reopen: the layer written through the
+    // degraded store must be absent from durable storage.
+    const reopened = await BrowserLayerStore.open();
+    assert.equal(
+      reopened.hasLayer(layer.header.id),
+      false,
+      'a layer stored through a degraded store must not have reached IndexedDB',
+    );
+  });
 });

--- a/apps/viewer/src/lib/layers/browser-store.test.ts
+++ b/apps/viewer/src/lib/layers/browser-store.test.ts
@@ -1,0 +1,141 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `readAll()` (browser-store.ts) used to listen only for `tx.oncomplete` /
+ * `tx.onerror`. Per the IndexedDB spec, an exception thrown inside a
+ * request's `onsuccess` handler ABORTS the transaction and fires `abort` —
+ * not `error`, not `complete` — so without a `tx.onabort` branch the
+ * returned promise hung forever. `BrowserLayerStore.open()` awaits two
+ * `readAll()` calls, and `getBrowserLayerStore()` memoises `open()`'s
+ * promise as an app-wide singleton, so the hang stalled layer-store init
+ * for the whole session.
+ *
+ * `readAll()` now rejects on both `error` and `abort`, matching the
+ * convention already used by idb-storage.ts / idb-log-storage.ts /
+ * idb-flavor-storage.ts / ifc-cache.ts. `open()` in turn catches that
+ * rejection and degrades to memory-only — otherwise the rejection would
+ * permanently poison the `getBrowserLayerStore()` singleton over what is
+ * usually a transient read glitch, trading a silent stall for a permanently
+ * broken layer store for the rest of the session.
+ *
+ * Lives in its own file because the assertions monkeypatch
+ * `IDBCursor.prototype`; `tsx --test` runs each file in its own process.
+ */
+
+// fake-indexeddb installs a Node-compatible IDB implementation on
+// `globalThis.indexedDB` (+ the IDB* constructors) via the `/auto` entry.
+import 'fake-indexeddb/auto';
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  computeLayerId,
+  computeStackHash,
+  createProvenanceManifest,
+  setProvenance,
+} from '@ifc-lite/ifcx';
+import type { IfcxFile, IfcxNode, ProvenanceCheck } from '@ifc-lite/ifcx';
+import { BrowserLayerStore } from './browser-store.js';
+
+function publishable(
+  data: IfcxNode[],
+  intent: string,
+  baseIds: string[] | null,
+  checks: ProvenanceCheck[] = [],
+): IfcxFile {
+  const bare: IfcxFile = {
+    header: { id: '', ifcxVersion: 'ifcx_alpha', dataVersion: '1.0.0', author: 't', timestamp: '2026-07-11T00:00:00Z' },
+    imports: [],
+    schemas: {},
+    data,
+  };
+  const manifest = createProvenanceManifest({
+    author: { kind: 'human', principal: 'alice' },
+    intent,
+    base: baseIds === null ? null : { kind: 'stack', id: computeStackHash(baseIds) },
+    created: '2026-07-11T00:00:00Z',
+    checks,
+  });
+  const withManifest = setProvenance(bare, manifest);
+  const id = computeLayerId(withManifest);
+  return { ...withManifest, header: { ...withManifest.header, id } };
+}
+
+/** Resolve to the settled outcome, or the literal 'HUNG' after `ms`. */
+async function settleOrHang<T>(p: Promise<T>, ms = 1000): Promise<
+  { kind: 'resolved'; value: T } | { kind: 'rejected'; error: unknown } | { kind: 'hung' }
+> {
+  return Promise.race([
+    p.then(
+      (value) => ({ kind: 'resolved' as const, value }),
+      (error: unknown) => ({ kind: 'rejected' as const, error }),
+    ),
+    new Promise<{ kind: 'hung' }>((resolve) => {
+      setTimeout(() => resolve({ kind: 'hung' as const }), ms).unref?.();
+    }),
+  ]);
+}
+
+/**
+ * One-shot: patch `IDBCursor.prototype.continue` so the very next call
+ * throws `InvalidStateError`. Per spec, a request's `onsuccess` handler
+ * throwing synchronously aborts its transaction — this reproduces that
+ * failure mode without needing invalid data or a broken store.
+ */
+function failNextCursorContinue(): void {
+  const proto = IDBCursor.prototype as unknown as Record<string, (...args: unknown[]) => void>;
+  const original = proto.continue;
+  proto.continue = function (this: IDBCursor, ...args: unknown[]) {
+    proto.continue = original; // restore immediately: strictly one-shot
+    throw new DOMException('Induced failure', 'InvalidStateError');
+  };
+}
+
+describe('BrowserLayerStore / readAll — IndexedDB transaction abort handling', () => {
+  it('bounding control: a normal reopen rehydrates every stored layer and ref', async () => {
+    const seed = await BrowserLayerStore.open();
+    const base = publishable(
+      [{ path: 'wall-1', attributes: { 'bsi::ifc::class': { code: 'IfcWall', uri: 'u' } } }],
+      'browser-store.test bounding control',
+      null,
+    );
+    seed.storeLayer(base);
+    seed.setRef('bounding-control-ref', { layers: [base.header.id] });
+
+    const rehydrated = await BrowserLayerStore.open();
+    assert.equal(rehydrated.hasLayer(base.header.id), true, 'stored layer must survive a reopen');
+    assert.deepEqual(rehydrated.getRef('bounding-control-ref'), { layers: [base.header.id] });
+  });
+
+  it('an aborted cursor transaction degrades open() to memory-only instead of hanging', async () => {
+    const seed = await BrowserLayerStore.open();
+    const base = publishable(
+      [{ path: 'wall-2', attributes: { 'bsi::ifc::class': { code: 'IfcWall', uri: 'u' } } }],
+      'browser-store.test induced abort',
+      null,
+    );
+    seed.storeLayer(base);
+
+    failNextCursorContinue();
+    const outcome = await settleOrHang(BrowserLayerStore.open());
+    assert.equal(outcome.kind, 'resolved', 'open() must reject-and-recover, not hang, when a readAll transaction aborts');
+
+    // Promise.all([readAll(LAYERS), readAll(REFS)]) is all-or-nothing: the
+    // induced abort on one store's cursor rejects the pair, so open()
+    // degrades to a fully memory-only store rather than a partial hydrate.
+    const store = outcome.kind === 'resolved' ? outcome.value : undefined;
+    assert.equal(store?.hasLayer(base.header.id), false, 'the induced-failure session starts memory-only, not partially hydrated');
+
+    // And the store is still usable — a degraded open() must not leave a
+    // broken object behind.
+    const fresh = publishable(
+      [{ path: 'wall-3', attributes: { 'bsi::ifc::class': { code: 'IfcWall', uri: 'u' } } }],
+      'browser-store.test post-degrade usability',
+      null,
+    );
+    store?.storeLayer(fresh);
+    assert.equal(store?.hasLayer(fresh.header.id), true);
+  });
+});

--- a/apps/viewer/src/lib/layers/browser-store.ts
+++ b/apps/viewer/src/lib/layers/browser-store.ts
@@ -44,8 +44,14 @@ function openDatabase(): Promise<IDBDatabase | null> {
   });
 }
 
+/**
+ * Reject on both `error` AND `abort` — an aborted transaction fires neither
+ * `oncomplete` nor `onerror`, so without the `onabort` branch the returned
+ * promise would hang forever. Matches the convention in idb-storage.ts /
+ * idb-log-storage.ts / idb-flavor-storage.ts / ifc-cache.ts.
+ */
 function readAll<T>(db: IDBDatabase, storeName: string): Promise<Map<string, T>> {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     const out = new Map<string, T>();
     const tx = db.transaction(storeName, 'readonly');
     const cursorReq = tx.objectStore(storeName).openCursor();
@@ -55,8 +61,10 @@ function readAll<T>(db: IDBDatabase, storeName: string): Promise<Map<string, T>>
       out.set(String(cursor.key), cursor.value as T);
       cursor.continue();
     };
+    cursorReq.onerror = () => reject(cursorReq.error);
     tx.oncomplete = () => resolve(out);
-    tx.onerror = () => resolve(out);
+    tx.onerror = () => reject(tx.error ?? new Error(`Layer store readAll(${storeName}) transaction failed.`));
+    tx.onabort = () => reject(tx.error ?? new Error(`Layer store readAll(${storeName}) transaction aborted.`));
   });
 }
 
@@ -69,17 +77,31 @@ export class BrowserLayerStore implements LayerRefStore {
     this.db = db;
   }
 
-  /** Hydrate the working state from IndexedDB (memory-only without it). */
+  /**
+   * Hydrate the working state from IndexedDB (memory-only without it).
+   *
+   * `readAll` now rejects on a transaction abort/error (see its own doc) so
+   * it no longer hangs forever, but this is a lazily-memoised singleton
+   * (`getBrowserLayerStore`) - if `open()` itself threw, the rejected
+   * promise would be cached permanently and every future call would fail
+   * for the rest of the session over what's usually a transient read glitch.
+   * Degrade to memory-only instead, matching `openDatabase`'s and
+   * `persist`'s "storage trouble never breaks the session" contract.
+   */
   static async open(): Promise<BrowserLayerStore> {
     const db = await openDatabase();
     const store = new BrowserLayerStore(db);
     if (db) {
-      const [layers, refs] = await Promise.all([
-        readAll<IfcxFile>(db, LAYERS),
-        readAll<RefEntry>(db, REFS),
-      ]);
-      for (const [id, file] of layers) store.layers.set(id, file);
-      for (const [name, entry] of refs) store.refs.set(name, entry);
+      try {
+        const [layers, refs] = await Promise.all([
+          readAll<IfcxFile>(db, LAYERS),
+          readAll<RefEntry>(db, REFS),
+        ]);
+        for (const [id, file] of layers) store.layers.set(id, file);
+        for (const [name, entry] of refs) store.refs.set(name, entry);
+      } catch (err) {
+        console.warn('[layer-store] Failed to hydrate from IndexedDB, starting memory-only:', err);
+      }
     }
     return store;
   }

--- a/apps/viewer/src/lib/layers/browser-store.ts
+++ b/apps/viewer/src/lib/layers/browser-store.ts
@@ -90,20 +90,26 @@ export class BrowserLayerStore implements LayerRefStore {
    */
   static async open(): Promise<BrowserLayerStore> {
     const db = await openDatabase();
-    const store = new BrowserLayerStore(db);
     if (db) {
       try {
         const [layers, refs] = await Promise.all([
           readAll<IfcxFile>(db, LAYERS),
           readAll<RefEntry>(db, REFS),
         ]);
+        const store = new BrowserLayerStore(db);
         for (const [id, file] of layers) store.layers.set(id, file);
         for (const [name, entry] of refs) store.refs.set(name, entry);
+        return store;
       } catch (err) {
         console.warn('[layer-store] Failed to hydrate from IndexedDB, starting memory-only:', err);
+        // Return a store built on `null`, not the retained `db`: persist()
+        // gates on `this.db`, so keeping the real handle here would let
+        // storeLayer()/setRef() keep writing to IndexedDB despite the
+        // "memory-only" degradation this catch exists to guarantee.
+        return new BrowserLayerStore(null);
       }
     }
-    return store;
+    return new BrowserLayerStore(null);
   }
 
   private persist(storeName: string, key: string, value: unknown): void {

--- a/packages/viewer/src/server.ts
+++ b/packages/viewer/src/server.ts
@@ -370,7 +370,26 @@ export async function startViewerServer(opts: ViewerServerOptions): Promise<View
   // gets a rejection with no handle to the still-listening socket, leaking
   // the port for the life of the process.
   return new Promise((promiseResolve, promiseReject) => {
+    // A bind failure (e.g. EADDRINUSE) emits `error` and NEVER runs the
+    // `listen` callback below -- so without this listener neither
+    // `promiseResolve` nor `promiseReject` would ever fire and the returned
+    // promise would hang forever, the same defect class as the onReady-throw
+    // path above. `once` self-removes: `listen`'s success callback also
+    // strips it below, and a bind failure vs. a successful bind are mutually
+    // exclusive outcomes of a single `listen()` call, so this can only ever
+    // fire once and cannot race the resolve path.
+    const onListenError = (err: NodeJS.ErrnoException) => {
+      // The server never bound on this path, so there is no listening
+      // socket to leak -- unlike the onReady-throw path, close() is neither
+      // needed nor safe to rely on here (a server that failed to bind is
+      // not "running", and close() on it just reports that back via its
+      // optional callback rather than doing anything useful).
+      promiseReject(err);
+    };
+    server.once('error', onListenError);
+
     server.listen(requestedPort, () => {
+      server.off('error', onListenError);
       const addr = server.address();
       const port = typeof addr === 'object' && addr ? addr.port : requestedPort;
       const url = `http://localhost:${port}`;

--- a/packages/viewer/src/server.ts
+++ b/packages/viewer/src/server.ts
@@ -362,14 +362,27 @@ export async function startViewerServer(opts: ViewerServerOptions): Promise<View
     }
   });
 
-  return new Promise((promiseResolve) => {
+  // `promiseReject` matters: `opts.onReady` runs inside the `listen`
+  // callback, outside any surrounding try/catch the caller can see. Without
+  // it, a throwing `onReady` would silently drop `promiseResolve` and the
+  // returned promise would hang forever. On that path the server is already
+  // bound to the port, so close it before rejecting -- otherwise the caller
+  // gets a rejection with no handle to the still-listening socket, leaking
+  // the port for the life of the process.
+  return new Promise((promiseResolve, promiseReject) => {
     server.listen(requestedPort, () => {
       const addr = server.address();
       const port = typeof addr === 'object' && addr ? addr.port : requestedPort;
       const url = `http://localhost:${port}`;
 
       if (opts.onReady) {
-        opts.onReady(port, url);
+        try {
+          opts.onReady(port, url);
+        } catch (err) {
+          server.close();
+          promiseReject(err);
+          return;
+        }
       }
 
       promiseResolve({

--- a/packages/viewer/test/server-routes.test.ts
+++ b/packages/viewer/test/server-routes.test.ts
@@ -773,4 +773,49 @@ describe('viewer server — startup contract', () => {
       server.close();
     }
   });
+
+  it('rejects (does not hang) when onReady throws, and releases the port', TEST_TIMEOUT, async () => {
+    // The executor used to take no `reject` parameter: `server.listen`'s
+    // callback runs outside any try/catch the caller can see, so a throwing
+    // `onReady` silently dropped `promiseResolve` and the returned promise
+    // hung forever. `Promise.race` against a short timer turns that hang
+    // into a clean failure instead of stalling the whole suite.
+    let seenPort = -1;
+    const attempt = startViewerServer({
+      filePath: null,
+      fileName: 'onready-throws.ifc',
+      port: 0,
+      onReady: (p) => {
+        seenPort = p;
+        throw new Error('INJECTED: onReady threw');
+      },
+    });
+    const HUNG = Symbol('hung');
+    const outcome = await Promise.race([
+      attempt.then(
+        (value) => ({ kind: 'resolved' as const, value }),
+        (error: unknown) => ({ kind: 'rejected' as const, error }),
+      ),
+      new Promise<typeof HUNG>((resolve) => setTimeout(() => resolve(HUNG), 5_000)),
+    ]);
+
+    assert.notEqual(outcome, HUNG, 'startViewerServer must reject, not hang, when onReady throws');
+    assert.equal((outcome as { kind: string }).kind, 'rejected');
+    const err = (outcome as { kind: 'rejected'; error: unknown }).error;
+    assert.match((err as Error).message, /INJECTED: onReady threw/);
+    assert.ok(seenPort > 0, 'onReady still ran (with the bound port) before throwing');
+
+    // Bounding control on the leak-not-hang question: a rejection that
+    // abandons a still-listening socket is worse than the hang it replaces.
+    // Prove the port was actually released by rebinding a plain server on
+    // it — EADDRINUSE here would mean `startViewerServer` closed nothing.
+    const net = await import('node:net');
+    await new Promise<void>((resolve, reject) => {
+      const probe = net.createServer();
+      probe.once('error', reject);
+      probe.listen(seenPort, () => {
+        probe.close(() => resolve());
+      });
+    });
+  });
 });

--- a/packages/viewer/test/server-routes.test.ts
+++ b/packages/viewer/test/server-routes.test.ts
@@ -818,4 +818,50 @@ describe('viewer server — startup contract', () => {
       });
     });
   });
+
+  it('rejects (does not hang) when server.listen() fails to bind (EADDRINUSE)', TEST_TIMEOUT, async () => {
+    // `server.on('error', ...)` only forwards to `opts.onError`; it never
+    // touches the startup promise. A bind failure emits `error` and skips
+    // the `listen` callback entirely, so `promiseResolve`/`promiseReject`
+    // are both never called and the returned promise hangs forever. Occupy
+    // a real port first, then ask startViewerServer to bind to the SAME
+    // port so the OS itself raises EADDRINUSE.
+    const net = await import('node:net');
+    const blocker = net.createServer();
+    await new Promise<void>((resolve, reject) => {
+      blocker.once('error', reject);
+      blocker.listen(0, () => resolve());
+    });
+    const addr = blocker.address();
+    const occupiedPort = typeof addr === 'object' && addr ? addr.port : -1;
+    assert.ok(occupiedPort > 0, 'must have a real occupied port to collide with');
+
+    try {
+      let sawOnError = false;
+      const attempt = startViewerServer({
+        filePath: null,
+        fileName: 'bind-fails.ifc',
+        port: occupiedPort,
+        onError: () => {
+          sawOnError = true;
+        },
+      });
+      const HUNG = Symbol('hung');
+      const outcome = await Promise.race([
+        attempt.then(
+          (value) => ({ kind: 'resolved' as const, value }),
+          (error: unknown) => ({ kind: 'rejected' as const, error }),
+        ),
+        new Promise<typeof HUNG>((resolve) => setTimeout(() => resolve(HUNG), 5_000)),
+      ]);
+
+      assert.notEqual(outcome, HUNG, 'startViewerServer must reject, not hang, on a listen() bind failure');
+      assert.equal((outcome as { kind: string }).kind, 'rejected');
+      const err = (outcome as { kind: 'rejected'; error: unknown }).error as NodeJS.ErrnoException;
+      assert.equal(err.code, 'EADDRINUSE');
+      assert.ok(sawOnError, 'opts.onError must still fire alongside the rejection');
+    } finally {
+      await new Promise<void>((resolve) => blocker.close(() => resolve()));
+    }
+  });
 });


### PR DESCRIPTION
Found by sweeping **all 76 `new Promise(` sites** in the repo rather than by chasing a single report. Three were classified SUSPECT and all three were **proven** to hang; the two with a live in-repo trigger are fixed here.

## 1. `apps/viewer/src/lib/layers/browser-store.ts` — `readAll()`

The executor handled `cursorReq.onerror` and `tx.oncomplete` but **not `tx.onabort`**. Per the IndexedDB spec, a throw inside an `onsuccess` handler **aborts** the transaction and fires `abort` — not `error`, not `complete` — so that path left the promise permanently unsettled.

This is a sibling asymmetry, and an unusually clear one: **four sibling files in this codebase already handle exactly this, with comments explaining why** — `idb-flavor-storage.ts` (`txDone`), `idb-log-storage.ts` (`bindTx`), `idb-storage.ts`, and `ifc-cache.ts`. `readAll` was the lone outlier.

**Blast radius:** `BrowserLayerStore.open()` awaits `Promise.all([readAll(LAYERS), readAll(REFS)])`, and `getBrowserLayerStore()` memoizes that promise as an app-wide singleton. A stall there wedges layer-store init for the whole session.

### The displacement check changed this fix

Making `readAll` reject is **not by itself an improvement**. Because the singleton is memoized with `singleton ??= …`, a rejection would poison it *forever* — turning a transient IDB glitch into a permanently broken layer store, which is worse than the stall.

So the fix is two-part: `readAll` now rejects (matching the four siblings), and **`open()` catches that rejection and degrades to memory-only** — matching this file's own existing contract in `openDatabase` and `persist` that storage trouble never breaks the session.

**RED:** a probe forcing `cursor.continue()` to throw `InvalidStateError` hung with `Result: TIMEOUT_5s`. The permanent regression test against unfixed code fails with `Promise resolution is still pending but the event loop has already resolved` — the hang signature.

**Bounding control:** a normal-path test asserts reopening the store rehydrates every stored layer and ref, so the fix can't pass by degrading everything to memory-only.

## 2. `packages/viewer/src/server.ts` — `startViewerServer()`

`new Promise((promiseResolve) => { … })` took **no `reject` parameter at all**. `opts.onReady` runs inside the `server.listen` callback, outside any try/catch the caller can see, so a throw there skipped `promiseResolve` and the returned promise never settled. `packages/cli`'s `commands/view.ts:89` awaits it — so `ifc-lite view` would hang forever.

**Displacement checked here too:** by the time `onReady` runs the server is already **bound to the port**, and a bare reject would abandon a listening socket — worse than the hang it replaces. `server.close()` is called before rejecting, and the new test proves the port was actually released by **rebinding a plain `net.createServer()` on it** after the rejection.

**RED, verified independently rather than taken on report:** with the unfixed `server.ts` restored by file copy, `test/server-routes.test.ts` failed with `failureType: 'uncaughtException'` **and the test process itself hung — killed by `timeout` at exit 124.** The fixed file was then restored by copy and proven byte-identical with `diff`.

## Verification

`packages/viewer` **248/248**. `apps/viewer` layers **29/29**. Both packages `tsc --noEmit` **exit 0**.

`packages/viewer` is published (`@ifc-lite/viewer-core` — no `private`, carries `publishConfig`) so it gets a patch changeset. `apps/viewer` is `"private": true`, so no changeset for fix 1.

## Two notes, reported rather than hidden

**An unrelated pre-existing flake**, seen once and not reproduced: `broadcasts addGeometry with the created IFC content` failed a single multi-file run with `Unexpected non-whitespace character after JSON at position 3`, then passed on rerun and passed 76/76 twice when `server-routes.test.ts` ran alone. It's in an addGeometry broadcast path this change doesn't touch, and it fails on unfixed code too. Flagging it as a real flake worth a look — not claiming the suite is clean when I saw it go red.

**`packages/parser/src/scan-worker-inline.ts:239`** is the third SUSPECT from the sweep. Genuine fragility, but no in-repo input can reach it today (the worker always posts a well-formed payload), so it is **deliberately not fixed here** rather than shipped as a speculative change. Happy to do it separately if you'd rather close the shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Viewer startup now fails promptly if initialization encounters an error and releases the listening port.
  * Browser layer storage no longer hangs or partially loads when IndexedDB operations fail.
  * IndexedDB hydration now falls back to a usable memory-only store when persistent storage is unavailable.

* **Tests**
  * Added coverage for server startup failures, port cleanup, and browser storage recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->