### PR TITLE
fix(symbolic): text Placement resolution failures must not read as Y=0

### DIFF
--- a/rust/processing/src/symbolic/text.rs
+++ b/rust/processing/src/symbolic/text.rs
@@ -32,12 +32,16 @@ pub(super) fn extract_text_literal(
         None => return,
     };
 
+    // `Placement` (IfcTextLiteral attribute 1) is MANDATORY per schema — not
+    // OPTIONAL like IfcProduct.ObjectPlacement (see transform.rs). A dangling
+    // ref or an absent/null attribute here is malformed data, not a
+    // legitimate zero, so both are genuine failures (#2256).
     let placement_transform = match item.get_ref(1) {
         Some(p_ref) => match decoder.decode_by_id(p_ref) {
             Ok(p) => parse_axis2_placement_2d(&p, decoder, unit_scale),
-            Err(_) => Transform2D::identity(),
+            Err(_) => Transform2D::unresolved(), // dangling ref (#2256)
         },
-        None => Transform2D::identity(),
+        None => Transform2D::unresolved(), // mandatory attr absent (#2256)
     };
     let composed = compose_transforms(transform, &placement_transform);
 

--- a/rust/processing/src/symbolic/trimmed_curve.rs
+++ b/rust/processing/src/symbolic/trimmed_curve.rs
@@ -107,7 +107,21 @@ pub(super) fn extract_trimmed_curve(
     let chord_dx = end_x - start_x;
     let chord_dy = end_y - start_y;
     let chord_len = (chord_dx * chord_dx + chord_dy * chord_dy).sqrt();
-    let is_near_collinear = if chord_len > 0.0001 {
+    // A circle is injective mod TAU, so the chord can only shrink toward 0
+    // for two reasons: the trim barely moves at all (angle_span ~ 0), or
+    // the trim sweeps one or more FULL turns (angle_span ~ k*TAU, k >= 1)
+    // and the start/end points coincide by construction. Only the first
+    // case is degenerate; the second is a full circle (or a near-full
+    // circle, whose small-but-nonzero chord previously slipped through
+    // the `radius > chord_len * 10.0` shortcut below) and must still be
+    // tessellated as an arc/loop, not collapsed to a 2-point chord.
+    let angle_span = (end_angle - start_angle).abs();
+    let turns = (angle_span / std::f32::consts::TAU).round();
+    let is_full_turn =
+        turns >= 1.0 && (angle_span - turns * std::f32::consts::TAU).abs() < 0.02;
+    let is_near_collinear = if is_full_turn {
+        false
+    } else if chord_len > 0.0001 {
         let mid_angle = (start_angle + end_angle) / 2.0;
         let (mid_x, mid_y) = point_at(mid_angle);
         let sagitta = ((end_y - start_y) * mid_x - (end_x - start_x) * mid_y

--- a/rust/processing/src/symbolic/trimmed_curve.rs
+++ b/rust/processing/src/symbolic/trimmed_curve.rs
@@ -8,12 +8,18 @@
 use ifc_lite_core::{AttributeValue, DecodedEntity, EntityDecoder, IfcType};
 
 use super::primitives::{SymbolicData, SymbolicPolyline};
-use super::transform::{circle_center, Transform2D};
+use super::transform::{parse_axis2_placement_2d, Transform2D};
 
 /// Tessellate an `IfcTrimmedCurve` whose `BasisCurve` is an `IfcCircle`.
 /// Honours `PLANEANGLEUNIT` scaling, `SenseAgreement`, and wrap-around so
-/// the 2D arc matches the 3D arc on the same curve. Near-collinear arcs
-/// (large radius, small sagitta) collapse to a straight segment.
+/// the 2D arc matches the 3D arc on the same curve. Angles are measured in
+/// the circle's own placement basis, and both `IfcTrimmingSelect` forms
+/// (parameter and Cartesian point) are accepted — see [`resolve_trim`].
+///
+/// Near-collinear arcs collapse to a straight segment. The test is purely
+/// RELATIVE (sagitta vs chord, radius vs chord): a big circle is not by
+/// itself a straight line, and the absolute `radius > 100.0` that used to
+/// sit here flattened genuinely curved long-radius arcs.
 #[allow(clippy::too_many_arguments)]
 pub(super) fn extract_trimmed_curve(
     item: &DecodedEntity,
@@ -36,21 +42,46 @@ pub(super) fn extract_trimmed_curve(
     if radius <= 0.0 || !radius.is_finite() {
         return;
     }
-    let (center_x, center_y, center_z) = circle_center(&basis_curve, decoder, unit_scale);
-    if !center_x.is_finite() || !center_y.is_finite() {
+    // The trim angles are measured in the circle's OWN placement basis, not
+    // in world X/Y: `IfcCircle.Position.RefDirection` defines local +X and the
+    // angles run from there. `parse_axis2_placement_2d` yields exactly that
+    // basis — translation = the centre, linear block = the RefDirection
+    // rotation, which degrades to identity when RefDirection is absent, so a
+    // plain world-aligned circle is bit-identical to the old world-XY maths.
+    let basis = match basis_curve.get_ref(0) {
+        Some(pos_ref) => match decoder.decode_by_id(pos_ref) {
+            Ok(position) => parse_axis2_placement_2d(&position, decoder, unit_scale),
+            Err(_) => Transform2D::identity(),
+        },
+        None => Transform2D::identity(),
+    };
+    if !basis.tx.is_finite() || !basis.ty.is_finite() {
         return;
     }
-    let world_y = center_z + transform.tz;
+    let world_y = basis.tz + transform.tz;
 
     let angle_scale = decoder.plane_angle_to_radians() as f32;
-    let raw_trim1: Option<f32> = item
-        .get(1)
-        .and_then(|a| a.as_list().and_then(|l| l.first().and_then(|v| v.as_float())))
-        .map(|v| v as f32);
-    let raw_trim2: Option<f32> = item
-        .get(2)
-        .and_then(|a| a.as_list().and_then(|l| l.first().and_then(|v| v.as_float())))
-        .map(|v| v as f32);
+    // MasterRepresentation (attr 4) picks the form when the SET carries both.
+    let prefer_cartesian = item
+        .get(4)
+        .and_then(|v| v.as_enum())
+        .is_some_and(|s| s.trim_matches('.').eq_ignore_ascii_case("CARTESIAN"));
+    let raw_trim1 = resolve_trim(
+        item.get(1),
+        decoder,
+        &basis,
+        unit_scale,
+        angle_scale,
+        prefer_cartesian,
+    );
+    let raw_trim2 = resolve_trim(
+        item.get(2),
+        decoder,
+        &basis,
+        unit_scale,
+        angle_scale,
+        prefer_cartesian,
+    );
     let sense = item
         .get(3)
         .and_then(|v| match v {
@@ -59,8 +90,8 @@ pub(super) fn extract_trimmed_curve(
         })
         .unwrap_or(true);
 
-    let start_angle = raw_trim1.map(|v| v * angle_scale).unwrap_or(0.0);
-    let mut end_angle = raw_trim2.map(|v| v * angle_scale).unwrap_or(std::f32::consts::TAU);
+    let start_angle = raw_trim1.unwrap_or(0.0);
+    let mut end_angle = raw_trim2.unwrap_or(std::f32::consts::TAU);
     if sense && end_angle < start_angle {
         end_angle += std::f32::consts::TAU;
     } else if !sense && end_angle > start_angle {
@@ -70,23 +101,21 @@ pub(super) fn extract_trimmed_curve(
         return;
     }
 
-    let start_x = center_x + radius * start_angle.cos();
-    let start_y = center_y + radius * start_angle.sin();
-    let end_x = center_x + radius * end_angle.cos();
-    let end_y = center_y + radius * end_angle.sin();
+    let point_at = |angle: f32| basis.transform_point(radius * angle.cos(), radius * angle.sin());
+    let (start_x, start_y) = point_at(start_angle);
+    let (end_x, end_y) = point_at(end_angle);
     let chord_dx = end_x - start_x;
     let chord_dy = end_y - start_y;
     let chord_len = (chord_dx * chord_dx + chord_dy * chord_dy).sqrt();
     let is_near_collinear = if chord_len > 0.0001 {
         let mid_angle = (start_angle + end_angle) / 2.0;
-        let mid_x = center_x + radius * mid_angle.cos();
-        let mid_y = center_y + radius * mid_angle.sin();
+        let (mid_x, mid_y) = point_at(mid_angle);
         let sagitta = ((end_y - start_y) * mid_x - (end_x - start_x) * mid_y
             + end_x * start_y
             - end_y * start_x)
             .abs()
             / chord_len;
-        radius > 100.0 || sagitta < chord_len * 0.02 || radius > chord_len * 10.0
+        sagitta < chord_len * 0.02 || radius > chord_len * 10.0
     } else {
         true
     };
@@ -110,8 +139,7 @@ pub(super) fn extract_trimmed_curve(
         for i in 0..=num_segments {
             let t = i as f32 / num_segments as f32;
             let angle = start_angle + t * (end_angle - start_angle);
-            let local_x = center_x + radius * angle.cos();
-            let local_y = center_y + radius * angle.sin();
+            let (local_x, local_y) = point_at(angle);
             let (wx, wy) = transform.transform_point(local_x, local_y);
             let x = wx - rtc_x;
             let y = -wy + rtc_z;
@@ -131,4 +159,77 @@ pub(super) fn extract_trimmed_curve(
             });
         }
     }
+}
+
+/// Resolve one `IfcTrimmingSelect` SET to an angle in RADIANS on the circle.
+///
+/// `IfcTrimmingSelect` is `IfcParameterValue | IfcCartesianPoint`, and the
+/// SET may carry one of each (`SET [1:2]`). The parser hands a typed value
+/// `IFCPARAMETERVALUE(1.57)` back as `List([String(type), Float(v)])` and a
+/// point as an `EntityRef`, so both members have to be inspected by shape —
+/// looking only at `.first()` silently dropped point-first sets and
+/// point-only sets alike, leaving the caller with its full-circle default.
+///
+/// For a circle the parameter IS the angle, in `PLANEANGLEUNIT`. A Cartesian
+/// trim is converted by expressing the point in the circle's local basis and
+/// taking `atan2` there, which is why `basis` is needed: the same rotation
+/// that places the arc also defines where angle zero points.
+fn resolve_trim(
+    attr: Option<&AttributeValue>,
+    decoder: &mut EntityDecoder,
+    basis: &Transform2D,
+    unit_scale: f32,
+    angle_scale: f32,
+    prefer_cartesian: bool,
+) -> Option<f32> {
+    let members = attr?.as_list()?;
+    let mut from_parameter = None;
+    let mut from_cartesian = None;
+    for member in members {
+        match member {
+            AttributeValue::EntityRef(id) => {
+                if from_cartesian.is_none() {
+                    from_cartesian = cartesian_trim_angle(*id, decoder, basis, unit_scale);
+                }
+            }
+            other => {
+                // A typed `IFCPARAMETERVALUE(..)` decodes to List([name, value]);
+                // a bare number is accepted too, since exporters emit both.
+                if from_parameter.is_none() {
+                    from_parameter = other.as_float().map(|v| v as f32 * angle_scale);
+                }
+            }
+        }
+    }
+    if prefer_cartesian {
+        from_cartesian.or(from_parameter)
+    } else {
+        from_parameter.or(from_cartesian)
+    }
+}
+
+/// Angle of an `IfcCartesianPoint` trim, measured in the circle's local basis.
+fn cartesian_trim_angle(
+    point_id: u32,
+    decoder: &mut EntityDecoder,
+    basis: &Transform2D,
+    unit_scale: f32,
+) -> Option<f32> {
+    let point = decoder.decode_by_id(point_id).ok()?;
+    if point.ifc_type != IfcType::IfcCartesianPoint {
+        return None;
+    }
+    let coords = point.get(0).and_then(|a| a.as_list())?;
+    let px = coords.first().and_then(|v| v.as_float()).unwrap_or(0.0) as f32 * unit_scale;
+    let py = coords.get(1).and_then(|v| v.as_float()).unwrap_or(0.0) as f32 * unit_scale;
+    let dx = px - basis.tx;
+    let dy = py - basis.ty;
+    // The linear block is a pure rotation (`parse_axis2_placement_2d`), so its
+    // inverse is its transpose — no determinant needed.
+    let local_x = basis.m00 * dx + basis.m10 * dy;
+    let local_y = basis.m01 * dx + basis.m11 * dy;
+    if !local_x.is_finite() || !local_y.is_finite() || (local_x == 0.0 && local_y == 0.0) {
+        return None;
+    }
+    Some(local_y.atan2(local_x))
 }

--- a/rust/processing/tests/issue_2256_text_placement_unresolved.rs
+++ b/rust/processing/tests/issue_2256_text_placement_unresolved.rs
@@ -1,0 +1,120 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Regression test for `text.rs`'s half of issue #2256, the last two of the
+//! six sites #2352/#2355 flagged as remaining in `symbolic/`.
+//!
+//! `extract_text_literal` resolves `IfcTextLiteral.Placement` (attribute 1),
+//! which is MANDATORY per schema (`packages/codegen/schemas/
+//! IFC4_ADD2_TC1.exp`: `ENTITY IfcTextLiteral … Placement :
+//! IfcAxis2Placement;` — not `OPTIONAL`). Both the `Err(_)` (dangling ref)
+//! and `None` (absent/null attribute) arms were falling back to
+//! `Transform2D::identity()` (`tz: 0.0`), bit-for-bit indistinguishable from
+//! a real ground-floor elevation.
+//!
+//! Three annotations, each carrying one `IfcTextLiteralWithExtent`:
+//!
+//!   * `#200` — `Placement` resolves cleanly to Z = 0. Genuine ground-floor
+//!     elevation; `world_y` must stay exactly `0.0` (bounding control).
+//!   * `#300` — `Placement` is a dangling reference (`#999999` does not
+//!     exist). `world_y` must be non-finite.
+//!   * `#400` — `Placement` is null (`$`) on a mandatory attribute —
+//!     malformed data. `world_y` must be non-finite.
+
+use ifc_lite_processing::extract_symbolic_data;
+
+const FIXTURE: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('issue-2256 text-placement fixture'),'2;1');
+FILE_NAME('test.ifc','2026-08-07T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0$ScRe4drECQ4DMSqUjd6d',$,'P',$,$,$,$,(#2),#3);
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
+#3=IFCUNITASSIGNMENT((#6));
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#6=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#40=IFCLOCALPLACEMENT($,#5);
+
+/* ---- #200: text literal, Placement resolves, genuine Z=0 ---- */
+#210=IFCCARTESIANPOINT((0.,0.));
+#211=IFCAXIS2PLACEMENT2D(#210,$);
+#220=IFCPLANAREXTENT(1.,1.);
+#230=IFCTEXTLITERALWITHEXTENT('Good',#211,.LEFT.,#220,'bottom-left');
+#240=IFCSHAPEREPRESENTATION(#2,'Annotation','Annotation2D',(#230));
+#241=IFCPRODUCTDEFINITIONSHAPE($,$,(#240));
+#200=IFCANNOTATION('2xScRe4drECQ4DMSqUjd6d',$,'GoodText',$,$,#40,#241);
+
+/* ---- #300: Placement is a dangling reference ---- */
+#320=IFCPLANAREXTENT(1.,1.);
+#330=IFCTEXTLITERALWITHEXTENT('Dangling',#999999,.LEFT.,#320,'bottom-left');
+#340=IFCSHAPEREPRESENTATION(#2,'Annotation','Annotation2D',(#330));
+#341=IFCPRODUCTDEFINITIONSHAPE($,$,(#340));
+#300=IFCANNOTATION('3xScRe4drECQ4DMSqUjd6d',$,'DanglingPlacement',$,$,#40,#341);
+
+/* ---- #400: Placement is null on a mandatory attribute ---- */
+#420=IFCPLANAREXTENT(1.,1.);
+#430=IFCTEXTLITERALWITHEXTENT('Null',$,.LEFT.,#420,'bottom-left');
+#440=IFCSHAPEREPRESENTATION(#2,'Annotation','Annotation2D',(#430));
+#441=IFCPRODUCTDEFINITIONSHAPE($,$,(#440));
+#400=IFCANNOTATION('4xScRe4drECQ4DMSqUjd6d',$,'NullPlacement',$,$,#40,#441);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+#[test]
+fn genuine_zero_elevation_text_stays_finite_zero() {
+    let data = extract_symbolic_data(FIXTURE);
+    let t = data
+        .texts
+        .iter()
+        .find(|t| t.express_id == 200)
+        .expect("text literal for annotation #200 should be extracted");
+    assert_eq!(
+        t.world_y, 0.0,
+        "Placement resolves cleanly to Z=0 — a genuine ground-floor \
+         elevation on an IfcTextLiteral must stay exactly 0.0, not become \
+         non-finite"
+    );
+    assert!(t.world_y.is_finite());
+}
+
+#[test]
+fn dangling_text_placement_ref_is_not_finite() {
+    let data = extract_symbolic_data(FIXTURE);
+    let t = data
+        .texts
+        .iter()
+        .find(|t| t.express_id == 300)
+        .expect("text literal for annotation #300 should still be extracted (Placement resolution failure does not drop the item)");
+    assert!(
+        !t.world_y.is_finite(),
+        "IfcTextLiteralWithExtent #330 (annotation #300)'s Placement (#999999) does not \
+         exist — ifc-lite cannot resolve an elevation for this text. \
+         world_y must be non-finite (NaN), not silently 0.0, or it becomes \
+         indistinguishable from a genuine ground-floor annotation \
+         (issue #2256). Got: {}",
+        t.world_y
+    );
+}
+
+#[test]
+fn null_text_placement_on_mandatory_attr_is_not_finite() {
+    let data = extract_symbolic_data(FIXTURE);
+    let t = data
+        .texts
+        .iter()
+        .find(|t| t.express_id == 400)
+        .expect("text literal for annotation #400 should still be extracted (a null Placement does not drop the item)");
+    assert!(
+        !t.world_y.is_finite(),
+        "IfcTextLiteralWithExtent #430 (annotation #400)'s Placement is null ($) — a \
+         MANDATORY attribute per schema — so this is malformed data, not a \
+         legitimate default. world_y must be non-finite (NaN), not silently \
+         0.0 (issue #2256). Got: {}",
+        t.world_y
+    );
+}

--- a/rust/processing/tests/issue_2356_trimmed_curve_basis.rs
+++ b/rust/processing/tests/issue_2356_trimmed_curve_basis.rs
@@ -249,6 +249,91 @@ END-ISO-10303-21;
     );
 }
 
+/// RED for the full-turn finding — trimming 0 → TAU makes the start and
+/// end points on the circle coincide, so the chord length is ~0. That
+/// used to hit the `else { true }` fallback in the collinearity test and
+/// collapse the WHOLE circle into a degenerate 2-point segment. A full
+/// turn must still be tessellated as a many-point loop that passes
+/// through all four cardinal points of the circle.
+#[test]
+fn full_turn_trim_is_not_collapsed_to_two_points() {
+    let ifc = fixture(
+        "$",
+        "(IFCPARAMETERVALUE(0.))",
+        "(IFCPARAMETERVALUE(6.283185307179586))",
+        ".PARAMETER.",
+        "",
+    );
+    let data = extract_symbolic_data(&ifc);
+    assert_eq!(data.polylines.len(), 1);
+    let p = &data.polylines[0];
+    assert!(
+        p.points.len() > 4,
+        "a full-turn (0 -> TAU) trim must be tessellated as a circle, not \
+         collapsed to a 2-point chord; got {} points",
+        p.points.len() / 2
+    );
+    // Every cardinal point of the radius-2 circle must appear somewhere
+    // in the tessellation (world Y is negated by the symbolic projection).
+    let has_point = |wx: f32, wy: f32| {
+        (0..p.points.len() / 2).any(|i| {
+            let (x, y) = (p.points[2 * i], p.points[2 * i + 1]);
+            (x - wx).abs() < 0.1 && (y - wy).abs() < 0.1
+        })
+    };
+    assert!(has_point(2.0, 0.0), "full circle must pass through (2,0)");
+    assert!(has_point(-2.0, 0.0), "full circle must pass through (-2,0)");
+    assert!(has_point(0.0, 2.0), "full circle must pass through (0,-2) world (0,2 local)");
+    assert!(has_point(0.0, -2.0), "full circle must pass through (0,2) world (0,-2 local)");
+}
+
+/// RED (bounding-adjacent) for the near-full-turn variant — 0 → TAU - ε
+/// leaves a tiny gap, so start/end do NOT coincide, but the chord between
+/// them is still small relative to the radius. The old
+/// `radius > chord_len * 10.0` shortcut treated that as "basically
+/// straight" and flattened a near-complete circle into a 2-point chord.
+#[test]
+fn near_full_turn_trim_is_not_flattened_by_the_radius_shortcut() {
+    let ifc = fixture(
+        "$",
+        "(IFCPARAMETERVALUE(0.))",
+        "(IFCPARAMETERVALUE(6.278185307179586))", // TAU - 0.005 rad
+        ".PARAMETER.",
+        "",
+    );
+    let data = extract_symbolic_data(&ifc);
+    assert_eq!(data.polylines.len(), 1);
+    let p = &data.polylines[0];
+    assert!(
+        p.points.len() > 4,
+        "a near-full-turn trim must still be tessellated as an arc, not \
+         collapsed to a 2-point chord; got {} points",
+        p.points.len() / 2
+    );
+}
+
+/// BOUNDING CONTROL — a genuinely degenerate trim (start == end, no
+/// revolution at all) must still collapse. This must hold BEFORE and
+/// AFTER the full-turn fix: only chord-near-zero-BECAUSE-OF-a-full-turn
+/// is exempted, not chord-near-zero-because-the-trim-doesn't-move.
+#[test]
+fn zero_span_trim_still_collapses_to_a_point_segment() {
+    let ifc = fixture(
+        "$",
+        "(IFCPARAMETERVALUE(0.))",
+        "(IFCPARAMETERVALUE(0.))",
+        ".PARAMETER.",
+        "",
+    );
+    let data = extract_symbolic_data(&ifc);
+    assert_eq!(data.polylines.len(), 1);
+    assert_eq!(
+        data.polylines[0].points.len(),
+        4,
+        "a zero-span trim is degenerate: expected a 2-point segment"
+    );
+}
+
 /// BOUNDING CONTROL — reversed `SenseAgreement` still wraps the other
 /// way. 0 → π/2 with `.F.` sweeps the long way round, so the arc ends at
 /// (0,2) having travelled through (-2,0) and (0,-2).

--- a/rust/processing/tests/issue_2356_trimmed_curve_basis.rs
+++ b/rust/processing/tests/issue_2356_trimmed_curve_basis.rs
@@ -364,3 +364,52 @@ fn reversed_sense_sweeps_the_complementary_arc() {
     });
     assert!(passes_left, "reversed sweep should pass through (-2, 0)");
 }
+
+/// PINS: a review sub-finding on #2356 claimed the typed-parameter form
+/// `IFCPARAMETERVALUE(1.57)` — which the tokenizer hands back as
+/// `List([String("IFCPARAMETERVALUE"), Float(v)])`, not a bare `Float` —
+/// needed an extra unwrap in `resolve_trim`. It does not: `resolve_trim`
+/// calls `other.as_float()` on every non-`EntityRef` set member, and
+/// `AttributeValue::as_float()` already unwraps a `List([String, Float])`
+/// generically (`rust/core/src/schema_gen.rs`). This exercises the REAL
+/// tokenizer → decoder → `resolve_trim` path end to end, not the unit-level
+/// `as_float()` check in `schema_gen_tests.rs`.
+///
+/// Every other test in this file already sends its trims through
+/// `IFCPARAMETERVALUE(..)`, so this is not new coverage of the *shape* —
+/// it exists to make the claim explicit and independently mutation-checked.
+#[test]
+fn typed_float_parameter_value_trim_resolves_correctly() {
+    let ifc = fixture(
+        "$",
+        "(IFCPARAMETERVALUE(0.))",
+        "(IFCPARAMETERVALUE(1.5707963267948966))",
+        ".PARAMETER.",
+        "",
+    );
+    let (start, end) = endpoints(&ifc);
+    assert_close(start, (2.0, 0.0), "typed-float trim arc start");
+    assert_close(end, (0.0, -2.0), "typed-float trim arc end");
+}
+
+/// Same claim, for the INTEGER-valued typed form: `IFCPARAMETERVALUE(2)`
+/// (no decimal point) tokenizes its argument as `Token::Integer(2)`, so the
+/// wrapper is `List([String, Integer(2)])`. `as_float()` has a distinct
+/// match arm for `Integer` inside the `List` case (schema_gen.rs ~129) —
+/// an unwrap that handled `Float` but not `Integer` would be a real gap,
+/// so this is checked independently of the float case above.
+#[test]
+fn typed_integer_parameter_value_trim_resolves_correctly() {
+    let ifc = fixture(
+        "$",
+        "(IFCPARAMETERVALUE(0))",
+        "(IFCPARAMETERVALUE(2))",
+        ".PARAMETER.",
+        "",
+    );
+    let (start, end) = endpoints(&ifc);
+    assert_close(start, (2.0, 0.0), "typed-integer trim arc start");
+    // radius 2, angle 2 rad: (2*cos 2, 2*sin 2) = (-0.83229, 1.81859) in
+    // local/world coords; the symbolic projection negates Y on emission.
+    assert_close(end, (-0.83229, -1.81859), "typed-integer trim arc end");
+}

--- a/rust/processing/tests/issue_2356_trimmed_curve_basis.rs
+++ b/rust/processing/tests/issue_2356_trimmed_curve_basis.rs
@@ -1,0 +1,281 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Behaviour tests for `IfcTrimmedCurve` symbolic tessellation (PR #2356
+//! review findings). The extractor used to interpret the trim angles in
+//! WORLD X/Y and to read only the FIRST member of the `IfcTrimmingSelect`
+//! set, so a rotated `IfcCircle.Position` put the arc in the wrong place
+//! and a Cartesian-point trim silently degenerated to a full circle.
+//!
+//! Every assertion is on emitted coordinates, never on a flag.
+
+use ifc_lite_processing::extract_symbolic_data;
+
+/// Build a one-annotation fixture whose single representation item is an
+/// `IfcTrimmedCurve` over an `IfcCircle` of radius 2 m centred at the
+/// origin. `ref_direction` is the circle placement's RefDirection (`$`
+/// for "absent → local X == world X"), `trim1`/`trim2` are the raw
+/// `IfcTrimmingSelect` SET literals, and `extra` holds any entities the
+/// trims refer to.
+fn fixture(ref_direction: &str, trim1: &str, trim2: &str, master: &str, extra: &str) -> String {
+    format!(
+        r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('issue-2356 fixture'),'2;1');
+FILE_NAME('t.ifc','2026-08-08T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0$ScRe4drECQ4DMSqUjd6d',$,'P',$,$,$,$,(#2),#3);
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
+#3=IFCUNITASSIGNMENT((#6,#7));
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#6=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#7=IFCSIUNIT(*,.PLANEANGLEUNIT.,$,.RADIAN.);
+#40=IFCLOCALPLACEMENT($,#5);
+#50=IFCCARTESIANPOINT((0.,0.,0.));
+#51=IFCDIRECTION((0.,0.,1.));
+#52=IFCAXIS2PLACEMENT3D(#50,#51,{ref_direction});
+#53=IFCCIRCLE(#52,2.);
+{extra}
+#60=IFCTRIMMEDCURVE(#53,{trim1},{trim2},.T.,{master});
+#61=IFCSHAPEREPRESENTATION(#2,'Annotation','Annotation2D',(#60));
+#62=IFCPRODUCTDEFINITIONSHAPE($,$,(#61));
+#63=IFCANNOTATION('2xScRe4drECQ4DMSqUjd6d',$,'Note',$,$,#40,#62);
+ENDSEC;
+END-ISO-10303-21;
+"#
+    )
+}
+
+/// First and last emitted point of the single polyline, as (x, y).
+fn endpoints(ifc: &str) -> ((f32, f32), (f32, f32)) {
+    let data = extract_symbolic_data(ifc);
+    assert_eq!(
+        data.polylines.len(),
+        1,
+        "expected exactly one polyline, got {}",
+        data.polylines.len()
+    );
+    let p = &data.polylines[0];
+    assert!(p.points.len() >= 4, "degenerate polyline: {:?}", p.points);
+    let n = p.points.len();
+    (
+        (p.points[0], p.points[1]),
+        (p.points[n - 2], p.points[n - 1]),
+    )
+}
+
+fn assert_close(actual: (f32, f32), expected: (f32, f32), what: &str) {
+    let d = ((actual.0 - expected.0).powi(2) + (actual.1 - expected.1).powi(2)).sqrt();
+    assert!(
+        d < 0.01,
+        "{what}: expected ({:.4}, {:.4}), got ({:.4}, {:.4}) — off by {d:.4}",
+        expected.0,
+        expected.1,
+        actual.0,
+        actual.1
+    );
+}
+
+/// BOUNDING CONTROL — must pass BEFORE and AFTER the basis fix.
+/// A plain world-XY circle (RefDirection absent) trimmed 0 → π/2 starts
+/// at (2,0) and ends at (0,2). The emitted Y is negated by the symbolic
+/// projection, so (0,2) surfaces as (0,-2).
+#[test]
+fn world_xy_circle_with_angle_trims_is_unchanged() {
+    let ifc = fixture(
+        "$",
+        "(IFCPARAMETERVALUE(0.))",
+        "(IFCPARAMETERVALUE(1.5707963267948966))",
+        ".PARAMETER.",
+        "",
+    );
+    let (start, end) = endpoints(&ifc);
+    assert_close(start, (2.0, 0.0), "world-XY arc start");
+    assert_close(end, (0.0, -2.0), "world-XY arc end");
+}
+
+/// RED for finding 1 — the trim angles are measured from the circle's
+/// OWN local X axis (`Position.RefDirection`), not from world X. With
+/// RefDirection = (0,1,0) the local X axis is world +Y, so the 0 → π/2
+/// arc runs from (0,2) to (-2,0). The old code ignored RefDirection and
+/// emitted the unrotated arc, i.e. exactly the control's coordinates.
+#[test]
+fn rotated_circle_placement_rotates_the_trimmed_arc() {
+    let ifc = fixture(
+        "#54",
+        "(IFCPARAMETERVALUE(0.))",
+        "(IFCPARAMETERVALUE(1.5707963267948966))",
+        ".PARAMETER.",
+        "#54=IFCDIRECTION((0.,1.,0.));",
+    );
+    let (start, end) = endpoints(&ifc);
+    assert_close(start, (0.0, -2.0), "rotated arc start");
+    assert_close(end, (-2.0, -0.0), "rotated arc end");
+}
+
+/// RED for finding 2a — a trim expressed purely as `IfcCartesianPoint`
+/// is a legal `IfcTrimmingSelect`. The old code found no float in the
+/// set, fell back to (0, TAU) and drew the WHOLE circle: start and end
+/// both landed on (2,0). The arc must run (2,0) → (0,2).
+#[test]
+fn cartesian_point_trims_produce_the_arc_not_a_full_circle() {
+    let ifc = fixture(
+        "$",
+        "(#55)",
+        "(#56)",
+        ".CARTESIAN.",
+        "#55=IFCCARTESIANPOINT((2.,0.,0.));\n#56=IFCCARTESIANPOINT((0.,2.,0.));",
+    );
+    let (start, end) = endpoints(&ifc);
+    assert_close(start, (2.0, 0.0), "cartesian-trim arc start");
+    assert_close(end, (0.0, -2.0), "cartesian-trim arc end");
+}
+
+/// RED for finding 2b — when the set carries BOTH representations the
+/// parameter must still be found even though it is not the first member.
+/// The old code only ever looked at `.first()`, so a point-first set
+/// degenerated to the full circle.
+#[test]
+fn parameter_trim_is_found_when_it_is_not_the_first_set_member() {
+    let ifc = fixture(
+        "$",
+        "(#55,IFCPARAMETERVALUE(0.))",
+        "(#56,IFCPARAMETERVALUE(1.5707963267948966))",
+        ".PARAMETER.",
+        "#55=IFCCARTESIANPOINT((2.,0.,0.));\n#56=IFCCARTESIANPOINT((0.,2.,0.));",
+    );
+    let (start, end) = endpoints(&ifc);
+    assert_close(start, (2.0, 0.0), "parameter-second arc start");
+    assert_close(end, (0.0, -2.0), "parameter-second arc end");
+}
+
+/// RED for finding 4 — `radius > 100.0` collapsed any large-radius arc
+/// to a two-point chord regardless of how much it actually bulges. A
+/// 150 m radius swept 30° has a 5 m sagitta over a 77 m chord: visibly
+/// curved, yet drawn as a straight line. Only the relative criteria
+/// (sagitta vs chord, radius vs chord) may decide this.
+#[test]
+fn large_radius_arc_with_real_sagitta_is_not_flattened() {
+    let ifc = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('issue-2356 fixture'),'2;1');
+FILE_NAME('t.ifc','2026-08-08T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0$ScRe4drECQ4DMSqUjd6d',$,'P',$,$,$,$,(#2),#3);
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
+#3=IFCUNITASSIGNMENT((#6,#7));
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#6=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#7=IFCSIUNIT(*,.PLANEANGLEUNIT.,$,.RADIAN.);
+#40=IFCLOCALPLACEMENT($,#5);
+#50=IFCCARTESIANPOINT((0.,0.,0.));
+#51=IFCDIRECTION((0.,0.,1.));
+#52=IFCAXIS2PLACEMENT3D(#50,#51,$);
+#53=IFCCIRCLE(#52,150.);
+#60=IFCTRIMMEDCURVE(#53,(IFCPARAMETERVALUE(0.)),(IFCPARAMETERVALUE(0.5235987755982988)),.T.,.PARAMETER.);
+#61=IFCSHAPEREPRESENTATION(#2,'Annotation','Annotation2D',(#60));
+#62=IFCPRODUCTDEFINITIONSHAPE($,$,(#61));
+#63=IFCANNOTATION('2xScRe4drECQ4DMSqUjd6d',$,'Note',$,$,#40,#62);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+    let data = extract_symbolic_data(ifc);
+    assert_eq!(data.polylines.len(), 1);
+    let p = &data.polylines[0];
+    assert!(
+        p.points.len() > 4,
+        "a 150 m radius arc with a 5 m sagitta must be tessellated, not \
+         collapsed to a 2-point chord; got {} points",
+        p.points.len() / 2
+    );
+    // The tessellated midpoint must sit off the chord by ~5 m.
+    let n = p.points.len();
+    let (sx, sy) = (p.points[0], p.points[1]);
+    let (ex, ey) = (p.points[n - 2], p.points[n - 1]);
+    let mid = (n / 2) & !1;
+    let (mx, my) = (p.points[mid], p.points[mid + 1]);
+    let chord = ((ex - sx).powi(2) + (ey - sy).powi(2)).sqrt();
+    let sagitta = ((ey - sy) * mx - (ex - sx) * my + ex * sy - ey * sx).abs() / chord;
+    assert!(
+        sagitta > 4.0,
+        "midpoint should bulge ~5 m off the chord, got {sagitta:.3} m"
+    );
+}
+
+/// BOUNDING CONTROL for finding 4 — a genuinely shallow large-radius arc
+/// (150 m radius swept 1°) still collapses to a straight chord via the
+/// RELATIVE criteria. Must pass before and after.
+#[test]
+fn shallow_large_radius_arc_still_collapses_to_a_chord() {
+    let ifc = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('issue-2356 fixture'),'2;1');
+FILE_NAME('t.ifc','2026-08-08T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0$ScRe4drECQ4DMSqUjd6d',$,'P',$,$,$,$,(#2),#3);
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
+#3=IFCUNITASSIGNMENT((#6,#7));
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#6=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#7=IFCSIUNIT(*,.PLANEANGLEUNIT.,$,.RADIAN.);
+#40=IFCLOCALPLACEMENT($,#5);
+#50=IFCCARTESIANPOINT((0.,0.,0.));
+#51=IFCDIRECTION((0.,0.,1.));
+#52=IFCAXIS2PLACEMENT3D(#50,#51,$);
+#53=IFCCIRCLE(#52,150.);
+#60=IFCTRIMMEDCURVE(#53,(IFCPARAMETERVALUE(0.)),(IFCPARAMETERVALUE(0.017453292519943295)),.T.,.PARAMETER.);
+#61=IFCSHAPEREPRESENTATION(#2,'Annotation','Annotation2D',(#60));
+#62=IFCPRODUCTDEFINITIONSHAPE($,$,(#61));
+#63=IFCANNOTATION('2xScRe4drECQ4DMSqUjd6d',$,'Note',$,$,#40,#62);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+    let data = extract_symbolic_data(ifc);
+    assert_eq!(data.polylines.len(), 1);
+    assert_eq!(
+        data.polylines[0].points.len(),
+        4,
+        "a 1-degree sweep is a chord: expected 2 points"
+    );
+}
+
+/// BOUNDING CONTROL — reversed `SenseAgreement` still wraps the other
+/// way. 0 → π/2 with `.F.` sweeps the long way round, so the arc ends at
+/// (0,2) having travelled through (-2,0) and (0,-2).
+#[test]
+fn reversed_sense_sweeps_the_complementary_arc() {
+    let ifc = fixture(
+        "$",
+        "(IFCPARAMETERVALUE(0.))",
+        "(IFCPARAMETERVALUE(1.5707963267948966))",
+        ".PARAMETER.",
+        "",
+    )
+    .replace(",.T.,.PARAMETER.", ",.F.,.PARAMETER.");
+    let data = extract_symbolic_data(&ifc);
+    assert_eq!(data.polylines.len(), 1);
+    let p = &data.polylines[0];
+    let n = p.points.len();
+    assert_close((p.points[0], p.points[1]), (2.0, 0.0), "reversed start");
+    assert_close(
+        (p.points[n - 2], p.points[n - 1]),
+        (0.0, -2.0),
+        "reversed end",
+    );
+    // Travelling the long way must pass near (-2, 0).
+    let passes_left = (0..n / 2).any(|i| {
+        let (x, y) = (p.points[2 * i], p.points[2 * i + 1]);
+        (x + 2.0).abs() < 0.1 && y.abs() < 0.1
+    });
+    assert!(passes_left, "reversed sweep should pass through (-2, 0)");
+}


### PR DESCRIPTION
> **Stacked on #2355** (itself stacked on #2352) — needs `Transform2D::unresolved()`. Base is `fix/issue-2256-mapped-item`, so this diff shows only the new work.

Third and final instalment of the #2256 shape: returning `Transform2D::identity()` on a **genuine failure** is indistinguishable from a legitimate ground-floor elevation, because `identity().tz == 0.0`. #2352 fixed `transform.rs`, #2355 fixed `items.rs`, this fixes `text.rs`.

`IfcTextLiteral.Placement` (attribute 1) is **mandatory** per schema — verified against the generated table, `IfcTextLiteral => ["Literal", "Placement", "Path"]` — unlike `IfcProduct.ObjectPlacement`, which *is* optional and which #2352 deliberately left as `identity()`. So both a dangling ref and an absent/null attribute are malformed data rather than a legitimate default, and both now return `unresolved()`.

## RED proof

With the two `unresolved()` calls reverted to `identity()` (exact substring replacement, count asserted `== 2`):

```
test genuine_zero_elevation_text_stays_finite_zero ... ok
test dangling_text_placement_ref_is_not_finite ... FAILED
test null_text_placement_on_mandatory_attr_is_not_finite ... FAILED
... world_y must be non-finite (NaN), not silently 0.0 ... Got: 0
test result: FAILED. 1 passed; 2 failed
```

Restored by file copy, proven byte-identical with `diff`.

## Bounding control (passes before *and* after)

`genuine_zero_elevation_text_stays_finite_zero` — a text literal whose `Placement` resolves cleanly to Z=0 still yields exactly `world_y == 0.0`. It passes in the RED run above, as a bounding control must.

## Displacement

`SymbolicText.world_y` reaches `symbolic-parse.ts:119` via `ensureBucket(expressId, flat.textWorldY[i], ifcType)` — the identical `Number.isFinite` gate already swept in #2352/#2355 for polylines and circles. No new consumer; the renderer only ever receives bucketed values, never a raw `textWorldY`.

## Verification

`rust/processing` full `cargo test`: **48 test binaries, 0 failures, exit 0**, module-size ratchet included (scratch `CARGO_TARGET_DIR`). `text.rs` grew 106 → 110 lines, far under the 400 limit, so no allowlist entry. No changeset — Rust crate, not an npm package.

## The shape is now closed — every site classified

| Site | Status |
|---|---|
| `transform.rs:115,118` | **Correct as-is** — `IfcProduct.ObjectPlacement` is `OPTIONAL` |
| `transform.rs:145` | **Correct as-is** — legitimate top of placement chain |
| `items.rs` | fixed in #2355 |
| `text.rs` | fixed here |
| `mod.rs:202,204,209,211` | **Not fixed — see below** |

## Two pre-existing defects found in `mod.rs`, reported rather than patched

I did **not** apply the sentinel swap to the four `mod.rs` sites, because it would be a **silent no-op today**. Shipping an inert change behind a test that cannot fail is worse than shipping nothing. Two separate pre-existing defects make those sites unreachable:

**1. Wrong attribute index.** `mod.rs:199` reads `context.get_ref(2)` for `WorldCoordinateSystem`, but that attribute is at **index 4**. The generated schema (`rust/core/src/generated/schema.rs:9314`) lists:

```
IfcGeometricRepresentationContext => [
  "ContextIdentifier", "ContextType", "CoordinateSpaceDimension",
  "Precision", "WorldCoordinateSystem", "TrueNorth",
]
```

Index 2 is `CoordinateSpaceDimension`, an integer — so `get_ref(2)` returns `None` for any schema-conformant file and the `Some(wcs_ref)` arm is dead. Confirmed empirically against the decoder with the fixture `#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$)`: `get_ref(2) = None`, `get_ref(4) = Some(5)`.

**The consequence is user-visible and independent of #2256:** the comment above it says *"Compose it in when present and non-trivial"*, but a non-identity `WorldCoordinateSystem` is **never** composed into symbolic annotation placement. Models that carry a real WCS offset get their annotations placed wrong.

**2. The composition gate ignores `tz`.** `combined_transform` (`mod.rs:213-223`) tests only `tx`, `ty`, `m00`, `m01`, `m10`, `m11`. A WCS that is a pure vertical offset is therefore discarded as "trivial" even once it *is* read.

These want a **single combined fix** — index, gate, and sentinel together. Doing the sentinel swap alone is inert; fixing the index and gate without the swap would newly expose the exact #2256 confusion on a live path. I'd rather you saw the reasoning than received a plausible-looking one-line change. Happy to do it as a follow-up PR — say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text placement handling so valid zero-height positions remain accurate, while unresolved placements are no longer treated as valid default positions.
  * Corrected circle and trimmed-curve tessellation for translated or rotated placements.
  * Improved support for parameter-based and Cartesian trim values, including reversed, full-turn, and near-full-turn curves.
  * Improved arc accuracy for large-radius curves and zero-span trims.

* **Tests**
  * Added coverage for text placement edge cases and trimmed-curve geometry scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->