### PR TITLE
feat(viewer): measure tool reports inclination, point coordinates and selection quantities (#2199)

### DIFF
--- a/apps/viewer/src/components/viewer/PropertiesPanel.tsx
+++ b/apps/viewer/src/components/viewer/PropertiesPanel.tsx
@@ -43,6 +43,7 @@ import type { EntityRef, FederatedModel } from '@/store/types';
 
 import { CoordVal, CoordRow } from './properties/CoordinateDisplay';
 import { renderToWorldViewer, viewerToIfcAxes } from './tools/measure-modes/coordinates';
+import { useRenderFrameOffsets } from '@/hooks/useRenderFrameOffsets';
 import { PropertySetCard } from './properties/PropertySetCard';
 import { QuantitySetCard } from './properties/QuantitySetCard';
 import { ModelMetadataPanel } from './properties/ModelMetadataPanel';
@@ -380,8 +381,15 @@ export function PropertiesPanel() {
   // To reverse back to world coordinates (Y-up):
   //   world_yup = scene_local + originShift + wasmRtcOffset_converted_to_yup
   //
-  // For multi-model: all models are aligned to the first model's RTC frame,
-  // so we always use the first model's wasmRtcOffset for reconstruction.
+  // For multi-model: all models are aligned to the first model's RTC frame, so
+  // BOTH offsets must come from that one model. This panel used to take
+  // `wasmRtcOffset` from the anchor and `originShift` from the SELECTED model,
+  // which mixes two frames and shifts the reported world centre by their
+  // difference. `useRenderFrameOffsets` is the one resolver — the same one the
+  // measure tool's picked-point readout uses — so the two cannot disagree about
+  // the frame any more than they can about which axis is up.
+  const renderFrame = useRenderFrameOffsets();
+
   const entityCoordinates = useMemo(() => {
     if (!selectedEntity) return null;
 
@@ -420,22 +428,6 @@ export function PropertiesPanel() {
     if (!found) return null;
 
     const coordInfo = geoResult.coordinateInfo;
-    const shift = coordInfo?.originShift ?? { x: 0, y: 0, z: 0 };
-
-    // Get the reference WASM RTC offset for world coordinate reconstruction.
-    // For multi-model: all models are aligned to the first model's RTC frame,
-    // so we must use the first model's wasmRtcOffset (not the current model's).
-    // For single/legacy: use the geometry result's own offset.
-    let wasmRtcIfc = coordInfo?.wasmRtcOffset;
-    if (models.size > 1) {
-      let earliest = Infinity;
-      for (const [, m] of models) {
-        if (m.loadedAt < earliest) {
-          earliest = m.loadedAt;
-          wasmRtcIfc = m.geometryResult?.coordinateInfo?.wasmRtcOffset;
-        }
-      }
-    }
 
     // Local (scene) center - what the renderer uses (Y-up, shifted)
     const localCenter = {
@@ -448,19 +440,16 @@ export function PropertiesPanel() {
     // then IFC Z-up for display. Both transforms live in the measure tool's
     // `coordinates` module so this panel and the picked-point readout can no
     // longer disagree about which axis is up or which sign a northing takes.
-    const worldCenterYup = renderToWorldViewer(localCenter, {
-      originShift: shift,
-      wasmRtcOffsetIfc: wasmRtcIfc ?? null,
-    });
+    const worldCenterYup = renderToWorldViewer(localCenter, renderFrame);
     const worldCenterZup = viewerToIfcAxes(worldCenterYup);
 
     return {
       local: { min: { x: minX, y: minY, z: minZ }, max: { x: maxX, y: maxY, z: maxZ }, center: localCenter },
       worldYup: { center: worldCenterYup },
       worldZup: { center: worldCenterZup },
-      hasLargeCoordinates: (coordInfo?.hasLargeCoordinates ?? false) || !!wasmRtcIfc,
+      hasLargeCoordinates: (coordInfo?.hasLargeCoordinates ?? false) || !!renderFrame.wasmRtcOffsetIfc,
     };
-  }, [selectedEntity, model, geometryResult, models]);
+  }, [selectedEntity, model, geometryResult, models, renderFrame]);
 
   // Get entity node - must be computed before early return to maintain hook order
   // IMPORTANT: Use selectedEntity.expressId (original ID) for IfcDataStore lookups

--- a/apps/viewer/src/components/viewer/PropertiesPanel.tsx
+++ b/apps/viewer/src/components/viewer/PropertiesPanel.tsx
@@ -42,6 +42,7 @@ import { EntityFlags, RelationshipType, isSpatialStructureTypeName, isStoreyLike
 import type { EntityRef, FederatedModel } from '@/store/types';
 
 import { CoordVal, CoordRow } from './properties/CoordinateDisplay';
+import { renderToWorldViewer, viewerToIfcAxes } from './tools/measure-modes/coordinates';
 import { PropertySetCard } from './properties/PropertySetCard';
 import { QuantitySetCard } from './properties/QuantitySetCard';
 import { ModelMetadataPanel } from './properties/ModelMetadataPanel';
@@ -436,12 +437,6 @@ export function PropertiesPanel() {
       }
     }
 
-    // Convert WASM RTC offset from IFC Z-up to viewer Y-up:
-    //   viewer X = IFC X, viewer Y = IFC Z, viewer Z = -IFC Y
-    const wasmRtcYup = wasmRtcIfc
-      ? { x: wasmRtcIfc.x, y: wasmRtcIfc.z, z: -wasmRtcIfc.y }
-      : { x: 0, y: 0, z: 0 };
-
     // Local (scene) center - what the renderer uses (Y-up, shifted)
     const localCenter = {
       x: (minX + maxX) / 2,
@@ -449,20 +444,15 @@ export function PropertiesPanel() {
       z: (minZ + maxZ) / 2,
     };
 
-    // World center (Y-up) = scene_local + originShift + wasmRtcOffset_yup
-    const worldCenterYup = {
-      x: localCenter.x + shift.x + wasmRtcYup.x,
-      y: localCenter.y + shift.y + wasmRtcYup.y,
-      z: localCenter.z + shift.z + wasmRtcYup.z,
-    };
-
-    // Convert world Y-up to IFC Z-up for display:
-    //   IFC X = viewer X, IFC Y = -viewer Z, IFC Z = viewer Y
-    const worldCenterZup = {
-      x: worldCenterYup.x,
-      y: -worldCenterYup.z,
-      z: worldCenterYup.y,
-    };
+    // World center (Y-up) = scene_local + originShift + wasmRtcOffset_yup, and
+    // then IFC Z-up for display. Both transforms live in the measure tool's
+    // `coordinates` module so this panel and the picked-point readout can no
+    // longer disagree about which axis is up or which sign a northing takes.
+    const worldCenterYup = renderToWorldViewer(localCenter, {
+      originShift: shift,
+      wasmRtcOffsetIfc: wasmRtcIfc ?? null,
+    });
+    const worldCenterZup = viewerToIfcAxes(worldCenterYup);
 
     return {
       local: { min: { x: minX, y: minY, z: minZ }, max: { x: maxX, y: maxY, z: maxZ }, center: localCenter },

--- a/apps/viewer/src/components/viewer/tools/MeasurePanel.tsx
+++ b/apps/viewer/src/components/viewer/tools/MeasurePanel.tsx
@@ -3,112 +3,51 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
- * Measure tool panel UI (measurement list, controls)
+ * Measure tool panel UI (measurement list, point coordinates, quantities).
+ *
+ * Rendered by `ToolOverlays` off `activeTool === 'measure'` alone, so it is the
+ * same panel whichever toolbar is in use — the classic strip and the ribbon
+ * both do nothing but set that tool.
  */
 
 import React, { useCallback, useState, useEffect } from 'react';
-import { X, Trash2, Ruler, ChevronDown, GripVertical, Globe } from 'lucide-react';
+import { X, Trash2, Ruler, GripVertical, Globe, List, Crosshair, Boxes } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useViewerStore, type Measurement } from '@/store';
 import { MeasurementOverlays } from './MeasurementVisuals';
+import { MeasurePointReadout } from './MeasurePointReadout';
+import { MeasureQuantities } from './MeasureQuantities';
 import { formatDistance } from './formatDistance';
 import {
   distanceComponents,
   formatAxisDeltas,
   formatHorizontalVertical,
 } from './measure-modes/components';
+import { inclination, formatInclination } from './measure-modes/inclination';
+import {
+  projectedEnh,
+  useProjectedLatLon,
+  EnhLine,
+  type Vec3Like,
+} from './measure-modes/geo-readout';
 import { useDraggablePanel } from '@/hooks/useDraggablePanel';
 import { useAnchorGeoreference, type AnchorGeoreference } from '@/lib/geo/useAnchorGeoreference';
-import { viewerPointToProjected } from '@/lib/geo/pick-to-geo';
-import { mapUnitsToMeters } from '@/lib/geo/cesium-placement';
-import {
-  reprojectPointToLatLon,
-  reprojectionInputKey,
-  type LatLon,
-} from '@/lib/geo/reproject';
-
-interface Vec3Like { x: number; y: number; z: number }
-interface Enh { e: string; n: string; h: string }
 
 /**
- * Project a picked viewer point to real-world Eastings/Northings/Height and
- * format it in the CRS's metre unit to millimetre precision. The stored
- * MapConversion offsets are in the authored map unit (millimetres for the
- * bundled sample), so we convert to metres with the anchor's map-unit scale —
- * the raw offsets would read ~1000x too large for a metre CRS.
+ * Which expandable section the panel is showing. `null` is collapsed, which is
+ * the default so the panel stays out of the way of the model.
+ *
+ * The three sections are surfaced as always-visible buttons rather than being
+ * hidden behind the collapse toggle: a feature reachable only after expanding
+ * a collapsed-by-default panel is a feature nobody finds.
  */
-function projectedEnh(point: Vec3Like, anchor: AnchorGeoreference): Enh {
-  const proj = viewerPointToProjected(point, anchor.eff, anchor.originViewer);
-  const { projectedCRS, lengthUnitScale } = anchor.eff;
-  return {
-    e: mapUnitsToMeters(proj.eastings, projectedCRS, lengthUnitScale).toFixed(3),
-    n: mapUnitsToMeters(proj.northings, projectedCRS, lengthUnitScale).toFixed(3),
-    h: mapUnitsToMeters(proj.height, projectedCRS, lengthUnitScale).toFixed(3),
-  };
-}
+type PanelSection = 'list' | 'point' | 'quantities';
 
-/** One compact monospace E/N/H line, optionally labelled (A/B endpoints). */
-function EnhLine({ label, enh }: { label?: string; enh: Enh }) {
-  return (
-    <div className="flex items-center gap-2 font-mono text-[10px] leading-tight text-muted-foreground whitespace-nowrap">
-      {label && <span className="text-muted-foreground/60 w-3 shrink-0">{label}</span>}
-      <span>E {enh.e}</span>
-      <span>N {enh.n}</span>
-      <span>H {enh.h}</span>
-    </div>
-  );
-}
-
-/**
- * Resolve a picked viewer point to WGS84 lat/lon asynchronously (proj4). The
- * synchronous E/N/H readout never blocks on this; lat/lon appears once the
- * projection resolves and is `null` for a CRS proj4 can't resolve (the line is
- * simply absent). The effect is keyed by a primitive derived from *all* inputs
- * the reprojection consumes (CRS name + projection metadata + unit scales +
- * quantised E/N) so it recomputes on any georef edit but not on unrelated
- * re-renders — see {@link reprojectionInputKey}.
- */
-function useProjectedLatLon(
-  point: Vec3Like | null,
-  anchor: AnchorGeoreference | null,
-): LatLon | null {
-  const [latLon, setLatLon] = useState<LatLon | null>(null);
-  const projected = point && anchor
-    ? viewerPointToProjected(point, anchor.eff, anchor.originViewer)
-    : null;
-  const key = projected && anchor
-    ? reprojectionInputKey(
-        projected.eastings,
-        projected.northings,
-        anchor.eff.projectedCRS,
-        anchor.eff.lengthUnitScale,
-      )
-    : '';
-
-  useEffect(() => {
-    if (!projected || !anchor) {
-      setLatLon(null);
-      return;
-    }
-    let cancelled = false;
-    void reprojectPointToLatLon(
-      projected.eastings,
-      projected.northings,
-      anchor.eff.projectedCRS,
-      anchor.eff.lengthUnitScale,
-    ).then((r) => {
-      if (!cancelled) setLatLon(r);
-    });
-    return () => {
-      cancelled = true;
-    };
-    // Keyed by the primitive `key` so unrelated re-renders don't refetch and a
-    // georef change that alters the projection always does.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [key]);
-
-  return latLon;
-}
+const SECTIONS: ReadonlyArray<{ id: PanelSection; label: string; icon: typeof List; title: string }> = [
+  { id: 'list', label: 'List', icon: List, title: 'Measurements taken' },
+  { id: 'point', label: 'Point', icon: Crosshair, title: 'Coordinates of the picked point' },
+  { id: 'quantities', label: 'Qty', icon: Boxes, title: 'Quantities of the selected elements' },
+];
 
 export function MeasureOverlay() {
   const measurements = useViewerStore((s) => s.measurements);
@@ -130,8 +69,8 @@ export function MeasureOverlay() {
   const cursorPosRef = React.useRef<{ x: number; y: number } | null>(null);
   // Only update snap indicator position when snap target changes (not on every cursor move)
   const [snapIndicatorPos, setSnapIndicatorPos] = useState<{ x: number; y: number } | null>(null);
-  // Panel collapsed by default for minimal UI
-  const [isPanelCollapsed, setIsPanelCollapsed] = useState(true);
+  // Collapsed by default for minimal UI.
+  const [section, setSection] = useState<PanelSection | null>(null);
   // Ref to the overlay container for coordinate conversion
   const overlayRef = React.useRef<HTMLDivElement>(null);
 
@@ -172,10 +111,6 @@ export function MeasureOverlay() {
   const handleDeleteMeasurement = useCallback((id: string) => {
     deleteMeasurement(id);
   }, [deleteMeasurement]);
-
-  const togglePanel = useCallback(() => {
-    setIsPanelCollapsed(prev => !prev);
-  }, []);
 
   const handleClose = useCallback(() => {
     setActiveTool('select');
@@ -221,7 +156,7 @@ export function MeasureOverlay() {
 
       {/* Compact Measure Tool Panel */}
       <div ref={panelRef} style={drag.style} className="pointer-events-auto absolute top-4 left-1/2 -translate-x-1/2 bg-background/95 backdrop-blur-sm rounded-lg border shadow-lg z-30">
-        {/* Header: grip drags (issue #1107), title button collapses. */}
+        {/* Header: grip drags (issue #1107), title + section buttons below. */}
         <div className="flex items-center justify-between gap-2 p-2">
           <div className="flex items-center gap-1 min-w-0">
             <span
@@ -231,17 +166,13 @@ export function MeasureOverlay() {
             >
               <GripVertical className="h-3.5 w-3.5" />
             </span>
-            <button
-              onClick={togglePanel}
-              className="flex items-center gap-2 hover:bg-accent/50 rounded px-2 py-1 transition-colors min-w-0"
-            >
+            <div className="flex items-center gap-2 px-2 py-1 min-w-0">
               <Ruler className="h-4 w-4 text-primary" />
               <span className="font-medium text-sm">Measure</span>
-              {measurements.length > 0 && !isPanelCollapsed && (
+              {measurements.length > 0 && (
                 <span className="text-xs text-muted-foreground">({measurements.length})</span>
               )}
-              <ChevronDown className={`h-3 w-3 transition-transform ${isPanelCollapsed ? '-rotate-90' : ''}`} />
-            </button>
+            </div>
           </div>
           <div className="flex items-center gap-1">
             {measurements.length > 0 && (
@@ -293,34 +224,58 @@ export function MeasureOverlay() {
           </button>
         </div>
 
-        {/* Expandable content */}
-        {!isPanelCollapsed && (
-          <div className="border-t px-2 pb-2 min-w-56">
-            {measurements.length > 0 ? (
-              <div className="space-y-1 mt-2">
-                {measurements.map((m, i) => (
-                  <MeasurementItem
-                    key={m.id}
-                    measurement={m}
-                    index={i}
-                    onDelete={handleDeleteMeasurement}
-                    geoAnchor={showGeo ? anchor : null}
-                  />
-                ))}
-                {measurements.length > 1 && (
-                  <div className="flex items-center justify-between border-t pt-1 mt-1 text-xs font-medium">
-                    <span>Total</span>
-                    <span className="font-mono">{formatDistance(totalDistance)}</span>
-                  </div>
-                )}
-              </div>
-            ) : (
-              <div className="text-center py-2 text-muted-foreground text-xs">
-                No measurements
-              </div>
-            )}
-          </div>
-        )}
+        {/* Section selector — always visible so each readout is one click from
+            the collapsed panel. Clicking the open section closes it. */}
+        <div className="flex items-center gap-1.5 border-t px-2 py-2">
+          {SECTIONS.map(({ id, label, icon: Icon, title }) => (
+            <button
+              key={id}
+              onClick={() => setSection((prev) => (prev === id ? null : id))}
+              title={title}
+              aria-pressed={section === id}
+              className={`flex items-center gap-1 px-2 py-1 font-mono text-[10px] uppercase tracking-wider border-2 transition-colors ${
+                section === id
+                  ? 'bg-primary text-primary-foreground border-primary'
+                  : 'bg-zinc-100 dark:bg-zinc-900 text-zinc-500 border-zinc-300 dark:border-zinc-700'
+              }`}
+            >
+              <Icon className="h-3 w-3" />
+              {label}
+            </button>
+          ))}
+        </div>
+
+        <div className="min-w-64 max-w-96">
+          {section === 'list' && (
+            <div className="border-t px-2 pb-2">
+              {measurements.length > 0 ? (
+                <div className="space-y-1 mt-2">
+                  {measurements.map((m, i) => (
+                    <MeasurementItem
+                      key={m.id}
+                      measurement={m}
+                      index={i}
+                      onDelete={handleDeleteMeasurement}
+                      geoAnchor={showGeo ? anchor : null}
+                    />
+                  ))}
+                  {measurements.length > 1 && (
+                    <div className="flex items-center justify-between border-t pt-1 mt-1 text-xs font-medium">
+                      <span>Total</span>
+                      <span className="font-mono">{formatDistance(totalDistance)}</span>
+                    </div>
+                  )}
+                </div>
+              ) : (
+                <div className="text-center py-2 text-muted-foreground text-xs">
+                  No measurements
+                </div>
+              )}
+            </div>
+          )}
+          {section === 'point' && <MeasurePointReadout />}
+          {section === 'quantities' && <MeasureQuantities />}
+        </div>
       </div>
 
       {/* Instruction hint - brutalist style with snap-colored shadow */}
@@ -413,6 +368,10 @@ function MeasurementItem({ measurement, index, onDelete, geoAnchor }: Measuremen
         </div>
         <div className="font-mono text-[10px] leading-tight text-muted-foreground whitespace-nowrap">
           {formatHorizontalVertical(components)}
+        </div>
+        {/* Inclination, derived from the same two endpoints (#2199 §4). */}
+        <div className="font-mono text-[10px] leading-tight text-muted-foreground whitespace-nowrap">
+          {formatInclination(inclination(components))}
         </div>
       </div>
       {geoAnchor && (

--- a/apps/viewer/src/components/viewer/tools/MeasurePointReadout.tsx
+++ b/apps/viewer/src/components/viewer/tools/MeasurePointReadout.tsx
@@ -1,0 +1,152 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Coordinates of the Measure tool's live point — issue #2199 §5.
+ *
+ * The point is whichever one the tool is already tracking: the moving end of
+ * the current drag, or the last finalized endpoint when nothing is being
+ * dragged. Nothing here re-picks and nothing here adds an interaction; it is
+ * the same point the georeferenced E/N/H box has always shown, expressed in
+ * the frames §5 asks for.
+ *
+ * Frames are stacked from the most local outwards, and a frame is shown only
+ * when it says something the one above it did not:
+ *
+ * - **Model** — the file's own coordinates, IFC Z-up. Always shown; this is
+ *   the one that was missing entirely before #2199.
+ * - **Render** — the shifted frame the renderer works in. Shown only when the
+ *   pipeline actually shifted the model, since otherwise it is the same row
+ *   twice under two labels.
+ * - **Reference** — offset from a user-set datum. Shown once one is set.
+ * - **Map** — projected E/N/H and WGS84 lat/lon. Unchanged from #1674/#1679,
+ *   and still gated on the Geo XYZ toggle and a usable IfcMapConversion.
+ */
+
+import { Crosshair, Globe, MapPin, XCircle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useViewerStore } from '@/store';
+import { useRenderFrameOffsets } from '@/hooks/useRenderFrameOffsets';
+import { useAnchorGeoreference } from '@/lib/geo/useAnchorGeoreference';
+import {
+  pointCoordinates,
+  relativeOffset,
+  viewerToIfcAxes,
+  formatCoordinateTriple,
+} from './measure-modes/coordinates';
+import { formatDistance } from './formatDistance';
+import { projectedEnh, useProjectedLatLon, type Vec3Like } from './measure-modes/geo-readout';
+
+/** One labelled coordinate row. */
+function CoordRow({ label, value, hint }: { label: string; value: string; hint?: string }) {
+  return (
+    <div className="flex items-baseline gap-2 whitespace-nowrap">
+      <span className="w-[4.5rem] shrink-0 font-mono text-[9px] uppercase tracking-wider text-muted-foreground/70">
+        {label}
+      </span>
+      <span className="font-mono text-[11px] tabular-nums">{value}</span>
+      {hint && <span className="font-mono text-[9px] text-muted-foreground/60">{hint}</span>}
+    </div>
+  );
+}
+
+export function MeasurePointReadout() {
+  const activeMeasurement = useViewerStore((s) => s.activeMeasurement);
+  const measurements = useViewerStore((s) => s.measurements);
+  const geoReadoutEnabled = useViewerStore((s) => s.geoReadoutEnabled);
+  const referencePoint = useViewerStore((s) => s.measureReferencePoint);
+  const setReferencePoint = useViewerStore((s) => s.setMeasureReferencePoint);
+
+  const frame = useRenderFrameOffsets();
+  const anchor = useAnchorGeoreference();
+
+  // The live point: the moving end of the current drag, else the most recent
+  // finalized endpoint. Same rule the georeferenced box has always used.
+  const livePoint: Vec3Like | null = activeMeasurement?.current
+    ?? (measurements.length > 0 ? measurements[measurements.length - 1].end : null);
+
+  const showGeo = geoReadoutEnabled && anchor !== null;
+  // Hook order is fixed: called unconditionally, gated by its arguments.
+  const latLon = useProjectedLatLon(showGeo ? livePoint : null, showGeo ? anchor : null);
+
+  if (!livePoint) {
+    return (
+      <div className="border-t px-2 py-2 text-center text-[10px] text-muted-foreground">
+        Measure a point to read its coordinates
+      </div>
+    );
+  }
+
+  const coords = pointCoordinates(livePoint, frame);
+  // The reference point is stored in renderer space, so it is converted to IFC
+  // axes here rather than being subtracted in one frame and displayed in
+  // another — mixing the two would negate the northing delta.
+  const offset = referencePoint
+    ? relativeOffset(coords.local, viewerToIfcAxes(referencePoint))
+    : null;
+  const enh = showGeo && anchor ? projectedEnh(livePoint, anchor) : null;
+
+  return (
+    <div className="border-t px-2 py-2 space-y-1.5">
+      <div className="flex items-center justify-between gap-2">
+        <span className="flex items-center gap-1 font-mono text-[10px] uppercase tracking-wider text-primary">
+          <Crosshair className="h-3 w-3" />
+          {activeMeasurement ? 'Live point' : 'Last point'}
+        </span>
+        <div className="flex items-center gap-1">
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            title="Set this point as the relative-coordinate reference"
+            onClick={() => setReferencePoint({ x: livePoint.x, y: livePoint.y, z: livePoint.z })}
+          >
+            <MapPin className="h-3 w-3" />
+          </Button>
+          {referencePoint && (
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              title="Clear the reference point"
+              onClick={() => setReferencePoint(null)}
+            >
+              <XCircle className="h-3 w-3" />
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <div className="overflow-x-auto">
+        <CoordRow label="Model" value={formatCoordinateTriple(coords.world)} hint="m" />
+        {/* Only when the pipeline actually shifted the model — otherwise this
+            is the Model row again under a different name. */}
+        {coords.shifted && (
+          <CoordRow label="Render" value={formatCoordinateTriple(coords.local)} hint="m" />
+        )}
+        {offset && (
+          <CoordRow
+            label="Rel. ref"
+            value={formatCoordinateTriple({ x: offset.dx, y: offset.dy, z: offset.dz })}
+            hint={formatDistance(offset.distance)}
+          />
+        )}
+        {enh && (
+          <CoordRow label="Map" value={`E ${enh.e}  N ${enh.n}  H ${enh.h}`} hint="m" />
+        )}
+        {latLon && (
+          <CoordRow
+            label="Lat / Lon"
+            value={`${latLon.lat.toFixed(6)}  ${latLon.lon.toFixed(6)}`}
+          />
+        )}
+      </div>
+
+      {enh && anchor && (
+        <div className="flex items-center gap-1 font-mono text-[9px] text-muted-foreground/70">
+          <Globe className="h-2.5 w-2.5" />
+          {anchor.eff.projectedCRS.name}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/viewer/src/components/viewer/tools/MeasurePointReadout.tsx
+++ b/apps/viewer/src/components/viewer/tools/MeasurePointReadout.tsx
@@ -15,7 +15,11 @@
  * when it says something the one above it did not:
  *
  * - **Model** — the file's own coordinates, IFC Z-up. Always shown; this is
- *   the one that was missing entirely before #2199.
+ *   the one that was missing entirely before #2199. Relabelled **Anchor** in a
+ *   federation whose alignment re-based another model into the scene frame:
+ *   there, a picked point (which belongs to no model — it is wherever the
+ *   cursor hit) comes back in the ANCHOR file's coordinate system, and calling
+ *   that "Model" would name a file the numbers may not belong to.
  * - **Render** — the shifted frame the renderer works in. Shown only when the
  *   pipeline actually shifted the model, since otherwise it is the same row
  *   twice under two labels.
@@ -117,7 +121,11 @@ export function MeasurePointReadout() {
       </div>
 
       <div className="overflow-x-auto">
-        <CoordRow label="Model" value={formatCoordinateTriple(coords.world)} hint="m" />
+        <CoordRow
+          label={frame.rebased ? 'Anchor' : 'Model'}
+          value={formatCoordinateTriple(coords.world)}
+          hint="m"
+        />
         {/* Only when the pipeline actually shifted the model — otherwise this
             is the Model row again under a different name. */}
         {coords.shifted && (
@@ -140,6 +148,14 @@ export function MeasurePointReadout() {
           />
         )}
       </div>
+
+      {frame.rebased && (
+        <div className="font-mono text-[9px] leading-tight text-muted-foreground/70">
+          Federation alignment re-based one or more models into
+          {frame.anchorName ? ` ${frame.anchorName}` : ' the anchor model'}'s frame,
+          so these are anchor coordinates, not necessarily the picked file's own.
+        </div>
+      )}
 
       {enh && anchor && (
         <div className="flex items-center gap-1 font-mono text-[9px] text-muted-foreground/70">

--- a/apps/viewer/src/components/viewer/tools/MeasureQuantities.tsx
+++ b/apps/viewer/src/components/viewer/tools/MeasureQuantities.tsx
@@ -267,7 +267,7 @@ export function MeasureQuantities() {
               title="Enclosed volume computed from the meshed geometry, after opening cuts. Not an IFC GrossVolume."
             >
               <span className="w-[5.5rem] shrink-0 font-mono text-[9px] uppercase tracking-wider text-muted-foreground/70">
-                Vol. mesh
+                Volume mesh
               </span>
               <span className="font-mono text-[11px] tabular-nums">{render(geometry.total, 2)}</span>
               {geometry.unproved > 0 && (
@@ -277,6 +277,19 @@ export function MeasureQuantities() {
               )}
             </div>
           )}
+        </div>
+      )}
+
+      {/* The openings question, stated rather than assumed. This tool never
+          decides whether an opening is subtracted — it reports which
+          convention each number was authored under and keeps them apart.
+          Zones v2 (#2508) faces the same question when apportioning a wall's
+          volume; stating it here is what lets the two features be compared
+          instead of quietly differing. */}
+      {!nothing && (
+        <div className="font-mono text-[9px] leading-tight text-muted-foreground/70">
+          net = openings excluded · gross = openings included · mesh = as built,
+          after opening cuts
         </div>
       )}
 

--- a/apps/viewer/src/components/viewer/tools/MeasureQuantities.tsx
+++ b/apps/viewer/src/components/viewer/tools/MeasureQuantities.tsx
@@ -1,0 +1,297 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Area / volume / weight / length for the current selection — issue #2199
+ * §1 (element surface area), §2 (volume) and §6 (weight).
+ *
+ * This measures what the MODEL says, not what the pixels say, and it is
+ * explicit about which. Two independent sources are shown side by side and
+ * never blended:
+ *
+ * - **Declared** — the file's own `IfcElementQuantity`, occurrence first with
+ *   the element's type as fallback (the #1745/#1755 rule, matching the Lists
+ *   engine and the material totals panel). Gross and net stay apart, which is
+ *   how §1's "indicate whether opening areas are included or excluded" is
+ *   answered: IFC already encodes it in the naming, so the tool surfaces the
+ *   distinction rather than inventing one.
+ * - **Geometry** — `MeshData.geometryVolume`, the kernel's enclosed volume,
+ *   present only where a single closed orientable solid could be PROVED. The
+ *   count of elements where it could not is reported rather than hidden, which
+ *   is §2's "report that the volume cannot be calculated reliably instead of
+ *   returning an incorrect result".
+ *
+ * Values are normalised to SI at read time, while each value is still next to
+ * the `ProjectUnits` that explain it, because a federation can mix a
+ * millimetre model with a metre one. Display then converts once, honouring the
+ * user's per-unit-type override from #1573.
+ */
+
+import { useMemo } from 'react';
+import { Boxes, TriangleAlert } from 'lucide-react';
+import { useViewerStore } from '@/store';
+import { useIfc } from '@/hooks/useIfc';
+import { stringToEntityRef, type EntityRef } from '@/store/types';
+import { toGlobalIdFromModels } from '@/store/globalId';
+import {
+  extractQuantitiesOnDemand,
+  extractTypeQuantitiesOnDemand,
+  extractProjectUnits,
+  ProjectUnits,
+  type IfcDataStore,
+} from '@ifc-lite/parser';
+import { RelationshipType } from '@ifc-lite/data';
+import {
+  QUANTITY_TYPE_UNIT,
+  resolveQuantityDisplay,
+  formatConverted,
+} from '@/lib/units/display';
+import { resolveFromUnit, convertValue } from '@/lib/units/convert';
+import {
+  pickElementQuantities,
+  rollupQuantities,
+  rollupGeometryVolumes,
+  type PickedQuantity,
+  type QuantityBasis,
+} from './measure-modes/quantities';
+
+const QUANTITY_TYPE_LABEL: Record<number, string> = {
+  0: 'Length',
+  1: 'Area',
+  2: 'Volume',
+  4: 'Weight',
+};
+
+const BASIS_LABEL: Record<QuantityBasis, string> = {
+  net: 'net',
+  gross: 'gross',
+  unqualified: '',
+};
+
+/**
+ * Build the file-unit -> SI converter for one store's declared units.
+ *
+ * Goes through `convertValue` rather than multiplying by `siScale` directly so
+ * an affine unit would carry its offset. None of the four families here is
+ * affine today, which is exactly why doing it by hand would look correct
+ * forever and then not be.
+ */
+function siConverterFor(units: ProjectUnits) {
+  return (value: number, quantityType: number): number => {
+    const entry = QUANTITY_TYPE_UNIT[quantityType];
+    if (!entry) return value;
+    const fileUnit = units.resolvedForUnitType(entry.unitType)
+      ?? { symbol: entry.defaultSymbol, siScale: 1.0 };
+    return convertValue(value, resolveFromUnit(entry.unitType, fileUnit), { scale: 1 });
+  };
+}
+
+/**
+ * Occurrence quantities win, with the element's type as fallback (#1755).
+ *
+ * "Win" requires at least one ACTUAL quantity: a named-but-empty occurrence
+ * quantity set must not mask populated type-level ones. Type extraction is
+ * cached per type, so a 500-door type is parsed once rather than 500 times.
+ */
+function quantitySetsFor(
+  store: IfcDataStore,
+  expressId: number,
+  typeCache: Map<number, ReturnType<typeof extractQuantitiesOnDemand>>,
+) {
+  const typeQsets = () => {
+    if (!store.relationships) return [];
+    const typeIds = store.relationships.getRelated(expressId, RelationshipType.DefinesByType, 'inverse');
+    if (typeIds.length === 0) return [];
+    const typeId = typeIds[0];
+    let cached = typeCache.get(typeId);
+    if (!cached) {
+      cached = extractTypeQuantitiesOnDemand(store, expressId)?.quantities ?? [];
+      typeCache.set(typeId, cached);
+    }
+    return cached;
+  };
+
+  const own = extractQuantitiesOnDemand(store, expressId);
+  return own.some((qset) => qset.quantities.length > 0) ? own : typeQsets();
+}
+
+export function MeasureQuantities() {
+  const selectedEntity = useViewerStore((s) => s.selectedEntity);
+  const selectedEntitiesSet = useViewerStore((s) => s.selectedEntitiesSet);
+  const unitDisplayOverrides = useViewerStore((s) => s.unitDisplayOverrides);
+  const { models, ifcDataStore, geometryResult } = useIfc();
+
+  /** The selection, as model-aware refs. Multi-selection first, primary as fallback. */
+  const refs: EntityRef[] = useMemo(() => {
+    if (selectedEntitiesSet.size > 0) {
+      return [...selectedEntitiesSet].map(stringToEntityRef);
+    }
+    return selectedEntity ? [selectedEntity] : [];
+  }, [selectedEntitiesSet, selectedEntity]);
+
+  const summary = useMemo(() => {
+    if (refs.length === 0) return null;
+
+    // One entry per element. `MeshData.geometryVolume` is a WHOLE-ENTITY value
+    // repeated on every submesh, so it is looked up per element rather than
+    // accumulated per mesh — summing submeshes would multiply an element's
+    // volume by its part count.
+    const volumeByGlobalId = new Map<number, number>();
+    const collectVolumes = (meshes: ReadonlyArray<{ expressId: number; geometryVolume?: number }> | undefined) => {
+      if (!meshes) return;
+      for (const mesh of meshes) {
+        if (mesh.geometryVolume === undefined) continue;
+        if (!volumeByGlobalId.has(mesh.expressId)) {
+          volumeByGlobalId.set(mesh.expressId, mesh.geometryVolume);
+        }
+      }
+    };
+    if (models.size > 0) {
+      for (const [, m] of models) collectVolumes(m.geometryResult?.meshes);
+    } else {
+      collectVolumes(geometryResult?.meshes);
+    }
+
+    const unitsCache = new Map<string, ProjectUnits>();
+    const typeCaches = new Map<string, Map<number, ReturnType<typeof extractQuantitiesOnDemand>>>();
+    const perElement: PickedQuantity[][] = [];
+    const geometryVolumes: Array<number | undefined> = [];
+    let withoutStore = 0;
+
+    for (const ref of refs) {
+      const store = (ref.modelId !== 'legacy'
+        ? (models.get(ref.modelId)?.ifcDataStore as IfcDataStore | undefined)
+        : undefined) ?? (ifcDataStore as IfcDataStore | null) ?? undefined;
+      if (!store) {
+        withoutStore += 1;
+        continue;
+      }
+
+      let units = unitsCache.get(ref.modelId);
+      if (!units) {
+        units = store.source?.length && store.entityIndex
+          ? extractProjectUnits(store.source, store.entityIndex)
+          : ProjectUnits.empty();
+        unitsCache.set(ref.modelId, units);
+      }
+      let typeCache = typeCaches.get(ref.modelId);
+      if (!typeCache) {
+        typeCache = new Map();
+        typeCaches.set(ref.modelId, typeCache);
+      }
+
+      perElement.push(
+        pickElementQuantities(
+          quantitySetsFor(store, ref.expressId, typeCache),
+          siConverterFor(units),
+        ),
+      );
+      geometryVolumes.push(
+        volumeByGlobalId.get(toGlobalIdFromModels(models, ref.modelId, ref.expressId)),
+      );
+    }
+
+    return {
+      declared: rollupQuantities(perElement),
+      geometry: rollupGeometryVolumes(geometryVolumes),
+      elements: refs.length,
+      withoutStore,
+    };
+  }, [refs, models, ifcDataStore, geometryResult]);
+
+  // Totals are already SI, so display resolves against an EMPTY unit context —
+  // handing it the file's declared millimetres would scale a metre total again.
+  const render = (value: number, quantityType: number): string => {
+    const disp = resolveQuantityDisplay(value, quantityType, ProjectUnits.empty(), unitDisplayOverrides);
+    const formatted = disp.converted !== null
+      ? formatConverted(disp.converted)
+      : value.toLocaleString(undefined, { maximumFractionDigits: 3 });
+    return disp.unit ? `${formatted} ${disp.unit}` : formatted;
+  };
+
+  if (!summary) {
+    return (
+      <div className="border-t px-2 py-2 text-center text-[10px] text-muted-foreground">
+        Select elements to read their quantities
+      </div>
+    );
+  }
+
+  const { declared, geometry, elements, withoutStore } = summary;
+  const nothing = declared.length === 0 && geometry.proved === 0;
+
+  return (
+    <div className="border-t px-2 py-2 space-y-1.5">
+      <div className="flex items-center justify-between gap-2">
+        <span className="flex items-center gap-1 font-mono text-[10px] uppercase tracking-wider text-primary">
+          <Boxes className="h-3 w-3" />
+          Quantities
+        </span>
+        <span className="font-mono text-[9px] text-muted-foreground">
+          {elements} element{elements === 1 ? '' : 's'}
+        </span>
+      </div>
+
+      {nothing ? (
+        <div className="flex items-start gap-1.5 text-[10px] leading-tight text-muted-foreground">
+          <TriangleAlert className="mt-0.5 h-3 w-3 shrink-0 text-amber-500" />
+          <span>
+            The selection declares no quantities, and no enclosed volume could be
+            proved from its geometry.
+          </span>
+        </div>
+      ) : (
+        <div className="space-y-0.5 overflow-x-auto">
+          {declared.map((r) => (
+            <div
+              key={`${r.quantityType}-${r.basis}`}
+              className="flex items-baseline gap-2 whitespace-nowrap"
+              title={r.provenance.join('\n')}
+            >
+              <span className="w-[5.5rem] shrink-0 font-mono text-[9px] uppercase tracking-wider text-muted-foreground/70">
+                {QUANTITY_TYPE_LABEL[r.quantityType] ?? r.quantityType} {BASIS_LABEL[r.basis]}
+              </span>
+              <span className="font-mono text-[11px] tabular-nums">{render(r.total, r.quantityType)}</span>
+              {r.contributing < elements && (
+                <span className="font-mono text-[9px] text-amber-600 dark:text-amber-500">
+                  {r.contributing}/{elements}
+                </span>
+              )}
+            </div>
+          ))}
+
+          {geometry.proved > 0 && (
+            <div
+              className="flex items-baseline gap-2 whitespace-nowrap"
+              title="Enclosed volume computed from the meshed geometry, after opening cuts. Not an IFC GrossVolume."
+            >
+              <span className="w-[5.5rem] shrink-0 font-mono text-[9px] uppercase tracking-wider text-muted-foreground/70">
+                Vol. mesh
+              </span>
+              <span className="font-mono text-[11px] tabular-nums">{render(geometry.total, 2)}</span>
+              {geometry.unproved > 0 && (
+                <span className="font-mono text-[9px] text-amber-600 dark:text-amber-500">
+                  {geometry.proved}/{elements}
+                </span>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
+      {geometry.unproved > 0 && (
+        <div className="font-mono text-[9px] leading-tight text-muted-foreground/70">
+          {geometry.unproved} element{geometry.unproved === 1 ? '' : 's'} had no
+          provable enclosed volume (open shell, layered or multi-part geometry).
+        </div>
+      )}
+      {withoutStore > 0 && (
+        <div className="font-mono text-[9px] leading-tight text-muted-foreground/70">
+          {withoutStore} selected element{withoutStore === 1 ? '' : 's'} could not
+          be resolved to a loaded model.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/viewer/src/components/viewer/tools/MeasureQuantities.tsx
+++ b/apps/viewer/src/components/viewer/tools/MeasureQuantities.tsx
@@ -20,7 +20,18 @@
  *   present only where a single closed orientable solid could be PROVED. The
  *   count of elements where it could not is reported rather than hidden, which
  *   is §2's "report that the volume cannot be calculated reliably instead of
- *   returning an incorrect result".
+ *   returning an incorrect result". Two things follow from that field's own
+ *   contract and are handled here rather than assumed away:
+ *   - A GPU-instanced-only element has NO flat mesh at all; the geometry pass
+ *     parks its proved volume in `GeometryResult.instancedGeometryVolumes`
+ *     instead. Reading only `meshes` would report an entire precast field as
+ *     unprovable while the answer sat in the side channel.
+ *   - A federated model that alignment RE-BAKED (`'same-crs'` / `'reprojected'`)
+ *     carries volumes measured at a size that is no longer on screen, and
+ *     nothing on this side can re-measure them (#1993). Those are withheld and
+ *     COUNTED SEPARATELY — "we scaled it away" is a different statement from
+ *     "the kernel could not prove it", and collapsing the two would be the
+ *     silent blend this whole panel exists to avoid.
  *
  * Values are normalised to SI at read time, while each value is still next to
  * the `ProjectUnits` that explain it, because a federation can mix a
@@ -42,6 +53,7 @@ import {
   type IfcDataStore,
 } from '@ifc-lite/parser';
 import { RelationshipType } from '@ifc-lite/data';
+import { geometryVolumesSurviveAlignment } from '@/lib/compare/alignmentTrust';
 import {
   QUANTITY_TYPE_UNIT,
   resolveQuantityDisplay,
@@ -93,6 +105,15 @@ function siConverterFor(units: ProjectUnits) {
  * "Win" requires at least one ACTUAL quantity: a named-but-empty occurrence
  * quantity set must not mask populated type-level ones. Type extraction is
  * cached per type, so a 500-door type is parsed once rather than 500 times.
+ *
+ * Both parse paths are served, mirroring the Lists adapter's split (#1751):
+ * `extractTypeQuantitiesOnDemand` walks the STEP source and returns `null`
+ * outright when there is none, which is every server-parsed store — those
+ * carry the type's own quantity sets in the prebuilt table instead, keyed by
+ * the TYPE's express id. Taking only the source-backed branch would drop
+ * type-declared volumes on the server path while the occurrence branch (whose
+ * extractor already falls back to that same table) kept working, so the loss
+ * would look like a file that simply declares nothing.
  */
 function quantitySetsFor(
   store: IfcDataStore,
@@ -106,7 +127,9 @@ function quantitySetsFor(
     const typeId = typeIds[0];
     let cached = typeCache.get(typeId);
     if (!cached) {
-      cached = extractTypeQuantitiesOnDemand(store, expressId)?.quantities ?? [];
+      cached = store.source?.length
+        ? (extractTypeQuantitiesOnDemand(store, expressId)?.quantities ?? [])
+        : (store.quantities?.getForEntity(typeId) ?? []);
       typeCache.set(typeId, cached);
     }
     return cached;
@@ -136,21 +159,42 @@ export function MeasureQuantities() {
     // One entry per element. `MeshData.geometryVolume` is a WHOLE-ENTITY value
     // repeated on every submesh, so it is looked up per element rather than
     // accumulated per mesh — summing submeshes would multiply an element's
-    // volume by its part count.
+    // volume by its part count. `instancedGeometryVolumes` holds the same
+    // whole-entity value for entities the pipeline kept ONLY as GPU instances
+    // (no flat mesh exists to carry it), already keyed by global id.
     const volumeByGlobalId = new Map<number, number>();
-    const collectVolumes = (meshes: ReadonlyArray<{ expressId: number; geometryVolume?: number }> | undefined) => {
-      if (!meshes) return;
-      for (const mesh of meshes) {
-        if (mesh.geometryVolume === undefined) continue;
-        if (!volumeByGlobalId.has(mesh.expressId)) {
-          volumeByGlobalId.set(mesh.expressId, mesh.geometryVolume);
+    const collectVolumes = (
+      meshes: ReadonlyArray<{ expressId: number; geometryVolume?: number }> | undefined,
+      instanced?: ReadonlyMap<number, number>,
+    ) => {
+      if (meshes) {
+        for (const mesh of meshes) {
+          if (mesh.geometryVolume === undefined) continue;
+          if (!volumeByGlobalId.has(mesh.expressId)) {
+            volumeByGlobalId.set(mesh.expressId, mesh.geometryVolume);
+          }
+        }
+      }
+      if (instanced) {
+        for (const [id, volume] of instanced) {
+          if (!volumeByGlobalId.has(id)) volumeByGlobalId.set(id, volume);
         }
       }
     };
+    // Models whose vertices federation alignment re-baked. Their volumes are
+    // not merely suspect, they describe a different size — so they are never
+    // read, rather than read and quietly compared.
+    const rescaledModelIds = new Set<string>();
     if (models.size > 0) {
-      for (const [, m] of models) collectVolumes(m.geometryResult?.meshes);
+      for (const [id, m] of models) {
+        if (!geometryVolumesSurviveAlignment(m.federationAlignmentStatus)) {
+          rescaledModelIds.add(id);
+          continue;
+        }
+        collectVolumes(m.geometryResult?.meshes, m.geometryResult?.instancedGeometryVolumes);
+      }
     } else {
-      collectVolumes(geometryResult?.meshes);
+      collectVolumes(geometryResult?.meshes, geometryResult?.instancedGeometryVolumes);
     }
 
     const unitsCache = new Map<string, ProjectUnits>();
@@ -158,6 +202,7 @@ export function MeasureQuantities() {
     const perElement: PickedQuantity[][] = [];
     const geometryVolumes: Array<number | undefined> = [];
     let withoutStore = 0;
+    let rescaled = 0;
 
     for (const ref of refs) {
       const store = (ref.modelId !== 'legacy'
@@ -187,9 +232,16 @@ export function MeasureQuantities() {
           siConverterFor(units),
         ),
       );
-      geometryVolumes.push(
-        volumeByGlobalId.get(toGlobalIdFromModels(models, ref.modelId, ref.expressId)),
-      );
+      // A re-baked model contributes no volume AND is not counted as unproved:
+      // the kernel proved one, alignment invalidated it, and the note below
+      // says exactly that.
+      if (rescaledModelIds.has(ref.modelId)) {
+        rescaled += 1;
+      } else {
+        geometryVolumes.push(
+          volumeByGlobalId.get(toGlobalIdFromModels(models, ref.modelId, ref.expressId)),
+        );
+      }
     }
 
     return {
@@ -197,6 +249,7 @@ export function MeasureQuantities() {
       geometry: rollupGeometryVolumes(geometryVolumes),
       elements: refs.length,
       withoutStore,
+      rescaled,
     };
   }, [refs, models, ifcDataStore, geometryResult]);
 
@@ -218,7 +271,7 @@ export function MeasureQuantities() {
     );
   }
 
-  const { declared, geometry, elements, withoutStore } = summary;
+  const { declared, geometry, elements, withoutStore, rescaled } = summary;
   const nothing = declared.length === 0 && geometry.proved === 0;
 
   return (
@@ -237,8 +290,10 @@ export function MeasureQuantities() {
         <div className="flex items-start gap-1.5 text-[10px] leading-tight text-muted-foreground">
           <TriangleAlert className="mt-0.5 h-3 w-3 shrink-0 text-amber-500" />
           <span>
-            The selection declares no quantities, and no enclosed volume could be
-            proved from its geometry.
+            The selection declares no quantities
+            {rescaled === elements
+              ? '.'
+              : ', and no enclosed volume could be proved from its geometry.'}
           </span>
         </div>
       ) : (
@@ -297,6 +352,13 @@ export function MeasureQuantities() {
         <div className="font-mono text-[9px] leading-tight text-muted-foreground/70">
           {geometry.unproved} element{geometry.unproved === 1 ? '' : 's'} had no
           provable enclosed volume (open shell, layered or multi-part geometry).
+        </div>
+      )}
+      {rescaled > 0 && (
+        <div className="font-mono text-[9px] leading-tight text-muted-foreground/70">
+          {rescaled} element{rescaled === 1 ? '' : 's'} sit{rescaled === 1 ? 's' : ''} in
+          a model federation alignment rescaled; {rescaled === 1 ? 'its' : 'their'} proved
+          volume no longer describes the geometry on screen and is withheld.
         </div>
       )}
       {withoutStore > 0 && (

--- a/apps/viewer/src/components/viewer/tools/MeasureQuantities.tsx
+++ b/apps/viewer/src/components/viewer/tools/MeasureQuantities.tsx
@@ -205,9 +205,16 @@ export function MeasureQuantities() {
     let rescaled = 0;
 
     for (const ref of refs) {
-      const store = (ref.modelId !== 'legacy'
-        ? (models.get(ref.modelId)?.ifcDataStore as IfcDataStore | undefined)
-        : undefined) ?? (ifcDataStore as IfcDataStore | null) ?? undefined;
+      // A federated ref resolves ONLY through its own model. Falling back to
+      // the legacy store for an id that is not in `models` would read some
+      // other file's quantities for that express id and present them as this
+      // element's — a wrong answer where `withoutStore` should have said "could
+      // not be resolved". The legacy store answers for the legacy ref, and for
+      // the single-model case where `models` is empty.
+      const federated = ref.modelId !== 'legacy' ? models.get(ref.modelId) : undefined;
+      const store = ref.modelId === 'legacy' || models.size === 0
+        ? ((ifcDataStore as IfcDataStore | null) ?? undefined)
+        : (federated?.ifcDataStore as IfcDataStore | undefined);
       if (!store) {
         withoutStore += 1;
         continue;

--- a/apps/viewer/src/components/viewer/tools/MeasurementVisuals.tsx
+++ b/apps/viewer/src/components/viewer/tools/MeasurementVisuals.tsx
@@ -16,6 +16,7 @@ import {
   formatAxisDeltas,
   formatHorizontalVertical,
 } from './measure-modes/components';
+import { inclination, formatInclination } from './measure-modes/inclination';
 
 export interface MeasurementOverlaysProps {
   measurements: Measurement[];
@@ -137,6 +138,10 @@ export const MeasurementOverlays = React.memo(function MeasurementOverlays({ mea
             <div className="font-normal text-[10px] leading-tight opacity-80">
               {formatHorizontalVertical(components)}
             </div>
+            {/* Inclination to horizontal (#2199 §4), from the same endpoints. */}
+            <div className="font-normal text-[10px] leading-tight opacity-80">
+              {formatInclination(inclination(components))}
+            </div>
           </div>
         </div>
         );
@@ -202,6 +207,9 @@ export const MeasurementOverlays = React.memo(function MeasurementOverlays({ mea
             </div>
             <div className="font-normal text-[10px] leading-tight opacity-80">
               {formatHorizontalVertical(distanceComponents(activeMeasurement.start, activeMeasurement.current))}
+            </div>
+            <div className="font-normal text-[10px] leading-tight opacity-80">
+              {formatInclination(inclination(distanceComponents(activeMeasurement.start, activeMeasurement.current)))}
             </div>
           </div>
         </div>

--- a/apps/viewer/src/components/viewer/tools/measure-modes/coordinates.test.ts
+++ b/apps/viewer/src/components/viewer/tools/measure-modes/coordinates.test.ts
@@ -1,0 +1,174 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import {
+  viewerToIfcAxes,
+  ifcToViewerAxes,
+  renderToWorldViewer,
+  pointCoordinates,
+  relativeOffset,
+  formatCoordinateTriple,
+} from './coordinates.js';
+
+describe('axis conversion', () => {
+  it('maps the viewer UP axis to IFC Z, not to IFC Y', () => {
+    // The whole risk: viewer Y is up, IFC Z is up. A point 10m above the
+    // origin must come out as Z=10. Passing the axes straight through would
+    // report it as Y=10 — a building's height filed under its northing.
+    assert.deepStrictEqual(
+      viewerToIfcAxes({ x: 0, y: 10, z: 0 }),
+      { x: 0, y: 0, z: 10 },
+    );
+  });
+
+  it('negates viewer Z when producing IFC Y', () => {
+    // Dropping the negation mirrors the model about its north axis: the
+    // numbers stay plausible and point the wrong way, which is the failure
+    // mode nobody notices.
+    assert.deepStrictEqual(
+      viewerToIfcAxes({ x: 0, y: 0, z: 7 }),
+      { x: 0, y: -7, z: 0 },
+    );
+  });
+
+  it('leaves X alone', () => {
+    assert.deepStrictEqual(viewerToIfcAxes({ x: 4, y: 0, z: 0 }), { x: 4, y: 0, z: 0 });
+  });
+
+  it('never emits negative zero from the negated axis', () => {
+    // Unary minus on 0 yields -0, which is not a coordinate anybody authored
+    // and which survives into equality checks and serialised output. Both
+    // directions negate one axis, so both can produce it.
+    assert.ok(!Object.is(viewerToIfcAxes({ x: 0, y: 0, z: 0 }).y, -0));
+    assert.ok(!Object.is(ifcToViewerAxes({ x: 0, y: 0, z: 0 }).z, -0));
+  });
+
+  it('round-trips through the inverse in both directions', () => {
+    const viewer = { x: 1.5, y: -2.25, z: 3.75 };
+    assert.deepStrictEqual(ifcToViewerAxes(viewerToIfcAxes(viewer)), viewer);
+    const ifc = { x: -9, y: 4.5, z: 0.25 };
+    assert.deepStrictEqual(viewerToIfcAxes(ifcToViewerAxes(ifc)), ifc);
+  });
+});
+
+describe('renderToWorldViewer', () => {
+  it('is the identity when neither shift was applied', () => {
+    const p = { x: 1, y: 2, z: 3 };
+    assert.deepStrictEqual(renderToWorldViewer(p, {}), p);
+    assert.deepStrictEqual(
+      renderToWorldViewer(p, { originShift: null, wasmRtcOffsetIfc: null }),
+      p,
+    );
+  });
+
+  it('ADDS the centroid shift back, rather than subtracting it again', () => {
+    // originShift records what was taken off on import; the world position is
+    // recovered by putting it back. Subtracting would double the error.
+    const world = renderToWorldViewer(
+      { x: 1, y: 2, z: 3 },
+      { originShift: { x: 10, y: 20, z: 30 } },
+    );
+    assert.deepStrictEqual(world, { x: 11, y: 22, z: 33 });
+  });
+
+  it('converts the RTC offset out of IFC axes before adding it', () => {
+    // wasmRtcOffset is recorded in IFC (Z-up) axes while originShift is in
+    // viewer axes. An RTC offset of IFC (0, 100, 0) is a NORTHING, so it must
+    // land on viewer Z (negated) — not on viewer Y, which would raise the
+    // whole model 100m into the air.
+    const world = renderToWorldViewer(
+      { x: 0, y: 0, z: 0 },
+      { wasmRtcOffsetIfc: { x: 0, y: 100, z: 0 } },
+    );
+    assert.deepStrictEqual(world, { x: 0, y: 0, z: -100 });
+  });
+
+  it('puts an IFC-Z RTC offset on the viewer UP axis', () => {
+    const world = renderToWorldViewer(
+      { x: 0, y: 0, z: 0 },
+      { wasmRtcOffsetIfc: { x: 0, y: 0, z: 100 } },
+    );
+    assert.deepStrictEqual(world, { x: 0, y: 100, z: 0 });
+  });
+
+  it('applies both offsets together', () => {
+    const world = renderToWorldViewer(
+      { x: 1, y: 1, z: 1 },
+      {
+        originShift: { x: 10, y: 20, z: 30 },
+        wasmRtcOffsetIfc: { x: 100, y: 200, z: 300 },
+      },
+    );
+    // viewer-space RTC = (100, 300, -200); plus shift (10, 20, 30); plus point.
+    assert.deepStrictEqual(world, { x: 111, y: 321, z: -169 });
+  });
+});
+
+describe('pointCoordinates', () => {
+  it('reports local and world in IFC axes, and flags that they differ', () => {
+    const c = pointCoordinates({ x: 1, y: 2, z: 3 }, { originShift: { x: 10, y: 0, z: 0 } });
+    // local: viewer (1,2,3) -> IFC (1, -3, 2)
+    assert.deepStrictEqual(c.local, { x: 1, y: -3, z: 2 });
+    // world: viewer (11,2,3) -> IFC (11, -3, 2)
+    assert.deepStrictEqual(c.world, { x: 11, y: -3, z: 2 });
+    assert.strictEqual(c.shifted, true);
+  });
+
+  it('reports shifted=false when the model was never moved', () => {
+    // A model authored near the origin has local === world, and the UI leans
+    // on this to avoid printing the same row twice under two different labels.
+    const c = pointCoordinates({ x: 1, y: 2, z: 3 }, {});
+    assert.strictEqual(c.shifted, false);
+    assert.deepStrictEqual(c.local, c.world);
+  });
+
+  it('reports shifted=false for an explicitly zero shift', () => {
+    const c = pointCoordinates(
+      { x: 1, y: 2, z: 3 },
+      { originShift: { x: 0, y: 0, z: 0 }, wasmRtcOffsetIfc: { x: 0, y: 0, z: 0 } },
+    );
+    assert.strictEqual(c.shifted, false);
+  });
+});
+
+describe('relativeOffset', () => {
+  it('subtracts the reference from the point, not the other way round', () => {
+    // A point 5m EAST of the reference must read +5, not -5.
+    const r = relativeOffset({ x: 15, y: 3, z: 1 }, { x: 10, y: 3, z: 1 });
+    assert.strictEqual(r.dx, 5);
+    assert.strictEqual(r.dy, 0);
+    assert.strictEqual(r.dz, 0);
+  });
+
+  it('reports a non-negative straight-line distance regardless of direction', () => {
+    const forward = relativeOffset({ x: 3, y: 4, z: 12 }, { x: 0, y: 0, z: 0 });
+    const back = relativeOffset({ x: 0, y: 0, z: 0 }, { x: 3, y: 4, z: 12 });
+    assert.strictEqual(forward.distance, 13);
+    assert.strictEqual(back.distance, 13);
+    assert.strictEqual(back.dx, -3);
+  });
+
+  it('is all zeroes against itself', () => {
+    const r = relativeOffset({ x: 2, y: 3, z: 4 }, { x: 2, y: 3, z: 4 });
+    assert.deepStrictEqual(r, { dx: 0, dy: 0, dz: 0, distance: 0 });
+  });
+});
+
+describe('formatCoordinateTriple', () => {
+  it('labels each axis and pads to millimetre precision', () => {
+    assert.strictEqual(
+      formatCoordinateTriple({ x: 12.5, y: -3.25, z: 0 }),
+      'X 12.500  Y -3.250  Z 0.000',
+    );
+  });
+
+  it('honours a caller-chosen precision', () => {
+    assert.strictEqual(
+      formatCoordinateTriple({ x: 1.23456, y: 0, z: 0 }, 1),
+      'X 1.2  Y 0.0  Z 0.0',
+    );
+  });
+});

--- a/apps/viewer/src/components/viewer/tools/measure-modes/coordinates.ts
+++ b/apps/viewer/src/components/viewer/tools/measure-modes/coordinates.ts
@@ -1,0 +1,167 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Point coordinates for the Measure tool — issue #2199 §5.
+ *
+ * The viewer already reports a picked point's GEOREFERENCED position
+ * (Eastings / Northings / Height, #1674) but never its plain model position,
+ * which is what most of §5 asks for. This module is the missing half: it maps
+ * a picked render-frame point back to the model's own coordinate system.
+ *
+ * TWO transforms are involved and they are independent, which is why they are
+ * separate exported functions rather than one lump:
+ *
+ * 1. **Frames.** Renderer positions are SHIFTED. The geometry pipeline moves
+ *    the model towards the origin to keep f32 precision usable, in up to two
+ *    stages — an RTC offset subtracted by the wasm mesh pass, then a further
+ *    centroid shift by `CoordinateHandler`. `CoordinateInfo` records both, so
+ *    adding them back recovers the file's own world coordinates.
+ * 2. **Axes.** Renderer space is Y-up; IFC is Z-up. Reporting a picked point in
+ *    renderer axes would put a building's height in the Y column, which
+ *    silently disagrees with every other coordinate the viewer shows (the
+ *    Properties panel, the georeferencing panel, the file itself).
+ *
+ * Units are metres throughout — geometry is unit-scaled to metres at import
+ * (`RouterConfig.unit_scale`), and both recorded offsets are in that same
+ * metre space. No unit conversion belongs here.
+ *
+ * The world-frame reconstruction deliberately mirrors the one already inlined
+ * in `PropertiesPanel.tsx`'s `entityCoordinates` memo, and that call site now
+ * routes through here, so the two can no longer drift apart.
+ */
+
+import type { Point3 } from './components';
+
+/**
+ * The offsets the geometry pipeline applied to get from the model's own
+ * coordinates to the render frame. Both are optional because both are
+ * genuinely absent for a small model authored near the origin — which is the
+ * case where local and world coordinates coincide.
+ */
+export interface RenderFrameOffsets {
+  /**
+   * Centroid shift applied by `CoordinateHandler`, in RENDERER (Y-up) metres.
+   * `CoordinateInfo.originShift`.
+   */
+  originShift?: Point3 | null;
+  /**
+   * RTC offset subtracted by the wasm mesh pass, in IFC (Z-up) metres.
+   * `CoordinateInfo.wasmRtcOffset`. Recorded in IFC axes, unlike
+   * `originShift` — hence the conversion below rather than a plain add.
+   */
+  wasmRtcOffsetIfc?: Point3 | null;
+}
+
+const ZERO: Point3 = { x: 0, y: 0, z: 0 };
+
+/**
+ * Convert a renderer-space (Y-up) point to IFC axes (Z-up).
+ *
+ * `IFC X = viewer X`, `IFC Y = -viewer Z`, `IFC Z = viewer Y`. The negation is
+ * not optional bookkeeping: dropping it mirrors the model about its own north
+ * axis, which reads as plausible numbers pointing the wrong way.
+ */
+export function viewerToIfcAxes(p: Point3): Point3 {
+  // `0 - p.z` rather than `-p.z`: unary minus on 0 yields -0, which is not a
+  // coordinate anybody authored and leaks into equality checks and serialised
+  // output. Subtraction from zero normalises it while leaving every other
+  // value — including NaN, which must stay NaN rather than becoming 0 —
+  // untouched.
+  return { x: p.x, y: 0 - p.z, z: p.y };
+}
+
+/**
+ * Convert an IFC-axes (Z-up) point to renderer axes (Y-up). The exact inverse
+ * of {@link viewerToIfcAxes}.
+ */
+export function ifcToViewerAxes(p: Point3): Point3 {
+  // See the signed-zero note on `viewerToIfcAxes`.
+  return { x: p.x, y: p.z, z: 0 - p.y };
+}
+
+/**
+ * Undo the render-frame shift: renderer-space point -> the model's own world
+ * position, still in renderer (Y-up) axes.
+ *
+ * Both offsets are ADDED back because both were subtracted on the way in.
+ * `wasmRtcOffsetIfc` is converted to renderer axes first — it is recorded in
+ * IFC axes while `originShift` is recorded in renderer axes, and adding them
+ * in the same axes would fold the model's north offset into its height.
+ */
+export function renderToWorldViewer(p: Point3, frame: RenderFrameOffsets): Point3 {
+  const shift = frame.originShift ?? ZERO;
+  const rtcIfc = frame.wasmRtcOffsetIfc ?? ZERO;
+  const rtcViewer = ifcToViewerAxes(rtcIfc);
+  return {
+    x: p.x + shift.x + rtcViewer.x,
+    y: p.y + shift.y + rtcViewer.y,
+    z: p.z + shift.z + rtcViewer.z,
+  };
+}
+
+/** A picked point expressed in every frame the viewer can honestly offer. */
+export interface PointCoordinates {
+  /**
+   * The render frame the picked point arrived in, converted to IFC axes.
+   * Small numbers near the origin; what the renderer and the snap system work
+   * in. Useful for reproducing a pick, not for talking to anyone else.
+   */
+  local: Point3;
+  /**
+   * The model's own coordinates — the render frame with every applied shift
+   * added back, in IFC axes. This is what the IFC file's global coordinate
+   * system says, and what matches the Properties panel's world readout.
+   */
+  world: Point3;
+  /**
+   * Whether the two above actually differ. False for a model authored near
+   * the origin, where showing both would be two identical rows pretending to
+   * be different information.
+   */
+  shifted: boolean;
+}
+
+/** Express a picked renderer-space point in local and world IFC coordinates. */
+export function pointCoordinates(p: Point3, frame: RenderFrameOffsets): PointCoordinates {
+  const worldViewer = renderToWorldViewer(p, frame);
+  const shifted =
+    worldViewer.x !== p.x || worldViewer.y !== p.y || worldViewer.z !== p.z;
+  return {
+    local: viewerToIfcAxes(p),
+    world: viewerToIfcAxes(worldViewer),
+    shifted,
+  };
+}
+
+/** A point's offset from a user-set temporary reference point. */
+export interface RelativeOffset {
+  /** Signed per-axis deltas, point minus reference, in the given frame. */
+  dx: number;
+  dy: number;
+  dz: number;
+  /** Straight-line distance between the two. Never negative. */
+  distance: number;
+}
+
+/**
+ * Offset of `p` from a temporary reference point `ref` — issue #2199 §5's
+ * "define a temporary reference point and display relative coordinate
+ * offsets".
+ *
+ * Frame-agnostic: it subtracts whatever it is given, so passing two IFC-axes
+ * points yields IFC-axes deltas and passing two renderer-space points yields
+ * renderer deltas. Callers must not mix the two.
+ */
+export function relativeOffset(p: Point3, ref: Point3): RelativeOffset {
+  const dx = p.x - ref.x;
+  const dy = p.y - ref.y;
+  const dz = p.z - ref.z;
+  return { dx, dy, dz, distance: Math.hypot(dx, dy, dz) };
+}
+
+/** Fixed-precision X/Y/Z triple, e.g. `X 12.500  Y -3.250  Z 0.000`. */
+export function formatCoordinateTriple(p: Point3, fractionDigits = 3): string {
+  return `X ${p.x.toFixed(fractionDigits)}  Y ${p.y.toFixed(fractionDigits)}  Z ${p.z.toFixed(fractionDigits)}`;
+}

--- a/apps/viewer/src/components/viewer/tools/measure-modes/geo-readout.test.tsx
+++ b/apps/viewer/src/components/viewer/tools/measure-modes/geo-readout.test.tsx
@@ -1,0 +1,124 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The lat/lon half of the measure tool's geo readout resolves through proj4,
+ * which is asynchronous — and the row it feeds sits directly under a synchronous
+ * E/N readout that updates on the same click.
+ *
+ * That gap is the whole subject here: between picking a new point and the
+ * reprojection resolving, the component must show NOTHING rather than the
+ * previous point's coordinates. A stale lat/lon under a fresh label is
+ * indistinguishable from a correct one, which makes it worse than an absent
+ * row — the same "state the basis, never guess" rule the rest of #2199 follows.
+ */
+
+import '@/test/setup-dom.js';
+import { describe, it, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { useProjectedLatLon } from './geo-readout.js';
+import type { AnchorGeoreference } from '@/lib/geo/useAnchorGeoreference';
+
+/**
+ * building-architecture.ifc's georeference (EPSG:32760, UTM 60S), the same
+ * fixture `lib/geo/reproject.test.ts` uses — a real CRS proj4 can resolve, so
+ * the async hop genuinely happens rather than short-circuiting to `null`.
+ */
+const ANCHOR = {
+  eff: {
+    mapConversion: {
+      eastings: 729013348.8297004,
+      northings: 9063992684.697363,
+      orthogonalHeight: 0,
+      xAxisAbscissa: 1,
+      xAxisOrdinate: 0,
+      scale: 1,
+    },
+    projectedCRS: { id: 18, name: 'EPSG:32760', mapUnit: 'MILLIMETRE', mapUnitScale: 0.001 },
+    lengthUnitScale: 0.001,
+  },
+  originViewer: { x: 0, y: 0, z: 0 },
+} as unknown as AnchorGeoreference;
+
+const mounted: Array<{ root: Root; host: HTMLElement }> = [];
+after(() => {
+  for (const { root, host } of mounted.splice(0)) {
+    act(() => root.unmount());
+    host.remove();
+  }
+});
+
+/**
+ * Flush pending promise jobs inside `act` until `done()` holds, so a resolved
+ * reprojection is committed before the next assertion reads it. Polled rather
+ * than a fixed number of ticks: `resolveProjection` loads its definition
+ * lazily, so the number of microtask hops is an implementation detail.
+ */
+async function settle(done: () => boolean = () => true): Promise<void> {
+  for (let i = 0; i < 50 && !done(); i++) {
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 5));
+    });
+  }
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, 5));
+  });
+}
+
+describe('the picked point\'s lat/lon never lags behind the point', () => {
+  it('clears the previous coordinates while the new ones are in flight', async () => {
+    const seen: Array<{ lat: number; lon: number } | null> = [];
+    function Probe({ point }: { point: { x: number; y: number; z: number } }) {
+      seen.push(useProjectedLatLon(point, ANCHOR));
+      return null;
+    }
+
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    mounted.push({ root, host });
+
+    act(() => root.render(<Probe point={{ x: 0, y: 0, z: 0 }} />));
+    await settle(() => seen.at(-1) !== null && seen.at(-1) !== undefined);
+    const first = seen.at(-1);
+    assert.ok(first, 'the fixture CRS must actually resolve, or this test proves nothing');
+
+    // A point 20 km east (viewer units are metres): far enough that its lat/lon
+    // differs beyond any rounding, near enough to stay inside the projection.
+    seen.length = 0;
+    act(() => root.render(<Probe point={{ x: 20_000, y: 0, z: 0 }} />));
+    assert.equal(
+      seen.at(-1),
+      null,
+      `the render right after the pick still showed the old point's lat/lon: ${JSON.stringify(seen)}`,
+    );
+
+    await settle(() => seen.at(-1) !== null && seen.at(-1) !== undefined);
+    const second = seen.at(-1);
+    assert.ok(second, 'and the new coordinates must arrive');
+    assert.notDeepEqual(second, first, 'a 50 km move must change the lat/lon');
+  });
+
+  it('is null with no anchor, and stays null once the anchor goes away', async () => {
+    const seen: Array<{ lat: number; lon: number } | null> = [];
+    function Probe({ anchor }: { anchor: AnchorGeoreference | null }) {
+      seen.push(useProjectedLatLon({ x: 0, y: 0, z: 0 }, anchor));
+      return null;
+    }
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    mounted.push({ root, host });
+
+    act(() => root.render(<Probe anchor={ANCHOR} />));
+    await settle(() => seen.at(-1) !== null && seen.at(-1) !== undefined);
+    assert.ok(seen.at(-1), 'resolved with an anchor');
+
+    act(() => root.render(<Probe anchor={null} />));
+    await settle();
+    assert.equal(seen.at(-1), null, 'dropping the georeference must drop the readout');
+  });
+});

--- a/apps/viewer/src/components/viewer/tools/measure-modes/geo-readout.tsx
+++ b/apps/viewer/src/components/viewer/tools/measure-modes/geo-readout.tsx
@@ -84,6 +84,11 @@ export function useProjectedLatLon(
       setLatLon(null);
       return;
     }
+    // Drop the PREVIOUS point's lat/lon before the async hop. Without this the
+    // readout keeps showing the last resolved coordinates while the new ones
+    // are in flight — a stale position under a fresh label, which is worse
+    // than a momentarily absent row.
+    setLatLon(null);
     let cancelled = false;
     void reprojectPointToLatLon(
       projected.eastings,

--- a/apps/viewer/src/components/viewer/tools/measure-modes/geo-readout.tsx
+++ b/apps/viewer/src/components/viewer/tools/measure-modes/geo-readout.tsx
@@ -1,0 +1,105 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Georeferenced readout for a picked point (#1657 / #1674 / #1679), extracted
+ * from `MeasurePanel` so the panel, the measurement list rows and the
+ * point-coordinates card can all reach it without importing each other.
+ *
+ * Behaviour is unchanged by the move — this is the same projection, the same
+ * unit handling and the same async lat/lon effect that shipped in #1674/#1679.
+ */
+
+import { useEffect, useState } from 'react';
+import type { AnchorGeoreference } from '@/lib/geo/useAnchorGeoreference';
+import { viewerPointToProjected } from '@/lib/geo/pick-to-geo';
+import { mapUnitsToMeters } from '@/lib/geo/cesium-placement';
+import {
+  reprojectPointToLatLon,
+  reprojectionInputKey,
+  type LatLon,
+} from '@/lib/geo/reproject';
+
+export interface Vec3Like { x: number; y: number; z: number }
+export interface Enh { e: string; n: string; h: string }
+
+/**
+ * Project a picked viewer point to real-world Eastings/Northings/Height and
+ * format it in the CRS's metre unit to millimetre precision. The stored
+ * MapConversion offsets are in the authored map unit (millimetres for the
+ * bundled sample), so we convert to metres with the anchor's map-unit scale —
+ * the raw offsets would read ~1000x too large for a metre CRS.
+ */
+export function projectedEnh(point: Vec3Like, anchor: AnchorGeoreference): Enh {
+  const proj = viewerPointToProjected(point, anchor.eff, anchor.originViewer);
+  const { projectedCRS, lengthUnitScale } = anchor.eff;
+  return {
+    e: mapUnitsToMeters(proj.eastings, projectedCRS, lengthUnitScale).toFixed(3),
+    n: mapUnitsToMeters(proj.northings, projectedCRS, lengthUnitScale).toFixed(3),
+    h: mapUnitsToMeters(proj.height, projectedCRS, lengthUnitScale).toFixed(3),
+  };
+}
+
+/** One compact monospace E/N/H line, optionally labelled (A/B endpoints). */
+export function EnhLine({ label, enh }: { label?: string; enh: Enh }) {
+  return (
+    <div className="flex items-center gap-2 font-mono text-[10px] leading-tight text-muted-foreground whitespace-nowrap">
+      {label && <span className="text-muted-foreground/60 w-3 shrink-0">{label}</span>}
+      <span>E {enh.e}</span>
+      <span>N {enh.n}</span>
+      <span>H {enh.h}</span>
+    </div>
+  );
+}
+
+/**
+ * Resolve a picked viewer point to WGS84 lat/lon asynchronously (proj4). The
+ * synchronous E/N/H readout never blocks on this; lat/lon appears once the
+ * projection resolves and is `null` for a CRS proj4 can't resolve (the line is
+ * simply absent). The effect is keyed by a primitive derived from *all* inputs
+ * the reprojection consumes (CRS name + projection metadata + unit scales +
+ * quantised E/N) so it recomputes on any georef edit but not on unrelated
+ * re-renders — see {@link reprojectionInputKey}.
+ */
+export function useProjectedLatLon(
+  point: Vec3Like | null,
+  anchor: AnchorGeoreference | null,
+): LatLon | null {
+  const [latLon, setLatLon] = useState<LatLon | null>(null);
+  const projected = point && anchor
+    ? viewerPointToProjected(point, anchor.eff, anchor.originViewer)
+    : null;
+  const key = projected && anchor
+    ? reprojectionInputKey(
+        projected.eastings,
+        projected.northings,
+        anchor.eff.projectedCRS,
+        anchor.eff.lengthUnitScale,
+      )
+    : '';
+
+  useEffect(() => {
+    if (!projected || !anchor) {
+      setLatLon(null);
+      return;
+    }
+    let cancelled = false;
+    void reprojectPointToLatLon(
+      projected.eastings,
+      projected.northings,
+      anchor.eff.projectedCRS,
+      anchor.eff.lengthUnitScale,
+    ).then((r) => {
+      if (!cancelled) setLatLon(r);
+    });
+    return () => {
+      cancelled = true;
+    };
+    // Keyed by the primitive `key` so unrelated re-renders don't refetch and a
+    // georef change that alters the projection always does.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key]);
+
+  return latLon;
+}

--- a/apps/viewer/src/components/viewer/tools/measure-modes/inclination.test.ts
+++ b/apps/viewer/src/components/viewer/tools/measure-modes/inclination.test.ts
@@ -1,0 +1,126 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { inclination, formatInclination } from './inclination.js';
+import { distanceComponents } from './components.js';
+
+/** Build components the way the panel does, from two picked points. */
+const between = (
+  start: { x: number; y: number; z: number },
+  end: { x: number; y: number; z: number },
+) => distanceComponents(start, end);
+
+describe('inclination', () => {
+  it('derives degrees from the vertical over the horizontal, not the reverse', () => {
+    // rise 5, run 5*sqrt(3) => 30 degrees. Swapping the atan2 arguments gives
+    // 60, which this pins. Run is laid out as (dx=15, dz=0) so horizontal is
+    // unambiguous.
+    const run = 5 * Math.sqrt(3);
+    const i = inclination(between({ x: 0, y: 0, z: 0 }, { x: run, y: 5, z: 0 }));
+    assert.ok(Math.abs(i.degrees - 30) < 1e-9, `expected 30, got ${i.degrees}`);
+  });
+
+  it('computes percent as rise over run, not run over rise', () => {
+    // rise 1 over run 4 is a 25% grade. The inverse would be 400%.
+    const i = inclination(between({ x: 0, y: 0, z: 0 }, { x: 4, y: 1, z: 0 }));
+    assert.ok(Math.abs(i.percent - 25) < 1e-9, `expected 25, got ${i.percent}`);
+  });
+
+  it('computes the 1:n ratio as run per unit rise — the reciprocal of percent', () => {
+    // A 1:20 fall is the drainage convention: 1 vertical to 20 horizontal.
+    // Inverting this reads a gentle fall as 1:0.05 and vice versa, so the
+    // number here is the whole point of the field.
+    const i = inclination(between({ x: 0, y: 0, z: 0 }, { x: 20, y: 1, z: 0 }));
+    assert.ok(Math.abs((i.ratioRun ?? 0) - 20) < 1e-9, `expected 20, got ${i.ratioRun}`);
+    // ...and it really is the reciprocal of the percentage's fraction.
+    assert.ok(Math.abs(i.percent - 5) < 1e-9);
+  });
+
+  it('uses the Y-up horizontal, so a run spread across X and Z is one run', () => {
+    // dx=3, dz=4 is a run of 5, rise 5 => 45 degrees. Treating dz as the
+    // vertical (the Z-up mistake `components.ts` warns about) would give a
+    // run of hypot(3,5) and a rise of 4 — about 34 degrees.
+    const i = inclination(between({ x: 0, y: 0, z: 0 }, { x: 3, y: 5, z: 4 }));
+    assert.ok(Math.abs(i.degrees - 45) < 1e-9, `expected 45, got ${i.degrees}`);
+    assert.strictEqual(i.kind, 'sloped');
+  });
+
+  it('is unsigned: a fall and a rise of the same gradient read alike', () => {
+    const up = inclination(between({ x: 0, y: 0, z: 0 }, { x: 4, y: 1, z: 0 }));
+    const down = inclination(between({ x: 0, y: 0, z: 0 }, { x: 4, y: -1, z: 0 }));
+    assert.deepStrictEqual(down, up);
+  });
+
+  describe('the four kinds', () => {
+    it('calls a plumb drop vertical, with an infinite gradient', () => {
+      const i = inclination(between({ x: 1, y: 9, z: 2 }, { x: 1, y: 3, z: 2 }));
+      assert.strictEqual(i.kind, 'vertical');
+      assert.strictEqual(i.degrees, 90);
+      assert.strictEqual(i.percent, Infinity);
+      assert.strictEqual(i.ratioRun, 0);
+    });
+
+    it('calls a level run level, with no ratio', () => {
+      const i = inclination(between({ x: 0, y: 7, z: 0 }, { x: 6, y: 7, z: 8 }));
+      assert.strictEqual(i.kind, 'level');
+      assert.strictEqual(i.degrees, 0);
+      assert.strictEqual(i.percent, 0);
+      assert.strictEqual(i.ratioRun, null);
+    });
+
+    it('separates a zero-length pick from a level run', () => {
+      // These two produce an IDENTICAL (0, 0, null) numeric triple, so `kind`
+      // is the only thing that can tell them apart. If the discriminator is
+      // ever collapsed, this is what catches it.
+      const nothing = inclination(between({ x: 2, y: 3, z: 4 }, { x: 2, y: 3, z: 4 }));
+      const level = inclination(between({ x: 0, y: 3, z: 0 }, { x: 5, y: 3, z: 0 }));
+      assert.strictEqual(nothing.kind, 'degenerate');
+      assert.strictEqual(level.kind, 'level');
+      assert.strictEqual(nothing.degrees, level.degrees);
+      assert.strictEqual(nothing.percent, level.percent);
+      assert.strictEqual(nothing.ratioRun, level.ratioRun);
+    });
+
+    it('never produces NaN, whatever the segment', () => {
+      for (const end of [
+        { x: 0, y: 0, z: 0 },
+        { x: 0, y: 5, z: 0 },
+        { x: 5, y: 0, z: 0 },
+        { x: 5, y: 5, z: 5 },
+      ]) {
+        const i = inclination(between({ x: 0, y: 0, z: 0 }, end));
+        assert.ok(!Number.isNaN(i.degrees), `NaN degrees for ${JSON.stringify(end)}`);
+        assert.ok(!Number.isNaN(i.percent), `NaN percent for ${JSON.stringify(end)}`);
+        assert.ok(i.ratioRun === null || !Number.isNaN(i.ratioRun));
+      }
+    });
+  });
+});
+
+describe('formatInclination', () => {
+  it('shows degrees, percent and ratio together for a real gradient', () => {
+    const i = inclination(between({ x: 0, y: 0, z: 0 }, { x: 20, y: 1, z: 0 }));
+    assert.strictEqual(formatInclination(i), '2.9°  5.0%  1:20.0');
+  });
+
+  it('says "vertical" rather than printing an infinite percentage', () => {
+    const i = inclination(between({ x: 0, y: 0, z: 0 }, { x: 0, y: 3, z: 0 }));
+    assert.strictEqual(formatInclination(i), '90.0°  vertical');
+    assert.ok(!formatInclination(i).includes('Infinity'));
+  });
+
+  it('says "level" for a horizontal run', () => {
+    const i = inclination(between({ x: 0, y: 0, z: 0 }, { x: 3, y: 0, z: 4 }));
+    assert.strictEqual(formatInclination(i), '0.0°  0.0%  level');
+  });
+
+  it('reports nothing measured for a zero-length pick, not "level"', () => {
+    // Reporting a degenerate pick as level would assert a fact the pick never
+    // established. This is the reason `kind` exists at all.
+    const i = inclination(between({ x: 1, y: 1, z: 1 }, { x: 1, y: 1, z: 1 }));
+    assert.strictEqual(formatInclination(i), '—');
+  });
+});

--- a/apps/viewer/src/components/viewer/tools/measure-modes/inclination.ts
+++ b/apps/viewer/src/components/viewer/tools/measure-modes/inclination.ts
@@ -1,0 +1,117 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Inclination (angle to horizontal) of a point-to-point measurement — issue
+ * #2199 §4, the part that needs no new picking interaction.
+ *
+ * Pure display maths over the two endpoints already stored on a Measurement,
+ * exactly like {@link distanceComponents}: nothing is persisted, nothing is
+ * re-picked. It consumes the horizontal / vertical split rather than the raw
+ * deltas so it inherits that module's Y-up axis convention instead of
+ * restating it — see `components.ts`, which is where the "viewer space is
+ * Y-up" decision lives.
+ */
+
+import type { DistanceComponents } from './components';
+
+/**
+ * Which of the four genuinely different answers a segment has.
+ *
+ * This is not decoration. A LEVEL run and a DEGENERATE zero-length pick
+ * produce the identical `(0 degrees, 0 percent, no ratio)` triple, so without
+ * a discriminator a formatter cannot tell "I measured along the floor" from
+ * "I measured nothing" — and would have to report one of them as the other.
+ */
+export type InclinationKind =
+  /** Both endpoints coincide: there is no segment, so no inclination. */
+  | 'degenerate'
+  /** Non-zero run, zero rise: horizontal. */
+  | 'level'
+  /** Zero run, non-zero rise: plumb. */
+  | 'vertical'
+  /** Both non-zero: a real gradient. */
+  | 'sloped';
+
+export interface Inclination {
+  kind: InclinationKind;
+  /**
+   * Angle between the measured segment and the horizontal ground plane, in
+   * degrees, always in [0, 90]. Unsigned: a fall of 30 degrees and a rise of
+   * 30 degrees both read 30. The DIRECTION is already carried by the signed
+   * `dY` in the axis-delta line, so signing this too would say the same thing
+   * twice while inviting the reader to think 0 is a floor rather than level.
+   */
+  degrees: number;
+  /**
+   * Slope as a percentage: rise over run times 100. `Infinity` for a purely
+   * vertical segment (zero run), which is a real answer and not an error —
+   * `formatInclination` renders that case as "vertical" rather than a number.
+   */
+  percent: number;
+  /**
+   * The `n` in a 1:n slope ratio — the run travelled per unit of rise. `null`
+   * when there is no rise at all, because 1:infinity is not a ratio anybody
+   * writes on a drawing.
+   *
+   * NOTE the direction of this fraction. Construction slope ratios are
+   * written 1 vertical to n horizontal (a 1:20 fall), so this is
+   * `horizontal / vertical` — the RECIPROCAL of the percentage's fraction.
+   * Inverting it turns a shallow drainage fall into a near-vertical one.
+   */
+  ratioRun: number | null;
+}
+
+/**
+ * Derive the inclination of a measured segment from its horizontal / vertical
+ * split.
+ *
+ * Degenerate cases are answered rather than thrown:
+ * - zero-length segment: `degenerate`, 0 degrees, 0 percent, no ratio;
+ * - level run: `level`, 0 degrees, 0 percent, no ratio;
+ * - plumb drop: `vertical`, 90 degrees, Infinity percent, ratio 0.
+ */
+export function inclination(c: DistanceComponents): Inclination {
+  const { horizontal, vertical } = c;
+
+  const kind: InclinationKind =
+    horizontal === 0
+      ? (vertical === 0 ? 'degenerate' : 'vertical')
+      : (vertical === 0 ? 'level' : 'sloped');
+
+  // atan2 rather than atan(v/h) so the zero-run case yields 90 instead of
+  // dividing by zero, and the zero-length case yields 0 instead of NaN.
+  const degrees = (Math.atan2(vertical, horizontal) * 180) / Math.PI;
+
+  const percent = horizontal === 0
+    // A plumb drop has infinite gradient; a coincident pair has none.
+    // Collapsing both to 0 (or both to Infinity) would report one of them
+    // wrongly.
+    ? (vertical === 0 ? 0 : Infinity)
+    : (vertical / horizontal) * 100;
+
+  const ratioRun = vertical === 0 ? null : horizontal / vertical;
+
+  return { kind, degrees, percent, ratioRun };
+}
+
+/**
+ * One-line inclination readout, e.g. `12.5°  22.2%  1:4.5`.
+ *
+ * The three forms are shown together on purpose: degrees is what a surveyor
+ * reads, percent is what a road or ramp gradient is specified in, and 1:n is
+ * what a drainage fall is drawn as. Picking one would make the tool useless to
+ * two of those three readers.
+ */
+export function formatInclination(i: Inclination): string {
+  switch (i.kind) {
+    // Em-dash, not "0°": nothing was measured, so claiming it was level would
+    // state a fact the pick never established.
+    case 'degenerate': return '—';
+    case 'level': return '0.0°  0.0%  level';
+    case 'vertical': return '90.0°  vertical';
+    case 'sloped':
+      return `${i.degrees.toFixed(1)}°  ${i.percent.toFixed(1)}%  1:${(i.ratioRun ?? 0).toFixed(1)}`;
+  }
+}

--- a/apps/viewer/src/components/viewer/tools/measure-modes/quantities.test.ts
+++ b/apps/viewer/src/components/viewer/tools/measure-modes/quantities.test.ts
@@ -1,0 +1,296 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import {
+  classifyBasis,
+  pickElementQuantities,
+  rollupQuantities,
+  rollupGeometryVolumes,
+  MEASURABLE_QUANTITY_TYPES,
+  type QuantitySetLike,
+} from './quantities.js';
+
+const { Length, Area, Volume, Weight } = MEASURABLE_QUANTITY_TYPES;
+/** QuantityType.Count — deliberately not a measurement this tool reports. */
+const COUNT = 3;
+/** QuantityType.Time — likewise. */
+const TIME = 5;
+
+const qset = (
+  name: string,
+  quantities: Array<{ name: string; type: number; value: number }>,
+): QuantitySetLike => ({ name, quantities });
+
+describe('classifyBasis', () => {
+  it('reads the openings-included/excluded distinction off the name prefix', () => {
+    assert.deepStrictEqual(classifyBasis('NetVolume'), { basis: 'net', stem: 'volume' });
+    assert.deepStrictEqual(classifyBasis('GrossVolume'), { basis: 'gross', stem: 'volume' });
+  });
+
+  it('does NOT guess a basis for an unqualified name', () => {
+    // Labelling a bare `Volume` as net would put a confidence on it the file
+    // never expressed — this is the claim the whole gross/net readout rests on.
+    assert.deepStrictEqual(classifyBasis('Volume'), { basis: 'unqualified', stem: 'volume' });
+  });
+
+  it('is case-insensitive on both the prefix and the stem', () => {
+    assert.deepStrictEqual(classifyBasis('NETSIDEAREA'), { basis: 'net', stem: 'sidearea' });
+    assert.deepStrictEqual(classifyBasis('grossArea'), { basis: 'gross', stem: 'area' });
+  });
+});
+
+describe('pickElementQuantities', () => {
+  it('classifies by QuantityType, not by the name', () => {
+    // A quantity called "Length" typed as a Volume is a Volume. Relying on the
+    // name would file it under Length and then add it to a metre total.
+    const picked = pickElementQuantities([
+      qset('Qto_Odd', [{ name: 'Length', type: Volume, value: 7 }]),
+    ]);
+    assert.strictEqual(picked.length, 1);
+    assert.strictEqual(picked[0].quantityType, Volume);
+  });
+
+  it('keeps net and gross as separate answers', () => {
+    const picked = pickElementQuantities([
+      qset('Qto_WallBaseQuantities', [
+        { name: 'NetVolume', type: Volume, value: 3 },
+        { name: 'GrossVolume', type: Volume, value: 4 },
+      ]),
+    ]);
+    assert.deepStrictEqual(
+      picked.map((p) => [p.basis, p.value]),
+      [['net', 3], ['gross', 4]],
+    );
+  });
+
+  it('takes ONE area per basis instead of summing an element\'s several areas', () => {
+    // This is the defect the bucket exists to prevent: a wall declares a side
+    // area, a footprint area and a cross-section area, and adding them reports
+    // an area the wall does not have. 5.5 + 2 + 0.3 = 7.8 must NOT appear.
+    const picked = pickElementQuantities([
+      qset('Qto_WallBaseQuantities', [
+        { name: 'NetSideArea', type: Area, value: 5.5 },
+        { name: 'NetFootprintArea', type: Area, value: 2 },
+        { name: 'CrossSectionArea', type: Area, value: 0.3 },
+      ]),
+    ]);
+    const netAreas = picked.filter((p) => p.quantityType === Area && p.basis === 'net');
+    assert.strictEqual(netAreas.length, 1);
+    assert.strictEqual(netAreas[0].value, 5.5);
+  });
+
+  it('prefers the more representative name when several compete in one bucket', () => {
+    // `NetArea` outranks `NetFootprintArea`, whatever order they arrive in.
+    const forward = pickElementQuantities([
+      qset('Qto_X', [
+        { name: 'NetFootprintArea', type: Area, value: 2 },
+        { name: 'NetArea', type: Area, value: 9 },
+      ]),
+    ]);
+    const reversed = pickElementQuantities([
+      qset('Qto_X', [
+        { name: 'NetArea', type: Area, value: 9 },
+        { name: 'NetFootprintArea', type: Area, value: 2 },
+      ]),
+    ]);
+    assert.strictEqual(forward[0].value, 9);
+    assert.strictEqual(reversed[0].value, 9);
+  });
+
+  it('keeps the first of two equally unranked names, so the pick is stable', () => {
+    const picked = pickElementQuantities([
+      qset('Qto_X', [
+        { name: 'NetWeirdArea', type: Area, value: 1 },
+        { name: 'NetOtherArea', type: Area, value: 2 },
+      ]),
+    ]);
+    assert.strictEqual(picked.length, 1);
+    assert.strictEqual(picked[0].value, 1);
+  });
+
+  it('records which quantity actually won', () => {
+    const picked = pickElementQuantities([
+      qset('Qto_WallBaseQuantities', [{ name: 'NetSideArea', type: Area, value: 5.5 }]),
+    ]);
+    assert.strictEqual(picked[0].provenance, 'Qto_WallBaseQuantities.NetSideArea');
+  });
+
+  it('ignores Count and Time', () => {
+    // Totalling a door count beside a volume would invite reading one as the
+    // other; neither is a measurement of the building's geometry.
+    const picked = pickElementQuantities([
+      qset('Qto_X', [
+        { name: 'NumberOfRisers', type: COUNT, value: 17 },
+        { name: 'Duration', type: TIME, value: 3600 },
+        { name: 'NetVolume', type: Volume, value: 1 },
+      ]),
+    ]);
+    assert.deepStrictEqual(picked.map((p) => p.quantityType), [Volume]);
+  });
+
+  it('drops non-finite values instead of carrying them into a sum', () => {
+    // One NaN poisons the total for every other element in the selection.
+    const picked = pickElementQuantities([
+      qset('Qto_X', [
+        { name: 'NetVolume', type: Volume, value: NaN },
+        { name: 'NetArea', type: Area, value: Infinity },
+        { name: 'Length', type: Length, value: 2 },
+      ]),
+    ]);
+    assert.deepStrictEqual(picked.map((p) => p.quantityType), [Length]);
+  });
+
+  it('merges across several quantity sets on the same element', () => {
+    const picked = pickElementQuantities([
+      qset('Qto_WallBaseQuantities', [{ name: 'NetVolume', type: Volume, value: 3 }]),
+      qset('Qto_BodyGeometryValidation', [{ name: 'NetWeight', type: Weight, value: 80 }]),
+    ]);
+    assert.deepStrictEqual(
+      picked.map((p) => p.quantityType),
+      [Volume, Weight],
+    );
+  });
+
+  it('returns rows in a stable type-then-basis order', () => {
+    const picked = pickElementQuantities([
+      qset('Qto_X', [
+        { name: 'GrossVolume', type: Volume, value: 4 },
+        { name: 'Weight', type: Weight, value: 80 },
+        { name: 'NetVolume', type: Volume, value: 3 },
+        { name: 'Length', type: Length, value: 2 },
+        { name: 'NetArea', type: Area, value: 1 },
+      ]),
+    ]);
+    assert.deepStrictEqual(
+      picked.map((p) => `${p.quantityType}:${p.basis}`),
+      [`${Length}:unqualified`, `${Area}:net`, `${Volume}:net`, `${Volume}:gross`, `${Weight}:unqualified`],
+    );
+  });
+
+  it('returns nothing for an element with no quantity sets', () => {
+    assert.deepStrictEqual(pickElementQuantities([]), []);
+    assert.deepStrictEqual(pickElementQuantities([qset('Qto_Empty', [])]), []);
+  });
+});
+
+describe('rollupQuantities', () => {
+  it('totals each bucket across elements and counts the contributors', () => {
+    const rollups = rollupQuantities([
+      pickElementQuantities([qset('Qto_A', [{ name: 'NetVolume', type: Volume, value: 3 }])]),
+      pickElementQuantities([qset('Qto_A', [{ name: 'NetVolume', type: Volume, value: 4.5 }])]),
+    ]);
+    assert.strictEqual(rollups.length, 1);
+    assert.strictEqual(rollups[0].total, 7.5);
+    assert.strictEqual(rollups[0].contributing, 2);
+  });
+
+  it('counts only the elements that had a value, not the whole selection', () => {
+    // Three elements selected, one with no quantities at all. Reporting
+    // "3 of 3 contributed" would hide that a third of the selection is missing
+    // from the total.
+    const rollups = rollupQuantities([
+      pickElementQuantities([qset('Qto_A', [{ name: 'NetVolume', type: Volume, value: 3 }])]),
+      pickElementQuantities([]),
+      pickElementQuantities([qset('Qto_A', [{ name: 'NetVolume', type: Volume, value: 1 }])]),
+    ]);
+    assert.strictEqual(rollups[0].contributing, 2);
+    assert.strictEqual(rollups[0].total, 4);
+  });
+
+  it('never merges net into gross', () => {
+    const rollups = rollupQuantities([
+      pickElementQuantities([
+        qset('Qto_A', [
+          { name: 'NetVolume', type: Volume, value: 3 },
+          { name: 'GrossVolume', type: Volume, value: 4 },
+        ]),
+      ]),
+    ]);
+    assert.deepStrictEqual(
+      rollups.map((r) => [r.basis, r.total]),
+      [['net', 3], ['gross', 4]],
+    );
+  });
+
+  it('reports every distinct source name summed into a heterogeneous total', () => {
+    // A wall's NetSideArea plus a slab's NetArea is still arithmetic, but the
+    // reader has to be able to see that the total mixes two different areas.
+    const rollups = rollupQuantities([
+      pickElementQuantities([qset('Qto_WallBaseQuantities', [{ name: 'NetSideArea', type: Area, value: 5 }])]),
+      pickElementQuantities([qset('Qto_SlabBaseQuantities', [{ name: 'NetArea', type: Area, value: 20 }])]),
+    ]);
+    assert.deepStrictEqual(rollups[0].provenance, [
+      'Qto_SlabBaseQuantities.NetArea',
+      'Qto_WallBaseQuantities.NetSideArea',
+    ]);
+  });
+
+  it('deduplicates the source list when every element used the same name', () => {
+    const rollups = rollupQuantities([
+      pickElementQuantities([qset('Qto_A', [{ name: 'NetVolume', type: Volume, value: 1 }])]),
+      pickElementQuantities([qset('Qto_A', [{ name: 'NetVolume', type: Volume, value: 1 }])]),
+    ]);
+    assert.deepStrictEqual(rollups[0].provenance, ['Qto_A.NetVolume']);
+  });
+
+  it('does not let one element contribute twice to a bucket', () => {
+    // The no-double-count guarantee is PER ELEMENT, which is why the rollup
+    // takes a list per element rather than a flattened list. Handing it one
+    // element's three areas must still total a single area.
+    const oneElement = pickElementQuantities([
+      qset('Qto_X', [
+        { name: 'NetSideArea', type: Area, value: 5 },
+        { name: 'NetFootprintArea', type: Area, value: 2 },
+      ]),
+    ]);
+    const rollups = rollupQuantities([oneElement]);
+    assert.strictEqual(rollups[0].total, 5);
+    assert.strictEqual(rollups[0].contributing, 1);
+  });
+
+  it('returns nothing for an empty selection', () => {
+    assert.deepStrictEqual(rollupQuantities([]), []);
+    assert.deepStrictEqual(rollupQuantities([[], []]), []);
+  });
+});
+
+describe('rollupGeometryVolumes', () => {
+  it('sums the proved volumes and counts the unproved separately', () => {
+    const r = rollupGeometryVolumes([1.5, undefined, 2.5, undefined, undefined]);
+    assert.strictEqual(r.total, 4);
+    assert.strictEqual(r.proved, 2);
+    assert.strictEqual(r.unproved, 3);
+  });
+
+  it('treats an absent volume as unproved, never as zero', () => {
+    // The kernel omits the value when it could not prove a closed solid.
+    // Reading that as 0 would report a confident, wrong total for an open
+    // shell — exactly what #2199 §2 asks the tool not to do.
+    const r = rollupGeometryVolumes([undefined, undefined]);
+    assert.strictEqual(r.proved, 0);
+    assert.strictEqual(r.unproved, 2);
+    assert.strictEqual(r.total, 0);
+  });
+
+  it('treats a non-finite volume as unproved rather than trusting it', () => {
+    const r = rollupGeometryVolumes([NaN, Infinity, 3]);
+    assert.strictEqual(r.total, 3);
+    assert.strictEqual(r.proved, 1);
+    assert.strictEqual(r.unproved, 2);
+  });
+
+  it('keeps a real zero volume as proved', () => {
+    // A proved 0 is a legitimate (degenerate) answer and must not be confused
+    // with the absent case above.
+    const r = rollupGeometryVolumes([0]);
+    assert.strictEqual(r.proved, 1);
+    assert.strictEqual(r.unproved, 0);
+  });
+
+  it('is all zeroes for an empty selection', () => {
+    assert.deepStrictEqual(rollupGeometryVolumes([]), { total: 0, proved: 0, unproved: 0 });
+  });
+});

--- a/apps/viewer/src/components/viewer/tools/measure-modes/quantities.test.ts
+++ b/apps/viewer/src/components/viewer/tools/measure-modes/quantities.test.ts
@@ -174,6 +174,50 @@ describe('pickElementQuantities', () => {
     assert.deepStrictEqual(pickElementQuantities([]), []);
     assert.deepStrictEqual(pickElementQuantities([qset('Qto_Empty', [])]), []);
   });
+
+  describe('SI normalisation', () => {
+    it('applies the converter, so a millimetre file does not out-sum a metre one', () => {
+      // A mm-declared model reports a 2 m³ volume as 2e9 mm³. Adding that to a
+      // metre model's 2 without normalising is off by a factor of a billion —
+      // and the total still looks like a number, which is what makes it bad.
+      const mmToSi = (v: number, t: number) => (t === Volume ? v * 1e-9 : v);
+      const picked = pickElementQuantities(
+        [qset('Qto_A', [{ name: 'NetVolume', type: Volume, value: 2e9 }])],
+        mmToSi,
+      );
+      assert.ok(Math.abs(picked[0].value - 2) < 1e-9, `expected 2, got ${picked[0].value}`);
+    });
+
+    it('leaves values untouched when no converter is supplied', () => {
+      const picked = pickElementQuantities([
+        qset('Qto_A', [{ name: 'NetVolume', type: Volume, value: 2 }]),
+      ]);
+      assert.strictEqual(picked[0].value, 2);
+    });
+
+    it('passes the quantity type to the converter so each family scales alone', () => {
+      // A mm file's area scale is 1e-6 while its volume scale is 1e-9 — one
+      // scale for everything is wrong for at least one of them.
+      const seen: number[] = [];
+      pickElementQuantities(
+        [qset('Qto_A', [
+          { name: 'NetArea', type: Area, value: 1 },
+          { name: 'NetVolume', type: Volume, value: 1 },
+        ])],
+        (v, t) => { seen.push(t); return v; },
+      );
+      assert.deepStrictEqual(seen.sort(), [Area, Volume].sort());
+    });
+
+    it('drops a value the converter turned non-finite', () => {
+      // The raw value passed the finiteness check; what came back did not.
+      const picked = pickElementQuantities(
+        [qset('Qto_A', [{ name: 'NetVolume', type: Volume, value: 2 }])],
+        () => NaN,
+      );
+      assert.deepStrictEqual(picked, []);
+    });
+  });
 });
 
 describe('rollupQuantities', () => {

--- a/apps/viewer/src/components/viewer/tools/measure-modes/quantities.ts
+++ b/apps/viewer/src/components/viewer/tools/measure-modes/quantities.ts
@@ -1,0 +1,260 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Reading area / volume / weight / length off a model's own IfcElementQuantity
+ * data — issue #2199 §1 (element surface area), §2 (volume) and §6 (weight).
+ *
+ * Pure: it takes quantity sets that somebody else already extracted and
+ * decides which numbers are answerable and how they add up. Store walking,
+ * occurrence-vs-type fallback and unit rendering all live at the call site.
+ *
+ * TWO decisions here carry the whole correctness of the feature.
+ *
+ * **What kind of quantity it is comes from `QuantityType`, never from the
+ * name.** IFC names are open-ended — `NetSideArea`, `GrossFootprintArea`,
+ * `CrossSectionArea` are all areas, and no name list will ever be complete.
+ * The enum is authored by the parser off the STEP entity type
+ * (`IFCQUANTITYAREA` and friends), so it cannot be wrong the way a regex can.
+ *
+ * **Exactly one value per (type, basis) per element.** An element commonly
+ * declares several areas in one quantity set; adding them together would
+ * report a wall's area as the sum of its side, footprint and cross-section.
+ * So each bucket keeps a single value and the rest are dropped, with the name
+ * that won recorded so the reader can see which one it was.
+ */
+
+/**
+ * Whether a quantity includes or excludes openings, read off its name prefix.
+ *
+ * This is issue #2199 §1's "the result should indicate whether opening areas
+ * are included or excluded" — IFC already encodes it, in the Gross/Net naming
+ * convention, so the tool surfaces the distinction rather than inventing one.
+ * `unqualified` is its own case and NOT a synonym for either: a plain `Volume`
+ * makes no claim about openings, and quietly labelling it "net" would put a
+ * confidence on it that the file never expressed.
+ */
+export type QuantityBasis = 'net' | 'gross' | 'unqualified';
+
+/** The minimal shape this module needs from an extracted quantity set. */
+export interface QuantitySetLike {
+  name: string;
+  quantities: ReadonlyArray<{ name: string; type: number; value: number }>;
+}
+
+/** One quantity chosen to represent a (type, basis) bucket for one element. */
+export interface PickedQuantity {
+  /** `QuantityType` enum value — Length 0, Area 1, Volume 2, Weight 4. */
+  quantityType: number;
+  basis: QuantityBasis;
+  value: number;
+  /** `Qto_WallBaseQuantities.NetSideArea` — which number this actually was. */
+  provenance: string;
+}
+
+/**
+ * `QuantityType` values this tool reports. Count and Time are deliberately
+ * absent: they are not measurements of the building's geometry, and totalling
+ * them beside a volume would invite reading them as one.
+ */
+export const MEASURABLE_QUANTITY_TYPES = {
+  Length: 0,
+  Area: 1,
+  Volume: 2,
+  Weight: 4,
+} as const;
+
+const MEASURABLE: ReadonlySet<number> = new Set(Object.values(MEASURABLE_QUANTITY_TYPES));
+
+/**
+ * Preferred names within a (type, basis) bucket, most representative first.
+ *
+ * This only breaks ties — a name absent from the list still competes, it just
+ * loses to any listed name and to whichever unlisted name was seen first. The
+ * ordering encodes "which area does a person mean by *the* area of a wall",
+ * which no amount of type information can answer.
+ */
+const NAME_PREFERENCE: Readonly<Record<number, readonly string[]>> = {
+  [MEASURABLE_QUANTITY_TYPES.Length]: ['length', 'perimeter', 'height', 'width', 'depth'],
+  [MEASURABLE_QUANTITY_TYPES.Area]: [
+    'area',
+    'sidearea',
+    'surfacearea',
+    'floorarea',
+    'footprintarea',
+    'coveringarea',
+    'crosssectionarea',
+  ],
+  [MEASURABLE_QUANTITY_TYPES.Volume]: ['volume'],
+  [MEASURABLE_QUANTITY_TYPES.Weight]: ['weight'],
+};
+
+/**
+ * Classify a quantity name as net / gross / unqualified, and return the name
+ * with that prefix removed so the preference list can match on the stem.
+ */
+export function classifyBasis(name: string): { basis: QuantityBasis; stem: string } {
+  const lower = name.toLowerCase();
+  if (lower.startsWith('net')) return { basis: 'net', stem: lower.slice(3) };
+  if (lower.startsWith('gross')) return { basis: 'gross', stem: lower.slice(5) };
+  return { basis: 'unqualified', stem: lower };
+}
+
+/** Rank of a stem in its type's preference list; unlisted names rank last. */
+function preferenceRank(quantityType: number, stem: string): number {
+  const list = NAME_PREFERENCE[quantityType];
+  if (!list) return Number.MAX_SAFE_INTEGER;
+  const i = list.indexOf(stem);
+  return i === -1 ? Number.MAX_SAFE_INTEGER : i;
+}
+
+const bucketKey = (quantityType: number, basis: QuantityBasis) => `${quantityType}|${basis}`;
+
+/** Row order within one quantity type: net first, then gross, then unqualified. */
+const BASIS_ORDER: Readonly<Record<QuantityBasis, number>> = {
+  net: 0,
+  gross: 1,
+  unqualified: 2,
+};
+
+/**
+ * Choose at most one quantity per (type, basis) bucket for a single element.
+ *
+ * Non-finite values are skipped rather than carried: a `NaN` propagates
+ * through every downstream sum and turns an otherwise good total for fifty
+ * elements into no answer at all.
+ *
+ * The result is ordered by quantity type, then net / gross / unqualified, so
+ * two renders of the same element never reorder their rows.
+ */
+export function pickElementQuantities(
+  qsets: ReadonlyArray<QuantitySetLike>,
+): PickedQuantity[] {
+  const chosen = new Map<string, { picked: PickedQuantity; rank: number }>();
+
+  for (const qset of qsets) {
+    for (const q of qset.quantities) {
+      if (!MEASURABLE.has(q.type)) continue;
+      if (!Number.isFinite(q.value)) continue;
+
+      const { basis, stem } = classifyBasis(q.name);
+      const key = bucketKey(q.type, basis);
+      const rank = preferenceRank(q.type, stem);
+      const existing = chosen.get(key);
+      // Strictly-better only, so the FIRST of two equally-ranked names wins
+      // and the pick is stable under the extractor's set ordering.
+      if (existing && existing.rank <= rank) continue;
+
+      chosen.set(key, {
+        rank,
+        picked: {
+          quantityType: q.type,
+          basis,
+          value: q.value,
+          provenance: `${qset.name}.${q.name}`,
+        },
+      });
+    }
+  }
+
+  return [...chosen.values()]
+    .map((c) => c.picked)
+    .sort((a, b) =>
+      a.quantityType - b.quantityType || BASIS_ORDER[a.basis] - BASIS_ORDER[b.basis]);
+}
+
+/** A (type, basis) total across a selection of elements. */
+export interface QuantityRollup {
+  quantityType: number;
+  basis: QuantityBasis;
+  total: number;
+  /** How many elements contributed a value. Never more than the selection. */
+  contributing: number;
+  /**
+   * Distinct `Qset.Name` strings summed into this total, sorted. More than one
+   * means the selection was heterogeneous — a total mixing `NetSideArea` and
+   * `NetFloorArea` is still arithmetic, but the reader deserves to know.
+   */
+  provenance: string[];
+}
+
+/**
+ * Total each (type, basis) bucket across a selection.
+ *
+ * Takes one already-picked list PER ELEMENT rather than a flat list, because
+ * the no-double-counting guarantee is per element: flattening first would let
+ * one element's two area names both land in the same bucket again.
+ */
+export function rollupQuantities(
+  perElement: ReadonlyArray<ReadonlyArray<PickedQuantity>>,
+): QuantityRollup[] {
+  const buckets = new Map<string, QuantityRollup & { names: Set<string> }>();
+
+  for (const element of perElement) {
+    for (const picked of element) {
+      const key = bucketKey(picked.quantityType, picked.basis);
+      let bucket = buckets.get(key);
+      if (!bucket) {
+        bucket = {
+          quantityType: picked.quantityType,
+          basis: picked.basis,
+          total: 0,
+          contributing: 0,
+          provenance: [],
+          names: new Set<string>(),
+        };
+        buckets.set(key, bucket);
+      }
+      bucket.total += picked.value;
+      bucket.contributing += 1;
+      bucket.names.add(picked.provenance);
+    }
+  }
+
+  return [...buckets.values()]
+    .map(({ names, ...rest }) => ({ ...rest, provenance: [...names].sort() }))
+    .sort((a, b) =>
+      a.quantityType - b.quantityType || BASIS_ORDER[a.basis] - BASIS_ORDER[b.basis]);
+}
+
+/**
+ * Total of the kernel's proved geometry volumes across a selection.
+ *
+ * `MeshData.geometryVolume` is present only where the mesh pass could PROVE a
+ * single closed orientable solid, and absent otherwise — never zero. That
+ * absence is the answer issue #2199 §2 asks for ("report that the volume
+ * cannot be calculated reliably instead of returning an incorrect result"), so
+ * it is counted and reported rather than skipped silently.
+ *
+ * Callers must pass ONE entry per element. Every submesh of an entity carries
+ * the same whole-entity volume, so passing submeshes would multiply the total
+ * by the element's part count.
+ */
+export interface GeometryVolumeRollup {
+  /** Sum over the elements whose volume was proved. */
+  total: number;
+  /** Elements with a proved volume. */
+  proved: number;
+  /** Elements whose geometry the kernel could not prove a volume for. */
+  unproved: number;
+}
+
+export function rollupGeometryVolumes(
+  perElement: ReadonlyArray<number | undefined>,
+): GeometryVolumeRollup {
+  let total = 0;
+  let proved = 0;
+  let unproved = 0;
+  for (const v of perElement) {
+    // `undefined` means unproved; a non-finite number would poison the sum, so
+    // it is treated as unproved too rather than trusted for being a number.
+    if (v === undefined || !Number.isFinite(v)) {
+      unproved += 1;
+      continue;
+    }
+    total += v;
+    proved += 1;
+  }
+  return { total, proved, unproved };
+}

--- a/apps/viewer/src/components/viewer/tools/measure-modes/quantities.ts
+++ b/apps/viewer/src/components/viewer/tools/measure-modes/quantities.ts
@@ -48,10 +48,30 @@ export interface PickedQuantity {
   /** `QuantityType` enum value — Length 0, Area 1, Volume 2, Weight 4. */
   quantityType: number;
   basis: QuantityBasis;
+  /**
+   * The value, in whatever unit {@link ToSiConverter} produced — SI base when
+   * one was supplied, the file's raw declared unit when it was not.
+   */
   value: number;
   /** `Qto_WallBaseQuantities.NetSideArea` — which number this actually was. */
   provenance: string;
 }
+
+/**
+ * Converts one raw quantity value from the file's declared unit into SI base
+ * (metres, square metres, cubic metres, kilograms).
+ *
+ * This exists because a federation can mix units: a millimetre model and a
+ * metre model both declare a `NetVolume`, and adding those numbers as they
+ * stand is off by a factor of a billion. Normalising at pick time — while the
+ * value is still next to the `ProjectUnits` that explain it — is the only
+ * point where the file unit is still known.
+ *
+ * Omitting it is legitimate ONLY when every value is already SI.
+ */
+export type ToSiConverter = (value: number, quantityType: number) => number;
+
+const IDENTITY_SI: ToSiConverter = (value) => value;
 
 /**
  * `QuantityType` values this tool reports. Count and Time are deliberately
@@ -130,6 +150,7 @@ const BASIS_ORDER: Readonly<Record<QuantityBasis, number>> = {
  */
 export function pickElementQuantities(
   qsets: ReadonlyArray<QuantitySetLike>,
+  toSi: ToSiConverter = IDENTITY_SI,
 ): PickedQuantity[] {
   const chosen = new Map<string, { picked: PickedQuantity; rank: number }>();
 
@@ -146,12 +167,18 @@ export function pickElementQuantities(
       // and the pick is stable under the extractor's set ordering.
       if (existing && existing.rank <= rank) continue;
 
+      const si = toSi(q.value, q.type);
+      // A converter that returns garbage must not poison the total either —
+      // the finiteness check above was on the RAW value, which says nothing
+      // about what came back.
+      if (!Number.isFinite(si)) continue;
+
       chosen.set(key, {
         rank,
         picked: {
           quantityType: q.type,
           basis,
-          value: q.value,
+          value: si,
           provenance: `${qset.name}.${q.name}`,
         },
       });

--- a/apps/viewer/src/components/viewer/tools/measure-parity.test.tsx
+++ b/apps/viewer/src/components/viewer/tools/measure-parity.test.tsx
@@ -77,6 +77,23 @@ function render(): HTMLElement {
   return container;
 }
 
+/**
+ * The LABEL of the coordinate row whose value matches `value`.
+ *
+ * Reads the rendered label cell rather than searching the panel text for the
+ * word: the frame name also appears in the explanatory footnote and can appear
+ * in a model's own name, so a text-wide `/Anchor/` would pass no matter what
+ * the row is actually called.
+ */
+function coordRowLabel(container: HTMLElement, value: RegExp): string {
+  const row = [...container.querySelectorAll('div')].find((d) => {
+    const spans = d.querySelectorAll(':scope > span');
+    return spans.length >= 2 && value.test(spans[1].textContent ?? '');
+  });
+  assert.ok(row, `no coordinate row whose value matches ${value}`);
+  return row.querySelector(':scope > span')?.textContent?.trim() ?? '';
+}
+
 /** Click the panel's section button whose label is `label`. */
 function openSection(container: HTMLElement, label: string): void {
   const button = [...container.querySelectorAll('button')].find(
@@ -371,16 +388,15 @@ describe('each printed number comes from the source it claims', () => {
       measurements: [{ id: 'm1', start: START, end: END, distance: Math.hypot(3, 3, 4) }],
       models: new Map([['m1', federatedModel({
         id: 'm1',
-        name: 'Anchor file',
+        name: 'Base file',
         federationAlignmentStatus: 'anchor',
         geometryResult: { meshes: [], coordinateInfo: {} },
       })]]),
     });
     const container = render();
     openSection(container, 'Point');
-    const text = container.textContent ?? '';
-    assert.match(text, /Model/, text);
-    assert.doesNotMatch(text, /Anchor coordinates|re-based/, text);
+    assert.equal(coordRowLabel(container, /X 3\.000/), 'Model');
+    assert.doesNotMatch(container.textContent ?? '', /re-based/, container.textContent ?? '');
   });
 
   it('labels a picked point Anchor once alignment re-based another model into the frame', () => {
@@ -389,7 +405,7 @@ describe('each printed number comes from the source it claims', () => {
       models: new Map([
         ['m1', federatedModel({
           id: 'm1',
-          name: 'Anchor file',
+          name: 'Base file',
           loadedAt: 1,
           federationAlignmentStatus: 'anchor',
           geometryResult: { meshes: [], coordinateInfo: {} },
@@ -409,8 +425,12 @@ describe('each printed number comes from the source it claims', () => {
     // The numbers are unchanged — they are the scene's frame either way. What
     // changes is the claim made about whose coordinate system they are in.
     assert.match(text, /X 3\.000\s+Y 4\.000\s+Z 3\.000/, `coordinates changed: ${text}`);
-    assert.match(text, /Anchor/, `the row is still labelled as the picked file's own: ${text}`);
-    assert.match(text, /re-based one or more models into Anchor file's frame/, text);
+    assert.equal(
+      coordRowLabel(container, /X 3\.000/),
+      'Anchor',
+      `the row is still labelled as the picked file's own: ${text}`,
+    );
+    assert.match(text, /re-based one or more models into Base file's frame/, text);
   });
 });
 

--- a/apps/viewer/src/components/viewer/tools/measure-parity.test.tsx
+++ b/apps/viewer/src/components/viewer/tools/measure-parity.test.tsx
@@ -1,0 +1,265 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Both-toolbar guard for the Measure tool (#2199).
+ *
+ * The viewer ships two desktop toolbars at once — the classic `MainToolbar`
+ * strip and the tabbed ribbon — and a user sits behind exactly one of them.
+ * #2510 and #2511 close that gap for camera and export by giving each a single
+ * ordered command registry plus a drift guard.
+ *
+ * Measure does not need a registry, and adding one would be the wrong fix: the
+ * two toolbars do not host measurement UI at all. Each does one thing —
+ * `setActiveTool('measure')` — and `ToolOverlays` renders the ONE panel off
+ * that store field. There is no second list to drift from the first.
+ *
+ * What CAN drift is that structure itself, in three ways, and this file guards
+ * each:
+ *
+ * 1. a toolbar stops dispatching `'measure'` (the ribbon-only search bug of
+ *    #2510, in its measure-shaped form);
+ * 2. a toolbar grows its own measurement UI beside the shared panel, which is
+ *    how two hand-maintained lists get created in the first place;
+ * 3. the shared panel stops hosting a section, so the section's own tests stay
+ *    green while the feature ships unreachable — the exact hole #2510 and
+ *    #2511 each found in their first guard.
+ *
+ * (3) is asserted by DRIVING `ToolOverlays`, the real host, not by rendering
+ * the section components directly: a section is proven only by clicking its
+ * button on the shipped panel and reading the numbers that come back.
+ *
+ * (1) and (2) are asserted in source with import statements stripped first —
+ * neither toolbar can be mounted in the node runner (`MainToolbar` drags in the
+ * whole viewer; `HomeTab` reaches `@/icons`, a Vite virtual module), and an
+ * import line left behind after the JSX was deleted is precisely what kept
+ * #2510's first guard green on the regression it existed to catch.
+ */
+
+import '@/test/setup-dom.js';
+import { describe, it, beforeEach, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { useViewerStore } from '@/store/index.js';
+import { ToolOverlays } from '../ToolOverlays.js';
+
+const here = fileURLToPath(new URL('.', import.meta.url));
+const read = (rel: string) => readFileSync(new URL(rel, import.meta.url), 'utf8');
+
+/** Source with every `import ... from '...'` statement removed, so a leftover
+ *  import can never stand in for a rendered control. */
+function withoutImports(source: string): string {
+  return source.replace(/^\s*import\s[\s\S]*?from\s*['"][^'"]+['"];?\s*$/gm, '');
+}
+
+const mounted: Array<{ root: Root; container: HTMLElement }> = [];
+
+function render(): HTMLElement {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(<ToolOverlays />);
+  });
+  mounted.push({ root, container });
+  return container;
+}
+
+/** Click the panel's section button whose label is `label`. */
+function openSection(container: HTMLElement, label: string): void {
+  const button = [...container.querySelectorAll('button')].find(
+    (b) => b.textContent?.trim() === label,
+  );
+  assert.ok(button, `no section button labelled "${label}" on the measure panel`);
+  act(() => {
+    button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
+}
+
+/**
+ * Unmount everything from the previous test BEFORE the next one seeds the
+ * store. A root left mounted re-renders on that seeding, which is both a
+ * React act() warning and a live component reading a half-built state it would
+ * never see in the app. Each root is unmounted in its OWN `act()`: batching
+ * them into one would let a throw from the first leave the rest mounted.
+ */
+function unmountAll(): void {
+  for (const { root, container } of mounted.splice(0)) {
+    act(() => root.unmount());
+    container.remove();
+  }
+}
+
+after(unmountAll);
+
+/**
+ * A measurement whose endpoints are chosen so every derived readout has a
+ * DISTINCT expected value — a 3-4-5 triangle in the horizontal plane with a
+ * 3 m rise, in renderer (Y-up) space.
+ *
+ * Renderer end point (3, 3, -4) is IFC (3, 4, 3): horizontal run 5, rise 3,
+ * so 30.96 degrees, 60% and 1:1.7. Swapping any axis or dropping the northing
+ * negation changes at least one printed number.
+ */
+/** `screenX`/`screenY` are the label anchors; nothing asserted here reads them. */
+const START = { x: 0, y: 0, z: 0, screenX: 0, screenY: 0 };
+const END = { x: 3, y: 3, z: -4, screenX: 0, screenY: 0 };
+
+/**
+ * A data store that resolves but declares nothing: zero-length `source` sends
+ * the extractor down its pre-computed-table path, and that table is empty. It
+ * isolates the geometry-volume half of the Qty section from the declared half.
+ */
+const EMPTY_STORE = {
+  source: new Uint8Array(),
+  quantities: { getForEntity: () => [] },
+  relationships: null,
+} as never;
+
+beforeEach(() => {
+  unmountAll();
+  useViewerStore.setState({
+    activeTool: 'measure',
+    measurements: [],
+    activeMeasurement: null,
+    pendingMeasurePoint: null,
+    measureReferencePoint: null,
+    selectedEntity: null,
+    selectedEntitiesSet: new Set<string>(),
+    models: new Map(),
+    ifcDataStore: null,
+    geometryResult: null,
+  });
+});
+
+describe('measure tool is hosted once, for both toolbars', () => {
+  it('renders the shared panel off activeTool alone, with all three sections', () => {
+    const container = render();
+    const labels = [...container.querySelectorAll('button')].map((b) => b.textContent?.trim());
+    for (const section of ['List', 'Point', 'Qty']) {
+      assert.ok(labels.includes(section), `missing "${section}" section button; saw ${labels.join(', ')}`);
+    }
+  });
+
+  it('does not render the panel for another tool', () => {
+    useViewerStore.setState({ activeTool: 'select' });
+    const container = render();
+    assert.equal(container.textContent?.includes('Drag to measure'), false);
+  });
+
+  it('both toolbars dispatch the measure tool, and neither hosts measurement UI of its own', () => {
+    const surfaces: Array<{ name: string; source: string }> = [
+      { name: 'MainToolbar (classic)', source: withoutImports(read('../MainToolbar.tsx')) },
+      { name: 'HomeTab (ribbon)', source: withoutImports(read('../ribbon/tabs/HomeTab.tsx')) },
+    ];
+
+    for (const { name, source } of surfaces) {
+      assert.match(
+        source,
+        /(setActiveTool\(\s*'measure'\s*\)|tool="measure")/,
+        `${name} no longer dispatches the measure tool`,
+      );
+      // A toolbar that reaches for the panel or its sections is building the
+      // second hand-maintained list this structure exists to avoid.
+      assert.doesNotMatch(
+        source,
+        /Measure(Overlay|Panel|Quantities|PointReadout)/,
+        `${name} hosts measurement UI of its own; it must only set the tool`,
+      );
+    }
+  });
+
+  it('ToolOverlays is mounted in one shared place, not per toolbar', () => {
+    const hosts = ['ViewportContainer.tsx', 'MainToolbar.tsx', 'ribbon/RibbonToolbar.tsx'].filter(
+      (f) => /<ToolOverlays\s*\/>/.test(withoutImports(read(`../${f}`))),
+    );
+    assert.deepEqual(hosts, ['ViewportContainer.tsx']);
+  });
+});
+
+describe('the shipped panel hosts each #2199 section', () => {
+  it('List shows inclination alongside the existing distance breakdown', () => {
+    useViewerStore.setState({
+      measurements: [{ id: 'm1', start: START, end: END, distance: Math.hypot(3, 3, 4) }],
+    });
+    const container = render();
+    openSection(container, 'List');
+    const text = container.textContent ?? '';
+    // 3 m rise over a 5 m run: 30.96 degrees, 60.0%, 1:1.7.
+    assert.match(text, /31\.0°/, `no inclination degrees in the List section: ${text}`);
+    assert.match(text, /60\.0%/, `no slope percent in the List section: ${text}`);
+    assert.match(text, /1:1\.7/, `no slope ratio in the List section: ${text}`);
+  });
+
+  it('Point shows the picked point in IFC axes, and its offset from a set reference', () => {
+    useViewerStore.setState({
+      measurements: [{ id: 'm1', start: START, end: END, distance: Math.hypot(3, 3, 4) }],
+      // A datum one metre below the origin in renderer Y, i.e. IFC Z -1.
+      measureReferencePoint: { x: 0, y: -1, z: 0 },
+    });
+    const container = render();
+    openSection(container, 'Point');
+    const text = container.textContent ?? '';
+    // Renderer (3, 3, -4) -> IFC (3, 4, 3). The northing is +4, not -4: the
+    // sign is what a dropped negation would flip.
+    assert.match(text, /X 3\.000\s+Y 4\.000\s+Z 3\.000/, `wrong model coordinates: ${text}`);
+    // Offset from IFC (0, 0, -1) is (3, 4, 4).
+    assert.match(text, /X 3\.000\s+Y 4\.000\s+Z 4\.000/, `wrong relative offset: ${text}`);
+  });
+
+  it('Qty answers for an empty selection instead of rendering nothing', () => {
+    const container = render();
+    openSection(container, 'Qty');
+    assert.match(container.textContent ?? '', /Select elements to read their quantities/);
+  });
+
+  it('Qty reports the kernel volume and states the openings convention beside it', () => {
+    useViewerStore.setState({
+      selectedEntitiesSet: new Set(['legacy:42']),
+      ifcDataStore: EMPTY_STORE,
+      geometryResult: {
+        meshes: [
+          // Two submeshes of ONE element, each carrying the same whole-entity
+          // volume. Counting per mesh instead of per element would print 5.
+          { expressId: 42, geometryVolume: 2.5 },
+          { expressId: 42, geometryVolume: 2.5 },
+        ],
+      } as never,
+    });
+    const container = render();
+    openSection(container, 'Qty');
+    const text = container.textContent ?? '';
+    assert.match(text, /Volume mesh\s*2\.5 m³/, `wrong mesh volume readout: ${text}`);
+    assert.match(
+      text,
+      /net = openings excluded · gross = openings included · mesh = as built,\s*after opening cuts/,
+      `the openings convention is not stated beside the numbers: ${text}`,
+    );
+  });
+
+  it('Qty says why it has no answer rather than rendering an empty box', () => {
+    useViewerStore.setState({
+      // Selected, but no store resolves for the ref: nothing is declared and
+      // nothing is proved.
+      selectedEntitiesSet: new Set(['legacy:42']),
+    });
+    const container = render();
+    openSection(container, 'Qty');
+    const text = container.textContent ?? '';
+    assert.match(text, /declares no quantities/, text);
+    assert.match(text, /could not\s+be resolved to a loaded model/, text);
+  });
+});
+
+/** The path assertions above are only meaningful if the files exist. */
+describe('guard sanity', () => {
+  it('reads real toolbar sources', () => {
+    for (const rel of ['../MainToolbar.tsx', '../ribbon/tabs/HomeTab.tsx', '../ViewportContainer.tsx']) {
+      assert.ok(read(rel).length > 500, `${rel} did not resolve to real source (from ${here})`);
+    }
+  });
+});

--- a/apps/viewer/src/components/viewer/tools/measure-parity.test.tsx
+++ b/apps/viewer/src/components/viewer/tools/measure-parity.test.tsx
@@ -53,6 +53,7 @@ import { fileURLToPath } from 'node:url';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { useViewerStore } from '@/store/index.js';
+import { useRenderFrameOffsets } from '@/hooks/useRenderFrameOffsets.js';
 import { ToolOverlays } from '../ToolOverlays.js';
 
 const here = fileURLToPath(new URL('.', import.meta.url));
@@ -461,5 +462,112 @@ describe('guard sanity', () => {
     for (const rel of ['../MainToolbar.tsx', '../ribbon/tabs/HomeTab.tsx', '../ViewportContainer.tsx']) {
       assert.ok(read(rel).length > 500, `${rel} did not resolve to real source (from ${here})`);
     }
+  });
+
+  describe('one frame per scene, resolved in one place', () => {
+    it('takes BOTH offsets from the same (earliest) model', () => {
+      // The defect this pins is a MIX: the anchor's `wasmRtcOffset` with the
+      // selected model's `originShift`. The two models below carry offsets that
+      // are distinguishable on every axis, so any cross-pairing is visible.
+      const seen: Array<{ originShift: unknown; wasmRtcOffsetIfc: unknown }> = [];
+      function Probe() {
+        const f = useRenderFrameOffsets();
+        seen.push({ originShift: f.originShift, wasmRtcOffsetIfc: f.wasmRtcOffsetIfc });
+        return null;
+      }
+      useViewerStore.setState({
+        geometryResult: null,
+        models: new Map([
+          ['m1', federatedModel({
+            id: 'm1', loadedAt: 1, federationAlignmentStatus: 'anchor',
+            geometryResult: { meshes: [], coordinateInfo: {
+              originShift: { x: 1, y: 2, z: 3 },
+              wasmRtcOffset: { x: 10, y: 20, z: 30 },
+            } },
+          })],
+          ['m2', federatedModel({
+            id: 'm2', loadedAt: 2, federationAlignmentStatus: 'identity',
+            geometryResult: { meshes: [], coordinateInfo: {
+              originShift: { x: 7, y: 8, z: 9 },
+              wasmRtcOffset: { x: 70, y: 80, z: 90 },
+            } },
+          })],
+        ]),
+      });
+      const host = document.createElement('div');
+      document.body.appendChild(host);
+      const probeRoot = createRoot(host);
+      try {
+        act(() => probeRoot.render(<Probe />));
+        assert.deepEqual(seen.at(-1), {
+          originShift: { x: 1, y: 2, z: 3 },
+          wasmRtcOffsetIfc: { x: 10, y: 20, z: 30 },
+        }, 'both offsets must come from the earliest-loaded model');
+      } finally {
+        act(() => probeRoot.unmount());
+        host.remove();
+        useViewerStore.setState({ models: new Map() });
+      }
+    });
+
+    it('the Properties panel resolves the frame through that hook, not its own loop', () => {
+      // A second copy of "which model owns the frame" is how the two readouts
+      // drifted in the first place. Imports are stripped so a leftover one
+      // cannot stand in for a call.
+      const body = withoutImports(read('../PropertiesPanel.tsx'));
+      assert.match(body, /useRenderFrameOffsets\(\)/, 'PropertiesPanel must use the shared resolver');
+      assert.doesNotMatch(
+        body,
+        /coordinateInfo\?\.wasmRtcOffset/,
+        'and must not re-derive the frame from a model of its own choosing',
+      );
+    });
+  });
+
+  describe('a quantity is only ever read from the element\'s OWN model', () => {
+    it('does not fall back to the legacy store for an unresolved federated ref', () => {
+      // A federated id that is not in `models` must be REPORTED as unresolved,
+      // not answered from whichever store happens to be lying around: the same
+      // express id in another file is a different element.
+      useViewerStore.setState({
+        selectedEntitiesSet: new Set(['ghost-model:42']),
+        models: new Map([['m1', federatedModel({ id: 'm1' })]]),
+        ifcDataStore: {
+          source: new Uint8Array(),
+          relationships: null,
+          quantities: {
+            getForEntity: () => [
+              { name: 'Qto_WallBaseQuantities', quantities: [{ name: 'NetVolume', type: 2, value: 99 }] },
+            ],
+          },
+        } as never,
+      });
+      const container = render();
+      openSection(container, 'Qty');
+      const text = container.textContent ?? '';
+      assert.doesNotMatch(text, /99/, `another model's quantity was reported as this element's: ${text}`);
+      assert.match(text, /could not\s+be resolved to a loaded model/, text);
+    });
+
+    it('still answers a legacy ref from the legacy store', () => {
+      // The control: narrowing the fallback must not break the single-model
+      // path, which is the common one.
+      useViewerStore.setState({
+        selectedEntitiesSet: new Set(['legacy:42']),
+        models: new Map(),
+        ifcDataStore: {
+          source: new Uint8Array(),
+          relationships: null,
+          quantities: {
+            getForEntity: () => [
+              { name: 'Qto_WallBaseQuantities', quantities: [{ name: 'NetVolume', type: 2, value: 5 }] },
+            ],
+          },
+        } as never,
+      });
+      const container = render();
+      openSection(container, 'Qty');
+      assert.match(container.textContent ?? '', /Volume net\s*5 m³/, container.textContent ?? '');
+    });
   });
 });

--- a/apps/viewer/src/components/viewer/tools/measure-parity.test.tsx
+++ b/apps/viewer/src/components/viewer/tools/measure-parity.test.tsx
@@ -30,6 +30,14 @@
  * the section components directly: a section is proven only by clicking its
  * button on the shipped panel and reading the numbers that come back.
  *
+ * That same harness then earns its keep a second time. The last describe block
+ * pins WHERE each printed number is allowed to come from — the instanced-only
+ * volume side channel, the server-parsed quantity table, a federated model
+ * whose volumes alignment invalidated, and the frame a picked point is
+ * genuinely expressed in. Each of those is a place where a plausible number
+ * can be printed from the wrong source, which is invisible to a test that only
+ * checks a number appeared.
+ *
  * (1) and (2) are asserted in source with import statements stripped first —
  * neither toolbar can be mounted in the node runner (`MainToolbar` drags in the
  * whole viewer; `HomeTab` reaches `@/icons`, a Vite virtual module), and an
@@ -252,6 +260,178 @@ describe('the shipped panel hosts each #2199 section', () => {
     const text = container.textContent ?? '';
     assert.match(text, /declares no quantities/, text);
     assert.match(text, /could not\s+be resolved to a loaded model/, text);
+  });
+});
+
+/**
+ * One federated model entry, minimal but REAL in the fields the panel reads:
+ * `idOffset` (global-id maths), `federationAlignmentStatus` (volume trust and
+ * frame provenance), `loadedAt` (which model owns the render frame) and
+ * `coordinateInfo` (the shift to undo).
+ */
+function federatedModel(over: Record<string, unknown>) {
+  return {
+    id: 'm',
+    name: 'model',
+    ifcDataStore: EMPTY_STORE,
+    geometryResult: null,
+    visible: true,
+    idOffset: 0,
+    maxExpressId: 100000,
+    loadedAt: 1,
+    ...over,
+  } as never;
+}
+
+describe('each printed number comes from the source it claims', () => {
+  it('reads the proved volume of a GPU-instanced-only element from the side channel', () => {
+    // The geometry pass drops the flat mesh for a fully instanced entity and
+    // parks its volume here instead. `meshes` is EMPTY on purpose: an
+    // implementation that only walks meshes reports this element as having no
+    // provable volume while the answer is right there.
+    useViewerStore.setState({
+      selectedEntitiesSet: new Set(['legacy:42']),
+      ifcDataStore: EMPTY_STORE,
+      geometryResult: {
+        meshes: [],
+        instancedGeometryVolumes: new Map([[42, 3.25]]),
+      } as never,
+    });
+    const container = render();
+    openSection(container, 'Qty');
+    const text = container.textContent ?? '';
+    assert.match(text, /Volume mesh\s*3\.25 m³/, `instanced-only volume not reported: ${text}`);
+  });
+
+  it('reads type-declared quantities on the server-parsed path, where the source is empty', () => {
+    // `store.source` is zero-length, which is what a server-parsed store looks
+    // like — the on-demand TYPE extractor returns null outright there, and the
+    // type's own sets live in the prebuilt table keyed by the TYPE's id.
+    const SERVER_STORE = {
+      source: new Uint8Array(),
+      relationships: { getRelated: () => [7] },
+      quantities: {
+        getForEntity: (id: number) =>
+          id === 7
+            ? [{ name: 'Qto_WallBaseQuantities', quantities: [{ name: 'NetVolume', type: 2, value: 4 }] }]
+            : [],
+      },
+    } as never;
+    useViewerStore.setState({
+      selectedEntitiesSet: new Set(['legacy:42']),
+      ifcDataStore: SERVER_STORE,
+      geometryResult: null,
+    });
+    const container = render();
+    openSection(container, 'Qty');
+    const text = container.textContent ?? '';
+    assert.match(text, /Volume net\s*4 m³/, `type quantities lost on the server path: ${text}`);
+  });
+
+  it('reports a federated model\'s proved volume when alignment left its vertices alone', () => {
+    useViewerStore.setState({
+      selectedEntitiesSet: new Set(['m1:42']),
+      models: new Map([['m1', federatedModel({
+        id: 'm1',
+        federationAlignmentStatus: 'anchor',
+        geometryResult: { meshes: [{ expressId: 42, geometryVolume: 2.5 }] },
+      })]]),
+    });
+    const container = render();
+    openSection(container, 'Qty');
+    const text = container.textContent ?? '';
+    assert.match(text, /Volume mesh\s*2\.5 m³/, `an anchored model's volume must be reported: ${text}`);
+    assert.doesNotMatch(text, /withheld/, text);
+  });
+
+  it('withholds — and explains — the proved volume of a model alignment rescaled', () => {
+    // Same model, same stored volume; only the alignment status differs. #1993:
+    // 'reprojected' re-baked every vertex through a map carrying a scale, so
+    // the stored 2.5 m³ describes geometry at a size that is no longer drawn.
+    useViewerStore.setState({
+      selectedEntitiesSet: new Set(['m1:42']),
+      models: new Map([['m1', federatedModel({
+        id: 'm1',
+        federationAlignmentStatus: 'reprojected',
+        geometryResult: { meshes: [{ expressId: 42, geometryVolume: 2.5 }] },
+      })]]),
+    });
+    const container = render();
+    openSection(container, 'Qty');
+    const text = container.textContent ?? '';
+    assert.doesNotMatch(text, /2\.5 m³/, `a rescaled model's stale volume was printed: ${text}`);
+    assert.match(text, /federation alignment rescaled/, `the withholding is not explained: ${text}`);
+    // NOT folded into the kernel's "could not prove" count: those are two
+    // different statements and the panel must not blur them.
+    assert.doesNotMatch(text, /had no\s+provable enclosed volume/, text);
+  });
+
+  it('labels a picked point Model when no model was re-based into the scene frame', () => {
+    useViewerStore.setState({
+      measurements: [{ id: 'm1', start: START, end: END, distance: Math.hypot(3, 3, 4) }],
+      models: new Map([['m1', federatedModel({
+        id: 'm1',
+        name: 'Anchor file',
+        federationAlignmentStatus: 'anchor',
+        geometryResult: { meshes: [], coordinateInfo: {} },
+      })]]),
+    });
+    const container = render();
+    openSection(container, 'Point');
+    const text = container.textContent ?? '';
+    assert.match(text, /Model/, text);
+    assert.doesNotMatch(text, /Anchor coordinates|re-based/, text);
+  });
+
+  it('labels a picked point Anchor once alignment re-based another model into the frame', () => {
+    useViewerStore.setState({
+      measurements: [{ id: 'm1', start: START, end: END, distance: Math.hypot(3, 3, 4) }],
+      models: new Map([
+        ['m1', federatedModel({
+          id: 'm1',
+          name: 'Anchor file',
+          loadedAt: 1,
+          federationAlignmentStatus: 'anchor',
+          geometryResult: { meshes: [], coordinateInfo: {} },
+        })],
+        ['m2', federatedModel({
+          id: 'm2',
+          name: 'Second file',
+          loadedAt: 2,
+          federationAlignmentStatus: 'same-crs',
+          geometryResult: { meshes: [], coordinateInfo: {} },
+        })],
+      ]),
+    });
+    const container = render();
+    openSection(container, 'Point');
+    const text = container.textContent ?? '';
+    // The numbers are unchanged — they are the scene's frame either way. What
+    // changes is the claim made about whose coordinate system they are in.
+    assert.match(text, /X 3\.000\s+Y 4\.000\s+Z 3\.000/, `coordinates changed: ${text}`);
+    assert.match(text, /Anchor/, `the row is still labelled as the picked file's own: ${text}`);
+    assert.match(text, /re-based one or more models into Anchor file's frame/, text);
+  });
+});
+
+describe('the relative-coordinate datum belongs to the scene it was picked in', () => {
+  it('survives clearing the measurement list', () => {
+    useViewerStore.setState({ measureReferencePoint: { x: 1, y: 2, z: 3 } });
+    useViewerStore.getState().clearMeasurements();
+    assert.deepEqual(
+      useViewerStore.getState().measureReferencePoint,
+      { x: 1, y: 2, z: 3 },
+      'tidying a distance list must not move the user\'s setting-out origin',
+    );
+  });
+
+  it('is dropped when a new primary file replaces the scene', () => {
+    // The datum is stored in RENDERER space. Carried into the next model it
+    // would subtract a point from the outgoing scene and print a plausible,
+    // meaningless offset.
+    useViewerStore.setState({ measureReferencePoint: { x: 1, y: 2, z: 3 } });
+    useViewerStore.getState().resetViewerState();
+    assert.equal(useViewerStore.getState().measureReferencePoint, null);
   });
 });
 

--- a/apps/viewer/src/hooks/useRenderFrameOffsets.ts
+++ b/apps/viewer/src/hooks/useRenderFrameOffsets.ts
@@ -4,27 +4,50 @@
 
 /**
  * The offsets the geometry pipeline applied to get the loaded model(s) into
- * the render frame, for turning a picked renderer-space point back into the
- * model's own world coordinates (#2199 §5).
+ * the render frame, for turning a picked renderer-space point back into world
+ * coordinates (#2199 §5).
  *
  * Unlike the Properties panel — which resolves these per SELECTED ENTITY, and
  * so per model — a picked point has no model of its own. It lands wherever the
  * cursor hit the shared scene. The scene has exactly one frame, so this
- * resolves the frame ONCE, from the earliest-loaded model.
+ * resolves the frame ONCE, from the earliest-loaded model: a federation is
+ * aligned to the first model's RTC frame at load (see `geometry-parallel`'s
+ * alignment pass), so the first model's offsets ARE the scene's offsets.
+ * Reading a later model's offsets instead would report a point's coordinates
+ * against a frame the scene is not actually drawn in.
  *
- * That is not an approximation: a federation is aligned to the first model's
- * RTC frame at load (see `geometry-parallel`'s alignment pass), so the first
- * model's offsets ARE the scene's offsets. Reading a later model's offsets
- * instead would report a point's world coordinates against a frame the scene
- * is not actually drawn in.
+ * That makes the NUMBERS right in every case, and the LABEL right in all but
+ * one. When alignment actually re-based another model into this frame
+ * (`'same-crs'` / `'reprojected'`), a point picked on that model comes back in
+ * the ANCHOR file's coordinate system, not in its own file's — the two differ
+ * by exactly the transform alignment applied. Since a picked point carries no
+ * model, there is nothing to invert against; what there is instead is the
+ * truth, so {@link RenderFrameProvenance.rebased} is reported and the readout
+ * labels the row for the frame it is genuinely in. Same rule as the rest of
+ * #2199: state the basis, do not pick one silently.
  */
 
 import { useMemo } from 'react';
 import type { CoordinateInfo } from '@ifc-lite/geometry';
 import { useViewerStore } from '@/store';
+import { geometryVolumesSurviveAlignment } from '@/lib/compare/alignmentTrust';
 import type { RenderFrameOffsets } from '@/components/viewer/tools/measure-modes/coordinates';
 
-export function useRenderFrameOffsets(): RenderFrameOffsets {
+/** Whose coordinate system a reconstructed world point is actually in. */
+export interface RenderFrameProvenance {
+  /**
+   * True when at least one OTHER loaded model was re-based into this frame by
+   * federation alignment, so "world" means the anchor file's coordinate
+   * system rather than necessarily the picked model's own.
+   */
+  rebased: boolean;
+  /** Name of the model that owns the frame, when it can be named. */
+  anchorName: string | null;
+}
+
+export type RenderFrameResult = RenderFrameOffsets & RenderFrameProvenance;
+
+export function useRenderFrameOffsets(): RenderFrameResult {
   const models = useViewerStore((s) => s.models);
   const geometryResult = useViewerStore((s) => s.geometryResult);
 
@@ -33,11 +56,18 @@ export function useRenderFrameOffsets(): RenderFrameOffsets {
     // was aligned to.
     let earliest = Infinity;
     let info: CoordinateInfo | null = null;
+    let anchorName: string | null = null;
+    let rebased = false;
     for (const [, m] of models) {
       if (m.loadedAt < earliest && m.geometryResult?.coordinateInfo) {
         earliest = m.loadedAt;
         info = m.geometryResult.coordinateInfo;
+        anchorName = m.name ?? null;
       }
+      // `geometryVolumesSurviveAlignment` is the same two-status question
+      // asked of the same alignment pass (#1993): those are exactly the
+      // statuses under which vertices were re-baked into the anchor frame.
+      if (!geometryVolumesSurviveAlignment(m.federationAlignmentStatus)) rebased = true;
     }
     // Legacy single-model load: no federated entry, one geometry result.
     if (!info) info = geometryResult?.coordinateInfo ?? null;
@@ -45,6 +75,8 @@ export function useRenderFrameOffsets(): RenderFrameOffsets {
     return {
       originShift: info?.originShift ?? null,
       wasmRtcOffsetIfc: info?.wasmRtcOffset ?? null,
+      rebased,
+      anchorName,
     };
   }, [models, geometryResult]);
 }

--- a/apps/viewer/src/hooks/useRenderFrameOffsets.ts
+++ b/apps/viewer/src/hooks/useRenderFrameOffsets.ts
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The offsets the geometry pipeline applied to get the loaded model(s) into
+ * the render frame, for turning a picked renderer-space point back into the
+ * model's own world coordinates (#2199 §5).
+ *
+ * Unlike the Properties panel — which resolves these per SELECTED ENTITY, and
+ * so per model — a picked point has no model of its own. It lands wherever the
+ * cursor hit the shared scene. The scene has exactly one frame, so this
+ * resolves the frame ONCE, from the earliest-loaded model.
+ *
+ * That is not an approximation: a federation is aligned to the first model's
+ * RTC frame at load (see `geometry-parallel`'s alignment pass), so the first
+ * model's offsets ARE the scene's offsets. Reading a later model's offsets
+ * instead would report a point's world coordinates against a frame the scene
+ * is not actually drawn in.
+ */
+
+import { useMemo } from 'react';
+import type { CoordinateInfo } from '@ifc-lite/geometry';
+import { useViewerStore } from '@/store';
+import type { RenderFrameOffsets } from '@/components/viewer/tools/measure-modes/coordinates';
+
+export function useRenderFrameOffsets(): RenderFrameOffsets {
+  const models = useViewerStore((s) => s.models);
+  const geometryResult = useViewerStore((s) => s.geometryResult);
+
+  return useMemo(() => {
+    // Federated: the earliest-loaded model owns the frame every other model
+    // was aligned to.
+    let earliest = Infinity;
+    let info: CoordinateInfo | null = null;
+    for (const [, m] of models) {
+      if (m.loadedAt < earliest && m.geometryResult?.coordinateInfo) {
+        earliest = m.loadedAt;
+        info = m.geometryResult.coordinateInfo;
+      }
+    }
+    // Legacy single-model load: no federated entry, one geometry result.
+    if (!info) info = geometryResult?.coordinateInfo ?? null;
+
+    return {
+      originShift: info?.originShift ?? null,
+      wasmRtcOffsetIfc: info?.wasmRtcOffset ?? null,
+    };
+  }, [models, geometryResult]);
+}

--- a/apps/viewer/src/lib/compare/alignmentTrust.ts
+++ b/apps/viewer/src/lib/compare/alignmentTrust.ts
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Which stored geometry facts survive federation alignment (#1993).
+ *
+ * Its own module rather than a member of `buildFingerprints.ts` because every
+ * consumer of `MeshData.geometryVolume` needs this question answered, not just
+ * Compare — the Measure tool (#2199) and Zones (#2508) read the same field —
+ * and reaching into `buildFingerprints` for one predicate would drag
+ * `@ifc-lite/diff` into chunks that have no diff in them. `buildFingerprints`
+ * re-exports it, so the existing import path is unchanged.
+ */
+
+import type { FederatedModel } from '@/store/types';
+
+/**
+ * Do a model's proved volumes (#1993) still describe its geometry after
+ * federation alignment put it where it now is?
+ *
+ * `'same-crs'` and `'reprojected'` re-bake every vertex through a map that
+ * carries a SCALE, so a volume measured before it is a volume of geometry at a
+ * size that is no longer on screen — and unlike the world box, it cannot be
+ * re-measured on this side. Every other status left the vertices alone:
+ * `'anchor'` and `'none'` never transformed anything, `'identity'` computed a
+ * transform and found nothing to apply, and `'failed'` gave up before applying
+ * one.
+ *
+ * An unset status is a model that predates federation entirely — trusted.
+ */
+export function geometryVolumesSurviveAlignment(
+  status: FederatedModel['federationAlignmentStatus'],
+): boolean {
+  return status !== 'same-crs' && status !== 'reprojected';
+}

--- a/apps/viewer/src/lib/compare/buildFingerprints.ts
+++ b/apps/viewer/src/lib/compare/buildFingerprints.ts
@@ -262,23 +262,14 @@ export async function buildEntityFingerprints(
 
 /**
  * Do a model's proved volumes (#1993) still describe its geometry after
- * federation alignment put it where it now is?
+ * federation alignment put it where it now is? See
+ * {@link BuildFingerprintsModel.geometryVolumesTrusted}.
  *
- * `'same-crs'` and `'reprojected'` re-bake every vertex through a map that
- * carries a SCALE, so a volume measured before it is a volume of geometry at a
- * size that is no longer on screen — and unlike the world box, it cannot be
- * re-measured on this side (see {@link BuildFingerprintsModel.geometryVolumesTrusted}).
- * Every other status left the vertices alone: `'anchor'` and `'none'` never
- * transformed anything, `'identity'` computed a transform and found nothing to
- * apply, and `'failed'` gave up before applying one.
- *
- * An unset status is a model that predates federation entirely — trusted.
+ * Defined in `./alignmentTrust.js` and re-exported here: the Measure tool
+ * (#2199) asks the same question of the same field, and importing this module
+ * for it would pull `@ifc-lite/diff` into a chunk that runs no diff.
  */
-export function geometryVolumesSurviveAlignment(
-  status: FederatedModel['federationAlignmentStatus'],
-): boolean {
-  return status !== 'same-crs' && status !== 'reprojected';
-}
+export { geometryVolumesSurviveAlignment } from './alignmentTrust.js';
 
 /** Does this side carry at least one usable geometry hash? Compares run on
  *  models loaded outside the WASM mesh path (e.g. huge native desktop loads)

--- a/apps/viewer/src/store/index.ts
+++ b/apps/viewer/src/store/index.ts
@@ -345,6 +345,13 @@ const createViewerStore = () => create<ViewerState>()((...args) => ({
       pendingMeasurePoint: null,
       activeMeasurement: null,
       snapTarget: null,
+      // #2199 §5: the relative-coordinate datum is stored in RENDERER space,
+      // so it belongs to the scene it was picked in. `clearMeasurements`
+      // deliberately keeps it (tidying a distance list must not move the
+      // user's setting-out origin), but a new primary file is a new scene —
+      // carried over, it would subtract a point from the outgoing model and
+      // print a plausible, meaningless offset.
+      measureReferencePoint: null,
       edgeLockState: {
         edge: null,
         meshExpressId: null,

--- a/apps/viewer/src/store/slices/measurementSlice.ts
+++ b/apps/viewer/src/store/slices/measurementSlice.ts
@@ -9,6 +9,7 @@
 import type { StateCreator } from 'zustand';
 import type { SnapTarget } from '@ifc-lite/renderer';
 import type {
+  Vec3,
   MeasurePoint,
   Measurement,
   ActiveMeasurement,
@@ -40,6 +41,17 @@ export interface MeasurementSlice {
   edgeLockState: EdgeLockState;
   /** Edge constraint for perpendicular measurements (when shift is held) */
   measurementConstraintEdge: MeasurementConstraintEdge | null;
+  /**
+   * Temporary reference point for relative coordinate readouts (#2199 §5),
+   * in RENDERER space (Y-up metres) — the same frame picked points arrive in,
+   * so the offset is a plain subtraction with no frame conversion in between.
+   *
+   * Deliberately NOT cleared by {@link clearMeasurements}: the reference is a
+   * setting-out datum the user established on purpose, and wiping it while
+   * tidying up a list of distances would silently change what every later
+   * coordinate readout is relative to.
+   */
+  measureReferencePoint: Vec3 | null;
 
   // Legacy measurement actions
   addMeasurePoint: (point: MeasurePoint) => void;
@@ -63,6 +75,9 @@ export interface MeasurementSlice {
 
   // Geo readout actions
   toggleGeoReadout: () => void;
+
+  /** Set or clear the temporary reference point for relative coordinates. */
+  setMeasureReferencePoint: (point: Vec3 | null) => void;
 
   // Edge lock actions
   setEdgeLock: (edge: EdgeLockState['edge'], meshExpressId: number | null, edgeT?: number) => void;
@@ -96,6 +111,7 @@ export const createMeasurementSlice: StateCreator<MeasurementSlice, [], [], Meas
   snapVisualization: null,
   edgeLockState: getDefaultEdgeLockState(),
   measurementConstraintEdge: null,
+  measureReferencePoint: null,
 
   // Legacy measurement actions
   addMeasurePoint: (point) => set({ pendingMeasurePoint: point }),
@@ -258,6 +274,8 @@ export const createMeasurementSlice: StateCreator<MeasurementSlice, [], [], Meas
 
   // Geo readout actions
   toggleGeoReadout: () => set((state) => ({ geoReadoutEnabled: !state.geoReadoutEnabled })),
+
+  setMeasureReferencePoint: (measureReferencePoint) => set({ measureReferencePoint }),
 
   // Edge lock actions
   setEdgeLock: (edge, meshExpressId, edgeT = EDGE_LOCK_DEFAULTS.INITIAL_T) => set({


### PR DESCRIPTION
Closes part of #2199. Six categories is several PRs, not one; the [scope assessment on the issue](https://github.com/LTplus-AG/ifc-lite/issues/2199#issuecomment-5233717857) costs each one against what the codebase already gives for free, and this PR builds only the three that are genuinely cheap because the data is already in hand. Three done properly beat six done thinly.

Measurement was distance-only before this: a drag from A to B, the dX/dY/dZ + H/V breakdown from #2284, and the georeferenced E/N/H from #1674/#1679.

## What this builds

**1. Inclination (§4, the horizontal-reference part).** Every distance measurement gains angle to horizontal in degrees, slope percent and 1:n ratio, derived on render from the two endpoints already stored. No new interaction, no new state, nothing persisted. The three forms are shown together on purpose: degrees is what a surveyor reads, percent is what a ramp gradient is specified in, and 1:n is what a drainage fall is drawn as.

The four cases are discriminated rather than collapsed — a level run and a zero-length pick both yield `(0°, 0%, no ratio)`, so without a discriminator a formatter cannot tell "I measured along the floor" from "I measured nothing".

**2. Coordinates (§5).** A picked point's model coordinates in IFC Z-up axes, which the viewer never surfaced before — only the georeferenced E/N/H existed. The render frame is shown as a separate row only when the pipeline actually shifted the model, and a settable temporary datum gives relative ΔX/ΔY/ΔZ plus distance.

`PropertiesPanel`'s world-coordinate reconstruction now routes through the same module, so the two surfaces can no longer drift on which axis is up or which sign a northing takes.

**3. Quantities (§1 element area, §2 volume, §6 weight).** Area / volume / weight / length for the current selection, single or aggregated, from two sources that are each labelled and never blended:

- **Declared** — the file's own `IfcElementQuantity`, occurrence first with the element's type as fallback (the #1745/#1755 rule). What kind of quantity it is comes from `QuantityType`, never from the name: `NetSideArea`, `GrossFootprintArea` and `CrossSectionArea` are all areas and no name list will ever be complete, but the enum is authored off the STEP entity type so it cannot be wrong the way a regex can. Exactly one value per (type, basis) per element, so a wall's area is never reported as the sum of its side, footprint and cross-section.
- **Geometry** — `MeshData.geometryVolume` (#1993), the kernel's enclosed volume, present only where a single closed orientable solid could be **proved**. Where it could not, the count is reported rather than hidden, which is §2's "report that the volume cannot be calculated reliably instead of returning an incorrect result".

Values normalise to SI at read time, while each value is still next to the `ProjectUnits` that explain it — a federation can mix a millimetre model with a metre one, and adding those as they stand is off by a factor of a billion. Display then converts once through `resolveQuantityDisplay`, honouring the per-unit-type override from #1573.

## The openings question

§1 and §2 both have to say whether a window void is subtracted, and **#2508 (zones v2) faces the identical question** when apportioning a wall's volume.

This tool never decides. It reports which convention each number was authored under and keeps them apart, with the legend rendered beside the numbers rather than hidden in a tooltip:

> net = openings excluded · gross = openings included · mesh = as built, after opening cuts

`unqualified` is its own case and not a synonym for either: a plain `Volume` makes no claim about openings, and labelling it "net" would put a confidence on it the file never expressed. The recommendation for #2508 is the same discipline — apportion from a *named* basis and carry the name with the number.

## Both toolbars

The viewer ships the classic strip and the ribbon at once. Measure needs no command registry and adding one would be the wrong fix: **neither toolbar hosts measurement UI**. Each does one thing — `setActiveTool('measure')` — and `ToolOverlays` renders the one panel off that store field, so there is no second list to drift from the first.

What can drift is that structure, and `tools/measure-parity.test.tsx` guards each way: a toolbar stopping its dispatch, a toolbar growing measurement UI of its own, and the panel stopping to host a section (so the section's own tests stay green while the feature ships unreachable — the exact hole #2510 and #2511 each found in their first guard). The third is asserted by **driving `ToolOverlays`**, the real host: each section is opened by clicking its button on the shipped panel and read off the numbers that come back. The first two are asserted in source with import statements stripped first, since neither toolbar mounts in the node runner and a leftover import is what kept #2510's first guard green.

## Verification

`building-architecture.ifc` (444 entities, IFC4) — length unit **millimetres**, area and volume m² and m³, which is exactly the case a hand-rolled conversion gets wrong. Every measurement below was taken twice, once with the ribbon active and once with the classic strip, by dragging on the canvas in each.

Wall `#315`:

| Row | Viewer | Independent source |
|---|---|---|
| Length | `6 m` | file declares `Length = 6000.000000000036` (mm) |
| Area net | `21.154 m²` | `NetSideArea = 21.154415587728412` |
| Volume net | `4.231 m³` | `NetVolume = 4.230883117545889` |
| Volume mesh | `4.231 m³` | kernel `geometryVolume = 4.230883568459656` |

The last two agree to 7 significant figures from two independent producers — the authoring tool's declared quantity and our meshing kernel, post opening-cut.

Measurements: a 1 m³ cube's edge reads **1.000 m** / `0.0° 0.0% level`; wall corner to cube corner reads **6.824 m**, `H 6.708 V 1.250`, `10.6° 18.6% 1:5.4` against hand-computed 6.82367 / 6.70820 / 1.25 / 10.556° / 18.634% / 1:5.367. Coordinates: renderer `(0, 1, 0)` reads `MODEL X 0.000 Y 0.000 Z 1.000 m`, Render row correctly suppressed on an unshifted model; datum set, second pick 1 m away reads `REL. REF X 0.000 Y 1.000 Z 0.000` / `1.000 m`.

- `npx turbo typecheck --force`: 76/76, 0 cached.
- `npx turbo test --force`: 86/86, 0 cached; viewer 3524 tests, 3518 pass, 0 fail.
- Mutation-checked: dropping the northing negation, un-hosting `MeasureQuantities` while leaving its import, dropping the ribbon's measure dispatch, accumulating submesh volumes instead of one per element, inverting the slope ratio, and letting a quantity bucket keep the last name instead of the preferred one each fail the specific assertions that name them. Control green first, tree clean after each restore.

`apps/viewer` is private, so no changeset and no api-surface update.

## Deliberately not built

Free-polygon and rectangle area, geometry-face and coplanar-face area, density-derived weight, edge / polyline / perimeter length, minimum distance, diameter and radius, three-point and face-to-face angles, circle-centre and intersection snapping. Each needs either a new multi-click interaction mode or real mesh analysis, and half-building them would be worse than leaving them. The two structural prerequisites they share are called out on the issue.
