### PR TITLE
fix(symbolic): worldY 0 is a real elevation, not "unresolved" (#2256)

### DIFF
--- a/apps/viewer/src/lib/overlay-parse/symbolic-flat.test.ts
+++ b/apps/viewer/src/lib/overlay-parse/symbolic-flat.test.ts
@@ -166,7 +166,10 @@ describe('collectFlatSymbolic', () => {
         fills: [
           // NaN secondary angle = "no cross-hatch"; must still become null.
           fill('IfcAnnotation', 32, 3.5, Number.NaN),
-          fill('IfcGridAxis', 33, 0, 1.25),
+          // NaN worldY = genuinely unresolvable elevation (issue #2256's
+          // `Transform2D::unresolved()` sentinel), not "elevation 0" — this
+          // must still fall back to the storey table.
+          fill('IfcGridAxis', 33, Number.NaN, 1.25),
         ],
       }),
     );
@@ -181,9 +184,38 @@ describe('collectFlatSymbolic', () => {
     const annotationHatch = direct.byStorey.get(3500)?.fills[0]?.hatching;
     assert.ok(annotationHatch, 'annotation fill bucketed at worldY 3.5');
     assert.strictEqual(annotationHatch.angleSecondary, null);
-    // worldY 0 falls back to the storey table (elevation 7 → bucket key 7000).
+    // Non-finite (unresolvable) worldY falls back to the storey table
+    // (elevation 7 → bucket key 7000) — the BOUNDING CONTROL for #2256:
+    // trusting every worldY, not just finite ones, would wrongly bucket
+    // this at key 0 (Math.round(NaN * 1000) is NaN, not 0) instead of
+    // falling back.
     const gridHatch = direct.gridByStorey.get(7000)?.fills[0]?.hatching;
     assert.ok(gridHatch, 'grid fill bucketed via the storey-elevation fallback');
     assert.strictEqual(gridHatch.angleSecondary, 1.25);
+  });
+
+  // Issue #2256: worldY === 0 is a legitimate elevation (a ground floor is
+  // commonly at Y=0), not a signal that the elevation could not be
+  // resolved. Previously `primitiveWorldY !== 0` sent every such annotation
+  // to the storey-table fallback; with no resolvable storey (the
+  // 3DEXPERIENCE / IfcPlusPlus exports this priority order was written
+  // for) it then landed in the loose bucket instead of its own storey.
+  it('buckets an annotation at worldY exactly 0 by its own elevation, not the loose bucket, even with no resolvable storey', () => {
+    const flat = collectFlatSymbolic(
+      makeCollection({
+        polylines: [poly('IfcAnnotation', 71, 0, [0, 0, 1, 1])],
+      }),
+    );
+    // No spatial hierarchy at all — mirrors the "SpatialHierarchyBuilder
+    // reports no storeys found" scenario from the issue.
+    const hierarchy = { storeyElevations: new Map(), elementToStorey: new Map() };
+
+    const result = buildParseResult(flat, hierarchy);
+
+    assert.strictEqual(result.loose.length, 0, 'must not fall through to the loose bucket');
+    const bucket = result.byStorey.get(0);
+    assert.ok(bucket, 'worldY 0 must bucket at key 0');
+    assert.strictEqual(bucket?.storeyElevation, 0);
+    assert.strictEqual(bucket?.lines.length, 1);
   });
 });

--- a/apps/viewer/src/lib/overlay-parse/symbolic-golden.test.ts
+++ b/apps/viewer/src/lib/overlay-parse/symbolic-golden.test.ts
@@ -55,12 +55,12 @@ interface GoldenFixture {
 const FIXTURES: GoldenFixture[] = [
   {
     path: 'tests/models/various/01_BIMcollab_Example_ARC.ifc',
-    digest: '838895dd19709818c72698fac680c63ef8de250c237d9997e3d6c9bc077770cc',
+    digest: '8a304204199f80174343ca4eec723104b28b2198d7d1547234febf22e5524b6c',
     minPrimitives: 80,
   },
   {
     path: 'tests/models/ara3d/ISSUE_102_M3D-CON-CD.ifc',
-    digest: '364152e3a148c0b2a303285d31f3ac31866b009a0b7aa2263935631d67046d3e',
+    digest: 'afe3a887e44469b3043913aa3dfd7b785d6b85ddf3300fb5f6fc6ec2ce63de3e',
     minPrimitives: 400,
   },
 ];

--- a/apps/viewer/src/lib/overlay-parse/symbolic-parse.ts
+++ b/apps/viewer/src/lib/overlay-parse/symbolic-parse.ts
@@ -116,7 +116,16 @@ export function buildParseResult(
     ifcType: string,
   ): AnnotationsForStorey | null => {
     let effectiveY: number | null = null;
-    if (Number.isFinite(primitiveWorldY) && primitiveWorldY !== 0) {
+    if (Number.isFinite(primitiveWorldY)) {
+      // 0 is a legitimate elevation (e.g. a ground floor). The WASM
+      // extractor now emits NaN — not 0 — when a placement genuinely
+      // cannot be resolved (rust/processing/src/symbolic/transform.rs
+      // `Transform2D::unresolved()`), so `Number.isFinite` alone is the
+      // right test; `!== 0` used to send every ground-floor annotation to
+      // the storey-table fallback, and with a broken spatial hierarchy
+      // (the 3DEXPERIENCE / IfcPlusPlus exports this priority order was
+      // written for) that fallback has nothing to resolve to either, so it
+      // landed in the loose bucket instead of its storey (issue #2256).
       effectiveY = primitiveWorldY;
     } else {
       const storeyId = elementToStorey?.get(expressId);

--- a/rust/processing/src/symbolic/transform.rs
+++ b/rust/processing/src/symbolic/transform.rs
@@ -47,6 +47,12 @@ impl Transform2D {
         }
     }
 
+    /// `tz: NaN` = unresolved (vs. `identity()`'s legitimate zero); NaN
+    /// propagates additively so consumers test `f32::is_finite()` (#2256).
+    pub(super) fn unresolved() -> Self {
+        Self { tz: f32::NAN, ..Self::identity() }
+    }
+
     /// Scale factor carried by the linear block, as `sqrt(|det|)`. For the
     /// similarity transforms this codebase actually authors (pure rotation,
     /// uniform scale, or both) `|det| = scale^2` exactly, so this returns the
@@ -112,7 +118,7 @@ pub(super) fn resolve_object_placement(
         return Transform2D::identity();
     }
     let Ok(Some(placement)) = decoder.resolve_ref(attr) else {
-        return Transform2D::identity();
+        return Transform2D::unresolved(); // dangling ref: unresolvable, not zero (#2256)
     };
     resolve_placement_for_symbolic(&placement, decoder, unit_scale, 0)
 }
@@ -126,7 +132,7 @@ fn resolve_placement_for_symbolic(
     depth: usize,
 ) -> Transform2D {
     if depth > 50 || placement.ifc_type != IfcType::IfcLocalPlacement {
-        return Transform2D::identity();
+        return Transform2D::unresolved(); // cycle guard/unsupported type (#2256)
     }
 
     let parent_transform = match placement.get(0) {
@@ -134,9 +140,9 @@ fn resolve_placement_for_symbolic(
             Ok(Some(parent)) => {
                 resolve_placement_for_symbolic(&parent, decoder, unit_scale, depth + 1)
             }
-            _ => Transform2D::identity(),
+            _ => Transform2D::unresolved(), // dangling/malformed (#2256)
         },
-        _ => Transform2D::identity(),
+        _ => Transform2D::identity(), // absent/null: legitimate top of chain
     };
 
     let local_transform = match placement.get(1) {
@@ -147,9 +153,9 @@ fn resolve_placement_for_symbolic(
             {
                 parse_axis2_placement_2d(&rel, decoder, unit_scale)
             }
-            _ => Transform2D::identity(),
+            _ => Transform2D::unresolved(), // dangling ref/wrong type (#2256)
         },
-        _ => Transform2D::identity(),
+        _ => Transform2D::unresolved(), // mandatory attr absent (#2256)
     };
 
     // Same composition `compose_transforms` performs (parent applied after

--- a/rust/processing/tests/issue_2256_world_y_zero.rs
+++ b/rust/processing/tests/issue_2256_world_y_zero.rs
@@ -1,0 +1,88 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Regression test for issue #2256 — `world_y == 0.0` must mean "genuinely
+//! at world Y = 0", never "elevation could not be resolved". Two
+//! `IfcAnnotation`s share the same footprint square:
+//!
+//!   * `#62` has a real `IfcLocalPlacement` chain that resolves cleanly to
+//!     the origin (Z = 0.0). This IS a legitimate ground-floor elevation
+//!     and `world_y` must be exactly `0.0`.
+//!   * `#72` has an `ObjectPlacement` (attribute 5) that references a
+//!     non-existent entity (`#999`) — a dangling reference the decoder
+//!     cannot resolve. `world_y` must be `NaN`, not `0.0`; collapsing it to
+//!     `0.0` is indistinguishable from `#62`'s genuine ground floor and is
+//!     exactly the defect #2256 reports.
+
+use ifc_lite_processing::extract_symbolic_data;
+
+const FIXTURE: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('issue-2256 fixture'),'2;1');
+FILE_NAME('test.ifc','2026-08-07T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0$ScRe4drECQ4DMSqUjd6d',$,'P',$,$,$,$,(#2),#3);
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
+#3=IFCUNITASSIGNMENT((#6));
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#6=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#40=IFCLOCALPLACEMENT($,#5);
+#50=IFCCARTESIANPOINT((0.,0.));
+#51=IFCCARTESIANPOINT((1.,0.));
+#52=IFCCARTESIANPOINT((1.,1.));
+#53=IFCCARTESIANPOINT((0.,1.));
+#54=IFCCARTESIANPOINT((0.,0.));
+#55=IFCPOLYLINE((#50,#51,#52,#53,#54));
+#60=IFCSHAPEREPRESENTATION(#2,'Annotation','Annotation2D',(#55));
+#61=IFCPRODUCTDEFINITIONSHAPE($,$,(#60));
+#62=IFCANNOTATION('2xScRe4drECQ4DMSqUjd6d',$,'GroundFloorNote',$,$,#40,#61);
+#70=IFCCARTESIANPOINT((5.,0.));
+#71=IFCCARTESIANPOINT((6.,0.));
+#73=IFCCARTESIANPOINT((6.,1.));
+#74=IFCCARTESIANPOINT((5.,1.));
+#76=IFCCARTESIANPOINT((5.,0.));
+#77=IFCPOLYLINE((#70,#71,#73,#74,#76));
+#80=IFCSHAPEREPRESENTATION(#2,'Annotation','Annotation2D',(#77));
+#81=IFCPRODUCTDEFINITIONSHAPE($,$,(#80));
+#72=IFCANNOTATION('3xScRe4drECQ4DMSqUjd6d',$,'UnresolvableNote',$,$,#999,#81);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+#[test]
+fn genuine_zero_elevation_stays_finite_zero() {
+    let data = extract_symbolic_data(FIXTURE);
+    let pl = data
+        .polylines
+        .iter()
+        .find(|p| p.express_id == 62)
+        .expect("annotation #62 should produce a polyline");
+    assert_eq!(
+        pl.world_y, 0.0,
+        "a real placement chain resolving to Z=0 is a genuine ground-floor \
+         elevation and must stay exactly 0.0, not become non-finite"
+    );
+    assert!(pl.world_y.is_finite());
+}
+
+#[test]
+fn dangling_placement_ref_is_not_finite() {
+    let data = extract_symbolic_data(FIXTURE);
+    let pl = data
+        .polylines
+        .iter()
+        .find(|p| p.express_id == 72)
+        .expect("annotation #72 should still produce a polyline (points are independent of placement resolution)");
+    assert!(
+        !pl.world_y.is_finite(),
+        "ObjectPlacement #999 does not exist — ifc-lite cannot resolve an \
+         elevation for this annotation. world_y must be non-finite (NaN), \
+         not silently 0.0, or it becomes indistinguishable from a genuine \
+         ground-floor annotation (issue #2256). Got: {}",
+        pl.world_y
+    );
+}

--- a/rust/processing/tests/issue_2256_world_y_zero.rs
+++ b/rust/processing/tests/issue_2256_world_y_zero.rs
@@ -78,11 +78,11 @@ fn dangling_placement_ref_is_not_finite() {
         .find(|p| p.express_id == 72)
         .expect("annotation #72 should still produce a polyline (points are independent of placement resolution)");
     assert!(
-        !pl.world_y.is_finite(),
+        pl.world_y.is_nan(),
         "ObjectPlacement #999 does not exist — ifc-lite cannot resolve an \
-         elevation for this annotation. world_y must be non-finite (NaN), \
-         not silently 0.0, or it becomes indistinguishable from a genuine \
-         ground-floor annotation (issue #2256). Got: {}",
+         elevation for this annotation. world_y must be exactly NaN, \
+         not silently 0.0 (issue #2256) and not +-Infinity either — \
+         `!is_finite()` alone would also accept those. Got: {}",
         pl.world_y
     );
 }


### PR DESCRIPTION
Fixes the defect tracked in **#2256**, now unblocked by **#2274** (step 2 of #2183) having merged. Not using a `Closes` keyword — that call is yours.

`symbolic-parse.ts` bucketed annotations with:

```ts
if (Number.isFinite(primitiveWorldY) && primitiveWorldY !== 0)
```

`0` is a finite, legitimate elevation. A ground floor at exactly Y=0 is common, so this sent real ground-floor annotations and grid axes to the storey-table fallback — and where the spatial hierarchy is absent, that fallback has nothing to resolve to either, so they landed in the **loose bucket** instead of their own storey.

## The producer change is load-bearing, not cosmetic

The issue proposes dropping `!== 0` **and** giving the extractor a NaN sentinel. Those halves are not independent, so I traced the producer before writing anything.

`rust/processing/src/symbolic/items.rs` computes `world_y = first_z.unwrap_or(0.0) + transform.tz`, and in `symbolic/transform.rs` **every genuine-failure branch** — dangling `ObjectPlacement` ref, decode error, malformed or absent mandatory `RelativePlacement`, cycle guard — returned `Transform2D::identity()`, whose `tz` is `0.0`. Bit-for-bit identical to a real ground-floor elevation.

**So dropping `!== 0` alone would have made this strictly worse**: every unresolvable placement would then be confidently bucketed at Y=0 instead of falling back.

- **Rust:** added `Transform2D::unresolved()` (`tz: f32::NAN`, otherwise identity). Genuine failures return it; NaN propagates through every additive `tz` composition, so one unresolved link anywhere NaN-taints the item's `world_y`. The one legitimately-absent-optional case — no parent placement, the normal top of the chain — deliberately stays `identity()`.
- **TS:** the condition is now `Number.isFinite(primitiveWorldY)` alone.

## Three-way measurement on the fixture repair

This PR changes an **existing** test's fixture (a grid fill's `worldY`, `0` → `NaN`), so I measured it three ways to distinguish a repair from a re-baseline:

| | result |
|---|---|
| old fixture + **unfixed** code | 4 pass, 0 fail — the test was vacuous |
| old fixture + **fixed** code | **FAILS** — the fixture encoded the bug |
| new fixture + **fixed** code | 5 pass, 0 fail |

The middle row is the one that matters. The old fixture used `0` to mean "genuinely unresolvable" — precisely the confusion being fixed — and its own comment read *"worldY 0 falls back to the storey table"*. It's a repair, not a re-baseline.

## RED proofs

TS, new test vs unfixed parse — only the new test fails:
```
not ok 5 - buckets an annotation at worldY exactly 0 ... even with no resolvable storey
           must not fall through to the loose bucket
# pass 4  # fail 1
```

Rust, new test vs unfixed `transform.rs`:
```
test dangling_placement_ref_is_not_finite ... FAILED
... world_y must be non-finite (NaN), not silently 0.0 ... Got: 0
```

## Bounding controls (pass before *and* after)

Rust `genuine_zero_elevation_stays_finite_zero` passes against unfixed code too, as a bounding control must. On the TS side, a genuinely unresolvable (NaN) grid fill must **still** fall back to the storey table, and a genuine non-zero elevation must still bucket directly. Without those, "trust every `worldY`" would satisfy the Y=0 test while quietly destroying the fallback.

## Displacement sweep — every raw `worldY` consumer checked

Emitting NaN where `0` used to flow is only safe if no consumer is poisoned by it, so I checked them all rather than assuming:

- **The renderer path is safe.** `useSymbolicAnnotations` lifts geometry with `resolveBucketY(bucket.storeyElevation, fallbackY)` — never the raw primitive — and NaN primitives land in the loose bucket, which uses a finite `fallbackY`. This one mattered: `packages/renderer`'s fill upload feeds `expandModelBoundsWithFlatVertices` and then `camera.setSceneBounds`, so a NaN vertex there would have poisoned **model bounds for the whole scene**, not just the annotation.
- **`useDrawingGeneration`'s section culling is safe.** It reads `SymbolicDrawingLine.worldY`, which `symbolic-drawing-lines.ts`'s `elevationOrUnknown` already maps non-finite → `undefined`, and the existing `wy === undefined` guard keeps (does not cull) such lines. I briefly added a redundant `Number.isFinite` guard here and reverted it once I found `elevationOrUnknown` — the diff is deliberately not widened.

## Verification

`apps/viewer` overlay-parse **46 pass / 0 fail**; `tsc --noEmit` **exit 0**. `rust/processing` full `cargo test`: **46 test binaries, all green**, module-size ratchet included (scratch `CARGO_TARGET_DIR` throughout). `rust/wasm-bindings` `cargo check` green.

**No changeset:** `apps/viewer` is `"private": true` and `rust/processing` is a Rust crate, not an npm package. Verified against history — no prior `rust/processing/src` commit carries one and none reference the wasm package. Say the word if you'd rather it did.

## Notes / deliberately not done

- **`transform.rs` is 393 → 399 lines against the ratchet's `LIMIT = 400`.** It fits, but with one line of headroom; the next addition there should split the module rather than raise a budget.
- **The `.wasm` binary is not rebuilt here** — only the upstream `rust/processing` crate changed, confirmed still compiling through `wasm-bindings`. Producing a new binary is a release-pipeline step, so the TS-side fix only takes effect once wasm is rebuilt. Flagging so this isn't mistaken for an immediately-live fix.
- **`items.rs`'s `IfcMappedItem` origin/target resolution has the same `identity()`-as-failure shape**, but that file is already **at** its ratchet ceiling (440/440) and it's a rarer nested path, not the top-level annotation placement this issue describes. Flagged for a follow-up rather than risking a ratchet violation for marginal coverage — happy to do it as a split-module PR if you want it closed now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected annotation elevation handling so valid placements at elevation `0` are preserved and grouped correctly.
  - Improved fallback behavior for unresolved elevations using available storey information.
  - Ensured invalid or unresolved placements remain distinguishable from legitimate zero-elevation placements.

- **Tests**
  - Added regression coverage for zero-elevation annotations and unresolved placement references.
  - Expanded validation of elevation bucketing and placement-resolution edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->