### PR TITLE
test(viewer): assert IFCX byte acquisition by driving the hook, not by reading its source

### DIFF
--- a/apps/viewer/src/hooks/useIfcFederation.ifcxBuffers.test.tsx
+++ b/apps/viewer/src/hooks/useIfcFederation.ifcxBuffers.test.tsx
@@ -1,0 +1,262 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * How `useIfcFederation` acquires bytes — asserted by driving the hook, not by
+ * reading its source (#2434).
+ *
+ * Two contracts live here:
+ *
+ * 1. **IFCX never SAB-streams** (memory guard for #647). IFCX is JSON, so the
+ *    bytes are handed to `safeUtf8Decode` → `JSON.parse`. Cross-thread string
+ *    decoding cannot read a `SharedArrayBuffer` directly, so a SAB-backed read
+ *    forces a full-file scratch copy on top of the JSON string: peak becomes
+ *    SAB + scratch + string, strictly worse than the plain `ArrayBuffer` path.
+ *    Both IFCX entry points must therefore stay on `file.arrayBuffer()`.
+ *
+ * 2. **`addModel` delegates the read to the canonical `loadFile`** rather than
+ *    acquiring bytes itself, so IFC/STEP keeps exactly one load pipeline (and
+ *    with it the SAB streaming that `acquireFileBuffer` provides above
+ *    `STREAM_SAB_THRESHOLD`).
+ *
+ * These were previously pinned by scanning `useIfcFederation.ts` for the
+ * strings `file.arrayBuffer()` / `acquireFileBuffer` / `loadFile(` inside the
+ * relevant function bodies. That scan could not fail for the regression it
+ * named: a read routed through a module-scope SAB helper, or a `loadFile`
+ * mentioned only in a comment, both leave the searched text intact. The
+ * instrumentation below observes what the hook actually *does* with the File.
+ */
+
+import '@/test/setup-dom.js';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { resolve, dirname } from 'node:path';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { useViewerStore } from '@/store';
+import { useIfcFederation } from './useIfcFederation.js';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../../..');
+const BASE_PATH = resolve(REPO_ROOT, 'tests/models/ifc5/Hello_Wall_hello-wall.ifcx');
+const OVERLAY_PATH = resolve(REPO_ROOT, 'tests/models/ifc5/Hello_Wall_hello-wall-add-fire-rating-60.ifcx');
+// Per AGENTS.md fixtures are fetched on demand; skip cleanly on a fresh
+// checkout rather than crashing the suite.
+const FIXTURES_AVAILABLE = existsSync(BASE_PATH) && existsSync(OVERLAY_PATH);
+
+/**
+ * `STREAM_SAB_THRESHOLD` (apps/viewer/src/utils/ifcConfig.ts) is 256 MiB, and
+ * `acquireFileBuffer` only SAB-streams at or above it. Reporting a size past
+ * that threshold is what makes a regression *observable*: a real 256 MiB
+ * fixture is not affordable in a unit test, but `size` is the only thing the
+ * SAB branch consults before it calls `file.stream()`. The bytes stay small.
+ */
+const ABOVE_SAB_THRESHOLD = 256 * 1024 * 1024 + 1;
+
+interface FileProbe {
+  /** Reads that went through `file.arrayBuffer()` — the required IFCX path. */
+  arrayBuffer: number;
+  /** Reads that went through `file.stream()` — how SAB streaming acquires bytes. */
+  stream: number;
+}
+
+/**
+ * A real `File` whose two read entry points are counted and whose reported
+ * size sits above the SAB streaming threshold.
+ */
+function probedFile(path: string, name: string, probe: FileProbe): File {
+  const file = new File([readFileSync(path)], name, { type: 'application/json' });
+  Object.defineProperty(file, 'size', { value: ABOVE_SAB_THRESHOLD });
+
+  const realArrayBuffer = file.arrayBuffer.bind(file);
+  Object.defineProperty(file, 'arrayBuffer', {
+    configurable: true,
+    value: (): Promise<ArrayBuffer> => {
+      probe.arrayBuffer++;
+      return realArrayBuffer();
+    },
+  });
+
+  const realStream = file.stream.bind(file);
+  Object.defineProperty(file, 'stream', {
+    configurable: true,
+    value: (): ReadableStream<Uint8Array> => {
+      probe.stream++;
+      return realStream() as ReadableStream<Uint8Array>;
+    },
+  });
+
+  return file;
+}
+
+/**
+ * Counts `new SharedArrayBuffer(n)` without allocating: a caller that reaches
+ * this stub has already lost the contract, and a truthful 256 MiB allocation
+ * would just make the failing run expensive. The stub hands back a real
+ * zero-length SAB so the caller's `new Uint8Array(sab)` still works and the
+ * failure surfaces as this counter rather than a TypeError from the harness.
+ */
+function withCountedSharedArrayBuffer<T>(sizes: number[], body: () => Promise<T>): Promise<T> {
+  // Only FILE-SIZED allocations are the defect. The IFCX pipeline legitimately
+  // takes an 8-byte SAB for an Atomics handshake on its first run; asserting
+  // "zero SABs" would fail on that and tempt the next maintainer to loosen the
+  // assertion rather than read it.
+  const holder = globalThis as { SharedArrayBuffer?: unknown };
+  const real = holder.SharedArrayBuffer as SharedArrayBufferConstructor;
+  holder.SharedArrayBuffer = function CountingSharedArrayBuffer(byteLength: number): SharedArrayBuffer {
+    sizes.push(byteLength);
+    return new real(0);
+  } as unknown as SharedArrayBufferConstructor;
+  return body().finally(() => {
+    holder.SharedArrayBuffer = real;
+  });
+}
+
+/**
+ * The SAB-streaming regression allocates `new SharedArrayBuffer(file.size)`.
+ * Anything at or beyond a mebibyte is that allocation and nothing else; the
+ * pipeline's own bookkeeping SABs are a handful of bytes.
+ */
+function fileSized(sizes: number[]): number[] {
+  return sizes.filter((n) => n >= 1024 * 1024);
+}
+
+let hookApi: ReturnType<typeof useIfcFederation> | null = null;
+let loadFileCalls: Array<{ file: File; target: unknown }> = [];
+const loadFile = async (file: File, target?: unknown): Promise<void> => {
+  loadFileCalls.push({ file, target });
+};
+
+function Probe(): null {
+  hookApi = useIfcFederation(loadFile);
+  return null;
+}
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+beforeEach(async () => {
+  hookApi = null;
+  loadFileCalls = [];
+  useViewerStore.getState().resetViewerState();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root!.render(<Probe />);
+  });
+});
+
+afterEach(async () => {
+  const current = root;
+  root = null;
+  if (current) await act(async () => current.unmount());
+  if (container) container.remove();
+  container = null;
+});
+
+describe(
+  'useIfcFederation - IFCX byte acquisition never uses SAB streaming (#647)',
+  { skip: !FIXTURES_AVAILABLE && 'tests/models/ifc5 fixtures missing - run `pnpm fixtures`' },
+  () => {
+    it('loadFederatedIfcx reads each file via arrayBuffer(), never via a SAB stream', async () => {
+      const probe: FileProbe = { arrayBuffer: 0, stream: 0 };
+      const sabSizes: number[] = [];
+
+      await withCountedSharedArrayBuffer(sabSizes, async () => {
+        await act(async () => {
+          await hookApi!.loadFederatedIfcx([probedFile(BASE_PATH, 'base.ifcx', probe)]);
+        });
+      });
+
+      // Reachability first: an assertion about how a load read its bytes is
+      // worthless if the load never happened.
+      assert.equal(useViewerStore.getState().error, null, 'federated load must succeed');
+      assert.ok(useViewerStore.getState().models.size > 0, 'federated load must register a model');
+
+      assert.equal(probe.arrayBuffer, 1, 'the IFCX file must be read via file.arrayBuffer()');
+      assert.equal(
+        probe.stream,
+        0,
+        'file.stream() is how bytes are pulled into a SharedArrayBuffer; the IFCX path must never do that',
+      );
+      assert.deepEqual(
+        fileSized(sabSizes),
+        [],
+        'no file-sized SharedArrayBuffer may be allocated for an IFCX load - SAB forces a full-file scratch copy in safeUtf8Decode on top of the JSON string (#647)',
+      );
+    });
+
+    it('addIfcxOverlays reads the overlay via arrayBuffer(), never via a SAB stream', async () => {
+      const baseProbe: FileProbe = { arrayBuffer: 0, stream: 0 };
+      await act(async () => {
+        await hookApi!.loadFederatedIfcx([probedFile(BASE_PATH, 'base.ifcx', baseProbe)]);
+      });
+      assert.equal(useViewerStore.getState().error, null, 'base load must succeed');
+
+      const overlayProbe: FileProbe = { arrayBuffer: 0, stream: 0 };
+      const sabSizes: number[] = [];
+      await withCountedSharedArrayBuffer(sabSizes, async () => {
+        await act(async () => {
+          await hookApi!.addIfcxOverlays([probedFile(OVERLAY_PATH, 'fire-rating.ifcx', overlayProbe)]);
+        });
+      });
+
+      assert.equal(useViewerStore.getState().error, null, 'overlay add must succeed');
+
+      assert.equal(overlayProbe.arrayBuffer, 1, 'the overlay must be read via file.arrayBuffer()');
+      assert.equal(overlayProbe.stream, 0, 'the overlay must not be pulled through a SAB stream');
+      assert.deepEqual(
+        fileSized(sabSizes),
+        [],
+        'no file-sized SharedArrayBuffer may be allocated when adding an IFCX overlay',
+      );
+    });
+  },
+);
+
+describe('useIfcFederation - addModel delegates byte acquisition to the canonical loadFile', () => {
+  it('hands the File to loadFile with a federated target and reads no bytes itself', async () => {
+    const probe: FileProbe = { arrayBuffer: 0, stream: 0 };
+    // Not an IFCX fixture: addModel is format-agnostic because it never looks
+    // at the bytes. A one-byte blob is enough, and keeps this case runnable
+    // without the downloaded fixtures.
+    const file = new File([new Uint8Array([0x49])], 'model.ifc');
+    Object.defineProperty(file, 'size', { value: ABOVE_SAB_THRESHOLD });
+    const realArrayBuffer = file.arrayBuffer.bind(file);
+    Object.defineProperty(file, 'arrayBuffer', {
+      configurable: true,
+      value: (): Promise<ArrayBuffer> => {
+        probe.arrayBuffer++;
+        return realArrayBuffer();
+      },
+    });
+    const realStream = file.stream.bind(file);
+    Object.defineProperty(file, 'stream', {
+      configurable: true,
+      value: (): ReadableStream<Uint8Array> => {
+        probe.stream++;
+        return realStream() as ReadableStream<Uint8Array>;
+      },
+    });
+
+    await act(async () => {
+      await hookApi!.addModel(file);
+    });
+
+    assert.equal(loadFileCalls.length, 1, 'addModel must route through the injected loadFile');
+    assert.equal(loadFileCalls[0]!.file, file, 'loadFile must receive the File itself, not bytes');
+    assert.equal(
+      (loadFileCalls[0]!.target as { kind?: string } | undefined)?.kind,
+      'federated',
+      'the canonical loader must be told this is a federated add',
+    );
+    assert.equal(
+      probe.arrayBuffer + probe.stream,
+      0,
+      'addModel must not acquire bytes itself - a second read path is exactly the duplication the single-loadFile rule exists to prevent',
+    );
+  });
+});

--- a/apps/viewer/src/hooks/useIfcFederation.resetState.test.tsx
+++ b/apps/viewer/src/hooks/useIfcFederation.resetState.test.tsx
@@ -38,13 +38,20 @@
  * as intentionally destructive to viewer state at the call site.
  *
  * These tests pin:
- *  1. `resetState` is no longer part of the public signature (grep-level,
- *     so a returning offer to "just wire it up" fails loudly).
- *  2. BOUNDING CONTROL - a first federated load resets state (unchanged
+ *  1. BOUNDING CONTROL - a first federated load resets state (unchanged
  *     behaviour, must never regress).
- *  3. The behaviour this fix is choosing: adding an overlay to an already-
+ *  2. The behaviour this fix is choosing: adding an overlay to an already-
  *     loaded federation ALSO resets state (selection/hidden/isolated all
  *     clear), because ids are not stable across recomposition.
+ *
+ * A third test used to grep `useIfcFederation.ts` for the identifier
+ * `resetState` and assert zero hits. It is gone (#2434): deleting the reset
+ * outright — the whole harm the dead option threatened — leaves that grep
+ * green while both tests below go red, so it contributed no failure-detection
+ * power. What matters is not that a spelling is absent but that the reset
+ * happens on EVERY composition, and that is what 1 and 2 assert. If someone
+ * re-adds the option and honours `resetState: false` from `addIfcxOverlays`,
+ * test 2 fails on the behaviour rather than on the name.
  */
 
 import '@/test/setup-dom.js';
@@ -69,24 +76,6 @@ function toFile(path: string, name: string): File {
   const bytes = readFileSync(path);
   return new File([bytes], name, { type: 'application/json' });
 }
-
-// ─── Signature-level pin: the misleading option must not exist ──────────
-
-describe('loadFederatedIfcxFromBuffers - dead resetState option', () => {
-  it('is not referenced anywhere in the hook source (declaration + call site both gone)', () => {
-    const src = readFileSync(
-      resolve(dirname(fileURLToPath(import.meta.url)), 'useIfcFederation.ts'),
-      'utf8',
-    );
-    const hits = src.match(/resetState/g) ?? [];
-    assert.deepStrictEqual(
-      hits,
-      [],
-      'resetState must not appear in useIfcFederation.ts - it was a dead option ' +
-      '(declared, never read) that misrepresented addIfcxOverlays as state-preserving',
-    );
-  });
-});
 
 // ─── Behavioural harness ──────────────────────────────────────────────────
 

--- a/apps/viewer/src/hooks/useIfcLoader.sabStreaming.test.tsx
+++ b/apps/viewer/src/hooks/useIfcLoader.sabStreaming.test.tsx
@@ -1,0 +1,201 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The IFC/STEP load path acquires its bytes by streaming into a
+ * `SharedArrayBuffer` — asserted by driving `useIfcLoader`, not by reading its
+ * source (#2434).
+ *
+ * `loadFile` streams a file at or above `STREAM_SAB_THRESHOLD` (256 MiB)
+ * straight into a pre-sized SAB instead of `await file.arrayBuffer()`, so peak
+ * memory is ~`fileSize` rather than `2 × fileSize` when the geometry pipeline
+ * copies into its own SAB (#600). Losing that call site does not break any
+ * output — the load still succeeds — it just doubles peak memory on exactly
+ * the files where that is fatal. So it needs a test of its own.
+ *
+ * This was previously pinned by scanning `useIfcLoader.ts` for
+ * `await acquireFileBuffer(`. That scan reads the WHOLE module, so any other
+ * helper or format path that happens to contain the same call satisfies it
+ * while the IFC/STEP call site is replaced by `file.arrayBuffer()` — the
+ * regression it names. It also could not distinguish a call from a mention
+ * until it was hardened, which is the shape of assertion #2434 exists to
+ * remove. Nothing below reads source text.
+ *
+ * **How a 256 MiB contract is driven in a unit test.** `file.size` is the only
+ * input the streaming branch consults before it calls `file.stream()`, and it
+ * is `defineProperty`-able on a real `File`; the bytes stay tiny. The
+ * `SharedArrayBuffer` constructor is replaced by one that RECORDS the
+ * requested size and hands back a SAB sized to the fixture's real length, so
+ * the read completes (`acquireFileBuffer` rejects a short read) without any
+ * run paying a quarter-gigabyte allocation.
+ *
+ * **The load then fails, after acquisition, and that is expected.** Node has no
+ * fetchable WASM engine, so the run prints a `[Geometry] init` failure and the
+ * store ends with a load error. Every assertion here is about how the bytes
+ * were READ, which happens before format handling and before the engine is
+ * touched; a failure that arrives EARLIER than the read cannot hide, because
+ * it leaves the read counters at zero and fails the test.
+ */
+
+import '@/test/setup-dom.js';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { useViewerStore } from '@/store';
+import { useIfcLoader } from './useIfcLoader.js';
+
+/**
+ * `STREAM_SAB_THRESHOLD` (apps/viewer/src/utils/ifcConfig.ts) is 256 MiB.
+ * `acquireFileBuffer` streams at or above it and takes `file.arrayBuffer()`
+ * below it, so a reported size past the threshold is what makes the streaming
+ * branch — and any regression out of it — observable.
+ */
+const ABOVE_SAB_THRESHOLD = 256 * 1024 * 1024 + 1;
+
+/**
+ * A STEP header is all `detectFormat` needs to route this down the IFC/STEP
+ * branch (`packages/ifcx/src/index.ts` matches `ISO-10303-21` in the first 100
+ * bytes), and the branch is entered after the bytes are read. Using real STEP
+ * content rather than a stand-in is what scopes this test to the IFC/STEP load
+ * path: the file the loader is handed is the one whose reads are counted.
+ */
+const STEP_BYTES = new TextEncoder().encode(
+  "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\n"
+  + "FILE_NAME('sab-streaming.ifc','2026-01-01T00:00:00',(''),(''),'','','');\n"
+  + "FILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\nENDSEC;\nEND-ISO-10303-21;\n",
+);
+
+interface FileProbe {
+  /** Whole-file reads through `file.arrayBuffer()` — the doubled-peak path. */
+  arrayBuffer: number;
+  /** Reads through `file.stream()` — how SAB streaming acquires bytes. */
+  stream: number;
+}
+
+/**
+ * A real `File` whose two read entry points are counted and whose reported
+ * size sits above the SAB streaming threshold. `file.slice(...)` is untouched
+ * on purpose: the loader's 4 KiB head slice for point-cloud detection is a
+ * separate `Blob`, so it never lands in these counters.
+ */
+function probedStepFile(probe: FileProbe): File {
+  const file = new File([STEP_BYTES], 'sab-streaming.ifc');
+  Object.defineProperty(file, 'size', { value: ABOVE_SAB_THRESHOLD });
+
+  const realArrayBuffer = file.arrayBuffer.bind(file);
+  Object.defineProperty(file, 'arrayBuffer', {
+    configurable: true,
+    value: (): Promise<ArrayBuffer> => {
+      probe.arrayBuffer++;
+      return realArrayBuffer();
+    },
+  });
+
+  const realStream = file.stream.bind(file);
+  Object.defineProperty(file, 'stream', {
+    configurable: true,
+    value: (): ReadableStream<Uint8Array> => {
+      probe.stream++;
+      return realStream() as ReadableStream<Uint8Array>;
+    },
+  });
+
+  return file;
+}
+
+/**
+ * Records every `new SharedArrayBuffer(n)` and returns one sized to the real
+ * fixture bytes. `acquireFileBuffer` throws on a short read, so the substitute
+ * has to be big enough to hold what the stream actually yields — and small
+ * enough that the run stays free.
+ */
+function withRecordedSharedArrayBuffer<T>(sizes: number[], body: () => Promise<T>): Promise<T> {
+  const holder = globalThis as { SharedArrayBuffer?: unknown };
+  const real = holder.SharedArrayBuffer as SharedArrayBufferConstructor;
+  holder.SharedArrayBuffer = function RecordingSharedArrayBuffer(byteLength: number): SharedArrayBuffer {
+    sizes.push(byteLength);
+    return new real(Math.min(byteLength, STEP_BYTES.byteLength));
+  } as unknown as SharedArrayBufferConstructor;
+  return body().finally(() => {
+    holder.SharedArrayBuffer = real;
+  });
+}
+
+/**
+ * Only a FILE-SIZED allocation is the one under test. The pipeline takes a
+ * handful of small bookkeeping SABs (an 8-byte Atomics handshake); asserting
+ * "exactly one SAB" would fail on those and tempt the next maintainer to
+ * loosen the assertion rather than read it.
+ */
+function fileSized(sizes: number[]): number[] {
+  return sizes.filter((n) => n >= 1024 * 1024);
+}
+
+let hookApi: ReturnType<typeof useIfcLoader> | null = null;
+
+function Probe(): null {
+  hookApi = useIfcLoader();
+  return null;
+}
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+beforeEach(async () => {
+  hookApi = null;
+  useViewerStore.getState().resetViewerState();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root!.render(<Probe />);
+  });
+});
+
+afterEach(async () => {
+  const current = root;
+  root = null;
+  if (current) await act(async () => current.unmount());
+  if (container) container.remove();
+  container = null;
+});
+
+describe('useIfcLoader - the IFC/STEP path keeps SAB streaming (#600)', () => {
+  it('reads a file above the threshold through file.stream() into a file-sized SharedArrayBuffer', async () => {
+    const probe: FileProbe = { arrayBuffer: 0, stream: 0 };
+    const sabSizes: number[] = [];
+    const file = probedStepFile(probe);
+
+    await withRecordedSharedArrayBuffer(sabSizes, async () => {
+      await act(async () => {
+        await hookApi!.loadFile(file);
+      });
+    });
+
+    // Reachability: an assertion about how a load read its bytes is worthless
+    // if `loadFile` returned before it got that far.
+    assert.equal(
+      useViewerStore.getState().models.size,
+      1,
+      'loadFile must have registered the model - otherwise it never reached byte acquisition and the counters below are vacuous',
+    );
+
+    assert.equal(
+      probe.stream,
+      1,
+      'a file at or above STREAM_SAB_THRESHOLD must be pulled through file.stream() - that is what streams it into a SharedArrayBuffer instead of paying a doubled peak (#600)',
+    );
+    assert.equal(
+      probe.arrayBuffer,
+      0,
+      'the IFC/STEP path must not take a whole-file file.arrayBuffer() above the threshold - that is the doubled peak this streaming exists to avoid',
+    );
+    assert.deepEqual(
+      fileSized(sabSizes),
+      [ABOVE_SAB_THRESHOLD],
+      'exactly one SharedArrayBuffer must be allocated at the file size, i.e. the destination the file streamed into',
+    );
+  });
+});

--- a/apps/viewer/src/utils/acquireFileBuffer.test.ts
+++ b/apps/viewer/src/utils/acquireFileBuffer.test.ts
@@ -152,70 +152,6 @@ describe('acquireFileBuffer', () => {
     }
   });
 
-  it('IFCX federation call sites do NOT use SAB streaming (memory regression guard for #647)', () => {
-    // IFCX is JSON. The federation parser path is:
-    //   parseFederatedIfcx → safeUtf8Decode(new Uint8Array(buffer)) → JSON.parse
-    // safeUtf8Decode must copy SAB-backed views into a scratch buffer in
-    // Chromium/Firefox (cross-thread JS string decoding cannot read SAB
-    // directly). Net peak with SAB streaming:
-    //   SAB (file.size) + scratch copy (file.size) + JSON string (~file.size)
-    //   — strictly worse than the plain ArrayBuffer path.
-    // Since #2183 that copy is a throwaway rather than a retained buffer
-    // (any IFCX big enough to stream to SAB is far above the 4 MiB retention
-    // cap), so the peak is lower than it was — but still worse than not
-    // copying at all, which is why this guard stands.
-    //
-    // This is a source-level guard: it ensures the two IFCX entry points in
-    // useIfcFederation.ts (loadFederatedIfcx + addIfcxOverlays) stay on
-    // file.arrayBuffer() and don't accidentally regress back to
-    // acquireFileBuffer(). The IFC/STEP path (addModel) keeps SAB streaming.
-    const here = dirname(fileURLToPath(import.meta.url));
-    const sourcePath = join(here, '..', 'hooks', 'useIfcFederation.ts');
-    const source = readFileSync(sourcePath, 'utf8');
-
-    // Find the loadFederatedIfcx and addIfcxOverlays function bodies and
-    // assert each one reads files via file.arrayBuffer(), not acquireFileBuffer.
-    const ifcxFnNames = ['loadFederatedIfcx', 'addIfcxOverlays'];
-    for (const fnName of ifcxFnNames) {
-      // Match the const declaration through the closing `}, [` of useCallback.
-      const startMarker = `const ${fnName} = useCallback`;
-      const startIdx = source.indexOf(startMarker);
-      assert.ok(startIdx >= 0, `expected ${fnName} declaration in useIfcFederation.ts`);
-      // End at the next useCallback dependency-array opener that closes this fn.
-      // We look for the first `}, [` after `startIdx`.
-      const endIdx = source.indexOf('}, [', startIdx);
-      assert.ok(endIdx > startIdx, `expected end of ${fnName} useCallback`);
-      const body = source.slice(startIdx, endIdx);
-      assert.ok(
-        body.includes('file.arrayBuffer()'),
-        `${fnName} must read files via file.arrayBuffer() (IFCX JSON path)`,
-      );
-      assert.ok(
-        !body.includes('acquireFileBuffer'),
-        `${fnName} must NOT use acquireFileBuffer() — SAB streaming worsens peak memory for IFCX/JSON (see PR #647 regression).`,
-      );
-    }
-
-    // Sanity check: the IFC/STEP path still SAB-streams. addModel now delegates
-    // to the canonical loadFile (one load path), so the acquireFileBuffer SAB
-    // streaming lives there — assert addModel routes through loadFile, and that
-    // loadFile keeps acquireFileBuffer for the STEP/IFC binary path. (IFCX is
-    // still guarded above: its federation entry points stay on file.arrayBuffer.)
-    const addModelStart = source.indexOf('const addModel = useCallback');
-    assert.ok(addModelStart >= 0, 'expected addModel declaration');
-    const addModelEnd = source.indexOf('}, [', addModelStart);
-    const addModelBody = source.slice(addModelStart, addModelEnd);
-    assert.ok(
-      addModelBody.includes('loadFile('),
-      'addModel must delegate to the canonical loadFile (one load path)',
-    );
-    const loaderSource = readFileSync(join(here, '..', 'hooks', 'useIfcLoader.ts'), 'utf8');
-    assert.ok(
-      loaderSource.includes('acquireFileBuffer'),
-      'loadFile (IFC/STEP path) must keep using acquireFileBuffer() for SAB streaming',
-    );
-  });
-
   it('falls back to arrayBuffer() when crossOriginIsolated is explicitly false', async () => {
     const originalDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'crossOriginIsolated');
     try {
@@ -239,5 +175,41 @@ describe('acquireFileBuffer', () => {
         delete (globalThis as { crossOriginIsolated?: boolean }).crossOriginIsolated;
       }
     }
+  });
+});
+
+/**
+ * KEPT AS A SOURCE-LEVEL GUARD, deliberately (#2434).
+ *
+ * The IFCX half of the old guard here — "the federation entry points must not
+ * SAB-stream" — is now driven through the hook in
+ * `../hooks/useIfcFederation.ifcxBuffers.test.tsx`, which observes the actual
+ * `arrayBuffer()`/`stream()` calls and any file-sized `SharedArrayBuffer`.
+ *
+ * This last claim resists the same treatment: `loadFile` only reaches the SAB
+ * branch for a file at or above `STREAM_SAB_THRESHOLD` (256 MiB), and there is
+ * no seam that lets a test inject a smaller threshold into `useIfcLoader`. So
+ * it stays a call-graph check — but a call-graph check that can actually fail.
+ * The previous form asserted `loaderSource.includes('acquireFileBuffer')`,
+ * which the `import` statement alone satisfies: replacing the call site with
+ * `file.arrayBuffer()` deleted SAB streaming from the STEP path and left the
+ * assertion green. Matching the CALL is what closes that hole.
+ *
+ * That `acquireFileBuffer` itself streams above the threshold is behavioural
+ * and covered by the suite above; this only pins that the loader still calls it.
+ */
+describe('IFC/STEP load path keeps SAB streaming', () => {
+  it('useIfcLoader calls acquireFileBuffer (not merely imports it)', () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const loaderSource = readFileSync(join(here, '..', 'hooks', 'useIfcLoader.ts'), 'utf8');
+    // Strip line comments so a mention in prose cannot satisfy the match: a
+    // comment that says `acquireFileBuffer(file)` is not a call.
+    const code = loaderSource.replace(/^\s*(?:\/\/|\*|\/\*).*$/gm, '');
+    assert.match(
+      code,
+      /\bawait\s+acquireFileBuffer\s*\(/,
+      'loadFile (IFC/STEP path) must keep calling acquireFileBuffer() — that call is what streams files ' +
+        '≥ STREAM_SAB_THRESHOLD straight into a SharedArrayBuffer instead of paying a doubled peak (#600).',
+    );
   });
 });

--- a/apps/viewer/src/utils/acquireFileBuffer.test.ts
+++ b/apps/viewer/src/utils/acquireFileBuffer.test.ts
@@ -4,9 +4,6 @@
 
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
-import { dirname, join } from 'node:path';
 
 // NOTE: We deliberately avoid importing from `./acquireFileBuffer` directly,
 // because that module pulls in `./ifcConfig`, which references
@@ -178,38 +175,16 @@ describe('acquireFileBuffer', () => {
   });
 });
 
-/**
- * KEPT AS A SOURCE-LEVEL GUARD, deliberately (#2434).
+/*
+ * WHERE THE TWO CALLER-SIDE GUARDS LIVE (#2434).
  *
- * The IFCX half of the old guard here — "the federation entry points must not
- * SAB-stream" — is now driven through the hook in
- * `../hooks/useIfcFederation.ifcxBuffers.test.tsx`, which observes the actual
- * `arrayBuffer()`/`stream()` calls and any file-sized `SharedArrayBuffer`.
+ * This file covers `acquireFileBuffer` itself. Both claims about its CALLERS
+ * used to be source scans over `useIfcFederation.ts` / `useIfcLoader.ts`; both
+ * are now driven through the hook that owns them, observing the real
+ * `arrayBuffer()` / `stream()` calls and any file-sized `SharedArrayBuffer`:
  *
- * This last claim resists the same treatment: `loadFile` only reaches the SAB
- * branch for a file at or above `STREAM_SAB_THRESHOLD` (256 MiB), and there is
- * no seam that lets a test inject a smaller threshold into `useIfcLoader`. So
- * it stays a call-graph check — but a call-graph check that can actually fail.
- * The previous form asserted `loaderSource.includes('acquireFileBuffer')`,
- * which the `import` statement alone satisfies: replacing the call site with
- * `file.arrayBuffer()` deleted SAB streaming from the STEP path and left the
- * assertion green. Matching the CALL is what closes that hole.
- *
- * That `acquireFileBuffer` itself streams above the threshold is behavioural
- * and covered by the suite above; this only pins that the loader still calls it.
+ *  - IFCX must never SAB-stream (#647) →
+ *    `../hooks/useIfcFederation.ifcxBuffers.test.tsx`
+ *  - the IFC/STEP path must keep SAB-streaming (#600) →
+ *    `../hooks/useIfcLoader.sabStreaming.test.tsx`
  */
-describe('IFC/STEP load path keeps SAB streaming', () => {
-  it('useIfcLoader calls acquireFileBuffer (not merely imports it)', () => {
-    const here = dirname(fileURLToPath(import.meta.url));
-    const loaderSource = readFileSync(join(here, '..', 'hooks', 'useIfcLoader.ts'), 'utf8');
-    // Strip line comments so a mention in prose cannot satisfy the match: a
-    // comment that says `acquireFileBuffer(file)` is not a call.
-    const code = loaderSource.replace(/^\s*(?:\/\/|\*|\/\*).*$/gm, '');
-    assert.match(
-      code,
-      /\bawait\s+acquireFileBuffer\s*\(/,
-      'loadFile (IFC/STEP path) must keep calling acquireFileBuffer() — that call is what streams files ' +
-        '≥ STREAM_SAB_THRESHOLD straight into a SharedArrayBuffer instead of paying a doubled peak (#600).',
-    );
-  });
-});


### PR DESCRIPTION
Part of #2434.

Three source-text assertions in `apps/viewer` are replaced by, or narrowed to, assertions that fail when the behaviour breaks. Each conversion is backed by a mutation pairing: the old assertion stays green under a realistic regression, the new one goes red.

## What changed

**1. IFCX must never SAB-stream (memory guard for #647)**

`acquireFileBuffer.test.ts` sliced `useIfcFederation.ts` between `const loadFederatedIfcx = useCallback` and the next `}, [`, then asserted the slice contains `file.arrayBuffer()` and does not contain `acquireFileBuffer`.

Replaced by `apps/viewer/src/hooks/useIfcFederation.ifcxBuffers.test.tsx`, which mounts the hook and drives `loadFederatedIfcx` / `addIfcxOverlays` with a real fixture File whose `arrayBuffer()` and `stream()` are counted, whose reported `size` sits above `STREAM_SAB_THRESHOLD` (that is the only input the SAB branch consults), and under a counting `SharedArrayBuffer` constructor. It asserts the read went through `arrayBuffer()`, that `stream()` was never called, that no file-sized SAB was allocated, and that the load actually registered a model, so the assertions are reachable rather than vacuously satisfied by a load that never happened.

*Pairing.* Regression: a module-scope helper that streams IFCX bytes into a SAB, selected at the call site with `SAB_OK ? await sabRead(file) : await file.arrayBuffer()`. The slice still contains `file.arrayBuffer()` and still contains no `acquireFileBuffer`.

- old source-scan: `# tests 7 / # pass 7 / # fail 0`
- new behavioural: `# tests 3 / # pass 1 / # fail 2` (both IFCX cases red)

**2. `addModel` delegates the read to the canonical `loadFile`**

Was `addModelBody.includes('loadFile(')`, which a comment satisfies. Now the hook is mounted with a spy `loadFile`: it must receive the File itself with a `kind: 'federated'` target, and `addModel` must read no bytes of its own.

*Pairing.* Regression: `addModel` calls `await file.arrayBuffer()` before delegating, a second read path alongside `loadFile`'s. `loadFile(` is still literally present.

- old source-scan: `# tests 7 / # pass 7 / # fail 0`
- new behavioural: `# tests 3 / # pass 2 / # fail 1`

**3. The dead `resetState` option (deleted, not converted)**

`useIfcFederation.resetState.test.tsx` grepped the hook for the identifier `resetState` and asserted zero hits. Deleting the `resetViewerState()` call outright, which is the entire harm the dead option threatened, leaves that grep green:

- grep test: `ok 1 - is not referenced anywhere in the hook source`
- behavioural pair in the same file: `not ok 1 - BOUNDING CONTROL ...`, `not ok 2 - adding an IFCX overlay ... ALSO resets state` (`# tests 3 / # pass 1 / # fail 2`)

It contributed no failure-detection power that the two behavioural tests beside it did not already have, so it is removed and the file banner records why.

## Converted after review

**4. The IFC/STEP path keeps SAB streaming (converted after review, `f5a37ee`)**

This one was first kept as a call-graph check, on the belief that `loadFile` only reaches the SAB branch at 256 MiB and there is no seam to inject a smaller threshold. The second half is true and irrelevant: `file.size` is the *only* input the streaming branch consults (`acquireFileBuffer.ts:59-61`), and it is `defineProperty`-able on a real `File`. No threshold injection is needed — the bytes stay tiny while the loader believes it holds 256 MiB.

`apps/viewer/src/hooks/useIfcLoader.sabStreaming.test.tsx` mounts `useIfcLoader` and drives `loadFile` with a real STEP file (an `ISO-10303-21` header, so `detectFormat` routes it down the IFC/STEP branch) reporting `STREAM_SAB_THRESHOLD + 1`, under counted `arrayBuffer()`/`stream()` and a `SharedArrayBuffer` constructor that records every requested size. It asserts the read went through `file.stream()`, that no whole-file `arrayBuffer()` was taken, that exactly one file-sized SAB was allocated at `file.size`, and that the model registered.

*Pairings.* Call site → `file.arrayBuffer()`: `# tests 1 / # pass 0 / # fail 1`. And the reviewer's variant — call site replaced **and** an unreferenced module-scope helper left carrying `await acquireFileBuffer(file)`, which the deleted regex still matched (verified directly): `# tests 1 / # pass 0 / # fail 1`.

The source scan is deleted; `acquireFileBuffer.test.ts` now only covers the helper itself, with a pointer to where each caller-side claim is driven.

## Verification

Fresh worktree off `origin/main` (`7c686f9ac`).

```
npx turbo typecheck --force
 Tasks:    76 successful, 76 total
Cached:    0 cached, 76 total
  Time:    1m55.64s
```

```
npx turbo test --force
 Tasks:    86 successful, 86 total
Cached:    0 cached, 86 total
  Time:    6m28.841s
```

`@ifc-lite/viewer:test` leaf counts: `# tests 3398 / # pass 3392 / # fail 0 / # skipped 6`. All six skips are pre-existing missing-fixture / missing-env skips in `@ifc-lite/wasm` and the OpenRouter and golden-parity suites; the three new tests ran and passed in that run.

No changeset: `apps/viewer` is private and no published package is touched.

## Inventory for the rest of #2434

Found by grepping every test file for `readFileSync`/`readFile` of a source file, source regexes, and `toString()` of a function.

Convertible, not done here (scope control):

- `packages/geometry/src/wasm-url-plumbing.test.ts` asserts `pkg.exports['./ifc-lite_bg.wasm'] === './pkg/ifc-lite_bg.wasm'`. Behavioural equivalent is resolving that subpath through Node's resolver, which exercises the exports map and proves the target exists. Held back because `packages/wasm/pkg/` is gitignored, so the test needs a build-dependent skip and the conversion is only an improvement once that is designed.
- `packages/pointcloud/src/streaming/worker-bundle.test.ts` regexes the built `dist/streaming/inline-worker.js` for `export const INLINE_WORKER_CODE`, a length floor, six class names, and a `startsWith('import ')` check. The last of those has a genuine behavioural form: compile the decoded string as a classic script and let module syntax throw, which is exactly what a Blob worker requires. The first two are dist-shape checks with no behaviour behind them.
- `apps/viewer/src/lib/using-declaration-build.test.ts` asserts `/\busing\b/` over the emitted esnext chunk. The sibling es2022 case already imports and runs the chunk and asserts disposal order; doing the same at esnext depends on the runner's native `using` support, so it needs a version gate.

Kept as legitimate, with reasons:

- `apps/viewer/src/utils/frameWait.test.ts` (#2385): a lint-like invariant scanning five files for an unbounded `await new Promise(rAF)`, with a `FRAME-WAIT-ALLOW` escape. There is no single behaviour to exercise; the property is "nobody reintroduced this shape anywhere".
- `apps/viewer/src/components/viewer/colorful-popover-opacity.test.ts` (#1924): a CSS `!important` cascade ordering contract. Tailwind utilities are not materialised in the test environment, so `getComputedStyle` would agree with whatever the file said.
- `packages/geometry/src/prepass-class-spans.test.ts`: pins TS constants against `rust/processing/src/shard_classes.rs`. Cross-language drift; TS cannot import a Rust `const`.
- `packages/codegen/test/crc32.test.ts`: generated-file drift check, and it overlaps open PR #2359, so untouched.
- `packages/create-ifc-lite/test/config-fixers.test.ts`: asserts on the `vite.config.ts` the tool *generates*, which is output, not source.
- `apps/viewer/src/lib/llm/free-models.test.ts`: reads `.env` as configuration, not source.

Not touched, contributor overlap: `apps/viewer/src/components/viewer/SearchModal.filter.wiring.test.ts` is the source-scan flagged on #2415 and lives in that open PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for IFCX federation loading and overlays, including file-buffer handling and viewer state resets.
  * Added coverage for large IFC/STEP file streaming, verifying efficient loading without whole-file reads.
  * Replaced fragile source-inspection tests with caller-level integration tests.
  * Added fixture checks and lifecycle assertions to improve test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
