### PR TITLE
fix(encoding,viewer): decode STEP strings exactly once, at the parse boundary

### DIFF
--- a/.changeset/display-decodes-once.md
+++ b/.changeset/display-decodes-once.md
@@ -1,0 +1,27 @@
+---
+"@ifc-lite/encoding": patch
+---
+
+Stop decoding STEP strings a second time at display
+
+`parsePropertyValue` decoded its input, but every producer of a property value
+already decodes exactly once at the parse boundary — `EntityExtractor` /
+`columnar-parser-attributes.ts` on the TypeScript path,
+`AttributeValue::from_token` on the Rust/WASM and server paths.
+
+That double decode was harmless while `decodeIfcString` passed `\\` through
+untouched. Since #2394 the decoder correctly collapses `\\` to `\`, which makes
+it non-idempotent: an authored UNC path `\\server\share` is stored, exported and
+round-tripped correctly but was **displayed** as `\server\share`. `C:\temp` is a
+fixed point of the decoder, which is why the defect hid on the common case.
+
+Making the decoder idempotent is not the alternative: idempotence requires
+treating an already-decoded `\` and an authored, still-doubled `\\` alike, which
+is exactly the ambiguity #2394 removed. The invariant is "decode once, at the
+parse boundary".
+
+Bump level: `patch`. No export is added, removed or renamed and the signature is
+unchanged; this only stops the function producing a wrong string. A caller that
+was relying on it to decode a raw STEP literal was relying on a second decode
+that has always been wrong for `\\` — such input should be decoded by its
+producer with `decodeIfcString`, which is still exported.

--- a/.changeset/display-decodes-once.md
+++ b/.changeset/display-decodes-once.md
@@ -1,5 +1,5 @@
 ---
-"@ifc-lite/encoding": patch
+"@ifc-lite/encoding": major
 ---
 
 Stop decoding STEP strings a second time at display
@@ -31,7 +31,13 @@ path that already decoded, so none of them changes meaning. The package README's
 `parsePropertyValue` entry is corrected in this PR; it said "raw STEP property
 values", which is what made the second decode look intended.
 
-Bump level: `patch`, matching how this package has shipped every previous
-correction to what these functions return — #2394 (`decodeIfcString` collapses
-`\\`), #1773 (`\X4\` out-of-range throws → U+FFFD), #1500 (`\S\` multi-byte).
-No export is added, removed or renamed and no signature changes.
+Bump level: `major`, on a >= 1.0 package. No export is added, removed or renamed
+and no signature changes — but the DOCUMENTED INPUT changes, and that is the
+distinction against the earlier `patch` corrections this package has shipped.
+#2394 (`decodeIfcString` collapses `\\`), #1773 (`\X4\` out-of-range throws →
+U+FFFD) and #1500 (`\S\` multi-byte) each fixed what the function returned for
+the SAME documented input; here the README moves from "raw STEP property values"
+to "a parsed STEP property value", so a caller who followed the old README and
+kept working code now gets a wrong answer with no error. A silent break needs a
+louder version than a loud one, and the migration is one call:
+`parsePropertyValue(decodeIfcString(literal))`.

--- a/.changeset/display-decodes-once.md
+++ b/.changeset/display-decodes-once.md
@@ -20,8 +20,18 @@ treating an already-decoded `\` and an authored, still-doubled `\\` alike, which
 is exactly the ambiguity #2394 removed. The invariant is "decode once, at the
 parse boundary".
 
-Bump level: `patch`. No export is added, removed or renamed and the signature is
-unchanged; this only stops the function producing a wrong string. A caller that
-was relying on it to decode a raw STEP literal was relying on a second decode
-that has always been wrong for `\\` — such input should be decoded by its
-producer with `decodeIfcString`, which is still exported.
+**Behaviour change for callers outside this repo.** If you were handing
+`parsePropertyValue` a *still-encoded* STEP literal, it decoded it for you and
+now returns it unchanged: `'Br\X2\00FC\X0\cke'` comes back as written rather
+than as `Brücke`. Decode at your parse boundary instead —
+`parsePropertyValue(decodeIfcString(literal))` — with `decodeIfcString` still
+exported for exactly that. Every in-repo caller (the viewer's property and
+quantity cards, `filter-match`, `@ifc-lite/lists`) sits downstream of a parse
+path that already decoded, so none of them changes meaning. The package README's
+`parsePropertyValue` entry is corrected in this PR; it said "raw STEP property
+values", which is what made the second decode look intended.
+
+Bump level: `patch`, matching how this package has shipped every previous
+correction to what these functions return — #2394 (`decodeIfcString` collapses
+`\\`), #1773 (`\X4\` out-of-range throws → U+FFFD), #1500 (`\S\` multi-byte).
+No export is added, removed or renamed and no signature changes.

--- a/apps/viewer/src/components/viewer/properties/PropertySetCard.escapes.test.tsx
+++ b/apps/viewer/src/components/viewer/properties/PropertySetCard.escapes.test.tsx
@@ -1,0 +1,136 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * #2323 follow-up: the property/quantity cards must render what the parse path
+ * stored, VERBATIM.
+ *
+ * Every producer of a pset name, property name, property value or quantity
+ * name decodes exactly once, at the parse boundary — `EntityExtractor` /
+ * `columnar-parser-attributes.ts` on the TypeScript path,
+ * `AttributeValue::from_token` on the Rust/WASM and server paths (#2394). A
+ * correct decoder is not idempotent: `decodeIfcString` collapses `\\` to `\`,
+ * so the cards' second decode turned the authored UNC path `\\server\share`
+ * into `\server\share` on screen while the stored, exported and round-tripped
+ * value stayed correct. `C:\temp` is a fixed point of the decoder, which is
+ * why the defect hides on the common case.
+ *
+ * An idempotent decoder is not the alternative: idempotence would require
+ * treating an already-decoded `\` and an authored, still-doubled `\\` alike,
+ * which is precisely the ambiguity #2323 removed.
+ *
+ * The assertions go through a real `createRoot` render rather than calling the
+ * helpers, because the defect lived in JSX that read as harmless — only what
+ * the DOM ends up holding proves it.
+ */
+
+import '@/test/setup-dom.js';
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import type { ReactElement } from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { ProjectUnits } from '@ifc-lite/parser';
+import { TooltipProvider } from '@/components/ui/tooltip.js';
+import { PropertySetCard } from './PropertySetCard.js';
+import { QuantitySetCard } from './QuantitySetCard.js';
+
+/**
+ * One authored UNC path per SITE, each naming a different host. Sharing one
+ * fixture would let the pset-name assertion be satisfied by the property name
+ * (or the value) and hide a site that still double-decodes.
+ */
+const PSET_NAME = '\\\\psethost\\share';
+const PROP_NAME = '\\\\prophost\\share';
+const PROP_VALUE = '\\\\valuehost\\share';
+const QSET_NAME = '\\\\qsethost\\share';
+const QTY_NAME = '\\\\qtyhost\\share';
+
+const UNITS = ProjectUnits.empty();
+
+let root: Root | null = null;
+let host: HTMLElement | null = null;
+
+function render(node: ReactElement): string {
+  host = document.createElement('div');
+  document.body.appendChild(host);
+  root = createRoot(host);
+  act(() => {
+    // The panel wraps the whole properties tree in a provider; the cards use
+    // Radix tooltips for the measure-type hints and throw without one.
+    root!.render(<TooltipProvider>{node}</TooltipProvider>);
+  });
+  return host.textContent ?? '';
+}
+
+afterEach(() => {
+  if (root) act(() => root!.unmount());
+  host?.remove();
+  root = null;
+  host = null;
+});
+
+describe('property/quantity cards render already-decoded text verbatim', () => {
+  it('keeps the adjacent backslashes of a UNC path in the pset name, property name and value', () => {
+    const text = render(
+      <PropertySetCard
+        pset={{
+          name: PSET_NAME,
+          properties: [{ name: PROP_NAME, value: PROP_VALUE }],
+        }}
+        projectUnits={UNITS}
+      />,
+    );
+
+    // A second decode rendered `\psethost\share` / `\prophost\share` /
+    // `\valuehost\share` — one separator short at each of the three sites.
+    assert.ok(text.includes(PSET_NAME), `pset name verbatim in: ${text}`);
+    assert.ok(text.includes(PROP_NAME), `property name verbatim in: ${text}`);
+    assert.ok(text.includes(PROP_VALUE), `property value verbatim in: ${text}`);
+  });
+
+  it('does not resolve a directive-shaped literal at display time', () => {
+    // The parse path already resolved every real directive; what reaches the
+    // card is literal text and must stay literal text.
+    const literal = 'caf\\X2\\00E9\\X0\\';
+    const text = render(
+      <PropertySetCard
+        pset={{ name: 'Pset_Literal', properties: [{ name: 'Label', value: literal }] }}
+        projectUnits={UNITS}
+      />,
+    );
+    assert.ok(text.includes(literal), `directive-shaped literal verbatim in: ${text}`);
+    assert.ok(!text.includes('café'), 'the card must not decode the directive');
+  });
+
+  it('keeps the qset and quantity names verbatim too', () => {
+    const text = render(
+      <QuantitySetCard
+        qset={{
+          name: QSET_NAME,
+          quantities: [{ name: QTY_NAME, value: 1.5, type: 0 }],
+        }}
+        projectUnits={UNITS}
+      />,
+    );
+    assert.ok(text.includes(QSET_NAME), `qset name verbatim in: ${text}`);
+    assert.ok(text.includes(QTY_NAME), `quantity name verbatim in: ${text}`);
+  });
+
+  // BOUNDING CONTROL — passes before and after. Deleting the decode must not
+  // also delete the rendering: a card that rendered nothing at all would
+  // satisfy neither of the assertions above, but a card that dropped only the
+  // *value* would still satisfy the name ones if they shared a fixture.
+  it('still renders ordinary names and values', () => {
+    const text = render(
+      <PropertySetCard
+        pset={{ name: 'Pset_WallCommon', properties: [{ name: 'IsExternal', value: '.T.' }] }}
+        projectUnits={UNITS}
+      />,
+    );
+    assert.ok(text.includes('Pset_WallCommon'), `plain pset name in: ${text}`);
+    assert.ok(text.includes('IsExternal'), `plain property name in: ${text}`);
+    assert.ok(text.includes('True'), `boolean enum still resolved in: ${text}`);
+  });
+});

--- a/apps/viewer/src/components/viewer/properties/PropertySetCard.tsx
+++ b/apps/viewer/src/components/viewer/properties/PropertySetCard.tsx
@@ -12,7 +12,7 @@ import { PropertyEditor, type PropertyEditScope } from '../PropertyEditor';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { Badge } from '@/components/ui/badge';
-import { decodeIfcString, parsePropertyValue } from './encodingUtils';
+import { parsePropertyValue } from './encodingUtils';
 import type { PropertySet } from './encodingUtils';
 import { PropertyValueType } from '@ifc-lite/data';
 import type { ProjectUnits } from '@ifc-lite/parser';
@@ -101,14 +101,16 @@ export function PropertySetCard({ pset, modelId, entityId, enableEditing, isType
             <TooltipContent>Inherited from type — edits apply to all instances of this type</TooltipContent>
           </Tooltip>
         )}
-        <span className="font-bold text-xs text-zinc-900 dark:text-zinc-100 truncate flex-1 min-w-0">{decodeIfcString(pset.name)}</span>
+        <span className="font-bold text-xs text-zinc-900 dark:text-zinc-100 truncate flex-1 min-w-0">{pset.name}</span>
         <span className="text-[10px] font-mono bg-zinc-100 dark:bg-zinc-900 px-1.5 py-0.5 border border-zinc-200 dark:border-zinc-800 text-zinc-600 dark:text-zinc-400 shrink-0">{pset.properties.length}</span>
       </CollapsibleTrigger>
       <CollapsibleContent>
         <div className="border-t-2 border-zinc-200 dark:border-zinc-800 divide-y divide-zinc-100 dark:divide-zinc-900">
           {pset.properties.map((prop: { name: string; value: unknown; isMutated?: boolean; type?: number; dataType?: string }) => {
             const parsed = parsePropertyValue(prop.value);
-            const decodedName = decodeIfcString(prop.name);
+            // Names render VERBATIM: the parse path already decoded them (see
+            // the note on `parsePropertyValue`), and decoding a second time
+            // collapses `\\` twice.
             const isMutated = prop.isMutated;
             const propKey = keyFor(prop.name);
             const isFocused = focusedPropKey != null && focusedPropKey === propKey;
@@ -144,7 +146,7 @@ export function PropertySetCard({ pset, modelId, entityId, enableEditing, isType
                       <Tooltip>
                         <TooltipTrigger asChild>
                           <span className={`font-medium cursor-help break-words ${isMutated ? 'text-purple-600 dark:text-purple-400' : 'text-zinc-500 dark:text-zinc-400'}`}>
-                            {decodedName}
+                            {prop.name}
                           </span>
                         </TooltipTrigger>
                         <TooltipContent side="top" className="text-[10px]">
@@ -155,7 +157,7 @@ export function PropertySetCard({ pset, modelId, entityId, enableEditing, isType
                       </Tooltip>
                     ) : (
                       <span className={`font-medium break-words ${isMutated ? 'text-purple-600 dark:text-purple-400' : 'text-zinc-500 dark:text-zinc-400'}`}>
-                        {decodedName}
+                        {prop.name}
                       </span>
                     )}
                   </div>

--- a/apps/viewer/src/components/viewer/properties/QuantitySetCard.tsx
+++ b/apps/viewer/src/components/viewer/properties/QuantitySetCard.tsx
@@ -8,7 +8,6 @@
 
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
-import { decodeIfcString } from './encodingUtils';
 import type { QuantitySet } from './encodingUtils';
 import type { ProjectUnits } from '@ifc-lite/parser';
 import { resolveQuantityDisplay, formatConverted } from '@/lib/units/display';
@@ -42,13 +41,15 @@ export function QuantitySetCard({ qset, projectUnits, unitDisplayOverrides }: Qu
   return (
     <Collapsible defaultOpen className="border-2 border-blue-200 dark:border-blue-800 bg-blue-50/20 dark:bg-blue-950/20 w-full max-w-full overflow-hidden">
       <CollapsibleTrigger className="flex items-center gap-2 w-full p-2.5 hover:bg-blue-50 dark:hover:bg-blue-900/30 text-left transition-colors overflow-hidden">
-        <span className="font-bold text-xs text-blue-700 dark:text-blue-400 truncate flex-1 min-w-0">{decodeIfcString(qset.name)}</span>
+        <span className="font-bold text-xs text-blue-700 dark:text-blue-400 truncate flex-1 min-w-0">{qset.name}</span>
         <span className="text-[10px] font-mono bg-blue-100 dark:bg-blue-900/50 px-1.5 py-0.5 border border-blue-200 dark:border-blue-800 text-blue-700 dark:text-blue-300 shrink-0">{qset.quantities.length}</span>
       </CollapsibleTrigger>
       <CollapsibleContent>
         <div className="border-t-2 border-blue-200 dark:border-blue-800 divide-y divide-blue-100 dark:divide-blue-900/30">
           {qset.quantities.map((q: { name: string; value: number; type: number }, index: number) => {
-            const decodedName = decodeIfcString(q.name);
+            // Names render VERBATIM: the parse path already decoded them
+            // (see the note on `parsePropertyValue`), and decoding a second
+            // time collapses `\\` twice.
             const typeName = QUANTITY_TYPE_NAMES[q.type];
             return (
               <div key={`${q.name}-${index}`} className="flex flex-col gap-0.5 px-3 py-2 text-xs hover:bg-blue-50/50 dark:hover:bg-blue-900/20">
@@ -57,7 +58,7 @@ export function QuantitySetCard({ qset, projectUnits, unitDisplayOverrides }: Qu
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <span className="text-zinc-500 dark:text-zinc-400 font-medium cursor-help break-words">
-                        {decodedName}
+                        {q.name}
                       </span>
                     </TooltipTrigger>
                     <TooltipContent side="top" className="text-[10px]">
@@ -68,7 +69,7 @@ export function QuantitySetCard({ qset, projectUnits, unitDisplayOverrides }: Qu
                   </Tooltip>
                 ) : (
                   <span className="text-zinc-500 dark:text-zinc-400 font-medium break-words">
-                    {decodedName}
+                    {q.name}
                   </span>
                 )}
                 {/* Quantity value */}

--- a/apps/viewer/src/components/viewer/properties/encodingUtils.ts
+++ b/apps/viewer/src/components/viewer/properties/encodingUtils.ts
@@ -9,8 +9,14 @@
  * viewer-specific types (PropertySet/QuantitySet with mutation tracking).
  */
 
-// Re-export core encoding functions from the package
-export { decodeIfcString, parsePropertyValue } from '@ifc-lite/encoding';
+// Re-export core encoding functions from the package.
+//
+// `decodeIfcString` is deliberately NOT re-exported. Everything the viewer
+// displays has already been decoded once, at the parse boundary, and correct
+// decoding is not idempotent — a second pass collapses `\\` again (#2323
+// follow-up). Anything that genuinely holds raw STEP bytes should import the
+// decoder from `@ifc-lite/encoding` directly and say why.
+export { parsePropertyValue } from '@ifc-lite/encoding';
 export type { ParsedPropertyValue } from '@ifc-lite/encoding';
 
 // ============================================================================

--- a/apps/viewer/src/lib/overlay-parse/symbolic-flat.test.ts
+++ b/apps/viewer/src/lib/overlay-parse/symbolic-flat.test.ts
@@ -66,6 +66,26 @@ function fill(ifcType: string, expressId: number, worldY: number, angleSecondary
   });
 }
 
+function text(ifcType: string, expressId: number, worldY: number, content: string) {
+  return tracked({
+    ifcType,
+    expressId,
+    worldY,
+    content,
+    alignment: 'center',
+    x: 0,
+    y: 0,
+    dirX: 1,
+    dirY: 0,
+    height: 0.18,
+    targetPx: 12,
+    colorR: 0,
+    colorG: 0,
+    colorB: 0,
+    colorA: 1,
+  });
+}
+
 /** Minimal stand-in for the wasm-bindgen collection handle. */
 function makeCollection(items: {
   polylines?: unknown[];
@@ -217,5 +237,40 @@ describe('collectFlatSymbolic', () => {
     assert.ok(bucket, 'worldY 0 must bucket at key 0');
     assert.strictEqual(bucket?.storeyElevation, 0);
     assert.strictEqual(bucket?.lines.length, 1);
+  });
+});
+
+/**
+ * The Rust extractor decodes annotation text at the parse boundary
+ * (`AttributeValue::from_token` → `decode_ifc_string`, #2394), so this side
+ * must NOT decode again. Correct decoding is not idempotent: it collapses `\\`
+ * a second time. Making the decoder idempotent instead is not an option — it
+ * would have to treat an authored, still-doubled `\\` and an already-decoded
+ * `\` alike, which is exactly the ambiguity #2323 removed.
+ */
+describe('buildParseResult text content', () => {
+  const flatFor = (content: string) =>
+    collectFlatSymbolic(makeCollection({ texts: [text('IfcAnnotation', 51, 3, content)] }));
+  const firstText = (content: string) =>
+    buildParseResult(flatFor(content), {}).byStorey.get(3000)?.texts[0];
+
+  it('renders an already-decoded label verbatim, adjacent backslashes included', () => {
+    // The authored UNC path `\\server\share`, as the parse path stores it.
+    const label = '\\\\server\\share';
+    assert.strictEqual(firstText(label)?.content, label);
+  });
+
+  it('does not re-run the STEP decoder over the label', () => {
+    // A literal that still looks like a directive is text, not an escape: the
+    // producer already resolved every real directive.
+    assert.strictEqual(firstText('caf\\X2\\00E9\\X0\\')?.content, 'caf\\X2\\00E9\\X0\\');
+    // BOUNDING CONTROL: real non-ASCII content still crosses intact, so a
+    // "fix" that dropped or mangled the content would not pass here.
+    assert.strictEqual(firstText('café')?.content, 'café');
+  });
+
+  it('still splits multi-line labels', () => {
+    const both = buildParseResult(flatFor('A\nB'), {}).byStorey.get(3000)?.texts;
+    assert.deepStrictEqual(both?.map((t) => t.content), ['A', 'B']);
   });
 });

--- a/apps/viewer/src/lib/overlay-parse/symbolic-flat.ts
+++ b/apps/viewer/src/lib/overlay-parse/symbolic-flat.ts
@@ -32,8 +32,8 @@
  *
  * Deliberately NOT done here, so their existing coverage keeps applying to the
  * code that ships: circle/polyline tessellation (`circleToSegments` /
- * `polylineToSegments`) and text decoding (`decodeIfcString` + the multi-line
- * split) stay on the main thread.
+ * `polylineToSegments`) and the multi-line text split stay on the main
+ * thread.
  */
 
 import type { SymbolicRepresentationCollection } from '@ifc-lite/wasm';
@@ -305,8 +305,9 @@ export function collectFlatSymbolic(
     try {
       const ifcType = text.ifcType;
       if (!keep(ifcType)) continue;
-      // Content crosses verbatim: `decodeIfcString` and the multi-line split
-      // stay main-side so the encoding behaviour is unchanged.
+      // Content crosses verbatim. It is already decoded — the Rust extractor
+      // decodes at the parse boundary (`AttributeValue::from_token`) — so the
+      // main side only splits it into lines.
       textContent.push(text.content);
       textAlignment.push(text.alignment);
       textX.push(text.x);

--- a/apps/viewer/src/lib/overlay-parse/symbolic-parse.ts
+++ b/apps/viewer/src/lib/overlay-parse/symbolic-parse.ts
@@ -17,8 +17,8 @@
  *   - `collectFlatSymbolic` (`symbolic-flat.ts`) walks the WASM handles and
  *     flattens them into transferable typed arrays. WASM-bound, worker-side.
  *   - `buildParseResult` turns those arrays into the `ParseResult` the overlay
- *     renders: tessellation, text decoding, and storey bucketing. Pure JS,
- *     main-thread-side.
+ *     renders: tessellation, multi-line text splitting, and storey bucketing.
+ *     Pure JS, main-thread-side.
  *
  * `parseSymbolicAnnotations` is the two composed on one thread. It stays the
  * reference implementation — the golden-digest test drives it — so the worker
@@ -26,7 +26,6 @@
  */
 
 import { GeometryProcessor } from '@ifc-lite/geometry';
-import { decodeIfcString } from '@ifc-lite/encoding';
 import {
   collectFlatSymbolic,
   createEmptyFlatSymbolic,
@@ -82,8 +81,8 @@ export interface SymbolicHierarchyInput {
 /**
  * Assemble the renderable `ParseResult` from a flattened collection.
  *
- * Main-thread half of the split: tessellation, STEP text decoding, and storey
- * bucketing. Takes no WASM handle, so the worker can hand `flat` over a
+ * Main-thread half of the split: tessellation, multi-line text splitting, and
+ * storey bucketing. Takes no WASM handle, so the worker can hand `flat` over a
  * `postMessage` and this runs unchanged on the other side.
  */
 export function buildParseResult(
@@ -192,12 +191,14 @@ export function buildParseResult(
     const ifcType = typeNames[flat.textType[i]];
     const expressId = flat.textOwner[i];
     // Skip empty literals so the renderer doesn't waste an instance slot.
-    // Decode STEP escapes — `\X2\NNNN\X0\` (UTF-16 hex code units) and
-    // `\X\NN` (Latin-1 hex byte). The Rust parser intentionally passes
-    // the literal through verbatim; this is where the JS encoding
-    // package gets applied. Without it, non-ASCII annotation labels
-    // (e.g. CJK content) render as raw escape sequences in the atlas.
-    const decoded = decodeIfcString(flat.textContent[i]);
+    //
+    // The content arrives ALREADY DECODED: the Rust extractor reads it through
+    // `AttributeValue::from_token`, which un-doubles `''` and runs
+    // `decode_ifc_string` (`\X2\NNNN\X0\`, `\X\NN`, `\S\X`, `\\`) at the parse
+    // boundary (#2394). Re-decoding here was a no-op for CJK labels but
+    // collapsed `\\` a second time, so an authored `\\server\share` rendered as
+    // `\server\share` (#2323 follow-up).
+    const decoded = flat.textContent[i];
     if (decoded.length === 0) continue;
 
     // Multi-line split: IfcTextLiteralWithExtent.SizeInY is the LAYOUT BOX

--- a/packages/encoding/README.md
+++ b/packages/encoding/README.md
@@ -34,7 +34,7 @@ parsePropertyValue(['IFCBOOLEAN', '.T.']); // { displayValue: 'True', ifcType: .
 - `generateIfcGuid`, `generateUuid`: new identifiers
 - `uuidToIfcGuid`, `ifcGuidToUuid`: convert between UUIDs and 22-char IFC GUIDs
 - `isValidIfcGuid`, `isValidUuid`: validation
-- `parsePropertyValue`: turn raw STEP property values (typed arrays, `.T.`/`.F.`, enums) into a display string plus optional IFC type name
+- `parsePropertyValue`: turn a parsed STEP property value (typed arrays, `.T.`/`.F.`, enums) into a display string plus optional IFC type name. It does **not** decode `\X2\`-style escapes: every ifc-lite parse path already decodes exactly once, at the parse boundary, and decoding a second time would collapse an authored `\\` a second time. Pass a still-encoded literal through `decodeIfcString` first.
 
 ## Links
 

--- a/packages/encoding/src/property-value.test.ts
+++ b/packages/encoding/src/property-value.test.ts
@@ -82,9 +82,44 @@ describe('parsePropertyValue', () => {
     expect(floatResult.ifcType).toBeUndefined();
   });
 
-  it('decodes IFC-encoded strings', () => {
-    const result = parsePropertyValue('Br\\X2\\00FC\\X0\\cke');
-    expect(result.displayValue).toBe('Brücke');
+  // Decoding happens exactly ONCE, at the parse boundary — `EntityExtractor`
+  // / `columnar-parser-attributes.ts` on the TypeScript path,
+  // `AttributeValue::from_token` on the Rust/WASM and server paths. So the
+  // value reaching this function is already literal text, and a second decode
+  // is not a no-op: since #2394 `decodeIfcString` collapses `\\` to `\`, which
+  // turned an authored UNC path into a wrong one on screen.
+  //
+  // Idempotence is not the alternative fix: it would require treating an
+  // already-decoded `\` and an authored, still-doubled `\\` alike, which is
+  // exactly the ambiguity #2323 removed.
+  it('passes an already-decoded value through unchanged (no second decode)', () => {
+    // What the parse path stores for the authored UNC path `\\server\share`.
+    const stored = '\\\\server\\share';
+    expect(parsePropertyValue(stored).displayValue).toBe(stored);
+  });
+
+  it('passes an already-decoded typed value through unchanged (both branches)', () => {
+    // The tuple branch…
+    const tuple = 'C:\\\\tuple\\logs';
+    expect(parsePropertyValue(['IFCTEXT', tuple])).toEqual({
+      displayValue: tuple,
+      ifcType: 'Text',
+    });
+    // …and the `String(array)`-flattened branch, with a DISTINCT fixture so
+    // neither assertion can be satisfied by the other branch's value.
+    const flattened = 'C:\\\\flat\\logs';
+    expect(parsePropertyValue(`IFCTEXT,${flattened}`)).toEqual({
+      displayValue: flattened,
+      ifcType: 'Text',
+    });
+  });
+
+  it('does not decode STEP escapes — the parse path already did', () => {
+    // A still-encoded literal arriving here would mean the PRODUCER skipped
+    // its decode; that is a bug in the producer, not something to paper over
+    // here, and papering over it is what double-collapses `\\`.
+    expect(parsePropertyValue('Br\\X2\\00FC\\X0\\cke').displayValue)
+      .toBe('Br\\X2\\00FC\\X0\\cke');
   });
 
   it('handles plain strings', () => {

--- a/packages/encoding/src/property-value.test.ts
+++ b/packages/encoding/src/property-value.test.ts
@@ -91,7 +91,7 @@ describe('parsePropertyValue', () => {
   //
   // Idempotence is not the alternative fix: it would require treating an
   // already-decoded `\` and an authored, still-doubled `\\` alike, which is
-  // exactly the ambiguity #2323 removed.
+  // exactly the ambiguity #2394 removed.
   it('passes an already-decoded value through unchanged (no second decode)', () => {
     // What the parse path stores for the authored UNC path `\\server\share`.
     const stored = '\\\\server\\share';

--- a/packages/encoding/src/property-value.ts
+++ b/packages/encoding/src/property-value.ts
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { decodeIfcString } from './ifc-string.js';
-
 /**
  * Result of parsing a property value.
  * Contains the display value and optional IFC type for tooltip.
@@ -55,9 +53,23 @@ const IFC_TYPE_DISPLAY_NAMES: Record<string, string> = {
  * Handles:
  * - TypedValues like [IFCIDENTIFIER, '100 x 150mm'] -> display '100 x 150mm', tooltip 'Identifier'
  * - Boolean enums like '.T.' -> 'True'
- * - IFC encoded strings with \X2\, \X\ escape sequences
  * - Null/undefined -> '\u2014'
  * - Regular values -> string conversion
+ *
+ * It deliberately does NOT decode STEP escapes. Every producer of a property
+ * value decodes exactly once, at parse time: the TypeScript path via
+ * `EntityExtractor.parseAttributeValue` / `columnar-parser-attributes.ts`, the
+ * Rust/WASM and server paths via `AttributeValue::from_token`. The input here
+ * is therefore already literal text, and decoding a second time is not a no-op
+ * \u2014 since #2394 `decodeIfcString` collapses `\\` to `\`, so an authored UNC
+ * path `\\server\share` would render as `\server\share`. `C:\temp` is a fixed
+ * point of the decoder, which is why the defect hides on the common case.
+ *
+ * Making the decoder idempotent instead would not work: idempotence requires
+ * treating an already-decoded `\` and an authored, still-doubled `\\` the same
+ * way, which is exactly the ambiguity the one-decode rule removes. The
+ * invariant to hold is "decode once, at the parse boundary", not "decode
+ * defensively wherever a string is displayed".
  */
 export function parsePropertyValue(value: unknown): ParsedPropertyValue {
   // Handle null/undefined
@@ -105,12 +117,12 @@ export function parsePropertyValue(value: unknown): ParsedPropertyValue {
         return { displayValue: BOOLEAN_MAP[upperInner], ifcType: friendlyType };
       }
 
-      // Decode IFC string encoding and return
-      return { displayValue: decodeIfcString(innerValue), ifcType: friendlyType };
+      // Already decoded by the parse path (see the note on this function).
+      return { displayValue: innerValue, ifcType: friendlyType };
     }
 
-    // Regular string - decode IFC encoding
-    return { displayValue: decodeIfcString(value) };
+    // Already decoded by the parse path (see the note on this function).
+    return { displayValue: value };
   }
 
   // Handle native booleans

--- a/packages/lists/src/engine.ts
+++ b/packages/lists/src/engine.ts
@@ -648,9 +648,12 @@ function findPropertyEntry(psets: PropertySet[], psetName: string, propName: str
 }
 
 /**
- * Resolve a raw IFC property value to a clean display value.
- * Handles typed arrays [IFCTYPE, value], boolean enums (.T./.F./.U.),
- * IFC string encodings, etc.
+ * Resolve a stored IFC property value to a clean display value.
+ * Handles typed arrays [IFCTYPE, value], boolean enums (.T./.F./.U.), etc.
+ *
+ * NOT STEP decoding: the value arrives already decoded from the parse boundary,
+ * and `parsePropertyValue` deliberately does not decode a second time (that
+ * collapses `\\` twice — see its own note).
  */
 function resolvePropertyValue(value: unknown): CellValue {
   if (value === null || value === undefined) return null;

--- a/rust/processing/src/symbolic/primitives.rs
+++ b/rust/processing/src/symbolic/primitives.rs
@@ -139,8 +139,12 @@ pub struct SymbolicText {
     pub dir_y: f32,
     /// Font height in model units (already unit-scaled).
     pub height: f32,
-    /// UTF-8 text content (verbatim from the IFC literal — JS-side
-    /// decodes any `\X2\…\X0\` escape sequences).
+    /// UTF-8 text content, ALREADY DECODED. It is read through
+    /// `AttributeValue::from_token`, which un-doubles `''` and runs
+    /// `decode_ifc_string` (`\X2\…\X0\`, `\X\NN`, `\S\X`, `\\`) at the parse
+    /// boundary (#2394) — so consumers must NOT decode it again. A second
+    /// decode is not idempotent: it collapses `\\` twice, turning an authored
+    /// `\\server\share` into `\server\share`.
     pub content: String,
     /// IFC `BoxAlignment` (`top-left`, `center`, `bottom-right`, …). Empty
     /// string when absent.


### PR DESCRIPTION
Builds on **BIMvoice's merged #2391, #2394, #2405 and #2408** — this PR is only the delta those did not include, rebased onto current `main` (`8bddeca78`). Our overlapping PRs #2484/#2485/#2486 are retired; nothing else from them is carried here.

## The regression this guards

#2394 made the STEP decoder **correct**: `decodeIfcString` / `decode_ifc_string` now collapse the ISO 10303-21 reverse-solidus doubling (`\\` is one `\`). Correct therefore means **non-idempotent** — and four display-time sites were decoding a second time a value the parse boundary had already decoded.

Measured on current `main`: an authored UNC path `\\server\share` is stored correctly, exports correctly and round-trips correctly, and **displays as `\server\share`**. A single backslash like `C:\temp` is a fixed point of the decoder, which is exactly why this hides on the common case.

Sites whose second decode is removed:

| site | what was decoded twice |
| --- | --- |
| `packages/encoding/src/property-value.ts` | `parsePropertyValue`, both string branches |
| `PropertySetCard.tsx` | pset name, property name |
| `QuantitySetCard.tsx` | qset name, quantity name |
| `apps/viewer/src/lib/overlay-parse/symbolic-parse.ts` | annotation label text |

Each site's input was verified to be already-decoded, not assumed:

- **TypeScript parse path** — `EntityExtractor.parseAttributeValue` (`entity-extractor.ts:263`) and `columnar-parser-attributes.ts:240` both un-double `''` and then `decodeIfcString`.
- **Rust/WASM + server path** — `AttributeValue::from_token` (`rust/core/src/schema_gen.rs`), as #2394 landed it.
- **Overlay / IFCX authored values** — literal text that was never STEP-encoded at all, so a decode there was always spurious.

No site can receive **both** raw and decoded input, so there is nothing here that needs a type distinction rather than a deleted call.

**Why not make the decoder idempotent.** Idempotence requires treating an already-decoded `\` and an authored, still-doubled `\\` the same way, which is precisely the ambiguity #2394 removed. The invariant is "decode once, at the parse boundary".

Two stale claims are corrected in the same pass, because they are what invites the next redundant decode:

- `symbolic-parse.ts` said the Rust parser "intentionally passes the literal through verbatim". Not true since #2394.
- `SymbolicText::content`'s own doc comment (`rust/processing/src/symbolic/primitives.rs`) said the same thing. Corrected to state that the value is already decoded.

`decodeIfcString` is also no longer re-exported from the viewer's `encodingUtils` barrel, so a future display site cannot reach for it by accident; a genuine raw-bytes consumer imports it from `@ifc-lite/encoding` directly and says why.

## Tests

- `packages/encoding/src/property-value.test.ts` — the already-decoded value passes through unchanged on both string branches, and a still-encoded literal is **not** rescued here.
- `apps/viewer/.../PropertySetCard.escapes.test.tsx` (new) — a real `createRoot` render of both cards. **Each of the five sites gets its own UNC host** (`\\psethost\share`, `\\prophost\share`, `\\valuehost\share`, `\\qsethost\share`, `\\qtyhost\share`) so no assertion can be satisfied by another site's string. Carries a bounding control that still asserts ordinary names, values and boolean-enum rendering.
- `apps/viewer/src/lib/overlay-parse/symbolic-flat.test.ts` — annotation labels cross verbatim, a directive-shaped literal stays literal, real non-ASCII content still crosses intact, and the multi-line split still works.

**Mutation-checked per site** (test counts, not exit codes; `packages/encoding`'s `dist` rebuilt before each run, since the viewer tests resolve the package through `dist`):

| mutation | result |
| --- | --- |
| restore the decode in `parsePropertyValue` | encoding `3 failed \| 11 passed`; cards `4 tests, 2 pass, 2 fail` |
| restore it in `PropertySetCard` | cards `4 tests, 3 pass, 1 fail` |
| restore it in `QuantitySetCard` | cards `4 tests, 3 pass, 1 fail` |
| restore it in `symbolic-parse.ts` | symbolic `7 tests, 5 pass, 2 fail` |

Each was restored with `git checkout --` and `git status --porcelain` confirmed empty afterwards.

## Gates

```
npx turbo typecheck --force
 Tasks:    76 successful, 76 total
Cached:    0 cached, 76 total
  Time:    53.752s

npx turbo test --force
 Tasks:    86 successful, 86 total
Cached:    0 cached, 86 total
  Time:    5m8.949s
```

`cargo clippy -p ifc-lite-processing --all-targets -- -D warnings` clean (the only Rust change is a doc comment). `scripts/check-api-surface.mjs` and `scripts/check-test-wiring.mjs` both pass. `apps/viewer` is `private: true`, so the changeset covers `@ifc-lite/encoding` only — `patch`, justified in the changeset file: no export is added, removed or renamed and the signature is unchanged; the function simply stops producing a wrong string.

## Deliberately not here

- **The `tz` / MappingTarget-Z fix from #2484.** BIMvoice's #2352 (worldY) is still open; that fix belongs on top of his implementation once it lands.
- **The `extract-walls.ts` overlay guard.** It does **not** reproduce on current `main`: `IfcDataStore.source` is a mandatory accessor whose no-source state is `EMPTY_SOURCE_BYTES` (an object), so `if (!store.source)` is always false and the early return above the overlay loop is unreachable. Verified by running an overlay-created wall through `extractWallSegmentsForStorey` on a source-less store — the wall comes out. The dead-guard correction that would make it reachable is adjacent ground to the unmerged #2398 and belongs there, not here.
- **The `disposeQuietly` reporting fix.** Already handled by merged #2391: `disposeBestEffort()` reports the secondary `free()` failure through `log.error` inside its own guarded `try/catch` and still calls `reset()`. That answers the open CodeRabbit thread about the silent `catch {}`.

## Adjacent, not fixed here

`serializeStepToken` (`apps/viewer/.../raw-step-format.ts`) renders a stored value as a STEP literal **without** doubling the reverse solidus, while `parseRawStepInput` does not un-double it either. The pair is self-consistent, so the raw-STEP editor round-trips, but the rendered line is not a faithful STEP literal for a value containing `\`. Different failure story from this PR's; flagged rather than folded in.
