### PR TITLE
fix(renderer): paired GPU allocations leaked the first buffer on failure

### DIFF
--- a/.changeset/renderer-paired-buffer-leak.md
+++ b/.changeset/renderer-paired-buffer-leak.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/renderer": patch
+---
+
+Fix a GPU buffer leak on two paired-allocation paths where a throw on the second `createBuffer` orphaned the first, already-created buffer.
+
+`appendPointSubBuffer` (point cloud chunk upload) creates a `vertexBuffer` then a `deviationBuffer`; if the second allocation throws (e.g. out of memory — the exact scenario `appendChunkToNode` splits large uploads to survive), the `vertexBuffer` was created and written but never referenced again and never destroyed. `DeviationPipeline.uploadBvh` has the same shape with `nodeBuf` then `triBuf`. Both sites now destroy the first buffer before the error propagates.
+
+No change to the success path.

--- a/packages/renderer/src/deviation/deviation-pipeline.ts
+++ b/packages/renderer/src/deviation/deviation-pipeline.ts
@@ -130,10 +130,25 @@ export class DeviationPipeline {
       // size in elements (so we slice down to the populated head).
       bvh.nodes.subarray(0, bvh.nodeCount * BVH_NODE_BYTES / 4),
     );
-    const triBuf = this.device.createBuffer({
-      size: bvh.triangleCount * TRIANGLE_BYTES,
-      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
-    });
+    // Paired with `nodeBuf` above: if this throws (e.g. OOM), `nodeBuf` would
+    // otherwise be orphaned — created and written, but never assigned to
+    // `this.bvhNodesBuffer` and never destroyed. Free it before propagating.
+    let triBuf: GPUBuffer;
+    try {
+      triBuf = this.device.createBuffer({
+        size: bvh.triangleCount * TRIANGLE_BYTES,
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+      });
+    } catch (err) {
+      try {
+        nodeBuf.destroy();
+      } catch (destroyErr) {
+        // Non-fatal: surfaced rather than swallowed, per the no-silent-catch
+        // house rule — this firing would mean a real teardown bug.
+        console.warn('[DeviationPipeline] failed to release nodeBuf after a paired allocation failure', destroyErr);
+      }
+      throw err;
+    }
     this.device.queue.writeBuffer(
       triBuf, 0,
       bvh.triangles.subarray(0, bvh.triangleCount * TRIANGLE_BYTES / 4),

--- a/packages/renderer/src/paired-buffer-leak.test.ts
+++ b/packages/renderer/src/paired-buffer-leak.test.ts
@@ -1,0 +1,171 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { appendChunkToNode, createNode } from './pointcloud/point-cloud-node.js';
+import type { PointRenderPipeline } from './pointcloud/point-pipeline.js';
+import { DeviationPipeline } from './deviation/deviation-pipeline.js';
+import type { TriangleBVHResult } from './deviation/triangle-bvh.js';
+
+// WebGPU enum globals referenced by DeviationPipeline's constructor / buffer
+// usage flags (not defined in node) — same polyfill as point-cloud-transform.test.ts.
+(globalThis as Record<string, unknown>).GPUShaderStage = { VERTEX: 1, FRAGMENT: 2, COMPUTE: 4 };
+(globalThis as Record<string, unknown>).GPUBufferUsage = {
+  MAP_READ: 1, MAP_WRITE: 2, COPY_SRC: 4, COPY_DST: 8, INDEX: 16,
+  VERTEX: 32, UNIFORM: 64, STORAGE: 128, INDIRECT: 256, QUERY_RESOLVE: 512,
+};
+
+/**
+ * Two sites allocate a PAIR of GPU buffers with no cleanup if the SECOND
+ * `createBuffer` throws: `appendPointSubBuffer` (vertexBuffer then
+ * deviationBuffer) and `DeviationPipeline.uploadBvh` (nodeBuf then triBuf).
+ * A throw on the second buffer must not leak the first — it must be
+ * `.destroy()`d before the error propagates.
+ */
+
+function fakeBuffer(): GPUBuffer & { destroyed: number } {
+  const buf = {
+    size: 0,
+    destroyed: 0,
+    destroy() {
+      this.destroyed++;
+    },
+  };
+  return buf as unknown as GPUBuffer & { destroyed: number };
+}
+
+describe('appendChunkToNode: paired buffer leak (point-cloud-node.ts)', () => {
+  function makeDevice(opts: { failSecondCreate: boolean }) {
+    const created: Array<GPUBuffer & { destroyed: number }> = [];
+    let createCount = 0;
+    const device = {
+      limits: {
+        maxBufferSize: 256 * 1024 * 1024,
+        maxStorageBufferBindingSize: 128 * 1024 * 1024,
+        maxComputeWorkgroupsPerDimension: 65535,
+      },
+      queue: {
+        writeBuffer: () => {},
+      },
+      createBuffer: (_desc: unknown) => {
+        createCount++;
+        if (opts.failSecondCreate && createCount === 2) {
+          throw new Error('simulated OOM on second createBuffer');
+        }
+        const buf = fakeBuffer();
+        created.push(buf);
+        return buf as unknown as GPUBuffer;
+      },
+    } as unknown as GPUDevice;
+    return { device, created };
+  }
+
+  function makePipeline(): PointRenderPipeline {
+    return {
+      createUniformBuffer: () => fakeBuffer() as unknown as GPUBuffer,
+      createBindGroup: () => ({} as GPUBindGroup),
+    } as unknown as PointRenderPipeline;
+  }
+
+  function makeChunk() {
+    return {
+      positions: new Float32Array([0, 0, 0, 1, 1, 1]),
+      colors: undefined,
+      classifications: undefined,
+      intensities: undefined,
+      pointCount: 2,
+      bbox: { min: [0, 0, 0] as [number, number, number], max: [1, 1, 1] as [number, number, number] },
+    };
+  }
+
+  it('RED/GREEN: destroys the vertexBuffer when the deviationBuffer allocation throws', () => {
+    const { device, created } = makeDevice({ failSecondCreate: true });
+    const pipeline = makePipeline();
+    const node = createNode(device, pipeline, { expressId: 1 });
+
+    assert.throws(() => appendChunkToNode(device, node, makeChunk()));
+
+    assert.strictEqual(created.length, 1, 'only the vertexBuffer should have been created');
+    assert.strictEqual(created[0].destroyed, 1, 'the leaked vertexBuffer must be destroyed');
+    assert.strictEqual(node.chunks.length, 0, 'no chunk should be registered on failure');
+  });
+
+  it('BOUNDING CONTROL (success path): neither buffer is destroyed and the chunk is registered', () => {
+    const { device, created } = makeDevice({ failSecondCreate: false });
+    const pipeline = makePipeline();
+    const node = createNode(device, pipeline, { expressId: 1 });
+
+    appendChunkToNode(device, node, makeChunk());
+
+    assert.strictEqual(created.length, 2, 'both vertexBuffer and deviationBuffer created');
+    assert.strictEqual(created[0].destroyed, 0, 'vertexBuffer must survive the success path');
+    assert.strictEqual(created[1].destroyed, 0, 'deviationBuffer must survive the success path');
+    assert.strictEqual(node.chunks.length, 1, 'chunk must be registered on success');
+    assert.strictEqual(node.pointCount, 2);
+  });
+});
+
+describe('DeviationPipeline.uploadBvh: paired buffer leak (deviation-pipeline.ts)', () => {
+  function makeDevice(opts: { failSecondCreate: boolean }) {
+    const created: Array<GPUBuffer & { destroyed: number }> = [];
+    let bufferCreateCount = 0;
+    const device = {
+      createBindGroupLayout: () => ({} as GPUBindGroupLayout),
+      createPipelineLayout: () => ({} as GPUPipelineLayout),
+      createShaderModule: () => ({} as GPUShaderModule),
+      createComputePipeline: () => ({} as GPUComputePipeline),
+      queue: {
+        writeBuffer: () => {},
+      },
+      createBuffer: (_desc: unknown) => {
+        bufferCreateCount++;
+        if (opts.failSecondCreate && bufferCreateCount === 2) {
+          throw new Error('simulated OOM on second createBuffer (triBuf)');
+        }
+        const buf = fakeBuffer();
+        created.push(buf);
+        return buf as unknown as GPUBuffer;
+      },
+    } as unknown as GPUDevice;
+    return { device, created };
+  }
+
+  function makeBvh(): TriangleBVHResult {
+    return {
+      nodes: new Float32Array(8),
+      triangles: new Float32Array(12),
+      triangleCount: 1,
+      nodeCount: 1,
+      meshCount: 1,
+      bounds: { min: [0, 0, 0], max: [1, 1, 1] },
+    };
+  }
+
+  it('RED/GREEN: destroys nodeBuf when the triBuf allocation throws', () => {
+    const { device, created } = makeDevice({ failSecondCreate: true });
+    const pipeline = new DeviationPipeline(device);
+
+    assert.throws(() => pipeline.uploadBvh(makeBvh()));
+
+    assert.strictEqual(created.length, 1, 'only nodeBuf should have been created');
+    assert.strictEqual(created[0].destroyed, 1, 'the leaked nodeBuf must be destroyed');
+    assert.strictEqual(pipeline.hasBvh(), false, 'no BVH should be considered uploaded on failure');
+  });
+
+  it('BOUNDING CONTROL (success path): neither buffer is destroyed and the BVH is registered', () => {
+    const { device, created } = makeDevice({ failSecondCreate: false });
+    const pipeline = new DeviationPipeline(device);
+
+    pipeline.uploadBvh(makeBvh());
+
+    assert.strictEqual(created.length, 2, 'both nodeBuf and triBuf created');
+    assert.strictEqual(created[0].destroyed, 0, 'nodeBuf must survive the success path');
+    assert.strictEqual(created[1].destroyed, 0, 'triBuf must survive the success path');
+    assert.strictEqual(pipeline.hasBvh(), true, 'BVH must be considered uploaded on success');
+    const stats = pipeline.getBvhStats();
+    assert.strictEqual(stats.triangleCount, 1);
+    assert.strictEqual(stats.nodeCount, 1);
+  });
+});

--- a/packages/renderer/src/pointcloud/point-cloud-node.ts
+++ b/packages/renderer/src/pointcloud/point-cloud-node.ts
@@ -276,10 +276,28 @@ function appendPointSubBuffer(
   // Pre-allocate the per-point deviation buffer (zero-initialised).
   // Bound as a vertex attribute by the splat pipeline AND as a
   // storage buffer by the deviation compute pass.
-  const deviationBuffer = device.createBuffer({
-    size: count * 4,
-    usage: GPUBufferUsage.VERTEX | GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
-  });
+  //
+  // This allocation is paired with `vertexBuffer` above: if it throws
+  // (e.g. OOM — the whole reason this upload is split into sub-buffers
+  // in the first place, see appendChunkToNode), `vertexBuffer` would
+  // otherwise be orphaned — created and written, but never referenced
+  // again and never destroyed. Free it before propagating the error.
+  let deviationBuffer: GPUBuffer;
+  try {
+    deviationBuffer = device.createBuffer({
+      size: count * 4,
+      usage: GPUBufferUsage.VERTEX | GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+    });
+  } catch (err) {
+    try {
+      vertexBuffer.destroy();
+    } catch (destroyErr) {
+      // Non-fatal: surfaced rather than swallowed, per the no-silent-catch
+      // house rule — this firing would mean a real teardown bug.
+      console.warn('[PointCloud] failed to release vertexBuffer after a paired allocation failure', destroyErr);
+    }
+    throw err;
+  }
   // Zero-init explicitly — WebGPU spec doesn't promise zeroed buffers
   // and some implementations skip the initial clear when STORAGE is set.
   device.queue.writeBuffer(deviationBuffer, 0, new Float32Array(count));


### PR DESCRIPTION
fix(renderer): paired GPU allocations leaked the first buffer on failure

Found by auditing `packages/renderer`, previously unaudited.

Two sites allocate a PAIR of GPU buffers with no cleanup if the SECOND
throws, leaking the first:

- `pointcloud/point-cloud-node.ts` `appendPointSubBuffer`: `vertexBuffer`
  is created and written, then `deviationBuffer` is created with no
  try/catch. On a throw the function exits before `node.chunks.push(...)`,
  so `vertexBuffer` is never referenced again and never destroyed.
- `deviation/deviation-pipeline.ts` `uploadBvh`: identical shape --
  `nodeBuf` leaks if `triBuf` throws. `disposeBvh()` exists and does the
  right cleanup, but is never reached on that path.

Plausible rather than theoretical: `appendChunkToNode` exists SPECIFICALLY
to split point-cloud uploads so one oversized `createBuffer` cannot fail.
A smaller sub-buffer failing (OOM, device lost mid-load) is exactly the
scenario this code was written to survive -- it just did not survive it
cleanly.

BLOCKING QUESTION: DOES createBuffer EVEN THROW?
------------------------------------------------
A try/catch is only right if allocation failure is synchronous. In
WebGPU an OOM `createBuffer` can instead return an INVALID buffer with
the error surfacing via `popErrorScope`, in which case a try/catch would
catch nothing and be pure cargo cult. Checked before writing it:

- `scene.ts:1936-1939`: "If a createBuffer fails part-way through,
  callers that CONTAIN the throw to keep the canvas alive..." -- a
  `try/finally` exists for exactly this.
- `index.ts:3480-3491`: a lost device used to hand out a zombie
  `GPUDevice`, and "every caller then called `createBuffer()` on it,
  which throws."
- Error scopes ARE used (`pipeline.ts:741-753`, `index.ts:1169-1186`),
  but for async VALIDATION diagnostics on submitted work -- a different
  failure class, not a competing mechanism for this one. So no sibling
  asymmetry between the two.

try/catch is the established idiom here. `.destroy()` itself is wrapped
and warned rather than swallowed, following `picker.ts:72-88`
(`releaseReadbacks`), since destroy can throw when the device is already
gone.

RED PROOF
---------
With the catch-block cleanup neutralised (exact substring replacement,
count asserted == 1):

  not ok 1 - RED/GREEN: destroys the vertexBuffer when the
             deviationBuffer allocation throws
      0 !== 1

The test asserts `destroy()` was actually CALLED on the first buffer, not
merely that the function threw.

BOUNDING CONTROL (passes before AND after)
------------------------------------------
The SUCCESS path must NOT destroy either buffer, and must still register
the chunk / BVH. This is the control that matters most here: an
over-eager cleanup freeing a live buffer would be far worse than the leak
being fixed. It passes in the RED run above, confirming it is a genuine
control rather than a test needing the fix.

DISPLACEMENT
------------
Checked for double-destroy: neither caller
(`point-cloud-renderer.ts:233`, `index.ts:722`) wraps these in try/catch
or does any cleanup of its own -- both let the throw propagate. So the
new cleanup cannot race an existing one.

VERIFICATION
------------
`packages/renderer` 457/457 (was 453; +4). `tsc --noEmit` exit 0.
Changeset added -- `packages/renderer` has no `"private"` field, so it is
published.

NOT FIXED HERE, from the same audit:
- `CameraAnimator.animateTo`/`animateToWithUp` share one set of animation
  fields, so two overlapping calls resolve together on the second's
  completion. STRUCTURAL and currently dormant -- no caller awaits the
  promise today -- but a trap for the next one that does.
- The section-plane bounds recompute (`index.ts:1665,1679`) checks
  `Number.isFinite(minX)` ONLY, not y/z or any max. Note `Infinity`
  SURVIVES `mergeGeometry`'s min/max comparisons where NaN does not
  (confirmed by direct invocation), so an Infinity in an unchecked axis
  would reach `camera.setSceneBounds`. No concrete producer of Infinity
  positions was traced, so it is reported rather than ranked.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GPU resource leaks when paired buffer allocation fails during point-cloud and BVH uploads.
  * Preserved the original allocation error while safely cleaning up partially created resources.
  * Prevented incomplete upload state from being committed after allocation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->