### PR TITLE
fix(renderer): import scene.js, not scene.ts, from the flush-chunk-end test

### DIFF
--- a/packages/renderer/src/scene-flush-chunk-end.test.ts
+++ b/packages/renderer/src/scene-flush-chunk-end.test.ts
@@ -5,7 +5,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 
-import { computeFlushChunkEnd } from './scene.ts';
+import { computeFlushChunkEnd } from './scene.js';
 
 // Mirrors flushPending()'s real constants so the "always progresses" contract
 // is checked against the shapes that actually occur, not toy numbers.


### PR DESCRIPTION
**Main is red; this is the one-line fix.**

#2399 added `packages/renderer/src/scene-flush-chunk-end.test.ts` with `import { computeFlushChunkEnd } from './scene.ts'`. That is the **only** `.ts`-extension import in the package, and no tsconfig enables `allowImportingTsExtensions`, so `Typecheck` fails on `main` and on every open PR as it re-runs.

My fault for merging it — the PR's own CI was green because it predates the merge that made the file reachable from the typecheck program.

Verified: `npx turbo typecheck --filter @ifc-lite/renderer --force` → 6/6, 0 cached (red before the change), and the renderer suite still passes.