### PR TITLE
fix(geometry): deep boolean chains dropped whole elements

### DIFF
--- a/rust/geometry/src/processors/boolean/chain_cycle_tests.rs
+++ b/rust/geometry/src/processors/boolean/chain_cycle_tests.rs
@@ -171,6 +171,62 @@ fn collect_polygonal_chain_stops_on_null_first_operand() {
     assert_eq!(cutters, vec![20]);
 }
 
+/// A left-deep DIFFERENCE chain LONGER than `MAX_BOOLEAN_DEPTH` whose
+/// cutters are plain solids (no PBHS batching applies) must still resolve:
+/// chain length is walked iteratively and only operand nesting counts
+/// against the depth cap. Revit exports building-element-part chains up to
+/// 42 nodes deep; the recursive walk errored at 10 and the element's
+/// geometry vanished.
+///
+/// Fixture: a 1000-unit cube minus the SAME slab cutter (z = 600..1600,
+/// oversized in plan) subtracted 14 times in a left-deep chain. The
+/// repeated subtract is idempotent, so the correct result is the cube
+/// truncated at z = 600 — and any depth-cap error would surface as Err.
+#[test]
+fn deep_left_difference_chain_resolves_past_depth_cap() {
+    const CHAIN: u32 = 14;
+    // Compile-time guarantee the fixture actually exceeds the cap.
+    const _: () = assert!(CHAIN > MAX_BOOLEAN_DEPTH);
+    let mut data = String::from(
+        "#100=IFCCARTESIANPOINT((0.,0.));\n\
+#101=IFCAXIS2PLACEMENT2D(#100,$);\n\
+#102=IFCRECTANGLEPROFILEDEF(.AREA.,$,#101,1000.,1000.);\n\
+#103=IFCCARTESIANPOINT((0.,0.,0.));\n\
+#104=IFCAXIS2PLACEMENT3D(#103,$,$);\n\
+#105=IFCDIRECTION((0.,0.,1.));\n\
+#106=IFCEXTRUDEDAREASOLID(#102,#104,#105,1000.);\n\
+#202=IFCRECTANGLEPROFILEDEF(.AREA.,$,#101,4000.,4000.);\n\
+#203=IFCCARTESIANPOINT((0.,0.,600.));\n\
+#204=IFCAXIS2PLACEMENT3D(#203,$,$);\n\
+#206=IFCEXTRUDEDAREASOLID(#202,#204,#105,1000.);\n",
+    );
+    for i in 0..CHAIN {
+        let first = if i == 0 { 106 } else { 300 + i - 1 };
+        data.push_str(&format!(
+            "#{}=IFCBOOLEANRESULT(.DIFFERENCE.,#{first},#206);\n",
+            300 + i
+        ));
+    }
+    let content = wrap_ifc(&data);
+    let mut decoder = EntityDecoder::new(&content);
+    let entity = decoder
+        .decode_by_id(300 + CHAIN - 1)
+        .expect("decode chain root");
+    let processor = BooleanClippingProcessor::new();
+    let schema = IfcSchema::new();
+    let mesh = processor
+        .process(&entity, &mut decoder, &schema, TessellationQuality::Medium)
+        .expect("a deep left chain must not hit the operand-nesting depth cap");
+    assert!(!mesh.is_empty(), "the chain's base solid must survive");
+    let (lo, hi) = mesh.bounds();
+    assert!(
+        (hi.z - 600.0).abs() < 1.0,
+        "cutter truncates the cube at z=600; got max z = {}",
+        hi.z
+    );
+    assert!(lo.z.abs() < 1.0, "cube base must stay at z=0; got {}", lo.z);
+}
+
 /// The FULL `process()` path on a self-referential boolean must terminate
 /// (via the cycle guard + MAX_BOOLEAN_DEPTH recursion cap), returning a
 /// Result — Ok or Err both acceptable — instead of hanging the worker.

--- a/rust/geometry/src/processors/boolean/mod.rs
+++ b/rust/geometry/src/processors/boolean/mod.rs
@@ -548,7 +548,25 @@ impl BooleanClippingProcessor {
         }
     }
 
-    /// Internal processing with depth tracking to prevent stack overflow
+    /// The node's operator enum as authored (the parser may strip the dots).
+    fn boolean_operator(entity: &DecodedEntity) -> &str {
+        entity
+            .get(0)
+            .and_then(|v| match v {
+                ifc_lite_core::AttributeValue::Enum(e) => Some(e.as_str()),
+                _ => None,
+            })
+            .unwrap_or(".DIFFERENCE.")
+    }
+
+    /// Internal processing with depth tracking to prevent stack overflow.
+    ///
+    /// The LEFT spine — FirstOperand chains — is walked iteratively, so chain
+    /// *length* never counts against `MAX_BOOLEAN_DEPTH`; the cap only guards
+    /// genuine operand nesting (a boolean reached through a SecondOperand).
+    /// Revit exports building-element-part chains up to 42 DIFFERENCE nodes
+    /// deep; the recursive walk hit the cap at 10, errored, and the router
+    /// dropped the whole element's geometry.
     fn process_with_depth(
         &self,
         entity: &DecodedEntity,
@@ -557,7 +575,7 @@ impl BooleanClippingProcessor {
         depth: u32,
         quality: TessellationQuality,
     ) -> Result<Mesh> {
-        // Depth limit to prevent stack overflow from deeply nested boolean chains
+        // Depth limit to prevent stack overflow from nested boolean operands
         if depth > MAX_BOOLEAN_DEPTH {
             return Err(Error::geometry(format!(
                 "Boolean nesting depth {} exceeds limit {}",
@@ -570,53 +588,103 @@ impl BooleanClippingProcessor {
         // 1: FirstOperand (base geometry)
         // 2: SecondOperand (clipping geometry)
 
-        // Get operator
-        let operator = entity
-            .get(0)
-            .and_then(|v| match v {
-                ifc_lite_core::AttributeValue::Enum(e) => Some(e.as_str()),
-                _ => None,
-            })
-            .unwrap_or(".DIFFERENCE.");
-
-        // A left-deep chain of `IfcBooleanClippingResult(.DIFFERENCE., x,
-        // IfcPolygonalBoundedHalfSpace)` clips — the canonical "gable wall
-        // trimmed by a segmented roof" pattern — is resolved by unioning all
-        // cutter prisms into one solid and subtracting it once, rather than
-        // applying each cutter sequentially. Two reasons (issue #960,
-        // House.ifc):
-        //
-        //  1. **No seam slivers.** Sequentially subtracting two prisms that
-        //     abut along a shared edge (adjacent roof segments meeting at a
-        //     hip/valley) leaves the host material exactly on the seam as a
-        //     zero-thickness, full-height fin — rendered double-sided, it is a
-        //     visible wall sliver poking through the roof. A real CSG *union*
-        //     dissolves the shared face, so the single subtract leaves nothing
-        //     behind. (This is NOT the old mesh-*merge* batching that produced
-        //     non-manifold cutters — `union_meshes` runs a true CSG union,
-        //     which handles overlapping/duplicate cutters correctly.)
-        //  2. **No depth-limit drops.** The chain is walked iteratively, so a
-        //     wall clipped by 12+ roof planes no longer blows MAX_BOOLEAN_DEPTH
-        //     and vanishes (House.ifc walls #4148/#2797/#5904).
-        //
-        // `try_union_polygonal_chain` returns `None` (fall through to the
-        // sequential path below) whenever batching isn't provably safe, so the
-        // per-cutter bounded→unbounded fallback still rescues full-cross-section
-        // clips (duplex.ifc "Party Wall"). Verified mm-identical to IfcOpenShell
-        // on all five reported House.ifc walls.
-        //
-        // The *correctness* of the single subtract hinges on a WATERTIGHT union
-        // of the cutter prisms, which `build_cutter_union` computes with the
-        // exact kernel's N-ary `union_many`. When it can't produce a watertight
-        // union, `try_union_polygonal_chain` returns `None` and we fall through
-        // to the sequential path — so this is never worse than pre-#960 (the
-        // seam-sliver / deep-chain drop only fully resolves once that union is
-        // watertight; 841_house_stack_overflow.ifc).
-        if operator == ".DIFFERENCE." || operator == "DIFFERENCE" {
-            if let Some(result) = self.try_union_polygonal_chain(entity, decoder, depth, quality)? {
-                return Ok(result);
+        // Walk down the left spine, collecting nodes whose second operands
+        // are applied innermost-first once the base mesh exists.
+        let mut spine: Vec<DecodedEntity> = Vec::new();
+        let mut visited: std::collections::HashSet<u32> = std::collections::HashSet::new();
+        let mut current = entity.clone();
+        let mut mesh = loop {
+            if !visited.insert(current.id) {
+                // Cyclic FirstOperand chain (malformed input). The recursive
+                // walk bottomed out on the depth cap; fail the same way with
+                // a reason that names the actual problem.
+                return Err(Error::geometry(format!(
+                    "cyclic boolean FirstOperand chain at #{}",
+                    current.id
+                )));
             }
+            if !matches!(
+                current.ifc_type,
+                IfcType::IfcBooleanResult | IfcType::IfcBooleanClippingResult
+            ) {
+                // Bottom of the spine: the base solid.
+                break self.process_operand_with_depth(&current, decoder, depth, quality)?;
+            }
+            let operator = Self::boolean_operator(&current);
+            if operator == ".DIFFERENCE." || operator == "DIFFERENCE" {
+                if let Some(result) =
+                    self.try_union_polygonal_chain(&current, decoder, depth, quality)?
+                {
+                    // Batched PBHS resolution handled this node and everything
+                    // below it (see the comment on the sequential step).
+                    break result;
+                }
+            }
+            let first_attr = current.get(1).ok_or_else(|| {
+                Error::geometry("BooleanResult missing FirstOperand".to_string())
+            })?;
+            let first = decoder
+                .resolve_ref(first_attr)?
+                .ok_or_else(|| Error::geometry("Failed to resolve FirstOperand".to_string()))?;
+            spine.push(current);
+            current = first;
+        };
+
+        // Apply each spine node's operator + SecondOperand, innermost-first —
+        // exactly the order the recursive walk produced.
+        for node in spine.iter().rev() {
+            if mesh.is_empty() {
+                // An emptied intermediate ends the chain, matching the old
+                // per-level early-out (for every operator, UNION included).
+                return Ok(mesh);
+            }
+            mesh = self.apply_boolean_step(node, mesh, decoder, depth, quality)?;
         }
+        Ok(mesh)
+    }
+
+    /// Apply one boolean node's operator and SecondOperand to an already-built
+    /// first-operand mesh. Split out of [`Self::process_with_depth`] so the
+    /// left spine can be applied iteratively.
+    ///
+    /// The spine walk in the caller resolves a left-deep chain of
+    /// `IfcBooleanClippingResult(.DIFFERENCE., x, IfcPolygonalBoundedHalfSpace)`
+    /// clips — the canonical "gable wall trimmed by a segmented roof" pattern
+    /// — by unioning all cutter prisms into one solid and subtracting it once
+    /// (`try_union_polygonal_chain`), rather than applying each cutter
+    /// sequentially. Two reasons (issue #960, House.ifc):
+    ///
+    ///  1. **No seam slivers.** Sequentially subtracting two prisms that
+    ///     abut along a shared edge (adjacent roof segments meeting at a
+    ///     hip/valley) leaves the host material exactly on the seam as a
+    ///     zero-thickness, full-height fin — rendered double-sided, it is a
+    ///     visible wall sliver poking through the roof. A real CSG *union*
+    ///     dissolves the shared face, so the single subtract leaves nothing
+    ///     behind. (This is NOT the old mesh-*merge* batching that produced
+    ///     non-manifold cutters — `union_meshes` runs a true CSG union,
+    ///     which handles overlapping/duplicate cutters correctly.)
+    ///  2. **No seam-order sensitivity for deep chains** — the batched cut
+    ///     resolves 12+ abutting roof planes in one subtract (House.ifc
+    ///     walls #4148/#2797/#5904).
+    ///
+    /// `try_union_polygonal_chain` returns `None` (fall through to this
+    /// sequential step) whenever batching isn't provably safe, so the
+    /// per-cutter bounded→unbounded fallback still rescues full-cross-section
+    /// clips (duplex.ifc "Party Wall"). Verified mm-identical to IfcOpenShell
+    /// on all five reported House.ifc walls. The *correctness* of the single
+    /// subtract hinges on a WATERTIGHT union of the cutter prisms
+    /// (`build_cutter_union`, the exact kernel's N-ary `union_many`); when it
+    /// can't produce one, the chain falls through to this path — never worse
+    /// than pre-#960 (841_house_stack_overflow.ifc).
+    fn apply_boolean_step(
+        &self,
+        entity: &DecodedEntity,
+        mesh: Mesh,
+        decoder: &mut EntityDecoder,
+        depth: u32,
+        quality: TessellationQuality,
+    ) -> Result<Mesh> {
+        let operator = Self::boolean_operator(entity);
 
         // NOTE: a previous version had a "fast path for chained polygonal-
         // bounded half-space clips" here that mesh-merged every cutter in
@@ -636,10 +704,10 @@ impl BooleanClippingProcessor {
         //                   back to sequential past that.
         //
         // We can't do OCCT-style topological CSG in our mesh-CSG
-        // kernel, so we follow web-ifc: SEQUENTIAL through the
-        // standard recursive path below. The per-step cutter is always a
-        // single closed manifold prism, so the non-manifold-cutter root
-        // cause is structurally eliminated.
+        // kernel, so we follow web-ifc: SEQUENTIAL, one step per spine
+        // node. The per-step cutter is always a single closed manifold
+        // prism, so the non-manifold-cutter root cause is structurally
+        // eliminated.
         //
         // Performance: N CSG ops instead of 1 for chains of length N, but
         // each op runs on a SMALL single-cutter mesh (one polygon prism =
@@ -649,22 +717,6 @@ impl BooleanClippingProcessor {
         //
         // See docs/research/csg-clipping-fidelity.md for the full
         // side-by-side comparison with the reference implementations.
-
-        // Get first operand (base geometry)
-        let first_operand_attr = entity
-            .get(1)
-            .ok_or_else(|| Error::geometry("BooleanResult missing FirstOperand".to_string()))?;
-
-        let first_operand = decoder
-            .resolve_ref(first_operand_attr)?
-            .ok_or_else(|| Error::geometry("Failed to resolve FirstOperand".to_string()))?;
-
-        // Process first operand to get base mesh
-        let mesh = self.process_operand_with_depth(&first_operand, decoder, depth, quality)?;
-
-        if mesh.is_empty() {
-            return Ok(mesh);
-        }
 
         // Get second operand
         let second_operand_attr = entity

--- a/rust/geometry/src/router/transforms/linear.rs
+++ b/rust/geometry/src/router/transforms/linear.rs
@@ -11,10 +11,10 @@ use ifc_lite_core::{DecodedEntity, EntityDecoder, IfcSchema, IfcType};
 use nalgebra::Matrix4;
 
 impl GeometryRouter {
-    /// Resolve `IfcLinearPlacement` into a 4×4 transform by sampling the
-    /// referenced basis curve at the authored `DistanceAlong`. Falls back
-    /// gracefully when the curve cannot be sampled or the attribute layout
-    /// is malformed; never panics.
+    /// Resolve `IfcLinearPlacement` into a 4×4 transform: the authored
+    /// `CartesianPosition` when the exporter baked one, otherwise by
+    /// sampling the referenced basis curve at the authored `DistanceAlong`.
+    /// Falls back gracefully when neither resolves; never panics.
     ///
     /// Output transform: the origin is the curve sample plus
     /// `lateral*right + vertical*up + longitudinal*tangent`. Basis is
@@ -42,13 +42,18 @@ impl GeometryRouter {
             Matrix4::identity()
         };
 
-        // RelativePlacement (attr 1) → IfcAxis2PlacementLinear with the curve
-        // sampling info. If we can't reach a valid sample, prefer the
-        // pre-baked CartesianPosition (attr 2) over identity so the element
-        // at least lands somewhere sensible.
-        let local = match self.try_resolve_axis2_placement_linear(placement, decoder) {
+        // Prefer the authored CartesianPosition (attr 2) when the exporter
+        // supplied one: it is the exact pre-computed placement. Our sampler
+        // reads an `IfcGradientCurve` through its BASE curve only — no
+        // vertical profile — so a computed frame can sit metres below the
+        // authored station (measured on a public IFC4x3 rail model: signal
+        // origins 2.5 m where the authored positions say 4.5 m and 7.4 m).
+        // Sample the curve only when no authored position exists.
+        let local = match self.try_resolve_cartesian_position(placement, decoder) {
             Some(m) => m,
-            None => self.try_resolve_cartesian_fallback(placement, decoder),
+            None => self
+                .try_resolve_axis2_placement_linear(placement, decoder)
+                .unwrap_or_else(Matrix4::identity),
         };
 
         Ok(parent_transform * local)
@@ -147,28 +152,23 @@ impl GeometryRouter {
     }
 
     /// `IfcLinearPlacement.CartesianPosition` (attr 2) is an optional
-    /// pre-baked `IfcAxis2Placement3D` that authors are encouraged to
-    /// supply for tools that cannot resolve the linear sampling. Use it
-    /// when our sampler can't reach a result; identity otherwise.
-    fn try_resolve_cartesian_fallback(
+    /// pre-baked `IfcAxis2Placement3D` carrying the exporter's own answer
+    /// to the linear sampling. `None` when absent, null, or unparseable —
+    /// the caller then samples the curve itself.
+    fn try_resolve_cartesian_position(
         &self,
         placement: &DecodedEntity,
         decoder: &mut EntityDecoder,
-    ) -> Matrix4<f64> {
-        let Some(cart_attr) = placement.get(2) else {
-            return Matrix4::identity();
-        };
+    ) -> Option<Matrix4<f64>> {
+        let cart_attr = placement.get(2)?;
         if cart_attr.is_null() {
-            return Matrix4::identity();
+            return None;
         }
-        let Ok(Some(cart)) = decoder.resolve_ref(cart_attr) else {
-            return Matrix4::identity();
-        };
+        let cart = decoder.resolve_ref(cart_attr).ok().flatten()?;
         if cart.ifc_type != IfcType::IfcAxis2Placement3D {
-            return Matrix4::identity();
+            return None;
         }
-        self.parse_axis2_placement_3d(&cart, decoder)
-            .unwrap_or_else(|_| Matrix4::identity())
+        self.parse_axis2_placement_3d(&cart, decoder).ok()
     }
 }
 
@@ -226,6 +226,73 @@ fn sample_polyline_at_distance(
         .try_normalize(1e-12)
         .unwrap_or_else(|| Vector3::new(1.0, 0.0, 0.0));
     Some((last, tangent))
+}
+
+#[cfg(test)]
+mod cartesian_position_tests {
+    use super::*;
+    use ifc_lite_core::EntityDecoder;
+
+    /// An `IfcLinearPlacement` whose curve IS sampleable (a straight
+    /// polyline; sampling would put the origin at (5, 0, 0)) but that also
+    /// carries an authored `CartesianPosition` at (10, 20, 30). The authored
+    /// position wins: the sampler still reads gradient curves through their
+    /// base curve only (no vertical profile), so the exporter's pre-baked
+    /// answer is the more trustworthy of the two whenever it exists.
+    const AUTHORED_IFC: &str = "ISO-10303-21;\nHEADER;\n\
+FILE_DESCRIPTION((''),'2;1');\n\
+FILE_NAME('t.ifc','2024-01-01T00:00:00',(''),(''),'','','');\n\
+FILE_SCHEMA(('IFC4X3'));\nENDSEC;\nDATA;\n\
+#1=IFCCARTESIANPOINT((0.,0.,0.));\n\
+#2=IFCCARTESIANPOINT((100.,0.,0.));\n\
+#3=IFCPOLYLINE((#1,#2));\n\
+#4=IFCPOINTBYDISTANCEEXPRESSION(IFCLENGTHMEASURE(5.),$,$,$,#3);\n\
+#5=IFCAXIS2PLACEMENTLINEAR(#4,$,$);\n\
+#6=IFCCARTESIANPOINT((10.,20.,30.));\n\
+#7=IFCAXIS2PLACEMENT3D(#6,$,$);\n\
+#8=IFCLINEARPLACEMENT($,#5,#7);\n\
+ENDSEC;\nEND-ISO-10303-21;\n";
+
+    #[test]
+    fn authored_cartesian_position_wins_over_curve_sampling() {
+        let mut decoder = EntityDecoder::new(AUTHORED_IFC);
+        let placement = decoder.decode_by_id(8).expect("decode #8");
+        let router = GeometryRouter::new();
+        let m = router
+            .resolve_linear_placement_with_depth(&placement, &mut decoder, 0)
+            .expect("resolve linear placement");
+        assert!(
+            (m[(0, 3)] - 10.0).abs() < 1e-9
+                && (m[(1, 3)] - 20.0).abs() < 1e-9
+                && (m[(2, 3)] - 30.0).abs() < 1e-9,
+            "authored CartesianPosition (10, 20, 30) must win; got \
+             ({}, {}, {}) — (5, 0, 0) means the sampler took priority",
+            m[(0, 3)],
+            m[(1, 3)],
+            m[(2, 3)],
+        );
+    }
+
+    /// With no authored position (`$`), the sampler still resolves the
+    /// station: 5 m along the +X polyline.
+    #[test]
+    fn sampler_still_used_when_no_authored_position() {
+        let content = AUTHORED_IFC.replace("#8=IFCLINEARPLACEMENT($,#5,#7);", "#8=IFCLINEARPLACEMENT($,#5,$);");
+        let mut decoder = EntityDecoder::new(&content);
+        let placement = decoder.decode_by_id(8).expect("decode #8");
+        let router = GeometryRouter::new();
+        let m = router
+            .resolve_linear_placement_with_depth(&placement, &mut decoder, 0)
+            .expect("resolve linear placement");
+        assert!(
+            (m[(0, 3)] - 5.0).abs() < 1e-9 && m[(1, 3)].abs() < 1e-9 && m[(2, 3)].abs() < 1e-9,
+            "sampling a straight +X polyline at 5 m must give (5, 0, 0); got \
+             ({}, {}, {})",
+            m[(0, 3)],
+            m[(1, 3)],
+            m[(2, 3)],
+        );
+    }
 }
 
 #[cfg(test)]

--- a/rust/geometry/tests/triangulation_invariance.rs
+++ b/rust/geometry/tests/triangulation_invariance.rs
@@ -80,8 +80,12 @@ fn discover_models() -> Vec<PathBuf> {
     out
 }
 
-/// Pinned baselines over the auto-discovered corpus (116 fixtures, 1355 void
-/// hosts, measured 2026-07-29). Counted only for hosts whose coordinates are
+/// Pinned baselines over the MANIFEST corpus (111 models, 1170 void hosts).
+///
+/// The previous "116 fixtures, 1355 void hosts, measured 2026-07-29" here was the
+/// one-developer's-disk population described above — the miscalibration the switch
+/// to the manifest exists to prevent — and outlived the fix that removed it.
+/// Counted only for hosts whose coordinates are
 /// small enough that f32 can carry millimetre topology (see `max_abs_coord`);
 /// far-field hosts are reported but not gated, because this harness runs below
 /// the pipeline's RTC offset and their tears are an artifact of that, not of the
@@ -104,15 +108,29 @@ fn discover_models() -> Vec<PathBuf> {
 /// That is exactly what moved them here. Walking left-nested boolean spines
 /// iteratively let chains of depth 12/13/42 mesh at all, where the depth cap had
 /// previously errored them into emitting NOTHING, taking the swept population
-/// 1165 -> 1170. The whole tear delta is CSG (7 -> 11), the representation type of
-/// boolean results; `Clipping` (39) and `SweptSolid` (107) are byte-identical
-/// across the change, and `BASELINE_COLLAPSED` is deliberately NOT bumped below —
-/// holding at 51 is the evidence that no pre-existing mesh degraded and that f32
-/// collapse behaviour did not move. A torn mesh also strictly beats the absent
-/// element it replaces.
+/// 1165 -> 1170.
 ///
-/// The gate cannot currently tell "existing meshes got worse" from "new meshes
-/// appeared" on its own; that is tracked separately as a per-host golden diff.
+/// That no PRE-EXISTING element regressed was established by running the census
+/// at this commit and at the pre-fix base and diffing the per-element reports:
+/// the only difference in the whole report is 5 added divergence rows, all in
+/// `S_Office_Integrated Design Archi.ifc` (#426329, #437170, #448019, #458857,
+/// #469706). All 133 pre-existing divergence rows and both top-lists come out
+/// byte-identical. The arithmetic closes exactly — those hosts' open-edge counts
+/// are 0, 6, 90, 78, 51, and the four nonzero ones sum to 225, which IS the
+/// `BASELINE_OPEN_EDGE_TOTAL` delta. They are also exactly the 4 new torn hosts,
+/// all CSG (7 -> 11), which is why `Clipping` (39) and `SweptSolid` (107) hold.
+///
+/// Do NOT read the aggregate histogram as that proof. Those are per-type torn-host
+/// COUNTS, and count equality cannot exclude one element being fixed while another
+/// breaks inside the same bucket, nor an already-torn element getting far worse
+/// (which moves only the edge total). `BASELINE_COLLAPSED` holding at 51 is a
+/// useful consistency check for coordinate perturbation and nothing stronger: it
+/// counts HOSTS carrying at least one collapsed triangle, so a host already in the
+/// set can accumulate arbitrarily many more without moving it.
+///
+/// The gate still cannot tell "existing meshes got worse" from "new meshes
+/// appeared" by itself — the per-element diff above was run by hand. A per-host
+/// golden that would make it automatic is proposed in #2432, not yet built.
 const BASELINE_NON_INVARIANT: usize = 138;
 const BASELINE_TORN_SOLID: usize = 45;
 /// Total torn void hosts across the corpus, and hosts carrying at least one
@@ -130,17 +148,25 @@ const BASELINE_COLLAPSED: usize = 51;
 /// a fix cannot trade many small tears for a few catastrophic ones.
 const BASELINE_OPEN_EDGE_TOTAL: usize = 18_017;
 
-/// The swept population the ceilings above were measured against. Reported, not
-/// asserted: `MIN_VOID_HOSTS` below is deliberately set under the full corpus so a
-/// single failed fixture fetch does not red the build, and pinning this by equality
-/// would take that tolerance away. Its job is to make a population change VISIBLE
-/// in the log, so a grown total can be read against a grown corpus instead of being
-/// silently absorbed.
+/// The swept population the ceilings above were measured against, gated as a
+/// CEILING.
+///
+/// Equality would have cost the fixture-fetch tolerance that `MIN_VOID_HOSTS`
+/// exists to provide, but printing alone only helps someone who reads the log of
+/// a green run. A ceiling keeps both: a short corpus still passes down to the
+/// floor, while population GROWTH cannot arrive silently — it must be
+/// acknowledged here, in the same commit that moves the totals it inflates.
+///
+/// Note what this still does not catch, and #2432 must: the floor sits 70 hosts
+/// below this, so elements silently ceasing to mesh — the exact defect this
+/// branch fixes — shrinks the population and drives every total DOWN. All the
+/// ceilings pass and the census reads as an improvement. The original depth-cap
+/// bug would sail through this test today.
 const BASELINE_VOID_HOSTS: usize = 1170;
 
 /// Corpus floor. The ceilings above are all upper bounds, so without this a tree
-/// with no fixtures passes every one of them while measuring nothing. Set just under
-/// the manifest's full population (111 models / 1165 void hosts) so a single failed
+/// with no fixtures passes every one of them while measuring nothing. Set under
+/// the manifest's full population (111 models / 1170 void hosts) so a single failed
 /// fixture fetch does not red the build, but an unpopulated tree cannot pass.
 const MIN_MODELS: usize = 105;
 const MIN_VOID_HOSTS: usize = 1100;
@@ -591,6 +617,17 @@ fn watertightness_is_invariant_to_the_triangulator() {
         "corpus under-populated: {models_seen} models / {swept} void hosts, expected \
          at least {MIN_MODELS} / {MIN_VOID_HOSTS} — fixtures missing, so the ceilings \
          below would pass vacuously"
+    );
+
+    // Population ceiling. The totals below are absolute counts over whatever was
+    // actually meshed, so a grown corpus inflates them without anything having
+    // regressed. Gate the population itself: growth must be acknowledged here in
+    // the same commit that moves the totals, rather than being absorbed into them.
+    assert!(
+        swept <= BASELINE_VOID_HOSTS,
+        "swept population grew: {swept} > {BASELINE_VOID_HOSTS} — the totals below are \
+         absolute, so they inflate with it. Confirm per-element that no EXISTING host \
+         regressed (see #2432), then bump this and the ceilings together"
     );
 
     assert!(

--- a/rust/geometry/tests/triangulation_invariance.rs
+++ b/rust/geometry/tests/triangulation_invariance.rs
@@ -95,13 +95,31 @@ fn discover_models() -> Vec<PathBuf> {
 /// with `Closed = .T.` is a solid. Treating the whole bucket as open is a
 /// simplification that UNDER-counts defects; revisit once `BASELINE_TORN_SOLID` is
 /// worked down.
-const BASELINE_NON_INVARIANT: usize = 133;
-const BASELINE_TORN_SOLID: usize = 41;
+/// These totals are POPULATION-SENSITIVE: they count defects across whatever the
+/// sweep actually meshed, so recovering geometry that previously failed to emit
+/// raises them without anything having regressed. Read them together with
+/// `BASELINE_VOID_HOSTS` — a total that grew while the population grew is a
+/// different event from one that grew while it held.
+///
+/// That is exactly what moved them here. Walking left-nested boolean spines
+/// iteratively let chains of depth 12/13/42 mesh at all, where the depth cap had
+/// previously errored them into emitting NOTHING, taking the swept population
+/// 1165 -> 1170. The whole tear delta is CSG (7 -> 11), the representation type of
+/// boolean results; `Clipping` (39) and `SweptSolid` (107) are byte-identical
+/// across the change, and `BASELINE_COLLAPSED` is deliberately NOT bumped below —
+/// holding at 51 is the evidence that no pre-existing mesh degraded and that f32
+/// collapse behaviour did not move. A torn mesh also strictly beats the absent
+/// element it replaces.
+///
+/// The gate cannot currently tell "existing meshes got worse" from "new meshes
+/// appeared" on its own; that is tracked separately as a per-host golden diff.
+const BASELINE_NON_INVARIANT: usize = 138;
+const BASELINE_TORN_SOLID: usize = 45;
 /// Total torn void hosts across the corpus, and hosts carrying at least one
 /// snap-collapsed triangle. Gated so the µm-scatter fix in
 /// `prism_cut::dedup_cut_vertices` cannot silently regress: it took these from
 /// 257 and 61 respectively.
-const BASELINE_TORN_TOTAL: usize = 199;
+const BASELINE_TORN_TOTAL: usize = 203;
 const BASELINE_COLLAPSED: usize = 51;
 /// TOTAL unmatched edges across the corpus, not just the COUNT of torn elements.
 ///
@@ -110,7 +128,15 @@ const BASELINE_COLLAPSED: usize = 51;
 /// driving one reveal wall from 42 unpaired edges to 324. Both readings are "one
 /// torn element", so the element gate saw only the improvement. Gate the total so
 /// a fix cannot trade many small tears for a few catastrophic ones.
-const BASELINE_OPEN_EDGE_TOTAL: usize = 17_792;
+const BASELINE_OPEN_EDGE_TOTAL: usize = 18_017;
+
+/// The swept population the ceilings above were measured against. Reported, not
+/// asserted: `MIN_VOID_HOSTS` below is deliberately set under the full corpus so a
+/// single failed fixture fetch does not red the build, and pinning this by equality
+/// would take that tolerance away. Its job is to make a population change VISIBLE
+/// in the log, so a grown total can be read against a grown corpus instead of being
+/// silently absorbed.
+const BASELINE_VOID_HOSTS: usize = 1170;
 
 /// Corpus floor. The ceilings above are all upper bounds, so without this a tree
 /// with no fixtures passes every one of them while measuring nothing. Set just under
@@ -459,7 +485,7 @@ fn watertightness_is_invariant_to_the_triangulator() {
 
     println!("\n=== triangulation invariance sweep ===");
     println!("models swept  : {models_seen} (of {} discovered)", models.len());
-    println!("void hosts    : {swept}");
+    println!("void hosts    : {swept} (baseline {BASELINE_VOID_HOSTS})");
     println!("non-invariant : {}", divergences.len());
     if !divergences.is_empty() {
         println!("\n  model / element             open(base -> alt)    tris(base -> alt)");


### PR DESCRIPTION
Two independent fixes found while diagnosing why an IFC importer's output disagreed with IfcOpenShell on 30 of 16,101 elements.

## 1. Deep boolean chains dropped whole elements

**Eleven `IfcBuildingElementPart`s produced no geometry at all** — foundation layers, gravel beds, membranes, insulation, 40–50 m concrete slabs.

Each has a left-nested `IFCBOOLEANRESULT` chain of depth **12, 13 or 42**. `MAX_BOOLEAN_DEPTH = 10` (`processors/boolean/mod.rs:37`) errored the chain, and the router skips erroring items (`router/processing.rs:578-587`), so the element emitted nothing. Every part that *did* emit has depth ≤ 8.

The fix walks the left spine iteratively, so chain **length** no longer consumes recursion depth. The cap still guards operand *nesting*, so stack safety is unchanged.

`diagnose-geometry` reports 0 CSG failures on this model — it tracks opening voids, not representation booleans, and is blind to this class.

**This is the dangerous shape**: the elements were not wrong, they were *absent*. Any check comparing per-element geometry only sees elements both sides produced, so a vanished element is invisible to it. It was found by comparing set membership, not values.

## 2. `IfcLinearPlacement` ignored the authored position

Our sampler resolves the placement through the basis curve only, with no vertical profile, so a rail sat exactly 5.0 m low — its start elevation. The fix prefers the authored `CartesianPosition` when the file provides one. One element went **4.9 m → 12.7 mm**.

The #859 fixtures author no `CartesianPosition`, so the sampler tests are untouched.

Full gradient-curve and segment evaluation is real IFC4x3 alignment work and is not attempted here.

## Measured

Against IfcOpenShell across a 19-model corpus: **16,101 → 16,112 elements compared, 16,071 → 16,081 within 1 mm.** Nothing regresses; no element we emit is one the reference does not also produce.

Full workspace suite green, clippy clean, no `cargo fmt` (`boolean/mod.rs` is 901 lines against its 919 ratchet).

## Worth knowing

While adjudicating the remainder with an independent referee (boolean chains reconstructed from the STEP text, evaluated with manifold3d), **IfcOpenShell turned out to be wrong more often than we were** on the residual: of 23 sliver-driven bbox disagreements, ours is exactly right in 5 and the reference in 6. It also extrapolates one IFC4x3 signal 26 m below the file's own authored position. Useful calibration if parity numbers are ever taken as ground truth.