### PR TITLE
fix(server-client): a partially-NaN mesh origin rode through into MeshData

### DIFF
--- a/.changeset/mesh-origin-nan-guard.md
+++ b/.changeset/mesh-origin-nan-guard.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/server-client": patch
+---
+
+Fix a mesh `origin` decode defect in `parquet-tables.ts`'s `transformFields`: `origin_x/y/z` are `Float64` columns server-side and can legitimately carry `NaN`/`Infinity` on a corrupted payload, but the truthiness check (`originX[index] || originY[index] || originZ[index]`) treated a NaN component as "present" whenever at least one of the other two components was truthy — a partially-NaN origin (e.g. `[NaN, 5, 0]`) rode straight through into `MeshData.origin`, where a NaN can later poison `expandModelBoundsWithFlatVertices` / scene-bounds arithmetic for the whole model. An all-NaN origin was already dropped (NaN is falsy), so the two corruption shapes were handled inconsistently.
+
+Both now fall back to "no origin" — the same graceful degradation `originIsUsable` already applies to a structurally short/absent column set — rather than throwing, matching this file's existing convention of reserving thrown errors for structural malformation (missing columns, length mismatches, out-of-bounds ranges) and never for a value inside an otherwise well-formed float column. A normal finite origin and the existing all-zero-origin-omitted behavior are unchanged. Applies to both the standard (`buildMeshesFromTables`) and optimized/instanced (`buildMeshesFromOptimizedTables`) decode paths, which share `transformFields`.

--- a/packages/server-client/src/parquet-tables.test.ts
+++ b/packages/server-client/src/parquet-tables.test.ts
@@ -164,6 +164,40 @@ describe('buildMeshesFromTables (standard format)', () => {
     expect(meshes.map((m) => m.origin?.[0])).toEqual([1, 2, 3]);
   });
 
+  it('omits an all-NaN origin instead of hiding corruption as world-baked', () => {
+    const [mesh] = buildMeshesFromTables(
+      meshTable(1, {
+        origin_x: new Float64Array([NaN]),
+        origin_y: new Float64Array([NaN]),
+        origin_z: new Float64Array([NaN]),
+      }),
+      vertexTable,
+      indexTable
+    );
+    expect('origin' in mesh).toBe(false);
+  });
+
+  it('omits a PARTIALLY-NaN origin rather than letting NaN reach MeshData.origin', () => {
+    const [mesh] = buildMeshesFromTables(
+      // origin_x is NaN; origin_y/origin_z are finite non-zero, so the old
+      // `||` truthiness check would have let this triplet through with the
+      // NaN intact — poisoning downstream bounds/position math.
+      meshTable(1, {
+        origin_x: new Float64Array([NaN]),
+        origin_y: new Float64Array([5]),
+        origin_z: new Float64Array([0]),
+      }),
+      vertexTable,
+      indexTable
+    );
+    expect('origin' in mesh).toBe(false);
+    // Belt and braces: even if a future change re-adds `origin`, it must
+    // never contain a NaN component.
+    if (mesh.origin) {
+      expect(mesh.origin.every((c) => Number.isFinite(c))).toBe(true);
+    }
+  });
+
   it('throws on a missing required vertex column instead of decoding NaN geometry', () => {
     const brokenVertices = table({
       x: new Float32Array([0, 1, 1]),
@@ -263,6 +297,33 @@ describe('buildMeshesFromOptimizedTables (instanced format)', () => {
     );
     expect(Array.from(mesh.positions.slice(0, 6))).toEqual([0, 0, 0, 1, 0, 0]);
     expect(mesh.origin).toEqual([5000, 0, 0]);
+  });
+
+  it('omits an all-NaN instance origin instead of hiding corruption as world-baked', () => {
+    const meshes = buildMeshesFromOptimizedTables(
+      optimizedFixture({
+        origin_x: new Float64Array([0, NaN]),
+        origin_y: new Float64Array([0, NaN]),
+        origin_z: new Float64Array([0, NaN]),
+      })
+    );
+    expect('origin' in meshes[1]).toBe(false);
+  });
+
+  it('omits a PARTIALLY-NaN instance origin rather than letting NaN reach MeshData.origin', () => {
+    const meshes = buildMeshesFromOptimizedTables(
+      // Instance 1's origin_x is NaN; origin_y/origin_z are finite non-zero,
+      // so the old `||` truthiness check would have let the NaN through.
+      optimizedFixture({
+        origin_x: new Float64Array([0, NaN]),
+        origin_y: new Float64Array([0, 5]),
+        origin_z: new Float64Array([0, -1000]),
+      })
+    );
+    expect('origin' in meshes[1]).toBe(false);
+    if (meshes[1].origin) {
+      expect(meshes[1].origin.every((c) => Number.isFinite(c))).toBe(true);
+    }
   });
 
   it('throws when an instance references a mesh or material that does not exist', () => {

--- a/packages/server-client/src/parquet-tables.ts
+++ b/packages/server-client/src/parquet-tables.ts
@@ -72,9 +72,25 @@ function transformFields(
   geometryClass: ArrayLike<number> | undefined,
   hasGeometryClass: boolean
 ): Partial<MeshData> {
+  // A column set can be structurally usable (present, parallel to the rows)
+  // yet still carry a non-finite VALUE at this row — origin_x/y/z are Float64
+  // server-side and can legitimately hold NaN/Infinity on a corrupted payload.
+  // `||` alone does not catch this: NaN is falsy, so an all-NaN triplet was
+  // already dropped, but a PARTIAL one (e.g. `[NaN, 5, 0]`) is truthy and the
+  // NaN would ride straight into `MeshData.origin` and poison downstream
+  // bounds/position math. Treat non-finite the same as "column unusable" —
+  // fall back to no origin, exactly like `originIsUsable`'s own structural
+  // fallback — rather than throwing: this file only throws for STRUCTURAL
+  // malformation (missing columns, length mismatch, out-of-bounds index),
+  // never for a value inside an otherwise well-formed float column.
+  const ox = hasOrigin ? originX![index] : undefined;
+  const oy = hasOrigin ? originY![index] : undefined;
+  const oz = hasOrigin ? originZ![index] : undefined;
+  const originFinite =
+    hasOrigin && Number.isFinite(ox) && Number.isFinite(oy) && Number.isFinite(oz);
   const origin =
-    hasOrigin && (originX![index] || originY![index] || originZ![index])
-      ? ([originX![index], originY![index], originZ![index]] as [number, number, number])
+    originFinite && (ox || oy || oz)
+      ? ([ox, oy, oz] as [number, number, number])
       : undefined;
   const geometry_class =
     hasGeometryClass && geometryClass![index] ? geometryClass![index] : undefined;


### PR DESCRIPTION
Found by auditing ~1800 lines of `packages/server-client` decoders that a previous audit pass ran out of budget for. Independent of the other open PRs — based directly on `main`.

`transformFields` decided whether a mesh has an origin with:

```ts
hasOrigin && (originX[i] || originY[i] || originZ[i])
```

`origin_x/y/z` are `Float64` server-side (`apps/server/src/services/parquet_schema.rs:37-39`), so unlike the UInt32 offset/count columns they can legitimately carry `NaN`/`Infinity` on a corrupted payload. That truthiness test then handles the two corruption shapes **inconsistently**:

| input | result |
|---|---|
| all-NaN | `undefined` — falsy, already dropped |
| **partial NaN** | **`[ NaN, 5, 0 ]` — truthy, NaN rides through** |
| all-zero | `undefined` |
| normal | `[ 1, 2, 3 ]` |

The partial case is the live defect: a NaN in `MeshData.origin` poisons downstream position and bounds arithmetic. Elsewhere in this repo a NaN reaching `expandModelBoundsWithFlatVertices` → `camera.setSceneBounds` corrupts model bounds for the **whole scene**, not just the offending mesh.

`originIsUsable` couldn't catch it — it checks presence and length parity only, never value sanity, so the guard whose own comment says a malformed set "must fall back to 'no origin'" doesn't cover a well-formed-but-NaN-valued column.

## Fall back, don't throw — decided from the file's own convention

Every `Malformed …` throw in this file guards a **structural** problem: a missing column, a length mismatch between parallel columns, or an out-of-bounds index. None validates the *value* inside a well-formed float column — `posX`/`normX` are equally `Float64` and equally unchecked for finiteness. And `originIsUsable`'s doc comment already establishes graceful degradation for this exact field.

Throwing here would introduce a class of validation the file applies nowhere else, so a non-finite component now falls back to no-origin — the same treatment all-NaN already received.

**The point is that both shapes are now handled the same way.** Which behaviour is right is arguable; handling them differently wasn't.

**Preserved deliberately:** an all-zero origin `(0,0,0)` still yields `undefined`. That's correct — a zero origin means no shift, so the two are equivalent — and the `(ox || oy || oz)` test is retained precisely to keep it. A naive rewrite to `hasOrigin ? [...] : undefined` would have "fixed" that too and attached a pointless origin to every mesh.

## RED proof

With the finiteness guard removed (exact substring replacement, count asserted `== 1`):

```
× omits a PARTIALLY-NaN origin rather than letting NaN reach MeshData.origin
× omits a PARTIALLY-NaN instance origin rather than letting NaN reach MeshData.origin
Tests  2 failed | 15 passed (17)
```

Exactly two failures, one on **each** build path — which doubles as the displacement proof below.

The all-NaN tests pass in that run too: they were never the broken half, so they stand as bounding controls rather than RED tests. Saying that explicitly rather than counting them as part of the fix.

## Bounding controls (pass before *and* after)

- a normal finite origin `[1000.5, 30, -2000.25]` is still emitted unchanged;
- an all-zero origin still yields `undefined` — the control that catches a naive rewrite;
- the existing "partial column set" and "not parallel to rows" tests still pass on both paths.

## Displacement

`transformFields` is shared by `buildMeshesFromTables` **and** `buildMeshesFromOptimizedTables`. Both got the new tests, and the RED run failed on both — so the fix lands on both callers rather than one, which is the sibling-asymmetry shape this repo keeps producing.

## Verification

`packages/server-client` **32/32** (was 28; +4). `tsc --noEmit` **exit 0**. Changeset added — the package has no `"private"` field and carries `publishConfig`, so it's published.

## Also found in the same audit, not fixed here

1. **`data-model-decoder.ts`'s five required sections have no bounds check.** The *optional* appended sections (`readOptionalSection`, ~374-386) validate `offset + len > data.byteLength` and throw a clear `Malformed data model: truncated appended section`. The five required sections (~339-366) and the nested spatial sub-sections (~513-537) have none — so a truncated payload still fails loudly, but with a native `RangeError` deep inside `decodeDataModel` instead of the clear message the optional path deliberately provides. 3 of 10 length-prefixed reads get the good error.
2. **Arrow column types are never verified against the expected schema.** The decoder calls `.toArray()` by column name and trusts what comes back. A compliant server can't trigger a problem (every offset column is `UInt32`, which becomes a `Uint32Array` that can't hold a negative or NaN), so this is defence-in-depth rather than a live bug — but the upper-bound-only guards would admit a negative offset if a payload redeclared a column as `Int32`.

Worth noting the audit also **confirmed the saturating-`subarray` pattern that caused real bugs elsewhere in this repo does not appear** in any of these five files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
