### PR TITLE
fix(viewer): the value dropdown offered "true" while the engine stores "True"

### DIFF
--- a/apps/viewer/src/lib/search/filter-evaluate.test.ts
+++ b/apps/viewer/src/lib/search/filter-evaluate.test.ts
@@ -202,7 +202,11 @@ describe('flattenPsets / matchPropertyRule', () => {
         ],
       },
     ]);
-    assert.deepStrictEqual(flat.map((r) => r.value), ['true', '0.24', 'EXT-A', '']);
+    // Boolean renders as "True" — matching the property table / list
+    // engine's display (`@ifc-lite/encoding`'s `parsePropertyValue`), not
+    // a bespoke lowercase convention. `valueOpMatches`'s eq/ne stay
+    // case-insensitive, so this doesn't change match outcomes.
+    assert.deepStrictEqual(flat.map((r) => r.value), ['True', '0.24', 'EXT-A', '']);
   });
 
   it('matches isSet / isNotSet by (set, prop) presence only', () => {

--- a/apps/viewer/src/lib/search/filter-match.test.ts
+++ b/apps/viewer/src/lib/search/filter-match.test.ts
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { parsePropertyValue } from '@ifc-lite/encoding';
+import { stringifyValue } from './filter-match.js';
+
+/**
+ * `discoverFilterValues` (filter-schema.ts) populates the List Builder /
+ * Search chip value dropdowns by stringifying sampled property values with
+ * `stringifyValue`. The property TABLE and the list engine's own display
+ * (`packages/lists/src/engine.ts` → `@ifc-lite/encoding`'s
+ * `parsePropertyValue`) both render an IFC boolean as "True"/"False".
+ *
+ * If discovery's stringification disagrees with the display/compare side,
+ * the dropdown offers a value ("true") the user never actually sees in the
+ * table ("True") — issue reported: user picks the dropdown value for
+ * Pset_WallCommon.IsExternal and the filter matches nothing.
+ */
+describe('stringifyValue — boolean rendering matches the display/compare side', () => {
+  it('renders a boolean the same way parsePropertyValue (the engine/table display) does', () => {
+    assert.strictEqual(stringifyValue(true), parsePropertyValue(true).displayValue);
+    assert.strictEqual(stringifyValue(false), parsePropertyValue(false).displayValue);
+  });
+
+  it('BOUNDING CONTROL: a plain string value (e.g. a FireRating) is unchanged', () => {
+    assert.strictEqual(stringifyValue('EI60'), 'EI60');
+  });
+
+  it('BOUNDING CONTROL: numeric values are unchanged', () => {
+    assert.strictEqual(stringifyValue(0.24), '0.24');
+    assert.strictEqual(stringifyValue(42), '42');
+  });
+
+  it('null/undefined still stringify to empty string', () => {
+    assert.strictEqual(stringifyValue(null), '');
+    assert.strictEqual(stringifyValue(undefined), '');
+  });
+});

--- a/apps/viewer/src/lib/search/filter-match.ts
+++ b/apps/viewer/src/lib/search/filter-match.ts
@@ -28,6 +28,7 @@ import {
   type ClassificationRule,
 } from './filter-rules.js';
 import { lensMaterialNames } from '../lens-material-names.js';
+import { parsePropertyValue } from '@ifc-lite/encoding';
 
 // ── Pset / Qto matching ──────────────────────────────────────────────────────
 
@@ -47,8 +48,13 @@ export function flattenPsets(
         setName: set.name,
         propertyName: p.name,
         // Stringify everything — `valueOpMatches` re-parses numeric ops
-        // from this representation. Booleans render as "true"/"false"
-        // which matches the chip UI's lowercased input convention.
+        // from this representation. Booleans render as "True"/"False" —
+        // the SAME capitalised display string the property table and the
+        // list engine (`@ifc-lite/encoding`'s `parsePropertyValue`) show —
+        // so a value picked from a chip/dropdown suggestion always matches
+        // what the user sees rendered elsewhere. `valueOpMatches`'s eq/ne
+        // are case-insensitive, so this doesn't change matching outcomes
+        // for either the search chips or free-typed "true"/"false".
         value: stringifyValue(p.value),
       });
     }
@@ -70,7 +76,11 @@ export function flattenQtys(
 
 export function stringifyValue(value: unknown): string {
   if (value === null || value === undefined) return '';
-  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  // Match `parsePropertyValue`'s boolean rendering ("True"/"False") — the
+  // SAME function the property table and the list engine's display use —
+  // so discovered dropdown suggestions equal what's actually shown/matched
+  // elsewhere (#IsExternal true/false mismatch report).
+  if (typeof value === 'boolean') return parsePropertyValue(value).displayValue;
   if (typeof value === 'number') return String(value);
   return String(value);
 }


### PR DESCRIPTION
Third and deepest layer of a user-reported bug. **The user didn't type the value** — they picked it from the list builder's dropdown, which offered lowercase `true`, and the filter matched nothing. The UI was offering a value that could never match.

For a property condition the options aren't hardcoded: `ListBuilder.tsx` (`discoverConditionValues`) calls `discoverFilterValues` (`lib/search/filter-schema.ts:273-323`), which renders each sampled value through `stringifyValue` (`filter-match.ts:71-76`). That function hand-rolled its own boolean rendering:

```ts
if (typeof value === 'boolean') return value ? 'true' : 'false';
```

Meanwhile the property **table** and the **list engine** render booleans through `parsePropertyValue` (`packages/encoding/src/property-value.ts:117-119`, used by `properties/PropertySetCard.tsx` and `lists/engine.ts:627`), which yields `"True"`/`"False"`.

Two code paths, same value, different answers — so the suggestion in the dropdown didn't equal the value the engine compares against, or the one shown in the table.

RED, before the fix:

```
expected: 'True'
actual:   'true'
```

## The fix: reuse, don't add a third spelling

`stringifyValue`'s boolean branch now calls `parsePropertyValue(value).displayValue` — the **same** function the table and the engine already use. `@ifc-lite/encoding` is already a workspace dependency and already used elsewhere in `apps/viewer/src` for exactly this. Adding a third hand-rolled stringification would have been the shape that caused the bug.

## One shared producer — so the search chips were affected too

`discoverFilterValues` feeds **both** the list builder and the search chip editor (`SearchModal.filter.editors.tsx:337`) from the same `FilterValueSchema.propertyValues`, so the search dropdown was offering the same unmatchable text.

That side's comparison (`valueOpMatches`, `filter-rules.ts:212-213`) already lowercases both operands, so **search match outcomes are unchanged** — only the suggested text improves. Worth stating precisely: this fixes what search *suggests*, not what it *matches*.

## Three-way measurement for the repaired assertion

One existing test pinned the old lowercase output (`filter-evaluate.test.ts`, *"stringifies booleans and numbers consistently"*), so it was measured rather than simply edited:

| | result |
|---|---|
| old expectation + **unfixed** code | PASSES — the shipped baseline |
| old expectation + **fixed** code | **FAILS** — `+ 'True'` / `- 'true'` |
| new expectation + fixed code | PASSES |

A genuine repair: the old expectation encoded the very mismatch being fixed.

## Bounding controls

The same assertion covers them, which is why only **one element of it moved**: a string (`'EXT-A'`), a number (`'0.24'`) and an empty value (`''`) are byte-identical before and after. That's what proves this didn't become a blanket transformation mangling ordinary values. Additional explicit cases in the new `filter-match.test.ts`: `'EI60'` → `'EI60'`, `0.24`/`42` unchanged.

## Verification

`apps/viewer` search suite **155/155**. Full app suite 3146 → 3150 tests, 3144 → 3148 pass, 0 fail, 2 skipped (unchanged). `tsc --noEmit` **exit 0**. No changeset — `apps/viewer` is `"private": true`; `packages/encoding` and `packages/lists` weren't modified.

## Related but separate, not touched here

- **#2373** makes the list engine's `equals` case-insensitive for boolean-like values — that fixes the *symptom*; this fixes the *cause*. Confirmed #2373 isn't on `main` yet and was neither duplicated nor reverted.
- **#2374** covers the search filter's type-inherited property sets.
- `result-export.ts:24` and `SearchModal.filter.tsx:634` each carry their own independent `boolean ? 'true' : 'false'`. They're outside the discovery chain traced here (CSV export and a different display path), so they're **flagged rather than folded in** — but they're two more copies of the same shape and deserve their own look.

## The grey badge in the user's screenshot: unexplained, not fixed

The report included a small grey pill reading `false` beside the `true` option. `ui/combo-input.tsx:138-157` — the component backing every value dropdown in the list builder, the search chips and `PropertyEditor` — renders each suggestion as a plain `<button>{o}</button>` with no badge, pill or secondary-value markup, and no consumer wraps options in one. Nothing in this repository was found that produces it.

Browser autofill chrome, or a deployed build ahead of this checkout, are plausible but **unverified** guesses — recorded as inference, not findings. Not addressed by this diff. If you recognise it, I'd rather be told than keep guessing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
