### PR TITLE
fix(lists): equals/notEquals were case-sensitive, so True never matched true

### DIFF
--- a/.changeset/lists-equals-boolean-case.md
+++ b/.changeset/lists-equals-boolean-case.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/lists": patch
+---
+
+Fix `equals`/`notEquals` list conditions being case-sensitive for boolean-like values, while their `contains` sibling was already case-insensitive. An `IfcBoolean` property displays as `"True"`/`"False"`, and a location-zone `Straddles` condition resolves to a raw JS boolean that stringifies as `"true"`/`"false"` — a condition typed as `IsExternal = true` (or a saved zone `Straddles = True` filter) could silently fail to match, and the equivalent `notEquals` condition could silently include rows that only differed by letter case.
+
+The fix is scoped to values that look like a boolean/logical (`"true"`/`"false"`/`"unknown"`, any case, or a genuine JS boolean) on both sides of the comparison. Every other value type — GlobalId, Name, classification codes, spatial container names, and any other string property — keeps the original exact, case-sensitive comparison, since e.g. two distinct IFC GlobalIds can differ only by case.

--- a/packages/lists/src/engine.test.ts
+++ b/packages/lists/src/engine.test.ts
@@ -439,6 +439,64 @@ describe('executeList', () => {
     expect(result.rows.map((r) => r.values[0]).sort()).toEqual([...expected]);
   });
 
+  // Bug: `equals`/`notEquals` were case-SENSITIVE while their sibling
+  // `contains` (line ~318) is case-insensitive. An IFC boolean property
+  // decodes and displays as "True"/"False" (resolvePropertyValue), so a user
+  // filtering on the natural lowercase "true"/"false" got no match — and
+  // `notEquals` silently INCLUDED rows that differed only by letter case.
+  // IsExternal: Wall-01=['IFCBOOLEAN','.T.'] -> "True", Wall-02=['IFCBOOLEAN','.F.'] -> "False",
+  // Slab-01 has no Pset_WallCommon at all (null -> excluded from every operator).
+  it.each([
+    // equals must match across case for boolean-like values.
+    { operator: 'equals', value: 'true', expected: ['Wall-01'] },
+    { operator: 'equals', value: 'TRUE', expected: ['Wall-01'] },
+    // Bounding control: a genuinely DIFFERENT boolean value must still NOT
+    // match — proves the fix didn't loosen equals into "match everything".
+    { operator: 'equals', value: 'false', expected: ['Wall-02'] },
+    // notEquals must NOT report "not equal" purely on letter case (Wall-01
+    // is "True", condition is 'true' -> they ARE equal -> excluded).
+    { operator: 'notEquals', value: 'true', expected: ['Wall-02'] },
+  ] as const)('boolean property $operator "$value" is case-insensitive', ({ operator, value, expected }) => {
+    const provider = createMockProvider();
+    const def: ListDefinition = {
+      id: 'cond-bool-case',
+      name: 'Test',
+      createdAt: 0,
+      updatedAt: 0,
+      entityTypes: [],
+      conditions: [{ source: 'property', psetName: 'Pset_WallCommon', propertyName: 'IsExternal', operator, value }],
+      columns: [{ id: 'name', source: 'attribute', propertyName: 'Name' }],
+    };
+
+    const result = executeList(def, provider);
+    expect(result.rows.map((r) => r.values[0]).sort()).toEqual([...expected]);
+  });
+
+  // Bounding control: GlobalId is a base64-ish IFC GUID where case IS
+  // significant (two distinct GUIDs can differ only by case). `equals` must
+  // stay case-sensitive here even after the boolean fix above, or a list
+  // could match the WRONG entity. Mock GlobalIds are lowercase hex
+  // ('0abc' for Wall-01) so an uppercase condition must NOT match.
+  it.each([
+    { operator: 'equals', value: '0abc', expected: ['Wall-01'] },
+    { operator: 'equals', value: '0ABC', expected: [] },
+    { operator: 'notEquals', value: '0ABC', expected: ['Slab-01', 'Wall-01', 'Wall-02'] },
+  ] as const)('GlobalId $operator "$value" stays case-sensitive', ({ operator, value, expected }) => {
+    const provider = createMockProvider();
+    const def: ListDefinition = {
+      id: 'cond-globalid-case',
+      name: 'Test',
+      createdAt: 0,
+      updatedAt: 0,
+      entityTypes: [],
+      conditions: [{ source: 'attribute', propertyName: 'GlobalId', operator, value }],
+      columns: [{ id: 'name', source: 'attribute', propertyName: 'Name' }],
+    };
+
+    const result = executeList(def, provider);
+    expect(result.rows.map((r) => r.values[0]).sort()).toEqual([...expected]);
+  });
+
   // Numeric operators (gt/lt/gte/lte/notEquals) plus the property/quantity
   // condition sources (getConditionValue's 'property'/'quantity' branches),
   // which the coverage above only exercises via columns, never via

--- a/packages/lists/src/engine.ts
+++ b/packages/lists/src/engine.ts
@@ -311,9 +311,9 @@ function matchesCondition(
 
   switch (condition.operator) {
     case 'equals':
-      return String(actualValue) === String(condition.value);
+      return equalsIgnoringBooleanCase(actualValue, condition.value);
     case 'notEquals':
-      return String(actualValue) !== String(condition.value);
+      return !equalsIgnoringBooleanCase(actualValue, condition.value);
     case 'contains':
       return String(actualValue).toLowerCase().includes(String(condition.value).toLowerCase());
     case 'gt':
@@ -327,6 +327,37 @@ function matchesCondition(
     default:
       return false;
   }
+}
+
+/** `true` for a JS boolean, or a string that stringifies an IFC boolean/
+ *  logical ("true" / "false" / "unknown", any case) — the only cases the
+ *  compared values can genuinely differ by CASE ALONE while meaning the same
+ *  thing (IfcBoolean displays as "True"/"False" via resolvePropertyValue,
+ *  IfcLogical adds "Unknown"; a raw JS boolean like `zone`'s Straddles flag
+ *  stringifies lowercase). Deliberately narrow: an arbitrary string field
+ *  (Name, GlobalId, classification code, …) is NOT boolean-like, so it falls
+ *  through to the exact, case-sensitive comparison below — a GlobalId that
+ *  differs only by case IS a different entity and must not match. */
+function isBooleanLike(value: CellValue): boolean {
+  if (typeof value === 'boolean') return true;
+  if (typeof value !== 'string') return false;
+  const lower = value.toLowerCase();
+  return lower === 'true' || lower === 'false' || lower === 'unknown';
+}
+
+/**
+ * `equals` comparison used by both `equals` and `notEquals` (case #: sibling
+ * asymmetry — `contains` was already case-insensitive, `equals`/`notEquals`
+ * were not, so `IsExternal = True` never matched a stored "true"). Only
+ * boolean-like values (see {@link isBooleanLike}) compare case-insensitively;
+ * everything else — including GlobalId, where two distinct GUIDs can differ
+ * only by case — keeps the original exact-match semantics.
+ */
+function equalsIgnoringBooleanCase(actualValue: CellValue, conditionValue: string | number | boolean): boolean {
+  if (isBooleanLike(actualValue) && isBooleanLike(conditionValue)) {
+    return String(actualValue).toLowerCase() === String(conditionValue).toLowerCase();
+  }
+  return String(actualValue) === String(conditionValue);
 }
 
 function getConditionValue(

--- a/packages/lists/src/engine.zone.test.ts
+++ b/packages/lists/src/engine.zone.test.ts
@@ -108,6 +108,22 @@ describe('zone column/condition (#1810)', () => {
     expect(result.rows.map(r => r.entityId)).toEqual([1]);
   });
 
+  // Straddles resolves to a RAW JS boolean (unlike a pset property, it never
+  // passes through resolvePropertyValue's display formatting), so it
+  // stringifies lowercase ("true"/"false"). Case-insensitive `equals` must
+  // still match a capitalized condition value like 'True' against it —
+  // proves the boolean-case fix covers a genuine `typeof === 'boolean'`
+  // CellValue, not just pset-derived "True"/"False" display strings.
+  it('filters via a zone Straddles equals condition regardless of value case', () => {
+    const result = executeList(
+      walls([{ id: 'z', source: 'zone', psetName: 'sections', propertyName: 'Zone' }], [
+        { source: 'zone', psetName: 'sections', propertyName: 'Straddles', operator: 'equals', value: 'True' },
+      ]),
+      createProvider(assignments),
+    );
+    expect(result.rows.map(r => r.entityId).sort()).toEqual([2, 4]);
+  });
+
   it('a provider with no getZoneAssignment resolves every zone column to null (backward compatible)', () => {
     const provider: ListDataProvider = {
       getEntitiesByType: (t) => (t === IfcTypeEnum.IfcWall ? [1] : []),


### PR DESCRIPTION
**User-reported:** filtering `IsExternal = True` in a list matched nothing, though the walls plainly have it set. Based directly on `main`.

`engine.ts`'s condition switch had a sibling asymmetry:

```
equals     -> String(a) === String(b)                    case-SENSITIVE
notEquals  -> String(a) !== String(b)                    case-SENSITIVE
contains   -> a.toLowerCase().includes(b.toLowerCase())  case-INSENSITIVE
```

The same file's multi-valued comparison (~line 429) also lowercases, and the separate search-rule engine lowercases its `eq` (`apps/viewer/src/lib/search/filter-rules.ts:212`) — so `equals`/`notEquals` were the odd ones out, and **the same logical filter behaved differently in search versus in a list**.

`notEquals` was the nastier half: it reported "not equal" purely on letter case, silently *including* rows that should have been excluded.

## Why there are two spellings of a boolean

Worth recording, because it explains why this bites in normal use rather than only on odd input. Booleans reach the comparison in two different string forms:

- `resolvePropertyValue` (~624-643) renders an IFC boolean (`.T.`/`.F.`/`.U.`, typed arrays, native booleans) as the **capitalised** display string `"True"`/`"False"`/`"Unknown"`;
- `getZoneValue`'s `Straddles` mode (~372) returns a **raw JS boolean**, which stringifies lowercase.

So the value shown in the table and the value the engine compares could differ in case depending on where it came from.

## Scoped to boolean-like values — a blanket lowercase would be a bug

The obvious one-line fix is wrong, and this was checked before writing it. `getConditionValue` dispatches on `condition.source`, and the `attribute` branch reaches `getAttributeValue`, whose `case 'GlobalId'` (~557-558) returns the entity's IFC GUID. **Two distinct GUIDs can differ only by case**, so lowercasing `equals` wholesale would make it match the *wrong entity* — worse than the bug being fixed.

So only boolean-like values compare case-insensitively, and only when **both** sides are boolean-like: `typeof === 'boolean'`, or a string that lowercases to `true`/`false`/`unknown`. Everything else keeps exact-match semantics.

## RED proof

With the boolean branch neutralised (exact substring replacement, count asserted `== 1`):

```
× filters via a zone Straddles equals condition regardless of value case
× boolean property 'equals' "'true'" is case-insensitive
× boolean property 'equals' "'TRUE'" is case-insensitive
× boolean property 'equals' "'false'" is case-insensitive
× boolean property 'notEquals' "'true'" is case-insensitive
Tests  5 failed | 155 passed (160)
```

Five failures across **both** boolean paths — the display-string property path and the raw-boolean zone path.

## Bounding controls (pass before *and* after)

- **GlobalId stays case-sensitive** — three tests using `'0abc'` vs `'0ABC'` pass identically before and after. This is the control that matters: it's what proves the fix didn't loosen GUID matching.
- **A genuinely different value still doesn't match** — `equals 'false'` still excludes a `"True"` row, so this isn't "lowercase everything".
- **`contains` is untouched** — its existing tests pass unmodified.

## Displacement

One existing test explicitly pins case-sensitivity: `engine.container-adversarial.test.ts:92-100`, *"equals is CASE-SENSITIVE (same as Storey/attribute equals)"*. It targets a spatial **container name**, which isn't boolean-like, so it's outside this fix's scope and passes unmodified. No test anywhere pinned case-sensitive *boolean* equality, so nothing encoded the bug and no fixture repair — or three-way measurement — was needed.

## Verification

`packages/lists` **160/160** (was 152; +8). `tsc --noEmit` **exit 0**. Changeset added — `packages/lists` has no `"private"` field, so it's published.

## Separate, not fixed here

The **search-side** filter can't see type-inherited property sets: `filter-evaluate.ts` uses only `extractPropertiesOnDemand`, while `PropertiesPanel.tsx:855`, `query-adapter.ts:197` and the LLM context builder also call `extractTypePropertiesOnDemand`. So a `Pset_WallCommon.IsExternal` attached to an `IfcWallType` is visible in the panel but unmatchable in search. Same user-visible symptom, different root cause — queued separately, since it needs a per-type cache to avoid a second extraction per entity and a decision on instance-over-type precedence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Boolean comparisons using `equals` and `notEquals` now work regardless of letter casing.
  * Supports JavaScript booleans and IFC boolean/logical values such as `true`, `false`, and `unknown`.
  * Non-boolean values, including `GlobalId` attributes, continue to use case-sensitive comparisons.
  * Zone filtering now correctly matches raw boolean values in straddling conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->