### PR TITLE
chore(deps): pin nanoid, dompurify and js-yaml past their open advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,8 @@
       "protobufjs": "^8.0.2",
       "protocol-buffers-schema": "^3.6.1",
       "postcss": "^8.5.10",
-      "dompurify": "^3.4.12",
+      "nanoid@3": "^3.3.17",
+      "dompurify": "^3.4.13",
       "lodash": "^4.18.0",
       "tar": "^7.5.21",
       "rollup": "^4.59.0",
@@ -111,7 +112,7 @@
       "picomatch@>=4": "^4.0.4",
       "uuid@<11.1.1": "^11.1.1",
       "@babel/core": "^7.29.6",
-      "js-yaml@4": "^4.3.0",
+      "js-yaml@4": "^4.3.1",
       "read-yaml-file": "^2.1.0",
       "brace-expansion": "^5.0.9",
       "minimatch": "^10.2.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,8 @@ overrides:
   protobufjs: ^8.0.2
   protocol-buffers-schema: ^3.6.1
   postcss: ^8.5.10
-  dompurify: ^3.4.12
+  nanoid@3: ^3.3.17
+  dompurify: ^3.4.13
   lodash: ^4.18.0
   tar: ^7.5.21
   rollup: ^4.59.0
@@ -25,7 +26,7 @@ overrides:
   picomatch@>=4: ^4.0.4
   uuid@<11.1.1: ^11.1.1
   '@babel/core': ^7.29.6
-  js-yaml@4: ^4.3.0
+  js-yaml@4: ^4.3.1
   read-yaml-file: ^2.1.0
   brace-expansion: ^5.0.9
   minimatch: ^10.2.5
@@ -3776,8 +3777,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.12:
-    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -4118,8 +4119,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsep@1.4.0:
@@ -4619,8 +4620,8 @@ packages:
   murmurhash-js@1.0.0:
     resolution: {integrity: sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -5699,7 +5700,7 @@ snapshots:
       '@zip.js/zip.js': 2.8.26
       autolinker: 4.1.5
       bitmap-sdf: 1.0.4
-      dompurify: 3.4.12
+      dompurify: 3.4.13
       draco3d: 1.5.7
       earcut: 3.0.2
       grapheme-splitter: 1.0.4
@@ -5845,7 +5846,7 @@ snapshots:
   '@changesets/parse@0.4.3':
     dependencies:
       '@changesets/types': 6.1.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
 
   '@changesets/pre@2.0.2':
     dependencies:
@@ -7687,7 +7688,7 @@ snapshots:
   cosmiconfig@8.3.6(typescript@6.0.3):
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -7781,7 +7782,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.12:
+  dompurify@3.4.13:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -8153,7 +8154,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -8192,7 +8193,7 @@ snapshots:
     optionalDependencies:
       canvg: 3.0.11
       core-js: 3.49.0
-      dompurify: 3.4.12
+      dompurify: 3.4.13
       html2canvas: 1.4.1
 
   jszip@3.10.1:
@@ -8820,7 +8821,7 @@ snapshots:
 
   murmurhash-js@1.0.0: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   no-case@3.0.4:
     dependencies:
@@ -9004,7 +9005,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -9014,7 +9015,7 @@ snapshots:
       '@posthog/core': 1.46.1
       '@posthog/types': 1.399.0
       core-js: 3.49.0
-      dompurify: 3.4.12
+      dompurify: 3.4.13
       fflate: 0.4.9
       preact: 10.29.8
       query-selector-shadow-dom: 1.0.1
@@ -9135,7 +9136,7 @@ snapshots:
 
   read-yaml-file@2.1.0:
     dependencies:
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       strip-bom: 4.0.0
 
   readable-stream@2.3.8:


### PR DESCRIPTION
Clears the three Dependabot alerts open on `main` (the ones the push warning has been printing all week). Nobody had triaged them, so this establishes reachability first and then fixes all three.

## Triage

| Alert | Package | Severity | Reaches shipped code? | Path |
| --- | --- | --- | --- | --- |
| GHSA-55q2-fjhq-7xh7 | dompurify | moderate | **Yes — viewer runtime** | `apps/viewer` -> `cesium` / `jspdf` / `posthog-js` -> `dompurify` |
| GHSA-2v37-7h3g-55p8 | nanoid | high | No — build-time only | `postcss` -> `nanoid`, and `postcss` only runs at build (vite / tailwind / autoprefixer) |
| GHSA-5p4m-2wfm-xmqj | js-yaml | high | No — dev tooling only | `@changesets/cli`, `cosmiconfig`, `knip` -> `js-yaml`, all `devDependencies` |

Two notes on the severity badges, which invert the real ordering here:

- **No published `@ifc-lite/*` package is affected by any of the three.** `pnpm why -r` resolves all three to only the root workspace and `@ifc-lite/viewer`, both `private: true`.
- The two **high** alerts are the two that do not ship; the **moderate** one is the only one that reaches ifclite.com. Verified against the built bundle: `DOMPurify` appears in `assets/cesium-*.js` and the lazy `assets/purify.es-*.js` chunk, while `nanoid` and `js-yaml` have **zero** occurrences in `apps/viewer/dist`.

Exploitability of the dompurify issue is low in practice — it requires a caller using `IN_PLACE` mode, and none of cesium, jspdf or posthog-js passes it — but it is a one-line override bump, so it is worth taking rather than reasoning around.

## Fix

Uses the established per-major `pnpm.overrides` mechanism rather than a new one. Two of the three entries already existed and just sat one patch short of the fix:

- `dompurify` `^3.4.12` -> `^3.4.13`
- `js-yaml@4` `^4.3.0` -> `^4.3.1`
- `nanoid@3` `^3.3.17` (new entry)

Every consumer already declares a compatible `^3.x` / `^4.x` range, so **all three are patch-level moves — no API change and no major bump of any direct dependency.** Resolved: dompurify 3.4.13, js-yaml 4.3.1, nanoid 3.3.18, one copy of each, no vulnerable version left in the tree. Lockfile regenerated and committed in the same change.

## Verification

- `npx turbo typecheck --force` — 77/77, **0 cached**
- `npx turbo test --force` — 86/86, **0 cached** (3793 viewer tests pass)
- `tests/e2e/viewer-smoke.e2e.spec.ts` on AC20-FZK-Haus — **2 passed**, including the "no uncaught errors on a clean load" case. This is the gate that matters for dompurify, since it is the one change that lands in the viewer runtime.
- No Rust dependency involved, so the cargo lanes are not implicated
- No changeset: no published package's dependency surface changes

## Coordination with the Dependabot group PR

No collision. #2522 is now **closed** with no replacement open yet; it bumped direct versions (cesium, posthog-js, maplibre-gl, vite, postcss, ...), whereas this change only moves transitive resolutions via overrides. The one adjacency is postcss (`^8.5.25` -> `^8.5.26` there), which still declares `nanoid: ^3.3.16` and is satisfied by 3.3.18 either way.

One observation that may help when Dependabot re-opens that group, offered as a lead rather than a bisected result: the three failing viewer lanes timed out on `waitForSelector('input[type="file"]')`, which is the **file input, not the model**. That means the viewer never finished booting — it is an app/bundle boot failure, not a geometry or model-load regression, which rules out most of the 18. Only the bumps that can affect `apps/viewer` at runtime or bundle time are candidates (cesium, posthog-js, maplibre-gl, lucide-react, @codemirror/view, vite, postcss); `@types/three` is types-only and `tsx` / `turbo` / `knip` / `@posthog/cli` are tooling, so none of those can produce that failure. Given this repo's history of a white screen caused by a deferred top-level-await chunk, the vite `8.2.0 -> 8.2.1` bump is worth eliminating first.