### PR TITLE
fix(viewer): file the /mcp WebGL degradation under the shared webgl_unavailable family

### DIFF
--- a/apps/viewer/src/components/mcp/mcp-three-surfaces.webgl.test.tsx
+++ b/apps/viewer/src/components/mcp/mcp-three-surfaces.webgl.test.tsx
@@ -33,6 +33,8 @@ import { PlaygroundViewer } from './PlaygroundViewer.js';
 import type { ViewerController } from './playground-viewer-types.js';
 import { parsePlaygroundModel, type LoadedPlaygroundModel } from './playground-dispatcher.js';
 import { resetThreeWebglSupportForTests, getThreeWebglVerdict } from './three-webgl-support.js';
+import { posthog } from '@/lib/analytics';
+import { classifyLoadError } from '@/lib/load-errors';
 
 /** A minimal real model, parsed the way the playground parses one. */
 async function schemaOnlyModel(): Promise<LoadedPlaygroundModel> {
@@ -118,6 +120,40 @@ describe('HeroScene on a device that refuses a WebGL context', () => {
       assert.deepEqual(getThreeWebglVerdict(), first, 'the latched verdict must stand for the session');
     } finally {
       document.createElement = realCreateElement;
+    }
+  });
+});
+
+describe('what a refused device actually reports', () => {
+  it('files the degradation into the WebGL-unavailable family (#2458)', () => {
+    // End to end, with only the PostHog SDK stubbed: a real mount on a device
+    // that really has no `webgl2` produces a real error object, and THAT object
+    // is what the classifier has to recognise. Asserting on a hand-written
+    // message instead would prove the regex compiles, not that the error the
+    // code reports is in the family — the two came apart before, which is how
+    // three's wordings ended up outside it while the minimap's were inside.
+    const captured: Array<{ err: unknown; props?: Record<string, unknown> }> = [];
+    const captureMock = mock.method(
+      posthog,
+      'captureException',
+      (err: unknown, props?: Record<string, unknown>) => {
+        captured.push({ err, props });
+      },
+    );
+    try {
+      act(() => {
+        root.render(<HeroScene step={0} />);
+      });
+
+      assert.equal(captured.length, 1, 'the degradation is reported exactly once');
+      assert.equal(captured[0].props?.context, 'mcp_three_webgl');
+      assert.equal(
+        classifyLoadError(captured[0].err),
+        'webgl_unavailable',
+        'the reported error must land in the shared family, not open its own issue',
+      );
+    } finally {
+      captureMock.mock.restore();
     }
   });
 });

--- a/apps/viewer/src/components/mcp/three-webgl-support.test.ts
+++ b/apps/viewer/src/components/mcp/three-webgl-support.test.ts
@@ -29,6 +29,7 @@ import {
 } from './three-webgl-support.js';
 import { threeWebglReportProperties } from './useThreeScene.js';
 import { scrubEvent } from '@/lib/analytics-scrub';
+import { classifyLoadError } from '@/lib/load-errors';
 
 /** posthog-js's `before_send` shape, as `analytics.test.ts` models it. */
 type CaptureEvent = { event?: string; properties?: Record<string, unknown> };
@@ -193,6 +194,59 @@ describe('the degradation report', () => {
     assert.equal(scrubbed?.properties?.three_surface, 'hero');
     assert.equal(scrubbed?.properties?.three_unavailable_reason, 'renderer_construction_failed');
     assert.equal(scrubbed?.properties?.webgl_context, 'attributes_refused');
+  });
+
+  it('groups with the minimap’s WebGL signal instead of minting its own issue (#2458)', () => {
+    // The half of the degradation the handled capture does NOT buy. PostHog
+    // groups by hashing type + message + stack unless the client supplies a
+    // fingerprint, and the stack names the hashed bundle — so before this,
+    // three's three wordings opened up to three issues, re-split on every
+    // deploy, none of them the `ifc-lite:webgl_unavailable` issue the very same
+    // device condition already files from the minimap.
+    //
+    // Driven through the REAL scrub pipeline (`tagErrorKind` -> `stampFingerprint`),
+    // not by asserting the matcher in isolation: the fingerprint is only reached
+    // if classification happens first and nothing later overwrites it.
+    const fingerprintFor = (message: string): unknown => {
+      const scrubbed = scrubEvent({
+        event: '$exception',
+        properties: {
+          $exception_list: [{
+            type: 'Error',
+            value: message,
+            mechanism: { handled: true, type: 'generic' },
+          }],
+          // posthog-js stamps every captured exception `error`, benign or not.
+          $exception_level: 'error',
+          ...threeWebglReportProperties('hero', 'renderer_construction_failed', new Error(message)),
+        },
+      } as CaptureEvent);
+      assert.notEqual(scrubbed, null, 'precondition: the report must survive the scrub');
+      assert.equal(scrubbed?.properties?.error_kind, 'webgl_unavailable');
+      // Membership in the family carries the family's severity: one dead panel
+      // on an unfixable device must stop competing with real breakage.
+      assert.equal(scrubbed?.properties?.$exception_level, 'warning');
+      return scrubbed?.properties?.$exception_fingerprint;
+    };
+
+    assert.equal(fingerprintFor(NO_CONTEXT), 'ifc-lite:webgl_unavailable');
+    assert.equal(fingerprintFor(ATTRIBUTES_REFUSED), 'ifc-lite:webgl_unavailable');
+    // The message LocationMap reports for the same device condition. Asserted
+    // here rather than assumed: "groups with the existing signal" is a claim
+    // about two call sites agreeing, so both have to be in one assertion.
+    assert.equal(
+      fingerprintFor('Failed to initialize WebGL (pre-flight probe)'),
+      'ifc-lite:webgl_unavailable',
+    );
+  });
+
+  it('classifies the message this module actually synthesises (#2458)', () => {
+    // Drift canary. The classifier in lib/load-errors.ts anchors on the probe
+    // wording, which is authored HERE — so a reworded `threeProbeFailureError`
+    // would otherwise silently drop the most-travelled arm out of the family
+    // with every test still green. This calls the real function rather than
+    // restating its output.
+    assert.equal(classifyLoadError(threeProbeFailureError()), 'webgl_unavailable');
   });
 
   it('files the failure under its own context, not the page-crash bucket', () => {

--- a/apps/viewer/src/lib/analytics-scrub.ts
+++ b/apps/viewer/src/lib/analytics-scrub.ts
@@ -482,7 +482,7 @@ const stampFingerprint = (
 // error-level. #2401 removed that premise — both `/mcp` scenes now mount behind
 // `useThreeScene`, degrade to a static panel, and report once as a HANDLED
 // exception — so #2458 folds those wordings into `webgl_unavailable` (see
-// `isThreeContextRefusal` in ./load-errors.ts) and they inherit this severity
+// `isThreeContextRefusal` in ./webgl-unavailable.ts) and they inherit this severity
 // with it. If a WebGLRenderer is ever constructed outside that guard again, the
 // throw would arrive here benign; the guard is the thing keeping this honest.
 const BENIGN_ERROR_KINDS = new Set<string>([

--- a/apps/viewer/src/lib/analytics-scrub.ts
+++ b/apps/viewer/src/lib/analytics-scrub.ts
@@ -474,12 +474,17 @@ const stampFingerprint = (
 // alter — the reported occurrences are a device whose GPU is missing an
 // extension or whose GPU process could not serve a second context. It stays
 // captured and queryable (with `map_unavailable_reason` and `webgl_status`
-// intact), just not competing with real breakage on an error-level list. Only
-// MapLibre's handled failure is in this bucket: three.js's
-// `THREE.WebGLRenderer: Error creating WebGL context.` is classified `unknown`
-// and stays error-level, because nothing catches it — it throws out of the MCP
-// playground's mount effect, which takes the React tree down with it. That is
-// breakage, not a degradation, and must not inherit this severity.
+// intact), just not competing with real breakage on an error-level list.
+//
+// three.js's `THREE.WebGLRenderer: Error creating WebGL context.` was pointedly
+// NOT in this bucket while nothing caught it: it threw out of an `/mcp` mount
+// effect and took the React tree down, which is breakage and had to stay
+// error-level. #2401 removed that premise — both `/mcp` scenes now mount behind
+// `useThreeScene`, degrade to a static panel, and report once as a HANDLED
+// exception — so #2458 folds those wordings into `webgl_unavailable` (see
+// `isThreeContextRefusal` in ./load-errors.ts) and they inherit this severity
+// with it. If a WebGLRenderer is ever constructed outside that guard again, the
+// throw would arrive here benign; the guard is the thing keeping this honest.
 const BENIGN_ERROR_KINDS = new Set<string>([
   'network_unavailable', 'cancelled', 'webgl_unavailable',
 ]);

--- a/apps/viewer/src/lib/analytics.test.ts
+++ b/apps/viewer/src/lib/analytics.test.ts
@@ -1099,16 +1099,36 @@ describe('scrubEvent — handled WebGL degradation (#2354)', () => {
     );
   });
 
-  it('keeps three.js\'s WebGL failure LOUD — nothing catches that one', () => {
-    // Issue 019fc458, thrown by THREE.WebGLRenderer out of the MCP playground's
-    // mount effect. An uncaught throw in a React effect tears the tree down, so
-    // it is real breakage, not a degradation. It must not inherit the minimap's
-    // fingerprint or its severity.
+  it('takes three.js\'s WebGL failure into the family too, now that it is caught (#2458)', () => {
+    // Issue 019fc458, thrown by THREE.WebGLRenderer out of the /mcp hero's
+    // mount effect. It USED to be real breakage — an uncaught throw in a React
+    // effect that took the route down — which is why this test previously
+    // asserted the opposite. #2401 put both /mcp scenes behind `useThreeScene`:
+    // the throw is caught, one panel degrades to a static notice, and the
+    // condition is reported once as a handled exception. Same device fact as
+    // the minimap's, so: same fingerprint, same warning severity, still sent.
     const out = scrubEvent(exceptionEvent(
       'THREE.WebGLRenderer: Error creating WebGL context.',
+      { $exception_level: 'error', context: 'mcp_three_webgl', three_surface: 'hero' },
+    ));
+    assert.notEqual(out, null, 'the degradation must still be reported');
+    assert.equal(out?.properties?.error_kind, 'webgl_unavailable');
+    assert.equal(out?.properties?.$exception_fingerprint, 'ifc-lite:webgl_unavailable');
+    assert.equal(out?.properties?.$exception_level, 'warning');
+    assert.equal(out?.properties?.three_surface, 'hero', 'which surface died must survive the scrub');
+  });
+
+  it('keeps a message that merely QUOTES three\'s wording LOUD (#2458)', () => {
+    // The other half of the reversal. Membership is by three's exact authored
+    // message; one of our own bugs that wraps it for context is not a device
+    // fact and must keep its own identity, its own issue and `error` severity —
+    // inheriting a benign fingerprint is how a real bug stops being triaged.
+    const out = scrubEvent(exceptionEvent(
+      'HeroScene: THREE.WebGLRenderer: Error creating WebGL context. after 3 retries',
       { $exception_level: 'error' },
     ));
     assert.notEqual(out, null);
+    assert.equal(out?.properties?.error_kind, undefined);
     assert.equal(out?.properties?.$exception_fingerprint, undefined);
     assert.equal(out?.properties?.$exception_level, 'error');
   });

--- a/apps/viewer/src/lib/cancelled-and-network-errors.ts
+++ b/apps/viewer/src/lib/cancelled-and-network-errors.ts
@@ -1,0 +1,143 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The two families that mean the work never finished for a reason outside the
+ * model: someone cancelled it, or the transport dropped it. The kinds
+ * themselves (`cancelled`, `network_unavailable`) are declared with the rest of
+ * the taxonomy in ./load-errors.ts, which calls these in its documented order.
+ *
+ * They live together because they are one design problem, not two. Both are in
+ * `BENIGN_ERROR_KINDS` (./analytics-scrub.ts), so a match downgrades the event
+ * to `warning`; `network_unavailable` is additionally DELETED outright on a
+ * client the browser reported offline. Matching is therefore how an actionable
+ * failure of ours stops being triaged, or stops existing — which is exactly
+ * what a substring test caused (#2410) and why every pattern below is anchored
+ * to the whole message, `STRINGIFIED_ERROR_PREFIX` and all. The one asymmetry
+ * between them (a cancellation report names its subject and carries authored
+ * detail after the token; a transport failure IS the browser's whole string) is
+ * spelled out on `CANCELLED_REPORT`, and only reads as a decision with the
+ * other pattern in view.
+ *
+ * Split out of ./load-errors.ts on size (#2459), not on behaviour: these are
+ * the same patterns, with the same anchors, called from the same place.
+ */
+
+/**
+ * A cross-realm throwable reaches the analytics path as `String(err)` — i.e.
+ * `"TypeError: Load failed"`, not `"Load failed"`. Structural, so the anchored
+ * matchers below tolerate it; BOUNDED, so it cannot stand in for an arbitrary
+ * leading sentence of ours that happens to end in "…Error:".
+ *
+ * `{0,32}`, not `{1,32}`: the commonest constructor is `Error` itself, whose
+ * stringification is the bare `Error: Load failed`, and requiring a letter in
+ * front excluded exactly that (Codex review, #2431). What does the real work is
+ * `[A-Za-z]` admitting no space and no colon — a leading clause of ours can
+ * never be swallowed however the count is written.
+ */
+const STRINGIFIED_ERROR_PREFIX = '(?:[A-Za-z]{0,32}Error:\\s*)?';
+
+/**
+ * The user (or a superseding load) cancelled the operation.
+ *
+ * ANCHORED, because `cancelled` is in `BENIGN_ERROR_KINDS` (./analytics-scrub.ts):
+ * matching it downgrades the event to `warning` and fingerprints it into the
+ * cancellation issue, taking an actionable failure off the error-level list as
+ * effectively as deleting it. The old `/\bcancel(?:led|ed)?\b/` fired on the word
+ * ANYWHERE — and, both suffixes optional, on a bare "cancel" — so `Upload failed:
+ * driver shim logged cancelled while retrying` read benign (#2410).
+ *
+ * Shaped differently from the whole-message anchor `isNetworkUnavailableError`
+ * uses, because the wordings have a different author: the transport strings
+ * come from `fetch()` and ARE the entire message, whereas cancellations are
+ * mostly ours and carry authored detail after the token (`Sync cancelled:
+ * <model> was removed while its update was downloading.`, `Clash run cancelled
+ * before meshing.`). So what is pinned is the SUBJECT — a cancellation report
+ * names what was cancelled in its opening words; a failure that merely mentions
+ * one reaches the token past a clause of its own. Two arms, because the bare
+ * token has no subject to name and so gets no trailing latitude at all
+ * (otherwise `cancelled and our upload pipeline then wrote 0 bytes` walks
+ * through). The residual, stated plainly: `Upload cancelled and the pipeline
+ * wrote 0 bytes` is still read as a cancellation report, because it is one.
+ */
+const CANCELLED_REPORT = new RegExp(
+  `^\\s*${STRINGIFIED_ERROR_PREFIX}(?:`
+  + 'cancell?ed\\.?\\s*$'
+  // `[^\s:]+` so the subject cannot be reached across a `:` — that separator is
+  // what makes "Upload failed: …" a sentence about the upload, not a cancellation.
+  + '|(?:[^\\s:]+\\s+){1,2}cancell?ed\\b'
+  + ')',
+  'i',
+);
+
+/**
+ * The browsers' own abort wordings — unlike ours these ARE the whole message,
+ * so both ends are pinned. `.name === 'AbortError'` already claims the live
+ * DOMException in {@link classifyLoadError}; this covers the analytics path,
+ * where all we ever have is the stringified value.
+ */
+const ABORTED_MESSAGE = new RegExp(
+  `^\\s*${STRINGIFIED_ERROR_PREFIX}(?:`
+  + 'the operation was aborted'          // Gecko
+  + '|the user aborted a request'        // Chromium
+  + '|fetch is aborted'                  // WebKit
+  + '|signal is aborted without reason'  // AbortController with no reason
+  + ')\\.?\\s*$',
+  'i',
+);
+
+export function isCancelledError(message: string): boolean {
+  // `AbortError` is the stringified NAME — an identity, not prose — so it is
+  // anchored to the start rather than matched as a substring anywhere.
+  return CANCELLED_REPORT.test(message)
+    || /^\s*AbortError\b/.test(message)
+    || ABORTED_MESSAGE.test(message);
+}
+
+/**
+ * A bare transport failure: the request never completed and the browser gave us
+ * nothing but its house phrasing. These strings originate inside `fetch()`
+ * rather than in our frames, so they arrive with an EMPTY stack — exactly how
+ * #1903 reached error tracking as an unattributable `TypeError: Load failed`.
+ * Checked LAST, so a failure that named itself (the engine binary, the file, a
+ * worker) keeps its own, more actionable kind.
+ *
+ * ANCHORED AT BOTH ENDS, and that is load-bearing rather than tidiness: this is
+ * the most dangerous label in the file. `analytics-scrub.ts` downgrades it to
+ * `warning` via `BENIGN_ERROR_KINDS` AND deletes the event outright when the
+ * browser also reported `navigator.onLine === false`, so the old substring test
+ * meant any failure of ours quoting a transport phrase (`Upload failed: driver
+ * shim logged Failed to fetch while retrying`) was silenced, and on an offline
+ * client destroyed with no record (#2410). The anchor is exactly the premise
+ * stated above — these strings come FROM `fetch()`, so anything wrapping one is
+ * by construction ours. A wrapped transport failure now falls to `unknown`:
+ * loud, own grouping, the safe direction for a droppable kind.
+ *
+ * This subsumes what used to be an explicit module-import exclusion: Chromium's
+ * `Failed to fetch dynamically imported module: …/assets/Foo-<hash>.js` is our
+ * deploy rotating an asset under a still-open tab, not a dropped connection, and
+ * it names the module, so it is no longer the whole wording. The guard that said
+ * so is gone rather than left as an unreachable branch — `load-errors.test.ts`
+ * keeps the regression test as the live gate on this anchor.
+ */
+const BARE_TRANSPORT_FAILURE = new RegExp(
+  `^\\s*${STRINGIFIED_ERROR_PREFIX}(?:`
+  // WebKit/Safari, Chromium, Gecko — the generic "fetch rejected" strings.
+  + 'load failed'
+  + '|failed to fetch'
+  // Gecko's full wording is `NetworkError when attempting to fetch resource.`;
+  // the noun is optional only because the old matcher keyed on the fragment.
+  + '|networkerror when attempting to fetch(?:\\s+resource)?'
+  // Darwin's CFNetwork wordings, surfaced verbatim by Safari/WebKit when the
+  // connection drops, the device is offline, or DNS cannot resolve the host.
+  + '|the network connection was lost'
+  + '|the internet connection appears to be offline'
+  + '|a server with the specified hostname could not be found'
+  + ')\\.?\\s*$',
+  'i',
+);
+
+export function isNetworkUnavailableError(message: string): boolean {
+  return BARE_TRANSPORT_FAILURE.test(message);
+}

--- a/apps/viewer/src/lib/load-errors.test.ts
+++ b/apps/viewer/src/lib/load-errors.test.ts
@@ -376,12 +376,51 @@ describe('classifyLoadError', () => {
     );
   });
 
-  it('does NOT claim three.js\'s WebGL failure, which nothing catches (#2354)', () => {
-    // PostHog issue 019fc458, thrown by THREE.WebGLRenderer out of the MCP
-    // playground's mount effect — an uncaught throw that tears the React tree
-    // down. Sweeping it into the benign family would silence real breakage.
+  it('classifies three.js\'s WebGL refusal into the same family (#2458)', () => {
+    // The reversal of the #2354 decision, and it turns on a fact that changed
+    // rather than a change of mind. Then: PostHog issue 019fc458 was
+    // `THREE.WebGLRenderer: Error creating WebGL context.` escaping the MCP
+    // hero's mount effect and taking the /mcp route down through
+    // ChunkErrorBoundary (recorded under `lazy_subtree_boundary`), and folding a
+    // page-killing crash into the benign minimap family would have hidden it.
+    // Now: #2401 put both /mcp scenes behind `useThreeScene`, and they are the
+    // only WebGLRenderer construction sites in this app, so these strings can
+    // only arrive as a handled degradation of one panel — the same device
+    // condition the minimap reports, and it belongs in the same bucket instead
+    // of minting one issue per wording.
     assert.equal(
       classifyLoadError(new Error('THREE.WebGLRenderer: Error creating WebGL context.')),
+      'webgl_unavailable',
+    );
+    assert.equal(
+      classifyLoadError(new Error('THREE.WebGLRenderer: Error creating WebGL context with your selected attributes.')),
+      'webgl_unavailable',
+    );
+    // The synthesised pre-flight message — the arm that fires first, and
+    // therefore the one most sessions actually report.
+    assert.equal(
+      classifyLoadError(new Error('THREE.WebGLRenderer: Error creating WebGL context. (pre-flight probe)')),
+      'webgl_unavailable',
+    );
+  });
+
+  it('does NOT claim a message that merely QUOTES three\'s wording (#2458)', () => {
+    // Same anchoring discipline as the MapLibre arms below: one of our own
+    // failures that wraps three's message for context is a bug of ours, and
+    // must keep its own identity rather than inherit a device-capability
+    // fingerprint nobody triages. Both ends, because anchoring one fixes one.
+    assert.equal(
+      classifyLoadError(new Error('THREE.WebGLRenderer: Error creating WebGL context. while building the hero')),
+      'unknown',
+    );
+    assert.equal(
+      classifyLoadError(new Error('HeroScene failed: THREE.WebGLRenderer: Error creating WebGL context.')),
+      'unknown',
+    );
+    // Not three's failure at all: a lost context is a different condition with
+    // a different remedy, and three words it differently on purpose.
+    assert.equal(
+      classifyLoadError(new Error('THREE.WebGLRenderer: Context Lost.')),
       'unknown',
     );
   });

--- a/apps/viewer/src/lib/load-errors.ts
+++ b/apps/viewer/src/lib/load-errors.ts
@@ -3,12 +3,17 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
- * Classification of model-load failures. The user-facing humanisation lives in
- * ./load-error-message.ts.
+ * Classification of model-load failures. This module owns the taxonomy and the
+ * ORDER the buckets are tried in; the user-facing humanisation lives in
+ * ./load-error-message.ts, and the two families whose matchers carry more
+ * rationale than pattern have their own modules (./webgl-unavailable.ts,
+ * ./cancelled-and-network-errors.ts) rather than a longer file here.
  *
  * Despite the name, this is the viewer's ONLY error-family classifier —
  * `analytics-scrub.ts` runs it over every captured `$exception` — so a non-load
- * family needing grouping belongs here too, not in a second one that would drift.
+ * family needing grouping belongs here too, not in a second one that would
+ * drift. The sibling modules are not that: they hold a family's WORDINGS, while
+ * every kind and the order it is tried in stays in {@link classifyLoadError}.
  *
  * The geometry/parser workers both initialise the same `@ifc-lite/wasm` binary.
  * wasm-bindgen's streaming loader rethrows on a non-OK HTTP status (it only
@@ -19,9 +24,8 @@
  * ./load-error-message.ts turns that kind into the user-facing message.
  */
 
-// Imported, not restated: a second copy of MapLibre's wordings would drift on
-// the next upgrade. That module imports nothing, so this adds no dependency.
-import { isWebglContextCreationError } from './geo/map-webgl-support.js';
+import { isCancelledError, isNetworkUnavailableError } from './cancelled-and-network-errors.js';
+import { isWebglUnavailable } from './webgl-unavailable.js';
 
 /** Stable, analytics-friendly classification of a load failure. */
 export type LoadErrorKind =
@@ -68,7 +72,8 @@ export type LoadErrorKind =
   | 'cancelled'
   /**
    * A fetch failed at the transport layer and the browser told us nothing else
-   * (the per-engine wordings are enumerated on `BARE_TRANSPORT_FAILURE` below).
+   * (the per-engine wordings are enumerated on `BARE_TRANSPORT_FAILURE`, in
+   * ./cancelled-and-network-errors.ts).
    * The connection dropped, went offline, or was killed mid-flight. Nothing in
    * the app is broken, so this is deliberately the LAST bucket checked: any
    * failure that identified itself keeps its own kind.
@@ -79,12 +84,9 @@ export type LoadErrorKind =
    * either `/mcp` three.js scene (#2458). Not a load failure and never reaches
    * `formatLoadError`; classified so the family gets ONE fingerprint instead of
    * one issue per deploy and per wording. Membership is by MESSAGE, not by who
-   * caught it: `isWebglContextCreationError` matches only MapLibre's own
-   * wordings and the two strings `LocationMap` synthesizes, and
-   * `isThreeContextRefusal` only three.js's two authored wordings and the one
-   * `three-webgl-support.ts` synthesizes — all of them anchored, so an error
-   * that merely MENTIONS the phrase keeps its own identity and its `error`
-   * severity.
+   * caught it, and both libraries' wordings live together in
+   * ./webgl-unavailable.ts — anchored, so an error that merely MENTIONS one of
+   * the phrases keeps its own identity and its `error` severity.
    */
   | 'webgl_unavailable'
   /** Anything else. */
@@ -221,168 +223,6 @@ function isWasmRuntimeCrashError(err: unknown, message: string): boolean {
   );
 }
 
-/**
- * A cross-realm throwable reaches the analytics path as `String(err)` — i.e.
- * `"TypeError: Load failed"`, not `"Load failed"`. Structural, so the anchored
- * matchers below tolerate it; BOUNDED, so it cannot stand in for an arbitrary
- * leading sentence of ours that happens to end in "…Error:".
- *
- * `{0,32}`, not `{1,32}`: the commonest constructor is `Error` itself, whose
- * stringification is the bare `Error: Load failed`, and requiring a letter in
- * front excluded exactly that (Codex review, #2431). What does the real work is
- * `[A-Za-z]` admitting no space and no colon — a leading clause of ours can
- * never be swallowed however the count is written.
- */
-const STRINGIFIED_ERROR_PREFIX = '(?:[A-Za-z]{0,32}Error:\\s*)?';
-
-/**
- * The user (or a superseding load) cancelled the operation.
- *
- * ANCHORED, because `cancelled` is in `BENIGN_ERROR_KINDS` (./analytics-scrub.ts):
- * matching it downgrades the event to `warning` and fingerprints it into the
- * cancellation issue, taking an actionable failure off the error-level list as
- * effectively as deleting it. The old `/\bcancel(?:led|ed)?\b/` fired on the word
- * ANYWHERE — and, both suffixes optional, on a bare "cancel" — so `Upload failed:
- * driver shim logged cancelled while retrying` read benign (#2410).
- *
- * Shaped differently from the whole-message anchor `isNetworkUnavailableError`
- * uses, because the wordings have a different author: the transport strings
- * come from `fetch()` and ARE the entire message, whereas cancellations are
- * mostly ours and carry authored detail after the token (`Sync cancelled:
- * <model> was removed while its update was downloading.`, `Clash run cancelled
- * before meshing.`). So what is pinned is the SUBJECT — a cancellation report
- * names what was cancelled in its opening words; a failure that merely mentions
- * one reaches the token past a clause of its own. Two arms, because the bare
- * token has no subject to name and so gets no trailing latitude at all
- * (otherwise `cancelled and our upload pipeline then wrote 0 bytes` walks
- * through). The residual, stated plainly: `Upload cancelled and the pipeline
- * wrote 0 bytes` is still read as a cancellation report, because it is one.
- */
-const CANCELLED_REPORT = new RegExp(
-  `^\\s*${STRINGIFIED_ERROR_PREFIX}(?:`
-  + 'cancell?ed\\.?\\s*$'
-  // `[^\s:]+` so the subject cannot be reached across a `:` — that separator is
-  // what makes "Upload failed: …" a sentence about the upload, not a cancellation.
-  + '|(?:[^\\s:]+\\s+){1,2}cancell?ed\\b'
-  + ')',
-  'i',
-);
-
-/**
- * The browsers' own abort wordings — unlike ours these ARE the whole message,
- * so both ends are pinned. `.name === 'AbortError'` already claims the live
- * DOMException in {@link classifyLoadError}; this covers the analytics path,
- * where all we ever have is the stringified value.
- */
-const ABORTED_MESSAGE = new RegExp(
-  `^\\s*${STRINGIFIED_ERROR_PREFIX}(?:`
-  + 'the operation was aborted'          // Gecko
-  + '|the user aborted a request'        // Chromium
-  + '|fetch is aborted'                  // WebKit
-  + '|signal is aborted without reason'  // AbortController with no reason
-  + ')\\.?\\s*$',
-  'i',
-);
-
-function isCancelledError(message: string): boolean {
-  // `AbortError` is the stringified NAME — an identity, not prose — so it is
-  // anchored to the start rather than matched as a substring anywhere.
-  return CANCELLED_REPORT.test(message)
-    || /^\s*AbortError\b/.test(message)
-    || ABORTED_MESSAGE.test(message);
-}
-
-/**
- * A bare transport failure: the request never completed and the browser gave us
- * nothing but its house phrasing. These strings originate inside `fetch()`
- * rather than in our frames, so they arrive with an EMPTY stack — exactly how
- * #1903 reached error tracking as an unattributable `TypeError: Load failed`.
- * Checked LAST, so a failure that named itself (the engine binary, the file, a
- * worker) keeps its own, more actionable kind.
- *
- * ANCHORED AT BOTH ENDS, and that is load-bearing rather than tidiness: this is
- * the most dangerous label in the file. `analytics-scrub.ts` downgrades it to
- * `warning` via `BENIGN_ERROR_KINDS` AND deletes the event outright when the
- * browser also reported `navigator.onLine === false`, so the old substring test
- * meant any failure of ours quoting a transport phrase (`Upload failed: driver
- * shim logged Failed to fetch while retrying`) was silenced, and on an offline
- * client destroyed with no record (#2410). The anchor is exactly the premise
- * stated above — these strings come FROM `fetch()`, so anything wrapping one is
- * by construction ours. A wrapped transport failure now falls to `unknown`:
- * loud, own grouping, the safe direction for a droppable kind.
- *
- * This subsumes what used to be an explicit module-import exclusion: Chromium's
- * `Failed to fetch dynamically imported module: …/assets/Foo-<hash>.js` is our
- * deploy rotating an asset under a still-open tab, not a dropped connection, and
- * it names the module, so it is no longer the whole wording. The guard that said
- * so is gone rather than left as an unreachable branch — `load-errors.test.ts`
- * keeps the regression test as the live gate on this anchor.
- */
-const BARE_TRANSPORT_FAILURE = new RegExp(
-  `^\\s*${STRINGIFIED_ERROR_PREFIX}(?:`
-  // WebKit/Safari, Chromium, Gecko — the generic "fetch rejected" strings.
-  + 'load failed'
-  + '|failed to fetch'
-  // Gecko's full wording is `NetworkError when attempting to fetch resource.`;
-  // the noun is optional only because the old matcher keyed on the fragment.
-  + '|networkerror when attempting to fetch(?:\\s+resource)?'
-  // Darwin's CFNetwork wordings, surfaced verbatim by Safari/WebKit when the
-  // connection drops, the device is offline, or DNS cannot resolve the host.
-  + '|the network connection was lost'
-  + '|the internet connection appears to be offline'
-  + '|a server with the specified hostname could not be found'
-  + ')\\.?\\s*$',
-  'i',
-);
-
-function isNetworkUnavailableError(message: string): boolean {
-  return BARE_TRANSPORT_FAILURE.test(message);
-}
-
-/**
- * The same device refusal, reached through three.js instead of MapLibre.
- *
- * `WebGLRenderer`'s constructor asks the canvas for `webgl2` and throws one of
- * exactly two authored messages when the browser says no (three@0.185.1):
- *
- *   'THREE.WebGLRenderer: Error creating WebGL context.'
- *   'THREE.WebGLRenderer: Error creating WebGL context with your selected attributes.'
- *
- * plus the third that `components/mcp/three-webgl-support.ts` synthesises when
- * its pre-flight probe answers before three is ever constructed — the arm that
- * fires FIRST on a device with no `webgl2`, and therefore the one production
- * mostly sees.
- *
- * Claimed here only because #2401 changed what these mean. #2354 deliberately
- * left them out: back then they escaped a mount effect and took the whole
- * `/mcp` route down through `ChunkErrorBoundary`, and folding a page-killing
- * crash into the benign minimap family would have hidden it. Both `/mcp` scenes
- * now mount behind `useThreeScene`, the only `WebGLRenderer` construction sites
- * in this app, so these strings can only arrive as the handled, one-per-session
- * degradation the minimap already files. Same device condition, same
- * fingerprint, and the same `warning` severity — `webgl_unavailable` is in
- * `BENIGN_ERROR_KINDS`, so this also stops one dead panel competing with real
- * breakage on the error-level list. `context` / `three_surface` still separate
- * the two surfaces inside the issue.
- *
- * ANCHORED, like every matcher here, and STRICTER than
- * `isThreeWebglContextError` in `three-webgl-support.ts`, which prefix-matches:
- * that one decides whether to degrade one panel and is recoverable when it
- * over-matches; this one hands out a shared fingerprint and is not.
- */
-const THREE_CONTEXT_REFUSAL = new RegExp(
-  '^\\s*THREE\\.WebGLRenderer: Error creating WebGL context'
-  + '(?: with your selected attributes)?\\.'
-  // The pre-flight suffix, kept in step with `threeProbeFailureError()`. A
-  // drift canary in three-webgl-support.test.ts classifies that function's
-  // real output, so a reworded probe cannot silently fall out of the family.
-  + '(?: \\(pre-flight probe\\))?\\s*$',
-);
-
-function isThreeContextRefusal(message: string): boolean {
-  return THREE_CONTEXT_REFUSAL.test(message);
-}
-
 /** Classify a load failure into a stable analytics bucket. */
 export function classifyLoadError(err: unknown): LoadErrorKind {
   const message = messageOf(err);
@@ -403,11 +243,9 @@ export function classifyLoadError(err: unknown): LoadErrorKind {
   if (name === 'AbortError') return 'cancelled';
   // BEFORE the memory/network buckets: MapLibre's failure carries the driver's
   // own `statusMessage`, vendor prose we do not control and free to contain the
-  // words those matchers key on ("allocation failed"). Safe to claim first — it
-  // takes only MapLibre's authored wordings and its event token, not a name.
-  if (isWebglContextCreationError(err) || isThreeContextRefusal(message)) {
-    return 'webgl_unavailable';
-  }
+  // words those matchers key on ("allocation failed"). Safe to claim first —
+  // every arm of it is anchored or structural (see ./webgl-unavailable.ts).
+  if (isWebglUnavailable(err, message)) return 'webgl_unavailable';
   if (isWasmEngineLoadError(message)) return 'wasm_engine_load';
   // Explicit memory-exhaustion signals win over the worker-crash bucket so a
   // worker that died with a clear OOM message is grouped as out_of_memory.

--- a/apps/viewer/src/lib/load-errors.ts
+++ b/apps/viewer/src/lib/load-errors.ts
@@ -75,13 +75,16 @@ export type LoadErrorKind =
    */
   | 'network_unavailable'
   /**
-   * The browser refused a WebGL context to the location minimap (#2354). Not a
-   * load failure and never reaches `formatLoadError`; classified so the
-   * family gets ONE fingerprint instead of one issue per deploy. Membership is
-   * by MESSAGE, not by who caught it: `isWebglContextCreationError` matches only
-   * MapLibre's own wordings and the two strings `LocationMap` synthesizes, all
-   * of them anchored, so an error that merely MENTIONS the phrase keeps its own
-   * identity and its `error` severity.
+   * The browser refused a WebGL context: to the location minimap (#2354) or to
+   * either `/mcp` three.js scene (#2458). Not a load failure and never reaches
+   * `formatLoadError`; classified so the family gets ONE fingerprint instead of
+   * one issue per deploy and per wording. Membership is by MESSAGE, not by who
+   * caught it: `isWebglContextCreationError` matches only MapLibre's own
+   * wordings and the two strings `LocationMap` synthesizes, and
+   * `isThreeContextRefusal` only three.js's two authored wordings and the one
+   * `three-webgl-support.ts` synthesizes — all of them anchored, so an error
+   * that merely MENTIONS the phrase keeps its own identity and its `error`
+   * severity.
    */
   | 'webgl_unavailable'
   /** Anything else. */
@@ -336,6 +339,50 @@ function isNetworkUnavailableError(message: string): boolean {
   return BARE_TRANSPORT_FAILURE.test(message);
 }
 
+/**
+ * The same device refusal, reached through three.js instead of MapLibre.
+ *
+ * `WebGLRenderer`'s constructor asks the canvas for `webgl2` and throws one of
+ * exactly two authored messages when the browser says no (three@0.185.1):
+ *
+ *   'THREE.WebGLRenderer: Error creating WebGL context.'
+ *   'THREE.WebGLRenderer: Error creating WebGL context with your selected attributes.'
+ *
+ * plus the third that `components/mcp/three-webgl-support.ts` synthesises when
+ * its pre-flight probe answers before three is ever constructed — the arm that
+ * fires FIRST on a device with no `webgl2`, and therefore the one production
+ * mostly sees.
+ *
+ * Claimed here only because #2401 changed what these mean. #2354 deliberately
+ * left them out: back then they escaped a mount effect and took the whole
+ * `/mcp` route down through `ChunkErrorBoundary`, and folding a page-killing
+ * crash into the benign minimap family would have hidden it. Both `/mcp` scenes
+ * now mount behind `useThreeScene`, the only `WebGLRenderer` construction sites
+ * in this app, so these strings can only arrive as the handled, one-per-session
+ * degradation the minimap already files. Same device condition, same
+ * fingerprint, and the same `warning` severity — `webgl_unavailable` is in
+ * `BENIGN_ERROR_KINDS`, so this also stops one dead panel competing with real
+ * breakage on the error-level list. `context` / `three_surface` still separate
+ * the two surfaces inside the issue.
+ *
+ * ANCHORED, like every matcher here, and STRICTER than
+ * `isThreeWebglContextError` in `three-webgl-support.ts`, which prefix-matches:
+ * that one decides whether to degrade one panel and is recoverable when it
+ * over-matches; this one hands out a shared fingerprint and is not.
+ */
+const THREE_CONTEXT_REFUSAL = new RegExp(
+  '^\\s*THREE\\.WebGLRenderer: Error creating WebGL context'
+  + '(?: with your selected attributes)?\\.'
+  // The pre-flight suffix, kept in step with `threeProbeFailureError()`. A
+  // drift canary in three-webgl-support.test.ts classifies that function's
+  // real output, so a reworded probe cannot silently fall out of the family.
+  + '(?: \\(pre-flight probe\\))?\\s*$',
+);
+
+function isThreeContextRefusal(message: string): boolean {
+  return THREE_CONTEXT_REFUSAL.test(message);
+}
+
 /** Classify a load failure into a stable analytics bucket. */
 export function classifyLoadError(err: unknown): LoadErrorKind {
   const message = messageOf(err);
@@ -358,7 +405,9 @@ export function classifyLoadError(err: unknown): LoadErrorKind {
   // own `statusMessage`, vendor prose we do not control and free to contain the
   // words those matchers key on ("allocation failed"). Safe to claim first — it
   // takes only MapLibre's authored wordings and its event token, not a name.
-  if (isWebglContextCreationError(err)) return 'webgl_unavailable';
+  if (isWebglContextCreationError(err) || isThreeContextRefusal(message)) {
+    return 'webgl_unavailable';
+  }
   if (isWasmEngineLoadError(message)) return 'wasm_engine_load';
   // Explicit memory-exhaustion signals win over the worker-crash bucket so a
   // worker that died with a clear OOM message is grouped as out_of_memory.

--- a/apps/viewer/src/lib/webgl-unavailable.ts
+++ b/apps/viewer/src/lib/webgl-unavailable.ts
@@ -1,0 +1,92 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Membership of the `webgl_unavailable` family (the kind is declared, with the
+ * rest of the taxonomy, in ./load-errors.ts).
+ *
+ * ONE device condition, two libraries. The browser refuses a WebGL context to
+ * MapLibre (the location minimap, #2354) or to three.js (either `/mcp` scene,
+ * #2458); both surfaces probe once, latch the verdict and degrade to a static
+ * fallback through the shared gate in ./webgl-capability.ts, and both report it
+ * as a handled exception. What this module decides is that those reports land
+ * in the SAME analytics issue instead of one per library, per wording and per
+ * deploy — and, because `webgl_unavailable` is in `BENIGN_ERROR_KINDS`
+ * (./analytics-scrub.ts), at `warning` rather than `error`.
+ *
+ * The whole family lives here so that the SET is visible in one read: a third
+ * GPU surface adds an arm to {@link isWebglUnavailable}, rather than a matcher
+ * somewhere else that nobody thinks to group. Membership is by MESSAGE, not by
+ * who caught it.
+ *
+ * EVERY arm is anchored or structural; none is a bare `includes`. That is a
+ * property of the whole boolean and has to be checked as one, because this
+ * predicate hands out both a shared fingerprint and a benign severity: a single
+ * loose arm is enough to relabel a real bug of ours as a dead GPU and bury it
+ * in an issue nobody triages (#2354). Adding an arm here means anchoring it.
+ *
+ * MapLibre's wordings are IMPORTED rather than restated: a second copy would
+ * drift on the next upgrade, and `lib/geo/map-webgl-support.ts` owns them for
+ * `lib/analytics-scrub.ts` too. That module imports no renderer library, so
+ * this adds no dependency.
+ */
+
+import { isWebglContextCreationError } from './geo/map-webgl-support.js';
+
+/**
+ * The same device refusal, reached through three.js instead of MapLibre.
+ *
+ * `WebGLRenderer`'s constructor asks the canvas for `webgl2` and throws one of
+ * exactly two authored messages when the browser says no (three@0.185.1):
+ *
+ *   'THREE.WebGLRenderer: Error creating WebGL context.'
+ *   'THREE.WebGLRenderer: Error creating WebGL context with your selected attributes.'
+ *
+ * plus the third that `components/mcp/three-webgl-support.ts` synthesises when
+ * its pre-flight probe answers before three is ever constructed — the arm that
+ * fires FIRST on a device with no `webgl2`, and therefore the one production
+ * mostly sees.
+ *
+ * Claimed here only because #2401 changed what these mean. #2354 deliberately
+ * left them out: back then they escaped a mount effect and took the whole
+ * `/mcp` route down through `ChunkErrorBoundary`, and folding a page-killing
+ * crash into the benign minimap family would have hidden it. Both `/mcp` scenes
+ * now mount behind `useThreeScene`, the only `WebGLRenderer` construction sites
+ * in this app, so these strings can only arrive as the handled, one-per-session
+ * degradation the minimap already files. Same device condition, same
+ * fingerprint, and the same `warning` severity — `webgl_unavailable` is in
+ * `BENIGN_ERROR_KINDS`, so this also stops one dead panel competing with real
+ * breakage on the error-level list. `context` / `three_surface` still separate
+ * the two surfaces inside the issue.
+ *
+ * ANCHORED, like every matcher here, and STRICTER than
+ * `isThreeWebglContextError` in `three-webgl-support.ts`, which prefix-matches:
+ * that one decides whether to degrade one panel and is recoverable when it
+ * over-matches; this one hands out a shared fingerprint and is not.
+ */
+const THREE_CONTEXT_REFUSAL = new RegExp(
+  '^\\s*THREE\\.WebGLRenderer: Error creating WebGL context'
+  + '(?: with your selected attributes)?\\.'
+  // The pre-flight suffix, kept in step with `threeProbeFailureError()`. A
+  // drift canary in three-webgl-support.test.ts classifies that function's
+  // real output, so a reworded probe cannot silently fall out of the family.
+  + '(?: \\(pre-flight probe\\))?\\s*$',
+);
+
+function isThreeContextRefusal(message: string): boolean {
+  return THREE_CONTEXT_REFUSAL.test(message);
+}
+
+/**
+ * Is this error the device refusing a WebGL context, to either library?
+ *
+ * Takes the throwable AND its stringified message because the two arms key on
+ * different things: MapLibre v6 identifies its failure by the error's `name` as
+ * well as by its wording, while `WebGLRenderer` throws a plain `Error` whose
+ * message is all there is. The message is passed in rather than re-derived so
+ * that this sees exactly what `classifyLoadError` classified.
+ */
+export function isWebglUnavailable(err: unknown, message: string): boolean {
+  return isWebglContextCreationError(err) || isThreeContextRefusal(message);
+}


### PR DESCRIPTION
## What this is, and what it is not

**#2458 is mostly already fixed.** It was filed from a static read of a checkout that predates #2401 / PR #2406 (`4e783fa58`), which shipped exactly the guard it asks for: both `/mcp` scenes mount through `useThreeScene`, probe once, latch the verdict for the session, catch three's context refusal, paint a static fallback, and report it once as a HANDLED exception. The line numbers in the issue no longer exist — `createScene` moved to `hero-scene.ts` / `playground-scene.ts` months of commits ago.

Two of the issue's three bullets were therefore already done. The third was not:

> report it as a degradation rather than an error, so it groups with the existing WebGL-unavailable signal instead of opening a new crash issue

Half of that shipped (handled, not a crash). The grouping half did not. `classifyLoadError` only knew MapLibre's wordings, so all three strings the `/mcp` path can report classified `unknown`:

```
"THREE.WebGLRenderer: Error creating WebGL context."                          -> unknown
"THREE.WebGLRenderer: Error creating WebGL context with your selected attributes." -> unknown
"THREE.WebGLRenderer: Error creating WebGL context. (pre-flight probe)"       -> unknown
"Failed to initialize WebGL"                                                 -> webgl_unavailable
```

No `error_kind` means no `ifc-lite:webgl_unavailable` fingerprint and no severity downgrade: one device condition still minted up to three error-level PostHog issues of its own, re-split on every deploy by the hashed bundle in the stack, none of them the issue the minimap already files for the identical refusal. The pre-flight arm is the one that fires first on a device with no `webgl2`, so it is the one most sessions would have reported.

## The change

- `lib/load-errors.ts`: an anchored `isThreeContextRefusal` covering three's two authored wordings plus the pre-flight message `three-webgl-support.ts` synthesises, OR'd into the `webgl_unavailable` branch.
- `lib/analytics-scrub.ts`: comment only. The `BENIGN_ERROR_KINDS` block explicitly documented why three's failure must stay error-level ("nothing catches it — it throws out of the MCP playground's mount effect"). That premise was removed by #2401; the comment now records why it was right then and what changed, rather than being deleted.

Deliberately stricter than `isThreeWebglContextError` in `three-webgl-support.ts`, which prefix-matches: that one decides whether to degrade one panel and is recoverable if it over-matches; this one hands out a shared fingerprint **and** a benign severity, and over-matching there is how a real bug of ours stops being triaged.

Consequence worth calling out explicitly: these events now downgrade from `error` to `warning`, because `webgl_unavailable` is in `BENIGN_ERROR_KINDS`. That is the intended reading of "report it as a degradation, not an error" — the report is still sent, still queryable, with `context` / `three_surface` / `webgl_context` intact.

## Verified

Every claim below was run, not read.

- **The gap is real, measured not inferred**: ran `classifyLoadError` + `scrubEvent` over the four messages before touching anything (output above). PostHog issue `019fc458` confirms the field shape: `handled: true`, `context: lazy_subtree_boundary`, `lazy_chunk: MCP page`, `$current_url: /mcp`, Chrome 116 on Linux.
- **Reachability**: happy-dom's `canvas.getContext('webgl2')` returns `null`, and the pinned three@0.185.1 really throws `THREE.WebGLRenderer: Error creating WebGL context.` there — verified by constructing a real `WebGLRenderer`, and it is verbatim the production message.
- **End to end, not fixtures**: a new test mounts the real `HeroScene` on that GPU-less environment with only `posthog.captureException` stubbed, and asserts the error object the code *actually reports* classifies into the family. A hand-written message would have proved the regex compiles, which is precisely how these two came apart before.
- **Mutation-checked, six mutations, each verified on disk first and read off the TEST COUNT (never just the exit code):**
  1. drop `|| isThreeContextRefusal(message)` -> 5 fail / 153 (the 4 new + the rewritten analytics one), count unchanged.
  2. drop the trailing `$` anchor -> only "does NOT claim a message that merely QUOTES three's wording" fails, 75/76.
  3. drop the leading `^` anchor -> same test fails, 54/55.
  4. reword `threeProbeFailureError()`'s suffix -> the drift canary and the end-to-end mount test fail, 19/21. (This is the point of that canary: the classifier anchors on a string authored in another file.)
  5. mutation 1 again across all four test files -> the kill list above.
  6. remove `webgl_unavailable` from `BENIGN_ERROR_KINDS` -> both new severity assertions fail, alongside the two pre-existing minimap ones.
- **Gates**, verbatim: `pnpm typecheck` -> `TYPECHECK_EXIT=0` (36/36 tasks). `pnpm test` -> `TEST_EXIT=0` (86/86 turbo tasks; `@ifc-lite/viewer` 3350 pass, 0 fail, 6 skipped).
- An earlier full run failed with exactly one test — the pre-existing `keeps three.js's WebGL failure LOUD` in `analytics.test.ts`, which asserted the behaviour this PR reverses. It is rewritten with the reversal rationale, and a companion test now pins the narrowness case (a message that merely quotes three's wording keeps `error` severity and its own issue).
- `apps/viewer` is `"private": true` — checked, no changeset needed.

## NOT verified

- **No real browser.** Nothing here was run on a GPU-less Chrome or against live PostHog. happy-dom reproduces the refusal faithfully at the `getContext` level, which is what the guard keys on, but the rendered fallback and the ingested `warning`-level event are unverified by me.
- **The severity downgrade is a judgement call, not a measurement.** If a WebGLRenderer is ever constructed outside `useThreeScene`, its throw would now arrive benign. There is no lint or test forbidding that; the guard is the only thing keeping it honest, and the code comment says so.
- **Pre-existing, untouched, and worth its own issue:** `startThreeScene` rethrows anything that is not three's context refusal — correct on the "our bugs stay loud" axis — but if `createScene` throws *after* the renderer exists, the live GL context is never released and its canvas may already be attached. The refused-context path genuinely has nothing to clean up (three builds a detached canvas and throws before we attach it), so this is only the scene-bug path, and fixing it means threading the renderer back out of both scene factories. Related to #2445 but not the same thing.

## On the issue's framing

Two corrections, both from running the code rather than reading it:

1. **"the React tree unmounts and the user gets a blank page" is wrong.** `App.tsx` has wrapped both `/mcp` routes in `ChunkErrorBoundary` since #1946, and it catches any render/effect error, not just chunk loads. Production showed the whole route replaced by an "MCP page stopped working / Reload" card — bad, and worth fixing, but not blank, and it was already being reported as handled. The PostHog event proves it: `context: lazy_subtree_boundary`.
2. **The suggested shape was already implemented.** The issue's read of `HeroScene.tsx:173` / `PlaygroundViewer.tsx:345` describes code that is no longer on main.

Neither correction changes that the remaining bullet was a genuine, live gap.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of WebGL availability issues in 3D scenes.
  * WebGL initialization failures are now consistently classified and reported with warning-level severity.
  * Related errors share a common diagnostic fingerprint, improving analytics consistency.
  * Prevented unrelated, wrapped, quoted, or context-loss messages from being misclassified.

* **Tests**
  * Added coverage for refused WebGL devices, pre-flight checks, and analytics reporting.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->