### PR TITLE
fix(viewer): guard import.meta.env reads so the properties-panel tree is testable

### DIFF
--- a/apps/viewer/src/components/viewer/properties/ModelMetadataPanel.importable.test.ts
+++ b/apps/viewer/src/components/viewer/properties/ModelMetadataPanel.importable.test.ts
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Proves `ModelMetadataPanel` (and the tree beneath it — `GeoreferencingPanel`
+ * -> `useIfc` -> `useIfcLoader`/`useIfcServer` -> `utils/ifcConfig.ts`) is
+ * importable under the plain `tsx --test` runner, which does not populate
+ * `import.meta.env` (Vite-only). Before the guard in `ifcConfig.ts`, this
+ * import throws at module-evaluation time and no test in this tree can run.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { ModelMetadataPanel } from './ModelMetadataPanel.js';
+
+describe('ModelMetadataPanel import', () => {
+  it('is importable and is a function component', () => {
+    assert.equal(typeof ModelMetadataPanel, 'function');
+  });
+});

--- a/apps/viewer/src/utils/ifcConfig.ts
+++ b/apps/viewer/src/utils/ifcConfig.ts
@@ -13,8 +13,14 @@ import type { DynamicBatchConfig } from '@ifc-lite/geometry';
 // Server Configuration
 // ============================================================================
 
+// `import.meta.env` is undefined under the Node `tsx --test` runner (no Vite
+// define plugin), and this module is loaded transitively by `useIfc` ->
+// `useIfcLoader`/`useIfcServer`, which many viewer components (e.g.
+// `GeoreferencingPanel`, `ModelMetadataPanel`) pull in. The optional chaining
+// keeps the module-top-level read safe there (same contract as
+// `lib/analytics.ts` and `store/slices/cesiumSlice.ts`). Do NOT drop it.
 /** IFC server URL - set via environment variable for server-side IFC processing */
-export const SERVER_URL = import.meta.env.VITE_IFC_SERVER_URL || import.meta.env.VITE_SERVER_URL || '';
+export const SERVER_URL = import.meta.env?.VITE_IFC_SERVER_URL || import.meta.env?.VITE_SERVER_URL || '';
 
 /**
  * Enable server-side IFC parsing (disabled by default — uses client-side WASM).
@@ -30,7 +36,7 @@ export const SERVER_URL = import.meta.env.VITE_IFC_SERVER_URL || import.meta.env
  *   VITE_IFC_SERVER_URL=https://ifc-server.example.com
  *   VITE_USE_SERVER=true
  */
-export const USE_SERVER = SERVER_URL !== '' && import.meta.env.VITE_USE_SERVER === 'true';
+export const USE_SERVER = SERVER_URL !== '' && import.meta.env?.VITE_USE_SERVER === 'true';
 
 // ============================================================================
 // File Size Thresholds (in bytes unless noted)


### PR DESCRIPTION
Small enabling fix, found while trying to write component tests for the properties-panel tree.

### The problem

`apps/viewer/src/utils/ifcConfig.ts` reads `import.meta.env` at module top level:

```ts
export const SERVER_URL = import.meta.env.VITE_IFC_SERVER_URL || import.meta.env.VITE_SERVER_URL || '';
export const USE_SERVER = SERVER_URL !== '' && import.meta.env.VITE_USE_SERVER === 'true';
```

Under the Node `tsx --test` runner there is no Vite define plugin, so `import.meta.env` is `undefined` and the read throws at import time. That matters well beyond this one module: `ifcConfig` is pulled in transitively via `useIfc` → `useIfcLoader`/`useIfcServer`, which a large part of the viewer component tree imports — `GeoreferencingPanel`, `ModelMetadataPanel`, and others. So the whole subtree was untestable, and the failure looked like an unrelated import error rather than a config read.

### The fix

Optional-chain both reads. This is the same contract two modules in the repo already use for exactly this reason — `lib/analytics.ts` and `store/slices/cesiumSlice.ts` — so it's an existing convention, not a new one.

Behaviour in the browser is unchanged: `import.meta.env` is always defined there, and `?.` only alters the case where it isn't.

The comment says explicitly not to drop the optional chaining, since the reason is non-local and the next reader would otherwise see it as redundant noise.

### Test

`ModelMetadataPanel.importable.test.ts` asserts the module can be imported at all under `tsx --test`. It fails without this change (import-time throw) and passes with it — 1/1 passing. It's deliberately narrow: it pins the importability contract that the future component tests depend on, without asserting anything about rendering.

No changeset — `apps/viewer` is `"private": true`.
