### PR TITLE
test(export): take module loading out of two test timing budgets

### DIFF
--- a/packages/export/src/parquet-geometry.test.ts
+++ b/packages/export/src/parquet-geometry.test.ts
@@ -168,6 +168,13 @@ function buildTypedStore(): IfcDataStore {
 beforeAll(async () => {
   await import('apache-arrow');
   await import('parquet-wasm');
+  // The `exportBOS` tests below also reach for jszip from inside their own
+  // bodies to read the archive back. That import is cheap today only because
+  // `ParquetExporter.exportBOS` itself lazily imports jszip, so the module is
+  // already resolved by the time the test asks for it — an incidental ordering
+  // the tests should not silently depend on. Warm it explicitly so it stays
+  // outside their budgets even if the exporter stops loading it first.
+  await import('jszip');
 }, 30_000);
 
 describe('ParquetExporter VertexBuffer.parquet', () => {

--- a/packages/export/src/step-serialization.test.ts
+++ b/packages/export/src/step-serialization.test.ts
@@ -15,6 +15,7 @@ import {
   tokenIsRealLiteral,
   toStepReal,
 } from './step-serialization.js';
+import { toStepRealScaled } from './unit-normalize.js';
 
 describe('resolveExpressBase', () => {
   it('resolves defined types to their EXPRESS primitive, following alias chains', () => {
@@ -181,8 +182,7 @@ describe('serializeAttributeValue (string attributes)', () => {
 });
 
 describe('toStepRealScaled', () => {
-  it('formats scaled values through the shared STEP REAL rewrite', async () => {
-    const { toStepRealScaled } = await import('./unit-normalize.js');
+  it('formats scaled values through the shared STEP REAL rewrite', () => {
     expect(toStepRealScaled(5e-8)).toBe('5.E-8');
     expect(toStepRealScaled(1e21)).toBe('1.E+21');
     expect(toStepRealScaled(-0)).toBe('0.');


### PR DESCRIPTION
Fixes #2426.

Takes module loading out of the timing budget of two tests in `@ifc-lite/export`.

## What changed

- `packages/export/src/step-serialization.test.ts` — hoists `toStepRealScaled` from an in-body `await import('./unit-normalize.js')` up to a module-scope import, and drops the now-unnecessary `async`.
- `packages/export/src/parquet-geometry.test.ts` — adds `jszip` to the `beforeAll` warm-up hook that already warms `apache-arrow` and `parquet-wasm`.

Test-only. **No changeset**: no runtime code in any published package is touched.

## Why hoist rather than raise `testTimeout`

The dynamic form here is incidental, not deliberate. Three things say so:

1. **There is no cycle to break.** `unit-normalize.ts:59` imports `./step-serialization.js`; `step-serialization.ts` does not import `unit-normalize.ts`. The single edge between them points the wrong way to matter, and a test file is a leaf module anyway, so a static import in one cannot create a cycle.
2. **The lazy path is not what is under test.** `packages/export/src/unit-normalize.test.ts:6-13` already imports that exact module statically at module scope, in the same package under the same config.
3. **Nothing marks it as intentional.** This is the strongest one: the package *does* mark its deliberate dynamic imports. `parquet-geometry.test.ts:33-40` carries a seven-line comment explaining that `src/vendor-types.d.ts` declares narrow ambient modules covering only the write side, so a named import of the read side would not typecheck. That one is load-bearing and documented. The `step-serialization.test.ts` one has no comment at all, and `git blame` puts it in cc92f1716 (#1772), the same commit that added the whole `toStepRealScaled` block — it reads as convenience while appending a describe to an existing file.

Raising `testTimeout` would also blanket every other test in the package, hiding a future genuine slowdown.

## Measurements

Metric is the duration vitest reports for `toStepRealScaled > formats scaled values through the shared STEP REAL rewrite`, against its 5000 ms budget. Each rep is a full `vitest run` of the package (28 files, 470 tests) on a 10-core machine.

| Condition | Before (ms) | After (ms) |
|---|---|---|
| No artificial load, n=5 | 8, 15, 16, 16, 16 | 0, 0, 0, 0, 0 |
| 24 busy-loop processes on 10 cores, n=5 | 1, 2, 4, 8, 78 | 0, 0, 0, 1, 1 |
| Concurrent full-monorepo `turbo run test --force` (41 other packages, 85 tasks, load avg 15-25), n=6 | 12, 15, 21, 23, 23, 37 | 0, 0, 0, 1, 1, 1 |

**Margins, not a verdict.** Worst observed before: **78 ms of a 5000 ms budget**, i.e. 4922 ms of headroom, a 64x margin. Worst observed after: **1 ms**, i.e. 4999 ms of headroom, a 5000x margin. 16 full-suite runs after the change, all exit 0, zero timeouts.

A single green run cannot establish that a flake is fixed, and this does not claim that. What it establishes is that the cost this test carries inside its own clock is now bounded by something that does not depend on another process.

## Two things I got wrong, corrected by measuring

Recording these because they change how much the fix should be credited with:

- **I predicted this import dragged the whole `@ifc-lite/parser` src graph into the test clock. It does not.** `step-serialization.ts:12` already imports `@ifc-lite/parser` statically, so parser is transformed during the collect phase, before any test runs. What actually sat inside the clock was only `unit-normalize.ts`'s own transform. That is why the before numbers are tens of milliseconds and not seconds.
- **I expected the hoist to make the test structurally incapable of timing out**, on the theory that a fully synchronous body never yields to let the timeout timer fire. I probed it: a sync test that blocks for 6000 ms *does* report `Test timed out in 5000ms` (reported duration 6054 ms). Vitest checks elapsed time after the fact. So the test is not immune afterwards, only much cheaper.

**Therefore: I could not reproduce anything close to a 5000 ms timeout by this mechanism.** Even under a full concurrent `turbo run test` the measured cost stayed under 40 ms. The 64x margin that existed *before* this change is not by itself consistent with the reported failures, so the transform cost is unlikely to have been the whole story. The likeliest missing factor is machine-wide starvation during the batch in which #2426 was filed: that machine hit ENOSPC with 0 bytes free (I hit it myself in this same batch, hard enough that no process could write). Under swap thrash and a full disk, any await-bearing test can blow a 5000 ms budget, and only 5 of the 31 tests in this file await anything at all.

This change is still correct and worth making — it removes an unnecessary, contention-dependent, cross-process cost from a measured window, for free. It should not be assumed to have removed the underlying cause. If #2426 recurs on a healthy machine, the disk/memory pressure angle is where I would look next, not this import.

## On the jszip half

Honest accounting: this one is **defensive, with no measured effect**. `parquet-exporter.ts:565` already does `await import('jszip')` inside `exportBOS()`, which every one of those tests calls before reaching its own import — so the test-body import was always a cache hit. The numbers confirm it (first jszip test, under turbo load: before 93-285 ms, after 72-234 ms, indistinguishable noise).

It is kept because the tests currently depend on production code happening to load jszip first, which is invisible and would break silently if `exportBOS` stopped doing that. The comment says exactly this rather than claiming a speedup.

## Repo-wide sweep: the pattern is confined to this package

Swept the whole repo for the combination that actually makes this bite: (a) `await import(` inside an `it()`/`test()` body, (b) a vitest config aliasing workspace packages to `src/` so modules are transformed on demand instead of loaded from a built `dist`, and (c) no `testTimeout`, so the default 5000 ms applies.

**No cluster. `packages/export` is the only package matching all three**, and the reason is structural rather than lucky: only 6 packages declare `src/` aliases (`export` 7, `query` 4, `apps/viewer-embed` 2, `bcf` 1, `embed-sdk` 1, `source-fixture` 1), and `export` is the only one of those 6 with any in-test dynamic import at all. The other five have zero.

Census: 74 raw `await import(` lines across 33 test files, of which 42 are in suites that vitest does not run (`apps/viewer`, `packages/viewer`, `packages/wasm`, `tests/integration.test.ts` and Playwright specs all use `node:test` / `tsx --test` / Playwright, so no 5000 ms vitest budget), 3 are `await import(...)` appearing inside template-literal *source samples* in `packages/extensions/src/validate/code.test.ts`, 7 are at module scope, and 4 are already in warm-up hooks. That leaves **17 genuinely in-test occurrences across 10 packages**.

The other 9 packages are all spared by condition (b), each for a concrete reason: `clash`, `pointcloud`, `mutations` and `collab-server` re-import a module the same test file already imports statically (pure cache hit); `collab` imports `yjs`, already pulled in by a static import; `codegen` imports a `data:text/javascript;base64,…` URL, which involves no Vite resolution at all; `extensions` imports a 173-line data module whose only import is type-only. There is also no inherited config anywhere: no root `vitest.config.*`, no `vitest.workspace.*`, no `--config` in any test script. Packages without their own config get zero aliases, and their cross-package imports resolve through pnpm symlinks to prebuilt `dist` (turbo's `test` task `dependsOn: ["build"]`). Config-level `testTimeout` exists in exactly two places repo-wide, both 30_000: `packages/create-ifc-lite/vitest.config.ts:12` and `packages/data/vitest.config.ts:14`.

Two borderline cases fail (b) literally (no aliases) but do pay an on-demand transform of a *cold* local `src/` graph inside a default 5000 ms budget, which is the same underlying mechanism. Not touched here, flagged for a possible follow-up:

- `packages/drawing-2d/src/projection-bands.test.ts:266` — `await import('./drawing-generator.js')`, not statically imported anywhere in that file, and it pulls in roughly 15 sibling src modules (`section-cutter`, `polygon-builder`, `edge-extractor`, `hidden-line`, `line-merger`, `hatch-generator`, `svg-exporter`, `gpu-section-cutter`, …). The largest cold graph of the non-`export` set.
- `packages/sandbox/src/transpile-wasm-url.test.ts:56` — `await import('./transpile.js')` with `vi.resetModules()` in `beforeEach`, so it re-imports per test. The module is small, but this is the only file in `packages/sandbox` without an explicit per-test timeout; every sibling uses `}, 30_000)` through `}, 120_000)`.

One correction to my own earlier read of this package: `parquet-geometry.test.ts:47,50` are written at module scope inside the `readArrowTable()` helper, but that helper is only ever reached from inside `it()` bodies, so their cost does land in a test budget rather than at collection. They were already covered by the #2248 warm-up; with `jszip` added, all four remaining in-test dynamic imports in this package are now warmed by the hook at `parquet-geometry.test.ts:168-178`.

## Verification

- `tsc --noEmit -p packages/export/tsconfig.json` — exit 0.
- Full `@ifc-lite/export` suite: 16 runs across the three load conditions, all exit 0, 470 passed / 30 skipped.
- **Mutation check**: replacing the first expected value with a sentinel fails the test as expected (`expected '5.E-8' to be 'MUTATION_PROBE'`, exit 1), proving the hoisted static import resolves to the real function and the assertions still bite. Reverted.
- `packages/export` has no lint script, so there is nothing to lint.
