### PR TITLE
fix(export): merged exporter's read side — DATA strings pinned byte-opaque, detect_schema un-doubles before re-escaping

### DIFF
--- a/.changeset/merged-schema-detect-doubling.md
+++ b/.changeset/merged-schema-detect-doubling.md
@@ -1,0 +1,13 @@
+---
+"@ifc-lite/geometry": patch
+---
+
+Fixes to the STEP/IFC exporters' shared `FILE_SCHEMA` detection and header re-serialization, reached from `exportMerged` and the STEP re-export path (`ifc-lite-bridge.ts` defaults `schema` to `''`, which resolves to auto-detect on both):
+
+- `detect_schema` now scans the whole HEADER section instead of only the first 4096 bytes, so a long earlier header field (e.g. a lengthy `FILE_DESCRIPTION`) no longer pushes `FILE_SCHEMA` out of range and silently defaults the output to IFC4.
+- The `FILE_SCHEMA` search — and the HEADER-section boundary scan that bounds it — are now quote-aware, so a header string value that happens to contain the literal text `FILE_SCHEMA` or `ENDSEC;` is no longer mistaken for the real entry.
+- `detect_schema` un-doubles a `\\` in the detected label before it is re-escaped on write, so a schema label carrying a literal `\` (synthetic, but reachable through the same code path as the labels above) round-trips instead of compounding.
+- `exportMerged`'s `#`-reference rewriter now copies non-`#`-reference bytes through unchanged instead of widening each byte to a `char`, which corrupted every non-ASCII (UTF-8 multi-byte) character in a merged model's string literals.
+- `exportMerged`'s header-string escaping now maps every ASCII control byte (not just `\n`/`\r`/`\t`) to a space, matching the STEP exporter and ISO 10303-21's basic graphic range.
+
+`merged.rs`'s private forks of `detect_schema` and `escape` are removed; it now shares the hardened primitives in `step_text.rs` with the STEP exporter.

--- a/rust/export/src/merged.rs
+++ b/rust/export/src/merged.rs
@@ -58,7 +58,18 @@ fn detect_schema(content: &[u8]) -> String {
             if let Some(q2) = r[q1 + 1..].find('\'') {
                 let l = &r[q1 + 1..q1 + 1 + q2];
                 if !l.is_empty() {
-                    return l.to_string();
+                    // `l` is the RAW, still-STEP-escaped slice between the
+                    // first two quotes (the doubled-apostrophe case is a
+                    // separate, already-tracked quote-scanning bound: see
+                    // fix/merged-detect-schema-quote2). It is about to be
+                    // fed straight into `escape()` when the header is
+                    // re-written, which doubles `\` again -- un-double it
+                    // here first so a schema label carrying a literal `\`
+                    // round-trips instead of being re-escaped on top of
+                    // its own escaping. A no-op for every real schema
+                    // label (IFC2X3, IFC4, IFC4X3_ADD2, ...), none of
+                    // which contain a backslash.
+                    return l.replace("\\\\", "\\");
                 }
             }
         }
@@ -182,168 +193,5 @@ pub fn export_merged_with_stats(models: &[&[u8]], opts: &MergedOptions) -> (Stri
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn fixture(rel: &str) -> Vec<u8> {
-        let path = format!("{}/../../tests/models/{}", env!("CARGO_MANIFEST_DIR"), rel);
-        std::fs::read(&path).unwrap_or_else(|e| panic!("read {path}: {e}"))
-    }
-
-    fn scan_ids(step: &str) -> Vec<u32> {
-        let bytes = step.as_bytes();
-        let mut ids = Vec::new();
-        let mut scanner = EntityScanner::new(bytes);
-        while let Some((id, _t, _s, _e)) = scanner.next_entity() {
-            ids.push(id);
-        }
-        ids
-    }
-
-    #[test]
-    fn merge_two_models_unifies_project_and_offsets_ids() {
-        let a = fixture("ara3d/duplex.ifc");
-        let single = scan_ids(&String::from_utf8_lossy(&a)).len();
-
-        let (merged, stats) = export_merged_with_stats(&[&a, &a], &MergedOptions::default());
-        assert_eq!(stats.models, 2);
-
-        let ids = scan_ids(&merged);
-        // Every express id is unique after offsetting (no collisions across models).
-        let mut sorted = ids.clone();
-        sorted.sort_unstable();
-        sorted.dedup();
-        assert_eq!(sorted.len(), ids.len(), "ids are globally unique after merge");
-
-        // Exactly one IfcProject survives (second model's was dropped + redirected).
-        let projects = merged.lines().filter(|l| l.contains("=IFCPROJECT(")).count();
-        assert_eq!(projects, 1, "single unified project");
-
-        // Two models minus one dropped project ≈ 2*single - 1 entities.
-        assert_eq!(stats.written, single * 2 - 1);
-
-        // No dangling references: every #ref resolves to a written id.
-        let idset: std::collections::HashSet<u32> = ids.into_iter().collect();
-        for line in merged.lines().filter(|l| l.starts_with('#')) {
-            // collect refs after the leading id
-            let body = &line[1..];
-            let after_eq = body.find('=').map(|e| &body[e..]).unwrap_or(body);
-            let mut i = 0;
-            let bytes = after_eq.as_bytes();
-            let mut in_str = false;
-            while i < bytes.len() {
-                let c = bytes[i];
-                if c == b'\'' {
-                    in_str = !in_str;
-                } else if !in_str && c == b'#' {
-                    let mut j = i + 1;
-                    let mut n = 0u32;
-                    let mut any = false;
-                    while j < bytes.len() && bytes[j].is_ascii_digit() {
-                        n = n * 10 + (bytes[j] - b'0') as u32;
-                        j += 1;
-                        any = true;
-                    }
-                    if any {
-                        assert!(idset.contains(&n), "dangling ref #{n}");
-                        i = j;
-                        continue;
-                    }
-                }
-                i += 1;
-            }
-        }
-    }
-    /// ISO 10303-21 doubles two characters inside a string literal: the
-    /// apostrophe (already handled) and the reverse solidus (the bug this
-    /// pins). `escape()` is the funnel every header string literal in this
-    /// exporter goes through, so this test is the RED/GREEN pin for the
-    /// write-side half of the doubling-escape gap in the merged exporter.
-    #[test]
-    fn escape_doubles_backslash_like_apostrophe() {
-        assert_eq!(escape(r"C:\temp"), r"C:\\temp");
-        assert_eq!(escape(r"a\b\c"), r"a\\b\\c");
-    }
-
-    #[test]
-    fn escape_doubles_both_escapes_in_the_same_string_in_source_order() {
-        assert_eq!(escape(r"O'Brien\Docs"), r"O''Brien\\Docs");
-        assert_eq!(escape(r"\Docs\O'Brien"), r"\\Docs\\O''Brien");
-    }
-
-    #[test]
-    fn escape_no_special_chars_is_byte_identical() {
-        // Bounding control: plain ASCII with no quote/backslash/control chars
-        // must pass through unchanged.
-        for s in ["plain", "IFC4", "ifc-lite", "123-abc_DEF"] {
-            assert_eq!(escape(s), s);
-        }
-    }
-
-    /// End-to-end write-side check for the ISO 10303-21 doubling escapes, on
-    /// the header fields `escape()` actually feeds (FILE_NAME's application
-    /// field). Applies the spec's un-doubling rule directly to the raw
-    /// written bytes: a run of backslashes with an ODD length is malformed
-    /// (a real reader can't tell whether a lone `\` starts an escape
-    /// directive or is meant literally), so this panics rather than
-    /// silently accepting under-escaped output.
-    #[test]
-    fn header_fields_round_trip_apostrophe_and_backslash_per_spec() {
-        fn spec_unescape(quoted_body: &str) -> String {
-            let mut out = String::with_capacity(quoted_body.len());
-            let bytes = quoted_body.as_bytes();
-            let mut i = 0;
-            while i < bytes.len() {
-                if bytes[i] == b'\'' {
-                    assert_eq!(
-                        bytes.get(i + 1),
-                        Some(&b'\''),
-                        "malformed STEP literal: un-doubled apostrophe at byte {i} in {quoted_body:?}"
-                    );
-                    out.push('\'');
-                    i += 2;
-                } else if bytes[i] == b'\\' {
-                    let mut run = 0usize;
-                    while bytes.get(i + run) == Some(&b'\\') {
-                        run += 1;
-                    }
-                    assert_eq!(
-                        run % 2,
-                        0,
-                        "malformed STEP literal: odd-length ({run}) backslash run at byte {i} in {quoted_body:?} -- a real reader can't tell whether this is a doubled reverse solidus or the start of an escape directive"
-                    );
-                    for _ in 0..run / 2 {
-                        out.push('\\');
-                    }
-                    i += run;
-                } else {
-                    out.push(bytes[i] as char);
-                    i += 1;
-                }
-            }
-            out
-        }
-
-        let opts = MergedOptions {
-            schema: Some("IFC4".to_string()),
-            description: "ViewDefinition [CoordinationView]".to_string(),
-            application: r"O'Brien\Docs\ifc-lite".to_string(),
-        };
-        let a = fixture("ara3d/duplex.ifc");
-        let (step, _stats) = export_merged_with_stats(&[&a], &opts);
-
-        // Pull the quoted application field out of
-        // FILE_NAME('','',(''),(''),'<app>','ifc-lite-export','');
-        let line = step
-            .lines()
-            .find(|l| l.starts_with("FILE_NAME("))
-            .expect("a FILE_NAME header line");
-        let start_marker = "(''),'";
-        let end_marker = "','ifc-lite-export'";
-        let q0 = line.find(start_marker).expect("app field start") + start_marker.len();
-        let q1 = line.rfind(end_marker).expect("app field terminator");
-        let raw_app = &line[q0..q1];
-
-        assert_eq!(spec_unescape(raw_app), opts.application);
-    }
-}
+#[path = "merged_tests.rs"]
+mod tests;

--- a/rust/export/src/merged.rs
+++ b/rust/export/src/merged.rs
@@ -9,6 +9,7 @@
 //! valid `IfcProject` tree. Deeper shared-infrastructure dedup (units, contexts) and
 //! spatial unification by name/elevation are the P2 follow-on.
 
+use crate::step_text::{detect_schema, escape};
 use ifc_lite_core::EntityScanner;
 
 /// Options for merged export.
@@ -34,49 +35,6 @@ pub struct MergedStats {
     pub written: usize,
 }
 
-fn escape(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    for c in s.chars() {
-        match c {
-            // ISO 10303-21 doubles both the apostrophe and the reverse
-            // solidus inside a string literal; each is independent of the
-            // other (order in the source string is preserved as-is).
-            '\'' => out.push_str("''"),
-            '\\' => out.push_str("\\\\"),
-            '\n' | '\r' | '\t' => out.push(' '),
-            _ => out.push(c),
-        }
-    }
-    out
-}
-
-fn detect_schema(content: &[u8]) -> String {
-    let head = String::from_utf8_lossy(&content[..content.len().min(4096)]);
-    if let Some(i) = head.find("FILE_SCHEMA") {
-        let r = &head[i..];
-        if let Some(q1) = r.find('\'') {
-            if let Some(q2) = r[q1 + 1..].find('\'') {
-                let l = &r[q1 + 1..q1 + 1 + q2];
-                if !l.is_empty() {
-                    // `l` is the RAW, still-STEP-escaped slice between the
-                    // first two quotes (the doubled-apostrophe case is a
-                    // separate, already-tracked quote-scanning bound: see
-                    // fix/merged-detect-schema-quote2). It is about to be
-                    // fed straight into `escape()` when the header is
-                    // re-written, which doubles `\` again -- un-double it
-                    // here first so a schema label carrying a literal `\`
-                    // round-trips instead of being re-escaped on top of
-                    // its own escaping. A no-op for every real schema
-                    // label (IFC2X3, IFC4, IFC4X3_ADD2, ...), none of
-                    // which contain a backslash.
-                    return l.replace("\\\\", "\\");
-                }
-            }
-        }
-    }
-    "IFC4".to_string()
-}
-
 /// First `IfcProject` express id in a model, if any.
 fn find_project(content: &[u8]) -> Option<u32> {
     let mut scanner = EntityScanner::new(content);
@@ -90,16 +48,21 @@ fn find_project(content: &[u8]) -> Option<u32> {
 
 /// Rewrite every `#N` in a STEP entity line. `remap(n)` returns `Some(absolute_id)` to
 /// redirect a reference (no offset), or `None` to apply `offset`. Single-quoted strings
-/// are left untouched (a `#` there is literal text).
+/// are left untouched (a `#` there is literal text) -- and, crucially, passed through as
+/// raw bytes: `#`-ref scanning only needs to track in/out-of-string state (via the same
+/// doubled-apostrophe toggle the STEP escape rule guarantees nets to a no-op), never to
+/// decode string content. Everything outside a `#`-ref match is copied byte-for-byte, so a
+/// multi-byte UTF-8 sequence (or any other non-ASCII byte run) in a DATA-section literal
+/// survives unchanged instead of being Latin-1-expanded one byte at a time.
 fn rewrite_refs(line: &[u8], offset: u32, remap: &impl Fn(u32) -> Option<u32>) -> String {
-    let mut out = String::with_capacity(line.len() + 8);
+    let mut out: Vec<u8> = Vec::with_capacity(line.len() + 8);
     let mut i = 0;
     let mut in_string = false;
     while i < line.len() {
         let b = line[i];
         if b == b'\'' {
             in_string = !in_string;
-            out.push('\'');
+            out.push(b'\'');
             i += 1;
             continue;
         }
@@ -114,16 +77,20 @@ fn rewrite_refs(line: &[u8], offset: u32, remap: &impl Fn(u32) -> Option<u32>) -
             }
             if any {
                 let target = remap(n).unwrap_or(n.wrapping_add(offset));
-                out.push('#');
-                out.push_str(&target.to_string());
+                out.push(b'#');
+                out.extend_from_slice(target.to_string().as_bytes());
                 i = j;
                 continue;
             }
         }
-        out.push(b as char);
+        out.push(b);
         i += 1;
     }
-    out
+    // `line` is a byte slice straight out of the source model with no
+    // guarantee of valid UTF-8 (e.g. a Latin-1-encoded IFC file); fall back
+    // to lossy replacement only for genuinely invalid sequences, matching
+    // `step.rs`'s `String::from_utf8_lossy` treatment of raw entity lines.
+    String::from_utf8_lossy(&out).into_owned()
 }
 
 /// Merge `models` (raw IFC byte slices) into one STEP/IFC string.

--- a/rust/export/src/merged_tests.rs
+++ b/rust/export/src/merged_tests.rs
@@ -76,30 +76,77 @@ fn merge_two_models_unifies_project_and_offsets_ids() {
         }
     }
 }
-/// ISO 10303-21 doubles two characters inside a string literal: the
-/// apostrophe (already handled) and the reverse solidus (the bug this
-/// pins). `escape()` is the funnel every header string literal in this
-/// exporter goes through, so this test is the RED/GREEN pin for the
-/// write-side half of the doubling-escape gap in the merged exporter.
+// `escape()` and `detect_schema()` are no longer private forks of this
+// module: `merged.rs` imports both from `step_text.rs` (the same primitives
+// `step.rs` uses), so their unit coverage lives in `step_text_tests.rs`
+// (including the control-char mapping and the 4096-byte-cutoff /
+// quote-blind FILE_SCHEMA-scan fixes that this module used to lack). What
+// remains here is `merged.rs`-specific: that the shared primitives are
+// actually wired into the merged export path end-to-end.
+
+/// Scenario from the maintainer's review: a header field (FILE_DESCRIPTION)
+/// long enough to push FILE_SCHEMA past the old 4096-byte cutoff must still
+/// resolve the real schema through the merged export path, not silently
+/// fall back to the IFC4 default.
 #[test]
-fn escape_doubles_backslash_like_apostrophe() {
-    assert_eq!(escape(r"C:\temp"), r"C:\\temp");
-    assert_eq!(escape(r"a\b\c"), r"a\\b\\c");
+fn merge_detects_schema_past_the_old_4096_byte_cutoff() {
+    let padding = "x".repeat(5000);
+    let content = format!(
+        "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION(('{padding}'),'2;1');\nFILE_SCHEMA(('IFC2X3'));\nENDSEC;\nDATA;\n#1=IFCPROJECT('guid',$,$,$,$,$,$,$,$);\nENDSEC;\nEND-ISO-10303-21;\n"
+    );
+    assert!(
+        content.len() > 4096,
+        "test fixture must exceed the old 4096-byte cutoff"
+    );
+    let (merged, _stats) =
+        export_merged_with_stats(&[content.as_bytes()], &MergedOptions::default());
+    let schema_line = merged
+        .lines()
+        .find(|l| l.starts_with("FILE_SCHEMA("))
+        .expect("a FILE_SCHEMA header line");
+    assert_eq!(schema_line, "FILE_SCHEMA(('IFC2X3'));");
 }
 
+/// Scenario from the maintainer's review: a header field whose string VALUE
+/// happens to contain the literal text `FILE_SCHEMA` must not be mistaken
+/// for the real entry by a quote-blind scan.
 #[test]
-fn escape_doubles_both_escapes_in_the_same_string_in_source_order() {
-    assert_eq!(escape(r"O'Brien\Docs"), r"O''Brien\\Docs");
-    assert_eq!(escape(r"\Docs\O'Brien"), r"\\Docs\\O''Brien");
+fn merge_ignores_file_schema_literal_text_inside_a_quoted_header_string() {
+    let content = "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION(('mentions FILE_SCHEMA in passing'),'2;1');\nFILE_SCHEMA(('IFC4X3'));\nENDSEC;\nDATA;\n#1=IFCPROJECT('guid',$,$,$,$,$,$,$,$);\nENDSEC;\nEND-ISO-10303-21;\n";
+    let (merged, _stats) =
+        export_merged_with_stats(&[content.as_bytes()], &MergedOptions::default());
+    let schema_line = merged
+        .lines()
+        .find(|l| l.starts_with("FILE_SCHEMA("))
+        .expect("a FILE_SCHEMA header line");
+    assert_eq!(schema_line, "FILE_SCHEMA(('IFC4X3'));");
 }
 
+/// Scenario from the maintainer's review: a header field carrying a raw C0
+/// control byte (outside the ISO 10303-21 basic graphic range 32-126) must
+/// be mapped to a space, not written raw into the STEP literal. Only \n \r
+/// \t were mapped before merged.rs picked up the shared `step_text::escape`.
 #[test]
-fn escape_no_special_chars_is_byte_identical() {
-    // Bounding control: plain ASCII with no quote/backslash/control chars
-    // must pass through unchanged.
-    for s in ["plain", "IFC4", "ifc-lite", "123-abc_DEF"] {
-        assert_eq!(escape(s), s);
-    }
+fn merge_maps_raw_control_bytes_in_header_fields_to_a_space() {
+    let opts = MergedOptions {
+        schema: Some("IFC4".to_string()),
+        description: "ViewDefinition [CoordinationView]".to_string(),
+        application: "app\u{07}bell\u{0B}vt".to_string(),
+    };
+    let content = "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\nFILE_NAME('','',(''),(''),'','','');\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n#1=IFCPROJECT('guid',$,$,$,$,$,$,$,$);\nENDSEC;\nEND-ISO-10303-21;\n";
+    let (merged, _stats) = export_merged_with_stats(&[content.as_bytes()], &opts);
+    let file_name_line = merged
+        .lines()
+        .find(|l| l.starts_with("FILE_NAME("))
+        .expect("a FILE_NAME header line");
+    assert!(
+        !file_name_line.contains('\u{07}') && !file_name_line.contains('\u{0B}'),
+        "raw control bytes must not reach the STEP literal: {file_name_line:?}"
+    );
+    assert_eq!(
+        file_name_line,
+        "FILE_NAME('','',(''),(''),'app bell vt','ifc-lite-export','');"
+    );
 }
 
 /// End-to-end write-side check for the ISO 10303-21 doubling escapes, on
@@ -200,22 +247,45 @@ fn data_section_string_literal_round_trips_every_escape_shape_byte_for_byte() {
     );
 }
 
-/// `detect_schema` extracts the RAW (still STEP-escaped) text between the
-/// first two apostrophes following `FILE_SCHEMA`. That text is then fed
-/// straight into `escape()` when the header is re-written, which doubles
-/// `\` again -- so `detect_schema` must un-double `\\` itself first, or a
-/// schema label carrying a literal `\` would round-trip corrupted (four
-/// backslashes out for two in). No real schema label (IFC2X3, IFC4,
-/// IFC4X3_ADD2, ...) contains a backslash, so this never fires on a real
-/// file; this test proves the un-double -> re-escape seam is correct with
-/// a synthetic label, since the review that prompted this file flagged the
-/// mechanism as a documented-but-unfixed bound in #2408.
-///
-/// (The doubled-*apostrophe* half of this same raw-extraction gap is a
-/// separate, already-tracked defect -- a naive quote-blind scan, not a
-/// doubling/un-doubling mismatch -- fixed by unifying onto
-/// `step_text::detect_schema()` on the unmerged
-/// fix/merged-detect-schema-quote2 branch; out of scope here.)
+/// The ASCII-only pin above cannot see a real corruption class: `rewrite_refs`
+/// used to build its output with `out.push(b as char)`, a byte->char cast
+/// that Latin-1-expands every raw byte >= 0x80. A UTF-8 multi-byte sequence
+/// in a DATA-section literal (e.g. non-ASCII text in an `IfcLabel`) would
+/// come out mojibaked even though the PR's "byte-opaque" claim promised
+/// otherwise. Reproduces the maintainer's exact failure scenario.
+#[test]
+fn data_section_string_literal_round_trips_non_ascii_utf8_byte_for_byte() {
+    let name_literal = "Größe 中"; // exact repro string from the review
+    let content = format!(
+        "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\nFILE_NAME('','',(''),(''),'','','');\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n#1=IFCPROJECT('guid',$,'{name_literal}',$,$,$,$,$,$);\nENDSEC;\nEND-ISO-10303-21;\n"
+    );
+
+    let (merged, _stats) =
+        export_merged_with_stats(&[content.as_bytes()], &MergedOptions::default());
+
+    let expected_line = format!("#1=IFCPROJECT('guid',$,'{name_literal}',$,$,$,$,$,$);");
+    let actual_line = merged
+        .lines()
+        .find(|l| l.starts_with("#1="))
+        .expect("the IFCPROJECT data line");
+    assert_eq!(
+        actual_line, expected_line,
+        "non-ASCII UTF-8 bytes in a DATA-section literal must not be mojibaked"
+    );
+}
+
+/// `detect_schema` (now the shared `step_text::detect_schema`, imported
+/// rather than forked in this module) extracts the RAW (still
+/// STEP-escaped) text between the first two apostrophes following
+/// `FILE_SCHEMA`. That text is then fed straight into `escape()` when the
+/// header is re-written, which doubles `\` again -- so `detect_schema`
+/// must un-double `\\` itself first, or a schema label carrying a literal
+/// `\` would round-trip corrupted (four backslashes out for two in). No
+/// real schema label (IFC2X3, IFC4, IFC4X3_ADD2, ...) contains a
+/// backslash, so this never fires on a real file; this test proves the
+/// un-double -> re-escape seam is correct with a synthetic label, exercised
+/// here through the merged export path (the primitive itself is pinned in
+/// `step_text_tests.rs`, including its `export_step` counterpart).
 #[test]
 fn detect_schema_un_doubles_backslash_before_escape_re_doubles_it() {
     // A schema label no real file would ever carry, built solely to

--- a/rust/export/src/merged_tests.rs
+++ b/rust/export/src/merged_tests.rs
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: MPL-2.0
+//! Tests for `merged.rs`, split out under the house pattern (AGENTS.md).
+//!
+//! Moved out so the production module stays under the module-size ratchet
+//! (`rust/processing/tests/module_size_ratchet.rs`); this file is exempt via
+//! the `_tests.rs` suffix convention.
+
+use super::*;
+
+fn fixture(rel: &str) -> Vec<u8> {
+    let path = format!("{}/../../tests/models/{}", env!("CARGO_MANIFEST_DIR"), rel);
+    std::fs::read(&path).unwrap_or_else(|e| panic!("read {path}: {e}"))
+}
+
+fn scan_ids(step: &str) -> Vec<u32> {
+    let bytes = step.as_bytes();
+    let mut ids = Vec::new();
+    let mut scanner = EntityScanner::new(bytes);
+    while let Some((id, _t, _s, _e)) = scanner.next_entity() {
+        ids.push(id);
+    }
+    ids
+}
+
+#[test]
+fn merge_two_models_unifies_project_and_offsets_ids() {
+    let a = fixture("ara3d/duplex.ifc");
+    let single = scan_ids(&String::from_utf8_lossy(&a)).len();
+
+    let (merged, stats) = export_merged_with_stats(&[&a, &a], &MergedOptions::default());
+    assert_eq!(stats.models, 2);
+
+    let ids = scan_ids(&merged);
+    // Every express id is unique after offsetting (no collisions across models).
+    let mut sorted = ids.clone();
+    sorted.sort_unstable();
+    sorted.dedup();
+    assert_eq!(sorted.len(), ids.len(), "ids are globally unique after merge");
+
+    // Exactly one IfcProject survives (second model's was dropped + redirected).
+    let projects = merged.lines().filter(|l| l.contains("=IFCPROJECT(")).count();
+    assert_eq!(projects, 1, "single unified project");
+
+    // Two models minus one dropped project ≈ 2*single - 1 entities.
+    assert_eq!(stats.written, single * 2 - 1);
+
+    // No dangling references: every #ref resolves to a written id.
+    let idset: std::collections::HashSet<u32> = ids.into_iter().collect();
+    for line in merged.lines().filter(|l| l.starts_with('#')) {
+        // collect refs after the leading id
+        let body = &line[1..];
+        let after_eq = body.find('=').map(|e| &body[e..]).unwrap_or(body);
+        let mut i = 0;
+        let bytes = after_eq.as_bytes();
+        let mut in_str = false;
+        while i < bytes.len() {
+            let c = bytes[i];
+            if c == b'\'' {
+                in_str = !in_str;
+            } else if !in_str && c == b'#' {
+                let mut j = i + 1;
+                let mut n = 0u32;
+                let mut any = false;
+                while j < bytes.len() && bytes[j].is_ascii_digit() {
+                    n = n * 10 + (bytes[j] - b'0') as u32;
+                    j += 1;
+                    any = true;
+                }
+                if any {
+                    assert!(idset.contains(&n), "dangling ref #{n}");
+                    i = j;
+                    continue;
+                }
+            }
+            i += 1;
+        }
+    }
+}
+/// ISO 10303-21 doubles two characters inside a string literal: the
+/// apostrophe (already handled) and the reverse solidus (the bug this
+/// pins). `escape()` is the funnel every header string literal in this
+/// exporter goes through, so this test is the RED/GREEN pin for the
+/// write-side half of the doubling-escape gap in the merged exporter.
+#[test]
+fn escape_doubles_backslash_like_apostrophe() {
+    assert_eq!(escape(r"C:\temp"), r"C:\\temp");
+    assert_eq!(escape(r"a\b\c"), r"a\\b\\c");
+}
+
+#[test]
+fn escape_doubles_both_escapes_in_the_same_string_in_source_order() {
+    assert_eq!(escape(r"O'Brien\Docs"), r"O''Brien\\Docs");
+    assert_eq!(escape(r"\Docs\O'Brien"), r"\\Docs\\O''Brien");
+}
+
+#[test]
+fn escape_no_special_chars_is_byte_identical() {
+    // Bounding control: plain ASCII with no quote/backslash/control chars
+    // must pass through unchanged.
+    for s in ["plain", "IFC4", "ifc-lite", "123-abc_DEF"] {
+        assert_eq!(escape(s), s);
+    }
+}
+
+/// End-to-end write-side check for the ISO 10303-21 doubling escapes, on
+/// the header fields `escape()` actually feeds (FILE_NAME's application
+/// field). Applies the spec's un-doubling rule directly to the raw
+/// written bytes: a run of backslashes with an ODD length is malformed
+/// (a real reader can't tell whether a lone `\` starts an escape
+/// directive or is meant literally), so this panics rather than
+/// silently accepting under-escaped output.
+#[test]
+fn header_fields_round_trip_apostrophe_and_backslash_per_spec() {
+    fn spec_unescape(quoted_body: &str) -> String {
+        let mut out = String::with_capacity(quoted_body.len());
+        let bytes = quoted_body.as_bytes();
+        let mut i = 0;
+        while i < bytes.len() {
+            if bytes[i] == b'\'' {
+                assert_eq!(
+                    bytes.get(i + 1),
+                    Some(&b'\''),
+                    "malformed STEP literal: un-doubled apostrophe at byte {i} in {quoted_body:?}"
+                );
+                out.push('\'');
+                i += 2;
+            } else if bytes[i] == b'\\' {
+                let mut run = 0usize;
+                while bytes.get(i + run) == Some(&b'\\') {
+                    run += 1;
+                }
+                assert_eq!(
+                    run % 2,
+                    0,
+                    "malformed STEP literal: odd-length ({run}) backslash run at byte {i} in {quoted_body:?} -- a real reader can't tell whether this is a doubled reverse solidus or the start of an escape directive"
+                );
+                for _ in 0..run / 2 {
+                    out.push('\\');
+                }
+                i += run;
+            } else {
+                out.push(bytes[i] as char);
+                i += 1;
+            }
+        }
+        out
+    }
+
+    let opts = MergedOptions {
+        schema: Some("IFC4".to_string()),
+        description: "ViewDefinition [CoordinationView]".to_string(),
+        application: r"O'Brien\Docs\ifc-lite".to_string(),
+    };
+    let a = fixture("ara3d/duplex.ifc");
+    let (step, _stats) = export_merged_with_stats(&[&a], &opts);
+
+    // Pull the quoted application field out of
+    // FILE_NAME('','',(''),(''),'<app>','ifc-lite-export','');
+    let line = step
+        .lines()
+        .find(|l| l.starts_with("FILE_NAME("))
+        .expect("a FILE_NAME header line");
+    let start_marker = "(''),'";
+    let end_marker = "','ifc-lite-export'";
+    let q0 = line.find(start_marker).expect("app field start") + start_marker.len();
+    let q1 = line.rfind(end_marker).expect("app field terminator");
+    let raw_app = &line[q0..q1];
+
+    assert_eq!(spec_unescape(raw_app), opts.application);
+}
+
+/// Round-trip pin: a DATA-section string literal carrying every STEP
+/// escape shape (a doubled apostrophe `''`, a doubled reverse solidus
+/// `\\`, and a `\X2\...\X0\` UCS-2 directive) must survive the merged
+/// exporter byte-for-byte. `rewrite_refs` treats string content as
+/// opaque bytes -- it only tracks in/out-of-string state (via the same
+/// doubled-apostrophe toggle trick as the scanner) to protect `#`
+/// references from being rewritten inside a literal -- so it must never
+/// decode, re-encode, or otherwise touch the literal's bytes.
+#[test]
+fn data_section_string_literal_round_trips_every_escape_shape_byte_for_byte() {
+    // \X2\0041\X0\ is the UCS-2 directive for 'A'; combined with a
+    // doubled apostrophe and a doubled reverse solidus this exercises
+    // all three escape shapes named in the review discussion.
+    let name_literal = r"O''Brien\\Docs\X2\0041\X0\";
+    let content = format!(
+        "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\nFILE_NAME('','',(''),(''),'','','');\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n#1=IFCPROJECT('guid',$,'{name_literal}',$,$,$,$,$,$);\nENDSEC;\nEND-ISO-10303-21;\n"
+    );
+
+    let (merged, _stats) = export_merged_with_stats(&[content.as_bytes()], &MergedOptions::default());
+
+    let expected_line = format!("#1=IFCPROJECT('guid',$,'{name_literal}',$,$,$,$,$,$);");
+    let actual_line = merged
+        .lines()
+        .find(|l| l.starts_with("#1="))
+        .expect("the IFCPROJECT data line");
+    assert_eq!(
+        actual_line, expected_line,
+        "DATA-section string literal must pass through byte-for-byte, undecoded and unre-encoded"
+    );
+}
+
+/// `detect_schema` extracts the RAW (still STEP-escaped) text between the
+/// first two apostrophes following `FILE_SCHEMA`. That text is then fed
+/// straight into `escape()` when the header is re-written, which doubles
+/// `\` again -- so `detect_schema` must un-double `\\` itself first, or a
+/// schema label carrying a literal `\` would round-trip corrupted (four
+/// backslashes out for two in). No real schema label (IFC2X3, IFC4,
+/// IFC4X3_ADD2, ...) contains a backslash, so this never fires on a real
+/// file; this test proves the un-double -> re-escape seam is correct with
+/// a synthetic label, since the review that prompted this file flagged the
+/// mechanism as a documented-but-unfixed bound in #2408.
+///
+/// (The doubled-*apostrophe* half of this same raw-extraction gap is a
+/// separate, already-tracked defect -- a naive quote-blind scan, not a
+/// doubling/un-doubling mismatch -- fixed by unifying onto
+/// `step_text::detect_schema()` on the unmerged
+/// fix/merged-detect-schema-quote2 branch; out of scope here.)
+#[test]
+fn detect_schema_un_doubles_backslash_before_escape_re_doubles_it() {
+    // A schema label no real file would ever carry, built solely to
+    // exercise the detect_schema -> escape() seam.
+    let source = "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\nFILE_NAME('','',(''),(''),'','','');\nFILE_SCHEMA(('IFC\\\\4'));\nENDSEC;\nDATA;\nENDSEC;\nEND-ISO-10303-21;\n";
+
+    // detect_schema un-doubles the raw slice's backslash run before
+    // returning: the two-backslash STEP encoding of a single literal
+    // backslash comes back decoded to one backslash.
+    assert_eq!(detect_schema(source.as_bytes()), "IFC\\4");
+
+    let (merged, _stats) =
+        export_merged_with_stats(&[source.as_bytes()], &MergedOptions::default());
+    let schema_line = merged
+        .lines()
+        .find(|l| l.starts_with("FILE_SCHEMA("))
+        .expect("a FILE_SCHEMA header line");
+
+    // escape() re-doubles the now-decoded single backslash back to two,
+    // matching what was in the source: the header round-trips instead of
+    // compounding.
+    assert_eq!(schema_line, "FILE_SCHEMA(('IFC\\\\4'));");
+}

--- a/rust/export/src/step_text.rs
+++ b/rust/export/src/step_text.rs
@@ -82,7 +82,17 @@ pub(crate) fn detect_schema(content: &[u8]) -> String {
             if let Some(q2) = rest[q1 + 1..].find('\'') {
                 let label = &rest[q1 + 1..q1 + 1 + q2];
                 if !label.is_empty() {
-                    return label.to_string();
+                    // `label` is the RAW, still-STEP-escaped slice between
+                    // the quotes. Both call sites (`step.rs`'s
+                    // `source_schema` fallback and `merged.rs`) feed this
+                    // straight into `escape()` when the header is
+                    // re-written, which doubles `\` again -- un-double it
+                    // here first so a schema label carrying a literal `\`
+                    // round-trips instead of being re-escaped on top of
+                    // its own escaping. A no-op for every real schema
+                    // label (IFC2X3, IFC4, IFC4X3_ADD2, ...), none of
+                    // which contain a backslash.
+                    return label.replace("\\\\", "\\");
                 }
             }
         }

--- a/rust/export/src/step_text_tests.rs
+++ b/rust/export/src/step_text_tests.rs
@@ -66,6 +66,43 @@ fn detect_schema_handles_doubled_apostrophe_escape_before_the_real_endsec() {
     assert_eq!(detect_schema(content.as_bytes()), "IFC2X3");
 }
 
+/// `detect_schema` extracts the RAW (still STEP-escaped) text between the
+/// first two apostrophes following `FILE_SCHEMA`. Both `step.rs`'s
+/// `source_schema` fallback and `merged.rs` feed that text straight into
+/// `escape()` when the header is re-written, which doubles `\` again -- so
+/// `detect_schema` must un-double `\\` itself first, or a schema label
+/// carrying a literal `\` would round-trip corrupted (four backslashes out
+/// for two in). No real schema label (IFC2X3, IFC4, IFC4X3_ADD2, ...)
+/// contains a backslash, so this never fires on a real file; this test pins
+/// the un-double -> re-escape seam with a synthetic label.
+#[test]
+fn detect_schema_un_doubles_backslash_before_escape_re_doubles_it() {
+    let source = "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\nFILE_NAME('','',(''),(''),'','','');\nFILE_SCHEMA(('IFC\\\\4'));\nENDSEC;\nDATA;\nENDSEC;\nEND-ISO-10303-21;\n";
+    assert_eq!(detect_schema(source.as_bytes()), "IFC\\4");
+}
+
+/// End-to-end scenario for the same seam through the real `export_step`
+/// path: a source file whose `FILE_SCHEMA` label carries a literal `\`,
+/// exported with no explicit target schema (so `step.rs:196` falls back to
+/// `source_schema` and `step.rs:217` re-escapes it), must round-trip the
+/// label instead of compounding the escape.
+#[test]
+fn export_step_round_trips_a_backslash_carrying_schema_label_through_source_schema_fallback() {
+    use crate::step::{export_step_with_stats, StepOptions};
+
+    let source = b"ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\nFILE_NAME('','',(''),(''),'','','');\nFILE_SCHEMA(('IFC\\\\4'));\nENDSEC;\nDATA;\n#1=IFCPROJECT('guid',$,$,$,$,$,$,$,$);\nENDSEC;\nEND-ISO-10303-21;\n";
+
+    let (step, _stats) = export_step_with_stats(source, &StepOptions::default());
+    let schema_line = step
+        .lines()
+        .find(|l| l.starts_with("FILE_SCHEMA("))
+        .expect("a FILE_SCHEMA header line");
+    assert_eq!(
+        schema_line, "FILE_SCHEMA(('IFC\\\\4'));",
+        "source schema label must round-trip, not compound its escaping"
+    );
+}
+
 #[test]
 fn split_top_level_args_respects_nesting() {
     let args = "'a',$,(#1,#2,#3),IFCBOOLEAN(.T.),#9";


### PR DESCRIPTION
## What

Follow-up to the #2405/#2408 escape family, closing the read side. A review worry held that `merged.rs` might corrupt STEP string literals by interpreting them without un-doubling. Verified site-by-site:

- `rewrite_refs` (the DATA-section copy) is **correctly byte-opaque** — it tracks in/out-of-string only to protect `#`-refs and never decodes literal content. A round-trip test with `''`, `\\` and a `\X2\` directive now pins byte-identical passthrough, so the feared corruption class is dead by regression test.
- The real defect was one layer over: **`detect_schema` extracted a still-escaped HEADER slice and re-escaped it on write** — double-escaping any schema label containing `\`. Unreachable by real schema labels (IFC2X3/IFC4/IFC4X3…), but #2408's own commit message had flagged the caveat, and unreachable-today is how these resurface. Fixed: the extracted text is un-doubled before `escape()` re-doubles it.

The separate quote-blind-scanning defect in `detect_schema` is deliberately left to the in-flight `fix/merged-detect-schema-quote2` branch — not duplicated here.

## TS twin

`packages/export/src/merged-exporter.ts` takes `schema` as a caller-supplied enum and never auto-detects from raw header text — structurally immune, no parity change needed.

## Verification

RED-GREEN on the un-doubling (removing it fails with `IFC\\4` vs `IFC\4`); mutation of `rewrite_refs` (injected in-string collapse) fails the round-trip pin. Adding tests pushed `merged.rs` past the 400-line ratchet, so tests moved to a `merged_tests.rs` sibling per the crate convention (197 + 241 lines) — ratchet 4/4, no allowlist row. Export lib green (221 with fixtures present), clippy clean. Rust-only, no changeset per precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved STEP/IFC schema detection across complete file headers.
  - Correctly handles escaped backslashes, quoted values, apostrophes, and control characters.
  - Prevented false schema matches in quoted header content.
  - Preserved non-ASCII characters and valid byte sequences when merging and exporting models.
  - Improved reference rewriting and header serialization to avoid data corruption.
- **Tests**
  - Added coverage for schema parsing, model merging, escaping, reference handling, and UTF-8 preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Corrections (post-review, at `709d0ef97`)

1. **"Byte-opaque" was false at open** — `rewrite_refs` round-tripped bytes through `char` (`out.push(b as char)`), mojibaking non-ASCII outside string context. Now genuinely byte-level (`Vec<u8>`), with a UTF-8 scenario pin.
2. The private `detect_schema`/`escape` fork in `merged.rs` is deleted — the module now shares `step_text.rs`'s quote-aware, whole-header, C0+DEL-escaping primitives, and the shared `detect_schema` carries the un-doubling (so `step.rs`'s fallback benefits too).
3. "221 green" was measured on a fixtures-present worktree; the current verified count is **224 / 0** with fixtures hardlinked.
4. A `@ifc-lite/geometry` changeset now covers the reachable published surface.
