### PR TITLE
test(parser): give the equivalence sweep a budget that fits its work

### DIFF
--- a/packages/parser/src/entity-extractor.equivalence.test.ts
+++ b/packages/parser/src/entity-extractor.equivalence.test.ts
@@ -109,6 +109,14 @@ describe('EntityExtractor source-shape equivalence', () => {
     expect(paths).toContain(FIXTURE_RELPATH);
   });
 
+  // 60s, not vitest's default 5s: this sweeps EVERY record in a ~44k-entity
+  // fixture through three extractors and six `JSON.stringify` calls per record
+  // (~130k stringifies). That is deliberate — the whole point is an exhaustive
+  // equivalence oracle, not a sample — but it means the default budget was
+  // never a considered one, and on a loaded CI runner the test lost to it and
+  // reddened unrelated PRs (#2320, #2349, #2360). It runs in ~180ms locally,
+  // so this ceiling is ~300x headroom: it will still fail loudly if the work
+  // becomes genuinely pathological, rather than flaking at the margin.
   it('extracts identical entities from a Uint8Array, an IfcSourceBytes, and a reference source', async (ctx) => {
     if (!existsSync(FIXTURE_PATH)) {
       // ctx.skip(), never a bare `return`: a return records a PASS, so on a
@@ -174,5 +182,5 @@ describe('EntityExtractor source-shape equivalence', () => {
     // nothing — count real entities, and real attribute values inside them.
     expect(extracted).toBeGreaterThanOrEqual(MIN_ENTITIES);
     expect(attributeValues).toBeGreaterThanOrEqual(MIN_ENTITIES);
-  });
+  }, 60_000);
 });


### PR DESCRIPTION
`packages/parser/src/entity-extractor.equivalence.test.ts` runs against vitest's **default** 5s timeout, which was never a considered budget for what it does: sweep **every** record of a ~44k-entity fixture through three extractors with six `JSON.stringify` calls each — roughly **130k stringifies**.

That thoroughness is the point — it is the exhaustive oracle behind the `Uint8Array | IfcSourceBytes` union contract from #2339, not a sample. The problem is only the budget.

## It is taking other people's PRs down

Three PRs failed on this test alone, with diffs nowhere near the parser:

| PR | its actual diff |
|---|---|
| #2320 | `apps/server` parquet guard |
| #2349 | **one viewer test file** |
| #2360 | four moonshot `.mjs` scripts |

Each showed `Test timed out in 5000ms` on `entity-extractor.equivalence.test.ts`. #2349's rerun passed unchanged, which is the signature of a margin flake rather than a real failure. A flake that reddens unrelated work costs more than the test saves.

## Why 60s and not "make it faster"

Locally it takes **~180ms** with the fixture present, so 60s is ~300x headroom. It will still fail loudly if the work becomes genuinely pathological; it just will not lose to runner contention. Sampling instead of sweeping would weaken the oracle, which is the wrong trade for a contract test.

## Not masking anything

The test is fixture-gated and uses `ctx.skip()` (never a bare `return`, which would record a false PASS). Verified both paths:

- without the fixture: **1 passed, 1 skipped**
- with the fixture staged: **2 passed, 179ms**