### PR TITLE
refactor(renderer): move the overlay layer and the section-plane frame out of index.ts

### DIFF
--- a/.changeset/renderer-index-split-overlays-section-plane.md
+++ b/.changeset/renderer-index-split-overlays-section-plane.md
@@ -1,0 +1,15 @@
+---
+"@ifc-lite/renderer": patch
+---
+
+Internal file split: move the overlay layer and the per-frame section-plane resolution out of `index.ts`, which was 3946 lines against the ~400-line house rule (issue #2425).
+
+- `renderer-overlays.ts` (`RendererOverlays`) now owns the section-plane gizmo, the 2D section drawing / cut cap, and the standalone 3D line overlays (IfcAnnotation lines, IfcAlignment centrelines, IfcGridAxis, the DXF reference layer, and the focused clash's box / contact lines). They were already one unit in everything but location: created together in `init()`, destroyed together in `destroy()`, drawn consecutively at the tail of the render pass.
+- `renderer-symbolic-overlays.ts` (`SymbolicOverlays`) owns the symbolic fill + text pipelines, which are a genuinely separate pair of GPU objects sharing no state with the `Section2DOverlayRenderer` behind the cap and the line layers. `RendererOverlays` composes it and keeps the draw order, which is the one thing the two families share.
+- `render-section-plane.ts` (`resolveSectionPlaneFrame`) owns the per-frame clip-plane resolution: the bounds aggregation the section slider is expressed in, the terrain-clip and explicit-plane branches, and the one-shot diagnostic.
+
+`index.ts` goes 3946 -> 3499 lines.
+
+**No behaviour change and no public API change.** Every moved method keeps a one-line delegate on `Renderer`, so the exported surface is byte-identical — `scripts/api-surface.json` needs no update. The move was verified against `main` by normalised diff (indentation, comments and the `this.` prefix stripped): the section-plane body, the overlay draw body, the upload facade and the camera-basis math all compare identical, and the nine-call overlay draw sequence is unchanged. The renderer suite stays at 494 tests with the same 111 suites.
+
+This is a `patch` because consumers do receive different built code even though nothing they can call has changed.

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -17,7 +17,6 @@ export { Picker } from './picker.js';
 export { MathUtils } from './math.js';
 export { SectionPlaneRenderer } from './section-plane.js';
 export { Section2DOverlayRenderer } from './section-2d-overlay.js';
-import { aabbEdgeLineList } from './aabb-edges.js';
 
 // IfcAnnotation overlay pipelines (3D world-space). Self-contained — caller
 // passes a GPUDevice + presentation format and invokes `.render(pass, viewProj)`
@@ -110,16 +109,14 @@ import type {
     ContactShadingQuality,
     SeparationLinesQuality,
 } from './types.js';
-import { SectionPlaneRenderer } from './section-plane.js';
 import { packClipBox } from './clip-box.js';
-import { Section2DOverlayRenderer, type CutPolygon2D, type DrawingLine2D } from './section-2d-overlay.js';
-import {
-  SymbolicFillPipeline,
-  SymbolicTextPipeline,
-  type SymbolicFillInput,
-  type SymbolicTextInput,
+import type { CutPolygon2D, DrawingLine2D } from './section-2d-overlay.js';
+import type {
+  SymbolicFillInput,
+  SymbolicTextInput,
 } from './symbolic-overlay-pipelines.js';
-import { DEFAULT_CAP_STYLE, HATCH_PATTERN_IDS } from './section-cap-style.js';
+import { RendererOverlays } from './renderer-overlays.js';
+import { resolveSectionPlaneFrame } from './render-section-plane.js';
 import { Raycaster, type Intersection } from './raycaster.js';
 import { SnapDetector, type SnapTarget, type SnapOptions, type EdgeLockInput, type MagneticSnapResult } from './snap-detector.js';
 import { PickingManager } from './picking-manager.js';
@@ -230,15 +227,21 @@ export class Renderer {
     private scene: Scene;
     private picker: Picker | null = null;
     private canvas: HTMLCanvasElement;
-    private sectionPlaneRenderer: SectionPlaneRenderer | null = null;
-    private section2DOverlayRenderer: Section2DOverlayRenderer | null = null;
-    // Overlay/section-cut line colour, kept on the Renderer so it survives a
-    // pre-init call and a section2DOverlayRenderer re-creation (re-applied below).
-    private overlayLineColor: readonly [number, number, number, number] = [0, 0, 0, 1];
-    // IfcAnnotation overlay pipelines (issue #653). Created on `init()` once
-    // the device exists; nulled until then.
-    private symbolicFillPipeline: SymbolicFillPipeline | null = null;
-    private symbolicTextPipeline: SymbolicTextPipeline | null = null;
+    /**
+     * Section-plane gizmo, 2D section drawing/cap, and the standalone 3D line
+     * + symbolic annotation overlays (issue #2425). Created here rather than in
+     * `init()` so a pre-init `setOverlayLineColor` still lands — the GPU
+     * objects inside stay null until `init()` calls `overlays.init()`.
+     */
+    private readonly overlays = new RendererOverlays({
+        getModelBounds: () => this.getModelBounds(),
+        expandModelBoundsWithFlatVertices: (positions, stride) =>
+            this.expandModelBoundsWithFlatVertices(positions, stride),
+        syncCameraSceneBounds: () => {
+            if (this.modelBounds) this.camera.setSceneBounds(this.modelBounds);
+        },
+        requestRender: () => this.requestRender(),
+    });
     private postProcessor: PostProcessor | null = null;
     private readonly interactionEffects = new InteractionEffectsGovernor();
     private edlPass: EdlPass | null = null;
@@ -452,28 +455,7 @@ export class Renderer {
 
         this.pipeline = new RenderPipeline(this.device, width, height);
         this.picker = new Picker(this.device, width, height);
-        this.sectionPlaneRenderer = new SectionPlaneRenderer(
-            this.device.getDevice(),
-            this.device.getFormat(),
-            this.pipeline.getSampleCount()
-        );
-        this.section2DOverlayRenderer = new Section2DOverlayRenderer(
-            this.device.getDevice(),
-            this.device.getFormat(),
-            this.pipeline.getSampleCount()
-        );
-        // Re-apply any colour set before this (re)creation so it isn't lost.
-        this.section2DOverlayRenderer.setOverlayLineColor(this.overlayLineColor);
-        // IfcAnnotation overlay pipelines (issue #653). Share the device +
-        // presentation format AND the MSAA sample count + objectId attachment
-        // shape with the rest of the renderer so they composite into the same
-        // RGBA pass without WebGPU pass-compatibility validation errors.
-        this.symbolicFillPipeline = new SymbolicFillPipeline(
-            this.device.getDevice(),
-            this.device.getFormat(),
-            this.pipeline.getSampleCount(),
-        );
-        this.symbolicTextPipeline = new SymbolicTextPipeline(
+        this.overlays.init(
             this.device.getDevice(),
             this.device.getFormat(),
             this.pipeline.getSampleCount(),
@@ -1904,214 +1886,27 @@ export class Renderer {
             // This ensures each mesh has its own color data
             const allMeshes = [...opaqueMeshes, ...transparentMeshes];
 
-            // Calculate section plane parameters and model bounds
-            // Always calculate bounds when sectionPlane is provided (for preview and active mode)
-            let sectionPlaneData: { normal: [number, number, number]; distance: number; enabled: boolean } | undefined;
-
-            // Terrain clip: when Cesium overlay is active, clip model below terrain.
-            // Normal (0,-1,0) + distance (-clipY) clips where worldPos.y < clipY.
-            if (options.terrainClipY !== undefined && !options.sectionPlane?.enabled) {
-                sectionPlaneData = {
-                    normal: [0, -1, 0],
-                    distance: -options.terrainClipY,
-                    enabled: true,
-                };
-            }
-
-            if (options.sectionPlane) {
-                // Get model bounds from batched meshes. We deliberately EXCLUDE
-                // individual meshes (`this.scene.getMeshes()`) here: those are
-                // created lazily for selection highlighting and can live at
-                // unexpected world positions (e.g. legacy transforms, overlay
-                // helpers), which would inflate the bounds range and make
-                // "1% of the slider" span the entire real model — producing
-                // the reported symptom where the model pops from fully visible
-                // to fully invisible across a tiny slider range.
-                const boundsMin = { x: Infinity, y: Infinity, z: Infinity };
-                const boundsMax = { x: -Infinity, y: -Infinity, z: -Infinity };
-
-                const batchedMeshes = this.scene.getBatchedMeshes();
-                for (const batch of batchedMeshes) {
-                    if (batch.bounds) {
-                        boundsMin.x = Math.min(boundsMin.x, batch.bounds.min[0]);
-                        boundsMin.y = Math.min(boundsMin.y, batch.bounds.min[1]);
-                        boundsMin.z = Math.min(boundsMin.z, batch.bounds.min[2]);
-                        boundsMax.x = Math.max(boundsMax.x, batch.bounds.max[0]);
-                        boundsMax.y = Math.max(boundsMax.y, batch.bounds.max[1]);
-                        boundsMax.z = Math.max(boundsMax.z, batch.bounds.max[2]);
-                    }
-                }
-                // Fold in point-cloud bounds too — without this, a
-                // pure point-cloud scene falls through to the default
-                // [-100,100], and a mixed scene clips against a
-                // smaller mesh-only range while the point pipeline
-                // (which honours the same sectionPlaneData) keeps
-                // drawing points outside the slider's reach.
-                const pcBoundsForSection = this.pointCloudRenderer?.getBounds();
-                if (pcBoundsForSection) {
-                    boundsMin.x = Math.min(boundsMin.x, pcBoundsForSection.min[0]);
-                    boundsMin.y = Math.min(boundsMin.y, pcBoundsForSection.min[1]);
-                    boundsMin.z = Math.min(boundsMin.z, pcBoundsForSection.min[2]);
-                    boundsMax.x = Math.max(boundsMax.x, pcBoundsForSection.max[0]);
-                    boundsMax.y = Math.max(boundsMax.y, pcBoundsForSection.max[1]);
-                    boundsMax.z = Math.max(boundsMax.z, pcBoundsForSection.max[2]);
-                }
-
-                // If no batched meshes have bounds yet (streaming, degenerate
-                // models), fall back to individual meshes so at least the
-                // slider has a workable range.
-                if (!Number.isFinite(boundsMin.x)) {
-                    for (const mesh of meshes) {
-                        if (mesh.bounds) {
-                            boundsMin.x = Math.min(boundsMin.x, mesh.bounds.min[0]);
-                            boundsMin.y = Math.min(boundsMin.y, mesh.bounds.min[1]);
-                            boundsMin.z = Math.min(boundsMin.z, mesh.bounds.min[2]);
-                            boundsMax.x = Math.max(boundsMax.x, mesh.bounds.max[0]);
-                            boundsMax.y = Math.max(boundsMax.y, mesh.bounds.max[1]);
-                            boundsMax.z = Math.max(boundsMax.z, mesh.bounds.max[2]);
-                        }
-                    }
-                }
-
-                // Fallback if no bounds found
-                if (!Number.isFinite(boundsMin.x)) {
-                    boundsMin.x = boundsMin.y = boundsMin.z = -100;
-                    boundsMax.x = boundsMax.y = boundsMax.z = 100;
-                }
-
-                // Store bounds for section plane visual and camera near/far
+            // This frame's clip plane and the bounds the section slider is
+            // expressed in — resolved in render-section-plane.ts, which owns
+            // the bounds aggregation, the terrain-clip and explicit-plane
+            // branches, and the one-shot diagnostic log (issue #2425).
+            const sectionFrame = resolveSectionPlaneFrame({
+                options,
+                batchedMeshes: this.scene.getBatchedMeshes(),
+                meshes,
+                pointCloudBounds: this.pointCloudRenderer?.getBounds() ?? null,
+                logSectionBounds: !this._loggedSectionBounds,
+                spendLogLatch: () => { this._loggedSectionBounds = true; },
+            });
+            const sectionPlaneData = sectionFrame.sectionPlaneData;
+            if (sectionFrame.bounds) {
+                // Store bounds for section plane visual and camera near/far.
+                // Two wrappers over the same min/max, exactly as before the
+                // extraction — the renderer's copy is replaced wholesale by the
+                // bounds helpers, the camera's is not.
+                const { min: boundsMin, max: boundsMax } = sectionFrame.bounds;
                 this.setModelBounds({ min: boundsMin, max: boundsMax });
                 this.camera.setSceneBounds({ min: boundsMin, max: boundsMax });
-
-                // Only calculate clipping data if section is enabled
-                // Terrain clip: when no section plane is active, use terrainClipY
-                // to clip fragments below terrain height. Normal (0,-1,0) with
-                // distance = -clipY clips worldPos.y < clipY.
-                if (!options.sectionPlane?.enabled && options.terrainClipY !== undefined) {
-                    sectionPlaneData = {
-                        normal: [0, -1, 0],
-                        distance: -options.terrainClipY,
-                        enabled: true,
-                    };
-                }
-
-                if (options.sectionPlane.enabled) {
-                    // Explicit normal + distance override (face-pick / arbitrary
-                    // plane, issue #243). Used verbatim: no axis mapping, no
-                    // position slider, no building rotation — the caller already
-                    // has the plane in world space.
-                    const explicitNormal   = options.sectionPlane.normal;
-                    const explicitDistance = options.sectionPlane.distance;
-                    const hasExplicitPlane =
-                        explicitNormal !== undefined &&
-                        explicitDistance !== undefined &&
-                        Number.isFinite(explicitDistance);
-
-                    let normal: [number, number, number];
-                    let distance: number;
-
-                    if (hasExplicitPlane) {
-                        // Defensive renormalisation in case the caller passed a
-                        // non-unit vector (e.g. mesh face normals quantised by
-                        // the geometry pipeline).
-                        const nx = explicitNormal![0];
-                        const ny = explicitNormal![1];
-                        const nz = explicitNormal![2];
-                        const len = Math.sqrt(nx * nx + ny * ny + nz * nz);
-                        if (len > 1e-6) {
-                            normal = [nx / len, ny / len, nz / len];
-                            distance = explicitDistance! / len;
-                        } else {
-                            normal = [0, 1, 0];
-                            distance = explicitDistance!;
-                        }
-                    } else {
-                        // Cardinal-axis preset path (unchanged behaviour).
-                        // down = Y axis (horizontal cut), front = Z axis, side = X axis
-                        normal = [0, 0, 0];
-                        if (options.sectionPlane.axis === 'side') normal[0] = 1;        // X axis
-                        else if (options.sectionPlane.axis === 'down') normal[1] = 1;   // Y axis (horizontal)
-                        else normal[2] = 1;                                              // Z axis (front)
-
-                        // Apply building rotation if present (rotate normal around Y axis)
-                        // Building rotation is in X-Y plane (Z is up in IFC, Y is up in WebGL)
-                        if (options.buildingRotation !== undefined && options.buildingRotation !== 0) {
-                            const cosR = Math.cos(options.buildingRotation);
-                            const sinR = Math.sin(options.buildingRotation);
-                            // Rotate normal vector around Y axis (vertical)
-                            // For X-Z plane rotation: x' = x*cos - z*sin, z' = x*sin + z*cos, y' = y
-                            const x = normal[0];
-                            const z = normal[2];
-                            normal[0] = x * cosR - z * sinR;
-                            normal[2] = x * sinR + z * cosR;
-                            // Normalize to maintain unit length
-                            const rlen = Math.sqrt(normal[0] * normal[0] + normal[1] * normal[1] + normal[2] * normal[2]);
-                            if (rlen > 0.0001) {
-                                normal[0] /= rlen;
-                                normal[1] /= rlen;
-                                normal[2] /= rlen;
-                            }
-                        }
-
-                        // Get axis-specific range. The renderer's own `boundsMin/Max`
-                        // are computed from the GPU vertex buffers this frame, so
-                        // they are guaranteed to be in the same Y-up world space as
-                        // `input.worldPos` in the shader. `options.sectionPlane.min/max`
-                        // comes from the UI via `coordinateInfo.shiftedBounds` and can
-                        // be stale during streaming or outright wrong during model
-                        // load (initialised to {0,0,0} before the first bounds update)
-                        // — using those directly was the cause of the "slider moves
-                        // 1% and the whole model disappears" bug.
-                        //
-                        // Policy: always use the renderer's own bounds for the Y-up
-                        // range. Only honour the UI override when it is a valid,
-                        // non-degenerate range that lies INSIDE the actual mesh
-                        // bounds (e.g. storey filtering from the level picker).
-                        const axisIdx = options.sectionPlane.axis === 'side' ? 'x' : options.sectionPlane.axis === 'down' ? 'y' : 'z';
-                        let minVal = boundsMin[axisIdx];
-                        let maxVal = boundsMax[axisIdx];
-                        const uiMin = options.sectionPlane.min;
-                        const uiMax = options.sectionPlane.max;
-                        if (
-                            Number.isFinite(uiMin) &&
-                            Number.isFinite(uiMax) &&
-                            (uiMax as number) - (uiMin as number) > 1e-6 &&
-                            (uiMin as number) >= minVal - 1e-3 &&
-                            (uiMax as number) <= maxVal + 1e-3
-                        ) {
-                            minVal = uiMin as number;
-                            maxVal = uiMax as number;
-                        }
-
-                        // Calculate plane distance from position percentage
-                        const range = maxVal - minVal;
-                        distance = minVal + (options.sectionPlane.position / 100) * range;
-                    }
-
-                    sectionPlaneData = { normal, distance, enabled: true };
-
-                    // One-shot diagnostic: when section first becomes active,
-                    // log the exact bounds + plane the shader will use. This
-                    // is the fastest way to confirm "bounds mismatch" / "plane
-                    // off-screen" bugs without asking the user to run a
-                    // debugger. The custom-plane branch logs `mode: 'explicit'`
-                    // so reports against tilted planes are easy to spot.
-                    if (!this._loggedSectionBounds) {
-                        this._loggedSectionBounds = true;
-                        console.info('[Section] Y-up bounds used for clip:', {
-                            mode: hasExplicitPlane ? 'explicit' : 'axis-aligned',
-                            axis: options.sectionPlane.axis,
-                            bounds: {
-                                min: { x: boundsMin.x, y: boundsMin.y, z: boundsMin.z },
-                                max: { x: boundsMax.x, y: boundsMax.y, z: boundsMax.z },
-                            },
-                            normal,
-                            distance,
-                            position: options.sectionPlane.position,
-                            batchedMeshCount: this.scene.getBatchedMeshes().length,
-                        });
-                    }
-                }
             }
 
             // Stash what we actually clipped this frame so the GPU picker mirrors
@@ -3057,137 +2852,17 @@ export class Renderer {
                 });
             }
 
-            // Draw section plane visual BEFORE pass.end() (within same MSAA render pass)
-            // Always show plane when sectionPlane options are provided (as preview or active)
-            const modelBounds = this.getModelBounds();
-            if (options.sectionPlane && this.sectionPlaneRenderer && modelBounds) {
-                this.sectionPlaneRenderer.draw(
-                    pass,
-                    {
-                        axis: options.sectionPlane.axis,
-                        position: options.sectionPlane.position,
-                        bounds: modelBounds,
-                        viewProj,
-                        isPreview: !options.sectionPlane.enabled, // Preview mode when not enabled
-                        min: options.sectionPlane.min,
-                        max: options.sectionPlane.max,
-                        // Custom-plane gizmo override (issue #243). When both
-                        // are set the gizmo bypasses the cardinal path; see
-                        // SectionPlaneRenderer.calculatePlaneVerticesFromNormal.
-                        normal: options.sectionPlane.normal,
-                        distance: options.sectionPlane.distance,
-                    }
-                );
-
-                // Draw 2D section overlay on the section plane (when section is
-                // active, not preview). The overlay is also the 3D SECTION CAP:
-                // its polygon fills come from `SectionCutter` (exact triangle-
-                // plane intersection), and the new fill shader applies the
-                // user's screen-space hatch + colour directly on those
-                // polygons. This replaces the old stencil-parity cap, which
-                // bled hatch into empty sky on non-manifold IFC geometry —
-                // the polygons here are mathematically correct, so the cap
-                // silhouette matches the 2D drawing exactly.
-                if (options.sectionPlane.enabled && this.section2DOverlayRenderer?.hasGeometry()) {
-                    const o = options.sectionPlane;
-                    const showFills    = o.showCap !== false;
-                    const showOutlines = o.showOutlines !== false;
-                    const style = { ...DEFAULT_CAP_STYLE, ...(o.capStyle ?? {}) };
-                    this.section2DOverlayRenderer.draw(
-                        pass,
-                        {
-                            axis: o.axis,
-                            position: o.position,
-                            bounds: modelBounds,
-                            viewProj,
-                            min: o.min,
-                            max: o.max,
-                            showFills,
-                            showOutlines,
-                            capStyle: showFills ? {
-                                fillColor:   style.fillColor,
-                                strokeColor: style.strokeColor,
-                                patternId:   HATCH_PATTERN_IDS[style.pattern],
-                                spacingPx:   style.spacingPx,
-                                angleRad:    style.angleRad,
-                                widthPx:     style.widthPx,
-                                secondaryAngleRad: style.secondaryAngleRad,
-                            } : undefined,
-                        }
-                    );
-                }
-
-            }
-
-            // Standalone IFC annotation overlay (issue #653). The line
-            // vertices were pre-lifted to world space at upload time, so
-            // this draw happens regardless of whether a section plane is
-            // active — annotations are a free-floating "drawing layer"
-            // that sits at each annotation's storey elevation.
-            //
-            // This block was previously nested inside the `if (options.sectionPlane && ...)`
-            // guard above, contradicting its own comment. Loading an
-            // annotation-only model with no section plane meant the entire
-            // overlay was skipped at draw time even though 9000+ vertices
-            // had been uploaded successfully. Pulled out to its own block.
-            //
-            // Order: fills (background) → lines (outlines on top) →
-            // texts (labels above everything).
-            if (this.symbolicFillPipeline?.hasGeometry()) {
-                this.symbolicFillPipeline.render(pass, viewProj);
-            }
-            if (this.section2DOverlayRenderer?.hasAnnotationLines3D()) {
-                this.section2DOverlayRenderer.drawAnnotationLines3D(pass, viewProj);
-            }
-            if (this.section2DOverlayRenderer?.hasAlignmentLines3D()) {
-                this.section2DOverlayRenderer.drawAlignmentLines3D(pass, viewProj);
-            }
-            if (this.section2DOverlayRenderer?.hasGridLines3D()) {
-                this.section2DOverlayRenderer.drawGridLines3D(pass, viewProj);
-            }
-            if (this.section2DOverlayRenderer?.hasDxfLines3D()) {
-                this.section2DOverlayRenderer.drawDxfLines3D(pass, viewProj);
-            }
-            if (this.section2DOverlayRenderer?.hasClashBoxLines3D()) {
-                this.section2DOverlayRenderer.drawClashBoxLines3D(pass, viewProj);
-            }
-            if (this.symbolicTextPipeline?.hasGeometry()) {
-                // Pass viewport pixel dimensions so the shader can scale glyphs
-                // to a constant on-screen size (BIMvision-style annotations)
-                // regardless of camera distance or authored text height.
-                //
-                // Also pass the screen-aligned camera basis (right, up) so
-                // billboarded glyphs (grid bubble tags) can face the camera
-                // in any orientation — top-down, eye-level, oblique alike.
-                const camPos = this.camera.getPosition();
-                const camTgt = this.camera.getTarget();
-                const camUpVec = this.camera.getUp();
-                // Forward = normalize(target - position).
-                let fx = camTgt.x - camPos.x;
-                let fy = camTgt.y - camPos.y;
-                let fz = camTgt.z - camPos.z;
-                let flen = Math.hypot(fx, fy, fz) || 1;
-                fx /= flen; fy /= flen; fz /= flen;
-                // Right = normalize(cross(forward, world-up)).
-                let rx = fy * camUpVec.z - fz * camUpVec.y;
-                let ry = fz * camUpVec.x - fx * camUpVec.z;
-                let rz = fx * camUpVec.y - fy * camUpVec.x;
-                let rlen = Math.hypot(rx, ry, rz) || 1;
-                rx /= rlen; ry /= rlen; rz /= rlen;
-                // True up = normalize(cross(right, forward)) — guaranteed
-                // perpendicular to both, defines screen-space vertical.
-                const ux = ry * fz - rz * fy;
-                const uy = rz * fx - rx * fz;
-                const uz = rx * fy - ry * fx;
-                this.symbolicTextPipeline.render(
-                    pass,
-                    viewProj,
-                    this.canvas.width,
-                    this.canvas.height,
-                    [rx, ry, rz],
-                    [ux, uy, uz],
-                );
-            }
+            // Section-plane gizmo, 2D section cap and every standalone 3D
+            // overlay (annotation / alignment / grid / DXF / clash / symbolic
+            // text). One draw call into the pass — see RendererOverlays.draw().
+            this.overlays.draw(pass, {
+                options,
+                viewProj,
+                modelBounds: this.getModelBounds(),
+                camera: this.camera,
+                canvasWidth: this.canvas.width,
+                canvasHeight: this.canvas.height,
+            });
 
             pass.end();
 
@@ -3475,6 +3150,11 @@ export class Renderer {
         return this.scene;
     }
 
+    // ─── Overlay facade ──────────────────────────────────────────────────
+    // The section-plane gizmo, the 2D section drawing/cap and the symbolic
+    // annotation overlays live in `RendererOverlays` (issue #2425). These
+    // methods are the published surface; the bodies moved with the state.
+
     /**
      * Upload 2D section drawing data for 3D overlay rendering.
      *
@@ -3503,45 +3183,14 @@ export class Renderer {
             bitangent: [number, number, number];
         },
     ): void {
-        if (!this.section2DOverlayRenderer) return;
-
-        if (customPlane) {
-            // Custom-plane path: planePosition / axis are unused — the
-            // basis the cap shader needs travels in `customPlane`. We pass
-            // 0 for `planePosition` and the existing `axis` so the cardinal
-            // shader code path that callers depend on (e.g. legacy SVG
-            // export) keeps working when customPlane is omitted.
-            this.section2DOverlayRenderer.uploadDrawing(
-                polygons, lines, axis, 0, flipped, customPlane,
-            );
-            return;
-        }
-
-        // Use EXACTLY same calculation as section plane in render() method:
-        // minVal = options.sectionPlane.min ?? boundsMin[axisIdx]
-        // maxVal = options.sectionPlane.max ?? boundsMax[axisIdx]
-        const axisIdx = axis === 'side' ? 'x' : axis === 'down' ? 'y' : 'z';
-
-        const modelBounds = this.getModelBounds();
-
-        // Allow upload if either sectionRange has both values, or modelBounds exists as fallback
-        const hasFullRange = sectionRange?.min !== undefined && sectionRange?.max !== undefined;
-        if (!hasFullRange && !modelBounds) return;
-
-        const minVal = sectionRange?.min ?? modelBounds!.min[axisIdx];
-        const maxVal = sectionRange?.max ?? modelBounds!.max[axisIdx];
-        const planePosition = minVal + (position / 100) * (maxVal - minVal);
-
-        this.section2DOverlayRenderer.uploadDrawing(polygons, lines, axis, planePosition, flipped);
+        this.overlays.uploadSection2DOverlay(polygons, lines, axis, position, sectionRange, flipped, customPlane);
     }
 
     /**
      * Clear the 2D section overlay
      */
     clearSection2DOverlay(): void {
-        if (this.section2DOverlayRenderer) {
-            this.section2DOverlayRenderer.clearGeometry();
-        }
+        this.overlays.clearSection2DOverlay();
     }
 
     /**
@@ -3551,11 +3200,7 @@ export class Renderer {
      * `SymbolicTextInput.color` on `uploadAnnotationTexts3D`.
      */
     setOverlayLineColor(color: readonly [number, number, number, number]): void {
-        // Persist on the Renderer so a pre-init call (and any later overlay
-        // re-creation) keeps the colour — init() re-applies this.overlayLineColor.
-        this.overlayLineColor = color;
-        this.section2DOverlayRenderer?.setOverlayLineColor(color);
-        this.requestRender();
+        this.overlays.setOverlayLineColor(color);
     }
 
     /**
@@ -3565,19 +3210,7 @@ export class Renderer {
      * Pass an empty Float32Array to clear.
      */
     uploadAnnotationLines3D(vertices: Float32Array): void {
-        if (!this.section2DOverlayRenderer) return;
-        this.section2DOverlayRenderer.uploadAnnotationLines3D(vertices);
-        // Contribute annotation extents to modelBounds + camera sceneBounds
-        // so an annotation-only model (no IfcProduct meshes — common for
-        // separate "annotation sheets") gets framed by Home / fit-to-view
-        // AND has correct near/far clipping. Without sceneBounds the camera
-        // frustum doesn't include the annotation cluster and they're clipped
-        // away even when the camera is pointed at them. Mirror the
-        // point-cloud upload path (`addPointClouds`, `setPointClouds`) which
-        // does the same thing.
-        this.expandModelBoundsWithFlatVertices(vertices, 3);
-        if (this.modelBounds) this.camera.setSceneBounds(this.modelBounds);
-        this.requestRender();
+        this.overlays.uploadAnnotationLines3D(vertices);
     }
 
     /** Walks a flat `[x,y,z,x,y,z,...]` vertex buffer and either initialises
@@ -3631,10 +3264,7 @@ export class Renderer {
      * Clear the standalone annotation line overlay.
      */
     clearAnnotationLines3D(): void {
-        if (this.section2DOverlayRenderer) {
-            this.section2DOverlayRenderer.clearAnnotationLines3D();
-            this.requestRender();
-        }
+        this.overlays.clearAnnotationLines3D();
     }
 
     /**
@@ -3643,21 +3273,12 @@ export class Renderer {
      * to match IfcGrid / IfcAnnotation. Pass an empty Float32Array to clear.
      */
     uploadAlignmentLines3D(vertices: Float32Array): void {
-        if (!this.section2DOverlayRenderer) return;
-        this.section2DOverlayRenderer.uploadAlignmentLines3D(vertices);
-        // Frame alignment-only files the same way annotation overlays are
-        // framed (see uploadAnnotationLines3D).
-        this.expandModelBoundsWithFlatVertices(vertices, 3);
-        if (this.modelBounds) this.camera.setSceneBounds(this.modelBounds);
-        this.requestRender();
+        this.overlays.uploadAlignmentLines3D(vertices);
     }
 
     /** Clear the alignment centerline overlay. */
     clearAlignmentLines3D(): void {
-        if (this.section2DOverlayRenderer) {
-            this.section2DOverlayRenderer.clearAlignmentLines3D();
-            this.requestRender();
-        }
+        this.overlays.clearAlignmentLines3D();
     }
 
     /**
@@ -3670,17 +3291,12 @@ export class Renderer {
      * grid axes routinely extend past the model envelope).
      */
     uploadGridLines3D(vertices: Float32Array): void {
-        if (!this.section2DOverlayRenderer) return;
-        this.section2DOverlayRenderer.uploadGridLines3D(vertices);
-        this.requestRender();
+        this.overlays.uploadGridLines3D(vertices);
     }
 
     /** Clear the structural-grid overlay. */
     clearGridLines3D(): void {
-        if (this.section2DOverlayRenderer) {
-            this.section2DOverlayRenderer.clearGridLines3D();
-            this.requestRender();
-        }
+        this.overlays.clearGridLines3D();
     }
 
     /**
@@ -3693,17 +3309,12 @@ export class Renderer {
      * visibility toggle, like grid axes. Pass an empty Float32Array to clear.
      */
     uploadDxfLines3D(vertices: Float32Array): void {
-        if (!this.section2DOverlayRenderer) return;
-        this.section2DOverlayRenderer.uploadDxfLines3D(vertices);
-        this.requestRender();
+        this.overlays.uploadDxfLines3D(vertices);
     }
 
     /** Clear the 3D DXF reference-layer overlay. */
     clearDxfLines3D(): void {
-        if (this.section2DOverlayRenderer) {
-            this.section2DOverlayRenderer.clearDxfLines3D();
-            this.requestRender();
-        }
+        this.overlays.clearDxfLines3D();
     }
 
     /**
@@ -3715,15 +3326,7 @@ export class Renderer {
     setClashOverlapBox(
         box: { min: [number, number, number]; max: [number, number, number]; color: [number, number, number, number] } | null,
     ): void {
-        if (!this.section2DOverlayRenderer) return;
-        if (!box) {
-            this.section2DOverlayRenderer.clearClashBoxLines3D();
-            this.requestRender();
-            return;
-        }
-        this.section2DOverlayRenderer.setClashBoxLineColor(box.color);
-        this.section2DOverlayRenderer.uploadClashBoxLines3D(aabbEdgeLineList(box.min, box.max));
-        this.requestRender();
+        this.overlays.setClashOverlapBox(box);
     }
 
     /**
@@ -3736,15 +3339,7 @@ export class Renderer {
     setClashContactLines(
         lines: { vertices: Float32Array; color: [number, number, number, number] } | null,
     ): void {
-        if (!this.section2DOverlayRenderer) return;
-        if (!lines || lines.vertices.length === 0) {
-            this.section2DOverlayRenderer.clearClashBoxLines3D();
-            this.requestRender();
-            return;
-        }
-        this.section2DOverlayRenderer.setClashBoxLineColor(lines.color);
-        this.section2DOverlayRenderer.uploadClashBoxLines3D(lines.vertices);
-        this.requestRender();
+        this.overlays.setClashContactLines(lines);
     }
 
     /**
@@ -3752,24 +3347,7 @@ export class Renderer {
      * (issue #653). Pass an empty array to clear.
      */
     uploadAnnotationFills3D(fills: readonly SymbolicFillInput[]): void {
-        if (!this.symbolicFillPipeline) return;
-        this.symbolicFillPipeline.upload(fills);
-        // Contribute fill extents to modelBounds — see uploadAnnotationLines3D.
-        for (const fill of fills) {
-            const pts = fill.points;
-            if (pts.length === 0) continue;
-            // points are flat [x,z,x,z,...]; lift to (x, fill.worldY, z) per
-            // vertex so we expand bounds in the same world space the renderer draws in.
-            const lifted = new Float32Array((pts.length / 2) * 3);
-            for (let i = 0, j = 0; i < pts.length; i += 2, j += 3) {
-                lifted[j] = pts[i];
-                lifted[j + 1] = fill.worldY;
-                lifted[j + 2] = pts[i + 1];
-            }
-            this.expandModelBoundsWithFlatVertices(lifted, 3);
-        }
-        if (this.modelBounds) this.camera.setSceneBounds(this.modelBounds);
-        this.requestRender();
+        this.overlays.uploadAnnotationFills3D(fills);
     }
 
     /**
@@ -3777,29 +3355,14 @@ export class Renderer {
      * (issue #653). Pass an empty array to clear.
      */
     uploadAnnotationTexts3D(texts: readonly SymbolicTextInput[]): void {
-        if (!this.symbolicTextPipeline) return;
-        this.symbolicTextPipeline.upload(texts);
-        // Text origins are single points; pack them into a flat buffer and
-        // expand bounds. Glyph extents are small enough that origin-only
-        // suffices for framing.
-        if (texts.length > 0) {
-            const buf = new Float32Array(texts.length * 3);
-            for (let i = 0; i < texts.length; i++) {
-                buf[i * 3 + 0] = texts[i].worldPos[0];
-                buf[i * 3 + 1] = texts[i].worldPos[1];
-                buf[i * 3 + 2] = texts[i].worldPos[2];
-            }
-            this.expandModelBoundsWithFlatVertices(buf, 3);
-            if (this.modelBounds) this.camera.setSceneBounds(this.modelBounds);
-        }
-        this.requestRender();
+        this.overlays.uploadAnnotationTexts3D(texts);
     }
 
     /**
      * Check if 2D section overlay has geometry to render
      */
     hasSection2DOverlay(): boolean {
-        return this.section2DOverlayRenderer?.hasGeometry() ?? false;
+        return this.overlays.hasSection2DOverlay();
     }
 
     /**
@@ -3900,19 +3463,9 @@ export class Renderer {
         this.skyPass?.destroy();
         this.skyPass = null;
 
-        // Section-plane renderers
-        this.sectionPlaneRenderer?.destroy();
-        this.sectionPlaneRenderer = null;
-        this.section2DOverlayRenderer?.dispose();
-        this.section2DOverlayRenderer = null;
-
-        // Symbolic annotation overlay pipelines own their own GPU buffers,
-        // sampler, and atlas texture — recreating the viewer without
-        // releasing them leaks resources on every reload.
-        this.symbolicFillPipeline?.destroy();
-        this.symbolicFillPipeline = null;
-        this.symbolicTextPipeline?.destroy();
-        this.symbolicTextPipeline = null;
+        // Section-plane gizmo, 2D section overlay and the symbolic annotation
+        // pipelines — see RendererOverlays.destroy().
+        this.overlays.destroy();
 
         // Point cloud GPU resources
         this.pointCloudRenderer?.clear();

--- a/packages/renderer/src/render-section-plane.ts
+++ b/packages/renderer/src/render-section-plane.ts
@@ -1,0 +1,306 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Per-frame section-plane resolution, lifted verbatim out of
+ * `Renderer.renderFrame()` (issue #2425).
+ *
+ * This is the "what does this frame clip against, and over what range" half of
+ * the section feature: it aggregates the bounds the slider is expressed in,
+ * turns `RenderOptions.sectionPlane` (or `terrainClipY`) into the world-space
+ * normal + distance the shader uniform carries, and reports the one-shot
+ * diagnostic log. It touches no GPU object and no `Renderer` field, which is
+ * why it can live here: everything it needs arrives as an argument. The bounds
+ * it computed come back in the return value for the caller to apply; the
+ * one-shot log latch is committed through the injected `spendLogLatch` so it
+ * still lands BEFORE the log, exactly as it did inline.
+ */
+
+import type { BatchedMesh, Mesh, RenderOptions } from './types.js';
+
+/** World-space AABB in the renderer's Y-up frame. */
+interface SectionFrameBounds {
+    min: { x: number; y: number; z: number };
+    max: { x: number; y: number; z: number };
+}
+
+/** The clip plane a frame hands to the mesh / point / instanced shaders. */
+interface SectionPlaneFrameData {
+    normal: [number, number, number];
+    distance: number;
+    enabled: boolean;
+}
+
+export interface SectionPlaneFrameInput {
+    options: RenderOptions;
+    /**
+     * `Scene.getBatchedMeshes()`. The primary bounds source — individual
+     * meshes are deliberately excluded, see the comment on the aggregation.
+     */
+    batchedMeshes: ReadonlyArray<BatchedMesh>;
+    /**
+     * The frame's individual-mesh list, used only as the streaming/degenerate
+     * bounds fallback. NOT raw `Scene.getMeshes()`: the call site passes the
+     * list *after* frustum culling and the hidden/isolated filters, which is
+     * what the pre-extraction code aggregated. Passing an unfiltered list would
+     * silently widen the fallback bounds, and with them the section slider's
+     * range, whenever the batched path has no bounds yet.
+     */
+    meshes: ReadonlyArray<Mesh>;
+    /** `PointCloudRenderer.getBounds()`, or null when no points are loaded. */
+    pointCloudBounds: { min: [number, number, number]; max: [number, number, number] } | null;
+    /**
+     * Whether the one-shot "Y-up bounds used for clip" diagnostic has still to
+     * fire. The renderer owns the latch (`_loggedSectionBounds`, re-armed by
+     * `destroy()` for the next model).
+     */
+    logSectionBounds: boolean;
+    /**
+     * Commit the renderer's one-shot latch. Called immediately BEFORE the
+     * diagnostic is emitted, not after this function returns.
+     *
+     * The ordering is load-bearing and matches the pre-extraction code
+     * (`this._loggedSectionBounds = true;` then `console.info(...)`). Spending
+     * the latch afterwards would leave it unspent if `console.info` threw — a
+     * monkey-patched console is the only realistic way that happens — and this
+     * runs inside `renderFrame`'s encode `try`, so every later section-enabled
+     * frame would throw again and be contained as a degraded frame, eventually
+     * firing `onPersistentRenderDegradation`. The original cost one contained
+     * frame, ever.
+     */
+    spendLogLatch: () => void;
+}
+
+export interface SectionPlaneFrameResult {
+    /** Undefined when nothing clips this frame. */
+    sectionPlaneData: SectionPlaneFrameData | undefined;
+    /**
+     * The bounds the section slider was resolved against, or null when
+     * `options.sectionPlane` was absent (in which case the renderer's cached
+     * model bounds are left alone).
+     */
+    bounds: SectionFrameBounds | null;
+}
+
+/**
+ * Resolve this frame's clip plane and the bounds it is expressed in.
+ *
+ * Pure apart from the one-shot diagnostic, which is gated by
+ * `input.logSectionBounds` and commits its latch through
+ * `input.spendLogLatch` before logging.
+ */
+export function resolveSectionPlaneFrame(input: SectionPlaneFrameInput): SectionPlaneFrameResult {
+    const { options, batchedMeshes, meshes, pointCloudBounds } = input;
+
+    // Calculate section plane parameters and model bounds
+    // Always calculate bounds when sectionPlane is provided (for preview and active mode)
+    let sectionPlaneData: SectionPlaneFrameData | undefined;
+
+    // Terrain clip: when Cesium overlay is active, clip model below terrain.
+    // Normal (0,-1,0) + distance (-clipY) clips where worldPos.y < clipY.
+    if (options.terrainClipY !== undefined && !options.sectionPlane?.enabled) {
+        sectionPlaneData = {
+            normal: [0, -1, 0],
+            distance: -options.terrainClipY,
+            enabled: true,
+        };
+    }
+
+    if (!options.sectionPlane) {
+        return { sectionPlaneData, bounds: null };
+    }
+
+    // Get model bounds from batched meshes. We deliberately EXCLUDE
+    // individual meshes (`this.scene.getMeshes()`) here: those are
+    // created lazily for selection highlighting and can live at
+    // unexpected world positions (e.g. legacy transforms, overlay
+    // helpers), which would inflate the bounds range and make
+    // "1% of the slider" span the entire real model — producing
+    // the reported symptom where the model pops from fully visible
+    // to fully invisible across a tiny slider range.
+    const boundsMin = { x: Infinity, y: Infinity, z: Infinity };
+    const boundsMax = { x: -Infinity, y: -Infinity, z: -Infinity };
+
+    for (const batch of batchedMeshes) {
+        if (batch.bounds) {
+            boundsMin.x = Math.min(boundsMin.x, batch.bounds.min[0]);
+            boundsMin.y = Math.min(boundsMin.y, batch.bounds.min[1]);
+            boundsMin.z = Math.min(boundsMin.z, batch.bounds.min[2]);
+            boundsMax.x = Math.max(boundsMax.x, batch.bounds.max[0]);
+            boundsMax.y = Math.max(boundsMax.y, batch.bounds.max[1]);
+            boundsMax.z = Math.max(boundsMax.z, batch.bounds.max[2]);
+        }
+    }
+    // Fold in point-cloud bounds too — without this, a
+    // pure point-cloud scene falls through to the default
+    // [-100,100], and a mixed scene clips against a
+    // smaller mesh-only range while the point pipeline
+    // (which honours the same sectionPlaneData) keeps
+    // drawing points outside the slider's reach.
+    if (pointCloudBounds) {
+        boundsMin.x = Math.min(boundsMin.x, pointCloudBounds.min[0]);
+        boundsMin.y = Math.min(boundsMin.y, pointCloudBounds.min[1]);
+        boundsMin.z = Math.min(boundsMin.z, pointCloudBounds.min[2]);
+        boundsMax.x = Math.max(boundsMax.x, pointCloudBounds.max[0]);
+        boundsMax.y = Math.max(boundsMax.y, pointCloudBounds.max[1]);
+        boundsMax.z = Math.max(boundsMax.z, pointCloudBounds.max[2]);
+    }
+
+    // If no batched meshes have bounds yet (streaming, degenerate
+    // models), fall back to individual meshes so at least the
+    // slider has a workable range.
+    if (!Number.isFinite(boundsMin.x)) {
+        for (const mesh of meshes) {
+            if (mesh.bounds) {
+                boundsMin.x = Math.min(boundsMin.x, mesh.bounds.min[0]);
+                boundsMin.y = Math.min(boundsMin.y, mesh.bounds.min[1]);
+                boundsMin.z = Math.min(boundsMin.z, mesh.bounds.min[2]);
+                boundsMax.x = Math.max(boundsMax.x, mesh.bounds.max[0]);
+                boundsMax.y = Math.max(boundsMax.y, mesh.bounds.max[1]);
+                boundsMax.z = Math.max(boundsMax.z, mesh.bounds.max[2]);
+            }
+        }
+    }
+
+    // Fallback if no bounds found
+    if (!Number.isFinite(boundsMin.x)) {
+        boundsMin.x = boundsMin.y = boundsMin.z = -100;
+        boundsMax.x = boundsMax.y = boundsMax.z = 100;
+    }
+
+    // Only calculate clipping data if section is enabled
+    // Terrain clip: when no section plane is active, use terrainClipY
+    // to clip fragments below terrain height. Normal (0,-1,0) with
+    // distance = -clipY clips worldPos.y < clipY.
+    if (!options.sectionPlane?.enabled && options.terrainClipY !== undefined) {
+        sectionPlaneData = {
+            normal: [0, -1, 0],
+            distance: -options.terrainClipY,
+            enabled: true,
+        };
+    }
+
+    if (options.sectionPlane.enabled) {
+        // Explicit normal + distance override (face-pick / arbitrary
+        // plane, issue #243). Used verbatim: no axis mapping, no
+        // position slider, no building rotation — the caller already
+        // has the plane in world space.
+        const explicitNormal   = options.sectionPlane.normal;
+        const explicitDistance = options.sectionPlane.distance;
+        const hasExplicitPlane =
+            explicitNormal !== undefined &&
+            explicitDistance !== undefined &&
+            Number.isFinite(explicitDistance);
+
+        let normal: [number, number, number];
+        let distance: number;
+
+        if (hasExplicitPlane) {
+            // Defensive renormalisation in case the caller passed a
+            // non-unit vector (e.g. mesh face normals quantised by
+            // the geometry pipeline).
+            const nx = explicitNormal![0];
+            const ny = explicitNormal![1];
+            const nz = explicitNormal![2];
+            const len = Math.sqrt(nx * nx + ny * ny + nz * nz);
+            if (len > 1e-6) {
+                normal = [nx / len, ny / len, nz / len];
+                distance = explicitDistance! / len;
+            } else {
+                normal = [0, 1, 0];
+                distance = explicitDistance!;
+            }
+        } else {
+            // Cardinal-axis preset path (unchanged behaviour).
+            // down = Y axis (horizontal cut), front = Z axis, side = X axis
+            normal = [0, 0, 0];
+            if (options.sectionPlane.axis === 'side') normal[0] = 1;        // X axis
+            else if (options.sectionPlane.axis === 'down') normal[1] = 1;   // Y axis (horizontal)
+            else normal[2] = 1;                                              // Z axis (front)
+
+            // Apply building rotation if present (rotate normal around Y axis)
+            // Building rotation is in X-Y plane (Z is up in IFC, Y is up in WebGL)
+            if (options.buildingRotation !== undefined && options.buildingRotation !== 0) {
+                const cosR = Math.cos(options.buildingRotation);
+                const sinR = Math.sin(options.buildingRotation);
+                // Rotate normal vector around Y axis (vertical)
+                // For X-Z plane rotation: x' = x*cos - z*sin, z' = x*sin + z*cos, y' = y
+                const x = normal[0];
+                const z = normal[2];
+                normal[0] = x * cosR - z * sinR;
+                normal[2] = x * sinR + z * cosR;
+                // Normalize to maintain unit length
+                const rlen = Math.sqrt(normal[0] * normal[0] + normal[1] * normal[1] + normal[2] * normal[2]);
+                if (rlen > 0.0001) {
+                    normal[0] /= rlen;
+                    normal[1] /= rlen;
+                    normal[2] /= rlen;
+                }
+            }
+
+            // Get axis-specific range. The renderer's own `boundsMin/Max`
+            // are computed from the GPU vertex buffers this frame, so
+            // they are guaranteed to be in the same Y-up world space as
+            // `input.worldPos` in the shader. `options.sectionPlane.min/max`
+            // comes from the UI via `coordinateInfo.shiftedBounds` and can
+            // be stale during streaming or outright wrong during model
+            // load (initialised to {0,0,0} before the first bounds update)
+            // — using those directly was the cause of the "slider moves
+            // 1% and the whole model disappears" bug.
+            //
+            // Policy: always use the renderer's own bounds for the Y-up
+            // range. Only honour the UI override when it is a valid,
+            // non-degenerate range that lies INSIDE the actual mesh
+            // bounds (e.g. storey filtering from the level picker).
+            const axisIdx = options.sectionPlane.axis === 'side' ? 'x' : options.sectionPlane.axis === 'down' ? 'y' : 'z';
+            let minVal = boundsMin[axisIdx];
+            let maxVal = boundsMax[axisIdx];
+            const uiMin = options.sectionPlane.min;
+            const uiMax = options.sectionPlane.max;
+            if (
+                Number.isFinite(uiMin) &&
+                Number.isFinite(uiMax) &&
+                (uiMax as number) - (uiMin as number) > 1e-6 &&
+                (uiMin as number) >= minVal - 1e-3 &&
+                (uiMax as number) <= maxVal + 1e-3
+            ) {
+                minVal = uiMin as number;
+                maxVal = uiMax as number;
+            }
+
+            // Calculate plane distance from position percentage
+            const range = maxVal - minVal;
+            distance = minVal + (options.sectionPlane.position / 100) * range;
+        }
+
+        sectionPlaneData = { normal, distance, enabled: true };
+
+        // One-shot diagnostic: when section first becomes active,
+        // log the exact bounds + plane the shader will use. This
+        // is the fastest way to confirm "bounds mismatch" / "plane
+        // off-screen" bugs without asking the user to run a
+        // debugger. The custom-plane branch logs `mode: 'explicit'`
+        // so reports against tilted planes are easy to spot.
+        if (input.logSectionBounds) {
+            input.spendLogLatch();
+            console.info('[Section] Y-up bounds used for clip:', {
+                mode: hasExplicitPlane ? 'explicit' : 'axis-aligned',
+                axis: options.sectionPlane.axis,
+                bounds: {
+                    min: { x: boundsMin.x, y: boundsMin.y, z: boundsMin.z },
+                    max: { x: boundsMax.x, y: boundsMax.y, z: boundsMax.z },
+                },
+                normal,
+                distance,
+                position: options.sectionPlane.position,
+                batchedMeshCount: batchedMeshes.length,
+            });
+        }
+    }
+
+    return {
+        sectionPlaneData,
+        bounds: { min: boundsMin, max: boundsMax },
+    };
+}

--- a/packages/renderer/src/renderer-overlays.ts
+++ b/packages/renderer/src/renderer-overlays.ts
@@ -1,0 +1,399 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The renderer's overlay layer, lifted verbatim out of `Renderer` (issue
+ * #2425): the section-plane gizmo, the 2D section drawing / cut cap, and the
+ * standalone 3D line overlays (IfcAnnotation lines, IfcAlignment centrelines,
+ * IfcGridAxis, the DXF reference layer, and the focused clash's box / contact
+ * lines).
+ *
+ * These were already one unit in everything but location: created together in
+ * `init()`, destroyed together in `destroy()`, drawn one after another at the
+ * tail of the render pass, and fed by a facade of upload/clear methods that
+ * touches nothing else. Owning them here follows the `PickingManager` /
+ * `RaycastEngine` precedent — a cohesive chunk of state plus its behaviour,
+ * composed by `Renderer` rather than inlined into it.
+ *
+ * The boundary is GPU-object ownership, not subject matter. Every 3D line
+ * layer above lives on the SAME `Section2DOverlayRenderer` instance as the
+ * section cap, so "section rendering" and "standalone line overlays" cannot be
+ * separate modules without giving one nullable, init-created / destroy-disposed
+ * object two owners in two files. The symbolic fill/text pipelines ARE separate
+ * GPU objects, so they live in `renderer-symbolic-overlays.ts` and are composed
+ * here — this class keeps only the draw ORDER, which is the one thing the two
+ * families share.
+ *
+ * Doc comments for the published methods live on the matching `Renderer`
+ * delegates, which are what consumers see in the emitted `.d.ts`; they are not
+ * duplicated here.
+ *
+ * What stayed on `Renderer` is what genuinely couples: model bounds. Several
+ * uploads grow the scene AABB so an annotation-only or alignment-only model can
+ * still be framed, and those bounds are read by the camera, the section slider
+ * and `getDiagnostics()`. Rather than give one AABB two owners, this reaches the
+ * renderer's copy through the narrow `OverlayHost` seam below.
+ */
+
+import type { Camera } from './camera.js';
+import { SectionPlaneRenderer } from './section-plane.js';
+import { Section2DOverlayRenderer, type CutPolygon2D, type DrawingLine2D } from './section-2d-overlay.js';
+import { SymbolicOverlays } from './renderer-symbolic-overlays.js';
+import type { SymbolicFillInput, SymbolicTextInput } from './symbolic-overlay-pipelines.js';
+import { DEFAULT_CAP_STYLE, HATCH_PATTERN_IDS } from './section-cap-style.js';
+import { aabbEdgeLineList } from './aabb-edges.js';
+import type { RenderOptions } from './types.js';
+
+/** World-space AABB in the renderer's Y-up frame. */
+type ModelBounds = { min: { x: number; y: number; z: number }; max: { x: number; y: number; z: number } };
+
+/**
+ * The slice of `Renderer` the overlays need. Deliberately four methods wide:
+ * the overlays own their GPU objects outright, and borrow only the model-bounds
+ * bookkeeping that the rest of the renderer also owns.
+ */
+export interface OverlayHost {
+    /** The renderer's cached model AABB, or null before any geometry. */
+    getModelBounds(): ModelBounds | null;
+    /** Grow (or seed) the model AABB from a flat `[x,y,z,...]` buffer. */
+    expandModelBoundsWithFlatVertices(positions: Float32Array, stride: number): void;
+    /** Push the current model AABB to the camera's near/far fit. */
+    syncCameraSceneBounds(): void;
+    /** Mark the viewport dirty for the next animation frame. */
+    requestRender(): void;
+}
+
+/** Everything the overlay draw pass reads from the frame in flight. */
+export interface OverlayDrawContext {
+    options: RenderOptions;
+    viewProj: Float32Array;
+    /** The bounds this frame resolved the section slider against. */
+    modelBounds: ModelBounds | null;
+    camera: Camera;
+    canvasWidth: number;
+    canvasHeight: number;
+}
+
+export class RendererOverlays {
+    private sectionPlaneRenderer: SectionPlaneRenderer | null = null;
+    private section2DOverlayRenderer: Section2DOverlayRenderer | null = null;
+    // Overlay/section-cut line colour, kept here so it survives a
+    // pre-init call and a section2DOverlayRenderer re-creation (re-applied below).
+    private overlayLineColor: readonly [number, number, number, number] = [0, 0, 0, 1];
+    private readonly symbolic: SymbolicOverlays;
+
+    constructor(private readonly host: OverlayHost) {
+        this.symbolic = new SymbolicOverlays(host);
+    }
+
+    /**
+     * Create the overlay GPU objects. Called from `Renderer.init()` once the
+     * device and the main pipeline (for its sample count) exist.
+     */
+    init(device: GPUDevice, format: GPUTextureFormat, sampleCount: number): void {
+        this.sectionPlaneRenderer = new SectionPlaneRenderer(device, format, sampleCount);
+        this.section2DOverlayRenderer = new Section2DOverlayRenderer(device, format, sampleCount);
+        // Re-apply any colour set before this (re)creation so it isn't lost.
+        this.section2DOverlayRenderer.setOverlayLineColor(this.overlayLineColor);
+        this.symbolic.init(device, format, sampleCount);
+    }
+
+    /** Release every overlay GPU resource. Idempotent, like `Renderer.destroy()`. */
+    destroy(): void {
+        this.sectionPlaneRenderer?.destroy();
+        this.sectionPlaneRenderer = null;
+        this.section2DOverlayRenderer?.dispose();
+        this.section2DOverlayRenderer = null;
+        this.symbolic.destroy();
+    }
+
+    /**
+     * Draw every overlay into the frame's render pass, in the documented order.
+     * Called from the encode region right before `pass.end()`.
+     */
+    draw(pass: GPURenderPassEncoder, ctx: OverlayDrawContext): void {
+        const { options, viewProj, modelBounds, camera } = ctx;
+
+        // Draw section plane visual BEFORE pass.end() (within same MSAA render pass)
+        // Always show plane when sectionPlane options are provided (as preview or active)
+        if (options.sectionPlane && this.sectionPlaneRenderer && modelBounds) {
+            this.sectionPlaneRenderer.draw(
+                pass,
+                {
+                    axis: options.sectionPlane.axis,
+                    position: options.sectionPlane.position,
+                    bounds: modelBounds,
+                    viewProj,
+                    isPreview: !options.sectionPlane.enabled, // Preview mode when not enabled
+                    min: options.sectionPlane.min,
+                    max: options.sectionPlane.max,
+                    // Custom-plane gizmo override (issue #243). When both
+                    // are set the gizmo bypasses the cardinal path; see
+                    // SectionPlaneRenderer.calculatePlaneVerticesFromNormal.
+                    normal: options.sectionPlane.normal,
+                    distance: options.sectionPlane.distance,
+                }
+            );
+
+            // Draw 2D section overlay on the section plane (when section is
+            // active, not preview). The overlay is also the 3D SECTION CAP:
+            // its polygon fills come from `SectionCutter` (exact triangle-
+            // plane intersection), and the new fill shader applies the
+            // user's screen-space hatch + colour directly on those
+            // polygons. This replaces the old stencil-parity cap, which
+            // bled hatch into empty sky on non-manifold IFC geometry —
+            // the polygons here are mathematically correct, so the cap
+            // silhouette matches the 2D drawing exactly.
+            if (options.sectionPlane.enabled && this.section2DOverlayRenderer?.hasGeometry()) {
+                const o = options.sectionPlane;
+                const showFills    = o.showCap !== false;
+                const showOutlines = o.showOutlines !== false;
+                const style = { ...DEFAULT_CAP_STYLE, ...(o.capStyle ?? {}) };
+                this.section2DOverlayRenderer.draw(
+                    pass,
+                    {
+                        axis: o.axis,
+                        position: o.position,
+                        bounds: modelBounds,
+                        viewProj,
+                        min: o.min,
+                        max: o.max,
+                        showFills,
+                        showOutlines,
+                        capStyle: showFills ? {
+                            fillColor:   style.fillColor,
+                            strokeColor: style.strokeColor,
+                            patternId:   HATCH_PATTERN_IDS[style.pattern],
+                            spacingPx:   style.spacingPx,
+                            angleRad:    style.angleRad,
+                            widthPx:     style.widthPx,
+                            secondaryAngleRad: style.secondaryAngleRad,
+                        } : undefined,
+                    }
+                );
+            }
+
+        }
+
+        // Standalone IFC annotation overlay (issue #653). The line
+        // vertices were pre-lifted to world space at upload time, so
+        // this draw happens regardless of whether a section plane is
+        // active — annotations are a free-floating "drawing layer"
+        // that sits at each annotation's storey elevation.
+        //
+        // This block was previously nested inside the `if (options.sectionPlane && ...)`
+        // guard above, contradicting its own comment. Loading an
+        // annotation-only model with no section plane meant the entire
+        // overlay was skipped at draw time even though 9000+ vertices
+        // had been uploaded successfully. Pulled out to its own block.
+        //
+        // Order: fills (background) → lines (outlines on top) →
+        // texts (labels above everything).
+        this.symbolic.drawFills(pass, viewProj);
+        if (this.section2DOverlayRenderer?.hasAnnotationLines3D()) {
+            this.section2DOverlayRenderer.drawAnnotationLines3D(pass, viewProj);
+        }
+        if (this.section2DOverlayRenderer?.hasAlignmentLines3D()) {
+            this.section2DOverlayRenderer.drawAlignmentLines3D(pass, viewProj);
+        }
+        if (this.section2DOverlayRenderer?.hasGridLines3D()) {
+            this.section2DOverlayRenderer.drawGridLines3D(pass, viewProj);
+        }
+        if (this.section2DOverlayRenderer?.hasDxfLines3D()) {
+            this.section2DOverlayRenderer.drawDxfLines3D(pass, viewProj);
+        }
+        if (this.section2DOverlayRenderer?.hasClashBoxLines3D()) {
+            this.section2DOverlayRenderer.drawClashBoxLines3D(pass, viewProj);
+        }
+        this.symbolic.drawTexts(pass, viewProj, ctx.canvasWidth, ctx.canvasHeight, camera);
+    }
+
+    /** See `Renderer.uploadSection2DOverlay` for the published contract. */
+    uploadSection2DOverlay(
+        polygons: CutPolygon2D[],
+        lines: DrawingLine2D[],
+        axis: 'down' | 'front' | 'side',
+        position: number,  // 0-100 percentage
+        sectionRange?: { min?: number; max?: number },  // Same storey-based range as section plane
+        flipped: boolean = false,
+        customPlane?: {
+            origin:    [number, number, number];
+            tangent:   [number, number, number];
+            bitangent: [number, number, number];
+        },
+    ): void {
+        if (!this.section2DOverlayRenderer) return;
+
+        if (customPlane) {
+            // Custom-plane path: planePosition / axis are unused — the
+            // basis the cap shader needs travels in `customPlane`. We pass
+            // 0 for `planePosition` and the existing `axis` so the cardinal
+            // shader code path that callers depend on (e.g. legacy SVG
+            // export) keeps working when customPlane is omitted.
+            this.section2DOverlayRenderer.uploadDrawing(
+                polygons, lines, axis, 0, flipped, customPlane,
+            );
+            return;
+        }
+
+        // Use EXACTLY same calculation as section plane in render() method:
+        // minVal = options.sectionPlane.min ?? boundsMin[axisIdx]
+        // maxVal = options.sectionPlane.max ?? boundsMax[axisIdx]
+        const axisIdx = axis === 'side' ? 'x' : axis === 'down' ? 'y' : 'z';
+
+        const modelBounds = this.host.getModelBounds();
+
+        // Allow upload if either sectionRange has both values, or modelBounds exists as fallback
+        const hasFullRange = sectionRange?.min !== undefined && sectionRange?.max !== undefined;
+        if (!hasFullRange && !modelBounds) return;
+
+        const minVal = sectionRange?.min ?? modelBounds!.min[axisIdx];
+        const maxVal = sectionRange?.max ?? modelBounds!.max[axisIdx];
+        const planePosition = minVal + (position / 100) * (maxVal - minVal);
+
+        this.section2DOverlayRenderer.uploadDrawing(polygons, lines, axis, planePosition, flipped);
+    }
+
+    /** See `Renderer.clearSection2DOverlay` for the published contract. */
+    clearSection2DOverlay(): void {
+        if (this.section2DOverlayRenderer) {
+            this.section2DOverlayRenderer.clearGeometry();
+        }
+    }
+
+    /** See `Renderer.setOverlayLineColor` for the published contract. */
+    setOverlayLineColor(color: readonly [number, number, number, number]): void {
+        // Persist here so a pre-init call (and any later overlay
+        // re-creation) keeps the colour — init() re-applies this.overlayLineColor.
+        this.overlayLineColor = color;
+        this.section2DOverlayRenderer?.setOverlayLineColor(color);
+        this.host.requestRender();
+    }
+
+    /** See `Renderer.uploadAnnotationLines3D` for the published contract. */
+    uploadAnnotationLines3D(vertices: Float32Array): void {
+        if (!this.section2DOverlayRenderer) return;
+        this.section2DOverlayRenderer.uploadAnnotationLines3D(vertices);
+        // Contribute annotation extents to modelBounds + camera sceneBounds
+        // so an annotation-only model (no IfcProduct meshes — common for
+        // separate "annotation sheets") gets framed by Home / fit-to-view
+        // AND has correct near/far clipping. Without sceneBounds the camera
+        // frustum doesn't include the annotation cluster and they're clipped
+        // away even when the camera is pointed at them. Mirror the
+        // point-cloud upload path (`addPointClouds`, `setPointClouds`) which
+        // does the same thing.
+        this.host.expandModelBoundsWithFlatVertices(vertices, 3);
+        this.host.syncCameraSceneBounds();
+        this.host.requestRender();
+    }
+
+    /** See `Renderer.clearAnnotationLines3D` for the published contract. */
+    clearAnnotationLines3D(): void {
+        if (this.section2DOverlayRenderer) {
+            this.section2DOverlayRenderer.clearAnnotationLines3D();
+            this.host.requestRender();
+        }
+    }
+
+    /** See `Renderer.uploadAlignmentLines3D` for the published contract. */
+    uploadAlignmentLines3D(vertices: Float32Array): void {
+        if (!this.section2DOverlayRenderer) return;
+        this.section2DOverlayRenderer.uploadAlignmentLines3D(vertices);
+        // Frame alignment-only files the same way annotation overlays are
+        // framed (see uploadAnnotationLines3D).
+        this.host.expandModelBoundsWithFlatVertices(vertices, 3);
+        this.host.syncCameraSceneBounds();
+        this.host.requestRender();
+    }
+
+    /** See `Renderer.clearAlignmentLines3D` for the published contract. */
+    clearAlignmentLines3D(): void {
+        if (this.section2DOverlayRenderer) {
+            this.section2DOverlayRenderer.clearAlignmentLines3D();
+            this.host.requestRender();
+        }
+    }
+
+    /**
+     * See `Renderer.uploadGridLines3D` for the published contract. Unlike
+     * alignment, grids do NOT expand model bounds: they're behind a visibility
+     * toggle, so toggling them on must not reframe the camera.
+     */
+    uploadGridLines3D(vertices: Float32Array): void {
+        if (!this.section2DOverlayRenderer) return;
+        this.section2DOverlayRenderer.uploadGridLines3D(vertices);
+        this.host.requestRender();
+    }
+
+    /** See `Renderer.clearGridLines3D` for the published contract. */
+    clearGridLines3D(): void {
+        if (this.section2DOverlayRenderer) {
+            this.section2DOverlayRenderer.clearGridLines3D();
+            this.host.requestRender();
+        }
+    }
+
+    /** See `Renderer.uploadDxfLines3D` for the published contract. */
+    uploadDxfLines3D(vertices: Float32Array): void {
+        if (!this.section2DOverlayRenderer) return;
+        this.section2DOverlayRenderer.uploadDxfLines3D(vertices);
+        this.host.requestRender();
+    }
+
+    /** See `Renderer.clearDxfLines3D` for the published contract. */
+    clearDxfLines3D(): void {
+        if (this.section2DOverlayRenderer) {
+            this.section2DOverlayRenderer.clearDxfLines3D();
+            this.host.requestRender();
+        }
+    }
+
+    /** See `Renderer.setClashOverlapBox` for the published contract. */
+    setClashOverlapBox(
+        box: { min: [number, number, number]; max: [number, number, number]; color: [number, number, number, number] } | null,
+    ): void {
+        if (!this.section2DOverlayRenderer) return;
+        if (!box) {
+            this.section2DOverlayRenderer.clearClashBoxLines3D();
+            this.host.requestRender();
+            return;
+        }
+        this.section2DOverlayRenderer.setClashBoxLineColor(box.color);
+        this.section2DOverlayRenderer.uploadClashBoxLines3D(aabbEdgeLineList(box.min, box.max));
+        this.host.requestRender();
+    }
+
+    /**
+     * See `Renderer.setClashContactLines` for the published contract. Shares the
+     * clash-box line buffer, so only one of this / setClashOverlapBox shows.
+     */
+    setClashContactLines(
+        lines: { vertices: Float32Array; color: [number, number, number, number] } | null,
+    ): void {
+        if (!this.section2DOverlayRenderer) return;
+        if (!lines || lines.vertices.length === 0) {
+            this.section2DOverlayRenderer.clearClashBoxLines3D();
+            this.host.requestRender();
+            return;
+        }
+        this.section2DOverlayRenderer.setClashBoxLineColor(lines.color);
+        this.section2DOverlayRenderer.uploadClashBoxLines3D(lines.vertices);
+        this.host.requestRender();
+    }
+
+    /** See `Renderer.uploadAnnotationFills3D` for the published contract. */
+    uploadAnnotationFills3D(fills: readonly SymbolicFillInput[]): void {
+        this.symbolic.uploadFills(fills);
+    }
+
+    /** See `Renderer.uploadAnnotationTexts3D` for the published contract. */
+    uploadAnnotationTexts3D(texts: readonly SymbolicTextInput[]): void {
+        this.symbolic.uploadTexts(texts);
+    }
+
+    /** See `Renderer.hasSection2DOverlay` for the published contract. */
+    hasSection2DOverlay(): boolean {
+        return this.section2DOverlayRenderer?.hasGeometry() ?? false;
+    }
+}

--- a/packages/renderer/src/renderer-symbolic-overlays.ts
+++ b/packages/renderer/src/renderer-symbolic-overlays.ts
@@ -1,0 +1,160 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The symbolic annotation overlay: filled IfcAnnotation regions and world-space
+ * text labels (issue #653).
+ *
+ * Split out of `RendererOverlays` because these are a genuinely separate pair of
+ * GPU objects — `SymbolicFillPipeline` and `SymbolicTextPipeline` own their own
+ * buffers, sampler and glyph-atlas texture, and share no state whatsoever with
+ * the `Section2DOverlayRenderer` that backs the section cap and every 3D line
+ * layer. `RendererOverlays` composes this and drives the draw order, because the
+ * order is the one thing the two families do share: fills paint underneath the
+ * line layers, text labels on top of everything.
+ */
+
+import type { Camera } from './camera.js';
+import {
+    SymbolicFillPipeline,
+    SymbolicTextPipeline,
+    type SymbolicFillInput,
+    type SymbolicTextInput,
+} from './symbolic-overlay-pipelines.js';
+
+/**
+ * The model-bounds bookkeeping the symbolic uploads borrow from `Renderer`.
+ * Structurally narrower than `OverlayHost` on purpose: this module never reads
+ * the bounds back, it only grows them and asks for a frame.
+ */
+export interface SymbolicOverlayHost {
+    expandModelBoundsWithFlatVertices(positions: Float32Array, stride: number): void;
+    syncCameraSceneBounds(): void;
+    requestRender(): void;
+}
+
+export class SymbolicOverlays {
+    private fillPipeline: SymbolicFillPipeline | null = null;
+    private textPipeline: SymbolicTextPipeline | null = null;
+
+    constructor(private readonly host: SymbolicOverlayHost) {}
+
+    /**
+     * Share the device + presentation format AND the MSAA sample count +
+     * objectId attachment shape with the rest of the renderer so these
+     * composite into the same RGBA pass without WebGPU pass-compatibility
+     * validation errors.
+     */
+    init(device: GPUDevice, format: GPUTextureFormat, sampleCount: number): void {
+        this.fillPipeline = new SymbolicFillPipeline(device, format, sampleCount);
+        this.textPipeline = new SymbolicTextPipeline(device, format, sampleCount);
+    }
+
+    /**
+     * These pipelines own their own GPU buffers, sampler, and atlas texture —
+     * recreating the viewer without releasing them leaks resources on every
+     * reload.
+     */
+    destroy(): void {
+        this.fillPipeline?.destroy();
+        this.fillPipeline = null;
+        this.textPipeline?.destroy();
+        this.textPipeline = null;
+    }
+
+    /** Background layer: painted before the 3D line overlays. */
+    drawFills(pass: GPURenderPassEncoder, viewProj: Float32Array): void {
+        if (this.fillPipeline?.hasGeometry()) {
+            this.fillPipeline.render(pass, viewProj);
+        }
+    }
+
+    /** Label layer: painted after everything else. */
+    drawTexts(
+        pass: GPURenderPassEncoder,
+        viewProj: Float32Array,
+        canvasWidth: number,
+        canvasHeight: number,
+        camera: Camera,
+    ): void {
+        if (!this.textPipeline?.hasGeometry()) return;
+        // Pass viewport pixel dimensions so the shader can scale glyphs
+        // to a constant on-screen size (BIMvision-style annotations)
+        // regardless of camera distance or authored text height.
+        //
+        // Also pass the screen-aligned camera basis (right, up) so
+        // billboarded glyphs (grid bubble tags) can face the camera
+        // in any orientation — top-down, eye-level, oblique alike.
+        const camPos = camera.getPosition();
+        const camTgt = camera.getTarget();
+        const camUpVec = camera.getUp();
+        // Forward = normalize(target - position).
+        let fx = camTgt.x - camPos.x;
+        let fy = camTgt.y - camPos.y;
+        let fz = camTgt.z - camPos.z;
+        let flen = Math.hypot(fx, fy, fz) || 1;
+        fx /= flen; fy /= flen; fz /= flen;
+        // Right = normalize(cross(forward, world-up)).
+        let rx = fy * camUpVec.z - fz * camUpVec.y;
+        let ry = fz * camUpVec.x - fx * camUpVec.z;
+        let rz = fx * camUpVec.y - fy * camUpVec.x;
+        let rlen = Math.hypot(rx, ry, rz) || 1;
+        rx /= rlen; ry /= rlen; rz /= rlen;
+        // True up = normalize(cross(right, forward)) — guaranteed
+        // perpendicular to both, defines screen-space vertical.
+        const ux = ry * fz - rz * fy;
+        const uy = rz * fx - rx * fz;
+        const uz = rx * fy - ry * fx;
+        this.textPipeline.render(
+            pass,
+            viewProj,
+            canvasWidth,
+            canvasHeight,
+            [rx, ry, rz],
+            [ux, uy, uz],
+        );
+    }
+
+    /** See `Renderer.uploadAnnotationFills3D` for the published contract. */
+    uploadFills(fills: readonly SymbolicFillInput[]): void {
+        if (!this.fillPipeline) return;
+        this.fillPipeline.upload(fills);
+        // Contribute fill extents to modelBounds — see uploadAnnotationLines3D.
+        for (const fill of fills) {
+            const pts = fill.points;
+            if (pts.length === 0) continue;
+            // points are flat [x,z,x,z,...]; lift to (x, fill.worldY, z) per
+            // vertex so we expand bounds in the same world space the renderer draws in.
+            const lifted = new Float32Array((pts.length / 2) * 3);
+            for (let i = 0, j = 0; i < pts.length; i += 2, j += 3) {
+                lifted[j] = pts[i];
+                lifted[j + 1] = fill.worldY;
+                lifted[j + 2] = pts[i + 1];
+            }
+            this.host.expandModelBoundsWithFlatVertices(lifted, 3);
+        }
+        this.host.syncCameraSceneBounds();
+        this.host.requestRender();
+    }
+
+    /** See `Renderer.uploadAnnotationTexts3D` for the published contract. */
+    uploadTexts(texts: readonly SymbolicTextInput[]): void {
+        if (!this.textPipeline) return;
+        this.textPipeline.upload(texts);
+        // Text origins are single points; pack them into a flat buffer and
+        // expand bounds. Glyph extents are small enough that origin-only
+        // suffices for framing.
+        if (texts.length > 0) {
+            const buf = new Float32Array(texts.length * 3);
+            for (let i = 0; i < texts.length; i++) {
+                buf[i * 3 + 0] = texts[i].worldPos[0];
+                buf[i * 3 + 1] = texts[i].worldPos[1];
+                buf[i * 3 + 2] = texts[i].worldPos[2];
+            }
+            this.host.expandModelBoundsWithFlatVertices(buf, 3);
+            this.host.syncCameraSceneBounds();
+        }
+        this.host.requestRender();
+    }
+}


### PR DESCRIPTION
Hygiene only. `packages/renderer/src/index.ts` was 3946 lines against the ~400-line house rule in `AGENTS.md`. This takes two of the seams issue #2425 records, as a pure move: no behaviour change, nothing renamed that a caller can see, no argument reordered.

There is no user-visible benefit here. Nothing renders differently, nothing is fixed. The only thing that changes is where three chunks of code live.

## Seams

**`renderer-overlays.ts` — `RendererOverlays` (534 lines).** The section-plane gizmo, the 2D section drawing / cut cap, and the standalone 3D line + symbolic overlays: annotation lines / fills / text, alignment centrelines, grid axes, the DXF reference layer, and the focused clash's box and contact lines. Those four GPU objects were already one unit in everything but location — created together in `init()`, destroyed together in `destroy()`, drawn one after another at the tail of the render pass, and fed by an upload facade that touches nothing else. This follows the `PickingManager` / `RaycastEngine` precedent the issue points at: a cohesive chunk of state plus its behaviour, composed rather than inlined.

`Renderer` keeps every public method as a one-line delegate, so the exported surface is unchanged. What stayed behind is what genuinely couples: the model-bounds AABB, which several uploads grow so an annotation-only or alignment-only model can still be framed, and which the camera, the section slider and `getDiagnostics()` all read. Rather than give one AABB two owners, the collaborator reaches the renderer's copy through a four-method `OverlayHost` seam.

**`render-section-plane.ts` — `resolveSectionPlaneFrame` (289 lines).** The per-frame clip-plane resolution, out of `renderFrame`'s encode region: the bounds aggregation the slider is expressed in (batched meshes, folded point clouds, the individual-mesh and `[-100, 100]` fallbacks), the terrain-clip and explicit-plane branches, the building rotation, the UI-override validity policy, and the one-shot `[Section]` diagnostic. It is a pure function — the two effects it used to have on the renderer (the bounds it computed, and whether it spent the log latch) come back in the return value for `renderFrame` to apply.

| file | before | after |
| --- | --- | --- |
| `packages/renderer/src/index.ts` | 3946 | **3499** (-447) |
| `packages/renderer/src/renderer-overlays.ts` | - | 399 |
| `packages/renderer/src/renderer-symbolic-overlays.ts` | - | 160 |
| `packages/renderer/src/render-section-plane.ts` | - | 306 |

All three new modules are under the ~400-line rule. (An earlier revision of this
body said 3495 / -451; that was wrong. 3499 / -447 is the measured figure.)

## What was deliberately left in `index.ts`

**The render-error lifecycle.** #2423's review already established the case against moving it, and it still holds: `containFrameThrow` / `notePersistentDegradation` read or write nine pieces of renderer state, three of them owned by code that would stay behind — `lastRenderErrorTime` / `RENDER_ERROR_THROTTLE_MS` shared with `drainErrorScope`, `_renderErrorCount` / `_lastRenderError` read by `getDiagnostics()`, and `consecutiveDegradedFrames` / `frameContainedThrow` written by `render()`. That last pair is one invariant, not two: the encode catch swallows its throw, so `renderFrame` returning normally is not proof the frame succeeded, which is why `render()` guards the reset on `frameContainedThrow`. Putting the increment and the reset in different files is what #2423 exists to have avoided. Moving it is a judgement call, not a mechanical move, so it does not belong in this PR.

**Model bounds, the point-cloud facade, and the rest of the encode region.** All still viable seams; each is worth its own PR, per the issue.

`index.ts` is still 3495 lines. This is a dent, not a fix.

## Verification

- Root `pnpm typecheck`: exit 0.
- Root `pnpm test`: exit 0, 86/86 turbo tasks. `@ifc-lite/renderer` **494 tests / 111 suites / 494 pass / 0 fail** — identical to the count at #2423's merge, no test moved or added.
- One earlier `pnpm test` run failed on `packages/sandbox/src/bridge-clash-cancel.test.ts` (a 20 s wall-clock QuickJS interrupt test) while a viewer build was saturating the machine. `@ifc-lite/sandbox` does not depend on `@ifc-lite/renderer`, and the clean re-run passed 182/182. Flagged rather than buried.
- `pnpm api-surface:update` produces no diff, so **no changeset**: nothing about the exported surface moved.
- `pnpm knip` reports nothing against either new module.

### #2423's mutations, re-run

Each mutation was applied to the post-split `index.ts`, confirmed present by grep, and run against the renderer suite; the control was re-run clean afterwards.

| mutation | result |
| --- | --- |
| latch on every throw (`if (isDeviceLossThrow(error))` -> `if (true)`) | **killed** - 16 fail, incl. "a NON-device throw costs one frame, not the session (#2229 review)", "the ENCODE region gets the same discrimination as the rest of the frame (#2417)", "a viewport that degrades and never recovers says so (#2417)" |
| `render()` resets the run unconditionally (drop the `!this.frameContainedThrow` guard) | **killed** - 3 fail, incl. both #2417 tests |
| `frameContainedThrow` never set | **killed** - 3 fail, incl. both #2417 tests |
| control (unmutated) | 494/494 pass, exit 0 |

## Residual risk

The moved code was checked against the original by normalised diff (indentation, comments and the `this.` prefix stripped): the section-plane body is line-for-line identical apart from the intended `if (!logged)` -> `if (logSectionBounds)` inversion and the early return that replaces the `if (options.sectionPlane)` wrapper; the overlay draw body differs only in reading the canvas size from the draw context; the upload facade is identical.

**One** ordering change remains, and it is deliberate:

- `setModelBounds` / `camera.setSceneBounds` now run *after* the enabled-plane branch instead of before it. Nothing in that branch reads either, and both still receive their own wrapper object over the same `min`/`max` — the aliasing is unchanged.

The second one is **gone**. An earlier revision moved the `_loggedSectionBounds` latch to after the `console.info`. That is not merely a re-entrancy question: the log runs inside `renderFrame`'s encode `try`, so if `console.info` threw (a monkey-patched console being the only realistic route), the latch would never be spent and **every** later section-enabled frame would throw again and be contained as a degraded frame, eventually firing `onPersistentRenderDegradation` — where the original cost one contained frame, ever. Fixed by injecting `spendLogLatch`, which commits the latch immediately before the log, restoring the inline ordering exactly.

Proven rather than asserted, with a control:

```
throwing console.info over 5 section-enabled frames: frames=5 throws=1 latchSpent=true
  -> PASS - one contained frame ever (matches pre-extraction)
control (commit-after-return):  frames=5 throws=5 latchSpent=false
  -> CONTROL CONFIRMS the bug the fix removes
```

The honest exposure is that CI exercises these GPU paths through fakes, so "494 green" proves the JS control flow, not what a real device draws. A rendering regression here would most plausibly show as a missing or mis-clipped overlay (section cap, annotation, grid, DXF, clash lines) or a wrong section slider range, and the fakes would not catch it. Worth a look at a real model with a section plane and an annotation/grid overlay before merging.

## Review findings: all five pre-existing, none fixed here

CodeRabbit raised three findings. Each was checked against `origin/main` before deciding whether it belonged in this PR, and all three are **byte-identical to `main`** — the move introduced none of them. Verified mechanically, not by eye: the three flagged spans were extracted from `git show origin/main:packages/renderer/src/index.ts` and diffed against their new homes with indentation, comments and the `this.` prefix normalised. All three came back IDENTICAL.

They are therefore **not fixed here**. This PR's entire safety argument is that it is a mechanical move verifiable by diff; three behaviour changes in code CI exercises only through fakes would destroy that. They are filed instead:

- **#2441** (the major one, on its own) - degenerate camera basis.
- **#2442** - the two minors: non-finite explicit-plane input, and `uploadSection2DOverlay` / `clearSection2DOverlay` never requesting a render.

That these became legible at all is a fair argument for the split: the same code sat unremarked inside a 3946-line file.

### The major finding is worse than reported, and its stated trigger is wrong

Verifying rather than accepting it changed both the severity and the fix location:

- **It is not a NaN in the glyph basis.** `Math.hypot(rx, ry, rz) || 1` already coerces an exact zero to 1, so the basis collapses to zero-length, not NaN.
- **The ViewCube top button does not trigger it.** `setPresetView('top')` deliberately sits `Math.sin(0.01) * distance` off the +Y pole, with a comment saying that is exactly why; orbit re-asserts world-Y up and clamps phi to `[0.01, PI - 0.01]`. Plan view via the ViewCube is safe.
- **There is a real trigger the review missed, and it is much worse.** `pickFitPolicy`'s linear branch applies its 20-degree "downward tilt" around the same axis it tilts from, so for a Y-dominant model it does not tilt at all: `forward` comes out exactly `(0,1,0)` with `camera.up` also exactly `(0,1,0)`. `MathUtils.lookAt` has no degenerate-up guard, so the **entire view-projection matrix is NaN** and the viewport draws nothing. Confirmed by executing `pickFitPolicy` + `Camera.snapToFitPolicy` on a 300 m x 5 m bbox: `kind = linear`, `|cross| = 0`, `viewProj = NaN x16`. It is on the load path (`useGeometryStreaming` calls `fitBoundsAdaptive`), and the gates are just aspect > 50 and longest >= 100 m - ordinary vertical infrastructure.

So the flagged line is a downstream symptom; the fix belongs in `pickFitPolicy` and `lookAt`. Full analysis and reproduction in #2441.

## Codex threads

### "Split the oversized overlay module" - taken, but along a different seam

Fair hit: a PR that exists to fix an oversized module had produced a 534-line one. Split, and all three new modules now land under the rule (399 / 160 / 306).

The **specific** cut proposed - section-plane/cap on one side, standalone 3D line overlays on the other - is a false seam, and this is checkable rather than a matter of taste. Both halves drive the *same* `Section2DOverlayRenderer` instance:

| half | methods it calls on that one object |
| --- | --- |
| section / cap | `uploadDrawing`, `clearGeometry`, `hasGeometry`, `draw`, `setOverlayLineColor` |
| standalone 3D lines | `upload/clear/draw` x `AnnotationLines3D`, `AlignmentLines3D`, `GridLines3D`, `DxfLines3D`, `ClashBoxLines3D`, plus `setClashBoxLineColor` |

47 references to one nullable object that `init()` creates and `destroy()` disposes. Cutting there gives it two owners in two files - exactly the anti-pattern #2425 records as the reason not to split the error lifecycle ("splitting them gives one window two owners in two files"). The topics look separate; the GPU object is not.

The seam that *is* real is `SymbolicFillPipeline` / `SymbolicTextPipeline`: separate GPU objects with their own buffers, sampler and glyph atlas, and **zero** shared state with `Section2DOverlayRenderer` (grep confirms `section-2d-overlay.ts` never mentions either). Those moved to `renderer-symbolic-overlays.ts`. `RendererOverlays` composes it and retains the draw **order**, which is the one thing the two families genuinely share - fills underneath the line layers, text labels on top.

Also removed the duplicated JSDoc: I had copied each method's full doc onto both the `Renderer` delegate and the collaborator. The published surface is what consumers see in the emitted `.d.ts`, so the doc stays there and the collaborator carries implementation notes only.

Verified the split changed nothing: the overlay draw sequence is **9 calls in identical order** on both sides, and the camera-basis arithmetic compares IDENTICAL against `main` line-for-line.

`renderer-overlays.ts` at 399 is under the rule but only just, and I would rather name that than dress it up. What remains is one GPU object's 16-method facade, which cannot be divided further without co-ownership. The deeper problem is upstream: `section-2d-overlay.ts` is itself 1176 lines because that one class owns the cap *and* five independent line-buffer families. Splitting **that** is the change that would let this facade divide naturally, and it is a separate PR.

### "Add a changeset" - correct, and I was wrong

Added: `patch` for `@ifc-lite/renderer`.

My earlier reasoning ("no api-surface diff, so no changeset") does not hold. That gate records **export names and kinds only** - it is blind to shapes and says nothing about behaviour, so it cannot answer the release question. `AGENTS.md` says "changes to published `packages/*` need `pnpm changeset`", not "API changes", and repo practice matches the artifact-based reading:

- **67 with a changeset vs 4 without** across `refactor|perf|chore|style|test` commits touching a published `packages/*/src` since 2026-06-01 (94%), and none of the 4 is a file-split.
- Every close analogue shipped a `patch` **with** the no-behaviour-change statement written into the changeset body rather than used as a reason to skip it: `5371d7def` (#2134, extract to `diagnostics.ts`), `37224e8cd` (#1791, module split), `7efc87833` (#614, `e57.ts` 631 -> 4 files plus the `point-cloud-renderer.ts` extract in this very package).
- `891efef5f` (#1071) bumped this package on a change whose changelog says "No public API changes."

So: **artifact-based reading**. Consumers receive different built code; `patch` records that. Surface unchanged, so `scripts/api-surface.json` is untouched and `pnpm api-surface:update` still produces no diff.

## Second review round (`ca33dfb0b`): two more findings, both pre-existing

Same provenance test as before — check against `origin/main` first, then decide whether it belongs here. Both are byte-identical to `main`, so neither is fixed here.

### `SymbolicOverlays.init()` replaces pipelines without destroying them - #2448

This one needed a sharper test than "is the method new", because the file *is* new this round. The method is new glue; the question is whether the **behaviour** changed. It did not:

| | destroys before assigning? |
| --- | --- |
| `origin/main` `Renderer.init()` | no |
| branch `RendererOverlays.init()` + `SymbolicOverlays.init()` | no |

A normalised diff of the four overlay constructions compares **IDENTICAL**. The extraction moved the assignments; it did not create the absence of a teardown.

Severity, checked rather than assumed: **unreachable today.** One production call site (`Viewport.tsx:750-757`), `new Renderer(canvas)` three lines above `init()`, cleanup at `:1089` unconditionally destroys. StrictMode re-runs the whole effect body, so it yields two renderers each `init()`ed once, not one `init()`ed twice. No device-loss re-init path, no retry-on-failure, and the tests never call `init()` at all. It is a latent hazard that a future auto-recovery path would make live — which is exactly why it is filed rather than dropped.

### Section slider range is wrong for a rotated building - #2447

Correctness, not hygiene, and user-visible. The distance-range block compares **IDENTICAL** to `main`. The plane's normal is rotated by `buildingRotation`, but its range is still the axis-aligned bbox extent along `x`/`y`/`z` — so the slider does not span the model along the direction the plane actually cuts.

Quantified on a 40 x 10 x 20 bbox with `axis: 'side'`:

| rotation | normal | slider 0% | slider 100% | true min | true max | covers |
| --- | --- | --- | --- | --- | --- | --- |
| 0 deg | `[1, 0, 0]` | -20.000 | 20.000 | -20.000 | 20.000 | yes |
| 45 deg | `[0.707, 0, 0.707]` | -20.000 | 20.000 | **-21.213** | **21.213** | **no** |

A 2.426-unit shortfall: at both ends of its travel the plane cannot reach the model's extremes. The same wrong range also gates the `uiMin`/`uiMax` storey-override check, and `uploadSection2DOverlay` repeats the formula. Fix and the two follow-on hazards are in #2447.

Fixes #2425.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved rendering of section planes, section caps, annotations, grids, DXF overlays, and clash visuals.
  - Enhanced support for standalone 3D overlays and symbolic annotation fills and labels.
  - Improved handling of model bounds, camera synchronization, building rotation, and section-plane ranges.
  - Preserved existing renderer behavior and public APIs.
  - Added more consistent overlay drawing and render updates for smoother visual results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
