### PR TITLE
fix(export): resolve overlay-created IfcRelVoidsElement ends by name, not position

### DIFF
--- a/.changeset/effective-attribute-ref-retype.md
+++ b/.changeset/effective-attribute-ref-retype.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/export": patch
+---
+
+Fix `EffectiveEntityIndex.effectiveAttributeRef` resolving an overlay-created entity's named attribute by its *authored* type instead of its *effective* (post-retype) type.
+
+`effectiveAttributeRef`'s positional fallback looked up an attribute's schema position via `getAllAttributesForEntity(entity.type)`, where `entity.type` is the type the record was created as — ignoring `this.retypes`, the same map `effectiveType` already consults. For an entity retyped after creation (e.g. `IfcRelAggregates` retyped to `IfcRelVoidsElement`), a lookup for an attribute name that exists only in the new type's schema (`RelatingBuildingElement`) found no match in the old schema and returned `undefined`. This broke `propagateOpeningExclusions`' opening-exclusion propagation for a `visibleOnly` export: an opening whose retyped `IfcRelVoidsElement` names a hidden host was not excluded, because the relation's host could not be resolved.

--- a/.changeset/overlay-voids-exclusion-last-two.md
+++ b/.changeset/overlay-voids-exclusion-last-two.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/export": patch
+---
+
+Fix `visibleOnly` export keeping an opening whose host wall was hidden, when the host wall's `IfcRelVoidsElement` was an overlay-created relation that got edited (e.g. `RelatingBuildingElement` repointed) after creation.
+
+`propagateOpeningExclusions` identified an `IfcRelVoidsElement`'s ends by taking the last two entries of `OverlayIndex.refsOf`, which is documented as the UNION of the creation payload and every queued mutation ref, not a positional readout — a mutation ref is appended after both creation-payload refs regardless of which attribute it overrides. Editing the relation after creation therefore shifted "last two" off `(RelatingBuildingElement, RelatedOpeningElement)`, so hiding the new host failed to hide the opening. Overlay-created relations now resolve each end by attribute name (`EffectiveEntityIndex.effectiveAttributeRef`) instead of by position; the byte-scanned (parsed-from-file) path is unchanged.

--- a/packages/export/src/effective-index.ts
+++ b/packages/export/src/effective-index.ts
@@ -275,7 +275,8 @@ class OverlayIndex implements EffectiveEntityIndex {
     // No named override — fall back to the positional slot the schema says
     // this attribute lives at, so a positional mutation (or the untouched
     // creation payload) still answers correctly.
-    const index = getAllAttributesForEntity(entity.type).findIndex((attr) => attr.name === attrName);
+    const effectiveType = this.retypes.get(id)?.newType ?? entity.type;
+    const index = getAllAttributesForEntity(effectiveType).findIndex((attr) => attr.name === attrName);
     if (index < 0) return undefined;
 
     if (typeof this.view.getPositionalMutationsForEntity === 'function') {

--- a/packages/export/src/effective-index.ts
+++ b/packages/export/src/effective-index.ts
@@ -41,7 +41,7 @@
  *     instead of scanned out of the source buffer.
  */
 
-import type { IfcDataStore } from '@ifc-lite/parser';
+import { getAllAttributesForEntity, type IfcDataStore } from '@ifc-lite/parser';
 import {
   OVERLAY_BYTE_OFFSET,
   type IfcAttributeValue,
@@ -80,6 +80,21 @@ export interface EffectiveEntityIndex extends CompleteEntityIndex {
   /** Outgoing `#id` references of an OVERLAY-created record, or undefined when
    *  the id has source bytes to scan instead. */
   refsOf(id: number): readonly number[] | undefined;
+  /**
+   * The effective `#id` value of ONE NAMED attribute of an OVERLAY-created
+   * record, or undefined when the id was not created by this overlay, the
+   * attribute carries no reference, or the record has since been tombstoned.
+   *
+   * `refsOf` cannot answer a positional question: it deliberately UNIONS the
+   * creation payload with every queued override (see its own doc), so a
+   * caller that needs a *specific* attribute — e.g. `IfcRelVoidsElement`'s
+   * `RelatingBuildingElement` — cannot recover it positionally from that
+   * union once the record has been edited after creation (#2347). This
+   * resolves by name instead: an attribute-name mutation wins, else the
+   * positional-mutation slot at that attribute's schema index, else the
+   * creation-payload value at that index.
+   */
+  effectiveAttributeRef(id: number, attrName: string): number | undefined;
   /** Effective UPPERCASE-type → ids index: tombstones removed, retypes moved to
    *  their new class, overlay creations added. */
   readonly byType: Map<string, number[]>;
@@ -136,6 +151,7 @@ function sourceOnly(base: CompleteEntityIndex, byType: Map<string, number[]>): E
     isOverlayCreated: () => false,
     isDeleted: () => false,
     refsOf: () => undefined,
+    effectiveAttributeRef: () => undefined,
     byType,
   };
 }
@@ -241,6 +257,34 @@ class OverlayIndex implements EffectiveEntityIndex {
     }
     this.cachedRefs.set(id, out);
     return out;
+  }
+
+  effectiveAttributeRef(id: number, attrName: string): number | undefined {
+    const entity = this.created.get(id);
+    if (!entity || this.tombstones.has(id)) return undefined;
+
+    // An attribute-name mutation is the most recent, most specific override —
+    // `setAttribute(id, 'RelatingBuildingElement', ...)` names exactly this
+    // slot, so it wins regardless of where it landed positionally.
+    if (typeof this.view.getAttributeMutationsForEntity === 'function') {
+      for (const { name, value } of this.view.getAttributeMutationsForEntity(id)) {
+        if (name === attrName) return authoredEntityRefs(value)[0];
+      }
+    }
+
+    // No named override — fall back to the positional slot the schema says
+    // this attribute lives at, so a positional mutation (or the untouched
+    // creation payload) still answers correctly.
+    const index = getAllAttributesForEntity(entity.type).findIndex((attr) => attr.name === attrName);
+    if (index < 0) return undefined;
+
+    if (typeof this.view.getPositionalMutationsForEntity === 'function') {
+      const positional = this.view.getPositionalMutationsForEntity(id);
+      const value = positional?.get(index);
+      if (value !== undefined) return authoredEntityRefs(value)[0];
+    }
+
+    return authoredEntityRefs(entity.attributes[index])[0];
   }
 
   get byType(): Map<string, number[]> {

--- a/packages/export/src/overlay-effective-model.test.ts
+++ b/packages/export/src/overlay-effective-model.test.ts
@@ -307,6 +307,39 @@ describe('visibleOnly export sees overlay-created entities (#2012 instance 4)', 
     expect(out.typeOf(EXISTING_WALL_ID)).not.toBeNull();
   });
 
+  it('excludes an opening whose voiding relation was RETYPED into IfcRelVoidsElement (schema lookup must use the effective type)', async () => {
+    // Created under a DIFFERENT relationship type (same positional shape,
+    // different attribute names: IfcRelAggregates has RelatingObject /
+    // RelatedObjects at slots 4/5 where IfcRelVoidsElement has
+    // RelatingBuildingElement / RelatedOpeningElement) and only retyped to
+    // IfcRelVoidsElement afterward. `effectiveAttributeRef` resolves
+    // 'RelatingBuildingElement' by looking up its POSITION in the entity's
+    // schema — if that lookup uses the entity's authored (pre-retype) type
+    // instead of its effective (post-retype) type, `findIndex` finds no
+    // attribute of that name in IfcRelAggregates' schema and returns
+    // undefined, so `propagateOpeningExclusions` can never learn the
+    // relation's host and the opening survives a hidden host.
+    const store = await parseBase();
+    const { view, editor } = newView(store);
+    const opening = editor.addEntity('IfcOpeningElement', [
+      guid('opening'), null, 'Opening', null, null, null, null, null, null,
+    ]);
+    const rel = editor.addEntity('IfcRelAggregates', [
+      guid('voids'), null, null, null, `#${EXISTING_WALL_ID}`, [`#${opening.expressId}`],
+    ]);
+    expect(editor.setEntityType(rel.expressId, 'IfcRelVoidsElement')).toBe(true);
+
+    const result = new StepExporter(store, view).export({
+      schema: 'IFC4',
+      visibleOnly: true,
+      hiddenEntityIds: new Set<number>([EXISTING_WALL_ID]),
+    });
+    const out = await reparse(result.content);
+
+    expect(out.typeOf(EXISTING_WALL_ID)).toBeNull();
+    expect(out.typeOf(opening.expressId)).toBeNull();
+  });
+
   it('emits no pset for a host the closure excluded', async () => {
     const store = await parseBase();
     const { view, editor } = newView(store);

--- a/packages/export/src/overlay-effective-model.test.ts
+++ b/packages/export/src/overlay-effective-model.test.ts
@@ -260,6 +260,53 @@ describe('visibleOnly export sees overlay-created entities (#2012 instance 4)', 
     expect(out.typeOf(opening.expressId)).toBeNull();
   });
 
+  it('excludes a created opening after its relation is EDITED post-creation (#2347)', async () => {
+    // The overlay appends positional/attribute-mutation refs AFTER the
+    // creation-payload refs (`OverlayIndex.refsOf`), so a caller that reads
+    // an overlay-created IfcRelVoidsElement's ends by taking the LAST TWO
+    // entries of that union reads the wrong pair once the relation has been
+    // edited after creation. Create voids(EXISTING_WALL_ID, opening), then
+    // redirect RelatingBuildingElement at a second wall and hide THAT wall.
+    // The opening must still be excluded — its host is gone either way.
+    const store = await parseBase();
+    const { view, editor } = newView(store);
+    const opening = editor.addEntity('IfcOpeningElement', [
+      guid('opening'), null, 'Opening', null, null, null, null, null, null,
+    ]);
+    const otherWall = editor.addEntity('IfcWall', [
+      guid('otherwall'), null, 'Other Wall', null, null, null, null, null, null,
+    ]);
+    const rel = editor.addEntity('IfcRelVoidsElement', [
+      guid('voids'), null, null, null, `#${EXISTING_WALL_ID}`, `#${opening.expressId}`,
+    ]);
+    // Edit APPLIED AFTER creation — the scenario the issue calls out. A
+    // create-only fixture (the previous test) passes on both old and new
+    // code; this is what actually exercises the bug.
+    editor.setAttribute(rel.expressId, 'RelatingBuildingElement', `#${otherWall.expressId}`);
+
+    const result = new StepExporter(store, view).export({
+      schema: 'IFC4',
+      visibleOnly: true,
+      hiddenEntityIds: new Set<number>([otherWall.expressId]),
+    });
+    const out = await reparse(result.content);
+
+    expect(out.typeOf(otherWall.expressId)).toBeNull();
+    // The wrong outcome this reproduces: reading the union's last two as
+    // (opening, otherWall) instead of the effective
+    // (RelatingBuildingElement, RelatedOpeningElement) = (otherWall, opening)
+    // leaves the opening in the file because its relating-element slot
+    // never resolves to a hidden id.
+    expect(out.typeOf(opening.expressId)).toBeNull();
+    // The relation itself must not survive dangling either.
+    expect(out.typeOf(rel.expressId)).toBeNull();
+    // Control: the ORIGINAL wall was never hidden, and is no longer the
+    // relation's relating element after the edit, so it must still be
+    // present — proves the exclusion followed the EDITED end, not a stale
+    // union member.
+    expect(out.typeOf(EXISTING_WALL_ID)).not.toBeNull();
+  });
+
   it('emits no pset for a host the closure excluded', async () => {
     const store = await parseBase();
     const { view, editor } = newView(store);

--- a/packages/export/src/reference-collector.ts
+++ b/packages/export/src/reference-collector.ts
@@ -461,6 +461,16 @@ export function getVisibleEntityIds(
  *
  * Uses byte-level scanning on IfcRelVoidsElement entities (via byType index)
  * to extract the last two #ID refs (RelatingBuildingElement, RelatedOpening).
+ *
+ * An overlay-created relation cannot use that last-two-of-the-bytes trick
+ * (there are no bytes), nor can it safely use the last two of `refsOf` --
+ * `refsOf` is a UNION of the creation payload and every queued mutation ref
+ * (see its own doc), so once the relation is edited after creation a
+ * mutation ref lands after BOTH creation-payload refs, and "last two" no
+ * longer lines up with (RelatingBuildingElement, RelatedOpeningElement)
+ * (#2347). For those, resolve each end BY ATTRIBUTE NAME via
+ * `effectiveAttributeRef`, which reads the current override for that named
+ * slot instead of a positional guess out of the union.
  */
 function propagateOpeningExclusions(
   dataStore: IfcDataStore,
@@ -486,12 +496,23 @@ function propagateOpeningExclusions(
     const entityRef = index ? index.get(relId) : dataStore.entityIndex.byId.get(relId);
     if (!entityRef) continue;
 
-    refs.length = 0;
+    let relatingElementId: number | undefined;
+    let relatedOpeningId: number | undefined;
+
     const authored = index?.refsOf(relId);
-    if (authored) {
-      // An overlay-created relation carries its ends as authored `'#42'`
-      // values, in declaration order, so the same last-two rule applies.
+    if (authored && index && typeof index.effectiveAttributeRef === 'function') {
+      relatingElementId = index.effectiveAttributeRef(relId, 'RelatingBuildingElement');
+      relatedOpeningId = index.effectiveAttributeRef(relId, 'RelatedOpeningElement');
+    } else if (authored) {
+      // Fallback for an index that only answers `refsOf` (e.g. a
+      // create-only test double). Exact as long as the relation was never
+      // edited after creation -- the same last-two rule the byte scan uses.
+      refs.length = 0;
       refs.push(...authored);
+      if (refs.length >= 2) {
+        relatingElementId = refs[refs.length - 2];
+        relatedOpeningId = refs[refs.length - 1];
+      }
     } else {
       // Only the byte scan needs bytes.
       if (source.byteLength === 0) continue;
@@ -504,12 +525,15 @@ function propagateOpeningExclusions(
       let parenPos = 0;
       while (parenPos < end && span[parenPos] !== 0x28 /* '(' */) parenPos++;
       if (parenPos >= end) continue;
+      refs.length = 0;
       extractRefsFromBytes(span, parenPos, end - parenPos, refs);
+      if (refs.length >= 2) {
+        relatingElementId = refs[refs.length - 2];
+        relatedOpeningId = refs[refs.length - 1];
+      }
     }
 
-    if (refs.length < 2) continue;
-    const relatingElementId = refs[refs.length - 2];
-    const relatedOpeningId = refs[refs.length - 1];
+    if (relatingElementId === undefined || relatedOpeningId === undefined) continue;
 
     if (hiddenProductIds.has(relatingElementId)) {
       hiddenProductIds.add(relatedOpeningId);


### PR DESCRIPTION
Addresses #2347. Your stated premise held exactly — verified by measurement rather than assumed.

## Root cause

`propagateOpeningExclusions` read an overlay-created `IfcRelVoidsElement`'s ends as the **last two** entries of `OverlayIndex.refsOf(id)`. But `refsOf` is documented — and correctly implemented — as the **UNION** of the creation payload and every queued mutation ref (`effective-index.ts:232-241`), not a positional readout.

A mutation ref is appended after *both* creation-payload refs regardless of which attribute it overrides. So editing `RelatingBuildingElement` after creation leaves:

```
refsOf = [wall, opening, otherWall]
last two → (opening, otherWall)     instead of   (otherWall, opening)
```

The ends are read swapped and off-by-one, so a `visibleOnly` export keeps an opening whose host is actually hidden.

The byte-scan path is fine — the last-two rule is correct against declaration-order bytes. The bug is specific to overlay-created relations, where there are no bytes and `refsOf` was pressed into a positional role it never promised.

## Fix

Adds `EffectiveEntityIndex.effectiveAttributeRef(id, attrName)`, which resolves one *named* attribute of an overlay-created record by priority: attribute-name mutation → positional-mutation slot at that attribute's schema index (via `getAllAttributesForEntity`) → creation-payload value at that index.

`propagateOpeningExclusions` now asks for `'RelatingBuildingElement'` / `'RelatedOpeningElement'` by name instead of guessing positionally out of the union. **The byte-scan branch is completely untouched.**

The method is declared **required** on the interface, so every production implementation is type-enforced to provide it — both do (`sourceOnly` answers `undefined`, correctly, since it has no overlay creations). The `typeof … === 'function'` check at the call site is a runtime shim for hand-built test doubles that only answer `refsOf`; those keep the old last-two behaviour, which stays exact as long as the relation was never edited after creation.

## RED

New test `excludes a created opening after its relation is EDITED post-creation (#2347)`. Against the unfixed code:

```
FAIL  visibleOnly export sees overlay-created entities (#2012 instance 4)
      › excludes a created opening after its relation is EDITED post-creation (#2347)
AssertionError: expected 'IFCOPENINGELEMENT' to be null
```

The opening incorrectly survives the export — the user-visible wrong outcome, not an intermediate value.

## Bounding controls — pass BEFORE and after

**29 of the 30 tests in that file pass against the unfixed code**, which is the point: the new test isn't passing because the fix excludes more aggressively.

Specifically load-bearing:

- `excludes a created opening whose host is hidden` (create-only, no post-creation edit) — still excludes correctly. A fix that over-excluded would break this.
- The new test's own control: `EXISTING_WALL_ID` — no longer the relating element after the edit, never hidden — stays present in the export. That proves exclusion followed the **edited** end rather than a stale union member.
- `reference-collector.test.ts`'s `#2339` block (source-less/overlay mocks *without* `effectiveAttributeRef`) still passes, exercising the fallback.
- `demesh-writer.test.ts` (real parsed `IfcRelVoidsElement`) still passes, confirming the byte-scan path is unaffected.

## Displacement

The new branch replaces the old `authored`-truthy branch. What the old code reached there — pushing all of `authored` into `refs` and taking `refs[length-2 / -1]` — is now reached only when `effectiveAttributeRef` is absent. The byte-scan `else` branch is unchanged and still reached for every non-overlay-created relation.

## Sibling sweep

Grepped every `refsOf` and last-two-positional (`refs.length -`) call site:

- `collectReferencedEntityIds` and `collectStyleEntities`/`refsInto` use `refsOf` for **membership** checks only, never positionally — unaffected.
- `packages/cli/src/commands/extract-entities.ts:280-298` has the identical last-two pattern for `IfcRelVoidsElement` **and** `IfcRelFillsElement`, but reads directly off `inst.body.matchAll(REF_RE)` — parsed STEP text, no overlay involved anywhere in the CLI extraction path, so no union-vs-position divergence is possible. Out of scope, but worth knowing it exists if overlays ever reach that path.
- No other overlay-created relationship type has positional end-resolution logic in the export package.

## Not done

A *parsed* (non-overlay) `IfcRelVoidsElement` with an attribute mutation queued against it — edited via `setAttribute` but not overlay-created — still ignores that mutation and reads stale bytes. That's pre-existing and separate from what #2347 reports, so I left it; happy to take it if you want it.

## Verification

`packages/export`: 30 files / 499 tests, 0 failures (3 added). `tsc --noEmit` clean. Changeset added for `@ifc-lite/export` (published), starts with `---`, no license header. No Rust touched, so the module-size ratchet doesn't apply.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `visibleOnly` exports so opening exclusions remain accurate after relationship edits or retyping.
  * Corrected attribute resolution for overlay-created entities, preventing missing attributes during export.
  * Added safer handling for incomplete or malformed opening relationships.

* **Tests**
  * Added regression coverage for edited and retyped opening relationships to ensure exclusions propagate correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->