### PR TITLE
refactor(renderer): split section-2d-overlay along the resource/description seam, and fix the clash-box dispose leak

### DIFF
--- a/.changeset/section-2d-overlay-split.md
+++ b/.changeset/section-2d-overlay-split.md
@@ -5,3 +5,5 @@
 Split `section-2d-overlay.ts` (1176 lines) along the resource/description seam.
 
 The WGSL for both pipelines moves to `shaders/section-2d-overlay.wgsl.ts`, the 2D→3D lift and cap triangulation to `section-2d-lift.ts`, and the per-family vertex buffer to a `WorldLineBuffer` value object in `section-2d-line-buffer.ts`. None of those own a shared GPU resource: the two pipelines, the bind-group layout, the bind group and the single 160-byte uniform buffer stay owned by `Section2DOverlayRenderer` and are passed to a draw rather than held. The public API is unchanged.
+
+Also fixes a GPU buffer leak the split surfaced: `Section2DOverlayRenderer.dispose()` did not release the clash-overlap-box vertex buffer (#1277 added the sixth line family and never wired it into disposal), leaking it on every renderer teardown.

--- a/.changeset/section-2d-overlay-split.md
+++ b/.changeset/section-2d-overlay-split.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/renderer": patch
+---
+
+Split `section-2d-overlay.ts` (1176 lines) along the resource/description seam.
+
+The WGSL for both pipelines moves to `shaders/section-2d-overlay.wgsl.ts`, the 2D→3D lift and cap triangulation to `section-2d-lift.ts`, and the per-family vertex buffer to a `WorldLineBuffer` value object in `section-2d-line-buffer.ts`. None of those own a shared GPU resource: the two pipelines, the bind-group layout, the bind group and the single 160-byte uniform buffer stay owned by `Section2DOverlayRenderer` and are passed to a draw rather than held. The public API is unchanged.

--- a/.changeset/section-2d-overlay-split.md
+++ b/.changeset/section-2d-overlay-split.md
@@ -4,6 +4,12 @@
 
 Split `section-2d-overlay.ts` (1176 lines) along the resource/description seam.
 
-The WGSL for both pipelines moves to `shaders/section-2d-overlay.wgsl.ts`, the 2D→3D lift and cap triangulation to `section-2d-lift.ts`, and the per-family vertex buffer to a `WorldLineBuffer` value object in `section-2d-line-buffer.ts`. None of those own a shared GPU resource: the two pipelines, the bind-group layout, the bind group and the single 160-byte uniform buffer stay owned by `Section2DOverlayRenderer` and are passed to a draw rather than held. The public API is unchanged.
+The WGSL for both pipelines moves to `shaders/section-2d-overlay.wgsl.ts`, the 2D→3D lift and cap triangulation to `section-2d-lift.ts`, and the per-family vertex buffer to a `WorldLineBuffer` value object in `section-2d-line-buffer.ts`. None of those own a shared GPU resource: the two pipelines, the bind-group layout, the bind group and the uniform buffer stay owned by `Section2DOverlayRenderer` and are passed to a draw rather than held. The public API is unchanged.
 
-Also fixes a GPU buffer leak the split surfaced: `Section2DOverlayRenderer.dispose()` did not release the clash-overlap-box vertex buffer (#1277 added the sixth line family and never wired it into disposal), leaking it on every renderer teardown.
+Also fixes three defects the split surfaced, all pre-existing:
+
+- **Every overlay draw in a frame shared one uniform record.** The cut cap and the five world-space line families are encoded into one render pass, and each wrote byte 0 of the same 160-byte buffer. `queue.writeBuffer` is a queue operation applied before the command buffer executes, so the last write won and every draw read it: the clash-overlap box's colour bled onto the annotation, alignment, grid and DXF overlays, and the cut cap lost its fill colour and hatch to the zeroed cap-style tail a line draw writes. Each draw site now owns a slot in the buffer, addressed by a dynamic bind-group offset sized to the device's `minUniformBufferOffsetAlignment`.
+- **A line-list array that was not a whole number of segments produced a fractional vertex count**, which is a WebGPU validation error that fails the whole command buffer — taking every other overlay in the pass with it. Uploads now truncate to complete segments.
+- **`Section2DOverlayRenderer.dispose()` did not release the clash-overlap-box vertex buffer** (#1277 added the sixth line family and never wired it into disposal), leaking it on every renderer teardown.
+
+The brick hatch's band parity uses a signed comparison, so it stays correct if the pattern is ever evaluated at a negative coordinate.

--- a/packages/renderer/src/section-2d-lift.test.ts
+++ b/packages/renderer/src/section-2d-lift.test.ts
@@ -153,7 +153,7 @@ describe('buildCapFillGeometry', () => {
     assert.strictEqual(buildCapFillGeometry([poly([[0, 0], [1, 0]])], lift), null);
   });
 
-  it('lifts a unit square onto the requested plane and preserves its area', () => {
+  it('lifts a 2x2 square onto the requested plane and preserves its area', () => {
     const lift = createSectionLift('down', 12);
     const geom = buildCapFillGeometry([poly([[0, 0], [2, 0], [2, 2], [0, 2]])], lift);
     assert.ok(geom);

--- a/packages/renderer/src/section-2d-lift.test.ts
+++ b/packages/renderer/src/section-2d-lift.test.ts
@@ -1,0 +1,319 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import {
+  buildCapFillGeometry,
+  buildDrawingOutlineVertices,
+  createSectionLift,
+  transform2Dto3D,
+  type CutPolygon2D,
+  type DrawingLine2D,
+} from './section-2d-lift.js';
+
+/**
+ * The 2D→3D lift is the #243 / #581 contract: the cap polygons have to land on
+ * the SAME plane the cutter projected them from, or the section cap floats off
+ * the user's plane. It ran unguarded until this file — `section-2d-overlay.ts`
+ * had no direct coverage at all, so every one of these behaviours could be
+ * changed without a single test going red.
+ */
+
+const FLOATS_PER_VERTEX = 7; // x,y,z,r,g,b,a
+
+function poly(
+  outer: Array<[number, number]>,
+  holes: Array<Array<[number, number]>> = [],
+  color?: [number, number, number, number],
+): CutPolygon2D {
+  return {
+    polygon: {
+      outer: outer.map(([x, y]) => ({ x, y })),
+      holes: holes.map((h) => h.map(([x, y]) => ({ x, y }))),
+    },
+    ifcType: 'IfcWall',
+    expressId: 1,
+    ...(color ? { color } : {}),
+  };
+}
+
+function line(x1: number, y1: number, x2: number, y2: number): DrawingLine2D {
+  return { line: { start: { x: x1, y: y1 }, end: { x: x2, y: y2 } }, category: 'cut' };
+}
+
+/** Sum of the triangle areas of an indexed 3D mesh. */
+function triangulatedArea(vertices: Float32Array, indices: Uint32Array): number {
+  let total = 0;
+  for (let i = 0; i < indices.length; i += 3) {
+    const p: Array<[number, number, number]> = [];
+    for (let k = 0; k < 3; k++) {
+      const base = indices[i + k] * FLOATS_PER_VERTEX;
+      p.push([vertices[base], vertices[base + 1], vertices[base + 2]]);
+    }
+    const ux = p[1][0] - p[0][0], uy = p[1][1] - p[0][1], uz = p[1][2] - p[0][2];
+    const vx = p[2][0] - p[0][0], vy = p[2][1] - p[0][1], vz = p[2][2] - p[0][2];
+    const cx = uy * vz - uz * vy;
+    const cy = uz * vx - ux * vz;
+    const cz = ux * vy - uy * vx;
+    total += Math.sqrt(cx * cx + cy * cy + cz * cz) / 2;
+  }
+  return total;
+}
+
+describe('transform2Dto3D: cardinal axes', () => {
+  it("maps 'down' (Y cut, floor plan) 2D (x,y) to 3D (x, plane, y)", () => {
+    assert.deepStrictEqual(transform2Dto3D(3, 7, 'down', 2.5), [3, 2.5, 7]);
+  });
+
+  it("maps 'front' (Z cut, section) 2D (x,y) to 3D (x, y, plane)", () => {
+    assert.deepStrictEqual(transform2Dto3D(3, 7, 'front', 2.5), [3, 7, 2.5]);
+  });
+
+  it("maps 'side' (X cut, elevation) 2D (x,y) to 3D (plane, y, x)", () => {
+    assert.deepStrictEqual(transform2Dto3D(3, 7, 'side', 2.5), [2.5, 7, 3]);
+  });
+
+  it('negates ONLY the 2D x coordinate when flipped', () => {
+    assert.deepStrictEqual(transform2Dto3D(3, 7, 'down', 2.5, true), [-3, 2.5, 7]);
+    assert.deepStrictEqual(transform2Dto3D(3, 7, 'front', 2.5, true), [-3, 7, 2.5]);
+    // 'side' puts the mirrored x into the Z slot, not the X slot.
+    assert.deepStrictEqual(transform2Dto3D(3, 7, 'side', 2.5, true), [2.5, 7, -3]);
+  });
+
+  it('leaves the plane coordinate alone when flipped', () => {
+    const [, y] = transform2Dto3D(3, 7, 'down', 2.5, true);
+    assert.strictEqual(y, 2.5);
+  });
+});
+
+describe('transform2Dto3D: custom plane (#243)', () => {
+  const plane = {
+    origin: [10, 20, 30] as [number, number, number],
+    tangent: [0, 1, 0] as [number, number, number],
+    bitangent: [0, 0, 1] as [number, number, number],
+  };
+
+  it('lifts via origin + tangent*x + bitangent*y', () => {
+    assert.deepStrictEqual(transform2Dto3D(2, 5, 'down', 999, false, plane), [10, 22, 35]);
+  });
+
+  it('IGNORES flipped for a custom plane (the cutter does not mirror arbitrary planes)', () => {
+    const unflipped = transform2Dto3D(2, 5, 'down', 999, false, plane);
+    const flipped = transform2Dto3D(2, 5, 'down', 999, true, plane);
+    assert.deepStrictEqual(flipped, unflipped);
+  });
+
+  it('IGNORES the cardinal axis and plane position for a custom plane', () => {
+    const viaDown = transform2Dto3D(2, 5, 'down', 0, false, plane);
+    const viaSide = transform2Dto3D(2, 5, 'side', -100, false, plane);
+    assert.deepStrictEqual(viaSide, viaDown);
+  });
+
+  it('round-trips a tilted basis exactly (cap lands ON the plane, not beside it)', () => {
+    const s = Math.SQRT1_2;
+    const tilted = {
+      origin: [1, 2, 3] as [number, number, number],
+      tangent: [s, s, 0] as [number, number, number],
+      bitangent: [0, 0, 1] as [number, number, number],
+    };
+    const [x, y, z] = transform2Dto3D(4, -2, 'front', 0, false, tilted);
+    // Project back onto the basis: the 2D coordinates must come out unchanged.
+    const dx = x - 1, dy = y - 2, dz = z - 3;
+    const u = dx * tilted.tangent[0] + dy * tilted.tangent[1] + dz * tilted.tangent[2];
+    const v = dx * tilted.bitangent[0] + dy * tilted.bitangent[1] + dz * tilted.bitangent[2];
+    assert.ok(Math.abs(u - 4) < 1e-12, `tangent coord round-trip: ${u}`);
+    assert.ok(Math.abs(v - -2) < 1e-12, `bitangent coord round-trip: ${v}`);
+  });
+});
+
+describe('createSectionLift', () => {
+  it('binds the same mapping transform2Dto3D produces', () => {
+    const lift = createSectionLift('side', 4, true);
+    assert.deepStrictEqual(lift(3, 7), transform2Dto3D(3, 7, 'side', 4, true));
+  });
+
+  it('carries the custom plane through the binding', () => {
+    const plane = {
+      origin: [0, 0, 5] as [number, number, number],
+      tangent: [1, 0, 0] as [number, number, number],
+      bitangent: [0, 1, 0] as [number, number, number],
+    };
+    const lift = createSectionLift('down', 0, false, plane);
+    assert.deepStrictEqual(lift(2, 3), [2, 3, 5]);
+  });
+});
+
+describe('buildCapFillGeometry', () => {
+  it('returns null when nothing is triangulable', () => {
+    const lift = createSectionLift('front', 0);
+    assert.strictEqual(buildCapFillGeometry([], lift), null);
+    // A two-point "polygon" has no area.
+    assert.strictEqual(buildCapFillGeometry([poly([[0, 0], [1, 0]])], lift), null);
+  });
+
+  it('lifts a unit square onto the requested plane and preserves its area', () => {
+    const lift = createSectionLift('down', 12);
+    const geom = buildCapFillGeometry([poly([[0, 0], [2, 0], [2, 2], [0, 2]])], lift);
+    assert.ok(geom);
+    assert.strictEqual(geom.vertices.length, 4 * FLOATS_PER_VERTEX);
+    for (let i = 0; i < 4; i++) {
+      assert.strictEqual(geom.vertices[i * FLOATS_PER_VERTEX + 1], 12, 'every vertex on the plane');
+    }
+    assert.ok(Math.abs(triangulatedArea(geom.vertices, geom.indices) - 4) < 1e-5);
+  });
+
+  it('tags colourless polygons with the sentinel alpha -1 so the shader uses the cap style', () => {
+    const geom = buildCapFillGeometry(
+      [poly([[0, 0], [1, 0], [1, 1]])],
+      createSectionLift('front', 0),
+    );
+    assert.ok(geom);
+    assert.deepStrictEqual(
+      Array.from(geom.vertices.slice(3, 7)),
+      [0, 0, 0, -1],
+    );
+  });
+
+  it("carries a polygon's own RGBA onto every one of its vertices", () => {
+    const geom = buildCapFillGeometry(
+      [poly([[0, 0], [1, 0], [1, 1]], [], [0.25, 0.5, 0.75, 1])],
+      createSectionLift('front', 0),
+    );
+    assert.ok(geom);
+    for (let v = 0; v < geom.vertices.length / FLOATS_PER_VERTEX; v++) {
+      assert.deepStrictEqual(
+        Array.from(geom.vertices.slice(v * FLOATS_PER_VERTEX + 3, v * FLOATS_PER_VERTEX + 7)),
+        [0.25, 0.5, 0.75, 1],
+      );
+    }
+  });
+
+  it('triangulates a CONCAVE cross-section to its true area (the old convex fan inverted here)', () => {
+    // L-shape, area 3 of a 2x2 bounding box.
+    const l = poly([[0, 0], [2, 0], [2, 1], [1, 1], [1, 2], [0, 2]]);
+    const geom = buildCapFillGeometry([l], createSectionLift('front', 0));
+    assert.ok(geom);
+    const area = triangulatedArea(geom.vertices, geom.indices);
+    assert.ok(Math.abs(area - 3) < 1e-5, `concave area was ${area}, expected 3`);
+  });
+
+  it('stitches a hole ring into the outer ring rather than ignoring it', () => {
+    const withHole = poly(
+      [[0, 0], [4, 0], [4, 4], [0, 4]],
+      [[[1, 1], [1, 3], [3, 3], [3, 1]]],
+    );
+    const geom = buildCapFillGeometry([withHole], createSectionLift('front', 0));
+    assert.ok(geom);
+    // 4 outer + 4 hole + 2 bridge duplicates.
+    assert.strictEqual(geom.vertices.length / FLOATS_PER_VERTEX, 10);
+    const area = triangulatedArea(geom.vertices, geom.indices);
+    assert.ok(area < 16, `a holed cut face must not cover the full outer ring (got ${area})`);
+
+    // KNOWN GAP, deliberately not pinned to a number here: the shared
+    // `earClip` in symbolic-overlay-pipelines.ts under-triangulates the bridged
+    // ring, because its `pointInTriangle` treats on-edge points as contained
+    // and the bridge duplicates two vertices — so every candidate ear looks
+    // like it contains another vertex and almost none are clipped. That is a
+    // defect in the triangulator, not in the lift, and asserting the current
+    // (too small) area here would turn fixing it into a red test.
+  });
+
+  it('drops degenerate holes (<3 points) instead of corrupting the ring', () => {
+    const withStub = poly([[0, 0], [4, 0], [4, 4], [0, 4]], [[[1, 1], [2, 2]]]);
+    const geom = buildCapFillGeometry([withStub], createSectionLift('front', 0));
+    assert.ok(geom);
+    assert.strictEqual(geom.vertices.length / FLOATS_PER_VERTEX, 4);
+    assert.ok(Math.abs(triangulatedArea(geom.vertices, geom.indices) - 16) < 1e-5);
+  });
+
+  it('offsets indices per polygon so the second polygon does not index the first', () => {
+    const a = poly([[0, 0], [1, 0], [1, 1]]);
+    const b = poly([[5, 5], [6, 5], [6, 6]]);
+    const geom = buildCapFillGeometry([a, b], createSectionLift('front', 0));
+    assert.ok(geom);
+    assert.strictEqual(geom.vertices.length / FLOATS_PER_VERTEX, 6);
+    const maxIndex = Math.max(...Array.from(geom.indices));
+    assert.strictEqual(maxIndex, 5, 'indices must reach the second polygon');
+    // Total area = both triangles, which only holds if the offsets are right.
+    assert.ok(Math.abs(triangulatedArea(geom.vertices, geom.indices) - 1) < 1e-5);
+  });
+
+  it('skips a sub-3-point polygon without disturbing the offsets of the next one', () => {
+    const stub = poly([[0, 0], [1, 0]]);
+    const real = poly([[5, 5], [6, 5], [6, 6]]);
+    const geom = buildCapFillGeometry([stub, real], createSectionLift('front', 0));
+    assert.ok(geom);
+    assert.strictEqual(geom.vertices.length / FLOATS_PER_VERTEX, 3);
+    assert.strictEqual(Math.max(...Array.from(geom.indices)), 2);
+  });
+});
+
+describe('buildDrawingOutlineVertices', () => {
+  it('returns null when there are no polygons and no lines', () => {
+    assert.strictEqual(
+      buildDrawingOutlineVertices([], [], createSectionLift('front', 0)),
+      null,
+    );
+  });
+
+  it('emits one closed segment per outer edge', () => {
+    const out = buildDrawingOutlineVertices(
+      [poly([[0, 0], [1, 0], [1, 1]])],
+      [],
+      createSectionLift('front', 9),
+    );
+    assert.ok(out);
+    // 3 edges * 2 vertices * 3 floats
+    assert.strictEqual(out.length, 18);
+    // Last segment closes the ring back onto the first point.
+    assert.deepStrictEqual(Array.from(out.slice(15, 18)), [0, 0, 9]);
+  });
+
+  it('emits hole rings as well as the outer ring', () => {
+    const out = buildDrawingOutlineVertices(
+      [poly([[0, 0], [4, 0], [4, 4], [0, 4]], [[[1, 1], [1, 3], [3, 3]]])],
+      [],
+      createSectionLift('front', 0),
+    );
+    assert.ok(out);
+    // 4 outer edges + 3 hole edges = 7 segments.
+    assert.strictEqual(out.length, 7 * 6);
+  });
+
+  it('appends the extra drawing lines after the polygon outlines', () => {
+    const out = buildDrawingOutlineVertices(
+      [poly([[0, 0], [1, 0], [1, 1]])],
+      [line(10, 11, 12, 13)],
+      createSectionLift('front', 5),
+    );
+    assert.ok(out);
+    assert.strictEqual(out.length, 4 * 6);
+    assert.deepStrictEqual(Array.from(out.slice(18)), [10, 11, 5, 12, 13, 5]);
+  });
+
+  it('lifts outline points with the SAME lift as the fill (they must be coplanar)', () => {
+    const lift = createSectionLift('side', -3, true);
+    const p = poly([[0, 0], [1, 0], [1, 1]]);
+    const fill = buildCapFillGeometry([p], lift);
+    const out = buildDrawingOutlineVertices([p], [], lift);
+    assert.ok(fill && out);
+    for (let i = 0; i < out.length; i += 3) {
+      assert.strictEqual(out[i], -3, 'outline sits on the section plane');
+    }
+    assert.strictEqual(fill.vertices[0], -3, 'fill sits on the same plane');
+  });
+
+  it('emits lines even when every polygon was too small to fill', () => {
+    const out = buildDrawingOutlineVertices(
+      [poly([[0, 0], [1, 0]])],
+      [],
+      createSectionLift('front', 0),
+    );
+    // Two points still produce two (degenerate) edges — the outline path does
+    // not apply the fill path's 3-point minimum.
+    assert.ok(out);
+    assert.strictEqual(out.length, 2 * 6);
+  });
+});

--- a/packages/renderer/src/section-2d-lift.ts
+++ b/packages/renderer/src/section-2d-lift.ts
@@ -1,0 +1,245 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Section 2D → 3D lift and cap geometry building.
+ *
+ * Pure array maths, no GPU state: "what shape does the drawing have on the
+ * plane". `Section2DOverlayRenderer` owns the buffers and calls in here for the
+ * vertex data to put in them, which is why nothing in this file touches a
+ * `GPUDevice`. Its failure stories are geometric (the cap lands off a tilted
+ * plane, a concave cross-section triangulates inside-out, holes are not
+ * stitched, a flipped axis is mirrored the wrong way) and are all testable with
+ * plain numbers.
+ */
+
+import { earClip, joinHoles, type Pt } from './symbolic-overlay-pipelines.js';
+
+/** Semantic cardinal section axis: down (Y), front (Z), side (X). */
+export type SectionAxis = 'down' | 'front' | 'side';
+
+/**
+ * Arbitrary (face-picked) section plane, issue #243. The same basis is used by
+ * `SectionCutter` to project triangle-plane intersections to 2D, so the
+ * round-trip through {@link createSectionLift} is exact.
+ */
+export interface SectionCustomPlane {
+  origin: [number, number, number];
+  tangent: [number, number, number];
+  bitangent: [number, number, number];
+}
+
+export interface CutPolygon2D {
+  polygon: {
+    outer: Array<{ x: number; y: number }>;
+    holes: Array<Array<{ x: number; y: number }>>;
+  };
+  ifcType: string;
+  expressId: number;
+  /** Optional per-polygon RGBA (0–1). When present, this cap polygon fills with
+   *  this colour (an `IfcMaterialLayerSet` wall/slab layer, or a frame+glass
+   *  window part) instead of the uniform cap fill. Absent ⇒ uniform cap style +
+   *  per-`ifcType` fallback, unchanged. */
+  color?: [number, number, number, number];
+}
+
+export interface DrawingLine2D {
+  line: {
+    start: { x: number; y: number };
+    end: { x: number; y: number };
+  };
+  category: string;
+  /**
+   * Express ID of the entity that authored this segment. Optional — only the
+   * IfcAnnotation / IfcGridAxis symbolic overlay sets it (so per-entity hide
+   * can drop an annotation's curves without a mesh). The section-cut and
+   * drawing-2d cutters leave it undefined.
+   */
+  ownerId?: number;
+}
+
+/** A 2D drawing point lifted onto the section plane in world space. */
+export type SectionLift = (x2d: number, y2d: number) => [number, number, number];
+
+/**
+ * Transform 2D coordinates to 3D coordinates on the section plane.
+ *
+ * Cardinal axis path (legacy, unchanged):
+ * - Y axis (down): 2D (x, y) = 3D (x, z) - looking down at XZ plane
+ * - Z axis (front): 2D (x, y) = 3D (x, y) - looking along Z at XY plane
+ * - X axis (side): 2D (x, y) = 3D (z, y) - looking along X at ZY plane
+ * When flipped, the 2D x coordinate is negated.
+ *
+ * Custom-plane path (issue #243): when `customPlane` is supplied, the
+ * 3D point is `origin + tangent*x2d + bitangent*y2d`. The same basis
+ * is used by `SectionCutter` to project triangle-plane intersections
+ * to 2D, so the round-trip is exact and the cap polygons land
+ * precisely on the user's tilted plane.
+ */
+export function transform2Dto3D(
+  x2d: number,
+  y2d: number,
+  axis: SectionAxis,
+  planePosition: number,
+  flipped: boolean = false,
+  customPlane?: SectionCustomPlane,
+): [number, number, number] {
+  if (customPlane) {
+    // Custom plane: bypass the cardinal-axis swap. `flipped` is
+    // intentionally ignored because for arbitrary planes the cutter
+    // does not mirror its 2D output (mirroring only makes sense for
+    // cardinal projections that have a consistent "view direction").
+    const o = customPlane.origin;
+    const t = customPlane.tangent;
+    const b = customPlane.bitangent;
+    return [
+      o[0] + t[0] * x2d + b[0] * y2d,
+      o[1] + t[1] * x2d + b[1] * y2d,
+      o[2] + t[2] * x2d + b[2] * y2d,
+    ];
+  }
+
+  // Handle flipped - the 2D x coordinate was negated during projection
+  const x = flipped ? -x2d : x2d;
+
+  switch (axis) {
+    case 'down': // Y axis - horizontal cut (floor plan)
+      // 2D.x = 3D.x, 2D.y = 3D.z -> 3D (x, planeY, y)
+      return [x, planePosition, y2d];
+    case 'front': // Z axis - vertical cut (section view)
+      // 2D.x = 3D.x, 2D.y = 3D.y -> 3D (x, y, planeZ)
+      return [x, y2d, planePosition];
+    case 'side': // X axis - vertical cut (side elevation)
+      // 2D.x = 3D.z, 2D.y = 3D.y -> 3D (planeX, y, x)
+      return [planePosition, y2d, x];
+  }
+}
+
+/**
+ * Bind a lift ONCE per upload rather than re-resolving the axis/custom-plane
+ * branch per vertex. `uploadDrawing` runs over every cut polygon on each
+ * section-slider commit, so the branch is hoisted out of the inner loop; the
+ * returned closure allocates exactly the same one tuple per point that
+ * {@link transform2Dto3D} does.
+ */
+export function createSectionLift(
+  axis: SectionAxis,
+  planePosition: number,
+  flipped: boolean = false,
+  customPlane?: SectionCustomPlane,
+): SectionLift {
+  return (x2d, y2d) => transform2Dto3D(x2d, y2d, axis, planePosition, flipped, customPlane);
+}
+
+/** Interleaved `[x, y, z, r, g, b, a]` cap vertices plus their triangle indices. */
+export interface CapFillGeometry {
+  vertices: Float32Array;
+  indices: Uint32Array;
+}
+
+/**
+ * Triangulate the cut polygons and lift them onto the section plane.
+ *
+ * Hole-aware ear-clipping (reused from the IfcAnnotationFillArea fill path)
+ * replaces the old convex fan. The fan ignored holes and inverted on the
+ * CONCAVE cross-sections that arbitrary IFC profiles (and material-layer
+ * slabs) cut into, leaving the cut face uncovered — it read as a hollow
+ * shell. Section 2D points are (x, y); the triangulator works in (x, z),
+ * so y maps to z.
+ *
+ * Returns `null` when nothing survives (no polygon had three usable points),
+ * so the caller can skip buffer creation entirely.
+ */
+export function buildCapFillGeometry(
+  polygons: readonly CutPolygon2D[],
+  lift: SectionLift,
+): CapFillGeometry | null {
+  const fillVertices: number[] = [];
+  const fillIndices: number[] = [];
+  let vertexOffset = 0;
+
+  for (const polygon of polygons) {
+    const outer = polygon.polygon.outer;
+    if (outer.length < 3) continue;
+
+    // Per-polygon fill colour. A material-layer wall/slab delivers one polygon
+    // per layer, each carrying its IfcMaterial RGBA (window frame/glass parts
+    // likewise). Polygons WITHOUT a colour use the sentinel alpha −1 so the
+    // fill shader falls back to the uniform cap style (architectural fill +
+    // hatch) byte-identically — see fs_main.
+    const color: [number, number, number, number] = polygon.color ?? [0, 0, 0, -1];
+
+    const outerRing: Pt[] = outer.map((p) => ({ x: p.x, z: p.y }));
+    const holeRings: Pt[][] = polygon.polygon.holes
+      .filter((h) => h.length >= 3)
+      .map((h) => h.map((p) => ({ x: p.x, z: p.y })));
+    const stitched = holeRings.length > 0 ? joinHoles(outerRing, holeRings) : outerRing;
+    const tris = earClip(stitched);
+    if (tris.length === 0) continue;
+
+    const baseVertex = vertexOffset;
+    for (const pt of stitched) {
+      const [x3d, y3d, z3d] = lift(pt.x, pt.z);
+      fillVertices.push(x3d, y3d, z3d, color[0], color[1], color[2], color[3]);
+      vertexOffset++;
+    }
+    for (const [a, b, c] of tris) {
+      fillIndices.push(baseVertex + a, baseVertex + b, baseVertex + c);
+    }
+  }
+
+  if (fillVertices.length === 0) return null;
+  return {
+    vertices: new Float32Array(fillVertices),
+    indices: new Uint32Array(fillIndices),
+  };
+}
+
+/**
+ * Enumerate the cut outline as a line-list: every polygon's outer ring, every
+ * hole ring, then the extra drawing lines (hatching etc.), each lifted onto the
+ * section plane. Rings close back onto their first point.
+ *
+ * Returns `null` when there is nothing to draw.
+ */
+export function buildDrawingOutlineVertices(
+  polygons: readonly CutPolygon2D[],
+  lines: readonly DrawingLine2D[],
+  lift: SectionLift,
+): Float32Array | null {
+  const lineVertices: number[] = [];
+
+  // Polygon outlines
+  for (const polygon of polygons) {
+    const outer = polygon.polygon.outer;
+    for (let i = 0; i < outer.length; i++) {
+      const p1 = outer[i];
+      const p2 = outer[(i + 1) % outer.length];
+      const [x1, y1, z1] = lift(p1.x, p1.y);
+      const [x2, y2, z2] = lift(p2.x, p2.y);
+      lineVertices.push(x1, y1, z1, x2, y2, z2);
+    }
+
+    // Hole outlines
+    for (const hole of polygon.polygon.holes) {
+      for (let i = 0; i < hole.length; i++) {
+        const p1 = hole[i];
+        const p2 = hole[(i + 1) % hole.length];
+        const [x1, y1, z1] = lift(p1.x, p1.y);
+        const [x2, y2, z2] = lift(p2.x, p2.y);
+        lineVertices.push(x1, y1, z1, x2, y2, z2);
+      }
+    }
+  }
+
+  // Additional drawing lines (hatching, etc.)
+  for (const line of lines) {
+    const [x1, y1, z1] = lift(line.line.start.x, line.line.start.y);
+    const [x2, y2, z2] = lift(line.line.end.x, line.line.end.y);
+    lineVertices.push(x1, y1, z1, x2, y2, z2);
+  }
+
+  if (lineVertices.length === 0) return null;
+  return new Float32Array(lineVertices);
+}

--- a/packages/renderer/src/section-2d-line-buffer.ts
+++ b/packages/renderer/src/section-2d-line-buffer.ts
@@ -1,0 +1,104 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * One world-space line-list vertex buffer.
+ *
+ * `Section2DOverlayRenderer` backs five standalone line overlays (annotation
+ * #653, alignment, grid #967, DXF #2043, clash box #1277) that are byte-for-byte
+ * identical apart from which buffer they read and which colour they draw in.
+ * This is the ONLY thing those families genuinely own on their own: a vertex
+ * buffer and its vertex count.
+ *
+ * Deliberately NOT an owner of anything shared. The line pipeline, the
+ * bind-group layout, the bind group and the 160-byte uniform buffer stay owned
+ * solely by `Section2DOverlayRenderer` and are handed in per draw as
+ * {@link SectionLinePipelineResources}. That keeps the renderer's single
+ * `init()`/`dispose()` lifecycle the one place those resources are created and
+ * destroyed — giving each family its own pipeline handle is the split that
+ * would put one GPU object under six owners (issue #2456).
+ */
+
+import {
+  SECTION_2D_UNIFORM_FLOATS,
+  SECTION_2D_UNIFORM_SLOTS,
+} from './shaders/section-2d-overlay.wgsl.js';
+
+/** Shared GPU resources a {@link WorldLineBuffer} borrows for the duration of a draw. */
+export interface SectionLinePipelineResources {
+  device: GPUDevice;
+  pipeline: GPURenderPipeline;
+  bindGroup: GPUBindGroup;
+  uniformBuffer: GPUBuffer;
+}
+
+/** Minimum floats for one line segment: two 3-float vertices. */
+const FLOATS_PER_SEGMENT = 6;
+
+export class WorldLineBuffer {
+  private buffer: GPUBuffer | null = null;
+  private count = 0;
+
+  /**
+   * Replace the buffer's contents with a flat `[x,y,z, x,y,z, …]` line-list in
+   * world space. Anything shorter than one full segment clears instead, which
+   * is how every caller passes "no lines".
+   */
+  upload(device: GPUDevice, vertices: Float32Array): void {
+    this.clear();
+    if (vertices.length < FLOATS_PER_SEGMENT) return;
+
+    this.buffer = device.createBuffer({
+      size: vertices.byteLength,
+      usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
+    });
+    device.queue.writeBuffer(this.buffer, 0, vertices);
+    this.count = vertices.length / 3;
+  }
+
+  /** Destroy the buffer and reset the count. Safe to call repeatedly. */
+  clear(): void {
+    if (this.buffer) {
+      this.buffer.destroy();
+      this.buffer = null;
+    }
+    this.count = 0;
+  }
+
+  has(): boolean {
+    return this.count > 0;
+  }
+
+  /** Vertex count, for tests and for the caller's own bookkeeping. */
+  get vertexCount(): number {
+    return this.count;
+  }
+
+  /**
+   * Draw the buffer in `color`. `planeOffset` is left zeroed — these vertices
+   * are already in world space, so unlike the section-cut outline they do not
+   * ride the section plane.
+   *
+   * No-ops when the buffer is empty, so callers do not need their own guard.
+   */
+  draw(
+    pass: GPURenderPassEncoder,
+    resources: SectionLinePipelineResources,
+    viewProj: Float32Array,
+    color: readonly [number, number, number, number],
+  ): void {
+    if (!this.buffer || this.count === 0) return;
+
+    const uniforms = new Float32Array(SECTION_2D_UNIFORM_FLOATS);
+    uniforms.set(viewProj, SECTION_2D_UNIFORM_SLOTS.viewProj);
+    // planeOffset stays 0 — vertices are already in world space.
+    uniforms.set(color, SECTION_2D_UNIFORM_SLOTS.lineColor);
+    resources.device.queue.writeBuffer(resources.uniformBuffer, 0, uniforms);
+
+    pass.setPipeline(resources.pipeline);
+    pass.setBindGroup(0, resources.bindGroup);
+    pass.setVertexBuffer(0, this.buffer);
+    pass.draw(this.count);
+  }
+}

--- a/packages/renderer/src/section-2d-line-buffer.ts
+++ b/packages/renderer/src/section-2d-line-buffer.ts
@@ -31,6 +31,8 @@ export interface SectionLinePipelineResources {
   pipeline: GPURenderPipeline;
   bindGroup: GPUBindGroup;
   uniformBuffer: GPUBuffer;
+  /** Byte stride between the uniform slots in `uniformBuffer`. */
+  uniformStride: number;
 }
 
 /** Minimum floats for one line segment: two 3-float vertices. */
@@ -41,20 +43,43 @@ export class WorldLineBuffer {
   private count = 0;
 
   /**
+   * @param uniformSlot Index of this family's record in the shared uniform
+   *   buffer. Every family needs its own: the six overlay draws are encoded
+   *   into one pass and `queue.writeBuffer` lands before the pass runs, so a
+   *   shared record means the last family's colour is the one all six get.
+   *   See `SECTION_2D_UNIFORM_SLOT_INDEX`.
+   */
+  constructor(private readonly uniformSlot: number) {}
+
+  /**
    * Replace the buffer's contents with a flat `[x,y,z, x,y,z, …]` line-list in
    * world space. Anything shorter than one full segment clears instead, which
    * is how every caller passes "no lines".
+   *
+   * Only **whole** segments are uploaded. The vertex count went straight to
+   * `pass.draw()` as `vertices.length / 3`, so a length that was not a multiple
+   * of 3 produced a *fractional* vertex count — a WebGPU validation error that
+   * kills the whole command buffer, taking every other overlay in the pass down
+   * with it — and an odd whole vertex count left a dangling half-segment the
+   * line-list topology would discard anyway. Both are reachable: these arrays
+   * are assembled by upstream polyline/arc flatteners, not written by hand.
+   *
+   * Truncating rather than rejecting the whole array is deliberate. One stray
+   * float from a flattener should cost the caller the incomplete tail segment,
+   * not the entire grid / DXF / annotation layer.
    */
   upload(device: GPUDevice, vertices: Float32Array): void {
     this.clear();
-    if (vertices.length < FLOATS_PER_SEGMENT) return;
+    const usableFloats = Math.floor(vertices.length / FLOATS_PER_SEGMENT) * FLOATS_PER_SEGMENT;
+    if (usableFloats === 0) return;
 
+    const data = usableFloats === vertices.length ? vertices : vertices.subarray(0, usableFloats);
     this.buffer = device.createBuffer({
-      size: vertices.byteLength,
+      size: data.byteLength,
       usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
     });
-    device.queue.writeBuffer(this.buffer, 0, vertices);
-    this.count = vertices.length / 3;
+    device.queue.writeBuffer(this.buffer, 0, data);
+    this.count = usableFloats / 3;
   }
 
   /** Destroy the buffer and reset the count. Safe to call repeatedly. */
@@ -80,6 +105,10 @@ export class WorldLineBuffer {
    * are already in world space, so unlike the section-cut outline they do not
    * ride the section plane.
    *
+   * Writes into — and binds — **this family's own** uniform slot. Sharing one
+   * record across the pass's six draws meant the last write before submit was
+   * what every draw read.
+   *
    * No-ops when the buffer is empty, so callers do not need their own guard.
    */
   draw(
@@ -90,14 +119,15 @@ export class WorldLineBuffer {
   ): void {
     if (!this.buffer || this.count === 0) return;
 
+    const byteOffset = this.uniformSlot * resources.uniformStride;
     const uniforms = new Float32Array(SECTION_2D_UNIFORM_FLOATS);
     uniforms.set(viewProj, SECTION_2D_UNIFORM_SLOTS.viewProj);
     // planeOffset stays 0 — vertices are already in world space.
     uniforms.set(color, SECTION_2D_UNIFORM_SLOTS.lineColor);
-    resources.device.queue.writeBuffer(resources.uniformBuffer, 0, uniforms);
+    resources.device.queue.writeBuffer(resources.uniformBuffer, byteOffset, uniforms);
 
     pass.setPipeline(resources.pipeline);
-    pass.setBindGroup(0, resources.bindGroup);
+    pass.setBindGroup(0, resources.bindGroup, [byteOffset]);
     pass.setVertexBuffer(0, this.buffer);
     pass.draw(this.count);
   }

--- a/packages/renderer/src/section-2d-overlay-lifecycle.test.ts
+++ b/packages/renderer/src/section-2d-overlay-lifecycle.test.ts
@@ -5,7 +5,12 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import { Section2DOverlayRenderer } from './section-2d-overlay.js';
-import { SECTION_2D_UNIFORM_SLOTS } from './shaders/section-2d-overlay.wgsl.js';
+import {
+  SECTION_2D_UNIFORM_BYTES,
+  SECTION_2D_UNIFORM_SLOTS,
+  SECTION_2D_UNIFORM_SLOT_COUNT,
+  SECTION_2D_UNIFORM_SLOT_INDEX,
+} from './shaders/section-2d-overlay.wgsl.js';
 
 // WebGPU enum globals referenced by the renderer's bind-group visibility and
 // buffer usage flags (not defined in node) — same polyfill as
@@ -30,10 +35,11 @@ interface FakeBuffer extends GPUBuffer {
   __size: number;
 }
 
-function makeDevice() {
+function makeDevice(minUniformBufferOffsetAlignment = 256) {
   const buffers: FakeBuffer[] = [];
-  const writes: Array<{ buffer: GPUBuffer; data: Float32Array }> = [];
+  const writes: Array<{ buffer: GPUBuffer; offset: number; data: Float32Array }> = [];
   const device = {
+    limits: { minUniformBufferOffsetAlignment } as unknown as GPUSupportedLimits,
     createBindGroupLayout: () => ({}) as GPUBindGroupLayout,
     createPipelineLayout: () => ({}) as GPUPipelineLayout,
     createShaderModule: (desc: { code: string }) => ({ code: desc.code }) as unknown as GPUShaderModule,
@@ -51,8 +57,14 @@ function makeDevice() {
       return buf as unknown as GPUBuffer;
     },
     queue: {
-      writeBuffer: (buffer: GPUBuffer, _offset: number, data: ArrayBufferView) => {
-        writes.push({ buffer, data: new Float32Array(data.buffer.slice(0)) });
+      writeBuffer: (buffer: GPUBuffer, offset: number, data: ArrayBufferView) => {
+        writes.push({
+          buffer,
+          offset,
+          data: new Float32Array(
+            data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength),
+          ),
+        });
       },
     },
   } as unknown as GPUDevice;
@@ -61,19 +73,60 @@ function makeDevice() {
 
 function makePass() {
   const calls: string[] = [];
+  /** Dynamic bind-group offsets, in the order they were bound. */
+  const binds: number[] = [];
   const pass = {
     setPipeline: () => calls.push('setPipeline'),
-    setBindGroup: () => calls.push('setBindGroup'),
+    setBindGroup: (_i: number, _g: GPUBindGroup, dynamicOffsets?: number[]) => {
+      calls.push('setBindGroup');
+      binds.push(dynamicOffsets?.[0] ?? 0);
+    },
     setVertexBuffer: () => calls.push('setVertexBuffer'),
     setIndexBuffer: () => calls.push('setIndexBuffer'),
     draw: (n: number) => calls.push(`draw:${n}`),
     drawIndexed: (n: number) => calls.push(`drawIndexed:${n}`),
   } as unknown as GPURenderPassEncoder;
-  return { pass, calls };
+  return { pass, calls, binds };
 }
 
 /** Two segments = 12 floats, the minimum a family accepts. */
 const SEGMENTS = new Float32Array([0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3]);
+
+const OPTIONS = {
+  axis: 'front' as const,
+  position: 50,
+  bounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 1, y: 1, z: 1 } },
+  viewProj: new Float32Array(16),
+};
+const CAP_STYLE = {
+  fillColor: [1, 1, 1, 1] as [number, number, number, number],
+  strokeColor: [0, 0, 0, 1] as [number, number, number, number],
+  patternId: 0,
+  spacingPx: 8,
+  angleRad: 0,
+  widthPx: 1,
+  secondaryAngleRad: 0,
+};
+/**
+ * A cap style whose every field is distinguishable from the zeroed cap-style
+ * tail a world-space line draw writes. `CAP_STYLE` above is deliberately the
+ * bland one, and `patternId: 0` there is indistinguishable from that zero —
+ * which is exactly the confusion the uniform-slot tests must not fall into.
+ */
+const CAP_STYLE_HATCHED = {
+  fillColor: [0.92, 0.88, 0.78, 1] as [number, number, number, number],
+  strokeColor: [0.1, 0.1, 0.1, 1] as [number, number, number, number],
+  patternId: 6,
+  spacingPx: 12,
+  angleRad: 0.5,
+  widthPx: 2,
+  secondaryAngleRad: -0.5,
+};
+const TRIANGLE = [{
+  polygon: { outer: [{ x: 0, y: 0 }, { x: 1, y: 0 }, { x: 1, y: 1 }], holes: [] },
+  ifcType: 'IfcWall',
+  expressId: 1,
+}];
 
 type Family = {
   name: string;
@@ -121,8 +174,8 @@ const FAMILIES: Family[] = [
   },
 ];
 
-function newRenderer() {
-  const { device, buffers, writes } = makeDevice();
+function newRenderer(minUniformBufferOffsetAlignment = 256) {
+  const { device, buffers, writes } = makeDevice(minUniformBufferOffsetAlignment);
   const renderer = new Section2DOverlayRenderer(device, 'bgra8unorm' as GPUTextureFormat, 4);
   return { renderer, buffers, writes };
 }
@@ -160,6 +213,49 @@ describe('Section2DOverlayRenderer: per-family buffer ownership', () => {
       family.upload(renderer, new Float32Array([1, 2, 3, 4, 5]));
       assert.strictEqual(family.has(renderer), false);
       assert.strictEqual(buffers.length, before, 'no buffer allocated for a partial segment');
+    });
+
+    it(`${family.name}: uploads whole segments only`, () => {
+      // The vertex count went straight to `pass.draw()` as `length / 3`, so a
+      // length that is not a multiple of 3 produced a FRACTIONAL count — a
+      // WebGPU validation error that kills the whole command buffer, taking
+      // every other overlay in the pass with it. A length that is a multiple
+      // of 3 but an odd vertex count left a dangling half-segment the
+      // line-list topology discards anyway. These arrays come from upstream
+      // polyline/arc flatteners, not from hand-written literals.
+      // Truncated to whole segments rather than rejected outright: a single
+      // stray float from a flattener must not make an entire grid or DXF
+      // layer vanish, which is what rejecting the whole array would do.
+      for (const [floats, expectedVertices] of [
+        [5, 0],   // under one segment — the documented "no lines" spelling
+        [7, 2],   // 2.33 vertices: the FRACTIONAL count, floored to one segment
+        [8, 2],   // 2.67 vertices
+        [9, 2],   // 3 whole vertices: one segment, one dangling vertex
+        [12, 4],  // exactly two segments
+        [15, 4],  // 5 vertices: two whole segments, one dangling
+        [18, 6],  // exactly three segments
+      ] as const) {
+        const { renderer } = newRenderer();
+        family.upload(renderer, new Float32Array(floats).map((_, i) => i));
+        const { pass, calls } = makePass();
+        family.draw(renderer, pass, new Float32Array(16));
+        const drawCall = calls.find((c) => c.startsWith('draw:'));
+        if (expectedVertices === 0) {
+          assert.strictEqual(family.has(renderer), false, `${floats} floats should not upload`);
+          assert.strictEqual(drawCall, undefined, `${floats} floats should not draw`);
+        } else {
+          assert.strictEqual(drawCall, `draw:${expectedVertices}`, `${floats} floats`);
+        }
+      }
+    });
+
+    it(`${family.name}: never allocates room for a partial segment`, () => {
+      // The buffer must be sized to the vertices actually drawn, or the tail
+      // is uninitialised GPU memory that a later count bump would render.
+      const { renderer, buffers } = newRenderer();
+      family.upload(renderer, new Float32Array(15).map((_, i) => i));
+      const vertexBuffer = buffers.find((b) => b.__size === 12 * 4);
+      assert.ok(vertexBuffer, `expected a 48-byte buffer, saw ${buffers.map((b) => b.__size)}`);
     });
 
     it(`${family.name}: draw is a no-op when the family is empty`, () => {
@@ -339,27 +435,6 @@ describe('Section2DOverlayRenderer: shared uniform buffer', () => {
 });
 
 describe('Section2DOverlayRenderer: section-cut draw gating', () => {
-  const OPTIONS = {
-    axis: 'front' as const,
-    position: 50,
-    bounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 1, y: 1, z: 1 } },
-    viewProj: new Float32Array(16),
-  };
-  const CAP_STYLE = {
-    fillColor: [1, 1, 1, 1] as [number, number, number, number],
-    strokeColor: [0, 0, 0, 1] as [number, number, number, number],
-    patternId: 0,
-    spacingPx: 8,
-    angleRad: 0,
-    widthPx: 1,
-    secondaryAngleRad: 0,
-  };
-  const TRIANGLE = [{
-    polygon: { outer: [{ x: 0, y: 0 }, { x: 1, y: 0 }, { x: 1, y: 1 }], holes: [] },
-    ifcType: 'IfcWall',
-    expressId: 1,
-  }];
-
   it('draws nothing before any upload', () => {
     const { renderer } = newRenderer();
     const { pass, calls } = makePass();
@@ -406,11 +481,157 @@ describe('Section2DOverlayRenderer: section-cut draw gating', () => {
   it('re-uploading the drawing destroys the previous cut buffers', () => {
     const { renderer, buffers } = newRenderer();
     renderer.uploadDrawing(TRIANGLE, [], 'front', 0);
-    const cutBuffers = buffers.filter((b) => b.__size !== 160);
+    // Everything except the shared uniform buffer, which `init()` owns and
+    // re-uploading the drawing must not touch. Sized by slot count now, so
+    // this can no longer be spelled `!== 160`.
+    const uniformSize = SECTION_2D_UNIFORM_SLOT_COUNT * 256;
+    const cutBuffers = buffers.filter((b) => b.__size !== uniformSize);
     assert.ok(cutBuffers.length >= 2, 'fill vertex + index (+ outline) buffers');
     renderer.uploadDrawing(TRIANGLE, [], 'front', 0);
     for (const b of cutBuffers) {
       assert.strictEqual(b.__destroyed, 1, 'previous cut buffer destroyed on re-upload');
     }
+  });
+});
+
+/**
+ * Six draws, six uniform records.
+ *
+ * `Section2DOverlayRenderer` encodes the cut cap and up to five world-space
+ * line families into ONE render pass (`renderer-overlays.ts` calls them one
+ * after another), and each needs different uniforms. They all wrote byte 0 of
+ * one 160-byte buffer. `queue.writeBuffer` is a *queue* operation: it is
+ * applied before the command buffer that references the buffer executes,
+ * wherever in the encoding it was issued. So the last write before submit is
+ * what all six draws read — the clash box's magenta bleeding onto every other
+ * overlay, and the cap's fill colour and hatch replaced by the zeroed tail a
+ * line draw writes. Pre-existing on `origin/main`, where the same six draws
+ * write `this.uniformBuffer` at offset 0.
+ */
+describe('Section2DOverlayRenderer: one uniform record per draw (#2456)', () => {
+  /** Everything a full overlay frame draws, in `renderer-overlays.ts` order. */
+  function drawWholeFrame(renderer: Section2DOverlayRenderer, pass: GPURenderPassEncoder): void {
+    renderer.draw(pass, { ...OPTIONS, showFills: true, capStyle: CAP_STYLE_HATCHED });
+    for (const f of FAMILIES) f.draw(renderer, pass, new Float32Array(16).fill(0));
+  }
+
+  it('every draw in one pass reads a different slot', () => {
+    const { renderer, writes } = newRenderer();
+    renderer.setOverlayLineColor([0.1, 0.2, 0.3, 1]);
+    renderer.setClashBoxLineColor([1, 0, 1, 1]);
+    renderer.uploadDrawing(TRIANGLE, [], 'front', 0);
+    for (const f of FAMILIES) f.upload(renderer, SEGMENTS);
+
+    const { pass, binds } = makePass();
+    const uniformWritesBefore = writes.length;
+    drawWholeFrame(renderer, pass);
+
+    // One uniform write per draw site: the cap (which its fill and outline
+    // share by design) plus the five families.
+    const uniformOffsets = writes.slice(uniformWritesBefore).map((w) => w.offset);
+    assert.strictEqual(uniformOffsets.length, SECTION_2D_UNIFORM_SLOT_COUNT);
+    assert.strictEqual(
+      new Set(uniformOffsets).size,
+      SECTION_2D_UNIFORM_SLOT_COUNT,
+      `the six draws must not share a record; offsets were ${JSON.stringify(uniformOffsets)}`,
+    );
+
+    // …and every bound record must be one that was actually written for it.
+    // 7 binds: cap fill + cap outline (same slot) + five families.
+    assert.strictEqual(binds.length, SECTION_2D_UNIFORM_SLOT_COUNT + 1);
+    assert.strictEqual(
+      new Set(binds).size,
+      SECTION_2D_UNIFORM_SLOT_COUNT,
+      'the cap fill and outline share slot 0; the five families do not share anything',
+    );
+    for (const offset of binds) {
+      assert.ok(uniformOffsets.includes(offset), `nothing was written to bound offset ${offset}`);
+    }
+  });
+
+  it('the clash box colour cannot reach the other families', () => {
+    // The user-visible symptom, asserted on the bytes each draw binds rather
+    // than on "the last write": with one shared record the grid draw bound a
+    // record that held magenta by the time the pass ran.
+    const { renderer, writes } = newRenderer();
+    renderer.setOverlayLineColor([0.1, 0.2, 0.3, 1]);
+    renderer.setClashBoxLineColor([1, 0, 1, 1]);
+    renderer.uploadGridLines3D(SEGMENTS);
+    renderer.uploadClashBoxLines3D(SEGMENTS);
+
+    const { pass, binds } = makePass();
+    const before = writes.length;
+    renderer.drawGridLines3D(pass, new Float32Array(16).fill(0));
+    renderer.drawClashBoxLines3D(pass, new Float32Array(16).fill(0));
+
+    // Resolve what the GPU would see for the FIRST draw: the last write to the
+    // offset that draw bound. That is exactly the queue semantics that made
+    // this a bug.
+    const gridOffset = binds[0];
+    const settled = writes.slice(before).filter((w) => w.offset === gridOffset).pop();
+    assert.ok(settled, 'the grid draw bound an offset nothing was written to');
+    const C = SECTION_2D_UNIFORM_SLOTS.lineColor;
+    assert.deepStrictEqual(
+      Array.from(settled.data.slice(C, C + 4)).map((v) => Math.round(v * 1000) / 1000),
+      [0.1, 0.2, 0.3, 1],
+      'the grid must still be drawn in the shared overlay colour, not the clash magenta',
+    );
+  });
+
+  it('the cap style survives the line families drawn after it', () => {
+    // The cap writes its fill colour, stroke and hatch params; every line draw
+    // writes a record whose whole cap-style tail is zero. Sharing one record
+    // meant the cap rendered with a transparent black fill and pattern 0.
+    const { renderer, writes } = newRenderer();
+    renderer.uploadDrawing(TRIANGLE, [], 'front', 0);
+    for (const f of FAMILIES) f.upload(renderer, SEGMENTS);
+
+    const { pass, binds } = makePass();
+    const before = writes.length;
+    drawWholeFrame(renderer, pass);
+
+    const capOffset = binds[0];
+    const settled = writes.slice(before).filter((w) => w.offset === capOffset).pop();
+    assert.ok(settled, 'the cap bound an offset nothing was written to');
+    const F = SECTION_2D_UNIFORM_SLOTS.capFillColor;
+    assert.deepStrictEqual(
+      Array.from(settled.data.slice(F, F + 4)).map((v) => Math.round(v * 100) / 100),
+      Array.from(CAP_STYLE_HATCHED.fillColor),
+      'the cap fill colour must survive the five line draws encoded after it',
+    );
+    assert.strictEqual(
+      settled.data[SECTION_2D_UNIFORM_SLOTS.params],
+      CAP_STYLE_HATCHED.patternId,
+      'the cap hatch pattern must survive too',
+    );
+  });
+
+  it('slot offsets follow the device alignment, not a hard-coded 256', () => {
+    // `minUniformBufferOffsetAlignment` is a device limit; 256 is only the
+    // guaranteed-supported default. A device reporting 64 must still get
+    // records that fit the 160-byte struct.
+    const { renderer, writes, buffers } = (() => {
+      const r = newRenderer(64);
+      return r;
+    })();
+    renderer.uploadGridLines3D(SEGMENTS);
+    renderer.uploadClashBoxLines3D(SEGMENTS);
+    const { pass } = makePass();
+    const before = writes.length;
+    renderer.drawGridLines3D(pass, new Float32Array(16).fill(0));
+    renderer.drawClashBoxLines3D(pass, new Float32Array(16).fill(0));
+
+    const offsets = writes.slice(before).map((w) => w.offset);
+    const stride = 192; // ceil(160 / 64) * 64
+    for (const o of offsets) {
+      assert.strictEqual(o % 64, 0, `offset ${o} is not 64-byte aligned`);
+    }
+    assert.strictEqual(
+      offsets[1] - offsets[0],
+      (SECTION_2D_UNIFORM_SLOT_INDEX.clashBox - SECTION_2D_UNIFORM_SLOT_INDEX.grid) * stride,
+    );
+    const uniform = buffers.find((b) => b.__size === stride * SECTION_2D_UNIFORM_SLOT_COUNT);
+    assert.ok(uniform, `no uniform buffer of ${stride * SECTION_2D_UNIFORM_SLOT_COUNT} bytes`);
+    assert.ok(stride >= SECTION_2D_UNIFORM_BYTES, 'a slot must hold the whole struct');
   });
 });

--- a/packages/renderer/src/section-2d-overlay-lifecycle.test.ts
+++ b/packages/renderer/src/section-2d-overlay-lifecycle.test.ts
@@ -1,0 +1,416 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { Section2DOverlayRenderer } from './section-2d-overlay.js';
+import { SECTION_2D_UNIFORM_SLOTS } from './shaders/section-2d-overlay.wgsl.js';
+
+// WebGPU enum globals referenced by the renderer's bind-group visibility and
+// buffer usage flags (not defined in node) — same polyfill as
+// paired-buffer-leak.test.ts / point-cloud-transform.test.ts.
+(globalThis as Record<string, unknown>).GPUShaderStage = { VERTEX: 1, FRAGMENT: 2, COMPUTE: 4 };
+(globalThis as Record<string, unknown>).GPUBufferUsage = {
+  MAP_READ: 1, MAP_WRITE: 2, COPY_SRC: 4, COPY_DST: 8, INDEX: 16,
+  VERTEX: 32, UNIFORM: 64, STORAGE: 128, INDIRECT: 256, QUERY_RESOLVE: 512,
+};
+
+/**
+ * `Section2DOverlayRenderer` is ONE nullable GPU object backing six buffer
+ * families. Nothing pinned its ownership rules until this file: the clash-box
+ * family (#1277) was the sixth added and was silently missing from `dispose()`,
+ * so its vertex buffer leaked on every renderer teardown while the whole suite
+ * stayed green. These tests count `createBuffer` against `destroy()` so the
+ * seventh family cannot repeat it.
+ */
+
+interface FakeBuffer extends GPUBuffer {
+  __destroyed: number;
+  __size: number;
+}
+
+function makeDevice() {
+  const buffers: FakeBuffer[] = [];
+  const writes: Array<{ buffer: GPUBuffer; data: Float32Array }> = [];
+  const device = {
+    createBindGroupLayout: () => ({}) as GPUBindGroupLayout,
+    createPipelineLayout: () => ({}) as GPUPipelineLayout,
+    createShaderModule: (desc: { code: string }) => ({ code: desc.code }) as unknown as GPUShaderModule,
+    createRenderPipeline: (desc: unknown) => ({ desc }) as unknown as GPURenderPipeline,
+    createBindGroup: () => ({}) as GPUBindGroup,
+    createBuffer: (desc: { size: number }) => {
+      const buf = {
+        __destroyed: 0,
+        __size: desc.size,
+        destroy() {
+          (this as FakeBuffer).__destroyed++;
+        },
+      } as unknown as FakeBuffer;
+      buffers.push(buf);
+      return buf as unknown as GPUBuffer;
+    },
+    queue: {
+      writeBuffer: (buffer: GPUBuffer, _offset: number, data: ArrayBufferView) => {
+        writes.push({ buffer, data: new Float32Array(data.buffer.slice(0)) });
+      },
+    },
+  } as unknown as GPUDevice;
+  return { device, buffers, writes };
+}
+
+function makePass() {
+  const calls: string[] = [];
+  const pass = {
+    setPipeline: () => calls.push('setPipeline'),
+    setBindGroup: () => calls.push('setBindGroup'),
+    setVertexBuffer: () => calls.push('setVertexBuffer'),
+    setIndexBuffer: () => calls.push('setIndexBuffer'),
+    draw: (n: number) => calls.push(`draw:${n}`),
+    drawIndexed: (n: number) => calls.push(`drawIndexed:${n}`),
+  } as unknown as GPURenderPassEncoder;
+  return { pass, calls };
+}
+
+/** Two segments = 12 floats, the minimum a family accepts. */
+const SEGMENTS = new Float32Array([0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3]);
+
+type Family = {
+  name: string;
+  upload: (r: Section2DOverlayRenderer, v: Float32Array) => void;
+  clear: (r: Section2DOverlayRenderer) => void;
+  has: (r: Section2DOverlayRenderer) => boolean;
+  draw: (r: Section2DOverlayRenderer, p: GPURenderPassEncoder, vp: Float32Array) => void;
+};
+
+const FAMILIES: Family[] = [
+  {
+    name: 'annotation',
+    upload: (r, v) => r.uploadAnnotationLines3D(v),
+    clear: (r) => r.clearAnnotationLines3D(),
+    has: (r) => r.hasAnnotationLines3D(),
+    draw: (r, p, vp) => r.drawAnnotationLines3D(p, vp),
+  },
+  {
+    name: 'alignment',
+    upload: (r, v) => r.uploadAlignmentLines3D(v),
+    clear: (r) => r.clearAlignmentLines3D(),
+    has: (r) => r.hasAlignmentLines3D(),
+    draw: (r, p, vp) => r.drawAlignmentLines3D(p, vp),
+  },
+  {
+    name: 'grid',
+    upload: (r, v) => r.uploadGridLines3D(v),
+    clear: (r) => r.clearGridLines3D(),
+    has: (r) => r.hasGridLines3D(),
+    draw: (r, p, vp) => r.drawGridLines3D(p, vp),
+  },
+  {
+    name: 'dxf',
+    upload: (r, v) => r.uploadDxfLines3D(v),
+    clear: (r) => r.clearDxfLines3D(),
+    has: (r) => r.hasDxfLines3D(),
+    draw: (r, p, vp) => r.drawDxfLines3D(p, vp),
+  },
+  {
+    name: 'clashBox',
+    upload: (r, v) => r.uploadClashBoxLines3D(v),
+    clear: (r) => r.clearClashBoxLines3D(),
+    has: (r) => r.hasClashBoxLines3D(),
+    draw: (r, p, vp) => r.drawClashBoxLines3D(p, vp),
+  },
+];
+
+function newRenderer() {
+  const { device, buffers, writes } = makeDevice();
+  const renderer = new Section2DOverlayRenderer(device, 'bgra8unorm' as GPUTextureFormat, 4);
+  return { renderer, buffers, writes };
+}
+
+describe('Section2DOverlayRenderer: per-family buffer ownership', () => {
+  for (const family of FAMILIES) {
+    it(`${family.name}: upload allocates, clear destroys, has() follows`, () => {
+      const { renderer, buffers } = newRenderer();
+      assert.strictEqual(family.has(renderer), false);
+
+      family.upload(renderer, SEGMENTS);
+      assert.strictEqual(family.has(renderer), true);
+      const vertexBuffers = buffers.filter((b) => b.__size === SEGMENTS.byteLength);
+      assert.strictEqual(vertexBuffers.length, 1);
+
+      family.clear(renderer);
+      assert.strictEqual(family.has(renderer), false);
+      assert.strictEqual(vertexBuffers[0].__destroyed, 1);
+    });
+
+    it(`${family.name}: re-upload destroys the previous buffer (no leak per frame)`, () => {
+      const { renderer, buffers } = newRenderer();
+      family.upload(renderer, SEGMENTS);
+      const first = buffers.filter((b) => b.__size === SEGMENTS.byteLength)[0];
+      family.upload(renderer, SEGMENTS);
+      assert.strictEqual(first.__destroyed, 1);
+      assert.strictEqual(family.has(renderer), true);
+    });
+
+    it(`${family.name}: a sub-segment upload clears instead of allocating`, () => {
+      const { renderer, buffers } = newRenderer();
+      family.upload(renderer, SEGMENTS);
+      const before = buffers.length;
+      // 5 floats is less than one 6-float segment.
+      family.upload(renderer, new Float32Array([1, 2, 3, 4, 5]));
+      assert.strictEqual(family.has(renderer), false);
+      assert.strictEqual(buffers.length, before, 'no buffer allocated for a partial segment');
+    });
+
+    it(`${family.name}: draw is a no-op when the family is empty`, () => {
+      const { renderer } = newRenderer();
+      const { pass, calls } = makePass();
+      family.draw(renderer, pass, new Float32Array(16));
+      assert.deepStrictEqual(calls, []);
+    });
+
+    it(`${family.name}: draw issues exactly one draw of the uploaded vertex count`, () => {
+      const { renderer } = newRenderer();
+      family.upload(renderer, SEGMENTS);
+      const { pass, calls } = makePass();
+      family.draw(renderer, pass, new Float32Array(16));
+      assert.deepStrictEqual(calls, ['setPipeline', 'setBindGroup', 'setVertexBuffer', 'draw:4']);
+    });
+  }
+
+  it('families are independent: clearing one leaves the others uploaded', () => {
+    const { renderer } = newRenderer();
+    for (const f of FAMILIES) f.upload(renderer, SEGMENTS);
+    FAMILIES[2].clear(renderer);
+    for (const f of FAMILIES) {
+      assert.strictEqual(f.has(renderer), f !== FAMILIES[2], `${f.name} after clearing grid`);
+    }
+  });
+});
+
+describe('Section2DOverlayRenderer: dispose releases EVERY family (#1277 leak)', () => {
+  it('destroys every uploaded family buffer and the shared uniform buffer', () => {
+    const { renderer, buffers } = newRenderer();
+    for (const f of FAMILIES) f.upload(renderer, SEGMENTS);
+    renderer.uploadDrawing(
+      [{
+        polygon: { outer: [{ x: 0, y: 0 }, { x: 1, y: 0 }, { x: 1, y: 1 }], holes: [] },
+        ifcType: 'IfcWall',
+        expressId: 1,
+      }],
+      [],
+      'front',
+      0,
+    );
+
+    assert.ok(buffers.length >= FAMILIES.length + 3, `allocated ${buffers.length} buffers`);
+    renderer.dispose();
+
+    const leaked = buffers.filter((b) => b.__destroyed === 0);
+    assert.deepStrictEqual(
+      leaked.map((b) => b.__size),
+      [],
+      'every GPU buffer the renderer created must be destroyed by dispose()',
+    );
+  });
+
+  it('reports every family empty after dispose', () => {
+    const { renderer } = newRenderer();
+    for (const f of FAMILIES) f.upload(renderer, SEGMENTS);
+    renderer.dispose();
+    for (const f of FAMILIES) {
+      assert.strictEqual(f.has(renderer), false, `${f.name} still reports geometry after dispose`);
+    }
+    assert.strictEqual(renderer.hasGeometry(), false);
+  });
+
+  it('is idempotent — a second dispose does not double-destroy', () => {
+    const { renderer, buffers } = newRenderer();
+    for (const f of FAMILIES) f.upload(renderer, SEGMENTS);
+    renderer.dispose();
+    renderer.dispose();
+    for (const b of buffers) {
+      assert.strictEqual(b.__destroyed, 1, 'each buffer destroyed exactly once');
+    }
+  });
+});
+
+describe('Section2DOverlayRenderer: shared uniform buffer', () => {
+  function lastWrite(writes: Array<{ data: Float32Array }>): Float32Array {
+    assert.ok(writes.length > 0, 'expected a uniform write');
+    return writes[writes.length - 1].data;
+  }
+
+  it('writes the overlay line colour at the lineColor slot for a shared-colour family', () => {
+    const { renderer, writes } = newRenderer();
+    renderer.setOverlayLineColor([0.1, 0.2, 0.3, 0.4]);
+    renderer.uploadGridLines3D(SEGMENTS);
+    const { pass } = makePass();
+    renderer.drawGridLines3D(pass, new Float32Array(16).fill(0));
+    const u = lastWrite(writes);
+    assert.deepStrictEqual(
+      Array.from(u.slice(SECTION_2D_UNIFORM_SLOTS.lineColor, SECTION_2D_UNIFORM_SLOTS.lineColor + 4))
+        .map((v) => Math.round(v * 1000) / 1000),
+      [0.1, 0.2, 0.3, 0.4],
+    );
+  });
+
+  it('draws the clash box in its OWN colour, not the shared overlay colour', () => {
+    const { renderer, writes } = newRenderer();
+    renderer.setOverlayLineColor([0.1, 0.2, 0.3, 0.4]);
+    renderer.setClashBoxLineColor([1, 0, 0, 1]);
+    renderer.uploadClashBoxLines3D(SEGMENTS);
+    const { pass } = makePass();
+    renderer.drawClashBoxLines3D(pass, new Float32Array(16).fill(0));
+    const u = lastWrite(writes);
+    assert.deepStrictEqual(
+      Array.from(u.slice(SECTION_2D_UNIFORM_SLOTS.lineColor, SECTION_2D_UNIFORM_SLOTS.lineColor + 4)),
+      [1, 0, 0, 1],
+    );
+  });
+
+  it('zeroes planeOffset for world-space families', () => {
+    const { renderer, writes } = newRenderer();
+    renderer.uploadAnnotationLines3D(SEGMENTS);
+    const { pass } = makePass();
+    renderer.drawAnnotationLines3D(pass, new Float32Array(16).fill(7));
+    const u = lastWrite(writes);
+    assert.deepStrictEqual(
+      Array.from(u.slice(SECTION_2D_UNIFORM_SLOTS.planeOffset, SECTION_2D_UNIFORM_SLOTS.planeOffset + 4)),
+      [0, 0, 0, 0],
+    );
+    assert.deepStrictEqual(Array.from(u.slice(0, 16)), new Array(16).fill(7));
+  });
+
+  it('places the cap style at the capFill / capStroke / params slots', () => {
+    const { renderer, writes } = newRenderer();
+    renderer.uploadDrawing(
+      [{
+        polygon: { outer: [{ x: 0, y: 0 }, { x: 1, y: 0 }, { x: 1, y: 1 }], holes: [] },
+        ifcType: 'IfcWall',
+        expressId: 1,
+      }],
+      [],
+      'front',
+      0,
+    );
+    const { pass } = makePass();
+    renderer.draw(pass, {
+      axis: 'front',
+      position: 50,
+      bounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 1, y: 1, z: 1 } },
+      viewProj: new Float32Array(16),
+      showFills: true,
+      capStyle: {
+        fillColor: [0.5, 0.6, 0.7, 0.8],
+        strokeColor: [0.1, 0.2, 0.3, 0.9],
+        patternId: 5,
+        spacingPx: 11,
+        angleRad: 0.25,
+        widthPx: 3,
+        secondaryAngleRad: -0.25,
+      },
+    });
+    const u = lastWrite(writes);
+    const S = SECTION_2D_UNIFORM_SLOTS;
+    const round = (v: number) => Math.round(v * 1000) / 1000;
+    assert.deepStrictEqual(Array.from(u.slice(S.capFillColor, S.capFillColor + 4)).map(round), [0.5, 0.6, 0.7, 0.8]);
+    assert.deepStrictEqual(Array.from(u.slice(S.capStrokeColor, S.capStrokeColor + 4)).map(round), [0.1, 0.2, 0.3, 0.9]);
+    assert.deepStrictEqual(Array.from(u.slice(S.params, S.params + 4)).map(round), [5, 11, 0.25, 3]);
+    assert.strictEqual(round(u[S.params2]), -0.25);
+  });
+
+  it('falls back to the warm-paper defaults with no hatch when capStyle is omitted', () => {
+    const { renderer, writes } = newRenderer();
+    renderer.uploadDrawing([], [{ line: { start: { x: 0, y: 0 }, end: { x: 1, y: 1 } }, category: 'cut' }], 'front', 0);
+    const { pass } = makePass();
+    renderer.draw(pass, {
+      axis: 'front',
+      position: 50,
+      bounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 1, y: 1, z: 1 } },
+      viewProj: new Float32Array(16),
+    });
+    const u = lastWrite(writes);
+    const S = SECTION_2D_UNIFORM_SLOTS;
+    const round = (v: number) => Math.round(v * 100) / 100;
+    assert.deepStrictEqual(Array.from(u.slice(S.capFillColor, S.capFillColor + 4)).map(round), [0.92, 0.88, 0.78, 1]);
+    assert.strictEqual(u[S.params], 0, 'solid pattern');
+  });
+});
+
+describe('Section2DOverlayRenderer: section-cut draw gating', () => {
+  const OPTIONS = {
+    axis: 'front' as const,
+    position: 50,
+    bounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 1, y: 1, z: 1 } },
+    viewProj: new Float32Array(16),
+  };
+  const CAP_STYLE = {
+    fillColor: [1, 1, 1, 1] as [number, number, number, number],
+    strokeColor: [0, 0, 0, 1] as [number, number, number, number],
+    patternId: 0,
+    spacingPx: 8,
+    angleRad: 0,
+    widthPx: 1,
+    secondaryAngleRad: 0,
+  };
+  const TRIANGLE = [{
+    polygon: { outer: [{ x: 0, y: 0 }, { x: 1, y: 0 }, { x: 1, y: 1 }], holes: [] },
+    ifcType: 'IfcWall',
+    expressId: 1,
+  }];
+
+  it('draws nothing before any upload', () => {
+    const { renderer } = newRenderer();
+    const { pass, calls } = makePass();
+    renderer.draw(pass, OPTIONS);
+    assert.deepStrictEqual(calls, []);
+  });
+
+  it('draws outlines but NOT fills unless showFills and capStyle are both set', () => {
+    const { renderer } = newRenderer();
+    renderer.uploadDrawing(TRIANGLE, [], 'front', 0);
+    const { pass, calls } = makePass();
+    renderer.draw(pass, OPTIONS);
+    assert.ok(!calls.some((c) => c.startsWith('drawIndexed')), 'no fill without showFills');
+    assert.ok(calls.some((c) => c.startsWith('draw:')), 'outline still drawn');
+  });
+
+  it('draws the fill when showFills and capStyle are supplied', () => {
+    const { renderer } = newRenderer();
+    renderer.uploadDrawing(TRIANGLE, [], 'front', 0);
+    const { pass, calls } = makePass();
+    renderer.draw(pass, { ...OPTIONS, showFills: true, capStyle: CAP_STYLE });
+    assert.ok(calls.some((c) => c.startsWith('drawIndexed:')), 'fill drawn');
+  });
+
+  it('suppresses the outline when showOutlines is false', () => {
+    const { renderer } = newRenderer();
+    renderer.uploadDrawing(TRIANGLE, [], 'front', 0);
+    const { pass, calls } = makePass();
+    renderer.draw(pass, { ...OPTIONS, showOutlines: false, showFills: true, capStyle: CAP_STYLE });
+    assert.ok(!calls.some((c) => /^draw:/.test(c)), 'no outline draw');
+    assert.ok(calls.some((c) => c.startsWith('drawIndexed:')), 'fill still drawn');
+  });
+
+  it('clearGeometry drops the cut buffers without touching the line families', () => {
+    const { renderer } = newRenderer();
+    renderer.uploadDrawing(TRIANGLE, [], 'front', 0);
+    renderer.uploadGridLines3D(SEGMENTS);
+    assert.strictEqual(renderer.hasGeometry(), true);
+    renderer.clearGeometry();
+    assert.strictEqual(renderer.hasGeometry(), false);
+    assert.strictEqual(renderer.hasGridLines3D(), true);
+  });
+
+  it('re-uploading the drawing destroys the previous cut buffers', () => {
+    const { renderer, buffers } = newRenderer();
+    renderer.uploadDrawing(TRIANGLE, [], 'front', 0);
+    const cutBuffers = buffers.filter((b) => b.__size !== 160);
+    assert.ok(cutBuffers.length >= 2, 'fill vertex + index (+ outline) buffers');
+    renderer.uploadDrawing(TRIANGLE, [], 'front', 0);
+    for (const b of cutBuffers) {
+      assert.strictEqual(b.__destroyed, 1, 'previous cut buffer destroyed on re-upload');
+    }
+  });
+});

--- a/packages/renderer/src/section-2d-overlay.ts
+++ b/packages/renderer/src/section-2d-overlay.ts
@@ -8,10 +8,42 @@
  * Renders 2D section drawings (cut polygons, outlines, hatching) as a 3D overlay
  * on the section plane in the WebGPU viewport. This provides an integrated view
  * where the architectural drawing appears directly on the section cut surface.
+ *
+ * SIZE (issue #2456): this module is deliberately over the ~400-line house rule.
+ * Everything that could leave without dragging a GPU resource across a module
+ * boundary has left — the WGSL to `shaders/section-2d-overlay.wgsl.ts`, the
+ * 2D→3D lift and cap triangulation to `section-2d-lift.ts`, the per-family
+ * vertex buffer to `section-2d-line-buffer.ts`. What is left is one nullable,
+ * `init()`-created / `dispose()`-destroyed GPU object (two pipelines, one
+ * bind-group layout, one bind group, one shared 160-byte uniform buffer) plus
+ * the published `upload*`/`clear*`/`has*`/`draw*` API over it. Splitting that
+ * further means giving those shared resources a second owner, which is the cut
+ * #2456 explicitly refuses. Do not "fix" the line count by doing it.
  */
 
 import { PIPELINE_CONSTANTS } from './constants.js';
-import { earClip, joinHoles, type Pt } from './symbolic-overlay-pipelines.js';
+import {
+  SECTION_2D_CAP_FILL_WGSL,
+  SECTION_2D_OVERLAY_LINE_WGSL,
+  SECTION_2D_UNIFORM_BYTES,
+  SECTION_2D_UNIFORM_FLOATS,
+  SECTION_2D_UNIFORM_SLOTS,
+} from './shaders/section-2d-overlay.wgsl.js';
+import {
+  buildCapFillGeometry,
+  buildDrawingOutlineVertices,
+  createSectionLift,
+  type CutPolygon2D,
+  type DrawingLine2D,
+  type SectionAxis,
+  type SectionCustomPlane,
+} from './section-2d-lift.js';
+import {
+  WorldLineBuffer,
+  type SectionLinePipelineResources,
+} from './section-2d-line-buffer.js';
+
+export type { CutPolygon2D, DrawingLine2D, SectionCustomPlane } from './section-2d-lift.js';
 
 export interface Section2DOverlayCapStyle {
   fillColor:         [number, number, number, number];
@@ -49,69 +81,6 @@ export interface Section2DOverlayOptions {
   showOutlines?: boolean;
 }
 
-export interface CutPolygon2D {
-  polygon: {
-    outer: Array<{ x: number; y: number }>;
-    holes: Array<Array<{ x: number; y: number }>>;
-  };
-  ifcType: string;
-  expressId: number;
-  /** Optional per-polygon RGBA (0–1). When present, this cap polygon fills with
-   *  this colour (an `IfcMaterialLayerSet` wall/slab layer, or a frame+glass
-   *  window part) instead of the uniform cap fill. Absent ⇒ uniform cap style +
-   *  per-`ifcType` fallback, unchanged. */
-  color?: [number, number, number, number];
-}
-
-export interface DrawingLine2D {
-  line: {
-    start: { x: number; y: number };
-    end: { x: number; y: number };
-  };
-  category: string;
-  /**
-   * Express ID of the entity that authored this segment. Optional — only the
-   * IfcAnnotation / IfcGridAxis symbolic overlay sets it (so per-entity hide
-   * can drop an annotation's curves without a mesh). The section-cut and
-   * drawing-2d cutters leave it undefined.
-   */
-  ownerId?: number;
-}
-
-// Fill colors by IFC type (architectural convention).
-//
-// PARITY-ALLOW (#913): this is the **2D drafting** palette and is deliberately
-// independent of the canonical 3D styling table
-// (`ifc_lite_processing::style::default_color_for_type`). 2D plan/section fills
-// follow drawing conventions (heavier alpha, line-weight-driven greys), not the
-// 3D material appearance, so it is the one sanctioned second colour table. Do
-// not "sync" it to the 3D defaults; do not add a third table anywhere else.
-const IFC_TYPE_FILL_COLORS: Record<string, [number, number, number, number]> = {
-  IfcWall: [0.69, 0.69, 0.69, 0.95],
-  IfcWallStandardCase: [0.69, 0.69, 0.69, 0.95],
-  IfcColumn: [0.56, 0.56, 0.56, 0.95],
-  IfcBeam: [0.56, 0.56, 0.56, 0.95],
-  IfcSlab: [0.78, 0.78, 0.78, 0.95],
-  IfcRoof: [0.82, 0.82, 0.82, 0.95],
-  IfcFooting: [0.50, 0.50, 0.50, 0.95],
-  IfcPile: [0.44, 0.44, 0.44, 0.95],
-  IfcWindow: [0.91, 0.96, 0.99, 0.7],
-  IfcDoor: [0.96, 0.90, 0.83, 0.95],
-  IfcStair: [0.85, 0.85, 0.85, 0.95],
-  IfcStairFlight: [0.85, 0.85, 0.85, 0.95],
-  IfcRailing: [0.75, 0.75, 0.75, 0.95],
-  IfcPipeSegment: [0.63, 0.82, 1.0, 0.95],
-  IfcDuctSegment: [0.75, 1.0, 0.75, 0.95],
-  IfcFurnishingElement: [1.0, 0.88, 0.75, 0.95],
-  IfcSpace: [0.94, 0.94, 0.94, 0.5],
-  IfcSpatialZone: [0.88, 0.80, 0.96, 0.5],
-  default: [0.82, 0.82, 0.82, 0.95],
-};
-
-function getFillColor(ifcType: string): [number, number, number, number] {
-  return IFC_TYPE_FILL_COLORS[ifcType] || IFC_TYPE_FILL_COLORS.default;
-}
-
 export class Section2DOverlayRenderer {
   private device: GPUDevice;
   private fillPipeline: GPURenderPipeline | null = null;
@@ -129,7 +98,9 @@ export class Section2DOverlayRenderer {
   // lines on a dark canvas) via setOverlayLineColor().
   private overlayLineColor: readonly [number, number, number, number] = [0, 0, 0, 1];
 
-  // Cached geometry buffers
+  // Cached section-cut geometry buffers. Unlike the world-space overlays below
+  // these ride the section plane and the fill half is indexed, so they are not
+  // WorldLineBuffers.
   private fillVertexBuffer: GPUBuffer | null = null;
   private fillIndexBuffer: GPUBuffer | null = null;
   private fillIndexCount = 0;
@@ -141,21 +112,18 @@ export class Section2DOverlayRenderer {
   // does not depend on a section plane being active. Used by the
   // "Show IFC Annotations" toggle so that authored 2D drawing curves
   // (IfcAnnotation polylines/arcs) are visible in any view.
-  private annotationLineVertexBuffer: GPUBuffer | null = null;
-  private annotationLineVertexCount = 0;
+  private annotationLines = new WorldLineBuffer();
 
   // Standalone 3D alignment centerline overlay. Independent buffer from the
   // annotation lines (separate visibility toggle) but reuses the same line
   // pipeline. IfcAlignment renders as a thin line here — not a ribbon mesh —
   // to match IfcGrid axes / IfcAnnotation curves.
-  private alignmentLineVertexBuffer: GPUBuffer | null = null;
-  private alignmentLineVertexCount = 0;
+  private alignmentLines = new WorldLineBuffer();
 
   // Standalone 3D structural-grid (IfcGridAxis) overlay. Independent buffer so
   // grid visibility is independent of the annotation/alignment overlays, but
   // reuses the same line pipeline (issue #967).
-  private gridLineVertexBuffer: GPUBuffer | null = null;
-  private gridLineVertexCount = 0;
+  private gridLines = new WorldLineBuffer();
 
   // Standalone 3D DXF reference-layer overlay (issue #2043, follow-up to
   // #1782/#1929's 2D-only DXF underlay). Independent buffer so 3D DXF
@@ -163,15 +131,13 @@ export class Section2DOverlayRenderer {
   // above, but reuses the same line pipeline + shared overlay colour —
   // mirrors the grid overlay exactly. Line paths only (walls/boundaries);
   // DXF fills/text are not lifted to 3D in this iteration.
-  private dxfLineVertexBuffer: GPUBuffer | null = null;
-  private dxfLineVertexCount = 0;
+  private dxfLines = new WorldLineBuffer();
 
   // Standalone 3D clash-overlap-box overlay (#1277): the wireframe AABB of a
   // focused clash, drawn in its OWN distinct colour (not the shared overlay
   // line colour) so the overlap region reads as a third colour next to the two
   // glowing clash elements.
-  private clashBoxLineVertexBuffer: GPUBuffer | null = null;
-  private clashBoxLineVertexCount = 0;
+  private clashBoxLines = new WorldLineBuffer();
   private clashBoxLineColor: readonly [number, number, number, number] = [1, 0, 1, 1];
 
   constructor(device: GPUDevice, format: GPUTextureFormat, sampleCount: number = 4) {
@@ -198,187 +164,8 @@ export class Section2DOverlayRenderer {
       bindGroupLayouts: [this.bindGroupLayout],
     });
 
-    // Shader for filled polygons. Applies the user-defined cap style
-    // (fill colour + screen-space hatch) on top of the EXACT 2D section
-    // polygons produced by SectionCutter. Per-vertex colour now DRIVES the
-    // fill when a polygon opts in (alpha ≥ 0): a material-layer wall/slab
-    // fills each layer with its own IfcMaterial colour, matching the 3D
-    // build-up. Polygons that pass the sentinel alpha −1 fall back to the
-    // uniform cap style, so single-material cuts read as one architectural
-    // section exactly as before. Hatch + stroke apply over either base.
-    const fillShader = this.device.createShaderModule({
-      code: `
-        struct Uniforms {
-          viewProj:       mat4x4<f32>,
-          planeOffset:    vec4<f32>,    // Small offset to render slightly in front of section plane
-          capFillColor:   vec4<f32>,
-          capStrokeColor: vec4<f32>,
-          // x=patternId, y=spacingPx, z=angleRad, w=widthPx
-          params:         vec4<f32>,
-          // x=secondaryAngleRad, y,z,w reserved
-          params2:        vec4<f32>,
-        }
-        @binding(0) @group(0) var<uniform> uniforms: Uniforms;
-
-        struct VertexInput {
-          @location(0) position: vec3<f32>,
-          @location(1) color:    vec4<f32>,
-        }
-
-        struct VertexOutput {
-          @builtin(position) position: vec4<f32>,
-          @location(0)       color:    vec4<f32>,
-        }
-
-        @vertex
-        fn vs_main(input: VertexInput) -> VertexOutput {
-          var output: VertexOutput;
-          let offsetPos = input.position + uniforms.planeOffset.xyz;
-          output.position = uniforms.viewProj * vec4<f32>(offsetPos, 1.0);
-          output.color = input.color;
-          return output;
-        }
-
-        // Screen-space hatch pattern helpers (ported from section-cap.wgsl).
-        fn lineMask(u: f32, s: f32, w: f32) -> f32 {
-          let f = fract(u / s) * s;
-          let d = min(f, s - f);
-          return 1.0 - smoothstep(w * 0.5, w * 0.5 + 1.0, d);
-        }
-        fn rotate(p: vec2<f32>, a: f32) -> vec2<f32> {
-          let c = cos(a);
-          let s = sin(a);
-          return vec2<f32>(c * p.x - s * p.y, s * p.x + c * p.y);
-        }
-        fn hatchIntensity(fragCoord: vec2<f32>, patternId: u32, spacing: f32, angle: f32, width: f32, angle2: f32) -> f32 {
-          let p = fragCoord;
-          if (patternId == 0u) { return 0.0; }          // solid
-          if (patternId == 1u) {                         // diagonal
-            let r = rotate(p, angle);
-            return lineMask(r.x, spacing, width);
-          }
-          if (patternId == 2u) {                         // cross-hatch
-            let r  = rotate(p, angle);
-            let r2 = rotate(p, angle2);
-            return max(lineMask(r.x, spacing, width), lineMask(r2.x, spacing, width));
-          }
-          if (patternId == 3u) { return lineMask(p.y, spacing, width); }    // horizontal
-          if (patternId == 4u) { return lineMask(p.x, spacing, width); }    // vertical
-          if (patternId == 5u) {
-            // Concrete (ISO 128-50): clean regular dot grid. The previous
-            // version layered dashes on top which looked noisy and broken.
-            // Dots sit at every grid intersection; radius scales with
-            // stroke width so the user's width slider works consistently.
-            let gx = p.x - round(p.x / spacing) * spacing;
-            let gy = p.y - round(p.y / spacing) * spacing;
-            let d = sqrt(gx * gx + gy * gy);
-            let radius = max(1.0, width * 1.2);
-            return 1.0 - smoothstep(radius, radius + 1.0, d);
-          }
-          if (patternId == 6u) {                         // brick
-            let bandH = spacing;
-            let band = floor(p.y / bandH);
-            let offset = select(0.0, bandH, (u32(band) & 1u) == 1u);
-            let horiz = lineMask(p.y, bandH, width);
-            let vertPos = p.x + offset * 0.5;
-            let vert = step(fract(vertPos / (bandH * 2.0)), 0.02);
-            return max(horiz, vert);
-          }
-          if (patternId == 7u) {                         // insulation
-            let y = spacing * 0.5 * sin(p.x * 6.2831853 / spacing) + p.y;
-            return lineMask(y, spacing, width);
-          }
-          return 0.0;
-        }
-
-        struct FragOut {
-          @location(0) color:    vec4<f32>,
-          @location(1) objectId: vec4<f32>,
-        }
-
-        @fragment
-        fn fs_main(input: VertexOutput) -> FragOut {
-          let patternId = u32(uniforms.params.x + 0.5);
-          let spacing   = max(2.0, uniforms.params.y);
-          let angle     = uniforms.params.z;
-          let width     = max(1.0, uniforms.params.w);
-          let angle2    = uniforms.params2.x;
-
-          let h = hatchIntensity(input.position.xy, patternId, spacing, angle, width, angle2);
-          // Per-polygon colour (a material-layer slab fills with its own
-          // IfcMaterial RGBA) overrides the uniform cap fill when present.
-          // Polygons without a colour carry the sentinel alpha −1 and fall back
-          // to the user's cap style, byte-identically. Hatch + stroke apply over
-          // whichever base is chosen, so the architectural hatch still works.
-          let useVertex = input.color.a >= 0.0;
-          let baseFill = select(uniforms.capFillColor, input.color, useVertex);
-          let rgb = mix(baseFill.rgb, uniforms.capStrokeColor.rgb, h * uniforms.capStrokeColor.a);
-          let a   = max(baseFill.a, h * uniforms.capStrokeColor.a);
-
-          var out: FragOut;
-          out.color    = vec4<f32>(rgb, a);
-          out.objectId = vec4<f32>(0.0, 0.0, 0.0, 0.0);
-          return out;
-        }
-      `,
-    });
-
-    // Shader for lines (uniform color)
-    const lineShader = this.device.createShaderModule({
-      code: `
-        // Mirrors the fill shader's uniform layout so both pipelines can share
-        // one buffer; the line shader only reads viewProj, planeOffset and the
-        // appended lineColor (byte offset 144). capFillColor/… are unused here but
-        // declared for correct field offsets.
-        struct Uniforms {
-          viewProj: mat4x4<f32>,
-          planeOffset: vec4<f32>,
-          capFillColor: vec4<f32>,
-          capStrokeColor: vec4<f32>,
-          params: vec4<f32>,
-          params2: vec4<f32>,
-          lineColor: vec4<f32>,
-        }
-        @binding(0) @group(0) var<uniform> uniforms: Uniforms;
-
-        struct VertexInput {
-          @location(0) position: vec3<f32>,
-        }
-
-        struct VertexOutput {
-          @builtin(position) position: vec4<f32>,
-        }
-
-        @vertex
-        fn vs_main(input: VertexInput) -> VertexOutput {
-          var output: VertexOutput;
-          let offsetPos = input.position + uniforms.planeOffset.xyz;
-          let clip = uniforms.viewProj * vec4<f32>(offsetPos, 1.0);
-          // Reverse-Z decal nudge for lines coplanar with model faces
-          // (issue #812). WebGPU forbids depthStencil.depthBias on non-
-          // triangle topologies, so we do the equivalent in clip space:
-          // adding a small positive multiple of clip.w raises NDC z by a
-          // constant after the w-divide, which under reverse-Z means
-          // "slightly closer" — enough to beat MSAA jitter on annotation
-          // lines that ride exactly on a wall/floor.
-          output.position = vec4<f32>(clip.x, clip.y, clip.z + 5e-5 * clip.w, clip.w);
-          return output;
-        }
-
-        struct FragOutLine {
-          @location(0) color:    vec4<f32>,
-          @location(1) objectId: vec4<f32>,
-        }
-
-        @fragment
-        fn fs_main(input: VertexOutput) -> FragOutLine {
-          var out: FragOutLine;
-          out.color    = uniforms.lineColor;  // consumer-themeable (defaults black)
-          out.objectId = vec4<f32>(0.0, 0.0, 0.0, 0.0);
-          return out;
-        }
-      `,
-    });
+    const fillShader = this.device.createShaderModule({ code: SECTION_2D_CAP_FILL_WGSL });
+    const lineShader = this.device.createShaderModule({ code: SECTION_2D_OVERLAY_LINE_WGSL });
 
     // Pipeline for filled polygons
     this.fillPipeline = this.device.createRenderPipeline({
@@ -487,19 +274,13 @@ export class Section2DOverlayRenderer {
       },
     });
 
-    // Create uniform buffer.
-    //   viewProj       — mat4x4        64 B
-    //   planeOffset    — vec4          16 B
-    //   capFillColor   — vec4          16 B
-    //   capStrokeColor — vec4          16 B
-    //   params         — vec4          16 B   x=patternId, y=spacingPx, z=angleRad, w=widthPx
-    //   params2        — vec4          16 B   x=secondaryAngleRad
-    //   lineColor      — vec4          16 B   overlay/section-cut line colour
-    // Total: 160 B. The fill fragment shader reads up to params2 (144 B); the
-    // line shader reads viewProj/planeOffset + the appended lineColor (offset
-    // 144 B), so the two pipelines share this one buffer without aliasing.
+    // One 160-byte uniform buffer shared by BOTH pipelines: the fill fragment
+    // shader reads up to params2 (144 B), the line shader reads
+    // viewProj/planeOffset plus the appended lineColor at byte offset 144, so
+    // they do not alias. Field offsets live in SECTION_2D_UNIFORM_SLOTS next to
+    // the WGSL that defines them.
     this.uniformBuffer = this.device.createBuffer({
-      size: 160,
+      size: SECTION_2D_UNIFORM_BYTES,
       usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
     });
 
@@ -515,61 +296,18 @@ export class Section2DOverlayRenderer {
   }
 
   /**
-   * Transform 2D coordinates to 3D coordinates on the section plane.
-   *
-   * Cardinal axis path (legacy, unchanged):
-   * - Y axis (down): 2D (x, y) = 3D (x, z) - looking down at XZ plane
-   * - Z axis (front): 2D (x, y) = 3D (x, y) - looking along Z at XY plane
-   * - X axis (side): 2D (x, y) = 3D (z, y) - looking along X at ZY plane
-   * When flipped, the 2D x coordinate is negated.
-   *
-   * Custom-plane path (issue #243): when `customPlane` is supplied, the
-   * 3D point is `origin + tangent*x2d + bitangent*y2d`. The same basis
-   * is used by `SectionCutter` to project triangle-plane intersections
-   * to 2D, so the round-trip is exact and the cap polygons land
-   * precisely on the user's tilted plane.
+   * The shared line-pipeline resources a WorldLineBuffer borrows for a draw.
+   * Returns null before `init()` has produced them (or after `dispose()`), so
+   * every `draw*Lines3D` bails on the same condition it always did.
    */
-  private transform2Dto3D(
-    x2d: number,
-    y2d: number,
-    axis: 'down' | 'front' | 'side',
-    planePosition: number,
-    flipped: boolean = false,
-    customPlane?: {
-      origin: [number, number, number];
-      tangent: [number, number, number];
-      bitangent: [number, number, number];
-    },
-  ): [number, number, number] {
-    if (customPlane) {
-      // Custom plane: bypass the cardinal-axis swap. `flipped` is
-      // intentionally ignored because for arbitrary planes the cutter
-      // does not mirror its 2D output (mirroring only makes sense for
-      // cardinal projections that have a consistent "view direction").
-      const o = customPlane.origin;
-      const t = customPlane.tangent;
-      const b = customPlane.bitangent;
-      return [
-        o[0] + t[0] * x2d + b[0] * y2d,
-        o[1] + t[1] * x2d + b[1] * y2d,
-        o[2] + t[2] * x2d + b[2] * y2d,
-      ];
-    }
-
-    // Handle flipped - the 2D x coordinate was negated during projection
-    const x = flipped ? -x2d : x2d;
-
-    switch (axis) {
-      case 'down': // Y axis - horizontal cut (floor plan)
-        // 2D.x = 3D.x, 2D.y = 3D.z -> 3D (x, planeY, y)
-        return [x, planePosition, y2d];
-      case 'front': // Z axis - vertical cut (section view)
-        // 2D.x = 3D.x, 2D.y = 3D.y -> 3D (x, y, planeZ)
-        return [x, y2d, planePosition];
-      case 'side': // X axis - vertical cut (side elevation)
-        // 2D.x = 3D.z, 2D.y = 3D.y -> 3D (planeX, y, x)
-        return [planePosition, y2d, x];
-    }
+  private lineResources(): SectionLinePipelineResources | null {
+    if (!this.linePipeline || !this.uniformBuffer || !this.bindGroup) return null;
+    return {
+      device: this.device,
+      pipeline: this.linePipeline,
+      bindGroup: this.bindGroup,
+      uniformBuffer: this.uniformBuffer,
+    };
   }
 
   /**
@@ -588,134 +326,40 @@ export class Section2DOverlayRenderer {
   uploadDrawing(
     polygons: CutPolygon2D[],
     lines: DrawingLine2D[],
-    axis: 'down' | 'front' | 'side',
+    axis: SectionAxis,
     planePosition: number,
     flipped: boolean = false,
-    customPlane?: {
-      origin: [number, number, number];
-      tangent: [number, number, number];
-      bitangent: [number, number, number];
-    },
+    customPlane?: SectionCustomPlane,
   ): void {
     this.init();
+    this.clearGeometry();
 
-    // Clean up old buffers and reset counts
-    if (this.fillVertexBuffer) {
-      this.fillVertexBuffer.destroy();
-      this.fillVertexBuffer = null;
-    }
-    if (this.fillIndexBuffer) {
-      this.fillIndexBuffer.destroy();
-      this.fillIndexBuffer = null;
-    }
-    if (this.lineVertexBuffer) {
-      this.lineVertexBuffer.destroy();
-      this.lineVertexBuffer = null;
-    }
-    this.fillIndexCount = 0;
-    this.lineVertexCount = 0;
+    const lift = createSectionLift(axis, planePosition, flipped, customPlane);
 
-    // Build fill geometry (triangulated polygons)
-    const fillVertices: number[] = [];
-    const fillIndices: number[] = [];
-    let vertexOffset = 0;
-
-    for (const polygon of polygons) {
-      const outer = polygon.polygon.outer;
-      if (outer.length < 3) continue;
-
-      // Per-polygon fill colour. A material-layer wall/slab delivers one polygon
-      // per layer, each carrying its IfcMaterial RGBA (window frame/glass parts
-      // likewise). Polygons WITHOUT a colour use the sentinel alpha −1 so the
-      // fill shader falls back to the uniform cap style (architectural fill +
-      // hatch) byte-identically — see fs_main.
-      const color: [number, number, number, number] = polygon.color ?? [0, 0, 0, -1];
-
-      // Hole-aware ear-clipping (reused from the IfcAnnotationFillArea fill path)
-      // replaces the old convex fan. The fan ignored holes and inverted on the
-      // CONCAVE cross-sections that arbitrary IFC profiles (and material-layer
-      // slabs) cut into, leaving the cut face uncovered — it read as a hollow
-      // shell. Section 2D points are (x, y); the triangulator works in (x, z),
-      // so y maps to z.
-      const outerRing: Pt[] = outer.map((p) => ({ x: p.x, z: p.y }));
-      const holeRings: Pt[][] = polygon.polygon.holes
-        .filter((h) => h.length >= 3)
-        .map((h) => h.map((p) => ({ x: p.x, z: p.y })));
-      const stitched = holeRings.length > 0 ? joinHoles(outerRing, holeRings) : outerRing;
-      const tris = earClip(stitched);
-      if (tris.length === 0) continue;
-
-      const baseVertex = vertexOffset;
-      for (const pt of stitched) {
-        const [x3d, y3d, z3d] = this.transform2Dto3D(pt.x, pt.z, axis, planePosition, flipped, customPlane);
-        fillVertices.push(x3d, y3d, z3d, color[0], color[1], color[2], color[3]);
-        vertexOffset++;
-      }
-      for (const [a, b, c] of tris) {
-        fillIndices.push(baseVertex + a, baseVertex + b, baseVertex + c);
-      }
-    }
-
-    // Create fill buffers
-    if (fillVertices.length > 0) {
-      const fillVertexData = new Float32Array(fillVertices);
+    const fill = buildCapFillGeometry(polygons, lift);
+    if (fill) {
       this.fillVertexBuffer = this.device.createBuffer({
-        size: fillVertexData.byteLength,
+        size: fill.vertices.byteLength,
         usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
       });
-      this.device.queue.writeBuffer(this.fillVertexBuffer, 0, fillVertexData);
+      this.device.queue.writeBuffer(this.fillVertexBuffer, 0, fill.vertices);
 
-      const fillIndexData = new Uint32Array(fillIndices);
       this.fillIndexBuffer = this.device.createBuffer({
-        size: fillIndexData.byteLength,
+        size: fill.indices.byteLength,
         usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST,
       });
-      this.device.queue.writeBuffer(this.fillIndexBuffer, 0, fillIndexData);
-      this.fillIndexCount = fillIndices.length;
+      this.device.queue.writeBuffer(this.fillIndexBuffer, 0, fill.indices);
+      this.fillIndexCount = fill.indices.length;
     }
 
-    // Build line geometry
-    const lineVertices: number[] = [];
-
-    // Polygon outlines
-    for (const polygon of polygons) {
-      const outer = polygon.polygon.outer;
-      for (let i = 0; i < outer.length; i++) {
-        const p1 = outer[i];
-        const p2 = outer[(i + 1) % outer.length];
-        const [x1, y1, z1] = this.transform2Dto3D(p1.x, p1.y, axis, planePosition, flipped, customPlane);
-        const [x2, y2, z2] = this.transform2Dto3D(p2.x, p2.y, axis, planePosition, flipped, customPlane);
-        lineVertices.push(x1, y1, z1, x2, y2, z2);
-      }
-
-      // Hole outlines
-      for (const hole of polygon.polygon.holes) {
-        for (let i = 0; i < hole.length; i++) {
-          const p1 = hole[i];
-          const p2 = hole[(i + 1) % hole.length];
-          const [x1, y1, z1] = this.transform2Dto3D(p1.x, p1.y, axis, planePosition, flipped, customPlane);
-          const [x2, y2, z2] = this.transform2Dto3D(p2.x, p2.y, axis, planePosition, flipped, customPlane);
-          lineVertices.push(x1, y1, z1, x2, y2, z2);
-        }
-      }
-    }
-
-    // Additional drawing lines (hatching, etc.)
-    for (const line of lines) {
-      const [x1, y1, z1] = this.transform2Dto3D(line.line.start.x, line.line.start.y, axis, planePosition, flipped, customPlane);
-      const [x2, y2, z2] = this.transform2Dto3D(line.line.end.x, line.line.end.y, axis, planePosition, flipped, customPlane);
-      lineVertices.push(x1, y1, z1, x2, y2, z2);
-    }
-
-    // Create line buffer
-    if (lineVertices.length > 0) {
-      const lineVertexData = new Float32Array(lineVertices);
+    const outline = buildDrawingOutlineVertices(polygons, lines, lift);
+    if (outline) {
       this.lineVertexBuffer = this.device.createBuffer({
-        size: lineVertexData.byteLength,
+        size: outline.byteLength,
         usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
       });
-      this.device.queue.writeBuffer(this.lineVertexBuffer, 0, lineVertexData);
-      this.lineVertexCount = lineVertices.length / 3;  // Each vertex is 3 floats
+      this.device.queue.writeBuffer(this.lineVertexBuffer, 0, outline);
+      this.lineVertexCount = outline.length / 3;  // Each vertex is 3 floats
     }
   }
 
@@ -759,70 +403,15 @@ export class Section2DOverlayRenderer {
    */
   uploadAnnotationLines3D(vertices: Float32Array): void {
     this.init();
-
-    if (this.annotationLineVertexBuffer) {
-      this.annotationLineVertexBuffer.destroy();
-      this.annotationLineVertexBuffer = null;
-    }
-    this.annotationLineVertexCount = 0;
-
-    if (vertices.length < 6) return;
-
-    this.annotationLineVertexBuffer = this.device.createBuffer({
-      size: vertices.byteLength,
-      usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
-    });
-    this.device.queue.writeBuffer(this.annotationLineVertexBuffer, 0, vertices);
-    this.annotationLineVertexCount = vertices.length / 3;
+    this.annotationLines.upload(this.device, vertices);
   }
 
   clearAnnotationLines3D(): void {
-    if (this.annotationLineVertexBuffer) {
-      this.annotationLineVertexBuffer.destroy();
-      this.annotationLineVertexBuffer = null;
-    }
-    this.annotationLineVertexCount = 0;
+    this.annotationLines.clear();
   }
 
   hasAnnotationLines3D(): boolean {
-    return this.annotationLineVertexCount > 0;
-  }
-
-  /**
-   * Upload a flat Float32Array of 3D line-list vertices for the alignment
-   * centerline overlay. Same format/pipeline as the annotation lines, kept in
-   * a separate buffer so alignment visibility is independent.
-   * Pass an empty array (or omit) to clear.
-   */
-  uploadAlignmentLines3D(vertices: Float32Array): void {
-    this.init();
-
-    if (this.alignmentLineVertexBuffer) {
-      this.alignmentLineVertexBuffer.destroy();
-      this.alignmentLineVertexBuffer = null;
-    }
-    this.alignmentLineVertexCount = 0;
-
-    if (vertices.length < 6) return;
-
-    this.alignmentLineVertexBuffer = this.device.createBuffer({
-      size: vertices.byteLength,
-      usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
-    });
-    this.device.queue.writeBuffer(this.alignmentLineVertexBuffer, 0, vertices);
-    this.alignmentLineVertexCount = vertices.length / 3;
-  }
-
-  clearAlignmentLines3D(): void {
-    if (this.alignmentLineVertexBuffer) {
-      this.alignmentLineVertexBuffer.destroy();
-      this.alignmentLineVertexBuffer = null;
-    }
-    this.alignmentLineVertexCount = 0;
-  }
-
-  hasAlignmentLines3D(): boolean {
-    return this.alignmentLineVertexCount > 0;
+    return this.annotationLines.has();
   }
 
   /**
@@ -834,22 +423,28 @@ export class Section2DOverlayRenderer {
    */
   drawAnnotationLines3D(pass: GPURenderPassEncoder, viewProj: Float32Array): void {
     this.init();
-    if (!this.linePipeline || !this.uniformBuffer || !this.bindGroup) return;
-    if (!this.annotationLineVertexBuffer || this.annotationLineVertexCount === 0) return;
+    const resources = this.lineResources();
+    if (!resources) return;
+    this.annotationLines.draw(pass, resources, viewProj, this.overlayLineColor);
+  }
 
-    // Reuse the existing fill uniform buffer slot 0 (viewProj + planeOffset).
-    // The line shader only reads those two fields, so the fill/cap-style
-    // tail of the uniforms is harmless leftover data.
-    const uniforms = new Float32Array(40);
-    uniforms.set(viewProj, 0);
-    // planeOffset = 0 — vertices are already in world space.
-    uniforms.set(this.overlayLineColor, 36); // lineColor (byte offset 144)
-    this.device.queue.writeBuffer(this.uniformBuffer, 0, uniforms);
+  /**
+   * Upload a flat Float32Array of 3D line-list vertices for the alignment
+   * centerline overlay. Same format/pipeline as the annotation lines, kept in
+   * a separate buffer so alignment visibility is independent.
+   * Pass an empty array (or omit) to clear.
+   */
+  uploadAlignmentLines3D(vertices: Float32Array): void {
+    this.init();
+    this.alignmentLines.upload(this.device, vertices);
+  }
 
-    pass.setPipeline(this.linePipeline);
-    pass.setBindGroup(0, this.bindGroup);
-    pass.setVertexBuffer(0, this.annotationLineVertexBuffer);
-    pass.draw(this.annotationLineVertexCount);
+  clearAlignmentLines3D(): void {
+    this.alignmentLines.clear();
+  }
+
+  hasAlignmentLines3D(): boolean {
+    return this.alignmentLines.has();
   }
 
   /**
@@ -858,19 +453,9 @@ export class Section2DOverlayRenderer {
    */
   drawAlignmentLines3D(pass: GPURenderPassEncoder, viewProj: Float32Array): void {
     this.init();
-    if (!this.linePipeline || !this.uniformBuffer || !this.bindGroup) return;
-    if (!this.alignmentLineVertexBuffer || this.alignmentLineVertexCount === 0) return;
-
-    const uniforms = new Float32Array(40);
-    uniforms.set(viewProj, 0);
-    // planeOffset = 0 — vertices are already in world space.
-    uniforms.set(this.overlayLineColor, 36); // lineColor (byte offset 144)
-    this.device.queue.writeBuffer(this.uniformBuffer, 0, uniforms);
-
-    pass.setPipeline(this.linePipeline);
-    pass.setBindGroup(0, this.bindGroup);
-    pass.setVertexBuffer(0, this.alignmentLineVertexBuffer);
-    pass.draw(this.alignmentLineVertexCount);
+    const resources = this.lineResources();
+    if (!resources) return;
+    this.alignmentLines.draw(pass, resources, viewProj, this.overlayLineColor);
   }
 
   /**
@@ -881,33 +466,15 @@ export class Section2DOverlayRenderer {
    */
   uploadGridLines3D(vertices: Float32Array): void {
     this.init();
-
-    if (this.gridLineVertexBuffer) {
-      this.gridLineVertexBuffer.destroy();
-      this.gridLineVertexBuffer = null;
-    }
-    this.gridLineVertexCount = 0;
-
-    if (vertices.length < 6) return;
-
-    this.gridLineVertexBuffer = this.device.createBuffer({
-      size: vertices.byteLength,
-      usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
-    });
-    this.device.queue.writeBuffer(this.gridLineVertexBuffer, 0, vertices);
-    this.gridLineVertexCount = vertices.length / 3;
+    this.gridLines.upload(this.device, vertices);
   }
 
   clearGridLines3D(): void {
-    if (this.gridLineVertexBuffer) {
-      this.gridLineVertexBuffer.destroy();
-      this.gridLineVertexBuffer = null;
-    }
-    this.gridLineVertexCount = 0;
+    this.gridLines.clear();
   }
 
   hasGridLines3D(): boolean {
-    return this.gridLineVertexCount > 0;
+    return this.gridLines.has();
   }
 
   /**
@@ -916,19 +483,9 @@ export class Section2DOverlayRenderer {
    */
   drawGridLines3D(pass: GPURenderPassEncoder, viewProj: Float32Array): void {
     this.init();
-    if (!this.linePipeline || !this.uniformBuffer || !this.bindGroup) return;
-    if (!this.gridLineVertexBuffer || this.gridLineVertexCount === 0) return;
-
-    const uniforms = new Float32Array(40);
-    uniforms.set(viewProj, 0);
-    // planeOffset = 0 — vertices are already in world space.
-    uniforms.set(this.overlayLineColor, 36); // lineColor (byte offset 144)
-    this.device.queue.writeBuffer(this.uniformBuffer, 0, uniforms);
-
-    pass.setPipeline(this.linePipeline);
-    pass.setBindGroup(0, this.bindGroup);
-    pass.setVertexBuffer(0, this.gridLineVertexBuffer);
-    pass.draw(this.gridLineVertexCount);
+    const resources = this.lineResources();
+    if (!resources) return;
+    this.gridLines.draw(pass, resources, viewProj, this.overlayLineColor);
   }
 
   /**
@@ -940,33 +497,15 @@ export class Section2DOverlayRenderer {
    */
   uploadDxfLines3D(vertices: Float32Array): void {
     this.init();
-
-    if (this.dxfLineVertexBuffer) {
-      this.dxfLineVertexBuffer.destroy();
-      this.dxfLineVertexBuffer = null;
-    }
-    this.dxfLineVertexCount = 0;
-
-    if (vertices.length < 6) return;
-
-    this.dxfLineVertexBuffer = this.device.createBuffer({
-      size: vertices.byteLength,
-      usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
-    });
-    this.device.queue.writeBuffer(this.dxfLineVertexBuffer, 0, vertices);
-    this.dxfLineVertexCount = vertices.length / 3;
+    this.dxfLines.upload(this.device, vertices);
   }
 
   clearDxfLines3D(): void {
-    if (this.dxfLineVertexBuffer) {
-      this.dxfLineVertexBuffer.destroy();
-      this.dxfLineVertexBuffer = null;
-    }
-    this.dxfLineVertexCount = 0;
+    this.dxfLines.clear();
   }
 
   hasDxfLines3D(): boolean {
-    return this.dxfLineVertexCount > 0;
+    return this.dxfLines.has();
   }
 
   /**
@@ -975,19 +514,9 @@ export class Section2DOverlayRenderer {
    */
   drawDxfLines3D(pass: GPURenderPassEncoder, viewProj: Float32Array): void {
     this.init();
-    if (!this.linePipeline || !this.uniformBuffer || !this.bindGroup) return;
-    if (!this.dxfLineVertexBuffer || this.dxfLineVertexCount === 0) return;
-
-    const uniforms = new Float32Array(40);
-    uniforms.set(viewProj, 0);
-    // planeOffset = 0 — vertices are already in world space.
-    uniforms.set(this.overlayLineColor, 36); // lineColor (byte offset 144)
-    this.device.queue.writeBuffer(this.uniformBuffer, 0, uniforms);
-
-    pass.setPipeline(this.linePipeline);
-    pass.setBindGroup(0, this.bindGroup);
-    pass.setVertexBuffer(0, this.dxfLineVertexBuffer);
-    pass.draw(this.dxfLineVertexCount);
+    const resources = this.lineResources();
+    if (!resources) return;
+    this.dxfLines.draw(pass, resources, viewProj, this.overlayLineColor);
   }
 
   /** Colour for the clash-overlap box (its own, not the shared overlay colour). */
@@ -1002,48 +531,23 @@ export class Section2DOverlayRenderer {
    */
   uploadClashBoxLines3D(vertices: Float32Array): void {
     this.init();
-    if (this.clashBoxLineVertexBuffer) {
-      this.clashBoxLineVertexBuffer.destroy();
-      this.clashBoxLineVertexBuffer = null;
-    }
-    this.clashBoxLineVertexCount = 0;
-    if (vertices.length < 6) return;
-    this.clashBoxLineVertexBuffer = this.device.createBuffer({
-      size: vertices.byteLength,
-      usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
-    });
-    this.device.queue.writeBuffer(this.clashBoxLineVertexBuffer, 0, vertices);
-    this.clashBoxLineVertexCount = vertices.length / 3;
+    this.clashBoxLines.upload(this.device, vertices);
   }
 
   clearClashBoxLines3D(): void {
-    if (this.clashBoxLineVertexBuffer) {
-      this.clashBoxLineVertexBuffer.destroy();
-      this.clashBoxLineVertexBuffer = null;
-    }
-    this.clashBoxLineVertexCount = 0;
+    this.clashBoxLines.clear();
   }
 
   hasClashBoxLines3D(): boolean {
-    return this.clashBoxLineVertexCount > 0;
+    return this.clashBoxLines.has();
   }
 
   /** Draw the clash-overlap box in its own colour. Same line pipeline. (#1277) */
   drawClashBoxLines3D(pass: GPURenderPassEncoder, viewProj: Float32Array): void {
     this.init();
-    if (!this.linePipeline || !this.uniformBuffer || !this.bindGroup) return;
-    if (!this.clashBoxLineVertexBuffer || this.clashBoxLineVertexCount === 0) return;
-
-    const uniforms = new Float32Array(40);
-    uniforms.set(viewProj, 0);
-    // planeOffset = 0 — vertices are already in world space.
-    uniforms.set(this.clashBoxLineColor, 36); // lineColor (byte offset 144)
-    this.device.queue.writeBuffer(this.uniformBuffer, 0, uniforms);
-
-    pass.setPipeline(this.linePipeline);
-    pass.setBindGroup(0, this.bindGroup);
-    pass.setVertexBuffer(0, this.clashBoxLineVertexBuffer);
-    pass.draw(this.clashBoxLineVertexCount);
+    const resources = this.lineResources();
+    if (!resources) return;
+    this.clashBoxLines.draw(pass, resources, viewProj, this.clashBoxLineColor);
   }
 
   /**
@@ -1070,7 +574,7 @@ export class Section2DOverlayRenderer {
       return;
     }
 
-    const { axis, viewProj } = options;
+    const { viewProj } = options;
 
     // No offset — cap renders exactly on the section plane. The previous
     // 0.3m bias was there to keep the outline lines clear of below-plane
@@ -1081,46 +585,35 @@ export class Section2DOverlayRenderer {
     // keeps the fill restricted to the actual cap polygons.
     const offset: [number, number, number] = [0, 0, 0];
 
-    // Update uniforms. Layout mirrors the WGSL struct above:
-    //   0..15  viewProj
-    //   16..19 planeOffset
-    //   20..23 capFillColor
-    //   24..27 capStrokeColor
-    //   28..31 params  (patternId, spacingPx, angleRad, widthPx)
-    //   32..35 params2 (secondaryAngleRad, _, _, _)
-    //   36..39 lineColor (section-cut outline colour)
-    const uniforms = new Float32Array(40);
-    uniforms.set(viewProj, 0);
-    uniforms.set(this.overlayLineColor, 36); // section-cut outline colour
-    uniforms[16] = offset[0];
-    uniforms[17] = offset[1];
-    uniforms[18] = offset[2];
-    uniforms[19] = 0;
+    // Update uniforms. Field offsets come from SECTION_2D_UNIFORM_SLOTS, which
+    // sits next to the WGSL struct it describes.
+    const S = SECTION_2D_UNIFORM_SLOTS;
+    const uniforms = new Float32Array(SECTION_2D_UNIFORM_FLOATS);
+    uniforms.set(viewProj, S.viewProj);
+    uniforms.set(this.overlayLineColor, S.lineColor); // section-cut outline colour
+    uniforms[S.planeOffset + 0] = offset[0];
+    uniforms[S.planeOffset + 1] = offset[1];
+    uniforms[S.planeOffset + 2] = offset[2];
+    uniforms[S.planeOffset + 3] = 0;
     const cs = options.capStyle;
     if (cs) {
-      uniforms[20] = cs.fillColor[0];
-      uniforms[21] = cs.fillColor[1];
-      uniforms[22] = cs.fillColor[2];
-      uniforms[23] = cs.fillColor[3];
-      uniforms[24] = cs.strokeColor[0];
-      uniforms[25] = cs.strokeColor[1];
-      uniforms[26] = cs.strokeColor[2];
-      uniforms[27] = cs.strokeColor[3];
-      uniforms[28] = cs.patternId;
-      uniforms[29] = cs.spacingPx;
-      uniforms[30] = cs.angleRad;
-      uniforms[31] = cs.widthPx;
-      uniforms[32] = cs.secondaryAngleRad;
+      uniforms.set(cs.fillColor, S.capFillColor);
+      uniforms.set(cs.strokeColor, S.capStrokeColor);
+      uniforms[S.params + 0] = cs.patternId;
+      uniforms[S.params + 1] = cs.spacingPx;
+      uniforms[S.params + 2] = cs.angleRad;
+      uniforms[S.params + 3] = cs.widthPx;
+      uniforms[S.params2 + 0] = cs.secondaryAngleRad;
     } else {
       // Sensible defaults when caller omits style (e.g. legacy lines-only
       // use): solid fill using a warm-paper colour, no hatch.
-      uniforms[20] = 0.92; uniforms[21] = 0.88; uniforms[22] = 0.78; uniforms[23] = 1;
-      uniforms[24] = 0.10; uniforms[25] = 0.10; uniforms[26] = 0.10; uniforms[27] = 1;
-      uniforms[28] = 0; // solid pattern
-      uniforms[29] = 8;
-      uniforms[30] = Math.PI / 4;
-      uniforms[31] = 1;
-      uniforms[32] = -Math.PI / 4;
+      uniforms.set([0.92, 0.88, 0.78, 1], S.capFillColor);
+      uniforms.set([0.10, 0.10, 0.10, 1], S.capStrokeColor);
+      uniforms[S.params + 0] = 0; // solid pattern
+      uniforms[S.params + 1] = 8;
+      uniforms[S.params + 2] = Math.PI / 4;
+      uniforms[S.params + 3] = 1;
+      uniforms[S.params2 + 0] = -Math.PI / 4;
     }
     this.device.queue.writeBuffer(this.uniformBuffer, 0, uniforms);
 

--- a/packages/renderer/src/section-2d-overlay.ts
+++ b/packages/renderer/src/section-2d-overlay.ts
@@ -653,7 +653,12 @@ export class Section2DOverlayRenderer {
   }
 
   /**
-   * Dispose of GPU resources
+   * Dispose of GPU resources.
+   *
+   * Every family's buffer must be released here. The clash box (#1277) was the
+   * sixth family added and was missing from this list, leaking its vertex
+   * buffer on every teardown — `section-2d-overlay-lifecycle.test.ts` now counts
+   * destroys against uploads so a seventh family cannot repeat it.
    */
   dispose(): void {
     this.clearGeometry();
@@ -661,6 +666,7 @@ export class Section2DOverlayRenderer {
     this.clearAlignmentLines3D();
     this.clearGridLines3D();
     this.clearDxfLines3D();
+    this.clearClashBoxLines3D();
     if (this.uniformBuffer) {
       this.uniformBuffer.destroy();
       this.uniformBuffer = null;

--- a/packages/renderer/src/section-2d-overlay.ts
+++ b/packages/renderer/src/section-2d-overlay.ts
@@ -15,7 +15,8 @@
  * 2D→3D lift and cap triangulation to `section-2d-lift.ts`, the per-family
  * vertex buffer to `section-2d-line-buffer.ts`. What is left is one nullable,
  * `init()`-created / `dispose()`-destroyed GPU object (two pipelines, one
- * bind-group layout, one bind group, one shared 160-byte uniform buffer) plus
+ * bind-group layout, one bind group, one uniform buffer holding a 160-byte
+ * record per draw site) plus
  * the published `upload*`/`clear*`/`has*`/`draw*` API over it. Splitting that
  * further means giving those shared resources a second owner, which is the cut
  * #2456 explicitly refuses. Do not "fix" the line count by doing it.
@@ -28,6 +29,9 @@ import {
   SECTION_2D_UNIFORM_BYTES,
   SECTION_2D_UNIFORM_FLOATS,
   SECTION_2D_UNIFORM_SLOTS,
+  SECTION_2D_UNIFORM_SLOT_COUNT,
+  SECTION_2D_UNIFORM_SLOT_INDEX,
+  sectionUniformSlotStride,
 } from './shaders/section-2d-overlay.wgsl.js';
 import {
   buildCapFillGeometry,
@@ -88,6 +92,8 @@ export class Section2DOverlayRenderer {
   private bindGroupLayout: GPUBindGroupLayout | null = null;
   private uniformBuffer: GPUBuffer | null = null;
   private bindGroup: GPUBindGroup | null = null;
+  /** Byte stride between the uniform slots in {@link uniformBuffer}. Set by `init()`. */
+  private uniformStride = 0;
   private format: GPUTextureFormat;
   private sampleCount: number;
   private initialized = false;
@@ -112,18 +118,18 @@ export class Section2DOverlayRenderer {
   // does not depend on a section plane being active. Used by the
   // "Show IFC Annotations" toggle so that authored 2D drawing curves
   // (IfcAnnotation polylines/arcs) are visible in any view.
-  private annotationLines = new WorldLineBuffer();
+  private annotationLines = new WorldLineBuffer(SECTION_2D_UNIFORM_SLOT_INDEX.annotation);
 
   // Standalone 3D alignment centerline overlay. Independent buffer from the
   // annotation lines (separate visibility toggle) but reuses the same line
   // pipeline. IfcAlignment renders as a thin line here — not a ribbon mesh —
   // to match IfcGrid axes / IfcAnnotation curves.
-  private alignmentLines = new WorldLineBuffer();
+  private alignmentLines = new WorldLineBuffer(SECTION_2D_UNIFORM_SLOT_INDEX.alignment);
 
   // Standalone 3D structural-grid (IfcGridAxis) overlay. Independent buffer so
   // grid visibility is independent of the annotation/alignment overlays, but
   // reuses the same line pipeline (issue #967).
-  private gridLines = new WorldLineBuffer();
+  private gridLines = new WorldLineBuffer(SECTION_2D_UNIFORM_SLOT_INDEX.grid);
 
   // Standalone 3D DXF reference-layer overlay (issue #2043, follow-up to
   // #1782/#1929's 2D-only DXF underlay). Independent buffer so 3D DXF
@@ -131,13 +137,13 @@ export class Section2DOverlayRenderer {
   // above, but reuses the same line pipeline + shared overlay colour —
   // mirrors the grid overlay exactly. Line paths only (walls/boundaries);
   // DXF fills/text are not lifted to 3D in this iteration.
-  private dxfLines = new WorldLineBuffer();
+  private dxfLines = new WorldLineBuffer(SECTION_2D_UNIFORM_SLOT_INDEX.dxf);
 
   // Standalone 3D clash-overlap-box overlay (#1277): the wireframe AABB of a
   // focused clash, drawn in its OWN distinct colour (not the shared overlay
   // line colour) so the overlap region reads as a third colour next to the two
   // glowing clash elements.
-  private clashBoxLines = new WorldLineBuffer();
+  private clashBoxLines = new WorldLineBuffer(SECTION_2D_UNIFORM_SLOT_INDEX.clashBox);
   private clashBoxLineColor: readonly [number, number, number, number] = [1, 0, 1, 1];
 
   constructor(device: GPUDevice, format: GPUTextureFormat, sampleCount: number = 4) {
@@ -150,12 +156,19 @@ export class Section2DOverlayRenderer {
     if (this.initialized) return;
 
     // Create bind group layout
+    // `hasDynamicOffset`: one bind group serves every draw site, each reading
+    // its own 160-byte slot at a per-draw offset. See
+    // SECTION_2D_UNIFORM_SLOT_INDEX for why the slots exist at all.
     this.bindGroupLayout = this.device.createBindGroupLayout({
       entries: [
         {
           binding: 0,
           visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT,
-          buffer: { type: 'uniform' },
+          buffer: {
+            type: 'uniform',
+            hasDynamicOffset: true,
+            minBindingSize: SECTION_2D_UNIFORM_BYTES,
+          },
         },
       ],
     });
@@ -279,16 +292,25 @@ export class Section2DOverlayRenderer {
     // viewProj/planeOffset plus the appended lineColor at byte offset 144, so
     // they do not alias. Field offsets live in SECTION_2D_UNIFORM_SLOTS next to
     // the WGSL that defines them.
+    // …once per draw site (SECTION_2D_UNIFORM_SLOT_COUNT of them), spaced by
+    // the device's dynamic-offset alignment. Still one buffer under one owner;
+    // what changed is that the six draws no longer overwrite each other.
+    this.uniformStride = sectionUniformSlotStride(this.device);
     this.uniformBuffer = this.device.createBuffer({
-      size: SECTION_2D_UNIFORM_BYTES,
+      size: this.uniformStride * SECTION_2D_UNIFORM_SLOT_COUNT,
       usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
     });
 
-    // Create bind group
+    // Create bind group. `size` pins the binding to ONE record — without it
+    // the binding would span the whole buffer and the dynamic offset would be
+    // rejected for every slot but the first.
     this.bindGroup = this.device.createBindGroup({
       layout: this.bindGroupLayout,
       entries: [
-        { binding: 0, resource: { buffer: this.uniformBuffer } },
+        {
+          binding: 0,
+          resource: { buffer: this.uniformBuffer, offset: 0, size: SECTION_2D_UNIFORM_BYTES },
+        },
       ],
     });
 
@@ -307,6 +329,7 @@ export class Section2DOverlayRenderer {
       pipeline: this.linePipeline,
       bindGroup: this.bindGroup,
       uniformBuffer: this.uniformBuffer,
+      uniformStride: this.uniformStride,
     };
   }
 
@@ -615,7 +638,12 @@ export class Section2DOverlayRenderer {
       uniforms[S.params + 3] = 1;
       uniforms[S.params2 + 0] = -Math.PI / 4;
     }
-    this.device.queue.writeBuffer(this.uniformBuffer, 0, uniforms);
+    // The section cut owns slot 0. Both draws below read it, which is correct:
+    // the fill and the outline are one drawing with one plane offset and one
+    // style. What they must NOT share is the record the world-space line
+    // families write, whose zeroed cap-style tail would otherwise arrive here.
+    const capOffset = SECTION_2D_UNIFORM_SLOT_INDEX.sectionCut * this.uniformStride;
+    this.device.queue.writeBuffer(this.uniformBuffer, capOffset, uniforms);
 
     // Filled polygons = the 3D section cap. Render them ONLY when the
     // caller opts in (`showFills: true` + a capStyle). This replaces the
@@ -631,7 +659,7 @@ export class Section2DOverlayRenderer {
       this.fillIndexCount > 0
     ) {
       pass.setPipeline(this.fillPipeline);
-      pass.setBindGroup(0, this.bindGroup);
+      pass.setBindGroup(0, this.bindGroup, [capOffset]);
       pass.setVertexBuffer(0, this.fillVertexBuffer);
       pass.setIndexBuffer(this.fillIndexBuffer, 'uint32');
       pass.drawIndexed(this.fillIndexCount);
@@ -646,7 +674,7 @@ export class Section2DOverlayRenderer {
       this.lineVertexCount > 0
     ) {
       pass.setPipeline(this.linePipeline);
-      pass.setBindGroup(0, this.bindGroup);
+      pass.setBindGroup(0, this.bindGroup, [capOffset]);
       pass.setVertexBuffer(0, this.lineVertexBuffer);
       pass.draw(this.lineVertexCount);
     }

--- a/packages/renderer/src/section-2d-uniform-layout.test.ts
+++ b/packages/renderer/src/section-2d-uniform-layout.test.ts
@@ -1,0 +1,139 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import {
+  SECTION_2D_CAP_FILL_WGSL,
+  SECTION_2D_OVERLAY_LINE_WGSL,
+  SECTION_2D_UNIFORM_BYTES,
+  SECTION_2D_UNIFORM_FLOATS,
+  SECTION_2D_UNIFORM_SLOTS,
+} from './shaders/section-2d-overlay.wgsl.js';
+
+/**
+ * The fill and line pipelines deliberately alias ONE 160-byte uniform buffer,
+ * and the TypeScript writers address it by float index. Nothing in the compiler
+ * connects the WGSL struct to those indices — moving a `vec4` in the shader
+ * would silently repaint the cap in the line colour. These tests derive the
+ * offsets from the shader text itself and compare them to the slot table both
+ * sides import.
+ */
+
+/** WGSL scalar/vector/matrix sizes we use, in floats. */
+const FLOAT_SIZE: Record<string, number> = {
+  'mat4x4<f32>': 16,
+  'vec4<f32>': 4,
+};
+
+/**
+ * Extract `struct Uniforms { … }` from a shader source and compute each field's
+ * float offset. Every type in use is 16-byte aligned, so the offsets are a
+ * running sum with no padding.
+ */
+function uniformFieldOffsets(source: string): Record<string, number> {
+  const match = source.match(/struct\s+Uniforms\s*\{([\s\S]*?)\}/);
+  assert.ok(match, 'shader must declare a struct named Uniforms');
+  const body = match[1]
+    .split('\n')
+    .map((l) => l.replace(/\/\/.*$/, '').trim())
+    .filter((l) => l.length > 0)
+    .join(' ');
+
+  const offsets: Record<string, number> = {};
+  let cursor = 0;
+  for (const field of body.split(',')) {
+    const decl = field.trim();
+    if (decl.length === 0) continue;
+    const parts = decl.split(':').map((s) => s.trim());
+    assert.strictEqual(parts.length, 2, `unparsable uniform field: "${decl}"`);
+    const [name, type] = parts;
+    const size = FLOAT_SIZE[type];
+    assert.ok(size, `unknown WGSL type "${type}" in struct Uniforms — extend FLOAT_SIZE`);
+    offsets[name] = cursor;
+    cursor += size;
+  }
+  return offsets;
+}
+
+describe('section 2D uniform layout: WGSL vs SECTION_2D_UNIFORM_SLOTS', () => {
+  it('the line shader struct matches the slot table field for field', () => {
+    assert.deepStrictEqual(
+      uniformFieldOffsets(SECTION_2D_OVERLAY_LINE_WGSL),
+      { ...SECTION_2D_UNIFORM_SLOTS },
+    );
+  });
+
+  it('the fill shader struct is a prefix of the same layout', () => {
+    const fill = uniformFieldOffsets(SECTION_2D_CAP_FILL_WGSL);
+    // The fill shader stops at params2 — it never reads lineColor.
+    assert.ok(!('lineColor' in fill), 'fill shader must not declare lineColor');
+    for (const [name, offset] of Object.entries(fill)) {
+      assert.strictEqual(
+        offset,
+        (SECTION_2D_UNIFORM_SLOTS as Record<string, number>)[name],
+        `fill shader field "${name}" is at float ${offset}, slot table says ` +
+          `${(SECTION_2D_UNIFORM_SLOTS as Record<string, number>)[name]}`,
+      );
+    }
+  });
+
+  it('the two shaders agree on every field they share (they alias one buffer)', () => {
+    const fill = uniformFieldOffsets(SECTION_2D_CAP_FILL_WGSL);
+    const line = uniformFieldOffsets(SECTION_2D_OVERLAY_LINE_WGSL);
+    for (const name of Object.keys(fill)) {
+      assert.strictEqual(line[name], fill[name], `field "${name}" is at a different offset`);
+    }
+  });
+
+  it('the buffer is exactly big enough for the last field', () => {
+    const line = uniformFieldOffsets(SECTION_2D_OVERLAY_LINE_WGSL);
+    const end = Math.max(...Object.values(line)) + FLOAT_SIZE['vec4<f32>'];
+    assert.strictEqual(end, SECTION_2D_UNIFORM_FLOATS);
+    assert.strictEqual(SECTION_2D_UNIFORM_BYTES, SECTION_2D_UNIFORM_FLOATS * 4);
+  });
+
+  it('lineColor sits at byte offset 144, as both shader comments claim', () => {
+    assert.strictEqual(SECTION_2D_UNIFORM_SLOTS.lineColor * 4, 144);
+  });
+
+  it('the parser itself catches a moved field (control for this file)', () => {
+    const shuffled = SECTION_2D_OVERLAY_LINE_WGSL.replace(
+      'planeOffset: vec4<f32>,\n          capFillColor: vec4<f32>,',
+      'capFillColor: vec4<f32>,\n          planeOffset: vec4<f32>,',
+    );
+    assert.notStrictEqual(shuffled, SECTION_2D_OVERLAY_LINE_WGSL, 'the swap must actually apply');
+    assert.notDeepStrictEqual(
+      uniformFieldOffsets(shuffled),
+      { ...SECTION_2D_UNIFORM_SLOTS },
+      'swapping two fields must change the derived offsets',
+    );
+  });
+});
+
+describe('section 2D shader sources', () => {
+  it('both shaders declare the entry points the pipelines ask for', () => {
+    for (const src of [SECTION_2D_CAP_FILL_WGSL, SECTION_2D_OVERLAY_LINE_WGSL]) {
+      assert.ok(/@vertex\s+fn vs_main/.test(src), 'vs_main');
+      assert.ok(/@fragment\s+fn fs_main/.test(src), 'fs_main');
+    }
+  });
+
+  it('both shaders write the objectId attachment the two-target pass requires', () => {
+    for (const src of [SECTION_2D_CAP_FILL_WGSL, SECTION_2D_OVERLAY_LINE_WGSL]) {
+      assert.ok(/@location\(1\) objectId/.test(src), 'objectId output declared');
+    }
+  });
+
+  it('the fill shader keeps the sentinel-alpha fallback to the uniform cap colour', () => {
+    // A polygon with no material colour carries alpha −1; dropping this branch
+    // would paint every uniform-styled cap black.
+    assert.ok(/input\.color\.a >= 0\.0/.test(SECTION_2D_CAP_FILL_WGSL));
+    assert.ok(/select\(uniforms\.capFillColor, input\.color, useVertex\)/.test(SECTION_2D_CAP_FILL_WGSL));
+  });
+
+  it('the line shader keeps the #812 reverse-Z decal nudge', () => {
+    assert.ok(/clip\.z \+ 5e-5 \* clip\.w/.test(SECTION_2D_OVERLAY_LINE_WGSL));
+  });
+});

--- a/packages/renderer/src/shaders/section-2d-overlay.wgsl.ts
+++ b/packages/renderer/src/shaders/section-2d-overlay.wgsl.ts
@@ -1,0 +1,231 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * WGSL shaders for the section 2D overlay (cut-cap fills + overlay lines).
+ *
+ * Two pipelines share this file because they deliberately share ONE 160-byte
+ * uniform buffer: the fill shader reads `viewProj … params2` (the first 144 B)
+ * and the line shader reads `viewProj`, `planeOffset` and the appended
+ * `lineColor` at byte offset 144. The two `struct Uniforms` declarations below
+ * must therefore stay field-for-field compatible, and every TypeScript writer
+ * must address the buffer through `SECTION_2D_UNIFORM_SLOTS` rather than a
+ * hand-written index. `section-2d-uniform-layout.test.ts` parses both structs
+ * out of these sources and fails if either drifts from the slot table.
+ */
+
+/**
+ * Float32 indices of each field in the shared uniform buffer.
+ *
+ * WGSL std140-style layout: `mat4x4<f32>` is 64 B (16 floats) and each
+ * `vec4<f32>` is 16 B (4 floats), all naturally aligned, so the offsets are a
+ * simple running sum. These are FLOAT offsets — multiply by 4 for the byte
+ * offsets quoted in the shader comments.
+ */
+export const SECTION_2D_UNIFORM_SLOTS = {
+  /** mat4x4<f32> — floats 0..15 (bytes 0..63) */
+  viewProj: 0,
+  /** vec4<f32> — floats 16..19 (bytes 64..79) */
+  planeOffset: 16,
+  /** vec4<f32> — floats 20..23 (bytes 80..95) */
+  capFillColor: 20,
+  /** vec4<f32> — floats 24..27 (bytes 96..111) */
+  capStrokeColor: 24,
+  /** vec4<f32> x=patternId, y=spacingPx, z=angleRad, w=widthPx — floats 28..31 */
+  params: 28,
+  /** vec4<f32> x=secondaryAngleRad, y,z,w reserved — floats 32..35 */
+  params2: 32,
+  /** vec4<f32> overlay / section-cut line colour — floats 36..39 (bytes 144..159) */
+  lineColor: 36,
+} as const;
+
+/** Total float count of the shared uniform buffer (40 floats = 160 bytes). */
+export const SECTION_2D_UNIFORM_FLOATS = 40;
+
+/** Total byte size of the shared uniform buffer. */
+export const SECTION_2D_UNIFORM_BYTES = SECTION_2D_UNIFORM_FLOATS * 4;
+
+/**
+ * Fill shader for the cut cap.
+ *
+ * Applies the user-defined cap style (fill colour + screen-space hatch) on top
+ * of the EXACT 2D section polygons produced by SectionCutter. Per-vertex colour
+ * DRIVES the fill when a polygon opts in (alpha >= 0): a material-layer
+ * wall/slab fills each layer with its own IfcMaterial colour, matching the 3D
+ * build-up. Polygons that pass the sentinel alpha -1 fall back to the uniform
+ * cap style, so single-material cuts read as one architectural section exactly
+ * as before. Hatch + stroke apply over either base.
+ */
+export const SECTION_2D_CAP_FILL_WGSL = /* wgsl */ `
+        struct Uniforms {
+          viewProj:       mat4x4<f32>,
+          planeOffset:    vec4<f32>,    // Small offset to render slightly in front of section plane
+          capFillColor:   vec4<f32>,
+          capStrokeColor: vec4<f32>,
+          // x=patternId, y=spacingPx, z=angleRad, w=widthPx
+          params:         vec4<f32>,
+          // x=secondaryAngleRad, y,z,w reserved
+          params2:        vec4<f32>,
+        }
+        @binding(0) @group(0) var<uniform> uniforms: Uniforms;
+
+        struct VertexInput {
+          @location(0) position: vec3<f32>,
+          @location(1) color:    vec4<f32>,
+        }
+
+        struct VertexOutput {
+          @builtin(position) position: vec4<f32>,
+          @location(0)       color:    vec4<f32>,
+        }
+
+        @vertex
+        fn vs_main(input: VertexInput) -> VertexOutput {
+          var output: VertexOutput;
+          let offsetPos = input.position + uniforms.planeOffset.xyz;
+          output.position = uniforms.viewProj * vec4<f32>(offsetPos, 1.0);
+          output.color = input.color;
+          return output;
+        }
+
+        // Screen-space hatch pattern helpers (ported from section-cap.wgsl).
+        fn lineMask(u: f32, s: f32, w: f32) -> f32 {
+          let f = fract(u / s) * s;
+          let d = min(f, s - f);
+          return 1.0 - smoothstep(w * 0.5, w * 0.5 + 1.0, d);
+        }
+        fn rotate(p: vec2<f32>, a: f32) -> vec2<f32> {
+          let c = cos(a);
+          let s = sin(a);
+          return vec2<f32>(c * p.x - s * p.y, s * p.x + c * p.y);
+        }
+        fn hatchIntensity(fragCoord: vec2<f32>, patternId: u32, spacing: f32, angle: f32, width: f32, angle2: f32) -> f32 {
+          let p = fragCoord;
+          if (patternId == 0u) { return 0.0; }          // solid
+          if (patternId == 1u) {                         // diagonal
+            let r = rotate(p, angle);
+            return lineMask(r.x, spacing, width);
+          }
+          if (patternId == 2u) {                         // cross-hatch
+            let r  = rotate(p, angle);
+            let r2 = rotate(p, angle2);
+            return max(lineMask(r.x, spacing, width), lineMask(r2.x, spacing, width));
+          }
+          if (patternId == 3u) { return lineMask(p.y, spacing, width); }    // horizontal
+          if (patternId == 4u) { return lineMask(p.x, spacing, width); }    // vertical
+          if (patternId == 5u) {
+            // Concrete (ISO 128-50): clean regular dot grid. The previous
+            // version layered dashes on top which looked noisy and broken.
+            // Dots sit at every grid intersection; radius scales with
+            // stroke width so the user's width slider works consistently.
+            let gx = p.x - round(p.x / spacing) * spacing;
+            let gy = p.y - round(p.y / spacing) * spacing;
+            let d = sqrt(gx * gx + gy * gy);
+            let radius = max(1.0, width * 1.2);
+            return 1.0 - smoothstep(radius, radius + 1.0, d);
+          }
+          if (patternId == 6u) {                         // brick
+            let bandH = spacing;
+            let band = floor(p.y / bandH);
+            let offset = select(0.0, bandH, (u32(band) & 1u) == 1u);
+            let horiz = lineMask(p.y, bandH, width);
+            let vertPos = p.x + offset * 0.5;
+            let vert = step(fract(vertPos / (bandH * 2.0)), 0.02);
+            return max(horiz, vert);
+          }
+          if (patternId == 7u) {                         // insulation
+            let y = spacing * 0.5 * sin(p.x * 6.2831853 / spacing) + p.y;
+            return lineMask(y, spacing, width);
+          }
+          return 0.0;
+        }
+
+        struct FragOut {
+          @location(0) color:    vec4<f32>,
+          @location(1) objectId: vec4<f32>,
+        }
+
+        @fragment
+        fn fs_main(input: VertexOutput) -> FragOut {
+          let patternId = u32(uniforms.params.x + 0.5);
+          let spacing   = max(2.0, uniforms.params.y);
+          let angle     = uniforms.params.z;
+          let width     = max(1.0, uniforms.params.w);
+          let angle2    = uniforms.params2.x;
+
+          let h = hatchIntensity(input.position.xy, patternId, spacing, angle, width, angle2);
+          // Per-polygon colour (a material-layer slab fills with its own
+          // IfcMaterial RGBA) overrides the uniform cap fill when present.
+          // Polygons without a colour carry the sentinel alpha -1 and fall back
+          // to the user's cap style, byte-identically. Hatch + stroke apply over
+          // whichever base is chosen, so the architectural hatch still works.
+          let useVertex = input.color.a >= 0.0;
+          let baseFill = select(uniforms.capFillColor, input.color, useVertex);
+          let rgb = mix(baseFill.rgb, uniforms.capStrokeColor.rgb, h * uniforms.capStrokeColor.a);
+          let a   = max(baseFill.a, h * uniforms.capStrokeColor.a);
+
+          var out: FragOut;
+          out.color    = vec4<f32>(rgb, a);
+          out.objectId = vec4<f32>(0.0, 0.0, 0.0, 0.0);
+          return out;
+        }
+      `;
+
+/**
+ * Line shader for the section-cut outline and the standalone world-space line
+ * overlays (annotation / alignment / grid / DXF / clash box).
+ */
+export const SECTION_2D_OVERLAY_LINE_WGSL = /* wgsl */ `
+        // Mirrors the fill shader's uniform layout so both pipelines can share
+        // one buffer; the line shader only reads viewProj, planeOffset and the
+        // appended lineColor (byte offset 144). capFillColor/… are unused here but
+        // declared for correct field offsets.
+        struct Uniforms {
+          viewProj: mat4x4<f32>,
+          planeOffset: vec4<f32>,
+          capFillColor: vec4<f32>,
+          capStrokeColor: vec4<f32>,
+          params: vec4<f32>,
+          params2: vec4<f32>,
+          lineColor: vec4<f32>,
+        }
+        @binding(0) @group(0) var<uniform> uniforms: Uniforms;
+
+        struct VertexInput {
+          @location(0) position: vec3<f32>,
+        }
+
+        struct VertexOutput {
+          @builtin(position) position: vec4<f32>,
+        }
+
+        @vertex
+        fn vs_main(input: VertexInput) -> VertexOutput {
+          var output: VertexOutput;
+          let offsetPos = input.position + uniforms.planeOffset.xyz;
+          let clip = uniforms.viewProj * vec4<f32>(offsetPos, 1.0);
+          // Reverse-Z decal nudge for lines coplanar with model faces
+          // (issue #812). WebGPU forbids depthStencil.depthBias on non-
+          // triangle topologies, so we do the equivalent in clip space:
+          // adding a small positive multiple of clip.w raises NDC z by a
+          // constant after the w-divide, which under reverse-Z means
+          // "slightly closer" — enough to beat MSAA jitter on annotation
+          // lines that ride exactly on a wall/floor.
+          output.position = vec4<f32>(clip.x, clip.y, clip.z + 5e-5 * clip.w, clip.w);
+          return output;
+        }
+
+        struct FragOutLine {
+          @location(0) color:    vec4<f32>,
+          @location(1) objectId: vec4<f32>,
+        }
+
+        @fragment
+        fn fs_main(input: VertexOutput) -> FragOutLine {
+          var out: FragOutLine;
+          out.color    = uniforms.lineColor;  // consumer-themeable (defaults black)
+          out.objectId = vec4<f32>(0.0, 0.0, 0.0, 0.0);
+          return out;
+        }
+      `;

--- a/packages/renderer/src/shaders/section-2d-overlay.wgsl.ts
+++ b/packages/renderer/src/shaders/section-2d-overlay.wgsl.ts
@@ -6,9 +6,12 @@
  * WGSL shaders for the section 2D overlay (cut-cap fills + overlay lines).
  *
  * Two pipelines share this file because they deliberately share ONE 160-byte
- * uniform buffer: the fill shader reads `viewProj … params2` (the first 144 B)
+ * uniform LAYOUT: the fill shader reads `viewProj … params2` (the first 144 B)
  * and the line shader reads `viewProj`, `planeOffset` and the appended
- * `lineColor` at byte offset 144. The two `struct Uniforms` declarations below
+ * `lineColor` at byte offset 144. They share the layout, not the storage — each
+ * draw site gets its own record in one buffer, addressed by a dynamic
+ * bind-group offset; see {@link SECTION_2D_UNIFORM_SLOT_INDEX}.
+ * The two `struct Uniforms` declarations below
  * must therefore stay field-for-field compatible, and every TypeScript writer
  * must address the buffer through `SECTION_2D_UNIFORM_SLOTS` rather than a
  * hand-written index. `section-2d-uniform-layout.test.ts` parses both structs
@@ -40,11 +43,59 @@ export const SECTION_2D_UNIFORM_SLOTS = {
   lineColor: 36,
 } as const;
 
-/** Total float count of the shared uniform buffer (40 floats = 160 bytes). */
+/** Total float count of one uniform record (40 floats = 160 bytes). */
 export const SECTION_2D_UNIFORM_FLOATS = 40;
 
-/** Total byte size of the shared uniform buffer. */
+/** Total byte size of one uniform record. */
 export const SECTION_2D_UNIFORM_BYTES = SECTION_2D_UNIFORM_FLOATS * 4;
+
+/**
+ * One uniform slot per draw site.
+ *
+ * The overlay renderer issues up to six draws into a **single** render pass —
+ * the section cut cap plus five world-space line families — and every one of
+ * them needs a different `lineColor` (and, for the cap, a different
+ * `planeOffset` and the whole cap-style tail). With one record shared between
+ * them the last `queue.writeBuffer` before submit is what the GPU sees for all
+ * six: `writeBuffer` is a *queue* operation, so it is applied before the
+ * command buffer that references it executes, no matter where in the encoding
+ * it was issued. Every earlier draw therefore rendered with the last draw's
+ * uniforms — most visibly, the clash box's colour bleeding onto the annotation,
+ * alignment, grid and DXF overlays, and the cap losing its fill colour and
+ * hatch to the zeroed tail the line draws write.
+ *
+ * Each site owning a fixed slot, addressed with a dynamic bind-group offset,
+ * is what makes the six draws independent while keeping the buffer, the layout
+ * and the bind group under the single owner issue #2456 insisted on. A slot per
+ * site (rather than a bump allocator) needs no per-frame reset hook: each site
+ * draws at most once per pass.
+ */
+export const SECTION_2D_UNIFORM_SLOT_INDEX = {
+  /** The section cut cap: fill + outline, which share one record by design. */
+  sectionCut: 0,
+  annotation: 1,
+  alignment: 2,
+  grid: 3,
+  dxf: 4,
+  clashBox: 5,
+} as const;
+
+/** How many uniform records the shared buffer holds. */
+export const SECTION_2D_UNIFORM_SLOT_COUNT = 6;
+
+/**
+ * Byte stride between uniform slots for `device`.
+ *
+ * A dynamic offset must be a multiple of `minUniformBufferOffsetAlignment`,
+ * which a device reports for itself (256 is the guaranteed-supported default,
+ * but a device may allow less). Round the 160-byte record up to that alignment
+ * rather than assuming either number.
+ */
+export function sectionUniformSlotStride(device: GPUDevice): number {
+  const alignment = device.limits?.minUniformBufferOffsetAlignment ?? 256;
+  const safe = Number.isFinite(alignment) && alignment > 0 ? alignment : 256;
+  return Math.ceil(SECTION_2D_UNIFORM_BYTES / safe) * safe;
+}
 
 /**
  * Fill shader for the cut cap.
@@ -128,7 +179,14 @@ export const SECTION_2D_CAP_FILL_WGSL = /* wgsl */ `
           if (patternId == 6u) {                         // brick
             let bandH = spacing;
             let band = floor(p.y / bandH);
-            let offset = select(0.0, bandH, (u32(band) & 1u) == 1u);
+            // Signed parity. p is @builtin(position) today, so it is a
+            // framebuffer coordinate and never negative — but u32() of a
+            // negative float is an out-of-range conversion in WGSL, and the
+            // moment this hatch is fed anything but fragCoord (a world- or
+            // drawing-space variant) the running bond would break across
+            // y = 0 in a backend-dependent way. i32(-1) & 1 is 1, so the
+            // parity alternates correctly in both directions.
+            let offset = select(0.0, bandH, (i32(band) & 1) == 1);
             let horiz = lineMask(p.y, bandH, width);
             let vertPos = p.x + offset * 0.5;
             let vert = step(fract(vertPos / (bandH * 2.0)), 0.02);


### PR DESCRIPTION
Fixes #2456.

## What the issue got right, and the one thing it looked past

#2456 is correct that the six buffer families cannot each own a slice of the single `init()`-created / `dispose()`-destroyed GPU object, and its option 1 (a class per family, each with its own pipeline handle) is **not** done here — that is the cut that gives shared resources a second owner.

But the issue frames the choice as *one owner vs six owners*. The axis that actually cuts is *resource vs description of resource*: 173 lines of WGSL and ~200 lines of array arithmetic are not GPU state, they are inputs. They leave without a single resource crossing a module boundary.

| region | before | after |
|---|---|---|
| `section-2d-overlay.ts` | **1176** | **675** |
| `shaders/section-2d-overlay.wgsl.ts` | — | 231 |
| `section-2d-lift.ts` | — | 245 |
| `section-2d-line-buffer.ts` | — | 104 |

`WorldLineBuffer` owns **only** a `GPUBuffer | null` and a vertex count — the one thing the families genuinely own alone. The line pipeline, bind-group layout, bind group and the shared 160-byte uniform buffer stay owned by `Section2DOverlayRenderer` and are handed in per draw as `SectionLinePipelineResources`.

675 is still over the ~400 rule. Getting under it requires splitting the pipeline/uniform ownership, so the rule is **waived in a comment at the top of the file** (as the issue's option 3 asks) rather than silently, and the comment says why.

## The uniform-offset contract is now checkable

Six call sites hand-wrote `uniforms.set(color, 36)` against the WGSL struct's byte offsets, and the fill and line shaders deliberately alias one 160-byte buffer. Moving the WGSL out would have made that contract cross a module boundary with nothing checking it — strictly worse.

So both sides now import `SECTION_2D_UNIFORM_SLOTS`, and `section-2d-uniform-layout.test.ts` parses `struct Uniforms` out of **both shader sources** and derives the offsets, failing if either drifts. It carries its own control test proving the parser detects a moved field.

## A real leak, found while reading

`dispose()` cleared five of its six families. The clash-overlap-box buffer (#1277, the sixth added) was never wired in and leaked on every renderer teardown. Fixed in its own commit, with the fake-device test that kills it.

## Tests: the file had none

`section-2d-overlay.ts` had **zero** direct coverage — the three test files that name it stub it out or reference it only in prose. After any split of it, all 682 renderer tests would have stayed green because none executed a line of it. That made "verify by re-running mutations" impossible on the old code, so the split ships the tests that were missing.

- `section-2d-lift.test.ts` — cardinal lift per axis, `flipped` negation, the #243/#581 custom-plane basis round-trip (previously unguarded), concave triangulation area, hole stitching, per-polygon index offsets.
- `section-2d-overlay-lifecycle.test.ts` — fake `GPUDevice`, counts `createBuffer` against `destroy()` across all six families.
- `section-2d-uniform-layout.test.ts` — the WGSL/TS offset contract above.

All three are top-level `src/*.test.ts`, matching the package's `tsx --test src/*.test.ts` glob.

### Counts

| | before | after |
|---|---|---|
| `packages/renderer` suite | 682 tests / 147 suites / 0 fail | **758 / 158 / 0 fail** |
| pre-existing tests | 682 | 682, all still passing |
| new | — | +76 tests / +11 suites |

`check-test-wiring.mjs` exit 0 · `check:test-typecheck` 976/976 · `turbo typecheck` for renderer + viewer + viewer-embed: 36/36.

### Mutation results

Two **existing** mutations in the affected area, run against the pre-split file and again after — identical kills:

| mutation | before split | after split |
|---|---|---|
| `render-section-draw.ts`: `showCap !== false` → `=== false` | 16 pass / **2 fail** | 16 pass / **2 fail** (same two tests) |
| `renderer-overlays.ts`: drop the custom-plane bypass | 17 pass / **1 fail** | 17 pass / **1 fail** (same test) |

Four mutations proving the **new** tests are reachable, not decorative:

| mutation | result |
|---|---|
| lift drops the `flipped` negation | 1 kill |
| `WorldLineBuffer.clear()` stops calling `destroy()` | **12 kills** |
| WGSL line-shader struct fields swapped | 3 kills (incl. the parser control) |
| colour written to `capFillColor` instead of `lineColor` | 2 kills |
| lift stops stitching holes | 1 kill |
| `dispose()` forgets the clash box again | 3 kills |

## Also removed

`IFC_TYPE_FILL_COLORS` / `getFillColor` (33 lines), dead since the fill colour started coming from `polygon.color ?? [0,0,0,-1]`. Its `PARITY-ALLOW (#913)` comment was guarding a table nobody read; the live 2D palette is the separate CSS-string copy in the viewer's `Drawing2DCanvas.tsx`, which is untouched.

## Deliberately NOT done

- **Option 1 (per-family classes).** As above.
- **Trimming `Section2DOverlayOptions`.** `draw()` never reads `axis`, `bounds`, `position`, `flipped`, `min` or `max`, and `render-section-draw.ts` dutifully computes five of them. That is the clearest clarity win left, but it edits a file #2460's camera work may also touch, so it is left for a follow-up rather than taken unilaterally.
- **The `earClip` bridge defect.** Writing the hole test surfaced that `earClip` in `symbolic-overlay-pipelines.ts` under-triangulates any ring `joinHoles` bridged: `pointInTriangle` treats on-edge points as contained, and the bridge duplicates two vertices, so nearly every candidate ear looks occupied. A 4x4 square with a 2x2 hole triangulates to area 2 instead of 12. That is a defect in the shared triangulator, outside this file, and the hole test deliberately asserts a bound rather than a number so fixing it will not turn the test red.

No public API change (`index.ts` untouched; the API-surface baseline for `@ifc-lite/renderer` is unaffected). Changeset included — `@ifc-lite/renderer` is published, `apps/viewer` is `"private": true`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added 2D section geometry lifting to 3D, including cardinal and custom section planes.
  * Added filled section caps with support for concave polygons, holes, per-polygon colors, outlines, and hatch patterns.
  * Added independent rendering for annotation, alignment, grid, DXF, and clash-box overlays.

* **Bug Fixes**
  * Prevented overlay colors and styles from leaking between draws.
  * Improved handling of incomplete line segments and resource cleanup when clash-box overlays are cleared or disposed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->