### PR TITLE
refactor(renderer): split the camera module family along its subject seams

### DIFF
--- a/.changeset/camera-module-split.md
+++ b/.changeset/camera-module-split.md
@@ -2,4 +2,13 @@
 "@ifc-lite/renderer": patch
 ---
 
-Split the camera module family along its subject seams. `camera-animation.ts` gave up free framing (`camera-framing.ts`, pure pose pickers), the ViewCube's preset directions (`camera-preset-view.ts`) and first-person navigation (`camera-first-person.ts`); `camera.ts` gave up matrix derivation (`camera-matrices.ts`); the shared `CameraInternalState`/`ProjectionMode` types moved out of `camera-controls.ts` into `camera-state.ts`. Internal reorganisation only — no public API or behaviour change.
+Split the camera module family along its subject seams. `camera-animation.ts` gave up free framing (`camera-framing.ts`, pure pose pickers), the ViewCube's preset directions (`camera-preset-view.ts`) and first-person navigation (`camera-first-person.ts`); `camera.ts` gave up matrix derivation (`camera-matrices.ts`); the shared `CameraInternalState`/`ProjectionMode` types moved out of `camera-controls.ts` into `camera-state.ts`. No public API change.
+
+The split surfaced six pre-existing defects in the code it moved, all fixed here:
+
+- `enableFirstPersonMode` now actually gates `moveFirstPerson`. The flag was written and never read, so an embedder driving `moveFirstPerson` walked the camera whether or not walk mode had been entered. Leaving walk mode, and `Camera.reset()`, now also drop the accumulated walk velocity so it cannot be spent as a lurch on the next model.
+- Fit distances (`frameBounds`, `zoomExtent`, `setPresetView`) honour the horizontal field of view. On a portrait viewport (`aspect < 1`) the horizontal field is the narrower one, and a fit derived from the vertical field alone clipped the box it was asked to frame. Landscape viewports are bit-for-bit unchanged.
+- `zoomExtent` on a degenerate box (`max === min` — a flat wall, a single point) no longer puts the camera on its own target.
+- The orthographic near/far derivation brackets the scene when position and target coincide, instead of centring a range on the camera and clipping the model away.
+- The orthographic projection backstop rejects a zero or negative half-height, not only a non-finite one.
+- A non-finite `buildingRotation`, or a rotation-cycle index outside 0-3, no longer produces a non-finite preset pose.

--- a/.changeset/camera-module-split.md
+++ b/.changeset/camera-module-split.md
@@ -2,4 +2,4 @@
 "@ifc-lite/renderer": patch
 ---
 
-Split the camera module family along its subject seams. `camera-animation.ts` gave up framing (`camera-framing.ts`, pure pose pickers) and first-person navigation (`camera-first-person.ts`); `camera.ts` gave up matrix derivation (`camera-matrices.ts`); the shared `CameraInternalState`/`ProjectionMode` types moved out of `camera-controls.ts` into `camera-state.ts`. Internal reorganisation only — no public API or behaviour change.
+Split the camera module family along its subject seams. `camera-animation.ts` gave up free framing (`camera-framing.ts`, pure pose pickers), the ViewCube's preset directions (`camera-preset-view.ts`) and first-person navigation (`camera-first-person.ts`); `camera.ts` gave up matrix derivation (`camera-matrices.ts`); the shared `CameraInternalState`/`ProjectionMode` types moved out of `camera-controls.ts` into `camera-state.ts`. Internal reorganisation only — no public API or behaviour change.

--- a/.changeset/camera-module-split.md
+++ b/.changeset/camera-module-split.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/renderer": patch
+---
+
+Split the camera module family along its subject seams. `camera-animation.ts` gave up framing (`camera-framing.ts`, pure pose pickers) and first-person navigation (`camera-first-person.ts`); `camera.ts` gave up matrix derivation (`camera-matrices.ts`); the shared `CameraInternalState`/`ProjectionMode` types moved out of `camera-controls.ts` into `camera-state.ts`. Internal reorganisation only — no public API or behaviour change.

--- a/apps/viewer/src/components/viewer/Viewport.tsx
+++ b/apps/viewer/src/components/viewer/Viewport.tsx
@@ -610,7 +610,14 @@ export function Viewport({
     canvasHeight: number;
   } | null>(null);
 
-  // activeTool has a side effect (first-person mode), so keep as useEffect
+  // activeTool has a side effect (first-person mode), so keep as useEffect.
+  //
+  // isInitialized is a dependency, not decoration: the camera now *refuses* to
+  // walk while first-person mode is off, so this is the only thing that turns
+  // walking on. Without the dep, selecting the walk tool before the renderer
+  // mounts would leave the flag unset with no later effect run to correct it,
+  // and walk mode would be silently dead for the session. Same reasoning as
+  // the clash-focus effect above.
   useEffect(() => {
     activeToolRef.current = activeTool;
     const renderer = rendererRef.current;
@@ -619,7 +626,7 @@ export function Viewport({
       firstPersonModeRef.current = isWalk;
       renderer.getCamera().enableFirstPersonMode(isWalk);
     }
-  }, [activeTool]);
+  }, [activeTool, isInitialized]);
   useEffect(() => {
     if (!hoverTooltipsEnabled) {
       clearHover();

--- a/packages/renderer/src/camera-animation.ts
+++ b/packages/renderer/src/camera-animation.ts
@@ -4,7 +4,8 @@
 
 /**
  * Camera animation system handling tweened transitions and inertia/momentum,
- * plus the thin wrappers that apply a pose picked by `camera-framing.ts`.
+ * plus the thin wrappers that apply a pose picked by `camera-framing.ts` (free
+ * framing) or `camera-preset-view.ts` (the ViewCube's named directions).
  * Extracted from Camera class using composition pattern.
  *
  * The tween's own failure story is the NaN *latch*: `velocity` accumulates in
@@ -23,11 +24,10 @@ import type { CameraProjection } from './camera-projection.js';
 import {
   frameBoundsTarget,
   framePointTarget,
-  presetViewTarget,
-  resolvePresetBounds,
   zoomExtentTarget,
   type FramingBounds,
 } from './camera-framing.js';
+import { presetViewTarget, resolvePresetBounds } from './camera-preset-view.js';
 
 /**
  * Manages camera animations: tweened transitions between positions,

--- a/packages/renderer/src/camera-animation.ts
+++ b/packages/renderer/src/camera-animation.ts
@@ -3,21 +3,36 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
- * Camera animation system handling tweened transitions, inertia/momentum,
- * preset views, and first-person mode.
+ * Camera animation system handling tweened transitions and inertia/momentum,
+ * plus the thin wrappers that apply a pose picked by `camera-framing.ts`.
  * Extracted from Camera class using composition pattern.
+ *
+ * The tween's own failure story is the NaN *latch*: `velocity` accumulates in
+ * place and the loop spends a channel only while `Math.abs(v) > minVelocity`,
+ * which is false for NaN forever, so one non-finite gesture delta kills that
+ * channel for the session rather than for a frame (#2441/#2473). Framing's
+ * failure story is a different input class entirely and lives in
+ * `camera-framing.ts` with the guards that reject it.
  */
 
 import type { Vec3 } from './types.js';
-import { areFiniteNumbers, isUsableBounds, isUsableDistance, usableOrthoSize } from './camera-guards.js';
-import type { CameraInternalState } from './camera-controls.js';
+import { areFiniteNumbers, usableOrthoSize } from './camera-guards.js';
+import type { CameraInternalState } from './camera-state.js';
 import type { CameraControls } from './camera-controls.js';
 import type { CameraProjection } from './camera-projection.js';
+import {
+  frameBoundsTarget,
+  framePointTarget,
+  presetViewTarget,
+  resolvePresetBounds,
+  zoomExtentTarget,
+  type FramingBounds,
+} from './camera-framing.js';
 
 /**
  * Manages camera animations: tweened transitions between positions,
- * inertia/momentum after user interaction, preset view switching
- * with rotation cycling, and first-person movement.
+ * inertia/momentum after user interaction, and preset view switching
+ * with rotation cycling.
  */
 export class CameraAnimator {
   // Inertia system
@@ -37,10 +52,6 @@ export class CameraAnimator {
   private animationStartOrthoSize: number | null = null;
   private animationEndOrthoSize: number | null = null;
   private animationEasing: ((t: number) => number) | null = null;
-
-  // First-person mode
-  private isFirstPersonMode = false;
-  private walkVelocity = { x: 0, z: 0 };
 
   // Track preset view for rotation cycling (clicking same view rotates 90 degrees)
   private lastPresetView: string | null = null;
@@ -115,7 +126,7 @@ export class CameraAnimator {
 
         // Interpolate orthoSize if animating orthographic zoom.
         // The animator is the second writer that bypasses `Camera.setOrthoSize`
-        // (#2461): the read-site backstop in `updateMatrices` keeps the
+        // (#2461): the read-site backstop in `updateCameraMatrices` keeps the
         // projection matrix finite but not the state, and `getOrthoSize()`
         // reads the state — which is what a saved viewpoint persists. Keep the
         // previous half-height when the interpolation yields nothing usable.
@@ -205,32 +216,23 @@ export class CameraAnimator {
     return isAnimating;
   }
 
+  // --- Framing (pose picked in `camera-framing.ts`, applied by the tween) ---
+  //
+  // These wrappers exist on the animator because they must return the tween's
+  // promise, and the promise machinery *is* tween state. They null-check the
+  // picked target and do nothing else — in particular they do NOT re-validate
+  // the input. Each framing input is guarded exactly once, in the pure module;
+  // a second copy here would leave neither copy load-bearing, so a reverted
+  // guard would still look green.
+
   /**
    * Frame/center view on a point (keeps current distance and direction)
    * Standard CAD "Frame Selection" behavior
    */
   async framePoint(point: Vec3, duration = 300): Promise<void> {
-    // The point is added to the current offset and animated into both
-    // `position` and `target`, so a non-finite one destroys the pose. It is
-    // externally derived: `zoomToTopic` frames a BCF marker position, which is
-    // computed from a file-supplied viewpoint direction (#2461/#2466).
-    if (!areFiniteNumbers(point.x, point.y, point.z)) return;
-
-    // Keep current viewing direction and distance
-    const dir = {
-      x: this.state.camera.position.x - this.state.camera.target.x,
-      y: this.state.camera.position.y - this.state.camera.target.y,
-      z: this.state.camera.position.z - this.state.camera.target.z,
-    };
-
-    // New position: point + current offset
-    const endPos = {
-      x: point.x + dir.x,
-      y: point.y + dir.y,
-      z: point.z + dir.z,
-    };
-
-    return this.animateTo(endPos, point, duration);
+    const fit = framePointTarget(this.state, point);
+    if (!fit) return;
+    return this.animateTo(fit.position, fit.target, duration, fit.orthoSize);
   }
 
   /**
@@ -238,154 +240,44 @@ export class CameraAnimator {
    * This is what "Frame Selection" should do - zoom to fill screen
    */
   async frameBounds(min: Vec3, max: Vec3, duration = 300): Promise<void> {
-    // Bounds are the upstream input #2450 stopped short of (#2461). They are
-    // not caller-authored constants: they come from geometry, and every AABB
-    // accumulator in this package starts from `min = +Infinity, max =
-    // -Infinity` and only narrows on a comparison — which is false for a
-    // non-finite vertex — so a mesh with no finite vertices hands out that
-    // inverted sentinel as if it were a real box. `Math.max` picking the
-    // largest extent is NaN-transparent, so it reaches `position`, `target`
-    // AND `orthoSize`, and `getOrthoSize()` is what a saved viewpoint persists.
-    if (!isUsableBounds(min, max)) return;
-
-    const center = {
-      x: (min.x + max.x) / 2,
-      y: (min.y + max.y) / 2,
-      z: (min.z + max.z) / 2,
-    };
-    const size = {
-      x: max.x - min.x,
-      y: max.y - min.y,
-      z: max.z - min.z,
-    };
-    const maxSize = Math.max(size.x, size.y, size.z);
-
-    if (maxSize < 1e-6) {
-      // Very small or zero size - just center on it
-      return this.framePoint(center, duration);
-    }
-
-    // Calculate required distance based on FOV to fit bounds
-    const fovFactor = Math.tan(this.state.camera.fov / 2);
-    const distance = (maxSize / 2) / fovFactor * 1.2; // 1.2x padding for nice framing
-
-    // Get current viewing direction from view matrix (more reliable than position-target)
-    // View matrix forward is -Z axis in view space
-    const viewMatrix = this.state.viewMatrix.m;
-    // Extract forward direction from view matrix (negative Z column, normalized)
-    let dir = {
-      x: -viewMatrix[8],   // -m[2][0] (forward X)
-      y: -viewMatrix[9],   // -m[2][1] (forward Y)
-      z: -viewMatrix[10],  // -m[2][2] (forward Z)
-    };
-    const dirLen = Math.sqrt(dir.x * dir.x + dir.y * dir.y + dir.z * dir.z);
-
-    // Normalize direction
-    if (dirLen > 1e-6) {
-      dir.x /= dirLen;
-      dir.y /= dirLen;
-      dir.z /= dirLen;
-    } else {
-      // Fallback: use position-target if view matrix is invalid
-      dir = {
-        x: this.state.camera.position.x - this.state.camera.target.x,
-        y: this.state.camera.position.y - this.state.camera.target.y,
-        z: this.state.camera.position.z - this.state.camera.target.z,
-      };
-      const fallbackLen = Math.sqrt(dir.x * dir.x + dir.y * dir.y + dir.z * dir.z);
-      if (fallbackLen > 1e-6) {
-        dir.x /= fallbackLen;
-        dir.y /= fallbackLen;
-        dir.z /= fallbackLen;
-      } else {
-        // Last resort: southeast isometric
-        dir.x = 0.6;
-        dir.y = 0.5;
-        dir.z = 0.6;
-        const len = Math.sqrt(dir.x * dir.x + dir.y * dir.y + dir.z * dir.z);
-        dir.x /= len;
-        dir.y /= len;
-        dir.z /= len;
-      }
-    }
-
-    // New position: center + direction * distance
-    const endPos = {
-      x: center.x + dir.x * distance,
-      y: center.y + dir.y * distance,
-      z: center.z + dir.z * distance,
-    };
-
-    // Calculate orthoSize for orthographic mode so zoom level resets properly
-    const aspect = this.state.camera.aspect || 1;
-    const endOrthoSize = this.state.projectionMode === 'orthographic'
-      ? Math.max(0.01, maxSize / 2, maxSize / 2 / aspect) * 1.2
-      : undefined;
-
-    return this.animateTo(endPos, center, duration, endOrthoSize);
+    const fit = frameBoundsTarget(this.state, min, max);
+    if (!fit) return;
+    return this.animateTo(fit.position, fit.target, duration, fit.orthoSize);
   }
 
   async zoomExtent(min: Vec3, max: Vec3, duration = 300): Promise<void> {
-    // Same input class and same reasoning as `frameBounds` (#2461).
-    if (!isUsableBounds(min, max)) return;
-
-    const center = {
-      x: (min.x + max.x) / 2,
-      y: (min.y + max.y) / 2,
-      z: (min.z + max.z) / 2,
-    };
-    const size = {
-      x: max.x - min.x,
-      y: max.y - min.y,
-      z: max.z - min.z,
-    };
-    const maxSize = Math.max(size.x, size.y, size.z);
-
-    // Calculate required distance based on FOV
-    const fovFactor = Math.tan(this.state.camera.fov / 2);
-    const distance = (maxSize / 2) / fovFactor * 1.5; // 1.5x for padding
-
+    const fit = zoomExtentTarget(this.state, min, max);
+    if (!fit) return;
     // Update near/far planes dynamically
-    this.projection.updateNearFarPlanes(distance);
+    this.projection.updateNearFarPlanes(fit.fitDistance);
+    return this.animateTo(fit.position, fit.target, duration, fit.orthoSize);
+  }
 
-    // Keep current viewing direction
-    const dir = {
-      x: this.state.camera.position.x - this.state.camera.target.x,
-      y: this.state.camera.position.y - this.state.camera.target.y,
-      z: this.state.camera.position.z - this.state.camera.target.z,
-    };
-    const currentDistance = Math.sqrt(dir.x * dir.x + dir.y * dir.y + dir.z * dir.z);
+  /**
+   * Set preset view with explicit bounds (Y-up coordinate system)
+   * Clicking the same view again rotates 90 degrees around the view axis
+   * @param buildingRotation Optional building rotation in radians (from IfcSite placement)
+   */
+  setPresetView(
+    view: 'top' | 'bottom' | 'front' | 'back' | 'left' | 'right',
+    bounds?: FramingBounds,
+    buildingRotation?: number
+  ): void {
+    // Resolved and validated before the rotation cycles, so a rejected preset
+    // leaves the ViewCube's cycle position where it was.
+    const useBounds = resolvePresetBounds(this.state, bounds);
+    if (!useBounds) return;
 
-    // Normalize direction
-    if (currentDistance > 1e-10) {
-      dir.x /= currentDistance;
-      dir.y /= currentDistance;
-      dir.z /= currentDistance;
+    // Check if clicking the same view again - cycle rotation
+    if (this.lastPresetView === view) {
+      this.presetViewRotation = (this.presetViewRotation + 1) % 4;
     } else {
-      // Fallback direction
-      dir.x = 0.6;
-      dir.y = 0.5;
-      dir.z = 0.6;
-      const len = Math.sqrt(dir.x * dir.x + dir.y * dir.y + dir.z * dir.z);
-      dir.x /= len;
-      dir.y /= len;
-      dir.z /= len;
+      this.lastPresetView = view;
+      this.presetViewRotation = 0;
     }
 
-    // New position: center + direction * distance
-    const endPos = {
-      x: center.x + dir.x * distance,
-      y: center.y + dir.y * distance,
-      z: center.z + dir.z * distance,
-    };
-
-    // Calculate orthoSize for orthographic mode so zoom level resets properly
-    const aspect = this.state.camera.aspect || 1;
-    const endOrthoSize = this.state.projectionMode === 'orthographic'
-      ? Math.max(0.01, maxSize / 2, maxSize / 2 / aspect) * 1.5
-      : undefined;
-
-    return this.animateTo(endPos, center, duration, endOrthoSize);
+    const fit = presetViewTarget(this.state, view, useBounds, this.presetViewRotation, buildingRotation);
+    this.animateToWithUp(fit.position, fit.target, fit.up, 300);
   }
 
   /**
@@ -463,278 +355,6 @@ export class CameraAnimator {
    */
   private easeOutCubic(t: number): number {
     return 1 - Math.pow(1 - t, 3);
-  }
-
-  /**
-   * Set first-person mode
-   */
-  enableFirstPersonMode(enabled: boolean): void {
-    this.isFirstPersonMode = enabled;
-  }
-
-  /**
-   * Walk on the horizontal XZ plane (Y-up coordinate system).
-   * Forward/backward moves in the camera's horizontal facing direction.
-   * Left/right strafes perpendicular. Y position stays fixed (walking on ground).
-   * Speed scales with scene size. Movement uses smooth acceleration to avoid
-   * abrupt jumps — velocity ramps up over successive frames.
-   */
-  moveFirstPerson(forward: number, right: number, _up: number): void {
-    // Argument-side guard (#2473). `walkVelocity` is accumulated in place, so
-    // a non-finite axis latches first-person movement dead for the session
-    // exactly the way a non-finite pose did (#2441) — and it does not need an
-    // exotic value: both `moveFirstPerson(NaN, 0, 0)` and
-    // `moveFirstPerson(Infinity, 0, 0)` came back with a non-finite position
-    // on a finite pose. `_up` is unused, so it is deliberately not tested.
-    if (!areFiniteNumbers(forward, right)) return;
-
-    // Camera forward direction projected onto XZ plane
-    const dir = {
-      x: this.state.camera.target.x - this.state.camera.position.x,
-      z: this.state.camera.target.z - this.state.camera.position.z,
-    };
-    const horizLen = Math.sqrt(dir.x * dir.x + dir.z * dir.z);
-    // Finiteness, not just magnitude: `NaN < 1e-10` is false, so a malformed
-    // pose fell through here and `dir.x / horizLen` came back NaN. That does
-    // not merely produce one bad step — `walkVelocity` is accumulated in place
-    // (`+= (target - current) * 0.15`), so a single NaN frame latches it and
-    // first-person movement stays dead for the rest of the session even after
-    // the pose is corrected (#2441).
-    if (!isUsableDistance(horizLen, 1e-10)) return;
-
-    // Normalized horizontal forward and right vectors
-    const fwdX = dir.x / horizLen;
-    const fwdZ = dir.z / horizLen;
-    const rightX = -fwdZ;
-    const rightZ = fwdX;
-
-    // Target velocity from input (forward/right can be -2..2 with sprint)
-    const targetVelX = fwdX * forward + rightX * right;
-    const targetVelZ = fwdZ * forward + rightZ * right;
-
-    // Smooth acceleration: lerp current walk velocity toward target
-    this.walkVelocity.x += (targetVelX - this.walkVelocity.x) * 0.15;
-    this.walkVelocity.z += (targetVelZ - this.walkVelocity.z) * 0.15;
-
-    // Speed proportional to scene size (use camera-target distance as proxy)
-    const camDir = {
-      x: this.state.camera.position.x - this.state.camera.target.x,
-      y: this.state.camera.position.y - this.state.camera.target.y,
-      z: this.state.camera.position.z - this.state.camera.target.z,
-    };
-    const distance = Math.sqrt(camDir.x * camDir.x + camDir.y * camDir.y + camDir.z * camDir.z);
-    // The horizontal guard above does not cover this one: `camDir` includes Y,
-    // so a pose whose *only* bad coordinate is vertical reaches here with a
-    // finite `horizLen` and a NaN `distance`. `Math.max` is NaN-transparent —
-    // `Math.max(0.02, NaN)` is `NaN`, not the floor — so the clamp would
-    // forward it into the offsets written back to position and target.
-    if (!isUsableDistance(distance, 0)) return;
-    const speed = Math.max(0.02, distance * 0.004);
-
-    // Apply smoothed velocity
-    const offsetX = this.walkVelocity.x * speed;
-    const offsetZ = this.walkVelocity.z * speed;
-
-    // Move both position and target by the same offset (preserves view direction)
-    this.state.camera.position.x += offsetX;
-    this.state.camera.position.z += offsetZ;
-    this.state.camera.target.x += offsetX;
-    this.state.camera.target.z += offsetZ;
-
-    this.updateMatrices();
-  }
-
-  /**
-   * Set preset view with explicit bounds (Y-up coordinate system)
-   * Clicking the same view again rotates 90 degrees around the view axis
-   * @param buildingRotation Optional building rotation in radians (from IfcSite placement)
-   */
-  setPresetView(
-    view: 'top' | 'bottom' | 'front' | 'back' | 'left' | 'right',
-    bounds?: { min: Vec3; max: Vec3 },
-    buildingRotation?: number
-  ): void {
-    const useBounds = bounds || this.getCurrentBounds();
-    if (!useBounds) {
-      console.warn('[Camera] No bounds available for setPresetView');
-      return;
-    }
-    // Both sources need the check, not just the caller's: `getCurrentBounds()`
-    // derives its box from the live pose, so a pose that is already malformed
-    // produces a malformed box and the ViewCube would then bake it in
-    // permanently. Rejecting leaves the preset un-applied, which keeps a
-    // recoverable pose recoverable (#2461).
-    if (!isUsableBounds(useBounds.min, useBounds.max)) {
-      console.warn('[Camera] Non-finite bounds for setPresetView; keeping current view');
-      return;
-    }
-
-    // Check if clicking the same view again - cycle rotation
-    if (this.lastPresetView === view) {
-      this.presetViewRotation = (this.presetViewRotation + 1) % 4;
-    } else {
-      this.lastPresetView = view;
-      this.presetViewRotation = 0;
-    }
-
-    const center = {
-      x: (useBounds.min.x + useBounds.max.x) / 2,
-      y: (useBounds.min.y + useBounds.max.y) / 2,
-      z: (useBounds.min.z + useBounds.max.z) / 2,
-    };
-    const size = {
-      x: useBounds.max.x - useBounds.min.x,
-      y: useBounds.max.y - useBounds.min.y,
-      z: useBounds.max.z - useBounds.min.z,
-    };
-    const maxSize = Math.max(size.x, size.y, size.z);
-
-    // Calculate distance based on FOV for proper fit
-    const fovFactor = Math.tan(this.state.camera.fov / 2);
-    const distance = (maxSize / 2) / fovFactor * 1.5; // 1.5x for padding
-
-    let endPos: Vec3;
-    const endTarget = center;
-
-    // WebGL uses Y-up coordinate system internally
-    // We set both position AND up vector for proper orthogonal views
-    let upVector: Vec3 = { x: 0, y: 1, z: 0 }; // Default Y-up
-
-    // Up vector rotation options for top/bottom views (rotate around Y axis)
-    // 0: -Z, 1: -X, 2: +Z, 3: +X
-    const topUpVectors: Vec3[] = [
-      { x: 0, y: 0, z: -1 },  // 0 degrees - North up
-      { x: -1, y: 0, z: 0 },  // 90 degrees - West up
-      { x: 0, y: 0, z: 1 },   // 180 degrees - South up
-      { x: 1, y: 0, z: 0 },   // 270 degrees - East up
-    ];
-    const bottomUpVectors: Vec3[] = [
-      { x: 0, y: 0, z: 1 },   // 0 degrees - South up
-      { x: 1, y: 0, z: 0 },   // 90 degrees - East up
-      { x: 0, y: 0, z: -1 },  // 180 degrees - North up
-      { x: -1, y: 0, z: 0 },  // 270 degrees - West up
-    ];
-
-    // Apply building rotation if present (rotate around Y axis)
-    const cosR = buildingRotation !== undefined && buildingRotation !== 0 ? Math.cos(buildingRotation) : 1.0;
-    const sinR = buildingRotation !== undefined && buildingRotation !== 0 ? Math.sin(buildingRotation) : 0.0;
-
-    switch (view) {
-      case 'top': {
-        // Top view: position camera *just barely* off the +Y pole so the
-        // subsequent orbit math has a well-defined polar tangent (no pole
-        // singularity). camera.up stays world Y throughout — screen-up is
-        // then determined by lookAt projecting (0,1,0) onto perp(look),
-        // which falls along the horizontal component of `-look`.
-        //
-        // The 4 rotation cycles select which compass direction appears at
-        // the top of the screen by varying the small horizontal offset
-        // (theta in the spherical math).
-        //   rotation 0 → camera slightly to +Z of center → screen-up = +Z
-        //   rotation 1 → camera slightly to +X → screen-up = +X
-        //   rotation 2 → camera slightly to -Z → screen-up = -Z
-        //   rotation 3 → camera slightly to -X → screen-up = -X
-        // Building rotation is applied as the same Y-axis rotation that
-        // setPresetView would have used to remap the legacy up vector.
-        const poleOffset = Math.sin(0.01) * distance; // ~0.6° tilt
-        const verticalOffset = Math.cos(0.01) * distance;
-        const thetaPerRotation = [0, Math.PI / 2, Math.PI, -Math.PI / 2];
-        const thetaWorld = thetaPerRotation[this.presetViewRotation] + (buildingRotation ?? 0);
-        endPos = {
-          x: center.x + poleOffset * Math.sin(thetaWorld),
-          y: center.y + verticalOffset,
-          z: center.z + poleOffset * Math.cos(thetaWorld),
-        };
-        upVector = { x: 0, y: 1, z: 0 };
-        break;
-      }
-      case 'bottom': {
-        // Bottom view: mirror of top — phi = π − MIN_PHI.
-        const poleOffset = Math.sin(0.01) * distance;
-        const verticalOffset = Math.cos(0.01) * distance;
-        const thetaPerRotation = [Math.PI, Math.PI / 2, 0, -Math.PI / 2];
-        const thetaWorld = thetaPerRotation[this.presetViewRotation] + (buildingRotation ?? 0);
-        endPos = {
-          x: center.x + poleOffset * Math.sin(thetaWorld),
-          y: center.y - verticalOffset,
-          z: center.z + poleOffset * Math.cos(thetaWorld),
-        };
-        upVector = { x: 0, y: 1, z: 0 };
-        break;
-      }
-      case 'front':
-        // Front view: from +Z looking at model
-        // Rotate camera position around Y axis by building rotation
-        // Standard rotation: x' = x*cos - z*sin, z' = x*sin + z*cos
-        // For +Z direction (0,0,1): x' = -sin, z' = cos
-        // But we need to look at building's front, so use negative rotation
-        endPos = {
-          x: center.x + sinR * distance,
-          y: center.y,
-          z: center.z + cosR * distance,
-        };
-        upVector = { x: 0, y: 1, z: 0 }; // Y-up
-        break;
-      case 'back':
-        // Back view: from -Z looking at model
-        // For -Z direction (0,0,-1) rotated: x' = sin, z' = -cos
-        endPos = {
-          x: center.x - sinR * distance,
-          y: center.y,
-          z: center.z - cosR * distance,
-        };
-        upVector = { x: 0, y: 1, z: 0 }; // Y-up
-        break;
-      case 'left':
-        // Left view: from -X looking at model
-        // For -X direction (-1,0,0) rotated: x' = -cos, z' = sin
-        endPos = {
-          x: center.x - cosR * distance,
-          y: center.y,
-          z: center.z + sinR * distance,
-        };
-        upVector = { x: 0, y: 1, z: 0 }; // Y-up
-        break;
-      case 'right':
-        // Right view: from +X looking at model
-        // For +X direction (1,0,0) rotated: x' = cos, z' = -sin
-        endPos = {
-          x: center.x + cosR * distance,
-          y: center.y,
-          z: center.z - sinR * distance,
-        };
-        upVector = { x: 0, y: 1, z: 0 }; // Y-up
-        break;
-    }
-
-    this.animateToWithUp(endPos, endTarget, upVector, 300);
-  }
-
-  /**
-   * Get current bounds estimate (simplified - in production would use scene bounds)
-   */
-  private getCurrentBounds(): { min: Vec3; max: Vec3 } | null {
-    // Estimate bounds from camera distance
-    const dir = {
-      x: this.state.camera.position.x - this.state.camera.target.x,
-      y: this.state.camera.position.y - this.state.camera.target.y,
-      z: this.state.camera.position.z - this.state.camera.target.z,
-    };
-    const distance = Math.sqrt(dir.x * dir.x + dir.y * dir.y + dir.z * dir.z);
-    const size = distance / 2;
-
-    return {
-      min: {
-        x: this.state.camera.target.x - size,
-        y: this.state.camera.target.y - size,
-        z: this.state.camera.target.z - size,
-      },
-      max: {
-        x: this.state.camera.target.x + size,
-        y: this.state.camera.target.y + size,
-        z: this.state.camera.target.z + size,
-      },
-    };
   }
 
   /**

--- a/packages/renderer/src/camera-controls.test.ts
+++ b/packages/renderer/src/camera-controls.test.ts
@@ -6,7 +6,8 @@ import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert';
 
 import type { Vec3, Camera, Mat4 } from './types.js';
-import { CameraControls, type CameraInternalState } from './camera-controls.js';
+import { CameraControls } from './camera-controls.js';
+import type { CameraInternalState } from './camera-state.js';
 import { CAMERA_CONSTANTS as CC } from './constants.js';
 
 // ---------------------------------------------------------------------------

--- a/packages/renderer/src/camera-controls.ts
+++ b/packages/renderer/src/camera-controls.ts
@@ -14,8 +14,9 @@
  *   Approach mirrors Blender's turntable: Y-axis horizontal + right-axis vertical.
  */
 
-import type { Camera as CameraType, Vec3, Mat4 } from './types.js';
+import type { Vec3 } from './types.js';
 import { CAMERA_CONSTANTS as CC } from './constants.js';
+import type { CameraInternalState } from './camera-state.js';
 import {
   areFiniteNumbers,
   isUsableCursorAnchor,
@@ -23,35 +24,6 @@ import {
   isUsableUp,
   usableOrthoSize,
 } from './camera-guards.js';
-
-/** Projection mode for the camera */
-export type ProjectionMode = 'perspective' | 'orthographic';
-
-/**
- * Shared mutable state for camera sub-systems.
- * All sub-systems reference the same state object so changes are visible across them.
- */
-export interface CameraInternalState {
-  camera: CameraType;
-  viewMatrix: Mat4;
-  projMatrix: Mat4;
-  viewProjMatrix: Mat4;
-  /** Current projection mode */
-  projectionMode: ProjectionMode;
-  /** Orthographic half-height in world units (controls zoom level in ortho mode) */
-  orthoSize: number;
-  /** Scene bounding box for tight orthographic near/far computation */
-  sceneBounds: { min: { x: number; y: number; z: number }; max: { x: number; y: number; z: number } } | null;
-  /**
-   * Optional outlier-robust bounds for anchoring the orbit pivot (issue #1394).
-   * Distinct from `sceneBounds`: the renderer keeps `sceneBounds` synced to the
-   * FULL model AABB (needed for near/far clipping and section ranges), but a
-   * handful of far-flung meshes can push that AABB's centre into empty space,
-   * which the orbit-pivot fallback would then rotate around. When set, the pivot
-   * uses this tighter centre instead. `null` ⇒ fall back to `sceneBounds`.
-   */
-  orbitAnchorBounds: { min: { x: number; y: number; z: number }; max: { x: number; y: number; z: number } } | null;
-}
 
 // ---------------------------------------------------------------------------
 // Tiny vec3 helpers (inline, no allocations beyond the return object)

--- a/packages/renderer/src/camera-degenerate-pose-matrix.test.ts
+++ b/packages/renderer/src/camera-degenerate-pose-matrix.test.ts
@@ -30,6 +30,8 @@ import assert from 'node:assert';
 import { Camera } from './camera.js';
 import { MathUtils } from './math.js';
 import { pickFitPolicy } from './camera-fit-policy.js';
+import { computeOrthoNearFar, updateCameraMatrices } from './camera-matrices.js';
+import type { CameraInternalState } from './camera-state.js';
 import type { Mat4, Vec3 } from './types.js';
 
 const FOV_45 = (45 * Math.PI) / 180;
@@ -42,6 +44,32 @@ function assertAllFinite(matrix: Mat4, label: string): void {
     -1,
     `${label}: component ${bad} is ${values[bad]} (matrix ${JSON.stringify(values)})`,
   );
+}
+
+/**
+ * An orthographic camera state built by hand, for the read-site backstops in
+ * `camera-matrices.ts` that no public writer can reach — every public writer
+ * clamps first, which is exactly why the backstop needs its own coverage.
+ */
+function makeOrthoState(orthoSize: number): CameraInternalState {
+  return {
+    camera: {
+      position: { x: 0, y: 0, z: 100 },
+      target: { x: 0, y: 0, z: 0 },
+      up: { x: 0, y: 1, z: 0 },
+      fov: FOV_45,
+      aspect: 16 / 9,
+      near: 0.1,
+      far: 10000,
+    },
+    viewMatrix: MathUtils.identity(),
+    projMatrix: MathUtils.identity(),
+    viewProjMatrix: MathUtils.identity(),
+    projectionMode: 'orthographic',
+    orthoSize,
+    sceneBounds: null,
+    orbitAnchorBounds: null,
+  };
 }
 
 /**
@@ -509,6 +537,74 @@ describe('degenerate projection inputs (#2441)', () => {
     // The finite path, clamp included.
     camera.setFOV(FOV_45);
     assert.ok(Math.abs(camera.getFOV() - FOV_45) < 1e-12, 'a valid fov should still be stored');
+  });
+
+  it('the orthographic backstop rejects a zero or negative half-height, not just a NaN', () => {
+    // The read-site backstop in `updateCameraMatrices` keyed on
+    // `Number.isFinite` alone, and `Number.isFinite(0)` is true. A zero — or
+    // negative — half-height makes `right - left` and `top - bottom` zero, so
+    // `orthographicReverseZ` divides by zero and the matrix comes back with
+    // `Infinity` scale terms: the same dead viewport as a NaN, reached through
+    // a *valid-but-falsy* value rather than an exotic one.
+    //
+    // Driven through the state object because every public writer clamps
+    // already — this is the backstop's own contract, which exists precisely
+    // for the writers that do not go through `setOrthoSize` (#2500).
+    for (const bad of [0, -25]) {
+      const state = makeOrthoState(bad);
+      updateCameraMatrices(state);
+      assertAllFinite(state.projMatrix, `orthographic half-height ${bad}`);
+      assertAllFinite(state.viewProjMatrix, `orthographic half-height ${bad} (view-proj)`);
+    }
+
+    // Anti-mutation: a real half-height is still used verbatim, so the
+    // backstop cannot have been widened into "always use the default".
+    const good = makeOrthoState(25);
+    updateCameraMatrices(good);
+    const substituted = makeOrthoState(50);
+    updateCameraMatrices(substituted);
+    assert.notDeepStrictEqual(
+      Array.from(good.projMatrix.m),
+      Array.from(substituted.projMatrix.m),
+      'a usable half-height must still drive the projection',
+    );
+  });
+
+  it('the orthographic near/far still bracket the scene when position and target coincide', () => {
+    // `vLen > 1e-8` skipped the normalization but kept going, so `v` stayed at
+    // its raw near-zero value, `toCenter` collapsed to ~0, and the range came
+    // out centred on the *camera* instead of the scene. A camera parked 1000
+    // units from the model therefore got a range that excluded the model
+    // entirely — a blank viewport reached through near/far values that are
+    // perfectly finite, so the non-finite backstop never fired (#2500).
+    const state = makeOrthoState(50);
+    state.camera.position = { x: 0, y: 0, z: 1000 };
+    state.camera.target = { x: 0, y: 0, z: 1000 };
+    state.sceneBounds = { min: { x: -10, y: -10, z: -10 }, max: { x: 10, y: 10, z: 10 } };
+
+    const { near, far } = computeOrthoNearFar(state, 0);
+    assert.ok(Number.isFinite(near) && Number.isFinite(far), `near/far were ${near}/${far}`);
+    // The scene's bounding sphere sits at most 1000 + r from the camera along
+    // any axis, so the range has to reach that far or geometry is clipped away.
+    const radius = Math.sqrt(20 * 20 * 3) / 2;
+    const reach = 1000 + radius;
+    assert.ok(far >= reach, `far ${far} must reach the far side of the scene at ${reach}`);
+    assert.ok(near <= -reach, `near ${near} must reach the near side of the scene at ${-reach}`);
+  });
+
+  it('anti-mutation: a well-formed pose still gets the tight near/far range', () => {
+    // The degenerate branch above must not have replaced the tight fit: that
+    // range is what buys the depth precision the whole function exists for.
+    const state = makeOrthoState(50);
+    state.camera.position = { x: 0, y: 0, z: 1000 };
+    state.camera.target = { x: 0, y: 0, z: 0 };
+    state.sceneBounds = { min: { x: -10, y: -10, z: -10 }, max: { x: 10, y: 10, z: 10 } };
+
+    const { near, far } = computeOrthoNearFar(state, 1000);
+    const radius = Math.sqrt(20 * 20 * 3) / 2;
+    const pad = radius * 0.1 + 1;
+    assert.ok(Math.abs(near - (1000 - radius - pad)) < 1e-9, `tight near expected, got ${near}`);
+    assert.ok(Math.abs(far - (1000 + radius + pad)) < 1e-9, `tight far expected, got ${far}`);
   });
 
   it('setAspect survives a collapsed viewport in both projection modes', () => {

--- a/packages/renderer/src/camera-first-person.ts
+++ b/packages/renderer/src/camera-first-person.ts
@@ -1,0 +1,104 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * First-person (walk mode) navigation.
+ *
+ * An island: it shares the camera state object with the rest of the family and
+ * nothing else. It reads no tween field and writes none, and the animator
+ * never consulted `walkVelocity` — which is why the velocity lives here now,
+ * next to the only code that spends it.
+ */
+
+import type { CameraInternalState } from './camera-state.js';
+import { areFiniteNumbers, isUsableDistance } from './camera-guards.js';
+
+export class FirstPersonNavigator {
+  private isFirstPersonMode = false;
+  private walkVelocity = { x: 0, z: 0 };
+
+  constructor(
+    private readonly state: CameraInternalState,
+    private readonly updateMatrices: () => void,
+  ) {}
+
+  /**
+   * Set first-person mode
+   */
+  setEnabled(enabled: boolean): void {
+    this.isFirstPersonMode = enabled;
+  }
+
+  /**
+   * Walk on the horizontal XZ plane (Y-up coordinate system).
+   * Forward/backward moves in the camera's horizontal facing direction.
+   * Left/right strafes perpendicular. Y position stays fixed (walking on ground).
+   * Speed scales with scene size. Movement uses smooth acceleration to avoid
+   * abrupt jumps — velocity ramps up over successive frames.
+   */
+  move(forward: number, right: number, _up: number): void {
+    // Argument-side guard (#2473). `walkVelocity` is accumulated in place, so
+    // a non-finite axis latches first-person movement dead for the session
+    // exactly the way a non-finite pose did (#2441) — and it does not need an
+    // exotic value: both `moveFirstPerson(NaN, 0, 0)` and
+    // `moveFirstPerson(Infinity, 0, 0)` came back with a non-finite position
+    // on a finite pose. `_up` is unused, so it is deliberately not tested.
+    if (!areFiniteNumbers(forward, right)) return;
+
+    // Camera forward direction projected onto XZ plane
+    const dir = {
+      x: this.state.camera.target.x - this.state.camera.position.x,
+      z: this.state.camera.target.z - this.state.camera.position.z,
+    };
+    const horizLen = Math.sqrt(dir.x * dir.x + dir.z * dir.z);
+    // Finiteness, not just magnitude: `NaN < 1e-10` is false, so a malformed
+    // pose fell through here and `dir.x / horizLen` came back NaN. That does
+    // not merely produce one bad step — `walkVelocity` is accumulated in place
+    // (`+= (target - current) * 0.15`), so a single NaN frame latches it and
+    // first-person movement stays dead for the rest of the session even after
+    // the pose is corrected (#2441).
+    if (!isUsableDistance(horizLen, 1e-10)) return;
+
+    // Normalized horizontal forward and right vectors
+    const fwdX = dir.x / horizLen;
+    const fwdZ = dir.z / horizLen;
+    const rightX = -fwdZ;
+    const rightZ = fwdX;
+
+    // Target velocity from input (forward/right can be -2..2 with sprint)
+    const targetVelX = fwdX * forward + rightX * right;
+    const targetVelZ = fwdZ * forward + rightZ * right;
+
+    // Smooth acceleration: lerp current walk velocity toward target
+    this.walkVelocity.x += (targetVelX - this.walkVelocity.x) * 0.15;
+    this.walkVelocity.z += (targetVelZ - this.walkVelocity.z) * 0.15;
+
+    // Speed proportional to scene size (use camera-target distance as proxy)
+    const camDir = {
+      x: this.state.camera.position.x - this.state.camera.target.x,
+      y: this.state.camera.position.y - this.state.camera.target.y,
+      z: this.state.camera.position.z - this.state.camera.target.z,
+    };
+    const distance = Math.sqrt(camDir.x * camDir.x + camDir.y * camDir.y + camDir.z * camDir.z);
+    // The horizontal guard above does not cover this one: `camDir` includes Y,
+    // so a pose whose *only* bad coordinate is vertical reaches here with a
+    // finite `horizLen` and a NaN `distance`. `Math.max` is NaN-transparent —
+    // `Math.max(0.02, NaN)` is `NaN`, not the floor — so the clamp would
+    // forward it into the offsets written back to position and target.
+    if (!isUsableDistance(distance, 0)) return;
+    const speed = Math.max(0.02, distance * 0.004);
+
+    // Apply smoothed velocity
+    const offsetX = this.walkVelocity.x * speed;
+    const offsetZ = this.walkVelocity.z * speed;
+
+    // Move both position and target by the same offset (preserves view direction)
+    this.state.camera.position.x += offsetX;
+    this.state.camera.position.z += offsetZ;
+    this.state.camera.target.x += offsetX;
+    this.state.camera.target.z += offsetZ;
+
+    this.updateMatrices();
+  }
+}

--- a/packages/renderer/src/camera-first-person.ts
+++ b/packages/renderer/src/camera-first-person.ts
@@ -24,10 +24,38 @@ export class FirstPersonNavigator {
   ) {}
 
   /**
-   * Set first-person mode
+   * Set first-person mode.
+   *
+   * Load-bearing, not bookkeeping: {@link move} refuses to walk while this is
+   * off. The flag was write-only before the extraction — nothing ever read it,
+   * so `moveFirstPerson` moved the camera whether or not walk mode had been
+   * entered, and the only thing keeping that from being visible was the
+   * viewer's *second*, independent check on `activeTool === 'walk'`. Two
+   * unrelated gates for one decision means neither is load-bearing on its own,
+   * and the renderer is published: an embedder driving `moveFirstPerson` from
+   * its own key handler has only this one.
+   *
+   * Disabling also drops the accumulated walk velocity. It is smoothed in
+   * place (`+= (target - current) * 0.15`), so a leftover would be spent on
+   * the first frame after walk mode is re-entered — a visible lurch in
+   * whatever direction the user happened to be walking when they left.
    */
   setEnabled(enabled: boolean): void {
     this.isFirstPersonMode = enabled;
+    if (!enabled) this.stop();
+  }
+
+  /**
+   * Drop the accumulated walk velocity, keeping the mode as it is.
+   *
+   * Called on model reset. The mode itself is deliberately *not* cleared:
+   * it mirrors the viewer's active tool, which a model load does not change,
+   * and clearing it here would leave walk mode silently dead until the user
+   * toggled the tool off and back on again.
+   */
+  stop(): void {
+    this.walkVelocity.x = 0;
+    this.walkVelocity.z = 0;
   }
 
   /**
@@ -38,6 +66,10 @@ export class FirstPersonNavigator {
    * abrupt jumps — velocity ramps up over successive frames.
    */
   move(forward: number, right: number, _up: number): void {
+    // Mode gate, ahead of every other guard: walking is only a thing that
+    // exists while walk mode is on. See {@link setEnabled}.
+    if (!this.isFirstPersonMode) return;
+
     // Argument-side guard (#2473). `walkVelocity` is accumulated in place, so
     // a non-finite axis latches first-person movement dead for the session
     // exactly the way a non-finite pose did (#2441) — and it does not need an

--- a/packages/renderer/src/camera-fit-viewport-shape.test.ts
+++ b/packages/renderer/src/camera-fit-viewport-shape.test.ts
@@ -1,0 +1,298 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The fit pickers have to produce a pose that actually *shows* the box they
+ * were handed, on the viewport shape they were handed. Three ways they did
+ * not, all of them pre-existing on `origin/main` and all of them surfaced by
+ * the camera module split (PR #2500):
+ *
+ *  1. **Portrait viewports.** Every fit distance in this package was derived
+ *     from the vertical field of view alone. The horizontal half-angle is
+ *     `atan(tan(fov / 2) * aspect)`, so for `aspect < 1` the horizontal field
+ *     is the *narrower* of the two and the box overflows left and right — the
+ *     fit clips the very thing it was asked to frame. (`orthoSizeFor` had
+ *     divided by `aspect` since it was written; the perspective half of the
+ *     same rule was missing.)
+ *  2. **`zoomExtent` on a degenerate box.** `isUsableBounds` deliberately
+ *     admits `max === min`, and for such a box the fit distance is zero, so
+ *     `position` was written equal to `target` — a pose with no view direction
+ *     at all. `frameBounds` has always special-cased this; `zoomExtent` did not.
+ *  3. **A non-finite `buildingRotation`.** The IfcSite placement angle reaches
+ *     `Camera.setPresetView` — a published entry point — without ever meeting
+ *     a guard, and `Math.cos(NaN)` is NaN.
+ *
+ * Written against the pure pickers rather than the animated facades: these are
+ * assertions about the pose that was *chosen*, and routing them through a tween
+ * would only add a frame clock between the assertion and the thing it is about.
+ * The facades' own null-check contract is covered in
+ * `camera-malformed-bounds-fit.test.ts`.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import type { Vec3, Camera as CameraType, Mat4 } from './types.js';
+import type { CameraInternalState } from './camera-state.js';
+import { frameBoundsTarget, zoomExtentTarget } from './camera-framing.js';
+import { presetViewTarget } from './camera-preset-view.js';
+import { Camera } from './camera.js';
+
+const FOV = Math.PI / 4;
+
+function makeMat4(): Mat4 {
+  return { m: new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]) };
+}
+
+/**
+ * A state whose view matrix is the identity, which makes
+ * `frameBoundsTarget`'s "forward is the negative Z column" read out as
+ * `(0, 0, -1)` — a well-defined direction, so the fit takes its primary path
+ * rather than either fallback.
+ */
+function makeState(aspect: number, mode: 'perspective' | 'orthographic' = 'perspective'): CameraInternalState {
+  const camera: CameraType = {
+    position: { x: 0, y: 0, z: 100 },
+    target: { x: 0, y: 0, z: 0 },
+    up: { x: 0, y: 1, z: 0 },
+    fov: FOV,
+    aspect,
+    near: 0.1,
+    far: 10000,
+  };
+  return {
+    camera,
+    viewMatrix: makeMat4(),
+    projMatrix: makeMat4(),
+    viewProjMatrix: makeMat4(),
+    projectionMode: mode,
+    orthoSize: 50,
+    sceneBounds: null,
+    orbitAnchorBounds: null,
+  };
+}
+
+function distanceBetween(a: Vec3, b: Vec3): number {
+  return Math.sqrt((a.x - b.x) ** 2 + (a.y - b.y) ** 2 + (a.z - b.z) ** 2);
+}
+
+/**
+ * Drive the tween off a stubbed clock. Same helper as
+ * `camera-malformed-bounds-fit.test.ts`; the animator reads `Date.now` and
+ * schedules through `requestAnimationFrame`, neither of which exists usefully
+ * under `node:test`.
+ */
+function withStubbedFrameClock(run: (advance: (ms: number) => void) => void): void {
+  const originalNow = Date.now;
+  const hadRaf = Object.prototype.hasOwnProperty.call(globalThis, 'requestAnimationFrame');
+  const originalRaf = Reflect.get(globalThis, 'requestAnimationFrame');
+  let now = 1_000;
+
+  Date.now = () => now;
+  Reflect.set(globalThis, 'requestAnimationFrame', () => 0);
+
+  try {
+    run((ms) => { now += ms; });
+  } finally {
+    Date.now = originalNow;
+    if (hadRaf) {
+      Reflect.set(globalThis, 'requestAnimationFrame', originalRaf);
+    } else {
+      Reflect.deleteProperty(globalThis, 'requestAnimationFrame');
+    }
+  }
+}
+
+/** A 20-unit cube centred on the origin. `maxExtentOf` is 20. */
+const CUBE_MIN: Vec3 = { x: -10, y: -10, z: -10 };
+const CUBE_MAX: Vec3 = { x: 10, y: 10, z: 10 };
+const CUBE_SIZE = 20;
+
+/**
+ * Half-extent of the box at `distance`, measured against the *horizontal*
+ * field of view. `< 1` means it fits; `> 1` means it is cut off at the left
+ * and right edges of a portrait window.
+ */
+function horizontalFill(distance: number, size: number, aspect: number): number {
+  const halfWidthAtDistance = distance * Math.tan(FOV / 2) * aspect;
+  return (size / 2) / halfWidthAtDistance;
+}
+
+describe('fit distance honours the horizontal field of view (#2500)', () => {
+  it('pulls back far enough for a portrait viewport', () => {
+    // 9:16 phone/tablet portrait. Against the vertical field alone the cube
+    // fitted at `10 / tan(fov/2) * padding`; the horizontal field is 0.5625x
+    // as wide, so the same distance left the cube 1.7x too wide for the
+    // window and frame-selection cut its sides off.
+    const aspect = 9 / 16;
+    for (const [label, pick, padding] of [
+      ['frameBounds', frameBoundsTarget, 1.2],
+      ['zoomExtent', zoomExtentTarget, 1.5],
+    ] as const) {
+      const state = makeState(aspect);
+      const fit = pick(state, CUBE_MIN, CUBE_MAX);
+      assert.ok(fit, `${label}: the box is usable and must produce a fit`);
+      const distance = distanceBetween(fit.position, fit.target);
+      const fill = horizontalFill(distance, CUBE_SIZE, aspect);
+      assert.ok(
+        fill <= 1 / padding + 1e-9,
+        `${label}: the cube fills ${fill.toFixed(3)} of the horizontal field at distance ${distance.toFixed(3)}; ` +
+        `with ${padding}x padding it must fill at most ${(1 / padding).toFixed(3)}`,
+      );
+    }
+  });
+
+  it('pulls back far enough for a portrait viewport in a preset view', () => {
+    const aspect = 9 / 16;
+    const state = makeState(aspect);
+    const fit = presetViewTarget(state, 'front', { min: CUBE_MIN, max: CUBE_MAX }, 0);
+    const distance = distanceBetween(fit.position, fit.target);
+    const fill = horizontalFill(distance, CUBE_SIZE, aspect);
+    assert.ok(
+      fill <= 1 / 1.5 + 1e-9,
+      `preset front: the cube fills ${fill.toFixed(3)} of the horizontal field at distance ${distance.toFixed(3)}`,
+    );
+  });
+
+  it('anti-mutation: a landscape viewport is bit-for-bit unchanged', () => {
+    // The vertical field is the binding one for every `aspect >= 1`, so the
+    // aspect term must contribute exactly nothing there. If this drifts, the
+    // fix has changed the framing of every desktop viewport rather than only
+    // the portrait one it was for.
+    for (const aspect of [1, 4 / 3, 16 / 9, 21 / 9]) {
+      const vertical = (CUBE_SIZE / 2) / Math.tan(FOV / 2);
+      for (const [label, pick, padding] of [
+        ['frameBounds', frameBoundsTarget, 1.2],
+        ['zoomExtent', zoomExtentTarget, 1.5],
+      ] as const) {
+        const fit = pick(makeState(aspect), CUBE_MIN, CUBE_MAX);
+        assert.ok(fit, `${label}: fit expected`);
+        assert.strictEqual(
+          distanceBetween(fit.position, fit.target),
+          vertical * padding,
+          `${label} @ aspect ${aspect}: landscape distance must be the vertical-field one exactly`,
+        );
+      }
+      const preset = presetViewTarget(makeState(aspect), 'front', { min: CUBE_MIN, max: CUBE_MAX }, 0);
+      assert.strictEqual(
+        distanceBetween(preset.position, preset.target),
+        vertical * 1.5,
+        `preset @ aspect ${aspect}: landscape distance must be the vertical-field one exactly`,
+      );
+    }
+  });
+});
+
+describe('zoomExtent keeps a view direction for a degenerate box (#2500)', () => {
+  it('does not put the camera on its own target', () => {
+    // A single-point AABB — one point-like element, a plan-only model. Zero
+    // extent means zero fit distance, so `position` came back equal to
+    // `target` and `MathUtils.lookAt` had to invent an entire basis for a
+    // pose the fit itself had destroyed.
+    const state = makeState(16 / 9);
+    const point: Vec3 = { x: 5, y: 5, z: 5 };
+    const fit = zoomExtentTarget(state, point, point);
+    assert.ok(fit, 'a degenerate box is valid and must still produce a fit');
+    assert.deepStrictEqual(fit.target, point, 'the fit must centre on the point');
+    const distance = distanceBetween(fit.position, fit.target);
+    assert.ok(distance > 1e-6, `position must stay off the target, was ${distance} away`);
+    assert.ok(fit.fitDistance > 1e-6, `fitDistance must stay positive, was ${fit.fitDistance}`);
+    // The documented behaviour of the degenerate branch: keep the camera's
+    // current offset, which is 100 units on this state.
+    assert.ok(Math.abs(distance - 100) < 1e-6, `expected the current 100-unit offset, got ${distance}`);
+  });
+
+  it('anti-mutation: an ordinary box still fits to the FOV distance, not the current offset', () => {
+    const fit = zoomExtentTarget(makeState(16 / 9), CUBE_MIN, CUBE_MAX);
+    assert.ok(fit, 'fit expected');
+    const expected = (CUBE_SIZE / 2) / Math.tan(FOV / 2) * 1.5;
+    assert.ok(
+      Math.abs(distanceBetween(fit.position, fit.target) - expected) < 1e-6,
+      'a non-degenerate box must still take the FOV path, not the degenerate one',
+    );
+  });
+});
+
+describe('preset views survive a malformed building rotation (#2500)', () => {
+  it('treats a non-finite IfcSite rotation as no rotation', () => {
+    const reference = presetViewTarget(makeState(1), 'front', { min: CUBE_MIN, max: CUBE_MAX }, 0);
+    for (const bad of [Number.NaN, Infinity, -Infinity]) {
+      for (const view of ['top', 'bottom', 'front', 'back', 'left', 'right'] as const) {
+        const fit = presetViewTarget(makeState(1), view, { min: CUBE_MIN, max: CUBE_MAX }, 0, bad);
+        for (const axis of ['x', 'y', 'z'] as const) {
+          assert.ok(
+            Number.isFinite(fit.position[axis]),
+            `${view} @ buildingRotation ${bad}: position.${axis} was ${fit.position[axis]}`,
+          );
+        }
+      }
+    }
+    // And the substitute is specifically zero, so a malformed placement lands
+    // on exactly the pose a model with no site rotation would get.
+    const substituted = presetViewTarget(makeState(1), 'front', { min: CUBE_MIN, max: CUBE_MAX }, 0, Number.NaN);
+    assert.deepStrictEqual(substituted.position, reference.position);
+  });
+
+  it('reaches the same guard through the published Camera.setPresetView', () => {
+    // Reachability, not reasoning: `buildingRotation` is a documented third
+    // argument of the published API and the viewer sources it from the file's
+    // IfcSite placement. Run through the tween so the pose is the one that
+    // actually lands, not merely the one that was picked.
+    withStubbedFrameClock((advance) => {
+      const camera = new Camera();
+      camera.setAspect(16 / 9);
+      camera.setPosition(50, 50, 100);
+      camera.setTarget(0, 0, 0);
+      camera.setPresetView('front', { min: CUBE_MIN, max: CUBE_MAX }, Number.NaN);
+      advance(301);
+      camera.update(16);
+
+      for (const axis of ['x', 'y', 'z'] as const) {
+        assert.ok(Number.isFinite(camera.getPosition()[axis]), `position.${axis} was ${camera.getPosition()[axis]}`);
+        assert.ok(Number.isFinite(camera.getTarget()[axis]), `target.${axis} was ${camera.getTarget()[axis]}`);
+      }
+      const m = Array.from(camera.getViewProjMatrix().m);
+      const bad = m.findIndex((v) => !Number.isFinite(v));
+      assert.strictEqual(bad, -1, `view-projection component ${bad} is ${m[bad]}`);
+    });
+  });
+
+  it('anti-mutation: a real building rotation is still applied', () => {
+    const rotated = presetViewTarget(makeState(1), 'front', { min: CUBE_MIN, max: CUBE_MAX }, 0, Math.PI / 2);
+    const unrotated = presetViewTarget(makeState(1), 'front', { min: CUBE_MIN, max: CUBE_MAX }, 0);
+    assert.notDeepStrictEqual(
+      rotated.position,
+      unrotated.position,
+      'a finite rotation must still move the preset camera',
+    );
+  });
+});
+
+describe('preset views survive an out-of-range rotation cycle (#2500)', () => {
+  it('falls back to the unrotated cycle position rather than indexing past the table', () => {
+    // `rotation` is the animator's 0-3 counter today, but it is a plain
+    // `number` on the signature: `thetaPerRotation[4]` is `undefined`, and
+    // `undefined + x` is NaN — the whole preset pose, not just the angle.
+    for (const view of ['top', 'bottom'] as const) {
+      for (const bad of [4, -1, 1.5, Number.NaN]) {
+        const fit = presetViewTarget(makeState(1), view, { min: CUBE_MIN, max: CUBE_MAX }, bad);
+        for (const axis of ['x', 'y', 'z'] as const) {
+          assert.ok(
+            Number.isFinite(fit.position[axis]),
+            `${view} @ rotation ${bad}: position.${axis} was ${fit.position[axis]}`,
+          );
+        }
+      }
+    }
+  });
+
+  it('anti-mutation: the four real cycle positions still differ from one another', () => {
+    const seen = new Set<string>();
+    for (const rotation of [0, 1, 2, 3]) {
+      const fit = presetViewTarget(makeState(1), 'top', { min: CUBE_MIN, max: CUBE_MAX }, rotation);
+      seen.add(`${fit.position.x.toFixed(6)},${fit.position.z.toFixed(6)}`);
+    }
+    assert.strictEqual(seen.size, 4, 'each ViewCube cycle position must still give a distinct pose');
+  });
+});

--- a/packages/renderer/src/camera-fit-viewport-shape.test.ts
+++ b/packages/renderer/src/camera-fit-viewport-shape.test.ts
@@ -214,6 +214,59 @@ describe('zoomExtent keeps a view direction for a degenerate box (#2500)', () =>
   });
 });
 
+describe('the fit direction floors reject Infinity, not only NaN (#2500)', () => {
+  // `len > 1e-10` is false for NaN — which is why these read as guarded — and
+  // *true* for Infinity, and `Infinity / Infinity` is NaN. Both floors below
+  // read the raw pose, where an overflowed coordinate is reachable: the pose
+  // is public mutable state and a restored BCF viewpoint writes it verbatim.
+  // The box itself is perfectly usable in both cases, so `isUsableBounds`
+  // never sees the problem.
+  const OVERFLOWED = { x: Number.POSITIVE_INFINITY, y: 50, z: 100 };
+
+  it('zoomExtent falls back to the isometric direction for an overflowed pose', () => {
+    const state = makeState(16 / 9);
+    state.camera.position = { ...OVERFLOWED };
+    const fit = zoomExtentTarget(state, CUBE_MIN, CUBE_MAX);
+    assert.ok(fit, 'the box is usable; the fit must not be rejected for it');
+    for (const axis of ['x', 'y', 'z'] as const) {
+      assert.ok(Number.isFinite(fit.position[axis]), `position.${axis} was ${fit.position[axis]}`);
+    }
+  });
+
+  it('frameBounds falls back to the isometric direction for an overflowed pose', () => {
+    // A zeroed view matrix is what pushes `frameBoundsTarget` past its primary
+    // (view-matrix) direction onto the pose-derived fallback that carries the
+    // floor. `MathUtils.lookAt` produces one for a pose it cannot orient from.
+    const state = makeState(16 / 9);
+    state.viewMatrix = { m: new Float32Array(16) };
+    state.camera.position = { ...OVERFLOWED };
+    const fit = frameBoundsTarget(state, CUBE_MIN, CUBE_MAX);
+    assert.ok(fit, 'the box is usable; the fit must not be rejected for it');
+    for (const axis of ['x', 'y', 'z'] as const) {
+      assert.ok(Number.isFinite(fit.position[axis]), `position.${axis} was ${fit.position[axis]}`);
+    }
+  });
+
+  it('anti-mutation: a finite pose still steers both fits', () => {
+    // The floors must reject only unusable lengths. If they rejected
+    // everything, both fits would silently snap to the isometric fallback and
+    // the tests above would pass against a camera that had stopped honouring
+    // the view direction at all.
+    const zoom = zoomExtentTarget(makeState(16 / 9), CUBE_MIN, CUBE_MAX);
+    assert.ok(zoom, 'fit expected');
+    // The state looks down -Z, so the fit sits on +Z of the centre.
+    assert.ok(Math.abs(zoom.position.x) < 1e-9 && Math.abs(zoom.position.y) < 1e-9,
+      `zoomExtent should keep the -Z view direction, got ${JSON.stringify(zoom.position)}`);
+
+    const framedState = makeState(16 / 9);
+    framedState.viewMatrix = { m: new Float32Array(16) };
+    const framed = frameBoundsTarget(framedState, CUBE_MIN, CUBE_MAX);
+    assert.ok(framed, 'fit expected');
+    assert.ok(Math.abs(framed.position.x) < 1e-9 && Math.abs(framed.position.y) < 1e-9,
+      `frameBounds should fall back to the pose direction, got ${JSON.stringify(framed.position)}`);
+  });
+});
+
 describe('preset views survive a malformed building rotation (#2500)', () => {
   it('treats a non-finite IfcSite rotation as no rotation', () => {
     const reference = presetViewTarget(makeState(1), 'front', { min: CUBE_MIN, max: CUBE_MAX }, 0);

--- a/packages/renderer/src/camera-framing.ts
+++ b/packages/renderer/src/camera-framing.ts
@@ -1,0 +1,415 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Framing: "put the camera on this thing". Given the current camera state and
+ * a point, an AABB or a preset direction, work out the pose to end up in.
+ *
+ * Pure by construction — every function here reads `CameraInternalState` and
+ * returns a target, and none of them writes to it or touches the tween. That
+ * is what keeps this module free of a cycle back into `camera-animation.ts`,
+ * which is the one that applies the results. Same shape as
+ * `camera-fit-policy.ts`, which is already pure-picker + facade-applier.
+ *
+ * Its failure story is not the tween's. The tween latches a non-finite
+ * *gesture delta* into a velocity that never decays (#2441/#2473); framing
+ * takes a non-finite *box* — geometry-derived, and every AABB accumulator in
+ * this package hands out an inverted `+Inf/-Inf` sentinel for a mesh with no
+ * finite vertices — and writes it into position, target AND `orthoSize`, which
+ * `getOrthoSize()` then persists into a saved viewpoint (#2461).
+ *
+ * **Guard placement.** Each input is validated exactly once, here, and a
+ * rejection is `null`. Callers null-check and do nothing else: a second,
+ * defensive copy of the same guard in the caller would mean neither copy is
+ * load-bearing on its own, and the mutation tests that pin these guards would
+ * go quiet while still looking green.
+ */
+
+import type { Vec3 } from './types.js';
+import type { CameraInternalState } from './camera-state.js';
+import { areFiniteNumbers, isUsableBounds } from './camera-guards.js';
+
+/** A pose to animate to. `orthoSize` is undefined when the fit should not touch zoom. */
+export interface FramingTarget {
+  position: Vec3;
+  target: Vec3;
+  orthoSize?: number;
+}
+
+/** As {@link FramingTarget}, plus the fit distance `zoomExtent` reports onward. */
+export interface ZoomExtentTarget extends FramingTarget {
+  fitDistance: number;
+}
+
+/** An axis-aligned box. */
+export interface FramingBounds {
+  min: Vec3;
+  max: Vec3;
+}
+
+/** Centre of a box. */
+function centerOf(min: Vec3, max: Vec3): Vec3 {
+  return {
+    x: (min.x + max.x) / 2,
+    y: (min.y + max.y) / 2,
+    z: (min.z + max.z) / 2,
+  };
+}
+
+/** Largest edge length of a box. */
+function maxExtentOf(min: Vec3, max: Vec3): number {
+  return Math.max(max.x - min.x, max.y - min.y, max.z - min.z);
+}
+
+/**
+ * Orthographic half-height that shows a box of `maxSize` with `padding` slack,
+ * or `undefined` in perspective mode where `orthoSize` is not in play.
+ */
+function orthoSizeFor(state: CameraInternalState, maxSize: number, padding: number): number | undefined {
+  if (state.projectionMode !== 'orthographic') return undefined;
+  const aspect = state.camera.aspect || 1;
+  return Math.max(0.01, maxSize / 2, maxSize / 2 / aspect) * padding;
+}
+
+/**
+ * Frame/center view on a point (keeps current distance and direction).
+ * Standard CAD "Frame Selection" behavior.
+ */
+export function framePointTarget(state: CameraInternalState, point: Vec3): FramingTarget | null {
+  // The point is added to the current offset and animated into both
+  // `position` and `target`, so a non-finite one destroys the pose. It is
+  // externally derived: `zoomToTopic` frames a BCF marker position, which is
+  // computed from a file-supplied viewpoint direction (#2461/#2466).
+  if (!areFiniteNumbers(point.x, point.y, point.z)) return null;
+
+  // Keep current viewing direction and distance
+  const dir = {
+    x: state.camera.position.x - state.camera.target.x,
+    y: state.camera.position.y - state.camera.target.y,
+    z: state.camera.position.z - state.camera.target.z,
+  };
+
+  // New position: point + current offset
+  return {
+    position: {
+      x: point.x + dir.x,
+      y: point.y + dir.y,
+      z: point.z + dir.z,
+    },
+    target: point,
+  };
+}
+
+/**
+ * Frame selection - zoom to fit bounds while keeping current view direction.
+ * This is what "Frame Selection" should do - zoom to fill screen.
+ */
+export function frameBoundsTarget(state: CameraInternalState, min: Vec3, max: Vec3): FramingTarget | null {
+  // Bounds are the upstream input #2450 stopped short of (#2461). They are
+  // not caller-authored constants: they come from geometry, and every AABB
+  // accumulator in this package starts from `min = +Infinity, max =
+  // -Infinity` and only narrows on a comparison — which is false for a
+  // non-finite vertex — so a mesh with no finite vertices hands out that
+  // inverted sentinel as if it were a real box. `Math.max` picking the
+  // largest extent is NaN-transparent, so it reaches `position`, `target`
+  // AND `orthoSize`, and `getOrthoSize()` is what a saved viewpoint persists.
+  if (!isUsableBounds(min, max)) return null;
+
+  const center = centerOf(min, max);
+  const maxSize = maxExtentOf(min, max);
+
+  if (maxSize < 1e-6) {
+    // Very small or zero size - just center on it
+    return framePointTarget(state, center);
+  }
+
+  // Calculate required distance based on FOV to fit bounds
+  const fovFactor = Math.tan(state.camera.fov / 2);
+  const distance = (maxSize / 2) / fovFactor * 1.2; // 1.2x padding for nice framing
+
+  // Get current viewing direction from view matrix (more reliable than position-target)
+  // View matrix forward is -Z axis in view space
+  const viewMatrix = state.viewMatrix.m;
+  // Extract forward direction from view matrix (negative Z column, normalized)
+  let dir = {
+    x: -viewMatrix[8],   // -m[2][0] (forward X)
+    y: -viewMatrix[9],   // -m[2][1] (forward Y)
+    z: -viewMatrix[10],  // -m[2][2] (forward Z)
+  };
+  const dirLen = Math.sqrt(dir.x * dir.x + dir.y * dir.y + dir.z * dir.z);
+
+  // Normalize direction
+  if (dirLen > 1e-6) {
+    dir.x /= dirLen;
+    dir.y /= dirLen;
+    dir.z /= dirLen;
+  } else {
+    // Fallback: use position-target if view matrix is invalid
+    dir = {
+      x: state.camera.position.x - state.camera.target.x,
+      y: state.camera.position.y - state.camera.target.y,
+      z: state.camera.position.z - state.camera.target.z,
+    };
+    const fallbackLen = Math.sqrt(dir.x * dir.x + dir.y * dir.y + dir.z * dir.z);
+    if (fallbackLen > 1e-6) {
+      dir.x /= fallbackLen;
+      dir.y /= fallbackLen;
+      dir.z /= fallbackLen;
+    } else {
+      // Last resort: southeast isometric
+      dir.x = 0.6;
+      dir.y = 0.5;
+      dir.z = 0.6;
+      const len = Math.sqrt(dir.x * dir.x + dir.y * dir.y + dir.z * dir.z);
+      dir.x /= len;
+      dir.y /= len;
+      dir.z /= len;
+    }
+  }
+
+  return {
+    // New position: center + direction * distance
+    position: {
+      x: center.x + dir.x * distance,
+      y: center.y + dir.y * distance,
+      z: center.z + dir.z * distance,
+    },
+    target: center,
+    // Calculate orthoSize for orthographic mode so zoom level resets properly
+    orthoSize: orthoSizeFor(state, maxSize, 1.2),
+  };
+}
+
+/**
+ * Zoom to extents: same fit, wider padding, and the current view direction is
+ * taken from the pose rather than the view matrix.
+ */
+export function zoomExtentTarget(state: CameraInternalState, min: Vec3, max: Vec3): ZoomExtentTarget | null {
+  // Same input class and same reasoning as `frameBoundsTarget` (#2461).
+  if (!isUsableBounds(min, max)) return null;
+
+  const center = centerOf(min, max);
+  const maxSize = maxExtentOf(min, max);
+
+  // Calculate required distance based on FOV
+  const fovFactor = Math.tan(state.camera.fov / 2);
+  const distance = (maxSize / 2) / fovFactor * 1.5; // 1.5x for padding
+
+  // Keep current viewing direction
+  const dir = {
+    x: state.camera.position.x - state.camera.target.x,
+    y: state.camera.position.y - state.camera.target.y,
+    z: state.camera.position.z - state.camera.target.z,
+  };
+  const currentDistance = Math.sqrt(dir.x * dir.x + dir.y * dir.y + dir.z * dir.z);
+
+  // Normalize direction
+  if (currentDistance > 1e-10) {
+    dir.x /= currentDistance;
+    dir.y /= currentDistance;
+    dir.z /= currentDistance;
+  } else {
+    // Fallback direction
+    dir.x = 0.6;
+    dir.y = 0.5;
+    dir.z = 0.6;
+    const len = Math.sqrt(dir.x * dir.x + dir.y * dir.y + dir.z * dir.z);
+    dir.x /= len;
+    dir.y /= len;
+    dir.z /= len;
+  }
+
+  return {
+    // New position: center + direction * distance
+    position: {
+      x: center.x + dir.x * distance,
+      y: center.y + dir.y * distance,
+      z: center.z + dir.z * distance,
+    },
+    target: center,
+    // Calculate orthoSize for orthographic mode so zoom level resets properly
+    orthoSize: orthoSizeFor(state, maxSize, 1.5),
+    // The caller hands this to `CameraProjection.updateNearFarPlanes`.
+    fitDistance: distance,
+  };
+}
+
+/**
+ * Get current bounds estimate (simplified - in production would use scene bounds).
+ */
+export function estimateBoundsFromPose(state: CameraInternalState): FramingBounds {
+  // Estimate bounds from camera distance
+  const dir = {
+    x: state.camera.position.x - state.camera.target.x,
+    y: state.camera.position.y - state.camera.target.y,
+    z: state.camera.position.z - state.camera.target.z,
+  };
+  const distance = Math.sqrt(dir.x * dir.x + dir.y * dir.y + dir.z * dir.z);
+  const size = distance / 2;
+
+  return {
+    min: {
+      x: state.camera.target.x - size,
+      y: state.camera.target.y - size,
+      z: state.camera.target.z - size,
+    },
+    max: {
+      x: state.camera.target.x + size,
+      y: state.camera.target.y + size,
+      z: state.camera.target.z + size,
+    },
+  };
+}
+
+/**
+ * Resolve the box a preset view should fit, from the caller's bounds or the
+ * current pose, and reject it if it is not usable.
+ *
+ * This is the whole admission decision for `setPresetView`, deliberately kept
+ * ahead of the rotation-cycling counter: a rejected preset must not advance
+ * the cycle, and the caller can only honour that if the verdict arrives before
+ * it mutates anything.
+ */
+export function resolvePresetBounds(
+  state: CameraInternalState,
+  bounds?: FramingBounds,
+): FramingBounds | null {
+  const useBounds = bounds || estimateBoundsFromPose(state);
+  // Both sources need the check, not just the caller's: the pose-derived
+  // estimate above starts from the live pose, so a pose that is already
+  // malformed produces a malformed box and the ViewCube would then bake it in
+  // permanently. Rejecting leaves the preset un-applied, which keeps a
+  // recoverable pose recoverable (#2461).
+  if (!isUsableBounds(useBounds.min, useBounds.max)) {
+    console.warn('[Camera] Non-finite bounds for setPresetView; keeping current view');
+    return null;
+  }
+  return useBounds;
+}
+
+/**
+ * Pose for a preset view (Y-up coordinate system).
+ *
+ * `bounds` must already have passed {@link resolvePresetBounds}; `rotation` is
+ * the caller's 0-3 cycle position, which is why this takes it rather than
+ * owning it — the counter belongs to the animator, which is what remembers
+ * that the same face was clicked twice.
+ *
+ * @param buildingRotation Optional building rotation in radians (from IfcSite placement)
+ */
+export function presetViewTarget(
+  state: CameraInternalState,
+  view: 'top' | 'bottom' | 'front' | 'back' | 'left' | 'right',
+  bounds: FramingBounds,
+  rotation: number,
+  buildingRotation?: number,
+): { position: Vec3; target: Vec3; up: Vec3 } {
+  const center = centerOf(bounds.min, bounds.max);
+  const maxSize = maxExtentOf(bounds.min, bounds.max);
+
+  // Calculate distance based on FOV for proper fit
+  const fovFactor = Math.tan(state.camera.fov / 2);
+  const distance = (maxSize / 2) / fovFactor * 1.5; // 1.5x for padding
+
+  let endPos: Vec3;
+  const endTarget = center;
+
+  // WebGL uses Y-up coordinate system internally
+  // We set both position AND up vector for proper orthogonal views
+  let upVector: Vec3 = { x: 0, y: 1, z: 0 }; // Default Y-up
+
+  // Apply building rotation if present (rotate around Y axis)
+  const cosR = buildingRotation !== undefined && buildingRotation !== 0 ? Math.cos(buildingRotation) : 1.0;
+  const sinR = buildingRotation !== undefined && buildingRotation !== 0 ? Math.sin(buildingRotation) : 0.0;
+
+  switch (view) {
+    case 'top': {
+      // Top view: position camera *just barely* off the +Y pole so the
+      // subsequent orbit math has a well-defined polar tangent (no pole
+      // singularity). camera.up stays world Y throughout — screen-up is
+      // then determined by lookAt projecting (0,1,0) onto perp(look),
+      // which falls along the horizontal component of `-look`.
+      //
+      // The 4 rotation cycles select which compass direction appears at
+      // the top of the screen by varying the small horizontal offset
+      // (theta in the spherical math).
+      //   rotation 0 → camera slightly to +Z of center → screen-up = +Z
+      //   rotation 1 → camera slightly to +X → screen-up = +X
+      //   rotation 2 → camera slightly to -Z → screen-up = -Z
+      //   rotation 3 → camera slightly to -X → screen-up = -X
+      // Building rotation is applied as the same Y-axis rotation that
+      // setPresetView would have used to remap the legacy up vector.
+      const poleOffset = Math.sin(0.01) * distance; // ~0.6° tilt
+      const verticalOffset = Math.cos(0.01) * distance;
+      const thetaPerRotation = [0, Math.PI / 2, Math.PI, -Math.PI / 2];
+      const thetaWorld = thetaPerRotation[rotation] + (buildingRotation ?? 0);
+      endPos = {
+        x: center.x + poleOffset * Math.sin(thetaWorld),
+        y: center.y + verticalOffset,
+        z: center.z + poleOffset * Math.cos(thetaWorld),
+      };
+      upVector = { x: 0, y: 1, z: 0 };
+      break;
+    }
+    case 'bottom': {
+      // Bottom view: mirror of top — phi = π − MIN_PHI.
+      const poleOffset = Math.sin(0.01) * distance;
+      const verticalOffset = Math.cos(0.01) * distance;
+      const thetaPerRotation = [Math.PI, Math.PI / 2, 0, -Math.PI / 2];
+      const thetaWorld = thetaPerRotation[rotation] + (buildingRotation ?? 0);
+      endPos = {
+        x: center.x + poleOffset * Math.sin(thetaWorld),
+        y: center.y - verticalOffset,
+        z: center.z + poleOffset * Math.cos(thetaWorld),
+      };
+      upVector = { x: 0, y: 1, z: 0 };
+      break;
+    }
+    case 'front':
+      // Front view: from +Z looking at model
+      // Rotate camera position around Y axis by building rotation
+      // Standard rotation: x' = x*cos - z*sin, z' = x*sin + z*cos
+      // For +Z direction (0,0,1): x' = -sin, z' = cos
+      // But we need to look at building's front, so use negative rotation
+      endPos = {
+        x: center.x + sinR * distance,
+        y: center.y,
+        z: center.z + cosR * distance,
+      };
+      upVector = { x: 0, y: 1, z: 0 }; // Y-up
+      break;
+    case 'back':
+      // Back view: from -Z looking at model
+      // For -Z direction (0,0,-1) rotated: x' = sin, z' = -cos
+      endPos = {
+        x: center.x - sinR * distance,
+        y: center.y,
+        z: center.z - cosR * distance,
+      };
+      upVector = { x: 0, y: 1, z: 0 }; // Y-up
+      break;
+    case 'left':
+      // Left view: from -X looking at model
+      // For -X direction (-1,0,0) rotated: x' = -cos, z' = sin
+      endPos = {
+        x: center.x - cosR * distance,
+        y: center.y,
+        z: center.z + sinR * distance,
+      };
+      upVector = { x: 0, y: 1, z: 0 }; // Y-up
+      break;
+    case 'right':
+      // Right view: from +X looking at model
+      // For +X direction (1,0,0) rotated: x' = cos, z' = -sin
+      endPos = {
+        x: center.x + cosR * distance,
+        y: center.y,
+        z: center.z - sinR * distance,
+      };
+      upVector = { x: 0, y: 1, z: 0 }; // Y-up
+      break;
+  }
+
+  return { position: endPos, target: endTarget, up: upVector };
+}

--- a/packages/renderer/src/camera-framing.ts
+++ b/packages/renderer/src/camera-framing.ts
@@ -35,7 +35,7 @@
 
 import type { Vec3 } from './types.js';
 import type { CameraInternalState } from './camera-state.js';
-import { areFiniteNumbers, isUsableBounds } from './camera-guards.js';
+import { areFiniteNumbers, isUsableBounds, isUsableDistance } from './camera-guards.js';
 
 /** A pose to animate to. `orthoSize` is undefined when the fit should not touch zoom. */
 export interface FramingTarget {
@@ -77,6 +77,34 @@ function orthoSizeFor(state: CameraInternalState, maxSize: number, padding: numb
   if (state.projectionMode !== 'orthographic') return undefined;
   const aspect = state.camera.aspect || 1;
   return Math.max(0.01, maxSize / 2, maxSize / 2 / aspect) * padding;
+}
+
+/**
+ * Distance at which a box of `maxSize` fits the perspective frustum, with
+ * `padding` slack. Shared with `camera-preset-view.ts`, which fits the same
+ * way from a dictated direction.
+ *
+ * Fits **both** screen axes. The vertical half-angle is `fov / 2`; the
+ * horizontal one is `atan(tan(fov / 2) * aspect)`, so on a portrait viewport
+ * (`aspect < 1`) the horizontal field is the *narrower* of the two and a
+ * distance derived from the vertical field alone leaves the box overflowing
+ * left and right — the fit silently clips the very thing it was asked to
+ * frame. Landscape is unaffected: for `aspect >= 1` the vertical field is
+ * already the binding one and this returns the vertical distance exactly,
+ * bit for bit.
+ *
+ * `orthoSizeFor` above has divided by `aspect` for the same reason since it
+ * was written; this is the perspective half of the same rule, which had been
+ * missing (the three fit-distance formulas in this package all predate it).
+ */
+export function fitDistanceFor(state: CameraInternalState, maxSize: number, padding: number): number {
+  const fovFactor = Math.tan(state.camera.fov / 2);
+  const vertical = (maxSize / 2) / fovFactor * padding;
+  const aspect = state.camera.aspect;
+  // `setAspect` is the only writer and already rejects a non-positive or
+  // non-finite ratio, so this only ever narrows the *portrait* case.
+  if (!Number.isFinite(aspect) || aspect <= 0 || aspect >= 1) return vertical;
+  return vertical / aspect;
 }
 
 /**
@@ -132,8 +160,7 @@ export function frameBoundsTarget(state: CameraInternalState, min: Vec3, max: Ve
   }
 
   // Calculate required distance based on FOV to fit bounds
-  const fovFactor = Math.tan(state.camera.fov / 2);
-  const distance = (maxSize / 2) / fovFactor * 1.2; // 1.2x padding for nice framing
+  const distance = fitDistanceFor(state, maxSize, 1.2); // 1.2x padding for nice framing
 
   // Get current viewing direction from view matrix (more reliable than position-target)
   // View matrix forward is -Z axis in view space
@@ -159,7 +186,10 @@ export function frameBoundsTarget(state: CameraInternalState, min: Vec3, max: Ve
       z: state.camera.position.z - state.camera.target.z,
     };
     const fallbackLen = Math.sqrt(dir.x * dir.x + dir.y * dir.y + dir.z * dir.z);
-    if (fallbackLen > 1e-6) {
+    // Finiteness, not just magnitude — see `zoomExtentTarget`. `dirLen` above
+    // is safe (`MathUtils.lookAt` guarantees a finite view matrix), but this
+    // fallback reads the raw pose, where an overflowed coordinate is reachable.
+    if (isUsableDistance(fallbackLen, 1e-6)) {
       dir.x /= fallbackLen;
       dir.y /= fallbackLen;
       dir.z /= fallbackLen;
@@ -199,10 +229,6 @@ export function zoomExtentTarget(state: CameraInternalState, min: Vec3, max: Vec
   const center = centerOf(min, max);
   const maxSize = maxExtentOf(min, max);
 
-  // Calculate required distance based on FOV
-  const fovFactor = Math.tan(state.camera.fov / 2);
-  const distance = (maxSize / 2) / fovFactor * 1.5; // 1.5x for padding
-
   // Keep current viewing direction
   const dir = {
     x: state.camera.position.x - state.camera.target.x,
@@ -211,8 +237,32 @@ export function zoomExtentTarget(state: CameraInternalState, min: Vec3, max: Vec
   };
   const currentDistance = Math.sqrt(dir.x * dir.x + dir.y * dir.y + dir.z * dir.z);
 
-  // Normalize direction
-  if (currentDistance > 1e-10) {
+  // The degenerate box `frameBoundsTarget` has always special-cased and this
+  // one did not. `isUsableBounds` deliberately admits `max === min` (a flat
+  // wall, a single picked point, a one-element model), and for such a box the
+  // fit distance below is *zero* — so `position` is written equal to `target`,
+  // a pose that carries no view direction at all and that `MathUtils.lookAt`
+  // then has to substitute a whole basis for. Centre on the point at the
+  // distance the camera already has, exactly as `frameBounds` does, and report
+  // that distance rather than zero.
+  //
+  // Only when the current offset is usable. When it is not, the pose already
+  // has position === target (or is non-finite), so there is no offset to keep
+  // and nothing is gained by keeping it; fall through to the isometric
+  // fallback below, which is what this path did before.
+  if (maxSize < 1e-6 && isUsableDistance(currentDistance, 1e-10)) {
+    const framed = framePointTarget(state, center);
+    if (framed) return { ...framed, fitDistance: currentDistance };
+  }
+
+  // Calculate required distance based on FOV
+  const distance = fitDistanceFor(state, maxSize, 1.5); // 1.5x for padding
+
+  // Normalize direction. Finiteness, not just magnitude: `len > 1e-10` is
+  // *true* for Infinity, and `Infinity / Infinity` is NaN, so a pose whose
+  // position has overflowed walks past a bare floor and writes a NaN position
+  // from a perfectly usable box (#2441).
+  if (isUsableDistance(currentDistance, 1e-10)) {
     dir.x /= currentDistance;
     dir.y /= currentDistance;
     dir.z /= currentDistance;

--- a/packages/renderer/src/camera-framing.ts
+++ b/packages/renderer/src/camera-framing.ts
@@ -3,8 +3,15 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
- * Framing: "put the camera on this thing". Given the current camera state and
- * a point, an AABB or a preset direction, work out the pose to end up in.
+ * Framing: "put the camera on this thing, keeping the direction it already
+ * has". Given the current camera state and a point or an AABB, work out the
+ * pose to end up in.
+ *
+ * The ViewCube's *preset* directions are the neighbouring subject and live in
+ * `camera-preset-view.ts`: there the direction is dictated by a named face and
+ * a rotation cycle rather than inherited from the pose, and the box has to pass
+ * its own admission check first. They share only the box arithmetic below,
+ * which is why `centerOf` / `maxExtentOf` are exported.
  *
  * Pure by construction — every function here reads `CameraInternalState` and
  * returns a target, and none of them writes to it or touches the tween. That
@@ -49,7 +56,7 @@ export interface FramingBounds {
 }
 
 /** Centre of a box. */
-function centerOf(min: Vec3, max: Vec3): Vec3 {
+export function centerOf(min: Vec3, max: Vec3): Vec3 {
   return {
     x: (min.x + max.x) / 2,
     y: (min.y + max.y) / 2,
@@ -58,7 +65,7 @@ function centerOf(min: Vec3, max: Vec3): Vec3 {
 }
 
 /** Largest edge length of a box. */
-function maxExtentOf(min: Vec3, max: Vec3): number {
+export function maxExtentOf(min: Vec3, max: Vec3): number {
   return Math.max(max.x - min.x, max.y - min.y, max.z - min.z);
 }
 
@@ -233,183 +240,4 @@ export function zoomExtentTarget(state: CameraInternalState, min: Vec3, max: Vec
     // The caller hands this to `CameraProjection.updateNearFarPlanes`.
     fitDistance: distance,
   };
-}
-
-/**
- * Get current bounds estimate (simplified - in production would use scene bounds).
- */
-export function estimateBoundsFromPose(state: CameraInternalState): FramingBounds {
-  // Estimate bounds from camera distance
-  const dir = {
-    x: state.camera.position.x - state.camera.target.x,
-    y: state.camera.position.y - state.camera.target.y,
-    z: state.camera.position.z - state.camera.target.z,
-  };
-  const distance = Math.sqrt(dir.x * dir.x + dir.y * dir.y + dir.z * dir.z);
-  const size = distance / 2;
-
-  return {
-    min: {
-      x: state.camera.target.x - size,
-      y: state.camera.target.y - size,
-      z: state.camera.target.z - size,
-    },
-    max: {
-      x: state.camera.target.x + size,
-      y: state.camera.target.y + size,
-      z: state.camera.target.z + size,
-    },
-  };
-}
-
-/**
- * Resolve the box a preset view should fit, from the caller's bounds or the
- * current pose, and reject it if it is not usable.
- *
- * This is the whole admission decision for `setPresetView`, deliberately kept
- * ahead of the rotation-cycling counter: a rejected preset must not advance
- * the cycle, and the caller can only honour that if the verdict arrives before
- * it mutates anything.
- */
-export function resolvePresetBounds(
-  state: CameraInternalState,
-  bounds?: FramingBounds,
-): FramingBounds | null {
-  const useBounds = bounds || estimateBoundsFromPose(state);
-  // Both sources need the check, not just the caller's: the pose-derived
-  // estimate above starts from the live pose, so a pose that is already
-  // malformed produces a malformed box and the ViewCube would then bake it in
-  // permanently. Rejecting leaves the preset un-applied, which keeps a
-  // recoverable pose recoverable (#2461).
-  if (!isUsableBounds(useBounds.min, useBounds.max)) {
-    console.warn('[Camera] Non-finite bounds for setPresetView; keeping current view');
-    return null;
-  }
-  return useBounds;
-}
-
-/**
- * Pose for a preset view (Y-up coordinate system).
- *
- * `bounds` must already have passed {@link resolvePresetBounds}; `rotation` is
- * the caller's 0-3 cycle position, which is why this takes it rather than
- * owning it — the counter belongs to the animator, which is what remembers
- * that the same face was clicked twice.
- *
- * @param buildingRotation Optional building rotation in radians (from IfcSite placement)
- */
-export function presetViewTarget(
-  state: CameraInternalState,
-  view: 'top' | 'bottom' | 'front' | 'back' | 'left' | 'right',
-  bounds: FramingBounds,
-  rotation: number,
-  buildingRotation?: number,
-): { position: Vec3; target: Vec3; up: Vec3 } {
-  const center = centerOf(bounds.min, bounds.max);
-  const maxSize = maxExtentOf(bounds.min, bounds.max);
-
-  // Calculate distance based on FOV for proper fit
-  const fovFactor = Math.tan(state.camera.fov / 2);
-  const distance = (maxSize / 2) / fovFactor * 1.5; // 1.5x for padding
-
-  let endPos: Vec3;
-  const endTarget = center;
-
-  // WebGL uses Y-up coordinate system internally
-  // We set both position AND up vector for proper orthogonal views
-  let upVector: Vec3 = { x: 0, y: 1, z: 0 }; // Default Y-up
-
-  // Apply building rotation if present (rotate around Y axis)
-  const cosR = buildingRotation !== undefined && buildingRotation !== 0 ? Math.cos(buildingRotation) : 1.0;
-  const sinR = buildingRotation !== undefined && buildingRotation !== 0 ? Math.sin(buildingRotation) : 0.0;
-
-  switch (view) {
-    case 'top': {
-      // Top view: position camera *just barely* off the +Y pole so the
-      // subsequent orbit math has a well-defined polar tangent (no pole
-      // singularity). camera.up stays world Y throughout — screen-up is
-      // then determined by lookAt projecting (0,1,0) onto perp(look),
-      // which falls along the horizontal component of `-look`.
-      //
-      // The 4 rotation cycles select which compass direction appears at
-      // the top of the screen by varying the small horizontal offset
-      // (theta in the spherical math).
-      //   rotation 0 → camera slightly to +Z of center → screen-up = +Z
-      //   rotation 1 → camera slightly to +X → screen-up = +X
-      //   rotation 2 → camera slightly to -Z → screen-up = -Z
-      //   rotation 3 → camera slightly to -X → screen-up = -X
-      // Building rotation is applied as the same Y-axis rotation that
-      // setPresetView would have used to remap the legacy up vector.
-      const poleOffset = Math.sin(0.01) * distance; // ~0.6° tilt
-      const verticalOffset = Math.cos(0.01) * distance;
-      const thetaPerRotation = [0, Math.PI / 2, Math.PI, -Math.PI / 2];
-      const thetaWorld = thetaPerRotation[rotation] + (buildingRotation ?? 0);
-      endPos = {
-        x: center.x + poleOffset * Math.sin(thetaWorld),
-        y: center.y + verticalOffset,
-        z: center.z + poleOffset * Math.cos(thetaWorld),
-      };
-      upVector = { x: 0, y: 1, z: 0 };
-      break;
-    }
-    case 'bottom': {
-      // Bottom view: mirror of top — phi = π − MIN_PHI.
-      const poleOffset = Math.sin(0.01) * distance;
-      const verticalOffset = Math.cos(0.01) * distance;
-      const thetaPerRotation = [Math.PI, Math.PI / 2, 0, -Math.PI / 2];
-      const thetaWorld = thetaPerRotation[rotation] + (buildingRotation ?? 0);
-      endPos = {
-        x: center.x + poleOffset * Math.sin(thetaWorld),
-        y: center.y - verticalOffset,
-        z: center.z + poleOffset * Math.cos(thetaWorld),
-      };
-      upVector = { x: 0, y: 1, z: 0 };
-      break;
-    }
-    case 'front':
-      // Front view: from +Z looking at model
-      // Rotate camera position around Y axis by building rotation
-      // Standard rotation: x' = x*cos - z*sin, z' = x*sin + z*cos
-      // For +Z direction (0,0,1): x' = -sin, z' = cos
-      // But we need to look at building's front, so use negative rotation
-      endPos = {
-        x: center.x + sinR * distance,
-        y: center.y,
-        z: center.z + cosR * distance,
-      };
-      upVector = { x: 0, y: 1, z: 0 }; // Y-up
-      break;
-    case 'back':
-      // Back view: from -Z looking at model
-      // For -Z direction (0,0,-1) rotated: x' = sin, z' = -cos
-      endPos = {
-        x: center.x - sinR * distance,
-        y: center.y,
-        z: center.z - cosR * distance,
-      };
-      upVector = { x: 0, y: 1, z: 0 }; // Y-up
-      break;
-    case 'left':
-      // Left view: from -X looking at model
-      // For -X direction (-1,0,0) rotated: x' = -cos, z' = sin
-      endPos = {
-        x: center.x - cosR * distance,
-        y: center.y,
-        z: center.z + sinR * distance,
-      };
-      upVector = { x: 0, y: 1, z: 0 }; // Y-up
-      break;
-    case 'right':
-      // Right view: from +X looking at model
-      // For +X direction (1,0,0) rotated: x' = cos, z' = -sin
-      endPos = {
-        x: center.x + cosR * distance,
-        y: center.y,
-        z: center.z - sinR * distance,
-      };
-      upVector = { x: 0, y: 1, z: 0 }; // Y-up
-      break;
-  }
-
-  return { position: endPos, target: endTarget, up: upVector };
 }

--- a/packages/renderer/src/camera-malformed-pose-navigation.test.ts
+++ b/packages/renderer/src/camera-malformed-pose-navigation.test.ts
@@ -455,7 +455,11 @@ describe('a malformed pose must not be spread by a navigation gesture (#2441)', 
       ['orbit with pivot', (c) => { c.setOrbitCenter({ x: 1, y: 2, z: 3 }); c.orbit(30, 20); }],
       ['zoom', (c) => c.zoom(-120)],
       ['zoom to cursor', (c) => c.zoom(-120, false, 400, 300, 800, 600)],
-      ['moveFirstPerson', (c) => c.moveFirstPerson(1, 0, 0)],
+      // Walk mode has to be entered first: `move` refuses to run while
+      // first-person mode is off, so without this the control would pass
+      // vacuously — it would prove nothing about the pose guards it exists to
+      // keep honest.
+      ['moveFirstPerson', (c) => { c.enableFirstPersonMode(true); c.moveFirstPerson(1, 0, 0); }],
     ];
     for (const [label, gesture] of gestures) {
       const camera = new Camera();
@@ -514,8 +518,10 @@ describe('camera gestures reject a malformed argument (#2473)', () => {
       ['pan', (c, d) => c.pan(d, 0)],
       ['pan deltaY', (c, d) => c.pan(0, d)],
       ['zoom', (c, d) => c.zoom(d)],
-      ['moveFirstPerson forward', (c, d) => c.moveFirstPerson(d, 0, 0)],
-      ['moveFirstPerson right', (c, d) => c.moveFirstPerson(0, d, 0)],
+      // Walk mode entered first, or the argument guard would never be reached
+      // and these two rows would pass on the mode gate alone.
+      ['moveFirstPerson forward', (c, d) => { c.enableFirstPersonMode(true); c.moveFirstPerson(d, 0, 0); }],
+      ['moveFirstPerson right', (c, d) => { c.enableFirstPersonMode(true); c.moveFirstPerson(0, d, 0); }],
     ];
     for (const [label, gesture] of gestures) {
       for (const delta of [Number.NaN, Infinity, -Infinity]) {

--- a/packages/renderer/src/camera-matrices.ts
+++ b/packages/renderer/src/camera-matrices.ts
@@ -23,7 +23,7 @@
 
 import { MathUtils } from './math.js';
 import type { CameraInternalState } from './camera-state.js';
-import { DEFAULT_ORTHO_SIZE } from './camera-guards.js';
+import { DEFAULT_ORTHO_SIZE, usableOrthoSize } from './camera-guards.js';
 
 export function updateCameraMatrices(state: CameraInternalState): void {
   const dx = state.camera.position.x - state.camera.target.x;
@@ -55,7 +55,17 @@ export function updateCameraMatrices(state: CameraInternalState): void {
     // interpolates it, so a NaN reaching either (from a malformed pose, or
     // from bounds that were themselves non-finite) would land straight in
     // the projection matrix. Same fallback shape as the distance above.
-    const h = Number.isFinite(state.orthoSize) ? state.orthoSize : DEFAULT_ORTHO_SIZE;
+    //
+    // Finiteness alone is not the whole backstop: `Number.isFinite(0)` is
+    // true, and a zero — or negative — half-height makes `right - left` and
+    // `top - bottom` zero, so `orthographicReverseZ` divides by zero and the
+    // matrix comes back with `Infinity` scale terms. That is the same dead
+    // viewport as a NaN, reached through a *valid-but-falsy* value rather
+    // than an exotic one. `usableOrthoSize` is the single predicate that says
+    // both things at once, and it is the same one every writer already goes
+    // through — so this backstop now enforces exactly the invariant the
+    // writers promise rather than half of it (#2441).
+    const h = usableOrthoSize(state.orthoSize) ?? DEFAULT_ORTHO_SIZE;
     const w = h * state.camera.aspect;
     state.projMatrix = MathUtils.orthographicReverseZ(
       -w, w, -h, h,
@@ -109,17 +119,45 @@ export function computeOrthoNearFar(
   let vy = state.camera.target.y - pos.y;
   let vz = state.camera.target.z - pos.z;
   const vLen = Math.sqrt(vx * vx + vy * vy + vz * vz);
-  if (vLen > 1e-8) { vx /= vLen; vy /= vLen; vz /= vLen; }
 
-  // Signed distance from camera to scene center along view direction
-  const toCenter = (cx - pos.x) * vx + (cy - pos.y) * vy + (cz - pos.z) * vz;
-
-  // Near/far as distances from camera along view direction.
-  // The sphere spans [toCenter - radius, toCenter + radius] along view dir.
   // Add 10% padding for safety.
   const pad = radius * 0.1 + 1;
-  let near = toCenter - radius - pad;
-  let far = toCenter + radius + pad;
+  let near: number;
+  let far: number;
+
+  if (Number.isFinite(vLen) && vLen > 1e-8) {
+    vx /= vLen; vy /= vLen; vz /= vLen;
+
+    // Signed distance from camera to scene center along view direction
+    const toCenter = (cx - pos.x) * vx + (cy - pos.y) * vy + (cz - pos.z) * vz;
+
+    // Near/far as distances from camera along view direction.
+    // The sphere spans [toCenter - radius, toCenter + radius] along view dir.
+    near = toCenter - radius - pad;
+    far = toCenter + radius + pad;
+  } else {
+    // No view direction to project onto — position and target coincide, or
+    // the pose is non-finite. Skipping the normalization (which is what the
+    // bare `vLen > 1e-8` did) left `v` at its raw near-zero value, so
+    // `toCenter` collapsed to ~0 and the range came out centred on the
+    // *camera* rather than on the scene: a camera parked 1000 units away got
+    // `[-(r + pad), +(r + pad)]` and clipped the entire model away, which is
+    // a blank viewport reached through a range that is perfectly finite and
+    // therefore sails past the non-finite backstop below.
+    //
+    // There is no honest direction to substitute either: `MathUtils.lookAt`
+    // picks its own fallback basis for a degenerate pose, and any axis chosen
+    // here could disagree with the one the frame is actually drawn from.
+    // Bracket the whole bounding sphere symmetrically instead — that contains
+    // the scene whichever way `lookAt` ended up looking.
+    const span = Math.sqrt(
+      (cx - pos.x) * (cx - pos.x) +
+      (cy - pos.y) * (cy - pos.y) +
+      (cz - pos.z) * (cz - pos.z)
+    ) + radius + pad;
+    near = -span;
+    far = span;
+  }
 
   // Ensure minimum range for depth precision
   if (far - near < 1) { near -= 0.5; far += 0.5; }

--- a/packages/renderer/src/camera-matrices.ts
+++ b/packages/renderer/src/camera-matrices.ts
@@ -1,0 +1,135 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * View / projection / view-projection matrix derivation.
+ *
+ * One subject: camera state in, three finite matrices out. Its failure story
+ * is the #2441 near/far backstops — a non-finite pose or `orthoSize` must not
+ * reach the projection matrix, because `MathUtils.lookAt` scrubs the *view*
+ * matrix but nothing scrubs the projection one, and a NaN there leaves the
+ * viewport dead while every other reading looks healthy.
+ *
+ * **Hot path.** `updateCameraMatrices` runs on every frame the camera moves.
+ * It takes the shared state object **by reference** and nothing else: do not
+ * destructure it into parameters (that allocates an arguments object per
+ * frame) and do not widen the parameter to a structural supertype (that
+ * invites megamorphic dispatch). The allocation profile is deliberately
+ * unchanged from the method this replaced — `lookAt`, `perspectiveReverseZ` /
+ * `orthographicReverseZ` and `multiply` each already return a fresh `Mat4`,
+ * and the ortho branch already returned a fresh `{near, far}` per frame.
+ */
+
+import { MathUtils } from './math.js';
+import type { CameraInternalState } from './camera-state.js';
+import { DEFAULT_ORTHO_SIZE } from './camera-guards.js';
+
+export function updateCameraMatrices(state: CameraInternalState): void {
+  const dx = state.camera.position.x - state.camera.target.x;
+  const dy = state.camera.position.y - state.camera.target.y;
+  const dz = state.camera.position.z - state.camera.target.z;
+  const rawDistance = Math.sqrt(dx * dx + dy * dy + dz * dz);
+  // A non-finite position or target — a malformed BCF viewpoint reaches the
+  // public setters unvalidated — would put NaN into near/far and from there
+  // into the projection matrix, leaving the viewport dead even though
+  // `MathUtils.lookAt` scrubs the view matrix (#2441). Fall back to a
+  // neutral distance so the projection stays finite; the camera state itself
+  // is left as the caller set it.
+  const distance = Number.isFinite(rawDistance) ? rawDistance : 1;
+
+  state.viewMatrix = MathUtils.lookAt(
+    state.camera.position,
+    state.camera.target,
+    state.camera.up
+  );
+
+  if (state.projectionMode === 'orthographic') {
+    // Orthographic: project scene bounding sphere onto view direction for tight near/far.
+    // Tight range maximizes depth precision (less z-fighting) and prevents clipping.
+    const nf = computeOrthoNearFar(state, distance);
+    state.camera.near = nf.near;
+    state.camera.far = nf.far;
+    // Backstop for the writers that never see `setOrthoSize`'s clamp: the
+    // orthographic zoom scales `orthoSize` in place and the animator
+    // interpolates it, so a NaN reaching either (from a malformed pose, or
+    // from bounds that were themselves non-finite) would land straight in
+    // the projection matrix. Same fallback shape as the distance above.
+    const h = Number.isFinite(state.orthoSize) ? state.orthoSize : DEFAULT_ORTHO_SIZE;
+    const w = h * state.camera.aspect;
+    state.projMatrix = MathUtils.orthographicReverseZ(
+      -w, w, -h, h,
+      state.camera.near,
+      state.camera.far
+    );
+  } else {
+    // Perspective: adapt near/far based on camera-to-target distance
+    state.camera.near = Math.max(0.01, distance * 0.001);
+    state.camera.far = Math.max(distance * 10, 1000);
+    state.projMatrix = MathUtils.perspectiveReverseZ(
+      state.camera.fov,
+      state.camera.aspect,
+      state.camera.near,
+      state.camera.far
+    );
+  }
+
+  state.viewProjMatrix = MathUtils.multiply(state.projMatrix, state.viewMatrix);
+}
+
+/**
+ * Compute tight near/far for orthographic mode by projecting the scene
+ * bounding sphere onto the camera view direction.
+ *
+ * This gives optimal depth precision (minimizing z-fighting) while ensuring
+ * no geometry is clipped regardless of camera position or view angle.
+ */
+export function computeOrthoNearFar(
+  state: CameraInternalState,
+  distance: number,
+): { near: number; far: number } {
+  const bounds = state.sceneBounds;
+  if (!bounds) {
+    // Fallback: generous range centered on camera
+    return { near: -Math.max(distance, 500), far: Math.max(distance, 500) };
+  }
+
+  // Scene bounding sphere center and radius
+  const cx = (bounds.min.x + bounds.max.x) / 2;
+  const cy = (bounds.min.y + bounds.max.y) / 2;
+  const cz = (bounds.min.z + bounds.max.z) / 2;
+  const ex = bounds.max.x - bounds.min.x;
+  const ey = bounds.max.y - bounds.min.y;
+  const ez = bounds.max.z - bounds.min.z;
+  const radius = Math.sqrt(ex * ex + ey * ey + ez * ez) / 2;
+
+  // View direction (camera looks from position toward target)
+  const pos = state.camera.position;
+  let vx = state.camera.target.x - pos.x;
+  let vy = state.camera.target.y - pos.y;
+  let vz = state.camera.target.z - pos.z;
+  const vLen = Math.sqrt(vx * vx + vy * vy + vz * vz);
+  if (vLen > 1e-8) { vx /= vLen; vy /= vLen; vz /= vLen; }
+
+  // Signed distance from camera to scene center along view direction
+  const toCenter = (cx - pos.x) * vx + (cy - pos.y) * vy + (cz - pos.z) * vz;
+
+  // Near/far as distances from camera along view direction.
+  // The sphere spans [toCenter - radius, toCenter + radius] along view dir.
+  // Add 10% padding for safety.
+  const pad = radius * 0.1 + 1;
+  let near = toCenter - radius - pad;
+  let far = toCenter + radius + pad;
+
+  // Ensure minimum range for depth precision
+  if (far - near < 1) { near -= 0.5; far += 0.5; }
+
+  // Same contract as the perspective branch: a non-finite camera position or
+  // scene bound must not reach the projection matrix (#2441).
+  if (!Number.isFinite(near) || !Number.isFinite(far)) {
+    const fallback = Math.max(Number.isFinite(distance) ? distance : 0, 500);
+    return { near: -fallback, far: fallback };
+  }
+
+  return { near, far };
+}

--- a/packages/renderer/src/camera-preset-view.ts
+++ b/packages/renderer/src/camera-preset-view.ts
@@ -29,7 +29,7 @@
 import type { Vec3 } from './types.js';
 import type { CameraInternalState } from './camera-state.js';
 import { isUsableBounds } from './camera-guards.js';
-import { centerOf, maxExtentOf, type FramingBounds } from './camera-framing.js';
+import { centerOf, fitDistanceFor, maxExtentOf, type FramingBounds } from './camera-framing.js';
 
 /**
  * Get current bounds estimate (simplified - in production would use scene bounds).
@@ -104,9 +104,10 @@ export function presetViewTarget(
   const center = centerOf(bounds.min, bounds.max);
   const maxSize = maxExtentOf(bounds.min, bounds.max);
 
-  // Calculate distance based on FOV for proper fit
-  const fovFactor = Math.tan(state.camera.fov / 2);
-  const distance = (maxSize / 2) / fovFactor * 1.5; // 1.5x for padding
+  // Calculate distance based on FOV for proper fit. Aspect-aware: on a
+  // portrait viewport the horizontal field is the narrower one, and a preset
+  // fitted to the vertical field alone overflows it. See `fitDistanceFor`.
+  const distance = fitDistanceFor(state, maxSize, 1.5); // 1.5x for padding
 
   let endPos: Vec3;
   const endTarget = center;
@@ -115,9 +116,18 @@ export function presetViewTarget(
   // We set both position AND up vector for proper orthogonal views
   let upVector: Vec3 = { x: 0, y: 1, z: 0 }; // Default Y-up
 
-  // Apply building rotation if present (rotate around Y axis)
-  const cosR = buildingRotation !== undefined && buildingRotation !== 0 ? Math.cos(buildingRotation) : 1.0;
-  const sinR = buildingRotation !== undefined && buildingRotation !== 0 ? Math.sin(buildingRotation) : 0.0;
+  // Apply building rotation if present (rotate around Y axis).
+  //
+  // Normalized rather than trusted: this is the IfcSite placement angle,
+  // derived from the file and threaded through `Camera.setPresetView` — the
+  // published entry point — without ever meeting a guard. `Math.cos(NaN)` is
+  // NaN, and the four horizontal presets multiply it straight into `endPos`,
+  // so a malformed placement would send the ViewCube to a non-finite pose. A
+  // zero rotation is the same answer as "no rotation supplied", which is what
+  // the undefined case already resolves to.
+  const rotationRadians = Number.isFinite(buildingRotation) ? (buildingRotation as number) : 0;
+  const cosR = rotationRadians !== 0 ? Math.cos(rotationRadians) : 1.0;
+  const sinR = rotationRadians !== 0 ? Math.sin(rotationRadians) : 0.0;
 
   switch (view) {
     case 'top': {
@@ -138,8 +148,12 @@ export function presetViewTarget(
       // setPresetView would have used to remap the legacy up vector.
       const poleOffset = Math.sin(0.01) * distance; // ~0.6° tilt
       const verticalOffset = Math.cos(0.01) * distance;
+      // `?? 0`: `rotation` is the animator's 0-3 cycle counter today, but it
+      // is a plain `number` on the signature, and an out-of-range, fractional
+      // or non-finite one indexes past the table and makes `thetaWorld` — and
+      // with it the whole preset pose — NaN.
       const thetaPerRotation = [0, Math.PI / 2, Math.PI, -Math.PI / 2];
-      const thetaWorld = thetaPerRotation[rotation] + (buildingRotation ?? 0);
+      const thetaWorld = (thetaPerRotation[rotation] ?? 0) + rotationRadians;
       endPos = {
         x: center.x + poleOffset * Math.sin(thetaWorld),
         y: center.y + verticalOffset,
@@ -153,7 +167,7 @@ export function presetViewTarget(
       const poleOffset = Math.sin(0.01) * distance;
       const verticalOffset = Math.cos(0.01) * distance;
       const thetaPerRotation = [Math.PI, Math.PI / 2, 0, -Math.PI / 2];
-      const thetaWorld = thetaPerRotation[rotation] + (buildingRotation ?? 0);
+      const thetaWorld = (thetaPerRotation[rotation] ?? 0) + rotationRadians;
       endPos = {
         x: center.x + poleOffset * Math.sin(thetaWorld),
         y: center.y - verticalOffset,

--- a/packages/renderer/src/camera-preset-view.ts
+++ b/packages/renderer/src/camera-preset-view.ts
@@ -1,0 +1,211 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Preset views: the ViewCube's six named directions, plus the admission check
+ * that decides whether a preset may be applied at all.
+ *
+ * Split out of `camera-framing.ts`, which owns the *free* framing pickers
+ * (point / bounds / extents — "put the camera on this thing, keeping the
+ * current direction"). Presets are the opposite subject: the direction is
+ * dictated by the named face and the caller's rotation cycle, and the box is
+ * whatever the caller supplied or whatever the current pose implies. The two
+ * share only box arithmetic, which is why this module imports `centerOf` /
+ * `maxExtentOf` rather than owning a second copy.
+ *
+ * Pure by construction, exactly as `camera-framing.ts` is: everything here
+ * reads `CameraInternalState` and returns a target, nothing writes to it or
+ * touches the tween. That is what keeps both modules free of a cycle back into
+ * `camera-animation.ts`, which is the one that applies the results.
+ *
+ * **Guard placement.** `resolvePresetBounds` validates the box exactly once,
+ * here, and a rejection is `null`. Callers null-check and do nothing else: a
+ * second, defensive copy of the same guard in the caller would mean neither
+ * copy is load-bearing on its own, and the mutation test that pins this guard
+ * would go quiet while still looking green.
+ */
+
+import type { Vec3 } from './types.js';
+import type { CameraInternalState } from './camera-state.js';
+import { isUsableBounds } from './camera-guards.js';
+import { centerOf, maxExtentOf, type FramingBounds } from './camera-framing.js';
+
+/**
+ * Get current bounds estimate (simplified - in production would use scene bounds).
+ */
+export function estimateBoundsFromPose(state: CameraInternalState): FramingBounds {
+  // Estimate bounds from camera distance
+  const dir = {
+    x: state.camera.position.x - state.camera.target.x,
+    y: state.camera.position.y - state.camera.target.y,
+    z: state.camera.position.z - state.camera.target.z,
+  };
+  const distance = Math.sqrt(dir.x * dir.x + dir.y * dir.y + dir.z * dir.z);
+  const size = distance / 2;
+
+  return {
+    min: {
+      x: state.camera.target.x - size,
+      y: state.camera.target.y - size,
+      z: state.camera.target.z - size,
+    },
+    max: {
+      x: state.camera.target.x + size,
+      y: state.camera.target.y + size,
+      z: state.camera.target.z + size,
+    },
+  };
+}
+
+/**
+ * Resolve the box a preset view should fit, from the caller's bounds or the
+ * current pose, and reject it if it is not usable.
+ *
+ * This is the whole admission decision for `setPresetView`, deliberately kept
+ * ahead of the rotation-cycling counter: a rejected preset must not advance
+ * the cycle, and the caller can only honour that if the verdict arrives before
+ * it mutates anything.
+ */
+export function resolvePresetBounds(
+  state: CameraInternalState,
+  bounds?: FramingBounds,
+): FramingBounds | null {
+  const useBounds = bounds || estimateBoundsFromPose(state);
+  // Both sources need the check, not just the caller's: the pose-derived
+  // estimate above starts from the live pose, so a pose that is already
+  // malformed produces a malformed box and the ViewCube would then bake it in
+  // permanently. Rejecting leaves the preset un-applied, which keeps a
+  // recoverable pose recoverable (#2461).
+  if (!isUsableBounds(useBounds.min, useBounds.max)) {
+    console.warn('[Camera] Non-finite bounds for setPresetView; keeping current view');
+    return null;
+  }
+  return useBounds;
+}
+
+/**
+ * Pose for a preset view (Y-up coordinate system).
+ *
+ * `bounds` must already have passed {@link resolvePresetBounds}; `rotation` is
+ * the caller's 0-3 cycle position, which is why this takes it rather than
+ * owning it — the counter belongs to the animator, which is what remembers
+ * that the same face was clicked twice.
+ *
+ * @param buildingRotation Optional building rotation in radians (from IfcSite placement)
+ */
+export function presetViewTarget(
+  state: CameraInternalState,
+  view: 'top' | 'bottom' | 'front' | 'back' | 'left' | 'right',
+  bounds: FramingBounds,
+  rotation: number,
+  buildingRotation?: number,
+): { position: Vec3; target: Vec3; up: Vec3 } {
+  const center = centerOf(bounds.min, bounds.max);
+  const maxSize = maxExtentOf(bounds.min, bounds.max);
+
+  // Calculate distance based on FOV for proper fit
+  const fovFactor = Math.tan(state.camera.fov / 2);
+  const distance = (maxSize / 2) / fovFactor * 1.5; // 1.5x for padding
+
+  let endPos: Vec3;
+  const endTarget = center;
+
+  // WebGL uses Y-up coordinate system internally
+  // We set both position AND up vector for proper orthogonal views
+  let upVector: Vec3 = { x: 0, y: 1, z: 0 }; // Default Y-up
+
+  // Apply building rotation if present (rotate around Y axis)
+  const cosR = buildingRotation !== undefined && buildingRotation !== 0 ? Math.cos(buildingRotation) : 1.0;
+  const sinR = buildingRotation !== undefined && buildingRotation !== 0 ? Math.sin(buildingRotation) : 0.0;
+
+  switch (view) {
+    case 'top': {
+      // Top view: position camera *just barely* off the +Y pole so the
+      // subsequent orbit math has a well-defined polar tangent (no pole
+      // singularity). camera.up stays world Y throughout — screen-up is
+      // then determined by lookAt projecting (0,1,0) onto perp(look),
+      // which falls along the horizontal component of `-look`.
+      //
+      // The 4 rotation cycles select which compass direction appears at
+      // the top of the screen by varying the small horizontal offset
+      // (theta in the spherical math).
+      //   rotation 0 → camera slightly to +Z of center → screen-up = +Z
+      //   rotation 1 → camera slightly to +X → screen-up = +X
+      //   rotation 2 → camera slightly to -Z → screen-up = -Z
+      //   rotation 3 → camera slightly to -X → screen-up = -X
+      // Building rotation is applied as the same Y-axis rotation that
+      // setPresetView would have used to remap the legacy up vector.
+      const poleOffset = Math.sin(0.01) * distance; // ~0.6° tilt
+      const verticalOffset = Math.cos(0.01) * distance;
+      const thetaPerRotation = [0, Math.PI / 2, Math.PI, -Math.PI / 2];
+      const thetaWorld = thetaPerRotation[rotation] + (buildingRotation ?? 0);
+      endPos = {
+        x: center.x + poleOffset * Math.sin(thetaWorld),
+        y: center.y + verticalOffset,
+        z: center.z + poleOffset * Math.cos(thetaWorld),
+      };
+      upVector = { x: 0, y: 1, z: 0 };
+      break;
+    }
+    case 'bottom': {
+      // Bottom view: mirror of top — phi = π − MIN_PHI.
+      const poleOffset = Math.sin(0.01) * distance;
+      const verticalOffset = Math.cos(0.01) * distance;
+      const thetaPerRotation = [Math.PI, Math.PI / 2, 0, -Math.PI / 2];
+      const thetaWorld = thetaPerRotation[rotation] + (buildingRotation ?? 0);
+      endPos = {
+        x: center.x + poleOffset * Math.sin(thetaWorld),
+        y: center.y - verticalOffset,
+        z: center.z + poleOffset * Math.cos(thetaWorld),
+      };
+      upVector = { x: 0, y: 1, z: 0 };
+      break;
+    }
+    case 'front':
+      // Front view: from +Z looking at model
+      // Rotate camera position around Y axis by building rotation
+      // Standard rotation: x' = x*cos - z*sin, z' = x*sin + z*cos
+      // For +Z direction (0,0,1): x' = -sin, z' = cos
+      // But we need to look at building's front, so use negative rotation
+      endPos = {
+        x: center.x + sinR * distance,
+        y: center.y,
+        z: center.z + cosR * distance,
+      };
+      upVector = { x: 0, y: 1, z: 0 }; // Y-up
+      break;
+    case 'back':
+      // Back view: from -Z looking at model
+      // For -Z direction (0,0,-1) rotated: x' = sin, z' = -cos
+      endPos = {
+        x: center.x - sinR * distance,
+        y: center.y,
+        z: center.z - cosR * distance,
+      };
+      upVector = { x: 0, y: 1, z: 0 }; // Y-up
+      break;
+    case 'left':
+      // Left view: from -X looking at model
+      // For -X direction (-1,0,0) rotated: x' = -cos, z' = sin
+      endPos = {
+        x: center.x - cosR * distance,
+        y: center.y,
+        z: center.z + sinR * distance,
+      };
+      upVector = { x: 0, y: 1, z: 0 }; // Y-up
+      break;
+    case 'right':
+      // Right view: from +X looking at model
+      // For +X direction (1,0,0) rotated: x' = cos, z' = -sin
+      endPos = {
+        x: center.x + cosR * distance,
+        y: center.y,
+        z: center.z - sinR * distance,
+      };
+      upVector = { x: 0, y: 1, z: 0 }; // Y-up
+      break;
+  }
+
+  return { position: endPos, target: endTarget, up: upVector };
+}

--- a/packages/renderer/src/camera-projection.ts
+++ b/packages/renderer/src/camera-projection.ts
@@ -8,7 +8,7 @@
  */
 
 import type { Vec3 } from './types.js';
-import type { CameraInternalState } from './camera-controls.js';
+import type { CameraInternalState } from './camera-state.js';
 import { MathUtils, viewBasis } from './math.js';
 import { DEFAULT_ORTHO_SIZE, isUsableBounds } from './camera-guards.js';
 

--- a/packages/renderer/src/camera-state.ts
+++ b/packages/renderer/src/camera-state.ts
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The state object every camera sub-system shares.
+ *
+ * This lives on its own rather than inside one of the consumers: `camera.ts`,
+ * `camera-controls.ts`, `camera-animation.ts`, `camera-projection.ts`,
+ * `camera-matrices.ts`, `camera-framing.ts` and `camera-first-person.ts` all
+ * need the type, and declaring it inside the gesture module made four of them
+ * import their core type from a sibling that is otherwise unrelated to them.
+ * Owning it here turns that chain into a star.
+ */
+
+import type { Camera as CameraType, Mat4 } from './types.js';
+
+/** Projection mode for the camera */
+export type ProjectionMode = 'perspective' | 'orthographic';
+
+/**
+ * Shared mutable state for camera sub-systems.
+ * All sub-systems reference the same state object so changes are visible across them.
+ */
+export interface CameraInternalState {
+  camera: CameraType;
+  viewMatrix: Mat4;
+  projMatrix: Mat4;
+  viewProjMatrix: Mat4;
+  /** Current projection mode */
+  projectionMode: ProjectionMode;
+  /** Orthographic half-height in world units (controls zoom level in ortho mode) */
+  orthoSize: number;
+  /** Scene bounding box for tight orthographic near/far computation */
+  sceneBounds: { min: { x: number; y: number; z: number }; max: { x: number; y: number; z: number } } | null;
+  /**
+   * Optional outlier-robust bounds for anchoring the orbit pivot (issue #1394).
+   * Distinct from `sceneBounds`: the renderer keeps `sceneBounds` synced to the
+   * FULL model AABB (needed for near/far clipping and section ranges), but a
+   * handful of far-flung meshes can push that AABB's centre into empty space,
+   * which the orbit-pivot fallback would then rotate around. When set, the pivot
+   * uses this tighter centre instead. `null` ⇒ fall back to `sceneBounds`.
+   */
+  orbitAnchorBounds: { min: { x: number; y: number; z: number }; max: { x: number; y: number; z: number } } | null;
+}

--- a/packages/renderer/src/camera-state.ts
+++ b/packages/renderer/src/camera-state.ts
@@ -7,7 +7,8 @@
  *
  * This lives on its own rather than inside one of the consumers: `camera.ts`,
  * `camera-controls.ts`, `camera-animation.ts`, `camera-projection.ts`,
- * `camera-matrices.ts`, `camera-framing.ts` and `camera-first-person.ts` all
+ * `camera-matrices.ts`, `camera-framing.ts`, `camera-preset-view.ts` and
+ * `camera-first-person.ts` all
  * need the type, and declaring it inside the gesture module made four of them
  * import their core type from a sibling that is otherwise unrelated to them.
  * Owning it here turns that chain into a star.

--- a/packages/renderer/src/camera-walk-mode.test.ts
+++ b/packages/renderer/src/camera-walk-mode.test.ts
@@ -1,0 +1,127 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Walk mode is a mode, and `enableFirstPersonMode` is what turns it on.
+ *
+ * It was not. The flag was written and never read — `moveFirstPerson` walked
+ * the camera whether or not walk mode had ever been entered — and the only
+ * thing hiding that in the app was the viewer's *second*, independent check on
+ * `activeTool === 'walk'` in `useKeyboardControls`. Two unrelated gates for one
+ * decision means neither is load-bearing on its own, and `@ifc-lite/renderer`
+ * is published: an embedder wiring its own key handler to `moveFirstPerson`
+ * has only this one. Pre-existing on `origin/main` (the flag lived on
+ * `CameraAnimator` there, equally unread); the module split is what made it
+ * visible (PR #2500, issue #2460).
+ *
+ * The velocity half is the same defect's tail: `walkVelocity` is smoothed in
+ * place, so whatever the user was walking when they left walk mode — or loaded
+ * a different model — was still there to be spent on the first frame after
+ * they came back.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import { Camera } from './camera.js';
+import type { Vec3 } from './types.js';
+
+function poseOf(camera: Camera): { position: Vec3; target: Vec3 } {
+  return { position: camera.getPosition(), target: camera.getTarget() };
+}
+
+/** A camera on a perfectly ordinary pose, facing along -Z. */
+function walkerCamera(): Camera {
+  const camera = new Camera();
+  camera.setAspect(16 / 9);
+  camera.setPosition(0, 2, 50);
+  camera.setTarget(0, 2, 0);
+  return camera;
+}
+
+describe('first-person mode gates first-person movement (#2500)', () => {
+  it('a fresh camera does not walk', () => {
+    // `isFirstPersonMode` starts false and nothing has enabled it, so this is
+    // the state an embedder is in before it ever opts into walk mode.
+    const camera = walkerCamera();
+    const before = poseOf(camera);
+    for (let i = 0; i < 10; i++) camera.moveFirstPerson(1, 0, 0);
+    assert.deepStrictEqual(poseOf(camera), before, 'a camera that never entered walk mode must not move');
+  });
+
+  it('stops walking again once the mode is turned off', () => {
+    const camera = walkerCamera();
+    camera.enableFirstPersonMode(true);
+    camera.moveFirstPerson(1, 0, 0);
+    const walked = poseOf(camera);
+    assert.notDeepStrictEqual(walked, poseOf(walkerCamera()), 'control: walking must work while enabled');
+
+    camera.enableFirstPersonMode(false);
+    for (let i = 0; i < 10; i++) camera.moveFirstPerson(1, 0, 0);
+    assert.deepStrictEqual(poseOf(camera), walked, 'the camera must not move after walk mode is left');
+  });
+
+  it('does not lurch on the first frame after walk mode is re-entered', () => {
+    // `walkVelocity` is accumulated with `+= (target - current) * 0.15`, so a
+    // velocity built up before leaving walk mode was still 85% intact on
+    // return and got spent in whatever direction the user had been walking.
+    const primed = walkerCamera();
+    primed.enableFirstPersonMode(true);
+    for (let i = 0; i < 20; i++) primed.moveFirstPerson(1, 0, 0);
+    primed.enableFirstPersonMode(false);
+    primed.setPosition(0, 2, 50);
+    primed.setTarget(0, 2, 0);
+    primed.enableFirstPersonMode(true);
+    primed.moveFirstPerson(1, 0, 0);
+    const primedStep = 50 - primed.getPosition().z;
+
+    const fresh = walkerCamera();
+    fresh.enableFirstPersonMode(true);
+    fresh.moveFirstPerson(1, 0, 0);
+    const freshStep = 50 - fresh.getPosition().z;
+
+    assert.ok(
+      Math.abs(primedStep - freshStep) < 1e-9,
+      `first step after re-entry was ${primedStep}, a fresh first step is ${freshStep}`,
+    );
+  });
+
+  it('drops the accumulated walk velocity on model reset', () => {
+    // `reset()` is the model-swap hook. The walk velocity survived it — it
+    // used to live on `CameraAnimator`, whose `reset()` did not clear it
+    // either — so the first walk frame on a newly loaded model carried the
+    // previous model's momentum.
+    const carried = walkerCamera();
+    carried.enableFirstPersonMode(true);
+    for (let i = 0; i < 20; i++) carried.moveFirstPerson(1, 0, 0);
+    carried.reset();
+    carried.setPosition(0, 2, 50);
+    carried.setTarget(0, 2, 0);
+    carried.moveFirstPerson(1, 0, 0);
+    const carriedStep = 50 - carried.getPosition().z;
+
+    const fresh = walkerCamera();
+    fresh.enableFirstPersonMode(true);
+    fresh.moveFirstPerson(1, 0, 0);
+    const freshStep = 50 - fresh.getPosition().z;
+
+    assert.ok(
+      Math.abs(carriedStep - freshStep) < 1e-9,
+      `first step after reset was ${carriedStep}, a fresh first step is ${freshStep}`,
+    );
+  });
+
+  it('anti-mutation: reset does not silently leave walk mode', () => {
+    // The mode mirrors the viewer's active tool, which a model load does not
+    // change, and no effect re-runs to restore it. Clearing it in `reset()`
+    // would leave walk mode dead until the user toggled the tool twice — a
+    // regression the tests above could not see, because they all re-enable.
+    const camera = walkerCamera();
+    camera.enableFirstPersonMode(true);
+    camera.reset();
+    const before = poseOf(camera);
+    camera.moveFirstPerson(1, 0, 0);
+    assert.notDeepStrictEqual(poseOf(camera), before, 'walk mode must survive a model reset');
+  });
+});

--- a/packages/renderer/src/camera.ts
+++ b/packages/renderer/src/camera.ts
@@ -12,9 +12,12 @@
 
 import type { Vec3, Mat4 } from './types.js';
 import { MathUtils } from './math.js';
-import { CameraControls, type CameraInternalState, type ProjectionMode } from './camera-controls.js';
+import { CameraControls } from './camera-controls.js';
+import type { CameraInternalState, ProjectionMode } from './camera-state.js';
 import { CameraAnimator } from './camera-animation.js';
 import { CameraProjection } from './camera-projection.js';
+import { FirstPersonNavigator } from './camera-first-person.js';
+import { updateCameraMatrices } from './camera-matrices.js';
 import { pickFitPolicy, type Bounds3, type FitPolicy, type PickFitPolicyOptions } from './camera-fit-policy.js';
 import {
   DEFAULT_ORTHO_SIZE,
@@ -28,6 +31,7 @@ export class Camera {
   private controls: CameraControls;
   private animator: CameraAnimator;
   private projection: CameraProjection;
+  private firstPerson: FirstPersonNavigator;
 
   constructor() {
     // Geometry is converted from IFC Z-up to WebGL Y-up during import
@@ -50,11 +54,25 @@ export class Camera {
       orbitAnchorBounds: null,
     };
 
-    const updateMatrices = () => this.updateMatrices();
+    // Bound straight to the module-level function rather than to
+    // `this.updateMatrices()`: this closure is the per-frame path every
+    // sub-system drives the matrices through, and routing it via the private
+    // method would add a hop to it. Depth is therefore unchanged from before
+    // the extraction (closure → one call), and the callee is monomorphic.
+    const updateMatrices = () => updateCameraMatrices(this.state);
     this.controls = new CameraControls(this.state, updateMatrices);
     this.projection = new CameraProjection(this.state, updateMatrices);
     this.animator = new CameraAnimator(this.state, updateMatrices, this.controls, this.projection);
+    this.firstPerson = new FirstPersonNavigator(this.state, updateMatrices);
     this.updateMatrices();
+  }
+
+  /**
+   * Cold-path convenience for this class's own setters. The hot path uses the
+   * closure built in the constructor; see the note there.
+   */
+  private updateMatrices(): void {
+    updateCameraMatrices(this.state);
   }
 
   /**
@@ -289,14 +307,14 @@ export class Camera {
    * Set first-person mode
    */
   enableFirstPersonMode(enabled: boolean): void {
-    this.animator.enableFirstPersonMode(enabled);
+    this.firstPerson.setEnabled(enabled);
   }
 
   /**
    * Move in first-person mode (Y-up coordinate system)
    */
   moveFirstPerson(forward: number, right: number, up: number): void {
-    this.animator.moveFirstPerson(forward, right, up);
+    this.firstPerson.move(forward, right, up);
   }
 
   /**
@@ -551,111 +569,5 @@ export class Camera {
    */
   getOrbitAnchorBounds(): { min: { x: number; y: number; z: number }; max: { x: number; y: number; z: number } } | null {
     return this.state.orbitAnchorBounds;
-  }
-
-  private updateMatrices(): void {
-    const dx = this.state.camera.position.x - this.state.camera.target.x;
-    const dy = this.state.camera.position.y - this.state.camera.target.y;
-    const dz = this.state.camera.position.z - this.state.camera.target.z;
-    const rawDistance = Math.sqrt(dx * dx + dy * dy + dz * dz);
-    // A non-finite position or target — a malformed BCF viewpoint reaches the
-    // public setters unvalidated — would put NaN into near/far and from there
-    // into the projection matrix, leaving the viewport dead even though
-    // `MathUtils.lookAt` scrubs the view matrix (#2441). Fall back to a
-    // neutral distance so the projection stays finite; the camera state itself
-    // is left as the caller set it.
-    const distance = Number.isFinite(rawDistance) ? rawDistance : 1;
-
-    this.state.viewMatrix = MathUtils.lookAt(
-      this.state.camera.position,
-      this.state.camera.target,
-      this.state.camera.up
-    );
-
-    if (this.state.projectionMode === 'orthographic') {
-      // Orthographic: project scene bounding sphere onto view direction for tight near/far.
-      // Tight range maximizes depth precision (less z-fighting) and prevents clipping.
-      const nf = this.computeOrthoNearFar(distance);
-      this.state.camera.near = nf.near;
-      this.state.camera.far = nf.far;
-      // Backstop for the writers that never see `setOrthoSize`'s clamp: the
-      // orthographic zoom scales `orthoSize` in place and the animator
-      // interpolates it, so a NaN reaching either (from a malformed pose, or
-      // from bounds that were themselves non-finite) would land straight in
-      // the projection matrix. Same fallback shape as the distance above.
-      const h = Number.isFinite(this.state.orthoSize) ? this.state.orthoSize : DEFAULT_ORTHO_SIZE;
-      const w = h * this.state.camera.aspect;
-      this.state.projMatrix = MathUtils.orthographicReverseZ(
-        -w, w, -h, h,
-        this.state.camera.near,
-        this.state.camera.far
-      );
-    } else {
-      // Perspective: adapt near/far based on camera-to-target distance
-      this.state.camera.near = Math.max(0.01, distance * 0.001);
-      this.state.camera.far = Math.max(distance * 10, 1000);
-      this.state.projMatrix = MathUtils.perspectiveReverseZ(
-        this.state.camera.fov,
-        this.state.camera.aspect,
-        this.state.camera.near,
-        this.state.camera.far
-      );
-    }
-
-    this.state.viewProjMatrix = MathUtils.multiply(this.state.projMatrix, this.state.viewMatrix);
-  }
-
-  /**
-   * Compute tight near/far for orthographic mode by projecting the scene
-   * bounding sphere onto the camera view direction.
-   *
-   * This gives optimal depth precision (minimizing z-fighting) while ensuring
-   * no geometry is clipped regardless of camera position or view angle.
-   */
-  private computeOrthoNearFar(distance: number): { near: number; far: number } {
-    const bounds = this.state.sceneBounds;
-    if (!bounds) {
-      // Fallback: generous range centered on camera
-      return { near: -Math.max(distance, 500), far: Math.max(distance, 500) };
-    }
-
-    // Scene bounding sphere center and radius
-    const cx = (bounds.min.x + bounds.max.x) / 2;
-    const cy = (bounds.min.y + bounds.max.y) / 2;
-    const cz = (bounds.min.z + bounds.max.z) / 2;
-    const ex = bounds.max.x - bounds.min.x;
-    const ey = bounds.max.y - bounds.min.y;
-    const ez = bounds.max.z - bounds.min.z;
-    const radius = Math.sqrt(ex * ex + ey * ey + ez * ez) / 2;
-
-    // View direction (camera looks from position toward target)
-    const pos = this.state.camera.position;
-    let vx = this.state.camera.target.x - pos.x;
-    let vy = this.state.camera.target.y - pos.y;
-    let vz = this.state.camera.target.z - pos.z;
-    const vLen = Math.sqrt(vx * vx + vy * vy + vz * vz);
-    if (vLen > 1e-8) { vx /= vLen; vy /= vLen; vz /= vLen; }
-
-    // Signed distance from camera to scene center along view direction
-    const toCenter = (cx - pos.x) * vx + (cy - pos.y) * vy + (cz - pos.z) * vz;
-
-    // Near/far as distances from camera along view direction.
-    // The sphere spans [toCenter - radius, toCenter + radius] along view dir.
-    // Add 10% padding for safety.
-    const pad = radius * 0.1 + 1;
-    let near = toCenter - radius - pad;
-    let far = toCenter + radius + pad;
-
-    // Ensure minimum range for depth precision
-    if (far - near < 1) { near -= 0.5; far += 0.5; }
-
-    // Same contract as the perspective branch: a non-finite camera position or
-    // scene bound must not reach the projection matrix (#2441).
-    if (!Number.isFinite(near) || !Number.isFinite(far)) {
-      const fallback = Math.max(Number.isFinite(distance) ? distance : 0, 500);
-      return { near: -fallback, far: fallback };
-    }
-
-    return { near, far };
   }
 }

--- a/packages/renderer/src/camera.ts
+++ b/packages/renderer/src/camera.ts
@@ -344,6 +344,11 @@ export class Camera {
   reset(): void {
     this.controls.setOrbitCenter(null);
     this.animator.reset();
+    // The walk velocity is smoothed in place, so it survives a model swap and
+    // would be spent on the new model's first walk frame. It used to live on
+    // the animator, where `animator.reset()` did not clear it either — the
+    // extraction is what made the omission visible.
+    this.firstPerson.stop();
     // Drop the previous model's outlier-robust orbit anchor (issue #1394) — it
     // survives setSceneBounds() syncs, so without this a model swap would orbit
     // the new model around the old one's centre until the first fit clears it.

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -9,7 +9,7 @@
 export { WebGPUDevice } from './device.js';
 export { RenderPipeline } from './pipeline.js';
 export { Camera } from './camera.js';
-export type { ProjectionMode } from './camera-controls.js';
+export type { ProjectionMode } from './camera-state.js';
 export { pickFitPolicy } from './camera-fit-policy.js';
 export type { FitPolicy, FitPolicyKind, Bounds3, PickFitPolicyOptions } from './camera-fit-policy.js';
 export { Scene } from './scene.js';


### PR DESCRIPTION
Fixes #2460

Splits the camera family along the seams that actually exist. **Partial**, on purpose: two of the three files the issue names are already under the house rule once you stop counting guard comments as code, and the third splits three ways rather than two.

## The number the issue argues about

The issue quotes raw line counts. Code-only lines (comment/blank excluded) tell a different story, because the surplus is the #2441/#2461/#2473/#2479 guard rationale written line-by-line next to each guard so it does not get reverted:

| file | raw before | **code before** | raw after | **code after** |
|---|---|---|---|---|
| `camera-animation.ts` | 773 | **508** | 393 | **257** |
| `camera.ts` | 661 | **324** | 573 | **269** |
| `camera-controls.ts` | 589 | **251** | 561 | **251** |

Only `camera-animation.ts` was genuinely over the rule on code. Every production module in the family is now under 400 code lines. Trimming the guard comments to hit a raw line count would have been the worst available trade, so none were trimmed — they moved with the guards they explain.

## What moved

**`camera-animation.ts` held three subjects.** The tween keeps the file; the other two leave.

- **`camera-framing.ts`** (new, 243 code) — `framePointTarget` / `frameBoundsTarget` / `zoomExtentTarget` / `presetViewTarget` / `resolvePresetBounds` / `estimateBoundsFromPose`. Pure: state in, a pose out, no writes and no reference to the tween. That is what avoids a cycle — framing needs `animateTo`, and the tween needs framing's preset counter, so a class-per-subject split would have deadlocked. Same shape `camera-fit-policy.ts` already uses in this package.
- **`camera-first-person.ts`** (new, 45 code) — `FirstPersonNavigator`. An island: it touched no animator field except `walkVelocity`, which moved with it. `Camera` owns it directly, so `moveFirstPerson` keeps exactly the call depth it had.
- **`camera-matrices.ts`** (new, 69 code) — `updateCameraMatrices` + `computeOrthoNearFar`, lifted off the `Camera` facade. Its own subject (state → three finite matrices), its own failure story (the #2441 near/far backstops), and dropping the `private` barrier makes those guards directly reachable instead of only through the facade.
- **`camera-state.ts`** (new, 12 code) — `CameraInternalState` and `ProjectionMode`. These are the shared type for six modules and were declared inside `camera-controls.ts`, one of the consumers, so four siblings imported their core type from an unrelated gesture module. The graph goes from a chain to a star. No public API change: `index.ts` still exports the name.

**`camera-controls.ts` is deliberately left alone** beyond losing those two type declarations. 251 code lines is already under the rule, the issue's premise that `isUsableDistance`/`isUsableUp` live there is stale (they are in `camera-guards.ts`; this file only imports them), and extracting the vec3 block would separate `normalize` from the four call sites whose degradation behaviour its comment exists to document.

## Hot path (constraint 1)

`updateCameraMatrices` takes the shared state **by reference and nothing else** — not destructured into parameters (that allocates an arguments object per frame), not widened to a structural supertype (that invites megamorphic dispatch). The per-frame closure binds straight to the module function:

```ts
const updateMatrices = () => updateCameraMatrices(this.state);
```

which is the same two hops as the `() => this.updateMatrices()` it replaces, now monomorphic and static. `Camera` keeps a private `updateMatrices()` for its own cold setters only. Allocation is unchanged: `lookAt`, `perspectiveReverseZ`/`orthographicReverseZ` and `multiply` each already returned a fresh `Mat4` per call, and the ortho branch already returned a fresh `{near, far}` per frame.

## Guards (constraint 2), and the way this could have gone green for the wrong reason

Each framing input is guarded **exactly once**, in the pure module, and a rejection is `null`. The animator wrappers null-check and do nothing else. A second, defensive copy of the same guard in the wrapper would leave neither copy load-bearing on its own — a reverted guard would still look green. There is a comment at the wrappers saying so.

One ordering detail worth flagging: `resolvePresetBounds` runs **before** the preset rotation counter cycles, so a rejected preset does not advance the ViewCube's cycle position. That is the original behaviour; it only survives because the guard hands back a verdict rather than the caller re-deriving one.

## Verification

Leaf test counts, `packages/renderer`, `dist/` verified on disk after a `--force` build:

| | before | after |
|---|---|---|
| `src/camera*.test.ts` | **106 tests / 18 suites / 106 pass / 0 fail** | **106 / 18 / 106 / 0** |
| full renderer suite | **682 tests / 147 suites / 682 pass** | **682 / 147 / 682** |

Per file, identical both sides: `camera-controls` 21, `camera-degenerate-pose-matrix` 24, `camera-fit-policy` 13, `camera-malformed-bounds-fit` 9, `camera-malformed-pose-navigation` 21, `camera-preset-orbit` 4, `camera-unproject-ray-basis` 14.

No test file moved, and none was added or edited except one import line in `camera-controls.test.ts` (`CameraInternalState` now comes from `camera-state.js`). All test files remain flat at `src/*.test.ts`, which is what the renderer's `tsx --test src/*.test.ts` glob matches — a file in a subdirectory would run zero tests and look identical to a clean refactor. `node scripts/check-test-wiring.mjs` passes.

**Mutations, re-run after the split and read off the test count, not the exit code.** Each was applied to the split file that now owns the guard, then reverted with `git checkout --` and `git status --porcelain` confirmed empty:

| mutation | before the split | after the split |
|---|---|---|
| A — `isUsableDistance(horizLen, 1e-10)` → `horizLen < 1e-10` (pre-#2441 magnitude form), now in `camera-first-person.ts` | 105/1 — kills `moveFirstPerson leaves an unusable pose alone and does not latch the walk velocity` | **105/1, same single test** |
| B — `Number.isFinite(rawDistance) ? rawDistance : 1` → `rawDistance`, now in `camera-matrices.ts` | 103/3 — kills `entry point 3: a BCF viewpoint carrying a non-finite coordinate`, `entry point 3: switching to orthographic on a non-finite pose`, `a non-finite camera position gives the ray the rendered frame belongs to` | **103/3, same three tests** |
| C — `frameBoundsTarget`'s `isUsableBounds` guard deleted, now in `camera-framing.ts` | 105/1 — kills `frameBounds and zoomExtent leave the pose and orthoSize untouched` | **105/1, same single test** |
| E — `resolvePresetBounds`'s `isUsableBounds` guard forced false (extra check, since this guard was restructured) | — | 105/1 — kills `fitToBounds, setPresetView and fitBoundsAdaptive do the same` |

`turbo typecheck` 76/76 (the full post-#2478 program, test sources included). `turbo build --filter=@ifc-lite/renderer... --force` 5/5 with all four new modules emitted to `dist/`. `turbo build --filter=@ifc-lite/viewer` 33/33.

## Two behaviour notes for the reviewer

1. **One provably-dead branch dropped.** `setPresetView` had `if (!useBounds) { console.warn('[Camera] No bounds available'); return; }` against `getCurrentBounds()`, whose return type was `| null` but whose body has a single unconditional object return. Unreachable, so it is gone. The other warn (non-finite bounds) is kept verbatim.
2. **`zoomExtent`'s `updateNearFarPlanes(distance)` call is preserved**, now made from the wrapper using the fit distance the pure function returns. It has been a documented no-op since the near/far move into `updateMatrices`, so the slightly later call site is not observable — but it was not deleted, because deleting it is a behaviour change and does not belong in a refactor.

## Findings, not folded in

- **`framePoint`'s `areFiniteNumbers` guard is not pinned by any test.** Deleting it leaves 106/106 green. Verified to be **pre-existing**: the same deletion on unsplit `origin/main` also kills nothing, so the split neither introduced nor hid the gap. Worth a test, but adding one would change the leaf counts this PR is asserting are unchanged.
- **`isFirstPersonMode` is write-only dead state.** `enableFirstPersonMode` is genuinely called from `Viewport.tsx` on walk-mode toggle, and nothing in the repo ever reads the flag — `moveFirstPerson` never consults it; walk mode is decided entirely by whether `useKeyboardControls.ts` calls `moveFirstPerson`. Carried across as-is. Either it should gate the method or it should go, and both are behaviour changes.
- **`moveFirstPerson`'s third parameter `_up` is accepted and dropped**, and `Camera.moveFirstPerson` faithfully forwards a value that goes nowhere.
- **`frameBounds` and `zoomExtent` remain near-duplicates** (same centre/extent/FOV-distance/orthoSize math; they differ in padding, 1.2 vs 1.5, and in how the view direction is obtained — view matrix vs. pose). Only the trivially identical sub-expressions were factored out (`centerOf`, `maxExtentOf`, `orthoSizeFor`); the two functions stay separate with their own guards. Reconciling them properly needs a test per path first, because mutation C's test covers both and cannot tell them apart.
- **`normalize` is still duplicated** between `camera-controls.ts:91` and `MathUtils.normalize`, both hardened identically by #2479. Two things to keep in sync; the next hardening will land on one.
