### PR TITLE
fix(mcp-playground): answer viewer tools terminally when the device has no WebGL

### DIFF
--- a/apps/viewer/src/components/mcp/PlaygroundViewer.tsx
+++ b/apps/viewer/src/components/mcp/PlaygroundViewer.tsx
@@ -51,6 +51,17 @@ export interface ViewerStatus {
   loaded: boolean;
   meshCount: number;
   selection: SelectionHit[];
+  /**
+   * The device refused a WebGL context, so the canvas never mounted (#2401).
+   *
+   * This is the difference between "not loaded yet" and "never will be":
+   * `loaded` is false in both cases, but the verdict behind this flag is
+   * latched for the whole session (`lib/webgl-capability.ts`), so no amount of
+   * waiting or re-opening ever turns `loaded` true. The dispatcher branches on
+   * it so the agent-facing answer can be terminal instead of the retry hint an
+   * agent would otherwise follow forever (#2412).
+   */
+  webglUnavailable: boolean;
 }
 
 export type ColorTuple = [number, number, number, number];
@@ -194,6 +205,7 @@ export const PlaygroundViewer = forwardRef<ViewerController, PlaygroundViewerPro
         loaded: sceneHandleRef.current !== null,
         meshCount,
         selection: sceneHandleRef.current?.getSelection() ?? [],
+        webglUnavailable: unavailable !== null,
       }),
       colorize: (args) => sceneHandleRef.current?.colorize(args) ?? { count: 0 },
       isolate: (args) => sceneHandleRef.current?.isolate(args) ?? { count: 0 },
@@ -209,7 +221,11 @@ export const PlaygroundViewer = forwardRef<ViewerController, PlaygroundViewerPro
       setOnSelectionChange: (h) => sceneHandleRef.current?.setOnSelectionChange(h),
       subscribeSelection: (h) => sceneHandleRef.current?.subscribeSelection(h) ?? (() => undefined),
     }),
-    [meshCount],
+    // `unavailable` belongs here with `meshCount`: the handle is a frozen
+    // closure, so leaving it out would hand the dispatcher a controller that
+    // reports `webglUnavailable: false` forever — the exact loop #2412 fixes,
+    // just moved one level down.
+    [meshCount, unavailable],
   );
 
   // Load geometry whenever the model changes (and the component is mounted —

--- a/apps/viewer/src/components/mcp/mcp-three-surfaces.webgl.test.tsx
+++ b/apps/viewer/src/components/mcp/mcp-three-surfaces.webgl.test.tsx
@@ -29,7 +29,7 @@ import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { GeometryProcessor } from '@ifc-lite/geometry';
 import { HeroScene } from './HeroScene.js';
-import { PlaygroundViewer } from './PlaygroundViewer.js';
+import { PlaygroundViewer, type ViewerController } from './PlaygroundViewer.js';
 import { parsePlaygroundModel, type LoadedPlaygroundModel } from './playground-dispatcher.js';
 import { resetThreeWebglSupportForTests, getThreeWebglVerdict } from './three-webgl-support.js';
 
@@ -132,6 +132,28 @@ describe('PlaygroundViewer on a device that refuses a WebGL context', () => {
     assert.match(text, /queries/i);
     // The idle phase panel must not double up underneath the fallback.
     assert.doesNotMatch(text, /load a model first/);
+  });
+
+  it('tells the agent-facing controller that WebGL is gone, after the re-render (#2412)', async () => {
+    // The wiring the dispatcher's terminal answers stand on. Two failure modes
+    // it has to survive, and only the second is obvious:
+    //
+    //   1. the flag is never exposed at all;
+    //   2. the flag is exposed but `useImperativeHandle` does not list
+    //      `unavailable` in its deps — the handle is a frozen closure, so it
+    //      would keep answering `false` from the FIRST render, when the mount
+    //      effect had not run yet. That is the #2412 loop moved one level down,
+    //      and it is invisible unless the assertion happens after the commit
+    //      that sets the state, which is what the async `act` below guarantees.
+    const ref = { current: null } as React.RefObject<ViewerController | null>;
+    await act(async () => {
+      root.render(<PlaygroundViewer model={null} ref={ref} />);
+    });
+
+    assert.ok(ref.current, 'the controller must attach even when the canvas does not');
+    const status = ref.current.status();
+    assert.equal(status.webglUnavailable, true, 'the controller must report the device refusal');
+    assert.equal(status.loaded, false, 'and it is emphatically not loaded');
   });
 
   it('starts no geometry work on the INITIAL refusal, not just afterwards', async () => {

--- a/apps/viewer/src/components/mcp/playground-dispatcher.ts
+++ b/apps/viewer/src/components/mcp/playground-dispatcher.ts
@@ -71,6 +71,10 @@ import { createBCFFromClashResult } from '@ifc-lite/clash/bcf';
 import { CATALOG, paramsFor } from './data';
 import type { CatalogTool } from './types';
 import type { ViewerController, ColorTuple } from './PlaygroundViewer';
+// Value import, but a deliberately cheap one: `three-webgl-support` pulls in
+// neither three.js nor React (see its header), so reading the latched verdict
+// costs the dispatcher nothing at import time.
+import { getThreeWebglVerdict } from './three-webgl-support';
 import { playgroundFiles } from './playground-files';
 import { playgroundUploads } from './playground-uploads';
 import { sanitizeFilename } from '../../lib/export/download';
@@ -215,7 +219,66 @@ type ToolImplResult = {
 };
 type ToolImpl = (model: LoadedPlaygroundModel, args: Record<string, unknown>, ctx: DispatchContext) => Promise<ToolImplResult>;
 
+/**
+ * The single agent-facing answer for a device that refuses WebGL (#2412).
+ *
+ * `isLoaded()` is false in two very different situations — geometry is still
+ * processing, or the canvas never mounted at all — and every viewer answer
+ * used to describe only the first. On a GPU-less device that produced a loop
+ * with no exit: `viewer_open` said "call viewer_status in a moment",
+ * `viewer_status` said "mounted but no geometry yet", and every other viewer
+ * tool said "call viewer_open first".
+ *
+ * So this text is deliberately terminal: no "shortly", no "try again", no
+ * reload hint. The verdict behind `webglUnavailable` is latched for the
+ * session (`lib/webgl-capability.ts`) and the refusal is a property of the
+ * device, so any retry wording would just relocate the loop.
+ */
+const NO_WEBGL_MESSAGE =
+  'This device cannot provide a WebGL context, so the inline 3D viewer never mounts. '
+  + 'Every viewer_* tool is unavailable for the rest of this session. '
+  + 'Parsing, queries, validation, BCF and export are unaffected.';
+
+const NO_WEBGL_HINT = 'Answer with the non-viewer tools; no 3D tool can succeed on this device.';
+
+/**
+ * Has three.js given up on WebGL for this session?
+ *
+ * Two sources, because neither alone covers the loop:
+ *
+ *   - the session latch (`getThreeWebglVerdict`) answers even when no viewer
+ *     is attached. That case is not hypothetical and is the second live
+ *     instance of this defect: `McpPlayground` unmounts `PlaygroundViewer`
+ *     whenever the panel collapses, which nulls the controller ref. Without
+ *     the latch, collapsing the panel after a failed mount would put every
+ *     viewer tool back on "Call viewer_open first" — the same loop, one user
+ *     click later. The latch is module-scope and never re-probes, so it
+ *     survives that remount by design.
+ *   - the mounted controller's `webglUnavailable`, which is the component's
+ *     own truth and what `viewer_status` reports in its structured payload.
+ *
+ * A `null` verdict with no viewer is deliberately NOT this state: it means
+ * nothing has tried yet, and `viewer_open` legitimately still has work to do.
+ * Nothing here probes; a probe would burn one of the page's ~16 context slots
+ * and, worse, latch the verdict before `useThreeScene` ever runs — which is
+ * exactly what suppresses that hook's once-per-session report to error
+ * tracking (`startThreeScene` omits `error` when the latch already knew). The
+ * dispatcher reads the verdict; it never manufactures one.
+ */
+function isWebglUnavailable(ctx: DispatchContext): boolean {
+  const latched = getThreeWebglVerdict();
+  if (latched && !latched.supported) return true;
+  return ctx.viewer?.status().webglUnavailable === true;
+}
+
 function requireViewer(ctx: DispatchContext): ViewerController {
+  if (isWebglUnavailable(ctx)) {
+    throw new ToolExecutionError({
+      code: ToolErrorCode.UNSUPPORTED_OPERATION,
+      message: NO_WEBGL_MESSAGE,
+      hint: NO_WEBGL_HINT,
+    });
+  }
   if (!ctx.viewer || !ctx.viewer.isLoaded()) {
     throw new ToolExecutionError({
       code: ToolErrorCode.UNSUPPORTED_OPERATION,
@@ -1226,7 +1289,12 @@ const IMPLS: Record<string, ToolImpl> = {
   },
 
   // ── Viewer (drives the inline Three.js panel) ──────────────────────────
-  async viewer_ask(_m, args) {
+  async viewer_ask(_m, args, ctx) {
+    // Asking the user for permission to open a panel that cannot exist spends
+    // a turn and then lands on viewer_open's refusal anyway.
+    if (isWebglUnavailable(ctx)) {
+      return { text: NO_WEBGL_MESSAGE, structured: { suggestedTool: null, webglUnavailable: true } };
+    }
     const reason = String(args.reason ?? '');
     return {
       text: `Ask the user: "I'd like to open the inline 3D viewer${reason ? ` to ${reason}` : ''}. May I?" If they agree, call viewer_open.`,
@@ -1235,6 +1303,13 @@ const IMPLS: Record<string, ToolImpl> = {
   },
 
   async viewer_open(_m, _args, ctx) {
+    // Checked before the panel is poked. Opening it again on a device that has
+    // already refused a context just re-renders the same fallback, and the
+    // optimistic "geometry is processing" text below is what sent the agent
+    // round the loop in the first place.
+    if (isWebglUnavailable(ctx)) {
+      return { text: NO_WEBGL_MESSAGE, structured: { open: false, pending: false, webglUnavailable: true } };
+    }
     if (ctx.openViewerPanel) ctx.openViewerPanel();
     if (ctx.viewer && ctx.viewer.isLoaded()) {
       const status = ctx.viewer.status();
@@ -1258,9 +1333,21 @@ const IMPLS: Record<string, ToolImpl> = {
   },
 
   async viewer_status(_m, _args, ctx) {
-    const v = ctx.viewer;
-    if (!v) return { text: 'No viewer attached.', structured: { open: false } };
-    const s = v.status();
+    const s = ctx.viewer?.status() ?? null;
+    // The third arm of the #2412 loop, and the one `viewer_open` sends the
+    // agent to: "mounted but no geometry yet" is literally true but reads as
+    // "wait", and here the wait never ends.
+    //
+    // Ahead of the null check, not after it, because "No viewer attached." is
+    // the answer a COLLAPSED panel gives — and once the panel has collapsed the
+    // session latch is the only thing left that remembers why re-opening it
+    // cannot help. One check covers both, since `isWebglUnavailable` already
+    // reads the controller flag; a second branch on `s.webglUnavailable` below
+    // would be unreachable, which a mutation run confirmed.
+    if (isWebglUnavailable(ctx)) {
+      return { text: NO_WEBGL_MESSAGE, structured: s ?? { open: false, loaded: false, webglUnavailable: true } };
+    }
+    if (!s) return { text: 'No viewer attached.', structured: { open: false } };
     return {
       text: s.loaded ? `Viewer open · ${s.meshCount} meshes · ${s.selection.length} picked.` : 'Viewer panel mounted but no geometry yet.',
       structured: s,

--- a/apps/viewer/src/components/mcp/playground-dispatcher.ts
+++ b/apps/viewer/src/components/mcp/playground-dispatcher.ts
@@ -1328,8 +1328,20 @@ const IMPLS: Record<string, ToolImpl> = {
     // The panel-collapse in this v1 isn't agent-controllable (the user owns
     // chrome). We surface a friendly status instead of pretending we
     // dismantled the canvas.
+    //
+    // Deliberately NOT given the #2412 treatment, unlike every other viewer
+    // tool. Three facts decide it: this answer is a constant (it reads no
+    // viewer state at all), it never claims success (`closed: false`), and it
+    // routes the agent to the USER rather than to another viewer tool — so it
+    // cannot be an arm of the loop. And the action it describes still works on
+    // a GPU-less device: `ViewerPanel` renders its toggle button OUTSIDE the
+    // `open &&` branch, so the chevron is there with or without a context, and
+    // collapsing a panel that is showing the degraded fallback is a real thing
+    // the user may want. Answering "this device cannot do WebGL" to a request
+    // about hiding a panel would be the one place where the terminal message
+    // refused something that is still available.
     void ctx;
-    return { text: 'Inline viewer panel is user-controlled in the playground; toggle it from the chevron above the canvas.', structured: { closed: false, note: 'user-toggle' } };
+    return { text: 'Inline viewer panel is user-controlled in the playground; toggle it from the chevron above the 3D viewer panel.', structured: { closed: false, note: 'user-toggle' } };
   },
 
   async viewer_status(_m, _args, ctx) {

--- a/apps/viewer/src/components/mcp/playground-dispatcher.webgl.test.ts
+++ b/apps/viewer/src/components/mcp/playground-dispatcher.webgl.test.ts
@@ -1,0 +1,284 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The playground agent tools on a device with no WebGL context (#2412).
+ *
+ * #2401 stopped the missing context from taking the whole `/mcp` page down,
+ * and left the panel painting a fallback. What it did not do is tell the
+ * AGENT, and the agent is what drives these tools. Every viewer answer was
+ * written for a viewer that is merely not ready yet:
+ *
+ *   viewer_open    "Geometry is processing — call viewer_status in a moment"
+ *   viewer_status  "Viewer panel mounted but no geometry yet."
+ *   everything else "Viewer is not open. Call viewer_open first."
+ *
+ * Each one points at the next, and on this device none of them can ever come
+ * true, so the model ping-pongs until the user gives up. These tests pin the
+ * exit: once three.js has refused a context, every viewer tool says so
+ * TERMINALLY — no "in a moment", no "try again", no reload.
+ *
+ * Two independent sources have to work, because the loop has two shapes:
+ *   • a mounted controller reporting `webglUnavailable`, and
+ *   • the session latch alone, with NO controller attached — which is the
+ *     state `McpPlayground` is in whenever the panel is collapsed, since it
+ *     unmounts `PlaygroundViewer` and nulls the ref.
+ *
+ * The latch is driven through the production entry point (`startThreeScene`
+ * with a factory that throws three's own context error), not by poking module
+ * state, so "the verdict is latched" is measured the way production reaches it.
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { ToolErrorCode } from '@ifc-lite/mcp/browser';
+import {
+  dispatch,
+  parsePlaygroundModel,
+  type DispatchContext,
+  type LoadedPlaygroundModel,
+} from './playground-dispatcher.js';
+import type { ViewerController, SelectionHit } from './PlaygroundViewer.js';
+import { startThreeScene, resetThreeWebglSupportForTests } from './three-webgl-support.js';
+
+/** Words that keep an agent in the loop. None may appear in a terminal answer. */
+const RETRY_VOCABULARY = ['in a moment', 'moment', 'shortly', 'try again', 'reload', 'wait', 'processing', 'not ready', 'yet'];
+
+function assertTerminal(text: string, label: string): void {
+  const lower = text.toLowerCase();
+  for (const word of RETRY_VOCABULARY) {
+    assert.equal(lower.includes(word), false, `${label} must not tell the agent to ${word}: ${text}`);
+  }
+  assert.equal(lower.includes('webgl'), true, `${label} must name the actual cause: ${text}`);
+}
+
+/**
+ * A viewer controller whose three states are all expressible.
+ *
+ * Deliberately a switchable record rather than a "broken viewer" stub: a fake
+ * that can only say `webglUnavailable: true` would make every assertion below
+ * pass no matter what the dispatcher does. The control tests at the bottom
+ * drive the OTHER two states through the same fake, so its ability to produce
+ * a passing viewer and a still-loading viewer is proven, not assumed.
+ */
+function fakeViewer(state: {
+  loaded: boolean;
+  webglUnavailable: boolean;
+  selection?: SelectionHit[];
+}): ViewerController & { calls: string[] } {
+  const calls: string[] = [];
+  const record = <T>(name: string, value: T): T => {
+    calls.push(name);
+    return value;
+  };
+  return {
+    calls,
+    isLoaded: () => state.loaded,
+    status: () => ({
+      loaded: state.loaded,
+      meshCount: state.loaded ? 7 : 0,
+      selection: state.selection ?? [],
+      webglUnavailable: state.webglUnavailable,
+    }),
+    colorize: () => record('colorize', { count: 3 }),
+    isolate: () => record('isolate', { count: 2 }),
+    hide: () => record('hide', { count: 1 }),
+    show: () => record('show', { count: 1 }),
+    reset: () => { calls.push('reset'); },
+    flyTo: () => record('flyTo', { count: 1 }),
+    setSection: () => { calls.push('setSection'); },
+    clearSection: () => { calls.push('clearSection'); },
+    colorByStorey: () => record('colorByStorey', { groups: 2 }),
+    colorByProperty: () => record('colorByProperty', { legend: [] }),
+    getSelection: () => record('getSelection', state.selection ?? []),
+    setOnSelectionChange: () => { calls.push('setOnSelectionChange'); },
+    subscribeSelection: () => {
+      calls.push('subscribeSelection');
+      return () => undefined;
+    },
+  };
+}
+
+/** Stands in for the container React hands the scene factory. */
+const CONTAINER = {} as HTMLElement;
+
+/**
+ * Latch the session verdict the way production does: three's constructor throws
+ * its context error, `startThreeScene` recognises it and marks the gate.
+ *
+ * (The probe path would need a DOM; this one is the failure actually seen in
+ * the field on the playground, and it exercises the same latch.)
+ */
+function latchNoWebgl(): void {
+  const started = startThreeScene(CONTAINER, () => {
+    throw new Error('THREE.WebGLRenderer: Error creating WebGL context.');
+  });
+  assert.equal(started.ok, false, 'precondition: the scene must have failed to start');
+}
+
+/**
+ * One parse for the file: none of these tools touch geometry or mutate the
+ * model, and re-parsing per test would only pay the WASM boot again.
+ */
+let model: LoadedPlaygroundModel;
+let parsed: Promise<LoadedPlaygroundModel> | null = null;
+
+beforeEach(async () => {
+  resetThreeWebglSupportForTests();
+  if (!parsed) {
+    const ifc = [
+      'ISO-10303-21;', 'HEADER;', "FILE_DESCRIPTION((''),'2;1');",
+      "FILE_NAME('','',(''),(''),'','','');", "FILE_SCHEMA(('IFC4'));", 'ENDSEC;',
+      'DATA;', "#1=IFCWALL('2412WebglLoopFixture0',$,'Wall A',$,$,$,$,$,.STANDARD.);", 'ENDSEC;',
+      'END-ISO-10303-21;', '',
+    ].join('\n');
+    const bytes = new TextEncoder().encode(ifc);
+    parsed = parsePlaygroundModel(bytes.buffer as ArrayBuffer, 'webgl-loop.ifc');
+  }
+  model = await parsed;
+});
+
+afterEach(() => {
+  resetThreeWebglSupportForTests();
+});
+
+describe('viewer tools on a device that refuses WebGL (#2412)', () => {
+  it('answers viewer_open terminally instead of promising geometry is processing', async () => {
+    latchNoWebgl();
+    let opened = 0;
+    const ctx: DispatchContext = {
+      viewer: fakeViewer({ loaded: false, webglUnavailable: true }),
+      openViewerPanel: () => { opened += 1; },
+    };
+
+    const res = await dispatch(model, 'viewer_open', {}, ctx);
+
+    assertTerminal(res.text, 'viewer_open');
+    assert.equal((res.structured as { open: boolean }).open, false);
+    assert.equal(opened, 0, 'must not re-open a panel that can only paint its fallback');
+  });
+
+  it('answers viewer_status terminally instead of "mounted but no geometry yet"', async () => {
+    latchNoWebgl();
+    const ctx: DispatchContext = { viewer: fakeViewer({ loaded: false, webglUnavailable: true }) };
+
+    const res = await dispatch(model, 'viewer_status', {}, ctx);
+
+    assertTerminal(res.text, 'viewer_status');
+    assert.equal((res.structured as { webglUnavailable: boolean }).webglUnavailable, true);
+  });
+
+  it('answers viewer_ask terminally instead of spending a user turn on consent', async () => {
+    latchNoWebgl();
+    const ctx: DispatchContext = { viewer: fakeViewer({ loaded: false, webglUnavailable: true }) };
+
+    const res = await dispatch(model, 'viewer_ask', { reason: 'highlight the walls' }, ctx);
+
+    assertTerminal(res.text, 'viewer_ask');
+    assert.equal((res.structured as { suggestedTool: string | null }).suggestedTool, null,
+      'suggesting viewer_open here is what closes the loop');
+  });
+
+  it('fails every action tool terminally instead of sending the agent back to viewer_open', async () => {
+    latchNoWebgl();
+    const ctx: DispatchContext = { viewer: fakeViewer({ loaded: false, webglUnavailable: true }) };
+
+    // The whole requireViewer family, not one representative: the reported arm
+    // was ONE of these and the rest share the message verbatim.
+    for (const tool of [
+      'viewer_colorize', 'viewer_isolate', 'viewer_hide', 'viewer_show', 'viewer_reset',
+      'viewer_fly_to', 'viewer_set_section', 'viewer_clear_section', 'viewer_color_by_storey',
+      'viewer_color_by_property', 'viewer_get_selection', 'viewer_describe_selection',
+    ]) {
+      const res = await dispatch(model, tool, { type: 'IfcWall', color: '#ff0000', property: 'Name' }, ctx);
+      assert.equal(res.isError, true, `${tool} must fail`);
+      assert.equal(res.errorCode, ToolErrorCode.UNSUPPORTED_OPERATION, `${tool} error code`);
+      assertTerminal(res.text, tool);
+      assert.equal(res.text.includes('viewer_open'), false, `${tool} must not point back at viewer_open`);
+    }
+  });
+
+  it('refuses viewer_wait_for_selection immediately instead of blocking on a canvas nobody can click', async () => {
+    latchNoWebgl();
+    const ctx: DispatchContext = { viewer: fakeViewer({ loaded: false, webglUnavailable: true }) };
+
+    const t0 = Date.now();
+    const res = await dispatch(model, 'viewer_wait_for_selection', { timeout_ms: 60_000 }, ctx);
+
+    assert.equal(res.isError, true);
+    assertTerminal(res.text, 'viewer_wait_for_selection');
+    assert.ok(Date.now() - t0 < 2_000, 'must not sit through its timeout waiting for a click that cannot happen');
+  });
+
+  it('stays terminal with NO controller attached — the collapsed-panel shape of the same loop', async () => {
+    // `McpPlayground` unmounts `PlaygroundViewer` when the panel collapses, so
+    // `ctx.viewer` is null again and the controller flag is gone. Only the
+    // session latch remembers, and it must be enough on its own.
+    latchNoWebgl();
+    const ctx: DispatchContext = { viewer: null, openViewerPanel: () => undefined };
+
+    const status = await dispatch(model, 'viewer_status', {}, ctx);
+    assertTerminal(status.text, 'viewer_status (no controller)');
+
+    const open = await dispatch(model, 'viewer_open', {}, ctx);
+    assertTerminal(open.text, 'viewer_open (no controller)');
+
+    const isolate = await dispatch(model, 'viewer_isolate', { type: 'IfcWall' }, ctx);
+    assert.equal(isolate.isError, true);
+    assertTerminal(isolate.text, 'viewer_isolate (no controller)');
+  });
+
+  it('stays terminal with NO latch — a controller that reports the refusal is enough on its own', async () => {
+    // The mirror of the case above: the two sources are ORed, so neither may
+    // be load-bearing for the other's scenario.
+    const ctx: DispatchContext = { viewer: fakeViewer({ loaded: false, webglUnavailable: true }) };
+
+    const res = await dispatch(model, 'viewer_colorize', { type: 'IfcWall', color: '#ff0000' }, ctx);
+
+    assert.equal(res.isError, true);
+    assertTerminal(res.text, 'viewer_colorize (controller only)');
+  });
+});
+
+describe('the WebGL-capable paths this must not disturb (#2412 controls)', () => {
+  it('still tells the agent to call viewer_open when the panel is merely closed', async () => {
+    // The pre-existing state, through the same fake: not loaded, but nothing
+    // has refused a context. This answer SHOULD point at viewer_open — turning
+    // it terminal would be its own dead end, on a device where 3D works.
+    const ctx: DispatchContext = { viewer: fakeViewer({ loaded: false, webglUnavailable: false }) };
+
+    const res = await dispatch(model, 'viewer_isolate', { type: 'IfcWall' }, ctx);
+
+    assert.equal(res.isError, true);
+    assert.equal(res.errorCode, ToolErrorCode.UNSUPPORTED_OPERATION);
+    assert.ok(res.text.includes('viewer_open'), `the closed-panel answer must still route to viewer_open: ${res.text}`);
+    assert.equal(res.text.toLowerCase().includes('webgl'), false, 'a closed panel is not a device refusal');
+  });
+
+  it('still reports a mounted, loaded viewer as ready', async () => {
+    const viewer = fakeViewer({ loaded: true, webglUnavailable: false });
+    const ctx: DispatchContext = { viewer };
+
+    const status = await dispatch(model, 'viewer_status', {}, ctx);
+    assert.ok(status.text.includes('7 meshes'), `expected the live status line, got: ${status.text}`);
+    assert.equal((status.structured as { loaded: boolean }).loaded, true);
+
+    const colorize = await dispatch(model, 'viewer_colorize', { type: 'IfcWall', color: '#ff0000' }, ctx);
+    assert.equal(colorize.isError, false);
+    assert.ok(viewer.calls.includes('colorize'), 'the working path must still reach the controller');
+  });
+
+  it('still opens the panel on a device whose verdict is simply unknown', async () => {
+    // Nothing has probed yet (the panel has never been expanded). `viewer_open`
+    // has real work to do here and must not be short-circuited.
+    let opened = 0;
+    const ctx: DispatchContext = { viewer: null, openViewerPanel: () => { opened += 1; } };
+
+    const res = await dispatch(model, 'viewer_open', {}, ctx);
+
+    assert.equal(opened, 1, 'an unknown verdict must still mount the panel');
+    assert.equal((res.structured as { open: boolean }).open, true);
+  });
+});

--- a/apps/viewer/src/components/mcp/playground-dispatcher.webgl.test.ts
+++ b/apps/viewer/src/components/mcp/playground-dispatcher.webgl.test.ts
@@ -131,7 +131,9 @@ beforeEach(async () => {
     const ifc = [
       'ISO-10303-21;', 'HEADER;', "FILE_DESCRIPTION((''),'2;1');",
       "FILE_NAME('','',(''),(''),'','','');", "FILE_SCHEMA(('IFC4'));", 'ENDSEC;',
-      'DATA;', "#1=IFCWALL('2412WebglLoopFixture0',$,'Wall A',$,$,$,$,$,.STANDARD.);", 'ENDSEC;',
+      // 22 characters: an IfcGloballyUniqueId is a base64-encoded UUID, and a
+      // fixture with a short one is what the next fixture gets copied from.
+      'DATA;', "#1=IFCWALL('2412WebglLoopFixture00',$,'Wall A',$,$,$,$,$,.STANDARD.);", 'ENDSEC;',
       'END-ISO-10303-21;', '',
     ].join('\n');
     const bytes = new TextEncoder().encode(ifc);
@@ -228,6 +230,34 @@ describe('viewer tools on a device that refuses WebGL (#2412)', () => {
     const isolate = await dispatch(model, 'viewer_isolate', { type: 'IfcWall' }, ctx);
     assert.equal(isolate.isError, true);
     assertTerminal(isolate.text, 'viewer_isolate (no controller)');
+  });
+
+  it('leaves viewer_close answerable — it is not an arm of the loop (#2436 review)', async () => {
+    // The one viewer tool deliberately left alone, pinned so the decision is
+    // not re-litigated. It reads no viewer state, never claims success
+    // (`closed: false`), and points at the USER rather than another viewer
+    // tool. What it describes still works here: `ViewerPanel` renders its
+    // toggle button outside the `open &&` branch, so the chevron exists with
+    // or without a context, and collapsing a panel showing the degraded
+    // fallback is a real thing to want. This test fails if someone later makes
+    // it route back into viewer_open/viewer_status, which WOULD be a loop arm.
+    latchNoWebgl();
+    const ctx: DispatchContext = { viewer: fakeViewer({ loaded: false, webglUnavailable: true }) };
+
+    const res = await dispatch(model, 'viewer_close', {}, ctx);
+
+    assert.equal(res.isError, false, 'hiding a panel is not blocked by a missing GPU');
+    // The load-bearing pair: without these the review's proposed change (return
+    // NO_WEBGL_MESSAGE here) passes this test, which would make it a test that
+    // cannot fail on the only axis it exists for. Verified by mutation.
+    assert.equal(res.text.toLowerCase().includes('webgl'), false,
+      'the device verdict is not an answer to "hide the panel" — the user can still collapse it');
+    assert.equal((res.structured as { note: string }).note, 'user-toggle',
+      'the agent must still learn who owns the panel');
+    assert.equal((res.structured as { closed: boolean }).closed, false, 'it must not claim to have closed anything');
+    assert.equal(res.text.includes('viewer_open'), false, 'routing back to viewer_open would make this a loop arm');
+    assert.equal(res.text.includes('viewer_status'), false, 'same for viewer_status');
+    assert.equal(res.text.toLowerCase().includes('canvas'), false, 'there is no canvas on this device to point at');
   });
 
   it('stays terminal with NO latch — a controller that reports the refusal is enough on its own', async () => {


### PR DESCRIPTION
On a device that refuses a WebGL context, the playground agent tools looped
forever. #2401 stopped the missing context from taking the `/mcp` page down and
left the panel painting a fallback, but nothing told the **agent**, and every
viewer answer was written for a viewer that is merely not ready yet:

| tool | answer before |
| --- | --- |
| `viewer_open` | "Geometry is processing — call `viewer_status` in a moment" |
| `viewer_status` | "Viewer panel mounted but no geometry yet." |
| every other viewer tool | "Viewer is not open. Call `viewer_open` first." |

Each points at the next, none can ever come true on that device, so the model
ping-pongs until the user gives up.

## The fix

`ViewerStatus` gains `webglUnavailable`, and the dispatcher reads it next to
the session-latched verdict in `three-webgl-support`:

```ts
function isWebglUnavailable(ctx: DispatchContext): boolean {
  const latched = getThreeWebglVerdict();
  if (latched && !latched.supported) return true;
  return ctx.viewer?.status().webglUnavailable === true;
}
```

Both sources are load-bearing. `McpPlayground` unmounts `PlaygroundViewer`
whenever the panel collapses, which nulls the controller ref — without the
latch, one user click puts every tool back on "Call `viewer_open` first", i.e.
the same loop one level over. Conversely the controller flag is what
`viewer_status` reports in its structured payload. Each term is killed by its
own mutation (see below).

The answer is deliberately terminal — no "shortly", no "try again", no reload
hint. The refusal is a property of the device and the verdict is latched for
the session, so any retry wording just relocates the loop.

Nothing probes from the dispatcher. A probe would burn one of the page's ~16
context slots and, worse, latch the verdict before `useThreeScene` runs — which
is exactly what suppresses that hook's once-per-session report to error
tracking (`startThreeScene` omits `error` when the latch already knew).

## Sibling sweep

Fixed the class, not the reported arm:

- `requireViewer` — all twelve action tools, plus `viewer_wait_for_selection`,
  which otherwise blocked for its full 60s timeout waiting for a click on a
  canvas that does not exist.
- `viewer_open` — and it no longer re-opens a panel that can only repaint its
  fallback.
- `viewer_status` — including the `!viewer` branch ("No viewer attached."),
  which is what a collapsed panel answers.
- `viewer_ask` — would otherwise spend a whole user turn asking consent to open
  a panel that cannot exist.
- `useImperativeHandle` deps get `unavailable`: the handle is a frozen closure,
  so omitting it would report `webglUnavailable: false` forever — the same
  defect one level down.

Nothing else in the dispatcher derives a "try again" answer from `isLoaded()`;
`packages/mcp`'s `viewer_open` is the stdio server's HTTP viewer and has no
browser WebGL dependency.

## Verification

- New `playground-dispatcher.webgl.test.ts` (10 tests) drives the latch through
  the **production** entry point (`startThreeScene` with three's own context
  error), asserts no retry vocabulary survives in any answer, and includes
  three controls: a closed panel must still route to `viewer_open`, a loaded
  viewer must still work, and an unknown verdict must still mount the panel.
  The fake controller is switchable across all three states, so it is proven
  able to express both the broken and the pre-existing states.
- `mcp-three-surfaces.webgl.test.tsx` gains the wiring test: the controller
  reports `webglUnavailable` **after** the commit that sets it (this is what
  makes the deps-array defect visible).
- Mutation-checked, each mutation verified on disk before the run: **10
  mutations, 10 killed**, control green before and after. Two of them only
  count because something was changed in response:
  - a second `s.webglUnavailable` branch inside `viewer_status` **survived**,
    proving it unreachable — it was **deleted** rather than left in as a line
    no test could fail on;
  - the `viewer_close` decision test initially **passed** under the mutation
    that applies the review's proposal, i.e. it pinned nothing on the axis it
    existed for; it was strengthened until both directions kill it.
- `apps/viewer`: `tsc --noEmit` exit 0; full suite 3337 pass / 0 fail (exit
  code captured directly, not through a pipe).

## Review round 1

- Fixture `IfcGloballyUniqueId` was 21 characters; corrected to 22.
- `viewer_close` was proposed for the same terminal treatment and **declined on
  the code**: its answer is a constant (`void ctx`), it never claims success
  (`closed: false`), it routes the agent to the user rather than to another
  viewer tool, and the action it describes still works here — `ViewerPanel`
  renders its toggle button outside the `open &&` branch, so the chevron exists
  with or without a context. Its wording was corrected ("the canvas" -> "the 3D
  viewer panel") and the decision is pinned by a mutation-checked test. Full
  reasoning in the review-round comment below.

Fixes #2412.
