### PR TITLE
fix(mcp): warn the agent when a model swap invalidates the ids it is holding

### DIFF
--- a/apps/viewer/src/components/mcp/PlaygroundChat.tsx
+++ b/apps/viewer/src/components/mcp/PlaygroundChat.tsx
@@ -29,6 +29,7 @@ import {
   useRef,
   useState,
 } from 'react';
+import { modelSwapNotice, type SwapModelRef } from './playground-model-swap.js';
 import Anthropic from '@anthropic-ai/sdk';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -141,6 +142,37 @@ export function PlaygroundChat({
   // a "to send" array we drain on each submit.
   const uploads = usePlaygroundUploads();
   const [pendingAttachments, setPendingAttachments] = useState<UploadedFile[]>([]);
+
+  // Swapping the loaded model invalidates every expressId already in the
+  // transcript: they are unique inside ONE STEP file, not across files. The
+  // conversation is deliberately kept (losing the user's thread on a file swap
+  // would be worse), so the boundary is stated in-band instead — the agent
+  // re-reads the whole transcript every turn, and this notice is the only
+  // thing standing between it and confidently acting on a stale id (#2471).
+  //
+  // `lastLoaded` is NOT cleared when the model is closed. It has to survive
+  // that, or load A -> close -> load B reads as a first load and says nothing
+  // — and the close button sits in the same toolbar as the file picker.
+  const lastLoaded = useRef<SwapModelRef | null>(null);
+  const loadCounter = useRef(0);
+  const nextRef = useRef<SwapModelRef | null>(null);
+  const currentModelObject = useRef<LoadedPlaygroundModel | null>(null);
+  if (model !== currentModelObject.current) {
+    currentModelObject.current = model;
+    // A new model OBJECT is a new load. The id is a slug of the filename, so
+    // re-dropping a revised `model.ifc` keeps the id while every expressId may
+    // have moved — the load counter is what distinguishes them.
+    loadCounter.current += 1;
+    nextRef.current = model ? { loadId: loadCounter.current, name: model.name } : null;
+  }
+  const next = nextRef.current;
+  useEffect(() => {
+    setMessages((prior) => {
+      const notice = modelSwapNotice(lastLoaded.current, next, prior.length);
+      return notice ? [...prior, notice] : prior;
+    });
+    if (next !== null) lastLoaded.current = next;
+  }, [next]);
 
   // Auto-scroll on new content
   useEffect(() => {
@@ -737,8 +769,11 @@ type ApiMessage =
  * tool_result message → standalone user text message) breaks that contract
  * the moment the user asks a follow-up after a tool round, because the
  * NEW user text lands AFTER the tool_result, separating it from the
- * tool_use by an extra turn (and yielding a double-user pair Anthropic
- * also rejects).
+ * tool_use by an extra turn (and yielding a double-user pair, which the
+ * Messages API now merges into one turn rather than rejecting — the
+ * tool_result-must-come-first ordering below is the part that still
+ * matters, and the model-swap notice at #2471 deliberately relies on
+ * consecutive user turns being accepted).
  *
  * Fix: merge an assistant turn's pending tool_results into the very next
  * user turn as combined blocks (`[tool_result_*…, { type:'text', text }]`).

--- a/apps/viewer/src/components/mcp/playground-dispatcher.ts
+++ b/apps/viewer/src/components/mcp/playground-dispatcher.ts
@@ -1957,6 +1957,26 @@ export interface AnthropicToolDef {
   input_schema: AnthropicInputSchema;
 }
 
+/**
+ * Descriptions that are true of the stdio MCP server but NOT of the browser
+ * playground, overridden for the agent only (#2471).
+ *
+ * CATALOG is shared: it also drives the public /mcp landing page, which
+ * documents the stdio server (`npx -y @ifc-lite/mcp`) and even ships a
+ * two-file `diff-versions` recipe built on `model_load`. Editing the catalog
+ * entry itself would trade an agent-facing inaccuracy for a docs-facing one,
+ * so the override lives here, where the audience is known.
+ */
+const PLAYGROUND_DESCRIPTION_OVERRIDES: Record<string, string> = {
+  // The impl throws UNSUPPORTED_OPERATION unconditionally, but the catalog
+  // text ("Load an additional .ifc from disk into the federated session")
+  // invited the agent to call it on every request and let it discover the
+  // single-model contract only from the runtime refusal.
+  model_load:
+    'NOT AVAILABLE HERE. The browser playground holds exactly one model and cannot federate. ' +
+    'Ask the user to load a different file instead. (The stdio MCP server does support this.)',
+};
+
 /** Build the `tools` array Anthropic expects, derived from CATALOG +
  *  supportedToolNames(). Always returns the literal-typed shape Anthropic's
  *  SDK demands (input_schema.type === 'object'). */
@@ -1966,7 +1986,7 @@ export function anthropicToolDefinitions(): AnthropicToolDef[] {
     .filter((t: CatalogTool) => supported.has(t.name))
     .map((t) => ({
       name: t.name,
-      description: t.description,
+      description: PLAYGROUND_DESCRIPTION_OVERRIDES[t.name] ?? t.description,
       input_schema: ensureObjectSchema(t),
     }));
 }

--- a/apps/viewer/src/components/mcp/playground-model-swap.test.ts
+++ b/apps/viewer/src/components/mcp/playground-model-swap.test.ts
@@ -1,0 +1,81 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * A model swap must invalidate the ids already in the transcript (#2471).
+ *
+ * The playground is single-model by construction, so the unqualified-identity
+ * defect #2471 was filed for is not reachable. This is the half that is: two
+ * files in one session, and an agent holding `expressId`s from the first.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { modelSwapNotice, type SwapModelRef } from './playground-model-swap.js';
+
+const A: SwapModelRef = { loadId: 1, name: 'tower.ifc' };
+const B: SwapModelRef = { loadId: 2, name: 'annex.ifc' };
+
+describe('modelSwapNotice', () => {
+  it('warns when a different model is loaded under an existing transcript', () => {
+    const notice = modelSwapNotice(A, B, 4);
+    assert.ok(notice, 'a swap with history must be announced');
+    assert.match(notice.text, /annex\.ifc/, 'names the model now loaded');
+    assert.match(notice.text, /expressId/, 'names what is invalidated');
+    // The agent reads the transcript as conversation; a notice it cannot see
+    // as input would never reach it.
+    assert.equal(notice.role, 'user');
+  });
+
+  it('does not claim GlobalIds are invalid — they can survive a revision', () => {
+    const notice = modelSwapNotice(A, B, 4);
+    assert.ok(notice);
+    assert.match(
+      notice.text,
+      /GlobalIds may survive/,
+      'two revisions of one project is the likeliest two-file session; ' +
+        'telling the agent every GlobalId is dead makes it re-query valid ones',
+    );
+  });
+
+  it('warns after unload-then-load, which is a button in the same toolbar', () => {
+    // Load A, close (lastLoaded must NOT be cleared), then load B. If the
+    // caller reset its ref on close this reads as a first load and the whole
+    // guard is bypassed.
+    assert.equal(modelSwapNotice(A, null, 5), null, 'closing says nothing yet');
+    const afterReload = modelSwapNotice(A, B, 5);
+    assert.ok(afterReload, 'the deferred warning must arrive on the next load');
+  });
+
+  it('warns when the same FILENAME is re-dropped, because ids are filename slugs', () => {
+    // A revised `tower.ifc` keeps the model id. Every expressId may have
+    // moved, so identity is the load, not the name.
+    const revised: SwapModelRef = { loadId: 7, name: 'tower.ifc' };
+    assert.ok(modelSwapNotice(A, revised, 3));
+  });
+
+  it('says nothing on the first load — there is no earlier id to invalidate', () => {
+    assert.equal(modelSwapNotice(null, A, 0), null);
+    assert.equal(modelSwapNotice(null, A, 3), null);
+  });
+
+  it('says nothing when the same load re-renders', () => {
+    assert.equal(modelSwapNotice(A, { ...A }, 5), null);
+  });
+
+  it('says nothing when the transcript is empty', () => {
+    assert.equal(modelSwapNotice(A, B, 0), null);
+  });
+
+  it('gives every load a distinct key, so A→B→A→B does not collide', () => {
+    // The transcript renders `<li key={m.id}>`; two messages sharing an id
+    // are a React key collision, not just a cosmetic repeat.
+    const ids = [
+      modelSwapNotice(A, B, 2),
+      modelSwapNotice(B, { loadId: 3, name: 'tower.ifc' }, 3),
+      modelSwapNotice({ loadId: 3, name: 'tower.ifc' }, { loadId: 4, name: 'annex.ifc' }, 4),
+    ].map((n) => n?.id);
+    assert.equal(new Set(ids).size, 3, `keys collided: ${ids.join(', ')}`);
+  });
+});

--- a/apps/viewer/src/components/mcp/playground-model-swap.ts
+++ b/apps/viewer/src/components/mcp/playground-model-swap.ts
@@ -1,0 +1,83 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * What to do to the chat transcript when the loaded model changes (#2471).
+ *
+ * The playground holds exactly one model and every write replaces it
+ * (`McpPlayground.tsx`: sample load, file drop, close). The transcript is NOT
+ * cleared on that swap — losing the user's thread because they opened a second
+ * file would be worse than the problem being solved.
+ *
+ * But `expressId` is unique inside ONE STEP file and not across files, so the
+ * moment the model changes, every id sitting in earlier tool results names a
+ * different element in the new file, or nothing at all. The agent re-reads the
+ * whole transcript on every turn and has no way to tell which side of the swap
+ * a result came from. Nothing else in the playground marks that boundary.
+ *
+ * This is the reachable half of #2471. The unqualified-identity defect that
+ * issue was filed for needs the playground to federate, which it cannot
+ * (`buildEntityRecords` throws on a second model, #2492) — but a stale id
+ * replayed across a swap needs only two files and one session.
+ *
+ * Kept as a pure function so the decision can be pinned, in the house style of
+ * `hooks/cacheTier.ts`'s deciders: the component owns the effect, this owns the
+ * rule.
+ *
+ * IDENTITY IS THE LOAD, NOT THE FILE. Every comparison here is on `loadId`, a
+ * token minted once per load by the caller — never on the model id, which is a
+ * slug of the filename (`parsePlaygroundModel`). Dropping a revised
+ * `model.ifc` over the old one is the single most likely two-file session
+ * there is, and it keeps the same id while every expressId may have moved.
+ */
+
+/** A loaded model, as this decision sees it. */
+export interface SwapModelRef {
+  /** Unique per LOAD. Two loads of the same filename are two different loads. */
+  loadId: number;
+  /** Display name, for the notice text. */
+  name: string;
+}
+
+/** The subset of `ChatMessage` this produces. */
+export interface SwapNotice {
+  id: string;
+  role: 'user';
+  text: string;
+}
+
+/**
+ * The notice to append when the loaded model moves from `lastLoaded` to
+ * `next`, or `null` when nothing needs saying.
+ *
+ * `lastLoaded` is the last model that was actually LOADED, which the caller
+ * must keep across a close. Clearing it on unload would let
+ * load A → close → load B slip through as a first load, and that path is a
+ * button in the same toolbar.
+ */
+export function modelSwapNotice(
+  lastLoaded: SwapModelRef | null,
+  next: SwapModelRef | null,
+  transcriptLength: number,
+): SwapNotice | null {
+  // Closing: nothing is loaded to confuse ids with, and the next load is
+  // still compared against `lastLoaded`, so the warning is only deferred.
+  if (next === null) return null;
+  // First load of the session: no earlier ids exist.
+  if (lastLoaded === null) return null;
+  // Same load re-rendering.
+  if (lastLoaded.loadId === next.loadId) return null;
+  if (transcriptLength === 0) return null;
+  return {
+    // Keyed on the load, so swapping A → B → A → B yields four distinct React
+    // keys rather than two colliding pairs.
+    id: `model-swap-${next.loadId}`,
+    role: 'user',
+    text:
+      `[The loaded model changed to "${next.name}". Every expressId from earlier tool ` +
+      'results belongs to the previous file and does not identify anything in this one. ' +
+      'GlobalIds may survive if these are two revisions of the same project, but verify ' +
+      'rather than assume. Re-query before acting on any id from above.]',
+  };
+}


### PR DESCRIPTION
Closes #2471.

The issue says to establish reachability before changing anything, and that if the surface is single-model by construction this should be *recorded as latent rather than fixed speculatively*. So: the answer, then the thing that turned out to be reachable.

## The federated collision is NOT reachable — six independent reasons

| # | Evidence |
| --- | --- |
| 1 | `App.tsx:72-84` renders `<McpPlayground/>` and returns **before** `<BimProvider>` at `:100`. `useIfcFederation` is reached only through `hooks/useIfc.ts:85`, inside that tree. The route cannot reach it. |
| 2 | No file under `components/mcp/` imports the store, `FederationRegistry`, or any hook. |
| 3 | `McpPlayground.tsx:82` holds one model slot; every write replaces it (`:108` sample, `:122` drop, `:132` close). |
| 4 | The only production `DispatchContext` (`:92-98`) omits `registry` — read solely by `resolveDiffModels` (`playground-dispatcher.ts:1796`). Grep finds **zero producers of that field anywhere**, tests included, so even the two-model diff path is dead. |
| 5 | `model_load` throws `UNSUPPORTED_OPERATION` (`:1595-1603`); `model_list` hard-codes one model (`:518-522`). |
| 6 | #2492 already made `buildEntityRecords` throw when handed a second model. |

So the three named sites (`colorByProperty`'s `byEntity` and `sample()`, `countEntities`, `byExpressId`) stay bare-keyed. Each is correct under the precondition and each already carries the comment naming it. **No qualified-identity rework** — that is the speculative fix the issue warned against, and the recipe stays on the issue until the guard actually fires.

## What IS reachable, and what this fixes

`PlaygroundChat` never annotates its transcript when the model is swapped.

`expressId` is unique inside **one** STEP file and not across files. After a swap, every id in an earlier tool result names a different element in the new file, or nothing — and the agent re-reads the whole transcript each turn with no way to tell which side of the swap a result came from. **Two files, one session, no federation required.**

The transcript is deliberately *not* cleared — losing the user's thread because they opened a second file is worse than the problem. The boundary is stated in-band instead.

## Three things the obvious version gets wrong

All three found by adversarial review, all now pinned by tests:

1. **`lastLoaded` survives a close.** Clearing it on unload lets `load A -> close -> load B` read as a first load and say nothing — and the close button is in the same toolbar as the file picker. This would have bypassed the entire fix.
2. **Identity is the LOAD, not the model id.** The id is a slug of the filename (`parsePlaygroundModel`), so re-dropping a revised `model.ifc` keeps it while every expressId may have moved. That is the single most likely two-file session there is.
3. **The key is per-load**, so `A->B->A->B` yields four distinct React keys rather than two colliding pairs — the transcript renders `<li key={m.id}>`.

The notice also does **not** claim GlobalIds are dead. They are persistent by design, and two revisions of one project is the likeliest two-file session; telling the agent otherwise makes it re-query valid ids.

## The catalog was inviting the agent to federate

`model_load`'s description read *"Load an additional .ifc from disk into the federated session"* while the impl unconditionally refuses. The agent saw that in its tool list on every request and learned the real contract only from the runtime error.

Overridden for the **playground only**. `CATALOG` is shared: it also drives the public `/mcp` landing page, which documents the **stdio** server — where `model_load` genuinely works, and which ships a two-file `diff-versions` recipe built on it. Editing the shared entry would have traded an agent-facing inaccuracy for a docs-facing one.

## Verification

- **8 tests, each killed by exactly one mutation** — all four guards, the message key, and the GlobalId wording. No assertion survives a targeted mutation.
- Viewer suite: **3747 tests, 3747 pass, 0 fail**
- Typecheck clean
- CodeRabbit CLI against `origin/main`: **no findings** (hosted review is rate-limited on this repo)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a notice when switching models in the playground, preserving the existing conversation while warning that previous `expressId` values may not apply.
  * Added clearer guidance that browser sessions support one loaded model at a time and that another file can be loaded through the interface.

* **Documentation**
  * Updated Anthropic message guidance to cover consecutive user messages and required tool-result ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->