### PR TITLE
fix(viewer): delete a resetState option that never did anything

### DIFF
--- a/apps/viewer/src/hooks/useIfcFederation.resetState.test.tsx
+++ b/apps/viewer/src/hooks/useIfcFederation.resetState.test.tsx
@@ -1,0 +1,186 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `loadFederatedIfcxFromBuffers` took a `{ resetState?: boolean }` option
+ * that was NEVER READ (grep confirms exactly two hits in the source file:
+ * the declaration and one call site). The function unconditionally calls
+ * `resetViewerState()` / `setGeometryResult(null)` / `clearAllModels()`
+ * regardless of what the caller passed. `addIfcxOverlays` called it with
+ * `{ resetState: false }`, which reads as "preserve selection/hidden/
+ * isolated state while adding an overlay" but that intent was silently
+ * discarded.
+ *
+ * Investigation (recorded here, not just in the PR description, so the
+ * "why" survives): expressIds in the composed IFCX entity table are
+ * SYNTHETIC and auto-incrementing over iteration order of the composed
+ * node map (`packages/ifcx/src/entity-extractor.ts`). That iteration order
+ * is seeded by `LayerStack.getAllPaths()`, which walks layers STRONGEST
+ * FIRST and inserts each layer's own path order first-come-first-served
+ * into an insertion-ordered Set (`packages/ifcx/src/layer-stack.ts`).
+ * Adding an overlay makes it the new strongest layer, so the overlay's own
+ * path order gets spliced to the FRONT of that Set - ahead of paths that
+ * previously sorted earlier. That reshuffles which entity gets which
+ * expressId, even for a PURE property overlay that adds zero new paths.
+ *
+ * This was verified empirically against real fixtures
+ * (tests/models/ifc5/Hello_Wall_hello-wall.ifcx + ...-add-fire-rating-60.ifcx):
+ * of 9 entities shared between "base alone" and "base + fire-rating overlay",
+ * 5 of 9 got a DIFFERENT expressId after recomposition, despite the overlay
+ * changing no geometry and adding no entities. Since federated models use
+ * `idOffset: 0` for every layer (globalId === expressId), a selection/
+ * hidden/isolated set captured before the overlay would silently point at
+ * DIFFERENT entities after it — exactly the "3D highlighting" corruption
+ * the in-code comment warns about. So the reset is CORRECT and the dead
+ * option is a lie: honouring `resetState: false` would reintroduce that
+ * bug. Conclusion: delete the option, keep the reset, document overlay-add
+ * as intentionally destructive to viewer state at the call site.
+ *
+ * These tests pin:
+ *  1. `resetState` is no longer part of the public signature (grep-level,
+ *     so a returning offer to "just wire it up" fails loudly).
+ *  2. BOUNDING CONTROL - a first federated load resets state (unchanged
+ *     behaviour, must never regress).
+ *  3. The behaviour this fix is choosing: adding an overlay to an already-
+ *     loaded federation ALSO resets state (selection/hidden/isolated all
+ *     clear), because ids are not stable across recomposition.
+ */
+
+import '@/test/setup-dom.js';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { resolve, dirname } from 'node:path';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { useViewerStore } from '@/store';
+import { useIfcFederation } from './useIfcFederation.js';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../../..');
+const BASE_PATH = resolve(REPO_ROOT, 'tests/models/ifc5/Hello_Wall_hello-wall.ifcx');
+const OVERLAY_PATH = resolve(REPO_ROOT, 'tests/models/ifc5/Hello_Wall_hello-wall-add-fire-rating-60.ifcx');
+// Per AGENTS.md fixtures are fetched on demand; skip cleanly on a fresh
+// checkout rather than crashing the suite.
+const FIXTURES_AVAILABLE = existsSync(BASE_PATH) && existsSync(OVERLAY_PATH);
+
+function toFile(path: string, name: string): File {
+  const bytes = readFileSync(path);
+  return new File([bytes], name, { type: 'application/json' });
+}
+
+// ─── Signature-level pin: the misleading option must not exist ──────────
+
+describe('loadFederatedIfcxFromBuffers - dead resetState option', () => {
+  it('is not referenced anywhere in the hook source (declaration + call site both gone)', () => {
+    const src = readFileSync(
+      resolve(dirname(fileURLToPath(import.meta.url)), 'useIfcFederation.ts'),
+      'utf8',
+    );
+    const hits = src.match(/resetState/g) ?? [];
+    assert.deepStrictEqual(
+      hits,
+      [],
+      'resetState must not appear in useIfcFederation.ts - it was a dead option ' +
+      '(declared, never read) that misrepresented addIfcxOverlays as state-preserving',
+    );
+  });
+});
+
+// ─── Behavioural harness ──────────────────────────────────────────────────
+
+let hookApi: ReturnType<typeof useIfcFederation> | null = null;
+const loadFile = async (): Promise<void> => {
+  throw new Error('loadFile should not be invoked by these federated-IFCX paths');
+};
+
+function Probe(): null {
+  hookApi = useIfcFederation(loadFile);
+  return null;
+}
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+async function mount(): Promise<void> {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root!.render(<Probe />);
+  });
+}
+
+function seedDirtyViewerState(): void {
+  useViewerStore.getState().resetViewerState();
+  useViewerStore.setState({
+    selectedEntityIds: new Set([1, 2, 3]),
+    hiddenEntities: new Set([4, 5]),
+    isolatedEntities: new Set([1]),
+  });
+}
+
+function isDirty(): boolean {
+  const s = useViewerStore.getState();
+  return s.selectedEntityIds.size > 0 || s.hiddenEntities.size > 0 || s.isolatedEntities !== null;
+}
+
+beforeEach(async () => {
+  hookApi = null;
+  await mount();
+});
+
+afterEach(async () => {
+  const current = root;
+  root = null;
+  if (current) await act(async () => current.unmount());
+  if (container) container.remove();
+  container = null;
+});
+
+describe(
+  'useIfcFederation - viewer state around federated IFCX loads',
+  { skip: !FIXTURES_AVAILABLE && 'tests/models/ifc5 fixtures missing - run `pnpm fixtures`' },
+  () => {
+    // BOUNDING CONTROL: unchanged behaviour. A first federated load must
+    // still fully reset viewer state - this must hold before AND after
+    // the fix, or "never reset" would pass the overlay test below while
+    // silently breaking normal loads.
+    it('BOUNDING CONTROL: a first federated load resets selection/hidden/isolated state', async () => {
+      seedDirtyViewerState();
+      assert.equal(isDirty(), true, 'precondition: dirty state must be seeded');
+
+      await act(async () => {
+        await hookApi!.loadFederatedIfcx([toFile(BASE_PATH, 'base.ifcx')]);
+      });
+
+      assert.equal(isDirty(), false, 'first federated load must reset selection/hidden/isolated state');
+    });
+
+    // The decided behaviour: adding an overlay to an already-federated
+    // model is intentionally destructive to viewer state too, because
+    // expressIds are not stable across recomposition (see file banner).
+    it('adding an IFCX overlay to an existing federation ALSO resets state (ids are not stable across recomposition)', async () => {
+      await act(async () => {
+        await hookApi!.loadFederatedIfcx([toFile(BASE_PATH, 'base.ifcx')]);
+      });
+      assert.equal(useViewerStore.getState().error, null, 'base load must succeed');
+
+      seedDirtyViewerState();
+      assert.equal(isDirty(), true, 'precondition: dirty state must be seeded after base load');
+
+      await act(async () => {
+        await hookApi!.addIfcxOverlays([toFile(OVERLAY_PATH, 'fire-rating.ifcx')]);
+      });
+
+      assert.equal(useViewerStore.getState().error, null, 'overlay add must succeed');
+      assert.equal(
+        isDirty(),
+        false,
+        'overlay-add must reset selection/hidden/isolated state - stale ids from before ' +
+        'the recomposition can point at a DIFFERENT entity afterwards',
+      );
+    });
+  },
+);

--- a/apps/viewer/src/hooks/useIfcFederation.ts
+++ b/apps/viewer/src/hooks/useIfcFederation.ts
@@ -375,13 +375,25 @@ export function useIfcFederation(
    */
   const loadFederatedIfcxFromBuffers = useCallback(async (
     buffers: Array<{ buffer: ArrayBuffer; name: string }>,
-    options: { resetState?: boolean } = {}
   ): Promise<void> => {
     const { resetViewerState, clearAllModels } = useViewerStore.getState();
 
     try {
-      // Always reset viewer state when geometry changes (selection, hidden entities, etc.)
-      // This ensures 3D highlighting works correctly after re-composition
+      // Reset viewer state on EVERY federated (re-)composition, including
+      // overlay-add. This used to be gated by a boolean "preserve state"
+      // option that was declared but never read (dead since #193) -
+      // `addIfcxOverlays` opted out believing it preserved selection,
+      // but the reset always ran anyway. Investigation confirmed the
+      // reset is correct, not just accidentally-always-on: expressIds in
+      // the composed IFCX entity table are synthetic and reassigned by
+      // iteration order over the composed node map, which shifts when a
+      // new overlay becomes the strongest layer - even a pure
+      // property-only overlay that adds no entities can reshuffle which
+      // expressId belongs to which entity. Since federated models share
+      // idOffset 0 (globalId === expressId), a selection/hidden/isolated
+      // set captured before recomposition can silently point at a
+      // DIFFERENT entity afterwards if left un-reset. So this reset is
+      // unconditional and there is no "preserve state" option to honour.
       resetViewerState();
 
       // Clear legacy geometry BEFORE clearing models to prevent stale fallback
@@ -619,7 +631,11 @@ export function useIfcFederation(
     // meant to override (#1717 V2).
     const allBuffers = [...existingBuffers, ...newBuffers];
 
-    await loadFederatedIfcxFromBuffers(allBuffers, { resetState: false });
+    // Re-composing (including this overlay add) always resets viewer
+    // state - see loadFederatedIfcxFromBuffers for why: expressIds are
+    // not stable across recomposition, so stale selection/hidden ids
+    // could point at the wrong entity afterwards.
+    await loadFederatedIfcxFromBuffers(allBuffers);
   }, [setError, loadFederatedIfcxFromBuffers]);
 
   /**


### PR DESCRIPTION
Found by auditing `apps/viewer/src/hooks/`, previously unaudited. Based directly on `main`.

`loadFederatedIfcxFromBuffers` declared `options: { resetState?: boolean }` and **never read it**. `addIfcxOverlays` passed `{ resetState: false }` — clearly intending to preserve selection while adding an overlay to an already-loaded federation — and that intent was silently discarded. The function always called `resetViewerState()`, `setGeometryResult(null)` and `clearAllModels()`.

Reachable live: `addIfcxOverlays` is called from `LayerDraftSection.tsx:104,144` (publishing a layer draft) and `toolbar/useFileCommands.tsx:203` (dropping IFCX onto a loaded model). So a user who selects, hides or isolates elements and then adds an overlay loses that state.

Both the option and the *"always reset … ensures 3D highlighting works correctly after re-composition"* comment arrived in the **same commit** (`5db4010a7`, a pure file-split refactor) — so the option was dead on arrival, never wired up during the split.

## Why delete rather than honour it

The obvious fix — gate the resets behind the option — would have been **wrong**, and this was settled by measurement rather than argument.

The question is whether ids survive recomposition. **They don't:**

- expressIds are **synthetic**, assigned by an auto-incrementing counter as the extractor iterates the composed map (`packages/ifcx/src/entity-extractor.ts:66-79`).
- That iteration order comes from walking layers strongest-first into an insertion-ordered `Set` (`federated-composition.ts:118-134`, `layer-stack.ts:269-273`). A new overlay becomes the **strongest** layer (`useIfcFederation.ts:620`, `ifcx/src/index.ts:517-524`), splicing its own path order to the *front* and reshuffling which entity gets which id.
- **Measured on real fixtures**: `Hello_Wall_hello-wall.ifcx` alone vs. the same plus `…add-fire-rating-60.ifcx` — same 9 entities, no new ones, pure property overlay, and **5 of 9 got a different expressId**.
- Federated models use `idOffset: 0`, so `globalId === expressId` (`store/globalId.ts:21-36`).

So a selection captured before an overlay-add would, after skipping the reset, point at a **different entity**. Preserving state would silently highlight the wrong things — worse than losing the selection. The in-code comment was right; the option was the mistake.

Re-mapping ids instead was considered and rejected: there's no path-based remap layer, and building one for a knob nobody currently needs isn't justified.

## What this changes at runtime: nothing

Stated plainly because it matters for review — the option was always dead, so **behaviour is byte-for-byte unchanged**. This removes a misleading API and replaces the comment with one explaining *why* the reset is unconditional, so the next refactor doesn't try to "fix" it again.

## Tests

1. **A pin that `resetState` no longer appears in the hook source.** This is a grep-level test rather than a behavioural one, which is unusual and worth flagging — it exists to stop the dead option being reintroduced, since no behavioural test can observe a parameter that is never read. RED before, GREEN after:

```
not ok 1 - is not referenced anywhere in the hook source
  + [ 'resetState', 'resetState' ]  - []
# tests 3 / # pass 2 / # fail 1
```

2. **Bounding control, passing before and after:** a *first* federated load still fully resets `selectedEntityIds`/`hiddenEntities`/`isolatedEntities`. That's correct behaviour and must not change — without it, a future "never reset" change would look fine.

3. **A behavioural pin** that `addIfcxOverlays` on an already-loaded federation also resets that state, loading real fixtures and seeding dirty state first. It passed pre-fix too, since the option was always dead — so it documents the decided-correct behaviour rather than fixing a regression, and I'd rather say that than count it as a fix.

## Displacement

Grepped the whole repo: the only other `resetState` is an unrelated local in `drawing2DSlice.ts:596`. `loadFederatedIfcxFromBuffers` is a local `const` never returned from the hook (`useIfcFederation.ts:642-653`), so it isn't exported — no external caller, no API break. The two live `addIfcxOverlays` callers are untouched; their signature didn't change.

## Verification

`apps/viewer` hooks suite **228/228**. Federation suite 31/31 unchanged. `acquireFileBuffer.test.ts` 7/7. `tsc --noEmit` **exit 0**. No changeset — `apps/viewer` is `"private": true`.

## Note

If you'd rather overlay-add *did* preserve selection, that's a real feature request but a bigger one — it needs a stable, path-based identity that survives recomposition, which doesn't exist today. Worth its own issue if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
