### PR TITLE
fix(viewer-embed): ADD_MODEL replaced the model instead of adding it

### DIFF
--- a/apps/viewer-embed/src/bridge/handler.test.ts
+++ b/apps/viewer-embed/src/bridge/handler.test.ts
@@ -156,6 +156,14 @@ function makeCtx(state: any, overrides: Partial<Record<string, any>> = {}) {
       ?? vi.fn(async () => ({ entities: 1, triangles: 2, vertices: 3 })),
     loadModelFromBuffer: overrides.loadModelFromBuffer
       ?? vi.fn(async () => ({ entities: 4, triangles: 5, vertices: 6 })),
+    // Federation-aware add: a real implementation registers a new model
+    // alongside whatever is already loaded (see EmbedViewer.tsx's wiring to
+    // useIfcFederation's addModel) and returns that model's REAL id, not a
+    // placeholder. The default double here does not touch state.models —
+    // tests that care about the federation registry effect supply their own
+    // override that does.
+    addModelFromUrl: overrides.addModelFromUrl
+      ?? vi.fn(async () => ({ modelId: 'default-added-id', entities: 10, triangles: 20, vertices: 30 })),
   };
 }
 
@@ -507,11 +515,11 @@ describe('command dispatch', () => {
     expect(fw.posted.at(-1)!.msg.data).toEqual({ entities: 9, triangles: 8, vertices: 7 });
   });
 
-  it('ADD_MODEL tags the response with a modelId', async () => {
+  it('ADD_MODEL tags the response with the real minted modelId (not a placeholder)', async () => {
     initBridge(makeCtx(state));
     await send(fw, cmd('ADD_MODEL', { url: 'https://x.test/a.ifc' }, 'r1'));
     expect(fw.posted.at(-1)!.msg.data).toEqual({
-      modelId: 'latest', entities: 1, triangles: 2, vertices: 3,
+      modelId: 'default-added-id', entities: 10, triangles: 20, vertices: 30,
     });
   });
 
@@ -519,6 +527,65 @@ describe('command dispatch', () => {
     initBridge(makeCtx(state));
     await send(fw, cmd('REMOVE_MODEL', { modelId: 'm1' }, 'r1'));
     expect(argsOf(state, 'removeModel')).toEqual(['m1']);
+  });
+
+  // -------------------------------------------------------------------------
+  // Federation: ADD_MODEL must be non-destructive; LOAD_MODEL must remain
+  // destructive. See apps/viewer-embed/src/components/EmbedViewer.tsx and
+  // apps/viewer/src/hooks/useIfcFederation.ts for the real wiring these
+  // doubles stand in for.
+  // -------------------------------------------------------------------------
+
+  it('ADD_MODEL routes through the federated add path and does not displace the existing model', async () => {
+    const addModelFromUrl = vi.fn(async () => {
+      // Mirror what the real callback does: register a second model in the
+      // federation registry alongside the one already there (m1).
+      state.models.set('new-model-id', {
+        id: 'new-model-id',
+        name: 'b.ifc',
+        visible: true,
+        ifcDataStore: { entities: makeEntities({}) },
+        geometryResult: { totalTriangles: 2 },
+      });
+      return { modelId: 'new-model-id', entities: 1, triangles: 2, vertices: 3 };
+    });
+    initBridge(makeCtx(state, { addModelFromUrl }));
+    await send(fw, cmd('ADD_MODEL', { url: 'https://x.test/b.ifc' }, 'r1'));
+
+    expect(addModelFromUrl).toHaveBeenCalledWith('https://x.test/b.ifc');
+    // The pre-existing model must survive the add — this is the registry-level
+    // assertion, not just "the call resolved".
+    expect(state.models.has('m1')).toBe(true);
+    expect(state.models.size).toBe(2);
+  });
+
+  it('the modelId ADD_MODEL returns round-trips through REMOVE_MODEL against the real registry', async () => {
+    const addModelFromUrl = vi.fn(async () => {
+      state.models.set('new-model-id', { id: 'new-model-id', name: 'b.ifc', visible: true });
+      return { modelId: 'new-model-id', entities: 1, triangles: 2, vertices: 3 };
+    });
+    initBridge(makeCtx(state, { addModelFromUrl }));
+    await send(fw, cmd('ADD_MODEL', { url: 'https://x.test/b.ifc' }, 'r1'));
+
+    const returnedId = fw.posted.at(-1)!.msg.data.modelId;
+    expect(returnedId).not.toBe('latest');
+    // The id must key a real entry in the federation registry — a string
+    // that merely echoes back through REMOVE_MODEL isn't enough; it has to
+    // actually identify the model that was added.
+    expect(state.models.has(returnedId)).toBe(true);
+
+    await send(fw, cmd('REMOVE_MODEL', { modelId: returnedId }, 'r2'));
+    expect(argsOf(state, 'removeModel')).toEqual([returnedId]);
+  });
+
+  it('BOUNDING CONTROL: LOAD_MODEL remains destructive — it never routes through the federated add path', async () => {
+    const loadModelFromUrl = vi.fn(async () => ({ entities: 9, triangles: 8, vertices: 7 }));
+    const addModelFromUrl = vi.fn(async () => ({ modelId: 'x', entities: 1, triangles: 1, vertices: 1 }));
+    initBridge(makeCtx(state, { loadModelFromUrl, addModelFromUrl }));
+    await send(fw, cmd('LOAD_MODEL', { url: 'https://x.test/a.ifc' }, 'r1'));
+
+    expect(loadModelFromUrl).toHaveBeenCalledWith('https://x.test/a.ifc');
+    expect(addModelFromUrl).not.toHaveBeenCalled();
   });
 
   it('rejects LOAD_MODEL_BUFFER above the 500 MB ceiling', async () => {

--- a/apps/viewer-embed/src/bridge/handler.ts
+++ b/apps/viewer-embed/src/bridge/handler.ts
@@ -28,10 +28,16 @@ import { toGlobalIdFromModels } from '@/store/index.js';
 /** Reference to the store's getState / setState for imperative access */
 interface BridgeContext {
   getState: () => ViewerState;
-  /** Callback to load a model from URL (async) */
+  /** Callback to load a model from URL (async). Replaces the whole scene — used by LOAD_MODEL. */
   loadModelFromUrl: (url: string) => Promise<{ entities: number; triangles: number; vertices: number }>;
   /** Callback to load a model from ArrayBuffer */
   loadModelFromBuffer: (buffer: ArrayBuffer, name?: string) => Promise<{ entities: number; triangles: number; vertices: number }>;
+  /**
+   * Callback to ADD a model to the federation alongside whatever is already
+   * loaded (does not replace existing models). Returns the real, freshly
+   * minted model id so the host can later target it with REMOVE_MODEL.
+   */
+  addModelFromUrl: (url: string) => Promise<{ modelId: string; entities: number; triangles: number; vertices: number }>;
 }
 
 /** Optional security knobs for the bridge (all opt-in; defaults preserve the public-widget behaviour). */
@@ -219,8 +225,11 @@ async function handleCommand(type: InboundCommandType, data: unknown, requestId?
 
     case 'ADD_MODEL': {
       const payload = data as InboundPayloads['ADD_MODEL'];
-      const stats = await ctx.loadModelFromUrl(payload.url);
-      if (requestId) emitToParent(createResponse(requestId, { modelId: 'latest', ...stats }));
+      // Federation-aware add: does NOT replace existing models (unlike
+      // LOAD_MODEL, which is destructive by design). The response carries the
+      // real minted model id so REMOVE_MODEL can target it later.
+      const result = await ctx.addModelFromUrl(payload.url);
+      if (requestId) emitToParent(createResponse(requestId, result));
       return;
     }
 

--- a/apps/viewer-embed/src/components/EmbedViewer.tsx
+++ b/apps/viewer-embed/src/components/EmbedViewer.tsx
@@ -25,7 +25,7 @@ import type { MeshData, CoordinateInfo } from '@ifc-lite/geometry';
 
 export function EmbedViewer() {
   const webgpu = useWebGPU();
-  const { geometryResult, ifcDataStore, loadFile, loading, models, clearAllModels } = useIfc();
+  const { geometryResult, ifcDataStore, loadFile, loading, models, clearAllModels, addModel } = useIfc();
   const storeModels = useViewerStore((s) => s.models);
   const typeVisibility = useViewerStore((s) => s.typeVisibility);
   const isolatedEntities = useViewerStore((s) => s.isolatedEntities);
@@ -95,13 +95,34 @@ export function EmbedViewer() {
           vertices: gr?.totalVertices ?? 0,
         };
       },
+      addModelFromUrl: async (url: string) => {
+        // Federation-aware add: routes through useIfcFederation's addModel,
+        // which loads with target `{ kind: 'federated' }` and therefore does
+        // NOT clear existing models (unlike loadFile's default primary
+        // target, which loadModelFromUrl above uses for LOAD_MODEL).
+        const safeUrl = assertFetchableUrl(url);
+        const response = await fetch(safeUrl, { signal: AbortSignal.timeout(60_000) });
+        if (!response.ok) throw new Error(`Failed to fetch model: ${response.statusText}`);
+        const buffer = await response.arrayBuffer();
+        const filename = url.split('/').pop() || 'model.ifc';
+        const file = new File([buffer], filename);
+        const modelId = await addModel(file);
+        if (!modelId) throw new Error('Failed to add model');
+        const added = useViewerStore.getState().models.get(modelId);
+        return {
+          modelId,
+          entities: added?.ifcDataStore?.entities?.count ?? 0,
+          triangles: added?.geometryResult?.totalTriangles ?? 0,
+          vertices: added?.geometryResult?.totalVertices ?? 0,
+        };
+      },
     }, {
       allowedOrigins: urlParams.allowOrigins,
       expectedParentOrigin,
     });
 
     return () => destroyBridge();
-  }, [loadFile, urlParams.allowOrigins, urlParams.parentOrigin]);
+  }, [loadFile, addModel, urlParams.allowOrigins, urlParams.parentOrigin]);
 
   // Auto-load model from URL param
   useEffect(() => {


### PR DESCRIPTION
Found by auditing `apps/viewer-embed`, which had never been audited. Independent of the other open PRs — based directly on `main`.

`packages/embed-sdk`'s README advertises **"federation via `addModel` / `removeModel`"**. In the shipped embed it did neither.

```
handler.ts  LOAD_MODEL -> ctx.loadModelFromUrl(payload.url)
handler.ts  ADD_MODEL  -> ctx.loadModelFromUrl(payload.url)   // identical
```

`loadModelFromUrl` is wired in `EmbedViewer.tsx` to `loadFile(file)` with the default target `{ kind: 'primary' }`, and a primary load calls `resetViewerState()` + `clearAllModels()` (`useIfcLoader.ts:383-384`) before loading. **So a host calling `addModel()` to build a multi-model scene had its existing model wiped and replaced.**

`ADD_MODEL` then answered `{ modelId: 'latest', ...stats }` — a hardcoded placeholder. `REMOVE_MODEL` resolves against the real `crypto.randomUUID()` id minted in `useIfcFederation.ts`, so the id the host was handed **could never match anything** and `removeModel()` was a guaranteed no-op. Both halves of the advertised feature were broken.

The federation-aware path already existed (`useIfcFederation.ts`, `target.kind === 'federated'`) — it was simply never plumbed into the embed's `BridgeContext`.

## The fix

Added a distinct `addModelFromUrl` to `BridgeContext`, wired to the federation `addModel` (federated target, real minted id). `ADD_MODEL` calls that and returns the **real** id. `LOAD_MODEL` is untouched.

The new callback validates like its siblings rather than trusting the URL: `assertFetchableUrl(url)` (http(s)-only, the same guard the URL-param path uses) and an explicit `response.ok` check before reading the body.

## Blocking question, answered first

**Nothing depended on the destructive behaviour.** `embed-sdk`'s `addModel()` is *already* typed `Promise<ModelStats & { modelId: string }>` (`index.ts:195`), and `embed-protocol` already contracts `ADD_MODEL: { modelId: string } & ModelStats` (`index.ts:110`) — both always expected a real id. The README documents no destructive semantics.

The **only** thing pinning the bug was `handler.test.ts`'s *"ADD_MODEL tags the response with a modelId"*, asserting `modelId: 'latest'`. That test encoded the bug, and was repaired.

## Three-way measurement for the repaired test

Measured with the test double left **intact**, so the failure is about behaviour and not a missing stub:

| | result |
|---|---|
| old expectation (`'latest'`) + **unfixed** code | PASSES — 115/115 baseline |
| old expectation (`'latest'`) + **fixed** code | **FAILS** |
| new expectation + fixed code | PASSES |

```
AssertionError: expected { modelId: 'default-added-id', …(3) }
                to deeply equal { modelId: 'latest', …(3) }
Tests  1 failed | 79 passed (80)
```

Exactly one test fails in the middle row, and for the right reason.

## RED proofs (new tests, against unfixed code)

- *"ADD_MODEL routes through the federated add path"* — `addModelFromUrl` never called (0 calls), proving it wasn't federating.
- *"the modelId ADD_MODEL returns round-trips through REMOVE_MODEL"* — `expect(returnedId).not.toBe('latest')` failed.

## Bounding control (passes before *and* after)

*"LOAD_MODEL remains destructive"* — `loadModelFromUrl` is called and `addModelFromUrl` is not, in either code state. Replace-everything is `LOAD_MODEL`'s documented contract; without this control, "make everything federated" would satisfy the new tests while silently breaking it.

## Displacement — reported, not fixed

`REMOVE_MODEL` with an unknown id still fails **safe but silently**: the store does `new Map(state.models).delete(modelId)` (`modelSlice.ts:147-213`), a no-op for an absent key, and the handler always answers a bare success — so the host is told the removal succeeded even when nothing was removed. Pre-existing, unchanged here, out of scope for this diff. Happy to fix separately if you want the handler to report it.

## Verification

`apps/viewer-embed` **118/118** (was 115; +2 new, 1 repaired). `tsc --noEmit` **exit 0**.

No changeset: `apps/viewer-embed` is `"private": true`. `embed-sdk` and `embed-protocol` are published but neither was modified — their types already matched the correct contract; the bug was entirely in the private app's handler wiring.

Two environment traps hit while verifying, noted so nobody else chases them: `tsc` first failed with `parser/dist` vs `parser/src` disagreeing about `IfcSourceBytes` (stale dist — fixed with `turbo build --filter=@ifc-lite/parser --force`), then on an unbuilt source-provider package. Neither implicated any changed file.

## Also found in the same audit, not fixed here

Reporting so they're visible; each wants its own diff:

1. **`EmbedViewer.tsx` bridge init/teardown guard asymmetry** — the mount side is ref-guarded, the cleanup side isn't, so under React 19 StrictMode's double-invoke the bridge is initialised, torn down, and never re-initialised. Dev-only (StrictMode is stripped in production), but it means the `READY → INIT → INIT_ACK` handshake never completes against a dev server. One-line fix: reset the ref in cleanup.
2. **`event.source` is validated on the SDK side but never on the embed side** — `embed-sdk/src/index.ts:323-327` checks both origin and source, with dedicated spoofing tests; `handler.ts`'s `onMessage` checks only origin. A sibling asymmetry across the two ends of one protocol.
3. **`initToken` is implemented and unit-tested but never wired** — no URL param sources it, so the INIT-token gate is always inert in the deployed embed.
4. **`GET_PROPERTIES` always returns empty `propertySets`/`quantitySets`** despite the protocol type promising real arrays.
5. **`GET_SCREENSHOT`** is listed in the SDK README with no caveat but always responds `NOT_IMPLEMENTED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
