### PR TITLE
fix(viewer): group the minimap's WebGL degradation as one warning, not an error per deploy (#2354)

### DIFF
--- a/apps/viewer/src/components/viewer/properties/LocationMap.tsx
+++ b/apps/viewer/src/components/viewer/properties/LocationMap.tsx
@@ -284,6 +284,16 @@ export function LocationMap({
    * point: an explicit capture is recorded as HANDLED, so an unsupported GPU
    * stops arriving as an error-level uncaught exception for something no user
    * and no code change can fix.
+   *
+   * Handled is not the same as low-severity, though, and posthog-js stamps
+   * every capture `$exception_level: 'error'` regardless. Grouping and severity
+   * are settled downstream in `lib/analytics-scrub.ts`, off the
+   * `webgl_unavailable` kind `classifyLoadError` derives from the message: ONE
+   * fingerprint for the whole family (the default hash includes the stack, so
+   * this minted a new issue per deploy — #2354) and `error` rewritten to
+   * `warning`. Nothing here needs to opt in; do not add a second reporting path
+   * for it. `map_load_failed` is deliberately outside that family — a chunk
+   * that would not download is ours to fix and stays loud.
    */
   const degradeMap = useCallback((reason: MapUnavailableReason, err: unknown) => {
     // A missing GPU capability is a property of the device, so latch it for the

--- a/apps/viewer/src/lib/analytics-scrub.ts
+++ b/apps/viewer/src/lib/analytics-scrub.ts
@@ -329,6 +329,13 @@ const tagErrorKind = (
 // single retention window, which is exactly the "same problem, one fix" case
 // PostHog documents custom fingerprints for.
 //
+// A constant message is not enough on its own, which is what #2354 showed: the
+// minimap's WebGL report is one fixed string per reason, yet it minted a fresh
+// issue on each deploy, because the stack that feeds the default hash names the
+// hashed bundle it came from (`main-DnUx64at.js`, then `index-B0OhdiDw.js`, …).
+// Four issues, one benign condition. A fingerprint is the only thing that
+// survives a release.
+//
 // Scoped deliberately to the families `classifyLoadError` recognises. An
 // unrecognised exception keeps PostHog's default per-message grouping, so we
 // never over-group unrelated failures into one meaningless bucket. The volatile
@@ -359,7 +366,24 @@ const stampFingerprint = (
 // `fatal` / `warning` / `info` is never clobbered. `wasm_engine_load` is
 // pointedly NOT in this set: a rotated or 404ing engine binary means the deploy
 // is broken for everyone and must stay loud.
-const BENIGN_ERROR_KINDS = new Set<string>(['network_unavailable', 'cancelled']);
+//
+// `webgl_unavailable` joins them for the same reason, on stronger evidence
+// (#2354). It is not a failure at all in the sense `error` claims: the minimap
+// probes for a WebGL context, the device refuses one, and `LocationMap` paints
+// its fallback with the coordinate readout, place search, the external map
+// links and KMZ export all still working. Nothing the user or a code change can
+// alter — the reported occurrences are a device whose GPU is missing an
+// extension or whose GPU process could not serve a second context. It stays
+// captured and queryable (with `map_unavailable_reason` and `webgl_status`
+// intact), just not competing with real breakage on an error-level list. Only
+// MapLibre's handled failure is in this bucket: three.js's
+// `THREE.WebGLRenderer: Error creating WebGL context.` is classified `unknown`
+// and stays error-level, because nothing catches it — it throws out of the MCP
+// playground's mount effect, which takes the React tree down with it. That is
+// breakage, not a degradation, and must not inherit this severity.
+const BENIGN_ERROR_KINDS = new Set<string>([
+  'network_unavailable', 'cancelled', 'webgl_unavailable',
+]);
 
 const downgradeBenignExceptions = (
   event: { event?: string; properties?: Record<string, unknown> },

--- a/apps/viewer/src/lib/analytics.test.ts
+++ b/apps/viewer/src/lib/analytics.test.ts
@@ -226,10 +226,32 @@ describe('scrubEvent — noise filter + PII guard (regression)', () => {
     assert.equal(out?.properties?.map_unavailable_reason, 'map_construction_failed');
   });
 
-  it('keeps an unrelated WebGL failure that merely mentions the words', () => {
-    // Narrowness guard: an actionable WebGL bug of ours must not be dropped.
-    assert.notEqual(scrubEvent(uncaught('Failed to initialize WebGPU adapter')), null);
-    assert.notEqual(scrubEvent(uncaught('WebGL warning: drawArrays: no program bound')), null);
+  it('keeps an unrelated WebGL failure INTACT when it merely mentions the words', () => {
+    // Narrowness guard. Survival (`!== null`) is NOT enough to state it: once
+    // #2354 made the same predicate assign `error_kind`, an over-broad match
+    // could leave the event alive but relabelled — benign kind, the minimap's
+    // fingerprint, `warning` instead of `error` — which buries an actionable
+    // bug just as effectively as dropping it, and the old survival-only
+    // assertion passed straight through that. So assert the identity too.
+    const intact = (value: string) => {
+      const out = scrubEvent({
+        event: '$exception',
+        properties: {
+          $exception_list: [{ type: 'Error', value, mechanism: { handled: false } }],
+          $exception_level: 'error',
+        },
+      } as CaptureEvent);
+      assert.notEqual(out, null, value);
+      assert.equal(out?.properties?.error_kind, undefined, value);
+      assert.equal(out?.properties?.$exception_fingerprint, undefined, value);
+      assert.equal(out?.properties?.$exception_level, 'error', value);
+    };
+    intact('Failed to initialize WebGPU adapter');
+    intact('WebGL warning: drawArrays: no program bound');
+    // The exact hazard MAPLIBRE_WEBGL_UNAVAILABLE's comment names, and the one
+    // an unanchored `includes` in the classifier would have swallowed.
+    intact('Failed to initialize WebGL renderer for the section overlay');
+    intact('SectionOverlay: Failed to initialize WebGL');
   });
 
   // #2112: PostHog auto-filed a GitHub issue from the LocationMap's own

--- a/apps/viewer/src/lib/analytics.test.ts
+++ b/apps/viewer/src/lib/analytics.test.ts
@@ -233,11 +233,11 @@ describe('scrubEvent — noise filter + PII guard (regression)', () => {
     // fingerprint, `warning` instead of `error` — which buries an actionable
     // bug just as effectively as dropping it, and the old survival-only
     // assertion passed straight through that. So assert the identity too.
-    const intact = (value: string) => {
+    const intact = (value: string, handled = false) => {
       const out = scrubEvent({
         event: '$exception',
         properties: {
-          $exception_list: [{ type: 'Error', value, mechanism: { handled: false } }],
+          $exception_list: [{ type: 'Error', value, mechanism: { handled } }],
           $exception_level: 'error',
         },
       } as CaptureEvent);
@@ -252,6 +252,15 @@ describe('scrubEvent — noise filter + PII guard (regression)', () => {
     // an unanchored `includes` in the classifier would have swallowed.
     intact('Failed to initialize WebGL renderer for the section overlay');
     intact('SectionOverlay: Failed to initialize WebGL');
+    // Round two of the same defect, on the OTHER two arms of the same boolean:
+    // the v5 token quoted inside unrelated text, and the v6 sentence quoted
+    // mid-message. Both used to take the minimap's kind, fingerprint and
+    // `warning`. Passed HANDLED, because the pre-existing drop matcher in
+    // analytics-scrub.ts still swallows the UNCAUGHT form of the token string
+    // outright — a separate, pre-existing over-match documented in the PR, not
+    // something this test should paper over.
+    intact('Upload failed: driver shim logged {"type":"webglcontextcreationerror"} while retrying', true);
+    intact('TileCache: WebGL2 is required to display this map, so the raster fallback was used');
   });
 
   // #2112: PostHog auto-filed a GitHub issue from the LocationMap's own

--- a/apps/viewer/src/lib/analytics.test.ts
+++ b/apps/viewer/src/lib/analytics.test.ts
@@ -595,6 +595,123 @@ describe('scrubEvent — benign network failures (#1903)', () => {
   });
 });
 
+// Issue #2354. The minimap's WebGL degradation is HANDLED and the user gets a
+// working fallback (coordinates, place search, the external map links and KMZ
+// export all keep working) — but posthog-js stamps every capture
+// `$exception_level: 'error'`, and PostHog's default grouping hashes the stack,
+// whose file name carries the deploy hash. So one benign condition arrived as
+// four separate error-level issues in six days: 019fdc16 + 019fc748 (both
+// "…(pre-flight probe)") and 019fccaa + 019fc35e (both "…(context lost)").
+// These pin the fix: one fingerprint for the family, `warning` not `error`, and
+// the report still leaves the browser with its diagnostics attached.
+describe('scrubEvent — handled WebGL degradation (#2354)', () => {
+  /** Exactly what `LocationMap`'s `degradeMap` hands `captureException`. */
+  const minimapReport = (
+    value: string,
+    reason: string,
+    extraProps: Record<string, unknown> = {},
+  ): CaptureEvent => ({
+    event: '$exception',
+    properties: {
+      $exception_list: [{
+        type: 'Error',
+        value,
+        mechanism: { handled: true, type: 'generic' },
+        stacktrace: { frames: [{ source: '/assets/main-DnUx64at.js' }] },
+      }],
+      $exception_level: 'error',
+      context: 'location_map_webgl',
+      map_unavailable_reason: reason,
+      ...extraProps,
+    },
+  });
+
+  const PROBE = 'Failed to initialize WebGL (pre-flight probe)';
+  const CONTEXT_LOST = 'Failed to initialize WebGL (context lost)';
+
+  it('collapses the whole family onto ONE fingerprint', () => {
+    const probe = scrubEvent(minimapReport(PROBE, 'probe_no_context'));
+    const lost = scrubEvent(minimapReport(CONTEXT_LOST, 'context_lost'));
+    // MapLibre v6's wording, from the reconstructed no-painter failure.
+    const v6 = scrubEvent(minimapReport(
+      'WebGL2 is required to display this map. The map could not start: MapLibre built no painter.',
+      'map_construction_failed',
+    ));
+    assert.equal(probe?.properties?.$exception_fingerprint, 'ifc-lite:webgl_unavailable');
+    assert.equal(lost?.properties?.$exception_fingerprint, 'ifc-lite:webgl_unavailable');
+    assert.equal(v6?.properties?.$exception_fingerprint, 'ifc-lite:webgl_unavailable');
+  });
+
+  it('downgrades it from error to warning', () => {
+    const out = scrubEvent(minimapReport(PROBE, 'probe_no_context'));
+    assert.equal(out?.properties?.error_kind, 'webgl_unavailable');
+    assert.equal(out?.properties?.$exception_level, 'warning');
+  });
+
+  it('still SENDS the report, with its diagnostics intact (never go dark)', () => {
+    // Downgrading severity is the fix; suppressing the signal would not be. A
+    // spike here is real information about a driver or a browser release.
+    const out = scrubEvent(minimapReport(CONTEXT_LOST, 'context_lost', {
+      webgl_status: 'OES_packed_depth_stencil support is required.',
+      webgl_event_type: 'webglcontextcreationerror',
+    }));
+    assert.notEqual(out, null);
+    assert.equal(out?.properties?.context, 'location_map_webgl');
+    assert.equal(out?.properties?.map_unavailable_reason, 'context_lost');
+    assert.equal(
+      out?.properties?.webgl_status,
+      'OES_packed_depth_stencil support is required.',
+    );
+    assert.equal(out?.properties?.webgl_event_type, 'webglcontextcreationerror');
+    assert.equal(
+      (out?.properties?.$exception_list as { value: string }[])[0].value,
+      CONTEXT_LOST,
+    );
+  });
+
+  it('keeps three.js\'s WebGL failure LOUD — nothing catches that one', () => {
+    // Issue 019fc458, thrown by THREE.WebGLRenderer out of the MCP playground's
+    // mount effect. An uncaught throw in a React effect tears the tree down, so
+    // it is real breakage, not a degradation. It must not inherit the minimap's
+    // fingerprint or its severity.
+    const out = scrubEvent(exceptionEvent(
+      'THREE.WebGLRenderer: Error creating WebGL context.',
+      { $exception_level: 'error' },
+    ));
+    assert.notEqual(out, null);
+    assert.equal(out?.properties?.$exception_fingerprint, undefined);
+    assert.equal(out?.properties?.$exception_level, 'error');
+  });
+
+  it('still drops the UNCAUGHT MapLibre form, and only that one', () => {
+    // The one path no try/catch of ours is on the stack for (MapLibre restoring
+    // a lost context from a DOM listener) is dropped outright, as before. The
+    // handled report with the same family must survive — the two rules have to
+    // keep coexisting.
+    assert.equal(
+      scrubEvent({
+        event: '$exception',
+        properties: {
+          $exception_list: [{
+            type: 'Error',
+            value: 'Failed to initialize WebGL',
+            mechanism: { handled: false },
+          }],
+        },
+      } as CaptureEvent),
+      null,
+    );
+    assert.notEqual(scrubEvent(minimapReport(PROBE, 'probe_no_context')), null);
+  });
+
+  it('never clobbers a level deliberately chosen at the capture site', () => {
+    const out = scrubEvent(minimapReport(PROBE, 'probe_no_context', {
+      $exception_level: 'info',
+    }));
+    assert.equal(out?.properties?.$exception_level, 'info');
+  });
+});
+
 // ── before_send wiring ──────────────────────────────────────────────────────
 // The two skew gates are unit-tested in isolation (chunk-version-skew.test.ts,
 // wasm-skew-noise.test.ts). What only a test of `beforeSend` itself can catch is

--- a/apps/viewer/src/lib/geo/map-webgl-support.ts
+++ b/apps/viewer/src/lib/geo/map-webgl-support.ts
@@ -208,8 +208,26 @@ export function probeMapWebglSupport(
  */
 const MAP_GPU_INIT_ERROR_NAME = 'GPUInitializationError';
 
-/** v6's wording. Kept as a second key in case a subclass renames itself. */
+/**
+ * v6's wording. Kept as a second key in case a subclass renames itself, and
+ * used verbatim by `reconstructMapInitFailure` to rebuild the error v6 drops.
+ */
 const MAP_WEBGL2_REQUIRED_MESSAGE = 'WebGL2 is required to display this map';
+
+/**
+ * The same wording as a matcher, anchored to the START rather than tested as a
+ * substring, for the reason spelled out on `MAP_WEBGL_INIT_REPORT` below.
+ *
+ * It cannot be anchored at both ends: `reconstructMapInitFailure` appends a
+ * sentence of our own to this exact phrase, while MapLibre's own message is the
+ * phrase alone. A prefix anchor admits both and still rejects the phrase quoted
+ * inside someone else's sentence — "TileCache: WebGL2 is required to display
+ * this map, so …" — which a bare `includes` accepted (#2354).
+ *
+ * Built from the constant above so the wording has ONE home and cannot drift.
+ * Safe to interpolate: the phrase is letters and spaces, no regex metacharacter.
+ */
+const MAP_WEBGL2_REQUIRED_REPORT = new RegExp(`^\\s*${MAP_WEBGL2_REQUIRED_MESSAGE}\\b`);
 
 /**
  * v5's bare wording, plus the two suffixed forms `LocationMap` synthesizes.
@@ -230,10 +248,45 @@ const MAP_WEBGL2_REQUIRED_MESSAGE = 'WebGL2 is required to display this map';
  * strings `LocationMap` builds; anything else is not ours to claim.
  */
 const MAP_WEBGL_INIT_REPORT =
-  /^\s*Failed to initialize WebGL(?:\s*\((?:pre-flight probe|context lost)\))?\s*$/;
+  /^\s*Failed to initialize WebGL(?: \((?:pre-flight probe|context lost)\))?\s*$/;
 
 /** The DOM event the driver dispatches when it refuses a context. */
 const CONTEXT_CREATION_ERROR_EVENT = 'webglcontextcreationerror';
+
+/**
+ * Is this message a COMPLETE maplibre-gl v5 context-creation payload?
+ *
+ * Structural, not a substring test on the token. v5's throw was
+ * `new Error(JSON.stringify({requestedAttributes, statusMessage, type, message}))`,
+ * so the token is the value of a `type` FIELD — and that is what we require,
+ * together with the anchored bare message that v5 always paired it with. A
+ * `message.includes('"type":"webglcontextcreationerror"')` would also fire on
+ * any text that merely quotes the token: a wrapped driver string, a serialized
+ * log line, a nested error payload. Under `classifyLoadError` that misfire is
+ * not cosmetic — it hands an unrelated error the minimap's fingerprint and its
+ * benign severity (#2354, and the same defect this module already fixed one
+ * clause above; when you anchor one arm of an OR, check every arm).
+ *
+ * Parsing rather than pattern-matching is this module's existing idiom for the
+ * shape — `describeMapInitFailure` below already `JSON.parse`s it behind the
+ * same `{` guard — so this adds no new technique, and the guard keeps the parse
+ * off every non-JSON message.
+ */
+function isMapV5FailurePayload(message: string): boolean {
+  if (!message.startsWith('{')) return false;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(message);
+  } catch {
+    // Not JSON after all; the other arms still get their say.
+    return false;
+  }
+  if (!parsed || typeof parsed !== 'object') return false;
+  const { type, message: inner } = parsed as Record<string, unknown>;
+  return type === CONTEXT_CREATION_ERROR_EVENT
+    && typeof inner === 'string'
+    && MAP_WEBGL_INIT_REPORT.test(inner);
+}
 
 /**
  * Watch a container for the driver's explanation of a refused context.
@@ -296,14 +349,20 @@ export function reconstructMapInitFailure(statusMessage: string | null): Error {
  * changes every build (the same discipline the Cesium matcher in
  * `analytics-scrub.ts` spells out). Over-matching here would silently swallow
  * an actionable map bug.
+ *
+ * EVERY message arm is anchored or structural; none is a bare `includes`. That
+ * is a property of the whole boolean, not of one clause, and it has to be
+ * checked as one: this predicate also assigns `error_kind`, so a single loose
+ * arm is enough to relabel an unrelated error benign and bury it in the
+ * minimap's issue (#2354). Adding an arm here means anchoring it too.
  */
 export function isWebglContextCreationError(err: unknown): boolean {
   if (err instanceof Error && err.name === MAP_GPU_INIT_ERROR_NAME) return true;
   const message = err instanceof Error ? err.message : typeof err === 'string' ? err : '';
   if (!message) return false;
-  return message.includes(MAP_WEBGL2_REQUIRED_MESSAGE)
+  return MAP_WEBGL2_REQUIRED_REPORT.test(message)
     || MAP_WEBGL_INIT_REPORT.test(message)
-    || message.includes('"type":"webglcontextcreationerror"');
+    || isMapV5FailurePayload(message);
 }
 
 export interface MapInitFailureDetail {

--- a/apps/viewer/src/lib/geo/map-webgl-support.ts
+++ b/apps/viewer/src/lib/geo/map-webgl-support.ts
@@ -254,6 +254,22 @@ const MAP_WEBGL_INIT_REPORT =
 const CONTEXT_CREATION_ERROR_EVENT = 'webglcontextcreationerror';
 
 /**
+ * Emitted when a message that LOOKED like the v5 JSON payload — it starts with
+ * `{` — turns out not to parse. Shared by the two places that make that guess.
+ *
+ * A fixed string with no interpolation, and the caught error is deliberately
+ * NOT logged alongside it. Both would defeat the point: these paths see
+ * arbitrary error text, and a modern V8 `SyntaxError` quotes a snippet of the
+ * offending source into its own message ("Unexpected token 'x', \"{bad…\" is
+ * not valid JSON"), so passing `err` would put that text in the console just as
+ * surely as interpolating the payload would. This satisfies the no-silent-catch
+ * rule without turning a diagnostic into a data leak; which of the two callers
+ * fired is recoverable from the stack the console attaches.
+ */
+const NON_JSON_PAYLOAD_WARNING =
+  '[ifc-lite] map WebGL matcher: message began with "{" but did not parse as JSON';
+
+/**
  * Is this message a COMPLETE maplibre-gl v5 context-creation payload?
  *
  * Structural, not a substring test on the token. v5's throw was
@@ -278,7 +294,10 @@ function isMapV5FailurePayload(message: string): boolean {
   try {
     parsed = JSON.parse(message);
   } catch {
-    // Not JSON after all; the other arms still get their say.
+    // Not JSON after all; the other arms still get their say. Reported rather
+    // than swallowed (no silent `catch {}`), and see the constant for why the
+    // caught error is deliberately NOT passed along.
+    console.warn(NON_JSON_PAYLOAD_WARNING);
     return false;
   }
   if (!parsed || typeof parsed !== 'object') return false;
@@ -414,7 +433,10 @@ export function describeMapInitFailure(err: unknown): MapInitFailureDetail {
     if (typeof type === 'string' && type) detail.eventType = type;
     return detail;
   } catch {
-    // Not JSON after all — the bare-message shape. No detail to add.
+    // Started with `{` but did not parse, so there is no detail to mine. Same
+    // no-silent-catch treatment as `isMapV5FailurePayload` above: this arm was
+    // equally silent, and fixing one while leaving its twin would be arbitrary.
+    console.warn(NON_JSON_PAYLOAD_WARNING);
     return {};
   }
 }

--- a/apps/viewer/src/lib/geo/map-webgl-support.ts
+++ b/apps/viewer/src/lib/geo/map-webgl-support.ts
@@ -212,16 +212,25 @@ const MAP_GPU_INIT_ERROR_NAME = 'GPUInitializationError';
 const MAP_WEBGL2_REQUIRED_MESSAGE = 'WebGL2 is required to display this map';
 
 /**
- * v5's wording, retained deliberately.
+ * v5's bare wording, plus the two suffixed forms `LocationMap` synthesizes.
  *
  * v5 threw `new Error(JSON.stringify({requestedAttributes, statusMessage, type,
- * message: 'Failed to initialize WebGL'}))`. v6 does not produce this shape at
- * all, so this line is dead against the pinned version. It stays because the
- * cost is one string comparison and the alternative, if maplibre-gl is ever
- * rolled back, is this module silently failing open on the exact failure it
- * exists to catch.
+ * message: 'Failed to initialize WebGL'}))`. v6 does not produce that shape at
+ * all, so the bare arm is dead against the pinned version. It stays because the
+ * cost is one test and the alternative, if maplibre-gl is ever rolled back, is
+ * this module silently failing open on the exact failure it exists to catch.
+ *
+ * ANCHORED, not a substring test, and that is load-bearing (#2354). The drop
+ * matcher in `lib/analytics-scrub.ts` anchors the same phrase for the same
+ * reason (#1914): an unrelated error that merely MENTIONS it — "Failed to
+ * initialize WebGL renderer for the …" — must keep its own identity. Once this
+ * predicate also feeds `classifyLoadError`, a substring match would hand such
+ * an error the minimap's fingerprint and its benign severity, burying a real
+ * bug in an issue nobody triages. The optional group covers exactly the two
+ * strings `LocationMap` builds; anything else is not ours to claim.
  */
-const MAP_WEBGL_INIT_MESSAGE = 'Failed to initialize WebGL';
+const MAP_WEBGL_INIT_REPORT =
+  /^\s*Failed to initialize WebGL(?:\s*\((?:pre-flight probe|context lost)\))?\s*$/;
 
 /** The DOM event the driver dispatches when it refuses a context. */
 const CONTEXT_CREATION_ERROR_EVENT = 'webglcontextcreationerror';
@@ -293,7 +302,7 @@ export function isWebglContextCreationError(err: unknown): boolean {
   const message = err instanceof Error ? err.message : typeof err === 'string' ? err : '';
   if (!message) return false;
   return message.includes(MAP_WEBGL2_REQUIRED_MESSAGE)
-    || message.includes(MAP_WEBGL_INIT_MESSAGE)
+    || MAP_WEBGL_INIT_REPORT.test(message)
     || message.includes('"type":"webglcontextcreationerror"');
 }
 

--- a/apps/viewer/src/lib/load-errors.test.ts
+++ b/apps/viewer/src/lib/load-errors.test.ts
@@ -296,6 +296,22 @@ describe('classifyLoadError', () => {
     );
   });
 
+  it('does NOT claim an error that merely MENTIONS the phrase (#1914/#2354)', () => {
+    // The hazard the drop matcher in analytics-scrub.ts anchors against, now
+    // that the same predicate also assigns `error_kind`. A substring test here
+    // would hand an unrelated bug of ours the minimap's fingerprint AND its
+    // benign severity — filed into an issue nobody triages. Both the trailing
+    // and the leading form, because anchoring only one end fixes only one.
+    assert.equal(
+      classifyLoadError(new Error('Failed to initialize WebGL renderer for the section overlay')),
+      'unknown',
+    );
+    assert.equal(
+      classifyLoadError(new Error('SectionOverlay: Failed to initialize WebGL')),
+      'unknown',
+    );
+  });
+
   it('leaves an unrelated GPU failure out of the webgl_unavailable bucket', () => {
     // Narrowness guard: the viewport renderer is WebGPU, and its failures are
     // not a minimap capability gap.

--- a/apps/viewer/src/lib/load-errors.test.ts
+++ b/apps/viewer/src/lib/load-errors.test.ts
@@ -250,6 +250,76 @@ describe('classifyLoadError', () => {
       'cancelled',
     );
   });
+
+  // ── webgl_unavailable (#2354) ─────────────────────────────────────────────
+  // The minimap's WebGL reports arrived as four separate PostHog issues (and
+  // GitHub issues) for one benign, handled condition, because the default
+  // grouping hashes the stack and the stack names the hashed bundle — so each
+  // deploy split the same message again. Classifying the family is what gives
+  // `analytics-scrub.ts` a stable fingerprint and the right severity.
+  it('classifies every shape of the minimap WebGL failure as webgl_unavailable', () => {
+    // The two messages LocationMap synthesizes; both are verbatim from the
+    // PostHog issues 019fdc16 / 019fc748 (probe) and 019fccaa / 019fc35e
+    // (context lost) — two issues each, for one string each.
+    assert.equal(
+      classifyLoadError(new Error('Failed to initialize WebGL (pre-flight probe)')),
+      'webgl_unavailable',
+    );
+    assert.equal(
+      classifyLoadError(new Error('Failed to initialize WebGL (context lost)')),
+      'webgl_unavailable',
+    );
+    // MapLibre v6's own wording, carried by the error LocationMap reconstructs
+    // when the constructor returns without a painter.
+    const v6 = new Error('WebGL2 is required to display this map. The map could not start: MapLibre built no painter.');
+    v6.name = 'GPUInitializationError';
+    assert.equal(classifyLoadError(v6), 'webgl_unavailable');
+    // v5's JSON blob, the shape PostHog issue 019fae1d recorded uncaught.
+    assert.equal(
+      classifyLoadError(new Error(JSON.stringify({
+        requestedAttributes: { depth: true, stencil: true },
+        statusMessage: 'OES_packed_depth_stencil support is required.',
+        type: 'webglcontextcreationerror',
+        message: 'Failed to initialize WebGL',
+      }))),
+      'webgl_unavailable',
+    );
+  });
+
+  it('does NOT claim three.js\'s WebGL failure, which nothing catches (#2354)', () => {
+    // PostHog issue 019fc458, thrown by THREE.WebGLRenderer out of the MCP
+    // playground's mount effect — an uncaught throw that tears the React tree
+    // down. Sweeping it into the benign family would silence real breakage.
+    assert.equal(
+      classifyLoadError(new Error('THREE.WebGLRenderer: Error creating WebGL context.')),
+      'unknown',
+    );
+  });
+
+  it('leaves an unrelated GPU failure out of the webgl_unavailable bucket', () => {
+    // Narrowness guard: the viewport renderer is WebGPU, and its failures are
+    // not a minimap capability gap.
+    assert.equal(classifyLoadError(new Error('Failed to initialize WebGPU adapter')), 'unknown');
+    assert.equal(
+      classifyLoadError(new Error('WebGL warning: drawArrays: no program bound')),
+      'unknown',
+    );
+  });
+
+  it('keeps the driver\'s own prose from being mis-bucketed (#2354)', () => {
+    // The driver's `statusMessage` is vendor text we do not control, and it is
+    // free to contain the words the memory/network matchers key on. The WebGL
+    // check runs first precisely so this lands in its own family instead of
+    // out_of_memory.
+    assert.equal(
+      classifyLoadError(new Error(JSON.stringify({
+        statusMessage: 'Could not create a WebGL context, allocation failed: .',
+        type: 'webglcontextcreationerror',
+        message: 'Failed to initialize WebGL',
+      }))),
+      'webgl_unavailable',
+    );
+  });
 });
 
 describe('errorCaptureProps', () => {

--- a/apps/viewer/src/lib/load-errors.test.ts
+++ b/apps/viewer/src/lib/load-errors.test.ts
@@ -312,6 +312,77 @@ describe('classifyLoadError', () => {
     );
   });
 
+  it('does NOT claim text that merely EMBEDS the v5 token or the v6 wording (#2354)', () => {
+    // Second round of the same defect: anchoring one arm of the OR left the
+    // other two as bare `includes`. A `"type":"webglcontextcreationerror"`
+    // token can appear inside a wrapped driver string, a serialized log line or
+    // a nested payload, and MapLibre's v6 sentence can be quoted mid-message.
+    // Membership must require the token to BE the payload's `type` field, and
+    // the v6 wording to START the message.
+    assert.equal(
+      classifyLoadError(new Error(
+        'Upload failed: driver shim logged {"type":"webglcontextcreationerror"} while retrying',
+      )),
+      'unknown',
+    );
+    assert.equal(
+      classifyLoadError(new Error(JSON.stringify({
+        error: 'render target lost',
+        context: '{"type":"webglcontextcreationerror"}',
+      }))),
+      'unknown',
+    );
+    assert.equal(
+      classifyLoadError(new Error(
+        'TileCache: WebGL2 is required to display this map, so the raster fallback was used',
+      )),
+      'unknown',
+    );
+  });
+
+  it('accepts only the exact spacing LocationMap emits (#2354)', () => {
+    // The suffix is joined by ONE literal space at the call site, so the
+    // matcher takes one literal space. `\s*` there would have admitted spacing
+    // no code produces, which is latitude the matcher has no reason to grant.
+    // This test also documents the coupling: change the string LocationMap
+    // builds and this fails rather than silently falling back to per-deploy
+    // issue churn.
+    assert.equal(
+      classifyLoadError(new Error('Failed to initialize WebGL  (context lost)')),
+      'unknown',
+    );
+    assert.equal(
+      classifyLoadError(new Error('Failed to initialize WebGL(context lost)')),
+      'unknown',
+    );
+    assert.equal(
+      classifyLoadError(new Error('Failed to initialize WebGL (context lost)')),
+      'webgl_unavailable',
+    );
+  });
+
+  it('still requires a COMPLETE v5 payload, not just the type field (#2354)', () => {
+    // The `type` field alone is not the failure: v5 always paired it with the
+    // bare message. A payload carrying the token but a different message is
+    // some other event of MapLibre's, not the context-creation throw.
+    assert.equal(
+      classifyLoadError(new Error(JSON.stringify({
+        type: 'webglcontextcreationerror',
+        message: 'Tile source could not be added',
+      }))),
+      'unknown',
+    );
+    // …and the genuine pairing still classifies.
+    assert.equal(
+      classifyLoadError(new Error(JSON.stringify({
+        statusMessage: 'OES_packed_depth_stencil support is required.',
+        type: 'webglcontextcreationerror',
+        message: 'Failed to initialize WebGL',
+      }))),
+      'webgl_unavailable',
+    );
+  });
+
   it('leaves an unrelated GPU failure out of the webgl_unavailable bucket', () => {
     // Narrowness guard: the viewport renderer is WebGPU, and its failures are
     // not a minimap capability gap.

--- a/apps/viewer/src/lib/load-errors.ts
+++ b/apps/viewer/src/lib/load-errors.ts
@@ -79,9 +79,11 @@ export type LoadErrorKind =
   /**
    * The browser refused a WebGL context to the location minimap (#2354). Not a
    * load failure and never reaches {@link formatLoadError}; classified so the
-   * family gets ONE fingerprint instead of one issue per deploy. Scoped to the
-   * failure `LocationMap` catches, latches and degrades around — an UNHANDLED
-   * one must never land here (./analytics-scrub.ts, `BENIGN_ERROR_KINDS`).
+   * family gets ONE fingerprint instead of one issue per deploy. Membership is
+   * by MESSAGE, not by who caught it: `isWebglContextCreationError` matches only
+   * MapLibre's own wordings and the two strings `LocationMap` synthesizes, all
+   * of them anchored, so an error that merely MENTIONS the phrase keeps its own
+   * identity and its `error` severity.
    */
   | 'webgl_unavailable'
   /** Anything else. */

--- a/apps/viewer/src/lib/load-errors.ts
+++ b/apps/viewer/src/lib/load-errors.ts
@@ -5,6 +5,10 @@
 /**
  * Classification + humanisation of model-load failures.
  *
+ * Despite the name, this is the viewer's ONLY error-family classifier —
+ * `analytics-scrub.ts` runs it over every captured `$exception` — so a non-load
+ * family needing grouping belongs here too, not in a second one that would drift.
+ *
  * The geometry/parser workers both initialise the same `@ifc-lite/wasm`
  * binary. wasm-bindgen's streaming loader rethrows on a non-OK HTTP status
  * (it only falls back for the wrong-MIME case), surfacing as a cryptic
@@ -15,6 +19,10 @@
  * This module maps such failures to a stable `kind` (for analytics
  * grouping) and a human-readable message (for the toast / model loadError).
  */
+
+// Imported, not restated: a second copy of MapLibre's wordings would drift on
+// the next upgrade. That module imports nothing, so this adds no dependency.
+import { isWebglContextCreationError } from './geo/map-webgl-support.js';
 
 /** Stable, analytics-friendly classification of a load failure. */
 export type LoadErrorKind =
@@ -68,6 +76,14 @@ export type LoadErrorKind =
    * checked: any failure that identified itself keeps its own kind.
    */
   | 'network_unavailable'
+  /**
+   * The browser refused a WebGL context to the location minimap (#2354). Not a
+   * load failure and never reaches {@link formatLoadError}; classified so the
+   * family gets ONE fingerprint instead of one issue per deploy. Scoped to the
+   * failure `LocationMap` catches, latches and degrades around — an UNHANDLED
+   * one must never land here (./analytics-scrub.ts, `BENIGN_ERROR_KINDS`).
+   */
+  | 'webgl_unavailable'
   /** Anything else. */
   | 'unknown';
 
@@ -260,6 +276,11 @@ export function classifyLoadError(err: unknown): LoadErrorKind {
   // need not contain the word "abort" at all (WebKit: "Fetch is aborted",
   // Chromium: "The user aborted a request."). Only `.name` is guaranteed.
   if (name === 'AbortError') return 'cancelled';
+  // BEFORE the memory/network buckets: MapLibre's failure carries the driver's
+  // own `statusMessage`, vendor prose we do not control and free to contain the
+  // words those matchers key on ("allocation failed"). Safe to claim first — it
+  // takes only MapLibre's authored wordings and its event token, not a name.
+  if (isWebglContextCreationError(err)) return 'webgl_unavailable';
   if (isWasmEngineLoadError(message)) return 'wasm_engine_load';
   // Explicit memory-exhaustion signals win over the worker-crash bucket so a
   // worker that died with a clear OOM message is grouped as out_of_memory.


### PR DESCRIPTION
## Judgement: the code is right, the reporting was wrong

Fixes #2354.

`LocationMap`'s WebGL pre-flight probe did exactly its job. It detected that the browser would not give the minimap a WebGL context, `degradeMap` handled it, and the user got a working degraded panel. What was wrong is that one benign, handled condition arrived in error tracking as a **new issue on every deploy** — and at `$exception_level: error` while it did. This PR changes the reporting only. No map behaviour changes.

**What actually fixes #2354 is the fingerprint collapse, not the severity downgrade.** I checked the live project rather than assuming: the GitHub-filing destination ("GitHub issue on issue created") triggers on the event `$error_tracking_issue_created` alone, with a single `description not_regex` exclusion and **no `$exception_level` condition anywhere**. Issue creation — and therefore GitHub filing — is level-independent. The downgrade to `warning` is kept because it is right on its own terms (error-level-list hygiene, the #1903 convention), but it contributes nothing to stopping the issue churn. Only the stable fingerprint does that.

### The evidence

Querying error tracking for this family over 90 days returns **four** issues carrying just **two** distinct messages:

| issue | message | first seen | occ | users | bundle named in the stack |
|---|---|---|---|---|---|
| `019fdc16` | `Failed to initialize WebGL (pre-flight probe)` | 2026-08-07 | 2 | 1 | `main-DnUx64at.js` |
| `019fc748` | `Failed to initialize WebGL (pre-flight probe)` | 2026-08-03 | 1 | 1 | `index-B0OhdiDw.js` |
| `019fccaa` | `Failed to initialize WebGL (context lost)` | 2026-08-04 | 4 | 4 | `main-Dv_wXUms.js` |
| `019fc35e` | `Failed to initialize WebGL (context lost)` | 2026-08-02 | 2 | 2 | `index-D6jsZWvj.js` |

Both messages are fixed strings `LocationMap` synthesizes itself, so a constant message was not enough on its own. PostHog's default grouping hashes exception type + message **+ stack**, and the stack names the hashed bundle the frame came from. Each deploy rotates that filename, so **each deploy split the same benign condition into a fresh issue** — and a fresh auto-filed GitHub issue with it. #2354 is the fourth telling of one story.

Independently of grouping, posthog-js stamps every capture `$exception_level: 'error'`. So an expected device capability gap — unfixable by the user and unfixable by any code change — also sat on the error-level list next to genuine breakage. That is a second, smaller problem, fixed here too, but it is not the one that produced four GitHub issues.

### Degraded-UX verification (read from the render path, not assumed)

Before touching the reporting I checked whether the user actually gets something, because if the map silently vanished, that would be the real bug and the priority. It does not:

- `mapUnavailable` is seeded from the session latch, so a remount on a device already known to refuse WebGL paints the fallback as its **first** frame — no probe, no construction, no flash of a dead canvas. (The Georeferencing section is a Radix Collapsible, so collapse/expand remounts this panel.)
- The fallback renders a `MapPinOff` icon, "Map preview unavailable on this device", and a reason-specific second line — different text for a failed chunk download than for a refused context.
- Everything that does not need a GPU stays live: the lat/lon readout in the header, the Google Maps and OpenStreetMap links, the KMZ export, and in edit mode the place search — which still drives the reverse projection and the Apply button.
- The only thing hidden is "Toggle style", because without a map it would be a permanent no-op.

So the degradation is correct and visible. Nothing to fix there.

### The change

Routed entirely through the existing helper — no second telemetry path, no new channel. `LocationMap.tsx` gains only a comment.

- **`lib/load-errors.ts`** — new `LoadErrorKind` member `webgl_unavailable`, matched by `classifyLoadError` via `isWebglContextCreationError`, **imported** from `lib/geo/map-webgl-support.ts` rather than restated. That function was already the authored, tested matcher for "is this MapLibre failing to get a context?" but had no production consumer; a second copy of MapLibre's wordings would drift on the next upgrade, and `map-webgl-support.ts` imports nothing, so this adds no dependency to the analytics path.

  It is checked **before** the memory and network buckets. MapLibre's failure carries the driver's own `statusMessage` — vendor prose we do not control, free to contain the exact words `isOutOfMemoryError` keys on ("allocation failed"). Test 4 pins that ordering.

- **`lib/analytics-scrub.ts`** — `webgl_unavailable` added to `BENIGN_ERROR_KINDS`, the existing convention introduced for #1903. From there the existing pipeline does the rest: `stampFingerprint` collapses the family onto `ifc-lite:webgl_unavailable` — one issue that survives a release — and `downgradeBenignExceptions` rewrites `error` → `warning`.

- **`lib/geo/map-webgl-support.ts`** — `isWebglContextCreationError`'s bare-phrase arm is now **anchored** (`MAP_WEBGL_INIT_REPORT`) instead of a `.includes()`. Found in adversarial review and fixed here. That predicate was written when it only decided whether to degrade the map; making it also assign `error_kind` changed what a loose match costs. Reproduced before fixing: `Failed to initialize WebGL renderer for the section overlay`, **as an uncaught error**, classified `webgl_unavailable`, took the minimap's fingerprint and was downgraded to `warning` — an actionable bug of ours, relabelled benign and filed into an issue nobody triages. That is exactly the hazard `MAPLIBRE_WEBGL_UNAVAILABLE`'s comment in `analytics-scrub.ts` names and anchors against (#1914); the import had quietly eroded it. The regex admits the bare v5 message and precisely the two suffixed strings `LocationMap` builds, nothing else. All four genuine shapes still classify.

  The pre-existing #1914 guard only asserted survival (`!== null`), so it passed straight through that erosion. It is **strengthened** here to assert identity — `error_kind === undefined`, no fingerprint, level still `error` — over four strings including both the trailing and leading mention forms. Survival is not the property that matters once the same predicate assigns a kind: an event can stay alive and still be relabelled into invisibility.

  **Round two, from a real CodeRabbit review:** anchoring one arm left the other two as bare substring tests, and both reproduced the identical erosion. `"type":"webglcontextcreationerror"` matched wherever the token was *quoted* — a wrapped driver string, a serialized log line, a nested payload — so `Upload failed: driver shim logged {"type":"webglcontextcreationerror"} while retrying` classified `webgl_unavailable`. And `WebGL2 is required to display this map` matched mid-sentence, so `TileCache: WebGL2 is required to display this map, so the raster fallback was used` came out `webgl_unavailable`, `warning`, benign fingerprint. Both fixed:

  - the v5 token arm is now **structural** — the message must parse as an object whose `type` field *is* the token and whose `message` field is the anchored bare wording, i.e. a complete v5 payload, which is exactly what v5 threw. Parsing is already this module's idiom for that shape (`describeMapInitFailure` parses it behind the same `{` guard), so this adds no new technique and no cost on non-JSON messages;
  - the v6 wording arm is **prefix-anchored**. It cannot be anchored at both ends, because `reconstructMapInitFailure` appends a sentence of ours to the phrase while MapLibre's own message is the phrase alone. The regex is built from the existing string constant so the wording keeps one home;
  - the suffix separator is one literal space instead of `\s*`, matching exactly what `LocationMap` emits, now pinned by a test that also documents that coupling.

  CodeRabbit flagged the token arm; the v6 arm was found by then checking every arm of the same boolean, which nobody had done. The predicate's doc comment now states that property of the whole boolean — every message arm anchored or structural — rather than of any one clause, because that is the invariant a future arm has to preserve.

  **Round three, from hosted CodeRabbit:** the structural check's `catch` returned `false` behind a comment, which is not a log — AGENTS.md forbids a silent `catch {}` in TypeScript. Both places in this module that guess "this message might be the v5 payload" now emit a fixed diagnostic first: the flagged one, and `describeMapInitFailure`, which was equally silent and pre-existing. Fixing one and leaving its twin 130 lines below would have been arbitrary, and it is the same condition behind the same `{` guard, so they share one constant.

  The caught error is deliberately **not** logged alongside it and the message interpolates nothing. Both paths see arbitrary error text, and a modern V8 `SyntaxError` quotes a snippet of the offending source into its own message, so passing `err` would put that text in the console exactly as interpolating the payload would. Verified by execution that both sites emit, with a single constant argument and no payload — a diagnostic that never runs is the same defect in a different costume. A sweep of the rest of the diff found no other `catch`: this was the only one it added.

### Mutation check

Fourteen new tests plus one pre-existing guard strengthened in review — fifteen rows — against nine mutations. With nine mutations a column-per-mutation grid stops being readable, so each row lists the mutations that kill it; the per-mutation totals are below the table and were tallied from these same cells.

| mutation | what it does |
|---|---|
| **A** | revert both original source files (the whole fix) |
| **B** | revert `analytics-scrub.ts` only — classification kept, severity not |
| **C** | widen the matcher to `/webgl/i` (over-reach) |
| **E** | `return null` on the kind instead of downgrading (go dark) |
| **F** | un-anchor the bare phrase back to `.includes()` |
| **G** | un-anchor the v5 token arm back to `.includes()` |
| **H** | un-anchor the v6 wording arm back to `.includes()` |
| **I** | drop the `message` requirement from the v5 payload check (type only) |
| **J** | restore `\s*` before the optional suffix |

| # | test | killed by |
|---|---|---|
| 1 | `load-errors`: classifies every shape of the minimap WebGL failure | **A** |
| 2 | `load-errors`: does NOT claim three.js's WebGL failure | **C** |
| 3 | `load-errors`: leaves an unrelated GPU failure out of the bucket | **C** |
| 4 | `load-errors`: keeps the driver's own prose from being mis-bucketed | **A** |
| 5 | `analytics`: collapses the whole family onto ONE fingerprint | **A, E** |
| 6 | `analytics`: downgrades it from error to warning | **A, B, E** |
| 7 | `analytics`: still SENDS the report, diagnostics intact | **E** |
| 8 | `analytics`: keeps three.js's WebGL failure LOUD | **C** |
| 9 | `analytics`: still drops the UNCAUGHT MapLibre form, and only that one | **E** |
| 10 | `analytics`: never clobbers a level chosen at the capture site | **E** |
| 11 | `load-errors`: does NOT claim an error that merely MENTIONS the phrase | **F** |
| 12 | `analytics`: keeps an unrelated WebGL failure INTACT (strengthened #1914 guard) | **F, G, H** |
| 13 | `load-errors`: does NOT claim text that merely EMBEDS the v5 token or v6 wording | **G, H** |
| 14 | `load-errors`: still requires a COMPLETE v5 payload, not just the type field | **G, I** |
| 15 | `load-errors`: accepts only the exact spacing LocationMap emits | **J** |

Failure counts: **A 4/15, B 1/15, C 3/15, E 5/15, F 2/15, G 3/15, H 2/15, I 1/15, J 1/15.**

Every row is killed by at least one mutation, and each of the nine mutations kills at least one row, so no test and no mutation is idle. The discrimination is specific rather than blanket: G and H both loosen an arm, yet H leaves row 14 passing because that row is about the payload's completeness rather than the token's anchoring, and I leaves rows 12 and 13 passing for the mirror-image reason.

**Honest note: rows 2, 3, 8, 11, 12, 13, 14 and 15 survive a plain revert, by design.** They are narrowness guards — they assert what must *not* be classified. A revert makes the code strictly narrower, which is the direction they permit, so a revert cannot fail them and a revert-only mutation check would say nothing about them. They are proved live by the over-reach mutations C, F, G, H, I and J instead. Rows 7, 9 and 10 are the same shape against the opposite hazard and are killed by E.

Worth stating for row 12 specifically: under mutations F, G and H the event it covers still *survives* the pipeline, so the pre-existing survival-only assertion passed. Only the added identity assertions fail. That is the whole reason the guard needed strengthening rather than just keeping.

The source was restored byte-identically after each mutation (`git diff --stat` unchanged, no mutation markers left in the tree). Restored run: **142 tests, 142 pass, 0 fail** across `load-errors.test.ts`, `analytics.test.ts` and `geo/map-webgl-support.test.ts`.

### Proof the report still FIRES

This repo has a prior incident where `$exception` capture went silently dark for 26 days, so "downgrade" must not quietly become "drop". Test 7, `still SENDS the report, with its diagnostics intact (never go dark)`, asserts on the **post-pipeline event** — no mock return values:

- `scrubEvent(...) !== null` — the event leaves the browser;
- `$exception_fingerprint === 'ifc-lite:webgl_unavailable'` — one issue, and it survives a release;
- `$exception_level === 'warning'` (its sibling test, same payload) — downgraded, not dropped;
- `context`, `map_unavailable_reason`, `webgl_status` and `webgl_event_type` all survive the privacy scrub, and the exception message is returned unmodified.

Mutation E is exactly the go-dark regression — `return null` on `webgl_unavailable` — and it fails this test. So "still reported, at warning, on one fingerprint" is pinned, not assumed.

### Verification

`main` was merged into this branch twice while the review was in flight, so every figure below was re-measured on the current head `1a56c8d22` — my commit rebased on top of those merges, never force-pushed over them. Root turbo commands only.

- `pnpm test` — **exit 0. 86/86 tasks successful** (40 cached), 2m49s. Zero `not ok` lines, zero vitest `failed` lines, zero `ELIFECYCLE` / `Force killed` / `Shutting down Turborepo` markers.
- `@ifc-lite/viewer:test`: 3234 tests, **3228 pass, 0 fail**, 6 skipped, 694 suites. The count moved 3187 → 3234; the +47 came in with the `main` merge (new type-pset filter tests and siblings), not from this PR, whose own additions accounted for the earlier 3183 → 3184 → 3187.
- All fifteen rows of the mutation table appear as `ok` in that run's output, so they still execute after the merge.
- `pnpm typecheck` — **exit 0, 36/36 tasks successful.**
- Touched suites in isolation (`load-errors`, `analytics`, `geo/map-webgl-support`): **142 tests, 142 pass, 0 fail.**

**One failed run is disclosed rather than buried.** The first full run after the rebase came back **`TEST_EXIT=1`, 73/83 tasks**, with one failing test — `@ifc-lite/export` › `parquet-geometry.test.ts` › *"reports the geometry statistics of the export it accompanies"* at 5063 ms — plus four packages (`viewer-core`, `sdk`, `create`, `mcp`) that turbo cut short after it, reporting `ELIFECYCLE` with no test output of their own. It is not this PR's:

- every commit here touches only `apps/viewer/src/lib/**`; `packages/export` does not import viewer application code, so there is no path from the change to that assertion;
- the same test passed **16/16 in isolation at the identical commit**, with no code change in between;
- and it passed again in the full re-run above (`468 passed | 30 skipped`).

The 5-second duration and a machine load average peaking near 54 from concurrent work in other worktrees identify it as a timeout under contention. It is reported here because a run that exits 1 should never be quietly re-rolled until it goes green — the re-run is offered as evidence alongside the failure, not instead of it.

### Disclosed gaps

- **`THREE.WebGLRenderer: Error creating WebGL context.` is a separate, genuine bug and is NOT fixed here.** Issue `019fc458`. `createScene` is called unguarded from the mount effects in `components/mcp/PlaygroundViewer.tsx` and `components/mcp/HeroScene.tsx`, so on a device that refuses WebGL the constructor throws out of a React effect and takes the surrounding tree down. That is breakage, not a degradation. It is deliberately left classified `unknown`, error-level and ungrouped so it stays loud, and tests 2 and 8 pin that it cannot drift into the benign bucket. It deserves the LocationMap treatment (probe, `try/catch`, fallback), which is a behaviour change to two components and does not belong in a reporting fix.
- The old uncaught MapLibre v5 shape (`019fae1d`) is already dropped outright by the existing `MAPLIBRE_WEBGL_UNAVAILABLE` matcher and is untouched; test 9 pins that the drop and the new downgrade keep coexisting.
- **A FOURTH instance of the same defect class exists in the DROP path, is pre-existing, and is deliberately NOT fixed here.** `MAPLIBRE_WEBGL_UNAVAILABLE` in `analytics-scrub.ts` is `/^\s*Failed to initialize WebGL\s*$|"type":\s*"webglcontextcreationerror"/` — the first arm anchored, the second a bare substring. Reproduced: an uncaught `Upload failed: driver shim logged {"type":"webglcontextcreationerror"} while retrying` is **dropped entirely**, never reaching error tracking. That is strictly worse than the downgrade this PR fixes, because a drop is silent and irreversible.

  It is not fixed here on purpose. It is pre-existing (#1914), it lives in a different function with different semantics, changing drop behaviour deserves its own mutation tests and its own review, and this PR has already been through three review rounds against a defined scope. Expanding it now would be the scope creep the earlier rounds avoided. The reproduction above is exact and the fix is one anchored alternation, so it is cheap to do as a follow-up — but it should be a decision, not a side effect of this PR. Row 12 of the mutation table works around it by passing the token case as a *handled* event, and says so in a comment rather than papering over it.
- The capture site in `LocationMap.tsx` is not itself under test — the change there is a comment, and the properties it sends were already covered. Mounting the component would need a maplibre + Radix + proj4 harness that does not exist in this area.
- **Whether a `warning`-level issue still auto-files a GitHub issue is PostHog alerting configuration, not code.** Severity and fingerprint are the only levers available here; this PR cannot assert on the alerting side.
- `load-errors.ts` ends at **399 lines**, back under the ~400 guideline after tightening the added doc comments twice (peak was 414; it was 379 before). Every distinct reason is kept — the vendor-prose ordering trap, the import/drift rationale, the "only classifier" note — with restatement cut. No cosmetic split of the classifier.
- **Expect exactly ONE more auto-filed GitHub issue after merge, and do not read it as the fix failing.** The first post-merge occurrence creates a new PostHog issue under the new fingerprint, and issue creation is what fires the GitHub destination. Our message is not in that destination's exclusion regex (`array buffer allocation failed|out of memory|cannot enlarge memory|memory access out of bounds|geometry worker (failed|error)|geometry stream stalled`), so one filing will happen and then the family collapses into it permanently. There is precedent for exactly this shape when a family is first given a fingerprint.
- **The four existing PostHog issues stay open and must be merged into the new one by hand.** A fingerprint applies going forward; it does not retroactively regroup events already assigned to an issue.
- **Required companion change, not in this PR: the GitHub destination is subscribed to `$error_tracking_issue_created` only.** Once this family collapses to a single issue that already exists, a deploy that breaks WebGL for *everyone* produces no automated signal at all — the issue simply gets busier. Subscribing the destination to `$error_tracking_issue_spiking` / `_reopened` restores that alarm. It is PostHog configuration rather than code, so it cannot ride along here; this PR should not be merged on the belief that it stands alone.
- Accuracy note on "`map_load_failed` stays loud": that holds for Chromium's `Failed to fetch dynamically imported module`, which `isNetworkUnavailableError` deliberately excludes. Safari words the same failure `Load failed`, which classifies `network_unavailable` and therefore is downgraded and fingerprinted. That is pre-existing #1903 behaviour, not introduced here, but the claim should not be read as absolute.
- `geocodeSearch` in `LocationMap.tsx` has a genuine silent `catch { return []; }`. It is **pre-existing and outside this diff** (this PR adds zero `catch` blocks to that file), and it is an unrelated concern — a Nominatim fetch, nothing to do with WebGL reporting. Flagged rather than fixed, unlike `describeMapInitFailure`'s silent catch, which *was* fixed because it is the identical twin of the line under review, in the same file, sharing the same guard and now the same constant.
- No `packages/*` touched, so no changeset.
