### PR TITLE
fix(geometry): hash surface invariants, not triangles — a re-triangulated identical shape is not "Reshaped"

### DIFF
--- a/packages/diff/src/content-match-types.ts
+++ b/packages/diff/src/content-match-types.ts
@@ -30,10 +30,12 @@ import type { EntityFingerprint } from './types.js';
  *   from a reshape.
  * - `reshaped`     — one base and one head entity share a data hash but not a
  *   geometry hash, and their bounding boxes differ in size beyond
- *   `DiffOptions.reshapeTolerance` — or agree entirely, which is what a
- *   re-tessellation looks like. A bounding box genuinely cannot separate a
- *   re-tessellation from a reshape confined to the interior, and this kind
- *   does not pretend otherwise.
+ *   `DiffOptions.reshapeTolerance` — or agree entirely, which is what a reshape
+ *   confined to the interior looks like. A pure re-triangulation of an
+ *   unchanged surface no longer lands here (the geometry hash is
+ *   retriangulation-invariant), but a re-tessellation that introduces new
+ *   vertices still does, and a bounding box genuinely cannot separate that from
+ *   an interior reshape. This kind does not pretend otherwise.
  * - `duplicated`   — one base entity's content matches several head entities
  *   (it looks like it was copied).
  * - `deduplicated` — several base entities' content matches one head entity

--- a/packages/diff/src/geometry-compare.ts
+++ b/packages/diff/src/geometry-compare.ts
@@ -170,10 +170,12 @@ export interface GeometryChange {
  *   distance still travels with the record for the caller to judge).
  * - same size, centre beyond `moveTolerance` → `moved`.
  * - same size and same centre, yet the hash differs → `reshaped` with distance
- *   0. This is what a re-tessellation looks like, and it is also what a
- *   reshape confined to the interior of the box looks like. An axis-aligned
- *   bounding box genuinely cannot separate those two, so this does not claim
- *   to: it reports the honest "the shape changed, it did not move".
+ *   0. This is what a reshape confined to the interior of the box looks like.
+ *   A pure re-triangulation of an unchanged surface no longer reaches here at
+ *   all — the geometry hash is retriangulation-invariant (see `geom_hash.rs`) —
+ *   but a re-tessellation that introduces new vertices still does. An
+ *   axis-aligned bounding box genuinely cannot separate those two, so this does
+ *   not claim to: it reports the honest "the shape changed, it did not move".
  */
 export function classifyGeometryChange(
   baseAabb: EntityAabb | undefined,

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -590,15 +590,13 @@ export class IfcAPI {
      * Enable or disable per-entity geometry fingerprinting in
      * `processGeometryBatch`, used by the viewer's revision-diff feature.
      *
-     * Pass a positive `tolerance` (metres) to enable — it is the quantization
-     * grid the hash snaps positions to (larger = more tolerant of float noise,
-     * smaller = catches finer edits; the `f32` precision floor of model-local
-     * coordinates means values below ~1 mm mostly hash noise). A request finer
-     * than `ifc_lite_geometry::MIN_GEOM_HASH_TOLERANCE` (1e-6 m) is silently
-     * clamped up to it — see that constant's doc for why finer is an `i128`
-     * overflow surface on a georeferenced model, not a precision win. Pass
-     * `null`/`undefined` (or a non-positive value) to disable. Default:
-     * disabled.
+     * Pass a positive `tolerance` (metres) to enable — the quantization grid
+     * positions snap to (larger tolerates more float noise, smaller catches
+     * finer edits; below the `f32` precision floor of model-local coordinates,
+     * ~1 mm, mostly hashes noise). Finer than
+     * `ifc_lite_geometry::MIN_GEOM_HASH_TOLERANCE` (1e-6 m) is clamped up to it
+     * — see that constant's doc for why (an `i128` overflow surface, not a
+     * precision win). `null`/`undefined`/non-positive disables. Default: off.
      */
     setComputeGeometryHashes(tolerance?: number | null): void;
     /**

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -593,8 +593,12 @@ export class IfcAPI {
      * Pass a positive `tolerance` (metres) to enable — it is the quantization
      * grid the hash snaps positions to (larger = more tolerant of float noise,
      * smaller = catches finer edits; the `f32` precision floor of model-local
-     * coordinates means values below ~1 mm mostly hash noise). Pass `null`/
-     * `undefined` (or a non-positive value) to disable. Default: disabled.
+     * coordinates means values below ~1 mm mostly hash noise). A request finer
+     * than `ifc_lite_geometry::MIN_GEOM_HASH_TOLERANCE` (1e-6 m) is silently
+     * clamped up to it — see that constant's doc for why finer is an `i128`
+     * overflow surface on a georeferenced model, not a precision win. Pass
+     * `null`/`undefined` (or a non-positive value) to disable. Default:
+     * disabled.
      */
     setComputeGeometryHashes(tolerance?: number | null): void;
     /**

--- a/rust/geometry/src/geom_accumulate.rs
+++ b/rust/geometry/src/geom_accumulate.rs
@@ -1,0 +1,174 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Folding one mesh segment's triangles into the hasher's private
+//! accumulators (vertex set, per-plane area, world bounds, volume, closure).
+//!
+//! Split out of the parent `geom_hash` module (whose child it is, so it
+//! reaches [`GeometryHasher`]'s private fields directly) because HOW a
+//! segment's triangles get folded in — the world reconstruction, the
+//! quantization, the per-triangle degenerate/volume/bounds bookkeeping — is a
+//! separate subject from what the surface channels mean ([`super::surface`])
+//! or what the struct/gate around them expose.
+
+use super::surface::{self, plane_of, vertex_hash};
+use super::{quantize, GeometryHasher};
+use crate::kernel::signed_volume::tetra_volume6;
+use crate::mesh_orient::OrientVerdict;
+
+impl GeometryHasher {
+    /// Reconstruct the full `f64` WORLD coordinate of one vertex. `origin` is
+    /// the per-mesh local-frame origin (`world = origin + position`); pass
+    /// `[0.0; 3]` for absolute-coordinate positions.
+    #[inline]
+    fn world(&self, positions: &[f32], vi: usize, origin: &[f64; 3]) -> [f64; 3] {
+        let base = vi * 3;
+        [
+            positions[base] as f64 + origin[0] + self.rtc[0],
+            positions[base + 1] as f64 + origin[1] + self.rtc[1],
+            positions[base + 2] as f64 + origin[2] + self.rtc[2],
+        ]
+    }
+
+    /// Snap a reconstructed world corner to the quantization grid.
+    #[inline]
+    fn quantize_corner(&self, world: &[f64; 3]) -> [i64; 3] {
+        [
+            quantize(world[0], self.inv_tol),
+            quantize(world[1], self.inv_tol),
+            quantize(world[2], self.inv_tol),
+        ]
+    }
+
+    /// Add one mesh segment (a flat `[x,y,z, ...]` position buffer and a
+    /// triangle index buffer). Indices that run past the position buffer or
+    /// trailing non-triangle remainder are skipped defensively.
+    pub fn add_mesh(&mut self, positions: &[f32], indices: &[u32]) {
+        self.add_mesh_with_origin(positions, indices, [0.0; 3]);
+    }
+
+    /// Like [`Self::add_mesh`] but for positions stored in a per-element LOCAL
+    /// frame: `origin` (the per-mesh AABB-centre origin) is folded back so the
+    /// hash is over absolute world coordinates. This keeps the fingerprint
+    /// identical whether the producer emitted absolute positions (native) or
+    /// local + origin (the wasm local-frame path), and still detects element
+    /// MOVES.
+    ///
+    /// The segment carries no topology verdict, so it counts as NOT a closed
+    /// solid and permanently disarms [`Self::volume`]. Producers that ran
+    /// [`crate::orient_mesh_outward_verdict`] on this exact buffer should call
+    /// [`Self::add_oriented_mesh`] instead.
+    pub fn add_mesh_with_origin(&mut self, positions: &[f32], indices: &[u32], origin: [f64; 3]) {
+        self.add_oriented_mesh(positions, indices, origin, OrientVerdict::INDETERMINATE);
+    }
+
+    /// [`Self::add_mesh_with_origin`] for a segment the producer just ran the
+    /// outward-orienter over, passing that pass's [`OrientVerdict`] along.
+    ///
+    /// `verdict` MUST describe this exact position/index buffer — the volume
+    /// below is only as honest as the closedness claim behind it. Anything
+    /// short of a single closed orientable component disarms the element's
+    /// volume permanently; see [`Self::volume`].
+    pub fn add_oriented_mesh(
+        &mut self,
+        positions: &[f32],
+        indices: &[u32],
+        origin: [f64; 3],
+        verdict: OrientVerdict,
+    ) {
+        // Σ 6·V for THIS segment, referenced to its own first in-range corner
+        // (`vol_ref`). Any reference gives the same total on a closed surface,
+        // but referencing a point ON the surface keeps every operand bounded by
+        // the segment's own diameter — a georeferenced model at 1e5 m would
+        // otherwise multiply three ~1e5 coordinates and cancel a ~1 m³ answer
+        // out of ~1e15, losing every significant digit.
+        let mut seg_volume6 = 0.0f64;
+        let mut vol_ref: Option<[f64; 3]> = None;
+        let vertex_limit = positions.len() / 3;
+        let triangle_end = indices.len() - (indices.len() % 3);
+        let mut i = 0;
+        while i < triangle_end {
+            let i0 = indices[i] as usize;
+            let i1 = indices[i + 1] as usize;
+            let i2 = indices[i + 2] as usize;
+            i += 3;
+            if i0 >= vertex_limit || i1 >= vertex_limit || i2 >= vertex_limit {
+                continue;
+            }
+
+            let world = [
+                self.world(positions, i0, &origin),
+                self.world(positions, i1, &origin),
+                self.world(positions, i2, &origin),
+            ];
+
+            // Bounds take EVERY in-range corner, including those of triangles
+            // the hash rejects as post-quantization degenerate below. A sliver
+            // or zero-area face carries no shape signal for the fingerprint,
+            // but its corners are real geometry and do contribute extent —
+            // dropping them would under-report the element's box.
+            for corner in &world {
+                self.extend_bounds(corner);
+            }
+
+            // Volume accumulates HERE, from `world`, whose corners are still in
+            // the buffer's authored order. The quantized copy `tri` below is
+            // SORTED (that is what makes the fingerprint winding-invariant), so
+            // anything downstream of that sort has no winding left to integrate.
+            //
+            // Every in-range triangle counts, including the ones the hash drops
+            // as post-quantization degenerate: a sub-millimetre sliver carries
+            // no shape signal for a fingerprint, but it is part of the closed
+            // surface, and its (near-zero) flux belongs in the sum.
+            let o = *vol_ref.get_or_insert(world[0]);
+            seg_volume6 += tetra_volume6(&world[0], &world[1], &world[2], &o);
+
+            // Sort the three quantized corners so triangle winding and the
+            // starting vertex don't affect the hash — only the (multiset of)
+            // positions and their adjacency as a triangle.
+            let mut tri = [
+                self.quantize_corner(&world[0]),
+                self.quantize_corner(&world[1]),
+                self.quantize_corner(&world[2]),
+            ];
+            tri.sort_unstable();
+
+            // Skip degenerate (zero-area) triangles. After quantization,
+            // coincident or colinear corners carry no shape signal, and
+            // counting them lets triangulation noise (sliver/zero-area faces)
+            // flip the fingerprint even when the rendered geometry is
+            // unchanged. `edge_cross` returns `None` for exactly those.
+            let Some(cross) = surface::edge_cross(&tri) else {
+                continue;
+            };
+
+            // Channel 1 — the vertex SET: every corner of every surviving
+            // triangle, deduplicated. A retriangulation reconnects the same
+            // corners, so this is exactly what it cannot move.
+            for corner in tri {
+                if self.vertices.insert(corner) {
+                    self.vertex_accum = self.vertex_accum.wrapping_add(vertex_hash(&corner));
+                }
+            }
+
+            // Channel 2 — area per supporting plane. The vertex set alone
+            // cannot see a face deleted from between corners other faces still
+            // use; the area can, and a retriangulation leaves it untouched.
+            let plane = plane_of(cross, &tri[0]);
+            self.plane_area_accum = self
+                .plane_area_accum
+                .wrapping_add(plane.key.wrapping_mul(plane.weight as u64));
+
+            self.triangle_count = self.triangle_count.wrapping_add(1);
+        }
+
+        // A call that contributed no in-range triangle is not a segment: it has
+        // no geometry, so its verdict says nothing about the element.
+        if vol_ref.is_none() {
+            return;
+        }
+        self.closure.fold_segment(&verdict);
+        self.volume6 += seg_volume6;
+    }
+}

--- a/rust/geometry/src/geom_hash.rs
+++ b/rust/geometry/src/geom_hash.rs
@@ -6,7 +6,10 @@
 //!
 //! The viewer's "compare two revisions" feature needs a stable per-entity
 //! signature so an unchanged element hashes identically across two files,
-//! while a genuine edit (moved, reshaped, retriangulated) hashes differently.
+//! while a genuine edit (moved, or reshaped so the surface itself changes)
+//! hashes differently. Re-triangulating an unchanged surface is *not* an edit
+//! and deliberately does not move the hash — see **Retriangulation-invariant**
+//! below, and [`GeometryHasher::finish`] for the limits of that.
 //!
 //! ## Design invariants
 //!

--- a/rust/geometry/src/geom_hash.rs
+++ b/rust/geometry/src/geom_hash.rs
@@ -49,7 +49,10 @@
 //!   [`DEFAULT_GEOM_HASH_TOLERANCE`] and the `tolerance_sweep` test for the
 //!   trade-off — the effective floor is the `f32` precision of the local
 //!   positions (~1e-4 m near origin), so tolerances below ~1 mm mostly hash
-//!   float noise.
+//!   float noise. A request finer than [`MIN_GEOM_HASH_TOLERANCE`] is clamped
+//!   up to it: below that grid, [`surface::plane_of`]'s `i128` plane-offset
+//!   arithmetic is an overflow surface on a georeferenced model, not a
+//!   precision win — see that constant for the measured bound.
 //!
 //! All inputs must be in a single consistent frame for both files (i.e. unit
 //! scaled to metres, and either both pre- or both post- any axis convention
@@ -107,6 +110,23 @@ use surface::{plane_of, vertex_hash};
 /// the `f32` precision floor of RTC-local coordinates; tune empirically with
 /// the `tolerance_sweep` test against real revision pairs.
 pub const DEFAULT_GEOM_HASH_TOLERANCE: f64 = 1.0e-3;
+
+/// Floor on the quantization tolerance ([`GeometryHasher::new`] clamps any
+/// smaller request up to this).
+///
+/// `plane_of`'s plane offset `d = n·point` is an `i128` product of a quantized
+/// normal and a quantized corner, both scaled by `1/tolerance`; it grows
+/// roughly as `1/tolerance²`. Measured on a georeferenced point (~2.6e6 m) and
+/// a 100 m triangle, `tolerance = 1e-9` pushes `d` to ~1.6e38 — within a factor
+/// of ~1 of `i128::MAX` (1.7e38), i.e. one differently-shaped input away from
+/// overflow (debug builds panic, release wraps and two unrelated planes can
+/// alias to the same key). At this floor the same inputs land `d` around
+/// 1.6e26 — six orders of magnitude of headroom. It is also three orders of
+/// magnitude finer than the documented useful floor (~1 mm, the `f32`
+/// precision limit of RTC-local coordinates — see the module docs'
+/// "Tolerance-quantized" bullet), so no real caller loses precision by being
+/// clamped to it.
+pub const MIN_GEOM_HASH_TOLERANCE: f64 = 1.0e-6;
 
 /// splitmix64 finalizer — strong avalanche for a single `u64`. Shared with
 /// `router::content_hash`'s 128-bit content hash, which uses this SAME
@@ -173,12 +193,16 @@ pub struct GeometryHasher {
 impl GeometryHasher {
     /// Create a hasher for one entity.
     ///
-    /// * `tolerance` — quantization grid in metres (must be `> 0`).
+    /// * `tolerance` — quantization grid in metres (must be `> 0`). Clamped up
+    ///   to [`MIN_GEOM_HASH_TOLERANCE`] — see that constant for why a smaller
+    ///   request is an `i128` overflow surface in [`surface::plane_of`], not a
+    ///   precision win.
     /// * `rtc_offset` — the file's RTC offset, added back to local positions to
     ///   reconstruct world coordinates. Pass `[0.0; 3]` if positions are
     ///   already in world space.
     pub fn new(tolerance: f64, rtc_offset: [f64; 3]) -> Self {
         debug_assert!(tolerance > 0.0, "geometry hash tolerance must be positive");
+        let tolerance = tolerance.max(MIN_GEOM_HASH_TOLERANCE);
         Self {
             inv_tol: 1.0 / tolerance,
             rtc: rtc_offset,

--- a/rust/geometry/src/geom_hash.rs
+++ b/rust/geometry/src/geom_hash.rs
@@ -24,6 +24,11 @@
 //!   Each triangle's three quantized vertices are sorted before hashing, and
 //!   triangles are combined commutatively, so reordering/rewinding does not move
 //!   the hash.
+//! * **Retriangulation-invariant.** So is the triangulator's DIAGONAL CHOICE.
+//!   The hash is therefore taken over the SURFACE, in two channels a
+//!   retriangulation cannot move — the SET of distinct quantized vertices, and
+//!   the total area within each supporting PLANE (see [`surface`]). See
+//!   [`GeometryHasher::finish`] for what that can and cannot distinguish.
 //! * **Tolerance-quantized.** Positions are snapped to a grid of `tolerance`
 //!   metres before hashing. Larger tolerance absorbs float noise (fewer false
 //!   "changed") at the cost of missing sub-tolerance edits. See
@@ -78,6 +83,12 @@ pub use closure::GeometryClosure;
 #[path = "geom_bounds.rs"]
 mod bounds;
 
+/// The two surface channels the fingerprint is built from. A CHILD module, not
+/// a sibling, so it can use this module's private `mix64`/`fold_i64`.
+#[path = "geom_surface.rs"]
+mod surface;
+use surface::{plane_of, vertex_hash};
+
 /// Default quantization grid in metres (1 mm). Chosen as a starting point near
 /// the `f32` precision floor of RTC-local coordinates; tune empirically with
 /// the `tolerance_sweep` test against real revision pairs.
@@ -116,8 +127,21 @@ fn quantize(world: f64, inv_tol: f64) -> i64 {
 pub struct GeometryHasher {
     inv_tol: f64,
     rtc: [f64; 3],
-    /// Commutative running sum of per-triangle hashes.
-    triangle_accum: u64,
+    /// The distinct quantized world vertices seen so far, over every
+    /// non-degenerate triangle (a degenerate one's corners are triangulation
+    /// noise, and are excluded here for the same reason they are excluded from
+    /// the hash). Membership only — [`Self::vertex_accum`] carries the hash.
+    vertices: rustc_hash::FxHashSet<[i64; 3]>,
+    /// Commutative running sum over the DISTINCT vertices in [`Self::vertices`]
+    /// (one term added on first insertion), so vertex-buffer order, duplicated
+    /// corners and segment splitting cannot move it.
+    vertex_accum: u64,
+    /// Commutative running sum of `plane_key * (twice-area)` over every
+    /// triangle. Multiplication distributes over the wrapping sum, so this is
+    /// exactly `Σ_planes plane_key * (that plane's total twice-area)`: a
+    /// per-plane area total in O(1) space, invariant to how each plane's region
+    /// was cut into triangles.
+    plane_area_accum: u64,
     triangle_count: u64,
     /// Unquantized `f64` world bounds over every in-range triangle corner.
     /// An axis still holding its `INFINITY..NEG_INFINITY` sentinel never
@@ -144,7 +168,9 @@ impl GeometryHasher {
         Self {
             inv_tol: 1.0 / tolerance,
             rtc: rtc_offset,
-            triangle_accum: 0,
+            vertices: rustc_hash::FxHashSet::default(),
+            vertex_accum: 0,
+            plane_area_accum: 0,
             triangle_count: 0,
             min: [f64::INFINITY; 3],
             max: [f64::NEG_INFINITY; 3],
@@ -272,35 +298,28 @@ impl GeometryHasher {
             // coincident or colinear corners carry no shape signal, and
             // counting them lets triangulation noise (sliver/zero-area faces)
             // flip the fingerprint even when the rendered geometry is
-            // unchanged. The cross product of two edges is the zero vector
-            // exactly when the three quantized corners are colinear (which
-            // includes the coincident case). i128 avoids overflow on the
-            // quantized-coordinate products.
-            let e1 = [
-                tri[1][0] as i128 - tri[0][0] as i128,
-                tri[1][1] as i128 - tri[0][1] as i128,
-                tri[1][2] as i128 - tri[0][2] as i128,
-            ];
-            let e2 = [
-                tri[2][0] as i128 - tri[0][0] as i128,
-                tri[2][1] as i128 - tri[0][1] as i128,
-                tri[2][2] as i128 - tri[0][2] as i128,
-            ];
-            let cross_x = e1[1] * e2[2] - e1[2] * e2[1];
-            let cross_y = e1[2] * e2[0] - e1[0] * e2[2];
-            let cross_z = e1[0] * e2[1] - e1[1] * e2[0];
-            if cross_x == 0 && cross_y == 0 && cross_z == 0 {
+            // unchanged. `edge_cross` returns `None` for exactly those.
+            let Some(cross) = surface::edge_cross(&tri) else {
                 continue;
-            }
+            };
 
-            let mut h = 0x5bd1_e995_u64; // arbitrary non-zero seed
+            // Channel 1 — the vertex SET: every corner of every surviving
+            // triangle, deduplicated. A retriangulation reconnects the same
+            // corners, so this is exactly what it cannot move.
             for corner in tri {
-                for c in corner {
-                    h = fold_i64(h, c);
+                if self.vertices.insert(corner) {
+                    self.vertex_accum = self.vertex_accum.wrapping_add(vertex_hash(&corner));
                 }
             }
-            // Commutative combine across triangles within and across segments.
-            self.triangle_accum = self.triangle_accum.wrapping_add(mix64(h));
+
+            // Channel 2 — area per supporting plane. The vertex set alone
+            // cannot see a face deleted from between corners other faces still
+            // use; the area can, and a retriangulation leaves it untouched.
+            let plane = plane_of(cross, &tri[0]);
+            self.plane_area_accum = self
+                .plane_area_accum
+                .wrapping_add(plane.key.wrapping_mul(plane.weight as u64));
+
             self.triangle_count = self.triangle_count.wrapping_add(1);
         }
 
@@ -320,16 +339,31 @@ impl GeometryHasher {
         self.triangle_count == 0
     }
 
-    /// Finalize the entity's geometry hash. Folds in the triangle count so two
-    /// distinct shapes that happen to collide on the commutative triangle sum
-    /// are still separated by their cardinality. Vertex count is intentionally
-    /// excluded: it is ambiguous under shared-vs-duplicated vertices and under
-    /// segment splitting (the same entity may arrive as one mesh or several
-    /// sharing a position buffer), whereas the triangle count is intrinsic and
-    /// additive across segments.
+    /// Finalize the entity's geometry hash: the distinct-vertex sum and the
+    /// per-plane area total.
+    ///
+    /// ## What a difference here means, and what it does not
+    ///
+    /// Two entities hash the same when they use the same set of quantized world
+    /// vertices AND every plane carries the same total area. That covers the
+    /// invariances the surface actually has — retriangulation, a re-rooted fan,
+    /// triangle/segment order, winding — and still separates every genuine edit
+    /// measured against it: a move, a scale, a face lifted out of its plane (new
+    /// plane key), and faces deleted, whether or not their corners survive
+    /// elsewhere in the mesh (the area falls either way).
+    ///
+    /// It is deliberately a weaker discriminator than the triangle set it
+    /// replaced. What it can no longer separate: two arrangements over the SAME
+    /// vertex set giving every plane the same total area (retriangulation is
+    /// the benign member of that family; a re-cut into a different region of
+    /// equal area on the same corners is the malign one, and is not something a
+    /// re-export produces), and a change of TRIANGLE COUNT alone — the count is
+    /// no longer folded in, being exactly what a retriangulation changes.
+    ///
+    /// Unchanged from before: winding is invisible, as is anything below the
+    /// quantization grid.
     pub fn finish(&self) -> u64 {
-        let mut h = self.triangle_accum;
-        h = fold_i64(h, self.triangle_count as i64);
+        let h = fold_i64(self.vertex_accum, self.plane_area_accum as i64);
         mix64(h)
     }
 }

--- a/rust/geometry/src/geom_hash.rs
+++ b/rust/geometry/src/geom_hash.rs
@@ -7,9 +7,11 @@
 //! The viewer's "compare two revisions" feature needs a stable per-entity
 //! signature so an unchanged element hashes identically across two files,
 //! while a genuine edit (moved, or reshaped so the surface itself changes)
-//! hashes differently. Re-triangulating an unchanged surface is *not* an edit
-//! and deliberately does not move the hash — see **Retriangulation-invariant**
-//! below, and [`GeometryHasher::finish`] for the limits of that.
+//! hashes differently. Re-cutting an unchanged surface over the SAME corners is
+//! *not* an edit and deliberately does not move the hash — see
+//! **Retriangulation-invariant** below for the exact scope of that guarantee,
+//! and [`GeometryHasher::finish`] for what the fingerprint can and cannot
+//! distinguish.
 //!
 //! ## Design invariants
 //!
@@ -27,11 +29,20 @@
 //!   Each triangle's three quantized vertices are sorted before hashing, and
 //!   triangles are combined commutatively, so reordering/rewinding does not move
 //!   the hash.
-//! * **Retriangulation-invariant.** So is the triangulator's DIAGONAL CHOICE.
-//!   The hash is therefore taken over the SURFACE, in two channels a
-//!   retriangulation cannot move — the SET of distinct quantized vertices, and
-//!   the total area within each supporting PLANE (see [`surface`]). See
-//!   [`GeometryHasher::finish`] for what that can and cannot distinguish.
+//! * **Retriangulation-invariant, over a fixed vertex set.** So is the
+//!   triangulator's DIAGONAL CHOICE. The hash is therefore taken over the
+//!   SURFACE, in two channels re-cutting cannot move — the SET of distinct
+//!   quantized vertices, and the total area within each supporting PLANE (see
+//!   [`surface`]).
+//!
+//!   The guarantee is exactly this: re-cutting a region over the corners it
+//!   already has (a re-split diagonal, a re-rooted fan) does not move the hash.
+//!   It does **not** extend to a tessellation that INTRODUCES vertices — a quad
+//!   refanned through a new centre point, or an edge split at a new midpoint,
+//!   adds a member to the vertex-set channel and so does hash differently, even
+//!   though the surface and its per-plane area are unchanged. Distinguishing
+//!   that from a genuine edit needs a channel this fingerprint does not have.
+//!   See [`GeometryHasher::finish`] for the rest of the limits.
 //! * **Tolerance-quantized.** Positions are snapped to a grid of `tolerance`
 //!   metres before hashing. Larger tolerance absorbs float noise (fewer false
 //!   "changed") at the cost of missing sub-tolerance edits. See

--- a/rust/geometry/src/geom_hash.rs
+++ b/rust/geometry/src/geom_hash.rs
@@ -84,9 +84,6 @@
 //! and none of the wrong numbers look wrong. [`GeometryClosure`] rides along so
 //! a consumer can say WHICH clause refused.
 
-use crate::kernel::signed_volume::tetra_volume6;
-use crate::mesh_orient::OrientVerdict;
-
 /// The volume gate (`GeometryClosure` + `GeometryHasher::volume`). A CHILD
 /// module, not a sibling, so it can read this module's private accumulators
 /// without widening their visibility.
@@ -104,7 +101,12 @@ mod bounds;
 /// a sibling, so it can use this module's private `mix64`/`fold_i64`.
 #[path = "geom_surface.rs"]
 mod surface;
-use surface::{plane_of, vertex_hash};
+
+/// The per-segment triangle fold (`add_mesh` / `add_mesh_with_origin` /
+/// `add_oriented_mesh`). A CHILD module, not a sibling, so it can read this
+/// module's private accumulators without widening their visibility.
+#[path = "geom_accumulate.rs"]
+mod accumulate;
 
 /// Default quantization grid in metres (1 mm). Chosen as a starting point near
 /// the `f32` precision floor of RTC-local coordinates; tune empirically with
@@ -215,159 +217,6 @@ impl GeometryHasher {
             volume6: 0.0,
             closure: GeometryClosure::EMPTY,
         }
-    }
-
-    /// Reconstruct the full `f64` WORLD coordinate of one vertex. `origin` is
-    /// the per-mesh local-frame origin (`world = origin + position`); pass
-    /// `[0.0; 3]` for absolute-coordinate positions.
-    #[inline]
-    fn world(&self, positions: &[f32], vi: usize, origin: &[f64; 3]) -> [f64; 3] {
-        let base = vi * 3;
-        [
-            positions[base] as f64 + origin[0] + self.rtc[0],
-            positions[base + 1] as f64 + origin[1] + self.rtc[1],
-            positions[base + 2] as f64 + origin[2] + self.rtc[2],
-        ]
-    }
-
-    /// Snap a reconstructed world corner to the quantization grid.
-    #[inline]
-    fn quantize_corner(&self, world: &[f64; 3]) -> [i64; 3] {
-        [
-            quantize(world[0], self.inv_tol),
-            quantize(world[1], self.inv_tol),
-            quantize(world[2], self.inv_tol),
-        ]
-    }
-
-    /// Add one mesh segment (a flat `[x,y,z, ...]` position buffer and a
-    /// triangle index buffer). Indices that run past the position buffer or
-    /// trailing non-triangle remainder are skipped defensively.
-    pub fn add_mesh(&mut self, positions: &[f32], indices: &[u32]) {
-        self.add_mesh_with_origin(positions, indices, [0.0; 3]);
-    }
-
-    /// Like [`add_mesh`] but for positions stored in a per-element LOCAL frame:
-    /// `origin` (the per-mesh AABB-centre origin) is folded back so the hash is
-    /// over absolute world coordinates. This keeps the fingerprint identical
-    /// whether the producer emitted absolute positions (native) or local +
-    /// origin (the wasm local-frame path), and still detects element MOVES.
-    ///
-    /// The segment carries no topology verdict, so it counts as NOT a closed
-    /// solid and permanently disarms [`Self::volume`]. Producers that ran
-    /// [`crate::orient_mesh_outward_verdict`] on this exact buffer should call
-    /// [`Self::add_oriented_mesh`] instead.
-    pub fn add_mesh_with_origin(&mut self, positions: &[f32], indices: &[u32], origin: [f64; 3]) {
-        self.add_oriented_mesh(positions, indices, origin, OrientVerdict::INDETERMINATE);
-    }
-
-    /// [`Self::add_mesh_with_origin`] for a segment the producer just ran the
-    /// outward-orienter over, passing that pass's [`OrientVerdict`] along.
-    ///
-    /// `verdict` MUST describe this exact position/index buffer — the volume
-    /// below is only as honest as the closedness claim behind it. Anything
-    /// short of a single closed orientable component disarms the element's
-    /// volume permanently; see [`Self::volume`].
-    pub fn add_oriented_mesh(
-        &mut self,
-        positions: &[f32],
-        indices: &[u32],
-        origin: [f64; 3],
-        verdict: OrientVerdict,
-    ) {
-        // Σ 6·V for THIS segment, referenced to its own first in-range corner
-        // (`vol_ref`). Any reference gives the same total on a closed surface,
-        // but referencing a point ON the surface keeps every operand bounded by
-        // the segment's own diameter — a georeferenced model at 1e5 m would
-        // otherwise multiply three ~1e5 coordinates and cancel a ~1 m³ answer
-        // out of ~1e15, losing every significant digit.
-        let mut seg_volume6 = 0.0f64;
-        let mut vol_ref: Option<[f64; 3]> = None;
-        let vertex_limit = positions.len() / 3;
-        let triangle_end = indices.len() - (indices.len() % 3);
-        let mut i = 0;
-        while i < triangle_end {
-            let i0 = indices[i] as usize;
-            let i1 = indices[i + 1] as usize;
-            let i2 = indices[i + 2] as usize;
-            i += 3;
-            if i0 >= vertex_limit || i1 >= vertex_limit || i2 >= vertex_limit {
-                continue;
-            }
-
-            let world = [
-                self.world(positions, i0, &origin),
-                self.world(positions, i1, &origin),
-                self.world(positions, i2, &origin),
-            ];
-
-            // Bounds take EVERY in-range corner, including those of triangles
-            // the hash rejects as post-quantization degenerate below. A sliver
-            // or zero-area face carries no shape signal for the fingerprint,
-            // but its corners are real geometry and do contribute extent —
-            // dropping them would under-report the element's box.
-            for corner in &world {
-                self.extend_bounds(corner);
-            }
-
-            // Volume accumulates HERE, from `world`, whose corners are still in
-            // the buffer's authored order. The quantized copy `tri` below is
-            // SORTED (that is what makes the fingerprint winding-invariant), so
-            // anything downstream of that sort has no winding left to integrate.
-            //
-            // Every in-range triangle counts, including the ones the hash drops
-            // as post-quantization degenerate: a sub-millimetre sliver carries
-            // no shape signal for a fingerprint, but it is part of the closed
-            // surface, and its (near-zero) flux belongs in the sum.
-            let o = *vol_ref.get_or_insert(world[0]);
-            seg_volume6 += tetra_volume6(&world[0], &world[1], &world[2], &o);
-
-            // Sort the three quantized corners so triangle winding and the
-            // starting vertex don't affect the hash — only the (multiset of)
-            // positions and their adjacency as a triangle.
-            let mut tri = [
-                self.quantize_corner(&world[0]),
-                self.quantize_corner(&world[1]),
-                self.quantize_corner(&world[2]),
-            ];
-            tri.sort_unstable();
-
-            // Skip degenerate (zero-area) triangles. After quantization,
-            // coincident or colinear corners carry no shape signal, and
-            // counting them lets triangulation noise (sliver/zero-area faces)
-            // flip the fingerprint even when the rendered geometry is
-            // unchanged. `edge_cross` returns `None` for exactly those.
-            let Some(cross) = surface::edge_cross(&tri) else {
-                continue;
-            };
-
-            // Channel 1 — the vertex SET: every corner of every surviving
-            // triangle, deduplicated. A retriangulation reconnects the same
-            // corners, so this is exactly what it cannot move.
-            for corner in tri {
-                if self.vertices.insert(corner) {
-                    self.vertex_accum = self.vertex_accum.wrapping_add(vertex_hash(&corner));
-                }
-            }
-
-            // Channel 2 — area per supporting plane. The vertex set alone
-            // cannot see a face deleted from between corners other faces still
-            // use; the area can, and a retriangulation leaves it untouched.
-            let plane = plane_of(cross, &tri[0]);
-            self.plane_area_accum = self
-                .plane_area_accum
-                .wrapping_add(plane.key.wrapping_mul(plane.weight as u64));
-
-            self.triangle_count = self.triangle_count.wrapping_add(1);
-        }
-
-        // A call that contributed no in-range triangle is not a segment: it has
-        // no geometry, so its verdict says nothing about the element.
-        if vol_ref.is_none() {
-            return;
-        }
-        self.closure.fold_segment(&verdict);
-        self.volume6 += seg_volume6;
     }
 
     /// `true` until at least one (non-degenerate, in-range) triangle has been

--- a/rust/geometry/src/geom_hash_tests.rs
+++ b/rust/geometry/src/geom_hash_tests.rs
@@ -356,28 +356,33 @@ fn a_hash_without_a_box_is_reachable() {
     assert!(empty.is_empty() && empty.world_aabb().is_none());
 }
 
-/// The AABB work must not perturb a single existing fingerprint. These are the
-/// hash values produced by `geom_hash.rs` BEFORE this change; they are pinned
-/// literals, not recomputed, so a future refactor of the corner reconstruction
-/// cannot silently re-key every stored diff.
+/// Pinned literals, not recomputed, so no later refactor of the corner
+/// reconstruction can silently re-key every stored diff.
+///
+/// These values moved ONCE, deliberately, when the fingerprint stopped hashing
+/// the triangle set and started hashing the surface (vertex set + per-plane
+/// area) to become retriangulation-invariant. That re-keys every fingerprint —
+/// which is safe only because they are computed on load and never persisted:
+/// both sides of a compare are hashed by the same build. Moving them again
+/// needs the same argument, which is what this test exists to force.
 #[test]
-fn hash_values_are_byte_identical_to_the_pre_aabb_implementation() {
+fn hash_values_are_pinned_against_a_silent_re_key() {
     let (pos, idx) = cube([0.0, 0.0, 0.0]);
     assert_eq!(
         hash_mesh_world(&pos, &idx, [0.0; 3], TOL),
-        9_804_297_170_738_711_971
+        6_825_412_298_365_256_040
     );
 
     let (pos, idx) = cube([1234.5, -67.25, 8.5]);
     assert_eq!(
         hash_mesh_world(&pos, &idx, [999_000.0, -2_000.0, 5_000.0], TOL),
-        16_570_244_528_967_140_961
+        15_006_160_787_977_600_551
     );
 
     let mut h = GeometryHasher::new(1.0e-2, [3.0, -1.0, 0.5]);
     let (pos, idx) = cube([10.0, 0.0, -4.0]);
     h.add_mesh_with_origin(&pos, &idx, [0.125, 0.25, -0.5]);
-    assert_eq!(h.finish(), 7_301_177_935_129_768_504);
+    assert_eq!(h.finish(), 12_803_763_652_453_329_586);
 }
 
 // ---------------------------------------------------------------------------
@@ -589,4 +594,260 @@ fn closure_flags_pack_one_bit_per_clause() {
     assert_eq!(GeometryClosure { all_orientable: false, ..base }.bits(), 0b1101);
     assert_eq!(GeometryClosure { all_single_component: false, ..base }.bits(), 0b1011);
     assert_eq!(GeometryClosure { segments: 2, ..base }.bits(), 0b0111);
+}
+
+// ---------------------------------------------------------------------------
+// Retriangulation invariance. A triangulator's diagonal choice is not a shape:
+// `tests/triangulation_invariance.rs` says outright that "nothing downstream is
+// entitled to depend on which one it gets", and a fingerprint that hashes
+// TRIANGLES depends on it — a flat quad re-split along the other diagonal is
+// the same surface with a different triangle set. These pin that the hash reads
+// the SURFACE (its vertex set and its per-plane area), while every genuine edit
+// below still moves it.
+// ---------------------------------------------------------------------------
+
+/// The four corners of one flat, axis-aligned quad, at the coordinates and the
+/// z of the measured false positive: a horizontal face of an infrastructure
+/// element whose two revisions differ only in how the quad was split.
+///
+/// Order is the boundary loop `A → B → E → D`, so `[A,B,E] + [A,E,D]` and
+/// `[A,B,D] + [B,E,D]` are the two diagonals of the SAME quad.
+const QUAD: [[f32; 3]; 4] = [
+    [-95.441_113, 650.0, 4.999_997],       // 0 = A
+    [-95.441_113, 895.808_18, 4.999_997],  // 1 = B
+    [-64.253_99, 843.158_94, 4.999_997],   // 2 = E
+    [-64.253_99, 650.0, 4.999_997],        // 3 = D
+];
+
+fn quad_positions() -> Vec<f32> {
+    QUAD.iter().flat_map(|v| *v).collect()
+}
+
+#[test]
+fn a_quad_split_along_the_other_diagonal_is_the_same_shape() {
+    let pos = quad_positions();
+    // Diagonal A–E versus diagonal B–D. Same four corners, same plane, same
+    // surface, same area; only the interior edge moves.
+    let ae = [0, 1, 2, 0, 2, 3];
+    let bd = [0, 1, 3, 1, 2, 3];
+    assert_eq!(
+        hash_mesh_world(&pos, &ae, [0.0; 3], TOL),
+        hash_mesh_world(&pos, &bd, [0.0; 3], TOL),
+        "re-splitting a flat quad along its other diagonal is not a shape change"
+    );
+}
+
+#[test]
+fn a_fan_re_rooted_on_another_corner_is_the_same_shape() {
+    // The same invariance one step past a quad: a convex pentagon fanned from
+    // corner 0 versus the same pentagon fanned from corner 2. Same boundary,
+    // same region, three triangles each, disjoint triangle sets.
+    let pos: Vec<f32> = [
+        [0.0_f32, 0.0, 2.5],
+        [4.0, 0.0, 2.5],
+        [5.0, 3.0, 2.5],
+        [2.0, 5.0, 2.5],
+        [-1.0, 3.0, 2.5],
+    ]
+    .iter()
+    .flat_map(|v| *v)
+    .collect();
+    let from_0 = [0, 1, 2, 0, 2, 3, 0, 3, 4];
+    let from_2 = [2, 3, 4, 2, 4, 0, 2, 0, 1];
+    assert_eq!(
+        hash_mesh_world(&pos, &from_0, [0.0; 3], TOL),
+        hash_mesh_world(&pos, &from_2, [0.0; 3], TOL),
+        "re-rooting a fan over the same polygon is not a shape change"
+    );
+}
+
+#[test]
+fn an_oblique_polygon_refanned_is_the_same_shape() {
+    // The same re-fan as above, but on a SLANTED plane (normal 2:3:6) and with
+    // the two fans distributing the area differently between their triangles
+    // (3+6+4 versus 5+5+3). Both matter:
+    //
+    // * A slanted plane is the only case where reducing the integer normal to
+    //   its primitive form takes real work — every axis-aligned face reduces in
+    //   one step. Get that reduction wrong and coplanar triangles of unequal
+    //   size no longer key to the same plane.
+    // * Unequal areas are what make the per-plane total load-bearing: with the
+    //   same three areas on both sides, an unreduced normal would cancel out by
+    //   accident and hide the defect.
+    //
+    // Convex pentagon (0,0) (3,0) (4,2) (2,4) (-1,2) in the plane's own basis
+    // u = (9,-6,0)/3, v = (0,2,-1), laid out here in metres.
+    let pos: Vec<f32> = [
+        [0.0_f32, 0.0, 0.0],
+        [9.0, -6.0, 0.0],
+        [12.0, -4.0, -2.0],
+        [6.0, 4.0, -4.0],
+        [-3.0, 6.0, -2.0],
+    ]
+    .iter()
+    .flat_map(|v| *v)
+    .collect();
+    let from_0 = [0, 1, 2, 0, 2, 3, 0, 3, 4];
+    let from_2 = [2, 3, 4, 2, 4, 0, 2, 0, 1];
+    assert_eq!(
+        hash_mesh_world(&pos, &from_0, [0.0; 3], TOL),
+        hash_mesh_world(&pos, &from_2, [0.0; 3], TOL),
+        "re-fanning a polygon on a slanted plane is not a shape change"
+    );
+}
+
+/// An `n x n` grid of unit quads in the plane `z = 0`, each split along its
+/// lower-left diagonal. `holes` lists cells (col, row) to leave empty — their
+/// corner vertices stay in the mesh via the neighbouring cells, so a hole
+/// removes AREA without removing a single vertex.
+fn grid(n: usize, holes: &[(usize, usize)]) -> (Vec<f32>, Vec<u32>) {
+    let stride = n + 1;
+    let mut positions = Vec::with_capacity(stride * stride * 3);
+    for row in 0..stride {
+        for col in 0..stride {
+            positions.extend_from_slice(&[col as f32, row as f32, 0.0]);
+        }
+    }
+    let mut indices = Vec::new();
+    for row in 0..n {
+        for col in 0..n {
+            if holes.contains(&(col, row)) {
+                continue;
+            }
+            let a = (row * stride + col) as u32;
+            let (b, c, d) = (a + 1, a + stride as u32, a + stride as u32 + 1);
+            indices.extend_from_slice(&[a, b, c, b, d, c]);
+        }
+    }
+    (positions, indices)
+}
+
+#[test]
+fn removing_triangles_is_still_a_change() {
+    // The control for the whole exercise, in the shape of the measured
+    // genuine edit: a mesh loses a large fraction of its triangles between two
+    // revisions (521 -> 394 there; 128 -> 116 here). That MUST stay flagged —
+    // a fix that silences the diagonal flip by silencing this is worthless.
+    let (pos, full) = grid(8, &[]);
+    let (_, cut) = grid(8, &[(1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6)]);
+    assert_eq!(full.len() / 3, 128);
+    assert_eq!(cut.len() / 3, 116);
+    assert_ne!(
+        hash_mesh_world(&pos, &full, [0.0; 3], TOL),
+        hash_mesh_world(&pos, &cut, [0.0; 3], TOL),
+        "triangles genuinely removed must still register as a change"
+    );
+}
+
+#[test]
+fn removing_area_registers_even_when_every_vertex_survives() {
+    // The same control with the vertex set held FIXED: the punched cell is
+    // interior, so all four of its corners remain in use by its neighbours.
+    // Nothing but the surface area itself is left to notice the hole, which is
+    // what makes this the test that the area channel is load-bearing.
+    let (pos, full) = grid(4, &[]);
+    let (_, holed) = grid(4, &[(1, 1)]);
+    assert_ne!(
+        hash_mesh_world(&pos, &full, [0.0; 3], TOL),
+        hash_mesh_world(&pos, &holed, [0.0; 3], TOL),
+        "a hole punched between surviving vertices is a change"
+    );
+}
+
+#[test]
+fn the_same_corners_covering_a_different_area_is_a_change() {
+    // Both meshes use all four QUAD corners, so the vertex set alone cannot
+    // separate them: the quad (two triangles tiling it) versus two OVERLAPPING
+    // triangles spanning the same corners. Different surface, different area.
+    let pos = quad_positions();
+    let tiled = [0, 1, 2, 0, 2, 3];
+    let overlapping = [0, 1, 3, 0, 1, 2];
+    assert_ne!(
+        hash_mesh_world(&pos, &tiled, [0.0; 3], TOL),
+        hash_mesh_world(&pos, &overlapping, [0.0; 3], TOL),
+        "the same corners covering a different area is a shape change"
+    );
+}
+
+#[test]
+fn a_coplanar_face_lifted_out_of_its_plane_is_a_change() {
+    // Guards the plane key: move one corner off the shared plane and the two
+    // triangles no longer live in one plane. Same corner COUNT, same triangle
+    // count, genuinely different surface.
+    let flat = quad_positions();
+    let mut folded = flat.clone();
+    folded[2 * 3 + 2] += 0.5; // lift corner E by 500 mm
+    let idx = [0, 1, 2, 0, 2, 3];
+    assert_ne!(
+        hash_mesh_world(&flat, &idx, [0.0; 3], TOL),
+        hash_mesh_world(&folded, &idx, [0.0; 3], TOL),
+        "folding a flat face out of plane is a shape change"
+    );
+}
+
+#[test]
+fn sliding_a_face_within_its_own_plane_is_a_change() {
+    // Isolates the VERTEX channel. Both meshes are one quad in the plane z = 0
+    // with the same area, so the plane key and the per-plane area are identical
+    // and only the corners differ. Nothing but the vertex set can see this.
+    let here: Vec<f32> = [[0.0_f32, 0.0, 0.0], [3.0, 0.0, 0.0], [3.0, 2.0, 0.0], [0.0, 2.0, 0.0]]
+        .iter()
+        .flat_map(|v| *v)
+        .collect();
+    let there: Vec<f32> =
+        here.chunks_exact(3).flat_map(|c| [c[0] + 10.0, c[1], c[2]]).collect();
+    let idx = [0, 1, 2, 0, 2, 3];
+    assert_ne!(
+        hash_mesh_world(&here, &idx, [0.0; 3], TOL),
+        hash_mesh_world(&there, &idx, [0.0; 3], TOL),
+        "the same face slid sideways within its plane is a change"
+    );
+}
+
+#[test]
+fn two_faces_at_different_heights_are_not_one_face_of_double_the_area() {
+    // Isolates the plane OFFSET. Both meshes use all eight corners of a box and
+    // carry the same total horizontal area on the same normal; they differ only
+    // in how that area is distributed between z = 0 and z = 1. Drop the offset
+    // from the plane key and the two heights collapse into one plane of double
+    // the area, and these two become indistinguishable.
+    let mut pos = Vec::new();
+    for &z in &[0.0_f32, 1.0] {
+        for &(x, y) in &[(0.0_f32, 0.0_f32), (3.0, 0.0), (3.0, 2.0), (0.0, 2.0)] {
+            pos.extend_from_slice(&[x, y, z]);
+        }
+    }
+    // 0..3 = the z=0 corners, 4..7 = the z=1 corners, in the same order. The
+    // walls are common to both and keep every corner in use on either side.
+    let walls = [0, 1, 5, 0, 5, 4, 2, 3, 7, 2, 7, 6];
+    let one_each: Vec<u32> =
+        [&[0, 1, 2, 0, 2, 3][..], &[4, 5, 6, 4, 6, 7][..], &walls[..]].concat();
+    let both_low: Vec<u32> =
+        [&[0, 1, 2, 0, 2, 3][..], &[0, 1, 2, 0, 2, 3][..], &walls[..]].concat();
+    assert_ne!(
+        hash_mesh_world(&pos, &one_each, [0.0; 3], TOL),
+        hash_mesh_world(&pos, &both_low, [0.0; 3], TOL),
+        "a face at each height is not two coincident faces at one height"
+    );
+}
+
+#[test]
+fn a_t_junction_vertex_is_still_reported_as_a_change() {
+    // The documented LIMIT, pinned so nobody reads more invariance into this
+    // than is there. Splitting a boundary edge at a new midpoint vertex leaves
+    // the same surface, but it is not the same vertex set — it is not
+    // retriangulation in the sense this fingerprint is invariant to, and it
+    // still reads as changed.
+    let pos = quad_positions();
+    let plain = hash_mesh_world(&pos, &[0, 1, 2, 0, 2, 3], [0.0; 3], TOL);
+
+    let mut with_mid = pos.clone();
+    // Midpoint of the A–B boundary edge.
+    with_mid.extend_from_slice(&[
+        (QUAD[0][0] + QUAD[1][0]) / 2.0,
+        (QUAD[0][1] + QUAD[1][1]) / 2.0,
+        QUAD[0][2],
+    ]);
+    let split = hash_mesh_world(&with_mid, &[0, 4, 2, 4, 1, 2, 0, 2, 3], [0.0; 3], TOL);
+    assert_ne!(plain, split, "a new T-junction vertex is outside the invariance");
 }

--- a/rust/geometry/src/geom_hash_tests.rs
+++ b/rust/geometry/src/geom_hash_tests.rs
@@ -606,9 +606,9 @@ fn closure_flags_pack_one_bit_per_clause() {
 // below still moves it.
 // ---------------------------------------------------------------------------
 
-/// The four corners of one flat, axis-aligned quad, at the coordinates and the
-/// z of the measured false positive: a horizontal face of an infrastructure
-/// element whose two revisions differ only in how the quad was split.
+/// The four corners of one flat, axis-aligned quad: a horizontal face lying
+/// off-origin at an oblique-cornered outline, so the two diagonals of the SAME
+/// quad produce genuinely different triangle sets.
 ///
 /// Order is the boundary loop `A → B → E → D`, so `[A,B,E] + [A,E,D]` and
 /// `[A,B,D] + [B,E,D]` are the two diagonals of the SAME quad.

--- a/rust/geometry/src/geom_hash_tests.rs
+++ b/rust/geometry/src/geom_hash_tests.rs
@@ -107,6 +107,51 @@ fn sub_tolerance_jitter_is_ignored() {
 }
 
 #[test]
+fn a_request_finer_than_the_floor_is_clamped_not_honoured() {
+    // A large triangle far from the origin (a georeferenced point, ~2.6e6 m,
+    // with a 100 m edge) at the maintainer-reported dangerous tolerance
+    // (1e-9 m) is exactly the shape that pushed `plane_of`'s `i128` plane
+    // offset to ~1.6e38 -- within a factor of ~1 of `i128::MAX`. This must
+    // neither panic (debug) nor silently wrap (release): `GeometryHasher::new`
+    // clamps any request finer than `MIN_GEOM_HASH_TOLERANCE` up to it.
+    let origin = [2_600_000.0_f32, 0.0, 0.0];
+    let positions: Vec<f32> = vec![
+        origin[0],
+        origin[1],
+        origin[2],
+        origin[0] + 100.0,
+        origin[1],
+        origin[2],
+        origin[0],
+        origin[1] + 100.0,
+        origin[2],
+    ];
+    let indices = vec![0u32, 1, 2];
+
+    // Must not panic.
+    let requested_1e_9 = hash_mesh_world(&positions, &indices, [0.0; 3], 1e-9);
+
+    // A request clamped to the floor must produce the SAME hash as asking for
+    // the floor directly -- proving the clamp actually took effect, not just
+    // that the finer request happened not to panic this run.
+    let at_floor = hash_mesh_world(&positions, &indices, [0.0; 3], MIN_GEOM_HASH_TOLERANCE);
+    assert_eq!(
+        requested_1e_9, at_floor,
+        "a tolerance finer than MIN_GEOM_HASH_TOLERANCE must be clamped up to it, \
+         not honoured verbatim"
+    );
+
+    // And it must actually differ from a call at the (coarser) default --
+    // otherwise the clamp could be silently clamping everything to the same
+    // value regardless of what was asked for.
+    let at_default = hash_mesh_world(&positions, &indices, [0.0; 3], DEFAULT_GEOM_HASH_TOLERANCE);
+    assert_ne!(
+        at_floor, at_default,
+        "the floor and the (coarser) default must not collapse to the same grid"
+    );
+}
+
+#[test]
 fn triangle_and_vertex_order_invariant() {
     let (pos, idx) = cube([3.0, 3.0, 3.0]);
     let canonical = hash_mesh_world(&pos, &idx, [0.0; 3], TOL);

--- a/rust/geometry/src/geom_hash_tests.rs
+++ b/rust/geometry/src/geom_hash_tests.rs
@@ -6,6 +6,7 @@
 //! the house 400-line rule (test files are ratchet-exempt).
 
 use super::*;
+use crate::mesh_orient::OrientVerdict;
 
 /// A unit cube (8 verts, 12 triangles) centred near `origin` in world
 /// coordinates. Returns positions already in world space.

--- a/rust/geometry/src/geom_surface.rs
+++ b/rust/geometry/src/geom_surface.rs
@@ -11,11 +11,10 @@
 //! `tests/triangulation_invariance.rs` says outright that "nothing downstream
 //! is entitled to depend on which one it gets". A fingerprint over triangles
 //! does depend on it — a flat quad re-split along its other diagonal is a
-//! different triangle set, and hashed differently. Measured on two revisions of
-//! one infrastructure model, that reported an element whose vertices, surface,
-//! area, centroid and bounding box were all identical as reshaped: 824
-//! triangles on both sides, three differing on each, one coplanar quad cut the
-//! other way.
+//! different triangle set, and hashed differently. A triangle-based fingerprint
+//! therefore reports an element as reshaped even when its vertices, surface,
+//! area, centroid and bounding box are all identical, because one coplanar quad
+//! was cut the other way.
 //!
 //! So [`super::GeometryHasher`] hashes a SURFACE instead, and the two things it
 //! hashes are computed here: the identity of the PLANE a triangle lies in

--- a/rust/geometry/src/geom_surface.rs
+++ b/rust/geometry/src/geom_surface.rs
@@ -1,0 +1,128 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! The two surface channels behind the geometry fingerprint — split out of
+//! `geom_hash.rs` to keep it under the house 400-line rule.
+//!
+//! ## Why the fingerprint is not over triangles
+//!
+//! A triangulator's DIAGONAL CHOICE is not a shape:
+//! `tests/triangulation_invariance.rs` says outright that "nothing downstream
+//! is entitled to depend on which one it gets". A fingerprint over triangles
+//! does depend on it — a flat quad re-split along its other diagonal is a
+//! different triangle set, and hashed differently. Measured on two revisions of
+//! one infrastructure model, that reported an element whose vertices, surface,
+//! area, centroid and bounding box were all identical as reshaped: 824
+//! triangles on both sides, three differing on each, one coplanar quad cut the
+//! other way.
+//!
+//! So [`super::GeometryHasher`] hashes a SURFACE instead, and the two things it
+//! hashes are computed here: the identity of the PLANE a triangle lies in
+//! together with that triangle's exact integer area ([`plane_of`]), and the
+//! hash of one distinct quantized vertex ([`vertex_hash`]).
+//!
+//! Everything here is exact integer arithmetic over already-quantized
+//! coordinates. That is the point: an area or a normal recomputed in floating
+//! point would land on either side of a rounding boundary depending on how the
+//! surface happened to be cut, which is the very dependency being removed.
+
+use super::{fold_i64, mix64};
+
+/// Fold one wide signed integer as its two 64-bit halves. Plane coefficients
+/// are exact `i128` products of quantized coordinates and do not fit `i64`.
+#[inline]
+fn fold_i128(acc: u64, v: i128) -> u64 {
+    let bits = v as u128;
+    fold_i64(fold_i64(acc, bits as u64 as i64), (bits >> 64) as u64 as i64)
+}
+
+/// The cross product of two edges of a quantized triangle — twice its area
+/// vector, exactly, in `i128` so the quantized-coordinate products cannot
+/// overflow. `None` when the three corners are colinear (which includes the
+/// coincident case), i.e. exactly when the triangle is degenerate after
+/// quantization and carries no shape signal.
+pub(super) fn edge_cross(tri: &[[i64; 3]; 3]) -> Option<[i128; 3]> {
+    let e1 = [
+        tri[1][0] as i128 - tri[0][0] as i128,
+        tri[1][1] as i128 - tri[0][1] as i128,
+        tri[1][2] as i128 - tri[0][2] as i128,
+    ];
+    let e2 = [
+        tri[2][0] as i128 - tri[0][0] as i128,
+        tri[2][1] as i128 - tri[0][1] as i128,
+        tri[2][2] as i128 - tri[0][2] as i128,
+    ];
+    let cross = [
+        e1[1] * e2[2] - e1[2] * e2[1],
+        e1[2] * e2[0] - e1[0] * e2[2],
+        e1[0] * e2[1] - e1[1] * e2[0],
+    ];
+    (cross != [0, 0, 0]).then_some(cross)
+}
+
+/// Greatest common divisor, Euclid. `gcd(x, 0) == x`, so a normal with zero
+/// components (every axis-aligned face) reduces correctly.
+#[inline]
+fn gcd(mut a: u128, mut b: u128) -> u128 {
+    while b != 0 {
+        let r = a % b;
+        a = b;
+        b = r;
+    }
+    a
+}
+
+/// The exact plane a quantized triangle lies in, and its area weight.
+///
+/// `cross` is the integer cross product of two of the triangle's edges, so it
+/// is `g * n` for the primitive (component-gcd-reduced) integer normal `n` and
+/// a positive integer `g`. Reducing to `n` makes the key equal for every
+/// triangle in the plane whatever its size, and `g` is then twice the
+/// triangle's area in units of `|n|` — the same unit for every triangle in that
+/// plane, so summing `g` per plane gives that plane's total area exactly, in
+/// integers, with no float rounding anywhere.
+///
+/// The sign is canonicalised (first non-zero component positive) so a plane and
+/// its opposite orientation key the same: winding is not shape.
+pub(super) struct TrianglePlane {
+    pub(super) key: u64,
+    /// Twice the triangle's area, in units of `|n|`. `> 0` for any triangle
+    /// with a non-zero `cross`.
+    pub(super) weight: u128,
+}
+
+/// Key the plane of a non-degenerate quantized triangle. `cross` must be
+/// non-zero; `point` is any corner of the triangle (all give the same key).
+pub(super) fn plane_of(cross: [i128; 3], point: &[i64; 3]) -> TrianglePlane {
+    let weight = gcd(
+        gcd(cross[0].unsigned_abs(), cross[1].unsigned_abs()),
+        cross[2].unsigned_abs(),
+    );
+    let g = weight as i128;
+    let mut n = [cross[0] / g, cross[1] / g, cross[2] / g];
+    // Canonical sign: first non-zero component positive. `cross` is non-zero,
+    // so some component is.
+    if n.iter().find(|c| **c != 0).is_some_and(|c| *c < 0) {
+        n = [-n[0], -n[1], -n[2]];
+    }
+    // Plane offset. Constant across the plane for the canonicalised `n`, and
+    // computed after the sign flip so both orientations agree on it.
+    let d = n[0] * point[0] as i128 + n[1] * point[1] as i128 + n[2] * point[2] as i128;
+
+    let mut h = 0x5bd1_e995_u64; // arbitrary non-zero seed
+    for c in n {
+        h = fold_i128(h, c);
+    }
+    TrianglePlane { key: mix64(fold_i128(h, d)), weight }
+}
+
+/// Hash one distinct quantized vertex, for the commutative vertex-set sum.
+#[inline]
+pub(super) fn vertex_hash(v: &[i64; 3]) -> u64 {
+    let mut h = 0x27d4_eb2f_u64; // arbitrary non-zero seed, distinct from the plane seed
+    for c in v {
+        h = fold_i64(h, *c);
+    }
+    mix64(h)
+}

--- a/rust/geometry/src/lib.rs
+++ b/rust/geometry/src/lib.rs
@@ -163,6 +163,7 @@ pub use diagnostics::{BoolFailure, BoolFailureReason, BoolOp};
 pub use error::{Error, Result};
 pub use geom_hash::{
     hash_mesh_world, GeometryClosure, GeometryHasher, DEFAULT_GEOM_HASH_TOLERANCE,
+    MIN_GEOM_HASH_TOLERANCE,
 };
 pub use extrusion::{extrude_profile, extrude_profile_lofted, extrude_profile_with_voids};
 pub use instancing::{

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -230,7 +230,13 @@
 # +37: hold the per-worker shared IfcMappedItem source cache field + drop it on content swap / setEntityIndex / setTessellationQuality, mirroring cached_item_dedup (#1623).
 # +10: drop the shared mapped-item cache in set_skip_small_cuts too (boolean-processor swap; #1623 P1 settings-hole fix).
 # +65: #1623 Phase 3 — cached_mapped_instance_plan field (doc + init + clear on clearPrePassCache/setEntityIndex) + setMappedInstancePlan wasm setter + mapped_instance_plan accessor (mirrors setReferencedRepmaps).
-     1088 rust/wasm-bindings/src/api/mod.rs
+# +3: three disjoint one-line additions that each landed at exactly the old
+# budget alone and only breach in combination: the `clash_solid` mod
+# declaration (#2573), the `set_panic_hook()` call that keeps init()'s
+# panic-location stash (#2539), and the geometry-hash tolerance clamp doc
+# (#2528). Splitting this file is the real fix and is tracked separately; it
+# would conflict with all three of those PRs at once.
+     1091 rust/wasm-bindings/src/api/mod.rs
 # +61: #1781 external image textures — textureId/textureUrl fields + getters, set_texture_ref, and the get/takeMesh/Clone field threading.
 # +17: #1891 follow-on — geometry_aabb_values field + geometryAabbValues getter (the doc carries the Y-up frame contract and the world-box rationale so a future reader does not re-derive them), the four constructor/Clone initializers, and the #[cfg(test)] include for mesh_tests.rs (the test file itself is ratchet-exempt). Net +17 and not +56, because the two Z-up→Y-up conversion helpers moved out to a new sibling frame_swap.rs (107 lines, under the house limit, no row): the box swap is now shared by the f32 local bounds and the f64 world AABB, so the min/max reversal lives in exactly one place.
 # -46: #1891 closedness added geometry_volume_values + geometry_closure_flags, and the whole per-entity fingerprint surface (the five index-parallel arrays' getters — including the Y-up swap on the way out — plus GeometryFingerprint and push_geometry_hash) moved OUT to the child module zero_copy/mesh_fingerprint.rs (new, 161 lines, under the house limit, no row) — net down despite two new arrays; budget refreshed downward.

--- a/rust/wasm-bindings/src/api/mod.rs
+++ b/rust/wasm-bindings/src/api/mod.rs
@@ -648,15 +648,13 @@ impl IfcAPI {
     /// Enable or disable per-entity geometry fingerprinting in
     /// `processGeometryBatch`, used by the viewer's revision-diff feature.
     ///
-    /// Pass a positive `tolerance` (metres) to enable — it is the quantization
-    /// grid the hash snaps positions to (larger = more tolerant of float noise,
-    /// smaller = catches finer edits; the `f32` precision floor of model-local
-    /// coordinates means values below ~1 mm mostly hash noise). A request finer
-    /// than `ifc_lite_geometry::MIN_GEOM_HASH_TOLERANCE` (1e-6 m) is silently
-    /// clamped up to it — see that constant's doc for why finer is an `i128`
-    /// overflow surface on a georeferenced model, not a precision win. Pass
-    /// `null`/`undefined` (or a non-positive value) to disable. Default:
-    /// disabled.
+    /// Pass a positive `tolerance` (metres) to enable — the quantization grid
+    /// positions snap to (larger tolerates more float noise, smaller catches
+    /// finer edits; below the `f32` precision floor of model-local coordinates,
+    /// ~1 mm, mostly hashes noise). Finer than
+    /// `ifc_lite_geometry::MIN_GEOM_HASH_TOLERANCE` (1e-6 m) is clamped up to it
+    /// — see that constant's doc for why (an `i128` overflow surface, not a
+    /// precision win). `null`/`undefined`/non-positive disables. Default: off.
     #[wasm_bindgen(js_name = setComputeGeometryHashes)]
     pub fn set_compute_geometry_hashes(&self, tolerance: Option<f64>) {
         use std::sync::atomic::Ordering::Relaxed;

--- a/rust/wasm-bindings/src/api/mod.rs
+++ b/rust/wasm-bindings/src/api/mod.rs
@@ -651,8 +651,12 @@ impl IfcAPI {
     /// Pass a positive `tolerance` (metres) to enable — it is the quantization
     /// grid the hash snaps positions to (larger = more tolerant of float noise,
     /// smaller = catches finer edits; the `f32` precision floor of model-local
-    /// coordinates means values below ~1 mm mostly hash noise). Pass `null`/
-    /// `undefined` (or a non-positive value) to disable. Default: disabled.
+    /// coordinates means values below ~1 mm mostly hash noise). A request finer
+    /// than `ifc_lite_geometry::MIN_GEOM_HASH_TOLERANCE` (1e-6 m) is silently
+    /// clamped up to it — see that constant's doc for why finer is an `i128`
+    /// overflow surface on a georeferenced model, not a precision win. Pass
+    /// `null`/`undefined` (or a non-positive value) to disable. Default:
+    /// disabled.
     #[wasm_bindgen(js_name = setComputeGeometryHashes)]
     pub fn set_compute_geometry_hashes(&self, tolerance: Option<f64>) {
         use std::sync::atomic::Ordering::Relaxed;


### PR DESCRIPTION
## What

`GeomHash` treated a re-triangulation as a shape change: the hash quantizes every world coordinate to a 1 mm grid (so float re-serialisation can't move it) but then hashes **triangles** — so a flat quad re-split along its other diagonal produced a different hash for an identical surface. Found on a real revision pair: an element reported "Reshaped" whose two versions contain the same 424 vertices, same bbox, same centroid — the only difference is which diagonal splits one coplanar quad. An independent third-party analysis of the same pair reached the same verdict.

## How

The hash now folds two exact-integer surface invariants over the already-quantized coordinates instead of raw triangles:

1. **Vertex set** — distinct quantized corners of non-degenerate triangles, commutative sum.
2. **Per-plane area** — each triangle's plane keyed by its gcd-reduced integer normal + offset; the reducing gcd *is* twice the triangle's area in units of that primitive normal, so summing per plane gives the plane's exact total, accumulated as `Σ plane_key × weight` (O(1) space).

Bbox and centroid are functions of the vertex set — subsumed. Both channels are exact integer arithmetic: no float boundary for a triangulation choice to land on. The codebase already states the principle this enforces (`triangulation_invariance.rs`: ear-clipping's diagonal choice is a heuristic, "nothing downstream is entitled to depend on which one it gets").

Enclosed volume is deliberately **not** a channel: `GeometryHasher::volume` is `None` for anything not proved a closed orientable solid, so it cannot gate most elements, and a float-derived channel would reintroduce the exact cut-dependency being removed.

## What it can and cannot distinguish

- Still caught: moves, scales, a face lifted out of plane, faces deleted (with or without surviving corners), the real geometry change in the same revision pair (521 → 394 triangles) — pinned by the mandatory control test.
- Now (correctly) invisible: re-triangulations — different diagonals/fans over the same vertex set with per-plane areas preserved. Sub-grid detail and winding were already invisible and still are.

## Verification

- Control written first: `removing_triangles_is_still_a_change` passes before AND after (bounding), `a_quad_split_along_the_other_diagonal_is_the_same_shape` + `a_fan_re_rooted_on_another_corner_is_the_same_shape` were RED before the change.
- 9 surgical mutations, all killed — including a 10th that initially survived (one-step gcd, all fixtures had axis-aligned normals) and was killed by adding an oblique-normal fixture rather than dropped.
- `geom_hash` tests 28 → 38; `ifc-lite-geometry` lib 608 passed / 0 failed; module-size ratchet green (the file was split into `geom_surface.rs` rather than allowlisted); clippy `-D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Geometry fingerprints are now invariant to retriangulation, including quad diagonal changes and polygon fan re-rooting.
  * Degenerate triangles are excluded from surface fingerprints.
  * Genuine surface changes remain detectable.
  * Positive tolerances below 1e-6 metres are safely clamped; non-positive or omitted values disable hashing.
  * Geometry change classification better distinguishes unchanged-surface retriangulation from vertex-adding re-tessellation.

* **Documentation**
  * Clarified geometry matching, reshaping, and tolerance behavior.

* **Tests**
  * Added comprehensive coverage for fingerprint invariance and surface change detection.
  * Updated expected regression fingerprints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->