### PR TITLE
fix(mcp): enforce the playground registry's single-model precondition

### DIFF
--- a/apps/viewer/src/components/mcp/playground-scene-ops.ts
+++ b/apps/viewer/src/components/mcp/playground-scene-ops.ts
@@ -129,6 +129,11 @@ export function colorByProperty(
   // The colouring still walks every submesh; only the counting and the
   // sampling are per entity, the same split the selector-driven ops landed on
   // (#2452).
+  //
+  // `expressId` alone is a sound entity key here because the registry holds ONE
+  // model — `buildEntityRecords` enforces that rather than assuming it (#2471).
+  // Across two federated models the same number would name two different
+  // entities and this map would merge them into one bucket.
   const records = reg.byType.get(type) ?? [];
   const byEntity = new Map<number, EntityRecord[]>();
   for (const r of records) {

--- a/apps/viewer/src/components/mcp/playground-scene-registry.test.ts
+++ b/apps/viewer/src/components/mcp/playground-scene-registry.test.ts
@@ -372,6 +372,51 @@ describe('playground registry: the single-model precondition is enforced (#2471)
     assert.equal(reg.byExpressId.get(WALL_A_ID)?.length, 2, 'exactly that load, nothing merged');
   });
 
+  it('claims the registry for a build that throws part-way, because its records are already in', async () => {
+    // The narrower form of the same bug (#2492 review). Claiming after the loop
+    // is only correct for builds that finish: one bad `MeshData` throws
+    // mid-loop, and the records built before it stay indexed while `reg.model`
+    // is still `null`. The guard reads that `null` as "empty registry, nothing
+    // to merge with" and lets the next model into the very same expressId
+    // buckets — which is the merge the precondition exists to stop, reached
+    // through the door the empty-build fix opened.
+    //
+    // The throw is three.js's own: `BufferAttribute` rejects a plain array, so
+    // the second mesh dies on the first statement of its iteration, after the
+    // first mesh has been fully indexed. No stubbing.
+    const reg = createEntityRegistry();
+    const modelGroup = new THREE.Group();
+    const malformed = {
+      ...tri(WALL_B_ID, 4, [1, 1, 1, 1]),
+      positions: [] as unknown as Float32Array,
+    };
+
+    assert.throws(
+      () => buildEntityRecords(
+        reg,
+        [tri(WALL_A_ID, 0, [1, 1, 1, 1]), malformed],
+        model,
+        modelGroup,
+        createSectionState(),
+      ),
+      /Typed Array/i,
+      'fixture check: the malformed mesh really is what three.js refuses',
+    );
+    assert.equal(reg.records.length, 1, 'fixture check: the first mesh was indexed before the throw');
+
+    assert.equal(reg.model, model, 'a partial build owns the keyspace it already filled');
+
+    // The consequence that matters, stated as behaviour rather than as state:
+    // the next model is refused instead of merged.
+    const second = await twoWallModel('other.ifc');
+    assert.throws(
+      () => buildEntityRecords(reg, splitMeshes(), second, modelGroup, createSectionState()),
+      /#2471/,
+      'a half-built registry is still a registry holding one model',
+    );
+    assert.equal(reg.byExpressId.get(WALL_A_ID)?.length, 1, 'and nothing of the second model merged in');
+  });
+
   it('releases the model identity on clear, so a model swap still works', async () => {
     // The one multi-model sequence the playground really performs: pick another
     // sample. `loadMeshes` clears, then builds — that must NOT trip the guard.

--- a/apps/viewer/src/components/mcp/playground-scene-registry.test.ts
+++ b/apps/viewer/src/components/mcp/playground-scene-registry.test.ts
@@ -345,6 +345,33 @@ describe('playground registry: the single-model precondition is enforced (#2471)
     assert.equal(reg.model, model);
   });
 
+  it('does not claim the registry for a build that indexes nothing', async () => {
+    // `EntityRegistry.model` documents `null` as "the registry is empty", and
+    // the guard exists to stop two models sharing one bare-expressId keyspace.
+    // A build that adds no records puts nothing in that keyspace, so claiming
+    // the registry for it would state something untrue (an empty registry
+    // naming a model it holds no record of) AND reject the next load for a
+    // merge that cannot happen. A geometry-less model is a real load: an IFC
+    // whose products all fail to tessellate reaches `loadMeshes` with `[]`.
+    const reg = createEntityRegistry();
+    const modelGroup = new THREE.Group();
+
+    const counts = buildEntityRecords(reg, [], model, modelGroup, createSectionState());
+
+    assert.deepEqual(counts, { opaqueCount: 0, transparentCount: 0 }, 'nothing was built');
+    assert.equal(reg.records.length, 0, 'and nothing was indexed');
+    assert.equal(reg.model, null, 'so the registry still belongs to no model');
+
+    // The consequence that matters: the next load is not refused.
+    const second = await twoWallModel('other.ifc');
+    assert.doesNotThrow(
+      () => buildEntityRecords(reg, splitMeshes(), second, modelGroup, createSectionState()),
+      'an empty registry must accept any model - there is nothing to merge with',
+    );
+    assert.equal(reg.model, second, 'and it is claimed by the load that actually filled it');
+    assert.equal(reg.byExpressId.get(WALL_A_ID)?.length, 2, 'exactly that load, nothing merged');
+  });
+
   it('releases the model identity on clear, so a model swap still works', async () => {
     // The one multi-model sequence the playground really performs: pick another
     // sample. `loadMeshes` clears, then builds — that must NOT trip the guard.

--- a/apps/viewer/src/components/mcp/playground-scene-registry.test.ts
+++ b/apps/viewer/src/components/mcp/playground-scene-registry.test.ts
@@ -33,6 +33,7 @@ import { parsePlaygroundModel, type LoadedPlaygroundModel } from './playground-d
 import {
   buildEntityRecords,
   clearEntityRecords,
+  countEntities,
   createEntityRegistry,
   selectTargets,
   type EntityRecord,
@@ -46,7 +47,7 @@ const WALL_A_GUID = '2443SplitWallAAAAAAAAA';
 const WALL_B_GUID = '2443SoloWallBBBBBBBBBB';
 
 /** Two walls, so the model has an element with submeshes AND a control. */
-async function twoWallModel(): Promise<LoadedPlaygroundModel> {
+async function twoWallModel(filename = 'split.ifc'): Promise<LoadedPlaygroundModel> {
   const bytes = new TextEncoder().encode([
     'ISO-10303-21;', 'HEADER;', "FILE_DESCRIPTION((''),'2;1');",
     "FILE_NAME('','',(''),(''),'','','');", "FILE_SCHEMA(('IFC4'));", 'ENDSEC;', 'DATA;',
@@ -54,7 +55,7 @@ async function twoWallModel(): Promise<LoadedPlaygroundModel> {
     `#${WALL_B_ID}=IFCWALL('${WALL_B_GUID}',$,'Solo Wall',$,$,$,$,$,.STANDARD.);`,
     'ENDSEC;', 'END-ISO-10303-21;', '',
   ].join('\n'));
-  return parsePlaygroundModel(bytes.buffer as ArrayBuffer, 'split.ifc');
+  return parsePlaygroundModel(bytes.buffer as ArrayBuffer, filename);
 }
 
 /** One triangle, offset so each submesh is a distinct object. */
@@ -244,6 +245,65 @@ describe('playground registry: id lookups cover every submesh (#2443)', () => {
     buildEntityRecords(reg, splitMeshes(), model, modelGroup, createSectionState());
     assert.equal(reg.byExpressId.get(WALL_A_ID)?.length, 2, 'exactly the new load, not both');
     assert.equal(selectTargets(reg, { expressIds: [WALL_A_ID] }).length, 2);
+  });
+});
+
+describe('playground registry: the single-model precondition is enforced (#2471)', () => {
+  /**
+   * Everything the registry exposes is keyed model-unqualified — `byExpressId`,
+   * `countEntities`, `colorByProperty`'s per-entity grouping, `byType`,
+   * `byStorey`. That is sound for one STEP file, where `expressId` is unique,
+   * and unsound the moment two models share the registry: `#1` would name two
+   * different walls and every lookup would merge them.
+   *
+   * The `/mcp` playground cannot reach that state (single `model` state, no
+   * `DispatchContext.registry`, `model_load` refuses, and `loadMeshes` clears
+   * before it builds). These tests pin the last link so the assumption is
+   * enforced rather than implicit — a future additive `loadMeshes` fails loudly
+   * instead of silently merging two models' entities.
+   */
+  it('refuses to build a second model into a populated registry', async () => {
+    const second = await twoWallModel('other.ifc');
+    assert.notEqual(second.id, model.id, 'fixture check: the two models really are distinct');
+
+    const { reg, modelGroup, section } = mount();
+    assert.equal(reg.modelId, model.id, 'the registry names the model it holds');
+
+    assert.throws(
+      () => buildEntityRecords(reg, splitMeshes(), second, modelGroup, section),
+      /#2471/,
+      'a second model must not silently share the bare-expressId keyspace',
+    );
+  });
+
+  it('leaves the first model untouched when it refuses', () => {
+    // A guard that half-applied would be worse than none: the throw has to
+    // happen before any indexing, or the registry ends up in exactly the merged
+    // state the guard exists to prevent.
+    const second = { ...model, id: 'other-model' };
+    const { reg, modelGroup, section } = mount();
+    const before = reg.records.length;
+
+    assert.throws(() => buildEntityRecords(reg, splitMeshes(), second, modelGroup, section));
+
+    assert.equal(reg.records.length, before, 'no record from the rejected model was indexed');
+    assert.equal(reg.byExpressId.get(WALL_A_ID)?.length, 2, 'and none merged into an existing bucket');
+    assert.equal(countEntities(reg.records), 2, 'the entity count is still the first model alone');
+    assert.equal(reg.modelId, model.id, 'the registry still names the model it actually holds');
+  });
+
+  it('releases the model identity on clear, so a model swap still works', async () => {
+    // The one multi-model sequence the playground really performs: pick another
+    // sample. `loadMeshes` clears, then builds — that must NOT trip the guard.
+    const second = await twoWallModel('other.ifc');
+    const { reg, modelGroup } = mount();
+
+    clearEntityRecords(reg, modelGroup);
+    assert.equal(reg.modelId, null, 'an empty registry belongs to no model');
+
+    buildEntityRecords(reg, splitMeshes(), second, modelGroup, createSectionState());
+    assert.equal(reg.modelId, second.id);
+    assert.equal(reg.byExpressId.get(WALL_A_ID)?.length, 2, 'exactly the new load, not both');
   });
 });
 

--- a/apps/viewer/src/components/mcp/playground-scene-registry.test.ts
+++ b/apps/viewer/src/components/mcp/playground-scene-registry.test.ts
@@ -261,13 +261,18 @@ describe('playground registry: the single-model precondition is enforced (#2471)
    * before it builds). These tests pin the last link so the assumption is
    * enforced rather than implicit — a future additive `loadMeshes` fails loudly
    * instead of silently merging two models' entities.
+   *
+   * The identity the guard tracks is the **model object**, not `model.id`:
+   * `parsePlaygroundModel` slugs `id` out of the filename alone, so it is not
+   * unique per load. The last two cases below are the ones an id comparison
+   * waves straight through.
    */
   it('refuses to build a second model into a populated registry', async () => {
     const second = await twoWallModel('other.ifc');
     assert.notEqual(second.id, model.id, 'fixture check: the two models really are distinct');
 
     const { reg, modelGroup, section } = mount();
-    assert.equal(reg.modelId, model.id, 'the registry names the model it holds');
+    assert.equal(reg.model, model, 'the registry names the model it holds');
 
     assert.throws(
       () => buildEntityRecords(reg, splitMeshes(), second, modelGroup, section),
@@ -276,11 +281,49 @@ describe('playground registry: the single-model precondition is enforced (#2471)
     );
   });
 
-  it('leaves the first model untouched when it refuses', () => {
+  it('refuses a re-upload of the SAME filename, which reuses the id', async () => {
+    // The case an `id` comparison cannot see. Re-uploading a file (edited or
+    // not) parses a second, independent model whose slug id is byte-identical
+    // to the first — `playground-dispatcher`'s clash mesh cache keys on
+    // `id:fileSize` precisely because of this. Its records must not merge into
+    // the live registry's expressId buckets.
+    const reupload = await twoWallModel();
+    assert.equal(reupload.id, model.id, 'fixture check: the re-upload really does reuse the id');
+    assert.notEqual(reupload, model, 'fixture check: but it is a distinct load');
+
+    const { reg, modelGroup, section } = mount();
+    assert.throws(
+      () => buildEntityRecords(reg, splitMeshes(), reupload, modelGroup, section),
+      /#2471/,
+      'a same-filename re-upload is still a second model',
+    );
+  });
+
+  it('refuses two filenames that slug to the SAME id', async () => {
+    // `id` is `filename.replace(/\.ifc$/i,'').replace(/[^a-zA-Z0-9]+/g,'-').toLowerCase()`,
+    // so genuinely different files collide: `A B.ifc` and `a-b.ifc` both become
+    // `a-b`. Two real models, one id — the merge the precondition forbids.
+    const spaced = await twoWallModel('A B.ifc');
+    const hyphenated = await twoWallModel('a-b.ifc');
+    assert.equal(spaced.id, hyphenated.id, 'fixture check: the two filenames really do collide');
+
+    const reg = createEntityRegistry();
+    const modelGroup = new THREE.Group();
+    buildEntityRecords(reg, splitMeshes(), spaced, modelGroup, createSectionState());
+
+    assert.throws(
+      () => buildEntityRecords(reg, splitMeshes(), hyphenated, modelGroup, createSectionState()),
+      /#2471/,
+      'a slug collision must not be mistaken for the same model',
+    );
+    assert.equal(reg.byExpressId.get(WALL_A_ID)?.length, 2, 'only the first model is indexed');
+  });
+
+  it('leaves the first model untouched when it refuses', async () => {
     // A guard that half-applied would be worse than none: the throw has to
     // happen before any indexing, or the registry ends up in exactly the merged
     // state the guard exists to prevent.
-    const second = { ...model, id: 'other-model' };
+    const second = await twoWallModel('other.ifc');
     const { reg, modelGroup, section } = mount();
     const before = reg.records.length;
 
@@ -289,7 +332,17 @@ describe('playground registry: the single-model precondition is enforced (#2471)
     assert.equal(reg.records.length, before, 'no record from the rejected model was indexed');
     assert.equal(reg.byExpressId.get(WALL_A_ID)?.length, 2, 'and none merged into an existing bucket');
     assert.equal(countEntities(reg.records), 2, 'the entity count is still the first model alone');
-    assert.equal(reg.modelId, model.id, 'the registry still names the model it actually holds');
+    assert.equal(reg.model, model, 'the registry still names the model it actually holds');
+  });
+
+  it('accepts an additive build of the model it already holds', () => {
+    // The guard rejects a second MODEL, not a second call. Re-entering with the
+    // very same load is how a caller would append meshes, and it must stay
+    // legal — otherwise the guard is a mutation nobody could distinguish from
+    // "throw on every second call".
+    const { reg, modelGroup, section } = mount();
+    assert.doesNotThrow(() => buildEntityRecords(reg, splitMeshes(), model, modelGroup, section));
+    assert.equal(reg.model, model);
   });
 
   it('releases the model identity on clear, so a model swap still works', async () => {
@@ -299,10 +352,10 @@ describe('playground registry: the single-model precondition is enforced (#2471)
     const { reg, modelGroup } = mount();
 
     clearEntityRecords(reg, modelGroup);
-    assert.equal(reg.modelId, null, 'an empty registry belongs to no model');
+    assert.equal(reg.model, null, 'an empty registry belongs to no model');
 
     buildEntityRecords(reg, splitMeshes(), second, modelGroup, createSectionState());
-    assert.equal(reg.modelId, second.id);
+    assert.equal(reg.model, second);
     assert.equal(reg.byExpressId.get(WALL_A_ID)?.length, 2, 'exactly the new load, not both');
   });
 });

--- a/apps/viewer/src/components/mcp/playground-scene-registry.ts
+++ b/apps/viewer/src/components/mcp/playground-scene-registry.ts
@@ -56,6 +56,12 @@ export interface EntityRegistry {
   byGlobalId: Map<string, EntityRecord[]>;
   byType: Map<string, EntityRecord[]>;
   byStorey: Map<string, EntityRecord[]>;
+  /**
+   * The `LoadedPlaygroundModel.id` every record here came from, or `null` when
+   * the registry is empty. This is the SINGLE-MODEL PRECONDITION (#2471) made
+   * explicit — see `buildEntityRecords`, which refuses to break it.
+   */
+  modelId: string | null;
 }
 
 export function createEntityRegistry(): EntityRegistry {
@@ -65,6 +71,7 @@ export function createEntityRegistry(): EntityRegistry {
     byGlobalId: new Map<string, EntityRecord[]>(),
     byType: new Map<string, EntityRecord[]>(),
     byStorey: new Map<string, EntityRecord[]>(),
+    modelId: null,
   };
 }
 
@@ -78,6 +85,11 @@ export function createEntityRegistry(): EntityRegistry {
  * answer a one-window `viewer_colorize` with "2" whenever that window
  * tessellated into glass + frame, which is the same id-vs-type disagreement
  * #2443 set out to remove, just moved into the response (#2443 follow-up).
+ *
+ * A bare `expressId` is a COMPLETE identity here only because the registry
+ * holds one model at a time — `expressId` is unique within a STEP file, not
+ * across files. `buildEntityRecords` enforces that precondition rather than
+ * assuming it, which is what makes this key sound (#2471).
  */
 export function countEntities(records: Iterable<EntityRecord>): number {
   const seen = new Set<number>();
@@ -123,6 +135,10 @@ export function clearEntityRecords(reg: EntityRegistry, modelGroup: THREE.Group)
   byGlobalId.clear();
   byType.clear();
   byStorey.clear();
+  // Releasing the model identity is part of emptying the registry: leaving it
+  // set would make the next `buildEntityRecords` reject a legitimate model
+  // swap, which is the ONE multi-model sequence the playground really performs.
+  reg.modelId = null;
 }
 
 /**
@@ -163,6 +179,26 @@ export function selectTargets(
  * Turn a tessellated `MeshData[]` into meshes on `modelGroup` plus registry
  * entries, enriching each with IFC metadata from the parsed store. Returns the
  * opaque/transparent tally the caller logs.
+ *
+ * **Single-model precondition (#2471).** Every key in this registry is
+ * model-unqualified: `byExpressId`, `countEntities`, `colorByProperty`'s
+ * per-entity grouping, `byType` and `byStorey` all address entities by a bare
+ * value. `expressId` is unique within one STEP file and NOT across files, so
+ * two federated models each holding an `#42` would silently merge into one
+ * bucket — sampled once, coloured together, counted as one.
+ *
+ * The `/mcp` playground cannot reach that today, and the reasons are structural
+ * rather than accidental: `McpPlayground` holds a single `model` state, its
+ * `DispatchContext` never populates `registry`, the `model_load` tool throws
+ * `UNSUPPORTED_OPERATION` naming the session single-model, and `loadMeshes`
+ * clears the registry before every build. This function turns the last of those
+ * from an implicit habit into an enforced invariant: feeding a second model's
+ * meshes into a populated registry throws instead of quietly merging.
+ *
+ * Qualifying the identity everywhere is the alternative, and it is the right
+ * fix the day the playground genuinely federates. Until then it would be
+ * threading a model id through code paths that provably only ever see one
+ * model, so the narrower guarantee is the honest contract.
  */
 export function buildEntityRecords(
   reg: EntityRegistry,
@@ -172,6 +208,15 @@ export function buildEntityRecords(
   section: SectionState,
 ): { opaqueCount: number; transparentCount: number } {
   const { records, byExpressId, byGlobalId, byType, byStorey } = reg;
+
+  if (reg.modelId !== null && reg.modelId !== model.id) {
+    throw new Error(
+      `[playground-registry] refusing to federate '${model.id}' into a registry already holding `
+      + `'${reg.modelId}': every lookup here keys on a bare expressId, which is unique per file `
+      + 'and not across files (#2471). Call clearEntityRecords() first, or qualify the identity.',
+    );
+  }
+  reg.modelId = model.id;
 
   // Build per-entity records.
   //

--- a/apps/viewer/src/components/mcp/playground-scene-registry.ts
+++ b/apps/viewer/src/components/mcp/playground-scene-registry.ts
@@ -229,10 +229,10 @@ export function buildEntityRecords(
       + 'and not across files (#2471). Call clearEntityRecords() first, or qualify the identity.',
     );
   }
-  // The identity is CLAIMED after the build, not before it — see the tail of
-  // this function. A build that indexes nothing must leave the registry at
-  // `null`, the state `EntityRegistry.model` documents for an empty registry.
-  const recordsBefore = records.length;
+  // The identity is CLAIMED by the first record this build indexes, not before
+  // the loop and not after it — see the claim inside the loop. A build that
+  // indexes nothing must leave the registry at `null`, the state
+  // `EntityRegistry.model` documents for an empty registry.
 
   // Build per-entity records.
   //
@@ -322,16 +322,27 @@ export function buildEntityRecords(
     if (globalId) index(byGlobalId, globalId, rec);
     if (ifcType) index(byType, ifcType, rec);
     if (storeyName) index(byStorey, storeyName, rec);
-  }
 
-  // Claim the registry for this model only if the build actually put entries
-  // in the bare-expressId keyspace. A geometry-less load (or a build handed an
-  // empty batch) indexes nothing, and there is nothing for a later model to
-  // merge WITH — claiming it there would leave an empty registry naming a
-  // model it holds no record of, and reject the next load for a collision that
-  // cannot happen. Keyed on the records actually added rather than on
-  // `meshes.length`, so it stays correct if the loop ever learns to skip one.
-  if (records.length > recordsBefore) reg.model = model;
+    // Claim the registry the moment it holds a record, not after the loop.
+    //
+    // The claim's job is to say who owns the bare-expressId keyspace, and the
+    // keyspace is occupied from the FIRST record onwards — so ownership has to
+    // be recorded there. Claiming after the loop was only correct for builds
+    // that run to completion: a `MeshData` this loop refuses (three.js rejects
+    // a non-typed-array buffer, an absent `color` fails to destructure) throws
+    // part-way and leaves records indexed with `reg.model` still `null`. The
+    // guard above reads that `null` as "empty registry, nothing to merge with"
+    // and waves the next model straight into those buckets — the exact
+    // cross-model `expressId` merge this precondition exists to stop (#2471,
+    // #2492 review).
+    //
+    // A build that indexes nothing never reaches this line, so an empty
+    // registry still belongs to no model — the invariant `EntityRegistry.model`
+    // documents, and the one the empty-build case pins. `reg.model` is `null`
+    // or already `model` here (any other value threw above), so this assigns
+    // once and cannot overwrite a live identity.
+    if (reg.model === null) reg.model = model;
+  }
 
   return { opaqueCount, transparentCount };
 }

--- a/apps/viewer/src/components/mcp/playground-scene-registry.ts
+++ b/apps/viewer/src/components/mcp/playground-scene-registry.ts
@@ -229,7 +229,10 @@ export function buildEntityRecords(
       + 'and not across files (#2471). Call clearEntityRecords() first, or qualify the identity.',
     );
   }
-  reg.model = model;
+  // The identity is CLAIMED after the build, not before it — see the tail of
+  // this function. A build that indexes nothing must leave the registry at
+  // `null`, the state `EntityRegistry.model` documents for an empty registry.
+  const recordsBefore = records.length;
 
   // Build per-entity records.
   //
@@ -320,6 +323,15 @@ export function buildEntityRecords(
     if (ifcType) index(byType, ifcType, rec);
     if (storeyName) index(byStorey, storeyName, rec);
   }
+
+  // Claim the registry for this model only if the build actually put entries
+  // in the bare-expressId keyspace. A geometry-less load (or a build handed an
+  // empty batch) indexes nothing, and there is nothing for a later model to
+  // merge WITH — claiming it there would leave an empty registry naming a
+  // model it holds no record of, and reject the next load for a collision that
+  // cannot happen. Keyed on the records actually added rather than on
+  // `meshes.length`, so it stays correct if the loop ever learns to skip one.
+  if (records.length > recordsBefore) reg.model = model;
 
   return { opaqueCount, transparentCount };
 }

--- a/apps/viewer/src/components/mcp/playground-scene-registry.ts
+++ b/apps/viewer/src/components/mcp/playground-scene-registry.ts
@@ -57,11 +57,20 @@ export interface EntityRegistry {
   byType: Map<string, EntityRecord[]>;
   byStorey: Map<string, EntityRecord[]>;
   /**
-   * The `LoadedPlaygroundModel.id` every record here came from, or `null` when
+   * The `LoadedPlaygroundModel` every record here came from, or `null` when
    * the registry is empty. This is the SINGLE-MODEL PRECONDITION (#2471) made
    * explicit — see `buildEntityRecords`, which refuses to break it.
+   *
+   * The **object**, deliberately, not its `id`. `parsePlaygroundModel` derives
+   * `id` from the filename alone (lower-cased, non-alphanumerics collapsed to
+   * `-`), so the id is not a per-load identity at all: `A B.ifc` and `a-b.ifc`
+   * both slug to `a-b`, and re-uploading one file produces the same id twice —
+   * which is exactly why the clash mesh cache keys on `id:fileSize` rather than
+   * `id`. Comparing ids would let both of those merge two loads into one bare
+   * `expressId` keyspace, the merge this precondition exists to stop. Every
+   * load allocates a fresh object, so reference identity collides for nothing.
    */
-  modelId: string | null;
+  model: LoadedPlaygroundModel | null;
 }
 
 export function createEntityRegistry(): EntityRegistry {
@@ -71,7 +80,7 @@ export function createEntityRegistry(): EntityRegistry {
     byGlobalId: new Map<string, EntityRecord[]>(),
     byType: new Map<string, EntityRecord[]>(),
     byStorey: new Map<string, EntityRecord[]>(),
-    modelId: null,
+    model: null,
   };
 }
 
@@ -138,7 +147,7 @@ export function clearEntityRecords(reg: EntityRegistry, modelGroup: THREE.Group)
   // Releasing the model identity is part of emptying the registry: leaving it
   // set would make the next `buildEntityRecords` reject a legitimate model
   // swap, which is the ONE multi-model sequence the playground really performs.
-  reg.modelId = null;
+  reg.model = null;
 }
 
 /**
@@ -209,14 +218,18 @@ export function buildEntityRecords(
 ): { opaqueCount: number; transparentCount: number } {
   const { records, byExpressId, byGlobalId, byType, byStorey } = reg;
 
-  if (reg.modelId !== null && reg.modelId !== model.id) {
+  // Reference identity, NOT `model.id` — see `EntityRegistry.model`. A
+  // filename slug collides (`A B.ifc` / `a-b.ifc`) and repeats across
+  // re-uploads, so an id comparison would wave through exactly the two cases
+  // that produce a merged keyspace.
+  if (reg.model !== null && reg.model !== model) {
     throw new Error(
-      `[playground-registry] refusing to federate '${model.id}' into a registry already holding `
-      + `'${reg.modelId}': every lookup here keys on a bare expressId, which is unique per file `
+      `[playground-registry] refusing to federate '${model.name}' into a registry already holding `
+      + `'${reg.model.name}': every lookup here keys on a bare expressId, which is unique per file `
       + 'and not across files (#2471). Call clearEntityRecords() first, or qualify the identity.',
     );
   }
-  reg.modelId = model.id;
+  reg.model = model;
 
   // Build per-entity records.
   //


### PR DESCRIPTION
Refs #2471.

## Verdict: the collision is not reachable in `/mcp` today

The issue's first question was whether a federated model is loadable in the playground at all. It is not, and the reasons are structural rather than accidental — four independent locks, any one of which alone would be enough:

1. **`McpPlayground.tsx:82`** holds `useState<LoadedPlaygroundModel | null>` — one model, replaced on every sample pick or drop.
2. **`McpPlayground.tsx:92`** is the only production `DispatchContext` producer and returns `{ viewer, openViewerPanel }`. `ctx.registry` (the `model_id → model` map) is never populated, so even the two-model diff path is dead in the browser.
3. **`playground-dispatcher.ts` `model_load`** throws `UNSUPPORTED_OPERATION` with the contract spelled out: *"isn't supported in the web playground (single-model session) … The stdio MCP supports federated load."*
4. **`playground-scene.ts` `loadMeshes`** calls `clearModel()` → `clearEntityRecords()` before every build, so the registry never holds two models' records at once.

Worth adding: the app's real federation path (`FederationRegistry`, `useIfcFederation`, `modelSlice`) lives in the main viewer, which `components/mcp/` imports nothing from — and it assigns each model a unique **expressId offset** precisely so ids do not collide. So the premise "two entities sharing a number" would not hold on that path either without also bypassing the offset.

## What this PR does instead

Option 2 from the issue — the narrower guarantee — because it is the honest contract. Lock 4 above was the only implicit one: an `EntityRegistry` that gains a second model breaks every bare key at once (`byExpressId`, `countEntities`, `colorByProperty`'s `byEntity`, `byType`, `byStorey`), and nothing said so.

- `EntityRegistry` carries `modelId: string | null` — the model it holds.
- `clearEntityRecords` releases it, so the one multi-model sequence the playground really performs (swap samples) still works.
- `buildEntityRecords` throws when handed a second model's meshes for a populated registry, before indexing anything, naming #2471 in the message.

A future additive `loadMeshes` now fails loudly instead of silently merging two models' entities into one bucket. Threading a qualified identity through every lookup remains the right fix the day the playground genuinely federates; today it would qualify code paths that provably only ever see one model.

## Every bare-`expressId` site in `components/mcp/`

All of them are model-unqualified, and all are sound only under the precondition this PR enforces:

| Site | What keys on the bare id |
| --- | --- |
| `playground-scene-registry.ts:55` | `byExpressId: Map<number, EntityRecord[]>` |
| `playground-scene-registry.ts:~96` | `countEntities` — `seen.add(r.expressId)` (#2452) |
| `playground-scene-registry.ts:~156` | `selectTargets` — `byExpressId.get(id)` |
| `playground-scene-registry.ts:~297` | `index(byExpressId, md.expressId, rec)` |
| `playground-scene-ops.ts:133-141` | `colorByProperty`'s `byEntity` map + its `sample(expressId)` lookup |
| `playground-scene.ts:149` | selection highlight — `registry.byExpressId.get(rec.expressId)` |
| `playground-scene.ts:152` | the reported `SelectionHit.expressId` |
| `playground-scene-registry.ts:~244` | `model.store.entityIndex.byId.has(md.expressId)` — already model-scoped by its argument |

`byGlobalId` / `byType` / `byStorey` share the same unqualified shape; `byType` and `byStorey` would merge across models too.

## Verification

`npx turbo typecheck --force` — 36 successful, 36 total, **0 cached**.
`npx turbo test --force` — 86 successful, 86 total, **0 cached**; `@ifc-lite/viewer` `# tests 3397 / # pass 3391 / # fail 0 / # skipped 6`, and zero `not ok` lines repo-wide.

Mutation evidence, leaf counts only (baseline 24 tests / 0 fail in the file):

| Mutation | Leaf failures | Which |
| --- | --- | --- |
| guard disabled (`if (false && …)`) | **2** | "refuses to build a second model…", "leaves the first model untouched…" |
| `clearEntityRecords` stops releasing `modelId` | **1** | "releases the model identity on clear…" |
| guard moved to *after* the indexing loop | **1** | "leaves the first model untouched…" (test 1 still passes — proves test 2 is not redundant) |

Each restore verified with `git status --porcelain` empty.

Typecheck coverage checked rather than assumed: a deliberate `const x: number = "s"` appended to the test file was reported by `apps/viewer`'s `tsc --noEmit` (`playground-scene-registry.test.ts(484,7): error TS2322`), then removed.

`apps/viewer` is `"private": true`, so no changeset.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented scene data from combining entities belonging to different loaded models.
  * Improved handling of model reloads and similarly named files to avoid identifier conflicts.
  * Ensured failed scene updates leave existing registry data unchanged.
  * Supports safely replacing a model after the previous scene data has been cleared.
* **Tests**
  * Added coverage for model validation, reload scenarios, identifier collisions, additive updates, and registry state preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->