### PR TITLE
fix(renderer): subtract holes from section cut caps and annotation fills

### DIFF
--- a/.changeset/cut-cap-hole-subtraction.md
+++ b/.changeset/cut-cap-hole-subtraction.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/renderer": patch
+---
+
+Section cut caps and `IfcAnnotationFillArea` fills now subtract their holes. The shared triangulator bridged hole rings in but almost never clipped an ear from the bridged ring, so a 4x4 profile with a 2x2 hole covered an area of 2 instead of 12 and any cut through a wall opening or slab void rendered a near-empty cap. Rings are now nested by the even-odd rule, so an island inside a hole fills, matching the 2D canvas and SVG export paths which already fill with `evenodd`. Hole-free profiles are unchanged.

--- a/packages/drawing-2d/src/polygon-builder.test.ts
+++ b/packages/drawing-2d/src/polygon-builder.test.ts
@@ -182,15 +182,19 @@ describe('PolygonBuilder — hole containment and winding (classifyLoops)', () =
    * mutation this regression kills below) the outer ring must come back CCW
    * and the hole CW, i.e. OPPOSITE winding.
    *
-   * This isn't cosmetic: `packages/renderer/src/section-2d-overlay.ts`
-   * feeds `polygon.outer`/`polygon.holes` straight into
-   * `triangulateRings()` to build the 3D cut-face fill, and every 2D
-   * consumer downstream (`Drawing2DCanvas` and `svg-exporter.ts` both fill
-   * with the `evenodd` rule) reads a hole as a ring wound against its
-   * boundary.
-   * Since #2516 the renderer re-normalises windings itself, so a same-wound
-   * hole no longer breaks the 3D cap — but it still misreports the drawing's
-   * own topology, which is what this test pins. Swapping `ensureCCW`/`ensureCW` for the
+   * The CONTAINMENT half is what every downstream consumer reads:
+   * `packages/renderer/src/section-2d-overlay.ts` feeds
+   * `polygon.outer`/`polygon.holes` straight into `triangulateRings()` for
+   * the 3D cut-face fill, while `Drawing2DCanvas` and `svg-exporter.ts`
+   * emit each ring as its own subpath and fill with `evenodd` — which
+   * decides fill from crossing parity and ignores winding entirely.
+   *
+   * The WINDING half is a producer-side invariant rather than something a
+   * consumer depends on: since #2516 the renderer re-normalises windings
+   * itself, so a same-wound hole no longer breaks the 3D cap. It is still
+   * pinned here because `classifyLoops` promising an orientation and then
+   * not delivering it is a silent lie to anything that reads the loops
+   * directly. Swapping `ensureCCW`/`ensureCW` for the
    * outer ring in `classifyLoops` (`ensureCCW(outer.points)` →
    * `ensureCW(outer.points)`) leaves both rings wound the SAME way; no
    * existing test in this file or `polygon-builder-opening.test.ts` builds

--- a/packages/drawing-2d/src/polygon-builder.test.ts
+++ b/packages/drawing-2d/src/polygon-builder.test.ts
@@ -183,10 +183,14 @@ describe('PolygonBuilder — hole containment and winding (classifyLoops)', () =
    * and the hole CW, i.e. OPPOSITE winding.
    *
    * This isn't cosmetic: `packages/renderer/src/section-2d-overlay.ts`
-   * feeds `polygon.outer`/`polygon.holes` straight into `joinHoles()` +
-   * `earClip()` to triangulate the 3D cut-face fill, and hole-joining
-   * ear-clipping algorithms rely on the hole being wound opposite the outer
-   * ring to bridge it in correctly. Swapping `ensureCCW`/`ensureCW` for the
+   * feeds `polygon.outer`/`polygon.holes` straight into
+   * `triangulateRings()` to build the 3D cut-face fill, and every 2D
+   * consumer downstream (`Drawing2DCanvas` and `svg-exporter.ts` both fill
+   * with the `evenodd` rule) reads a hole as a ring wound against its
+   * boundary.
+   * Since #2516 the renderer re-normalises windings itself, so a same-wound
+   * hole no longer breaks the 3D cap — but it still misreports the drawing's
+   * own topology, which is what this test pins. Swapping `ensureCCW`/`ensureCW` for the
    * outer ring in `classifyLoops` (`ensureCCW(outer.points)` →
    * `ensureCW(outer.points)`) leaves both rings wound the SAME way; no
    * existing test in this file or `polygon-builder-opening.test.ts` builds

--- a/packages/renderer/src/fill-bridge-anchor.test.ts
+++ b/packages/renderer/src/fill-bridge-anchor.test.ts
@@ -5,7 +5,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import { chooseBridgeAnchor } from './fill-bridge-anchor.js';
-import { signedRingArea, triangulateRings, type Pt } from './fill-triangulate.js';
+import { joinHoles, signedRingArea, triangulateRings, type Pt } from './fill-triangulate.js';
 
 /**
  * A hole is spliced into its boundary along a bridge edge, and the merged ring
@@ -185,6 +185,39 @@ describe('chooseBridgeAnchor', () => {
 
   it('returns -1 for an empty boundary instead of indexing off the end', () => {
     assert.strictEqual(chooseBridgeAnchor([], ORIGIN_HOLE, 0), -1);
+  });
+
+  it('returns -1 rather than throwing when there is no bridge start', () => {
+    // Both of these read `hole[startIdx]` as undefined. A TypeError here
+    // would take out the whole cap upload, not just this hole.
+    const square = P([
+      [0, 0],
+      [4, 0],
+      [4, 4],
+      [0, 4],
+    ]);
+    assert.strictEqual(chooseBridgeAnchor(square, [], 0), -1);
+    assert.strictEqual(chooseBridgeAnchor(square, ORIGIN_HOLE, 99), -1);
+    assert.strictEqual(chooseBridgeAnchor(square, ORIGIN_HOLE, -1), -1);
+  });
+
+  it('skips a hole ring too small to be a ring instead of bridging a spur', () => {
+    // A 1- or 2-point "hole" used to splice in as a zero-width spur, which is
+    // silently wrong geometry rather than a dropped hole.
+    const square = P([
+      [0, 0],
+      [4, 0],
+      [4, 4],
+      [0, 4],
+    ]);
+    assert.strictEqual(joinHoles(square, [[]]).length, 4);
+    assert.strictEqual(joinHoles(square, [P([[1, 1]])]).length, 4);
+    assert.strictEqual(joinHoles(square, [P([[1, 1], [2, 2]])]).length, 4);
+    // A real hole alongside a degenerate one still bridges.
+    assert.strictEqual(
+      joinHoles(square, [P([[1, 1]]), P([[1, 1], [3, 1], [3, 3], [1, 3]])]).length,
+      10,
+    );
   });
 
   it('bridges a multi-notch boundary past the tooth in the way', () => {

--- a/packages/renderer/src/fill-bridge-anchor.test.ts
+++ b/packages/renderer/src/fill-bridge-anchor.test.ts
@@ -1,0 +1,153 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { chooseBridgeAnchor } from './fill-bridge-anchor.js';
+import { signedRingArea, triangulateRings, type Pt } from './fill-triangulate.js';
+
+/**
+ * A hole is spliced into its boundary along a bridge edge, and the merged ring
+ * has to stay a SIMPLE polygon — ear clipping is undefined on anything else.
+ * Ranking anchors by "to the right, then nearest" almost always lands on a
+ * visible vertex, because a wall's own corner is nearer than anything behind
+ * it. Almost: a long blocking edge whose endpoints are both far away leaves a
+ * vertex behind it as the nearest candidate, and bridging to it cuts straight
+ * through the wall.
+ *
+ * `SLOTTED` below is that shape, and it is a genuine simple polygon rather
+ * than a synthetic input the triangulator could never see.
+ */
+
+const P = (pts: Array<[number, number]>): Pt[] => pts.map(([x, z]) => ({ x, z }));
+
+/**
+ * A rectangle with a thin horizontal slot open at its right edge, and a spike
+ * protruding upward from the slot's FAR side. The spike's foot at (0.5, 0.55)
+ * is the nearest boundary vertex to the right of a hole sitting at the origin
+ * — and is separated from it by the slot's lower edge, which runs from
+ * (50, 0.5) all the way to (-49, 0.5) with both endpoints far away.
+ */
+const SLOTTED = P([
+  [-50, -10],
+  [50, -10],
+  [50, 0.5],
+  [-49, 0.5],
+  [-49, 0.55],
+  [0.1, 0.55],
+  [0.3, 3],
+  [0.5, 0.55],
+  [50, 0.55],
+  [50, 10],
+  [-50, 10],
+]);
+const ORIGIN_HOLE = P([
+  [-0.2, -0.2],
+  [0.2, -0.2],
+  [0.2, 0.2],
+  [-0.2, 0.2],
+]);
+
+function rightmostIndex(ring: readonly Pt[]): number {
+  let best = 0;
+  for (let i = 1; i < ring.length; i++) if (ring[i].x > ring[best].x) best = i;
+  return best;
+}
+
+/** The ranking with no visibility filter — what this used to do. */
+function nearestToTheRight(boundary: readonly Pt[], start: Pt): number {
+  let best = -1;
+  let bestDist = Infinity;
+  for (let i = 0; i < boundary.length; i++) {
+    const p = boundary[i];
+    if (p.x <= start.x) continue;
+    const d = (p.x - start.x) ** 2 + (p.z - start.z) ** 2;
+    if (d < bestDist) {
+      bestDist = d;
+      best = i;
+    }
+  }
+  return best;
+}
+
+function triangulatedArea(rings: Pt[][]): number {
+  const { points, triangles } = triangulateRings(rings);
+  let sum = 0;
+  for (const [i, j, k] of triangles) {
+    const a = points[i];
+    const b = points[j];
+    const c = points[k];
+    sum += Math.abs((b.x - a.x) * (c.z - a.z) - (c.x - a.x) * (b.z - a.z)) / 2;
+  }
+  return sum;
+}
+
+describe('chooseBridgeAnchor', () => {
+  it('refuses an anchor whose bridge would cut through a boundary edge', () => {
+    const start = rightmostIndex(ORIGIN_HOLE);
+    const naive = nearestToTheRight(SLOTTED, ORIGIN_HOLE[start]);
+    assert.deepStrictEqual(
+      SLOTTED[naive],
+      { x: 0.5, z: 0.55 },
+      'the fixture must actually put a blocked vertex nearest — otherwise this test proves nothing',
+    );
+    const chosen = chooseBridgeAnchor(SLOTTED, ORIGIN_HOLE, start);
+    assert.notStrictEqual(chosen, naive, 'the blocked anchor must be rejected');
+    assert.deepStrictEqual(SLOTTED[chosen], { x: 50, z: 0.5 });
+  });
+
+  it('triangulates that shape to its exact analytic area', () => {
+    const expected =
+      Math.abs(signedRingArea(SLOTTED)) - Math.abs(signedRingArea(ORIGIN_HOLE));
+    const area = triangulatedArea([SLOTTED, ORIGIN_HOLE]);
+    assert.ok(Math.abs(area - expected) < 1e-6, `area was ${area}, expected ${expected}`);
+  });
+
+  it('still takes the nearest vertex to the right when nothing blocks it', () => {
+    // The ordinary convex case must be unchanged, or every simple profile
+    // re-tessellates for no reason.
+    const square = P([
+      [0, 0],
+      [4, 0],
+      [4, 4],
+      [0, 4],
+    ]);
+    const hole = P([
+      [1, 1],
+      [3, 1],
+      [3, 3],
+      [1, 3],
+    ]);
+    const start = rightmostIndex(hole);
+    assert.strictEqual(
+      chooseBridgeAnchor(square, hole, start),
+      nearestToTheRight(square, hole[start]),
+    );
+  });
+
+  it('falls back to the nearest candidate rather than dropping the hole', () => {
+    // No vertex lies to the right of the bridge start, and every bridge
+    // touches something: the hole must still be spliced somewhere.
+    const square = P([
+      [0, 0],
+      [4, 0],
+      [4, 4],
+      [0, 4],
+    ]);
+    const flush = P([
+      [2, 1],
+      [4, 1],
+      [4, 3],
+      [2, 3],
+    ]);
+    const start = rightmostIndex(flush);
+    const chosen = chooseBridgeAnchor(square, flush, start);
+    assert.ok(chosen >= 0 && chosen < square.length);
+    assert.ok(Math.abs(triangulatedArea([square, flush]) - 12) < 1e-6);
+  });
+
+  it('returns -1 for an empty boundary instead of indexing off the end', () => {
+    assert.strictEqual(chooseBridgeAnchor([], ORIGIN_HOLE, 0), -1);
+  });
+});

--- a/packages/renderer/src/fill-bridge-anchor.test.ts
+++ b/packages/renderer/src/fill-bridge-anchor.test.ts
@@ -150,4 +150,33 @@ describe('chooseBridgeAnchor', () => {
   it('returns -1 for an empty boundary instead of indexing off the end', () => {
     assert.strictEqual(chooseBridgeAnchor([], ORIGIN_HOLE, 0), -1);
   });
+
+  it('makes the same call on the same shape at any model scale', () => {
+    // The predicates behind this are cross products and dot products, whose
+    // units are SQUARED coordinates. An absolute tolerance therefore means
+    // something different in a model authored in millimetres than in one
+    // authored in kilometres, and at a small enough scale every crossing looks
+    // collinear and the blocked anchor comes back as "clear".
+    const scaled = (rings: Pt[][], k: number): Pt[][] =>
+      rings.map((r) => r.map((p) => ({ x: p.x * k, z: p.z * k })));
+
+    const start = rightmostIndex(ORIGIN_HOLE);
+    const reference = chooseBridgeAnchor(SLOTTED, ORIGIN_HOLE, start);
+
+    for (const k of [1e-7, 1e-3, 1e3, 1e6]) {
+      const [boundary, hole] = scaled([SLOTTED, ORIGIN_HOLE], k);
+      assert.strictEqual(
+        chooseBridgeAnchor(boundary, hole, rightmostIndex(hole)),
+        reference,
+        `anchor changed at scale ${k}`,
+      );
+      const expected =
+        Math.abs(signedRingArea(boundary)) - Math.abs(signedRingArea(hole));
+      const area = triangulatedArea([boundary, hole]);
+      assert.ok(
+        Math.abs(area - expected) <= 1e-9 * expected,
+        `scale ${k}: area ${area}, expected ${expected}`,
+      );
+    }
+  });
 });

--- a/packages/renderer/src/fill-bridge-anchor.test.ts
+++ b/packages/renderer/src/fill-bridge-anchor.test.ts
@@ -83,6 +83,42 @@ function triangulatedArea(rings: Pt[][]): number {
   return sum;
 }
 
+/**
+ * A multi-notch boundary — a wall with returns, or a slab with several
+ * rebates — is a plausible section cross-section, and it is where the
+ * unguarded "nearest vertex to the right" ranking actually fails on
+ * well-formed input. Reported on #2523 by Codex against this branch's first
+ * commit: the nearest candidate is the tip of the NEXT tooth, and the bridge
+ * to it runs straight through the wall between them.
+ */
+const COMB = P([
+  [0, 0],
+  [12, 0],
+  [12, 12],
+  [9, 12],
+  [9, 3],
+  [7, 3],
+  [7, 10],
+  [5, 10],
+  [5, 3],
+  [3, 3],
+  [3, 12],
+  [0, 12],
+]);
+/** Stated CLOCKWISE, which is the winding `joinHoles` normalises holes to
+ *  before it asks for an anchor. The order matters to the assertion below and
+ *  only to that: the rightmost-vertex tie-break picks (0.95, 7.45) here and
+ *  (0.95, 7.25) from the reversed ring, and those two rank the candidates
+ *  differently. `triangulateRings` normalises internally, so the AREA
+ *  assertions hold whichever way the ring is stated — which the
+ *  "does not care which winding the caller supplies" case already pins. */
+const COMB_HOLE = P([
+  [0.75, 7.45],
+  [0.95, 7.45],
+  [0.95, 7.25],
+  [0.75, 7.25],
+]);
+
 describe('chooseBridgeAnchor', () => {
   it('refuses an anchor whose bridge would cut through a boundary edge', () => {
     const start = rightmostIndex(ORIGIN_HOLE);
@@ -149,6 +185,36 @@ describe('chooseBridgeAnchor', () => {
 
   it('returns -1 for an empty boundary instead of indexing off the end', () => {
     assert.strictEqual(chooseBridgeAnchor([], ORIGIN_HOLE, 0), -1);
+  });
+
+  it('bridges a multi-notch boundary past the tooth in the way', () => {
+    // Unguarded, the nearest vertex to the right of the hole is the middle
+    // tooth's tip at (5, 10) — on the far side of the wall (3, 3)-(3, 12).
+    // Bridging there leaves a weakly-simple ring the clipper stalls on: 10 of
+    // 16 triangles and area 91.01 instead of 103.96.
+    const start = rightmostIndex(COMB_HOLE);
+    const naive = nearestToTheRight(COMB, COMB_HOLE[start]);
+    assert.deepStrictEqual(
+      COMB[naive],
+      { x: 5, z: 10 },
+      'the fixture must still put the blocked tooth tip nearest, or it proves nothing',
+    );
+    assert.deepStrictEqual(COMB[chooseBridgeAnchor(COMB, COMB_HOLE, start)], { x: 3, z: 3 });
+  });
+
+  it('triangulates that multi-notch profile to its exact analytic area', () => {
+    const area = triangulatedArea([COMB, COMB_HOLE]);
+    const reversed = triangulatedArea([COMB, COMB_HOLE.slice().reverse()]);
+    assert.ok(Math.abs(area - reversed) < 1e-9, 'the area must not depend on ring order');
+    assert.ok(
+      Math.abs(area - 103.96) < 1e-6,
+      `multi-notch cap area was ${area}, expected 103.96 (91.01 = the stalled bridge)`,
+    );
+  });
+
+  it('leaves the same multi-notch boundary WITHOUT a hole unchanged', () => {
+    // Control: the notches alone were never the problem, so this must not move.
+    assert.ok(Math.abs(triangulatedArea([COMB]) - 104) < 1e-6);
   });
 
   it('makes the same call on the same shape at any model scale', () => {

--- a/packages/renderer/src/fill-bridge-anchor.ts
+++ b/packages/renderer/src/fill-bridge-anchor.ts
@@ -9,9 +9,11 @@
  * "Nearest vertex to the right" alone is not enough. The bridge has to be a
  * segment that stays inside the material — if it crosses a boundary edge, an
  * already-spliced hole, or an earlier bridge, the merged ring is no longer a
- * simple polygon and ear clipping is entitled to emit nonsense. A concave
- * boundary makes this reachable: the nearest vertex to the right of a hole can
- * sit on the far side of a wall, in a lobe the hole cannot see.
+ * simple polygon and ear clipping is entitled to emit nonsense. Ranking by
+ * distance lands on a visible vertex in nearly every case, because a wall's own
+ * corner is nearer than anything behind it; the exception is a long blocking
+ * edge whose endpoints are both far away, which leaves a vertex on its far side
+ * as the nearest candidate.
  *
  * So candidates are ranked exactly as before (to the right first, then by
  * distance) and the first one whose bridge crosses nothing wins. The ranking is
@@ -20,36 +22,7 @@
  */
 
 import type { Pt } from './fill-triangulate.js';
-
-/** Cross product of (q - p) x (r - p). Sign gives which side of pq r is on. */
-function cross(p: Pt, q: Pt, r: Pt): number {
-  return (q.x - p.x) * (r.z - p.z) - (q.z - p.z) * (r.x - p.x);
-}
-
-const EPS = 1e-12;
-
-/** True when ab and cd cross at a point interior to both — shared endpoints
- *  and touching do not count, they are handled by {@link vertexOnSegment}. */
-function properlyCross(a: Pt, b: Pt, c: Pt, d: Pt): boolean {
-  const d1 = cross(c, d, a);
-  const d2 = cross(c, d, b);
-  const d3 = cross(a, b, c);
-  const d4 = cross(a, b, d);
-  return (
-    ((d1 > EPS && d2 < -EPS) || (d1 < -EPS && d2 > EPS)) &&
-    ((d3 > EPS && d4 < -EPS) || (d3 < -EPS && d4 > EPS))
-  );
-}
-
-/** True when `p` lies on the open segment ab. A vertex sitting on the bridge
- *  makes the merged ring degenerate rather than simple, so it disqualifies the
- *  anchor just as a crossing does. */
-function vertexOnSegment(p: Pt, a: Pt, b: Pt): boolean {
-  if (Math.abs(cross(a, b, p)) > EPS) return false;
-  const dot = (p.x - a.x) * (b.x - a.x) + (p.z - a.z) * (b.z - a.z);
-  const len = (b.x - a.x) ** 2 + (b.z - a.z) ** 2;
-  return dot > EPS && dot < len - EPS;
-}
+import { pointOnSegment, properlyCross } from './fill-predicates.js';
 
 /**
  * True when the segment `boundary[anchorIdx]` → `hole[startIdx]` crosses
@@ -70,7 +43,7 @@ function bridgeIsClear(
     if (i !== anchorIdx && j !== anchorIdx && properlyCross(a, b, boundary[i], boundary[j])) {
       return false;
     }
-    if (i !== anchorIdx && vertexOnSegment(boundary[i], a, b)) return false;
+    if (i !== anchorIdx && pointOnSegment(boundary[i], a, b, false)) return false;
   }
 
   for (let i = 0; i < hole.length; i++) {
@@ -78,7 +51,7 @@ function bridgeIsClear(
     if (i !== startIdx && j !== startIdx && properlyCross(a, b, hole[i], hole[j])) {
       return false;
     }
-    if (i !== startIdx && vertexOnSegment(hole[i], a, b)) return false;
+    if (i !== startIdx && pointOnSegment(hole[i], a, b, false)) return false;
   }
 
   return true;

--- a/packages/renderer/src/fill-bridge-anchor.ts
+++ b/packages/renderer/src/fill-bridge-anchor.ts
@@ -1,0 +1,118 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Where a hole's bridge edge attaches to the boundary it is being spliced into
+ * (see `joinHoles` in `fill-triangulate.ts`).
+ *
+ * "Nearest vertex to the right" alone is not enough. The bridge has to be a
+ * segment that stays inside the material — if it crosses a boundary edge, an
+ * already-spliced hole, or an earlier bridge, the merged ring is no longer a
+ * simple polygon and ear clipping is entitled to emit nonsense. A concave
+ * boundary makes this reachable: the nearest vertex to the right of a hole can
+ * sit on the far side of a wall, in a lobe the hole cannot see.
+ *
+ * So candidates are ranked exactly as before (to the right first, then by
+ * distance) and the first one whose bridge crosses nothing wins. The ranking is
+ * unchanged for the common convex case, which is why simple profiles produce
+ * byte-identical rings to before.
+ */
+
+import type { Pt } from './fill-triangulate.js';
+
+/** Cross product of (q - p) x (r - p). Sign gives which side of pq r is on. */
+function cross(p: Pt, q: Pt, r: Pt): number {
+  return (q.x - p.x) * (r.z - p.z) - (q.z - p.z) * (r.x - p.x);
+}
+
+const EPS = 1e-12;
+
+/** True when ab and cd cross at a point interior to both — shared endpoints
+ *  and touching do not count, they are handled by {@link vertexOnSegment}. */
+function properlyCross(a: Pt, b: Pt, c: Pt, d: Pt): boolean {
+  const d1 = cross(c, d, a);
+  const d2 = cross(c, d, b);
+  const d3 = cross(a, b, c);
+  const d4 = cross(a, b, d);
+  return (
+    ((d1 > EPS && d2 < -EPS) || (d1 < -EPS && d2 > EPS)) &&
+    ((d3 > EPS && d4 < -EPS) || (d3 < -EPS && d4 > EPS))
+  );
+}
+
+/** True when `p` lies on the open segment ab. A vertex sitting on the bridge
+ *  makes the merged ring degenerate rather than simple, so it disqualifies the
+ *  anchor just as a crossing does. */
+function vertexOnSegment(p: Pt, a: Pt, b: Pt): boolean {
+  if (Math.abs(cross(a, b, p)) > EPS) return false;
+  const dot = (p.x - a.x) * (b.x - a.x) + (p.z - a.z) * (b.z - a.z);
+  const len = (b.x - a.x) ** 2 + (b.z - a.z) ** 2;
+  return dot > EPS && dot < len - EPS;
+}
+
+/**
+ * True when the segment `boundary[anchorIdx]` → `hole[startIdx]` crosses
+ * nothing. Edges incident to either endpoint are skipped: they share that
+ * endpoint by construction and can never be a genuine crossing.
+ */
+function bridgeIsClear(
+  boundary: readonly Pt[],
+  hole: readonly Pt[],
+  anchorIdx: number,
+  startIdx: number,
+): boolean {
+  const a = boundary[anchorIdx];
+  const b = hole[startIdx];
+
+  for (let i = 0; i < boundary.length; i++) {
+    const j = (i + 1) % boundary.length;
+    if (i !== anchorIdx && j !== anchorIdx && properlyCross(a, b, boundary[i], boundary[j])) {
+      return false;
+    }
+    if (i !== anchorIdx && vertexOnSegment(boundary[i], a, b)) return false;
+  }
+
+  for (let i = 0; i < hole.length; i++) {
+    const j = (i + 1) % hole.length;
+    if (i !== startIdx && j !== startIdx && properlyCross(a, b, hole[i], hole[j])) {
+      return false;
+    }
+    if (i !== startIdx && vertexOnSegment(hole[i], a, b)) return false;
+  }
+
+  return true;
+}
+
+/**
+ * Pick the boundary vertex the hole's bridge should attach to, or -1 when the
+ * boundary has no vertices at all.
+ *
+ * Candidates to the right of the bridge start come first (the direction the
+ * hole's rightmost vertex looks in), then everything else, each group ordered
+ * by distance. The first candidate with a clear bridge wins. If none is clear —
+ * only reachable on malformed input such as a hole that pokes outside its
+ * boundary — the nearest candidate is used anyway, which is what this did
+ * before any visibility check existed.
+ */
+export function chooseBridgeAnchor(
+  boundary: readonly Pt[],
+  hole: readonly Pt[],
+  startIdx: number,
+): number {
+  if (boundary.length === 0) return -1;
+  const start = hole[startIdx];
+
+  const ranked = boundary
+    .map((p, i) => ({
+      i,
+      right: p.x > start.x,
+      d: (p.x - start.x) ** 2 + (p.z - start.z) ** 2,
+    }))
+    .sort((a, b) => (a.right === b.right ? a.d - b.d : a.right ? -1 : 1));
+
+  for (const candidate of ranked) {
+    if (bridgeIsClear(boundary, hole, candidate.i, startIdx)) return candidate.i;
+  }
+  return ranked[0].i;
+}

--- a/packages/renderer/src/fill-bridge-anchor.ts
+++ b/packages/renderer/src/fill-bridge-anchor.ts
@@ -21,8 +21,7 @@
  * byte-identical rings to before.
  */
 
-import type { Pt } from './fill-triangulate.js';
-import { pointOnSegment, properlyCross } from './fill-predicates.js';
+import { pointOnSegment, properlyCross, type Pt } from './fill-predicates.js';
 
 /**
  * True when the segment `boundary[anchorIdx]` → `hole[startIdx]` crosses

--- a/packages/renderer/src/fill-bridge-anchor.ts
+++ b/packages/renderer/src/fill-bridge-anchor.ts
@@ -75,6 +75,10 @@ export function chooseBridgeAnchor(
 ): number {
   if (boundary.length === 0) return -1;
   const start = hole[startIdx];
+  // No bridge start means no bridge. Reachable only through the exported
+  // entry point, but returning -1 is what `joinHoles` already handles, and a
+  // TypeError on the render thread is not.
+  if (start === undefined) return -1;
 
   const ranked = boundary
     .map((p, i) => ({

--- a/packages/renderer/src/fill-predicates.ts
+++ b/packages/renderer/src/fill-predicates.ts
@@ -1,0 +1,81 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Scale-aware geometric predicates for the fill triangulator.
+ *
+ * Every tolerance in here is RELATIVE. An absolute one would be a trap: a
+ * cross product carries squared coordinate units, so a threshold tuned for a
+ * cut face measured in metres silently reclassifies every crossing in a face
+ * measured in millimetres — collinear where it is not, "clear" where the
+ * bridge in fact cuts through a wall. The section overlay sees both, because
+ * the model's own unit assignment decides what a coordinate means.
+ *
+ * So orientation is tested as a SINE (determinant over the two operand
+ * lengths) and position along a segment as a PARAMETER (dot over the squared
+ * length). Both are dimensionless, so the same constant means the same thing
+ * at any model scale.
+ */
+
+import type { Pt } from './fill-triangulate.js';
+
+/** Dimensionless tolerance: a sine for orientation, a fraction for position. */
+const REL_EPS = 1e-12;
+
+/**
+ * Which side of the directed line pq the point r falls on: 1 left, -1 right,
+ * 0 collinear within {@link REL_EPS} of the two operands' magnitudes.
+ */
+export function orient(p: Pt, q: Pt, r: Pt): number {
+  const ux = q.x - p.x;
+  const uz = q.z - p.z;
+  const vx = r.x - p.x;
+  const vz = r.z - p.z;
+  const det = ux * vz - uz * vx;
+  const scale = Math.hypot(ux, uz) * Math.hypot(vx, vz);
+  if (Math.abs(det) <= REL_EPS * scale) return 0;
+  return det > 0 ? 1 : -1;
+}
+
+/** True when ab and cd cross at a point interior to BOTH segments. Shared
+ *  endpoints and touching do not count — {@link pointOnSegment} covers those. */
+export function properlyCross(a: Pt, b: Pt, c: Pt, d: Pt): boolean {
+  return orient(c, d, a) * orient(c, d, b) < 0 && orient(a, b, c) * orient(a, b, d) < 0;
+}
+
+/**
+ * True when `p` lies on segment ab. `includeEnds` decides whether the two
+ * endpoints count, which is the difference between "this vertex is ON the ring"
+ * (yes) and "this vertex sits in the middle of my bridge" (no).
+ */
+export function pointOnSegment(p: Pt, a: Pt, b: Pt, includeEnds: boolean): boolean {
+  if (orient(a, b, p) !== 0) return false;
+  const len = (b.x - a.x) ** 2 + (b.z - a.z) ** 2;
+  if (len === 0) return includeEnds && p.x === a.x && p.z === a.z;
+  const t = ((p.x - a.x) * (b.x - a.x) + (p.z - a.z) * (b.z - a.z)) / len;
+  return includeEnds ? t >= -REL_EPS && t <= 1 + REL_EPS : t > REL_EPS && t < 1 - REL_EPS;
+}
+
+/** Longest side of the ring's bounding box — the characteristic length the
+ *  coordinate comparisons below are measured against. */
+export function ringScale(ring: readonly Pt[]): number {
+  let minX = Infinity;
+  let maxX = -Infinity;
+  let minZ = Infinity;
+  let maxZ = -Infinity;
+  for (const p of ring) {
+    if (p.x < minX) minX = p.x;
+    if (p.x > maxX) maxX = p.x;
+    if (p.z < minZ) minZ = p.z;
+    if (p.z > maxZ) maxZ = p.z;
+  }
+  const extent = Math.max(maxX - minX, maxZ - minZ);
+  return Number.isFinite(extent) && extent > 0 ? extent : 1;
+}
+
+/** True when two vertices are the same point, relative to `scale`. */
+export function samePoint(a: Pt, b: Pt, scale: number): boolean {
+  const tol = REL_EPS * scale;
+  return Math.abs(a.x - b.x) <= tol && Math.abs(a.z - b.z) <= tol;
+}

--- a/packages/renderer/src/fill-predicates.ts
+++ b/packages/renderer/src/fill-predicates.ts
@@ -18,7 +18,12 @@
  * at any model scale.
  */
 
-import type { Pt } from './fill-triangulate.js';
+/**
+ * A point on the fill plane. Y is constant per fill, so only (x, z) travel.
+ * Defined here, in the leaf module, so the dependency graph runs one way:
+ * predicates <- bridge anchor <- triangulator.
+ */
+export type Pt = { x: number; z: number };
 
 /** Dimensionless tolerance: a sine for orientation, a fraction for position. */
 const REL_EPS = 1e-12;

--- a/packages/renderer/src/fill-triangulate.test.ts
+++ b/packages/renderer/src/fill-triangulate.test.ts
@@ -1,0 +1,377 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import {
+  earClip,
+  groupRingsByNesting,
+  joinHoles,
+  signedRingArea,
+  triangulateRings,
+  type Pt,
+} from './fill-triangulate.js';
+
+/**
+ * Issue #2516. The shared cut-cap / IfcAnnotationFillArea triangulator did not
+ * subtract holes: a 4x4 square with a 2x2 hole came out at area 2 instead of
+ * 12, so every section cut through a wall opening or a slab void rendered a
+ * near-empty cap.
+ *
+ * Area is the assertion of record here because it is the one number that
+ * distinguishes all three behaviours at once:
+ *
+ *   2  — the shipped bug (the bridged ring deadlocks the ear clipper)
+ *   20 — the naive "flip the hole's winding" fix (hole ADDED, not subtracted)
+ *   12 — correct
+ *
+ * The nested cases exist so an implementation that special-cases one level of
+ * holes cannot pass by luck: with even-odd nesting an island inside a hole is
+ * solid again, which no single-level rule produces.
+ */
+
+function P(pts: Array<[number, number]>): Pt[] {
+  return pts.map(([x, z]) => ({ x, z }));
+}
+
+function triangulatedArea(points: readonly Pt[], triangles: readonly number[][]): number {
+  let sum = 0;
+  for (const [i, j, k] of triangles) {
+    const a = points[i];
+    const b = points[j];
+    const c = points[k];
+    sum += Math.abs((b.x - a.x) * (c.z - a.z) - (c.x - a.x) * (b.z - a.z)) / 2;
+  }
+  return sum;
+}
+
+function areaOf(rings: Pt[][]): number {
+  const { points, triangles } = triangulateRings(rings);
+  return triangulatedArea(points, triangles);
+}
+
+/** Even-odd containment, computed straight from the rings — the oracle the
+ *  triangulation has to agree with pointwise, not just in total area. */
+function evenOddInside(p: Pt, rings: readonly Pt[][]): boolean {
+  let crossings = 0;
+  for (const ring of rings) {
+    let inside = false;
+    for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+      const a = ring[i];
+      const b = ring[j];
+      if (
+        a.z > p.z !== b.z > p.z &&
+        p.x < ((b.x - a.x) * (p.z - a.z)) / (b.z - a.z) + a.x
+      ) {
+        inside = !inside;
+      }
+    }
+    if (inside) crossings++;
+  }
+  return crossings % 2 === 1;
+}
+
+/** How many emitted triangles strictly contain `p`. */
+function coverCount(p: Pt, points: readonly Pt[], triangles: readonly number[][]): number {
+  let n = 0;
+  for (const [i, j, k] of triangles) {
+    const a = points[i];
+    const b = points[j];
+    const c = points[k];
+    const det = (b.z - c.z) * (a.x - c.x) + (c.x - b.x) * (a.z - c.z);
+    if (Math.abs(det) < 1e-15) continue;
+    const l1 = ((b.z - c.z) * (p.x - c.x) + (c.x - b.x) * (p.z - c.z)) / det;
+    const l2 = ((c.z - a.z) * (p.x - c.x) + (a.x - c.x) * (p.z - c.z)) / det;
+    const l3 = 1 - l1 - l2;
+    if (l1 > 1e-7 && l2 > 1e-7 && l3 > 1e-7) n++;
+  }
+  return n;
+}
+
+const SQUARE_4 = P([
+  [0, 0],
+  [4, 0],
+  [4, 4],
+  [0, 4],
+]);
+const HOLE_2 = P([
+  [1, 1],
+  [1, 3],
+  [3, 3],
+  [3, 1],
+]);
+
+describe('triangulateRings — holes are subtracted (#2516)', () => {
+  it('gives a 4x4 square with a 2x2 hole its exact analytic area of 12', () => {
+    const area = areaOf([SQUARE_4, HOLE_2]);
+    assert.ok(
+      Math.abs(area - 12) < 1e-6,
+      `square-with-hole triangulated to ${area}; 2 = the #2516 bug, ` +
+        `20 = the hole added instead of subtracted, 12 = correct`,
+    );
+  });
+
+  it('leaves a hole-free profile byte-identical: same vertices, same order', () => {
+    const { points, triangles } = triangulateRings([SQUARE_4]);
+    assert.deepStrictEqual(points, SQUARE_4, 'hole-free rings must pass through untouched');
+    assert.strictEqual(triangles.length, 2);
+    assert.ok(Math.abs(triangulatedArea(points, triangles) - 16) < 1e-6);
+  });
+
+  it('keeps a concave hole-free cross-section at its true area', () => {
+    // L-shape, area 3 of a 2x2 bounding box.
+    const l = P([
+      [0, 0],
+      [2, 0],
+      [2, 1],
+      [1, 1],
+      [1, 2],
+      [0, 2],
+    ]);
+    assert.ok(Math.abs(areaOf([l]) - 3) < 1e-6);
+  });
+
+  it('fills an island inside a hole (even-odd, not one level of holes)', () => {
+    const outer = P([
+      [0, 0],
+      [10, 0],
+      [10, 10],
+      [0, 10],
+    ]);
+    const hole = P([
+      [2, 2],
+      [2, 8],
+      [8, 8],
+      [8, 2],
+    ]);
+    const island = P([
+      [4, 4],
+      [4, 6],
+      [6, 6],
+      [6, 4],
+    ]);
+    // 100 - 36 + 4. A rule that treats "every ring after the first" as a hole
+    // yields 100 - 36 - 4 = 60; the shipped bug yields ~2.
+    const area = areaOf([outer, hole, island]);
+    assert.ok(Math.abs(area - 68) < 1e-6, `nested island area was ${area}, expected 68`);
+  });
+
+  it('alternates fill and void four rings deep', () => {
+    const rings = [1, 2, 3, 4].map((_, i) => {
+      const d = i;
+      return P([
+        [d, d],
+        [10 - d, d],
+        [10 - d, 10 - d],
+        [d, 10 - d],
+      ]);
+    });
+    // 100 - 64 + 36 - 16.
+    assert.ok(Math.abs(areaOf(rings) - 56) < 1e-6);
+  });
+
+  it('does not care which winding the caller supplies', () => {
+    const cwOuter = P([
+      [0, 4],
+      [4, 4],
+      [4, 0],
+      [0, 0],
+    ]);
+    const cwHole = P([
+      [1, 1],
+      [3, 1],
+      [3, 3],
+      [1, 3],
+    ]);
+    for (const rings of [
+      [SQUARE_4, HOLE_2],
+      [SQUARE_4, cwHole],
+      [cwOuter, HOLE_2],
+      [cwOuter, cwHole],
+    ]) {
+      assert.ok(Math.abs(areaOf(rings) - 12) < 1e-6);
+    }
+  });
+
+  it('does not care which order the rings arrive in', () => {
+    assert.ok(Math.abs(areaOf([HOLE_2, SQUARE_4]) - 12) < 1e-6);
+  });
+
+  it('treats two disjoint rings as two filled boundaries, not one holed one', () => {
+    const a = P([
+      [0, 0],
+      [2, 0],
+      [2, 2],
+      [0, 2],
+    ]);
+    const b = P([
+      [5, 5],
+      [7, 5],
+      [7, 7],
+      [5, 7],
+    ]);
+    assert.ok(Math.abs(areaOf([a, b]) - 8) < 1e-6);
+  });
+
+  it('subtracts a hole flush against the outer edge', () => {
+    const flush = P([
+      [2, 1],
+      [2, 3],
+      [4, 3],
+      [4, 1],
+    ]);
+    assert.ok(Math.abs(areaOf([SQUARE_4, flush]) - 12) < 1e-6);
+  });
+
+  it('subtracts two separate holes', () => {
+    const outer = P([
+      [0, 0],
+      [10, 0],
+      [10, 6],
+      [0, 6],
+    ]);
+    const h1 = P([
+      [1, 1],
+      [1, 3],
+      [3, 3],
+      [3, 1],
+    ]);
+    const h2 = P([
+      [5, 1],
+      [5, 3],
+      [7, 3],
+      [7, 1],
+    ]);
+    assert.ok(Math.abs(areaOf([outer, h1, h2]) - 52) < 1e-6);
+  });
+
+  it('drops rings with fewer than 3 vertices instead of corrupting the result', () => {
+    const stub = P([
+      [1, 1],
+      [2, 2],
+    ]);
+    assert.ok(Math.abs(areaOf([SQUARE_4, stub]) - 16) < 1e-6);
+    assert.deepStrictEqual(triangulateRings([stub]).triangles, []);
+    assert.deepStrictEqual(triangulateRings([]).triangles, []);
+  });
+
+  it('covers every interior point exactly once and no exterior point at all', () => {
+    // Area alone cannot tell "right total, overlapping triangles + gaps" from
+    // "right tessellation". Sampling can.
+    const rings = [SQUARE_4, HOLE_2];
+    const { points, triangles } = triangulateRings(rings);
+    let seed = 987654321;
+    const rnd = () => {
+      seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+      return seed / 0x7fffffff;
+    };
+    for (let s = 0; s < 4000; s++) {
+      const p = { x: -1 + rnd() * 6, z: -1 + rnd() * 6 };
+      const want = evenOddInside(p, rings) ? 1 : 0;
+      assert.strictEqual(
+        coverCount(p, points, triangles),
+        want,
+        `point (${p.x}, ${p.z}) covered wrongly`,
+      );
+    }
+  });
+
+  it('holds on a fuzz of concave star boundaries with concave star holes', () => {
+    let seed = 12345;
+    const rnd = () => {
+      seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+      return seed / 0x7fffffff;
+    };
+    const star = (cx: number, cz: number, r0: number, r1: number, n: number): Pt[] => {
+      const pts: Pt[] = [];
+      for (let i = 0; i < n; i++) {
+        const t = (i / n) * Math.PI * 2;
+        const r = i % 2 === 0 ? r1 : r0 + rnd() * (r1 - r0);
+        pts.push({ x: cx + Math.cos(t) * r, z: cz + Math.sin(t) * r });
+      }
+      return pts;
+    };
+    const centres: Array<[number, number]> = [
+      [-2.4, -1.8],
+      [2.4, -1.8],
+      [0, 2.4],
+    ];
+
+    for (let iter = 0; iter < 200; iter++) {
+      const outer = star(0, 0, 6, 10, 6 + Math.floor(rnd() * 10) * 2);
+      const rings = [outer];
+      const holeCount = Math.floor(rnd() * 3);
+      for (let h = 0; h < holeCount; h++) {
+        rings.push(star(centres[h][0], centres[h][1], 0.8, 1.6, 4 + Math.floor(rnd() * 4) * 2));
+      }
+      let expected = Math.abs(signedRingArea(outer));
+      for (let h = 1; h < rings.length; h++) expected -= Math.abs(signedRingArea(rings[h]));
+      const got = areaOf(rings);
+      assert.ok(
+        Math.abs(got - expected) < 1e-6 * Math.max(1, expected),
+        `iter ${iter} (${holeCount} holes): area ${got}, expected ${expected}`,
+      );
+    }
+  });
+});
+
+describe('groupRingsByNesting', () => {
+  it('reads depth, not arrival order, when deciding what is a hole', () => {
+    const outer = P([
+      [0, 0],
+      [10, 0],
+      [10, 10],
+      [0, 10],
+    ]);
+    const hole = P([
+      [2, 2],
+      [2, 8],
+      [8, 8],
+      [8, 2],
+    ]);
+    const island = P([
+      [4, 4],
+      [4, 6],
+      [6, 6],
+      [6, 4],
+    ]);
+    const groups = groupRingsByNesting([island, hole, outer]);
+    assert.strictEqual(groups.length, 2, 'outer and island are both filled boundaries');
+    const withHole = groups.find((g) => g.holes.length === 1);
+    assert.ok(withHole, 'the depth-0 ring must own the depth-1 ring as a hole');
+    assert.strictEqual(Math.abs(signedRingArea(withHole.outer)), 100);
+    assert.strictEqual(Math.abs(signedRingArea(withHole.holes[0])), 36);
+    const islandGroup = groups.find((g) => g.holes.length === 0);
+    assert.ok(islandGroup);
+    assert.strictEqual(Math.abs(signedRingArea(islandGroup.outer)), 4);
+  });
+});
+
+describe('joinHoles + earClip', () => {
+  it('bridges the hole in with exactly two duplicated vertices', () => {
+    const stitched = joinHoles(SQUARE_4, [HOLE_2]);
+    // 4 outer + 4 hole + 2 bridge duplicates.
+    assert.strictEqual(stitched.length, 10);
+  });
+
+  it('clips the bridged ring rather than stalling on the bridge duplicates', () => {
+    // The #2516 root cause: the old ear test let a vertex sitting exactly ON a
+    // candidate ear veto it, and the bridge puts two such vertices in the ring,
+    // so the clipper emitted 1 triangle out of 8 and stopped.
+    const stitched = joinHoles(SQUARE_4, [HOLE_2]);
+    const tris = earClip(stitched);
+    assert.strictEqual(tris.length, stitched.length - 2, 'a simple n-gon has n-2 triangles');
+    assert.ok(Math.abs(triangulatedArea(stitched, tris) - 12) < 1e-6);
+  });
+
+  it('returns the ring untouched when there are no holes', () => {
+    assert.strictEqual(joinHoles(SQUARE_4, []), SQUARE_4);
+  });
+
+  it('reports ring winding by signed area', () => {
+    assert.ok(signedRingArea(SQUARE_4) > 0);
+    assert.strictEqual(signedRingArea(SQUARE_4), 16);
+    assert.strictEqual(signedRingArea(SQUARE_4.slice().reverse()), -16);
+  });
+});

--- a/packages/renderer/src/fill-triangulate.test.ts
+++ b/packages/renderer/src/fill-triangulate.test.ts
@@ -442,6 +442,35 @@ describe('joinHoles + earClip', () => {
     assert.ok(Math.abs(triangulatedArea(stitched, tris) - 12) < 1e-6);
   });
 
+  it('emits counter-clockwise triangles whatever the ring winding is', () => {
+    // A 3-vertex fast path used to return the caller's index order unchanged,
+    // so a clockwise TRIANGLE came back clockwise while a clockwise quad came
+    // back counter-clockwise. Nothing renders differently today (both cap
+    // pipelines are cullMode 'none') but anything deriving a facing direction
+    // from these indices would read one of the two backwards.
+    const orientationOf = (ring: Pt[], tri: number[]): number => {
+      const [i, j, k] = tri;
+      const a = ring[i];
+      const b = ring[j];
+      const c = ring[k];
+      return Math.sign((b.x - a.x) * (c.z - a.z) - (c.x - a.x) * (b.z - a.z));
+    };
+    const rings: Array<[string, Pt[]]> = [
+      ['CW triangle', P([[0, 0], [0, 4], [4, 0]])],
+      ['CCW triangle', P([[0, 0], [4, 0], [0, 4]])],
+      ['CW quad', P([[0, 0], [0, 4], [4, 4], [4, 0]])],
+      ['CCW quad', SQUARE_4],
+      ['CW concave L', P([[0, 0], [0, 2], [1, 2], [1, 1], [2, 1], [2, 0]])],
+    ];
+    for (const [name, ring] of rings) {
+      const tris = earClip(ring);
+      assert.ok(tris.length > 0, `${name} produced no triangles`);
+      for (const tri of tris) {
+        assert.strictEqual(orientationOf(ring, tri), 1, `${name} emitted a non-CCW triangle`);
+      }
+    }
+  });
+
   it('returns the ring untouched when there are no holes', () => {
     assert.strictEqual(joinHoles(SQUARE_4, []), SQUARE_4);
   });

--- a/packages/renderer/src/fill-triangulate.test.ts
+++ b/packages/renderer/src/fill-triangulate.test.ts
@@ -316,6 +316,83 @@ describe('triangulateRings — holes are subtracted (#2516)', () => {
   });
 });
 
+describe('triangulateRings — degradation on malformed rings', () => {
+  /**
+   * The ear clipper can run out of ears on a ring that is not simple. It then
+   * returns a PARTIAL fill rather than throwing. These inputs are all
+   * schema-illegal (IFC requires inner bounds to be contained in their outer
+   * bound, and rings not to self-intersect), so there is no correct answer to
+   * assert — what is pinned here is the failure MODE.
+   *
+   * Note what is deliberately NOT claimed: that the degradation only ever
+   * omits area. It does for an inner bound that pokes out of its outer bound,
+   * but NOT for a self-intersecting ring — a bow-tie triangulates to 16 where
+   * even-odd says 8, because ear clipping reads "inside" from the ring's
+   * normalised orientation rather than from crossing parity. Asserting
+   * one-sidedness here would be asserting something false.
+   *
+   * What does hold, and is what a render thread actually needs, is that every
+   * one of these RETURNS, in bounded time, with finite geometry that stays
+   * inside the input's own extent.
+   */
+  const malformed: Array<[string, Pt[][]]> = [
+    [
+      'inner bound pokes outside its outer bound',
+      [SQUARE_4, P([[3, 3], [6, 3], [6, 6], [3, 6]])],
+    ],
+    ['self-intersecting bow-tie', [P([[0, 0], [4, 4], [4, 0], [0, 4]])]],
+    [
+      'two overlapping inner bounds',
+      [
+        P([[0, 0], [10, 0], [10, 10], [0, 10]]),
+        P([[2, 2], [6, 2], [6, 6], [2, 6]]),
+        P([[4, 4], [8, 4], [8, 8], [4, 8]]),
+      ],
+    ],
+    ['ring that doubles back on itself', [P([[0, 0], [10, 0], [10, 10], [5, 10], [5, 5], [5, 10], [0, 10]])]],
+    ['fully collinear ring', [P([[0, 0], [1, 0], [2, 0], [3, 0]])]],
+  ];
+
+  for (const [name, rings] of malformed) {
+    it(`degrades inside the input's own extent: ${name}`, () => {
+      const { points, triangles } = triangulateRings(rings);
+      const covered = triangulatedArea(points, triangles);
+      assert.ok(Number.isFinite(covered), 'degraded output must still be finite');
+
+      // Every emitted vertex has to be one of the input's own, so a stalled
+      // clipper can only ever under-report — it can never invent geometry
+      // somewhere else on the plane.
+      const all = rings.flat();
+      for (const p of points) {
+        assert.ok(
+          all.some((q) => q.x === p.x && q.z === p.z),
+          `emitted vertex (${p.x}, ${p.z}) is not an input vertex`,
+        );
+      }
+
+      // And it cannot cover more than the bounding box it was handed.
+      const xs = all.map((p) => p.x);
+      const zs = all.map((p) => p.z);
+      const bbox =
+        (Math.max(...xs) - Math.min(...xs)) * (Math.max(...zs) - Math.min(...zs));
+      assert.ok(covered <= bbox + 1e-9, `covered ${covered} exceeds the bbox ${bbox}`);
+    });
+  }
+
+  it('terminates on a ring built to starve the ear clipper', () => {
+    // 200 vertices spiralling into themselves. The guard here is that the test
+    // returns at all: an unbounded retry loop would hang the render thread.
+    const spiral: Pt[] = [];
+    for (let i = 0; i < 200; i++) {
+      const t = (i / 200) * Math.PI * 12;
+      const r = 10 - i * 0.045;
+      spiral.push({ x: Math.cos(t) * r, z: Math.sin(t) * r });
+    }
+    const { points, triangles } = triangulateRings([spiral]);
+    assert.ok(Number.isFinite(triangulatedArea(points, triangles)));
+  });
+});
+
 describe('groupRingsByNesting', () => {
   it('reads depth, not arrival order, when deciding what is a hole', () => {
     const outer = P([

--- a/packages/renderer/src/fill-triangulate.ts
+++ b/packages/renderer/src/fill-triangulate.ts
@@ -332,7 +332,11 @@ function findZeroAreaVertex(ring: ReadonlyArray<Pt>, indices: readonly number[])
   return -1;
 }
 
-/** Triangulated ring set: a deduplicated point list plus index triples. */
+/**
+ * Triangulated ring set: a concatenated point list plus index triples into it.
+ * Points are NOT deduplicated — each group contributes its bridged ring whole,
+ * which repeats two vertices per hole (see {@link joinHoles}).
+ */
 export interface TriangulatedRings {
   points: Pt[];
   triangles: number[][];

--- a/packages/renderer/src/fill-triangulate.ts
+++ b/packages/renderer/src/fill-triangulate.ts
@@ -1,0 +1,366 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Even-odd triangulation of a flat ring set (issue #2516).
+ *
+ * Two consumers hand us the same shape of input — a bag of closed 2D rings in
+ * the (x, z) plane with no promised winding and no promised order:
+ *
+ *   - section cut caps (`buildCapFillGeometry`), where the rings are a cut
+ *     polygon's outer boundary plus the openings/voids the plane sliced
+ *     through;
+ *   - `IfcAnnotationFillArea` (`SymbolicFillPipeline`), where the rings are the
+ *     annotation's outer bound plus its inner bounds.
+ *
+ * Both used to assume "ring 0 is the outer boundary, everything else is a hole"
+ * and then bridge the holes in and ear-clip. That produced a *near-empty* cap
+ * wherever a profile had a hole: the bridge duplicates two vertices, and the
+ * old ear test treated any vertex lying ON a candidate ear (including those
+ * duplicates) as obstructing it, so almost no ear was ever clipped. A 4x4
+ * square with a 2x2 hole came out at area 2 instead of 12.
+ *
+ * The fix here is deliberately NOT "reverse the hole's winding" — with the
+ * hole merely added rather than subtracted the same case comes out at 20. What
+ * is actually needed is the even-odd rule:
+ *
+ *   1. Nest the rings: a ring's depth is the number of other rings that
+ *      contain it. Even depth = filled boundary, odd depth = hole. That is what
+ *      makes a hole-inside-a-hole (an island) come back as solid rather than as
+ *      another void.
+ *   2. Group each even-depth ring with its immediate children.
+ *   3. Bridge each group's holes into its boundary and ear-clip, with an ear
+ *      test that (a) only lets REFLEX vertices obstruct an ear and (b) ignores
+ *      vertices coincident with the ear's own corners, which is exactly the
+ *      bridge duplicate that used to deadlock the clipper.
+ *
+ * Everything is O(n²) in the ring's vertex count, which is fine: fill regions
+ * and cut cross-sections are tens of vertices, not thousands.
+ */
+
+/** A point on the fill plane. Y is constant per fill, so only (x, z) travel. */
+export type Pt = { x: number; z: number };
+
+/** Below this, a cross product is treated as zero (collinear/degenerate). */
+const EPS_CROSS = 1e-12;
+/** Coordinate tolerance for "these two vertices are the same point". */
+const EPS_SAME = 1e-9;
+
+/**
+ * Shoelace area of a ring in the (x, z) plane. Positive = counter-clockwise.
+ * Winding normalisation is built on this, and tests use it to state the
+ * analytic area a ring set must triangulate to.
+ */
+export function signedRingArea(ring: readonly Pt[]): number {
+  let a = 0;
+  for (let i = 0; i < ring.length; i++) {
+    const p = ring[i];
+    const q = ring[(i + 1) % ring.length];
+    a += p.x * q.z - q.x * p.z;
+  }
+  return a / 2;
+}
+
+/** Crossing-number point-in-polygon. Points exactly on the ring are undefined
+ *  here — callers screen those out with {@link pointOnRing} first. */
+function pointInRing(p: Pt, ring: readonly Pt[]): boolean {
+  let inside = false;
+  for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+    const a = ring[i];
+    const b = ring[j];
+    if (
+      a.z > p.z !== b.z > p.z &&
+      p.x < ((b.x - a.x) * (p.z - a.z)) / (b.z - a.z) + a.x
+    ) {
+      inside = !inside;
+    }
+  }
+  return inside;
+}
+
+/** True when `p` lies on one of the ring's edges (within tolerance). */
+function pointOnRing(p: Pt, ring: readonly Pt[]): boolean {
+  for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+    const a = ring[i];
+    const b = ring[j];
+    const cross = (b.x - a.x) * (p.z - a.z) - (b.z - a.z) * (p.x - a.x);
+    if (Math.abs(cross) > EPS_SAME) continue;
+    const dot = (p.x - a.x) * (b.x - a.x) + (p.z - a.z) * (b.z - a.z);
+    const len = (b.x - a.x) ** 2 + (b.z - a.z) ** 2;
+    if (dot >= -EPS_SAME && dot <= len + EPS_SAME) return true;
+  }
+  return false;
+}
+
+/**
+ * True when `inner` sits inside `outer`. Well-formed IFC bounds never cross,
+ * so the first vertex of `inner` that is not ON `outer` settles it; shared
+ * vertices and shared edge stretches (a hole flush against the boundary) are
+ * skipped rather than decided.
+ */
+function ringInsideRing(inner: readonly Pt[], outer: readonly Pt[]): boolean {
+  for (const p of inner) {
+    if (pointOnRing(p, outer)) continue;
+    return pointInRing(p, outer);
+  }
+  return false;
+}
+
+/** One filled boundary and the holes cut directly out of it. */
+export interface RingGroup {
+  outer: Pt[];
+  holes: Pt[][];
+}
+
+/**
+ * Sort a bag of rings into filled boundaries and their holes by the even-odd
+ * rule. Rings with fewer than 3 vertices are dropped.
+ *
+ * A ring nested at odd depth is a hole; at even depth it is filled — so an
+ * island inside a hole comes back as its own group rather than being counted
+ * as void. A ring at depth d+1 that is contained in a ring at depth d is
+ * necessarily its immediate child (every ring containing the child also
+ * contains the parent, so the counts can only differ by the parent itself),
+ * which is why no explicit tree is built.
+ */
+export function groupRingsByNesting(rings: readonly (readonly Pt[])[]): RingGroup[] {
+  const usable = rings.filter((r) => r.length >= 3).map((r) => r.slice());
+  const depth = usable.map((r, i) =>
+    usable.reduce((d, other, j) => (j !== i && ringInsideRing(r, other) ? d + 1 : d), 0),
+  );
+
+  const groups: RingGroup[] = [];
+  for (let i = 0; i < usable.length; i++) {
+    if (depth[i] % 2 !== 0) continue;
+    const holes: Pt[][] = [];
+    for (let j = 0; j < usable.length; j++) {
+      if (j === i || depth[j] !== depth[i] + 1) continue;
+      if (ringInsideRing(usable[j], usable[i])) holes.push(usable[j]);
+    }
+    groups.push({ outer: usable[i], holes });
+  }
+  return groups;
+}
+
+function asCcw(ring: Pt[]): Pt[] {
+  return signedRingArea(ring) >= 0 ? ring : ring.slice().reverse();
+}
+
+function asCw(ring: Pt[]): Pt[] {
+  return signedRingArea(ring) <= 0 ? ring : ring.slice().reverse();
+}
+
+/**
+ * Stitch each hole into the outer ring with a single bridge edge so the result
+ * is one simple polygon ear-clipping can handle. Mirrors mapbox/earcut's
+ * `eliminateHoles` pass:
+ *
+ *   1. For each hole, pick its rightmost (max-x) vertex as the bridge start.
+ *   2. Sort holes by descending bridge-start x so outer holes go in first.
+ *   3. Walk the outer ring for the nearest vertex to the right of the bridge
+ *      start, falling back to the global nearest when the hole touches the
+ *      outer ring's right edge.
+ *   4. Splice the hole in at that anchor, closing both ends back to their
+ *      starts to form a zero-area bridge edge.
+ *
+ * Windings are normalised here rather than assumed: the boundary is made CCW
+ * and every hole CW, so the merged ring's signed area stays consistent no
+ * matter how the caller's rings were wound.
+ */
+export function joinHoles(outer: Pt[], holes: Pt[][]): Pt[] {
+  if (holes.length === 0) return outer;
+
+  type HoleEntry = { ring: Pt[]; startIdx: number; startX: number; startZ: number };
+  const sorted: HoleEntry[] = holes
+    .map((h) => asCw(h))
+    .map((ring) => {
+      let bestI = 0;
+      for (let i = 1; i < ring.length; i++) {
+        if (ring[i].x > ring[bestI].x) bestI = i;
+      }
+      return { ring, startIdx: bestI, startX: ring[bestI].x, startZ: ring[bestI].z };
+    })
+    .sort((a, b) => b.startX - a.startX);
+
+  let result: Pt[] = asCcw(outer).slice();
+
+  for (const { ring, startIdx, startX, startZ } of sorted) {
+    let bestIdx = -1;
+    let bestDist = Infinity;
+    for (let i = 0; i < result.length; i++) {
+      const p = result[i];
+      if (p.x <= startX) continue;
+      const d = (p.x - startX) ** 2 + (p.z - startZ) ** 2;
+      if (d < bestDist) {
+        bestDist = d;
+        bestIdx = i;
+      }
+    }
+    if (bestIdx < 0) {
+      for (let i = 0; i < result.length; i++) {
+        const p = result[i];
+        const d = (p.x - startX) ** 2 + (p.z - startZ) ** 2;
+        if (d < bestDist) {
+          bestDist = d;
+          bestIdx = i;
+        }
+      }
+    }
+    if (bestIdx < 0) continue;
+
+    const rotated = [...ring.slice(startIdx), ...ring.slice(0, startIdx)];
+    result = [
+      ...result.slice(0, bestIdx + 1),
+      ...rotated,
+      rotated[0],
+      result[bestIdx],
+      ...result.slice(bestIdx + 1),
+    ];
+  }
+
+  return result;
+}
+
+function samePoint(a: Pt, b: Pt): boolean {
+  return Math.abs(a.x - b.x) <= EPS_SAME && Math.abs(a.z - b.z) <= EPS_SAME;
+}
+
+function pointInTriangle(p: Pt, a: Pt, b: Pt, c: Pt): boolean {
+  const s1 = (p.x - c.x) * (a.z - c.z) - (a.x - c.x) * (p.z - c.z);
+  const s2 = (p.x - a.x) * (b.z - a.z) - (b.x - a.x) * (p.z - a.z);
+  const s3 = (p.x - b.x) * (c.z - b.z) - (c.x - b.x) * (p.z - b.z);
+  const hasNeg = s1 < 0 || s2 < 0 || s3 < 0;
+  const hasPos = s1 > 0 || s2 > 0 || s3 > 0;
+  return !(hasNeg && hasPos);
+}
+
+/**
+ * Ear-clipping triangulation of a simple polygon (which may be a bridged
+ * polygon-with-holes). Returns triangles as index triples into `ring`.
+ *
+ * Two properties keep the bridged case from deadlocking, and both are the
+ * #2516 fix:
+ *
+ *   - only a REFLEX vertex can obstruct an ear of a simple polygon, so convex
+ *     vertices are not tested at all. Testing them made every vertex lying on
+ *     an axis-aligned ear edge veto that ear;
+ *   - a vertex coincident with one of the ear's own corners is skipped. That
+ *     is precisely the duplicate the bridge introduces; the slit it belongs to
+ *     has zero width, so it cannot cover any of the ear.
+ *
+ * When no ear can be found the clipper drops one zero-area (collinear or
+ * duplicated) vertex — which cannot change the covered region — and retries,
+ * rather than bailing out with most of the polygon untriangulated.
+ */
+export function earClip(ring: ReadonlyArray<Pt>): number[][] {
+  const n = ring.length;
+  if (n < 3) return [];
+  if (n === 3) return [[0, 1, 2]];
+
+  // Walk the ring counter-clockwise so the ear test below has a fixed sign.
+  let area2 = 0;
+  for (let i = 0; i < n; i++) {
+    const a = ring[i];
+    const b = ring[(i + 1) % n];
+    area2 += a.x * b.z - b.x * a.z;
+  }
+  const indices: number[] = [];
+  for (let i = 0; i < n; i++) indices.push(area2 > 0 ? i : n - 1 - i);
+
+  const triangles: number[][] = [];
+  let safety = indices.length * indices.length;
+
+  while (indices.length > 3 && safety-- > 0) {
+    let found = false;
+    for (let i = 0; i < indices.length; i++) {
+      if (!isEar(ring, indices, i)) continue;
+      const m = indices.length;
+      triangles.push([indices[(i + m - 1) % m], indices[i], indices[(i + 1) % m]]);
+      indices.splice(i, 1);
+      found = true;
+      break;
+    }
+    if (found) continue;
+
+    const degenerate = findZeroAreaVertex(ring, indices);
+    if (degenerate < 0) break; // genuinely stuck — emit what we have
+    indices.splice(degenerate, 1);
+  }
+
+  if (indices.length === 3) {
+    triangles.push([indices[0], indices[1], indices[2]]);
+  }
+  return triangles;
+}
+
+function isEar(ring: ReadonlyArray<Pt>, indices: readonly number[], i: number): boolean {
+  const m = indices.length;
+  const ia = indices[(i + m - 1) % m];
+  const ib = indices[i];
+  const ic = indices[(i + 1) % m];
+  const a = ring[ia];
+  const b = ring[ib];
+  const c = ring[ic];
+
+  const cross = (b.x - a.x) * (c.z - b.z) - (b.z - a.z) * (c.x - b.x);
+  if (cross <= EPS_CROSS) return false; // reflex or degenerate corner
+
+  for (let j = 0; j < m; j++) {
+    const ij = indices[j];
+    if (ij === ia || ij === ib || ij === ic) continue;
+    const p = ring[ij];
+    if (samePoint(p, a) || samePoint(p, b) || samePoint(p, c)) continue;
+
+    const prev = ring[indices[(j + m - 1) % m]];
+    const next = ring[indices[(j + 1) % m]];
+    const pCross = (p.x - prev.x) * (next.z - p.z) - (p.z - prev.z) * (next.x - p.x);
+    if (pCross > EPS_CROSS) continue; // strictly convex — cannot obstruct
+
+    if (pointInTriangle(p, a, b, c)) return false;
+  }
+  return true;
+}
+
+function findZeroAreaVertex(ring: ReadonlyArray<Pt>, indices: readonly number[]): number {
+  const m = indices.length;
+  for (let i = 0; i < m; i++) {
+    const a = ring[indices[(i + m - 1) % m]];
+    const b = ring[indices[i]];
+    const c = ring[indices[(i + 1) % m]];
+    const cross = (b.x - a.x) * (c.z - b.z) - (b.z - a.z) * (c.x - b.x);
+    if (Math.abs(cross) <= EPS_CROSS) return i;
+  }
+  return -1;
+}
+
+/** Triangulated ring set: a deduplicated point list plus index triples. */
+export interface TriangulatedRings {
+  points: Pt[];
+  triangles: number[][];
+}
+
+/**
+ * Triangulate a bag of rings under the even-odd rule. This is the single entry
+ * point both fill consumers call; see the module comment for why.
+ *
+ * A hole-free ring set takes the same path it always did — the ring is handed
+ * straight to {@link earClip} in its original vertex order — so profiles
+ * without holes are byte-identical to before #2516.
+ */
+export function triangulateRings(rings: readonly (readonly Pt[])[]): TriangulatedRings {
+  const points: Pt[] = [];
+  const triangles: number[][] = [];
+
+  for (const group of groupRingsByNesting(rings)) {
+    const stitched =
+      group.holes.length === 0 ? group.outer : joinHoles(group.outer, group.holes);
+    const tris = earClip(stitched);
+    if (tris.length === 0) continue;
+    const base = points.length;
+    for (const p of stitched) points.push(p);
+    for (const [a, b, c] of tris) triangles.push([base + a, base + b, base + c]);
+  }
+
+  return { points, triangles };
+}

--- a/packages/renderer/src/fill-triangulate.ts
+++ b/packages/renderer/src/fill-triangulate.ts
@@ -42,14 +42,10 @@
 // `fill-bridge-anchor.ts` imports only the `Pt` TYPE back from here, which is
 // erased at compile time, so this pairing is not a runtime cycle.
 import { chooseBridgeAnchor } from './fill-bridge-anchor.js';
+import { orient, pointOnSegment, ringScale, samePoint } from './fill-predicates.js';
 
 /** A point on the fill plane. Y is constant per fill, so only (x, z) travel. */
 export type Pt = { x: number; z: number };
-
-/** Below this, a cross product is treated as zero (collinear/degenerate). */
-const EPS_CROSS = 1e-12;
-/** Coordinate tolerance for "these two vertices are the same point". */
-const EPS_SAME = 1e-9;
 
 /**
  * Shoelace area of a ring in the (x, z) plane. Positive = counter-clockwise.
@@ -83,16 +79,10 @@ function pointInRing(p: Pt, ring: readonly Pt[]): boolean {
   return inside;
 }
 
-/** True when `p` lies on one of the ring's edges (within tolerance). */
+/** True when `p` lies on one of the ring's edges, endpoints included. */
 function pointOnRing(p: Pt, ring: readonly Pt[]): boolean {
   for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
-    const a = ring[i];
-    const b = ring[j];
-    const cross = (b.x - a.x) * (p.z - a.z) - (b.z - a.z) * (p.x - a.x);
-    if (Math.abs(cross) > EPS_SAME) continue;
-    const dot = (p.x - a.x) * (b.x - a.x) + (p.z - a.z) * (b.z - a.z);
-    const len = (b.x - a.x) ** 2 + (b.z - a.z) ** 2;
-    if (dot >= -EPS_SAME && dot <= len + EPS_SAME) return true;
+    if (pointOnSegment(p, ring[i], ring[j], true)) return true;
   }
   return false;
 }
@@ -205,10 +195,6 @@ export function joinHoles(outer: Pt[], holes: Pt[][]): Pt[] {
   return result;
 }
 
-function samePoint(a: Pt, b: Pt): boolean {
-  return Math.abs(a.x - b.x) <= EPS_SAME && Math.abs(a.z - b.z) <= EPS_SAME;
-}
-
 function pointInTriangle(p: Pt, a: Pt, b: Pt, c: Pt): boolean {
   const s1 = (p.x - c.x) * (a.z - c.z) - (a.x - c.x) * (p.z - c.z);
   const s2 = (p.x - a.x) * (b.z - a.z) - (b.x - a.x) * (p.z - a.z);
@@ -241,6 +227,11 @@ export function earClip(ring: ReadonlyArray<Pt>): number[][] {
   if (n < 3) return [];
   if (n === 3) return [[0, 1, 2]];
 
+  // Coordinate comparisons are measured against the ring's own extent, so the
+  // same ring triangulates identically whether it is stated in metres or in
+  // millimetres.
+  const scale = ringScale(ring);
+
   // Walk the ring counter-clockwise so the ear test below has a fixed sign.
   let area2 = 0;
   for (let i = 0; i < n; i++) {
@@ -257,7 +248,7 @@ export function earClip(ring: ReadonlyArray<Pt>): number[][] {
   while (indices.length > 3 && safety-- > 0) {
     let found = false;
     for (let i = 0; i < indices.length; i++) {
-      if (!isEar(ring, indices, i)) continue;
+      if (!isEar(ring, indices, i, scale)) continue;
       const m = indices.length;
       triangles.push([indices[(i + m - 1) % m], indices[i], indices[(i + 1) % m]]);
       indices.splice(i, 1);
@@ -277,7 +268,12 @@ export function earClip(ring: ReadonlyArray<Pt>): number[][] {
   return triangles;
 }
 
-function isEar(ring: ReadonlyArray<Pt>, indices: readonly number[], i: number): boolean {
+function isEar(
+  ring: ReadonlyArray<Pt>,
+  indices: readonly number[],
+  i: number,
+  scale: number,
+): boolean {
   const m = indices.length;
   const ia = indices[(i + m - 1) % m];
   const ib = indices[i];
@@ -286,19 +282,17 @@ function isEar(ring: ReadonlyArray<Pt>, indices: readonly number[], i: number): 
   const b = ring[ib];
   const c = ring[ic];
 
-  const cross = (b.x - a.x) * (c.z - b.z) - (b.z - a.z) * (c.x - b.x);
-  if (cross <= EPS_CROSS) return false; // reflex or degenerate corner
+  if (orient(a, b, c) <= 0) return false; // reflex or degenerate corner
 
   for (let j = 0; j < m; j++) {
     const ij = indices[j];
     if (ij === ia || ij === ib || ij === ic) continue;
     const p = ring[ij];
-    if (samePoint(p, a) || samePoint(p, b) || samePoint(p, c)) continue;
+    if (samePoint(p, a, scale) || samePoint(p, b, scale) || samePoint(p, c, scale)) continue;
 
     const prev = ring[indices[(j + m - 1) % m]];
     const next = ring[indices[(j + 1) % m]];
-    const pCross = (p.x - prev.x) * (next.z - p.z) - (p.z - prev.z) * (next.x - p.x);
-    if (pCross > EPS_CROSS) continue; // strictly convex — cannot obstruct
+    if (orient(prev, p, next) > 0) continue; // strictly convex — cannot obstruct
 
     if (pointInTriangle(p, a, b, c)) return false;
   }
@@ -311,8 +305,7 @@ function findZeroAreaVertex(ring: ReadonlyArray<Pt>, indices: readonly number[])
     const a = ring[indices[(i + m - 1) % m]];
     const b = ring[indices[i]];
     const c = ring[indices[(i + 1) % m]];
-    const cross = (b.x - a.x) * (c.z - b.z) - (b.z - a.z) * (c.x - b.x);
-    if (Math.abs(cross) <= EPS_CROSS) return i;
+    if (orient(a, b, c) === 0) return i;
   }
   return -1;
 }

--- a/packages/renderer/src/fill-triangulate.ts
+++ b/packages/renderer/src/fill-triangulate.ts
@@ -39,13 +39,19 @@
  * and cut cross-sections are tens of vertices, not thousands.
  */
 
-// `fill-bridge-anchor.ts` imports only the `Pt` TYPE back from here, which is
-// erased at compile time, so this pairing is not a runtime cycle.
 import { chooseBridgeAnchor } from './fill-bridge-anchor.js';
-import { orient, pointOnSegment, ringScale, samePoint } from './fill-predicates.js';
+import {
+  orient,
+  pointOnSegment,
+  ringScale,
+  samePoint,
+  type Pt,
+} from './fill-predicates.js';
 
-/** A point on the fill plane. Y is constant per fill, so only (x, z) travel. */
-export type Pt = { x: number; z: number };
+// Re-exported so consumers keep importing `Pt` alongside the triangulator they
+// already import; it is DEFINED in `fill-predicates.ts`, the leaf module, so
+// the dependency graph runs one way.
+export type { Pt };
 
 /**
  * Shoelace area of a ring in the (x, z) plane. Positive = counter-clockwise.
@@ -251,7 +257,10 @@ function pointInTriangle(p: Pt, a: Pt, b: Pt, c: Pt): boolean {
 export function earClip(ring: ReadonlyArray<Pt>): number[][] {
   const n = ring.length;
   if (n < 3) return [];
-  if (n === 3) return [[0, 1, 2]];
+  // No 3-vertex fast path: it returned the caller's index order unnormalised,
+  // so a clockwise TRIANGLE came back clockwise while a clockwise quad came
+  // back counter-clockwise. The winding-normalisation below costs nothing at
+  // n = 3 and makes every emitted triangle agree.
 
   // Coordinate comparisons are measured against the ring's own extent, so the
   // same ring triangulates identically whether it is stated in metres or in

--- a/packages/renderer/src/fill-triangulate.ts
+++ b/packages/renderer/src/fill-triangulate.ts
@@ -221,6 +221,28 @@ function pointInTriangle(p: Pt, a: Pt, b: Pt, c: Pt): boolean {
  * When no ear can be found the clipper drops one zero-area (collinear or
  * duplicated) vertex — which cannot change the covered region — and retries,
  * rather than bailing out with most of the polygon untriangulated.
+ *
+ * If even that leaves no ear the loop stops and returns what it has, which is
+ * a PARTIAL fill. That is deliberate, and it is the least-bad option rather
+ * than an oversight:
+ *
+ *   - it is not reachable for well-formed rings. Measured over 20 000 rotated
+ *     multi-notch boundaries with a hole in a random solid column, 4 000
+ *     axis-aligned ones and 2 000 concave stars with up to three concave
+ *     holes: zero occurrences, zero area error. It fires on schema-illegal
+ *     input, e.g. an inner bound that pokes outside its outer bound;
+ *   - throwing would lose the whole cap upload over one bad profile;
+ *   - falling back to a fan over the outer ring would reintroduce BOTH defects
+ *     this module exists to remove — holes not subtracted, and inversion on
+ *     concave cross-sections.
+ *
+ * What the partial output does NOT promise is that it only ever omits area:
+ * a self-intersecting ring triangulates to more than even-odd would fill,
+ * because ear clipping reads "inside" from the ring's normalised orientation
+ * rather than from crossing parity. What it does promise — and what a render
+ * thread needs — is that it returns in bounded time, emits only vertices it
+ * was given, and stays inside the input's own extent.
+ * `fill-triangulate.test.ts` pins those.
  */
 export function earClip(ring: ReadonlyArray<Pt>): number[][] {
   const n = ring.length;
@@ -258,7 +280,7 @@ export function earClip(ring: ReadonlyArray<Pt>): number[][] {
     if (found) continue;
 
     const degenerate = findZeroAreaVertex(ring, indices);
-    if (degenerate < 0) break; // genuinely stuck — emit what we have
+    if (degenerate < 0) break; // see the note above on partial output
     indices.splice(degenerate, 1);
   }
 

--- a/packages/renderer/src/fill-triangulate.ts
+++ b/packages/renderer/src/fill-triangulate.ts
@@ -39,6 +39,10 @@
  * and cut cross-sections are tens of vertices, not thousands.
  */
 
+// `fill-bridge-anchor.ts` imports only the `Pt` TYPE back from here, which is
+// erased at compile time, so this pairing is not a runtime cycle.
+import { chooseBridgeAnchor } from './fill-bridge-anchor.js';
+
 /** A point on the fill plane. Y is constant per fill, so only (x, z) travel. */
 export type Pt = { x: number; z: number };
 
@@ -158,9 +162,8 @@ function asCw(ring: Pt[]): Pt[] {
  *
  *   1. For each hole, pick its rightmost (max-x) vertex as the bridge start.
  *   2. Sort holes by descending bridge-start x so outer holes go in first.
- *   3. Walk the outer ring for the nearest vertex to the right of the bridge
- *      start, falling back to the global nearest when the hole touches the
- *      outer ring's right edge.
+ *   3. Pick the anchor on the boundary the bridge can actually reach without
+ *      crossing anything — see `fill-bridge-anchor.ts`.
  *   4. Splice the hole in at that anchor, closing both ends back to their
  *      starts to form a zero-area bridge edge.
  *
@@ -171,7 +174,7 @@ function asCw(ring: Pt[]): Pt[] {
 export function joinHoles(outer: Pt[], holes: Pt[][]): Pt[] {
   if (holes.length === 0) return outer;
 
-  type HoleEntry = { ring: Pt[]; startIdx: number; startX: number; startZ: number };
+  type HoleEntry = { ring: Pt[]; startIdx: number; startX: number };
   const sorted: HoleEntry[] = holes
     .map((h) => asCw(h))
     .map((ring) => {
@@ -179,34 +182,14 @@ export function joinHoles(outer: Pt[], holes: Pt[][]): Pt[] {
       for (let i = 1; i < ring.length; i++) {
         if (ring[i].x > ring[bestI].x) bestI = i;
       }
-      return { ring, startIdx: bestI, startX: ring[bestI].x, startZ: ring[bestI].z };
+      return { ring, startIdx: bestI, startX: ring[bestI].x };
     })
     .sort((a, b) => b.startX - a.startX);
 
   let result: Pt[] = asCcw(outer).slice();
 
-  for (const { ring, startIdx, startX, startZ } of sorted) {
-    let bestIdx = -1;
-    let bestDist = Infinity;
-    for (let i = 0; i < result.length; i++) {
-      const p = result[i];
-      if (p.x <= startX) continue;
-      const d = (p.x - startX) ** 2 + (p.z - startZ) ** 2;
-      if (d < bestDist) {
-        bestDist = d;
-        bestIdx = i;
-      }
-    }
-    if (bestIdx < 0) {
-      for (let i = 0; i < result.length; i++) {
-        const p = result[i];
-        const d = (p.x - startX) ** 2 + (p.z - startZ) ** 2;
-        if (d < bestDist) {
-          bestDist = d;
-          bestIdx = i;
-        }
-      }
-    }
+  for (const { ring, startIdx } of sorted) {
+    const bestIdx = chooseBridgeAnchor(result, ring, startIdx);
     if (bestIdx < 0) continue;
 
     const rotated = [...ring.slice(startIdx), ...ring.slice(0, startIdx)];

--- a/packages/renderer/src/fill-triangulate.ts
+++ b/packages/renderer/src/fill-triangulate.ts
@@ -166,6 +166,10 @@ export function joinHoles(outer: Pt[], holes: Pt[][]): Pt[] {
 
   type HoleEntry = { ring: Pt[]; startIdx: number; startX: number };
   const sorted: HoleEntry[] = holes
+    // Same degenerate-ring rule the rest of the module uses. Without it a
+    // 1- or 2-point "hole" bridges in as a spur, which is silently wrong
+    // geometry rather than a dropped hole.
+    .filter((h) => h.length >= 3)
     .map((h) => asCw(h))
     .map((ring) => {
       let bestI = 0;

--- a/packages/renderer/src/section-2d-lift.test.ts
+++ b/packages/renderer/src/section-2d-lift.test.ts
@@ -199,7 +199,7 @@ describe('buildCapFillGeometry', () => {
     assert.ok(Math.abs(area - 3) < 1e-5, `concave area was ${area}, expected 3`);
   });
 
-  it('stitches a hole ring into the outer ring rather than ignoring it', () => {
+  it('subtracts a hole ring from the cut face (#2516)', () => {
     const withHole = poly(
       [[0, 0], [4, 0], [4, 4], [0, 4]],
       [[[1, 1], [1, 3], [3, 3], [3, 1]]],
@@ -209,15 +209,25 @@ describe('buildCapFillGeometry', () => {
     // 4 outer + 4 hole + 2 bridge duplicates.
     assert.strictEqual(geom.vertices.length / FLOATS_PER_VERTEX, 10);
     const area = triangulatedArea(geom.vertices, geom.indices);
-    assert.ok(area < 16, `a holed cut face must not cover the full outer ring (got ${area})`);
+    // 2 = the pre-#2516 bug (the bridged ring deadlocked the ear clipper and
+    // the cap rendered near-empty); 20 = the hole added instead of subtracted;
+    // 12 = correct.
+    assert.ok(Math.abs(area - 12) < 1e-5, `holed cut face area was ${area}, expected 12`);
+  });
 
-    // KNOWN GAP, deliberately not pinned to a number here: the shared
-    // `earClip` in symbolic-overlay-pipelines.ts under-triangulates the bridged
-    // ring, because its `pointInTriangle` treats on-edge points as contained
-    // and the bridge duplicates two vertices — so every candidate ear looks
-    // like it contains another vertex and almost none are clipped. That is a
-    // defect in the triangulator, not in the lift, and asserting the current
-    // (too small) area here would turn fixing it into a red test.
+  it('fills an island nested inside a cut hole rather than voiding it', () => {
+    const nested = poly(
+      [[0, 0], [10, 0], [10, 10], [0, 10]],
+      [
+        [[2, 2], [2, 8], [8, 8], [8, 2]],
+        [[4, 4], [4, 6], [6, 6], [6, 4]],
+      ],
+    );
+    const geom = buildCapFillGeometry([nested], createSectionLift('front', 0));
+    assert.ok(geom);
+    const area = triangulatedArea(geom.vertices, geom.indices);
+    // 100 - 36 + 4. Treating every ring past the first as a hole gives 60.
+    assert.ok(Math.abs(area - 68) < 1e-5, `nested cut face area was ${area}, expected 68`);
   });
 
   it('drops degenerate holes (<3 points) instead of corrupting the ring', () => {

--- a/packages/renderer/src/section-2d-lift.ts
+++ b/packages/renderer/src/section-2d-lift.ts
@@ -14,7 +14,7 @@
  * plain numbers.
  */
 
-import { earClip, joinHoles, type Pt } from './symbolic-overlay-pipelines.js';
+import { triangulateRings, type Pt } from './fill-triangulate.js';
 
 /** Semantic cardinal section axis: down (Y), front (Z), side (X). */
 export type SectionAxis = 'down' | 'front' | 'side';
@@ -141,12 +141,16 @@ export interface CapFillGeometry {
 /**
  * Triangulate the cut polygons and lift them onto the section plane.
  *
- * Hole-aware ear-clipping (reused from the IfcAnnotationFillArea fill path)
- * replaces the old convex fan. The fan ignored holes and inverted on the
- * CONCAVE cross-sections that arbitrary IFC profiles (and material-layer
- * slabs) cut into, leaving the cut face uncovered — it read as a hollow
- * shell. Section 2D points are (x, y); the triangulator works in (x, z),
- * so y maps to z.
+ * Even-odd hole-aware triangulation (shared with the IfcAnnotationFillArea
+ * fill path) replaces the old convex fan. The fan ignored holes and inverted
+ * on the CONCAVE cross-sections that arbitrary IFC profiles (and
+ * material-layer slabs) cut into, leaving the cut face uncovered — it read as
+ * a hollow shell. Section 2D points are (x, y); the triangulator works in
+ * (x, z), so y maps to z.
+ *
+ * Holes are SUBTRACTED, not merely stitched (#2516): a plane through a wall
+ * opening or a slab void used to come back with the hole's own ring bridged in
+ * but almost nothing clipped, so the cap rendered near-empty.
  *
  * Returns `null` when nothing survives (no polygon had three usable points),
  * so the caller can skip buffer creation entirely.
@@ -174,12 +178,14 @@ export function buildCapFillGeometry(
     const holeRings: Pt[][] = polygon.polygon.holes
       .filter((h) => h.length >= 3)
       .map((h) => h.map((p) => ({ x: p.x, z: p.y })));
-    const stitched = holeRings.length > 0 ? joinHoles(outerRing, holeRings) : outerRing;
-    const tris = earClip(stitched);
+    const { points: capPoints, triangles: tris } = triangulateRings([
+      outerRing,
+      ...holeRings,
+    ]);
     if (tris.length === 0) continue;
 
     const baseVertex = vertexOffset;
-    for (const pt of stitched) {
+    for (const pt of capPoints) {
       const [x3d, y3d, z3d] = lift(pt.x, pt.z);
       fillVertices.push(x3d, y3d, z3d, color[0], color[1], color[2], color[3]);
       vertexOffset++;

--- a/packages/renderer/src/symbolic-fill-triangulate.test.ts
+++ b/packages/renderer/src/symbolic-fill-triangulate.test.ts
@@ -1,0 +1,144 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { SymbolicFillPipeline, type SymbolicFillInput } from './symbolic-overlay-pipelines.js';
+
+// WebGPU enum globals referenced by the pipeline's bind-group visibility and
+// buffer usage flags (not defined in node) — same polyfill as
+// section-2d-overlay-lifecycle.test.ts.
+(globalThis as Record<string, unknown>).GPUShaderStage = { VERTEX: 1, FRAGMENT: 2, COMPUTE: 4 };
+(globalThis as Record<string, unknown>).GPUColorWrite = {
+  RED: 1, GREEN: 2, BLUE: 4, ALPHA: 8, ALL: 15,
+};
+(globalThis as Record<string, unknown>).GPUBufferUsage = {
+  MAP_READ: 1, MAP_WRITE: 2, COPY_SRC: 4, COPY_DST: 8, INDEX: 16,
+  VERTEX: 32, UNIFORM: 64, STORAGE: 128, INDIRECT: 256, QUERY_RESOLVE: 512,
+};
+
+/**
+ * `IfcAnnotationFillArea` is the SECOND consumer of the shared cut-cap
+ * triangulator (issue #2516), and it reaches it down a different road: a flat
+ * `points` buffer split into rings by `holesOffsets`, rather than an explicit
+ * outer/holes pair. Testing the kernel alone would leave that split — and the
+ * even-odd nesting it feeds — unverified, which is exactly how the annotation
+ * path could keep rendering a hollow hatch after the cap path was fixed.
+ *
+ * So this drives the real `SymbolicFillPipeline.upload()` over a fake device
+ * and measures the vertex stream it actually writes to the GPU.
+ */
+
+const FLOATS_PER_VERTEX = 7; // x, y, z, r, g, b, a
+
+function makeDevice() {
+  const writes: Float32Array[] = [];
+  const device = {
+    limits: {} as unknown as GPUSupportedLimits,
+    createBindGroupLayout: () => ({}) as GPUBindGroupLayout,
+    createPipelineLayout: () => ({}) as GPUPipelineLayout,
+    createShaderModule: (desc: { code: string }) =>
+      ({ code: desc.code }) as unknown as GPUShaderModule,
+    createRenderPipeline: (desc: unknown) => ({ desc }) as unknown as GPURenderPipeline,
+    createBindGroup: () => ({}) as GPUBindGroup,
+    createBuffer: (desc: { size: number; usage: number }) =>
+      ({ __size: desc.size, __usage: desc.usage, destroy() {} }) as unknown as GPUBuffer,
+    queue: {
+      writeBuffer: (_buffer: GPUBuffer, _offset: number, data: ArrayBufferView) => {
+        writes.push(
+          new Float32Array(data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength)),
+        );
+      },
+    },
+  } as unknown as GPUDevice;
+  return { device, writes };
+}
+
+function fill(
+  points: number[],
+  holesOffsets: number[],
+  worldY = 0,
+): SymbolicFillInput {
+  return {
+    points: Float32Array.from(points),
+    holesOffsets: Uint32Array.from(holesOffsets),
+    worldY,
+    color: [1, 0, 0, 1],
+  };
+}
+
+/** Area of the triangle soup the pipeline uploaded, in the fill's own plane. */
+function uploadedArea(stream: Float32Array): number {
+  let sum = 0;
+  for (let v = 0; v + 3 * FLOATS_PER_VERTEX <= stream.length; v += 3 * FLOATS_PER_VERTEX) {
+    const ax = stream[v];
+    const az = stream[v + 2];
+    const bx = stream[v + FLOATS_PER_VERTEX];
+    const bz = stream[v + FLOATS_PER_VERTEX + 2];
+    const cx = stream[v + 2 * FLOATS_PER_VERTEX];
+    const cz = stream[v + 2 * FLOATS_PER_VERTEX + 2];
+    sum += Math.abs((bx - ax) * (cz - az) - (cx - ax) * (bz - az)) / 2;
+  }
+  return sum;
+}
+
+function upload(fills: SymbolicFillInput[]): Float32Array {
+  const { device, writes } = makeDevice();
+  const pipeline = new SymbolicFillPipeline(device, 'bgra8unorm', 1);
+  pipeline.upload(fills);
+  assert.ok(pipeline.hasGeometry(), 'pipeline uploaded no geometry at all');
+  assert.strictEqual(writes.length, 1, 'exactly one vertex-buffer write per upload');
+  return writes[0];
+}
+
+const SQUARE_4 = [0, 0, 4, 0, 4, 4, 0, 4];
+const HOLE_2 = [1, 1, 1, 3, 3, 3, 3, 1];
+
+describe('SymbolicFillPipeline — IfcAnnotationFillArea holes (#2516)', () => {
+  it('subtracts an inner bound from the fill it is nested in', () => {
+    const stream = upload([fill([...SQUARE_4, ...HOLE_2], [4])]);
+    const area = uploadedArea(stream);
+    assert.ok(
+      Math.abs(area - 12) < 1e-5,
+      `annotation fill uploaded area ${area}; 2 = the #2516 bug, ` +
+        `20 = the hole added instead of subtracted, 12 = correct`,
+    );
+  });
+
+  it('leaves a hole-free fill exactly as it was: 2 triangles, area 16', () => {
+    const stream = upload([fill(SQUARE_4, [])]);
+    assert.strictEqual(stream.length / FLOATS_PER_VERTEX, 6, 'two triangles');
+    assert.ok(Math.abs(uploadedArea(stream) - 16) < 1e-5);
+  });
+
+  it('fills an island nested inside an inner bound', () => {
+    const outer = [0, 0, 10, 0, 10, 10, 0, 10];
+    const hole = [2, 2, 2, 8, 8, 8, 8, 2];
+    const island = [4, 4, 4, 6, 6, 6, 6, 4];
+    const stream = upload([fill([...outer, ...hole, ...island], [4, 8])]);
+    const area = uploadedArea(stream);
+    // 100 - 36 + 4. "Every ring after the first is a hole" would give 60.
+    assert.ok(Math.abs(area - 68) < 1e-5, `nested annotation fill area was ${area}, expected 68`);
+  });
+
+  it('keeps every vertex on the fill plane and carries the colour through', () => {
+    const stream = upload([fill([...SQUARE_4, ...HOLE_2], [4], 2.5)]);
+    for (let v = 0; v < stream.length; v += FLOATS_PER_VERTEX) {
+      assert.strictEqual(stream[v + 1], 2.5, 'worldY must be constant across the fill');
+      assert.deepStrictEqual(Array.from(stream.slice(v + 3, v + 7)), [1, 0, 0, 1]);
+    }
+  });
+
+  it('drops a degenerate inner bound without losing the outer fill', () => {
+    // A 2-vertex "hole" is not a ring; the outer square must still come out whole.
+    const stream = upload([fill([...SQUARE_4, 1, 1, 2, 2], [4])]);
+    assert.ok(Math.abs(uploadedArea(stream) - 16) < 1e-5);
+  });
+
+  it('accumulates several holed fills into one buffer', () => {
+    const shifted = [10, 0, 14, 0, 14, 4, 10, 4, 11, 1, 11, 3, 13, 3, 13, 1];
+    const stream = upload([fill([...SQUARE_4, ...HOLE_2], [4]), fill(shifted, [4])]);
+    assert.ok(Math.abs(uploadedArea(stream) - 24) < 1e-5);
+  });
+});

--- a/packages/renderer/src/symbolic-overlay-pipelines.ts
+++ b/packages/renderer/src/symbolic-overlay-pipelines.ts
@@ -9,11 +9,9 @@
  * viewProj)` entry point that the caller invokes from inside an existing
  * RGBA-blended render pass.
  *
- * Triangulation: simple ear-clipping for polygon-with-optional-holes,
- * inlined below to avoid adding a dependency. Good enough for typical IFC
- * fill regions (rooms, hatched zones) which are usually convex or near-convex.
- * Pathological concave shapes with many holes may show tessellation glitches —
- * an `earcut` upgrade is straightforward when it matters.
+ * Triangulation lives in `fill-triangulate.ts` and is shared with the section
+ * cut caps: rings are nested by the even-odd rule, holes are bridged in, and
+ * the result is ear-clipped.
  */
 
 import { SymbolicTextAtlas } from './symbolic-text-atlas.js';
@@ -22,6 +20,7 @@ import {
   SYMBOLIC_TEXT_WGSL,
 } from './shaders/symbolic-overlay.wgsl.js';
 import { PIPELINE_CONSTANTS } from './constants.js';
+import { triangulateRings, type Pt } from './fill-triangulate.js';
 
 const FILL_VERTEX_STRIDE_BYTES = (3 + 4) * 4; // pos.xyz + color.rgba, 4 bytes each
 const TEXT_INSTANCE_STRIDE_BYTES = (3 + 3 + 3 + 4 + 4 + 3 + 1 + 1 + 4 + 1) * 4;
@@ -707,14 +706,14 @@ function parseBoxAlignment(s: string): { horizontal: number; vertical: number } 
 }
 
 /**
- * Triangulate a polygon-with-holes via ear-clipping. Each output triangle is
- * appended to `stream` as 3 × (x, y, z, r, g, b, a) entries (matching the
- * fill pipeline's vertex layout). Holes that fully enclose nothing or have
- * < 3 valid vertices are silently dropped.
+ * Triangulate a fill region (outer bound plus inner bounds) and append every
+ * output triangle to `stream` as 3 x (x, y, z, r, g, b, a) entries, matching
+ * the fill pipeline's vertex layout.
  *
- * Ear-clipping is O(n²) which is fine for fill regions (typically < 100
- * vertices). For pathological inputs we'd want earcut proper, but adding the
- * npm dependency for marginal gain isn't worth it.
+ * `holesOffsets` splits the flat `points` buffer into rings; rings with fewer
+ * than 3 vertices are dropped. Which of those rings are filled and which are
+ * voids is decided by nesting, not by position, so an inner bound that itself
+ * contains an island fills that island (see `fill-triangulate.ts`).
  */
 function triangulateFillTo(stream: number[], fill: SymbolicFillInput): void {
   const { points, holesOffsets, worldY, color } = fill;
@@ -725,13 +724,12 @@ function triangulateFillTo(stream: number[], fill: SymbolicFillInput): void {
   const ringStarts: number[] = [0, ...Array.from(holesOffsets), totalVerts];
   if (ringStarts.length < 2) return;
 
-  // Pull each ring's vertices out.
-  const rings: Array<Array<{ x: number; z: number }>> = [];
+  const rings: Pt[][] = [];
   for (let r = 0; r < ringStarts.length - 1; r++) {
     const start = ringStarts[r];
     const end = ringStarts[r + 1];
     if (end - start < 3) continue;
-    const ring: Array<{ x: number; z: number }> = [];
+    const ring: Pt[] = [];
     for (let v = start; v < end; v++) {
       ring.push({ x: points[v * 2], z: points[v * 2 + 1] });
     }
@@ -739,191 +737,11 @@ function triangulateFillTo(stream: number[], fill: SymbolicFillInput): void {
   }
   if (rings.length === 0) return;
 
-  // Stitch each hole into the outer ring with a bridge edge from the hole's
-  // rightmost vertex to the nearest outer-ring vertex (the same approach
-  // earcut.js takes for polygon-with-holes input). Ear-clipping then runs on
-  // the resulting simple polygon. The hole's winding is reversed first so the
-  // combined ring's signed area stays consistent and the ear-test sign holds.
-  const outer = rings[0];
-  const holes = rings.slice(1);
-  const stitched = holes.length === 0 ? outer : joinHoles(outer, holes);
-  const triangles = earClip(stitched);
+  const { points: verts, triangles } = triangulateRings(rings);
   for (const tri of triangles) {
     for (const idx of tri) {
-      const v = stitched[idx];
+      const v = verts[idx];
       stream.push(v.x, worldY, v.z, color[0], color[1], color[2], color[3]);
     }
   }
-}
-
-/**
- * Stitch each hole into the outer ring with a single bridge edge so the
- * result is a simple polygon ear-clipping can handle. Mirrors mapbox/earcut's
- * `eliminateHoles` pass:
- *
- *   1. For each hole, pick its rightmost (max-x) vertex as the bridge start.
- *   2. Sort holes by descending bridge-start x so outer holes go in first.
- *   3. Walk the outer ring for the vertex on the right side of the bridge
- *      that's "visible" from the hole — closest match wins.
- *   4. Splice the hole (rotated to start at its bridge vertex, and reversed
- *      so its winding opposes the outer ring) into the outer ring at the
- *      anchor, closing both ends back to their starts to form a zero-area
- *      bridge edge.
- *
- * This breaks under pathological inputs (overlapping holes, holes outside
- * the outer ring) but those don't occur in well-formed `IfcAnnotationFillArea`
- * geometry — the IFC schema requires the outer bound to contain all inner
- * bounds.
- */
-export type Pt = { x: number; z: number };
-export function joinHoles(outer: Pt[], holes: Pt[][]): Pt[] {
-  if (holes.length === 0) return outer;
-
-  type HoleEntry = { ring: Pt[]; startIdx: number; startX: number; startZ: number };
-  const sorted: HoleEntry[] = holes
-    .map((h) => {
-      let bestI = 0;
-      for (let i = 1; i < h.length; i++) {
-        if (h[i].x > h[bestI].x) bestI = i;
-      }
-      return { ring: h, startIdx: bestI, startX: h[bestI].x, startZ: h[bestI].z };
-    })
-    .sort((a, b) => b.startX - a.startX);
-
-  let result: Pt[] = outer.slice();
-
-  for (const { ring, startIdx, startX, startZ } of sorted) {
-    // Find the outer-ring index with the smallest distance to the bridge
-    // start, preferring vertices to the right (x > startX). When nothing is
-    // to the right (hole touches the outer ring's right edge), fall back to
-    // global nearest.
-    let bestIdx = -1;
-    let bestDist = Infinity;
-    for (let i = 0; i < result.length; i++) {
-      const p = result[i];
-      if (p.x <= startX) continue;
-      const d = (p.x - startX) * (p.x - startX) + (p.z - startZ) * (p.z - startZ);
-      if (d < bestDist) {
-        bestDist = d;
-        bestIdx = i;
-      }
-    }
-    if (bestIdx < 0) {
-      for (let i = 0; i < result.length; i++) {
-        const p = result[i];
-        const d = (p.x - startX) * (p.x - startX) + (p.z - startZ) * (p.z - startZ);
-        if (d < bestDist) {
-          bestDist = d;
-          bestIdx = i;
-        }
-      }
-    }
-    if (bestIdx < 0) continue;
-
-    // Hole reversed so its winding opposes outer (outer is CCW after earClip
-    // normalisation; holes should be CW for the combined ring's area to come
-    // out right). Rotate to start at the bridge vertex.
-    const reversed = ring.slice().reverse();
-    const reversedStartIdx = ring.length - 1 - startIdx;
-    const rotated = [
-      ...reversed.slice(reversedStartIdx),
-      ...reversed.slice(0, reversedStartIdx),
-    ];
-
-    result = [
-      ...result.slice(0, bestIdx + 1),
-      ...rotated,
-      rotated[0],
-      result[bestIdx],
-      ...result.slice(bestIdx + 1),
-    ];
-  }
-
-  return result;
-}
-
-/** Ear-clipping triangulation of a simple polygon. Returns triangle vertex indices. */
-export function earClip(ring: ReadonlyArray<{ x: number; z: number }>): number[][] {
-  const n = ring.length;
-  if (n < 3) return [];
-  if (n === 3) return [[0, 1, 2]];
-
-  // Working list of indices.
-  const indices: number[] = [];
-  // Determine winding: positive shoelace = CCW; otherwise reverse so the
-  // ear-test below uses a consistent sign.
-  let area = 0;
-  for (let i = 0; i < n; i++) {
-    const a = ring[i];
-    const b = ring[(i + 1) % n];
-    area += (a.x * b.z) - (b.x * a.z);
-  }
-  const ccw = area > 0;
-  for (let i = 0; i < n; i++) {
-    indices.push(ccw ? i : n - 1 - i);
-  }
-
-  const triangles: number[][] = [];
-  let safety = indices.length * indices.length;
-
-  while (indices.length > 3 && safety-- > 0) {
-    let found = false;
-    for (let i = 0; i < indices.length; i++) {
-      const ia = indices[(i + indices.length - 1) % indices.length];
-      const ib = indices[i];
-      const ic = indices[(i + 1) % indices.length];
-      const a = ring[ia];
-      const b = ring[ib];
-      const c = ring[ic];
-
-      // Convex check (cross product of (b-a) × (c-b) > 0 for CCW).
-      const cross = (b.x - a.x) * (c.z - b.z) - (b.z - a.z) * (c.x - b.x);
-      if (cross <= 0) continue;
-
-      // No other vertex inside triangle (a, b, c).
-      let containsOther = false;
-      for (let j = 0; j < indices.length; j++) {
-        const ij = indices[j];
-        if (ij === ia || ij === ib || ij === ic) continue;
-        if (pointInTriangle(ring[ij], a, b, c)) {
-          containsOther = true;
-          break;
-        }
-      }
-      if (containsOther) continue;
-
-      triangles.push([ia, ib, ic]);
-      indices.splice(i, 1);
-      found = true;
-      break;
-    }
-    if (!found) break; // degenerate polygon — emit what we have
-  }
-
-  if (indices.length === 3) {
-    triangles.push([indices[0], indices[1], indices[2]]);
-  }
-  return triangles;
-}
-
-function pointInTriangle(
-  p: { x: number; z: number },
-  a: { x: number; z: number },
-  b: { x: number; z: number },
-  c: { x: number; z: number },
-): boolean {
-  const s1 = sign(p, a, b);
-  const s2 = sign(p, b, c);
-  const s3 = sign(p, c, a);
-  const hasNeg = s1 < 0 || s2 < 0 || s3 < 0;
-  const hasPos = s1 > 0 || s2 > 0 || s3 > 0;
-  return !(hasNeg && hasPos);
-}
-
-function sign(
-  p1: { x: number; z: number },
-  p2: { x: number; z: number },
-  p3: { x: number; z: number },
-): number {
-  return (p1.x - p3.x) * (p2.z - p3.z) - (p2.x - p3.x) * (p1.z - p3.z);
 }

--- a/packages/renderer/src/symbolic-overlay-pipelines.ts
+++ b/packages/renderer/src/symbolic-overlay-pipelines.ts
@@ -196,12 +196,14 @@ export class SymbolicFillPipeline {
   }
 
   /**
-   * Upload a list of fill regions. Each region is triangulated (ear-clipping,
-   * holes-aware) into a single shared vertex buffer.
+   * Upload a list of fill regions. Each region is triangulated by the shared
+   * even-odd triangulator (`fill-triangulate.ts`) into a single vertex buffer.
    *
-   * Pass an empty array to clear. Triangulation skips degenerate rings
-   * (< 3 vertices) and silently drops any hole that can't be merged into the
-   * outer ring (rare; usually overlapping rings in malformed IFC).
+   * Pass an empty array to clear. Rings with fewer than 3 vertices are
+   * dropped, and so is any ring set that yields no triangle at all (a fully
+   * collinear bound). Inner bounds themselves are never dropped: since #2516
+   * the bridge always finds an anchor, so a hole cannot fall out of the
+   * result the way it used to when it "couldn't be merged".
    */
   upload(fills: readonly SymbolicFillInput[]): void {
     this.init();


### PR DESCRIPTION
Fixes #2516

## The defect

The shared cut-cap / `IfcAnnotationFillArea` triangulator bridged hole rings into the outer ring, then almost never clipped an ear from the bridged ring. Its ear test treated **any** vertex lying *on* a candidate ear as obstructing it, and the bridge duplicates two vertices by construction, so every candidate ear looked blocked.

Measured on `main`, a 4x4 square with a 2x2 hole:

| | area |
|---|---|
| `main` | **2** |
| naive "reverse the hole's winding" | **20** |
| correct | **12** |

So any section plane through a wall opening or a slab void rendered a near-empty cap.

## The fix

Not a sign flip — the hole has to be *subtracted*, and one level of holes is not the general case. Triangulation moves into three small modules shared by both consumers.

**`fill-triangulate.ts`** — the even-odd pipeline:

1. **Nest the rings.** A ring's depth is the number of other rings containing it; even depth is a filled boundary, odd depth is a hole. A ring at depth `d+1` contained in a ring at depth `d` is necessarily its immediate child, so no explicit tree is built. This is what makes an *island inside a hole* fill rather than void — and it lines the 3D path up with `Drawing2DCanvas` and `svg-exporter.ts`, which already fill with `evenodd`.
2. **Bridge each group's holes in**, normalising windings (boundary CCW, holes CW) rather than assuming the caller supplied them that way.
3. **Ear-clip with a sound obstruction test**: only *reflex* vertices can obstruct an ear of a simple polygon, and a vertex coincident with one of the ear's own corners is skipped — that is exactly the zero-width bridge duplicate that used to deadlock the clipper. When no ear is available the clipper drops one zero-area (collinear/duplicate) vertex, which cannot change the covered region, and retries instead of bailing out.

A hole-free ring set takes the same path it always did: the ring goes straight to `earClip` in its original vertex order, so hole-free profiles are unchanged down to vertex order.

**`fill-bridge-anchor.ts`** — where the bridge attaches. Ranking candidates by "to the right, then nearest" lands on a visible vertex in nearly every case, because a wall's own corner is nearer than anything behind it. The exception is a long blocking edge whose endpoints are both far away, which leaves a vertex on its far side as the nearest candidate; bridging to it makes the merged ring weakly simple, and ear clipping stalls on it. Candidates keep the same ranking and the first one whose bridge crosses nothing wins, so convex profiles are byte-identical.

The real-world case for this guard is a **multi-notch boundary** — a wall with returns, a slab with several rebates — found by Codex on this PR (thread on `fill-triangulate.ts:261`). For the comb `[(0,0),(12,0),(12,12),(9,12),(9,3),(7,3),(7,10),(5,10),(5,3),(3,3),(3,12),(0,12)]` with a 0.2 x 0.2 hole at (0.75, 7.25), the nearest vertex to the right of the hole is the middle tooth's tip at (5, 10), and the bridge to it runs through the wall (3, 3)-(3, 12). Unguarded that yields 10 of 16 triangles and area **91.01** instead of **103.96**; guarded it picks (3, 3) and lands exactly. Pinned in `fill-bridge-anchor.test.ts` with a hole-free control on the same comb.

**`fill-predicates.ts`** — scale-aware geometric predicates. Cross products carry squared coordinate units, so an absolute tolerance means something different in a model authored in millimetres than in one authored in metres. Orientation is tested as a *sine* (determinant over the operand lengths) and position along a segment as a *parameter* (dot over squared length); both are dimensionless. Vertex coincidence is measured against the ring's own extent.

### Why TypeScript and not `rust/geometry/src/bool2d.rs`

The missing capability is **triangulation**, and the Rust kernel does not provide it: `bool2d.rs` / `contour_bool2d.rs` return `Profile2D` contours, `i_overlay` emits contours rather than triangles, and there is no `i_triangle` in the workspace — a Rust round trip would still need this code on the way back. On top of that `@ifc-lite/renderer` has no wasm dependency, and both call sites (`buildCapFillGeometry` on every section-slider commit, `SymbolicFillPipeline.upload`) are synchronous GPU-upload paths, so routing through wasm would make a published sync API async for no correctness gain. The nesting classification is ~40 lines and is now covered directly.

## Both consumers verified

- **Section cut caps** — `section-2d-lift.test.ts`. The existing `stitches a hole ring…` test carried a `KNOWN GAP` note explaining that the area was deliberately *not* pinned because the triangulator under-counted; that note is gone and the area is pinned at 12, plus a new nested-island case at 68.
- **`IfcAnnotationFillArea`** — new `symbolic-fill-triangulate.test.ts` drives the real `SymbolicFillPipeline.upload()` over a fake `GPUDevice` and measures the vertex stream actually written. That path reaches the triangulator differently (a flat `points` buffer split by `holesOffsets`, not an explicit outer/holes pair), so testing the kernel alone would have left it unverified.

Both cap pipelines use `cullMode: 'none'`, so the winding normalisation cannot change what renders.

## Coverage

Beyond the analytic areas, `fill-triangulate.test.ts` asserts pointwise agreement with an even-odd oracle: over 4000 sample points, every interior point is covered by **exactly one** triangle and every exterior point by none — area alone cannot distinguish a correct tessellation from overlapping triangles plus gaps. A 200-iteration fuzz over concave star boundaries with concave star holes checks the triangulated area against the analytic one.

## Mutation results

Run first unmutated; counts read off `# tests` / `# pass` / `# fail`, leaf failures only; working tree verified clean after each restore.

| | tests | pass | fail |
|---|---|---|---|
| control | 57 | 57 | 0 |
| **A** — restore the shipped ear test (every vertex obstructs) | 51 | 36 | **15** |
| **B** — naive sign flip, hole added not subtracted | 51 | 36 | **15** |
| **C** — over-broad: disturb the hole-free path too | 51 | 50 | **1** |
| **D** — drop the bridge visibility filter | 56 | 54 | **2** |
| **E** — scale-blind absolute tolerance | 57 | 56 | **1** |
| **F** — drop the bridge visibility filter (post-comb) | 66 | 61 | **5** |
| **G** — fan from an invented centroid on a stalled clip | 66 | 62 | **4** |

Under **A** the 4x4/2x2 case reports area 2; under **B** it reports **20** — the exact number the issue predicted for the naive fix. Under both, every hole-free control stayed green, so the new tests are targeted at hole subtraction rather than at triangulation in general. **C** exists to show the hole-free control is not vacuous: it fails alone, and no holed test notices. **D** drops the blocked-bridge shape from area 1994.4 to 819.2, so the visibility filter is load-bearing rather than defensive decoration. **E** fails only the scale-invariance case.

Under **F** the comb test reports **91.00999999999999**, reproducing Codex's number from the test rather than from a script, while the hole-free comb control stays green. **G** is the fallback I argued against — a fan over the ring on stall — and it fails the degradation tests *and* two valid-input cases, which is the evidence for keeping the partial output.

(A–C predate the bridge-anchor and predicate work, hence the smaller test totals.)

## What the clipper does when it runs out of ears

`earClip` can stall on a ring that is not simple, and it then returns a **partial** fill. That is deliberate:

- **It is not reachable for well-formed rings.** Measured over 20 000 rotated, non-axis-aligned multi-notch boundaries with a hole in a random solid column (containment verified per case, not assumed), 4 000 axis-aligned combs and 2 000 concave stars with up to three concave holes: zero area error, zero stalls. It fires on schema-illegal input, e.g. an inner bound poking outside its outer bound.
- **Throwing** would lose the whole cap upload over one bad profile.
- **A fan over the outer ring** would reintroduce both defects this PR removes: holes not subtracted, and inversion on concave cross-sections. Mutation G measures that.

What is *not* claimed is that the degradation only omits area — true for a hole poking out, false for a self-intersecting ring, where a bow-tie triangulates to 16 against even-odd's 8 because ear clipping reads "inside" from orientation rather than crossing parity. The tests assert what does hold and what a render thread needs: it returns, in bounded time, emitting only vertices it was given, inside the input's own extent.

## Gate

`npx turbo typecheck --force` 77/77, 0 cached. `npx turbo test --force` 86/86, 0 cached (`@ifc-lite/renderer` 852/852). No Rust touched. CodeRabbit CLI run locally: two completed runs on the final tree, both `No new findings`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected hole subtraction in section cut caps and annotation fills.
  * Added support for nested rings and islands using even-odd fill behavior.
  * Preserved correct rendering for hole-free shapes and varying ring winding or order.
  * Improved handling of degenerate or malformed shapes with safer, bounded results.

* **Tests**
  * Added comprehensive coverage for concave shapes, multiple holes, nested regions, scale variations, and exact filled areas.
  * Expanded regression checks for section geometry and annotation rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->