### PR TITLE
fix(viewer): make the advanced Filter tab's row click actually show the framing

### DIFF
--- a/apps/viewer/src/components/viewer/SearchModal.filter.tsx
+++ b/apps/viewer/src/components/viewer/SearchModal.filter.tsx
@@ -65,6 +65,7 @@ export function SearchModalFilter() {
     activeModelId,
     setSelectedEntity,
     setSelectedEntityId,
+    setSelectedEntityIds,
     cameraCallbacks,
     setPendingListDraft,
     setListPanelVisible,
@@ -86,6 +87,7 @@ export function SearchModalFilter() {
       activeModelId: s.activeModelId,
       setSelectedEntity: s.setSelectedEntity,
       setSelectedEntityId: s.setSelectedEntityId,
+      setSelectedEntityIds: s.setSelectedEntityIds,
       cameraCallbacks: s.cameraCallbacks,
       setPendingListDraft: s.setPendingListDraft,
       setListPanelVisible: s.setListPanelVisible,
@@ -280,12 +282,31 @@ export function SearchModalFilter() {
         : null;
     if (expressId === null || expressId <= 0) return;
     const globalId = toGlobalIdFromModels(models, rowModelId, expressId);
+    // Clear any live multi-selection FIRST. `frameSelection` prefers the
+    // numeric `selectedEntityIds` set over `selectedEntityId`
+    // (Viewport.tsx:935), so a stale set left over from a previous
+    // box/basket selection would frame the OLD elements instead of this row.
+    // Ordering is load-bearing: `setSelectedEntityIds([])` also resets
+    // `selectedEntityId`, so it has to run before the two setters below —
+    // same sequence HierarchyPanel uses (HierarchyPanel.tsx:410-411).
+    setSelectedEntityIds([]);
     setSelectedEntityId(globalId);
     setSelectedEntity({ modelId: rowModelId, expressId });
     if (cameraCallbacks.frameSelection) {
       window.setTimeout(() => cameraCallbacks.frameSelection?.(), 50);
     }
-  }, [activeModelId, cameraCallbacks, models, modelIdColumnIndex, selectionKeyIndex, setSelectedEntity, setSelectedEntityId]);
+    // Close the modal so the framing is actually visible. The dialog overlay
+    // is `fixed inset-0 bg-black/80` (ui/dialog.tsx:23), so without this the
+    // camera does fly to the element behind a full-screen scrim and the click
+    // reads as doing nothing. The Search tab (SearchModal.text.tsx) and the
+    // inline bar (SearchInline.tsx) both already close on commit; this is
+    // parity with them and with the modal's own documented commit semantics
+    // ("select + frame + ... + close", SearchModal.tsx:19).
+    // Results survive: `searchFilterResult` is only dropped on a model change
+    // (store/index.ts:544), never on close, so reopening shows the same table
+    // without re-running the filter.
+    setSearchModalOpen(false);
+  }, [activeModelId, cameraCallbacks, models, modelIdColumnIndex, selectionKeyIndex, setSearchModalOpen, setSelectedEntity, setSelectedEntityId, setSelectedEntityIds]);
 
   const handleExport = useCallback((format: 'csv' | 'json') => {
     if (!searchFilterResult || searchFilterResult.rows.length === 0) return;

--- a/apps/viewer/src/components/viewer/SearchModal.filter.wiring.test.ts
+++ b/apps/viewer/src/components/viewer/SearchModal.filter.wiring.test.ts
@@ -1,0 +1,109 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Source-level wiring tests for the advanced Filter tab's row-click handler.
+ *
+ * `SearchModalFilter` reads the store directly and renders a virtualized
+ * table, so it cannot be mounted under `tsx --test`, and this repo rejects
+ * `mock.module` (see `apps/viewer/src/sdk/ExtensionHostProvider.tsx:27-30`).
+ * What actually broke here was not logic but WIRING — the handler selected
+ * and framed but never cleared the stale multi-selection and never closed the
+ * modal, so the camera flew to the element behind a full-screen `bg-black/80`
+ * scrim and the click read as doing nothing. Only a test that pins the call
+ * sequence catches that class of regression.
+ *
+ * The ordering assertion is the load-bearing one: `setSelectedEntityIds([])`
+ * also resets `selectedEntityId` (HierarchyPanel.tsx:410-411), so clearing
+ * AFTER selecting would silently throw the selection away and frame nothing.
+ */
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(join(here, 'SearchModal.filter.tsx'), 'utf8');
+
+/**
+ * Strip `//` line comments. Without this these tests are VACUOUS: the
+ * handler's own comments quote the very calls being asserted (e.g.
+ * "`setSelectedEntityIds([])` also resets `selectedEntityId`"), so a naive
+ * `indexOf` matches the comment rather than the statement — and since the
+ * comment sits above both calls, the ordering assertion passes no matter
+ * how the real statements are ordered. Verified by mutation: swapping the
+ * two calls left all assertions green until comments were stripped.
+ */
+function stripLineComments(text: string): string {
+  return text
+    .split('\n')
+    .filter((line) => !line.trimStart().startsWith('//'))
+    .join('\n');
+}
+
+/** The body of `handleRowClick`, from its declaration to the dependency array. */
+function handleRowClickBody(): string {
+  const start = source.indexOf('const handleRowClick = useCallback(');
+  assert.notEqual(start, -1, 'handleRowClick must exist in SearchModal.filter.tsx');
+  const end = source.indexOf('}, [', start);
+  assert.notEqual(end, -1, 'handleRowClick must end with a dependency array');
+  const body = stripLineComments(source.slice(start, end));
+  // Guard the guard: if the stripping ever removes the statements themselves,
+  // every assertion below would fail loudly rather than silently pass.
+  assert.ok(body.includes('setSelectedEntityId('), 'stripped body must retain the selection calls');
+  return body;
+}
+
+describe('advanced Filter tab: row-click wiring', () => {
+  test('clears the multi-selection, selects, frames, and closes the modal', () => {
+    const body = handleRowClickBody();
+    for (const call of [
+      'setSelectedEntityIds([])',
+      'setSelectedEntityId(globalId)',
+      'setSelectedEntity({',
+      'cameraCallbacks.frameSelection',
+      'setSearchModalOpen(false)',
+    ]) {
+      assert.ok(body.includes(call), `handleRowClick must call ${call}`);
+    }
+  });
+
+  test('clears the multi-selection BEFORE selecting, since clearing resets selectedEntityId', () => {
+    const body = handleRowClickBody();
+    const cleared = body.indexOf('setSelectedEntityIds([])');
+    const selected = body.indexOf('setSelectedEntityId(globalId)');
+    assert.ok(cleared >= 0 && selected >= 0, 'both calls must be present');
+    assert.ok(
+      cleared < selected,
+      'setSelectedEntityIds([]) must run BEFORE setSelectedEntityId — clearing also resets selectedEntityId, so the reverse order discards the selection and frames nothing',
+    );
+  });
+
+  test('closes the modal only after requesting the frame', () => {
+    const body = handleRowClickBody();
+    const frame = body.indexOf('cameraCallbacks.frameSelection');
+    const close = body.indexOf('setSearchModalOpen(false)');
+    assert.ok(frame >= 0 && close >= 0, 'both calls must be present');
+    assert.ok(close > frame, 'the frame must be requested before the modal closes');
+  });
+
+  test('the handler declares every store setter it calls as a dependency', () => {
+    const start = source.indexOf('const handleRowClick = useCallback(');
+    const depsStart = source.indexOf('}, [', start);
+    const depsEnd = source.indexOf(']);', depsStart);
+    const deps = source.slice(depsStart, depsEnd);
+    for (const dep of ['setSearchModalOpen', 'setSelectedEntityIds', 'setSelectedEntityId']) {
+      assert.ok(deps.includes(dep), `${dep} must be in the useCallback dependency array`);
+    }
+  });
+
+  test('the component binds setSelectedEntityIds from the store', () => {
+    assert.ok(
+      source.includes('setSelectedEntityIds: s.setSelectedEntityIds'),
+      'setSelectedEntityIds must be pulled from the store selector, or the handler would reference an undefined binding',
+    );
+  });
+});


### PR DESCRIPTION
Reported by a user: *"I search using the advanced search in the elements tab, it does not frame the object or does not apply the filter in the search bar on the model view."*

That's two separate things. **One is a bug and is fixed here; the other has never been implemented**, and I don't think it should be added without your call. Splitting them out below.

## 1. "Does not frame the object" — a real bug, fixed

The Filter tab's row click *does* select and frame (`SearchModal.filter.tsx:285-287`). But it never closes the modal, and the dialog overlay is `fixed inset-0 z-50 bg-black/80` (`ui/dialog.tsx:23`) — so the camera flies to the element behind a full-screen scrim, and the click reads as doing nothing.

Both siblings already close on commit: the Search tab (`SearchModal.text.tsx:136`, `onClose()`) and the inline bar (`SearchInline.tsx:279`, `closeSearch()`). The two handlers are otherwise near-identical — the missing close is the entire behavioural difference. The modal's own header doc states the intent: *"Enter — commit (select + frame + enter vim cycle + close)"* (`SearchModal.tsx:19`).

Closing is safe: `searchFilterResult` is dropped only on a **model change** (`store/index.ts:544`), never on close, so reopening shows the same table without re-running the filter.

### A second, quieter bug on the same line

The handler never cleared the numeric multi-selection — but `frameSelection` *prefers* it:

```ts
const ids = set && set.size > 0 ? Array.from(set) : ...   // Viewport.tsx:935
```

So with a live box or basket selection, clicking a filter row framed the **old** elements. `HierarchyPanel` already guards this (`"Clear multi-selection first"`, `HierarchyPanel.tsx:410-411`); the search paths don't.

Ordering is load-bearing: `setSelectedEntityIds([])` also resets `selectedEntityId`, so clearing *after* selecting would silently discard the selection and frame nothing. Clear first, then select — the sequence `HierarchyPanel` uses.

## 2. "Does not apply the filter on the model view" — never implemented

Not a broken wire. The advanced filter's output is read by nothing outside its own table: `searchFilterResult` appears only in the slice declaration, its setter, the model-change reset, and its tests. It never writes `isolatedEntities`, `hiddenEntities`, `classFilter`, or the basket.

The inline bar reflects only the **rule-count badge** (`SearchInline.tsx:106`) and the shared query text — never the result set. The one bridge from filter results to the rest of the app is the manual **"Create list"** button.

There's also an explicit comment framing the filter as a query concept deliberately decoupled from visibility (`sdk/adapters/query-adapter.ts:317-328`): *"Hidden/isolated visibility is intentionally NOT consulted: the chosen semantics are 'active search/filter only'."* That governs the query→export direction rather than this one, and I found **no** comment, doc, or test asserting a filter run should isolate geometry — so I'm not claiming the edge was designed and dropped.

An "Isolate these results in the 3D view" action next to *Create list* / *Export* would be small and the isolation machinery already exists (`isolateEntities`, `executeBasketIsolate`). Happy to add it — but it's a product decision, so I'd rather you rule on it than have me infer it.

## Testing

`SearchModalFilter` reads the store directly and renders a virtualized table, so it can't be mounted under `tsx --test`, and this repo rejects `mock.module` (`ExtensionHostProvider.tsx:27-30`). What broke here was wiring, not logic, so the test pins the call sequence at source level — the only thing that catches a disconnected wire.

**Worth flagging: the first version of that test was vacuous.** It passed against a deliberately reordered handler, because the handler's own comments quote the calls being asserted, so `indexOf` matched the *comment* — which sits above both statements, making the ordering assertion unfalsifiable. Comments are now stripped first, with a guard asserting the stripped body still contains the statements so the stripper can't silently gut the test.

Mutation-verified after the fix:

| Mutation | Result |
|---|---|
| remove `setSearchModalOpen(false)` | 2 of 5 fail |
| swap the clear and the select | 1 of 5 fails (`must run BEFORE`) |

## Deliberately not done

- The Filter tab still doesn't call `enterVimCycle`, so `n`/`N` stepping is unavailable there. Wiring it needs a shape conversion (`unknown[][]` rows vs `SearchResult[]`) — more than this fix warrants, but it's the natural follow-up if you'd rather users step through matches than reopen.
- The stale-multi-selection guard is also missing from `SearchInline.tsx:235` and `SearchModal.text.tsx:125` — same shape. Left alone rather than widened without review; say the word and I'll take them.

## Verification

`apps/viewer`: **3198 tests, 0 failures, 2 skipped** (5 added). `tsc --noEmit` clean. No changeset — `apps/viewer` is `"private": true`.
