### PR TITLE
fix(mcp): let an init() failure reach dispose() in the four export tools

### DIFF
--- a/.changeset/export-tools-init-outside-try.md
+++ b/.changeset/export-tools-init-outside-try.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/mcp": patch
+---
+
+Move `await gp.init()` inside the `try` in `export_glb`, `export_obj`, `export_ifcx`, and `export_usd`, so an `init()` rejection reaches `dispose()` instead of skipping it.
+
+All four handlers in `packages/mcp/src/tools/export.ts` called `await gp.init()` before the `try { ... } finally { gp.dispose(); }` block, so an `init()` rejection bypassed `dispose()` entirely. `packages/mcp/src/tools/clash.ts` already used the correct shape; all four export tools now match it.
+
+Scope, stated precisely: this makes the cleanup path *reachable*, which is the shape the codebase already standardises on, but on today's code the recovered `dispose()` is a no-op. `IfcLiteBridge.init()` catches its own failures and calls `reset()`, which nulls `ifcApi` without calling `free()` (`packages/geometry/src/ifc-lite-bridge.ts:229`), and `dispose()` is optional-chained on that now-null handle. So a WASM handle allocated before a late `init()` throw is still not freed after this change — the leak lives one layer down, in the bridge's own error path, and is tracked separately. This change is correct and defensive, but it should not be read as closing that leak.

--- a/packages/mcp/src/tools/export-init-dispose.test.ts
+++ b/packages/mcp/src/tools/export-init-dispose.test.ts
@@ -1,0 +1,220 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `export_glb` / `export_obj` / `export_ifcx` / `export_usd` all follow:
+ *
+ *   const gp = new GeometryProcessor();
+ *   await gp.init();
+ *   try { ... } finally { gp.dispose(); }
+ *
+ * `gp.init()` sitting outside the `try` (#2342) means a rejection there skips
+ * `dispose()` entirely — the correct shape (already used by
+ * `packages/mcp/src/tools/clash.ts`) is `try { await gp.init(); ... } finally
+ * { gp.dispose(); }`. `GeometryProcessor` is mocked so `init()` can be made to
+ * reject deterministically; the real compiled pipeline is covered elsewhere
+ * (`scripts/test-wasm-contract.mjs`, the e2e export specs).
+ *
+ * What these tests pin, stated precisely: that `dispose()` is REACHED on the
+ * init-failure path. They do not pin that a WASM handle is freed, and on
+ * today's code it is not — `IfcLiteBridge.init()` catches its own failures and
+ * calls `reset()`, which nulls `ifcApi` without `free()`, so the recovered
+ * `dispose()` optional-chains to a no-op. That leak lives in the bridge's error
+ * path and is tracked separately; do not read a green run here as evidence the
+ * handle was released.
+ */
+
+import { mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const gp = vi.hoisted(() => {
+  const init = vi.fn(async () => undefined);
+  const exportGlb = vi.fn();
+  const exportObj = vi.fn();
+  const exportIfcx = vi.fn();
+  const exportUsd = vi.fn();
+  const dispose = vi.fn();
+  class GeometryProcessor {
+    init = init;
+    exportGlb = exportGlb;
+    exportObj = exportObj;
+    exportIfcx = exportIfcx;
+    exportUsd = exportUsd;
+    dispose = dispose;
+  }
+  return { init, exportGlb, exportObj, exportIfcx, exportUsd, dispose, GeometryProcessor };
+});
+
+vi.mock('@ifc-lite/geometry', () => ({
+  GeometryProcessor: gp.GeometryProcessor,
+  isNoRenderGeometryError: () => false,
+}));
+
+import type { ToolContext } from '../context.js';
+import {
+  DEFAULT_CONFIG,
+  InMemoryModelRegistry,
+  NOOP_PROGRESS,
+  SILENT_LOGGER,
+} from '../context.js';
+import { fullScope } from '../auth/scope.js';
+import { loadIfcModel } from '../loader.js';
+import { exportTools } from './export.js';
+
+/**
+ * Assemble a minimal GLB (12-byte header + JSON chunk + BIN chunk), same
+ * layout as `packages/export/src/glb.test.ts`'s `buildGlb`, so `export_glb`'s
+ * `countGlbMeshes` defense-in-depth check sees a non-zero mesh count on the
+ * success path.
+ */
+function buildGlb(json: unknown): Uint8Array {
+  const jsonBytes = new TextEncoder().encode(JSON.stringify(json));
+  const pad4 = (n: number) => (4 - (n % 4)) % 4;
+  const jsonChunkLen = jsonBytes.length + pad4(jsonBytes.length);
+  const total = 12 + 8 + jsonChunkLen + 8;
+  const out = new Uint8Array(total);
+  const dv = new DataView(out.buffer);
+  let o = 0;
+  dv.setUint32(o, 0x46546c67, true); o += 4; // magic 'glTF'
+  dv.setUint32(o, 2, true); o += 4; // version
+  dv.setUint32(o, total, true); o += 4; // total length
+  dv.setUint32(o, jsonChunkLen, true); o += 4;
+  dv.setUint32(o, 0x4e4f534a, true); o += 4; // 'JSON'
+  out.set(jsonBytes, o); o += jsonBytes.length;
+  for (let i = 0; i < pad4(jsonBytes.length); i++) out[o++] = 0x20;
+  dv.setUint32(o, 0, true); o += 4; // zero-length BIN chunk
+  dv.setUint32(o, 0x004e4942, true); o += 4; // 'BIN\0'
+  return out;
+}
+
+const MODEL = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('m','2026',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1= IFCPROJECT('0000000000000000000PRJ',$,'Proj',$,$,$,$,(#20),#30);
+#20= IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#21,$);
+#21= IFCAXIS2PLACEMENT3D(#22,$,$);
+#22= IFCCARTESIANPOINT((0.,0.,0.));
+#30= IFCUNITASSIGNMENT((#31));
+#31= IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#40= IFCLOCALPLACEMENT($,#21);
+#41= IFCBUILDINGSTOREY('0000000000000000000STO',$,'L01',$,$,#40,$,$,.ELEMENT.,0.);
+#72= IFCWALL('0000000000000000000WAL',$,'Wall A',$,$,#40,$,'tagA',$);
+ENDSEC;
+END-ISO-10303-21;
+`;
+
+const exportGlbTool = exportTools.find((t) => t.name === 'export_glb')!;
+const exportObjTool = exportTools.find((t) => t.name === 'export_obj')!;
+const exportIfcxTool = exportTools.find((t) => t.name === 'export_ifcx')!;
+const exportUsdTool = exportTools.find((t) => t.name === 'export_usd')!;
+
+let tmp: string;
+let ctx: ToolContext;
+
+beforeAll(async () => {
+  tmp = await realpath(await mkdtemp(join(tmpdir(), 'ifc-lite-mcp-export-init-')));
+  await writeFile(join(tmp, 'm.ifc'), MODEL, 'utf-8');
+});
+
+afterAll(async () => {
+  await rm(tmp, { recursive: true, force: true });
+});
+
+beforeEach(async () => {
+  gp.init.mockReset();
+  gp.init.mockImplementation(async () => undefined);
+  gp.exportGlb.mockReset();
+  gp.exportObj.mockReset();
+  gp.exportIfcx.mockReset();
+  gp.exportUsd.mockReset();
+  gp.dispose.mockReset();
+  ctx = {
+    registry: new InMemoryModelRegistry(),
+    scope: fullScope(),
+    progress: NOOP_PROGRESS,
+    log: SILENT_LOGGER,
+    signal: new AbortController().signal,
+    config: { ...DEFAULT_CONFIG, allowedPaths: [tmp] },
+  };
+  ctx.registry.add(await loadIfcModel(join(tmp, 'm.ifc'), { modelId: 'm' }));
+});
+
+describe.each([
+  { name: 'export_glb', tool: () => exportGlbTool, out: 'out.glb' },
+  { name: 'export_obj', tool: () => exportObjTool, out: 'out.obj' },
+  { name: 'export_ifcx', tool: () => exportIfcxTool, out: 'out.ifcx' },
+  { name: 'export_usd', tool: () => exportUsdTool, out: 'out.usda' },
+])('$name: init() rejection', ({ tool, out }) => {
+  it('still disposes the processor when init() rejects after allocating', async () => {
+    const initError = new Error('WASM init failed after allocating the IfcAPI handle');
+    gp.init.mockImplementation(async () => {
+      throw initError;
+    });
+    const filePath = join(tmp, out);
+
+    await expect(tool().handler({ file_path: filePath }, ctx)).rejects.toThrow(initError);
+
+    // This is the assertion that matters: dispose() must actually run on the
+    // init-failure path, not merely that the call rejected (a bare `rejects`
+    // assertion would pass identically before and after the fix).
+    expect(gp.dispose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('export_glb tool: bounding control', () => {
+  it('disposes exactly once and returns the correct result on success', async () => {
+    const glb = buildGlb({ asset: { version: '2.0' }, meshes: [{}] });
+    gp.exportGlb.mockReturnValue(glb);
+    const out = join(tmp, 'ok.glb');
+
+    const res = await exportGlbTool.handler({ file_path: out }, ctx);
+
+    expect(res.isError).toBeUndefined();
+    expect(gp.init).toHaveBeenCalledTimes(1);
+    expect(gp.exportGlb).toHaveBeenCalledTimes(1);
+    expect(new Uint8Array(await readFile(out))).toEqual(glb);
+    expect(res.structuredContent).toMatchObject({ filePath: out, bytes: glb.length });
+    expect(gp.dispose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('export_obj tool: bounding control', () => {
+  it('disposes exactly once and returns the correct result on success', async () => {
+    const obj = new TextEncoder().encode('o Wall A\nv 0 0 0\n');
+    gp.exportObj.mockReturnValue(obj);
+    const out = join(tmp, 'ok.obj');
+
+    const res = await exportObjTool.handler({ file_path: out }, ctx);
+
+    expect(res.isError).toBeUndefined();
+    expect(gp.init).toHaveBeenCalledTimes(1);
+    expect(gp.exportObj).toHaveBeenCalledTimes(1);
+    expect(new Uint8Array(await readFile(out))).toEqual(obj);
+    expect(res.structuredContent).toMatchObject({ filePath: out, bytes: obj.length });
+    expect(gp.dispose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('export_ifcx tool: bounding control', () => {
+  it('disposes exactly once and returns the correct result on success', async () => {
+    const ifcx = new TextEncoder().encode('{"header":{}}');
+    gp.exportIfcx.mockReturnValue(ifcx);
+    const out = join(tmp, 'ok.ifcx');
+
+    const res = await exportIfcxTool.handler({ file_path: out }, ctx);
+
+    expect(res.isError).toBeUndefined();
+    expect(gp.init).toHaveBeenCalledTimes(1);
+    expect(gp.exportIfcx).toHaveBeenCalledTimes(1);
+    expect(new Uint8Array(await readFile(out))).toEqual(ifcx);
+    expect(res.structuredContent).toMatchObject({ filePath: out, bytes: ifcx.length });
+    expect(gp.dispose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/mcp/src/tools/export.ts
+++ b/packages/mcp/src/tools/export.ts
@@ -193,8 +193,8 @@ const exportGlb: Tool = {
     }
     return withIfcBytes(m, async (bytes) => {
       const gp = new GeometryProcessor();
-      await gp.init();
       try {
+        await gp.init();
         let glb: Uint8Array | null;
         try {
           glb = gp.exportGlb(bytes, false, new Uint32Array(), isolated, '');
@@ -265,8 +265,8 @@ const exportObj: Tool = {
     }
     return withIfcBytes(m, async (bytes) => {
       const gp = new GeometryProcessor();
-      await gp.init();
       try {
+        await gp.init();
         const obj = gp.exportObj(bytes, true, new Uint32Array(), isolated);
         if (obj == null) {
           throw new ToolExecutionError({ code: ToolErrorCode.INTERNAL_ERROR, message: 'OBJ export produced no output.' });
@@ -299,8 +299,8 @@ const exportIfcx: Tool = {
     const filePath = await resolveSafePath(input.file_path, ctx, 'write');
     return withIfcBytes(m, async (bytes) => {
       const gp = new GeometryProcessor();
-      await gp.init();
       try {
+        await gp.init();
         const ifcx = gp.exportIfcx(bytes, input.all_properties !== true, true);
         if (ifcx == null) {
           throw new ToolExecutionError({ code: ToolErrorCode.INTERNAL_ERROR, message: 'IFCX export produced no output.' });
@@ -332,8 +332,8 @@ const exportUsd: Tool = {
     const filePath = await resolveSafePath(input.file_path, ctx, 'write');
     return withIfcBytes(m, async (bytes) => {
       const gp = new GeometryProcessor();
-      await gp.init();
       try {
+        await gp.init();
         const usd = gp.exportUsd(bytes);
         if (usd == null) {
           throw new ToolExecutionError({ code: ToolErrorCode.INTERNAL_ERROR, message: 'USD export produced no output.' });


### PR DESCRIPTION
Addresses #2342.

All four export handlers in `packages/mcp/src/tools/export.ts` called `await gp.init()` **before** the `try { ... } finally { gp.dispose(); }` block, so an `init()` rejection skipped the cleanup entirely.

### Four sites, not one

`export_glb` (195), `export_obj` (267), `export_ifcx` (301), `export_usd` (334) all carry the identical shape. `packages/mcp/src/tools/clash.ts:60` already used the correct one, so this aligns the exports with the convention already standardised on. I grepped every `GeometryProcessor` construction site in `packages/mcp/src` — those five are all of them, and `clash.ts` is untouched.

### What this does *not* fix — worth reading before merging

The reorder makes `dispose()` **reachable** on the failure path. It does not free a handle, and I'd rather say that plainly than let the changeset imply otherwise.

`IfcLiteBridge.init()` catches its own failures and calls `this.reset()` (`packages/geometry/src/ifc-lite-bridge.ts:206`), and `reset()` nulls `ifcApi` **without** calling `free()` (line 229). `dispose()` is `this.ifcApi?.free()` — optional-chained. So in the exact scenario the issue names — a late throw after `this.ifcApi = new IfcAPI()` (line 189), e.g. a WASM trap in one of the four `apply*()` calls that follow it — the handle is already null by the time the recovered `dispose()` runs, and the free never happens.

`free()` occurs **exactly once** in the whole bridge, inside `dispose()`. There is no other route to it, so the init-failure path cannot free anything today.

That's a real leak, one layer down in the bridge's own error path. Fixing it there is delicate — `free()` on an instance that just trapped can itself throw, and an unguarded throw in that `catch` would replace the original init error with a less useful one — so it isn't bundled here. A separate change is in progress for it.

The test header and the changeset both state this limitation explicitly, so a future reader can't mistake a green run here for evidence the handle was released.

### `dispose()` after a failed `init()` is safe

Verified before widening the `try`, since the reorder makes that call newly reachable: `init()`'s catch runs `reset()` before every rethrow; `dispose()` is `this.ifcApi?.free(); this.reset();` (optional-chained, documented idempotent at `ifc-lite-bridge.ts:240-244`); and `GeometryProcessor.dispose()` is `this.bridge?.dispose()`. No init-success tracking needed.

### RED, against the pre-fix code

```
FAIL 'export_glb': init() rejection > still disposes the processor when init() rejects after allocating
FAIL 'export_obj': ...
FAIL 'export_ifcx': ...
FAIL 'export_usd': ...
AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
  expect(gp.dispose).toHaveBeenCalledTimes(1);
```

The assertion is on `dispose` actually being **called**. A bare `rejects.toThrow` would have passed identically before and after, proving nothing.

### Bounding controls — pass BEFORE and after

Three success-path tests assert `dispose` called exactly once **and** the correct bytes/result returned, plus the pre-existing `export-usd.test.ts` success test. All four are green against the **unfixed** code too — so the new tests can't be passing merely by rejecting everything, which is the failure mode that matters when a change adds an early-cleanup path.

### Displacement

Widening a `try` changes what its `finally` covers. Checked: `gp` is never returned or referenced outside its owning `withIfcBytes` callback at any of the four sites, and only `gp.init`/`gp.exportX`/`gp.dispose` are called inside the widened block. No caller depends on the processor outliving the function, and the inner `catch` in `export_glb` (the `isNoRenderGeometryError` mapping) is unaffected — it sits below the moved line and still wraps only `exportGlb`.

### Verification

`packages/mcp`: 24 files / 251 tests → 25 files / 258 tests, 0 failures. `tsc --noEmit` clean. Changeset starts with `---` and carries no license header; `@ifc-lite/mcp` has no `"private"` field, so one is required.
