### PR TITLE
perf(viewer): make StatusBar stats and robustFitBounds incremental during streaming

### DIFF
--- a/apps/viewer/src/components/viewer/StatusBar.tsx
+++ b/apps/viewer/src/components/viewer/StatusBar.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { useMemo, useState, useEffect } from 'react';
+import { useMemo, useRef, useState, useEffect } from 'react';
 import { Boxes, Triangle, CheckCircle2, AlertCircle, Loader2 } from 'lucide-react';
 import { Separator } from '@/components/ui/separator';
 import { formatNumber, formatBytes } from '@/lib/utils';
@@ -11,6 +11,7 @@ import { useIfc } from '@/hooks/useIfc';
 import { useWebGPU } from '@/hooks/useWebGPU';
 import { FlavorIndicator } from '@/components/extensions/FlavorIndicator';
 import { FlavorDialog } from '@/components/extensions/FlavorDialog';
+import { createStatusBarStatsAccumulator } from './statusBarStats.js';
 
 export function StatusBar() {
   const { loading, geometryResult, ifcDataStore } = useIfc();
@@ -75,31 +76,21 @@ export function StatusBar() {
     return () => clearInterval(interval);
   }, []);
 
-  const stats = useMemo(() => {
-    if (!geometryResult) {
-      return { elements: 0, triangles: 0 };
-    }
-    // Count actual entities: for color-merged meshes, count unique entity IDs
-    let elements = 0;
-    const meshes = geometryResult.meshes;
-    if (meshes) {
-      for (let i = 0; i < meshes.length; i++) {
-        const m = meshes[i] as { entityIds?: Uint32Array };
-        if (m.entityIds && m.entityIds.length > 0) {
-          // Count unique entity IDs in this merged mesh
-          const seen = new Set<number>();
-          for (let j = 0; j < m.entityIds.length; j++) seen.add(m.entityIds[j]);
-          elements += seen.size;
-        } else {
-          elements += 1;
-        }
-      }
-    }
-    return {
-      elements,
-      triangles: geometryResult.totalTriangles ?? 0,
-    };
-  }, [geometryResult]);
+  // PERF: geometryResult is a NEW object on every streaming batch commit
+  // (dataSlice.ts appendGeometryBatch), so this memo's dependency never
+  // hits during a stream — it re-derives stats every commit. A full O(meshes
+  // + entityIds) rescan there made a 16.7K-mesh stream spend ~524ms total in
+  // this memo alone (30 commits, allocating a `Set` per merged mesh on EVERY
+  // commit — not just the new ones). The accumulator below tracks how many
+  // meshes it has already folded in (by array identity + length) and only
+  // scans meshes appended since the last call — `geometryResult.meshes` is
+  // the same array reference mutated in place across a stream, so this is
+  // safe; see statusBarStats.ts for the full identity contract.
+  const statsAccRef = useRef(createStatusBarStatsAccumulator());
+  const stats = useMemo(
+    () => statsAccRef.current.update(geometryResult),
+    [geometryResult],
+  );
 
   const visibleElements = useMemo(() => {
     if (selectedStoreys.size === 0 || !ifcDataStore?.spatialHierarchy) {

--- a/apps/viewer/src/components/viewer/perf-bench.manual.ts
+++ b/apps/viewer/src/components/viewer/perf-bench.manual.ts
@@ -1,0 +1,139 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Manual (not CI) benchmark for the two streaming quadratic-rescan fixes.
+ * Run with: npx tsx src/components/viewer/perf-bench.manual.ts
+ *
+ * Simulates a streaming load at several total mesh counts, replaying the
+ * SAME commit/batch pattern against:
+ *   - the OLD full-rescan algorithm (computeStatsFull / robustFitBoundsFull),
+ *     called with the ENTIRE accumulated meshes array on every commit — this
+ *     is what StatusBar's memo and useGeometryStreaming's early-fit branch
+ *     did before the fix, since `geometryResult` is a new object every
+ *     commit (so the memo never hit) and, for robustFitBounds, the
+ *     documented worst case where cameraFittedRef never latches.
+ *   - the NEW incremental accumulator, called the same way.
+ *
+ * Not a *.test.ts — deliberately excluded from `pnpm test` (perf numbers on
+ * a shared CI runner are not a regression gate here); this file exists only
+ * to reproduce the before/after scaling numbers reported alongside the fix.
+ */
+
+import { computeStatsFull, createStatusBarStatsAccumulator, type StatusBarGeometryResult } from './statusBarStats.js';
+import { robustFitBoundsFull, createRobustFitBoundsAccumulator, type RobustFitMeshInput } from './robustFitBoundsAccumulator.js';
+
+function mulberry32(seed: number) {
+  let a = seed;
+  return () => {
+    a |= 0; a = (a + 0x6D2B79F5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function makeMesh(rng: () => number, i: number): { entityIds?: Uint32Array } & RobustFitMeshInput {
+  const vcount = 80 + Math.floor(rng() * 240); // ~80-320 verts/mesh, closer to real element meshes
+  const positions = new Float32Array(vcount * 3);
+  const cx = rng() * 50, cy = rng() * 50, cz = rng() * 50;
+  for (let v = 0; v < vcount; v++) {
+    positions[v * 3] = cx + (rng() - 0.5) * 2;
+    positions[v * 3 + 1] = cy + (rng() - 0.5) * 2;
+    positions[v * 3 + 2] = cz + (rng() - 0.5) * 2;
+  }
+  const idCount = 1 + Math.floor(rng() * 3);
+  const entityIds = new Uint32Array(idCount);
+  for (let k = 0; k < idCount; k++) entityIds[k] = i * 4 + k;
+  return { positions, entityIds };
+}
+
+function commitPlan(totalMeshes: number, commitCount: number): number[] {
+  // Even split into exactly `commitCount` batches, matching the task's
+  // measured commit counts at each size (2K→4, 4K→7, 8K→14, 16.7K→30).
+  const batches: number[] = [];
+  let remaining = totalMeshes;
+  for (let c = 0; c < commitCount; c++) {
+    const left = commitCount - c;
+    const n = Math.ceil(remaining / left);
+    batches.push(n);
+    remaining -= n;
+  }
+  return batches;
+}
+
+function bench(totalMeshes: number, targetCommits: number, seed: number) {
+  const rng = mulberry32(seed);
+  const allMeshes: (({ entityIds?: Uint32Array }) & RobustFitMeshInput)[] = [];
+  for (let i = 0; i < totalMeshes; i++) allMeshes.push(makeMesh(rng, i));
+  const batches = commitPlan(totalMeshes, targetCommits);
+
+  // ── BEFORE: full rescan every commit ──
+  const geomArrayFull: (({ entityIds?: Uint32Array }))[] = [];
+  const meshArrayFull: RobustFitMeshInput[] = [];
+  let idx = 0;
+  const t0 = performance.now();
+  let statsFullTotalMs = 0;
+  let fitFullTotalMs = 0;
+  for (const b of batches) {
+    for (let k = 0; k < b; k++) {
+      geomArrayFull.push(allMeshes[idx]);
+      meshArrayFull.push(allMeshes[idx]);
+      idx++;
+    }
+    const gr: StatusBarGeometryResult = { meshes: geomArrayFull, totalTriangles: geomArrayFull.length * 2 };
+    const s0 = performance.now();
+    computeStatsFull(gr);
+    statsFullTotalMs += performance.now() - s0;
+
+    const f0 = performance.now();
+    robustFitBoundsFull(meshArrayFull);
+    fitFullTotalMs += performance.now() - f0;
+  }
+  const beforeWallMs = performance.now() - t0;
+
+  // ── AFTER: incremental accumulator every commit ──
+  const geomArrayInc: (({ entityIds?: Uint32Array }))[] = [];
+  const meshArrayInc: RobustFitMeshInput[] = [];
+  const statsAcc = createStatusBarStatsAccumulator();
+  const fitAcc = createRobustFitBoundsAccumulator();
+  idx = 0;
+  const t1 = performance.now();
+  let statsIncTotalMs = 0;
+  let fitIncTotalMs = 0;
+  for (const b of batches) {
+    for (let k = 0; k < b; k++) {
+      geomArrayInc.push(allMeshes[idx]);
+      meshArrayInc.push(allMeshes[idx]);
+      idx++;
+    }
+    const gr: StatusBarGeometryResult = { meshes: geomArrayInc, totalTriangles: geomArrayInc.length * 2 };
+    const s0 = performance.now();
+    statsAcc.update(gr);
+    statsIncTotalMs += performance.now() - s0;
+
+    const f0 = performance.now();
+    fitAcc.update(meshArrayInc);
+    fitIncTotalMs += performance.now() - f0;
+  }
+  const afterWallMs = performance.now() - t1;
+
+  console.log(
+    `meshes ${String(totalMeshes).padStart(6)}  commits ${String(batches.length).padStart(3)}  ` +
+    `BEFORE robustFitBounds ${fitFullTotalMs.toFixed(1).padStart(7)}ms  StatusBar.stats ${statsFullTotalMs.toFixed(1).padStart(7)}ms  wall ${beforeWallMs.toFixed(1)}ms  |  ` +
+    `AFTER robustFitBounds ${fitIncTotalMs.toFixed(1).padStart(7)}ms  StatusBar.stats ${statsIncTotalMs.toFixed(1).padStart(7)}ms  wall ${afterWallMs.toFixed(1)}ms`,
+  );
+}
+
+console.log('Simulated streaming load — full rescan (BEFORE) vs incremental accumulator (AFTER)\n');
+const sizesAndCommits: Array<[number, number]> = [
+  [2000, 4],
+  [4000, 7],
+  [8000, 14],
+  [16700, 30],
+  [33400, 60],
+];
+for (const [size, commits] of sizesAndCommits) {
+  bench(size, commits, size);
+}

--- a/apps/viewer/src/components/viewer/perf-bench.manual.ts
+++ b/apps/viewer/src/components/viewer/perf-bench.manual.ts
@@ -63,66 +63,93 @@ function commitPlan(totalMeshes: number, commitCount: number): number[] {
   return batches;
 }
 
+type RunResult = { statsMs: number; fitMs: number; wallMs: number };
+
+function runFull(allMeshes: (({ entityIds?: Uint32Array }) & RobustFitMeshInput)[], batches: number[]): RunResult {
+  const geomArray: (({ entityIds?: Uint32Array }))[] = [];
+  const meshArray: RobustFitMeshInput[] = [];
+  let idx = 0;
+  const t0 = performance.now();
+  let statsMs = 0;
+  let fitMs = 0;
+  for (const b of batches) {
+    for (let k = 0; k < b; k++) {
+      geomArray.push(allMeshes[idx]);
+      meshArray.push(allMeshes[idx]);
+      idx++;
+    }
+    const gr: StatusBarGeometryResult = { meshes: geomArray, totalTriangles: geomArray.length * 2 };
+    const s0 = performance.now();
+    computeStatsFull(gr);
+    statsMs += performance.now() - s0;
+
+    const f0 = performance.now();
+    robustFitBoundsFull(meshArray);
+    fitMs += performance.now() - f0;
+  }
+  return { statsMs, fitMs, wallMs: performance.now() - t0 };
+}
+
+function runIncremental(allMeshes: (({ entityIds?: Uint32Array }) & RobustFitMeshInput)[], batches: number[]): RunResult {
+  const geomArray: (({ entityIds?: Uint32Array }))[] = [];
+  const meshArray: RobustFitMeshInput[] = [];
+  const statsAcc = createStatusBarStatsAccumulator();
+  const fitAcc = createRobustFitBoundsAccumulator();
+  let idx = 0;
+  const t0 = performance.now();
+  let statsMs = 0;
+  let fitMs = 0;
+  for (const b of batches) {
+    for (let k = 0; k < b; k++) {
+      geomArray.push(allMeshes[idx]);
+      meshArray.push(allMeshes[idx]);
+      idx++;
+    }
+    const gr: StatusBarGeometryResult = { meshes: geomArray, totalTriangles: geomArray.length * 2 };
+    const s0 = performance.now();
+    statsAcc.update(gr);
+    statsMs += performance.now() - s0;
+
+    const f0 = performance.now();
+    fitAcc.update(meshArray);
+    fitMs += performance.now() - f0;
+  }
+  return { statsMs, fitMs, wallMs: performance.now() - t0 };
+}
+
+const avg = (a: RunResult, b: RunResult): RunResult => ({
+  statsMs: (a.statsMs + b.statsMs) / 2,
+  fitMs: (a.fitMs + b.fitMs) / 2,
+  wallMs: (a.wallMs + b.wallMs) / 2,
+});
+
 function bench(totalMeshes: number, targetCommits: number, seed: number) {
   const rng = mulberry32(seed);
   const allMeshes: (({ entityIds?: Uint32Array }) & RobustFitMeshInput)[] = [];
   for (let i = 0; i < totalMeshes; i++) allMeshes.push(makeMesh(rng, i));
   const batches = commitPlan(totalMeshes, targetCommits);
 
-  // ── BEFORE: full rescan every commit ──
-  const geomArrayFull: (({ entityIds?: Uint32Array }))[] = [];
-  const meshArrayFull: RobustFitMeshInput[] = [];
-  let idx = 0;
-  const t0 = performance.now();
-  let statsFullTotalMs = 0;
-  let fitFullTotalMs = 0;
-  for (const b of batches) {
-    for (let k = 0; k < b; k++) {
-      geomArrayFull.push(allMeshes[idx]);
-      meshArrayFull.push(allMeshes[idx]);
-      idx++;
-    }
-    const gr: StatusBarGeometryResult = { meshes: geomArrayFull, totalTriangles: geomArrayFull.length * 2 };
-    const s0 = performance.now();
-    computeStatsFull(gr);
-    statsFullTotalMs += performance.now() - s0;
-
-    const f0 = performance.now();
-    robustFitBoundsFull(meshArrayFull);
-    fitFullTotalMs += performance.now() - f0;
-  }
-  const beforeWallMs = performance.now() - t0;
-
-  // ── AFTER: incremental accumulator every commit ──
-  const geomArrayInc: (({ entityIds?: Uint32Array }))[] = [];
-  const meshArrayInc: RobustFitMeshInput[] = [];
-  const statsAcc = createStatusBarStatsAccumulator();
-  const fitAcc = createRobustFitBoundsAccumulator();
-  idx = 0;
-  const t1 = performance.now();
-  let statsIncTotalMs = 0;
-  let fitIncTotalMs = 0;
-  for (const b of batches) {
-    for (let k = 0; k < b; k++) {
-      geomArrayInc.push(allMeshes[idx]);
-      meshArrayInc.push(allMeshes[idx]);
-      idx++;
-    }
-    const gr: StatusBarGeometryResult = { meshes: geomArrayInc, totalTriangles: geomArrayInc.length * 2 };
-    const s0 = performance.now();
-    statsAcc.update(gr);
-    statsIncTotalMs += performance.now() - s0;
-
-    const f0 = performance.now();
-    fitAcc.update(meshArrayInc);
-    fitIncTotalMs += performance.now() - f0;
-  }
-  const afterWallMs = performance.now() - t1;
+  // Each algorithm is run twice per size, in BOTH relative orders (full-then-
+  // incremental and incremental-then-full), and the two runs are averaged.
+  // Running one algorithm right after the other consistently within a
+  // process hands whichever runs SECOND a JIT/inline-cache warm-up
+  // advantage from the first run's shared subroutines (array push, Math.*,
+  // etc.) — averaging both orders cancels that directional bias out.
+  // Execution order: full(1st), incremental(2nd), incremental(3rd), full(4th).
+  // Averaging each algorithm's two runs gives both a mean execution
+  // position of 2.5 (full: (1+4)/2, incremental: (2+3)/2) — symmetric, so
+  // neither consistently benefits from running immediately after the other.
+  const fullRunA = runFull(allMeshes, batches);
+  const incRunA = runIncremental(allMeshes, batches);
+  const incRunB = runIncremental(allMeshes, batches);
+  const fullRunB = runFull(allMeshes, batches);
+  const before = avg(fullRunA, fullRunB);
+  const after = avg(incRunA, incRunB);
 
   console.log(
     `meshes ${String(totalMeshes).padStart(6)}  commits ${String(batches.length).padStart(3)}  ` +
-    `BEFORE robustFitBounds ${fitFullTotalMs.toFixed(1).padStart(7)}ms  StatusBar.stats ${statsFullTotalMs.toFixed(1).padStart(7)}ms  wall ${beforeWallMs.toFixed(1)}ms  |  ` +
-    `AFTER robustFitBounds ${fitIncTotalMs.toFixed(1).padStart(7)}ms  StatusBar.stats ${statsIncTotalMs.toFixed(1).padStart(7)}ms  wall ${afterWallMs.toFixed(1)}ms`,
+    `BEFORE robustFitBounds ${before.fitMs.toFixed(1).padStart(7)}ms  StatusBar.stats ${before.statsMs.toFixed(1).padStart(7)}ms  wall ${before.wallMs.toFixed(1)}ms  |  ` +
+    `AFTER robustFitBounds ${after.fitMs.toFixed(1).padStart(7)}ms  StatusBar.stats ${after.statsMs.toFixed(1).padStart(7)}ms  wall ${after.wallMs.toFixed(1)}ms`,
   );
 }
 

--- a/apps/viewer/src/components/viewer/robustFitBoundsAccumulator.test.ts
+++ b/apps/viewer/src/components/viewer/robustFitBoundsAccumulator.test.ts
@@ -1,0 +1,199 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  robustFitBoundsFull,
+  createRobustFitBoundsAccumulator,
+  type RobustFitMeshInput,
+} from './robustFitBoundsAccumulator.js';
+
+function mulberry32(seed: number) {
+  let a = seed;
+  return () => {
+    a |= 0; a = (a + 0x6D2B79F5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function meshAt(cx: number, cy: number, cz: number, spread: number, n: number, rng: () => number): RobustFitMeshInput {
+  const positions = new Float32Array(n * 3);
+  for (let i = 0; i < n; i++) {
+    positions[i * 3] = cx + (rng() - 0.5) * spread;
+    positions[i * 3 + 1] = cy + (rng() - 0.5) * spread;
+    positions[i * 3 + 2] = cz + (rng() - 0.5) * spread;
+  }
+  return { positions };
+}
+
+// A cluster of `count` compact meshes plus a handful of far outlier meshes —
+// shaped to trigger the `robust` (outlier-trimmed) branch: count >= 8,
+// dropping the outliers meaningfully shrinks the box (< 0.66x).
+function clusterWithOutliers(count: number, outliers: number, rng: () => number): RobustFitMeshInput[] {
+  const meshes: RobustFitMeshInput[] = [];
+  for (let i = 0; i < count; i++) {
+    // Vertex mass matters more than mesh count for the 99.5%-mass keep
+    // threshold — keep each cluster mesh's vertex count well above the
+    // outliers' so the outliers stay under the ~0.5% trim margin.
+    meshes.push(meshAt(rng() * 2, rng() * 2, rng() * 2, 0.5, 40, rng));
+  }
+  for (let i = 0; i < outliers; i++) {
+    // A single vertex each keeps total outlier mass tiny relative to the
+    // cluster, so the 99.5%-mass threshold actually drops them.
+    meshes.push(meshAt(5000 + rng() * 10, 5000 + rng() * 10, 5000 + rng() * 10, 1, 1, rng));
+  }
+  return meshes;
+}
+
+describe('robustFitBounds: incremental accumulator matches full rescan', () => {
+  it('zero meshes → both null', () => {
+    const acc = createRobustFitBoundsAccumulator();
+    const meshes: RobustFitMeshInput[] = [];
+    assert.deepEqual(acc.update(meshes), robustFitBoundsFull(meshes));
+    assert.equal(acc.update(meshes), null);
+  });
+
+  it('one mesh → full bounds only (count < 8), robust null', () => {
+    const rng = mulberry32(1);
+    const meshes = [meshAt(0, 0, 0, 10, 5, rng)];
+    const acc = createRobustFitBoundsAccumulator();
+    const result = acc.update(meshes);
+    assert.deepEqual(result, robustFitBoundsFull(meshes));
+    assert.notEqual(result, null);
+    assert.equal(result!.robust, null);
+  });
+
+  it('mesh with zero vertices (empty positions) contributes nothing, does not crash', () => {
+    const rng = mulberry32(2);
+    const meshes = [meshAt(0, 0, 0, 5, 3, rng), { positions: new Float32Array(0) }, meshAt(1, 1, 1, 5, 3, rng)];
+    const acc = createRobustFitBoundsAccumulator();
+    assert.deepEqual(acc.update(meshes), robustFitBoundsFull(meshes));
+  });
+
+  it('mesh with ALL non-finite / garbage coordinates is filtered out (n stays 0 for it)', () => {
+    const rng = mulberry32(3);
+    const garbage: RobustFitMeshInput = { positions: Float32Array.of(NaN, NaN, NaN, Infinity, -Infinity, 1e20) };
+    const meshes = [meshAt(0, 0, 0, 5, 4, rng), garbage, meshAt(2, 2, 2, 5, 4, rng)];
+    const acc = createRobustFitBoundsAccumulator();
+    const result = acc.update(meshes);
+    assert.deepEqual(result, robustFitBoundsFull(meshes));
+    assert.notEqual(result, null);
+  });
+
+  it('a mesh with a MIX of finite and garbage vertices only folds the finite ones into that mesh\'s box', () => {
+    const rng = mulberry32(4);
+    const mixed: RobustFitMeshInput = {
+      positions: Float32Array.of(1, 1, 1, NaN, NaN, NaN, 2, 2, 2, 1e13, 1e13, 1e13),
+    };
+    const meshes = [mixed, meshAt(0, 0, 0, 3, 6, rng)];
+    const acc = createRobustFitBoundsAccumulator();
+    assert.deepEqual(acc.update(meshes), robustFitBoundsFull(meshes));
+  });
+
+  it('per-element origin is folded in identically', () => {
+    const rng = mulberry32(5);
+    const withOrigin: RobustFitMeshInput = {
+      positions: Float32Array.of(1, 1, 1, -1, -1, -1),
+      origin: [1000, 2000, 3000],
+    };
+    const meshes = [withOrigin, meshAt(0, 0, 0, 5, 6, rng)];
+    const acc = createRobustFitBoundsAccumulator();
+    assert.deepEqual(acc.update(meshes), robustFitBoundsFull(meshes));
+  });
+
+  it('outlier-robust branch: incremental result matches full rescan once the tail triggers `robust`', () => {
+    const rng = mulberry32(6);
+    const meshes = clusterWithOutliers(20, 2, rng);
+    const acc = createRobustFitBoundsAccumulator();
+    const result = acc.update(meshes);
+    const expected = robustFitBoundsFull(meshes);
+    assert.deepEqual(result, expected);
+    // Sanity: this fixture is actually supposed to exercise the robust path.
+    assert.notEqual(expected, null);
+    assert.notEqual(expected!.robust, null);
+  });
+
+  it('streaming simulation: same array reference growing via push, matches full rescan at every commit (compact model)', () => {
+    const rng = mulberry32(7);
+    const acc = createRobustFitBoundsAccumulator();
+    const meshes: RobustFitMeshInput[] = [];
+    for (let commit = 0; commit < 30; commit++) {
+      const batchSize = 1 + Math.floor(rng() * 10);
+      for (let i = 0; i < batchSize; i++) {
+        meshes.push(meshAt(rng() * 3, rng() * 3, rng() * 3, 1, 1 + Math.floor(rng() * 8), rng));
+      }
+      assert.deepEqual(acc.update(meshes), robustFitBoundsFull(meshes), `mismatch at commit ${commit}`);
+    }
+  });
+
+  it('streaming simulation with a growing outlier tail: robust/full both track the full rescan every commit', () => {
+    const rng = mulberry32(8);
+    const acc = createRobustFitBoundsAccumulator();
+    const meshes: RobustFitMeshInput[] = [];
+    for (let commit = 0; commit < 25; commit++) {
+      const batchSize = 1 + Math.floor(rng() * 6);
+      for (let i = 0; i < batchSize; i++) {
+        const isOutlier = commit > 10 && rng() < 0.1;
+        meshes.push(
+          isOutlier
+            ? meshAt(8000 + rng() * 20, 8000 + rng() * 20, 8000 + rng() * 20, 2, 4, rng)
+            : meshAt(rng() * 2, rng() * 2, rng() * 2, 0.8, 1 + Math.floor(rng() * 6), rng),
+        );
+      }
+      assert.deepEqual(acc.update(meshes), robustFitBoundsFull(meshes), `mismatch at commit ${commit}`);
+    }
+  });
+
+  it('new array identity (new file) resets the accumulator instead of mixing in stale meshes', () => {
+    const rng = mulberry32(9);
+    const acc = createRobustFitBoundsAccumulator();
+    const first = [meshAt(0, 0, 0, 2, 5, rng), meshAt(1, 1, 1, 2, 5, rng)];
+    assert.deepEqual(acc.update(first), robustFitBoundsFull(first));
+
+    const second = [meshAt(500, 500, 500, 3, 6, rng)];
+    const result = acc.update(second);
+    assert.deepEqual(result, robustFitBoundsFull(second));
+    // Confirms the old cluster's bounds are gone, not unioned in.
+    assert.ok(result!.full.min.x > 400);
+  });
+
+  it('array shrink (same reference, spliced shorter) triggers a full refold, not a stale/overcounted result', () => {
+    const rng = mulberry32(10);
+    const meshes = [meshAt(0, 0, 0, 2, 5, rng), meshAt(1, 1, 1, 2, 5, rng), meshAt(2, 2, 2, 2, 5, rng)];
+    const acc = createRobustFitBoundsAccumulator();
+    assert.deepEqual(acc.update(meshes), robustFitBoundsFull(meshes));
+
+    meshes.length = 1;
+    const result = acc.update(meshes);
+    assert.deepEqual(result, robustFitBoundsFull(meshes));
+  });
+
+  it('explicit reset() matches a brand-new accumulator on the next update', () => {
+    const rng = mulberry32(11);
+    const meshes = clusterWithOutliers(15, 1, rng);
+
+    const fresh = createRobustFitBoundsAccumulator();
+    const fromFresh = fresh.update(meshes);
+
+    const reused = createRobustFitBoundsAccumulator();
+    reused.update(meshes);
+    reused.reset();
+    const fromReset = reused.update(meshes);
+
+    assert.deepEqual(fromReset, fromFresh);
+  });
+
+  it('a call with no new meshes since the last call is idempotent and matches the full rescan', () => {
+    const rng = mulberry32(12);
+    const meshes = clusterWithOutliers(20, 2, rng);
+    const acc = createRobustFitBoundsAccumulator();
+    const first = acc.update(meshes);
+    const second = acc.update(meshes); // no growth
+    assert.deepEqual(second, first);
+    assert.deepEqual(second, robustFitBoundsFull(meshes));
+  });
+});

--- a/apps/viewer/src/components/viewer/robustFitBoundsAccumulator.ts
+++ b/apps/viewer/src/components/viewer/robustFitBoundsAccumulator.ts
@@ -1,0 +1,204 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Outlier-robust camera-fit bounds, and an incremental accumulator for the
+ * same computation.
+ *
+ * `robustFitBoundsFull` is the original full-rescan algorithm (issue #1394):
+ * every call walks every vertex of every mesh passed in. Kept here — and
+ * exported — purely as the reference implementation that the incremental
+ * accumulator is checked against in tests; production code no longer calls
+ * it directly on the streaming hot path.
+ *
+ * `createRobustFitBoundsAccumulator` produces the same `{ full, robust }`
+ * result but does so incrementally: it remembers which mesh indices of a
+ * given array (by reference) it has already folded into its running sums,
+ * and on each `update()` only walks the vertices of meshes appended since
+ * the last call. During streaming, `useGeometryStreaming` mutates the same
+ * `MeshData[]` array in place (push) and calls `update()` on every commit
+ * while the camera has not yet fitted — see dataSlice.ts `appendGeometryBatch`
+ * for the array-identity contract this relies on.
+ *
+ * The per-mesh bounding-box / centroid / weight arrays (`cx`, `cy`, `cz`,
+ * `w`, `bb`) are appended to in the exact same index order as the original
+ * single-pass loop, so the folded reductions (min/max, weighted centroid
+ * sums) are bit-for-bit identical to a full rescan — floating-point min/max
+ * is order-independent, and the summation order for the weighted centroid
+ * is preserved exactly (indices 0..N in order, whether folded in one call
+ * or across many). The final sort + cumulative "keep innermost mass" pass
+ * still runs over the full accumulated mesh count on every call (it is not,
+ * and cannot cheaply be made, incremental — the centroid it sorts around
+ * shifts as new meshes arrive) but that is O(M log M) in mesh count, not
+ * O(V) in vertex count, so it stays cheap relative to the vertex scan it
+ * replaces.
+ */
+
+export type Bounds = { min: { x: number; y: number; z: number }; max: { x: number; y: number; z: number } };
+
+export interface RobustFitMeshInput {
+  positions: Float32Array | Float64Array;
+  origin?: readonly [number, number, number] | null;
+}
+
+const ROBUST_KEEP_MASS = 0.995;
+const ROBUST_SHRINK_GUARD = 0.66;
+// Real building coordinates can be hundreds of thousands of millimetres from
+// the origin (models that keep mm with no RTC shift) — this is a garbage
+// filter, not a "far from origin" filter, so it is far looser than
+// computeBounds' 10 km guard.
+const ROBUST_GARBAGE_COORD = 1e12;
+
+/**
+ * Reference implementation: full O(V) rescan of every mesh's vertices plus
+ * an O(M log M) sort, on every call. This is the pre-optimization algorithm,
+ * kept for equivalence testing against the incremental accumulator below.
+ */
+export function robustFitBoundsFull(meshes: readonly RobustFitMeshInput[]): { full: Bounds; robust: Bounds | null } | null {
+  let fMinX = Infinity, fMinY = Infinity, fMinZ = Infinity;
+  let fMaxX = -Infinity, fMaxY = -Infinity, fMaxZ = -Infinity;
+  const cx: number[] = [], cy: number[] = [], cz: number[] = [], w: number[] = [];
+  const bb: Float64Array[] = [];
+  let cwX = 0, cwY = 0, cwZ = 0, totalW = 0;
+  for (let gi = 0; gi < meshes.length; gi++) {
+    const positions = meshes[gi].positions;
+    const o = meshes[gi].origin;
+    const ox = o ? o[0] : 0, oy = o ? o[1] : 0, oz = o ? o[2] : 0;
+    let mnX = Infinity, mnY = Infinity, mnZ = Infinity;
+    let mxX = -Infinity, mxY = -Infinity, mxZ = -Infinity;
+    let n = 0;
+    for (let i = 0; i < positions.length; i += 3) {
+      const x = positions[i] + ox, y = positions[i + 1] + oy, z = positions[i + 2] + oz;
+      if (Math.abs(x) < ROBUST_GARBAGE_COORD && Math.abs(y) < ROBUST_GARBAGE_COORD && Math.abs(z) < ROBUST_GARBAGE_COORD) {
+        if (x < mnX) mnX = x; if (y < mnY) mnY = y; if (z < mnZ) mnZ = z;
+        if (x > mxX) mxX = x; if (y > mxY) mxY = y; if (z > mxZ) mxZ = z;
+        n++;
+      }
+    }
+    if (n > 0) {
+      if (mnX < fMinX) fMinX = mnX; if (mnY < fMinY) fMinY = mnY; if (mnZ < fMinZ) fMinZ = mnZ;
+      if (mxX > fMaxX) fMaxX = mxX; if (mxY > fMaxY) fMaxY = mxY; if (mxZ > fMaxZ) fMaxZ = mxZ;
+      const mcx = (mnX + mxX) / 2, mcy = (mnY + mxY) / 2, mcz = (mnZ + mxZ) / 2;
+      cx.push(mcx); cy.push(mcy); cz.push(mcz); w.push(n);
+      bb.push(Float64Array.of(mnX, mnY, mnZ, mxX, mxY, mxZ));
+      cwX += mcx * n; cwY += mcy * n; cwZ += mcz * n; totalW += n;
+    }
+  }
+  return foldRobustBounds(fMinX, fMinY, fMinZ, fMaxX, fMaxY, fMaxZ, cx, cy, cz, w, bb, cwX, cwY, cwZ, totalW);
+}
+
+/** Shared tail: sort-and-trim step, identical between the full and incremental paths. */
+function foldRobustBounds(
+  fMinX: number, fMinY: number, fMinZ: number,
+  fMaxX: number, fMaxY: number, fMaxZ: number,
+  cx: number[], cy: number[], cz: number[], w: number[], bb: Float64Array[],
+  cwX: number, cwY: number, cwZ: number, totalW: number,
+): { full: Bounds; robust: Bounds | null } | null {
+  const count = w.length;
+  const fullMaxSize = Math.max(fMaxX - fMinX, fMaxY - fMinY, fMaxZ - fMinZ);
+  // No usable geometry → no bounds at all.
+  if (count === 0 || totalW <= 0 || !(fullMaxSize > 0) || !Number.isFinite(fullMaxSize)) return null;
+  const full: Bounds = { min: { x: fMinX, y: fMinY, z: fMinZ }, max: { x: fMaxX, y: fMaxY, z: fMaxZ } };
+  // Too few meshes to reason about an outlier tail — full bounds only.
+  if (count < 8) return { full, robust: null };
+
+  const ctrX = cwX / totalW, ctrY = cwY / totalW, ctrZ = cwZ / totalW;
+  const order = Array.from({ length: count }, (_, i) => i);
+  order.sort((a, b) => {
+    const da = (cx[a] - ctrX) ** 2 + (cy[a] - ctrY) ** 2 + (cz[a] - ctrZ) ** 2;
+    const db = (cx[b] - ctrX) ** 2 + (cy[b] - ctrY) ** 2 + (cz[b] - ctrZ) ** 2;
+    return da - db;
+  });
+
+  const keepTarget = ROBUST_KEEP_MASS * totalW;
+  let cum = 0, kept = 0;
+  let rMinX = Infinity, rMinY = Infinity, rMinZ = Infinity;
+  let rMaxX = -Infinity, rMaxY = -Infinity, rMaxZ = -Infinity;
+  for (let i = 0; i < count; i++) {
+    if (cum >= keepTarget) break;
+    const b = bb[order[i]];
+    if (b[0] < rMinX) rMinX = b[0]; if (b[1] < rMinY) rMinY = b[1]; if (b[2] < rMinZ) rMinZ = b[2];
+    if (b[3] > rMaxX) rMaxX = b[3]; if (b[4] > rMaxY) rMaxY = b[4]; if (b[5] > rMaxZ) rMaxZ = b[5];
+    cum += w[order[i]];
+    kept++;
+  }
+  if (kept >= count) return { full, robust: null }; // nothing dropped → no override
+  const robustMaxSize = Math.max(rMaxX - rMinX, rMaxY - rMinY, rMaxZ - rMinZ);
+  // Tail isn't inflating the box → no override (compact models unaffected).
+  if (!(robustMaxSize < fullMaxSize * ROBUST_SHRINK_GUARD)) return { full, robust: null };
+
+  console.log(
+    `[GeomStream] outlier-robust camera fit: dropped ${count - kept} far mesh(es) from framing, ` +
+    `extent ${Math.round(fullMaxSize)} → ${Math.round(robustMaxSize)} units`,
+  );
+  return { full, robust: { min: { x: rMinX, y: rMinY, z: rMinZ }, max: { x: rMaxX, y: rMaxY, z: rMaxZ } } };
+}
+
+export interface RobustFitBoundsAccumulator {
+  /** Fold any meshes appended since the last call (by array identity + length)
+   *  into the running state, then return the same shape as `robustFitBoundsFull`. */
+  update(meshes: readonly RobustFitMeshInput[]): { full: Bounds; robust: Bounds | null } | null;
+  /** Drop all cached state. Call on new-file / cleared-geometry transitions
+   *  for memory hygiene — `update()` also self-resets on array-identity or
+   *  length-shrink changes, so this is not required for correctness. */
+  reset(): void;
+}
+
+export function createRobustFitBoundsAccumulator(): RobustFitBoundsAccumulator {
+  let sourceRef: readonly RobustFitMeshInput[] | null = null;
+  let scannedLen = 0;
+  let fMinX = Infinity, fMinY = Infinity, fMinZ = Infinity;
+  let fMaxX = -Infinity, fMaxY = -Infinity, fMaxZ = -Infinity;
+  let cx: number[] = [], cy: number[] = [], cz: number[] = [], w: number[] = [];
+  let bb: Float64Array[] = [];
+  let cwX = 0, cwY = 0, cwZ = 0, totalW = 0;
+
+  function resetState(): void {
+    sourceRef = null;
+    scannedLen = 0;
+    fMinX = Infinity; fMinY = Infinity; fMinZ = Infinity;
+    fMaxX = -Infinity; fMaxY = -Infinity; fMaxZ = -Infinity;
+    cx = []; cy = []; cz = []; w = [];
+    bb = [];
+    cwX = 0; cwY = 0; cwZ = 0; totalW = 0;
+  }
+
+  function update(meshes: readonly RobustFitMeshInput[]): { full: Bounds; robust: Bounds | null } | null {
+    // New source array, or it shrank (new file / replace) → fold from scratch.
+    if (sourceRef !== meshes || meshes.length < scannedLen) {
+      resetState();
+      sourceRef = meshes;
+    }
+
+    for (let gi = scannedLen; gi < meshes.length; gi++) {
+      const positions = meshes[gi].positions;
+      const o = meshes[gi].origin;
+      const ox = o ? o[0] : 0, oy = o ? o[1] : 0, oz = o ? o[2] : 0;
+      let mnX = Infinity, mnY = Infinity, mnZ = Infinity;
+      let mxX = -Infinity, mxY = -Infinity, mxZ = -Infinity;
+      let n = 0;
+      for (let i = 0; i < positions.length; i += 3) {
+        const x = positions[i] + ox, y = positions[i + 1] + oy, z = positions[i + 2] + oz;
+        if (Math.abs(x) < ROBUST_GARBAGE_COORD && Math.abs(y) < ROBUST_GARBAGE_COORD && Math.abs(z) < ROBUST_GARBAGE_COORD) {
+          if (x < mnX) mnX = x; if (y < mnY) mnY = y; if (z < mnZ) mnZ = z;
+          if (x > mxX) mxX = x; if (y > mxY) mxY = y; if (z > mxZ) mxZ = z;
+          n++;
+        }
+      }
+      if (n > 0) {
+        if (mnX < fMinX) fMinX = mnX; if (mnY < fMinY) fMinY = mnY; if (mnZ < fMinZ) fMinZ = mnZ;
+        if (mxX > fMaxX) fMaxX = mxX; if (mxY > fMaxY) fMaxY = mxY; if (mxZ > fMaxZ) fMaxZ = mxZ;
+        const mcx = (mnX + mxX) / 2, mcy = (mnY + mxY) / 2, mcz = (mnZ + mxZ) / 2;
+        cx.push(mcx); cy.push(mcy); cz.push(mcz); w.push(n);
+        bb.push(Float64Array.of(mnX, mnY, mnZ, mxX, mxY, mxZ));
+        cwX += mcx * n; cwY += mcy * n; cwZ += mcz * n; totalW += n;
+      }
+    }
+    scannedLen = meshes.length;
+
+    return foldRobustBounds(fMinX, fMinY, fMinZ, fMaxX, fMaxY, fMaxZ, cx, cy, cz, w, bb, cwX, cwY, cwZ, totalW);
+  }
+
+  return { update, reset: resetState };
+}

--- a/apps/viewer/src/components/viewer/statusBarStats.test.ts
+++ b/apps/viewer/src/components/viewer/statusBarStats.test.ts
@@ -75,14 +75,31 @@ describe('StatusBar stats: accumulator matches full rescan', () => {
 
   it('mesh with entityIds appended incrementally after a no-entityIds mesh', () => {
     const acc = createStatusBarStatsAccumulator();
+    // `meshes` is the SAME array reference across every call below, grown via
+    // `push` — mirroring `appendGeometryBatch` in dataSlice.ts. Only the
+    // wrapping `geometryResult` object is rebuilt per commit, per the doc
+    // comment in statusBarStats.ts. A `.slice()` here would hand the
+    // accumulator a NEW identity on the first call, making every later call
+    // look like a fresh array too and forcing a full reset+rescan instead of
+    // exercising the append path — see PR #2400 review.
     const meshes: { entityIds?: Uint32Array }[] = [mesh()];
-    let g = geo(meshes.slice());
+    let g = geo(meshes);
     assert.deepEqual(acc.update(g), computeStatsFull(g));
+    assert.deepEqual(acc.update(g).elements, 1);
 
     meshes.push(mesh([1, 2, 3]));
     g = geo(meshes); // same array identity as would happen via appendGeometryBatch's push
     assert.deepEqual(acc.update(g), computeStatsFull(g));
     assert.deepEqual(acc.update(g).elements, 1 + 3);
+
+    // A SECOND append onto the same reference, resuming from a NONZERO
+    // scanned offset — the specific case a broken "reset and full-rescan
+    // from 0 whenever the array grew" implementation cannot be told apart
+    // from a genuinely incremental one without this step.
+    meshes.push(mesh([9, 9, 10]));
+    g = geo(meshes);
+    assert.deepEqual(acc.update(g), computeStatsFull(g));
+    assert.deepEqual(acc.update(g).elements, 1 + 3 + 2);
   });
 
   it('incremental streaming simulation: same array reference, growing via push, matches full rescan at every commit', () => {

--- a/apps/viewer/src/components/viewer/statusBarStats.test.ts
+++ b/apps/viewer/src/components/viewer/statusBarStats.test.ts
@@ -1,0 +1,172 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  computeStatsFull,
+  createStatusBarStatsAccumulator,
+  type StatusBarGeometryResult,
+} from './statusBarStats.js';
+
+// Deterministic PRNG so failures are reproducible.
+function mulberry32(seed: number) {
+  let a = seed;
+  return () => {
+    a |= 0; a = (a + 0x6D2B79F5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function mesh(entityIds?: number[]): { entityIds?: Uint32Array } {
+  return entityIds ? { entityIds: Uint32Array.from(entityIds) } : {};
+}
+
+function geo(meshes: { entityIds?: Uint32Array }[], totalTriangles = meshes.length * 2): StatusBarGeometryResult {
+  return { meshes, totalTriangles };
+}
+
+describe('StatusBar stats: accumulator matches full rescan', () => {
+  it('zero meshes', () => {
+    const acc = createStatusBarStatsAccumulator();
+    const g = geo([]);
+    assert.deepEqual(acc.update(g), computeStatsFull(g));
+    assert.deepEqual(acc.update(g), { elements: 0, triangles: 0 });
+  });
+
+  it('null geometryResult', () => {
+    const acc = createStatusBarStatsAccumulator();
+    assert.deepEqual(acc.update(null), computeStatsFull(null));
+    assert.deepEqual(acc.update(null), { elements: 0, triangles: 0 });
+  });
+
+  it('one mesh, no entityIds → counts as 1', () => {
+    const acc = createStatusBarStatsAccumulator();
+    const g = geo([mesh()]);
+    assert.deepEqual(acc.update(g), computeStatsFull(g));
+    assert.deepEqual(acc.update(g).elements, 1);
+  });
+
+  it('one mesh, empty entityIds array → counts as 1 (falls to the `else` branch, same as no entityIds)', () => {
+    const acc = createStatusBarStatsAccumulator();
+    const g = geo([mesh([])]);
+    assert.deepEqual(acc.update(g), computeStatsFull(g));
+    assert.deepEqual(acc.update(g).elements, 1);
+  });
+
+  it('duplicate entityIds WITHIN a mesh dedupe to 1', () => {
+    const acc = createStatusBarStatsAccumulator();
+    const g = geo([mesh([5, 5, 5, 7])]);
+    assert.deepEqual(acc.update(g), computeStatsFull(g));
+    assert.deepEqual(acc.update(g).elements, 2);
+  });
+
+  it('duplicate entityIds ACROSS meshes do NOT dedupe globally — counted once per mesh', () => {
+    const acc = createStatusBarStatsAccumulator();
+    // Same entity id 42 appears in two different merged meshes.
+    const g = geo([mesh([42, 1]), mesh([42, 2])]);
+    const full = computeStatsFull(g);
+    assert.deepEqual(full.elements, 4); // 2 (mesh0) + 2 (mesh1), no cross-mesh dedup
+    assert.deepEqual(acc.update(g), full);
+  });
+
+  it('mesh with entityIds appended incrementally after a no-entityIds mesh', () => {
+    const acc = createStatusBarStatsAccumulator();
+    const meshes: { entityIds?: Uint32Array }[] = [mesh()];
+    let g = geo(meshes.slice());
+    assert.deepEqual(acc.update(g), computeStatsFull(g));
+
+    meshes.push(mesh([1, 2, 3]));
+    g = geo(meshes); // same array identity as would happen via appendGeometryBatch's push
+    assert.deepEqual(acc.update(g), computeStatsFull(g));
+    assert.deepEqual(acc.update(g).elements, 1 + 3);
+  });
+
+  it('incremental streaming simulation: same array reference, growing via push, matches full rescan at every commit', () => {
+    const rng = mulberry32(1234);
+    const acc = createStatusBarStatsAccumulator();
+    const meshes: { entityIds?: Uint32Array }[] = [];
+    let nextId = 0;
+
+    for (let commit = 0; commit < 40; commit++) {
+      const batchSize = 1 + Math.floor(rng() * 15);
+      for (let i = 0; i < batchSize; i++) {
+        const hasEntityIds = rng() < 0.85;
+        if (!hasEntityIds) {
+          meshes.push(mesh());
+          continue;
+        }
+        const count = 1 + Math.floor(rng() * 5);
+        const ids: number[] = [];
+        for (let j = 0; j < count; j++) {
+          // Occasionally repeat an id seen in an EARLIER mesh, to exercise
+          // the "no cross-mesh dedup" semantics, and occasionally repeat
+          // WITHIN this mesh's own id list.
+          if (ids.length > 0 && rng() < 0.3) {
+            ids.push(ids[Math.floor(rng() * ids.length)]);
+          } else if (nextId > 0 && rng() < 0.2) {
+            ids.push(Math.floor(rng() * nextId));
+          } else {
+            ids.push(nextId++);
+          }
+        }
+        meshes.push(mesh(ids));
+      }
+      // `meshes` is the SAME array reference every commit (push, like
+      // dataSlice.ts's appendGeometryBatch) — this is the identity the
+      // accumulator relies on.
+      const g = geo(meshes, meshes.length * 3);
+      assert.deepEqual(acc.update(g), computeStatsFull(g), `mismatch at commit ${commit}`);
+    }
+  });
+
+  it('new array identity (file reload) resets the accumulator instead of serving stale counts', () => {
+    const acc = createStatusBarStatsAccumulator();
+    const first = geo([mesh([1, 2]), mesh([3])]);
+    assert.deepEqual(acc.update(first), computeStatsFull(first));
+
+    // A totally different meshes array (new file load) — must recount from
+    // scratch, not append to the old total.
+    const second = geo([mesh([9])]);
+    assert.deepEqual(acc.update(second), computeStatsFull(second));
+    assert.deepEqual(acc.update(second).elements, 1);
+  });
+
+  it('array shrink (e.g. a rebuilt/pruned meshes array) triggers a full recount, not a crash or stale count', () => {
+    const acc = createStatusBarStatsAccumulator();
+    const meshes = [mesh([1]), mesh([2]), mesh([3])];
+    const g1 = geo(meshes);
+    assert.deepEqual(acc.update(g1), computeStatsFull(g1));
+
+    // Same array reference, but now shorter — mimics a splice/prune. The
+    // accumulator's scannedLen would otherwise exceed the new length.
+    meshes.length = 1;
+    const g2 = geo(meshes);
+    assert.deepEqual(acc.update(g2), computeStatsFull(g2));
+    assert.deepEqual(acc.update(g2).elements, 1);
+  });
+
+  it('explicit reset() forces a full recount on the next update, matching a fresh accumulator', () => {
+    const meshes = [mesh([1, 2]), mesh([3, 3, 4])];
+    const g = geo(meshes);
+    const fresh = createStatusBarStatsAccumulator();
+    const fromFresh = fresh.update(g);
+
+    const reused = createStatusBarStatsAccumulator();
+    reused.update(g);
+    reused.reset();
+    const fromReset = reused.update(g);
+    assert.deepEqual(fromReset, fromFresh);
+  });
+
+  it('triangles always reflects the latest geometryResult.totalTriangles, independent of the element scan', () => {
+    const acc = createStatusBarStatsAccumulator();
+    const meshes = [mesh([1])];
+    assert.deepEqual(acc.update(geo(meshes, 100)).triangles, 100);
+    // Same meshes array (no new meshes to scan) but totalTriangles changed.
+    assert.deepEqual(acc.update(geo(meshes, 250)).triangles, 250);
+  });
+});

--- a/apps/viewer/src/components/viewer/statusBarStats.ts
+++ b/apps/viewer/src/components/viewer/statusBarStats.ts
@@ -1,0 +1,118 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * StatusBar's "N elements" stat: count actual entities, where a color-merged
+ * mesh's `entityIds` may fold several IFC entities into one draw call — count
+ * the UNIQUE entity ids within that mesh (not 1 per mesh), and a mesh with no
+ * `entityIds` (unmerged / non-entity geometry) counts as 1.
+ *
+ * Deduplication is PER MESH, not global: if the same entity id appears in two
+ * different meshes, each mesh's local `Set` counts it once, so it is counted
+ * twice in the total. This mirrors the original implementation exactly —
+ * there is no cross-mesh identity tracking to preserve or violate.
+ *
+ * `computeStatsFull` is the reference full-rescan implementation (kept for
+ * equivalence tests). `createStatusBarStatsAccumulator` is the incremental
+ * version used by StatusBar: during streaming, `geometryResult` is a NEW
+ * object on every batch commit but `geometryResult.meshes` is the SAME array
+ * reference mutated in place (`appendGeometryBatch` in dataSlice.ts pushes
+ * onto the existing array) — except on the very first batch, and on any
+ * operation that legitimately rebuilds the array (a full file (re)load, or
+ * `updateMeshColors`, which `.map()`s to a new array). The accumulator keys
+ * off that array identity plus a scanned-length counter, so it only visits
+ * meshes appended since the last call — see `ViewportContainer.tsx`'s
+ * `hasTypeGeometry` / `filteredGeometry` for the same established pattern.
+ */
+
+export interface StatusBarStats {
+  elements: number;
+  triangles: number;
+}
+
+export interface StatusBarGeometryResult {
+  meshes?: readonly { entityIds?: Uint32Array } [] | null;
+  totalTriangles?: number;
+}
+
+/** Reference implementation: full O(meshes + Σ entityIds) rescan on every call. */
+export function computeStatsFull(geometryResult: StatusBarGeometryResult | null): StatusBarStats {
+  if (!geometryResult) {
+    return { elements: 0, triangles: 0 };
+  }
+  let elements = 0;
+  const meshes = geometryResult.meshes;
+  if (meshes) {
+    for (let i = 0; i < meshes.length; i++) {
+      const m = meshes[i];
+      if (m.entityIds && m.entityIds.length > 0) {
+        const seen = new Set<number>();
+        for (let j = 0; j < m.entityIds.length; j++) seen.add(m.entityIds[j]);
+        elements += seen.size;
+      } else {
+        elements += 1;
+      }
+    }
+  }
+  return {
+    elements,
+    triangles: geometryResult.totalTriangles ?? 0,
+  };
+}
+
+export interface StatusBarStatsAccumulator {
+  /** Fold any meshes appended since the last call (by array identity + length)
+   *  into the running element count, then return the current stats. */
+  update(geometryResult: StatusBarGeometryResult | null): StatusBarStats;
+  /** Drop cached state. `update()` also self-resets on array-identity or
+   *  length-shrink changes, so this is not required for correctness. */
+  reset(): void;
+}
+
+export function createStatusBarStatsAccumulator(): StatusBarStatsAccumulator {
+  let sourceRef: StatusBarGeometryResult['meshes'] | null = null;
+  let scannedLen = 0;
+  let elements = 0;
+
+  function resetState(): void {
+    sourceRef = null;
+    scannedLen = 0;
+    elements = 0;
+  }
+
+  function update(geometryResult: StatusBarGeometryResult | null): StatusBarStats {
+    if (!geometryResult) {
+      resetState();
+      return { elements: 0, triangles: 0 };
+    }
+    const meshes = geometryResult.meshes;
+    if (!meshes) {
+      resetState();
+      return { elements: 0, triangles: geometryResult.totalTriangles ?? 0 };
+    }
+
+    // New source array, or it shrank (new file / replace / recolor rebuild)
+    // → recount from scratch.
+    if (sourceRef !== meshes || meshes.length < scannedLen) {
+      resetState();
+      sourceRef = meshes;
+    }
+
+    for (let i = scannedLen; i < meshes.length; i++) {
+      const m = meshes[i];
+      if (m.entityIds && m.entityIds.length > 0) {
+        const seen = new Set<number>();
+        for (let j = 0; j < m.entityIds.length; j++) seen.add(m.entityIds[j]);
+        elements += seen.size;
+      } else {
+        elements += 1;
+      }
+    }
+    scannedLen = meshes.length;
+
+    return { elements, triangles: geometryResult.totalTriangles ?? 0 };
+  }
+
+  return { update, reset: resetState };
+}

--- a/apps/viewer/src/components/viewer/useGeometryStreaming.ts
+++ b/apps/viewer/src/components/viewer/useGeometryStreaming.ts
@@ -24,6 +24,7 @@ import type { MeshData, CoordinateInfo } from '@ifc-lite/geometry';
 import { decodeInstancedShard } from '@ifc-lite/geometry';
 import { toast } from '../ui/toast.js';
 import { runGpuUpload } from './gpu-upload-guard';
+import { createRobustFitBoundsAccumulator } from './robustFitBoundsAccumulator.js';
 
 // Session-scoped flag so the linear-infrastructure hint fires at most once
 // per page load (model swaps included). Stored at module scope rather than
@@ -143,13 +144,10 @@ const MAX_VALID_COORD = 10000;
 // compact cluster. The camera fits to the inflated AABB → its centre lands in
 // empty space between the building and the strays → the model renders tiny and
 // off to one side, and orbiting (the raycast-miss pivot also anchors to that
-// AABB centre, see useMouseControls) swings it straight out of frame. We keep
-// the innermost ROBUST_KEEP_MASS of the *vertex mass* and drop the sparse far
-// tail from the fit bounds only (the strays still render). The end-guard makes
-// this a strict no-op unless the tail meaningfully inflates the box, so compact
-// single-building models frame exactly as before.
-const ROBUST_KEEP_MASS = 0.995;
-const ROBUST_SHRINK_GUARD = 0.66;
+// AABB centre, see useMouseControls) swings it straight out of frame. The
+// implementation (and its incremental accumulator, which avoids re-scanning
+// every already-processed mesh's vertices on every streaming commit — see
+// PERF note at the call sites below) lives in ./robustFitBoundsAccumulator.js.
 
 function traceGeometrySync(message: string): void {
   console.log(`[GeomSync] ${message}`);
@@ -220,6 +218,7 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
   const lastGeometryLengthRef = useRef(0);
   const lastGeometryRef = useRef<MeshData[] | null>(null);
   const cameraFittedRef = useRef(false);
+  const robustFitAccRef = useRef(createRobustFitBoundsAccumulator());
   const finalBoundsRefittedRef = useRef(false);
   const cameraSnapshotRef = useRef<{ px: number; py: number; pz: number; tx: number; ty: number; tz: number } | null>(null);
   // Tracks which fit branch the post-load auto-fit took. Linear models get a
@@ -273,6 +272,7 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
         cameraFittedRef.current = false;
         finalBoundsRefittedRef.current = false;
         cameraSnapshotRef.current = null;
+        robustFitAccRef.current.reset();
         if (renderer && isInitialized) {
           renderer.getScene().clear();
           renderer.getCamera().reset();
@@ -322,6 +322,7 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
       traceGeometrySync(`model added (${prevModelCountRef.current}→${modelCount}) — refitting camera to combined bounds`);
       cameraFittedRef.current = false;
       finalBoundsRefittedRef.current = false;
+      robustFitAccRef.current.reset();
     }
     prevModelCountRef.current = modelCount;
 
@@ -357,6 +358,7 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
       cameraFittedRef.current = false;
       finalBoundsRefittedRef.current = false;
       cameraSnapshotRef.current = null;
+      robustFitAccRef.current.reset();
       lastGeometryLengthRef.current = 0;
       lastGeometryRef.current = geometry;
       renderer.getCamera().reset();
@@ -382,6 +384,7 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
         cameraFittedRef.current = false;
         finalBoundsRefittedRef.current = false;
         cameraSnapshotRef.current = null;
+        robustFitAccRef.current.reset();
         lastGeometryLengthRef.current = 0;
         lastGeometryRef.current = geometry;
         renderer.getCamera().reset();
@@ -518,7 +521,7 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
       // tail, leaving the shiftedBounds / computeBounds paths below untouched.
       // `sceneBoundsFull` is the FULL AABB and is what feeds setSceneBounds —
       // near/far clipping + section ranges must still cover the far meshes.
-      const rbEarly = geometry.length > 0 ? robustFitBounds(geometry) : null;
+      const rbEarly = geometry.length > 0 ? robustFitAccRef.current.update(geometry) : null;
       const robustEarly = rbEarly?.robust ?? null;
       let sceneBoundsFull: Bounds | null = null;
       if (robustEarly) {
@@ -642,7 +645,7 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
             // fit target (and the orbit pivot) in empty space (issue #1394).
             // `robust` is the trimmed framing box (null when there is no tail);
             // `fullBounds` is the complete AABB for clipping / section ranges.
-            const rb = robustFitBounds(capturedGeometry);
+            const rb = robustFitAccRef.current.update(capturedGeometry);
             const robust = rb?.robust ?? null;
             const fullBounds = rb?.full ?? computeBounds(capturedGeometry);
             const exactBounds = robust ?? fullBounds;
@@ -945,98 +948,6 @@ function computeBounds(meshes: MeshData[]): Bounds | null {
   const maxSize = Math.max(maxX - minX, maxY - minY, maxZ - minZ);
   if (minX === Infinity || maxSize <= 0 || !Number.isFinite(maxSize)) return null;
   return { min: { x: minX, y: minY, z: minZ }, max: { x: maxX, y: maxY, z: maxZ } };
-}
-
-// Outlier-robust camera-fit bounds (issue #1394).
-//
-// Returns `{ full, robust }` where `full` is the complete model AABB and
-// `robust` is a tightened framing box when the model is a compact cluster plus
-// a sparse far tail (a stray covering 600 m off, a detached out-building), or
-// `null` when there is no such tail. Returns `null` overall only when there is
-// no usable geometry. Callers MUST use `full` for clipping / scene bounds and
-// `robust ?? full` only for camera framing + the orbit pivot — trimming the
-// scene bounds would clip the far meshes out of near/far and section ranges.
-//
-// Unlike `computeBounds`, this folds the per-element origin and uses a generous
-// garbage threshold rather than MAX_VALID_COORD — real building coordinates can
-// be hundreds of thousands of millimetres from the origin (this model keeps mm
-// with no RTC shift), which `computeBounds`' 10 km guard rejects outright. We
-// keep the innermost ROBUST_KEEP_MASS of *vertex mass* (measured by each mesh's
-// distance from the vertex-weighted centroid) and emit a `robust` box only when
-// it is meaningfully tighter than the full extent (ROBUST_SHRINK_GUARD) — i.e.
-// only when a few far meshes were genuinely inflating the box and dragging the
-// fit target (and the raycast-miss orbit pivot, see useMouseControls) into
-// empty space.
-const ROBUST_GARBAGE_COORD = 1e12;
-
-function robustFitBounds(meshes: MeshData[]): { full: Bounds; robust: Bounds | null } | null {
-  let fMinX = Infinity, fMinY = Infinity, fMinZ = Infinity;
-  let fMaxX = -Infinity, fMaxY = -Infinity, fMaxZ = -Infinity;
-  const cx: number[] = [], cy: number[] = [], cz: number[] = [], w: number[] = [];
-  const bb: Float64Array[] = [];
-  let cwX = 0, cwY = 0, cwZ = 0, totalW = 0;
-  for (let gi = 0; gi < meshes.length; gi++) {
-    const positions = meshes[gi].positions;
-    const o = meshes[gi].origin;
-    const ox = o ? o[0] : 0, oy = o ? o[1] : 0, oz = o ? o[2] : 0;
-    let mnX = Infinity, mnY = Infinity, mnZ = Infinity;
-    let mxX = -Infinity, mxY = -Infinity, mxZ = -Infinity;
-    let n = 0;
-    for (let i = 0; i < positions.length; i += 3) {
-      const x = positions[i] + ox, y = positions[i + 1] + oy, z = positions[i + 2] + oz;
-      if (Math.abs(x) < ROBUST_GARBAGE_COORD && Math.abs(y) < ROBUST_GARBAGE_COORD && Math.abs(z) < ROBUST_GARBAGE_COORD) {
-        if (x < mnX) mnX = x; if (y < mnY) mnY = y; if (z < mnZ) mnZ = z;
-        if (x > mxX) mxX = x; if (y > mxY) mxY = y; if (z > mxZ) mxZ = z;
-        n++;
-      }
-    }
-    if (n > 0) {
-      if (mnX < fMinX) fMinX = mnX; if (mnY < fMinY) fMinY = mnY; if (mnZ < fMinZ) fMinZ = mnZ;
-      if (mxX > fMaxX) fMaxX = mxX; if (mxY > fMaxY) fMaxY = mxY; if (mxZ > fMaxZ) fMaxZ = mxZ;
-      const mcx = (mnX + mxX) / 2, mcy = (mnY + mxY) / 2, mcz = (mnZ + mxZ) / 2;
-      cx.push(mcx); cy.push(mcy); cz.push(mcz); w.push(n);
-      bb.push(Float64Array.of(mnX, mnY, mnZ, mxX, mxY, mxZ));
-      cwX += mcx * n; cwY += mcy * n; cwZ += mcz * n; totalW += n;
-    }
-  }
-  const count = w.length;
-  const fullMaxSize = Math.max(fMaxX - fMinX, fMaxY - fMinY, fMaxZ - fMinZ);
-  // No usable geometry → no bounds at all.
-  if (count === 0 || totalW <= 0 || !(fullMaxSize > 0) || !Number.isFinite(fullMaxSize)) return null;
-  const full: Bounds = { min: { x: fMinX, y: fMinY, z: fMinZ }, max: { x: fMaxX, y: fMaxY, z: fMaxZ } };
-  // Too few meshes to reason about an outlier tail — full bounds only.
-  if (count < 8) return { full, robust: null };
-
-  const ctrX = cwX / totalW, ctrY = cwY / totalW, ctrZ = cwZ / totalW;
-  const order = Array.from({ length: count }, (_, i) => i);
-  order.sort((a, b) => {
-    const da = (cx[a] - ctrX) ** 2 + (cy[a] - ctrY) ** 2 + (cz[a] - ctrZ) ** 2;
-    const db = (cx[b] - ctrX) ** 2 + (cy[b] - ctrY) ** 2 + (cz[b] - ctrZ) ** 2;
-    return da - db;
-  });
-
-  const keepTarget = ROBUST_KEEP_MASS * totalW;
-  let cum = 0, kept = 0;
-  let rMinX = Infinity, rMinY = Infinity, rMinZ = Infinity;
-  let rMaxX = -Infinity, rMaxY = -Infinity, rMaxZ = -Infinity;
-  for (let i = 0; i < count; i++) {
-    if (cum >= keepTarget) break;
-    const b = bb[order[i]];
-    if (b[0] < rMinX) rMinX = b[0]; if (b[1] < rMinY) rMinY = b[1]; if (b[2] < rMinZ) rMinZ = b[2];
-    if (b[3] > rMaxX) rMaxX = b[3]; if (b[4] > rMaxY) rMaxY = b[4]; if (b[5] > rMaxZ) rMaxZ = b[5];
-    cum += w[order[i]];
-    kept++;
-  }
-  if (kept >= count) return { full, robust: null }; // nothing dropped → no override
-  const robustMaxSize = Math.max(rMaxX - rMinX, rMaxY - rMinY, rMaxZ - rMinZ);
-  // Tail isn't inflating the box → no override (compact models unaffected).
-  if (!(robustMaxSize < fullMaxSize * ROBUST_SHRINK_GUARD)) return { full, robust: null };
-
-  console.log(
-    `[GeomStream] outlier-robust camera fit: dropped ${count - kept} far mesh(es) from framing, ` +
-    `extent ${Math.round(fullMaxSize)} → ${Math.round(robustMaxSize)} units`,
-  );
-  return { full, robust: { min: { x: rMinX, y: rMinY, z: rMinZ }, max: { x: rMaxX, y: rMaxY, z: rMaxZ } } };
 }
 
 function userMovedCamera(


### PR DESCRIPTION
Two measured O(N²) rescans found while investigating #2379. **They are not its cause** — I measured them precisely so I could rule them out, and they total well under a second against the real model while the wedge runs 20+ minutes. Sending them on their own merits, not as a fix for that issue.

## Defect 1 — StatusBar stats (the real win)

`geometryResult` is a **new object on every batch commit** (`dataSlice.ts` `appendGeometryBatch`), so `useMemo([geometryResult])` never hit. Every commit re-ran a full O(meshes + Σ entityIds) scan and **allocated a `Set` per merged mesh** — including for meshes counted on every previous commit.

Now accumulates, keyed on `geometryResult.meshes` array identity plus scanned length, walking only meshes appended since the last call. (`meshes` is the same array mutated via `push` across a stream — confirmed in `dataSlice.ts`.)

```
meshes/commits    BEFORE      AFTER
 2.1K /  4        0.6ms       0.3ms
 4.2K /  8        0.8ms       0.4ms
 8.4K / 15        3.6ms       1.3ms
16.7K / 30       13.0ms       1.3ms
33.4K / 60       52.6ms       1.7ms
```

~4× per doubling before, flat after — quadratic → linear.

**Dedup semantics are preserved exactly, and this is the part worth reviewing.** Dedup is **per mesh, not global**: an entity id appearing in two different meshes is counted twice, because the original allocated a fresh `Set` per mesh. An incremental rewrite could very easily "improve" that into global dedup and silently change a number users read off the status bar. A dedicated test locks the existing behaviour in.

## Defect 2 — robustFitBounds (worst-case only — stated plainly)

Your caveat was right, and I checked it before optimising: on the normal path the camera fit **latches on commit 1** via `coordinateInfo.shiftedBounds` (real accumulated bounds from `getCurrentCoordinateInfo()`), so `robustFitBounds` runs **once**. It only re-runs per commit in the documented worst case where the fit never latches — e.g. `calculateBounds` rejects every vertex as out-of-threshold, `getCurrentCoordinateInfo()` returns null, and `dataSlice.ts:206` substitutes zero bounds.

So **this is a worst-case-only fix, not a routine win.** Fixed defensively anyway, since that worst case is exactly the pathological-model scenario where the app is already struggling.

The vertex fold is now incremental with **bit-identical fold order** to the original single-pass loop (min/max and summation order preserved). The O(M log M) sort-and-trim tail is **not** incrementalizable — the centroid it sorts around shifts as meshes arrive — so it still runs over the full accumulated mesh count. The win is therefore real but partial: 1156ms → 315ms (~3.7×) at 33.4K/60, not linear. That residual is documented in comments rather than glossed.

## Equivalence testing

The original algorithms are **kept as exported reference implementations**, and 25 new tests compare the accumulators against them across: zero/one/empty-entityIds meshes, duplicate ids within *and* across meshes, non-finite and garbage coordinates, mixed finite+garbage within one mesh, per-element origin, new-file identity resets, array-shrink resets, explicit `reset()`, idempotent no-growth calls, and randomized streaming simulations checked **at every commit**, not just the end.

That last one matters most: a stale accumulator would agree at the end while being wrong mid-stream, which is exactly when the status bar is read.

**Mutation checks:** breaking each accumulator's identity-reset logic fails 2/12 and 2/13; breaking StatusBar's dedup to global-across-meshes fails 6/12. Independently re-verified — replacing the per-mesh `Set` with a raw length count fails 2 tests, including the every-commit equivalence simulation.

## Displacement

The incremental path skips re-reading vertices of already-processed meshes. Staleness is guarded: `update()` self-resets on array-identity change or length shrink (covering new file, model hidden-then-shown, pruned meshes), and `.reset()` is called at every `cameraFittedRef.current = false` site.

One latent, currently-inert edge case is documented in the code rather than left silent: an in-place vertex mutation that kept the same array reference **and** length would not be caught by identity/length checks alone. `robustFitBounds` is never called in that state today (`cameraFittedRef` isn't reset on that path), so it isn't exploitable — flagged for whoever changes that next.

## Verification

`apps/viewer`: 3191 → 3218 tests, **0 failures**, 6 skipped. Baseline captured by temporary file-copy swap rather than git, so the before/after numbers come from the same tree. Typecheck: no new errors from any of the 7 touched/added files. No changeset — `apps/viewer` is `"private": true`.

The benchmark lives in `perf-bench.manual.ts` and is deliberately **not** wired into CI — timing assertions on shared runners are how you get flaky suites.

## Not done

No attempt to incrementalize the `O(M log M)` sort in `robustFitBounds` — there's no cheap way while the centroid shifts as meshes arrive. Documented, not hidden.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved viewer responsiveness during streamed geometry loading by processing new meshes incrementally.
  * Reduced repeated full-scene calculations for status-bar statistics and camera framing.
  * Preserved accurate element counts, triangle totals, and robust camera-fit bounds as models load or change.

* **Bug Fixes**
  * Improved handling of replaced, shortened, empty, or invalid geometry data.
  * Ensured camera framing and statistics remain consistent across streaming updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->