### PR TITLE
fix(moonshot): materialize the source accessor before meshing

### DIFF
--- a/scripts/moonshot/b45-m1-midterm/run.mjs
+++ b/scripts/moonshot/b45-m1-midterm/run.mjs
@@ -656,7 +656,11 @@ async function main() {
   await processor.init();
   const bytes =
     store.source && store.source.byteLength > 0
-      ? store.source
+      // `store.source` is an IfcSourceBytes ACCESSOR since #2339, not a
+      // Uint8Array. It still answers `byteLength`, so this guard passes --
+      // but `GeometryProcessor.process(buffer: Uint8Array)` then meshes
+      // nothing and returns 0 entries. Materialize the whole file.
+      ? store.source.materialize()
       : new Uint8Array(readFileSync(FIXTURE));
   const meshStart = performance.now();
   const geomResult = await processor.process(bytes);

--- a/scripts/moonshot/g1-memoized-recompute.mjs
+++ b/scripts/moonshot/g1-memoized-recompute.mjs
@@ -312,7 +312,11 @@ async function runMeshBearingExam() {
   await processor.init();
   const bytes =
     store.source && store.source.byteLength > 0
-      ? store.source
+      // `store.source` is an IfcSourceBytes ACCESSOR since #2339, not a
+      // Uint8Array. It still answers `byteLength`, so this guard passes --
+      // but `GeometryProcessor.process(buffer: Uint8Array)` then meshes
+      // nothing and returns 0 entries. Materialize the whole file.
+      ? store.source.materialize()
       : new Uint8Array(await (await import('node:fs/promises')).readFile(MESH_FIXTURE));
   const meshStart = performance.now();
   const geomResult = await processor.process(bytes);

--- a/scripts/moonshot/g2-footprint-tightness.mjs
+++ b/scripts/moonshot/g2-footprint-tightness.mjs
@@ -257,7 +257,11 @@ async function main() {
   await processor.init();
   const bytes =
     store.source && store.source.byteLength > 0
-      ? store.source
+      // `store.source` is an IfcSourceBytes ACCESSOR since #2339, not a
+      // Uint8Array. It still answers `byteLength`, so this guard passes --
+      // but `GeometryProcessor.process(buffer: Uint8Array)` then meshes
+      // nothing and returns 0 entries. Materialize the whole file.
+      ? store.source.materialize()
       : new Uint8Array(await (await import('node:fs/promises')).readFile(FIXTURE));
   const geomResult = await processor.process(bytes);
   console.error(`[g2] meshed (${geomResult.meshes.length} MeshData entries, ${geomResult.totalTriangles} triangles)`);

--- a/scripts/moonshot/m5-constrained-decoding/kernel.mjs
+++ b/scripts/moonshot/m5-constrained-decoding/kernel.mjs
@@ -46,7 +46,7 @@ export async function kernelGate(content, newExpressIds = []) {
   }
   if (newExpressIds.length > 0) {
     const processor = await initChecks();
-    const result = await processor.process(store.source);
+    const result = await processor.process(store.source.materialize());
     const meshed = new Set(result.meshes.map((m) => m.expressId));
     for (const id of newExpressIds) {
       if (!meshed.has(id)) {
@@ -105,7 +105,7 @@ export async function measureModel(content) {
   }
 
   const processor = await initChecks();
-  const meshResult = await processor.process(store.source);
+  const meshResult = await processor.process(store.source.materialize());
   const typeOf = (id) => new EntityNode(store, id).type ?? '';
 
   let all = null;

--- a/tools/world-gym/lib/checks.mjs
+++ b/tools/world-gym/lib/checks.mjs
@@ -145,11 +145,16 @@ export function schemaCheckInProcess(store) {
 export async function clashCheckInProcess(store, modelId = 'model.ifc', probeExpressIds = []) {
   const processor = await initChecks();
   return withQuietConsole(async () => {
-    const bytes = store.source;
-    if (!bytes || bytes.byteLength === 0) {
+    // `store.source` is an IfcSourceBytes ACCESSOR since #2339, not a
+    // Uint8Array. It still answers `byteLength`, so the guard below passes --
+    // but `GeometryProcessor.process(buffer: Uint8Array)` then meshes nothing
+    // and returns 0 entries, which silently zeroes every clash rule. Scope the
+    // materialized buffer to the call, matching packages/cli gym/channels.ts.
+    const source = store.source;
+    if (!source || source.byteLength === 0) {
       return { ok: false, error: 'store did not retain source bytes' };
     }
-    const result = await processor.process(bytes);
+    const result = await source.withMaterializedAsync((bytes) => processor.process(bytes));
     const meshes = result.meshes;
     const meshedIds = new Set(meshes.map((m) => m.expressId));
     const probesMeshed = {};


### PR DESCRIPTION
**Main is broken.** The `Moonshot exams` lane fails on any PR that triggers it, and I reproduced it on plain `main` with no other changes.

## Symptom

```
[g2] parsed (38898 entities, 2380763 bytes)
[g2] meshed (0 MeshData entries, 0 triangles)
[g2] candidate elements (pset + mesh + valid AABB): 0
Error: [g2] fewer than 2 candidate elements found — cannot build pairs
```

## Cause

`GeometryProcessor.process(buffer: Uint8Array)` still requires real bytes, but since #2339 `IfcDataStore.source` is an `IfcSourceBytes` **accessor**. Five call sites across four moonshot scripts pass the accessor straight in.

The guards do not catch it, and that is by design — `IfcSourceBytes` deliberately exposes `byteLength` and `length` so that *"existing `?.length` guards compile and behave identically"*. So `store.source && store.source.byteLength > 0` stays true, the accessor reaches `process()`, and meshing silently returns zero entries rather than throwing.

Nothing type-checked this: these are untyped `.mjs` scripts, so a breaking signature change could not be caught at build time. `EntityExtractor` and `extractProjectUnits` were correctly updated to accept `Uint8Array | IfcSourceBytes` and are left alone here — `process()` is the only consumer that still needs whole bytes.

## Why it went unnoticed

Main has run **no** Moonshot lane since #2339 landed (last run 08:20Z; the refactor merged 10:27Z), the workflow is path-filtered, and no test lane runs on pushes to main at all. It sat undetected until a PR touching `rust/processing` tripped it — BIMvoice's #2352, which is entirely unrelated to the cause and is exonerated by this.

## Verification

Against the last known-good run (`main @ 5dd1d1814`, before #2339):

| | broken main | with this fix | last good run |
|---|---|---|---|
| g2 meshes | 0 | **622** | 622 |
| g2 triangles | 0 | **39334** | 39334 |
| g2 candidates | 0 | **143** | 143 |
| g2 M4 criterion | ERROR | **PASS** | PASS |

An exact match on all three counts, not merely "non-zero". `g1` likewise returns 622 meshes / 39334 triangles / 2067 DAG nodes.

## Follow-up worth considering (not in this PR)

The root enabler is that `scripts/**.mjs` is outside the typecheck graph, so a `!`-breaking package change cannot fail the build there. Options are type-checking the scripts via JSDoc + `checkJs`, or having `process()` reject a non-`Uint8Array` argument loudly instead of meshing nothing. Deliberately out of scope here — this PR restores main and nothing else.