### PR TITLE
fix(viewer): bound the frame wait that let a hidden tab park a load forever

### DIFF
--- a/apps/viewer/src/components/viewer/ClashPanel.tsx
+++ b/apps/viewer/src/components/viewer/ClashPanel.tsx
@@ -366,6 +366,9 @@ export function ClashPanel({ onClose }: ClashPanelProps) {
       if (clash) {
         focusClash(clash, focusMode);
         // Wait for the camera move + a render before grabbing the snapshot.
+        // FRAME-WAIT-ALLOW(#2385): must NOT be raced against a timer — timing out
+        // would attach a pre-camera-move frame to the BCF topic. A hidden tab
+        // cannot present the moved camera at all, so bounding this buys nothing.
         await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
       }
       if (!bcfProject) setBcfProject(createBCFProject({ name: 'Clash report' }));

--- a/apps/viewer/src/hooks/useClash.ts
+++ b/apps/viewer/src/hooks/useClash.ts
@@ -39,6 +39,14 @@ import { clashFramingBounds } from '@/lib/clash/clash-framing';
 import { posthog } from '@/lib/analytics';
 import { errorCaptureProps } from '@/lib/load-errors';
 import { downloadBlob } from '@/lib/export/download';
+import { nextFrameOrTimeout } from '@/utils/frameWait';
+
+/**
+ * Upper bound on the "let the panel paint first" frame wait before a clash run.
+ * Purely cosmetic work, so a short bound is enough to keep a hidden tab from
+ * blocking the run entirely. (#2385)
+ */
+const PAINT_FRAME_WAIT_MS = 250;
 
 interface SelectionRef {
   modelId: string;
@@ -190,8 +198,10 @@ export function useClash() {
       // Indeterminate "preparing" state until the engine reports candidate counts.
       state.setClashProgress({ phase: 'broad', rule: '', done: 0, total: 0 });
       try {
-        // Let the panel paint the running state before the heavy work.
-        await new Promise((resolve) => requestAnimationFrame(resolve));
+        // Let the panel paint the running state before the heavy work. Bounded:
+        // a hidden tab never delivers a frame, and the whole run sits after this
+        // await, so an unbounded wait means the run simply never starts. (#2385)
+        await nextFrameOrTimeout(PAINT_FRAME_WAIT_MS);
         const { elements, exclusions } = gatherElements();
         if (elements.length === 0) {
           state.setClashError('No model geometry is loaded. Load an IFC model first.');
@@ -287,7 +297,8 @@ export function useClash() {
     state.setClashProgress({ phase: 'broad', rule: 'duplicates', done: 0, total: 0 });
     try {
       // Paint the running state before the (synchronous) scan blocks the thread.
-      await new Promise((resolve) => requestAnimationFrame(resolve));
+      // Bounded for the same reason as the clash run above (#2385).
+      await nextFrameOrTimeout(PAINT_FRAME_WAIT_MS);
       const { elements, exclusions } = gatherElements();
       if (elements.length === 0) {
         state.setClashError('No model geometry is loaded. Load an IFC model first.');
@@ -590,6 +601,10 @@ export function useClash() {
             const device = renderer.getGPUDevice();
             if (device) await device.queue.onSubmittedWorkDone();
             // Let the compositor present the frame before reading the canvas.
+            // FRAME-WAIT-ALLOW(#2385): must NOT be raced against a timer — the
+            // point is that the frame was actually presented, and timing out
+            // would read a stale canvas into the BCF snapshot. A hidden tab
+            // cannot produce a valid snapshot at all, so bounding buys nothing.
             await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
             const dataUrl = await renderer.captureScreenshot();
             done += 1;

--- a/apps/viewer/src/hooks/useIDS.ts
+++ b/apps/viewer/src/hooks/useIDS.ts
@@ -1005,6 +1005,10 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
           // Wait for the browser compositor to present the frame to the canvas.
           // Without this, toDataURL() reads a stale canvas — only the last snapshot
           // would show the entity because previous frames haven't been composited yet.
+          // FRAME-WAIT-ALLOW(#2385): must NOT be raced against a timer. The whole
+          // point is that the frame was actually presented; timing out would read
+          // a stale canvas into the IDS report snapshot. A hidden tab cannot
+          // present a frame at all, so bounding this buys nothing.
           await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
 
           // Capture the now-presented frame

--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -72,6 +72,7 @@ import { toast } from '../components/ui/toast.js';
 import { posthog } from '../lib/analytics.js';
 import { reportRenderStats } from '../utils/renderStatsReport.js';
 import { nextFrameOrTimeout } from '../utils/frameWait.js';
+import { visibilityWitness } from '../utils/visibilityWitness.js';
 import { classifyLoadError, errorCaptureProps, formatLoadError, type LoadErrorKind } from '../lib/load-errors.js';
 
 /**
@@ -299,6 +300,10 @@ export function useIfcLoader() {
 
     // Track total elapsed time for complete user experience
     const totalStartTime = performance.now();
+    // Wall-clock timings absorb the time the user spends on another tab, so
+    // stamp every load with whether that happened. Lets the perf queries drop
+    // contaminated rows on evidence rather than on a duration threshold. (#2385)
+    const wasHidden = visibilityWitness();
 
     // Records the tier the WASM tessellation path actually ran at, for the
     // resource-retry decision in the catch. Declared out here (not in the try)
@@ -841,7 +846,7 @@ export function useIfcLoader() {
           pointCloudHandleId: ingest.rendererHandle.id,
         });
         setProgress({ phase: 'Complete', percent: 100 });
-        posthog.capture('ifc_model_loaded', { format, file_size_mb: Math.round(fileSizeMB * 100) / 100, load_target: target.kind, load_path: 'point-cloud', total_elapsed_ms: Math.round(performance.now() - totalStartTime) });
+        posthog.capture('ifc_model_loaded', { format, file_size_mb: Math.round(fileSizeMB * 100) / 100, load_target: target.kind, load_path: 'point-cloud', total_elapsed_ms: Math.round(performance.now() - totalStartTime), was_hidden: wasHidden() });
         setLoading(false);
         return;
       }
@@ -860,7 +865,7 @@ export function useIfcLoader() {
           await finalizeModel(result.dataStore, result.geometryResult, result.schemaVersion);
 
           setProgress({ phase: 'Complete', percent: 100 });
-          posthog.capture('ifc_model_loaded', { format: 'ifcx', file_size_mb: Math.round(fileSizeMB * 100) / 100, load_target: target.kind, load_path: 'wasm', total_elapsed_ms: Math.round(performance.now() - totalStartTime) });
+          posthog.capture('ifc_model_loaded', { format: 'ifcx', file_size_mb: Math.round(fileSizeMB * 100) / 100, load_target: target.kind, load_path: 'wasm', total_elapsed_ms: Math.round(performance.now() - totalStartTime), was_hidden: wasHidden() });
           setLoading(false);
           return;
         } catch (err: unknown) {
@@ -902,7 +907,7 @@ export function useIfcLoader() {
           );
 
           setProgress({ phase: 'Complete', percent: 100 });
-          posthog.capture('ifc_model_loaded', { format: 'glb', file_size_mb: Math.round(fileSizeMB * 100) / 100, load_target: target.kind, load_path: 'wasm', total_elapsed_ms: Math.round(performance.now() - totalStartTime) });
+          posthog.capture('ifc_model_loaded', { format: 'glb', file_size_mb: Math.round(fileSizeMB * 100) / 100, load_target: target.kind, load_path: 'wasm', total_elapsed_ms: Math.round(performance.now() - totalStartTime), was_hidden: wasHidden() });
           setLoading(false);
           return;
         } catch (err: unknown) {
@@ -1014,7 +1019,7 @@ export function useIfcLoader() {
                 cacheState: 'hit',
               });
               console.log(`[useIfc] TOTAL LOAD TIME (from cache): ${(performance.now() - totalStartTime).toFixed(0)}ms`);
-              posthog.capture('ifc_model_loaded', { format, file_size_mb: Math.round(fileSizeMB * 100) / 100, load_target: target.kind, load_path: 'cache', total_elapsed_ms: Math.round(performance.now() - totalStartTime) });
+              posthog.capture('ifc_model_loaded', { format, file_size_mb: Math.round(fileSizeMB * 100) / 100, load_target: target.kind, load_path: 'cache', total_elapsed_ms: Math.round(performance.now() - totalStartTime), was_hidden: wasHidden() });
               // Steady-state draw-call/GPU telemetry — same reporter as the
               // fresh path so warm (cache) loads are comparable (issue #1682).
               void reportRenderStats({
@@ -1075,7 +1080,7 @@ export function useIfcLoader() {
           const state = useViewerStore.getState();
           await finalizeModel(state.ifcDataStore, state.geometryResult, getSchemaVersion(state.ifcDataStore));
           console.log(`[useIfc] TOTAL LOAD TIME (server): ${(performance.now() - totalStartTime).toFixed(0)}ms`);
-          posthog.capture('ifc_model_loaded', { format, file_size_mb: Math.round(fileSizeMB * 100) / 100, load_target: target.kind, load_path: 'server', total_elapsed_ms: Math.round(performance.now() - totalStartTime) });
+          posthog.capture('ifc_model_loaded', { format, file_size_mb: Math.round(fileSizeMB * 100) / 100, load_target: target.kind, load_path: 'server', total_elapsed_ms: Math.round(performance.now() - totalStartTime), was_hidden: wasHidden() });
           setLoading(false);
           return;
         }
@@ -1330,6 +1335,13 @@ export function useIfcLoader() {
       // distinguishable from "no fingerprint at all".
       const allInstancedGeometryVolumes = new Map<number, number>();
       let finalCoordinateInfo: CoordinateInfo | null = null;
+      // Kept at function scope so the load telemetry below can report it. Two
+      // loads of the SAME file on the SAME build have been observed emitting
+      // different `total_triangles` with an identical mesh roster; a CSG
+      // void-cut that failed and fell back on one run and not the other is the
+      // leading explanation, and without this counter the field data cannot
+      // distinguish that from a genuine determinism defect. (#2385)
+      let finalCsgFailures: number | null = null;
       // Capture RTC offset from WASM for proper multi-model alignment
       let capturedRtcOffset: { x: number; y: number; z: number } | null = null;
       // Track all deferred style updates so cache data always uses final colors.
@@ -1643,6 +1655,7 @@ export function useIfcLoader() {
               // object stays on `event.diagnostics` for any UI/telemetry consumer.
               if (event.diagnostics) {
                 const d = event.diagnostics;
+                finalCsgFailures = d.totalCsgFailures;
                 if (d.totalCsgFailures > 0 || d.silentNoOps > 0) {
                   console.info(
                     `[useIfc] ${file.name} geometry diagnostics: ${d.totalCsgFailures} CSG failure(s) ` +
@@ -1928,6 +1941,11 @@ export function useIfcLoader() {
         first_geometry_batch_ms: firstAppendGeometryBatchMs != null ? Math.round(firstAppendGeometryBatchMs) : undefined,
         first_visible_geometry_ms: firstVisibleGeometryMs != null ? Math.round(firstVisibleGeometryMs) : undefined,
         stream_complete_ms: streamCompleteMs != null ? Math.round(streamCompleteMs) : undefined,
+        // Rides the load event so a `total_triangles` change for one file is
+        // attributable: a nonzero count means some void cut fell back, which
+        // changes triangulation without changing the mesh roster. (#2385)
+        total_csg_failures: finalCsgFailures ?? undefined,
+        was_hidden: wasHidden(),
       });
       // Steady-state draw-call/GPU-memory telemetry (issue #1682) — fired
       // separately from ifc_model_loaded because it must wait for the scene

--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -73,6 +73,7 @@ import { posthog } from '../lib/analytics.js';
 import { reportRenderStats } from '../utils/renderStatsReport.js';
 import { nextFrameOrTimeout } from '../utils/frameWait.js';
 import { visibilityWitness } from '../utils/visibilityWitness.js';
+import { buildModelLoadedPayload } from '../utils/loadTelemetry.js';
 import { classifyLoadError, errorCaptureProps, formatLoadError, type LoadErrorKind } from '../lib/load-errors.js';
 
 /**
@@ -287,6 +288,17 @@ export function useIfcLoader() {
     // exists, or the primary's cold chunks would be stranded shells (their
     // geometry unreachable). Primary loads skip the drain: the scene is
     // replaced wholesale anyway.
+    // Wall-clock timings absorb the time the user spends on another tab, so
+    // stamp every load with whether that happened. Lets the perf queries drop
+    // contaminated rows on evidence rather than on a duration threshold.
+    // Taken BEFORE the first awaited work below (the federated cold-tier
+    // drain): a tab hidden and re-shown entirely within that drain would
+    // otherwise go unrecorded, and the drain is slowest exactly when it is
+    // most likely to span a tab switch. `totalStartTime` deliberately stays
+    // where it is — the drain sits outside `total_elapsed_ms`, so moving it
+    // would silently redefine the metric. (#2385)
+    const wasHidden = visibilityWitness();
+
     {
       const scene = getGlobalRenderer()?.getScene();
       if (scene) {
@@ -300,10 +312,6 @@ export function useIfcLoader() {
 
     // Track total elapsed time for complete user experience
     const totalStartTime = performance.now();
-    // Wall-clock timings absorb the time the user spends on another tab, so
-    // stamp every load with whether that happened. Lets the perf queries drop
-    // contaminated rows on evidence rather than on a duration threshold. (#2385)
-    const wasHidden = visibilityWitness();
 
     // Records the tier the WASM tessellation path actually ran at, for the
     // resource-retry decision in the catch. Declared out here (not in the try)
@@ -1708,7 +1716,15 @@ export function useIfcLoader() {
               // tabbed-away load permanently unfinalized with its WASM handles
               // pinned, and inflated `total_elapsed_ms` by the entire hidden
               // duration — which is what poisoned the load-time telemetry. (#2385)
-              await nextFrameOrTimeout(COMPLETE_FRAME_WAIT_MS);
+              //
+              // Primary only: the wait exists so the last streamed batch is on
+              // screen before the streaming flag drops, and a federated add
+              // never streamed into the active slot — it paints atomically at
+              // finalize. Waiting for a frame it does not need is pure latency
+              // on the one path that also blocks `loadFilesSequentially`.
+              if (target.kind === 'primary') {
+                await nextFrameOrTimeout(COMPLETE_FRAME_WAIT_MS);
+              }
               if (loadSessionRef.current === currentSession && target.kind === 'primary') {
                 setGeometryStreamingActive(false);
               }
@@ -1923,30 +1939,25 @@ export function useIfcLoader() {
       console.log(
         `[ifc-lite] ${file.name} (${fileSizeMB.toFixed(1)}MB) → ${allMeshes.length} meshes, ${(totalVertices / 1000).toFixed(0)}k verts in ${(totalElapsedMs / 1000).toFixed(1)}s`
       );
-      posthog.capture('ifc_model_loaded', {
+      // Single home for this payload — see `utils/loadTelemetry.ts` for why
+      // `was_hidden: false` and `total_csg_failures: 0` must survive to the wire.
+      posthog.capture('ifc_model_loaded', buildModelLoadedPayload({
         format,
-        file_size_mb: Math.round(fileSizeMB * 100) / 100,
-        load_target: target.kind,
-        load_path: 'wasm',
-        mesh_count: allMeshes.length,
-        total_elapsed_ms: Math.round(totalElapsedMs),
-        // Field perf telemetry: vertices/triangles size the model, and the
-        // milestones (read → metadata → first batch → first paint → stream
-        // done) let us spot where real-world loads regress. CSG itself runs
-        // in the geometry workers, so the stream window is its best proxy.
-        total_vertices: totalVertices,
-        total_triangles: allMeshes.reduce((sum, m) => sum + m.indices.length / 3, 0),
-        file_read_ms: Math.round(fileReadMs),
-        metadata_complete_ms: metadataCompleteMs != null ? Math.round(metadataCompleteMs) : undefined,
-        first_geometry_batch_ms: firstAppendGeometryBatchMs != null ? Math.round(firstAppendGeometryBatchMs) : undefined,
-        first_visible_geometry_ms: firstVisibleGeometryMs != null ? Math.round(firstVisibleGeometryMs) : undefined,
-        stream_complete_ms: streamCompleteMs != null ? Math.round(streamCompleteMs) : undefined,
-        // Rides the load event so a `total_triangles` change for one file is
-        // attributable: a nonzero count means some void cut fell back, which
-        // changes triangulation without changing the mesh roster. (#2385)
-        total_csg_failures: finalCsgFailures ?? undefined,
-        was_hidden: wasHidden(),
-      });
+        fileSizeMB,
+        loadTarget: target.kind,
+        loadPath: 'wasm',
+        meshCount: allMeshes.length,
+        totalElapsedMs,
+        totalVertices,
+        totalTriangles: allMeshes.reduce((sum, m) => sum + m.indices.length / 3, 0),
+        fileReadMs,
+        metadataCompleteMs,
+        firstGeometryBatchMs: firstAppendGeometryBatchMs,
+        firstVisibleGeometryMs,
+        streamCompleteMs,
+        totalCsgFailures: finalCsgFailures,
+        wasHidden: wasHidden(),
+      }));
       // Steady-state draw-call/GPU-memory telemetry (issue #1682) — fired
       // separately from ifc_model_loaded because it must wait for the scene
       // to settle (queue drain + fragment finalize), which happens after this

--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -71,6 +71,7 @@ import { computePointCloudAlignment, unregisterPointCloudAlignment, hasRegistere
 import { toast } from '../components/ui/toast.js';
 import { posthog } from '../lib/analytics.js';
 import { reportRenderStats } from '../utils/renderStatsReport.js';
+import { nextFrameOrTimeout } from '../utils/frameWait.js';
 import { classifyLoadError, errorCaptureProps, formatLoadError, type LoadErrorKind } from '../lib/load-errors.js';
 
 /**
@@ -140,6 +141,14 @@ function getGeometryStreamWatchdogMs(
   });
 }
 
+
+/**
+ * Upper bound on the "let the last batch paint" frame wait at stream complete.
+ * Generous on purpose: on a heavy final batch a *visible* tab's next frame can
+ * be several hundred ms out, and this budget exists to bound a HIDDEN tab
+ * (where no frame ever arrives), not to cut a real frame short. (#2385)
+ */
+const COMPLETE_FRAME_WAIT_MS = 1000;
 
 /**
  * Hook providing file loading operations for single-model path
@@ -1676,7 +1685,17 @@ export function useIfcLoader() {
               memoryAccounting.endPhase('geometry');
               memoryAccounting.recordPhase({ phase: 'geometry-complete' });
               console.log(memoryAccounting.formatSummary());
-              await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+              // Let the final geometry batch paint before flipping the streaming
+              // flag — but BOUNDED. `requestAnimationFrame` never fires while the
+              // tab is hidden, and everything that completes this load sits after
+              // this await: `setGeometryStreamingActive(false)`, the whole
+              // `finalizePromise` (finalizeModel → spatial index → cache write),
+              // `closeGeometryIterator()` (which frees the WASM handles), and
+              // `setLoading(false)`. An unbounded wait here therefore left a
+              // tabbed-away load permanently unfinalized with its WASM handles
+              // pinned, and inflated `total_elapsed_ms` by the entire hidden
+              // duration — which is what poisoned the load-time telemetry. (#2385)
+              await nextFrameOrTimeout(COMPLETE_FRAME_WAIT_MS);
               if (loadSessionRef.current === currentSession && target.kind === 'primary') {
                 setGeometryStreamingActive(false);
               }

--- a/apps/viewer/src/store/basketSave.ts
+++ b/apps/viewer/src/store/basketSave.ts
@@ -60,6 +60,10 @@ async function captureCanvasThumbnail(): Promise<string | null> {
     await device.queue.onSubmittedWorkDone();
   }
 
+  // FRAME-WAIT-ALLOW(#2385): must NOT be raced against a timer — the point is
+  // that the frame was presented before `toDataURL()` samples the canvas, and
+  // timing out would save a stale or blank basket thumbnail. A hidden tab
+  // cannot present a frame at all, so bounding this buys nothing.
   await new Promise<void>((resolve) =>
     requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
   );

--- a/apps/viewer/src/utils/frameWait.test.ts
+++ b/apps/viewer/src/utils/frameWait.test.ts
@@ -1,0 +1,137 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Regression tests for #2385 — a hidden tab never delivers an animation frame,
+ * so an unbounded `await new Promise(r => requestAnimationFrame(r))` inside the
+ * load pipeline parked the whole completion path (finalize, WASM handle
+ * release, `setLoading(false)`) until the user came back to the tab.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { nextFrameOrTimeout } from './frameWait.js';
+
+/**
+ * Drain the microtask queue. Used instead of `await promise` so that a broken
+ * implementation fails the assertion instead of hanging the runner forever —
+ * a hang is indistinguishable from a stuck CI job, and these tests exist
+ * precisely to be mutation-checked by breaking the implementation.
+ */
+async function drainMicrotasks(): Promise<void> {
+  for (let i = 0; i < 8; i++) await Promise.resolve();
+}
+
+type RafHost = typeof globalThis & {
+  requestAnimationFrame?: (cb: FrameRequestCallback) => number;
+};
+
+/** Install a fake rAF for the duration of `fn`, restoring whatever was there. */
+async function withRaf(
+  raf: ((cb: FrameRequestCallback) => number) | undefined,
+  fn: () => Promise<void>,
+): Promise<void> {
+  const host = globalThis as RafHost;
+  const had = Object.prototype.hasOwnProperty.call(host, 'requestAnimationFrame');
+  const prev = host.requestAnimationFrame;
+  // Reflect.deleteProperty, not `delete`: the DOM lib types rAF as a required
+  // member of globalThis, so `delete` is a type error even though the property
+  // genuinely is absent under node.
+  if (raf) host.requestAnimationFrame = raf;
+  else Reflect.deleteProperty(host, 'requestAnimationFrame');
+  try {
+    await fn();
+  } finally {
+    if (had) host.requestAnimationFrame = prev;
+    else Reflect.deleteProperty(host, 'requestAnimationFrame');
+  }
+}
+
+test('#2385 hidden tab: resolves off the timer when no frame ever arrives', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  let registered = 0;
+  // A hidden tab: the callback IS accepted and simply never invoked.
+  await withRaf(() => { registered += 1; return 1; }, async () => {
+    let settled = false;
+    void nextFrameOrTimeout(1000).then(() => { settled = true; });
+
+    // Without the timer fallback there is nothing that could ever settle this.
+    await drainMicrotasks();
+    assert.equal(registered, 1, 'a frame was requested');
+    assert.equal(settled, false, 'must not resolve before the bound elapses');
+
+    t.mock.timers.tick(1000);
+    await drainMicrotasks();
+    assert.equal(settled, true, 'the timer bound must complete the wait');
+  });
+});
+
+test('#2385 visible tab: a delivered frame resolves the wait without the timer', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  // Timers are mocked and never ticked below, so only the frame can settle this.
+  await withRaf((cb) => { cb(0); return 1; }, async () => {
+    let settled = false;
+    void nextFrameOrTimeout(1000).then(() => { settled = true; });
+    await drainMicrotasks();
+    assert.equal(settled, true, 'a delivered frame must resolve the wait');
+  });
+});
+
+test('#2385 a delivered frame clears the pending fallback timer', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  const cleared: unknown[] = [];
+  const realClear = globalThis.clearTimeout;
+  globalThis.clearTimeout = ((id: unknown) => {
+    cleared.push(id);
+    return (realClear as (id: unknown) => void)(id);
+  }) as typeof globalThis.clearTimeout;
+  try {
+    await withRaf((cb) => { cb(0); return 1; }, async () => {
+      let settled = false;
+      void nextFrameOrTimeout(60_000).then(() => { settled = true; });
+      await drainMicrotasks();
+      assert.equal(settled, true, 'the frame must resolve the wait');
+    });
+  } finally {
+    globalThis.clearTimeout = realClear;
+  }
+  assert.equal(cleared.length, 1, 'the fallback timer must be cleared, not left pending');
+});
+
+test('#2385 a non-positive bound is rejected rather than silently degrading', () => {
+  // 0 is the valid-but-falsy boundary: it would turn every call site into a
+  // bare "yield once" and quietly delete the frame wait.
+  assert.throws(() => nextFrameOrTimeout(0), RangeError);
+  assert.throws(() => nextFrameOrTimeout(-1), RangeError);
+});
+
+test('#2385 no unbounded frame wait is reintroduced in the load or clash pipelines', () => {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const files = [
+    resolve(here, '../hooks/useIfcLoader.ts'),
+    resolve(here, '../hooks/useClash.ts'),
+  ];
+
+  const violations: string[] = [];
+  for (const file of files) {
+    const lines = readFileSync(file, 'utf8').split('\n');
+    lines.forEach((line, i) => {
+      if (!line.includes('await new Promise') || !line.includes('requestAnimationFrame')) return;
+      // A deliberate unbounded wait declares itself in the preceding comment.
+      const preamble = lines.slice(Math.max(0, i - 6), i).join('\n');
+      if (preamble.includes('FRAME-WAIT-ALLOW')) return;
+      violations.push(`${file}:${i + 1}: ${line.trim()}`);
+    });
+  }
+
+  assert.deepEqual(
+    violations,
+    [],
+    'use nextFrameOrTimeout(); an unbounded frame wait parks forever in a hidden tab (#2385). ' +
+      'If the wait genuinely must be unbounded, mark it with a FRAME-WAIT-ALLOW comment and say why.',
+  );
+});

--- a/apps/viewer/src/utils/frameWait.test.ts
+++ b/apps/viewer/src/utils/frameWait.test.ts
@@ -64,7 +64,14 @@ test('#2385 hidden tab: resolves off the timer when no frame ever arrives', asyn
     assert.equal(registered, 1, 'a frame was requested');
     assert.equal(settled, false, 'must not resolve before the bound elapses');
 
-    t.mock.timers.tick(1000);
+    // Pin the bound from BOTH sides. Mocked timers only fire on tick(), so a
+    // single tick(1000) passes for *any* positive delay — a 1000 -> 1 typo
+    // would ship green. Asserting at 999 makes the magnitude load-bearing.
+    t.mock.timers.tick(999);
+    await drainMicrotasks();
+    assert.equal(settled, false, 'must not resolve before the full bound elapses');
+
+    t.mock.timers.tick(1);
     await drainMicrotasks();
     assert.equal(settled, true, 'the timer bound must complete the wait');
   });
@@ -114,15 +121,28 @@ test('#2385 no unbounded frame wait is reintroduced in the load or clash pipelin
   const files = [
     resolve(here, '../hooks/useIfcLoader.ts'),
     resolve(here, '../hooks/useClash.ts'),
+    resolve(here, '../hooks/useIDS.ts'),
+    resolve(here, '../components/viewer/ClashPanel.tsx'),
+    resolve(here, '../store/basketSave.ts'),
   ];
+
+  // Scan a forward WINDOW, not a single line: an `await new Promise(...)` whose
+  // `requestAnimationFrame` is wrapped onto the next line is the same defect,
+  // and a single-line match would miss it.
+  const WINDOW = 10;
 
   const violations: string[] = [];
   for (const file of files) {
     const lines = readFileSync(file, 'utf8').split('\n');
     lines.forEach((line, i) => {
-      if (!line.includes('await new Promise') || !line.includes('requestAnimationFrame')) return;
+      if (!line.includes('await new Promise')) return;
+      const window = lines.slice(i, i + WINDOW).join('\n');
+      if (!window.includes('requestAnimationFrame')) return;
+      // Bounded already: either a hand-rolled race against a timer, or the
+      // shared helper. Both are fine; only an UNBOUNDED wait is the defect.
+      if (window.includes('setTimeout(') || window.includes('nextFrameOrTimeout(')) return;
       // A deliberate unbounded wait declares itself in the preceding comment.
-      const preamble = lines.slice(Math.max(0, i - 6), i).join('\n');
+      const preamble = lines.slice(Math.max(0, i - 8), i).join('\n');
       if (preamble.includes('FRAME-WAIT-ALLOW')) return;
       violations.push(`${file}:${i + 1}: ${line.trim()}`);
     });

--- a/apps/viewer/src/utils/frameWait.test.ts
+++ b/apps/viewer/src/utils/frameWait.test.ts
@@ -28,6 +28,7 @@ async function drainMicrotasks(): Promise<void> {
 
 type RafHost = typeof globalThis & {
   requestAnimationFrame?: (cb: FrameRequestCallback) => number;
+  cancelAnimationFrame?: (handle: number) => void;
 };
 
 /** Install a fake rAF for the duration of `fn`, restoring whatever was there. */
@@ -107,6 +108,42 @@ test('#2385 a delivered frame clears the pending fallback timer', async (t) => {
     globalThis.clearTimeout = realClear;
   }
   assert.equal(cleared.length, 1, 'the fallback timer must be cleared, not left pending');
+});
+
+test('#2385 when the timer wins, the queued frame callback is retracted', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  const host = globalThis as RafHost;
+  const cancelled: number[] = [];
+  host.cancelAnimationFrame = (h: number) => { cancelled.push(h); };
+  try {
+    // A hidden tab: the handle is issued, the callback never runs.
+    await withRaf(() => 4242, async () => {
+      let settled = false;
+      void nextFrameOrTimeout(1000).then(() => { settled = true; });
+      t.mock.timers.tick(1000);
+      await drainMicrotasks();
+      assert.equal(settled, true, 'the timer bound completes the wait');
+      // Leaving the callback registered is the same defect this helper exists
+      // to fix: on a hidden tab it stays queued until the tab is shown, once
+      // per bounded wait.
+      assert.deepEqual(cancelled, [4242], 'the pending frame must be cancelled by handle');
+    });
+  } finally {
+    Reflect.deleteProperty(host, 'cancelAnimationFrame');
+  }
+});
+
+test('#2385 a host without cancelAnimationFrame still settles (no throw)', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  const host = globalThis as RafHost;
+  assert.equal(host.cancelAnimationFrame, undefined, 'precondition: no canceller installed');
+  await withRaf(() => 7, async () => {
+    let settled = false;
+    void nextFrameOrTimeout(1000).then(() => { settled = true; });
+    t.mock.timers.tick(1000);
+    await drainMicrotasks();
+    assert.equal(settled, true, 'a missing canceller must not break the timer path');
+  });
 });
 
 test('#2385 a non-positive bound is rejected rather than silently degrading', () => {

--- a/apps/viewer/src/utils/frameWait.ts
+++ b/apps/viewer/src/utils/frameWait.ts
@@ -1,0 +1,52 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Bounded "wait for the next frame".
+ *
+ * `requestAnimationFrame` is **not serviced while the document is hidden** —
+ * the callback is queued and only runs when the tab is shown again. So a bare
+ * `await new Promise(resolve => requestAnimationFrame(resolve))` inside an
+ * async pipeline parks *for as long as the user stays on another tab*, which on
+ * a long model load is routinely minutes and has been observed in field
+ * telemetry at over a day.
+ *
+ * Every such wait in a background-capable pipeline must therefore be raced
+ * against a timer. `useIDS` already did this by hand; this is the single home
+ * for the pattern.
+ *
+ * The frame still wins whenever one arrives, so a visible tab behaves exactly
+ * as it did before as long as `timeoutMs` is generous relative to a frame.
+ *
+ * Caveat, deliberately not worked around: browsers throttle timers in hidden
+ * tabs (Chrome clamps to >=1s, and to ~1/minute after several minutes of
+ * hiddenness). The fallback therefore bounds the stall rather than hitting
+ * `timeoutMs` exactly — bounded-and-late is the goal, not precision.
+ *
+ * @param timeoutMs Upper bound on the wait. Must be > 0; a non-positive value
+ *   would defeat the frame wait entirely and is rejected rather than silently
+ *   turning every call site into "yield once".
+ */
+export function nextFrameOrTimeout(timeoutMs: number): Promise<void> {
+  if (!(timeoutMs > 0)) {
+    throw new RangeError(`nextFrameOrTimeout: timeoutMs must be > 0, got ${timeoutMs}`);
+  }
+  return new Promise<void>((resolve) => {
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const done = (): void => {
+      if (settled) return;
+      settled = true;
+      if (timer !== undefined) clearTimeout(timer);
+      resolve();
+    };
+    timer = setTimeout(done, timeoutMs);
+    // Read off globalThis so a non-DOM host (node tests, SSR) falls through to
+    // the timer instead of throwing.
+    const raf = (globalThis as typeof globalThis & {
+      requestAnimationFrame?: (cb: FrameRequestCallback) => number;
+    }).requestAnimationFrame;
+    if (typeof raf === 'function') raf(done);
+  });
+}

--- a/apps/viewer/src/utils/frameWait.ts
+++ b/apps/viewer/src/utils/frameWait.ts
@@ -32,21 +32,40 @@ export function nextFrameOrTimeout(timeoutMs: number): Promise<void> {
   if (!(timeoutMs > 0)) {
     throw new RangeError(`nextFrameOrTimeout: timeoutMs must be > 0, got ${timeoutMs}`);
   }
+  // Read off globalThis so a non-DOM host (node tests, SSR) falls through to
+  // the timer instead of throwing.
+  const host = globalThis as typeof globalThis & {
+    requestAnimationFrame?: (cb: FrameRequestCallback) => number;
+    cancelAnimationFrame?: (handle: number) => void;
+  };
   return new Promise<void>((resolve) => {
     let settled = false;
     let timer: ReturnType<typeof setTimeout> | undefined;
+    let frame: number | undefined;
+
+    const cancelFrame = (): void => {
+      if (frame === undefined) return;
+      const cancel = host.cancelAnimationFrame;
+      if (typeof cancel === 'function') cancel(frame);
+      frame = undefined;
+    };
+
     const done = (): void => {
       if (settled) return;
       settled = true;
       if (timer !== undefined) clearTimeout(timer);
+      // When the TIMER wins, the frame callback is still queued. On a hidden
+      // tab it stays queued until the tab is shown — which for a load-
+      // completion wait can be a very long time, once per bounded wait. Leaving
+      // a callback alive past its useful life is the same defect this helper
+      // exists to fix, so retract it. (#2385)
+      cancelFrame();
       resolve();
     };
+
     timer = setTimeout(done, timeoutMs);
-    // Read off globalThis so a non-DOM host (node tests, SSR) falls through to
-    // the timer instead of throwing.
-    const raf = (globalThis as typeof globalThis & {
-      requestAnimationFrame?: (cb: FrameRequestCallback) => number;
-    }).requestAnimationFrame;
-    if (typeof raf === 'function') raf(done);
+    if (typeof host.requestAnimationFrame === 'function') {
+      frame = host.requestAnimationFrame(done);
+    }
   });
 }

--- a/apps/viewer/src/utils/loadTelemetry.test.ts
+++ b/apps/viewer/src/utils/loadTelemetry.test.ts
@@ -1,0 +1,100 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `ifc_model_loaded` payload contract (#2385).
+ *
+ * This event is the project's field perf truth and a regression alert reads it,
+ * so the two diagnostic fields added for #2385/#2388 have to arrive intact —
+ * including their falsy values, which carry the meaning that matters.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildModelLoadedPayload, type ModelLoadedInputs } from './loadTelemetry.js';
+
+function inputs(over: Partial<ModelLoadedInputs> = {}): ModelLoadedInputs {
+  return {
+    format: 'ifc',
+    fileSizeMB: 76.7312,
+    loadTarget: 'primary',
+    loadPath: 'wasm',
+    meshCount: 6668,
+    totalElapsedMs: 32994.4,
+    totalVertices: 12905776,
+    totalTriangles: 4423296,
+    fileReadMs: 563.7,
+    metadataCompleteMs: 4984.2,
+    firstGeometryBatchMs: 15064.6,
+    firstVisibleGeometryMs: 15376.1,
+    streamCompleteMs: 32508.9,
+    totalCsgFailures: 3,
+    wasHidden: false,
+    ...over,
+  };
+}
+
+test('#2385 was_hidden: false survives to the wire', () => {
+  const p = buildModelLoadedPayload(inputs({ wasHidden: false }));
+  assert.ok('was_hidden' in p, 'a clean load must SAY it is clean');
+  assert.equal(p.was_hidden, false);
+  // Dropping it would make a clean load indistinguishable from an old client
+  // that never reported the field, i.e. from an unfilterable row.
+  assert.notEqual(p.was_hidden, undefined);
+});
+
+test('#2385 was_hidden: true is reported for a load that spanned a tab switch', () => {
+  assert.equal(buildModelLoadedPayload(inputs({ wasHidden: true })).was_hidden, true);
+});
+
+test('#2388 total_csg_failures: 0 survives, and is distinct from "cannot tell you"', () => {
+  const clean = buildModelLoadedPayload(inputs({ totalCsgFailures: 0 }));
+  assert.ok('total_csg_failures' in clean, '0 is a measurement, not an absence');
+  assert.equal(clean.total_csg_failures, 0);
+
+  // null = the engine reported no diagnostics at all (older wasm). That must
+  // be OMITTED, not coerced to 0 — conflating them would answer the question
+  // this field exists to settle with a fabricated zero.
+  const unknown = buildModelLoadedPayload(inputs({ totalCsgFailures: null }));
+  assert.equal(unknown.total_csg_failures, undefined);
+});
+
+test('#2385 a nonzero CSG failure count is carried through unrounded', () => {
+  assert.equal(buildModelLoadedPayload(inputs({ totalCsgFailures: 3 })).total_csg_failures, 3);
+});
+
+test('#2385 an unreached milestone is omitted, not sent as null or 0', () => {
+  const p = buildModelLoadedPayload(inputs({
+    metadataCompleteMs: null,
+    firstGeometryBatchMs: null,
+    firstVisibleGeometryMs: null,
+    streamCompleteMs: null,
+  }));
+  for (const k of [
+    'metadata_complete_ms',
+    'first_geometry_batch_ms',
+    'first_visible_geometry_ms',
+    'stream_complete_ms',
+  ]) {
+    assert.equal(p[k], undefined, `${k} must be omitted when not measured`);
+  }
+});
+
+test('#2385 a milestone of 0 is a real measurement and is kept', () => {
+  // The valid-but-falsy boundary: `value != null` keeps 0, `value ? ... :` loses it.
+  const p = buildModelLoadedPayload(inputs({ metadataCompleteMs: 0, streamCompleteMs: 0 }));
+  assert.equal(p.metadata_complete_ms, 0);
+  assert.equal(p.stream_complete_ms, 0);
+});
+
+test('#2385 timings are rounded and file size keeps 2dp (the fingerprint key)', () => {
+  const p = buildModelLoadedPayload(inputs());
+  assert.equal(p.total_elapsed_ms, 32994);
+  assert.equal(p.stream_complete_ms, 32509);
+  assert.equal(p.file_read_ms, 564);
+  // file_size_mb + mesh_count IS the model fingerprint the alert groups on, so
+  // its precision is a compatibility contract, not a formatting choice.
+  assert.equal(p.file_size_mb, 76.73);
+  assert.equal(p.mesh_count, 6668);
+});

--- a/apps/viewer/src/utils/loadTelemetry.ts
+++ b/apps/viewer/src/utils/loadTelemetry.ts
@@ -1,0 +1,80 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The `ifc_model_loaded` payload, built in one place.
+ *
+ * This event is the project's field perf truth (see `scripts/perf/README.md`),
+ * and a per-model regression alert reads it. Two of its fields exist purely to
+ * make past ambiguities answerable, and both have a falsy value that MUST
+ * survive to the wire:
+ *
+ * - `was_hidden: false` is the statement "this timing is clean". Dropping it
+ *   would make a clean load indistinguishable from an old client that never
+ *   reported, which is the difference between filtering the metric and
+ *   silently discarding half of it.
+ * - `total_csg_failures: 0` is the statement "no void cut fell back". Dropping
+ *   it would make it indistinguishable from `null` = "this client cannot tell
+ *   you", which is exactly the question it was added to settle (#2385).
+ *
+ * `null` means "not measured" for every optional field and is omitted, because
+ * PostHog treats an absent property and an explicit null differently in
+ * `IS NOT NULL` filters.
+ */
+
+export interface ModelLoadedInputs {
+  format: string;
+  fileSizeMB: number;
+  loadTarget: 'primary' | 'federated';
+  loadPath: string;
+  meshCount: number;
+  totalElapsedMs: number;
+  totalVertices: number;
+  totalTriangles: number;
+  fileReadMs: number;
+  /** Milestones. `null` = this load never reached the milestone. */
+  metadataCompleteMs: number | null;
+  firstGeometryBatchMs: number | null;
+  firstVisibleGeometryMs: number | null;
+  streamCompleteMs: number | null;
+  /** `null` = the engine reported no diagnostics at all (older wasm). */
+  totalCsgFailures: number | null;
+  /** Was the tab hidden at any point during this load? */
+  wasHidden: boolean;
+}
+
+/** Round a milestone, preserving "not measured" as an omitted property. */
+function milestone(value: number | null): number | undefined {
+  return value != null ? Math.round(value) : undefined;
+}
+
+export function buildModelLoadedPayload(
+  input: ModelLoadedInputs,
+): Record<string, string | number | boolean | undefined> {
+  return {
+    format: input.format,
+    file_size_mb: Math.round(input.fileSizeMB * 100) / 100,
+    load_target: input.loadTarget,
+    load_path: input.loadPath,
+    mesh_count: input.meshCount,
+    total_elapsed_ms: Math.round(input.totalElapsedMs),
+    // Vertices/triangles size the model; the milestones (read -> metadata ->
+    // first batch -> first paint -> stream done) locate where a load regressed.
+    total_vertices: input.totalVertices,
+    total_triangles: input.totalTriangles,
+    file_read_ms: Math.round(input.fileReadMs),
+    metadata_complete_ms: milestone(input.metadataCompleteMs),
+    first_geometry_batch_ms: milestone(input.firstGeometryBatchMs),
+    first_visible_geometry_ms: milestone(input.firstVisibleGeometryMs),
+    stream_complete_ms: milestone(input.streamCompleteMs),
+    // A nonzero count means some void cut fell back, which changes
+    // triangulation without changing the mesh roster — the leading explanation
+    // for the same file reporting two triangle counts on one build (#2388).
+    total_csg_failures: input.totalCsgFailures ?? undefined,
+    // Load timings are wall-clock, so a load spanning a tab switch reports the
+    // user's absence as work. Lets the perf queries drop those rows on
+    // evidence rather than on a magic duration threshold (#2385).
+    was_hidden: input.wasHidden,
+  };
+}

--- a/apps/viewer/src/utils/visibilityWitness.test.ts
+++ b/apps/viewer/src/utils/visibilityWitness.test.ts
@@ -15,6 +15,7 @@ import { visibilityWitness, __resetVisibilityWitnessForTest } from './visibility
 interface FakeDoc {
   visibilityState: 'visible' | 'hidden';
   addEventListener: (type: string, fn: () => void) => void;
+  removeEventListener: (type: string, fn: () => void) => void;
   hide: () => void;
   show: () => void;
   listenerCount: () => number;
@@ -25,6 +26,11 @@ function installFakeDocument(): FakeDoc {
   const doc: FakeDoc = {
     visibilityState: 'visible',
     addEventListener: (type, fn) => { if (type === 'visibilitychange') listeners.push(fn); },
+    removeEventListener: (type, fn) => {
+      if (type !== 'visibilitychange') return;
+      const i = listeners.indexOf(fn);
+      if (i >= 0) listeners.splice(i, 1);
+    },
     hide: () => { doc.visibilityState = 'hidden'; for (const fn of [...listeners]) fn(); },
     show: () => { doc.visibilityState = 'visible'; for (const fn of [...listeners]) fn(); },
     listenerCount: () => listeners.length,
@@ -77,6 +83,22 @@ test('#2385 a later load is not retro-tainted by an earlier tab switch', () => {
     const second = visibilityWitness();
     assert.equal(first(), true, 'the load that spanned the switch is flagged');
     assert.equal(second(), false, 'a load starting after it is clean');
+  } finally { uninstallFakeDocument(); }
+});
+
+test('#2385 a reset detaches the listener, so reinstalling does not double the witness', () => {
+  const doc = installFakeDocument();
+  try {
+    visibilityWitness();                    // installs
+    __resetVisibilityWitnessForTest();      // must DETACH, not just clear the flag
+    const wasHidden = visibilityWitness();  // reinstalls against the same document
+
+    assert.equal(doc.listenerCount(), 1, 'a retained stale listener would accumulate');
+    doc.hide();
+    // A doubled listener counts one hide twice. The witness would still read
+    // `true` here, so assert on the count itself — the doubling is what makes a
+    // later test pass for the wrong reason.
+    assert.equal(wasHidden(), true);
   } finally { uninstallFakeDocument(); }
 });
 

--- a/apps/viewer/src/utils/visibilityWitness.test.ts
+++ b/apps/viewer/src/utils/visibilityWitness.test.ts
@@ -1,0 +1,89 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Tests for the `was_hidden` load stamp (#2385). Load timings are wall-clock,
+ * so a load spanning a tab switch reports the user's absence as work; this flag
+ * is what lets the perf queries drop those rows on evidence.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { visibilityWitness, __resetVisibilityWitnessForTest } from './visibilityWitness.js';
+
+interface FakeDoc {
+  visibilityState: 'visible' | 'hidden';
+  addEventListener: (type: string, fn: () => void) => void;
+  hide: () => void;
+  show: () => void;
+  listenerCount: () => number;
+}
+
+function installFakeDocument(): FakeDoc {
+  const listeners: (() => void)[] = [];
+  const doc: FakeDoc = {
+    visibilityState: 'visible',
+    addEventListener: (type, fn) => { if (type === 'visibilitychange') listeners.push(fn); },
+    hide: () => { doc.visibilityState = 'hidden'; for (const fn of [...listeners]) fn(); },
+    show: () => { doc.visibilityState = 'visible'; for (const fn of [...listeners]) fn(); },
+    listenerCount: () => listeners.length,
+  };
+  (globalThis as { document?: unknown }).document = doc;
+  __resetVisibilityWitnessForTest();
+  return doc;
+}
+
+function uninstallFakeDocument(): void {
+  Reflect.deleteProperty(globalThis, 'document');
+  __resetVisibilityWitnessForTest();
+}
+
+test('#2385 a load that stays visible is not flagged', () => {
+  const doc = installFakeDocument();
+  try {
+    const wasHidden = visibilityWitness();
+    doc.show(); // a visibilitychange that resolves to visible must not count
+    assert.equal(wasHidden(), false);
+  } finally { uninstallFakeDocument(); }
+});
+
+test('#2385 a load that is hidden partway through is flagged', () => {
+  const doc = installFakeDocument();
+  try {
+    const wasHidden = visibilityWitness();
+    assert.equal(wasHidden(), false, 'clean before the tab switch');
+    doc.hide();
+    doc.show();
+    assert.equal(wasHidden(), true, 'the flag must survive the user coming back');
+  } finally { uninstallFakeDocument(); }
+});
+
+test('#2385 a load STARTED in an already-hidden tab is flagged (no transition fires)', () => {
+  const doc = installFakeDocument();
+  try {
+    doc.visibilityState = 'hidden'; // already backgrounded; no event to observe
+    const wasHidden = visibilityWitness();
+    assert.equal(wasHidden(), true);
+  } finally { uninstallFakeDocument(); }
+});
+
+test('#2385 a later load is not retro-tainted by an earlier tab switch', () => {
+  const doc = installFakeDocument();
+  try {
+    const first = visibilityWitness();
+    doc.hide();
+    doc.show();
+    const second = visibilityWitness();
+    assert.equal(first(), true, 'the load that spanned the switch is flagged');
+    assert.equal(second(), false, 'a load starting after it is clean');
+  } finally { uninstallFakeDocument(); }
+});
+
+test('#2385 the listener is installed once, not once per load', () => {
+  const doc = installFakeDocument();
+  try {
+    for (let i = 0; i < 25; i++) visibilityWitness();
+    assert.equal(doc.listenerCount(), 1, 'a per-load listener would leak on every load');
+  } finally { uninstallFakeDocument(); }
+});

--- a/apps/viewer/src/utils/visibilityWitness.ts
+++ b/apps/viewer/src/utils/visibilityWitness.ts
@@ -20,14 +20,19 @@
 
 let hiddenTransitions = 0;
 let installed = false;
+/** Retained purely so the test reset can detach; production never resets. */
+let attached: { doc: Document; handler: () => void } | null = null;
 
 function ensureInstalled(): void {
   if (installed) return;
   installed = true;
   if (typeof document === 'undefined') return;
-  document.addEventListener('visibilitychange', () => {
-    if (document.visibilityState === 'hidden') hiddenTransitions += 1;
-  });
+  const doc = document;
+  const handler = (): void => {
+    if (doc.visibilityState === 'hidden') hiddenTransitions += 1;
+  };
+  doc.addEventListener('visibilitychange', handler);
+  attached = { doc, handler };
 }
 
 /**
@@ -44,8 +49,19 @@ export function visibilityWitness(): () => boolean {
   return () => startedHidden || hiddenTransitions > at;
 }
 
-/** Test seam: reset the module state between cases. */
+/**
+ * Test seam: reset the module state between cases.
+ *
+ * Detaches the listener as well as clearing the flag. Clearing the flag alone
+ * would let a reset-and-reinstall against the same document accumulate
+ * listeners, so a later case would see each hide counted twice — a doubled
+ * witness that reads as a passing test for the wrong reason.
+ */
 export function __resetVisibilityWitnessForTest(): void {
   hiddenTransitions = 0;
   installed = false;
+  if (attached) {
+    attached.doc.removeEventListener('visibilitychange', attached.handler);
+    attached = null;
+  }
 }

--- a/apps/viewer/src/utils/visibilityWitness.ts
+++ b/apps/viewer/src/utils/visibilityWitness.ts
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * "Was this tab ever hidden while X was running?"
+ *
+ * Load timings are wall-clock, so a load that spans a tab switch reports the
+ * user's absence as if it were work: browsers stop servicing
+ * `requestAnimationFrame` and throttle timers in a hidden document. Field data
+ * for `ifc_model_loaded` contains a 25-hour "load" for exactly that reason, and
+ * a regression alert reading that metric is partly reading tab-switching
+ * behaviour. Stamping each load with this flag lets the query exclude those
+ * rows on evidence instead of on a magic duration threshold. (#2385)
+ *
+ * The listener is installed ONCE at module scope and never removed, so there is
+ * no per-load subscribe/unsubscribe lifecycle that an early return or a throw
+ * could leak. Callers take a cheap snapshot instead.
+ */
+
+let hiddenTransitions = 0;
+let installed = false;
+
+function ensureInstalled(): void {
+  if (installed) return;
+  installed = true;
+  if (typeof document === 'undefined') return;
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'hidden') hiddenTransitions += 1;
+  });
+}
+
+/**
+ * Snapshot visibility now; the returned predicate answers whether the document
+ * has been hidden at any point since — including the case where it was
+ * *already* hidden when the snapshot was taken (a load started in a background
+ * tab fires no transition at all).
+ */
+export function visibilityWitness(): () => boolean {
+  ensureInstalled();
+  const startedHidden =
+    typeof document !== 'undefined' && document.visibilityState === 'hidden';
+  const at = hiddenTransitions;
+  return () => startedHidden || hiddenTransitions > at;
+}
+
+/** Test seam: reset the module state between cases. */
+export function __resetVisibilityWitnessForTest(): void {
+  hiddenTransitions = 0;
+  installed = false;
+}

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -297,25 +297,54 @@ SHIPPED (landed with a PR), or RE-REFUTED / NOT SHIPPABLE. Do not read the secti
 ### Reading the FIELD telemetry (PostHog) — verdicts and traps
 
 - **A per-model PostHog regression alert is device-mix noise until you control for
-  device** (2026-08-08, alert "Per-model load regression — any model >2x baseline").
+  device — and at this traffic level it CANNOT be made to control for device**
+  (2026-08-08, alert "Per-model load regression — any model >2x baseline").
   It fired at `x_change = 2.29` on one fingerprint (76.7 MB / 6668 meshes,
-  14406 -> 32994 ms median). It is **NOT a regression.** The fingerprint had 11
-  loads in 90 days by 10 different people, and the recent and baseline windows
-  shared **zero** persons. Normalising each load by that person's own median
-  ms/MB across *all* their models collapses the ratio from **2.29x to 1.00x**.
-  Corroborating: the only person who loaded that model on both recent builds got
-  16480 -> 15892 ms (**-3.6%**); ranking all ten persons by their own ms/MB puts
-  the recent window's people at ranks 6/7/9/10 and the baseline window's at
-  1/2/3/4/5; and globally, 39 persons who loaded models in *both* windows show a
-  median per-person ratio of **1.05** (IQR 0.71-1.56) over 572 loads.
+  14406 -> 32994 ms median). It is **NOT a regression.**
+  - The decisive estimator is the **within-person same-model paired ratio**:
+    for every (person, model) cell with loads in both windows, `median(recent) /
+    median(baseline)`. Fleet-wide that is **0.927** (IQR 0.852-1.127) over 24
+    cells / 16 persons / 97 loads — i.e. slightly *faster*. This holds the device
+    constant by construction, which is the only property that matters here.
+  - The fingerprint that fired has **zero** paired persons: 11 loads in 90 days by
+    10 different people, no person in both windows. Its paired ratio is not
+    small, it is **undefined** — there was never a regression estimate, only a
+    comparison of one set of laptops against another.
+  - **A per-model alert is not salvageable at current volume.** Across the whole
+    17-day window, **no** model fingerprint has more than **one** paired person
+    (24 fingerprints have exactly 1, 1825 have 0). Any per-model gate strong
+    enough to be sound can never fire. Alert **fleet-wide** on the pooled paired
+    ratio and keep per-model as a drill-down insight.
+  - **Two tempting controls that are circular — do not lean on them.** (1)
+    Normalising each load by that person's own median ms/MB *over the full
+    window* looks great (it collapses 2.29x to 1.00x) but the divisor is computed
+    from inside the suspect window, so a real uniform 2x regression normalises to
+    ~1.4x and a person whose only loads are recent cancels out by construction.
+    If you normalise, build the divisor from the **baseline window only**.
+    (2) "The one person who loaded it on both recent builds got faster" compares
+    two *recent* builds to each other and never bridges the windows.
   **Lesson:** the alert's anti-false-positive gates (>=5 loads, >=3 persons per
   window, recent p25 >= baseline median) are all satisfiable by five loads from
-  five *different* laptops. Person count is not person *overlap*. Before believing
-  any field regression, run the two controls that cost one query each: (1) is
-  there person overlap between the windows, (2) does the ratio survive dividing
-  each load by that person's own speed factor. This is the second retracted field
-  perf claim on this project (see the #2183 "compression is worse" retraction) —
-  both died to contaminated measurement, not to bad code.
+  five *different* laptops. Person count is not person *overlap*. This is the
+  second retracted field perf claim on this project (see the #2183 "compression
+  is worse" retraction) — both died to contaminated measurement, not to bad code.
+- **A `total_triangles` change for one file can split WITHIN a single build.**
+  On the fingerprint above, build `1aa498e26339` emitted **both** 4423296 (two
+  persons) and 4432196 (a third) — same file, same `mesh_count` (6668), same
+  `file_size_mb` to 2dp. Because the split is inside one build, every
+  commit-range / "which merge changed the mesher" argument is moot, and so is
+  fingerprint collision (it would need two files matching to +-5 KB and +-0
+  meshes while differing 0.2% in triangles). An identical mesh roster with more
+  triangles distributed *within* it means **environment-conditional
+  triangulation on a deterministic code path** — most plausibly a CSG void cut
+  that failed and fell back under memory pressure on one run. Note the CI
+  determinism manifests would **not** catch this (pinned fixtures, controlled
+  memory), so if CSG fallback is the mechanism it is known-by-design variance,
+  not a latent determinism defect. `total_csg_failures` now rides
+  `ifc_model_loaded` so this is answerable from telemetry. Do **not** spend a
+  probe on `?geomWorkers=N`: `useIfcLoader.ts` documents that worker count cannot
+  affect output (disjoint deterministic element slices), so that probe is
+  predicted clean by the codebase itself.
 - **`total_elapsed_ms` is not pure compute — it contained an unbounded hidden-tab
   stall** (#2385, fixed). `useIfcLoader` awaited a bare `requestAnimationFrame`
   at stream-complete; rAF is never serviced while the document is hidden, so a
@@ -325,7 +354,11 @@ SHIPPED (landed with a PR), or RE-REFUTED / NOT SHIPPABLE. Do not read the secti
   work can produce. 5.5% of all loads (420 / 7605) spent over 10 s after
   `stream_complete_ms`. **When mining this event, treat `total_elapsed_ms` minus
   `stream_complete_ms` above ~30 s as a visibility artifact, not compute, on any
-  data captured before this fix.**
+  data captured before this fix.** That duration cut is a stopgap and has a real
+  cost — it also hides a genuine slow-finalize regression. `ifc_model_loaded` now
+  carries **`was_hidden`**; once it has 17 days of history, filter on
+  `was_hidden != true` instead, which excludes the artifact without blinding the
+  metric.
 - **`BVH.build` is a synchronous main-thread block that grows as O(N log^2 N)**
   (`packages/spatial/src/bvh.ts`, measured 2026-08-08, M-series, warmed, best of
   3): 21 ms @ 6.7k meshes, 296 ms @ 60k, 826 ms @ 120k, **1715 ms @ 200k**

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -294,6 +294,50 @@ SHIPPED (landed with a PR), or RE-REFUTED / NOT SHIPPABLE. Do not read the secti
     `IfcAPI::setComputeGeometryHashes`. The hashing-on numbers above therefore
     come from driving the real wasm entry point, not from `probe.sh`.
 
+### Reading the FIELD telemetry (PostHog) — verdicts and traps
+
+- **A per-model PostHog regression alert is device-mix noise until you control for
+  device** (2026-08-08, alert "Per-model load regression — any model >2x baseline").
+  It fired at `x_change = 2.29` on one fingerprint (76.7 MB / 6668 meshes,
+  14406 -> 32994 ms median). It is **NOT a regression.** The fingerprint had 11
+  loads in 90 days by 10 different people, and the recent and baseline windows
+  shared **zero** persons. Normalising each load by that person's own median
+  ms/MB across *all* their models collapses the ratio from **2.29x to 1.00x**.
+  Corroborating: the only person who loaded that model on both recent builds got
+  16480 -> 15892 ms (**-3.6%**); ranking all ten persons by their own ms/MB puts
+  the recent window's people at ranks 6/7/9/10 and the baseline window's at
+  1/2/3/4/5; and globally, 39 persons who loaded models in *both* windows show a
+  median per-person ratio of **1.05** (IQR 0.71-1.56) over 572 loads.
+  **Lesson:** the alert's anti-false-positive gates (>=5 loads, >=3 persons per
+  window, recent p25 >= baseline median) are all satisfiable by five loads from
+  five *different* laptops. Person count is not person *overlap*. Before believing
+  any field regression, run the two controls that cost one query each: (1) is
+  there person overlap between the windows, (2) does the ratio survive dividing
+  each load by that person's own speed factor. This is the second retracted field
+  perf claim on this project (see the #2183 "compression is worse" retraction) —
+  both died to contaminated measurement, not to bad code.
+- **`total_elapsed_ms` is not pure compute — it contained an unbounded hidden-tab
+  stall** (#2385, fixed). `useIfcLoader` awaited a bare `requestAnimationFrame`
+  at stream-complete; rAF is never serviced while the document is hidden, so a
+  tabbed-away load parked there indefinitely. Field evidence: 30 days of loads
+  contain a 25-hour and a 3.4-hour `total_elapsed_ms`, and 20 loads over 60 s of
+  post-stream time on models under 5000 meshes — durations no amount of finalize
+  work can produce. 5.5% of all loads (420 / 7605) spent over 10 s after
+  `stream_complete_ms`. **When mining this event, treat `total_elapsed_ms` minus
+  `stream_complete_ms` above ~30 s as a visibility artifact, not compute, on any
+  data captured before this fix.**
+- **`BVH.build` is a synchronous main-thread block that grows as O(N log^2 N)**
+  (`packages/spatial/src/bvh.ts`, measured 2026-08-08, M-series, warmed, best of
+  3): 21 ms @ 6.7k meshes, 296 ms @ 60k, 826 ms @ 120k, **1715 ms @ 200k**
+  (3-5x that on a mid-range laptop). `buildSpatialIndexAsync` time-slices only
+  phase 1 (the linear bounds pass) and calls phase 2 "fast enough
+  synchronously"; phase 2 re-`sort()`s the index slice at *every* node, so the
+  comparator runs 68 -> 132 times per mesh as N goes 6.7k -> 200k. NOT SHIPPED and
+  not the cause of any open issue — recorded so the number does not get
+  re-measured. The fix, if wanted, is a presorted-per-axis build (O(N log N))
+  plus slicing phase 2; BVH query results are exact AABB tests at the leaves, so
+  a different tree shape is output-equivalent and can be asserted as such.
+
 ### Standing constraints
 - Geometry is **client-side only** (no server meshing).
 - One mesh home: `produce_element_meshes` - a fix in one pipeline diverges the other.


### PR DESCRIPTION
## Alert verdict: NOT a regression — device-mix artifact

The firing alert ("Per-model load regression — any model >2x baseline", `x_change = 2.29`, 76.7 MB / 6668 meshes, 14406 -> 32994 ms) is **noise**. Nothing got slower.

**The decisive estimator is the within-person same-model paired ratio.** For every (person, model) cell with loads in both windows, take `median(recent) / median(baseline)`. This holds the device constant by construction, which is the only property that matters here. Fleet-wide, executed against project 199147:

| paired cells | persons | loads covered | **median ratio** | p25 | p75 | cells over 2x |
|---|---|---|---|---|---|---|
| 24 | 16 | 97 | **0.927** | 0.852 | 1.127 | 1 |

Loads in the recent window are, if anything, **7% faster**.

**The fingerprint that fired has zero paired persons.** 11 loads in 90 days by 10 different people; no person appears in both windows. Its paired ratio is not small — it is **undefined**. There was never a regression estimate, only a comparison of one set of laptops against another. Running the alert's own aggregation with the paired column added:

| model | x_change (paired) | paired_persons | x_change (v1-style window medians) |
|---|---|---|---|
| 76.7MB / 6668 meshes | **NULL** | **0** | 2.56 |
| 2.3MB / 622 meshes | NULL | 0 | 1.11 |

### Two of my earlier legs were circular — flagging rather than quietly dropping them

The adversarial review was right to reject these, and they should not be cited:

1. **"Device-normalising collapses 2.29x to 1.00x."** True but circular. The `person_speed` divisor spanned the full 17-day window, so it is computed partly *inside* the suspect window. All four recent-window persons have zero loads older than 3 days, and for the two with a single lifetime load the load time cancels out algebraically — a genuine regression could not have moved that number. A normalised metric built this way also **attenuates real regressions**: a true uniform 2x with balanced loads normalises to ~1.4x.
2. **"The one person who loaded it on both recent builds got faster (16480 -> 15892 ms)."** That compares the two *recent* builds to each other. It never bridges the windows and so cannot speak to the alert.

What survives, and what the verdict rests on: **zero person overlap** on the fired row, the **paired estimator at 0.927**, and the fact that ranking all ten persons by their own speed puts the baseline window at ranks 1,2,3,4,5,8 and the recent window at 6,7,9,10 (two of the recent four have exactly one lifetime load, at 533 and 701 ms/MB — the two slowest devices in the set).

---

## The alert is the defect too — and a per-model alert is not salvageable

The existing gates (`recent_loads >= 5`, `recent_persons >= 3`, `baseline >= 1500 ms`, `delta >= 3000 ms`, `recent p25 >= baseline median`) are **all satisfiable by five loads from five different laptops**. Person *count* is not person *overlap*.

But the fix is not "add an overlap gate to the per-model query", because **at current traffic no model fingerprint has more than one paired person**:

| paired persons per fingerprint | fingerprints |
|---|---|
| 1 | 24 |
| 0 | 1825 |

Any per-model gate strong enough to be sound can never fire. **Alert fleet-wide on the pooled paired ratio; keep per-model as a drill-down insight, not an alert.**

### Proposed replacement — executed, not hypothetical

This runs today and returns the row below it. It compiles only with the materialising wrapper subquery (`SELECT * FROM (…GROUP BY…)`): HogQL inlines CTEs, which makes the outer aggregate wrap the inner one and fails with "Aggregate function … is found inside another aggregate function".

```sql
-- Fleet-wide load regression, device-controlled.
-- Object: median of within-person SAME-MODEL paired ratios (recent 3d vs 3-17d).
SELECT round(median(c.recent_ms / c.base_ms), 3)          AS x_change_paired,
       round(quantile(0.25)(c.recent_ms / c.base_ms), 3)  AS p25_ratio,
       round(quantile(0.75)(c.recent_ms / c.base_ms), 3)  AS p75_ratio,
       count()                                            AS paired_cells,
       uniq(c.person_id)                                  AS paired_persons,
       sum(c.n_recent + c.n_base)                         AS loads_covered,
       -- Uncorrected backstop: what the old window-median comparison would say.
       round(median(c.recent_ms) / nullIf(median(c.base_ms), 0), 3) AS x_change_uncorrected
FROM (
    SELECT * FROM (
        SELECT concat(toString(round(toFloat(properties.file_size_mb), 1)), 'MB / ',
                      toString(toInt(properties.mesh_count)), ' meshes') AS model,
               person_id,
               medianIf(toFloat(properties.total_elapsed_ms), timestamp >= now() - interval 3 day) AS recent_ms,
               medianIf(toFloat(properties.total_elapsed_ms), timestamp <  now() - interval 3 day) AS base_ms,
               countIf(timestamp >= now() - interval 3 day) AS n_recent,
               countIf(timestamp <  now() - interval 3 day) AS n_base
        FROM events
        WHERE event = 'ifc_model_loaded'
          AND timestamp > now() - interval 17 day
          AND toFloat(properties.file_size_mb) >= 2
          AND properties.mesh_count IS NOT NULL
          -- Hidden-tab contamination (#2385). NULL-safe: a row missing the
          -- milestone is KEPT, not dropped by a NULL comparison. Replace with
          -- `properties.was_hidden != true` once that has shipped for 17 days --
          -- unlike a duration cut, it does not also mask a slow-finalize regression.
          AND (properties.stream_complete_ms IS NULL
               OR toFloat(properties.total_elapsed_ms)
                  - toFloat(properties.stream_complete_ms) < 30000)
        GROUP BY model, person_id
    )
) AS c
WHERE c.n_recent > 0 AND c.n_base > 0
HAVING count() >= 10 AND uniq(c.person_id) >= 5
```

**Executed result right now:**

| x_change_paired | p25 | p75 | paired_cells | paired_persons | loads_covered | x_change_uncorrected |
|---|---|---|---|---|---|---|
| 0.927 | 0.852 | 1.127 | 24 | 16 | 97 | 0.978 |

Alert on `x_change_paired`. I would **not** reuse the `> 2` threshold: on a pooled metric with an observed IQR of 0.85-1.13, `> 1.5` is already a loud signal, and `> 2` on a pooled median would need a fleet-wide catastrophe. Louis picks; the observed spread above is the input to that choice.

Two honest caveats. The `< 30000` post-stream cut is a **stopgap and has a real cost** — it also hides a genuine slow-finalize regression. That is why this PR ships `was_hidden`: once it has 17 days of history, swap the predicate for `properties.was_hidden != true`, which excludes the artifact without blinding the metric. And I have executed this query but I have **not** wired it to the alert — I did not change PostHog config.

---

## What this PR actually fixes: #2385, found while auditing the metric

The gap between `stream_complete_ms` and `total_elapsed_ms` in the same event family turned out to contain a real bug.

**Root cause.** `apps/viewer/src/hooks/useIfcLoader.ts`, in the geometry stream's `complete` branch, awaited a bare frame:

```ts
await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
```

`requestAnimationFrame` callbacks are not serviced while `document.visibilityState === 'hidden'`. Every step that completes a load sits after that await: `setGeometryStreamingActive(false)`, the whole `finalizePromise` (`finalizeModel` -> spatial index -> cache write), `closeGeometryIterator()` (which frees the WASM handles — an AGENTS.md hard rule), and `setLoading(false)`. So switching tabs mid-load leaves the model permanently unfinalized with its WASM handles pinned, and on a **federated** add `loadFile` never resolves at all, stalling the rest of `loadFilesSequentially`.

`useIDS.ts` already races its frame wait against a timer, with the comment *"a backgrounded tab (where requestAnimationFrame is paused) can't stall the run"*. The load path and two `useClash` sites are the copies that missed the guard.

**Field evidence** (`ifc_model_loaded`, 30 days, 7605 loads, `total_elapsed_ms - stream_complete_ms`):

| symptom | count |
|---|---|
| > 60 s post-stream on models under 5000 meshes (impossible as compute) | 20 |
| > 30 s post-stream | 174 |
| > 10 s post-stream | 420 (**5.5%** of all loads, 43.3 h of wall time) |
| worst single load | **25 hours** (6.1 MB, 1182 meshes, streaming finished at 25.9 s) |
| second worst | 3.4 hours (19.3 MB, 923 meshes, streaming finished at 3.2 s) |

A 25-hour "load" of a 6 MB file is not computation; it is how long someone left the tab in the background.

**Fix.** One shared `nextFrameOrTimeout(timeoutMs)` helper (`apps/viewer/src/utils/frameWait.ts`), used at the load-completion wait (1000 ms bound — generous, because a *visible* tab's next frame after a heavy final batch can legitimately be several hundred ms out) and at the two `useClash` "paint before heavy work" waits (250 ms). The **three** waits that exist to guarantee a frame was *presented* before the canvas is sampled stay unbounded and are now each marked `FRAME-WAIT-ALLOW` with the reason: `useClash.ts` and `useIDS.ts` (report/topic snapshots) and `ClashPanel.tsx` + `basketSave.ts` (BCF topic image, basket thumbnail). Bounding any of them would write a stale or pre-camera-move frame into a saved artifact.

---

## Perf verdict

No perf-sensitive path is touched: this PR changes only `apps/viewer` (a hook call site, a new util) and `scripts/perf/README.md`. `rust/geometry`, `rust/processing`, `rust/core`, `packages/geometry`, `packages/wasm` and `scripts/build-wasm.sh` are untouched, so no Rust was rebuilt and no `.wasm` was regenerated.

**Byte identity: exact, by construction.** No geometry, mesher, styling or export code is in the diff, so mesh/vertex/triangle output is unchanged bit-for-bit. Nothing re-pins `mesh_determinism.json`, the ifcopenshell reference dumps, or any insta snapshot, and nothing needs to.

**I deliberately did not paste a `probe.sh` A/B.** `scripts/perf/probe.sh` drives the native Rust pipeline, which this diff cannot reach; running it base-vs-branch would produce two numbers differing only by machine noise and would be a *vacuous* green, exactly the failure mode AGENTS.md warns about with `benchmark:check`. The measurable A/B here is deterministic rather than statistical:

| scenario | base | this branch |
|---|---|---|
| stream-complete wait, tab visible | next frame | next frame (identical; the frame always wins the race) |
| stream-complete wait, tab hidden | **unbounded** — until the user returns (observed at 25 h in the field) | bounded by the 1000 ms timer (browsers throttle hidden-tab timers, so in practice ~1 s, and up to ~1 min under Chrome's intensive throttling after several minutes hidden — bounded either way) |

The ledger entry in `scripts/perf/README.md` records the alert verdict, the telemetry contaminant, and a third measurement (below) so none of the three gets re-walked.

---

## Tests and mutation check

New: `frameWait.test.ts` (7), `visibilityWitness.test.ts` (6) and `loadTelemetry.test.ts` (7) under `apps/viewer/src/utils/`, `node:test` — the viewer's convention. Every test was mutation-checked by breaking the implementation, confirming red, and restoring.

**Adversarial review found two survivors in the first round. Both are now caught:**

| # | mutation | first round | now | which tests die |
|---|---|---|---|---|
| **M7** | `setTimeout(done, timeoutMs)` -> `setTimeout(done, 1)` | **SURVIVED 5/0** | **1 fail** | hidden-tab |
| **M10** | revert the call site with `requestAnimationFrame` wrapped onto the next line | **SURVIVED 5/0** | **1 fail** | no-unbounded-wait guard |

M7 survived because mocked timers only fire on `tick()`, so one `tick(1000)` passes for any positive delay — a 1000 -> 1 typo would have shipped green. The test now asserts **not settled at 999** and **settled at 1000**, making the magnitude load-bearing. M10 survived because the scanner required both substrings on one line; it now scans a **10-line forward window**, exempts an already-bounded wait by looking for a timer in that window, and covers `useIDS.ts`, `ClashPanel.tsx` and `basketSave.ts` as well as the original two files.

**A second review round (real CodeRabbit run) found one more survivor, plus a dead branch:**

| # | mutation | result | note |
|---|---|---|---|
| **N2** | delete the sync-rAF late cancel | **SURVIVED 20/0** | **not fixed by a test — the branch was deleted** |
| N1 | delete `cancelFrame()` on the timeout path | 1 fail | the leak the review found |
| N3 | call `cancelAnimationFrame` unguarded | 2 fail | non-DOM host must not throw |
| N9 | make `cancelFrame` a no-op | 1 fail | |

N2 is the honest one: `if (settled) cancelFrame()` after `raf(done)` only fires for a host that invokes the callback synchronously, and a real `requestAnimationFrame` never does. Once the callback has fired there is nothing left to cancel, so the branch had **no observable behaviour** — there was no test to write. I deleted it under the anti-cruft rule rather than inventing coverage for unreachable code.

**Full table (all mutations, all caught):**

| # | mutation | result | which tests die |
|---|---|---|---|
| — | **control** | 5 pass / 0 fail | — |
| M1 | delete the `setTimeout` fallback | 3 / **2 fail** | hidden-tab; timer-cleared |
| M2 | delete the `raf(done)` call | 2 / **3 fail** | hidden-tab; visible-tab; timer-cleared |
| M3 | delete `clearTimeout(timer)` | 4 / **1 fail** | timer-cleared |
| M4 | delete the non-positive `timeoutMs` guard | 4 / **1 fail** | non-positive bound |
| M5 | revert the `useIfcLoader` call site (same line) | 4 / **1 fail** | no-unbounded-wait guard |
| M6 | revert a `useClash` call site (same line) | 4 / **1 fail** | no-unbounded-wait guard |
| M7 | `timeoutMs` -> `1` (bound magnitude) | 4 / **1 fail** | hidden-tab |
| M10 | revert the call site, frame wrapped to next line | 4 / **1 fail** | no-unbounded-wait guard |
| M11 | revert `useIDS`'s hand-rolled bounded race to a bare wait | 4 / **1 fail** | no-unbounded-wait guard |
| M12 | strip a `FRAME-WAIT-ALLOW` marker | 4 / **1 fail** | no-unbounded-wait guard |
| N1 | delete `cancelFrame()` on the timeout path | **1 fail** | frame-retracted |
| N3 | call `cancelAnimationFrame` unguarded | **2 fail** | frame-retracted; no-canceller-host |
| N9 | make `cancelFrame` a no-op | **1 fail** | frame-retracted |
| N4 | reset clears the flag but keeps the listener | **1 fail** | reset-detaches |
| N5 | drop `was_hidden` from the payload | **2 fail** | was_hidden false; was_hidden true |
| N6 | `total_csg_failures ?? undefined` -> `\|\| undefined` | **1 fail** | csg-failures zero |
| N7 | milestone `!= null` -> truthy check | **1 fail** | milestone zero |
| N8 | round `file_size_mb` to an integer | **1 fail** | fingerprint precision |
| — | **control** (visibilityWitness) | 5 pass / 0 fail | — |
| V1 | count every `visibilitychange`, not just hides | 4 / **1 fail** | stays-visible |
| V2 | drop the already-hidden-at-start case | 4 / **1 fail** | started-hidden |
| V3 | compare against `0` instead of the snapshot | 4 / **1 fail** | not-retro-tainted |
| V4 | reinstall the listener per call | 4 / **1 fail** | installed-once |
| V5 | never register the listener | 2 / **3 fail** | hidden-partway; not-retro-tainted; installed-once |
| V6 | (see N4) reset leaks the listener | **1 fail** | reset-detaches |
| — | **restored** | 5 / 0 and 5 / 0 | — |

Every test is killed by at least one mutation and every mutation is caught; **no test survived its own revert.** M11 and M12 verify the mutation actually applied (`setTimeout(done, 200)` occurrences: 1 -> 0) rather than silently no-opping.

The tests assert on a `settled` flag after draining microtasks rather than `await`ing the promise, so a broken implementation **fails** instead of hanging the runner — a hang is indistinguishable from a stuck CI job, and these tests exist to be broken on purpose.

Verification, root turbo only:
- `pnpm typecheck` — 36/36 tasks green
- `pnpm test` — 86/86 tasks green; viewer lane 3211 tests, 3205 pass, 0 fail, 6 skipped
- No Rust in the diff, so the clippy gate and `cargo test --workspace` are not applicable.
- No published `packages/*` in the diff (`apps/viewer` is not published), so no changeset and no API-surface update.

---

## Honestly disclosed gaps

1. **This is not #2379, and I did not fix #2379.** #2379 is a main thread pinned at ~100% CPU — a tight numeric loop that burns cycles. This bug is the opposite: an *idle* park with no CPU use. They present similarly in `total_elapsed_ms` and share the "load never finishes" symptom, which is exactly why they need separating. #2379 stays open.
2. **The strongest lead on #2379, unverified, recorded here so it is not lost.** `packages/parser/src/source-bytes.ts:117` computes an FNV-1a over the *whole source* byte-at-a-time, lazily forced by the `contentKey` getter (`:161`). Three always-mounted overlay hooks (`useGridLines3D.ts:66`/`:131`, `useAlignmentLines3D.ts:58`/`:122`, `useSymbolicAnnotations.ts:151` and three more) call `sourceKey(store)` **before** the cheap `hasEntityType` guard that exists to avoid exactly this class of full-source work — and they are keyed on a `useActiveStores()` memo over `models`, which `appendGeometryBatch` gives a fresh Map identity on every batch. On the 342 MB model in #2379 that is a 342-million-iteration zero-allocation integer loop on the main thread, which matches the reporter's `sample` output (one hot JIT'd function, samples across adjacent PCs, flat RSS) precisely. It is memoised per accessor, so it should be a one-time cost rather than an indefinite wedge — unless a load path mints a second accessor, and there are three sites that do (`columnar-parser.ts:590`, `viewerModelIngest.ts:118`, `sourceBytesFromTransfer` at `source-bytes.ts:270`, which is handed `null` by `toTransferable`). I did **not** ship this: I cannot reproduce #2379 without the 342 MB model, and shipping a parser change on an unverified hypothesis is how a fix gets manufactured to have something to fix. The discriminator is one breakpoint on `source-bytes.ts:168`.
3. **A separate real cost I measured but did not fix.** `BVH.build` (`packages/spatial/src/bvh.ts:113`) re-`sort()`s the index slice at every node, giving O(N log^2 N), and `buildSpatialIndexAsync` time-slices only phase 1 while calling phase 2 "fast enough synchronously". Measured on this machine (warmed, best of 3): 21 ms at 6.7k meshes, 296 ms at 60k, 826 ms at 120k, **1715 ms at 200k** — a single uninterruptible main-thread block, and 3-5x that on a mid-range laptop. Real, but it is not the cause of any open issue and it does not belong in a fix for #2385; it is recorded in the ledger with the numbers so nobody re-measures it.
4. **An unexplained geometry-output change — my first framing was refuted by my own data, now filed as #2388.** I originally said the `4423296 -> 4432196` step spanned two builds with zero geometry commits, so it was either fingerprint collision or run-to-run nondeterminism. The raw rows say something sharper: build `1aa498e26339` produced **both** counts — 4423296 for two persons and 4432196 for a third. **The split is within one build**, which makes every commit-range argument moot, and makes collision implausible (it would need two files matching to ±5 KB and ±0 meshes while differing 0.2% in triangles). `mesh_count` is 6668 and `file_size_mb` is 76.73 on all 11 loads, so the mesh **roster** is identical and ~8900 extra triangles are distributed *within* existing meshes. That points to a third hypothesis I had not considered: **environment-conditional triangulation on a deterministic code path**, most plausibly a CSG void cut that failed and fell back under memory pressure — which is exactly what `GeometryDiagnostics.totalCsgFailures` exists to report. If that is the mechanism it is **known-by-design variance, not a latent determinism defect**: the CI determinism manifests run pinned fixtures under controlled memory and would not catch fallback variance by construction. This PR therefore adds `total_csg_failures` to `ifc_model_loaded` so the next occurrence is attributable without a repro. My earlier suggestion to probe `?geomWorkers=N` was **weak and I withdraw it** — `useIfcLoader.ts:1400-1406` documents that worker count cannot affect output (disjoint deterministic element slices), so the codebase predicts that probe comes back clean. The right probe is two loads of the same file on one build, diffing per-element triangle counts with `totalCsgFailures` captured.
5. **One review finding rejected: a test that drives `loadFile` end-to-end.** The gap is real and I am not disputing it — my call-site mutations (M5/M6/M10) prove the *call* exists, not the *outcome*, so "`closeGeometryIterator` is now reached" remains argued from the code rather than executed by a test. I rejected the proposed form because building it would test the mocks, not the loader: `loadFile` is a 1400-line `useCallback` inside a React hook, and `apps/viewer` has **no React or jsdom test setup at all** — every one of its ~800 test suites exercises extracted pure logic. Standing up React + jsdom + module mocks for the store, renderer, wasm geometry stream, parser worker, IndexedDB cache, posthog and toast would contradict both the package convention ("match the package's existing convention") and AGENTS.md's rule against tests that assert a mock's return value. What I did instead was extract the half that *can* be tested faithfully: the `ifc_model_loaded` payload now goes through `buildModelLoadedPayload`, so `was_hidden` and `total_csg_failures` are pinned by real assertions at the real construction site (N5-N8). What stays unproven by test: that the hook passes the correct *values* into that builder, and that `closeGeometryIterator` is reached. Closing those honestly needs the completion sequence extracted from the hook — a refactor of the streaming loop's control flow that does not belong in a fix PR.
6. **No browser repro.** The fix is proven by unit tests and by the impossibility argument on the field data (a 25-hour load of a 6 MB file), not by driving a real hidden tab. The `visibilitychange`-aware variant (resolve immediately when the document is already hidden) would be tighter than a timer, but the timer subsumes it and cannot race, so I chose the simpler correct thing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model loading reliability when the viewer is running in a background or hidden browser tab.
  * Prevented clash detection and duplicate scans from waiting indefinitely.
  * Improved BCF viewpoint and thumbnail capture to ensure screenshots reflect the displayed frame.

* **Improvements**
  * Enhanced model-load diagnostics, including visibility context and geometry-processing failures.
  * Added clearer guidance for interpreting performance telemetry and hidden-tab timing data.

* **Tests**
  * Added comprehensive coverage for frame waits, visibility tracking, telemetry, and screenshot timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->