### PR TITLE
fix(viewer): clear stale multi-selection before framing a search result

### DIFF
--- a/apps/viewer/src/components/viewer/SearchInline.tsx
+++ b/apps/viewer/src/components/viewer/SearchInline.tsx
@@ -85,6 +85,7 @@ export function SearchInline() {
     models,
     setSelectedEntity,
     setSelectedEntityId,
+    setSelectedEntityIds,
     toggleEntitySelection,
     cameraCallbacks,
   } = useViewerStore(
@@ -108,6 +109,7 @@ export function SearchInline() {
       models: s.models,
       setSelectedEntity: s.setSelectedEntity,
       setSelectedEntityId: s.setSelectedEntityId,
+      setSelectedEntityIds: s.setSelectedEntityIds,
       toggleEntitySelection: s.toggleEntitySelection,
       cameraCallbacks: s.cameraCallbacks,
     })),
@@ -232,6 +234,8 @@ export function SearchInline() {
         return;
       }
 
+      // Clear multi-selection first (setSelectedEntityIds([]) resets selectedEntityId)
+      setSelectedEntityIds([]);
       setSelectedEntityId(globalId);
       setSelectedEntity(ref);
       if (cameraCallbacks.frameSelection) {
@@ -247,6 +251,7 @@ export function SearchInline() {
       models,
       setSelectedEntity,
       setSelectedEntityId,
+      setSelectedEntityIds,
       toggleEntitySelection,
     ],
   );

--- a/apps/viewer/src/components/viewer/SearchInline.wiring.test.ts
+++ b/apps/viewer/src/components/viewer/SearchInline.wiring.test.ts
@@ -1,0 +1,139 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Source-level wiring tests for `SearchInline`'s `applySelection` — the
+ * shared select+frame helper used by both Enter-commit and n/N vim-cycle
+ * stepping.
+ *
+ * `SearchInline` reads the store directly via `useViewerStore`, so it
+ * cannot be mounted under `tsx --test`, and this repo rejects
+ * `mock.module` (see `apps/viewer/src/sdk/ExtensionHostProvider.tsx:27-30`).
+ * `frameSelection` (Viewport.tsx) PREFERS the numeric multi-selection set
+ * over the single selection, so a stale box/basket selection made the
+ * camera frame the OLD elements instead of a freshly-picked search result.
+ * `HierarchyPanel` already guards this with `setSelectedEntityIds([])`
+ * before selecting; `applySelection`'s non-additive branch must do the
+ * same. Only a test that pins the call sequence catches a regression here.
+ *
+ * The ordering assertion is load-bearing: `setSelectedEntityIds([])` also
+ * resets `selectedEntityId` (selectionSlice.ts), so clearing AFTER
+ * selecting would silently discard the selection and frame nothing.
+ *
+ * The additive (Shift+Enter) branch is deliberately NOT touched: it is
+ * meant to build up the multi-selection across successive picks, so
+ * clearing there would defeat its purpose.
+ */
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(join(here, 'SearchInline.tsx'), 'utf8');
+
+/**
+ * Strip `//` line comments. Without this these tests are VACUOUS: the
+ * function's own comment quotes the very calls being asserted (e.g.
+ * "`setSelectedEntityIds([])` resets `selectedEntityId`"), so a naive
+ * `indexOf` matches the comment rather than the statement — and since the
+ * comment sits above both calls, the ordering assertion passes no matter
+ * how the real statements are ordered.
+ */
+function stripLineComments(text: string): string {
+  return text
+    .split('\n')
+    .filter((line) => !line.trimStart().startsWith('//'))
+    .join('\n');
+}
+
+/** The body of `applySelection`, from its declaration to the dependency array. */
+function applySelectionBody(): string {
+  const start = source.indexOf('const applySelection = useCallback(');
+  assert.notEqual(start, -1, 'applySelection must exist in SearchInline.tsx');
+  const end = source.indexOf('    [\n', start);
+  assert.notEqual(end, -1, 'applySelection must end with a dependency array');
+  const body = stripLineComments(source.slice(start, end));
+  // Guard the guard: if the stripping ever removes the statements
+  // themselves, every assertion below would fail loudly rather than
+  // silently pass.
+  assert.ok(body.includes('setSelectedEntityId('), 'stripped body must retain the selection calls');
+  return body;
+}
+
+/** The non-additive tail of applySelection, i.e. after the `addToSelection` early return. */
+function nonAdditiveBody(): string {
+  const body = applySelectionBody();
+  const returnIdx = body.indexOf('return;');
+  assert.notEqual(returnIdx, -1, 'applySelection must have the additive early-return branch');
+  return body.slice(returnIdx + 'return;'.length);
+}
+
+describe('SearchInline: applySelection non-additive wiring', () => {
+  test('clears the multi-selection before selecting and framing', () => {
+    const body = nonAdditiveBody();
+    for (const call of [
+      'setSelectedEntityIds([])',
+      'setSelectedEntityId(globalId)',
+      'setSelectedEntity(ref)',
+      'cameraCallbacks.frameSelection',
+    ]) {
+      assert.ok(body.includes(call), `applySelection (non-additive) must call ${call}`);
+    }
+  });
+
+  test('clears the multi-selection BEFORE selecting, since clearing resets selectedEntityId', () => {
+    const body = nonAdditiveBody();
+    const cleared = body.indexOf('setSelectedEntityIds([])');
+    const selected = body.indexOf('setSelectedEntityId(globalId)');
+    assert.ok(cleared >= 0 && selected >= 0, 'both calls must be present');
+    assert.ok(
+      cleared < selected,
+      'setSelectedEntityIds([]) must run BEFORE setSelectedEntityId — clearing also resets selectedEntityId, so the reverse order discards the selection and frames nothing',
+    );
+  });
+
+  test('the additive (Shift+Enter) branch does NOT clear the multi-selection', () => {
+    const body = applySelectionBody();
+    const returnIdx = body.indexOf('return;');
+    const additiveBody = body.slice(0, returnIdx);
+    assert.ok(
+      additiveBody.includes('toggleEntitySelection('),
+      'the additive branch must still toggle into the multi-selection',
+    );
+    assert.ok(
+      !additiveBody.includes('setSelectedEntityIds([])'),
+      'the additive branch must NOT clear the multi-selection — Shift+Enter is meant to build it up',
+    );
+  });
+
+  test('applySelection declares every store setter it calls as a dependency', () => {
+    const start = source.indexOf('const applySelection = useCallback(');
+    const depsStart = source.indexOf('    [\n', start);
+    const depsEnd = source.indexOf('  );', depsStart);
+    const deps = source.slice(depsStart, depsEnd);
+    for (const dep of ['setSelectedEntityIds', 'setSelectedEntityId', 'setSelectedEntity', 'toggleEntitySelection']) {
+      assert.ok(deps.includes(dep), `${dep} must be in the useCallback dependency array`);
+    }
+  });
+
+  test('the component binds setSelectedEntityIds from the store', () => {
+    assert.ok(
+      source.includes('setSelectedEntityIds: s.setSelectedEntityIds'),
+      'setSelectedEntityIds must be pulled from the store selector, or applySelection would reference an undefined binding',
+    );
+  });
+
+  test('n/N vim-cycle stepping reuses applySelection (so the fix also covers it)', () => {
+    const cycleEffectStart = source.indexOf('const isEntry = !last || last.results !== searchVimCycle.results;');
+    assert.notEqual(cycleEffectStart, -1, 'the vim-cycle-step effect must exist');
+    const tail = source.slice(cycleEffectStart, cycleEffectStart + 400);
+    assert.ok(
+      tail.includes('applySelection(current, false)'),
+      'the vim-cycle-step effect must call applySelection(current, false) — the same non-additive path that clears the stale multi-selection',
+    );
+  });
+});

--- a/apps/viewer/src/components/viewer/SearchModal.text.tsx
+++ b/apps/viewer/src/components/viewer/SearchModal.text.tsx
@@ -58,6 +58,7 @@ export function SearchModalText({ results, availableModelIds, onClose }: SearchM
     setSearchHighlightIndex,
     setSelectedEntity,
     setSelectedEntityId,
+    setSelectedEntityIds,
     addEntitiesToSelection,
     toggleEntitySelection,
     clearEntitySelection,
@@ -77,6 +78,7 @@ export function SearchModalText({ results, availableModelIds, onClose }: SearchM
       setSearchHighlightIndex: s.setSearchHighlightIndex,
       setSelectedEntity: s.setSelectedEntity,
       setSelectedEntityId: s.setSelectedEntityId,
+      setSelectedEntityIds: s.setSelectedEntityIds,
       addEntitiesToSelection: s.addEntitiesToSelection,
       toggleEntitySelection: s.toggleEntitySelection,
       clearEntitySelection: s.clearEntitySelection,
@@ -127,6 +129,8 @@ export function SearchModalText({ results, availableModelIds, onClose }: SearchM
       const ref = { modelId: r.modelId, expressId: r.expressId };
       const isLegacy = r.modelId === 'legacy' || r.modelId === '__legacy__' || models.size === 0;
       const globalId = isLegacy ? r.expressId : toGlobalIdFromModels(models, r.modelId, r.expressId);
+      // Clear multi-selection first (setSelectedEntityIds([]) resets selectedEntityId)
+      setSelectedEntityIds([]);
       setSelectedEntityId(globalId);
       setSelectedEntity(ref);
       if (cameraCallbacks.frameSelection) {
@@ -144,6 +148,7 @@ export function SearchModalText({ results, availableModelIds, onClose }: SearchM
       searchQuery,
       setSelectedEntity,
       setSelectedEntityId,
+      setSelectedEntityIds,
     ],
   );
 

--- a/apps/viewer/src/components/viewer/SearchModal.text.wiring.test.ts
+++ b/apps/viewer/src/components/viewer/SearchModal.text.wiring.test.ts
@@ -1,0 +1,125 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Source-level wiring tests for the Search tab's row-click / Enter `commit`
+ * handler in `SearchModal.text.tsx`.
+ *
+ * `SearchModalText` reads the store directly via `useViewerStore` and
+ * renders a virtualized list, so it cannot be mounted under `tsx --test`,
+ * and this repo rejects `mock.module` (see
+ * `apps/viewer/src/sdk/ExtensionHostProvider.tsx:27-30`).
+ * `frameSelection` (Viewport.tsx) PREFERS the numeric multi-selection set
+ * over the single selection, so a stale box/basket selection made `commit`
+ * frame the OLD elements instead of the search result the user just
+ * clicked/entered. `HierarchyPanel` already guards this with
+ * `setSelectedEntityIds([])` before selecting; `commit` must do the same.
+ *
+ * The ordering assertion is load-bearing: `setSelectedEntityIds([])` also
+ * resets `selectedEntityId` (selectionSlice.ts), so clearing AFTER
+ * selecting would silently discard the selection and frame nothing.
+ */
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(join(here, 'SearchModal.text.tsx'), 'utf8');
+
+/**
+ * Strip `//` line comments. Without this these tests are VACUOUS: the
+ * handler's own comment quotes the very calls being asserted (e.g.
+ * "`setSelectedEntityIds([])` resets `selectedEntityId`"), so a naive
+ * `indexOf` matches the comment rather than the statement — and since the
+ * comment sits above both calls, the ordering assertion passes no matter
+ * how the real statements are ordered. This exact failure mode shipped
+ * once already (PR #2396) before comment-stripping was added there.
+ */
+function stripLineComments(text: string): string {
+  return text
+    .split('\n')
+    .filter((line) => !line.trimStart().startsWith('//'))
+    .join('\n');
+}
+
+/** The body of `commit`, from its declaration to the dependency array. */
+function commitBody(): string {
+  const start = source.indexOf('const commit = useCallback(');
+  assert.notEqual(start, -1, 'commit must exist in SearchModal.text.tsx');
+  const end = source.indexOf('    [\n', start);
+  assert.notEqual(end, -1, 'commit must end with a dependency array');
+  const body = stripLineComments(source.slice(start, end));
+  // Guard the guard: if the stripping ever removes the statements
+  // themselves, every assertion below would fail loudly rather than
+  // silently pass.
+  assert.ok(body.includes('setSelectedEntityId('), 'stripped body must retain the selection calls');
+  return body;
+}
+
+describe('SearchModalText: commit wiring', () => {
+  test('clears the multi-selection, selects, frames, enters vim cycle, and closes', () => {
+    const body = commitBody();
+    for (const call of [
+      'setSelectedEntityIds([])',
+      'setSelectedEntityId(globalId)',
+      'setSelectedEntity(ref)',
+      'cameraCallbacks.frameSelection',
+      'enterVimCycle(',
+      'onClose()',
+    ]) {
+      assert.ok(body.includes(call), `commit must call ${call}`);
+    }
+  });
+
+  test('clears the multi-selection BEFORE selecting, since clearing resets selectedEntityId', () => {
+    const body = commitBody();
+    const cleared = body.indexOf('setSelectedEntityIds([])');
+    const selected = body.indexOf('setSelectedEntityId(globalId)');
+    assert.ok(cleared >= 0 && selected >= 0, 'both calls must be present');
+    assert.ok(
+      cleared < selected,
+      'setSelectedEntityIds([]) must run BEFORE setSelectedEntityId — clearing also resets selectedEntityId, so the reverse order discards the selection and frames nothing',
+    );
+  });
+
+  test('clears the multi-selection BEFORE entering the vim cycle', () => {
+    const body = commitBody();
+    const cleared = body.indexOf('setSelectedEntityIds([])');
+    const cycle = body.indexOf('enterVimCycle(');
+    assert.ok(cleared >= 0 && cycle >= 0, 'both calls must be present');
+    assert.ok(cleared < cycle, 'setSelectedEntityIds([]) must run before enterVimCycle');
+  });
+
+  test('the handler declares every store setter it calls as a dependency', () => {
+    const start = source.indexOf('const commit = useCallback(');
+    const depsStart = source.indexOf('    [\n', start);
+    const depsEnd = source.indexOf('  );', depsStart);
+    const deps = source.slice(depsStart, depsEnd);
+    for (const dep of ['setSelectedEntityIds', 'setSelectedEntityId', 'setSelectedEntity', 'enterVimCycle', 'onClose']) {
+      assert.ok(deps.includes(dep), `${dep} must be in the useCallback dependency array`);
+    }
+  });
+
+  test('the component binds setSelectedEntityIds from the store', () => {
+    assert.ok(
+      source.includes('setSelectedEntityIds: s.setSelectedEntityIds'),
+      'setSelectedEntityIds must be pulled from the store selector, or commit would reference an undefined binding',
+    );
+  });
+
+  test('the additive (Shift+Enter) toggleAdditive path does NOT clear the multi-selection', () => {
+    const start = source.indexOf('const toggleAdditive = useCallback(');
+    assert.notEqual(start, -1, 'toggleAdditive must exist');
+    const end = source.indexOf('  );', start);
+    const body = stripLineComments(source.slice(start, end));
+    assert.ok(body.includes('toggleEntitySelection('), 'toggleAdditive must still toggle into the multi-selection');
+    assert.ok(
+      !body.includes('setSelectedEntityIds([])'),
+      'toggleAdditive must NOT clear the multi-selection — Shift+Enter is meant to build it up',
+    );
+  });
+});


### PR DESCRIPTION
Follow-up offered in #2396, which fixed this same shape in the Filter tab. These are the two search paths that PR deliberately left alone.

## The bug

`frameSelection` **prefers** the numeric multi-selection over the single selection (`Viewport.tsx:930-937`):

```ts
const ids = set && set.size > 0
  ? Array.from(set)                       // numeric multi-selection — PREFERRED
  : hl && hl.size > 0
    ? Array.from(hl.keys())               // clash highlight
    : single !== null ? [single] : [];    // single selection — last resort
```

So with a box or basket selection live, picking a search result frames the **old** set, not the element just clicked. `HierarchyPanel` already guards this (`HierarchyPanel.tsx:409-411`); the search paths didn't.

## Ordering is the whole fix

`setSelectedEntityIds([])` **also resets `selectedEntityId`** (`selectionSlice.ts:160-163`):

```ts
setSelectedEntityIds: (ids) => set({
  selectedEntityIds: new Set(ids),
  selectedEntityId: ids.length > 0 ? ids[ids.length - 1] : null,
}),
```

Clearing *after* selecting would silently discard the selection and frame nothing — trading this bug for a worse one. Clear first, then select, matching `HierarchyPanel`'s sequence and its comment.

## Per-site verdict

| Site | Verdict |
|---|---|
| `SearchInline.tsx` `applySelection`, non-additive branch | **fixed** |
| `SearchModal.text.tsx` `commit` | **fixed** — clear placed before `enterVimCycle` too, tested explicitly |
| `SearchInline.tsx` additive branch (Shift+Enter) | **deliberately not fixed** |
| `SearchModal.text.tsx` `toggleAdditive` | **deliberately not fixed** |
| `SearchModal.filter.tsx` | untouched — already handled in #2396 |

The additive branches build a multi-selection up across successive picks via `toggleEntitySelection`; clearing there would defeat the feature outright. A test asserts the additive branch never calls `setSelectedEntityIds([])`, so a later "consistency" cleanup can't quietly break it.

Worth noting the n/N vim-cycle stepping reuses `applySelection(current, false)` — the same non-additive path — so stepping is covered by the same fix rather than needing its own.

## Mutation checks

| Mutation | Result |
|---|---|
| swap clear/select in both files | 2 of 12 fail (the ordering assertions) |
| independently re-verified in `SearchInline` alone | 1 of 6 fails — `clears the multi-selection BEFORE selecting, since clearing resets selectedEntityId` |

These are source-level wiring tests, because the components read the store directly and render virtualized lists — they can't be mounted under `tsx --test`, and this repo rejects `mock.module`.

**On the vacuity risk specifically:** #2396 shipped a wiring test that passed against a deliberately broken handler, because `indexOf` matched a *code comment* quoting the asserted call rather than the statement. These tests strip comments before matching and carry a "guard the guard" assertion that the stripped body still contains real statements. Checked here whether stripping was load-bearing for this particular phrasing — it wasn't, the swap mutation was caught either way — but it stays as a structural safeguard, since the phrasing that defeats it is one comment edit away.

## Displacement

Clearing skips nothing the old code reached on the non-additive path — `selectedEntityIds` was already semantically stale there, and `frameSelection` was the only consumer preferring it. The additive paths are untouched, so nothing that legitimately wanted the set preserved is affected.

## Verification

`apps/viewer`: 3234 tests, **0 failures**, 2 skipped (12 added). `tsc --noEmit` clean for both touched files and both new tests. No changeset — `apps/viewer` is `"private": true`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search results now correctly clear existing multi-selection when selecting a new primary result.
  * Additive search selection continues to preserve and toggle existing selections.
  * Vim-style search navigation now follows the same consistent selection behavior.

* **Tests**
  * Added coverage for inline and modal search selection, framing, closing, and additive-selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->