### PR TITLE
fix(core,encoding): collapse both STEP doubling escapes on the attribute path

### DIFF
--- a/.changeset/step-doubled-escape-collapsing.md
+++ b/.changeset/step-doubled-escape-collapsing.md
@@ -1,0 +1,13 @@
+---
+"@ifc-lite/encoding": patch
+---
+
+`decodeIfcString` now collapses the doubled reverse solidus (`\\` → `\`), so a Windows path or a regex stored in an IFC string attribute reads back as its real value instead of with every separator doubled.
+
+ISO 10303-21 doubles two characters inside a STEP string literal: the apostrophe (`''`) and the reverse solidus (`\\`). The apostrophe is un-doubled by this decoder's callers (they strip the surrounding quotes and un-double before decoding, which must happen in that order). The reverse solidus was collapsed by nobody at all — it fell into the "unknown escape, pass through" branch — so `C:\\temp` in a file surfaced as `C:\\temp` rather than `C:\temp`.
+
+The pair is collapsed **after** the `\X2\` / `\X4\` / `\X\` / `\S\` / `\P..\` directive arms, not in a pre-pass. A directive immediately followed by an escaped backslash ends in three backslashes (`\X2\00FC\X0\` + `\\`); collapsing pairs left-to-right first would eat the directive's own terminator and leave an unterminated `\X2\`. Conversely a leading escaped backslash makes the text after it literal (`\\X2\00FC\X0\` is the characters `\X2\00FC\X0\`, not `ü`).
+
+Strings with no escapes are unchanged, and `\X2\00E9\X0\` still decodes to `é`. The one behaviour change beyond the fix itself is on malformed input: `\X4\\X0\` (an empty, and therefore invalid, hex payload) now decodes to `\X4\X0\` rather than keeping both backslashes, because what is left after the invalid directive genuinely is a doubled reverse solidus.
+
+The Rust decoder in `ifc-lite-core` gets the same arm, and the shared cross-language vector fixture gains cases for both escapes plus a new end-to-end set that pins the composed un-double-then-decode contract — the two decoders agreeing was not enough to catch this, since neither of them owns the `''` half.

--- a/packages/encoding/src/ifc-string.parity.test.ts
+++ b/packages/encoding/src/ifc-string.parity.test.ts
@@ -20,8 +20,21 @@ interface Vector {
   decoded: string;
 }
 
+/** End-to-end vector: the STEP literal's INNER bytes and the value a consumer must see. */
+interface LiteralVector {
+  name: string;
+  raw: string;
+  value: string;
+}
+
+interface Fixture {
+  cases: Vector[];
+  literal_cases: LiteralVector[];
+}
+
 describe.skipIf(!existsSync(fixturePath))('decodeIfcString shared parity vectors', () => {
-  const cases = (JSON.parse(readFileSync(fixturePath, 'utf8')) as { cases: Vector[] }).cases;
+  const fixture = JSON.parse(readFileSync(fixturePath, 'utf8')) as Fixture;
+  const cases = fixture.cases;
 
   it('fixture has cases', () => {
     expect(cases.length).toBeGreaterThan(0);
@@ -30,6 +43,27 @@ describe.skipIf(!existsSync(fixturePath))('decodeIfcString shared parity vectors
   for (const c of cases) {
     it(`matches the Rust decoder: ${c.name}`, () => {
       expect(decodeIfcString(c.encoded)).toBe(c.decoded);
+    });
+  }
+});
+
+// The decoders agreeing is only half the contract (#2323). `decodeIfcString`
+// deliberately never touches quotes, so `''` is collapsed only if the caller
+// un-doubles FIRST — the order every consumer here uses (entity-extractor,
+// columnar-parser-attributes, source-header, mcp). Rust drives these same
+// vectors through AttributeValue::from_token, so both engines are pinned to the
+// composed behaviour a CSV/JSON/Parquet reader actually gets, not just to each
+// other's decoder.
+describe.skipIf(!existsSync(fixturePath))('STEP literal end-to-end parity vectors', () => {
+  const literalCases = (JSON.parse(readFileSync(fixturePath, 'utf8')) as Fixture).literal_cases;
+
+  it('fixture has literal cases', () => {
+    expect(literalCases.length).toBeGreaterThan(0);
+  });
+
+  for (const c of literalCases) {
+    it(`matches the Rust attribute path: ${c.name}`, () => {
+      expect(decodeIfcString(c.raw.replace(/''/g, "'"))).toBe(c.value);
     });
   }
 });

--- a/packages/encoding/src/ifc-string.test.ts
+++ b/packages/encoding/src/ifc-string.test.ts
@@ -65,9 +65,12 @@ describe('decodeIfcString', () => {
   });
 
   it('passes malformed \\X2\\/\\X4\\ payloads through literally without throwing', () => {
-    // Empty payload: the hex regex requires at least one digit.
-    expect(decodeIfcString('\\X4\\\\X0\\')).toBe('\\X4\\\\X0\\');
-    expect(decodeIfcString('\\X2\\\\X0\\')).toBe('\\X2\\\\X0\\');
+    // Empty payload: the hex regex requires at least one digit, so the leading
+    // `\X4\` is not a directive. What is left IS a doubled reverse solidus
+    // (`\X4` + `\\` + `X0` + a dangling `\`), so the pair collapses to one
+    // backslash (#2323). Before that arm existed both backslashes survived.
+    expect(decodeIfcString('\\X4\\\\X0\\')).toBe('\\X4\\X0\\');
+    expect(decodeIfcString('\\X2\\\\X0\\')).toBe('\\X2\\X0\\');
     // Odd-length payloads (not a multiple of 8 / 4 hex digits).
     expect(decodeIfcString('\\X4\\0001D11\\X0\\')).toBe('\\X4\\0001D11\\X0\\');
     expect(decodeIfcString('\\X2\\00E\\X0\\')).toBe('\\X2\\00E\\X0\\');
@@ -76,6 +79,24 @@ describe('decodeIfcString', () => {
     // Unterminated directive (no \X0\ closer) stays literal.
     expect(decodeIfcString('\\X2\\00E4')).toBe('\\X2\\00E4');
     expect(decodeIfcString('\\X4\\0001D11E')).toBe('\\X4\\0001D11E');
+  });
+
+  it('collapses the doubled reverse solidus to one backslash', () => {
+    // ISO 10303-21 doubles `\` inside a string literal exactly as it doubles
+    // `'`, so `C:\\temp` in the file is the value `C:\temp` (#2323).
+    expect(decodeIfcString('C:\\\\temp')).toBe('C:\\temp');
+    expect(decodeIfcString('\\\\')).toBe('\\');
+    expect(decodeIfcString('\\\\\\\\')).toBe('\\\\');
+  });
+
+  it('gives a directive precedence over the doubled-backslash pair', () => {
+    // A directive immediately followed by an escaped backslash ends in THREE
+    // backslashes. The directive must consume its own `\X0\` terminator first;
+    // a pre-pass that collapsed pairs left-to-right would eat the terminator.
+    expect(decodeIfcString('\\X2\\00FC\\X0\\\\\\')).toBe('\u00fc\\');
+    // The mirror case: an ESCAPED backslash followed by the literal text
+    // `X2\00FC\X0\` is not a directive at all.
+    expect(decodeIfcString('\\\\X2\\00FC\\X0\\')).toBe('\\X2\\00FC\\X0\\');
   });
 
   it('decodes \\X\\ ISO-8859-1 single byte', () => {

--- a/packages/encoding/src/ifc-string.ts
+++ b/packages/encoding/src/ifc-string.ts
@@ -10,6 +10,12 @@
  * - \X\XX\ - ISO-8859-1 hex encoding
  * - \S\X - Extended ASCII with escape
  * - \P..\ - Code page switches (supported as directives and removed)
+ * - \\ - one literal backslash (ISO 10303-21 doubles the reverse solidus)
+ *
+ * The \\ pair is collapsed AFTER the directive arms: a directive immediately
+ * followed by an escaped backslash ends in three backslashes
+ * (`\X2\00FC\X0\` + `\\`), so collapsing pairs in a pre-pass would eat the
+ * directive's own terminator and leave an unterminated `\X2\`.
  *
  * This handles only backslash escapes. The '' doubled-quote escape is collapsed
  * by the STEP tokenizer's consumers (they strip surrounding quotes and
@@ -112,6 +118,15 @@ export function decodeIfcString(str: string): string {
           continue;
         }
       }
+    }
+
+    // Handle \\ - one literal backslash. Checked after the directive arms so a
+    // `\X0\`/`\X\` terminator adjacent to an escaped backslash is consumed by
+    // its own directive first, never paired with the escape that follows it.
+    if (str[i + 1] === '\\') {
+      result += '\\';
+      i += 2;
+      continue;
     }
 
     // Unknown escape sequence: keep the backslash and move on.

--- a/rust/core/src/schema_gen.rs
+++ b/rust/core/src/schema_gen.rs
@@ -9,6 +9,7 @@
 
 use crate::generated::IfcType;
 use crate::parser::Token;
+use std::borrow::Cow;
 use std::collections::HashMap;
 
 /// Geometry representation categories (internal use only)
@@ -58,11 +59,31 @@ impl AttributeValue {
         match token {
             Token::EntityRef(id) => AttributeValue::EntityRef(*id),
             Token::String(s) => {
-                // Decode STEP escapes (\X2\, \X4\, \X\, \S\, \P\) so every
-                // consumer of a string attribute sees native UTF-8, matching
-                // the TS decodeIfcString. No-escape strings stay zero-cost.
+                // Un-double the `''` quote escape, THEN decode the backslash
+                // escapes (\X2\, \X4\, \X\, \S\, \P\) — the same order the TS
+                // parser uses (columnar-parser-attributes.ts). The tokenizer
+                // hands over the raw inner bytes with `''` intact, and
+                // `decode_ifc_string` deliberately never touches quotes, so
+                // without this step every consumer of a string attribute saw
+                // `O''Brien` (#2323).
+                //
+                // The order is load-bearing, not cosmetic: decoding first would
+                // let two SEPARATE escaped apostrophes (`\X\27\X\27`) decode to
+                // `''` and then collapse into one, losing a character.
+                //
+                // This is the single funnel every Rust consumer of
+                // `AttributeValue::String` goes through. `quick_metadata.rs`
+                // un-doubles on its own raw-byte path, which never builds a
+                // Token, so nothing double-collapses.
                 let raw = String::from_utf8_lossy(s);
-                AttributeValue::String(crate::step_encoding::decode_ifc_string(&raw).into_owned())
+                let undoubled = if raw.contains("''") {
+                    Cow::Owned(raw.replace("''", "'"))
+                } else {
+                    raw
+                };
+                AttributeValue::String(
+                    crate::step_encoding::decode_ifc_string(&undoubled).into_owned(),
+                )
             }
             Token::Integer(i) => AttributeValue::Integer(*i),
             Token::Float(f) => AttributeValue::Float(*f),

--- a/rust/core/src/step_encoding.rs
+++ b/rust/core/src/step_encoding.rs
@@ -13,6 +13,12 @@
 //! - `\S\C` extended ASCII: code point of `C` plus 128
 //! - `\PC\` code-page directive, consumed and dropped
 //!
+//! ISO 10303-21 also doubles the reverse solidus inside a string literal, so
+//! `\\` decodes to one `\`. That arm sits AFTER the directive arms: a directive
+//! immediately followed by an escaped backslash ends in three backslashes
+//! (`\X2\00FC\X0\` + `\\`), and collapsing pairs first would eat the
+//! directive's own terminator.
+//!
 //! Unknown or malformed escapes are passed through unchanged. The `''`
 //! doubled-quote escape is NOT handled here — the tokenizer's consumers strip
 //! the surrounding quotes and un-double before calling this.
@@ -113,6 +119,16 @@ pub fn decode_ifc_string(s: &str) -> Cow<'_, str> {
             }
         }
 
+        // `\\`: one literal reverse solidus (ISO 10303-21 doubles it inside a
+        // string literal). Checked after the directive arms so a `\X0\`/`\X\`
+        // terminator adjacent to an escaped backslash is consumed by its own
+        // directive first, never paired with the escape that follows it.
+        if i + 1 < n && bytes[i + 1] == b'\\' {
+            out.push('\\');
+            i += 2;
+            continue;
+        }
+
         // Unknown escape: keep the backslash and advance one byte.
         out.push('\\');
         i += 1;
@@ -208,6 +224,20 @@ mod tests {
     #[test]
     fn drops_code_page_directive() {
         assert_eq!(decode_ifc_string(r"\PA\Hello"), "Hello");
+    }
+
+    #[test]
+    fn collapses_the_doubled_reverse_solidus() {
+        // ISO 10303-21 doubles the reverse solidus inside a string literal just
+        // as it doubles the apostrophe, so the pair is ONE backslash (#2323).
+        assert_eq!(decode_ifc_string(r"C:\\temp"), r"C:\temp");
+        // Two escaped backslashes stay two: exactly one collapsing pass.
+        assert_eq!(decode_ifc_string(r"\\\\"), r"\\");
+        // A directive consumes its own \X0\ terminator before the pair escape is
+        // considered, so a trailing escaped backslash survives whole.
+        assert_eq!(decode_ifc_string("\\X2\\00FC\\X0\\\\\\"), "\u{FC}\\");
+        // Mirror case: a leading escaped backslash makes the rest literal text.
+        assert_eq!(decode_ifc_string(r"\\X2\00FC\X0\"), r"\X2\00FC\X0\");
     }
 
     #[test]

--- a/rust/core/tests/fixtures/ifc_string_vectors.json
+++ b/rust/core/tests/fixtures/ifc_string_vectors.json
@@ -52,6 +52,42 @@
       "decoded": "a\\Qb"
     },
     {
+      "name": "backslash_pair_is_one_backslash",
+      "_comment": "#2323. ISO 10303-21 doubles the reverse solidus inside a string literal, so a doubled backslash is ONE backslash. Neither decoder collapsed it before.",
+      "encoded": "C:\\\\temp",
+      "decoded": "C:\\temp"
+    },
+    {
+      "name": "backslash_pair_doubled",
+      "_comment": "Two escaped backslashes are two literal backslashes - exactly one collapsing pass, never a repeated one.",
+      "encoded": "\\\\\\\\",
+      "decoded": "\\\\"
+    },
+    {
+      "name": "directive_then_escaped_backslash",
+      "_comment": "A directive followed by an escaped backslash ends in THREE backslashes. The directive must consume its own \\X0\\ terminator first; a pre-pass collapsing pairs left-to-right would eat it and leave an unterminated \\X2\\.",
+      "encoded": "\\X2\\00FC\\X0\\\\\\",
+      "decoded": "\u00fc\\"
+    },
+    {
+      "name": "escaped_backslash_then_literal_directive_text",
+      "_comment": "The mirror case: an escaped backslash followed by the literal characters X2\\00FC\\X0\\ is NOT a directive, so that text survives verbatim.",
+      "encoded": "\\\\X2\\00FC\\X0\\",
+      "decoded": "\\X2\\00FC\\X0\\"
+    },
+    {
+      "name": "malformed_x4_empty_payload",
+      "_comment": "An empty hex payload is not a directive, so what remains is a doubled reverse solidus plus a dangling terminator backslash.",
+      "encoded": "\\X4\\\\X0\\",
+      "decoded": "\\X4\\X0\\"
+    },
+    {
+      "name": "doubled_quote_is_NOT_touched_by_the_decoder",
+      "_comment": "Contract pin: '' is un-doubled by the tokenizer's consumers BEFORE they call the decoder (see literal_cases). If a decoder collapsed it here too, those callers would double-collapse.",
+      "encoded": "O''Brien",
+      "decoded": "O''Brien"
+    },
+    {
       "name": "malformed_x2_no_terminator",
       "encoded": "\\X2\\00FC",
       "decoded": "\\X2\\00FC"
@@ -61,6 +97,62 @@
       "_comment": "Malformed: \\S\\ is spec-defined for ASCII only. Pins that both decoders read the whole code point (U+1F600) plus 128 (=U+1F680) and advance past the surrogate pair, rather than diverging on a trailing surrogate.",
       "encoded": "\\S\\\uD83D\uDE00",
       "decoded": "\uD83D\uDE80"
+    }
+  ],
+  "_literal_comment": "END-TO-END cases (#2323). `raw` is a STEP string literal's INNER bytes, exactly as the tokenizer hands them over with '' still doubled; `value` is what a consumer must surface. The two decoders agreeing is not enough: the '' escape is delegated to the caller, so the contract only holds if callers un-double FIRST and then decode. Rust drives these through AttributeValue::from_token, TS through decodeIfcString(raw.replace(/''/g, \"'\")).",
+  "literal_cases": [
+    {
+      "name": "plain_unchanged",
+      "raw": "Plain Wall Name",
+      "value": "Plain Wall Name"
+    },
+    {
+      "name": "apostrophe",
+      "raw": "O''Brien",
+      "value": "O'Brien"
+    },
+    {
+      "name": "entity_name_apostrophe",
+      "raw": "O''Brien Wall",
+      "value": "O'Brien Wall"
+    },
+    {
+      "name": "backslash",
+      "raw": "C:\\\\temp",
+      "value": "C:\\temp"
+    },
+    {
+      "name": "unicode_x2_still_works",
+      "raw": "caf\\X2\\00E9\\X0\\",
+      "value": "caf\u00e9"
+    },
+    {
+      "name": "mixed_both_escapes",
+      "raw": "a''b\\\\c",
+      "value": "a'b\\c"
+    },
+    {
+      "name": "four_quotes_are_two_apostrophes",
+      "_comment": "Over-collapse guard: exactly ONE un-doubling pass. A second would turn this into a single apostrophe.",
+      "raw": "''''",
+      "value": "''"
+    },
+    {
+      "name": "order_proof_two_separately_escaped_apostrophes",
+      "_comment": "ORDER PROOF. Un-double THEN decode yields two apostrophes (correct: two independent \\X\\27 escapes). Decode THEN un-double yields ONE, silently losing a character.",
+      "raw": "\\X\\27\\X\\27",
+      "value": "''"
+    },
+    {
+      "name": "order_proof_s_escape_over_a_doubled_quote",
+      "_comment": "ORDER PROOF. Un-double THEN decode makes the \\S\\ operand an apostrophe (0x27+128 = U+00A7). Decode THEN un-double consumes only the first quote as the operand and leaves a stray second one.",
+      "raw": "\\S\\''",
+      "value": "\u00a7"
+    },
+    {
+      "name": "unknown_escape_still_passes_through",
+      "raw": "a\\Qb",
+      "value": "a\\Qb"
     }
   ]
 }

--- a/rust/core/tests/ifc_string_parity.rs
+++ b/rust/core/tests/ifc_string_parity.rs
@@ -16,6 +16,33 @@ fn parsed_string_attribute_is_decoded() {
     }
 }
 
+/// End-to-end half of the shared contract (#2323): `decode_ifc_string` never
+/// touches quotes, so `''` is only collapsed if the caller un-doubles FIRST.
+/// These vectors pin the composed behaviour, which is what a CSV/JSON/Parquet
+/// consumer actually sees — the two decoders agreeing is not enough on its own.
+#[test]
+fn parsed_string_attribute_matches_shared_literal_vectors() {
+    let raw = include_str!("fixtures/ifc_string_vectors.json");
+    let doc: serde_json::Value = serde_json::from_str(raw).expect("fixture is valid JSON");
+    let cases = doc["literal_cases"].as_array().expect("literal_cases is an array");
+    assert!(!cases.is_empty(), "fixture has at least one literal case");
+
+    for case in cases {
+        let name = case["name"].as_str().unwrap_or("<unnamed>");
+        let inner = case["raw"].as_str().expect("raw is a string");
+        let expected = case["value"].as_str().expect("value is a string");
+        let line = format!("#1=IFCWALL('{inner}',$,$);");
+        let (_id, _ty, tokens) = parse_entity(line.as_bytes())
+            .unwrap_or_else(|_| panic!("case `{name}`: {line} parses"));
+        match AttributeValue::from_token(&tokens[0]) {
+            AttributeValue::String(got) => {
+                assert_eq!(got, expected, "case `{name}`: literal {inner:?}");
+            }
+            other => panic!("case `{name}`: expected String, got {other:?}"),
+        }
+    }
+}
+
 #[test]
 fn rust_decoder_matches_shared_vectors() {
     let raw = include_str!("fixtures/ifc_string_vectors.json");

--- a/rust/export/tests/issue_2323_step_escapes.rs
+++ b/rust/export/tests/issue_2323_step_escapes.rs
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: MPL-2.0
+//! #2323: STEP doubles BOTH escapes that are not backslash sequences — `''` is
+//! one apostrophe and `\\` is one reverse solidus (ISO 10303-21). The Rust
+//! attribute export collapsed neither, so `O'Brien` surfaced as `O''Brien` and
+//! `C:\temp` as `C:\\temp` in CSV/JSON/JSON-LD/IFC5/Parquet and the wheel.
+//!
+//! These are WRONG VALUES, not cosmetic: an IDS check or a downstream join
+//! against `O'Brien` silently fails to match `O''Brien`.
+
+use ifc_lite_export::stream_export_model;
+
+/// The issue's own reproduction file, byte-for-byte.
+const MODEL: &[u8] = br#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('t.ifc','2026-01-01T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#7=IFCWALL('1Ab1c2d3e4f5g6h7i8j9k0',$,'O''Brien Wall',$,$,$,$,$,$);
+#9=IFCPROPERTYSET('2Ab1c2d3e4f5g6h7i8j9k0',$,'Pset_O''Brien',$,(#10,#11,#12,#13));
+#10=IFCPROPERTYSINGLEVALUE('Apostrophe',$,IFCLABEL('O''Brien'),$);
+#11=IFCPROPERTYSINGLEVALUE('Backslash',$,IFCLABEL('C:\\temp'),$);
+#12=IFCPROPERTYSINGLEVALUE('Unicode',$,IFCLABEL('caf\X2\00E9\X0\'),$);
+#13=IFCPROPERTYSINGLEVALUE('Mixed',$,IFCLABEL('a''b\\c'),$);
+#14=IFCRELDEFINESBYPROPERTIES('3Ab1c2d3e4f5g6h7i8j9k0',$,$,$,(#7),#9);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+fn wall_props() -> (Option<String>, Vec<(String, String)>, Vec<String>) {
+    let mut rows = Vec::new();
+    stream_export_model(MODEL, |r| rows.push(r));
+    let wall = rows
+        .iter()
+        .find(|r| r.express_id == 7)
+        .expect("#7 IfcWall gets an attribute row");
+    let props = wall
+        .property_sets
+        .iter()
+        .flat_map(|ps| ps.properties.iter())
+        .map(|p| (p.name.clone(), p.value.clone()))
+        .collect();
+    let pset_names = wall.property_sets.iter().map(|ps| ps.name.clone()).collect();
+    (wall.name.clone(), props, pset_names)
+}
+
+#[test]
+fn issue_2323_wanted_values() {
+    let (name, props, pset_names) = wall_props();
+    let get = |k: &str| -> String {
+        props
+            .iter()
+            .find(|(n, _)| n == k)
+            .unwrap_or_else(|| panic!("property {k} present; got {props:?}"))
+            .1
+            .clone()
+    };
+
+    // The issue's want column, verbatim.
+    assert_eq!(get("Apostrophe"), "O'Brien", "'' is ONE apostrophe");
+    assert_eq!(get("Backslash"), r"C:\temp", r"\\ is ONE reverse solidus");
+    assert_eq!(get("Unicode"), "caf\u{e9}", r"\X2\ already worked — must not regress");
+    assert_eq!(get("Mixed"), r"a'b\c", "both escapes in one value");
+    assert_eq!(name.as_deref(), Some("O'Brien Wall"), "entity Name is affected too");
+    assert_eq!(pset_names, vec!["Pset_O'Brien".to_string()], "pset name too");
+}
+
+/// Bounding control: nothing without an escape may change, and the `''` escape
+/// must not OVER-collapse — `''''` is two literal apostrophes, not one.
+#[test]
+fn issue_2323_bounding_controls() {
+    const M: &[u8] = br#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('t.ifc','2026-01-01T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#7=IFCWALL('1Ab1c2d3e4f5g6h7i8j9k0',$,'Plain Wall Name',$,$,$,$,$,$);
+#9=IFCPROPERTYSET('2Ab1c2d3e4f5g6h7i8j9k0',$,'Pset_Plain',$,(#10,#11,#12));
+#10=IFCPROPERTYSINGLEVALUE('NoEscapes',$,IFCLABEL('C/D-E_F 12 (g)'),$);
+#11=IFCPROPERTYSINGLEVALUE('FourQuotes',$,IFCLABEL(''''''),$);
+#12=IFCPROPERTYSINGLEVALUE('UnknownEscape',$,IFCLABEL('a\Qb'),$);
+#14=IFCRELDEFINESBYPROPERTIES('3Ab1c2d3e4f5g6h7i8j9k0',$,$,$,(#7),#9);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+    let mut rows = Vec::new();
+    stream_export_model(M, |r| rows.push(r));
+    let wall = rows.iter().find(|r| r.express_id == 7).expect("#7 row");
+    let props: Vec<(String, String)> = wall
+        .property_sets
+        .iter()
+        .flat_map(|ps| ps.properties.iter())
+        .map(|p| (p.name.clone(), p.value.clone()))
+        .collect();
+    let get = |k: &str| props.iter().find(|(n, _)| n == k).map(|(_, v)| v.clone());
+
+    assert_eq!(wall.name.as_deref(), Some("Plain Wall Name"));
+    assert_eq!(get("NoEscapes").as_deref(), Some("C/D-E_F 12 (g)"));
+    // `''''` (four raw quotes) is TWO literal apostrophes. One un-doubling pass
+    // only; a second would over-collapse this to one.
+    assert_eq!(get("FourQuotes").as_deref(), Some("''"));
+    // An unrecognised backslash escape is still passed through unchanged.
+    assert_eq!(get("UnknownEscape").as_deref(), Some(r"a\Qb"));
+}

--- a/rust/processing/src/processor/quick_metadata.rs
+++ b/rust/processing/src/processor/quick_metadata.rs
@@ -218,6 +218,22 @@ mod tests {
     // A malformed IfcRelAggregates graph making two nodes each other's child would
     // recurse forever (stack-overflow abort). The back-edge child is skipped and
     // the rest of the tree still builds.
+    /// #2323 double-collapse guard. This module un-doubles `''` on its OWN
+    /// raw-byte path (it never builds a `Token`, so `AttributeValue::from_token`
+    /// never runs over the same bytes). Exactly ONE un-doubling pass must
+    /// happen here: `''''` is two literal apostrophes, not one.
+    #[test]
+    fn parse_step_string_un_doubles_exactly_once() {
+        assert_eq!(parse_step_string(b"'O''Brien'").as_deref(), Some("O'Brien"));
+        assert_eq!(parse_step_string(b"''''''").as_deref(), Some("''"));
+        // The decoder now collapses the doubled reverse solidus too, and this
+        // path picks that up for free rather than needing its own pass.
+        assert_eq!(parse_step_string(br"'C:\\temp'").as_deref(), Some(r"C:\temp"));
+        // Unicode escapes still decode, and plain text is untouched.
+        assert_eq!(parse_step_string(br"'caf\X2\00E9\X0\'").as_deref(), Some("caf\u{e9}"));
+        assert_eq!(parse_step_string(b"'Plain Name'").as_deref(), Some("Plain Name"));
+    }
+
     #[test]
     fn cyclic_aggregate_graph_does_not_stack_overflow() {
         let mut nodes = HashMap::new();


### PR DESCRIPTION
Addresses #2323.

## The issue's premise needs one correction, and it changes the fix

> The browser path decodes both correctly, so the same file reads differently depending on which engine produced the output.

Measured against unmodified `main`, driving the real TS decoder in its production order (`decodeIfcString(rawInner.replace(/''/g, "'"))`):

```
Apostrophe   in=[O''Brien]          got=[O'Brien]   want=[O'Brien]   MATCH
Backslash    in=[C:\\temp]          got=[C:\\temp]  want=[C:\temp]   *** MISMATCH ***
Unicode      in=[caf\X2\00E9\X0\]   got=[café]      want=[café]      MATCH
Mixed        in=[a''b\\c]           got=[a'b\\c]    want=[a'b\c]     *** MISMATCH ***
FourQuotes   in=['''']              got=['']        want=['']        MATCH
```

So the issue's **Cause 2 is right and its opening line is not**: TS is correct about `''` (its callers un-double) and **wrong about `\\` exactly like Rust** — `decodeIfcString` reaches the same "unknown escape, pass through" branch.

That matters, because fixing only Rust would have opened a parity break in the opposite direction. Both sides move here, plus the shared fixture.

## Central, not local

`AttributeValue::from_token` is the single funnel — the only place in Rust that turns a `Token::String` into an `AttributeValue::String`. Local fixes at `opt_string` and the pset name would have left `render_value`, `render_attributes`, `georef.rs:22`, `processing/properties.rs:106` and every future consumer wrong.

The double-collapse risk that argued for the local fix turns out not to exist: `grep -rn 'replace("''"' rust --include='*.rs'` returns exactly one hit, `quick_metadata.rs:85`, and that function works on raw token bytes from its own splitter and never constructs a `Token`. It's structurally on a different path. A new test pins that (`''''` → `''`, un-doubled exactly once).

## Ordering is load-bearing, and there are distinguishing cases

Un-double **then** decode (matching TS). Decoding first loses characters:

```
raw="\X\27\X\27"    undouble->decode = "''"   decode->undouble = "'"    <- loses a character
raw="\S\''"         undouble->decode = "§"    decode->undouble = "§'"   <- stray quote
```

And the `\\` arm goes **after** the directive arms, not in a pre-pass:

```
raw="\\X2\00FC\X0\"   in-loop arm (ours) = "\X2\00FC\X0\"   pre-pass = "ü"   <- mis-reads literal text as a directive
```

A directive followed by an escaped backslash ends in three backslashes, so collapsing pairs left-to-right first would eat the directive's own terminator. Both order proofs are fixture cases (`order_proof_*`). `source-header.ts:98-137` already documented this same precedence trap; its hand-rolled scan stays correct and doesn't double-collapse.

## Why the existing parity test passed over this

`ifc_string_parity.rs` pinned the two decoders **against each other**, and neither owns the `''` half — so it stayed green while end-to-end behaviour diverged. The fixture gains a new `literal_cases` set pinning the real contract (raw inner bytes → surfaced value) on both engines, which is what actually bites.

## RED

```
running 2 tests
test issue_2323_bounding_controls ... FAILED
test issue_2323_wanted_values ... FAILED

assertion `left == right` failed: '' is ONE apostrophe
  left: "O''Brien"
 right: "O'Brien"

assertion `left == right` failed
  left: Some("''''")
 right: Some("''")
```

It asserts the issue's whole want column — `O'Brien`, `C:\temp`, `café`, `a'b\c`, entity Name `O'Brien Wall`, pset name `Pset_O'Brien`. After the fix: 2 passed.

## Three-way measurement

One existing assertion changed — `decodeIfcString('\X4\\X0\')` (malformed empty hex payload):

- old assertion + unfixed → **PASS** (59 passed)
- old assertion + fixed → **FAIL** (`expected '\X4\X0\' to be '\X4\\X0\'`)
- new assertion + fixed → **PASS** (78 passed)

The new value is correct: after the invalid directive, what remains genuinely *is* a doubled reverse solidus plus a dangling terminator. Also measured: the new fixture against the **unfixed** Rust decoder fails both parity tests, so the new vectors bite rather than decorate.

## Bounding controls (pass before AND after)

No-escape strings unchanged; `\X2\00E9\X0\` → `café`; `''''` → `''` (not over-collapsed); `a\Qb` still passed through; a trailing lone `\` still passed through.

## Displacement

The new `\\` arm is reached only when `bytes[i] == '\\'` and no directive arm matched. Every directive arm requires `bytes[i+1] ∈ {P, S, X}`, so the new branch is disjoint from all of them and can never displace a directive. What it displaces is the final fallthrough, which used to emit the first backslash and re-enter the loop to emit the second. At end-of-string the guard is false, so a dangling `\` still takes the old path.

The new `if raw.contains("''")` passes an identical `Cow` on the false branch, so no-quote strings are byte-identical to before. `Token::TypedValue`'s type name and `Token::Enum` build on separate arms and are untouched.

**Known and unchanged:** `PropertySetCard.tsx:104` calls `decodeIfcString` on a name that may already be Rust-decoded. A decoded value holding two adjacent literal backslashes would be over-collapsed by that second pass. This double-decode shape pre-dates this change (it already applied to surviving `\X2\` text), so I left it alone rather than widen scope.

## Deliberately not done

`escape()` in `rust/export/src/step.rs:79` writes a literal backslash **undoubled** — the write-side half of the same spec gap. Now that the reader collapses `\\`, a value with two adjacent literal backslashes written by that path no longer round-trips.

I implemented and tested the one-line fix, but it pushed `step.rs` from 611 to 617 lines and **tripped the module-size ratchet**. Since budgets must never be raised and splitting `step.rs` is well outside this issue, I reverted it byte-identically (verified: empty `git diff` on that file). Worth a follow-up — happy to do the split separately if you want it.

## Verification

Rust core+export+processing: 538 → 543 passed, 0 failed. Full workspace `cargo test`: 1594 passed, 0 failed, 20 ignored. `cargo clippy --workspace --all-targets` clean. `packages/encoding`: 59 → 78 passed. `pnpm typecheck` 36/36. Module-size ratchet passes with no budget raised (`step_encoding.rs` 267, `schema_gen.rs` 498 against 553).

Changeset: `"@ifc-lite/encoding": patch` — the only public npm package whose source changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved STEP/IFC string decoding for escaped backslashes and apostrophes.
  - Preserved Unicode escapes and unknown escape sequences while correctly handling adjacent escape directives.
  - Fixed decoding across entity names, property-set names, and property values.
  - Added coverage for malformed and boundary cases to ensure existing behavior remains stable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->