### PR TITLE
fix(drawing-2d): break the parent-pointer cycle that hung classifyLoops at 95% load

### DIFF
--- a/.changeset/drawing2d-classify-loops-hang.md
+++ b/.changeset/drawing2d-classify-loops-hang.md
@@ -1,0 +1,5 @@
+---
+'@ifc-lite/drawing-2d': patch
+---
+
+Fix an infinite loop in `PolygonBuilder.classifyLoops` that hung the viewer at ~95% load (issue #2364). The nearest-ancestor search introduced by #2331 tested containment with a single point, so two partially-overlapping loops could each "contain" the other's start vertex, making the parent pointers cyclic and the nesting-depth walk spin forever. Parents are now restricted to earlier (larger-or-equal-area) loops in the area-descending sort, which keeps the ancestor relation acyclic by construction.

--- a/packages/drawing-2d/src/polygon-builder.test.ts
+++ b/packages/drawing-2d/src/polygon-builder.test.ts
@@ -250,4 +250,55 @@ describe('PolygonBuilder — hole containment and winding (classifyLoops)', () =
     expect(isCounterClockwise(islandPoly.polygon.outer)).toBe(true);
     expect(Math.abs(polygonSignedArea(islandPoly.polygon.outer))).toBeCloseTo(4, 5);
   });
+
+  /**
+   * Regression for issue #2364: the viewer hung forever inside
+   * `classifyLoops` on real-world section cuts with overlapping loops.
+   *
+   * Containment is decided by a SINGLE point (`isLoopContainedIn` tests only
+   * `inner[0]`), so two partially-overlapping loops whose start vertices each
+   * lie inside the OTHER loop "contain" each other. The nearest-ancestor
+   * search introduced by #2331 then produced parent[A] = B and parent[B] = A,
+   * and the nesting-depth walk (`p = parent[p]`) cycled forever — a
+   * deterministic hang on any model whose cut yields such loops (coplanar
+   * duplicate faces in dense tessellated geometry are a common source).
+   *
+   * The two equal-area squares below overlap diagonally; each ring is ordered
+   * so its first vertex sits strictly inside the other square. The only thing
+   * this test truly pins is TERMINATION — plus a sane classification: one loop
+   * becomes the outer, the other its hole, never two mutual parents.
+   */
+  it('terminates on mutually-overlapping loops whose start points contain each other (#2364)', () => {
+    const ring = (corners: [number, number][], entityId: number): CutSegment[] =>
+      corners.map((a, i) => {
+        const b = corners[(i + 1) % corners.length];
+        return {
+          p0: { x: a[0], y: a[1], z: 0 },
+          p1: { x: b[0], y: b[1], z: 0 },
+          p0_2d: { x: a[0], y: a[1] },
+          p1_2d: { x: b[0], y: b[1] },
+          entityId,
+          ifcType: 'IfcWall',
+          modelIndex: 0,
+          color: undefined,
+        };
+      });
+
+    const segments = [
+      // Square [1,5]×[1,5], first vertex (5,5) — strictly inside the second square.
+      ...ring([[5, 5], [1, 5], [1, 1], [5, 1]], 700),
+      // Square [2,6]×[2,6], first vertex (2,2) — strictly inside the first square.
+      ...ring([[2, 2], [6, 2], [6, 6], [2, 6]], 700),
+    ];
+
+    const polygons = new PolygonBuilder().buildPolygons(segments);
+
+    // Equal areas make the outer/hole tie-break an implementation detail;
+    // what matters is one solid polygon with the other ring as its hole.
+    expect(polygons).toHaveLength(1);
+    const { outer, holes } = polygons[0].polygon;
+    expect(holes).toHaveLength(1);
+    expect(Math.abs(polygonSignedArea(outer))).toBeCloseTo(16, 5);
+    expect(Math.abs(polygonSignedArea(holes[0]))).toBeCloseTo(16, 5);
+  });
 });

--- a/packages/drawing-2d/src/polygon-builder.ts
+++ b/packages/drawing-2d/src/polygon-builder.ts
@@ -550,28 +550,26 @@ export class PolygonBuilder {
   private classifyLoops(loops: Loop[]): Array<{ outer: Point2D[]; holes: Point2D[][] }> {
     if (loops.length === 0) return [];
 
-    // Sort by absolute area (largest first) — the nearest-ancestor search
-    // below relies on iterating candidates by area, not on this order.
+    // Sort by absolute area (largest first). The parent search below only
+    // considers EARLIER (larger-or-equal-area) loops as containers: a genuine
+    // container can never be smaller than what it contains, and restricting
+    // parents to earlier indices keeps the relation acyclic even when
+    // overlapping or duplicate loops make the single-point containment test
+    // mutual (A "contains" B's start point and B "contains" A's) — without it
+    // the ancestor walk below would spin forever on such input.
     const sorted = [...loops].sort((a, b) => Math.abs(b.area) - Math.abs(a.area));
     const n = sorted.length;
 
-    // Nearest containing ancestor: the smallest-area OTHER loop that
-    // contains this one. -1 = top-level (no containing loop).
+    // Nearest containing ancestor: walking earlier loops from smallest area
+    // upward, the first one that contains this loop. -1 = top-level.
     const parent: number[] = new Array(n).fill(-1);
     for (let i = 0; i < n; i++) {
-      let bestParent = -1;
-      let bestArea = Infinity;
-      for (let j = 0; j < n; j++) {
-        if (i === j) continue;
+      for (let j = i - 1; j >= 0; j--) {
         if (this.isLoopContainedIn(sorted[i].points, sorted[j].points)) {
-          const area = Math.abs(sorted[j].area);
-          if (area < bestArea) {
-            bestArea = area;
-            bestParent = j;
-          }
+          parent[i] = j;
+          break;
         }
       }
-      parent[i] = bestParent;
     }
 
     // Nesting depth = length of the ancestor chain to the top level.


### PR DESCRIPTION
Fixes #2364 — a model that loaded fine 1–2 weeks ago now hangs at ~95% ("Rendering geometry"), debugger stuck in `classifyLoops`. Reproducible in Chrome and Firefox.

## Root cause

#2331 (merged this morning, ~6h before the report) rewrote `classifyLoops` to compute a nearest-containing-ancestor `parent[]` array and derive nesting depth by walking the chain:

```ts
while (p !== -1) { d++; p = parent[p]; }
```

Containment is decided by a **single point** — `isLoopContainedIn` tests only `inner[0]`. Two partially-overlapping loops (coplanar duplicate faces in dense tessellated Bonsai/IfcOpenShell exports are a common source) can each contain the other's start vertex, giving `parent[A] = B` and `parent[B] = A`. The depth walk then cycles forever: a deterministic, browser-independent infinite loop, exactly matching the report.

## Fix

Only loops **earlier** in the area-descending sort may be parents. A genuine container can never have smaller area than what it contains, so nothing real is lost — and `parent[i] < i` by construction means ancestor chains strictly decrease and can never cycle, even on overlapping or duplicate rings where the single-point test is mutual. Scanning `j` from `i-1` downward, the first container found is the nearest (smallest-area) one, so the #2331 island-promotion semantics are preserved (its tests still pass unchanged).

## Verification

- **Mutation check (control first):** new regression test — two equal-area squares overlapping diagonally, each ring ordered so its first vertex lies strictly inside the other — passes on the fixed code. With the #2331 parent computation restored verbatim, the same test **hangs** and is killed by a 40s watchdog (SIGKILL, exit 137).
- Full `drawing-2d` suite: 242 passing across 24 files (was 241).
- `tsc --noEmit` clean (after building workspace deps).

The reporter offered the IFC privately; with the cycle mechanism demonstrated by the unit repro I did not need it, but it would be a good confirmation on the preview deployment.