### PR TITLE
fix(viewer): measurement distance readouts honour unitDisplayOverrides (#2199 slice)

### DIFF
--- a/apps/viewer/src/components/viewer/tools/MeasurePanel.tsx
+++ b/apps/viewer/src/components/viewer/tools/MeasurePanel.tsx
@@ -17,7 +17,7 @@ import { useViewerStore, type Measurement } from '@/store';
 import { MeasurementOverlays } from './MeasurementVisuals';
 import { MeasurePointReadout } from './MeasurePointReadout';
 import { MeasureQuantities } from './MeasureQuantities';
-import { formatDistance } from './formatDistance';
+import { formatDistanceDisplay } from './formatDistance';
 import {
   distanceComponents,
   formatAxisDeltas,
@@ -64,6 +64,7 @@ export function MeasureOverlay() {
   const clearMeasurements = useViewerStore((s) => s.clearMeasurements);
   const setActiveTool = useViewerStore((s) => s.setActiveTool);
   const projectToScreen = useViewerStore((s) => s.cameraCallbacks.projectToScreen);
+  const unitDisplayOverrides = useViewerStore((s) => s.unitDisplayOverrides);
 
   // Track cursor position in ref (no re-renders on mouse move)
   const cursorPosRef = React.useRef<{ x: number; y: number } | null>(null);
@@ -257,12 +258,13 @@ export function MeasureOverlay() {
                       index={i}
                       onDelete={handleDeleteMeasurement}
                       geoAnchor={showGeo ? anchor : null}
+                      unitDisplayOverrides={unitDisplayOverrides}
                     />
                   ))}
                   {measurements.length > 1 && (
                     <div className="flex items-center justify-between border-t pt-1 mt-1 text-xs font-medium">
                       <span>Total</span>
-                      <span className="font-mono">{formatDistance(totalDistance)}</span>
+                      <span className="font-mono">{formatDistanceDisplay(totalDistance, unitDisplayOverrides)}</span>
                     </div>
                   )}
                 </div>
@@ -332,6 +334,7 @@ export function MeasureOverlay() {
         hoverPosition={snapIndicatorPos}
         projectToScreen={projectToScreen}
         constraintEdge={measurementConstraintEdge}
+        unitDisplayOverrides={unitDisplayOverrides}
       />
     </>
   );
@@ -343,16 +346,19 @@ interface MeasurementItemProps {
   onDelete: (id: string) => void;
   /** When set, show real-world E/N/H for the measurement's two endpoints. */
   geoAnchor: AnchorGeoreference | null;
+  /** The user's per-unit-type display override (#1573), so the measurement
+   *  readout honours the same unit the rest of the app is showing. */
+  unitDisplayOverrides: Record<string, string>;
 }
 
-function MeasurementItem({ measurement, index, onDelete, geoAnchor }: MeasurementItemProps) {
+function MeasurementItem({ measurement, index, onDelete, geoAnchor, unitDisplayOverrides }: MeasurementItemProps) {
   // Pure display: derived from the stored endpoints, nothing is persisted.
   const components = distanceComponents(measurement.start, measurement.end);
   return (
     <div className="bg-muted/50 rounded px-2 py-0.5 text-xs">
       <div className="flex items-center justify-between">
         <span className="text-muted-foreground text-xs">#{index + 1}</span>
-        <span className="font-mono font-medium">{formatDistance(measurement.distance)}</span>
+        <span className="font-mono font-medium">{formatDistanceDisplay(measurement.distance, unitDisplayOverrides)}</span>
         <Button
           variant="ghost"
           size="icon-sm"
@@ -364,10 +370,10 @@ function MeasurementItem({ measurement, index, onDelete, geoAnchor }: Measuremen
       </div>
       <div className="overflow-x-auto">
         <div className="font-mono text-[10px] leading-tight text-muted-foreground whitespace-nowrap">
-          {formatAxisDeltas(components)}
+          {formatAxisDeltas(components, unitDisplayOverrides)}
         </div>
         <div className="font-mono text-[10px] leading-tight text-muted-foreground whitespace-nowrap">
-          {formatHorizontalVertical(components)}
+          {formatHorizontalVertical(components, unitDisplayOverrides)}
         </div>
         {/* Inclination, derived from the same two endpoints (#2199 §4). */}
         <div className="font-mono text-[10px] leading-tight text-muted-foreground whitespace-nowrap">

--- a/apps/viewer/src/components/viewer/tools/MeasurePanel.tsx
+++ b/apps/viewer/src/components/viewer/tools/MeasurePanel.tsx
@@ -17,7 +17,7 @@ import { useViewerStore, type Measurement } from '@/store';
 import { MeasurementOverlays } from './MeasurementVisuals';
 import { MeasurePointReadout } from './MeasurePointReadout';
 import { MeasureQuantities } from './MeasureQuantities';
-import { formatDistanceDisplay } from './formatDistance';
+import { formatDistance } from './formatDistance';
 import {
   distanceComponents,
   formatAxisDeltas,
@@ -264,7 +264,7 @@ export function MeasureOverlay() {
                   {measurements.length > 1 && (
                     <div className="flex items-center justify-between border-t pt-1 mt-1 text-xs font-medium">
                       <span>Total</span>
-                      <span className="font-mono">{formatDistanceDisplay(totalDistance, unitDisplayOverrides)}</span>
+                      <span className="font-mono">{formatDistance(totalDistance, unitDisplayOverrides)}</span>
                     </div>
                   )}
                 </div>
@@ -358,7 +358,7 @@ function MeasurementItem({ measurement, index, onDelete, geoAnchor, unitDisplayO
     <div className="bg-muted/50 rounded px-2 py-0.5 text-xs">
       <div className="flex items-center justify-between">
         <span className="text-muted-foreground text-xs">#{index + 1}</span>
-        <span className="font-mono font-medium">{formatDistanceDisplay(measurement.distance, unitDisplayOverrides)}</span>
+        <span className="font-mono font-medium">{formatDistance(measurement.distance, unitDisplayOverrides)}</span>
         <Button
           variant="ghost"
           size="icon-sm"

--- a/apps/viewer/src/components/viewer/tools/MeasurePointReadout.tsx
+++ b/apps/viewer/src/components/viewer/tools/MeasurePointReadout.tsx
@@ -39,7 +39,7 @@ import {
   viewerToIfcAxes,
   formatCoordinateTriple,
 } from './measure-modes/coordinates';
-import { formatDistance } from './formatDistance';
+import { formatDistanceDisplay } from './formatDistance';
 import { projectedEnh, useProjectedLatLon, type Vec3Like } from './measure-modes/geo-readout';
 
 /** One labelled coordinate row. */
@@ -61,6 +61,7 @@ export function MeasurePointReadout() {
   const geoReadoutEnabled = useViewerStore((s) => s.geoReadoutEnabled);
   const referencePoint = useViewerStore((s) => s.measureReferencePoint);
   const setReferencePoint = useViewerStore((s) => s.setMeasureReferencePoint);
+  const unitDisplayOverrides = useViewerStore((s) => s.unitDisplayOverrides);
 
   const frame = useRenderFrameOffsets();
   const anchor = useAnchorGeoreference();
@@ -135,7 +136,7 @@ export function MeasurePointReadout() {
           <CoordRow
             label="Rel. ref"
             value={formatCoordinateTriple({ x: offset.dx, y: offset.dy, z: offset.dz })}
-            hint={formatDistance(offset.distance)}
+            hint={formatDistanceDisplay(offset.distance, unitDisplayOverrides)}
           />
         )}
         {enh && (

--- a/apps/viewer/src/components/viewer/tools/MeasurePointReadout.tsx
+++ b/apps/viewer/src/components/viewer/tools/MeasurePointReadout.tsx
@@ -39,7 +39,7 @@ import {
   viewerToIfcAxes,
   formatCoordinateTriple,
 } from './measure-modes/coordinates';
-import { formatDistanceDisplay } from './formatDistance';
+import { formatDistance, formatSignedTriple } from './formatDistance';
 import { projectedEnh, useProjectedLatLon, type Vec3Like } from './measure-modes/geo-readout';
 
 /** One labelled coordinate row. */
@@ -135,8 +135,12 @@ export function MeasurePointReadout() {
         {offset && (
           <CoordRow
             label="Rel. ref"
-            value={formatCoordinateTriple({ x: offset.dx, y: offset.dy, z: offset.dz })}
-            hint={formatDistanceDisplay(offset.distance, unitDisplayOverrides)}
+            // dx/dy/dz are a LENGTH DELTA, not a raw model coordinate — unlike
+            // the Model/Render/Map rows above, this triple must honour the
+            // same LENGTHUNIT override as the trailing distance hint, or the
+            // two disagree (#2538 deep review).
+            value={formatSignedTriple({ x: offset.dx, y: offset.dy, z: offset.dz }, unitDisplayOverrides)}
+            hint={formatDistance(offset.distance, unitDisplayOverrides)}
           />
         )}
         {enh && (

--- a/apps/viewer/src/components/viewer/tools/MeasurementVisuals.tsx
+++ b/apps/viewer/src/components/viewer/tools/MeasurementVisuals.tsx
@@ -10,7 +10,7 @@ import React, { useMemo } from 'react';
 import type { Measurement, SnapVisualization } from '@/store';
 import type { MeasurementConstraintEdge } from '@/store/types';
 import { SnapType, type SnapTarget } from '@ifc-lite/renderer';
-import { formatDistance } from './formatDistance';
+import { formatDistanceDisplay } from './formatDistance';
 import {
   distanceComponents,
   formatAxisDeltas,
@@ -29,9 +29,12 @@ export interface MeasurementOverlaysProps {
   hoverPosition?: { x: number; y: number } | null;
   projectToScreen?: (worldPos: { x: number; y: number; z: number }) => { x: number; y: number } | null;
   constraintEdge?: MeasurementConstraintEdge | null;
+  /** The user's per-unit-type display override (#1573); defaults to none so
+   *  callers that don't pass it keep the previous auto-scaled-metric labels. */
+  unitDisplayOverrides?: Record<string, string>;
 }
 
-export const MeasurementOverlays = React.memo(function MeasurementOverlays({ measurements, pending, activeMeasurement, snapTarget, snapVisualization, hoverPosition, projectToScreen, constraintEdge }: MeasurementOverlaysProps) {
+export const MeasurementOverlays = React.memo(function MeasurementOverlays({ measurements, pending, activeMeasurement, snapTarget, snapVisualization, hoverPosition, projectToScreen, constraintEdge, unitDisplayOverrides = {} }: MeasurementOverlaysProps) {
   // Determine snap indicator position
   // Priority: activeMeasurement.current > snapTarget projected position > hoverPosition (fallback)
   const snapIndicatorPos = useMemo(() => {
@@ -130,13 +133,13 @@ export const MeasurementOverlays = React.memo(function MeasurementOverlays({ mea
               top: (m.start.screenY + m.end.screenY) / 2,
             }}
           >
-            {formatDistance(m.distance)}
+            {formatDistanceDisplay(m.distance, unitDisplayOverrides)}
             {/* Axis breakdown, derived on render (see measure-modes/components). */}
             <div className="font-normal text-[10px] leading-tight opacity-80">
-              {formatAxisDeltas(components)}
+              {formatAxisDeltas(components, unitDisplayOverrides)}
             </div>
             <div className="font-normal text-[10px] leading-tight opacity-80">
-              {formatHorizontalVertical(components)}
+              {formatHorizontalVertical(components, unitDisplayOverrides)}
             </div>
             {/* Inclination to horizontal (#2199 §4), from the same endpoints. */}
             <div className="font-normal text-[10px] leading-tight opacity-80">
@@ -197,16 +200,16 @@ export const MeasurementOverlays = React.memo(function MeasurementOverlays({ mea
               top: (activeMeasurement.start.screenY + activeMeasurement.current.screenY) / 2,
             }}
           >
-            {formatDistance(activeMeasurement.distance)}
+            {formatDistanceDisplay(activeMeasurement.distance, unitDisplayOverrides)}
             {/* Live axis breakdown, derived on render (see measure-modes/components).
                 Mirrors the completed-measurement label: axis deltas first, then
                 horizontal/vertical — the drag is exactly when a setting-out user
                 wants dX/dY/dZ, so the live readout must not be the poorer one. */}
             <div className="font-normal text-[10px] leading-tight opacity-80">
-              {formatAxisDeltas(distanceComponents(activeMeasurement.start, activeMeasurement.current))}
+              {formatAxisDeltas(distanceComponents(activeMeasurement.start, activeMeasurement.current), unitDisplayOverrides)}
             </div>
             <div className="font-normal text-[10px] leading-tight opacity-80">
-              {formatHorizontalVertical(distanceComponents(activeMeasurement.start, activeMeasurement.current))}
+              {formatHorizontalVertical(distanceComponents(activeMeasurement.start, activeMeasurement.current), unitDisplayOverrides)}
             </div>
             <div className="font-normal text-[10px] leading-tight opacity-80">
               {formatInclination(inclination(distanceComponents(activeMeasurement.start, activeMeasurement.current)))}
@@ -602,6 +605,20 @@ export function measurementOverlaysPropsEqual(prevProps: MeasurementOverlaysProp
   if (!!prevProps.constraintEdge !== !!nextProps.constraintEdge) return false;
   if (prevProps.constraintEdge && nextProps.constraintEdge) {
     if (prevProps.constraintEdge.activeAxis !== nextProps.constraintEdge.activeAxis) return false;
+  }
+
+  // Compare unitDisplayOverrides — every distance label routes through it
+  // (#2199 formatDistance/unitDisplayOverrides gap). A shallow key/value
+  // compare, not a reference compare: the store spreads a new object on
+  // every `setUnitDisplayOverride` call, but an unrelated re-render must not
+  // force this component to re-render just because its identity changed.
+  const prevOverrides = prevProps.unitDisplayOverrides ?? {};
+  const nextOverrides = nextProps.unitDisplayOverrides ?? {};
+  const prevKeys = Object.keys(prevOverrides);
+  const nextKeys = Object.keys(nextOverrides);
+  if (prevKeys.length !== nextKeys.length) return false;
+  for (const key of prevKeys) {
+    if (prevOverrides[key] !== nextOverrides[key]) return false;
   }
 
   return true; // All props are equal, skip re-render

--- a/apps/viewer/src/components/viewer/tools/MeasurementVisuals.tsx
+++ b/apps/viewer/src/components/viewer/tools/MeasurementVisuals.tsx
@@ -10,7 +10,7 @@ import React, { useMemo } from 'react';
 import type { Measurement, SnapVisualization } from '@/store';
 import type { MeasurementConstraintEdge } from '@/store/types';
 import { SnapType, type SnapTarget } from '@ifc-lite/renderer';
-import { formatDistanceDisplay } from './formatDistance';
+import { formatDistance } from './formatDistance';
 import {
   distanceComponents,
   formatAxisDeltas,
@@ -133,7 +133,7 @@ export const MeasurementOverlays = React.memo(function MeasurementOverlays({ mea
               top: (m.start.screenY + m.end.screenY) / 2,
             }}
           >
-            {formatDistanceDisplay(m.distance, unitDisplayOverrides)}
+            {formatDistance(m.distance, unitDisplayOverrides)}
             {/* Axis breakdown, derived on render (see measure-modes/components). */}
             <div className="font-normal text-[10px] leading-tight opacity-80">
               {formatAxisDeltas(components, unitDisplayOverrides)}
@@ -200,7 +200,7 @@ export const MeasurementOverlays = React.memo(function MeasurementOverlays({ mea
               top: (activeMeasurement.start.screenY + activeMeasurement.current.screenY) / 2,
             }}
           >
-            {formatDistanceDisplay(activeMeasurement.distance, unitDisplayOverrides)}
+            {formatDistance(activeMeasurement.distance, unitDisplayOverrides)}
             {/* Live axis breakdown, derived on render (see measure-modes/components).
                 Mirrors the completed-measurement label: axis deltas first, then
                 horizontal/vertical — the drag is exactly when a setting-out user

--- a/apps/viewer/src/components/viewer/tools/formatDistance.test.ts
+++ b/apps/viewer/src/components/viewer/tools/formatDistance.test.ts
@@ -9,39 +9,80 @@
  * distance readout; #2514 only wired the override through
  * `resolveQuantityDisplay` for element quantities (area/volume/weight), not
  * for the distances the measure tool itself produces.
+ *
+ * `formatDistance` is the single distance formatter — the maintainer's deep
+ * review on #2538 flagged that a separate `formatDistanceDisplay` beside an
+ * unconditionally-metric `formatDistance` left every measure-tool call site
+ * free to pick either name and silently get an unconverted result. The
+ * override handling was folded into `formatDistance` itself instead.
  */
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { formatDistance, formatDistanceDisplay } from './formatDistance.js';
+import { formatDistance, formatSignedTriple } from './formatDistance.js';
 
-describe('formatDistanceDisplay', () => {
+describe('formatDistance', () => {
+  it('falls back to the auto-scaled metric string when overrides is omitted', () => {
+    assert.strictEqual(formatDistance(3), '3.000 m');
+    assert.strictEqual(formatDistance(0.25), '25.0 cm');
+  });
+
   it('falls back to the auto-scaled metric string when no override is set', () => {
-    assert.strictEqual(formatDistanceDisplay(3, {}), formatDistance(3));
-    assert.strictEqual(formatDistanceDisplay(0.25, {}), formatDistance(0.25));
+    assert.strictEqual(formatDistance(3, {}), formatDistance(3));
+    assert.strictEqual(formatDistance(0.25, {}), formatDistance(0.25));
   });
 
   it('falls back when overrides carries an unrelated unit type', () => {
-    assert.strictEqual(formatDistanceDisplay(6.824, { AREAUNIT: 'ft2' }), formatDistance(6.824));
+    assert.strictEqual(formatDistance(6.824, { AREAUNIT: 'ft2' }), formatDistance(6.824));
   });
 
   it('converts into the LENGTHUNIT override instead of auto-scaled metric', () => {
     // 1 m3 cube edge from the maintainer's own verification numbers: 1.000 m
     // measured, which at 3.28084 ft/m is 3.2808 ft, capped to 4 fraction
     // digits by formatConverted.
-    assert.strictEqual(formatDistanceDisplay(1, { LENGTHUNIT: 'ft' }), '3.2808 ft');
+    assert.strictEqual(formatDistance(1, { LENGTHUNIT: 'ft' }), '3.2808 ft');
   });
 
   it('converts a sub-metre distance the same way the auto-scaled path would have shown as cm', () => {
-    // 0.25 m -> formatDistance would say "25.0 cm"; the override must win
+    // 0.25 m -> the no-override path says "25.0 cm"; the override must win
     // instead of the auto cm/mm scaling.
-    assert.strictEqual(formatDistanceDisplay(0.25, { LENGTHUNIT: 'ft' }), '0.8202 ft');
+    assert.strictEqual(formatDistance(0.25, { LENGTHUNIT: 'ft' }), '0.8202 ft');
   });
 
   it('converts into the millimetre override', () => {
     // Kept under 1000 so a locale's thousands-separator can't make this
     // assertion flaky — formatConverted's grouping is exercised separately
     // in lib/units/display.test.ts.
-    assert.strictEqual(formatDistanceDisplay(0.00125, { LENGTHUNIT: 'mm' }), '1.25 mm');
+    assert.strictEqual(formatDistance(0.00125, { LENGTHUNIT: 'mm' }), '1.25 mm');
+  });
+});
+
+// #2538 deep review: MeasurePointReadout's "Rel. ref" row converted only its
+// trailing distance hint, leaving the X/Y/Z triple beside it in unlabelled
+// metres — a `ft` override made the row read a metre triple next to a feet
+// distance. `formatSignedTriple` is the fix: the same LENGTHUNIT conversion
+// `formatDistance` applies to the hint, applied per axis to the triple.
+describe('formatSignedTriple', () => {
+  it('keeps the pre-#2199 unlabelled-metres triple when overrides is omitted', () => {
+    assert.strictEqual(formatSignedTriple({ x: 1, y: 2, z: 3 }), 'X 1.000  Y 2.000  Z 3.000');
+  });
+
+  it('keeps the unlabelled-metres triple for an empty override map', () => {
+    assert.strictEqual(formatSignedTriple({ x: 1, y: 2, z: 3 }, {}), 'X 1.000  Y 2.000  Z 3.000');
+  });
+
+  it('converts every axis into the LENGTHUNIT override, matching formatDistance per axis', () => {
+    // 1 m -> 3.2808 ft, 2 m -> 6.5617 ft, 3 m -> 9.8425 ft (3.28084 ft/m).
+    assert.strictEqual(
+      formatSignedTriple({ x: 1, y: 2, z: 3 }, { LENGTHUNIT: 'ft' }),
+      'X 3.2808  Y 6.5617  Z 9.8425',
+    );
+  });
+
+  it('keeps negative axes signed after conversion', () => {
+    assert.strictEqual(
+      formatSignedTriple({ x: -1, y: 0, z: 3.048 }, { LENGTHUNIT: 'ft' }),
+      'X -3.2808  Y 0  Z 10',
+    );
   });
 });

--- a/apps/viewer/src/components/viewer/tools/formatDistance.test.ts
+++ b/apps/viewer/src/components/viewer/tools/formatDistance.test.ts
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `formatDistance()` ignoring `unitDisplayOverrides` — issue #2199,
+ * maintainer's "worth its own small fix" note. A user who has set feet as
+ * the LENGTHUNIT display override still got metres from every measure-tool
+ * distance readout; #2514 only wired the override through
+ * `resolveQuantityDisplay` for element quantities (area/volume/weight), not
+ * for the distances the measure tool itself produces.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { formatDistance, formatDistanceDisplay } from './formatDistance.js';
+
+describe('formatDistanceDisplay', () => {
+  it('falls back to the auto-scaled metric string when no override is set', () => {
+    assert.strictEqual(formatDistanceDisplay(3, {}), formatDistance(3));
+    assert.strictEqual(formatDistanceDisplay(0.25, {}), formatDistance(0.25));
+  });
+
+  it('falls back when overrides carries an unrelated unit type', () => {
+    assert.strictEqual(formatDistanceDisplay(6.824, { AREAUNIT: 'ft2' }), formatDistance(6.824));
+  });
+
+  it('converts into the LENGTHUNIT override instead of auto-scaled metric', () => {
+    // 1 m3 cube edge from the maintainer's own verification numbers: 1.000 m
+    // measured, which at 3.28084 ft/m is 3.2808 ft, capped to 4 fraction
+    // digits by formatConverted.
+    assert.strictEqual(formatDistanceDisplay(1, { LENGTHUNIT: 'ft' }), '3.2808 ft');
+  });
+
+  it('converts a sub-metre distance the same way the auto-scaled path would have shown as cm', () => {
+    // 0.25 m -> formatDistance would say "25.0 cm"; the override must win
+    // instead of the auto cm/mm scaling.
+    assert.strictEqual(formatDistanceDisplay(0.25, { LENGTHUNIT: 'ft' }), '0.8202 ft');
+  });
+
+  it('converts into the millimetre override', () => {
+    // Kept under 1000 so a locale's thousands-separator can't make this
+    // assertion flaky — formatConverted's grouping is exercised separately
+    // in lib/units/display.test.ts.
+    assert.strictEqual(formatDistanceDisplay(0.00125, { LENGTHUNIT: 'mm' }), '1.25 mm');
+  });
+});

--- a/apps/viewer/src/components/viewer/tools/formatDistance.ts
+++ b/apps/viewer/src/components/viewer/tools/formatDistance.ts
@@ -2,6 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { QuantityType } from '@ifc-lite/data';
+import { ProjectUnits } from '@ifc-lite/parser';
+import { resolveQuantityDisplay, formatConverted } from '@/lib/units/display';
+
 /**
  * Format a distance in meters to a human-readable string with appropriate units
  */
@@ -15,4 +19,24 @@ export function formatDistance(meters: number): string {
   } else {
     return `${(meters / 1000).toFixed(2)} km`;
   }
+}
+
+/**
+ * Format a distance honoring the user's LENGTHUNIT display override (#1573),
+ * falling back to {@link formatDistance}'s auto-scaled metric when no
+ * override is set for LENGTHUNIT.
+ *
+ * `meters` is always already SI: every distance the measure tool produces —
+ * drag endpoints, axis deltas, picked-point offsets — is renderer/model
+ * space, which is metres throughout (geometry is unit-scaled to metres at
+ * import; see `measure-modes/coordinates.ts`). Display therefore resolves
+ * against an EMPTY unit context, exactly like `MeasureQuantities`' totals:
+ * handing it a file's declared millimetres would scale an already-metre
+ * value a second time.
+ */
+export function formatDistanceDisplay(meters: number, overrides: Record<string, string>): string {
+  const disp = resolveQuantityDisplay(meters, QuantityType.Length, ProjectUnits.empty(), overrides);
+  if (disp.converted === null) return formatDistance(meters);
+  const formatted = formatConverted(disp.converted);
+  return disp.unit ? `${formatted} ${disp.unit}` : formatted;
 }

--- a/apps/viewer/src/components/viewer/tools/formatDistance.ts
+++ b/apps/viewer/src/components/viewer/tools/formatDistance.ts
@@ -6,10 +6,15 @@ import { QuantityType } from '@ifc-lite/data';
 import { ProjectUnits } from '@ifc-lite/parser';
 import { resolveQuantityDisplay, formatConverted } from '@/lib/units/display';
 
-/**
- * Format a distance in meters to a human-readable string with appropriate units
- */
-export function formatDistance(meters: number): string {
+// Constructed once rather than per call: every measure-tool distance readout
+// (including the live-drag SVG labels, which reformat on every pointer-move
+// frame) resolves against this same empty context, so there is no reason to
+// allocate a fresh one each time.
+const EMPTY_UNITS = ProjectUnits.empty();
+
+/** Auto-scaled metric string (mm / cm / m / km), the fallback used when no
+ *  LENGTHUNIT override is set. */
+function formatAutoScaledMetric(meters: number): string {
   if (meters < 0.01) {
     return `${(meters * 1000).toFixed(1)} mm`;
   } else if (meters < 1) {
@@ -22,9 +27,18 @@ export function formatDistance(meters: number): string {
 }
 
 /**
- * Format a distance honoring the user's LENGTHUNIT display override (#1573),
- * falling back to {@link formatDistance}'s auto-scaled metric when no
- * override is set for LENGTHUNIT.
+ * Format a distance in meters to a human-readable string, honoring the
+ * user's LENGTHUNIT display override (#1573) when one is set and falling
+ * back to the auto-scaled metric (mm/cm/m/km) otherwise. `overrides`
+ * defaults to `{}` so every pre-#2199 call site (which never knew about
+ * unit overrides) keeps its exact prior behaviour unchanged.
+ *
+ * This is deliberately the ONE exported distance formatter — #2199 briefly
+ * shipped a second, override-aware `formatDistanceDisplay` beside this
+ * unconditionally-metric one, which left every measure-tool call site free
+ * to pick either name and get a plausible-looking but wrong (unconverted)
+ * result. Folding the override handling in here removes that choice instead
+ * of guarding it.
  *
  * `meters` is always already SI: every distance the measure tool produces —
  * drag endpoints, axis deltas, picked-point offsets — is renderer/model
@@ -34,9 +48,47 @@ export function formatDistance(meters: number): string {
  * handing it a file's declared millimetres would scale an already-metre
  * value a second time.
  */
-export function formatDistanceDisplay(meters: number, overrides: Record<string, string>): string {
-  const disp = resolveQuantityDisplay(meters, QuantityType.Length, ProjectUnits.empty(), overrides);
-  if (disp.converted === null) return formatDistance(meters);
+export function formatDistance(meters: number, overrides: Record<string, string> = {}): string {
+  const disp = resolveQuantityDisplay(meters, QuantityType.Length, EMPTY_UNITS, overrides);
+  if (disp.converted === null) return formatAutoScaledMetric(meters);
   const formatted = formatConverted(disp.converted);
   return disp.unit ? `${formatted} ${disp.unit}` : formatted;
+}
+
+/**
+ * A single length axis, converted the same way {@link formatDistance} does,
+ * but WITHOUT the trailing unit symbol — the numeric half only. Used to build
+ * a multi-axis triple that prints one shared unit instead of repeating it
+ * per axis (see `formatSignedTriple` below).
+ */
+function formatDistanceMagnitude(meters: number, overrides: Record<string, string>): string {
+  const disp = resolveQuantityDisplay(meters, QuantityType.Length, EMPTY_UNITS, overrides);
+  return disp.converted === null ? meters.toFixed(3) : formatConverted(disp.converted);
+}
+
+/**
+ * Format a signed X/Y/Z LENGTH-DELTA triple honoring the LENGTHUNIT display
+ * override, e.g. `X 3.2808  Y 6.5617  Z 9.8425`.
+ *
+ * This is for a triple that IS a distance — the Measure tool's
+ * relative-reference offset (dx/dy/dz from a user-set datum), the same kind
+ * of signed length `formatAxisDeltas` already converts — not a raw model
+ * coordinate. `formatCoordinateTriple` in `measure-modes/coordinates.ts`
+ * stays in unlabelled metres for the Model / Render / Map rows, which are
+ * point positions in a file's own coordinate system or a projected CRS, and
+ * are deliberately out of #2199's scope.
+ *
+ * Deep review on #2538: before this, the "Rel. ref" row converted only its
+ * trailing distance hint, leaving the triple beside it in unlabelled metres —
+ * a `ft` override made the row read e.g. `X 1.000 Y 2.000 Z 3.000  12.2758
+ * ft`, mixing units in one line. All three axes share one override, so the
+ * unit is resolved once by the caller (from the accompanying
+ * {@link formatDistance} hint) rather than printed three times here.
+ */
+export function formatSignedTriple(
+  p: { x: number; y: number; z: number },
+  overrides: Record<string, string> = {},
+): string {
+  const axis = (n: number) => formatDistanceMagnitude(n, overrides);
+  return `X ${axis(p.x)}  Y ${axis(p.y)}  Z ${axis(p.z)}`;
 }

--- a/apps/viewer/src/components/viewer/tools/measure-modes/components.test.ts
+++ b/apps/viewer/src/components/viewer/tools/measure-modes/components.test.ts
@@ -86,4 +86,43 @@ describe('measurement readout lines', () => {
     const c = distanceComponents({ x: 0, y: 0, z: 0 }, { x: 3, y: 12, z: 4 });
     assert.strictEqual(formatHorizontalVertical(c), 'H 5.000 m  V 12.000 m');
   });
+
+  // #2199: formatDistance() ignoring unitDisplayOverrides — the dX/dY/dZ and
+  // H/V breakdowns route through formatSignedDistance / formatDistanceDisplay
+  // internally, so a LENGTHUNIT override set in feet must show up here too,
+  // not just on the plain distance figure.
+  it('honours a LENGTHUNIT override in the axis-delta line', () => {
+    const c = distanceComponents({ x: 0, y: 0, z: 0 }, { x: 3.048, y: 0, z: 0 });
+    assert.strictEqual(
+      formatAxisDeltas(c, { LENGTHUNIT: 'ft' }),
+      'dX 10 ft  dY 0 ft  dZ 0 ft',
+    );
+  });
+
+  it('honours a LENGTHUNIT override in the horizontal/vertical line', () => {
+    const c = distanceComponents({ x: 0, y: 0, z: 0 }, { x: 3, y: 3.048, z: 4 });
+    assert.strictEqual(
+      formatHorizontalVertical(c, { LENGTHUNIT: 'ft' }),
+      'H 16.4042 ft  V 10 ft',
+    );
+  });
+
+  it('keeps the default auto-scaled metric when overrides is omitted, as before', () => {
+    const c = distanceComponents({ x: 0, y: 0, z: 0 }, { x: 3, y: 12, z: -4 });
+    // No third argument at all — the pre-#2199-fix call shape must still work.
+    assert.strictEqual(formatAxisDeltas(c), 'dX 3.000 m  dY 12.000 m  dZ -4.000 m');
+    // horizontal = hypot(dx, dz) = hypot(3, -4) = 5; vertical = |dy| = 12.
+    assert.strictEqual(formatHorizontalVertical(c), 'H 5.000 m  V 12.000 m');
+  });
+});
+
+describe('formatSignedDistance with a LENGTHUNIT override', () => {
+  it('converts the magnitude and keeps the sign in front of it', () => {
+    assert.strictEqual(formatSignedDistance(3.048, { LENGTHUNIT: 'ft' }), '10 ft');
+    assert.strictEqual(formatSignedDistance(-3.048, { LENGTHUNIT: 'ft' }), '-10 ft');
+  });
+
+  it('falls back to the auto-scaled metric for an empty override map', () => {
+    assert.strictEqual(formatSignedDistance(-0.25, {}), '-25.0 cm');
+  });
 });

--- a/apps/viewer/src/components/viewer/tools/measure-modes/components.test.ts
+++ b/apps/viewer/src/components/viewer/tools/measure-modes/components.test.ts
@@ -88,7 +88,7 @@ describe('measurement readout lines', () => {
   });
 
   // #2199: formatDistance() ignoring unitDisplayOverrides — the dX/dY/dZ and
-  // H/V breakdowns route through formatSignedDistance / formatDistanceDisplay
+  // H/V breakdowns route through formatSignedDistance / formatDistance
   // internally, so a LENGTHUNIT override set in feet must show up here too,
   // not just on the plain distance figure.
   it('honours a LENGTHUNIT override in the axis-delta line', () => {

--- a/apps/viewer/src/components/viewer/tools/measure-modes/components.ts
+++ b/apps/viewer/src/components/viewer/tools/measure-modes/components.ts
@@ -15,7 +15,7 @@
  * silently wrong for every model.
  */
 
-import { formatDistanceDisplay } from '../formatDistance';
+import { formatDistance } from '../formatDistance';
 
 export interface Point3 {
   x: number;
@@ -62,7 +62,7 @@ export function distanceComponents(start: Point3, end: Point3): DistanceComponen
  * auto-scaled-metric behaviour.
  */
 export function formatSignedDistance(meters: number, overrides: Record<string, string> = {}): string {
-  const magnitude = formatDistanceDisplay(Math.abs(meters), overrides);
+  const magnitude = formatDistance(Math.abs(meters), overrides);
   return meters < 0 ? `-${magnitude}` : magnitude;
 }
 
@@ -73,5 +73,5 @@ export function formatAxisDeltas(c: DistanceComponents, overrides: Record<string
 
 /** One-line horizontal/vertical readout, e.g. `H 5.000 m  V 12.000 m`. */
 export function formatHorizontalVertical(c: DistanceComponents, overrides: Record<string, string> = {}): string {
-  return `H ${formatDistanceDisplay(c.horizontal, overrides)}  V ${formatDistanceDisplay(c.vertical, overrides)}`;
+  return `H ${formatDistance(c.horizontal, overrides)}  V ${formatDistance(c.vertical, overrides)}`;
 }

--- a/apps/viewer/src/components/viewer/tools/measure-modes/components.ts
+++ b/apps/viewer/src/components/viewer/tools/measure-modes/components.ts
@@ -15,7 +15,7 @@
  * silently wrong for every model.
  */
 
-import { formatDistance } from '../formatDistance';
+import { formatDistanceDisplay } from '../formatDistance';
 
 export interface Point3 {
   x: number;
@@ -55,18 +55,23 @@ export function distanceComponents(start: Point3, end: Point3): DistanceComponen
   };
 }
 
-/** Format a signed delta, keeping the sign in front of the unit-scaled magnitude. */
-export function formatSignedDistance(meters: number): string {
-  const magnitude = formatDistance(Math.abs(meters));
+/**
+ * Format a signed delta, keeping the sign in front of the unit-scaled
+ * magnitude. `overrides` is the user's LENGTHUNIT display override (#1573,
+ * `unitDisplayOverrides`); omitting it (or passing `{}`) keeps the previous
+ * auto-scaled-metric behaviour.
+ */
+export function formatSignedDistance(meters: number, overrides: Record<string, string> = {}): string {
+  const magnitude = formatDistanceDisplay(Math.abs(meters), overrides);
   return meters < 0 ? `-${magnitude}` : magnitude;
 }
 
 /** One-line per-axis readout, e.g. `dX 3.000 m  dY 12.000 m  dZ 4.000 m`. */
-export function formatAxisDeltas(c: DistanceComponents): string {
-  return `dX ${formatSignedDistance(c.dx)}  dY ${formatSignedDistance(c.dy)}  dZ ${formatSignedDistance(c.dz)}`;
+export function formatAxisDeltas(c: DistanceComponents, overrides: Record<string, string> = {}): string {
+  return `dX ${formatSignedDistance(c.dx, overrides)}  dY ${formatSignedDistance(c.dy, overrides)}  dZ ${formatSignedDistance(c.dz, overrides)}`;
 }
 
 /** One-line horizontal/vertical readout, e.g. `H 5.000 m  V 12.000 m`. */
-export function formatHorizontalVertical(c: DistanceComponents): string {
-  return `H ${formatDistance(c.horizontal)}  V ${formatDistance(c.vertical)}`;
+export function formatHorizontalVertical(c: DistanceComponents, overrides: Record<string, string> = {}): string {
+  return `H ${formatDistanceDisplay(c.horizontal, overrides)}  V ${formatDistanceDisplay(c.vertical, overrides)}`;
 }

--- a/apps/viewer/src/components/viewer/tools/measure-parity.test.tsx
+++ b/apps/viewer/src/components/viewer/tools/measure-parity.test.tsx
@@ -159,6 +159,7 @@ beforeEach(() => {
     models: new Map(),
     ifcDataStore: null,
     geometryResult: null,
+    unitDisplayOverrides: {},
   });
 });
 
@@ -278,6 +279,100 @@ describe('the shipped panel hosts each #2199 section', () => {
     const text = container.textContent ?? '';
     assert.match(text, /declares no quantities/, text);
     assert.match(text, /could not\s+be resolved to a loaded model/, text);
+  });
+});
+
+/**
+ * #2538 deep review, "major": all 14 tests #2199 added for the unit-override
+ * fix are pure-function tests of `formatDistance` / `formatAxisDeltas` /
+ * `formatHorizontalVertical` / `measurementOverlaysPropsEqual` — none of them
+ * mount a component or read a rendered string, so deleting the
+ * `unitDisplayOverrides` prop-threading at any of MeasurePanel.tsx's call
+ * sites (or the store subscriptions feeding it) would leave the whole suite
+ * green while the feature shipped dead.
+ *
+ * These drive the real path, exactly like the rest of this file: seed the
+ * store with a `unitDisplayOverrides` LENGTHUNIT override, mount the shipped
+ * `ToolOverlays`, click into a section, and read the printed string. A
+ * mutation that drops any prop/subscription in the chain turns 'ft' back
+ * into unconverted metres and one of these fails.
+ */
+describe('the LENGTHUNIT override reaches every rendered readout (#2538 wiring gap)', () => {
+  // A 3.048 m run along X — exactly 10 ft at 0.3048 m/ft — so a dropped
+  // conversion is visible as a wrong NUMBER, not just a wrong unit symbol.
+  const FT_START = { x: 0, y: 0, z: 0, screenX: 0, screenY: 0 };
+  const FT_END = { x: 3.048, y: 0, z: 0, screenX: 0, screenY: 0 };
+
+  it('List: per-measurement distance and the multi-measurement Total both convert', () => {
+    useViewerStore.setState({
+      measurements: [
+        { id: 'm1', start: FT_START, end: FT_END, distance: 3.048 },
+        { id: 'm2', start: FT_START, end: FT_END, distance: 3.048 },
+      ],
+      unitDisplayOverrides: { LENGTHUNIT: 'ft' },
+    });
+    const container = render();
+    openSection(container, 'List');
+    const text = container.textContent ?? '';
+    assert.match(text, /10 ft/, `per-measurement distance did not convert to ft: ${text}`);
+    // Total of the two 10 ft measurements: 20 ft.
+    assert.match(text, /20 ft/, `Total row did not convert to ft: ${text}`);
+    assert.doesNotMatch(text, /6\.096/, `Total fell back to unconverted metres: ${text}`);
+  });
+
+  it('List: dX/dY/dZ and H/V breakdown lines convert', () => {
+    useViewerStore.setState({
+      measurements: [{ id: 'm1', start: FT_START, end: FT_END, distance: 3.048 }],
+      unitDisplayOverrides: { LENGTHUNIT: 'ft' },
+    });
+    const container = render();
+    openSection(container, 'List');
+    const text = container.textContent ?? '';
+    assert.match(text, /dX 10 ft\s+dY 0 ft\s+dZ 0 ft/, `axis-delta line did not convert to ft: ${text}`);
+    assert.match(text, /H 10 ft\s+V 0 ft/, `horizontal\/vertical line did not convert to ft: ${text}`);
+  });
+
+  it('Point: the Rel. ref triple and its distance hint agree in the override unit', () => {
+    useViewerStore.setState({
+      measurements: [{ id: 'm1', start: FT_START, end: FT_END, distance: 3.048 }],
+      // Reference point at the origin (renderer space) so the offset to the
+      // live point (3.048, 0, 0) is exactly (3.048, 0, 0) again.
+      measureReferencePoint: { x: 0, y: 0, z: 0 },
+      unitDisplayOverrides: { LENGTHUNIT: 'ft' },
+    });
+    const container = render();
+    openSection(container, 'Point');
+
+    // Isolate the "Rel. ref" row specifically — the Model row above it stays
+    // in unlabelled metres by design (#2199 scope), and DOES print "X 3.048"
+    // for this same fixture, so a whole-panel text search cannot tell the two
+    // apart.
+    const relRefRow = [...container.querySelectorAll('div')].find(
+      (d) => d.querySelector(':scope > span')?.textContent?.trim() === 'Rel. ref',
+    );
+    assert.ok(relRefRow, `no "Rel. ref" row rendered: ${container.textContent}`);
+    const spans = relRefRow!.querySelectorAll(':scope > span');
+    const value = spans[1]?.textContent ?? '';
+    const hint = spans[2]?.textContent ?? '';
+
+    // Renderer (3.048, 0, 0) -> IFC (3.048, 0, 0): dx=3.048 -> 10 ft.
+    assert.match(value, /X 10\s+Y 0\s+Z 0/, `Rel. ref triple did not convert to ft: "${value}"`);
+    assert.equal(hint, '10 ft', `Rel. ref distance hint did not convert to ft: "${hint}"`);
+    // The failure mode this guards: hint converts but the triple stays in
+    // unlabelled metres, e.g. "X 3.048  Y 0.000  Z 0.000" next to "10 ft".
+    assert.doesNotMatch(value, /X 3\.048/, `Rel. ref triple fell back to unconverted metres: "${value}"`);
+  });
+
+  it('does not convert when unitDisplayOverrides is empty, as the control for the tests above', () => {
+    useViewerStore.setState({
+      measurements: [{ id: 'm1', start: FT_START, end: FT_END, distance: 3.048 }],
+      unitDisplayOverrides: {},
+    });
+    const container = render();
+    openSection(container, 'List');
+    const text = container.textContent ?? '';
+    assert.match(text, /3\.048 m/, `no-override case must stay in unconverted metres: ${text}`);
+    assert.doesNotMatch(text, /10 ft/, text);
   });
 });
 
@@ -461,6 +556,34 @@ describe('guard sanity', () => {
   it('reads real toolbar sources', () => {
     for (const rel of ['../MainToolbar.tsx', '../ribbon/tabs/HomeTab.tsx', '../ViewportContainer.tsx']) {
       assert.ok(read(rel).length > 500, `${rel} did not resolve to real source (from ${here})`);
+    }
+  });
+
+  it('formatDistance is the ONE distance formatter — no unguarded second name to pick wrong (#2538)', () => {
+    // #2199 briefly shipped `formatDistanceDisplay` beside an
+    // unconditionally-metric `formatDistance`, exported side by side with no
+    // guard stopping a new measure readout from calling the wrong one — which
+    // is exactly what the maintainer reported was still happening on the
+    // live `feat/measurement-tools` branch. The override handling was folded
+    // into `formatDistance` itself; this pins that there is only one name to
+    // find and call from here on.
+    const source = read('./formatDistance.ts');
+    assert.doesNotMatch(
+      source,
+      /export function formatDistanceDisplay/,
+      'a second, override-aware distance formatter has reappeared beside formatDistance — fold it back in instead of exporting two names',
+    );
+    for (const rel of [
+      './MeasurePanel.tsx',
+      './MeasurePointReadout.tsx',
+      './MeasurementVisuals.tsx',
+      './measure-modes/components.ts',
+    ]) {
+      assert.doesNotMatch(
+        read(rel),
+        /formatDistanceDisplay/,
+        `${rel} still references the removed formatDistanceDisplay name`,
+      );
     }
   });
 

--- a/apps/viewer/src/components/viewer/tools/measurementOverlaysPropsEqual.test.ts
+++ b/apps/viewer/src/components/viewer/tools/measurementOverlaysPropsEqual.test.ts
@@ -127,4 +127,40 @@ describe('measurementOverlaysPropsEqual', () => {
 
     assert.equal(measurementOverlaysPropsEqual(a, b), false);
   });
+
+  // #2199: every distance label now routes through `unitDisplayOverrides`
+  // (formatDistanceDisplay). Without this clause the memo would keep an old
+  // measurement showing metres after the user switched the LENGTHUNIT
+  // display override to feet — same class of staleness the world-coordinate
+  // clauses above exist to prevent, just triggered by a store change instead
+  // of a drag.
+  it('re-renders when unitDisplayOverrides changes with no other prop different', () => {
+    const a = completed(pt(0, 0, 0), pt(1, 2, 3));
+    const withFeet = { ...a, unitDisplayOverrides: { LENGTHUNIT: 'ft' } };
+    const empty = { ...a, unitDisplayOverrides: {} };
+
+    assert.equal(measurementOverlaysPropsEqual(empty, withFeet), false);
+    assert.equal(measurementOverlaysPropsEqual(withFeet, empty), false);
+  });
+
+  it('re-renders when switching between two different override units', () => {
+    const a = { ...completed(pt(0, 0, 0), pt(1, 2, 3)), unitDisplayOverrides: { LENGTHUNIT: 'ft' } };
+    const b = { ...completed(pt(0, 0, 0), pt(1, 2, 3)), unitDisplayOverrides: { LENGTHUNIT: 'mm' } };
+
+    assert.equal(measurementOverlaysPropsEqual(a, b), false);
+  });
+
+  it('treats a missing unitDisplayOverrides the same as an empty one', () => {
+    const a = completed(pt(0, 0, 0), pt(1, 2, 3)); // unitDisplayOverrides omitted
+    const b = { ...a, unitDisplayOverrides: {} };
+
+    assert.equal(measurementOverlaysPropsEqual(a, b), true);
+  });
+
+  it('still skips the re-render when unitDisplayOverrides is unchanged', () => {
+    const a = { ...completed(pt(0, 0, 0), pt(1, 2, 3)), unitDisplayOverrides: { LENGTHUNIT: 'ft' } };
+    const b = { ...completed(pt(0, 0, 0), pt(1, 2, 3)), unitDisplayOverrides: { LENGTHUNIT: 'ft' } };
+
+    assert.equal(measurementOverlaysPropsEqual(a, b), true);
+  });
 });


### PR DESCRIPTION
## What

The slice your #2199 comment called "worth its own small fix": `formatDistance()` readouts ignored `unitDisplayOverrides`, so picked-point and measurement readouts stayed in metres regardless of the user's display unit — while #2514's quantity readouts honoured it. Verified first against your live `feat/measurement-tools` branch that neither this nor edge-length is touched there (its `MeasurePointReadout.tsx` still calls the raw formatter, which is the named gap).

## How

Seven readouts routed through an override-aware `formatDistanceDisplay`: total distance, per-measurement list entries, dX/dY/dZ, H/V, both SVG line labels (completed + live-drag), and the rel-ref distance hint. Deliberately out of scope: `formatCoordinateTriple` X/Y/Z rows and the Map E/N/H readout (CRS projection units, a different concern than LENGTHUNIT), and other tools' panels.

The sweep also surfaced a staleness bug: `MeasurementOverlays`' custom memo comparator didn't compare the new prop, so a mid-session unit change would leave stale SVG labels — same class the comparator's world-coordinate clauses already guard; added the clause.

## Verification

Mutation 1 (formatter reduced to the old unconditional metric form — the exact bug) → 6 tests fail. Mutation 2 (memo clause deleted) → 2 fail. Both restored with `diff` proof. 14 new test cases; viewer suite 3736 pass / 0 fail; root typecheck 77/77 (1021-file test program). `apps/viewer`-only, no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
