### PR TITLE
test(cli): raise the gym determinism test's ceiling to absorb its CI tail

### DIFF
--- a/packages/cli/src/commands/gym.test.ts
+++ b/packages/cli/src/commands/gym.test.ts
@@ -344,7 +344,28 @@ describe.skipIf(!MODEL_AVAILABLE)('gymCommand (fixture: AB22.ifc)', { timeout: A
     // this case timed out at 5.59 s TWICE, having never once disagreed on a
     // byte. A determinism test that fails by running out of clock reports the
     // opposite of what it measures, which is worth more than the 10 s.
-  }, 20_000);
+    //
+    // 20 s was still not enough. On 2026-08-08 this timed out on three PRs that
+    // touch nothing it depends on -- #2326 (cache bounds), #2362 (viewer-embed
+    // teardown) and #2408 (STEP header escaping). Re-running the identical
+    // commits with no code change turned #2326 and #2408 green, so the failure
+    // is clock-bound, not a real disagreement: it has still never once differed
+    // on a byte.
+    //
+    // Note the margin is NOT simply thin, and it is worth not pretending we
+    // fully explain this. Measured locally: this case 5663 ms, with the two
+    // siblings at 3414 ms and 4146 ms. Those same siblings log 6347 ms and
+    // 6521 ms on CI, i.e. CI runs 1.6-1.9x slower, which predicts roughly 10 s
+    // here -- about 2x under the old 20 s ceiling. It nonetheless blew past 20 s
+    // three times in one day, so the tail is heavier than a flat scale factor
+    // implies (runner contention is the likely cause, unconfirmed). 45 s buys
+    // ~4.5x over the predicted cost; it is a margin that absorbs the observed
+    // tail, not a diagnosis of it.
+    //
+    // Raising the ceiling rather than trimming the work, because the double run
+    // IS the assertion: both runs must be independent for byte-identity to mean
+    // anything, so there is no shared parse to hoist out.
+  }, 45_000);
 
   it('reset mid-session restores the pristine model', async () => {
     const lines = await runGym(


### PR DESCRIPTION
`packages/cli`'s `gym.test.ts` case *"produces byte-identical reward lines for the same 3-step episode run twice"* has been timing out at 20 s and taking unrelated PRs down with it.

## It was red for a clock reason, not a real one

It failed on three PRs that touch nothing it depends on:

- **#2326** — cache slice-bounds guards
- **#2362** — viewer-embed StrictMode teardown
- **#2408** — STEP header escaping in `merged.rs`

Re-running the **identical commits with no code change** turned #2326 and #2408 green. The assertion itself has never once disagreed on a byte; it only ever runs out of clock. A determinism test that fails by timing out reports the opposite of what it measures.

## The margin was not simply thin, and I'd rather not overclaim

The obvious story is "it sits just under the ceiling and slow runners tip it over". The measurements don't fully support that:

| test | local | CI |
| --- | --- | --- |
| `reset emits a well-formed observation…` | 3414 ms | 6347 ms |
| `a benign property step…` | 4146 ms | 6521 ms |
| **`produces byte-identical reward lines…`** | **5663 ms** | **timed out (>20000 ms)** |

The two siblings put CI at **1.6–1.9x** local, which predicts roughly **10 s** for this case — about **2x under** the old 20 s ceiling. It still blew past 20 s three times in one day. So the tail is heavier than a flat scale factor implies. Runner contention is the likely cause (vitest runs files concurrently), but I have not confirmed that, and this PR does not claim to.

**45 s is a margin sized to absorb the observed tail, not a diagnosis of it.** If it recurs at 45 s, the right next step is instrumenting the run rather than raising the number again — it has already gone 5 s -> 20 s -> 45 s.

## Why raise the ceiling instead of making it cheaper

The double run *is* the assertion. Both runs have to be independent for byte-identity to mean anything, so there is no shared fixture parse to hoist out without destroying what the test measures.

## Verification

Ran the full `@ifc-lite/cli` suite locally with the fixture present: **33 files, 371 passed, 0 failed** (the gym cases skip themselves when `tests/models/AB22.ifc` is absent, which is why a first run reported 363 passed / 8 skipped — that run proved nothing and I re-ran it after fetching the fixture).

Test-only change; nothing shipped changes, so no changeset.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the determinism test timeout to improve reliability in slower or variable CI environments.
  * Added explanatory documentation about runtime variance and repeated timeout conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->