### PR TITLE
test(geometry): pin the per-hop reduction a deep boolean spine depends on

### DIFF
--- a/rust/geometry/src/processors/boolean/chain_cycle_tests.rs
+++ b/rust/geometry/src/processors/boolean/chain_cycle_tests.rs
@@ -230,7 +230,27 @@ fn deep_left_difference_chain_resolves_past_depth_cap() {
 /// Exact f32-bit key for a vertex, so a sub-micron displacement of a shared
 /// vertex splits the pair it was supposed to form instead of being rounded back
 /// together. That exactness is what makes these instruments right for a seam.
+/// Both buffers must be whole triplets. `chunks_exact` DISCARDS a ragged tail,
+/// so a mesh with a stray coordinate or a two-index triangle would be silently
+/// truncated and could then satisfy all three instruments below — a shorter
+/// mesh than the one under test, certified as the one under test.
+fn assert_mesh_buffer_layout(mesh: &Mesh) {
+    assert_eq!(
+        mesh.positions.len() % 3,
+        0,
+        "positions must be whole xyz triplets; got {}",
+        mesh.positions.len()
+    );
+    assert_eq!(
+        mesh.indices.len() % 3,
+        0,
+        "indices must be whole triangles; got {}",
+        mesh.indices.len()
+    );
+}
+
 fn vertex_keys(mesh: &Mesh) -> Vec<[u32; 3]> {
+    assert_mesh_buffer_layout(mesh);
     mesh.positions
         .chunks_exact(3)
         .map(|p| [p[0].to_bits(), p[1].to_bits(), p[2].to_bits()])
@@ -296,6 +316,7 @@ fn duplicate_face_count(mesh: &Mesh) -> usize {
 /// `abs()` here would let a wholly inverted result report the expected
 /// magnitude.
 fn mesh_volume(mesh: &Mesh) -> f64 {
+    assert_mesh_buffer_layout(mesh);
     let v = |i: u32| {
         let b = i as usize * 3;
         [
@@ -555,6 +576,36 @@ fn watertightness_instruments_reject_the_defects_they_guard() {
         0,
         "inverted winding is invisible to the duplicate-face instrument"
     );
+}
+
+/// A ragged buffer must be REJECTED, not quietly truncated. Both instruments
+/// that read the raw buffers are covered: `open_edge_count` and
+/// `duplicate_face_count` go through `vertex_keys`, `mesh_volume` asserts for
+/// itself. Split into two tests so each panic is attributed to the buffer that
+/// caused it — one combined test would pass on a guard that only checks
+/// positions.
+#[test]
+#[should_panic(expected = "positions must be whole xyz triplets")]
+fn a_ragged_position_buffer_is_rejected() {
+    let mut mesh = Mesh::new();
+    // One trailing coordinate: `chunks_exact(3)` would drop the partial vertex
+    // and hand back a mesh one vertex short of the one under test.
+    mesh.positions = vec![0.0; 3 * 3 + 1];
+    mesh.normals = vec![0.0; mesh.positions.len()];
+    mesh.indices = vec![0, 1, 2];
+    let _ = open_edge_count(&mesh);
+}
+
+#[test]
+#[should_panic(expected = "indices must be whole triangles")]
+fn a_ragged_index_buffer_is_rejected() {
+    let mut mesh = Mesh::new();
+    mesh.positions = vec![0.0; 3 * 3];
+    mesh.normals = vec![0.0; mesh.positions.len()];
+    // A two-index tail: the dropped pair is exactly the kind of open edge these
+    // instruments exist to find.
+    mesh.indices = vec![0, 1, 2, 0, 1];
+    let _ = mesh_volume(&mesh);
 }
 
 /// The FULL `process()` path on a self-referential boolean must terminate

--- a/rust/geometry/src/processors/boolean/chain_cycle_tests.rs
+++ b/rust/geometry/src/processors/boolean/chain_cycle_tests.rs
@@ -227,6 +227,150 @@ fn deep_left_difference_chain_resolves_past_depth_cap() {
     assert!(lo.z.abs() < 1.0, "cube base must stay at z=0; got {}", lo.z);
 }
 
+/// Unpaired directed edges, keyed on exact f32 vertex bits. A watertight mesh
+/// has none: every directed edge is cancelled by its twin on the adjacent
+/// triangle. Any sub-micron displacement of a shared vertex splits the pair and
+/// shows up here, which is what makes this the right instrument for a seam.
+fn open_edge_count(mesh: &Mesh) -> usize {
+    use std::collections::HashMap;
+    let key = |i: u32| -> [u32; 3] {
+        let b = i as usize * 3;
+        [
+            mesh.positions[b].to_bits(),
+            mesh.positions[b + 1].to_bits(),
+            mesh.positions[b + 2].to_bits(),
+        ]
+    };
+    let mut edges: HashMap<([u32; 3], [u32; 3]), i32> = HashMap::new();
+    for t in mesh.indices.chunks_exact(3) {
+        let k = [key(t[0]), key(t[1]), key(t[2])];
+        for (u, v) in [(0, 1), (1, 2), (2, 0)] {
+            *edges.entry((k[u], k[v])).or_insert(0) += 1;
+            *edges.entry((k[v], k[u])).or_insert(0) -= 1;
+        }
+    }
+    edges.values().map(|c| c.unsigned_abs() as usize).sum()
+}
+
+/// Signed-volume of a closed triangle soup (divergence theorem).
+fn mesh_volume(mesh: &Mesh) -> f64 {
+    let v = |i: u32| {
+        let b = i as usize * 3;
+        [
+            mesh.positions[b] as f64,
+            mesh.positions[b + 1] as f64,
+            mesh.positions[b + 2] as f64,
+        ]
+    };
+    let mut s = 0.0;
+    for t in mesh.indices.chunks_exact(3) {
+        let (a, b, c) = (v(t[0]), v(t[1]), v(t[2]));
+        s += a[0] * (b[1] * c[2] - b[2] * c[1]) - a[1] * (b[0] * c[2] - b[2] * c[0])
+            + a[2] * (b[0] * c[1] - b[1] * c[0]);
+    }
+    (s / 6.0).abs()
+}
+
+/// A deep left-nested DIFFERENCE spine whose cutters SHARE SEAMS must come out
+/// watertight AND compact, hop by hop (#2433).
+///
+/// #2433 proposed evaluating such a spine as ONE arrangement — staying in the
+/// kernel's f64 `Vec<Tri>` across the whole chain and crossing the `Mesh`
+/// boundary once at the end — on the theory that the per-hop
+/// `f32 -> f64+snap -> f32` round trip in `mesh_bridge` re-jitters and re-cracks
+/// the previous hop's seams. Measurement refuted that: dropping the round trip
+/// leaves the open-edge count unchanged (the cracks are already present in the
+/// f64 arrangement output, before any narrowing), while dropping the per-hop
+/// `Mesh` step also drops the `consolidate_coplanar` that runs inside
+/// `ClippingProcessor::subtract_mesh`. That consolidation is what keeps the
+/// accumulator from fragmenting: on the real depth-12 spine that motivated the
+/// issue it holds the result at 60 triangles instead of 702, and the resulting
+/// operand growth cost three orders of magnitude of wall time.
+///
+/// So the per-hop `Mesh` boundary is not overhead to be collapsed — it is where
+/// the accumulator is reduced. This test pins that: the fixture is 12 cutters on
+/// an off-snap-grid pitch (0.37 m against a 2^-16 m grid), each overlapping its
+/// predecessor so hop N+1 always lands on hop N's fresh seam — the exact regime
+/// the issue argued was damaged.
+#[test]
+fn deep_seam_sharing_difference_spine_stays_watertight_and_compact() {
+    const CHAIN: usize = 12;
+    const _: () = assert!(CHAIN > MAX_BOOLEAN_DEPTH as usize);
+    // 12 x 0.3 x 3 m wall host.
+    let mut data = String::from(
+        "#100=IFCCARTESIANPOINT((0.,0.));\n\
+#101=IFCAXIS2PLACEMENT2D(#100,$);\n\
+#102=IFCRECTANGLEPROFILEDEF(.AREA.,$,#101,12.,0.3);\n\
+#103=IFCCARTESIANPOINT((0.,0.,0.));\n\
+#104=IFCAXIS2PLACEMENT3D(#103,$,$);\n\
+#105=IFCDIRECTION((0.,0.,1.));\n\
+#106=IFCEXTRUDEDAREASOLID(#102,#104,#105,3.);\n\
+#110=IFCRECTANGLEPROFILEDEF(.AREA.,$,#101,0.5,1.);\n",
+    );
+    // Cutters: 0.5 m wide on a 0.37 m pitch, so consecutive cutters overlap by
+    // 0.13 m and every hop re-cuts the seam the previous hop just created. Each
+    // is a through-cut (1.0 m across a 0.3 m wall) spanning z = 0.6..2.0.
+    for i in 0..CHAIN {
+        let x = -5.5 + (i as f64) * 0.37;
+        let id = 1000 + i * 10;
+        data.push_str(&format!(
+            "#{p}=IFCCARTESIANPOINT(({x:.9},0.,0.6));\n\
+#{a}=IFCAXIS2PLACEMENT3D(#{p},$,$);\n\
+#{s}=IFCEXTRUDEDAREASOLID(#110,#{a},#105,1.4);\n",
+            p = id,
+            a = id + 1,
+            s = id + 2,
+        ));
+    }
+    for i in 0..CHAIN {
+        let first = if i == 0 { 106 } else { 5000 + i - 1 };
+        data.push_str(&format!(
+            "#{}=IFCBOOLEANRESULT(.DIFFERENCE.,#{first},#{cut});\n",
+            5000 + i,
+            cut = 1000 + i * 10 + 2
+        ));
+    }
+    let content = wrap_ifc(&data);
+    let mut decoder = EntityDecoder::new(&content);
+    let entity = decoder
+        .decode_by_id((5000 + CHAIN - 1) as u32)
+        .expect("decode spine root");
+    let mesh = BooleanClippingProcessor::new()
+        .process(
+            &entity,
+            &mut decoder,
+            &IfcSchema::new(),
+            TessellationQuality::Medium,
+        )
+        .expect("a 12-deep solid-cutter spine must resolve");
+
+    assert_eq!(
+        open_edge_count(&mesh),
+        0,
+        "every hop's seam must stay closed across a 12-deep seam-sharing spine"
+    );
+
+    // The 12 overlapping cutters merge into ONE notch spanning
+    // x = -5.75 .. -1.18, full wall thickness, 1.4 m tall:
+    // 12*0.3*3 - 4.57*0.3*1.4 = 8.8806 m^3.
+    let volume = mesh_volume(&mesh);
+    assert!(
+        (volume - 8.8806).abs() < 1.0e-2,
+        "spine must remove exactly the merged notch; expected ~8.8806 m^3, got {volume}"
+    );
+
+    // Fragmentation guard. The merged notch is a simple prismatic cavity, so the
+    // consolidated result is a few dozen triangles. Without the per-hop
+    // reduction the same spine fragments by an order of magnitude, which is both
+    // the wrong geometry to hand the renderer and the reason an all-at-once
+    // arrangement is dramatically slower.
+    assert!(
+        mesh.triangle_count() <= 64,
+        "a 12-hop spine over one merged notch must stay consolidated; got {} triangles",
+        mesh.triangle_count()
+    );
+}
+
 /// The FULL `process()` path on a self-referential boolean must terminate
 /// (via the cycle guard + MAX_BOOLEAN_DEPTH recursion cap), returning a
 /// Result — Ok or Err both acceptable — instead of hanging the worker.

--- a/rust/geometry/src/processors/boolean/chain_cycle_tests.rs
+++ b/rust/geometry/src/processors/boolean/chain_cycle_tests.rs
@@ -227,32 +227,74 @@ fn deep_left_difference_chain_resolves_past_depth_cap() {
     assert!(lo.z.abs() < 1.0, "cube base must stay at z=0; got {}", lo.z);
 }
 
-/// Unpaired directed edges, keyed on exact f32 vertex bits. A watertight mesh
-/// has none: every directed edge is cancelled by its twin on the adjacent
-/// triangle. Any sub-micron displacement of a shared vertex splits the pair and
-/// shows up here, which is what makes this the right instrument for a seam.
-fn open_edge_count(mesh: &Mesh) -> usize {
-    use std::collections::HashMap;
-    let key = |i: u32| -> [u32; 3] {
-        let b = i as usize * 3;
-        [
-            mesh.positions[b].to_bits(),
-            mesh.positions[b + 1].to_bits(),
-            mesh.positions[b + 2].to_bits(),
-        ]
-    };
-    let mut edges: HashMap<([u32; 3], [u32; 3]), i32> = HashMap::new();
-    for t in mesh.indices.chunks_exact(3) {
-        let k = [key(t[0]), key(t[1]), key(t[2])];
-        for (u, v) in [(0, 1), (1, 2), (2, 0)] {
-            *edges.entry((k[u], k[v])).or_insert(0) += 1;
-            *edges.entry((k[v], k[u])).or_insert(0) -= 1;
-        }
-    }
-    edges.values().map(|c| c.unsigned_abs() as usize).sum()
+/// Exact f32-bit key for a vertex, so a sub-micron displacement of a shared
+/// vertex splits the pair it was supposed to form instead of being rounded back
+/// together. That exactness is what makes these instruments right for a seam.
+fn vertex_keys(mesh: &Mesh) -> Vec<[u32; 3]> {
+    mesh.positions
+        .chunks_exact(3)
+        .map(|p| [p[0].to_bits(), p[1].to_bits(), p[2].to_bits()])
+        .collect()
 }
 
-/// Signed-volume of a closed triangle soup (divergence theorem).
+/// Edges that are not manifold-paired. A watertight, orientable surface uses
+/// every undirected edge exactly twice, once in each direction; anything else —
+/// a crack (one incidence), a bowtie or T-junction (three or more), or two
+/// same-way incidences — is reported here.
+///
+/// Counting the two directions SEPARATELY matters: a net-signed tally lets an
+/// edge with two forward and two reverse incidences cancel to zero, so a
+/// non-manifold seam would be certified watertight (see
+/// `watertightness_instruments_reject_the_defects_they_guard`).
+fn open_edge_count(mesh: &Mesh) -> usize {
+    use std::collections::HashMap;
+    let keys = vertex_keys(mesh);
+    let mut edges: HashMap<([u32; 3], [u32; 3]), (u32, u32)> = HashMap::new();
+    for t in mesh.indices.chunks_exact(3) {
+        let k = [
+            keys[t[0] as usize],
+            keys[t[1] as usize],
+            keys[t[2] as usize],
+        ];
+        for (u, v) in [(0, 1), (1, 2), (2, 0)] {
+            let incidence = if k[u] <= k[v] {
+                &mut edges.entry((k[u], k[v])).or_default().0
+            } else {
+                &mut edges.entry((k[v], k[u])).or_default().1
+            };
+            *incidence += 1;
+        }
+    }
+    edges
+        .values()
+        .filter(|&&(forward, reverse)| forward != 1 || reverse != 1)
+        .count()
+}
+
+/// Triangles that repeat the same three vertices, counted without regard to
+/// winding. A coincident pair with opposite winding is a zero-thickness
+/// duplicate surface: it contributes nothing to the signed volume and pairs its
+/// own edges perfectly, so neither of the other two instruments sees it.
+fn duplicate_face_count(mesh: &Mesh) -> usize {
+    use std::collections::HashMap;
+    let keys = vertex_keys(mesh);
+    let mut faces: HashMap<[[u32; 3]; 3], usize> = HashMap::new();
+    for t in mesh.indices.chunks_exact(3) {
+        let mut k = [
+            keys[t[0] as usize],
+            keys[t[1] as usize],
+            keys[t[2] as usize],
+        ];
+        k.sort_unstable();
+        *faces.entry(k).or_insert(0) += 1;
+    }
+    faces.values().map(|&n| n - 1).sum()
+}
+
+/// SIGNED volume of a closed triangle soup (divergence theorem). The sign is
+/// kept deliberately: outward winding is the geometry contract, and taking
+/// `abs()` here would let a wholly inverted result report the expected
+/// magnitude.
 fn mesh_volume(mesh: &Mesh) -> f64 {
     let v = |i: u32| {
         let b = i as usize * 3;
@@ -268,7 +310,7 @@ fn mesh_volume(mesh: &Mesh) -> f64 {
         s += a[0] * (b[1] * c[2] - b[2] * c[1]) - a[1] * (b[0] * c[2] - b[2] * c[0])
             + a[2] * (b[0] * c[1] - b[1] * c[0]);
     }
-    (s / 6.0).abs()
+    s / 6.0
 }
 
 /// A deep left-nested DIFFERENCE spine whose cutters SHARE SEAMS must come out
@@ -335,7 +377,8 @@ fn deep_seam_sharing_difference_spine_stays_watertight_and_compact() {
     let entity = decoder
         .decode_by_id((5000 + CHAIN - 1) as u32)
         .expect("decode spine root");
-    let mesh = BooleanClippingProcessor::new()
+    let processor = BooleanClippingProcessor::new();
+    let mesh = processor
         .process(
             &entity,
             &mut decoder,
@@ -344,19 +387,34 @@ fn deep_seam_sharing_difference_spine_stays_watertight_and_compact() {
         )
         .expect("a 12-deep solid-cutter spine must resolve");
 
+    // `process` returning Ok only says the walk finished; a hop that fell back
+    // instead of cutting is recorded here, and the spine must take none.
+    let failures = processor.take_failures();
+    assert!(
+        failures.is_empty(),
+        "the deep spine must resolve without entering a boolean failure path; got {failures:?}"
+    );
+
     assert_eq!(
         open_edge_count(&mesh),
         0,
         "every hop's seam must stay closed across a 12-deep seam-sharing spine"
     );
+    assert_eq!(
+        duplicate_face_count(&mesh),
+        0,
+        "no hop may leave a coincident duplicate face behind"
+    );
 
     // The 12 overlapping cutters merge into ONE notch spanning
     // x = -5.75 .. -1.18, full wall thickness, 1.4 m tall:
-    // 12*0.3*3 - 4.57*0.3*1.4 = 8.8806 m^3.
+    // 12*0.3*3 - 4.57*0.3*1.4 = 8.8806 m^3. Compared SIGNED, so an inward-wound
+    // result fails instead of matching on magnitude.
     let volume = mesh_volume(&mesh);
     assert!(
         (volume - 8.8806).abs() < 1.0e-2,
-        "spine must remove exactly the merged notch; expected ~8.8806 m^3, got {volume}"
+        "spine must remove exactly the merged notch and stay outward-wound; \
+         expected ~+8.8806 m^3, got {volume}"
     );
 
     // Fragmentation guard. The merged notch is a simple prismatic cavity, so the
@@ -368,6 +426,134 @@ fn deep_seam_sharing_difference_spine_stays_watertight_and_compact() {
         mesh.triangle_count() <= 64,
         "a 12-hop spine over one merged notch must stay consolidated; got {} triangles",
         mesh.triangle_count()
+    );
+}
+
+/// A guard is worth exactly what it can catch. Each mesh below is INVALID and
+/// each is INVISIBLE to the other two instruments, which is why the spine
+/// regression asserts on all three: weaken any one of them and the
+/// corresponding case here starts certifying broken geometry.
+#[test]
+fn watertightness_instruments_reject_the_defects_they_guard() {
+    /// Append an outward-wound tetrahedron over four positively oriented
+    /// corners, i.e. `(c1-c0) x (c2-c0) . (c3-c0) > 0`.
+    fn push_tetra(positions: &mut Vec<f32>, indices: &mut Vec<u32>, corners: [[f32; 3]; 4]) {
+        let base = (positions.len() / 3) as u32;
+        for c in corners {
+            positions.extend_from_slice(&c);
+        }
+        for f in [[0u32, 2, 1], [0, 1, 3], [1, 2, 3], [0, 3, 2]] {
+            indices.extend_from_slice(&[base + f[0], base + f[1], base + f[2]]);
+        }
+    }
+    fn mesh_of(positions: Vec<f32>, indices: Vec<u32>) -> Mesh {
+        let mut mesh = Mesh::new();
+        mesh.normals = vec![0.0; positions.len()];
+        mesh.positions = positions;
+        mesh.indices = indices;
+        mesh
+    }
+    const UNIT: [[f32; 3]; 4] = [
+        [0.0, 0.0, 0.0],
+        [1.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [0.0, 0.0, 1.0],
+    ];
+
+    // Control: a single closed tetrahedron is clean on all three instruments.
+    let (mut positions, mut indices) = (Vec::new(), Vec::new());
+    push_tetra(&mut positions, &mut indices, UNIT);
+    let good = mesh_of(positions, indices);
+    assert_eq!(open_edge_count(&good), 0, "control tetra has no open edge");
+    assert_eq!(
+        duplicate_face_count(&good),
+        0,
+        "control tetra has no duplicate face"
+    );
+    assert!(
+        (mesh_volume(&good) - 1.0 / 6.0).abs() < 1.0e-6,
+        "control tetra encloses +1/6 m^3, got {}",
+        mesh_volume(&good)
+    );
+
+    // (1) BOWTIE. Two closed tetrahedra meeting along one shared edge. That edge
+    // carries two forward and two reverse incidences, which a net-signed tally
+    // cancels to zero — this is the exact regression `open_edge_count` counting
+    // the two directions separately exists to catch.
+    let (mut positions, mut indices) = (Vec::new(), Vec::new());
+    push_tetra(&mut positions, &mut indices, UNIT);
+    push_tetra(
+        &mut positions,
+        &mut indices,
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, -1.0, 0.0],
+            [0.0, 0.0, -1.0],
+        ],
+    );
+    let bowtie = mesh_of(positions, indices);
+    assert_eq!(
+        open_edge_count(&bowtie),
+        1,
+        "the shared edge is non-manifold and must be reported, not cancelled"
+    );
+    assert_eq!(
+        duplicate_face_count(&bowtie),
+        0,
+        "the bowtie is invisible to the duplicate-face instrument"
+    );
+    assert!(
+        (mesh_volume(&bowtie) - 2.0 / 6.0).abs() < 1.0e-6,
+        "the bowtie is invisible to the volume instrument"
+    );
+
+    // (2) ZERO-THICKNESS DUPLICATE SURFACE. A coincident pair of opposite-wound
+    // triangles pairs its own edges perfectly and contributes nothing to the
+    // signed volume, so only `duplicate_face_count` can see it.
+    let (mut positions, mut indices) = (Vec::new(), Vec::new());
+    push_tetra(&mut positions, &mut indices, UNIT);
+    let sheet = (positions.len() / 3) as u32;
+    positions.extend_from_slice(&[5.0, 0.0, 0.0, 6.0, 0.0, 0.0, 5.0, 1.0, 0.0]);
+    indices.extend_from_slice(&[sheet, sheet + 1, sheet + 2, sheet, sheet + 2, sheet + 1]);
+    let doubled = mesh_of(positions, indices);
+    assert_eq!(
+        duplicate_face_count(&doubled),
+        1,
+        "the coincident pair must be reported"
+    );
+    assert_eq!(
+        open_edge_count(&doubled),
+        0,
+        "the duplicate surface is invisible to the edge instrument"
+    );
+    assert!(
+        (mesh_volume(&doubled) - 1.0 / 6.0).abs() < 1.0e-6,
+        "the duplicate surface is invisible to the volume instrument"
+    );
+
+    // (3) FULLY INVERTED WINDING. Reversing every triangle keeps the surface
+    // manifold and duplicate-free; only a SIGNED volume notices.
+    let (mut positions, mut indices) = (Vec::new(), Vec::new());
+    push_tetra(&mut positions, &mut indices, UNIT);
+    for t in indices.chunks_exact_mut(3) {
+        t.swap(1, 2);
+    }
+    let inverted = mesh_of(positions, indices);
+    assert!(
+        (mesh_volume(&inverted) + 1.0 / 6.0).abs() < 1.0e-6,
+        "an inverted solid must report a NEGATIVE volume, got {}",
+        mesh_volume(&inverted)
+    );
+    assert_eq!(
+        open_edge_count(&inverted),
+        0,
+        "inverted winding is invisible to the edge instrument"
+    );
+    assert_eq!(
+        duplicate_face_count(&inverted),
+        0,
+        "inverted winding is invisible to the duplicate-face instrument"
     );
 }
 


### PR DESCRIPTION
Closes #2433 — by measuring it and concluding it should not be built. What ships is the invariant that the proposed change would have broken.

## What #2433 asked for

Evaluate a deep left-nested `IFCBOOLEANRESULT` spine as **one arrangement**: stay in the kernel's f64 `Vec<Tri>` across the whole chain and call `tris_to_mesh` once at the end, on the theory that the per-hop `f32 -> f64+snap -> f32` round trip in `mesh_bridge` re-jitters and re-cracks the previous hop's seams. "Plausibly a speed win too."

## 1. The premise about the mechanism is refuted

The spine really is a chain today — the CSG census records exactly N kernel ops for a depth-N solid-cutter spine (42 ops at depth 42), and only PBHS cutters get batched by `try_union_polygonal_chain`. So far so good.

But a 2x2 isolating the round trip from `consolidate_coplanar`, on the four real deep spines in `ara3d/S_Office_Integrated Design Archi.ifc` (the depth 42/13/12 chains #2382 recovered, plus a depth-8 control), says the round trip is not the variable:

| root | depth | SEQ (round trip + consolidate) | SEQ-RAW (round trip, no consolidate) | TRI-NATIVE (no round trip, no consolidate) |
|---|---|---|---|---|
| #396610 | 42 | 450 tri, **472** open, 71866519326.652 | 553 tri, 236 open, 71988329294.266 | 546 tri, 226 open, 71988311955.187 |
| #469699 | 13 | 961 tri, **102** open, 23618430425.251 | 1210 tri, 328 open, 19628852220.184 | 1210 tri, 328 open, 19628852220.184 |
| #488943 | 12 | 60 tri, **0** open, 60124999.802 | 702 tri, 196 open, 60048201.456 | 702 tri, 196 open, 60048201.445 |
| #487492 | 8 | 36 tri, **0** open, 16575000.198 | 274 tri, 0 open, 16575000.198 | 276 tri, 12 open, 16575000.198 |

SEQ-RAW and TRI-NATIVE are **bit-identical** on two of four spines and within 12 open edges on the others. Removing the f32 round trip changes essentially nothing.

The direct check agrees: the open-edge count measured on the f64 `Tri` soup **before** narrowing is 228 / 328 / 196 / 16 against 226 / 328 / 196 / 12 after. The cracks are already in the arrangement output. The narrowing and the snap are not creating them.

Input hygiene rules out garbage-in for the headline case: for #396610 the base and **all 42 cutters** have zero open edges. For #469699, 4 of 13 cutters arrive already non-watertight (20/20/40/20).

## 2. Both proposed arrangements are worse

- **N-ary cutter union + one subtract** (`union_many` + `subtract_mesh`): on #396610 it produces **1020** open edges against sequential's 472, because the union of the 42 cutters is *itself* non-watertight (578 open edges). 1.5x–14.5x slower.
- **`difference_all` / `subtract_mesh_many`**: silently returns the **uncut host** on three of the four spines (#396610 result volume 74604440737.840 == base volume). It is only sound for pairwise-disjoint cutters, which a spine's operands are not — as its own contract says.
- **Tri-native chain, the issue's literal proposal**, with the single `consolidate_coplanar` at the end: worse on two spines (548 vs 472 open at depth 42; 44 vs 0 at depth 12), better on one (72 vs 102), tied on one — and **19x to 1240x slower** on every one.

## 3. There is no speed win — the opposite

Sequential is the fastest path on all four spines. Wall time, same machine, deterministic across three repeat runs (geometry identical to every digit, timings within 4%):

| root | depth | SEQ | UNION+SUB | TRI-NATIVE |
|---|---|---|---|---|
| #396610 | 42 | **57 ms** | 225 ms | 1128 ms |
| #469699 | 13 | **488 ms** | 6930 ms | 8910 ms |
| #488943 | 12 | **12.5 ms** | 18.8 ms | 15 490 ms |
| #487492 | 8 | **7.5 ms** | 10.0 ms | 3121 ms |

The 1240x on #488943 is the whole story in one number. The per-hop `Mesh` step is not overhead wrapped around the work — it is where `consolidate_coplanar` **reduces the accumulator**, 60 triangles instead of 702. Drop it and every subsequent hop arranges against a mesh an order of magnitude larger, with exact predicates.

Since CSG is the dominant load cost and WASM CSG is memory-bandwidth bound, a change that multiplies operand size is the wrong direction regardless of seam quality.

## 4. Where the depth-42 tears actually come from

The per-hop damage curve for #396610 is `[0 x36, 24, 36, 60, 24, 138, 472]` — flat for 36 hops, then concentrated in the last six. And SEQ (472) is worse than SEQ-RAW (236) there: on that one spine `consolidate_coplanar` is the crack **source**, exactly as `csg/mod.rs:427-433` already documents ("can still re-open a closed cut along a µm-offset plane pair... a seam-preserving consolidation is the remaining follow-up").

So the real lever for those tears is seam-preserving consolidation — an already-identified follow-up — not spine arrangement. Reorganising the spine cannot reach it.

## What ships

`deep_seam_sharing_difference_spine_stays_watertight_and_compact`: a 12-deep DIFFERENCE spine of solid cutters, 0.5 m wide on a 0.37 m pitch against a 2^-16 m snap grid, so every cutter overlaps its predecessor and each hop lands on the seam the last hop just made — the exact regime #2433 argued was damaged. It asserts watertightness, the analytic volume of the merged notch (8.8806 m³), and consolidation.

That is the invariant an "evaluate the spine as one arrangement" rewrite breaks, and it was implicit until now. Test-only; no production behaviour changes, no changeset.

### Mutation checks

Control first: 9 passed, 0 failed. Each mutation verified on disk, run, then reverted with `git status --porcelain` clean.

| mutation | result | assertion that fired |
|---|---|---|
| `subtract_mesh`: `let result = raw` (drop `consolidate_coplanar`) | 8 passed, **1 failed** | `got 452 triangles` (bound is 64) |
| `SNAP_GRID = 1.0/1237.0` (coarse, non-dyadic) | 8 passed, **1 failed** | `expected ~8.8806 m^3, got 8.901946096445597` |
| `tris_to_mesh`: 2 µm x-displacement on every other triangle | 8 passed, **1 failed** | `left: 1692, right: 0` open edges |

Only the new test failed in each case. A fourth mutation (per-**vertex** jitter) correctly did *not* fail — a consistent per-vertex map keeps seams paired — which is itself a check that the open-edge instrument measures unpairing rather than movement.

### Gates

- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0, zero warnings.
- `cargo test --workspace --no-fail-fast` — exit 0, **1624 passed, 0 failed, 20 ignored** across 156 test binaries (module-size ratchet included; `chain_cycle_tests.rs` is a test file and exempt).

### Not verified

The measurement is a `cargo test` debug build (the workspace already sets `opt-level = 3` for `ifc-lite-geometry` and the bignum crates, so the hot path is optimised, but this is not a release profile). Ratios of 19x–1240x are far outside any plausible profile effect; the 1.3x–1.5x margins at depth 8/12 for UNION+SUB are not.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for complex overlapping geometry operations involving deep cutter chains.
  * Added safeguards for watertight meshes, correct volume preservation, duplicate-face prevention, and controlled triangle counts.
* **Tests**
  * Expanded coverage for chained seam-sharing operations and invalid mesh inputs, including self-intersections, duplicate surfaces, and inverted winding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->