### PR TITLE
fix(sandbox): retire the QuickJS module a teardown abort poisons (#1922)

### DIFF
--- a/.changeset/sandbox-retire-aborted-quickjs-module.md
+++ b/.changeset/sandbox-retire-aborted-quickjs-module.md
@@ -1,0 +1,18 @@
+---
+"@ifc-lite/sandbox": minor
+---
+
+Survive the upstream QuickJS teardown abort (#1922) by retiring the WASM module it poisons, instead of leaving every later sandbox in the process on it.
+
+A script that exhausts the memory limit inside a *drained promise job* — the reported shape is the post-`await` body of an `async function run()` — leaves objects orphaned on `rt->gc_obj_list` with leaked refcounts, and upstream `JS_FreeRuntime` asserts that list is empty. `runtime.dispose()` therefore comes back as `Aborted(Assertion failed: list_empty(&rt->gc_obj_list))`. That is an emscripten `abort()`, and its `ABORT` flag is latched **per module instance** — so on the process-wide module behind `getQuickJS()`, which every sandbox shared, the first abort was also the last one that could report itself: a second runtime left in exactly the same broken state disposed "successfully" while silently leaking whatever `JS_FreeRuntime` had not reached (measured: `#1 -> ABORT`, `#2 -> CLEAN`). In the browser the shared module also took scripting down with it until a page reload.
+
+The abort itself is upstream and still unfixed — quickjs-emscripten 0.32 exposes no GC entry point, and forcing a collection, lifting the limit, re-draining the job queue and skipping the context free were all measured against the reproducer and all still abort. What is new is that it is no longer terminal:
+
+- `Sandbox` now acquires its module through this package's own cache (`newQuickJSWASMModule()`, which is exactly what `getQuickJS()` memoizes) and remembers which instance its runtime came from.
+- A `runtime.dispose()` that aborts retires that module, so the *next* `Sandbox.init()` instantiates a fresh one — measured at 1-5 ms and ~1-2 MB, and only ever on this path. A later abort then reports itself again, because the new module's latch has not fired.
+- Retiring also unpins the poisoned module, which upstream's singleton held for the life of the process.
+- New `Sandbox.moduleRetired` tells a long-lived host (an extension runtime) that its sandbox is running on a module whose latch has fired: it still executes scripts, but can no longer report its own teardown, so it should be discarded and recreated.
+- `isSandboxRuntimeAborted()` is unchanged in shape and still latched, but is now documented as a diagnostic rather than a health check — a `true` no longer means scripting is dead.
+- `SandboxAbortError`'s message says the module was retired and the next sandbox will be fresh, instead of advising a reload.
+
+Minor rather than major: nothing is removed or renamed. The package's export list is unchanged (`check:api-surface` reports no diff), `isSandboxRuntimeAborted()` keeps its signature and its trigger — true iff a teardown abort has happened in this process — and every existing call still compiles and still means what it meant. What is added is `Sandbox.moduleRetired`; what changes is behaviour on a path that previously ended in a dead module, so no working caller can regress.

--- a/apps/viewer/src/hooks/useSandbox.teardownAbort.test.tsx
+++ b/apps/viewer/src/hooks/useSandbox.teardownAbort.test.tsx
@@ -1,0 +1,126 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `useSandbox().execute()` must settle a run's outcome at TEARDOWN, not before
+ * it (#1922, PR #2509 review).
+ *
+ * The #1922 shape is that the failure is invisible to the run that caused it:
+ * a script exhausting the sandbox heap inside a drained promise job leaves the
+ * `eval()` resolving normally — the issue's reproducer returns `"started"` —
+ * and only `dispose()` reports the damage. Reporting that abort from a
+ * `finally` reaches the store but NOT the return value, because a `finally`
+ * runs after the return expression has already been evaluated. Every caller
+ * reads success off exactly that value: `ExecutableCodeBlock.handleRun` treats
+ * any non-null result as success and ChatPanel's auto-execute path only
+ * handles failure when the result is null, so a crashed run was still
+ * announced as a good one while the panel showed an error next to it. The
+ * same ordering let `bumpScriptRunSeq()` — the scripting tour's run gate —
+ * count a run that died.
+ *
+ * These tests drive the REAL QuickJS runtime with the real reproducer, because
+ * the abort is an upstream emscripten assertion that no fake can stand in for
+ * honestly. Only the SDK is stubbed (through `BimReactContext`); the script
+ * below never touches `bim`.
+ *
+ * ORDER IS LOAD-BEARING. Emscripten latches `ABORT` per module instance, so
+ * the healthy-path test runs first, before any abort has fired.
+ */
+
+import '@/test/setup-dom.js';
+import { after, before, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import type { BimContext } from '@ifc-lite/sdk';
+import type { ScriptResult, SandboxConfig } from '@ifc-lite/sandbox';
+import { BimReactContext } from '@/sdk/BimProvider.js';
+import { useViewerStore } from '@/store';
+import { SANDBOX_ABORT_MESSAGE } from '@/lib/sandboxAbort.js';
+import { useSandbox } from './useSandbox.js';
+
+/** The #1922 reproducer verbatim: OOM inside the post-await body of a job. */
+const OOM_IN_JOB =
+  'async function run() { await 0; const a = []; for (;;) { a.push({ k: "v" }); } } run(); "started"';
+
+/** Small heap so the reproducer trips in tens of milliseconds, not seconds. */
+const CONFIG: SandboxConfig = { limits: { memoryBytes: 4 * 1024 * 1024, timeoutMs: 10_000 } };
+
+let execute: ((code: string) => Promise<ScriptResult | null>) | null = null;
+
+function Probe() {
+  ({ execute } = useSandbox(CONFIG));
+  return null;
+}
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+before(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root!.render(
+      <BimReactContext.Provider value={{} as BimContext}>
+        <Probe />
+      </BimReactContext.Provider>,
+    );
+  });
+  assert.ok(execute, 'the probe must have mounted and exposed execute()');
+});
+
+after(() => {
+  act(() => root?.unmount());
+  container?.remove();
+});
+
+describe('useSandbox().execute() — teardown decides the outcome (#1922)', () => {
+  it('reports a healthy run as a success and counts it', async () => {
+    // Runs FIRST, before any abort has latched on the WASM module.
+    const before = useViewerStore.getState().scriptRunSeq;
+    let result: ScriptResult | null = null;
+    await act(async () => {
+      result = await execute!('1 + 1');
+    });
+
+    assert.ok(result, 'a healthy run must resolve with a result');
+    assert.equal((result as ScriptResult).value, 2);
+    assert.equal(useViewerStore.getState().scriptLastError, null);
+    assert.equal(
+      useViewerStore.getState().scriptRunSeq,
+      before + 1,
+      'a healthy run must advance the run gate',
+    );
+  });
+
+  it('returns null for a run the teardown abort proves died, and does not count it', async () => {
+    const before = useViewerStore.getState().scriptRunSeq;
+    let result: ScriptResult | null = null;
+    await act(async () => {
+      result = await execute!(OOM_IN_JOB);
+    });
+
+    // The store half — this already worked; it is here to prove the run really
+    // was the #1922 one and not some ordinary failure that never reached
+    // teardown at all. Without it the assertions below could pass vacuously.
+    assert.equal(
+      useViewerStore.getState().scriptLastError,
+      SANDBOX_ABORT_MESSAGE,
+      'the reproducer must actually produce a teardown abort',
+    );
+
+    // The two halves of the defect.
+    assert.equal(
+      result,
+      null,
+      'execute() must not hand a truthy ScriptResult back for a run that died at teardown',
+    );
+    assert.equal(
+      useViewerStore.getState().scriptRunSeq,
+      before,
+      'a crashed run must not advance the scripting tour run gate',
+    );
+  });
+});

--- a/apps/viewer/src/hooks/useSandbox.ts
+++ b/apps/viewer/src/hooks/useSandbox.ts
@@ -162,6 +162,23 @@ export function useSandbox(config?: SandboxConfig) {
     }
 
     let sandbox: Sandbox | null = null;
+    let torndown = false;
+    /**
+     * Tear the sandbox down exactly once and report a #1922 teardown abort.
+     *
+     * Called from the success path *before* the run is reported, and from the
+     * `finally` for every other path; whichever arrives second is a no-op.
+     */
+    const teardown = (): string | null => {
+      if (torndown) return null;
+      torndown = true;
+      const message = sandbox ? disposeSandboxReportingAbort(sandbox) : null;
+      if (activeSandboxRef.current === sandbox) {
+        activeSandboxRef.current = null;
+      }
+      return message;
+    };
+
     try {
       // Create a fresh sandbox for every execution — full isolation. Because
       // it is fresh, a prior run's #1922 teardown abort costs this one
@@ -177,6 +194,33 @@ export function useSandbox(config?: SandboxConfig) {
       activeSandboxRef.current = sandbox;
 
       const result = await sandbox.eval(code);
+
+      // Settle the run BEFORE reporting it, because teardown is where this
+      // run's real outcome lives. A teardown abort is the *only* signal that
+      // the script exhausted the sandbox heap inside a drained job (#1922):
+      // that eval() resolves normally — the reproducer returns "started".
+      //
+      // Disposing here rather than only in the `finally` is what lets the
+      // failure reach the RETURN value. A `finally` runs after the return
+      // expression has already been evaluated, so reporting the abort only
+      // there left `execute()` resolving with a truthy ScriptResult for a run
+      // that died, and every caller reads success off exactly that:
+      // `ExecutableCodeBlock.handleRun` treats any non-null result as success,
+      // and ChatPanel's auto-execute path only handles failure when the result
+      // is null. The store said "error" while the UI said "ran fine".
+      const teardownAbortMessage = teardown();
+      if (teardownAbortMessage) {
+        // Keep the captured logs — they are the only record of how far the
+        // script got — but not the value, which is a lie about a dead run.
+        setResult({
+          value: undefined,
+          logs: result.logs,
+          durationMs: result.durationMs,
+        });
+        setError(teardownAbortMessage);
+        return null;
+      }
+
       setResult({
         value: result.value,
         logs: result.logs,
@@ -184,7 +228,8 @@ export function useSandbox(config?: SandboxConfig) {
       });
       // Successful-run signal for baseline consumers (scripting tour run
       // gate). Deliberately NOT bumped on the error-path setResult below
-      // (that call only preserves captured logs) or on reset().
+      // (that call only preserves captured logs), on reset(), or on the
+      // teardown-abort path above — a crashed run must not count as a run.
       useViewerStore.getState().bumpScriptRunSeq();
       return result;
     } catch (err: unknown) {
@@ -213,19 +258,14 @@ export function useSandbox(config?: SandboxConfig) {
       setError(runtime.message, runtime.diagnostics);
       return null;
     } finally {
-      // Always dispose the sandbox after execution.
-      //
-      // A teardown abort here is the *only* signal that the script exhausted
-      // the sandbox heap inside a drained job (#1922): that run resolves
-      // normally — the reproducer returns `"started"` — so without this the
-      // user is handed a clean-looking result for a script that died. Reported
-      // after the result is set, because setResult clears the store's error.
-      const teardownAbortMessage = sandbox ? disposeSandboxReportingAbort(sandbox) : null;
+      // Always dispose the sandbox after execution. A no-op on the success
+      // path, which already settled itself above; this covers create/eval
+      // throwing, and a teardown abort on the way out of a failed run.
+      // Reported after the result is set, because setResult clears the
+      // store's error.
+      const teardownAbortMessage = teardown();
       if (teardownAbortMessage) {
         setError(teardownAbortMessage);
-      }
-      if (activeSandboxRef.current === sandbox) {
-        activeSandboxRef.current = null;
       }
     }
   }, [bim, config?.permissions, config?.limits, setDiagnostics, setExecutionState, setResult, setError]);

--- a/apps/viewer/src/hooks/useSandbox.ts
+++ b/apps/viewer/src/hooks/useSandbox.ts
@@ -20,25 +20,7 @@ import {
   formatDiagnosticsForDisplay,
   type RuntimeScriptDiagnostic,
 } from '../lib/llm/script-diagnostics.js';
-import { describeSandboxAbort } from '../lib/sandboxAbort.js';
-
-/**
- * Tear a sandbox down without letting a teardown failure escape.
- *
- * An out-of-memory or CPU-timeout exception raised inside a drained promise
- * job leaves QuickJS holding objects with leaked refcounts, and upstream
- * `JS_FreeRuntime` aborts on it (#1922). Every call site here runs in a
- * `finally` or a React cleanup, where a throw would discard the run's own
- * result or escape an unmount — so report it and carry on. `Sandbox.dispose()`
- * has already released everything it owns by the time it throws.
- */
-function disposeSandbox(sandbox: Sandbox): void {
-  try {
-    sandbox.dispose();
-  } catch (err) {
-    console.error('[ifc-lite] sandbox teardown failed', err);
-  }
-}
+import { describeSandboxAbort, disposeSandboxReportingAbort } from '../lib/sandboxAbort.js';
 
 /** Type guard for ScriptError shape (has logs + durationMs) */
 function isScriptError(err: unknown): err is { message: string; logs: Array<{ level: string; args: unknown[]; timestamp: number }>; durationMs: number } {
@@ -181,17 +163,12 @@ export function useSandbox(config?: SandboxConfig) {
 
     let sandbox: Sandbox | null = null;
     try {
-      // Create a fresh sandbox for every execution — full isolation
-      const { createSandbox, isSandboxRuntimeAborted } = await import('@ifc-lite/sandbox');
-
-      // The shared QuickJS WASM module is dead for the rest of the document
-      // once a teardown abort has latched (#1922) — fail fast instead of
-      // creating a sandbox that cannot tear down cleanly either.
-      const abortedBeforeAttempt = describeSandboxAbort(isSandboxRuntimeAborted());
-      if (abortedBeforeAttempt) {
-        setError(abortedBeforeAttempt);
-        return null;
-      }
+      // Create a fresh sandbox for every execution — full isolation. Because
+      // it is fresh, a prior run's #1922 teardown abort costs this one
+      // nothing: the package retired that WASM module, so this sandbox is
+      // built on a healthy one. (The pre-flight refusal that used to stand
+      // here reported "reload the page" for the rest of the document.)
+      const { createSandbox } = await import('@ifc-lite/sandbox');
 
       sandbox = await createSandbox(bim, {
         permissions: { model: true, query: true, viewer: true, mutate: true, store: true, lens: true, export: true, files: true, ...config?.permissions },
@@ -211,11 +188,11 @@ export function useSandbox(config?: SandboxConfig) {
       useViewerStore.getState().bumpScriptRunSeq();
       return result;
     } catch (err: unknown) {
-      // A dispose() thrown from a prior run's teardown latches the runtime as
-      // aborted (#1922); a SandboxAbortError surfacing here means this very
-      // attempt hit it. Either way the fix is "reload", not the generic
-      // script-error diagnostics below.
-      const abortMessage = describeSandboxAbort(false, err);
+      // A SandboxAbortError surfacing from create/eval is the #1922 teardown
+      // abort, not a fault in the script — the generic diagnostics below would
+      // only mislead. (The ordinary route is the `finally`: the abort happens
+      // during teardown, after this run has already returned.)
+      const abortMessage = describeSandboxAbort(err);
       if (abortMessage) {
         setError(abortMessage);
         return null;
@@ -236,9 +213,16 @@ export function useSandbox(config?: SandboxConfig) {
       setError(runtime.message, runtime.diagnostics);
       return null;
     } finally {
-      // Always dispose the sandbox after execution
-      if (sandbox) {
-        disposeSandbox(sandbox);
+      // Always dispose the sandbox after execution.
+      //
+      // A teardown abort here is the *only* signal that the script exhausted
+      // the sandbox heap inside a drained job (#1922): that run resolves
+      // normally — the reproducer returns `"started"` — so without this the
+      // user is handed a clean-looking result for a script that died. Reported
+      // after the result is set, because setResult clears the store's error.
+      const teardownAbortMessage = sandbox ? disposeSandboxReportingAbort(sandbox) : null;
+      if (teardownAbortMessage) {
+        setError(teardownAbortMessage);
       }
       if (activeSandboxRef.current === sandbox) {
         activeSandboxRef.current = null;
@@ -249,7 +233,7 @@ export function useSandbox(config?: SandboxConfig) {
   /** Reset clears any active sandbox (no-op if none running) */
   const reset = useCallback(() => {
     if (activeSandboxRef.current) {
-      disposeSandbox(activeSandboxRef.current);
+      disposeSandboxReportingAbort(activeSandboxRef.current);
       activeSandboxRef.current = null;
     }
     setExecutionState('idle');
@@ -262,7 +246,7 @@ export function useSandbox(config?: SandboxConfig) {
   useEffect(() => {
     return () => {
       if (activeSandboxRef.current) {
-        disposeSandbox(activeSandboxRef.current);
+        disposeSandboxReportingAbort(activeSandboxRef.current);
         activeSandboxRef.current = null;
       }
     };

--- a/apps/viewer/src/lib/sandboxAbort.test.ts
+++ b/apps/viewer/src/lib/sandboxAbort.test.ts
@@ -3,33 +3,79 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
- * Reactive half of #1922 containment: the app must actually read the latch
- * (`isSandboxRuntimeAborted()`) and a caught `SandboxAbortError`, and turn
- * either into the "reload the page" message — not a generic script error.
+ * Reactive half of #1922 handling: the app must recognise a caught
+ * `SandboxAbortError` and turn it into the abort message rather than a generic
+ * script error — and must NOT claim a page reload is needed, because the
+ * package now retires the aborted WASM module and builds the next sandbox on a
+ * fresh one.
  *
- * `describeSandboxAbort` takes the aborted flag as a plain boolean rather
- * than reading `isSandboxRuntimeAborted()` itself, so these tests set the
- * latched state up directly instead of reproducing the upstream OOM.
+ * `describeSandboxAbort` inspects the caught error only, so these tests
+ * construct the failure directly instead of reproducing the upstream OOM.
  */
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import type { Sandbox } from '@ifc-lite/sandbox';
 import { SandboxAbortError } from '@ifc-lite/sandbox';
-import { describeSandboxAbort, SANDBOX_ABORT_RELOAD_MESSAGE } from './sandboxAbort.js';
+import {
+  describeSandboxAbort,
+  disposeSandboxReportingAbort,
+  SANDBOX_ABORT_MESSAGE,
+  SANDBOX_MODULE_RETIRED_MESSAGE,
+} from './sandboxAbort.js';
 
 describe('describeSandboxAbort', () => {
-  it('returns the reload message when the runtime is already latched aborted, before any attempt', () => {
-    assert.equal(describeSandboxAbort(true), SANDBOX_ABORT_RELOAD_MESSAGE);
-  });
-
-  it('returns the reload message for a SandboxAbortError caught mid-attempt, even if not latched going in', () => {
+  it('returns the abort message for a SandboxAbortError', () => {
     const err = new SandboxAbortError(new Error('Aborted(Assertion failed: list_empty(&rt->gc_obj_list))'));
-    assert.equal(describeSandboxAbort(false, err), SANDBOX_ABORT_RELOAD_MESSAGE);
+    assert.equal(describeSandboxAbort(err), SANDBOX_ABORT_MESSAGE);
   });
 
-  it('leaves an ordinary script error alone on a healthy runtime', () => {
+  it('leaves an ordinary script error alone', () => {
+    assert.equal(describeSandboxAbort(new Error("'foo' is not defined")), null);
+  });
+
+  it('treats a clean teardown (no error) as no abort', () => {
+    assert.equal(describeSandboxAbort(null), null);
+    assert.equal(describeSandboxAbort(undefined), null);
+  });
+
+  it('does not tell the user to reload - recovery is automatic', () => {
+    // The behaviour change this issue turns on. Both messages describe a
+    // failure the user can retry past; advising a reload would be wrong now
+    // and was the user-visible symptom in #1922.
+    for (const message of [SANDBOX_ABORT_MESSAGE, SANDBOX_MODULE_RETIRED_MESSAGE]) {
+      assert.equal(/reload the page/i.test(message), false, message);
+      assert.equal(/run again/i.test(message), true, message);
+      assert.equal(/no reload needed/i.test(message), true, message);
+    }
+  });
+});
+
+describe('disposeSandboxReportingAbort', () => {
+  function fakeSandbox(dispose: () => void): Sandbox {
+    return { dispose } as unknown as Sandbox;
+  }
+
+  it('surfaces a teardown abort as a message, because the run itself resolved clean', () => {
+    // The #1922 shape: eval() returned "started", so this is the only place
+    // the viewer can learn the script actually died.
+    const message = disposeSandboxReportingAbort(
+      fakeSandbox(() => {
+        throw new SandboxAbortError(new Error('Aborted(Assertion failed: list_empty(&rt->gc_obj_list))'));
+      }),
+    );
+    assert.equal(message, SANDBOX_ABORT_MESSAGE);
+  });
+
+  it('reports nothing for a clean teardown', () => {
+    let disposed = false;
+    assert.equal(disposeSandboxReportingAbort(fakeSandbox(() => { disposed = true; })), null);
+    assert.equal(disposed, true);
+  });
+
+  it('swallows an unrelated teardown failure rather than escaping a finally or an unmount', () => {
     assert.equal(
-      describeSandboxAbort(false, new Error("'foo' is not defined")),
+      disposeSandboxReportingAbort(fakeSandbox(() => { throw new Error('Lifetime not alive'); })),
       null,
     );
   });

--- a/apps/viewer/src/lib/sandboxAbort.ts
+++ b/apps/viewer/src/lib/sandboxAbort.ts
@@ -3,44 +3,67 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
- * Turns the process-wide QuickJS teardown abort (`@ifc-lite/sandbox`'s
- * `isSandboxRuntimeAborted()` / `SandboxAbortError`, ifc-lite#1922) into a
- * user-facing message.
+ * Turns the QuickJS teardown abort (`@ifc-lite/sandbox`'s `SandboxAbortError`,
+ * ifc-lite#1922) into a user-facing message.
  *
- * Containment in `@ifc-lite/sandbox` names the failure and latches it so it
- * is observable after the first occurrence, but nothing that latch is
- * connected to anything: every sandbox call site (`useSandbox.ts`, the
- * extension host's `sandbox-factory.ts`) either attempted an eval that could
- * not succeed, or reported the crash as a generic script error with no
- * mention that a reload is the only way out. This is the piece that reads
- * the flag.
+ * The abort itself is upstream: a script that exhausts the heap inside a
+ * drained promise job leaves objects orphaned on `rt->gc_obj_list`, and
+ * `JS_FreeRuntime` asserts that list is empty. Two things make it hard to
+ * report well, and this is where both are handled:
  *
- * `aborted` is a plain boolean, not read from `isSandboxRuntimeAborted()` in
- * here, so callers set it up directly (real latch or a fabricated `true`)
- * without needing to reproduce the upstream OOM to exercise this logic.
+ * - It surfaces at **teardown**, long after the `eval()` that caused it
+ *   resolved normally — so without a message here the user sees a clean result
+ *   for a script that actually died.
+ * - It used to be terminal for the document, because every sandbox shared one
+ *   WASM module. It no longer is: the package retires the aborted module and
+ *   builds the next sandbox on a fresh one, so the honest advice is "run
+ *   again", not "reload the page".
  */
 
-import { SandboxAbortError } from '@ifc-lite/sandbox';
+import { SandboxAbortError, type Sandbox } from '@ifc-lite/sandbox';
 
-export const SANDBOX_ABORT_RELOAD_MESSAGE =
-  'The script sandbox has crashed and can no longer run scripts (quickjs-emscripten ' +
-  'teardown abort, ifc-lite#1922). Reload the page to restore it.';
+export const SANDBOX_ABORT_MESSAGE =
+  'The script crashed the QuickJS runtime while it was being torn down, usually a ' +
+  'script that exhausts the sandbox memory limit inside an async function ' +
+  '(quickjs-emscripten teardown abort, ifc-lite#1922). Any result shown for this ' +
+  'run is incomplete. A fresh runtime is created automatically, so run again; ' +
+  'no reload needed.';
+
+export const SANDBOX_MODULE_RETIRED_MESSAGE =
+  'This sandbox was running on a QuickJS module that crashed (ifc-lite#1922), so it ' +
+  'could no longer be torn down safely. It has been discarded. Run again and the ' +
+  'runtime will reactivate on a fresh module; no reload needed.';
 
 /**
- * Decide whether a sandbox failure — or an attempt about to be made — should
- * be reported as "reload the page" rather than as an ordinary script error.
+ * Decide whether a failure caught from a sandbox operation is the #1922
+ * teardown abort rather than an ordinary script error.
  *
- * @param aborted Whether the shared QuickJS runtime is already known to be
- *   aborted, checked *before* attempting the operation so a doomed attempt
- *   is never made.
- * @param err The error caught from the attempt, if any. Recognised even when
- *   `aborted` was false going in, since `dispose()` throws `SandboxAbortError`
- *   at the moment the abort is discovered.
- * @returns The reload message, or `null` if this is an ordinary failure.
+ * @param err The error caught from `eval()` or from `dispose()`.
+ * @returns The abort message, or `null` if this is an ordinary failure.
  */
-export function describeSandboxAbort(aborted: boolean, err?: unknown): string | null {
-  if (aborted || err instanceof SandboxAbortError) {
-    return SANDBOX_ABORT_RELOAD_MESSAGE;
+export function describeSandboxAbort(err: unknown): string | null {
+  return err instanceof SandboxAbortError ? SANDBOX_ABORT_MESSAGE : null;
+}
+
+/**
+ * Tear a sandbox down, reporting a #1922 teardown abort as a message for the
+ * user rather than only to the console.
+ *
+ * This is the *only* place the viewer can learn that a script exhausted the
+ * sandbox heap inside a drained job: that `eval()` resolves normally — the
+ * issue's reproducer returns `"started"` — so the run has already reported
+ * success by the time `dispose()` fails.
+ *
+ * Never throws: teardown runs in a `finally` and on unmount, where a throw
+ * would replace the real outcome or break a React cleanup. Any other teardown
+ * failure is logged and returns `null`, exactly as before.
+ */
+export function disposeSandboxReportingAbort(sandbox: Sandbox): string | null {
+  try {
+    sandbox.dispose();
+    return null;
+  } catch (err) {
+    console.error('[ifc-lite] sandbox teardown failed', err);
+    return describeSandboxAbort(err);
   }
-  return null;
 }

--- a/apps/viewer/src/sdk/BimProvider.tsx
+++ b/apps/viewer/src/sdk/BimProvider.tsx
@@ -23,7 +23,14 @@ import { createContext, useContext, type ReactNode } from 'react';
 import type { BimContext } from '@ifc-lite/sdk';
 import { useBimHost } from './useBimHost.js';
 
-const BimReactContext = createContext<BimContext | null>(null);
+/**
+ * Exported as a rendering-test seam, same rationale as
+ * `ExtensionHostContext`: tests supply a stub `BimContext` through this
+ * context instead of `mock.module`, which is flag-gated
+ * (`--experimental-test-module-mocks`) on Node 22. `apps/viewer` is a
+ * private, unpublished app, so exporting this widens no public API.
+ */
+export const BimReactContext = createContext<BimContext | null>(null);
 
 /** Provider that initializes the SDK and makes it available via useBim() */
 export function BimProvider({ children }: { children: ReactNode }) {

--- a/apps/viewer/src/services/extensions/sandbox-factory.test.ts
+++ b/apps/viewer/src/services/extensions/sandbox-factory.test.ts
@@ -3,32 +3,39 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
- * The extension host's sandbox handle must read #1922 containment too — see
+ * The extension host's sandbox handle must react to #1922 — see
  * `../../lib/sandboxAbort.test.ts` for the pure decision logic. This pins the
- * wiring: `run()` turns a caught `SandboxAbortError` into the reload
- * message instead of passing the raw teardown-abort text through.
+ * wiring: `run()` turns a caught `SandboxAbortError` into the abort message
+ * instead of passing the raw teardown text through, and refuses to run a
+ * sandbox whose WASM module was retired, discarding it so the runtime
+ * reactivates on a fresh one.
  *
- * `sandbox.eval` is faked to throw directly — no WASM, no real OOM — so this
- * is about how `BimSandboxHandle.run()` reacts to the latched failure, not
- * about reproducing the upstream abort.
+ * `sandbox` is faked — no WASM, no real OOM — so this is about how
+ * `BimSandboxHandle` reacts to the conditions, not about reproducing the
+ * upstream abort. `packages/sandbox/src/module-recovery.test.ts` drives the
+ * real module for that.
  */
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import type { Sandbox } from '@ifc-lite/sandbox';
 import { SandboxAbortError } from '@ifc-lite/sandbox';
-import { SANDBOX_ABORT_RELOAD_MESSAGE } from '../../lib/sandboxAbort.js';
+import { SANDBOX_ABORT_MESSAGE, SANDBOX_MODULE_RETIRED_MESSAGE } from '../../lib/sandboxAbort.js';
 import { BimSandboxHandle } from './sandbox-factory.js';
 
-function fakeSandbox(evalImpl: () => Promise<never>): Sandbox {
+function fakeSandbox(
+  evalImpl: () => Promise<unknown>,
+  extra: { moduleRetired?: boolean; dispose?: () => void } = {},
+): Sandbox {
   return {
     eval: evalImpl,
-    dispose: () => {},
+    moduleRetired: extra.moduleRetired ?? false,
+    dispose: extra.dispose ?? (() => {}),
   } as unknown as Sandbox;
 }
 
 describe('BimSandboxHandle.run', () => {
-  it('reports the reload message when eval() throws SandboxAbortError, not the raw teardown text', async () => {
+  it('reports the abort message when eval() throws SandboxAbortError, not the raw teardown text', async () => {
     const sandbox = fakeSandbox(async () => {
       throw new SandboxAbortError(new Error('Aborted(Assertion failed: list_empty(&rt->gc_obj_list))'));
     });
@@ -38,10 +45,46 @@ describe('BimSandboxHandle.run', () => {
       () => handle.run('1 + 1'),
       (err: unknown) => {
         assert.ok(err instanceof Error);
-        assert.equal(err.message, SANDBOX_ABORT_RELOAD_MESSAGE);
+        assert.equal(err.message, SANDBOX_ABORT_MESSAGE);
         return true;
       },
     );
+    // The sandbox died with the abort, so the handle must read as disposed and
+    // the runtime reactivate rather than keep calling into a dead realm.
+    assert.equal(handle.isDisposed, true);
+  });
+
+  it('discards a sandbox whose WASM module was retired instead of running on it', async () => {
+    let evalCalls = 0;
+    let disposed = false;
+    const sandbox = fakeSandbox(
+      async () => {
+        evalCalls += 1;
+        return { value: 1, logs: [], durationMs: 0 };
+      },
+      { moduleRetired: true, dispose: () => { disposed = true; } },
+    );
+    const handle = new BimSandboxHandle(sandbox);
+
+    await assert.rejects(
+      () => handle.run('1 + 1'),
+      (err: unknown) => {
+        assert.ok(err instanceof Error);
+        assert.equal(err.message, SANDBOX_MODULE_RETIRED_MESSAGE);
+        return true;
+      },
+    );
+    assert.equal(evalCalls, 0, 'must not run against a retired module');
+    assert.equal(disposed, true, 'the doomed sandbox must be torn down');
+    assert.equal(handle.isDisposed, true);
+  });
+
+  it('still runs on a healthy sandbox', async () => {
+    const sandbox = fakeSandbox(async () => ({ value: 2, logs: [], durationMs: 1 }));
+    const handle = new BimSandboxHandle(sandbox);
+    const result = await handle.run('1 + 1');
+    assert.equal(result.value, 2);
+    assert.equal(handle.isDisposed, false);
   });
 
   it('leaves an ordinary eval failure untouched', async () => {

--- a/apps/viewer/src/services/extensions/sandbox-factory.ts
+++ b/apps/viewer/src/services/extensions/sandbox-factory.ts
@@ -34,9 +34,9 @@ import {
   type RuntimeSandboxFactory,
   type RuntimeSandboxHandle,
 } from '@ifc-lite/extensions';
-import { createSandbox, isSandboxRuntimeAborted, type Sandbox } from '@ifc-lite/sandbox';
+import { createSandbox, type Sandbox } from '@ifc-lite/sandbox';
 import type { BimContext } from '@ifc-lite/sdk';
-import { describeSandboxAbort } from '../../lib/sandboxAbort.js';
+import { describeSandboxAbort, SANDBOX_MODULE_RETIRED_MESSAGE } from '../../lib/sandboxAbort.js';
 
 export interface SandboxFactoryOptions {
   sdk: BimContext;
@@ -162,12 +162,21 @@ export class BimSandboxHandle implements RuntimeSandboxHandle {
   async run(source: string, _opts?: RuntimeRunOptions): Promise<RuntimeRunResult> {
     if (this.disposed) throw new Error('Sandbox disposed.');
 
-    // The shared QuickJS WASM module is dead for the rest of the document
-    // once a teardown abort has latched (#1922) — fail fast instead of
-    // running an extension against a module that cannot tear down cleanly.
-    const abortedBeforeAttempt = describeSandboxAbort(isSandboxRuntimeAborted());
-    if (abortedBeforeAttempt) {
-      throw new Error(abortedBeforeAttempt);
+    // This handle is long-lived, so unlike the viewer's per-run sandbox it can
+    // outlive a #1922 teardown abort raised by some *other* sandbox on the
+    // same WASM module. It would still run scripts, but its own teardown could
+    // no longer report a failure — emscripten's ABORT latch is per module and
+    // has already fired — so it would leak silently on dispose. Drop it and
+    // let the runtime reactivate; the replacement is built on a fresh module,
+    // which is why this says "run again" rather than "reload".
+    if (this.sandbox.moduleRetired) {
+      this.disposed = true;
+      try {
+        this.sandbox.dispose();
+      } catch (err) {
+        console.warn('[sandbox-factory] teardown of a retired-module sandbox failed', err);
+      }
+      throw new Error(SANDBOX_MODULE_RETIRED_MESSAGE);
     }
 
     const prelude = [...this.globals.values()].join('\n');
@@ -177,10 +186,12 @@ export class BimSandboxHandle implements RuntimeSandboxHandle {
       result = await this.sandbox.eval(wrapped, { typescript: false });
     } catch (err) {
       // A SandboxAbortError here means this attempt hit the #1922 teardown
-      // abort (or a prior run's dispose() already latched it). Reload is the
-      // only remedy, so say that instead of the generic passthrough below.
-      const abortMessage = describeSandboxAbort(false, err);
+      // abort. The sandbox is gone with it, so mark this handle disposed and
+      // say what happened instead of the generic passthrough below; the next
+      // activation gets a sandbox on a fresh module.
+      const abortMessage = describeSandboxAbort(err);
       if (abortMessage) {
+        this.disposed = true;
         throw new Error(abortMessage);
       }
 

--- a/docs/guide/scripting-sdk.md
+++ b/docs/guide/scripting-sdk.md
@@ -119,6 +119,24 @@ Or reach it through the SDK as `bim.sandbox.eval(script, config)`, which returns
 
 One case is still **not** reported: a rejection in a promise the script never hands back — `run(); 'started'` rather than `return run()`. There is no handle to inspect, and quickjs-emscripten exposes no host rejection tracker, so nothing observes it.
 
+**When `dispose()` throws.** The same unawaited shape has a second failure mode: if that detached job exhausts the memory limit, it leaves objects orphaned on QuickJS's GC list and upstream `JS_FreeRuntime` asserts, so teardown comes back as an emscripten abort — a `SandboxAbortError` from `dispose()` ([#1922](https://github.com/LTplus-AG/ifc-lite/issues/1922)). The `eval()` that caused it resolved normally, so **teardown is the only place that run's failure is observable**: settle a run's outcome *after* disposing it, not before, or you will report a clean result for a script that died.
+
+The abort poisons the whole WASM module, not just the one sandbox. The package retires it and builds the next sandbox on a fresh instance — a few milliseconds, no page reload, and nothing to do for the common case where a sandbox is created per run.
+
+A host that keeps **one sandbox alive across many runs** — an extension runtime, a REPL — does have something to do. Its sandbox may be sitting on a module that some *other* sandbox's abort retired. It still executes scripts, but emscripten's abort latch is per module and has already fired on it, so its own teardown can no longer report a failure and it will silently leak. `Sandbox.moduleRetired` is that signal; the contract is to discard, not to reuse:
+
+```ts
+import { createSandbox, type Sandbox, type SandboxConfig } from '@ifc-lite/sandbox';
+
+async function ensureLiveSandbox(sandbox: Sandbox, config: SandboxConfig): Promise<Sandbox> {
+  if (!sandbox.moduleRetired) return sandbox;
+  sandbox.dispose();
+  return createSandbox(bim, config); // fresh module, no page reload
+}
+```
+
+Check it while the sandbox is live: `dispose()` releases the module reference, after which `moduleRetired` reads `false`. The process-wide `isSandboxRuntimeAborted()` is a diagnostic — latched for the process lifetime — not a health check; a `true` does not mean scripting is dead.
+
 **Permissions** gate which namespaces the script can touch (`model`, `query`, `viewer`, `mutate`, `store`, `lens`, `export`, `files`). The defaults are read-only: `mutate` and `store` are off, everything else on. **Limits** cap resources, defaulting to 64 MB heap, a 30-second timeout, and a 512 KB stack. A namespace whose permission is disabled is simply not built on the sandboxed `bim` handle, so a script cannot call what it was not granted.
 
 ### Sandboxed vs. direct

--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -32,6 +32,38 @@ console.log(result.logs);  // captured console output
 sandbox.dispose();
 ```
 
+## Recovering from a teardown abort
+
+A script that exhausts the memory limit inside a *drained promise job* — the post-`await` body of an `async function run()` that nothing awaits — trips an upstream assertion in `JS_FreeRuntime`, so `dispose()` comes back as an emscripten abort ([#1922](https://github.com/LTplus-AG/ifc-lite/issues/1922)). Two consequences a consumer has to handle:
+
+**`dispose()` can throw, and that throw is the run's verdict.** It rejects with `SandboxAbortError`. The `eval()` that caused it already resolved normally — the reproducer returns `"started"` — so teardown is the *only* place the failure is observable. Treat a throwing `dispose()` as that run having failed, and settle the run's outcome after teardown rather than before it:
+
+```ts
+import { SandboxAbortError, type ScriptResult } from '@ifc-lite/sandbox';
+
+let result: ScriptResult | null = await sandbox.eval(code);
+try {
+  sandbox.dispose();
+} catch (err) {
+  if (err instanceof SandboxAbortError) {
+    result = null; // the run died; whatever it "returned" is incomplete
+  }
+}
+```
+
+**A long-lived sandbox must be discarded once `moduleRetired` is true.** The abort poisons the whole WASM module, so this package retires it and builds the next sandbox on a fresh one — 1-5 ms, no page reload, and nothing for a caller to do. But a host that *keeps* one sandbox across many runs (an extension runtime, a REPL) can be holding one whose module was retired by some other sandbox's abort. That sandbox still executes scripts, yet emscripten's `ABORT` latch is per module and has already fired on it: its own teardown can no longer report a failure, and it will silently leak whatever `JS_FreeRuntime` does not reach. Check before running, and replace rather than reuse:
+
+```ts
+if (sandbox.moduleRetired) {
+  sandbox.dispose();
+  sandbox = await createSandbox(bim, config); // built on a fresh module
+}
+```
+
+`moduleRetired` is always `false` after `dispose()`, which releases the module reference — so check it while the sandbox is live. Sandboxes created per run (the viewer's script panel) never observe it: they are already gone by then.
+
+`isSandboxRuntimeAborted()` reports whether *any* teardown abort has happened in this process. It is a diagnostic, latched for the process lifetime; it is not a health check, and a `true` does not mean scripting is dead.
+
 ## Features
 
 - QuickJS interpreter compiled to WASM: full isolation from the host page
@@ -40,6 +72,7 @@ sandbox.dispose();
 - Captured console logs and structured `ScriptResult` / `ScriptError`
 - TypeScript support via `transpileTypeScript` (esbuild-wasm)
 - Machine-readable bridge schema (`NAMESPACE_SCHEMAS`, exported at `@ifc-lite/sandbox/schema`) for LLM tool integration
+- Survives the upstream QuickJS teardown abort by retiring the WASM module it poisons (`SandboxAbortError`, `Sandbox.moduleRetired` — see above)
 
 ## Links
 

--- a/packages/sandbox/src/module-recovery.test.ts
+++ b/packages/sandbox/src/module-recovery.test.ts
@@ -1,0 +1,132 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Recovery from the upstream teardown abort (#1922).
+ *
+ * `oom-job-dispose.test.ts` pins the *containment* — the abort arrives as a
+ * named error and the sandbox reads as disposed. This file pins the thing that
+ * makes the failure survivable: the poisoned WASM module is retired, so the
+ * next sandbox is created on a fresh instance and scripting keeps working
+ * without a page reload.
+ *
+ * Everything here drives the real quickjs-emscripten module. A stub cannot
+ * prove any of it: the assertion, the `ABORT` latch and the module identity
+ * all live in the WASM glue.
+ *
+ * IMPORTANT — test order in this file is load-bearing, for the reason the fix
+ * exists. Emscripten latches `ABORT` **per module instance**, so a module that
+ * has already aborted once reports every later abort as a false clean. The
+ * healthy-path tests therefore run before the first poisoning, and each
+ * poisoning test must be the first one on its own module. The file is kept
+ * separate so vitest gives it a dedicated process.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { BimContext } from '@ifc-lite/sdk';
+import { createSandbox, Sandbox, SandboxAbortError } from './sandbox.js';
+import {
+  acquireQuickJSModule,
+  isQuickJSModuleRetired,
+  isSandboxRuntimeAborted,
+  retireQuickJSModule,
+} from './quickjs-module.js';
+
+/** The #1922 reproducer verbatim: OOM inside the post-await body of a job. */
+const OOM_IN_JOB =
+  'async function run() { await 0; const a = []; for (;;) { a.push({ k: "v" }); } } run(); "started"';
+
+/** Small enough that the reproducer reaches the ceiling in well under a second. */
+const SMALL_HEAP = { limits: { memoryBytes: 8 * 1024 * 1024 } };
+
+describe('QuickJS module cache (#1922)', () => {
+  it('hands every sandbox the same module until one is retired', async () => {
+    const first = await acquireQuickJSModule();
+    expect(await acquireQuickJSModule()).toBe(first);
+    expect(isQuickJSModuleRetired(first)).toBe(false);
+
+    retireQuickJSModule(first);
+
+    expect(isQuickJSModuleRetired(first)).toBe(true);
+    const replacement = await acquireQuickJSModule();
+    expect(replacement).not.toBe(first);
+    expect(isQuickJSModuleRetired(replacement)).toBe(false);
+  }, 60000);
+
+  it('retires nothing for a sandbox that never reached a module', () => {
+    // A `dispose()` before `init()` resolved passes null through; it must not
+    // throw and must not retire whatever happens to be cached.
+    expect(() => retireQuickJSModule(null)).not.toThrow();
+    expect(isQuickJSModuleRetired(null)).toBe(false);
+  });
+});
+
+describe('sandbox recovery after a teardown abort (#1922)', () => {
+  it('tells a sandbox still running on the aborted module that it was retired', async () => {
+    // Created first, so it shares the module the doomed sandbox is about to
+    // poison — the extension host's long-lived sandbox, in miniature.
+    const survivor: Sandbox = await createSandbox({} as BimContext);
+    expect(survivor.moduleRetired).toBe(false);
+    expect(isSandboxRuntimeAborted()).toBe(false);
+
+    const doomed = await createSandbox({} as BimContext, SMALL_HEAP);
+    expect(doomed.moduleRetired).toBe(false);
+    // The defect in one line: the run that breaks teardown resolves normally.
+    expect((await doomed.eval(OOM_IN_JOB, { typescript: false })).value).toBe('started');
+
+    let caught: unknown;
+    try {
+      doomed.dispose();
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(SandboxAbortError);
+    expect(isSandboxRuntimeAborted()).toBe(true);
+
+    // The survivor still executes — the module was measured to keep running
+    // scripts correctly — but it can no longer report its own teardown, and
+    // this is the flag that says so.
+    expect(survivor.moduleRetired).toBe(true);
+    expect((await survivor.eval('1 + 1', { typescript: false })).value).toBe(2);
+    survivor.dispose();
+
+    // The aborted sandbox released its module reference, so it reports false
+    // rather than pinning the retired instance.
+    expect(doomed.moduleRetired).toBe(false);
+  }, 60000);
+
+  it('creates the next sandbox on a fresh module, which still runs scripts', async () => {
+    const recovered = await createSandbox({} as BimContext);
+    expect(recovered.moduleRetired).toBe(false);
+    expect((await recovered.eval('1 + 1', { typescript: false })).value).toBe(2);
+    expect(() => recovered.dispose()).not.toThrow();
+  }, 60000);
+
+  it('reports a second abort instead of swallowing it, because the new module has its own latch', async () => {
+    // The load-bearing assertion of the whole fix. On the shared singleton the
+    // second sandbox broken exactly like the first tears down *silently* —
+    // emscripten only reports the first abort per module — so `caught` comes
+    // back undefined and the host is told nothing while `JS_FreeRuntime`
+    // half-finishes. On a fresh module the latch has not fired, so the failure
+    // reports itself again.
+    const second = await createSandbox({} as BimContext, SMALL_HEAP);
+    expect(second.moduleRetired).toBe(false);
+    await second.eval(OOM_IN_JOB, { typescript: false });
+
+    let caught: unknown;
+    try {
+      second.dispose();
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(SandboxAbortError);
+  }, 60000);
+
+  it('is still recoverable after the second abort', async () => {
+    const third = await createSandbox({} as BimContext);
+    expect(third.moduleRetired).toBe(false);
+    expect((await third.eval('"ok"', { typescript: false })).value).toBe('ok');
+    expect(() => third.dispose()).not.toThrow();
+  }, 60000);
+});

--- a/packages/sandbox/src/oom-job-dispose.test.ts
+++ b/packages/sandbox/src/oom-job-dispose.test.ts
@@ -16,13 +16,16 @@
  * remedies that were measured and rejected. What this pins is the containment:
  * the failure is reported as a named error that says what happened and which
  * issue it is, the sandbox reads as disposed rather than half-alive, and the
- * process records that no *later* teardown failure can report itself.
+ * process records that an abort happened at all.
+ *
+ * Surviving it — retiring the poisoned WASM module so the next sandbox is
+ * built on a fresh one — is pinned separately, in `module-recovery.test.ts`.
  *
  * IMPORTANT — test order in this file is load-bearing. Emscripten latches its
- * `ABORT` flag, so the first abort in a process is the only one that throws;
- * every later one returns a false clean. The healthy-path test therefore runs
- * first, and no test after the reproducer may assume a throwing teardown.
- * The file is kept separate so vitest gives it a dedicated worker.
+ * `ABORT` flag per module instance, so the first abort on a given module is
+ * the only one that throws. The healthy-path test therefore runs first, and no
+ * test after the reproducer may assume a throwing teardown. The file is kept
+ * separate so vitest gives it a dedicated worker.
  */
 
 import { describe, expect, it } from 'vitest';
@@ -95,11 +98,12 @@ describe('sandbox teardown after an OOM inside a drained job (#1922)', () => {
     await expect(sandbox.eval('1 + 1', { typescript: false })).rejects.toThrow(/disposed/i);
   }, 60000);
 
-  it('keeps the process flag set once the abort latch has swallowed the throw', async () => {
-    // The reason `isSandboxRuntimeAborted()` exists. A second sandbox broken
-    // exactly like the first tears down *silently*, because emscripten only
-    // reports the first abort in a process — so the throw is no longer a
-    // signal a host can rely on, and the flag is.
+  it('keeps the process flag set across a second abort', async () => {
+    // The flag is latched: once an abort has happened in this process it stays
+    // observable, whatever the second teardown does. Whether that teardown
+    // throws depends on which module it ran on — emscripten's latch is per
+    // module instance, and `module-recovery.test.ts` is where that is pinned —
+    // so this asserts only the part that holds either way.
     const sandbox = await createSandbox({} as BimContext, {
       limits: { memoryBytes: 8 * 1024 * 1024 },
     });
@@ -110,10 +114,9 @@ describe('sandbox teardown after an OOM inside a drained job (#1922)', () => {
     } catch (err) {
       caught = err;
     }
-    // Whether this throws at all is upstream's business — the abort latch
-    // usually swallows it by now — but if it does throw it must still arrive
-    // contained, not as a raw emscripten assertion. Bound rather than
-    // discarded (AGENTS.md: no silent `catch {}`).
+    // Whether this throws at all is upstream's business, but if it does throw
+    // it must still arrive contained, not as a raw emscripten assertion. Bound
+    // rather than discarded (AGENTS.md: no silent `catch {}`).
     if (caught !== undefined) expect(caught).toBeInstanceOf(SandboxAbortError);
     expect(isSandboxRuntimeAborted()).toBe(true);
   }, 60000);

--- a/packages/sandbox/src/quickjs-module.ts
+++ b/packages/sandbox/src/quickjs-module.ts
@@ -1,0 +1,145 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Which QuickJS WASM module instance backs new sandboxes, and how a poisoned
+ * one is retired (#1922).
+ *
+ * ## Why this exists
+ *
+ * An out-of-memory raised inside a *drained promise job* leaves objects
+ * orphaned on `rt->gc_obj_list` with leaked refcounts, and upstream
+ * `JS_FreeRuntime` asserts that list is empty — so `runtime.dispose()` comes
+ * back as `Aborted(Assertion failed: list_empty(&rt->gc_obj_list))`. That is
+ * an emscripten `abort()`, which latches a module-wide `ABORT` flag. The abort
+ * itself is upstream and not preventable from here; what *is* ours is which
+ * module the next sandbox runs on.
+ *
+ * The package used to hand every sandbox the process-wide singleton behind
+ * `getQuickJS()`, so one bad script poisoned scripting for the rest of the
+ * document. Two measured consequences, both gone once the module is replaced:
+ *
+ * - The latch is per module instance, so after the first abort **no later
+ *   teardown failure on that module can report itself**: a second runtime left
+ *   in exactly the same broken state disposes "successfully" while silently
+ *   leaking whatever `JS_FreeRuntime` had not reached. Measured directly, two
+ *   runtimes poisoned identically: `#1 -> ABORT`, `#2 -> CLEAN`.
+ * - `getQuickJS()` memoizes its module in an upstream module-level variable,
+ *   so the poisoned instance and its heap are pinned for the life of the
+ *   process even after the last sandbox using it is gone.
+ *
+ * ## What this does
+ *
+ * `acquireQuickJSModule()` owns the cache instead of upstream: it is
+ * `newQuickJSWASMModule()` behind the same de-duplicating promise, so first
+ * load is byte-for-byte the previous behaviour (`getQuickJS()` is itself only
+ * a memoized `newQuickJSWASMModule()`). `retireQuickJSModule()` drops the
+ * cache when a teardown abort proves the module is poisoned, so the *next*
+ * `Sandbox.init()` instantiates a fresh one — measured at 1-5 ms and ~1-2 MB,
+ * and only ever on this path. Sandboxes still holding runtimes on the retired
+ * module keep working (measured), but their teardown can no longer report a
+ * failure, so `isQuickJSModuleRetired()` lets a host recreate them instead.
+ *
+ * Retiring also *unpins* the poisoned module: nothing here holds it once the
+ * last sandbox on it is released, which the upstream singleton never allowed.
+ *
+ * This is the same shape `@ifc-lite/geometry`'s `recordWasmRuntimeTrap` settled
+ * on for #1898: drop the poisoned handle so the next `init()` builds a clean
+ * one, let the failing operation fail loudly with its own error, and do *not*
+ * latch a realm-wide refusal — that version bricked every unrelated consumer
+ * after one failure, and it is what the pre-flight checks removed from
+ * `useSandbox` / `sandbox-factory` were doing here.
+ */
+
+import { newQuickJSWASMModule, type QuickJSWASMModule } from 'quickjs-emscripten';
+
+/** Cached WASM module promise — de-duplicates concurrent init calls. */
+let modulePromise: Promise<QuickJSWASMModule> | null = null;
+/** Resolved value of `modulePromise`, so a retire can identify what it holds. */
+let activeModule: QuickJSWASMModule | null = null;
+/**
+ * Weak so a retired module is collectable once the sandboxes still running on
+ * it are released — the whole point of not leaving it in upstream's singleton.
+ */
+const retiredModules = new WeakSet<QuickJSWASMModule>();
+let runtimeAborted = false;
+
+/**
+ * The module instance new sandboxes should run on, loading it if needed.
+ *
+ * Concurrent callers share one load. A load that *fails* clears the cache so
+ * the next caller retries, rather than every later `init()` inheriting one
+ * transient fetch failure forever.
+ */
+export function acquireQuickJSModule(): Promise<QuickJSWASMModule> {
+  if (!modulePromise) {
+    const pending: Promise<QuickJSWASMModule> = newQuickJSWASMModule().then((module) => {
+      // "Adopt only if still the cached load." Defensive rather than
+      // load-bearing today: `retireQuickJSModule` only clears the cache for
+      // the module it already holds as active, and `activeModule` is null for
+      // the whole of an in-flight load, so nothing can currently reassign
+      // `modulePromise` between here and the line above. Kept because the
+      // alternative — an unconditional assignment — turns any future third
+      // writer of `modulePromise` into a silently resurrected retired module,
+      // and this costs one reference comparison per load.
+      if (modulePromise === pending) activeModule = module;
+      return module;
+    });
+    pending.catch(() => {
+      if (modulePromise === pending) modulePromise = null;
+    });
+    modulePromise = pending;
+  }
+  return modulePromise;
+}
+
+/**
+ * Stop handing `module` to new sandboxes — its emscripten `ABORT` latch has
+ * fired, so nothing running on it can report a teardown failure any more.
+ *
+ * Idempotent, and a no-op for `null` (a sandbox torn down before `init()`
+ * reached a module never had one).
+ */
+export function retireQuickJSModule(module: QuickJSWASMModule | null): void {
+  if (!module) return;
+  retiredModules.add(module);
+  if (activeModule === module) {
+    activeModule = null;
+    modulePromise = null;
+  }
+}
+
+/** Whether `module` has been retired after a teardown abort. */
+export function isQuickJSModuleRetired(module: QuickJSWASMModule | null): boolean {
+  return module !== null && retiredModules.has(module);
+}
+
+/**
+ * Whether a QuickJS teardown has ever aborted a WASM module in this process
+ * (#1922).
+ *
+ * Latched and never cleared — it is a diagnostic, not a health check. It does
+ * **not** mean scripting is broken: the poisoned module is retired at the
+ * moment of the abort and the next sandbox gets a fresh one, so a `true` here
+ * is compatible with a fully working sandbox. A host wanting to know whether a
+ * *particular* sandbox is still trustworthy should read `Sandbox.moduleRetired`
+ * instead; this is for telemetry and for explaining a script that crashed.
+ */
+export function isSandboxRuntimeAborted(): boolean {
+  return runtimeAborted;
+}
+
+/**
+ * Record a teardown abort. Reported at error level on *every* occurrence, not
+ * only the first: each aborting module is retired, so each new abort happens
+ * on a module whose latch has not fired yet and is a genuinely distinct event.
+ */
+export function markRuntimeAborted(cause: unknown): void {
+  runtimeAborted = true;
+  console.error(
+    '[ifc-lite/sandbox] QuickJS aborted while freeing a runtime (#1922). That WASM ' +
+      'module has been retired; the next sandbox will be created on a fresh one.',
+    cause,
+  );
+}

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -6,7 +6,8 @@
  * Sandbox — QuickJS-in-WASM script execution environment.
  *
  * Architecture:
- * - One WASM module loaded per app lifetime (shared across sandboxes)
+ * - One WASM module loaded per app lifetime (shared across sandboxes), retired
+ *   and replaced if a teardown abort poisons it (see quickjs-module.ts, #1922)
  * - Each sandbox creates a fresh QuickJS context (cheap — a few KB)
  * - The `bim` API is built inside the context via bridge.ts
  * - Scripts run synchronously inside QuickJS
@@ -15,7 +16,6 @@
  */
 
 import {
-  getQuickJS,
   type QuickJSWASMModule,
   type QuickJSContext,
   type QuickJSHandle,
@@ -27,17 +27,21 @@ import { DEFAULT_LIMITS, DEFAULT_PERMISSIONS } from './types.js';
 import { buildBridge } from './bridge.js';
 import type { HostWorkQueue } from './bridge-async.js';
 import { transpileTypeScript } from './transpile.js';
+import {
+  acquireQuickJSModule,
+  isQuickJSModuleRetired,
+  markRuntimeAborted,
+  retireQuickJSModule,
+} from './quickjs-module.js';
 
-/** Cached WASM module promise — deduplicates concurrent init calls */
-let modulePromise: Promise<QuickJSWASMModule> | null = null;
+/**
+ * Re-exported from its own module so every existing import path keeps working;
+ * see quickjs-module.ts for what it now means (it is a diagnostic, not a
+ * "scripting is dead" flag — #1922 recovery replaces the poisoned module).
+ */
+export { isSandboxRuntimeAborted } from './quickjs-module.js';
+
 let nextSandboxSessionId = 1;
-
-function getModule(): Promise<QuickJSWASMModule> {
-  if (!modulePromise) {
-    modulePromise = getQuickJS();
-  }
-  return modulePromise!;
-}
 
 /**
  * Reported by every entry point that a disposed sandbox refuses: `init()` and
@@ -95,6 +99,16 @@ function describeError(vm: QuickJSContext, handle: QuickJSHandle): string {
 }
 
 export class Sandbox {
+  /**
+   * The WASM module this sandbox's runtime was created on (#1922).
+   *
+   * Held so `dispose()` can retire exactly the module that aborted — the
+   * cached one may already be a different instance by then — and so
+   * `moduleRetired` can tell a host that this sandbox is running on a module
+   * whose abort latch has fired. Cleared by `dispose()`: keeping it would pin
+   * a retired module's heap for as long as the caller holds the sandbox.
+   */
+  private module: QuickJSWASMModule | null = null;
   private runtime: QuickJSRuntime | null = null;
   private vm: QuickJSContext | null = null;
   private logs: LogEntry[] = [];
@@ -122,8 +136,8 @@ export class Sandbox {
    * happens) would leave the handle alive. A handle created through the context
    * is an unmanaged lifetime that `vm.dispose()` does NOT free, so the orphan
    * keeps a JSObject on the runtime's GC list and `JS_FreeRuntime` then trips
-   * `assert(list_empty(&rt->gc_obj_list))` — the #1922 abort that puts the
-   * shared WASM module into an undefined state for the rest of the document.
+   * `assert(list_empty(&rt->gc_obj_list))` — the #1922 abort, which costs the
+   * whole WASM module (it is retired and rebuilt, not merely this sandbox).
    *
    * `dispose()` frees it before the vm and runtime; `runEval`'s `finally`
    * clears the field and frees it on the ordinary path. `safeDispose` ignores
@@ -182,6 +196,25 @@ export class Sandbox {
     return this.isDisposed;
   }
 
+  /**
+   * Whether the WASM module backing this sandbox was retired after a teardown
+   * abort (#1922).
+   *
+   * True means some sandbox on this module hit the upstream
+   * `JS_FreeRuntime` assertion, so emscripten's module-wide `ABORT` latch has
+   * fired: this sandbox still *runs* scripts, but its own teardown can no
+   * longer report a failure, and it will silently leak whatever
+   * `JS_FreeRuntime` does not reach. A long-lived host (the extension runtime)
+   * should drop such a sandbox and create a new one — the replacement is built
+   * on a fresh module, so no page reload is needed. Sandboxes created per run
+   * (the viewer's script panel) never observe this: they are already gone.
+   *
+   * Always false after `dispose()`, which releases the module reference.
+   */
+  get moduleRetired(): boolean {
+    return isQuickJSModuleRetired(this.module);
+  }
+
   constructor(
     private sdk: BimContext,
     config: SandboxConfig = {},
@@ -203,12 +236,15 @@ export class Sandbox {
     // holding anything that could. Both checks precede every allocation, so
     // the rejection leaves nothing behind.
     if (this.isDisposed) throw new Error(DISPOSED_MESSAGE);
-    const module = await getModule();
+    const module = await acquireQuickJSModule();
     if (this.isDisposed) throw new Error(DISPOSED_MESSAGE);
     // Set this.runtime before the try so dispose() can free it if any
     // subsequent step (newContext / buildBridge) throws — otherwise a failed
     // init() leaks the WASM runtime for the page/process lifetime, since the
     // caller never receives a handle to dispose.
+    // Recorded alongside it, and for the same reason: a dispose() that has to
+    // retire the module must know which instance this runtime came from.
+    this.module = module;
     this.runtime = module.newRuntime();
 
     try {
@@ -509,18 +545,23 @@ export class Sandbox {
    *
    * The abort itself is upstream and cannot be prevented from here (#1922) —
    * see `SandboxAbortError` for what was measured and what is done instead.
+   * What *is* done here is to retire the aborted WASM module, so the next
+   * sandbox is created on a fresh one instead of inheriting a poisoned heap
+   * and a fired `ABORT` latch (see quickjs-module.ts).
    */
   dispose(): void {
     const bridgeDispose = this.bridgeDispose;
     const pendingEvalHandle = this.pendingEvalHandle;
     const vm = this.vm;
     const runtime = this.runtime;
+    const module = this.module;
     this.bridgeDispose = null;
     this.pendingEvalHandle = null;
     this.resetLogs = null;
     this.hostWork = null;
     this.vm = null;
     this.runtime = null;
+    this.module = null;
     // Set before the frees, not after: if `runtime.dispose()` aborts, the
     // sandbox must already read as disposed, so a later eval() reports a dead
     // sandbox instead of running against half-freed structures.
@@ -536,50 +577,15 @@ export class Sandbox {
     try {
       runtime.dispose();
     } catch (err) {
-      // Record it before rethrowing: from here on, no later teardown in this
-      // process can be trusted to report its own failure (see markRuntimeAborted).
+      // Retire before rethrowing. This module's emscripten `ABORT` latch has
+      // fired, so from here on nothing running on it can report a teardown
+      // failure — the next sandbox must be built somewhere else.
+      retireQuickJSModule(module);
       markRuntimeAborted(err);
       throw new SandboxAbortError(err);
     }
   }
 
-}
-
-/**
- * Whether a QuickJS teardown has aborted the shared WASM module in this
- * process (#1922).
- *
- * Once true, the module's heap is in an undefined state and — critically —
- * emscripten's `abort()` latch means **no later teardown failure can report
- * itself**: a second runtime left in the same broken state disposes
- * "successfully" while silently leaking whatever `JS_FreeRuntime` had not yet
- * freed. Measured directly: with two runtimes poisoned identically, the first
- * `dispose()` throws the assertion and the second returns cleanly.
- *
- * A host that cares about that distinction (the viewer, an extension host)
- * should treat a `true` here as "reload before trusting sandbox teardown
- * again". Nothing in this package refuses to run on an aborted module: the
- * module was measured to keep executing scripts correctly afterwards, so
- * hard-failing every later sandbox would break more than the bug does.
- */
-export function isSandboxRuntimeAborted(): boolean {
-  return runtimeAborted;
-}
-
-let runtimeAborted = false;
-
-function markRuntimeAborted(cause: unknown): void {
-  if (runtimeAborted) return;
-  runtimeAborted = true;
-  // Reported once, at error level, because this is the only moment the
-  // condition is observable: every later occurrence is swallowed by the
-  // emscripten abort latch.
-  console.error(
-    '[ifc-lite/sandbox] QuickJS aborted while freeing a runtime (#1922). The shared ' +
-      'WASM module is now in an undefined state and later teardown failures will be ' +
-      'silent. Reload before relying on sandbox teardown again.',
-    cause,
-  );
 }
 
 /**
@@ -594,10 +600,10 @@ function markRuntimeAborted(cause: unknown): void {
  * `eval()` that caused it resolved normally, with a message that says nothing
  * about which script did it or what to do next.
  *
- * This class does not fix that; it contains it. The following were each
- * measured against the issue's reproducer in a **fresh process per trial** —
- * the isolation matters, because emscripten latches `ABORT` and every trial
- * after the first in one process reports a false clean:
+ * This class does not fix that; it names it. The following were each measured
+ * against the issue's reproducer in a **fresh process per trial** — the
+ * isolation matters, because emscripten latches `ABORT` per module instance
+ * and every trial after the first on one module reports a false clean:
  *
  * - forcing a QuickJS collection before teardown, by allocating 256 through
  *   1,000,000 object literals in the realm: still aborts. The orphaned objects
@@ -607,17 +613,20 @@ function markRuntimeAborted(cause: unknown): void {
  * - draining the job queue repeatedly, creating and freeing a second context,
  *   and skipping `context.dispose()`: all still abort.
  *
- * quickjs-emscripten 0.32 exposes no GC entry point, so there is no remaining
- * in-repo lever. What is left is to name the failure accurately, point at the
- * issue, and record that the module is now unreliable.
+ * quickjs-emscripten 0.32 exposes no GC entry point, so *preventing* the abort
+ * has no in-repo lever. Surviving it does: the aborted module is retired and
+ * the next sandbox is built on a fresh instance, so this error means "the
+ * script that just ran is over", not "scripting is over until a page reload"
+ * (see quickjs-module.ts).
  */
 export class SandboxAbortError extends Error {
   constructor(public readonly cause: unknown) {
     super(
       'QuickJS aborted while freeing the sandbox runtime. This is upstream ' +
         'quickjs-emscripten behaviour after an out-of-memory or interrupt inside a ' +
-        'drained promise job (ifc-lite#1922); the sandbox is unusable and the shared ' +
-        'WASM module is in an undefined state. Original error: ' +
+        'drained promise job (ifc-lite#1922); this sandbox is gone and its WASM ' +
+        'module has been retired, so the next sandbox will be created on a fresh ' +
+        'one. Original error: ' +
         (cause instanceof Error ? cause.message : String(cause)),
     );
     this.name = 'SandboxAbortError';


### PR DESCRIPTION
Fixes #1922

## The defect, reproduced

```js
async function run() { await 0; const a = []; for (;;) { a.push({ k: "v" }); } } run(); "started"
```

Measured directly against `quickjs-emscripten@0.32.0`, `getQuickJS()` singleton, 8 MB limit:

```
#1 eval RESOLVED with "started"
#1 runtime.dispose -> ABORT: Aborted(Assertion failed: list_empty(&rt->gc_obj_list),
                             at: ../../vendor/quickjs/quickjs.c,2036,JS_FreeRuntime)
getQuickJS returns same instance: true
#2 eval RESOLVED with "started"
#2 runtime.dispose -> CLEAN
```

Two separate problems in five lines. The `eval()` **resolves**, so the host is handed a clean-looking result for a script that died; and the abort latches emscripten's module-wide `ABORT` flag, so `#2` — a runtime left in exactly the same broken state — reports a **false clean** while silently leaking whatever `JS_FreeRuntime` never reached.

## Can the abort be prevented?

No, not from here. Each lever was measured against the reproducer on a **fresh module per trial**, because a module that has already aborted reports every later abort as a false clean:

| lever | result |
| --- | --- |
| baseline (drain result disposed, per #1905) | ABORT |
| lift the memory limit before dispose | ABORT |
| re-drain jobs until `hasPendingJob()` is false | ABORT |
| allocation pressure to provoke a collection | ABORT |
| lift limit + alloc + re-drain, combined | ABORT |
| skip `context.dispose()` | ABORT |
| **control:** same harness, benign sync script | CLEAN |
| **control:** same harness, benign async job | CLEAN |

The two controls are what make the table mean anything: the harness reports CLEAN when it should. `quickjs-emscripten` 0.32 exposes no GC entry point (no `RunGC` anywhere in `@jitl/quickjs-ffi-types`), so there is no remaining in-repo lever. The abort is upstream's.

## What this does instead: contain it, and make it visible

**Contain.** The package now owns the module cache — `newQuickJSWASMModule()`, which is byte-for-byte what `getQuickJS()` memoizes, so first load is unchanged — and each `Sandbox` remembers the instance its runtime came from. A `dispose()` that aborts retires that instance, so the next `Sandbox.init()` builds a fresh one:

```
module1 -> ABORT
poisoned-module survivor    eval= 2  dispose=CLEAN   (the false clean, still there, now flagged)
replacement load ms 3       distinct instance: true
fresh module healthy        eval= 2  dispose=CLEAN
module2 -> ABORT                                      <- reports itself, because its latch has not fired
fresh module after its own abort  eval= 2  dispose=CLEAN
```

Replacement costs 2-8 ms and ~1-2 MB, only ever on this path. Retiring also unpins the poisoned module, which upstream's singleton held for the life of the process.

**Make it visible.** The teardown abort is the *only* moment the viewer can learn the script exhausted the heap, since the run already returned `"started"`. It now becomes the run's error rather than a console line under a green result. Both user-facing messages say "run again" instead of "reload the page" — which is now true.

**Removed:** the pre-flight refusals that read the latched process flag before every run. They turned one bad script into a document-wide refusal, which is exactly the failure mode `@ifc-lite/geometry`'s `recordWasmRuntimeTrap` already rejected for #1898 ("that version bricked every unrelated consumer after one failure"). This follows the same precedent: drop the poisoned handle, let the failing operation fail loudly with its own error, latch nothing. `wasm-runtime-trap.ts` reserves its "cannot recover in this document" verdict for the case where a fresh instance is genuinely unobtainable; here one is obtainable in 3 ms, so that verdict would be wrong.

## Tests

`packages/sandbox/src/module-recovery.test.ts` drives the **real** quickjs-emscripten module — no stub, no mock. A stub could not prove any of this: the assertion, the `ABORT` latch and module identity all live in the WASM glue. Test order in the file is load-bearing and documented, for the same reason the fix exists.

Its load-bearing assertion is *"reports a second abort instead of swallowing it"*. On the old shared singleton that second teardown is silent; passing it requires the replacement module to be a genuinely distinct WASM instance.

The viewer-side tests (`sandboxAbort.test.ts`, `sandbox-factory.test.ts`) do use fakes, and say so in their headers — they pin decision logic (which message, does the handle discard itself), not the abort.

### Mutation table

Run unmutated first (11/11 pass), then revert each mechanism, then `git checkout --` and re-verify `git status --porcelain` is clean. Leaf failures only.

| mutation | tests | pass | fail | which leaves |
| --- | --- | --- | --- | --- |
| *(control, unmutated)* | 11 | 11 | 0 | — |
| drop `retireQuickJSModule(module)` from `dispose()` | 11 | 9 | 2 | "tells a sandbox still running on the aborted module that it was retired"; **"reports a second abort instead of swallowing it"** |
| `acquireQuickJSModule` back to `getQuickJS()` | 11 | 6 | 5 | the module-cache test + all four recovery tests |
| `if (false && this.sandbox.moduleRetired)` in the extension handle | 11 | 10 | 1 | "discards a sandbox whose WASM module was retired instead of running on it" |
| `disposeSandboxReportingAbort` returns `null` unconditionally | 11 | 10 | 1 | "surfaces a teardown abort as a message, because the run itself resolved clean" |

## Gate

- `npx turbo typecheck --force` — 76 successful, 76 total, **0 cached**
- `npx turbo test --force` — 86 successful, 86 total, **0 cached**; `@ifc-lite/sandbox` 195/195, viewer 3453 pass / 0 fail
- `node scripts/check-api-surface.mjs` — no diff. `Sandbox.moduleRetired` is a class member, not a package export, so no `api-surface:update` is needed.
- Changeset is **minor** and justifies itself in the file: nothing removed or renamed, `isSandboxRuntimeAborted()` keeps its signature and its trigger, and the behaviour change is on a path that previously ended in a dead module.

## Not verified

Measured under Node, not in a browser. There, the poisoned module keeps executing scripts after the abort (which is what makes the false clean dangerous); the issue reports the browser module as unusable. The fix is correct either way — the replacement is a fresh instance in both — but the *survivor* behaviour that `Sandbox.moduleRetired` describes was only observed under Node.

One wart left alone: `bumpScriptRunSeq()` still fires on the success path before the `finally` discovers the abort, so the scripting-tour run gate counts a crashed run as successful. Deferring it would churn a hot path for a tour gate.
