### PR TITLE
fix(viewer): stop a stored ?geomTier= override silently overriding Exact geometry

### DIFF
--- a/apps/viewer/src/components/viewer/GeometryModeBanner.tsx
+++ b/apps/viewer/src/components/viewer/GeometryModeBanner.tsx
@@ -3,11 +3,14 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
- * Reload-to-apply banner for the "Fast / Exact geometry" load-time mode,
- * mirroring {@link MergeLayersBanner}. The user flips the mode in the Visibility
- * dropdown; when a model is already loaded the store sets
+ * Reload-to-apply banner for the load-time geometry inputs, mirroring
+ * {@link MergeLayersBanner}. The user changes one in the Visibility dropdown
+ * (the Fast/Exact mode switch, or clearing a pinned `?geomTier=` detail
+ * override); when a model is already loaded the store sets
  * `geometryModePendingReload` and we surface this non-modal banner above the
- * canvas asking the user to reload (re-tessellating with the new mode).
+ * canvas asking the user to reload (re-tessellating with the new input).
+ * `geometryReloadReason` picks the headline so the prompt names the change the
+ * user actually made — one banner, two inputs.
  *
  * Anchored slightly below the merge-layers banner so the two don't overlap if
  * both are pending at once.
@@ -29,6 +32,7 @@ export interface GeometryModeBannerProps {
 export function GeometryModeBanner({ onReload }: GeometryModeBannerProps) {
   const pending = useViewerStore((s) => s.geometryModePendingReload);
   const mode = useViewerStore((s) => s.geometryMode);
+  const reason = useViewerStore((s) => s.geometryReloadReason);
   const dismiss = useViewerStore((s) => s.clearGeometryModePendingReload);
 
   const handleReload = useCallback(() => {
@@ -62,7 +66,11 @@ export function GeometryModeBanner({ onReload }: GeometryModeBannerProps) {
         </div>
         <div className="flex flex-col leading-tight min-w-0">
           <span className="text-xs font-semibold text-foreground">
-            {mode === 'fast' ? 'Fast geometry enabled' : 'Exact geometry enabled'}
+            {reason === 'tier'
+              ? 'Detail pin removed'
+              : mode === 'fast'
+                ? 'Fast geometry enabled'
+                : 'Exact geometry enabled'}
           </span>
           <span className="text-[11px] text-muted-foreground truncate">
             Reload model to apply the new setting.

--- a/apps/viewer/src/components/viewer/toolbar/ClassVisibilityMenu.tsx
+++ b/apps/viewer/src/components/viewer/toolbar/ClassVisibilityMenu.tsx
@@ -11,8 +11,11 @@
  * <label> wrapping a right-aligned Switch, so toggling does NOT close
  * the menu — users routinely flip several classes in one pass. State
  * reads two ways: the switch position and the row dimming when off.
- * All rows render unconditionally (persisted preferences, sticky across
- * models/reloads); toggling a class the model lacks is a no-op.
+ * The preference rows render unconditionally (persisted, sticky across
+ * models/reloads); toggling a class the model lacks is a no-op. The two
+ * exceptions are state reports rather than preferences, and appear only when
+ * they have something to say: the Model/Types switch (needs type geometry) and
+ * the pinned-detail notice (needs a stored `?geomTier=` override).
  */
 
 import React from 'react';
@@ -21,6 +24,7 @@ import {
   BoxSelect,
   Boxes,
   Building2,
+  Gauge,
   Grid3x3,
   Layers2,
   Pencil,
@@ -32,6 +36,7 @@ import { Button } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
 import { DropdownMenuContent, DropdownMenuSeparator } from '@/components/ui/dropdown-menu';
 import { useViewerStore } from '@/store';
+import { isPreviewTier } from '@/store/constants';
 import { cn } from '@/lib/utils';
 
 interface ClassVisibilityRowProps {
@@ -102,6 +107,9 @@ export function ClassVisibilityMenuContent({ align = 'start' }: { align?: 'start
   const setMergeLayers = useViewerStore((state) => state.setMergeLayers);
   const geometryMode = useViewerStore((state) => state.geometryMode);
   const setGeometryMode = useViewerStore((state) => state.setGeometryMode);
+  // #2544: a pinned `?geomTier=` override is otherwise invisible and permanent.
+  const geomTierOverride = useViewerStore((state) => state.geomTierOverride);
+  const clearGeomTierOverride = useViewerStore((state) => state.clearGeomTierOverride);
   const { visible: visibleClassCount, total: classToggleCount } = useVisibleClassCount();
 
   return (
@@ -268,6 +276,39 @@ export function ClassVisibilityMenuContent({ align = 'start' }: { align?: 'start
           onCheckedChange={(next) => setGeometryMode(next === true ? 'fast' : 'exact')}
         />
       </label>
+
+      {/* A `?geomTier=` override persists to localStorage from a single link
+          visit and then silently governs every later load. Before #2544 nothing
+          in the UI said so and the only ways out were `?geomTier=auto` or
+          clearing site data — so a borrowed debug link could pin a browser to
+          preview fidelity forever. Rendered ONLY while an override is stored:
+          for everyone else there is nothing to say, and a permanent "Detail:
+          auto" row would be noise. Not a <label>/Switch like the rows above,
+          because this is not a preference the user set here; it is a stuck
+          state with exactly one useful action. */}
+      {geomTierOverride && (
+        <div className="flex items-center justify-between gap-3 rounded-md border border-primary/40 bg-primary/5 px-2 py-1.5">
+          <span className="flex items-center gap-2.5 min-w-0">
+            <Gauge className="h-4 w-4 shrink-0 text-primary" />
+            <span className="grid gap-0.5 min-w-0">
+              <span className="text-sm leading-tight truncate">Detail pinned: {geomTierOverride}</span>
+              <span className="text-[10px] leading-tight text-muted-foreground truncate">
+                {isPreviewTier(geomTierOverride) && geometryMode !== 'fast'
+                  ? 'Ignored in Exact · from a ?geomTier= link'
+                  : 'Overrides automatic detail · from a ?geomTier= link'}
+              </span>
+            </span>
+          </span>
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-7 shrink-0 px-2 text-[11px] font-semibold uppercase tracking-wider"
+            onClick={clearGeomTierOverride}
+          >
+            Clear
+          </Button>
+        </div>
+      )}
     </DropdownMenuContent>
   );
 }

--- a/apps/viewer/src/store/constants.test.ts
+++ b/apps/viewer/src/store/constants.test.ts
@@ -5,7 +5,12 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 
-import { resolveLoadTessellationTier, AUTO_LOW_TIER_MB, AUTO_LOWEST_TIER_MB } from './constants.js';
+import {
+  isPreviewTier,
+  resolveLoadTessellationTier,
+  AUTO_LOW_TIER_MB,
+  AUTO_LOWEST_TIER_MB,
+} from './constants.js';
 
 // In node:test there is no `window`, so getGeomTierOverride() returns undefined
 // and these assertions exercise the pure size + mode logic deterministically.
@@ -32,5 +37,60 @@ describe('resolveLoadTessellationTier (geometry mode gating)', () => {
 
   it('defaults to fast mode when omitted', () => {
     assert.strictEqual(resolveLoadTessellationTier(AUTO_LOW_TIER_MB), 'low');
+  });
+});
+
+describe('isPreviewTier', () => {
+  // The set must stay in lockstep with `quality_skips_small_cuts` in
+  // rust/geometry/src/processors/boolean/mod.rs (`Lowest | Low`). If a tier is
+  // added to that Rust match without appearing here, `exact` mode silently
+  // starts dropping small cuts again — the whole of #2544.
+  it('is exactly the tiers below the engine default', () => {
+    assert.strictEqual(isPreviewTier('lowest'), true);
+    assert.strictEqual(isPreviewTier('low'), true);
+    assert.strictEqual(isPreviewTier('medium'), false);
+    assert.strictEqual(isPreviewTier('high'), false);
+    assert.strictEqual(isPreviewTier('highest'), false);
+  });
+
+  it('treats "no override" as not a preview tier', () => {
+    assert.strictEqual(isPreviewTier(undefined), false);
+  });
+});
+
+// #2544: a `?geomTier=` override persists to localStorage from one link visit
+// and used to win in EVERY mode, so `exact` silently served preview geometry
+// (coarse curves AND dropped sub-10% cuts) while the UI promised full fidelity.
+// The override is injected here rather than stubbing localStorage, which is
+// also why `resolveLoadTessellationTier` takes it as a parameter.
+describe('resolveLoadTessellationTier (stored ?geomTier= override)', () => {
+  it('exact mode refuses a preview override, at any file size', () => {
+    for (const tier of ['low', 'lowest'] as const) {
+      assert.strictEqual(resolveLoadTessellationTier(10, 'exact', tier), undefined);
+      assert.strictEqual(resolveLoadTessellationTier(76.73, 'exact', tier), undefined);
+      assert.strictEqual(
+        resolveLoadTessellationTier(AUTO_LOWEST_TIER_MB + 1000, 'exact', tier),
+        undefined,
+      );
+    }
+  });
+
+  it('exact mode still honours a medium-or-finer override', () => {
+    // Pinning full density on a large model is why the override exists, and it
+    // cannot violate the exact contract — so it must survive the fix.
+    assert.strictEqual(resolveLoadTessellationTier(200, 'exact', 'high'), 'high');
+    assert.strictEqual(resolveLoadTessellationTier(200, 'exact', 'highest'), 'highest');
+    assert.strictEqual(resolveLoadTessellationTier(200, 'exact', 'medium'), 'medium');
+  });
+
+  it('fast mode still lets any override win over the size heuristic', () => {
+    // Fast is the tuning mode; the override is a knob there, not a trap.
+    assert.strictEqual(resolveLoadTessellationTier(10, 'fast', 'lowest'), 'lowest');
+    assert.strictEqual(resolveLoadTessellationTier(AUTO_LOWEST_TIER_MB, 'fast', 'high'), 'high');
+  });
+
+  it('falls back to the size heuristic when no override is stored', () => {
+    assert.strictEqual(resolveLoadTessellationTier(AUTO_LOW_TIER_MB, 'fast', undefined), 'low');
+    assert.strictEqual(resolveLoadTessellationTier(AUTO_LOW_TIER_MB, 'exact', undefined), undefined);
   });
 });

--- a/apps/viewer/src/store/constants.ts
+++ b/apps/viewer/src/store/constants.ts
@@ -9,6 +9,24 @@
 import type { TypeVisibility } from './types.js';
 import type { TessellationQuality } from '@ifc-lite/geometry';
 
+// Load-time geometry fidelity (mode, tier, sticky `?geomTier=` override) now
+// lives in its own module - it was the largest cohesive block here and this file
+// is long past the ~400-line house limit. Re-exported so the many existing
+// `store/constants` importers keep one import site.
+export {
+  AUTO_LOW_TIER_MB,
+  AUTO_LOWEST_TIER_MB,
+  GEOM_TIER_STORAGE_KEY,
+  GEOMETRY_MODE_STORAGE_KEY,
+  clearGeomTierOverride,
+  getGeomTierOverride,
+  getInitialGeometryMode,
+  isPreviewTier,
+  resolveLoadTessellationTier,
+  type GeometryMode,
+} from './geometryFidelity.js';
+import { getGeomTierOverride, getInitialGeometryMode } from './geometryFidelity.js';
+
 // ============================================================================
 // Camera Defaults
 // ============================================================================
@@ -114,7 +132,6 @@ function getInitialMergeLayers(): boolean {
  * localStorage key for the geometry-worker-count A/B override.
  */
 export const GEOM_WORKERS_STORAGE_KEY = 'ifc-lite-geom-workers';
-export const GEOM_TIER_STORAGE_KEY = 'ifc-lite-geom-tier';
 
 /**
  * localStorage key for the source-decoupled mesh-only cache KILL SWITCH. The
@@ -123,50 +140,8 @@ export const GEOM_TIER_STORAGE_KEY = 'ifc-lite-geom-tier';
  */
 export const MESH_ONLY_CACHE_STORAGE_KEY = 'ifc-lite-mesh-cache';
 
-// Auto-low tessellation density for heavy models. The on-screen load already
-// skips tiny detail boolean cuts on every load (#1286), which removes the
-// exact-tier escalations that dominate boolean-heavy steel; this is the
-// ORTHOGONAL triangle-count lever — dropping vertex density (low = 0.5x,
-// lowest = 0.25x) so a multi-million-triangle model uploads + fits in GPU
-// memory fast for first paint. The signal is file size, the only model-weight
-// proxy available before geometry runs (the pre-pass job count arrives after
-// the cache key is committed). Size correlates with triangle count at scale but
-// can't tell a dense-but-small model (e.g. 20 MB detailed steel, ~8M tris) from
-// a light one — those still load at medium density (the skip keeps them fast),
-// or can be forced low via `?geomTier=low`. Thresholds are deliberately high so
-// normal models keep full curve density; tune here.
-export const AUTO_LOW_TIER_MB = 50; // >= this → 'low'
-export const AUTO_LOWEST_TIER_MB = 150; // >= this → 'lowest'
-
-/** localStorage key for the load-time geometry fidelity mode (mirrors merge-layers). */
-export const GEOMETRY_MODE_STORAGE_KEY = 'ifc-lite-geometry-mode';
-
 /** localStorage key for the active Hierarchy view mode. */
 export const HIERARCHY_MODE_STORAGE_KEY = 'hierarchy-mode';
-
-/**
- * Load-time geometry fidelity mode — a user-facing, persistent switch that
- * mirrors the merge-layers load-time input (sticky in localStorage, folded into
- * the geometry cache key, reload-to-apply).
- * - `fast` (default): skip tiny detail boolean cuts (#1286) + auto-low
- *   tessellation density for heavy models, for fast first paint. PREVIEW
- *   fidelity — sub-10% cutters (bolt holes, copes) are dropped and curves may be
- *   coarser; display, measure AND export all read this same geometry, so it is a
- *   deliberate, visible choice rather than a silent default.
- * - `exact`: full boolean cuts + full curve density everywhere — display,
- *   measure and export consistent. Slower on boolean-heavy / dense models.
- */
-export type GeometryMode = 'fast' | 'exact';
-
-/** Resolve the initial geometry mode from localStorage; default `fast`. */
-function getInitialGeometryMode(): GeometryMode {
-  if (typeof window === 'undefined') return 'fast';
-  try {
-    return localStorage.getItem(GEOMETRY_MODE_STORAGE_KEY) === 'exact' ? 'exact' : 'fast';
-  } catch {
-    return 'fast';
-  }
-}
 
 /**
  * Resolve an explicit geometry-worker count override for A/B tuning, or
@@ -201,83 +176,6 @@ export function getGeomWorkerOverride(): number | undefined {
     if (Number.isFinite(stored) && stored >= 1 && stored <= 16) return stored;
   } catch {
     /* SSR / blocked storage — fall through to the heuristic */
-  }
-  return undefined;
-}
-
-const TESSELLATION_TIERS: readonly TessellationQuality[] = [
-  'lowest',
-  'low',
-  'medium',
-  'high',
-  'highest',
-];
-
-/**
- * The tiers BELOW the engine default, i.e. the preview ones. They are the tiers
- * `exact` mode must refuse (#2544), and the distinction is not merely about
- * vertex density: `quality_skips_small_cuts` in the Rust boolean processor
- * (`rust/geometry/src/processors/boolean/mod.rs`) is exactly `Lowest | Low`, and
- * it is OR'd with the `skip_small_cuts` flag. So a preview tier drops sub-10%
- * cutters on its own, no matter what the flag says — breaking BOTH halves of the
- * `exact` promise ("full boolean cuts + full curve density"). `medium` and finer
- * break neither, which is why they survive an `exact` load below.
- */
-const PREVIEW_TIERS: readonly TessellationQuality[] = ['lowest', 'low'];
-
-/** Whether `tier` is a preview tier (coarser than the engine default). */
-export function isPreviewTier(tier: TessellationQuality | undefined): boolean {
-  return tier != null && PREVIEW_TIERS.includes(tier);
-}
-
-/**
- * Drop any stored `?geomTier=` override, restoring automatic tier selection.
- *
- * The override persists across sessions by design, but nothing in the URL says
- * so after the first visit, so this is the UI's way out (the Visibility menu's
- * "Detail pinned" row) alongside the pre-existing `?geomTier=auto`.
- */
-export function clearGeomTierOverride(): void {
-  try {
-    localStorage.removeItem(GEOM_TIER_STORAGE_KEY);
-  } catch (err) {
-    // Blocked/unavailable storage. Don't swallow silently (AGENTS.md); the
-    // in-memory store still clears, so this load behaves as requested.
-    console.warn('[geom-tier] clear failed; override may return on reload', err);
-  }
-}
-
-/**
- * Per-host manual override for the load-time tessellation tier, mirroring
- * `getGeomWorkerOverride`. `?geomTier=low` (or lowest/medium/high/highest) sets
- * it AND persists to localStorage so it survives the reload a re-measure needs
- * (and a shared link carries it). `?geomTier=auto` clears the override. Useful
- * for forcing low density on a dense-but-small model the size heuristic can't
- * detect, or pinning full density on a large one.
- */
-export function getGeomTierOverride(): TessellationQuality | undefined {
-  if (typeof window === 'undefined') return undefined;
-  try {
-    const param = new URLSearchParams(window.location.search).get('geomTier');
-    if (param != null) {
-      if (param === 'auto') {
-        localStorage.removeItem(GEOM_TIER_STORAGE_KEY);
-        return undefined;
-      }
-      if ((TESSELLATION_TIERS as readonly string[]).includes(param)) {
-        localStorage.setItem(GEOM_TIER_STORAGE_KEY, param);
-        return param as TessellationQuality;
-      }
-    }
-    const stored = localStorage.getItem(GEOM_TIER_STORAGE_KEY) ?? '';
-    if ((TESSELLATION_TIERS as readonly string[]).includes(stored)) {
-      return stored as TessellationQuality;
-    }
-  } catch (err) {
-    // Blocked/unavailable storage (Safari private mode, locked storage) or a
-    // bad URL — fall back to the heuristic, but don't swallow silently
-    // (AGENTS.md: no silent catch). A persisted ?geomTier override is lost here.
-    console.warn('[geom-tier] override read failed; using heuristic', err);
   }
   return undefined;
 }
@@ -334,39 +232,6 @@ export function isMeshOnlyCacheEnabled(): boolean {
     console.warn('[mesh-cache] storage unavailable; honouring URL param, else default-on', err);
     return resolveMeshCacheDecision(param, null).enabled;
   }
-}
-
-/**
- * Resolve the load-time tessellation tier for a model of `fileSizeMB` under the
- * given geometry `mode`. In `fast` mode a manual `?geomTier=` override wins,
- * else auto-low for heavy models by size, else `undefined` (engine default =
- * medium, full curve density). Returning `undefined` at the medium default keeps
- * pre-existing cache entries valid (the tier discriminator is omitted from the
- * cache key at medium — see `buildGeometryCacheKey`).
- *
- * `exact` mode never auto-lows, and since #2544 it also refuses a stored PREVIEW
- * override. The override persists to localStorage from a single `?geomTier=low`
- * link, invisibly and forever, and it used to win in every mode — so a browser
- * that had once opened such a link kept meshing at preview fidelity (coarse
- * curves AND dropped sub-10% cuts, see `isPreviewTier`) while the UI said
- * "Exact: full cuts + density". Display, measure and export all read that
- * geometry, so the mismatch was not cosmetic. A `medium`-or-finer override is
- * still honoured in `exact` mode: pinning full density on a large model is the
- * documented reason the override exists, and it cannot violate the promise.
- *
- * `override` is injectable so the decision is testable without a DOM; callers
- * should omit it and let it read the persisted value.
- */
-export function resolveLoadTessellationTier(
-  fileSizeMB: number,
-  mode: GeometryMode = 'fast',
-  override: TessellationQuality | undefined = getGeomTierOverride()
-): TessellationQuality | undefined {
-  if (mode !== 'fast') return isPreviewTier(override) ? undefined : override;
-  if (override) return override;
-  if (fileSizeMB >= AUTO_LOWEST_TIER_MB) return 'lowest';
-  if (fileSizeMB >= AUTO_LOW_TIER_MB) return 'low';
-  return undefined;
 }
 
 /**

--- a/apps/viewer/src/store/constants.ts
+++ b/apps/viewer/src/store/constants.ts
@@ -214,6 +214,40 @@ const TESSELLATION_TIERS: readonly TessellationQuality[] = [
 ];
 
 /**
+ * The tiers BELOW the engine default, i.e. the preview ones. They are the tiers
+ * `exact` mode must refuse (#2544), and the distinction is not merely about
+ * vertex density: `quality_skips_small_cuts` in the Rust boolean processor
+ * (`rust/geometry/src/processors/boolean/mod.rs`) is exactly `Lowest | Low`, and
+ * it is OR'd with the `skip_small_cuts` flag. So a preview tier drops sub-10%
+ * cutters on its own, no matter what the flag says — breaking BOTH halves of the
+ * `exact` promise ("full boolean cuts + full curve density"). `medium` and finer
+ * break neither, which is why they survive an `exact` load below.
+ */
+const PREVIEW_TIERS: readonly TessellationQuality[] = ['lowest', 'low'];
+
+/** Whether `tier` is a preview tier (coarser than the engine default). */
+export function isPreviewTier(tier: TessellationQuality | undefined): boolean {
+  return tier != null && PREVIEW_TIERS.includes(tier);
+}
+
+/**
+ * Drop any stored `?geomTier=` override, restoring automatic tier selection.
+ *
+ * The override persists across sessions by design, but nothing in the URL says
+ * so after the first visit, so this is the UI's way out (the Visibility menu's
+ * "Detail pinned" row) alongside the pre-existing `?geomTier=auto`.
+ */
+export function clearGeomTierOverride(): void {
+  try {
+    localStorage.removeItem(GEOM_TIER_STORAGE_KEY);
+  } catch (err) {
+    // Blocked/unavailable storage. Don't swallow silently (AGENTS.md); the
+    // in-memory store still clears, so this load behaves as requested.
+    console.warn('[geom-tier] clear failed; override may return on reload', err);
+  }
+}
+
+/**
  * Per-host manual override for the load-time tessellation tier, mirroring
  * `getGeomWorkerOverride`. `?geomTier=low` (or lowest/medium/high/highest) sets
  * it AND persists to localStorage so it survives the reload a re-measure needs
@@ -304,20 +338,32 @@ export function isMeshOnlyCacheEnabled(): boolean {
 
 /**
  * Resolve the load-time tessellation tier for a model of `fileSizeMB` under the
- * given geometry `mode`: a manual `?geomTier=` override wins in any mode; else
- * in `fast` mode auto-low for heavy models by size; else `undefined` (engine
- * default = medium, full curve density). In `exact` mode auto-low never fires,
- * so dense models keep full density. Returning `undefined` at the medium default
- * keeps pre-existing cache entries valid (the tier discriminator is omitted from
- * the cache key at medium — see `buildGeometryCacheKey`).
+ * given geometry `mode`. In `fast` mode a manual `?geomTier=` override wins,
+ * else auto-low for heavy models by size, else `undefined` (engine default =
+ * medium, full curve density). Returning `undefined` at the medium default keeps
+ * pre-existing cache entries valid (the tier discriminator is omitted from the
+ * cache key at medium — see `buildGeometryCacheKey`).
+ *
+ * `exact` mode never auto-lows, and since #2544 it also refuses a stored PREVIEW
+ * override. The override persists to localStorage from a single `?geomTier=low`
+ * link, invisibly and forever, and it used to win in every mode — so a browser
+ * that had once opened such a link kept meshing at preview fidelity (coarse
+ * curves AND dropped sub-10% cuts, see `isPreviewTier`) while the UI said
+ * "Exact: full cuts + density". Display, measure and export all read that
+ * geometry, so the mismatch was not cosmetic. A `medium`-or-finer override is
+ * still honoured in `exact` mode: pinning full density on a large model is the
+ * documented reason the override exists, and it cannot violate the promise.
+ *
+ * `override` is injectable so the decision is testable without a DOM; callers
+ * should omit it and let it read the persisted value.
  */
 export function resolveLoadTessellationTier(
   fileSizeMB: number,
-  mode: GeometryMode = 'fast'
+  mode: GeometryMode = 'fast',
+  override: TessellationQuality | undefined = getGeomTierOverride()
 ): TessellationQuality | undefined {
-  const override = getGeomTierOverride();
+  if (mode !== 'fast') return isPreviewTier(override) ? undefined : override;
   if (override) return override;
-  if (mode !== 'fast') return undefined;
   if (fileSizeMB >= AUTO_LOWEST_TIER_MB) return 'lowest';
   if (fileSizeMB >= AUTO_LOW_TIER_MB) return 'low';
   return undefined;
@@ -434,6 +480,12 @@ export const UI_DEFAULTS = {
    * `exact` for full display/measure/export fidelity.
    */
   GEOMETRY_MODE: getInitialGeometryMode(),
+  /**
+   * Stored `?geomTier=` tessellation override, read once on boot so the
+   * Visibility menu can SHOW that detail is pinned and offer a way out (#2544).
+   * `undefined` = automatic tier selection, the normal case.
+   */
+  GEOM_TIER_OVERRIDE: getGeomTierOverride(),
   /**
    * Desktop toolbar style (issue #1686): the tabbed `ribbon` (default) or
    * the original `classic` single strip. Read from localStorage on boot so

--- a/apps/viewer/src/store/geomTierOverride.test.ts
+++ b/apps/viewer/src/store/geomTierOverride.test.ts
@@ -27,7 +27,15 @@ import {
 const savedWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
 const savedLocalStorage = Object.getOwnPropertyDescriptor(globalThis, 'localStorage');
 
-/** Install a fake `window.location.search` + `localStorage`; returns the store. */
+/**
+ * Install a fake `window` (location + history + localStorage); returns the
+ * storage map.
+ *
+ * `history.replaceState` rewrites `location.search`/`href` the way a browser
+ * does, so a test can assert what the NEXT `getGeomTierOverride()` sees rather
+ * than merely that replaceState was called. That distinction is the whole point
+ * of the URL-stripping test below.
+ */
 function stub(search: string, initial: Record<string, string> = {}): Map<string, string> {
   const store = new Map<string, string>(Object.entries(initial));
   const localStorage = {
@@ -35,8 +43,19 @@ function stub(search: string, initial: Record<string, string> = {}): Map<string,
     setItem: (k: string, v: string) => { store.set(k, v); },
     removeItem: (k: string) => { store.delete(k); },
   };
+  const location = {
+    search,
+    href: `https://viewer.test/${search}`,
+  };
+  const history = {
+    replaceState: (_data: unknown, _title: string, url: string) => {
+      const next = new URL(url, 'https://viewer.test/');
+      location.search = next.search;
+      location.href = next.toString();
+    },
+  };
   Object.defineProperty(globalThis, 'window', {
-    value: { location: { search }, localStorage },
+    value: { location, history, localStorage },
     configurable: true,
     writable: true,
   });
@@ -85,6 +104,31 @@ describe('clearGeomTierOverride', () => {
     assert.equal(getGeomTierOverride(), 'lowest');
     clearGeomTierOverride();
     assert.equal(store.has(GEOM_TIER_STORAGE_KEY), false);
+    assert.equal(getGeomTierOverride(), undefined);
+  });
+
+  it('also strips geomTier from the URL, so the pin cannot resurrect itself', () => {
+    // The failure this prevents: clearing ONLY localStorage leaves the query
+    // parameter in place, and `getGeomTierOverride` re-reads and re-persists it
+    // on the very next call. On the originating `?geomTier=low` link - exactly
+    // the case the Clear action exists for - the pin would silently come back.
+    const store = stub('?geomTier=low&other=keep');
+    assert.equal(getGeomTierOverride(), 'low');
+    assert.equal(store.get(GEOM_TIER_STORAGE_KEY), 'low');
+
+    clearGeomTierOverride();
+
+    assert.equal(window.location.search, '?other=keep', 'unrelated params must survive');
+    assert.equal(store.has(GEOM_TIER_STORAGE_KEY), false);
+    // The real assertion: a subsequent read cannot bring the pin back.
+    assert.equal(getGeomTierOverride(), undefined);
+    assert.equal(store.has(GEOM_TIER_STORAGE_KEY), false);
+  });
+
+  it('leaves the URL alone when it carries no geomTier', () => {
+    stub('?other=keep', { [GEOM_TIER_STORAGE_KEY]: 'low' });
+    clearGeomTierOverride();
+    assert.equal(window.location.search, '?other=keep');
     assert.equal(getGeomTierOverride(), undefined);
   });
 

--- a/apps/viewer/src/store/geomTierOverride.test.ts
+++ b/apps/viewer/src/store/geomTierOverride.test.ts
@@ -1,0 +1,134 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * #2544 — the stored `?geomTier=` override, end-to-end through the
+ * window/localStorage-reading wrappers.
+ *
+ * `constants.test.ts` covers the resolution rule by injecting the override, so
+ * it cannot catch the wrapper being unwired from the persisted value. These
+ * tests exercise the real production path (`resolveLoadTessellationTier` reading
+ * `getGeomTierOverride()` itself) with the globals stubbed, which is the only
+ * way a regression in the *plumbing* fails a test rather than the *rule*.
+ */
+
+import { describe, it, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  clearGeomTierOverride,
+  getGeomTierOverride,
+  resolveLoadTessellationTier,
+  AUTO_LOW_TIER_MB,
+  GEOM_TIER_STORAGE_KEY,
+} from './constants.js';
+
+const savedWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+const savedLocalStorage = Object.getOwnPropertyDescriptor(globalThis, 'localStorage');
+
+/** Install a fake `window.location.search` + `localStorage`; returns the store. */
+function stub(search: string, initial: Record<string, string> = {}): Map<string, string> {
+  const store = new Map<string, string>(Object.entries(initial));
+  const localStorage = {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => { store.set(k, v); },
+    removeItem: (k: string) => { store.delete(k); },
+  };
+  Object.defineProperty(globalThis, 'window', {
+    value: { location: { search }, localStorage },
+    configurable: true,
+    writable: true,
+  });
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: localStorage,
+    configurable: true,
+    writable: true,
+  });
+  return store;
+}
+
+afterEach(() => {
+  if (savedWindow) Object.defineProperty(globalThis, 'window', savedWindow);
+  else delete (globalThis as Record<string, unknown>).window;
+  if (savedLocalStorage) Object.defineProperty(globalThis, 'localStorage', savedLocalStorage);
+  else delete (globalThis as Record<string, unknown>).localStorage;
+});
+
+describe('getGeomTierOverride (persistence)', () => {
+  it('persists a URL param so a LATER plain load still resolves it', () => {
+    // This stickiness is the whole hazard: one link visit governs every load
+    // afterwards, with nothing in the URL to say so.
+    const store = stub('?geomTier=low');
+    assert.equal(getGeomTierOverride(), 'low');
+    assert.equal(store.get(GEOM_TIER_STORAGE_KEY), 'low');
+
+    stub('', { [GEOM_TIER_STORAGE_KEY]: 'low' });
+    assert.equal(getGeomTierOverride(), 'low');
+  });
+
+  it('ignores a bogus tier rather than pinning garbage', () => {
+    stub('?geomTier=ultra');
+    assert.equal(getGeomTierOverride(), undefined);
+  });
+
+  it('?geomTier=auto clears the persisted override', () => {
+    const store = stub('?geomTier=auto', { [GEOM_TIER_STORAGE_KEY]: 'low' });
+    assert.equal(getGeomTierOverride(), undefined);
+    assert.equal(store.has(GEOM_TIER_STORAGE_KEY), false);
+  });
+});
+
+describe('clearGeomTierOverride', () => {
+  it('drops the persisted override so the next load resolves automatically', () => {
+    const store = stub('', { [GEOM_TIER_STORAGE_KEY]: 'lowest' });
+    assert.equal(getGeomTierOverride(), 'lowest');
+    clearGeomTierOverride();
+    assert.equal(store.has(GEOM_TIER_STORAGE_KEY), false);
+    assert.equal(getGeomTierOverride(), undefined);
+  });
+
+  it('does not throw when storage is blocked (Safari private mode)', () => {
+    const throwing = {
+      getItem: () => { throw new DOMException('blocked', 'SecurityError'); },
+      setItem: () => { throw new DOMException('blocked', 'SecurityError'); },
+      removeItem: () => { throw new DOMException('blocked', 'SecurityError'); },
+    };
+    Object.defineProperty(globalThis, 'window', {
+      value: { location: { search: '' }, localStorage: throwing }, configurable: true, writable: true,
+    });
+    Object.defineProperty(globalThis, 'localStorage', { value: throwing, configurable: true, writable: true });
+    assert.doesNotThrow(() => clearGeomTierOverride());
+  });
+});
+
+describe('a pinned preview tier cannot govern an exact load (#2544)', () => {
+  it('exact mode ignores a persisted low override on the real read path', () => {
+    // The regression this exists for: `exact` promises "full boolean cuts +
+    // full curve density", but a persisted `low` used to win, and `low` also
+    // trips `quality_skips_small_cuts` in the Rust boolean processor — so the
+    // model was meshed with coarse curves AND dropped sub-10% cutters while the
+    // UI said Exact. Display, measure and export all read that geometry.
+    stub('', { [GEOM_TIER_STORAGE_KEY]: 'low' });
+    assert.equal(resolveLoadTessellationTier(76.73, 'exact'), undefined);
+    assert.equal(resolveLoadTessellationTier(10, 'exact'), undefined);
+  });
+
+  it('exact mode keeps a persisted high override (pinning full density still works)', () => {
+    stub('', { [GEOM_TIER_STORAGE_KEY]: 'high' });
+    assert.equal(resolveLoadTessellationTier(200, 'exact'), 'high');
+  });
+
+  it('fast mode still honours a persisted low override over the size heuristic', () => {
+    stub('', { [GEOM_TIER_STORAGE_KEY]: 'lowest' });
+    assert.equal(resolveLoadTessellationTier(AUTO_LOW_TIER_MB, 'fast'), 'lowest');
+  });
+
+  it('clearing the override hands the exact load back to the engine default', () => {
+    stub('', { [GEOM_TIER_STORAGE_KEY]: 'low' });
+    clearGeomTierOverride();
+    assert.equal(resolveLoadTessellationTier(76.73, 'exact'), undefined);
+    // ...and the fast load back to the size heuristic rather than the pin.
+    assert.equal(resolveLoadTessellationTier(76.73, 'fast'), 'low');
+  });
+});

--- a/apps/viewer/src/store/geometryFidelity.ts
+++ b/apps/viewer/src/store/geometryFidelity.ts
@@ -1,0 +1,197 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Load-time geometry fidelity: the `fast`/`exact` mode, the tessellation tier,
+ * and the sticky `?geomTier=` override that ties them together.
+ *
+ * Split out of `constants.ts` (which re-exports everything here for its existing
+ * consumers) because this is one decision with one failure story — what density
+ * and which boolean cuts a load is meshed at — and it was the largest cohesive
+ * block in a module long past the ~400-line house limit.
+ */
+
+import type { TessellationQuality } from '@ifc-lite/geometry';
+
+/** localStorage key for the sticky tessellation-tier override. */
+export const GEOM_TIER_STORAGE_KEY = 'ifc-lite-geom-tier';
+
+/** localStorage key for the load-time geometry fidelity mode (mirrors merge-layers). */
+export const GEOMETRY_MODE_STORAGE_KEY = 'ifc-lite-geometry-mode';
+
+// Auto-low tessellation density for heavy models. The on-screen load already
+// skips tiny detail boolean cuts on every load (#1286), which removes the
+// exact-tier escalations that dominate boolean-heavy steel; this is the
+// ORTHOGONAL triangle-count lever - dropping vertex density (low = 0.5x,
+// lowest = 0.25x) so a multi-million-triangle model uploads + fits in GPU
+// memory fast for first paint. The signal is file size, the only model-weight
+// proxy available before geometry runs (the pre-pass job count arrives after
+// the cache key is committed). Size correlates with triangle count at scale but
+// can't tell a dense-but-small model (e.g. 20 MB detailed steel, ~8M tris) from
+// a light one - those still load at medium density (the skip keeps them fast),
+// or can be forced low via `?geomTier=low`. Thresholds are deliberately high so
+// normal models keep full curve density; tune here.
+export const AUTO_LOW_TIER_MB = 50; // >= this -> 'low'
+export const AUTO_LOWEST_TIER_MB = 150; // >= this -> 'lowest'
+
+/**
+ * Load-time geometry fidelity mode - a user-facing, persistent switch that
+ * mirrors the merge-layers load-time input (sticky in localStorage, folded into
+ * the geometry cache key, reload-to-apply).
+ * - `fast` (default): skip tiny detail boolean cuts (#1286) + auto-low
+ *   tessellation density for heavy models, for fast first paint. PREVIEW
+ *   fidelity - sub-10% cutters (bolt holes, copes) are dropped and curves may be
+ *   coarser; display, measure AND export all read this same geometry, so it is a
+ *   deliberate, visible choice rather than a silent default.
+ * - `exact`: full boolean cuts + full curve density everywhere - display,
+ *   measure and export consistent. Slower on boolean-heavy / dense models.
+ */
+export type GeometryMode = 'fast' | 'exact';
+
+/** Resolve the initial geometry mode from localStorage; default `fast`. */
+export function getInitialGeometryMode(): GeometryMode {
+  if (typeof window === 'undefined') return 'fast';
+  try {
+    return localStorage.getItem(GEOMETRY_MODE_STORAGE_KEY) === 'exact' ? 'exact' : 'fast';
+  } catch {
+    return 'fast';
+  }
+}
+
+const TESSELLATION_TIERS: readonly TessellationQuality[] = [
+  'lowest',
+  'low',
+  'medium',
+  'high',
+  'highest',
+];
+
+/**
+ * The tiers BELOW the engine default, i.e. the preview ones. They are the tiers
+ * `exact` mode must refuse (#2544), and the distinction is not merely about
+ * vertex density: `quality_skips_small_cuts` in the Rust boolean processor
+ * (`rust/geometry/src/processors/boolean/mod.rs`) is exactly `Lowest | Low`, and
+ * it is OR'd with the `skip_small_cuts` flag. So a preview tier drops sub-10%
+ * cutters on its own, no matter what the flag says - breaking BOTH halves of the
+ * `exact` promise ("full boolean cuts + full curve density"). `medium` and finer
+ * break neither, which is why they survive an `exact` load below.
+ */
+const PREVIEW_TIERS: readonly TessellationQuality[] = ['lowest', 'low'];
+
+/** Whether `tier` is a preview tier (coarser than the engine default). */
+export function isPreviewTier(tier: TessellationQuality | undefined): boolean {
+  return tier != null && PREVIEW_TIERS.includes(tier);
+}
+
+/**
+ * Per-host manual override for the load-time tessellation tier, mirroring
+ * `getGeomWorkerOverride`. `?geomTier=low` (or lowest/medium/high/highest) sets
+ * it AND persists to localStorage so it survives the reload a re-measure needs
+ * (and a shared link carries it). `?geomTier=auto` clears the override. Useful
+ * for forcing low density on a dense-but-small model the size heuristic can't
+ * detect, or pinning full density on a large one.
+ */
+export function getGeomTierOverride(): TessellationQuality | undefined {
+  if (typeof window === 'undefined') return undefined;
+  try {
+    const param = new URLSearchParams(window.location.search).get('geomTier');
+    if (param != null) {
+      if (param === 'auto') {
+        localStorage.removeItem(GEOM_TIER_STORAGE_KEY);
+        return undefined;
+      }
+      if ((TESSELLATION_TIERS as readonly string[]).includes(param)) {
+        localStorage.setItem(GEOM_TIER_STORAGE_KEY, param);
+        return param as TessellationQuality;
+      }
+    }
+    const stored = localStorage.getItem(GEOM_TIER_STORAGE_KEY) ?? '';
+    if ((TESSELLATION_TIERS as readonly string[]).includes(stored)) {
+      return stored as TessellationQuality;
+    }
+  } catch (err) {
+    // Blocked/unavailable storage (Safari private mode, locked storage) or a
+    // bad URL - fall back to the heuristic, but don't swallow silently
+    // (AGENTS.md: no silent catch). A persisted ?geomTier override is lost here.
+    console.warn('[geom-tier] override read failed; using heuristic', err);
+  }
+  return undefined;
+}
+
+/**
+ * Drop `geomTier` from the address bar without navigating.
+ *
+ * Clearing localStorage alone is NOT enough: `getGeomTierOverride` re-reads the
+ * query parameter on every call and re-persists it, so on the originating
+ * `?geomTier=low` link the very next load would silently restore the pin - and
+ * that link is precisely the case the clear action exists for. Stripping the
+ * parameter also stops the user re-sharing a URL that re-pins the next reader.
+ */
+function stripGeomTierParam(): void {
+  if (typeof window === 'undefined') return;
+  const href = window.location?.href;
+  // Guarded rather than try/caught so the no-DOM test/SSR paths stay silent:
+  // absence here is normal, only a real failure below deserves a warning.
+  if (typeof href !== 'string' || typeof window.history?.replaceState !== 'function') return;
+  try {
+    const url = new URL(href);
+    if (!url.searchParams.has('geomTier')) return;
+    url.searchParams.delete('geomTier');
+    window.history.replaceState(null, '', `${url.pathname}${url.search}${url.hash}`);
+  } catch (err) {
+    console.warn('[geom-tier] could not strip the URL parameter; the pin may return', err);
+  }
+}
+
+/**
+ * Drop any stored `?geomTier=` override, restoring automatic tier selection.
+ *
+ * The override persists across sessions by design, but nothing in the URL says
+ * so after the first visit, so this is the UI's way out (the Visibility menu's
+ * "Detail pinned" row) alongside the pre-existing `?geomTier=auto`. Clears BOTH
+ * homes of the pin - storage and query string - see `stripGeomTierParam`.
+ */
+export function clearGeomTierOverride(): void {
+  try {
+    localStorage.removeItem(GEOM_TIER_STORAGE_KEY);
+  } catch (err) {
+    // Blocked/unavailable storage. Don't swallow silently (AGENTS.md); the
+    // in-memory store still clears, so this load behaves as requested.
+    console.warn('[geom-tier] clear failed; override may return on reload', err);
+  }
+  stripGeomTierParam();
+}
+
+/**
+ * Resolve the load-time tessellation tier for a model of `fileSizeMB` under the
+ * given geometry `mode`. In `fast` mode a manual `?geomTier=` override wins,
+ * else auto-low for heavy models by size, else `undefined` (engine default =
+ * medium, full curve density). Returning `undefined` at the medium default keeps
+ * pre-existing cache entries valid (the tier discriminator is omitted from the
+ * cache key at medium - see `buildGeometryCacheKey`).
+ *
+ * `exact` mode never auto-lows, and since #2544 it also refuses a stored PREVIEW
+ * override. The override persists to localStorage from a single `?geomTier=low`
+ * link, invisibly and forever, and it used to win in every mode - so a browser
+ * that had once opened such a link kept meshing at preview fidelity (coarse
+ * curves AND dropped sub-10% cuts, see `isPreviewTier`) while the UI said
+ * "Exact: full cuts + density". Display, measure and export all read that
+ * geometry, so the mismatch was not cosmetic. A `medium`-or-finer override is
+ * still honoured in `exact` mode: pinning full density on a large model is the
+ * documented reason the override exists, and it cannot violate the promise.
+ *
+ * `override` is injectable so the decision is testable without a DOM; callers
+ * should omit it and let it read the persisted value.
+ */
+export function resolveLoadTessellationTier(
+  fileSizeMB: number,
+  mode: GeometryMode = 'fast',
+  override: TessellationQuality | undefined = getGeomTierOverride()
+): TessellationQuality | undefined {
+  if (mode !== 'fast') return isPreviewTier(override) ? undefined : override;
+  if (override) return override;
+  if (fileSizeMB >= AUTO_LOWEST_TIER_MB) return 'lowest';
+  if (fileSizeMB >= AUTO_LOW_TIER_MB) return 'low';
+  return undefined;
+}

--- a/apps/viewer/src/store/slices/geometryLoadSettings.ts
+++ b/apps/viewer/src/store/slices/geometryLoadSettings.ts
@@ -1,0 +1,153 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The load-time geometry settings: merge-layers, the Fast/Exact fidelity mode,
+ * and the sticky `?geomTier=` tessellation pin.
+ *
+ * Split out of `uiSlice.ts` (which composes it, so the store shape is
+ * unchanged) because these share one contract that none of the slice's other
+ * state has: each is read only on the NEXT model load, is folded into the
+ * geometry cache key, and therefore has to prompt a reload when a model is
+ * already in scope. `uiSlice.ts` is well past the ~400-line house limit and this
+ * was its most self-contained block.
+ */
+
+import {
+  GEOMETRY_MODE_STORAGE_KEY,
+  MERGE_LAYERS_STORAGE_KEY,
+  UI_DEFAULTS,
+  clearGeomTierOverride as clearStoredGeomTier,
+  type GeometryMode,
+} from '../constants.js';
+import type { TessellationQuality } from '@ifc-lite/geometry';
+
+/**
+ * Which load-time geometry input armed the reload prompt, so the banner names
+ * the change the user actually made rather than always reporting the mode.
+ */
+export type GeometryReloadReason = 'mode' | 'tier';
+
+export interface GeometryLoadSettingsState {
+  /**
+   * Issue #540 - "Merge Multilayer Walls" load-time toggle. Reading this on
+   * next file load is what the WASM bridge actually uses; flipping it while a
+   * model is in scope sets `mergeLayersPendingReload` so the UI can prompt.
+   */
+  mergeLayers: boolean;
+  /** True after the user flipped `mergeLayers` while a model was loaded. */
+  mergeLayersPendingReload: boolean;
+  /**
+   * Load-time geometry fidelity mode (`fast` = skip tiny cuts + auto-low
+   * density; `exact` = full fidelity). Like `mergeLayers`, it is read on the
+   * next file load.
+   */
+  geometryMode: GeometryMode;
+  /**
+   * True after a load-time geometry input changed while a model was loaded:
+   * either `geometryMode` or the pinned tessellation tier. One flag, one
+   * banner - `geometryReloadReason` says which, so the prompt can name it.
+   */
+  geometryModePendingReload: boolean;
+  /** Which load-time geometry input armed `geometryModePendingReload`. */
+  geometryReloadReason: GeometryReloadReason;
+  /**
+   * Stored `?geomTier=` tessellation override, or `undefined` when the tier is
+   * chosen automatically. Mirrored into the store so the Visibility menu can
+   * surface it: it persists from a single link visit and, before #2544, was
+   * invisible with no way out but `?geomTier=auto` or clearing site data.
+   */
+  geomTierOverride: TessellationQuality | undefined;
+}
+
+export interface GeometryLoadSettingsActions {
+  /** Update the merge-layers toggle and persist to localStorage. */
+  setMergeLayers: (v: boolean) => void;
+  /** Acknowledge the merge-layers reload banner without performing a reload. */
+  clearMergeLayersPendingReload: () => void;
+  /** Update the geometry fidelity mode and persist to localStorage. */
+  setGeometryMode: (v: GeometryMode) => void;
+  /** Acknowledge the geometry reload banner without performing a reload. */
+  clearGeometryModePendingReload: () => void;
+  /**
+   * Drop a pinned `?geomTier=` override and return to automatic tier selection,
+   * arming the reload prompt when a model is in scope (#2544).
+   */
+  clearGeomTierOverride: () => void;
+}
+
+export const geometryLoadSettingsInitialState: GeometryLoadSettingsState = {
+  mergeLayers: UI_DEFAULTS.MERGE_LAYERS,
+  mergeLayersPendingReload: false,
+  geometryMode: UI_DEFAULTS.GEOMETRY_MODE,
+  geometryModePendingReload: false,
+  geometryReloadReason: 'mode',
+  geomTierOverride: UI_DEFAULTS.GEOM_TIER_OVERRIDE,
+};
+
+/**
+ * Build the load-time geometry actions.
+ *
+ * `isModelLoaded` is injected rather than read from a cross-slice `get()` so
+ * this module needs no knowledge of the rest of the store (and no import cycle
+ * back into `uiSlice`); the caller owns that question.
+ */
+export function createGeometryLoadSettings(
+  set: (partial: Partial<GeometryLoadSettingsState>) => void,
+  get: () => GeometryLoadSettingsState,
+  isModelLoaded: () => boolean,
+): GeometryLoadSettingsActions {
+  return {
+    setMergeLayers: (next) => {
+      if (get().mergeLayers === next) return;
+      // Persist eagerly so the next page-load picks the same value up through
+      // `getInitialMergeLayers` (constants.ts). Wrap in try/catch - Safari
+      // private mode / locked storage throws.
+      try {
+        localStorage.setItem(MERGE_LAYERS_STORAGE_KEY, String(next));
+      } catch {
+        /* storage unavailable - accept the in-memory toggle silently */
+      }
+      // Only ask the user to reload if a model is currently in scope. Toggling
+      // on an empty viewer simply changes the future load with no visible
+      // effect.
+      set({ mergeLayers: next, mergeLayersPendingReload: isModelLoaded() });
+    },
+
+    clearMergeLayersPendingReload: () => set({ mergeLayersPendingReload: false }),
+
+    setGeometryMode: (next) => {
+      if (get().geometryMode === next) return;
+      // Persist eagerly so the next page-load picks the same value up through
+      // `getInitialGeometryMode`.
+      try {
+        localStorage.setItem(GEOMETRY_MODE_STORAGE_KEY, next);
+      } catch (err) {
+        // Storage unavailable - accept the in-memory toggle, but don't swallow
+        // silently (AGENTS.md: no silent catch). The choice won't persist.
+        console.warn('[geometry-mode] persist failed; in-memory only', err);
+      }
+      set({
+        geometryMode: next,
+        geometryModePendingReload: isModelLoaded(),
+        geometryReloadReason: 'mode',
+      });
+    },
+
+    clearGeometryModePendingReload: () => set({ geometryModePendingReload: false }),
+
+    clearGeomTierOverride: () => {
+      if (get().geomTierOverride === undefined) return;
+      clearStoredGeomTier();
+      // Same reload-to-apply contract as the mode switch: the tier is a
+      // load-time tessellation input folded into the geometry cache key, so the
+      // model in scope keeps its pinned-tier geometry until it is re-meshed.
+      set({
+        geomTierOverride: undefined,
+        geometryModePendingReload: isModelLoaded(),
+        geometryReloadReason: 'tier',
+      });
+    },
+  };
+}

--- a/apps/viewer/src/store/slices/uiSlice.geom-tier.test.ts
+++ b/apps/viewer/src/store/slices/uiSlice.geom-tier.test.ts
@@ -1,0 +1,149 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * #2544 — the store side of the pinned `?geomTier=` override: the Visibility
+ * menu can only surface and clear the pin if the slice seeds it and the clear
+ * action actually reaches localStorage.
+ *
+ * Same harness as `uiSlice.merge-layers.test.ts`. The globals must be installed
+ * BEFORE the first import of the slice, because `UI_DEFAULTS.GEOM_TIER_OVERRIDE`
+ * is evaluated at module-import time — hence the dynamic import inside
+ * `buildSlice` and no static import of the slice or constants here.
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+
+const STORAGE_KEY = 'ifc-lite-geom-tier';
+
+interface MutableStorage {
+  store: Record<string, string>;
+}
+
+function installGlobals(initial: Record<string, string> = {}): MutableStorage {
+  const handle: MutableStorage = { store: { ...initial } };
+  const storage = {
+    getItem: (key: string) => (key in handle.store ? handle.store[key] : null),
+    setItem: (key: string, value: string) => { handle.store[key] = String(value); },
+    removeItem: (key: string) => { delete handle.store[key]; },
+    clear: () => { handle.store = {}; },
+    key: (i: number) => Object.keys(handle.store)[i] ?? null,
+    get length() { return Object.keys(handle.store).length; },
+  };
+  Object.defineProperty(globalThis, 'localStorage', { value: storage, configurable: true, writable: true });
+  Object.defineProperty(globalThis, 'window', { value: globalThis, configurable: true, writable: true });
+  // `window === globalThis` here, so `getGeomTierOverride`'s
+  // `window.location.search` read needs a location on globalThis. Without it the
+  // read throws, the catch swallows it into "no override", and every assertion
+  // below would pass for the wrong reason.
+  Object.defineProperty(globalThis, 'location', {
+    value: { search: '' }, configurable: true, writable: true,
+  });
+  Object.defineProperty(globalThis, 'matchMedia', {
+    value: () => ({
+      matches: false, media: '', onchange: null,
+      addListener: () => {}, removeListener: () => {},
+      addEventListener: () => {}, removeEventListener: () => {}, dispatchEvent: () => false,
+    }),
+    configurable: true,
+    writable: true,
+  });
+  Object.defineProperty(globalThis, 'document', {
+    value: {
+      documentElement: {
+        classList: { toggle: () => {}, add: () => {}, remove: () => {}, contains: () => false },
+      },
+    },
+    configurable: true,
+    writable: true,
+  });
+  return handle;
+}
+
+function uninstallGlobals(): void {
+  for (const k of ['localStorage', 'window', 'location', 'matchMedia', 'document']) {
+    Reflect.deleteProperty(globalThis as Record<string, unknown>, k);
+  }
+}
+
+async function buildSlice(
+  crossSlice: { models?: Map<string, unknown>; geometryResult?: { meshes: unknown[] } | null } = {},
+) {
+  const mod = await import('./uiSlice.js');
+  const createUISlice = (mod as { createUISlice: (...args: unknown[]) => unknown }).createUISlice;
+  let state: Record<string, unknown> = {
+    models: crossSlice.models ?? new Map(),
+    geometryResult: crossSlice.geometryResult ?? null,
+  };
+  const setState = (partial: unknown) => {
+    state = typeof partial === 'function'
+      ? { ...state, ...(partial as (s: Record<string, unknown>) => Record<string, unknown>)(state) }
+      : { ...state, ...(partial as Record<string, unknown>) };
+  };
+  state = {
+    ...state,
+    ...(createUISlice as (set: unknown, get: unknown, api: unknown) => Record<string, unknown>)(
+      setState, () => state, {},
+    ),
+  };
+  return { get state() { return state; } };
+}
+
+const clear = (s: { state: Record<string, unknown> }) =>
+  (s.state.clearGeomTierOverride as () => void)();
+
+describe('UISlice — pinned tessellation tier (#2544)', () => {
+  let storage: MutableStorage | null = null;
+
+  // Seeded with a pin, because that is the state the whole feature exists for:
+  // ESM caches the module, so the FIRST import in this process bakes
+  // UI_DEFAULTS.GEOM_TIER_OVERRIDE, and every case here needs it present.
+  beforeEach(() => { storage = installGlobals({ [STORAGE_KEY]: 'low' }); });
+  afterEach(() => { storage = null; uninstallGlobals(); });
+
+  it('seeds geomTierOverride from the persisted pin', async () => {
+    const slice = await buildSlice();
+    assert.strictEqual(slice.state.geomTierOverride, 'low');
+  });
+
+  it('clearGeomTierOverride removes the persisted key AND the store value', async () => {
+    const slice = await buildSlice();
+    clear(slice);
+    assert.strictEqual(slice.state.geomTierOverride, undefined);
+    assert.strictEqual(STORAGE_KEY in storage!.store, false, 'the pin must not survive a reload');
+  });
+
+  it('arms the reload prompt, labelled as a tier change, when a model is loaded', async () => {
+    const slice = await buildSlice({ geometryResult: { meshes: [{}] } });
+    clear(slice);
+    assert.strictEqual(slice.state.geometryModePendingReload, true);
+    // The banner reads this to name the change; without it the prompt would
+    // claim the Fast/Exact mode changed, which it did not.
+    assert.strictEqual(slice.state.geometryReloadReason, 'tier');
+  });
+
+  it('does NOT arm the reload prompt on an empty viewer', async () => {
+    const slice = await buildSlice({ models: new Map(), geometryResult: null });
+    clear(slice);
+    assert.strictEqual(slice.state.geomTierOverride, undefined);
+    assert.strictEqual(slice.state.geometryModePendingReload, false);
+  });
+
+  it('is a no-op once no pin remains, so it cannot re-arm the banner', async () => {
+    const slice = await buildSlice({ geometryResult: { meshes: [{}] } });
+    clear(slice);
+    (slice.state.clearGeometryModePendingReload as () => void)();
+    clear(slice);
+    assert.strictEqual(slice.state.geometryModePendingReload, false);
+  });
+
+  it('a later mode flip relabels the prompt, so the banner tracks the last change', async () => {
+    const slice = await buildSlice({ geometryResult: { meshes: [{}] } });
+    clear(slice);
+    assert.strictEqual(slice.state.geometryReloadReason, 'tier');
+    (slice.state.setGeometryMode as (v: 'fast' | 'exact') => void)('exact');
+    assert.strictEqual(slice.state.geometryReloadReason, 'mode');
+  });
+});

--- a/apps/viewer/src/store/slices/uiSlice.ts
+++ b/apps/viewer/src/store/slices/uiSlice.ts
@@ -15,16 +15,23 @@ import {
   RIBBON_COLLAPSED_STORAGE_KEY,
   RIBBON_CONTEXTUAL_TABS_STORAGE_KEY,
   UI_DEFAULTS,
+  clearGeomTierOverride,
   type GeometryMode,
   type RibbonTabId,
   type ToolbarStyle,
 } from '../constants.js';
 import type { ContactShadingQuality, SeparationLinesQuality } from '@ifc-lite/renderer';
 import type { FederatedModel } from '../types.js';
-import type { GeometryResult } from '@ifc-lite/geometry';
+import type { GeometryResult, TessellationQuality } from '@ifc-lite/geometry';
 import type { CesiumPlacementDraft } from './cesiumSlice.js';
 
 export type ThemeMode = 'light' | 'dark' | 'colorful';
+
+/**
+ * Which load-time geometry input armed the reload prompt, so the banner names
+ * the change the user actually made rather than always reporting the mode.
+ */
+export type GeometryReloadReason = 'mode' | 'tier';
 export type HierarchyMode = 'spatial' | 'type' | 'ifc-type' | 'material' | 'groups';
 
 function getInitialHierarchyMode(): HierarchyMode {
@@ -149,8 +156,21 @@ export interface UISlice {
    * `geometryModePendingReload` so the UI can prompt a reload.
    */
   geometryMode: GeometryMode;
-  /** True after the user flipped `geometryMode` while a model was loaded. */
+  /**
+   * True after a load-time geometry input changed while a model was loaded:
+   * either `geometryMode` or the pinned tessellation tier. One flag, one
+   * banner — `geometryReloadReason` says which, so the prompt can name it.
+   */
   geometryModePendingReload: boolean;
+  /** Which load-time geometry input armed `geometryModePendingReload`. */
+  geometryReloadReason: GeometryReloadReason;
+  /**
+   * Stored `?geomTier=` tessellation override, or `undefined` when the tier is
+   * chosen automatically. Mirrored into the store so the Visibility menu can
+   * surface it: it persists from a single link visit and, before #2544, was
+   * invisible with no way out but `?geomTier=auto` or clearing site data.
+   */
+  geomTierOverride: TessellationQuality | undefined;
   /**
    * Desktop toolbar style (issue #1686): the tabbed, IFCFlux-style
    * `ribbon` (the default) or the original `classic` strip. Persisted
@@ -208,8 +228,13 @@ export interface UISlice {
   clearMergeLayersPendingReload: () => void;
   /** Update the geometry fidelity mode and persist to localStorage. */
   setGeometryMode: (v: GeometryMode) => void;
-  /** Acknowledge the geometry-mode reload banner without performing a reload. */
+  /** Acknowledge the geometry reload banner without performing a reload. */
   clearGeometryModePendingReload: () => void;
+  /**
+   * Drop a pinned `?geomTier=` override and return to automatic tier selection,
+   * arming the reload prompt when a model is in scope (#2544).
+   */
+  clearGeomTierOverride: () => void;
   /** Switch the desktop toolbar style and persist the choice. */
   setToolbarStyle: (style: ToolbarStyle) => void;
   /** Collapse/expand the ribbon band and persist the choice. */
@@ -265,6 +290,8 @@ export const createUISlice: StateCreator<UISlice & UICrossSliceState, [], [], UI
   mergeLayersPendingReload: false,
   geometryMode: UI_DEFAULTS.GEOMETRY_MODE,
   geometryModePendingReload: false,
+  geometryReloadReason: 'mode',
+  geomTierOverride: UI_DEFAULTS.GEOM_TIER_OVERRIDE,
   toolbarStyle: UI_DEFAULTS.TOOLBAR_STYLE,
   ribbonCollapsed: UI_DEFAULTS.RIBBON_COLLAPSED,
   ribbonTab: UI_DEFAULTS.RIBBON_TAB,
@@ -425,10 +452,25 @@ export const createUISlice: StateCreator<UISlice & UICrossSliceState, [], [], UI
     // Only prompt a reload if a model is currently in scope; toggling on an
     // empty viewer simply changes the next load with no visible effect.
     const pending = hasLoadedModel(current);
-    set({ geometryMode: next, geometryModePendingReload: pending });
+    set({ geometryMode: next, geometryModePendingReload: pending, geometryReloadReason: 'mode' });
   },
 
   clearGeometryModePendingReload: () => set({ geometryModePendingReload: false }),
+
+  clearGeomTierOverride: () => {
+    const current = get();
+    if (current.geomTierOverride === undefined) return;
+    clearGeomTierOverride();
+    // Same reload-to-apply contract as the mode switch: the tier is a load-time
+    // tessellation input folded into the geometry cache key, so the model in
+    // scope keeps its pinned-tier geometry until it is re-meshed.
+    const pending = hasLoadedModel(current);
+    set({
+      geomTierOverride: undefined,
+      geometryModePendingReload: pending,
+      geometryReloadReason: 'tier',
+    });
+  },
 
   setToolbarStyle: (toolbarStyle) => {
     // Persist eagerly so the next page-load boots straight into the chosen

--- a/apps/viewer/src/store/slices/uiSlice.ts
+++ b/apps/viewer/src/store/slices/uiSlice.ts
@@ -8,30 +8,28 @@
 
 import type { StateCreator } from 'zustand';
 import {
-  MERGE_LAYERS_STORAGE_KEY,
-  GEOMETRY_MODE_STORAGE_KEY,
   HIERARCHY_MODE_STORAGE_KEY,
   TOOLBAR_STYLE_STORAGE_KEY,
   RIBBON_COLLAPSED_STORAGE_KEY,
   RIBBON_CONTEXTUAL_TABS_STORAGE_KEY,
   UI_DEFAULTS,
-  clearGeomTierOverride,
-  type GeometryMode,
   type RibbonTabId,
   type ToolbarStyle,
 } from '../constants.js';
+import {
+  createGeometryLoadSettings,
+  geometryLoadSettingsInitialState,
+  type GeometryLoadSettingsActions,
+  type GeometryLoadSettingsState,
+} from './geometryLoadSettings.js';
 import type { ContactShadingQuality, SeparationLinesQuality } from '@ifc-lite/renderer';
 import type { FederatedModel } from '../types.js';
-import type { GeometryResult, TessellationQuality } from '@ifc-lite/geometry';
+import type { GeometryResult } from '@ifc-lite/geometry';
 import type { CesiumPlacementDraft } from './cesiumSlice.js';
 
 export type ThemeMode = 'light' | 'dark' | 'colorful';
+export type { GeometryReloadReason } from './geometryLoadSettings.js';
 
-/**
- * Which load-time geometry input armed the reload prompt, so the banner names
- * the change the user actually made rather than always reporting the mode.
- */
-export type GeometryReloadReason = 'mode' | 'tier';
 export type HierarchyMode = 'spatial' | 'type' | 'ifc-type' | 'material' | 'groups';
 
 function getInitialHierarchyMode(): HierarchyMode {
@@ -96,7 +94,7 @@ export interface UICrossSliceState {
   cesiumPlacementDraft: CesiumPlacementDraft | null;
 }
 
-export interface UISlice {
+export interface UISlice extends GeometryLoadSettingsState, GeometryLoadSettingsActions {
   // State
   leftPanelCollapsed: boolean;
   rightPanelCollapsed: boolean;
@@ -140,37 +138,6 @@ export interface UISlice {
   separationLinesQuality: SeparationLinesQuality;
   separationLinesIntensity: number;
   separationLinesRadius: number;
-  /**
-   * Issue #540 — "Merge Multilayer Walls" load-time toggle. Reading
-   * this on next file load is what the WASM bridge actually uses;
-   * flipping it while a model is in scope sets
-   * `mergeLayersPendingReload` so the UI can prompt the user.
-   */
-  mergeLayers: boolean;
-  /** True after the user flipped `mergeLayers` while a model was loaded. */
-  mergeLayersPendingReload: boolean;
-  /**
-   * Load-time geometry fidelity mode (`fast` = skip tiny cuts + auto-low
-   * density; `exact` = full fidelity). Like `mergeLayers`, it is read on the
-   * next file load; flipping it while a model is in scope sets
-   * `geometryModePendingReload` so the UI can prompt a reload.
-   */
-  geometryMode: GeometryMode;
-  /**
-   * True after a load-time geometry input changed while a model was loaded:
-   * either `geometryMode` or the pinned tessellation tier. One flag, one
-   * banner — `geometryReloadReason` says which, so the prompt can name it.
-   */
-  geometryModePendingReload: boolean;
-  /** Which load-time geometry input armed `geometryModePendingReload`. */
-  geometryReloadReason: GeometryReloadReason;
-  /**
-   * Stored `?geomTier=` tessellation override, or `undefined` when the tier is
-   * chosen automatically. Mirrored into the store so the Visibility menu can
-   * surface it: it persists from a single link visit and, before #2544, was
-   * invisible with no way out but `?geomTier=auto` or clearing site data.
-   */
-  geomTierOverride: TessellationQuality | undefined;
   /**
    * Desktop toolbar style (issue #1686): the tabbed, IFCFlux-style
    * `ribbon` (the default) or the original `classic` strip. Persisted
@@ -222,19 +189,6 @@ export interface UISlice {
   setSeparationLinesQuality: (quality: SeparationLinesQuality) => void;
   setSeparationLinesIntensity: (intensity: number) => void;
   setSeparationLinesRadius: (radius: number) => void;
-  /** Update the merge-layers toggle and persist to localStorage. */
-  setMergeLayers: (v: boolean) => void;
-  /** Acknowledge the reload banner without performing a reload. */
-  clearMergeLayersPendingReload: () => void;
-  /** Update the geometry fidelity mode and persist to localStorage. */
-  setGeometryMode: (v: GeometryMode) => void;
-  /** Acknowledge the geometry reload banner without performing a reload. */
-  clearGeometryModePendingReload: () => void;
-  /**
-   * Drop a pinned `?geomTier=` override and return to automatic tier selection,
-   * arming the reload prompt when a model is in scope (#2544).
-   */
-  clearGeomTierOverride: () => void;
   /** Switch the desktop toolbar style and persist the choice. */
   setToolbarStyle: (style: ToolbarStyle) => void;
   /** Collapse/expand the ribbon band and persist the choice. */
@@ -264,6 +218,8 @@ function hasLoadedModel(state: UICrossSliceState): boolean {
 }
 
 export const createUISlice: StateCreator<UISlice & UICrossSliceState, [], [], UISlice> = (set, get) => ({
+  ...geometryLoadSettingsInitialState,
+  ...createGeometryLoadSettings(set, get, () => hasLoadedModel(get())),
   // Initial state
   leftPanelCollapsed: false,
   rightPanelCollapsed: false,
@@ -286,12 +242,6 @@ export const createUISlice: StateCreator<UISlice & UICrossSliceState, [], [], UI
   separationLinesQuality: UI_DEFAULTS.SEPARATION_LINES_QUALITY,
   separationLinesIntensity: UI_DEFAULTS.SEPARATION_LINES_INTENSITY,
   separationLinesRadius: UI_DEFAULTS.SEPARATION_LINES_RADIUS,
-  mergeLayers: UI_DEFAULTS.MERGE_LAYERS,
-  mergeLayersPendingReload: false,
-  geometryMode: UI_DEFAULTS.GEOMETRY_MODE,
-  geometryModePendingReload: false,
-  geometryReloadReason: 'mode',
-  geomTierOverride: UI_DEFAULTS.GEOM_TIER_OVERRIDE,
   toolbarStyle: UI_DEFAULTS.TOOLBAR_STYLE,
   ribbonCollapsed: UI_DEFAULTS.RIBBON_COLLAPSED,
   ribbonTab: UI_DEFAULTS.RIBBON_TAB,
@@ -416,61 +366,6 @@ export const createUISlice: StateCreator<UISlice & UICrossSliceState, [], [], UI
   setSeparationLinesIntensity: (separationLinesIntensity) => set({ separationLinesIntensity }),
   setSeparationLinesRadius: (separationLinesRadius) => set({ separationLinesRadius }),
 
-  setMergeLayers: (next) => {
-    const current = get();
-    if (current.mergeLayers === next) return;
-    // Persist eagerly so the next page-load picks the same value up
-    // through `getInitialMergeLayers` (constants.ts). Wrap in
-    // try/catch — Safari private mode / locked storage throws.
-    try {
-      localStorage.setItem(MERGE_LAYERS_STORAGE_KEY, String(next));
-    } catch {
-      /* storage unavailable — accept the in-memory toggle silently */
-    }
-    // Only ask the user to reload if a model is currently in scope.
-    // Toggling the setting on an empty viewer simply changes the
-    // future load behaviour with no visible effect.
-    const pending = hasLoadedModel(current);
-    set({ mergeLayers: next, mergeLayersPendingReload: pending });
-  },
-
-  clearMergeLayersPendingReload: () => set({ mergeLayersPendingReload: false }),
-
-  setGeometryMode: (next) => {
-    const current = get();
-    if (current.geometryMode === next) return;
-    // Persist eagerly so the next page-load picks the same value up through
-    // `getInitialGeometryMode` (constants.ts). Wrap in try/catch — Safari
-    // private mode / locked storage throws.
-    try {
-      localStorage.setItem(GEOMETRY_MODE_STORAGE_KEY, next);
-    } catch (err) {
-      // Storage unavailable — accept the in-memory toggle, but don't swallow
-      // silently (AGENTS.md: no silent catch). The choice won't persist.
-      console.warn('[geometry-mode] persist failed; in-memory only', err);
-    }
-    // Only prompt a reload if a model is currently in scope; toggling on an
-    // empty viewer simply changes the next load with no visible effect.
-    const pending = hasLoadedModel(current);
-    set({ geometryMode: next, geometryModePendingReload: pending, geometryReloadReason: 'mode' });
-  },
-
-  clearGeometryModePendingReload: () => set({ geometryModePendingReload: false }),
-
-  clearGeomTierOverride: () => {
-    const current = get();
-    if (current.geomTierOverride === undefined) return;
-    clearGeomTierOverride();
-    // Same reload-to-apply contract as the mode switch: the tier is a load-time
-    // tessellation input folded into the geometry cache key, so the model in
-    // scope keeps its pinned-tier geometry until it is re-meshed.
-    const pending = hasLoadedModel(current);
-    set({
-      geomTierOverride: undefined,
-      geometryModePendingReload: pending,
-      geometryReloadReason: 'tier',
-    });
-  },
 
   setToolbarStyle: (toolbarStyle) => {
     // Persist eagerly so the next page-load boots straight into the chosen


### PR DESCRIPTION
Fixes #2544. Found while measuring #2388.

## The bug

`?geomTier=low` persists to `localStorage` and is replayed on every later load. That part is intended. Two consequences were not:

1. `resolveLoadTessellationTier` returned the override **before** consulting the geometry mode, so it won in `exact` too.
2. A preview tier is not only coarser curves. `quality_skips_small_cuts` in the Rust boolean processor is `Lowest | Low`, OR'd with the `skip_small_cuts` flag, so a pinned `low` dropped sub-10% cutters regardless of what the flag said.

Net: a browser profile that once opened a shared `?geomTier=low` link rendered, measured and **exported** at preview fidelity forever, while the Visibility menu read "Exact: full cuts + density" and the banner confirmed Exact. No UI showed the override; the only ways out were `?geomTier=auto` or clearing site data.

## The fix

Both halves of the problem, addressed separately:

- **`exact` refuses a preview override** (`isPreviewTier`), so Exact means what it says. A `medium`-or-finer override still applies, because pinning full density on a large model is the documented reason the override exists and it cannot violate the promise. `fast` mode is untouched, so the knob still tunes.
- **The Visibility menu surfaces a stored pin** with a one-click Clear, and says when the pin is being ignored in Exact. The reload prompt reuses the existing geometry banner, relabelled via `geometryReloadReason` so it names the change the user actually made instead of always reporting the mode. One banner, two inputs.

## On testing

`resolveLoadTessellationTier` now takes the override as an injectable parameter so the decision is testable without a DOM. That alone would be a test that cannot catch the wrapper being unwired from the persisted value, so `geomTierOverride.test.ts` additionally drives the real read path through stubbed globals, and `uiSlice.geom-tier.test.ts` covers the store action reaching localStorage.

All three suites were checked against mutants: reverting the resolution order and removing the storage write each turn them red.

## Verified in the browser

Not only by unit test. Driven on localhost with a model loaded:

- `low` pinned + Exact: `[useIfc] loadFile ... geomMode=exact tier=medium cacheKey=ifc-113264-...-v13` (no `-sc`, no `-tlow`). Before the fix this was `tier=low` with `-sc-tlow`.
- `lowest` pinned + Fast: still `tier=lowest`, `cacheKey=...-sc-tlowest`. No regression to the tuning knob.
- The row shows "Detail pinned: low / Overrides automatic detail" in Fast and "Ignored in Exact" in Exact.
- Clear removes the localStorage key, drops the row, raises "Detail pin removed", and the clear survives a page reload on a bare URL.

## Checks

`pnpm typecheck` green (1029/1029 test files in a program). `@ifc-lite/viewer` suite: 3801 tests, 0 fail, 2 pre-existing skips. `check-test-wiring` green. No published package touched, so no changeset.

## One thing to flag

`store/constants.ts` goes 550 to 620 lines and `slices/uiSlice.ts` 455 to 506; both were already past the ~400-line house rule before this change. There is a real seam here (the load-time geometry fidelity block would extract cleanly to its own module), but doing it inside a bug fix would dominate the diff. Happy to do it as a follow-up if you want it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistent geometry detail settings, allowing selected quality tiers to remain active across sessions.
  * Added a **Clear** option in the visibility menu to remove a pinned detail setting and return to automatic selection.
  * Added context-sensitive notices explaining pinned detail settings and their removal.
  * Improved reload prompts to indicate whether changes come from geometry mode or detail quality settings.

* **Bug Fixes**
  * Improved handling of detail settings across Fast and Exact geometry modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->