### PR TITLE
fix(viewer): flag a model that is georeferenced twice instead of placing it 6000 km out (#2526)

### DIFF
--- a/apps/viewer/src/components/viewer/properties/GeoreferencingPanel.tsx
+++ b/apps/viewer/src/components/viewer/properties/GeoreferencingPanel.tsx
@@ -32,11 +32,19 @@ import { toast } from '@/components/ui/toast';
 
 // ── Field-specific assistance data ─────────────────────────────────────
 
-/** Metres → a short human-readable distance ("5,206 km", "820 m"). */
+/**
+ * Metres → a short human-readable distance ("6,004 km", "820 m").
+ *
+ * Past ~2.5 Earth circumferences the figure stops meaning anything to a reader
+ * and starts looking like a formatting bug, so say what it actually implies
+ * instead. A file that also mis-scales lands there easily: a 1000× scale on
+ * map-sized coordinates produces billions of km.
+ */
 function formatDistance(metres: number): string {
-  if (!Number.isFinite(metres)) return '?';
-  if (metres >= 1000) return `${Math.round(metres / 1000).toLocaleString()} km`;
-  return `${Math.round(metres).toLocaleString()} m`;
+  if (!Number.isFinite(metres)) return 'an unknown distance';
+  if (metres > 100_000_000) return 'more than a planet-width';
+  if (metres >= 1000) return `about ${Math.round(metres / 1000).toLocaleString()} km`;
+  return `about ${Math.round(metres).toLocaleString()} m`;
 }
 
 const COMMON_DATUMS = ['WGS84', 'ETRS89', 'NAD83', 'NAD27', 'GRS80', 'Bessel 1841', 'Clarke 1866'];
@@ -527,13 +535,17 @@ export function GeoreferencingPanel({ georef, modelId, enableEditing, schemaVers
 
   // Clear a duplicated MapConversion offset (#2526): the geometry is already in
   // the map CRS, so the conversion has to be a horizontal identity.
-  const applyIdentityConversion = useCallback(() => {
+  const applyIdentityConversion = useCallback((scaleCorrection: number | null) => {
     if (!modelId || !setGeorefFields) return;
-    setGeorefFields(modelId, 'mapConversion', identityConversionFields().map(({ field, value }) => ({
-      field,
-      value,
-      oldValue: mergedConversion?.[field as keyof MapConversion] as number | undefined,
-    })));
+    setGeorefFields(
+      modelId,
+      'mapConversion',
+      identityConversionFields(scaleCorrection).map(({ field, value }) => ({
+        field,
+        value,
+        oldValue: mergedConversion?.[field as keyof MapConversion] as number | undefined,
+      })),
+    );
     posthog.capture('georeference_set', { method: 'double_georeference_identity' });
     setConversionOpen(true);
     requestAlignmentReload();
@@ -714,15 +726,19 @@ export function GeoreferencingPanel({ georef, modelId, enableEditing, schemaVers
               <strong>Model is georeferenced twice.</strong>{' '}
               The geometry already sits at map coordinates (E{' '}
               {doubleGeoref.worldCenter.x.toFixed(0)} N {doubleGeoref.worldCenter.y.toFixed(0)}),
-              and this IfcMapConversion repeats the same offset. Applying it moves the model
-              about {formatDistance(doubleGeoref.displacement)} away from where it belongs.
+              and this IfcMapConversion repeats the same offset. Applying it displaces the model
+              by {formatDistance(doubleGeoref.displacement)}.
               {editable
-                ? ' The fix below zeroes Eastings/Northings and resets the rotation to grid-aligned, treating the geometry as already being in the map CRS. OrthogonalHeight and Scale are left as authored.'
+                ? ` The fix below zeroes Eastings/Northings and resets the rotation to grid-aligned${
+                  doubleGeoref.scaleCorrection !== null
+                    ? `, sets Scale to ${doubleGeoref.scaleCorrection.toPrecision(4)} so the geometry is no longer re-scaled about the map origin,`
+                    : ''
+                } and treats the geometry as already being in the map CRS. OrthogonalHeight is left as authored.`
                 : ' Enable editing to correct it.'}
-              {/* The fingerprint matches on translation, so when the file gives
-                  us no way to corroborate the rotation, say that the resulting
-                  orientation is our choice rather than the file's. */}
-              {editable && !doubleGeoref.rotationCorroborated && (
+              {/* The fingerprint matches on TRANSLATION, so when the file authors
+                  a rotation of its own we are choosing the orientation, not
+                  restating it. Say so rather than applying it silently. */}
+              {editable && doubleGeoref.overridesAuthoredRotation && (
                 <>
                   {' '}This file authors a rotation that cannot be reconciled with its own
                   coordinates, so check the orientation afterwards and set Angle to Grid North
@@ -733,7 +749,7 @@ export function GeoreferencingPanel({ georef, modelId, enableEditing, schemaVers
           </div>
           {editable && (
             <button
-              onClick={applyIdentityConversion}
+              onClick={() => applyIdentityConversion(doubleGeoref.scaleCorrection)}
               className="mt-1.5 ml-[18px] text-[10px] text-amber-800 dark:text-amber-300 hover:text-amber-950 dark:hover:text-amber-200 px-1.5 py-0.5 border border-amber-400/60 dark:border-amber-700/60 hover:bg-amber-100/70 dark:hover:bg-amber-900/40 transition-colors"
             >
               Treat geometry as already in the map CRS

--- a/apps/viewer/src/components/viewer/properties/GeoreferencingPanel.tsx
+++ b/apps/viewer/src/components/viewer/properties/GeoreferencingPanel.tsx
@@ -26,10 +26,18 @@ import {
   mergeProjectedCRS,
   supportsStandardGeoreferencing,
 } from '@/lib/geo/effective-georef';
+import { detectDoubleGeoreference, identityConversionFields } from '@/lib/geo/double-georeference';
 import { useIfc } from '@/hooks/useIfc';
 import { toast } from '@/components/ui/toast';
 
 // ── Field-specific assistance data ─────────────────────────────────────
+
+/** Metres → a short human-readable distance ("5,206 km", "820 m"). */
+function formatDistance(metres: number): string {
+  if (!Number.isFinite(metres)) return '?';
+  if (metres >= 1000) return `${Math.round(metres / 1000).toLocaleString()} km`;
+  return `${Math.round(metres).toLocaleString()} m`;
+}
 
 const COMMON_DATUMS = ['WGS84', 'ETRS89', 'NAD83', 'NAD27', 'GRS80', 'Bessel 1841', 'Clarke 1866'];
 const COMMON_PROJECTIONS = ['Transverse Mercator', 'UTM', 'Lambert Conformal Conic', 'Mercator', 'Stereographic', 'Oblique Mercator'];
@@ -387,6 +395,18 @@ export function GeoreferencingPanel({ georef, modelId, enableEditing, schemaVers
     );
   }, [mergedConversion, mergedCRS?.mapUnitScale, lengthUnitScale]);
 
+  // Geometry already at absolute map coordinates AND a MapConversion repeating
+  // the same offset — applying it a second time throws the model thousands of
+  // km off (#2526). Report only; the user decides.
+  const doubleGeoref = useMemo(() => {
+    return detectDoubleGeoreference(
+      mergedConversion,
+      mergedCRS,
+      coordinateInfo,
+      lengthUnitScale ?? 1,
+    );
+  }, [mergedConversion, mergedCRS, coordinateInfo, lengthUnitScale]);
+
   const mapUnitSuffix = useMemo(() => {
     const mapUnit = mergedCRS?.mapUnit?.toUpperCase();
     if (!mapUnit) return 'm';
@@ -502,6 +522,20 @@ export function GeoreferencingPanel({ georef, modelId, enableEditing, schemaVers
       { field: 'xAxisOrdinate', value: ordinate, oldValue: mergedConversion?.xAxisOrdinate },
     ]);
     posthog.capture('georeference_set', { method: 'true_north' });
+    requestAlignmentReload();
+  }, [modelId, setGeorefFields, mergedConversion, requestAlignmentReload]);
+
+  // Clear a duplicated MapConversion offset (#2526): the geometry is already in
+  // the map CRS, so the conversion has to be a horizontal identity.
+  const applyIdentityConversion = useCallback(() => {
+    if (!modelId || !setGeorefFields) return;
+    setGeorefFields(modelId, 'mapConversion', identityConversionFields().map(({ field, value }) => ({
+      field,
+      value,
+      oldValue: mergedConversion?.[field as keyof MapConversion] as number | undefined,
+    })));
+    posthog.capture('georeference_set', { method: 'double_georeference_identity' });
+    setConversionOpen(true);
     requestAlignmentReload();
   }, [modelId, setGeorefFields, mergedConversion, requestAlignmentReload]);
 
@@ -669,6 +703,35 @@ export function GeoreferencingPanel({ georef, modelId, enableEditing, schemaVers
         )}
       </div>
 
+      {/* Doubly-georeferenced model (#2526). Sits ABOVE the collapsibles and
+          outside them: a multi-thousand-km placement error must not be hidden
+          behind a collapsed section the way the scale note is. */}
+      {doubleGeoref && (
+        <div className="px-3 py-2 border-b border-zinc-100 dark:border-zinc-900 bg-amber-50/60 dark:bg-amber-950/25">
+          <div className="flex items-start gap-1.5 text-[10px] text-amber-700 dark:text-amber-400">
+            <AlertTriangle className="h-3 w-3 mt-0.5 shrink-0" />
+            <span className="leading-snug">
+              <strong>Model is georeferenced twice.</strong>{' '}
+              The geometry already sits at map coordinates (E{' '}
+              {doubleGeoref.worldCenter.x.toFixed(0)} N {doubleGeoref.worldCenter.y.toFixed(0)}),
+              and this IfcMapConversion repeats the same offset. Applying it moves the model
+              about {formatDistance(doubleGeoref.displacement)} away from where it belongs.
+              {editable
+                ? ' Clearing the offset treats the geometry as already being in the map CRS.'
+                : ' Enable editing to clear the offset.'}
+            </span>
+          </div>
+          {editable && (
+            <button
+              onClick={applyIdentityConversion}
+              className="mt-1.5 ml-[18px] text-[10px] text-amber-800 dark:text-amber-300 hover:text-amber-950 dark:hover:text-amber-200 px-1.5 py-0.5 border border-amber-400/60 dark:border-amber-700/60 hover:bg-amber-100/70 dark:hover:bg-amber-900/40 transition-colors"
+            >
+              Clear the duplicated offset
+            </button>
+          )}
+        </div>
+      )}
+
       {/* IfcProjectedCRS */}
       {mergedCRS && (
         <div>
@@ -719,7 +782,10 @@ export function GeoreferencingPanel({ georef, modelId, enableEditing, schemaVers
             <ChevronRight className={`h-3 w-3 text-teal-500 shrink-0 transition-transform ${conversionOpen ? 'rotate-90' : ''}`} />
             <MapPin className="h-3 w-3 text-teal-500 shrink-0" />
             <span className="font-bold text-[11px] text-zinc-700 dark:text-zinc-300 uppercase tracking-wide flex-1 text-left">Coordinate Operation</span>
-            {scaleMismatch && (
+            {/* A COMPENSATED scale deviation gets no warning glyph: nothing is
+                mis-sized here, and an amber flag on a non-problem is what made
+                the real defect in #2526 easy to miss. */}
+            {scaleMismatch && !scaleMismatch.compensated && (
               <Tooltip>
                 <TooltipTrigger asChild>
                   <AlertTriangle
@@ -751,16 +817,24 @@ export function GeoreferencingPanel({ georef, modelId, enableEditing, schemaVers
               <AngleRow angle={angleToGridNorth} editable={editable} onAngleChange={handleAngleChange} />
               <GeorefRow label="Scale" value={mergedConversion.scale} isNumber editable={editable} isMutated={isMutated('mapConversion', 'scale')} fieldEntity="mapConversion" fieldName="scale" onSave={v => handleSave('mapConversion', 'scale', v)} />
               {scaleMismatch && (
-                <div className="px-3 py-2 flex items-start gap-1.5 text-[10px] text-amber-600 dark:text-amber-400 bg-amber-50/50 dark:bg-amber-950/20">
+                <div className={`px-3 py-2 flex items-start gap-1.5 text-[10px] leading-snug ${
+                  scaleMismatch.compensated
+                    ? 'text-zinc-500 dark:text-zinc-400 bg-zinc-50/60 dark:bg-zinc-900/40'
+                    : 'text-amber-600 dark:text-amber-400 bg-amber-50/50 dark:bg-amber-950/20'
+                }`}>
                   <AlertTriangle className="h-3 w-3 mt-0.5 shrink-0" />
-                  <span className="leading-snug">
+                  <span>
                     <strong>Scale inconsistent with project/map units.</strong>{' '}
                     Per IFC schema, IfcMapConversion.Scale should bridge the unit
                     difference between the project length unit and map CRS unit.
                     Current Scale = {scaleMismatch.rawScale}; expected ≈{' '}
-                    {scaleMismatch.expectedScale.toPrecision(4)}. Geometry is
-                    being placed at {scaleMismatch.effectiveScale.toPrecision(4)}×
-                    its physical size — adjust Scale (or MapUnit) to fix.
+                    {scaleMismatch.expectedScale.toPrecision(4)}.{' '}
+                    {scaleMismatch.compensated
+                      ? `ifc-lite compensates and places the geometry at 1× — no action needed here, but a
+                         tool that follows the schema strictly will render this file at
+                         ${scaleMismatch.specEffectiveScale.toPrecision(4)}× its physical size.`
+                      : `Geometry is being placed at ${scaleMismatch.effectiveScale.toPrecision(4)}×
+                         its physical size — adjust Scale (or MapUnit) to fix.`}
                   </span>
                 </div>
               )}

--- a/apps/viewer/src/components/viewer/properties/GeoreferencingPanel.tsx
+++ b/apps/viewer/src/components/viewer/properties/GeoreferencingPanel.tsx
@@ -717,8 +717,18 @@ export function GeoreferencingPanel({ georef, modelId, enableEditing, schemaVers
               and this IfcMapConversion repeats the same offset. Applying it moves the model
               about {formatDistance(doubleGeoref.displacement)} away from where it belongs.
               {editable
-                ? ' Clearing the offset treats the geometry as already being in the map CRS.'
-                : ' Enable editing to clear the offset.'}
+                ? ' The fix below zeroes Eastings/Northings and resets the rotation to grid-aligned, treating the geometry as already being in the map CRS. OrthogonalHeight and Scale are left as authored.'
+                : ' Enable editing to correct it.'}
+              {/* The fingerprint matches on translation, so when the file gives
+                  us no way to corroborate the rotation, say that the resulting
+                  orientation is our choice rather than the file's. */}
+              {editable && !doubleGeoref.rotationCorroborated && (
+                <>
+                  {' '}This file authors a rotation that cannot be reconciled with its own
+                  coordinates, so check the orientation afterwards and set Angle to Grid North
+                  by hand if it looks wrong.
+                </>
+              )}
             </span>
           </div>
           {editable && (
@@ -726,7 +736,7 @@ export function GeoreferencingPanel({ georef, modelId, enableEditing, schemaVers
               onClick={applyIdentityConversion}
               className="mt-1.5 ml-[18px] text-[10px] text-amber-800 dark:text-amber-300 hover:text-amber-950 dark:hover:text-amber-200 px-1.5 py-0.5 border border-amber-400/60 dark:border-amber-700/60 hover:bg-amber-100/70 dark:hover:bg-amber-900/40 transition-colors"
             >
-              Clear the duplicated offset
+              Treat geometry as already in the map CRS
             </button>
           )}
         </div>

--- a/apps/viewer/src/lib/geo/double-georeference.test.ts
+++ b/apps/viewer/src/lib/geo/double-georeference.test.ts
@@ -181,6 +181,24 @@ describe('detectDoubleGeoreference', () => {
       );
     });
 
+    it('corrects a NEAR-unit scale whose induced drift is still kilometres', () => {
+      // Effective scale 1.004 is inside detectScaleUnitMismatch's 0.5% band,
+      // but multiplied by a ~6 000 km coordinate it drags the model ~24 km. A
+      // fraction-based tolerance would wave this through.
+      const nearUnit: MapConversion = { ...ISSUE_2526_CONVERSION, scale: 1.004 };
+      const info = coordInfoAt(311988.18054, 5996148.56499);
+      const found = detectDoubleGeoreference(nearUnit, METRE_CRS, info, 1);
+      assert.ok(found);
+      assert.ok(found!.scaleCorrection !== null, 'a 24 km drift must be corrected');
+      const fixed: MapConversion = {
+        ...nearUnit,
+        ...Object.fromEntries(
+          identityConversionFields(found!.scaleCorrection).map(f => [f.field, f.value]),
+        ),
+      };
+      assert.strictEqual(detectDoubleGeoreference(fixed, METRE_CRS, info, 1), null);
+    });
+
     it('leaves a genuine foot/metre bridge alone', () => {
       // Foot project, foot MapUnit, Scale 1: effective scale is 1, so nothing
       // to correct and the authored Scale survives untouched.
@@ -282,6 +300,37 @@ describe('detectDoubleGeoreference', () => {
       detectDoubleGeoreference(broken, METRE_CRS, coordInfoAt(311988, 5996149), 0.001),
       null,
     );
+  });
+
+  it('returns null for a non-finite axis rather than quoting a NaN distance', () => {
+    // hasStandardGeoreferencing deliberately lets a non-finite axis through (it
+    // has downstream fallbacks elsewhere), so the guard has to live here: a NaN
+    // axis would poison `displacement` and flip `overridesAuthoredRotation` by
+    // accident.
+    const info = coordInfoAt(311988.18054, 5996148.56499);
+    for (const broken of [
+      { ...ISSUE_2526_CONVERSION, xAxisAbscissa: NaN },
+      { ...ISSUE_2526_CONVERSION, xAxisOrdinate: Number.POSITIVE_INFINITY },
+    ] satisfies MapConversion[]) {
+      assert.strictEqual(detectDoubleGeoreference(broken, METRE_CRS, info, 0.001), null);
+    }
+  });
+
+  it('still flags when Scale is NaN, because the effective scale resolves to 1', () => {
+    // Not an oversight: getEffectiveHorizontalScale's unset/1 heuristic treats a
+    // NaN Scale as "not provided" (NaN fails its `> 1e-9` test) and returns 1,
+    // so the effective scale is well defined and the duplicated offsets are
+    // still the real defect. The finite guard above is for the axis, which has
+    // no such upstream normalisation.
+    const found = detectDoubleGeoreference(
+      { ...ISSUE_2526_CONVERSION, scale: NaN },
+      METRE_CRS,
+      coordInfoAt(311988.18054, 5996148.56499),
+      0.001,
+    );
+    assert.ok(found);
+    assert.strictEqual(found!.scaleCorrection, null);
+    assert.ok(Number.isFinite(found!.displacement));
   });
 });
 

--- a/apps/viewer/src/lib/geo/double-georeference.test.ts
+++ b/apps/viewer/src/lib/geo/double-georeference.test.ts
@@ -88,17 +88,30 @@ describe('detectDoubleGeoreference', () => {
     );
   });
 
-  describe('rotationCorroborated (Codex review, PR #2543)', () => {
-    // The fingerprint matches on TRANSLATION, so it does not by itself prove
-    // the model's local axes are grid-aligned. The fix resets the axis anyway
-    // (a non-identity rotation acting on a map-sized coordinate is
-    // unrecoverable whatever the offsets are), so the flag tells the UI when
-    // that reset merely restates the file and when it is our choice.
+  describe('overridesAuthoredRotation (PR #2543 review)', () => {
+    // The fingerprint matches on TRANSLATION, so it does not prove the model's
+    // local axes are grid-aligned. The fix resets the axis anyway (a
+    // non-identity rotation acting on a map-sized coordinate is unrecoverable
+    // whatever the offsets are), so this flag tells the UI when that reset is
+    // OUR choice of orientation rather than a restatement of the file's.
 
-    it('is true when the site placement carries the rotation (issue #2526)', () => {
-      // Site X axis (-0.46689605, -0.88431221) = -117.833°, baked into the
-      // world coordinates — those world axes ARE the grid axes, so the
-      // conversion's own rotation is redundant.
+    it('is true whenever the file authors a rotation of its own', () => {
+      const found = detectDoubleGeoreference(
+        ISSUE_2526_CONVERSION,
+        METRE_CRS,
+        coordInfoAt(311988.18054, 5996148.56499),
+        0.001,
+      );
+      assert.ok(found);
+      assert.strictEqual(found!.overridesAuthoredRotation, true);
+    });
+
+    it('stays true even when the site placement carries its own rotation', () => {
+      // A rotating placement is evidence that the world frame IS the map frame,
+      // but not proof: the placement rotation and the conversion axis can
+      // simply disagree (they do here — -117.833° vs +90°). Treating it as
+      // corroboration would silently pick one, which is what the flag exists to
+      // prevent.
       const found = detectDoubleGeoreference(
         ISSUE_2526_CONVERSION,
         METRE_CRS,
@@ -106,10 +119,10 @@ describe('detectDoubleGeoreference', () => {
         0.001,
       );
       assert.ok(found);
-      assert.strictEqual(found!.rotationCorroborated, true);
+      assert.strictEqual(found!.overridesAuthoredRotation, true);
     });
 
-    it('is true when the conversion authors no rotation at all', () => {
+    it('is false when the conversion authors no rotation at all', () => {
       const noRotation: MapConversion = {
         ...ISSUE_2526_CONVERSION,
         xAxisAbscissa: 1,
@@ -122,22 +135,70 @@ describe('detectDoubleGeoreference', () => {
         0.001,
       );
       assert.ok(found);
-      assert.strictEqual(found!.rotationCorroborated, true);
+      assert.strictEqual(found!.overridesAuthoredRotation, false);
     });
+  });
 
-    it('is FALSE for a translation-only placement plus an authored rotation', () => {
-      // The reviewed hazard: the placement contributes the absolute offset but
-      // no rotation, so the conversion's rotation might have been the real one.
-      // Still flagged (the translation IS duplicated) but the UI must warn that
-      // the resulting orientation is a choice.
+  describe('scaleCorrection (PR #2543 review)', () => {
+    it('is null when the effective horizontal scale is already 1', () => {
+      // #2526's file: Scale unset on a mm project with a metre MapUnit, which
+      // getEffectiveHorizontalScale already resolves to 1.
       const found = detectDoubleGeoreference(
         ISSUE_2526_CONVERSION,
         METRE_CRS,
-        coordInfoAt(311988.18054, 5996148.56499, 0, 0),
+        coordInfoAt(311988.18054, 5996148.56499),
         0.001,
       );
       assert.ok(found);
-      assert.strictEqual(found!.rotationCorroborated, false);
+      assert.strictEqual(found!.scaleCorrection, null);
+    });
+
+    it('supplies the unit bridge when a non-unit scale really is applied', () => {
+      // Scale explicitly 1000 on a mm project: the unset-Scale heuristic does
+      // not rescue it, so 1e6 is applied and would keep re-scaling the map-sized
+      // coordinates about the map origin after the offsets are cleared.
+      const scaled: MapConversion = { ...ISSUE_2526_CONVERSION, scale: 1000 };
+      const found = detectDoubleGeoreference(
+        scaled,
+        METRE_CRS,
+        coordInfoAt(311988.18054, 5996148.56499),
+        0.001,
+      );
+      assert.ok(found);
+      assert.ok(found!.scaleCorrection !== null);
+      // lengthUnitScale / mapUnitScale = 0.001 / 1.
+      assert.ok(Math.abs(found!.scaleCorrection! - 0.001) < 1e-12);
+      // And it must actually neutralise: (0.001 * 1) / 0.001 = 1.
+      const fixed: MapConversion = {
+        ...scaled,
+        ...Object.fromEntries(
+          identityConversionFields(found!.scaleCorrection).map(f => [f.field, f.value]),
+        ),
+      };
+      assert.strictEqual(
+        detectDoubleGeoreference(fixed, METRE_CRS, coordInfoAt(311988.18054, 5996148.56499), 0.001),
+        null,
+      );
+    });
+
+    it('leaves a genuine foot/metre bridge alone', () => {
+      // Foot project, foot MapUnit, Scale 1: effective scale is 1, so nothing
+      // to correct and the authored Scale survives untouched.
+      const footConversion: MapConversion = {
+        ...ISSUE_2526_CONVERSION,
+        eastings: 311988.181 / 0.3048,
+        northings: 5996148.565 / 0.3048,
+        scale: 1,
+      };
+      const found = detectDoubleGeoreference(
+        footConversion,
+        { mapUnitScale: 0.3048 },
+        coordInfoAt(311988.18054, 5996148.56499),
+        0.3048,
+      );
+      assert.ok(found);
+      assert.strictEqual(found!.scaleCorrection, null);
+      assert.ok(!identityConversionFields(found!.scaleCorrection).some(f => f.field === 'scale'));
     });
   });
 
@@ -231,12 +292,22 @@ describe('identityConversionFields', () => {
       Object.fromEntries(fields.map(f => [f.field, f.value])),
       { eastings: 0, northings: 0, xAxisAbscissa: 1, xAxisOrdinate: 0 },
     );
-    // OrthogonalHeight and Scale must NOT be in the fix: the fingerprint is
-    // horizontal, and zeroing a height that legitimately carries the site
-    // altitude would trade one error for another.
+    // OrthogonalHeight must NOT be in the fix: the fingerprint is horizontal,
+    // and zeroing a height that legitimately carries the site altitude would
+    // trade one error for another. Scale only joins when it is actually being
+    // applied as non-unit (see the scaleCorrection suite).
     const names = fields.map(f => f.field);
     assert.ok(!names.includes('orthogonalHeight'));
     assert.ok(!names.includes('scale'));
+  });
+
+  it('adds Scale only when a correction was supplied', () => {
+    const fields = identityConversionFields(0.001);
+    assert.deepStrictEqual(
+      Object.fromEntries(fields.map(f => [f.field, f.value])),
+      { eastings: 0, northings: 0, xAxisAbscissa: 1, xAxisOrdinate: 0, scale: 0.001 },
+    );
+    assert.ok(!fields.some(f => f.field === 'orthogonalHeight'));
   });
 
   it('makes the flagged model stop being flagged', () => {

--- a/apps/viewer/src/lib/geo/double-georeference.test.ts
+++ b/apps/viewer/src/lib/geo/double-georeference.test.ts
@@ -200,17 +200,18 @@ describe('detectDoubleGeoreference', () => {
     });
 
     it('leaves a genuine foot/metre bridge alone', () => {
-      // Foot project, foot MapUnit, Scale 1: effective scale is 1, so nothing
-      // to correct and the authored Scale survives untouched.
-      const footConversion: MapConversion = {
-        ...ISSUE_2526_CONVERSION,
-        eastings: 311988.181 / 0.3048,
-        northings: 5996148.565 / 0.3048,
-        scale: 1,
-      };
+      // A real bridge needs the units to DIFFER: a foot project with a metre
+      // MapUnit, and Scale = 0.3048 doing exactly what the schema asks. The
+      // effective scale is then (0.3048 × 1) / 0.3048 = 1, so there is nothing
+      // to correct and the authored Scale must survive untouched — this is the
+      // case the "only correct a non-unit effective scale" rule exists to
+      // protect. (An earlier version of this test used foot units on BOTH
+      // sides with Scale = 1, which bridges nothing and so never exercised the
+      // rule it was named after — CodeRabbit, PR #2543.)
+      const footProject: MapConversion = { ...ISSUE_2526_CONVERSION, scale: 0.3048 };
       const found = detectDoubleGeoreference(
-        footConversion,
-        { mapUnitScale: 0.3048 },
+        footProject,
+        METRE_CRS,
         coordInfoAt(311988.18054, 5996148.56499),
         0.3048,
       );

--- a/apps/viewer/src/lib/geo/double-georeference.test.ts
+++ b/apps/viewer/src/lib/geo/double-georeference.test.ts
@@ -19,7 +19,12 @@ import { detectDoubleGeoreference, identityConversionFields } from './double-geo
  * keeps these tests about the detector, not about the axis swap (which
  * reproject.test.ts already pins).
  */
-function coordInfoAt(ifcX: number, ifcY: number, halfExtent = 0): CoordinateInfo {
+function coordInfoAt(
+  ifcX: number,
+  ifcY: number,
+  halfExtent = 0,
+  buildingRotation?: number,
+): CoordinateInfo {
   const originShift = { x: ifcX, y: 0, z: -ifcY };
   const shiftedBounds = {
     min: { x: -halfExtent, y: 0, z: -halfExtent },
@@ -42,6 +47,7 @@ function coordInfoAt(ifcX: number, ifcY: number, halfExtent = 0): CoordinateInfo
       },
     },
     hasLargeCoordinates: true,
+    buildingRotation,
   };
 }
 
@@ -80,6 +86,59 @@ describe('detectDoubleGeoreference', () => {
       Math.abs(found!.displacement - 6_004_000) < 10_000,
       `expected ≈6 004 km of displacement, got ${found!.displacement}`,
     );
+  });
+
+  describe('rotationCorroborated (Codex review, PR #2543)', () => {
+    // The fingerprint matches on TRANSLATION, so it does not by itself prove
+    // the model's local axes are grid-aligned. The fix resets the axis anyway
+    // (a non-identity rotation acting on a map-sized coordinate is
+    // unrecoverable whatever the offsets are), so the flag tells the UI when
+    // that reset merely restates the file and when it is our choice.
+
+    it('is true when the site placement carries the rotation (issue #2526)', () => {
+      // Site X axis (-0.46689605, -0.88431221) = -117.833°, baked into the
+      // world coordinates — those world axes ARE the grid axes, so the
+      // conversion's own rotation is redundant.
+      const found = detectDoubleGeoreference(
+        ISSUE_2526_CONVERSION,
+        METRE_CRS,
+        coordInfoAt(311988.18054, 5996148.56499, 0, -2.0566),
+        0.001,
+      );
+      assert.ok(found);
+      assert.strictEqual(found!.rotationCorroborated, true);
+    });
+
+    it('is true when the conversion authors no rotation at all', () => {
+      const noRotation: MapConversion = {
+        ...ISSUE_2526_CONVERSION,
+        xAxisAbscissa: 1,
+        xAxisOrdinate: 0,
+      };
+      const found = detectDoubleGeoreference(
+        noRotation,
+        METRE_CRS,
+        coordInfoAt(311988.18054, 5996148.56499),
+        0.001,
+      );
+      assert.ok(found);
+      assert.strictEqual(found!.rotationCorroborated, true);
+    });
+
+    it('is FALSE for a translation-only placement plus an authored rotation', () => {
+      // The reviewed hazard: the placement contributes the absolute offset but
+      // no rotation, so the conversion's rotation might have been the real one.
+      // Still flagged (the translation IS duplicated) but the UI must warn that
+      // the resulting orientation is a choice.
+      const found = detectDoubleGeoreference(
+        ISSUE_2526_CONVERSION,
+        METRE_CRS,
+        coordInfoAt(311988.18054, 5996148.56499, 0, 0),
+        0.001,
+      );
+      assert.ok(found);
+      assert.strictEqual(found!.rotationCorroborated, false);
+    });
   });
 
   it('does NOT flag a correctly authored local-frame model', () => {

--- a/apps/viewer/src/lib/geo/double-georeference.test.ts
+++ b/apps/viewer/src/lib/geo/double-georeference.test.ts
@@ -1,0 +1,198 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import type { MapConversion, ProjectedCRS } from '@ifc-lite/parser';
+import type { CoordinateInfo } from '@ifc-lite/geometry';
+
+import { detectDoubleGeoreference, identityConversionFields } from './double-georeference.js';
+
+/**
+ * Build a CoordinateInfo whose model centre lands on the given IFC world
+ * position (Z-up metres). `computeModelCenterInIfcMeters` reads
+ * `shiftedBounds` + `originShift` + `wasmRtcOffset` and maps viewer Y-up back
+ * to IFC Z-up as `ifcX = worldX`, `ifcY = -worldZ`. Putting the whole position
+ * in `originShift` with zero-extent bounds keeps that inversion trivial and
+ * keeps these tests about the detector, not about the axis swap (which
+ * reproject.test.ts already pins).
+ */
+function coordInfoAt(ifcX: number, ifcY: number, halfExtent = 0): CoordinateInfo {
+  const originShift = { x: ifcX, y: 0, z: -ifcY };
+  const shiftedBounds = {
+    min: { x: -halfExtent, y: 0, z: -halfExtent },
+    max: { x: halfExtent, y: 0, z: halfExtent },
+  };
+  return {
+    originShift,
+    shiftedBounds,
+    // The producer's invariant: shiftedBounds = originalBounds - originShift.
+    originalBounds: {
+      min: {
+        x: shiftedBounds.min.x + originShift.x,
+        y: shiftedBounds.min.y + originShift.y,
+        z: shiftedBounds.min.z + originShift.z,
+      },
+      max: {
+        x: shiftedBounds.max.x + originShift.x,
+        y: shiftedBounds.max.y + originShift.y,
+        z: shiftedBounds.max.z + originShift.z,
+      },
+    },
+    hasLargeCoordinates: true,
+  };
+}
+
+/** The reporter's file (#2526): Vectorworks, EPSG:25833, mm project, m MapUnit. */
+const ISSUE_2526_CONVERSION: MapConversion = {
+  id: 73,
+  sourceCRS: 41,
+  targetCRS: 71,
+  eastings: 311988.181,
+  northings: 5996148.565,
+  orthogonalHeight: 0,
+  xAxisAbscissa: 0,
+  xAxisOrdinate: 1,
+  scale: undefined,
+};
+
+const METRE_CRS: Pick<ProjectedCRS, 'mapUnitScale'> = { mapUnitScale: 1 };
+
+describe('detectDoubleGeoreference', () => {
+  it('flags the issue #2526 file and reports the real displacement', () => {
+    const found = detectDoubleGeoreference(
+      ISSUE_2526_CONVERSION,
+      METRE_CRS,
+      // Site placement #49 = (311988180.54, 5996148564.99) mm.
+      coordInfoAt(311988.18054, 5996148.56499),
+      0.001,
+    );
+    assert.ok(found, 'expected a double georeference report');
+    assert.ok(found!.residual < 1, `residual should be sub-metre, got ${found!.residual}`);
+    // The file's 90° rotation swings the (map-sized) world centre too, so the
+    // error is NOT simply ‖offset‖: the model goes from (X, Y) to (E - Y, N + X),
+    // i.e. hypot(E - Y - X, N + X - Y) ≈ 6 004 km in projected metres. (The
+    // 5 206 km quoted in the issue is the geodesic distance measured after the
+    // inverse projection — a different, smaller quantity.)
+    assert.ok(
+      Math.abs(found!.displacement - 6_004_000) < 10_000,
+      `expected ≈6 004 km of displacement, got ${found!.displacement}`,
+    );
+  });
+
+  it('does NOT flag a correctly authored local-frame model', () => {
+    // Geometry near the IFC origin, conversion carries the real site offset.
+    assert.strictEqual(
+      detectDoubleGeoreference(ISSUE_2526_CONVERSION, METRE_CRS, coordInfoAt(12, -30), 0.001),
+      null,
+    );
+  });
+
+  it('does NOT flag a correctly authored absolute-coordinate model (LoGeoRef 20)', () => {
+    // Geometry at map coordinates, conversion is already the identity — the
+    // world centre is map-sized but does not coincide with a 0/0 offset.
+    const identity: MapConversion = {
+      ...ISSUE_2526_CONVERSION,
+      eastings: 0,
+      northings: 0,
+      xAxisAbscissa: 1,
+      xAxisOrdinate: 0,
+    };
+    assert.strictEqual(
+      detectDoubleGeoreference(identity, METRE_CRS, coordInfoAt(311988, 5996149), 0.001),
+      null,
+    );
+  });
+
+  it('does NOT flag a map-sized model whose offset is an unrelated location', () => {
+    // Same CRS, but the conversion points 400 km away: not a duplication.
+    const elsewhere: MapConversion = { ...ISSUE_2526_CONVERSION, northings: 5596148.565 };
+    assert.strictEqual(
+      detectDoubleGeoreference(elsewhere, METRE_CRS, coordInfoAt(311988, 5996149), 0.001),
+      null,
+    );
+  });
+
+  it('tolerates a large-extent site (centre offset from the placement origin)', () => {
+    // A 3 km-wide site puts its centre ~1.5 km from the site origin; the
+    // relative tolerance (0.1% of ‖offset‖ ≈ 6 km here) must still catch it.
+    const found = detectDoubleGeoreference(
+      ISSUE_2526_CONVERSION,
+      METRE_CRS,
+      coordInfoAt(311988 + 1500, 5996149 + 1500),
+      0.001,
+    );
+    assert.ok(found, 'expected the duplication to be caught despite the site extent');
+  });
+
+  it('scales millimetre MapConversion offsets before comparing', () => {
+    // Same duplication expressed with a MILLIMETRE MapUnit: the offsets are
+    // 1000× larger and only match the world centre after mapUnitScale.
+    const mmConversion: MapConversion = {
+      ...ISSUE_2526_CONVERSION,
+      eastings: 311988180.54,
+      northings: 5996148564.99,
+    };
+    const found = detectDoubleGeoreference(
+      mmConversion,
+      { mapUnitScale: 0.001 },
+      coordInfoAt(311988.18054, 5996148.56499),
+      0.001,
+    );
+    assert.ok(found, 'expected the mm-unit duplication to be caught');
+    assert.ok(found!.residual < 1);
+  });
+
+  it('returns null without a conversion or without coordinate info', () => {
+    assert.strictEqual(
+      detectDoubleGeoreference(undefined, METRE_CRS, coordInfoAt(311988, 5996149), 0.001),
+      null,
+    );
+    assert.strictEqual(
+      detectDoubleGeoreference(ISSUE_2526_CONVERSION, METRE_CRS, undefined, 0.001),
+      null,
+    );
+  });
+
+  it('returns null for a non-finite offset rather than reporting NaN', () => {
+    const broken: MapConversion = { ...ISSUE_2526_CONVERSION, eastings: NaN };
+    assert.strictEqual(
+      detectDoubleGeoreference(broken, METRE_CRS, coordInfoAt(311988, 5996149), 0.001),
+      null,
+    );
+  });
+});
+
+describe('identityConversionFields', () => {
+  it('zeroes the horizontal offset and resets the axis, and touches nothing else', () => {
+    const fields = identityConversionFields();
+    assert.deepStrictEqual(
+      Object.fromEntries(fields.map(f => [f.field, f.value])),
+      { eastings: 0, northings: 0, xAxisAbscissa: 1, xAxisOrdinate: 0 },
+    );
+    // OrthogonalHeight and Scale must NOT be in the fix: the fingerprint is
+    // horizontal, and zeroing a height that legitimately carries the site
+    // altitude would trade one error for another.
+    const names = fields.map(f => f.field);
+    assert.ok(!names.includes('orthogonalHeight'));
+    assert.ok(!names.includes('scale'));
+  });
+
+  it('makes the flagged model stop being flagged', () => {
+    const fixed: MapConversion = {
+      ...ISSUE_2526_CONVERSION,
+      ...Object.fromEntries(identityConversionFields().map(f => [f.field, f.value])),
+    };
+    assert.strictEqual(
+      detectDoubleGeoreference(
+        fixed,
+        METRE_CRS,
+        coordInfoAt(311988.18054, 5996148.56499),
+        0.001,
+      ),
+      null,
+    );
+  });
+});

--- a/apps/viewer/src/lib/geo/double-georeference.ts
+++ b/apps/viewer/src/lib/geo/double-georeference.ts
@@ -151,6 +151,14 @@ export function detectDoubleGeoreference(
   const abscissa = conversion.xAxisAbscissa ?? 1;
   const ordinate = conversion.xAxisOrdinate ?? 0;
   const scale = getEffectiveHorizontalScale(conversion.scale, mapScale, lengthUnitScale);
+  // `hasStandardGeoreferencing` deliberately does NOT gate on the axis pair or
+  // Scale being finite (see effective-georef.ts), so a NaN can reach here. It
+  // would poison `displacement` and make `rotationIsIdentity` false by
+  // accident, i.e. we would flag a malformed file and quote it a nonsense
+  // number. Stay quiet instead. (PR #2543 review.)
+  if (!Number.isFinite(abscissa) || !Number.isFinite(ordinate) || !Number.isFinite(scale)) {
+    return null;
+  }
   const appliedE = easting + scale * (abscissa * ifcX - ordinate * ifcY);
   const appliedN = northing + scale * (ordinate * ifcX + abscissa * ifcY);
 
@@ -161,7 +169,14 @@ export function detectDoubleGeoreference(
   // cleared, so "already in the map CRS" would still be false. The Scale value
   // that makes the effective scale 1 is the spec unit bridge,
   // lengthUnitScale / mapUnitScale.
-  const scaleIsUnit = Math.abs(scale - 1) <= 0.005;
+  //
+  // The tolerance is expressed as INDUCED POSITION ERROR, not as a fraction.
+  // `detectScaleUnitMismatch`'s 0.5% band is calibrated for geometry sitting a
+  // few tens of metres from its own origin; here the scale multiplies a
+  // map-sized coordinate, so 0.4% of a 6 000 km easting is 24 km of drift — a
+  // fraction-based band would wave that through. One metre at the model's own
+  // distance from the origin is the threshold that matters. (PR #2543 review.)
+  const scaleIsUnit = Math.abs(scale - 1) * worldMagnitude <= 1;
   const mapUnitScale = mapScale > 0 ? mapScale : 1;
   const lengthScale = lengthUnitScale > 0 ? lengthUnitScale : 1;
 

--- a/apps/viewer/src/lib/geo/double-georeference.ts
+++ b/apps/viewer/src/lib/geo/double-georeference.ts
@@ -80,6 +80,30 @@ export interface DoubleGeoreference {
    * (already map-sized) world centre around as well.
    */
   displacement: number;
+  /**
+   * Whether we can corroborate that clearing the conversion's ROTATION is safe,
+   * as opposed to only its translation.
+   *
+   * The fingerprint below matches on translation alone, so on its own it does
+   * not prove the model's local axes are grid-aligned. Two cases make the
+   * rotation reset unambiguous, and this flag marks them:
+   *
+   *   - the authored rotation is already the identity, so there is nothing to
+   *     reset; or
+   *   - the geometry's own placement carries a rotation
+   *     (`CoordinateInfo.buildingRotation`, baked into the world coordinates by
+   *     the geometry pipeline). That rotation is exactly what turns the site's
+   *     local frame INTO the map frame, so the world axes are grid axes and the
+   *     conversion's rotation is redundant. This is the reporter's file
+   *     (#2526): site X axis (-0.46689605, -0.88431221), i.e. -117.833°.
+   *
+   * When it is false the file cannot be reconciled at all — a non-identity
+   * rotation applied to map-sized world coordinates swings the model thousands
+   * of km whatever the translation is, so no choice of offsets rescues it — but
+   * the ORIENTATION the fix lands on (grid-aligned) is then our choice rather
+   * than the file's. Callers must say so instead of applying it silently.
+   */
+  rotationCorroborated: boolean;
 }
 
 /**
@@ -129,11 +153,15 @@ export function detectDoubleGeoreference(
   const appliedE = easting + scale * (abscissa * ifcX - ordinate * ifcY);
   const appliedN = northing + scale * (ordinate * ifcX + abscissa * ifcY);
 
+  const rotationIsIdentity = Math.abs(abscissa - 1) < 1e-9 && Math.abs(ordinate) < 1e-9;
+  const placementCarriesRotation = Math.abs(coordinateInfo.buildingRotation ?? 0) > 1e-6;
+
   return {
     worldCenter: { x: ifcX, y: ifcY },
     offset: { easting, northing },
     residual,
     displacement: Math.hypot(appliedE - ifcX, appliedN - ifcY),
+    rotationCorroborated: rotationIsIdentity || placementCarriesRotation,
   };
 }
 
@@ -148,6 +176,15 @@ export function detectDoubleGeoreference(
  * vertical one. `Scale` is likewise left as authored — `getEffectiveHorizontalScale`
  * already resolves it, and overwriting it here would discard a genuine
  * foot/metre bridge.
+ *
+ * The axis pair IS included, and that is not symmetric with the two above. A
+ * rotation is applied to the coordinates BEFORE the translation, so a
+ * non-identity rotation acting on a map-sized world coordinate swings the model
+ * by a distance of order ‖world‖ — millions of metres — no matter what the
+ * offsets are. Leaving it while zeroing the offsets would move the model from
+ * one wrong continent to another, so there is no "translation-only" fix to
+ * offer. See {@link DoubleGeoreference.rotationCorroborated} for when that
+ * reset merely restates the file and when it is our choice.
  */
 export function identityConversionFields(): Array<{ field: string; value: number }> {
   return [

--- a/apps/viewer/src/lib/geo/double-georeference.ts
+++ b/apps/viewer/src/lib/geo/double-georeference.ts
@@ -12,9 +12,8 @@
  * coordinate system, so the correct reading is to apply it on top of those
  * already-absolute coordinates — which adds the offset a second time and flings
  * the model roughly `‖(E, N)‖` away from where it belongs. Issue #2526: a
- * Vectorworks export of a site in Rostock (E 311 988 / N 5 996 149, EPSG:25833)
- * landed at 33.71 N / -49.12 E, ~5 200 km out in the North Atlantic, on an empty
- * basemap.
+ * Vectorworks export in EPSG:25833 (E 311 988 / N 5 996 149) landed thousands
+ * of km out in the North Atlantic, on an empty basemap.
  *
  * The fingerprint is unusually crisp, which is why this is a translation match
  * rather than an "is the result inside the CRS's area of use" test (we ship no
@@ -81,29 +80,31 @@ export interface DoubleGeoreference {
    */
   displacement: number;
   /**
-   * Whether we can corroborate that clearing the conversion's ROTATION is safe,
-   * as opposed to only its translation.
+   * True when the fix would REPLACE a rotation the file actually authors,
+   * rather than just restating an already-identity one.
    *
-   * The fingerprint below matches on translation alone, so on its own it does
-   * not prove the model's local axes are grid-aligned. Two cases make the
-   * rotation reset unambiguous, and this flag marks them:
+   * The fingerprint matches on translation, so it says nothing about whether
+   * the model's local axes are grid-aligned. The fix resets the axis anyway,
+   * because there is no translation-only alternative to offer (see
+   * {@link identityConversionFields}) — but when this is true, the orientation
+   * it lands on is OUR choice rather than the file's, and callers must say so
+   * instead of applying it silently. (PR #2543 review.)
    *
-   *   - the authored rotation is already the identity, so there is nothing to
-   *     reset; or
-   *   - the geometry's own placement carries a rotation
-   *     (`CoordinateInfo.buildingRotation`, baked into the world coordinates by
-   *     the geometry pipeline). That rotation is exactly what turns the site's
-   *     local frame INTO the map frame, so the world axes are grid axes and the
-   *     conversion's rotation is redundant. This is the reporter's file
-   *     (#2526): site X axis (-0.46689605, -0.88431221), i.e. -117.833°.
-   *
-   * When it is false the file cannot be reconciled at all — a non-identity
-   * rotation applied to map-sized world coordinates swings the model thousands
-   * of km whatever the translation is, so no choice of offsets rescues it — but
-   * the ORIENTATION the fix lands on (grid-aligned) is then our choice rather
-   * than the file's. Callers must say so instead of applying it silently.
+   * An earlier version also treated a non-zero `CoordinateInfo.buildingRotation`
+   * as corroboration, on the theory that a rotating site placement is what
+   * turns the local frame INTO the map frame. That is evidence, not proof: the
+   * placement rotation and the conversion's axis can simply disagree (they do
+   * in #2526 — -117.833° versus +90°), and picking the placement silently is
+   * exactly the outcome the flag exists to prevent. A caveat sentence costs a
+   * line of prose; a silently mis-oriented model costs a re-export.
    */
-  rotationCorroborated: boolean;
+  overridesAuthoredRotation: boolean;
+  /**
+   * True when the fix must also rewrite `Scale`, because the scale the viewer
+   * currently applies is not 1 and would keep mis-sizing the geometry about the
+   * map origin after the offsets are cleared. Carries the value to write.
+   */
+  scaleCorrection: number | null;
 }
 
 /**
@@ -154,14 +155,23 @@ export function detectDoubleGeoreference(
   const appliedN = northing + scale * (ordinate * ifcX + abscissa * ifcY);
 
   const rotationIsIdentity = Math.abs(abscissa - 1) < 1e-9 && Math.abs(ordinate) < 1e-9;
-  const placementCarriesRotation = Math.abs(coordinateInfo.buildingRotation ?? 0) > 1e-6;
+  // `scale` above is the EFFECTIVE horizontal scale, i.e. what the viewer
+  // actually applies to metre geometry. Anything other than 1 keeps re-scaling
+  // the map-sized coordinates about the map origin after the offsets are
+  // cleared, so "already in the map CRS" would still be false. The Scale value
+  // that makes the effective scale 1 is the spec unit bridge,
+  // lengthUnitScale / mapUnitScale.
+  const scaleIsUnit = Math.abs(scale - 1) <= 0.005;
+  const mapUnitScale = mapScale > 0 ? mapScale : 1;
+  const lengthScale = lengthUnitScale > 0 ? lengthUnitScale : 1;
 
   return {
     worldCenter: { x: ifcX, y: ifcY },
     offset: { easting, northing },
     residual,
     displacement: Math.hypot(appliedE - ifcX, appliedN - ifcY),
-    rotationCorroborated: rotationIsIdentity || placementCarriesRotation,
+    overridesAuthoredRotation: !rotationIsIdentity,
+    scaleCorrection: scaleIsUnit ? null : lengthScale / mapUnitScale,
   };
 }
 
@@ -169,28 +179,38 @@ export function detectDoubleGeoreference(
  * The `IfcMapConversion` field values that make the conversion a horizontal
  * identity, i.e. "the geometry is already in the map CRS".
  *
- * `OrthogonalHeight` and `Scale` are deliberately absent. The fingerprint this
- * module matches is a duplicated HORIZONTAL offset and says nothing about the
- * vertical: zeroing an `OrthogonalHeight` that legitimately carries the site
- * altitude (while the geometry Z is local) would trade a horizontal error for a
- * vertical one. `Scale` is likewise left as authored — `getEffectiveHorizontalScale`
- * already resolves it, and overwriting it here would discard a genuine
- * foot/metre bridge.
+ * `OrthogonalHeight` is deliberately absent. The fingerprint this module matches
+ * is a duplicated HORIZONTAL offset and says nothing about the vertical: zeroing
+ * an `OrthogonalHeight` that legitimately carries the site altitude (while the
+ * geometry Z is local) would trade a horizontal error for a vertical one.
  *
- * The axis pair IS included, and that is not symmetric with the two above. A
- * rotation is applied to the coordinates BEFORE the translation, so a
- * non-identity rotation acting on a map-sized world coordinate swings the model
- * by a distance of order ‖world‖ — millions of metres — no matter what the
- * offsets are. Leaving it while zeroing the offsets would move the model from
- * one wrong continent to another, so there is no "translation-only" fix to
- * offer. See {@link DoubleGeoreference.rotationCorroborated} for when that
- * reset merely restates the file and when it is our choice.
+ * The axis pair is always included, and `Scale` is included when
+ * {@link DoubleGeoreference.scaleCorrection} is set. Neither is symmetric with
+ * `OrthogonalHeight`, because both act on the coordinates BEFORE the
+ * translation: a non-identity rotation or scale applied to a map-sized world
+ * coordinate moves the model by a distance of order ‖world‖ — millions of
+ * metres — no matter what the offsets are. Leaving either while zeroing the
+ * offsets would move the model from one wrong continent to another, so there is
+ * no "offsets-only" fix to offer. (PR #2543 review.)
+ *
+ * `Scale` is left alone when the EFFECTIVE horizontal scale is already 1, which
+ * covers both a spec-correct unit bridge and the unset-Scale heuristic — so a
+ * genuine foot/metre bridge survives untouched.
+ *
+ * @param scaleCorrection `DoubleGeoreference.scaleCorrection`: the Scale value
+ *   that makes the effective horizontal scale 1, or null to leave Scale alone.
  */
-export function identityConversionFields(): Array<{ field: string; value: number }> {
-  return [
+export function identityConversionFields(
+  scaleCorrection: number | null = null,
+): Array<{ field: string; value: number }> {
+  const fields = [
     { field: 'eastings', value: 0 },
     { field: 'northings', value: 0 },
     { field: 'xAxisAbscissa', value: 1 },
     { field: 'xAxisOrdinate', value: 0 },
   ];
+  if (scaleCorrection !== null) {
+    fields.push({ field: 'scale', value: scaleCorrection });
+  }
+  return fields;
 }

--- a/apps/viewer/src/lib/geo/double-georeference.ts
+++ b/apps/viewer/src/lib/geo/double-georeference.ts
@@ -1,0 +1,159 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Detect a model that is georeferenced TWICE.
+ *
+ * Some authoring tools place the `IfcSite` (and therefore every element under
+ * it) at absolute map coordinates via its `IfcLocalPlacement`, AND also emit an
+ * `IfcMapConversion` carrying the very same eastings/northings. Per IFC4 the
+ * conversion is defined on the `IfcGeometricRepresentationContext`'s world
+ * coordinate system, so the correct reading is to apply it on top of those
+ * already-absolute coordinates — which adds the offset a second time and flings
+ * the model roughly `‖(E, N)‖` away from where it belongs. Issue #2526: a
+ * Vectorworks export of a site in Rostock (E 311 988 / N 5 996 149, EPSG:25833)
+ * landed at 33.71 N / -49.12 E, ~5 200 km out in the North Atlantic, on an empty
+ * basemap.
+ *
+ * The fingerprint is unusually crisp, which is why this is a translation match
+ * rather than an "is the result inside the CRS's area of use" test (we ship no
+ * area-of-use extents, and that test has a far larger false-positive surface):
+ *
+ *   1. the model's world centre is itself already map-sized (>= 100 km from the
+ *      IFC origin — no ordinary local-frame model is), AND
+ *   2. that centre coincides with the MapConversion offset to within a
+ *      tolerance that a duplicated value clears trivially and an independent
+ *      value essentially never does.
+ *
+ * A correctly authored absolute-coordinate model (buildingSMART LoGeoRef 20/30)
+ * fails (2) precisely because its conversion offset is 0/0, so it is not
+ * flagged. A correctly authored local-frame model fails (1).
+ *
+ * This module only REPORTS. Nothing here changes placement: the viewer keeps
+ * rendering the file as authored, and the georeferencing panel offers the user
+ * a one-click correction.
+ */
+
+import type { MapConversion, ProjectedCRS } from '@ifc-lite/parser';
+import type { CoordinateInfo } from '@ifc-lite/geometry';
+
+import { computeModelCenterInIfcMeters } from './reproject';
+import { getEffectiveHorizontalScale, resolveMapUnitToMetreScale } from './geo-scale';
+
+/**
+ * How far the model centre must sit from the IFC origin before a coincidence
+ * with the MapConversion offset means anything. A local-frame building model
+ * lives within a few km of its origin; 100 km is comfortably clear of even a
+ * sprawling site or an infrastructure alignment, while every map-coordinate
+ * easting/northing pair worth worrying about is in the 10^5..10^7 m range.
+ */
+const MIN_WORLD_MAGNITUDE_M = 100_000;
+
+/**
+ * Absolute floor on the coincidence tolerance. The model CENTRE is compared
+ * against the offset, and the offset is normally the site/project origin, so
+ * the two differ by roughly half the model's plan extent. 1 km covers any
+ * building and most sites outright.
+ */
+const MIN_RESIDUAL_TOLERANCE_M = 1_000;
+
+/**
+ * Relative part of the coincidence tolerance, applied to the magnitude of the
+ * offset. Keeps large-extent models (infrastructure alignments, whole
+ * districts) inside the tolerance without widening it for small coordinates.
+ */
+const RESIDUAL_TOLERANCE_FRACTION = 0.001;
+
+export interface DoubleGeoreference {
+  /** Model centre in IFC world metres, Z-up (X ≈ easting, Y ≈ northing). */
+  worldCenter: { x: number; y: number };
+  /** `IfcMapConversion` eastings/northings converted to metres. */
+  offset: { easting: number; northing: number };
+  /** Distance between the two, metres. Small by construction when flagged. */
+  residual: number;
+  /**
+   * How far the duplicated offset displaces the model, in projected metres:
+   * the distance from where the geometry already sits in the map CRS to where
+   * applying the conversion puts it. This is the size of the error the user
+   * sees, and it is NOT simply ‖offset‖ — the conversion's rotation swings the
+   * (already map-sized) world centre around as well.
+   */
+  displacement: number;
+}
+
+/**
+ * Report a duplicated georeference, or `null` when the model does not match the
+ * fingerprint. See the module header for the two conditions and why they are
+ * safe against correctly authored files.
+ *
+ * @param conversion      Effective `IfcMapConversion` (file values + any edits).
+ * @param crs             Effective `IfcProjectedCRS` (for `mapUnitScale`).
+ * @param coordinateInfo  Geometry bounds + origin/RTC shifts.
+ * @param lengthUnitScale IFC project length unit to metres.
+ */
+export function detectDoubleGeoreference(
+  conversion: MapConversion | undefined,
+  crs: Pick<ProjectedCRS, 'mapUnitScale'> | undefined,
+  coordinateInfo: CoordinateInfo | undefined,
+  lengthUnitScale = 1,
+): DoubleGeoreference | null {
+  if (!conversion || !coordinateInfo) return null;
+
+  const mapScale = resolveMapUnitToMetreScale(crs?.mapUnitScale, lengthUnitScale);
+  const easting = conversion.eastings * mapScale;
+  const northing = conversion.northings * mapScale;
+  if (!Number.isFinite(easting) || !Number.isFinite(northing)) return null;
+
+  const { ifcX, ifcY } = computeModelCenterInIfcMeters(coordinateInfo);
+  if (!Number.isFinite(ifcX) || !Number.isFinite(ifcY)) return null;
+
+  const worldMagnitude = Math.hypot(ifcX, ifcY);
+  if (worldMagnitude < MIN_WORLD_MAGNITUDE_M) return null;
+
+  const offsetMagnitude = Math.hypot(easting, northing);
+  const residual = Math.hypot(ifcX - easting, ifcY - northing);
+  const tolerance = Math.max(
+    MIN_RESIDUAL_TOLERANCE_M,
+    RESIDUAL_TOLERANCE_FRACTION * offsetMagnitude,
+  );
+  if (residual > tolerance) return null;
+
+  // Where applying the conversion puts the model, versus where its geometry
+  // already sits in the map CRS. Mirrors `computeProjectedCenter` exactly,
+  // including the `?? 1 / ?? 0` axis defaults and the effective (not raw)
+  // horizontal scale, so the reported error is the one the viewer renders.
+  const abscissa = conversion.xAxisAbscissa ?? 1;
+  const ordinate = conversion.xAxisOrdinate ?? 0;
+  const scale = getEffectiveHorizontalScale(conversion.scale, mapScale, lengthUnitScale);
+  const appliedE = easting + scale * (abscissa * ifcX - ordinate * ifcY);
+  const appliedN = northing + scale * (ordinate * ifcX + abscissa * ifcY);
+
+  return {
+    worldCenter: { x: ifcX, y: ifcY },
+    offset: { easting, northing },
+    residual,
+    displacement: Math.hypot(appliedE - ifcX, appliedN - ifcY),
+  };
+}
+
+/**
+ * The `IfcMapConversion` field values that make the conversion a horizontal
+ * identity, i.e. "the geometry is already in the map CRS".
+ *
+ * `OrthogonalHeight` and `Scale` are deliberately absent. The fingerprint this
+ * module matches is a duplicated HORIZONTAL offset and says nothing about the
+ * vertical: zeroing an `OrthogonalHeight` that legitimately carries the site
+ * altitude (while the geometry Z is local) would trade a horizontal error for a
+ * vertical one. `Scale` is likewise left as authored — `getEffectiveHorizontalScale`
+ * already resolves it, and overwriting it here would discard a genuine
+ * foot/metre bridge.
+ */
+export function identityConversionFields(): Array<{ field: string; value: number }> {
+  return [
+    { field: 'eastings', value: 0 },
+    { field: 'northings', value: 0 },
+    { field: 'xAxisAbscissa', value: 1 },
+    { field: 'xAxisOrdinate', value: 0 },
+  ];
+}

--- a/apps/viewer/src/lib/geo/effective-georef.test.ts
+++ b/apps/viewer/src/lib/geo/effective-georef.test.ts
@@ -309,18 +309,36 @@ describe('effective georeferencing', () => {
       assert.strictEqual(detectScaleUnitMismatch(undefined, 1, 1), null);
     });
 
-    it('flags the common Scale=1 + mm-project + m-map error', () => {
+    it('flags the common Scale=1 + mm-project + m-map error as COMPENSATED', () => {
+      // The file is off-spec, but `getEffectiveHorizontalScale`'s unset/1 Scale
+      // heuristic already places the geometry at 1×. Reporting effectiveScale
+      // 1000 here claimed a mis-sizing the code prevents, and that false
+      // warning was the only thing the panel said about the #2526 file.
       const m = detectScaleUnitMismatch(1, 1, 0.001);
       assert.ok(m, 'expected a mismatch report');
       assert.strictEqual(m!.rawScale, 1);
-      assert.strictEqual(m!.effectiveScale, 1000);
+      assert.strictEqual(m!.specEffectiveScale, 1000);
+      assert.strictEqual(m!.effectiveScale, 1);
+      assert.strictEqual(m!.compensated, true);
       assert.strictEqual(m!.expectedScale, 0.001);
     });
 
-    it('flags Scale omitted when units differ', () => {
+    it('flags Scale omitted when units differ as COMPENSATED', () => {
       const m = detectScaleUnitMismatch(undefined, 1, 0.001);
       assert.ok(m);
-      assert.strictEqual(m!.effectiveScale, 1000);
+      assert.strictEqual(m!.specEffectiveScale, 1000);
+      assert.strictEqual(m!.effectiveScale, 1);
+      assert.strictEqual(m!.compensated, true);
+    });
+
+    it('does NOT mark a genuine mis-scaling as compensated', () => {
+      // Scale explicitly 1000 on a mm project: the heuristic only rescues an
+      // unset/1 Scale, so this really is applied and really does mis-size.
+      const m = detectScaleUnitMismatch(1000, 1, 0.001);
+      assert.ok(m);
+      assert.strictEqual(m!.effectiveScale, 1e6);
+      assert.strictEqual(m!.specEffectiveScale, 1e6);
+      assert.strictEqual(m!.compensated, false);
     });
 
     it('tolerates tiny floating-point noise around 1.0', () => {
@@ -333,6 +351,7 @@ describe('effective georeferencing', () => {
       const m = detectScaleUnitMismatch(2, 1, 1);
       assert.ok(m);
       assert.strictEqual(m!.effectiveScale, 2);
+      assert.strictEqual(m!.compensated, false);
     });
   });
 

--- a/apps/viewer/src/lib/geo/geo-scale.ts
+++ b/apps/viewer/src/lib/geo/geo-scale.ts
@@ -85,9 +85,10 @@ export interface ScaleUnitMismatch {
    * off-spec (worth telling the author, because a spec-strict tool WILL render
    * it at `specEffectiveScale`), but nothing is mis-sized here — callers must
    * not claim otherwise. Issue #2526: the panel reported "Geometry is being
-   * placed at 1000× its physical size" for a Vectorworks file that ifc-lite
-   * renders at exactly 1×, which sent the reporter chasing a scale problem
-   * while the actual 5 200 km placement error went unmentioned.
+   * placed at 1000× its physical size" about geometry ifc-lite places at
+   * exactly 1×. It was the only warning that file raised, so it sent the
+   * reader chasing a non-problem while the real placement defect went
+   * unmentioned.
    */
   compensated: boolean;
   /** Raw IfcMapConversion.Scale (or 1 if absent). */

--- a/apps/viewer/src/lib/geo/geo-scale.ts
+++ b/apps/viewer/src/lib/geo/geo-scale.ts
@@ -68,8 +68,28 @@ export function getEffectiveHorizontalScale(
 }
 
 export interface ScaleUnitMismatch {
-  /** Effective horizontal scale applied to viewer-space (metre) geometry. */
+  /**
+   * Horizontal scale ifc-lite ACTUALLY applies to viewer-space (metre)
+   * geometry — {@link getEffectiveHorizontalScale}, heuristic included.
+   */
   effectiveScale: number;
+  /**
+   * Horizontal scale the spec-strict formula implies,
+   * `(Scale × mapUnitScale) / lengthUnitScale`. Differs from `effectiveScale`
+   * exactly when the unset-Scale heuristic above fired.
+   */
+  specEffectiveScale: number;
+  /**
+   * True when that heuristic already neutralised the file's deviation, i.e.
+   * `effectiveScale ≈ 1` while `specEffectiveScale` is not. The file is still
+   * off-spec (worth telling the author, because a spec-strict tool WILL render
+   * it at `specEffectiveScale`), but nothing is mis-sized here — callers must
+   * not claim otherwise. Issue #2526: the panel reported "Geometry is being
+   * placed at 1000× its physical size" for a Vectorworks file that ifc-lite
+   * renders at exactly 1×, which sent the reporter chasing a scale problem
+   * while the actual 5 200 km placement error went unmentioned.
+   */
+  compensated: boolean;
   /** Raw IfcMapConversion.Scale (or 1 if absent). */
   rawScale: number;
   /** Map unit → metres factor (e.g. 1 for METRE, 0.001 for MILLIMETRE). */
@@ -86,13 +106,15 @@ export interface ScaleUnitMismatch {
 /**
  * Detect when IfcMapConversion.Scale is inconsistent with the project and map
  * units. Per the IFC schema, Scale × mapUnitScale should equal lengthUnitScale
- * (i.e. effectiveScale = 1.0). A deviation usually means the authoring tool
- * forgot to set Scale to bridge a unit difference (e.g. mm project + m map
+ * (i.e. an effective scale of 1.0). A deviation usually means the authoring
+ * tool forgot to set Scale to bridge a unit difference (e.g. mm project + m map
  * with Scale=1.0). Files like this render at the wrong size in any tool that
  * follows the schema strictly — see issue #595.
  *
- * Returns null when the values are consistent (within 0.5% of 1.0); otherwise
- * returns the diagnostic data so callers can surface a warning.
+ * Returns null when the file is consistent (within 0.5% of 1.0); otherwise the
+ * diagnostic data. Read `compensated` before choosing the wording: when it is
+ * true, the deviation is an authoring defect that ifc-lite absorbs, and the
+ * only true statement left to make is about what OTHER tools will do with it.
  */
 export function detectScaleUnitMismatch(
   ifcMapConversionScale: number | undefined,
@@ -102,10 +124,13 @@ export function detectScaleUnitMismatch(
   const lus = lengthUnitScale && lengthUnitScale > 0 ? lengthUnitScale : 1;
   const mus = mapUnitScale && mapUnitScale > 0 ? mapUnitScale : 1;
   const rawScale = ifcMapConversionScale ?? 1.0;
-  const effectiveScale = (rawScale * mus) / lus;
-  if (Math.abs(effectiveScale - 1) <= 0.005) return null;
+  const specEffectiveScale = (rawScale * mus) / lus;
+  if (Math.abs(specEffectiveScale - 1) <= 0.005) return null;
+  const effectiveScale = getEffectiveHorizontalScale(ifcMapConversionScale, mus, lus);
   return {
     effectiveScale,
+    specEffectiveScale,
+    compensated: Math.abs(effectiveScale - 1) <= 0.005,
     rawScale,
     mapUnitScale: mus,
     lengthUnitScale: lus,


### PR DESCRIPTION
Closes #2526. Discussion: #2338.

## The bug

The reporter's Vectorworks Architect 2026 IFC4 export is georeferenced **twice**:

```
#49= IFCCARTESIANPOINT((311988180.54, 5996148564.99, 14000.));   // mm
#53= IFCLOCALPLACEMENT($,#52);                                    // IfcSite, PlacementRelTo = $
#73= IFCMAPCONVERSION(#41,#71, 311988.181, 5996148.565, 0., 0., 1., $);
```

`#53` already places every element at absolute UTM33N coordinates (the placement chain runs storey to `#55` to `#54` to `#53`), and `#73` re-declares the identical offset, matching to sub-millimetre. `#73`'s SourceCRS is `#41`, whose WorldCoordinateSystem `#39` is the identity, so per IFC4 the conversion is defined on exactly those coordinates. ifc-lite applies the spec formula and counts the offset twice:

```
E = 311988.181  + (0*311988 - 1*5996149) = -5 684 160
N = 5996148.565 + (1*311988 + 0*5996149) =  6 308 137   ->  33.714 N, -49.115 E
```

5 206 km from the real site, in the open North Atlantic, which is why the reporter also saw no basemap under the pin. The file's own `IfcSite.RefLatitude/RefLongitude` says where it belongs.

The math in `reproject.ts`, `cesium-bridge.ts` and `georef.rs` is correct. The file is self-contradictory, and two more attributes prove it: `XAxisAbscissa=0, XAxisOrdinate=1` (+90 degrees) contradicts the file's own `TrueNorth` `#40`, which is bit-identical to `R^T*(0,1)` derived from the site placement's X axis (both agree on -117.833 degrees), and `OrthogonalHeight=0` drops the placement's 14 m.

## What this PR does

**1. Detects the duplication** (`apps/viewer/src/lib/geo/double-georeference.ts`). The fingerprint is crisp, which is why this is a translation match and not an "is the result inside the CRS area of use" test (we ship no area-of-use extents, and that test has a far larger false-positive surface):

- the model's world centre is itself map-sized, at least 100 km from the IFC origin, which no local-frame model is, **and**
- it coincides with the MapConversion offset to within `max(1 km, 0.1% of the offset)`.

A correctly authored absolute-coordinate model (buildingSMART LoGeoRef 20/30) fails the second test precisely because its offset is 0/0. A correctly authored local-frame model fails the first.

**2. Reports, never acts.** Placement is unchanged; the panel shows a banner above the collapsibles (a multi-thousand-km error must not hide inside a collapsed section), quotes how far the conversion displaces the model, and offers one click to make the conversion a horizontal identity.

What the fix writes, and why each field is in or out:

| field | in the fix? | why |
|---|---|---|
| `Eastings` / `Northings` | always | the duplicated offset itself |
| `XAxisAbscissa` / `XAxisOrdinate` | always | rotation applies *before* translation, so a non-identity rotation on a map-sized coordinate moves the model by order the coordinate magnitude whatever the offsets are. There is no offsets-only fix to offer. When the file authors a rotation of its own, the banner says the resulting orientation is our choice and to check `Angle to Grid North` by hand (`overridesAuthoredRotation`) |
| `Scale` | only when the *effective* scale is not 1 | same argument as the rotation. Tolerance is expressed as induced position error (one metre at the model's own distance from the origin), not as a fraction: 0.4% of a 6 000 km easting is 24 km of drift, which a fraction-based band would wave through. A spec-correct unit bridge and the unset-Scale heuristic both leave it untouched |
| `OrthogonalHeight` | never | the fingerprint is horizontal and says nothing about the vertical; zeroing a height that legitimately carries the site altitude would trade one error for another |

**3. Stops the scale note from lying.** `detectScaleUnitMismatch` reported the spec-strict scale while `getEffectiveHorizontalScale` had already neutralised it, so this file's panel claimed *"Geometry is being placed at 1000x its physical size"* about geometry ifc-lite places at exactly 1x. That was the only warning the panel showed for this file, and it is what sent the reporter chasing the coordinate system. It now carries both `effectiveScale` (what ifc-lite applies) and `specEffectiveScale`, plus a `compensated` flag; the panel drops the amber glyph for the compensated case and says what is true: a tool that follows the schema strictly will render the file at 1000x.

## Verification

Run in the viewer on the reporter's file and on controls hand-built from it, re-run after every code round rather than once at the end:

| file | banner | fix result |
|---|---|---|
| reporter's file, before | n/a | 33.71362, -49.11519 (mid-Atlantic, blank map) |
| reporter's file, after | shown, "displaces the model by about 6,004 km", no Scale mention | **54.07927, 12.12622** (Rostock, streets and buildings render) |
| variant: near-unit `Scale=1.004` | shown, announces the Scale correction | **54.07927, 12.12622** (reprojection returns `null` before the fix, so the banner is the only signal) |
| variant: `Scale=1000` | shown, "more than a planet-width", announces the Scale correction | **54.07927, 12.12622** |
| control: site at the origin (normal local frame) | **not shown** | 54.07895, 12.12597 |
| control: LoGeoRef 20 (absolute coords, identity conversion) | **not shown** | 54.07927, 12.12622 |
| control: translation-only placement + authored rotation | shown, with the orientation caveat | n/a |

(6 004 km is the displacement in projected metres, which the file's 90 degree rotation makes larger than the 5 206 km geodesic distance after the inverse projection. Both are quoted where they apply.)

20 detector unit tests cover the positive case, all negative controls, an unrelated-offset case 400 km away, a large-extent site inside the relative tolerance, millimetre MapUnit offsets, the near-unit and gross scale corrections, a genuine foot-to-metre bridge, and the NaN/missing-input guards. Two existing `detectScaleUnitMismatch` tests changed: they asserted `effectiveScale === 1000` for exactly the case the heuristic neutralises, i.e. they pinned the false claim.

`pnpm typecheck` and `pnpm test` both exit 0.

## Review

The CI CodeRabbit and Cursor Bugbot checks were rate-limited / over usage cap for most of this PR, so their green checks were false passes. Ran the CodeRabbit CLI locally against `main` each round instead: **6 findings, then 3, then 0**. Codex's inline P2 and CodeRabbit's PR review are both addressed; reasoning for each taken/partial/skipped call is in the two review-round comments below. The best catch was CodeRabbit's: a test named "leaves a genuine foot/metre bridge alone" that used foot units on both sides and so bridged nothing, and would have passed with the rule it was named after deleted.

## Deliberately not in this PR

- **`IfcSite.RefLatitude/RefLongitude` cross-check.** The strongest backstop when the fingerprint does not apply, but both extractors currently discard site lat/lon whenever an IfcMapConversion exists, so it is not even on `GeoreferenceInfo`. That needs a parser API change and a changeset.
- **`TrueNorth` cross-check.** ifc-lite has no consumer of `IfcGeometricRepresentationContext.TrueNorth` at all today. Worth adding, but as corroboration only: the tolerance must be at least 10 degrees because TrueNorth is true north while the MapConversion axis is grid north (meridian convergence is -2.33 degrees at this very site), and it must skip an absent or default `(0,1)` TrueNorth or it will flag correct files.
- **Area-of-use bounding boxes in the EPSG index.** Independently useful; does not block this.
- **Splitting `GeoreferencingPanel.tsx`** (889 lines before this PR, ~950 after). Pre-existing, and a refactor here would bury the diff.
- **Reporting the export defect to Vectorworks.**

No changeset: `apps/viewer` is not a published package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)