### PR TITLE
fix(viewer): compose assistant script edits before dispatching them

### DIFF
--- a/apps/viewer/src/components/viewer/CodeEditor.tsx
+++ b/apps/viewer/src/components/viewer/CodeEditor.tsx
@@ -20,6 +20,8 @@ import { syntaxHighlighting, defaultHighlightStyle, bracketMatching, indentOnInp
 import { highlightSelectionMatches } from '@codemirror/search';
 import { NAMESPACE_SCHEMAS } from '@ifc-lite/sandbox/schema';
 import type { ScriptEditorSelection, ScriptEditorTextChange } from '@/lib/llm/types';
+import { planScriptEditorChanges } from '@/lib/llm/script-editor-changes';
+import { posthog } from '@/lib/analytics';
 
 /** Shared structural styles (mode-agnostic) */
 const baseTheme = EditorView.theme({
@@ -318,11 +320,34 @@ export function CodeEditor({
         if (!active) return;
         const safeFrom = Math.max(0, Math.min(selection.from, nextContent.length));
         const safeTo = Math.max(safeFrom, Math.min(selection.to, nextContent.length));
-        const changes = options?.changes && options.changes.length > 0
-          ? options.changes
-          : [{ from: 0, to: active.state.doc.length, insert: nextContent }];
+        // Incremental specs are SEQUENTIAL and measured against the store's
+        // copy of the script; `planScriptEditorChanges` replays them onto THIS
+        // live document and verifies they reproduce `nextContent`. Handing the
+        // raw array to one `dispatch` read them as original-document
+        // coordinates instead — the uncaught RangeError of #2357 / #2300.
+        const plan = options?.changes && options.changes.length > 0
+          ? planScriptEditorChanges(active.state.doc, options.changes, nextContent)
+          : null;
+        if (plan && !plan.ok) {
+          // Degrade to a whole-document set below: coarser undo granularity,
+          // but the editor still holds exactly the text the store records.
+          posthog.captureException(
+            new Error(`Script editor incremental apply rejected: ${plan.reason}`),
+            {
+              context: 'script_editor_apply',
+              rejection_reason: plan.reason,
+              doc_length: plan.docLength,
+              expected_length: plan.expectedLength,
+              range_from: plan.rangeFrom,
+              range_to: plan.rangeTo,
+              change_count: options?.changes?.length ?? 0,
+            },
+          );
+        }
         active.dispatch({
-          changes,
+          changes: plan?.ok
+            ? plan.changes
+            : { from: 0, to: active.state.doc.length, insert: nextContent },
           selection: { anchor: safeFrom, head: safeTo },
           annotations: options?.userEvent ? [Transaction.userEvent.of(options.userEvent)] : undefined,
         });

--- a/apps/viewer/src/lib/llm/script-editor-changes.test.ts
+++ b/apps/viewer/src/lib/llm/script-editor-changes.test.ts
@@ -1,0 +1,199 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { ChangeSet, Text } from '@codemirror/state';
+import { planScriptEditorChanges } from './script-editor-changes.js';
+import { applyScriptEditOperations } from './script-edit-ops.js';
+import type { ScriptEditorTextChange } from './types.js';
+
+function docOf(content: string): Text {
+  return Text.of(content.split('\n'));
+}
+
+/** The splice semantics `applyScriptEditOperations` itself uses for `changes`. */
+function spliceSequentially(content: string, changes: readonly ScriptEditorTextChange[]): string {
+  let out = content;
+  for (const change of changes) {
+    out = out.slice(0, change.from) + change.insert + out.slice(change.to);
+  }
+  return out;
+}
+
+/**
+ * Regression for #2300 — `RangeError: Invalid change range 8048 to 10082 (in
+ * doc of length 7932)` — reproduced from the reported numbers.
+ *
+ * A 2150-char insert followed by a `replaceRange` that runs to the end of the
+ * base snapshot: rebased, the second spec is [5898+2150, 7932+2150] =
+ * [8048, 10082]. Those are coordinates in the content the FIRST spec
+ * produced, but the old adapter handed the whole array to one `dispatch`,
+ * where CodeMirror reads every spec against the original 7932-char document.
+ */
+test('#2300: a grown-past-the-document batch composes instead of throwing a RangeError', () => {
+  const base = 'x'.repeat(7932);
+  const changes: ScriptEditorTextChange[] = [
+    { from: 100, to: 100, insert: 'y'.repeat(2150) },
+    { from: 8048, to: 10082, insert: 'tail' },
+  ];
+  const nextContent = spliceSequentially(base, changes);
+  const doc = docOf(base);
+
+  // The pre-fix dispatch, pinned so the mechanism cannot be misremembered.
+  assert.throws(
+    () => ChangeSet.of(changes, doc.length),
+    /Invalid change range 8048 to 10082 \(in doc of length 7932\)/,
+  );
+
+  const plan = planScriptEditorChanges(doc, changes, nextContent);
+  assert.equal(plan.ok, true, 'the batch must be replayable onto the live document');
+  assert.equal(plan.ok && plan.changes.apply(doc).toString(), nextContent);
+});
+
+/**
+ * Regression for #2357 — `RangeError: Invalid change range 2090 to 2197 (in
+ * doc of length 2159)`. Same shape, a 38-char insert ahead of a
+ * replace-to-end-of-snapshot: [2052+38, 2159+38] = [2090, 2197].
+ */
+test('#2357: the smaller reported overflow composes instead of throwing', () => {
+  const base = 'a'.repeat(2159);
+  const changes: ScriptEditorTextChange[] = [
+    { from: 12, to: 12, insert: 'b'.repeat(38) },
+    { from: 2090, to: 2197, insert: 'const done = true;' },
+  ];
+  const nextContent = spliceSequentially(base, changes);
+  const doc = docOf(base);
+
+  assert.throws(
+    () => ChangeSet.of(changes, doc.length),
+    /Invalid change range 2090 to 2197 \(in doc of length 2159\)/,
+  );
+
+  const plan = planScriptEditorChanges(doc, changes, nextContent);
+  assert.equal(plan.ok, true);
+  assert.equal(plan.ok && plan.changes.apply(doc).toString(), nextContent);
+});
+
+/**
+ * The silent half of #2357 / #2300: when the sequential coordinates happen to
+ * fit the original document, the old dispatch did not throw — it applied a
+ * DIFFERENT edit, leaving CodeMirror holding text the store never had.
+ */
+test('#2300: in-bounds sequential specs still apply sequentially, not as original-document specs', () => {
+  const base = 'ABCDEF';
+  const changes: ScriptEditorTextChange[] = [
+    { from: 0, to: 0, insert: 'XX' },
+    { from: 1, to: 2, insert: 'Z' },
+  ];
+  const nextContent = spliceSequentially(base, changes);
+  const doc = docOf(base);
+  assert.equal(nextContent, 'XZABCDEF');
+
+  // Original-document semantics would give a different string entirely, with
+  // no error to reveal it.
+  assert.equal(ChangeSet.of(changes, doc.length).apply(doc).toString(), 'XXAZCDEF');
+
+  const plan = planScriptEditorChanges(doc, changes, nextContent);
+  assert.equal(plan.ok, true);
+  assert.equal(plan.ok && plan.changes.apply(doc).toString(), 'XZABCDEF');
+});
+
+/**
+ * End-to-end producer/consumer invariant: whatever `applyScriptEditOperations`
+ * writes into the store, replaying its own `changes` onto the document the
+ * store was in sync with must reproduce byte for byte. This is the contract
+ * the crash violated.
+ */
+test('#2357: the applier\'s own changes replay onto the editor document exactly', () => {
+  const base = [
+    'const models = bim.model.list()',
+    'const walls = bim.query.byType("IfcWall")',
+    'console.log(walls.length)',
+    '',
+  ].join('\n');
+
+  const result = applyScriptEditOperations({
+    content: base,
+    selection: { from: 0, to: 0 },
+    revision: 4,
+    operations: [
+      { opId: 'add-header', type: 'insert', baseRevision: 4, at: 0, text: '// Wall audit\n'.repeat(4) },
+      {
+        opId: 'rewrite-tail',
+        type: 'replaceRange',
+        baseRevision: 4,
+        from: base.indexOf('console.log'),
+        to: base.length,
+        text: 'console.log("walls:", walls.length)\n',
+      },
+    ],
+  });
+
+  assert.equal(result.ok, true);
+  const produced = result.changes ?? [];
+  assert.equal(produced.length, 2, 'both ops must have produced a change spec');
+  const doc = docOf(base);
+  // The batch grows past the base length, so the pre-fix dispatch threw here.
+  assert.throws(() => ChangeSet.of(produced, doc.length), /Invalid change range/);
+
+  const plan = planScriptEditorChanges(doc, produced, result.content);
+  assert.equal(plan.ok, true);
+  assert.equal(plan.ok && plan.changes.apply(doc).toString(), result.content);
+});
+
+/**
+ * The divergence case the adapter must catch rather than dispatch: the live
+ * document is not what the store thinks it is (shorter here), so the batch
+ * cannot be replayed. Rejecting lets the caller fall back to a whole-document
+ * set, which keeps the two copies equal.
+ */
+test('#2300: a batch that does not fit the live document is rejected, not dispatched', () => {
+  const storeContent = 'a'.repeat(400);
+  const changes: ScriptEditorTextChange[] = [{ from: 380, to: 400, insert: 'end' }];
+  const nextContent = spliceSequentially(storeContent, changes);
+
+  const drifted = docOf('a'.repeat(120));
+  const plan = planScriptEditorChanges(drifted, changes, nextContent);
+  assert.equal(plan.ok, false);
+  assert.equal(plan.ok === false && plan.reason, 'out_of_bounds');
+  assert.equal(plan.ok === false && plan.docLength, 120);
+  assert.equal(plan.ok === false && plan.rangeTo, 400);
+});
+
+/**
+ * In-bounds but wrong: the document drifted in CONTENT, not length. Applying
+ * would leave CodeMirror and `scriptEditorContent` holding different text, so
+ * this must be rejected too.
+ */
+test('#2357: a batch that applies cleanly but misses the expected content is rejected', () => {
+  const storeContent = 'const total = 1\nconst other = 2\n';
+  const changes: ScriptEditorTextChange[] = [{ from: 14, to: 15, insert: '9' }];
+  const nextContent = spliceSequentially(storeContent, changes);
+
+  // Same length, so every range still fits — but the user changed a line the
+  // batch does not touch, so the batch cannot land on `nextContent`.
+  const drifted = docOf('const total = 1\nconst other = 7\n');
+  const plan = planScriptEditorChanges(drifted, changes, nextContent);
+  assert.equal(plan.ok, false);
+  assert.equal(plan.ok === false && plan.reason, 'content_mismatch');
+});
+
+/** A batch that does fit and does reproduce the content is accepted as-is. */
+test('#2300: an in-sync single-op batch is still applied incrementally', () => {
+  const storeContent = 'const total = 1\nconst other = 2\n';
+  const changes: ScriptEditorTextChange[] = [{ from: 14, to: 15, insert: '9' }];
+  const nextContent = spliceSequentially(storeContent, changes);
+  const doc = docOf(storeContent);
+
+  const plan = planScriptEditorChanges(doc, changes, nextContent);
+  assert.equal(plan.ok, true);
+  assert.equal(plan.ok && plan.changes.apply(doc).toString(), nextContent);
+  // Incremental, not a whole-document replace: only the one touched range may
+  // be reported as changed, so CodeMirror's undo history and cursor mapping
+  // still see a one-character edit.
+  const touched: Array<[number, number]> = [];
+  if (plan.ok) plan.changes.iterChangedRanges((fromA, toA) => { touched.push([fromA, toA]); });
+  assert.deepEqual(touched, [[14, 15]]);
+});

--- a/apps/viewer/src/lib/llm/script-editor-changes.test.ts
+++ b/apps/viewer/src/lib/llm/script-editor-changes.test.ts
@@ -163,6 +163,31 @@ test('#2300: a batch that does not fit the live document is rejected, not dispat
 });
 
 /**
+ * The exact boundary of the bounds guard. `to === length` is the accept side
+ * (a replace running to the very end of the document, which is what both
+ * reported crashes ended on), so the reject side has to be pinned at
+ * `length + 1` or an off-by-one in the guard is invisible: relaxing it to
+ * `change.to <= length + 1` reintroduces the uncaught throw, because
+ * `ChangeSet.of({from: 0, to: 6, insert: 'x'}, 5)` raises
+ * `Invalid change range 0 to 6 (in doc of length 5)`.
+ */
+test('#2357: a one-past-the-end range is rejected rather than thrown', () => {
+  const doc = docOf('a'.repeat(100));
+  const changes: ScriptEditorTextChange[] = [{ from: 0, to: 101, insert: '' }];
+
+  const plan = planScriptEditorChanges(doc, changes, '');
+  assert.equal(plan.ok, false, 'to === length + 1 must not be treated as applicable');
+  assert.equal(plan.ok === false && plan.reason, 'out_of_bounds');
+  assert.equal(plan.ok === false && plan.docLength, 100);
+  assert.equal(plan.ok === false && plan.rangeTo, 101);
+
+  // The accept side of the same boundary, so the guard cannot be "fixed" by
+  // rejecting everything that reaches the end of the document.
+  const atEnd = planScriptEditorChanges(doc, [{ from: 0, to: 100, insert: '' }], '');
+  assert.equal(atEnd.ok, true, 'to === length is a legal replace-to-end-of-document');
+});
+
+/**
  * In-bounds but wrong: the document drifted in CONTENT, not length. Applying
  * would leave CodeMirror and `scriptEditorContent` holding different text, so
  * this must be rejected too.
@@ -178,6 +203,32 @@ test('#2357: a batch that applies cleanly but misses the expected content is rej
   const plan = planScriptEditorChanges(drifted, changes, nextContent);
   assert.equal(plan.ok, false);
   assert.equal(plan.ok === false && plan.reason, 'content_mismatch');
+});
+
+/**
+ * Line endings are a real second source of store/document drift, not a
+ * hypothetical one. CodeMirror splits on `/\r\n?|\n/` when it builds a
+ * document AND when it applies an insert, so a `\r\n` script that reached
+ * `scriptEditorContent` without passing through the editor (see the PR body)
+ * leaves the store's copy longer than the document by one char per CRLF, and
+ * every range measured against the store then overshoots.
+ *
+ * This pins what the fix guarantees in that case: a rejection the adapter can
+ * degrade from, never the uncaught RangeError.
+ */
+test('#2300: CRLF drift between the store and the document is rejected, not thrown', () => {
+  const storeContent = 'const a = 1\r\nconst b = 2\r\n';
+  // What CodeMirror actually holds after being handed that text.
+  const doc = docOf(storeContent.replace(/\r\n/g, '\n'));
+  assert.equal(storeContent.length - doc.length, 2, 'the store copy is longer by one char per CRLF');
+
+  const changes: ScriptEditorTextChange[] = [
+    { from: 12, to: storeContent.length, insert: 'const b = 3\r\n' },
+  ];
+  const plan = planScriptEditorChanges(doc, changes, spliceSequentially(storeContent, changes));
+  assert.equal(plan.ok, false);
+  assert.equal(plan.ok === false && plan.reason, 'out_of_bounds');
+  assert.equal(plan.ok === false && plan.rangeTo, storeContent.length);
 });
 
 /** A batch that does fit and does reproduce the content is accepted as-is. */

--- a/apps/viewer/src/lib/llm/script-editor-changes.ts
+++ b/apps/viewer/src/lib/llm/script-editor-changes.ts
@@ -1,0 +1,107 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Turns a batch of `ScriptEditorTextChange` specs into ONE CodeMirror
+ * `ChangeSet` against the live editor document.
+ *
+ * Two coordinate systems meet here, and conflating them is what produced the
+ * production `RangeError`s in #2357 / #2300:
+ *
+ * - `applyScriptEditOperations` emits its `changes` **sequentially**: every
+ *   spec's `from`/`to` index the content *after* the preceding specs in the
+ *   same batch have been applied. That is literal — the same numbers are the
+ *   arguments to its own running `content.slice()` splice.
+ * - CodeMirror's `ChangeSet.of(specs, length)` reads an ARRAY of specs as all
+ *   relative to the **original** document. Handing it sequential coordinates
+ *   therefore either throws (`Invalid change range <from> to <to> (in doc of
+ *   length <n>)`, the crash) or, when the numbers happen to fit, silently
+ *   applies the wrong edit.
+ *
+ * So each spec is composed one at a time against the length its own
+ * coordinates belong to, and the composed result is verified to reproduce
+ * `nextContent` exactly. A batch that cannot be replayed onto this document
+ * (because the document has drifted from the store's copy) is rejected rather
+ * than dispatched, so the caller can fall back to a whole-document set and
+ * keep the store and the editor holding the same text.
+ */
+
+import { ChangeSet, type Text } from '@codemirror/state';
+import type { ScriptEditorTextChange } from './types.js';
+
+/** Why a batch could not be replayed onto the live document. */
+export type ScriptEditorChangeRejection =
+  /** A spec's range falls outside the document it would apply to. */
+  | 'out_of_bounds'
+  /** The specs applied cleanly but did not reproduce the expected content. */
+  | 'content_mismatch';
+
+export type ScriptEditorChangePlan =
+  | { ok: true; changes: ChangeSet }
+  | {
+      ok: false;
+      reason: ScriptEditorChangeRejection;
+      /** Length of the document the failing spec was measured against. */
+      docLength: number;
+      /** Length the batch was expected to produce. */
+      expectedLength: number;
+      rangeFrom: number;
+      rangeTo: number;
+    };
+
+function isApplicableRange(change: ScriptEditorTextChange, length: number): boolean {
+  return (
+    Number.isInteger(change.from) &&
+    Number.isInteger(change.to) &&
+    typeof change.insert === 'string' &&
+    change.from >= 0 &&
+    change.to >= change.from &&
+    change.to <= length
+  );
+}
+
+/**
+ * Compose sequential change specs into a single `ChangeSet` for `doc`.
+ *
+ * Returns a rejection instead of throwing when the batch does not fit the
+ * document — the ranges are validated against the LIVE document (and, for
+ * each subsequent spec, against the length the batch has reached), never
+ * against the store's possibly-stale copy of the script.
+ */
+export function planScriptEditorChanges(
+  doc: Text,
+  changes: readonly ScriptEditorTextChange[],
+  nextContent: string,
+): ScriptEditorChangePlan {
+  let composed = ChangeSet.empty(doc.length);
+  for (const change of changes) {
+    const length = composed.newLength;
+    if (!isApplicableRange(change, length)) {
+      return {
+        ok: false,
+        reason: 'out_of_bounds',
+        docLength: length,
+        expectedLength: nextContent.length,
+        rangeFrom: change.from,
+        rangeTo: change.to,
+      };
+    }
+    composed = composed.compose(
+      ChangeSet.of({ from: change.from, to: change.to, insert: change.insert }, length),
+    );
+  }
+
+  if (composed.newLength !== nextContent.length || composed.apply(doc).toString() !== nextContent) {
+    return {
+      ok: false,
+      reason: 'content_mismatch',
+      docLength: doc.length,
+      expectedLength: nextContent.length,
+      rangeFrom: 0,
+      rangeTo: composed.newLength,
+    };
+  }
+
+  return { ok: true, changes: composed };
+}

--- a/apps/viewer/src/lib/llm/types.ts
+++ b/apps/viewer/src/lib/llm/types.ts
@@ -46,6 +46,17 @@ export interface ScriptEditorSelection {
   to: number;
 }
 
+/**
+ * One text splice from an assistant edit batch.
+ *
+ * Coordinates are **sequential**: within a batch, each change's `from`/`to`
+ * index the content *after* every preceding change has been applied (they are
+ * the literal arguments to the applier's own running splice). This is NOT
+ * CodeMirror's array-of-specs convention, which reads every spec against the
+ * original document — pass a batch through `planScriptEditorChanges`
+ * (`./script-editor-changes.ts`) to convert it, never straight to `dispatch`
+ * (#2357 / #2300).
+ */
 export interface ScriptEditorTextChange {
   from: number;
   to: number;


### PR DESCRIPTION
Two uncaught `RangeError`s from the script editor, reported by error tracking against production on two different builds and browsers:

- #2357 (Firefox 153 / macOS): `Invalid change range 2090 to 2197 (in doc of length 2159)`
- #2300 (Edge 150 / Windows): `Invalid change range 8048 to 10082 (in doc of length 7932)`

Both die inside `applyScriptEditOps` -> `scriptEditorApplyAdapter.apply` -> `EditorView.dispatch`, which kills the whole assistant-edit interaction.

Fixes #2357.
Fixes #2300.

## The mechanism, proved

`applyScriptEditOperations` emits its `changes` in **sequential** coordinates: each spec's `from`/`to` index the content that the *preceding* specs in the same batch produced. That is literal, not inferred, in `script-edit-ops.ts` every spec is pushed with the same numbers that are passed to the running `content.slice()` splice:

```ts
content = replaceRange(content, rebasedFrom, rebasedTo, op.text);
changes.push({ from: rebasedFrom, to: rebasedTo, insert: op.text });
```

CodeMirror's `ChangeSet.of(specs, length)` reads an **array** of specs as all relative to the *original* document. The adapter in `CodeEditor.tsx` handed the array straight to one `dispatch`, so every spec after the first was read in the wrong coordinate system.

The reported numbers land on this exactly. Reproducing #2300's arithmetic (7932-char base, a 2150-char insert, then a `replaceRange` running to the end of the base snapshot, so `[5898+2150, 7932+2150]`) against real `@codemirror/state` gives the reported string byte for byte:

```
ChangeSet.of(array) THREW: RangeError: Invalid change range 8048 to 10082 (in doc of length 7932)
```

#2357 is the same shape at a smaller size: a 38-char insert ahead of a replace-to-end-of-snapshot, `[2052+38, 2159+38]` = `[2090, 2197]` against a 2159-char document.

On what the numbers do and do not establish. `2159 + 38` and `7932 + 2150` are consistent with the two copies being in sync and the overflow coming entirely from intra-batch growth, and **no drift is required to reproduce either crash**: a batch of two or more ops where an earlier one grows the script is sufficient, which is what the reproductions above do.

That is consistency, not proof, and it should not be read as more. `to = docLength + delta` fits *any* out-of-bounds range, so any overflow can be written after the fact as "an insert of `delta`, then a replace to the end of the snapshot" — and a genuine store/document drift with a single op produces a byte-identical error string. Both readings survive the evidence. The fix handles both, because it validates against the live document rather than trusting either copy, and the CRLF section below documents a drift mechanism that is real and executed rather than hypothetical.

There is a silent half to this as well. When the sequential numbers happen to fit the original document, the old dispatch did not throw, it applied a *different* edit. `[{from:0,to:0,insert:'XX'}, {from:1,to:2,insert:'Z'}]` on `ABCDEF` yields `XZABCDEF` sequentially and `XXAZCDEF` as original-document specs, and only the first is what the store recorded.

## The fix

New `apps/viewer/src/lib/llm/script-editor-changes.ts` (`planScriptEditorChanges`) replays a batch onto the **live** `EditorView` document one spec at a time, composing each against the length its own coordinates belong to. It then verifies the composed result reproduces the exact `nextContent` the store is about to record, and returns a rejection instead of throwing when it cannot.

`CodeEditor.tsx` uses it, and on a rejection:

- falls back to a whole-document set built from `nextContent`, so CodeMirror and `scriptEditorContent` hold the same text (coarser undo granularity for that one edit is the whole cost; the one exception is line endings, see the CRLF section)
- reports through the existing handled-report path, `posthog.captureException` with `context: 'script_editor_apply'`, carrying only the rejection enum and lengths/offsets, never script text

This covers the drift reading as well as the in-sync one, which is the point of validating at the adapter: ranges are checked against the document that is actually about to be written, not against the store's copy, so it does not matter which of the two produced a given report.

`applyScriptEditOperations` is unchanged. Its sequential contract is correct, it was simply undocumented and misread, so it is now spelled out on `ScriptEditorTextChange`.

## Mutation check

`apps/viewer/src/lib/llm/script-editor-changes.test.ts`, 9 tests, each citing #2357 or #2300. Every test was re-run against five reverts of the fix.

| # | Test | M1 pre-fix consumer | M2 never compose | M3 no content check | M4 no bounds check | M5 off-by-one bounds | Fix in place |
|---|------|----|----|----|----|----|----|
| 1 | #2300 overflow composes, no RangeError | FAIL | FAIL | pass | pass | pass | pass |
| 2 | #2357 overflow composes, no RangeError | FAIL | FAIL | pass | pass | pass | pass |
| 3 | in-bounds specs apply sequentially, not as original-doc specs | FAIL | FAIL | pass | pass | pass | pass |
| 4 | the applier's own `changes` replay onto the document exactly | FAIL | FAIL | pass | pass | pass | pass |
| 5 | a batch that does not fit the live document is rejected | FAIL | FAIL | pass | **FAIL** | pass | pass |
| 6 | a one-past-the-end range is rejected rather than thrown | FAIL | FAIL | pass | **FAIL** | **FAIL** | pass |
| 7 | a batch that fits but misses the expected content is rejected | FAIL | pass | **FAIL** | pass | pass | pass |
| 8 | CRLF drift between store and document is rejected, not thrown | FAIL | FAIL | pass | **FAIL** | pass | pass |
| 9 | an in-sync single-op batch is still applied incrementally | pass | **FAIL** | pass | pass | pass | pass |
| | **totals** | **8F / 1P** | **8F / 1P** | **1F / 8P** | **3F / 6P** | **1F / 8P** | **9P / 0F** |

- M1 restores the pre-fix consumer: the whole array to one `ChangeSet.of` against the original document, no validation, no verification.
- M2 makes the planner always reject, forcing the whole-document fallback.
- M3 removes only the "did this reproduce `nextContent`" check.
- M4 removes only the live-document bounds validation.
- M5 relaxes that validation by exactly one, `change.to <= length` to `change.to <= length + 1`.

**M5 is here because review found it surviving.** The original 7 tests all passed against it, while the mutant demonstrably reintroduces the crash. Test 6 was added to close it, and it does not merely assert a rejection: under M5 it fails by *throwing the production signature itself*, `Invalid change range 0 to 101 (in doc of length 100)`, from the node runner. The accept side of the same boundary (`to === length`, a legal replace to end of document, which is what both reported crashes ended on) is asserted in the same test so the guard cannot be "fixed" by rejecting everything that reaches the end.

Every test is now killed by at least one mutation, so none is vacuous. Disclosed honestly: **test 9 survives M1 by design.** It is the control, a single in-bounds spec behaves identically under both coordinate systems, and it exists to prove the fix did not turn every edit into a whole-document replace. M2 kills it, which is what pins its value.

The helper was restored byte-identically (`diff` clean) after each of the five mutations, and the final run is against the restored file.

## Verification

Run in the worktree, after rebasing onto current `main` (`9c17d7db4`, which already carries #2307), through the root turbo commands, never a package-local vitest or tsc:

| Command | Result |
|---|---|
| `pnpm install` | clean |
| `pnpm typecheck` (first run, 7 tests) | **36/36 tasks successful, exit 0**, `Cached: 0 cached, 36 total`, so every task including the whole `^build` graph really executed, nothing was replayed from cache |
| `pnpm test` (first run, 7 tests) | **86/86 tasks successful, exit 0**. `@ifc-lite/viewer`: 3198 tests, 3192 pass, **0 fail**, 6 skipped (the usual fixture-gated skips) |
| `pnpm typecheck` (after adding tests 6 and 8) | **36/36 successful, exit 0**, `35 cached` — only `@ifc-lite/viewer:typecheck` re-executed, which is exactly the lane that changed |
| `pnpm test` (after adding tests 6 and 8) | **86/86 successful, exit 0**. `@ifc-lite/viewer`: **3200 tests, 3194 pass, 0 fail**, 6 skipped |

Two independent checks that the new tests really ran rather than being silently skipped: the viewer lane count moved **3198 to 3200, exactly +2** for the two added tests, and the file is inside the viewer's own lane glob (`find src -type f -name '*.test.ts'`, entry 159 of 287). The `0 cached` line on the first typecheck additionally means `pnpm build` ran green as part of the graph rather than being replayed, so none of this is a stale-artifact green.

## Relation to #2307

No overlap. #2307 (merged) changes `script-edit-ops.ts` so a positional op cannot follow a cross-batch `replaceAll`. This PR does not touch that file at all, it fixes how the resulting `changes` are handed to CodeMirror. The two are complementary: #2307 removes a class of semantically wrong ops, this removes the crash that came from reading correct ops in the wrong coordinate system. This branch is rebased on top of it.

## CRLF: a second, real drift mechanism, deliberately NOT fixed here

Review raised that `parseSearchReplaceFence` normalizes `\r\n` while `parseJsonFence` does not, and suggested normalizing op text in `parseJsonFence` to match. I chased it and **it is real and worse than "an inconsistency between two parse paths"**, which is exactly why the suggested one-line fix does not belong in this PR.

Executed against the real `@codemirror/state`:

```
create: input len 7 -> doc len 5 "a\nb\nc"          // CodeMirror splits on /\r\n?|\n/
insert: inserted len 4 -> doc len 5 "Xa\nbY"        // and again on every insert
fallback: store len 26, doc len 24, equal? false
range from store THREW against the LF doc:
  RangeError: Invalid change range 0 to 26 (in doc of length 24)
```

So CodeMirror silently normalizes line endings on document creation **and** on every insert. Any `\r\n` content that reaches `scriptEditorContent` without passing through the editor leaves the store's copy longer than the document by one character per CRLF, and every range measured against the store then overshoots by that count, producing an error string byte-identical to the two reported here. This is a genuine candidate mechanism for these issues, and #2357's 38-character overflow in a ~2.2 KB script is numerically plausible as CRLF drift in a way #2300's 2150 is not.

**Why I did not take the suggested fix.** It is partial, and shipping it would buy false confidence. `parseJsonFence` is only one entry point; the larger one is `replaceScriptContentFallback(lastBlock.code)` in `ChatPanel`, which writes a fenced code block from the model straight into the store. It calls the adapter first and `set({ scriptEditorContent })` afterwards, so CodeMirror's normalized text is overwritten by the raw CRLF text, leaving the store's copy the longer one, which is the direction the crash needs. `setScriptEditorContent` from `CommandPalette` and `IdeasPanel` are further entry points. Normalizing in `parseJsonFence` closes none of those.

**The complete fix is a different defect.** It is a line-ending contract across the eight places the slice writes `scriptEditorContent`, and it reaches persistence (saved-script `code` round-trips through `localStorage`) and sandbox execution. That deserves its own PR with its own test matrix rather than a one-liner smuggled into a coordinate-system fix.

**What this PR does about it meanwhile:** test 8 pins that CRLF drift produces a *rejection* the adapter can degrade from, never the uncaught RangeError. The residue is that the whole-document fallback then writes CRLF text that CodeMirror normalizes again, so the store and the editor disagree for one render until `CodeEditor`'s value-sync effect heals it; the healing costs a revision bump that can revision-conflict the assistant's follow-on ops. That is strictly better than the pre-fix behaviour (an uncaught throw) and is the honest limit of the guarantee below.

## Known gaps

- The tested unit is the pure planner plus real `applyScriptEditOperations` output, not the React `CodeEditor` component. Driving a real `EditorView` needs a DOM harness the viewer's `node:test` setup does not use for this area, so the wiring inside `registerApplyAdapter` (the `plan.ok` branch and the `captureException` call) is covered by review and typecheck, not by a test.
- The whole-document fallback collapses that one edit into a single undo step. It only fires on a rejection, which should now be rare.
- "CodeMirror and `scriptEditorContent` can never hold different text" holds **modulo line endings**, per the CRLF section: after a CRLF-triggered fallback the two disagree for one render before the value-sync effect heals them. Closing that needs the separate line-ending PR described above.
- No changeset: `apps/viewer` is not a published package.

