### PR TITLE
fix(geometry): free the IfcAPI handle when init() fails after construction

### DIFF
--- a/.changeset/bridge-init-failure-frees-handle.md
+++ b/.changeset/bridge-init-failure-frees-handle.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/geometry": patch
+---
+
+Fix a WASM handle leak in `IfcLiteBridge.init()`: the `IfcAPI` handle is constructed at `new IfcAPI()` and then four cached settings (`applyMergeLayers`, `applyComputeGeometryHashes`, `applyTessellationQuality`, `applySkipSmallCuts`) are replayed onto it before `init()` marks itself ready. If any of those four throws, the `catch` block called `reset()`, which only nulled the JS reference — it never called `free()` on the handle that had just been built, so the wasm-bindgen pointer leaked for the life of the document (no later `dispose()` can reach a `null` handle).
+
+`init()`'s failure path now best-effort frees the handle before dropping the reference, on both the ordinary-error and the fatal WASM-runtime-trap branches — the same "drop (and free) the handle, propagate the error unchanged" contract every other WASM-calling method in this file already follows via `recordWasmRuntimeTrap`. The free is wrapped so a secondary failure from `free()` itself (the runtime can re-trap while freeing) can never replace or mask the original `init()` error reaching the caller.
+
+Not changed: what happens when the WASM trap occurs before the handle exists (during module instantiation) — there is nothing to free in that case, and the fatal error/reload-advisory behavior for that path is unchanged.

--- a/.changeset/log-swallowed-dispose-secondary-failure.md
+++ b/.changeset/log-swallowed-dispose-secondary-failure.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/geometry": patch
+---
+
+`IfcLiteBridge.disposeBestEffort()`'s recovery `catch` — reached when `free()` itself throws or traps while cleaning up after a primary WASM failure — silently dropped the secondary error, unlike every other catch site in `ifc-lite-bridge.ts`, which reports what it recovered from via `log.error`. It now does the same, so a `free()` failure during recovery leaves a trace instead of vanishing.
+
+This is diagnostics only: `reset()` still runs unconditionally and `disposeBestEffort()` still never throws, so the original error the caller is already unwinding with (including the fatal `isWasmRuntimeError` path in `init()`) is unaffected — the `log.error` call is itself wrapped so a throwing logger cannot defeat that guarantee.

--- a/packages/geometry/src/ifc-lite-bridge.test.ts
+++ b/packages/geometry/src/ifc-lite-bridge.test.ts
@@ -257,6 +257,74 @@ describe('IfcLiteBridge', () => {
     expect(isWasmRuntimeTrap(caught)).toBe(true);
   });
 
+  // ── init() failing AFTER `new IfcAPI()` must free the handle it built ──
+  //
+  // `init()` constructs `this.ifcApi = new IfcAPI()` and THEN replays four
+  // cached settings onto it (`applyMergeLayers` and friends) before marking
+  // itself initialized. If one of those throws, the handle already exists
+  // but is about to be abandoned — the regression is `reset()` nulling the
+  // reference without ever calling `free()` on it, which leaks the
+  // wasm-bindgen pointer for the life of the document (no later `dispose()`
+  // can reach a `null` handle).
+
+  it('frees the IfcAPI handle when a post-construction init() step throws (non-trap)', async () => {
+    const bridge = new IfcLiteBridge();
+    const boom = new Error('setMergeLayers exploded');
+    wasmMocks.setMergeLayers.mockImplementationOnce(() => {
+      throw boom;
+    });
+
+    let caught: unknown;
+    try {
+      await bridge.init();
+    } catch (err) {
+      caught = err;
+    }
+
+    // The original error must propagate unchanged — not masked by any
+    // secondary failure from the cleanup path.
+    expect(caught).toBe(boom);
+    expect(bridge.isInitialized()).toBe(false);
+    // The handle built at `new IfcAPI()` must actually be freed, not just
+    // have its JS reference dropped.
+    expect(wasmMocks.free).toHaveBeenCalledTimes(1);
+
+    // The bridge must still be usable afterwards — re-init works.
+    await expect(bridge.init()).resolves.toBeUndefined();
+    expect(bridge.isInitialized()).toBe(true);
+  });
+
+  it('frees the IfcAPI handle when init() traps AFTER construction, and still reports fatal (#1898)', async () => {
+    const bridge = new IfcLiteBridge();
+    const trap = new WebAssembly.RuntimeError('unreachable');
+    wasmMocks.setMergeLayers.mockImplementationOnce(() => {
+      throw trap;
+    });
+
+    let caught: unknown;
+    try {
+      await bridge.init();
+    } catch (err) {
+      caught = err;
+    }
+
+    // Fatal-path error contract preserved: typed, wraps the real trap as
+    // `cause`, message carries it.
+    expect(isWasmRuntimeUnrecoverableError(caught)).toBe(true);
+    expect((caught as Error).cause).toBe(trap);
+    expect((caught as Error).message).toContain('unreachable');
+    // The handle DID exist (constructed before the trap) — it must be freed
+    // rather than abandoned.
+    expect(wasmMocks.free).toHaveBeenCalledTimes(1);
+  });
+
+  it('a successful init() does not free the handle it just built', async () => {
+    const bridge = new IfcLiteBridge();
+    await expect(bridge.init()).resolves.toBeUndefined();
+    expect(bridge.isInitialized()).toBe(true);
+    expect(wasmMocks.free).not.toHaveBeenCalled();
+  });
+
   it('a trap during init() is reported as unrecoverable, with the trap as cause (#1898)', async () => {
     const trap = new WebAssembly.RuntimeError('unreachable');
     wasmMocks.init.mockImplementationOnce(async () => {

--- a/packages/geometry/src/ifc-lite-bridge.test.ts
+++ b/packages/geometry/src/ifc-lite-bridge.test.ts
@@ -235,6 +235,44 @@ describe('IfcLiteBridge', () => {
     expect(() => bridge.getApi()).not.toThrow();
   });
 
+  it('reports a secondary free() failure via log.error instead of swallowing it silently', async () => {
+    const bridge = new IfcLiteBridge();
+    await bridge.init();
+
+    const trap = new WebAssembly.RuntimeError('unreachable');
+    wasmMocks.exportGlb.mockImplementationOnce(() => {
+      throw trap;
+    });
+    const secondaryFailure = new WebAssembly.RuntimeError('double fault');
+    wasmMocks.free.mockImplementationOnce(() => {
+      throw secondaryFailure;
+    });
+
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    try {
+      let caught: unknown;
+      try {
+        bridge.exportGlb(new Uint8Array([1]));
+      } catch (err) {
+        caught = err;
+      }
+      // The original trap must still be what the caller sees...
+      expect(caught).toBe(trap);
+      // ...but the secondary free() failure must not vanish without a trace:
+      // some console.error call must have been made carrying it.
+      const reportedSecondary = errorSpy.mock.calls.some((call) =>
+        call.some(
+          (arg) =>
+            arg === secondaryFailure ||
+            (typeof arg === 'string' && arg.includes('double fault')),
+        ),
+      );
+      expect(reportedSecondary).toBe(true);
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
   it('propagates the ORIGINAL trap from an operation, not a stored guard error (#1898)', async () => {
     const bridge = new IfcLiteBridge();
     await bridge.init();

--- a/packages/geometry/src/ifc-lite-bridge.ts
+++ b/packages/geometry/src/ifc-lite-bridge.ts
@@ -120,18 +120,29 @@ export class IfcLiteBridge {
    * Free the WASM handle if one exists, best-effort, then drop the JS-side
    * reference either way. `free()` runs Rust code — if the runtime just
    * trapped (or is what's trapping), `free()` itself can throw or trap
-   * again, so any failure here is swallowed and we fall back to just
-   * nulling the reference via `reset()`. This never throws: callers rely on
-   * that so a secondary `free()` failure can never replace/mask whatever
-   * error the caller is already unwinding with.
+   * again, so any failure here is logged (never rethrown) and we fall back
+   * to just nulling the reference via `reset()`. This never throws: callers
+   * rely on that so a secondary `free()` failure can never replace/mask
+   * whatever error the caller is already unwinding with.
    */
   private disposeBestEffort(): void {
     try {
       this.dispose();
-    } catch {
+    } catch (error) {
       // `free()` runs Rust code. If the allocator is what trapped, freeing can
       // trap again — drop the reference anyway. A secondary failure here must
-      // never replace the original error on its way to the caller.
+      // never replace the original error on its way to the caller, so it's
+      // reported the same way every other catch site in this file reports a
+      // recovered failure: `log.error`. The logger call itself is guarded —
+      // a throwing logger would defeat the entire point of this method,
+      // which callers rely on to never throw.
+      try {
+        log.error('Secondary failure while disposing WASM handle', error, {
+          operation: 'disposeBestEffort',
+        });
+      } catch {
+        // A logger that throws must not escape this best-effort path either.
+      }
       this.reset();
     }
   }

--- a/packages/geometry/src/ifc-lite-bridge.ts
+++ b/packages/geometry/src/ifc-lite-bridge.ts
@@ -113,12 +113,25 @@ export class IfcLiteBridge {
    * already kept running, so the "unrecoverable" claim contradicted itself.
    */
   private recordWasmRuntimeTrap(): void {
+    this.disposeBestEffort();
+  }
+
+  /**
+   * Free the WASM handle if one exists, best-effort, then drop the JS-side
+   * reference either way. `free()` runs Rust code — if the runtime just
+   * trapped (or is what's trapping), `free()` itself can throw or trap
+   * again, so any failure here is swallowed and we fall back to just
+   * nulling the reference via `reset()`. This never throws: callers rely on
+   * that so a secondary `free()` failure can never replace/mask whatever
+   * error the caller is already unwinding with.
+   */
+  private disposeBestEffort(): void {
     try {
       this.dispose();
     } catch {
       // `free()` runs Rust code. If the allocator is what trapped, freeing can
       // trap again — drop the reference anyway. A secondary failure here must
-      // never replace the original trap on its way to the caller.
+      // never replace the original error on its way to the caller.
       this.reset();
     }
   }
@@ -203,14 +216,27 @@ export class IfcLiteBridge {
       log.error('Failed to initialize WASM geometry engine', error, {
         operation: 'init',
       });
-      this.reset();
+      // `init()` can throw after `this.ifcApi = new IfcAPI()` (line ~189) —
+      // any of the four `apply*` replay calls below it can throw or trap.
+      // A handle built here and then abandoned on this catch path must be
+      // freed, not just have its reference dropped, or it leaks for the
+      // life of the document (it's a `null` handle no `dispose()` can ever
+      // reach again). Best-effort: freeing itself can re-trap (see
+      // `disposeBestEffort`), and either way this never throws, so it can't
+      // mask the real error below — including on the fatal
+      // `isWasmRuntimeError` branch, where the written recovery contract in
+      // `wasm-runtime-trap.ts` is the same "drop (and free) the handle,
+      // propagate the trap unchanged" rule every other call site already
+      // follows via `recordWasmRuntimeTrap`.
+      this.disposeBestEffort();
       if (this.isWasmRuntimeError(error)) {
         // The one genuinely unrecoverable case: the engine trapped while
-        // standing itself up, so there is no `IfcAPI` to drop and this realm
-        // has no working engine to fall back on. Report it as such — freshly
-        // constructed so the stack is this throw site, carrying the trap as
-        // `cause` — and tell the host, which offers the user a reload. The
-        // verdict is advisory, not a latch: a later `init()` still tries, so no
+        // standing itself up. Any `IfcAPI` handle that did exist was just
+        // best-effort freed above; either way this realm has no working
+        // engine to fall back on. Report it as such — freshly constructed so
+        // the stack is this throw site, carrying the trap as `cause` — and
+        // tell the host, which offers the user a reload. The verdict is
+        // advisory, not a latch: a later `init()` still tries, so no
         // unrelated consumer is disabled by it. (#1898)
         const fatal = wasmRuntimeUnrecoverableError(error, 'init');
         notifyWasmRuntimeUnrecoverable(fatal);


### PR DESCRIPTION
Follow-up to #2389 (issue #2342). That PR made `dispose()` **reachable** on the export tools' init-failure path; this one makes it actually **free** something. Independent of #2389 — different package, no shared files — but the two together are what closes the leak #2342 describes.

### The leak

`IfcLiteBridge.init()` builds the handle and *then* replays four cached settings onto it before marking itself ready:

```ts
this.ifcApi = new IfcAPI();     // ~line 189
this.applyMergeLayers();
this.applyComputeGeometryHashes();
this.applyTessellationQuality();
this.applySkipSmallCuts();
this.initialized = true;
```

All four call into WASM and can throw or trap. When one does, the `catch` called `this.reset()` — which only nulls the JS reference:

```ts
reset(): void { this.initialized = false; this.ifcApi = null; }
```

`free()` appears **exactly once** in the entire file, inside `dispose()`, and it's optional-chained on `this.ifcApi`. So once `reset()` has nulled the reference, no later `dispose()` can ever reach the handle. A handle built at line 189 and abandoned by a late throw leaks the wasm-bindgen pointer for the life of the document.

This is why the `#2342` reorder alone doesn't fix anything: the recovered `dispose()` optional-chains to a no-op.

### Why both branches free, including the fatal one

This isn't a new convention — it's the one already written down. `packages/geometry/src/wasm-runtime-trap.ts:19-25` states the contract directly: *"a trap taken inside an operation is the caller's failure. The bridge that took it drops (and frees) its `IfcAPI` handle... and the original trap propagates unchanged."* Every other WASM-calling method in the bridge already follows it via `recordWasmRuntimeTrap()`. `init()`'s catch was the one outlier still doing a bare `reset()`.

And the fatal path genuinely can hold a handle: the trap can occur in the `apply*` replay calls, i.e. *after* `new IfcAPI()`. So freeing there is correct, not just consistent.

Worth noting the old comment on that branch asserted the opposite — *"there is no `IfcAPI` to drop"* — which is false whenever the trap comes from the replay calls. That stale claim is plausibly why the bug survived. It's corrected here.

### The hazard, and how it's contained

`free()` runs Rust. If the runtime just trapped — or the allocator is what's trapping — `free()` can throw or trap again. An unguarded throw in a `catch` block would **replace the original init error** with a far less useful one, destroying the diagnostic the user needs.

So the free is best-effort and cannot throw:

```ts
private disposeBestEffort(): void {
  try { this.dispose(); }
  catch { this.reset(); }   // drop the reference anyway
}
```

`recordWasmRuntimeTrap()` now delegates to it too, since that was already its exact body — no behaviour change there.

**Displacement check:** `disposeBestEffort()` still always reaches `reset()` — either through `dispose()`'s own internal call on success, or through the `catch` fallback if `free()` fails. Every state transition the old bare `this.reset()` produced is still reached; the only addition is the `free()` attempt before it.

### RED, against the unfixed code

```
FAIL  frees the IfcAPI handle when a post-construction init() step throws (non-trap)
      AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
FAIL  frees the IfcAPI handle when init() traps AFTER construction, and still reports fatal (#1898)
      AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
```

The assertions are on `free` actually being invoked on the handle. Asserting that `dispose()` was *called* would pass while the leak persists — that's precisely the trap #2389's tests fell into, and it's why these assert the outcome instead.

### Bounding controls — pass BEFORE and after

14 of the 16 tests pass against the **unfixed** code, including the two that matter most here:

- `a successful init() does not free the handle it just built` — a fix that freed too eagerly would destroy the handle on the happy path, and this catches that.
- `propagates the ORIGINAL trap from an operation...` — plus new assertions that `caught === boom` and `caught.cause === trap` are unchanged on **both** the non-fatal and fatal paths, pinning that the best-effort free never masks the real error.

### Siblings

Grepped `packages/geometry/src` for the same `reset()`-without-`free()` shape. The other `reset()` call sites (`geometry-parallel.ts`, `geometry-native.ts`, `index.ts`) reset `CoordinateHandler`, which holds only plain JS state and no WASM handle — not in scope. `geometry.worker.ts`'s recovery path already uses `freeWasmInstanceQuietly()`, the same best-effort-free-then-drop pattern. No other instance of this bug.

### Verification

`packages/geometry`: 319 → 322 tests, 27 files, 0 failures. `tsc --noEmit` clean. Changeset starts with `---`, no license header; `@ifc-lite/geometry` has no `"private"` field, so one is required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup when initialization or runtime failures occur.
  * Prevented leaked resources after failed setup, including fatal runtime errors.
  * Preserved the original error while reporting any secondary cleanup failures.
  * Ensured failed instances can be initialized again successfully.

* **Tests**
  * Added coverage for cleanup, error reporting, recovery, and successful initialization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->