### PR TITLE
feat(viewer): wire n/N result stepping into the advanced Filter tab

### DIFF
--- a/apps/viewer/src/components/viewer/SearchModal.filter.tsx
+++ b/apps/viewer/src/components/viewer/SearchModal.filter.tsx
@@ -292,10 +292,15 @@ export function SearchModalFilter() {
     const raw = row[selectionKeyIndex];
     const expressId = typeof raw === 'number'
       ? raw
-      : typeof raw === 'string' && !Number.isNaN(Number(raw))
+      : typeof raw === 'string'
         ? Number(raw)
         : null;
-    if (expressId === null || expressId <= 0) return;
+    // Kept in sync with filter-result-to-search-results.ts's identical
+    // guard: express ids are Uint32Array-backed integers, so a row must
+    // satisfy the same Number.isInteger check to be clickable as it does
+    // to enter the vim cycle (otherwise a row could be one but not the
+    // other).
+    if (expressId === null || !Number.isInteger(expressId) || expressId <= 0) return;
     const globalId = toGlobalIdFromModels(models, rowModelId, expressId);
     // Clear any live multi-selection FIRST. `frameSelection` prefers the
     // numeric `selectedEntityIds` set over `selectedEntityId`

--- a/apps/viewer/src/components/viewer/SearchModal.filter.tsx
+++ b/apps/viewer/src/components/viewer/SearchModal.filter.tsx
@@ -37,6 +37,7 @@ import { evaluateFilterRulesFederated } from '@/lib/search/filter-evaluate';
 import { runTier0Scan, type ScanModel } from '@/lib/search/tier0-scan';
 import { queryTier1Indexes, type Tier1Index } from '@/lib/search/tier1-index';
 import { downloadResult } from '@/lib/search/result-export';
+import { filterResultToSearchResults } from '@/lib/search/filter-result-to-search-results';
 import type { ListDefinition } from '@/lib/lists';
 import { SearchModalFilterBuilder } from './SearchModal.filter.builder';
 
@@ -66,6 +67,7 @@ export function SearchModalFilter() {
     setSelectedEntity,
     setSelectedEntityId,
     setSelectedEntityIds,
+    enterVimCycle,
     cameraCallbacks,
     setPendingListDraft,
     setListPanelVisible,
@@ -88,6 +90,7 @@ export function SearchModalFilter() {
       setSelectedEntity: s.setSelectedEntity,
       setSelectedEntityId: s.setSelectedEntityId,
       setSelectedEntityIds: s.setSelectedEntityIds,
+      enterVimCycle: s.enterVimCycle,
       cameraCallbacks: s.cameraCallbacks,
       setPendingListDraft: s.setPendingListDraft,
       setListPanelVisible: s.setListPanelVisible,
@@ -268,6 +271,18 @@ export function SearchModalFilter() {
     return -1;
   }, [searchFilterResult]);
 
+  // Frozen (per-run) conversion of the filter table into SearchResult-shaped
+  // entries so the existing vim-cycle machinery (enterVimCycle/stepVimCycle,
+  // stepped by SearchInline's n/N listener) can step through Filter-tab
+  // results the same way it steps through Search-tab results. Only recomputed
+  // when the result table itself changes, not per click, so the array identity
+  // stays stable across a run's clicks — the same 'frozen snapshot' semantics
+  // the Search tab's cycle documents (searchSlice.ts SearchVimCycleState).
+  const cycleResults = useMemo(
+    () => (searchFilterResult ? filterResultToSearchResults(searchFilterResult, activeModelId) : []),
+    [searchFilterResult, activeModelId],
+  );
+
   const handleRowClick = useCallback((row: unknown[]) => {
     if (selectionKeyIndex < 0) return;
     const rowModelId = modelIdColumnIndex >= 0 && typeof row[modelIdColumnIndex] === 'string'
@@ -295,6 +310,16 @@ export function SearchModalFilter() {
     if (cameraCallbacks.frameSelection) {
       window.setTimeout(() => cameraCallbacks.frameSelection?.(), 50);
     }
+    // Enter the vim cycle so n/N steps through the rest of this run's
+    // matches, same as the Search tab. Index is found by (modelId, expressId)
+    // rather than by row position, since filterResultToSearchResults can skip
+    // unselectable rows and the two arrays needn't stay position-aligned.
+    const cycleIndex = cycleResults.findIndex(
+      (r) => r.modelId === rowModelId && r.expressId === expressId,
+    );
+    if (cycleIndex >= 0) {
+      enterVimCycle(`filter: ${searchFilter.rules.length} rule${searchFilter.rules.length === 1 ? '' : 's'}`, cycleResults, cycleIndex);
+    }
     // Close the modal so the framing is actually visible. The dialog overlay
     // is `fixed inset-0 bg-black/80` (ui/dialog.tsx:23), so without this the
     // camera does fly to the element behind a full-screen scrim and the click
@@ -306,7 +331,7 @@ export function SearchModalFilter() {
     // (store/index.ts:544), never on close, so reopening shows the same table
     // without re-running the filter.
     setSearchModalOpen(false);
-  }, [activeModelId, cameraCallbacks, models, modelIdColumnIndex, selectionKeyIndex, setSearchModalOpen, setSelectedEntity, setSelectedEntityId, setSelectedEntityIds]);
+  }, [activeModelId, cameraCallbacks, cycleResults, enterVimCycle, models, modelIdColumnIndex, searchFilter.rules.length, selectionKeyIndex, setSearchModalOpen, setSelectedEntity, setSelectedEntityId, setSelectedEntityIds]);
 
   const handleExport = useCallback((format: 'csv' | 'json') => {
     if (!searchFilterResult || searchFilterResult.rows.length === 0) return;

--- a/apps/viewer/src/components/viewer/SearchModal.filter.wiring.test.ts
+++ b/apps/viewer/src/components/viewer/SearchModal.filter.wiring.test.ts
@@ -106,4 +106,43 @@ describe('advanced Filter tab: row-click wiring', () => {
       'setSelectedEntityIds must be pulled from the store selector, or the handler would reference an undefined binding',
     );
   });
+
+  test('enters the vim cycle after framing and before closing the modal, so n/N can step through the rest of the filter run', () => {
+    const body = handleRowClickBody();
+    const frame = body.indexOf('cameraCallbacks.frameSelection');
+    const enter = body.indexOf('enterVimCycle(');
+    const close = body.indexOf('setSearchModalOpen(false)');
+    assert.ok(frame >= 0 && enter >= 0 && close >= 0, 'frameSelection, enterVimCycle, and the close must all be present');
+    assert.ok(frame < enter, 'enterVimCycle must run AFTER the frame is requested');
+    assert.ok(enter < close, 'enterVimCycle must run BEFORE the modal closes, matching the Search tab (SearchModal.text.tsx) ordering');
+  });
+
+  test('enterVimCycle receives the frozen (memoized) conversion of the filter result, not a fresh scan of the clicked row', () => {
+    const body = handleRowClickBody();
+    assert.ok(
+      body.includes('enterVimCycle(') && body.includes('cycleResults, cycleIndex)'),
+      'enterVimCycle must be called with the filter-tab cycleResults array and the index of the clicked row within it',
+    );
+  });
+
+  test('the component binds enterVimCycle from the store and converts the filter result via filterResultToSearchResults', () => {
+    assert.ok(
+      source.includes('enterVimCycle: s.enterVimCycle'),
+      'enterVimCycle must be pulled from the store selector, or the handler would reference an undefined binding',
+    );
+    assert.ok(
+      source.includes("import { filterResultToSearchResults } from '@/lib/search/filter-result-to-search-results';"),
+      'SearchModal.filter.tsx must import the shape-bridge helper to convert unknown[][] rows into SearchResult[]',
+    );
+  });
+
+  test('the handler declares enterVimCycle and cycleResults as dependencies', () => {
+    const start = source.indexOf('const handleRowClick = useCallback(');
+    const depsStart = source.indexOf('}, [', start);
+    const depsEnd = source.indexOf(']);', depsStart);
+    const deps = source.slice(depsStart, depsEnd);
+    for (const dep of ['enterVimCycle', 'cycleResults']) {
+      assert.ok(deps.includes(dep), `${dep} must be in the useCallback dependency array`);
+    }
+  });
 });

--- a/apps/viewer/src/lib/search/filter-result-to-search-results.test.ts
+++ b/apps/viewer/src/lib/search/filter-result-to-search-results.test.ts
@@ -88,6 +88,25 @@ describe('filterResultToSearchResults', () => {
     assert.deepEqual(filterResultToSearchResults(result, null), []);
   });
 
+  it('skips NaN, Infinity, -Infinity, and fractional express ids — express ids are Uint32Array-backed integers, never fractional', () => {
+    const result = {
+      columns: ['express_id', 'global_id', 'name', 'type'],
+      rows: [
+        [NaN, 'GUID-A', 'NaN row', 'IfcWall'],
+        [Infinity, 'GUID-B', 'Infinity row', 'IfcWall'],
+        [-Infinity, 'GUID-C', '-Infinity row', 'IfcWall'],
+        [7.5, 'GUID-D', 'Fractional row', 'IfcWall'],
+        ['NaN', 'GUID-E', 'String NaN row', 'IfcWall'],
+        ['Infinity', 'GUID-F', 'String Infinity row', 'IfcWall'],
+        ['7.5', 'GUID-G', 'String fractional row', 'IfcWall'],
+        [9, 'GUID-H', 'Good', 'IfcWall'],
+      ],
+    };
+    const out = filterResultToSearchResults(result, 'model-1');
+    assert.equal(out.length, 1);
+    assert.equal(out[0].expressId, 9);
+  });
+
   it('recognises entity_id as a selection-key column alias', () => {
     const result = {
       columns: ['entity_id', 'name'],

--- a/apps/viewer/src/lib/search/filter-result-to-search-results.test.ts
+++ b/apps/viewer/src/lib/search/filter-result-to-search-results.test.ts
@@ -1,0 +1,115 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Pure-helper coverage for the Filter tab -> vim-cycle bridge. Before this
+ * helper existed, running `n`/`N` after clicking a Filter-tab row was
+ * impossible: `enterVimCycle` requires `SearchResult[]`, and the Filter
+ * tab only ever produced `SearchFilterResult` (`unknown[][]` rows +
+ * `columns: string[]`) — nothing converted between the two shapes. See the
+ * "does not exist" assertions below and PR #2396's "Deliberately not done"
+ * note (`SearchModal.filter.tsx`'s row click never called `enterVimCycle`).
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { filterResultToSearchResults } from './filter-result-to-search-results.js';
+
+describe('filterResultToSearchResults', () => {
+  it('converts single-model rows (no model_id column) using the fallback modelId', () => {
+    const result = {
+      columns: ['express_id', 'global_id', 'name', 'type'],
+      rows: [
+        [101, 'GUID-A', 'Wall A', 'IfcWall'],
+        [102, 'GUID-B', 'Wall B', 'IfcWall'],
+      ],
+    };
+    const out = filterResultToSearchResults(result, 'model-1');
+    assert.equal(out.length, 2);
+    assert.deepEqual(
+      out.map((r) => [r.modelId, r.expressId, r.name, r.typeName, r.globalId]),
+      [
+        ['model-1', 101, 'Wall A', 'IfcWall', 'GUID-A'],
+        ['model-1', 102, 'Wall B', 'IfcWall', 'GUID-B'],
+      ],
+    );
+  });
+
+  it('uses each row\'s own model_id in a federated (multi-model) result, ignoring the fallback', () => {
+    const result = {
+      columns: ['express_id', 'global_id', 'name', 'type', 'model_id'],
+      rows: [
+        [1, 'GUID-A', 'Door A', 'IfcDoor', 'model-a'],
+        [2, 'GUID-B', 'Door B', 'IfcDoor', 'model-b'],
+      ],
+    };
+    const out = filterResultToSearchResults(result, 'model-a');
+    assert.deepEqual(out.map((r) => r.modelId), ['model-a', 'model-b']);
+  });
+
+  it('skips a row with no usable express id (non-numeric, zero, or negative)', () => {
+    const result = {
+      columns: ['express_id', 'global_id', 'name', 'type'],
+      rows: [
+        ['not-a-number', 'GUID-A', 'Bad', 'IfcWall'],
+        [0, 'GUID-B', 'Zero', 'IfcWall'],
+        [-5, 'GUID-C', 'Negative', 'IfcWall'],
+        [7, 'GUID-D', 'Good', 'IfcWall'],
+      ],
+    };
+    const out = filterResultToSearchResults(result, 'model-1');
+    assert.equal(out.length, 1);
+    assert.equal(out[0].expressId, 7);
+  });
+
+  it('falls back to fallbackModelId for a multi-model row whose model_id cell is missing/non-string — same rule SearchModalFilter.handleRowClick already uses for a single click', () => {
+    const result = {
+      columns: ['express_id', 'global_id', 'name', 'type', 'model_id'],
+      rows: [
+        [1, 'GUID-A', 'A', 'IfcWall', 'model-a'],
+        [2, 'GUID-B', 'B', 'IfcWall', null],
+      ],
+    };
+    const out = filterResultToSearchResults(result, 'active-model');
+    assert.deepEqual(out.map((r) => r.modelId), ['model-a', 'active-model']);
+  });
+
+  it('returns an empty array when the result has no recognised selection-key column', () => {
+    const result = { columns: ['name', 'type'], rows: [['Wall A', 'IfcWall']] };
+    assert.deepEqual(filterResultToSearchResults(result, 'model-1'), []);
+  });
+
+  it('returns an empty array (never throws) with no fallback modelId and no model_id column', () => {
+    const result = {
+      columns: ['express_id', 'global_id', 'name', 'type'],
+      rows: [[101, 'GUID-A', 'Wall A', 'IfcWall']],
+    };
+    assert.deepEqual(filterResultToSearchResults(result, null), []);
+  });
+
+  it('recognises entity_id as a selection-key column alias', () => {
+    const result = {
+      columns: ['entity_id', 'name'],
+      rows: [[55, 'Slab A']],
+    };
+    const out = filterResultToSearchResults(result, 'model-1');
+    assert.equal(out.length, 1);
+    assert.equal(out[0].expressId, 55);
+  });
+
+  it('produces entries directly consumable by enterVimCycle / applySelection: only modelId + expressId matter for stepping', () => {
+    const result = {
+      columns: ['express_id', 'global_id', 'name', 'type'],
+      rows: [[1, 'G1', 'A', 'IfcWall'], [2, 'G2', 'B', 'IfcWall'], [3, 'G3', 'C', 'IfcWall']],
+    };
+    const out = filterResultToSearchResults(result, 'm');
+    // Simulates SearchInline's applySelection, which reads only these two fields.
+    const stepped = out.map((r) => ({ modelId: r.modelId, expressId: r.expressId }));
+    assert.deepEqual(stepped, [
+      { modelId: 'm', expressId: 1 },
+      { modelId: 'm', expressId: 2 },
+      { modelId: 'm', expressId: 3 },
+    ]);
+  });
+});

--- a/apps/viewer/src/lib/search/filter-result-to-search-results.ts
+++ b/apps/viewer/src/lib/search/filter-result-to-search-results.ts
@@ -60,10 +60,14 @@ export function filterResultToSearchResults(
     const raw = row[keyIdx];
     const expressId = typeof raw === 'number'
       ? raw
-      : typeof raw === 'string' && !Number.isNaN(Number(raw))
+      : typeof raw === 'string'
         ? Number(raw)
         : null;
-    if (expressId === null || expressId <= 0) continue;
+    // Express ids are Uint32Array-backed (`compact-entity-index.ts`), so
+    // they are always positive integers. `Number.isInteger` rejects NaN,
+    // +/-Infinity, and fractions in one guard (Infinity, unlike NaN,
+    // satisfies `> 0` so a NaN-only check would let it through).
+    if (expressId === null || !Number.isInteger(expressId) || expressId <= 0) continue;
 
     const modelId = modelIdx >= 0 && typeof row[modelIdx] === 'string'
       ? (row[modelIdx] as string)

--- a/apps/viewer/src/lib/search/filter-result-to-search-results.ts
+++ b/apps/viewer/src/lib/search/filter-result-to-search-results.ts
@@ -1,0 +1,86 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Bridges the advanced Filter tab's tabular result (`unknown[][]` rows +
+ * `columns: string[]`, see `SearchFilterResult` in `store/slices/searchSlice.ts`)
+ * into the `SearchResult[]` shape the vim-cycle machinery expects
+ * (`enterVimCycle`, `stepVimCycle`, and the `n`/`N` stepping consumer in
+ * `SearchInline.tsx`'s `applySelection`).
+ *
+ * Deliberately the SMALL bridge: convert at commit time rather than
+ * generalising `SearchVimCycleState` to a `{modelId, expressId}` shape.
+ * `applySelection` (the only place that reads cycle results while
+ * stepping) touches nothing but `modelId` / `expressId`; the hint badge
+ * (`VimCycleHint`) shows only `query` / `index` / `total`. So the extra
+ * `SearchResult` fields are populated from the filter's own `name` /
+ * `type` / `global_id` columns when present (all three are always emitted
+ * by `SearchModalFilter`'s `runFilter`), never fabricated, and never
+ * consumed by the cycle-stepping path itself. This keeps the Search tab's
+ * cycle — which still stores real scored results — untouched.
+ */
+
+import type { SearchResult, MatchField } from './tier0-scan.js';
+
+/** Columns a filter row's selection key may appear under (kept in sync
+ *  with `SearchModalFilter`'s own `SELECTION_COLUMNS`). */
+const SELECTION_COLUMNS: readonly string[] = ['express_id', 'entity_id'];
+
+/** Placeholder — the cycle-stepping path never reads `matchField` /
+ *  `score`; only `modelId` / `expressId` drive selection + framing. */
+const PLACEHOLDER_MATCH_FIELD: MatchField = 'name';
+
+/**
+ * Convert a Filter-tab result table into `SearchResult[]` for
+ * `enterVimCycle`. Rows whose selection-key cell isn't a positive integer
+ * are skipped (nothing to select). In a federated (multi-model) result the
+ * `model_id` column resolves each row's model; in a single-model result
+ * (no `model_id` column) every row falls back to `fallbackModelId` — pass
+ * `null` there and rows are skipped when it's absent, rather than guessed.
+ *
+ * Returns `[]` (never throws) if the result has no recognised selection-key
+ * column — mirrors `SearchModalFilter`'s own `selectionKeyIndex < 0` guard.
+ */
+export function filterResultToSearchResults(
+  result: { columns: string[]; rows: unknown[][] },
+  fallbackModelId: string | null,
+): SearchResult[] {
+  const { columns, rows } = result;
+  const keyIdx = columns.findIndex((c) => SELECTION_COLUMNS.includes(c));
+  if (keyIdx < 0) return [];
+
+  const modelIdx = columns.indexOf('model_id');
+  const globalIdIdx = columns.indexOf('global_id');
+  const nameIdx = columns.indexOf('name');
+  const typeIdx = columns.indexOf('type');
+
+  const out: SearchResult[] = [];
+  for (const row of rows) {
+    const raw = row[keyIdx];
+    const expressId = typeof raw === 'number'
+      ? raw
+      : typeof raw === 'string' && !Number.isNaN(Number(raw))
+        ? Number(raw)
+        : null;
+    if (expressId === null || expressId <= 0) continue;
+
+    const modelId = modelIdx >= 0 && typeof row[modelIdx] === 'string'
+      ? (row[modelIdx] as string)
+      : fallbackModelId;
+    if (!modelId) continue;
+
+    out.push({
+      modelId,
+      expressId,
+      typeName: typeIdx >= 0 ? String(row[typeIdx] ?? '') : '',
+      name: nameIdx >= 0 ? String(row[nameIdx] ?? '') : '',
+      globalId: globalIdIdx >= 0 ? String(row[globalIdIdx] ?? '') : '',
+      description: '',
+      objectType: '',
+      matchField: PLACEHOLDER_MATCH_FIELD,
+      score: 0,
+    });
+  }
+  return out;
+}


### PR DESCRIPTION
Builds on #2396 (now merged). That PR made the Filter tab's row click select, frame, and close — but left `n`/`N` stepping unwired, so a user had to reopen the modal for each result. This finishes it.

## The shape problem, and the smaller answer

The two tabs hold results differently: the Search tab has `SearchResult[]`, the Filter tab has `unknown[][]` rows plus a `columns` header. #2396 deferred this rather than reshape the store.

Rather than generalise `SearchVimCycleState`, I traced **what actually reads the cycle while stepping**: `applySelection` in `SearchInline.tsx` (the global `n`/`N` listener lives there, not in the modal), which touches only `r.modelId` / `r.expressId`. The hint badge reads only `query` / `index` / `total`.

So a pure conversion helper is sufficient: `filterResultToSearchResults(result, fallbackModelId)` maps filter rows into `SearchResult`-shaped entries, filling `name` / `typeName` / `globalId` from the filter's own always-present columns. **`searchSlice.ts` and `SearchVimCycleState` are untouched** — zero risk to the Search tab's cycle, which works today.

## Two details that a naive version gets wrong

**Index by identity, not by row position.** The helper skips unselectable rows (no usable express id, no model id), so the cycle array and the table's rows are *not* position-aligned. `handleRowClick` therefore finds the cycle index by `(modelId, expressId)`. Using the row index would silently step to the wrong element whenever any row was skipped.

**Frozen snapshot semantics.** The Search tab's cycle freezes its list at commit time so later edits don't shift it (`searchSlice.ts` `SearchVimCycleState`). `cycleResults` is memoised on `[searchFilterResult, activeModelId]`, so array identity is stable across clicks within one run and changes only on a new Run — matching that contract rather than cycling over a live-mutating array.

## Multi-model

Federated results carry a `model_id` column and the helper uses it per row. Single-model results fall back to a caller-supplied `fallbackModelId`; I pass `activeModelId`, the same fallback rule `handleRowClick` already uses for its own selection, so the two stay consistent.

## Displacement

Nothing pre-existing is skipped. #2396's clear → select → frame → close sequence runs exactly as before; `enterVimCycle` is purely additive, inserted between the frame request and the close, matching the Search tab's ordering.

## Mutation checks

| Mutation | Result |
|---|---|
| remove the unselectable-row skip | 1 of 8 helper tests fails |
| remove the `enterVimCycle(...)` call | 2 of 9 wiring tests fail |
| move `enterVimCycle` after the modal close | 1 of 9 fails (the "must run before close" assertion) |

Independently re-verified the first: removing `if (expressId === null || expressId <= 0) continue;` fails exactly `skips a row with no usable express id`.

The wiring tests strip `//` comments before matching, per the pattern #2396 established after one of its tests passed against a deliberately broken handler by matching a code comment.

## Bounding controls — pass BEFORE and after

- `searchSlice.test.ts` (34 tests covering `enterVimCycle`/`stepVimCycle`/`exitVimCycle`) — untouched file, green throughout. This is the control that matters: the Search tab's cycle must not regress.
- `SearchModal.filter.wiring.test.ts`'s 5 tests from #2396 still pass **unmodified**, including the close-vs-frame ordering assertion, since `enterVimCycle` sits between them.

## Verification

`apps/viewer`: **3266 tests, 0 failures**, 2 skipped. Root `pnpm typecheck` (turbo, per AGENTS.md): 36/36 clean. No changeset — `apps/viewer` is `"private": true`.

## Not done

`SearchInline.tsx`, `SearchModal.text.tsx` and `searchSlice.ts` are untouched. `SearchVimCycleState` was deliberately **not** generalised to `{modelId, expressId}` — the conversion helper is smaller and carries no risk to the working path. #2403 (the stale multi-selection clear for the Search tab and inline bar) is still open and out of scope here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Filter results now support Vim-style navigation with `n`/`N` after selecting a row.
  * Search selections retain relevant model and entity details across filter results.
  * Invalid or incomplete filter-result entries are safely excluded from navigation.

* **Tests**
  * Added coverage for filter-result conversion, model resolution, selection aliases, invalid IDs, and Vim-cycle integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->