### PR TITLE
fix(viewer): search filter could not see type-inherited property sets

### DIFF
--- a/apps/viewer/src/lib/search/filter-evaluate-type-psets.test.ts
+++ b/apps/viewer/src/lib/search/filter-evaluate-type-psets.test.ts
@@ -1,0 +1,139 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Search filter must see TYPE-inherited property sets, the way the
+ * Properties panel already shows them (`extractTypePropertiesOnDemand`,
+ * `PropertiesPanel.tsx`'s "inherited type properties" section) — the bug
+ * this covers is `Pset_WallCommon.IsExternal = true` not matching a wall
+ * whose `IsExternal` is only defined on its `IfcWallType`.
+ *
+ * Fixture (real STEP text parsed through the WASM-less columnar parser,
+ * `IfcParser.parseColumnar`, so `extractTypePropertiesOnDemand`'s
+ * source-backed path is genuinely exercised, not mocked):
+ *
+ *  - Wall-A (#100): OWN `Pset_WallCommon` with `Reference = 'INSTANCE-REF'`.
+ *    No own `IsExternal`. Its type (#200, IfcWallType "WT-Std") carries
+ *    `Pset_WallCommon` with `IsExternal = true` AND `Reference = 'TYPE-REF'`
+ *    — the SAME property name as the instance, so Wall-A pins the
+ *    instance-wins precedence rule (IFC: occurrence overrides type).
+ *  - Wall-B (#110): NO own property sets at all — every property it
+ *    exposes comes from the type. Pins pure type-only visibility.
+ *  - Door-C (#120): no relations, no psets anywhere — the "neither"
+ *    bounding control.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { IfcParser, type IfcDataStore } from '@ifc-lite/parser';
+import { evaluateFilterRules } from './filter-evaluate.js';
+import { Rule } from './filter-rules.js';
+
+const FIXTURE = `ISO-10303-21;
+HEADER;
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('Proj0000000000000000001',$,'P',$,$,$,$,$,$);
+#100=IFCWALL('Wall00000000000000001A',$,'Wall-A',$,$,$,$,$,.SOLIDWALL.);
+#110=IFCWALL('Wall00000000000000001B',$,'Wall-B',$,$,$,$,$,.SOLIDWALL.);
+#120=IFCDOOR('Door000000000000000001C',$,'Door-C',$,$,$,$,$,$);
+#200=IFCWALLTYPE('Type00000000000000001A',$,'WT-Std',$,$,(#210),$,$,$,.STANDARD.);
+#210=IFCPROPERTYSET('Pset00000000000000001A',$,'Pset_WallCommon',$,(#211,#212));
+#211=IFCPROPERTYSINGLEVALUE('IsExternal',$,IFCBOOLEAN(.T.),$);
+#212=IFCPROPERTYSINGLEVALUE('Reference',$,IFCLABEL('TYPE-REF'),$);
+#230=IFCRELDEFINESBYTYPE('Rdbt00000000000000001A',$,$,$,(#100,#110),#200);
+#250=IFCPROPERTYSET('Pset00000000000000002A',$,'Pset_WallCommon',$,(#251));
+#251=IFCPROPERTYSINGLEVALUE('Reference',$,IFCLABEL('INSTANCE-REF'),$);
+#260=IFCRELDEFINESBYPROPERTIES('Rdbp00000000000000001A',$,$,$,(#100),#250);
+ENDSEC;
+END-ISO-10303-21;
+`;
+
+async function buildStore(): Promise<IfcDataStore> {
+  const bytes = new TextEncoder().encode(FIXTURE);
+  return new IfcParser().parseColumnar(bytes.buffer as ArrayBuffer, { disableWorkerScan: true }) as unknown as Promise<IfcDataStore>;
+}
+
+describe('evaluateFilterRules — TYPE-inherited property sets', () => {
+  it('matches a property that exists ONLY on the type (Wall-A and Wall-B both inherit IsExternal)', async () => {
+    const store = await buildStore();
+    const out = evaluateFilterRules('m1', store, [
+      Rule.property('Pset_WallCommon', 'IsExternal', 'eq', 'true'),
+    ], 'AND');
+    assert.deepStrictEqual(out.map((r) => r.expressId).sort((a, b) => a - b), [100, 110]);
+  });
+
+  it('PRECEDENCE: instance value wins over type value for the same property name', async () => {
+    const store = await buildStore();
+
+    // Wall-A's OWN Reference ('INSTANCE-REF') must win over its type's
+    // Reference ('TYPE-REF') — only Wall-A matches, not Wall-B (whose
+    // Reference comes solely from the type and is 'TYPE-REF').
+    const instanceMatch = evaluateFilterRules('m1', store, [
+      Rule.property('Pset_WallCommon', 'Reference', 'eq', 'INSTANCE-REF'),
+    ], 'AND');
+    assert.deepStrictEqual(instanceMatch.map((r) => r.expressId), [100]);
+
+    // The type's own value must NOT leak through for Wall-A (it's shadowed
+    // by the instance override) — only Wall-B, which has no instance
+    // override, matches 'TYPE-REF'.
+    const typeValueMatch = evaluateFilterRules('m1', store, [
+      Rule.property('Pset_WallCommon', 'Reference', 'eq', 'TYPE-REF'),
+    ], 'AND');
+    assert.deepStrictEqual(typeValueMatch.map((r) => r.expressId), [110]);
+  });
+
+  it('BOUNDING CONTROL (i): an instance-level-only property still matches exactly as before', async () => {
+    const store = await buildStore();
+    // Wall-A's Reference is an instance-only override in this fixture from
+    // Wall-B's perspective too — but to isolate "instance property, no type
+    // involvement at all" re-use IsExternal is type-only, so assert the
+    // pre-existing instance-property path (Reference on Wall-A) still
+    // resolves via the ordinary instance pset row, independent of type
+    // merging (a type with NO Pset_WallCommon.Reference key would still let
+    // this match — precedence test above already isolates the override).
+    const out = evaluateFilterRules('m1', store, [
+      Rule.property('Pset_WallCommon', 'Reference', 'eq', 'INSTANCE-REF'),
+    ], 'AND');
+    assert.deepStrictEqual(out.map((r) => r.expressId), [100]);
+  });
+
+  it('BOUNDING CONTROL (ii): an entity with NEITHER instance nor type pset does not match', async () => {
+    const store = await buildStore();
+    const out = evaluateFilterRules('m1', store, [
+      Rule.property('Pset_WallCommon', 'IsExternal', 'eq', 'true'),
+    ], 'AND');
+    assert.ok(!out.some((r) => r.expressId === 120), 'Door-C has no Pset_WallCommon anywhere and must not match');
+
+    const outAny = evaluateFilterRules('m1', store, [
+      Rule.property('Pset_WallCommon', 'Reference', 'isSet', ''),
+    ], 'AND');
+    assert.ok(!outAny.some((r) => r.expressId === 120), 'Door-C must not match isSet either — it has no Pset_WallCommon at all');
+  });
+
+  it('BOUNDING CONTROL (iii) — DELIBERATE BEHAVIOUR CHANGE: isSet now counts a type-only property as "set"', async () => {
+    const store = await buildStore();
+    // Wall-B has NO own psets — IsExternal is set ONLY via the type. Before
+    // this fix isSet only consulted instance psets, so this would have been
+    // false for Wall-B. That is the deliberate, called-out behaviour change:
+    // presence semantics now match what the Properties panel already shows
+    // the user (the type-inherited section).
+    const isSetOut = evaluateFilterRules('m1', store, [
+      Rule.property('Pset_WallCommon', 'IsExternal', 'isSet', ''),
+    ], 'AND');
+    assert.deepStrictEqual(isSetOut.map((r) => r.expressId).sort((a, b) => a - b), [100, 110]);
+
+    // Scoped to Wall/Door so the assertion isn't diluted by the fixture's
+    // other entities (IfcProject, IfcWallType, IfcRelDefinesByType), none of
+    // which carry a Pset_WallCommon either and would otherwise also match.
+    const isNotSetOut = evaluateFilterRules('m1', store, [
+      Rule.ifcType(['IfcWall', 'IfcDoor']),
+      Rule.property('Pset_WallCommon', 'IsExternal', 'isNotSet', ''),
+    ], 'AND');
+    // Door-C (no psets anywhere) is the only one for which IsExternal is
+    // genuinely not set.
+    assert.deepStrictEqual(isNotSetOut.map((r) => r.expressId), [120]);
+  });
+});

--- a/apps/viewer/src/lib/search/filter-evaluate.ts
+++ b/apps/viewer/src/lib/search/filter-evaluate.ts
@@ -37,11 +37,15 @@
 import {
   extractPropertiesOnDemand,
   extractQuantitiesOnDemand,
+  extractTypePropertiesOnDemand,
   extractAllMaterialsOnDemand,
   extractClassificationsOnDemand,
+  mergeInheritedPropertySets,
   type IfcDataStore,
   type ClassificationInfo,
 } from '@ifc-lite/parser';
+
+import { RelationshipType } from '@ifc-lite/data';
 
 import {
   combineRuleResults,
@@ -126,6 +130,7 @@ export function evaluateFilterRules(
     hasQuantityRule: orderedRules.some((r) => r.kind === 'quantity'),
     hasMaterialRule: orderedRules.some((r) => r.kind === 'material'),
     hasClassificationRule: orderedRules.some((r) => r.kind === 'classification'),
+    typePsetCache: new Map(),
   };
 
   for (const expressId of iterIds) {
@@ -230,6 +235,7 @@ export async function evaluateFilterRulesFederated(
       hasQuantityRule: orderedRules.some((r) => r.kind === 'quantity'),
       hasMaterialRule: orderedRules.some((r) => r.kind === 'material'),
       hasClassificationRule: orderedRules.some((r) => r.kind === 'classification'),
+      typePsetCache: new Map(),
     };
 
     // Walk the per-model iter in chunkSize-sized strides, yielding the
@@ -387,6 +393,11 @@ export function orderRulesByCost(rules: readonly FilterRule[]): FilterRule[] {
 
 // ── Per-entity inner loop ────────────────────────────────────────────────────
 
+/** Type-level pset rows in the same shape `extractPropertiesOnDemand` /
+ *  `extractTypePropertiesOnDemand` return — what `flattenPsets` /
+ *  `mergeInheritedPropertySets` expect. */
+type TypePsetList = ReturnType<typeof extractPropertiesOnDemand>;
+
 interface EvalContext {
   store: IfcDataStore;
   table: IfcDataStore['entities'];
@@ -395,6 +406,13 @@ interface EvalContext {
   hasQuantityRule: boolean;
   hasMaterialRule: boolean;
   hasClassificationRule: boolean;
+  /** Per-TYPE pset cache, keyed by the type's expressId and shared across
+   *  every entity evaluated against this store (one `EvalContext` per
+   *  model/plan). Many instances share one `IfcWallType` etc., so this
+   *  turns what would be N source-buffer parses (one per instance) into
+   *  one parse per distinct type — see the AGENTS.md §2 large-loop
+   *  warning this module already guards against for instance psets. */
+  typePsetCache: Map<number, TypePsetList>;
 }
 
 function evaluateOneEntity(
@@ -412,7 +430,17 @@ function evaluateOneEntity(
   let matCache: string[] | null = null;
   let classCache: readonly ClassificationInfo[] | null = null;
   const psetsFor = (): PsetRows => {
-    if (!psetCache) psetCache = flattenPsets(extractPropertiesOnDemand(ctx.store, expressId));
+    if (!psetCache) {
+      const ownSets = extractPropertiesOnDemand(ctx.store, expressId);
+      const typeSets = getInheritedTypePsets(ctx, expressId);
+      // IFC inheritance is per-PROPERTY, not per-set, and the occurrence's
+      // own value wins on a name collision — same rule the IDS bridge
+      // already applies (`mergeInheritedPropertySets`, packages/parser).
+      // A type-only pset (nothing on the instance) is appended as-is, so
+      // `isSet`/`isNotSet` now also see properties that exist ONLY on the
+      // type — a deliberate presence-semantics change (was instance-only).
+      psetCache = flattenPsets(mergeInheritedPropertySets(ownSets, typeSets));
+    }
     return psetCache;
   };
   const qtysFor = (): QtyRows => {
@@ -452,6 +480,41 @@ function evaluateOneEntity(
     if (combinator === 'OR' && result) return true;
   }
   return combineRuleResults(combinator, ruleResults);
+}
+
+/**
+ * Resolve `expressId`'s TYPE-level property sets (e.g. `IfcWallType`'s
+ * `Pset_WallCommon`) via `IfcRelDefinesByType`, caching the parse per
+ * TYPE (`ctx.typePsetCache`) rather than per instance. Many occurrences
+ * share one type, so this is O(distinct types) source-buffer parses per
+ * filter run, not O(entities) — see the AGENTS.md §2 warning this module
+ * already guards for instance psets.
+ *
+ * Mirrors `packages/ids/src/bridge/properties.ts`'s `inheritedPropertySets`
+ * / `typePropertySetsFromTable` split: `extractTypePropertiesOnDemand` only
+ * resolves from the source buffer, so on a server-parsed store (no
+ * `source`, e.g. after collab/session load) it always returns null — the
+ * type's psets there are keyed under the type's own expressId in the
+ * pre-built `PropertyTable` (`store.properties.getForEntity(typeId)`,
+ * issue #1787's server-path fallback).
+ */
+function getInheritedTypePsets(ctx: EvalContext, expressId: number): TypePsetList {
+  if (!ctx.store.relationships) return [];
+  const typeIds = ctx.store.relationships.getRelated(expressId, RelationshipType.DefinesByType, 'inverse');
+  if (typeIds.length === 0) return [];
+  const typeId = typeIds[0];
+
+  const cached = ctx.typePsetCache.get(typeId);
+  if (cached !== undefined) return cached;
+
+  let resolved: TypePsetList;
+  if (ctx.store.source && ctx.store.source.length > 0) {
+    resolved = extractTypePropertiesOnDemand(ctx.store, expressId)?.properties ?? [];
+  } else {
+    resolved = (ctx.store.properties?.getForEntity?.(typeId) ?? []) as unknown as TypePsetList;
+  }
+  ctx.typePsetCache.set(typeId, resolved);
+  return resolved;
 }
 
 function evaluateRule(


### PR DESCRIPTION
Second half of a user-reported bug: filtering `Pset_WallCommon.IsExternal = true` didn't match walls that visibly have it. The **list** half (a case-sensitive `equals`) shipped as #2373; this is the **search** half — a different root cause with the same symptom. Based directly on `main`, independent of #2373.

`filter-evaluate.ts` built its pset rows from **only** `extractPropertiesOnDemand(ctx.store, expressId)` — instance psets — while three other consumers also read type-inherited ones: `PropertiesPanel.tsx:855`, `sdk/adapters/query-adapter.ts:197`, and `lib/llm/context-builder.ts:132`.

So when a pset is attached to `IfcWallType` via `IfcRelDefinesByType` rather than to each wall, the user **sees** `IsExternal = true` in the panel, the SDK sees it, the LLM sees it — and the filter can't match it.

Confirmed with a fixture parsed through the **real** columnar parser (not a mock), with the pset attached only to the type: `evaluateFilterRules` matched 0 walls before, both after.

## Precedence: reused the canonical implementation

IFC says the occurrence wins when an instance and its type define the same property. Rather than write a second implementation of that rule — the duplicate-logic shape that keeps producing defects here — this reuses `mergeInheritedPropertySets` (`packages/parser/src/property-set-merge.ts`), the same function the IDS bridge uses (`packages/ids/src/bridge/properties.ts`, bugfix #1913).

RED-proven with colliding values: instance `Reference='INSTANCE-REF'` vs type `Reference='TYPE-REF'`. After the fix, `eq 'INSTANCE-REF'` matches only the wall with the override and `eq 'TYPE-REF'` matches only the wall without one — the overridden type value never leaks through.

## Performance: measured, not assumed

`filter-evaluate.ts` carries an explicit AGENTS.md §2 warning never to call `extractPropertiesOnDemand` in a large loop, and a filter runs over every entity — so a naive second extraction per entity would be a real regression. Type psets are cached **per type id**, not per instance (many instances share one type), keyed via an O(1) prebuilt edge-slice lookup (`relationship-graph.ts:211`).

Measured on `schependomlaan.ifc` (714,485 entities; 652 walls, 26 wall types), 3 runs each:

| scenario | before | after |
|---|---|---|
| prefiltered (`ifcType` AND property) | 43.6 / 36.4 / 40.8 ms | 44.6 / 37.8 / 37.3 ms |
| worst case: property rule alone over all 714K entities | 299 / 288 / 414 ms | 309 / 291 / 295 ms |

Noise-level. Note that fixture's psets are instance-level, so match counts were identical before and after — it measured pure **overhead**. Correctness was proven separately on the synthetic type-only fixture.

## A deliberate behaviour change, pinned

`isSet`/`isNotSet` semantics change once type psets are in scope: a property existing **only** on the type must now count as "set". That's correct — it's what the user is shown — but it *is* a change, so it has its own test and a comment at the merge site rather than sliding in unnoticed.

## RED proof

With the merge reverted to instance-only psets (exact substring replacement, count asserted `== 1`):

```
not ok 1 - matches a property that exists ONLY on the type
not ok 2 - PRECEDENCE: instance value wins over type value
not ok 5 - BOUNDING CONTROL (iii) — DELIBERATE BEHAVIOUR CHANGE: isSet now counts a type-only property as "set"
# pass 2  # fail 3
```

## Bounding controls (pass before *and* after — the 2 passing above)

An instance-level property still matches exactly as today, and an entity with **neither** an instance nor a type pset still doesn't match. Without those, "return everything" would satisfy the new tests.

## Displacement

`flattenPsets`/`matchPropertyRule`/`psetsFor` are used only inside `filter-evaluate.ts`/`filter-match.ts` — no other consumer touches them. `evaluateFilterRules`/`evaluateFilterRulesFederated` are called from `SearchModal.filter.tsx` (wants the fix) and `query-adapter.ts:337` `entitiesMatchingActiveFilter`, which backs CSV/scripted exports of the current filtered view and therefore wants it too, for consistency with what the panel shows. The SDK's separate `extractTypePropertiesOnDemand` call at `query-adapter.ts:197` is an unrelated per-entity accessor — untouched.

## Verification

`apps/viewer` search suite **156/156**. `tsc --noEmit` **exit 0**. No changeset — `apps/viewer` is `"private": true` and no published package source was modified; `mergeInheritedPropertySets` and `extractTypePropertiesOnDemand` were consumed as already-exported API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search filters now include properties inherited from an element’s type.
  * Instance-level property values take precedence over inherited type values.
  * Presence checks correctly recognize properties defined only on the element type.
  * Filtering continues to support instance-only properties and excludes entities without matching property sets.

* **Tests**
  * Added coverage for inherited properties, precedence rules, and updated presence-filter behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->