### PR TITLE
fix(viewer): single-source the export formats both toolbars offer, and guard the boundary

### DIFF
--- a/apps/viewer/src/components/viewer/MainToolbar.tsx
+++ b/apps/viewer/src/components/viewer/MainToolbar.tsx
@@ -74,11 +74,6 @@ import { executeBasketIsolate } from '@/store/basket/basketCommands';
 import { useIfc } from '@/hooks/useIfc';
 import { cn } from '@/lib/utils';
 import { FileSpreadsheet, FileJson, FileText, Filter, Upload, Pencil, DraftingCompass } from 'lucide-react';
-import { ExportDialog } from './ExportDialog';
-import { GLBExportDialog } from './GLBExportDialog';
-import { KmzExportDialog } from './KmzExportDialog';
-import { HbjsonExportDialog } from './HbjsonExportDialog';
-import { UsdExportDialog } from './UsdExportDialog';
 import { BulkPropertyEditor } from './BulkPropertyEditor';
 import { DataConnector } from './DataConnector';
 import { ExportChangesButton } from './ExportChangesButton';
@@ -88,7 +83,7 @@ import { ThemeSwitch } from './ThemeSwitch';
 import { ExtensionToolbarSlot } from '@/components/extensions/ExtensionToolbarSlot';
 import { tourAnchor, toolAnchor } from '@/lib/tours/anchors';
 import { useFileCommands } from './toolbar/useFileCommands';
-import { useExportCommands } from './toolbar/useExportCommands';
+import { ClassicExportMenuItems } from './toolbar/ClassicExportMenuItems';
 import { useWorkspacePanelControls } from './toolbar/useWorkspacePanelControls';
 import { ClassVisibilityMenuContent } from './toolbar/ClassVisibilityMenu';
 
@@ -286,7 +281,6 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
     canRefresh,
     hasModelsLoaded,
   } = useFileCommands();
-  const { handleExportCSV, handleExportJSON, handleScreenshot } = useExportCommands();
   const {
     activeWorkspacePanels,
     workspacePanelLabel,
@@ -459,83 +453,7 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent>
-          <ExportDialog
-            trigger={
-              <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
-                <FileText className="h-4 w-4 mr-2" />
-                Export IFC (with changes)
-              </DropdownMenuItem>
-            }
-          />
-          <DropdownMenuSeparator />
-          <GLBExportDialog
-            trigger={
-              <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
-                <Download className="h-4 w-4 mr-2" />
-                Export GLB (3D Model)
-              </DropdownMenuItem>
-            }
-          />
-          <KmzExportDialog
-            trigger={
-              <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
-                <Globe2 className="h-4 w-4 mr-2" />
-                Export KMZ (Google Earth Pro)
-              </DropdownMenuItem>
-            }
-          />
-          <DropdownMenuSeparator />
-          <HbjsonExportDialog
-            trigger={
-              <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
-                <Download className="h-4 w-4 mr-2" />
-                Export HBJSON (Energy Model)
-              </DropdownMenuItem>
-            }
-          />
-          <UsdExportDialog
-            trigger={
-              <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
-                <Download className="h-4 w-4 mr-2" />
-                Export USD (OpenUSD)
-              </DropdownMenuItem>
-            }
-          />
-          <DropdownMenuSeparator />
-          <DropdownMenuSub>
-            <DropdownMenuSubTrigger disabled={!ifcDataStore}>
-              <FileSpreadsheet className="h-4 w-4 mr-2" />
-              Export CSV
-            </DropdownMenuSubTrigger>
-            <DropdownMenuSubContent>
-              <DropdownMenuItem onClick={() => handleExportCSV('entities')}>
-                <FileSpreadsheet className="h-4 w-4 mr-2" />
-                Entities
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => handleExportCSV('properties')}>
-                <FileSpreadsheet className="h-4 w-4 mr-2" />
-                Properties
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => handleExportCSV('quantities')}>
-                <FileSpreadsheet className="h-4 w-4 mr-2" />
-                Quantities
-              </DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem onClick={() => handleExportCSV('spatial')}>
-                <FileSpreadsheet className="h-4 w-4 mr-2" />
-                Spatial Hierarchy
-              </DropdownMenuItem>
-            </DropdownMenuSubContent>
-          </DropdownMenuSub>
-          <DropdownMenuItem onClick={handleExportJSON} disabled={!ifcDataStore}>
-            <FileJson className="h-4 w-4 mr-2" />
-            Export JSON (All Data)
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem onClick={handleScreenshot}>
-            <Camera className="h-4 w-4 mr-2" />
-            Screenshot
-          </DropdownMenuItem>
+          <ClassicExportMenuItems />
         </DropdownMenuContent>
       </DropdownMenu>
 

--- a/apps/viewer/src/components/viewer/ribbon/tabs/FileTab.tsx
+++ b/apps/viewer/src/components/viewer/ribbon/tabs/FileTab.tsx
@@ -8,24 +8,13 @@
  */
 
 import React from 'react';
-import { AddFile, Loading, OpenFile, Refresh, Screenshot, FileCsv, FileIfc, FileGlb, FileKmz, FileJson, FileHbjson, FileUsd, Share, CollabsRoom } from '@/icons';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
+import { AddFile, Loading, OpenFile, Refresh, Share, CollabsRoom } from '@/icons';
 import { useViewerStore } from '@/store';
 import { useIfc } from '@/hooks/useIfc';
 import { isCollabEnabled } from '@/lib/collab/config';
-import { ExportDialog } from '../../ExportDialog';
-import { GLBExportDialog } from '../../GLBExportDialog';
-import { KmzExportDialog } from '../../KmzExportDialog';
-import { HbjsonExportDialog } from '../../HbjsonExportDialog';
-import { UsdExportDialog } from '../../UsdExportDialog';
 import type { FileCommands } from '../../toolbar/useFileCommands';
-import { useExportCommands } from '../../toolbar/useExportCommands';
+import { RibbonExportGroup } from './RibbonExportGroup';
+import { RIBBON_EXPORT_ICONS } from './ribbon-export-icons';
 import {
   RibbonGroup,
   RibbonGroupDivider,
@@ -36,8 +25,7 @@ import {
 
 export function FileTab({ fileCommands }: { fileCommands: FileCommands }) {
   const { handleOpenClick, handleAddModelClick, handleRefresh, canRefresh, hasModelsLoaded, openShareDialog } = fileCommands;
-  const { loading, models, ifcDataStore } = useIfc();
-  const { handleExportCSV, handleExportJSON, handleScreenshot } = useExportCommands();
+  const { loading, models } = useIfc();
 
   // Collaboration: the Share cluster is gated behind the collab feature flag.
   // The ShareDialog itself (and its `ifc-lite:open-share-dialog` listener)
@@ -47,8 +35,6 @@ export function FileTab({ fileCommands }: { fileCommands: FileCommands }) {
   const collabPeerCount = useViewerStore((s) => s.collabPeers.length);
   const collabRoomId = useViewerStore((s) => s.collabRoomId);
   const collabPanelVisible = useViewerStore((s) => s.collabPanelVisible);
-
-  const canExport = hasModelsLoaded || Boolean(ifcDataStore);
 
   return (
     <>
@@ -81,66 +67,7 @@ export function FileTab({ fileCommands }: { fileCommands: FileCommands }) {
 
       <RibbonGroupDivider />
 
-      <RibbonGroup label="Export">
-        {/* Gate on any loaded model, not the legacy single-model geometryResult:
-            federated / multi-model sessions populate `models` but leave
-            geometryResult null, which would hide the whole export group. */}
-        <ExportDialog
-          trigger={
-            <RibbonLargeButton icon={FileIfc} label="IFC" tooltip="Export IFC (with changes)" disabled={!canExport} />
-          }
-        />
-        <RibbonSmallStack>
-          <GLBExportDialog
-            trigger={<RibbonSmallButton icon={FileGlb} label="GLB" tooltip="Export GLB (3D model)" disabled={!canExport} />}
-          />
-          <KmzExportDialog
-            trigger={<RibbonSmallButton icon={FileKmz} label="KMZ" tooltip="Export KMZ (Google Earth Pro)" disabled={!canExport} />}
-          />
-        </RibbonSmallStack>
-        <RibbonSmallStack>
-          <UsdExportDialog
-            trigger={<RibbonSmallButton icon={FileUsd} label="USD" tooltip="Export USD (OpenUSD .usda)" disabled={!canExport} />}
-          />
-          <HbjsonExportDialog
-            trigger={<RibbonSmallButton icon={FileHbjson} label="HBJSON" tooltip="Export HBJSON (energy model)" disabled={!canExport} />}
-          />
-        </RibbonSmallStack>
-        <RibbonSmallStack>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <RibbonSmallButton icon={FileCsv} label="CSV" hasMenu tooltip="Export CSV tables" disabled={!ifcDataStore} />
-            </DropdownMenuTrigger>
-            <DropdownMenuContent>
-              <DropdownMenuItem onClick={() => handleExportCSV('entities')}>
-                <FileCsv className="h-4 w-4 mr-2" />
-                Entities
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => handleExportCSV('properties')}>
-                <FileCsv className="h-4 w-4 mr-2" />
-                Properties
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => handleExportCSV('quantities')}>
-                <FileCsv className="h-4 w-4 mr-2" />
-                Quantities
-              </DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem onClick={() => handleExportCSV('spatial')}>
-                <FileCsv className="h-4 w-4 mr-2" />
-                Spatial Hierarchy
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-          <RibbonSmallButton
-            icon={FileJson}
-            label="JSON"
-            tooltip="Export JSON (all data)"
-            disabled={!ifcDataStore}
-            onClick={handleExportJSON}
-          />
-          <RibbonSmallButton icon={Screenshot} label="Screenshot" tooltip="Save viewport as PNG" onClick={handleScreenshot} />
-        </RibbonSmallStack>
-      </RibbonGroup>
+      <RibbonExportGroup icons={RIBBON_EXPORT_ICONS} />
 
       {collabEnabled && (
         <>

--- a/apps/viewer/src/components/viewer/ribbon/tabs/RibbonExportGroup.tsx
+++ b/apps/viewer/src/components/viewer/ribbon/tabs/RibbonExportGroup.tsx
@@ -1,0 +1,116 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Ribbon rendering of the export registry: the File tab's Export group. Every
+ * button is generated from `EXPORT_COMMANDS`, so the ribbon cannot fall behind
+ * the classic strip — see `toolbar/export-commands.ts`.
+ *
+ * The icon set arrives as a prop rather than being imported here: the ribbon's
+ * icons come from `@/icons`, which resolves through the `unplugin-icons` Vite
+ * plugin and therefore cannot be loaded by the node test runner. Injecting it
+ * keeps this component renderable in `export-ui-parity.test.tsx`, while the
+ * real set (`RIBBON_EXPORT_ICONS`) stays exhaustive at the type level.
+ */
+
+import React from 'react';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+  groupExportCommands,
+  type CsvExportType,
+  type ExportIconSet,
+} from '../../toolbar/export-commands';
+import { useExportCommands, type ResolvedExportCommand } from '../../toolbar/useExportCommands';
+import { RibbonGroup, RibbonLargeButton, RibbonSmallButton, RibbonSmallStack } from '../primitives';
+
+interface RibbonExportButtonProps extends ResolvedExportCommand {
+  icons: ExportIconSet;
+  onExportCsv: (type: CsvExportType) => void;
+  onRunAction: (action: 'json' | 'screenshot') => void;
+}
+
+function RibbonExportButton({
+  command,
+  disabled,
+  icons,
+  onExportCsv,
+  onRunAction,
+}: RibbonExportButtonProps) {
+  const Button = command.emphasis === 'large' ? RibbonLargeButton : RibbonSmallButton;
+  const shared = {
+    icon: icons[command.id],
+    label: command.label,
+    tooltip: command.tooltip,
+    disabled,
+    'data-export-command': command.id,
+  };
+
+  if (command.kind === 'dialog') {
+    const { Dialog } = command;
+    return <Dialog trigger={<Button {...shared} />} />;
+  }
+
+  if (command.kind === 'table-menu') {
+    const Icon = icons[command.id];
+    return (
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button {...shared} hasMenu />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          {command.items.map((item) => (
+            <React.Fragment key={item.type}>
+              {item.separatorBefore && <DropdownMenuSeparator />}
+              <DropdownMenuItem onClick={() => onExportCsv(item.type)}>
+                <Icon className="h-4 w-4 mr-2" />
+                {item.label}
+              </DropdownMenuItem>
+            </React.Fragment>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    );
+  }
+
+  return <Button {...shared} onClick={() => onRunAction(command.action)} />;
+}
+
+/**
+ * The File tab's Export group, in registry order. Gating comes from the shared
+ * hook: any loaded model (federated sessions leave the legacy single-model
+ * `geometryResult` null, which would otherwise hide the whole group), plus a
+ * parsed data store for the table exports.
+ */
+export function RibbonExportGroup({ icons }: { icons: ExportIconSet }) {
+  const { commands, handleExportCSV, runExportAction } = useExportCommands();
+  const groups = groupExportCommands(commands, (resolved) => resolved.command.group);
+
+  return (
+    <RibbonGroup label="Export">
+      {groups.map((group) => {
+        const buttons = group.map((resolved) => (
+          <RibbonExportButton
+            key={resolved.command.id}
+            {...resolved}
+            icons={icons}
+            onExportCsv={(type) => void handleExportCSV(type)}
+            onRunAction={runExportAction}
+          />
+        ));
+        // A lone headline command stands on its own; everything else stacks.
+        return group.length === 1 && group[0].command.emphasis === 'large' ? (
+          <React.Fragment key={group[0].command.id}>{buttons}</React.Fragment>
+        ) : (
+          <RibbonSmallStack key={group[0].command.id}>{buttons}</RibbonSmallStack>
+        );
+      })}
+    </RibbonGroup>
+  );
+}

--- a/apps/viewer/src/components/viewer/ribbon/tabs/ribbon-export-icons.ts
+++ b/apps/viewer/src/components/viewer/ribbon/tabs/ribbon-export-icons.ts
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The ribbon's icon per export format. Exhaustive over `ExportCommandId`, so
+ * adding a format to `toolbar/export-commands.ts` fails to compile until the
+ * ribbon has an icon for it — the ribbon can never silently skip a format.
+ *
+ * Isolated in its own module because `@/icons` resolves through the
+ * `unplugin-icons` Vite plugin: keeping the import out of `RibbonExportGroup`
+ * lets the node test runner render that component.
+ */
+
+import { FileCsv, FileGlb, FileHbjson, FileIfc, FileJson, FileKmz, FileUsd, Screenshot } from '@/icons';
+import type { ExportIconSet } from '../../toolbar/export-commands';
+
+export const RIBBON_EXPORT_ICONS: ExportIconSet = {
+  ifc: FileIfc,
+  glb: FileGlb,
+  kmz: FileKmz,
+  usd: FileUsd,
+  hbjson: FileHbjson,
+  csv: FileCsv,
+  json: FileJson,
+  screenshot: Screenshot,
+};

--- a/apps/viewer/src/components/viewer/toolbar/ClassicExportMenuItems.tsx
+++ b/apps/viewer/src/components/viewer/toolbar/ClassicExportMenuItems.tsx
@@ -1,0 +1,117 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Classic toolbar (`MainToolbar`) rendering of the export registry: the body
+ * of the Download dropdown. Every row is generated from `EXPORT_COMMANDS`, so
+ * the classic strip cannot fall behind the ribbon — see `export-commands.ts`.
+ */
+
+import React from 'react';
+import { Camera, Download, FileJson, FileSpreadsheet, FileText, Globe2 } from 'lucide-react';
+import {
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+} from '@/components/ui/dropdown-menu';
+import { groupExportCommands, type CsvExportType, type ExportIconSet } from './export-commands';
+import { useExportCommands, type ResolvedExportCommand } from './useExportCommands';
+
+/** Lucide icon per format — exhaustive, so a new registry entry breaks the build here. */
+export const CLASSIC_EXPORT_ICONS: ExportIconSet = {
+  ifc: FileText,
+  glb: Download,
+  kmz: Globe2,
+  usd: Download,
+  hbjson: Download,
+  csv: FileSpreadsheet,
+  json: FileJson,
+  screenshot: Camera,
+};
+
+interface ClassicExportRowProps extends ResolvedExportCommand {
+  onExportCsv: (type: CsvExportType) => void;
+  onRunAction: (action: 'json' | 'screenshot') => void;
+}
+
+function ClassicExportRow({ command, disabled, onExportCsv, onRunAction }: ClassicExportRowProps) {
+  const Icon = CLASSIC_EXPORT_ICONS[command.id];
+
+  if (command.kind === 'dialog') {
+    const { Dialog } = command;
+    return (
+      <Dialog
+        trigger={
+          <DropdownMenuItem
+            data-export-command={command.id}
+            disabled={disabled}
+            onSelect={(e) => e.preventDefault()}
+          >
+            <Icon className="h-4 w-4 mr-2" />
+            {command.menuLabel}
+          </DropdownMenuItem>
+        }
+      />
+    );
+  }
+
+  if (command.kind === 'table-menu') {
+    return (
+      <DropdownMenuSub>
+        <DropdownMenuSubTrigger data-export-command={command.id} disabled={disabled}>
+          <Icon className="h-4 w-4 mr-2" />
+          {command.menuLabel}
+        </DropdownMenuSubTrigger>
+        <DropdownMenuSubContent>
+          {command.items.map((item) => (
+            <React.Fragment key={item.type}>
+              {item.separatorBefore && <DropdownMenuSeparator />}
+              <DropdownMenuItem onClick={() => onExportCsv(item.type)}>
+                <Icon className="h-4 w-4 mr-2" />
+                {item.label}
+              </DropdownMenuItem>
+            </React.Fragment>
+          ))}
+        </DropdownMenuSubContent>
+      </DropdownMenuSub>
+    );
+  }
+
+  return (
+    <DropdownMenuItem
+      data-export-command={command.id}
+      disabled={disabled}
+      onClick={() => onRunAction(command.action)}
+    >
+      <Icon className="h-4 w-4 mr-2" />
+      {command.menuLabel}
+    </DropdownMenuItem>
+  );
+}
+
+/** The rows of the classic export dropdown, in registry order. */
+export function ClassicExportMenuItems() {
+  const { commands, handleExportCSV, runExportAction } = useExportCommands();
+  const groups = groupExportCommands(commands, (resolved) => resolved.command.group);
+
+  return (
+    <>
+      {groups.map((group, index) => (
+        <React.Fragment key={group[0].command.id}>
+          {index > 0 && <DropdownMenuSeparator />}
+          {group.map((resolved) => (
+            <ClassicExportRow
+              key={resolved.command.id}
+              {...resolved}
+              onExportCsv={(type) => void handleExportCSV(type)}
+              onRunAction={runExportAction}
+            />
+          ))}
+        </React.Fragment>
+      ))}
+    </>
+  );
+}

--- a/apps/viewer/src/components/viewer/toolbar/export-commands.ts
+++ b/apps/viewer/src/components/viewer/toolbar/export-commands.ts
@@ -1,0 +1,226 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Export command registry — the single source of truth for which formats the
+ * viewer's toolbars can export.
+ *
+ * The viewer ships two toolbar styles: the classic `MainToolbar` strip and the
+ * tabbed `RibbonToolbar`. Both render their Export cluster by mapping over
+ * `EXPORT_COMMANDS`, so a format can never be reachable in one style and
+ * missing in the other — there is one list, one order, one gating rule.
+ *
+ * Adding a format = adding one entry here. `ExportCommandId` is derived from
+ * the array, so every `Record<ExportCommandId, …>` — notably each toolbar
+ * style's icon map — stops compiling until that style has been taught the new
+ * format. `export-ui-parity.test.tsx` then checks at runtime that both styles
+ * actually render every id, and that neither hand-rolls an entry beside it.
+ *
+ * Out of scope: exports that belong to a panel rather than a toolbar (IDS
+ * reports, BCF, clash BCF, list/schedule tables, compare reports, drawing
+ * sheets). Those live in exactly one panel each and are opened the same way
+ * from both toolbar styles, so they cannot drift.
+ */
+
+import type React from 'react';
+import { ExportDialog } from '../ExportDialog';
+import { GLBExportDialog } from '../GLBExportDialog';
+import { KmzExportDialog } from '../KmzExportDialog';
+import { HbjsonExportDialog } from '../HbjsonExportDialog';
+import { UsdExportDialog } from '../UsdExportDialog';
+
+/** The CSV tables the exporter can emit. */
+export type CsvExportType = 'entities' | 'properties' | 'quantities' | 'spatial';
+
+/** Every export dialog takes the calling toolbar's own element as its trigger. */
+export type ExportDialogComponent = React.ComponentType<{ trigger?: React.ReactNode }>;
+
+interface ExportCommandBase {
+  /** Stable id — also the `data-export-command` attribute both styles render. */
+  readonly id: string;
+  /** Short label: ribbon buttons, where the icon carries most of the meaning. */
+  readonly label: string;
+  /** Long label: classic dropdown rows, which have only text to go on. */
+  readonly menuLabel: string;
+  /** Tooltip / accessible name. */
+  readonly tooltip: string;
+  /**
+   * What has to be loaded first. `model` means any loaded model (federated or
+   * legacy single-result); `dataStore` means a parsed entity store.
+   */
+  readonly requires: 'model' | 'dataStore';
+  /**
+   * Visual cluster. Consecutive commands sharing a group render as one small
+   * button stack in the ribbon and one separator-delimited block in the
+   * classic menu. Keep a group at three commands or fewer — that is the
+   * ribbon stack's height.
+   */
+  readonly group: number;
+  /**
+   * `large` marks the headline command of the Export cluster — the ribbon
+   * draws it as a big button; everything else is a small stacked row.
+   */
+  readonly emphasis: 'large' | 'small';
+}
+
+/** A format whose options live in a dialog (the dialog owns the download). */
+export interface ExportDialogCommand extends ExportCommandBase {
+  readonly kind: 'dialog';
+  readonly Dialog: ExportDialogComponent;
+}
+
+/** A one-click export handled by `useExportCommands`. */
+export interface ExportActionCommand extends ExportCommandBase {
+  readonly kind: 'action';
+  readonly action: 'json' | 'screenshot';
+}
+
+/** A format offered as a menu of tables (CSV). */
+export interface ExportTableMenuCommand extends ExportCommandBase {
+  readonly kind: 'table-menu';
+  readonly items: readonly {
+    readonly type: CsvExportType;
+    readonly label: string;
+    /** Draw a separator above this row. */
+    readonly separatorBefore: boolean;
+  }[];
+}
+
+export type ExportCommand =
+  | ExportDialogCommand
+  | ExportActionCommand
+  | ExportTableMenuCommand;
+
+/**
+ * The registry. Order and grouping here are the order and grouping the user
+ * sees in *both* toolbar styles.
+ */
+export const EXPORT_COMMANDS = [
+  {
+    id: 'ifc',
+    kind: 'dialog',
+    Dialog: ExportDialog,
+    label: 'IFC',
+    menuLabel: 'Export IFC (with changes)',
+    tooltip: 'Export IFC (with changes)',
+    requires: 'model',
+    group: 0,
+    emphasis: 'large',
+  },
+  {
+    id: 'glb',
+    kind: 'dialog',
+    Dialog: GLBExportDialog,
+    label: 'GLB',
+    menuLabel: 'Export GLB (3D Model)',
+    tooltip: 'Export GLB (3D model)',
+    requires: 'model',
+    group: 1,
+    emphasis: 'small',
+  },
+  {
+    id: 'kmz',
+    kind: 'dialog',
+    Dialog: KmzExportDialog,
+    label: 'KMZ',
+    menuLabel: 'Export KMZ (Google Earth Pro)',
+    tooltip: 'Export KMZ (Google Earth Pro)',
+    requires: 'model',
+    group: 1,
+    emphasis: 'small',
+  },
+  {
+    id: 'usd',
+    kind: 'dialog',
+    Dialog: UsdExportDialog,
+    label: 'USD',
+    menuLabel: 'Export USD (OpenUSD)',
+    tooltip: 'Export USD (OpenUSD .usda)',
+    requires: 'model',
+    group: 2,
+    emphasis: 'small',
+  },
+  {
+    id: 'hbjson',
+    kind: 'dialog',
+    Dialog: HbjsonExportDialog,
+    label: 'HBJSON',
+    menuLabel: 'Export HBJSON (Energy Model)',
+    tooltip: 'Export HBJSON (energy model)',
+    requires: 'model',
+    group: 2,
+    emphasis: 'small',
+  },
+  {
+    id: 'csv',
+    kind: 'table-menu',
+    label: 'CSV',
+    menuLabel: 'Export CSV',
+    tooltip: 'Export CSV tables',
+    requires: 'dataStore',
+    group: 3,
+    emphasis: 'small',
+    items: [
+      { type: 'entities', label: 'Entities', separatorBefore: false },
+      { type: 'properties', label: 'Properties', separatorBefore: false },
+      { type: 'quantities', label: 'Quantities', separatorBefore: false },
+      { type: 'spatial', label: 'Spatial Hierarchy', separatorBefore: true },
+    ],
+  },
+  {
+    id: 'json',
+    kind: 'action',
+    action: 'json',
+    label: 'JSON',
+    menuLabel: 'Export JSON (All Data)',
+    tooltip: 'Export JSON (all data)',
+    requires: 'dataStore',
+    group: 3,
+    emphasis: 'small',
+  },
+  {
+    id: 'screenshot',
+    kind: 'action',
+    action: 'screenshot',
+    label: 'Screenshot',
+    menuLabel: 'Screenshot',
+    tooltip: 'Save viewport as PNG',
+    requires: 'model',
+    group: 3,
+    emphasis: 'small',
+  },
+] as const satisfies readonly ExportCommand[];
+
+/**
+ * Derived from the registry, so a new entry immediately widens the union and
+ * every exhaustive `Record<ExportCommandId, …>` in the codebase goes red.
+ */
+export type ExportCommandId = (typeof EXPORT_COMMANDS)[number]['id'];
+
+/**
+ * A concrete registry entry (literal types preserved), which is what the
+ * toolbar renderers switch on.
+ */
+export type RegisteredExportCommand = (typeof EXPORT_COMMANDS)[number];
+
+/** Registry ids in registry order. */
+export const EXPORT_COMMAND_IDS: readonly ExportCommandId[] = EXPORT_COMMANDS.map((c) => c.id);
+
+/** An icon per export command, supplied by each toolbar style in its own set. */
+export type ExportIconSet = Record<ExportCommandId, React.ElementType>;
+
+/** Split a registry-ordered list into its visual groups, preserving order. */
+export function groupExportCommands<T>(items: readonly T[], groupOf: (item: T) => number): T[][] {
+  const groups: T[][] = [];
+  let current: number | null = null;
+  for (const item of items) {
+    const group = groupOf(item);
+    if (group !== current) {
+      groups.push([]);
+      current = group;
+    }
+    groups[groups.length - 1].push(item);
+  }
+  return groups;
+}

--- a/apps/viewer/src/components/viewer/toolbar/export-ui-parity.test.tsx
+++ b/apps/viewer/src/components/viewer/toolbar/export-ui-parity.test.tsx
@@ -11,15 +11,19 @@
  * emits exactly the ids in `EXPORT_COMMANDS`, in the same order — so adding a
  * format to one surface and not the other fails here.
  *
- * It also nails down the two ways someone could get around the registry:
- * hand-rolling an export entry inside a toolbar (source guard), and adding a
+ * It also nails down the three ways someone could get around the registry:
+ * hand-rolling an export entry inside a toolbar (source guard), adding a
  * registry entry without teaching a style's icon set about it (icon-set
  * coverage, checked for the ribbon by source because `@/icons` only resolves
- * through the Vite plugin).
+ * through the Vite plugin), and — the one that bites hardest — deleting a
+ * surface's Export cluster while leaving its import behind, which every other
+ * test here happily survives because they render the cluster components
+ * directly rather than the toolbars that host them.
  *
  * Presence is not enough — a wired-looking button whose handler does nothing
  * has shipped here before — so the last tests actually click through both
- * surfaces and assert a download is produced and a dialog opens.
+ * surfaces and assert a download is produced, the right one is produced, and a
+ * dialog opens.
  */
 
 import '@/test/setup-dom.js';
@@ -49,6 +53,25 @@ const VIEWER_SRC = fileURLToPath(new URL('../../..', import.meta.url));
 
 function readSource(relativePath: string): string {
   return readFileSync(`${VIEWER_SRC}/${relativePath}`, 'utf8');
+}
+
+/** Import statements (including multi-line named imports), matched as a unit. */
+const IMPORT_STATEMENT =
+  /^import\b[\s\S]*?from\s*['"][^'"]*['"];?[ \t]*$|^import\s+['"][^'"]*['"];?[ \t]*$/gm;
+
+/**
+ * The part of a module that actually *does* something. An import is not reach:
+ * deleting `<ClassicExportMenuItems />` from `MainToolbar` while leaving the
+ * import line behind is exactly the regression the surface test below exists to
+ * catch, and matching against the whole file would let it through.
+ */
+function bodyWithoutImports(source: string): string {
+  return source.replace(IMPORT_STATEMENT, '');
+}
+
+/** True when `name` is referenced somewhere other than an import statement. */
+function usedOutsideImports(source: string, name: string): boolean {
+  return new RegExp(`\\b${name}\\b`).test(bodyWithoutImports(source));
 }
 
 /**
@@ -259,6 +282,49 @@ describe('export UI parity', () => {
     }
   });
 
+  it('each toolbar style actually renders its export cluster', () => {
+    // Every other test in this file renders ClassicExportMenuItems /
+    // RibbonExportGroup itself, so it proves the clusters work — not that the
+    // shipped toolbars still host them. Neither host can be rendered here
+    // (MainToolbar drags in the whole viewer; FileTab reaches `@/icons`, a Vite
+    // virtual module), so the host edge is checked in source, with imports
+    // stripped so a leftover import line does not count as reach.
+    const hosts = [
+      {
+        surface: 'components/viewer/MainToolbar.tsx',
+        cluster: 'ClassicExportMenuItems',
+        extras: [] as string[],
+      },
+      {
+        surface: 'components/viewer/ribbon/tabs/FileTab.tsx',
+        cluster: 'RibbonExportGroup',
+        // The ribbon's real icon set only reaches the group through this prop;
+        // it appears in FileTab's import line whether or not it is passed.
+        extras: ['RIBBON_EXPORT_ICONS'],
+      },
+    ];
+
+    for (const { surface, cluster, extras } of hosts) {
+      const body = bodyWithoutImports(readSource(surface));
+      assert.ok(
+        body.length > 0,
+        `${surface} has no body left after stripping imports — the import matcher is broken`,
+      );
+      assert.match(
+        body,
+        new RegExp(`<${cluster}[\\s/>]`),
+        `${surface} must render <${cluster} /> — without it this toolbar style ships ` +
+          'no exports at all, and every other test here still passes',
+      );
+      for (const extra of extras) {
+        assert.ok(
+          usedOutsideImports(readSource(surface), extra),
+          `${surface} imports ${extra} but never uses it`,
+        );
+      }
+    }
+  });
+
   it('the JSON export actually downloads a file from both toolbar styles', async () => {
     loadFakeModel();
 
@@ -282,6 +348,42 @@ describe('export UI parity', () => {
       });
     });
     assert.deepEqual(fromRibbon, ['json'], 'the ribbon JSON button must produce a download');
+  });
+
+  it('the screenshot export saves a PNG from both toolbar styles', async () => {
+    // The second `kind: 'action'` command, and the one that had already drifted
+    // (the ribbon offered it with no model loaded). Asserting the *extension*
+    // rather than "something downloaded" is what makes a cross-wired dispatch —
+    // both action ids landing on the same handler — fail here.
+    loadFakeModel();
+    const canvas = document.createElement('canvas');
+    canvas.toDataURL = () => 'data:image/png;base64,iVBORw0KGgo=';
+    document.body.appendChild(canvas);
+
+    try {
+      renderClassicExports();
+      const fromClassic = await captureDownloads(async () => {
+        await act(async () => {
+          exportControl('screenshot').click();
+        });
+      });
+      assert.deepEqual(fromClassic, ['png'], 'the classic Screenshot row must save a PNG');
+
+      for (const { root, container } of mounted.splice(0)) {
+        act(() => root.unmount());
+        container.remove();
+      }
+
+      renderRibbonExports();
+      const fromRibbon = await captureDownloads(async () => {
+        await act(async () => {
+          exportControl('screenshot').click();
+        });
+      });
+      assert.deepEqual(fromRibbon, ['png'], 'the ribbon Screenshot button must save a PNG');
+    } finally {
+      canvas.remove();
+    }
   });
 
   it('a dialog format opens its dialog from both toolbar styles', async () => {

--- a/apps/viewer/src/components/viewer/toolbar/export-ui-parity.test.tsx
+++ b/apps/viewer/src/components/viewer/toolbar/export-ui-parity.test.tsx
@@ -3,7 +3,31 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
- * Export parity between the two toolbar styles.
+ * Export parity between the two toolbar styles (ifc-lite#2511).
+ *
+ * WHAT THIS IS A REGRESSION TEST FOR. Every test below traces to a specific
+ * defect, and each names its own in the test title so a failure here is
+ * readable without this header. Together:
+ *
+ * - **#2511** — the two toolbars kept separate hand-written export lists, and
+ *   had already drifted on *when* a format is offered: the ribbon's Screenshot
+ *   button carried no `disabled` gate, so it was clickable with no model
+ *   loaded, while the classic strip's dialog rows carried no gate either and
+ *   were merely unreachable behind a disabled Download trigger. Both are now
+ *   one `requires` field in `export-commands.ts`.
+ * - **#2511** — a federated CSV/JSON export reads only the active
+ *   `ifcDataStore`, so it covers one model of several, and both styles
+ *   reported it as a whole-model export.
+ * - **#2510**, the sibling PR that did this for three non-export toolbar
+ *   capabilities, found the hole this file had too: rendering the export
+ *   clusters directly proves the clusters work, not that the shipped toolbars
+ *   still host them. Deleting `<ClassicExportMenuItems />` from `MainToolbar`
+ *   while leaving its import behind kept this file 10/10 green with the
+ *   classic Export menu shipping empty.
+ *
+ * The three capability gaps that motivated the sibling guard — camera
+ * rotate-90 ribbon-only, the desktop zoom cluster hidden from classic, inline
+ * search classic-only — are listed in `../toolbar-parity.test.ts` (#2510).
  *
  * The viewer ships the classic `MainToolbar` strip *and* the tabbed
  * `RibbonToolbar`; a user on either must reach the same export formats. This
@@ -286,7 +310,7 @@ afterEach(() => {
   }
 });
 
-describe('export UI parity', () => {
+describe('export UI parity (ifc-lite#2511)', () => {
   it('the registry is internally consistent', () => {
     const ids = EXPORT_COMMANDS.map((c) => c.id);
     assert.deepEqual([...EXPORT_COMMAND_IDS], ids, 'EXPORT_COMMAND_IDS must mirror the registry');
@@ -304,7 +328,7 @@ describe('export UI parity', () => {
     assert.deepEqual(renderedExportIds(), [...EXPORT_COMMAND_IDS]);
   });
 
-  it('both toolbar styles expose the same formats in the same order', () => {
+  it('both toolbar styles expose the same formats in the same order (#2511: two hand-written lists)', () => {
     renderClassicExports();
     const classic = renderedExportIds();
     unmountAll();
@@ -319,7 +343,7 @@ describe('export UI parity', () => {
     );
   });
 
-  it('both toolbar styles gate every format identically', () => {
+  it('both toolbar styles gate every format identically (#2511: the ribbon offered Screenshot with no model loaded)', () => {
     // No model, no data store: everything is off in both styles.
     renderClassicExports();
     const classicOff = renderedExportIds().filter((id) => {
@@ -350,7 +374,7 @@ describe('export UI parity', () => {
     assert.deepEqual(keys.sort(), [...EXPORT_COMMAND_IDS].sort());
   });
 
-  it('neither toolbar hand-rolls an export entry beside the registry', () => {
+  it('neither toolbar hand-rolls an export entry beside the registry (#2511: routing around the single source)', () => {
     const surfaces = [
       'components/viewer/MainToolbar.tsx',
       ...readdirSync(`${VIEWER_SRC}/components/viewer/ribbon/tabs`)
@@ -381,7 +405,7 @@ describe('export UI parity', () => {
     }
   });
 
-  it('each toolbar style actually renders its export cluster', () => {
+  it('each toolbar style actually renders its export cluster (#2510: a cluster deleted with its import left behind kept this file green)', () => {
     // Every other test in this file renders ClassicExportMenuItems /
     // RibbonExportGroup itself, so it proves the clusters work — not that the
     // shipped toolbars still host them. Neither host can be rendered here
@@ -446,7 +470,7 @@ describe('export UI parity', () => {
     assert.deepEqual(fromRibbon, ['json'], 'the ribbon JSON button must produce a download');
   });
 
-  it('the screenshot export saves a PNG from both toolbar styles', async () => {
+  it('the screenshot export saves a PNG from both toolbar styles (#2511: a cross-wired action dispatch would still download something)', async () => {
     // The second `kind: 'action'` command, and the one that had already drifted
     // (the ribbon offered it with no model loaded). Asserting the *extension*
     // rather than "something downloaded" is what makes a cross-wired dispatch —
@@ -479,7 +503,7 @@ describe('export UI parity', () => {
     }
   });
 
-  it('both toolbar styles say so when a data export covers the active model only', async () => {
+  it('both toolbar styles say so when a data export covers the active model only (#2511: a federated CSV/JSON export was reported as whole-model)', async () => {
     // CSV/JSON read the one active `ifcDataStore`, so a federated session gets
     // a partial export. Spanning the federation changes the output contract and
     // is deliberately not done here — but a partial export must not be reported

--- a/apps/viewer/src/components/viewer/toolbar/export-ui-parity.test.tsx
+++ b/apps/viewer/src/components/viewer/toolbar/export-ui-parity.test.tsx
@@ -27,7 +27,7 @@
  */
 
 import '@/test/setup-dom.js';
-import { describe, it, beforeEach, afterEach } from 'node:test';
+import { describe, it, beforeEach, afterEach, mock } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync, readdirSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
@@ -40,6 +40,12 @@ import {
 } from '@/components/ui/dropdown-menu.js';
 import { TooltipProvider } from '@/components/ui/tooltip.js';
 import { useViewerStore } from '@/store/index.js';
+// Bare specifiers, matching what the code under test imports: a `.js`-suffixed
+// copy could resolve to a second module instance, and the toast spy would then
+// watch an object nothing calls.
+import { toast } from '@/components/ui/toast';
+import type { FederatedModel } from '@/store/types';
+import type { IfcDataStore } from '@ifc-lite/parser';
 import { EVENT_FILE_DOWNLOADED } from '@/lib/tours/events.js';
 import {
   EXPORT_COMMANDS,
@@ -131,28 +137,127 @@ function exportControl(id: string): HTMLElement {
 }
 
 /**
- * Minimal data store: enough for the JSON export to walk one entity, and
- * enough for the CSV/JSON gate (`requires: 'dataStore'`) to open.
+ * Tear down everything mounted so far, then PROVE the screen is empty before
+ * the next surface is rendered.
+ *
+ * Every query in this file is global (`document.body`), and Radix portals its
+ * menus and dialogs OUTSIDE the test container — so anything that outlived its
+ * root would silently answer the second surface's assertions with the first
+ * surface's DOM, and a ribbon that opened nothing would read as a pass. That
+ * path is not reachable today (React does remove the portal on unmount), so
+ * these two assertions are a latch on an invariant the tests depend on rather
+ * than a live bug fix: `forceMount` on a future dialog, a root that fails to
+ * unmount, or collapsing this loop into a single `act()` would each re-open it.
+ *
+ * Each root is unmounted in its OWN `act()`: one `act()` around the whole loop
+ * batches the work, and a component that never actually tore down then looks
+ * exactly like one that did.
  */
-function fakeDataStore() {
+function unmountAll(): void {
+  for (const { root, container } of mounted.splice(0)) {
+    act(() => root.unmount());
+    container.remove();
+  }
+  assert.deepEqual(
+    renderedExportIds(),
+    [],
+    'export controls outlived their root — a later surface would be asserted against this one',
+  );
+  assert.equal(
+    document.body.querySelector('[role="dialog"]'),
+    null,
+    'a dialog outlived its root — a later surface would be asserted against this one',
+  );
+}
+
+/**
+ * Exactly the slice of `IfcDataStore` the export handlers touch, with every
+ * member's type taken FROM the real store rather than restated. A fake typed
+ * `as any` compiles no matter what the real contract does; this one goes red
+ * the moment a member it stands in for changes shape, which is the whole
+ * reason for having it.
+ */
+type ExportDataStoreSlice = {
+  source: Pick<IfcDataStore['source'], 'byteLength' | 'materialize'>;
+  entities: Pick<
+    IfcDataStore['entities'],
+    'count' | 'expressId' | 'getGlobalId' | 'getName' | 'getTypeName'
+  >;
+  properties: Pick<IfcDataStore['properties'], 'getForEntity'>;
+};
+
+/**
+ * Minimal data store: enough for the JSON export to walk one entity, and
+ * enough for the CSV/JSON gate (`requires: 'dataStore'`) to open. Annotated at
+ * the declaration, so the literal is checked against the real member types
+ * before the single widening cast in `loadFakeModel` is applied.
+ */
+function fakeDataStore(): ExportDataStoreSlice {
   return {
     source: { byteLength: 4, materialize: () => new Uint8Array([1, 2, 3, 4]) },
     entities: {
       count: 1,
-      expressId: new Int32Array([1]),
+      // Uint32Array, not Int32Array: the `as any` cast this fake used to carry
+      // accepted the wrong element type silently for as long as it existed.
+      expressId: new Uint32Array([1]),
       getGlobalId: () => '0000000000000000000001',
       getName: () => 'Wall',
       getTypeName: () => 'IfcWall',
     },
-    properties: { getForEntity: () => ({}) },
+    properties: { getForEntity: () => [] },
   };
 }
 
 function loadFakeModel(): void {
-  useViewerStore.setState({
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ifcDataStore: fakeDataStore() as any,
+  // One widening cast, at the store boundary and nowhere else: the object it
+  // widens has already been checked against `ExportDataStoreSlice` above.
+  useViewerStore.setState({ ifcDataStore: fakeDataStore() as unknown as IfcDataStore });
+}
+
+/**
+ * `n` loaded models. Fully typed against `FederatedModel` — no cast — because
+ * only `models.size` is read here and every required member has a real value.
+ */
+function fakeFederation(n: number): Map<string, FederatedModel> {
+  const entries: Array<[string, FederatedModel]> = [];
+  for (let i = 0; i < n; i++) {
+    entries.push([
+      `model-${i}`,
+      {
+        id: `model-${i}`,
+        name: `model-${i}.ifc`,
+        ifcDataStore: null,
+        geometryResult: null,
+        visible: true,
+        collapsed: false,
+        schemaVersion: 'IFC4',
+        loadedAt: 0,
+        fileSize: 0,
+        idOffset: 0,
+        maxExpressId: 0,
+      },
+    ]);
+  }
+  return new Map(entries);
+}
+
+/**
+ * The message of the single success toast raised while `run` executed. Spying
+ * on the real `toast` object (the same module instance the hook imports) means
+ * a spy that never fired shows up as a count mismatch, not as a silent pass.
+ */
+async function captureSuccessToast(run: () => Promise<void> | void): Promise<string> {
+  const messages: string[] = [];
+  const spy = mock.method(toast, 'success', (message: string) => {
+    messages.push(message);
   });
+  try {
+    await run();
+  } finally {
+    spy.mock.restore();
+  }
+  assert.equal(messages.length, 1, `expected exactly one success toast, saw ${messages.length}`);
+  return messages[0];
 }
 
 /** Filenames (by extension) downloaded while `run` executed. */
@@ -202,10 +307,7 @@ describe('export UI parity', () => {
   it('both toolbar styles expose the same formats in the same order', () => {
     renderClassicExports();
     const classic = renderedExportIds();
-    for (const { root, container } of mounted.splice(0)) {
-      act(() => root.unmount());
-      container.remove();
-    }
+    unmountAll();
     renderRibbonExports();
     const ribbon = renderedExportIds();
 
@@ -224,10 +326,7 @@ describe('export UI parity', () => {
       const el = exportControl(id);
       return el.hasAttribute('disabled') || el.getAttribute('data-disabled') !== null;
     });
-    for (const { root, container } of mounted.splice(0)) {
-      act(() => root.unmount());
-      container.remove();
-    }
+    unmountAll();
     renderRibbonExports();
     const ribbonOff = renderedExportIds().filter((id) => {
       const el = exportControl(id);
@@ -336,10 +435,7 @@ describe('export UI parity', () => {
     });
     assert.deepEqual(fromClassic, ['json'], 'the classic JSON row must produce a download');
 
-    for (const { root, container } of mounted.splice(0)) {
-      act(() => root.unmount());
-      container.remove();
-    }
+    unmountAll();
 
     renderRibbonExports();
     const fromRibbon = await captureDownloads(async () => {
@@ -369,10 +465,7 @@ describe('export UI parity', () => {
       });
       assert.deepEqual(fromClassic, ['png'], 'the classic Screenshot row must save a PNG');
 
-      for (const { root, container } of mounted.splice(0)) {
-        act(() => root.unmount());
-        container.remove();
-      }
+      unmountAll();
 
       renderRibbonExports();
       const fromRibbon = await captureDownloads(async () => {
@@ -384,6 +477,52 @@ describe('export UI parity', () => {
     } finally {
       canvas.remove();
     }
+  });
+
+  it('both toolbar styles say so when a data export covers the active model only', async () => {
+    // CSV/JSON read the one active `ifcDataStore`, so a federated session gets
+    // a partial export. Spanning the federation changes the output contract and
+    // is deliberately not done here — but a partial export must not be reported
+    // as a whole one, in EITHER style, since both read the same hook.
+    loadFakeModel();
+    useViewerStore.setState({ models: fakeFederation(3) });
+
+    renderClassicExports();
+    const classicToast = await captureSuccessToast(async () => {
+      await act(async () => {
+        exportControl('json').click();
+      });
+    });
+    assert.match(
+      classicToast,
+      /active model only, 2 other loaded models not included/,
+      'the classic JSON row must not report a federated partial export as a whole one',
+    );
+
+    unmountAll();
+
+    renderRibbonExports();
+    const ribbonToast = await captureSuccessToast(async () => {
+      await act(async () => {
+        exportControl('json').click();
+      });
+    });
+    assert.equal(
+      ribbonToast,
+      classicToast,
+      'both styles read one hook, so they must describe the same export identically',
+    );
+
+    // ...and a single-model session must NOT carry the note.
+    unmountAll();
+    useViewerStore.setState({ models: fakeFederation(1) });
+    renderRibbonExports();
+    const soloToast = await captureSuccessToast(async () => {
+      await act(async () => {
+        exportControl('json').click();
+      });
+    });
+    assert.doesNotMatch(soloToast, /active model only/, 'a single-model export is not partial');
   });
 
   it('a dialog format opens its dialog from both toolbar styles', async () => {
@@ -398,10 +537,7 @@ describe('export UI parity', () => {
       'the classic IFC row must open the export dialog',
     );
 
-    for (const { root, container } of mounted.splice(0)) {
-      act(() => root.unmount());
-      container.remove();
-    }
+    unmountAll();
 
     renderRibbonExports();
     await act(async () => {

--- a/apps/viewer/src/components/viewer/toolbar/export-ui-parity.test.tsx
+++ b/apps/viewer/src/components/viewer/toolbar/export-ui-parity.test.tsx
@@ -1,0 +1,313 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Export parity between the two toolbar styles.
+ *
+ * The viewer ships the classic `MainToolbar` strip *and* the tabbed
+ * `RibbonToolbar`; a user on either must reach the same export formats. This
+ * file is the gate: it renders both styles' Export clusters and asserts each
+ * emits exactly the ids in `EXPORT_COMMANDS`, in the same order — so adding a
+ * format to one surface and not the other fails here.
+ *
+ * It also nails down the two ways someone could get around the registry:
+ * hand-rolling an export entry inside a toolbar (source guard), and adding a
+ * registry entry without teaching a style's icon set about it (icon-set
+ * coverage, checked for the ribbon by source because `@/icons` only resolves
+ * through the Vite plugin).
+ *
+ * Presence is not enough — a wired-looking button whose handler does nothing
+ * has shipped here before — so the last tests actually click through both
+ * surfaces and assert a download is produced and a dialog opens.
+ */
+
+import '@/test/setup-dom.js';
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu.js';
+import { TooltipProvider } from '@/components/ui/tooltip.js';
+import { useViewerStore } from '@/store/index.js';
+import { EVENT_FILE_DOWNLOADED } from '@/lib/tours/events.js';
+import {
+  EXPORT_COMMANDS,
+  EXPORT_COMMAND_IDS,
+  type ExportIconSet,
+} from './export-commands.js';
+import { CLASSIC_EXPORT_ICONS, ClassicExportMenuItems } from './ClassicExportMenuItems.js';
+import { RibbonExportGroup } from '../ribbon/tabs/RibbonExportGroup.js';
+
+const VIEWER_SRC = fileURLToPath(new URL('../../..', import.meta.url));
+
+function readSource(relativePath: string): string {
+  return readFileSync(`${VIEWER_SRC}/${relativePath}`, 'utf8');
+}
+
+/**
+ * The ribbon's real icons come from `@/icons`, which resolves through
+ * `unplugin-icons` and cannot be loaded by the node test runner; the component
+ * takes the set as a prop so it stays renderable here. The real set is covered
+ * by `ribbon icon set covers every registered format` below.
+ */
+function StubIcon(props: React.SVGProps<SVGSVGElement>) {
+  return <svg {...props} />;
+}
+const STUB_ICONS = Object.fromEntries(
+  EXPORT_COMMAND_IDS.map((id) => [id, StubIcon]),
+) as ExportIconSet;
+
+const mounted: Array<{ root: Root; container: HTMLElement }> = [];
+
+function render(node: React.ReactNode): HTMLElement {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(<TooltipProvider>{node}</TooltipProvider>);
+  });
+  mounted.push({ root, container });
+  return container;
+}
+
+/** The classic strip's Export cluster: the body of its Download dropdown. */
+function renderClassicExports(): void {
+  render(
+    <DropdownMenu open modal={false}>
+      <DropdownMenuTrigger>Export and download</DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <ClassicExportMenuItems />
+      </DropdownMenuContent>
+    </DropdownMenu>,
+  );
+}
+
+/** The ribbon's Export cluster: the File tab's Export group. */
+function renderRibbonExports(): void {
+  render(<RibbonExportGroup icons={STUB_ICONS} />);
+}
+
+/** Export ids currently on screen, in DOM order. */
+function renderedExportIds(): string[] {
+  return [...document.body.querySelectorAll('[data-export-command]')].map(
+    (el) => el.getAttribute('data-export-command') ?? '',
+  );
+}
+
+function exportControl(id: string): HTMLElement {
+  const el = document.body.querySelector<HTMLElement>(`[data-export-command="${id}"]`);
+  assert.ok(el, `an export control for "${id}" must be on screen`);
+  return el;
+}
+
+/**
+ * Minimal data store: enough for the JSON export to walk one entity, and
+ * enough for the CSV/JSON gate (`requires: 'dataStore'`) to open.
+ */
+function fakeDataStore() {
+  return {
+    source: { byteLength: 4, materialize: () => new Uint8Array([1, 2, 3, 4]) },
+    entities: {
+      count: 1,
+      expressId: new Int32Array([1]),
+      getGlobalId: () => '0000000000000000000001',
+      getName: () => 'Wall',
+      getTypeName: () => 'IfcWall',
+    },
+    properties: { getForEntity: () => ({}) },
+  };
+}
+
+function loadFakeModel(): void {
+  useViewerStore.setState({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ifcDataStore: fakeDataStore() as any,
+  });
+}
+
+/** Filenames (by extension) downloaded while `run` executed. */
+async function captureDownloads(run: () => Promise<void> | void): Promise<string[]> {
+  const kinds: string[] = [];
+  const listener = (e: Event) => {
+    kinds.push((e as CustomEvent<{ kind: string }>).detail.kind);
+  };
+  window.addEventListener(EVENT_FILE_DOWNLOADED, listener);
+  try {
+    await run();
+  } finally {
+    window.removeEventListener(EVENT_FILE_DOWNLOADED, listener);
+  }
+  return kinds;
+}
+
+beforeEach(() => {
+  useViewerStore.setState({ ifcDataStore: null, geometryResult: null, models: new Map() });
+});
+
+afterEach(() => {
+  for (const { root, container } of mounted.splice(0)) {
+    act(() => root.unmount());
+    container.remove();
+  }
+});
+
+describe('export UI parity', () => {
+  it('the registry is internally consistent', () => {
+    const ids = EXPORT_COMMANDS.map((c) => c.id);
+    assert.deepEqual([...EXPORT_COMMAND_IDS], ids, 'EXPORT_COMMAND_IDS must mirror the registry');
+    assert.equal(new Set(ids).size, ids.length, 'export command ids must be unique');
+    assert.ok(ids.length > 0, 'the registry must not be empty');
+  });
+
+  it('the classic toolbar renders every registered export format', () => {
+    renderClassicExports();
+    assert.deepEqual(renderedExportIds(), [...EXPORT_COMMAND_IDS]);
+  });
+
+  it('the ribbon renders every registered export format', () => {
+    renderRibbonExports();
+    assert.deepEqual(renderedExportIds(), [...EXPORT_COMMAND_IDS]);
+  });
+
+  it('both toolbar styles expose the same formats in the same order', () => {
+    renderClassicExports();
+    const classic = renderedExportIds();
+    for (const { root, container } of mounted.splice(0)) {
+      act(() => root.unmount());
+      container.remove();
+    }
+    renderRibbonExports();
+    const ribbon = renderedExportIds();
+
+    assert.deepEqual(
+      ribbon,
+      classic,
+      'a format reachable in one toolbar style must be reachable in the other — ' +
+        'add it to EXPORT_COMMANDS instead of to a single toolbar',
+    );
+  });
+
+  it('both toolbar styles gate every format identically', () => {
+    // No model, no data store: everything is off in both styles.
+    renderClassicExports();
+    const classicOff = renderedExportIds().filter((id) => {
+      const el = exportControl(id);
+      return el.hasAttribute('disabled') || el.getAttribute('data-disabled') !== null;
+    });
+    for (const { root, container } of mounted.splice(0)) {
+      act(() => root.unmount());
+      container.remove();
+    }
+    renderRibbonExports();
+    const ribbonOff = renderedExportIds().filter((id) => {
+      const el = exportControl(id);
+      return el.hasAttribute('disabled') || el.getAttribute('data-disabled') !== null;
+    });
+
+    assert.deepEqual(ribbonOff, classicOff);
+    assert.deepEqual(ribbonOff, [...EXPORT_COMMAND_IDS], 'nothing is exportable with no model loaded');
+  });
+
+  it('the classic icon set covers every registered format', () => {
+    assert.deepEqual(Object.keys(CLASSIC_EXPORT_ICONS).sort(), [...EXPORT_COMMAND_IDS].sort());
+  });
+
+  it('the ribbon icon set covers every registered format', () => {
+    // Read as source: `@/icons` resolves only through the Vite plugin, so the
+    // real map cannot be imported here. Its keys must still be exhaustive.
+    const source = readSource('components/viewer/ribbon/tabs/ribbon-export-icons.ts');
+    const body = source.slice(source.indexOf('RIBBON_EXPORT_ICONS'));
+    const keys = [...body.matchAll(/^\s{2}([A-Za-z0-9_]+):/gm)].map((m) => m[1]);
+    assert.deepEqual(keys.sort(), [...EXPORT_COMMAND_IDS].sort());
+  });
+
+  it('neither toolbar hand-rolls an export entry beside the registry', () => {
+    const surfaces = [
+      'components/viewer/MainToolbar.tsx',
+      ...readdirSync(`${VIEWER_SRC}/components/viewer/ribbon/tabs`)
+        .filter((f) => f.endsWith('.tsx') && f !== 'RibbonExportGroup.tsx')
+        .map((f) => `components/viewer/ribbon/tabs/${f}`),
+    ];
+
+    for (const surface of surfaces) {
+      const source = readSource(surface);
+      assert.equal(
+        /from ['"][^'"]*Export(Dialog|Modal)['"]/.test(source),
+        false,
+        `${surface} imports an export dialog directly — register the format in ` +
+          'toolbar/export-commands.ts so both toolbar styles get it',
+      );
+      assert.equal(
+        source.includes('data-export-command'),
+        false,
+        `${surface} renders an export control of its own — register the format in ` +
+          'toolbar/export-commands.ts so both toolbar styles get it',
+      );
+      assert.equal(
+        source.includes('useExportCommands'),
+        false,
+        `${surface} drives exports by hand — render ClassicExportMenuItems / ` +
+          'RibbonExportGroup instead',
+      );
+    }
+  });
+
+  it('the JSON export actually downloads a file from both toolbar styles', async () => {
+    loadFakeModel();
+
+    renderClassicExports();
+    const fromClassic = await captureDownloads(async () => {
+      await act(async () => {
+        exportControl('json').click();
+      });
+    });
+    assert.deepEqual(fromClassic, ['json'], 'the classic JSON row must produce a download');
+
+    for (const { root, container } of mounted.splice(0)) {
+      act(() => root.unmount());
+      container.remove();
+    }
+
+    renderRibbonExports();
+    const fromRibbon = await captureDownloads(async () => {
+      await act(async () => {
+        exportControl('json').click();
+      });
+    });
+    assert.deepEqual(fromRibbon, ['json'], 'the ribbon JSON button must produce a download');
+  });
+
+  it('a dialog format opens its dialog from both toolbar styles', async () => {
+    loadFakeModel();
+
+    renderClassicExports();
+    await act(async () => {
+      exportControl('ifc').click();
+    });
+    assert.ok(
+      document.body.querySelector('[role="dialog"]'),
+      'the classic IFC row must open the export dialog',
+    );
+
+    for (const { root, container } of mounted.splice(0)) {
+      act(() => root.unmount());
+      container.remove();
+    }
+
+    renderRibbonExports();
+    await act(async () => {
+      exportControl('ifc').click();
+    });
+    assert.ok(
+      document.body.querySelector('[role="dialog"]'),
+      'the ribbon IFC button must open the export dialog',
+    );
+  });
+});

--- a/apps/viewer/src/components/viewer/toolbar/export-ui-parity.test.tsx
+++ b/apps/viewer/src/components/viewer/toolbar/export-ui-parity.test.tsx
@@ -513,6 +513,36 @@ describe('export UI parity', () => {
       'both styles read one hook, so they must describe the same export identically',
     );
 
+    // CSV is the other data export and takes the note from the same value —
+    // but "the same value" is exactly what a one-sided edit breaks. It cannot
+    // be driven here (its exporter loads the wasm over a `file://` URL, which
+    // fetch refuses), so it is covered by source, the same way the ribbon's
+    // icon set is: both handlers must carry the note, and the screenshot —
+    // which is a viewport capture, not a model export — must not.
+    const hookSource = readSource('components/viewer/toolbar/useExportCommands.ts');
+    // Backtick, single- and double-quoted forms alike: the screenshot's toast
+    // is a plain string, and a regex that only saw template literals would
+    // quietly drop it and check two toasts while claiming three.
+    const successToasts = [...hookSource.matchAll(/toast\.success\((['"`])([\s\S]*?)\1\)/g)].map(
+      (m) => m[2],
+    );
+    assert.equal(successToasts.length, 3, 'expected one success toast per one-click export');
+    for (const format of ['CSV', 'JSON']) {
+      const message = successToasts.find((t) => t.includes(format));
+      assert.ok(message, `no success toast mentions ${format}`);
+      assert.ok(
+        message.includes('${activeModelOnlyNote}'),
+        `the ${format} success toast must carry the partial-export note`,
+      );
+    }
+    const screenshotToast = successToasts.find((t) => t.includes('Screenshot'));
+    assert.ok(screenshotToast, 'no success toast mentions the screenshot');
+    assert.equal(
+      screenshotToast.includes('${activeModelOnlyNote}'),
+      false,
+      'a screenshot captures the viewport, so it is not an active-model-only export',
+    );
+
     // ...and a single-model session must NOT carry the note.
     unmountAll();
     useViewerStore.setState({ models: fakeFederation(1) });

--- a/apps/viewer/src/components/viewer/toolbar/useExportCommands.ts
+++ b/apps/viewer/src/components/viewer/toolbar/useExportCommands.ts
@@ -38,18 +38,39 @@ export function useExportCommands() {
     models.size > 0 || Boolean(geometryResult?.meshes && geometryResult.meshes.length > 0);
   const canExport = hasModelsLoaded || Boolean(ifcDataStore);
 
+  /**
+   * The data exports (CSV / JSON) read the single `ifcDataStore` slot, which
+   * `setActiveModel` keeps pointed at the ACTIVE model — so in a federated
+   * session they cover that one model and none of the others. That predates
+   * the registry (it is what `useExportCommands` did on main, and what both
+   * toolbars gated on) and making them span the federation is a real change of
+   * the output contract: express ids collide across models, so it means either
+   * one file per model or a new model column / envelope, which would break
+   * anything parsing today's shape. That decision belongs in its own change.
+   *
+   * What must not survive until then is a PARTIAL export presented as a whole
+   * one, so the toast says which it is. The geometry exports (IFC/GLB/KMZ/USD)
+   * are unaffected — they go through their own dialogs, which handle the
+   * federation themselves.
+   */
+  const otherModelCount = Math.max(0, models.size - 1);
+  const activeModelOnlyNote =
+    otherModelCount > 0
+      ? ` — active model only, ${otherModelCount} other loaded model${otherModelCount === 1 ? '' : 's'} not included`
+      : '';
+
   const handleExportCSV = useCallback(async (type: CsvExportType) => {
     if (!ifcDataStore || ifcDataStore.source.byteLength <= 0) return;
     try {
       const csv = await exportCsvFromBytes(ifcDataStore.source.materialize(), type, { includeProperties: type === 'entities' });
       const filename = type === 'spatial' ? 'spatial-hierarchy.csv' : `${type}.csv`;
       downloadFile(csv, filename, 'text/csv');
-      toast.success(`Exported ${type} CSV`);
+      toast.success(`Exported ${type} CSV${activeModelOnlyNote}`);
     } catch (err) {
       console.error('CSV export failed:', err);
       toast.error(`CSV export failed: ${err instanceof Error ? err.message : 'Unknown error'}`);
     }
-  }, [ifcDataStore]);
+  }, [ifcDataStore, activeModelOnlyNote]);
 
   const handleExportJSON = useCallback(() => {
     if (!ifcDataStore) return;
@@ -68,12 +89,12 @@ export function useExportCommands() {
 
       const json = JSON.stringify({ entities }, null, 2);
       downloadFile(json, 'model-data.json', 'application/json');
-      toast.success(`Exported ${entities.length} entities as JSON`);
+      toast.success(`Exported ${entities.length} entities as JSON${activeModelOnlyNote}`);
     } catch (err) {
       console.error('JSON export failed:', err);
       toast.error(`JSON export failed: ${err instanceof Error ? err.message : 'Unknown error'}`);
     }
-  }, [ifcDataStore]);
+  }, [ifcDataStore, activeModelOnlyNote]);
 
   const handleScreenshot = useCallback(() => {
     const canvas = document.querySelector('canvas');

--- a/apps/viewer/src/components/viewer/toolbar/useExportCommands.ts
+++ b/apps/viewer/src/components/viewer/toolbar/useExportCommands.ts
@@ -3,22 +3,40 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
- * Data-export commands (CSV / JSON / screenshot) shared by the classic
- * toolbar and the ribbon. The dialog-based exporters (IFC, GLB, KMZ,
- * HBJSON) stay as dialog components with a `trigger` prop — each
- * toolbar style supplies its own trigger element.
+ * Runtime half of the export command registry: the handlers behind the
+ * one-click exports (CSV / JSON / screenshot) plus the gating that decides
+ * which registry entries are live right now.
+ *
+ * Both toolbar styles call this hook and render `commands` — the classic strip
+ * through `ClassicExportMenuItems`, the ribbon through `RibbonExportGroup` —
+ * so the enabled/disabled rule for a format is written once. The dialog-based
+ * formats stay dialog components with a `trigger` prop; each style supplies
+ * its own trigger element.
  */
 
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useIfc } from '@/hooks/useIfc';
 import { exportCsvFromBytes } from '@/lib/export/csv';
 import { downloadFile, downloadDataUrl } from '@/lib/export/download';
 import { toast } from '@/components/ui/toast';
+import { EXPORT_COMMANDS, type CsvExportType, type RegisteredExportCommand } from './export-commands';
 
-export type CsvExportType = 'entities' | 'properties' | 'quantities' | 'spatial';
+export type { CsvExportType };
+
+/** A registry entry plus whether it can run against the current session. */
+export interface ResolvedExportCommand {
+  command: RegisteredExportCommand;
+  disabled: boolean;
+}
 
 export function useExportCommands() {
-  const { ifcDataStore } = useIfc();
+  const { ifcDataStore, models, geometryResult } = useIfc();
+
+  // Same rule as `useFileCommands.hasModelsLoaded`: federated sessions fill
+  // `models` and leave the legacy single-model `geometryResult` null.
+  const hasModelsLoaded =
+    models.size > 0 || Boolean(geometryResult?.meshes && geometryResult.meshes.length > 0);
+  const canExport = hasModelsLoaded || Boolean(ifcDataStore);
 
   const handleExportCSV = useCallback(async (type: CsvExportType) => {
     if (!ifcDataStore || ifcDataStore.source.byteLength <= 0) return;
@@ -69,5 +87,27 @@ export function useExportCommands() {
     }
   }, []);
 
-  return { ifcDataStore, handleExportCSV, handleExportJSON, handleScreenshot };
+  /** Dispatch for the registry's one-click (`kind: 'action'`) commands. */
+  const runExportAction = useCallback((action: 'json' | 'screenshot') => {
+    if (action === 'json') handleExportJSON();
+    else handleScreenshot();
+  }, [handleExportJSON, handleScreenshot]);
+
+  const commands = useMemo<ResolvedExportCommand[]>(
+    () => EXPORT_COMMANDS.map((command) => ({
+      command,
+      disabled: command.requires === 'dataStore' ? !ifcDataStore : !canExport,
+    })),
+    [ifcDataStore, canExport],
+  );
+
+  return {
+    ifcDataStore,
+    canExport,
+    commands,
+    handleExportCSV,
+    handleExportJSON,
+    handleScreenshot,
+    runExportAction,
+  };
 }


### PR DESCRIPTION
The viewer ships two desktop toolbars at once — the classic `MainToolbar` strip and the tabbed ribbon — and `RibbonSwitchNotice` moves users between them. Each kept its own hand-written list of export formats. They happened to agree on *which* formats today, but nothing held them together, and they had already drifted on *when* a format is offered. This replaces both lists with one registry and adds the guard that fails when they diverge again.

Sibling to #2510, which did the same for three non-export toolbar capabilities. Same directory, same `<name>-commands.ts` data module + rendering module split, same type-exhaustive icon map. Read them together.

## The drift that was already there

**Screenshot was offered with no model loaded in the ribbon.** Every other ribbon export button carried `disabled={!canExport}` or `disabled={!ifcDataStore}`; the Screenshot button carried none, so a ribbon user could click it on an empty viewport. The classic strip had the opposite shape: its five dialog rows carried no `disabled` prop at all and were unreachable only because the whole Download button is disabled without a model, which meant the two styles' gating rules were written in different places and could not be compared. Both now come from one `requires: 'model' | 'dataStore'` field, and the guard asserts the two styles' disabled sets are identical.

**Everything else was one edit away from a real capability loss.** A format added to one surface would have shipped as a silent halving of that capability, and CI would have been green: both surfaces typecheck, both render, both pass their own tests.

## The registry

`toolbar/export-commands.ts` is the single ordered export command set — id, short label (ribbon), long label (classic menu), tooltip, gating requirement, visual group, emphasis, and the kind (`dialog` / `action` / `table-menu`). Order and grouping there are the order and grouping the user sees in *both* styles.

`ExportCommandId` is **derived from the array** rather than hand-written, so adding an entry immediately widens the union and every `Record<ExportCommandId, …>` goes red — notably each style's icon map (`CLASSIC_EXPORT_ICONS`, `RIBBON_EXPORT_ICONS`). A new format cannot compile until both toolbars have been taught it. (#2510 hand-writes its id union; deriving is the stronger version of the same trick and is where the two should converge.)

Rendering stays in each style's own idiom — `toolbar/ClassicExportMenuItems.tsx` for the Download dropdown body, `ribbon/tabs/RibbonExportGroup.tsx` for the File tab's Export group — but both map over the one list, and `toolbar/useExportCommands.ts` holds the one gating rule and the one-click handlers.

The ribbon's icon set lives in its own `ribbon-export-icons.ts` and arrives as a prop: `@/icons` is a Vite virtual module, so keeping the import out of the component is what lets the node test runner render the real ribbon group instead of a stand-in.

## Format matrix

| Format | Classic | Ribbon | CLI |
|---|---|---|---|
| IFC (with changes) | yes | yes | `--format ifc` (+ `step` for faithful re-serialisation) |
| GLB | yes | yes | `--format glb` / `gltf` |
| KMZ | yes | yes | — |
| USD (.usda) | yes | yes | `--format usd` |
| HBJSON | yes | yes | `--format hbjson` |
| CSV (entities / properties / quantities / spatial) | yes | yes | `--format csv` |
| JSON | yes | yes | `--format json` |
| Screenshot (PNG) | yes | yes | n/a (no viewport) |
| OBJ | — | — | `--format obj` |
| JSON-LD | — | — | `--format jsonld` |
| IFCX | — | — | `--format ifcx` |

The bottom three are CLI-only and stay that way here; this PR is about the two toolbars not diverging from each other, and adding a format to the viewer is now a one-line change if we want them.

Deliberately out of the registry's scope: exports that belong to a panel rather than a toolbar (IDS reports, BCF, clash BCF, list/schedule tables, compare reports, drawing sheets). Each lives in exactly one panel and is opened the same way from both styles, so it cannot drift. `ExportChangesButton` is rendered by both `MainToolbar` and `RibbonToolbar` and is likewise not a drift risk.

## The guard, and the hole it had

`export-ui-parity.test.tsx` renders both styles' Export clusters and asserts each emits exactly the registry ids in the same order, with the same disabled set — expectations derived from the registry, never hardcoded — then clicks through: JSON downloads a file from both, Screenshot saves a **PNG** from both (asserting the extension is what makes a cross-wired dispatch fail rather than pass), and the IFC dialog opens from both. Source guards catch the two ways to route around the registry: importing an export dialog into a toolbar, and rendering a `data-export-command` of one's own.

It had the same hole #2510 found in its own guard. Every test rendered `ClassicExportMenuItems` / `RibbonExportGroup` **directly**, which proves the clusters work but not that the shipped toolbars still host them — deleting `<ClassicExportMenuItems />` from `MainToolbar` while leaving the import line behind kept the file 10/10 green while the classic Export menu shipped empty. Neither host can be rendered in the node runner (`MainToolbar` drags in the whole viewer; `FileTab` reaches `@/icons`), so the host edge is asserted in source **with import statements stripped first**, and `FileTab` is held to actually passing `RIBBON_EXPORT_ICONS` rather than merely importing it.

**What it cannot catch:** a control that renders and dispatches but whose exporter produces a broken file; a format wrong only in layout, ordering within a group, or discoverability; a difference in a dialog's *contents* between styles (both mount the same dialog component, so this is structural, not asserted); and the source-level host check cannot see a cluster rendered behind a never-true condition — it sees the JSX, not whether it runs. Those need the flow driven in both toolbars, which is what was done below.

## Verification

**Both surfaces, one browser session, real exports.** Loaded `building-architecture.ifc` (444 entities, IFC4) through the app's own load-file bus, with every `<a download>` intercepted so the produced bytes could be measured. Surfaces switched via the `ifc-lite-toolbar-style` localStorage key.

All eight formats executed end to end in **each** style — not menu-presence checks:

| | classic | ribbon |
|---|---|---|
| IFC | `building-architecture_export.ifc` 225,601 B | 225,601 B |
| GLB | `building-architecture.glb` 67,832 B | 67,832 B |
| KMZ | `building-architecture.kmz` 103,211 B | 103,211 B |
| USD | `building-architecture.usda` 168,449 B | 168,449 B |
| HBJSON | `building-architecture.hbjson` 7,810 B | 7,810 B |
| CSV | `entities.csv` 3,742 B | 3,742 B |
| JSON | `model-data.json` 15,082 B | 15,082 B |
| Screenshot | `screenshot.png` 20,020 B | 17,667 B |

Byte-identical across styles for everything except the screenshot, which differs only because the two toolbars leave the viewport a different height. Click path: classic — open `Export and download`, then each row in turn, with the CSV submenu opened and `Entities` selected, and each dialog's own `Export` pressed; ribbon — `File` tab, then each button, CSV dropdown to `Entities`, same dialog `Export`. With no model loaded, all eight ids report disabled in both styles (and the classic Download trigger is itself disabled). No console errors.

**Mutation-checked**, control green first, `git status --porcelain` clean after each restore, results read off `# tests` / `# pass` / `# fail`:

| mutation | result |
|---|---|
| control | 12 tests, 12 pass, 0 fail |
| delete `<ClassicExportMenuItems />` from `MainToolbar`, keep the import | 1 fail — *each toolbar style actually renders its export cluster* (**10/10 green before this PR**) |
| delete `<RibbonExportGroup …/>` from `FileTab`, keep the import | 1 fail — same test |
| `FileTab` keeps the `RIBBON_EXPORT_ICONS` import but passes a stub set | 1 fail — same test |
| classic surface filters `kmz` out of the registry | 3 fail — classic renders every format / same order / same gating |
| ribbon cross-wires the screenshot button to the JSON handler | 1 fail — screenshot saves a PNG from both styles |

Full gate, verbatim, 0 cached: `npx turbo typecheck --force` 76/76 successful; `npx turbo test --force` 86/86 successful, viewer 3465 tests / 3459 pass / 0 fail / 6 skipped.

`apps/viewer` is private, so no changeset and no API-surface update apply.

## Fits #1344 (DFJSON energy export)

Confirmed by simulation, not by reading. Applying that PR's three mechanical edits — the `hbjson` entry becoming `id: 'energy'` / `label: 'Energy'` / `menuLabel: 'Energy Model (HBJSON / DFJSON)'` with an `EnergyModelExportDialog`, and the key renamed in both icon maps — behaves exactly as designed: renaming the registry id **alone** fails typecheck in *both* icon maps (`TS2561: 'hbjson' does not exist in type 'ExportIconSet'`), and with both maps renamed typecheck is clean and the parity suite is 12/12 with the new id flowing through automatically, since the expectations are derived from the registry rather than hardcoded. Reverted afterwards — **#1344 owns those edits**, nothing here touches them.

## Note for sequencing with #2510

Two things are worth extracting once both land, and neither is worth doing while the other PR is open:

- The "an import is not reach" rule now exists twice, as the closure-walk import edge in `toolbar-parity.test.ts` (#2510) and as `bodyWithoutImports` / `usedOutsideImports` here. One shared test helper should own that definition, so a future guard cannot re-open the hole a third time.
- `Record<CameraCommandId, React.ElementType>` and `ExportIconSet` are the same idea; a shared `IconMap<Id>` alias in `toolbar/` would make the convention explicit. The grouping helpers are *not* the same and should stay separate — `groupExportCommands` preserves consecutive runs, #2510's groups by distinct value.
