### PR TITLE
fix(mcp): submesh-aware registry, depthWrite sync, WebGL context release, projectPin docs

### DIFF
--- a/apps/viewer/src/components/mcp/hero-scene.ts
+++ b/apps/viewer/src/components/mcp/hero-scene.ts
@@ -22,6 +22,7 @@ import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { STOREY, buildHeroBuilding } from './hero-scene-building';
 import { createHeroAnimationState, createStepController } from './hero-scene-steps';
+import { releaseRenderer } from './release-renderer';
 
 const NIGHT = 0x0a0a0c;
 
@@ -204,10 +205,7 @@ export function createScene(container: HTMLElement): SceneHandle {
       // explicitly so the canvas-backed GPU texture doesn't leak across
       // mount/unmount cycles.
       pinTex.dispose();
-      renderer.dispose();
-      if (renderer.domElement.parentNode === container) {
-        container.removeChild(renderer.domElement);
-      }
+      releaseRenderer(renderer, container);
     },
   };
 }

--- a/apps/viewer/src/components/mcp/hero-scene.ts
+++ b/apps/viewer/src/components/mcp/hero-scene.ts
@@ -32,8 +32,15 @@ export interface SceneHandle {
   /**
    * Project the BCF pin's world position into the host element's local
    * coordinate space so a sibling HTML overlay can track it through orbit
-   * and camera transitions. Returns null when the pin is behind the camera
-   * or the host has no size yet.
+   * and camera transitions.
+   *
+   * Two distinct outcomes, and callers must handle both (#2446):
+   * - `null` — the host has no size yet, so there is no coordinate space to
+   *   project into and no position to report.
+   * - a frame with `visible: false` — the pin projected fine but fell outside
+   *   the camera's depth range (behind it, or beyond the far plane). `x` / `y`
+   *   are still filled in and are meaningless; read `visible` before using
+   *   them.
    */
   projectPin(): { x: number; y: number; visible: boolean } | null;
 }
@@ -177,6 +184,8 @@ export function createScene(container: HTMLElement): SceneHandle {
     projectPin() {
       const w = container.clientWidth;
       const h = container.clientHeight;
+      // No size yet — the ONLY null this returns (#2446). Out-of-frustum is
+      // reported through `visible` below, never by returning null.
       if (w === 0 || h === 0) return null;
       projScratch.copy(pin.position).project(camera);
       const visible = projScratch.z >= -1 && projScratch.z <= 1;

--- a/apps/viewer/src/components/mcp/hero-scene.ts
+++ b/apps/viewer/src/components/mcp/hero-scene.ts
@@ -41,6 +41,11 @@ export interface SceneHandle {
    *   the camera's depth range (behind it, or beyond the far plane). `x` / `y`
    *   are still filled in and are meaningless; read `visible` before using
    *   them.
+   *
+   * `visible` is a DEPTH test only, which is a known defect rather than the
+   * intended contract: a pin outside the left/right/top/bottom bounds still
+   * reports `visible: true`, and on the BCF pin step that is about a quarter
+   * of every revolution (#2453). Do not build on the current meaning.
    */
   projectPin(): { x: number; y: number; visible: boolean } | null;
 }

--- a/apps/viewer/src/components/mcp/playground-scene-ops.ts
+++ b/apps/viewer/src/components/mcp/playground-scene-ops.ts
@@ -14,7 +14,7 @@
 
 import * as THREE from 'three';
 import type { ColorTuple } from './playground-viewer-types';
-import { selectTargets, type EntityRecord, type EntityRegistry } from './playground-scene-registry';
+import { isTranslucent, selectTargets, type EntityRecord, type EntityRegistry } from './playground-scene-registry';
 import type { SectionState } from './playground-scene-view';
 
 export function colorize(
@@ -29,11 +29,16 @@ export function colorize(
   // base colour so subsequent reset() / clear-selection paths put it
   // back, not pick a stale opacity from before this call.
   const alpha = args.color[3] ?? 1;
+  // `depthWrite` is derived from transparency at construction, so it has to be
+  // re-derived here too: leaving it stale makes a translucent repaint write
+  // depth and occlude what is behind it (#2444).
+  const translucent = isTranslucent(alpha);
   for (const r of targets) {
     const mat = r.mesh.material as THREE.MeshStandardMaterial;
     mat.color.copy(c);
     r.baseColor.copy(c);
-    mat.transparent = alpha < 0.999;
+    mat.transparent = translucent;
+    mat.depthWrite = !translucent;
     mat.opacity = alpha;
     r.baseOpacity = alpha;
   }
@@ -75,7 +80,10 @@ export function reset(reg: EntityRegistry, section: SectionState): void {
     const mat = r.mesh.material as THREE.MeshStandardMaterial;
     mat.color.copy(r.baseColor);
     mat.opacity = r.baseOpacity;
-    mat.transparent = r.baseOpacity < 0.999;
+    // Same derived pair as construction and colorize() (#2444).
+    const translucent = isTranslucent(r.baseOpacity);
+    mat.transparent = translucent;
+    mat.depthWrite = !translucent;
   }
   section.active = null;
   section.planes.length = 0;

--- a/apps/viewer/src/components/mcp/playground-scene-ops.ts
+++ b/apps/viewer/src/components/mcp/playground-scene-ops.ts
@@ -14,7 +14,7 @@
 
 import * as THREE from 'three';
 import type { ColorTuple } from './playground-viewer-types';
-import { isTranslucent, selectTargets, type EntityRecord, type EntityRegistry } from './playground-scene-registry';
+import { countEntities, isTranslucent, selectTargets, type EntityRecord, type EntityRegistry } from './playground-scene-registry';
 import type { SectionState } from './playground-scene-view';
 
 export function colorize(
@@ -32,6 +32,15 @@ export function colorize(
   // `depthWrite` is derived from transparency at construction, so it has to be
   // re-derived here too: leaving it stale makes a translucent repaint write
   // depth and occlude what is behind it (#2444).
+  //
+  // Caveat, deliberately not fixed here: `transparent` alone does not reach
+  // the GPU. three.js folds it into the `opaque` PROGRAM parameter, which
+  // emits `#define OPAQUE` and forces `diffuseColor.a = 1.0`, and its
+  // `needsProgramChange` check never inspects `transparent` — so flipping it
+  // without `mat.needsUpdate = true` leaves the old shader bound and the
+  // entity does not actually become see-through. Pre-existing, tracked in
+  // #2454. `depthWrite` and `opacity` are per-draw state and a uniform, so
+  // both take effect immediately and the fix below is sound as written.
   const translucent = isTranslucent(alpha);
   for (const r of targets) {
     const mat = r.mesh.material as THREE.MeshStandardMaterial;
@@ -42,7 +51,7 @@ export function colorize(
     mat.opacity = alpha;
     r.baseOpacity = alpha;
   }
-  return { count: targets.length };
+  return { count: countEntities(targets) };
 }
 
 export function isolate(
@@ -53,7 +62,7 @@ export function isolate(
   for (const r of reg.records) {
     r.mesh.visible = targets.has(r);
   }
-  return { count: targets.size };
+  return { count: countEntities(targets) };
 }
 
 export function hide(
@@ -62,7 +71,7 @@ export function hide(
 ): { count: number } {
   const targets = selectTargets(reg, args);
   for (const r of targets) r.mesh.visible = false;
-  return { count: targets.length };
+  return { count: countEntities(targets) };
 }
 
 export function show(
@@ -71,7 +80,7 @@ export function show(
 ): { count: number } {
   const targets = selectTargets(reg, args);
   for (const r of targets) r.mesh.visible = true;
-  return { count: targets.length };
+  return { count: countEntities(targets) };
 }
 
 export function reset(reg: EntityRegistry, section: SectionState): void {
@@ -113,6 +122,9 @@ export function colorByProperty(
     sample: (expressId: number) => string | number | boolean | null;
   },
 ): { legend: Array<{ value: string; count: number; color: ColorTuple }> } {
+  // NOTE: these are submesh records, so a bucket over elements that tessellate
+  // into several parts over-counts and re-samples the property per part.
+  // Pre-existing and out of scope for the count fix in the sibling ops (#2455).
   const records = reg.byType.get(type) ?? [];
   const buckets = new Map<string, EntityRecord[]>();
   for (const r of records) {

--- a/apps/viewer/src/components/mcp/playground-scene-registry.test.ts
+++ b/apps/viewer/src/components/mcp/playground-scene-registry.test.ts
@@ -3,7 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
- * The playground registry's id lookups against multi-submesh elements (#2443).
+ * The playground registry's id lookups against multi-submesh elements (#2443),
+ * and the transparency state its operations re-derive (#2444).
  *
  * Why this is reachable from CI when the scene is not: only `createScene`
  * needs a GPU (`new THREE.WebGLRenderer` throws under happy-dom, which is why
@@ -36,7 +37,7 @@ import {
   type EntityRecord,
 } from './playground-scene-registry.js';
 import { createSectionState } from './playground-scene-view.js';
-import { colorize, hide, isolate, show } from './playground-scene-ops.js';
+import { colorize, hide, isolate, reset, show } from './playground-scene-ops.js';
 
 const WALL_A_ID = 1;
 const WALL_B_ID = 2;
@@ -209,5 +210,73 @@ describe('playground registry: id lookups cover every submesh (#2443)', () => {
     buildEntityRecords(reg, splitMeshes(), model, modelGroup, createSectionState());
     assert.equal(reg.byExpressId.get(WALL_A_ID)?.length, 2, 'exactly the new load, not both');
     assert.equal(selectTargets(reg, { expressIds: [WALL_A_ID] }).length, 2);
+  });
+});
+
+describe('playground registry: colorize/reset keep depthWrite in sync (#2444)', () => {
+  it('drops depthWrite when an opaque entity is colourised translucent', () => {
+    const { reg } = mount();
+    const target = (reg.byExpressId.get(WALL_B_ID) ?? [])[0];
+    assert.equal(mat(target).depthWrite, true, 'it loaded opaque');
+
+    colorize(reg, { expressIds: [WALL_B_ID], color: [1, 0, 0, 0.3] });
+
+    assert.equal(mat(target).transparent, true);
+    assert.equal(mat(target).depthWrite, false, 'a translucent material must not write depth');
+  });
+
+  it('restores depthWrite when a translucent entity is colourised opaque', () => {
+    const { reg } = mount([tri(WALL_B_ID, 0, [0.5, 0.5, 0.5, 0.3])]);
+    const target = (reg.byExpressId.get(WALL_B_ID) ?? [])[0];
+    assert.equal(mat(target).depthWrite, false, 'it loaded translucent');
+
+    colorize(reg, { expressIds: [WALL_B_ID], color: [1, 0, 0, 1] });
+
+    assert.equal(mat(target).transparent, false);
+    assert.equal(mat(target).depthWrite, true, 'an opaque material must write depth again');
+  });
+
+  it('re-derives the whole transparency triple on reset()', () => {
+    // `viewer_reset` is the put-everything-back tool: whatever touched the
+    // material in between, afterwards its rendering state must be exactly what
+    // the record's base state implies. It restored `opacity` and `transparent`
+    // only, so a material whose depthWrite disagreed with its own alpha stayed
+    // that way (#2444).
+    //
+    // Driving it through colorize() would prove nothing here — colorize
+    // overwrites `baseOpacity` too, so the two agree by construction and the
+    // assertion holds with or without the fix. The stale state is set directly
+    // instead, which is the invariant reset() actually owes its callers.
+    const { reg, section } = mount([tri(WALL_B_ID, 0, [0.5, 0.5, 0.5, 0.3])]);
+    const target = (reg.byExpressId.get(WALL_B_ID) ?? [])[0];
+    assert.equal(target.baseOpacity, 0.3, 'the base state of the record is translucent');
+
+    const m = mat(target);
+    m.transparent = false;
+    m.opacity = 1;
+    m.depthWrite = true;
+
+    reset(reg, section);
+
+    assert.equal(m.opacity, 0.3);
+    assert.equal(m.transparent, true);
+    assert.equal(m.depthWrite, false, 'depthWrite is part of what reset() restores');
+  });
+
+  it('agrees with construction on the transparency threshold', () => {
+    // The constructor used `a < 1` while the operations used `a < 0.999`, so
+    // an alpha in between mounted one way and reset() the other.
+    const alpha = 0.9995;
+    const { reg, section } = mount([tri(WALL_B_ID, 0, [1, 1, 1, alpha])]);
+    const target = (reg.byExpressId.get(WALL_B_ID) ?? [])[0];
+    const mounted = { transparent: mat(target).transparent, depthWrite: mat(target).depthWrite };
+
+    reset(reg, section);
+
+    assert.deepEqual(
+      { transparent: mat(target).transparent, depthWrite: mat(target).depthWrite },
+      mounted,
+      'a reset with no colorize in between must be a no-op on transparency state',
+    );
   });
 });

--- a/apps/viewer/src/components/mcp/playground-scene-registry.test.ts
+++ b/apps/viewer/src/components/mcp/playground-scene-registry.test.ts
@@ -1,0 +1,213 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The playground registry's id lookups against multi-submesh elements (#2443).
+ *
+ * Why this is reachable from CI when the scene is not: only `createScene`
+ * needs a GPU (`new THREE.WebGLRenderer` throws under happy-dom, which is why
+ * `PlaygroundViewer.test.ts` refuses to mount the component). Everything under
+ * test here — `buildEntityRecords`, `selectTargets`, and the colour/visibility
+ * operations — are plain functions over an `EntityRegistry`, and the three.js
+ * objects they build (`BufferGeometry`, `MeshStandardMaterial`, `Group`)
+ * construct, mutate and dispose entirely on the CPU. So the defect is testable
+ * even though the factory that wires it up is not.
+ *
+ * The fixture is the oracle, and it is the whole point: WALL_A tessellates
+ * into TWO `MeshData` entries — the per-material / per-CSG-part split that
+ * `packages/geometry/src/types.ts` documents as normal — and WALL_B into one.
+ * A fixture with one submesh per element could not express the broken state
+ * (last-wins and accumulate are indistinguishable at N=1), so it would prove
+ * nothing.
+ */
+
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import * as THREE from 'three';
+
+import type { MeshData } from '@ifc-lite/geometry';
+import { parsePlaygroundModel, type LoadedPlaygroundModel } from './playground-dispatcher.js';
+import {
+  buildEntityRecords,
+  clearEntityRecords,
+  createEntityRegistry,
+  selectTargets,
+  type EntityRecord,
+} from './playground-scene-registry.js';
+import { createSectionState } from './playground-scene-view.js';
+import { colorize, hide, isolate, show } from './playground-scene-ops.js';
+
+const WALL_A_ID = 1;
+const WALL_B_ID = 2;
+const WALL_A_GUID = '2443SplitWallAAAAAAAAA';
+const WALL_B_GUID = '2443SoloWallBBBBBBBBBB';
+
+/** Two walls, so the model has an element with submeshes AND a control. */
+async function twoWallModel(): Promise<LoadedPlaygroundModel> {
+  const bytes = new TextEncoder().encode([
+    'ISO-10303-21;', 'HEADER;', "FILE_DESCRIPTION((''),'2;1');",
+    "FILE_NAME('','',(''),(''),'','','');", "FILE_SCHEMA(('IFC4'));", 'ENDSEC;', 'DATA;',
+    `#${WALL_A_ID}=IFCWALL('${WALL_A_GUID}',$,'Split Wall',$,$,$,$,$,.STANDARD.);`,
+    `#${WALL_B_ID}=IFCWALL('${WALL_B_GUID}',$,'Solo Wall',$,$,$,$,$,.STANDARD.);`,
+    'ENDSEC;', 'END-ISO-10303-21;', '',
+  ].join('\n'));
+  return parsePlaygroundModel(bytes.buffer as ArrayBuffer, 'split.ifc');
+}
+
+/** One triangle, offset so each submesh is a distinct object. */
+function tri(expressId: number, offset: number, color: [number, number, number, number]): MeshData {
+  return {
+    expressId,
+    ifcType: 'IfcWall',
+    positions: new Float32Array([offset, 0, 0, offset + 1, 0, 0, offset, 1, 0]),
+    normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+    indices: new Uint32Array([0, 1, 2]),
+    color,
+  };
+}
+
+/**
+ * WALL_A as a glass + frame pair, WALL_B as a single solid. The two WALL_A
+ * submeshes carry different colours precisely so a fix that indexes only one
+ * of them cannot hide behind identical materials.
+ */
+function splitMeshes(): MeshData[] {
+  return [
+    tri(WALL_A_ID, 0, [1, 1, 1, 1]),   // frame, opaque
+    tri(WALL_A_ID, 2, [0, 0.4, 1, 1]), // glass, opaque (alpha varied per-test)
+    tri(WALL_B_ID, 4, [0.5, 0.5, 0.5, 1]),
+  ];
+}
+
+function mat(r: EntityRecord): THREE.MeshStandardMaterial {
+  return r.mesh.material as THREE.MeshStandardMaterial;
+}
+
+let model: LoadedPlaygroundModel;
+before(async () => { model = await twoWallModel(); });
+
+/** A fresh registry + model group holding the three submeshes above. */
+function mount(meshes: MeshData[] = splitMeshes()) {
+  const reg = createEntityRegistry();
+  const modelGroup = new THREE.Group();
+  const section = createSectionState();
+  const tally = buildEntityRecords(reg, meshes, model, modelGroup, section);
+  return { reg, modelGroup, section, tally };
+}
+
+describe('playground registry: id lookups cover every submesh (#2443)', () => {
+  it('resolves the fixture metadata the rest of the suite stands on', () => {
+    // Guards the fixture itself: if GlobalId enrichment ever stopped
+    // resolving, every globalId assertion below would pass vacuously by
+    // selecting nothing.
+    const { reg } = mount();
+    assert.equal(reg.records.length, 3, 'three submeshes across two elements');
+    assert.deepEqual(
+      reg.records.map((r) => r.globalId),
+      [WALL_A_GUID, WALL_A_GUID, WALL_B_GUID],
+      'each record carries the GlobalId of the element it belongs to',
+    );
+  });
+
+  it('indexes both submeshes of one element under its expressId', () => {
+    const { reg } = mount();
+    assert.equal(reg.byExpressId.get(WALL_A_ID)?.length, 2);
+    assert.equal(reg.byExpressId.get(WALL_B_ID)?.length, 1);
+  });
+
+  it('selects both submeshes by expressId', () => {
+    const { reg } = mount();
+    assert.equal(selectTargets(reg, { expressIds: [WALL_A_ID] }).length, 2);
+  });
+
+  it('selects both submeshes by GlobalId', () => {
+    const { reg } = mount();
+    assert.equal(selectTargets(reg, { globalIds: [WALL_A_GUID] }).length, 2);
+  });
+
+  it('makes id-addressing and type-addressing agree on the same element', () => {
+    // The headline symptom: `viewer_isolate({ type })` reached every submesh
+    // while `viewer_colorize({ expressIds })` reached one, so the same element
+    // answered differently depending on how the agent named it.
+    const { reg } = mount();
+    const byType = selectTargets(reg, { type: 'IfcWall' })
+      .filter((r) => r.expressId === WALL_A_ID);
+    const byId = selectTargets(reg, { expressIds: [WALL_A_ID] });
+    const byGuid = selectTargets(reg, { globalIds: [WALL_A_GUID] });
+    assert.equal(byType.length, 2, 'type-addressing already reached both');
+    assert.deepEqual(new Set(byId), new Set(byType));
+    assert.deepEqual(new Set(byGuid), new Set(byType));
+  });
+
+  it('colorizes every submesh of an element addressed by expressId', () => {
+    const { reg } = mount();
+    const res = colorize(reg, { expressIds: [WALL_A_ID], color: [1, 0, 0, 1] });
+    assert.equal(res.count, 2, 'the tool reports both submeshes');
+
+    for (const r of reg.byExpressId.get(WALL_A_ID) ?? []) {
+      assert.deepEqual(
+        [mat(r).color.r, mat(r).color.g, mat(r).color.b], [1, 0, 0],
+        'no submesh of the addressed element keeps its old colour',
+      );
+    }
+    const other = (reg.byExpressId.get(WALL_B_ID) ?? [])[0];
+    assert.notDeepEqual([mat(other).color.r, mat(other).color.g, mat(other).color.b], [1, 0, 0]);
+  });
+
+  it('hides every submesh of an element addressed by GlobalId', () => {
+    const { reg } = mount();
+    const res = hide(reg, { globalIds: [WALL_A_GUID] });
+    assert.equal(res.count, 2);
+    for (const r of reg.byExpressId.get(WALL_A_ID) ?? []) {
+      assert.equal(r.mesh.visible, false, 'a partial ghost means one submesh was missed');
+    }
+    assert.equal((reg.byExpressId.get(WALL_B_ID) ?? [])[0].mesh.visible, true);
+
+    show(reg, { globalIds: [WALL_A_GUID] });
+    for (const r of reg.byExpressId.get(WALL_A_ID) ?? []) {
+      assert.equal(r.mesh.visible, true, 'and show() must bring all of them back');
+    }
+  });
+
+  it('isolates every submesh of an element addressed by expressId', () => {
+    const { reg } = mount();
+    const res = isolate(reg, { expressIds: [WALL_A_ID] });
+    assert.equal(res.count, 2);
+    for (const r of reg.byExpressId.get(WALL_A_ID) ?? []) {
+      assert.equal(r.mesh.visible, true, 'isolating an element must not hide half of it');
+    }
+    assert.equal((reg.byExpressId.get(WALL_B_ID) ?? [])[0].mesh.visible, false);
+  });
+
+  it('disposes every submesh, not just the last one indexed', () => {
+    const { reg, modelGroup } = mount();
+    const disposed = new Set<string>();
+    reg.records.forEach((r, i) => {
+      r.mesh.geometry.addEventListener('dispose', () => disposed.add(`geom${i}`));
+      mat(r).addEventListener('dispose', () => disposed.add(`mat${i}`));
+    });
+
+    clearEntityRecords(reg, modelGroup);
+
+    assert.deepEqual(
+      [...disposed].sort(),
+      ['geom0', 'geom1', 'geom2', 'mat0', 'mat1', 'mat2'],
+      'every GPU resource of every submesh is released',
+    );
+    assert.equal(modelGroup.children.length, 0);
+    assert.equal(reg.records.length, 0);
+    assert.equal(reg.byExpressId.size, 0);
+    assert.equal(reg.byGlobalId.size, 0);
+  });
+
+  it('re-indexes cleanly across a model swap', () => {
+    // clearEntityRecords empties the lists rather than orphaning them; a
+    // second load must not accumulate on top of the first.
+    const { reg, modelGroup } = mount();
+    clearEntityRecords(reg, modelGroup);
+    buildEntityRecords(reg, splitMeshes(), model, modelGroup, createSectionState());
+    assert.equal(reg.byExpressId.get(WALL_A_ID)?.length, 2, 'exactly the new load, not both');
+    assert.equal(selectTargets(reg, { expressIds: [WALL_A_ID] }).length, 2);
+  });
+});

--- a/apps/viewer/src/components/mcp/playground-scene-registry.test.ts
+++ b/apps/viewer/src/components/mcp/playground-scene-registry.test.ts
@@ -144,7 +144,8 @@ describe('playground registry: id lookups cover every submesh (#2443)', () => {
   it('colorizes every submesh of an element addressed by expressId', () => {
     const { reg } = mount();
     const res = colorize(reg, { expressIds: [WALL_A_ID], color: [1, 0, 0, 1] });
-    assert.equal(res.count, 2, 'the tool reports both submeshes');
+    // The contract in one line: act on every submesh, report in entities.
+    assert.equal(res.count, 1, 'the agent asked for one element and is told one');
 
     for (const r of reg.byExpressId.get(WALL_A_ID) ?? []) {
       assert.deepEqual(
@@ -159,7 +160,7 @@ describe('playground registry: id lookups cover every submesh (#2443)', () => {
   it('hides every submesh of an element addressed by GlobalId', () => {
     const { reg } = mount();
     const res = hide(reg, { globalIds: [WALL_A_GUID] });
-    assert.equal(res.count, 2);
+    assert.equal(res.count, 1, 'one element hidden, reported as one');
     for (const r of reg.byExpressId.get(WALL_A_ID) ?? []) {
       assert.equal(r.mesh.visible, false, 'a partial ghost means one submesh was missed');
     }
@@ -174,11 +175,43 @@ describe('playground registry: id lookups cover every submesh (#2443)', () => {
   it('isolates every submesh of an element addressed by expressId', () => {
     const { reg } = mount();
     const res = isolate(reg, { expressIds: [WALL_A_ID] });
-    assert.equal(res.count, 2);
+    assert.equal(res.count, 1, 'one element isolated, reported as one');
     for (const r of reg.byExpressId.get(WALL_A_ID) ?? []) {
       assert.equal(r.mesh.visible, true, 'isolating an element must not hide half of it');
     }
     assert.equal((reg.byExpressId.get(WALL_B_ID) ?? [])[0].mesh.visible, false);
+  });
+
+  it('reports entities, not submeshes, while still acting on every submesh', () => {
+    // The mirror of the bug #2443 fixed. Making `selectTargets` return every
+    // submesh silently changed what `{ count }` MEANS: a one-window colorize
+    // started answering "2" whenever that window tessellated into glass +
+    // frame. These tools are agent-facing and the dispatcher renders the
+    // number as "Painted N entities", so the count has to be in entities or
+    // the request and the response disagree — the same class of inconsistency
+    // #2443 set out to remove, just moved into the reply.
+    const { reg } = mount();
+
+    // Both halves of the contract, asserted together: two materials change,
+    // one entity is reported.
+    const painted = colorize(reg, { expressIds: [WALL_A_ID], color: [1, 0, 0, 1] });
+    const repainted = reg.records.filter(
+      (r) => mat(r).color.r === 1 && mat(r).color.g === 0 && mat(r).color.b === 0,
+    );
+    assert.equal(repainted.length, 2, 'both submeshes were actually recoloured');
+    assert.equal(painted.count, 1, 'and the agent is told one entity');
+
+    // Multi-entity selection: 3 submeshes across 2 elements reports 2.
+    assert.equal(
+      colorize(reg, { expressIds: [WALL_A_ID, WALL_B_ID], color: [0, 1, 0, 1] }).count, 2,
+      'two elements, three submeshes, reported as two',
+    );
+    assert.equal(hide(reg, { type: 'IfcWall' }).count, 2, 'type-addressing counts entities too');
+    assert.equal(show(reg, { type: 'IfcWall' }).count, 2);
+    assert.equal(isolate(reg, { type: 'IfcWall' }).count, 2);
+
+    // And the unmatched case still reports nothing rather than throwing.
+    assert.equal(hide(reg, { expressIds: [99999] }).count, 0);
   });
 
   it('disposes every submesh, not just the last one indexed', () => {

--- a/apps/viewer/src/components/mcp/playground-scene-registry.ts
+++ b/apps/viewer/src/components/mcp/playground-scene-registry.ts
@@ -75,6 +75,23 @@ function index<K>(map: Map<K, EntityRecord[]>, key: K, rec: EntityRecord): void 
   else map.set(key, [rec]);
 }
 
+/**
+ * Whether an alpha value renders translucent — the single predicate behind
+ * both `transparent` and `depthWrite`.
+ *
+ * `buildEntityRecords` derives the pair once at construction; `colorize()` and
+ * `reset()` re-derive it later. Those two used to set only `transparent`, so
+ * an entity colourised translucent kept `depthWrite: true` and occluded what
+ * was behind it, and the mirror case (translucent entity painted opaque) kept
+ * `depthWrite: false` and got drawn over. They also disagreed on the
+ * threshold — construction tested `a < 1`, the operations `a < 0.999` — so an
+ * alpha in between mounted one way and came back the other from a plain
+ * `viewer_reset`. One predicate, one place (#2444).
+ */
+export function isTranslucent(alpha: number): boolean {
+  return alpha < 0.999;
+}
+
 /** Dispose every mesh + material and empty the registry. */
 export function clearEntityRecords(reg: EntityRegistry, modelGroup: THREE.Group): void {
   const { records, byExpressId, byGlobalId, byType, byStorey } = reg;
@@ -171,7 +188,7 @@ export function buildEntityRecords(
     geom.computeBoundingSphere();
     const [r, g, b, a] = md.color;
     const baseColor = new THREE.Color(r, g, b);
-    const isTransparent = a < 1;
+    const isTransparent = isTranslucent(a);
     if (isTransparent) transparentCount++; else opaqueCount++;
     const mat = new THREE.MeshStandardMaterial({
       color: baseColor,

--- a/apps/viewer/src/components/mcp/playground-scene-registry.ts
+++ b/apps/viewer/src/components/mcp/playground-scene-registry.ts
@@ -5,8 +5,9 @@
 /**
  * Per-entity book-keeping for the playground scene.
  *
- * One Three.js mesh per IFC entity, plus the lookup maps the agent's tools
- * address them through (expressId / GlobalId / IfcType / storey). Owning this
+ * One Three.js mesh per tessellated `MeshData` entry — an IFC entity owns one
+ * or more of them — plus the lookup maps the agent's tools address them
+ * through (expressId / GlobalId / IfcType / storey). Owning this
  * separately from the scene factory keeps the registry — the part every viewer
  * tool touches — readable on its own; `playground-scene.ts` holds the GPU
  * lifecycle and `playground-scene-ops.ts` / `playground-scene-view.ts` hold
@@ -35,12 +36,24 @@ export interface EntityRecord {
   baseOpacity: number;
 }
 
-/** The record list plus the four lookup maps, all pointing at the same
- *  `EntityRecord` objects. */
+/**
+ * The record list plus the four lookup maps, all pointing at the same
+ * `EntityRecord` objects.
+ *
+ * Every map values a **list**, because one IFC element routinely tessellates
+ * into several `MeshData` entries — one per material, CSG part, or
+ * representation item — and `MeshData`'s own contract says to group by
+ * `expressId` for per-element operations (`packages/geometry/src/types.ts`).
+ * `byExpressId` / `byGlobalId` used to hold a single record and so kept only
+ * the LAST submesh, which made id-addressing and type-addressing disagree
+ * about the same element: `viewer_isolate({ type })` reached every submesh of
+ * a split window while `viewer_colorize({ expressIds })` recoloured one of
+ * them (#2443).
+ */
 export interface EntityRegistry {
   records: EntityRecord[];
-  byExpressId: Map<number, EntityRecord>;
-  byGlobalId: Map<string, EntityRecord>;
+  byExpressId: Map<number, EntityRecord[]>;
+  byGlobalId: Map<string, EntityRecord[]>;
   byType: Map<string, EntityRecord[]>;
   byStorey: Map<string, EntityRecord[]>;
 }
@@ -48,11 +61,18 @@ export interface EntityRegistry {
 export function createEntityRegistry(): EntityRegistry {
   return {
     records: [],
-    byExpressId: new Map<number, EntityRecord>(),
-    byGlobalId: new Map<string, EntityRecord>(),
+    byExpressId: new Map<number, EntityRecord[]>(),
+    byGlobalId: new Map<string, EntityRecord[]>(),
     byType: new Map<string, EntityRecord[]>(),
     byStorey: new Map<string, EntityRecord[]>(),
   };
+}
+
+/** Append `rec` to the list `key` indexes, creating the list on first use. */
+function index<K>(map: Map<K, EntityRecord[]>, key: K, rec: EntityRecord): void {
+  const list = map.get(key);
+  if (list) list.push(rec);
+  else map.set(key, [rec]);
 }
 
 /** Dispose every mesh + material and empty the registry. */
@@ -71,6 +91,12 @@ export function clearEntityRecords(reg: EntityRegistry, modelGroup: THREE.Group)
   byStorey.clear();
 }
 
+/**
+ * Resolve a tool's selector to the records it addresses.
+ *
+ * Every branch unions **all** submeshes of a matched element, so addressing
+ * one element by id, by GlobalId or by type reaches the same set (#2443).
+ */
 export function selectTargets(
   reg: EntityRegistry,
   args: { globalIds?: string[]; expressIds?: number[]; type?: string },
@@ -78,10 +104,10 @@ export function selectTargets(
   const { records, byExpressId, byGlobalId, byType } = reg;
   const out = new Set<EntityRecord>();
   if (args.expressIds) for (const id of args.expressIds) {
-    const r = byExpressId.get(id); if (r) out.add(r);
+    for (const r of byExpressId.get(id) ?? []) out.add(r);
   }
   if (args.globalIds) for (const gid of args.globalIds) {
-    const r = byGlobalId.get(gid); if (r) out.add(r);
+    for (const r of byGlobalId.get(gid) ?? []) out.add(r);
   }
   if (args.type) {
     // Match by leading IfcType (case-insensitive). The geometry pipeline
@@ -194,19 +220,13 @@ export function buildEntityRecords(
       baseColor,
       baseOpacity: md.color[3],
     };
+    // Every map accumulates: an element with several submeshes must be fully
+    // reachable through each of them, not just its last one (#2443).
     records.push(rec);
-    byExpressId.set(md.expressId, rec);
-    if (globalId) byGlobalId.set(globalId, rec);
-    if (ifcType) {
-      const list = byType.get(ifcType) ?? [];
-      list.push(rec);
-      byType.set(ifcType, list);
-    }
-    if (storeyName) {
-      const list = byStorey.get(storeyName) ?? [];
-      list.push(rec);
-      byStorey.set(storeyName, list);
-    }
+    index(byExpressId, md.expressId, rec);
+    if (globalId) index(byGlobalId, globalId, rec);
+    if (ifcType) index(byType, ifcType, rec);
+    if (storeyName) index(byStorey, storeyName, rec);
   }
 
   return { opaqueCount, transparentCount };

--- a/apps/viewer/src/components/mcp/playground-scene-registry.ts
+++ b/apps/viewer/src/components/mcp/playground-scene-registry.ts
@@ -68,6 +68,23 @@ export function createEntityRegistry(): EntityRegistry {
   };
 }
 
+/**
+ * How many distinct IFC entities a record set covers.
+ *
+ * The operations act on every record (that is the whole point of #2443), but
+ * they report back to the agent in entities, because that is the unit the
+ * agent asked in and the unit the dispatcher's wording promises — it renders
+ * these counts as "Painted N entities". Returning `records.length` would
+ * answer a one-window `viewer_colorize` with "2" whenever that window
+ * tessellated into glass + frame, which is the same id-vs-type disagreement
+ * #2443 set out to remove, just moved into the response (#2443 follow-up).
+ */
+export function countEntities(records: Iterable<EntityRecord>): number {
+  const seen = new Set<number>();
+  for (const r of records) seen.add(r.expressId);
+  return seen.size;
+}
+
 /** Append `rec` to the list `key` indexes, creating the list on first use. */
 function index<K>(map: Map<K, EntityRecord[]>, key: K, rec: EntityRecord): void {
   const list = map.get(key);

--- a/apps/viewer/src/components/mcp/playground-scene.ts
+++ b/apps/viewer/src/components/mcp/playground-scene.ts
@@ -30,6 +30,7 @@ import type { LoadedPlaygroundModel } from './playground-dispatcher';
 import {
   buildEntityRecords,
   clearEntityRecords,
+  countEntities,
   createEntityRegistry,
   selectTargets,
 } from './playground-scene-registry';
@@ -249,8 +250,10 @@ export function createScene(container: HTMLElement): SceneHandle {
     flyTo(args) {
       const targets = selectTargets(registry, args);
       if (targets.length === 0) return { count: 0 };
+      // Frame on every submesh (a partial bbox is what made the camera fit too
+      // tight on multi-part elements) but report entities, like the other ops.
       frameOn(view, targets);
-      return { count: targets.length };
+      return { count: countEntities(targets) };
     },
 
     setSection(args) {

--- a/apps/viewer/src/components/mcp/playground-scene.ts
+++ b/apps/viewer/src/components/mcp/playground-scene.ts
@@ -42,6 +42,7 @@ import {
   reset,
   show,
 } from './playground-scene-ops';
+import { releaseRenderer } from './release-renderer';
 import {
   clearSection,
   createSectionState,
@@ -287,10 +288,7 @@ export function createScene(container: HTMLElement): SceneHandle {
       ro.disconnect();
       controls.dispose();
       clearModel();
-      renderer.dispose();
-      if (renderer.domElement.parentNode === container) {
-        container.removeChild(renderer.domElement);
-      }
+      releaseRenderer(renderer, container);
     },
   };
 

--- a/apps/viewer/src/components/mcp/playground-scene.ts
+++ b/apps/viewer/src/components/mcp/playground-scene.ts
@@ -141,7 +141,12 @@ export function createScene(container: HTMLElement): SceneHandle {
     const rec = records.find((r) => r.mesh === hit);
     if (!rec) return;
     clearSelectionHighlight();
-    (rec.mesh.material as THREE.MeshStandardMaterial).color.copy(SELECTION_COLOR);
+    // The ray hits ONE submesh, but selection is reported per element, so the
+    // highlight has to cover every submesh of that element or a split window
+    // reads as half-selected (#2443).
+    for (const r of registry.byExpressId.get(rec.expressId) ?? [rec]) {
+      (r.mesh.material as THREE.MeshStandardMaterial).color.copy(SELECTION_COLOR);
+    }
     selection = [{ expressId: rec.expressId, globalId: rec.globalId, ifcType: rec.ifcType }];
     notifySelection(selection);
   }

--- a/apps/viewer/src/components/mcp/release-renderer.test.ts
+++ b/apps/viewer/src/components/mcp/release-renderer.test.ts
@@ -1,0 +1,78 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The `/mcp` renderer teardown sequence (#2445).
+ *
+ * Both scenes used to end `dispose()` with `renderer.dispose()` and a
+ * `removeChild`, never calling `forceContextLoss()`, so the WebGL context was
+ * released only whenever the canvas happened to be collected. That matters on
+ * `/mcp` specifically, where `McpPlayground` unmounts and remounts
+ * `PlaygroundViewer` every time the 3D panel is toggled.
+ *
+ * What this can and cannot prove: `THREE.WebGLRenderer` is unconstructible
+ * under happy-dom (no WebGL at all), so no suite can observe a real GL context
+ * being handed back. What is testable — and what actually regressed — is the
+ * *sequence*: dispose, then force the loss, then detach. That is why it was
+ * extracted into `releaseRenderer` with a structural parameter. The container
+ * and canvas below are real DOM; only the renderer is a stand-in, and it is
+ * built so the pre-fix behaviour (no `forceContextLoss` call) is exactly what
+ * the assertions reject.
+ */
+
+import '@/test/setup-dom.js';
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { releaseRenderer, type ReleasableRenderer } from './release-renderer.js';
+
+/** Records the teardown calls in the order the code under test makes them. */
+function fakeRenderer(): ReleasableRenderer & { calls: string[] } {
+  const calls: string[] = [];
+  return {
+    calls,
+    domElement: document.createElement('canvas'),
+    dispose() { calls.push('dispose'); },
+    forceContextLoss() { calls.push('forceContextLoss'); },
+  };
+}
+
+describe('releaseRenderer (#2445)', () => {
+  it('forces the context loss, after dispose and before detaching the canvas', () => {
+    const container = document.createElement('div');
+    const renderer = fakeRenderer();
+    container.appendChild(renderer.domElement);
+    const realRemoveChild = container.removeChild.bind(container);
+    container.removeChild = (<T extends Node>(child: T): T => {
+      renderer.calls.push('detached');
+      return realRemoveChild(child);
+    }) as typeof container.removeChild;
+
+    releaseRenderer(renderer, container);
+
+    assert.deepEqual(
+      renderer.calls,
+      ['dispose', 'forceContextLoss', 'detached'],
+      'three.js resources go first, then the browser is asked for the context back, then the DOM',
+    );
+    assert.equal(renderer.domElement.parentNode, null, 'and the canvas is detached');
+    assert.equal(container.childNodes.length, 0);
+  });
+
+  it('still releases the context when the canvas was never in this container', () => {
+    // The DOM guard predates this change and is deliberately kept: a canvas
+    // reparented (or already removed) by something else must not be yanked out
+    // of whatever now owns it. Releasing the GL context is unconditional
+    // though — that is the resource this exists to reclaim.
+    const container = document.createElement('div');
+    const elsewhere = document.createElement('div');
+    const renderer = fakeRenderer();
+    elsewhere.appendChild(renderer.domElement);
+
+    releaseRenderer(renderer, container);
+
+    assert.deepEqual(renderer.calls, ['dispose', 'forceContextLoss']);
+    assert.equal(renderer.domElement.parentNode, elsewhere, 'someone else owns the canvas');
+  });
+});

--- a/apps/viewer/src/components/mcp/release-renderer.ts
+++ b/apps/viewer/src/components/mcp/release-renderer.ts
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Hand a three.js renderer's WebGL context back to the browser on permanent
+ * unmount — the tail of both `/mcp` scenes' `dispose()`.
+ *
+ * `WebGLRenderer.dispose()` releases three.js-side resources; it does **not**
+ * ask the browser to relinquish the underlying drawing context, which is then
+ * reclaimed only when the canvas is garbage-collected — non-deterministically.
+ * A page gets roughly 16 live WebGL contexts and evicts the oldest when one is
+ * requested past that, and `/mcp` is where that budget is under pressure: the
+ * hero mounts on every visit, and `McpPlayground` unmounts `PlaygroundViewer`
+ * whenever the 3D panel collapses and remounts it when reopened, so a long
+ * session toggling the panel churns mount/unmount cycles (#2445). This is the
+ * resource-exhaustion neighbour of #2401 / #2406: those made a *refused*
+ * context degrade gracefully, this is about not manufacturing refusals.
+ *
+ * Order is load-bearing: dispose, then force the loss, then detach the canvas.
+ * `forceContextLoss()` is a no-op where `WEBGL_lose_context` is unavailable
+ * (three.js calls `loseContext()` only when `extensions.get()` returns one),
+ * so it is safe on every device rather than a throw to guard against.
+ *
+ * The parameter is structural rather than `THREE.WebGLRenderer` for one
+ * reason: no suite can construct a real renderer (happy-dom has no WebGL), so
+ * typing the collaborator this way is what makes the sequence itself
+ * reachable from CI. `THREE.WebGLRenderer` satisfies it as-is.
+ */
+
+export interface ReleasableRenderer {
+  dispose(): void;
+  forceContextLoss(): void;
+  domElement: HTMLCanvasElement;
+}
+
+/** Dispose, release the GL context, and detach the canvas from `container`. */
+export function releaseRenderer(renderer: ReleasableRenderer, container: HTMLElement): void {
+  renderer.dispose();
+  renderer.forceContextLoss();
+  if (renderer.domElement.parentNode === container) {
+    container.removeChild(renderer.domElement);
+  }
+}


### PR DESCRIPTION
Four `/mcp` follow-ups filed off the #2440 review, all pre-existing and all in `apps/viewer/src/components/mcp/`. One commit each so they read independently.

Fixes #2443.
Fixes #2444.
Fixes #2445.
Fixes #2446.

## #2443 — the registry kept only the last submesh per expressId/GlobalId

`buildEntityRecords` accumulated `byType` / `byStorey` into arrays but let `byExpressId` / `byGlobalId` overwrite. One IFC element routinely produces several `MeshData` entries — `packages/geometry/src/types.ts` says so outright and tells consumers to group by `expressId` — so a window split into glass + frame registered N records and left one reachable by id.

That made the two ways an agent names the same element disagree: `viewer_isolate({ type })` reached every submesh while `viewer_colorize({ expressIds })` recoloured one and `viewer_hide({ global_ids })` left a partial ghost.

Both id maps now accumulate and `selectTargets` unions the lists, so colorize / hide / show / isolate / fly-to all reach the whole element. Picking also highlights every submesh of the element it reports rather than the one triangle the ray hit — selection was already per-element, only the highlight was not. Disposal already iterated the flat `records` array and is unchanged; the new test pins that so it stays true.

## #2444 — colorize()/reset() left depthWrite stale

`buildEntityRecords` sets `depthWrite: !isTransparent` at construction; `colorize()` and `reset()` re-derived `transparent` / `opacity` and left `depthWrite` alone. An entity colourised translucent kept writing depth and occluded what was behind it; the mirror case (translucent painted opaque) kept `depthWrite: false` and got drawn over.

The two sites also disagreed on the threshold — `a < 1` at construction, `a < 0.999` in the operations — so an alpha in between mounted one way and came back the other from a plain `viewer_reset`. Both now go through one exported `isTranslucent()` predicate.

## #2445 — neither scene released its WebGL context

Both `dispose()` bodies ended at `renderer.dispose()`, which frees three.js-side resources but never asks the browser for the drawing context back; it was reclaimed only when the canvas happened to be collected. `/mcp` is where that matters: the hero mounts on every visit and `McpPlayground` unmounts `PlaygroundViewer` each time the 3D panel collapses, so a long session churns mount/unmount cycles against a ~16-context budget. This is the resource-exhaustion neighbour of #2401 / #2406 — those made a *refused* context degrade gracefully, this is about not manufacturing refusals.

Both now call `forceContextLoss()` after `dispose()` and before detaching the canvas. Confirmed harmless where the extension is missing: three.js's implementation is `const extension = extensions.get('WEBGL_lose_context'); if (extension) extension.loseContext();` — a no-op, not a throw.

The sequence is shared as `releaseRenderer()` so it exists once instead of twice.

## #2446 — projectPin() JSDoc

The contract claimed `null` for "behind the camera **or** no host size". Only the second produces `null`; out-of-frustum yields a populated frame with `visible: false`. Corrected on the interface and pinned with a comment at the one `return null` in the implementation. Documentation only — the sole caller already handles both shapes.

## Testing, and what it does not cover

`createScene` never executes in any suite (happy-dom has no WebGL), so nothing inside either scene factory is reachable from CI. Two seams get around that for three of the four:

- **#2443 / #2444 are genuinely covered.** `buildEntityRecords`, `selectTargets` and the colour/visibility operations are plain functions over an `EntityRegistry`, and the three.js objects they build (`BufferGeometry`, `MeshStandardMaterial`, `Group`) are CPU-only — only `WebGLRenderer` needs the GPU. `playground-scene-registry.test.ts` drives them against a real parsed IFC model whose **WALL_A tessellates into two submeshes**; a one-submesh-per-element fixture cannot distinguish last-wins from accumulate and would have proved nothing.
- **#2445 is covered only as a call sequence.** No suite can construct a real `WebGLRenderer`, so no test observes an actual context being handed back. `releaseRenderer` takes a structural parameter and `release-renderer.test.ts` pins dispose → forceContextLoss → detach against a fake renderer with a real DOM canvas. That the released context is genuinely reclaimed by the browser is **not** verified here.

Not verified at all:
- **#2446** has no test — a JSDoc correction has no behaviour to assert.
- The **picking highlight** change in `playground-scene.ts` sits inside `createScene` and is unreachable from CI, like the rest of that file.
- Nothing was exercised in a real browser; this is a static + unit-test verdict only.

Every test was mutation-checked (revert the fix, prove failure, restore, prove pass), with each mutation confirmed on disk before running:

| Mutation | Killed |
| --- | --- |
| M1 id maps back to last-wins | 8 of 10 |
| M2 `selectTargets` takes only the first record | 7 of 10 |
| M3 disposal iterates one submesh per id | 1 (the disposal test — proves it is not vacuous) |
| M4 drop `depthWrite` from `colorize()` | 2 |
| M5 drop `depthWrite` from `reset()` | 1 |
| M6 construction threshold back to `a < 1` | 1 |
| M7 remove `forceContextLoss()` | 2 of 2 |
| M8 force the loss before `dispose()` | 2 of 2 |

M5 caught a real problem first time round: the original reset test drove the stale state through `colorize()`, which also overwrites `baseOpacity`, so the two agreed by construction and the assertion held with or without the fix. It was rewritten to set the stale state directly — the invariant `reset()` actually owes its callers — and now fails under M5.

## Review round 2

Three findings, routed by provenance.

**Fixed here (introduced by this PR): the counts changed meaning.** Making `selectTargets` return every submesh silently redefined the `{ count }` that `colorize` / `isolate` / `hide` / `show` / `flyTo` return — it became a count of submeshes while the dispatcher renders it as `Painted N entities`, so a one-window colorize answered "2 entities". That is the mirror of the bug this PR fixes: #2443 existed because id-addressing and type-addressing disagreed about an element, and answering an entity request in submeshes moves the disagreement into the reply. All five now count distinct expressIds via `countEntities()` while still acting on (and framing on) every submesh. Type-addressing was already reporting submeshes, so this is what makes the two addressing modes agree end to end. The count assertions from the first round encoded the wrong contract and are corrected; the new test asserts both halves together, because only the pair is the contract — colourising the split wall changes **2 materials** and reports **1 entity**.

**Filed, not fixed (all pre-existing, none introduced here):**

- **#2453 — `projectPin()` tests depth only**, so a pin outside the lateral frustum reports `visible: true`. I first probed the initial camera and got a clean result (max abs(ndc.x) 0.823); sweeping *every* `cameraTarget` in `hero-scene-steps.ts` over the full orbit reversed that. The BCF pin step itself (camera `(9.5, 4, 10)`) peaks at **1.087** and spends **178 of 720 azimuth samples — about 89 degrees of every revolution** — telling the caption it is visible while the pin is off-screen. The portrait `4/5` stage is the reason: it narrows the horizontal FOV to roughly 28 degrees against the 35 degree vertical, so the pin runs out sideways long before vertically (max abs(ndc.y) never exceeds 0.59 anywhere). Behaviour change, so it does not belong in a docs commit; the JSDoc now says the depth-only test is a known defect rather than the contract.
- **#2454 — `colorize()`/`reset()` flip `material.transparent` without `needsUpdate`.** The review suggested guarding an unconditional `needsUpdate` write; there is no such write in this file (`playground-scene-ops.ts` contains no `needsUpdate` at all, and this PR touches it nowhere). The real defect underneath is the opposite: `needsUpdate` is *missing* and is genuinely required. In three r185 `getParameters()` folds `transparent` into the `opaque` **program parameter**, which emits `#define OPAQUE` and forces `diffuseColor.a = 1.0`, and `setProgram`'s `needsProgramChange` block never inspects `transparent` or `opaque` — so translucency never reaches the shader. Worth stating plainly for this PR: that means **#2444's `depthWrite` fix works as written** (`depthWrite` is per-draw state, `depthBuffer.setMask`, and `opacity` is a per-frame uniform) but its sibling `transparent` flip has never taken effect. A comment next to the fix says so.
- **#2455 — `colorByProperty()`'s legend counts submeshes**, and re-samples the property once per part. Same drift as the counts fixed above, but it does not go through `selectTargets`, so it was outside this change's blast radius.

Gates re-run after rebasing onto current `main` (which moved twice during this round), exit codes captured directly: `pnpm typecheck` exit **0** (36/36); `pnpm test` exit **0** (86/86; viewer 3368 tests, 3362 pass, **0 fail**, 6 skipped, and zero `not ok` lines anywhere in the run).

Mutation added this round: **M9** — revert all five counts to `targets.length` / `targets.size`, i.e. exactly the state the first commit left them in. Kills 4 tests. Restored, 15/15 green.

One caveat on review coverage: CodeRabbit is rate-limited (org spending cap), so the hosted check passing is not evidence. This PR has had one real CLI pass plus Codex.

## Gates

Rebased onto current `main` and re-run after the rebase. Root turbo, exit codes captured directly:

- `pnpm typecheck` → exit **0**, 36/36 tasks
- `pnpm test` → exit **0**, 86/86 tasks; `@ifc-lite/viewer` 3368 tests, 3362 pass, 0 fail, 6 skipped

`apps/viewer` is private, so no changeset.
