### PR TITLE
fix(symbolic): IfcMappedItem resolution failures must not read as Y=0

### DIFF
--- a/rust/processing/src/symbolic/items.rs
+++ b/rust/processing/src/symbolic/items.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use ifc_lite_core::{AttributeValue, DecodedEntity, EntityDecoder, IfcType};
+use ifc_lite_core::{DecodedEntity, EntityDecoder, IfcType};
 use std::collections::HashMap;
 
 use super::fill::extract_annotation_fill_area;
@@ -12,6 +12,7 @@ use super::transform::{
     circle_center, compose_transforms, parse_axis2_placement_2d,
     parse_cartesian_transformation_operator, Transform2D,
 };
+use super::trimmed_curve::extract_trimmed_curve;
 
 // ────────────────────────────────────────────────────────────────────────────
 // Item dispatch. One function per IFC representation-item type; recursive
@@ -58,21 +59,25 @@ pub(super) fn extract_symbolic_item(
             let Some(source_id) = item.get_ref(0) else { return };
             let Ok(rep_map) = decoder.decode_by_id(source_id) else { return };
 
-            // MappingOrigin (rep_map attr 0) defines the local coord origin.
+            // MappingOrigin (rep_map attr 0) is MANDATORY on IfcRepresentationMap
+            // (unlike ObjectPlacement's optional PlacementRelTo): a dangling ref
+            // or an absent/null attribute is malformed data, not a legitimate
+            // zero, so both become `unresolved()` (#2256).
             let mapping_origin_transform = match rep_map.get_ref(0) {
                 Some(origin_id) => match decoder.decode_by_id(origin_id) {
                     Ok(origin) => parse_axis2_placement_2d(&origin, decoder, unit_scale),
-                    Err(_) => Transform2D::identity(),
+                    Err(_) => Transform2D::unresolved(), // dangling ref (#2256)
                 },
-                None => Transform2D::identity(),
+                None => Transform2D::unresolved(), // mandatory attr absent (#2256)
             };
-            // MappingTarget (item attr 1) — additional transform.
+            // MappingTarget (item attr 1) is likewise MANDATORY on
+            // IfcMappedItem — same failure/absence treatment as above.
             let mapping_target_transform = match item.get_ref(1) {
                 Some(target_ref) => match decoder.decode_by_id(target_ref) {
                     Ok(target) => parse_cartesian_transformation_operator(&target, decoder, unit_scale),
-                    Err(_) => Transform2D::identity(),
+                    Err(_) => Transform2D::unresolved(), // dangling ref (#2256)
                 },
-                None => Transform2D::identity(),
+                None => Transform2D::unresolved(), // mandatory attr absent (#2256)
             };
             let origin_with_target =
                 compose_transforms(&mapping_target_transform, &mapping_origin_transform);
@@ -316,125 +321,3 @@ pub(super) fn extract_symbolic_item(
     }
 }
 
-/// Tessellate an `IfcTrimmedCurve` whose `BasisCurve` is an `IfcCircle`.
-/// Honours `PLANEANGLEUNIT` scaling, `SenseAgreement`, and wrap-around so
-/// the 2D arc matches the 3D arc on the same curve. Near-collinear arcs
-/// (large radius, small sagitta) collapse to a straight segment.
-#[allow(clippy::too_many_arguments)]
-fn extract_trimmed_curve(
-    item: &DecodedEntity,
-    decoder: &mut EntityDecoder,
-    express_id: u32,
-    ifc_type: &str,
-    rep_identifier: &str,
-    unit_scale: f32,
-    transform: &Transform2D,
-    rtc_x: f32,
-    rtc_z: f32,
-    out: &mut SymbolicData,
-) {
-    let Some(basis_ref) = item.get_ref(0) else { return };
-    let Ok(basis_curve) = decoder.decode_by_id(basis_ref) else { return };
-    if basis_curve.ifc_type != IfcType::IfcCircle {
-        return;
-    }
-    let radius = basis_curve.get(1).and_then(|a| a.as_float()).unwrap_or(0.0) as f32 * unit_scale;
-    if radius <= 0.0 || !radius.is_finite() {
-        return;
-    }
-    let (center_x, center_y, center_z) = circle_center(&basis_curve, decoder, unit_scale);
-    if !center_x.is_finite() || !center_y.is_finite() {
-        return;
-    }
-    let world_y = center_z + transform.tz;
-
-    let angle_scale = decoder.plane_angle_to_radians() as f32;
-    let raw_trim1: Option<f32> = item
-        .get(1)
-        .and_then(|a| a.as_list().and_then(|l| l.first().and_then(|v| v.as_float())))
-        .map(|v| v as f32);
-    let raw_trim2: Option<f32> = item
-        .get(2)
-        .and_then(|a| a.as_list().and_then(|l| l.first().and_then(|v| v.as_float())))
-        .map(|v| v as f32);
-    let sense = item
-        .get(3)
-        .and_then(|v| match v {
-            AttributeValue::Enum(s) => Some(s == "T" || s == "TRUE" || s == ".T."),
-            _ => None,
-        })
-        .unwrap_or(true);
-
-    let start_angle = raw_trim1.map(|v| v * angle_scale).unwrap_or(0.0);
-    let mut end_angle = raw_trim2.map(|v| v * angle_scale).unwrap_or(std::f32::consts::TAU);
-    if sense && end_angle < start_angle {
-        end_angle += std::f32::consts::TAU;
-    } else if !sense && end_angle > start_angle {
-        end_angle -= std::f32::consts::TAU;
-    }
-    if !start_angle.is_finite() || !end_angle.is_finite() {
-        return;
-    }
-
-    let start_x = center_x + radius * start_angle.cos();
-    let start_y = center_y + radius * start_angle.sin();
-    let end_x = center_x + radius * end_angle.cos();
-    let end_y = center_y + radius * end_angle.sin();
-    let chord_dx = end_x - start_x;
-    let chord_dy = end_y - start_y;
-    let chord_len = (chord_dx * chord_dx + chord_dy * chord_dy).sqrt();
-    let is_near_collinear = if chord_len > 0.0001 {
-        let mid_angle = (start_angle + end_angle) / 2.0;
-        let mid_x = center_x + radius * mid_angle.cos();
-        let mid_y = center_y + radius * mid_angle.sin();
-        let sagitta = ((end_y - start_y) * mid_x - (end_x - start_x) * mid_y
-            + end_x * start_y
-            - end_y * start_x)
-            .abs()
-            / chord_len;
-        radius > 100.0 || sagitta < chord_len * 0.02 || radius > chord_len * 10.0
-    } else {
-        true
-    };
-
-    if is_near_collinear {
-        let (wsx, wsy) = transform.transform_point(start_x, start_y);
-        let (wex, wey) = transform.transform_point(end_x, end_y);
-        let points = vec![wsx - rtc_x, -wsy + rtc_z, wex - rtc_x, -wey + rtc_z];
-        out.polylines.push(SymbolicPolyline {
-            express_id,
-            ifc_type: ifc_type.to_string(),
-            points,
-            closed: false,
-            world_y,
-            representation: rep_identifier.to_string(),
-        });
-    } else {
-        let arc_length = (end_angle - start_angle).abs();
-        let num_segments = ((arc_length * radius / 0.1) as usize).max(8).min(64);
-        let mut points = Vec::with_capacity((num_segments + 1) * 2);
-        for i in 0..=num_segments {
-            let t = i as f32 / num_segments as f32;
-            let angle = start_angle + t * (end_angle - start_angle);
-            let local_x = center_x + radius * angle.cos();
-            let local_y = center_y + radius * angle.sin();
-            let (wx, wy) = transform.transform_point(local_x, local_y);
-            let x = wx - rtc_x;
-            let y = -wy + rtc_z;
-            if x.is_finite() && y.is_finite() {
-                points.push(x);
-                points.push(y);
-            }
-        }
-        if points.len() >= 4 {
-            out.polylines.push(SymbolicPolyline {
-                express_id,
-                ifc_type: ifc_type.to_string(),
-                points,
-                closed: false,
-                world_y,
-                representation: rep_identifier.to_string(),
-            });
-        }
-    }
-}

--- a/rust/processing/src/symbolic/items.rs
+++ b/rust/processing/src/symbolic/items.rs
@@ -65,7 +65,13 @@ pub(super) fn extract_symbolic_item(
             // zero, so both become `unresolved()` (#2256).
             let mapping_origin_transform = match rep_map.get_ref(0) {
                 Some(origin_id) => match decoder.decode_by_id(origin_id) {
-                    Ok(origin) => parse_axis2_placement_2d(&origin, decoder, unit_scale),
+                    Ok(origin)
+                        if origin.ifc_type == IfcType::IfcAxis2Placement2D
+                            || origin.ifc_type == IfcType::IfcAxis2Placement3D =>
+                    {
+                        parse_axis2_placement_2d(&origin, decoder, unit_scale)
+                    }
+                    Ok(_) => Transform2D::unresolved(), // wrong type (#2355)
                     Err(_) => Transform2D::unresolved(), // dangling ref (#2256)
                 },
                 None => Transform2D::unresolved(), // mandatory attr absent (#2256)
@@ -74,7 +80,19 @@ pub(super) fn extract_symbolic_item(
             // IfcMappedItem — same failure/absence treatment as above.
             let mapping_target_transform = match item.get_ref(1) {
                 Some(target_ref) => match decoder.decode_by_id(target_ref) {
-                    Ok(target) => parse_cartesian_transformation_operator(&target, decoder, unit_scale),
+                    Ok(target)
+                        if matches!(
+                            target.ifc_type,
+                            IfcType::IfcCartesianTransformationOperator
+                                | IfcType::IfcCartesianTransformationOperator2D
+                                | IfcType::IfcCartesianTransformationOperator2DnonUniform
+                                | IfcType::IfcCartesianTransformationOperator3D
+                                | IfcType::IfcCartesianTransformationOperator3DnonUniform
+                        ) =>
+                    {
+                        parse_cartesian_transformation_operator(&target, decoder, unit_scale)
+                    }
+                    Ok(_) => Transform2D::unresolved(), // wrong type (#2355)
                     Err(_) => Transform2D::unresolved(), // dangling ref (#2256)
                 },
                 None => Transform2D::unresolved(), // mandatory attr absent (#2256)

--- a/rust/processing/src/symbolic/mod.rs
+++ b/rust/processing/src/symbolic/mod.rs
@@ -70,6 +70,7 @@ mod items;
 mod primitives;
 mod text;
 mod transform;
+mod trimmed_curve;
 
 pub use primitives::{
     SymbolicCircle, SymbolicData, SymbolicFillArea, SymbolicGridAxis, SymbolicPolyline, SymbolicText,

--- a/rust/processing/src/symbolic/transform.rs
+++ b/rust/processing/src/symbolic/transform.rs
@@ -186,9 +186,9 @@ pub(super) fn parse_axis2_placement_2d(
                 let raw_z = coords.get(2).and_then(|v| v.as_float()).unwrap_or(0.0) as f32;
                 (raw_x * unit_scale, raw_y * unit_scale, raw_z * unit_scale)
             }
-            _ => (0.0, 0.0, 0.0),
+            _ => return Transform2D::unresolved(), // dangling ref/wrong type: mandatory Location (#2355)
         },
-        None => (0.0, 0.0, 0.0),
+        None => return Transform2D::unresolved(), // mandatory Location absent (#2355)
     };
 
     // RefDirection lives at attr 2 for 3D, attr 1 for 2D.

--- a/rust/processing/src/symbolic/trimmed_curve.rs
+++ b/rust/processing/src/symbolic/trimmed_curve.rs
@@ -1,0 +1,134 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! `IfcTrimmedCurve` tessellation, split out of `items.rs` to keep that
+//! module's dispatch table under the module-size ratchet (#2256 follow-up).
+
+use ifc_lite_core::{AttributeValue, DecodedEntity, EntityDecoder, IfcType};
+
+use super::primitives::{SymbolicData, SymbolicPolyline};
+use super::transform::{circle_center, Transform2D};
+
+/// Tessellate an `IfcTrimmedCurve` whose `BasisCurve` is an `IfcCircle`.
+/// Honours `PLANEANGLEUNIT` scaling, `SenseAgreement`, and wrap-around so
+/// the 2D arc matches the 3D arc on the same curve. Near-collinear arcs
+/// (large radius, small sagitta) collapse to a straight segment.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn extract_trimmed_curve(
+    item: &DecodedEntity,
+    decoder: &mut EntityDecoder,
+    express_id: u32,
+    ifc_type: &str,
+    rep_identifier: &str,
+    unit_scale: f32,
+    transform: &Transform2D,
+    rtc_x: f32,
+    rtc_z: f32,
+    out: &mut SymbolicData,
+) {
+    let Some(basis_ref) = item.get_ref(0) else { return };
+    let Ok(basis_curve) = decoder.decode_by_id(basis_ref) else { return };
+    if basis_curve.ifc_type != IfcType::IfcCircle {
+        return;
+    }
+    let radius = basis_curve.get(1).and_then(|a| a.as_float()).unwrap_or(0.0) as f32 * unit_scale;
+    if radius <= 0.0 || !radius.is_finite() {
+        return;
+    }
+    let (center_x, center_y, center_z) = circle_center(&basis_curve, decoder, unit_scale);
+    if !center_x.is_finite() || !center_y.is_finite() {
+        return;
+    }
+    let world_y = center_z + transform.tz;
+
+    let angle_scale = decoder.plane_angle_to_radians() as f32;
+    let raw_trim1: Option<f32> = item
+        .get(1)
+        .and_then(|a| a.as_list().and_then(|l| l.first().and_then(|v| v.as_float())))
+        .map(|v| v as f32);
+    let raw_trim2: Option<f32> = item
+        .get(2)
+        .and_then(|a| a.as_list().and_then(|l| l.first().and_then(|v| v.as_float())))
+        .map(|v| v as f32);
+    let sense = item
+        .get(3)
+        .and_then(|v| match v {
+            AttributeValue::Enum(s) => Some(s == "T" || s == "TRUE" || s == ".T."),
+            _ => None,
+        })
+        .unwrap_or(true);
+
+    let start_angle = raw_trim1.map(|v| v * angle_scale).unwrap_or(0.0);
+    let mut end_angle = raw_trim2.map(|v| v * angle_scale).unwrap_or(std::f32::consts::TAU);
+    if sense && end_angle < start_angle {
+        end_angle += std::f32::consts::TAU;
+    } else if !sense && end_angle > start_angle {
+        end_angle -= std::f32::consts::TAU;
+    }
+    if !start_angle.is_finite() || !end_angle.is_finite() {
+        return;
+    }
+
+    let start_x = center_x + radius * start_angle.cos();
+    let start_y = center_y + radius * start_angle.sin();
+    let end_x = center_x + radius * end_angle.cos();
+    let end_y = center_y + radius * end_angle.sin();
+    let chord_dx = end_x - start_x;
+    let chord_dy = end_y - start_y;
+    let chord_len = (chord_dx * chord_dx + chord_dy * chord_dy).sqrt();
+    let is_near_collinear = if chord_len > 0.0001 {
+        let mid_angle = (start_angle + end_angle) / 2.0;
+        let mid_x = center_x + radius * mid_angle.cos();
+        let mid_y = center_y + radius * mid_angle.sin();
+        let sagitta = ((end_y - start_y) * mid_x - (end_x - start_x) * mid_y
+            + end_x * start_y
+            - end_y * start_x)
+            .abs()
+            / chord_len;
+        radius > 100.0 || sagitta < chord_len * 0.02 || radius > chord_len * 10.0
+    } else {
+        true
+    };
+
+    if is_near_collinear {
+        let (wsx, wsy) = transform.transform_point(start_x, start_y);
+        let (wex, wey) = transform.transform_point(end_x, end_y);
+        let points = vec![wsx - rtc_x, -wsy + rtc_z, wex - rtc_x, -wey + rtc_z];
+        out.polylines.push(SymbolicPolyline {
+            express_id,
+            ifc_type: ifc_type.to_string(),
+            points,
+            closed: false,
+            world_y,
+            representation: rep_identifier.to_string(),
+        });
+    } else {
+        let arc_length = (end_angle - start_angle).abs();
+        let num_segments = ((arc_length * radius / 0.1) as usize).max(8).min(64);
+        let mut points = Vec::with_capacity((num_segments + 1) * 2);
+        for i in 0..=num_segments {
+            let t = i as f32 / num_segments as f32;
+            let angle = start_angle + t * (end_angle - start_angle);
+            let local_x = center_x + radius * angle.cos();
+            let local_y = center_y + radius * angle.sin();
+            let (wx, wy) = transform.transform_point(local_x, local_y);
+            let x = wx - rtc_x;
+            let y = -wy + rtc_z;
+            if x.is_finite() && y.is_finite() {
+                points.push(x);
+                points.push(y);
+            }
+        }
+        if points.len() >= 4 {
+            out.polylines.push(SymbolicPolyline {
+                express_id,
+                ifc_type: ifc_type.to_string(),
+                points,
+                closed: false,
+                world_y,
+                representation: rep_identifier.to_string(),
+            });
+        }
+    }
+}

--- a/rust/processing/tests/issue_2256_mapped_item_unresolved.rs
+++ b/rust/processing/tests/issue_2256_mapped_item_unresolved.rs
@@ -1,0 +1,157 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Regression test for the `items.rs` half of issue #2256, follow-up to
+//! #2352 (which fixed the top-level `ObjectPlacement` chain in
+//! `transform.rs` but deliberately left `IfcMappedItem`'s own
+//! `MappingOrigin` / `MappingTarget` resolution alone — that file was at
+//! its module-size ratchet ceiling at the time).
+//!
+//! `extract_symbolic_item`'s `IfcMappedItem` branch composes two 2D
+//! transforms before recursing into the mapped representation:
+//!
+//!   * `MappingOrigin` (`IfcRepresentationMap` attribute 0) — MANDATORY.
+//!   * `MappingTarget` (`IfcMappedItem` attribute 1) — MANDATORY.
+//!
+//! Both were falling back to `Transform2D::identity()` (`tz: 0.0`) on a
+//! dangling reference, which is bit-for-bit indistinguishable from a real
+//! ground-floor elevation — exactly the #2256 defect, just one level
+//! deeper in the recursion than the case #2352 already fixed.
+//!
+//! Three annotations share the same footprint square, each via a
+//! different `IfcMappedItem`:
+//!
+//!   * `#200` — everything resolves cleanly to Z = 0. This is a genuine
+//!     ground-floor elevation and `world_y` must stay exactly `0.0`
+//!     (bounding control: proves the fix does not just return NaN
+//!     unconditionally).
+//!   * `#300` — `MappingOrigin` is a dangling reference (`#999999` does
+//!     not exist). `world_y` must be non-finite.
+//!   * `#400` — `MappingTarget` is a dangling reference (`#999998` does
+//!     not exist). `world_y` must be non-finite.
+
+use ifc_lite_processing::extract_symbolic_data;
+
+const FIXTURE: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('issue-2256 mapped-item fixture'),'2;1');
+FILE_NAME('test.ifc','2026-08-07T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0$ScRe4drECQ4DMSqUjd6d',$,'P',$,$,$,$,(#2),#3);
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
+#3=IFCUNITASSIGNMENT((#6));
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#6=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#40=IFCLOCALPLACEMENT($,#5);
+
+/* ---- #200: mapped item, origin + target both resolve, genuine Z=0 ---- */
+#210=IFCCARTESIANPOINT((0.,0.));
+#211=IFCCARTESIANPOINT((1.,0.));
+#212=IFCCARTESIANPOINT((1.,1.));
+#213=IFCCARTESIANPOINT((0.,1.));
+#214=IFCCARTESIANPOINT((0.,0.));
+#220=IFCPOLYLINE((#210,#211,#212,#213,#214));
+#230=IFCSHAPEREPRESENTATION(#2,'Body','Curve2D',(#220));
+#240=IFCCARTESIANPOINT((0.,0.));
+#241=IFCAXIS2PLACEMENT2D(#240,$);
+#250=IFCREPRESENTATIONMAP(#241,#230);
+#260=IFCCARTESIANPOINT((0.,0.));
+#261=IFCCARTESIANTRANSFORMATIONOPERATOR2D($,$,#260,$);
+#270=IFCMAPPEDITEM(#250,#261);
+#280=IFCSHAPEREPRESENTATION(#2,'Annotation','MappedRepresentation',(#270));
+#281=IFCPRODUCTDEFINITIONSHAPE($,$,(#280));
+#200=IFCANNOTATION('2xScRe4drECQ4DMSqUjd6d',$,'GoodMappedZero',$,$,#40,#281);
+
+/* ---- #300: MappingOrigin (RepresentationMap attr 0) is dangling ---- */
+#310=IFCCARTESIANPOINT((5.,0.));
+#311=IFCCARTESIANPOINT((6.,0.));
+#312=IFCCARTESIANPOINT((6.,1.));
+#313=IFCCARTESIANPOINT((5.,1.));
+#314=IFCCARTESIANPOINT((5.,0.));
+#320=IFCPOLYLINE((#310,#311,#312,#313,#314));
+#330=IFCSHAPEREPRESENTATION(#2,'Body','Curve2D',(#320));
+#350=IFCREPRESENTATIONMAP(#999999,#330);
+#360=IFCCARTESIANPOINT((0.,0.));
+#361=IFCCARTESIANTRANSFORMATIONOPERATOR2D($,$,#360,$);
+#370=IFCMAPPEDITEM(#350,#361);
+#380=IFCSHAPEREPRESENTATION(#2,'Annotation','MappedRepresentation',(#370));
+#381=IFCPRODUCTDEFINITIONSHAPE($,$,(#380));
+#300=IFCANNOTATION('3xScRe4drECQ4DMSqUjd6d',$,'DanglingMappingOrigin',$,$,#40,#381);
+
+/* ---- #400: MappingTarget (MappedItem attr 1) is dangling ---- */
+#410=IFCCARTESIANPOINT((10.,0.));
+#411=IFCCARTESIANPOINT((11.,0.));
+#412=IFCCARTESIANPOINT((11.,1.));
+#413=IFCCARTESIANPOINT((10.,1.));
+#414=IFCCARTESIANPOINT((10.,0.));
+#420=IFCPOLYLINE((#410,#411,#412,#413,#414));
+#430=IFCSHAPEREPRESENTATION(#2,'Body','Curve2D',(#420));
+#440=IFCCARTESIANPOINT((0.,0.));
+#441=IFCAXIS2PLACEMENT2D(#440,$);
+#450=IFCREPRESENTATIONMAP(#441,#430);
+#470=IFCMAPPEDITEM(#450,#999998);
+#480=IFCSHAPEREPRESENTATION(#2,'Annotation','MappedRepresentation',(#470));
+#481=IFCPRODUCTDEFINITIONSHAPE($,$,(#480));
+#400=IFCANNOTATION('4xScRe4drECQ4DMSqUjd6d',$,'DanglingMappingTarget',$,$,#40,#481);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+#[test]
+fn genuine_zero_elevation_mapped_item_stays_finite_zero() {
+    let data = extract_symbolic_data(FIXTURE);
+    let pl = data
+        .polylines
+        .iter()
+        .find(|p| p.express_id == 200)
+        .expect("annotation #200 should produce a polyline via its IfcMappedItem");
+    assert_eq!(
+        pl.world_y, 0.0,
+        "MappingOrigin and MappingTarget both resolve cleanly to Z=0 — a \
+         genuine ground-floor elevation reached through an IfcMappedItem \
+         must stay exactly 0.0, not become non-finite"
+    );
+    assert!(pl.world_y.is_finite());
+}
+
+#[test]
+fn dangling_mapping_origin_is_not_finite() {
+    let data = extract_symbolic_data(FIXTURE);
+    let pl = data
+        .polylines
+        .iter()
+        .find(|p| p.express_id == 300)
+        .expect("annotation #300 should still produce a polyline (points are independent of MappingOrigin resolution)");
+    assert!(
+        !pl.world_y.is_finite(),
+        "IfcRepresentationMap #350's MappingOrigin (#999999) does not exist \
+         — ifc-lite cannot resolve the mapped item's local origin. world_y \
+         must be non-finite (NaN), not silently 0.0, or it becomes \
+         indistinguishable from a genuine ground-floor mapped item \
+         (issue #2256). Got: {}",
+        pl.world_y
+    );
+}
+
+#[test]
+fn dangling_mapping_target_is_not_finite() {
+    let data = extract_symbolic_data(FIXTURE);
+    let pl = data
+        .polylines
+        .iter()
+        .find(|p| p.express_id == 400)
+        .expect("annotation #400 should still produce a polyline (points are independent of MappingTarget resolution)");
+    assert!(
+        !pl.world_y.is_finite(),
+        "IfcMappedItem #470's MappingTarget (#999998) does not exist — \
+         ifc-lite cannot resolve the mapped item's target transform. \
+         world_y must be non-finite (NaN), not silently 0.0, or it becomes \
+         indistinguishable from a genuine ground-floor mapped item \
+         (issue #2256). Got: {}",
+        pl.world_y
+    );
+}

--- a/rust/processing/tests/issue_2355_wrong_type_resolution.rs
+++ b/rust/processing/tests/issue_2355_wrong_type_resolution.rs
@@ -1,0 +1,194 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Regression test for two #2256-shaped defects flagged on PR #2355 by
+//! maintainer review, both still open in `transform.rs` / `items.rs` after
+//! the `IfcMappedItem` fix landed:
+//!
+//!   * `parse_axis2_placement_2d` falls back to `(0.0, 0.0, 0.0)` — a
+//!     legitimate-looking resolved transform — when an `IfcAxis2Placement2D`
+//!     / `IfcAxis2Placement3D`'s own mandatory `Location` (attribute 0) is a
+//!     dangling reference or not an `IfcCartesianPoint`. The placement
+//!     entity itself is correctly typed and reached through a normal
+//!     `IfcLocalPlacement` chain — only its `Location` is malformed.
+//!   * `extract_symbolic_item`'s `IfcMappedItem` branch calls
+//!     `parse_axis2_placement_2d` / `parse_cartesian_transformation_operator`
+//!     on whatever `MappingOrigin` / `MappingTarget` resolve to, without
+//!     checking the resolved entity is actually the expected type first
+//!     (unlike `resolve_placement_for_symbolic`, which does check). A
+//!     `MappingOrigin` that resolves to some other entity (e.g. a bare
+//!     `IfcCartesianPoint`, which has no `RefDirection` attribute) is read
+//!     as an all-defaults identity transform instead of `unresolved()`.
+//!
+//! Both collapse a genuine resolution *failure* into a plausible-looking
+//! zero/identity transform, indistinguishable from a real ground-floor
+//! placement — exactly the #2256 defect shape, one level deeper.
+
+use ifc_lite_processing::extract_symbolic_data;
+
+const FIXTURE: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('issue-2355 wrong-type resolution fixture'),'2;1');
+FILE_NAME('test.ifc','2026-08-08T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0$ScRe4drECQ4DMSqUjd6d',$,'P',$,$,$,$,(#2),#3);
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
+#3=IFCUNITASSIGNMENT((#6));
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#6=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#40=IFCLOCALPLACEMENT($,#5);
+
+/* ---- #100: ground truth, resolves cleanly to genuine Z=0 ---- */
+#110=IFCCARTESIANPOINT((0.,0.));
+#111=IFCCARTESIANPOINT((1.,0.));
+#112=IFCCARTESIANPOINT((1.,1.));
+#113=IFCCARTESIANPOINT((0.,1.));
+#114=IFCCARTESIANPOINT((0.,0.));
+#120=IFCPOLYLINE((#110,#111,#112,#113,#114));
+#130=IFCSHAPEREPRESENTATION(#2,'Annotation','Annotation2D',(#120));
+#131=IFCPRODUCTDEFINITIONSHAPE($,$,(#130));
+#100=IFCANNOTATION('1xScRe4drECQ4DMSqUjd6d',$,'GenuineZero',$,$,#40,#131);
+
+/* ---- #200: ObjectPlacement's RelativePlacement is a correctly-typed
+   IFCAXIS2PLACEMENT3D, but ITS OWN Location (attr 0) is dangling (#999990
+   does not exist). The placement chain is otherwise completely normal. ---- */
+#210=IFCCARTESIANPOINT((5.,0.));
+#211=IFCCARTESIANPOINT((6.,0.));
+#212=IFCCARTESIANPOINT((6.,1.));
+#213=IFCCARTESIANPOINT((5.,1.));
+#214=IFCCARTESIANPOINT((5.,0.));
+#220=IFCPOLYLINE((#210,#211,#212,#213,#214));
+#230=IFCSHAPEREPRESENTATION(#2,'Annotation','Annotation2D',(#220));
+#231=IFCPRODUCTDEFINITIONSHAPE($,$,(#230));
+#240=IFCAXIS2PLACEMENT3D(#999990,$,$);
+#250=IFCLOCALPLACEMENT($,#240);
+#200=IFCANNOTATION('2xScRe4drECQ4DMSqUjd6d',$,'DanglingLocationOnValidPlacement',$,$,#250,#231);
+
+/* ---- #300: IfcMappedItem's MappingOrigin (RepresentationMap attr 0)
+   resolves to an entity that EXISTS but is the WRONG type — a bare
+   IFCCARTESIANPOINT instead of an IFCAXIS2PLACEMENT2D/3D. ---- */
+#310=IFCCARTESIANPOINT((10.,0.));
+#311=IFCCARTESIANPOINT((11.,0.));
+#312=IFCCARTESIANPOINT((11.,1.));
+#313=IFCCARTESIANPOINT((10.,1.));
+#314=IFCCARTESIANPOINT((10.,0.));
+#320=IFCPOLYLINE((#310,#311,#312,#313,#314));
+#330=IFCSHAPEREPRESENTATION(#2,'Body','Curve2D',(#320));
+#340=IFCCARTESIANPOINT((0.,0.));
+/* Malformed on purpose: attr 0 of an IFCLOCALPLACEMENT is normally
+   PlacementRelTo (an ObjectPlacement ref), but this file points it at
+   #340, a genuine IFCCARTESIANPOINT — the STEP decoder resolves refs by
+   id regardless of expected type, so #341's own express type is
+   IfcLocalPlacement while its attr(0) coincidentally resolves to a real
+   IfcCartesianPoint. This exercises the items.rs call site's type check
+   in isolation: parse_axis2_placement_2d's OWN internal Location-fallback
+   fix (transform.rs) cannot catch this, because attr(0) here legitimately
+   decodes as an IfcCartesianPoint — only rejecting #341's outer type
+   (IfcLocalPlacement is not IfcAxis2Placement2D/3D) catches it. */
+#341=IFCLOCALPLACEMENT(#340,#340);
+#350=IFCREPRESENTATIONMAP(#341,#330);
+#360=IFCCARTESIANPOINT((0.,0.));
+#361=IFCCARTESIANTRANSFORMATIONOPERATOR2D($,$,#360,$);
+#370=IFCMAPPEDITEM(#350,#361);
+#380=IFCSHAPEREPRESENTATION(#2,'Annotation','MappedRepresentation',(#370));
+#381=IFCPRODUCTDEFINITIONSHAPE($,$,(#380));
+#300=IFCANNOTATION('3xScRe4drECQ4DMSqUjd6d',$,'WrongTypeMappingOrigin',$,$,#40,#381);
+
+/* ---- #400: IfcMappedItem's MappingTarget (MappedItem attr 1) resolves
+   to an entity that EXISTS but is the WRONG type — a bare IFCCARTESIANPOINT
+   instead of an IFCCARTESIANTRANSFORMATIONOPERATOR2D/3D. ---- */
+#410=IFCCARTESIANPOINT((15.,0.));
+#411=IFCCARTESIANPOINT((16.,0.));
+#412=IFCCARTESIANPOINT((16.,1.));
+#413=IFCCARTESIANPOINT((15.,1.));
+#414=IFCCARTESIANPOINT((15.,0.));
+#420=IFCPOLYLINE((#410,#411,#412,#413,#414));
+#430=IFCSHAPEREPRESENTATION(#2,'Body','Curve2D',(#420));
+#440=IFCCARTESIANPOINT((0.,0.));
+#441=IFCAXIS2PLACEMENT2D(#440,$);
+#450=IFCREPRESENTATIONMAP(#441,#430);
+#460=IFCCARTESIANPOINT((0.,0.));
+#470=IFCMAPPEDITEM(#450,#460);
+#480=IFCSHAPEREPRESENTATION(#2,'Annotation','MappedRepresentation',(#470));
+#481=IFCPRODUCTDEFINITIONSHAPE($,$,(#480));
+#400=IFCANNOTATION('4xScRe4drECQ4DMSqUjd6d',$,'WrongTypeMappingTarget',$,$,#40,#481);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+#[test]
+fn genuine_zero_elevation_stays_finite_zero() {
+    let data = extract_symbolic_data(FIXTURE);
+    let pl = data
+        .polylines
+        .iter()
+        .find(|p| p.express_id == 100)
+        .expect("annotation #100 should produce a polyline");
+    assert_eq!(
+        pl.world_y, 0.0,
+        "a fully-resolved chain to a real ground-floor elevation must stay \
+         exactly 0.0 — bounding control proving the fix does not just \
+         return NaN unconditionally"
+    );
+    assert!(pl.world_y.is_finite());
+}
+
+#[test]
+fn dangling_location_on_correctly_typed_placement_is_not_finite() {
+    let data = extract_symbolic_data(FIXTURE);
+    let pl = data
+        .polylines
+        .iter()
+        .find(|p| p.express_id == 200)
+        .expect("annotation #200 should still produce a polyline (points are independent of placement resolution)");
+    assert!(
+        !pl.world_y.is_finite(),
+        "IFCAXIS2PLACEMENT3D #240 is the correct type reached through a \
+         normal IfcLocalPlacement chain, but its own Location (#999990) is \
+         a dangling reference. world_y must be non-finite (NaN), not \
+         silently 0.0 — a resolved-looking (0,0,0) here is indistinguishable \
+         from #100's genuine ground floor. Got: {}",
+        pl.world_y
+    );
+}
+
+#[test]
+fn wrong_type_mapping_origin_is_not_finite() {
+    let data = extract_symbolic_data(FIXTURE);
+    let pl = data
+        .polylines
+        .iter()
+        .find(|p| p.express_id == 300)
+        .expect("annotation #300 should still produce a polyline (points are independent of MappingOrigin resolution)");
+    assert!(
+        !pl.world_y.is_finite(),
+        "IfcRepresentationMap #350's MappingOrigin (#341) exists but is an \
+         IFCLOCALPLACEMENT, not an IFCAXIS2PLACEMENT2D/3D — parsing it as a \
+         placement anyway (its attr(0) coincidentally decodes as a real \
+         IfcCartesianPoint) silently produces a plausible identity \
+         transform. world_y must be non-finite (NaN). Got: {}",
+        pl.world_y
+    );
+}
+
+#[test]
+fn wrong_type_mapping_target_is_not_finite() {
+    let data = extract_symbolic_data(FIXTURE);
+    let pl = data
+        .polylines
+        .iter()
+        .find(|p| p.express_id == 400)
+        .expect("annotation #400 should still produce a polyline (points are independent of MappingTarget resolution)");
+    assert!(
+        !pl.world_y.is_finite(),
+        "IfcMappedItem #470's MappingTarget (#460) exists but is an \
+         IFCCARTESIANPOINT, not an IFCCARTESIANTRANSFORMATIONOPERATOR2D/3D \
+         — parsing it as an operator anyway silently produces a plausible \
+         identity transform. world_y must be non-finite (NaN). Got: {}",
+        pl.world_y
+    );
+}

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -218,7 +218,6 @@
     1661 rust/processing/src/processor/mod.rs
 # +410: NEW row — #858 palette guard added the indexed_colour_split_ids param to process_entity_job (already the extracted per-job worker body from the #1623 file split), pushing this existing large module one line over 400; splitting the single job function further would fragment the tightly-coupled worker setup.
      410 rust/processing/src/processor/jobs.rs
-     440 rust/processing/src/symbolic/items.rs
 # +6: wire per-batch point-cache hit/miss stats into record_pipeline_batch (perf/brep-point-cache-instrumentation).
 # +13: attach the per-worker shared IfcMappedItem source cache to each batch router, mirroring the item-dedup attach (#1623).
 # +155: #1623 Phase 3 browser don't-bake — produce_batch gains arm_instancing (batch-local plan arm + occurrence collection + finalize call/return-tuple change) and the partitioned path folds the kept occurrences into the IFNS shard as empty-geometry refs; the finalize + recovery bodies were extracted to gpu_meshes/instancing.rs (new, ~165 lines) to hold the net down.


### PR DESCRIPTION
> **Stacked on #2352** — it needs that PR's `Transform2D::unresolved()`. Base is `fix/issue-2256-worldy`, so this diff shows only the new work. Review/merge #2352 first and this will retarget to `main` cleanly.

#2352 established the shape: in `symbolic/transform.rs`, returning `Transform2D::identity()` on a **genuine failure** was indistinguishable from a legitimate ground-floor elevation, because `identity().tz == 0.0`. `items.rs`'s `IfcMappedItem` branch has the identical shape and was left out of #2352 *only* because that file sat exactly **at** its module-size ratchet ceiling (440/440). This closes it.

## Four call sites, all mandatory attributes

- `rep_map.get_ref(0)` = `IfcRepresentationMap.MappingOrigin`
- `item.get_ref(1)` = `IfcMappedItem.MappingTarget`

Both the `Err(_)` (dangling ref) and `None` (absent/null) arms of each now return `unresolved()`.

**Attribute indices verified against the generated schema rather than assumed** — `rust/core/src/generated/schema.rs:11510` lists `IfcRepresentationMap => ["MappingOrigin", "MappedRepresentation"]` (index 0), and `:9843` lists `IfcMappedItem => ["MappingSource", "MappingTarget"]` (index 1).

Both attributes are **mandatory** in the schema, so absence is malformed data rather than a legitimate default. That's exactly the distinction #2352 drew — it deliberately **kept** `identity()` for `ObjectPlacement`, which *is* optional on `IfcProduct` (`transform.rs:114-119`). I re-verified that treatment is still correct rather than copying the new pattern blindly.

**Deliberately not changed:** the dangling `MappingSource` path at the top of the branch. It early-returns and emits nothing at all, so there's no elevation to be ambiguous about — a "drop the item" failure, not a "silently poison to 0.0" one.

## Ratchet: split, not raised

The fix alone pushed `items.rs` to 444 against its 440 ceiling. **No budget was raised.** `extract_trimmed_curve` — a self-contained `IfcTrimmedCurve` tessellation helper with no other callers — moved to a new sibling module `symbolic/trimmed_curve.rs`, following this directory's existing per-concern-file convention (`fill.rs`, `grid.rs`, `text.rs`).

`items.rs` is now **323 lines** — under the global `LIMIT` of 400 — so its allowlist row was **deleted entirely** rather than adjusted, per the ratchet's own documented rule.

The move was verified to be a **pure move**: I extracted the function from both the before and after files and compared them — 117 lines, byte-identical modulo the visibility keyword a cross-module move requires. The split carries no behaviour risk of its own.

## RED proof

With the four `unresolved()` calls reverted to `identity()` (exact substring replacement, count asserted `== 4`):

```
test genuine_zero_elevation_mapped_item_stays_finite_zero ... ok
test dangling_mapping_origin_is_not_finite ... FAILED
test dangling_mapping_target_is_not_finite ... FAILED
... world_y must be non-finite (NaN), not silently 0.0 ... Got: 0
test result: FAILED. 1 passed; 2 failed
```

Restored by file copy and proven byte-identical with `diff`.

## Bounding control (passes before *and* after)

`genuine_zero_elevation_mapped_item_stays_finite_zero` — a mapped item whose `MappingOrigin` and `MappingTarget` both resolve cleanly to Z=0 still yields exactly `world_y == 0.0`. Note it **passes in the RED run above**, as a bounding control must. Without it, "return NaN unconditionally" would satisfy both failure tests.

## Displacement

This widens NaN to a rarer, deeper case on the **same field #2352 already swept** (`SymbolicPolyline.world_y` and its circle/text equivalents), through the identical pipe, so no new consumer is exposed. I re-confirmed the two that matter: `symbolic-parse.ts:119` gates on `Number.isFinite` and is source-agnostic, and the renderer never receives a raw primitive Y — `useSymbolicAnnotations` passes `resolveBucketY(bucket.storeyElevation, fallbackY)`, both finite. That second one matters because the fill upload feeds `expandModelBoundsWithFlatVertices` → `camera.setSceneBounds`, where a NaN would poison model bounds for the whole scene.

## Verification

`rust/processing` full `cargo test`: **47 test binaries, all green, exit 0**, module-size ratchet included (scratch `CARGO_TARGET_DIR` throughout). +3 tests. No changeset — Rust crate, not an npm package.

## The shape is not yet fully closed — enumerated, not estimated

Six `Transform2D::identity()`-on-failure sites remain in this directory: **`text.rs:38`, `text.rs:40`, and `mod.rs:202,204,209,211`**. They are *not* fixed here and are being handled separately rather than silently widening this diff.

The three remaining sites in `transform.rs` (115, 118, 145) are **correct as-is** — those are the optional-`ObjectPlacement` and top-of-placement-chain cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed or missing mapped-item references and placements.
  * Prevented invalid geometry from being treated as valid zero-position transforms.
  * Improved tessellation of circular trimmed curves, including angle wrapping, units, and invalid geometry handling.

* **Tests**
  * Added regression coverage for unresolved, dangling, and incorrectly typed references.
  * Verified valid zero coordinates remain correctly recognized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->