### PR TITLE
fix(viewer,create): correct dead store.source truthiness checks

### DIFF
--- a/.changeset/dead-source-truthy-guards.md
+++ b/.changeset/dead-source-truthy-guards.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/create": patch
+---
+
+Fix `resolveSpatialAnchor`'s four `store.source` guards (#2345): `IfcDataStore.source` is a mandatory accessor object, never `null`/`undefined` — even a source-less store carries `EMPTY_SOURCE_BYTES` — so a plain `if (store.source)` / `if (!store.source)` truthiness check was always true and never actually detected the "no source bytes" case it was written for. Replaced with an explicit `byteLength` check.
+
+No behavior change for real callers: every current call site passes a store this same process just parsed, which always has resident source bytes. Verified with a synthetic empty-source store that the function still fails closed (throws) rather than silently misresolving, in both the old and the new code.

--- a/apps/viewer/src/components/viewer/CommandPalette.tsx
+++ b/apps/viewer/src/components/viewer/CommandPalette.tsx
@@ -553,13 +553,13 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
           finally { gp.dispose(); }
         } },
       { id: 'export:csv-entities', label: 'Export CSV: Entities', keywords: 'spreadsheet properties download', category: 'Export', icon: FileSpreadsheet,
-        action: async () => { const d = useViewerStore.getState().ifcDataStore; if (!d?.source) return; try { downloadFile(await exportCsvFromBytes(d.source.materialize(), 'entities', { includeProperties: true }), 'entities.csv', 'text/csv'); } catch (e) { console.error(e); } } },
+        action: async () => { const d = useViewerStore.getState().ifcDataStore; if (!d || d.source.byteLength <= 0) return; try { downloadFile(await exportCsvFromBytes(d.source.materialize(), 'entities', { includeProperties: true }), 'entities.csv', 'text/csv'); } catch (e) { console.error(e); } } },
       { id: 'export:csv-properties', label: 'Export CSV: Properties', keywords: 'pset spreadsheet download', category: 'Export', icon: FileSpreadsheet,
-        action: async () => { const d = useViewerStore.getState().ifcDataStore; if (!d?.source) return; try { downloadFile(await exportCsvFromBytes(d.source.materialize(), 'properties'), 'properties.csv', 'text/csv'); } catch (e) { console.error(e); } } },
+        action: async () => { const d = useViewerStore.getState().ifcDataStore; if (!d || d.source.byteLength <= 0) return; try { downloadFile(await exportCsvFromBytes(d.source.materialize(), 'properties'), 'properties.csv', 'text/csv'); } catch (e) { console.error(e); } } },
       { id: 'export:csv-quantities', label: 'Export CSV: Quantities', keywords: 'qto spreadsheet download', category: 'Export', icon: FileSpreadsheet,
-        action: async () => { const d = useViewerStore.getState().ifcDataStore; if (!d?.source) return; try { downloadFile(await exportCsvFromBytes(d.source.materialize(), 'quantities'), 'quantities.csv', 'text/csv'); } catch (e) { console.error(e); } } },
+        action: async () => { const d = useViewerStore.getState().ifcDataStore; if (!d || d.source.byteLength <= 0) return; try { downloadFile(await exportCsvFromBytes(d.source.materialize(), 'quantities'), 'quantities.csv', 'text/csv'); } catch (e) { console.error(e); } } },
       { id: 'export:csv-spatial', label: 'Export CSV: Spatial', keywords: 'hierarchy spreadsheet download', category: 'Export', icon: FileSpreadsheet,
-        action: async () => { const d = useViewerStore.getState().ifcDataStore; if (!d?.source) return; try { downloadFile(await exportCsvFromBytes(d.source.materialize(), 'spatial'), 'spatial-hierarchy.csv', 'text/csv'); } catch (e) { console.error(e); } } },
+        action: async () => { const d = useViewerStore.getState().ifcDataStore; if (!d || d.source.byteLength <= 0) return; try { downloadFile(await exportCsvFromBytes(d.source.materialize(), 'spatial'), 'spatial-hierarchy.csv', 'text/csv'); } catch (e) { console.error(e); } } },
       { id: 'export:json', label: 'Export JSON', keywords: 'data entities all download', category: 'Export', icon: FileJson,
         action: () => {
           const d = useViewerStore.getState().ifcDataStore; if (!d) return;

--- a/apps/viewer/src/components/viewer/toolbar/useExportCommands.ts
+++ b/apps/viewer/src/components/viewer/toolbar/useExportCommands.ts
@@ -21,7 +21,7 @@ export function useExportCommands() {
   const { ifcDataStore } = useIfc();
 
   const handleExportCSV = useCallback(async (type: CsvExportType) => {
-    if (!ifcDataStore?.source) return;
+    if (!ifcDataStore || ifcDataStore.source.byteLength <= 0) return;
     try {
       const csv = await exportCsvFromBytes(ifcDataStore.source.materialize(), type, { includeProperties: type === 'entities' });
       const filename = type === 'spatial' ? 'spatial-hierarchy.csv' : `${type}.csv`;

--- a/apps/viewer/src/components/viewer/usd-export-source.test.ts
+++ b/apps/viewer/src/components/viewer/usd-export-source.test.ts
@@ -13,8 +13,28 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { EMPTY_SOURCE_BYTES, IfcParser, type IfcDataStore } from '@ifc-lite/parser';
 import type { FederatedModel } from '@/store/types.js';
-import { isUsdExportableModel } from './usd-export-source.js';
+import { isUsdExportableModel, resolveUsdExportBytes, type UsdExportModel } from './usd-export-source.js';
+
+/** Trivial but valid IFC4 file — just enough for `IfcParser.parseColumnar`. */
+const MINIMAL_IFC = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('t.ifc','',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0proj00000000000000000',$,'P',$,$,$,$,$,$);
+ENDSEC;
+END-ISO-10303-21;`;
+
+async function parsedDataStore(): Promise<IfcDataStore> {
+  return new IfcParser().parseColumnar(
+    new TextEncoder().encode(MINIMAL_IFC).buffer as ArrayBuffer,
+    { disableWorkerScan: true },
+  );
+}
 
 function model(name: string | null): FederatedModel {
   return {
@@ -49,5 +69,51 @@ describe('isUsdExportableModel', () => {
     assert.equal(isUsdExportableModel(model(null)), false);
     assert.equal(isUsdExportableModel(model('scan.glb')), false);
     assert.equal(isUsdExportableModel(model('cloud.las')), false);
+  });
+});
+
+/**
+ * `IfcDataStore.source` is a MANDATORY accessor (#2183, #2345): even the
+ * "no source" state is an object (`EMPTY_SOURCE_BYTES`), never
+ * null/undefined, so a plain `model.ifcDataStore?.source` truthiness check
+ * is always true and can never fall through to step 3 (raw `sourceFile`
+ * bytes). Only `byteLength` distinguishes "has usable bytes" from "does
+ * not" — this suite locks that step 3 still fires for a genuinely
+ * source-less store (server-parsed, synthetic) instead of silently handing
+ * `exportUsd` zero bytes, which produces an empty USD stage with no error.
+ */
+describe('resolveUsdExportBytes', () => {
+  const RAW_FILE_BYTES = new Uint8Array([1, 2, 3, 4, 5]);
+  const noMutationView = () => null;
+
+  function usdModel(ifcDataStore: IfcDataStore | null): UsdExportModel {
+    return {
+      id: 'm',
+      name: 'building',
+      sourceFile: new File([RAW_FILE_BYTES], 'building.ifc'),
+      ifcDataStore,
+      schemaVersion: 'IFC4',
+    };
+  }
+
+  it('falls back to the raw sourceFile bytes when ifcDataStore is null', async () => {
+    const bytes = await resolveUsdExportBytes(usdModel(null), noMutationView);
+    assert.deepEqual(bytes, RAW_FILE_BYTES);
+  });
+
+  it('falls back to the raw sourceFile bytes when the store has an EMPTY source (server-parsed / synthetic)', async () => {
+    const parsed = await parsedDataStore();
+    const store: IfcDataStore = { ...parsed, source: EMPTY_SOURCE_BYTES };
+    const bytes = await resolveUsdExportBytes(usdModel(store), noMutationView);
+    // RED (pre-fix): materialize()'d EMPTY_SOURCE_BYTES yields a zero-length
+    // array here instead — a silent empty USD stage, not an error.
+    assert.deepEqual(bytes, RAW_FILE_BYTES);
+  });
+
+  it('still prefers the parsed store bytes when the store DOES have real source (bounding control)', async () => {
+    const store = await parsedDataStore();
+    const bytes = await resolveUsdExportBytes(usdModel(store), noMutationView);
+    assert.deepEqual(bytes, store.source.materialize());
+    assert.ok(bytes.byteLength > 0);
   });
 });

--- a/apps/viewer/src/components/viewer/usd-export-source.ts
+++ b/apps/viewer/src/components/viewer/usd-export-source.ts
@@ -65,7 +65,7 @@ export async function resolveUsdExportBytes(
       schema: mutationSource.dataStore.schemaVersion,
     }).content;
   }
-  if (model.ifcDataStore?.source) {
+  if (model.ifcDataStore && model.ifcDataStore.source.byteLength > 0) {
     // Whole-file consumer: USD export re-reads the raw STEP.
     return model.ifcDataStore.source.materialize();
   }

--- a/packages/create/src/in-store/resolve-anchor-empty-source.test.ts
+++ b/packages/create/src/in-store/resolve-anchor-empty-source.test.ts
@@ -1,0 +1,80 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `IfcDataStore.source` is a MANDATORY accessor (#2183, #2345): even a
+ * store with no usable bytes carries `EMPTY_SOURCE_BYTES`, never
+ * null/undefined, so a plain `if (store.source)` / `if (!store.source)`
+ * check in `resolve-anchor.ts` never actually fires on a source-less store
+ * — it was dead.
+ *
+ * The maintainer's call that fixing these four guards is "no behavior
+ * change" holds for every REAL call site: `resolveSpatialAnchor` is only
+ * ever invoked (from `create`'s in-store builders) on a store this same
+ * process just parsed, which always carries real, resident source bytes —
+ * an empty-source store never reaches this function today. This suite
+ * pins the hypothetical (currently unreached) case anyway, for the record:
+ * with a synthetic empty-source store (real `entityIndex`, but `source`
+ * swapped to `EMPTY_SOURCE_BYTES`, modelling a hypothetical future
+ * server-parsed caller), BOTH the old dead-checked code and the new
+ * correctly-expressed guard fail closed — never a silent wrong anchor —
+ * just via different internal paths: the old code's checks never fire, so
+ * `EntityExtractor` runs against a clamped-empty slice, every extraction
+ * attempt returns `undefined`, and `findBodyContextId`/`findAxisContextId`
+ * mask that by falling back to `ctxIds[0]` regardless, deferring the
+ * failure to `findStoreyPlacementId` and a generic "no resolvable
+ * IfcLocalPlacement" error; the new guard instead reports the absence at
+ * its own, more specific call site. Same "still throws, different message"
+ * class as `resolve-source.ts` — not a silent-output regression.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { EMPTY_SOURCE_BYTES, IfcParser, type IfcDataStore } from '@ifc-lite/parser';
+import { resolveSpatialAnchor } from './resolve-anchor.js';
+
+const STOREY_MODEL = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('t.ifc','',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0proj00000000000000000',$,'P',$,$,$,$,(#7),#9);
+#5=IFCCARTESIANPOINT((0.,0.,0.));
+#6=IFCAXIS2PLACEMENT3D(#5,$,$);
+#7=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-05,#6,$);
+#8=IFCGEOMETRICREPRESENTATIONSUBCONTEXT('Body','Model',*,*,*,*,#7,$,.MODEL_VIEW.,$);
+#9=IFCUNITASSIGNMENT((#91));
+#91=IFCSIUNIT(*,.LENGTHUNIT.,.MILLI.,.METRE.);
+#20=IFCLOCALPLACEMENT($,#6);
+#30=IFCBUILDINGSTOREY('0storey000000000000000',$,'Level 0',$,$,#20,$,$,.ELEMENT.,0.);
+ENDSEC;
+END-ISO-10303-21;`;
+
+describe('resolveSpatialAnchor: store with no source bytes (hypothetical, not reached today)', () => {
+  it('fails closed with a thrown error, never a silently-wrong anchor', async () => {
+    const parsed = await new IfcParser().parseColumnar(
+      new TextEncoder().encode(STOREY_MODEL).buffer as ArrayBuffer,
+      { disableWorkerScan: true },
+    );
+    // Simulate a store whose source was never resident: real entityIndex,
+    // but IfcSourceBytes.source is the shared EMPTY sentinel.
+    const store: IfcDataStore = { ...parsed, source: EMPTY_SOURCE_BYTES };
+
+    expect(() => resolveSpatialAnchor(store, 30)).toThrow();
+  });
+
+  it('bounding control: a store WITH real source still resolves the anchor correctly', async () => {
+    const store = await new IfcParser().parseColumnar(
+      new TextEncoder().encode(STOREY_MODEL).buffer as ArrayBuffer,
+      { disableWorkerScan: true },
+    );
+
+    const anchor = resolveSpatialAnchor(store, 30);
+
+    expect(anchor.storeyPlacementId).toBe(20);
+    expect(anchor.bodyContextId).toBe(7);
+    expect(anchor.axisContextId).toBe(7);
+  });
+});

--- a/packages/create/src/in-store/resolve-anchor.ts
+++ b/packages/create/src/in-store/resolve-anchor.ts
@@ -56,7 +56,7 @@ export function resolveSpatialAnchor(store: IfcDataStore, storeyExpressId: numbe
   // conversion in extract-walls.ts.
   let lengthUnitScale = 1.0;
   try {
-    if (store.source) {
+    if (store.source.byteLength > 0) {
       const s = extractLengthUnitScale(store.source, store.entityIndex);
       if (Number.isFinite(s) && s > 0) lengthUnitScale = s;
     }
@@ -79,7 +79,7 @@ function findOwnerHistoryId(store: IfcDataStore): number | null {
  * otherwise fall back to the first 3D IfcGeometricRepresentationContext.
  */
 function findBodyContextId(store: IfcDataStore): number | null {
-  if (!store.source) return null;
+  if (store.source.byteLength <= 0) return null;
   const extractor = new EntityExtractor(store.source);
   const subIds = store.entityIndex.byType.get('IFCGEOMETRICREPRESENTATIONSUBCONTEXT') ?? [];
   for (const id of subIds) {
@@ -111,7 +111,7 @@ function findBodyContextId(store: IfcDataStore): number | null {
  * otherwise fall back to the first 3D IfcGeometricRepresentationContext.
  */
 function findAxisContextId(store: IfcDataStore): number | null {
-  if (!store.source) return null;
+  if (store.source.byteLength <= 0) return null;
   const extractor = new EntityExtractor(store.source);
 
   const subIds = store.entityIndex.byType.get('IFCGEOMETRICREPRESENTATIONSUBCONTEXT') ?? [];
@@ -148,7 +148,7 @@ function findAxisContextId(store: IfcDataStore): number | null {
  * working if the schema gen ever shifts inheritance.
  */
 function findStoreyPlacementId(store: IfcDataStore, storeyExpressId: number): number | null {
-  if (!store.source) return null;
+  if (store.source.byteLength <= 0) return null;
   const ref = store.entityIndex.byId.get(storeyExpressId);
   if (!ref) return null;
   const extractor = new EntityExtractor(store.source);


### PR DESCRIPTION
Addresses #2345, including the follow-on comment's widened scope.

### Verdict: the guards were mis-expressed, not redundant

Worth stating up front, because it changes the fix. `IfcDataStore.source` is a mandatory accessor object — even the no-source state is `EMPTY_SOURCE_BYTES`, an object, never `null`/`undefined` (`packages/parser/src/columnar-parser.ts:69`, `packages/parser/src/source-bytes.ts:71-79`). So every `if (store.source)` / `if (!store.source)` was always-true/always-false.

The tempting reading is "dead code, delete it." That would have been wrong at every site. The condition these guards were written for — *this store has no usable source bytes* — is real and reachable; it was just expressed in a way that can never detect it. So each becomes an explicit `byteLength` check rather than being removed, which makes the fallback they guard reachable again.

| Site | Consequence today |
|---|---|
| `usd-export-source.ts:68` | **silent empty USD stage** — step 3's raw-`sourceFile` fallback was unreachable |
| `CommandPalette.tsx:556,558,560,562` | empty CSV instead of bailing out (4 commands) |
| `toolbar/useExportCommands.ts:24` | same |
| `create/src/in-store/resolve-anchor.ts:59,82,114,151` | no outward change — see below |

The USD one is the bug that matters: a wrong file, written successfully, with no error.

### The site the issue didn't name

`resolve-anchor.ts:151` (`findStoreyPlacementId`) carries the identical shape to the three named in the follow-on comment, in the same file. Fixed alongside them.

### On the CSV sites

These now return without downloading, rather than handing zero bytes to the exporter. That preserves the early-return convention already in each of those actions (`if (!d) return`) rather than introducing a new silent no-op — and not producing a file beats producing a corrupt empty one.

### RED, against the unfixed code

```
not ok 2 - falls back to the raw sourceFile bytes when the store has an EMPTY source (server-parsed / synthetic)
# tests 6 | pass 5 | fail 1
```

The assertion is on the actual returned bytes (`[1,2,3,4,5]` from `sourceFile`), not on a boolean — unfixed, it returns `Uint8Array(0)`, which is exactly the silent empty export users would see.

### Bounding controls — pass BEFORE and after

The other 5 tests in that file pass against the **unfixed** code, so the new one can't be passing by making everything take the fallback path. That's the specific risk here: a careless fix would route stores *with* valid source bytes through the raw-file fallback too. Explicitly covered — a store with resident bytes still resolves through the store path, before and after.

### Displacement

`usd-export-source.ts` now reaches step 3 (`model.sourceFile.arrayBuffer()`) when the store's source is empty — previously unreachable. The CSV sites now skip `exportCsvFromBytes` entirely on empty input. `resolve-anchor.ts` now returns `null` immediately instead of running `EntityExtractor` over a clamped-empty slice that failed anyway; both old and new fail closed, so the difference is internal (and at one site, a less specific error message) rather than a behavioural change for real callers — every current caller passes a store this same process just parsed, which always has resident bytes.

### Siblings assessed but deliberately not fixed

Reported rather than swept into an unreviewed change:

- `RawStepCard.tsx:58` — neutral; double-guarded by `ref.byteLength <= 0` immediately after.
- `useDrawingGeneration.ts:304` — benign; the failure is already caught and degrades to the silhouette path, which the comment documents as accepted.
- `create/src/in-store/extract-walls.ts:146,173,276,342` — same shape as `resolve-anchor`, not maintainer-named.
- `create/src/in-store/resolve-source.ts:68` and `export/src/demesh-writer.ts:103` — throw today; the dead check means a different, less specific error throws instead. Message change, not silent failure.
- **`export/src/step-exporter.ts` — 8 sites, structurally the highest-risk remaining class**, being the same shape as the `usd-export-source.ts` bug fixed here. Unreviewed in this pass; worth prioritising, and happy to take it in a follow-up if you'd like.

### Verification

`apps/viewer` (`tsx --test`): 3188 pass / 0 fail / 6 skipped, unchanged baseline. `packages/create` (vitest): 125 → 127, 18 files, 0 failures. `pnpm typecheck`: 36/36. Changeset for `@ifc-lite/create` (published); none for `apps/viewer` (`"private": true`).
