### PR TITLE
style(export): run cargo fmt over the crate

### DIFF
--- a/rust/export/examples/dump_hbjson.rs
+++ b/rust/export/examples/dump_hbjson.rs
@@ -8,8 +8,13 @@ fn main() {
     };
     let bytes = std::fs::read(path).expect("read ifc");
     let name = args.get(2).cloned().unwrap_or_else(|| "model".to_string());
-    let (json, stats) =
-        ifc_lite_export::export_hbjson_with_stats(&bytes, &ifc_lite_export::HbjsonOptions { name, tolerance: 0.01 });
+    let (json, stats) = ifc_lite_export::export_hbjson_with_stats(
+        &bytes,
+        &ifc_lite_export::HbjsonOptions {
+            name,
+            tolerance: 0.01,
+        },
+    );
     eprintln!(
         "IfcSpace: {} | rooms: {} | skipped: {} | windows: {} | doors: {} | shades: {} | constructions: {} | interior-adj: {}",
         stats.spaces, stats.rooms, stats.skipped, stats.apertures, stats.doors, stats.shades, stats.constructions, stats.interior_adjacencies

--- a/rust/export/examples/glb_export_profile.rs
+++ b/rust/export/examples/glb_export_profile.rs
@@ -39,13 +39,10 @@ fn main() {
     let mut top_n = 15usize;
     while let Some(a) = args.next() {
         if a == "--top" {
-            top_n = args
-                .next()
-                .and_then(|v| v.parse().ok())
-                .unwrap_or_else(|| {
-                    eprintln!("--top expects a positive integer");
-                    std::process::exit(2);
-                });
+            top_n = args.next().and_then(|v| v.parse().ok()).unwrap_or_else(|| {
+                eprintln!("--top expects a positive integer");
+                std::process::exit(2);
+            });
         } else {
             eprintln!("unknown argument: {a}\nusage: glb_export_profile <file.ifc> [--top N]");
             std::process::exit(2);
@@ -68,7 +65,10 @@ fn main() {
         eprintln!("read {path}: {e}");
         std::process::exit(2);
     });
-    println!("file: {path} ({:.1} MB)", content.len() as f64 / 1.048_576e6);
+    println!(
+        "file: {path} ({:.1} MB)",
+        content.len() as f64 / 1.048_576e6
+    );
 
     // Phase 1: entity index (the scan).
     let t = Instant::now();
@@ -136,7 +136,12 @@ fn main() {
     let t_export = t.elapsed();
     let assemble = t_export
         .checked_sub(t_index + t_mesh)
-        .map(|d| format!("{:.1} ms (approx: export - index - mesh)", d.as_secs_f64() * 1e3))
+        .map(|d| {
+            format!(
+                "{:.1} ms (approx: export - index - mesh)",
+                d.as_secs_f64() * 1e3
+            )
+        })
         .unwrap_or_else(|| "n/a (export ran faster than the separate phases)".to_string());
     println!(
         "\nexport:  {:>9.1} ms  ({} bytes GLB; {} meshes, {} tris after dedup/instancing)",

--- a/rust/export/src/adjacency.rs
+++ b/rust/export/src/adjacency.rs
@@ -10,8 +10,8 @@
 //! geometry change. Only full-wall (equal-area, aligned) pairs are matched; partial overlaps
 //! are left exterior (they would need face splitting).
 
-use crate::hbjson::Room;
 use crate::geom::{center, dot, newell_normal, polygon_area};
+use crate::hbjson::Room;
 
 /// Max plane separation to treat as a shared wall (a generous wall thickness), metres.
 const MAX_GAP: f64 = 0.6;
@@ -21,7 +21,9 @@ const MAX_LATERAL: f64 = 0.15;
 /// rarely produce perfectly congruent faces), so only near-congruent walls are paired.
 const MAX_AREA_DIFF: f64 = 0.01;
 
-fn sub(a: [f64; 3], b: [f64; 3]) -> [f64; 3] { [a[0] - b[0], a[1] - b[1], a[2] - b[2]] }
+fn sub(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
+    [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
+}
 fn dist(a: [f64; 3], b: [f64; 3]) -> f64 {
     let d = sub(a, b);
     (d[0] * d[0] + d[1] * d[1] + d[2] * d[2]).sqrt()
@@ -86,7 +88,11 @@ pub fn solve_adjacency(rooms: &mut [Room]) -> usize {
             }
             // b's centroid projected onto a's plane must sit on top of a's centroid.
             let off = dot(sub(b.c, a.c), a.n);
-            let b_proj = [b.c[0] - a.n[0] * off, b.c[1] - a.n[1] * off, b.c[2] - a.n[2] * off];
+            let b_proj = [
+                b.c[0] - a.n[0] * off,
+                b.c[1] - a.n[1] * off,
+                b.c[2] - a.n[2] * off,
+            ];
             let lateral = dist(a.c, b_proj);
             if lateral > MAX_LATERAL {
                 continue;
@@ -162,7 +168,10 @@ mod tests {
     fn solve_adjacency_pairs_faces_with_correct_face_then_room_order() {
         let mut rooms = facing_rooms();
         let created = solve_adjacency(&mut rooms);
-        assert_eq!(created, 2, "expected exactly one matched pair (2 interior faces)");
+        assert_eq!(
+            created, 2,
+            "expected exactly one matched pair (2 interior faces)"
+        );
 
         let bc_a = &rooms[0].faces[0].boundary_condition;
         let bc_b = &rooms[1].faces[0].boundary_condition;
@@ -171,11 +180,23 @@ mod tests {
 
         // Room A's face must reference [FaceB, RoomB] — face id first, room id second —
         // and NOT its own room.
-        let objs_a = bc_a.boundary_condition_objects.as_ref().expect("room A objects");
-        assert_eq!(objs_a.as_slice(), ["FaceB".to_string(), "RoomB".to_string()].as_slice());
+        let objs_a = bc_a
+            .boundary_condition_objects
+            .as_ref()
+            .expect("room A objects");
+        assert_eq!(
+            objs_a.as_slice(),
+            ["FaceB".to_string(), "RoomB".to_string()].as_slice()
+        );
 
         // Room B's face must reference [FaceA, RoomA], the mirror image.
-        let objs_b = bc_b.boundary_condition_objects.as_ref().expect("room B objects");
-        assert_eq!(objs_b.as_slice(), ["FaceA".to_string(), "RoomA".to_string()].as_slice());
+        let objs_b = bc_b
+            .boundary_condition_objects
+            .as_ref()
+            .expect("room B objects");
+        assert_eq!(
+            objs_b.as_slice(),
+            ["FaceA".to_string(), "RoomA".to_string()].as_slice()
+        );
     }
 }

--- a/rust/export/src/collada.rs
+++ b/rust/export/src/collada.rs
@@ -156,7 +156,11 @@ pub fn export_collada_from_meshes(
         let tri_len = islice.len() - islice.len() % 3;
         for tri in islice[..tri_len].chunks_exact(3) {
             if tri.iter().all(|&idx| (idx as usize) < vc) {
-                let (a, b, c) = (l2g[tri[0] as usize], l2g[tri[1] as usize], l2g[tri[2] as usize]);
+                let (a, b, c) = (
+                    l2g[tri[0] as usize],
+                    l2g[tri[1] as usize],
+                    l2g[tri[2] as usize],
+                );
                 if a != b && b != c && a != c {
                     mat_tris[mi].extend_from_slice(&[a, b, c]);
                 }
@@ -208,12 +212,7 @@ pub fn export_collada_from_meshes(
 /// emitted as one array fails to parse and renders nothing — the "model loads but is
 /// invisible" failure on large models (#1427). Each chunk is self-contained (its own
 /// POSITION/NORMAL sources, re-indexed chunk-local) so no triangle spans a chunk.
-fn write_dae(
-    pos: &[f32],
-    nrm: &[f32],
-    mat_colors: &[[f32; 4]],
-    mat_tris: &[Vec<u32>],
-) -> Vec<u8> {
+fn write_dae(pos: &[f32], nrm: &[f32], mat_colors: &[[f32; 4]], mat_tris: &[Vec<u32>]) -> Vec<u8> {
     // Two independent caps per chunk, both of which Google Earth enforces and which a
     // strict XML parser also implies:
     //  - MAX_VERTS: keeps a geometry under Google Earth's ~64K-vertex-per-model limit
@@ -231,7 +230,11 @@ fn write_dae(
     }
 
     let mut chunks: Vec<Chunk> = Vec::new();
-    let mut cur = Chunk { pos: Vec::new(), nrm: Vec::new(), tris: vec![Vec::new(); mat_colors.len()] };
+    let mut cur = Chunk {
+        pos: Vec::new(),
+        nrm: Vec::new(),
+        tris: vec![Vec::new(); mat_colors.len()],
+    };
     let mut cur_tris = 0usize;
     let mut remap: HashMap<u32, u32> = HashMap::new();
     for (m, tris) in mat_tris.iter().enumerate() {
@@ -242,7 +245,11 @@ fn write_dae(
             {
                 chunks.push(std::mem::replace(
                     &mut cur,
-                    Chunk { pos: Vec::new(), nrm: Vec::new(), tris: vec![Vec::new(); mat_colors.len()] },
+                    Chunk {
+                        pos: Vec::new(),
+                        nrm: Vec::new(),
+                        tris: vec![Vec::new(); mat_colors.len()],
+                    },
                 ));
                 cur_tris = 0;
                 remap.clear();
@@ -273,7 +280,8 @@ fn write_dae(
 
     // `<created>`/`<modified>` are REQUIRED by the COLLADA 1.4.1 schema; a fixed
     // epoch keeps the document deterministic and wasm-safe (no wall clock).
-    s.push_str(r#"<?xml version="1.0" encoding="UTF-8"?>
+    s.push_str(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
 <COLLADA xmlns="http://www.collada.org/2005/11/COLLADASchema" version="1.4.1">
   <asset>
     <contributor><authoring_tool>IFC-Lite</authoring_tool></contributor>
@@ -282,7 +290,8 @@ fn write_dae(
     <unit name="meter" meter="1"/>
     <up_axis>Z_UP</up_axis>
   </asset>
-"#);
+"#,
+    );
 
     // ── Effects: emission = colour (Google Earth glow) + double_sided ───────────
     s.push_str("  <library_effects>\n");
@@ -346,7 +355,10 @@ fn write_dae(
     s.push_str("  <library_geometries>\n");
     for (ci, ch) in chunks.iter().enumerate() {
         let vc = ch.pos.len() / 3;
-        let _ = write!(s, "    <geometry id=\"geo{ci}\" name=\"geo{ci}\">\n      <mesh>\n");
+        let _ = write!(
+            s,
+            "    <geometry id=\"geo{ci}\" name=\"geo{ci}\">\n      <mesh>\n"
+        );
         // POSITION source.
         let _ = write!(s, "        <source id=\"geo{ci}-pos\">\n          <float_array id=\"geo{ci}-pos-arr\" count=\"{}\">", ch.pos.len());
         append_floats(&mut s, &ch.pos);
@@ -384,7 +396,10 @@ fn write_dae(
             if t.is_empty() {
                 continue;
             }
-            let _ = writeln!(s, "              <instance_material symbol=\"sym{k}\" target=\"#mat{k}\"/>");
+            let _ = writeln!(
+                s,
+                "              <instance_material symbol=\"sym{k}\" target=\"#mat{k}\"/>"
+            );
         }
         s.push_str("            </technique_common>\n          </bind_material>\n        </instance_geometry>\n      </node>\n");
     }
@@ -430,14 +445,32 @@ mod tests {
     use super::*;
 
     /// `(positions, normals, indices, vertex_counts, index_counts, colors, origins)`.
-    type MeshArrays = (Vec<f32>, Vec<f32>, Vec<u32>, Vec<u32>, Vec<u32>, Vec<f32>, Vec<f64>);
+    type MeshArrays = (
+        Vec<f32>,
+        Vec<f32>,
+        Vec<u32>,
+        Vec<u32>,
+        Vec<u32>,
+        Vec<f32>,
+        Vec<f64>,
+    );
 
     fn one_quad() -> MeshArrays {
         // A unit quad in the XY plane (Y-up input), single red mesh.
         let positions = vec![0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0, 0.0, 1.0];
-        let normals: Vec<f32> = std::iter::repeat_n([0.0f32, 1.0, 0.0], 4).flatten().collect();
+        let normals: Vec<f32> = std::iter::repeat_n([0.0f32, 1.0, 0.0], 4)
+            .flatten()
+            .collect();
         let indices = vec![0u32, 1, 2, 0, 2, 3];
-        (positions, normals, indices, vec![4], vec![6], vec![1.0, 0.0, 0.0, 1.0], vec![0.0, 0.0, 0.0])
+        (
+            positions,
+            normals,
+            indices,
+            vec![4],
+            vec![6],
+            vec![1.0, 0.0, 0.0, 1.0],
+            vec![0.0, 0.0, 0.0],
+        )
     }
 
     #[test]
@@ -457,7 +490,8 @@ mod tests {
     #[test]
     fn emission_carries_colour_and_double_sided() {
         let (p, n, i, vc, ic, col, og) = one_quad();
-        let xml = String::from_utf8(export_collada_from_meshes(&p, &n, &i, &vc, &ic, &col, &og)).unwrap();
+        let xml =
+            String::from_utf8(export_collada_from_meshes(&p, &n, &i, &vc, &ic, &col, &og)).unwrap();
         // Red emission = brightness lever for Google Earth.
         assert!(xml.contains("<emission><color>1 0 0 1</color></emission>"));
         assert!(xml.contains("<double_sided>1</double_sided>"));
@@ -473,7 +507,11 @@ mod tests {
             let tag_end = s.find('>').unwrap();
             let close = s.find("</float_array>").unwrap();
             if s[..tag_end].contains("-pos-arr") {
-                out.extend(s[tag_end + 1..close].split_whitespace().map(|t| t.parse::<f32>().unwrap()));
+                out.extend(
+                    s[tag_end + 1..close]
+                        .split_whitespace()
+                        .map(|t| t.parse::<f32>().unwrap()),
+                );
             }
             rest = &s[close + "</float_array>".len()..];
         }
@@ -511,15 +549,29 @@ mod tests {
         // Y-up input vertex (0,1,0) ("up") must land at Z-up Z=1 (up preserved), and the
         // geometry is centred on its horizontal AABB so the .dae origin == geometry centre.
         let positions = vec![0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0];
-        let normals: Vec<f32> = std::iter::repeat_n([0.0f32, 0.0, 1.0], 3).flatten().collect();
+        let normals: Vec<f32> = std::iter::repeat_n([0.0f32, 0.0, 1.0], 3)
+            .flatten()
+            .collect();
         let xml = String::from_utf8(export_collada_from_meshes(
-            &positions, &normals, &[0, 1, 2], &[3], &[3], &[0.5, 0.5, 0.5, 1.0], &[0.0, 0.0, 0.0],
+            &positions,
+            &normals,
+            &[0, 1, 2],
+            &[3],
+            &[3],
+            &[0.5, 0.5, 0.5, 1.0],
+            &[0.0, 0.0, 0.0],
         ))
         .unwrap();
         let verts = parse_positions(&xml);
-        assert!(verts.iter().any(|v| (v[2] - 1.0).abs() < 1e-4), "Y-up (0,1,0) -> Z-up Z=1");
+        assert!(
+            verts.iter().any(|v| (v[2] - 1.0).abs() < 1e-4),
+            "Y-up (0,1,0) -> Z-up Z=1"
+        );
         let (cx, cy) = hbounds(&verts);
-        assert!(cx.abs() < 1e-4 && cy.abs() < 1e-4, "geometry centred: ({cx}, {cy})");
+        assert!(
+            cx.abs() < 1e-4 && cy.abs() < 1e-4,
+            "geometry centred: ({cx}, {cy})"
+        );
     }
 
     #[test]
@@ -530,14 +582,28 @@ mod tests {
         let positions = vec![
             100.0, 0.0, 200.0, 110.0, 0.0, 200.0, 110.0, 0.0, 220.0, 100.0, 0.0, 220.0,
         ];
-        let normals: Vec<f32> = std::iter::repeat_n([0.0f32, 1.0, 0.0], 4).flatten().collect();
+        let normals: Vec<f32> = std::iter::repeat_n([0.0f32, 1.0, 0.0], 4)
+            .flatten()
+            .collect();
         let xml = String::from_utf8(export_collada_from_meshes(
-            &positions, &normals, &[0, 1, 2, 0, 2, 3], &[4], &[6], &[0.6, 0.6, 0.6, 1.0], &[0.0, 0.0, 0.0],
+            &positions,
+            &normals,
+            &[0, 1, 2, 0, 2, 3],
+            &[4],
+            &[6],
+            &[0.6, 0.6, 0.6, 1.0],
+            &[0.0, 0.0, 0.0],
         ))
         .unwrap();
         let (cx, cy) = hbounds(&parse_positions(&xml));
-        assert!(cx.abs() < 1e-3, "X re-centred to ~0 (geometry was ~105 from origin): {cx}");
-        assert!(cy.abs() < 1e-3, "Y re-centred to ~0 (geometry was ~210 from origin): {cy}");
+        assert!(
+            cx.abs() < 1e-3,
+            "X re-centred to ~0 (geometry was ~105 from origin): {cx}"
+        );
+        assert!(
+            cy.abs() < 1e-3,
+            "Y re-centred to ~0 (geometry was ~210 from origin): {cy}"
+        );
     }
 
     #[test]
@@ -546,18 +612,35 @@ mod tests {
         // collapses to 4 unique — a and c are shared with identical position+normal.
         // This is the lever that shrinks per-face IFC meshes under Google Earth's
         // vertex/triangle limits (#1427).
-        let (a, b, c, d) = ([0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 0.0, 1.0], [0.0, 0.0, 1.0]);
+        let (a, b, c, d) = (
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [1.0, 0.0, 1.0],
+            [0.0, 0.0, 1.0],
+        );
         let mut positions = vec![];
         for v in [a, b, c, a, c, d] {
             positions.extend_from_slice(&v);
         }
-        let normals: Vec<f32> = std::iter::repeat_n([0.0f32, 1.0, 0.0], 6).flatten().collect();
+        let normals: Vec<f32> = std::iter::repeat_n([0.0f32, 1.0, 0.0], 6)
+            .flatten()
+            .collect();
         let indices: Vec<u32> = (0..6).collect();
         let xml = String::from_utf8(export_collada_from_meshes(
-            &positions, &normals, &indices, &[6], &[6], &[0.5, 0.5, 0.5, 1.0], &[0.0, 0.0, 0.0],
+            &positions,
+            &normals,
+            &indices,
+            &[6],
+            &[6],
+            &[0.5, 0.5, 0.5, 1.0],
+            &[0.0, 0.0, 0.0],
         ))
         .unwrap();
-        assert_eq!(parse_positions(&xml).len(), 4, "6 input verts dedupe to 4 unique");
+        assert_eq!(
+            parse_positions(&xml).len(),
+            4,
+            "6 input verts dedupe to 4 unique"
+        );
     }
 
     #[test]
@@ -578,13 +661,25 @@ mod tests {
             indices.push(i as u32);
         }
         let xml = String::from_utf8(export_collada_from_meshes(
-            &positions, &normals, &indices, &[vcount as u32], &[vcount as u32],
-            &[0.5, 0.5, 0.5, 1.0], &[0.0, 0.0, 0.0],
+            &positions,
+            &normals,
+            &indices,
+            &[vcount as u32],
+            &[vcount as u32],
+            &[0.5, 0.5, 0.5, 1.0],
+            &[0.0, 0.0, 0.0],
         ))
         .unwrap();
-        assert!(xml.matches("<geometry ").count() >= 2, "geometry split into ≥2 chunks");
+        assert!(
+            xml.matches("<geometry ").count() >= 2,
+            "geometry split into ≥2 chunks"
+        );
         // All vertices survive the split (75k in, 75k out across chunks).
-        assert_eq!(parse_positions(&xml).len(), vcount, "no vertices dropped by chunking");
+        assert_eq!(
+            parse_positions(&xml).len(),
+            vcount,
+            "no vertices dropped by chunking"
+        );
         assert!(
             max_float_array_bytes(&xml) < 5_000_000,
             "largest float_array stays small: {} bytes",
@@ -596,37 +691,64 @@ mod tests {
             .map(|(i, _)| {
                 let tag = &xml[i..i + xml[i..].find('>').unwrap()];
                 let c = tag.find("count=\"").unwrap() + 7;
-                tag[c..tag[c..].find('"').unwrap() + c].parse::<usize>().unwrap()
+                tag[c..tag[c..].find('"').unwrap() + c]
+                    .parse::<usize>()
+                    .unwrap()
             })
             .max()
             .unwrap();
-        assert!(max_tri <= 21_845, "no <triangles> over the 16-bit ceiling: {max_tri}");
+        assert!(
+            max_tri <= 21_845,
+            "no <triangles> over the 16-bit ceiling: {max_tri}"
+        );
     }
 
     #[test]
     fn triangles_count_matches_index_list_on_ragged_input() {
         // A malformed index count (not a multiple of 3) must not desync the emitted
         // <triangles count> from the <p> list — keep only whole triangles.
-        let positions = vec![0.0f32, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.5, 0.0, 0.5];
-        let normals: Vec<f32> = std::iter::repeat_n([0.0f32, 1.0, 0.0], 4).flatten().collect();
+        let positions = vec![
+            0.0f32, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.5, 0.0, 0.5,
+        ];
+        let normals: Vec<f32> = std::iter::repeat_n([0.0f32, 1.0, 0.0], 4)
+            .flatten()
+            .collect();
         let indices = vec![0u32, 1, 2, 0, 2]; // 5 indices = one whole triangle + a stray pair
         let xml = String::from_utf8(export_collada_from_meshes(
-            &positions, &normals, &indices, &[4], &[5], &[0.3, 0.3, 0.3, 1.0], &[0.0, 0.0, 0.0],
+            &positions,
+            &normals,
+            &indices,
+            &[4],
+            &[5],
+            &[0.3, 0.3, 0.3, 1.0],
+            &[0.0, 0.0, 0.0],
         ))
         .unwrap();
         // Exactly one triangle survives; its <p> holds 3 vertex+normal index pairs (6 ints).
         assert!(xml.contains("<triangles material=\"sym0\" count=\"1\">"));
         let p_start = xml.find("<p>").unwrap() + 3;
         let p = &xml[p_start..xml[p_start..].find("</p>").unwrap() + p_start];
-        assert_eq!(p.split_whitespace().count(), 6, "one triangle = 3 pairs = 6 indices: {p}");
+        assert_eq!(
+            p.split_whitespace().count(),
+            6,
+            "one triangle = 3 pairs = 6 indices: {p}"
+        );
     }
 
     #[test]
     fn translucent_material_emits_transparency() {
         let positions = vec![0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 1.0];
-        let normals: Vec<f32> = std::iter::repeat_n([0.0f32, 1.0, 0.0], 3).flatten().collect();
+        let normals: Vec<f32> = std::iter::repeat_n([0.0f32, 1.0, 0.0], 3)
+            .flatten()
+            .collect();
         let xml = String::from_utf8(export_collada_from_meshes(
-            &positions, &normals, &[0, 1, 2], &[3], &[3], &[0.0, 1.0, 0.0, 0.5], &[0.0, 0.0, 0.0],
+            &positions,
+            &normals,
+            &[0, 1, 2],
+            &[3],
+            &[3],
+            &[0.0, 1.0, 0.0, 0.5],
+            &[0.0, 0.0, 0.0],
         ))
         .unwrap();
         assert!(xml.contains("<transparency>"));

--- a/rust/export/src/constructions.rs
+++ b/rust/export/src/constructions.rs
@@ -17,13 +17,23 @@ use crate::hbjson::{EnergyMaterial, ModelEnergy, OpaqueConstruction};
 /// Default (conductivity W/mK, density kg/m³, specific heat J/kgK) by material-name keyword.
 fn thermal_props(name: &str) -> (f64, f64, f64) {
     let n = name.to_lowercase();
-    if n.contains("insul") || n.contains("mineral") || n.contains("wool") || n.contains("eps") || n.contains("xps") || n.contains("polystyr") {
+    if n.contains("insul")
+        || n.contains("mineral")
+        || n.contains("wool")
+        || n.contains("eps")
+        || n.contains("xps")
+        || n.contains("polystyr")
+    {
         (0.035, 30.0, 1200.0)
     } else if n.contains("concrete") {
         (2.3, 2300.0, 900.0)
     } else if n.contains("brick") || n.contains("masonry") || n.contains("block") {
         (0.7, 1900.0, 800.0)
-    } else if n.contains("gypsum") || n.contains("plaster") || n.contains("board") || n.contains("drywall") {
+    } else if n.contains("gypsum")
+        || n.contains("plaster")
+        || n.contains("board")
+        || n.contains("drywall")
+    {
         (0.25, 900.0, 1000.0)
     } else if n.contains("timber") || n.contains("wood") || n.contains("plywood") {
         (0.14, 500.0, 1600.0)
@@ -41,8 +51,15 @@ fn thermal_props(name: &str) -> (f64, f64, f64) {
 }
 
 fn sanitize(s: &str) -> String {
-    let out: String = s.chars().map(|c| if c.is_alphanumeric() { c } else { '_' }).collect();
-    if out.is_empty() { "Material".to_string() } else { out }
+    let out: String = s
+        .chars()
+        .map(|c| if c.is_alphanumeric() { c } else { '_' })
+        .collect();
+    if out.is_empty() {
+        "Material".to_string()
+    } else {
+        out
+    }
 }
 
 /// Map every `IfcMaterial` entity id to its Name (attr 0).
@@ -74,7 +91,12 @@ pub struct Constructions {
 
 impl Constructions {
     fn none() -> Self {
-        Self { energy: None, wall: None, floor: None, roof: None }
+        Self {
+            energy: None,
+            wall: None,
+            floor: None,
+            roof: None,
+        }
     }
 }
 
@@ -97,11 +119,24 @@ fn build_one(
     }
     let mut refs = Vec::new();
     for (mid, thickness) in layers {
-        let name = names.get(mid).cloned().unwrap_or_else(|| format!("Material{}", mid));
-        let ident = format!("{}_{}mm", sanitize(&name), (thickness * 1000.0).round() as i64);
+        let name = names
+            .get(mid)
+            .cloned()
+            .unwrap_or_else(|| format!("Material{}", mid));
+        let ident = format!(
+            "{}_{}mm",
+            sanitize(&name),
+            (thickness * 1000.0).round() as i64
+        );
         if seen_mat.insert(ident.clone()) {
             let (k, rho, cp) = thermal_props(&name);
-            materials.push(EnergyMaterial::new(ident.clone(), thickness.max(0.001), k, rho, cp));
+            materials.push(EnergyMaterial::new(
+                ident.clone(),
+                thickness.max(0.001),
+                k,
+                rho,
+                cp,
+            ));
         }
         refs.push(ident);
     }
@@ -135,8 +170,14 @@ pub fn build_constructions(content: &[u8], profiles: &[ExtractedProfile]) -> Con
             if ls.is_empty() {
                 continue;
             }
-            let sig: Vec<(u32, i64)> = ls.iter().map(|l| (l.material_id, (l.thickness * scale * 1000.0).round() as i64)).collect();
-            let vals: Vec<(u32, f64)> = ls.iter().map(|l| (l.material_id, l.thickness * scale)).collect();
+            let sig: Vec<(u32, i64)> = ls
+                .iter()
+                .map(|l| (l.material_id, (l.thickness * scale * 1000.0).round() as i64))
+                .collect();
+            let vals: Vec<(u32, f64)> = ls
+                .iter()
+                .map(|l| (l.material_id, l.thickness * scale))
+                .collect();
             let bucket = if is_wall { &mut wall } else { &mut slab };
             bucket.entry(sig).or_insert((0, vals)).0 += 1;
         }
@@ -145,14 +186,32 @@ pub fn build_constructions(content: &[u8], profiles: &[ExtractedProfile]) -> Con
     let mut materials = Vec::new();
     let mut constructions = Vec::new();
     let mut seen_mat = HashSet::new();
-    let wall_id = build_one(&wall, "ifclite_wall", &names, &mut materials, &mut constructions, &mut seen_mat);
-    let slab_id = build_one(&slab, "ifclite_slab", &names, &mut materials, &mut constructions, &mut seen_mat);
+    let wall_id = build_one(
+        &wall,
+        "ifclite_wall",
+        &names,
+        &mut materials,
+        &mut constructions,
+        &mut seen_mat,
+    );
+    let slab_id = build_one(
+        &slab,
+        "ifclite_slab",
+        &names,
+        &mut materials,
+        &mut constructions,
+        &mut seen_mat,
+    );
 
     if constructions.is_empty() {
         return Constructions::none();
     }
     Constructions {
-        energy: Some(ModelEnergy { ty: "ModelEnergyProperties", materials, constructions }),
+        energy: Some(ModelEnergy {
+            ty: "ModelEnergyProperties",
+            materials,
+            constructions,
+        }),
         wall: wall_id,
         floor: slab_id.clone(),
         roof: slab_id,

--- a/rust/export/src/csv.rs
+++ b/rust/export/src/csv.rs
@@ -30,7 +30,10 @@ pub struct CsvOptions {
 
 impl Default for CsvOptions {
     fn default() -> Self {
-        Self { delimiter: ",".to_string(), include_properties: false }
+        Self {
+            delimiter: ",".to_string(),
+            include_properties: false,
+        }
     }
 }
 
@@ -67,7 +70,8 @@ pub fn export_csv(content: &[u8], mode: CsvMode, opts: &CsvOptions) -> String {
 /// One row per spatial node, depth-first from the project root.
 fn spatial_csv(content: &[u8], model: &ExportModel, opts: &CsvOptions) -> String {
     let d = &opts.delimiter;
-    let by_id: HashMap<u32, &EntityRow> = model.entities.iter().map(|e| (e.express_id, e)).collect();
+    let by_id: HashMap<u32, &EntityRow> =
+        model.entities.iter().map(|e| (e.express_id, e)).collect();
     let (children, project) = crate::ifc5::spatial_children(content);
 
     // The project node isn't an IfcProduct, so decode its GlobalId + Name directly.
@@ -76,14 +80,26 @@ fn spatial_csv(content: &[u8], model: &ExportModel, opts: &CsvOptions) -> String
         let index = ifc_lite_core::build_entity_index(content);
         let mut dec = ifc_lite_core::EntityDecoder::with_index(content, index);
         if let Ok(e) = dec.decode_by_id(pid) {
-            proj_gid = e.get(0).and_then(|a| a.as_string()).unwrap_or("").to_string();
-            proj_name = e.get(2).and_then(|a| a.as_string()).unwrap_or("").to_string();
+            proj_gid = e
+                .get(0)
+                .and_then(|a| a.as_string())
+                .unwrap_or("")
+                .to_string();
+            proj_name = e
+                .get(2)
+                .and_then(|a| a.as_string())
+                .unwrap_or("")
+                .to_string();
         }
     }
 
     let info = |id: u32| -> (String, String, String) {
         if Some(id) == project {
-            (proj_gid.clone(), proj_name.clone(), "IfcProject".to_string())
+            (
+                proj_gid.clone(),
+                proj_name.clone(),
+                "IfcProject".to_string(),
+            )
         } else if let Some(e) = by_id.get(&id) {
             (
                 e.global_id.clone().unwrap_or_default(),
@@ -96,7 +112,10 @@ fn spatial_csv(content: &[u8], model: &ExportModel, opts: &CsvOptions) -> String
     };
 
     let headers = ["expressId", "globalId", "name", "type", "parentId", "level"];
-    let mut lines = vec![join(&headers.iter().map(|h| escape(h, d)).collect::<Vec<_>>(), d)];
+    let mut lines = vec![join(
+        &headers.iter().map(|h| escape(h, d)).collect::<Vec<_>>(),
+        d,
+    )];
 
     let mut visited = HashSet::new();
     let mut stack: Vec<(u32, Option<u32>, usize)> = Vec::new();
@@ -131,10 +150,18 @@ fn spatial_csv(content: &[u8], model: &ExportModel, opts: &CsvOptions) -> String
 
 fn entities_csv(model: &ExportModel, opts: &CsvOptions) -> String {
     let d = &opts.delimiter;
-    let mut headers: Vec<String> = ["expressId", "globalId", "name", "type", "description", "objectType", "hasGeometry"]
-        .iter()
-        .map(|s| s.to_string())
-        .collect();
+    let mut headers: Vec<String> = [
+        "expressId",
+        "globalId",
+        "name",
+        "type",
+        "description",
+        "objectType",
+        "hasGeometry",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect();
 
     // Collect flattened property columns (first-seen order, deduped).
     let mut flat_cols: Vec<(String, String)> = Vec::new();
@@ -156,7 +183,10 @@ fn entities_csv(model: &ExportModel, opts: &CsvOptions) -> String {
     }
 
     let mut lines = Vec::with_capacity(model.entities.len() + 1);
-    lines.push(join(&headers.iter().map(|h| escape(h, d)).collect::<Vec<_>>(), d));
+    lines.push(join(
+        &headers.iter().map(|h| escape(h, d)).collect::<Vec<_>>(),
+        d,
+    ));
 
     for e in &model.entities {
         let mut row = vec![
@@ -181,8 +211,20 @@ fn entities_csv(model: &ExportModel, opts: &CsvOptions) -> String {
 
 fn properties_csv(model: &ExportModel, opts: &CsvOptions) -> String {
     let d = &opts.delimiter;
-    let headers = ["entityId", "globalId", "entityName", "entityType", "psetName", "propName", "value", "type"];
-    let mut lines = vec![join(&headers.iter().map(|h| escape(h, d)).collect::<Vec<_>>(), d)];
+    let headers = [
+        "entityId",
+        "globalId",
+        "entityName",
+        "entityType",
+        "psetName",
+        "propName",
+        "value",
+        "type",
+    ];
+    let mut lines = vec![join(
+        &headers.iter().map(|h| escape(h, d)).collect::<Vec<_>>(),
+        d,
+    )];
 
     for e in &model.entities {
         for ps in &e.property_sets {
@@ -206,8 +248,20 @@ fn properties_csv(model: &ExportModel, opts: &CsvOptions) -> String {
 
 fn quantities_csv(model: &ExportModel, opts: &CsvOptions) -> String {
     let d = &opts.delimiter;
-    let headers = ["entityId", "globalId", "entityName", "entityType", "qsetName", "quantityName", "value", "type"];
-    let mut lines = vec![join(&headers.iter().map(|h| escape(h, d)).collect::<Vec<_>>(), d)];
+    let headers = [
+        "entityId",
+        "globalId",
+        "entityName",
+        "entityType",
+        "qsetName",
+        "quantityName",
+        "value",
+        "type",
+    ];
+    let mut lines = vec![join(
+        &headers.iter().map(|h| escape(h, d)).collect::<Vec<_>>(),
+        d,
+    )];
 
     for e in &model.entities {
         for qs in &e.quantity_sets {
@@ -240,9 +294,16 @@ mod tests {
 
     #[test]
     fn entities_csv_has_header_and_rows() {
-        let csv = export_csv(&fixture("ara3d/duplex.ifc"), CsvMode::Entities, &CsvOptions::default());
+        let csv = export_csv(
+            &fixture("ara3d/duplex.ifc"),
+            CsvMode::Entities,
+            &CsvOptions::default(),
+        );
         let mut lines = csv.lines();
-        assert_eq!(lines.next().unwrap(), "expressId,globalId,name,type,description,objectType,hasGeometry");
+        assert_eq!(
+            lines.next().unwrap(),
+            "expressId,globalId,name,type,description,objectType,hasGeometry"
+        );
         assert!(csv.lines().count() > 50, "expected many product rows");
         // Each data row has exactly 7 native columns (no flatten).
         for line in csv.lines().skip(1).take(20) {
@@ -254,20 +315,34 @@ mod tests {
 
     #[test]
     fn flatten_adds_property_columns() {
-        let plain = export_csv(&fixture("ara3d/duplex.ifc"), CsvMode::Entities, &CsvOptions::default());
+        let plain = export_csv(
+            &fixture("ara3d/duplex.ifc"),
+            CsvMode::Entities,
+            &CsvOptions::default(),
+        );
         let flat = export_csv(
             &fixture("ara3d/duplex.ifc"),
             CsvMode::Entities,
-            &CsvOptions { include_properties: true, ..CsvOptions::default() },
+            &CsvOptions {
+                include_properties: true,
+                ..CsvOptions::default()
+            },
         );
         let plain_cols = plain.lines().next().unwrap().split(',').count();
         let flat_cols = flat.lines().next().unwrap().split(',').count();
-        assert!(flat_cols > plain_cols, "flatten should add Pset_Prop columns");
+        assert!(
+            flat_cols > plain_cols,
+            "flatten should add Pset_Prop columns"
+        );
     }
 
     #[test]
     fn properties_csv_one_row_per_value() {
-        let csv = export_csv(&fixture("ara3d/duplex.ifc"), CsvMode::Properties, &CsvOptions::default());
+        let csv = export_csv(
+            &fixture("ara3d/duplex.ifc"),
+            CsvMode::Properties,
+            &CsvOptions::default(),
+        );
         assert_eq!(
             csv.lines().next().unwrap(),
             "entityId,globalId,entityName,entityType,psetName,propName,value,type"
@@ -282,14 +357,20 @@ mod tests {
             CsvMode::SpatialHierarchy,
             &CsvOptions::default(),
         );
-        assert_eq!(csv.lines().next().unwrap(), "expressId,globalId,name,type,parentId,level");
+        assert_eq!(
+            csv.lines().next().unwrap(),
+            "expressId,globalId,name,type,parentId,level"
+        );
         assert!(csv.contains(",IfcProject,"), "project row present");
         assert!(csv.lines().count() > 3, "expected spatial nodes");
         // Exactly one root at level 0 (the project, with an empty parentId).
         let level0 = csv.lines().skip(1).filter(|l| l.ends_with(",0")).count();
         assert_eq!(level0, 1, "single root at level 0");
         // Storeys/spaces appear deeper in the tree.
-        assert!(csv.contains("IfcBuildingStorey"), "storeys present in the hierarchy");
+        assert!(
+            csv.contains("IfcBuildingStorey"),
+            "storeys present in the hierarchy"
+        );
     }
 
     #[test]

--- a/rust/export/src/error.rs
+++ b/rust/export/src/error.rs
@@ -82,7 +82,11 @@ impl fmt::Display for ExportError {
                 write!(f, "{}: failed to serialize {stage}: {detail}", self.code())
             }
             ExportError::MalformedMeshInput { detail } => {
-                write!(f, "{}: from-meshes inputs are inconsistent: {detail}", self.code())
+                write!(
+                    f,
+                    "{}: from-meshes inputs are inconsistent: {detail}",
+                    self.code()
+                )
             }
         }
     }

--- a/rust/export/src/frame.rs
+++ b/rust/export/src/frame.rs
@@ -82,7 +82,12 @@ pub(crate) struct YUpScratch {
 
 impl YUpScratch {
     pub(crate) fn new() -> Self {
-        Self { positions: Vec::new(), normals: Vec::new(), indices: Vec::new(), origin: [0.0; 3] }
+        Self {
+            positions: Vec::new(),
+            normals: Vec::new(),
+            indices: Vec::new(),
+            origin: [0.0; 3],
+        }
     }
 }
 
@@ -99,12 +104,16 @@ pub(crate) fn to_yup_into(
     scratch.positions.clear();
     scratch.positions.reserve(positions.len());
     for c in positions.chunks_exact(3) {
-        scratch.positions.extend_from_slice(&yup_f32([c[0], c[1], c[2]]));
+        scratch
+            .positions
+            .extend_from_slice(&yup_f32([c[0], c[1], c[2]]));
     }
     scratch.normals.clear();
     scratch.normals.reserve(normals.len());
     for c in normals.chunks_exact(3) {
-        scratch.normals.extend_from_slice(&yup_f32([c[0], c[1], c[2]]));
+        scratch
+            .normals
+            .extend_from_slice(&yup_f32([c[0], c[1], c[2]]));
     }
     scratch.indices.clear();
     scratch.indices.extend_from_slice(indices);

--- a/rust/export/src/frame_tests.rs
+++ b/rust/export/src/frame_tests.rs
@@ -6,7 +6,6 @@
 
 use super::*;
 
-
 /// Two triangles whose index triples are all distinct, so an unswapped
 /// pass-through is distinguishable from a correctly reversed winding.
 const TRIS: [u32; 6] = [0, 1, 2, 1, 2, 3];
@@ -48,7 +47,10 @@ fn to_yup_into_reverses_triangle_winding() {
     let positions = cube_corner_positions();
     let normals = vec![0.0f32; positions.len()];
     to_yup_into(&mut scratch, &positions, &normals, &TRIS, [0.0, 0.0, 0.0]);
-    assert_eq!(scratch.indices, TRIS_REVERSED, "streaming path must reverse winding");
+    assert_eq!(
+        scratch.indices, TRIS_REVERSED,
+        "streaming path must reverse winding"
+    );
 }
 
 #[test]
@@ -67,8 +69,12 @@ fn to_yup_in_place_reverses_triangle_winding() {
 /// coordinates so a swapped or unnegated axis cannot survive.
 #[test]
 fn to_yup_into_and_in_place_agree_on_every_output() {
-    let positions = vec![1.0f32, 2.0, 3.0, -4.0, 5.0, -6.0, 7.0, -8.0, 9.0, 0.5, 0.25, -0.125];
-    let normals = vec![0.0f32, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, -1.0, 0.0, 0.0];
+    let positions = vec![
+        1.0f32, 2.0, 3.0, -4.0, 5.0, -6.0, 7.0, -8.0, 9.0, 0.5, 0.25, -0.125,
+    ];
+    let normals = vec![
+        0.0f32, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, -1.0, 0.0, 0.0,
+    ];
     let origin = [10.0f64, -20.0, 30.0];
 
     let mut scratch = YUpScratch::new();
@@ -86,8 +92,14 @@ fn to_yup_into_and_in_place_agree_on_every_output() {
     assert_eq!(scratch.origin, io);
     // The fixture must actually exercise the conversion: an all-zero or
     // symmetric input would make this equivalence hold vacuously.
-    assert_ne!(scratch.positions, positions, "fixture must not be a fixed point of the swap");
-    assert_ne!(scratch.origin, origin, "origin fixture must not be a fixed point");
+    assert_ne!(
+        scratch.positions, positions,
+        "fixture must not be a fixed point of the swap"
+    );
+    assert_ne!(
+        scratch.origin, origin,
+        "origin fixture must not be a fixed point"
+    );
 }
 
 #[test]
@@ -118,7 +130,13 @@ fn trailing_partial_triangle_is_left_alone() {
 
     let mut scratch = YUpScratch::new();
     let indices: Vec<u32> = vec![0, 1, 2, 3];
-    to_yup_into(&mut scratch, &positions, &normals, &indices, [0.0, 0.0, 0.0]);
+    to_yup_into(
+        &mut scratch,
+        &positions,
+        &normals,
+        &indices,
+        [0.0, 0.0, 0.0],
+    );
     assert_eq!(scratch.indices, vec![0, 2, 1, 3], "streaming path");
 
     let mut ip = positions.clone();

--- a/rust/export/src/geom.rs
+++ b/rust/export/src/geom.rs
@@ -61,7 +61,11 @@ fn newell_raw(b: &[[f64; 3]]) -> [f64; 3] {
 pub(crate) fn newell_normal(b: &[[f64; 3]]) -> [f64; 3] {
     let n = newell_raw(b);
     let len = (n[0] * n[0] + n[1] * n[1] + n[2] * n[2]).sqrt();
-    if len > 0.0 { [n[0] / len, n[1] / len, n[2] / len] } else { [0.0, 0.0, 0.0] }
+    if len > 0.0 {
+        [n[0] / len, n[1] / len, n[2] / len]
+    } else {
+        [0.0, 0.0, 0.0]
+    }
 }
 
 /// Planar polygon area (`|Newell| / 2`).
@@ -110,14 +114,25 @@ fn segments_cross(p1: (f64, f64), p2: (f64, f64), p3: (f64, f64), p4: (f64, f64)
     let d2 = orient2d(p3, p4, p2);
     let d3 = orient2d(p1, p2, p3);
     let d4 = orient2d(p1, p2, p4);
-    ((d1 > 0.0) != (d2 > 0.0)) && ((d3 > 0.0) != (d4 > 0.0)) && d1 != 0.0 && d2 != 0.0 && d3 != 0.0 && d4 != 0.0
+    ((d1 > 0.0) != (d2 > 0.0))
+        && ((d3 > 0.0) != (d4 > 0.0))
+        && d1 != 0.0
+        && d2 != 0.0
+        && d3 != 0.0
+        && d4 != 0.0
 }
 
 /// True when edges `a1a2` and `b1b2` are collinear (within `tol`) and overlap by more than
 /// `tol` along their shared line — i.e. the polygon doubles back over itself. Works for
 /// segments that share an endpoint (a backtracking spike) — the touch point alone is not an
 /// overlap, only a genuine doubling-back is.
-fn collinear_overlap(a1: (f64, f64), a2: (f64, f64), b1: (f64, f64), b2: (f64, f64), tol: f64) -> bool {
+fn collinear_overlap(
+    a1: (f64, f64),
+    a2: (f64, f64),
+    b1: (f64, f64),
+    b2: (f64, f64),
+    tol: f64,
+) -> bool {
     let dx = a2.0 - a1.0;
     let dy = a2.1 - a1.1;
     let len = (dx * dx + dy * dy).sqrt();
@@ -223,7 +238,9 @@ pub(crate) fn center(b: &[[f64; 3]]) -> [f64; 3] {
     let m = b.len().max(1) as f64;
     let mut c = [0.0; 3];
     for p in b {
-        for k in 0..3 { c[k] += p[k]; }
+        for k in 0..3 {
+            c[k] += p[k];
+        }
     }
     [c[0] / m, c[1] / m, c[2] / m]
 }

--- a/rust/export/src/geom_tests.rs
+++ b/rust/export/src/geom_tests.rs
@@ -16,7 +16,12 @@ use crate::adjacency::solve_adjacency;
 use crate::hbjson::{Face, Face3D, Room};
 
 fn unit_square_xy() -> Vec<[f64; 3]> {
-    vec![[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [0.0, 1.0, 0.0]]
+    vec![
+        [0.0, 0.0, 0.0],
+        [1.0, 0.0, 0.0],
+        [1.0, 1.0, 0.0],
+        [0.0, 1.0, 0.0],
+    ]
 }
 
 #[test]
@@ -55,11 +60,23 @@ fn xf_reads_the_transform_column_major() {
     t[14] = 30.0; // translation z
 
     for idx in [0usize, 1, 2, 4, 5, 6, 12, 13, 14] {
-        assert!(t[idx] != 0.0, "xf reads t[{idx}]; a zero entry hides a row/col swap");
+        assert!(
+            t[idx] != 0.0,
+            "xf reads t[{idx}]; a zero entry hides a row/col swap"
+        );
     }
-    assert_ne!(t[1], t[4], "c(1,0) must differ from c(0,1) or the swap is invisible");
-    assert_ne!(t[2], t[4], "c(2,0) must differ from c(0,1) or the swap is invisible");
-    assert_ne!(t[2], t[1], "c(2,0) must differ from c(1,0) or the swap is invisible");
+    assert_ne!(
+        t[1], t[4],
+        "c(1,0) must differ from c(0,1) or the swap is invisible"
+    );
+    assert_ne!(
+        t[2], t[4],
+        "c(2,0) must differ from c(0,1) or the swap is invisible"
+    );
+    assert_ne!(
+        t[2], t[1],
+        "c(2,0) must differ from c(1,0) or the swap is invisible"
+    );
 
     // Y-up: x = 2*1 + 3*2 + 10 = 18, y = 5*1 + 7*2 + 20 = 39, z = 11*1 + 13*2 + 30 = 67.
     // zup([18, 39, 67]) = [18, -67, 39].
@@ -73,7 +90,11 @@ fn polygon_area_is_half_the_newell_magnitude() {
     // Kills: `0.5 * |newell|` -> `1.0 * |newell|`.
     assert!((polygon_area(&unit_square_xy()) - 1.0).abs() < 1e-12);
     let tri = [[0.0, 0.0, 0.0], [2.0, 0.0, 0.0], [0.0, 3.0, 0.0]];
-    assert!((polygon_area(&tri) - 3.0).abs() < 1e-12, "got {}", polygon_area(&tri));
+    assert!(
+        (polygon_area(&tri) - 3.0).abs() < 1e-12,
+        "got {}",
+        polygon_area(&tri)
+    );
 }
 
 #[test]
@@ -84,7 +105,10 @@ fn newell_normal_is_unit_and_follows_the_winding() {
     reversed.reverse();
     assert!((newell_normal(&reversed)[2] + 1.0).abs() < 1e-12);
     // Degenerate (collinear) rings return the zero vector, not NaN.
-    assert_eq!(newell_normal(&[[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0]]), [0.0; 3]);
+    assert_eq!(
+        newell_normal(&[[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0]]),
+        [0.0; 3]
+    );
 }
 
 #[test]
@@ -94,7 +118,10 @@ fn clean_ring_merges_vertices_at_exactly_the_merge_distance() {
     // edge, so keeping it is the failure this guard exists to prevent.
     // Kills: `dist(&p, q) > merge` -> `>= merge`.
     let ring = vec![[0.0, 0.0, 0.0], [0.5, 0.0, 0.0], [2.0, 0.0, 0.0]];
-    assert_eq!(clean_ring(ring, 0.5), vec![[0.0, 0.0, 0.0], [2.0, 0.0, 0.0]]);
+    assert_eq!(
+        clean_ring(ring, 0.5),
+        vec![[0.0, 0.0, 0.0], [2.0, 0.0, 0.0]]
+    );
 }
 
 #[test]
@@ -115,12 +142,22 @@ fn face_ok_rejects_slivers_and_non_planar_rings() {
     assert!(face_ok(&unit_square_xy(), tol));
     // Sliver: area below AREA_EPS.
     assert!(!face_ok(
-        &[[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1e-6, 0.0], [0.0, 1e-6, 0.0]],
+        &[
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [1.0, 1e-6, 0.0],
+            [0.0, 1e-6, 0.0]
+        ],
         tol
     ));
     // Non-planar: one corner lifted well past the tolerance.
     assert!(!face_ok(
-        &[[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 1.0], [0.0, 1.0, 0.0]],
+        &[
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [1.0, 1.0, 1.0],
+            [0.0, 1.0, 0.0]
+        ],
         tol
     ));
 }
@@ -163,9 +200,21 @@ fn collinear_overlap_tolerance_scales_with_the_edge_length() {
         0.01
     ));
     // Genuinely off the line at any scale.
-    assert!(!collinear_overlap((0.0, 0.0), (100.0, 0.0), (0.0, 5.0), (100.0, 5.0), 0.01));
+    assert!(!collinear_overlap(
+        (0.0, 0.0),
+        (100.0, 0.0),
+        (0.0, 5.0),
+        (100.0, 5.0),
+        0.01
+    ));
     // Collinear but only touching at a point: not an overlap.
-    assert!(!collinear_overlap((0.0, 0.0), (1.0, 0.0), (1.0, 0.0), (2.0, 0.0), 0.01));
+    assert!(!collinear_overlap(
+        (0.0, 0.0),
+        (1.0, 0.0),
+        (1.0, 0.0),
+        (2.0, 0.0),
+        0.01
+    ));
 }
 
 #[test]
@@ -173,7 +222,10 @@ fn is_simple_polygon_rejects_rings_with_fewer_than_three_vertices() {
     // A 2-vertex ring projects onto a degenerate segment, so every downstream
     // check silently passes it — only the explicit `m < 3` guard rejects it.
     // Kills: `if m < 3` -> `if m < 2`.
-    assert!(!is_simple_polygon(&[[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]], 0.01));
+    assert!(!is_simple_polygon(
+        &[[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
+        0.01
+    ));
     assert!(is_simple_polygon(&unit_square_xy(), 0.01));
 }
 
@@ -182,7 +234,12 @@ fn is_simple_polygon_rejects_bowties_and_pinches() {
     let tol = 0.01;
     // Self-crossing bowtie.
     assert!(!is_simple_polygon(
-        &[[0.0, 0.0, 0.0], [1.0, 1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+        &[
+            [0.0, 0.0, 0.0],
+            [1.0, 1.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0]
+        ],
         tol
     ));
     // Pinch: two non-adjacent vertices coincide.
@@ -249,7 +306,12 @@ fn wall_at_x(id: &str, x0: f64, facing_plus_x: bool) -> Face {
 
 /// A 1x1 floor face in the plane `z = 0` (normal +Z).
 fn floor_face(id: &str) -> Face {
-    Face::new(id.to_string(), Face3D::new(unit_square_xy()), "Floor", "Outdoors")
+    Face::new(
+        id.to_string(),
+        Face3D::new(unit_square_xy()),
+        "Floor",
+        "Outdoors",
+    )
 }
 
 fn adjacent_room_of(room: &Room, face: usize) -> Option<String> {
@@ -270,7 +332,11 @@ fn solve_adjacency_pairs_anti_parallel_walls_and_counts_both_faces() {
         Room::new("A".into(), vec![wall_at_x("A-w", 0.0, true)]),
         Room::new("B".into(), vec![wall_at_x("B-w", 0.1, false)]),
     ];
-    assert_eq!(solve_adjacency(&mut rooms), 2, "one pair = two interior faces");
+    assert_eq!(
+        solve_adjacency(&mut rooms),
+        2,
+        "one pair = two interior faces"
+    );
     assert_eq!(rooms[0].faces[0].boundary_condition.ty, "Surface");
     assert_eq!(rooms[1].faces[0].boundary_condition.ty, "Surface");
     assert_eq!(adjacent_room_of(&rooms[0], 0).as_deref(), Some("B"));
@@ -296,10 +362,30 @@ fn solve_adjacency_rejects_perpendicular_faces() {
     ];
     wall_ring.reverse();
     let mut rooms = vec![
-        Room::new("A".into(), vec![Face::new("A-f".into(), Face3D::new(ring), "Floor", "Outdoors")]),
-        Room::new("B".into(), vec![Face::new("B-w".into(), Face3D::new(wall_ring), "Wall", "Outdoors")]),
+        Room::new(
+            "A".into(),
+            vec![Face::new(
+                "A-f".into(),
+                Face3D::new(ring),
+                "Floor",
+                "Outdoors",
+            )],
+        ),
+        Room::new(
+            "B".into(),
+            vec![Face::new(
+                "B-w".into(),
+                Face3D::new(wall_ring),
+                "Wall",
+                "Outdoors",
+            )],
+        ),
     ];
-    assert_eq!(solve_adjacency(&mut rooms), 0, "perpendicular faces are not adjacent");
+    assert_eq!(
+        solve_adjacency(&mut rooms),
+        0,
+        "perpendicular faces are not adjacent"
+    );
     assert_eq!(rooms[0].faces[0].boundary_condition.ty, "Outdoors");
 }
 
@@ -336,7 +422,12 @@ fn solve_adjacency_ignores_faces_beyond_the_wall_thickness_budget() {
     let mut degenerate = vec![
         Room::new(
             "A".into(),
-            vec![Face::new("A-d".into(), Face3D::new(vec![[0.0; 3], [1.0, 0.0, 0.0]]), "Wall", "Outdoors")],
+            vec![Face::new(
+                "A-d".into(),
+                Face3D::new(vec![[0.0; 3], [1.0, 0.0, 0.0]]),
+                "Wall",
+                "Outdoors",
+            )],
         ),
         Room::new("B".into(), vec![floor_face("B-f")]),
     ];

--- a/rust/export/src/gltf.rs
+++ b/rust/export/src/gltf.rs
@@ -33,8 +33,9 @@ use crate::error::ExportError;
 use ifc_lite_core::EntityIndex;
 use ifc_lite_geometry::{collate_refs, InstanceMeshRef, InstanceMeta, InstanceTemplate};
 use ifc_lite_processing::{
-    process_geometry, process_geometry_streaming_filtered_with_options, process_geometry_with_index,
-    build_entity_index_parallel, MeshData, OpeningFilterMode, ProcessingResult, StreamingOptions,
+    build_entity_index_parallel, process_geometry,
+    process_geometry_streaming_filtered_with_options, process_geometry_with_index, MeshData,
+    OpeningFilterMode, ProcessingResult, StreamingOptions,
 };
 use serde::Serialize;
 use serde_json::{json, Value};
@@ -351,7 +352,9 @@ fn make_material(color: [f32; 4], lit: bool, emissive: bool) -> Material {
         extensions: if lit || emissive {
             None
         } else {
-            Some(Extensions { khr_materials_unlit: EmptyObj {} })
+            Some(Extensions {
+                khr_materials_unlit: EmptyObj {},
+            })
         },
         alpha_mode: if color[3] < 1.0 { Some("BLEND") } else { None },
         double_sided: true,
@@ -446,7 +449,10 @@ impl<'s> Chunker<'s> {
             // The single-buffer GLB path keeps exactly one (possibly empty) buffer to
             // match the legacy output byte-for-byte; multi-buffer skips empty chunks.
             if self.sink.is_none() && self.next_buffer == 0 {
-                self.buffers.push(Buffer { byte_length: 0, uri: None });
+                self.buffers.push(Buffer {
+                    byte_length: 0,
+                    uri: None,
+                });
                 self.next_buffer += 1;
             }
             return;
@@ -465,16 +471,25 @@ impl<'s> Chunker<'s> {
         );
         let buf = self.next_buffer;
         self.buffer_views.push(BufferView {
-            buffer: buf, byte_offset: 0, byte_length: pl as u32,
-            byte_stride: Some(self.vec3_stride), target: 34962,
+            buffer: buf,
+            byte_offset: 0,
+            byte_length: pl as u32,
+            byte_stride: Some(self.vec3_stride),
+            target: 34962,
         });
         self.buffer_views.push(BufferView {
-            buffer: buf, byte_offset: pl as u32, byte_length: nl as u32,
-            byte_stride: Some(self.vec3_stride), target: 34962,
+            buffer: buf,
+            byte_offset: pl as u32,
+            byte_length: nl as u32,
+            byte_stride: Some(self.vec3_stride),
+            target: 34962,
         });
         self.buffer_views.push(BufferView {
-            buffer: buf, byte_offset: (pl + nl) as u32, byte_length: il as u32,
-            byte_stride: None, target: 34963,
+            buffer: buf,
+            byte_offset: (pl + nl) as u32,
+            byte_length: il as u32,
+            byte_stride: None,
+            target: 34963,
         });
         match self.sink.as_mut() {
             Some(sink) => {
@@ -488,7 +503,10 @@ impl<'s> Chunker<'s> {
                 self.norm.clear();
                 self.idx.clear();
                 let name = format!("buffer{buf}.bin");
-                self.buffers.push(Buffer { byte_length: total as u32, uri: Some(name.clone()) });
+                self.buffers.push(Buffer {
+                    byte_length: total as u32,
+                    uri: Some(name.clone()),
+                });
                 sink(name, bin);
             }
             None => {
@@ -502,7 +520,10 @@ impl<'s> Chunker<'s> {
                     self.next_buffer == 0,
                     "single-buffer GLB path must flush exactly once (cap == usize::MAX)",
                 );
-                self.buffers.push(Buffer { byte_length: total as u32, uri: None });
+                self.buffers.push(Buffer {
+                    byte_length: total as u32,
+                    uri: None,
+                });
             }
         }
         self.next_buffer += 1;
@@ -563,8 +584,10 @@ fn push_mesh(
     // Normals + indices are copied verbatim (no per-element transform), so reinterpret
     // each whole slice as LE bytes in one memcpy — byte-identical on LE targets (the
     // only ones this crate builds for) to the per-element `to_le_bytes` loop.
-    ch.norm.extend_from_slice(bytemuck::cast_slice::<f32, u8>(mesh.normals));
-    ch.idx.extend_from_slice(bytemuck::cast_slice::<u32, u8>(mesh.indices));
+    ch.norm
+        .extend_from_slice(bytemuck::cast_slice::<f32, u8>(mesh.normals));
+    ch.idx
+        .extend_from_slice(bytemuck::cast_slice::<u32, u8>(mesh.indices));
 
     let pos_acc = accessors.len() as u32;
     accessors.push(Accessor {
@@ -610,7 +633,10 @@ fn push_mesh(
     let mesh_idx = meshes.len() as u32;
     meshes.push(Mesh {
         primitives: vec![Primitive {
-            attributes: Attributes { position: pos_acc, normal: norm_acc },
+            attributes: Attributes {
+                position: pos_acc,
+                normal: norm_acc,
+            },
             indices: idx_acc,
             material: Some(material),
         }],
@@ -720,14 +746,16 @@ fn push_mesh_quantized(
     // mesh stays 4-aligned regardless of this mesh's index width.
     let small = nverts <= u16::MAX as u32 + 1;
     let idx_off = ch.idx.len() as u32;
-    ch.idx.reserve(mesh.indices.len() * if small { 2 } else { 4 } + 3);
+    ch.idx
+        .reserve(mesh.indices.len() * if small { 2 } else { 4 } + 3);
     if small {
         for &i in mesh.indices {
             ch.idx.extend_from_slice(&(i as u16).to_le_bytes());
         }
     } else {
         // u32 indices are copied verbatim — one memcpy of the whole run (LE targets).
-        ch.idx.extend_from_slice(bytemuck::cast_slice::<u32, u8>(mesh.indices));
+        ch.idx
+            .extend_from_slice(bytemuck::cast_slice::<u32, u8>(mesh.indices));
     }
     while !ch.idx.len().is_multiple_of(4) {
         ch.idx.push(0);
@@ -778,7 +806,10 @@ fn push_mesh_quantized(
     let mesh_idx = meshes.len() as u32;
     meshes.push(Mesh {
         primitives: vec![Primitive {
-            attributes: Attributes { position: pos_acc, normal: norm_acc },
+            attributes: Attributes {
+                position: pos_acc,
+                normal: norm_acc,
+            },
             indices: idx_acc,
             material: Some(material),
         }],
@@ -944,22 +975,47 @@ fn quaternion_from_column_major(m: &[f64; 16]) -> [f32; 4] {
     let trace = m00 + m11 + m22;
     let (x, y, z, w) = if trace > 0.0 {
         let s = (trace + 1.0).sqrt() * 2.0;
-        ((at(2, 1) - at(1, 2)) / s, (at(0, 2) - at(2, 0)) / s, (at(1, 0) - at(0, 1)) / s, 0.25 * s)
+        (
+            (at(2, 1) - at(1, 2)) / s,
+            (at(0, 2) - at(2, 0)) / s,
+            (at(1, 0) - at(0, 1)) / s,
+            0.25 * s,
+        )
     } else if m00 > m11 && m00 > m22 {
         let s = (1.0 + m00 - m11 - m22).sqrt() * 2.0;
-        (0.25 * s, (at(0, 1) + at(1, 0)) / s, (at(0, 2) + at(2, 0)) / s, (at(2, 1) - at(1, 2)) / s)
+        (
+            0.25 * s,
+            (at(0, 1) + at(1, 0)) / s,
+            (at(0, 2) + at(2, 0)) / s,
+            (at(2, 1) - at(1, 2)) / s,
+        )
     } else if m11 > m22 {
         let s = (1.0 + m11 - m00 - m22).sqrt() * 2.0;
-        ((at(0, 1) + at(1, 0)) / s, 0.25 * s, (at(1, 2) + at(2, 1)) / s, (at(0, 2) - at(2, 0)) / s)
+        (
+            (at(0, 1) + at(1, 0)) / s,
+            0.25 * s,
+            (at(1, 2) + at(2, 1)) / s,
+            (at(0, 2) - at(2, 0)) / s,
+        )
     } else {
         let s = (1.0 + m22 - m00 - m11).sqrt() * 2.0;
-        ((at(0, 2) + at(2, 0)) / s, (at(1, 2) + at(2, 1)) / s, 0.25 * s, (at(1, 0) - at(0, 1)) / s)
+        (
+            (at(0, 2) + at(2, 0)) / s,
+            (at(1, 2) + at(2, 1)) / s,
+            0.25 * s,
+            (at(1, 0) - at(0, 1)) / s,
+        )
     };
     let n = (x * x + y * y + z * z + w * w).sqrt();
     if n < 1e-12 {
         return [0.0, 0.0, 0.0, 1.0];
     }
-    [(x / n) as f32, (y / n) as f32, (z / n) as f32, (w / n) as f32]
+    [
+        (x / n) as f32,
+        (y / n) as f32,
+        (z / n) as f32,
+        (w / n) as f32,
+    ]
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1014,7 +1070,12 @@ fn build_gltf(
     let mut nodes: Vec<Node> = Vec::new();
     let mut element_node_indices: Vec<u32> = Vec::new();
 
-    let mut stats = GltfStats { meshes: 0, vertices: 0, triangles: 0, materials: 0 };
+    let mut stats = GltfStats {
+        meshes: 0,
+        vertices: 0,
+        triangles: 0,
+        materials: 0,
+    };
 
     // ── Pass 1.5: collate by representation identity ────────────────────────────
     // Group occurrences that share a representation (IfcMappedItem / repeated
@@ -1067,7 +1128,12 @@ fn build_gltf(
         let m_ref_inv = (!rigid)
             .then(|| visible[template.template_index].instance)
             .flatten()
-            .filter(|_| template.occurrences.iter().all(|o| visible[o.mesh_index].instance.is_some()))
+            .filter(|_| {
+                template
+                    .occurrences
+                    .iter()
+                    .all(|o| visible[o.mesh_index].instance.is_some())
+            })
             .and_then(|ti| affine_inverse(&compose_world_meta(ti)));
         match m_ref_inv {
             Some(inv) => instanced.push((template, inv)),
@@ -1083,7 +1149,14 @@ fn build_gltf(
     // instanced output never regresses below the plain content-hash baseline.
     let flat_keys: Vec<u128> = flat
         .iter()
-        .map(|&i| geom_color_key(visible[i].positions, visible[i].normals, visible[i].indices, visible[i].color))
+        .map(|&i| {
+            geom_color_key(
+                visible[i].positions,
+                visible[i].normals,
+                visible[i].indices,
+                visible[i].color,
+            )
+        })
         .collect();
     let mut flat_counts: FxHashMap<u128, u32> = FxHashMap::default();
     for &k in &flat_keys {
@@ -1112,14 +1185,28 @@ fn build_gltf(
             let (mi, center, half) = if shared {
                 *flat_cache.entry(key).or_insert_with(|| {
                     push_mesh_quantized(
-                        &mut *ch, &mut accessors, &mut meshes,
-                        &mut materials, &mut material_map, mesh, lit, emissive, &mut stats,
+                        &mut *ch,
+                        &mut accessors,
+                        &mut meshes,
+                        &mut materials,
+                        &mut material_map,
+                        mesh,
+                        lit,
+                        emissive,
+                        &mut stats,
                     )
                 })
             } else {
                 push_mesh_quantized(
-                    &mut *ch, &mut accessors, &mut meshes,
-                    &mut materials, &mut material_map, mesh, lit, emissive, &mut stats,
+                    &mut *ch,
+                    &mut accessors,
+                    &mut meshes,
+                    &mut materials,
+                    &mut material_map,
+                    mesh,
+                    lit,
+                    emissive,
+                    &mut stats,
                 )
             };
             mesh_idx = mi;
@@ -1133,19 +1220,38 @@ fn build_gltf(
             // Repeated baked geometry: emit LOCAL once, place via node translation.
             let (mi, _, _) = *flat_cache.entry(key).or_insert_with(|| {
                 let mi = push_mesh(
-                    &mut *ch, &mut accessors, &mut meshes,
-                    &mut materials, &mut material_map, mesh, [0.0, 0.0, 0.0], lit, emissive, &mut stats,
+                    &mut *ch,
+                    &mut accessors,
+                    &mut meshes,
+                    &mut materials,
+                    &mut material_map,
+                    mesh,
+                    [0.0, 0.0, 0.0],
+                    lit,
+                    emissive,
+                    &mut stats,
                 );
                 (mi, [0.0; 3], [0.0; 3])
             });
             mesh_idx = mi;
-            translation = placement.iter().any(|c| c.abs() > 1e-9).then_some(placement);
+            translation = placement
+                .iter()
+                .any(|c| c.abs() > 1e-9)
+                .then_some(placement);
             scale = None;
         } else {
             // Singleton: bake world-minus-center into the vertices, identity node.
             mesh_idx = push_mesh(
-                &mut *ch, &mut accessors, &mut meshes,
-                &mut materials, &mut material_map, mesh, placement, lit, emissive, &mut stats,
+                &mut *ch,
+                &mut accessors,
+                &mut meshes,
+                &mut materials,
+                &mut material_map,
+                mesh,
+                placement,
+                lit,
+                emissive,
+                &mut stats,
             );
             translation = None;
             scale = None;
@@ -1158,7 +1264,13 @@ fn build_gltf(
             translation,
             scale,
             matrix: None,
-            extras: node_extras(include_metadata, mesh.express_id, mesh.ifc_type, mesh.global_id, model_id),
+            extras: node_extras(
+                include_metadata,
+                mesh.express_id,
+                mesh.ifc_type,
+                mesh.global_id,
+                model_id,
+            ),
         });
         element_node_indices.push(node_idx);
     }
@@ -1205,15 +1317,29 @@ fn build_gltf(
             // occurrence nodes need; f32 bakes nothing (`vertex_offset = 0`).
             let (mesh_idx, dequant) = if quantize {
                 let (mi, center, half) = push_mesh_quantized(
-                    &mut *ch, &mut accessors,
-                    &mut meshes, &mut materials, &mut material_map, &tmpl_mesh, lit, emissive, &mut stats,
+                    &mut *ch,
+                    &mut accessors,
+                    &mut meshes,
+                    &mut materials,
+                    &mut material_map,
+                    &tmpl_mesh,
+                    lit,
+                    emissive,
+                    &mut stats,
                 );
                 (mi, Some((center, half)))
             } else {
                 let mi = push_mesh(
-                    &mut *ch, &mut accessors,
-                    &mut meshes, &mut materials, &mut material_map, &tmpl_mesh,
-                    [0.0, 0.0, 0.0], lit, emissive, &mut stats,
+                    &mut *ch,
+                    &mut accessors,
+                    &mut meshes,
+                    &mut materials,
+                    &mut material_map,
+                    &tmpl_mesh,
+                    [0.0, 0.0, 0.0],
+                    lit,
+                    emissive,
+                    &mut stats,
                 );
                 (mi, None)
             };
@@ -1222,11 +1348,23 @@ fn build_gltf(
                 let occ_view = visible[occ.mesh_index];
                 // Safe: the partition only kept this group when every occurrence has
                 // an instance side-channel and the template inverse exists.
-                let occ_meta = occ_view.instance.expect("instanced occurrence has InstanceMeta");
+                let occ_meta = occ_view
+                    .instance
+                    .expect("instanced occurrence has InstanceMeta");
                 let matrix = occurrence_node_matrix(
-                    occ_meta, &m_ref_inv, rtc_zup, t_origin_yup, scene_center,
+                    occ_meta,
+                    &m_ref_inv,
+                    rtc_zup,
+                    t_origin_yup,
+                    scene_center,
                 );
-                let extras = node_extras(include_metadata, occ_view.express_id, occ_view.ifc_type, occ_view.global_id, model_id);
+                let extras = node_extras(
+                    include_metadata,
+                    occ_view.express_id,
+                    occ_view.ifc_type,
+                    occ_view.global_id,
+                    model_id,
+                );
                 let node_idx = if let Some((center, half)) = dequant {
                     // Quantized: the dequant is a non-uniform scale; folding it into the
                     // occurrence matrix would make three.js `Matrix4.decompose` mangle the
@@ -1234,7 +1372,7 @@ fn build_gltf(
                     // `extras` (a raycast pick hits the mesh), placement rides the parent.
                     let child_idx = nodes.len() as u32;
                     nodes.push(Node {
-            rotation: None,
+                        rotation: None,
                         mesh: Some(mesh_idx),
                         children: None,
                         translation: Some(center),
@@ -1244,7 +1382,7 @@ fn build_gltf(
                     });
                     let parent_idx = nodes.len() as u32;
                     nodes.push(Node {
-            rotation: None,
+                        rotation: None,
                         mesh: None,
                         children: Some(vec![child_idx]),
                         translation: None,
@@ -1256,7 +1394,7 @@ fn build_gltf(
                 } else {
                     let ni = nodes.len() as u32;
                     nodes.push(Node {
-            rotation: None,
+                        rotation: None,
                         mesh: Some(mesh_idx),
                         children: None,
                         translation: None,
@@ -1308,12 +1446,20 @@ fn build_gltf(
     };
 
     let gltf = Gltf {
-        asset: Asset { version: "2.0", generator: "IFC-Lite", extras: asset_extras },
+        asset: Asset {
+            version: "2.0",
+            generator: "IFC-Lite",
+            extras: asset_extras,
+        },
         scene: 0,
         scenes: vec![Scene { nodes: scene_nodes }],
         nodes,
         meshes,
-        materials: if materials.is_empty() { None } else { Some(materials) },
+        materials: if materials.is_empty() {
+            None
+        } else {
+            Some(materials)
+        },
         accessors,
         buffer_views: std::mem::take(&mut ch.buffer_views),
         buffers: std::mem::take(&mut ch.buffers),
@@ -1440,7 +1586,12 @@ fn with_result_views<R>(
         .collect();
     for &i in &vis_idx {
         let m = &mut result.meshes[i];
-        crate::frame::to_yup_in_place(&mut m.positions, &mut m.normals, &mut m.indices, &mut m.origin);
+        crate::frame::to_yup_in_place(
+            &mut m.positions,
+            &mut m.normals,
+            &mut m.indices,
+            &mut m.origin,
+        );
     }
     let views: Vec<MeshView> = vis_idx
         .iter()
@@ -1472,8 +1623,15 @@ fn export_glb_from_result(result: ProcessingResult, opts: &GltfOptions) -> (Vec<
     with_result_views(result, opts, |views, rtc_zup, site_zup| {
         let mut ch = Chunker::new(if opts.quantize { 8 } else { 12 }, usize::MAX, None);
         let (gltf, stats) = build_gltf(
-            views, opts.include_metadata, opts.model_id.as_deref(), opts.lit, opts.emissive,
-            rtc_zup, site_zup, opts.quantize, &mut ch,
+            views,
+            opts.include_metadata,
+            opts.model_id.as_deref(),
+            opts.lit,
+            opts.emissive,
+            rtc_zup,
+            site_zup,
+            opts.quantize,
+            &mut ch,
         );
         let json = serde_json::to_vec(&gltf).expect("glTF JSON serializes");
         (pack_glb(&json, &ch.pos, &ch.norm, &ch.idx), stats)
@@ -1563,7 +1721,13 @@ fn export_gltf_streaming_impl(
                 if !filter.visible(m) {
                     continue;
                 }
-                crate::frame::to_yup_into(&mut yscratch, &m.positions, &m.normals, &m.indices, m.origin);
+                crate::frame::to_yup_into(
+                    &mut yscratch,
+                    &m.positions,
+                    &m.normals,
+                    &m.indices,
+                    m.origin,
+                );
                 let y = &yscratch;
                 for p in y.positions.chunks_exact(3) {
                     for k in 0..3 {
@@ -1593,9 +1757,18 @@ fn export_gltf_streaming_impl(
     let mut materials: Vec<Material> = Vec::new();
     let mut material_map: FxHashMap<(i32, i32, i32, i32), u32> = FxHashMap::default();
     let mut element_node_indices: Vec<u32> = Vec::new();
-    let mut stats = GltfStats { meshes: 0, vertices: 0, triangles: 0, materials: 0 };
+    let mut stats = GltfStats {
+        meshes: 0,
+        vertices: 0,
+        triangles: 0,
+        materials: 0,
+    };
     let mut adapt = |name: String, bytes: Vec<u8>| sink(GltfBuffer { name, bytes });
-    let mut ch = Chunker::new(if opts.quantize { 8 } else { 12 }, chunk_cap, Some(&mut adapt));
+    let mut ch = Chunker::new(
+        if opts.quantize { 8 } else { 12 },
+        chunk_cap,
+        Some(&mut adapt),
+    );
 
     process_geometry_streaming_filtered_with_options(
         content,
@@ -1606,7 +1779,13 @@ fn export_gltf_streaming_impl(
                 if !filter.visible(m) {
                     continue;
                 }
-                crate::frame::to_yup_into(&mut yscratch, &m.positions, &m.normals, &m.indices, m.origin);
+                crate::frame::to_yup_into(
+                    &mut yscratch,
+                    &m.positions,
+                    &m.normals,
+                    &m.indices,
+                    m.origin,
+                );
                 let y = &yscratch;
                 let view = MeshView {
                     express_id: m.express_id,
@@ -1632,8 +1811,15 @@ fn export_gltf_streaming_impl(
                 let scale;
                 if opts.quantize {
                     let (mi, center, half) = push_mesh_quantized(
-                        &mut ch, &mut accessors, &mut meshes, &mut materials,
-                        &mut material_map, &view, opts.lit, opts.emissive, &mut stats,
+                        &mut ch,
+                        &mut accessors,
+                        &mut meshes,
+                        &mut materials,
+                        &mut material_map,
+                        &view,
+                        opts.lit,
+                        opts.emissive,
+                        &mut stats,
                     );
                     mesh_idx = mi;
                     translation = Some([
@@ -1644,23 +1830,34 @@ fn export_gltf_streaming_impl(
                     scale = Some(half);
                 } else {
                     mesh_idx = push_mesh(
-                        &mut ch, &mut accessors, &mut meshes, &mut materials,
-                        &mut material_map, &view, placement, opts.lit, opts.emissive, &mut stats,
+                        &mut ch,
+                        &mut accessors,
+                        &mut meshes,
+                        &mut materials,
+                        &mut material_map,
+                        &view,
+                        placement,
+                        opts.lit,
+                        opts.emissive,
+                        &mut stats,
                     );
                     translation = None;
                     scale = None;
                 }
                 let node_idx = nodes.len() as u32;
                 nodes.push(Node {
-            rotation: None,
+                    rotation: None,
                     mesh: Some(mesh_idx),
                     children: None,
                     translation,
                     scale,
                     matrix: None,
                     extras: node_extras(
-                        opts.include_metadata, m.express_id, &m.ifc_type,
-                        m.global_id.as_deref(), opts.model_id.as_deref(),
+                        opts.include_metadata,
+                        m.express_id,
+                        &m.ifc_type,
+                        m.global_id.as_deref(),
+                        opts.model_id.as_deref(),
                     ),
                 });
                 element_node_indices.push(node_idx);
@@ -1701,12 +1898,20 @@ fn export_gltf_streaming_impl(
         })
     });
     let gltf = Gltf {
-        asset: Asset { version: "2.0", generator: "IFC-Lite", extras: asset_extras },
+        asset: Asset {
+            version: "2.0",
+            generator: "IFC-Lite",
+            extras: asset_extras,
+        },
         scene: 0,
         scenes: vec![Scene { nodes: scene_nodes }],
         nodes,
         meshes,
-        materials: if materials.is_empty() { None } else { Some(materials) },
+        materials: if materials.is_empty() {
+            None
+        } else {
+            Some(materials)
+        },
         accessors,
         buffer_views: std::mem::take(&mut ch.buffer_views),
         buffers: std::mem::take(&mut ch.buffers),
@@ -2023,7 +2228,13 @@ fn plan_bounded_glb(
                 if !filter.visible(m) {
                     continue;
                 }
-                crate::frame::to_yup_into(&mut yscratch, &m.positions, &m.normals, &m.indices, m.origin);
+                crate::frame::to_yup_into(
+                    &mut yscratch,
+                    &m.positions,
+                    &m.normals,
+                    &m.indices,
+                    m.origin,
+                );
                 let y = &yscratch;
                 // Same geometry-sanity gate as `view_ok` on the in-memory path.
                 if y.indices.is_empty()
@@ -2100,7 +2311,12 @@ fn plan_bounded_glb(
     let mut materials: Vec<Material> = Vec::new();
     let mut material_map: FxHashMap<(i32, i32, i32, i32), u32> = FxHashMap::default();
     let mut element_node_indices: Vec<u32> = Vec::new();
-    let mut stats = GltfStats { meshes: 0, vertices: 0, triangles: 0, materials: 0 };
+    let mut stats = GltfStats {
+        meshes: 0,
+        vertices: 0,
+        triangles: 0,
+        materials: 0,
+    };
     // key -> (mesh_idx, dequant center, dequant half). center/half are dummy
     // zeros/ones on the f32 path (node scale stays None), the per-mesh dequant
     // the node folds in on the quantized path (mirrors build_gltf's flat_cache).
@@ -2143,8 +2359,11 @@ fn plan_bounded_glb(
         };
         let emit = !(shared && shared_cache.contains_key(&meta.key));
         // f32 path only: singletons bake world-minus-centre into the vertices.
-        let vertex_offset =
-            if shared || quantize { [0.0, 0.0, 0.0] } else { placement };
+        let vertex_offset = if shared || quantize {
+            [0.0, 0.0, 0.0]
+        } else {
+            placement
+        };
         let (mesh_idx, center, half) = if emit {
             let (pos_acc, norm_acc, idx_acc) = if quantize {
                 // Quantize is monotone per axis, so the accessor min/max are the
@@ -2232,15 +2451,20 @@ fn plan_bounded_glb(
                 });
                 (pos_acc, norm_acc, idx_acc)
             };
-            let material = *material_map.entry(color_key(meta.color)).or_insert_with(|| {
-                let idx = materials.len() as u32;
-                materials.push(make_material(meta.color, opts.lit, opts.emissive));
-                idx
-            });
+            let material = *material_map
+                .entry(color_key(meta.color))
+                .or_insert_with(|| {
+                    let idx = materials.len() as u32;
+                    materials.push(make_material(meta.color, opts.lit, opts.emissive));
+                    idx
+                });
             let mesh_idx = meshes.len() as u32;
             meshes.push(Mesh {
                 primitives: vec![Primitive {
-                    attributes: Attributes { position: pos_acc, normal: norm_acc },
+                    attributes: Attributes {
+                        position: pos_acc,
+                        normal: norm_acc,
+                    },
                     indices: idx_acc,
                     material: Some(material),
                 }],
@@ -2288,13 +2512,20 @@ fn plan_bounded_glb(
             )
         } else if shared {
             (
-                placement.iter().any(|c| c.abs() > 1e-9).then_some(placement),
+                placement
+                    .iter()
+                    .any(|c| c.abs() > 1e-9)
+                    .then_some(placement),
                 None,
             )
         } else {
             (None, None)
         };
-        per_meta.push(Emitted { mesh_idx, translation, scale });
+        per_meta.push(Emitted {
+            mesh_idx,
+            translation,
+            scale,
+        });
     }
     for (meta, emitted) in metas.iter().zip(&per_meta) {
         let node_idx = nodes.len() as u32;
@@ -2325,10 +2556,19 @@ fn plan_bounded_glb(
     // only ever emitted when the size fits (an oversize plan is discarded), so
     // every path that actually produces bytes stays correct.
     let (buffers, buffer_views) = if bin_total == 0 && stats.meshes == 0 {
-        (vec![Buffer { byte_length: 0, uri: None }], Vec::new())
+        (
+            vec![Buffer {
+                byte_length: 0,
+                uri: None,
+            }],
+            Vec::new(),
+        )
     } else {
         (
-            vec![Buffer { byte_length: bin_total as u32, uri: None }],
+            vec![Buffer {
+                byte_length: bin_total as u32,
+                uri: None,
+            }],
             vec![
                 BufferView {
                     buffer: 0,
@@ -2383,12 +2623,20 @@ fn plan_bounded_glb(
         })
     });
     let gltf = Gltf {
-        asset: Asset { version: "2.0", generator: "IFC-Lite", extras: asset_extras },
+        asset: Asset {
+            version: "2.0",
+            generator: "IFC-Lite",
+            extras: asset_extras,
+        },
         scene: 0,
         scenes: vec![Scene { nodes: scene_nodes }],
         nodes,
         meshes,
-        materials: if materials.is_empty() { None } else { Some(materials) },
+        materials: if materials.is_empty() {
+            None
+        } else {
+            Some(materials)
+        },
         accessors,
         buffer_views,
         buffers,
@@ -2412,7 +2660,15 @@ fn plan_bounded_glb(
     // here — the size has to stay a reliable > 4 GiB fail-fast signal.
     let total = glb_container_size(json.len() as u64, bin_total);
 
-    BoundedGlbPlan { metas, json, pos_len, norm_len, bin_total, total, stats }
+    BoundedGlbPlan {
+        metas,
+        json,
+        pos_len,
+        norm_len,
+        bin_total,
+        total,
+        stats,
+    }
 }
 
 /// Pass 2 of the bounded assembler: preallocate the exact GLB container from
@@ -2433,7 +2689,15 @@ fn write_bounded_glb(
         entity_index: index.clone(),
         ..StreamingOptions::default()
     };
-    let BoundedGlbPlan { metas, json, pos_len, norm_len, bin_total, total, stats } = plan;
+    let BoundedGlbPlan {
+        metas,
+        json,
+        pos_len,
+        norm_len,
+        bin_total,
+        total,
+        stats,
+    } = plan;
 
     // ── Preallocate the exact GLB container, then pass 2 writes into it ─────
     // Safe to narrow to usize here: the caller validated `total`/`bin_total` fit
@@ -2472,7 +2736,13 @@ fn write_bounded_glb(
                 if !filter.visible(m) {
                     continue;
                 }
-                crate::frame::to_yup_into(&mut yscratch, &m.positions, &m.normals, &m.indices, m.origin);
+                crate::frame::to_yup_into(
+                    &mut yscratch,
+                    &m.positions,
+                    &m.normals,
+                    &m.indices,
+                    m.origin,
+                );
                 let y = &yscratch;
                 if y.indices.is_empty()
                     || y.positions.len() < 9
@@ -2494,8 +2764,12 @@ fn write_bounded_glb(
                         && meta.key == geom_color_key(&y.positions, &y.normals, &y.indices, m.color),
                     "GLB streaming pass 2 diverged from pass 1 at mesh {cursor} \
                      (expected #{} {}v/{}i, got #{} {}v/{}i); the mesh stream is not deterministic",
-                    meta.express_id, meta.nverts, meta.nidx,
-                    m.express_id, y.positions.len() / 3, y.indices.len(),
+                    meta.express_id,
+                    meta.nverts,
+                    meta.nidx,
+                    m.express_id,
+                    y.positions.len() / 3,
+                    y.indices.len(),
                 );
                 if let Some(w) = &meta.write {
                     if let Some((center, half, small)) = &w.quant {
@@ -2577,7 +2851,6 @@ fn write_bounded_glb(
 
     (out, stats)
 }
-
 
 /// Pack a glTF JSON document and the binary buffer's three runs (positions | normals |
 /// indices) into a GLB container (little-endian). The runs are appended straight into the

--- a/rust/export/src/gltf/from_meshes.rs
+++ b/rust/export/src/gltf/from_meshes.rs
@@ -79,8 +79,17 @@ pub fn try_export_glb_from_meshes(
     // Every count is backed and every mesh's normals/indices are present, so the
     // infallible assembler's malformed-input `break` is unreachable and no mesh is dropped.
     Ok(export_glb_from_meshes(
-        positions, normals, indices, vertex_counts, index_counts, colors, origins,
-        express_ids, include_metadata, lit, emissive,
+        positions,
+        normals,
+        indices,
+        vertex_counts,
+        index_counts,
+        colors,
+        origins,
+        express_ids,
+        include_metadata,
+        lit,
+        emissive,
     ))
 }
 
@@ -164,26 +173,25 @@ pub fn export_glb_from_meshes(
     // side-channel), so there is no RTC frame to compensate. Quantization is a
     // from-bytes feature; the viewer path stays f32.
     let mut ch = Chunker::new(12, usize::MAX, None);
-    let (gltf, stats) =
-        build_gltf(
-            &views,
-            include_metadata,
-            None,
-            lit,
-            emissive,
-            [0.0, 0.0, 0.0],
-            // No `ProcessingResult` reaches this path, so there is no site
-            // placement available to restore.
-            //
-            // Not the same as "there is nothing to restore". The viewer's own
-            // `MeshData` comes through the same pipeline and, for a translated
-            // site, *is* site-local, so a GLB exported from the viewer stays in
-            // that frame. Fixing that needs the API to carry `site_transform`,
-            // which is a change to its signature rather than to this line.
-            None,
-            false,
-            &mut ch,
-        );
+    let (gltf, stats) = build_gltf(
+        &views,
+        include_metadata,
+        None,
+        lit,
+        emissive,
+        [0.0, 0.0, 0.0],
+        // No `ProcessingResult` reaches this path, so there is no site
+        // placement available to restore.
+        //
+        // Not the same as "there is nothing to restore". The viewer's own
+        // `MeshData` comes through the same pipeline and, for a translated
+        // site, *is* site-local, so a GLB exported from the viewer stays in
+        // that frame. Fixing that needs the API to carry `site_transform`,
+        // which is a change to its signature rather than to this line.
+        None,
+        false,
+        &mut ch,
+    );
     let json = serde_json::to_vec(&gltf).expect("glTF JSON serializes");
     (pack_glb(&json, &ch.pos, &ch.norm, &ch.idx), stats)
 }

--- a/rust/export/src/gltf/matrix.rs
+++ b/rust/export/src/gltf/matrix.rs
@@ -84,9 +84,15 @@ fn row_major_f64_to_col_major_f32(m: &[f64; 16]) -> [f32; 16] {
 /// (cofactor / determinant) and map the translation by `-R⁻¹·t`. Returns `None` if
 /// the 3x3 is singular (degenerate placement) so the caller can fall back to flat.
 pub(super) fn affine_inverse(m: &[f64; 16]) -> Option<[f64; 16]> {
-    let a = m[0]; let b = m[1]; let c = m[2];
-    let d = m[4]; let e = m[5]; let f = m[6];
-    let g = m[8]; let h = m[9]; let i = m[10];
+    let a = m[0];
+    let b = m[1];
+    let c = m[2];
+    let d = m[4];
+    let e = m[5];
+    let f = m[6];
+    let g = m[8];
+    let h = m[9];
+    let i = m[10];
     let det = a * (e * i - f * h) - b * (d * i - f * g) + c * (d * h - e * g);
     if det.abs() < 1e-18 {
         return None;
@@ -170,7 +176,9 @@ mod tests {
 
         // Row-major helpers.
         let translate = |t: [f64; 3]| -> [f64; 16] {
-            [1., 0., 0., t[0], 0., 1., 0., t[1], 0., 0., 1., t[2], 0., 0., 0., 1.]
+            [
+                1., 0., 0., t[0], 0., 1., 0., t[1], 0., 0., 1., t[2], 0., 0., 0., 1.,
+            ]
         };
         // Rotation about Z (Z-up): (x,y) rotate, z fixed.
         let rot_z = |deg: f64| -> [f64; 16] {
@@ -227,9 +235,14 @@ mod tests {
         let origin_yup = crate::frame::yup_f64(origin_z);
         let tmpl_local_yup: Vec<[f64; 3]> = tmpl_baked
             .iter()
-            .map(|p| crate::frame::yup_f64([p[0] - origin_z[0], p[1] - origin_z[1], p[2] - origin_z[2]]))
+            .map(|p| {
+                crate::frame::yup_f64([p[0] - origin_z[0], p[1] - origin_z[1], p[2] - origin_z[2]])
+            })
             .collect();
-        let occ_world_yup: Vec<[f64; 3]> = occ_baked.iter().map(|p| crate::frame::yup_f64(*p)).collect();
+        let occ_world_yup: Vec<[f64; 3]> = occ_baked
+            .iter()
+            .map(|p| crate::frame::yup_f64(*p))
+            .collect();
 
         // scene_center = centre of the combined baked Y-up AABB.
         let mut lo = [f64::INFINITY; 3];
@@ -241,7 +254,11 @@ mod tests {
                 hi[k] = hi[k].max(y[k]);
             }
         }
-        let scene_center = [(lo[0] + hi[0]) * 0.5, (lo[1] + hi[1]) * 0.5, (lo[2] + hi[2]) * 0.5];
+        let scene_center = [
+            (lo[0] + hi[0]) * 0.5,
+            (lo[1] + hi[1]) * 0.5,
+            (lo[2] + hi[2]) * 0.5,
+        ];
 
         let meta = |transform: [f64; 16]| InstanceMeta {
             transform,
@@ -252,16 +269,29 @@ mod tests {
         };
         let m_ref_inv = super::affine_inverse(&super::compose_world_meta(&meta(m_ref)))
             .expect("template placement invertible");
-        let node = super::occurrence_node_matrix(&meta(m_k), &m_ref_inv, rtc, origin_yup, scene_center);
+        let node =
+            super::occurrence_node_matrix(&meta(m_k), &m_ref_inv, rtc, origin_yup, scene_center);
 
         // Reconstruct: world = scene_center(root) + node(col-major) · template_local.
         let mut max_err = 0.0f64;
         for (lv, truth) in tmpl_local_yup.iter().zip(&occ_world_yup) {
             let (x, y, z) = (lv[0], lv[1], lv[2]);
             let world = [
-                scene_center[0] + node[0] as f64 * x + node[4] as f64 * y + node[8] as f64 * z + node[12] as f64,
-                scene_center[1] + node[1] as f64 * x + node[5] as f64 * y + node[9] as f64 * z + node[13] as f64,
-                scene_center[2] + node[2] as f64 * x + node[6] as f64 * y + node[10] as f64 * z + node[14] as f64,
+                scene_center[0]
+                    + node[0] as f64 * x
+                    + node[4] as f64 * y
+                    + node[8] as f64 * z
+                    + node[12] as f64,
+                scene_center[1]
+                    + node[1] as f64 * x
+                    + node[5] as f64 * y
+                    + node[9] as f64 * z
+                    + node[13] as f64,
+                scene_center[2]
+                    + node[2] as f64 * x
+                    + node[6] as f64 * y
+                    + node[10] as f64 * z
+                    + node[14] as f64,
             ];
             for k in 0..3 {
                 max_err = max_err.max((world[k] - truth[k]).abs());
@@ -318,7 +348,12 @@ mod tests {
         let world = [m[3], m[7], m[11]];
         let want = [10.0, 1.0, 0.0];
         for k in 0..3 {
-            assert!((world[k] - want[k]).abs() < 1e-9, "axis {k}: {} != {}", world[k], want[k]);
+            assert!(
+                (world[k] - want[k]).abs() < 1e-9,
+                "axis {k}: {} != {}",
+                world[k],
+                want[k]
+            );
         }
     }
 
@@ -335,7 +370,9 @@ mod tests {
             [c, -s, 0., 0., s, c, 0., 0., 0., 0., 1., 0., 0., 0., 0., 1.]
         };
         let translate = |t: [f64; 3]| {
-            [1., 0., 0., t[0], 0., 1., 0., t[1], 0., 0., 1., t[2], 0., 0., 0., 1.]
+            [
+                1., 0., 0., t[0], 0., 1., 0., t[1], 0., 0., 1., t[2], 0., 0., 0., 1.,
+            ]
         };
         let apply = |m: &[f64; 16], p: [f64; 3]| {
             [
@@ -356,12 +393,19 @@ mod tests {
         // rotated 25° about Z and translated. rtc / origin / scene_center all zero.
         let m_ref = super::compose_world_meta(&meta(super::IDENTITY16));
         let m_ref_inv = super::affine_inverse(&m_ref).expect("identity invertible");
-        let m_k = super::compose_world_meta(&meta(
-            super::mat4_mul(&translate([7.0, -3.0, 2.0]), &rot_z(25.0)),
-        ));
-        let node = super::occurrence_node_matrix(&meta(m_k), &m_ref_inv, [0.0; 3], [0.0; 3], [0.0; 3]);
+        let m_k = super::compose_world_meta(&meta(super::mat4_mul(
+            &translate([7.0, -3.0, 2.0]),
+            &rot_z(25.0),
+        )));
+        let node =
+            super::occurrence_node_matrix(&meta(m_k), &m_ref_inv, [0.0; 3], [0.0; 3], [0.0; 3]);
 
-        let canonical = [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.3, 0.4, 0.5]];
+        let canonical = [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.3, 0.4, 0.5],
+        ];
         let mut max_err = 0.0f64;
         for &p in &canonical {
             // Template local (Y-up): identity template at origin 0, so just the Y-up point.
@@ -369,15 +413,27 @@ mod tests {
             // Truth: the occurrence's own baked (rtc = 0) geometry, in Y-up.
             let truth = crate::frame::yup_f64(apply(&m_k, p));
             let world = [
-                node[0] as f64 * lv[0] + node[4] as f64 * lv[1] + node[8] as f64 * lv[2] + node[12] as f64,
-                node[1] as f64 * lv[0] + node[5] as f64 * lv[1] + node[9] as f64 * lv[2] + node[13] as f64,
-                node[2] as f64 * lv[0] + node[6] as f64 * lv[1] + node[10] as f64 * lv[2] + node[14] as f64,
+                node[0] as f64 * lv[0]
+                    + node[4] as f64 * lv[1]
+                    + node[8] as f64 * lv[2]
+                    + node[12] as f64,
+                node[1] as f64 * lv[0]
+                    + node[5] as f64 * lv[1]
+                    + node[9] as f64 * lv[2]
+                    + node[13] as f64,
+                node[2] as f64 * lv[0]
+                    + node[6] as f64 * lv[1]
+                    + node[10] as f64 * lv[2]
+                    + node[14] as f64,
             ];
             for k in 0..3 {
                 max_err = max_err.max((world[k] - truth[k]).abs());
             }
         }
         // The node matrix is downcast to f32, so the bound is f32 precision, not f64.
-        assert!(max_err < 1e-4, "zero-rtc non-identity occurrence mis-placed by {max_err}");
+        assert!(
+            max_err < 1e-4,
+            "zero-rtc non-identity occurrence mis-placed by {max_err}"
+        );
     }
 }

--- a/rust/export/src/gltf_tests.rs
+++ b/rust/export/src/gltf_tests.rs
@@ -30,7 +30,11 @@ fn parse_glb(glb: &[u8]) -> (Value, Vec<u8>) {
     // Assert the literal magic bytes (not a derived constant) so a wrong magic
     // constant in pack_glb can't pass the test self-consistently.
     assert_eq!(&glb[0..4], b"glTF", "glTF magic");
-    assert_eq!(u32::from_le_bytes(glb[4..8].try_into().unwrap()), 2, "version 2");
+    assert_eq!(
+        u32::from_le_bytes(glb[4..8].try_into().unwrap()),
+        2,
+        "version 2"
+    );
     let total = u32::from_le_bytes(glb[8..12].try_into().unwrap()) as usize;
     assert_eq!(total, glb.len(), "header total length matches");
 
@@ -68,7 +72,10 @@ fn geom_color_key_distinguishes_one_position_bit() {
     let color = [1.0f32, 0.0, 0.0, 1.0];
     let key_a = geom_color_key(&positions_a, &normals, &indices, color);
     let key_b = geom_color_key(&positions_b, &normals, &indices, color);
-    assert_ne!(key_a, key_b, "a one-bit position difference must not collapse the dedup key");
+    assert_ne!(
+        key_a, key_b,
+        "a one-bit position difference must not collapse the dedup key"
+    );
 }
 
 #[test]
@@ -80,7 +87,10 @@ fn geom_color_key_distinguishes_color_only() {
     let color_b = [0.0f32, 1.0, 0.0, 1.0];
     let key_a = geom_color_key(&positions, &normals, &indices, color_a);
     let key_b = geom_color_key(&positions, &normals, &indices, color_b);
-    assert_ne!(key_a, key_b, "colour is part of the key: material rides the primitive, not the node");
+    assert_ne!(
+        key_a, key_b,
+        "colour is part of the key: material rides the primitive, not the node"
+    );
 }
 
 #[test]
@@ -92,7 +102,10 @@ fn geom_color_key_distinguishes_normals_only() {
     let color = [1.0f32, 0.0, 0.0, 1.0];
     let key_a = geom_color_key(&positions, &normals_a, &indices, color);
     let key_b = geom_color_key(&positions, &normals_b, &indices, color);
-    assert_ne!(key_a, key_b, "a normals-only difference must not collapse the dedup key");
+    assert_ne!(
+        key_a, key_b,
+        "a normals-only difference must not collapse the dedup key"
+    );
 }
 
 #[test]
@@ -104,7 +117,10 @@ fn geom_color_key_distinguishes_indices_only() {
     let color = [1.0f32, 0.0, 0.0, 1.0];
     let key_a = geom_color_key(&positions, &normals, &indices_a, color);
     let key_b = geom_color_key(&positions, &normals, &indices_b, color);
-    assert_ne!(key_a, key_b, "an indices-only difference must not collapse the dedup key");
+    assert_ne!(
+        key_a, key_b,
+        "an indices-only difference must not collapse the dedup key"
+    );
 }
 
 #[test]
@@ -119,7 +135,10 @@ fn geom_color_key_is_stable_for_bit_identical_meshes() {
     let normals_b = normals;
     let indices_b = indices;
     let key_b = geom_color_key(&positions_b, &normals_b, &indices_b, color);
-    assert_eq!(key_a, key_b, "bit-identical meshes must collapse to the same dedup key");
+    assert_eq!(
+        key_a, key_b,
+        "bit-identical meshes must collapse to the same dedup key"
+    );
 }
 
 #[test]
@@ -178,7 +197,10 @@ fn with_index_glb_is_byte_identical() {
     let (plain, _) = export_glb_with_stats(&bytes, &opts);
     let idx = Arc::new(crate::build_entity_index(&bytes));
     let (shared, _) = export_glb_with_stats_with_index(&bytes, &opts, idx);
-    assert_eq!(plain, shared, "shared-index GLB must equal self-indexed GLB");
+    assert_eq!(
+        plain, shared,
+        "shared-index GLB must equal self-indexed GLB"
+    );
 }
 
 // ── #1516: streaming shared-index + fail-fast size ────────────────────
@@ -193,10 +215,16 @@ fn glb_container_size_does_not_truncate() {
     // A > 4 GiB BIN payload must stay > u32::MAX (not wrap to a small usize).
     let big = 5_000_000_000u64; // > u32::MAX (4_294_967_295)
     let total = glb_container_size(100, big);
-    assert_eq!(total, 12 + 8 + 100 + 8 + big, "no truncation, exact u64 sum");
-    assert!(total > u32::MAX as u64, "oversize total must exceed 4 GiB, got {total}");
+    assert_eq!(
+        total,
+        12 + 8 + 100 + 8 + big,
+        "no truncation, exact u64 sum"
+    );
+    assert!(
+        total > u32::MAX as u64,
+        "oversize total must exceed 4 GiB, got {total}"
+    );
 }
-
 
 /// The shared-index BOUNDED GLB path must emit byte-for-byte the same GLB as
 /// the self-indexing one — the injected index equals the one the bounded
@@ -205,11 +233,17 @@ fn glb_container_size_does_not_truncate() {
 fn bounded_glb_with_index_is_byte_identical() {
     let bytes = fixture("ara3d/duplex.ifc");
     for quantize in [false, true] {
-        let opts = GltfOptions { quantize, ..GltfOptions::default() };
+        let opts = GltfOptions {
+            quantize,
+            ..GltfOptions::default()
+        };
         let (plain, ps) = export_glb_streaming_bounded(&bytes, &opts);
         let idx = Arc::new(crate::build_entity_index(&bytes));
         let (shared, ss) = export_glb_streaming_bounded_with_index(&bytes, &opts, idx);
-        assert_eq!(plain, shared, "shared-index bounded GLB must match (quantize={quantize})");
+        assert_eq!(
+            plain, shared,
+            "shared-index bounded GLB must match (quantize={quantize})"
+        );
         assert_eq!(ps, ss, "stats must match");
     }
 }
@@ -230,7 +264,10 @@ fn gltf_streaming_with_index_is_byte_identical() {
     let shared_json =
         export_gltf_streaming_with_index(&bytes, &opts, idx, cap, |b| shared_bufs.push(b.bytes));
 
-    assert_eq!(plain_json, shared_json, "shared-index .gltf JSON must match");
+    assert_eq!(
+        plain_json, shared_json,
+        "shared-index .gltf JSON must match"
+    );
     assert_eq!(plain_bufs, shared_bufs, "shared-index buffers must match");
 }
 
@@ -242,7 +279,10 @@ fn gltf_streaming_with_index_is_byte_identical() {
 fn project_glb_size_matches_bounded_output() {
     let bytes = fixture("ara3d/duplex.ifc");
     for quantize in [false, true] {
-        let opts = GltfOptions { quantize, ..GltfOptions::default() };
+        let opts = GltfOptions {
+            quantize,
+            ..GltfOptions::default()
+        };
         let proj = project_glb_size(&bytes, &opts);
         let (glb, stats) = export_glb_streaming_bounded(&bytes, &opts);
         assert_eq!(
@@ -270,14 +310,20 @@ fn try_export_bounded_matches_export_for_fitting_model() {
     let (want, wstats) = export_glb_streaming_bounded(&bytes, &opts);
     let (got, gstats) = try_export_glb_streaming_bounded(&bytes, &opts)
         .expect("duplex fits — must not be TooLarge");
-    assert_eq!(want, got, "checked bounded GLB must equal the panicking one");
+    assert_eq!(
+        want, got,
+        "checked bounded GLB must equal the panicking one"
+    );
     assert_eq!(wstats, gstats);
 
     // The top-level fail-closed API agrees with the in-memory export for a
     // small model and still guards the empty case.
     let (glb, _) = try_export_glb_with_stats(&bytes, &opts).expect("has geometry");
     let (want2, _) = export_glb_with_stats(&bytes, &opts);
-    assert_eq!(glb, want2, "try_export_glb_with_stats must match export_glb_with_stats");
+    assert_eq!(
+        glb, want2,
+        "try_export_glb_with_stats must match export_glb_with_stats"
+    );
 }
 
 // ── KHR_mesh_quantization ────────────────────────────────────────────
@@ -311,13 +357,27 @@ fn node_local(node: &Value) -> [f64; 16] {
     let t = node.get("translation").and_then(Value::as_array);
     let s = node.get("scale").and_then(Value::as_array);
     let g = |a: Option<&Vec<Value>>, i: usize, d: f64| {
-        a.and_then(|a| a.get(i)).and_then(Value::as_f64).unwrap_or(d)
+        a.and_then(|a| a.get(i))
+            .and_then(Value::as_f64)
+            .unwrap_or(d)
     };
     [
-        g(s, 0, 1.0), 0.0, 0.0, 0.0,
-        0.0, g(s, 1, 1.0), 0.0, 0.0,
-        0.0, 0.0, g(s, 2, 1.0), 0.0,
-        g(t, 0, 0.0), g(t, 1, 0.0), g(t, 2, 0.0), 1.0,
+        g(s, 0, 1.0),
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        g(s, 1, 1.0),
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        g(s, 2, 1.0),
+        0.0,
+        g(t, 0, 0.0),
+        g(t, 1, 0.0),
+        g(t, 2, 0.0),
+        1.0,
     ]
 }
 /// Decode one POSITION accessor (f32 or normalized SHORT) to local-space points.
@@ -332,7 +392,10 @@ fn decode_positions(json: &Value, bufs: &[&[u8]], acc_idx: usize) -> Vec<[f64; 3
     // Respect the declared byteStride (don't assume tight packing — the quantized
     // SHORT VEC3 attrs are padded to an 8-byte stride).
     let csz = if ct == 5126 { 4 } else { 2 };
-    let stride = bv["byteStride"].as_u64().map(|s| s as usize).unwrap_or(csz * 3);
+    let stride = bv["byteStride"]
+        .as_u64()
+        .map(|s| s as usize)
+        .unwrap_or(csz * 3);
     let mut out = Vec::with_capacity(count);
     for i in 0..count {
         let comp = |k: usize| -> f64 {
@@ -356,7 +419,10 @@ fn world_aabb(json: &Value, bufs: &[&[u8]]) -> ([f64; 3], [f64; 3]) {
     let nodes = json["nodes"].as_array().unwrap();
     let ident = {
         let mut m = [0.0; 16];
-        m[0] = 1.0; m[5] = 1.0; m[10] = 1.0; m[15] = 1.0;
+        m[0] = 1.0;
+        m[5] = 1.0;
+        m[10] = 1.0;
+        m[15] = 1.0;
         m
     };
     let mut lo = [f64::INFINITY; 3];
@@ -400,7 +466,10 @@ fn quantized_glb_matches_f32_world_bounds() {
     let (f32_glb, _) = export_glb_with_stats(&bytes, &GltfOptions::default());
     let (q_glb, _) = export_glb_with_stats(
         &bytes,
-        &GltfOptions { quantize: true, ..Default::default() },
+        &GltfOptions {
+            quantize: true,
+            ..Default::default()
+        },
     );
     let (j0, b0) = parse_glb(&f32_glb);
     let (j1, b1) = parse_glb(&q_glb);
@@ -410,7 +479,10 @@ fn quantized_glb_matches_f32_world_bounds() {
         assert!(
             (lo0[k] - lo1[k]).abs() < 0.01 && (hi0[k] - hi1[k]).abs() < 0.01,
             "world AABB axis {k} drifted: f32 [{},{}] vs quant [{},{}]",
-            lo0[k], hi0[k], lo1[k], hi1[k]
+            lo0[k],
+            hi0[k],
+            lo1[k],
+            hi1[k]
         );
     }
 }
@@ -444,7 +516,11 @@ fn multibuffer_splits_and_matches_single_glb() {
     // gets its own over-cap buffer — geometry can't span buffers.)
     let cap = 256 * 1024;
     let (j, bufs) = streaming_export(&bytes, &opts, cap);
-    assert!(bufs.len() >= 2, "cap must split; got {} buffers", bufs.len());
+    assert!(
+        bufs.len() >= 2,
+        "cap must split; got {} buffers",
+        bufs.len()
+    );
     for b in &bufs {
         assert!(b.len() <= cap, "buffer {} exceeds cap {cap}", b.len());
     }
@@ -475,9 +551,20 @@ fn multibuffer_quantized_roundtrips() {
     let (lo0, hi0) = world_aabb(&gj, &[&gb]);
 
     let cap = 64 * 1024;
-    let (j, bufs) = streaming_export(&bytes, &GltfOptions { quantize: true, ..Default::default() }, cap);
+    let (j, bufs) = streaming_export(
+        &bytes,
+        &GltfOptions {
+            quantize: true,
+            ..Default::default()
+        },
+        cap,
+    );
     assert!(bufs.len() >= 2);
-    assert!(j["extensionsRequired"].as_array().unwrap().iter().any(|e| e == "KHR_mesh_quantization"));
+    assert!(j["extensionsRequired"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|e| e == "KHR_mesh_quantization"));
     let refs: Vec<&[u8]> = bufs.iter().map(Vec::as_slice).collect();
     let (lo1, hi1) = world_aabb(&j, &refs);
     for k in 0..3 {
@@ -532,12 +619,17 @@ fn quantized_glb_is_structurally_valid() {
     let bytes = fixture("ara3d/duplex.ifc");
     let (glb, stats) = export_glb_with_stats(
         &bytes,
-        &GltfOptions { quantize: true, ..Default::default() },
+        &GltfOptions {
+            quantize: true,
+            ..Default::default()
+        },
     );
     let (json, bin) = parse_glb(&glb);
     assert!(stats.meshes > 0);
     // Extension declared and required.
-    let req = json["extensionsRequired"].as_array().expect("extensionsRequired");
+    let req = json["extensionsRequired"]
+        .as_array()
+        .expect("extensionsRequired");
     assert!(req.iter().any(|e| e == "KHR_mesh_quantization"));
     // Positions/normals are normalized SHORT; indices are u16 or u32.
     for acc in json["accessors"].as_array().unwrap() {
@@ -546,7 +638,10 @@ fn quantized_glb_is_structurally_valid() {
             assert_eq!(ct, 5122, "VEC3 attrs must be SHORT when quantized");
             assert_eq!(acc["normalized"], Value::Bool(true));
         } else {
-            assert!(ct == 5123 || ct == 5125, "indices must be u16/u32, got {ct}");
+            assert!(
+                ct == 5123 || ct == 5125,
+                "indices must be u16/u32, got {ct}"
+            );
         }
     }
     // Vertex-attribute bufferViews must declare a byteStride that is a multiple of 4
@@ -572,15 +667,24 @@ fn quantized_glb_is_structurally_valid() {
             + acc["count"].as_u64().unwrap()
                 * n_per(acc["type"].as_str().unwrap())
                 * comp_size(acc["componentType"].as_u64().unwrap());
-        assert!(end <= bv["byteLength"].as_u64().unwrap(), "accessor overruns bufferView");
+        assert!(
+            end <= bv["byteLength"].as_u64().unwrap(),
+            "accessor overruns bufferView"
+        );
     }
-    assert_eq!(bin.len() as u64, json["buffers"][0]["byteLength"].as_u64().unwrap());
+    assert_eq!(
+        bin.len() as u64,
+        json["buffers"][0]["byteLength"].as_u64().unwrap()
+    );
 }
 
 #[test]
 fn quantized_glb_is_byte_deterministic() {
     let bytes = fixture("ara3d/duplex.ifc");
-    let opts = GltfOptions { quantize: true, ..Default::default() };
+    let opts = GltfOptions {
+        quantize: true,
+        ..Default::default()
+    };
     let (a, _) = export_glb_with_stats(&bytes, &opts);
     let (b, _) = export_glb_with_stats(&bytes, &opts);
     assert_eq!(a, b, "quantized GLB must be byte-deterministic");
@@ -603,7 +707,9 @@ fn quantization_roundtrip_precision() {
         }
     }
     let center: Vec<f64> = (0..3).map(|k| (lo[k] + hi[k]) * 0.5).collect();
-    let half: Vec<f64> = (0..3).map(|k| ((hi[k] - lo[k]) * 0.5).max(f64::MIN_POSITIVE)).collect();
+    let half: Vec<f64> = (0..3)
+        .map(|k| ((hi[k] - lo[k]) * 0.5).max(f64::MIN_POSITIVE))
+        .collect();
     let mut worst = 0.0f64;
     for p in pos.chunks_exact(3) {
         for k in 0..3 {
@@ -613,13 +719,15 @@ fn quantization_roundtrip_precision() {
             worst = worst.max((deq - p[k] as f64).abs());
         }
     }
-    assert!(worst < 0.001, "per-axis quant error {worst} m exceeds 1 mm on a 10 m mesh");
+    assert!(
+        worst < 0.001,
+        "per-axis quant error {worst} m exceeds 1 mm on a 10 m mesh"
+    );
 }
 
 #[test]
 fn duplex_exports_valid_glb() {
-    let (glb, stats) =
-        export_glb_with_stats(&fixture("ara3d/duplex.ifc"), &GltfOptions::default());
+    let (glb, stats) = export_glb_with_stats(&fixture("ara3d/duplex.ifc"), &GltfOptions::default());
     assert!(stats.meshes > 0 && stats.triangles > 0);
 
     let (json, bin) = parse_glb(&glb);
@@ -633,7 +741,11 @@ fn duplex_exports_valid_glb() {
     // them all. `meshes` is the DEDUPED unique-geometry count (repeated shapes
     // share one mesh), so meshes <= occurrences and json meshes == stats.meshes.
     let occurrences = nodes.len() - 1;
-    assert_eq!(meshes.len(), stats.meshes, "json meshes == deduped mesh count");
+    assert_eq!(
+        meshes.len(),
+        stats.meshes,
+        "json meshes == deduped mesh count"
+    );
     assert!(stats.meshes <= occurrences, "unique meshes <= occurrences");
 
     // Scene has exactly one top-level node: the root. It carries the model
@@ -642,7 +754,10 @@ fn duplex_exports_valid_glb() {
     assert_eq!(scene_nodes.len(), 1, "single root node");
     let root_idx = scene_nodes[0].as_u64().unwrap() as usize;
     let root = &nodes[root_idx];
-    assert!(root.get("mesh").is_none(), "root is a transform node, no mesh");
+    assert!(
+        root.get("mesh").is_none(),
+        "root is a transform node, no mesh"
+    );
     assert_eq!(
         root["children"].as_array().unwrap().len(),
         occurrences,
@@ -669,8 +784,14 @@ fn duplex_exports_valid_glb() {
     }
     // duplex repeats geometry, so instancing must have fired: fewer unique meshes
     // than occurrences AND at least one occurrence placed via a node matrix.
-    assert!(stats.meshes < occurrences, "duplex repeats geometry -> dedup fired");
-    assert!(instanced_nodes > 0, "shared templates are placed via node matrix");
+    assert!(
+        stats.meshes < occurrences,
+        "duplex repeats geometry -> dedup fired"
+    );
+    assert!(
+        instanced_nodes > 0,
+        "shared templates are placed via node matrix"
+    );
 
     // Materials present + LIT by default (#1321: no KHR_materials_unlit) +
     // double-sided.
@@ -680,11 +801,19 @@ fn duplex_exports_valid_glb() {
         "lit by default: no extensionsUsed / unlit extension"
     );
     assert!(
-        json["materials"].as_array().unwrap().iter().all(|m| m.get("extensions").is_none()),
+        json["materials"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|m| m.get("extensions").is_none()),
         "lit materials carry no extensions"
     );
     assert!(
-        json["materials"].as_array().unwrap().iter().all(|m| m["doubleSided"] == true),
+        json["materials"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|m| m["doubleSided"] == true),
         "materials double-sided (IFC winding isn't reliably outward)"
     );
 
@@ -704,11 +833,17 @@ fn duplex_exports_valid_glb() {
         };
         let len = acc["count"].as_u64().unwrap() * per * comp;
         let end = acc["byteOffset"].as_u64().unwrap() + len;
-        assert!(end <= bv["byteLength"].as_u64().unwrap(), "accessor overruns bufferView");
+        assert!(
+            end <= bv["byteLength"].as_u64().unwrap(),
+            "accessor overruns bufferView"
+        );
     }
 
     // Binary buffer length matches the declared buffer.
-    assert_eq!(bin.len(), json["buffers"][0]["byteLength"].as_u64().unwrap() as usize);
+    assert_eq!(
+        bin.len(),
+        json["buffers"][0]["byteLength"].as_u64().unwrap() as usize
+    );
 }
 
 #[test]
@@ -773,12 +908,24 @@ fn from_meshes_glb_preserves_source_welded_vertices() {
 
     // World extent preserved: the plate is still GxG and flat (one axis span
     // is 0, the other two are G), regardless of the Y-up axis order.
-    let mn: Vec<f64> = pos_acc["min"].as_array().unwrap().iter().map(|v| v.as_f64().unwrap()).collect();
-    let mx: Vec<f64> = pos_acc["max"].as_array().unwrap().iter().map(|v| v.as_f64().unwrap()).collect();
+    let mn: Vec<f64> = pos_acc["min"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_f64().unwrap())
+        .collect();
+    let mx: Vec<f64> = pos_acc["max"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_f64().unwrap())
+        .collect();
     let mut spans: Vec<f64> = (0..3).map(|i| mx[i] - mn[i]).collect();
     spans.sort_by(|a, b| a.partial_cmp(b).unwrap());
     assert!(
-        spans[0].abs() < 1e-4 && (spans[1] - G as f64).abs() < 1e-4 && (spans[2] - G as f64).abs() < 1e-4,
+        spans[0].abs() < 1e-4
+            && (spans[1] - G as f64).abs() < 1e-4
+            && (spans[2] - G as f64).abs() < 1e-4,
         "welded plate keeps its GxG flat extent (spans {spans:?})"
     );
 }
@@ -791,7 +938,9 @@ fn from_meshes_assembles_valid_glb() {
         0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0, // mesh 0
         0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0, // mesh 1
     ];
-    let normals: Vec<f32> = std::iter::repeat_n([0.0f32, 0.0, 1.0], 8).flatten().collect();
+    let normals: Vec<f32> = std::iter::repeat_n([0.0f32, 0.0, 1.0], 8)
+        .flatten()
+        .collect();
     let indices: Vec<u32> = vec![0, 1, 2, 0, 2, 3, 0, 1, 2, 0, 2, 3];
     let vertex_counts = vec![4u32, 4];
     let index_counts = vec![6u32, 6];
@@ -800,8 +949,17 @@ fn from_meshes_assembles_valid_glb() {
     let express_ids = vec![10u32, 20];
 
     let (glb, stats) = export_glb_from_meshes(
-        &positions, &normals, &indices, &vertex_counts, &index_counts, &colors, &origins,
-        &express_ids, true, true, false,
+        &positions,
+        &normals,
+        &indices,
+        &vertex_counts,
+        &index_counts,
+        &colors,
+        &origins,
+        &express_ids,
+        true,
+        true,
+        false,
     );
     assert_eq!(stats.meshes, 2);
     assert_eq!(stats.triangles, 4);
@@ -815,8 +973,10 @@ fn from_meshes_assembles_valid_glb() {
 
     // Exactly ONE node carries a translation — the single root. Per-element
     // node.translation (the "all centre aligned" failure mode) is gone.
-    let translated: Vec<&Value> =
-        nodes.iter().filter(|n| n.get("translation").is_some()).collect();
+    let translated: Vec<&Value> = nodes
+        .iter()
+        .filter(|n| n.get("translation").is_some())
+        .collect();
     assert_eq!(translated.len(), 1, "only the root node is translated");
     let scene_nodes = json["scenes"][0]["nodes"].as_array().unwrap();
     assert_eq!(scene_nodes.len(), 1);
@@ -836,12 +996,18 @@ fn from_meshes_assembles_valid_glb() {
     let mut bmin = [f64::INFINITY; 3];
     let mut bmax = [f64::NEG_INFINITY; 3];
     for mesh in json["meshes"].as_array().unwrap() {
-        let pa = mesh["primitives"][0]["attributes"]["POSITION"].as_u64().unwrap() as usize;
+        let pa = mesh["primitives"][0]["attributes"]["POSITION"]
+            .as_u64()
+            .unwrap() as usize;
         for k in 0..3 {
             let lo = accs[pa]["min"][k].as_f64().unwrap();
             let hi = accs[pa]["max"][k].as_f64().unwrap();
-            if lo < bmin[k] { bmin[k] = lo; }
-            if hi > bmax[k] { bmax[k] = hi; }
+            if lo < bmin[k] {
+                bmin[k] = lo;
+            }
+            if hi > bmax[k] {
+                bmax[k] = hi;
+            }
         }
     }
     assert!(
@@ -857,17 +1023,34 @@ fn from_meshes_assembles_valid_glb() {
         let wmin = center[k] + bmin[k];
         assert!(wmin.abs() < 1.0, "world min ~0 on axis {k}: {wmin}");
         let expect = [1001.0, 2001.0, 3000.0][k];
-        assert!((wmax - expect).abs() < 1.0, "world max ~{expect} on axis {k}: {wmax}");
+        assert!(
+            (wmax - expect).abs() < 1.0,
+            "world max ~{expect} on axis {k}: {wmax}"
+        );
     }
 
     // Translucent material → BLEND.
-    assert!(json["materials"].as_array().unwrap().iter().any(|m| m["alphaMode"] == "BLEND"));
-    assert_eq!(bin.len(), json["buffers"][0]["byteLength"].as_u64().unwrap() as usize);
+    assert!(json["materials"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|m| m["alphaMode"] == "BLEND"));
+    assert_eq!(
+        bin.len(),
+        json["buffers"][0]["byteLength"].as_u64().unwrap() as usize
+    );
 
     // Lit (the call above passed lit = true): no unlit extension anywhere.
-    assert!(json.get("extensionsUsed").is_none(), "lit export omits extensionsUsed");
     assert!(
-        json["materials"].as_array().unwrap().iter().all(|m| m.get("extensions").is_none()),
+        json.get("extensionsUsed").is_none(),
+        "lit export omits extensionsUsed"
+    );
+    assert!(
+        json["materials"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|m| m.get("extensions").is_none()),
         "lit materials carry no extensions"
     );
 }
@@ -911,14 +1094,20 @@ fn try_from_meshes_rejects_counts_past_buffers() {
     let (_, stats) = export_glb_from_meshes(
         &positions, &normals, &indices, &vc, &ic, &color, &origin, &ids, false, true, false,
     );
-    assert_eq!(stats.meshes, 1, "infallible path drops the un-backed second mesh silently");
+    assert_eq!(
+        stats.meshes, 1,
+        "infallible path drops the un-backed second mesh silently"
+    );
 
     // Fail-closed: surfaces it as a typed error the caller can act on.
     let err = try_export_glb_from_meshes(
         &positions, &normals, &indices, &vc, &ic, &color, &origin, &ids, false, true, false,
     )
     .expect_err("counts past the buffers must be MalformedMeshInput");
-    assert!(matches!(err, ExportError::MalformedMeshInput { .. }), "got {err:?}");
+    assert!(
+        matches!(err, ExportError::MalformedMeshInput { .. }),
+        "got {err:?}"
+    );
     assert_eq!(err.code(), "MALFORMED_MESH_INPUT");
 }
 
@@ -937,14 +1126,30 @@ fn try_from_meshes_rejects_short_normals() {
         &positions, &normals, &indices, &vc, &ic, &color, &origin, &ids, false, true, false,
     )
     .expect_err("short normals must be MalformedMeshInput");
-    assert!(matches!(err, ExportError::MalformedMeshInput { .. }), "got {err:?}");
+    assert!(
+        matches!(err, ExportError::MalformedMeshInput { .. }),
+        "got {err:?}"
+    );
 
     // Empty normals is the degenerate case that would drop the WHOLE model.
     let err_empty = try_export_glb_from_meshes(
-        &positions, &[], &indices, &vc, &ic, &color, &origin, &ids, false, true, false,
+        &positions,
+        &[],
+        &indices,
+        &vc,
+        &ic,
+        &color,
+        &origin,
+        &ids,
+        false,
+        true,
+        false,
     )
     .expect_err("empty normals must be MalformedMeshInput");
-    assert!(matches!(err_empty, ExportError::MalformedMeshInput { .. }), "got {err_empty:?}");
+    assert!(
+        matches!(err_empty, ExportError::MalformedMeshInput { .. }),
+        "got {err_empty:?}"
+    );
 }
 
 #[test]
@@ -962,7 +1167,10 @@ fn try_from_meshes_rejects_index_counts_past_buffer() {
         &positions, &normals, &indices, &vc, &ic, &color, &origin, &ids, false, true, false,
     )
     .expect_err("index_counts past `indices` must be MalformedMeshInput");
-    assert!(matches!(err, ExportError::MalformedMeshInput { .. }), "got {err:?}");
+    assert!(
+        matches!(err, ExportError::MalformedMeshInput { .. }),
+        "got {err:?}"
+    );
 }
 
 #[test]
@@ -970,8 +1178,20 @@ fn export_is_byte_deterministic() {
     // Instancing groups by HashMap keys (rep colour buckets, material dedup);
     // emission order must be fixed so repeated exports are byte-identical.
     let content = fixture("ara3d/C20-Institute-Var-2.ifc");
-    let a = export_glb(&content, &GltfOptions { include_metadata: true, ..Default::default() });
-    let b = export_glb(&content, &GltfOptions { include_metadata: true, ..Default::default() });
+    let a = export_glb(
+        &content,
+        &GltfOptions {
+            include_metadata: true,
+            ..Default::default()
+        },
+    );
+    let b = export_glb(
+        &content,
+        &GltfOptions {
+            include_metadata: true,
+            ..Default::default()
+        },
+    );
     assert_eq!(a, b, "repeated GLB exports must be byte-identical");
 }
 
@@ -992,7 +1212,9 @@ fn nodes_carry_global_id_and_model_id() {
     let mut saw_global = false;
     let mut element_nodes = 0;
     for n in nodes {
-        let Some(extras) = n.get("extras") else { continue };
+        let Some(extras) = n.get("extras") else {
+            continue;
+        };
         if extras.get("expressId").is_none() {
             continue; // structural node (e.g. root), not an element
         }
@@ -1011,12 +1233,18 @@ fn nodes_carry_global_id_and_model_id() {
     assert!(saw_global, "at least one node carries an IFC GlobalId");
 
     // Without a model id, no `modelId` key is emitted.
-    let plain = GltfOptions { include_metadata: true, ..GltfOptions::default() };
+    let plain = GltfOptions {
+        include_metadata: true,
+        ..GltfOptions::default()
+    };
     let (glb2, _) = export_glb_with_stats(&content, &plain);
     let (json2, _) = parse_glb(&glb2);
     for n in json2["nodes"].as_array().unwrap() {
         if let Some(extras) = n.get("extras") {
-            assert!(extras.get("modelId").is_none(), "no modelId without a model id");
+            assert!(
+                extras.get("modelId").is_none(),
+                "no modelId without a model id"
+            );
         }
     }
 }
@@ -1040,7 +1268,9 @@ fn glb_nodes_have_export_rows_for_legacy_products() {
         "ifcopenshell/1032-curve.ifc",
         "issues/860_solid_stratum.ifc",
     ] {
-        let Some(content) = fixture_opt(rel) else { continue };
+        let Some(content) = fixture_opt(rel) else {
+            continue;
+        };
         found += 1;
         let opts = GltfOptions {
             include_metadata: true,
@@ -1055,7 +1285,9 @@ fn glb_nodes_have_export_rows_for_legacy_products() {
             .collect();
         let mut checked = 0;
         for n in json["nodes"].as_array().unwrap() {
-            let Some(extras) = n.get("extras") else { continue };
+            let Some(extras) = n.get("extras") else {
+                continue;
+            };
             let Some(eid) = extras.get("expressId").and_then(|v| v.as_u64()) else {
                 continue;
             };
@@ -1066,7 +1298,10 @@ fn glb_nodes_have_export_rows_for_legacy_products() {
                 extras.get("ifcType")
             );
         }
-        assert!(checked > 0, "{rel}: expected at least one meshed element node");
+        assert!(
+            checked > 0,
+            "{rel}: expected at least one meshed element node"
+        );
     }
     // Per the fixture_opt house rule the test is green when the corpus isn't
     // fetched — but say so, so a silent zero-coverage run (Greptile #1511) is
@@ -1090,7 +1325,10 @@ fn instanced_occurrences_reconstruct_world_positions() {
     // Z-up→Y-up conjugation, scene-center folding, and the f32 node matrix — on
     // genuinely rotated, placed occurrences, so any frame/RTC error surfaces.
     let content = fixture("ara3d/C20-Institute-Var-2.ifc");
-    let opts = GltfOptions { include_metadata: true, ..GltfOptions::default() };
+    let opts = GltfOptions {
+        include_metadata: true,
+        ..GltfOptions::default()
+    };
     let (glb, _stats) = export_glb_with_stats(&content, &opts);
     let (json, bin) = parse_glb(&glb);
 
@@ -1104,7 +1342,13 @@ fn instanced_occurrences_reconstruct_world_positions() {
         if !super::mesh_visible(m, &default_opts) || m.positions.len() < 9 {
             continue;
         }
-        crate::frame::to_yup_into(&mut yscratch, &m.positions, &m.normals, &m.indices, m.origin);
+        crate::frame::to_yup_into(
+            &mut yscratch,
+            &m.positions,
+            &m.normals,
+            &m.indices,
+            m.origin,
+        );
         let y = &yscratch;
         let verts: Vec<[f64; 3]> = y
             .positions
@@ -1134,7 +1378,11 @@ fn instanced_occurrences_reconstruct_world_positions() {
         .get("translation")
         .map(|v| {
             let a = v.as_array().unwrap();
-            [a[0].as_f64().unwrap(), a[1].as_f64().unwrap(), a[2].as_f64().unwrap()]
+            [
+                a[0].as_f64().unwrap(),
+                a[1].as_f64().unwrap(),
+                a[2].as_f64().unwrap(),
+            ]
         })
         .unwrap_or([0.0; 3]);
 
@@ -1165,18 +1413,27 @@ fn instanced_occurrences_reconstruct_world_positions() {
     for child in root["children"].as_array().unwrap() {
         let node = &nodes[child.as_u64().unwrap() as usize];
         // Instanced occurrences carry a node matrix; flat ones do not.
-        let Some(mv) = node.get("matrix") else { continue };
+        let Some(mv) = node.get("matrix") else {
+            continue;
+        };
         let express = node["extras"]["expressId"].as_u64().unwrap() as u32;
         if dup_ids.contains(&express) {
             continue;
         }
-        let Some(truth_verts) = truth.get(&express) else { continue };
+        let Some(truth_verts) = truth.get(&express) else {
+            continue;
+        };
         let locals = read_positions(node["mesh"].as_u64().unwrap() as usize);
         if locals.len() != truth_verts.len() {
             continue;
         }
         // Column-major 4x4: element (row r, col c) = m[c*4 + r].
-        let m: Vec<f64> = mv.as_array().unwrap().iter().map(|x| x.as_f64().unwrap()).collect();
+        let m: Vec<f64> = mv
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|x| x.as_f64().unwrap())
+            .collect();
         for (lv, t) in locals.iter().zip(truth_verts) {
             let (lx, ly, lz) = (lv[0] as f64, lv[1] as f64, lv[2] as f64);
             let world = [
@@ -1190,9 +1447,15 @@ fn instanced_occurrences_reconstruct_world_positions() {
         }
         checked += 1;
     }
-    assert!(checked > 50, "expected many instanced occurrences to verify, got {checked}");
+    assert!(
+        checked > 50,
+        "expected many instanced occurrences to verify, got {checked}"
+    );
     // f32 vertex/matrix precision at building scale: well under a millimetre.
-    assert!(max_err < 1e-3, "instanced world reconstruction error {max_err} m too large");
+    assert!(
+        max_err < 1e-3,
+        "instanced world reconstruction error {max_err} m too large"
+    );
 }
 
 #[test]
@@ -1200,7 +1463,9 @@ fn unlit_option_emits_khr_materials_unlit() {
     // #1321: lit = false reproduces the historical flat material — every
     // material tagged KHR_materials_unlit and the extension declared globally.
     let positions: Vec<f32> = vec![0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0];
-    let normals: Vec<f32> = std::iter::repeat_n([0.0f32, 0.0, 1.0], 4).flatten().collect();
+    let normals: Vec<f32> = std::iter::repeat_n([0.0f32, 0.0, 1.0], 4)
+        .flatten()
+        .collect();
     let indices: Vec<u32> = vec![0, 1, 2, 0, 2, 3];
     let (glb, _) = export_glb_from_meshes(
         &positions,
@@ -1218,9 +1483,11 @@ fn unlit_option_emits_khr_materials_unlit() {
     let (json, _) = parse_glb(&glb);
     assert_eq!(json["extensionsUsed"][0], "KHR_materials_unlit");
     assert!(
-        json["materials"].as_array().unwrap().iter().all(|m| m["extensions"]
-            ["KHR_materials_unlit"]
-            .is_object()),
+        json["materials"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|m| m["extensions"]["KHR_materials_unlit"].is_object()),
         "unlit materials carry the KHR_materials_unlit extension"
     );
 }
@@ -1231,7 +1498,9 @@ fn emissive_option_sets_emissive_factor_to_base_colour() {
     // so Google Earth (no ambient/IBL, hard sun) shows the true colour instead of
     // a near-black shaded surface. emissiveFactor is core glTF 2.0 — no extension.
     let positions: Vec<f32> = vec![0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0];
-    let normals: Vec<f32> = std::iter::repeat_n([0.0f32, 0.0, 1.0], 4).flatten().collect();
+    let normals: Vec<f32> = std::iter::repeat_n([0.0f32, 0.0, 1.0], 4)
+        .flatten()
+        .collect();
     let indices: Vec<u32> = vec![0, 1, 2, 0, 2, 3];
     let (glb, _) = export_glb_from_meshes(
         &positions,
@@ -1254,10 +1523,18 @@ fn emissive_option_sets_emissive_factor_to_base_colour() {
     assert!((ef[0].as_f64().unwrap() - 0.25).abs() < 1e-6);
     assert!((ef[1].as_f64().unwrap() - 0.5).abs() < 1e-6);
     assert!((ef[2].as_f64().unwrap() - 0.75).abs() < 1e-6);
-    let bc = m["pbrMetallicRoughness"]["baseColorFactor"].as_array().unwrap();
-    assert!((bc[0].as_f64().unwrap() - 0.25).abs() < 1e-6, "base colour kept (no regression)");
+    let bc = m["pbrMetallicRoughness"]["baseColorFactor"]
+        .as_array()
+        .unwrap();
+    assert!(
+        (bc[0].as_f64().unwrap() - 0.25).abs() < 1e-6,
+        "base colour kept (no regression)"
+    );
     // emissive is core glTF: no extension is declared for it.
-    assert!(json.get("extensionsUsed").is_none(), "emissive needs no extension");
+    assert!(
+        json.get("extensionsUsed").is_none(),
+        "emissive needs no extension"
+    );
 }
 
 #[test]
@@ -1267,7 +1544,9 @@ fn emissive_takes_precedence_over_unlit() {
     // AND emissive = true), emissive must win — never emit a material that
     // declares unlit alongside a non-zero emissiveFactor (a spec violation).
     let positions: Vec<f32> = vec![0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0];
-    let normals: Vec<f32> = std::iter::repeat_n([0.0f32, 0.0, 1.0], 4).flatten().collect();
+    let normals: Vec<f32> = std::iter::repeat_n([0.0f32, 0.0, 1.0], 4)
+        .flatten()
+        .collect();
     let indices: Vec<u32> = vec![0, 1, 2, 0, 2, 3];
     let (glb, _) = export_glb_from_meshes(
         &positions,
@@ -1283,13 +1562,24 @@ fn emissive_takes_precedence_over_unlit() {
         true,  // …but emissive = true wins.
     );
     let (json, _) = parse_glb(&glb);
-    assert!(json.get("extensionsUsed").is_none(), "emissive suppresses the unlit extension");
     assert!(
-        json["materials"].as_array().unwrap().iter().all(|m| m.get("extensions").is_none()),
+        json.get("extensionsUsed").is_none(),
+        "emissive suppresses the unlit extension"
+    );
+    assert!(
+        json["materials"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|m| m.get("extensions").is_none()),
         "no material carries KHR_materials_unlit when emissive is on"
     );
     assert!(
-        json["materials"].as_array().unwrap().iter().all(|m| m["emissiveFactor"].is_array()),
+        json["materials"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|m| m["emissiveFactor"].is_array()),
         "materials carry emissiveFactor"
     );
 }
@@ -1298,7 +1588,10 @@ fn emissive_takes_precedence_over_unlit() {
 fn metadata_and_isolation() {
     let with_meta = export_glb_with_stats(
         &fixture("ara3d/duplex.ifc"),
-        &GltfOptions { include_metadata: true, ..GltfOptions::default() },
+        &GltfOptions {
+            include_metadata: true,
+            ..GltfOptions::default()
+        },
     )
     .0;
     let (json, _) = parse_glb(&with_meta);
@@ -1315,7 +1608,10 @@ fn metadata_and_isolation() {
         .unwrap();
     let iso = export_glb_with_stats(
         &fixture("ara3d/duplex.ifc"),
-        &GltfOptions { isolated: vec![some_id], ..GltfOptions::default() },
+        &GltfOptions {
+            isolated: vec![some_id],
+            ..GltfOptions::default()
+        },
     )
     .1;
     assert!(iso.meshes >= 1 && iso.meshes <= full.meshes);
@@ -1341,9 +1637,18 @@ fn mesh_visible_hidden_excludes_only_the_listed_express_id() {
     // express ids it names must be dropped, everything else stays visible.
     let hidden_mesh = synthetic_mesh(42, "IfcWall");
     let other_mesh = synthetic_mesh(43, "IfcWall");
-    let opts = GltfOptions { hidden: vec![42], ..GltfOptions::default() };
-    assert!(!mesh_visible(&hidden_mesh, &opts), "express id 42 is in `hidden` and must be excluded");
-    assert!(mesh_visible(&other_mesh, &opts), "express id 43 is not in `hidden` and must stay visible");
+    let opts = GltfOptions {
+        hidden: vec![42],
+        ..GltfOptions::default()
+    };
+    assert!(
+        !mesh_visible(&hidden_mesh, &opts),
+        "express id 42 is in `hidden` and must be excluded"
+    );
+    assert!(
+        mesh_visible(&other_mesh, &opts),
+        "express id 43 is not in `hidden` and must stay visible"
+    );
 
     // With an empty hidden list both are visible again (no accidental default-hide).
     let none_hidden = GltfOptions::default();
@@ -1358,9 +1663,18 @@ fn mesh_visible_hidden_types_excludes_the_whole_class() {
     // meshes of other types are unaffected.
     let wall = synthetic_mesh(1, "IfcWall");
     let slab = synthetic_mesh(2, "IfcSlab");
-    let opts = GltfOptions { hidden_types: vec!["IfcWall".to_string()], ..GltfOptions::default() };
-    assert!(!mesh_visible(&wall, &opts), "IfcWall is in `hidden_types` and must be excluded");
-    assert!(mesh_visible(&slab, &opts), "IfcSlab is not in `hidden_types` and must stay visible");
+    let opts = GltfOptions {
+        hidden_types: vec!["IfcWall".to_string()],
+        ..GltfOptions::default()
+    };
+    assert!(
+        !mesh_visible(&wall, &opts),
+        "IfcWall is in `hidden_types` and must be excluded"
+    );
+    assert!(
+        mesh_visible(&slab, &opts),
+        "IfcSlab is not in `hidden_types` and must stay visible"
+    );
 
     // A different express id of the same hidden type is still excluded (the
     // filter is class-level, not per-instance).
@@ -1399,20 +1713,33 @@ fn try_export_glb_fails_closed_on_geometryless_model() {
 /// wasm/TS boundary can match on (mirroring NO_RENDER_GEOMETRY).
 #[test]
 fn too_large_error_code_and_message() {
-    let err = ExportError::TooLarge { bytes: 5_000_000_000 };
+    let err = ExportError::TooLarge {
+        bytes: 5_000_000_000,
+    };
     assert_eq!(err.code(), "TOO_LARGE");
-    assert!(err.to_string().contains("5000000000"), "message carries the byte size");
-    assert!(err.to_string().starts_with("TOO_LARGE"), "code prefixes the message");
+    assert!(
+        err.to_string().contains("5000000000"),
+        "message carries the byte size"
+    );
+    assert!(
+        err.to_string().starts_with("TOO_LARGE"),
+        "code prefixes the message"
+    );
 }
 
 #[test]
 fn try_export_glb_matches_fail_open_path_when_nonempty() {
-    let Some(content) = fixture_opt("ifcopenshell/1019-column.ifc") else { return };
+    let Some(content) = fixture_opt("ifcopenshell/1019-column.ifc") else {
+        return;
+    };
     let (glb, stats) =
         try_export_glb_with_stats(&content, &GltfOptions::default()).expect("has geometry");
     assert!(stats.meshes >= 1);
     let (baseline, _) = export_glb_with_stats(&content, &GltfOptions::default());
-    assert_eq!(glb, baseline, "try_ path must be byte-identical to export_glb");
+    assert_eq!(
+        glb, baseline,
+        "try_ path must be byte-identical to export_glb"
+    );
 }
 
 /// Sum of world triangles: every node instance of a mesh counts its index
@@ -1422,7 +1749,9 @@ fn world_triangles(json: &Value) -> u64 {
     let nodes = json["nodes"].as_array().unwrap_or(&empty);
     let mut tris = 0u64;
     for node in nodes {
-        let Some(mi) = node["mesh"].as_u64() else { continue };
+        let Some(mi) = node["mesh"].as_u64() else {
+            continue;
+        };
         let prim = &json["meshes"][mi as usize]["primitives"][0];
         let ai = prim["indices"].as_u64().expect("indices accessor") as usize;
         tris += json["accessors"][ai]["count"].as_u64().expect("count") / 3;
@@ -1435,13 +1764,24 @@ fn streaming_bounded_is_byte_identical_on_flat_models() {
     // Models with no instanceable groups exercise exactly the code the two
     // assemblers share (flat emission + content dedup); their output must be
     // byte-for-byte identical, JSON and BIN.
-    for rel in ["ifcopenshell/1019-column.ifc", "ifcopenshell/1030-sphere.ifc"] {
-        let Some(content) = fixture_opt(rel) else { continue };
-        let opts = GltfOptions { include_metadata: true, ..GltfOptions::default() };
+    for rel in [
+        "ifcopenshell/1019-column.ifc",
+        "ifcopenshell/1030-sphere.ifc",
+    ] {
+        let Some(content) = fixture_opt(rel) else {
+            continue;
+        };
+        let opts = GltfOptions {
+            include_metadata: true,
+            ..GltfOptions::default()
+        };
         let (in_memory, mem_stats) = export_glb_from_result(process_geometry(&content), &opts);
         let (streamed, stream_stats) = export_glb_streaming_bounded(&content, &opts);
         assert_eq!(mem_stats.meshes, stream_stats.meshes, "{rel}: mesh stats");
-        assert_eq!(in_memory, streamed, "{rel}: bounded assembler must be byte-identical");
+        assert_eq!(
+            in_memory, streamed,
+            "{rel}: bounded assembler must be byte-identical"
+        );
     }
 }
 
@@ -1450,7 +1790,9 @@ fn streaming_bounded_preserves_world_geometry_on_instanced_model() {
     // duplex has rep-identity groups the streaming path deliberately skips
     // (bounded memory cannot hold every occurrence). World geometry must be
     // identical anyway: same element nodes, same total placed triangles.
-    let Some(content) = fixture_opt("ara3d/duplex.ifc") else { return };
+    let Some(content) = fixture_opt("ara3d/duplex.ifc") else {
+        return;
+    };
     let opts = GltfOptions::default();
     let (in_memory, _) = export_glb_from_result(process_geometry(&content), &opts);
     let (streamed, stream_stats) = export_glb_streaming_bounded(&content, &opts);
@@ -1477,13 +1819,22 @@ fn streaming_bounded_preserves_world_geometry_on_instanced_model() {
         .sum();
     // pos/norm are 12-byte and idx 4-byte multiples, so the BIN needs no padding
     // and must be exactly the three declared runs.
-    assert_eq!(declared as usize, str_bin.len(), "BIN length matches declared runs");
+    assert_eq!(
+        declared as usize,
+        str_bin.len(),
+        "BIN length matches declared runs"
+    );
 }
 
 #[test]
 fn streaming_bounded_quantized_is_byte_identical_on_flat_models() {
-    for rel in ["ifcopenshell/1019-column.ifc", "ifcopenshell/1030-sphere.ifc"] {
-        let Some(content) = fixture_opt(rel) else { continue };
+    for rel in [
+        "ifcopenshell/1019-column.ifc",
+        "ifcopenshell/1030-sphere.ifc",
+    ] {
+        let Some(content) = fixture_opt(rel) else {
+            continue;
+        };
         let opts = GltfOptions {
             quantize: true,
             include_metadata: true,
@@ -1492,14 +1843,22 @@ fn streaming_bounded_quantized_is_byte_identical_on_flat_models() {
         let (in_memory, mem_stats) = export_glb_from_result(process_geometry(&content), &opts);
         let (streamed, stream_stats) = export_glb_streaming_bounded(&content, &opts);
         assert_eq!(mem_stats.meshes, stream_stats.meshes, "{rel}: mesh stats");
-        assert_eq!(in_memory, streamed, "{rel}: quantized bounded must be byte-identical");
+        assert_eq!(
+            in_memory, streamed,
+            "{rel}: quantized bounded must be byte-identical"
+        );
     }
 }
 
 #[test]
 fn streaming_bounded_quantized_preserves_world_geometry_on_instanced_model() {
-    let Some(content) = fixture_opt("ara3d/duplex.ifc") else { return };
-    let opts = GltfOptions { quantize: true, ..GltfOptions::default() };
+    let Some(content) = fixture_opt("ara3d/duplex.ifc") else {
+        return;
+    };
+    let opts = GltfOptions {
+        quantize: true,
+        ..GltfOptions::default()
+    };
     let (in_memory, _) = export_glb_from_result(process_geometry(&content), &opts);
     let (streamed, stream_stats) = export_glb_streaming_bounded(&content, &opts);
     assert!(stream_stats.meshes > 0);
@@ -1526,5 +1885,8 @@ fn streaming_bounded_matches_in_memory_on_empty_model() {
     let (in_memory, _) = export_glb_from_result(process_geometry(empty), &opts);
     let (streamed, stats) = export_glb_streaming_bounded(empty, &opts);
     assert_eq!(stats.meshes, 0);
-    assert_eq!(in_memory, streamed, "empty-model GLB must be byte-identical");
+    assert_eq!(
+        in_memory, streamed,
+        "empty-model GLB must be byte-identical"
+    );
 }

--- a/rust/export/src/hbjson.rs
+++ b/rust/export/src/hbjson.rs
@@ -17,7 +17,10 @@ pub struct Face3D {
 
 impl Face3D {
     pub fn new(boundary: Vec<[f64; 3]>) -> Self {
-        Self { ty: "Face3D", boundary }
+        Self {
+            ty: "Face3D",
+            boundary,
+        }
     }
 }
 
@@ -33,11 +36,17 @@ pub struct BoundaryCondition {
 
 impl BoundaryCondition {
     pub fn new(ty: &'static str) -> Self {
-        Self { ty, boundary_condition_objects: None }
+        Self {
+            ty,
+            boundary_condition_objects: None,
+        }
     }
     /// A `Surface` boundary condition pointing at the adjacent `[face, room]`.
     pub fn surface(adjacent_face: String, adjacent_room: String) -> Self {
-        Self { ty: "Surface", boundary_condition_objects: Some(vec![adjacent_face, adjacent_room]) }
+        Self {
+            ty: "Surface",
+            boundary_condition_objects: Some(vec![adjacent_face, adjacent_room]),
+        }
     }
 }
 
@@ -66,7 +75,13 @@ pub struct EnergyMaterial {
 }
 
 impl EnergyMaterial {
-    pub fn new(identifier: String, thickness: f64, conductivity: f64, density: f64, specific_heat: f64) -> Self {
+    pub fn new(
+        identifier: String,
+        thickness: f64,
+        conductivity: f64,
+        density: f64,
+        specific_heat: f64,
+    ) -> Self {
         Self {
             ty: "EnergyMaterial",
             identifier,
@@ -93,7 +108,11 @@ pub struct OpaqueConstruction {
 
 impl OpaqueConstruction {
     pub fn new(identifier: String, materials: Vec<String>) -> Self {
-        Self { ty: "OpaqueConstructionAbridged", identifier, materials }
+        Self {
+            ty: "OpaqueConstructionAbridged",
+            identifier,
+            materials,
+        }
     }
 }
 
@@ -151,7 +170,9 @@ impl Aperture {
             ty: "Aperture",
             identifier,
             display_name,
-            properties: TypedProps { ty: "AperturePropertiesAbridged" },
+            properties: TypedProps {
+                ty: "AperturePropertiesAbridged",
+            },
             geometry,
             is_operable,
             boundary_condition: BoundaryCondition::new("Outdoors"),
@@ -179,7 +200,9 @@ impl Door {
             ty: "Door",
             identifier,
             display_name,
-            properties: TypedProps { ty: "DoorPropertiesAbridged" },
+            properties: TypedProps {
+                ty: "DoorPropertiesAbridged",
+            },
             geometry,
             is_glass,
             boundary_condition: BoundaryCondition::new("Outdoors"),
@@ -214,8 +237,14 @@ impl ShadeMesh {
             ty: "ShadeMesh",
             identifier,
             display_name,
-            properties: TypedProps { ty: "ShadeMeshPropertiesAbridged" },
-            geometry: Mesh3D { ty: "Mesh3D", vertices, faces },
+            properties: TypedProps {
+                ty: "ShadeMeshPropertiesAbridged",
+            },
+            geometry: Mesh3D {
+                ty: "Mesh3D",
+                vertices,
+                faces,
+            },
         }
     }
 }
@@ -238,13 +267,21 @@ pub struct Face {
 }
 
 impl Face {
-    pub fn new(identifier: String, geometry: Face3D, face_type: &'static str, bc: &'static str) -> Self {
+    pub fn new(
+        identifier: String,
+        geometry: Face3D,
+        face_type: &'static str,
+        bc: &'static str,
+    ) -> Self {
         let display_name = identifier.clone();
         Self {
             ty: "Face",
             identifier,
             display_name,
-            properties: FaceProperties { ty: "FacePropertiesAbridged", energy: None },
+            properties: FaceProperties {
+                ty: "FacePropertiesAbridged",
+                energy: None,
+            },
             geometry,
             face_type,
             boundary_condition: BoundaryCondition::new(bc),
@@ -289,7 +326,9 @@ impl Room {
             ty: "Room",
             identifier,
             display_name,
-            properties: TypedProps { ty: "RoomPropertiesAbridged" },
+            properties: TypedProps {
+                ty: "RoomPropertiesAbridged",
+            },
             faces,
         }
     }
@@ -325,7 +364,10 @@ impl Model {
             identifier: identifier.to_string(),
             display_name: identifier.to_string(),
             units: "Meters",
-            properties: ModelProperties { ty: "ModelProperties", energy },
+            properties: ModelProperties {
+                ty: "ModelProperties",
+                energy,
+            },
             rooms,
             shade_meshes,
             tolerance,

--- a/rust/export/src/ifc5.rs
+++ b/rust/export/src/ifc5.rs
@@ -20,9 +20,23 @@ const IMPORT_PROP: &str = "https://ifcx.dev/@standards.buildingsmart.org/ifc/cor
 /// Property names with official IFC5 schema definitions (prop@v5a.ifcx). IFC4 props
 /// outside this set are dropped — the viewer flags "Missing schema" otherwise.
 const KNOWN_PROPS: &[&str] = &[
-    "UsageType", "TypeName", "IsExternal", "RefElevation", "ElevationOfRefHeight",
-    "ElevationOfTerrain", "NumberOfStoreys", "Height", "Width", "Length", "Depth",
-    "Volume", "NetVolume", "NetArea", "NetSideArea", "CrossSectionArea", "Station",
+    "UsageType",
+    "TypeName",
+    "IsExternal",
+    "RefElevation",
+    "ElevationOfRefHeight",
+    "ElevationOfTerrain",
+    "NumberOfStoreys",
+    "Height",
+    "Width",
+    "Length",
+    "Depth",
+    "Volume",
+    "NetVolume",
+    "NetArea",
+    "NetSideArea",
+    "CrossSectionArea",
+    "Station",
 ];
 
 /// Options for IFC5/IFCX export.
@@ -50,15 +64,32 @@ fn uuid_from_id(id: u32) -> String {
     let a = (id as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15) ^ 0xABCD_EF01_2345_6789;
     let b = (id as u64).wrapping_mul(0xC2B2_AE3D_27D4_EB4F) ^ 0x0F1E_2D3C_4B5A_6978;
     let s = format!("{a:016x}{b:016x}");
-    format!("{}-{}-{}-{}-{}", &s[0..8], &s[8..12], &s[12..16], &s[16..20], &s[20..32])
+    format!(
+        "{}-{}-{}-{}-{}",
+        &s[0..8],
+        &s[8..12],
+        &s[12..16],
+        &s[16..20],
+        &s[20..32]
+    )
 }
 
 /// Sanitize a USD prim name (the keys in a node's `children` dict).
 fn prim_name(name: &str, fallback_type: &str, id: u32) -> String {
-    let base = if name.trim().is_empty() { fallback_type } else { name };
+    let base = if name.trim().is_empty() {
+        fallback_type
+    } else {
+        name
+    };
     let mut out: String = base
         .chars()
-        .map(|c| if c.is_ascii_alphanumeric() || c == '_' { c } else { '_' })
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
         .collect();
     if out.is_empty() || !out.chars().next().unwrap().is_ascii_alphabetic() {
         out = format!("p_{out}");
@@ -90,7 +121,11 @@ pub(crate) fn project_name(content: &[u8], project_id: u32) -> String {
         .unwrap_or_else(|| "Project".to_string())
 }
 
-fn build_node_attributes(row: Option<&EntityRow>, ifc_type: &str, opts: &Ifc5Options) -> Map<String, Value> {
+fn build_node_attributes(
+    row: Option<&EntityRow>,
+    ifc_type: &str,
+    opts: &Ifc5Options,
+) -> Map<String, Value> {
     let mut attrs = Map::new();
     attrs.insert("bsi::ifc::class".into(), json!({ "code": ifc_type }));
     if let Some(r) = row {
@@ -115,14 +150,18 @@ fn build_node_attributes(row: Option<&EntityRow>, ifc_type: &str, opts: &Ifc5Opt
 /// Export the model in `content` as an IFCX (IFC5) document string.
 pub fn export_ifc5(content: &[u8], opts: &Ifc5Options) -> String {
     let model = build_export_model(content);
-    let by_id: HashMap<u32, &EntityRow> = model.entities.iter().map(|e| (e.express_id, e)).collect();
+    let by_id: HashMap<u32, &EntityRow> =
+        model.entities.iter().map(|e| (e.express_id, e)).collect();
     let (children, project) = spatial_children(content);
 
     // Names/types for prim-name + class. Products come from the model; the project
     // is decoded separately.
     let mut name_of: HashMap<u32, (String, String)> = HashMap::new(); // id -> (name, type)
     for e in &model.entities {
-        name_of.insert(e.express_id, (e.name.clone().unwrap_or_default(), e.ifc_type.clone()));
+        name_of.insert(
+            e.express_id,
+            (e.name.clone().unwrap_or_default(), e.ifc_type.clone()),
+        );
     }
 
     // Determine which nodes to emit: the project + everything reachable through
@@ -219,13 +258,20 @@ mod tests {
         assert_eq!(v["imports"][0]["uri"], IMPORT_CORE);
 
         let data = v["data"].as_array().expect("data array");
-        assert!(data.len() > 20, "expected a populated node graph, got {}", data.len());
+        assert!(
+            data.len() > 20,
+            "expected a populated node graph, got {}",
+            data.len()
+        );
 
         // Every node has a UUID path; classes are bsi::ifc::*.
         let paths: HashSet<&str> = data.iter().filter_map(|n| n["path"].as_str()).collect();
         assert_eq!(paths.len(), data.len(), "paths are unique");
         for n in data {
-            assert!(n["path"].as_str().unwrap().contains('-'), "uuid-shaped path");
+            assert!(
+                n["path"].as_str().unwrap().contains('-'),
+                "uuid-shaped path"
+            );
         }
 
         // A project root exists and its class is IfcProject.
@@ -238,7 +284,10 @@ mod tests {
         for n in data {
             if let Some(ch) = n["children"].as_object() {
                 for (_k, cpath) in ch {
-                    assert!(paths.contains(cpath.as_str().unwrap()), "child path resolves");
+                    assert!(
+                        paths.contains(cpath.as_str().unwrap()),
+                        "child path resolves"
+                    );
                 }
             }
         }
@@ -246,7 +295,8 @@ mod tests {
         // At least one node carries a known IFC5 property in the bsi::ifc::prop:: namespace.
         let has_prop = data.iter().any(|n| {
             n["attributes"].as_object().is_some_and(|a| {
-                a.keys().any(|k| k.starts_with("bsi::ifc::prop::") && k != "bsi::ifc::prop::Name")
+                a.keys()
+                    .any(|k| k.starts_with("bsi::ifc::prop::") && k != "bsi::ifc::prop::Name")
             })
         });
         assert!(has_prop, "expected a typed IFC5 property somewhere");

--- a/rust/export/src/json.rs
+++ b/rust/export/src/json.rs
@@ -19,18 +19,32 @@ pub struct JsonOptions {
 
 impl Default for JsonOptions {
     fn default() -> Self {
-        Self { pretty: false, include_properties: true, include_quantities: true }
+        Self {
+            pretty: false,
+            include_properties: true,
+            include_quantities: true,
+        }
     }
 }
 
 /// Coerce a rendered property value to a typed JSON value using its IFC type tag.
 pub(crate) fn typed_value(p: &PropValue) -> Value {
     match p.value_type.as_str() {
-        "IFCREAL" | "IFCINTEGER" | "IFCNUMBER" | "IFCLENGTHMEASURE" | "IFCAREAMEASURE"
-        | "IFCVOLUMEMEASURE" | "IFCPOSITIVELENGTHMEASURE" | "IFCCOUNTMEASURE"
-        | "IFCMASSMEASURE" | "IFCRATIOMEASURE" | "IFCNORMALISEDRATIOMEASURE" => {
-            p.value.parse::<f64>().map(|n| json!(n)).unwrap_or_else(|_| json!(p.value))
-        }
+        "IFCREAL"
+        | "IFCINTEGER"
+        | "IFCNUMBER"
+        | "IFCLENGTHMEASURE"
+        | "IFCAREAMEASURE"
+        | "IFCVOLUMEMEASURE"
+        | "IFCPOSITIVELENGTHMEASURE"
+        | "IFCCOUNTMEASURE"
+        | "IFCMASSMEASURE"
+        | "IFCRATIOMEASURE"
+        | "IFCNORMALISEDRATIOMEASURE" => p
+            .value
+            .parse::<f64>()
+            .map(|n| json!(n))
+            .unwrap_or_else(|_| json!(p.value)),
         "IFCBOOLEAN" | "IFCLOGICAL" => match p.value.as_str() {
             "true" => json!(true),
             "false" => json!(false),
@@ -96,7 +110,11 @@ fn entity_to_json(e: &EntityRow, opts: &JsonOptions) -> Value {
 /// Export the model as a JSON array string.
 pub fn export_json(content: &[u8], opts: &JsonOptions) -> String {
     let model = build_export_model(content);
-    let arr: Vec<Value> = model.entities.iter().map(|e| entity_to_json(e, opts)).collect();
+    let arr: Vec<Value> = model
+        .entities
+        .iter()
+        .map(|e| entity_to_json(e, opts))
+        .collect();
     let value = Value::Array(arr);
     if opts.pretty {
         serde_json::to_string_pretty(&value).expect("json serializes")
@@ -130,11 +148,16 @@ mod tests {
             e["propertySets"].as_array().is_some_and(|ps| {
                 ps.iter().any(|p| {
                     p["properties"].as_array().is_some_and(|props| {
-                        props.iter().any(|pr| pr["value"].is_number() || pr["value"].is_boolean())
+                        props
+                            .iter()
+                            .any(|pr| pr["value"].is_number() || pr["value"].is_boolean())
                     })
                 })
             })
         });
-        assert!(has_typed_number, "expected at least one typed (number/bool) property value");
+        assert!(
+            has_typed_number,
+            "expected at least one typed (number/bool) property value"
+        );
     }
 }

--- a/rust/export/src/jsonld.rs
+++ b/rust/export/src/jsonld.rs
@@ -158,13 +158,23 @@ mod tests {
             .map(|n| n["ifc:expressId"].as_u64().unwrap() as u32)
             .collect();
 
-        let opts = JsonLdOptions { included: pick.clone(), ..Default::default() };
+        let opts = JsonLdOptions {
+            included: pick.clone(),
+            ..Default::default()
+        };
         let filtered: Value = serde_json::from_str(&export_jsonld(&bytes, &opts)).unwrap();
         let graph = filtered["@graph"].as_array().unwrap();
-        assert_eq!(graph.len(), 2, "isolated export emits only the requested ids");
+        assert_eq!(
+            graph.len(),
+            2,
+            "isolated export emits only the requested ids"
+        );
         for n in graph {
             let id = n["ifc:expressId"].as_u64().unwrap() as u32;
-            assert!(pick.contains(&id), "unexpected entity {id} in filtered graph");
+            assert!(
+                pick.contains(&id),
+                "unexpected entity {id} in filtered graph"
+            );
         }
     }
 }

--- a/rust/export/src/kmz.rs
+++ b/rust/export/src/kmz.rs
@@ -196,7 +196,11 @@ const DOS_DATE: u16 = 0x0021;
 
 impl StoredZip {
     fn new() -> Self {
-        StoredZip { out: Vec::new(), central: Vec::new(), count: 0 }
+        StoredZip {
+            out: Vec::new(),
+            central: Vec::new(),
+            count: 0,
+        }
     }
 
     fn add(&mut self, name: &str, data: &[u8]) {
@@ -215,13 +219,15 @@ impl StoredZip {
         self.out.extend_from_slice(&crc.to_le_bytes());
         self.out.extend_from_slice(&size.to_le_bytes()); // compressed size
         self.out.extend_from_slice(&size.to_le_bytes()); // uncompressed size
-        self.out.extend_from_slice(&(name_bytes.len() as u16).to_le_bytes());
+        self.out
+            .extend_from_slice(&(name_bytes.len() as u16).to_le_bytes());
         self.out.extend_from_slice(&0u16.to_le_bytes()); // extra length
         self.out.extend_from_slice(name_bytes);
         self.out.extend_from_slice(data);
 
         // Central directory record.
-        self.central.extend_from_slice(&0x0201_4b50u32.to_le_bytes());
+        self.central
+            .extend_from_slice(&0x0201_4b50u32.to_le_bytes());
         self.central.extend_from_slice(&20u16.to_le_bytes()); // version made by
         self.central.extend_from_slice(&20u16.to_le_bytes()); // version needed
         self.central.extend_from_slice(&0u16.to_le_bytes()); // flags
@@ -231,7 +237,8 @@ impl StoredZip {
         self.central.extend_from_slice(&crc.to_le_bytes());
         self.central.extend_from_slice(&size.to_le_bytes());
         self.central.extend_from_slice(&size.to_le_bytes());
-        self.central.extend_from_slice(&(name_bytes.len() as u16).to_le_bytes());
+        self.central
+            .extend_from_slice(&(name_bytes.len() as u16).to_le_bytes());
         self.central.extend_from_slice(&0u16.to_le_bytes()); // extra length
         self.central.extend_from_slice(&0u16.to_le_bytes()); // comment length
         self.central.extend_from_slice(&0u16.to_le_bytes()); // disk number start
@@ -303,7 +310,11 @@ mod tests {
             x_axis_ordinate: Some(0.0),
             name: Some("Bldg <A>".to_string()),
         };
-        let kml = build_kml(&opts, ifc_angle_to_kml_heading(opts.x_axis_abscissa, opts.x_axis_ordinate), "model.dae");
+        let kml = build_kml(
+            &opts,
+            ifc_angle_to_kml_heading(opts.x_axis_abscissa, opts.x_axis_ordinate),
+            "model.dae",
+        );
         assert!(kml.contains("<latitude>47.5</latitude>"));
         assert!(kml.contains("<longitude>8.5</longitude>"));
         assert!(kml.contains("<altitude>412</altitude>"));
@@ -351,12 +362,18 @@ mod tests {
         // Starts with a local file header, ends with the EOCD signature.
         assert_eq!(&kmz[0..4], &0x0403_4b50u32.to_le_bytes());
         let eocd = &0x0605_4b50u32.to_le_bytes();
-        assert!(kmz.windows(4).any(|w| w == eocd), "has end-of-central-directory");
+        assert!(
+            kmz.windows(4).any(|w| w == eocd),
+            "has end-of-central-directory"
+        );
 
         // Both entry names + the GLB bytes are present (stored, uncompressed).
         assert!(kmz.windows(7).any(|w| w == b"doc.kml"));
         assert!(kmz.windows(9).any(|w| w == b"model.glb"));
-        assert!(kmz.windows(glb.len()).any(|w| w == glb), "GLB stored verbatim");
+        assert!(
+            kmz.windows(glb.len()).any(|w| w == glb),
+            "GLB stored verbatim"
+        );
     }
 
     #[test]
@@ -364,7 +381,9 @@ mod tests {
         // #1427: the working path embeds a COLLADA model (model.dae) — the format
         // Google Earth's <Model> actually loads — not a glTF GLB.
         let positions = vec![0.0f32, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 1.0];
-        let normals: Vec<f32> = std::iter::repeat_n([0.0f32, 1.0, 0.0], 3).flatten().collect();
+        let normals: Vec<f32> = std::iter::repeat_n([0.0f32, 1.0, 0.0], 3)
+            .flatten()
+            .collect();
         let opts = KmzOptions {
             latitude: 52.15,
             longitude: 5.38,
@@ -386,7 +405,10 @@ mod tests {
         );
         // Stored ZIP holding doc.kml + model.dae, KML referencing the .dae.
         assert!(kmz.windows(7).any(|w| w == b"doc.kml"));
-        assert!(kmz.windows(9).any(|w| w == b"model.dae"), "embeds model.dae");
+        assert!(
+            kmz.windows(9).any(|w| w == b"model.dae"),
+            "embeds model.dae"
+        );
         assert!(
             kmz.windows(8).any(|w| w == b"COLLADA "),
             "the .dae is COLLADA, not glTF"

--- a/rust/export/src/lib.rs
+++ b/rust/export/src/lib.rs
@@ -23,10 +23,10 @@ mod kmz;
 mod merged;
 mod model;
 mod obj;
-mod relationships;
 mod openings;
 #[cfg(feature = "parquet-bos")]
 mod parquet_bos;
+mod relationships;
 mod rooms;
 mod schema_convert;
 mod shades;
@@ -60,11 +60,10 @@ pub use ifc_lite_core::{AttributeValue, DecodedEntity, IfcType};
 // Re-exported alongside the model so a consumer of `EntityRow` attribute values
 // can interpret them: those values are in the file's own units, unlike the
 // geometry exporters' output, which is normalised to metres.
-pub use ifc_lite_processing::prepass::UnitScales;
 pub use ifc5::{export_ifc5, Ifc5Options};
+pub use ifc_lite_processing::prepass::UnitScales;
 // Spatial and type relationships, which `EntityRow` cannot carry because IFC
 // models them as separate entities that are not products.
-pub use relationships::{relationships, Relationships};
 pub use json::{export_json, JsonOptions};
 pub use jsonld::{export_jsonld, JsonLdOptions};
 pub use kmz::{
@@ -79,6 +78,7 @@ pub use model::{
 pub use obj::{export_obj, export_obj_with_stats, ObjOptions, ObjStats};
 #[cfg(feature = "parquet-bos")]
 pub use parquet_bos::{export_bos, ParquetBosOptions};
+pub use relationships::{relationships, Relationships};
 pub use step::{
     export_step, export_step_json, export_step_with_stats, AttrMutation, PropMutation, StepOptions,
     StepStats,
@@ -92,9 +92,19 @@ use ifc_lite_geometry::extract_profiles;
 fn sanitize_identifier(s: &str) -> String {
     let out: String = s
         .chars()
-        .map(|c| if c.is_alphanumeric() || c == '_' || c == '-' { c } else { '_' })
+        .map(|c| {
+            if c.is_alphanumeric() || c == '_' || c == '-' {
+                c
+            } else {
+                '_'
+            }
+        })
         .collect();
-    if out.is_empty() { "model".to_string() } else { out }
+    if out.is_empty() {
+        "model".to_string()
+    } else {
+        out
+    }
 }
 
 /// Options for HBJSON export.
@@ -107,7 +117,10 @@ pub struct HbjsonOptions {
 
 impl Default for HbjsonOptions {
     fn default() -> Self {
-        Self { name: "ifc_lite_model".to_string(), tolerance: 0.01 }
+        Self {
+            name: "ifc_lite_model".to_string(),
+            tolerance: 0.01,
+        }
     }
 }
 
@@ -167,13 +180,36 @@ pub fn export_hbjson_with_stats(content: &[u8], opts: &HbjsonOptions) -> (String
         }
     }
 
-    let apertures = rooms.iter().flat_map(|r| &r.faces).map(|f| f.apertures.len()).sum();
-    let doors = rooms.iter().flat_map(|r| &r.faces).map(|f| f.doors.len()).sum();
+    let apertures = rooms
+        .iter()
+        .flat_map(|r| &r.faces)
+        .map(|f| f.apertures.len())
+        .sum();
+    let doors = rooms
+        .iter()
+        .flat_map(|r| &r.faces)
+        .map(|f| f.doors.len())
+        .sum();
     let shades = shade_meshes.len();
     let n_constructions = cons.energy.as_ref().map_or(0, |e| e.constructions.len());
-    let stats = HbjsonStats { spaces, rooms: rooms.len(), skipped, apertures, doors, shades, constructions: n_constructions, interior_adjacencies };
+    let stats = HbjsonStats {
+        spaces,
+        rooms: rooms.len(),
+        skipped,
+        apertures,
+        doors,
+        shades,
+        constructions: n_constructions,
+        interior_adjacencies,
+    };
 
-    let model = Model::new(&sanitize_identifier(&opts.name), rooms, shade_meshes, cons.energy, opts.tolerance);
+    let model = Model::new(
+        &sanitize_identifier(&opts.name),
+        rooms,
+        shade_meshes,
+        cons.energy,
+        opts.tolerance,
+    );
     let json = serde_json::to_string(&model).expect("HBJSON model serializes");
     (json, stats)
 }
@@ -215,12 +251,24 @@ mod tests {
         };
         let (json, stats) = export_hbjson_with_stats(&bytes, &HbjsonOptions::default());
         // P2: windows and doors are placed on exterior walls.
-        assert!(stats.apertures > 0, "expected windows, got {}", stats.apertures);
+        assert!(
+            stats.apertures > 0,
+            "expected windows, got {}",
+            stats.apertures
+        );
         assert!(stats.doors > 0, "expected doors, got {}", stats.doors);
         // P5: shared interior walls are paired as Surface adjacencies.
-        assert!(stats.interior_adjacencies > 0, "expected interior adjacencies, got {}", stats.interior_adjacencies);
+        assert!(
+            stats.interior_adjacencies > 0,
+            "expected interior adjacencies, got {}",
+            stats.interior_adjacencies
+        );
         // P4: material layer sets become opaque constructions assigned to faces.
-        assert!(stats.constructions > 0, "expected constructions, got {}", stats.constructions);
+        assert!(
+            stats.constructions > 0,
+            "expected constructions, got {}",
+            stats.constructions
+        );
         let v: Value = serde_json::from_str(&json).expect("valid JSON");
 
         // Energy + adjacency surface through the schema (materials, constructions, Surface BCs).
@@ -228,7 +276,10 @@ mod tests {
         assert_eq!(energy["type"], "ModelEnergyProperties");
         assert!(!energy["materials"].as_array().unwrap().is_empty());
         assert!(!energy["constructions"].as_array().unwrap().is_empty());
-        let surface_faces = v["rooms"].as_array().unwrap().iter()
+        let surface_faces = v["rooms"]
+            .as_array()
+            .unwrap()
+            .iter()
             .flat_map(|r| r["faces"].as_array().unwrap())
             .filter(|f| f["boundary_condition"]["type"] == "Surface")
             .count();
@@ -237,7 +288,13 @@ mod tests {
         for r in v["rooms"].as_array().unwrap() {
             for f in r["faces"].as_array().unwrap() {
                 if f["boundary_condition"]["type"] == "Surface" {
-                    assert_eq!(f["boundary_condition"]["boundary_condition_objects"].as_array().unwrap().len(), 2);
+                    assert_eq!(
+                        f["boundary_condition"]["boundary_condition_objects"]
+                            .as_array()
+                            .unwrap()
+                            .len(),
+                        2
+                    );
                 }
             }
         }
@@ -247,7 +304,11 @@ mod tests {
         assert_eq!(v["tolerance"], 0.01);
 
         let rooms = v["rooms"].as_array().expect("rooms array");
-        assert!(rooms.len() >= 15, "expected >=15 IfcSpace rooms, got {}", rooms.len());
+        assert!(
+            rooms.len() >= 15,
+            "expected >=15 IfcSpace rooms, got {}",
+            rooms.len()
+        );
 
         // Every room must have exactly one Floor + one RoofCeiling + >=3 Walls.
         for room in rooms {
@@ -283,7 +344,11 @@ mod tests {
             return;
         };
         let (json, stats) = export_hbjson_with_stats(&bytes, &HbjsonOptions::default());
-        assert!(stats.constructions > 0, "expected constructions, got {}", stats.constructions);
+        assert!(
+            stats.constructions > 0,
+            "expected constructions, got {}",
+            stats.constructions
+        );
         let v: Value = serde_json::from_str(&json).expect("valid JSON");
 
         let mut saw_wall_construction = false;
@@ -306,8 +371,14 @@ mod tests {
                 }
             }
         }
-        assert!(saw_wall_construction, "expected at least one Wall face with a construction");
-        assert!(saw_slab_construction, "expected at least one Floor/RoofCeiling face with a construction");
+        assert!(
+            saw_wall_construction,
+            "expected at least one Wall face with a construction"
+        );
+        assert!(
+            saw_slab_construction,
+            "expected at least one Floor/RoofCeiling face with a construction"
+        );
     }
 
     #[test]
@@ -319,17 +390,33 @@ mod tests {
         };
         let (json, stats) = export_hbjson_with_stats(&bytes, &HbjsonOptions::default());
         // P2/P3: windows, doors and railing shades are all present on this Revit model.
-        assert!(stats.apertures > 0 && stats.doors > 0, "openings: {} win / {} door", stats.apertures, stats.doors);
-        assert!(stats.shades > 0, "expected railing shades, got {}", stats.shades);
+        assert!(
+            stats.apertures > 0 && stats.doors > 0,
+            "openings: {} win / {} door",
+            stats.apertures,
+            stats.doors
+        );
+        assert!(
+            stats.shades > 0,
+            "expected railing shades, got {}",
+            stats.shades
+        );
         let v: Value = serde_json::from_str(&json).unwrap();
         let rooms = v["rooms"].as_array().unwrap();
-        assert!(rooms.len() >= 30, "expected >=30 rooms, got {}", rooms.len());
+        assert!(
+            rooms.len() >= 30,
+            "expected >=30 rooms, got {}",
+            rooms.len()
+        );
         // No coordinate should exceed ~1km from the rebased origin.
         for room in rooms {
             for f in room["faces"].as_array().unwrap() {
                 for p in f["geometry"]["boundary"].as_array().unwrap() {
                     for c in p.as_array().unwrap() {
-                        assert!(c.as_f64().unwrap().abs() < 1000.0, "coordinate not rebased: {c}");
+                        assert!(
+                            c.as_f64().unwrap().abs() < 1000.0,
+                            "coordinate not rebased: {c}"
+                        );
                     }
                 }
             }

--- a/rust/export/src/merged.rs
+++ b/rust/export/src/merged.rs
@@ -120,7 +120,10 @@ pub fn export_merged_with_stats(models: &[&[u8]], opts: &MergedOptions) -> (Stri
 
     let mut out = String::new();
     out.push_str("ISO-10303-21;\nHEADER;\n");
-    out.push_str(&format!("FILE_DESCRIPTION(('{}'),'2;1');\n", escape(&opts.description)));
+    out.push_str(&format!(
+        "FILE_DESCRIPTION(('{}'),'2;1');\n",
+        escape(&opts.description)
+    ));
     out.push_str(&format!(
         "FILE_NAME('','',(''),(''),'{}','ifc-lite-export','');\n",
         escape(&opts.application)
@@ -166,7 +169,13 @@ pub fn export_merged_with_stats(models: &[&[u8]], opts: &MergedOptions) -> (Stri
     }
 
     out.push_str("ENDSEC;\nEND-ISO-10303-21;\n");
-    (out, MergedStats { models: models.len(), written })
+    (
+        out,
+        MergedStats {
+            models: models.len(),
+            written,
+        },
+    )
 }
 
 #[cfg(test)]
@@ -201,10 +210,17 @@ mod tests {
         let mut sorted = ids.clone();
         sorted.sort_unstable();
         sorted.dedup();
-        assert_eq!(sorted.len(), ids.len(), "ids are globally unique after merge");
+        assert_eq!(
+            sorted.len(),
+            ids.len(),
+            "ids are globally unique after merge"
+        );
 
         // Exactly one IfcProject survives (second model's was dropped + redirected).
-        let projects = merged.lines().filter(|l| l.contains("=IFCPROJECT(")).count();
+        let projects = merged
+            .lines()
+            .filter(|l| l.contains("=IFCPROJECT("))
+            .count();
         assert_eq!(projects, 1, "single unified project");
 
         // Two models minus one dropped project ≈ 2*single - 1 entities.

--- a/rust/export/src/model.rs
+++ b/rust/export/src/model.rs
@@ -234,8 +234,6 @@ pub fn stream_export_model_with_options(
 
     let mut decoder = EntityDecoder::with_arc_index(content, entity_index.clone());
 
-
-
     // Pass 1 — one scan that collects, uncached (each entity visited once here):
     //   • object → attached property/quantity definitions (IfcRelDefinesByProperties),
     //   • the #957/#1518 type-product orphan-geometry bookkeeping, mirroring the
@@ -386,18 +384,21 @@ pub fn stream_export_model_with_options(
         let def_ids = defs_by_object.get(&id).cloned().unwrap_or_default();
         let (property_sets, quantity_sets) = resolve_pset_defs(&mut decoder, &def_ids);
 
-        f(EntityRow {
-            express_id: id,
-            ifc_type,
-            global_id,
-            name,
-            description,
-            object_type,
-            has_geometry,
-            placement,
-            property_sets,
-            quantity_sets,
-        }, Some(&entity));
+        f(
+            EntityRow {
+                express_id: id,
+                ifc_type,
+                global_id,
+                name,
+                description,
+                object_type,
+                has_geometry,
+                placement,
+                property_sets,
+                quantity_sets,
+            },
+            Some(&entity),
+        );
 
         // Keep the property-resolution cache bounded across the whole file.
         // `clear_entity_cache`, not `clear_cache`: the latter also drops the
@@ -436,24 +437,27 @@ pub fn stream_export_model_with_options(
         // IfcRelDefinesByProperties.
         let (property_sets, quantity_sets) = resolve_pset_defs(&mut decoder, &cand.pset_def_ids);
 
-        f(EntityRow {
-            express_id: cand.express_id,
-            // PascalCase canonical name (IfcBoilerType) — equals the node's
-            // `ifcType` extra the geometry pass emits.
-            ifc_type: cand.ifc_type.name().to_string(),
-            global_id: cand.global_id.clone(),
-            name: cand.name.clone(),
-            description: cand.description.clone(),
-            // IfcTypeObject has no ObjectType attribute (attr 4 is
-            // ApplicableOccurrence); leave unset rather than mislabel it.
-            object_type: None,
-            // It is meshed by construction (RepresentationMaps present).
-            has_geometry: true,
-            // A type object has no ObjectPlacement — it is not an occurrence.
-            placement: None,
-            property_sets,
-            quantity_sets,
-        }, None);
+        f(
+            EntityRow {
+                express_id: cand.express_id,
+                // PascalCase canonical name (IfcBoilerType) — equals the node's
+                // `ifcType` extra the geometry pass emits.
+                ifc_type: cand.ifc_type.name().to_string(),
+                global_id: cand.global_id.clone(),
+                name: cand.name.clone(),
+                description: cand.description.clone(),
+                // IfcTypeObject has no ObjectType attribute (attr 4 is
+                // ApplicableOccurrence); leave unset rather than mislabel it.
+                object_type: None,
+                // It is meshed by construction (RepresentationMaps present).
+                has_geometry: true,
+                // A type object has no ObjectPlacement — it is not an occurrence.
+                placement: None,
+                property_sets,
+                quantity_sets,
+            },
+            None,
+        );
 
         if decoder.cache_size() > PSET_CACHE_CAP {
             decoder.clear_entity_cache();

--- a/rust/export/src/model_props.rs
+++ b/rust/export/src/model_props.rs
@@ -69,7 +69,9 @@ pub(super) fn quantity_kind(ty: IfcType) -> Option<&'static str> {
 }
 
 pub(super) fn opt_string(av: Option<&AttributeValue>) -> Option<String> {
-    av.and_then(|a| a.as_string()).map(|s| s.to_string()).filter(|s| !s.is_empty())
+    av.and_then(|a| a.as_string())
+        .map(|s| s.to_string())
+        .filter(|s| !s.is_empty())
 }
 
 /// Collect the entity references in a STEP list attribute (e.g. `(#44,#45)`),
@@ -81,8 +83,15 @@ pub(super) fn ref_list(av: Option<&AttributeValue>) -> Vec<u32> {
 }
 
 /// Decode one `IfcPropertySet` definition into our model.
-pub(super) fn decode_property_set(decoder: &mut EntityDecoder, def: &DecodedEntity) -> Option<PropertySet> {
-    let name = def.get(2).and_then(|a| a.as_string()).unwrap_or("").to_string();
+pub(super) fn decode_property_set(
+    decoder: &mut EntityDecoder,
+    def: &DecodedEntity,
+) -> Option<PropertySet> {
+    let name = def
+        .get(2)
+        .and_then(|a| a.as_string())
+        .unwrap_or("")
+        .to_string();
     let has_props = def.get(4)?;
     let props = decoder.resolve_ref_list(has_props).ok()?;
     let mut properties = Vec::new();
@@ -93,7 +102,11 @@ pub(super) fn decode_property_set(decoder: &mut EntityDecoder, def: &DecodedEnti
                 _ => continue,
             };
             if let Some((value, value_type)) = p.get(2).and_then(render_value) {
-                properties.push(PropValue { name: pname, value, value_type });
+                properties.push(PropValue {
+                    name: pname,
+                    value,
+                    value_type,
+                });
             }
         }
         // Other property kinds (enumerated/list/bounded/complex) are P-next.
@@ -102,8 +115,15 @@ pub(super) fn decode_property_set(decoder: &mut EntityDecoder, def: &DecodedEnti
 }
 
 /// Decode one `IfcElementQuantity` definition into our model.
-pub(super) fn decode_quantity_set(decoder: &mut EntityDecoder, def: &DecodedEntity) -> Option<QuantitySet> {
-    let name = def.get(2).and_then(|a| a.as_string()).unwrap_or("").to_string();
+pub(super) fn decode_quantity_set(
+    decoder: &mut EntityDecoder,
+    def: &DecodedEntity,
+) -> Option<QuantitySet> {
+    let name = def
+        .get(2)
+        .and_then(|a| a.as_string())
+        .unwrap_or("")
+        .to_string();
     let quantities_attr = def.get(5)?;
     let quants = decoder.resolve_ref_list(quantities_attr).ok()?;
     let mut quantities = Vec::new();
@@ -114,7 +134,11 @@ pub(super) fn decode_quantity_set(decoder: &mut EntityDecoder, def: &DecodedEnti
                 _ => continue,
             };
             if let Some(value) = q.get(3).and_then(|a| a.as_float()) {
-                quantities.push(QuantityValue { name: qname, value, kind });
+                quantities.push(QuantityValue {
+                    name: qname,
+                    value,
+                    kind,
+                });
             }
         }
     }

--- a/rust/export/src/model_tests.rs
+++ b/rust/export/src/model_tests.rs
@@ -54,7 +54,10 @@ fn type_only_geometry_emits_attribute_row() {
 
     // build == stream still holds with type rows present.
     let collected = build_export_model(&bytes).entities;
-    assert_eq!(collected, rows, "build and stream must agree with type rows");
+    assert_eq!(
+        collected, rows,
+        "build and stream must agree with type rows"
+    );
 }
 
 /// The adversarial join test: EVERY mesh the geometry pass tags as
@@ -89,10 +92,16 @@ fn type_product_meshes_all_have_rows() {
         let mut rows = Vec::new();
         stream_export_model(&bytes, |r| rows.push(r));
         for (id, ty) in &type_meshes {
-            let row = rows.iter().find(|r| r.express_id == *id).unwrap_or_else(|| {
-                panic!("{rel}: meshed type-product #{id} ({ty}) has no attribute row")
-            });
-            assert_eq!(&row.ifc_type, ty, "{rel}: #{id} row type must match its mesh");
+            let row = rows
+                .iter()
+                .find(|r| r.express_id == *id)
+                .unwrap_or_else(|| {
+                    panic!("{rel}: meshed type-product #{id} ({ty}) has no attribute row")
+                });
+            assert_eq!(
+                &row.ifc_type, ty,
+                "{rel}: #{id} row type must match its mesh"
+            );
         }
     }
 }
@@ -100,16 +109,27 @@ fn type_product_meshes_all_have_rows() {
 #[test]
 fn duplex_model_has_products_and_psets() {
     let model = build_export_model(&fixture("ara3d/duplex.ifc"));
-    assert!(model.entities.len() > 50, "expected many products, got {}", model.entities.len());
+    assert!(
+        model.entities.len() > 50,
+        "expected many products, got {}",
+        model.entities.len()
+    );
 
     // Every row carries a GlobalId + type.
     for e in &model.entities {
         assert!(!e.ifc_type.is_empty());
     }
-    assert!(model.entities.iter().any(|e| e.global_id.is_some()), "some GlobalIds");
+    assert!(
+        model.entities.iter().any(|e| e.global_id.is_some()),
+        "some GlobalIds"
+    );
 
     // At least one element carries property sets with named single values.
-    let with_psets = model.entities.iter().filter(|e| !e.property_sets.is_empty()).count();
+    let with_psets = model
+        .entities
+        .iter()
+        .filter(|e| !e.property_sets.is_empty())
+        .count();
     assert!(with_psets > 0, "expected elements with property sets");
     let any_prop = model
         .entities
@@ -137,7 +157,10 @@ fn stream_matches_build_row_for_row() {
     let mut streamed = Vec::new();
     stream_export_model(&bytes, |r| streamed.push(r));
     assert!(!streamed.is_empty(), "expected products");
-    assert_eq!(collected, streamed, "stream and collect must agree row-for-row");
+    assert_eq!(
+        collected, streamed,
+        "stream and collect must agree row-for-row"
+    );
 }
 
 #[test]
@@ -157,7 +180,10 @@ fn stream_with_index_matches_plain() {
     let mut shared = Vec::new();
     stream_export_model_with_index(&bytes, &idx, |r| shared.push(r));
     assert!(!plain.is_empty(), "expected products");
-    assert_eq!(plain, shared, "injected-index rows must match self-indexed rows");
+    assert_eq!(
+        plain, shared,
+        "injected-index rows must match self-indexed rows"
+    );
 }
 
 #[test]
@@ -390,7 +416,10 @@ fn the_placement_chain_composes_parent_then_local() {
 
     let opts = ModelOptions::default().with_placements(true);
     let rows = rows_with(&content, &opts);
-    let t = row_named(&rows, "W").placement.expect("placed").translation();
+    let t = row_named(&rows, "W")
+        .placement
+        .expect("placed")
+        .translation();
 
     let close = |a: f64, b: f64| (a - b).abs() < 1e-9;
     assert!(
@@ -424,11 +453,19 @@ fn the_callback_receives_the_entity_each_row_was_built_from() {
     let mut seen = Vec::new();
     stream_export_model_with_options(bytes, &index, &ModelOptions::default(), |row, entity| {
         let entity = entity.expect("an IfcProduct row has an occurrence entity");
-        assert_eq!(entity.id, row.express_id, "the row's own entity, not another");
+        assert_eq!(
+            entity.id, row.express_id,
+            "the row's own entity, not another"
+        );
         // Attribute 2 is Name for every rooted entity. A consumer should reach
         // it through `IfcType::attribute_index("Name")` rather than a literal;
         // this asserts the entity arrives, which is what the argument is for.
-        seen.push(entity.get(2).and_then(|a| a.as_string()).map(str::to_string));
+        seen.push(
+            entity
+                .get(2)
+                .and_then(|a| a.as_string())
+                .map(str::to_string),
+        );
     });
     assert_eq!(seen, vec![Some("W".to_string()), Some("U".to_string())]);
 }

--- a/rust/export/src/obj.rs
+++ b/rust/export/src/obj.rs
@@ -30,7 +30,11 @@ pub struct ObjOptions {
 
 impl Default for ObjOptions {
     fn default() -> Self {
-        Self { include_normals: true, isolated: Vec::new(), hidden: Vec::new() }
+        Self {
+            include_normals: true,
+            isolated: Vec::new(),
+            hidden: Vec::new(),
+        }
     }
 }
 
@@ -70,10 +74,17 @@ pub fn export_obj_with_stats(content: &[u8], opts: &ObjOptions) -> (String, ObjS
 
     let mut out = String::new();
     let _ = writeln!(out, "# ifc-lite OBJ export");
-    let _ = writeln!(out, "# units: metres (renderer Y-up frame, origin-folded world coords)");
+    let _ = writeln!(
+        out,
+        "# units: metres (renderer Y-up frame, origin-folded world coords)"
+    );
 
     let mut vert_base: usize = 0; // 0-based count of vertices written so far
-    let mut stats = ObjStats { meshes: 0, vertices: 0, triangles: 0 };
+    let mut stats = ObjStats {
+        meshes: 0,
+        vertices: 0,
+        triangles: 0,
+    };
 
     for mesh in &result.meshes {
         if !mesh_visible(mesh, &opts.isolated, &opts.hidden) {
@@ -158,7 +169,10 @@ mod tests {
         for line in obj.lines().filter(|l| l.starts_with("f ")) {
             for tok in line[2..].split_whitespace() {
                 let v: usize = tok.split("//").next().unwrap().parse().unwrap();
-                assert!(v >= 1 && v <= max_idx, "face index {v} out of range 1..={max_idx}");
+                assert!(
+                    v >= 1 && v <= max_idx,
+                    "face index {v} out of range 1..={max_idx}"
+                );
             }
         }
     }
@@ -177,7 +191,10 @@ mod tests {
 
         let isolated = export_obj_with_stats(
             &fixture("ara3d/duplex.ifc"),
-            &ObjOptions { isolated: vec![some_id], ..ObjOptions::default() },
+            &ObjOptions {
+                isolated: vec![some_id],
+                ..ObjOptions::default()
+            },
         )
         .1;
         assert!(isolated.meshes >= 1);
@@ -221,12 +238,24 @@ mod tests {
         let idx = |i: u32| vert_base + i as usize + 1;
         let expected = format!("f {} {} {}", idx(tri[0]), idx(tri[2]), idx(tri[1]));
 
-        let obj = export_obj(&bytes, &ObjOptions { include_normals: false, ..ObjOptions::default() });
-        let first_face = obj.lines().find(|l| l.starts_with("f ")).expect("a face line");
+        let obj = export_obj(
+            &bytes,
+            &ObjOptions {
+                include_normals: false,
+                ..ObjOptions::default()
+            },
+        );
+        let first_face = obj
+            .lines()
+            .find(|l| l.starts_with("f "))
+            .expect("a face line");
 
         // A triangle whose 2nd and 3rd source indices coincide would make the
         // reversal unobservable; assert the fixture is not that degenerate case.
         assert_ne!(tri[1], tri[2], "fixture triangle must distinguish b from c");
-        assert_eq!(first_face, expected, "OBJ must emit a, c, b — winding reversed");
+        assert_eq!(
+            first_face, expected,
+            "OBJ must emit a, c, b — winding reversed"
+        );
     }
 }

--- a/rust/export/src/openings.rs
+++ b/rust/export/src/openings.rs
@@ -12,13 +12,19 @@ use std::collections::HashMap;
 
 use ifc_lite_geometry::ExtractedProfile;
 
-use crate::hbjson::{Aperture, Door, Face3D, Room};
 use crate::geom::{center, dot, newell_normal, xf, zup};
+use crate::hbjson::{Aperture, Door, Face3D, Room};
 
-fn sub(a: [f64; 3], b: [f64; 3]) -> [f64; 3] { [a[0] - b[0], a[1] - b[1], a[2] - b[2]] }
+fn sub(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
+    [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
+}
 fn norm(a: [f64; 3]) -> [f64; 3] {
     let l = (a[0] * a[0] + a[1] * a[1] + a[2] * a[2]).sqrt();
-    if l > 0.0 { [a[0] / l, a[1] / l, a[2] / l] } else { [0.0, 0.0, 0.0] }
+    if l > 0.0 {
+        [a[0] / l, a[1] / l, a[2] / l]
+    } else {
+        [0.0, 0.0, 0.0]
+    }
 }
 
 /// All corner points of an occurrence's profile prisms (base + extruded), Z-up, rebased.
@@ -26,12 +32,27 @@ fn occurrence_points(profiles: &[&ExtractedProfile], origin: [f64; 3]) -> Vec<[f
     let mut pts = Vec::new();
     for p in profiles {
         let n = p.outer_points.len() / 2;
-        let dir = zup([p.extrusion_dir[0] as f64, p.extrusion_dir[1] as f64, p.extrusion_dir[2] as f64]);
+        let dir = zup([
+            p.extrusion_dir[0] as f64,
+            p.extrusion_dir[1] as f64,
+            p.extrusion_dir[2] as f64,
+        ]);
         let depth = p.extrusion_depth as f64;
         for i in 0..n {
-            let base = sub(xf(&p.transform, p.outer_points[i * 2] as f64, p.outer_points[i * 2 + 1] as f64), origin);
+            let base = sub(
+                xf(
+                    &p.transform,
+                    p.outer_points[i * 2] as f64,
+                    p.outer_points[i * 2 + 1] as f64,
+                ),
+                origin,
+            );
             pts.push(base);
-            pts.push([base[0] + dir[0] * depth, base[1] + dir[1] * depth, base[2] + dir[2] * depth]);
+            pts.push([
+                base[0] + dir[0] * depth,
+                base[1] + dir[1] * depth,
+                base[2] + dir[2] * depth,
+            ]);
         }
     }
     pts
@@ -63,9 +84,24 @@ fn collect_exterior_walls(rooms: &[Room]) -> Vec<WallFace> {
             let origin = b[0];
             let uax = norm(sub(b[1], origin));
             let vax = norm(sub(b[b.len() - 1], origin));
-            let ulen = b.iter().map(|p| dot(sub(*p, origin), uax)).fold(f64::MIN, f64::max);
-            let vlen = b.iter().map(|p| dot(sub(*p, origin), vax)).fold(f64::MIN, f64::max);
-            out.push(WallFace { ri, fi, origin, uax, vax, ulen, vlen, n: newell_normal(b) });
+            let ulen = b
+                .iter()
+                .map(|p| dot(sub(*p, origin), uax))
+                .fold(f64::MIN, f64::max);
+            let vlen = b
+                .iter()
+                .map(|p| dot(sub(*p, origin), vax))
+                .fold(f64::MIN, f64::max);
+            out.push(WallFace {
+                ri,
+                fi,
+                origin,
+                uax,
+                vax,
+                ulen,
+                vlen,
+                n: newell_normal(b),
+            });
         }
     }
     out
@@ -82,18 +118,37 @@ fn project(verts: &[[f64; 3]], walls: &[WallFace]) -> Option<(usize, usize, Vec<
         let d = dot(sub(c, w.origin), w.n).abs();
         let u = dot(sub(c, w.origin), w.uax);
         let v = dot(sub(c, w.origin), w.vax);
-        if d < 0.7 && u > -0.5 && u < w.ulen + 0.5 && v > -0.5 && v < w.vlen + 0.5
-            && best.is_none_or(|(bd, _)| d < bd) {
-                best = Some((d, i));
-            }
+        if d < 0.7
+            && u > -0.5
+            && u < w.ulen + 0.5
+            && v > -0.5
+            && v < w.vlen + 0.5
+            && best.is_none_or(|(bd, _)| d < bd)
+        {
+            best = Some((d, i));
+        }
     }
     let w = &walls[best?.1];
-    let us: Vec<f64> = verts.iter().map(|p| dot(sub(*p, w.origin), w.uax)).collect();
-    let vs: Vec<f64> = verts.iter().map(|p| dot(sub(*p, w.origin), w.vax)).collect();
+    let us: Vec<f64> = verts
+        .iter()
+        .map(|p| dot(sub(*p, w.origin), w.uax))
+        .collect();
+    let vs: Vec<f64> = verts
+        .iter()
+        .map(|p| dot(sub(*p, w.origin), w.vax))
+        .collect();
     let u0 = us.iter().cloned().fold(f64::MAX, f64::min).max(0.05);
-    let u1 = us.iter().cloned().fold(f64::MIN, f64::max).min(w.ulen - 0.05);
+    let u1 = us
+        .iter()
+        .cloned()
+        .fold(f64::MIN, f64::max)
+        .min(w.ulen - 0.05);
     let v0 = vs.iter().cloned().fold(f64::MAX, f64::min).max(0.05);
-    let v1 = vs.iter().cloned().fold(f64::MIN, f64::max).min(w.vlen - 0.05);
+    let v1 = vs
+        .iter()
+        .cloned()
+        .fold(f64::MIN, f64::max)
+        .min(w.vlen - 0.05);
     if u1 - u0 < 0.1 || v1 - v0 < 0.1 {
         return None;
     }
@@ -104,7 +159,11 @@ fn project(verts: &[[f64; 3]], walls: &[WallFace]) -> Option<(usize, usize, Vec<
             w.origin[2] + w.uax[2] * u + w.vax[2] * v,
         ]
     };
-    Some((w.ri, w.fi, vec![pt(u0, v0), pt(u1, v0), pt(u1, v1), pt(u0, v1)]))
+    Some((
+        w.ri,
+        w.fi,
+        vec![pt(u0, v0), pt(u1, v0), pt(u1, v1), pt(u0, v1)],
+    ))
 }
 
 enum Pending {
@@ -121,7 +180,10 @@ pub fn attach_openings(profiles: &[ExtractedProfile], rooms: &mut [Room], origin
     for p in profiles {
         let is_window = p.ifc_type == "IfcWindow";
         if is_window || p.ifc_type == "IfcDoor" {
-            by.entry(p.express_id).or_insert((is_window, Vec::new())).1.push(p);
+            by.entry(p.express_id)
+                .or_insert((is_window, Vec::new()))
+                .1
+                .push(p);
         }
     }
 
@@ -135,17 +197,33 @@ pub fn attach_openings(profiles: &[ExtractedProfile], rooms: &mut [Room], origin
         let (is_window, ps) = &by[id];
         let pts = occurrence_points(ps, origin);
         if let Some((ri, fi, geo)) = project(&pts, &walls) {
-            pending.push((ri, fi, if *is_window { Pending::Window(*id, geo) } else { Pending::Door(*id, geo) }));
+            pending.push((
+                ri,
+                fi,
+                if *is_window {
+                    Pending::Window(*id, geo)
+                } else {
+                    Pending::Door(*id, geo)
+                },
+            ));
         }
     }
 
     for (ri, fi, p) in pending {
         match p {
             Pending::Window(id, geo) => {
-                rooms[ri].faces[fi].apertures.push(Aperture::new(format!("Ap{}", id), Face3D::new(geo), false));
+                rooms[ri].faces[fi].apertures.push(Aperture::new(
+                    format!("Ap{}", id),
+                    Face3D::new(geo),
+                    false,
+                ));
             }
             Pending::Door(id, geo) => {
-                rooms[ri].faces[fi].doors.push(Door::new(format!("Dr{}", id), Face3D::new(geo), false));
+                rooms[ri].faces[fi].doors.push(Door::new(
+                    format!("Dr{}", id),
+                    Face3D::new(geo),
+                    false,
+                ));
             }
         }
     }

--- a/rust/export/src/parquet_bos.rs
+++ b/rust/export/src/parquet_bos.rs
@@ -25,7 +25,10 @@ use crate::model::{build_export_model, fmt_num, ExportModel};
 /// Wrap a downstream encoder error (Arrow/Parquet/zip/serde_json) as
 /// [`ExportError::Serialization`], tagged with the stage that failed.
 fn ser_err<E: std::fmt::Display>(stage: &'static str) -> impl FnOnce(E) -> ExportError {
-    move |e| ExportError::Serialization { stage, detail: e.to_string() }
+    move |e| ExportError::Serialization {
+        stage,
+        detail: e.to_string(),
+    }
 }
 
 /// Options for BOS export.
@@ -36,7 +39,9 @@ pub struct ParquetBosOptions {
 
 impl Default for ParquetBosOptions {
     fn default() -> Self {
-        Self { include_geometry: true }
+        Self {
+            include_geometry: true,
+        }
     }
 }
 
@@ -50,7 +55,9 @@ fn to_parquet(batch: &RecordBatch) -> Result<Vec<u8>, ExportError> {
     {
         let mut writer = ArrowWriter::try_new(&mut buf, batch.schema(), None)
             .map_err(ser_err("arrow writer"))?;
-        writer.write(batch).map_err(ser_err("write parquet batch"))?;
+        writer
+            .write(batch)
+            .map_err(ser_err("write parquet batch"))?;
         writer.close().map_err(ser_err("close parquet"))?;
     }
     Ok(buf)
@@ -75,13 +82,19 @@ fn entities_table(model: &ExportModel) -> Result<Vec<u8>, ExportError> {
         has_geom.push(e.has_geometry);
     }
     let batch = RecordBatch::try_from_iter(vec![
-        ("ExpressId", Arc::new(UInt32Array::from(express)) as ArrayRef),
+        (
+            "ExpressId",
+            Arc::new(UInt32Array::from(express)) as ArrayRef,
+        ),
         ("GlobalId", str_col(global)),
         ("Name", str_col(name)),
         ("Description", str_col(desc)),
         ("Type", str_col(ty)),
         ("ObjectType", str_col(otype)),
-        ("HasGeometry", Arc::new(BooleanArray::from(has_geom)) as ArrayRef),
+        (
+            "HasGeometry",
+            Arc::new(BooleanArray::from(has_geom)) as ArrayRef,
+        ),
     ])
     .map_err(ser_err("entities batch"))?;
     to_parquet(&batch)
@@ -218,11 +231,26 @@ fn geometry_tables(content: &[u8]) -> Result<GeometryTables, ExportError> {
     .map_err(ser_err("index batch"))?;
 
     let mbatch = RecordBatch::try_from_iter(vec![
-        ("ExpressId", Arc::new(UInt32Array::from(mesh_express)) as ArrayRef),
-        ("VertexStart", Arc::new(UInt32Array::from(vstart)) as ArrayRef),
-        ("VertexCount", Arc::new(UInt32Array::from(vcount)) as ArrayRef),
-        ("IndexStart", Arc::new(UInt32Array::from(istart)) as ArrayRef),
-        ("IndexCount", Arc::new(UInt32Array::from(icount)) as ArrayRef),
+        (
+            "ExpressId",
+            Arc::new(UInt32Array::from(mesh_express)) as ArrayRef,
+        ),
+        (
+            "VertexStart",
+            Arc::new(UInt32Array::from(vstart)) as ArrayRef,
+        ),
+        (
+            "VertexCount",
+            Arc::new(UInt32Array::from(vcount)) as ArrayRef,
+        ),
+        (
+            "IndexStart",
+            Arc::new(UInt32Array::from(istart)) as ArrayRef,
+        ),
+        (
+            "IndexCount",
+            Arc::new(UInt32Array::from(icount)) as ArrayRef,
+        ),
     ])
     .map_err(ser_err("mesh batch"))?;
 
@@ -251,7 +279,8 @@ pub fn export_bos(content: &[u8], opts: &ParquetBosOptions) -> Result<Vec<u8>, E
                name: &str,
                bytes: &[u8]|
      -> Result<(), ExportError> {
-        zip.start_file(name, file_opts).map_err(ser_err("zip start_file"))?;
+        zip.start_file(name, file_opts)
+            .map_err(ser_err("zip start_file"))?;
         zip.write_all(bytes).map_err(ser_err("zip write"))?;
         Ok(())
     };
@@ -324,13 +353,25 @@ mod tests {
 
         // Each parquet entry starts + ends with the PAR1 magic.
         let mut entities = Vec::new();
-        archive.by_name("Entities.parquet").unwrap().read_to_end(&mut entities).unwrap();
+        archive
+            .by_name("Entities.parquet")
+            .unwrap()
+            .read_to_end(&mut entities)
+            .unwrap();
         assert_eq!(&entities[0..4], b"PAR1", "parquet header magic");
-        assert_eq!(&entities[entities.len() - 4..], b"PAR1", "parquet footer magic");
+        assert_eq!(
+            &entities[entities.len() - 4..],
+            b"PAR1",
+            "parquet footer magic"
+        );
 
         // Metadata.json is valid + reports entities.
         let mut meta = String::new();
-        archive.by_name("Metadata.json").unwrap().read_to_string(&mut meta).unwrap();
+        archive
+            .by_name("Metadata.json")
+            .unwrap()
+            .read_to_string(&mut meta)
+            .unwrap();
         let v: serde_json::Value = serde_json::from_str(&meta).unwrap();
         assert_eq!(v["format"], "ara3d-bos");
         assert!(v["entityCount"].as_u64().unwrap() > 50);

--- a/rust/export/src/relationships.rs
+++ b/rust/export/src/relationships.rs
@@ -131,8 +131,14 @@ END-ISO-10303-21;
     fn aggregation_and_containment_land_in_one_tree() {
         let r = relationships(FILE);
         assert_eq!(r.project, Some(1));
-        assert_eq!(r.spatial_children.get(&1).map(Vec::as_slice), Some(&[2u32][..]));
-        assert_eq!(r.spatial_children.get(&2).map(Vec::as_slice), Some(&[3u32][..]));
+        assert_eq!(
+            r.spatial_children.get(&1).map(Vec::as_slice),
+            Some(&[2u32][..])
+        );
+        assert_eq!(
+            r.spatial_children.get(&2).map(Vec::as_slice),
+            Some(&[3u32][..])
+        );
     }
 
     #[test]

--- a/rust/export/src/rooms.rs
+++ b/rust/export/src/rooms.rs
@@ -26,17 +26,25 @@ use crate::hbjson::{Face, Face3D, Room};
 #[allow(clippy::needless_range_loop)]
 pub fn build_rooms(profiles: &[ExtractedProfile], tol: f64) -> (Vec<Room>, [f64; 3], usize) {
     let mut skipped = 0usize;
-    let spaces: Vec<&ExtractedProfile> =
-        profiles.iter().filter(|p| p.ifc_type == "IfcSpace").collect();
+    let spaces: Vec<&ExtractedProfile> = profiles
+        .iter()
+        .filter(|p| p.ifc_type == "IfcSpace")
+        .collect();
 
     // Model-wide origin to rebase against (kills survey-coordinate f32 collapse).
     let mut origin = [f64::MAX; 3];
     for s in &spaces {
         let n = s.outer_points.len() / 2;
         for i in 0..n {
-            let w = xf(&s.transform, s.outer_points[i * 2] as f64, s.outer_points[i * 2 + 1] as f64);
+            let w = xf(
+                &s.transform,
+                s.outer_points[i * 2] as f64,
+                s.outer_points[i * 2 + 1] as f64,
+            );
             for k in 0..3 {
-                if w[k] < origin[k] { origin[k] = w[k]; }
+                if w[k] < origin[k] {
+                    origin[k] = w[k];
+                }
             }
         }
     }
@@ -59,12 +67,20 @@ pub fn build_rooms(profiles: &[ExtractedProfile], tol: f64) -> (Vec<Room>, [f64;
             continue;
         }
         // extrusion_dir is also Y-up → convert (linear, no translation).
-        let dir = zup([s.extrusion_dir[0] as f64, s.extrusion_dir[1] as f64, s.extrusion_dir[2] as f64]);
+        let dir = zup([
+            s.extrusion_dir[0] as f64,
+            s.extrusion_dir[1] as f64,
+            s.extrusion_dir[2] as f64,
+        ]);
         let depth = s.extrusion_depth as f64;
 
         let ring: Vec<[f64; 3]> = (0..n)
             .map(|i| {
-                let w = xf(&s.transform, s.outer_points[i * 2] as f64, s.outer_points[i * 2 + 1] as f64);
+                let w = xf(
+                    &s.transform,
+                    s.outer_points[i * 2] as f64,
+                    s.outer_points[i * 2 + 1] as f64,
+                );
                 [w[0] - origin[0], w[1] - origin[1], w[2] - origin[2]]
             })
             .collect();
@@ -76,7 +92,13 @@ pub fn build_rooms(profiles: &[ExtractedProfile], tol: f64) -> (Vec<Room>, [f64;
         }
         let extruded: Vec<[f64; 3]> = floor
             .iter()
-            .map(|p| [p[0] + dir[0] * depth, p[1] + dir[1] * depth, p[2] + dir[2] * depth])
+            .map(|p| {
+                [
+                    p[0] + dir[0] * depth,
+                    p[1] + dir[1] * depth,
+                    p[2] + dir[2] * depth,
+                ]
+            })
             .collect();
 
         // Designate the lower ring as the Floor, the upper as the RoofCeiling (handles a
@@ -92,10 +114,14 @@ pub fn build_rooms(profiles: &[ExtractedProfile], tol: f64) -> (Vec<Room>, [f64;
         // Room centroid for outward-orientation.
         let mut cen = [0.0; 3];
         for p in floor_ring.iter().chain(roof_ring.iter()) {
-            for k in 0..3 { cen[k] += p[k]; }
+            for k in 0..3 {
+                cen[k] += p[k];
+            }
         }
         let tot = (floor_ring.len() + roof_ring.len()) as f64;
-        for k in 0..3 { cen[k] /= tot; }
+        for k in 0..3 {
+            cen[k] /= tot;
+        }
 
         // Faces typed BY CONSTRUCTION (not normal inference): floor, roof, then wall quads.
         let m = floor_ring.len();
@@ -104,7 +130,10 @@ pub fn build_rooms(profiles: &[ExtractedProfile], tol: f64) -> (Vec<Room>, [f64;
         raw.push((roof_ring.clone(), "RoofCeiling"));
         for i in 0..m {
             let j = (i + 1) % m;
-            raw.push((vec![floor_ring[i], floor_ring[j], roof_ring[j], roof_ring[i]], "Wall"));
+            raw.push((
+                vec![floor_ring[i], floor_ring[j], roof_ring[j], roof_ring[i]],
+                "Wall",
+            ));
         }
 
         // Orient every face outward; reject the whole room if any face is degenerate.
@@ -136,8 +165,17 @@ pub fn build_rooms(profiles: &[ExtractedProfile], tol: f64) -> (Vec<Room>, [f64;
             .into_iter()
             .enumerate()
             .map(|(fi, (b, face_type))| {
-                let bc = if face_type == "Floor" { "Ground" } else { "Outdoors" };
-                Face::new(format!("R{}_F{}", s.express_id, fi), Face3D::new(b), face_type, bc)
+                let bc = if face_type == "Floor" {
+                    "Ground"
+                } else {
+                    "Outdoors"
+                };
+                Face::new(
+                    format!("R{}_F{}", s.express_id, fi),
+                    Face3D::new(b),
+                    face_type,
+                    bc,
+                )
             })
             .collect();
         rooms.push(Room::new(format!("R{}", s.express_id), faces));
@@ -173,8 +211,16 @@ fn room_signature(r: &Room) -> Option<Sig> {
         .faces
         .iter()
         .flat_map(|f| &f.geometry.boundary)
-        .fold((f64::MAX, f64::MIN), |(lo, hi), p| (lo.min(p[2]), hi.max(p[2])));
-    Some(Sig { cx, cy, area: polygon_area(b), zmin, zmax })
+        .fold((f64::MAX, f64::MIN), |(lo, hi), p| {
+            (lo.min(p[2]), hi.max(p[2]))
+        });
+    Some(Sig {
+        cx,
+        cy,
+        area: polygon_area(b),
+        zmin,
+        zmax,
+    })
 }
 
 /// True when two rooms are near-identical copies (Revit duplicate-space artifact): same
@@ -194,12 +240,18 @@ fn dedupe_colliding(rooms: Vec<Room>) -> (Vec<Room>, usize) {
     let sigs: Vec<Option<Sig>> = rooms.iter().map(room_signature).collect();
     let mut order: Vec<usize> = (0..rooms.len()).collect();
     let area_of = |i: usize| sigs[i].as_ref().map_or(0.0, |s| s.area);
-    order.sort_by(|&a, &b| area_of(b).partial_cmp(&area_of(a)).unwrap_or(std::cmp::Ordering::Equal));
+    order.sort_by(|&a, &b| {
+        area_of(b)
+            .partial_cmp(&area_of(a))
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
     let mut keep = vec![false; rooms.len()];
     let mut kept: Vec<usize> = Vec::new();
     for &i in &order {
         let dup = match &sigs[i] {
-            Some(si) => kept.iter().any(|&j| sigs[j].as_ref().is_some_and(|sj| is_duplicate(si, sj))),
+            Some(si) => kept
+                .iter()
+                .any(|&j| sigs[j].as_ref().is_some_and(|sj| is_duplicate(si, sj))),
             None => false,
         };
         if !dup {
@@ -208,6 +260,11 @@ fn dedupe_colliding(rooms: Vec<Room>) -> (Vec<Room>, usize) {
         }
     }
     let dropped = keep.iter().filter(|k| !**k).count();
-    let out = rooms.into_iter().enumerate().filter(|(i, _)| keep[*i]).map(|(_, r)| r).collect();
+    let out = rooms
+        .into_iter()
+        .enumerate()
+        .filter(|(i, _)| keep[*i])
+        .map(|(_, r)| r)
+        .collect();
     (out, dropped)
 }

--- a/rust/export/src/schema_convert.rs
+++ b/rust/export/src/schema_convert.rs
@@ -33,30 +33,59 @@ fn map_4_to_2x3(t: &str) -> Option<&'static str> {
     Some(match t {
         "IFCELECTRICDISTRIBUTIONBOARD" => "IFCELECTRICDISTRIBUTIONPOINT",
         "IFCBURNERTYPE" => "IFCGASTERMINALTYPE",
-        "IFCCHIMNEY" | "IFCSHADINGDEVICE" | "IFCCIVILELEMENT" | "IFCGEOGRAPHICELEMENT"
-        | "IFCBEARING" | "IFCCOURSE" | "IFCKERB" | "IFCBUILTELEMENT" => "IFCBUILDINGELEMENTPROXY",
+        "IFCCHIMNEY"
+        | "IFCSHADINGDEVICE"
+        | "IFCCIVILELEMENT"
+        | "IFCGEOGRAPHICELEMENT"
+        | "IFCBEARING"
+        | "IFCCOURSE"
+        | "IFCKERB"
+        | "IFCBUILTELEMENT" => "IFCBUILDINGELEMENTPROXY",
         "IFCDEEPFOUNDATION" => "IFCFOOTING",
         "IFCPAVEMENT" => "IFCSLAB",
-        "IFCFACILITY" | "IFCBRIDGE" | "IFCROAD" | "IFCRAILWAY" | "IFCMARINEFACILITY" => "IFCBUILDING",
-        "IFCFACILITYPART" | "IFCFACILITYPARTCOMMON" | "IFCBRIDGEPART" | "IFCROADPART"
-        | "IFCRAILWAYPART" | "IFCMARINEPART" => "IFCBUILDINGSTOREY",
+        "IFCFACILITY" | "IFCBRIDGE" | "IFCROAD" | "IFCRAILWAY" | "IFCMARINEFACILITY" => {
+            "IFCBUILDING"
+        }
+        "IFCFACILITYPART"
+        | "IFCFACILITYPARTCOMMON"
+        | "IFCBRIDGEPART"
+        | "IFCROADPART"
+        | "IFCRAILWAYPART"
+        | "IFCMARINEPART" => "IFCBUILDINGSTOREY",
         _ => return None,
     })
 }
 
 fn map_4x3_to_4(t: &str) -> Option<&'static str> {
     Some(match t {
-        "IFCFACILITY" | "IFCBRIDGE" | "IFCROAD" | "IFCRAILWAY" | "IFCMARINEFACILITY" => "IFCBUILDING",
-        "IFCFACILITYPART" | "IFCFACILITYPARTCOMMON" | "IFCBRIDGEPART" | "IFCROADPART"
-        | "IFCRAILWAYPART" | "IFCMARINEPART" => "IFCBUILDINGSTOREY",
-        "IFCBUILTELEMENT" | "IFCEARTHWORKSCUT" | "IFCEARTHWORKSELEMENT" | "IFCEARTHWORKSFILL"
-        | "IFCNAVIGATIONELEMENT" | "IFCMOORINGDEVICE" | "IFCRAIL" | "IFCREINFORCEDSOIL"
-        | "IFCSIGN" | "IFCSIGNAL" | "IFCTRACKELEMENT" | "IFCKERB" | "IFCCOURSE" => {
-            "IFCBUILDINGELEMENTPROXY"
+        "IFCFACILITY" | "IFCBRIDGE" | "IFCROAD" | "IFCRAILWAY" | "IFCMARINEFACILITY" => {
+            "IFCBUILDING"
         }
+        "IFCFACILITYPART"
+        | "IFCFACILITYPARTCOMMON"
+        | "IFCBRIDGEPART"
+        | "IFCROADPART"
+        | "IFCRAILWAYPART"
+        | "IFCMARINEPART" => "IFCBUILDINGSTOREY",
+        "IFCBUILTELEMENT"
+        | "IFCEARTHWORKSCUT"
+        | "IFCEARTHWORKSELEMENT"
+        | "IFCEARTHWORKSFILL"
+        | "IFCNAVIGATIONELEMENT"
+        | "IFCMOORINGDEVICE"
+        | "IFCRAIL"
+        | "IFCREINFORCEDSOIL"
+        | "IFCSIGN"
+        | "IFCSIGNAL"
+        | "IFCTRACKELEMENT"
+        | "IFCKERB"
+        | "IFCCOURSE" => "IFCBUILDINGELEMENTPROXY",
         "IFCCAISSONFOUNDATION" => "IFCFOOTING",
         "IFCPAVEMENT" => "IFCSLAB",
-        "IFCLINEARPOSITIONINGELEMENT" | "IFCPOSITIONINGELEMENT" | "IFCREFERENT" | "IFCALIGNMENT"
+        "IFCLINEARPOSITIONINGELEMENT"
+        | "IFCPOSITIONINGELEMENT"
+        | "IFCREFERENT"
+        | "IFCALIGNMENT"
         | "IFCLINEARELEMENT" => "IFCPROXY",
         "IFCCONVEYORSEGMENT" => "IFCFLOWSEGMENT",
         "IFCLIQUIDTERMINAL" => "IFCFLOWTERMINAL",
@@ -70,13 +99,32 @@ fn map_4x3_to_4(t: &str) -> Option<&'static str> {
 /// Max positional attributes an entity may carry in IFC2X3 (for downgrade trimming).
 fn ifc2x3_attr_count(t: &str) -> Option<usize> {
     Some(match t {
-        "IFCWALL" | "IFCBEAM" | "IFCCOLUMN" | "IFCMEMBER" | "IFCPLATE" | "IFCOPENINGELEMENT"
-        | "IFCFURNISHINGELEMENT" | "IFCCURTAINWALL" | "IFCFLOWSEGMENT" | "IFCFLOWTERMINAL"
-        | "IFCFLOWCONTROLLER" | "IFCFLOWFITTING" | "IFCFLOWMOVINGDEVICE" | "IFCFLOWSTORAGEDEVICE"
-        | "IFCFLOWTREATMENTDEVICE" | "IFCENERGYCONVERSIONDEVICE" | "IFCDISTRIBUTIONELEMENT"
-        | "IFCDISTRIBUTIONFLOWELEMENT" | "IFCDISTRIBUTIONCONTROLELEMENT"
+        "IFCWALL"
+        | "IFCBEAM"
+        | "IFCCOLUMN"
+        | "IFCMEMBER"
+        | "IFCPLATE"
+        | "IFCOPENINGELEMENT"
+        | "IFCFURNISHINGELEMENT"
+        | "IFCCURTAINWALL"
+        | "IFCFLOWSEGMENT"
+        | "IFCFLOWTERMINAL"
+        | "IFCFLOWCONTROLLER"
+        | "IFCFLOWFITTING"
+        | "IFCFLOWMOVINGDEVICE"
+        | "IFCFLOWSTORAGEDEVICE"
+        | "IFCFLOWTREATMENTDEVICE"
+        | "IFCENERGYCONVERSIONDEVICE"
+        | "IFCDISTRIBUTIONELEMENT"
+        | "IFCDISTRIBUTIONFLOWELEMENT"
+        | "IFCDISTRIBUTIONCONTROLELEMENT"
         | "IFCDISTRIBUTIONCHAMBERELEMENT" => 8,
-        "IFCROOF" | "IFCSTAIR" | "IFCRAMP" | "IFCRAILING" | "IFCFOOTING" | "IFCCOVERING"
+        "IFCROOF"
+        | "IFCSTAIR"
+        | "IFCRAMP"
+        | "IFCRAILING"
+        | "IFCFOOTING"
+        | "IFCCOVERING"
         | "IFCBUILDINGELEMENTPROXY" => 9,
         "IFCPILE" => 11,
         "IFCDOOR" | "IFCWINDOW" => 10,
@@ -91,7 +139,10 @@ fn should_skip_entity(t: &str, to: &str) -> bool {
     }
     matches!(
         t,
-        "IFCALIGNMENTCANT" | "IFCALIGNMENTHORIZONTAL" | "IFCALIGNMENTVERTICAL" | "IFCALIGNMENTSEGMENT"
+        "IFCALIGNMENTCANT"
+            | "IFCALIGNMENTHORIZONTAL"
+            | "IFCALIGNMENTVERTICAL"
+            | "IFCALIGNMENTSEGMENT"
     )
 }
 
@@ -243,11 +294,20 @@ mod tests {
 
     #[test]
     fn entity_type_renames() {
-        assert_eq!(convert_entity_type("IFCBURNERTYPE", "IFC4", "IFC2X3"), "IFCGASTERMINALTYPE");
-        assert_eq!(convert_entity_type("IFCCHIMNEY", "IFC4", "IFC2X3"), "IFCBUILDINGELEMENTPROXY");
+        assert_eq!(
+            convert_entity_type("IFCBURNERTYPE", "IFC4", "IFC2X3"),
+            "IFCGASTERMINALTYPE"
+        );
+        assert_eq!(
+            convert_entity_type("IFCCHIMNEY", "IFC4", "IFC2X3"),
+            "IFCBUILDINGELEMENTPROXY"
+        );
         assert_eq!(convert_entity_type("IFCWALL", "IFC2X3", "IFC4"), "IFCWALL"); // unchanged
-        // chained 4X3 → 2X3 (via 4): IfcFacility → IfcBuilding
-        assert_eq!(convert_entity_type("IFCFACILITY", "IFC4X3", "IFC2X3"), "IFCBUILDING");
+                                                                                 // chained 4X3 → 2X3 (via 4): IfcFacility → IfcBuilding
+        assert_eq!(
+            convert_entity_type("IFCFACILITY", "IFC4X3", "IFC2X3"),
+            "IFCBUILDING"
+        );
     }
 
     #[test]
@@ -256,7 +316,10 @@ mod tests {
         let line = "#5=IFCWALL('guid',$,'W1',$,$,#6,#7,'tag',.STANDARD.);";
         let out = convert_step_line(line, "IFC4", "IFC2X3", 5);
         assert!(out.starts_with("#5=IFCWALL("), "type kept");
-        assert!(!out.contains(".STANDARD."), "9th attr (PredefinedType) trimmed");
+        assert!(
+            !out.contains(".STANDARD."),
+            "9th attr (PredefinedType) trimmed"
+        );
         // 8 top-level attrs remain → 7 commas.
         let inner = &out["#5=IFCWALL(".len()..out.len() - 2];
         assert_eq!(inner.split(',').count(), 8, "trimmed to 8 attrs");
@@ -276,7 +339,10 @@ mod tests {
         let line = "#3=IFCALIGNMENTHORIZONTAL('g',$,$,$,$,#4);";
         let out = convert_step_line(line, "IFC4X3", "IFC4", 3);
         assert!(out.starts_with("#3=IFCPROXY("), "alignment → proxy");
-        assert!(out.contains("'IFCALIGNMENTHORIZONTAL'"), "original type recorded as name");
+        assert!(
+            out.contains("'IFCALIGNMENTHORIZONTAL'"),
+            "original type recorded as name"
+        );
     }
 
     #[test]

--- a/rust/export/src/shades.rs
+++ b/rust/export/src/shades.rs
@@ -10,8 +10,8 @@ use std::collections::HashMap;
 
 use ifc_lite_geometry::ExtractedProfile;
 
-use crate::hbjson::ShadeMesh;
 use crate::geom::{clean_ring, xf, zup};
+use crate::hbjson::ShadeMesh;
 
 /// Build one `ShadeMesh` per `IfcRailing` occurrence from its extruded profile prisms.
 pub fn build_shades(profiles: &[ExtractedProfile], origin: [f64; 3]) -> Vec<ShadeMesh> {
@@ -37,11 +37,19 @@ pub fn build_shades(profiles: &[ExtractedProfile], origin: [f64; 3]) -> Vec<Shad
             if n < 3 {
                 continue;
             }
-            let dir = zup([p.extrusion_dir[0] as f64, p.extrusion_dir[1] as f64, p.extrusion_dir[2] as f64]);
+            let dir = zup([
+                p.extrusion_dir[0] as f64,
+                p.extrusion_dir[1] as f64,
+                p.extrusion_dir[2] as f64,
+            ]);
             let depth = p.extrusion_depth as f64;
             let ring: Vec<[f64; 3]> = (0..n)
                 .map(|i| {
-                    let w = xf(&p.transform, p.outer_points[i * 2] as f64, p.outer_points[i * 2 + 1] as f64);
+                    let w = xf(
+                        &p.transform,
+                        p.outer_points[i * 2] as f64,
+                        p.outer_points[i * 2 + 1] as f64,
+                    );
                     [w[0] - origin[0], w[1] - origin[1], w[2] - origin[2]]
                 })
                 .collect();
@@ -56,7 +64,11 @@ pub fn build_shades(profiles: &[ExtractedProfile], origin: [f64; 3]) -> Vec<Shad
                 verts.push(*r);
             }
             for r in &ring {
-                verts.push([r[0] + dir[0] * depth, r[1] + dir[1] * depth, r[2] + dir[2] * depth]);
+                verts.push([
+                    r[0] + dir[0] * depth,
+                    r[1] + dir[1] * depth,
+                    r[2] + dir[2] * depth,
+                ]);
             }
             // side quads → two triangles each (the visible shade surface).
             for i in 0..m {

--- a/rust/export/src/step.rs
+++ b/rust/export/src/step.rs
@@ -259,7 +259,11 @@ pub fn export_step_json(
         attribute_mutations: muts
             .attribute_updates
             .into_iter()
-            .map(|a| AttrMutation { express_id: a.express_id, index: a.index, value: a.value })
+            .map(|a| AttrMutation {
+                express_id: a.express_id,
+                index: a.index,
+                value: a.value,
+            })
             .collect(),
         property_mutations: muts
             .property_mutations
@@ -326,19 +330,25 @@ pub fn export_step_with_stats(content: &[u8], opts: &StepOptions) -> (String, St
     let source_schema = detect_schema(content);
     let schema = opts.schema.clone().unwrap_or_else(|| source_schema.clone());
     // Only convert entity types/attributes when an explicit target differs from source.
-    let converting = opts.schema.is_some()
-        && crate::schema_convert::needs_conversion(&source_schema, &schema);
+    let converting =
+        opts.schema.is_some() && crate::schema_convert::needs_conversion(&source_schema, &schema);
 
     // Root-attribute edits, grouped by entity id.
     let mut muts_by_id: HashMap<u32, Vec<(usize, String)>> = HashMap::new();
     for m in &opts.attribute_mutations {
-        muts_by_id.entry(m.express_id).or_default().push((m.index, m.value.clone()));
+        muts_by_id
+            .entry(m.express_id)
+            .or_default()
+            .push((m.index, m.value.clone()));
     }
 
     // 3. Emit header + filtered entities (source order) + footer.
     let mut out = String::new();
     out.push_str("ISO-10303-21;\nHEADER;\n");
-    out.push_str(&format!("FILE_DESCRIPTION(('{}'),'2;1');\n", escape(&opts.description)));
+    out.push_str(&format!(
+        "FILE_DESCRIPTION(('{}'),'2;1');\n",
+        escape(&opts.description)
+    ));
     out.push_str(&format!(
         "FILE_NAME('','',('{}'),('{}'),'{}','ifc-lite-export','');\n",
         escape(&opts.author),
@@ -407,7 +417,11 @@ pub fn export_step_with_stats(content: &[u8], opts: &StepOptions) -> (String, St
             }
             let psid = next;
             next += 1;
-            let refs_str = prop_refs.iter().map(|r| format!("#{r}")).collect::<Vec<_>>().join(",");
+            let refs_str = prop_refs
+                .iter()
+                .map(|r| format!("#{r}"))
+                .collect::<Vec<_>>()
+                .join(",");
             out.push_str(&format!(
                 "#{psid}=IFCPROPERTYSET('{}',$,'{}',$,({}));\n",
                 crate::schema_convert::placeholder_guid(psid),
@@ -427,7 +441,13 @@ pub fn export_step_with_stats(content: &[u8], opts: &StepOptions) -> (String, St
 
     out.push_str("ENDSEC;\nEND-ISO-10303-21;\n");
 
-    (out, StepStats { total: order.len(), written })
+    (
+        out,
+        StepStats {
+            total: order.len(),
+            written,
+        },
+    )
 }
 
 #[cfg(test)]
@@ -481,12 +501,18 @@ mod tests {
 
         let (step, stats) = export_step_with_stats(
             &src,
-            &StepOptions { included: Some(vec![wall_id]), ..StepOptions::default() },
+            &StepOptions {
+                included: Some(vec![wall_id]),
+                ..StepOptions::default()
+            },
         );
         let (_n, ids, _schema) = parse_back(&step);
 
         assert!(ids.contains(&wall_id), "the requested wall is present");
-        assert!(stats.written < stats.total, "subset is smaller than the whole model");
+        assert!(
+            stats.written < stats.total,
+            "subset is smaller than the whole model"
+        );
 
         // Reference-closed: every #ref emitted must itself be present (no dangling refs).
         for line in step.lines().filter(|l| l.starts_with('#')) {
@@ -574,14 +600,19 @@ mod tests {
         // distinct from duplex's original rels which carry a real OwnerHistory ref.
         let synth_rel = format!(",$,$,$,(#{wall}),#");
         assert!(
-            step.lines().any(|l| l.contains("=IFCRELDEFINESBYPROPERTIES(") && l.contains(&synth_rel)),
+            step.lines()
+                .any(|l| l.contains("=IFCRELDEFINESBYPROPERTIES(") && l.contains(&synth_rel)),
             "synthesized rel targeting the wall not found"
         );
 
         // Re-parses, and the synthesized entities are counted (written = original + 3).
         let (reparsed, _ids, _schema) = parse_back(&step);
         assert_eq!(reparsed, stats.written, "every written entity re-parses");
-        assert_eq!(stats.written, stats.total + 3, "added 1 prop + 1 pset + 1 rel");
+        assert_eq!(
+            stats.written,
+            stats.total + 3,
+            "added 1 prop + 1 pset + 1 rel"
+        );
     }
 
     #[test]
@@ -598,7 +629,10 @@ mod tests {
         let src = fixture("ara3d/duplex.ifc");
         let (step, stats) = export_step_with_stats(
             &src,
-            &StepOptions { schema: Some("IFC4".to_string()), ..StepOptions::default() },
+            &StepOptions {
+                schema: Some("IFC4".to_string()),
+                ..StepOptions::default()
+            },
         );
         assert!(step.contains("FILE_SCHEMA(('IFC4'))"));
         // Conversion preserves every express id (renames type, never drops entities).

--- a/rust/export/src/usd.rs
+++ b/rust/export/src/usd.rs
@@ -52,7 +52,10 @@ pub struct UsdOptions {
 
 impl Default for UsdOptions {
     fn default() -> Self {
-        Self { author: "ifc-lite".to_string(), instancing: true }
+        Self {
+            author: "ifc-lite".to_string(),
+            instancing: true,
+        }
     }
 }
 
@@ -83,7 +86,11 @@ pub fn export_usd(content: &[u8], opts: &UsdOptions) -> String {
     }
 
     // De-baked instance occurrences (empty unless instancing is active + safe).
-    let instances: &[InstanceRecord] = if use_instancing { &result.instances } else { &[] };
+    let instances: &[InstanceRecord] = if use_instancing {
+        &result.instances
+    } else {
+        &[]
+    };
     let instances_by_id: HashMap<u32, &InstanceRecord> =
         instances.iter().map(|r| (r.express_id, r)).collect();
 
@@ -127,7 +134,10 @@ pub fn export_usd(content: &[u8], opts: &UsdOptions) -> String {
     // instance record's own metadata so a geometry-only element still gets a typed prim).
     let mut info: HashMap<u32, (String, String)> = HashMap::new();
     for e in &model.entities {
-        info.insert(e.express_id, (e.name.clone().unwrap_or_default(), e.ifc_type.clone()));
+        info.insert(
+            e.express_id,
+            (e.name.clone().unwrap_or_default(), e.ifc_type.clone()),
+        );
     }
     let (children, project) = spatial_children(content);
     if let Some(pid) = project {
@@ -137,7 +147,10 @@ pub fn export_usd(content: &[u8], opts: &UsdOptions) -> String {
     for id in &mesh_order {
         if !info.contains_key(id) {
             if let Some(m) = meshes_by_id.get(id).and_then(|v| v.first()) {
-                info.insert(*id, (m.name.clone().unwrap_or_default(), m.ifc_type.clone()));
+                info.insert(
+                    *id,
+                    (m.name.clone().unwrap_or_default(), m.ifc_type.clone()),
+                );
             }
         }
     }
@@ -206,8 +219,11 @@ pub fn export_usd(content: &[u8], opts: &UsdOptions) -> String {
 
     // Leftover geometry-bearing ids the spatial walk never reached (type-product meshes,
     // instances/elements outside the spatial tree). NEVER silently dropped.
-    let leftover: Vec<u32> =
-        all_ids.iter().copied().filter(|id| !emitted.contains(id)).collect();
+    let leftover: Vec<u32> = all_ids
+        .iter()
+        .copied()
+        .filter(|id| !emitted.contains(id))
+        .collect();
     if !leftover.is_empty() {
         if project.is_some() {
             // Park them under a synthetic sibling so the project tree stays clean.

--- a/rust/export/src/usd/emit.rs
+++ b/rust/export/src/usd/emit.rs
@@ -88,7 +88,15 @@ pub(super) fn emit_prim(
     if depth < MAX_DEPTH {
         if let Some(kids) = ctx.children.get(&id) {
             for &cid in kids {
-                emit_prim(out, ctx, cid, indent + 1, depth + 1, emitted, &mut child_names);
+                emit_prim(
+                    out,
+                    ctx,
+                    cid,
+                    indent + 1,
+                    depth + 1,
+                    emitted,
+                    &mut child_names,
+                );
             }
         }
     }
@@ -168,7 +176,14 @@ pub(super) fn write_geometry_body(out: &mut String, indent: usize, m: &MeshData)
         if !pts.is_empty() {
             pts.push_str(", ");
         }
-        write!(pts, "({}, {}, {})", fmt_f32(p[0]), fmt_f32(p[1]), fmt_f32(p[2])).ok();
+        write!(
+            pts,
+            "({}, {}, {})",
+            fmt_f32(p[0]),
+            fmt_f32(p[1]),
+            fmt_f32(p[2])
+        )
+        .ok();
     }
 
     // Normals (1:1 with points → vertex interpolation).
@@ -177,7 +192,14 @@ pub(super) fn write_geometry_body(out: &mut String, indent: usize, m: &MeshData)
         if !nrm.is_empty() {
             nrm.push_str(", ");
         }
-        write!(nrm, "({}, {}, {})", fmt_f32(n[0]), fmt_f32(n[1]), fmt_f32(n[2])).ok();
+        write!(
+            nrm,
+            "({}, {}, {})",
+            fmt_f32(n[0]),
+            fmt_f32(n[1]),
+            fmt_f32(n[2])
+        )
+        .ok();
     }
 
     // faceVertexCounts (all triangles) + indices — built straight into a String.
@@ -230,8 +252,18 @@ pub(super) fn write_display_material(out: &mut String, indent: usize, color: [f3
         fmt_f32(c[2])
     )
     .ok();
-    writeln!(out, "{inner}float[] primvars:displayOpacity = [{}]", fmt_f32(c[3])).ok();
-    writeln!(out, "{inner}rel material:binding = </World/Looks/{}>", mat_name(color_key(color))).ok();
+    writeln!(
+        out,
+        "{inner}float[] primvars:displayOpacity = [{}]",
+        fmt_f32(c[3])
+    )
+    .ok();
+    writeln!(
+        out,
+        "{inner}rel material:binding = </World/Looks/{}>",
+        mat_name(color_key(color))
+    )
+    .ok();
 }
 
 /// Emit one full `UsdGeomMesh` prim. `positions` are authored verbatim as object-LOCAL
@@ -267,7 +299,11 @@ pub(super) fn emit_mesh(
             fmt_f64(m.origin[2])
         )
         .ok();
-        writeln!(out, "{inner}uniform token[] xformOpOrder = [\"xformOp:translate\"]").ok();
+        writeln!(
+            out,
+            "{inner}uniform token[] xformOpOrder = [\"xformOp:translate\"]"
+        )
+        .ok();
     }
     writeln!(out, "{pad}}}").ok();
 }
@@ -322,9 +358,24 @@ pub(super) fn write_header(out: &mut String, opts: &UsdOptions, content: &[u8]) 
     out.push_str("    metersPerUnit = 1\n");
     out.push_str("    upAxis = \"Z\"\n");
     out.push_str("    customLayerData = {\n");
-    writeln!(out, "        string author = \"{}\"", escape_str(&opts.author)).ok();
-    writeln!(out, "        string generator = \"ifc-lite {}\"", env!("CARGO_PKG_VERSION")).ok();
-    writeln!(out, "        string sourceFingerprint = \"{}\"", source_fingerprint(content)).ok();
+    writeln!(
+        out,
+        "        string author = \"{}\"",
+        escape_str(&opts.author)
+    )
+    .ok();
+    writeln!(
+        out,
+        "        string generator = \"ifc-lite {}\"",
+        env!("CARGO_PKG_VERSION")
+    )
+    .ok();
+    writeln!(
+        out,
+        "        string sourceFingerprint = \"{}\"",
+        source_fingerprint(content)
+    )
+    .ok();
     out.push_str("    }\n)\n\n");
 }
 
@@ -349,6 +400,9 @@ pub(super) fn source_fingerprint(content: &[u8]) -> String {
 /// are marked `guide` so they don't occlude the model in the default render but stay
 /// available in guide displays. Everything else uses the default (render) purpose.
 fn guide_purpose(ifc_type: &str) -> Option<&'static str> {
-    matches!(ifc_type, "IfcOpeningElement" | "IfcVoidingFeature" | "IfcSpace")
-        .then_some("guide")
+    matches!(
+        ifc_type,
+        "IfcOpeningElement" | "IfcVoidingFeature" | "IfcSpace"
+    )
+    .then_some("guide")
 }

--- a/rust/export/src/usd/fmt.rs
+++ b/rust/export/src/usd/fmt.rs
@@ -32,12 +32,22 @@ pub(super) fn clamp_color(c: [f32; 4]) -> [f32; 4] {
 
 /// Map every character outside `[A-Za-z0-9_]` to `_`.
 fn map_ident_chars(s: &str) -> String {
-    s.chars().map(|c| if c.is_ascii_alphanumeric() || c == '_' { c } else { '_' }).collect()
+    s.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
 }
 
 /// True when `s` begins with a legal USD identifier start (`[A-Za-z_]`).
 fn starts_legally(s: &str) -> bool {
-    s.chars().next().is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+    s.chars()
+        .next()
+        .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
 }
 
 /// Sanitize a string to a USD identifier segment: `[A-Za-z_][A-Za-z0-9_]*`. Empty or
@@ -54,9 +64,17 @@ pub(super) fn sanitize_ident(s: &str, fallback: &str) -> String {
 /// USD prim name for an element: sanitized display-name (or type) + `_<express id>`
 /// so element siblings are always unique regardless of name collisions.
 pub(super) fn prim_name(name: &str, fallback_type: &str, id: u32) -> String {
-    let base = if name.trim().is_empty() { fallback_type } else { name };
+    let base = if name.trim().is_empty() {
+        fallback_type
+    } else {
+        name
+    };
     let out = map_ident_chars(base);
-    let out = if starts_legally(&out) { out } else { format!("p_{out}") };
+    let out = if starts_legally(&out) {
+        out
+    } else {
+        format!("p_{out}")
+    };
     format!("{out}_{id}")
 }
 
@@ -112,7 +130,9 @@ pub(super) struct Namer {
 
 impl Namer {
     pub(super) fn new() -> Self {
-        Self { used: HashSet::new() }
+        Self {
+            used: HashSet::new(),
+        }
     }
 
     /// Reserve a name (for fixed structural children like `Looks` / `Unassigned`).

--- a/rust/export/src/usd/instance.rs
+++ b/rust/export/src/usd/instance.rs
@@ -84,7 +84,9 @@ fn all_instances_safe(r: &ProcessingResult) -> bool {
         *submesh_count.entry(m.express_id).or_default() += 1;
     }
     instances_authorable(
-        r.instances.iter().map(|rec| (rec.express_id, rec.template_express_id, rec.transform)),
+        r.instances
+            .iter()
+            .map(|rec| (rec.express_id, rec.template_express_id, rec.transform)),
         &submesh_count,
     )
 }
@@ -100,9 +102,11 @@ pub(super) fn instances_authorable(
 ) -> bool {
     // `instances_by_id` is keyed by `express_id`, so a repeated id would be overwritten.
     let mut seen_occurrence: HashSet<u32> = HashSet::new();
-    instances.into_iter().all(|(express_id, template_id, transform)| {
-        // A finite, affine transform (the authored `matrix4d` would otherwise misplace it).
-        transform_is_affine_finite(&transform)
+    instances
+        .into_iter()
+        .all(|(express_id, template_id, transform)| {
+            // A finite, affine transform (the authored `matrix4d` would otherwise misplace it).
+            transform_is_affine_finite(&transform)
             // Exactly one record per element id.
             && seen_occurrence.insert(express_id)
             // The occurrence must NOT also own a full mesh: the emitter takes the instance
@@ -112,7 +116,7 @@ pub(super) fn instances_authorable(
             // exactly ONE emittable submesh — else `.first()` is an ambiguous prototype for
             // a template element that backs several maps.
             && submesh_count.get(&template_id).copied() == Some(1)
-    })
+        })
 }
 
 /// True when `a` is finite and affine (bottom row ≈ (0,0,0,1)). A projective row would make
@@ -140,7 +144,8 @@ pub(super) fn usd_transform_rows(a: &[f32; 16], origin: [f64; 3]) -> Option<[[f6
     }
     let at = |r: usize, c: usize| a[r * 4 + c] as f64;
     // Translation of M = A · T(origin): tᵢ = Aᵢ₀·oₓ + Aᵢ₁·o_y + Aᵢ₂·o_z + Aᵢ₃.
-    let t = |i: usize| at(i, 0) * origin[0] + at(i, 1) * origin[1] + at(i, 2) * origin[2] + at(i, 3);
+    let t =
+        |i: usize| at(i, 0) * origin[0] + at(i, 1) * origin[1] + at(i, 2) * origin[2] + at(i, 3);
     // USD rows are the COLUMNS of M (transpose): linear 3×3 = A's, translation in row 3.
     Some([
         [at(0, 0), at(1, 0), at(2, 0), 0.0],
@@ -170,7 +175,10 @@ pub(super) fn emit_instance_occurrence(
     template_origin: &HashMap<u32, [f64; 3]>,
     purpose: Option<&str>,
 ) {
-    let origin = template_origin.get(&rec.template_express_id).copied().unwrap_or([0.0; 3]);
+    let origin = template_origin
+        .get(&rec.template_express_id)
+        .copied()
+        .unwrap_or([0.0; 3]);
     // Gated by `all_instances_safe` before we ever reach the instanced path.
     let Some(rows) = usd_transform_rows(&rec.transform, origin) else {
         return;
@@ -180,7 +188,11 @@ pub(super) fn emit_instance_occurrence(
     let proto = proto_name(rec.template_express_id);
 
     writeln!(out, "\n{pad}def Mesh \"{name}\" (").ok();
-    writeln!(out, "{inner}prepend references = </World/Prototypes/{proto}>").ok();
+    writeln!(
+        out,
+        "{inner}prepend references = </World/Prototypes/{proto}>"
+    )
+    .ok();
     writeln!(out, "{inner}prepend apiSchemas = [\"MaterialBindingAPI\"]").ok();
     writeln!(out, "{pad})").ok();
     writeln!(out, "{pad}{{").ok();
@@ -188,13 +200,29 @@ pub(super) fn emit_instance_occurrence(
         out,
         "{inner}matrix4d xformOp:transform = ( ({}, {}, {}, {}), ({}, {}, {}, {}), \
          ({}, {}, {}, {}), ({}, {}, {}, {}) )",
-        fmt_f64(rows[0][0]), fmt_f64(rows[0][1]), fmt_f64(rows[0][2]), fmt_f64(rows[0][3]),
-        fmt_f64(rows[1][0]), fmt_f64(rows[1][1]), fmt_f64(rows[1][2]), fmt_f64(rows[1][3]),
-        fmt_f64(rows[2][0]), fmt_f64(rows[2][1]), fmt_f64(rows[2][2]), fmt_f64(rows[2][3]),
-        fmt_f64(rows[3][0]), fmt_f64(rows[3][1]), fmt_f64(rows[3][2]), fmt_f64(rows[3][3]),
+        fmt_f64(rows[0][0]),
+        fmt_f64(rows[0][1]),
+        fmt_f64(rows[0][2]),
+        fmt_f64(rows[0][3]),
+        fmt_f64(rows[1][0]),
+        fmt_f64(rows[1][1]),
+        fmt_f64(rows[1][2]),
+        fmt_f64(rows[1][3]),
+        fmt_f64(rows[2][0]),
+        fmt_f64(rows[2][1]),
+        fmt_f64(rows[2][2]),
+        fmt_f64(rows[2][3]),
+        fmt_f64(rows[3][0]),
+        fmt_f64(rows[3][1]),
+        fmt_f64(rows[3][2]),
+        fmt_f64(rows[3][3]),
     )
     .ok();
-    writeln!(out, "{inner}uniform token[] xformOpOrder = [\"xformOp:transform\"]").ok();
+    writeln!(
+        out,
+        "{inner}uniform token[] xformOpOrder = [\"xformOp:transform\"]"
+    )
+    .ok();
     if let Some(p) = purpose {
         writeln!(out, "{inner}uniform token purpose = \"{p}\"").ok();
     }

--- a/rust/export/src/usd/tests.rs
+++ b/rust/export/src/usd/tests.rs
@@ -20,8 +20,10 @@ use std::collections::HashSet;
 /// Git-tracked hello-wall fixture (IFC4, metres): Project → Site → Building → Storey,
 /// a meshed IfcWall (#1222) with `Pset_WallCommon.IsExternal`, surface styles.
 fn hello_wall() -> Vec<u8> {
-    let path =
-        format!("{}/../../apps/landing/samples/hello-wall.ifc", env!("CARGO_MANIFEST_DIR"));
+    let path = format!(
+        "{}/../../apps/landing/samples/hello-wall.ifc",
+        env!("CARGO_MANIFEST_DIR")
+    );
     std::fs::read(&path).unwrap_or_else(|e| panic!("read {path}: {e}"))
 }
 
@@ -58,7 +60,9 @@ fn strip_quotes(line: &str) -> String {
 
 /// `def <Type> "<name>"` or `class <Type> "<name>"` → `(Type, name)`, else None.
 fn def_of(trimmed: &str) -> Option<(String, String)> {
-    let rest = trimmed.strip_prefix("def ").or_else(|| trimmed.strip_prefix("class "))?;
+    let rest = trimmed
+        .strip_prefix("def ")
+        .or_else(|| trimmed.strip_prefix("class "))?;
     let ty: String = rest.chars().take_while(|c| !c.is_whitespace()).collect();
     let start = rest.find('"')? + 1;
     let end = rest[start..].find('"')? + start;
@@ -68,7 +72,9 @@ fn def_of(trimmed: &str) -> Option<(String, String)> {
 /// Walk the stage body from `/World`, asserting braces AND parens balance and that no
 /// two prims share a name within the same parent scope. Returns all `(type, name)` defs.
 fn scan(usda: &str) -> Vec<(String, String)> {
-    let start = usda.find("\ndef Xform \"World\"").expect("World prim present");
+    let start = usda
+        .find("\ndef Xform \"World\"")
+        .expect("World prim present");
     let body = &usda[start + 1..];
     let mut scopes: Vec<HashSet<String>> = vec![HashSet::new()];
     let mut parens: i32 = 0;
@@ -77,7 +83,10 @@ fn scan(usda: &str) -> Vec<(String, String)> {
         let t = raw.trim_start();
         if let Some((ty, name)) = def_of(t) {
             let fresh = scopes.last_mut().unwrap().insert(name.clone());
-            assert!(fresh, "duplicate prim name `{name}` within one parent scope");
+            assert!(
+                fresh,
+                "duplicate prim name `{name}` within one parent scope"
+            );
             defs.push((ty, name));
         }
         for c in strip_quotes(raw).chars() {
@@ -94,7 +103,11 @@ fn scan(usda: &str) -> Vec<(String, String)> {
             assert!(parens >= 0, "unbalanced `)` in USDA");
         }
     }
-    assert_eq!(scopes.len(), 1, "unbalanced scopes (a `def` block never closed)");
+    assert_eq!(
+        scopes.len(),
+        1,
+        "unbalanced scopes (a `def` block never closed)"
+    );
     assert_eq!(parens, 0, "unbalanced prim-metadata parens");
     defs
 }
@@ -159,8 +172,10 @@ fn parse_meshes(usda: &str) -> Vec<ParsedMesh> {
             } else if let Some(a) = t.strip_prefix("int[] faceVertexIndices = ") {
                 m.indices = nums_u32(a);
             } else if let Some(a) = t.strip_prefix("double3 xformOp:translate = ") {
-                let v: Vec<f64> =
-                    a.split(['(', ')', ',']).filter_map(|x| x.trim().parse::<f64>().ok()).collect();
+                let v: Vec<f64> = a
+                    .split(['(', ')', ','])
+                    .filter_map(|x| x.trim().parse::<f64>().ok())
+                    .collect();
                 if v.len() == 3 {
                     m.translate = Some([v[0], v[1], v[2]]);
                 }
@@ -179,13 +194,28 @@ fn parse_meshes(usda: &str) -> Vec<ParsedMesh> {
 fn exports_valid_usda_header_and_geometry() {
     let usda = export(&hello_wall());
 
-    assert!(usda.starts_with("#usda 1.0\n(\n"), "must open with the magic + metadata block");
+    assert!(
+        usda.starts_with("#usda 1.0\n(\n"),
+        "must open with the magic + metadata block"
+    );
     let first_def = usda.find("\ndef ").expect("a root prim");
     let header = &usda[..first_def];
-    assert!(header.contains("defaultPrim = \"World\""), "defaultPrim in layer metadata");
-    assert!(header.contains("metersPerUnit = 1"), "metersPerUnit in layer metadata");
-    assert!(header.contains("upAxis = \"Z\""), "upAxis in layer metadata");
-    assert!(header.contains("customLayerData = {"), "author routed through customLayerData");
+    assert!(
+        header.contains("defaultPrim = \"World\""),
+        "defaultPrim in layer metadata"
+    );
+    assert!(
+        header.contains("metersPerUnit = 1"),
+        "metersPerUnit in layer metadata"
+    );
+    assert!(
+        header.contains("upAxis = \"Z\""),
+        "upAxis in layer metadata"
+    );
+    assert!(
+        header.contains("customLayerData = {"),
+        "author routed through customLayerData"
+    );
 
     assert!(usda.contains("def Xform \"World\""), "root World Xform");
     assert!(usda.contains("def Mesh \""), "at least one mesh");
@@ -201,25 +231,43 @@ fn blocker_syntax_present() {
 
     // B2: every authored translate MUST be paired 1:1 with an xformOpOrder.
     let translates = usda.matches("double3 xformOp:translate").count();
-    let orders = usda.matches("uniform token[] xformOpOrder = [\"xformOp:translate\"]").count();
-    assert_eq!(translates, orders, "each xformOp:translate needs its xformOpOrder");
+    let orders = usda
+        .matches("uniform token[] xformOpOrder = [\"xformOp:translate\"]")
+        .count();
+    assert_eq!(
+        translates, orders,
+        "each xformOp:translate needs its xformOpOrder"
+    );
 
     // B3: every material:binding needs MaterialBindingAPI applied.
     let bindings = usda.matches("rel material:binding").count();
-    let applied = usda.matches("prepend apiSchemas = [\"MaterialBindingAPI\"]").count();
+    let applied = usda
+        .matches("prepend apiSchemas = [\"MaterialBindingAPI\"]")
+        .count();
     assert!(bindings > 0, "the wall binds a material");
-    assert_eq!(bindings, applied, "each bound prim applies MaterialBindingAPI");
+    assert_eq!(
+        bindings, applied,
+        "each bound prim applies MaterialBindingAPI"
+    );
 
     // B4: meshes must opt out of subdivision or authored normals are ignored.
     let meshes = usda.matches("def Mesh \"").count();
-    let none = usda.matches("uniform token subdivisionScheme = \"none\"").count();
+    let none = usda
+        .matches("uniform token subdivisionScheme = \"none\"")
+        .count();
     assert_eq!(meshes, none, "every mesh sets subdivisionScheme = none");
 }
 
 #[test]
 fn hierarchy_has_project_and_spatial_chain() {
     let usda = export(&hello_wall());
-    for class in ["IfcProject", "IfcSite", "IfcBuilding", "IfcBuildingStorey", "IfcWall"] {
+    for class in [
+        "IfcProject",
+        "IfcSite",
+        "IfcBuilding",
+        "IfcBuildingStorey",
+        "IfcWall",
+    ] {
         assert!(
             usda.contains(&format!("custom string ifc:class = \"{class}\"")),
             "expected an {class} prim",
@@ -234,11 +282,18 @@ fn join_complete_no_mesh_dropped() {
     let ids = xform_ids(&scan(&usda));
 
     let result = process_geometry(&bytes);
-    let meshed: HashSet<u32> =
-        result.meshes.iter().filter(|m| mesh_emittable(m)).map(|m| m.express_id).collect();
+    let meshed: HashSet<u32> = result
+        .meshes
+        .iter()
+        .filter(|m| mesh_emittable(m))
+        .map(|m| m.express_id)
+        .collect();
     assert!(!meshed.is_empty(), "fixture has geometry");
     for id in &meshed {
-        assert!(ids.contains(id), "meshed element #{id} has no prim (geometry dropped)");
+        assert!(
+            ids.contains(id),
+            "meshed element #{id} has no prim (geometry dropped)"
+        );
     }
 }
 
@@ -253,15 +308,25 @@ fn geometry_content_matches_source() {
 
     // Per-mesh USD invariants (usdchecker would enforce these).
     for m in &parsed {
-        assert_eq!(m.points.len(), m.normals.len(), "points/normals length mismatch");
-        assert!(m.counts.iter().all(|&c| c == 3), "all faces must be triangles");
+        assert_eq!(
+            m.points.len(),
+            m.normals.len(),
+            "points/normals length mismatch"
+        );
+        assert!(
+            m.counts.iter().all(|&c| c == 3),
+            "all faces must be triangles"
+        );
         assert_eq!(
             m.counts.iter().sum::<u32>() as usize,
             m.indices.len(),
             "sum(faceVertexCounts) must equal faceVertexIndices length",
         );
         let vc = (m.points.len() / 3) as u32;
-        assert!(m.indices.iter().all(|&i| i < vc), "index out of vertex range");
+        assert!(
+            m.indices.iter().all(|&i| i < vc),
+            "index out of vertex range"
+        );
     }
 
     let result = process_geometry(&bytes);
@@ -281,7 +346,9 @@ fn geometry_content_matches_source() {
     assert_eq!(hit.indices, target.indices, "indices must match source");
 
     if target.origin.iter().any(|v| v.abs() > 0.0) {
-        let t = hit.translate.expect("origin-bearing mesh must author a translate");
+        let t = hit
+            .translate
+            .expect("origin-bearing mesh must author a translate");
         for (a, b) in t.iter().zip(target.origin.iter()) {
             assert!((a - b).abs() < 1e-6, "translate must equal origin");
         }
@@ -302,15 +369,28 @@ fn local_points_are_object_scale() {
 #[test]
 fn deterministic() {
     let bytes = hello_wall();
-    assert_eq!(export(&bytes), export(&bytes), "export must be byte-deterministic");
+    assert_eq!(
+        export(&bytes),
+        export(&bytes),
+        "export must be byte-deterministic"
+    );
 }
 
 #[test]
 fn materials_and_properties_present() {
     let usda = export(&hello_wall());
-    assert!(usda.contains("def Material \"Mat_"), "a UsdPreviewSurface material");
-    assert!(usda.contains("uniform token info:id = \"UsdPreviewSurface\""), "preview surface shader");
-    assert!(usda.contains("color3f[] primvars:displayColor = ["), "displayColor fallback");
+    assert!(
+        usda.contains("def Material \"Mat_"),
+        "a UsdPreviewSurface material"
+    );
+    assert!(
+        usda.contains("uniform token info:id = \"UsdPreviewSurface\""),
+        "preview surface shader"
+    );
+    assert!(
+        usda.contains("color3f[] primvars:displayColor = ["),
+        "displayColor fallback"
+    );
     assert!(
         usda.contains("custom string ifc:pset:Pset_WallCommon:IsExternal ="),
         "the wall's Pset_WallCommon.IsExternal property survives to a custom attr",
@@ -321,16 +401,26 @@ fn materials_and_properties_present() {
 fn provenance_in_customlayerdata() {
     let usda = export(&hello_wall());
     let header = &usda[..usda.find("\ndef ").expect("a root prim")];
-    assert!(header.contains("string generator = \"ifc-lite "), "generator provenance present");
+    assert!(
+        header.contains("string generator = \"ifc-lite "),
+        "generator provenance present"
+    );
     let marker = "string sourceFingerprint = \"";
     let start = header.find(marker).expect("source fingerprint present") + marker.len();
     let fp = &header[start..start + 16];
-    assert!(fp.chars().all(|c| c.is_ascii_hexdigit()), "fingerprint is 16 hex digits, got {fp}");
+    assert!(
+        fp.chars().all(|c| c.is_ascii_hexdigit()),
+        "fingerprint is 16 hex digits, got {fp}"
+    );
     // The fingerprint tracks the source: a different input yields a different value.
     let other = b"ISO-10303-21;\nHEADER;\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\nENDSEC;\nEND-ISO-10303-21;\n";
     let other_usda = export(other);
     let os = other_usda.find(marker).expect("fp") + marker.len();
-    assert_ne!(fp, &other_usda[os..os + 16], "fingerprint must depend on source bytes");
+    assert_ne!(
+        fp,
+        &other_usda[os..os + 16],
+        "fingerprint must depend on source bytes"
+    );
 }
 
 /// The text between an `ifc:class = "<class>"` marker and that prim's first `def` child
@@ -346,7 +436,10 @@ fn xform_attr_block<'a>(usda: &'a str, class: &str) -> Option<&'a str> {
 fn element_block<'a>(usda: &'a str, class: &str) -> Option<&'a str> {
     let pos = usda.find(&format!("ifc:class = \"{class}\""))?;
     let rest = &usda[pos..];
-    let end = rest[1..].find("custom string ifc:class = ").map(|i| i + 1).unwrap_or(rest.len());
+    let end = rest[1..]
+        .find("custom string ifc:class = ")
+        .map(|i| i + 1)
+        .unwrap_or(rest.len());
     Some(&rest[..end])
 }
 
@@ -369,7 +462,10 @@ fn openings_and_spaces_are_guide_purpose() {
     }
     // Ordinary building elements keep the default (render) purpose everywhere.
     let wall = element_block(&usda, "IfcWall").expect("wall prim");
-    assert!(!wall.contains("purpose = \"guide\""), "IfcWall must never be guide");
+    assert!(
+        !wall.contains("purpose = \"guide\""),
+        "IfcWall must never be guide"
+    );
 }
 
 #[test]
@@ -377,7 +473,10 @@ fn source_fingerprint_is_stable_fnv1a64() {
     // Canonical FNV-1a-64 vectors — identical on every platform/toolchain (unlike the
     // std DefaultHasher this replaced), so the lineage anchor and the export stay stable.
     assert_eq!(super::emit::source_fingerprint(b""), "cbf29ce484222325");
-    assert_eq!(super::emit::source_fingerprint(b"foobar"), "85944171f73967e8");
+    assert_eq!(
+        super::emit::source_fingerprint(b"foobar"),
+        "85944171f73967e8"
+    );
 }
 
 #[test]
@@ -407,12 +506,19 @@ fn type_product_geometry_lands_in_unassigned() {
     let ids = xform_ids(&scan(&usda));
 
     let result = process_geometry(&bytes);
-    let meshed: Vec<u32> =
-        result.meshes.iter().filter(|m| mesh_emittable(m)).map(|m| m.express_id).collect();
+    let meshed: Vec<u32> = result
+        .meshes
+        .iter()
+        .filter(|m| mesh_emittable(m))
+        .map(|m| m.express_id)
+        .collect();
     if meshed.is_empty() {
         return;
     }
-    assert!(usda.contains("def Xform \"Unassigned\""), "type geometry needs the Unassigned bucket");
+    assert!(
+        usda.contains("def Xform \"Unassigned\""),
+        "type geometry needs the Unassigned bucket"
+    );
     for id in &meshed {
         assert!(ids.contains(id), "type-product mesh #{id} dropped");
     }
@@ -449,7 +555,10 @@ fn mesh_emittable_rejects_bad_index_and_origin() {
     // S1: index buffer not a whole number of triangles.
     let mut bad = good.clone();
     bad.indices = vec![0, 1, 2, 0];
-    assert!(!mesh_emittable(&bad), "non-multiple-of-3 index buffer must be rejected");
+    assert!(
+        !mesh_emittable(&bad),
+        "non-multiple-of-3 index buffer must be rejected"
+    );
 
     // S1: index out of vertex range.
     let mut bad = good.clone();
@@ -464,7 +573,10 @@ fn mesh_emittable_rejects_bad_index_and_origin() {
     // Non-finite coordinate.
     let mut bad = good.clone();
     bad.positions[0] = f32::INFINITY;
-    assert!(!mesh_emittable(&bad), "non-finite position must be rejected");
+    assert!(
+        !mesh_emittable(&bad),
+        "non-finite position must be rejected"
+    );
 }
 
 #[test]
@@ -482,8 +594,16 @@ fn emit_attributes_dedups_colliding_names() {
         property_sets: vec![PropertySet {
             name: "Pset_Test".into(),
             properties: vec![
-                PropValue { name: "Fire Rating".into(), value: "A".into(), value_type: "IFCLABEL".into() },
-                PropValue { name: "Fire-Rating".into(), value: "B".into(), value_type: "IFCLABEL".into() },
+                PropValue {
+                    name: "Fire Rating".into(),
+                    value: "A".into(),
+                    value_type: "IFCLABEL".into(),
+                },
+                PropValue {
+                    name: "Fire-Rating".into(),
+                    value: "B".into(),
+                    value_type: "IFCLABEL".into(),
+                },
             ],
         }],
         quantity_sets: vec![],
@@ -513,8 +633,12 @@ fn sanitize_ident_is_valid() {
         (first.is_ascii_alphabetic() || first == '_')
             && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
     };
-    for (input, fb) in [("Fire Rating", "Prop"), ("2ndFloor", "Prop"), ("", "Prop"), ("é—x", "Prop")]
-    {
+    for (input, fb) in [
+        ("Fire Rating", "Prop"),
+        ("2ndFloor", "Prop"),
+        ("", "Prop"),
+        ("é—x", "Prop"),
+    ] {
         assert!(ok(&sanitize_ident(input, fb)), "`{input}` → invalid ident");
     }
 }
@@ -534,7 +658,10 @@ fn color_key_clamps_out_of_gamut() {
     let key = color_key([-0.1, 2.0, 0.5, f32::NAN]);
     assert_eq!(key, (0, 100, 50, 0));
     let name = mat_name(key);
-    assert!(name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_'), "{name} illegal");
+    assert!(
+        name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_'),
+        "{name} illegal"
+    );
 }
 
 #[test]
@@ -575,12 +702,20 @@ fn apply_usd(rows: &[[f64; 4]; 4], p: [f64; 3]) -> [f64; 3] {
 fn instancing_emits_prototypes_and_references() {
     for bytes in [hello_wall(), synthetic_instances()] {
         let usda = export_usd(&bytes, &UsdOptions::default());
-        assert!(usda.matches("class Mesh \"Proto_").count() >= 1, "expected prototypes");
         assert!(
-            usda.matches("prepend references = </World/Prototypes/Proto_").count() >= 1,
+            usda.matches("class Mesh \"Proto_").count() >= 1,
+            "expected prototypes"
+        );
+        assert!(
+            usda.matches("prepend references = </World/Prototypes/Proto_")
+                .count()
+                >= 1,
             "expected instance references",
         );
-        assert!(usda.contains("matrix4d xformOp:transform"), "instance transform");
+        assert!(
+            usda.contains("matrix4d xformOp:transform"),
+            "instance transform"
+        );
         let defs = scan(&usda);
         let proto_names: HashSet<&str> = defs
             .iter()
@@ -588,11 +723,15 @@ fn instancing_emits_prototypes_and_references() {
             .map(|(_, n)| n.as_str())
             .collect();
         for line in usda.lines() {
-            if let Some(rest) =
-                line.trim().strip_prefix("prepend references = </World/Prototypes/")
+            if let Some(rest) = line
+                .trim()
+                .strip_prefix("prepend references = </World/Prototypes/")
             {
                 let name = rest.trim_end_matches('>');
-                assert!(proto_names.contains(name), "reference target {name} missing");
+                assert!(
+                    proto_names.contains(name),
+                    "reference target {name} missing"
+                );
             }
         }
     }
@@ -603,9 +742,17 @@ fn prototypes_author_no_xform_ops() {
     // A prototype that authored any xformOp would be silently DROPPED by the referencer's
     // own xformOpOrder (strongest-opinion-wins, wholesale) → misplaced geometry.
     let usda = export(&synthetic_instances());
-    let start = usda.find("def Scope \"Prototypes\"").expect("prototypes scope");
-    let end = usda[start..].find("\n    }\n").map(|i| i + start).unwrap_or(usda.len());
-    assert!(!usda[start..end].contains("xformOp"), "prototype scope authored an xformOp");
+    let start = usda
+        .find("def Scope \"Prototypes\"")
+        .expect("prototypes scope");
+    let end = usda[start..]
+        .find("\n    }\n")
+        .map(|i| i + start)
+        .unwrap_or(usda.len());
+    assert!(
+        !usda[start..end].contains("xformOp"),
+        "prototype scope authored an xformOp"
+    );
 }
 
 /// The correctness gate: the authored USD matrix, applied USD-style to the prototype's LOCAL
@@ -634,21 +781,33 @@ fn instance_transform_reconstructs_baked_world() {
                 .expect("safe instance has an affine transform");
             let occ = baked[&rec.express_id];
             let n = t.positions.len() / 3;
-            assert_eq!(n * 3, occ.positions.len(), "template/occurrence vertex count mismatch");
+            assert_eq!(
+                n * 3,
+                occ.positions.len(),
+                "template/occurrence vertex count mismatch"
+            );
             let mut max_err = 0.0f64;
             for v in 0..n {
-                let local =
-                    [t.positions[v * 3] as f64, t.positions[v * 3 + 1] as f64, t.positions[v * 3 + 2] as f64];
+                let local = [
+                    t.positions[v * 3] as f64,
+                    t.positions[v * 3 + 1] as f64,
+                    t.positions[v * 3 + 2] as f64,
+                ];
                 let r = apply_usd(&rows, local);
                 let w = [
                     occ.origin[0] + occ.positions[v * 3] as f64,
                     occ.origin[1] + occ.positions[v * 3 + 1] as f64,
                     occ.origin[2] + occ.positions[v * 3 + 2] as f64,
                 ];
-                let e = ((r[0] - w[0]).powi(2) + (r[1] - w[1]).powi(2) + (r[2] - w[2]).powi(2)).sqrt();
+                let e =
+                    ((r[0] - w[0]).powi(2) + (r[1] - w[1]).powi(2) + (r[2] - w[2]).powi(2)).sqrt();
                 max_err = max_err.max(e);
             }
-            assert!(max_err < 1e-4, "instance {} world error {max_err:.3e} m", rec.express_id);
+            assert!(
+                max_err < 1e-4,
+                "instance {} world error {max_err:.3e} m",
+                rec.express_id
+            );
         }
     }
 }
@@ -664,7 +823,10 @@ fn instancing_no_geometry_dropped() {
     }
     assert!(!expected.is_empty());
     for id in &expected {
-        assert!(ids.contains(id), "occurrence #{id} dropped from instanced stage");
+        assert!(
+            ids.contains(id),
+            "occurrence #{id} dropped from instanced stage"
+        );
     }
 }
 
@@ -674,13 +836,23 @@ fn instance_colours_have_materials() {
     let usda = export(&synthetic_instances());
     let materials: HashSet<&str> = usda
         .lines()
-        .filter_map(|l| l.trim().strip_prefix("def Material \"").and_then(|r| r.strip_suffix('"')))
+        .filter_map(|l| {
+            l.trim()
+                .strip_prefix("def Material \"")
+                .and_then(|r| r.strip_suffix('"'))
+        })
         .collect();
     let mut bindings = 0;
     for line in usda.lines() {
-        if let Some(rest) = line.trim().strip_prefix("rel material:binding = </World/Looks/") {
+        if let Some(rest) = line
+            .trim()
+            .strip_prefix("rel material:binding = </World/Looks/")
+        {
             let name = rest.trim_end_matches('>');
-            assert!(materials.contains(name), "dangling material:binding to {name}");
+            assert!(
+                materials.contains(name),
+                "dangling material:binding to {name}"
+            );
             bindings += 1;
         }
     }
@@ -690,13 +862,29 @@ fn instance_colours_have_materials() {
 #[test]
 fn instancing_disabled_bakes_everything() {
     let bytes = synthetic_instances();
-    let usda = export_usd(&bytes, &UsdOptions { instancing: false, ..UsdOptions::default() });
-    assert!(!usda.contains("Prototypes"), "instancing:false must not author prototypes");
-    assert!(!usda.contains("references ="), "instancing:false must not author references");
+    let usda = export_usd(
+        &bytes,
+        &UsdOptions {
+            instancing: false,
+            ..UsdOptions::default()
+        },
+    );
+    assert!(
+        !usda.contains("Prototypes"),
+        "instancing:false must not author prototypes"
+    );
+    assert!(
+        !usda.contains("references ="),
+        "instancing:false must not author references"
+    );
     let ids = xform_ids(&scan(&usda));
     let flat = process_geometry(&bytes);
     for m in flat.meshes.iter().filter(|m| mesh_emittable(m)) {
-        assert!(ids.contains(&m.express_id), "baked occurrence #{} missing", m.express_id);
+        assert!(
+            ids.contains(&m.express_id),
+            "baked occurrence #{} missing",
+            m.express_id
+        );
     }
 }
 
@@ -708,15 +896,24 @@ fn instancing_deterministic() {
 
 #[test]
 fn usd_transform_rows_identity_and_translation() {
-    let id: [f32; 16] =
-        [1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0];
+    let id: [f32; 16] = [
+        1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+    ];
     // Identity A, zero origin → identity USD rows.
     assert_eq!(
         usd_transform_rows(&id, [0.0; 3]).unwrap(),
-        [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]]
+        [
+            [1.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 1.0]
+        ]
     );
     // Identity A, origin (5,2,3) → translation in the LAST row (row-vector convention).
-    assert_eq!(usd_transform_rows(&id, [5.0, 2.0, 3.0]).unwrap()[3], [5.0, 2.0, 3.0, 1.0]);
+    assert_eq!(
+        usd_transform_rows(&id, [5.0, 2.0, 3.0]).unwrap()[3],
+        [5.0, 2.0, 3.0, 1.0]
+    );
     // A pure translation composes with origin: t = A_trans + A·origin.
     let mut a = id;
     a[3] = 10.0;
@@ -736,8 +933,9 @@ fn usd_transform_rows_identity_and_translation() {
 /// No fixture in the corpus exercises these shapes, so this is the only coverage they get.
 #[test]
 fn instances_authorable_rejects_unrepresentable_shapes() {
-    let id: [f32; 16] =
-        [1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0];
+    let id: [f32; 16] = [
+        1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+    ];
     // Template 7 has one emittable submesh; ids 10/11 are pure occurrences.
     let counts: std::collections::HashMap<u32, usize> = [(7u32, 1usize)].into_iter().collect();
 
@@ -786,7 +984,7 @@ fn usd_transform_rows_handles_rotation() {
     assert_eq!(
         rows,
         [
-            [0.0, 1.0, 0.0, 0.0],   // ≠ its transpose → catches a linear-block transpose
+            [0.0, 1.0, 0.0, 0.0], // ≠ its transpose → catches a linear-block transpose
             [-1.0, 0.0, 0.0, 0.0],
             [0.0, 0.0, 1.0, 0.0],
             [-20.0, 10.0, 30.0, 1.0], // A·origin = (-oy, ox, oz)
@@ -815,7 +1013,12 @@ fn parse_matrix4d(usda: &str) -> [[f64; 4]; 4] {
         .split(['(', ')', ',', '=', ' ', '\t'])
         .filter_map(|t| t.trim().parse::<f64>().ok())
         .collect();
-    assert_eq!(nums.len(), 16, "matrix4d must have 16 components, got {}", nums.len());
+    assert_eq!(
+        nums.len(),
+        16,
+        "matrix4d must have 16 components, got {}",
+        nums.len()
+    );
     let mut m = [[0.0f64; 4]; 4];
     for (k, &v) in nums.iter().enumerate() {
         m[k / 4][k % 4] = v;
@@ -860,12 +1063,23 @@ fn emitted_matrix4d_roundtrips_usd_transform_rows() {
     emit_instance_occurrence(&mut out, 3, "geom", &rec, &origins, None);
 
     // Exact equality: fmt_f64 is shortest-round-trip, so re-parsing is lossless.
-    assert_eq!(parse_matrix4d(&out), expected, "emitted matrix4d text != authored rows");
+    assert_eq!(
+        parse_matrix4d(&out),
+        expected,
+        "emitted matrix4d text != authored rows"
+    );
     // Structural sanity independent of the value check: affine → last column (0,0,0,1),
     // translation lives in the LAST row (row-vector convention), never a stray transpose.
     let m = parse_matrix4d(&out);
     for (r, row) in m.iter().enumerate() {
-        assert_eq!(row[3], if r == 3 { 1.0 } else { 0.0 }, "row {r} last component");
+        assert_eq!(
+            row[3],
+            if r == 3 { 1.0 } else { 0.0 },
+            "row {r} last component"
+        );
     }
-    assert_eq!([m[3][0], m[3][1], m[3][2]], [expected[3][0], expected[3][1], expected[3][2]]);
+    assert_eq!(
+        [m[3][0], m[3][1], m[3][2]],
+        [expected[3][0], expected[3][1], expected[3][2]]
+    );
 }


### PR DESCRIPTION
Formatting only. **169 tests pass unchanged and clippy is clean**, which is the entire claim.

Deliberately kept out of #2372. That change was 4 files and 192 insertions; this is 38 files and 2,831 lines. Reviewing them together would have meant reading the real change through the noise of this one — and #2372 touched frame conversions and quaternions, which needed reading closely. It found three defects on adversarial review, one of them inside the fix itself, and that would have been much harder to spot in a 3,000-line diff.

`rustfmt --check` was already failing on this crate before either change: `gltf.rs` alone was 2,135 diff lines adrift.