### PR TITLE
fix(viewer-embed): StrictMode left the postMessage bridge permanently dead

### DIFF
--- a/apps/viewer-embed/src/bridge/lifecycle.test.ts
+++ b/apps/viewer-embed/src/bridge/lifecycle.test.ts
@@ -57,7 +57,14 @@ function installWindow(): FakeWindow {
       posted.push({ msg, targetOrigin });
     },
   };
-  (globalThis as any).window = win;
+  // `window` is a non-optional DOM-lib global, so a plain assignment/delete
+  // pair does not typecheck without a cast; define it as a configurable
+  // property instead so `afterEach` can remove it again.
+  Object.defineProperty(globalThis, 'window', {
+    value: win,
+    configurable: true,
+    writable: true,
+  });
   return {
     posted,
     listenerCount: () => listeners.size,
@@ -91,7 +98,7 @@ function cmd(type: string) {
 
 afterEach(() => {
   destroyBridge();
-  delete (globalThis as any).window;
+  Reflect.deleteProperty(globalThis, 'window');
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/viewer-embed/src/bridge/lifecycle.test.ts
+++ b/apps/viewer-embed/src/bridge/lifecycle.test.ts
@@ -1,0 +1,232 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * StrictMode bridge teardown regression tests.
+ *
+ * React 19's <React.StrictMode> double-invokes effects in dev: mount ->
+ * cleanup -> mount. `EmbedViewer`'s bridge-init effect used to guard only
+ * the mount side with a ref; the cleanup unconditionally tore the bridge
+ * down without resetting that guard, so the StrictMode remount saw the
+ * guard already flipped and skipped re-init -- the postMessage listener
+ * was gone for good, and the READY -> INIT -> INIT_ACK handshake could
+ * never complete in dev.
+ *
+ * These tests wire `mountBridgeLifecycle`/`unmountBridgeLifecycle` (the
+ * extracted guard used by EmbedViewer.tsx) around the REAL
+ * `initBridge`/`destroyBridge` from ./handler.js, against a hand-rolled
+ * `window` stub (same technique as handler.test.ts). A regression here
+ * shows up as "the inbound listener is dead / a message goes unanswered",
+ * not merely as an init call-count mismatch.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { EMBED_SOURCE, PROTOCOL_VERSION } from '@ifc-lite/embed-protocol';
+import { destroyBridge, initBridge } from './handler.js';
+import { mountBridgeLifecycle, unmountBridgeLifecycle, type MountGuardRef } from './lifecycle.js';
+
+// ---------------------------------------------------------------------------
+// Test doubles (mirrors handler.test.ts's installWindow/makeCtx)
+// ---------------------------------------------------------------------------
+
+interface Posted {
+  msg: any;
+  targetOrigin: string;
+}
+
+interface FakeWindow {
+  posted: Posted[];
+  listenerCount: () => number;
+  dispatch: (event: { data: unknown; origin: string }) => void;
+}
+
+function installWindow(): FakeWindow {
+  const posted: Posted[] = [];
+  const listeners = new Set<(e: unknown) => void>();
+  const win: any = {
+    addEventListener: (type: string, fn: (e: unknown) => void) => {
+      if (type === 'message') listeners.add(fn);
+    },
+    removeEventListener: (type: string, fn: (e: unknown) => void) => {
+      if (type === 'message') listeners.delete(fn);
+    },
+  };
+  win.parent = {
+    postMessage: (msg: any, targetOrigin: string) => {
+      posted.push({ msg, targetOrigin });
+    },
+  };
+  (globalThis as any).window = win;
+  return {
+    posted,
+    listenerCount: () => listeners.size,
+    dispatch: (event) => {
+      for (const fn of [...listeners]) fn(event);
+    },
+  };
+}
+
+function makeState() {
+  const calls: string[] = [];
+  return {
+    state: { showAllInAllModels: () => { calls.push('showAllInAllModels'); } },
+    calls,
+  };
+}
+
+function makeCtx(state: any) {
+  return {
+    getState: () => state,
+    loadModelFromUrl: async () => ({ entities: 0, triangles: 0, vertices: 0 }),
+    loadModelFromBuffer: async () => ({ entities: 0, triangles: 0, vertices: 0 }),
+  };
+}
+
+const PARENT = 'https://host.example';
+
+function cmd(type: string) {
+  return { source: EMBED_SOURCE, version: PROTOCOL_VERSION, type };
+}
+
+afterEach(() => {
+  destroyBridge();
+  delete (globalThis as any).window;
+});
+
+// ---------------------------------------------------------------------------
+// The regression itself
+// ---------------------------------------------------------------------------
+
+describe('StrictMode mount -> cleanup -> remount', () => {
+  it('leaves the bridge ALIVE: listener registered and still handling inbound messages', async () => {
+    const fw = installWindow();
+    const { state, calls } = makeState();
+    const ref: MountGuardRef = { current: false };
+
+    const mount = () => mountBridgeLifecycle(ref, () => initBridge(makeCtx(state)));
+    const unmount = () => unmountBridgeLifecycle(ref, () => destroyBridge());
+
+    // Exactly what React 19 StrictMode does to every effect in dev.
+    mount();
+    unmount();
+    mount();
+
+    // Not just "was init called again" -- the listener must actually be
+    // live and actually handle a message. This is what an asymmetric
+    // guard (mount ref-checked, cleanup unconditional) breaks: mount() on
+    // the second pass returns early because the guard was never reset, so
+    // initBridge() never re-runs and no listener is registered.
+    expect(fw.listenerCount()).toBe(1);
+
+    fw.dispatch({ data: cmd('SHOW_ALL'), origin: PARENT });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(calls).toContain('showAllInAllModels');
+  });
+
+  it('returns the listener count to zero after every unmount and never exceeds one across repeated cycles', () => {
+    const fw = installWindow();
+    const { state } = makeState();
+    const ref: MountGuardRef = { current: false };
+
+    const mount = () => mountBridgeLifecycle(ref, () => initBridge(makeCtx(state)));
+    const unmount = () => unmountBridgeLifecycle(ref, () => destroyBridge());
+
+    mount();
+    expect(fw.listenerCount()).toBe(1);
+    unmount();
+    expect(fw.listenerCount()).toBe(0);
+    mount();
+    expect(fw.listenerCount()).toBe(1);
+    unmount();
+    expect(fw.listenerCount()).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bounding control: a normal single mount (no StrictMode) must still
+// initialize exactly once. Without this, "just delete the guard entirely"
+// would also pass the regression test above while reintroducing
+// double-init / duplicate READY / duplicate listeners on every real mount.
+// ---------------------------------------------------------------------------
+
+describe('a single mount (no StrictMode cycling)', () => {
+  it('initializes the bridge exactly once: one listener, one READY', () => {
+    const fw = installWindow();
+    const { state } = makeState();
+    const ref: MountGuardRef = { current: false };
+    let initCount = 0;
+
+    mountBridgeLifecycle(ref, () => {
+      initCount++;
+      initBridge(makeCtx(state));
+    });
+
+    expect(initCount).toBe(1);
+    expect(fw.listenerCount()).toBe(1);
+    expect(fw.posted.filter((p) => p.msg.type === 'READY')).toHaveLength(1);
+  });
+
+  it('mounting twice in a row without an intervening unmount does not re-init', () => {
+    const fw = installWindow();
+    const { state } = makeState();
+    const ref: MountGuardRef = { current: false };
+    let initCount = 0;
+    const mount = () => mountBridgeLifecycle(ref, () => {
+      initCount++;
+      initBridge(makeCtx(state));
+    });
+
+    mount();
+    mount();
+
+    expect(initCount).toBe(1);
+    expect(fw.listenerCount()).toBe(1);
+    expect(fw.posted.filter((p) => p.msg.type === 'READY')).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Displacement: what the fix could break if it were careless.
+// ---------------------------------------------------------------------------
+
+describe('displacement checks', () => {
+  it('destroyBridge() via unmountBridgeLifecycle on a never-mounted guard is a safe no-op', () => {
+    const fw = installWindow();
+    const ref: MountGuardRef = { current: false };
+    let destroyCount = 0;
+
+    unmountBridgeLifecycle(ref, () => {
+      destroyCount++;
+      destroyBridge();
+    });
+
+    expect(destroyCount).toBe(0);
+    expect(fw.listenerCount()).toBe(0);
+  });
+
+  it('calling the real initBridge() twice directly does not duplicate the listener', () => {
+    // Bypasses the ref guard entirely to check handler.ts's own behaviour:
+    // onMessage is a single stable module-level function reference, so
+    // addEventListener('message', onMessage) twice is deduped exactly like
+    // native DOM semantics (same type + same listener reference).
+    const fw = installWindow();
+    const { state } = makeState();
+
+    initBridge(makeCtx(state));
+    initBridge(makeCtx(state));
+
+    expect(fw.listenerCount()).toBe(1);
+  });
+
+  it('every addEventListener has exactly one matching removeEventListener: destroyBridge after a double initBridge clears it fully', () => {
+    const fw = installWindow();
+    const { state } = makeState();
+
+    initBridge(makeCtx(state));
+    initBridge(makeCtx(state));
+    destroyBridge();
+
+    expect(fw.listenerCount()).toBe(0);
+  });
+});

--- a/apps/viewer-embed/src/bridge/lifecycle.test.ts
+++ b/apps/viewer-embed/src/bridge/lifecycle.test.ts
@@ -87,6 +87,16 @@ function makeCtx(state: any) {
     getState: () => state,
     loadModelFromUrl: async () => ({ entities: 0, triangles: 0, vertices: 0 }),
     loadModelFromBuffer: async () => ({ entities: 0, triangles: 0, vertices: 0 }),
+    // Required on BridgeContext since #2361. These lifecycle tests never issue
+    // ADD_MODEL, but the double has to satisfy the real interface — typecheck
+    // covers test sources, and a cast here would silence the next field the
+    // interface grows as well.
+    addModelFromUrl: async () => ({
+      modelId: 'lifecycle-added-id',
+      entities: 0,
+      triangles: 0,
+      vertices: 0,
+    }),
   };
 }
 

--- a/apps/viewer-embed/src/bridge/lifecycle.ts
+++ b/apps/viewer-embed/src/bridge/lifecycle.ts
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * StrictMode-safe mount/unmount guard for the postMessage bridge.
+ *
+ * React 19's <React.StrictMode> double-invokes effects in development:
+ * mount -> cleanup -> mount. `EmbedViewer`'s bridge-init effect guards the
+ * MOUNT side with a ref ("already initialized? skip"), but the guard must
+ * also be reset on the CLEANUP side -- otherwise the StrictMode remount
+ * sees the guard still flipped, skips re-init, and the bridge is left
+ * permanently dead (listener removed, never re-added) even though the
+ * component is mounted and alive.
+ *
+ * This is deliberately plain TS (no JSX) so it can be unit-tested under
+ * this package's `src/**\/*.test.ts`-only vitest include glob, which does
+ * not collect `.tsx` test files.
+ */
+
+export interface MountGuardRef {
+  current: boolean;
+}
+
+/**
+ * Run `init` only if the guard is not already set. Pair with
+ * `unmountBridgeLifecycle` using the SAME ref so a StrictMode
+ * cleanup+remount correctly re-initializes instead of leaving the bridge
+ * dead.
+ */
+export function mountBridgeLifecycle(ref: MountGuardRef, init: () => void): void {
+  if (ref.current) return;
+  ref.current = true;
+  init();
+}
+
+/**
+ * Tear down only if `mountBridgeLifecycle` actually ran `init` for this
+ * guard (idempotent: unmounting a never-mounted guard is a no-op).
+ */
+export function unmountBridgeLifecycle(ref: MountGuardRef, destroy: () => void): void {
+  if (!ref.current) return;
+  // Reset the guard BEFORE tearing down so a StrictMode cleanup+remount
+  // (mount -> cleanup -> mount, all synchronous) sees an unset guard on the
+  // second mount and correctly re-initializes, instead of finding the guard
+  // still flipped `true` and skipping init forever.
+  ref.current = false;
+  destroy();
+}

--- a/apps/viewer-embed/src/components/EmbedViewer.tsx
+++ b/apps/viewer-embed/src/components/EmbedViewer.tsx
@@ -21,6 +21,7 @@ import { useViewerStore } from '@/store';
 import { toGlobalIdFromModels } from '@/store/globalId';
 import { parseUrlParams, assertFetchableUrl } from '../bridge/urlParams.js';
 import { initBridge, destroyBridge, emitEvent } from '../bridge/handler.js';
+import { mountBridgeLifecycle, unmountBridgeLifecycle } from '../bridge/lifecycle.js';
 import type { MeshData, CoordinateInfo } from '@ifc-lite/geometry';
 
 export function EmbedViewer() {
@@ -45,83 +46,88 @@ export function EmbedViewer() {
     setTheme(urlParams.theme === 'dark' ? 'dark' : 'light');
   }, [urlParams.theme, setTheme]);
 
-  // Initialize the postMessage bridge
+  // Initialize the postMessage bridge.
+  //
+  // Guarded via mountBridgeLifecycle/unmountBridgeLifecycle so a React 19
+  // <StrictMode> mount -> cleanup -> remount cycle (dev only) re-initializes
+  // instead of leaving the bridge permanently dead: the mount side was
+  // ref-guarded but the cleanup never reset it, so the remount saw the guard
+  // already set, skipped initBridge(), and the inbound listener stayed removed.
   useEffect(() => {
-    if (bridgeInitialized.current) return;
-    bridgeInitialized.current = true;
-
-    // Derive the expected parent origin (so content-bearing auto-load events
-    // are not broadcast to '*' before any inbound command arrives): prefer the
-    // explicit ?parentOrigin= param, then fall back to the referrer's origin.
-    let expectedParentOrigin = urlParams.parentOrigin;
-    if (!expectedParentOrigin && document.referrer) {
-      try {
-        expectedParentOrigin = new URL(document.referrer).origin;
-      } catch (error) {
-        // Malformed referrer — leave undefined and rely on the inbound handshake.
-        console.warn('[embed] Failed to derive parent origin from document.referrer', document.referrer, error);
-        expectedParentOrigin = undefined;
+    mountBridgeLifecycle(bridgeInitialized, () => {
+      // Derive the expected parent origin (so content-bearing auto-load events
+      // are not broadcast to '*' before any inbound command arrives): prefer the
+      // explicit ?parentOrigin= param, then fall back to the referrer's origin.
+      let expectedParentOrigin = urlParams.parentOrigin;
+      if (!expectedParentOrigin && document.referrer) {
+        try {
+          expectedParentOrigin = new URL(document.referrer).origin;
+        } catch (error) {
+          // Malformed referrer — leave undefined and rely on the inbound handshake.
+          console.warn('[embed] Failed to derive parent origin from document.referrer', document.referrer, error);
+          expectedParentOrigin = undefined;
+        }
       }
-    }
 
-    initBridge({
-      getState: () => useViewerStore.getState(),
-      loadModelFromUrl: async (url: string) => {
-        // Enforce the same http(s)-only allowlist as the URL-param path so the
-        // postMessage bridge can't be steered to file:/data:/internal targets.
-        const safeUrl = assertFetchableUrl(url);
-        const response = await fetch(safeUrl, { signal: AbortSignal.timeout(60_000) });
-        if (!response.ok) throw new Error(`Failed to fetch model: ${response.statusText}`);
-        const buffer = await response.arrayBuffer();
-        const filename = url.split('/').pop() || 'model.ifc';
-        const file = new File([buffer], filename);
-        await loadFile(file);
-        const state = useViewerStore.getState();
-        const gr = state.geometryResult;
-        return {
-          entities: state.ifcDataStore?.entities?.count ?? 0,
-          triangles: gr?.totalTriangles ?? 0,
-          vertices: gr?.totalVertices ?? 0,
-        };
-      },
-      loadModelFromBuffer: async (buffer: ArrayBuffer, name?: string) => {
-        const file = new File([buffer], name || 'model.ifc');
-        await loadFile(file);
-        const state = useViewerStore.getState();
-        const gr = state.geometryResult;
-        return {
-          entities: state.ifcDataStore?.entities?.count ?? 0,
-          triangles: gr?.totalTriangles ?? 0,
-          vertices: gr?.totalVertices ?? 0,
-        };
-      },
-      addModelFromUrl: async (url: string) => {
-        // Federation-aware add: routes through useIfcFederation's addModel,
-        // which loads with target `{ kind: 'federated' }` and therefore does
-        // NOT clear existing models (unlike loadFile's default primary
-        // target, which loadModelFromUrl above uses for LOAD_MODEL).
-        const safeUrl = assertFetchableUrl(url);
-        const response = await fetch(safeUrl, { signal: AbortSignal.timeout(60_000) });
-        if (!response.ok) throw new Error(`Failed to fetch model: ${response.statusText}`);
-        const buffer = await response.arrayBuffer();
-        const filename = url.split('/').pop() || 'model.ifc';
-        const file = new File([buffer], filename);
-        const modelId = await addModel(file);
-        if (!modelId) throw new Error('Failed to add model');
-        const added = useViewerStore.getState().models.get(modelId);
-        return {
-          modelId,
-          entities: added?.ifcDataStore?.entities?.count ?? 0,
-          triangles: added?.geometryResult?.totalTriangles ?? 0,
-          vertices: added?.geometryResult?.totalVertices ?? 0,
-        };
-      },
-    }, {
-      allowedOrigins: urlParams.allowOrigins,
-      expectedParentOrigin,
+      initBridge({
+        getState: () => useViewerStore.getState(),
+        loadModelFromUrl: async (url: string) => {
+          // Enforce the same http(s)-only allowlist as the URL-param path so the
+          // postMessage bridge can't be steered to file:/data:/internal targets.
+          const safeUrl = assertFetchableUrl(url);
+          const response = await fetch(safeUrl, { signal: AbortSignal.timeout(60_000) });
+          if (!response.ok) throw new Error(`Failed to fetch model: ${response.statusText}`);
+          const buffer = await response.arrayBuffer();
+          const filename = url.split('/').pop() || 'model.ifc';
+          const file = new File([buffer], filename);
+          await loadFile(file);
+          const state = useViewerStore.getState();
+          const gr = state.geometryResult;
+          return {
+            entities: state.ifcDataStore?.entities?.count ?? 0,
+            triangles: gr?.totalTriangles ?? 0,
+            vertices: gr?.totalVertices ?? 0,
+          };
+        },
+        loadModelFromBuffer: async (buffer: ArrayBuffer, name?: string) => {
+          const file = new File([buffer], name || 'model.ifc');
+          await loadFile(file);
+          const state = useViewerStore.getState();
+          const gr = state.geometryResult;
+          return {
+            entities: state.ifcDataStore?.entities?.count ?? 0,
+            triangles: gr?.totalTriangles ?? 0,
+            vertices: gr?.totalVertices ?? 0,
+          };
+        },
+        addModelFromUrl: async (url: string) => {
+          // Federation-aware add: routes through useIfcFederation's addModel,
+          // which loads with target `{ kind: 'federated' }` and therefore does
+          // NOT clear existing models (unlike loadFile's default primary
+          // target, which loadModelFromUrl above uses for LOAD_MODEL).
+          const safeUrl = assertFetchableUrl(url);
+          const response = await fetch(safeUrl, { signal: AbortSignal.timeout(60_000) });
+          if (!response.ok) throw new Error(`Failed to fetch model: ${response.statusText}`);
+          const buffer = await response.arrayBuffer();
+          const filename = url.split('/').pop() || 'model.ifc';
+          const file = new File([buffer], filename);
+          const modelId = await addModel(file);
+          if (!modelId) throw new Error('Failed to add model');
+          const added = useViewerStore.getState().models.get(modelId);
+          return {
+            modelId,
+            entities: added?.ifcDataStore?.entities?.count ?? 0,
+            triangles: added?.geometryResult?.totalTriangles ?? 0,
+            vertices: added?.geometryResult?.totalVertices ?? 0,
+          };
+        },
+      }, {
+        allowedOrigins: urlParams.allowOrigins,
+        expectedParentOrigin,
+      });
     });
 
-    return () => destroyBridge();
+    return () => unmountBridgeLifecycle(bridgeInitialized, () => destroyBridge());
   }, [loadFile, addModel, urlParams.allowOrigins, urlParams.parentOrigin]);
 
   // Auto-load model from URL param


### PR DESCRIPTION
> **Stacked on #2361** — both touch the same `useEffect` in `EmbedViewer.tsx`, so this is based on that branch rather than `main` to avoid handing you a conflict. Merge #2361 first and this retargets cleanly.

Found by the same audit that produced #2361.

`EmbedViewer.tsx`'s bridge effect guarded the **mount** side with a ref and left the **cleanup** side unguarded — a sibling asymmetry:

```ts
if (bridgeInitialized.current) return;   // mount: guarded
bridgeInitialized.current = true;
...
return () => destroyBridge();            // cleanup: NOT guarded
```

`main.tsx` wraps the app in `<React.StrictMode>` on React 19, which double-invokes effects in development — mount → cleanup → mount:

1. effect runs, guard flips true, `initBridge` registers the `message` listener and posts READY;
2. StrictMode runs the cleanup, `destroyBridge()` removes the listener;
3. StrictMode re-invokes the effect — but the ref is **still true**, so it returns early and `initBridge` never runs again.

The bridge is left permanently dead with no inbound listener. The embed posts READY once and then can't hear `INIT`, so the `READY → INIT → INIT_ACK` handshake never completes and `IFCLiteEmbed.create()` times out (default 15s).

**Scope, stated honestly: this is dev-only.** Production builds strip StrictMode's double-invoke, and the effect's deps are referentially stable, so it runs once outside dev. It's not a production outage — it's a broken local development experience against a real parent page.

## The fix

Reset the guard on cleanup. Extracted into `src/bridge/lifecycle.ts` rather than inlined, for one concrete reason: this package's vitest include glob is `src/**/*.test.ts` — **`.ts` only** — so a `.tsx` test isn't even *collected*. That's exactly why `EmbedViewer.tsx` has zero coverage today. Putting the guard in plain TS makes it testable without widening the glob for the whole app. `vitest.config.ts` is untouched, byte-identical.

`unmountBridgeLifecycle` resets the ref **before** calling destroy, so the synchronous StrictMode remount sees an unset guard.

## RED proof

With the `ref.current = false` reset removed (exact substring replacement, count asserted `== 1`):

```
× leaves the bridge ALIVE: listener registered and still handling inbound messages
× returns the listener count to zero after every unmount and never exceeds one across repeated cycles
  AssertionError: expected +0 to be 1
Tests  2 failed | 5 passed (7)
```

Note what those tests assert: that the listener is **alive and still handles a dispatched message** after mount/cleanup/remount — not that `initBridge` was called N times. A call-count assertion would pass even with a dead listener, which is the entire failure mode here.

## Bounding control (passes before *and* after)

A single normal mount must still initialise **exactly once**: one `initBridge` call, listener count 1, exactly one READY posted — including for two mounts with no intervening unmount. Without it, "just delete the ref guard" would satisfy the regression tests while reintroducing double-initialisation and a duplicate READY.

## Displacement

- unmount on a never-mounted guard: no-op, destroy not called, listener count stays 0.
- `initBridge` twice directly: listener count stays 1 — `onMessage` is a stable module-level reference, so `addEventListener` dedupes exactly as the DOM does.
- `destroyBridge` after a double init: count returns to 0, so the add/remove pair stays matched even under redundant init.

## Verification

`apps/viewer-embed` **125/125** (118 from #2361, +7 new). `tsc --noEmit` **exit 0**.

No changeset: `apps/viewer-embed` is `"private": true`, and neither `embed-sdk` nor `embed-protocol` was modified.

The large line count in `EmbedViewer.tsx` is almost entirely **re-indenting** the effect body into the mount callback — the substantive change is four lines: the import, the comment, the mount wrapper, and the cleanup.

## Still open from the same audit

Not fixed here, each wants its own diff: `event.source` validated on the SDK side but never on the embed side; `initToken` implemented and tested but never wired to any URL param; `GET_PROPERTIES` always returning empty `propertySets`/`quantitySets`; `GET_SCREENSHOT` documented without a caveat but always `NOT_IMPLEMENTED`; and `REMOVE_MODEL` reporting success when it removed nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved embedded viewer bridge behavior during React StrictMode remounts.
  * Ensured message listeners are restored after remounts and removed during unmounts.
  * Prevented duplicate initialization and maintained reliable inbound command handling.
  * Preserved model loading, validation, origin restrictions, and result reporting behavior.

* **Tests**
  * Added comprehensive coverage for mounting, unmounting, remounting, and repeated lifecycle cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->