### PR TITLE
fix(viewer): close three toolbar-parity gaps and guard the boundary

### DIFF
--- a/apps/viewer/src/components/ui/dropdown-menu.overflow.test.tsx
+++ b/apps/viewer/src/components/ui/dropdown-menu.overflow.test.tsx
@@ -1,0 +1,116 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * A dropdown menu body must stay inside the viewport and scroll what does not
+ * fit (PR #2510 review, Codex P2).
+ *
+ * The classic strip's View menu grew a 12-command camera block, and on a short
+ * desktop window the whole menu no longer fitted: measured at 1280x640 it drew
+ * 697px of menu into 640px of window, ending 101px below the fold. Nothing
+ * recovered those items — the base style was `overflow-hidden` with no
+ * `max-height`, so the Projection / Helpers / Toolbar controls at the bottom
+ * could be neither seen nor scrolled to. Radix already measures the space it
+ * has (`--radix-dropdown-menu-content-available-height`); the styling simply
+ * never read it.
+ *
+ * SCOPE OF THIS TEST. happy-dom has no layout engine, so nothing here can
+ * measure a rendered height — that half was verified in a real browser, before
+ * and after (before: 697px tall, `max-height: none`, `overflow-y: hidden`,
+ * last item bottom at y=736 with the window 640 tall and unreachable; after:
+ * capped at 596.5px, `overflow-y: auto`, scrollHeight 695 > clientHeight 595,
+ * last item reachable by scrolling; and at a tall window the cap does not
+ * bind and no scrollbar appears). What this test pins is that the two
+ * declarations doing the work are still on the REAL rendered menu node, for
+ * both the menu body and its submenus, so they cannot be dropped silently.
+ */
+
+import '@/test/setup-dom.js';
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { act, type ReactNode } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from './dropdown-menu.js';
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+function render(node: ReactNode): void {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => root!.render(node));
+}
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  root = null;
+  container = null;
+});
+
+/** The Radix variable is the whole point: a fixed cap would be wrong at every
+ *  other window height, and a viewport unit ignores where the trigger sits. */
+const AVAILABLE_HEIGHT_VAR = '--radix-dropdown-menu-content-available-height';
+
+function assertFitsAndScrolls(node: Element, label: string): void {
+  const classes = node.className;
+  assert.ok(
+    classes.includes(`max-h-[var(${AVAILABLE_HEIGHT_VAR})]`),
+    `${label} must cap its height at the space Radix measured, got: ${classes}`,
+  );
+  assert.ok(
+    classes.includes('overflow-y-auto'),
+    `${label} must scroll what does not fit, got: ${classes}`,
+  );
+  // The shorthand must be gone rather than merely paired with `overflow-y-auto`:
+  // with both present, which one wins is Tailwind's emitted rule order, not ours.
+  assert.ok(
+    !/(?:^|\s)overflow-hidden(?:\s|$)/.test(classes),
+    `${label} must not re-add the overflow shorthand next to overflow-y-auto, got: ${classes}`,
+  );
+}
+
+describe('dropdown menu bodies fit the viewport', () => {
+  it('caps the menu body and scrolls the overflow', () => {
+    render(
+      <DropdownMenu open>
+        <DropdownMenuTrigger>open</DropdownMenuTrigger>
+        <DropdownMenuContent className="w-56">
+          <DropdownMenuItem>Only item</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    );
+    const menu = document.querySelector('[role="menu"]');
+    assert.ok(menu, 'the menu body must render');
+    assertFitsAndScrolls(menu, 'DropdownMenuContent');
+  });
+
+  it('caps submenu bodies too', () => {
+    render(
+      <DropdownMenu open>
+        <DropdownMenuTrigger>open</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuSub open>
+            <DropdownMenuSubTrigger>More</DropdownMenuSubTrigger>
+            <DropdownMenuSubContent>
+              <DropdownMenuItem>Nested item</DropdownMenuItem>
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    );
+    const menus = [...document.querySelectorAll('[role="menu"]')];
+    assert.equal(menus.length, 2, 'both the menu and its submenu must render');
+    for (const menu of menus) assertFitsAndScrolls(menu, 'submenu body');
+  });
+});

--- a/apps/viewer/src/components/ui/dropdown-menu.tsx
+++ b/apps/viewer/src/components/ui/dropdown-menu.tsx
@@ -34,6 +34,27 @@ const DropdownMenuSubTrigger = React.forwardRef<
 ));
 DropdownMenuSubTrigger.displayName = DropdownMenuPrimitive.SubTrigger.displayName;
 
+/**
+ * Height bound shared by both menu bodies.
+ *
+ * Radix measures the space left between the trigger and the collision boundary
+ * and publishes it as `--radix-dropdown-menu-content-available-height`. Without
+ * a `max-height` reading it, a menu taller than the viewport is simply drawn
+ * past the bottom edge — and because the base style is `overflow-hidden`, the
+ * items down there cannot be scrolled to either. Measured on the classic
+ * strip's View menu at a 1280x640 viewport: 697px of menu in 640px of window,
+ * with "Toolbar" and its controls starting below the fold and unreachable.
+ * `overflow-x` stays hidden; `overflow-y` becomes `auto` so the overflow that
+ * remains is scrollable rather than lost. The shorthand is deliberately gone —
+ * an `overflow-hidden` alongside `overflow-y-auto` would leave which one wins
+ * up to Tailwind's emitted rule order.
+ *
+ * If the variable is ever absent, the declaration is invalid at computed-value
+ * time and `max-height` falls back to `none`, i.e. exactly today's behaviour.
+ */
+const MENU_BODY_FIT =
+  'max-h-[var(--radix-dropdown-menu-content-available-height)] overflow-x-hidden overflow-y-auto';
+
 const DropdownMenuSubContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
@@ -41,7 +62,8 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+      MENU_BODY_FIT,
+      'z-50 min-w-[8rem] rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
       className
     )}
     {...props}
@@ -58,7 +80,8 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        MENU_BODY_FIT,
+        'z-50 min-w-[8rem] rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         className
       )}
       {...props}

--- a/apps/viewer/src/components/viewer/MainToolbar.tsx
+++ b/apps/viewer/src/components/viewer/MainToolbar.tsx
@@ -19,11 +19,6 @@ import {
   Home,
   Maximize2,
   Grid3x3,
-  ArrowUp,
-  ArrowDown,
-  ArrowLeft,
-  ArrowRight,
-  Box,
   HelpCircle,
   Loader2,
   Camera,
@@ -91,6 +86,7 @@ import { useFileCommands } from './toolbar/useFileCommands';
 import { useExportCommands } from './toolbar/useExportCommands';
 import { useWorkspacePanelControls } from './toolbar/useWorkspacePanelControls';
 import { ClassVisibilityMenuContent } from './toolbar/ClassVisibilityMenu';
+import { CameraCommandMenuItems } from './toolbar/CameraCommands';
 
 type Tool = 'select' | 'walk' | 'measure' | 'section' | 'annotate' | 'addElement' | 'split' | 'spaceSketch';
 
@@ -1119,30 +1115,10 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
           <TooltipContent>View options</TooltipContent>
         </Tooltip>
         <DropdownMenuContent align="end" className="w-56">
-          <DropdownMenuLabel className="text-[10px] uppercase tracking-wide text-muted-foreground">
-            Preset views
-          </DropdownMenuLabel>
-          <DropdownMenuItem onClick={handleHome}>
-            <Box className="h-4 w-4 mr-2" /> Isometric <span className="ml-auto text-xs opacity-60">H</span>
-          </DropdownMenuItem>
-          <DropdownMenuItem onClick={() => cameraCallbacks.setPresetView?.('top')}>
-            <ArrowUp className="h-4 w-4 mr-2" /> Top <span className="ml-auto text-xs opacity-60">1</span>
-          </DropdownMenuItem>
-          <DropdownMenuItem onClick={() => cameraCallbacks.setPresetView?.('bottom')}>
-            <ArrowDown className="h-4 w-4 mr-2" /> Bottom <span className="ml-auto text-xs opacity-60">2</span>
-          </DropdownMenuItem>
-          <DropdownMenuItem onClick={() => cameraCallbacks.setPresetView?.('front')}>
-            <ArrowRight className="h-4 w-4 mr-2" /> Front <span className="ml-auto text-xs opacity-60">3</span>
-          </DropdownMenuItem>
-          <DropdownMenuItem onClick={() => cameraCallbacks.setPresetView?.('back')}>
-            <ArrowLeft className="h-4 w-4 mr-2" /> Back <span className="ml-auto text-xs opacity-60">4</span>
-          </DropdownMenuItem>
-          <DropdownMenuItem onClick={() => cameraCallbacks.setPresetView?.('left')}>
-            <ArrowLeft className="h-4 w-4 mr-2" /> Left <span className="ml-auto text-xs opacity-60">5</span>
-          </DropdownMenuItem>
-          <DropdownMenuItem onClick={() => cameraCallbacks.setPresetView?.('right')}>
-            <ArrowRight className="h-4 w-4 mr-2" /> Right <span className="ml-auto text-xs opacity-60">6</span>
-          </DropdownMenuItem>
+          {/* Camera, preset views and the 90° rotations — rendered from the
+              shared command list so this menu can't fall behind the ribbon's
+              View tab (it did: rotate was ribbon-only, see CameraCommands). */}
+          <CameraCommandMenuItems />
           <DropdownMenuSeparator />
           <DropdownMenuLabel className="text-[10px] uppercase tracking-wide text-muted-foreground">
             Projection

--- a/apps/viewer/src/components/viewer/ViewportOverlays.tsx
+++ b/apps/viewer/src/components/viewer/ViewportOverlays.tsx
@@ -144,7 +144,11 @@ export function ViewportOverlays({ hideViewCube = false }: { hideViewCube?: bool
   return (
     <>
       <PointCloudPanelMount />
-      {/* Touch navigation stays available on mobile; the desktop Ribbon owns these controls. */}
+      {/* Touch navigation stays available on mobile. On desktop BOTH toolbar
+          styles carry zoom and Home from the shared camera command list
+          (`toolbar/CameraCommands`) — when this guard first narrowed to
+          mobile only the ribbon did, which left classic users with no zoom
+          button anywhere. */}
       {isMobile && !cesiumEnabled && (
         <div
           className="absolute left-4 bottom-[15%] flex flex-col gap-1 rounded-md border bg-background/90 p-1 backdrop-blur-sm"

--- a/apps/viewer/src/components/viewer/ribbon/RibbonToolbar.tsx
+++ b/apps/viewer/src/components/viewer/ribbon/RibbonToolbar.tsx
@@ -27,6 +27,7 @@ import { useIfc } from '@/hooks/useIfc';
 import { cn } from '@/lib/utils';
 import { TOUR_ANCHORS, tourAnchor } from '@/lib/tours/anchors';
 import { ThemeSwitch } from '../ThemeSwitch';
+import { SearchInline } from '../SearchInline';
 import { ExportChangesButton } from '../ExportChangesButton';
 import { ExtensionToolbarSlot } from '@/components/extensions/ExtensionToolbarSlot';
 import { useFileCommands } from '../toolbar/useFileCommands';
@@ -118,6 +119,17 @@ export function RibbonToolbar({ onShowShortcuts }: RibbonToolbarProps = {} as Ri
               </button>
             );
           })}
+        </div>
+
+        {/* Inline search — the very component the classic strip hosts, not
+            a ribbon copy of it, so `/` and ⌘F focus a field here too, the
+            n/N result cycle is reachable, and the recent-search popover
+            plus the "N filter rules active" badge (with its one-click
+            clear) exist in both styles. It sits in the tab strip rather
+            than inside a tab so it survives collapse and tab switches,
+            matching the classic strip's always-visible field. */}
+        <div className="ml-3">
+          <SearchInline />
         </div>
 
         <div className="flex-1" />

--- a/apps/viewer/src/components/viewer/ribbon/tabs/ViewTab.tsx
+++ b/apps/viewer/src/components/viewer/ribbon/tabs/ViewTab.tsx
@@ -8,10 +8,10 @@
  */
 
 import { Globe2, MousePointerClick, Move, PanelTop, } from 'lucide-react';
-import { TopView, BottomView, FrontView, BackView, LeftView, RightView, ZoomIn, ZoomOut, IsometricView, Orthographic, Viewpoint, SpaceMouse, Lighting, FitAll, RotateLeft, RotateRight } from '@/icons';
+import { Orthographic, Viewpoint, SpaceMouse, Lighting } from '@/icons';
 import { useViewerStore } from '@/store';
-import { goHomeFromStore } from '@/store/homeView';
 import { TOUR_ANCHORS, tourAnchor } from '@/lib/tours/anchors';
+import { useCameraCommands } from '../../toolbar/CameraCommands';
 import {
   RibbonGroup,
   RibbonGroupDivider,
@@ -21,7 +21,10 @@ import {
 } from '../primitives';
 
 export function ViewTab() {
-  const cameraCallbacks = useViewerStore((state) => state.cameraCallbacks);
+  // Camera, preset views and the 90° rotations come from the shared
+  // command list the classic toolbar also renders, so the two styles
+  // cannot host different camera commands (see toolbar/CameraCommands).
+  const cameraCommands = useCameraCommands();
   const projectionMode = useViewerStore((state) => state.projectionMode);
   const toggleProjectionMode = useViewerStore((state) => state.toggleProjectionMode);
   const setToolbarStyle = useViewerStore((state) => state.setToolbarStyle);
@@ -71,59 +74,52 @@ export function ViewTab() {
       <RibbonGroupDivider />
 
       <RibbonGroup label="Camera">
-        <RibbonLargeButton
-          icon={IsometricView}
-          label="Isometric"
-          tooltip="Home (isometric + reset visibility)"
-          shortcut="H"
-          onClick={goHomeFromStore}
-        />
-        <RibbonLargeButton
-          icon={ZoomIn}
-          label="Zoom in"
-          tooltip="Zoom In"
-          onClick={() => cameraCallbacks.zoomIn?.()}
-        />
-        <RibbonLargeButton
-          icon={ZoomOut}
-          label="Zoom out"
-          tooltip="Zoom Out"
-          onClick={() => cameraCallbacks.zoomOut?.()}
-        />
+        {cameraCommands
+          .filter((command) => command.group === 'camera')
+          .map((command) => (
+            <RibbonLargeButton
+              key={command.id}
+              icon={command.icon}
+              label={command.label}
+              tooltip={command.tooltip}
+              shortcut={command.shortcut}
+              onClick={command.run}
+            />
+          ))}
       </RibbonGroup>
 
       <RibbonGroupDivider />
 
       <RibbonGroup label="View">
-        <RibbonSmallStack>
-          <RibbonSmallButton icon={TopView} label="Top" shortcut="1" onClick={() => cameraCallbacks.setPresetView?.('top')} />
-          <RibbonSmallButton icon={FrontView} label="Front" shortcut="3" onClick={() => cameraCallbacks.setPresetView?.('front')} />
-          <RibbonSmallButton icon={LeftView} label="Left" shortcut="5" onClick={() => cameraCallbacks.setPresetView?.('left')} />
-        </RibbonSmallStack>
-        <RibbonSmallStack>
-          <RibbonSmallButton icon={BottomView} label="Bottom" shortcut="2" onClick={() => cameraCallbacks.setPresetView?.('bottom')} />
-          <RibbonSmallButton icon={BackView} label="Back" shortcut="4" onClick={() => cameraCallbacks.setPresetView?.('back')} />
-          <RibbonSmallButton icon={RightView} label="Right" shortcut="6" onClick={() => cameraCallbacks.setPresetView?.('right')} />
-        </RibbonSmallStack>
-        <RibbonLargeButton
-          icon={RotateLeft}
-          label="Rotate left"
-          tooltip="Rotate Left 90°"
-          onClick={() => cameraCallbacks.rotateLeft?.()}
-        />
-        <RibbonLargeButton
-          icon={RotateRight}
-          label="Rotate right"
-          tooltip="Rotate Right 90°"
-          onClick={() => cameraCallbacks.rotateRight?.()}
-        />
-        <RibbonLargeButton
-          icon={FitAll}
-          label="Fit all"
-          tooltip="Fit all in view"
-          shortcut="Z"
-          onClick={() => cameraCallbacks.fitAll?.()}
-        />
+        {/* The six axis views split across two small stacks in registry
+            order (top/front/left over bottom/back/right). */}
+        {[0, 1].map((column) => (
+          <RibbonSmallStack key={column}>
+            {cameraCommands
+              .filter((command) => command.group === 'preset')
+              .filter((_, index) => index % 2 === column)
+              .map((command) => (
+                <RibbonSmallButton
+                  key={command.id}
+                  icon={command.icon}
+                  label={command.label}
+                  shortcut={command.shortcut}
+                  onClick={command.run}
+                />
+              ))}
+          </RibbonSmallStack>
+        ))}
+        {cameraCommands
+          .filter((command) => command.group === 'rotate')
+          .map((command) => (
+            <RibbonLargeButton
+              key={command.id}
+              icon={command.icon}
+              label={command.label}
+              tooltip={command.tooltip}
+              onClick={command.run}
+            />
+          ))}
       </RibbonGroup>
 
       <RibbonGroupDivider />

--- a/apps/viewer/src/components/viewer/ribbon/tabs/ViewTab.tsx
+++ b/apps/viewer/src/components/viewer/ribbon/tabs/ViewTab.tsx
@@ -109,8 +109,10 @@ export function ViewTab() {
               ))}
           </RibbonSmallStack>
         ))}
+        {/* Everything that isn't a camera command or an axis view — the 90°
+            rotations today, and whatever the shared list grows next. */}
         {cameraCommands
-          .filter((command) => command.group === 'rotate')
+          .filter((command) => command.group !== 'camera' && command.group !== 'preset')
           .map((command) => (
             <RibbonLargeButton
               key={command.id}

--- a/apps/viewer/src/components/viewer/ribbon/tabs/ViewTab.tsx
+++ b/apps/viewer/src/components/viewer/ribbon/tabs/ViewTab.tsx
@@ -119,6 +119,7 @@ export function ViewTab() {
               icon={command.icon}
               label={command.label}
               tooltip={command.tooltip}
+              shortcut={command.shortcut}
               onClick={command.run}
             />
           ))}

--- a/apps/viewer/src/components/viewer/toolbar-parity.test.ts
+++ b/apps/viewer/src/components/viewer/toolbar-parity.test.ts
@@ -187,8 +187,16 @@ function closure(root: string): Set<string> {
       if (!resolved || seen.has(resolved) || isStopped(resolved)) return;
       if (clause !== undefined) {
         const names = boundNames(clause);
+        // `\b` treats `$` as a boundary, so it would match `foo` inside `$foo`
+        // and `foo$` — both valid identifiers that are NOT this binding. Use
+        // explicit identifier-character lookarounds instead, and escape the
+        // name so a binding containing regex metacharacters cannot alter the
+        // pattern.
         const used = names.length === 0
-          || names.some((name) => new RegExp(`\\b${name}\\b`).test(bodyOnly));
+          || names.some((name) => {
+            const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            return new RegExp(`(?<![$\\w])${escaped}(?![$\\w])`).test(bodyOnly);
+          });
         if (!used) return;
       }
       queue.push(resolved);

--- a/apps/viewer/src/components/viewer/toolbar-parity.test.ts
+++ b/apps/viewer/src/components/viewer/toolbar-parity.test.ts
@@ -20,12 +20,13 @@
  * symbol only one surface can reach is a capability only one surface can
  * offer — unless it is listed below with a reason.
  *
- * What it CANNOT catch: a control that renders but is dead (both surfaces
- * naming the same symbol proves reachability of state, not of behaviour),
- * a capability that lives in a symbol both surfaces already read for some
- * other reason, layout/discoverability differences, and anything reached
- * through a lib/ function rather than a store symbol. Those still need the
- * flow executed in both toolbars.
+ * What it CANNOT catch: a control that renders but is dead (reaching a
+ * symbol proves reachability of state, not of behaviour), a control behind
+ * a condition that is never true, a capability that lives in a symbol both
+ * surfaces already read for some other reason, layout/discoverability
+ * differences, and anything reached through a lib/ function rather than a
+ * store symbol. Those still need the flow executed in both toolbars — which
+ * is why every fix here was also clicked through in both styles.
  */
 
 import '@/test/setup-dom.js';
@@ -142,7 +143,36 @@ function isStopped(file: string): boolean {
     || rel.endsWith('.test.tsx');
 }
 
-/** Every component/hook file a toolbar reaches, transitively. */
+/** The identifiers an import clause binds (`X`, `{ a, b as c }`, `* as ns`). */
+function boundNames(clause: string): string[] {
+  const names: string[] = [];
+  const braces = clause.match(/\{([^}]*)\}/);
+  if (braces) {
+    for (const part of braces[1].split(',')) {
+      const name = part.trim().replace(/^type\s+/, '').split(/\s+as\s+/).pop()?.trim();
+      if (name) names.push(name);
+    }
+  }
+  const rest = clause.replace(/\{[^}]*\}/g, '');
+  const namespace = rest.match(/\*\s+as\s+([A-Za-z_$][\w$]*)/);
+  if (namespace) names.push(namespace[1]);
+  for (const part of rest.replace(/\*\s+as\s+[A-Za-z_$][\w$]*/g, '').split(',')) {
+    const name = part.trim().replace(/^type\s+/, '');
+    if (/^[A-Za-z_$][\w$]*$/.test(name)) names.push(name);
+  }
+  return names;
+}
+
+/**
+ * Every component/hook file a toolbar reaches, transitively.
+ *
+ * An import only counts as reach when the file actually USES what it
+ * imported. Without that check, deleting `<CameraCommandMenuItems />`
+ * from the classic menu while leaving its import line behind kept the
+ * whole camera closure "reachable" and this guard stayed green on a
+ * regression it exists to catch (verified: it did). Side-effect imports,
+ * dynamic `import()` and re-exports bind nothing, so they always count.
+ */
 function closure(root: string): Set<string> {
   const seen = new Set<string>();
   const queue = [path.join(SRC, root)];
@@ -151,12 +181,23 @@ function closure(root: string): Set<string> {
     if (seen.has(file)) continue;
     seen.add(file);
     const source = readFileSync(file, 'utf8');
-    const importRe = /(?:from\s+|import\s*\(\s*)['"]([^'"]+)['"]/g;
+    const bodyOnly = source.replace(/^\s*import\s[^;]*?from\s*['"][^'"]+['"];?/gm, '');
+    const enqueue = (spec: string, clause?: string) => {
+      const resolved = resolveImport(spec, file);
+      if (!resolved || seen.has(resolved) || isStopped(resolved)) return;
+      if (clause !== undefined) {
+        const names = boundNames(clause);
+        const used = names.length === 0
+          || names.some((name) => new RegExp(`\\b${name}\\b`).test(bodyOnly));
+        if (!used) return;
+      }
+      queue.push(resolved);
+    };
+    const bindingRe = /import\s+([^;'"]*?)\s+from\s*['"]([^'"]+)['"]/g;
     let match: RegExpExecArray | null;
-    while ((match = importRe.exec(source)) !== null) {
-      const resolved = resolveImport(match[1], file);
-      if (resolved && !seen.has(resolved) && !isStopped(resolved)) queue.push(resolved);
-    }
+    while ((match = bindingRe.exec(source)) !== null) enqueue(match[2], match[1]);
+    const bareRe = /(?:export\s+[^;]*?\s+from\s*|import\s*\(\s*|^\s*import\s*)['"]([^'"]+)['"]/gm;
+    while ((match = bareRe.exec(source)) !== null) enqueue(match[1]);
   }
   return seen;
 }

--- a/apps/viewer/src/components/viewer/toolbar-parity.test.ts
+++ b/apps/viewer/src/components/viewer/toolbar-parity.test.ts
@@ -1,0 +1,254 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Toolbar parity drift guard.
+ *
+ * The viewer ships TWO toolbars — the classic single strip (`MainToolbar`)
+ * and the tabbed `RibbonToolbar` — and a user sits behind exactly one of
+ * them (`uiSlice.toolbarStyle`, switchable from both). A capability wired
+ * into only one is therefore a silent loss for half the users, and nothing
+ * else in CI notices: both surfaces typecheck, both render, both pass their
+ * own tests. Three such gaps shipped unnoticed before this guard existed —
+ * camera rotate-90° was ribbon-only, the desktop zoom cluster was hidden
+ * from classic as a side effect, and inline search was classic-only.
+ *
+ * The oracle: walk each toolbar's component/hook closure (its own tree
+ * plus every shared hook and menu body it pulls in), collect the viewer-store
+ * symbols and camera commands each one reaches, and diff the two sets. A
+ * symbol only one surface can reach is a capability only one surface can
+ * offer — unless it is listed below with a reason.
+ *
+ * What it CANNOT catch: a control that renders but is dead (both surfaces
+ * naming the same symbol proves reachability of state, not of behaviour),
+ * a capability that lives in a symbol both surfaces already read for some
+ * other reason, layout/discoverability differences, and anything reached
+ * through a lib/ function rather than a store symbol. Those still need the
+ * flow executed in both toolbars.
+ */
+
+import '@/test/setup-dom.js';
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { useViewerStore } from '@/store/index.js';
+
+const SRC = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+type Surface = 'classic' | 'ribbon';
+
+const ROOTS: Record<Surface, string> = {
+  classic: 'components/viewer/MainToolbar.tsx',
+  ribbon: 'components/viewer/ribbon/RibbonToolbar.tsx',
+};
+
+/**
+ * Directories the walk does not descend into. `components/ui` is design-system
+ * plumbing, `lib`/`store`/`icons` are shared infrastructure rather than command
+ * surfaces — including them would drown the diff in symbols neither toolbar
+ * chooses to host.
+ */
+const STOP_PREFIXES = ['components/ui/', 'lib/', 'store/', 'icons/', 'sdk/'];
+
+/**
+ * Every entry is a capability ONE toolbar deliberately does not offer.
+ * Adding one is a design decision: say why here, or wire the capability
+ * into both surfaces instead.
+ */
+const ALLOWLIST: { surface: Surface; symbol: string; reason: string }[] = [
+  {
+    surface: 'ribbon',
+    symbol: 'ribbonTab',
+    reason: 'Tabs are the ribbon\'s own geography; the classic strip has no tabs to select.',
+  },
+  {
+    surface: 'ribbon',
+    symbol: 'setRibbonTab',
+    reason: 'Same: only the ribbon has a tab to switch, including via the contextual-tab driver.',
+  },
+  {
+    surface: 'ribbon',
+    symbol: 'ribbonCollapsed',
+    reason: 'Collapse/expand of the command band — the classic strip is a single strip with nothing to collapse.',
+  },
+  {
+    surface: 'ribbon',
+    symbol: 'setRibbonCollapsed',
+    reason: 'Same as ribbonCollapsed.',
+  },
+  {
+    surface: 'ribbon',
+    symbol: 'ribbonContextualTabs',
+    reason: '"Follow work" makes the active tab follow the working context; meaningless without tabs.',
+  },
+  {
+    surface: 'ribbon',
+    symbol: 'setRibbonContextualTabs',
+    reason: 'Same as ribbonContextualTabs.',
+  },
+  {
+    surface: 'ribbon',
+    symbol: 'isMobile',
+    reason: 'RibbonSwitchNotice suppresses its one-time "the toolbar changed" line on mobile, where neither desktop toolbar renders at all (ViewerLayout picks MobileToolbar).',
+  },
+  {
+    surface: 'ribbon',
+    symbol: 'hierarchyMode',
+    reason: 'The Elements tab mirrors the hierarchy panel\'s grouping switch as a ribbon shortcut. The capability itself lives in HierarchyPanel, which both toolbar styles show, so classic users are not missing it.',
+  },
+  {
+    surface: 'ribbon',
+    symbol: 'setHierarchyMode',
+    reason: 'Same shortcut as hierarchyMode.',
+  },
+  {
+    surface: 'ribbon',
+    symbol: 'setPanelShownInSidebar',
+    reason: 'Used only to reveal the hierarchy panel when that ribbon shortcut is pressed.',
+  },
+  {
+    surface: 'ribbon',
+    symbol: 'setLeftPanelCollapsed',
+    reason: 'Same: un-collapses the left panel so the hierarchy shortcut has somewhere to land.',
+  },
+];
+
+function resolveImport(spec: string, fromFile: string): string | null {
+  let base: string;
+  if (spec.startsWith('@/')) base = path.join(SRC, spec.slice(2));
+  else if (spec.startsWith('.')) base = path.resolve(path.dirname(fromFile), spec);
+  else return null;
+  // `@/store/index.js` style specifiers resolve to the .ts source here.
+  const withoutJs = base.endsWith('.js') ? base.slice(0, -3) : base;
+  const candidates = [
+    withoutJs + '.tsx',
+    withoutJs + '.ts',
+    path.join(withoutJs, 'index.tsx'),
+    path.join(withoutJs, 'index.ts'),
+  ];
+  for (const candidate of candidates) {
+    if (existsSync(candidate) && statSync(candidate).isFile()) return candidate;
+  }
+  return null;
+}
+
+function isStopped(file: string): boolean {
+  const rel = path.relative(SRC, file);
+  return STOP_PREFIXES.some((prefix) => rel.startsWith(prefix))
+    || rel.endsWith('.test.ts')
+    || rel.endsWith('.test.tsx');
+}
+
+/** Every component/hook file a toolbar reaches, transitively. */
+function closure(root: string): Set<string> {
+  const seen = new Set<string>();
+  const queue = [path.join(SRC, root)];
+  while (queue.length > 0) {
+    const file = queue.shift()!;
+    if (seen.has(file)) continue;
+    seen.add(file);
+    const source = readFileSync(file, 'utf8');
+    const importRe = /(?:from\s+|import\s*\(\s*)['"]([^'"]+)['"]/g;
+    let match: RegExpExecArray | null;
+    while ((match = importRe.exec(source)) !== null) {
+      const resolved = resolveImport(match[1], file);
+      if (resolved && !seen.has(resolved) && !isStopped(resolved)) queue.push(resolved);
+    }
+  }
+  return seen;
+}
+
+const STORE_KEYS = new Set(Object.keys(useViewerStore.getState()));
+
+/**
+ * Capabilities a file reaches: viewer-store symbols (`s.x` / `state.x`,
+ * validated against the live store so another store's selector — the tour
+ * store's `s.status`, say — cannot masquerade as one) and camera commands
+ * (`cameraCallbacks.x`, plus the shared command list's own `callbacks.x`
+ * dispatch), namespaced so the two can't collide.
+ */
+function capabilities(files: Iterable<string>): Map<string, Set<string>> {
+  const found = new Map<string, Set<string>>();
+  const add = (symbol: string, file: string) => {
+    if (!found.has(symbol)) found.set(symbol, new Set());
+    found.get(symbol)!.add(path.relative(SRC, file));
+  };
+  for (const file of files) {
+    const source = readFileSync(file, 'utf8');
+    const storeRe = /\b(?:s|state|store)\.([A-Za-z_$][\w$]*)/g;
+    let match: RegExpExecArray | null;
+    while ((match = storeRe.exec(source)) !== null) {
+      if (STORE_KEYS.has(match[1])) add(match[1], file);
+    }
+    const cameraRe = /\b(?:cameraCallbacks|callbacks)\.([A-Za-z_$][\w$]*)/g;
+    while ((match = cameraRe.exec(source)) !== null) add(`camera:${match[1]}`, file);
+  }
+  return found;
+}
+
+const surfaces = {
+  classic: capabilities(closure(ROOTS.classic)),
+  ribbon: capabilities(closure(ROOTS.ribbon)),
+} satisfies Record<Surface, Map<string, Set<string>>>;
+
+function exclusiveTo(surface: Surface): string[] {
+  const other: Surface = surface === 'classic' ? 'ribbon' : 'classic';
+  return [...surfaces[surface].keys()].filter((symbol) => !surfaces[other].has(symbol)).sort();
+}
+
+function allowed(surface: Surface): Set<string> {
+  return new Set(ALLOWLIST.filter((entry) => entry.surface === surface).map((entry) => entry.symbol));
+}
+
+function describeSymbol(surface: Surface, symbol: string): string {
+  return `${symbol} (only in ${[...(surfaces[surface].get(symbol) ?? [])].join(', ')})`;
+}
+
+describe('toolbar parity between the classic strip and the ribbon', () => {
+  it('walks a non-trivial closure for both surfaces', () => {
+    // Guards the guard: a broken resolver would silently compare two empty
+    // sets and pass forever.
+    assert.ok(surfaces.classic.size > 50, `classic reached only ${surfaces.classic.size} symbols`);
+    assert.ok(surfaces.ribbon.size > 50, `ribbon reached only ${surfaces.ribbon.size} symbols`);
+  });
+
+  it('hosts no capability in the classic strip that the ribbon cannot reach', () => {
+    const unexplained = exclusiveTo('classic').filter((symbol) => !allowed('classic').has(symbol));
+    assert.deepEqual(
+      unexplained.map((symbol) => describeSymbol('classic', symbol)),
+      [],
+      'classic-only capabilities: wire them into the ribbon too, or add an ALLOWLIST entry saying why not',
+    );
+  });
+
+  it('hosts no capability in the ribbon that the classic strip cannot reach', () => {
+    const unexplained = exclusiveTo('ribbon').filter((symbol) => !allowed('ribbon').has(symbol));
+    assert.deepEqual(
+      unexplained.map((symbol) => describeSymbol('ribbon', symbol)),
+      [],
+      'ribbon-only capabilities: wire them into the classic strip too, or add an ALLOWLIST entry saying why not',
+    );
+  });
+
+  it('carries no stale allowlist entry', () => {
+    const stale = ALLOWLIST
+      .filter((entry) => !exclusiveTo(entry.surface).includes(entry.symbol))
+      .map((entry) => `${entry.surface}:${entry.symbol}`);
+    assert.deepEqual(stale, [], 'these are no longer one-sided — delete the entry with its reason');
+  });
+
+  it('reaches the same camera commands from both surfaces', () => {
+    // The camera set is the one this guard was written for, so it is asserted
+    // on its own too: an exclusive here can never be right, since both styles
+    // render the same shared command list (toolbar/CameraCommands).
+    const cameraOf = (surface: Surface) =>
+      [...surfaces[surface].keys()].filter((symbol) => symbol.startsWith('camera:')).sort();
+    assert.deepEqual(cameraOf('classic'), cameraOf('ribbon'));
+    for (const id of ['camera:zoomIn', 'camera:zoomOut', 'camera:rotateLeft', 'camera:rotateRight']) {
+      assert.ok(surfaces.classic.has(id), `${id} unreachable from the classic strip`);
+    }
+  });
+});

--- a/apps/viewer/src/components/viewer/toolbar-parity.test.ts
+++ b/apps/viewer/src/components/viewer/toolbar-parity.test.ts
@@ -20,6 +20,17 @@
  * symbol only one surface can reach is a capability only one surface can
  * offer — unless it is listed below with a reason.
  *
+ * Everything the walk reads comes from the TypeScript AST, never from raw
+ * text. Raw text was this guard's own recurring defect, three layers deep:
+ * an import counted as reach whether or not the file used it; then `\b`
+ * matched `foo` inside `$foo`; then a name left behind in a COMMENT or a
+ * string still counted as a use — so commenting out `<CameraCommandMenuItems />`
+ * while leaving the text in place kept every camera capability "reachable"
+ * and the guard stayed green on exactly the regression it exists to catch.
+ * A parse has no such layers: a comment is not an identifier, and the same
+ * parse decides both halves of the oracle (which imports count as reach, and
+ * which store/camera members a file actually reads).
+ *
  * What it CANNOT catch: a control that renders but is dead (reaching a
  * symbol proves reachability of state, not of behaviour), a control behind
  * a condition that is never true, a capability that lives in a symbol both
@@ -35,6 +46,7 @@ import assert from 'node:assert/strict';
 import { existsSync, readFileSync, statSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
 import { useViewerStore } from '@/store/index.js';
 
 const SRC = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
@@ -143,35 +155,137 @@ function isStopped(file: string): boolean {
     || rel.endsWith('.test.tsx');
 }
 
-/** The identifiers an import clause binds (`X`, `{ a, b as c }`, `* as ns`). */
-function boundNames(clause: string): string[] {
+/** Identifiers a `bim`-style holder is read through, per capability family. */
+const STORE_HOLDERS = new Set(['s', 'state', 'store']);
+const CAMERA_HOLDERS = new Set(['cameraCallbacks', 'callbacks']);
+
+interface ModuleFacts {
+  /**
+   * One entry per module edge out of this file. `names === null` means the
+   * form binds nothing the file could go on to use — a side-effect import,
+   * a dynamic `import()`, a re-export — so it always counts as reach.
+   */
+  edges: { spec: string; names: string[] | null }[];
+  /** Identifiers this file REFERENCES: not its import clauses, not the member
+   *  half of a property access, not a declared property name. */
+  referenced: Set<string>;
+  /** Member names read off `s` / `state` / `store`. */
+  storeMembers: Set<string>;
+  /** Member names read off `cameraCallbacks` / `callbacks`. */
+  cameraMembers: Set<string>;
+}
+
+/** The names an import clause binds (`X`, `* as ns`, `{ a, b as c }`). */
+function importedNames(clause: ts.ImportClause | undefined): string[] | null {
+  if (!clause) return null;
   const names: string[] = [];
-  const braces = clause.match(/\{([^}]*)\}/);
-  if (braces) {
-    for (const part of braces[1].split(',')) {
-      const name = part.trim().replace(/^type\s+/, '').split(/\s+as\s+/).pop()?.trim();
-      if (name) names.push(name);
+  if (clause.name) names.push(clause.name.text);
+  const bindings = clause.namedBindings;
+  if (bindings) {
+    if (ts.isNamespaceImport(bindings)) names.push(bindings.name.text);
+    else for (const element of bindings.elements) names.push(element.name.text);
+  }
+  return names.length > 0 ? names : null;
+}
+
+/**
+ * Whether an identifier occurrence is a REFERENCE to a binding, rather than a
+ * member name that merely spells the same word. `foo` in `other.foo`,
+ * `{ foo: 1 }` or `interface X { foo: string }` must not make an imported
+ * `foo` look used.
+ */
+function isReference(node: ts.Identifier): boolean {
+  const parent = node.parent as ts.Node | undefined;
+  if (!parent) return true;
+  const named = parent as { name?: ts.Node };
+  if (ts.isPropertyAccessExpression(parent) && parent.name === node) return false;
+  if (ts.isQualifiedName(parent) && parent.right === node) return false;
+  if (
+    (ts.isPropertyAssignment(parent)
+      || ts.isPropertySignature(parent)
+      || ts.isPropertyDeclaration(parent)
+      || ts.isMethodSignature(parent)
+      || ts.isMethodDeclaration(parent)
+      || ts.isEnumMember(parent)
+      || ts.isJsxAttribute(parent))
+    && named.name === node
+  ) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Everything the oracle needs from one file, read once off its AST.
+ *
+ * Parsing is what makes the two halves below honest. The reachability half
+ * asks whether an imported binding is REFERENCED, so a name surviving only in
+ * a comment or a string literal no longer keeps a module in the closure; the
+ * capability half reads real property accesses, so `s.foo` written in prose
+ * above a function no longer counts as touching `foo`.
+ */
+const factsCache = new Map<string, ModuleFacts>();
+
+function facts(file: string): ModuleFacts {
+  const cached = factsCache.get(file);
+  if (cached) return cached;
+
+  const source = ts.createSourceFile(
+    file,
+    readFileSync(file, 'utf8'),
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    file.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+  );
+  const edges: ModuleFacts['edges'] = [];
+  const referenced = new Set<string>();
+  const storeMembers = new Set<string>();
+  const cameraMembers = new Set<string>();
+
+  const specifierOf = (node: ts.Node | undefined): string | null =>
+    node !== undefined && ts.isStringLiteralLike(node) ? node.text : null;
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isImportDeclaration(node)) {
+      const spec = specifierOf(node.moduleSpecifier);
+      if (spec !== null) edges.push({ spec, names: importedNames(node.importClause) });
+      // An import clause names bindings; it does not use them.
+      return;
     }
-  }
-  const rest = clause.replace(/\{[^}]*\}/g, '');
-  const namespace = rest.match(/\*\s+as\s+([A-Za-z_$][\w$]*)/);
-  if (namespace) names.push(namespace[1]);
-  for (const part of rest.replace(/\*\s+as\s+[A-Za-z_$][\w$]*/g, '').split(',')) {
-    const name = part.trim().replace(/^type\s+/, '');
-    if (/^[A-Za-z_$][\w$]*$/.test(name)) names.push(name);
-  }
-  return names;
+    if (ts.isExportDeclaration(node) && node.moduleSpecifier) {
+      const spec = specifierOf(node.moduleSpecifier);
+      if (spec !== null) edges.push({ spec, names: null });
+      return;
+    }
+    if (ts.isCallExpression(node) && node.expression.kind === ts.SyntaxKind.ImportKeyword) {
+      const spec = specifierOf(node.arguments[0]);
+      if (spec !== null) edges.push({ spec, names: null });
+      // Falls through: the rest of the call is ordinary code.
+    }
+    if (ts.isPropertyAccessExpression(node) && ts.isIdentifier(node.expression)) {
+      const holder = node.expression.text;
+      if (STORE_HOLDERS.has(holder)) storeMembers.add(node.name.text);
+      if (CAMERA_HOLDERS.has(holder)) cameraMembers.add(node.name.text);
+    }
+    if (ts.isIdentifier(node) && isReference(node)) referenced.add(node.text);
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+
+  const result: ModuleFacts = { edges, referenced, storeMembers, cameraMembers };
+  factsCache.set(file, result);
+  return result;
 }
 
 /**
  * Every component/hook file a toolbar reaches, transitively.
  *
- * An import only counts as reach when the file actually USES what it
- * imported. Without that check, deleting `<CameraCommandMenuItems />`
- * from the classic menu while leaving its import line behind kept the
- * whole camera closure "reachable" and this guard stayed green on a
- * regression it exists to catch (verified: it did). Side-effect imports,
- * dynamic `import()` and re-exports bind nothing, so they always count.
+ * An import only counts as reach when the file actually REFERENCES what it
+ * imported. Without that check, deleting `<CameraCommandMenuItems />` from the
+ * classic menu while leaving its import line behind kept the whole camera
+ * closure "reachable" and this guard stayed green on a regression it exists to
+ * catch (verified: it did) — and while the import line is gone, the same hole
+ * reopens for a usage left behind as a comment unless the check reads the AST.
  */
 function closure(root: string): Set<string> {
   const seen = new Set<string>();
@@ -180,32 +294,13 @@ function closure(root: string): Set<string> {
     const file = queue.shift()!;
     if (seen.has(file)) continue;
     seen.add(file);
-    const source = readFileSync(file, 'utf8');
-    const bodyOnly = source.replace(/^\s*import\s[^;]*?from\s*['"][^'"]+['"];?/gm, '');
-    const enqueue = (spec: string, clause?: string) => {
-      const resolved = resolveImport(spec, file);
-      if (!resolved || seen.has(resolved) || isStopped(resolved)) return;
-      if (clause !== undefined) {
-        const names = boundNames(clause);
-        // `\b` treats `$` as a boundary, so it would match `foo` inside `$foo`
-        // and `foo$` — both valid identifiers that are NOT this binding. Use
-        // explicit identifier-character lookarounds instead, and escape the
-        // name so a binding containing regex metacharacters cannot alter the
-        // pattern.
-        const used = names.length === 0
-          || names.some((name) => {
-            const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-            return new RegExp(`(?<![$\\w])${escaped}(?![$\\w])`).test(bodyOnly);
-          });
-        if (!used) return;
-      }
+    const { edges, referenced } = facts(file);
+    for (const edge of edges) {
+      const resolved = resolveImport(edge.spec, file);
+      if (!resolved || seen.has(resolved) || isStopped(resolved)) continue;
+      if (edge.names !== null && !edge.names.some((name) => referenced.has(name))) continue;
       queue.push(resolved);
-    };
-    const bindingRe = /import\s+([^;'"]*?)\s+from\s*['"]([^'"]+)['"]/g;
-    let match: RegExpExecArray | null;
-    while ((match = bindingRe.exec(source)) !== null) enqueue(match[2], match[1]);
-    const bareRe = /(?:export\s+[^;]*?\s+from\s*|import\s*\(\s*|^\s*import\s*)['"]([^'"]+)['"]/gm;
-    while ((match = bareRe.exec(source)) !== null) enqueue(match[1]);
+    }
   }
   return seen;
 }
@@ -226,14 +321,9 @@ function capabilities(files: Iterable<string>): Map<string, Set<string>> {
     found.get(symbol)!.add(path.relative(SRC, file));
   };
   for (const file of files) {
-    const source = readFileSync(file, 'utf8');
-    const storeRe = /\b(?:s|state|store)\.([A-Za-z_$][\w$]*)/g;
-    let match: RegExpExecArray | null;
-    while ((match = storeRe.exec(source)) !== null) {
-      if (STORE_KEYS.has(match[1])) add(match[1], file);
-    }
-    const cameraRe = /\b(?:cameraCallbacks|callbacks)\.([A-Za-z_$][\w$]*)/g;
-    while ((match = cameraRe.exec(source)) !== null) add(`camera:${match[1]}`, file);
+    const { storeMembers, cameraMembers } = facts(file);
+    for (const name of storeMembers) if (STORE_KEYS.has(name)) add(name, file);
+    for (const name of cameraMembers) add(`camera:${name}`, file);
   }
   return found;
 }

--- a/apps/viewer/src/components/viewer/toolbar/CameraCommands.tsx
+++ b/apps/viewer/src/components/viewer/toolbar/CameraCommands.tsx
@@ -1,0 +1,265 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The camera command set — Home, zoom, the six preset views and the 90°
+ * rotations — as ONE ordered list shared by the classic toolbar and the
+ * ribbon, so neither style can host a camera command the other lacks.
+ *
+ * This exists because they did fork: `rotateLeft`/`rotateRight` landed
+ * with a single call site in the ribbon's View tab (#1829), leaving the
+ * classic toolbar with no way to rotate the camera at all, and the same
+ * change hid the viewport's desktop zoom cluster for BOTH styles on the
+ * (ribbon-only) grounds that "the ribbon owns these controls". A list is
+ * the fix that scales: a command added here shows up in both surfaces
+ * without anyone remembering to wire the second one.
+ *
+ * Each surface still renders in its own idiom — the ribbon as labeled
+ * groups of large/small buttons, the classic strip as its View-options
+ * dropdown (`CameraCommandMenuItems` below) — but the *set* is single
+ * sourced. Same pattern as `ClassVisibilityMenu`.
+ */
+
+import React, { useMemo } from 'react';
+import {
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+} from '@/components/ui/dropdown-menu';
+import {
+  TopView,
+  BottomView,
+  FrontView,
+  BackView,
+  LeftView,
+  RightView,
+  IsometricView,
+  ZoomIn,
+  ZoomOut,
+  FitAll,
+  RotateLeft,
+  RotateRight,
+} from '@/icons';
+import { useViewerStore } from '@/store';
+import { goHomeFromStore } from '@/store/homeView';
+import type { CameraCallbacks } from '@/store/types';
+
+export type CameraCommandId =
+  | 'home'
+  | 'zoomIn'
+  | 'zoomOut'
+  | 'fitAll'
+  | 'viewTop'
+  | 'viewBottom'
+  | 'viewFront'
+  | 'viewBack'
+  | 'viewLeft'
+  | 'viewRight'
+  | 'rotateLeft'
+  | 'rotateRight';
+
+/**
+ * Layout hint, not a capability boundary: every surface renders every
+ * group. `preset` is the six axis views (rendered as a compact block),
+ * `rotate` the two 90° steps.
+ */
+export type CameraCommandGroup = 'camera' | 'preset' | 'rotate';
+
+export interface CameraCommand {
+  id: CameraCommandId;
+  /** Short button caption. */
+  label: string;
+  /** Longer tooltip / menu-item description when the label isn't the whole story. */
+  tooltip: string;
+  /** Keyboard shortcut, when one exists (see `useKeyboardShortcuts`). */
+  shortcut?: string;
+  icon: React.ElementType;
+  group: CameraCommandGroup;
+  /**
+   * True when users press it repeatedly (zoom, rotate). Menu surfaces keep
+   * themselves open on select for these; a menu that closes after one 90°
+   * step makes a half-turn a four-click errand.
+   */
+  repeatable?: boolean;
+  run: () => void;
+}
+
+export interface CameraCommandContext {
+  callbacks: CameraCallbacks;
+  /** Home is more than a camera pose (it also resets visibility), so it's injected. */
+  goHome: () => void;
+}
+
+/**
+ * Pure builder — the hook below binds it to the live store. Kept separate
+ * so the command set and its dispatch can be asserted without a renderer.
+ */
+export function buildCameraCommands({ callbacks, goHome }: CameraCommandContext): CameraCommand[] {
+  return [
+    {
+      id: 'home',
+      label: 'Isometric',
+      tooltip: 'Home (isometric + reset visibility)',
+      shortcut: 'H',
+      icon: IsometricView,
+      group: 'camera',
+      run: () => goHome(),
+    },
+    {
+      id: 'zoomIn',
+      label: 'Zoom in',
+      tooltip: 'Zoom in',
+      icon: ZoomIn,
+      group: 'camera',
+      repeatable: true,
+      run: () => callbacks.zoomIn?.(),
+    },
+    {
+      id: 'zoomOut',
+      label: 'Zoom out',
+      tooltip: 'Zoom out',
+      icon: ZoomOut,
+      group: 'camera',
+      repeatable: true,
+      run: () => callbacks.zoomOut?.(),
+    },
+    {
+      id: 'fitAll',
+      label: 'Fit all',
+      tooltip: 'Fit all in view',
+      shortcut: 'Z',
+      icon: FitAll,
+      group: 'camera',
+      run: () => callbacks.fitAll?.(),
+    },
+    {
+      id: 'viewTop',
+      label: 'Top',
+      tooltip: 'Top view',
+      shortcut: '1',
+      icon: TopView,
+      group: 'preset',
+      run: () => callbacks.setPresetView?.('top'),
+    },
+    {
+      id: 'viewBottom',
+      label: 'Bottom',
+      tooltip: 'Bottom view',
+      shortcut: '2',
+      icon: BottomView,
+      group: 'preset',
+      run: () => callbacks.setPresetView?.('bottom'),
+    },
+    {
+      id: 'viewFront',
+      label: 'Front',
+      tooltip: 'Front view',
+      shortcut: '3',
+      icon: FrontView,
+      group: 'preset',
+      run: () => callbacks.setPresetView?.('front'),
+    },
+    {
+      id: 'viewBack',
+      label: 'Back',
+      tooltip: 'Back view',
+      shortcut: '4',
+      icon: BackView,
+      group: 'preset',
+      run: () => callbacks.setPresetView?.('back'),
+    },
+    {
+      id: 'viewLeft',
+      label: 'Left',
+      tooltip: 'Left view',
+      shortcut: '5',
+      icon: LeftView,
+      group: 'preset',
+      run: () => callbacks.setPresetView?.('left'),
+    },
+    {
+      id: 'viewRight',
+      label: 'Right',
+      tooltip: 'Right view',
+      shortcut: '6',
+      icon: RightView,
+      group: 'preset',
+      run: () => callbacks.setPresetView?.('right'),
+    },
+    {
+      id: 'rotateLeft',
+      label: 'Rotate left',
+      tooltip: 'Rotate left 90°',
+      icon: RotateLeft,
+      group: 'rotate',
+      repeatable: true,
+      run: () => callbacks.rotateLeft?.(),
+    },
+    {
+      id: 'rotateRight',
+      label: 'Rotate right',
+      tooltip: 'Rotate right 90°',
+      icon: RotateRight,
+      group: 'rotate',
+      repeatable: true,
+      run: () => callbacks.rotateRight?.(),
+    },
+  ];
+}
+
+/** The command set bound to the live camera. */
+export function useCameraCommands(): CameraCommand[] {
+  const callbacks = useViewerStore((s) => s.cameraCallbacks);
+  return useMemo(
+    () => buildCameraCommands({ callbacks, goHome: goHomeFromStore }),
+    [callbacks],
+  );
+}
+
+const GROUP_LABEL: Record<CameraCommandGroup, string> = {
+  camera: 'Camera',
+  preset: 'Preset views',
+  rotate: 'Rotate',
+};
+
+/**
+ * The camera block of the classic toolbar's View-options dropdown.
+ * Repeatable commands keep the menu open so zoom/rotate can be pressed
+ * several times without re-opening it.
+ */
+export function CameraCommandMenuItems() {
+  const commands = useCameraCommands();
+  const groups: CameraCommandGroup[] = ['camera', 'preset', 'rotate'];
+  return (
+    <>
+      {groups.map((group, index) => (
+        <React.Fragment key={group}>
+          {index > 0 && <DropdownMenuSeparator />}
+          <DropdownMenuLabel className="text-[10px] uppercase tracking-wide text-muted-foreground">
+            {GROUP_LABEL[group]}
+          </DropdownMenuLabel>
+          {commands
+            .filter((command) => command.group === group)
+            .map((command) => {
+              const Icon = command.icon;
+              return (
+                <DropdownMenuItem
+                  key={command.id}
+                  onSelect={(event) => {
+                    if (command.repeatable) event.preventDefault();
+                    command.run();
+                  }}
+                >
+                  <Icon className="h-4 w-4 mr-2" /> {command.label}
+                  {command.shortcut && (
+                    <span className="ml-auto text-xs opacity-60">{command.shortcut}</span>
+                  )}
+                </DropdownMenuItem>
+              );
+            })}
+        </React.Fragment>
+      ))}
+    </>
+  );
+}

--- a/apps/viewer/src/components/viewer/toolbar/CameraCommands.tsx
+++ b/apps/viewer/src/components/viewer/toolbar/CameraCommands.tsx
@@ -3,22 +3,13 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
- * The camera command set — Home, zoom, the six preset views and the 90°
- * rotations — as ONE ordered list shared by the classic toolbar and the
- * ribbon, so neither style can host a camera command the other lacks.
- *
- * This exists because they did fork: `rotateLeft`/`rotateRight` landed
- * with a single call site in the ribbon's View tab (#1829), leaving the
- * classic toolbar with no way to rotate the camera at all, and the same
- * change hid the viewport's desktop zoom cluster for BOTH styles on the
- * (ribbon-only) grounds that "the ribbon owns these controls". A list is
- * the fix that scales: a command added here shows up in both surfaces
- * without anyone remembering to wire the second one.
- *
- * Each surface still renders in its own idiom — the ribbon as labeled
- * groups of large/small buttons, the classic strip as its View-options
- * dropdown (`CameraCommandMenuItems` below) — but the *set* is single
- * sourced. Same pattern as `ClassVisibilityMenu`.
+ * Rendering half of the shared camera command set (`camera-commands.ts`):
+ * the icon per command, the hook that binds the list to the live camera,
+ * and the classic toolbar's menu body. Each surface still renders in its
+ * own idiom — the ribbon as labeled groups of buttons, the classic strip
+ * as the block below inside its View-options dropdown — but the *set* is
+ * single sourced, the same way `ClassVisibilityMenu` shares one dropdown
+ * body between both styles.
  */
 
 import React, { useMemo } from 'react';
@@ -43,176 +34,39 @@ import {
 } from '@/icons';
 import { useViewerStore } from '@/store';
 import { goHomeFromStore } from '@/store/homeView';
-import type { CameraCallbacks } from '@/store/types';
+import {
+  buildCameraCommands,
+  type CameraCommand,
+  type CameraCommandGroup,
+  type CameraCommandId,
+} from './camera-commands';
 
-export type CameraCommandId =
-  | 'home'
-  | 'zoomIn'
-  | 'zoomOut'
-  | 'fitAll'
-  | 'viewTop'
-  | 'viewBottom'
-  | 'viewFront'
-  | 'viewBack'
-  | 'viewLeft'
-  | 'viewRight'
-  | 'rotateLeft'
-  | 'rotateRight';
+/** Exhaustive by type: a new command id doesn't compile until it has an icon. */
+const CAMERA_COMMAND_ICONS: Record<CameraCommandId, React.ElementType> = {
+  home: IsometricView,
+  zoomIn: ZoomIn,
+  zoomOut: ZoomOut,
+  fitAll: FitAll,
+  viewTop: TopView,
+  viewBottom: BottomView,
+  viewFront: FrontView,
+  viewBack: BackView,
+  viewLeft: LeftView,
+  viewRight: RightView,
+  rotateLeft: RotateLeft,
+  rotateRight: RotateRight,
+};
 
-/**
- * Layout hint, not a capability boundary: every surface renders every
- * group. `preset` is the six axis views (rendered as a compact block),
- * `rotate` the two 90° steps.
- */
-export type CameraCommandGroup = 'camera' | 'preset' | 'rotate';
-
-export interface CameraCommand {
-  id: CameraCommandId;
-  /** Short button caption. */
-  label: string;
-  /** Longer tooltip / menu-item description when the label isn't the whole story. */
-  tooltip: string;
-  /** Keyboard shortcut, when one exists (see `useKeyboardShortcuts`). */
-  shortcut?: string;
+export interface RenderableCameraCommand extends CameraCommand {
   icon: React.ElementType;
-  group: CameraCommandGroup;
-  /**
-   * True when users press it repeatedly (zoom, rotate). Menu surfaces keep
-   * themselves open on select for these; a menu that closes after one 90°
-   * step makes a half-turn a four-click errand.
-   */
-  repeatable?: boolean;
-  run: () => void;
 }
 
-export interface CameraCommandContext {
-  callbacks: CameraCallbacks;
-  /** Home is more than a camera pose (it also resets visibility), so it's injected. */
-  goHome: () => void;
-}
-
-/**
- * Pure builder — the hook below binds it to the live store. Kept separate
- * so the command set and its dispatch can be asserted without a renderer.
- */
-export function buildCameraCommands({ callbacks, goHome }: CameraCommandContext): CameraCommand[] {
-  return [
-    {
-      id: 'home',
-      label: 'Isometric',
-      tooltip: 'Home (isometric + reset visibility)',
-      shortcut: 'H',
-      icon: IsometricView,
-      group: 'camera',
-      run: () => goHome(),
-    },
-    {
-      id: 'zoomIn',
-      label: 'Zoom in',
-      tooltip: 'Zoom in',
-      icon: ZoomIn,
-      group: 'camera',
-      repeatable: true,
-      run: () => callbacks.zoomIn?.(),
-    },
-    {
-      id: 'zoomOut',
-      label: 'Zoom out',
-      tooltip: 'Zoom out',
-      icon: ZoomOut,
-      group: 'camera',
-      repeatable: true,
-      run: () => callbacks.zoomOut?.(),
-    },
-    {
-      id: 'fitAll',
-      label: 'Fit all',
-      tooltip: 'Fit all in view',
-      shortcut: 'Z',
-      icon: FitAll,
-      group: 'camera',
-      run: () => callbacks.fitAll?.(),
-    },
-    {
-      id: 'viewTop',
-      label: 'Top',
-      tooltip: 'Top view',
-      shortcut: '1',
-      icon: TopView,
-      group: 'preset',
-      run: () => callbacks.setPresetView?.('top'),
-    },
-    {
-      id: 'viewBottom',
-      label: 'Bottom',
-      tooltip: 'Bottom view',
-      shortcut: '2',
-      icon: BottomView,
-      group: 'preset',
-      run: () => callbacks.setPresetView?.('bottom'),
-    },
-    {
-      id: 'viewFront',
-      label: 'Front',
-      tooltip: 'Front view',
-      shortcut: '3',
-      icon: FrontView,
-      group: 'preset',
-      run: () => callbacks.setPresetView?.('front'),
-    },
-    {
-      id: 'viewBack',
-      label: 'Back',
-      tooltip: 'Back view',
-      shortcut: '4',
-      icon: BackView,
-      group: 'preset',
-      run: () => callbacks.setPresetView?.('back'),
-    },
-    {
-      id: 'viewLeft',
-      label: 'Left',
-      tooltip: 'Left view',
-      shortcut: '5',
-      icon: LeftView,
-      group: 'preset',
-      run: () => callbacks.setPresetView?.('left'),
-    },
-    {
-      id: 'viewRight',
-      label: 'Right',
-      tooltip: 'Right view',
-      shortcut: '6',
-      icon: RightView,
-      group: 'preset',
-      run: () => callbacks.setPresetView?.('right'),
-    },
-    {
-      id: 'rotateLeft',
-      label: 'Rotate left',
-      tooltip: 'Rotate left 90°',
-      icon: RotateLeft,
-      group: 'rotate',
-      repeatable: true,
-      run: () => callbacks.rotateLeft?.(),
-    },
-    {
-      id: 'rotateRight',
-      label: 'Rotate right',
-      tooltip: 'Rotate right 90°',
-      icon: RotateRight,
-      group: 'rotate',
-      repeatable: true,
-      run: () => callbacks.rotateRight?.(),
-    },
-  ];
-}
-
-/** The command set bound to the live camera. */
-export function useCameraCommands(): CameraCommand[] {
+/** The command set bound to the live camera, each entry carrying its icon. */
+export function useCameraCommands(): RenderableCameraCommand[] {
   const callbacks = useViewerStore((s) => s.cameraCallbacks);
   return useMemo(
-    () => buildCameraCommands({ callbacks, goHome: goHomeFromStore }),
+    () => buildCameraCommands({ callbacks, goHome: goHomeFromStore })
+      .map((command) => ({ ...command, icon: CAMERA_COMMAND_ICONS[command.id] })),
     [callbacks],
   );
 }
@@ -224,13 +78,14 @@ const GROUP_LABEL: Record<CameraCommandGroup, string> = {
 };
 
 /**
- * The camera block of the classic toolbar's View-options dropdown.
- * Repeatable commands keep the menu open so zoom/rotate can be pressed
- * several times without re-opening it.
+ * The camera block of the classic toolbar's View-options dropdown. Group
+ * order comes from the command list itself, so a group added there shows
+ * up here without a second edit. Repeatable commands keep the menu open,
+ * so zoom and rotate can be pressed several times in one visit.
  */
 export function CameraCommandMenuItems() {
   const commands = useCameraCommands();
-  const groups: CameraCommandGroup[] = ['camera', 'preset', 'rotate'];
+  const groups = [...new Set(commands.map((command) => command.group))];
   return (
     <>
       {groups.map((group, index) => (

--- a/apps/viewer/src/components/viewer/toolbar/camera-commands.test.ts
+++ b/apps/viewer/src/components/viewer/toolbar/camera-commands.test.ts
@@ -1,0 +1,84 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The shared camera command list is what both toolbar styles render, so a
+ * command that dispatches to the wrong camera callback is wrong in both at
+ * once. These assert the dispatch table itself; that each surface renders
+ * the list is asserted by `components/viewer/toolbar-parity.test.ts`.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import type { CameraCallbacks } from '@/store/types.js';
+import { buildCameraCommands, type CameraCommandId } from './camera-commands.js';
+
+/** Records which camera callback fired, and with what. */
+function recordingCallbacks() {
+  const calls: string[] = [];
+  const callbacks: CameraCallbacks = {
+    zoomIn: () => calls.push('zoomIn'),
+    zoomOut: () => calls.push('zoomOut'),
+    fitAll: () => calls.push('fitAll'),
+    rotateLeft: () => calls.push('rotateLeft'),
+    rotateRight: () => calls.push('rotateRight'),
+    setPresetView: (view) => calls.push(`setPresetView:${view}`),
+    frameSelection: () => calls.push('frameSelection'),
+  };
+  return { calls, callbacks };
+}
+
+/** What each command must do when pressed. */
+const EXPECTED_DISPATCH: Record<CameraCommandId, string> = {
+  home: 'goHome',
+  zoomIn: 'zoomIn',
+  zoomOut: 'zoomOut',
+  fitAll: 'fitAll',
+  viewTop: 'setPresetView:top',
+  viewBottom: 'setPresetView:bottom',
+  viewFront: 'setPresetView:front',
+  viewBack: 'setPresetView:back',
+  viewLeft: 'setPresetView:left',
+  viewRight: 'setPresetView:right',
+  rotateLeft: 'rotateLeft',
+  rotateRight: 'rotateRight',
+};
+
+describe('shared camera command list', () => {
+  it('dispatches every command to its own camera callback', () => {
+    for (const [id, expected] of Object.entries(EXPECTED_DISPATCH) as [CameraCommandId, string][]) {
+      const { calls, callbacks } = recordingCallbacks();
+      const command = buildCameraCommands({ callbacks, goHome: () => calls.push('goHome') })
+        .find((candidate) => candidate.id === id);
+      assert.ok(command, `no command with id ${id}`);
+      command.run();
+      assert.deepEqual(calls, [expected], `${id} dispatched wrongly`);
+    }
+  });
+
+  it('offers exactly the camera commands both toolbars are expected to host', () => {
+    const ids = buildCameraCommands({ callbacks: {}, goHome: () => {} }).map((command) => command.id);
+    assert.deepEqual(ids.slice().sort(), Object.keys(EXPECTED_DISPATCH).sort());
+    // Rotate-90° existed only in the ribbon and zoom only outside the classic
+    // strip until this list; naming them keeps a future trim honest (#1829).
+    for (const id of ['rotateLeft', 'rotateRight', 'zoomIn', 'zoomOut'] as CameraCommandId[]) {
+      assert.ok(ids.includes(id), `${id} dropped from the shared camera commands`);
+    }
+  });
+
+  it('survives a camera that has not registered its callbacks yet', () => {
+    // Before the Viewport mounts, `cameraCallbacks` is empty; pressing a
+    // toolbar button then must no-op rather than throw.
+    const commands = buildCameraCommands({ callbacks: {}, goHome: () => {} });
+    for (const command of commands) assert.doesNotThrow(() => command.run());
+  });
+
+  it('marks the press-repeatedly commands so menu surfaces stay open', () => {
+    const repeatable = buildCameraCommands({ callbacks: {}, goHome: () => {} })
+      .filter((command) => command.repeatable)
+      .map((command) => command.id)
+      .sort();
+    assert.deepEqual(repeatable, ['rotateLeft', 'rotateRight', 'zoomIn', 'zoomOut']);
+  });
+});

--- a/apps/viewer/src/components/viewer/toolbar/camera-commands.ts
+++ b/apps/viewer/src/components/viewer/toolbar/camera-commands.ts
@@ -1,0 +1,169 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The camera command set — Home, zoom, the six preset views and the 90°
+ * rotations — as ONE ordered list, shared by the classic toolbar and the
+ * ribbon so neither style can host a camera command the other lacks.
+ *
+ * This exists because they did fork: `rotateLeft`/`rotateRight` landed with
+ * a single call site in the ribbon's View tab (#1829), leaving the classic
+ * toolbar with no way to rotate the camera at all, and the same change hid
+ * the viewport's desktop zoom cluster from BOTH styles on the (ribbon-only)
+ * grounds that the ribbon owned those controls. A list is the fix that
+ * scales: a command added here reaches both surfaces without anyone
+ * remembering to wire the second one.
+ *
+ * Icons and rendering live in `CameraCommands.tsx` — the icon module is a
+ * Vite virtual module, so keeping the command data here is what lets the
+ * dispatch be asserted in a plain node test.
+ */
+
+import type { CameraCallbacks } from '@/store/types';
+
+export type CameraCommandId =
+  | 'home'
+  | 'zoomIn'
+  | 'zoomOut'
+  | 'fitAll'
+  | 'viewTop'
+  | 'viewBottom'
+  | 'viewFront'
+  | 'viewBack'
+  | 'viewLeft'
+  | 'viewRight'
+  | 'rotateLeft'
+  | 'rotateRight';
+
+/**
+ * Layout hint, not a capability boundary: every surface renders every
+ * group. `preset` is the six axis views (rendered as a compact block),
+ * `rotate` the two 90° steps.
+ */
+export type CameraCommandGroup = 'camera' | 'preset' | 'rotate';
+
+export interface CameraCommand {
+  id: CameraCommandId;
+  /** Short button caption. */
+  label: string;
+  /** Longer tooltip when the label isn't the whole story. */
+  tooltip: string;
+  /** Keyboard shortcut, where one exists (see `useKeyboardShortcuts`). */
+  shortcut?: string;
+  group: CameraCommandGroup;
+  /**
+   * True when users press it repeatedly (zoom, rotate). Menu surfaces stay
+   * open on select for these; a menu that closes after one 90° step makes a
+   * half-turn a four-click errand.
+   */
+  repeatable?: boolean;
+  run: () => void;
+}
+
+export interface CameraCommandContext {
+  callbacks: CameraCallbacks;
+  /** Home also resets visibility, so it is more than a camera pose — injected. */
+  goHome: () => void;
+}
+
+export function buildCameraCommands({ callbacks, goHome }: CameraCommandContext): CameraCommand[] {
+  return [
+    {
+      id: 'home',
+      label: 'Isometric',
+      tooltip: 'Home (isometric + reset visibility)',
+      shortcut: 'H',
+      group: 'camera',
+      run: () => goHome(),
+    },
+    {
+      id: 'zoomIn',
+      label: 'Zoom in',
+      tooltip: 'Zoom in',
+      group: 'camera',
+      repeatable: true,
+      run: () => callbacks.zoomIn?.(),
+    },
+    {
+      id: 'zoomOut',
+      label: 'Zoom out',
+      tooltip: 'Zoom out',
+      group: 'camera',
+      repeatable: true,
+      run: () => callbacks.zoomOut?.(),
+    },
+    {
+      id: 'fitAll',
+      label: 'Fit all',
+      tooltip: 'Fit all in view',
+      shortcut: 'Z',
+      group: 'camera',
+      run: () => callbacks.fitAll?.(),
+    },
+    {
+      id: 'viewTop',
+      label: 'Top',
+      tooltip: 'Top view',
+      shortcut: '1',
+      group: 'preset',
+      run: () => callbacks.setPresetView?.('top'),
+    },
+    {
+      id: 'viewBottom',
+      label: 'Bottom',
+      tooltip: 'Bottom view',
+      shortcut: '2',
+      group: 'preset',
+      run: () => callbacks.setPresetView?.('bottom'),
+    },
+    {
+      id: 'viewFront',
+      label: 'Front',
+      tooltip: 'Front view',
+      shortcut: '3',
+      group: 'preset',
+      run: () => callbacks.setPresetView?.('front'),
+    },
+    {
+      id: 'viewBack',
+      label: 'Back',
+      tooltip: 'Back view',
+      shortcut: '4',
+      group: 'preset',
+      run: () => callbacks.setPresetView?.('back'),
+    },
+    {
+      id: 'viewLeft',
+      label: 'Left',
+      tooltip: 'Left view',
+      shortcut: '5',
+      group: 'preset',
+      run: () => callbacks.setPresetView?.('left'),
+    },
+    {
+      id: 'viewRight',
+      label: 'Right',
+      tooltip: 'Right view',
+      shortcut: '6',
+      group: 'preset',
+      run: () => callbacks.setPresetView?.('right'),
+    },
+    {
+      id: 'rotateLeft',
+      label: 'Rotate left',
+      tooltip: 'Rotate left 90°',
+      group: 'rotate',
+      repeatable: true,
+      run: () => callbacks.rotateLeft?.(),
+    },
+    {
+      id: 'rotateRight',
+      label: 'Rotate right',
+      tooltip: 'Rotate right 90°',
+      group: 'rotate',
+      repeatable: true,
+      run: () => callbacks.rotateRight?.(),
+    },
+  ];
+}


### PR DESCRIPTION
The viewer ships two desktop toolbars — the classic single strip and the tabbed ribbon — and a user sits behind exactly one of them. Three capabilities had drifted into only one of them, so half the users silently lost each. Nothing in CI noticed: both surfaces typecheck, both render, both pass their own tests.

## The three gaps

**1. Camera rotate 90° was ribbon-only.** `cameraCallbacks.rotateLeft`/`rotateRight` arrived with #1829 — an external contribution that added a real capability the viewer did not have before — wired to exactly one call site in the ribbon's View tab. There is no keyboard shortcut for it (`R`/`Shift+R` rotate the *selected entity*, not the camera), no command-palette entry and no ViewCube control, so a classic-toolbar user could not rotate the camera 90° at all.

**2. The desktop zoom buttons left classic with no zoom control.** #1829 also narrowed the viewport nav guard from `!cesiumEnabled` to `isMobile && !cesiumEnabled`, on the reasoning that "the desktop Ribbon owns these controls." That is true of the ribbon, which does own them — it is an unintended side effect on the other style, not carelessness. Classic kept Home and Fit All but lost zoom entirely (`+`/`=` are bound to basket operations).

**3. Inline search was classic-only**, which bites hardest because the ribbon is the default. `SearchInline` rendered from `MainToolbar` and nowhere else, so for a ribbon user `/` and ⌘F did nothing (⌘F fell through to the browser's native Find), the `n`/`N` result cycle was unreachable, the recent-search MRU was unreachable, and the "N filter rules active" badge with its one-click clear did not exist. Text search itself was fine in both surfaces via `SearchModal`.

## The fixes

All three came from the same cause — two hand-maintained lists — so the fix is a shared source rather than a second hand-maintained list.

**`toolbar/camera-commands.ts`** is now the single ordered camera command set (Home, zoom, the six axis views, the two 90° rotations), with an `id`-keyed dispatch and a `repeatable` flag. `toolbar/CameraCommands.tsx` adds a type-exhaustive icon map (a new id does not compile until it has an icon), the hook that binds the list to the live camera, and the classic dropdown body. The ribbon's View tab and the classic View-options menu both render that one list, so neither style can host a camera command the other lacks. Repeatable commands keep the classic menu open on select — a menu that closes after one 90° step makes a half-turn a four-click errand.

Classic gets zoom back in its View-options menu, next to Home and Fit All where classic users already look, rather than by restoring the floating viewport cluster — that cluster would then be duplicated by the ribbon's own zoom buttons, which is presumably why #1829 hid it. The viewport guard is unchanged; only its comment is corrected, since it claimed something about both styles that was only true of one.

**The ribbon now hosts `SearchInline` itself** — the very component the classic strip renders, not a ribbon copy of it. It sits in the tab strip rather than inside a tab, so it survives ribbon collapse and tab switches, matching the classic strip's always-visible field. Hosting the component rather than relocating its logic deliberately leaves the global `n`/`N` listener and `SearchVimCycleState` exactly where they are, so #2415 is unaffected.

## The drift guard

`components/viewer/toolbar-parity.test.ts` walks each toolbar's component/hook closure, collects the viewer-store symbols and camera callbacks each side can reach, and asserts the classic-only and ribbon-only sets are empty or allowlisted **with a written reason**. Allowlisted today: the ribbon's tab/collapse/contextual-tab state, its mobile suppression of the one-time switch notice, and its hierarchy-panel shortcuts. A stale allowlist entry is itself a failure, and a sanity assertion on closure size stops a broken resolver from comparing two empty sets forever.

An import counts as reach only when the file actually uses what it imported — without that, deleting `<CameraCommandMenuItems />` while leaving the import line behind kept the camera closure "reachable" and the guard stayed green on exactly the regression it exists to catch (found by mutation, then fixed).

What it cannot catch: a control that renders but is dead, a control behind a never-true condition, a capability hiding inside a symbol both surfaces already read for another reason, and layout or discoverability differences. Those still need the flow executed in both toolbars, which is what was done here: rotate both directions, zoom in and out, and the full search flow (`/`, ⌘F, typing, `n`/`N` cycling, the recents popover, and the filter-rule badge with rules active) were each driven in both styles against a loaded model.

## Verification

- `npx turbo typecheck --force`: 76/76, 0 cached.
- `npx turbo test --force`: 86/86, 0 cached; viewer 3462 tests, 3456 pass, 0 fail.
- Every fix and the guard were mutation-checked: a wrong `rotateRight` dispatch fails the dispatch test; dropping `SearchInline` from the ribbon fails the classic-only assertion naming `searchQuery`/`searchVimCycle`/`clearFilterRules`; dropping the classic camera block fails both the ribbon-only and the camera-set assertions. Control green first, tree clean after each restore.

Credit to #1829 for the rotate controls themselves — this PR extends them to the other toolbar and guards the boundary, it does not replace them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent camera controls across classic and ribbon toolbars, including Home, zoom, fit-all, preset views, and rotation actions.
  * Added keyboard shortcut hints and repeatable camera actions that keep menus open for continued use.
  * Added a search field that remains visible while switching ribbon tabs or collapsing the ribbon.

* **Bug Fixes**
  * Improved consistency between toolbar styles by aligning their available camera capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->