### PR TITLE
fix(geometry,create): free the IfcAPI handle on a late init() failure; close the dead source-guard class

### DIFF
--- a/.changeset/bridge-init-failure-frees-handle.md
+++ b/.changeset/bridge-init-failure-frees-handle.md
@@ -1,0 +1,13 @@
+---
+"@ifc-lite/geometry": patch
+---
+
+Free the `IfcAPI` handle when `IfcLiteBridge.init()` fails after allocating it ([#2342](https://github.com/LTplus-AG/ifc-lite/issues/2342)).
+
+`init()` constructs `new IfcAPI()` and then makes four `apply*()` calls — `setMergeLayers`, `setComputeGeometryHashes`, `setTessellationQuality`, `setSkipSmallCuts` — that each reach into WASM. So "init failed" does not imply "nothing was allocated": any of those four throwing (a trap, or the engine rejecting a value) lands in the catch with a live handle. That catch called `reset()`, which nulls `ifcApi` without freeing it, and `dispose()` is the only route to `free()` in the class — so the wasm-bindgen pointer, and the whole per-load pre-pass / entity / style cache set behind it, was stranded with no remaining reference for the lifetime of the realm.
+
+The class already documented the correct recovery for the operation-trap path (`recordWasmRuntimeTrap`: dispose, and fall back to `reset()` if `free()` itself traps, so a secondary failure cannot replace the error already on its way to the caller). Both paths now share it. The comment claiming there is "no `IfcAPI` to drop" when init trapped is corrected — it is true only for a trap raised before `new IfcAPI()`.
+
+This is the layer the [#2389](https://github.com/LTplus-AG/ifc-lite/pull/2389) reorder of `packages/mcp/src/tools/export.ts` deliberately left alone: that change made `dispose()` reachable on the failure path, but the handle was already nulled by then, so the free still never happened. The fix here is in the bridge, so it holds for every consumer regardless of whether the caller reaches its own `dispose()`.
+
+No behaviour change on the dominant failure. A missing or rotated WASM binary throws before `new IfcAPI()`, where the optional chain in `dispose()` makes this identical to the previous `reset()`.

--- a/.changeset/create-last-dead-source-guards.md
+++ b/.changeset/create-last-dead-source-guards.md
@@ -1,0 +1,13 @@
+---
+"@ifc-lite/create": patch
+---
+
+Correct the last two dead `store.source` truthiness guards in `in-store` ([#2345](https://github.com/LTplus-AG/ifc-lite/issues/2345)).
+
+`IfcDataStore.source` is a mandatory accessor ([#2183](https://github.com/LTplus-AG/ifc-lite/issues/2183)): even the no-source state is `EMPTY_SOURCE_BYTES`, an object, never null/undefined. So `if (store.source)` is always true and `if (!store.source)` is always false, and the early returns beneath them could not fire. `resolve-anchor.ts` was corrected in [#2392](https://github.com/LTplus-AG/ifc-lite/pull/2392); `extract-walls.ts` (4 sites) and `resolve-source.ts` (1) are its siblings in the same directory, and `extract-walls.ts` is the very file `resolve-anchor.ts`'s own comment names as the one it mirrors.
+
+Neither is the silent-wrong-output failure the USD exporter had — both already failed closed, producing nothing rather than something wrong. What the dead guards cost is diagnostic, on the models that actually have no source: server-parsed, synthetic, GLB and point-cloud.
+
+`extractWallSegmentsForStorey` ran `extractLengthUnitScale` over the empty source. That cannot resolve IFCPROJECT, so it took a `warnUnknownUnit` path and told the user their model may be mis-scaled and is being read as metres — about a model with no source to scale from. Its documented `'no source bytes on data store — extraction cannot run'` early return could never be reached either, so the function went on to build the relating/children indices and walk the storey before arriving at the same empty result.
+
+`resolveDuplicateSource` threw `resolveDuplicateSource: could not parse #N`, blaming the entity, when the entity is fine and the store simply has no bytes to parse it out of. It now throws `data store has no source bytes`, which is the message that was already written for this case and unreachable.

--- a/packages/create/src/in-store/extract-walls-empty-source.test.ts
+++ b/packages/create/src/in-store/extract-walls-empty-source.test.ts
@@ -1,0 +1,135 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The last two `in-store` files carrying the dead `store.source` truthiness
+ * check (#2345). `resolve-anchor.ts` was corrected in #2392; these two are its
+ * siblings — `extract-walls.ts` is even named in `resolve-anchor.ts`'s own
+ * comment as the file it mirrors, and it is the copy that was left behind.
+ *
+ * `IfcDataStore.source` is a MANDATORY accessor (#2183): the no-source state is
+ * `EMPTY_SOURCE_BYTES`, an object, never null/undefined. So `if (store.source)`
+ * is always true and `if (!store.source)` is always false, and the early
+ * returns beneath them could not fire.
+ *
+ * Neither of these is the silent-wrong-output failure the USD exporter had —
+ * both still fail closed, by producing nothing. What the dead guards cost is
+ * DIAGNOSTIC, and that is what these tests assert on, because it is the only
+ * thing that actually differs:
+ *
+ *   - `extractWallSegmentsForStorey` ran `extractLengthUnitScale` over the
+ *     empty source, which cannot resolve IFCPROJECT and so emitted the
+ *     "#2104 unconfirmed unit" console warning — telling the user their model
+ *     may be mis-scaled, on a model that has no source to scale from.
+ *   - `resolveDuplicateSource` threw `could not parse #N`, blaming the entity,
+ *     instead of `data store has no source bytes`, which names the real cause.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { EMPTY_SOURCE_BYTES, IfcParser, type IfcDataStore } from '@ifc-lite/parser';
+import { extractWallSegmentsForStorey } from './extract-walls.js';
+import { resolveDuplicateSource } from './resolve-source.js';
+
+const STOREY_MODEL = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('t.ifc','',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0proj00000000000000000',$,'P',$,$,$,$,(#7),#9);
+#5=IFCCARTESIANPOINT((0.,0.,0.));
+#6=IFCAXIS2PLACEMENT3D(#5,$,$);
+#7=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-05,#6,$);
+#9=IFCUNITASSIGNMENT((#91));
+#91=IFCSIUNIT(*,.LENGTHUNIT.,.MILLI.,.METRE.);
+#20=IFCLOCALPLACEMENT($,#6);
+#30=IFCBUILDINGSTOREY('0storey000000000000000',$,'Level 0',$,$,#20,$,$,.ELEMENT.,0.);
+ENDSEC;
+END-ISO-10303-21;`;
+
+const STOREY_ID = 30;
+
+async function parsedStore(): Promise<IfcDataStore> {
+  return new IfcParser().parseColumnar(
+    new TextEncoder().encode(STOREY_MODEL).buffer as ArrayBuffer,
+    { disableWorkerScan: true },
+  );
+}
+
+/**
+ * A real `entityIndex` with the source swapped out — the shape a server-parsed
+ * or point-cloud model carries (`serverDataModel.ts` assigns exactly this
+ * constant). Keeping the index real is what makes the test meaningful: the
+ * dead guards got PAST it precisely because the index still resolves ids.
+ */
+async function sourcelessStore(): Promise<IfcDataStore> {
+  return { ...(await parsedStore()), source: EMPTY_SOURCE_BYTES };
+}
+
+describe('extractWallSegmentsForStorey on a source-less store (#2345)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does not emit a unit warning for a model that has no source to read units from', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const store = await sourcelessStore();
+
+    const result = extractWallSegmentsForStorey(store, STOREY_ID, undefined, {});
+
+    // RED (pre-fix): `if (store.source)` was always true, so
+    // `extractLengthUnitScale` ran over the empty source, failed to read
+    // IFCPROJECT and warned '[UnitExtractor] ... defaulting to meters'.
+    const unitWarnings = warn.mock.calls.filter((c) => String(c[0]).includes('[UnitExtractor]'));
+    expect(unitWarnings).toEqual([]);
+
+    // …and the documented "extraction cannot run" early return is reached, so
+    // the metre default still comes back rather than a guessed scale.
+    expect(result.lengthUnitScale).toBe(1.0);
+    expect(result.segments).toEqual([]);
+    expect(result.considered).toBe(0);
+  });
+
+  // BOUNDING CONTROL — passes before and after. A "fix" that simply stopped
+  // reading units at all, or that routed every store down the early return,
+  // would look identical to the real one without this.
+  it('still reads the real unit scale from a store that HAS source bytes', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const store = await parsedStore();
+
+    const result = extractWallSegmentsForStorey(store, STOREY_ID, undefined, {});
+
+    // The fixture declares MILLI.METRE, so the scale must be resolved (0.001),
+    // not defaulted — proving the units path is still live for real stores.
+    expect(result.lengthUnitScale).toBeCloseTo(0.001, 10);
+    expect(warn.mock.calls.filter((c) => String(c[0]).includes('[UnitExtractor]'))).toEqual([]);
+  });
+});
+
+describe('resolveDuplicateSource on a source-less store (#2345)', () => {
+  it('names the missing source rather than blaming the entity', async () => {
+    const store = await sourcelessStore();
+
+    // The id IS in the entity index — that is why the dead guard sailed past
+    // it and the failure surfaced one step later, as a parse failure.
+    expect(store.entityIndex.byId.get(STOREY_ID)).toBeDefined();
+
+    // RED (pre-fix): 'resolveDuplicateSource: could not parse #30'.
+    expect(() => resolveDuplicateSource(store, STOREY_ID)).toThrow(
+      'resolveDuplicateSource: data store has no source bytes',
+    );
+  });
+
+  // BOUNDING CONTROL — a store WITH bytes must still get past the guard and
+  // resolve real attributes, not be swept into the new early throw.
+  it('still resolves attributes from a store that HAS source bytes', async () => {
+    const store = await parsedStore();
+    const resolved = resolveDuplicateSource(store, STOREY_ID);
+    // Real attributes read back out of the source buffer — the guard let it
+    // through and the extractor found the entity.
+    expect(resolved.attributes[0]).toBe('0storey000000000000000');
+    expect(resolved.placementExpressId).toBe(20);
+  });
+});

--- a/packages/create/src/in-store/extract-walls-empty-source.test.ts
+++ b/packages/create/src/in-store/extract-walls-empty-source.test.ts
@@ -27,8 +27,8 @@
  */
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { EMPTY_SOURCE_BYTES, IfcParser, type IfcDataStore } from '@ifc-lite/parser';
-import { extractWallSegmentsForStorey } from './extract-walls.js';
+import { EMPTY_SOURCE_BYTES, IfcParser, type IfcAttributeValue, type IfcDataStore } from '@ifc-lite/parser';
+import { extractWallSegmentsForStorey, type OverlayWallReader } from './extract-walls.js';
 import { resolveDuplicateSource } from './resolve-source.js';
 
 const STOREY_MODEL = `ISO-10303-21;
@@ -105,6 +105,70 @@ describe('extractWallSegmentsForStorey on a source-less store (#2345)', () => {
     // not defaulted — proving the units path is still live for real stores.
     expect(result.lengthUnitScale).toBeCloseTo(0.001, 10);
     expect(warn.mock.calls.filter((c) => String(c[0]).includes('[UnitExtractor]'))).toEqual([]);
+  });
+});
+
+/**
+ * A minimal overlay reader carrying ONE wall authored entirely in the overlay
+ * (`editor.addEntity('IfcWall', …)`), with its placement chain and `Axis`
+ * representation — the shape `addWallToStore` emits. Every id is above the
+ * fixture's own ids so none of them resolve through `entityIndex.byId`, which
+ * is exactly what makes `readEntity` take its documented overlay fallback.
+ */
+function overlayWithOneWall(): OverlayWallReader {
+  const entities = [
+    { expressId: 1000, type: 'IfcWall', attributes: [
+      'guid-overlay-wall', null, 'Overlay Wall', null, null, 1001, 1002, null, null,
+    ] as IfcAttributeValue[] },
+    { expressId: 1001, type: 'IfcLocalPlacement', attributes: [null, 1003] as IfcAttributeValue[] },
+    { expressId: 1003, type: 'IfcAxis2Placement3D', attributes: [1004, null, null] as IfcAttributeValue[] },
+    { expressId: 1004, type: 'IfcCartesianPoint', attributes: [[0, 0, 0]] as IfcAttributeValue[] },
+    { expressId: 1002, type: 'IfcProductDefinitionShape', attributes: [null, null, [1005]] as IfcAttributeValue[] },
+    { expressId: 1005, type: 'IfcShapeRepresentation', attributes: [null, 'Axis', 'Curve2D', [1006]] as IfcAttributeValue[] },
+    { expressId: 1006, type: 'IfcPolyline', attributes: [[1007, 1008]] as IfcAttributeValue[] },
+    { expressId: 1007, type: 'IfcCartesianPoint', attributes: [[0, 0, 0]] as IfcAttributeValue[] },
+    { expressId: 1008, type: 'IfcCartesianPoint', attributes: [[4, 0, 0]] as IfcAttributeValue[] },
+  ];
+  return { getNewEntities: () => entities };
+}
+
+/**
+ * Regression for the review finding on #2485: the source-bytes guard must
+ * suppress only what DEPENDS on source bytes (the unit-scale read and its
+ * warning, and the source-backed storey scan) — never the overlay pass.
+ *
+ * A source-less store with an overlay is the live Auto Spaces case: the model
+ * came from the server / a point cloud (`EMPTY_SOURCE_BYTES`) and every wall
+ * the user drew lives in the mutation overlay. Returning early before the
+ * overlay loop makes `generateSpacesFromWalls` report zero regions for walls
+ * that are right there.
+ */
+describe('extractWallSegmentsForStorey: overlay walls on a source-less store', () => {
+  it('still extracts an overlay-created wall when the store has no source bytes', async () => {
+    const store = await sourcelessStore();
+
+    const result = extractWallSegmentsForStorey(store, STOREY_ID, overlayWithOneWall(), {});
+
+    // RED (before the fix): the source-bytes early return fired ahead of the
+    // overlay loop, so considered=0 and no segment came back at all.
+    expect(result.considered).toBe(1);
+    expect(result.contributingWallIds).toEqual([1000]);
+    expect(result.segments).toHaveLength(1);
+    // Overlay walls are authored in metres and must NOT be re-scaled.
+    expect(result.segments[0]).toEqual({ a: [0, 0], b: [4, 0] });
+    expect(result.skipped).toEqual([]);
+  });
+
+  // BOUNDING CONTROL — passes before and after. Pins that the overlay pass was
+  // never source-dependent in the first place, so "it works with source bytes"
+  // cannot be mistaken for the fix.
+  it('extracts the same overlay wall from a store that HAS source bytes', async () => {
+    const store = await parsedStore();
+
+    const result = extractWallSegmentsForStorey(store, STOREY_ID, overlayWithOneWall(), {});
+
+    expect(result.contributingWallIds).toEqual([1000]);
+    expect(result.segments).toEqual([{ a: [0, 0], b: [4, 0] }]);
   });
 });
 

--- a/packages/create/src/in-store/extract-walls.ts
+++ b/packages/create/src/in-store/extract-walls.ts
@@ -143,7 +143,7 @@ export function extractWallSegmentsForStorey(
   // would produce coords like (31614, 23345) and the panel's
   // metre-based snap tolerance would be effectively zero.
   let lengthUnitScale = 1.0;
-  if (store.source) {
+  if (store.source.byteLength > 0) {
     try {
       lengthUnitScale = extractLengthUnitScale(store.source, store.entityIndex);
       if (!Number.isFinite(lengthUnitScale) || lengthUnitScale <= 0) lengthUnitScale = 1.0;
@@ -170,7 +170,7 @@ export function extractWallSegmentsForStorey(
   }
   log(`length unit scale = ${lengthUnitScale} (raw → metres)`);
 
-  if (!store.source) {
+  if (store.source.byteLength <= 0) {
     log('no source bytes on data store — extraction cannot run');
     return { segments, contributingWallIds: contributing, wallThicknesses, skipped, considered: 0, lengthUnitScale };
   }
@@ -273,7 +273,7 @@ function collectDividerIdsOnStorey(
 ): number[] {
   const ids: number[] = [];
   const seen = new Set<number>();
-  if (!store.source) return ids;
+  if (store.source.byteLength <= 0) return ids;
 
   // Build relating → related-children indices ONCE, then walk in O(1) per
   // parent. Previously each `descendAggregate` / `walkContainmentInto`
@@ -339,7 +339,7 @@ function collectDividerIdsOnStorey(
  */
 export function existingSpaceFootprintsByStorey(store: IfcDataStore): Map<number, Vec2[][]> {
   const out = new Map<number, Vec2[][]>();
-  if (!store.source) return out;
+  if (store.source.byteLength <= 0) return out;
   const extractor = new EntityExtractor(store.source);
   const scale = extractLengthUnitScale(store.source, store.entityIndex) ?? 1;
   const aggregated = buildRelatingChildrenIndex(store, extractor, 'IFCRELAGGREGATES', 4, 5);

--- a/packages/create/src/in-store/extract-walls.ts
+++ b/packages/create/src/in-store/extract-walls.ts
@@ -170,9 +170,17 @@ export function extractWallSegmentsForStorey(
   }
   log(`length unit scale = ${lengthUnitScale} (raw → metres)`);
 
+  // NOT an early return. Only the SOURCE-BACKED half of this function depends
+  // on the bytes; `collectDividerIdsOnStorey` carries the same guard and comes
+  // back empty, which is the whole cost. The overlay pass below is independent
+  // — `readEntity` resolves overlay-created entities through
+  // `overlay.getNewEntities()` — and a source-less store WITH an overlay is a
+  // live case, not a theoretical one: a server-parsed or point-cloud model
+  // (`EMPTY_SOURCE_BYTES`) whose walls were all drawn by the user. Returning
+  // here made `generateSpacesFromWalls` report zero regions for walls that are
+  // right there.
   if (store.source.byteLength <= 0) {
-    log('no source bytes on data store — extraction cannot run');
-    return { segments, contributingWallIds: contributing, wallThicknesses, skipped, considered: 0, lengthUnitScale };
+    log('no source bytes on data store — source-backed extraction cannot run (overlay walls, if any, still are)');
   }
 
   const dividerTypes = new Set(DEFAULT_DIVIDER_TYPES);

--- a/packages/create/src/in-store/resolve-source.ts
+++ b/packages/create/src/in-store/resolve-source.ts
@@ -65,7 +65,7 @@ export function resolveDuplicateSource(
   store: IfcDataStore,
   sourceExpressId: number,
 ): SourceAttributes {
-  if (!store.source) {
+  if (store.source.byteLength <= 0) {
     throw new Error('resolveDuplicateSource: data store has no source bytes');
   }
   const sourceRef = store.entityIndex.byId.get(sourceExpressId);

--- a/packages/geometry/src/ifc-lite-bridge.test.ts
+++ b/packages/geometry/src/ifc-lite-bridge.test.ts
@@ -190,6 +190,74 @@ describe('IfcLiteBridge', () => {
     expect(wasmMocks.free).toHaveBeenCalledTimes(1);
   });
 
+  // ── Review follow-up: a discarded cleanup failure is undiagnosable ───────
+  //
+  // The catch in `disposeQuietly()` must keep the ORIGINAL error the one that
+  // propagates — that is the whole point of the method — but the `free()`
+  // failure it swallows is precisely the case where the handle may still be
+  // leaked, so it has to be reported. A bare `catch {}` is also what
+  // AGENTS.md forbids.
+
+  it('reports a free() failure it swallows instead of discarding it', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const cleanupFailure = new WebAssembly.RuntimeError('free() double fault');
+      wasmMocks.setMergeLayers.mockImplementationOnce(() => {
+        throw new Error('the original init failure');
+      });
+      wasmMocks.free.mockImplementationOnce(() => {
+        throw cleanupFailure;
+      });
+
+      const bridge = new IfcLiteBridge();
+      // Unchanged contract: the caller still sees why init() failed.
+      await expect(bridge.init()).rejects.toThrow('the original init failure');
+
+      // RED before the follow-up: the cleanup error was swallowed by a bare
+      // `catch {}`, so nothing anywhere named the possibly-leaked handle.
+      const reported = consoleError.mock.calls.filter((call) =>
+        call.some((arg) => String(arg).includes('may be leaked')),
+      );
+      expect(reported).toHaveLength(1);
+      // …and it carries the actual cleanup failure, not just a generic notice.
+      expect(reported[0].some((arg) => String(arg).includes('free() double fault'))).toBe(true);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it('a report that itself throws cannot replace the original error either', async () => {
+    // The reporting added above runs INSIDE the error path, so it must not be
+    // able to become the failure. This is not hypothetical: the logger renders
+    // the value it is handed (`formatError` reads `.name`/`.message`/`.stack`),
+    // and a value whose getter throws makes the report throw. Only the cleanup
+    // error takes this shape — `init()` hands its own logger a plain Error —
+    // so the fault is isolated to the branch under test.
+    const hostile = new WebAssembly.RuntimeError('free() double fault');
+    Object.defineProperty(hostile, 'stack', {
+      get() {
+        throw new Error('reporting exploded');
+      },
+    });
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      wasmMocks.setMergeLayers.mockImplementationOnce(() => {
+        throw new Error('the original init failure');
+      });
+      wasmMocks.free.mockImplementationOnce(() => {
+        throw hostile;
+      });
+
+      const bridge = new IfcLiteBridge();
+      await expect(bridge.init()).rejects.toThrow('the original init failure');
+      // The handle reference is dropped regardless, so the bridge still rebuilds.
+      expect(bridge.isInitialized()).toBe(false);
+      await expect(bridge.init()).resolves.toBeUndefined();
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
   // BOUNDING CONTROL — passes before and after the fix. Without it, a change
   // that freed unconditionally (or that broke the optional chain) would look
   // just as green as the real fix.

--- a/packages/geometry/src/ifc-lite-bridge.test.ts
+++ b/packages/geometry/src/ifc-lite-bridge.test.ts
@@ -117,6 +117,97 @@ describe('IfcLiteBridge', () => {
     expect(wasmMocks.free).not.toHaveBeenCalled();
   });
 
+  // ── #2342: a late init() failure must not strand the handle ─────────────
+  //
+  // `init()` allocates the `IfcAPI` and THEN makes four `apply*()` calls that
+  // each reach into WASM, so "init failed" does not imply "nothing was
+  // allocated". The catch used to call `reset()`, which nulls `ifcApi` without
+  // freeing it, and `dispose()` is the only route to `free()` in the whole
+  // class — so the pointer was stranded with no remaining reference.
+  //
+  // These assert on `free` being CALLED. A bare `rejects.toThrow` passes
+  // identically before and after and proves nothing.
+
+  it('frees the handle when init() throws AFTER allocating it (#2342)', async () => {
+    // A throw from `applyMergeLayers()` — i.e. from a WASM call made on the
+    // handle constructed one line earlier. This is the "late throw that
+    // allocates first" path, which the pre-fix comment claimed could not exist.
+    wasmMocks.setMergeLayers.mockImplementationOnce(() => {
+      throw new Error('setMergeLayers exploded');
+    });
+
+    const bridge = new IfcLiteBridge();
+    await expect(bridge.init()).rejects.toThrow('setMergeLayers exploded');
+
+    expect(wasmMocks.free).toHaveBeenCalledTimes(1);
+    expect(bridge.isInitialized()).toBe(false);
+
+    // …and the recovered handle is really gone, so a later dispose() by the
+    // owner (the shape every MCP export tool uses) cannot double-free it.
+    bridge.dispose();
+    expect(wasmMocks.free).toHaveBeenCalledTimes(1);
+  });
+
+  it('frees the handle when a WASM TRAP ends init() after allocation (#2342)', async () => {
+    // Same ordering, but the throw is a trap, so it also takes the
+    // "unrecoverable" branch. Both halves have to hold: the caller still gets
+    // the typed fatal error AND the handle is released.
+    const trap = new WebAssembly.RuntimeError('unreachable');
+    wasmMocks.setMergeLayers.mockImplementationOnce(() => {
+      throw trap;
+    });
+
+    const bridge = new IfcLiteBridge();
+    let caught: unknown;
+    try {
+      await bridge.init();
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(isWasmRuntimeUnrecoverableError(caught)).toBe(true);
+    expect((caught as Error).cause).toBe(trap);
+    expect(wasmMocks.free).toHaveBeenCalledTimes(1);
+  });
+
+  it('a free() that itself traps while recovering a failed init() does not mask the original error (#2342)', async () => {
+    // `free()` runs Rust. If the allocator is what broke, releasing can break
+    // again — and the caller must still see why init() failed, not why the
+    // cleanup did.
+    wasmMocks.setMergeLayers.mockImplementationOnce(() => {
+      throw new Error('the original init failure');
+    });
+    wasmMocks.free.mockImplementationOnce(() => {
+      throw new WebAssembly.RuntimeError('unreachable');
+    });
+
+    const bridge = new IfcLiteBridge();
+    await expect(bridge.init()).rejects.toThrow('the original init failure');
+    expect(bridge.isInitialized()).toBe(false);
+    // Asserted so this test DISCRIMINATES: without the fix `free()` is never
+    // reached at all, so "the original error survived" would hold vacuously
+    // and the test would pass against the bug it is meant to bound.
+    expect(wasmMocks.free).toHaveBeenCalledTimes(1);
+  });
+
+  // BOUNDING CONTROL — passes before and after the fix. Without it, a change
+  // that freed unconditionally (or that broke the optional chain) would look
+  // just as green as the real fix.
+  it('frees NOTHING when init() fails BEFORE allocating a handle (#2342)', async () => {
+    // The dominant failure: a missing or rotated engine binary. `init()` never
+    // reaches `new IfcAPI()`, so there is no handle and the recovery must stay
+    // a no-op rather than inventing a free.
+    wasmMocks.init
+      .mockRejectedValueOnce(new TypeError('Load failed'))
+      .mockRejectedValueOnce(new TypeError('Load failed'));
+
+    const bridge = new IfcLiteBridge();
+    await expect(bridge.init()).rejects.toThrow(/ifc-lite_bg\.wasm/);
+
+    expect(wasmMocks.free).not.toHaveBeenCalled();
+    expect(bridge.isInitialized()).toBe(false);
+  }, 10_000);
+
   // Issue #1903. The two workers have wrapped their `init()` in
   // `initWasmWithRetry` since #1363; the MAIN-THREAD bridge did not, so a
   // single blip on the ~1.3 MB engine-binary download killed the whole load —

--- a/packages/geometry/src/ifc-lite-bridge.ts
+++ b/packages/geometry/src/ifc-lite-bridge.ts
@@ -132,11 +132,31 @@ export class IfcLiteBridge {
   private disposeQuietly(): void {
     try {
       this.dispose();
-    } catch {
+    } catch (cleanupError) {
       // `free()` runs Rust code. If the allocator is what trapped, freeing can
       // trap again — drop the reference anyway. A secondary failure here must
       // never replace the original trap on its way to the caller.
+      //
+      // Order is load-bearing: `reset()` FIRST, so the reference is dropped
+      // even if reporting the failure somehow misbehaves.
       this.reset();
+      // "Quietly" means it does not THROW, not that it vanishes. This is the
+      // one branch where the handle may genuinely still be leaked — `free()`
+      // failed — so it is the branch that most needs to be diagnosable, and a
+      // bare `catch {}` is what AGENTS.md forbids. Reported, never rethrown.
+      try {
+        log.error(
+          'WASM handle cleanup failed while recovering from an earlier failure; the handle may be leaked',
+          cleanupError,
+          { operation: 'disposeQuietly' },
+        );
+      } catch {
+        // The logger formats the error it is handed, and a hostile/exotic
+        // value can throw from a getter while being formatted. Swallowing
+        // THAT is correct and is the only thing swallowed here: letting a
+        // logging failure escape would do exactly what this whole method
+        // exists to prevent — replace the caller's original error.
+      }
     }
   }
 

--- a/packages/geometry/src/ifc-lite-bridge.ts
+++ b/packages/geometry/src/ifc-lite-bridge.ts
@@ -113,6 +113,23 @@ export class IfcLiteBridge {
    * already kept running, so the "unrecoverable" claim contradicted itself.
    */
   private recordWasmRuntimeTrap(): void {
+    this.disposeQuietly();
+  }
+
+  /**
+   * Drop the WASM handle on an error path, FREEING it when one exists, without
+   * letting the cleanup replace the error already on its way to the caller.
+   *
+   * `dispose()` rather than `reset()` is the whole point: `reset()` only nulls
+   * `ifcApi`, and `free()` occurs exactly once in this class (inside
+   * `dispose()`), so a `reset()` on a live handle strands that wasm-bindgen
+   * pointer with no remaining route to it — a permanent leak of the engine's
+   * entire per-load cache set. When no handle was allocated the optional chain
+   * in `dispose()` makes this identical to `reset()`, which is why the
+   * dominant failure (a missing or rotated WASM binary, which throws before
+   * `new IfcAPI()`) is unaffected.
+   */
+  private disposeQuietly(): void {
     try {
       this.dispose();
     } catch {
@@ -203,11 +220,20 @@ export class IfcLiteBridge {
       log.error('Failed to initialize WASM geometry engine', error, {
         operation: 'init',
       });
-      this.reset();
+      // `disposeQuietly()`, not `reset()` (#2342). A failure here is not always
+      // a failure to *build* the engine: `new IfcAPI()` is followed by four
+      // `apply*()` calls that each reach into WASM, so any of them throwing
+      // lands in this catch with a live handle already allocated. `reset()`
+      // nulled it without freeing, and `dispose()` is the only route to
+      // `free()` in this class, so that handle — and the whole per-load cache
+      // set behind it — leaked for the lifetime of the realm. Before
+      // `new IfcAPI()` there is no handle and this is a no-op, so the dominant
+      // failure (a missing or rotated WASM binary) behaves exactly as before.
+      this.disposeQuietly();
       if (this.isWasmRuntimeError(error)) {
         // The one genuinely unrecoverable case: the engine trapped while
-        // standing itself up, so there is no `IfcAPI` to drop and this realm
-        // has no working engine to fall back on. Report it as such — freshly
+        // standing itself up, and this realm has no working engine to fall
+        // back on. Report it as such — freshly
         // constructed so the stack is this throw site, carrying the trap as
         // `cause` — and tell the host, which offers the user a reload. The
         // verdict is advisory, not a latch: a later `init()` still tries, so no


### PR DESCRIPTION
Fixes #2345
Fixes #2342

## Read this first: both issues were partly fixed while they stayed open

Neither issue was in the state it describes. `main` already carries #2392 (for #2345) and #2389 (for #2342); both merged on 2026-08-08 without a closing keyword, so both issues stayed open. **Each of those PRs explicitly deferred the layer underneath it**, and that is what this PR does — plus an audit of what was left, because "already fixed" is a claim that has to be checked rather than assumed.

I mutation-checked both merged fixes before building on them. Both are real:

| Merged fix | Mutation applied | Result |
|---|---|---|
| #2392 `usd-export-source.ts` | reverted to `if (model.ifcDataStore?.source)` | `# tests 6 / # pass 5 / # fail 1` — leaf: *"falls back to the raw sourceFile bytes when the store has an EMPTY source"* |
| #2389 `packages/mcp/src/tools/export.ts` | moved `await gp.init()` back outside the `try` at all 4 sites | `Tests 4 failed | 3 passed (7)` — one per export tool |

So #2345's named consequence — a source-less model silently exporting an empty USD stage — is genuinely fixed and genuinely covered. That is the reproduction the fix is owed, and it exists.

---

## #2342 — the leak is LIVE, and it was still unfixed

#2389 moved `init()` inside the `try` so `dispose()` becomes reachable. Its own description is careful to say that this **does not free anything**, and that is correct. The handle was still leaking, one layer down:

```ts
// packages/geometry/src/ifc-lite-bridge.ts, init()
this.ifcApi = new IfcAPI();   // ← allocated
this.applyMergeLayers();       // ← four WASM calls follow
this.applyComputeGeometryHashes();
this.applyTessellationQuality();
this.applySkipSmallCuts();
// ...
} catch (error) {
  this.reset();                // ← nulls ifcApi WITHOUT freeing
```

`reset()` is `initialized = false; ifcApi = null`. `free()` occurs **exactly once** in the whole class, inside `dispose()`. So a throw from any of those four `apply*()` calls stranded a live wasm-bindgen pointer — and the per-load pre-pass / entity / style cache set behind it — with no remaining reference, for the lifetime of the realm. By the time #2389's recovered `gp.dispose()` ran, `ifcApi` was already `null` and the optional chain made it a no-op.

**Live, not latent.** The issue asks whether a late-throw path that allocates first actually exists. It does: those four `apply*()` methods each call into WASM (`api.setMergeLayers(...)`, `api.setSkipSmallCuts(...)`, …), after the handle is constructed. The pre-fix comment in the catch asserted the opposite — *"the engine trapped while standing itself up, so there is no `IfcAPI` to drop"* — which holds only for a trap raised before `new IfcAPI()`. That comment is corrected here.

**Is `dispose()` safe on a partially-initialised processor?** Yes, and this was checked before widening anything: `dispose()` is `this.ifcApi?.free(); this.reset();`, optional-chained and documented idempotent, and `GeometryProcessor.dispose()` is `this.bridge?.dispose()`. No init-success tracking is needed.

### The fix

The class *already documents the correct recovery* for the operation-trap path — `recordWasmRuntimeTrap()`: dispose, and fall back to `reset()` if `free()` itself traps, so a secondary failure never replaces the error on its way to the caller. `init()`'s catch was the odd one out. Both now share it as `disposeQuietly()`.

Deliberately **not** reused under the trap-flavoured name: the same code under a name that means "a trap happened" would move that method's blast radius onto a path where the error is usually a failed download. Extracted and named for what it does instead.

Fixing it in the bridge rather than at the call sites means it holds for **every** consumer, not just the four MCP export tools — regardless of whether the caller ever reaches its own `dispose()`.

### Mutation results — `packages/geometry`, vitest

Fixed: `Tests 17 passed (17)`. Mutated (`disposeQuietly()` → `reset()` in the catch, one line):

```
FAIL  frees the handle when init() throws AFTER allocating it (#2342)
FAIL  frees the handle when a WASM TRAP ends init() after allocation (#2342)
FAIL  a free() that itself traps while recovering a failed init() does not mask the original error (#2342)
Tests  3 failed | 14 passed (17)
```

The third test initially did **not** discriminate — with `reset()`, `free()` is never reached, so "the original error survived" held vacuously and it passed against the bug it was meant to bound. It now also asserts `free` was called, which is what makes it fail above. Reporting this because a test that passes both ways is exactly the defect class the repo keeps hitting.

**Bounding control, passes before and after:** *"frees NOTHING when init() fails BEFORE allocating a handle"* — the dominant failure (missing/rotated WASM binary). Without it, a change that freed unconditionally would look as green as the real fix. The 13 pre-existing bridge tests also pass both ways.

---

## #2345 — audit of what #2392 left, and what it costs

#2392 fixed the three named sites plus `resolve-anchor.ts`, and listed siblings it deliberately did not sweep. I checked each rather than taking the list on trust, and **the conclusion is narrower than the list implies: there is no remaining silent-wrong-output anywhere in this class.**

The one I expected to be the real remaining bug — `step-exporter.ts` (8 sites), flagged in #2392 as *"structurally the highest-risk remaining class"* — **is not a bug.** I built two reproductions against it rather than reasoning about it:

1. A source-less store with a pset edit, `visibleOnly` off vs on → `DATA` lines: **0 vs 0**. Every source-backed ref on such a store has `byteLength === 0`, and the source-iteration pass skips those on the line *after* the dead guard.
2. The case that could actually have lost data — an overlay-*created* product on a source-less store, since `allowedEntityIds` filters new entities too → `DATA` lines: **1 vs 1**, the wall emitted both ways.

So all 8 are bounded by a downstream check. **This matters for the collision below:** the file needs no change from anyone for #2345.

That leaves the residual, which this PR fixes: `extract-walls.ts` (4 sites) and `resolve-source.ts` (1) in `packages/create` — the siblings of the `resolve-anchor.ts` that #2392 corrected, and `extract-walls.ts` is the very file `resolve-anchor.ts`'s own comment names as the one it mirrors.

**These are diagnostic defects, not output defects, and the PR says so rather than dressing them up:**

- `extractWallSegmentsForStorey` ran `extractLengthUnitScale` over the empty source. That cannot resolve IFCPROJECT, so it took a `warnUnknownUnit` path and warned the user their model may be **mis-scaled** and is being read as metres — about a model with no source to scale from. Its documented `'no source bytes — extraction cannot run'` early return could never fire either, so it went on to build the relating/children indices and walk the storey before reaching the same empty result.
- `resolveDuplicateSource` threw `could not parse #N`, blaming the entity, when the entity is fine and the store has no bytes to parse it out of. The accurate message was already written for this case and unreachable.

**On "fallback or error":** the fallback is right where one exists and is reachable (the USD site — a wrong file written successfully with no error is the worst outcome, and #2392 took that call correctly). Both sites here already failed closed by producing nothing, so there is nothing to fall back *to*; the right behaviour is the accurate diagnostic, which is what the dead code was already trying to give.

### Mutation results — `packages/create`, vitest

Fixed: `Tests 4 passed (4)`. Mutated (all 5 guards reverted to the truthiness form):

```
FAIL  does not emit a unit warning for a model that has no source to read units from
FAIL  names the missing source rather than blaming the entity
Tests  2 failed | 2 passed (4)
```

The two that pass under mutation are the bounding controls — a store **with** bytes still resolves `0.001` from the fixture's `MILLI.METRE` and still reads real attributes. Without them, a "fix" that routed every store down the early return, or stopped reading units at all, would look identical to the real one. The empty-source store keeps a **real** `entityIndex` with only `source` swapped for `EMPTY_SOURCE_BYTES` — the shape `serverDataModel.ts` builds — because the dead guards got past it precisely by resolving ids.

### On the accessor trap (#2339/#2360)

Checked at every site before choosing a predicate, since a source accessor that keeps `byteLength` while `process()` meshes nothing would make a `byteLength` test just as dead as a presence test. Every site here reads `IfcSourceBytes` directly, where `byteLength === 0` is the documented, supported "this model has no source" state (`source-bytes.ts`), and `EMPTY_SOURCE_BYTES` is the frozen singleton for it. `byteLength` is the right discriminator here. Predicate form matches the house style #2392 established in `resolve-anchor.ts` (`> 0` / `<= 0`), not a new one.

---

## Sites left alone, with reasons

- **`packages/export/src/step-exporter.ts` (8 sites) — untouched, and a live-agent collision.** Another agent is editing this file right now. It also needs no change: reproductions above show all 8 are bounded downstream. Same for `demesh-writer.ts:103` (throws either way, message-only) — left alone to keep this PR out of `packages/export` entirely.
- **`mcp/tools/discovery.ts:44`, `mcp/tools/query.ts:607`, `playground-dispatcher.ts:733`** — dead, but `extractLengthUnitScale` returns `1.0` in band on an empty source, so the answer is identical; and MCP stores are parsed from disk, so a source-less store is not reachable there today. Cosmetic.
- **`hbjson-export-source.ts:67` and `RawStepCard.tsx:58`** — the dead check is immediately followed by a real `length === 0` / `byteLength <= 0` check. Correct as written.
- **`useDrawingGeneration.ts:221/223/304`** — `:221` yields a cache key of `"0"` for any source-less model, so two different such models collide on it. Real but confined to the legacy single-model branch, and outside both issues; reported rather than swept in.

## Verification

```
npx turbo typecheck --force   →  Tasks: 36 successful, 36 total   Cached: 0 cached, 36 total
npx turbo test --force        →  Tasks: 86 successful, 86 total   Cached: 0 cached, 86 total
```

One caveat worth flagging: the first full `turbo test --force` run failed with a single leaf failure in `apps/viewer/src/components/viewer/device-loss-report.test.ts` (*"a stopped viewport must say so on screen, 0 !== 1"*). It is **not** from this branch — my diff touches zero files under `apps/viewer`. Confirmed by running the whole viewer suite twice: at `origin/main` sources `# tests 3394 / # pass 3388 / # fail 0`, and at this branch `# tests 3394 / # pass 3388 / # fail 0`. It is an order-dependent flake in that file (it passes 15/15 in isolation either way), in the same area as an in-flight device-loss branch.

Changesets: `@ifc-lite/geometry` and `@ifc-lite/create` (both published — verified no `"private"` field). None for `apps/viewer`, which is `"private": true` and unchanged here anyway.


---

## Review round 2 (both threads resolved)

**`extract-walls.ts` — a regression this PR introduced, now fixed.** The source-bytes guard returned *before* the overlay loop, so on a source-less store (`EMPTY_SOURCE_BYTES` — server-parsed / point-cloud model) overlay-created walls stopped contributing entirely and `generateSpacesFromWalls` reported zero regions. Reproduced first: a source-less store plus an overlay carrying one `IfcWall` gave `Tests 1 failed | 5 passed (6)`, `considered` 0 instead of 1, while the paired control (same overlay, store WITH bytes) passed.

The early return is gone; the guard now only logs. It was redundant for the source path anyway — `collectDividerIdsOnStorey` carries the same `byteLength <= 0` guard one frame down and returns empty, so the relating/children indices are still never built and the storey is still never walked. Mutation-check (restore the early return): `Tests 1 failed | 5 passed (6)`, the failing leaf being the new overlay test.

`resolve-source.ts` was checked for the same shape and does **not** have it: `resolveDuplicateSource` takes no overlay parameter and has no overlay path, so an overlay-created entity was never resolvable there before this PR either (it threw `entity #N not found`). Same for `resolve-anchor.ts`.

**`disposeQuietly()` — the swallowed cleanup error is now reported.** `reset()` first (so the reference is dropped regardless), then `log.error(... 'the handle may be leaked', cleanupError ...)` inside its own `try`/`catch` so the report cannot itself become the propagating error. Two new tests, each mutation-checked to fail exactly one leaf:

| mutation | result |
|---|---|
| drop the report entirely (bare `catch`) | `Tests 1 failed \| 18 passed (19)` — *"reports a free() failure it swallows instead of discarding it"* |
| keep the report, neutralise the inner `try`/`catch` | `Tests 1 failed \| 18 passed (19)` — *"a report that itself throws cannot replace the original error either"* |

### Smaller finding, recorded rather than swept in

`init()`'s own `log.error('Failed to initialize WASM geometry engine', error, …)` — the line immediately above `disposeQuietly()` — is **not** wrapped. A logger that throws while formatting there replaces the init error for every caller, which is the same defect class the thread above is about, one frame up. It needs a different shape than a local `try` (every `log.error` on an error path has it), so it is noted here rather than widened into this PR.

### Verification, round 2

```
npx turbo typecheck --force   →  Tasks: 36 successful, 36 total   Cached: 0 cached, 36 total
npx turbo test --force        →  Tasks: 86 successful, 86 total   Cached: 0 cached, 86 total
```

Viewer leaf counts `# tests 3394 / # pass 3388 / # fail 0 / # skipped 6`, zero `not ok` lines in the whole run. The 6 skips are the fixture-backed golden tests skipping on a worktree without `pnpm fixtures`; fetched the fixtures and re-ran them explicitly — `# tests 4 / # pass 4 / # fail 0 / # skipped 0`. No Rust files are touched by this PR (`git diff --stat -- rust/` is empty), so the cargo gates are not applicable.
