### PR TITLE
fix(mcp): shader-level transparency, frustum-truthful pin visibility, entity-counted legend

### DIFF
--- a/apps/viewer/src/components/mcp/hero-pin-frame.test.ts
+++ b/apps/viewer/src/components/mcp/hero-pin-frame.test.ts
@@ -1,0 +1,184 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * That `visible` answers for the whole frustum, not just for depth (#2453).
+ *
+ * Two oracles, and the second is what keeps the first honest:
+ *
+ * 1. A SWEEP of the authored hero scene. The BCF-pin step orbits a fixed pin
+ *    with `autoRotate` on, so the interesting states are reached by the page
+ *    itself within seconds — no user input required. Sampling a full
+ *    revolution at the real camera distance is therefore a faithful model of
+ *    what the hero does, and the depth-only predicate calls the pin visible on
+ *    every one of those samples including the ones where it has left the frame
+ *    sideways. Measured on the authored constants: 178 of 720 azimuths, peak
+ *    |ndc.x| = 1.087.
+ * 2. A camera where the pin never leaves the frame (`cameraDefault`, peak
+ *    |ndc.x| = 0.795), which must still report visible on all 720 samples.
+ *    Without it, "return false more often" would pass the first oracle.
+ *
+ * The exact boundary is then pinned separately against an orthographic camera
+ * whose NDC x equals world x, so ±1 and ±(1 + ε) can be stated exactly rather
+ * than approached.
+ *
+ * Scene constants are a snapshot of the authored hero (`hero-scene-building.ts`
+ * — pin at (2.6, 1.9, FRONT_Z + 0.1) with FRONT_Z = D/2 + 0.001, D = 5 — and
+ * `hero-scene-steps.ts`, step 10's `cameraTarget`). If they drift, the
+ * reachability assertions below fail loudly rather than going quiet, which is
+ * the failure mode to want: re-measure and update the numbers.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import * as THREE from 'three';
+
+import { projectPinFrame } from './hero-pin-frame.js';
+import { STOREY } from './hero-scene-building.js';
+
+/** The hero's BCF pin, in world space. */
+const PIN = new THREE.Vector3(2.6, 1.9, 5 / 2 + 0.001 + 0.1);
+/** `OrbitControls.target` in `createScene`. */
+const ORBIT_TARGET = new THREE.Vector3(0, STOREY, 0);
+/** The stage is `aspect-[4/5]`; any size with that ratio gives the same NDC. */
+const STAGE_W = 480;
+const STAGE_H = 600;
+const SAMPLES = 720;
+
+/** The camera `createScene` builds, aimed from `position` at the orbit target. */
+function heroCamera(position: THREE.Vector3): THREE.PerspectiveCamera {
+  const camera = new THREE.PerspectiveCamera(35, STAGE_W / STAGE_H, 0.1, 100);
+  camera.position.copy(position);
+  camera.lookAt(ORBIT_TARGET);
+  camera.updateMatrixWorld(true);
+  camera.updateProjectionMatrix();
+  return camera;
+}
+
+interface Sample {
+  ndc: THREE.Vector3;
+  /** What `projectPin()` reports today. */
+  visible: boolean;
+  /** What it reported before the fix: depth alone. */
+  depthOnlyVisible: boolean;
+}
+
+/** One full `autoRotate` revolution from `start`, sampled `SAMPLES` times. */
+function sweepOrbit(start: [number, number, number]): Sample[] {
+  const spherical = new THREE.Spherical().setFromVector3(
+    new THREE.Vector3(...start).sub(ORBIT_TARGET),
+  );
+  const out: Sample[] = [];
+  for (let i = 0; i < SAMPLES; i++) {
+    const at = new THREE.Vector3().setFromSpherical(new THREE.Spherical(
+      spherical.radius, spherical.phi, spherical.theta + (i / SAMPLES) * Math.PI * 2,
+    )).add(ORBIT_TARGET);
+    const camera = heroCamera(at);
+    const ndc = PIN.clone().project(camera);
+    const frame = projectPinFrame(PIN, camera, STAGE_W, STAGE_H);
+    assert.ok(frame, 'a sized stage must never project to null');
+    out.push({ ndc, visible: frame.visible, depthOnlyVisible: ndc.z >= -1 && ndc.z <= 1 });
+  }
+  return out;
+}
+
+describe('hero pin projection: visible means inside the frustum (#2453)', () => {
+  it('stops reporting visible while the BCF-pin step has orbited the pin out of frame', () => {
+    // Step 10 — the one step that fades the pin in and renders the caption.
+    const samples = sweepOrbit([9.5, 4, 10]);
+    const escaped = samples.filter((s) => Math.abs(s.ndc.x) > 1);
+
+    // Reachability first: if the scene ever stops putting the pin off-frame,
+    // every assertion below would hold vacuously.
+    assert.ok(escaped.length > 100, `the pin must leave the frame on this step (got ${escaped.length}/${SAMPLES})`);
+    assert.ok(
+      Math.max(...samples.map((s) => Math.abs(s.ndc.x))) > 1.05,
+      'and overshoot the edge by a margin no rounding could explain',
+    );
+    // The defect, stated as a control: depth alone called every one of these
+    // visible, so `HeroOverlay` placed the caption at `x + 22` off-canvas.
+    assert.ok(escaped.every((s) => s.depthOnlyVisible), 'control: the old predicate saw all of them as visible');
+
+    assert.ok(escaped.every((s) => !s.visible), 'a pin outside the lateral bounds is not visible');
+    assert.ok(
+      samples.filter((s) => s.visible).every((s) => Math.abs(s.ndc.x) <= 1 && Math.abs(s.ndc.y) <= 1),
+      'nothing reported visible may sit outside the frustum',
+    );
+  });
+
+  it('still reports visible for every angle of an orbit that keeps the pin in frame', () => {
+    // Anti-mutation. `cameraDefault` peaks at |ndc.x| = 0.795, so any predicate
+    // tighter than the true frustum — a safety margin, a hard-coded 0.75, an
+    // accidental sign flip — starts hiding a caption that belongs on screen and
+    // this fails.
+    const samples = sweepOrbit([12, 8, 13]);
+    assert.equal(samples.filter((s) => s.visible).length, SAMPLES, 'the pin never leaves this frame');
+    assert.ok(
+      Math.max(...samples.map((s) => Math.abs(s.ndc.x))) < 1,
+      'fixture check: this camera is the in-frame control',
+    );
+  });
+
+  it('places the frustum edge exactly at |ndc| == 1, and excludes anything past it', () => {
+    // An orthographic camera spanning [-1, 1] makes NDC x equal world x, so
+    // the boundary can be stated rather than approached.
+    const camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0.1, 10);
+    camera.position.set(0, 0, 5);
+    camera.lookAt(0, 0, 0);
+    camera.updateMatrixWorld(true);
+    camera.updateProjectionMatrix();
+
+    const visible = (x: number, y: number, z = 0) =>
+      projectPinFrame(new THREE.Vector3(x, y, z), camera, STAGE_W, STAGE_H)?.visible;
+
+    // Inclusive on purpose: the pin is a world-space sprite with extent, so at
+    // exactly the edge its centre is on the boundary and half of it is drawn.
+    assert.equal(visible(1, 0), true, 'the right edge is on screen');
+    assert.equal(visible(-1, 0), true, 'so is the left');
+    assert.equal(visible(0, 1), true, 'and the top');
+    assert.equal(visible(0, -1), true, 'and the bottom');
+
+    // One part in a million past it is off screen — an over-broad predicate
+    // (bounds of 1.1, or a `< 1.5` fudge) fails here.
+    assert.equal(visible(1.000001, 0), false, 'a hair past the right edge is not');
+    assert.equal(visible(0, -1.000001), false, 'nor past the bottom');
+    assert.equal(visible(0.999999, 0.999999), true, 'a hair inside still is');
+
+    // Depth is still part of it — the half that already worked.
+    assert.equal(visible(0, 0, 6), false, 'behind the camera stays invisible');
+  });
+
+  it('reports the position of an off-frustum pin rather than returning null (#2446)', () => {
+    const camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0.1, 10);
+    camera.position.set(0, 0, 5);
+    camera.lookAt(0, 0, 0);
+    camera.updateMatrixWorld(true);
+    camera.updateProjectionMatrix();
+
+    const frame = projectPinFrame(new THREE.Vector3(3, 0, 0), camera, STAGE_W, STAGE_H);
+    assert.ok(frame, 'out-of-frustum is reported through `visible`, never by returning null');
+    assert.equal(frame.visible, false);
+    assert.equal(Number.isFinite(frame.x) && Number.isFinite(frame.y), true, 'x/y are filled in, and meaningless');
+
+    // `null` has exactly one cause: no coordinate space to project into.
+    assert.equal(projectPinFrame(new THREE.Vector3(0, 0, 0), camera, 0, STAGE_H), null);
+    assert.equal(projectPinFrame(new THREE.Vector3(0, 0, 0), camera, STAGE_W, 0), null);
+  });
+
+  it('maps NDC into host pixels with y pointing down', () => {
+    // The overlay anchors to these numbers with CSS `left` / `top`, so the
+    // flip matters as much as the visibility flag.
+    const camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0.1, 10);
+    camera.position.set(0, 0, 5);
+    camera.lookAt(0, 0, 0);
+    camera.updateMatrixWorld(true);
+    camera.updateProjectionMatrix();
+
+    const centre = projectPinFrame(new THREE.Vector3(0, 0, 0), camera, STAGE_W, STAGE_H);
+    assert.deepEqual([centre?.x, centre?.y], [STAGE_W / 2, STAGE_H / 2]);
+
+    const top = projectPinFrame(new THREE.Vector3(0, 1, 0), camera, STAGE_W, STAGE_H);
+    assert.equal(top?.y, 0, 'the top of NDC is y = 0 in CSS pixels');
+  });
+});

--- a/apps/viewer/src/components/mcp/hero-pin-frame.ts
+++ b/apps/viewer/src/components/mcp/hero-pin-frame.ts
@@ -1,0 +1,76 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Project the hero's BCF pin into its host element's pixel space — the body
+ * behind `SceneHandle.projectPin()`.
+ *
+ * It lives outside `hero-scene.ts` for the reason `release-renderer.ts` does:
+ * `createScene` needs a WebGL context and so never executes in CI (happy-dom
+ * refuses one), while this is pure maths over a camera and a point and runs
+ * anywhere. That seam is what makes #2453 testable at all.
+ *
+ * `visible` used to be a DEPTH test only (`z >= -1 && z <= 1`). After
+ * `.project()` all three components are NDC, so a pin that had orbited out of
+ * frame sideways still reported `visible: true` and `McpLanding`'s
+ * `HeroOverlay` went on rendering the `BCF #04` caption at `pinFrame.x + 22` —
+ * outside a stage that is `overflow-hidden`, so the caption was clipped away
+ * while the code believed it was showing it. Sweeping the real constants (pin
+ * at (2.6, 1.9, 2.601), orbit target (0, 3, 0), `PerspectiveCamera(35, 4/5)`)
+ * over a full revolution, the BCF-pin step spends 178 of 720 sampled azimuths
+ * in that state and peaks at |ndc.x| = 1.087. The portrait `aspect-[4/5]`
+ * stage is what makes it lateral: it narrows the horizontal FOV to about 28°
+ * against the 35° vertical, so |ndc.y| never exceeds 0.59 on any hero camera.
+ */
+
+import type * as THREE from 'three';
+import { Vector3 } from 'three';
+
+export interface PinFrame {
+  /** Pixels from the host element's left edge. */
+  x: number;
+  /** Pixels from the host element's top edge. */
+  y: number;
+  /** Whether the pin is inside the camera frustum — see `projectPinFrame`. */
+  visible: boolean;
+}
+
+/** Re-usable scratch vector: this runs once per animation frame. */
+const scratch = new Vector3();
+
+/**
+ * Project `pin` through `camera` into `width` x `height` pixel space.
+ *
+ * Returns `null` only when the host has no size yet, so there is no coordinate
+ * space to project into (#2446). Out-of-frame is reported through `visible`,
+ * never by returning `null`.
+ *
+ * `visible` means "the pin is inside the view frustum": all three NDC
+ * components within [-1, 1], bounds included. It is deliberately a statement
+ * about the PIN and not about any overlay anchored to it — the caption's own
+ * offset and width are the overlay's layout problem, and folding a pixel
+ * margin in here would make `visible: false` mean two different things. The
+ * bounds are inclusive because the pin is a world-space sprite with extent: at
+ * exactly |ndc| == 1 its centre is on the edge and half of it is still drawn,
+ * so excluding the boundary would hide the caption of a pin the viewer can
+ * see. `x` and `y` are still filled in when `visible` is false, and are
+ * meaningless — read `visible` first.
+ */
+export function projectPinFrame(
+  pin: THREE.Vector3,
+  camera: THREE.Camera,
+  width: number,
+  height: number,
+): PinFrame | null {
+  if (width === 0 || height === 0) return null;
+  scratch.copy(pin).project(camera);
+  const visible = scratch.z >= -1 && scratch.z <= 1
+    && scratch.x >= -1 && scratch.x <= 1
+    && scratch.y >= -1 && scratch.y <= 1;
+  return {
+    x: ((scratch.x + 1) / 2) * width,
+    y: ((-scratch.y + 1) / 2) * height,
+    visible,
+  };
+}

--- a/apps/viewer/src/components/mcp/hero-scene.ts
+++ b/apps/viewer/src/components/mcp/hero-scene.ts
@@ -22,6 +22,7 @@ import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { STOREY, buildHeroBuilding } from './hero-scene-building';
 import { createHeroAnimationState, createStepController } from './hero-scene-steps';
+import { projectPinFrame, type PinFrame } from './hero-pin-frame';
 import { setTransparent } from './material-transparency';
 import { releaseRenderer } from './release-renderer';
 
@@ -39,16 +40,14 @@ export interface SceneHandle {
    * - `null` — the host has no size yet, so there is no coordinate space to
    *   project into and no position to report.
    * - a frame with `visible: false` — the pin projected fine but fell outside
-   *   the camera's depth range (behind it, or beyond the far plane). `x` / `y`
-   *   are still filled in and are meaningless; read `visible` before using
-   *   them.
+   *   the camera's frustum, on any axis: behind it, beyond the far plane, or
+   *   (much the commoner case on this stage) orbited out of frame sideways.
+   *   `x` / `y` are still filled in and are meaningless; read `visible` before
+   *   using them.
    *
-   * `visible` is a DEPTH test only, which is a known defect rather than the
-   * intended contract: a pin outside the left/right/top/bottom bounds still
-   * reports `visible: true`, and on the BCF pin step that is about a quarter
-   * of every revolution (#2453). Do not build on the current meaning.
+   * `projectPinFrame` owns the maths and the exact meaning of `visible`.
    */
-  projectPin(): { x: number; y: number; visible: boolean } | null;
+  projectPin(): PinFrame | null;
 }
 
 export function createScene(container: HTMLElement): SceneHandle {
@@ -187,24 +186,10 @@ export function createScene(container: HTMLElement): SceneHandle {
 
   update(0);
 
-  // Re-usable scratch vector to avoid alloc churn in projectPin().
-  const projScratch = new THREE.Vector3();
-
   return {
     update,
     projectPin() {
-      const w = container.clientWidth;
-      const h = container.clientHeight;
-      // No size yet — the ONLY null this returns (#2446). Out-of-frustum is
-      // reported through `visible` below, never by returning null.
-      if (w === 0 || h === 0) return null;
-      projScratch.copy(pin.position).project(camera);
-      const visible = projScratch.z >= -1 && projScratch.z <= 1;
-      return {
-        x: ((projScratch.x + 1) / 2) * w,
-        y: ((-projScratch.y + 1) / 2) * h,
-        visible,
-      };
+      return projectPinFrame(pin.position, camera, container.clientWidth, container.clientHeight);
     },
     dispose() {
       disposed = true;

--- a/apps/viewer/src/components/mcp/hero-scene.ts
+++ b/apps/viewer/src/components/mcp/hero-scene.ts
@@ -22,6 +22,7 @@ import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { STOREY, buildHeroBuilding } from './hero-scene-building';
 import { createHeroAnimationState, createStepController } from './hero-scene-steps';
+import { setTransparent } from './material-transparency';
 import { releaseRenderer } from './release-renderer';
 
 const NIGHT = 0x0a0a0c;
@@ -155,7 +156,12 @@ export function createScene(container: HTMLElement): SceneHandle {
       mat.color.lerp(el.targetColor, 0.07);
       const targetOpacity = el.hidden ? 0 : el.targetOpacity;
       mat.opacity = THREE.MathUtils.lerp(mat.opacity, targetOpacity, 0.07);
-      mat.transparent = mat.opacity < 0.999;
+      // Through the helper, not by assignment: `transparent` is a shader
+      // define, so a fade that crosses the threshold has to invalidate the
+      // program or the element keeps rendering at alpha 1 (#2454). The helper
+      // only requests the rebuild on an actual transition, which matters most
+      // here — this runs on every element on every frame.
+      setTransparent(mat, mat.opacity < 0.999);
       // Optional Y slide (used for the new-door reveal)
       if (el.baseY !== undefined && el.yOffset !== undefined) {
         const targetY = el.baseY + el.yOffset;

--- a/apps/viewer/src/components/mcp/material-transparency.test.ts
+++ b/apps/viewer/src/components/mcp/material-transparency.test.ts
@@ -202,8 +202,10 @@ describe('material transparency reaches the shader (#2454)', () => {
   it('does not recompile when the flag is re-set to the value it already has', () => {
     // Anti-mutation for the transition guard. The hero re-derives `transparent`
     // for every element on every frame, so an unconditional
-    // `mat.needsUpdate = true` would throw away and rebuild every program 60
-    // times a second. Dropping the guard makes this fail on the program count.
+    // `mat.needsUpdate = true` would bump `version` 60 times a second per
+    // material — a `getParameters()` rebuild and cache lookup each time, though
+    // three's program cache serves the identical parameter set rather than
+    // recompiling. Dropping the guard makes this fail on the program count.
     const gpu = createStubGpu();
     const material = new THREE.MeshStandardMaterial({ transparent: false, opacity: 1 });
     const { scene, camera } = oneTriangleScene(material);

--- a/apps/viewer/src/components/mcp/material-transparency.test.ts
+++ b/apps/viewer/src/components/mcp/material-transparency.test.ts
@@ -1,0 +1,242 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * That a runtime `transparent` flip reaches the SHADER (#2454).
+ *
+ * Asserting `material.transparent === true` after the flip would prove
+ * nothing: that was already true while the bound program went on forcing
+ * `diffuseColor.a = 1.0`. The defect lives one layer down, in which program
+ * three.js compiles and binds — so that is what this reads back.
+ *
+ * The oracle: drive a REAL `THREE.WebGLRenderer` over a stub GL context that
+ * records every `shaderSource()` and every `useProgram()`, then read the
+ * fragment shader three actually bound for the draw and look for
+ * `#define OPAQUE`. Everything that decides the answer is real three.js —
+ * `WebGLPrograms.getParameters()`, the define emission, the program cache key,
+ * and `setProgram()`'s version-gated `needsProgramChange` guard. Only the GPU
+ * is fake, and no GPU is needed to observe a string that three composed on the
+ * CPU. That is why this is not the "we can only pin the bookkeeping" test the
+ * issue expected.
+ *
+ * What it still cannot prove: that the GPU, having been handed a program
+ * without `#define OPAQUE`, blends the pixels. That is three's and the
+ * driver's contract, not ours.
+ *
+ * The stub is deliberately generous — unknown members resolve to a no-op
+ * function, unknown SCREAMING_CASE members to a unique constant — because the
+ * point is to get three's own program pipeline to run, not to model WebGL.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import * as THREE from 'three';
+
+import { setTransparent } from './material-transparency.js';
+
+interface StubGpu {
+  renderer: THREE.WebGLRenderer;
+  /** Fragment shader source of the program bound by the last draw. */
+  boundFragmentShader(): string;
+  /** How many programs three has compiled so far. */
+  programCount(): number;
+}
+
+function createStubGpu(): StubGpu {
+  const shaderSources = new Map<object, string>();
+  const programShaders = new Map<object, object[]>();
+  const constants = new Map<string, number>();
+  const constantNames = new Map<number, string>();
+  let nextConstant = 0x9000;
+  let usedProgram: object | null = null;
+
+  const constant = (name: string): number => {
+    let value = constants.get(name);
+    if (value === undefined) {
+      value = nextConstant++;
+      constants.set(name, value);
+      constantNames.set(value, name);
+    }
+    return value;
+  };
+
+  const impl: Record<string, unknown> = {
+    getContextAttributes: () => ({ alpha: true }),
+    getExtension: () => null,
+    getParameter: (pname: number) => {
+      switch (constantNames.get(pname)) {
+        case 'VERSION': return 'WebGL 2.0 (stub)';
+        case 'SHADING_LANGUAGE_VERSION': return 'WebGL GLSL ES 3.00 (stub)';
+        case 'VENDOR': case 'RENDERER': return 'stub';
+        case 'SCISSOR_BOX': case 'VIEWPORT': return new Int32Array([0, 0, 300, 150]);
+        default: return 16384;
+      }
+    },
+    getShaderPrecisionFormat: () => ({ precision: 23, rangeMin: 127, rangeMax: 127 }),
+    createShader: () => ({}),
+    shaderSource: (shader: object, source: string) => { shaderSources.set(shader, source); },
+    getShaderParameter: () => true,
+    getShaderInfoLog: () => '',
+    createProgram: () => { const p = {}; programShaders.set(p, []); return p; },
+    attachShader: (program: object, shader: object) => { programShaders.get(program)?.push(shader); },
+    // LINK_STATUS must be truthy; ACTIVE_UNIFORMS / ACTIVE_ATTRIBUTES 0 keeps
+    // three's reflection loops empty, which is all this test needs.
+    getProgramParameter: (_p: object, pname: number) => (constantNames.get(pname) === 'LINK_STATUS'),
+    getProgramInfoLog: () => '',
+    useProgram: (program: object) => { usedProgram = program; },
+    createBuffer: () => ({}),
+    createTexture: () => ({}),
+    createVertexArray: () => ({}),
+    createFramebuffer: () => ({}),
+    isContextLost: () => false,
+  };
+  constant('LINK_STATUS');
+
+  const gl = new Proxy({} as Record<string, unknown>, {
+    get(_target, prop) {
+      if (typeof prop !== 'string') return undefined;
+      if (prop in impl) return impl[prop];
+      if (/^[A-Z0-9_]+$/.test(prop)) return constant(prop);
+      return () => undefined;
+    },
+  });
+
+  const canvas = {
+    width: 300, height: 150, style: {},
+    addEventListener() {}, removeEventListener() {},
+  };
+
+  const renderer = new THREE.WebGLRenderer({
+    canvas: canvas as unknown as HTMLCanvasElement,
+    context: gl as unknown as WebGL2RenderingContext,
+  });
+
+  return {
+    renderer,
+    boundFragmentShader() {
+      assert.ok(usedProgram, 'the draw bound no program at all — the harness is broken');
+      const sources = (programShaders.get(usedProgram) ?? []).map((s) => shaderSources.get(s) ?? '');
+      const fragment = sources.find((s) => s.includes('gl_FragColor'));
+      assert.ok(fragment, 'no fragment shader recorded for the bound program');
+      return fragment;
+    },
+    programCount: () => programShaders.size,
+  };
+}
+
+/** A scene holding one triangle with one material, ready to render. */
+function oneTriangleScene(material: THREE.MeshStandardMaterial) {
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute('position', new THREE.BufferAttribute(new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]), 3));
+  geometry.setAttribute('normal', new THREE.BufferAttribute(new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]), 3));
+  geometry.setIndex(new THREE.BufferAttribute(new Uint32Array([0, 1, 2]), 1));
+  const scene = new THREE.Scene();
+  scene.add(new THREE.Mesh(geometry, material));
+  const camera = new THREE.PerspectiveCamera(50, 1, 0.1, 100);
+  camera.position.z = 5;
+  return { scene, camera };
+}
+
+describe('material transparency reaches the shader (#2454)', () => {
+  it('binds an OPAQUE program for an opaque material, and drops it on a flip', () => {
+    const gpu = createStubGpu();
+    const material = new THREE.MeshStandardMaterial({ transparent: false, opacity: 1 });
+    const { scene, camera } = oneTriangleScene(material);
+
+    gpu.renderer.render(scene, camera);
+    assert.match(
+      gpu.boundFragmentShader(), /#define OPAQUE/,
+      'reachability control: an opaque material must compile WITH the define, '
+      + 'or the assertion below would pass without the fix',
+    );
+
+    setTransparent(material, true);
+    material.opacity = 0.3;
+    gpu.renderer.render(scene, camera);
+
+    // The whole point. `#ifdef OPAQUE → diffuseColor.a = 1.0` (three.module.js
+    // :461): while that define survives, the entity renders solid however low
+    // `opacity` goes, which is exactly what `viewer_colorize` did.
+    assert.doesNotMatch(
+      gpu.boundFragmentShader(), /#define OPAQUE/,
+      'the bound shader still forces alpha 1 — the flip never reached the GPU',
+    );
+  });
+
+  it('leaves the stale program bound when `transparent` is merely assigned', () => {
+    // The defect itself, reproduced against the same oracle. This is what
+    // `mat.transparent = translucent` did, and it is why a test asserting
+    // `material.transparent === true` proves nothing: it is true here too.
+    const gpu = createStubGpu();
+    const material = new THREE.MeshStandardMaterial({ transparent: false, opacity: 1 });
+    const { scene, camera } = oneTriangleScene(material);
+
+    gpu.renderer.render(scene, camera);
+    material.transparent = true;
+    material.opacity = 0.3;
+    gpu.renderer.render(scene, camera);
+
+    assert.equal(material.transparent, true, 'the flag reads back flipped …');
+    assert.match(gpu.boundFragmentShader(), /#define OPAQUE/, '… while the shader ignores it');
+    assert.equal(gpu.programCount(), 1, 'and three never compiled a second program');
+  });
+
+  it('restores an OPAQUE program when a translucent material is painted opaque', () => {
+    // The mirror leak: an entity that loaded translucent kept a non-OPAQUE
+    // program and stayed blended after `viewer_colorize` painted it solid.
+    const gpu = createStubGpu();
+    const material = new THREE.MeshStandardMaterial({ transparent: true, opacity: 0.3 });
+    const { scene, camera } = oneTriangleScene(material);
+
+    gpu.renderer.render(scene, camera);
+    assert.doesNotMatch(gpu.boundFragmentShader(), /#define OPAQUE/, 'control: it loaded translucent');
+
+    setTransparent(material, false);
+    material.opacity = 1;
+    gpu.renderer.render(scene, camera);
+
+    assert.match(gpu.boundFragmentShader(), /#define OPAQUE/, 'painting it opaque must restore the define');
+  });
+
+  it('does not recompile when the flag is re-set to the value it already has', () => {
+    // Anti-mutation for the transition guard. The hero re-derives `transparent`
+    // for every element on every frame, so an unconditional
+    // `mat.needsUpdate = true` would throw away and rebuild every program 60
+    // times a second. Dropping the guard makes this fail on the program count.
+    const gpu = createStubGpu();
+    const material = new THREE.MeshStandardMaterial({ transparent: false, opacity: 1 });
+    const { scene, camera } = oneTriangleScene(material);
+
+    gpu.renderer.render(scene, camera);
+    const compiled = gpu.programCount();
+    const versionBefore = material.version;
+
+    for (let frame = 0; frame < 5; frame++) {
+      assert.equal(setTransparent(material, false), false, 'a no-op flip reports no change');
+      gpu.renderer.render(scene, camera);
+    }
+
+    assert.equal(material.version, versionBefore, 'no-op repaints must not bump the material version');
+    assert.equal(gpu.programCount(), compiled, 'nor compile a single extra program');
+  });
+
+  it('bumps the material version on a real transition, and only then', () => {
+    // The bookkeeping, checked without a renderer — `needsUpdate` is
+    // write-only on a three material (a setter with no getter), so `version`
+    // is the only readable evidence, and it is the exact field
+    // `needsProgramChange` compares against `materialProperties.__version`.
+    const material = new THREE.MeshStandardMaterial({ transparent: false });
+    const start = material.version;
+
+    assert.equal(setTransparent(material, false), false);
+    assert.equal(material.version, start);
+
+    assert.equal(setTransparent(material, true), true);
+    assert.equal(material.version, start + 1, 'the transition requested a rebuild');
+    assert.equal(material.transparent, true);
+
+    assert.equal(setTransparent(material, true), false);
+    assert.equal(material.version, start + 1, 'and re-asserting the same value did not');
+  });
+});

--- a/apps/viewer/src/components/mcp/material-transparency.ts
+++ b/apps/viewer/src/components/mcp/material-transparency.ts
@@ -40,9 +40,12 @@
  * `colorize()`'s `depthWrite` fix (#2444) is sound exactly as written.
  *
  * The transition guard is load-bearing, not an optimisation: the hero's
- * animation loop re-derives `transparent` on every element on every frame, and
- * an unconditional `needsUpdate` there would throw away and recompile every
- * program 60 times a second.
+ * animation loop re-derives `transparent` on every element on every frame, so
+ * an unconditional `needsUpdate` there would bump `version` 60 times a second
+ * per material. Three's program cache absorbs the worst of that — an identical
+ * parameter set is served as a cache hit rather than recompiled — so the cost
+ * is a full `getParameters()` build and cache lookup per material per frame,
+ * not a shader recompile. Still worth avoiding, and cheap to avoid.
  */
 
 /**

--- a/apps/viewer/src/components/mcp/material-transparency.ts
+++ b/apps/viewer/src/components/mcp/material-transparency.ts
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Flip a material's `transparent` flag so the change actually reaches the
+ * shader — the one transparency field on a three.js material that a plain
+ * assignment does not deliver.
+ *
+ * Both `/mcp` scenes re-derive transparency at runtime (`colorize()` /
+ * `reset()` in `playground-scene-ops.ts`, and the hero's per-frame opacity
+ * lerp), and both used to assign the field directly. In three r185 that leaves
+ * the previously compiled program bound:
+ *
+ * 1. `WebGLPrograms.getParameters()` folds the flag into a PROGRAM parameter —
+ *    `opaque: material.transparent === false && material.blending ===
+ *    NormalBlending && material.alphaToCoverage === false`
+ *    (`build/three.module.js:7635`).
+ * 2. `parameters.opaque` becomes a preprocessor define (`:7010`,
+ *    `parameters.opaque ? '#define OPAQUE' : ''`) and part of the program
+ *    cache key (`:7954`).
+ * 3. The `opaque_fragment` chunk (`:461`) is
+ *    `#ifdef OPAQUE\ndiffuseColor.a = 1.0;\n#endif`, so an OPAQUE program
+ *    forces every fragment to alpha 1 no matter what `opacity` says.
+ * 4. `WebGLRenderer.setProgram()`'s `needsProgramChange` chain (`:18382`)
+ *    only runs at all while `material.version === materialProperties.__version`
+ *    and never inspects `transparent` or `opaque` — grep the whole block for
+ *    either and it returns nothing. Only `material.needsUpdate = true` bumps
+ *    `version` (`three.core.js:7126`), which is what fails that guard and
+ *    forces the rebuild.
+ *
+ * So an entity that loaded opaque stayed visually opaque through a translucent
+ * `viewer_colorize`, and the mirror case stayed blended after being painted
+ * opaque (#2454).
+ *
+ * The two fields either side of it need none of this, which is exactly why the
+ * defect was easy to miss and why `needsUpdate` is NOT sprinkled on them:
+ * `opacity` is a uniform, re-uploaded every frame, and `depthWrite` is
+ * per-draw state (`depthBuffer.setMask(material.depthWrite)`, `:10413`).
+ * `colorize()`'s `depthWrite` fix (#2444) is sound exactly as written.
+ *
+ * The transition guard is load-bearing, not an optimisation: the hero's
+ * animation loop re-derives `transparent` on every element on every frame, and
+ * an unconditional `needsUpdate` there would throw away and recompile every
+ * program 60 times a second.
+ */
+
+/**
+ * The slice of `THREE.Material` this touches. Structural rather than the class
+ * so the mechanism can be exercised against a plain object as well as a real
+ * material — `THREE.Material` satisfies it as-is.
+ *
+ * Note `needsUpdate` is write-only on a real material (three declares a setter
+ * with no getter), so reading it back proves nothing; `material.version` is the
+ * observable the renderer itself compares.
+ */
+export interface TransparencyFlaggable {
+  transparent: boolean;
+  needsUpdate: boolean;
+}
+
+/**
+ * Set `mat.transparent`, requesting a program rebuild only when the value
+ * actually changed. Returns whether it changed.
+ */
+export function setTransparent(mat: TransparencyFlaggable, transparent: boolean): boolean {
+  if (mat.transparent === transparent) return false;
+  mat.transparent = transparent;
+  // `transparent` is a shader define, not just render state — see the module
+  // comment. Without this the old program stays bound.
+  mat.needsUpdate = true;
+  return true;
+}

--- a/apps/viewer/src/components/mcp/playground-dispatcher.ts
+++ b/apps/viewer/src/components/mcp/playground-dispatcher.ts
@@ -1469,7 +1469,9 @@ const IMPLS: Record<string, ToolImpl> = {
         return m.bim.property(ref, psetName, propName);
       },
     });
-    const lines = out.legend.map((l) => `  • ${l.value} — ${l.count}`);
+    // Spell the noun out: the count is entities, not submeshes (#2455), and a
+    // bare number in a histogram invites the agent to guess which (#2452).
+    const lines = out.legend.map((l) => `  • ${l.value} — ${l.count} entit${l.count === 1 ? 'y' : 'ies'}`);
     return { text: `Coloured ${type} by ${psetName}.${propName} — ${out.legend.length} bucket(s):\n${lines.join('\n')}`, structured: out };
   },
 

--- a/apps/viewer/src/components/mcp/playground-scene-ops.ts
+++ b/apps/viewer/src/components/mcp/playground-scene-ops.ts
@@ -122,17 +122,28 @@ export function colorByProperty(
     sample: (expressId: number) => string | number | boolean | null;
   },
 ): { legend: Array<{ value: string; count: number; color: ColorTuple }> } {
-  // NOTE: these are submesh records, so a bucket over elements that tessellate
-  // into several parts over-counts and re-samples the property per part.
-  // Pre-existing and out of scope for the count fix in the sibling ops (#2455).
+  // `byType` values RECORDS — submeshes — and an element routinely tessellates
+  // into several. Group them by element before bucketing, or a histogram over
+  // 10 windows that each split into glass + frame answers "20", and the
+  // property lookup runs once per part instead of once per element (#2455).
+  // The colouring still walks every submesh; only the counting and the
+  // sampling are per entity, the same split the selector-driven ops landed on
+  // (#2452).
   const records = reg.byType.get(type) ?? [];
-  const buckets = new Map<string, EntityRecord[]>();
+  const byEntity = new Map<number, EntityRecord[]>();
   for (const r of records) {
-    const v = sample(r.expressId);
+    const parts = byEntity.get(r.expressId);
+    if (parts) parts.push(r);
+    else byEntity.set(r.expressId, [r]);
+  }
+  const buckets = new Map<string, { entities: number; records: EntityRecord[] }>();
+  for (const [expressId, parts] of byEntity) {
+    const v = sample(expressId);
     const key = v == null ? '(missing)' : String(v);
-    const list = buckets.get(key) ?? [];
-    list.push(r);
-    buckets.set(key, list);
+    const bucket = buckets.get(key) ?? { entities: 0, records: [] };
+    bucket.entities += 1;
+    bucket.records.push(...parts);
+    buckets.set(key, bucket);
   }
   const PALETTE: ColorTuple[] = [
     [0.84, 1.0, 0.25, 1],
@@ -145,14 +156,14 @@ export function colorByProperty(
   ];
   const legend: Array<{ value: string; count: number; color: ColorTuple }> = [];
   let i = 0;
-  for (const [value, list] of buckets) {
+  for (const [value, bucket] of buckets) {
     const color = value === '(missing)' ? [0.4, 0.4, 0.45, 1] as ColorTuple : PALETTE[i++ % PALETTE.length];
     const c = new THREE.Color(color[0], color[1], color[2]);
-    for (const r of list) {
+    for (const r of bucket.records) {
       (r.mesh.material as THREE.MeshStandardMaterial).color.copy(c);
       r.baseColor.copy(c);
     }
-    legend.push({ value, count: list.length, color });
+    legend.push({ value, count: bucket.entities, color });
   }
   return { legend };
 }

--- a/apps/viewer/src/components/mcp/playground-scene-ops.ts
+++ b/apps/viewer/src/components/mcp/playground-scene-ops.ts
@@ -15,6 +15,7 @@
 import * as THREE from 'three';
 import type { ColorTuple } from './playground-viewer-types';
 import { countEntities, isTranslucent, selectTargets, type EntityRecord, type EntityRegistry } from './playground-scene-registry';
+import { setTransparent } from './material-transparency';
 import type { SectionState } from './playground-scene-view';
 
 export function colorize(
@@ -33,20 +34,18 @@ export function colorize(
   // re-derived here too: leaving it stale makes a translucent repaint write
   // depth and occlude what is behind it (#2444).
   //
-  // Caveat, deliberately not fixed here: `transparent` alone does not reach
-  // the GPU. three.js folds it into the `opaque` PROGRAM parameter, which
-  // emits `#define OPAQUE` and forces `diffuseColor.a = 1.0`, and its
-  // `needsProgramChange` check never inspects `transparent` — so flipping it
-  // without `mat.needsUpdate = true` leaves the old shader bound and the
-  // entity does not actually become see-through. Pre-existing, tracked in
-  // #2454. `depthWrite` and `opacity` are per-draw state and a uniform, so
-  // both take effect immediately and the fix below is sound as written.
+  // `transparent` goes through `setTransparent` because it alone does not
+  // reach the GPU on assignment — three folds it into a shader define, so a
+  // flip without `needsUpdate` left the entity looking opaque however low the
+  // alpha went (#2454, mechanism in `material-transparency.ts`). `depthWrite`
+  // and `opacity` are per-draw state and a uniform, so they land immediately
+  // and are assigned directly.
   const translucent = isTranslucent(alpha);
   for (const r of targets) {
     const mat = r.mesh.material as THREE.MeshStandardMaterial;
     mat.color.copy(c);
     r.baseColor.copy(c);
-    mat.transparent = translucent;
+    setTransparent(mat, translucent);
     mat.depthWrite = !translucent;
     mat.opacity = alpha;
     r.baseOpacity = alpha;
@@ -89,9 +88,10 @@ export function reset(reg: EntityRegistry, section: SectionState): void {
     const mat = r.mesh.material as THREE.MeshStandardMaterial;
     mat.color.copy(r.baseColor);
     mat.opacity = r.baseOpacity;
-    // Same derived pair as construction and colorize() (#2444).
+    // Same derived pair as construction and colorize() (#2444), and the same
+    // shader-define caveat on `transparent` (#2454).
     const translucent = isTranslucent(r.baseOpacity);
-    mat.transparent = translucent;
+    setTransparent(mat, translucent);
     mat.depthWrite = !translucent;
   }
   section.active = null;

--- a/apps/viewer/src/components/mcp/playground-scene-registry.test.ts
+++ b/apps/viewer/src/components/mcp/playground-scene-registry.test.ts
@@ -297,6 +297,42 @@ describe('playground registry: colorize/reset keep depthWrite in sync (#2444)', 
     assert.equal(m.depthWrite, false, 'depthWrite is part of what reset() restores');
   });
 
+  it('requests a shader rebuild when colorize() flips transparency, and not otherwise', () => {
+    // The call-site half of #2454. `material-transparency.test.ts` proves at
+    // the shader level that the rebuild is what makes the flip visible; what
+    // is left to check here is that these two ops actually ask for it.
+    // `version` is the observable — `needsUpdate` is write-only on a three
+    // material, and it is the field `needsProgramChange` compares.
+    const { reg } = mount();
+    const target = (reg.byExpressId.get(WALL_B_ID) ?? [])[0];
+    const opaque = mat(target).version;
+
+    colorize(reg, { expressIds: [WALL_B_ID], color: [1, 0, 0, 0.3] });
+    assert.equal(mat(target).version, opaque + 1, 'opaque → translucent invalidates the program');
+
+    colorize(reg, { expressIds: [WALL_B_ID], color: [0, 1, 0, 0.2] });
+    assert.equal(mat(target).version, opaque + 1, 'a second translucent repaint changes no define');
+
+    colorize(reg, { expressIds: [WALL_B_ID], color: [0, 0, 1, 1] });
+    assert.equal(mat(target).version, opaque + 2, 'translucent → opaque invalidates it again');
+  });
+
+  it('requests a shader rebuild when reset() puts transparency back', () => {
+    const { reg, section } = mount([tri(WALL_B_ID, 0, [0.5, 0.5, 0.5, 0.3])]);
+    const target = (reg.byExpressId.get(WALL_B_ID) ?? [])[0];
+    const m = mat(target);
+
+    const translucent = m.version;
+    reset(reg, section);
+    assert.equal(m.version, translucent, 'a reset that changes nothing must not recompile');
+
+    // Stale state, as a colorize-then-reset round trip leaves it.
+    m.transparent = false;
+    m.depthWrite = true;
+    reset(reg, section);
+    assert.equal(m.version, translucent + 1, 'restoring translucency has to reach the shader too');
+  });
+
   it('agrees with construction on the transparency threshold', () => {
     // The constructor used `a < 1` while the operations used `a < 0.999`, so
     // an alpha in between mounted one way and reset() the other.

--- a/apps/viewer/src/components/mcp/playground-scene-registry.test.ts
+++ b/apps/viewer/src/components/mcp/playground-scene-registry.test.ts
@@ -4,7 +4,8 @@
 
 /**
  * The playground registry's id lookups against multi-submesh elements (#2443),
- * and the transparency state its operations re-derive (#2444).
+ * the transparency state its operations re-derive (#2444), and the entity
+ * counts they report back to the agent (#2452, #2455).
  *
  * Why this is reachable from CI when the scene is not: only `createScene`
  * needs a GPU (`new THREE.WebGLRenderer` throws under happy-dom, which is why
@@ -37,7 +38,7 @@ import {
   type EntityRecord,
 } from './playground-scene-registry.js';
 import { createSectionState } from './playground-scene-view.js';
-import { colorize, hide, isolate, reset, show } from './playground-scene-ops.js';
+import { colorByProperty, colorize, hide, isolate, reset, show } from './playground-scene-ops.js';
 
 const WALL_A_ID = 1;
 const WALL_B_ID = 2;
@@ -311,5 +312,75 @@ describe('playground registry: colorize/reset keep depthWrite in sync (#2444)', 
       mounted,
       'a reset with no colorize in between must be a no-op on transparency state',
     );
+  });
+});
+
+describe('playground ops: the property legend counts entities (#2455)', () => {
+  /** `viewer_color_by_property`'s sampler, plus the ids it was asked about. */
+  function sampler(values: Record<number, string | null>) {
+    const asked: number[] = [];
+    return {
+      asked,
+      sample: (expressId: number) => { asked.push(expressId); return values[expressId] ?? null; },
+    };
+  }
+
+  const args = { pset: 'Pset_WallCommon', property: 'IsExternal' };
+
+  it('reports one element as one, however many submeshes it tessellates into', () => {
+    // The fixture is the whole oracle: WALL_A is ONE wall that arrives as two
+    // `MeshData` entries, so `byType` lists three records for two elements.
+    // Bucketing those records answered the agent's histogram with 2 for a
+    // bucket holding a single wall.
+    const { reg } = mount();
+    const { asked, sample } = sampler({ [WALL_A_ID]: 'true', [WALL_B_ID]: 'false' });
+
+    const { legend } = colorByProperty(reg, { type: 'IfcWall', ...args, sample });
+
+    assert.deepEqual(
+      legend.map((l) => [l.value, l.count]),
+      [['true', 1], ['false', 1]],
+      'two walls, three submeshes, one entity per bucket',
+    );
+    // Sampling is per element too — the lookup used to repeat for every part.
+    assert.deepEqual(asked.slice().sort((a, b) => a - b), [WALL_A_ID, WALL_B_ID]);
+  });
+
+  it('still recolours every submesh of a counted element', () => {
+    // The other half of the contract, and the reason the fix cannot just be
+    // `countEntities(records)`: acting per submesh, reporting per entity.
+    const { reg } = mount();
+    const { sample } = sampler({ [WALL_A_ID]: 'true', [WALL_B_ID]: 'false' });
+
+    const { legend } = colorByProperty(reg, { type: 'IfcWall', ...args, sample });
+    const [r, g, b] = legend[0].color;
+
+    const parts = reg.byExpressId.get(WALL_A_ID) ?? [];
+    assert.equal(parts.length, 2, 'fixture check: the wall really does have two submeshes');
+    for (const part of parts) {
+      assert.deepEqual([mat(part).color.r, mat(part).color.g, mat(part).color.b], [r, g, b],
+        'a half-painted wall means the bucket dropped one of its parts');
+      assert.deepEqual([part.baseColor.r, part.baseColor.g, part.baseColor.b], [r, g, b],
+        'and the base colour has to follow, or reset() undoes half of it');
+    }
+  });
+
+  it('counts an element once in the (missing) bucket too', () => {
+    // The null path buckets by a literal key rather than by value, so it is
+    // the one branch that could keep the old per-record count by accident.
+    const { reg } = mount();
+    const { asked, sample } = sampler({});
+
+    const { legend } = colorByProperty(reg, { type: 'IfcWall', ...args, sample });
+
+    assert.deepEqual(legend.map((l) => [l.value, l.count]), [['(missing)', 2]]);
+    assert.equal(asked.length, 2, 'still one lookup per element');
+  });
+
+  it('reports nothing for a type the model does not have', () => {
+    const { reg } = mount();
+    const { asked, sample } = sampler({});
+    assert.deepEqual(colorByProperty(reg, { type: 'IfcDoor', ...args, sample }).legend, []);
+    assert.equal(asked.length, 0);
   });
 });


### PR DESCRIPTION
Three pre-existing defects on the `/mcp` surfaces, all found by review on #2452. Each was reproduced before it was fixed.

Closes #2453, closes #2454, closes #2455.

## #2454 — a `transparent` flip never reached the shader

`colorize()`, `reset()` and the hero's animation loop assigned `material.transparent` directly. In three r185 that is not enough, because the flag is a **program parameter**, not just render state:

- `WebGLPrograms.getParameters()` computes `opaque: material.transparent === false && …` (`three.module.js:7635`)
- `parameters.opaque` emits `#define OPAQUE` (`:7010`) and is part of the program cache key (`:7954`)
- `opaque_fragment` is `#ifdef OPAQUE → diffuseColor.a = 1.0` (`:461`)
- `setProgram()`'s `needsProgramChange` chain (`:18382`) only runs while `material.version === materialProperties.__version`, and greps 0 for `transparent`/`opaque` across the whole block. Only `needsUpdate = true` bumps that version.

So `viewer_colorize({ color: [1, 0, 0, 0.3] })` re-bucketed the entity into the transparent pass and enabled blending while the bound shader went on writing alpha 1 — the entity did not actually become see-through. The mirror case leaked the other way.

One helper (`material-transparency.ts`) now owns the flip and requests the rebuild **only on a real transition** — load-bearing for the hero, which re-derives the flag for every element on every frame. `opacity` (a uniform) and `depthWrite` (per-draw state) need none of this and keep their plain assignments; `needsUpdate` is deliberately not sprinkled on them.

**Proof, not a proxy.** The test drives a real `THREE.WebGLRenderer` over a stub GL context that records every `shaderSource()` and `useProgram()`, then reads back the fragment shader three actually bound for the draw. Every step that decides the answer is real three.js; only the GPU is fake, and none is needed to read a string three composed on the CPU. Pre-fix the bound shader still carries `#define OPAQUE` after the flip — that case is kept in the suite as an explicit control.

## #2453 — `projectPin()` reported visible for a pin off-screen sideways

Visibility was decided from depth alone (`z >= -1 && z <= 1`), but after `.project()` all three components are NDC. Sweeping the authored constants over a full revolution:

| camera target | max abs(ndc.x) | off-screen yet "visible" |
| --- | --- | --- |
| `cameraDefault` (12,8,13) | 0.795 | 0 / 720 |
| `cameraRightAngle` (14,6,6) | 0.952 | 0 / 720 |
| **step 10 — the BCF pin step** | **1.087** | **178 / 720** |
| `cameraClose` (8,5.5,10) | 1.143 | 224 / 720 |
| step 6 (4,3.5,10) | 1.431 | 351 / 720 |

The portrait `aspect-[4/5]` stage is what makes it lateral: it narrows the horizontal FOV to about 28° against the 35° vertical, so max abs(ndc.y) never exceeds 0.59 on any hero camera. `HeroOverlay` renders the caption at `pinFrame.x + 22` whenever `visible`, inside an `overflow-hidden` stage — so for about a quarter of every revolution the caption was clipped away while the code believed it was showing it.

`visible` now means "inside the frustum" on all three axes, **bounds included**: the pin is a world-space sprite with extent, so at exactly |ndc| == 1 its centre is on the edge and half of it is still drawn. It stays a statement about the *pin*, not about the caption — folding a pixel margin in here would make `visible: false` mean two things at once, and the overlay's own offset is its layout problem. The maths moved into `hero-pin-frame.ts`, the same seam `release-renderer.ts` uses, because `createScene` needs a GPU and never runs in CI while this is reachable from a plain node test.

## #2455 — the colour-by-property legend counted submeshes

`colorByProperty()` bucketed `reg.byType.get(type)`, which values **records**, so an element that tessellates into glass + frame landed in its bucket twice and the property lookup ran once per part. A histogram over 10 windows reported 20, straight to the agent. Now grouped by expressId first: sample once per element, colour every submesh of it, report the entity count — the same split #2452 gave the selector-driven ops. The legend line names its unit too.

## Verification

- `npx turbo typecheck --force` — 36/36 successful, 0 cached.
- `npx turbo test --force` — 86/86 successful, 0 cached; viewer `# tests 3389 / # pass 3383 / # fail 0 / # skipped 6`.
- `npx turbo lint --force` — 43/43, 0 cached.
- Mutation-checked, leaf counts only:
  - drop `needsUpdate` → 3/5 fail (both shader-level cases + the version bump)
  - make `needsUpdate` unconditional → 2/5 fail (the anti-mutation: it would recompile every program every frame)
  - revert `colorize`/`reset` to plain assignment → 2 fail
  - restore the depth-only predicate → 3/5 fail
  - narrow the bounds to ±0.75 → 2/5 fail (the in-frame control catches an over-broad fix)
  - count records in the legend again → 2 fail; sample per submesh → 2 fail; colour only the first submesh → 1 fail

`apps/viewer` is `"private": true`, so no changeset.

## Known limit

No test can show that the GPU, handed a program without `#define OPAQUE`, actually blends the pixels — that is three's and the driver's contract. The hero's own call site is likewise unreachable from CI (`createScene` needs a real context); the helper it calls is covered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved 3D pin positioning and visibility across camera angles, including accurate screen-edge behavior.
  * Fixed transparency updates so visual opacity changes consistently appear without stale rendering.
  * Corrected property-based coloring to count distinct entities rather than individual subcomponents.
  * Improved handling of missing or unavailable property values.

* **UI Improvements**
  * Legend counts now clearly identify entities, with correct singular and plural wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
