### PR TITLE
fix(processing,server-client): let the unresolved sentinel survive JSON

### DIFF
--- a/.changeset/symbolic-unresolved-world-y-null.md
+++ b/.changeset/symbolic-unresolved-world-y-null.md
@@ -1,0 +1,13 @@
+---
+"@ifc-lite/server-client": minor
+---
+
+Declare the unresolved-elevation sentinel on `symbolic_data`: `SymbolicGridAxis`, `SymbolicPolyline`, `SymbolicCircle`, `SymbolicText` and `SymbolicFillArea` now type `world_y` as `number | null` instead of `number`.
+
+**This is a type correction, not a wire change.** The server has always been able to send `null` here. `world_y` is `f32::NAN` in the Rust model when the placement chain resolved no elevation, and `serde_json` writes a non-finite float as JSON `null` — so the payload already carried `null` while the declaration promised `number`. `hatch_angle_secondary` on `SymbolicFillArea` was already declared `number | null` for exactly this reason; the elevation fields were the ones left lying. The bytes on the wire are byte-identical before and after, now pinned by a fixture emitted from the Rust serializer itself (`packages/server-client/src/__fixtures__/symbolic-unresolved-wire.json`) and asserted from both sides.
+
+**`null` is not `0`.** `world_y: 0` is a real elevation at datum; `world_y: null` means the server never resolved one. Branch on `x === null` — do not coerce, because `Number(null)` is `0` and would silently invent a datum-level elevation for every unresolved primitive. Anything that buckets, sorts or filters by elevation must exclude the `null`s rather than fold them into the zero bucket. An omitted key stays distinct from both: the server rejects a payload with `world_y` missing outright, so a truncated body can never masquerade as "elevation unknown".
+
+**Migrating.** Marked `minor` because the widened type can fail compilation where the old one did not: `const y: number = axis.world_y` now needs a `null` branch (or `?? fallback`, chosen deliberately). No runtime behaviour changes for a consumer that was already handling the values it actually received.
+
+Shipped alongside a Rust-side fix (`ifc-lite-processing`, `ifc-lite-server`) for the same sentinel: the derived `Deserialize` could not read `null` back into an `f32` (`invalid type: null, expected f32`), so the server's own symbolic cache could not re-read the blob it had just written. One unresolved scalar anywhere in a model made the entire `{cache_key}-symbolic-v1` entry unparseable, and `load_cached_symbolic`'s error fallback then served `SymbolicData::default()` — every replayed request silently returned no 2D symbols at all, for the whole model.

--- a/apps/server/src/routes/parse/cache_keys_symbolic_tests.rs
+++ b/apps/server/src/routes/parse/cache_keys_symbolic_tests.rs
@@ -1,0 +1,108 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Symbolic-cache round-trip tests for `cache_keys.rs`.
+//!
+//! Split out of `cache_keys.rs`'s inline `mod tests` to keep that module under
+//! the 400-line ratchet (`rust/processing/tests/module_size_ratchet.rs`).
+//!
+//! The subject is the NaN "unresolved" sentinel. `world_y` is `f32::NAN` when
+//! the placement chain resolved no elevation, and `hatch_angle_secondary` is
+//! `f32::NAN` when a fill carries no cross-hatch — the sentinel exists so that
+//! "unresolved" cannot be mistaken for `0.0`, which is a real elevation at
+//! datum. JSON has no NaN: `serde_json` writes a non-finite float as `null`,
+//! and the derived `Deserialize` could not read `null` back into an `f32`, so
+//! `load_cached_symbolic` fell into its
+//! `unwrap_or_else(|_| SymbolicData::default())` arm. ONE unresolved scalar
+//! anywhere in the model therefore made the ENTIRE cached blob unreadable, and
+//! every replayed request silently served no symbolic data at all.
+
+use super::cache_keys::{cache_symbolic_data, load_cached_symbolic};
+use crate::services::cache::DiskCache;
+use ifc_lite_processing::{SymbolicCircle, SymbolicData};
+
+/// Fresh on-disk cache in a uniquely-named temp directory.
+async fn cache_for(label: &str) -> DiskCache {
+    let dir = std::env::temp_dir().join(format!(
+        "ifc-lite-server-symbolic-cache-{}-{label}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    DiskCache::new(dir.to_str().unwrap()).await
+}
+
+/// One circle whose elevation is `world_y`.
+fn one_circle(world_y: f32) -> SymbolicData {
+    let mut data = SymbolicData::default();
+    data.circles.push(SymbolicCircle::full(
+        42,
+        "IFCANNOTATION".to_string(),
+        1.5,
+        2.5,
+        3.0,
+        world_y,
+        "Annotation".to_string(),
+    ));
+    data
+}
+
+/// RED before the `nan_as_null` serde adapter: `load_cached_symbolic` failed
+/// to parse the blob it had just written and returned `SymbolicData::default()`
+/// — the model's whole 2D symbol set, silently gone.
+///
+/// Asserted with `is_nan()`, not `!is_finite()` — `Infinity` is also
+/// non-finite and is not the sentinel.
+#[tokio::test]
+async fn unresolved_world_y_survives_the_symbolic_cache_round_trip() {
+    let cache = cache_for("unresolved").await;
+    let data = one_circle(f32::NAN);
+
+    cache_symbolic_data(&cache, "unresolved-key", &data).await;
+    let loaded = load_cached_symbolic(&cache, "unresolved-key").await;
+
+    assert!(
+        !loaded.is_empty(),
+        "one unresolved world_y must not wipe the whole cached blob"
+    );
+    assert!(
+        loaded.circles[0].world_y.is_nan(),
+        "unresolved world_y must come back unresolved, got {}",
+        loaded.circles[0].world_y
+    );
+}
+
+/// BOUNDING CONTROL — passes before AND after the fix. A genuine `0.0`
+/// elevation must still come back as exactly `0.0` and must never read as
+/// unresolved. If these two ever converge, the sentinel has stopped meaning
+/// anything and the fix is worse than the bug.
+#[tokio::test]
+async fn a_genuine_zero_elevation_survives_the_cache_and_is_not_unresolved() {
+    let cache = cache_for("zero-elevation").await;
+
+    cache_symbolic_data(&cache, "zero-key", &one_circle(0.0)).await;
+    let loaded = load_cached_symbolic(&cache, "zero-key").await;
+
+    assert!(!loaded.is_empty());
+    assert_eq!(loaded.circles[0].world_y, 0.0);
+    assert!(
+        !loaded.circles[0].world_y.is_nan(),
+        "a real 0.0 elevation must never read as unresolved"
+    );
+}
+
+/// The two must remain distinguishable AFTER the cache hop, not merely
+/// individually correct.
+#[tokio::test]
+async fn zero_and_unresolved_stay_distinct_through_the_cache() {
+    let cache = cache_for("distinct").await;
+
+    cache_symbolic_data(&cache, "zero", &one_circle(0.0)).await;
+    cache_symbolic_data(&cache, "nan", &one_circle(f32::NAN)).await;
+
+    let zero = load_cached_symbolic(&cache, "zero").await.circles[0].world_y;
+    let unresolved = load_cached_symbolic(&cache, "nan").await.circles[0].world_y;
+
+    assert!(!zero.is_nan() && zero == 0.0);
+    assert!(unresolved.is_nan());
+}

--- a/apps/server/src/routes/parse/mod.rs
+++ b/apps/server/src/routes/parse/mod.rs
@@ -242,6 +242,9 @@ mod json_tests;
 mod fetch_tests;
 
 #[cfg(test)]
+mod cache_keys_symbolic_tests;
+
+#[cfg(test)]
 mod resolved_tessellation_quality_tests {
     use super::*;
     use crate::error::ApiError;

--- a/packages/server-client/src/__fixtures__/symbolic-unresolved-wire.json
+++ b/packages/server-client/src/__fixtures__/symbolic-unresolved-wire.json
@@ -1,0 +1,61 @@
+{
+  "grid_axes": [
+    {
+      "express_id": 1,
+      "grid_express_id": 2,
+      "tag": "A",
+      "endpoints": [
+        0.0,
+        0.0,
+        1.0,
+        0.0
+      ],
+      "world_y": null
+    }
+  ],
+  "polylines": [
+    {
+      "express_id": 3,
+      "ifc_type": "IfcAnnotation",
+      "points": [
+        0.0,
+        0.0,
+        1.0,
+        1.0
+      ],
+      "closed": false,
+      "world_y": 0.0,
+      "representation": "Annotation"
+    }
+  ],
+  "circles": [],
+  "texts": [],
+  "fills": [
+    {
+      "express_id": 4,
+      "ifc_type": "IfcAnnotation",
+      "points": [
+        0.0,
+        0.0,
+        1.0,
+        0.0,
+        1.0,
+        1.0
+      ],
+      "holes_offsets": [],
+      "fill_color": [
+        0.0,
+        0.0,
+        0.0,
+        1.0
+      ],
+      "has_hatching": true,
+      "hatch_spacing": 0.1,
+      "hatch_angle": 0.0,
+      "hatch_angle_secondary": null,
+      "hatch_line_width": 0.01,
+      "world_y": 3.5,
+      "representation": "Annotation"
+    }
+  ]
+}

--- a/packages/server-client/src/symbolic-unresolved-wire.test.ts
+++ b/packages/server-client/src/symbolic-unresolved-wire.test.ts
@@ -26,17 +26,23 @@ const raw = readFileSync(
 );
 
 /**
- * Compile-time assertion: the declared type must ADMIT `null`. Back when
+ * Type-level assertion: the declared type must ADMIT `null`. Back when
  * `world_y` was declared `number`, this assignment did not compile — which is
- * precisely the half-fix this test exists to prevent.
+ * precisely the half-fix this test exists to prevent. Deliberately NOT
+ * wrapped in an `it()`: the const is a literal `null`, so
+ * `expect(admitsUnresolved).toBeNull()` would assert a value against itself
+ * and could never fail regardless of what `world_y`'s real type is — that
+ * runtime assertion has been removed as vacuous.
+ *
+ * Note this package's tsconfig excludes `*.test.ts` from `tsc`/`typecheck`,
+ * so this line is not compiled in CI today; it is a type-error-on-edit signal
+ * for whoever narrows `world_y` back to `number`, not a gate this suite can
+ * enforce on its own.
  */
 const admitsUnresolved: SymbolicData['grid_axes'][number]['world_y'] = null;
+void admitsUnresolved; // referenced only to avoid an unused-const complaint from editors
 
 describe('symbolic_data unresolved scalars on the wire', () => {
-  it('admits null in the declared type', () => {
-    expect(admitsUnresolved).toBeNull();
-  });
-
   it('parses the real server payload and reads unresolved as null', () => {
     const data = JSON.parse(raw) as SymbolicData;
 

--- a/packages/server-client/src/symbolic-unresolved-wire.test.ts
+++ b/packages/server-client/src/symbolic-unresolved-wire.test.ts
@@ -1,0 +1,90 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * The server side of `symbolic_data` uses `f32::NAN` as a sentinel meaning
+ * "this elevation / cross-hatch angle was never resolved". JSON has no NaN, so
+ * it reaches this client as `null` — and `null` is emphatically NOT `0`, which
+ * is a real elevation at datum.
+ *
+ * The payload under test is NOT hand-written here. It is emitted by the actual
+ * Rust serializer (`rust/processing/tests/symbolic_nan_sentinel_json_roundtrip.rs`,
+ * `the_typescript_wire_fixture_matches_what_the_serializer_emits`) and checked
+ * in; that test fails if the wire drifts from these bytes, so a format change
+ * cannot land on one side only.
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import type { SymbolicData } from './types.js';
+
+const raw = readFileSync(
+  fileURLToPath(new URL('./__fixtures__/symbolic-unresolved-wire.json', import.meta.url)),
+  'utf8',
+);
+
+/**
+ * Compile-time assertion: the declared type must ADMIT `null`. Back when
+ * `world_y` was declared `number`, this assignment did not compile — which is
+ * precisely the half-fix this test exists to prevent.
+ */
+const admitsUnresolved: SymbolicData['grid_axes'][number]['world_y'] = null;
+
+describe('symbolic_data unresolved scalars on the wire', () => {
+  it('admits null in the declared type', () => {
+    expect(admitsUnresolved).toBeNull();
+  });
+
+  it('parses the real server payload and reads unresolved as null', () => {
+    const data = JSON.parse(raw) as SymbolicData;
+
+    expect(data.grid_axes[0].world_y).toBeNull();
+    expect(data.fills[0].hatch_angle_secondary).toBeNull();
+  });
+
+  /**
+   * BOUNDING CONTROL — the one that matters. A genuine `0.0` elevation must
+   * survive as the number `0`, and must stay distinguishable from unresolved.
+   * `Number(null)` is `0`, so a consumer that coerces instead of branching
+   * invents a datum-level elevation out of "we don't know"; asserted here so
+   * that trap stays visible.
+   */
+  it('keeps a genuine 0 elevation distinct from unresolved', () => {
+    const data = JSON.parse(raw) as SymbolicData;
+
+    const zero = data.polylines[0].world_y;
+    const unresolved = data.grid_axes[0].world_y;
+
+    expect(zero).toBe(0);
+    expect(typeof zero).toBe('number');
+    expect(unresolved).toBeNull();
+    expect(zero).not.toBe(unresolved);
+
+    // The coercion trap, pinned: both would read as 0 if anything used it.
+    expect(Number(unresolved)).toBe(0);
+  });
+
+  it('carries resolved non-zero elevations through unchanged', () => {
+    const data = JSON.parse(raw) as SymbolicData;
+    expect(data.fills[0].world_y).toBe(3.5);
+  });
+
+  /**
+   * `null` (unresolved) must stay distinguishable from an absent key. The Rust
+   * deserializer rejects a missing `world_y` outright; on this side the
+   * difference is visible as `undefined` vs `null`, so a consumer branching on
+   * `=== null` never mistakes a truncated payload for a legitimate
+   * "elevation unknown" signal.
+   */
+  it('distinguishes unresolved (null) from absent (undefined)', () => {
+    const data = JSON.parse(raw) as SymbolicData;
+    const present = data.grid_axes[0] as unknown as Record<string, unknown>;
+
+    expect('world_y' in present).toBe(true);
+    expect(present.world_y).toBeNull();
+    expect(present.no_such_field).toBeUndefined();
+    expect(present.world_y).not.toBe(present.no_such_field);
+  });
+});

--- a/packages/server-client/src/types.ts
+++ b/packages/server-client/src/types.ts
@@ -229,6 +229,16 @@ export interface GeometryDiagnostics {
 // ============================================
 // 2D Symbol Data (IfcAnnotation + IfcGrid)
 // ============================================
+//
+// UNRESOLVED SCALARS. `world_y` and `hatch_angle_secondary` arrive as `null`
+// when the server could not resolve them — the Rust model spells that
+// `f32::NAN` and `serde_json` writes a non-finite float as JSON `null`.
+//
+// `null` is NOT `0`. `world_y: 0` is a real elevation at datum; `world_y:
+// null` means the placement chain never produced one. Branch on `x === null`
+// (or `typeof x === 'number'`) — do not coerce, because `Number(null)` is `0`
+// and would silently invent a datum-level elevation. Anything that buckets or
+// sorts by elevation must exclude the `null`s rather than treat them as zero.
 
 /**
  * A single `IfcGridAxis` tag + axis curve (compact endpoint-pair shape).
@@ -239,7 +249,11 @@ export interface SymbolicGridAxis {
   tag: string;
   /** Endpoint pair `[x0, y0, x1, y1]` in metres (plan view). */
   endpoints: [number, number, number, number];
-  world_y: number;
+  /**
+   * World-Y elevation in metres, or `null` when unresolved. See the
+   * "UNRESOLVED SCALARS" note at the top of this section — `null` is not `0`.
+   */
+  world_y: number | null;
 }
 
 /**
@@ -252,7 +266,11 @@ export interface SymbolicPolyline {
   /** Flat `[x0, y0, x1, y1, …]` plan-view coordinates. */
   points: number[];
   closed: boolean;
-  world_y: number;
+  /**
+   * World-Y elevation in metres, or `null` when unresolved. See the
+   * "UNRESOLVED SCALARS" note at the top of this section — `null` is not `0`.
+   */
+  world_y: number | null;
   representation: string;
 }
 
@@ -265,7 +283,11 @@ export interface SymbolicCircle {
   center_x: number;
   center_y: number;
   radius: number;
-  world_y: number;
+  /**
+   * World-Y elevation in metres, or `null` when unresolved. See the
+   * "UNRESOLVED SCALARS" note at the top of this section — `null` is not `0`.
+   */
+  world_y: number | null;
   /** Start angle in radians (0 for a full circle). */
   start_angle: number;
   /** End angle in radians (`2π` for a full circle). */
@@ -289,7 +311,11 @@ export interface SymbolicText {
   content: string;
   /** IFC `BoxAlignment` (`top-left`, `center`, …). Empty when absent. */
   alignment: string;
-  world_y: number;
+  /**
+   * World-Y elevation in metres, or `null` when unresolved. See the
+   * "UNRESOLVED SCALARS" note at the top of this section — `null` is not `0`.
+   */
+  world_y: number | null;
   /** sRGB straight-alpha colour `[r, g, b, a]`. */
   color: [number, number, number, number];
   /** Per-instance target screen-pixel cap height (`0` = renderer default). */
@@ -317,7 +343,11 @@ export interface SymbolicFillArea {
    */
   hatch_angle_secondary: number | null;
   hatch_line_width: number;
-  world_y: number;
+  /**
+   * World-Y elevation in metres, or `null` when unresolved. See the
+   * "UNRESOLVED SCALARS" note at the top of this section — `null` is not `0`.
+   */
+  world_y: number | null;
   representation: string;
 }
 

--- a/rust/processing/src/symbolic/primitives.rs
+++ b/rust/processing/src/symbolic/primitives.rs
@@ -5,6 +5,59 @@
 use serde::{Deserialize, Serialize};
 
 // ────────────────────────────────────────────────────────────────────────────
+// NaN sentinel <-> JSON `null`.
+//
+// Several scalars below use `f32::NAN` as a SENTINEL meaning "never resolved"
+// — `world_y` when the placement chain yields no elevation, and
+// `hatch_angle_secondary` when a fill carries no cross-hatch. The whole point
+// of that sentinel is that "unresolved" must not read as `0.0`, which is a
+// perfectly real elevation / angle.
+//
+// JSON has no NaN. `serde_json` already WRITES a non-finite `f32` as `null`,
+// but the derived `Deserialize` could not READ it back: `invalid type: null,
+// expected f32`. So every JSON hop destroyed the sentinel — most sharply in
+// `apps/server/src/routes/parse/cache_keys.rs`, where the symbolic cache is
+// re-read with `from_slice(..).unwrap_or_else(|_| SymbolicData::default())`,
+// meaning ONE unresolved scalar made the entire cached blob unreadable and
+// every replayed request served no symbolic data at all.
+//
+// `nan_as_null` fixes the READ side only. Its serialize half emits exactly
+// what `serde_json` already emitted (`null` for NaN, the plain number
+// otherwise), so no finite value — `0.0` included — changes shape on the
+// wire. `null` and `0` stay distinct, and an OMITTED key stays a hard
+// deserialization error rather than a third spelling of "unresolved".
+// ────────────────────────────────────────────────────────────────────────────
+
+/// `serialize_with`/`deserialize_with` pair mapping the `f32::NAN`
+/// "unresolved" sentinel to and from JSON `null`.
+///
+/// Read back, any `null` becomes `f32::NAN`. `serde_json` also writes `±inf`
+/// as `null`, so an infinity would return as NaN — no producer in this crate
+/// emits one, and NaN is the correct reading of "not a usable elevation"
+/// either way. Consumers must test `is_nan()`, not `!is_finite()`.
+pub(crate) mod nan_as_null {
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub(crate) fn serialize<S>(value: &f32, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if value.is_nan() {
+            serializer.serialize_none()
+        } else {
+            serializer.serialize_f32(*value)
+        }
+    }
+
+    pub(crate) fn deserialize<'de, D>(deserializer: D) -> Result<f32, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(Option::<f32>::deserialize(deserializer)?.unwrap_or(f32::NAN))
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
 // Pure-Rust serializable primitive types. The wasm-bindgen wrappers in
 // `rust/wasm-bindings/src/zero_copy.rs` are thin views over these.
 // ────────────────────────────────────────────────────────────────────────────
@@ -21,7 +74,10 @@ pub struct SymbolicPolyline {
     /// True if the curve is a closed loop.
     pub closed: bool,
     /// World-Y elevation captured from the placement chain or the
-    /// polyline's own 3D `IfcCartesianPoint` Z component.
+    /// polyline's own 3D `IfcCartesianPoint` Z component. `f32::NAN` when the
+    /// elevation could not be resolved — distinct from a genuine `0.0`, and
+    /// spelled `null` on the JSON wire (see [`nan_as_null`]).
+    #[serde(with = "nan_as_null")]
     pub world_y: f32,
     /// Representation identifier (`Plan`, `Annotation`, `FootPrint`, `Axis`).
     pub representation: String,
@@ -36,6 +92,7 @@ pub struct SymbolicCircle {
     pub center_y: f32,
     pub radius: f32,
     /// World-Y elevation (see [`SymbolicPolyline::world_y`]).
+    #[serde(with = "nan_as_null")]
     pub world_y: f32,
     /// Start angle in radians (0 for full circle).
     pub start_angle: f32,
@@ -89,6 +146,7 @@ pub struct SymbolicText {
     /// string when absent.
     pub alignment: String,
     /// World-Y elevation (see [`SymbolicPolyline::world_y`]).
+    #[serde(with = "nan_as_null")]
     pub world_y: f32,
     /// sRGB straight-alpha colour `[r, g, b, a]`. Defaults to dark-grey
     /// when no IfcStyledItem chain resolves a colour.
@@ -119,9 +177,13 @@ pub struct SymbolicFillArea {
     pub has_hatching: bool,
     pub hatch_spacing: f32,
     pub hatch_angle: f32,
-    /// Secondary cross-hatch angle. NaN if absent.
+    /// Secondary cross-hatch angle. NaN if absent — `null` on the JSON wire
+    /// (see [`nan_as_null`]), which is NOT the same as a genuine `0.0` angle.
+    #[serde(with = "nan_as_null")]
     pub hatch_angle_secondary: f32,
     pub hatch_line_width: f32,
+    /// World-Y elevation (see [`SymbolicPolyline::world_y`]).
+    #[serde(with = "nan_as_null")]
     pub world_y: f32,
     pub representation: String,
 }
@@ -137,6 +199,8 @@ pub struct SymbolicGridAxis {
     pub tag: String,
     /// Endpoint pair `[x0, y0, x1, y1]` in metres (plan view).
     pub endpoints: [f32; 4],
+    /// World-Y elevation (see [`SymbolicPolyline::world_y`]).
+    #[serde(with = "nan_as_null")]
     pub world_y: f32,
 }
 

--- a/rust/processing/tests/symbolic_nan_sentinel_json_roundtrip.rs
+++ b/rust/processing/tests/symbolic_nan_sentinel_json_roundtrip.rs
@@ -1,0 +1,265 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! The symbolic primitives use `f32::NAN` as a SENTINEL meaning "this scalar
+//! was never resolved" — `world_y` when the placement chain yields no
+//! elevation, `hatch_angle_secondary` when a fill carries no cross-hatch.
+//! The distinction that sentinel exists to preserve is "unresolved" vs. a
+//! genuine `0.0`, which is a real elevation / a real angle.
+//!
+//! JSON has no NaN. `serde_json` writes `f32::NAN` as `null` and — before the
+//! fix — the derived `Deserialize` could not read `null` back into an `f32`
+//! (`invalid type: null, expected f32`). Every JSON hop therefore DESTROYED
+//! the sentinel:
+//!
+//! - `apps/server/src/routes/parse/cache_keys.rs` serializes `SymbolicData`
+//!   into the `{cache_key}-symbolic-v1` cache entry and reads it back with
+//!   `serde_json::from_slice(..).unwrap_or_else(|_| SymbolicData::default())`
+//!   — so ONE unresolved scalar anywhere in the model made the whole cached
+//!   blob unreadable and every replayed request silently served NO symbolic
+//!   data at all.
+//! - `apps/server/src/types/response.rs` embeds `SymbolicData` in the
+//!   `complete` stream event and in `POST /api/v1/parse`, so the same value
+//!   reaches TypeScript clients.
+//!
+//! These tests drive the REAL serializer and the REAL deserializer — never a
+//! hand-written JSON literal — so they pin the wire format rather than an
+//! assumption about it.
+
+use ifc_lite_processing::{SymbolicData, SymbolicFillArea, SymbolicGridAxis, SymbolicPolyline};
+
+fn axis(world_y: f32) -> SymbolicGridAxis {
+    SymbolicGridAxis {
+        express_id: 1,
+        grid_express_id: 2,
+        tag: "A".to_string(),
+        endpoints: [0.0, 0.0, 1.0, 0.0],
+        world_y,
+    }
+}
+
+fn polyline(world_y: f32) -> SymbolicPolyline {
+    SymbolicPolyline {
+        express_id: 3,
+        ifc_type: "IfcAnnotation".to_string(),
+        points: vec![0.0, 0.0, 1.0, 1.0],
+        closed: false,
+        world_y,
+        representation: "Annotation".to_string(),
+    }
+}
+
+fn fill(world_y: f32, hatch_angle_secondary: f32) -> SymbolicFillArea {
+    SymbolicFillArea {
+        express_id: 4,
+        ifc_type: "IfcAnnotation".to_string(),
+        points: vec![0.0, 0.0, 1.0, 0.0, 1.0, 1.0],
+        holes_offsets: vec![],
+        fill_color: [0.0, 0.0, 0.0, 1.0],
+        has_hatching: true,
+        hatch_spacing: 0.1,
+        hatch_angle: 0.0,
+        hatch_angle_secondary,
+        hatch_line_width: 0.01,
+        world_y,
+        representation: "Annotation".to_string(),
+    }
+}
+
+/// RED: an unresolved `world_y` must survive a full JSON round-trip through
+/// the same serializer/deserializer pair the server's symbolic cache uses.
+///
+/// Before the fix this panicked on `from_str` with
+/// `invalid type: null, expected f32`.
+#[test]
+fn unresolved_world_y_survives_a_json_round_trip() {
+    let data = SymbolicData {
+        grid_axes: vec![axis(f32::NAN)],
+        polylines: vec![polyline(f32::NAN)],
+        circles: vec![],
+        texts: vec![],
+        fills: vec![fill(f32::NAN, f32::NAN)],
+    };
+
+    let json = serde_json::to_string(&data).expect("SymbolicData serializes");
+    let back: SymbolicData =
+        serde_json::from_str(&json).expect("unresolved SymbolicData must deserialize");
+
+    assert!(
+        back.grid_axes[0].world_y.is_nan(),
+        "grid axis world_y must come back unresolved, got {}",
+        back.grid_axes[0].world_y
+    );
+    assert!(
+        back.polylines[0].world_y.is_nan(),
+        "polyline world_y must come back unresolved, got {}",
+        back.polylines[0].world_y
+    );
+    assert!(
+        back.fills[0].world_y.is_nan(),
+        "fill world_y must come back unresolved, got {}",
+        back.fills[0].world_y
+    );
+    assert!(
+        back.fills[0].hatch_angle_secondary.is_nan(),
+        "absent cross-hatch angle must come back unresolved, got {}",
+        back.fills[0].hatch_angle_secondary
+    );
+}
+
+/// The wire spelling of "unresolved" is JSON `null` — not a missing key, not
+/// a magic number. Pinned so the TypeScript declaration
+/// (`packages/server-client/src/types.ts`, `world_y: number | null`) and this
+/// side cannot drift apart.
+#[test]
+fn unresolved_world_y_is_spelled_null_on_the_wire() {
+    let data = SymbolicData {
+        grid_axes: vec![axis(f32::NAN)],
+        polylines: vec![],
+        circles: vec![],
+        texts: vec![],
+        fills: vec![],
+    };
+
+    let json = serde_json::to_value(&data).expect("SymbolicData serializes");
+    let wire = &json["grid_axes"][0];
+    assert!(
+        wire.as_object().unwrap().contains_key("world_y"),
+        "unresolved must be an explicit null, never an omitted key: {json}"
+    );
+    assert!(
+        wire["world_y"].is_null(),
+        "unresolved world_y must serialize as null, got {}",
+        wire["world_y"]
+    );
+}
+
+/// Cross-language pin. The TypeScript declaration of this payload lives in
+/// `packages/server-client/src/types.ts`, and a hand-written JSON literal on
+/// that side would only test TypeScript's assumption about the wire, not the
+/// wire. So the fixture the TS test reads is EMITTED HERE, by the real
+/// serializer, and this test fails if the checked-in bytes drift from what
+/// the serializer now produces.
+///
+/// Regenerate deliberately with `UPDATE_SYMBOLIC_WIRE_FIXTURE=1 cargo test`.
+/// A regeneration that changes these bytes IS a wire-format change and must
+/// be matched on the TypeScript side in the same commit.
+#[test]
+fn the_typescript_wire_fixture_matches_what_the_serializer_emits() {
+    let data = SymbolicData {
+        // Unresolved elevation.
+        grid_axes: vec![axis(f32::NAN)],
+        // A genuine 0.0 elevation — the value `null` must never collapse into.
+        polylines: vec![polyline(0.0)],
+        circles: vec![],
+        texts: vec![],
+        // Resolved elevation, absent cross-hatch.
+        fills: vec![fill(3.5, f32::NAN)],
+    };
+    let mut emitted = serde_json::to_string_pretty(&data).expect("SymbolicData serializes");
+    emitted.push('\n');
+
+    let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../packages/server-client/src/__fixtures__/symbolic-unresolved-wire.json");
+
+    if std::env::var_os("UPDATE_SYMBOLIC_WIRE_FIXTURE").is_some() {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, &emitted).unwrap();
+        return;
+    }
+
+    let checked_in = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("missing wire fixture {}: {e}", path.display()));
+    assert_eq!(
+        checked_in,
+        emitted,
+        "the symbolic wire format changed; `packages/server-client/src/types.ts` \
+         must be updated to match, then regenerate with \
+         UPDATE_SYMBOLIC_WIRE_FIXTURE=1"
+    );
+}
+
+/// BOUNDING CONTROL — the one that matters most. A genuine finite `world_y`,
+/// **including exactly `0.0`**, must round-trip bit-for-bit and must stay
+/// distinguishable from unresolved. This passes before AND after the fix; if
+/// it ever stops passing, the fix has eaten a real elevation.
+#[test]
+fn finite_world_y_including_zero_round_trips_unchanged() {
+    for &value in &[0.0f32, -0.0, 3.5, -12.25, 1e-7, 1.0e9] {
+        let data = SymbolicData {
+            grid_axes: vec![axis(value)],
+            polylines: vec![polyline(value)],
+            circles: vec![],
+            texts: vec![],
+            fills: vec![fill(value, 0.0)],
+        };
+
+        let json = serde_json::to_string(&data).expect("SymbolicData serializes");
+        let back: SymbolicData = serde_json::from_str(&json).expect("finite data deserializes");
+
+        assert_eq!(
+            back.grid_axes[0].world_y.to_bits(),
+            value.to_bits(),
+            "finite grid-axis world_y {value} must round-trip exactly"
+        );
+        assert_eq!(
+            back.polylines[0].world_y.to_bits(),
+            value.to_bits(),
+            "finite polyline world_y {value} must round-trip exactly"
+        );
+        assert_eq!(
+            back.fills[0].world_y.to_bits(),
+            value.to_bits(),
+            "finite fill world_y {value} must round-trip exactly"
+        );
+        assert_eq!(
+            back.fills[0].hatch_angle_secondary, 0.0,
+            "a genuine 0.0 cross-hatch angle must NOT be read back as absent"
+        );
+        assert!(
+            !back.grid_axes[0].world_y.is_nan(),
+            "finite {value} must never be confused with unresolved"
+        );
+    }
+}
+
+/// BOUNDING CONTROL — `0.0` and unresolved must produce DIFFERENT wire bytes
+/// and stay different after the round-trip. This is the whole point of the
+/// sentinel; a representation that collapses them is worse than the bug.
+#[test]
+fn zero_and_unresolved_stay_distinguishable_across_the_boundary() {
+    let zero = serde_json::to_string(&axis(0.0)).unwrap();
+    let unresolved = serde_json::to_string(&axis(f32::NAN)).unwrap();
+    assert_ne!(
+        zero, unresolved,
+        "a real 0.0 elevation and an unresolved one must not share a wire form"
+    );
+
+    let zero_back: SymbolicGridAxis = serde_json::from_str(&zero).unwrap();
+    let unresolved_back: SymbolicGridAxis = serde_json::from_str(&unresolved).unwrap();
+    assert_eq!(zero_back.world_y, 0.0);
+    assert!(!zero_back.world_y.is_nan());
+    assert!(unresolved_back.world_y.is_nan());
+}
+
+/// "Unresolved" (`null`) must stay distinguishable from "the producer never
+/// wrote this field at all" (key missing). A missing key is a hard
+/// deserialization error — it is NOT quietly reinterpreted as unresolved —
+/// so a truncated or foreign payload can never masquerade as a legitimate
+/// "elevation not known" signal.
+///
+/// Guarding `is_nan()` rather than `!is_finite()` matters here: `Infinity`
+/// also fails `is_finite`, and it is not the sentinel.
+#[test]
+fn a_missing_world_y_is_an_error_not_an_unresolved_value() {
+    let mut wire = serde_json::to_value(axis(f32::NAN)).unwrap();
+    wire.as_object_mut().unwrap().remove("world_y");
+
+    let err = serde_json::from_value::<SymbolicGridAxis>(wire)
+        .expect_err("a missing world_y must not silently become unresolved");
+    assert!(
+        err.to_string().contains("world_y"),
+        "error should name the missing field, got: {err}"
+    );
+}


### PR DESCRIPTION
Finding #5 from your review of #2355, which that PR scoped out. **It turns out to be a live bug on `main` today, and the worst consumer is the server itself.**

## Not theoretical — reproduces on `main` right now

`rust/processing/src/symbolic/fill.rs:63` sets `hatch_angle_secondary: f32::NAN` on **every** fill, including non-hatched ones (`has_hatching: false` sits directly above it). So this fires on ordinary models, without #2355 needing to land.

And `serde_json` cannot round-trip it:

```
serde_json::to_string(&f32::NAN)  ->  "null"
deserialize "null" into f32       ->  Error("invalid type: null, expected f32")
```

## The consumer that matters is inside the server

```
cache_keys.rs:103  serde_json::to_vec(symbolic)                 // write
cache_keys.rs:123  from_slice(..).unwrap_or_else(|e| { error!(); SymbolicData::default() })
```

The server writes symbolic data to `{cache_key}-symbolic-v1`, then reads it back. **One unresolved scalar anywhere in the model makes the whole entry unparseable**, and that `unwrap_or_else` then serves `SymbolicData::default()` — so every replayed request silently returns **no 2D symbols at all, for the entire model**. Not a client parse error you'd notice; a silent total loss, server-side, logged and moved past.

## Design: `serialize_with`/`deserialize_with`, not a type reshape

The decisive property is that **the serialize half emits exactly what `serde_json` already emitted** — `null` for NaN, the plain number otherwise. The wire is byte-identical before and after; only the *read* side gains the ability to map `null` back to `f32::NAN`. Reshaping to `Option<f32>` would have churned every producer and consumer in `symbolic/` and `wasm-bindings/` for no wire benefit.

Your constraint that unresolved ≠ absent falls out for free, and is pinned: `deserialize_with` **without** `#[serde(default)]` still requires the key, so a missing `world_y` is a hard error rather than a third spelling of "unresolved" (`a_missing_world_y_is_an_error_not_an_unresolved_value`).

**Scope extended past `world_y` deliberately**: the adapter is on all five `world_y` fields *and* `hatch_angle_secondary`. That last one is the field that makes this reproducible on `main` today — fixing only `world_y` would have left the cache bug fully intact.

**TS side**: `world_y: number | null` on all five interfaces. Worth noting `types.ts:318` already declared `hatch_angle_secondary: number | null` — someone had seen the `null` on the wire and half-fixed it in TS only. Added a note about the coercion trap, since `Number(null) === 0` would silently invent a datum-level elevation.

**Cross-language pin**: the fixture the TS test reads is *emitted by the Rust serializer*, and a Rust test fails if the checked-in bytes drift — so neither side can move alone.

## RED

```
test zero_and_unresolved_stay_distinguishable_across_the_boundary ... FAILED
test unresolved_world_y_survives_a_json_round_trip ... FAILED
  Error("invalid type: null, expected f32", line: 1, column: 104)
```

Independently reproduced by removing all six adapters. Two tests that **still pass** in that RED run are the useful signal: `unresolved_world_y_is_spelled_null_on_the_wire` (confirming the serialize half really is unchanged) and the finite/zero control below.

## Bounding controls — pass BEFORE and after

`finite_world_y_including_zero_round_trips_unchanged` asserts `to_bits()` equality over `[0.0, -0.0, 3.5, -12.25, 1e-7, 1e9]` across all three carrier types, plus a genuine `0.0` cross-hatch angle. `a_genuine_zero_elevation_survives_the_cache_and_is_not_unresolved` does the same through the real `DiskCache`. The fixture carries `"world_y": null` and `"world_y": 0.0` side by side.

## Displacement

- **Server cache** — the only behaviour that changes: previously fell back to empty on any unresolved scalar, now parses. Strictly a recovery.
- **HTTP responses** — bytes unchanged.
- **wasm zero-copy path** (`packages/geometry`, `packages/renderer`, viewer overlay-parse) — never crosses JSON and carries no `worldY` on the server shape, so `Number.isFinite(worldY)` consumers are untouched.
- Nothing outside `types.ts` reads snake-case `world_y`.

## Verification

`ifc-lite-processing` 47 binaries all ok (6 new); `ifc-lite-server` **199 passed, 0 failed**; `@ifc-lite/server-client` 37 passed. `pnpm turbo typecheck` 33/33. Producer behaviour untouched — that's #2355/#2356's business.

**Module-size ratchet**: the new server tests would have pushed `cache_keys.rs` 385 → 465, over the limit. No budget raised and no allowlist row added — they were split into `cache_keys_symbolic_tests.rs`, following the existing `*_tests.rs` sibling convention, leaving `cache_keys.rs` at 385.

## One thing you may want to know about

`node scripts/add-license-headers.mjs --check` has **no `--check` flag** and silently ignores it — it added headers to 78 unrelated files instead of doing a dry run. Caught via `git status` and reverted exactly those paths. That script probably ought to reject unknown flags.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected symbolic elevation handling so unresolved `world_y` values are represented as `null` instead of zero.
  - Preserved the distinction between unresolved, zero, non-zero, and omitted values during serialization and deserialization.
  - Applied consistent handling across symbolic geometry and annotation elements.

- **Documentation**
  - Updated client type definitions and guidance to reflect nullable unresolved elevations.

- **Tests**
  - Added coverage for JSON and cache round trips, fixture compatibility, and finite-value preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->