### PR TITLE
test(geometry): gate the watertightness census per host, not on absolute totals

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -552,6 +552,18 @@ jobs:
         run: node scripts/fixtures/fetch-fixtures.mjs
       - name: Census
         run: cargo test -p ifc-lite-geometry --features triangulation-alt --test triangulation_invariance -- --nocapture
+      # The per-host rows this run measured, uploaded pass or fail. The census
+      # gates against a checked-in golden, and its log prints its per-element
+      # lists truncated, so without this a run that disagrees with the golden
+      # could only be diagnosed by reproducing a ~20-minute sweep over a 1.4 GB
+      # fixture corpus locally. Re-blessing is now: download, replace the golden.
+      - name: Upload the census rows
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: watertightness-census-rows
+          path: target/watertightness_census.run.tsv
+          if-no-files-found: warn
 
   # Plato clash-math single-source freshness gate. The clash narrow-phase math
   # is written once in Plato and transpiled to Rust + TypeScript; the committed

--- a/rust/geometry/tests/census_golden/mod.rs
+++ b/rust/geometry/tests/census_golden/mod.rs
@@ -1,0 +1,805 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Per-host golden for the watertightness census, and the diff that gives its
+//! numbers a DIRECTION (#2432).
+//!
+//! The census used to gate absolute totals over whatever the sweep happened to
+//! mesh. Two opposite events moved those totals the same way:
+//!
+//! 1. an existing mesh got worse — a regression, and
+//! 2. an element that previously failed to mesh at all now meshes imperfectly —
+//!    an improvement.
+//!
+//! and one event moved them the *reassuring* way while being the worst of the
+//! three: an element that silently stopped meshing takes its own defects out of
+//! every total, so coverage loss reads as an improvement.
+//!
+//! Absolute totals cannot separate those, because nothing in them pins element
+//! identity across runs. This module does: one row per swept void host, keyed by
+//! `(model, express id)`, checked in and diffed. The four cases are then
+//! distinct, and the failure message says which one happened.
+//!
+//! # The key is the manifest-relative PATH, not the basename
+//!
+//! Three basenames appear twice in the fixture manifest
+//! (`basin-tessellation.ifc`, `tessellation-with-individual-colors.ifc`,
+//! `column-straight-rectangle-tessellation.ifc`, each under two vendor
+//! directories). Keying on the basename would collide their hosts and let one
+//! model's row answer for another's.
+//!
+//! # Models that were not swept are not compared
+//!
+//! `MIN_MODELS` deliberately sits under the full corpus so a single failed
+//! fixture fetch does not red the build. A whole-corpus golden would throw that
+//! away: every host of an unfetched model would read as coverage loss. So the
+//! diff is scoped to the models this run actually swept, and blessing preserves
+//! the rows of the ones it did not. The census prints the models it did not
+//! sweep, because that is the one remaining way coverage can leave quietly.
+//!
+//! # Scope
+//!
+//! The census sweeps VOID HOSTS, so this gives coverage-regression detection for
+//! those ~1170 elements, not for every product in the corpus. An element with no
+//! `IfcRelVoidsElement` that stops meshing is still invisible here. Widening the
+//! sweep is a separate, much more expensive change: the ~20-minute run already
+//! only processes about one element in a hundred.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+/// Representation types that describe a CLOSED solid and are therefore
+/// legitimately expected to produce watertight geometry.
+pub fn is_closed_solid(rep: &str) -> bool {
+    matches!(rep, "SweptSolid" | "CSG" | "Clipping" | "Brep" | "AdvancedBrep")
+}
+
+/// Open boundary edges of the same host with NO voids applied — the reading
+/// that separates "arrived torn" from "the boolean tore it".
+///
+/// Only computed for hosts that are torn WITH voids, because that is the only
+/// place it is read; recomputing it for the ~85% of hosts that are watertight
+/// would double the sweep for nothing.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PreVoid {
+    /// Host is watertight with voids applied, so the no-void reading was never taken.
+    NotTaken,
+    /// Processing the host without voids failed outright.
+    Failed,
+    /// Open boundary edges without voids.
+    Open(usize),
+}
+
+/// One swept void host.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HostRow {
+    /// Manifest-relative path of the fixture. See the module note on basenames.
+    pub model: String,
+    pub id: u32,
+    /// `RepresentationType` of the Body representation.
+    pub rep: String,
+    /// Open boundary edges on the 1 mm snapped topology.
+    pub open: usize,
+    /// Triangles in the emitted mesh. Load-bearing on its own: a host whose mesh
+    /// degrades to EMPTY still returns `Ok` and still reports `open == 0`, which
+    /// is indistinguishable from a perfect watertight solid under an
+    /// open-count-only golden.
+    pub tris: usize,
+    /// Host carries at least one triangle collapsed by the 1 mm snap.
+    pub collapsed: bool,
+    /// Largest |coordinate| is beyond what f32 can carry mm topology at, so this
+    /// host's tears are an artifact of running below the pipeline's RTC offset.
+    /// Reported, never gated.
+    pub far: bool,
+    /// Open boundary edges under the ALTERNATE triangulator. `None` when that
+    /// pass failed to process the host at all.
+    pub alt: Option<usize>,
+    /// See [`PreVoid`]. Diagnostic: carried so the origin split and the
+    /// closed-solid expectation are derivable from the golden, never compared.
+    pub pre: PreVoid,
+}
+
+impl HostRow {
+    /// Does this host's watertightness depend on the triangulator's diagonal
+    /// choice? A failed alternate pass counts as divergence — it is a difference
+    /// in outcome, and the old census counted it as one too.
+    pub fn diverged(&self) -> bool {
+        self.alt != Some(self.open)
+    }
+
+    /// Is this a genuine watertightness defect: a closed solid, torn, at
+    /// coordinates f32 handles cleanly, whose no-void pass did not itself fail?
+    pub fn is_torn_solid(&self) -> bool {
+        self.open > 0
+            && is_closed_solid(&self.rep)
+            && !self.far
+            && self.pre != PreVoid::Failed
+    }
+
+    fn key(&self) -> (&str, u32) {
+        (self.model.as_str(), self.id)
+    }
+}
+
+/// The corpus totals the census reports, every one of them a pure function of a
+/// set of host rows.
+///
+/// Deriving both the run's readings and the golden's expectations from ONE
+/// function is the point: the previous ceilings were hand-written constants that
+/// could only be checked against the log of a green run, and nothing forced the
+/// number in the source to still mean what the sweep computes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Totals {
+    pub hosts: usize,
+    pub torn: usize,
+    pub open_edges: usize,
+    pub collapsed: usize,
+    pub torn_solid: usize,
+    pub non_invariant: usize,
+}
+
+pub fn totals<'a>(rows: impl IntoIterator<Item = &'a HostRow>) -> Totals {
+    let mut t = Totals {
+        hosts: 0,
+        torn: 0,
+        open_edges: 0,
+        collapsed: 0,
+        torn_solid: 0,
+        non_invariant: 0,
+    };
+    for r in rows {
+        t.hosts += 1;
+        t.open_edges += r.open;
+        t.torn += usize::from(r.open > 0);
+        t.collapsed += usize::from(r.collapsed);
+        t.torn_solid += usize::from(r.is_torn_solid());
+        t.non_invariant += usize::from(r.diverged());
+    }
+    t
+}
+
+/// A host that is present in both the golden and the run, and differs.
+///
+/// Only the run's row is carried: every reason string names both sides
+/// (`"open edges 10 -> 11"`), so a second copy of the golden row would be one
+/// more thing that can disagree with the message next to it.
+#[derive(Clone, Debug)]
+pub struct Delta {
+    pub run: HostRow,
+    /// Human-readable, one per dimension that moved.
+    pub reasons: Vec<String>,
+}
+
+/// The four outcomes the old aggregate totals could not tell apart, plus the
+/// one they could not see at all.
+#[derive(Default, Debug)]
+pub struct Diff {
+    /// Strictly worse on at least one gated dimension. A real regression.
+    pub regressed: Vec<Delta>,
+    /// In the golden, its model WAS swept, and it produced nothing. Coverage
+    /// loss — the defect class that used to make every total look better.
+    pub missing: Vec<HostRow>,
+    /// Meshed in this run and absent from the golden. An addition, not a defect.
+    pub added: Vec<HostRow>,
+    /// Differs in a way that is neither better nor worse: the host was
+    /// reclassified. See [`reclassifications`].
+    pub changed: Vec<Delta>,
+    /// Strictly better. Reported, never a failure.
+    ///
+    /// So the golden is a CEILING per host, not an equality snapshot, and a fix
+    /// does not red the lane it improves. The cost is that the ratchet does not
+    /// self-tighten: after an unblessed improvement from 40 open edges to 10, a
+    /// later slide back to 40 reads as clean. Blessing is what tightens it, and
+    /// the improvement list printed by the census is the prompt to do so. Making
+    /// improvements fail instead would buy that tightening at the price of
+    /// redding every geometry fix on the commit that makes it, which is the
+    /// friction that got the old constants bumped without scrutiny.
+    pub improved: Vec<Delta>,
+}
+
+impl Diff {
+    /// Everything the golden must be re-blessed to absorb.
+    pub fn requires_bless(&self) -> bool {
+        !self.regressed.is_empty()
+            || !self.missing.is_empty()
+            || !self.added.is_empty()
+            || !self.changed.is_empty()
+    }
+}
+
+/// Should this run rewrite the golden instead of gating against it?
+///
+/// Blessing REWRITES the gate's own expectations and returns before every check
+/// below it, so a blessing run is vacuously green — the one path by which this
+/// census could report "all good" because it stopped measuring. On a developer
+/// machine that is a deliberate act and exactly what the flag is for. In CI it
+/// would disarm the lane silently and permanently, so it is refused there: CI
+/// re-blesses by downloading the run-rows artifact, which every run writes
+/// unconditionally, gated or not.
+pub fn bless_mode(bless_set: bool, in_ci: bool) -> Result<bool, &'static str> {
+    if bless_set && in_ci {
+        return Err(
+            "refusing to bless in CI: blessing rewrites the golden and skips every check \
+             below it, so the lane would be vacuously green. Download the run-rows \
+             artifact from this job and commit it as the golden instead.",
+        );
+    }
+    Ok(bless_set)
+}
+
+/// Dimensions on which a matched pair can be RECLASSIFIED: neither better nor
+/// worse, but a different thing is now being measured, so the census must not
+/// absorb it silently.
+///
+/// `far` belongs here with `rep` because both are inputs to
+/// [`HostRow::is_torn_solid`] that carry no direction of their own. A host
+/// crossing the f32 magnitude threshold enters or leaves the gated defect
+/// population without any of its own counts moving, which is exactly the kind of
+/// silent population change this golden exists to surface.
+fn reclassifications(g: &HostRow, r: &HostRow) -> Vec<String> {
+    let mut out = Vec::new();
+    if g.rep != r.rep {
+        out.push(format!("representation {} -> {}", g.rep, r.rep));
+    }
+    if g.far != r.far {
+        let side = |f: bool| if f { "far-field" } else { "f32-safe" };
+        out.push(format!("coordinate magnitude {} -> {}", side(g.far), side(r.far)));
+    }
+    out
+}
+
+/// How one matched pair moved.
+#[derive(Default)]
+struct Classified {
+    /// A COUNT this host carries got worse. Directional on its own: no
+    /// relabelling of the host can make more unmatched edges into good news.
+    worse_counts: Vec<String>,
+    /// The gated `is_torn_solid` predicate started holding. Kept apart from
+    /// `worse_counts` because it is DERIVED from `rep`/`far`/`pre` as well as
+    /// from `open`, so a pure reclassification flips it without any count
+    /// moving, and calling that a geometry regression would be the same
+    /// misattribution in the opposite direction.
+    worse_gated: Vec<String>,
+    better: Vec<String>,
+}
+
+/// Classify one matched pair.
+fn classify(g: &HostRow, r: &HostRow) -> Classified {
+    let mut c = Classified::default();
+
+    if r.open > g.open {
+        c.worse_counts.push(format!("open edges {} -> {}", g.open, r.open));
+    } else if r.open < g.open {
+        c.better.push(format!("open edges {} -> {}", g.open, r.open));
+    }
+
+    // Triangles SHRINKING is the loss direction: geometry disappeared while the
+    // host still reported success.
+    if r.tris < g.tris {
+        c.worse_counts.push(format!("triangles {} -> {} (geometry lost)", g.tris, r.tris));
+    } else if r.tris > g.tris {
+        c.better.push(format!("triangles {} -> {}", g.tris, r.tris));
+    }
+
+    if r.collapsed && !g.collapsed {
+        c.worse_counts.push("gained snap-collapsed triangles".to_string());
+    } else if !r.collapsed && g.collapsed {
+        c.better.push("no longer has snap-collapsed triangles".to_string());
+    }
+
+    if r.diverged() && !g.diverged() {
+        c.worse_counts.push("newly depends on the triangulator's diagonal choice".to_string());
+    } else if !r.diverged() && g.diverged() {
+        c.better.push("no longer depends on the triangulator's diagonal choice".to_string());
+    }
+
+    // The gated predicate itself, not only its inputs. `is_torn_solid` also reads
+    // `pre`, and a no-void pass that starts or stops failing moves a host into or
+    // out of the genuine-defect population while `open`, `tris`, `collapsed` and
+    // `alt` all hold. Without this the derived `closed solids that are not
+    // watertight` ceiling could grow with every per-host check silent — a total
+    // moving with nothing to attribute it to, which is the whole complaint.
+    if r.is_torn_solid() && !g.is_torn_solid() {
+        c.worse_gated
+            .push("newly a genuine watertightness defect (closed solid, f32-safe, torn)".to_string());
+    } else if !r.is_torn_solid() && g.is_torn_solid() {
+        c.better.push("no longer a genuine watertightness defect".to_string());
+    }
+
+    c
+}
+
+/// Diff a run against the golden, scoped to the models this run actually swept.
+///
+/// A host is only ever reported MISSING when its model was swept — see the
+/// module note on fixture-fetch tolerance.
+pub fn diff(golden: &[HostRow], run: &[HostRow], swept_models: &BTreeSet<String>) -> Diff {
+    let by_key: BTreeMap<(&str, u32), &HostRow> = golden.iter().map(|r| (r.key(), r)).collect();
+    let seen: BTreeSet<(&str, u32)> = run.iter().map(|r| r.key()).collect();
+
+    let mut out = Diff::default();
+    for r in run {
+        let Some(g) = by_key.get(&r.key()) else {
+            out.added.push(r.clone());
+            continue;
+        };
+        let reclassified = reclassifications(g, r);
+        let c = classify(g, r);
+        let delta = |reasons| Delta { run: r.clone(), reasons };
+        // Order matters, and it is the whole point of the issue.
+        //
+        // A worsened COUNT outranks everything, including a reclassification.
+        // Filing a host that both changed representation type AND tore further
+        // under "reclassified — review, then re-bless" would invite precisely
+        // the re-bless that absorbs the tear. Worse on any count also outranks
+        // an improvement on another: trading a tear for a collapse is not a
+        // wash.
+        //
+        // A reclassification then outranks the DERIVED `is_torn_solid` flip,
+        // because a host relabelled `SurfaceModel -> CSG` joins the gated defect
+        // population without a single one of its counts moving, and that is a
+        // change of question, not a degradation.
+        if !c.worse_counts.is_empty() {
+            let mut reasons = c.worse_counts;
+            reasons.extend(c.worse_gated);
+            reasons.extend(reclassified);
+            out.regressed.push(delta(reasons));
+        } else if !reclassified.is_empty() {
+            let mut reasons = reclassified;
+            reasons.extend(c.worse_gated);
+            out.changed.push(delta(reasons));
+        } else if !c.worse_gated.is_empty() {
+            out.regressed.push(delta(c.worse_gated));
+        } else if !c.better.is_empty() {
+            out.improved.push(delta(c.better));
+        }
+    }
+    for g in golden {
+        if swept_models.contains(&g.model) && !seen.contains(&g.key()) {
+            out.missing.push(g.clone());
+        }
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Serialization
+//
+// TSV, one host per line, sorted. The whole point of this file is that a human
+// reviews its diff, and a 1170-element JSON array does not diff readably: one
+// changed count would render as a multi-line hunk. One line per host means one
+// changed host is one changed line.
+// ---------------------------------------------------------------------------
+
+const HEADER: &str = "\
+# Per-host watertightness census golden. Generated, do not hand-edit.
+#
+# Re-bless with:
+#   IFCLITE_CENSUS_BLESS=1 cargo test -p ifc-lite-geometry \\
+#     --features triangulation-alt --test triangulation_invariance
+#
+# model: manifest-relative path (basenames are NOT unique across the corpus).
+# open:  open boundary edges, 1 mm snapped topology.
+# tris:  emitted triangles. A shrink is geometry loss even when open stays 0.
+# coll:  1 if any triangle collapsed under the snap.
+# far:   1 if |coord| is past what f32 carries mm topology at (reported, not gated).
+# alt:   open edges under the alternate triangulator, or x if that pass failed.
+# pre:   open edges with no voids applied; x if that pass failed, - if not taken.
+model\tid\trep\topen\ttris\tcoll\tfar\talt\tpre";
+
+fn pre_token(p: PreVoid) -> String {
+    match p {
+        PreVoid::NotTaken => "-".to_string(),
+        PreVoid::Failed => "x".to_string(),
+        PreVoid::Open(v) => v.to_string(),
+    }
+}
+
+fn parse_pre(tok: &str) -> Result<PreVoid, String> {
+    match tok {
+        "-" => Ok(PreVoid::NotTaken),
+        "x" => Ok(PreVoid::Failed),
+        v => v.parse().map(PreVoid::Open).map_err(|_| format!("bad pre {v:?}")),
+    }
+}
+
+fn parse_flag(tok: &str) -> Result<bool, String> {
+    match tok {
+        "0" => Ok(false),
+        "1" => Ok(true),
+        v => Err(format!("bad flag {v:?}")),
+    }
+}
+
+pub fn render(rows: &[HostRow]) -> String {
+    let mut rows: Vec<&HostRow> = rows.iter().collect();
+    rows.sort_by(|a, b| a.key().cmp(&b.key()));
+    let mut out = String::from(HEADER);
+    for r in rows {
+        let alt = r.alt.map(|v| v.to_string()).unwrap_or_else(|| "x".to_string());
+        out.push_str(&format!(
+            "\n{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+            r.model,
+            r.id,
+            r.rep,
+            r.open,
+            r.tris,
+            u8::from(r.collapsed),
+            u8::from(r.far),
+            alt,
+            pre_token(r.pre),
+        ));
+    }
+    out.push('\n');
+    out
+}
+
+pub fn parse(text: &str) -> Result<Vec<HostRow>, String> {
+    let mut out = Vec::new();
+    for (n, line) in text.lines().enumerate() {
+        // Skip comments, the column header and blank lines. `model\t` catches
+        // the header without also swallowing a fixture literally named "model".
+        if line.is_empty() || line.starts_with('#') || line.starts_with("model\t") {
+            continue;
+        }
+        let f: Vec<&str> = line.split('\t').collect();
+        if f.len() != 9 {
+            return Err(format!("line {}: expected 9 columns, got {}", n + 1, f.len()));
+        }
+        let num = |i: usize| -> Result<usize, String> {
+            f[i].parse::<usize>().map_err(|_| format!("line {}: bad number {:?}", n + 1, f[i]))
+        };
+        out.push(HostRow {
+            model: f[0].to_string(),
+            id: f[1].parse().map_err(|_| format!("line {}: bad id {:?}", n + 1, f[1]))?,
+            rep: f[2].to_string(),
+            open: num(3)?,
+            tris: num(4)?,
+            collapsed: parse_flag(f[5]).map_err(|e| format!("line {}: {e}", n + 1))?,
+            far: parse_flag(f[6]).map_err(|e| format!("line {}: {e}", n + 1))?,
+            alt: if f[7] == "x" { None } else { Some(num(7)?) },
+            pre: parse_pre(f[8]).map_err(|e| format!("line {}: {e}", n + 1))?,
+        });
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(model: &str, id: u32, open: usize, tris: usize) -> HostRow {
+        HostRow {
+            model: model.to_string(),
+            id,
+            rep: "SweptSolid".to_string(),
+            open,
+            tris,
+            collapsed: false,
+            far: false,
+            alt: Some(open),
+            pre: PreVoid::NotTaken,
+        }
+    }
+
+    fn swept(models: &[&str]) -> BTreeSet<String> {
+        models.iter().map(|m| m.to_string()).collect()
+    }
+
+    #[test]
+    fn a_grown_open_count_is_a_regression_and_a_shrunk_one_is_not() {
+        let g = vec![row("a.ifc", 1, 10, 100)];
+        let worse = diff(&g, &[row("a.ifc", 1, 11, 100)], &swept(&["a.ifc"]));
+        assert_eq!(worse.regressed.len(), 1, "open 10 -> 11 must regress");
+        assert!(worse.improved.is_empty());
+
+        let better = diff(&g, &[row("a.ifc", 1, 9, 100)], &swept(&["a.ifc"]));
+        assert!(better.regressed.is_empty(), "open 10 -> 9 must not regress");
+        assert_eq!(better.improved.len(), 1);
+        assert!(!better.requires_bless(), "an improvement alone must not red the build");
+    }
+
+    #[test]
+    fn losing_triangles_regresses_even_while_open_stays_zero() {
+        // The failure this column exists for: a host whose mesh degrades to
+        // empty still returns Ok and still reports open == 0, which reads as a
+        // perfect watertight solid under an open-count-only golden.
+        let g = vec![row("a.ifc", 1, 0, 800)];
+        let d = diff(&g, &[row("a.ifc", 1, 0, 0)], &swept(&["a.ifc"]));
+        assert_eq!(d.regressed.len(), 1, "800 -> 0 triangles must regress");
+        assert!(d.regressed[0].reasons[0].contains("geometry lost"));
+    }
+
+    #[test]
+    fn a_host_that_stopped_meshing_is_coverage_loss_not_an_improvement() {
+        // The #2382 bug class: under absolute totals this element's defects
+        // simply leave the sum and the census reads greener.
+        let g = vec![row("a.ifc", 1, 40, 100), row("a.ifc", 2, 0, 50)];
+        let d = diff(&g, &[row("a.ifc", 2, 0, 50)], &swept(&["a.ifc"]));
+        assert_eq!(d.missing.len(), 1);
+        assert_eq!(d.missing[0].id, 1);
+        assert!(d.improved.is_empty(), "a vanished host is not an improvement");
+        assert!(d.requires_bless());
+    }
+
+    #[test]
+    fn a_model_that_was_not_swept_reports_no_coverage_loss() {
+        // Fixture-fetch tolerance: MIN_MODELS sits under the corpus on purpose.
+        let g = vec![row("a.ifc", 1, 40, 100), row("unfetched.ifc", 7, 0, 20)];
+        let d = diff(&g, &[row("a.ifc", 1, 40, 100)], &swept(&["a.ifc"]));
+        assert!(d.missing.is_empty(), "an unswept model's hosts are not missing");
+        assert!(!d.requires_bless());
+    }
+
+    #[test]
+    fn a_newly_meshing_host_is_an_addition_not_a_regression() {
+        let g = vec![row("a.ifc", 1, 0, 100)];
+        let d = diff(&g, &[row("a.ifc", 1, 0, 100), row("a.ifc", 2, 90, 400)], &swept(&["a.ifc"]));
+        assert!(d.regressed.is_empty(), "recovered geometry must not read as a regression");
+        assert_eq!(d.added.len(), 1);
+        assert_eq!(d.added[0].id, 2);
+        assert!(d.requires_bless(), "an addition must still be acknowledged");
+    }
+
+    #[test]
+    fn worse_on_one_dimension_beats_better_on_another() {
+        let mut r = row("a.ifc", 1, 5, 400);
+        r.collapsed = true;
+        let d = diff(&[row("a.ifc", 1, 10, 100)], &[r], &swept(&["a.ifc"]));
+        assert_eq!(d.regressed.len(), 1, "a gained collapse is not offset by fewer open edges");
+        assert!(d.improved.is_empty());
+    }
+
+    #[test]
+    fn a_newly_triangulator_dependent_host_regresses() {
+        let mut r = row("a.ifc", 1, 10, 100);
+        r.alt = Some(12);
+        let d = diff(&[row("a.ifc", 1, 10, 100)], &[r], &swept(&["a.ifc"]));
+        assert_eq!(d.regressed.len(), 1);
+        assert!(d.regressed[0].reasons[0].contains("diagonal choice"));
+
+        // A failed alternate pass is a divergence too.
+        let mut f = row("a.ifc", 1, 10, 100);
+        f.alt = None;
+        let d = diff(&[row("a.ifc", 1, 10, 100)], &[f], &swept(&["a.ifc"]));
+        assert_eq!(d.regressed.len(), 1);
+    }
+
+    #[test]
+    fn crossing_the_f32_magnitude_threshold_is_a_reclassification() {
+        // `far` is an input to `is_torn_solid` with no direction of its own, so a
+        // host crossing the threshold enters or leaves the gated defect
+        // population while every count it carries holds. Silently absorbing that
+        // would be a population change with nothing to attribute it to.
+        let mut g = row("a.ifc", 1, 4, 100);
+        g.rep = "CSG".to_string();
+        g.pre = PreVoid::Open(0);
+        g.far = true;
+        let mut r = g.clone();
+        r.far = false;
+        let d = diff(&[g.clone()], &[r], &swept(&["a.ifc"]));
+        assert_eq!(d.changed.len(), 1, "a far -> near flip must be acknowledged");
+        assert!(d.changed[0].reasons[0].contains("coordinate magnitude"));
+        assert!(d.regressed.is_empty());
+        assert!(d.improved.is_empty());
+    }
+
+    #[test]
+    fn a_no_void_pass_that_stops_failing_makes_the_host_a_gated_defect() {
+        // The other input to `is_torn_solid` that moves on its own. With `pre`
+        // Failed the host is excluded from the genuine-defect count; once that
+        // pass succeeds it joins, and `open`, `tris`, `collapsed` and `alt` are
+        // all unmoved. Only the gated predicate itself sees this.
+        let mut g = row("a.ifc", 1, 4, 100);
+        g.rep = "CSG".to_string();
+        g.pre = PreVoid::Failed;
+        assert!(!g.is_torn_solid());
+        let mut r = g.clone();
+        r.pre = PreVoid::Open(0);
+        assert!(r.is_torn_solid());
+
+        let d = diff(&[g.clone()], &[r.clone()], &swept(&["a.ifc"]));
+        assert_eq!(d.regressed.len(), 1, "joining the gated defect set is a regression");
+        assert!(d.regressed[0].reasons[0].contains("genuine watertightness defect"));
+
+        // And the reverse direction is an improvement, not a regression.
+        let back = diff(&[r], &[g], &swept(&["a.ifc"]));
+        assert!(back.regressed.is_empty());
+        assert_eq!(back.improved.len(), 1);
+    }
+
+    /// Every `HostRow` shape that matters, for the exhaustive invariant below.
+    fn variants() -> Vec<HostRow> {
+        let mut out = Vec::new();
+        for rep in ["CSG", "SurfaceModel"] {
+            for open in [0usize, 3] {
+                for tris in [0usize, 5] {
+                    for collapsed in [false, true] {
+                        for far in [false, true] {
+                            for alt in [None, Some(0usize), Some(3), Some(9)] {
+                                for pre in
+                                    [PreVoid::NotTaken, PreVoid::Failed, PreVoid::Open(0), PreVoid::Open(2)]
+                                {
+                                    out.push(HostRow {
+                                        model: "a.ifc".to_string(),
+                                        id: 1,
+                                        rep: rep.to_string(),
+                                        open,
+                                        tris,
+                                        collapsed,
+                                        far,
+                                        alt,
+                                        pre,
+                                    });
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn a_clean_diff_can_never_let_a_derived_total_grow() {
+        // The census still prints and asserts corpus ceilings, now DERIVED from
+        // the golden. Those assertions are only honest if they are implied by the
+        // per-host checks: a total that can grow while every host reads clean
+        // would fail with a message naming no element, which is precisely the
+        // unattributable number this issue is about.
+        //
+        // Exhaustive over every dimension the classifier reads, both sides.
+        let vs = variants();
+        let all = swept(&["a.ifc"]);
+        let mut checked = 0usize;
+        for g in &vs {
+            for r in &vs {
+                let d = diff(std::slice::from_ref(g), std::slice::from_ref(r), &all);
+                if d.requires_bless() {
+                    continue;
+                }
+                checked += 1;
+                let (want, got) = (totals([g]), totals([r]));
+                assert!(got.open_edges <= want.open_edges, "open edges: {g:?} -> {r:?}");
+                assert!(got.torn <= want.torn, "torn: {g:?} -> {r:?}");
+                assert!(got.collapsed <= want.collapsed, "collapsed: {g:?} -> {r:?}");
+                assert!(got.torn_solid <= want.torn_solid, "torn solid: {g:?} -> {r:?}");
+                assert!(got.non_invariant <= want.non_invariant, "non-invariant: {g:?} -> {r:?}");
+                assert_eq!(got.hosts, want.hosts);
+            }
+        }
+        // Guard against the loop vacuously skipping everything.
+        assert!(checked > vs.len(), "only {checked} clean pairs of {}", vs.len() * vs.len());
+    }
+
+    #[test]
+    fn a_reclassified_host_that_also_tore_further_is_a_regression() {
+        // The re-bless trap. Under a reclassification-first rule this host reads
+        // as "reclassified — review, then re-bless", and the re-bless absorbs a
+        // 10 -> 400 tear without anyone having been told there was one.
+        let mut r = row("a.ifc", 1, 400, 100);
+        r.rep = "CSG".to_string();
+        let d = diff(&[row("a.ifc", 1, 10, 100)], &[r], &swept(&["a.ifc"]));
+        assert!(d.changed.is_empty(), "a worsened count must not be filed as a relabel");
+        assert_eq!(d.regressed.len(), 1);
+        let reasons = d.regressed[0].reasons.join("; ");
+        assert!(reasons.contains("open edges 10 -> 400"), "{reasons}");
+        assert!(reasons.contains("representation SweptSolid -> CSG"), "{reasons}");
+    }
+
+    #[test]
+    fn joining_the_gated_defect_set_by_relabel_alone_is_a_reclassification() {
+        // The opposite misattribution. `is_torn_solid` reads `rep`, so a host
+        // relabelled SurfaceModel -> CSG enters the gated defect population with
+        // every count it carries unmoved. That is a change of question, not a
+        // degradation, and calling it a regression would send someone hunting a
+        // geometry bug that does not exist.
+        let mut g = row("a.ifc", 1, 4, 100);
+        g.rep = "SurfaceModel".to_string();
+        g.pre = PreVoid::Open(0);
+        assert!(!g.is_torn_solid());
+        let mut r = g.clone();
+        r.rep = "CSG".to_string();
+        assert!(r.is_torn_solid());
+
+        let d = diff(&[g], &[r], &swept(&["a.ifc"]));
+        assert!(d.regressed.is_empty(), "a pure relabel is not a geometry regression");
+        assert_eq!(d.changed.len(), 1);
+        let reasons = d.changed[0].reasons.join("; ");
+        assert!(reasons.contains("representation SurfaceModel -> CSG"), "{reasons}");
+        // Still says the gated population grew — acknowledged, not hidden.
+        assert!(reasons.contains("genuine watertightness defect"), "{reasons}");
+    }
+
+    #[test]
+    fn blessing_is_refused_in_ci_and_allowed_locally() {
+        // The one path that returns green without measuring anything.
+        assert_eq!(bless_mode(true, false), Ok(true), "a developer may re-bless");
+        assert_eq!(bless_mode(false, true), Ok(false));
+        assert_eq!(bless_mode(false, false), Ok(false));
+        let err = bless_mode(true, true).expect_err("CI must never bless");
+        assert!(err.contains("vacuously green"), "{err}");
+    }
+
+    #[test]
+    fn a_reclassified_representation_is_neither_better_nor_worse() {
+        let mut r = row("a.ifc", 1, 10, 100);
+        r.rep = "CSG".to_string();
+        let d = diff(&[row("a.ifc", 1, 10, 100)], &[r], &swept(&["a.ifc"]));
+        assert!(d.regressed.is_empty());
+        assert!(d.improved.is_empty());
+        assert_eq!(d.changed.len(), 1);
+        assert!(d.requires_bless());
+    }
+
+    #[test]
+    fn identical_basenames_under_different_directories_stay_distinct() {
+        // Three basenames genuinely repeat across the fixture manifest. Keying
+        // on the basename would let one model's row answer for another's.
+        let g = vec![row("x/basin.ifc", 1, 0, 10), row("y/basin.ifc", 1, 0, 10)];
+        let run = vec![row("x/basin.ifc", 1, 0, 10), row("y/basin.ifc", 1, 99, 10)];
+        let d = diff(&g, &run, &swept(&["x/basin.ifc", "y/basin.ifc"]));
+        assert_eq!(d.regressed.len(), 1);
+        assert_eq!(d.regressed[0].run.model, "y/basin.ifc");
+    }
+
+    #[test]
+    fn render_round_trips_through_parse() {
+        let rows = vec![
+            HostRow {
+                model: "vendor/a.ifc".to_string(),
+                id: 42,
+                rep: "CSG".to_string(),
+                open: 7,
+                tris: 300,
+                collapsed: true,
+                far: false,
+                alt: None,
+                pre: PreVoid::Open(3),
+            },
+            HostRow {
+                model: "vendor/a.ifc".to_string(),
+                id: 7,
+                rep: "SurfaceModel".to_string(),
+                open: 0,
+                tris: 0,
+                collapsed: false,
+                far: true,
+                alt: Some(0),
+                pre: PreVoid::Failed,
+            },
+        ];
+        let text = render(&rows);
+        let back = parse(&text).expect("round trip");
+        // render sorts, so compare against the sorted expectation.
+        let mut want = rows.clone();
+        want.sort_by(|a, b| (a.model.as_str(), a.id).cmp(&(b.model.as_str(), b.id)));
+        assert_eq!(back, want);
+        // And the file is stable: re-rendering what we parsed is byte-identical.
+        assert_eq!(render(&back), text);
+    }
+
+    #[test]
+    fn a_truncated_row_is_an_error_not_a_silently_short_golden() {
+        let err = parse("model\tid\trep\topen\ttris\tcoll\tfar\talt\tpre\na.ifc\t1\tCSG\t0\t0\t0\t0\n")
+            .expect_err("a 7-column row must not parse");
+        assert!(err.contains("expected 9 columns"), "{err}");
+    }
+
+    #[test]
+    fn torn_solid_counts_only_f32_safe_closed_solids_that_processed() {
+        let solid = |rep: &str, open: usize, far: bool, pre: PreVoid| HostRow {
+            rep: rep.to_string(),
+            open,
+            far,
+            pre,
+            ..row("a.ifc", 1, 0, 10)
+        };
+        assert!(solid("CSG", 4, false, PreVoid::Open(0)).is_torn_solid());
+        assert!(!solid("CSG", 0, false, PreVoid::Open(0)).is_torn_solid(), "watertight");
+        assert!(!solid("SurfaceModel", 4, false, PreVoid::Open(0)).is_torn_solid(), "open by design");
+        assert!(!solid("CSG", 4, true, PreVoid::Open(0)).is_torn_solid(), "far field is not gated");
+        assert!(!solid("CSG", 4, false, PreVoid::Failed).is_torn_solid(), "no-void pass failed");
+    }
+}

--- a/rust/geometry/tests/manifests/watertightness_census.tsv
+++ b/rust/geometry/tests/manifests/watertightness_census.tsv
@@ -1,0 +1,1184 @@
+# Per-host watertightness census golden. Generated, do not hand-edit.
+#
+# Re-bless with:
+#   IFCLITE_CENSUS_BLESS=1 cargo test -p ifc-lite-geometry \
+#     --features triangulation-alt --test triangulation_invariance
+#
+# model: manifest-relative path (basenames are NOT unique across the corpus).
+# open:  open boundary edges, 1 mm snapped topology.
+# tris:  emitted triangles. A shrink is geometry loss even when open stays 0.
+# coll:  1 if any triangle collapsed under the snap.
+# far:   1 if |coord| is past what f32 carries mm topology at (reported, not gated).
+# alt:   open edges under the alternate triangulator, or x if that pass failed.
+# pre:   open edges with no voids applied; x if that pass failed, - if not taken.
+model	id	rep	open	tris	coll	far	alt	pre
+ara3d/AC20-FZK-Haus.ifc	17040	SweptSolid	0	36	0	0	0	-
+ara3d/AC20-FZK-Haus.ifc	18698	SweptSolid	0	54	0	0	0	-
+ara3d/AC20-FZK-Haus.ifc	21966	SweptSolid	0	80	0	0	0	-
+ara3d/AC20-FZK-Haus.ifc	27421	SweptSolid	0	80	0	0	0	-
+ara3d/AC20-FZK-Haus.ifc	31470	SweptSolid	0	52	0	0	0	-
+ara3d/AC20-FZK-Haus.ifc	32407	SweptSolid	0	72	0	0	0	-
+ara3d/AC20-FZK-Haus.ifc	59290	SweptSolid	0	32	0	0	0	-
+ara3d/AC20-FZK-Haus.ifc	60012	Clipping	0	204	0	0	18	-
+ara3d/AC20-FZK-Haus.ifc	67828	Clipping	0	196	0	0	18	-
+ara3d/C20-Institute-Var-2.ifc	31190	SweptSolid	0	320	0	0	0	-
+ara3d/C20-Institute-Var-2.ifc	35819	SweptSolid	0	324	0	0	0	-
+ara3d/C20-Institute-Var-2.ifc	40505	SweptSolid	0	600	0	0	0	-
+ara3d/C20-Institute-Var-2.ifc	47404	SweptSolid	0	116	0	0	0	-
+ara3d/C20-Institute-Var-2.ifc	50078	SweptSolid	0	130	0	0	0	-
+ara3d/C20-Institute-Var-2.ifc	52075	SweptSolid	0	52	0	0	0	-
+ara3d/C20-Institute-Var-2.ifc	55353	SweptSolid	0	42	0	0	0	-
+ara3d/C20-Institute-Var-2.ifc	56404	SweptSolid	0	40	0	0	0	-
+ara3d/C20-Institute-Var-2.ifc	57708	SweptSolid	0	40	0	0	0	-
+ara3d/C20-Institute-Var-2.ifc	72946	SweptSolid	0	80	0	0	0	-
+ara3d/C20-Institute-Var-2.ifc	81755	SweptSolid	0	32	0	0	0	-
+ara3d/C20-Institute-Var-2.ifc	82662	SweptSolid	0	32	0	0	0	-
+ara3d/C20-Institute-Var-2.ifc	83555	SweptSolid	0	320	0	0	0	-
+ara3d/C20-Institute-Var-2.ifc	87784	SweptSolid	0	70	0	0	0	-
+ara3d/C20-Institute-Var-2.ifc	90339	SweptSolid	0	320	0	0	0	-
+ara3d/C20-Institute-Var-2.ifc	94567	SweptSolid	0	324	0	0	0	-
+ara3d/C20-Institute-Var-2.ifc	99022	SweptSolid	0	100	0	0	0	-
+ara3d/C20-Institute-Var-2.ifc	100667	SweptSolid	0	72	0	0	0	-
+ara3d/C20-Institute-Var-2.ifc	101958	SweptSolid	0	120	0	0	0	-
+ara3d/C20-Institute-Var-2.ifc	104309	SweptSolid	0	64	0	0	0	-
+ara3d/C20-Institute-Var-2.ifc	107811	SweptSolid	0	328	0	0	0	-
+ara3d/C20-Institute-Var-2.ifc	112277	SweptSolid	0	36	0	0	0	-
+ara3d/C20-Institute-Var-2.ifc	113099	SweptSolid	0	42	0	0	0	-
+ara3d/C20-Institute-Var-2.ifc	114155	SweptSolid	0	32	0	0	0	-
+ara3d/C20-Institute-Var-2.ifc	114727	SweptSolid	0	32	0	0	0	-
+ara3d/C20-Institute-Var-2.ifc	125284	SweptSolid	0	80	0	0	0	-
+ara3d/C20-Institute-Var-2.ifc	135395	SweptSolid	0	320	0	0	0	-
+ara3d/C20-Institute-Var-2.ifc	139845	SweptSolid	0	324	0	0	0	-
+ara3d/C20-Institute-Var-2.ifc	144069	SweptSolid	0	32	0	0	0	-
+ara3d/C20-Institute-Var-2.ifc	144635	SweptSolid	0	32	0	0	0	-
+ara3d/C20-Institute-Var-2.ifc	145201	SweptSolid	0	948	0	0	0	-
+ara3d/C20-Institute-Var-2.ifc	154762	SweptSolid	0	116	0	0	0	-
+ara3d/C20-Institute-Var-2.ifc	157112	SweptSolid	0	120	0	0	0	-
+ara3d/C20-Institute-Var-2.ifc	159462	SweptSolid	0	192	0	0	0	-
+ara3d/C20-Institute-Var-2.ifc	165435	SweptSolid	0	34	0	0	0	-
+ara3d/C20-Institute-Var-2.ifc	166266	SweptSolid	0	40	0	0	0	-
+ara3d/C20-Institute-Var-2.ifc	167338	SweptSolid	0	40	0	0	0	-
+ara3d/C20-Institute-Var-2.ifc	178044	SweptSolid	0	64	0	0	0	-
+ara3d/C20-Institute-Var-2.ifc	188155	SweptSolid	0	320	0	0	0	-
+ara3d/C20-Institute-Var-2.ifc	192605	SweptSolid	0	324	0	0	0	-
+ara3d/C20-Institute-Var-2.ifc	196829	SweptSolid	0	32	0	0	0	-
+ara3d/C20-Institute-Var-2.ifc	197395	SweptSolid	0	32	0	0	0	-
+ara3d/C20-Institute-Var-2.ifc	197961	SweptSolid	0	948	0	0	0	-
+ara3d/C20-Institute-Var-2.ifc	207522	SweptSolid	0	116	0	0	0	-
+ara3d/C20-Institute-Var-2.ifc	209872	SweptSolid	0	120	0	0	0	-
+ara3d/C20-Institute-Var-2.ifc	212222	SweptSolid	0	182	0	0	0	-
+ara3d/C20-Institute-Var-2.ifc	218661	SweptSolid	0	40	0	0	0	-
+ara3d/C20-Institute-Var-2.ifc	219733	SweptSolid	0	40	0	0	0	-
+ara3d/C20-Institute-Var-2.ifc	220884	SweptSolid	0	64	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	26448	SweptSolid	0	72	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	26635	SweptSolid	0	52	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	30660	SweptSolid	0	28	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	30826	SweptSolid	0	28	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	31022	SweptSolid	0	28	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	40974	SweptSolid	0	28	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	52867	SweptSolid	0	34	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	53112	SweptSolid	0	34	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	61530	SweptSolid	0	48	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	67415	SweptSolid	0	28	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	67562	SweptSolid	0	28	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	67758	SweptSolid	0	28	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	77712	SweptSolid	0	28	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	89640	SweptSolid	0	34	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	89885	SweptSolid	0	34	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	90210	SweptSolid	0	48	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	99281	SweptSolid	0	72	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	100158	SweptSolid	0	168	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	100207	SweptSolid	0	186	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	106167	Clipping	0	48	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	106259	SweptSolid	0	40	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	106951	SweptSolid	0	100	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	136983	SweptSolid	0	80	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	137547	Clipping	0	60	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	138037	Clipping	12	301	1	0	21	0
+ara3d/FM_ARC_DigitalHub.ifc	138279	SweptSolid	0	60	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	138767	Clipping	0	80	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	139288	Clipping	9	300	1	0	9	0
+ara3d/FM_ARC_DigitalHub.ifc	139605	Clipping	9	300	1	0	9	0
+ara3d/FM_ARC_DigitalHub.ifc	139864	Clipping	0	184	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	139985	Clipping	9	300	1	0	18	0
+ara3d/FM_ARC_DigitalHub.ifc	140227	SweptSolid	0	184	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	140337	SweptSolid	0	496	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	146777	SweptSolid	0	222	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	149094	SweptSolid	0	668	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	155733	SweptSolid	0	282	0	0	11	-
+ara3d/FM_ARC_DigitalHub.ifc	187843	SweptSolid	0	172	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	188186	SweptSolid	0	32	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	188235	SweptSolid	0	52	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	188333	SweptSolid	0	74	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	188424	SweptSolid	0	28	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	196863	SweptSolid	0	112	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	196912	SweptSolid	0	52	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	196961	SweptSolid	0	132	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	197010	SweptSolid	0	52	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	197353	SweptSolid	0	52	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	197794	SweptSolid	0	52	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	200204	SweptSolid	0	52	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	200253	SweptSolid	0	52	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	200449	SweptSolid	0	52	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	200645	SweptSolid	0	52	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	216340	SweptSolid	0	68	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	216561	SweptSolid	0	44	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	216762	SweptSolid	0	28	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	217867	SweptSolid	0	72	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	218038	SweptSolid	0	32	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	218227	SweptSolid	0	72	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	218398	SweptSolid	0	32	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	218587	SweptSolid	0	52	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	218718	SweptSolid	0	52	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	219094	SweptSolid	0	52	0	0	0	-
+ara3d/FM_ARC_DigitalHub.ifc	219225	SweptSolid	0	52	0	0	0	-
+ara3d/ISSUE_005_haus.ifc	17040	SweptSolid	0	36	0	0	0	-
+ara3d/ISSUE_005_haus.ifc	18698	SweptSolid	0	54	0	0	0	-
+ara3d/ISSUE_005_haus.ifc	21966	SweptSolid	0	80	0	0	0	-
+ara3d/ISSUE_005_haus.ifc	27421	SweptSolid	0	80	0	0	0	-
+ara3d/ISSUE_005_haus.ifc	31470	SweptSolid	0	52	0	0	0	-
+ara3d/ISSUE_005_haus.ifc	32407	SweptSolid	0	72	0	0	0	-
+ara3d/ISSUE_005_haus.ifc	59290	SweptSolid	0	32	0	0	0	-
+ara3d/ISSUE_005_haus.ifc	60012	Clipping	0	204	0	0	18	-
+ara3d/ISSUE_005_haus.ifc	67828	Clipping	0	196	0	0	18	-
+ara3d/ISSUE_126_model.ifc	40983	SweptSolid	0	52	0	0	0	-
+ara3d/ISSUE_126_model.ifc	43236	SweptSolid	0	20	0	0	0	-
+ara3d/ISSUE_126_model.ifc	49197	SweptSolid	0	20	0	0	0	-
+ara3d/ISSUE_126_model.ifc	49964	SweptSolid	0	20	0	0	0	-
+ara3d/ISSUE_126_model.ifc	50658	SweptSolid	0	54	0	0	0	-
+ara3d/ISSUE_126_model.ifc	50766	SweptSolid	0	58	0	0	0	-
+ara3d/ISSUE_126_model.ifc	52352	SweptSolid	0	34	0	0	0	-
+ara3d/ISSUE_126_model.ifc	56758	SweptSolid	0	30	0	0	0	-
+ara3d/ISSUE_126_model.ifc	73237	SweptSolid	0	28	0	0	0	-
+ara3d/ISSUE_126_model.ifc	73349	SweptSolid	0	216	0	0	0	-
+ara3d/ISSUE_126_model.ifc	77438	SweptSolid	0	80	0	0	0	-
+ara3d/ISSUE_126_model.ifc	78232	SweptSolid	0	52	0	0	0	-
+ara3d/ISSUE_126_model.ifc	78975	SweptSolid	0	170	0	0	0	-
+ara3d/ISSUE_126_model.ifc	82108	SweptSolid	0	28	0	0	0	-
+ara3d/ISSUE_126_model.ifc	82925	SweptSolid	0	34	0	0	0	-
+ara3d/ISSUE_126_model.ifc	83323	SweptSolid	0	66	0	0	0	-
+ara3d/ISSUE_126_model.ifc	83694	SweptSolid	0	20	0	0	0	-
+ara3d/ISSUE_126_model.ifc	84442	SweptSolid	0	34	0	0	0	-
+ara3d/ISSUE_126_model.ifc	86446	SweptSolid	0	54	0	0	0	-
+ara3d/ISSUE_126_model.ifc	86609	SweptSolid	0	28	0	0	0	-
+ara3d/ISSUE_126_model.ifc	98282	SweptSolid	24	130	0	0	24	0
+ara3d/ISSUE_126_model.ifc	100504	SweptSolid	0	50	0	0	0	-
+ara3d/ISSUE_126_model.ifc	111997	SweptSolid	27	51	0	0	27	0
+ara3d/ISSUE_126_model.ifc	131771	SweptSolid	0	96	0	0	0	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	6891	Clipping	91	345	0	1	56	6
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	7526	SweptSolid	1113	958	1	1	993	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	8434	Clipping	0	44	0	1	0	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	8756	Clipping	4	28	0	1	3	3
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	9094	SweptSolid	864	1160	1	1	860	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	11115	Clipping	21	167	0	1	9	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	12381	SweptSolid	1674	1399	1	1	1234	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	32810	SweptSolid	252	1513	0	1	155	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	34385	SweptSolid	443	485	0	1	460	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	36735	SweptSolid	461	867	0	1	395	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	57084	SweptSolid	54	109	0	1	52	12
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	57776	SweptSolid	57	111	0	1	41	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	57944	Clipping	23	99	0	1	23	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	58297	Clipping	67	221	0	1	19	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	59111	SweptSolid	244	393	0	1	214	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	59957	SweptSolid	37	55	0	1	37	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	60118	SweptSolid	17	123	1	1	17	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	60344	SweptSolid	0	36	0	1	0	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	61300	Clipping	728	1413	1	1	758	3
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	63146	Clipping	20	106	0	1	23	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	63466	Clipping	16	164	0	1	22	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	63721	SweptSolid	6	22	0	1	6	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	68263	Clipping	15	71	0	1	15	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	68943	Clipping	26	162	0	1	29	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	69569	Clipping	7	43	0	1	7	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	69961	Clipping	21	119	0	1	21	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	81223	Clipping	17	135	0	1	20	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	81562	Clipping	43	181	0	1	43	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	81869	Clipping	0	28	0	1	0	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	83043	Clipping	13	41	0	1	13	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	138693	Clipping	31	91	0	1	31	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	138919	Clipping	11	71	0	1	11	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	139190	SweptSolid	22	144	0	1	22	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	139364	Clipping	35	152	0	1	35	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	139571	SweptSolid	38	276	0	1	38	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	141060	SweptSolid	67	99	0	1	41	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	145270	SweptSolid	46	96	0	1	50	6
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	145756	SweptSolid	13	101	0	1	13	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	145897	SweptSolid	32	70	0	1	32	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	148665	SweptSolid	474	912	0	1	350	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	148864	SweptSolid	3	97	0	1	3	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	149277	SweptSolid	221	447	1	1	261	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	149280	SweptSolid	230	825	0	1	187	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	196139	SweptSolid	145	161	0	1	130	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	196326	SweptSolid	88	68	0	1	91	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	233296	SweptSolid	0	46	0	1	0	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	244479	SweptSolid	356	394	0	1	267	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	247051	Clipping	29	164	1	1	29	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	247203	Clipping	18	88	0	1	18	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	247726	Clipping	38	180	0	1	38	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	247953	Clipping	37	165	0	1	38	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	295370	SweptSolid	1050	915	1	1	999	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	296868	SweptSolid	425	273	1	1	620	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	299369	SweptSolid	0	32	0	1	0	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	299638	SweptSolid	10	10	0	1	10	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	316547	SweptSolid	263	576	0	1	183	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	332017	SweptSolid	172	360	0	1	118	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	332205	SweptSolid	63	263	0	1	3	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	333923	SweptSolid	1124	1143	1	1	1311	6
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	335218	SweptSolid	791	764	1	1	1425	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	337691	SweptSolid	27	93	0	1	27	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	359157	SweptSolid	0	52	0	1	6	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	359305	SweptSolid	20	60	0	1	12	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	359480	SweptSolid	32	44	0	1	32	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	359627	SweptSolid	0	52	0	1	6	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	359926	SweptSolid	0	52	0	1	6	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	360075	SweptSolid	33	44	0	1	33	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	360237	SweptSolid	57	79	0	1	57	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	360384	SweptSolid	7	43	0	1	7	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	360680	SweptSolid	0	32	0	1	0	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	360821	SweptSolid	0	32	0	1	0	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	360966	SweptSolid	10	36	0	1	10	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	361107	SweptSolid	3	35	0	1	3	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	4380	SweptSolid	6	94	0	0	0	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	4630	SweptSolid	0	38	1	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	4732	SweptSolid	0	28	0	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	4834	SweptSolid	0	44	0	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	4940	SweptSolid	0	44	0	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	6012	Clipping	6	144	0	0	6	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	8511	SweptSolid	0	36	0	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	27148	SweptSolid	3	117	1	0	0	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	27562	SweptSolid	0	28	0	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	27770	SweptSolid	0	28	0	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	28290	SweptSolid	0	44	0	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	34099	SweptSolid	35	259	0	0	30	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	37094	SweptSolid	0	64	1	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	46565	SweptSolid	0	100	0	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	46667	SweptSolid	0	32	0	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	46769	SweptSolid	0	28	0	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	46871	SweptSolid	0	44	0	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	47807	SweptSolid	0	168	0	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	49773	SweptSolid	0	36	0	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	63308	SweptSolid	0	28	0	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	63516	SweptSolid	0	28	0	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	64036	SweptSolid	0	44	0	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	76544	SweptSolid	0	60	0	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	78513	SweptSolid	0	156	0	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	78918	Clipping	12	106	0	0	0	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	79070	Clipping	0	50	1	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	79197	Clipping	0	44	0	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	79969	AdvancedBrep	0	80	0	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	80101	Clipping	0	80	0	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	81274	Clipping	12	140	0	0	12	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	83292	Clipping	0	52	0	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	87331	Clipping	0	132	0	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	87839	Clipping	0	44	1	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	88116	Clipping	0	46	1	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	88776	Clipping	0	76	1	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	92201	Clipping	17	141	0	0	20	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	94199	Clipping	0	66	1	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	95188	Clipping	6	96	0	0	6	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	95332	Clipping	0	44	0	0	3	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	95459	Clipping	0	44	0	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	95605	Clipping	0	80	0	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	96778	Clipping	12	132	0	0	12	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	98786	Clipping	0	48	0	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	100558	Clipping	0	44	1	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	100835	Clipping	0	46	1	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	101495	Clipping	0	76	1	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	103251	Clipping	0	78	1	0	3	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	105519	SweptSolid	0	156	0	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	119816	SweptSolid	6	62	0	0	0	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	119924	SweptSolid	3	63	1	0	0	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	120028	SweptSolid	0	28	0	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	120132	SweptSolid	0	44	0	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	120448	SweptSolid	0	96	0	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	121490	SweptSolid	0	60	0	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	122695	SweptSolid	12	144	1	0	0	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	123117	SweptSolid	0	28	0	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	123329	SweptSolid	0	28	0	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	123859	SweptSolid	0	44	0	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	124711	SweptSolid	0	204	0	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	127658	SweptSolid	0	54	1	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	128193	SweptSolid	3	97	1	0	0	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	128297	SweptSolid	0	32	0	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	128401	SweptSolid	0	28	0	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	128505	SweptSolid	0	44	0	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	129459	SweptSolid	0	120	0	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	131443	SweptSolid	0	36	0	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	132587	SweptSolid	0	28	0	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	132799	SweptSolid	0	28	0	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	133329	SweptSolid	0	44	0	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	134472	SweptSolid	0	60	0	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	135938	SweptSolid	0	128	0	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	137886	SweptSolid	0	112	0	0	0	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	139140	SweptSolid	0	36	0	0	0	-
+ara3d/ISSUE_171_IfcSurfaceCurveSweptAreaSolid.ifc	61	SweptSolid	0	114	0	0	0	-
+ara3d/ISSUE_171_IfcSurfaceCurveSweptAreaSolid.ifc	528	SweptSolid	0	64	0	0	0	-
+ara3d/ISSUE_171_IfcSurfaceCurveSweptAreaSolid.ifc	733	SweptSolid	0	32	0	0	0	-
+ara3d/ISSUE_171_IfcSurfaceCurveSweptAreaSolid.ifc	880	SweptSolid	0	64	0	0	0	-
+ara3d/ISSUE_171_IfcSurfaceCurveSweptAreaSolid.ifc	1085	SweptSolid	0	72	0	0	0	-
+ara3d/ISSUE_171_IfcSurfaceCurveSweptAreaSolid.ifc	1290	SweptSolid	0	58	0	0	0	-
+ara3d/ISSUE_171_IfcSurfaceCurveSweptAreaSolid.ifc	1512	SweptSolid	0	36	0	0	0	-
+ara3d/ISSUE_171_IfcSurfaceCurveSweptAreaSolid.ifc	1812	SweptSolid	0	58	0	0	0	-
+ara3d/ISSUE_171_IfcSurfaceCurveSweptAreaSolid.ifc	2017	SweptSolid	0	68	0	0	0	-
+ara3d/IfcOpenHouse_IFC4.ifc	40	SweptSolid	0	56	0	0	0	-
+ara3d/IfcOpenHouse_IFC4.ifc	268	Clipping	0	40	0	0	0	-
+ara3d/IfcOpenHouse_IFC4.ifc	281	Clipping	0	42	0	0	0	-
+ara3d/Office_A_20110811.ifc	65	SweptSolid	0	92	0	0	0	-
+ara3d/Office_A_20110811.ifc	71	SweptSolid	0	308	0	0	0	-
+ara3d/Office_A_20110811.ifc	76	SweptSolid	0	140	0	0	0	-
+ara3d/Office_A_20110811.ifc	81	SweptSolid	0	312	0	0	0	-
+ara3d/Office_A_20110811.ifc	82	SweptSolid	0	32	0	0	0	-
+ara3d/Office_A_20110811.ifc	83	SweptSolid	0	292	0	0	0	-
+ara3d/Office_A_20110811.ifc	88	SweptSolid	0	60	0	0	0	-
+ara3d/Office_A_20110811.ifc	97	SweptSolid	0	44	0	0	0	-
+ara3d/Office_A_20110811.ifc	100	SweptSolid	0	152	0	0	0	-
+ara3d/Office_A_20110811.ifc	101	SweptSolid	0	164	0	0	0	-
+ara3d/Office_A_20110811.ifc	102	SweptSolid	0	140	0	0	0	-
+ara3d/Office_A_20110811.ifc	104	SweptSolid	0	92	0	0	0	-
+ara3d/Office_A_20110811.ifc	105	SweptSolid	0	28	0	0	0	-
+ara3d/Office_A_20110811.ifc	106	SweptSolid	0	172	0	0	0	-
+ara3d/Office_A_20110811.ifc	130	SweptSolid	0	76	0	0	0	-
+ara3d/Office_A_20110811.ifc	134	SweptSolid	0	92	0	0	0	-
+ara3d/Office_A_20110811.ifc	139	SweptSolid	0	76	0	0	0	-
+ara3d/Office_A_20110811.ifc	143	SweptSolid	0	44	0	0	0	-
+ara3d/Office_A_20110811.ifc	156	SweptSolid	0	44	0	0	0	-
+ara3d/Office_A_20110811.ifc	161	SweptSolid	0	60	0	0	0	-
+ara3d/Office_A_20110811.ifc	164	SweptSolid	0	44	0	0	0	-
+ara3d/Office_A_20110811.ifc	165	SweptSolid	0	44	0	0	0	-
+ara3d/Office_A_20110811.ifc	166	SweptSolid	0	100	0	0	0	-
+ara3d/Office_A_20110811.ifc	175	SweptSolid	0	28	0	0	0	-
+ara3d/Office_A_20110811.ifc	178	SweptSolid	0	44	0	0	0	-
+ara3d/Office_A_20110811.ifc	179	SweptSolid	0	60	0	0	0	-
+ara3d/Office_A_20110811.ifc	183	SweptSolid	0	44	0	0	0	-
+ara3d/Office_A_20110811.ifc	185	SweptSolid	0	44	0	0	0	-
+ara3d/Office_A_20110811.ifc	188	SweptSolid	0	44	0	0	0	-
+ara3d/Office_A_20110811.ifc	191	SweptSolid	0	28	0	0	0	-
+ara3d/Office_A_20110811.ifc	193	SweptSolid	0	28	0	0	0	-
+ara3d/Office_A_20110811.ifc	195	SweptSolid	0	28	0	0	0	-
+ara3d/Office_A_20110811.ifc	196	SweptSolid	0	44	0	0	0	-
+ara3d/Office_A_20110811.ifc	197	SweptSolid	0	28	0	0	0	-
+ara3d/Office_A_20110811.ifc	198	SweptSolid	0	28	0	0	0	-
+ara3d/Office_A_20110811.ifc	223	SweptSolid	0	28	0	0	0	-
+ara3d/Office_A_20110811.ifc	224	SweptSolid	0	44	0	0	0	-
+ara3d/Office_A_20110811.ifc	227	SweptSolid	0	44	0	0	0	-
+ara3d/Office_A_20110811.ifc	228	SweptSolid	0	44	0	0	0	-
+ara3d/Office_A_20110811.ifc	234	SweptSolid	0	28	0	0	0	-
+ara3d/Office_A_20110811.ifc	238	SweptSolid	0	28	0	0	0	-
+ara3d/Office_A_20110811.ifc	239	SweptSolid	0	44	0	0	0	-
+ara3d/Office_A_20110811.ifc	242	SweptSolid	0	28	0	0	0	-
+ara3d/Office_A_20110811.ifc	246	SweptSolid	0	60	0	0	0	-
+ara3d/Office_A_20110811.ifc	247	SweptSolid	0	44	0	0	0	-
+ara3d/Office_A_20110811.ifc	248	SweptSolid	0	28	0	0	0	-
+ara3d/Office_A_20110811.ifc	277	SweptSolid	0	28	0	0	0	-
+ara3d/Office_A_20110811.ifc	282	SweptSolid	0	28	0	0	0	-
+ara3d/Office_A_20110811.ifc	288	SweptSolid	0	28	0	0	0	-
+ara3d/Office_A_20110811.ifc	307	SweptSolid	0	28	0	0	0	-
+ara3d/Office_A_20110811.ifc	314	SweptSolid	0	28	0	0	0	-
+ara3d/Office_A_20110811.ifc	326	SweptSolid	0	28	0	0	0	-
+ara3d/Office_A_20110811.ifc	351	SweptSolid	0	28	0	0	0	-
+ara3d/Office_A_20110811.ifc	354	SweptSolid	0	28	0	0	0	-
+ara3d/Office_A_20110811.ifc	361	SweptSolid	0	28	0	0	0	-
+ara3d/Office_A_20110811.ifc	363	SweptSolid	0	28	0	0	0	-
+ara3d/Office_A_20110811.ifc	364	SweptSolid	0	180	0	0	0	-
+ara3d/Office_A_20110811.ifc	417	SweptSolid	0	122	0	0	0	-
+ara3d/Office_A_20110811.ifc	429	SweptSolid	0	32	0	0	0	-
+ara3d/Office_A_20110811.ifc	607	SweptSolid	0	122	0	0	0	-
+ara3d/Office_A_20110811.ifc	684	SweptSolid	0	122	0	0	0	-
+ara3d/Office_A_20110811.ifc	1028	SweptSolid	0	678	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	4172	SweptSolid	0	32	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	5434	SweptSolid	0	36	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	6155	SweptSolid	0	32	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	14416	SweptSolid	0	52	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	35182	SweptSolid	0	32	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	36567	SweptSolid	0	52	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	43442	SweptSolid	0	80	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	48600	SweptSolid	0	44	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	49149	SweptSolid	0	52	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	89022	unknown	0	0	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	89141	SweptSolid	0	232	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	89264	SweptSolid	0	232	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	89384	SweptSolid	0	232	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	89504	SweptSolid	0	232	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	89624	SweptSolid	0	232	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	90617	Curve2D	0	0	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	91291	CSG	3	46	1	0	3	6
+ara3d/S_Office_Integrated Design Archi.ifc	91968	CSG	0	120	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	92642	CSG	12	68	1	0	13	12
+ara3d/S_Office_Integrated Design Archi.ifc	93316	CSG	0	64	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	93990	CSG	0	108	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	94664	CSG	0	32	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	99549	SweptSolid	0	52	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	368885	SweptSolid	0	36	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	414959	SweptSolid	0	40	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	415490	unknown	0	0	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	426329	CSG	0	496	0	0	6	-
+ara3d/S_Office_Integrated Design Archi.ifc	437170	CSG	6	380	0	0	0	6
+ara3d/S_Office_Integrated Design Archi.ifc	448019	CSG	90	1034	0	0	89	164
+ara3d/S_Office_Integrated Design Archi.ifc	458857	CSG	78	1062	0	0	80	78
+ara3d/S_Office_Integrated Design Archi.ifc	469706	CSG	51	1077	0	0	61	51
+ara3d/S_Office_Integrated Design Archi.ifc	489748	SweptSolid	0	40	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	495955	SweptSolid	0	36	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	496628	SweptSolid	0	52	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	503263	unknown	0	0	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	503302	SweptSolid	0	172	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	503345	SweptSolid	0	172	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	503385	SweptSolid	0	172	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	503425	SweptSolid	0	172	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	503482	SweptSolid	0	172	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	543063	SweptSolid	0	36	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	639833	SweptSolid	0	52	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	670546	SweptSolid	0	32	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	701210	SweptSolid	0	52	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	704150	SweptSolid	0	32	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	719862	SweptSolid	0	32	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	722750	Curve2D	0	0	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	723436	CSG	0	216	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	724125	CSG	0	216	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	724811	CSG	3	81	0	0	3	3
+ara3d/S_Office_Integrated Design Archi.ifc	725497	CSG	7	185	0	0	7	12
+ara3d/S_Office_Integrated Design Archi.ifc	726183	CSG	0	212	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	726869	CSG	0	212	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	730647	SweptSolid	0	32	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	753197	SweptSolid	0	52	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	763256	Curve2D	0	0	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	763898	CSG	0	122	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	764543	CSG	0	124	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	765185	CSG	0	118	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	765827	CSG	0	64	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	766469	CSG	0	112	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	767111	CSG	0	32	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	767445	Curve2D	0	0	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	768209	CSG	0	224	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	768976	CSG	0	232	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	769740	CSG	0	280	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	770504	CSG	0	100	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	771268	CSG	0	196	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	772032	CSG	0	196	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	803290	SweptSolid	0	52	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	832090	Curve2D	0	0	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	832800	CSG	0	224	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	833513	CSG	0	216	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	834223	CSG	0	200	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	834933	CSG	0	100	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	835643	CSG	0	196	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	836353	CSG	0	196	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	857637	unknown	0	0	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	857676	SweptSolid	0	156	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	857719	SweptSolid	0	156	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	857759	SweptSolid	0	156	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	857799	SweptSolid	0	156	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	857839	SweptSolid	0	156	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	866873	SweptSolid	0	36	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	867376	Curve2D	0	0	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	868018	CSG	0	122	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	868663	CSG	0	124	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	869305	CSG	0	118	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	869947	CSG	0	64	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	870589	CSG	0	108	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	871231	CSG	0	32	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	902095	SweptSolid	0	36	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	903633	SweptSolid	0	52	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	904243	SweptSolid	0	32	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	904620	Curve2D	0	0	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	905288	CSG	0	216	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	905959	CSG	0	216	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	906627	CSG	6	82	0	0	6	6
+ara3d/S_Office_Integrated Design Archi.ifc	907295	CSG	0	52	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	907963	CSG	0	216	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	908631	CSG	0	216	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	909123	SweptSolid	0	32	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	909362	SweptSolid	0	32	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	909877	SweptSolid	0	52	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	910230	SweptSolid	0	52	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	910609	SweptSolid	0	32	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	912366	SweptSolid	0	52	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	918017	SweptSolid	0	52	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	918355	SweptSolid	0	32	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	929798	SweptSolid	0	52	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	930704	SweptSolid	0	32	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	951036	Curve2D	0	0	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	951723	CSG	0	216	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	952413	CSG	0	216	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	953100	CSG	3	137	1	0	3	3
+ara3d/S_Office_Integrated Design Archi.ifc	953787	CSG	0	116	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	954474	CSG	16	228	0	0	16	13
+ara3d/S_Office_Integrated Design Archi.ifc	955161	CSG	0	216	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	955764	SweptSolid	0	32	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	969935	Curve2D	0	0	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	970645	CSG	0	224	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	971358	CSG	0	216	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	972068	CSG	0	200	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	972778	CSG	0	100	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	973488	CSG	0	196	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	974198	CSG	0	196	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	974760	unknown	0	0	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	974799	SweptSolid	0	156	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	974842	SweptSolid	0	156	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	974882	SweptSolid	0	156	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	974922	SweptSolid	0	156	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	974962	SweptSolid	0	156	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	976762	Curve2D	0	0	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	977404	CSG	0	120	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	978049	CSG	0	120	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	978691	CSG	0	114	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	979333	CSG	0	60	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	979975	CSG	0	114	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	980617	CSG	0	32	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	986525	SweptSolid	0	36	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	987406	SweptSolid	0	32	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	997903	SweptSolid	0	36	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	998325	SweptSolid	0	52	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	1001521	SweptSolid	0	32	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	1001906	SweptSolid	0	32	0	0	0	-
+ara3d/advanced_model.ifc	552611	SweptSolid	0	158	0	0	0	-
+ara3d/advanced_model.ifc	552761	SweptSolid	0	168	0	0	0	-
+ara3d/advanced_model.ifc	552894	SweptSolid	0	104	0	0	0	-
+ara3d/advanced_model.ifc	553010	Clipping	0	82	0	0	0	-
+ara3d/advanced_model.ifc	555082	SweptSolid	0	88	0	0	0	-
+ara3d/advanced_model.ifc	555224	SweptSolid	0	28	0	0	0	-
+ara3d/advanced_model.ifc	555268	SweptSolid	0	124	0	0	0	-
+ara3d/advanced_model.ifc	555433	SweptSolid	0	172	0	0	0	-
+ara3d/advanced_model.ifc	555613	Clipping	0	90	0	0	0	-
+ara3d/advanced_model.ifc	555770	Clipping	0	56	0	0	0	-
+ara3d/advanced_model.ifc	555985	SweptSolid	0	184	0	0	0	-
+ara3d/advanced_model.ifc	556264	SweptSolid	0	192	0	0	0	-
+ara3d/advanced_model.ifc	559034	SweptSolid	0	88	0	0	0	-
+ara3d/advanced_model.ifc	559171	SweptSolid	0	92	0	0	0	-
+ara3d/advanced_model.ifc	559270	SweptSolid	0	44	0	0	0	-
+ara3d/advanced_model.ifc	559314	SweptSolid	0	52	0	0	0	-
+ara3d/advanced_model.ifc	561445	SweptSolid	0	28	0	0	0	-
+ara3d/advanced_model.ifc	563598	SweptSolid	0	28	0	0	0	-
+ara3d/advanced_model.ifc	563980	SweptSolid	0	156	0	0	0	-
+ara3d/advanced_model.ifc	612062	SweptSolid	0	92	0	0	0	-
+ara3d/advanced_model.ifc	612150	SweptSolid	0	124	0	0	0	-
+ara3d/advanced_model.ifc	612315	SweptSolid	0	128	0	0	0	-
+ara3d/advanced_model.ifc	612436	SweptSolid	0	28	0	0	0	-
+ara3d/advanced_model.ifc	632450	Clipping	0	126	0	0	0	-
+ara3d/advanced_model.ifc	636693	SweptSolid	0	92	0	0	0	-
+ara3d/advanced_model.ifc	636774	SweptSolid	0	44	0	0	0	-
+ara3d/advanced_model.ifc	636818	SweptSolid	0	52	0	0	0	-
+ara3d/advanced_model.ifc	636995	SweptSolid	0	28	0	0	0	-
+ara3d/advanced_model.ifc	637271	SweptSolid	0	76	0	0	0	-
+ara3d/advanced_model.ifc	637377	SweptSolid	0	28	0	0	0	-
+ara3d/advanced_model.ifc	637697	SweptSolid	0	28	0	0	0	-
+ara3d/advanced_model.ifc	637785	SweptSolid	0	60	0	0	0	-
+ara3d/advanced_model.ifc	637873	SweptSolid	0	44	0	0	0	-
+ara3d/advanced_model.ifc	637917	SweptSolid	0	44	0	0	0	-
+ara3d/advanced_model.ifc	646621	SweptSolid	0	28	0	0	0	-
+ara3d/advanced_model.ifc	646665	SweptSolid	0	28	0	0	0	-
+ara3d/advanced_model.ifc	650657	SweptSolid	0	68	0	0	0	-
+ara3d/advanced_model.ifc	650761	SweptSolid	0	76	0	0	0	-
+ara3d/advanced_model.ifc	650893	SweptSolid	0	56	0	0	0	-
+ara3d/advanced_model.ifc	651604	SweptSolid	0	76	0	0	0	-
+ara3d/advanced_model.ifc	674148	SweptSolid	0	76	0	0	0	-
+ara3d/advanced_model.ifc	679345	SweptSolid	0	140	0	0	0	-
+ara3d/advanced_model.ifc	694436	SweptSolid	0	92	0	0	0	-
+ara3d/advanced_model.ifc	737480	SweptSolid	0	92	0	0	0	-
+ara3d/advanced_model.ifc	737716	SweptSolid	0	28	0	0	0	-
+ara3d/advanced_model.ifc	737804	SweptSolid	0	28	0	0	0	-
+ara3d/advanced_model.ifc	737892	SweptSolid	0	28	0	0	0	-
+ara3d/advanced_model.ifc	737936	SweptSolid	0	156	0	0	0	-
+ara3d/advanced_model.ifc	738205	SweptSolid	0	92	0	0	0	-
+ara3d/advanced_model.ifc	738433	SweptSolid	0	1860	0	0	0	-
+ara3d/advanced_model.ifc	739014	SweptSolid	0	1832	0	0	0	-
+ara3d/advanced_model.ifc	797099	SweptSolid	0	192	0	0	0	-
+ara3d/advanced_model.ifc	797102	SweptSolid	0	192	0	0	0	-
+ara3d/advanced_model.ifc	797108	SweptSolid	0	308	0	0	0	-
+ara3d/advanced_model.ifc	797111	SweptSolid	0	308	0	0	0	-
+ara3d/advanced_model.ifc	797114	SweptSolid	0	464	0	0	0	-
+ara3d/advanced_model.ifc	797120	SweptSolid	0	308	0	0	0	-
+ara3d/advanced_model.ifc	797123	SweptSolid	0	308	0	0	0	-
+ara3d/advanced_model.ifc	797126	SweptSolid	0	604	0	0	0	-
+ara3d/advanced_model.ifc	797129	SweptSolid	0	308	0	0	0	-
+ara3d/advanced_model.ifc	798479	SweptSolid	0	612	0	0	0	-
+ara3d/advanced_model.ifc	798926	SweptSolid	0	2900	0	0	0	-
+ara3d/advanced_model.ifc	799400	SweptSolid	0	604	0	0	0	-
+ara3d/advanced_model.ifc	799566	SweptSolid	0	604	0	0	0	-
+ara3d/advanced_model.ifc	799732	SweptSolid	0	604	0	0	0	-
+ara3d/advanced_model.ifc	800371	SweptSolid	0	604	0	0	0	-
+ara3d/advanced_model.ifc	800374	SweptSolid	0	308	0	0	0	-
+ara3d/advanced_model.ifc	800377	SweptSolid	0	464	0	0	0	-
+ara3d/advanced_model.ifc	800380	SweptSolid	0	308	0	0	0	-
+ara3d/advanced_model.ifc	800383	SweptSolid	0	308	0	0	0	-
+ara3d/advanced_model.ifc	800389	SweptSolid	0	308	0	0	0	-
+ara3d/advanced_model.ifc	800395	SweptSolid	0	308	0	0	0	-
+ara3d/advanced_model.ifc	800398	SweptSolid	0	308	0	0	0	-
+ara3d/advanced_model.ifc	800410	SweptSolid	0	340	0	0	0	-
+ara3d/advanced_model.ifc	800413	SweptSolid	0	160	0	0	0	-
+ara3d/advanced_model.ifc	800416	SweptSolid	0	372	0	0	0	-
+ara3d/advanced_model.ifc	800422	SweptSolid	0	324	0	0	0	-
+ara3d/advanced_model.ifc	801940	SweptSolid	0	44	0	0	0	-
+ara3d/advanced_model.ifc	801984	SweptSolid	0	44	0	0	0	-
+ara3d/advanced_model.ifc	806064	SweptSolid	0	28	0	0	0	-
+ara3d/advanced_model.ifc	806149	SweptSolid	0	508	0	0	0	-
+ara3d/advanced_model.ifc	815104	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	94	SweptSolid	0	232	0	0	0	-
+ara3d/dental_clinic.ifc	95	SweptSolid	0	172	0	0	0	-
+ara3d/dental_clinic.ifc	101	SweptSolid	0	128	0	0	0	-
+ara3d/dental_clinic.ifc	146	SweptSolid	0	192	0	0	0	-
+ara3d/dental_clinic.ifc	156	SweptSolid	0	60	0	0	0	-
+ara3d/dental_clinic.ifc	157	SweptSolid	0	92	0	0	0	-
+ara3d/dental_clinic.ifc	159	SweptSolid	0	108	0	0	0	-
+ara3d/dental_clinic.ifc	163	SweptSolid	0	128	0	0	0	-
+ara3d/dental_clinic.ifc	166	SweptSolid	0	76	0	0	0	-
+ara3d/dental_clinic.ifc	167	Clipping	10	192	0	0	10	0
+ara3d/dental_clinic.ifc	169	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	175	Clipping	0	168	0	0	0	-
+ara3d/dental_clinic.ifc	180	Clipping	0	168	0	0	0	-
+ara3d/dental_clinic.ifc	184	SweptSolid	0	92	0	0	0	-
+ara3d/dental_clinic.ifc	195	SweptSolid	0	44	0	0	0	-
+ara3d/dental_clinic.ifc	196	SweptSolid	0	64	0	0	0	-
+ara3d/dental_clinic.ifc	202	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	203	SweptSolid	0	76	0	0	0	-
+ara3d/dental_clinic.ifc	205	SweptSolid	0	76	0	0	0	-
+ara3d/dental_clinic.ifc	206	SweptSolid	0	32	0	0	0	-
+ara3d/dental_clinic.ifc	207	Clipping	8	278	0	0	8	0
+ara3d/dental_clinic.ifc	212	SweptSolid	0	76	0	0	0	-
+ara3d/dental_clinic.ifc	213	SweptSolid	0	44	0	0	0	-
+ara3d/dental_clinic.ifc	214	SweptSolid	0	76	0	0	0	-
+ara3d/dental_clinic.ifc	215	SweptSolid	0	68	0	0	0	-
+ara3d/dental_clinic.ifc	216	SweptSolid	0	92	0	0	0	-
+ara3d/dental_clinic.ifc	217	SweptSolid	0	26	0	0	0	-
+ara3d/dental_clinic.ifc	218	SweptSolid	0	20	0	0	0	-
+ara3d/dental_clinic.ifc	231	SweptSolid	0	60	0	0	0	-
+ara3d/dental_clinic.ifc	232	SweptSolid	0	44	0	0	0	-
+ara3d/dental_clinic.ifc	233	SweptSolid	0	76	0	0	0	-
+ara3d/dental_clinic.ifc	234	SweptSolid	0	60	0	0	0	-
+ara3d/dental_clinic.ifc	235	SweptSolid	0	112	0	0	0	-
+ara3d/dental_clinic.ifc	236	SweptSolid	0	72	0	0	0	-
+ara3d/dental_clinic.ifc	248	SweptSolid	0	44	0	0	0	-
+ara3d/dental_clinic.ifc	249	SweptSolid	0	60	0	0	0	-
+ara3d/dental_clinic.ifc	262	SweptSolid	0	76	0	0	0	-
+ara3d/dental_clinic.ifc	263	SweptSolid	0	44	0	0	0	-
+ara3d/dental_clinic.ifc	264	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	265	SweptSolid	0	44	0	0	0	-
+ara3d/dental_clinic.ifc	266	SweptSolid	0	60	0	0	0	-
+ara3d/dental_clinic.ifc	269	SweptSolid	0	60	0	0	0	-
+ara3d/dental_clinic.ifc	270	SweptSolid	0	60	0	0	0	-
+ara3d/dental_clinic.ifc	271	Clipping	0	72	0	0	0	-
+ara3d/dental_clinic.ifc	272	SweptSolid	0	60	0	0	0	-
+ara3d/dental_clinic.ifc	273	SweptSolid	0	60	0	0	0	-
+ara3d/dental_clinic.ifc	284	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	285	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	286	SweptSolid	0	60	0	0	0	-
+ara3d/dental_clinic.ifc	287	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	288	SweptSolid	0	32	0	0	0	-
+ara3d/dental_clinic.ifc	297	SweptSolid	0	60	0	0	0	-
+ara3d/dental_clinic.ifc	298	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	299	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	300	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	301	SweptSolid	0	44	0	0	0	-
+ara3d/dental_clinic.ifc	302	SweptSolid	0	72	0	0	0	-
+ara3d/dental_clinic.ifc	303	SweptSolid	0	44	0	0	0	-
+ara3d/dental_clinic.ifc	319	Clipping	0	38	0	0	0	-
+ara3d/dental_clinic.ifc	320	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	321	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	322	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	323	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	324	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	325	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	326	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	327	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	329	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	349	SweptSolid	0	44	0	0	0	-
+ara3d/dental_clinic.ifc	350	SweptSolid	0	44	0	0	0	-
+ara3d/dental_clinic.ifc	351	SweptSolid	0	44	0	0	0	-
+ara3d/dental_clinic.ifc	352	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	353	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	354	SweptSolid	0	60	0	0	0	-
+ara3d/dental_clinic.ifc	355	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	356	SweptSolid	0	52	0	0	0	-
+ara3d/dental_clinic.ifc	357	SweptSolid	0	20	0	0	0	-
+ara3d/dental_clinic.ifc	360	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	361	SweptSolid	0	32	0	0	0	-
+ara3d/dental_clinic.ifc	375	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	376	SweptSolid	0	44	0	0	0	-
+ara3d/dental_clinic.ifc	377	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	378	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	379	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	380	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	381	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	424	SweptSolid	0	44	0	0	0	-
+ara3d/dental_clinic.ifc	425	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	426	SweptSolid	0	44	0	0	0	-
+ara3d/dental_clinic.ifc	427	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	428	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	429	SweptSolid	0	104	0	0	0	-
+ara3d/dental_clinic.ifc	430	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	431	SweptSolid	0	44	0	0	0	-
+ara3d/dental_clinic.ifc	432	SweptSolid	0	32	0	0	0	-
+ara3d/dental_clinic.ifc	434	SweptSolid	0	12	0	0	0	-
+ara3d/dental_clinic.ifc	437	SweptSolid	0	44	0	0	0	-
+ara3d/dental_clinic.ifc	438	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	439	SweptSolid	0	44	0	0	0	-
+ara3d/dental_clinic.ifc	475	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	481	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	482	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	483	SweptSolid	0	44	0	0	0	-
+ara3d/dental_clinic.ifc	484	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	488	SweptSolid	0	20	0	0	0	-
+ara3d/dental_clinic.ifc	490	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	491	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	507	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	522	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	523	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	524	SweptSolid	0	44	0	0	0	-
+ara3d/dental_clinic.ifc	525	SweptSolid	0	44	0	0	0	-
+ara3d/dental_clinic.ifc	526	SweptSolid	0	44	0	0	0	-
+ara3d/dental_clinic.ifc	527	SweptSolid	0	44	0	0	0	-
+ara3d/dental_clinic.ifc	528	SweptSolid	0	44	0	0	0	-
+ara3d/dental_clinic.ifc	529	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	530	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	531	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	532	Clipping	0	22	0	0	0	-
+ara3d/dental_clinic.ifc	542	Clipping	0	22	0	0	0	-
+ara3d/dental_clinic.ifc	545	SweptSolid	0	44	0	0	0	-
+ara3d/dental_clinic.ifc	584	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	590	SweptSolid	0	56	0	0	0	-
+ara3d/dental_clinic.ifc	591	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	592	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	593	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	594	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	595	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	596	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	597	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	598	SweptSolid	0	44	0	0	0	-
+ara3d/dental_clinic.ifc	599	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	600	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	601	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	627	SweptSolid	0	32	0	0	0	-
+ara3d/dental_clinic.ifc	628	SweptSolid	0	44	0	0	0	-
+ara3d/dental_clinic.ifc	675	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	686	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	696	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	697	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	698	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	699	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	700	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	701	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	702	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	703	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	704	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	736	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	804	SweptSolid	0	32	0	0	0	-
+ara3d/dental_clinic.ifc	825	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	827	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	828	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	829	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	830	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	831	Clipping	0	64	0	0	0	-
+ara3d/dental_clinic.ifc	872	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	931	SweptSolid	0	32	0	0	0	-
+ara3d/dental_clinic.ifc	964	Clipping	0	30	0	0	0	-
+ara3d/dental_clinic.ifc	965	Clipping	0	30	0	0	0	-
+ara3d/dental_clinic.ifc	966	Clipping	0	30	0	0	0	-
+ara3d/dental_clinic.ifc	973	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	974	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	975	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	976	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	977	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	978	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	979	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	980	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	981	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	982	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	983	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	984	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	985	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	986	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	987	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	988	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	989	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	990	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	991	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	992	SweptSolid	0	54	0	0	0	-
+ara3d/dental_clinic.ifc	993	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	994	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	995	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	996	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	997	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	998	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	999	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	1003	Clipping	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	1022	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	1085	Clipping	0	32	0	0	0	-
+ara3d/dental_clinic.ifc	1093	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	1094	SweptSolid	0	36	0	0	0	-
+ara3d/dental_clinic.ifc	1096	SweptSolid	0	36	0	0	0	-
+ara3d/dental_clinic.ifc	1183	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	1194	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	1195	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	1242	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	1252	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	1253	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	1310	SweptSolid	0	164	0	0	0	-
+ara3d/dental_clinic.ifc	1311	Clipping	10	80	0	0	10	0
+ara3d/dental_clinic.ifc	1314	SweptSolid	0	58	0	0	0	-
+ara3d/dental_clinic.ifc	1331	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	1643	Clipping	0	30	0	0	0	-
+ara3d/dental_clinic.ifc	1673	Clipping	9	32	1	0	9	0
+ara3d/dental_clinic.ifc	1757	Clipping	3	28	1	0	3	0
+ara3d/dental_clinic.ifc	1831	SweptSolid	0	24	0	0	0	-
+ara3d/dental_clinic.ifc	1832	SweptSolid	0	24	0	0	0	-
+ara3d/dental_clinic.ifc	2093	SweptSolid	0	28	0	0	0	-
+ara3d/dental_clinic.ifc	2268	SweptSolid	0	48	0	0	0	-
+ara3d/dental_clinic.ifc	2269	SweptSolid	0	44	0	0	0	-
+ara3d/dental_clinic.ifc	2270	SweptSolid	0	56	0	0	0	-
+ara3d/dental_clinic.ifc	2275	SweptSolid	0	64	0	0	0	-
+ara3d/dental_clinic.ifc	2276	SweptSolid	0	76	0	0	0	-
+ara3d/dental_clinic.ifc	2278	SweptSolid	0	72	0	0	0	-
+ara3d/dental_clinic.ifc	2279	SweptSolid	0	68	0	0	0	-
+ara3d/dental_clinic.ifc	2280	SweptSolid	0	68	0	0	0	-
+ara3d/dental_clinic.ifc	2285	SweptSolid	0	548	0	0	0	-
+ara3d/dental_clinic.ifc	2286	SweptSolid	0	44	0	0	0	-
+ara3d/dental_clinic.ifc	2287	SweptSolid	0	44	0	0	0	-
+ara3d/dental_clinic.ifc	2288	SweptSolid	0	44	0	0	0	-
+ara3d/dental_clinic.ifc	2289	SweptSolid	0	44	0	0	0	-
+ara3d/dental_clinic.ifc	2290	SweptSolid	0	44	0	0	0	-
+ara3d/dental_clinic.ifc	2291	SweptSolid	0	44	0	0	0	-
+ara3d/dental_clinic.ifc	2292	SweptSolid	19	305	1	0	6	0
+ara3d/dental_clinic.ifc	2293	SweptSolid	0	44	0	0	0	-
+ara3d/dental_clinic.ifc	2294	SweptSolid	0	44	0	0	0	-
+ara3d/dental_clinic.ifc	2295	SweptSolid	0	44	0	0	0	-
+ara3d/dental_clinic.ifc	2296	SweptSolid	0	44	0	0	0	-
+ara3d/dental_clinic.ifc	2297	SweptSolid	0	44	0	0	0	-
+ara3d/dental_clinic.ifc	2298	SweptSolid	0	44	0	0	0	-
+ara3d/dental_clinic.ifc	2299	SweptSolid	0	44	0	0	0	-
+ara3d/dental_clinic.ifc	2300	SweptSolid	0	64	0	0	0	-
+ara3d/dental_clinic.ifc	2301	SweptSolid	6	634	0	0	6	0
+ara3d/dental_clinic.ifc	2302	SweptSolid	7	366	1	0	7	0
+ara3d/dental_clinic.ifc	2304	SweptSolid	0	56	0	0	0	-
+ara3d/dental_clinic.ifc	2305	SweptSolid	0	56	0	0	0	-
+ara3d/dental_clinic.ifc	2306	SweptSolid	0	56	0	0	0	-
+ara3d/dental_clinic.ifc	2307	SweptSolid	0	56	0	0	0	-
+ara3d/dental_clinic.ifc	2308	SweptSolid	0	56	0	0	0	-
+ara3d/dental_clinic.ifc	2309	SweptSolid	0	56	0	0	0	-
+ara3d/dental_clinic.ifc	2310	SweptSolid	0	56	0	0	0	-
+ara3d/dental_clinic.ifc	2311	SweptSolid	0	56	0	0	0	-
+ara3d/dental_clinic.ifc	2312	SweptSolid	0	56	0	0	0	-
+ara3d/dental_clinic.ifc	2313	SweptSolid	0	56	0	0	0	-
+ara3d/duplex.ifc	3797	SweptSolid	0	48	0	0	0	-
+ara3d/duplex.ifc	3999	SweptSolid	0	48	0	0	0	-
+ara3d/duplex.ifc	4043	SweptSolid	0	48	0	0	0	-
+ara3d/duplex.ifc	4087	SweptSolid	0	48	0	0	0	-
+ara3d/duplex.ifc	4219	SweptSolid	0	28	0	0	0	-
+ara3d/duplex.ifc	4508	SweptSolid	0	28	0	0	0	-
+ara3d/duplex.ifc	5448	SweptSolid	0	142	0	0	0	-
+ara3d/duplex.ifc	5498	SweptSolid	0	218	0	0	0	-
+ara3d/duplex.ifc	5548	SweptSolid	0	164	0	0	0	-
+ara3d/duplex.ifc	5598	SweptSolid	0	226	0	0	0	-
+ara3d/duplex.ifc	5642	SweptSolid	0	32	0	0	0	-
+ara3d/duplex.ifc	5687	SweptSolid	0	28	0	0	0	-
+ara3d/duplex.ifc	5731	SweptSolid	0	28	0	0	0	-
+ara3d/duplex.ifc	5903	SweptSolid	0	32	0	0	0	-
+ara3d/duplex.ifc	5948	SweptSolid	0	28	0	0	0	-
+ara3d/duplex.ifc	5992	SweptSolid	0	28	0	0	0	-
+ara3d/duplex.ifc	12574	SurfaceModel	89	292	0	0	89	70
+ara3d/duplex.ifc	12976	SurfaceModel	84	292	0	0	85	70
+ara3d/duplex.ifc	13331	SurfaceModel	89	292	0	0	89	70
+ara3d/duplex.ifc	13685	SurfaceModel	84	292	0	0	85	70
+ara3d/duplex.ifc	14040	SurfaceModel	89	292	0	0	89	70
+ara3d/duplex.ifc	14394	SurfaceModel	85	292	0	0	86	70
+ara3d/duplex.ifc	14749	SurfaceModel	89	292	0	0	89	70
+ara3d/duplex.ifc	15103	SurfaceModel	85	292	0	0	86	70
+ara3d/duplex.ifc	16261	SweptSolid	0	68	0	0	0	-
+ara3d/duplex.ifc	16802	SweptSolid	3	727	0	0	3	0
+ara3d/duplex.ifc	22475	unknown	0	0	0	0	0	-
+ara3d/duplex.ifc	22492	SweptSolid	0	60	0	0	0	-
+ara3d/duplex.ifc	35199	SweptSolid	0	28	0	0	0	-
+ara3d/duplex.ifc	35357	SweptSolid	0	28	0	0	0	-
+ara3d/schependomlaan.ifc	46535	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	49281	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	52348	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	72010	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	76629	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	80335	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	99074	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	101868	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	112392	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	115669	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	119854	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	125502	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	133655	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	136076	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	140907	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	143594	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	154792	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	159728	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	163917	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	169275	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	171696	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	178863	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	186163	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	188256	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	263912	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	270253	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	271891	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	311100	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	313863	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	315576	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	325984	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	338352	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	340160	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	345463	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	368479	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	401470	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	404402	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	409878	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	411995	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	415563	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	422700	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	424453	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	426206	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	435307	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	472665	SweptSolid	0	80	0	0	0	-
+ara3d/schependomlaan.ifc	534371	SweptSolid	0	12	0	0	0	-
+ara3d/schependomlaan.ifc	558010	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	562146	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	597457	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	605031	SweptSolid	0	40	0	0	0	-
+ara3d/schependomlaan.ifc	618431	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	640164	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	643860	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	668602	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	711509	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	717596	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	753581	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	766683	SweptSolid	0	12	0	0	0	-
+ara3d/schependomlaan.ifc	778605	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	783014	SweptSolid	0	40	0	0	0	-
+ara3d/schependomlaan.ifc	787207	SweptSolid	0	48	0	0	0	-
+ara3d/schependomlaan.ifc	820735	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	822589	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	826337	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	829534	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	876846	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	878050	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	879248	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	880446	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	967617	SweptSolid	0	0	0	0	0	-
+ara3d/schependomlaan.ifc	969938	SweptSolid	0	0	0	0	0	-
+ara3d/tested_sample_project.ifc	186	SweptSolid	0	192	0	0	0	-
+ara3d/tested_sample_project.ifc	294	SweptSolid	0	28	0	0	0	-
+buildingsmart/wall-with-opening-and-window.ifc	45	unknown	0	32	0	0	0	-
+ifc5/Hello_Wall_hello-wall.ifc	1222	SweptSolid	0	68	0	0	0	-
+ifcopenshell/faceted_brep_csg.ifc	1096640	CSG	0	58	0	0	0	-
+issues/1007_roof_brep_opening_winding.ifc	1112	Brep	0	98	0	0	0	-
+issues/218_IFC-test-lite.ifc	417	SweptSolid	8	72	0	0	8	8
+issues/821_TallBuilding.ifc	615	Clipping	0	52	0	0	0	-
+issues/821_TallBuilding.ifc	810	Clipping	0	52	0	0	0	-
+issues/821_TallBuilding.ifc	887	Clipping	0	52	0	0	0	-
+issues/821_TallBuilding.ifc	964	Clipping	0	52	0	0	0	-
+issues/821_TallBuilding.ifc	1297	Clipping	0	44	0	0	0	-
+issues/821_TallBuilding.ifc	1850	Clipping	0	52	0	0	0	-
+issues/821_TallBuilding.ifc	1926	Clipping	0	52	0	0	0	-
+issues/821_TallBuilding.ifc	2002	Clipping	0	52	0	0	0	-
+issues/821_TallBuilding.ifc	2078	Clipping	0	52	0	0	0	-
+issues/821_TallBuilding.ifc	2401	Clipping	0	68	0	0	0	-
+issues/821_TallBuilding.ifc	2477	Clipping	0	72	0	0	0	-
+issues/821_TallBuilding.ifc	11462	Clipping	0	44	0	0	0	-
+issues/832_opening_representations.ifc	50	SweptSolid	0	32	0	0	0	-
+issues/832_opening_representations.ifc	89	SweptSolid	0	36	0	0	0	-
+issues/832_opening_representations.ifc	128	SweptSolid	0	32	0	0	0	-
+issues/832_opening_representations.ifc	175	SweptSolid	0	28	0	0	0	-
+issues/832_opening_representations.ifc	222	SweptSolid	0	28	0	0	0	-
+issues/841_house_stack_overflow.ifc	96	SweptSolid	0	96	0	0	0	-
+issues/841_house_stack_overflow.ifc	144	SweptSolid	0	28	0	0	0	-
+issues/841_house_stack_overflow.ifc	192	SweptSolid	0	68	0	0	0	-
+issues/841_house_stack_overflow.ifc	240	SweptSolid	0	32	0	0	0	-
+issues/841_house_stack_overflow.ifc	336	SweptSolid	0	174	0	0	0	-
+issues/841_house_stack_overflow.ifc	384	SweptSolid	0	322	1	0	0	-
+issues/841_house_stack_overflow.ifc	432	SweptSolid	0	338	1	0	0	-
+issues/841_house_stack_overflow.ifc	528	SweptSolid	0	60	0	0	0	-
+issues/841_house_stack_overflow.ifc	576	SweptSolid	0	28	0	0	0	-
+issues/841_house_stack_overflow.ifc	768	SweptSolid	0	48	0	0	0	-
+issues/841_house_stack_overflow.ifc	914	SweptSolid	0	32	0	0	0	-
+issues/841_house_stack_overflow.ifc	1020	SweptSolid	0	40	0	0	0	-
+issues/841_house_stack_overflow.ifc	1070	SweptSolid	0	58	0	0	0	-
+issues/841_house_stack_overflow.ifc	1118	SweptSolid	0	60	0	0	0	-
+issues/841_house_stack_overflow.ifc	1166	SweptSolid	0	36	0	0	0	-
+issues/841_house_stack_overflow.ifc	1362	Clipping	0	92	0	0	0	-
+issues/841_house_stack_overflow.ifc	1878	Clipping	0	114	0	0	0	-
+issues/841_house_stack_overflow.ifc	2152	Clipping	55	236	1	0	6	4
+issues/841_house_stack_overflow.ifc	2797	Clipping	0	44	0	0	0	-
+issues/841_house_stack_overflow.ifc	3698	Clipping	0	68	0	0	0	-
+issues/841_house_stack_overflow.ifc	4148	Clipping	0	142	0	0	0	-
+issues/841_house_stack_overflow.ifc	4219	Clipping	0	52	0	0	0	-
+issues/841_house_stack_overflow.ifc	4267	SweptSolid	0	30	0	0	0	-
+issues/841_house_stack_overflow.ifc	4374	Clipping	0	62	0	0	0	-
+issues/841_house_stack_overflow.ifc	4897	Clipping	0	130	0	0	0	-
+issues/841_house_stack_overflow.ifc	5904	Clipping	0	124	0	0	0	-
+issues/841_house_stack_overflow.ifc	13928	SweptSolid	0	28	0	0	0	-
+issues/845_wall_elemented_case.ifc	130	SweptSolid	0	224	0	0	0	-
+issues/845_wall_elemented_case.ifc	133	SweptSolid	0	392	0	0	0	-
+issues/845_wall_elemented_case.ifc	145	SweptSolid	0	224	0	0	0	-
+issues/845_wall_elemented_case.ifc	146	SweptSolid	0	200	0	0	0	-
+issues/845_wall_elemented_case.ifc	148	unknown	0	0	0	0	0	-
+issues/853_slab_pocket.ifc	303	SweptSolid	0	260	0	0	0	-
+issues/953_trimmed_curve_cartesian_arc.ifc	1112	Brep	0	98	0	0	0	-
+issues/960_house_segmented_roof_clip.ifc	2152	Clipping	55	236	1	0	6	4
+issues/960_house_segmented_roof_clip.ifc	2797	Clipping	0	44	0	0	0	-
+issues/960_house_segmented_roof_clip.ifc	4148	Clipping	0	142	0	0	0	-
+issues/960_house_segmented_roof_clip.ifc	4374	Clipping	0	62	0	0	0	-
+issues/960_house_segmented_roof_clip.ifc	5904	Clipping	0	124	0	0	0	-
+issues/964_slab_arbitrary_profile_voids.ifc	6443	SweptSolid	111	322	0	0	113	64
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	430	SweptSolid	0	280	0	0	0	-
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	654	SweptSolid	0	284	0	0	0	-
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	857	SweptSolid	0	52	0	0	0	-
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	1029	SweptSolid	0	128	0	0	0	-
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	1183	SweptSolid	0	172	0	0	0	-
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	1369	SweptSolid	0	204	0	0	0	-
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	1536	SweptSolid	0	92	0	0	0	-
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	1649	SweptSolid	0	32	0	0	0	-
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	1691	SweptSolid	0	76	0	0	0	-
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	1789	SweptSolid	0	496	0	0	0	-
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	1992	SweptSolid	0	32	0	0	0	-
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	2036	SweptSolid	0	588	0	0	0	-
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	2411	SweptSolid	0	1406	0	0	0	-
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	3051	SweptSolid	0	48	0	0	0	-
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	3110	SweptSolid	0	112	0	0	0	-
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	3394	Clipping	0	32	0	0	0	-
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	25758	SweptSolid	40	308	0	0	40	50
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	26830	SweptSolid	0	32	0	0	0	-
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	27921	Clipping	0	32	0	0	0	-
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	45444	SweptSolid	0	64	0	0	0	-
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	45708	SweptSolid	0	176	0	0	0	-
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	45774	Clipping	0	40	0	0	0	-
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	71367	SweptSolid	0	216	0	0	0	-
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	81962	SweptSolid	136	784	0	0	136	158
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	100256	SweptSolid	0	84	0	0	0	-
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	100536	SweptSolid	0	176	0	0	0	-
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	124547	SweptSolid	0	968	0	0	0	-
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	74	SweptSolid	0	52	0	0	0	-
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	75	SweptSolid	0	76	0	0	0	-
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	77	SweptSolid	0	524	0	0	0	-
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	78	SweptSolid	0	240	0	0	0	-
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	90	SweptSolid	0	340	0	0	0	-
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	91	SweptSolid	0	84	0	0	0	-
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	92	SweptSolid	0	52	0	0	0	-
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	93	SweptSolid	0	58	0	0	0	-
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	94	SweptSolid	0	52	0	0	0	-
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	103	SweptSolid	0	32	0	0	0	-
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	104	SweptSolid	0	48	0	0	0	-
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	105	SweptSolid	0	250	0	0	0	-
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	106	SweptSolid	0	84	0	0	0	-
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	107	SweptSolid	0	32	0	0	0	-
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	108	SweptSolid	0	476	0	0	0	-
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	109	SweptSolid	0	158	0	0	0	-
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	110	SweptSolid	0	96	0	0	0	-
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	111	SweptSolid	0	28	0	0	0	-
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	112	SweptSolid	0	56	0	0	0	-
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	113	SweptSolid	0	32	0	0	0	-
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	114	SweptSolid	0	164	0	0	0	-
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	115	SweptSolid	0	32	0	0	0	-
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	116	SweptSolid	0	68	0	0	0	-
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	136	SweptSolid	0	32	0	0	0	-
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	137	SweptSolid	0	128	0	0	0	-
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	138	SweptSolid	0	180	0	0	0	-
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	139	SweptSolid	0	48	0	0	0	-
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	140	SweptSolid	0	194	0	0	0	-
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	141	SweptSolid	0	28	0	0	0	-
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	142	SweptSolid	0	56	0	0	0	-
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	143	SweptSolid	0	120	0	0	0	-
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	144	SweptSolid	0	172	0	0	0	-
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	145	SweptSolid	0	94	0	0	0	-
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	146	SweptSolid	0	40	0	0	0	-
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	179	SweptSolid	0	136	0	0	0	-
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	180	SweptSolid	0	124	0	0	0	-
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	181	SweptSolid	0	32	0	0	0	-
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	182	SweptSolid	0	128	0	0	0	-
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	183	SweptSolid	0	28	0	0	0	-
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	214	SweptSolid	0	32	0	0	0	-
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	276	SweptSolid	0	72	0	0	0	-
+various/issue-604-door.ifc	55	SweptSolid	0	28	0	0	0	-
+various/rvt01.ifc	5941	Tessellation	78	240	0	1	81	11
+various/rvt01.ifc	6073	Tessellation	58	213	0	1	69	0
+various/rvt01.ifc	6163	SweptSolid	19	69	0	1	19	0
+various/rvt01.ifc	6243	SweptSolid	48	118	0	1	63	8
+various/rvt01.ifc	6305	SweptSolid	104	228	0	1	97	8
+various/rvt01.ifc	6420	SweptSolid	65	143	0	1	72	6
+various/rvt01.ifc	6511	SweptSolid	70	152	0	1	61	6
+various/rvt01.ifc	6588	SweptSolid	53	113	0	1	53	0
+various/rvt01.ifc	6724	SweptSolid	50	190	0	1	51	8
+various/rvt01.ifc	6810	SweptSolid	84	198	0	1	86	27
+various/rvt01.ifc	6934	SweptSolid	23	89	0	1	29	0
+various/rvt01.ifc	7013	SweptSolid	60	167	0	1	50	8
+various/rvt01.ifc	7075	SweptSolid	78	216	0	1	67	8
+various/rvt01.ifc	7137	SweptSolid	40	149	0	1	43	0
+various/rvt01.ifc	7216	SweptSolid	39	129	0	1	37	0
+various/rvt01.ifc	7295	SweptSolid	65	100	0	1	42	6
+various/rvt01.ifc	7403	Tessellation	11	41	0	1	11	3
+various/rvt01.ifc	7544	SweptSolid	99	192	1	1	91	8
+various/rvt01.ifc	7700	SweptSolid	61	92	0	1	69	0
+various/rvt01.ifc	7834	SweptSolid	87	195	0	1	91	16
+various/rvt01.ifc	8881	SweptSolid	70	176	0	1	44	8
+various/rvt01.ifc	8997	SweptSolid	86	174	0	1	76	26
+various/rvt01.ifc	9058	SweptSolid	91	176	0	1	94	8
+various/rvt01.ifc	9229	SweptSolid	72	175	0	1	79	8
+various/rvt01.ifc	9400	SweptSolid	55	167	0	1	61	0
+various/rvt01.ifc	9730	SweptSolid	50	114	0	1	57	8
+various/rvt01.ifc	9901	SweptSolid	45	97	0	1	48	8
+various/rvt01.ifc	10191	Tessellation	13	29	0	1	14	0
+various/rvt01.ifc	10335	Tessellation	9	9	0	1	7	0
+various/rvt01.ifc	10526	Tessellation	29	59	0	1	29	0
+various/rvt01.ifc	10632	Tessellation	19	117	0	1	17	0
+various/rvt01.ifc	11110	Tessellation	0	4	0	1	3	-
+various/rvt01.ifc	11168	Tessellation	26	66	0	1	23	0
+various/rvt01.ifc	11232	Tessellation	14	56	0	1	14	6
+various/rvt01.ifc	11304	Tessellation	7	27	0	1	7	0
+various/rvt01.ifc	11477	Tessellation	0	0	0	1	7	-
+various/rvt01.ifc	11563	Tessellation	15	15	0	1	11	0
+various/rvt01.ifc	11627	Tessellation	46	54	0	1	17	3
+various/rvt01.ifc	11690	Tessellation	26	82	0	1	26	6
+various/rvt01.ifc	11753	Tessellation	6	2	0	1	9	0
+various/rvt01.ifc	11803	SweptSolid	26	52	0	1	22	0
+various/rvt01.ifc	12235	SweptSolid	13	33	0	1	13	0
+various/rvt01.ifc	12345	SweptSolid	5	67	0	1	5	0
+various/rvt01.ifc	12449	Tessellation	44	145	1	1	48	9
+various/rvt01.ifc	13735	SweptSolid	52	161	0	1	38	8
+various/rvt01.ifc	13797	Tessellation	161	374	1	1	115	42
+various/rvt01.ifc	14014	SweptSolid	49	164	0	1	41	8
+various/rvt01.ifc	14132	SweptSolid	79	156	0	1	70	8
+various/rvt01.ifc	14194	SweptSolid	64	159	0	1	68	8
+various/rvt01.ifc	14256	SweptSolid	55	173	0	1	61	0
+various/rvt01.ifc	14447	SweptSolid	47	225	0	1	50	0
+various/rvt01.ifc	14638	SweptSolid	50	140	0	1	50	8
+various/rvt01.ifc	14797	SweptSolid	40	134	0	1	40	0
+various/rvt01.ifc	15020	SweptSolid	62	156	0	1	63	8
+various/rvt01.ifc	15301	SweptSolid	69	188	0	1	72	8
+various/rvt01.ifc	15857	SweptSolid	61	178	0	1	67	12
+various/rvt01.ifc	15917	SweptSolid	64	187	0	1	83	16
+various/rvt01.ifc	16231	SweptSolid	45	100	0	1	42	0
+various/rvt01.ifc	16286	SweptSolid	53	130	1	1	66	8
+various/rvt01.ifc	16805	SweptSolid	45	95	0	1	39	8
+various/rvt01.ifc	17553	Tessellation	4	10	0	1	4	0
+various/rvt01.ifc	17615	Tessellation	20	44	0	1	20	0
+various/rvt01.ifc	17919	Tessellation	9	45	0	1	16	0
+various/rvt01.ifc	17985	Tessellation	40	52	0	1	34	0
+various/rvt01.ifc	18169	SweptSolid	78	135	1	1	73	8
+various/rvt01.ifc	21999	SweptSolid	0	40	0	1	0	-
+various/rvt01.ifc	25694	Tessellation	15	105	0	1	15	0
+various/rvt01.ifc	25914	SweptSolid	38	154	0	1	38	0
+various/rvt01.ifc	26166	Tessellation	36	96	0	1	32	0
+various/rvt01.ifc	26300	Tessellation	63	103	1	1	57	0
+various/rvt01.ifc	26610	Tessellation	18	58	0	1	18	0
+various/rvt01.ifc	26681	Tessellation	32	142	0	1	24	0
+various/rvt01.ifc	26832	Tessellation	11	17	0	1	11	0
+various/rvt01.ifc	30054	Tessellation	11	41	0	1	11	0
+various/rvt01.ifc	30125	Tessellation	13	39	0	1	6	0
+various/rvt01.ifc	30518	Tessellation	59	215	0	1	39	0
+various/rvt01.ifc	31083	Tessellation	28	42	0	1	17	0
+various/rvt01.ifc	31156	Tessellation	41	125	0	1	40	0
+various/rvt01.ifc	31323	Tessellation	0	8	0	1	0	-
+various/rvt01.ifc	31430	Tessellation	17	41	0	1	14	0
+various/rvt01.ifc	31577	Tessellation	11	41	0	1	11	0
+various/rvt01.ifc	31648	Tessellation	13	39	0	1	6	0
+various/rvt01.ifc	32081	SweptSolid	62	175	1	1	52	0
+various/rvt01.ifc	33639	SweptSolid	168	214	0	1	169	24
+various/rvt01.ifc	37278	Tessellation	4	16	0	1	5	0
+various/rvt01.ifc	37347	Tessellation	49	106	0	1	46	0
+various/rvt01.ifc	37455	Tessellation	66	145	1	1	57	3
+various/rvt01.ifc	37570	SweptSolid	3	75	0	1	3	0
+various/rvt01.ifc	38680	Tessellation	32	84	0	1	34	0
+various/rvt01.ifc	38745	SweptSolid	22	44	0	1	22	0
+various/rvt01.ifc	38800	SweptSolid	72	201	1	1	95	14

--- a/rust/geometry/tests/triangulation_invariance.rs
+++ b/rust/geometry/tests/triangulation_invariance.rs
@@ -21,16 +21,40 @@
 //!     --test triangulation_invariance -- --nocapture
 //!
 //! Without the feature the test reports that it was skipped and passes, so the
-//! default `cargo test` stays fast.
+//! default `cargo test` stays fast. The golden's own unit tests in
+//! [`census_golden`] do NOT need the feature and run in the default suite.
 //!
-//! The pinned `BASELINE_*` constants are ceilings, not an allow-list: each is a
-//! defect count to drive DOWN, and the test fails if any grows. `MIN_MODELS` /
-//! `MIN_VOID_HOSTS` are the matching floor, so a corpus that failed to load cannot
-//! satisfy the ceilings vacuously.
+//! # What gates this, and why it is no longer a set of constants
+//!
+//! It used to be five pinned `BASELINE_*` ceilings over absolute corpus totals.
+//! Those totals count defects across whatever the sweep actually meshed, so they
+//! could not tell an existing mesh getting worse from an element that had never
+//! meshed at all now meshing imperfectly — and they moved the *reassuring* way
+//! when an element silently stopped meshing, because its defects left every sum
+//! with it. Re-baselining was therefore indistinguishable from covering up.
+//!
+//! The gate is now a checked-in per-host golden (#2432): one row per swept void
+//! host, keyed by `(manifest-relative path, express id)`. Regressions, coverage
+//! losses, additions and reclassifications are separate outcomes with separate
+//! messages, and the corpus totals are DERIVED from the golden rather than
+//! hand-edited, so there is no constant left to bump. `MIN_MODELS` /
+//! `MIN_VOID_HOSTS` remain as the floor: every other check is an upper bound, so
+//! without them an unpopulated tree satisfies all of them vacuously.
+//!
+//! Every run also writes the rows it measured to [`RUN_REPORT_PATH`], which CI
+//! uploads as an artifact, so re-blessing does not require reproducing the sweep
+//! on the machine that disagreed. Re-blessing IN CI is refused outright (see
+//! [`census_golden::bless_mode`]): the bless path returns before every check, so
+//! a leaked `IFCLITE_CENSUS_BLESS` would leave the lane permanently and silently
+//! green, which is worse than a lane that reports a problem.
 
+mod census_golden;
+
+use census_golden::{is_closed_solid, totals, HostRow, PreVoid};
 use ifc_lite_core::{build_entity_index, EntityDecoder, EntityScanner};
 use ifc_lite_geometry::{propagate_voids_to_parts, GeometryRouter, Mesh};
 use rustc_hash::FxHashMap;
+use std::collections::BTreeSet;
 use std::path::PathBuf;
 
 /// The gated corpus: every `.ifc` in `tests/models/manifest.json` up to
@@ -46,29 +70,54 @@ use std::path::PathBuf;
 /// coverage for free.
 const MAX_FIXTURE_BYTES: u64 = 50 * 1024 * 1024;
 
-fn discover_models() -> Vec<PathBuf> {
-    let models = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("..")
-        .join("..")
-        .join("tests/models");
+/// Per-host golden. See [`census_golden`].
+const GOLDEN_PATH: &str = "tests/manifests/watertightness_census.tsv";
+
+/// Where this run's own rows are written, every run, pass or fail.
+///
+/// Under `target/`, so it is gitignored and never mistaken for the golden. The
+/// CI job uploads it as an artifact: the census log prints its per-element lists
+/// truncated (`take(12)`, `take(15)`), so before this there was no way to
+/// recover what a run actually measured, and re-blessing meant reproducing a
+/// ~20-minute sweep over a 1.4 GB fixture corpus on a developer machine and
+/// hoping it agreed with the runner. Now a drifted run hands back the exact rows
+/// it saw.
+const RUN_REPORT_PATH: &str = "../../target/watertightness_census.run.tsv";
+
+const BLESS_ENV: &str = "IFCLITE_CENSUS_BLESS";
+
+const BLESS_CMD: &str = "IFCLITE_CENSUS_BLESS=1 cargo test -p ifc-lite-geometry \
+                         --features triangulation-alt --test triangulation_invariance";
+
+fn crate_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// `(manifest-relative path, absolute path)` for each gated fixture.
+///
+/// The relative path is the golden's key, NOT the basename: three basenames
+/// repeat across the manifest under different vendor directories, and keying on
+/// them would let one model's hosts answer for another's.
+fn discover_models() -> Vec<(String, PathBuf)> {
+    let models = crate_dir().join("..").join("..").join("tests/models");
     let Ok(raw) = std::fs::read_to_string(models.join("manifest.json")) else {
         return Vec::new();
     };
     let Ok(json) = serde_json::from_str::<serde_json::Value>(&raw) else {
         return Vec::new();
     };
-    let mut out: Vec<PathBuf> = json["files"]
+    let mut out: Vec<(String, PathBuf)> = json["files"]
         .as_array()
         .map(|files| {
             files
                 .iter()
-                .filter(|f| f["path"].as_str().is_some_and(|p| p.ends_with(".ifc")))
                 .filter_map(|f| f["path"].as_str())
-                .map(|rel| models.join(rel))
+                .filter(|p| p.ends_with(".ifc"))
+                .map(|rel| (rel.to_string(), models.join(rel)))
                 // Size checked against the file ON DISK, not the manifest's recorded
                 // `size`: a stale manifest or a replaced fetch would otherwise let an
                 // oversized fixture through and silently change the swept population.
-                .filter(|p| {
+                .filter(|(_, p)| {
                     std::fs::metadata(p)
                         .map(|m| m.is_file() && m.len() <= MAX_FIXTURE_BYTES)
                         .unwrap_or(false)
@@ -80,102 +129,13 @@ fn discover_models() -> Vec<PathBuf> {
     out
 }
 
-/// Pinned baselines over the MANIFEST corpus (111 models, 1170 void hosts).
-///
-/// The previous "116 fixtures, 1355 void hosts, measured 2026-07-29" here was the
-/// one-developer's-disk population described above — the miscalibration the switch
-/// to the manifest exists to prevent — and outlived the fix that removed it.
-/// Counted only for hosts whose coordinates are
-/// small enough that f32 can carry millimetre topology (see `max_abs_coord`);
-/// far-field hosts are reported but not gated, because this harness runs below
-/// the pipeline's RTC offset and their tears are an artifact of that, not of the
-/// geometry. Both are defect counts to drive DOWN; the test
-/// fails if either grows. `TORN_SOLID` is the number that matters: hosts whose
-/// Body representation is a closed solid and which are nonetheless not
-/// watertight. SurfaceModel and Tessellation are reported separately because
-/// they need not close.
-///
-/// NB: `Tessellation` is only conditionally open — an `IfcTriangulatedFaceSet`
-/// with `Closed = .T.` is a solid. Treating the whole bucket as open is a
-/// simplification that UNDER-counts defects; revisit once `BASELINE_TORN_SOLID` is
-/// worked down.
-/// These totals are POPULATION-SENSITIVE: they count defects across whatever the
-/// sweep actually meshed, so recovering geometry that previously failed to emit
-/// raises them without anything having regressed. Read them together with
-/// `BASELINE_VOID_HOSTS` — a total that grew while the population grew is a
-/// different event from one that grew while it held.
-///
-/// That is exactly what moved them here. Walking left-nested boolean spines
-/// iteratively let chains of depth 12/13/42 mesh at all, where the depth cap had
-/// previously errored them into emitting NOTHING, taking the swept population
-/// 1165 -> 1170.
-///
-/// That no PRE-EXISTING element regressed was established by running the census
-/// at this commit and at the pre-fix base and diffing the per-element reports:
-/// the only difference in the whole report is 5 added divergence rows, all in
-/// `S_Office_Integrated Design Archi.ifc` (#426329, #437170, #448019, #458857,
-/// #469706). All 133 pre-existing divergence rows and both top-lists come out
-/// byte-identical. The arithmetic closes exactly — those hosts' open-edge counts
-/// are 0, 6, 90, 78, 51, and the four nonzero ones sum to 225, which IS the
-/// `BASELINE_OPEN_EDGE_TOTAL` delta. They are also exactly the 4 new torn hosts,
-/// all CSG (7 -> 11), which is why `Clipping` (39) and `SweptSolid` (107) hold.
-///
-/// Do NOT read the aggregate histogram as that proof. Those are per-type torn-host
-/// COUNTS, and count equality cannot exclude one element being fixed while another
-/// breaks inside the same bucket, nor an already-torn element getting far worse
-/// (which moves only the edge total). `BASELINE_COLLAPSED` holding at 51 is a
-/// useful consistency check for coordinate perturbation and nothing stronger: it
-/// counts HOSTS carrying at least one collapsed triangle, so a host already in the
-/// set can accumulate arbitrarily many more without moving it.
-///
-/// The gate still cannot tell "existing meshes got worse" from "new meshes
-/// appeared" by itself — the per-element diff above was run by hand. A per-host
-/// golden that would make it automatic is proposed in #2432, not yet built.
-const BASELINE_NON_INVARIANT: usize = 138;
-const BASELINE_TORN_SOLID: usize = 45;
-/// Total torn void hosts across the corpus, and hosts carrying at least one
-/// snap-collapsed triangle. Gated so the µm-scatter fix in
-/// `prism_cut::dedup_cut_vertices` cannot silently regress: it took these from
-/// 257 and 61 respectively.
-const BASELINE_TORN_TOTAL: usize = 203;
-const BASELINE_COLLAPSED: usize = 51;
-/// TOTAL unmatched edges across the corpus, not just the COUNT of torn elements.
-///
-/// Element counts alone are severity-blind, and that nearly shipped a bad fix: a
-/// seam-preserving consolidation took torn elements from 76 down to 62 while
-/// driving one reveal wall from 42 unpaired edges to 324. Both readings are "one
-/// torn element", so the element gate saw only the improvement. Gate the total so
-/// a fix cannot trade many small tears for a few catastrophic ones.
-const BASELINE_OPEN_EDGE_TOTAL: usize = 18_017;
-
-/// The swept population the ceilings above were measured against, gated as a
-/// CEILING.
-///
-/// Equality would have cost the fixture-fetch tolerance that `MIN_VOID_HOSTS`
-/// exists to provide, but printing alone only helps someone who reads the log of
-/// a green run. A ceiling keeps both: a short corpus still passes down to the
-/// floor, while population GROWTH cannot arrive silently — it must be
-/// acknowledged here, in the same commit that moves the totals it inflates.
-///
-/// Note what this still does not catch, and #2432 must: the floor sits 70 hosts
-/// below this, so elements silently ceasing to mesh — the exact defect this
-/// branch fixes — shrinks the population and drives every total DOWN. All the
-/// ceilings pass and the census reads as an improvement. The original depth-cap
-/// bug would sail through this test today.
-const BASELINE_VOID_HOSTS: usize = 1170;
-
-/// Corpus floor. The ceilings above are all upper bounds, so without this a tree
-/// with no fixtures passes every one of them while measuring nothing. Set under
-/// the manifest's full population (111 models / 1170 void hosts) so a single failed
+/// Corpus floor. Every other check here is an upper bound or a per-host
+/// comparison scoped to the models actually swept, so without this a tree with
+/// no fixtures passes all of them while measuring nothing. Set under the
+/// manifest's full population (111 models / 1170 void hosts) so a single failed
 /// fixture fetch does not red the build, but an unpopulated tree cannot pass.
 const MIN_MODELS: usize = 105;
 const MIN_VOID_HOSTS: usize = 1100;
-
-/// Representation types that describe a CLOSED solid and are therefore
-/// legitimately expected to produce watertight geometry.
-fn is_closed_solid(rep: &str) -> bool {
-    matches!(rep, "SweptSolid" | "CSG" | "Clipping" | "Brep" | "AdvancedBrep")
-}
 
 /// Arm/disarm the differential oracle. A no-op without the feature, so this file
 /// still compiles in the default `cargo test --workspace` run, where the test body
@@ -264,6 +224,34 @@ fn open_boundary_edges(mesh: &Mesh) -> usize {
     edge_stats(mesh).0
 }
 
+/// Byte offset of each entity's `#id=` line, built in ONE pass over the file.
+///
+/// `representation_type` used to locate every line with `content.find("\n#id=")`,
+/// which is O(file) per lookup, and it walks a frontier several levels deep. That
+/// was affordable while it ran only for the ~200 torn hosts; the golden needs a
+/// representation for all ~1170 swept hosts, and per-lookup scanning of a 50 MB
+/// fixture is not. First occurrence wins, matching the `find` it replaces.
+fn line_index(content: &str) -> FxHashMap<u32, usize> {
+    let mut idx: FxHashMap<u32, usize> = FxHashMap::default();
+    let mut pos = 0usize;
+    for line in content.split_inclusive('\n') {
+        let b = line.as_bytes();
+        if b.first() == Some(&b'#') {
+            let mut j = 1;
+            while j < b.len() && b[j].is_ascii_digit() {
+                j += 1;
+            }
+            if j > 1 && b.get(j) == Some(&b'=') {
+                if let Ok(id) = line[1..j].parse::<u32>() {
+                    idx.entry(id).or_insert(pos);
+                }
+            }
+        }
+        pos += line.len();
+    }
+    idx
+}
+
 /// `RepresentationType` of an element's **Body** representation, read from the
 /// STEP text. Prefers the `Body` identifier over `Axis`/`FootPrint`, and
 /// resolves `MappedRepresentation` through `IFCMAPPEDITEM` ->
@@ -272,10 +260,9 @@ fn open_boundary_edges(mesh: &Mesh) -> usize {
 ///
 /// This decides whether a torn element is a defect or correct output: a
 /// `SurfaceModel` or an `Axis` curve has no watertightness to lose.
-fn representation_type(content: &str, id: u32) -> String {
-    fn line_of(content: &str, eid: u32) -> Option<&str> {
-        let pat = format!("\n#{eid}=");
-        let i = content.find(&pat)? + 1;
+fn representation_type(content: &str, lines: &FxHashMap<u32, usize>, id: u32) -> String {
+    fn line_of<'a>(content: &'a str, lines: &FxHashMap<u32, usize>, eid: u32) -> Option<&'a str> {
+        let i = *lines.get(&eid)?;
         let j = content[i..].find(';')? + i;
         Some(&content[i..j])
     }
@@ -314,25 +301,30 @@ fn representation_type(content: &str, id: u32) -> String {
         }
     }
     /// Follow a MappedRepresentation to the type of the mapped source.
-    fn resolve_mapped(content: &str, rep_line: &str, depth: usize) -> Option<String> {
+    fn resolve_mapped(
+        content: &str,
+        lines: &FxHashMap<u32, usize>,
+        rep_line: &str,
+        depth: usize,
+    ) -> Option<String> {
         if depth == 0 {
             return None;
         }
         for item in refs(rep_line) {
-            let Some(l) = line_of(content, item) else { continue };
+            let Some(l) = line_of(content, lines, item) else { continue };
             if !l.contains("IFCMAPPEDITEM") {
                 continue;
             }
             for m in refs(l) {
-                let Some(ml) = line_of(content, m) else { continue };
+                let Some(ml) = line_of(content, lines, m) else { continue };
                 if !ml.contains("IFCREPRESENTATIONMAP") {
                     continue;
                 }
                 for src in refs(ml) {
-                    let Some(sl) = line_of(content, src) else { continue };
+                    let Some(sl) = line_of(content, lines, src) else { continue };
                     if let Some((_, t)) = ident_and_type(sl) {
                         if t == "MappedRepresentation" {
-                            if let Some(inner) = resolve_mapped(content, sl, depth - 1) {
+                            if let Some(inner) = resolve_mapped(content, lines, sl, depth - 1) {
                                 return Some(inner);
                             }
                         }
@@ -354,7 +346,7 @@ fn representation_type(content: &str, id: u32) -> String {
             if !seen.insert(e) {
                 continue;
             }
-            let Some(l) = line_of(content, e) else { continue };
+            let Some(l) = line_of(content, lines, e) else { continue };
             if let Some((ident, t)) = ident_and_type(l) {
                 found.push((ident, t, l.to_string()));
                 continue; // do not descend into representation items
@@ -372,7 +364,7 @@ fn representation_type(content: &str, id: u32) -> String {
         .find(|(ident, _, _)| ident == "Body")
         .unwrap_or(&found[0]);
     if pick.1 == "MappedRepresentation" {
-        if let Some(t) = resolve_mapped(content, &pick.2, 4) {
+        if let Some(t) = resolve_mapped(content, lines, &pick.2, 4) {
             return t;
         }
     }
@@ -394,13 +386,11 @@ fn max_abs_coord(mesh: &Mesh) -> f64 {
     mesh.positions.iter().fold(0.0f64, |m, &v| m.max((v as f64).abs()))
 }
 
-struct Divergence {
-    model: String,
-    id: u32,
-    base_open: usize,
-    alt_open: Option<usize>,
-    base_tris: usize,
-    alt_tris: usize,
+fn fmt_host(r: &HostRow) -> String {
+    format!(
+        "{} #{}  {:<14} open={} tris={}",
+        r.model, r.id, r.rep, r.open, r.tris
+    )
 }
 
 #[test]
@@ -413,35 +403,22 @@ fn watertightness_is_invariant_to_the_triangulator() {
         return;
     }
 
-    let mut divergences: Vec<Divergence> = Vec::new();
-    // Absolute census: hosts that are not watertight AT ALL, independent of
-    // which triangulator ran. Separate defect class from non-invariance.
-    let mut torn: Vec<(String, String, u32, usize)> = Vec::new();
-    // Open edges of the SAME element with no voids applied, index-aligned to `torn`.
-    let mut pre_tears: Vec<usize> = Vec::new();
-    let mut tri_counts: Vec<usize> = Vec::new();
-    // Hosts with at least one triangle collapsed by the 1 mm snap: f32 precision
-    // loss on large coordinates, not a topology defect.
-    let mut collapsed = 0usize;
-    let mut open_edge_total = 0usize;
-    // Largest |coordinate| per torn host, index-aligned to `torn`.
-    let mut mags: Vec<f64> = Vec::new();
-    let mut swept = 0usize;
-    let mut models_seen = 0usize;
+    let mut rows: Vec<HostRow> = Vec::new();
+    let mut swept_models: BTreeSet<String> = BTreeSet::new();
 
     let models = discover_models();
-    for path in &models {
+    for (rel, path) in &models {
         let Ok(content) = std::fs::read_to_string(path) else {
             continue;
         };
-        models_seen += 1;
-        let basename = path
-            .file_name()
-            .map(|f| f.to_string_lossy().into_owned())
-            .unwrap_or_default();
+        swept_models.insert(rel.clone());
         let voids = void_index(&content);
         let mut hosts: Vec<u32> = voids.keys().copied().collect();
         hosts.sort_unstable();
+        if hosts.is_empty() {
+            continue; // nothing to index the lines for
+        }
+        let lines = line_index(&content);
 
         for id in hosts {
             set_alt(false);
@@ -452,204 +429,312 @@ fn watertightness_is_invariant_to_the_triangulator() {
             let alt = process(&content, id, &voids);
             set_alt(false);
 
-            swept += 1;
-            let bo = open_boundary_edges(&base);
-            if edge_stats(&base).1 > 0 {
-                collapsed += 1;
-            }
-            open_edge_total += bo;
-            if bo > 0 {
-                mags.push(max_abs_coord(&base));
-                let rep = representation_type(&content, id);
-                // Was it already torn BEFORE any boolean?
-                let pre = process_no_voids(&content, id)
-                    .map(|m| open_boundary_edges(&m))
-                    .unwrap_or(usize::MAX);
-                torn.push((rep, basename.clone(), id, bo));
-                pre_tears.push(pre);
-                tri_counts.push(base.indices.len() / 3);
-            }
-            match alt {
-                None => divergences.push(Divergence {
-                    model: basename.clone(),
-                    id,
-                    base_open: bo,
-                    alt_open: None,
-                    base_tris: base.indices.len() / 3,
-                    alt_tris: 0,
-                }),
-                Some(alt) => {
-                    let ao = open_boundary_edges(&alt);
-                    if bo != ao {
-                        divergences.push(Divergence {
-                            model: basename.clone(),
-                            id,
-                            base_open: bo,
-                            alt_open: Some(ao),
-                            base_tris: base.indices.len() / 3,
-                            alt_tris: alt.indices.len() / 3,
-                        });
-                    }
+            let (open, degenerate) = edge_stats(&base);
+            // Only taken for torn hosts: it is a full second processing pass,
+            // and it is only ever read to attribute a tear to construction or
+            // to the boolean.
+            let pre = if open == 0 {
+                PreVoid::NotTaken
+            } else {
+                match process_no_voids(&content, id).map(|m| open_boundary_edges(&m)) {
+                    Some(v) => PreVoid::Open(v),
+                    None => PreVoid::Failed,
                 }
-            }
+            };
+            rows.push(HostRow {
+                model: rel.clone(),
+                id,
+                rep: representation_type(&content, &lines, id),
+                open,
+                tris: base.indices.len() / 3,
+                collapsed: degenerate > 0,
+                far: max_abs_coord(&base) >= F32_SAFE_MAGNITUDE,
+                alt: alt.as_ref().map(open_boundary_edges),
+                pre,
+            });
         }
     }
 
+    let models_seen = swept_models.len();
+    let run = totals(&rows);
+
     println!("\n=== watertightness census (production triangulator) ===");
-    println!("void hosts torn: {}/{swept}", torn.len());
-    println!("hosts with collapsed triangles (f32 precision): {collapsed}/{swept}");
-    println!("TOTAL unmatched edges across corpus: {open_edge_total}");
-    let mut by_rep: std::collections::BTreeMap<String, usize> = Default::default();
-    for (rep, _, _, _) in &torn {
-        *by_rep.entry(rep.clone()).or_insert(0) += 1;
+    println!("void hosts torn: {}/{}", run.torn, run.hosts);
+    println!(
+        "hosts with collapsed triangles (f32 precision): {}/{}",
+        run.collapsed, run.hosts
+    );
+    println!("TOTAL unmatched edges across corpus: {}", run.open_edges);
+    let mut by_rep: std::collections::BTreeMap<&str, usize> = Default::default();
+    for r in rows.iter().filter(|r| r.open > 0) {
+        *by_rep.entry(r.rep.as_str()).or_insert(0) += 1;
     }
     println!("\n  torn hosts by representation type:");
     for (rep, n) in &by_rep {
-        let closed = matches!(rep.as_str(), "SweptSolid" | "CSG" | "Clipping" | "Brep" | "AdvancedBrep");
-        println!("  {:<20} {:>5}   {}", rep, n, if closed { "<- SHOULD be watertight" } else { "open by design" });
+        println!(
+            "  {:<20} {:>5}   {}",
+            rep,
+            n,
+            if is_closed_solid(rep) { "<- SHOULD be watertight" } else { "open by design" }
+        );
     }
 
     println!("\n=== triangulation invariance sweep ===");
     println!("models swept  : {models_seen} (of {} discovered)", models.len());
-    println!("void hosts    : {swept} (baseline {BASELINE_VOID_HOSTS})");
-    println!("non-invariant : {}", divergences.len());
-    if !divergences.is_empty() {
-        println!("\n  model / element             open(base -> alt)    tris(base -> alt)");
-        for d in &divergences {
-            let alt_open = match d.alt_open {
+    println!("void hosts    : {}", run.hosts);
+    println!("non-invariant : {}", run.non_invariant);
+    if run.non_invariant > 0 {
+        println!("\n  model / element             open(base -> alt)    tris");
+        for r in rows.iter().filter(|r| r.diverged()) {
+            let alt_open = match r.alt {
                 None => "PROCESS FAILED".to_string(),
                 Some(v) => v.to_string(),
             };
             println!(
-                "  {:<27} {:>4} -> {:<13} {:>5} -> {}",
-                format!("{} #{}", d.model, d.id),
-                d.base_open,
+                "  {:<27} {:>4} -> {:<13} {:>5}",
+                format!("{} #{}", r.model, r.id),
+                r.open,
                 alt_open,
-                d.base_tris,
-                d.alt_tris
+                r.tris
             );
         }
     }
 
-    // Split closed-solid tears by whether the boolean caused them.
-    let mut pre_broken = 0usize;
-    let mut csg_broke = 0usize;
-    let mut pre_failed = 0usize;
-    for (i, (rep, _, _, _)) in torn.iter().enumerate() {
-        if !is_closed_solid(rep) {
-            continue;
-        }
-        match pre_tears[i] {
-            usize::MAX => pre_failed += 1,
-            0 => csg_broke += 1,
-            _ => pre_broken += 1,
-        }
-    }
-    // Is the tear population explained by coordinate magnitude rather than by
-    // the boolean? f32 cannot carry mm topology far from the origin.
-    // (pre-broken, csg-broke), split at `F32_SAFE_MAGNITUDE`.
-    let mut near = (0usize, 0usize);
+    // Split closed-solid tears by whether the boolean caused them, and by
+    // whether coordinate magnitude explains them instead. f32 cannot carry mm
+    // topology far from the origin.
+    let solids: Vec<&HostRow> =
+        rows.iter().filter(|r| r.open > 0 && is_closed_solid(&r.rep)).collect();
+    let mut near = (0usize, 0usize); // (pre-broken, csg-broke)
     let mut far = (0usize, 0usize);
-    for (i, (rep, _, _, _)) in torn.iter().enumerate() {
-        if !is_closed_solid(rep) {
-            continue;
-        }
-        let bucket = if mags[i] < F32_SAFE_MAGNITUDE { &mut near } else { &mut far };
-        match pre_tears[i] {
-            0 => bucket.1 += 1,
-            usize::MAX => {}
-            _ => bucket.0 += 1,
+    let mut pre_failed = 0usize;
+    for r in &solids {
+        let bucket = if r.far { &mut far } else { &mut near };
+        match r.pre {
+            PreVoid::Failed => pre_failed += 1,
+            PreVoid::Open(0) => bucket.1 += 1,
+            PreVoid::Open(_) => bucket.0 += 1,
+            // Unreachable: `pre` is always taken for a torn host.
+            PreVoid::NotTaken => {}
         }
     }
     println!("\n  closed-solid tears by coordinate magnitude:");
-    println!("    |coord| <  {F32_SAFE_MAGNITUDE:e} (f32 step 0.12 mm) : {} pre-broken, {} csg-broke", near.0, near.1);
-    println!("    |coord| >= {F32_SAFE_MAGNITUDE:e} (f32 too coarse)   : {} pre-broken, {} csg-broke", far.0, far.1);
-
+    println!(
+        "    |coord| <  {F32_SAFE_MAGNITUDE:e} (f32 step 0.12 mm) : {} pre-broken, {} csg-broke",
+        near.0, near.1
+    );
+    println!(
+        "    |coord| >= {F32_SAFE_MAGNITUDE:e} (f32 too coarse)   : {} pre-broken, {} csg-broke",
+        far.0, far.1
+    );
     println!("\n  closed-solid tears, by origin:");
-    println!("    already torn BEFORE any boolean : {pre_broken}   <- solid construction");
-    println!("    watertight before, torn after   : {csg_broke}   <- CSG kernel");
+    println!("    already torn BEFORE any boolean : {}   <- solid construction", near.0 + far.0);
+    println!("    watertight before, torn after   : {}   <- CSG kernel", near.1 + far.1);
     println!("    no-void processing failed       : {pre_failed}");
 
     // Smallest pre-broken closed solids: minimal reproducers for the
     // construction-path defect.
-    let mut pre: Vec<(&str, &str, u32, usize, usize)> = torn
+    let mut pre: Vec<&HostRow> = solids
         .iter()
-        .enumerate()
-        .filter(|(i, (rep, _, _, _))| is_closed_solid(rep) && pre_tears[*i] > 0 && pre_tears[*i] != usize::MAX)
-        .map(|(i, (rep, m, id, _))| (rep.as_str(), m.as_str(), *id, pre_tears[i], tri_counts[i]))
+        .filter(|r| matches!(r.pre, PreVoid::Open(v) if v > 0))
+        .copied()
         .collect();
-    pre.sort_by_key(|r| (r.4, r.3));
+    pre.sort_by_key(|r| (r.tris, r.open));
     // Minimal reproducers for the kernel defect: watertight solid in, torn out,
     // at coordinates f32 handles cleanly.
-    let mut kern: Vec<(&str, &str, u32, usize, usize)> = torn
+    let mut kern: Vec<&HostRow> = solids
         .iter()
-        .enumerate()
-        .filter(|(i, (rep, _, _, _))| {
-            is_closed_solid(rep) && pre_tears[*i] == 0 && mags[*i] < F32_SAFE_MAGNITUDE
-        })
-        .map(|(i, (rep, m, id, open))| (rep.as_str(), m.as_str(), *id, *open, tri_counts[i]))
+        .filter(|r| r.pre == PreVoid::Open(0) && !r.far)
+        .copied()
         .collect();
-    kern.sort_by_key(|r| (r.4, r.3));
+    kern.sort_by_key(|r| (r.tris, r.open));
     println!("\n  smallest KERNEL-caused tears (watertight in, torn out, f32-safe):");
     println!("    rep            model / element                  open  tris");
-    for (rep, m, id, open, tris) in kern.iter().take(12) {
-        println!("    {:<14} {:<32} {:>4}  {:>5}", rep, format!("{m} #{id}"), open, tris);
+    for r in kern.iter().take(12) {
+        println!(
+            "    {:<14} {:<32} {:>4}  {:>5}",
+            r.rep,
+            format!("{} #{}", r.model, r.id),
+            r.open,
+            r.tris
+        );
     }
-
     println!("\n  smallest pre-broken closed solids (no voids applied):");
     println!("    rep            model / element                  open  tris");
-    for (rep, m, id, open, tris) in pre.iter().take(15) {
-        println!("    {:<14} {:<32} {:>4}  {:>5}", rep, format!("{m} #{id}"), open, tris);
+    for r in pre.iter().take(15) {
+        let p = match r.pre {
+            PreVoid::Open(v) => v,
+            _ => 0,
+        };
+        println!(
+            "    {:<14} {:<32} {:>4}  {:>5}",
+            r.rep,
+            format!("{} #{}", r.model, r.id),
+            p,
+            r.tris
+        );
     }
 
-    let torn_solid = near.0 + near.1;
-    println!("\ngenuine defects (closed solid, f32-safe coordinates): {torn_solid} (baseline {BASELINE_TORN_SOLID})");
-    println!("  of which the boolean caused: {}", near.1);
-    println!("  of which arrived torn      : {}", near.0);
-    println!("far-field (below RTC, f32 cannot hold mm): {} not gated", far.0 + far.1);
-    println!("non-invariant total: {} (baseline {BASELINE_NON_INVARIANT})", divergences.len());
-
-    // FLOOR. Every other assertion here is an upper bound, so a missing or partial
-    // `tests/models` tree (shallow clone, fixtures not fetched, path drift) yields
-    // zeros and a green run that certifies nothing. Pin the corpus size too.
+    // FLOOR. Every check below is an upper bound or a comparison scoped to the
+    // models actually swept, so a missing or partial `tests/models` tree (shallow
+    // clone, fixtures not fetched, path drift) would otherwise yield zeros and a
+    // green run that certifies nothing. This also runs BEFORE the bless path, so
+    // an under-populated tree can never write a truncated golden.
     assert!(
-        models_seen >= MIN_MODELS && swept >= MIN_VOID_HOSTS,
-        "corpus under-populated: {models_seen} models / {swept} void hosts, expected \
-         at least {MIN_MODELS} / {MIN_VOID_HOSTS} — fixtures missing, so the ceilings \
-         below would pass vacuously"
+        models_seen >= MIN_MODELS && run.hosts >= MIN_VOID_HOSTS,
+        "corpus under-populated: {models_seen} models / {} void hosts, expected \
+         at least {MIN_MODELS} / {MIN_VOID_HOSTS} — fixtures missing, so the checks \
+         below would pass vacuously",
+        run.hosts
     );
 
-    // Population ceiling. The totals below are absolute counts over whatever was
-    // actually meshed, so a grown corpus inflates them without anything having
-    // regressed. Gate the population itself: growth must be acknowledged here in
-    // the same commit that moves the totals, rather than being absorbed into them.
+    // Written BEFORE any assertion, so a failing run still hands back what it
+    // measured. Best-effort: a read-only target/ must not turn a green census red.
+    let report_path = crate_dir().join(RUN_REPORT_PATH);
+    if let Some(dir) = report_path.parent() {
+        let _ = std::fs::create_dir_all(dir);
+    }
+    match std::fs::write(&report_path, census_golden::render(&rows)) {
+        Ok(()) => println!("\nthis run's rows: {}", report_path.display()),
+        Err(e) => println!("\ncould not write {}: {e}", report_path.display()),
+    }
+
+    let golden_path = crate_dir().join(GOLDEN_PATH);
+    let golden_text = std::fs::read_to_string(&golden_path).unwrap_or_default();
+    let golden = census_golden::parse(&golden_text)
+        .unwrap_or_else(|e| panic!("{} is unreadable: {e}", golden_path.display()));
+
+    let bless = census_golden::bless_mode(
+        std::env::var_os(BLESS_ENV).is_some(),
+        std::env::var_os("CI").is_some_and(|v| !v.is_empty() && v != "0" && v != "false"),
+    )
+    .unwrap_or_else(|e| panic!("{e}"));
+
+    if bless {
+        // Preserve the rows of models this run did NOT sweep, so blessing on a
+        // partial fixture tree cannot silently delete their coverage.
+        let mut next: Vec<HostRow> = golden
+            .iter()
+            .filter(|r| !swept_models.contains(&r.model))
+            .cloned()
+            .collect();
+        let kept = next.len();
+        next.extend(rows.iter().cloned());
+        if let Some(dir) = golden_path.parent() {
+            std::fs::create_dir_all(dir).expect("create golden directory");
+        }
+        std::fs::write(&golden_path, census_golden::render(&next)).expect("write golden");
+        println!(
+            "\nBLESSED {} — {} swept rows written, {kept} rows kept for unswept models",
+            golden_path.display(),
+            rows.len()
+        );
+        return;
+    }
+
     assert!(
-        swept <= BASELINE_VOID_HOSTS,
-        "swept population grew: {swept} > {BASELINE_VOID_HOSTS} — the totals below are \
-         absolute, so they inflate with it. Confirm per-element that no EXISTING host \
-         regressed (see #2432), then bump this and the ceilings together"
+        !golden.is_empty(),
+        "{} is missing or empty. Generate it with:\n  {BLESS_CMD}",
+        golden_path.display()
+    );
+
+    let diff = census_golden::diff(&golden, &rows, &swept_models);
+    let expected = totals(golden.iter().filter(|r| swept_models.contains(&r.model)));
+
+    println!("\n=== per-host golden ({}) ===", GOLDEN_PATH);
+    println!("regressed : {}", diff.regressed.len());
+    println!("coverage loss (in golden, produced nothing): {}", diff.missing.len());
+    println!("added (newly meshing): {}", diff.added.len());
+    println!("reclassified: {}", diff.changed.len());
+    println!("improved  : {}", diff.improved.len());
+    for d in &diff.improved {
+        println!("  IMPROVED  {}  [{}]", fmt_host(&d.run), d.reasons.join("; "));
+    }
+
+    // Not a failure: `MIN_MODELS` sits under the corpus precisely so a failed
+    // fixture fetch does not red the build, and a model that did not load has no
+    // hosts to call missing. But it is the one way coverage can still leave the
+    // census quietly, so it is printed rather than left to be inferred.
+    let unswept: BTreeSet<&str> = golden
+        .iter()
+        .map(|r| r.model.as_str())
+        .filter(|m| !swept_models.contains(*m))
+        .collect();
+    if !unswept.is_empty() {
+        println!(
+            "NOT SWEPT (in the golden, no fixture on disk): {} model(s) — {}",
+            unswept.len(),
+            unswept.into_iter().collect::<Vec<_>>().join(", ")
+        );
+    }
+
+    println!("\ncorpus totals (run vs golden, over the {models_seen} swept models):");
+    println!("  void hosts        : {} vs {}", run.hosts, expected.hosts);
+    println!("  torn hosts        : {} vs {}", run.torn, expected.torn);
+    println!("  unmatched edges   : {} vs {}", run.open_edges, expected.open_edges);
+    println!("  collapsed hosts   : {} vs {}", run.collapsed, expected.collapsed);
+    println!("  genuine defects   : {} vs {}", run.torn_solid, expected.torn_solid);
+    println!("  non-invariant     : {} vs {}", run.non_invariant, expected.non_invariant);
+
+    // Regressions first: they are the only outcome that is unambiguously a
+    // defect, and burying them under an addition list would repeat the mistake
+    // this golden exists to fix.
+    assert!(
+        diff.regressed.is_empty(),
+        "{} host(s) REGRESSED against the golden — an existing mesh got worse:\n{}",
+        diff.regressed.len(),
+        diff.regressed
+            .iter()
+            .map(|d| format!("  {}  [{}]", fmt_host(&d.run), d.reasons.join("; ")))
+            .collect::<Vec<_>>()
+            .join("\n")
     );
 
     assert!(
-        open_edge_total <= BASELINE_OPEN_EDGE_TOTAL,
-        "total unmatched edges grew: {open_edge_total} > {BASELINE_OPEN_EDGE_TOTAL}"
+        diff.missing.is_empty(),
+        "COVERAGE LOSS: {} host(s) in the golden produced NO geometry in this run, \
+         from models that WERE swept. Absolute totals read this as an improvement \
+         because the missing element's defects leave every sum with it:\n{}",
+        diff.missing.len(),
+        diff.missing.iter().map(|r| format!("  {}", fmt_host(r))).collect::<Vec<_>>().join("\n")
     );
+
     assert!(
-        torn.len() <= BASELINE_TORN_TOTAL,
-        "total torn void hosts grew: {} > {BASELINE_TORN_TOTAL}",
-        torn.len()
+        diff.added.is_empty(),
+        "{} host(s) meshed that the golden does not carry. These are ADDITIONS, not \
+         regressions: geometry that produced nothing before produces something now, \
+         which inflates every corpus total without anything having degraded. Confirm \
+         that is what happened, then re-bless:\n  {BLESS_CMD}\n{}",
+        diff.added.len(),
+        diff.added.iter().map(|r| format!("  {}", fmt_host(r))).collect::<Vec<_>>().join("\n")
     );
+
     assert!(
-        collapsed <= BASELINE_COLLAPSED,
-        "hosts with snap-collapsed triangles grew: {collapsed} > {BASELINE_COLLAPSED}"
+        diff.changed.is_empty(),
+        "{} host(s) were RECLASSIFIED — neither better nor worse, but it changes what \
+         the census believes it is measuring. Review, then re-bless:\n  {BLESS_CMD}\n{}",
+        diff.changed.len(),
+        diff.changed
+            .iter()
+            .map(|d| format!("  {}  [{}]", fmt_host(&d.run), d.reasons.join("; ")))
+            .collect::<Vec<_>>()
+            .join("\n")
     );
-    assert!(
-        torn_solid <= BASELINE_TORN_SOLID,
-        "closed-solid elements that are not watertight grew: {torn_solid} > {BASELINE_TORN_SOLID}"
-    );
-    assert!(
-        divergences.len() <= BASELINE_NON_INVARIANT,
-        "elements depending on the triangulator's diagonal choice grew: {} > {BASELINE_NON_INVARIANT}",
-        divergences.len()
-    );
+
+    // Corpus ceilings, DERIVED from the golden rather than pinned as editable
+    // constants — there is no number here for a red build to tempt someone into
+    // bumping. Implied by the per-host checks above, and kept because they are
+    // what would catch a bug in the classifier itself, and because severity
+    // (total unmatched edges) has to stay in view alongside counts: a fix once
+    // took torn elements 76 -> 62 while driving one reveal wall from 42 unpaired
+    // edges to 324, and an element-count gate saw only the improvement.
+    for (name, got, want) in [
+        ("total unmatched edges", run.open_edges, expected.open_edges),
+        ("torn void hosts", run.torn, expected.torn),
+        ("hosts with snap-collapsed triangles", run.collapsed, expected.collapsed),
+        ("closed solids that are not watertight", run.torn_solid, expected.torn_solid),
+        ("hosts depending on the triangulator's diagonal choice", run.non_invariant, expected.non_invariant),
+    ] {
+        assert!(got <= want, "{name} grew: {got} > {want} (golden-derived)");
+    }
 }

--- a/rust/geometry/tests/triangulation_invariance.rs
+++ b/rust/geometry/tests/triangulation_invariance.rs
@@ -575,21 +575,11 @@ fn watertightness_is_invariant_to_the_triangulator() {
         );
     }
 
-    // FLOOR. Every check below is an upper bound or a comparison scoped to the
-    // models actually swept, so a missing or partial `tests/models` tree (shallow
-    // clone, fixtures not fetched, path drift) would otherwise yield zeros and a
-    // green run that certifies nothing. This also runs BEFORE the bless path, so
-    // an under-populated tree can never write a truncated golden.
-    assert!(
-        models_seen >= MIN_MODELS && run.hosts >= MIN_VOID_HOSTS,
-        "corpus under-populated: {models_seen} models / {} void hosts, expected \
-         at least {MIN_MODELS} / {MIN_VOID_HOSTS} — fixtures missing, so the checks \
-         below would pass vacuously",
-        run.hosts
-    );
-
-    // Written BEFORE any assertion, so a failing run still hands back what it
-    // measured. Best-effort: a read-only target/ must not turn a green census red.
+    // Written BEFORE any assertion, INCLUDING the floor below, so every failing
+    // run hands back what it measured. An under-populated corpus is precisely
+    // when the rows are wanted — they say which models loaded and which did not
+    // — and writing after the floor would leave that run with no artifact at all.
+    // Best-effort: a read-only target/ must not turn a green census red.
     let report_path = crate_dir().join(RUN_REPORT_PATH);
     if let Some(dir) = report_path.parent() {
         let _ = std::fs::create_dir_all(dir);
@@ -598,6 +588,21 @@ fn watertightness_is_invariant_to_the_triangulator() {
         Ok(()) => println!("\nthis run's rows: {}", report_path.display()),
         Err(e) => println!("\ncould not write {}: {e}", report_path.display()),
     }
+
+    // FLOOR. Every check below is an upper bound or a comparison scoped to the
+    // models actually swept, so a missing or partial `tests/models` tree (shallow
+    // clone, fixtures not fetched, path drift) would otherwise yield zeros and a
+    // green run that certifies nothing. Writing the run report above it is safe:
+    // that file lives under `target/` and is never the gate. What must stay below
+    // this floor is the BLESS path, so an under-populated tree can never write a
+    // truncated golden.
+    assert!(
+        models_seen >= MIN_MODELS && run.hosts >= MIN_VOID_HOSTS,
+        "corpus under-populated: {models_seen} models / {} void hosts, expected \
+         at least {MIN_MODELS} / {MIN_VOID_HOSTS} — fixtures missing, so the checks \
+         below would pass vacuously",
+        run.hosts
+    );
 
     let golden_path = crate_dir().join(GOLDEN_PATH);
     let golden_text = std::fs::read_to_string(&golden_path).unwrap_or_default();


### PR DESCRIPTION
Fixes #2432

## The defect, reproduced

The census gates five **absolute** defect totals over whatever the sweep happened to mesh. Nothing pins element identity across runs, so the totals cannot separate a regression from a recovery, and they move the *reassuring* way for the worst case of the three.

Reproduced by restoring the pre-#2382 depth cap on the boolean processor (a left-spine step counting against `MAX_BOOLEAN_DEPTH` again) and running the census unchanged from `main`:

| metric | main | with the cap restored |
| --- | --- | --- |
| void hosts | 1170 | **1165** |
| unmatched edges | 18017 | **17792** |
| torn hosts | 203 | **199** |
| collapsed hosts | 51 | 51 |
| genuine defects | 45 | **41** |
| non-invariant | 138 | **133** |

```
test result: ok. 1 passed; 0 failed; ... finished in 399.14s
```

Five CSG hosts stopped producing geometry and **the census passed**. Every ceiling is an upper bound, so their defects left every sum with them and the run reads as an improvement. Those numbers are the issue's own "before" column, element for element: the five hosts are `#426329, #437170, #448019, #458857, #469706` in `ara3d/S_Office_Integrated Design Archi.ifc`, open counts `0, 6, 90, 78, 51`, whose non-zero sum is exactly the 225-edge delta.

The other direction is the same failure wearing the opposite sign. Diffing the two real row sets, recovery (1165 -> 1170) raises `open_edge_total` past the ceiling and reds the build with `total unmatched edges grew` -- a message shaped identically to a genuine regression's. That is the perverse incentive: the cheapest way to green a recovery is to bump the baselines, which is also how a real regression is waved through.

## The fix

A checked-in per-host golden, `rust/geometry/tests/manifests/watertightness_census.tsv`, one row per swept void host keyed by `(manifest-relative path, express id)`. Basenames repeat three times across the manifest under different vendor directories, so keying on them would let one model's row answer for another's.

The four outcomes are separate, with separate messages:

| outcome | verdict |
| --- | --- |
| in both, worse on any count | **REGRESSED**, naming the element and the dimension |
| in the golden, its model swept, produced nothing | **COVERAGE LOSS** |
| only in the run | **ADDITION** -- reviewable, not a defect |
| representation type or f32-magnitude class moved | **RECLASSIFIED** |
| strictly better | improved, printed, never fails |

Against the same mutated kernel:

```
regressed : 0
coverage loss (in golden, produced nothing): 5
added (newly meshing): 0

COVERAGE LOSS: 5 host(s) in the golden produced NO geometry in this run, from
models that WERE swept. Absolute totals read this as an improvement because the
missing element's defects leave every sum with it:
  ara3d/S_Office_Integrated Design Archi.ifc #426329  CSG  open=0 tris=496
  ara3d/S_Office_Integrated Design Archi.ifc #437170  CSG  open=6 tris=380
  ara3d/S_Office_Integrated Design Archi.ifc #448019  CSG  open=90 tris=1034
  ara3d/S_Office_Integrated Design Archi.ifc #458857  CSG  open=78 tris=1062
  ara3d/S_Office_Integrated Design Archi.ifc #469706  CSG  open=51 tris=1077
```

and replaying the recovery direction over the same two row sets gives `added: 5, regressed: 0` -- named, attributed, and not a defect.

**Triangle count is carried alongside open edges.** A host whose mesh degrades to empty still returns `Ok` and still reports zero open edges, which is indistinguishable from a perfect watertight solid under an open-count-only golden.

**The corpus ceilings survive, derived from the golden** rather than pinned as editable constants, so there is no number left for a red build to tempt someone into bumping. An exhaustive test over every dimension the classifier reads proves a clean diff can never let one of them grow -- which is what makes them honest to keep: a derived ceiling that fires now means the classifier is broken, not that a total drifted. Severity stays in view for the reason the `BASELINE_OPEN_EDGE_TOTAL` comment records; injecting the two real regressions it warns about gives

```
  REGRESS  ara3d/S_Office_Integrated Design Archi.ifc #437170  [open edges 6 -> 324]
  REGRESS  ara3d/dental_clinic.ifc #1757  [triangles 28 -> 0 (geometry lost); newly depends on the triangulator's diagonal choice]
```

while the aggregate torn count went *down* (203 -> 202) and genuine defects *down* (45 -> 44).

## Keeping it meaningful, not merely green

A census that reports "all good" because it stopped measuring is worse than one that reports a problem. Every way this lane could go quietly green:

| if this happened | what fires |
| --- | --- |
| an element stops meshing | `COVERAGE LOSS`, naming it |
| an existing mesh gets worse | `REGRESSED`, naming the dimension |
| geometry is recovered | `ADDITION` -- explicitly not a regression |
| fixtures missing / partial tree | `MIN_MODELS` / `MIN_VOID_HOSTS` floor, evaluated **before** the bless path, so a partial tree can never write a truncated golden |
| the golden is missing or empty | hard assert, with the bless command |
| the golden is truncated | every orphaned run host reports as an `ADDITION` |
| a row is malformed | parse error, not a silently short golden |
| the classifier itself breaks | the golden-derived ceilings still fire |
| `IFCLITE_CENSUS_BLESS` leaks into CI | **refused** -- blessing returns before every check, so it would disarm the lane permanently |

That last one is why the job now uploads `target/watertightness_census.run.tsv`, written every run pass or fail: CI re-blesses by downloading the rows, never by setting the env var. It also fixes a standing problem -- the census log prints its per-element lists truncated (`take(12)`, `take(15)`), so a runner that disagreed could previously only be diagnosed by reproducing a ~20-minute sweep over a 1.4 GB corpus and hoping it agreed.

Improvements are reported and never fail, so the golden is a per-host **ceiling** rather than an equality snapshot and a geometry fix does not red the lane it improves. The cost is that the ratchet does not self-tighten until someone re-blesses; making improvements fail instead would buy that at the price of redding every geometry fix on the commit that makes it, which is the friction that got the old constants bumped without scrutiny in the first place.

## Scope

The census sweeps void hosts, so this gives coverage-regression detection for those ~1170 elements, not for every product in the corpus. An element with no `IfcRelVoidsElement` that stops meshing is still invisible here. Widening the sweep is a separate and much more expensive change.

## Verification

- Control census, full corpus, unmutated: `19 passed; 0 failed`, diff `regressed 0 / coverage loss 0 / added 0 / reclassified 0`, run vs golden identical on all six totals.
- `cargo test --workspace --no-fail-fast`: 156 test binaries `ok`, 0 failed, exit 0. The golden's own 18 unit tests run in that default suite in 0.69s -- they do not need the `triangulation-alt` feature.
- `cargo clippy --workspace --all-targets -- -D warnings` from the repo root: clean. Also clean under `--features triangulation-alt`.
- Eight mutations, each reverted and the tree confirmed clean afterwards; every one dropped the passing count from 18 and failed exactly the intended test: reclassification-first routing, the derived-predicate flip, the CI bless refusal, coverage-loss detection, addition vs improvement, triangle-shrink loss, swept-model scoping, and the row-width check.

Test-only; no published package behaviour changes, so no changeset.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved geometry census reporting with per-model and per-element tracking.
  * Detects regressions, missing coverage, new entries, improvements, and defect reclassifications.
  * Preserves census artifacts in CI even when validation encounters failures.

* **Tests**
  * Added extensive validation for malformed reports, triangulation differences, coverage changes, and aggregate totals.
  * Added safer baseline updates with CI-aware checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->