### PR TITLE
fix(export): hoist dynamic module imports out of timed test bodies

### DIFF
--- a/packages/export/src/parquet-geometry.test.ts
+++ b/packages/export/src/parquet-geometry.test.ts
@@ -18,6 +18,7 @@
 
 import { describe, it, expect, beforeAll } from 'vitest';
 import { ParquetExporter } from './parquet-exporter.js';
+import JSZip from 'jszip';
 import type { IfcDataStore } from '@ifc-lite/parser';
 import type { GeometryResult, MeshData } from '@ifc-lite/geometry';
 import {
@@ -401,7 +402,6 @@ describe('ParquetExporter Metadata.json', () => {
     const exporter = new ParquetExporter(buildTypedStore(), geometry([a]));
     const zipBytes = await exporter.exportBOS();
 
-    const JSZip = (await import('jszip')).default;
     const zip = await JSZip.loadAsync(zipBytes);
     const metadata = JSON.parse(await zip.file('Metadata.json')!.async('string'));
 
@@ -415,7 +415,6 @@ describe('ParquetExporter Metadata.json', () => {
     // The two-valued signal in both directions: the branch above must not be
     // passing merely because the numbers happen to be non-zero.
     const zipBytes = await new ParquetExporter(buildTypedStore()).exportBOS();
-    const JSZip = (await import('jszip')).default;
     const zip = await JSZip.loadAsync(zipBytes);
     const metadata = JSON.parse(await zip.file('Metadata.json')!.async('string'));
 

--- a/packages/export/src/step-serialization.test.ts
+++ b/packages/export/src/step-serialization.test.ts
@@ -15,6 +15,7 @@ import {
   tokenIsRealLiteral,
   toStepReal,
 } from './step-serialization.js';
+import { toStepRealScaled } from './unit-normalize.js';
 
 describe('resolveExpressBase', () => {
   it('resolves defined types to their EXPRESS primitive, following alias chains', () => {
@@ -181,8 +182,7 @@ describe('serializeAttributeValue (string attributes)', () => {
 });
 
 describe('toStepRealScaled', () => {
-  it('formats scaled values through the shared STEP REAL rewrite', async () => {
-    const { toStepRealScaled } = await import('./unit-normalize.js');
+  it('formats scaled values through the shared STEP REAL rewrite', () => {
     expect(toStepRealScaled(5e-8)).toBe('5.E-8');
     expect(toStepRealScaled(1e21)).toBe('1.E+21');
     expect(toStepRealScaled(-0)).toBe('0.');


### PR DESCRIPTION
Addresses #2426.

## Diagnosis confirmed

`step-serialization.test.ts:185` did `await import('./unit-normalize.js')` **inside the test body**, so vitest's default 5000 ms `testTimeout` (no override in `packages/export/vitest.config.ts`) covered module transform and resolution through the package's seven workspace-src aliases — not just the microsecond-scale string-formatting assertions the test actually makes.

Your framing of why this matters is the right one: it re-runs green, which is exactly the shape that trains people to re-run instead of read. It has been showing up on unrelated PRs in our own runs too.

## Why it was dynamic: no reason

Checked before moving it, since a dynamic import can be load-bearing (cycles, deferred side effects, per-test module state). None applies here:

- `unit-normalize.ts` imports `splitTopLevelStepArguments` **from** `step-serialization.ts`, but there's no reverse dependency, so no cycle involves the test file.
- No laziness is under test.
- `unit-normalize.ts`'s module scope is `Set`/`Map`/`RegExp` constants — no I/O, no logging, nothing order-sensitive.

So it's hoisted to a plain top-level import.

## Sibling sweep — and what was deliberately left alone

Grepped every `*.test.ts` in `packages/export` for `await import(`. Seven occurrences across two files; **only two were this bug**:

| Site | Action |
|---|---|
| `step-serialization.test.ts:185` | **fixed** — the reported bug |
| `parquet-geometry.test.ts:404,418` (`jszip`, inside `it()` bodies) | **fixed** — same no-reason shape; hoisted to a top-level `import JSZip from 'jszip'`, matching the static-import convention already used in `packages/bcf/src/reader.ts`, `writer.ts`, and `packages/parser/src/ifczip.ts` |
| `parquet-geometry.test.ts:47,50` (`parquet-wasm`, `apache-arrow`) | **left dynamic, deliberately** — the file documents (lines 33–40) that `vendor-types.d.ts` declares intentionally narrow ambient types for these packages, so reaching `readParquet`/`tableFromIPC` requires a typed dynamic import rather than widening the ambient module. Different problem. |
| `parquet-geometry.test.ts:169-170` | **already correct** — preloaded once in `beforeAll(..., 30_000)` precisely to keep transform cost out of any single test's timing window. The file's own comment describes exactly this reasoning. |

That last one is worth noting: someone had already solved this problem correctly in the same file, which is a good argument that the pattern is understood and this was an oversight rather than a convention.

## Honest note on reproduction

**I could not reproduce the CI timeout locally** — this machine is fast and the "before" run never approached 5000 ms even with the dynamic import in place. What I can show is the timing shift: the fixed test's own reported duration goes from 3 ms to 0 ms, because the ~880–1000 ms module transform now happens once during the file's import phase, outside any single test's clock.

So this is reported as a structural fix for a timing hazard, not as a reproduced-and-cured flake.

## Displacement

Hoisting changes import order only in ways that provably don't matter here: no top-level side effects in the hoisted modules, no mocks, no module-level mutable state shared across tests, and no test in either file depends on late loading.

## Verification

`packages/export`: **30 files, 500 tests, 0 failures** — same assertions, same counts, before and after. Test-only change, so no changeset.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified archive metadata tests by using a synchronous ZIP library import.
  * Updated STEP serialization tests to run synchronously while preserving existing assertions.
  * No user-facing functionality or public APIs changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->