### PR TITLE
fix(viewer): map-absolute IFC no longer double-georeferenced — EPSG:25833 model lands in Rostock, not the Atlantic

### DIFF
--- a/.changeset/coordinate-handler-batch-metadata.md
+++ b/.changeset/coordinate-handler-batch-metadata.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/geometry": patch
+---
+
+Surface `wasmRtcOffset` / `lengthUnitScale` on the batch `processMeshes` path, not just the incremental one.
+
+`CoordinateHandler.processMeshes` — the path behind the synchronous `GeometryProcessor.process()` — returned its `CoordinateInfo` without the wasm metadata that `setWasmMetadata` had recorded, while the incremental/streaming path attached it. For a model whose placement the wasm pre-pass re-based (coordinates >10 km from the origin, e.g. a Vectorworks export with the IfcSite at absolute EPSG:25833 map coordinates, issue #2526), every sync-path consumer then read the re-based bounds as if they were absolute: the site offset — including its elevation — silently vanished from georeferencing math. All `processMeshes` returns (empty, no-shift, and shifted) now attach the same metadata the incremental path reports, via one shared helper.

--- a/apps/viewer/src/components/viewer/CesiumPlacementEditor.mapAbsolute.test.tsx
+++ b/apps/viewer/src/components/viewer/CesiumPlacementEditor.mapAbsolute.test.tsx
@@ -1,0 +1,166 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Scenario test for `CesiumPlacementEditor`'s map-absolute UI guard
+ * (issue #2526's guard, #2534 review finding).
+ *
+ * Deep review of #2534 (2026-08-10, louistrue) — blocking issue on
+ * CesiumPlacementEditor.tsx:507-530: "On a map-absolute file the placement
+ * gizmo becomes a silent no-op inside the 10km window ... Disclosed only in
+ * a source comment; no UI guard, no test." Also: "the cesium-placement.test.
+ * ts cases exercise the new helper functions directly, not the component
+ * that decides what to pass them" and "CesiumPlacementEditor.tsx — both
+ * `...ForGeometry` swaps ... are untested."
+ *
+ * This file mounts the REAL component (not the pure helpers) with a
+ * map-absolute fixture and asserts the warning banner it now renders
+ * (`data-testid="cesium-placement-map-absolute-warning"`) appears — and
+ * does NOT appear for a compliant file. It also exercises the
+ * `guardConversion` fix: the banner must track the DRAFT anchor (not just
+ * the frozen session baseline), reproducing the "second drag disagrees with
+ * the preview" scenario the review described.
+ */
+
+import '@/test/setup-dom.js';
+import { describe, it, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import type { MapConversion, ProjectedCRS } from '@ifc-lite/parser';
+import type { CoordinateInfo } from '@ifc-lite/geometry';
+
+import { useViewerStore } from '@/store';
+import { CesiumPlacementEditor } from './CesiumPlacementEditor.js';
+
+const projectedCRS: ProjectedCRS = { id: 2, name: 'EPSG:25833', mapUnitScale: 1 };
+
+// #2526 Vectorworks-style map-absolute anchor: geometry re-based right next
+// to the declared (repeated) anchor — inside the 10km detection window.
+const mapAbsoluteConversion: MapConversion = {
+  id: 1, sourceCRS: 0, targetCRS: 0,
+  eastings: 312000, northings: 5996150, orthogonalHeight: 0,
+  xAxisAbscissa: 0, xAxisOrdinate: 1, scale: 1,
+};
+const mapAbsoluteCoordinateInfo: CoordinateInfo = {
+  originShift: { x: 0, y: 0, z: 0 },
+  originalBounds: { min: { x: -1, y: -1, z: -1 }, max: { x: 1, y: 1, z: 1 } },
+  shiftedBounds: { min: { x: -1, y: -1, z: -1 }, max: { x: 1, y: 1, z: 1 } },
+  hasLargeCoordinates: false,
+  wasmRtcOffset: { x: 312000, y: 5996150, z: 10 },
+};
+
+// Compliant file: declared anchor far from LOCAL geometry (near-zero bounds).
+const compliantConversion: MapConversion = {
+  id: 2, sourceCRS: 0, targetCRS: 0,
+  eastings: 5000, northings: 3000, orthogonalHeight: 0,
+  xAxisAbscissa: 1, xAxisOrdinate: 0, scale: 1,
+};
+const compliantCoordinateInfo: CoordinateInfo = {
+  originShift: { x: 0, y: 0, z: 0 },
+  originalBounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 10, y: 3, z: 10 } },
+  shiftedBounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 10, y: 3, z: 10 } },
+  hasLargeCoordinates: false,
+};
+
+async function mount(props: {
+  mapConversion: MapConversion;
+  baseMapConversion: MapConversion;
+  coordinateInfo: CoordinateInfo;
+}): Promise<{ root: Root; container: HTMLDivElement }> {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(
+      <CesiumPlacementEditor
+        modelId="m0"
+        mapConversion={props.mapConversion}
+        baseMapConversion={props.baseMapConversion}
+        projectedCRS={projectedCRS}
+        coordinateInfo={props.coordinateInfo}
+        lengthUnitScale={1}
+      />,
+    );
+  });
+  return { root, container };
+}
+
+const originalState = useViewerStore.getState();
+after(() => { useViewerStore.setState(originalState, true); });
+
+describe('CesiumPlacementEditor — map-absolute UI guard (#2534 review)', () => {
+  it('shows the map-absolute warning banner for a map-absolute file', async () => {
+    useViewerStore.setState({
+      cesiumPlacementEditMode: true,
+      cesiumPlacementDraftModelId: null,
+      cesiumPlacementDraft: null,
+    });
+    const { root, container } = await mount({
+      mapConversion: mapAbsoluteConversion,
+      baseMapConversion: mapAbsoluteConversion,
+      coordinateInfo: mapAbsoluteCoordinateInfo,
+    });
+    try {
+      const banner = container.querySelector('[data-testid="cesium-placement-map-absolute-warning"]');
+      assert.ok(banner, 'expected the map-absolute warning banner to render');
+    } finally {
+      await act(async () => { root.unmount(); });
+      container.remove();
+    }
+  });
+
+  it('does NOT show the warning banner for a compliant file', async () => {
+    useViewerStore.setState({
+      cesiumPlacementEditMode: true,
+      cesiumPlacementDraftModelId: null,
+      cesiumPlacementDraft: null,
+    });
+    const { root, container } = await mount({
+      mapConversion: compliantConversion,
+      baseMapConversion: compliantConversion,
+      coordinateInfo: compliantCoordinateInfo,
+    });
+    try {
+      const banner = container.querySelector('[data-testid="cesium-placement-map-absolute-warning"]');
+      assert.strictEqual(banner, null, 'compliant files must not show the map-absolute banner');
+    } finally {
+      await act(async () => { root.unmount(); });
+      container.remove();
+    }
+  });
+
+  it('tracks a live draft anchor: the banner reflects the CURRENT draft, not just the frozen session baseline', async () => {
+    // Reproduces the review's "second drag disagrees with the preview"
+    // scenario: an in-progress draft has already moved the anchor OUT of
+    // the map-absolute window (a nudge past 10km), while baseMapConversion
+    // (the session's original, still map-absolute) stays put. The guard
+    // must react to the CURRENT draft, not the stale baseline — proving
+    // `guardConversion = { ...baseMapConversion, ...activeDraft }` is wired
+    // through to the banner, not just `baseMapConversion` alone.
+    useViewerStore.setState({
+      cesiumPlacementEditMode: true,
+      cesiumPlacementDraftModelId: 'm0',
+      cesiumPlacementDraft: {
+        eastings: mapAbsoluteConversion.eastings + 50_000, // far outside the 10km window
+        northings: mapAbsoluteConversion.northings,
+        orthogonalHeight: 0,
+        xAxisAbscissa: 0,
+        xAxisOrdinate: 1,
+      },
+    });
+    const { root, container } = await mount({
+      mapConversion: mapAbsoluteConversion,
+      baseMapConversion: mapAbsoluteConversion,
+      coordinateInfo: mapAbsoluteCoordinateInfo,
+    });
+    try {
+      const banner = container.querySelector('[data-testid="cesium-placement-map-absolute-warning"]');
+      assert.strictEqual(banner, null, 'the banner must clear once the live draft anchor has left the detection window');
+    } finally {
+      await act(async () => { root.unmount(); });
+      container.remove();
+    }
+  });
+});

--- a/apps/viewer/src/components/viewer/CesiumPlacementEditor.tsx
+++ b/apps/viewer/src/components/viewer/CesiumPlacementEditor.tsx
@@ -15,8 +15,8 @@ import {
   intersectRayWithHorizontalPlane,
   mapUnitsToMeters,
   metersToMapUnits,
-  projectedDeltaToViewerDelta,
-  viewerDeltaToProjectedDelta,
+  projectedDeltaToViewerDeltaForGeometry,
+  viewerDeltaToProjectedDeltaForGeometry,
 } from '@/lib/geo/cesium-placement';
 import { findClampAnchorY } from '@/lib/geo/clamp-anchor';
 import { cn } from '@/lib/utils';
@@ -363,12 +363,15 @@ export function CesiumPlacementEditor({
     const centerX = bounds ? (bounds.min.x + bounds.max.x) / 2 : 0;
     const centerZ = bounds ? (bounds.min.z + bounds.max.z) / 2 : 0;
     const anchorY = findClampAnchorY(bounds, storeyElevations);
-    const xyOffset = projectedDeltaToViewerDelta(
+    // Map-absolute geometry (#2526): route through the guard so the preview
+    // offset uses the map axes (identity rotation) the drag math uses too.
+    const xyOffset = projectedDeltaToViewerDeltaForGeometry(
       deltaE,
       deltaN,
       baseMapConversion,
       projectedCRS,
       lengthUnitScale,
+      coordinateInfo,
     );
 
     return {
@@ -378,7 +381,9 @@ export function CesiumPlacementEditor({
     };
   }, [
     baseMapConversion,
-    coordinateInfo?.originalBounds,
+    // The guard also reads shiftedBounds/originShift/wasmRtcOffset, so depend
+    // on the whole coordinateInfo, not just originalBounds.
+    coordinateInfo,
     deltaE,
     deltaN,
     deltaHeightMeters,
@@ -502,20 +507,37 @@ export function CesiumPlacementEditor({
     const deltaX = hit.x - dragState.startHit.x;
     const deltaZ = hit.z - dragState.startHit.z;
     // The horizontal-plane hit gives the world-space displacement directly;
-    // viewerDeltaToProjectedDelta then applies the file's xAxis rotation and
-    // unit scale to express it in Eastings/Northings.
-    const projectedDelta = viewerDeltaToProjectedDelta(
+    // viewerDeltaToProjectedDeltaForGeometry then applies the file's xAxis
+    // rotation and unit scale to express it in Eastings/Northings — routed
+    // through the map-absolute guard (#2526) so a drag on geometry that
+    // already sits at the absolute map coordinates moves E/N along the map
+    // axes instead of rotating the drag by the double-georeferenced axis.
+    // The draft is spread over the full authored conversion because the
+    // guard's detection reads the declared anchor (eastings/northings).
+    //
+    // Known limit, inherited from the guard's design rather than this
+    // routing: on a map-absolute file every placement consumer neutralises
+    // the SAVED anchor too, so an applied edit has no effect while the new
+    // anchor stays within the 10 km detection window of the geometry centre
+    // (the pin has behaved this way since #2526), and an edit that crosses
+    // the window snaps to the fully-applied conversion — at which point this
+    // drag math and the preview above (which detects on the BASE anchor) can
+    // briefly disagree about the axis. The map-pick Apply flow is the
+    // sanctioned way to move such a model: reprojectFromLatLon deliberately
+    // saves an anchor that escapes the window (see reproject.ts).
+    const projectedDelta = viewerDeltaToProjectedDeltaForGeometry(
       deltaX,
       deltaZ,
-      dragState.startDraft,
+      { ...mapConversion, ...dragState.startDraft },
       projectedCRS,
       lengthUnitScale,
+      coordinateInfo,
     );
     updateDraft({
       eastings: round2(dragState.startDraft.eastings + projectedDelta.eastings),
       northings: round2(dragState.startDraft.northings + projectedDelta.northings),
     });
-  }, [lengthUnitScale, projectedCRS, updateDraft]);
+  }, [coordinateInfo, lengthUnitScale, mapConversion, projectedCRS, updateDraft]);
 
   const handlePointerUp = useCallback((e: React.PointerEvent<Element>) => {
     if (!dragStateRef.current) return;

--- a/apps/viewer/src/components/viewer/CesiumPlacementEditor.tsx
+++ b/apps/viewer/src/components/viewer/CesiumPlacementEditor.tsx
@@ -19,6 +19,7 @@ import {
   viewerDeltaToProjectedDeltaForGeometry,
 } from '@/lib/geo/cesium-placement';
 import { findClampAnchorY } from '@/lib/geo/clamp-anchor';
+import { effectiveMapConversionForGeometry } from '@/lib/geo/map-absolute';
 import { cn } from '@/lib/utils';
 import { useViewerStore, type CesiumPlacementDraft } from '@/store';
 
@@ -358,17 +359,46 @@ export function CesiumPlacementEditor({
   const dirty = Math.abs(deltaE) > 1e-6 || Math.abs(deltaN) > 1e-6 || Math.abs(deltaH) > 1e-6 || Math.abs(deltaAngle) > 1e-6;
   const nudgeStep = round2(metersToMapUnits(1, projectedCRS, lengthUnitScale));
 
+  // The map-absolute guard (#2526) reads the DECLARED anchor (eastings/
+  // northings) to decide whether geometry is already at the map coordinate.
+  // Both the visual preview (anchorWorld, below) and the drag math
+  // (handlePointerMove) must evaluate that guard against the SAME anchor —
+  // `baseMapConversion` overridden by the CURRENT draft's e/n/h/axis — or the
+  // two disagree about which regime (identity vs authored rotation) is
+  // active. Before this fix, the preview always used the frozen
+  // `baseMapConversion` (the whole editing session's baseline) while the
+  // drag used `{ ...mapConversion (base + live preview), ...startDraft
+  // (frozen at THIS gesture's start) }`; after a first drag moved the draft
+  // away from the session baseline, a second drag's guard decision diverged
+  // from the still-baseline-anchored preview mid-session.
+  const guardConversion: MapConversion = useMemo(
+    () => ({ ...baseMapConversion, ...activeDraft }),
+    [baseMapConversion, activeDraft],
+  );
+
+  // Whether the map-absolute guard is CURRENTLY firing for this model's
+  // active anchor. `effectiveMapConversionForGeometry` returns the SAME
+  // object reference when it doesn't fire, and a new (neutralised) object
+  // when it does — a cheap, exact signal with no separate re-derivation of
+  // the detection condition.
+  const mapAbsoluteActive = useMemo(
+    () => effectiveMapConversionForGeometry(guardConversion, mapUnitScale, coordinateInfo) !== guardConversion,
+    [guardConversion, mapUnitScale, coordinateInfo],
+  );
+
   const anchorWorld = useMemo((): WorldPoint => {
     const bounds = coordinateInfo?.originalBounds;
     const centerX = bounds ? (bounds.min.x + bounds.max.x) / 2 : 0;
     const centerZ = bounds ? (bounds.min.z + bounds.max.z) / 2 : 0;
     const anchorY = findClampAnchorY(bounds, storeyElevations);
-    // Map-absolute geometry (#2526): route through the guard so the preview
-    // offset uses the map axes (identity rotation) the drag math uses too.
+    // Map-absolute geometry (#2526): route through the guard, evaluated
+    // against the SAME current-draft anchor the drag math uses (see
+    // `guardConversion` above), so the preview offset uses the map axes
+    // (identity rotation) the drag applies too.
     const xyOffset = projectedDeltaToViewerDeltaForGeometry(
       deltaE,
       deltaN,
-      baseMapConversion,
+      guardConversion,
       projectedCRS,
       lengthUnitScale,
       coordinateInfo,
@@ -380,7 +410,7 @@ export function CesiumPlacementEditor({
       z: centerZ + xyOffset.z,
     };
   }, [
-    baseMapConversion,
+    guardConversion,
     // The guard also reads shiftedBounds/originShift/wasmRtcOffset, so depend
     // on the whole coordinateInfo, not just originalBounds.
     coordinateInfo,
@@ -512,23 +542,32 @@ export function CesiumPlacementEditor({
     // through the map-absolute guard (#2526) so a drag on geometry that
     // already sits at the absolute map coordinates moves E/N along the map
     // axes instead of rotating the drag by the double-georeferenced axis.
-    // The draft is spread over the full authored conversion because the
-    // guard's detection reads the declared anchor (eastings/northings).
+    // The draft is spread over `baseMapConversion` (NOT the live `mapConversion`
+    // prop, which already carries this render's in-progress preview) so the
+    // guard's detection basis matches `anchorWorld`'s `guardConversion` above
+    // exactly: both read `{ session baseline, ...current draft }`. Using the
+    // live `mapConversion` prop here previously let a SECOND drag gesture in
+    // the same edit session disagree with the (always baseline-anchored)
+    // preview about which anchor decides the guard.
     //
-    // Known limit, inherited from the guard's design rather than this
-    // routing: on a map-absolute file every placement consumer neutralises
-    // the SAVED anchor too, so an applied edit has no effect while the new
-    // anchor stays within the 10 km detection window of the geometry centre
-    // (the pin has behaved this way since #2526), and an edit that crosses
-    // the window snaps to the fully-applied conversion — at which point this
-    // drag math and the preview above (which detects on the BASE anchor) can
-    // briefly disagree about the axis. The map-pick Apply flow is the
-    // sanctioned way to move such a model: reprojectFromLatLon deliberately
-    // saves an anchor that escapes the window (see reproject.ts).
+    // Known remaining limit, inherited from the guard's design rather than
+    // this routing: on a map-absolute file every placement consumer
+    // neutralises the SAVED anchor too, so an applied edit has no effect
+    // while the new anchor stays within the 10 km detection window of the
+    // geometry centre (the pin has behaved this way since #2526), and an
+    // edit that crosses the window snaps to the fully-applied conversion.
+    // `dragState.startDraft` freezes the guard decision for the DURATION of
+    // one gesture (so a single drag doesn't re-decide its own axis mid-move);
+    // a gesture that itself crosses the window boundary can still end
+    // disagreeing with the live preview for that one frame. The map-pick
+    // Apply flow is the sanctioned way to move such a model: reprojectFromLatLon
+    // deliberately saves an anchor that escapes the window (see reproject.ts).
+    // `mapAbsoluteActive` (below) surfaces this regime to the user instead of
+    // leaving a silent no-op.
     const projectedDelta = viewerDeltaToProjectedDeltaForGeometry(
       deltaX,
       deltaZ,
-      { ...mapConversion, ...dragState.startDraft },
+      { ...baseMapConversion, ...dragState.startDraft },
       projectedCRS,
       lengthUnitScale,
       coordinateInfo,
@@ -537,7 +576,7 @@ export function CesiumPlacementEditor({
       eastings: round2(dragState.startDraft.eastings + projectedDelta.eastings),
       northings: round2(dragState.startDraft.northings + projectedDelta.northings),
     });
-  }, [coordinateInfo, lengthUnitScale, mapConversion, projectedCRS, updateDraft]);
+  }, [baseMapConversion, coordinateInfo, lengthUnitScale, projectedCRS, updateDraft]);
 
   const handlePointerUp = useCallback((e: React.PointerEvent<Element>) => {
     if (!dragStateRef.current) return;
@@ -874,6 +913,19 @@ export function CesiumPlacementEditor({
                 accent="text-fuchsia-700 dark:text-fuchsia-300"
               />
             </div>
+
+            {mapAbsoluteActive && (
+              <div
+                data-testid="cesium-placement-map-absolute-warning"
+                role="status"
+                className="mt-2 border border-amber-500 bg-amber-50 dark:bg-amber-950/40 px-2 py-1.5 text-[9px] leading-snug text-amber-800 dark:text-amber-300"
+              >
+                This model&apos;s geometry already sits at its declared map
+                anchor. Small XY drags inside ~10 km of the anchor have no
+                visible effect (the guard keeps neutralising it) — use the
+                map-pick tool to relocate it in one step instead.
+              </div>
+            )}
 
             <div className="mt-2 space-y-1">
               <div className="pb-1 text-[9px] leading-snug text-zinc-500 dark:text-zinc-400">

--- a/apps/viewer/src/hooks/dxfExportGeoref.test.ts
+++ b/apps/viewer/src/hooks/dxfExportGeoref.test.ts
@@ -477,6 +477,29 @@ describe('resolveDxfExportGeoreference (PR #1871 review: edited georeferencing m
     close(out.y, 1_199_994);
   });
 
+  it('threads the legacy single-model coordinateInfo into the georeference (#2526 map-absolute guard input)', async () => {
+    const store = await parseStore(GEOREF_FIXTURE);
+    const legacyCoordinateInfo = {
+      originShift: { x: 0, y: 0, z: 0 },
+      originalBounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 0, y: 0, z: 0 } },
+      shiftedBounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 0, y: 0, z: 0 } },
+      hasLargeCoordinates: false,
+    };
+    const georef = resolveDxfExportGeoreference({
+      models: new Map(),
+      legacyDataStore: store,
+      legacyCoordinateInfo,
+      georefMutations: new Map(),
+    });
+    assert.ok(georef);
+    // The SAME object, not a copy — the map-absolute guard in
+    // resolveGeorefLinearParams reads it to decide whether the anchor model's
+    // geometry already sits at the declared anchor. A caller that omits it
+    // (as useDxfMapToWorldTransform once did) silently splits the forward
+    // and inverse transforms onto different conversions for such files.
+    assert.strictEqual(georef.coordinateInfo, legacyCoordinateInfo);
+  });
+
   it('an applied placement edit (georefMutations) changes the exported DXF coordinates', async () => {
     const store = await parseStore(GEOREF_FIXTURE);
     const mutations = new Map<string, GeorefMutationDataLike>([
@@ -820,5 +843,94 @@ describe('buildDxfMapToWorldTransform', () => {
     assert.ok(Number.isFinite(mapPoint.y), `expected finite y, got ${mapPoint.y}`);
     close(mapPoint.x, 500_000 + 1007);
     close(mapPoint.y, 6_000_000 + 2001);
+  });
+});
+
+describe('DXF georeference with map-absolute geometry (#2526)', () => {
+  // Vectorworks-style file: geometry authored at the ABSOLUTE projected
+  // coordinates (rebased into wasmRtcOffset), IfcMapConversion repeating the
+  // same anchor with a 90-degree rotation. The exported DXF must carry the
+  // geometry's absolute coordinates unchanged — applying the authored
+  // conversion on top would double-transform, exactly like the pin did.
+  const mapAbsInfo: NonNullable<GeometryResult['coordinateInfo']> = {
+    originShift: { x: 0, y: 0, z: 0 },
+    originalBounds: { min: { x: -1, y: -1, z: -1 }, max: { x: 1, y: 1, z: 1 } },
+    shiftedBounds: { min: { x: -1, y: -1, z: -1 }, max: { x: 1, y: 1, z: 1 } },
+    hasLargeCoordinates: false,
+    wasmRtcOffset: { x: 312000, y: 5996150, z: 10 },
+  };
+  const mapAbsGeoreference = (coordinateInfo?: GeometryResult['coordinateInfo']) => ({
+    mapConversion: {
+      id: 1,
+      sourceCRS: 0,
+      targetCRS: 0,
+      eastings: 312000,
+      northings: 5996150,
+      orthogonalHeight: 0,
+      xAxisAbscissa: 0,
+      xAxisOrdinate: 1,
+      scale: 1,
+    },
+    projectedCRS: { id: 2, name: 'EPSG:25833', mapUnitScale: 1 },
+    lengthUnitScale: 1,
+    coordinateInfo,
+  });
+
+  it('exports the absolute world coordinate unchanged instead of double-applying the anchor + rotation', () => {
+    const transform = buildDxfExportTransform({
+      coordinateInfo: mapAbsInfo,
+      sectionAxis: 'down',
+      isCustomPlane: false,
+      flipped: false,
+      georeference: mapAbsGeoreference(mapAbsInfo),
+    });
+    // dxfWorldShift = (rtc.x, rtc.y) = (312000, 5996150); drawing (10, 10)
+    // is the absolute world/map point (312010, 5996140).
+    const out = transform({ x: 10, y: 10 });
+    close(out.x, 312010);
+    close(out.y, 5996140);
+  });
+
+  it('imports a georeferenced DXF underlay at the absolute world coordinate (inverse agrees)', () => {
+    const mapToWorld = buildDxfMapToWorldTransform(mapAbsGeoreference(mapAbsInfo));
+    const out = mapToWorld({ x: 312010, y: 5996140 });
+    close(out.x, 312010);
+    close(out.y, 5996140);
+  });
+
+  it('control: a compliant file (no RTC rebase) keeps the authored conversion in both directions', () => {
+    const compliantInfo: GeometryResult['coordinateInfo'] = {
+      ...mapAbsInfo,
+      wasmRtcOffset: undefined,
+    };
+    const georeference = mapAbsGeoreference(compliantInfo);
+    const transform = buildDxfExportTransform({
+      coordinateInfo: compliantInfo,
+      sectionAxis: 'down',
+      isCustomPlane: false,
+      flipped: false,
+      georeference,
+    });
+    // world (3, -4) under the authored 90-degree rotation:
+    // x = 312000 + (0*3 - 1*(-4)) = 312004; y = 5996150 + (1*3 + 0) = 5996153.
+    const out = transform({ x: 3, y: 4 });
+    close(out.x, 312004);
+    close(out.y, 5996153);
+    const roundTrip = buildDxfMapToWorldTransform(georeference)(out);
+    close(roundTrip.x, 3);
+    close(roundTrip.y, -4);
+  });
+
+  it('control: a georeference without coordinateInfo keeps the authored conversion', () => {
+    const transform = buildDxfExportTransform({
+      coordinateInfo: undefined,
+      sectionAxis: 'down',
+      isCustomPlane: false,
+      flipped: false,
+      georeference: mapAbsGeoreference(undefined),
+    });
+    const out = transform({ x: 3, y: 4 });
+    close(out.x, 312004);
+    close(out.y, 5996153);
   });
 });

--- a/apps/viewer/src/hooks/dxfExportGeoref.ts
+++ b/apps/viewer/src/hooks/dxfExportGeoref.ts
@@ -92,6 +92,7 @@ import type { GeometryResult } from '@ifc-lite/geometry';
 import type { MapConversion, ProjectedCRS } from '@ifc-lite/parser';
 import { dxfWorldShift } from './dxfUnderlayMath';
 import { getEffectiveHorizontalScale, resolveMapUnitToMetreScale } from '@/lib/geo/geo-scale';
+import { effectiveMapConversionForGeometry } from '@/lib/geo/map-absolute';
 import {
   selectAnchorGeoref,
   type SelectAnchorGeorefParams,
@@ -103,6 +104,15 @@ export interface DxfExportGeoreference {
   projectedCRS: ProjectedCRS;
   /** IFC project length-unit → metres (from `IfcUnitAssignment`). */
   lengthUnitScale: number;
+  /**
+   * The ANCHOR model's coordinate info — the geometry the `mapConversion`
+   * belongs to. Feeds the map-absolute guard (#2526) in
+   * {@link resolveGeorefLinearParams}: geometry that already sits at the
+   * declared map anchor neutralises the conversion for both transform
+   * directions. Absent (older callers / no geometry yet) the authored
+   * conversion applies unchanged.
+   */
+  coordinateInfo?: GeometryResult['coordinateInfo'];
 }
 
 /**
@@ -125,7 +135,7 @@ export function resolveDxfExportGeoreference(
   const selection = selectAnchorGeoref(params);
   if (!selection) return null;
   const { mapConversion, projectedCRS, lengthUnitScale } = selection.eff;
-  return { mapConversion, projectedCRS, lengthUnitScale };
+  return { mapConversion, projectedCRS, lengthUnitScale, coordinateInfo: selection.coordinateInfo };
 }
 
 export interface DxfExportTransformParams {
@@ -194,8 +204,18 @@ function resolveGeorefLinearParams(georeference: DxfExportGeoreference): {
   abscissa: number;
   ordinate: number;
 } {
-  const { mapConversion, projectedCRS, lengthUnitScale } = georeference;
+  const { projectedCRS, lengthUnitScale } = georeference;
   const mapUnitScale = resolveMapUnitToMetreScale(projectedCRS.mapUnitScale, lengthUnitScale);
+  // Map-absolute geometry (#2526): geometry already at the declared anchor
+  // reads/writes map coordinates through a neutralised conversion. Routed
+  // HERE — the single point both the forward (buildDxfExportTransform) and
+  // inverse (buildDxfMapToWorldTransform) transforms resolve their linear
+  // params through — so the two directions can never disagree about it.
+  const mapConversion = effectiveMapConversionForGeometry(
+    georeference.mapConversion,
+    mapUnitScale,
+    georeference.coordinateInfo,
+  );
   // Guard the pathological IfcMapConversion.Scale = 0 (or negative/NaN):
   // getEffectiveHorizontalScale passes an explicit 0 through, which would
   // collapse every exported point onto the eastings/northings origin (or,

--- a/apps/viewer/src/hooks/ingest/federationAlign.test.ts
+++ b/apps/viewer/src/hooks/ingest/federationAlign.test.ts
@@ -440,3 +440,101 @@ describe('alignGeometryToReference — the world AABB rides with the vertices (#
     assertBoxClose(mesh.geometryAabb, expected, 0.05, 'reprojected');
   });
 });
+
+describe('alignGeometryToReference with a map-absolute source (#2526)', () => {
+  // Vectorworks-style source: geometry authored at the ABSOLUTE projected
+  // coordinates (rebased into wasmRtcOffset by the wasm RTC pre-pass) while
+  // its IfcMapConversion repeats the same anchor with a 90-degree rotation.
+  // Aligning such a model into a compliant reference must read the geometry's
+  // absolute coordinates through a NEUTRALISED conversion — applying the
+  // authored rotation on top would fling the model by the double transform.
+  const mapAbsSourceInfo = coordinateInfo({
+    originalBounds: { min: { x: -1, y: -1, z: -1 }, max: { x: 1, y: 1, z: 1 } },
+    shiftedBounds: { min: { x: -1, y: -1, z: -1 }, max: { x: 1, y: 1, z: 1 } },
+    wasmRtcOffset: { x: 312000, y: 5996150, z: 10 },
+  });
+  const mapAbsConversion: Partial<MapConversion> = {
+    eastings: 312000,
+    northings: 5996150,
+    orthogonalHeight: 0,
+    xAxisAbscissa: 0,
+    xAxisOrdinate: 1,
+  };
+  // Compliant reference in the same CRS, identity rotation, no viewer shift.
+  const referenceGeoref = () => georef(
+    { eastings: 312050, northings: 5996100, orthogonalHeight: 0 },
+    'EPSG:25833',
+    coordinateInfo(),
+  );
+
+  it('places the source at its absolute map position in the reference frame', async () => {
+    const mesh = boxMesh(1, [-1, -1, -1], [1, 1, 1]);
+    const geom = geometry([mesh], mapAbsSourceInfo);
+    const status = await alignGeometryToReference(
+      geom,
+      georef(mapAbsConversion, 'EPSG:25833', mapAbsSourceInfo),
+      referenceGeoref(),
+    );
+    assert.equal(status, 'same-crs');
+    // Absolute vertex (E, N, H) = local + rtc; reference inverse (identity
+    // rotation) gives viewer = (E - 312050, H, -(N - 5996100)):
+    //   x' = x + 312000 - 312050 = x - 50
+    //   y' = y + 10
+    //   z' = z + (5996100 - 5996150) = z - 50
+    assertBoxClose(
+      geom.coordinateInfo?.originalBounds
+        ? {
+            min: [
+              geom.coordinateInfo.originalBounds.min.x,
+              geom.coordinateInfo.originalBounds.min.y,
+              geom.coordinateInfo.originalBounds.min.z,
+            ],
+            max: [
+              geom.coordinateInfo.originalBounds.max.x,
+              geom.coordinateInfo.originalBounds.max.y,
+              geom.coordinateInfo.originalBounds.max.z,
+            ],
+          }
+        : undefined,
+      { min: [-51, 9, -51], max: [-49, 11, -49] },
+      1e-3,
+      'map-absolute source',
+    );
+  });
+
+  it('control: a compliant source (no RTC rebase) still aligns with its authored rotation', async () => {
+    const compliantInfo = coordinateInfo({
+      originalBounds: { min: { x: -1, y: -1, z: -1 }, max: { x: 1, y: 1, z: 1 } },
+      shiftedBounds: { min: { x: -1, y: -1, z: -1 }, max: { x: 1, y: 1, z: 1 } },
+    });
+    const mesh = boxMesh(1, [-1, -1, -1], [1, 1, 1]);
+    const geom = geometry([mesh], compliantInfo);
+    const status = await alignGeometryToReference(
+      geom,
+      georef(mapAbsConversion, 'EPSG:25833', compliantInfo),
+      referenceGeoref(),
+    );
+    assert.equal(status, 'same-crs');
+    // Authored 90-degree source rotation: E = 312000 + vz, N = 5996150 + vx;
+    // reference inverse: x' = vz - 50, y' = vy, z' = -(50 + vx).
+    assertBoxClose(
+      geom.coordinateInfo?.originalBounds
+        ? {
+            min: [
+              geom.coordinateInfo.originalBounds.min.x,
+              geom.coordinateInfo.originalBounds.min.y,
+              geom.coordinateInfo.originalBounds.min.z,
+            ],
+            max: [
+              geom.coordinateInfo.originalBounds.max.x,
+              geom.coordinateInfo.originalBounds.max.y,
+              geom.coordinateInfo.originalBounds.max.z,
+            ],
+          }
+        : undefined,
+      { min: [-51, -1, -51], max: [-49, 1, -49] },
+      1e-3,
+      'compliant source',
+    );
+  });
+});

--- a/apps/viewer/src/hooks/ingest/federationAlign.ts
+++ b/apps/viewer/src/hooks/ingest/federationAlign.ts
@@ -7,8 +7,10 @@
  *
  * Extracted verbatim from useIfcFederation.ts so the unified model-load path
  * (useIfcLoader's finalizeModel) can reuse them without a circular dependency.
- * Behaviour-preserving move — do not change the georef maths or the issue-#595 /
- * issue-#658 comments, which encode subtle alignment behaviour.
+ * The extraction was behaviour-preserving; keep the issue-#595 / issue-#658
+ * comments, which encode subtle alignment behaviour. Since then, #2526 routed
+ * every read of a model's MapConversion through `effectiveConv` (the
+ * map-absolute guard); that is the only deliberate change to the maths.
  */
 
 import {
@@ -20,6 +22,7 @@ import type { CoordinateInfo } from '@ifc-lite/geometry';
 import { useViewerStore, type FederatedModel } from '../../store/index.js';
 import { getEffectiveGeoreference, getEffectiveHorizontalScale, hasStandardGeoreferencing, type GeorefMutationDataLike } from '../../lib/geo/effective-georef.js';
 import { resolveMapUnitToMetreScale } from '../../lib/geo/geo-scale.js';
+import { effectiveMapConversionForGeometry } from '../../lib/geo/map-absolute.js';
 import { resolveProjection } from '../../lib/geo/reproject.js';
 import {
   alignEntityWorldAabbs,
@@ -46,8 +49,23 @@ function getMapUnitScale(georef: ModelGeoref): number {
   return resolveMapUnitToMetreScale(georef.projectedCRS.mapUnitScale, georef.lengthUnitScale ?? 1);
 }
 
+/**
+ * The conversion the alignment maths must apply for this model: the authored
+ * one, unless the model's geometry already sits at the declared map anchor —
+ * the map-absolute double-georeferencing signature (#2526) — in which case
+ * the neutralised (zero-offset, identity-rotation) conversion reads the
+ * geometry's absolute coordinates through instead of transforming them twice.
+ */
+function effectiveConv(georef: ModelGeoref): MapConversion {
+  return effectiveMapConversionForGeometry(
+    georef.mapConversion,
+    getMapUnitScale(georef),
+    georef.coordinateInfo,
+  );
+}
+
 function getAxis(georef: ModelGeoref): { a: number; o: number; scale: number; denom: number } {
-  const conversion = georef.mapConversion;
+  const conversion = effectiveConv(georef);
   const a = conversion.xAxisAbscissa ?? 1;
   const o = conversion.xAxisOrdinate ?? 0;
   // Use the effective horizontal scale: viewer geometry is already in metres,
@@ -132,8 +150,10 @@ function updateBounds(bounds: ReturnType<typeof emptyBounds>, x: number, y: numb
 }
 
 function buildGeorefAlignmentTransform(source: ModelGeoref, reference: ModelGeoref): AffineTransform3D | null {
-  const sourceConv = source.mapConversion;
-  const refConv = reference.mapConversion;
+  // Map-absolute geometry (#2526): per-model effective conversion, matching
+  // the axis pair getAxis() resolves from the same guard.
+  const sourceConv = effectiveConv(source);
+  const refConv = effectiveConv(reference);
   const sourceAxis = getAxis(source);
   const refAxis = getAxis(reference);
   const refDenom = refAxis.scale * refAxis.denom;
@@ -354,8 +374,9 @@ async function alignGeometryAcrossCrs(
   if (Math.abs(refDenom) < 1e-12) return false;
   const invRefDenom = 1 / refDenom;
 
-  const sourceConv = source.mapConversion;
-  const refConv = reference.mapConversion;
+  // Map-absolute geometry (#2526): same per-model guard as the same-CRS path.
+  const sourceConv = effectiveConv(source);
+  const refConv = effectiveConv(reference);
 
   const bounds = emptyBounds();
   let found = false;

--- a/apps/viewer/src/hooks/ingest/pointCloudAlignment.test.ts
+++ b/apps/viewer/src/hooks/ingest/pointCloudAlignment.test.ts
@@ -397,3 +397,72 @@ describe('getPointCloudAlignmentMatrix', () => {
     }
   });
 });
+
+describe('computePointCloudAlignment with map-absolute geometry (#2526)', () => {
+  // Vectorworks-style reference model: geometry authored at the ABSOLUTE
+  // projected coordinates (rebased into wasmRtcOffset), IfcMapConversion
+  // repeating the same anchor with a 90-degree rotation. A .laz scan carries
+  // the SAME absolute coordinates, so aligning it must be a pure viewer-shift
+  // subtraction (identity conversion) — inverting the authored conversion
+  // would rotate the cloud away from the model it was scanned against.
+  const mapAbsInfo: NonNullable<ModelGeoref['coordinateInfo']> = {
+    originShift: { x: 0, y: 0, z: 0 },
+    originalBounds: { min: { x: -1, y: -1, z: -1 }, max: { x: 1, y: 1, z: 1 } },
+    shiftedBounds: { min: { x: -1, y: -1, z: -1 }, max: { x: 1, y: 1, z: 1 } },
+    hasLargeCoordinates: false,
+    wasmRtcOffset: { x: 312000, y: 5996150, z: 10 },
+  };
+  const mapAbsGeoref = (coordinateInfo?: ModelGeoref['coordinateInfo']) => makeGeoref({
+    mapConversion: {
+      eastings: 312000,
+      northings: 5996150,
+      orthogonalHeight: 0,
+      xAxisAbscissa: 0,
+      xAxisOrdinate: 1,
+    },
+    coordinateInfo,
+  });
+
+  it('lands a scan point exactly on the model: identity conversion, viewer shift only', () => {
+    const t = computePointCloudAlignment(mapAbsGeoref(mapAbsInfo));
+    assert.ok(t);
+    // Viewer origin in map space under the NEUTRALISED conversion is the
+    // total Y-up offset unswapped to Z-up: (312000, 5996150, 10).
+    assertClose(t.decodeOriginOffset[0], 312000, 1e-6, 'decode E');
+    assertClose(t.decodeOriginOffset[1], 5996150, 1e-6, 'decode N');
+    assertClose(t.decodeOriginOffset[2], 10, 1e-6, 'decode H');
+    // Raw scan point (E, N, H) = (312010, 5996140, 12) — same absolute frame
+    // as the geometry — must land at viewer (10, 2, 10).
+    const out = runAlignmentChain(t, [312010, 5996140, 12]);
+    assertClose(out.x, 10, 1e-6, 'x');
+    assertClose(out.y, 2, 1e-6, 'y');
+    assertClose(out.z, 10, 1e-6, 'z');
+  });
+
+  it('control: a compliant reference (no RTC rebase) keeps the authored rotation', () => {
+    const compliant = mapAbsGeoref({ ...mapAbsInfo, wasmRtcOffset: undefined });
+    const t = computePointCloudAlignment(compliant);
+    assert.ok(t);
+    // off = 0, authored conversion: decode offset is the anchor itself.
+    assertClose(t.decodeOriginOffset[0], 312000, 1e-6, 'decode E');
+    assertClose(t.decodeOriginOffset[1], 5996150, 1e-6, 'decode N');
+    assertClose(t.decodeOriginOffset[2], 0, 1e-6, 'decode H');
+    // map -> local under the authored 90-degree rotation, then Z-up -> Y-up:
+    // local = invert(anchor+90deg, raw); expected viewer = (local.x, local.z, -local.y).
+    const local = invertMapConversion(
+      {
+        eastings: 312000,
+        northings: 5996150,
+        orthogonalHeight: 0,
+        xAxisAbscissa: 0,
+        xAxisOrdinate: 1,
+      },
+      312010, 5996140, 12,
+    );
+    assert.ok(local);
+    const out = runAlignmentChain(t, [312010, 5996140, 12]);
+    assertClose(out.x, local.x, 1e-6, 'x');
+    assertClose(out.y, local.z, 1e-6, 'y');
+    assertClose(out.z, -local.y, 1e-6, 'z');
+  });
+});

--- a/apps/viewer/src/hooks/ingest/pointCloudAlignment.ts
+++ b/apps/viewer/src/hooks/ingest/pointCloudAlignment.ts
@@ -71,6 +71,7 @@
 
 import type { ModelGeoref } from './federationAlign.js';
 import { getEffectiveHorizontalScale, resolveMapUnitToMetreScale } from '../../lib/geo/geo-scale.js';
+import { effectiveMapConversionForGeometry } from '../../lib/geo/map-absolute.js';
 import { totalYupOffset } from '../../lib/geo/ifc-origin.js';
 
 export interface MapConversionParams {
@@ -196,10 +197,19 @@ export interface PointCloudAlignmentTransform {
  * the caller can hide/disable the alignment toggle.
  */
 export function computePointCloudAlignment(georef: ModelGeoref): PointCloudAlignmentTransform | null {
-  const conv = georef.mapConversion;
   const lengthUnitScale = georef.lengthUnitScale ?? 1;
   const mapUnitScale = resolveMapUnitToMetreScale(georef.projectedCRS.mapUnitScale, lengthUnitScale);
   if (!(mapUnitScale > 0)) return null;
+  // Map-absolute geometry (#2526): a reference model whose geometry already
+  // sits at the declared anchor lives in the SAME absolute frame as the scan,
+  // so the alignment reduces to the viewer shift alone — inverting the
+  // authored conversion would subtract the anchor twice and rotate the cloud
+  // off the model it was scanned against.
+  const conv = effectiveMapConversionForGeometry(
+    georef.mapConversion,
+    mapUnitScale,
+    georef.coordinateInfo,
+  );
   const scale = getEffectiveHorizontalScale(conv.scale, mapUnitScale, lengthUnitScale);
   if (Math.abs(scale) < 1e-12) return null;
 

--- a/apps/viewer/src/hooks/useDxfUnderlay.scenario.test.tsx
+++ b/apps/viewer/src/hooks/useDxfUnderlay.scenario.test.tsx
@@ -1,0 +1,117 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Scenario test for `useDxfMapToWorldTransform` (issue #2526's map-absolute
+ * guard, through the REAL hook call site rather than the pure helpers it
+ * wraps).
+ *
+ * Deep review of #2534 (2026-08-10, louistrue): "three of the routed call
+ * sites have no test that can fail. (a) useDxfUnderlay.ts:83 — deleting the
+ * new `legacyCoordinateInfo: geometryResult?.coordinateInfo` line breaks
+ * nothing; the added dxfExportGeoref.test.ts case tests
+ * `resolveDxfExportGeoreference`'s threading, not the hook's call site, and
+ * no test imports `useDxfMapToWorldTransform`." This file imports and
+ * mounts the hook itself, through the Zustand store, exactly as
+ * `Section2DPanel`/`useDxfUnderlaysForDrawing` do, and asserts on the
+ * transform it publishes for a map-absolute legacy-store model. Deleting
+ * the `legacyCoordinateInfo` line under test fails the "identity axis"
+ * assertion below (the guard would never fire without it, and the
+ * authored 90-degree rotation would come through instead).
+ */
+
+import '@/test/setup-dom.js';
+import { describe, it, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { IfcParser } from '@ifc-lite/parser';
+import type { GeometryResult } from '@ifc-lite/geometry';
+
+import { useViewerStore } from '@/store';
+import { useDxfMapToWorldTransform, type DxfMapToWorld } from './useDxfUnderlay.js';
+
+// Vectorworks-style map-absolute fixture (#2526): geometry authored at the
+// absolute EPSG:25833 coordinate (rebased into wasmRtcOffset), IfcMapConversion
+// repeating the same anchor with a 90-degree rotation.
+const MAP_ABSOLUTE_FIXTURE = `ISO-10303-21;
+HEADER;
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('Proj0000000000000000001',$,'P',$,$,$,$,(#10),#20);
+#10=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#11,$);
+#11=IFCAXIS2PLACEMENT3D(#12,$,$);
+#12=IFCCARTESIANPOINT((0.,0.,0.));
+#20=IFCUNITASSIGNMENT((#21));
+#21=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#30=IFCPROJECTEDCRS('EPSG:25833','ETRS89 / UTM zone 33N',$,$,$,$,#21);
+#31=IFCMAPCONVERSION(#10,#30,312000.,5996150.,0.,0.,1.,1.);
+ENDSEC;
+END-ISO-10303-21;
+`;
+
+async function parseStore(source: string) {
+  const bytes = new TextEncoder().encode(source);
+  return new IfcParser().parseColumnar(bytes.buffer as ArrayBuffer, { disableWorkerScan: true });
+}
+
+/** Render `useDxfMapToWorldTransform()` once and capture what it returns. */
+async function renderHook(): Promise<DxfMapToWorld> {
+  let result: DxfMapToWorld | null = null;
+  function Harness(): null {
+    result = useDxfMapToWorldTransform();
+    return null;
+  }
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  let root: Root | null = null;
+  try {
+    await act(async () => { root = createRoot(container); root.render(<Harness />); });
+    assert.ok(result, 'harness never rendered — the hook was not called');
+    return result!;
+  } finally {
+    if (root) await act(async () => { root!.unmount(); });
+    container.remove();
+  }
+}
+
+const originalState = useViewerStore.getState();
+after(() => { useViewerStore.setState(originalState, true); });
+
+describe('useDxfMapToWorldTransform (real hook call site, #2534 review gap)', () => {
+  it('routes the legacy single-model store through the map-absolute guard (identity axis, not the authored 90deg rotation)', async () => {
+    const store = await parseStore(MAP_ABSOLUTE_FIXTURE);
+    const coordinateInfo: NonNullable<GeometryResult['coordinateInfo']> = {
+      originShift: { x: 0, y: 0, z: 0 },
+      originalBounds: { min: { x: -1, y: -1, z: -1 }, max: { x: 1, y: 1, z: 1 } },
+      shiftedBounds: { min: { x: -1, y: -1, z: -1 }, max: { x: 1, y: 1, z: 1 } },
+      hasLargeCoordinates: false,
+      // Geometry re-based right next to the declared anchor — inside the
+      // 10km detection window (#2526 signature).
+      wasmRtcOffset: { x: 312000, y: 5996150, z: 10 },
+    };
+    useViewerStore.setState({
+      ifcDataStore: store as never,
+      geometryResult: { coordinateInfo, meshes: [] } as unknown as GeometryResult,
+      models: new Map(),
+      anchorModelIdOverride: null,
+      georefMutations: new Map(),
+      mutationVersion: 0,
+    });
+
+    const { transform, available } = await renderHook();
+    assert.strictEqual(available, true, 'a map-absolute legacy model must still resolve a usable georeference');
+
+    // The guard-neutralised conversion is the identity axis: a map point
+    // offset from the anchor round-trips to the SAME offset in world space
+    // (no 90-degree rotation applied). Without `legacyCoordinateInfo`
+    // threaded into `resolveDxfExportGeoreference`, the guard never sees
+    // `coordinateInfo`, never fires, and the authored 90-degree rotation
+    // would instead swap/negate the offset.
+    const out = transform({ x: 312010, y: 5996140 });
+    assert.ok(Math.abs(out.x - 312010) < 1e-6, `x = ${out.x}`);
+    assert.ok(Math.abs(out.y - 5996140) < 1e-6, `y = ${out.y}`);
+  });
+});

--- a/apps/viewer/src/hooks/useDxfUnderlay.ts
+++ b/apps/viewer/src/hooks/useDxfUnderlay.ts
@@ -68,6 +68,7 @@ export interface DxfMapToWorld {
 export function useDxfMapToWorldTransform(): DxfMapToWorld {
   const models = useViewerStore((s) => s.models);
   const ifcDataStore = useViewerStore((s) => s.ifcDataStore);
+  const geometryResult = useViewerStore((s) => s.geometryResult);
   const anchorModelIdOverride = useViewerStore((s) => s.anchorModelIdOverride);
   const georefMutations = useViewerStore((s) => s.georefMutations);
   // Georef edits replace the map, but subscribe to mutationVersion too so
@@ -78,12 +79,17 @@ export function useDxfMapToWorldTransform(): DxfMapToWorld {
     const georeference = resolveDxfExportGeoreference({
       models,
       legacyDataStore: ifcDataStore,
+      // The legacy single-model coordinateInfo must be threaded exactly like
+      // useDrawingExport does, or the map-absolute guard (#2526) fires on
+      // export but not on this import path and the two directions disagree
+      // for a map-absolute model loaded through the legacy store.
+      legacyCoordinateInfo: geometryResult?.coordinateInfo,
       anchorModelIdOverride,
       georefMutations,
     });
     return { transform: buildDxfMapToWorldTransform(georeference), available: georeference !== null };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [models, ifcDataStore, anchorModelIdOverride, georefMutations, mutationVersion]);
+  }, [models, ifcDataStore, geometryResult, anchorModelIdOverride, georefMutations, mutationVersion]);
 }
 
 export function useDxfUnderlaysForDrawing(params: {

--- a/apps/viewer/src/hooks/useSolarEnvironment.scenario.test.tsx
+++ b/apps/viewer/src/hooks/useSolarEnvironment.scenario.test.tsx
@@ -1,0 +1,103 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Scenario test for `useSolarEnvironment` (issue #2526's map-absolute
+ * guard), through the REAL hook call site rather than the pure
+ * `enuToViewerDirection` helper.
+ *
+ * Deep review of #2534 (2026-08-10, louistrue): "useSolarEnvironment.ts:
+ * 108-110 — reverting `effectiveConversion?.xAxisAbscissa` to
+ * `mapConversion?.xAxisAbscissa` fails no test." This file mounts the hook
+ * itself and reads the direction it publishes to `solarSunDirection`,
+ * asserting it matches the IDENTITY-axis rotation (the map-absolute guard
+ * firing) rather than the authored 90-degree rotation.
+ */
+
+import '@/test/setup-dom.js';
+import { describe, it, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import type { MapConversion, ProjectedCRS } from '@ifc-lite/parser';
+import type { CoordinateInfo } from '@ifc-lite/geometry';
+import { sunPosition, azimuthAltitudeToEnu } from '@ifc-lite/solar';
+
+import { useViewerStore } from '@/store';
+import { computeCesiumModelOrigin } from '@/lib/geo/cesium-bridge';
+import { enuToViewerDirection } from '@/lib/geo/solar-direction';
+import { useSolarEnvironment, type SolarEnvironmentGeoref } from './useSolarEnvironment.js';
+
+// #2526 Vectorworks-style map-absolute anchor: geometry re-based right next
+// to the declared (repeated) anchor, 90-degree authored rotation.
+const mapConversion: MapConversion = {
+  id: 1, sourceCRS: 0, targetCRS: 0,
+  eastings: 312000, northings: 5996150, orthogonalHeight: 0,
+  xAxisAbscissa: 0, xAxisOrdinate: 1, scale: 1,
+};
+const projectedCRS: ProjectedCRS = { id: 2, name: 'EPSG:25833', mapUnitScale: 1 };
+const coordinateInfo: CoordinateInfo = {
+  originShift: { x: 0, y: 0, z: 0 },
+  originalBounds: { min: { x: -1, y: -1, z: -1 }, max: { x: 1, y: 1, z: 1 } },
+  shiftedBounds: { min: { x: -1, y: -1, z: -1 }, max: { x: 1, y: 1, z: 1 } },
+  hasLargeCoordinates: false,
+  wasmRtcOffset: { x: 312000, y: 5996150, z: 10 },
+};
+
+async function mountHook(georef: SolarEnvironmentGeoref | null): Promise<Root> {
+  function Harness(): null {
+    useSolarEnvironment(georef);
+    return null;
+  }
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => { root.render(<Harness />); });
+  // computeCesiumModelOrigin resolves proj4 (EPSG lookup + async import)
+  // before the hook's origin effect settles; flush past that.
+  await act(async () => { await new Promise((resolve) => setTimeout(resolve, 50)); });
+  return root;
+}
+
+const originalState = useViewerStore.getState();
+after(() => { useViewerStore.setState(originalState, true); });
+
+describe('useSolarEnvironment (real hook call site, #2534 review gap)', () => {
+  it('publishes the sun direction rotated by the IDENTITY axis, not the authored 90deg rotation', async () => {
+    const solarDateMs = Date.UTC(2026, 5, 21, 12, 0, 0); // fixed instant, no flakiness
+    useViewerStore.setState({ solarEnabled: true, solarDateMs, cesiumEnabled: true });
+
+    const root = await mountHook({ mapConversion, projectedCRS, coordinateInfo, lengthUnitScale: 1 });
+    try {
+      const published = useViewerStore.getState().solarSunDirection;
+      assert.ok(published, 'the hook must publish a sun direction for an enabled solar study');
+
+      // Independently reconstruct the origin (lat/lon/gamma) the SAME way
+      // the hook's own effect does — `computeCesiumModelOrigin` already
+      // neutralises internally, so this call is unaffected by the finding.
+      const origin = await computeCesiumModelOrigin(mapConversion, projectedCRS, coordinateInfo, 1);
+      assert.ok(origin, 'origin must resolve for this fixture');
+      const date = new Date(solarDateMs);
+      const sp = sunPosition(date, origin!.latitude, origin!.longitude);
+      const enu = azimuthAltitudeToEnu(sp.azimuth, sp.altitude);
+
+      const identityAxisDirection = enuToViewerDirection(enu, 1, 0, origin!.gamma);
+      const authoredAxisDirection = enuToViewerDirection(enu, mapConversion.xAxisAbscissa!, mapConversion.xAxisOrdinate!, origin!.gamma);
+
+      // The 90-degree authored rotation must NOT have been applied.
+      const dist = (a: readonly number[], b: readonly number[]) =>
+        Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]);
+      assert.ok(
+        dist(published!, authoredAxisDirection) > 0.1,
+        `published direction must not match the authored-rotation prediction: published=${published}, authored=${authoredAxisDirection}`,
+      );
+      assert.ok(
+        dist(published!, identityAxisDirection) < 1e-6,
+        `published direction must match the identity-axis (guard-neutralised) prediction: published=${published}, identity=${identityAxisDirection}`,
+      );
+    } finally {
+      await act(async () => { root.unmount(); });
+    }
+  });
+});

--- a/apps/viewer/src/hooks/useSolarEnvironment.ts
+++ b/apps/viewer/src/hooks/useSolarEnvironment.ts
@@ -16,12 +16,14 @@
  * write (it uses the terrain-clamped bridge origin).
  */
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { MapConversion, ProjectedCRS } from '@ifc-lite/parser';
 import type { CoordinateInfo } from '@ifc-lite/geometry';
 import { sunPosition, sunTimes, azimuthAltitudeToEnu } from '@ifc-lite/solar';
 import { useViewerStore } from '@/store';
 import { computeCesiumModelOrigin } from '@/lib/geo/cesium-bridge';
+import { effectiveMapConversionForGeometry } from '@/lib/geo/map-absolute';
+import { resolveMapUnitToMetreScale } from '@/lib/geo/geo-scale';
 import { enuToViewerDirection } from '@/lib/geo/solar-direction';
 
 export interface SolarEnvironmentGeoref {
@@ -50,6 +52,23 @@ export function useSolarEnvironment(georef: SolarEnvironmentGeoref | null): void
 
   const mapConversion = georef?.mapConversion;
   const projectedCRS = georef?.projectedCRS;
+  const coordinateInfo = georef?.coordinateInfo;
+  const lengthUnitScale = georef?.lengthUnitScale ?? 1;
+
+  // Map-absolute geometry (#2526): `computeCesiumModelOrigin` neutralises the
+  // conversion internally, so the sun rotation below must read the SAME
+  // effective conversion — mixing the authored XAxis rotation with the
+  // neutralised origin/gamma would swing the sun by that rotation relative to
+  // the camera/model frame (the exact disagreement viewer-enu-rotation.ts
+  // exists to prevent).
+  const effectiveConversion = useMemo(() => {
+    if (!mapConversion) return undefined;
+    return effectiveMapConversionForGeometry(
+      mapConversion,
+      resolveMapUnitToMetreScale(projectedCRS?.mapUnitScale, lengthUnitScale),
+      coordinateInfo,
+    );
+  }, [mapConversion, projectedCRS?.mapUnitScale, coordinateInfo, lengthUnitScale]);
 
   // Resolve the site's lat/lon once per georeference (proj4 lookup is async).
   useEffect(() => {
@@ -89,8 +108,8 @@ export function useSolarEnvironment(georef: SolarEnvironmentGeoref | null): void
     const enu = azimuthAltitudeToEnu(sp.azimuth, sp.altitude);
     setSolarSunDirection(enuToViewerDirection(
       enu,
-      mapConversion?.xAxisAbscissa ?? 1,
-      mapConversion?.xAxisOrdinate ?? 0,
+      effectiveConversion?.xAxisAbscissa ?? 1,
+      effectiveConversion?.xAxisOrdinate ?? 0,
       origin.gamma,
     ));
 
@@ -112,8 +131,8 @@ export function useSolarEnvironment(georef: SolarEnvironmentGeoref | null): void
     solarDateMs,
     origin,
     cesiumEnabled,
-    mapConversion?.xAxisAbscissa,
-    mapConversion?.xAxisOrdinate,
+    effectiveConversion?.xAxisAbscissa,
+    effectiveConversion?.xAxisOrdinate,
     setSolarSunDirection,
     setSolarSunInfo,
   ]);

--- a/apps/viewer/src/lib/geo/cesium-bridge.test.ts
+++ b/apps/viewer/src/lib/geo/cesium-bridge.test.ts
@@ -7,7 +7,9 @@ import assert from 'node:assert';
 
 import proj4 from 'proj4';
 
-import { computeGridConvergence, viewerToEnuRotation } from './cesium-bridge.js';
+import { computeGridConvergence, createCesiumBridge, viewerToEnuRotation } from './cesium-bridge.js';
+import type { CoordinateInfo } from '@ifc-lite/geometry';
+import type { MapConversion, ProjectedCRS } from '@ifc-lite/parser';
 
 /**
  * Independent grid-convergence ground truth: reproject a grid-north step to
@@ -159,5 +161,55 @@ describe('viewerToEnuRotation — model/camera share one convergence-corrected r
     assert.ok(Math.abs(r.northFromVx - (sg * g.eastFromVx + cg * g.northFromVx)) < 1e-12);
     assert.ok(Math.abs(r.eastFromVz - (cg * g.eastFromVz - sg * g.northFromVz)) < 1e-12);
     assert.ok(Math.abs(r.northFromVz - (sg * g.eastFromVz + cg * g.northFromVz)) < 1e-12);
+  });
+});
+
+describe('createCesiumBridge with map-absolute geometry (#2526)', () => {
+  // Same fixture shape as reproject.test.ts's #2526 block: geometry already at
+  // the absolute EPSG:25833 coordinates (via wasmRtcOffset), MapConversion
+  // repeating the anchor with a 90-degree XAxis rotation.
+  const vwCoordinateInfo: CoordinateInfo = {
+    originShift: { x: 0, y: 0, z: 0 },
+    originalBounds: {
+      min: { x: -29.07, y: -0.2, z: -13.68 },
+      max: { x: 5.98, y: 3.76, z: 31.68 },
+    },
+    shiftedBounds: {
+      min: { x: -29.07, y: -0.2, z: -13.68 },
+      max: { x: 5.98, y: 3.76, z: 31.68 },
+    },
+    hasLargeCoordinates: false,
+    wasmRtcOffset: { x: 312018.898, y: 5996169.654, z: 14 },
+  };
+  const vwConversion: MapConversion = {
+    id: 73,
+    sourceCRS: 41,
+    targetCRS: 71,
+    eastings: 311988.181,
+    northings: 5996148.565,
+    orthogonalHeight: 0,
+    xAxisAbscissa: 0,
+    xAxisOrdinate: 1,
+  };
+  const vwCrs: ProjectedCRS = {
+    id: 71,
+    name: 'EPSG:25833 ETRS89 / UTM zone 33N',
+    geodeticDatum: 'ETRS89',
+    mapUnit: 'METRE',
+    mapUnitScale: 1,
+  };
+
+  it('neutralises the double-applied rotation and reads viewer points at their absolute map position', async () => {
+    const bridge = await createCesiumBridge(vwConversion, vwCrs, vwCoordinateInfo, 0.001);
+    assert.ok(bridge, 'expected a bridge');
+    // The 90-degree XAxis rotation is already baked into the absolute
+    // geometry — re-applying it would spin the model around a correct origin.
+    assert.strictEqual(bridge.rotationAngle, 0);
+    // Viewer origin (0,0,0) = the rtc offset = IFC (312018.898, 5996169.654, 14).
+    const geo = bridge.viewerToGeodetic(0, 0, 0);
+    assert.ok(geo, 'expected a geodetic position');
+    assert.ok(Math.abs(geo.latitude - 54.0794) < 5e-3, `lat ${geo.latitude} should be Rostock`);
+    assert.ok(Math.abs(geo.longitude - 12.1264) < 5e-3, `lon ${geo.longitude} should be Rostock`);
+    assert.ok(Math.abs(geo.height - 14) < 1e-6, `height ${geo.height} should keep the absolute 14 m`);
   });
 });

--- a/apps/viewer/src/lib/geo/cesium-bridge.ts
+++ b/apps/viewer/src/lib/geo/cesium-bridge.ts
@@ -28,7 +28,7 @@
 import proj4 from 'proj4';
 import type { MapConversion, ProjectedCRS } from '@ifc-lite/parser';
 import type { CoordinateInfo } from '@ifc-lite/geometry';
-import { computeModelCenterInIfcMeters, resolveProjection } from './reproject';
+import { computeModelCenterInIfcMeters, effectiveMapConversionForGeometry, resolveProjection } from './reproject';
 import {
   resolveTerrainElevationDetailed,
   type ResolveTerrainElevationOptions,
@@ -127,10 +127,13 @@ export async function computeCesiumModelOrigin(
   const projDef = await resolveProjection(projectedCRS);
   if (!projDef) return null;
 
+  const mapScale = resolveMapUnitToMetreScale(projectedCRS.mapUnitScale, lengthUnitScale);
+  // Map-absolute geometry (#2526): neutralise a conversion the geometry
+  // already carries, or the offsets/rotation get applied twice.
+  mapConversion = effectiveMapConversionForGeometry(mapConversion, mapScale, coordinateInfo);
   const absc = mapConversion.xAxisAbscissa ?? 1.0;
   const ordi = mapConversion.xAxisOrdinate ?? 0.0;
   const center = computeModelCenterInIfcMeters(coordinateInfo);
-  const mapScale = resolveMapUnitToMetreScale(projectedCRS.mapUnitScale, lengthUnitScale);
   const horizontalScale = getEffectiveHorizontalScale(
     mapConversion.scale,
     mapScale,
@@ -252,6 +255,14 @@ export async function createCesiumBridge(
   const projDef = await resolveProjection(projectedCRS);
   if (!projDef) return null;
 
+  // Map-absolute geometry (#2526): the Helmert rotation below must use the
+  // same neutralised conversion as `computeCesiumModelOrigin`, or the model
+  // spins by the double-applied XAxis rotation around a correct origin.
+  mapConversion = effectiveMapConversionForGeometry(
+    mapConversion,
+    resolveMapUnitToMetreScale(projectedCRS.mapUnitScale, lengthUnitScale),
+    coordinateInfo,
+  );
   const absc = mapConversion.xAxisAbscissa ?? 1.0;
   const ordi = mapConversion.xAxisOrdinate ?? 0.0;
   const rotAngle = Math.atan2(ordi, absc);

--- a/apps/viewer/src/lib/geo/cesium-placement.test.ts
+++ b/apps/viewer/src/lib/geo/cesium-placement.test.ts
@@ -16,10 +16,14 @@ import {
   metersToMapUnits,
   orthometricTargetForTerrain,
   projectedDeltaToViewerDelta,
+  projectedDeltaToViewerDeltaForGeometry,
   shouldApplyGeoidUndulation,
   shouldPreferOrthometricTerrain,
   viewerDeltaToProjectedDelta,
+  viewerDeltaToProjectedDeltaForGeometry,
 } from './cesium-placement.js';
+import type { CoordinateInfo } from '@ifc-lite/geometry';
+import type { MapConversion } from '@ifc-lite/parser';
 
 describe('cesium placement helpers', () => {
   it('defaults to METRES when MapUnit is absent (overrides project length unit)', () => {
@@ -347,5 +351,89 @@ describe('snap-to-terrain geoid round-trip (#1456)', () => {
       Math.abs((orthogonalHeight + appliedN) - ellipsoidalTerrain) < 0.02,
       `expected round-trip to ${ellipsoidalTerrain}, got ${orthogonalHeight + appliedN}`,
     );
+  });
+});
+
+describe('placement-gizmo deltas with map-absolute geometry (#2526)', () => {
+  // Vectorworks-style file: geometry at the ABSOLUTE map coordinates (folded
+  // into wasmRtcOffset), IfcMapConversion repeating the anchor with a
+  // 90-degree rotation. A gizmo drag is a DELTA: it has no offsets to double
+  // apply, but the bogus authored rotation still turns "drag east" into a
+  // northing change. For map-absolute geometry the viewer axes ARE the map
+  // axes, so the delta must go through the neutralised (identity-rotation)
+  // conversion.
+  const mapAbsInfo: CoordinateInfo = {
+    originShift: { x: 0, y: 0, z: 0 },
+    originalBounds: { min: { x: -1, y: -1, z: -1 }, max: { x: 1, y: 1, z: 1 } },
+    shiftedBounds: { min: { x: -1, y: -1, z: -1 }, max: { x: 1, y: 1, z: 1 } },
+    hasLargeCoordinates: false,
+    wasmRtcOffset: { x: 312000, y: 5996150, z: 10 },
+  };
+  const mapAbsConversion: MapConversion = {
+    id: 1,
+    sourceCRS: 0,
+    targetCRS: 0,
+    eastings: 312000,
+    northings: 5996150,
+    orthogonalHeight: 0,
+    xAxisAbscissa: 0,
+    xAxisOrdinate: 1,
+    scale: 1,
+  };
+  const crs = { mapUnitScale: 1 };
+  const near = (a: number, b: number, label: string) =>
+    assert.ok(Math.abs(a - b) < 1e-9, `${label}: expected ${b}, got ${a}`);
+
+  it('viewerDeltaToProjectedDeltaForGeometry expresses a drag in the map frame (identity rotation)', () => {
+    const delta = viewerDeltaToProjectedDeltaForGeometry(
+      5, -7, mapAbsConversion, crs, 1, mapAbsInfo,
+    );
+    // Viewer +X is map east, viewer -Z is map north for absolute geometry.
+    near(delta.eastings, 5, 'eastings');
+    near(delta.northings, 7, 'northings');
+  });
+
+  it('projectedDeltaToViewerDeltaForGeometry previews an E/N delta along the map axes', () => {
+    const delta = projectedDeltaToViewerDeltaForGeometry(
+      5, 7, mapAbsConversion, crs, 1, mapAbsInfo,
+    );
+    near(delta.x, 5, 'x');
+    near(delta.z, -7, 'z');
+  });
+
+  it('round-trips through both directions', () => {
+    const projected = viewerDeltaToProjectedDeltaForGeometry(
+      3.25, -1.5, mapAbsConversion, crs, 1, mapAbsInfo,
+    );
+    const viewer = projectedDeltaToViewerDeltaForGeometry(
+      projected.eastings, projected.northings, mapAbsConversion, crs, 1, mapAbsInfo,
+    );
+    near(viewer.x, 3.25, 'x');
+    near(viewer.z, -1.5, 'z');
+  });
+
+  it('control: a compliant file (no RTC rebase) keeps the authored rotation for the delta', () => {
+    const compliant = { ...mapAbsInfo, wasmRtcOffset: undefined };
+    const guarded = viewerDeltaToProjectedDeltaForGeometry(
+      5, -7, mapAbsConversion, crs, 1, compliant,
+    );
+    const authored = viewerDeltaToProjectedDelta(5, -7, mapAbsConversion, crs, 1);
+    near(guarded.eastings, authored.eastings, 'eastings');
+    near(guarded.northings, authored.northings, 'northings');
+    const guardedViewer = projectedDeltaToViewerDeltaForGeometry(
+      5, 7, mapAbsConversion, crs, 1, compliant,
+    );
+    const authoredViewer = projectedDeltaToViewerDelta(5, 7, mapAbsConversion, crs, 1);
+    near(guardedViewer.x, authoredViewer.x, 'x');
+    near(guardedViewer.z, authoredViewer.z, 'z');
+  });
+
+  it('control: no coordinateInfo keeps the authored rotation', () => {
+    const guarded = viewerDeltaToProjectedDeltaForGeometry(
+      5, -7, mapAbsConversion, crs, 1, undefined,
+    );
+    const authored = viewerDeltaToProjectedDelta(5, -7, mapAbsConversion, crs, 1);
+    near(guarded.eastings, authored.eastings, 'eastings');
+    near(guarded.northings, authored.northings, 'northings');
   });
 });

--- a/apps/viewer/src/lib/geo/cesium-placement.ts
+++ b/apps/viewer/src/lib/geo/cesium-placement.ts
@@ -7,6 +7,7 @@ import type { MapConversion, ProjectedCRS } from '@ifc-lite/parser';
 
 import { findClampAnchorY } from './clamp-anchor';
 import { computeModelCenterInIfcMeters } from './reproject';
+import { effectiveMapConversionForGeometry } from './map-absolute';
 import { getEffectiveHorizontalScale, resolveMapUnitToMetreScale } from './geo-scale';
 
 export function getMapUnitScale(
@@ -291,4 +292,65 @@ export function projectedDeltaToViewerDelta(
     x: (abscissa * eastMeters + ordinate * northMeters) / denom,
     z: (ordinate * eastMeters - abscissa * northMeters) / denom,
   };
+}
+
+/**
+ * {@link viewerDeltaToProjectedDelta} routed through the map-absolute guard
+ * (#2526), for the placement gizmo's drag math.
+ *
+ * A delta has no offsets to double-apply — the guard's zeroed
+ * eastings/northings are inert here because the delta formulas read only the
+ * axis pair and scale. What a "neutralised conversion" means for a DELTA is
+ * the identity ROTATION: map-absolute geometry's viewer axes ARE the map
+ * axes, so a drag along viewer +X is a pure easting change, while the
+ * authored (double-georeferencing) axis would rotate the drag into the wrong
+ * E/N direction. For a compliant file the guard does not fire and the
+ * authored rotation applies exactly as in the raw function.
+ *
+ * Takes the FULL MapConversion (offsets included) because the guard's
+ * detection compares the declared anchor against the geometry centre.
+ */
+export function viewerDeltaToProjectedDeltaForGeometry(
+  deltaX: number,
+  deltaZ: number,
+  mapConversion: MapConversion,
+  projectedCRS: Pick<ProjectedCRS, 'mapUnitScale'> | undefined,
+  lengthUnitScale: number,
+  coordinateInfo: CoordinateInfo | undefined,
+): { eastings: number; northings: number } {
+  const conversion = effectiveMapConversionForGeometry(
+    mapConversion,
+    getMapUnitScale(projectedCRS, lengthUnitScale),
+    coordinateInfo,
+  );
+  return viewerDeltaToProjectedDelta(deltaX, deltaZ, conversion, projectedCRS, lengthUnitScale);
+}
+
+/**
+ * {@link projectedDeltaToViewerDelta} routed through the map-absolute guard
+ * (#2526) — the inverse counterpart of
+ * {@link viewerDeltaToProjectedDeltaForGeometry}, used by the gizmo's
+ * draft-offset preview. Both directions must route identically or the gizmo
+ * stops tracking the cursor for map-absolute files.
+ */
+export function projectedDeltaToViewerDeltaForGeometry(
+  eastingsDelta: number,
+  northingsDelta: number,
+  mapConversion: MapConversion,
+  projectedCRS: Pick<ProjectedCRS, 'mapUnitScale'> | undefined,
+  lengthUnitScale: number,
+  coordinateInfo: CoordinateInfo | undefined,
+): { x: number; z: number } {
+  const conversion = effectiveMapConversionForGeometry(
+    mapConversion,
+    getMapUnitScale(projectedCRS, lengthUnitScale),
+    coordinateInfo,
+  );
+  return projectedDeltaToViewerDelta(
+    eastingsDelta,
+    northingsDelta,
+    conversion,
+    projectedCRS,
+    lengthUnitScale,
+  );
 }

--- a/apps/viewer/src/lib/geo/ifc-origin.test.ts
+++ b/apps/viewer/src/lib/geo/ifc-origin.test.ts
@@ -214,6 +214,63 @@ describe('computeIfcOriginViewerPosition', () => {
     assert.ok(Math.abs(out!.viewer.z) < 5, `viewer.z residual = ${out!.viewer.z}`);
   });
 
+  it('#2534 review: neutralises a map-absolute ANCHOR before inverting, matching federationAlign (BasepointOverlay no longer contradicts the aligned geometry)', async () => {
+    // Deep review of #2534 (2026-08-10, louistrue), blocking issue on
+    // ifc-origin.ts:93-140: `federationAlign.ts` aligns geometry through the
+    // NEUTRALISED anchor conversion (`effectiveConv`), but this function
+    // used to invert the AUTHORED one — for a map-absolute anchor the two
+    // disagreed by the full anchor magnitude (hundreds of km), and
+    // BasepointOverlay drew that model's origin dot nowhere near its
+    // geometry. Fixture is the #2526 Vectorworks anchor: RTC re-based
+    // geometry sitting ~37m from the declared (repeated) anchor, with a
+    // 90-degree XAxis rotation — the map-absolute detection signature.
+    const anchorConv: MapConversion = {
+      id: 1, sourceCRS: 1, targetCRS: 2,
+      eastings: 311_988.181, northings: 5_996_148.565, orthogonalHeight: 0,
+      xAxisAbscissa: 0, xAxisOrdinate: 1, scale: 1,
+    };
+    const anchor: ModelGeorefInput = {
+      coordinateInfo: {
+        originShift: { x: 0, y: 0, z: 0 },
+        // wasmRtcOffset re-bases the anchor's geometry right next to the
+        // declared anchor (~37m away — inside the 10km detection window),
+        // which is exactly the #2526 double-georeferencing signature.
+        wasmRtcOffset: { x: 312_018.898, y: 5_996_169.654, z: 14 },
+        originalBounds: { min: { x: 0, y: 7, z: 0 }, max: { x: 0, y: 7, z: 0 } },
+        shiftedBounds: { min: { x: 0, y: 7, z: 0 }, max: { x: 0, y: 7, z: 0 } },
+        hasLargeCoordinates: true,
+      },
+      mapConversion: anchorConv,
+      projectedCRS: rdCrs(),
+      lengthUnitScale: 1,
+    };
+    // A COMPLIANT second model federated onto the map-absolute anchor: its
+    // own declared anchor is far from ITS local (near-zero) geometry — the
+    // guard must NOT fire for this model.
+    const compliantConv = makeConversion(312_050, 5_996_100);
+    const compliant: ModelGeorefInput = {
+      coordinateInfo: emptyCoordinateInfo(),
+      mapConversion: compliantConv,
+      projectedCRS: rdCrs(),
+      lengthUnitScale: 1,
+    };
+    const out = await computeIfcOriginViewerPosition(compliant, anchor);
+    assert.ok(out);
+    assert.strictEqual(out!.source, 'anchor');
+    // Pre-fix (inverting the AUTHORED anchor conversion) landed this dot at
+    // viewer ≈ (-312067, ?, 5996231) — hundreds of km from the geometry
+    // federationAlign.ts actually aligns onto (tx/tz of a few tens of
+    // metres, per the review's own hand-derivation). The fix must land in
+    // that same small neighbourhood, not the pre-fix magnitude.
+    assert.ok(Math.abs(out!.viewer.x) < 1000, `viewer.x should be tens of metres, not ~312067km-scale: ${out!.viewer.x}`);
+    assert.ok(Math.abs(out!.viewer.z) < 1000, `viewer.z should be tens of metres, not ~5996231km-scale: ${out!.viewer.z}`);
+    // Exact value, hand-derived: with the anchor neutralised (eastings=0,
+    // northings=0, axis=(1,0), scale=1), ifcX = eA = 312050, ifcY = nA =
+    // 5996100; anchorOff = rtcYup = (312018.898, 14, -5996169.654).
+    assert.ok(Math.abs(out!.viewer.x - 31.102) < 1e-2, `viewer.x = ${out!.viewer.x}`);
+    assert.ok(Math.abs(out!.viewer.z - 69.654) < 1e-2, `viewer.z = ${out!.viewer.z}`);
+  });
+
   it('falls back to the model own frame when the anchor lacks georef', async () => {
     const model: ModelGeorefInput = {
       coordinateInfo: {

--- a/apps/viewer/src/lib/geo/ifc-origin.ts
+++ b/apps/viewer/src/lib/geo/ifc-origin.ts
@@ -29,6 +29,7 @@ import type { MapConversion, ProjectedCRS } from '@ifc-lite/parser';
 import type { CoordinateInfo } from '@ifc-lite/geometry';
 import { resolveProjection } from './reproject';
 import { getEffectiveHorizontalScale, resolveMapUnitToMetreScale } from './geo-scale';
+import { effectiveMapConversionForGeometry } from './map-absolute';
 
 export interface IfcOriginPlacement {
   /** Viewer-local position (Y-up) where this model's IFC (0,0,0) currently sits. */
@@ -90,9 +91,19 @@ export async function computeIfcOriginViewerPosition(
   // multiply zero — only the eastings/northings/orthogonalHeight remain.
   const modelLengthScale = model.lengthUnitScale ?? 1;
   const modelMapUnitScale = resolveMapUnitToMetreScale(model.projectedCRS.mapUnitScale, modelLengthScale);
-  const eM = model.mapConversion.eastings * modelMapUnitScale;
-  const nM = model.mapConversion.northings * modelMapUnitScale;
-  const hM = model.mapConversion.orthogonalHeight * modelMapUnitScale;
+  // Map-absolute geometry (#2526): `federationAlign.ts` aligns this model's
+  // GEOMETRY through the neutralised conversion (`effectiveConv`); inverting
+  // the AUTHORED conversion here instead would draw the origin dot far from
+  // the geometry it belongs to the moment a map-absolute model is federated
+  // — the two computations must read the same effective conversion.
+  const modelConv = effectiveMapConversionForGeometry(
+    model.mapConversion,
+    modelMapUnitScale,
+    model.coordinateInfo,
+  );
+  const eM = modelConv.eastings * modelMapUnitScale;
+  const nM = modelConv.northings * modelMapUnitScale;
+  const hM = modelConv.orthogonalHeight * modelMapUnitScale;
 
   // Step 2: same CRS → identity; different CRS → proj4 hop.
   let eA = eM;
@@ -120,13 +131,22 @@ export async function computeIfcOriginViewerPosition(
   // Step 3: anchor projected → anchor IFC (invert anchor's MapConversion).
   const anchorLengthScale = anchor.lengthUnitScale ?? 1;
   const anchorMapUnitScale = resolveMapUnitToMetreScale(anchor.projectedCRS.mapUnitScale, anchorLengthScale);
-  const eAnchor = anchor.mapConversion.eastings * anchorMapUnitScale;
-  const nAnchor = anchor.mapConversion.northings * anchorMapUnitScale;
-  const hAnchor = anchor.mapConversion.orthogonalHeight * anchorMapUnitScale;
-  const anchorAbsc = anchor.mapConversion.xAxisAbscissa ?? 1;
-  const anchorOrd = anchor.mapConversion.xAxisOrdinate ?? 0;
+  // Same neutralisation on the anchor side: a map-absolute ANCHOR must be
+  // inverted through its own effective (identity) conversion too, or a
+  // non-anchor model federated onto it lands via the authored rotation while
+  // the anchor's own geometry never moved.
+  const anchorConv = effectiveMapConversionForGeometry(
+    anchor.mapConversion,
+    anchorMapUnitScale,
+    anchor.coordinateInfo,
+  );
+  const eAnchor = anchorConv.eastings * anchorMapUnitScale;
+  const nAnchor = anchorConv.northings * anchorMapUnitScale;
+  const hAnchor = anchorConv.orthogonalHeight * anchorMapUnitScale;
+  const anchorAbsc = anchorConv.xAxisAbscissa ?? 1;
+  const anchorOrd = anchorConv.xAxisOrdinate ?? 0;
   const anchorScale = getEffectiveHorizontalScale(
-    anchor.mapConversion.scale,
+    anchorConv.scale,
     anchorMapUnitScale,
     anchorLengthScale,
   );

--- a/apps/viewer/src/lib/geo/kmz-export.test.ts
+++ b/apps/viewer/src/lib/geo/kmz-export.test.ts
@@ -7,7 +7,9 @@ import assert from 'node:assert';
 
 import type { CoordinateInfo } from '@ifc-lite/geometry';
 
-import { computeKmzAltitude } from './kmz-export.js';
+import type { MapConversion } from '@ifc-lite/parser';
+
+import { computeKmzAltitude, resolveKmzHeading } from './kmz-export.js';
 
 describe('computeKmzAltitude', () => {
   it('scales OrthogonalHeight from map units to metres (mm-CRS file is not 1000x off)', () => {
@@ -27,5 +29,53 @@ describe('computeKmzAltitude', () => {
 
   it('matches the pre-fix behaviour for the common metre-CRS, non-RTC model', () => {
     assert.strictEqual(computeKmzAltitude(455.5, { mapUnitScale: 1 }, 1, {} as CoordinateInfo), 455.5);
+  });
+});
+
+describe('resolveKmzHeading', () => {
+  // Deep review of #2534 (2026-08-10, louistrue) — blocking issue on
+  // kmz-export.ts:97-108: `buildKmzForModel` got the PIN position through
+  // the map-absolute guard (#2526, via `reprojectToLatLon`) but passed the
+  // AUTHORED xAxisAbscissa/xAxisOrdinate straight through as the KML
+  // heading. For the #2526 file shape (90-degree authored rotation, already
+  // map-axis-aligned geometry), that rotated an otherwise-correctly-placed
+  // .dae by 90 degrees in Google Earth. `resolveKmzHeading` must return the
+  // SAME identity axis the position uses.
+  function makeConversion(overrides: Partial<MapConversion> = {}): MapConversion {
+    return {
+      id: 1, sourceCRS: 1, targetCRS: 2,
+      eastings: 311_988.181, northings: 5_996_148.565, orthogonalHeight: 0,
+      xAxisAbscissa: 0, xAxisOrdinate: 1, scale: 1,
+      ...overrides,
+    };
+  }
+
+  it('returns the identity axis (not the authored 90-degree rotation) for a map-absolute file', () => {
+    const conversion = makeConversion();
+    // Geometry centre ~37m from the declared anchor — inside the 10km
+    // detection window (#2526 signature).
+    const coordinateInfo = {
+      originShift: { x: 0, y: 0, z: 0 },
+      wasmRtcOffset: { x: 312_018.898, y: 5_996_169.654, z: 14 },
+      originalBounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 0, y: 0, z: 0 } },
+      shiftedBounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 0, y: 0, z: 0 } },
+      hasLargeCoordinates: true,
+    } as CoordinateInfo;
+    const heading = resolveKmzHeading(conversion, { mapUnitScale: 1 }, 1, coordinateInfo);
+    assert.strictEqual(heading.xAxisAbscissa, 1, 'heading must be the identity axis, not the authored rotation');
+    assert.strictEqual(heading.xAxisOrdinate, 0, 'heading must be the identity axis, not the authored rotation');
+  });
+
+  it('keeps the authored axis for a compliant (non map-absolute) file', () => {
+    const conversion = makeConversion({ eastings: 5000, northings: 3000, xAxisAbscissa: 0.6, xAxisOrdinate: 0.8 });
+    const coordinateInfo = {
+      originShift: { x: 0, y: 0, z: 0 },
+      originalBounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 10, y: 3, z: 10 } },
+      shiftedBounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 10, y: 3, z: 10 } },
+      hasLargeCoordinates: false,
+    } as CoordinateInfo;
+    const heading = resolveKmzHeading(conversion, { mapUnitScale: 1 }, 1, coordinateInfo);
+    assert.strictEqual(heading.xAxisAbscissa, 0.6);
+    assert.strictEqual(heading.xAxisOrdinate, 0.8);
   });
 });

--- a/apps/viewer/src/lib/geo/kmz-export.ts
+++ b/apps/viewer/src/lib/geo/kmz-export.ts
@@ -8,11 +8,13 @@
  * both go through one georef → WGS84 → COLLADA KMZ path (#1427).
  */
 
-import { extractGeoreferencingOnDemand, extractLengthUnitScale, type IfcDataStore, type ProjectedCRS } from '@ifc-lite/parser';
+import { extractGeoreferencingOnDemand, extractLengthUnitScale, type IfcDataStore, type MapConversion, type ProjectedCRS } from '@ifc-lite/parser';
 import type { CoordinateInfo, GeometryResult, MeshData } from '@ifc-lite/geometry';
 import type { GeorefMutationData } from '@/store/slices/mutationSlice';
 import { getMapUnitScale } from './cesium-placement';
 import { mergeMapConversion, mergeProjectedCRS } from './effective-georef';
+import { resolveMapUnitToMetreScale } from './geo-scale';
+import { effectiveMapConversionForGeometry } from './map-absolute';
 import { reprojectToLatLon } from './reproject';
 import { buildKmz, type KmzAltitudeMode } from './kmz-exporter';
 import { suggestAbsoluteAltitudeForKmz } from './kmz-altitude-hint';
@@ -79,6 +81,31 @@ export function kmzSuggestsAbsoluteAltitude(
 }
 
 /**
+ * KML `<heading>` (via xAxisAbscissa/xAxisOrdinate) for a model's COLLADA
+ * asset — routed through the same map-absolute guard (#2526) that
+ * {@link reprojectToLatLon} already applies to the PIN position.
+ *
+ * The .dae geometry the KMZ embeds is whatever the guard determines: for a
+ * map-absolute file, the mesh vertices are already map-axis-aligned (that is
+ * the guard's whole premise — geometry sits at the absolute coordinate with
+ * no conversion needed on top), so the heading must be the identity axis
+ * too, not the authored (repeated-anchor) rotation. Passing the authored
+ * axis here would correctly place the model (via the guarded position) and
+ * then rotate its already-aligned geometry by the very rotation the guard
+ * exists to suppress.
+ */
+export function resolveKmzHeading(
+  conversion: MapConversion,
+  crs: Pick<ProjectedCRS, 'mapUnitScale'> | undefined,
+  lengthUnitScale: number,
+  coordinateInfo: CoordinateInfo | undefined,
+): { xAxisAbscissa?: number; xAxisOrdinate?: number } {
+  const mapScale = resolveMapUnitToMetreScale(crs?.mapUnitScale, lengthUnitScale);
+  const effective = effectiveMapConversionForGeometry(conversion, mapScale, coordinateInfo);
+  return { xAxisAbscissa: effective.xAxisAbscissa, xAxisOrdinate: effective.xAxisOrdinate };
+}
+
+/**
  * Resolve a model's (merged) georeference to WGS84 and build a Google Earth KMZ
  * (a COLLADA model + KML placement). Returns the KMZ bytes, or a `KmzBuildError`
  * string when the model isn't georeferenced or its location can't be projected.
@@ -96,6 +123,7 @@ export async function buildKmzForModel(input: BuildKmzInput): Promise<Uint8Array
   if (!conversion || !crs) return 'not-georeferenced';
   const latLon = await reprojectToLatLon(conversion, crs, input.geometryResult.coordinateInfo, scale);
   if (!latLon) return 'unprojectable';
+  const heading = resolveKmzHeading(conversion, crs, scale, input.geometryResult.coordinateInfo);
   return buildKmz({
     latLon,
     altitude: computeKmzAltitude(
@@ -104,8 +132,8 @@ export async function buildKmzForModel(input: BuildKmzInput): Promise<Uint8Array
       scale,
       input.geometryResult.coordinateInfo,
     ),
-    xAxisAbscissa: conversion.xAxisAbscissa,
-    xAxisOrdinate: conversion.xAxisOrdinate,
+    xAxisAbscissa: heading.xAxisAbscissa,
+    xAxisOrdinate: heading.xAxisOrdinate,
     meshes: input.geometryResult.meshes as MeshData[],
     name: input.name,
     altitudeMode: input.altitudeMode,

--- a/apps/viewer/src/lib/geo/map-absolute.test.ts
+++ b/apps/viewer/src/lib/geo/map-absolute.test.ts
@@ -1,0 +1,109 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Deep review of #2534 (2026-08-10, louistrue) — minor finding on
+ * `map-absolute.ts`: the guard zeroed eastings/northings and forced the
+ * identity axis, but left `scale` authored. A non-unity `IfcMapConversion.
+ * Scale` (a UTM point-scale factor like 0.9996, or any authored value) then
+ * multiplied the model's FULL absolute coordinate instead of a small local
+ * delta — moving the pin kilometres off for a file that would otherwise be
+ * placed exactly right by this detection.
+ *
+ * These tests pin the exact scenario from the review (E ≈ 312 007,
+ * N ≈ 5 996 161, Scale = 0.9996) and fail on a revert of the `scale: 1`
+ * line in `effectiveMapConversionForGeometry`'s returned object.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import type { CoordinateInfo } from '@ifc-lite/geometry';
+import type { MapConversion } from '@ifc-lite/parser';
+
+import { effectiveMapConversionForGeometry } from './map-absolute.js';
+import { getEffectiveHorizontalScale } from './geo-scale.js';
+
+/** Model geometry centred exactly at the declared anchor (ifcX/ifcY == anchorE/anchorN). */
+function coordinateInfoAtAnchor(anchorE: number, anchorN: number): CoordinateInfo {
+  // ifcX = worldYupX = cx; ifcY = -worldYupZ = -cz  =>  cz = -ifcY.
+  const bounds = { min: { x: anchorE, y: 0, z: -anchorN }, max: { x: anchorE, y: 0, z: -anchorN } };
+  return {
+    originShift: { x: 0, y: 0, z: 0 },
+    originalBounds: bounds,
+    shiftedBounds: bounds,
+    hasLargeCoordinates: true,
+  };
+}
+
+function makeConversion(overrides: Partial<MapConversion> = {}): MapConversion {
+  return {
+    id: 1,
+    sourceCRS: 1,
+    targetCRS: 2,
+    eastings: 312_007,
+    northings: 5_996_161,
+    orthogonalHeight: 0,
+    xAxisAbscissa: 1,
+    xAxisOrdinate: 0,
+    scale: 0.9996,
+    ...overrides,
+  };
+}
+
+describe('effectiveMapConversionForGeometry — scale neutralisation', () => {
+  it('neutralises Scale to 1 when the map-absolute signature fires', () => {
+    const conversion = makeConversion();
+    const coordinateInfo = coordinateInfoAtAnchor(conversion.eastings, conversion.northings);
+    const effective = effectiveMapConversionForGeometry(conversion, 1, coordinateInfo);
+    assert.strictEqual(effective.eastings, 0);
+    assert.strictEqual(effective.northings, 0);
+    assert.strictEqual(effective.xAxisAbscissa, 1);
+    assert.strictEqual(effective.xAxisOrdinate, 0);
+    assert.strictEqual(effective.scale, 1, 'authored Scale=0.9996 must not survive into the neutralised conversion');
+  });
+
+  it('reproduces the review scenario: without the scale fix the pin would land ~2.4km south', () => {
+    // Reviewer's failure scenario: metre-unit file (mus == lus == 1), authored
+    // Scale = 0.9996 (a UTM point-scale factor). getEffectiveHorizontalScale
+    // does NOT apply the unit-bridging heuristic here because mus == lus, so
+    // an unfixed guard (Scale left authored) would compute
+    // northing = 0.9996 * 5_996_161 = 5_993_763 (a ~2398m southward error).
+    const conversion = makeConversion();
+    const coordinateInfo = coordinateInfoAtAnchor(conversion.eastings, conversion.northings);
+    const mapUnitScale = 1;
+    const lengthUnitScale = 1;
+    const effective = effectiveMapConversionForGeometry(conversion, mapUnitScale, coordinateInfo);
+
+    // Downstream formula (reproject.ts's computeProjectedCenter):
+    // N = northings*mapScale + hScale*(ordinate*ifcX + abscissa*ifcY)
+    const hScale = getEffectiveHorizontalScale(effective.scale, mapUnitScale, lengthUnitScale);
+    const ifcY = conversion.northings; // geometry centre coincides with the anchor
+    const northing = effective.northings * mapUnitScale + hScale * (0 * 0 + 1 * ifcY);
+    assert.strictEqual(hScale, 1, 'neutralised scale must yield an effective horizontal scale of exactly 1');
+    assert.strictEqual(northing, conversion.northings, 'geometry\'s own absolute northing must pass through unchanged');
+
+    // Sanity: prove the failure this fix prevents — the UNFIXED formula
+    // (authored Scale kept) really would have landed ~2398 m south.
+    const unfixedHScale = getEffectiveHorizontalScale(conversion.scale, mapUnitScale, lengthUnitScale);
+    const unfixedNorthing = 0 * mapUnitScale + unfixedHScale * (0 * 0 + 1 * ifcY);
+    assert.ok(
+      Math.abs(unfixedNorthing - conversion.northings) > 2000,
+      `expected the unfixed formula to diverge by >2km, got ${Math.abs(unfixedNorthing - conversion.northings)}`,
+    );
+  });
+
+  it('does not fire (and scale stays authored) for a compliant file', () => {
+    const conversion = makeConversion({ eastings: 5_000, northings: 3_000 }); // below MIN_ANCHOR_METERS
+    const coordinateInfo: CoordinateInfo = {
+      originShift: { x: 0, y: 0, z: 0 },
+      originalBounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 10, y: 3, z: 10 } },
+      shiftedBounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 10, y: 3, z: 10 } },
+      hasLargeCoordinates: false,
+    };
+    const effective = effectiveMapConversionForGeometry(conversion, 1, coordinateInfo);
+    assert.strictEqual(effective, conversion, 'guard must not fire for a compliant small-offset file');
+    assert.strictEqual(effective.scale, 0.9996, 'authored scale is untouched when the guard does not fire');
+  });
+});

--- a/apps/viewer/src/lib/geo/map-absolute.ts
+++ b/apps/viewer/src/lib/geo/map-absolute.ts
@@ -1,0 +1,125 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The model's position in the IFC world frame, and the detection of geometry
+ * that is ALREADY in absolute map coordinates (issue #2526).
+ */
+
+import type { MapConversion } from '@ifc-lite/parser';
+import type { CoordinateInfo } from '@ifc-lite/geometry';
+
+/**
+ * Compute the model's center in IFC Z-up metres from coordinate info.
+ * This is the geometry center before MapConversion is applied.
+ */
+export function computeModelCenterInIfcMeters(
+  coordinateInfo?: CoordinateInfo,
+): { ifcX: number; ifcY: number; ifcZ: number } {
+  if (!coordinateInfo) return { ifcX: 0, ifcY: 0, ifcZ: 0 };
+
+  // `shiftedBounds`, NOT `originalBounds`. The producer defines
+  // `shiftedBounds = originalBounds - originShift`
+  // (utils/localParsingUtils.ts), so `originalBounds` is ALREADY in the world
+  // frame — adding `shift` to it below would count the shift twice and put the
+  // model centre `originShift` away from where the footprint polygon
+  // (computeFootprintGeoJSON, which reads `shiftedBounds`) places the very same
+  // box. This matches the rule stated in reproject.ts's pipeline doc:
+  // `world_yup = bounds_center + originShift`, from the VIEWER bounds.
+  const bounds = coordinateInfo.shiftedBounds;
+  const shift = coordinateInfo.originShift;
+  const rtc = coordinateInfo.wasmRtcOffset;
+
+  const rtcYup = rtc
+    ? { x: rtc.x, y: rtc.z, z: -rtc.y }
+    : { x: 0, y: 0, z: 0 };
+
+  const cx = (bounds.min.x + bounds.max.x) / 2;
+  const cy = (bounds.min.y + bounds.max.y) / 2;
+  const cz = (bounds.min.z + bounds.max.z) / 2;
+
+  const worldYupX = cx + shift.x + rtcYup.x;
+  const worldYupY = cy + shift.y + rtcYup.y;
+  const worldYupZ = cz + shift.z + rtcYup.z;
+
+  return {
+    ifcX: worldYupX,
+    ifcY: -worldYupZ,
+    ifcZ: worldYupY,
+  };
+}
+
+/**
+ * The declared anchor must sit at real projected-CRS magnitude before the
+ * map-absolute detection may fire. Compliant zero-ish offsets (site grids a
+ * few km out) stay below this, so a small legitimate offset + rotation is
+ * never silently dropped. Real projected CRS coordinates (UTM, national
+ * grids) start in the hundreds of km.
+ */
+const MAP_ABSOLUTE_MIN_ANCHOR_METERS = 100_000;
+/**
+ * How close (metres) the geometry centre must be to the declared anchor to
+ * count as "already sitting at it". Matches the wasm RTC re-base threshold
+ * (10 km): a compliant file's geometry lives near the LOCAL origin, so its
+ * centre is `anchorDistance` (>100 km) away from the anchor and stays outside
+ * this radius. (A file that intentionally draws its local geometry right at
+ * the anchor's magnitude AND means the conversion to apply on top would be
+ * misread — that coincidence is treated as the absolute-placement signature.)
+ */
+const MAP_ABSOLUTE_MAX_CENTER_DISTANCE_METERS = 10_000;
+
+/**
+ * Detect geometry that is ALREADY in absolute map coordinates and neutralise
+ * the IfcMapConversion for it (issue #2526).
+ *
+ * Vectorworks exports place the IfcSite at the absolute projected coordinates
+ * (in project units) AND write an IfcMapConversion whose Eastings/Northings
+ * repeat the same anchor (in map units), often with a rotation. Applying that
+ * conversion on top of the absolute geometry double-transforms: the #2526
+ * EPSG:25833 file (Rostock, E 311 988 / N 5 996 149) landed in the mid
+ * Atlantic because its 90-degree XAxis rotation turned the ~6 000 km northing
+ * into a huge negative easting.
+ *
+ * Signature checked: the declared map anchor is at projected-CRS magnitude
+ * (>100 km from the local origin) AND the model centre — with the RTC/origin
+ * shifts folded back in — sits within RTC-threshold reach (10 km) of that
+ * anchor. A compliant file keeps its geometry near the LOCAL origin, so its
+ * centre is the full anchor distance away and the detection cannot fire.
+ *
+ * When detected, the returned conversion carries zero offsets and the
+ * no-rotation axis so every consumer of the standard formula
+ * `E = Eastings*mapScale + s*(a*x - o*y)` reads the geometry's absolute
+ * coordinates through unchanged. `orthogonalHeight` stays authored: the
+ * #2526 file carries the absolute elevation in the placement (folded into
+ * the geometry's Z) and 0 in OrthogonalHeight, so keeping it is correct
+ * there; a map-absolute file that ALSO wrote a non-zero OrthogonalHeight
+ * would double-count height — the detection reads only the horizontal
+ * signature and cannot tell. The authored entity values are NOT modified —
+ * panels and exports still see the file's data.
+ */
+export function effectiveMapConversionForGeometry(
+  conversion: MapConversion,
+  mapUnitScale: number,
+  coordinateInfo: CoordinateInfo | undefined,
+): MapConversion {
+  if (!coordinateInfo) return conversion;
+  const anchorE = conversion.eastings * mapUnitScale;
+  const anchorN = conversion.northings * mapUnitScale;
+  const anchorDistance = Math.hypot(anchorE, anchorN);
+  if (!Number.isFinite(anchorDistance) || anchorDistance < MAP_ABSOLUTE_MIN_ANCHOR_METERS) {
+    return conversion;
+  }
+  const { ifcX, ifcY } = computeModelCenterInIfcMeters(coordinateInfo);
+  const centerDistance = Math.hypot(ifcX - anchorE, ifcY - anchorN);
+  if (!Number.isFinite(centerDistance) || centerDistance >= MAP_ABSOLUTE_MAX_CENTER_DISTANCE_METERS) {
+    return conversion;
+  }
+  return {
+    ...conversion,
+    eastings: 0,
+    northings: 0,
+    xAxisAbscissa: 1,
+    xAxisOrdinate: 0,
+  };
+}

--- a/apps/viewer/src/lib/geo/map-absolute.ts
+++ b/apps/viewer/src/lib/geo/map-absolute.ts
@@ -87,10 +87,16 @@ const MAP_ABSOLUTE_MAX_CENTER_DISTANCE_METERS = 10_000;
  * anchor. A compliant file keeps its geometry near the LOCAL origin, so its
  * centre is the full anchor distance away and the detection cannot fire.
  *
- * When detected, the returned conversion carries zero offsets and the
- * no-rotation axis so every consumer of the standard formula
- * `E = Eastings*mapScale + s*(a*x - o*y)` reads the geometry's absolute
- * coordinates through unchanged. `orthogonalHeight` stays authored: the
+ * When detected, the returned conversion carries zero offsets, the
+ * no-rotation axis, AND unit scale (1) so every consumer of the standard
+ * formula `E = Eastings*mapScale + s*(a*x - o*y)` reads the geometry's
+ * absolute coordinates through completely unchanged — `s` must be 1, not
+ * merely authored-and-left-alone: with eastings=0 and axis=(1,0) the formula
+ * reduces to `E = s*x`, so an authored non-unity `Scale` (e.g. a UTM point
+ * scale factor like 0.9996, or a spec unit-bridging value) would still
+ * multiply the model's FULL absolute coordinate — the offset this detection
+ * exists to zero, not the small local delta `Scale` is meant to condition.
+ * `orthogonalHeight` stays authored: the
  * #2526 file carries the absolute elevation in the placement (folded into
  * the geometry's Z) and 0 in OrthogonalHeight, so keeping it is correct
  * there; a map-absolute file that ALSO wrote a non-zero OrthogonalHeight
@@ -121,5 +127,6 @@ export function effectiveMapConversionForGeometry(
     northings: 0,
     xAxisAbscissa: 1,
     xAxisOrdinate: 0,
+    scale: 1,
   };
 }

--- a/apps/viewer/src/lib/geo/pick-to-geo.test.ts
+++ b/apps/viewer/src/lib/geo/pick-to-geo.test.ts
@@ -11,6 +11,7 @@ import {
   type MapGeoreference,
 } from './pick-to-geo.js';
 import type { EffectiveGeoreference } from './effective-georef.js';
+import type { CoordinateInfo } from '@ifc-lite/geometry';
 
 /**
  * Ground truth from the bundled `apps/viewer/public/samples/building-architecture.ifc`:
@@ -177,5 +178,73 @@ describe('hasUsableMapGeoref', () => {
       mapConversion: undefined,
     };
     assert.strictEqual(hasUsableMapGeoref(noConversion), false);
+  });
+});
+
+describe('viewerPointToProjected with map-absolute geometry (#2526)', () => {
+  // Vectorworks-style file: geometry authored at the ABSOLUTE projected
+  // coordinates (rebased into wasmRtcOffset by the wasm RTC pre-pass) while
+  // the IfcMapConversion repeats the same anchor with a 90-degree rotation.
+  // The measure readout must report the point's absolute E/N, not the anchor
+  // plus a rotated delta (which double-applies the georeference).
+  const mapAbsInfo: CoordinateInfo = {
+    originShift: { x: 0, y: 0, z: 0 },
+    originalBounds: { min: { x: -1, y: -1, z: -1 }, max: { x: 1, y: 1, z: 1 } },
+    shiftedBounds: { min: { x: -1, y: -1, z: -1 }, max: { x: 1, y: 1, z: 1 } },
+    hasLargeCoordinates: false,
+    wasmRtcOffset: { x: 312000, y: 5996150, z: 10 },
+  };
+
+  function mapAbsGeoref(coordinateInfo?: CoordinateInfo): MapGeoreference {
+    return {
+      hasGeoreference: true,
+      source: 'mapConversion',
+      projectedCRS: { id: 1, name: 'EPSG:25833', mapUnit: 'METRE', mapUnitScale: 1 },
+      mapConversion: {
+        id: 2,
+        sourceCRS: 10,
+        targetCRS: 1,
+        eastings: 312000,
+        northings: 5996150,
+        orthogonalHeight: 0,
+        xAxisAbscissa: 0,
+        xAxisOrdinate: 1,
+        scale: 1,
+      },
+      lengthUnitScale: 1,
+      coordinateInfo,
+    };
+  }
+
+  const near = (a: number, b: number, label: string) =>
+    assert.ok(Math.abs(a - b) < 1e-6, `${label}: expected ${b}, got ${a}`);
+
+  it('reads the picked point\'s ABSOLUTE map coordinates instead of double-applying the anchor + rotation', () => {
+    const eff = mapAbsGeoref(mapAbsInfo);
+    // -totalYupOffset for the fixture: rtcYup = (312000, 10, -5996150).
+    const originViewer = { x: -312000, y: -10, z: 5996150 };
+    // Viewer position of the absolute map point (E 312010, N 5996140, H 12).
+    const point = { x: 10, y: 2, z: 10 };
+    const out = viewerPointToProjected(point, eff, originViewer);
+    near(out.eastings, 312010, 'eastings');
+    near(out.northings, 5996140, 'northings');
+    near(out.height, 12, 'height');
+  });
+
+  it('control: a compliant file (geometry near the local origin) keeps the authored conversion exactly', () => {
+    const eff = mapAbsGeoref({ ...mapAbsInfo, wasmRtcOffset: undefined });
+    const out = viewerPointToProjected({ x: 3, y: 2, z: -4 }, eff, { x: 0, y: 0, z: 0 });
+    // Authored 90-degree rotation applied to the delta, anchor added:
+    // east = anchor + (a*dx + o*dz) = 312000 - 4; north = anchor + (o*dx - a*dz).
+    near(out.eastings, 311996, 'eastings');
+    near(out.northings, 5996153, 'northings');
+    near(out.height, 2, 'height');
+  });
+
+  it('control: no coordinateInfo on the georef keeps the authored conversion', () => {
+    const eff = mapAbsGeoref(undefined);
+    const out = viewerPointToProjected({ x: 3, y: 2, z: -4 }, eff, { x: 0, y: 0, z: 0 });
+    near(out.eastings, 311996, 'eastings');
+    near(out.northings, 5996153, 'northings');
   });
 });

--- a/apps/viewer/src/lib/geo/pick-to-geo.ts
+++ b/apps/viewer/src/lib/geo/pick-to-geo.ts
@@ -33,7 +33,8 @@
 
 import type { MapConversion, ProjectedCRS } from '@ifc-lite/parser';
 import { hasStandardGeoreferencing, type EffectiveGeoreference } from './effective-georef';
-import { metersToMapUnits, viewerDeltaToProjectedDelta } from './cesium-placement';
+import { getMapUnitScale, metersToMapUnits, viewerDeltaToProjectedDelta } from './cesium-placement';
+import { effectiveMapConversionForGeometry } from './map-absolute';
 
 export interface Vec3 {
   x: number;
@@ -89,7 +90,17 @@ export function viewerPointToProjected(
   eff: MapGeoreference,
   originViewer: Vec3,
 ): ProjectedPoint {
-  const { mapConversion, projectedCRS, lengthUnitScale } = eff;
+  const { projectedCRS, lengthUnitScale } = eff;
+  // Map-absolute geometry (#2526): the delta below is taken from the IFC
+  // origin, so for a file whose geometry already sits at the absolute map
+  // coordinates it IS the absolute coordinate — the neutralised conversion
+  // (zero offsets, identity rotation) reads it through, while the authored
+  // one would add the anchor again and rotate the delta by the bogus axis.
+  const mapConversion = effectiveMapConversionForGeometry(
+    eff.mapConversion,
+    getMapUnitScale(projectedCRS, lengthUnitScale),
+    eff.coordinateInfo,
+  );
   const dx = point.x - originViewer.x;
   const dy = point.y - originViewer.y;
   const dz = point.z - originViewer.z;

--- a/apps/viewer/src/lib/geo/reproject.test.ts
+++ b/apps/viewer/src/lib/geo/reproject.test.ts
@@ -9,6 +9,7 @@ import { computeCesiumModelOrigin } from './cesium-bridge.js';
 import {
   computeFootprintGeoJSON,
   computeModelCenterInIfcMeters,
+  effectiveMapConversionForGeometry,
   reprojectFromLatLon,
   reprojectionInputKey,
   reprojectPointToLatLon,
@@ -558,5 +559,153 @@ describe('reprojectionInputKey (effect dependency correctness)', () => {
     // lengthUnitScale is a non-CRS input the reprojection reads too.
     const diffLength = reprojectionInputKey(729013348.1, 9063992684.1, crs, 0.01);
     assert.notStrictEqual(diffLength, base, 'a lengthUnitScale change must change the key');
+  });
+});
+
+describe('map-absolute geometry detection (#2526 Vectorworks EPSG:25833)', () => {
+  // Shape of the issue #2526 file: Vectorworks placed the IfcSite at the
+  // ABSOLUTE map coordinates (311988180.54 mm E, 5996148564.99 mm N, 14 m up)
+  // while ALSO writing an IfcMapConversion with the same offsets (in metres)
+  // and a 90-degree XAxis rotation. The wasm RTC pre-pass rebased the huge
+  // placement, so the browser-frame CoordinateInfo carries the absolute
+  // position in wasmRtcOffset (IFC Z-up metres).
+  const vwCoordinateInfo: CoordinateInfo = {
+    originShift: { x: 0, y: 0, z: 0 },
+    originalBounds: {
+      min: { x: -29.07, y: -0.2, z: -13.68 },
+      max: { x: 5.98, y: 3.76, z: 31.68 },
+    },
+    shiftedBounds: {
+      min: { x: -29.07, y: -0.2, z: -13.68 },
+      max: { x: 5.98, y: 3.76, z: 31.68 },
+    },
+    hasLargeCoordinates: false,
+    wasmRtcOffset: { x: 312018.898, y: 5996169.654, z: 14 },
+  };
+  const vwConversion: MapConversion = {
+    id: 73,
+    sourceCRS: 41,
+    targetCRS: 71,
+    eastings: 311988.181,
+    northings: 5996148.565,
+    orthogonalHeight: 0,
+    xAxisAbscissa: 0,
+    xAxisOrdinate: 1,
+  };
+  const vwCrs: ProjectedCRS = {
+    id: 71,
+    name: 'EPSG:25833 ETRS89 / UTM zone 33N',
+    geodeticDatum: 'ETRS89',
+    mapUnit: 'METRE',
+    mapUnitScale: 1,
+  };
+
+  // Absolute model centre in IFC Z-up metres (bounds centre + rtc offset):
+  //   ifcX = -11.545 + 312018.898 = 312007.353
+  //   ifcY = -(9.0 - 5996169.654) = 5996160.654
+  const CENTER_E = 312007.353;
+  const CENTER_N = 5996160.654;
+
+  it('rebases the conversion to identity when geometry already sits at the declared map anchor', () => {
+    const effective = effectiveMapConversionForGeometry(vwConversion, 1, vwCoordinateInfo);
+    assert.strictEqual(effective.eastings, 0);
+    assert.strictEqual(effective.northings, 0);
+    assert.strictEqual(effective.xAxisAbscissa, 1);
+    assert.strictEqual(effective.xAxisOrdinate, 0);
+    // Authored height and identity fields survive untouched.
+    assert.strictEqual(effective.orthogonalHeight, vwConversion.orthogonalHeight);
+    assert.strictEqual(effective.id, vwConversion.id);
+  });
+
+  it('keeps the conversion for a compliant file whose geometry sits near the local origin', () => {
+    const compliant: CoordinateInfo = {
+      ...vwCoordinateInfo,
+      wasmRtcOffset: undefined,
+    };
+    const effective = effectiveMapConversionForGeometry(vwConversion, 1, compliant);
+    assert.strictEqual(effective, vwConversion);
+  });
+
+  it('keeps the conversion when the declared anchor is below projected-CRS magnitude', () => {
+    // Small anchor + nearby geometry centre: NOT the Vectorworks signature —
+    // rebasing here would silently drop a legitimate small offset + rotation.
+    const smallConversion: MapConversion = {
+      ...vwConversion, eastings: 2000, northings: 3000,
+    };
+    const nearAnchor: CoordinateInfo = {
+      ...vwCoordinateInfo,
+      wasmRtcOffset: { x: 2100, y: -3050, z: 0 },
+    };
+    const effective = effectiveMapConversionForGeometry(smallConversion, 1, nearAnchor);
+    assert.strictEqual(effective, smallConversion);
+  });
+
+  it('keeps the conversion without coordinateInfo', () => {
+    assert.strictEqual(effectiveMapConversionForGeometry(vwConversion, 1, undefined), vwConversion);
+  });
+
+  it('honours the map unit scale when comparing the anchor to the geometry centre', () => {
+    // Same file authored with MapUnit = MILLIMETRE: offsets 1000x larger,
+    // mapUnitScale 0.001 — the metre-space anchor is identical, so the
+    // detection must still fire.
+    const mmConversion: MapConversion = {
+      ...vwConversion,
+      eastings: 311988181,
+      northings: 5996148565,
+    };
+    const effective = effectiveMapConversionForGeometry(mmConversion, 0.001, vwCoordinateInfo);
+    assert.strictEqual(effective.eastings, 0);
+    assert.strictEqual(effective.northings, 0);
+  });
+
+  it('reprojectToLatLon lands the pin at the model, not double-transformed into the Atlantic', async () => {
+    const latLon = await reprojectToLatLon(vwConversion, vwCrs, vwCoordinateInfo, 0.001);
+    assert.ok(latLon, 'expected a lat/lon');
+    // EPSG:25833 (312007, 5996161) is Rostock, Germany: 54.079N 12.126E.
+    close(latLon.lat, 54.0791, 5e-3);
+    close(latLon.lon, 12.1261, 5e-3);
+  });
+
+  it('computeCesiumModelOrigin places the georeferenced context at the absolute centre and keeps the authored height', async () => {
+    const origin = await computeCesiumModelOrigin(vwConversion, vwCrs, vwCoordinateInfo, 0.001);
+    assert.ok(origin, 'expected an origin');
+    close(origin.easting, CENTER_E, 0.01);
+    close(origin.northing, CENTER_N, 0.01);
+    // OrthogonalHeight 0 + absolute IFC Z centre (1.78 + 14).
+    close(origin.ifcOriginHeight, 15.78, 0.01);
+  });
+
+  it('the map-pick Apply loop stays self-consistent: saving reprojectFromLatLon output and recomputing lands the pin where picked', async () => {
+    // LocationMap's Apply saves reprojectFromLatLon's E/N into the mutated
+    // MapConversion while the authored rotation stays. The invariant that
+    // must hold for a map-absolute file is NOT the shape of the intermediate
+    // values but that the recomputed pin equals the picked location — the
+    // saved anchor moves the mutated conversion out of the map-absolute
+    // detection window, so the forward math applies the authored rotation to
+    // exactly the values the inverse accounted for.
+    const picked = { lat: 54.081, lon: 12.13 };
+    const saved = await reprojectFromLatLon(picked, vwCrs, vwConversion, vwCoordinateInfo, 0.001);
+    assert.ok(saved, 'expected projected coordinates');
+    const mutated: MapConversion = {
+      ...vwConversion,
+      eastings: saved.easting,
+      northings: saved.northing,
+    };
+    const recomputed = await reprojectToLatLon(mutated, vwCrs, vwCoordinateInfo, 0.001);
+    assert.ok(recomputed, 'expected a recomputed pin');
+    close(recomputed.lat, picked.lat, 1e-6);
+    close(recomputed.lon, picked.lon, 1e-6);
+  });
+
+  it('computeFootprintGeoJSON draws the footprint around the pin instead of rotating it through the double transform', async () => {
+    const ring = await computeFootprintGeoJSON(vwConversion, vwCrs, vwCoordinateInfo, 0.001);
+    assert.ok(ring, 'expected a footprint');
+    const pin = await reprojectToLatLon(vwConversion, vwCrs, vwCoordinateInfo, 0.001);
+    assert.ok(pin);
+    for (const [lon, lat] of ring) {
+      // Every corner within ~100 m of the pin (model is ~45 m across).
+      close(lat, pin.lat, 2e-3);
+      close(lon, pin.lon, 2e-3);
+    }
   });
 });

--- a/apps/viewer/src/lib/geo/reproject.ts
+++ b/apps/viewer/src/lib/geo/reproject.ts
@@ -20,6 +20,9 @@ import type { MapConversion, ProjectedCRS } from '@ifc-lite/parser';
 import type { CoordinateInfo } from '@ifc-lite/geometry';
 import { lookupEpsgByCode } from '@ifc-lite/data';
 import { getEffectiveHorizontalScale, resolveMapUnitToMetreScale } from './geo-scale';
+import { computeModelCenterInIfcMeters, effectiveMapConversionForGeometry } from './map-absolute';
+
+export { computeModelCenterInIfcMeters, effectiveMapConversionForGeometry } from './map-absolute';
 import { resolvePrecisionDef } from './precision-grids';
 
 export interface LatLon {
@@ -387,11 +390,14 @@ export async function resolveProjection(crs: ProjectedCRS): Promise<string | nul
  *   northing = mapConversion.northings + scale * (sin*ifc_x + cos*ifc_y)
  */
 function computeProjectedCenter(
-  conversion: MapConversion,
+  rawConversion: MapConversion,
   coordinateInfo: CoordinateInfo | undefined,
   mapUnitScale: number,
   lengthUnitScale: number,
 ): { easting: number; northing: number } {
+  // Map-absolute geometry (#2526): neutralise a conversion the geometry
+  // already carries, or the offsets/rotation get applied twice.
+  const conversion = effectiveMapConversionForGeometry(rawConversion, mapUnitScale, coordinateInfo);
   const { ifcX, ifcY } = computeModelCenterInIfcMeters(coordinateInfo);
 
   // Geometry coordinates (ifcX, ifcY) are already in metres — the geometry engine
@@ -543,46 +549,6 @@ export function reprojectionInputKey(
 }
 
 /**
- * Compute the model's center in IFC Z-up metres from coordinate info.
- * This is the geometry center before MapConversion is applied.
- */
-export function computeModelCenterInIfcMeters(
-  coordinateInfo?: CoordinateInfo,
-): { ifcX: number; ifcY: number; ifcZ: number } {
-  if (!coordinateInfo) return { ifcX: 0, ifcY: 0, ifcZ: 0 };
-
-  // `shiftedBounds`, NOT `originalBounds`. The producer defines
-  // `shiftedBounds = originalBounds - originShift`
-  // (utils/localParsingUtils.ts), so `originalBounds` is ALREADY in the world
-  // frame — adding `shift` to it below would count the shift twice and put the
-  // model centre `originShift` away from where the footprint polygon
-  // (computeFootprintGeoJSON, which reads `shiftedBounds`) places the very same
-  // box. This matches the rule stated in this module's own pipeline doc above:
-  // `world_yup = bounds_center + originShift`, from the VIEWER bounds.
-  const bounds = coordinateInfo.shiftedBounds;
-  const shift = coordinateInfo.originShift;
-  const rtc = coordinateInfo.wasmRtcOffset;
-
-  const rtcYup = rtc
-    ? { x: rtc.x, y: rtc.z, z: -rtc.y }
-    : { x: 0, y: 0, z: 0 };
-
-  const cx = (bounds.min.x + bounds.max.x) / 2;
-  const cy = (bounds.min.y + bounds.max.y) / 2;
-  const cz = (bounds.min.z + bounds.max.z) / 2;
-
-  const worldYupX = cx + shift.x + rtcYup.x;
-  const worldYupY = cy + shift.y + rtcYup.y;
-  const worldYupZ = cz + shift.z + rtcYup.z;
-
-  return {
-    ifcX: worldYupX,
-    ifcY: -worldYupZ,
-    ifcZ: worldYupY,
-  };
-}
-
-/**
  * Reverse-project a WGS84 lat/lon into the IfcMapConversion eastings/northings
  * values that would place the model center at the given location.
  *
@@ -612,6 +578,17 @@ export async function reprojectFromLatLon(
     // Convert projected metres back to MapConversion's unit.
     // Geometry offsets (ifcX/Y) are already in metres.
     const mapScale = resolveMapUnitToMetreScale(crs.mapUnitScale, lengthUnitScale);
+    // Map-absolute geometry (#2526): this inverse DELIBERATELY uses the
+    // AUTHORED conversion, not `effectiveMapConversionForGeometry`. Its only
+    // consumer is the map-pick Apply flow, which SAVES the returned E/N into
+    // the mutated MapConversion while the authored rotation stays. Inverting
+    // the authored conversion keeps that loop self-consistent: the saved
+    // anchor moves the mutated conversion out of the map-absolute detection
+    // window, and the forward math then applies the authored rotation to the
+    // same values this inverse accounted for — the pin lands where picked.
+    // Inverting the NEUTRALISED conversion instead would save a near-zero
+    // anchor next to the authored rotation, un-fire the detection, and fling
+    // the model by the double-applied rotation on the very next recompute.
     const invScale = mapScale !== 0 ? 1 / mapScale : 1;
     const { ifcX, ifcY } = computeModelCenterInIfcMeters(coordinateInfo);
     // Effective horizontal scale for metre-converted geometry — see issue #595.
@@ -642,7 +619,7 @@ export async function reprojectFromLatLon(
  * @returns A single GeoJSON-compatible polygon: closed ring of [lon, lat] pairs
  */
 export async function computeFootprintGeoJSON(
-  conversion: MapConversion,
+  rawConversion: MapConversion,
   crs: ProjectedCRS,
   coordinateInfo: CoordinateInfo,
   lengthUnitScale = 1,
@@ -662,6 +639,8 @@ export async function computeFootprintGeoJSON(
 
   // Effective horizontal scale for metre-converted geometry — see issue #595.
   const mapScale = resolveMapUnitToMetreScale(crs.mapUnitScale, lengthUnitScale);
+  // Map-absolute geometry (#2526): same neutralisation as the centre pin.
+  const conversion = effectiveMapConversionForGeometry(rawConversion, mapScale, coordinateInfo);
   const scale = getEffectiveHorizontalScale(conversion.scale, mapScale, lengthUnitScale);
   const abscissa = conversion.xAxisAbscissa ?? 1.0;
   const ordinate = conversion.xAxisOrdinate ?? 0.0;

--- a/packages/geometry/src/coordinate-handler.ts
+++ b/packages/geometry/src/coordinate-handler.ts
@@ -282,6 +282,7 @@ export class CoordinateHandler {
                 max: { x: 0, y: 0, z: 0 },
             },
             hasLargeCoordinates: false,
+            ...this.wasmMetadataProps(),
         };
 
         if (meshes.length === 0) {
@@ -322,6 +323,7 @@ export class CoordinateHandler {
                 originalBounds,
                 shiftedBounds: originalBounds,
                 hasLargeCoordinates: false,
+                ...this.wasmMetadataProps(),
             };
         }
 
@@ -343,6 +345,25 @@ export class CoordinateHandler {
             originalBounds,
             shiftedBounds,
             hasLargeCoordinates: true,
+            ...this.wasmMetadataProps(),
+        };
+    }
+
+    /**
+     * World→render metadata for a returned {@link CoordinateInfo}: the
+     * length-unit scale and the RTC offset the WASM mesh path actually
+     * subtracted (see {@link setWasmMetadata}). `wasmRtcOffset` is attached
+     * only when a shift was actually applied, so `wasmRtcOffset !== undefined`
+     * keeps meaning "geometry re-based" for downstream federation / cache /
+     * georeference consumers. The batch `processMeshes` path used to DROP
+     * this metadata (only the incremental path attached it), so every sync
+     * `process()` consumer read the re-based bounds as if they were absolute
+     * — losing the site offset that georeferencing math needs (#2526).
+     */
+    private wasmMetadataProps(): Pick<CoordinateInfo, 'wasmRtcOffset' | 'lengthUnitScale'> {
+        return {
+            ...(this.appliedWasmRtcOffset ? { wasmRtcOffset: { ...this.appliedWasmRtcOffset } } : {}),
+            ...(this.lengthUnitScale !== undefined ? { lengthUnitScale: this.lengthUnitScale } : {}),
         };
     }
 
@@ -529,11 +550,7 @@ export class CoordinateHandler {
             originalBounds: { ...this.accumulatedBounds },
             shiftedBounds,
             hasLargeCoordinates,
-            // Only attach wasmRtcOffset when a shift was actually applied, so
-            // `wasmRtcOffset !== undefined` keeps meaning "geometry re-based"
-            // for downstream federation / cache consumers.
-            ...(this.appliedWasmRtcOffset ? { wasmRtcOffset: { ...this.appliedWasmRtcOffset } } : {}),
-            ...(this.lengthUnitScale !== undefined ? { lengthUnitScale: this.lengthUnitScale } : {}),
+            ...this.wasmMetadataProps(),
         };
     }
 
@@ -558,8 +575,7 @@ export class CoordinateHandler {
                 max: { x: 0, y: 0, z: 0 },
             },
             hasLargeCoordinates: false,
-            ...(this.appliedWasmRtcOffset ? { wasmRtcOffset: { ...this.appliedWasmRtcOffset } } : {}),
-            ...(this.lengthUnitScale !== undefined ? { lengthUnitScale: this.lengthUnitScale } : {}),
+            ...this.wasmMetadataProps(),
         };
     }
 

--- a/packages/geometry/src/geometry.test.ts
+++ b/packages/geometry/src/geometry.test.ts
@@ -684,6 +684,40 @@ describe('CoordinateHandler', () => {
       expect(info.wasmRtcOffset).toBeUndefined();
     });
 
+    it('surfaces the metadata on the batch processMeshes path too (#2526)', () => {
+      // The sync GeometryProcessor.process() path goes through processMeshes,
+      // not processMeshesIncremental + getFinalCoordinateInfo. Dropping the
+      // rtc offset there makes every downstream georef consumer read the
+      // rebased bounds as if they were absolute — the map-conversion math
+      // then loses the re-based site offset (height AND position).
+      handler.setWasmMetadata(0.001, { x: 312018.898, y: 5996169.654, z: 14 });
+      const info = handler.processMeshes([
+        createTestMesh({
+          expressId: 1,
+          positions: new Float32Array([0, 0, 0, 10, 10, 10]),
+        }),
+      ]);
+
+      expect(info.lengthUnitScale).toBe(0.001);
+      expect(info.wasmRtcOffset).toEqual({ x: 312018.898, y: 5996169.654, z: 14 });
+    });
+
+    it('keeps lengthUnitScale on the processMeshes large-coordinate shift branch', () => {
+      // No wasm RTC (offset null) but a known unit scale; the TS-side shift
+      // kicks in for >10km coordinates and must not drop the metadata.
+      handler.setWasmMetadata(0.001, null);
+      const info = handler.processMeshes([
+        createTestMesh({
+          expressId: 1,
+          positions: new Float32Array([20000, 20000, 0, 20010, 20010, 10]),
+        }),
+      ]);
+
+      expect(info.hasLargeCoordinates).toBe(true);
+      expect(info.lengthUnitScale).toBe(0.001);
+      expect(info.wasmRtcOffset).toBeUndefined();
+    });
+
     it('clears metadata on reset', () => {
       handler.setWasmMetadata(0.001, { x: 1, y: 2, z: 3 });
       handler.reset();


### PR DESCRIPTION
## What

Fixes #2526. A Vectorworks IFC4 file georeferenced to EPSG:25833 rendered "not located correctly" — reproduced with the reporter's file: the georeferenced pin landed at **(33.71 N, 49.12 W), the mid-Atlantic**, instead of Rostock (54.079 N, 12.126 E), and the site's 14 m elevation was lost on one load path.

## Mechanism (reproduced, not inferred)

The file has the decisive shape: **the IfcSite placement sits at the absolute map coordinates in millimetres** (E 311,988,180 mm …) *and* an `IFCMAPCONVERSION` repeats the same anchor in metres with a 90° XAxis rotation. Two independent bugs:

1. **Double georeferencing** — the wasm RTC pre-pass correctly rebases the huge placement (f32 precision is *not* the mechanism), but the MapConversion was then applied on top of geometry already in map coordinates; the 90° rotation turned the ~6,000 km northing into a huge negative easting.
2. **The batch mesh path dropped RTC metadata** — `CoordinateHandler.processMeshes` (sync consumers) lost `wasmRtcOffset`/`lengthUnitScale` that the streaming path attached, so the site offset — including its elevation — vanished (height 1.78 m instead of 15.78 m).

## How

- New `apps/viewer/src/lib/geo/map-absolute.ts`: `effectiveMapConversionForGeometry` detects the map-absolute signature (anchor > 100 km from local origin AND model centre within the RTC threshold of the anchor) and neutralises the conversion for **geometry-derived** consumers; authored entity values are untouched.
- Routed through it: pin reprojection, footprint, Cesium origin + Helmert rotation, WebGPU sun, measure-tool E/N readout, DXF export georef (forward and inverse, plus the legacy-store import path found by adversarial review), federation alignment (per model), point-cloud alignment, and both placement-gizmo delta sites — where "neutralised" for a *delta* means the identity rotation (a drag east is an easting change; offsets are provably inert for deltas).
- `reprojectFromLatLon` (map-pick Apply) deliberately keeps the authored inverse — neutralising it corrupts the georef on Apply; documented and tested as an invariant.
- `packages/geometry`: all `processMeshes` returns now attach the wasm metadata (changeset included).

After the fix, on the reporter's file: pin (54.0793, 12.1262) — Rostock — height 15.78 m, sync and streaming paths agreeing.

## Verification

- End-to-end reproduction on the actual attached file, before/after.
- RED-GREEN per consumer with map-absolute fixtures and compliant-file controls (authored conversion still applied exactly as before — every control green).
- 20 surgical mutations across detection and all call sites, zero survivors.
- Viewer 3749 pass / 0 fail (+~30 tests over the branch), geometry 325, typecheck clean.

## Honest limits (documented in-code, not silently "fixed")

- A map-absolute file that also writes a non-zero `OrthogonalHeight` **and** absolute Z would double-count height — undetectable from the horizontal signature alone.
- An applied anchor edit on a map-absolute file inside the detection window is neutralised like the pin; the map-pick Apply flow remains the sanctioned mover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Corrections (post-review, at `dd58573d4`)

1. `processMeshes` metadata attachment matters for **sync consumers**, not the viewer's own load path — the viewer streams.
2. `kmz-export` and `ifc-origin` were **not** routed through the guard at open; they are now (this round's majors).
3. Three of the routed call sites had no killing test at open; they do now (11 new tests this round).
4. The `reprojectFromLatLon` invariant is **pin self-consistency on Apply**, not CRS validity.
5. The neutralised conversion now also pins `scale: 1` — the authored scale multiplying an absolute coordinate was a residual double-transform (review's 0.9996 → ~2.4 km case).
