### PR TITLE
fix(viewer): bound the rAF wait that gates load completion (#2385)

### DIFF
--- a/apps/viewer/src/hooks/useClash.ts
+++ b/apps/viewer/src/hooks/useClash.ts
@@ -38,6 +38,7 @@ import { buildClashPairColors, CLASH_COLOR_A, CLASH_COLOR_OVERLAP } from '@/lib/
 import { clashFramingBounds } from '@/lib/clash/clash-framing';
 import { posthog } from '@/lib/analytics';
 import { errorCaptureProps } from '@/lib/load-errors';
+import { waitForFrameOrTimeout } from '@/utils/frameOrTimeout';
 import { downloadBlob } from '@/lib/export/download';
 
 interface SelectionRef {
@@ -191,7 +192,9 @@ export function useClash() {
       state.setClashProgress({ phase: 'broad', rule: '', done: 0, total: 0 });
       try {
         // Let the panel paint the running state before the heavy work.
-        await new Promise((resolve) => requestAnimationFrame(resolve));
+        // Bounded: a backgrounded tab (where requestAnimationFrame is
+        // paused) must not stall clashRunning forever (#2385).
+        await waitForFrameOrTimeout();
         const { elements, exclusions } = gatherElements();
         if (elements.length === 0) {
           state.setClashError('No model geometry is loaded. Load an IFC model first.');
@@ -287,7 +290,9 @@ export function useClash() {
     state.setClashProgress({ phase: 'broad', rule: 'duplicates', done: 0, total: 0 });
     try {
       // Paint the running state before the (synchronous) scan blocks the thread.
-      await new Promise((resolve) => requestAnimationFrame(resolve));
+      // Bounded: a backgrounded tab (where requestAnimationFrame is paused)
+      // must not stall clashRunning forever (#2385).
+      await waitForFrameOrTimeout();
       const { elements, exclusions } = gatherElements();
       if (elements.length === 0) {
         state.setClashError('No model geometry is loaded. Load an IFC model first.');
@@ -590,6 +595,9 @@ export function useClash() {
             const device = renderer.getGPUDevice();
             if (device) await device.queue.onSubmittedWorkDone();
             // Let the compositor present the frame before reading the canvas.
+            // Deliberately UNBOUNDED, unlike waitForFrameOrTimeout elsewhere on
+            // this path: a timeout fallback here would read the canvas before the
+            // frame was actually presented, producing a stale BCF snapshot (#2385).
             await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
             const dataUrl = await renderer.captureScreenshot();
             done += 1;

--- a/apps/viewer/src/hooks/useIDS.ts
+++ b/apps/viewer/src/hooks/useIDS.ts
@@ -37,6 +37,7 @@ import { loadIdsContent } from './ids/loadIdsContent';
 import type { EntityBoundsInput, IDSBCFExportOptions } from '@ifc-lite/bcf';
 import type { IDSBCFExportSettings, IDSExportProgress } from '@/components/viewer/IDSExportDialog';
 import { getEntityBounds } from '@/utils/viewportUtils';
+import { waitForFrameOrTimeout } from '@/utils/frameOrTimeout';
 import { getGlobalRenderer } from '@/hooks/useBCF';
 
 import { createDataAccessor } from './ids/idsDataAccessor';
@@ -361,17 +362,8 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
       // worker and doing any heavy synchronous work, so the spinner +
       // initial progress bar are guaranteed on screen immediately. Race
       // the frame wait against a timer so a backgrounded tab (where
-      // requestAnimationFrame is paused) can't stall the run.
-      await new Promise<void>((resolve) => {
-        let settled = false;
-        const done = () => {
-          if (settled) return;
-          settled = true;
-          resolve();
-        };
-        requestAnimationFrame(() => requestAnimationFrame(done));
-        setTimeout(done, 200);
-      });
+      // requestAnimationFrame is paused) can't stall the run (#2385).
+      await waitForFrameOrTimeout(2, 200);
 
       const schemaVersion = dataStore.schemaVersion || 'IFC4';
 
@@ -1005,6 +997,9 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
           // Wait for the browser compositor to present the frame to the canvas.
           // Without this, toDataURL() reads a stale canvas — only the last snapshot
           // would show the entity because previous frames haven't been composited yet.
+          // Deliberately UNBOUNDED, unlike waitForFrameOrTimeout elsewhere on this
+          // path: a timeout fallback here would read the canvas before the frame
+          // was actually presented, producing a corrupt/stale snapshot (#2385).
           await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
 
           // Capture the now-presented frame

--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -37,6 +37,7 @@ import {
 import { resolveResourceRetryTier } from '../lib/resource-retry.js';
 import { acquireFileBuffer, type AcquiredBuffer } from '../utils/acquireFileBuffer.js';
 import { buildSpatialIndexGuarded, buildSpatialIndexForModel } from '../utils/loadingUtils.js';
+import { waitForFrameOrTimeout } from '../utils/frameOrTimeout.js';
 import { buildGeometryCacheKey } from './geometryCacheKey.js';
 import { type GeometryData } from '@ifc-lite/cache';
 
@@ -1676,7 +1677,12 @@ export function useIfcLoader() {
               memoryAccounting.endPhase('geometry');
               memoryAccounting.recordPhase({ phase: 'geometry-complete' });
               console.log(memoryAccounting.formatSummary());
-              await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+              // Race the frame wait against a timer so a backgrounded tab
+              // (where requestAnimationFrame is paused) can't stall the rest
+              // of this load — setGeometryStreamingActive(false), finalizeModel,
+              // closeGeometryIterator() and setLoading(false) all sit after this
+              // point (#2385).
+              await waitForFrameOrTimeout();
               if (loadSessionRef.current === currentSession && target.kind === 'primary') {
                 setGeometryStreamingActive(false);
               }

--- a/apps/viewer/src/utils/frameOrTimeout.test.ts
+++ b/apps/viewer/src/utils/frameOrTimeout.test.ts
@@ -1,0 +1,143 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { waitForFrameOrTimeout, type FrameOrTimeoutDeps } from './frameOrTimeout.js';
+
+/** A rAF stand-in that NEVER calls its callback — simulates a hidden tab, where
+ * the browser suspends the callback queue indefinitely. */
+function hiddenTabDeps(log: string[]): FrameOrTimeoutDeps {
+  let timeoutId = 0;
+  const timers = new Map<number, () => void>();
+  return {
+    requestFrame: () => {
+      log.push('rAF queued (never fires)');
+      return -1;
+    },
+    setTimeoutFn: (cb, ms) => {
+      const id = ++timeoutId;
+      timers.set(id, cb);
+      log.push(`timeout armed (${ms}ms)`);
+      // Fire synchronously for the test — stands in for "the timer elapsed".
+      queueMicrotask(() => {
+        if (timers.has(id)) {
+          timers.delete(id);
+          log.push('timeout fired');
+          cb();
+        }
+      });
+      return id;
+    },
+    clearTimeoutFn: (id) => {
+      if (timers.delete(id as number)) log.push('timeout cleared');
+    },
+  };
+}
+
+/** A rAF stand-in that fires immediately (synchronously via microtask) — the
+ * normal, visible-tab case. */
+function visibleTabDeps(log: string[]): FrameOrTimeoutDeps {
+  let timeoutId = 0;
+  const timers = new Map<number, () => void>();
+  return {
+    requestFrame: (cb) => {
+      log.push('rAF fires');
+      queueMicrotask(cb);
+      return -1;
+    },
+    setTimeoutFn: (cb, ms) => {
+      const id = ++timeoutId;
+      timers.set(id, cb);
+      log.push(`timeout armed (${ms}ms)`);
+      return id;
+    },
+    clearTimeoutFn: (id) => {
+      if (timers.delete(id as number)) log.push('timeout cleared');
+    },
+  };
+}
+
+describe('waitForFrameOrTimeout', () => {
+  it('RED: an unbounded bare-rAF wait never settles when rAF never fires (hidden tab)', async () => {
+    // Demonstrates the exact bug shape from #2385: a plain
+    // `new Promise(resolve => requestAnimationFrame(resolve))` awaited
+    // directly against an rAF stand-in that never calls back.
+    let requestFrame: (cb: () => void) => void = () => {
+      /* never calls cb — simulates a hidden tab's suspended rAF queue */
+    };
+    const bareWait = new Promise<void>((resolve) => requestFrame(() => resolve()));
+    const bounded = Promise.race([
+      bareWait.then(() => 'resolved' as const),
+      new Promise<'timed-out'>((resolve) => setTimeout(() => resolve('timed-out'), 50)),
+    ]);
+    const outcome = await bounded;
+    // The bare wait never resolves on its own — only the test's own outer
+    // timeout saves us here. This is the hang the issue describes.
+    assert.equal(outcome, 'timed-out');
+  });
+
+  it('hidden tab: falls back to the timeout and resolves within the bound', async () => {
+    const log: string[] = [];
+    const start = Date.now();
+    await waitForFrameOrTimeout(1, 200, hiddenTabDeps(log));
+    const elapsed = Date.now() - start;
+    assert.ok(elapsed < 1000, `expected to resolve well under 1s, took ${elapsed}ms`);
+    assert.ok(log.includes('timeout fired'), 'expected the timeout fallback to fire');
+  });
+
+  it('visible tab: resolves via rAF and clears the fallback timer (bounding control)', async () => {
+    const log: string[] = [];
+    await waitForFrameOrTimeout(1, 200, visibleTabDeps(log));
+    assert.ok(log.includes('rAF fires'), 'expected rAF to be requested');
+    assert.ok(log.includes('timeout cleared'), 'expected the fallback timer to be cleared by rAF winning the race');
+    assert.ok(!log.includes('timeout fired'), 'the fallback timer must not fire once rAF has already resolved');
+  });
+
+  it('does not resolve twice when both the frame and the timeout could fire', async () => {
+    let resolveCount = 0;
+    let capturedCb: (() => void) | null = null;
+    let capturedTimeoutCb: (() => void) | null = null;
+    const deps: FrameOrTimeoutDeps = {
+      requestFrame: (cb) => {
+        capturedCb = cb;
+        return -1;
+      },
+      setTimeoutFn: (cb) => {
+        capturedTimeoutCb = cb;
+        return -1;
+      },
+      clearTimeoutFn: () => {
+        /* no-op: deliberately don't clear, to prove `done()` is still idempotent */
+      },
+    };
+    const p = waitForFrameOrTimeout(1, 200, deps).then(() => {
+      resolveCount++;
+    });
+    // Fire the frame callback AND the timeout callback — both "win" the race
+    // at the deps level; the promise must still only settle once.
+    capturedCb!();
+    capturedTimeoutCb!();
+    capturedCb!();
+    capturedTimeoutCb!();
+    await p;
+    assert.equal(resolveCount, 1);
+  });
+
+  it('frames=2 waits two rAF ticks deep before resolving', async () => {
+    const calls: number[] = [];
+    const deps: FrameOrTimeoutDeps = {
+      requestFrame: (cb) => {
+        calls.push(calls.length + 1);
+        cb();
+        return -1;
+      },
+      setTimeoutFn: () => -1,
+      clearTimeoutFn: () => {},
+    };
+    await waitForFrameOrTimeout(2, 200, deps);
+    assert.deepEqual(calls, [1, 2]);
+  });
+});

--- a/apps/viewer/src/utils/frameOrTimeout.ts
+++ b/apps/viewer/src/utils/frameOrTimeout.ts
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Race a `requestAnimationFrame` wait against a timeout, for the "let this
+ * paint before doing heavy/blocking work" pattern used at several points on
+ * the load and clash-run paths.
+ *
+ * Browsers throttle or fully suspend rAF callbacks while
+ * `document.visibilityState === 'hidden'` — they queue and only run once the
+ * tab is shown again. A bare `await new Promise(r => requestAnimationFrame(r))`
+ * on a pipeline that must complete (finalize a load, flip a "running" flag
+ * back off, close WASM handles) therefore hangs indefinitely if the user
+ * switches tabs mid-run (#2385). Racing against a short timeout bounds the
+ * wait without changing anything for the common, visible-tab case: rAF still
+ * wins the race there (it fires within one frame, well under the timeout),
+ * so the paint that callers rely on still happens first.
+ *
+ * NOT for waits that must guarantee a frame was actually PRESENTED before
+ * reading the canvas (e.g. immediately before `captureScreenshot()`) —
+ * timing those out would read a stale, not-yet-composited canvas. Those
+ * sites (useClash's BCF snapshot loop, useIDS's entity-snapshot capture)
+ * intentionally stay on a bare, unbounded rAF.
+ *
+ * @param frames - `1` waits for the next animation frame; `2` waits two
+ *   frames deep (`requestAnimationFrame(() => requestAnimationFrame(done))`),
+ *   matching call sites that want a frame after the frame after the
+ *   triggering render.
+ * @param timeoutMs - fallback delay in case no rAF is serviced in time
+ *   (hidden tab). Deps are injected so this is exercisable under the Node
+ *   test runner without a DOM/rAF (same pattern as `cacheTier.ts`).
+ */
+export interface FrameOrTimeoutDeps {
+  requestFrame: (cb: () => void) => unknown;
+  setTimeoutFn: (cb: () => void, ms: number) => unknown;
+  clearTimeoutFn: (id: unknown) => void;
+}
+
+const browserDeps: FrameOrTimeoutDeps = {
+  requestFrame: (cb) => globalThis.requestAnimationFrame(cb),
+  setTimeoutFn: (cb, ms) => globalThis.setTimeout(cb, ms),
+  clearTimeoutFn: (id) => globalThis.clearTimeout(id as ReturnType<typeof setTimeout>),
+};
+
+export function waitForFrameOrTimeout(
+  frames: 1 | 2 = 1,
+  timeoutMs = 200,
+  deps: FrameOrTimeoutDeps = browserDeps,
+): Promise<void> {
+  return new Promise<void>((resolve) => {
+    let settled = false;
+    const done = () => {
+      if (settled) return;
+      settled = true;
+      deps.clearTimeoutFn(timer);
+      resolve();
+    };
+    const timer = deps.setTimeoutFn(done, timeoutMs);
+    if (frames === 2) {
+      deps.requestFrame(() => deps.requestFrame(done));
+    } else {
+      deps.requestFrame(done);
+    }
+  });
+}


### PR DESCRIPTION
Addresses #2385.

`requestAnimationFrame` callbacks are suspended while a tab is hidden — they queue and only run once it's shown again. The geometry-stream `complete` branch awaited a bare rAF promise at `useIfcLoader.ts:1679`, and everything that *finishes* a load sits after it: `setGeometryStreamingActive(false)`, the whole `finalizePromise`, `closeGeometryIterator()`, `setLoading(false)`. Switch tabs mid-load and the load hangs indefinitely — a promise that never settles.

### What the rAF was waiting for decides the fix

This is the part worth checking rather than assuming. That wait is a *"let Complete/100% paint"* defer — nothing downstream reads the canvas. So in a hidden tab, where no paint will happen, proceeding is correct; waiting forever is not.

That is emphatically **not** true of every rAF on these paths, which is why this isn't a blanket replacement.

### Classification of every rAF wait found

| Site | Verdict |
|---|---|
| `useIfcLoader.ts:1679` | **Bug** — gates load completion. Fixed. |
| `useClash.ts:194`, `useClash.ts:290` | **Bug** — "paint the running state before heavy work"; `clashRunning`/`clashProgress` would never clear. Fixed. |
| `useClash.ts:593`, `useIDS.ts:1008` | **Correct as-is.** These wait for the compositor to actually present a frame before `captureScreenshot()`. A timeout fallback here would read a stale, not-yet-composited canvas. Left unbounded, now with an explicit comment so they aren't "fixed" by mistake later. |
| `useIfcLoader.ts:1354` | Fire-and-forget, nothing awaits it. Correct. |
| `useIfcLoader.ts:1878` | Already races rAF against a 250 ms fallback. Untouched. |
| ~50 others across viewer / viewer-embed | Render-loop ticks (camera sync, tour spotlight, animation, raycast throttling) that are *supposed* to pause when hidden. Untouched. |

I also confirmed there's no existing `visibilitychange`/`document.hidden` handling anywhere on the load path (checked with two grep phrasings), so nothing already covered this.

### The fix

Extracts the race-against-a-timer pattern that already existed in `useIDS.ts` into `apps/viewer/src/utils/frameOrTimeout.ts` — `waitForFrameOrTimeout(frames, timeoutMs, deps)`, dependency-injected so it's testable under `tsx --test` without a DOM (the `cacheTier.ts` pattern; `mock.module` is rejected here). Applied at the three buggy sites, and `useIDS.ts`'s own inline duplicate refactored onto it.

**No `visibilitychange` listener was added**, which avoids the double-resolve and listener-leak risks entirely. A `settled` latch plus clearing the timer when rAF wins means the promise resolves exactly once.

### Bounding control — the one that matters here

A fix that always took the fallback would silently remove the paint guarantee for every user. So the visible-tab control is explicit: rAF fires, wins the race, the fallback timer is cleared, and the fallback is proven **never to fire** (`!log.includes('timeout fired')`). Visible-tab behaviour is unchanged before and after.

Also covered: a no-double-resolve test firing *both* callbacks manually, and a `frames=2` test pinning the double-rAF-deep semantics `useIDS` relies on.

### RED

The bare rAF wait against a never-firing rAF stand-in never settles — proven with an outer race timeout that always wins. With the fix, the same hidden-tab scenario resolves via the 200 ms fallback, well under a 1 s bound.

I also verified the helper's own tests fail if the fallback is stripped out, so they're pinning the bound rather than passing incidentally.

### Displacement

The fallback path skips waiting for the next paint. In that window the old code did nothing but wait for a frame that would never come — no state was read or mutated. The only effect is delaying the "Complete: 100%" progress paint by up to 200 ms in the rare hidden-tab-mid-load case; painting on resume still happens naturally on the next real frame.

### Verification

Full `apps/viewer` suite: **3198 tests, 0 failures, 2 skipped**. Helper tests 5/5. `tsc --noEmit` clean on all five touched files. No changeset — `apps/viewer` is `"private": true`.

### Not done

No integration test driving the full `useIfcLoader`/`useClash` hooks under a simulated hidden tab — there's no harness for those hooks, and standing one up is well beyond this fix. The extracted, injectable helper is the testable unit instead, matching the established pattern.
