### PR TITLE
fix(viewer): give saved filters the unreadable-entry guard its sibling has

### DIFF
--- a/apps/viewer/src/lib/search/saved-filters.test.ts
+++ b/apps/viewer/src/lib/search/saved-filters.test.ts
@@ -208,6 +208,21 @@ describe('saved-filters: an unreadable catalog is never deleted', () => {
     assert.strictEqual(ls.store.size, 0, 'an explicit wipe leaves nothing behind');
   });
 
+  it('treats an empty stored string as a read failure, not "no entry" (sibling of #2348)', () => {
+    // getItem returns '' when the key EXISTS but holds an empty string, and
+    // null when the key is genuinely ABSENT. `!raw` conflated the two, so an
+    // empty entry (the shape a truncated or interrupted write leaves behind)
+    // skipped JSON.parse entirely and was never quarantined -- the very next
+    // save silently overwrote it without ever recording that a corrupt entry
+    // was there.
+    ls.setItem(__internal.STORAGE_KEY, '');
+    assert.deepStrictEqual(loadSavedFilters(), []);
+    assert.ok(
+      [...ls.store.keys()].some((k) => k !== __internal.STORAGE_KEY && k.startsWith(`${__internal.STORAGE_KEY}:unreadable`)),
+      'no :unreadable backup was created for the empty stored entry',
+    );
+  });
+
   it('refuses to write when the unreadable catalog could not even be backed up', () => {
     // Quota is exhausted for the backup write specifically. `safeStorage`
     // probes storage first, so rejecting every write here would make the test

--- a/apps/viewer/src/lib/search/saved-filters.ts
+++ b/apps/viewer/src/lib/search/saved-filters.ts
@@ -79,7 +79,13 @@ function readRaw(): SavedFilterPreset[] {
   if (!ls) return [];
   catalogUnwritable = false;
   const raw = ls.getItem(STORAGE_KEY);
-  if (!raw) return [];
+  // '' (empty string) is a distinct, corrupt entry, not "nothing saved" (null)
+  // -- it must still reach JSON.parse so the catch below quarantines it via
+  // `preserveUnreadableEntry`, the same way a truncated/hand-edited catalog
+  // does. Collapsing the two here bypassed that path entirely: an empty
+  // string never threw, so `catalogUnwritable` was never latched and the
+  // next ordinary save silently overwrote the corrupt entry unprotected.
+  if (raw === null) return [];
   try {
     const parsed: unknown = JSON.parse(raw);
     if (!Array.isArray(parsed)) {


### PR DESCRIPTION
Sibling of the bug fixed in #2348, which flagged this exact site (`saved-filters.ts:81`) as the same shape and deliberately left it out of scope.

## Why it's a real bug, not a tidy-up

`localStorage.getItem` returns `null` when the key is **absent** and `''` when it exists holding an empty string. `if (!raw) return []` collapsed the two — but they are not the same thing here, and the difference is load-bearing:

An empty string is a **corrupt entry** (a truncated or interrupted write). Returning early meant it never reached `JSON.parse`, so it never threw, so it never reached the `catch` that calls `preserveUnreadableEntry`. `catalogUnwritable` was never latched and no `:unreadable` backup was created — and **the next ordinary save silently overwrote the corrupt entry**, bypassing the quarantine machinery this file exists to provide (`#2085`/`#2089`).

So the user's saved filters were destroyed by exactly the failure mode the preserve path was written to protect against.

```ts
// '' (empty string) is a distinct, corrupt entry, not "nothing saved" (null)
// -- it must still reach JSON.parse so the catch below quarantines it via
// `preserveUnreadableEntry`, the same way a truncated/hand-edited catalog
// does.
if (raw === null) return [];
```

## Sibling sweep — and why most `!raw` sites are NOT this bug

Grepped every `getItem` (~70 sites) and every `if (!raw)` guard (~25 sites) under `apps/viewer/src`.

**Only two files use the preserve/quarantine machinery** (`preserveUnreadableEntry` / `onReadFailure` / `unwritableKeys` / `catalogUnwritable`): this one, and `lib/clash/persistence.ts` (fixed in #2348).

Every other `!raw` site — `store/slices/*.ts`, `lib/sources/persistence.ts`, `lib/scripts/persistence.ts`, `lib/tours/storage.ts`, `lib/llm/models.ts`, `lib/lists/persistence.ts`, `lib/search/recent-searches.ts` — has **no quarantine step to bypass**: `''` and `null` both fall through to the same default and nothing is lost. They are not this bug class, so they're reported rather than swept into an unreviewed change.

That distinction is the point: the conflation only matters where something downstream depends on the parse *failing*.

## RED

```
not ok 7 - treats an empty stored string as a read failure, not "no entry" (sibling of #2348)
not ok 2 - saved-filters: an unreadable catalog is never deleted
# tests 18 | pass 17 | fail 1
```

The assertion is that an `:unreadable` backup is actually created — the user-visible protection — not that a boolean changed.

## Bounding controls — pass BEFORE and after

Both matter here, because a careless fix would start throwing on the common first-run path where nothing is saved yet:

- `returns an empty list when nothing is stored` — a genuinely absent key still returns `[]` with no backup created.
- `saves a preset and reads it back sorted by name` — a valid entry still round-trips.

17 of 18 tests pass against the unfixed code, so the new test isn't passing by making everything take the failure path.

## Displacement

The new branch changes behaviour **only** for `raw === ''`. Every other value — `null`, and any parseable or unparseable string — reaches exactly the same code path as before.

## Verification

`apps/viewer`: **3236 tests, 0 failures**, 2 skipped. `tsc --noEmit` clean. Mutation check: reverting to `!raw` fails exactly the one new test. No changeset — `apps/viewer` is `"private": true`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty saved-filter data so it is recognized as unreadable rather than missing.
  * Preserved unreadable saved-filter data through backup and recovery handling, preventing silent overwrites.
  * Added safeguards for cases where unreadable data cannot be preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->