### PR TITLE
fix(viewer): anchor every arm of the analytics noise filter, not just the flagged one

### DIFF
--- a/apps/viewer/src/lib/analytics-scrub.ts
+++ b/apps/viewer/src/lib/analytics-scrub.ts
@@ -187,6 +187,14 @@ const scrubExceptionMessages = (
 // like a fix: `^`-only still eats our trailing sentence, `$`-only still eats
 // our leading one.
 //
+// There are TWO axes and an arm has to be tight on both. EXTENT: how much of
+// the value the match covers, which is what anchoring buys. IDENTITY: whether
+// what matched actually IS the third-party failure. An arm can be exact about
+// the shape it matched and vague about whose shape that is — "contains these
+// three key names" dropped anything HTTP-ish until `isCesiumRequestError`
+// below required Cesium's own-property set exactly. Same defect family,
+// different axis, found one review apart.
+//
 // Adding an arm means constraining both ends AND listing its wording in
 // `DROPPED_NOISE_SAMPLES` (./analytics.test.ts), which re-runs every sample
 // under four carriers — text before, text after, both sides, and a comma-led
@@ -215,9 +223,8 @@ const scrubExceptionMessages = (
 // reason posthog re-coerces through this same path rather than prefixing it.
 //
 // STRUCTURAL, over the complete value: the ctor token (quoted or bare depending
-// on which coercion ran, never spaced), then a key list that must parse AS a
-// key list — every comma-separated member a bare own-property name — and
-// contain all three of Cesium's. Anchoring at `^` alone was not enough and is
+// on which coercion ran, never spaced), then a key list whose members are
+// EXACTLY Cesium's three own properties. Anchoring at `^` alone was not enough and is
 // the same half-measure this file exists to remove: the lookaheads scanned the
 // rest of the value, so "RequestErrorEvent captured as exception with keys:
 // statusCode, response, responseHeaders and our uploader then wrote 0 bytes"
@@ -225,20 +232,41 @@ const scrubExceptionMessages = (
 // instead of searching it also leaves posthog free to reorder or respace the
 // keys (it sorts and `", "`-joins them today), which a fully literal `^…$`
 // would not.
+//
+// The ctor token is matched but NOT required to read `RequestErrorEvent`, and
+// that is not an oversight: in production Cesium's class name is minified —
+// the recorded occurrence behind #1175 is literally `'D_'`, which is why that
+// issue keyed on the property shape in the first place. Requiring the readable
+// name makes this arm dead everywhere it matters (verified: it fails #1175's
+// own regression test). The identity constraint that DOES survive minification
+// is the exact own-property set, which is what the length check below enforces.
 const CESIUM_REQUEST_ERROR_KEYS = ['statusCode', 'response', 'responseHeaders'];
 
 // The whole stringification, with the key list captured for validation rather
 // than searched. Bounded runs only: no nested quantifier to backtrack on.
 const CAPTURED_WITH_KEYS = /^\S{1,64} captured as exception with keys:[ \t]*(\S[^\n]{0,512})$/;
 
-/** A bare own-property name. A sentence of ours is not one — that is the test. */
-const OWN_KEY_NAME = /^[A-Za-z_$][\w$]{0,63}$/;
-
 const isCesiumRequestError = (value: string): boolean => {
   const match = CAPTURED_WITH_KEYS.exec(value);
   if (!match) return false;
   const keys = match[1].split(',').map((key) => key.trim());
-  if (!keys.every((key) => OWN_KEY_NAME.test(key))) return false;
+  // EXACTLY Cesium's three own properties, not merely "contains" them. Own
+  // property names are unique, so length plus containment IS set equality, and
+  // set equality is what carries both jobs at once:
+  //
+  //  identity — containment alone left this arm precise about the shape it
+  //    matched and vague about whose shape it was, so any throwable carrying
+  //    those three among its keys was deleted as Cesium noise. `{statusCode,
+  //    response, responseHeaders}` is a generic HTTP-ish shape, not a
+  //    Cesium-unique one, and ours may legitimately carry all three plus its
+  //    own request id.
+  //  extent — three members that each equal one of three fixed names cannot
+  //    also carry a sentence of ours, so the trailing prose case falls out of
+  //    the same check. (An explicit "every member is a bare identifier" guard
+  //    stood here and was deleted with this change: set equality made it
+  //    unable to alter any outcome, and a check that cannot fail is worse than
+  //    no check — it reads as protection.)
+  if (keys.length !== CESIUM_REQUEST_ERROR_KEYS.length) return false;
   return CESIUM_REQUEST_ERROR_KEYS.every((key) => keys.includes(key));
 };
 

--- a/apps/viewer/src/lib/analytics-scrub.ts
+++ b/apps/viewer/src/lib/analytics-scrub.ts
@@ -189,9 +189,16 @@ const scrubExceptionMessages = (
 //
 // Adding an arm means constraining both ends AND listing its wording in
 // `DROPPED_NOISE_SAMPLES` (./analytics.test.ts), which re-runs every sample
-// under three carriers — text before, text after, text both sides — and fails
-// unless each survives with its own kind, level and fingerprint. Checked there,
-// not merely remembered here.
+// under four carriers — text before, text after, both sides, and a comma-led
+// trailing sentence for the arms that SPLIT the value — and fails unless each
+// survives with its own kind, level and fingerprint.
+//
+// Know what that does and does not buy you. Every wording IN the list is
+// protected: loosening any registered arm turns the harness red, including
+// arms nobody wrote a dedicated test for. An arm you add and DON'T register is
+// invisible to it — a fresh `value.includes(…)` clause with no list entry
+// passes everything. Registration is a convention this comment asks for, not a
+// gate. Skipping it is how the next instance of this defect gets in.
 //
 // Cesium rejects failed tile / terrain / imagery / ion-asset requests with a
 // `RequestErrorEvent` — a plain `{ statusCode, response, responseHeaders }`

--- a/apps/viewer/src/lib/analytics-scrub.ts
+++ b/apps/viewer/src/lib/analytics-scrub.ts
@@ -178,18 +178,20 @@ const scrubExceptionMessages = (
 // cannot be re-derived from anything.
 //
 // INVARIANT, a property of the whole boolean and not of any one clause: every
-// arm matches the exception value AS A WHOLE — anchored, or structural (parse
-// the payload and require the field to BE the token) — never as a bare
-// substring, so an unrelated actionable error that merely QUOTES one of these
-// strings still reaches us. #1914 named that hazard while anchoring one arm;
-// three siblings were found loose afterwards, each by checking the neighbours
-// of an arm somebody had already fixed.
+// arm matches the exception value AS A WHOLE — anchored at BOTH ends, or
+// structural (parse the payload and require the field to BE the token) — so an
+// unrelated actionable error that merely QUOTES one of these strings still
+// reaches us. #1914 named that hazard while anchoring one arm; three siblings
+// were found loose afterwards, each by checking the neighbours of an arm
+// somebody had already fixed. A one-end anchor is NOT enough and reads exactly
+// like a fix: `^`-only still eats our trailing sentence, `$`-only still eats
+// our leading one.
 //
-// Adding an arm means anchoring it AND listing its wording in
+// Adding an arm means constraining both ends AND listing its wording in
 // `DROPPED_NOISE_SAMPLES` (./analytics.test.ts), which re-runs every sample
-// quoted inside a carrier sentence and fails unless the carrier survives with
-// its own kind, level and fingerprint. Checked there, not merely remembered
-// here.
+// under three carriers — text before, text after, text both sides — and fails
+// unless each survives with its own kind, level and fingerprint. Checked there,
+// not merely remembered here.
 //
 // Cesium rejects failed tile / terrain / imagery / ion-asset requests with a
 // `RequestErrorEvent` — a plain `{ statusCode, response, responseHeaders }`
@@ -204,11 +206,34 @@ const scrubExceptionMessages = (
 // "'<ctor>' captured as exception with keys: <comma-separated own keys>", and
 // that IS the whole value — even for an unhandled rejection, whose non-Error
 // reason posthog re-coerces through this same path rather than prefixing it.
-// Hence the leading anchor (one ctor token, quoted or bare depending on which
-// coercion ran, never spaced): the same three key names quoted inside someone
-// else's message is a failure of OURS and survives.
-const CESIUM_REQUEST_ERROR =
-  /^\S{1,64} captured as exception with keys:(?=[^]*\bstatusCode\b)(?=[^]*\bresponse\b)(?=[^]*\bresponseHeaders\b)/;
+//
+// STRUCTURAL, over the complete value: the ctor token (quoted or bare depending
+// on which coercion ran, never spaced), then a key list that must parse AS a
+// key list — every comma-separated member a bare own-property name — and
+// contain all three of Cesium's. Anchoring at `^` alone was not enough and is
+// the same half-measure this file exists to remove: the lookaheads scanned the
+// rest of the value, so "RequestErrorEvent captured as exception with keys:
+// statusCode, response, responseHeaders and our uploader then wrote 0 bytes"
+// was dropped with our own trailing sentence inside it. Validating the list
+// instead of searching it also leaves posthog free to reorder or respace the
+// keys (it sorts and `", "`-joins them today), which a fully literal `^…$`
+// would not.
+const CESIUM_REQUEST_ERROR_KEYS = ['statusCode', 'response', 'responseHeaders'];
+
+// The whole stringification, with the key list captured for validation rather
+// than searched. Bounded runs only: no nested quantifier to backtrack on.
+const CAPTURED_WITH_KEYS = /^\S{1,64} captured as exception with keys:[ \t]*(\S[^\n]{0,512})$/;
+
+/** A bare own-property name. A sentence of ours is not one — that is the test. */
+const OWN_KEY_NAME = /^[A-Za-z_$][\w$]{0,63}$/;
+
+const isCesiumRequestError = (value: string): boolean => {
+  const match = CAPTURED_WITH_KEYS.exec(value);
+  if (!match) return false;
+  const keys = match[1].split(',').map((key) => key.trim());
+  if (!keys.every((key) => OWN_KEY_NAME.test(key))) return false;
+  return CESIUM_REQUEST_ERROR_KEYS.every((key) => keys.includes(key));
+};
 
 // Microsoft's Outlook SafeLinks / Office link-preview crawler injects a script
 // into the page and rejects a promise with this bare string when its own
@@ -304,7 +329,7 @@ const isUnactionableThirdPartyException = (
   return list.some((entry) => {
     const value = (entry as { value?: unknown })?.value;
     if (typeof value !== 'string') return false;
-    if (CESIUM_REQUEST_ERROR.test(value)) return true;
+    if (isCesiumRequestError(value)) return true;
     if (OUTLOOK_SAFELINK_NOISE.test(value)) return true;
     // Scoped to the UNCAUGHT form only: the LocationMap's own once-per-session
     // handled report carries the same message and has to survive, otherwise

--- a/apps/viewer/src/lib/analytics-scrub.ts
+++ b/apps/viewer/src/lib/analytics-scrub.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { classifyLoadError } from './load-errors.js';
+import { isMapWebglInitFailureMessage } from './geo/map-webgl-support.js';
 
 // PostHog `before_send` pipeline: the single gate every captured event passes
 // through before it leaves the browser. Kept dependency-free (no posthog-js) so
@@ -171,6 +172,25 @@ const scrubExceptionMessages = (
 };
 
 // ── Noise filter ───────────────────────────────────────────────────────────
+// Every matcher here decides whether to DELETE an event — irreversibly and
+// silently, since nothing anywhere records that the event existed. A
+// misclassification can at least be re-derived from the stored event; a drop
+// cannot be re-derived from anything.
+//
+// INVARIANT, a property of the whole boolean and not of any one clause: every
+// arm matches the exception value AS A WHOLE — anchored, or structural (parse
+// the payload and require the field to BE the token) — never as a bare
+// substring, so an unrelated actionable error that merely QUOTES one of these
+// strings still reaches us. #1914 named that hazard while anchoring one arm;
+// three siblings were found loose afterwards, each by checking the neighbours
+// of an arm somebody had already fixed.
+//
+// Adding an arm means anchoring it AND listing its wording in
+// `DROPPED_NOISE_SAMPLES` (./analytics.test.ts), which re-runs every sample
+// quoted inside a carrier sentence and fails unless the carrier survives with
+// its own kind, level and fingerprint. Checked there, not merely remembered
+// here.
+//
 // Cesium rejects failed tile / terrain / imagery / ion-asset requests with a
 // `RequestErrorEvent` — a plain `{ statusCode, response, responseHeaders }`
 // object, not an Error. During continuous globe rendering these fire from deep
@@ -181,17 +201,29 @@ const scrubExceptionMessages = (
 // drop the `$exception` event entirely. Match on Cesium's stable property-name
 // shape (those three keys), NOT the minified class name (`D_`), which changes
 // every build. posthog-js stringifies a non-Error throwable as
-// "'<ctor>' captured as exception with keys: <comma-separated own keys>".
+// "'<ctor>' captured as exception with keys: <comma-separated own keys>", and
+// that IS the whole value — even for an unhandled rejection, whose non-Error
+// reason posthog re-coerces through this same path rather than prefixing it.
+// Hence the leading anchor (one ctor token, quoted or bare depending on which
+// coercion ran, never spaced): the same three key names quoted inside someone
+// else's message is a failure of OURS and survives.
 const CESIUM_REQUEST_ERROR =
-  /captured as exception with keys:(?=[^]*\bstatusCode\b)(?=[^]*\bresponse\b)(?=[^]*\bresponseHeaders\b)/;
+  /^\S{1,64} captured as exception with keys:(?=[^]*\bstatusCode\b)(?=[^]*\bresponse\b)(?=[^]*\bresponseHeaders\b)/;
 
 // Microsoft's Outlook SafeLinks / Office link-preview crawler injects a script
 // into the page and rejects a promise with this bare string when its own
 // bookkeeping misses. It is not our code, carries no stack, and fires only for
 // visitors arriving from an Outlook link — 18 occurrences made it the single
 // highest-volume "issue" in error tracking, all of it someone else's crawler.
+//
+// Anchored at BOTH ends over the crawler's complete sentence, so the phrase
+// quoted inside a message of OURS survives. The optional leading group is
+// posthog's own wrapper for a rejection whose reason was a bare string, which
+// is how this one always arrives and why `^` alone will not do; the trailing
+// `ParamCount` is optional so a crawler build that omits it still drops.
+// Everything before it is attested verbatim in our recorded occurrences.
 const OUTLOOK_SAFELINK_NOISE =
-  /Object Not Found Matching Id:\s*\d+,\s*MethodName:/i;
+  /^(?:Non-Error promise rejection captured with value:\s*)?Object Not Found Matching Id:\s*\d+,\s*MethodName:\s*\w{1,64}(?:,\s*ParamCount:\s*\d+)?\.?\s*$/i;
 
 // MapLibre cannot get a WebGL context: `_setupPainter()` throws either a bare
 // "Failed to initialize WebGL" or that message wrapped in a JSON blob carrying
@@ -208,13 +240,20 @@ const OUTLOOK_SAFELINK_NOISE =
 // stable message + the `webglcontextcreationerror` token, never on a minified
 // name — the same discipline as the Cesium matcher above. Deliberately narrow:
 // a WebGL failure that is ever actionable must not be silently dropped.
-// The bare case is ANCHORED, not a substring test: MapLibre throws exactly
-// this message and nothing else, so an unrelated error that merely mentions
-// the phrase ("Failed to initialize WebGL renderer for the ...") must still
-// reach us. Dropping is irreversible — a matcher that is loose here goes
-// blind exactly where it matters.
-const MAPLIBRE_WEBGL_UNAVAILABLE =
-  /^\s*Failed to initialize WebGL\s*$|"type":\s*"webglcontextcreationerror"/;
+//
+// Both shapes come from `isMapWebglInitFailureMessage`, imported rather than
+// restated so MapLibre's wordings keep ONE home. #1914 anchored the bare
+// message and left the payload arm a bare `"type": "webglcontextcreationerror"`
+// substring test, so an uncaught `Upload failed: driver shim logged
+// {"type":"webglcontextcreationerror"} while retrying` was deleted outright and
+// no record kept. That arm is now structural: the message must PARSE as JSON
+// whose `type` field IS the token and whose `message` is MapLibre's own
+// anchored wording — the shape v5 actually threw.
+//
+// The set stays exactly MapLibre's two throw shapes and is NOT widened to v6's
+// `WebGL2 is required to display this map`: #2354 keeps that family (classified
+// `webgl_unavailable`, one fingerprint, downgraded to `warning`) precisely so
+// the condition stays queryable, and dropping more of it would undo that.
 
 // The browser's opaque cross-origin error: `window.onerror` reports literally
 // "Script error." with no file, line, or stack when a script from another
@@ -270,7 +309,7 @@ const isUnactionableThirdPartyException = (
     // Scoped to the UNCAUGHT form only: the LocationMap's own once-per-session
     // handled report carries the same message and has to survive, otherwise
     // this rule would blind us to the very condition it exists to de-noise.
-    if (MAPLIBRE_WEBGL_UNAVAILABLE.test(value) && isUnhandled(entry)) return true;
+    if (isMapWebglInitFailureMessage(value) && isUnhandled(entry)) return true;
     if (OPAQUE_CROSS_ORIGIN.test(value.trim()) && frameCount(entry) === 0) return true;
     if (RESIZE_OBSERVER_LOOP.test(value.trim()) && frameCount(entry) === 0) return true;
     return false;

--- a/apps/viewer/src/lib/analytics.test.ts
+++ b/apps/viewer/src/lib/analytics.test.ts
@@ -376,7 +376,7 @@ const DROPPED_NOISE_SAMPLES: ReadonlyArray<{ label: string; value: string }> = [
     value: "'D_' captured as exception with keys: response, responseHeaders, statusCode",
   },
   {
-    label: 'outlook safelinks crawler',
+    label: 'outlook safelinks crawler (#1855)',
     value:
       'Non-Error promise rejection captured with value: '
       + 'Object Not Found Matching Id:2, MethodName:update, ParamCount:4',
@@ -394,10 +394,57 @@ const DROPPED_NOISE_SAMPLES: ReadonlyArray<{ label: string; value: string }> = [
       message: 'Failed to initialize WebGL',
     }),
   },
-  { label: 'opaque cross-origin', value: 'Script error.' },
+  { label: 'opaque cross-origin (#1855)', value: 'Script error.' },
   {
-    label: 'resizeobserver loop (#2120)',
+    label: 'resizeobserver loop (#2120, PR #2124)',
     value: 'ResizeObserver loop completed with undelivered notifications.',
+  },
+];
+
+// The mirror of the list above: values that LOOK like registered noise and must
+// NOT be dropped, each asserted to keep its own kind, level and fingerprint.
+//
+// DROPPED_NOISE_SAMPLES plus the carriers pin the EXTENT axis — how much of the
+// value an arm may match. This list pins the IDENTITY axis — whether what
+// matched is really the third-party failure. `isCesiumRequestError` was precise
+// about shape and vague about identity: "carries these three key names among
+// its keys" is a generic HTTP-ish shape, so a throwable of ours with those
+// fields plus its own was deleted as Cesium noise (#2402 review).
+const KEPT_LOOKALIKE_SAMPLES: ReadonlyArray<{ label: string; value: string }> = [
+  {
+    // Cesium's three own properties AND one of ours. Not Cesium's object, so
+    // not ours to delete — the arm now requires the own-property set EXACTLY.
+    label: 'cesium-shaped keys plus a fourth of our own (#2402 review)',
+    value: "'UploadError' captured as exception with keys: response, responseHeaders, statusCode, uploadId",
+  },
+  {
+    // Same three keys, readable ctor, but one key short of Cesium's object.
+    label: 'a subset of cesium\'s keys (#2402 review)',
+    value: "'HttpProbe' captured as exception with keys: response, statusCode",
+  },
+  {
+    // Cesium's key COUNT and one of its names, but not its object. Pins that
+    // the check is set equality and not "three keys, one of which is theirs" —
+    // a mutation to `.some(...)` passed everything until this sample existed.
+    label: 'three keys, only one of them cesium\'s (#2402 review)',
+    value: "'UploadError' captured as exception with keys: response, requestId, uploadId",
+  },
+  {
+    // The v5 token present but not as the `type` field's value.
+    label: 'v5 token in the wrong JSON field (#2402)',
+    value: JSON.stringify({
+      type: 'upload_retry',
+      message: 'Failed to initialize WebGL',
+      note: '"type": "webglcontextcreationerror"',
+    }),
+  },
+  {
+    // Cesium's exact stringification on line one, our diagnostic underneath.
+    // Multi-line is how a message of ours carries its own context, and the
+    // whole-value constraint has to hold across the newline too.
+    label: 'cesium stringification with our own second line (#2402 review)',
+    value: "'D_' captured as exception with keys: response, responseHeaders, statusCode\n"
+      + 'raised while our uploader was writing chunk 3 of 9',
   },
 ];
 
@@ -473,6 +520,19 @@ describe('scrubEvent — the noise filter never drops on a substring', () => {
     assert.notEqual(out, null);
     assert.equal(out?.properties?.error_kind, undefined);
     assert.equal(out?.properties?.$exception_level, 'error');
+  });
+
+  it('KEEPS every noise LOOKALIKE with its identity intact (identity axis)', () => {
+    // Same assertions as the carrier loop, different axis: these are not the
+    // registered noise wrapped in text, they are values whose SHAPE resembles
+    // it closely enough that a matcher vague about identity would delete them.
+    for (const { label, value } of KEPT_LOOKALIKE_SAMPLES) {
+      const out = scrubEvent(autocaptured(value));
+      assert.notEqual(out, null, label);
+      assert.equal(out?.properties?.error_kind, undefined, label);
+      assert.equal(out?.properties?.$exception_fingerprint, undefined, label);
+      assert.equal(out?.properties?.$exception_level, 'error', label);
+    }
   });
 
   it('never drops the v6 wording, even UNCAUGHT (#2354 keeps that family queryable)', () => {

--- a/apps/viewer/src/lib/analytics.test.ts
+++ b/apps/viewer/src/lib/analytics.test.ts
@@ -348,6 +348,130 @@ describe('scrubEvent — noise filter + PII guard (regression)', () => {
   });
 });
 
+// ── The noise filter's whole-value invariant ─────────────────────────────────
+// Every matcher in `analytics-scrub.ts`'s noise-filter section DELETES the
+// event. That is silent and irreversible: unlike a misclassification, which
+// leaves a stored event to re-derive the truth from, a drop leaves no record
+// anywhere that the event existed.
+//
+// So the invariant is not "the flagged arm is anchored", it is: EVERY arm of
+// EVERY matcher there matches the value as a whole — anchored or structural —
+// and an unrelated, actionable error that merely QUOTES one of these strings
+// still reaches PostHog with its own kind, level and grouping. #1914 anchored
+// one arm of this matcher and named the hazard in a comment; the sibling arm in
+// the same expression stayed a bare substring test, and survived three later
+// rounds of fixing this very defect class next door in the classify path
+// (#2354) — which is what a comment buys you. This list is the structural
+// version: adding an arm to the noise filter means adding its wording here, and
+// the quoted-in-context test below then fails until the new arm is anchored too.
+const DROPPED_NOISE_SAMPLES: ReadonlyArray<{ label: string; value: string }> = [
+  {
+    label: 'cesium request error (#1175)',
+    value: "'D_' captured as exception with keys: response, responseHeaders, statusCode",
+  },
+  {
+    label: 'outlook safelinks crawler',
+    value:
+      'Non-Error promise rejection captured with value: '
+      + 'Object Not Found Matching Id:2, MethodName:update, ParamCount:4',
+  },
+  {
+    label: 'maplibre bare wording (#1914)',
+    value: 'Failed to initialize WebGL',
+  },
+  {
+    label: 'maplibre v5 JSON payload (#1914)',
+    value: JSON.stringify({
+      requestedAttributes: { alpha: true, depth: true, stencil: true },
+      statusMessage: 'OES_packed_depth_stencil support is required.',
+      type: 'webglcontextcreationerror',
+      message: 'Failed to initialize WebGL',
+    }),
+  },
+  { label: 'opaque cross-origin', value: 'Script error.' },
+  {
+    label: 'resizeobserver loop (#2120)',
+    value: 'ResizeObserver loop completed with undelivered notifications.',
+  },
+];
+
+describe('scrubEvent — the noise filter never drops on a substring', () => {
+  /** An autocaptured (uncaught) exception, error-level, with no frames. */
+  const autocaptured = (value: string): CaptureEvent => ({
+    event: '$exception',
+    properties: {
+      $exception_list: [{ type: 'Error', value, mechanism: { handled: false, synthetic: false, type: 'generic' } }],
+      $exception_level: 'error',
+    },
+  });
+
+  it('drops every genuine noise sample (the control for the test below)', () => {
+    // Runs first on purpose: without it, the quoted-in-context test could pass
+    // vacuously against a matcher that had stopped matching anything at all.
+    for (const { label, value } of DROPPED_NOISE_SAMPLES) {
+      assert.equal(scrubEvent(autocaptured(value)), null, label);
+    }
+  });
+
+  it('KEEPS a real failure that merely quotes a noise sample, with its identity intact', () => {
+    // The reported repro (this PR): an uncaught `Upload failed: driver shim
+    // logged {"type":"webglcontextcreationerror"} while retrying` was deleted
+    // outright by the MapLibre arm's bare substring test. Sweeping the siblings
+    // found the Cesium and Outlook arms doing the same.
+    //
+    // Presence (`!== null`) is deliberately NOT the whole assertion: an event
+    // can survive and still be relabelled benign, fingerprinted into someone
+    // else's issue and downgraded off the error list, which buries it just as
+    // effectively. Assert the classification, not just the survival.
+    for (const { label, value } of DROPPED_NOISE_SAMPLES) {
+      const carrier = `Upload failed: driver shim logged ${value} while retrying`;
+      const out = scrubEvent(autocaptured(carrier));
+      assert.notEqual(out, null, label);
+      assert.equal(out?.properties?.error_kind, undefined, label);
+      assert.equal(out?.properties?.$exception_fingerprint, undefined, label);
+      assert.equal(out?.properties?.$exception_level, 'error', label);
+    }
+  });
+
+  it('KEEPS the reported repro verbatim', () => {
+    const out = scrubEvent(autocaptured(
+      'Upload failed: driver shim logged {"type":"webglcontextcreationerror"} while retrying',
+    ));
+    assert.notEqual(out, null);
+    assert.equal(out?.properties?.error_kind, undefined);
+    assert.equal(out?.properties?.$exception_level, 'error');
+  });
+
+  it('still drops a genuine v5 payload whose statusMessage quotes a carrier sentence', () => {
+    // The structural arm keys on the `type` FIELD, so hostile-looking prose in
+    // the driver's own `statusMessage` — vendor text we do not control — cannot
+    // rescue an event that IS MapLibre's failure.
+    const payload = JSON.stringify({
+      statusMessage: 'Upload failed: while retrying, "type": "webglcontextcreationerror"',
+      type: 'webglcontextcreationerror',
+      message: 'Failed to initialize WebGL',
+    });
+    assert.equal(scrubEvent(autocaptured(payload)), null);
+  });
+
+  it('KEEPS a JSON payload that carries the token in the wrong field', () => {
+    // Structural, not "contains a type key": a serialized log line whose `type`
+    // is something else entirely, or whose message is not MapLibre's wording,
+    // is not MapLibre's failure and is not ours to delete.
+    const wrongType = JSON.stringify({
+      type: 'upload_retry',
+      message: 'Failed to initialize WebGL',
+      note: '"type": "webglcontextcreationerror"',
+    });
+    const wrongMessage = JSON.stringify({
+      type: 'webglcontextcreationerror',
+      message: 'Failed to initialize WebGL renderer for the section overlay',
+    });
+    assert.notEqual(scrubEvent(autocaptured(wrongType)), null);
+    assert.notEqual(scrubEvent(autocaptured(wrongMessage)), null);
+  });
+});
+
 describe('scrubEvent — issue grouping', () => {
   it('collapses every stream-watchdog variant onto one fingerprint', () => {
     // The volatile mesh count used to mint a separate PostHog issue (and a

--- a/apps/viewer/src/lib/analytics.test.ts
+++ b/apps/viewer/src/lib/analytics.test.ts
@@ -370,6 +370,12 @@ describe('scrubEvent — noise filter + PII guard (regression)', () => {
 // weakened without turning red. It does not protect an arm nobody registers —
 // a fresh loose clause with no entry in this list passes the whole suite.
 // Registration is a convention, not a gate.
+//
+// And assert the property the test is NAMED for, not a proxy for it. Survival
+// (`!== null`) does not pin classification; `error_kind` does not pin the
+// message; "verbatim" is only pinned by comparing the message to the input.
+// Three findings in this PR's reviews were all this same substitution — the
+// assertion checked that something was present rather than what it was.
 const DROPPED_NOISE_SAMPLES: ReadonlyArray<{ label: string; value: string }> = [
   {
     label: 'cesium request error (#1175)',
@@ -513,12 +519,19 @@ describe('scrubEvent — the noise filter never drops on a substring', () => {
     }
   });
 
-  it('KEEPS the reported repro verbatim', () => {
-    const out = scrubEvent(autocaptured(
-      'Upload failed: driver shim logged {"type":"webglcontextcreationerror"} while retrying',
-    ));
+  it('KEEPS the reported repro verbatim (#2402)', () => {
+    // "Verbatim" is the claim in the name, so the message itself is asserted,
+    // not just the event's survival and labels: a scrubber that rewrote
+    // `$exception_list[0].value` — the redaction pass two functions below walks
+    // exactly this field — would satisfy every other assertion here while
+    // destroying the thing the test is named for.
+    const repro = 'Upload failed: driver shim logged {"type":"webglcontextcreationerror"} while retrying';
+    const out = scrubEvent(autocaptured(repro));
     assert.notEqual(out, null);
+    const list = out?.properties?.$exception_list as Array<{ value?: unknown }> | undefined;
+    assert.equal(list?.[0]?.value, repro);
     assert.equal(out?.properties?.error_kind, undefined);
+    assert.equal(out?.properties?.$exception_fingerprint, undefined);
     assert.equal(out?.properties?.$exception_level, 'error');
   });
 

--- a/apps/viewer/src/lib/analytics.test.ts
+++ b/apps/viewer/src/lib/analytics.test.ts
@@ -365,6 +365,11 @@ describe('scrubEvent — noise filter + PII guard (regression)', () => {
 // version: adding an arm to the noise filter means adding its wording here, and
 // the quoted-in-context tests below then fail until the new arm constrains the
 // whole value — at both ends, which the CARRIERS table is what actually proves.
+//
+// Scope, stated plainly: this protects every arm REGISTERED here, and cannot be
+// weakened without turning red. It does not protect an arm nobody registers —
+// a fresh loose clause with no entry in this list passes the whole suite.
+// Registration is a convention, not a gate.
 const DROPPED_NOISE_SAMPLES: ReadonlyArray<{ label: string; value: string }> = [
   {
     label: 'cesium request error (#1175)',
@@ -468,6 +473,23 @@ describe('scrubEvent — the noise filter never drops on a substring', () => {
     assert.notEqual(out, null);
     assert.equal(out?.properties?.error_kind, undefined);
     assert.equal(out?.properties?.$exception_level, 'error');
+  });
+
+  it('never drops the v6 wording, even UNCAUGHT (#2354 keeps that family queryable)', () => {
+    // The non-widening decision, pinned END TO END rather than on the helper.
+    // `isMapWebglInitFailureMessage` deliberately excludes v6's wording, and the
+    // map-webgl unit tests pin that — but nothing there stops a future editor
+    // restating the wording in the drop arm itself, which would silently undo
+    // #2354's keep-and-downgrade. This asserts through `scrubEvent`: the event
+    // survives AND arrives classified, downgraded and fingerprinted, which is
+    // the outcome #2354 chose over deleting it.
+    const out = scrubEvent(autocaptured(
+      'WebGL2 is required to display this map. The map could not start: MapLibre built no painter.',
+    ));
+    assert.notEqual(out, null);
+    assert.equal(out?.properties?.error_kind, 'webgl_unavailable');
+    assert.equal(out?.properties?.$exception_level, 'warning');
+    assert.equal(out?.properties?.$exception_fingerprint, 'ifc-lite:webgl_unavailable');
   });
 
   it('KEEPS a Cesium-shaped stringification whose key list is really a sentence', () => {

--- a/apps/viewer/src/lib/analytics.test.ts
+++ b/apps/viewer/src/lib/analytics.test.ts
@@ -355,15 +355,16 @@ describe('scrubEvent — noise filter + PII guard (regression)', () => {
 // anywhere that the event existed.
 //
 // So the invariant is not "the flagged arm is anchored", it is: EVERY arm of
-// EVERY matcher there matches the value as a whole — anchored or structural —
-// and an unrelated, actionable error that merely QUOTES one of these strings
-// still reaches PostHog with its own kind, level and grouping. #1914 anchored
-// one arm of this matcher and named the hazard in a comment; the sibling arm in
-// the same expression stayed a bare substring test, and survived three later
-// rounds of fixing this very defect class next door in the classify path
-// (#2354) — which is what a comment buys you. This list is the structural
+// EVERY matcher there matches the value as a whole — anchored at BOTH ends, or
+// structural — and an unrelated, actionable error that merely QUOTES one of
+// these strings still reaches PostHog with its own kind, level and grouping.
+// #1914 anchored one arm of this matcher and named the hazard in a comment; the
+// sibling arm in the same expression stayed a bare substring test, and survived
+// three later rounds of fixing this very defect class next door in the classify
+// path (#2354) — which is what a comment buys you. This list is the structural
 // version: adding an arm to the noise filter means adding its wording here, and
-// the quoted-in-context test below then fails until the new arm is anchored too.
+// the quoted-in-context tests below then fail until the new arm constrains the
+// whole value — at both ends, which the CARRIERS table is what actually proves.
 const DROPPED_NOISE_SAMPLES: ReadonlyArray<{ label: string; value: string }> = [
   {
     label: 'cesium request error (#1175)',
@@ -413,23 +414,50 @@ describe('scrubEvent — the noise filter never drops on a substring', () => {
     }
   });
 
+  // THREE carriers, because one is blind. Each catches a different half-anchored
+  // matcher, and a matcher anchored at one end passes the other two:
+  //
+  //   surrounded     text on both sides — catches an unanchored substring test
+  //   leading only   text before, sample at the end — catches a `$`-only matcher
+  //   trailing only  sample first, text after — catches a `^`-only matcher
+  //
+  // The first review of this PR shipped a `^`-only Cesium arm and the harness
+  // said nothing, because the single carrier it had was `surrounded`: leading
+  // text already fails `^`, so the arm never fired and the event survived for
+  // the wrong reason. A carrier set that only probes one end can only find
+  // looseness at that end.
+  const CARRIERS: ReadonlyArray<{ label: string; wrap: (value: string) => string }> = [
+    { label: 'surrounded', wrap: (v) => `Upload failed: driver shim logged ${v} while retrying` },
+    { label: 'leading only', wrap: (v) => `Upload failed: driver shim logged ${v}` },
+    { label: 'trailing only', wrap: (v) => `${v} and our upload pipeline then wrote 0 bytes` },
+    // Comma-led, because a structural matcher that SPLITS the value has a
+    // second way to be loose: glue the sentence onto the last member and it
+    // fails the member test, but hand it its own delimiter and it can sail
+    // through as one more member. Mutating away the member validation left the
+    // three sentences above all passing; this one kills it.
+    { label: 'trailing only, comma-led', wrap: (v) => `${v}, and our upload pipeline then wrote 0 bytes` },
+  ];
+
   it('KEEPS a real failure that merely quotes a noise sample, with its identity intact', () => {
     // The reported repro (this PR): an uncaught `Upload failed: driver shim
     // logged {"type":"webglcontextcreationerror"} while retrying` was deleted
     // outright by the MapLibre arm's bare substring test. Sweeping the siblings
-    // found the Cesium and Outlook arms doing the same.
+    // found the Cesium and Outlook arms doing the same, and sweeping the
+    // carriers one axis over found the Cesium arm again from the other end.
     //
     // Presence (`!== null`) is deliberately NOT the whole assertion: an event
     // can survive and still be relabelled benign, fingerprinted into someone
     // else's issue and downgraded off the error list, which buries it just as
     // effectively. Assert the classification, not just the survival.
     for (const { label, value } of DROPPED_NOISE_SAMPLES) {
-      const carrier = `Upload failed: driver shim logged ${value} while retrying`;
-      const out = scrubEvent(autocaptured(carrier));
-      assert.notEqual(out, null, label);
-      assert.equal(out?.properties?.error_kind, undefined, label);
-      assert.equal(out?.properties?.$exception_fingerprint, undefined, label);
-      assert.equal(out?.properties?.$exception_level, 'error', label);
+      for (const carrier of CARRIERS) {
+        const where = `${label} / ${carrier.label}`;
+        const out = scrubEvent(autocaptured(carrier.wrap(value)));
+        assert.notEqual(out, null, where);
+        assert.equal(out?.properties?.error_kind, undefined, where);
+        assert.equal(out?.properties?.$exception_fingerprint, undefined, where);
+        assert.equal(out?.properties?.$exception_level, 'error', where);
+      }
     }
   });
 
@@ -440,6 +468,50 @@ describe('scrubEvent — the noise filter never drops on a substring', () => {
     assert.notEqual(out, null);
     assert.equal(out?.properties?.error_kind, undefined);
     assert.equal(out?.properties?.$exception_level, 'error');
+  });
+
+  it('KEEPS a Cesium-shaped stringification whose key list is really a sentence', () => {
+    // The `^`-only arm's exact escape (CodeRabbit, round two of this PR): the
+    // three key names are all present and the value starts correctly, so every
+    // lookahead was satisfied and our trailing sentence went with it.
+    const out = scrubEvent(autocaptured(
+      'RequestErrorEvent captured as exception with keys: statusCode, response, '
+      + 'responseHeaders and our uploader then wrote 0 bytes',
+    ));
+    assert.notEqual(out, null);
+    assert.equal(out?.properties?.error_kind, undefined);
+    assert.equal(out?.properties?.$exception_level, 'error');
+  });
+
+  it('KEEPS a Cesium-shaped value whose key list runs past the bounded scan', () => {
+    // The bound on the captured key list is not cosmetic. posthog caps its key
+    // list at 40 characters, so a tail this long is by construction not its
+    // stringification — and if the end anchor were dropped, the matcher would
+    // read the first few hundred characters, find a tidy key list, and delete
+    // whatever our sentence said after it. Mutating the `$` away is invisible
+    // to every other test here, because the capture is greedy to end-of-line.
+    const padding = Array.from({ length: 60 }, (_, i) => `padKey${String(i).padStart(4, '0')}`).join(', ');
+    const out = scrubEvent(autocaptured(
+      `'D_' captured as exception with keys: statusCode, response, responseHeaders, ${padding} `
+      + 'and our uploader then wrote 0 bytes',
+    ));
+    assert.notEqual(out, null);
+    assert.equal(out?.properties?.error_kind, undefined);
+    assert.equal(out?.properties?.$exception_level, 'error');
+  });
+
+  it('still drops Cesium\'s stringification whatever the key order or spacing', () => {
+    // Validating the list instead of matching it literally is what buys this:
+    // posthog sorts and `", "`-joins the keys today, and that is not our
+    // contract to depend on.
+    assert.equal(
+      scrubEvent(autocaptured('Object captured as exception with keys: statusCode,response,responseHeaders')),
+      null,
+    );
+    assert.equal(
+      scrubEvent(autocaptured("'D_' captured as exception with keys: responseHeaders, statusCode, response")),
+      null,
+    );
   });
 
   it('still drops a genuine v5 payload whose statusMessage quotes a carrier sentence', () => {

--- a/apps/viewer/src/lib/geo/map-webgl-support.test.ts
+++ b/apps/viewer/src/lib/geo/map-webgl-support.test.ts
@@ -10,6 +10,7 @@ import {
   takeMapWebglReportSlot,
   getMapWebglVerdict,
   isWebglContextCreationError,
+  isMapWebglInitFailureMessage,
   describeMapInitFailure,
   watchContextCreationStatus,
   reconstructMapInitFailure,
@@ -161,6 +162,63 @@ describe('isWebglContextCreationError', () => {
     assert.equal(isWebglContextCreationError(null), false);
     assert.equal(isWebglContextCreationError(undefined), false);
     assert.equal(isWebglContextCreationError({}), false);
+  });
+});
+
+describe('isMapWebglInitFailureMessage', () => {
+  // The narrower predicate `analytics-scrub.ts` DROPS on. Its boundaries are a
+  // decision, not an implementation detail: everything it returns true for is
+  // deleted before it leaves the browser, so both directions are pinned here.
+  it('recognises exactly the shapes MapLibre throws', () => {
+    assert.equal(isMapWebglInitFailureMessage(MISSING_EXTENSION), true);
+    assert.equal(isMapWebglInitFailureMessage(GPU_PROCESS_CONTENTION), true);
+    assert.equal(isMapWebglInitFailureMessage(BARE_MESSAGE), true);
+  });
+
+  it('does NOT claim the v6 wording, which stays captured and downgraded', () => {
+    // Deliberate asymmetry with `isWebglContextCreationError`: #2354 keeps the
+    // v6 family (one fingerprint, `warning` severity) rather than deleting it,
+    // so widening the drop set to cover it would undo that decision.
+    assert.equal(
+      isMapWebglInitFailureMessage('WebGL2 is required to display this map. The map could not start.'),
+      false,
+    );
+  });
+
+  it('does not fire on the token or the wording quoted inside another message', () => {
+    // The defect this predicate exists to close: a bare substring test deleted
+    // an actionable upload failure that merely quoted the driver's payload.
+    assert.equal(
+      isMapWebglInitFailureMessage(
+        'Upload failed: driver shim logged {"type":"webglcontextcreationerror"} while retrying',
+      ),
+      false,
+    );
+    assert.equal(
+      isMapWebglInitFailureMessage('SectionOverlay: Failed to initialize WebGL'),
+      false,
+    );
+    assert.equal(
+      isMapWebglInitFailureMessage('Failed to initialize WebGL renderer for the section overlay'),
+      false,
+    );
+    // Structural, not "is JSON mentioning the token": the token must BE the
+    // value of `type`, and `message` must be MapLibre's own wording.
+    assert.equal(
+      isMapWebglInitFailureMessage(JSON.stringify({
+        type: 'upload_retry',
+        message: 'Failed to initialize WebGL',
+        note: '"type": "webglcontextcreationerror"',
+      })),
+      false,
+    );
+    assert.equal(
+      isMapWebglInitFailureMessage(JSON.stringify({
+        type: 'webglcontextcreationerror',
+        message: 'Failed to initialize WebGL renderer for the section overlay',
+      })),
+      false,
+    );
   });
 });
 

--- a/apps/viewer/src/lib/geo/map-webgl-support.test.ts
+++ b/apps/viewer/src/lib/geo/map-webgl-support.test.ts
@@ -185,9 +185,11 @@ describe('isMapWebglInitFailureMessage', () => {
     );
   });
 
-  it('does not fire on the token or the wording quoted inside another message', () => {
-    // The defect this predicate exists to close: a bare substring test deleted
-    // an actionable upload failure that merely quoted the driver's payload.
+  it('does not fire on the token or the wording quoted inside another message (#2402)', () => {
+    // Regression for #2402: the drop path's bare `"type": "webglcontextcreation
+    // error"` substring test deleted an actionable upload failure that merely
+    // quoted the driver's payload. Same hazard #1914 anchored the sibling arm
+    // for, and the one #2354 fixed three times over in the classify path.
     assert.equal(
       isMapWebglInitFailureMessage(
         'Upload failed: driver shim logged {"type":"webglcontextcreationerror"} while retrying',

--- a/apps/viewer/src/lib/geo/map-webgl-support.ts
+++ b/apps/viewer/src/lib/geo/map-webgl-support.ts
@@ -308,6 +308,27 @@ function isMapV5FailurePayload(message: string): boolean {
 }
 
 /**
+ * Is this message one of the two shapes MapLibre's painter setup throws when
+ * the browser refuses it a context — the bare wording, or the JSON payload?
+ *
+ * Exported because `lib/analytics-scrub.ts` needs exactly this set, and only
+ * this set, to decide whether to DROP an autocaptured exception (#1914). It
+ * cannot use {@link isWebglContextCreationError}: that one also claims v6's
+ * `WebGL2 is required…` wording, which #2354 deliberately keeps (classified,
+ * fingerprinted, downgraded to `warning`) rather than deletes. Restating the
+ * wordings over there instead would give MapLibre's strings a second home and
+ * let the two drift, which is the whole reason this module exports them.
+ *
+ * Both arms are anchored/structural, per the invariant on
+ * {@link isWebglContextCreationError}. The bare arm also admits the two
+ * suffixed strings `LocationMap` synthesizes; those only ever reach analytics
+ * as HANDLED captures, which the drop path excludes before it ever asks.
+ */
+export function isMapWebglInitFailureMessage(message: string): boolean {
+  return MAP_WEBGL_INIT_REPORT.test(message) || isMapV5FailurePayload(message);
+}
+
+/**
  * Watch a container for the driver's explanation of a refused context.
  *
  * MapLibre v6 does not hand us its `GPUInitializationError`: `_setupPainter`
@@ -380,8 +401,7 @@ export function isWebglContextCreationError(err: unknown): boolean {
   const message = err instanceof Error ? err.message : typeof err === 'string' ? err : '';
   if (!message) return false;
   return MAP_WEBGL2_REQUIRED_REPORT.test(message)
-    || MAP_WEBGL_INIT_REPORT.test(message)
-    || isMapV5FailurePayload(message);
+    || isMapWebglInitFailureMessage(message);
 }
 
 export interface MapInitFailureDetail {


### PR DESCRIPTION
Fixes #2402.

Rebased onto `main` now that #2384 has merged; the diff is only this PR's own commits, and #2384's `NON_JSON_PAYLOAD_WARNING` reporting is preserved untouched. Follow-up filed as #2410 (not fixed here).

`scrubEvent`'s noise filter is the only stage that can **delete** an event. Three of its arms tested the exception value as a bare substring, so an unrelated, actionable error that merely quoted a noise token was discarded — silently, irreversibly, with no record anywhere that the event existed.

## Repro, through the real `before_send` pipeline

Every noise sample was run through `scrubEvent` verbatim, and again quoted inside a carrier sentence (`Upload failed: driver shim logged <sample> while retrying`), as an uncaught, error-level exception:

| arm | genuine | quoted in a carrier — before | after |
| --- | --- | --- | --- |
| MapLibre bare wording | dropped | kept (anchored by #1914) | kept |
| MapLibre `"type": "webglcontextcreationerror"` | dropped | **DROPPED** | kept, `error_kind` unset, `error` level |
| Cesium `RequestErrorEvent` | dropped | **DROPPED** | kept, `error_kind` unset, `error` level |
| Outlook SafeLinks crawler | dropped | **DROPPED** | kept, `error_kind` unset, `error` level |
| `Script error.` | dropped | kept | kept |
| ResizeObserver loop | dropped | kept | kept |

The reviewer's reported case — an uncaught `Upload failed: driver shim logged {"type":"webglcontextcreationerror"} while retrying` — is the second row. All six genuine forms are still dropped after the fix.

## Approach

**MapLibre (the flagged arm): structural, and reusing #2384's module rather than a second copy.** `map-webgl-support.ts` already parses this payload and requires `type` to *be* the token and `message` to match the anchored wording — the shape v5 actually emitted. That module now exports `isMapWebglInitFailureMessage` (bare wording OR v5 payload); `isWebglContextCreationError` is expressed in terms of it, and the drop path calls it. MapLibre's wordings keep one home; the drop path no longer restates them.

The drop set is deliberately **not** widened to `isWebglContextCreationError` itself, which also claims v6's `WebGL2 is required to display this map`. #2354 decided that family is *kept* — classified `webgl_unavailable`, one fingerprint, downgraded to `warning` — precisely so the condition stays queryable. Widening the drop would undo that, in a PR whose whole point is that dropping is the worst available outcome.

**Cesium: structural over the complete value.** posthog-js emits `<ctor> captured as exception with keys: <keys>` as the *whole* value, including for an unhandled rejection (a non-Error reason is re-coerced through the same path, not prefixed) — verified against the pinned posthog-js. The arm requires that single ctor token at `^`, then a key list that must **parse as a key list** (every comma-separated member a bare own-property name) and contain all three of Cesium's. Validating the list rather than searching it also leaves posthog free to reorder or respace the keys, which it sorts and `", "`-joins today. See "review round two" below: this arm shipped `^`-only first, and that was the fifth instance of the defect.

**Outlook: anchored at both ends** over the crawler's complete sentence, with one optional leading group for posthog's `Non-Error promise rejection captured with value:` wrapper (which is how this one always arrives, and why `^` alone will not do) and an optional trailing `ParamCount`.

Where anchoring is imprecise it errs toward *keeping* the event: the failure mode of a too-tight matcher is noise reaching the dashboard, which is recoverable. The failure mode of a too-loose one is not.

## Every arm after the sweep

| matcher | arm | form |
| --- | --- | --- |
| Cesium (`isCesiumRequestError`) | posthog stringification + 3 required key names | structural: anchored `^…$`, key list must parse as key names |
| `OUTLOOK_SAFELINK_NOISE` | crawler sentence | anchored `^…$`, optional posthog wrapper prefix |
| MapLibre (`isMapWebglInitFailureMessage`) | bare wording | anchored `^…$` (plus the two suffixed strings `LocationMap` synthesizes) |
| MapLibre (`isMapWebglInitFailureMessage`) | v5 JSON payload | structural: parses, `type` **is** the token, `message` matches the anchored wording |
| `OPAQUE_CROSS_ORIGIN` | `Script error.` | anchored `^…$` + `frameCount === 0` |
| `RESIZE_OBSERVER_LOOP` | both browser wordings | anchored `^…$` + `frameCount === 0` |

No bare substring test remains in the section. The MapLibre arm additionally requires `mechanism.handled === false`, unchanged.

## Making the invariant structural

A comment stating the property is what failed here: #1914 wrote the hazard down, anchored one arm, and the sibling stayed loose through three later rounds of fixing the same defect class next door.

`DROPPED_NOISE_SAMPLES` in `analytics.test.ts` is the list of every value the filter deletes. Two tests drive it: one asserts each genuine sample is still dropped (the control, so the second cannot pass vacuously), the other runs each sample under **four carriers** and asserts every one survives **with its own `error_kind`, `$exception_level` and `$exception_fingerprint`** — not merely `!== null`.

The carrier set is the part that took two rounds to get right, because one carrier is blind:

| carrier | shape | catches |
| --- | --- | --- |
| surrounded | `Upload failed: … <sample> … while retrying` | an unanchored substring test |
| leading only | `Upload failed: … <sample>` | a `$`-only matcher |
| trailing only | `<sample> and our upload pipeline then wrote 0 bytes` | a `^`-only matcher |
| trailing only, comma-led | `<sample>, and our upload pipeline then wrote 0 bytes` | a structural matcher that splits the value and accepts the sentence as one more member | Presence-only assertions are exactly why this class went unnoticed three times: an event can survive and still be relabelled benign and buried in someone else's issue. Adding an arm to the noise filter means adding its wording to that list, and the test then fails until the arm is anchored.

## Mutation checks

Nine mutations, each applied to the source, run, and reverted. Every one killed its intended test, and every restore returned to green. A test that survived its own mutation would be worthless; none did.

| # | mutation | result |
| --- | --- | --- |
| 1 | MapLibre payload arm back to a bare substring | 4 tests fail (incl. #2384's classify guard) |
| 2 | Cesium arm un-anchored | 1 fails (quoted-in-carrier) |
| 3 | Outlook arm un-anchored | 1 fails (quoted-in-carrier) |
| 4 | structural check stops requiring MapLibre's own `message` | 1 fails (wrong-field payload) |
| 5 | MapLibre drop arm disabled entirely | 4 fail (incl. the drop control) |
| 6 | **ResizeObserver arm un-anchored** — an arm this PR does not touch | 1 fails |
| 7 | `isMapWebglInitFailureMessage` payload arm loosened | 1 fails (helper unit test) |
| 8 | helper widened to v6's wording | 1 fails (helper unit test) |
| 9 | helper always false | 4 fail (helper controls) |
| 10 | Cesium arm back to the `^`-only lookahead form | 3 fail (carrier loop + both dedicated tests) |
| 11 | trailing `$` dropped from the key-list capture | 1 fails (bounded-scan test) |
| 12 | member validation removed | 1 fails (comma-led carrier) |
| 13 | `isCesiumRequestError` always false | 3 fail (drop controls) |
| 14 | `^`-only arm **plus** only the original single carrier | the carrier loop **passes** — the harness blindness, reproduced |

Mutation 6 is the point of the exercise: the invariant test catches an arm going loose even when nobody thought to write a test for that arm. Mutation 14 is the confession — it reproduces the state this PR was in at first review, and shows the old single-carrier harness reporting green on a loose arm.

Mutations 11 and 12 initially appeared to survive; both turned out never to have been applied (a `perl` substitution that silently matched nothing). Re-run with the edit verified on disk, they survived *genuinely* — the harness had no case for either — which is what added the comma-led carrier and the bounded-scan test. The driver now holds the pristine sources in memory, asserts each mutation lands exactly once, and byte-verifies every restore.

## Verification

- `pnpm typecheck` (root, turbo): 36/36 tasks successful.
- `pnpm test` (root, turbo): 86/86 tasks successful, exit 0, watched to completion (`@ifc-lite/viewer`: 3259 pass, 0 fail), on the rebased tree in this PR.

## Review round two

CodeRabbit flagged the Cesium arm this PR *added* as `^`-anchored with no end constraint — the fifth instance of the class, and a fair hit. Fixed structurally (above), and the harness was extended with the leading-only, trailing-only and comma-led carriers that would have caught it.

Arm-by-arm result of the new carrier sweep, run through the real pipeline before the round-two fix. Only Cesium was loose; every other arm already constrained both ends:

| arm | surrounded | leading only | trailing only |
| --- | --- | --- | --- |
| Cesium | kept | kept | **DROPPED** |
| Outlook | kept | kept | kept |
| MapLibre bare | kept | kept | kept |
| MapLibre v5 payload | kept | kept | kept |
| `Script error.` | kept | kept | kept |
| ResizeObserver | kept | kept | kept |

After the fix all 24 carrier cases survive with kind, level and fingerprint intact, and all six bare samples still drop.

The other finding, a "critical" duplicate `DROPPED_NOISE_SAMPLES` declaration, is a false positive: one declaration at line 367, uses at 411 and 426, and the tree typechecks and tests green. Verified rather than assumed.

## Review round three

**The #2354 non-widening is now pinned end to end, not only on the helper.** Adding the v6 wording *directly to the drop arm* survived every test: mutation 8 widens `isMapWebglInitFailureMessage` and the map-webgl unit test kills it, but nothing stopped a future editor restating the wording locally. A new test asserts through `scrubEvent` that the v6 wording survives UNCAUGHT and arrives `webgl_unavailable` / `warning` / `ifc-lite:webgl_unavailable`. Mutation: restating the wording in the drop arm now **fails** that test.

**The single-anchor blindness is closed, and measured.** On the previous head, removing Outlook's `^` *alone* and its `$` *alone* both survived, because one carrier wrapped every sample on both sides so either anchor masked the other's loss. With the four carriers:

| mutation | before | now |
| --- | --- | --- |
| Outlook `^` removed alone | survived | **killed** (carrier loop) |
| Outlook `$` removed alone | survived | **killed** (carrier loop) |

**Registration is a convention, not a gate — stated in both invariant comments.** A brand-new unregistered arm (`value.includes('QuotaExceeded')`, no `DROPPED_NOISE_SAMPLES` entry) passes the whole suite. Verified by mutation and documented where the next author will read it, rather than left implied.

**Module size: not split, deliberately.** `analytics-scrub.ts` is 506 lines against the ~400 guideline, but **195 of those are non-blank non-comment** — the file was 435/188 before this PR, so the change adds 71 lines of prose and **7 lines of code**. The noise filter would split on a clean seam (`frameCount` and `isUnhandled` are used nowhere else), so the option is real, but two things argue against doing it here: the drop decision and the severity downgrade are deliberately balanced against each other (the v6 wording is *not dropped* precisely so `downgradeBenignExceptions` can act on it — that is what the new end-to-end test pins), and a file move would scatter the reasoning across two files in the same PR that rewrites it. Happy to do the split as its own PR if wanted; it should not ride along with a defect fix.

## Review round four — identity, not just extent

The Cesium arm validated the key list structurally but never constrained *whose* keys they were: `{statusCode, response, responseHeaders}` is a generic HTTP-ish shape, so any throwable of ours carrying those three among its keys was deleted as third-party noise. Extent looseness (how much of the value matched) and identity looseness (whether what matched is really theirs) are the same defect family on different axes, and the invariant comment now names both.

**The suggested fix — require the constructor to read `RequestErrorEvent` — is wrong here, and was tested rather than assumed.** In production Cesium's class name is minified: #1175's recorded occurrence is literally `'D_'`, which is why that issue keyed on the property shape in the first place. Applied, it fails #1175's own regression test and two others, making the arm dead exactly where it is needed:

```
not ok 1 - drops the Cesium RequestErrorEvent noise (issue #1175)
not ok 1 - drops every genuine noise sample (the control for the test below)
not ok 7 - still drops Cesium's stringification whatever the key order or spacing
```

The identity constraint that *survives minification* is the exact own-property **set**: `keys.length === 3` plus containment, which for unique own-property names is set equality. A throwable carrying those three plus its own `uploadId` is no longer ours to delete.

**Residual, stated rather than hidden:** a plain throwable whose own keys are *exactly* those three is still dropped whatever its class name. That is unavoidable while the class name is minified, and it is the trade #1175 already made.

**Dead code deleted with the change that orphaned it.** Set equality subsumes the "every member is a bare identifier" guard — three members each equal to one of three fixed names cannot also carry a sentence. Mutation proved the guard could no longer alter any outcome, so it went; a check that cannot fail reads as protection without being any.

**`KEPT_LOOKALIKE_SAMPLES`** is the must-NOT-drop mirror of `DROPPED_NOISE_SAMPLES`, driven by the same generic assertions (kind, level, fingerprint) on the identity axis. Its multi-line entry also restores the trailing-`$` mutation's detectability, which the new key-count check would otherwise have masked.

| mutation | result |
| --- | --- |
| drop the exact key-SET check | **killed** (carrier loop + lookalike loop) |
| drop the trailing `$` anchor | **killed** (multi-line lookalike) |
| relax containment to "any of the three" | **killed** — but only after adding a three-key/one-Cesium-key sample; it survived first |
| `isCesiumRequestError` always false (control) | **killed** (3 drop tests) |
| require ctor `RequestErrorEvent` (the suggested fix) | **breaks 3 passing tests** — see above |

Two mutations survived their first run and both were informative rather than noise: the containment relaxation had no sample that could see it, and the member-name guard turned out to be provably redundant. Neither was papered over.

Citations added where AGENTS.md requires them: the two `DROPPED_NOISE_SAMPLES` labels that lacked one (`outlook safelinks crawler`, `opaque cross-origin` — both #1855) and the map-webgl narrowness test (#2402). The rest were checked against `git log -S` rather than assumed accurate: Cesium #1175 (PR #1216), MapLibre #1914 (PR #1919), ResizeObserver #2120 (PR #2124).

## Review round five

**Codex P2 (`analytics-scrub.ts`, outdated) — already fixed, verified not assumed.** The exact reported string, through the real `scrubEvent`: `kept  kind=undefined level=error fp=undefined valueUnchanged=true`, while the genuine Cesium stringification still drops. Two changes get it there — the whole-value anchor (extent) and the exact own-property set (identity), the latter being what rejects `"statusCode while processing an upload"` as a member. Replied on the thread with the evidence and resolved.

**CodeRabbit minor (`analytics.test.ts`) — valid, fixed.** The verbatim test asserted survival, kind and severity, none of which pin the message, while `scrubExceptionMessages` walks `$exception_list[].value` two functions away. It now asserts the retained value equals the input exactly, plus `$exception_fingerprint === undefined`.

Mutation-checked in both directions, since "it passes now" proves nothing:

| mutation in `scrubExceptionMessages` | old assertions | new assertions |
| --- | --- | --- |
| append ` [scrubbed]` to the retained value | **`ok 3`** — passed | **fails** |
| truncate the retained value to 40 chars | passed | **fails** |

The first row is the finding: the strengthening is what earns the kill, not the mutation being easy to catch.

Third presence-for-content substitution in this PR's reviews, so the rule is now in the harness's invariant comment rather than left to memory: **assert the property the test is NAMED for, not a proxy for it** — survival does not pin classification, and classification does not pin the message.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filtering of known, non-actionable map and browser error messages.
  * Reduced false positives by validating complete, correctly structured error messages.
  * Improved detection of supported MapLibre WebGL initialization failures.
  * Preserved important error events while removing only verified noise.

* **Tests**
  * Added coverage for WebGL failures, Cesium errors, browser warnings, and wrapped messages.
  * Added regression tests to prevent partial-text matches and unrelated messages from being filtered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->