### PR TITLE
refactor(viewer): split SpaceSketchOverlay into hooks that take their state with them

### DIFF
--- a/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
+++ b/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
@@ -93,7 +93,7 @@ export function SpaceSketchOverlay() {
   // Panel size + the world↔screen transform, with a single writer for `fitRef`
   // so the `fitTick` bump the underlay memo depends on can't be forgotten.
   const {
-    svgRef, fitRef, fitTick, size, fitToPoints, panBy, svgPoint, resizeHandlers,
+    svgRef, attachSvg, fitRef, fitTick, size, fitToPoints, panBy, svgPoint, resizeHandlers,
   } = useSpaceViewport();
   const panelRef = useRef<HTMLDivElement | null>(null);
   const rafRef = useRef<number | null>(null);
@@ -1418,7 +1418,7 @@ export function SpaceSketchOverlay() {
       {helpOpen && <HelpPopover />}
 
       <SpaceSketchCanvas
-        svgRef={svgRef}
+        svgRef={attachSvg}
         width={size.w}
         height={size.h}
         cursor={cursor}

--- a/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
+++ b/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
@@ -27,23 +27,13 @@ import { useIfc } from '@/hooks/useIfc';
 import { snapPoint, alignToAxes, type SnapKind } from '@/lib/space-snap';
 import { editError } from '@/lib/space-edit-error';
 import { pointerButton, isRemoveModifier } from '@/lib/space-interaction';
-import {
-  SpacePlateSession,
-  ensureSpaceWasm,
-  flattenWallRects,
-  type Room,
-  type Boundary,
-} from '@/lib/space-plate-session';
+import { type Room, type Boundary } from '@/lib/space-plate-session';
 import { wallRectsFromMeshes, type WallRect } from '@/lib/wall-rects-from-meshes';
 import {
-  polyArea, pointInPoly, centroid, uniqueVerts, distToSeg, projectOnSeg,
-  computeFitFromPoints, zoomFit, sX, sY, wX, wY, PAD, type Fit, type Pt,
+  polyArea, uniqueVerts, distToSeg, projectOnSeg,
+  sX, sY, wX, wY, PAD, type Pt,
 } from '@/lib/space-sketch-geometry';
-import {
-  existingSpaceFootprintsByStorey,
-  GENERATED_SPACE_OBJECTTYPE,
-  type BoundaryMode,
-} from '@ifc-lite/create';
+import { type BoundaryMode } from '@ifc-lite/create';
 import { X, Undo2, Redo2, Layers, Maximize, Magnet, SlidersHorizontal, HelpCircle, Eraser, Square, PenLine, Frame, Check, Minus, Building2 } from 'lucide-react';
 import { toast } from '@/components/ui/toast';
 import { SpaceSketchCanvas } from './space-sketch/SpaceSketchCanvas';
@@ -52,17 +42,15 @@ import { SpaceSketchReopenPill } from './space-sketch/SpaceSketchReopenPill';
 import { useSpaceGhostPreview, type GhostSpec } from './space-sketch/useSpaceGhostPreview';
 import { useSpaceSceneFraming } from './space-sketch/useSpaceSceneFraming';
 import { exteriorPerimeter, perimeterWalls } from './space-sketch/storey-footprint';
-import { acquireSession } from './space-sketch/session-registry';
+import { useSpacePlateSessions } from './space-sketch/useSpacePlateSessions';
+import { useSpaceViewport } from './space-sketch/useSpaceViewport';
+import { useSpaceSketchKeys } from './space-sketch/useSpaceSketchKeys';
+import { useSpaceBake } from './space-sketch/useSpaceBake';
+import { floorToFloorHeight } from './space-sketch/space-bake';
 import type { Hover, SplitTarget, IntentTone } from './space-sketch/types';
-import { eventKey, isTextEntryTarget } from '@/lib/keyboard-event';
 
-const DEFAULT_W = 420;
-const DEFAULT_H = 340;
-const MIN_W = 320;
-const MIN_H = 240;
 const PICK_PX = 12;
 const SNAP_PX = 10;
-const BAKE_HEIGHT = 3;
 const EPS = 1e-6;
 
 /** Lock `p` to a horizontal or vertical line through `anchor` (Shift-ortho),
@@ -73,8 +61,6 @@ function orthoLock(anchor: Pt, p: Pt): Pt {
 
 export function SpaceSketchOverlay() {
   const setActiveTool = useViewerStore((s) => s.setActiveTool);
-  const addSpace = useViewerStore((s) => s.addSpace);
-  const removeEntity = useViewerStore((s) => s.removeEntity);
   const activeModelId = useViewerStore((s) => s.activeModelId);
   const models = useViewerStore((s) => s.models);
   const toGlobalId = useViewerStore((s) => s.toGlobalId);
@@ -100,23 +86,18 @@ export function SpaceSketchOverlay() {
   // collected for a single confirm-on-close (the user never confirms per storey).
   // `sessionRef` points at the active storey's session; `sessionsRef` keeps them
   // all alive until the tool closes (or the drafts are created / discarded).
-  const sessionsRef = useRef<Map<number, SpacePlateSession>>(new Map());
-  const sessionRef = useRef<SpacePlateSession | null>(null);
-  const svgRef = useRef<SVGSVGElement | null>(null);
+  // The hook owns their whole lifetime, including the disposed-after-unmount
+  // guard that stops a suspended build allocating a plate nothing would free.
+  const { sessionsRef, sessionRef, disposedRef, buildPlate, buildStoreyPlate, ensureWasm } =
+    useSpacePlateSessions();
+  // Panel size + the world↔screen transform, with a single writer for `fitRef`
+  // so the `fitTick` bump the underlay memo depends on can't be forgotten.
+  const {
+    svgRef, fitRef, fitTick, size, fitToPoints, panBy, svgPoint, resizeHandlers,
+  } = useSpaceViewport();
   const panelRef = useRef<HTMLDivElement | null>(null);
-  const fitRef = useRef<Fit>({ scale: 1, offX: PAD, offY: DEFAULT_H - PAD });
   const rafRef = useRef<number | null>(null);
   const rebuildTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const buildSeqRef = useRef(0);
-  // Set by the unmount cleanup below, which disposes every session and clears
-  // `sessionsRef`. Any async path that resumes AFTER that point must not
-  // allocate a fresh `SpacePlateSession`: nothing would ever free it, so
-  // closing the tool mid-derive would leak a wasm plate. Reset on (re)mount so
-  // StrictMode's mount/cleanup/mount cycle does not leave the overlay poisoned.
-  const disposedRef = useRef(false);
-  // IfcSpace expressIds this tool created per storey — so confirming again
-  // replaces the spaces it dropped instead of duplicating.
-  const generatedRef = useRef<Map<number, number[]>>(new Map());
   // Bumped whenever a storey's draft room count changes, to recompute the
   // pending-spaces tally (which reads the per-storey sessions, not React state).
   const [pendingTick, setPendingTick] = useState(0);
@@ -127,13 +108,10 @@ export function SpaceSketchOverlay() {
   const otherVertsRef = useRef<Pt[]>([]);
   const draggedRef = useRef(false);
   const panningRef = useRef(false); // Issue 4: middle-mouse / empty-drag panning
-  const resizeRef = useRef<{ x: number; y: number; w: number; h: number } | null>(null);
   // While drawing, Undo pops the last placed point onto this stack and Redo
   // re-adds it — so point placement uses the panel Undo/Redo, not a separate
   // draw-only control. Cleared when the draw is committed/cancelled.
   const drawRedoRef = useRef<Pt[]>([]);
-  // Timestamp of the last bare Esc — a second within 400 ms closes the panel.
-  const escTimeRef = useRef(0);
   // Building wall lines (room frame) for snapping; synced from a memo so the
   // per-frame pointer math can read it without re-binding processMove.
   const buildingSegmentsRef = useRef<Array<[Pt, Pt]>>([]);
@@ -174,14 +152,6 @@ export function SpaceSketchOverlay() {
   const [alignGuides, setAlignGuides] = useState<{ vRef: Pt | null; hRef: Pt | null }>({ vRef: null, hRef: null });
   // Live "what will this click do" label, shown top-right of the canvas.
   const [intent, setIntent] = useState<{ text: string; tone: IntentTone } | null>(null);
-  // Issue 4: canvas size (resizable) + a tick that forces a re-render whenever
-  // the view transform in fitRef changes (zoom/pan/fit) without making the
-  // per-frame pointer math go through React state.
-  const [size, setSize] = useState({ w: DEFAULT_W, h: DEFAULT_H });
-  const sizeRef = useRef(size);
-  sizeRef.current = size;
-  const [fitTick, setFitTick] = useState(0);
-  const applyFit = useCallback((next: Fit) => { fitRef.current = next; setFitTick((t) => t + 1); }, []);
   const [derivedStorey, setDerivedStorey] = useState<number | null>(null);
   const [snapTol, setSnapTol] = useState<number | null>(null); // null = auto-escalate
   const [usedTol, setUsedTol] = useState(0.1);
@@ -347,78 +317,31 @@ export function SpaceSketchOverlay() {
     }
   }, [resetInteraction, commit]);
 
-  // Ctrl/Cmd+Z (Shift = redo) must drive THIS overlay's history, not the 3D
-  // model behind the panel. The global handler in useKeyboardShortcuts routes
-  // Ctrl+Z to the active model's mutation stack; a capture-phase listener here
-  // runs before it and stopPropagation()s, so the sketch and the in-panel
-  // Undo/Redo buttons share one history. Skip when a text input is focused so
-  // native field undo (and the global handler, which also skips inputs) is
-  // untouched. The overlay only mounts while the tool is active, so this
-  // listener's lifetime is exactly the tool's.
-  useEffect(() => {
-    const onUndoRedo = (e: KeyboardEvent) => {
-      if (eventKey(e) !== 'z' || !(e.ctrlKey || e.metaKey)) return;
-      if (isTextEntryTarget(e)) return;
-      e.preventDefault();
-      e.stopPropagation();
-      if (e.shiftKey) redo(); else undo();
-    };
-    window.addEventListener('keydown', onUndoRedo, true);
-    return () => window.removeEventListener('keydown', onUndoRedo, true);
-  }, [undo, redo]);
-
-  // Wheel = zoom about the cursor (Issue 4). A native non-passive listener so
-  // preventDefault() actually stops the page from scrolling under the panel.
-  useEffect(() => {
-    const el = svgRef.current;
-    if (!el) return;
-    const onWheel = (e: WheelEvent) => {
-      e.preventDefault();
-      const rect = el.getBoundingClientRect();
-      const factor = Math.exp(-e.deltaY * 0.0015); // scroll up → zoom in
-      const next = zoomFit(fitRef.current, factor, e.clientX - rect.left, e.clientY - rect.top);
-      if (next.scale >= 0.5 && next.scale <= 5000) { fitRef.current = next; setFitTick((t) => t + 1); }
-    };
-    el.addEventListener('wheel', onWheel, { passive: false });
-    return () => el.removeEventListener('wheel', onWheel);
-  }, []);
-
   // Build a face-based plate from the storey's wall RECTANGLES (read from the
   // rendered meshes): rooms are the gaps between walls, so the room boundary IS
   // the rendered wall faces and every node lands on the true wall axis. `snapTol`
   // welds nearby rectangle corners (default 5 cm); a manual override comes from
-  // the slider.
+  // the slider. Session ownership, the re-entrancy guard and the
+  // disposed-after-unmount guard all live in `useSpacePlateSessions`; this is
+  // the UI half — what the user sees once a build lands.
   const buildFrom = useCallback(async (rects: WallRect[], label: string, storey: number | null) => {
-    // Re-entrancy guard: a rapid rebuild (snap slider) must not let an older
-    // async build free/replace the plate a newer one is using — that races the
-    // shared wasm heap. Only the latest build applies; superseded ones bail.
-    const seq = ++buildSeqRef.current;
+    // Record the inputs BEFORE the await, so the corner-tolerance slider can
+    // retry a build that threw (the arrangement input cap, a wasm load failure)
+    // instead of silently rebuilding the last storey that happened to succeed.
+    // The most recently REQUESTED build is also the one `buildPlate` lets win,
+    // so recording at call time cannot leave a stale storey here.
+    lastBuildRef.current = { rects, label, storey };
     try {
-      await ensureSpaceWasm();
-      if (seq !== buildSeqRef.current) return;
-      lastBuildRef.current = { rects, label, storey };
       const snapTol = snapTolRef.current ?? 0.05;
-      // One session per storey: reuse the storey's session if it exists, else
-      // create + register it. Building replaces that storey's plate only.
-      // Returns null once the overlay has been unmounted — unmount does NOT
-      // bump `buildSeqRef`, so a build suspended on the await above would
-      // otherwise resume, find the cleared registry, and build a wasm plate
-      // into a session nothing is left to free (see `session-registry.ts`).
-      const session = acquireSession(
-        sessionsRef.current, storey, sessionRef.current, disposedRef.current,
-        () => new SpacePlateSession(),
-      );
-      if (!session) return;
-      sessionRef.current = session;
-      const { rooms: snap } = session.buildFromRects(flattenWallRects(rects.map((r) => r.corners)), snapTol, 0.3);
+      const snap = await buildPlate(rects, storey, snapTol);
+      if (!snap) return; // superseded by a newer build, or the overlay is gone
       setUsedTol(snapTol);
       // Frame the rooms when any were detected, otherwise frame the walls so a
       // storey with no enclosed rooms (e.g. a foundation level) still shows its
       // plan to sketch against instead of a tiny off-canvas cluster.
-      const fitPts = snap.length > 0
+      fitToPoints(snap.length > 0
         ? snap.flatMap((r) => r.outline)
-        : rects.flatMap((r) => r.corners);
-      applyFit(computeFitFromPoints(fitPts, sizeRef.current.w, sizeRef.current.h));
+        : rects.flatMap((r) => r.corners));
       resetInteraction();
       setDerivedStorey(storey);
       setRooms(snap); setHist((v) => v + 1);
@@ -437,7 +360,7 @@ export function SpaceSketchOverlay() {
     } catch (e) {
       setStatus(`Build failed: ${String(e)}`);
     }
-  }, [resetInteraction, applyFit]);
+  }, [buildPlate, resetInteraction, fitToPoints]);
 
   // Manual weld-tolerance override (null → 5 cm default). Rebuilds the current
   // plate from its wall rectangles at the chosen tolerance.
@@ -498,14 +421,13 @@ export function SpaceSketchOverlay() {
     resetInteraction();
     setDerivedStorey(storey);
     setRooms(snap); setHist((v) => v + 1);
-    const fitPts = snap.length > 0
+    fitToPoints(snap.length > 0
       ? snap.flatMap((r) => r.outline)
-      : (build?.rects ?? []).flatMap((r) => r.corners);
-    applyFit(computeFitFromPoints(fitPts, sizeRef.current.w, sizeRef.current.h));
+      : (build?.rects ?? []).flatMap((r) => r.corners));
     const total = snap.reduce((s, r) => s + r.area, 0);
     setStatus(`${build?.label ?? `Storey ${storey}`}: ${snap.length} room(s), ${total.toFixed(1)} m² (your draft).`);
     return true;
-  }, [resetInteraction, applyFit]);
+  }, [sessionsRef, sessionRef, resetInteraction, fitToPoints]);
 
   // On a storey change (and on open): restore that storey's existing draft if we
   // have one, otherwise derive it from the walls. Edits on every storey persist
@@ -518,12 +440,9 @@ export function SpaceSketchOverlay() {
     if (!activateStorey(storeyId)) void deriveFromStorey();
   }, [storeyId, activeModelId, ifcDataStore, derivedStorey, activateStorey, deriveFromStorey]);
 
-  const floorToFloor = useCallback((sid: number): number => {
-    const idx = storeys.findIndex((s) => s.id === sid);
-    const next = idx >= 0 ? storeys[idx + 1] : undefined;
-    const ff = next ? next.elev - storeys[idx].elev : BAKE_HEIGHT;
-    return ff > 0.1 && ff < 50 ? ff : BAKE_HEIGHT;
-  }, [storeys]);
+  // Floor-to-floor for a storey: the space height on bake, and the height band
+  // the wall-rect derive slices. Rules in `space-bake.ts`.
+  const floorToFloor = useCallback((sid: number): number => floorToFloorHeight(storeys, sid), [storeys]);
 
   // ── 3D coupling ────────────────────────────────────────────────────────────
   // The 2D plan and the model stay in lockstep: every storey's drafts mirror
@@ -566,91 +485,11 @@ export function SpaceSketchOverlay() {
     contextIds: existingSpaceIds,
   });
 
-  /**
-   * IfcSpace is class-hidden by default (TYPE_VISIBILITY_SEMANTIC_DEFAULTS).
-   * Flip the toggle on after creating spaces so the user sees what they just
-   * created — and, since the toggle persists, so the spaces stay visible when
-   * the exported file is reopened.
-   */
-  const revealSpaces = useCallback(() => {
-    const s = useViewerStore.getState();
-    if (!s.typeVisibility.spaces) s.toggleTypeVisibility('spaces');
-  }, []);
-
-  /**
-   * Create one storey's draft rooms as real IfcSpace. (1) Replace: remove the
-   * spaces this tool previously created on the storey. (2) Skip rooms that
-   * overlap an existing authored space (dedup). (3) Emit each via `addSpace`,
-   * which mirrors a mesh into the 3D scene immediately. Net/gross/centre outline,
-   * floor-to-floor height. Returns counts.
-   */
-  const createSpacesForStorey = useCallback((
-    sid: number,
-    rooms: { outline: Pt[]; boundary: Pt[] }[],
-    authored: Pt[][],
-  ): { emitted: number; skipped: number; error: string | null } => {
-    if (!sketchModelId) return { emitted: 0, skipped: 0, error: 'no model to create spaces in' };
-    for (const id of generatedRef.current.get(sid) ?? []) removeEntity(sketchModelId, id);
-    generatedRef.current.delete(sid);
-    const height = floorToFloor(sid);
-    const newIds: number[] = [];
-    let skipped = 0;
-    // An addSpace failure (anchor resolution, missing mutation view, …) is
-    // NOT an "already a space" skip — keep the first error so the status
-    // line tells the user the truth instead of silently dropping spaces
-    // that would then be missing from the export.
-    let error: string | null = null;
-    for (const room of rooms) {
-      const [cx, cy] = centroid(room.outline);
-      if (authored.some((fp) => pointInPoly(cx, cy, fp))) { skipped++; continue; }
-      // `boundary` is the engine's net/gross/centre outline; gross area stays on
-      // the centreline so the quantity reflects the room, not the wall face.
-      const res = addSpace(sketchModelId, sid, {
-        Profile: 'polygon', OuterCurve: room.boundary, Height: height,
-        Name: `Space ${newIds.length + 1}`, ObjectType: GENERATED_SPACE_OBJECTTYPE,
-        grossFloorArea: polyArea(room.outline),
-      });
-      if (res && 'expressId' in res) newIds.push(res.expressId);
-      else error ??= (res && 'error' in res ? res.error : 'unknown error');
-    }
-    generatedRef.current.set(sid, newIds);
-    return { emitted: newIds.length, skipped, error };
-  }, [sketchModelId, removeEntity, addSpace, floorToFloor]);
-
-  /**
-   * Confirm: turn EVERY storey's collected draft into IfcSpace at once — the
-   * single create path, run on close. Reads each per-storey session's rooms at
-   * the active boundary mode and dedupes against existing authored spaces.
-   */
-  const createAllSpaces = useCallback((): { emitted: number; floors: number; error: string | null } => {
-    // Report a real error rather than a silent zero: `confirmCreate` treats a
-    // null error as success and closes the tool, which would discard every
-    // draft the user has drawn. `sketchModelId` is genuinely reachable as null
-    // — with several models loaded and none active we deliberately refuse to
-    // guess which one to author into, rather than picking an arbitrary one.
-    if (!sketchModelId) {
-      return { emitted: 0, floors: 0, error: 'No active model — pick one in the model list, then confirm again.' };
-    }
-    if (!ifcDataStore) {
-      return { emitted: 0, floors: 0, error: 'Model data is still loading — confirm again in a moment.' };
-    }
-    const authoredMap = existingSpaceFootprintsByStorey(ifcDataStore);
-    let emitted = 0, floors = 0;
-    let firstError: string | null = null;
-    for (const [sid, session] of sessionsRef.current) {
-      if (!session.alive || session.roomCount === 0) continue;
-      const rooms = session.rooms().map((r) => ({
-        outline: r.outline,
-        boundary: session.boundaryOutline(r.face, boundaryMode),
-      }));
-      const res = createSpacesForStorey(sid, rooms, authoredMap.get(sid) ?? []);
-      emitted += res.emitted;
-      if (res.emitted) floors++;
-      firstError ??= res.error;
-    }
-    if (emitted > 0) revealSpaces();
-    return { emitted, floors, error: firstError };
-  }, [sketchModelId, ifcDataStore, boundaryMode, createSpacesForStorey, revealSpaces]);
+  // Confirm-on-close: turn every storey's draft into real IfcSpace. Owns the
+  // ids it authored, so confirming twice replaces rather than duplicates.
+  const { createAllSpaces, createdIds } = useSpaceBake({
+    sketchModelId, ifcDataStore, boundaryMode, sessionsRef, floorToFloor,
+  });
 
   /**
    * Derive rooms on EVERY storey into its own draft session, so the whole
@@ -672,7 +511,7 @@ export function SpaceSketchOverlay() {
     setStatus('Deriving rooms on every storey…');
     // Yield once so the status above paints before the first (expensive)
     // wall-rect extraction blocks the main thread.
-    await ensureSpaceWasm();
+    await ensureWasm();
     await new Promise((resolve) => setTimeout(resolve, 0));
     try {
     // Same disposed-session guard as `buildFrom`: closing the tool during
@@ -693,9 +532,7 @@ export function SpaceSketchOverlay() {
       const rects = wallRectsFromMeshes(meshes, coord, st.elev, floorToFloor(st.id));
       if (!rects.length) continue;
       try {
-        const session = new SpacePlateSession();
-        sessionsRef.current.set(st.id, session);
-        const { rooms } = session.buildFromRects(flattenWallRects(rects.map((r) => r.corners)), snapTol, 0.3);
+        const rooms = buildStoreyPlate(st.id, rects, snapTol);
         const name = ifcDataStore.entities.getName(st.id) || `Storey #${st.id}`;
         buildsRef.current.set(st.id, {
           rects, label: name,
@@ -704,16 +541,11 @@ export function SpaceSketchOverlay() {
         if (rooms.length) floors++;
       } catch (e) {
         // A storey that exceeds the arrangement input cap (or otherwise fails to
-        // build) must not abort the whole run or leave an unhandled rejection that
-        // can tear down the canvas; record it and move on to the next storey.
-        // Drop the half-built draft so the storey is retryable rather than stuck
-        // holding a session that never produced rooms. Dispose before dropping:
-        // `SpacePlateSession` owns Rust-heap handles, and while the likely throw
-        // (the arrangement input cap) fires before the handle is assigned, a
-        // throw from `rooms()`/`snapshot()` would leave a live one behind.
+        // build) must not abort the whole run or leave an unhandled rejection
+        // that can tear down the canvas; record it and move on to the next
+        // storey. `buildStoreyPlate` has already disposed + unregistered the
+        // half-built session, so the storey is retryable.
         firstError ??= e instanceof Error ? e.message : String(e);
-        sessionsRef.current.get(st.id)?.dispose();
-        sessionsRef.current.delete(st.id);
         buildsRef.current.delete(st.id);
       }
     }
@@ -733,7 +565,8 @@ export function SpaceSketchOverlay() {
       derivingAllRef.current = false;
       setDerivingAll(false);
     }
-  }, [ifcDataStore, geometryResult, storeys, floorToFloor, storeyId, activateStorey]);
+  }, [ifcDataStore, geometryResult, storeys, floorToFloor, storeyId, activateStorey,
+      sessionsRef, disposedRef, ensureWasm, buildStoreyPlate]);
 
   // One space for the whole floor: replace the draft with a single room whose
   // outline is the storey's exterior wall perimeter (convex hull of the wall
@@ -766,33 +599,17 @@ export function SpaceSketchOverlay() {
     setStatus('Footprint added: one room over the storey outline. Confirm on close to create it.');
   }, [ifcDataStore, storeyId, geometryResult, storeys, floorToFloor, buildFrom, rooms.length, footprintArmed]);
 
-  useEffect(() => {
-    const sessions = sessionsRef.current;
-    disposedRef.current = false;
-    return () => {
-      disposedRef.current = true;
-      if (rafRef.current) cancelAnimationFrame(rafRef.current);
-      if (rebuildTimerRef.current) clearTimeout(rebuildTimerRef.current);
-      if (snapDeltaTimerRef.current) clearTimeout(snapDeltaTimerRef.current);
-      // Free every storey's session (each owns wasm heap handles).
-      for (const s of sessions.values()) s.dispose();
-      sessions.clear();
-      sessionRef.current = null;
-    };
+  // Pending frame + timers. The wasm plates are disposed by
+  // `useSpacePlateSessions`, whose cleanup runs first (it is the component's
+  // first effect) and nulls `sessionRef` — every session call site below is
+  // optional-chained or `alive`-guarded, and no event can interleave two
+  // cleanups of the same synchronous unmount, so a callback cancelled here
+  // could never have run against a freed plate.
+  useEffect(() => () => {
+    if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    if (rebuildTimerRef.current) clearTimeout(rebuildTimerRef.current);
+    if (snapDeltaTimerRef.current) clearTimeout(snapDeltaTimerRef.current);
   }, []);
-
-  const svgPoint = (e: React.MouseEvent): Pt => {
-    const rect = svgRef.current!.getBoundingClientRect();
-    // Clamp to the canvas: during a drag the pointer is captured, so moving it
-    // past the panel (e.g. dragging a vertex down off the bottom) would report
-    // coordinates far outside the SVG → a huge off-screen world position. That
-    // pushed the room off-canvas ("disappears") and made the SVG rasterise a
-    // polygon spanning to extreme coordinates, freezing the browser.
-    return [
-      Math.max(0, Math.min(sizeRef.current.w, e.clientX - rect.left)),
-      Math.max(0, Math.min(sizeRef.current.h, e.clientY - rect.top)),
-    ];
-  };
 
   const pickVertex = useCallback((wx: number, wy: number): number | null => {
     return sessionRef.current?.findVertexNear(wx, wy, PICK_PX / fitRef.current.scale) ?? null;
@@ -1007,9 +824,7 @@ export function SpaceSketchOverlay() {
     }
     if (res.emitted > 0) {
       const store = useViewerStore.getState();
-      const created: number[] = [];
-      for (const ids of generatedRef.current.values()) created.push(...ids);
-      store.setSelectedEntityIds(created.map((id) => toGlobalId(sketchModelId ?? 'legacy', id)));
+      store.setSelectedEntityIds(createdIds().map((id) => toGlobalId(sketchModelId ?? 'legacy', id)));
       toast.success(
         `Created ${res.emitted} ${res.emitted === 1 ? 'space' : 'spaces'}` +
           (res.floors > 1 ? ` across ${res.floors} storeys` : ''),
@@ -1018,36 +833,15 @@ export function SpaceSketchOverlay() {
     clearGhosts();
     restoreScene({ keepSpacesVisible: true });
     setActiveTool('select');
-  }, [createAllSpaces, clearGhosts, restoreScene, setActiveTool, sketchModelId, toGlobalId]);
+  }, [createAllSpaces, createdIds, clearGhosts, restoreScene, setActiveTool, sketchModelId, toGlobalId]);
 
-  // While the panel is open, Esc belongs to the sketch — NOT the global
-  // shortcut (which closes the tool and would lose the sketch). Capture-phase +
-  // stopImmediatePropagation beats the window-level handler in useKeyboardShortcuts.
-  // Esc: close a popover/confirm → abort the current op → (double-tap) close, with
-  // an unconfirmed-drafts guard. Enter closes a drawn room.
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      const t = e.target as HTMLElement | null;
-      const inField = !!t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable);
-      if (e.key === 'Escape') {
-        e.preventDefault();
-        e.stopImmediatePropagation(); // own Esc; don't let the global handler close us
-        if (helpOpen || optionsOpen) { setHelpOpen(false); setOptionsOpen(false); return; }
-        const now = Date.now();
-        if (abortCurrentOp()) { escTimeRef.current = 0; return; }
-        // Double-tap Esc cancels (close without creating); the Confirm button is
-        // the only create path.
-        if (now - escTimeRef.current <= 400) { escTimeRef.current = 0; closeNow(); }
-        else { escTimeRef.current = now; setStatus(needsConfirm ? 'Esc again to close without creating (use Confirm to create).' : 'Press Esc again to close.'); }
-      } else if (e.key === 'Enter' && drawPts.length > 0 && !inField) {
-        e.preventDefault();
-        e.stopImmediatePropagation();
-        commitDraw();
-      }
-    };
-    window.addEventListener('keydown', onKey, true);
-    return () => window.removeEventListener('keydown', onKey, true);
-  }, [abortCurrentOp, commitDraw, drawPts.length, needsConfirm, closeNow, helpOpen, optionsOpen]);
+  // Close whichever disclosure popover is open. Returns true if one was, so Esc
+  // can spend itself on the popover instead of on the sketch.
+  const closePopovers = useCallback((): boolean => {
+    if (!helpOpen && !optionsOpen) return false;
+    setHelpOpen(false); setOptionsOpen(false);
+    return true;
+  }, [helpOpen, optionsOpen]);
 
   // "Clean up" — sweep the whole plate clean in the engine: remove dangling
   // spur walls, isolated nodes, and redundant collinear nodes left by the
@@ -1195,35 +989,44 @@ export function SpaceSketchOverlay() {
     setIntent(m.shift ? { text: 'Pan', tone: 'pan' } : { text: 'Draw room', tone: 'draw' });
   }, [drawPts, splitPick, rooms, pickEdge, pickVertex, nearestVertPos, resolveSplitTarget, refreshRooms, drawMode, rectCornersFrom]);
 
+  // ONE scheduler for `processMove`. Both the pointer path and the modifier
+  // repaint go through it: two `rafRef`s would run processMove twice per frame,
+  // with no symptom except the tool feeling heavier.
+  const scheduleMove = useCallback(() => {
+    if (rafRef.current == null) rafRef.current = requestAnimationFrame(processMove);
+  }, [processMove]);
+
   const onPointerMove = useCallback((e: React.PointerEvent) => {
     if (panningRef.current) {
       // Pan by the raw pointer delta (movement*), so it doesn't fight the
       // canvas-edge clamp in svgPoint.
-      fitRef.current = { scale: fitRef.current.scale, offX: fitRef.current.offX + e.movementX, offY: fitRef.current.offY + e.movementY };
-      setFitTick((t) => t + 1);
+      panBy(e.movementX, e.movementY);
       return;
     }
     const [x, y] = svgPoint(e);
     moveRef.current = { x, y, shift: e.shiftKey, del: isRemoveModifier(e) };
-    if (rafRef.current == null) rafRef.current = requestAnimationFrame(processMove);
-  }, [processMove]);
+    scheduleMove();
+  }, [scheduleMove, panBy, svgPoint]);
 
   // Pressing/releasing a modifier re-evaluates the hover preview at the current
   // cursor (so the action label + cues flip the instant you hold ⌥/Ctrl/Shift,
   // without having to move). No-op until the cursor has been over the canvas.
-  useEffect(() => {
-    const onMod = (e: KeyboardEvent) => {
-      if (e.key !== 'Alt' && e.key !== 'Control' && e.key !== 'Meta' && e.key !== 'Shift') return;
-      const m = moveRef.current;
-      if (!m || dragRef.current != null || panningRef.current) return;
-      m.del = isRemoveModifier(e);
-      m.shift = e.shiftKey;
-      if (rafRef.current == null) rafRef.current = requestAnimationFrame(processMove);
-    };
-    window.addEventListener('keydown', onMod);
-    window.addEventListener('keyup', onMod);
-    return () => { window.removeEventListener('keydown', onMod); window.removeEventListener('keyup', onMod); };
-  }, [processMove]);
+  const onModifiers = useCallback((e: KeyboardEvent) => {
+    const m = moveRef.current;
+    if (!m || dragRef.current != null || panningRef.current) return;
+    m.del = isRemoveModifier(e);
+    m.shift = e.shiftKey;
+    scheduleMove();
+  }, [scheduleMove]);
+
+  // Ctrl/Cmd+Z, Esc and Enter belong to the sketch while the panel is open.
+  // The capture-phase registration that takes them off the global handler
+  // lives in the hook; the policy each one runs is above.
+  useSpaceSketchKeys({
+    undo, redo, closePopovers, abortCurrentOp, closeNow, needsConfirm, setStatus,
+    commitDraw: drawPts.length > 0 ? commitDraw : null,
+    onModifiers,
+  });
 
   // The "remove at this point" gesture, shared by modifier+left-click
   // (onPointerDown) and right-click / macOS Ctrl-click (onContextMenu): a node
@@ -1582,12 +1385,11 @@ export function SpaceSketchOverlay() {
         </button>
         <button className={iconBtn} onClick={cleanupOrphans}
           disabled={!rooms.length} title="Clean up: remove orphaned inner walls and redundant nodes (room shapes unchanged)"><Eraser className="h-4 w-4" /></button>
-        <button className={`${iconBtn} ml-auto`} onClick={() => {
-            const pts = rooms.length > 0
+        <button className={`${iconBtn} ml-auto`} onClick={() => fitToPoints(
+            rooms.length > 0
               ? rooms.flatMap((r) => r.outline)
-              : (lastBuildRef.current?.rects ?? []).flatMap((r) => r.corners);
-            applyFit(computeFitFromPoints(pts, sizeRef.current.w, sizeRef.current.h));
-          }}
+              : (lastBuildRef.current?.rects ?? []).flatMap((r) => r.corners),
+          )}
           disabled={derivedStorey == null} title="Fit plan to canvas (reset zoom & pan)"><Maximize className="h-4 w-4" /></button>
       </div>
 
@@ -1697,9 +1499,7 @@ export function SpaceSketchOverlay() {
       {/* Resize grip (Issue 4) — drag to grow/shrink the canvas; the plan stays
           put (hit ⤢ to reframe). */}
       <div
-        onPointerDown={(e) => { e.preventDefault(); e.stopPropagation(); resizeRef.current = { x: e.clientX, y: e.clientY, w: size.w, h: size.h }; (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId); }}
-        onPointerMove={(e) => { const r = resizeRef.current; if (!r) return; setSize({ w: Math.max(MIN_W, Math.round(r.w + (e.clientX - r.x))), h: Math.max(MIN_H, Math.round(r.h + (e.clientY - r.y))) }); }}
-        onPointerUp={(e) => { resizeRef.current = null; (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId); }}
+        {...resizeHandlers}
         title="Drag to resize the panel"
         className="absolute bottom-1 right-1 h-3.5 w-3.5 cursor-nwse-resize text-muted-foreground/50 hover:text-foreground"
         style={{ touchAction: 'none' }}>

--- a/apps/viewer/src/components/viewer/tools/space-sketch/SpaceSketchCanvas.tsx
+++ b/apps/viewer/src/components/viewer/tools/space-sketch/SpaceSketchCanvas.tsx
@@ -40,7 +40,9 @@ interface BoundaryInfo { disp: Pt[]; unbounded: boolean }
 interface Diagnostic { a: Pt; b: Pt; bounding: boolean }
 
 export interface SpaceSketchCanvasProps {
-  svgRef: React.RefObject<SVGSVGElement | null>;
+  /** Callback OR object ref — the overlay passes a callback so the wheel
+   *  listener re-binds when this canvas is remounted (minimize/reopen). */
+  svgRef: React.Ref<SVGSVGElement>;
   width: number;
   height: number;
   cursor: string;

--- a/apps/viewer/src/components/viewer/tools/space-sketch/space-bake.test.ts
+++ b/apps/viewer/src/components/viewer/tools/space-sketch/space-bake.test.ts
@@ -1,0 +1,106 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import type { Pt } from '@/lib/space-sketch-geometry.js';
+import { BAKE_HEIGHT, floorToFloorHeight, planStoreySpaces, type DraftRoom } from './space-bake.js';
+
+const STOREYS = [
+  { id: 10, elev: 0 },
+  { id: 20, elev: 3.2 },
+  { id: 30, elev: 6.4 },
+];
+
+/** A `size`×`size` square with its lower-left corner at `(x, y)`. */
+function square(x: number, y: number, size: number): Pt[] {
+  return [[x, y], [x + size, y], [x + size, y + size], [x, y + size]];
+}
+
+/** A draft room whose emit boundary is inset from its centreline outline. */
+function room(outline: Pt[], boundary: Pt[] = outline): DraftRoom {
+  return { outline, boundary };
+}
+
+describe('floorToFloorHeight', () => {
+  it('measures the gap to the storey above', () => {
+    assert.equal(floorToFloorHeight(STOREYS, 10), 3.2);
+    assert.ok(Math.abs(floorToFloorHeight(STOREYS, 20) - 3.2) < 1e-9);
+  });
+
+  it('falls back for the top storey, which has nothing above it', () => {
+    assert.equal(floorToFloorHeight(STOREYS, 30), BAKE_HEIGHT);
+  });
+
+  it('falls back for a storey that is not in the list', () => {
+    assert.equal(floorToFloorHeight(STOREYS, 999), BAKE_HEIGHT);
+    assert.equal(floorToFloorHeight([], 10), BAKE_HEIGHT);
+  });
+
+  it('refuses a zero or negative gap', () => {
+    // Two storeys exported at the same elevation is common. Taking the gap
+    // literally gives a zero-height band, and `wallRectsFromMeshes` then finds
+    // no walls at all — the plan comes up empty with no error to explain it.
+    const flat = [{ id: 1, elev: 4 }, { id: 2, elev: 4 }, { id: 3, elev: 2 }];
+    assert.equal(floorToFloorHeight(flat, 1), BAKE_HEIGHT, 'zero gap');
+    assert.equal(floorToFloorHeight(flat, 2), BAKE_HEIGHT, 'negative gap (unsorted list)');
+  });
+
+  it('refuses a gap far too large to be a storey height', () => {
+    // A storey elevation left in millimetres reads as kilometres of gap, which
+    // would sweep the entire building into one storey's plan.
+    const mm = [{ id: 1, elev: 0 }, { id: 2, elev: 3200 }];
+    assert.equal(floorToFloorHeight(mm, 1), BAKE_HEIGHT);
+  });
+
+  it('keeps a low but plausible storey height', () => {
+    const low = [{ id: 1, elev: 0 }, { id: 2, elev: 2.2 }];
+    assert.equal(floorToFloorHeight(low, 1), 2.2);
+  });
+});
+
+describe('planStoreySpaces', () => {
+  it('plans one space per room at the storey height', () => {
+    const rooms = [room(square(0, 0, 4)), room(square(10, 0, 2))];
+    const { planned, skipped } = planStoreySpaces(rooms, [], 3.2);
+    assert.equal(skipped, 0);
+    assert.deepEqual(planned.map((p) => p.Height), [3.2, 3.2]);
+  });
+
+  it('emits the BOUNDARY outline but measures area on the CENTRELINE', () => {
+    // The user's net/gross choice changes the profile that lands in the file;
+    // the quantity must still describe the room, not the wall face. Emitting
+    // the boundary while measuring the boundary would make gross area shrink
+    // whenever the user switched to "inner".
+    const outline = square(0, 0, 4);       // 16 m² on the centreline
+    const boundary = square(0.1, 0.1, 3.8); // the inset net face
+    const { planned } = planStoreySpaces([room(outline, boundary)], [], 3);
+    assert.deepEqual(planned[0].OuterCurve, boundary, 'the inset face is what gets created');
+    assert.equal(planned[0].grossFloorArea, 16, 'the area stays on the centreline');
+  });
+
+  it('skips a room whose centroid sits inside an already-authored space', () => {
+    // The tool derives rooms from walls, so on a model that already has spaces
+    // every one of them would otherwise be authored a second time.
+    const authored = [square(0, 0, 4)];
+    const rooms = [room(square(0, 0, 4)), room(square(10, 0, 2))];
+    const { planned, skipped } = planStoreySpaces(rooms, authored, 3);
+    assert.equal(skipped, 1);
+    assert.equal(planned.length, 1);
+    assert.equal(planned[0].grossFloorArea, 4, 'the surviving room is the far one');
+  });
+
+  it('does not skip a room that merely touches an authored footprint', () => {
+    // Dedup is by centroid containment, not by overlap: two rooms sharing a
+    // wall with an authored space must both still be created.
+    const authored = [square(0, 0, 4)];
+    const { planned, skipped } = planStoreySpaces([room(square(4, 0, 4))], authored, 3);
+    assert.equal(skipped, 0);
+    assert.equal(planned.length, 1);
+  });
+
+  it('plans nothing from no rooms', () => {
+    assert.deepEqual(planStoreySpaces([], [square(0, 0, 1)], 3), { planned: [], skipped: 0 });
+  });
+});

--- a/apps/viewer/src/components/viewer/tools/space-sketch/space-bake.ts
+++ b/apps/viewer/src/components/viewer/tools/space-sketch/space-bake.ts
@@ -1,0 +1,97 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Pure bake planning for Space Sketch: what a storey's draft rooms become when
+ * the user confirms, decided without React, wasm, or the viewer store.
+ *
+ * The bake half of the overlay reads the plate and never mutates it, and its
+ * failure stories are all decisions rather than plumbing: a room emitted on top
+ * of an authored space (duplicate rooms in the file), a floor-to-floor taken
+ * from a storey list that is unsorted or has a nonsense gap (spaces a hundred
+ * metres tall, or the wall band the derive reads collapsing to nothing), and
+ * gross floor area measured off the wrong outline (the display boundary rather
+ * than the centreline, which would make the quantity describe the wall face).
+ * Those are the decisions this module owns; `useSpaceBake` owns the emitting.
+ */
+
+import { centroid, pointInPoly, polyArea, type Pt } from '@/lib/space-sketch-geometry';
+
+/** Floor-to-floor used when the storey list offers no usable one. */
+export const BAKE_HEIGHT = 3;
+/** A storey gap outside this range is a data artefact, not a floor height. */
+const MIN_FLOOR_TO_FLOOR = 0.1;
+const MAX_FLOOR_TO_FLOOR = 50;
+
+/** The subset of the overlay's storey list this module needs. */
+export interface StoreyElevation {
+  id: number;
+  elev: number;
+}
+
+/**
+ * Floor-to-floor for storey `sid`: the elevation gap to the storey above it in
+ * `storeys`, which the caller keeps sorted low → high.
+ *
+ * Falls back to {@link BAKE_HEIGHT} for the top storey, an unknown storey, and
+ * for a gap that cannot be a storey height. That guard is not cosmetic: this
+ * height is also the band `wallRectsFromMeshes` slices to find the storey's
+ * walls, so a zero/negative gap (two storeys at the same elevation, a common
+ * export artefact) would find no walls at all, and a 500 m gap (a storey
+ * elevation left in millimetres) would sweep the whole building into one plan.
+ */
+export function floorToFloorHeight(storeys: StoreyElevation[], sid: number): number {
+  const idx = storeys.findIndex((s) => s.id === sid);
+  if (idx < 0) return BAKE_HEIGHT;
+  const next = storeys[idx + 1];
+  const ff = next ? next.elev - storeys[idx].elev : BAKE_HEIGHT;
+  return ff > MIN_FLOOR_TO_FLOOR && ff < MAX_FLOOR_TO_FLOOR ? ff : BAKE_HEIGHT;
+}
+
+/**
+ * One drafted room as the bake sees it: the topology outline (always the wall
+ * centreline) and the display/emit boundary at the user's chosen boundary mode.
+ */
+export interface DraftRoom {
+  outline: Pt[];
+  boundary: Pt[];
+}
+
+/** An IfcSpace footprint the caller is cleared to create. */
+export interface PlannedSpace {
+  /** The emitted profile — the net/gross/centre boundary the user picked. */
+  OuterCurve: Pt[];
+  Height: number;
+  /** Measured on the CENTRELINE outline, so the quantity is the room. */
+  grossFloorArea: number;
+}
+
+/**
+ * Decide which of a storey's draft rooms become IfcSpace.
+ *
+ * A room whose centroid falls inside an already-authored space footprint is
+ * skipped: the tool derives rooms from walls, so on a model that already has
+ * spaces every one of them would otherwise be emitted a second time.
+ */
+export function planStoreySpaces(
+  rooms: DraftRoom[],
+  authored: Pt[][],
+  height: number,
+): { planned: PlannedSpace[]; skipped: number } {
+  const planned: PlannedSpace[] = [];
+  let skipped = 0;
+  for (const room of rooms) {
+    const [cx, cy] = centroid(room.outline);
+    if (authored.some((fp) => pointInPoly(cx, cy, fp))) {
+      skipped++;
+      continue;
+    }
+    planned.push({
+      OuterCurve: room.boundary,
+      Height: height,
+      grossFloorArea: polyArea(room.outline),
+    });
+  }
+  return { planned, skipped };
+}

--- a/apps/viewer/src/components/viewer/tools/space-sketch/space-viewport.test.ts
+++ b/apps/viewer/src/components/viewer/tools/space-sketch/space-viewport.test.ts
@@ -67,8 +67,38 @@ describe('zoomStep', () => {
     assert.equal(zoomStep(tooFarOut, 400, 100, 100), null);
   });
 
-  it('allows a step that lands exactly on a bound', () => {
-    const atBound = zoomStep({ scale: MIN_ZOOM_SCALE, offX: 0, offY: 0 }, -1e-9, 0, 0);
-    assert.ok(atBound && atBound.scale >= MIN_ZOOM_SCALE);
+  it('accepts a step that lands exactly ON a bound', () => {
+    // deltaY 0 is a real event (a horizontal-only wheel gesture) and its zoom
+    // factor is exactly 1, so the resulting scale is bit-identical to the
+    // starting one. Sitting on the limit must not blank the transform.
+    for (const scale of [MIN_ZOOM_SCALE, MAX_ZOOM_SCALE]) {
+      const next = zoomStep({ scale, offX: 7, offY: 11 }, 0, 100, 100);
+      assert.ok(next, `a zero-delta wheel at scale ${scale} must not be refused`);
+      assert.equal(next.scale, scale);
+    }
+  });
+
+  it('refuses at the bounds themselves, not at some other scale', () => {
+    // Bisect for the deltaY where accept flips to refuse, so the test pins WHERE
+    // the limit is without having to know the wheel sensitivity. A wrong bound
+    // constant, or a comparison against the wrong field, moves this threshold.
+    const from: Fit = { scale: 10, offX: 3, offY: 4 };
+    const flipScale = (accepted: number, refused: number): number => {
+      for (let i = 0; i < 200; i++) {
+        const mid = (accepted + refused) / 2;
+        if (zoomStep(from, mid, 100, 100)) accepted = mid; else refused = mid;
+      }
+      return zoomStep(from, accepted, 100, 100)!.scale;
+    };
+    // Zooming out (positive deltaY) bottoms out at the minimum...
+    const outLimit = flipScale(0, 1e5);
+    assert.ok(Math.abs(outLimit - MIN_ZOOM_SCALE) / MIN_ZOOM_SCALE < 1e-9,
+      `zoom-out stops at ${outLimit}, expected ${MIN_ZOOM_SCALE}`);
+    assert.notEqual(outLimit, from.scale, 'and it really did zoom on the way there');
+    // ...and zooming in (negative deltaY) tops out at the maximum.
+    const inLimit = flipScale(0, -1e5);
+    assert.ok(Math.abs(inLimit - MAX_ZOOM_SCALE) / MAX_ZOOM_SCALE < 1e-9,
+      `zoom-in stops at ${inLimit}, expected ${MAX_ZOOM_SCALE}`);
+    assert.notEqual(inLimit, from.scale);
   });
 });

--- a/apps/viewer/src/components/viewer/tools/space-sketch/space-viewport.test.ts
+++ b/apps/viewer/src/components/viewer/tools/space-sketch/space-viewport.test.ts
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { wX, wY, type Fit } from '@/lib/space-sketch-geometry.js';
+import { clampToCanvas, zoomStep, MIN_ZOOM_SCALE, MAX_ZOOM_SCALE } from './space-viewport.js';
+
+const CANVAS_W = 420;
+const CANVAS_H = 340;
+const FIT: Fit = { scale: 20, offX: 36, offY: 304 };
+
+describe('clampToCanvas', () => {
+  it('leaves a position inside the canvas alone', () => {
+    assert.deepEqual(clampToCanvas(120, 80, CANVAS_W, CANVAS_H), [120, 80]);
+  });
+
+  it('clamps to the edges rather than reporting an off-canvas position', () => {
+    assert.deepEqual(clampToCanvas(-40, -12, CANVAS_W, CANVAS_H), [0, 0]);
+    assert.deepEqual(clampToCanvas(9999, 9999, CANVAS_W, CANVAS_H), [CANVAS_W, CANVAS_H]);
+  });
+
+  it('keeps a captured drag off the canvas from producing an extreme world point', () => {
+    // The failure this exists for: during a vertex drag the pointer is
+    // captured, so dragging past the panel reported coordinates far outside the
+    // SVG. Unclamped, that becomes a world position hundreds of metres away —
+    // the room "disappeared" and the SVG rasterised a polygon spanning to
+    // extreme coordinates, freezing the browser.
+    const runaway = 40_000;
+    const [cx, cy] = clampToCanvas(runaway, runaway, CANVAS_W, CANVAS_H);
+    const world = [wX(FIT, cx), wY(FIT, cy)];
+    assert.ok(Math.abs(world[0]) < 100 && Math.abs(world[1]) < 100,
+      `a clamped pointer must stay near the plan, got ${world.join(',')}`);
+    // Same input unclamped, for contrast: this is the value that froze it.
+    assert.ok(Math.abs(wX(FIT, runaway)) > 1000, 'the unclamped value really is extreme');
+  });
+
+  it('clamps each axis independently', () => {
+    assert.deepEqual(clampToCanvas(-5, 100, CANVAS_W, CANVAS_H), [0, 100]);
+    assert.deepEqual(clampToCanvas(100, 9999, CANVAS_W, CANVAS_H), [100, CANVAS_H]);
+  });
+});
+
+describe('zoomStep', () => {
+  it('zooms in on a scroll up and out on a scroll down', () => {
+    assert.ok(zoomStep(FIT, -100, 200, 170)!.scale > FIT.scale);
+    assert.ok(zoomStep(FIT, 100, 200, 170)!.scale < FIT.scale);
+  });
+
+  it('keeps the point under the cursor fixed', () => {
+    const ax = 200, ay = 170;
+    const before = [wX(FIT, ax), wY(FIT, ay)];
+    const next = zoomStep(FIT, -240, ax, ay)!;
+    const after = [wX(next, ax), wY(next, ay)];
+    assert.ok(Math.abs(before[0] - after[0]) < 1e-9, 'x under the cursor is unchanged');
+    assert.ok(Math.abs(before[1] - after[1]) < 1e-9, 'y under the cursor is unchanged');
+  });
+
+  it('refuses a step that would leave the usable range, moving NOTHING', () => {
+    // Returning null rather than a scale-clamped fit is the point: clamping the
+    // scale while still applying the offset shift would drift the plan sideways
+    // under a wheel that no longer zooms.
+    const tooFarIn: Fit = { scale: MAX_ZOOM_SCALE, offX: 10, offY: 20 };
+    assert.equal(zoomStep(tooFarIn, -400, 100, 100), null);
+    const tooFarOut: Fit = { scale: MIN_ZOOM_SCALE, offX: 10, offY: 20 };
+    assert.equal(zoomStep(tooFarOut, 400, 100, 100), null);
+  });
+
+  it('allows a step that lands exactly on a bound', () => {
+    const atBound = zoomStep({ scale: MIN_ZOOM_SCALE, offX: 0, offY: 0 }, -1e-9, 0, 0);
+    assert.ok(atBound && atBound.scale >= MIN_ZOOM_SCALE);
+  });
+});

--- a/apps/viewer/src/components/viewer/tools/space-sketch/space-viewport.ts
+++ b/apps/viewer/src/components/viewer/tools/space-sketch/space-viewport.ts
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Pure viewport rules for the Space Sketch canvas: where a pointer event lands
+ * and how far the wheel may zoom.
+ *
+ * Both exist because of a specific failure, and both were previously inline in
+ * the overlay where nothing could pin them.
+ */
+
+import { zoomFit, type Fit } from '@/lib/space-sketch-geometry';
+
+/** Wheel-zoom range. Outside it the gesture is refused, not clamped. */
+export const MIN_ZOOM_SCALE = 0.5;
+export const MAX_ZOOM_SCALE = 5000;
+/** Wheel sensitivity: scroll up (negative deltaY) zooms in. */
+const ZOOM_PER_WHEEL_UNIT = 0.0015;
+
+/**
+ * Clamp a canvas-relative pointer position into the `w`×`h` canvas.
+ *
+ * During a drag the pointer is captured, so moving it past the panel (e.g.
+ * dragging a vertex down off the bottom) reports coordinates far outside the
+ * SVG → a huge off-screen world position. That pushed the room off-canvas
+ * ("disappears") and made the SVG rasterise a polygon spanning to extreme
+ * coordinates, freezing the browser.
+ */
+export function clampToCanvas(x: number, y: number, w: number, h: number): [number, number] {
+  return [Math.max(0, Math.min(w, x)), Math.max(0, Math.min(h, y))];
+}
+
+/**
+ * The fit after a wheel notch of `deltaY` about canvas point `(ax, ay)`, or
+ * `null` when the result would leave the usable zoom range.
+ *
+ * Returning null rather than a clamped fit is deliberate: clamping the *scale*
+ * while still applying the offset shift would drift the plan sideways under a
+ * wheel that no longer zooms, so a refused gesture must move nothing at all.
+ */
+export function zoomStep(f: Fit, deltaY: number, ax: number, ay: number): Fit | null {
+  const next = zoomFit(f, Math.exp(-deltaY * ZOOM_PER_WHEEL_UNIT), ax, ay);
+  return next.scale >= MIN_ZOOM_SCALE && next.scale <= MAX_ZOOM_SCALE ? next : null;
+}

--- a/apps/viewer/src/components/viewer/tools/space-sketch/useSpaceBake.test.tsx
+++ b/apps/viewer/src/components/viewer/tools/space-sketch/useSpaceBake.test.tsx
@@ -1,0 +1,176 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Space Sketch confirm-on-close (#2438).
+ *
+ * The decisions (dedup, floor-to-floor, which outline carries the area) are
+ * pinned in `space-bake.test.ts`. What this file pins is the part that needs a
+ * mounted hook because it is carried in a ref across calls: the ids this tool
+ * authored per storey.
+ *
+ * A partial failure keeps the tool open so nothing is silently dropped, which
+ * means confirming a second time is a normal path — and the second confirm has
+ * to REPLACE what the first one created, not add a second copy of every room to
+ * the file. That ledger lives in `generatedRef`, so it can only be exercised
+ * through the hook.
+ */
+
+import '@/test/setup-dom.js';
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { useViewerStore } from '@/store/index.js';
+import type { IfcDataStore } from '@ifc-lite/parser';
+import type { SpacePlateSession } from '@/lib/space-plate-session.js';
+import type { Pt } from '@/lib/space-sketch-geometry.js';
+import { useSpaceBake, type UseSpaceBake } from './useSpaceBake.js';
+
+const MODEL = 'model-a';
+
+/** A plate session with `n` unit-square rooms, as the bake reads it. */
+function fakeSession(n: number, alive = true): SpacePlateSession {
+  const rooms = Array.from({ length: n }, (_, i) => ({
+    face: i,
+    outline: [[i * 10, 0], [i * 10 + 2, 0], [i * 10 + 2, 2], [i * 10, 2]] as Pt[],
+    area: 4,
+    simple: true,
+  }));
+  return {
+    alive,
+    roomCount: n,
+    rooms: () => rooms,
+    boundaryOutline: (face: number) => rooms[face].outline,
+  } as unknown as SpacePlateSession;
+}
+
+/** `existingSpaceFootprintsByStorey` short-circuits to empty without a source. */
+const EMPTY_STORE = { source: undefined } as unknown as IfcDataStore;
+
+interface Emitted { modelId: string; storeyId: number; name: string }
+
+let added: Emitted[] = [];
+let removed: Array<{ modelId: string; id: number }> = [];
+let nextId = 0;
+let failCalls: Set<number>;
+let callSeq = 0;
+let root: Root | null = null;
+let container: HTMLElement | null = null;
+let api: UseSpaceBake | null = null;
+let sessions: Map<number, SpacePlateSession>;
+let storeBackup: { addSpace: unknown; removeEntity: unknown };
+
+function Harness() {
+  const ref = { current: sessions };
+  api = useSpaceBake({
+    sketchModelId: MODEL,
+    ifcDataStore: EMPTY_STORE,
+    boundaryMode: 'center',
+    sessionsRef: ref,
+    floorToFloor: () => 3,
+  });
+  return null;
+}
+
+beforeEach(() => {
+  added = [];
+  removed = [];
+  nextId = 5000;
+  failCalls = new Set();
+  callSeq = 0;
+  sessions = new Map();
+  const s = useViewerStore.getState();
+  storeBackup = { addSpace: s.addSpace, removeEntity: s.removeEntity };
+  useViewerStore.setState({
+    addSpace: ((modelId: string, storeyId: number, params: { Name: string }) => {
+      const seq = callSeq++;
+      if (failCalls.has(seq)) return { error: `refused room ${seq}` };
+      added.push({ modelId, storeyId, name: params.Name });
+      return { expressId: nextId++ };
+    }) as typeof s.addSpace,
+    removeEntity: ((modelId: string, id: number) => { removed.push({ modelId, id }); }) as typeof s.removeEntity,
+  });
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => { root!.render(<Harness />); });
+});
+
+afterEach(() => {
+  if (root) act(() => root!.unmount());
+  root = null;
+  container?.remove();
+  useViewerStore.setState(storeBackup as Partial<ReturnType<typeof useViewerStore.getState>>);
+});
+
+describe('useSpaceBake', () => {
+  it('creates one space per drafted room across every storey', () => {
+    sessions.set(1, fakeSession(2));
+    sessions.set(2, fakeSession(1));
+    const res = api!.createAllSpaces();
+    assert.deepEqual(res, { emitted: 3, floors: 2, error: null });
+    assert.deepEqual(added.map((a) => a.storeyId), [1, 1, 2]);
+    assert.deepEqual(added.map((a) => a.name), ['Space 1', 'Space 2', 'Space 1'],
+      'names restart per storey');
+    assert.equal(removed.length, 0, 'a first confirm removes nothing');
+    assert.deepEqual(api!.createdIds(), [5000, 5001, 5002]);
+  });
+
+  it('REPLACES on a second confirm instead of duplicating the file', () => {
+    // Reachable normally: a partial failure keeps the tool open, so the user
+    // fixes it and confirms again. Without the per-storey id ledger the model
+    // ends up with two IfcSpace for every room.
+    sessions.set(1, fakeSession(2));
+    api!.createAllSpaces();
+    const firstIds = [...api!.createdIds()];
+    added = [];
+
+    const res = api!.createAllSpaces();
+    assert.equal(res.emitted, 2, 'the same two rooms are re-created');
+    assert.deepEqual(removed, firstIds.map((id) => ({ modelId: MODEL, id })),
+      'and the previous pair is removed first');
+    assert.deepEqual(api!.createdIds(), [5002, 5003], 'the ledger now holds only the new ids');
+  });
+
+  it('reports an addSpace failure instead of counting it as a dedup skip', () => {
+    // A refused space is missing from the export. Reporting a null error would
+    // let `confirmCreate` close the tool and discard the rest of the drafts.
+    sessions.set(1, fakeSession(2));
+    failCalls.add(0); // the first room is refused by the store
+    const res = api!.createAllSpaces();
+    assert.equal(res.emitted, 1);
+    assert.match(res.error ?? '', /refused room 0/);
+  });
+
+  it('numbers surviving spaces by successful emission, leaving no gap', () => {
+    sessions.set(1, fakeSession(3));
+    failCalls.add(0);
+    api!.createAllSpaces();
+    assert.deepEqual(added.map((a) => a.name), ['Space 1', 'Space 2'],
+      'the second room takes the freed number rather than showing a hole');
+  });
+
+  it('ignores a disposed or empty storey plate', () => {
+    sessions.set(1, fakeSession(0));
+    sessions.set(2, fakeSession(2, false));
+    const res = api!.createAllSpaces();
+    assert.deepEqual(res, { emitted: 0, floors: 0, error: null });
+    assert.equal(added.length, 0);
+  });
+
+  it('reveals the IfcSpace class only when something was created', () => {
+    useViewerStore.setState({
+      typeVisibility: { ...useViewerStore.getState().typeVisibility, spaces: false },
+    });
+    api!.createAllSpaces(); // nothing drafted
+    assert.equal(useViewerStore.getState().typeVisibility.spaces, false,
+      'a no-op confirm must not change the user\'s visibility settings');
+
+    sessions.set(1, fakeSession(1));
+    api!.createAllSpaces();
+    assert.equal(useViewerStore.getState().typeVisibility.spaces, true,
+      'spaces are class-hidden by default, so a created space would be invisible');
+  });
+});

--- a/apps/viewer/src/components/viewer/tools/space-sketch/useSpaceBake.test.tsx
+++ b/apps/viewer/src/components/viewer/tools/space-sketch/useSpaceBake.test.tsx
@@ -60,7 +60,9 @@ let root: Root | null = null;
 let container: HTMLElement | null = null;
 let api: UseSpaceBake | null = null;
 let sessions: Map<number, SpacePlateSession>;
-let storeBackup: { addSpace: unknown; removeEntity: unknown };
+/** Everything this file writes into the module-level store, so `afterEach` can
+ *  put it all back — the viewer runs its whole suite in ONE process. */
+let storeBackup: Record<string, unknown>;
 
 function Harness() {
   const ref = { current: sessions };
@@ -82,7 +84,7 @@ beforeEach(() => {
   callSeq = 0;
   sessions = new Map();
   const s = useViewerStore.getState();
-  storeBackup = { addSpace: s.addSpace, removeEntity: s.removeEntity };
+  storeBackup = { addSpace: s.addSpace, removeEntity: s.removeEntity, typeVisibility: s.typeVisibility };
   useViewerStore.setState({
     addSpace: ((modelId: string, storeyId: number, params: { Name: string }) => {
       const seq = callSeq++;

--- a/apps/viewer/src/components/viewer/tools/space-sketch/useSpaceBake.ts
+++ b/apps/viewer/src/components/viewer/tools/space-sketch/useSpaceBake.ts
@@ -1,0 +1,164 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The emit half of Space Sketch: turning every storey's draft plate into real
+ * `IfcSpace`, once, on confirm.
+ *
+ * Split out of `SpaceSketchOverlay.tsx` because this is a self-contained
+ * subject with its own state (`generatedRef`, the ids this tool authored per
+ * storey) and its own failure stories, none of which involve the 2D editor:
+ * re-confirming duplicating spaces instead of replacing them, one storey's
+ * `addSpace` failure being reported as a "skip" and silently dropping rooms
+ * from the export, and a partial failure closing the tool and discarding the
+ * remaining drafts. The decisions live in `space-bake.ts`; this hook is the
+ * store-facing plumbing around them.
+ */
+
+import { useCallback, useRef } from 'react';
+import { useViewerStore } from '@/store';
+import type { IfcDataStore } from '@ifc-lite/parser';
+import {
+  existingSpaceFootprintsByStorey,
+  GENERATED_SPACE_OBJECTTYPE,
+  type BoundaryMode,
+} from '@ifc-lite/create';
+import type { SpacePlateSession } from '@/lib/space-plate-session';
+import type { Pt } from '@/lib/space-sketch-geometry';
+import { planStoreySpaces, type DraftRoom } from './space-bake';
+
+export interface SpaceBakeResult {
+  emitted: number;
+  floors: number;
+  error: string | null;
+}
+
+export interface UseSpaceBakeOptions {
+  /** Model the spaces are authored into; null refuses to guess. */
+  sketchModelId: string | null;
+  ifcDataStore: IfcDataStore | null;
+  /** Net / gross / centre outline the user picked. */
+  boundaryMode: BoundaryMode;
+  /** Every storey's draft plate, keyed by storey expressId. */
+  sessionsRef: React.RefObject<Map<number, SpacePlateSession>>;
+  floorToFloor: (sid: number) => number;
+}
+
+export interface UseSpaceBake {
+  /** Create every storey's draft as IfcSpace. Never throws. */
+  createAllSpaces: () => SpaceBakeResult;
+  /** Every expressId this tool has authored, across all storeys. */
+  createdIds: () => number[];
+}
+
+export function useSpaceBake({
+  sketchModelId,
+  ifcDataStore,
+  boundaryMode,
+  sessionsRef,
+  floorToFloor,
+}: UseSpaceBakeOptions): UseSpaceBake {
+  const addSpace = useViewerStore((s) => s.addSpace);
+  const removeEntity = useViewerStore((s) => s.removeEntity);
+
+  // IfcSpace expressIds this tool created per storey — so confirming again
+  // replaces the spaces it dropped instead of duplicating.
+  const generatedRef = useRef<Map<number, number[]>>(new Map());
+
+  /**
+   * IfcSpace is class-hidden by default (TYPE_VISIBILITY_SEMANTIC_DEFAULTS).
+   * Flip the toggle on after creating spaces so the user sees what they just
+   * created — and, since the toggle persists, so the spaces stay visible when
+   * the exported file is reopened.
+   */
+  const revealSpaces = useCallback(() => {
+    const s = useViewerStore.getState();
+    if (!s.typeVisibility.spaces) s.toggleTypeVisibility('spaces');
+  }, []);
+
+  /**
+   * Create one storey's draft rooms as real IfcSpace. (1) Replace: remove the
+   * spaces this tool previously created on the storey. (2) Skip rooms that
+   * overlap an existing authored space (dedup, decided in `space-bake.ts`).
+   * (3) Emit each via `addSpace`, which mirrors a mesh into the 3D scene
+   * immediately. Returns counts.
+   */
+  const createSpacesForStorey = useCallback((
+    sid: number,
+    rooms: DraftRoom[],
+    authored: Pt[][],
+  ): { emitted: number; skipped: number; error: string | null } => {
+    if (!sketchModelId) return { emitted: 0, skipped: 0, error: 'no model to create spaces in' };
+    for (const id of generatedRef.current.get(sid) ?? []) removeEntity(sketchModelId, id);
+    generatedRef.current.delete(sid);
+    const { planned, skipped } = planStoreySpaces(rooms, authored, floorToFloor(sid));
+    const newIds: number[] = [];
+    // An addSpace failure (anchor resolution, missing mutation view, …) is
+    // NOT an "already a space" skip — keep the first error so the status
+    // line tells the user the truth instead of silently dropping spaces
+    // that would then be missing from the export.
+    let error: string | null = null;
+    for (const space of planned) {
+      // `OuterCurve` is the engine's net/gross/centre outline; gross area stays
+      // on the centreline so the quantity reflects the room, not the wall face.
+      // The name counts SUCCESSFUL emissions, so a failed space does not leave
+      // a gap in the numbering the user can see.
+      const res = addSpace(sketchModelId, sid, {
+        Profile: 'polygon',
+        OuterCurve: space.OuterCurve,
+        Height: space.Height,
+        Name: `Space ${newIds.length + 1}`,
+        ObjectType: GENERATED_SPACE_OBJECTTYPE,
+        grossFloorArea: space.grossFloorArea,
+      });
+      if (res && 'expressId' in res) newIds.push(res.expressId);
+      else error ??= (res && 'error' in res ? res.error : 'unknown error');
+    }
+    generatedRef.current.set(sid, newIds);
+    return { emitted: newIds.length, skipped, error };
+  }, [sketchModelId, removeEntity, addSpace, floorToFloor]);
+
+  /**
+   * Confirm: turn EVERY storey's collected draft into IfcSpace at once — the
+   * single create path, run on close. Reads each per-storey session's rooms at
+   * the active boundary mode and dedupes against existing authored spaces.
+   */
+  const createAllSpaces = useCallback((): SpaceBakeResult => {
+    // Report a real error rather than a silent zero: `confirmCreate` treats a
+    // null error as success and closes the tool, which would discard every
+    // draft the user has drawn. `sketchModelId` is genuinely reachable as null
+    // — with several models loaded and none active we deliberately refuse to
+    // guess which one to author into, rather than picking an arbitrary one.
+    if (!sketchModelId) {
+      return { emitted: 0, floors: 0, error: 'No active model — pick one in the model list, then confirm again.' };
+    }
+    if (!ifcDataStore) {
+      return { emitted: 0, floors: 0, error: 'Model data is still loading — confirm again in a moment.' };
+    }
+    const authoredMap = existingSpaceFootprintsByStorey(ifcDataStore);
+    let emitted = 0, floors = 0;
+    let firstError: string | null = null;
+    for (const [sid, session] of sessionsRef.current) {
+      if (!session.alive || session.roomCount === 0) continue;
+      const rooms = session.rooms().map((r) => ({
+        outline: r.outline,
+        boundary: session.boundaryOutline(r.face, boundaryMode),
+      }));
+      const res = createSpacesForStorey(sid, rooms, authoredMap.get(sid) ?? []);
+      emitted += res.emitted;
+      if (res.emitted) floors++;
+      firstError ??= res.error;
+    }
+    if (emitted > 0) revealSpaces();
+    return { emitted, floors, error: firstError };
+  }, [sketchModelId, ifcDataStore, boundaryMode, sessionsRef, createSpacesForStorey, revealSpaces]);
+
+  const createdIds = useCallback((): number[] => {
+    const out: number[] = [];
+    for (const ids of generatedRef.current.values()) out.push(...ids);
+    return out;
+  }, []);
+
+  return { createAllSpaces, createdIds };
+}

--- a/apps/viewer/src/components/viewer/tools/space-sketch/useSpacePlateSessions.test.tsx
+++ b/apps/viewer/src/components/viewer/tools/space-sketch/useSpacePlateSessions.test.tsx
@@ -199,7 +199,7 @@ describe('useSpacePlateSessions', () => {
     assert.equal(sessions[0].built, 1, 'and the plate is built exactly once');
   });
 
-  it('unregisters and frees a storey plate whose build throws', () => {
+  it('frees a storey plate whose build throws, and registers nothing', () => {
     // derive-all walks every storey; one that blows the arrangement input cap
     // must leave nothing behind, or the storey is stuck holding a live handle
     // that never produced rooms.
@@ -222,6 +222,69 @@ describe('useSpacePlateSessions', () => {
     assert.equal(sessions.length, 1, 'a session was allocated before the throw');
     assert.equal(sessions[0].disposed, true, 'and freed on the way out');
     assert.equal(api!.sessionsRef.current.has(5), false, 'the storey is retryable');
+  });
+
+  it('keeps the storey plate it already had when a rebuild throws', async () => {
+    // Registering the new session BEFORE the build succeeds would drop the
+    // storey's existing plate out of the registry: the failure path disposes
+    // only the new one, so the old plate would still be alive, unreachable, and
+    // never freed — and the user's draft on that storey would be gone.
+    const { deps, sessions, releaseWasm } = makeFakeDeps();
+    let failNext = false;
+    const guarded: PlateDeps = {
+      ensureWasm: deps.ensureWasm,
+      createSession: () => {
+        const s = deps.createSession();
+        if (failNext) {
+          const entry = sessions[sessions.length - 1];
+          entry.session = { ...s, buildFromRects() { throw new Error('arrangement input cap'); } } as unknown as SpacePlateSession;
+          Object.defineProperty(entry.session, 'dispose', { value: () => { entry.disposed = true; } });
+          return entry.session;
+        }
+        return s;
+      },
+    };
+    mount(guarded);
+    const p = api!.buildPlate(RECTS, 5, 0.05);
+    releaseWasm();
+    await p;
+    const original = sessions[0];
+
+    failNext = true;
+    assert.throws(() => api!.buildStoreyPlate(5, RECTS, 0.05), /arrangement input cap/);
+    assert.equal(sessions.length, 2, 'a replacement plate was allocated');
+    assert.equal(sessions[1].disposed, true, 'and freed when its build threw');
+    assert.equal(original.disposed, false, 'the plate that was already there survives');
+    assert.equal(api!.sessionsRef.current.get(5), original.session, 'and is still the storey\'s plate');
+  });
+
+  it('frees the plate it replaces, and re-points the active session at the new one', () => {
+    const { deps, sessions } = makeFakeDeps();
+    mount({ ...deps, ensureWasm: () => Promise.resolve() });
+    api!.buildStoreyPlate(5, RECTS, 0.05);
+    const first = sessions[0];
+    api!.sessionRef.current = first.session; // as an activate/derive would leave it
+    api!.buildStoreyPlate(5, RECTS, 0.05);
+    const second = sessions[1];
+    assert.equal(first.disposed, true, 'the replaced plate is freed, not orphaned');
+    assert.equal(api!.sessionsRef.current.get(5), second.session);
+    assert.equal(api!.sessionRef.current, second.session,
+      'the overlay must not keep editing a plate that is no longer registered');
+  });
+
+  it('frees an active session that was never registered under a storey', async () => {
+    // `acquireSession`'s storey-less path returns a session it does not put in
+    // the registry. A cleanup that walks only the map's values would null that
+    // one away without `dispose()`, leaking its wasm-owned handles.
+    const { deps, sessions, releaseWasm } = makeFakeDeps();
+    mount(deps);
+    const p = api!.buildPlate(RECTS, null, 0.05);
+    releaseWasm();
+    await p;
+    assert.equal(sessions.length, 1);
+    assert.equal(api!.sessionsRef.current.size, 0, 'the storey-less path registers nothing');
+    unmount();
+    assert.equal(sessions[0].disposed, true, 'and unmount still frees it');
   });
 
   it('clears the disposed flag on remount, so StrictMode does not poison it', async () => {

--- a/apps/viewer/src/components/viewer/tools/space-sketch/useSpacePlateSessions.test.tsx
+++ b/apps/viewer/src/components/viewer/tools/space-sketch/useSpacePlateSessions.test.tsx
@@ -1,0 +1,242 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The Space Sketch plate lifetime, at the level where it actually goes wrong:
+ * a build suspended across the overlay's unmount.
+ *
+ * `acquireSession` (session-registry.ts) has been mutation-checked as a pure
+ * function since #1344, but the COMPONENT-LEVEL wiring around it had no
+ * executable test at all — the overlay's only entry into that path suspends on
+ * `ensureSpaceWasm()`, which rejects under the node harness, so the code that
+ * decides what `disposedRef.current` is at the moment `acquireSession` is
+ * called was verified by reading a three-line diff. Taking the wasm touch
+ * points as injected dependencies is what makes it reachable: this file holds
+ * `ensureWasm` pending, unmounts, then resolves.
+ *
+ * The leak these guard: `SpacePlateSession` owns raw Rust-heap handles freed
+ * only through `dispose()`. A resumed build that allocates a fresh session into
+ * a registry the unmount already cleared builds a wasm plate nothing is left to
+ * free — closing the tool mid-derive leaked it (#2438 / #1344).
+ */
+
+import '@/test/setup-dom.js';
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import type { SpacePlateSession } from '@/lib/space-plate-session.js';
+import type { WallRect } from '@/lib/wall-rects-from-meshes.js';
+import {
+  useSpacePlateSessions,
+  type PlateDeps,
+  type UseSpacePlateSessions,
+} from './useSpacePlateSessions.js';
+
+/** A one-metre square wall rectangle — the build input's shape is all we need. */
+const RECTS: WallRect[] = [
+  {
+    corners: [[0, 0], [1, 0], [1, 1], [0, 1]],
+    centreline: [[0, 0], [1, 0]],
+    thickness: 0.2,
+  } as unknown as WallRect,
+];
+
+/** Every session the fake `createSession` handed out, with its dispose state. */
+interface FakeSession {
+  disposed: boolean;
+  built: number;
+  session: SpacePlateSession;
+}
+
+function makeFakeDeps(): {
+  deps: PlateDeps;
+  sessions: FakeSession[];
+  /** Resolve every outstanding `ensureWasm()` — there can be more than one. */
+  releaseWasm: () => void;
+} {
+  const sessions: FakeSession[] = [];
+  const pending: Array<() => void> = [];
+  const deps: PlateDeps = {
+    ensureWasm: () => new Promise<void>((resolve) => { pending.push(resolve); }),
+    createSession: () => {
+      const entry: FakeSession = {
+        disposed: false,
+        built: 0,
+        session: null as unknown as SpacePlateSession,
+      };
+      entry.session = {
+        alive: true,
+        dispose() { entry.disposed = true; },
+        buildFromRects() { entry.built++; return { rooms: [] }; },
+      } as unknown as SpacePlateSession;
+      sessions.push(entry);
+      return entry.session;
+    },
+  };
+  return {
+    deps,
+    sessions,
+    releaseWasm: () => { while (pending.length > 0) pending.shift()!(); },
+  };
+}
+
+let root: Root | null = null;
+let container: HTMLElement | null = null;
+let api: UseSpacePlateSessions | null = null;
+
+function Harness({ deps }: { deps: PlateDeps }) {
+  api = useSpacePlateSessions(deps);
+  return null;
+}
+
+function mount(deps: PlateDeps): void {
+  act(() => { root!.render(<Harness deps={deps} />); });
+}
+
+function unmount(): void {
+  act(() => { root!.unmount(); });
+  root = null;
+}
+
+/** Let the resolved `ensureWasm` promise's continuation run. */
+async function settle(): Promise<void> {
+  await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  api = null;
+});
+
+afterEach(() => {
+  if (root) act(() => root!.unmount());
+  root = null;
+  container?.remove();
+});
+
+describe('useSpacePlateSessions', () => {
+  it('builds into a session it registers under the storey', async () => {
+    const { deps, sessions, releaseWasm } = makeFakeDeps();
+    mount(deps);
+    const built = api!.buildPlate(RECTS, 7, 0.05);
+    releaseWasm();
+    const rooms = await built;
+    assert.deepEqual(rooms, [], 'a completed build returns the plate rooms');
+    assert.equal(sessions.length, 1, 'one session allocated');
+    assert.equal(sessions[0].built, 1, 'and the plate was built into it');
+    assert.equal(api!.sessionsRef.current.get(7), sessions[0].session);
+    assert.equal(api!.sessionRef.current, sessions[0].session, 'and it became active');
+  });
+
+  it('reuses a storey session instead of allocating a second plate', async () => {
+    const { deps, sessions, releaseWasm } = makeFakeDeps();
+    mount(deps);
+    const first = api!.buildPlate(RECTS, 7, 0.05);
+    releaseWasm();
+    await first;
+    const second = api!.buildPlate(RECTS, 7, 0.05);
+    releaseWasm();
+    await second;
+    assert.equal(sessions.length, 1, 'the storey keeps its plate across rebuilds');
+    assert.equal(sessions[0].built, 2, 'which is rebuilt in place');
+  });
+
+  it('allocates NOTHING when the overlay unmounts while the build is suspended', async () => {
+    // The #2438 leak, end to end through the component wiring: the build is
+    // parked on `ensureWasm()` when the user closes the tool. Unmount does not
+    // bump the build sequence, so nothing but `disposedRef` stops the resumed
+    // build from constructing a plate into the cleared registry.
+    const { deps, sessions, releaseWasm } = makeFakeDeps();
+    mount(deps);
+    const pending = api!.buildPlate(RECTS, 7, 0.05);
+    const held = api!;
+    assert.equal(sessions.length, 0, 'nothing is allocated before the wasm resolves');
+
+    unmount();
+    assert.equal(held.disposedRef.current, true, 'unmount marks the overlay disposed');
+
+    releaseWasm();
+    const rooms = await pending;
+    await settle();
+
+    assert.equal(rooms, null, 'a build resuming after unmount applies nothing');
+    assert.equal(sessions.length, 0, 'and allocates no wasm plate at all');
+    assert.equal(held.sessionsRef.current.size, 0, 'the cleared registry stays cleared');
+    assert.equal(held.sessionRef.current, null, 'and no session is re-attached');
+  });
+
+  it('disposes every storey plate on unmount, exactly once', async () => {
+    const { deps, sessions, releaseWasm } = makeFakeDeps();
+    mount(deps);
+    for (const storey of [3, 4]) {
+      const p = api!.buildPlate(RECTS, storey, 0.05);
+      releaseWasm();
+      await p;
+    }
+    assert.equal(sessions.length, 2, 'one plate per storey');
+    const held = api!;
+    unmount();
+    assert.deepEqual(sessions.map((s) => s.disposed), [true, true], 'both plates freed');
+    assert.equal(held.sessionsRef.current.size, 0);
+    assert.equal(held.sessionRef.current, null);
+  });
+
+  it('lets only the newest build apply when two overlap', async () => {
+    // The snap slider fires a rebuild per tick. An older build resuming late
+    // must not replace the plate a newer one is already using.
+    const { deps, sessions, releaseWasm } = makeFakeDeps();
+    mount(deps);
+    const stale = api!.buildPlate(RECTS, 7, 0.05);
+    const fresh = api!.buildPlate(RECTS, 7, 0.02);
+    releaseWasm(); // both builds resume; only the newer one may apply
+    assert.equal(await stale, null, 'the superseded build applies nothing');
+    assert.deepEqual(await fresh, [], 'the newest build applies');
+    assert.equal(sessions.length, 1);
+    assert.equal(sessions[0].built, 1, 'and the plate is built exactly once');
+  });
+
+  it('unregisters and frees a storey plate whose build throws', () => {
+    // derive-all walks every storey; one that blows the arrangement input cap
+    // must leave nothing behind, or the storey is stuck holding a live handle
+    // that never produced rooms.
+    const sessions: FakeSession[] = [];
+    const deps: PlateDeps = {
+      ensureWasm: () => Promise.resolve(),
+      createSession: () => {
+        const entry: FakeSession = { disposed: false, built: 0, session: null as unknown as SpacePlateSession };
+        entry.session = {
+          alive: true,
+          dispose() { entry.disposed = true; },
+          buildFromRects() { throw new Error('arrangement input cap'); },
+        } as unknown as SpacePlateSession;
+        sessions.push(entry);
+        return entry.session;
+      },
+    };
+    mount(deps);
+    assert.throws(() => api!.buildStoreyPlate(5, RECTS, 0.05), /arrangement input cap/);
+    assert.equal(sessions.length, 1, 'a session was allocated before the throw');
+    assert.equal(sessions[0].disposed, true, 'and freed on the way out');
+    assert.equal(api!.sessionsRef.current.has(5), false, 'the storey is retryable');
+  });
+
+  it('clears the disposed flag on remount, so StrictMode does not poison it', async () => {
+    // React StrictMode mounts, runs the cleanup, then mounts again. If
+    // `disposedRef` stayed true after that cycle the overlay could never build
+    // anything for the rest of its life.
+    const { deps, sessions, releaseWasm } = makeFakeDeps();
+    mount(deps);
+    unmount();
+    root = createRoot(container!);
+    mount(deps);
+    assert.equal(api!.disposedRef.current, false, 'a fresh mount is not disposed');
+    const p = api!.buildPlate(RECTS, 7, 0.05);
+    releaseWasm();
+    assert.deepEqual(await p, [], 'and can still build');
+    assert.equal(sessions.length, 1);
+  });
+});

--- a/apps/viewer/src/components/viewer/tools/space-sketch/useSpacePlateSessions.ts
+++ b/apps/viewer/src/components/viewer/tools/space-sketch/useSpacePlateSessions.ts
@@ -1,0 +1,164 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Ownership of the Space Sketch wasm plates: one `SpacePlateSession` per
+ * storey, their lifetime, and the async build that allocates into them.
+ *
+ * This is the piece of the overlay where a mistake costs heap rather than
+ * pixels. `SpacePlateSession` owns raw Rust-heap handles freed only through
+ * `dispose()`, and the build path suspends on `ensureWasm()` — so unmount can
+ * land in the middle of it. `session-registry.ts` decides whether a resumed
+ * build may allocate; this hook is the wiring that gives it a truthful
+ * `disposed` flag and disposes everything exactly once.
+ *
+ * ## Why the dependencies are injected
+ *
+ * The overlay's only entry into this path suspends on `ensureSpaceWasm()`,
+ * which rejects under the node test harness (no `fetch` for the `.wasm`), so
+ * the component-level wiring around `acquireSession` had no executable test at
+ * all — the guard was mutation-checked as a pure function while the code that
+ * passes it `disposedRef.current` was verified by reading a diff. Taking the
+ * two wasm touch points as parameters with production defaults makes the
+ * suspended-across-unmount case reachable from a test: hold `ensureWasm`
+ * pending, unmount, resolve, and assert nothing was allocated.
+ *
+ * These are ordinary parameters, not a test backdoor — the overlay passes
+ * nothing and gets the real wasm.
+ */
+
+import { useCallback, useEffect, useRef } from 'react';
+import {
+  SpacePlateSession,
+  ensureSpaceWasm,
+  flattenWallRects,
+  type Room,
+} from '@/lib/space-plate-session';
+import type { WallRect } from '@/lib/wall-rects-from-meshes';
+import { acquireSession } from './session-registry';
+
+/** Weld distance for coincident wall-rectangle corners, m. */
+const CORNER_WELD_SPAN = 0.3;
+
+export interface PlateDeps {
+  /** Resolves once the space wasm module is usable. */
+  ensureWasm: () => Promise<unknown>;
+  /** Allocates a fresh plate session (owns wasm heap until `dispose()`). */
+  createSession: () => SpacePlateSession;
+}
+
+export const defaultPlateDeps: PlateDeps = {
+  ensureWasm: ensureSpaceWasm,
+  createSession: () => new SpacePlateSession(),
+};
+
+export interface UseSpacePlateSessions {
+  /** Every storey's plate, alive until the tool closes. */
+  sessionsRef: React.RefObject<Map<number, SpacePlateSession>>;
+  /** The active storey's plate. Null once the overlay has unmounted. */
+  sessionRef: React.RefObject<SpacePlateSession | null>;
+  /** True once unmount has disposed everything; no new plate may be built. */
+  disposedRef: React.RefObject<boolean>;
+  /**
+   * Build `rects` into `storey`'s plate (creating it if needed) and return its
+   * rooms, or `null` when this build was superseded by a newer one or the
+   * overlay was unmounted while it was suspended. Rejects if the build itself
+   * throws — the caller reports that to the user.
+   */
+  buildPlate: (rects: WallRect[], storey: number | null, snapTol: number) => Promise<Room[] | null>;
+  /**
+   * Allocate + register `storey`'s plate and build `rects` into it, for the
+   * derive-all path (which walks every storey in one synchronous loop rather
+   * than through the async `buildPlate`). Rethrows a build failure AFTER
+   * disposing and unregistering the half-built session, so the storey is
+   * retryable rather than stuck holding a plate nothing will free.
+   */
+  buildStoreyPlate: (storey: number, rects: WallRect[], snapTol: number) => Room[];
+  /**
+   * Resolves once the space wasm is usable — the same touch point `buildPlate`
+   * uses, so the overlay reaches wasm in exactly one place and derive-all is
+   * injectable for the same reason `buildPlate` is.
+   */
+  ensureWasm: () => Promise<unknown>;
+}
+
+export function useSpacePlateSessions(deps: PlateDeps = defaultPlateDeps): UseSpacePlateSessions {
+  const sessionsRef = useRef<Map<number, SpacePlateSession>>(new Map());
+  const sessionRef = useRef<SpacePlateSession | null>(null);
+  const disposedRef = useRef(false);
+  const buildSeqRef = useRef(0);
+  // Render-phase mirror so `buildPlate` keeps a stable identity even when the
+  // caller passes a fresh deps object each render — it is a dependency of
+  // several effects downstream, and churning it would re-register listeners.
+  const depsRef = useRef(deps);
+  depsRef.current = deps;
+
+  const buildPlate = useCallback(async (
+    rects: WallRect[],
+    storey: number | null,
+    snapTol: number,
+  ): Promise<Room[] | null> => {
+    // Re-entrancy guard: a rapid rebuild (snap slider) must not let an older
+    // async build free/replace the plate a newer one is using — that races the
+    // shared wasm heap. Only the latest build applies; superseded ones bail.
+    const seq = ++buildSeqRef.current;
+    await depsRef.current.ensureWasm();
+    if (seq !== buildSeqRef.current) return null;
+    // Returns null once the overlay has been unmounted — unmount does NOT bump
+    // `buildSeqRef`, so a build suspended on the await above would otherwise
+    // resume, find the cleared registry, and build a wasm plate into a session
+    // nothing is left to free (see `session-registry.ts`).
+    const session = acquireSession(
+      sessionsRef.current, storey, sessionRef.current, disposedRef.current,
+      depsRef.current.createSession,
+    );
+    if (!session) return null;
+    sessionRef.current = session;
+    const { rooms } = session.buildFromRects(
+      flattenWallRects(rects.map((r) => r.corners)), snapTol, CORNER_WELD_SPAN,
+    );
+    return rooms;
+  }, []);
+
+  const buildStoreyPlate = useCallback((storey: number, rects: WallRect[], snapTol: number): Room[] => {
+    const session = depsRef.current.createSession();
+    sessionsRef.current.set(storey, session);
+    try {
+      const { rooms } = session.buildFromRects(
+        flattenWallRects(rects.map((r) => r.corners)), snapTol, CORNER_WELD_SPAN,
+      );
+      return rooms;
+    } catch (e) {
+      // A storey that exceeds the arrangement input cap (or otherwise fails to
+      // build) must not leave a half-built draft behind. Dispose before
+      // dropping: the likely throw (the input cap) fires before the handle is
+      // assigned, but a throw from `rooms()`/`snapshot()` would leave a live
+      // one behind.
+      session.dispose();
+      sessionsRef.current.delete(storey);
+      throw e;
+    }
+  }, []);
+
+  const ensureWasm = useCallback(() => depsRef.current.ensureWasm(), []);
+
+  // Lifetime. Reset `disposedRef` on (re)mount so StrictMode's
+  // mount/cleanup/mount cycle does not leave the overlay permanently poisoned.
+  useEffect(() => {
+    const sessions = sessionsRef.current;
+    disposedRef.current = false;
+    return () => {
+      disposedRef.current = true;
+      // Free every storey's session (each owns wasm heap handles). Null the
+      // active one in the SAME cleanup: every call site reads it optionally
+      // (`sessionRef.current?.undo()`) or behind an `alive` check, so nulling
+      // here is what makes a late caller a no-op rather than a use-after-free.
+      for (const s of sessions.values()) s.dispose();
+      sessions.clear();
+      sessionRef.current = null;
+    };
+  }, []);
+
+  return { sessionsRef, sessionRef, disposedRef, buildPlate, buildStoreyPlate, ensureWasm };
+}

--- a/apps/viewer/src/components/viewer/tools/space-sketch/useSpacePlateSessions.ts
+++ b/apps/viewer/src/components/viewer/tools/space-sketch/useSpacePlateSessions.ts
@@ -123,22 +123,32 @@ export function useSpacePlateSessions(deps: PlateDeps = defaultPlateDeps): UseSp
 
   const buildStoreyPlate = useCallback((storey: number, rects: WallRect[], snapTol: number): Room[] => {
     const session = depsRef.current.createSession();
-    sessionsRef.current.set(storey, session);
+    let rooms: Room[];
     try {
-      const { rooms } = session.buildFromRects(
+      ({ rooms } = session.buildFromRects(
         flattenWallRects(rects.map((r) => r.corners)), snapTol, CORNER_WELD_SPAN,
-      );
-      return rooms;
+      ));
     } catch (e) {
       // A storey that exceeds the arrangement input cap (or otherwise fails to
-      // build) must not leave a half-built draft behind. Dispose before
-      // dropping: the likely throw (the input cap) fires before the handle is
-      // assigned, but a throw from `rooms()`/`snapshot()` would leave a live
-      // one behind.
+      // build) must not leave a half-built draft behind. Dispose the plate we
+      // just allocated — the likely throw (the input cap) fires before the
+      // handle is assigned, but a throw from `rooms()`/`snapshot()` would leave
+      // a live one behind — and leave the REGISTRY untouched, so a storey that
+      // already had a draft keeps it instead of losing it to a failed rebuild.
       session.dispose();
-      sessionsRef.current.delete(storey);
       throw e;
     }
+    // Registration happens only on success, for the same reason. Replacing a
+    // storey's plate frees the one it replaces, and re-points `sessionRef` if
+    // it was the active one — otherwise the overlay would go on editing a plate
+    // that is no longer registered and would never be disposed.
+    const prior = sessionsRef.current.get(storey);
+    sessionsRef.current.set(storey, session);
+    if (prior && prior !== session) {
+      if (sessionRef.current === prior) sessionRef.current = session;
+      prior.dispose();
+    }
+    return rooms;
   }, []);
 
   const ensureWasm = useCallback(() => depsRef.current.ensureWasm(), []);
@@ -154,7 +164,13 @@ export function useSpacePlateSessions(deps: PlateDeps = defaultPlateDeps): UseSp
       // active one in the SAME cleanup: every call site reads it optionally
       // (`sessionRef.current?.undo()`) or behind an `alive` check, so nulling
       // here is what makes a late caller a no-op rather than a use-after-free.
+      const active = sessionRef.current;
       for (const s of sessions.values()) s.dispose();
+      // `acquireSession`'s storey-less path hands back a session it never
+      // registers, so disposing only the map's values would leak that one's
+      // handles. `dispose()` is idempotent (every `free()` is optional-chained
+      // and the field nulled), so a session that IS registered costs a no-op.
+      active?.dispose();
       sessions.clear();
       sessionRef.current = null;
     };

--- a/apps/viewer/src/components/viewer/tools/space-sketch/useSpaceSketchKeys.test.tsx
+++ b/apps/viewer/src/components/viewer/tools/space-sketch/useSpaceSketchKeys.test.tsx
@@ -1,0 +1,235 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Space Sketch keyboard ownership (#2438).
+ *
+ * The mechanism these pin is a single `true` argument. `useKeyboardShortcuts`
+ * registers a window `keydown` listener in the BUBBLE phase; the sketch
+ * registers in CAPTURE, so it runs first, and Escape additionally calls
+ * `stopImmediatePropagation()`. Drop the capture flag or the
+ * stopImmediatePropagation and:
+ *
+ * - the first Escape reaches the global handler, which closes the tool — every
+ *   drafted room on every storey is discarded without a confirm;
+ * - Ctrl+Z undoes the 3D model's last mutation instead of the sketch's last
+ *   plate edit, so the panel's own Undo button and the shortcut disagree.
+ *
+ * Neither has a visible symptom in source review, so each test below asserts
+ * through a BUBBLE-phase spy standing in for the global handler: the spy firing
+ * IS the regression.
+ */
+
+import '@/test/setup-dom.js';
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { useSpaceSketchKeys, DOUBLE_ESC_MS, type UseSpaceSketchKeysOptions } from './useSpaceSketchKeys.js';
+
+interface Calls {
+  undo: number;
+  redo: number;
+  closePopovers: number;
+  abortCurrentOp: number;
+  closeNow: number;
+  commitDraw: number;
+  modifiers: string[];
+  status: string[];
+}
+
+let calls: Calls;
+let root: Root | null = null;
+let container: HTMLElement | null = null;
+/** Stands in for `useKeyboardShortcuts`: a BUBBLE-phase window listener. */
+let globalSpy: KeyboardEvent[] = [];
+let onGlobal: ((e: KeyboardEvent) => void) | null = null;
+
+function options(over: Partial<UseSpaceSketchKeysOptions> = {}): UseSpaceSketchKeysOptions {
+  return {
+    undo: () => { calls.undo++; },
+    redo: () => { calls.redo++; },
+    closePopovers: () => { calls.closePopovers++; return false; },
+    abortCurrentOp: () => { calls.abortCurrentOp++; return false; },
+    closeNow: () => { calls.closeNow++; },
+    needsConfirm: false,
+    setStatus: (s) => { calls.status.push(s); },
+    commitDraw: null,
+    onModifiers: (e) => { calls.modifiers.push(e.key); },
+    ...over,
+  };
+}
+
+function Harness(props: { opts: UseSpaceSketchKeysOptions }) {
+  useSpaceSketchKeys(props.opts);
+  return null;
+}
+
+function mount(opts: UseSpaceSketchKeysOptions): void {
+  act(() => { root!.render(<Harness opts={opts} />); });
+}
+
+/** Dispatch a real key at `document.body`, so it propagates window→target→window. */
+function press(key: string, init: KeyboardEventInit = {}): KeyboardEvent {
+  const ev = new window.KeyboardEvent('keydown', { key, bubbles: true, cancelable: true, ...init });
+  act(() => { document.body.dispatchEvent(ev); });
+  return ev;
+}
+
+function release(key: string, init: KeyboardEventInit = {}): void {
+  act(() => {
+    document.body.dispatchEvent(new window.KeyboardEvent('keyup', { key, bubbles: true, cancelable: true, ...init }));
+  });
+}
+
+beforeEach(() => {
+  calls = { undo: 0, redo: 0, closePopovers: 0, abortCurrentOp: 0, closeNow: 0, commitDraw: 0, modifiers: [], status: [] };
+  globalSpy = [];
+  onGlobal = (e: KeyboardEvent) => { globalSpy.push(e); };
+  window.addEventListener('keydown', onGlobal); // bubble, like the real one
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  if (onGlobal) window.removeEventListener('keydown', onGlobal);
+  onGlobal = null;
+  if (root) act(() => root!.unmount());
+  root = null;
+  container?.remove();
+});
+
+describe('useSpaceSketchKeys — Escape ownership', () => {
+  it('takes the first Escape away from the global handler and does not close', () => {
+    mount(options());
+    press('Escape');
+    assert.equal(globalSpy.length, 0, 'the global keydown handler must never see Escape');
+    assert.equal(calls.closeNow, 0, 'a single Escape does not close the tool');
+    assert.equal(calls.abortCurrentOp, 1, 'it offers itself to the in-progress op first');
+    assert.deepEqual(calls.status, ['Press Esc again to close.']);
+  });
+
+  it('closes on a second Escape within the double-tap window', () => {
+    mount(options());
+    press('Escape');
+    press('Escape');
+    assert.equal(calls.closeNow, 1, 'the second Escape closes');
+    assert.equal(globalSpy.length, 0, 'and neither one leaked to the global handler');
+  });
+
+  it('does not close when the second Escape lands after the window', async () => {
+    mount(options());
+    press('Escape');
+    await act(async () => { await new Promise((r) => setTimeout(r, DOUBLE_ESC_MS + 60)); });
+    press('Escape');
+    assert.equal(calls.closeNow, 0, 'a late second Escape re-arms instead of closing');
+    assert.equal(calls.status.length, 2);
+  });
+
+  it('spends Escape on an open popover, and re-arms the double-tap from scratch', () => {
+    mount(options({ closePopovers: () => { calls.closePopovers++; return true; } }));
+    press('Escape');
+    assert.equal(calls.closePopovers, 1);
+    assert.equal(calls.abortCurrentOp, 0, 'the popover consumed it before the op');
+    assert.equal(calls.closeNow, 0);
+  });
+
+  it('spends Escape on the in-progress op, and that Escape does not count towards closing', () => {
+    mount(options({ abortCurrentOp: () => { calls.abortCurrentOp++; return true; } }));
+    press('Escape'); // aborts the draw
+    press('Escape'); // must NOT close: the abort reset the double-tap clock
+    assert.equal(calls.closeNow, 0, 'aborting an op must not arm the close');
+    assert.equal(calls.abortCurrentOp, 2);
+  });
+
+  it('warns about unconfirmed drafts rather than closing silently', () => {
+    mount(options({ needsConfirm: true }));
+    press('Escape');
+    assert.match(calls.status[0], /without creating/);
+  });
+});
+
+describe('useSpaceSketchKeys — Ctrl/Cmd+Z ownership', () => {
+  it('takes Ctrl+Z away from the global model-undo handler', () => {
+    mount(options());
+    press('z', { ctrlKey: true });
+    assert.equal(calls.undo, 1, 'the sketch history handles it');
+    assert.equal(globalSpy.length, 0, 'the model mutation stack never sees it');
+  });
+
+  it('routes Ctrl+Shift+Z to redo', () => {
+    mount(options());
+    press('z', { ctrlKey: true, shiftKey: true });
+    assert.equal(calls.redo, 1);
+    assert.equal(calls.undo, 0);
+  });
+
+  it('leaves a bare z alone', () => {
+    mount(options());
+    press('z');
+    assert.equal(calls.undo, 0);
+    assert.equal(globalSpy.length, 1, 'an unclaimed key still reaches the app');
+  });
+
+  it('leaves native field undo alone while typing', () => {
+    mount(options());
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    const ev = new window.KeyboardEvent('keydown', { key: 'z', ctrlKey: true, bubbles: true, cancelable: true });
+    act(() => { input.dispatchEvent(ev); });
+    assert.equal(calls.undo, 0, 'the sketch does not steal undo from a text field');
+    assert.equal(ev.defaultPrevented, false);
+    input.remove();
+  });
+});
+
+describe('useSpaceSketchKeys — Enter and modifiers', () => {
+  it('closes the drawn room on Enter, and keeps Enter from the app', () => {
+    mount(options({ commitDraw: () => { calls.commitDraw++; } }));
+    press('Enter');
+    assert.equal(calls.commitDraw, 1);
+    assert.equal(globalSpy.length, 0);
+  });
+
+  it('leaves Enter alone when no draw is in progress', () => {
+    mount(options());
+    press('Enter');
+    assert.equal(calls.commitDraw, 0);
+    assert.equal(globalSpy.length, 1, 'Enter belongs to the app when nothing is drawn');
+  });
+
+  it('leaves Enter alone inside a text field even mid-draw', () => {
+    mount(options({ commitDraw: () => { calls.commitDraw++; } }));
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    act(() => {
+      input.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }));
+    });
+    assert.equal(calls.commitDraw, 0);
+    input.remove();
+  });
+
+  it('repaints the hover preview on modifier down AND up, and on nothing else', () => {
+    mount(options());
+    press('Alt');
+    release('Alt');
+    press('Shift');
+    press('a');
+    assert.deepEqual(calls.modifiers, ['Alt', 'Alt', 'Shift'],
+      'only modifier keys repaint, and a release repaints too');
+  });
+
+  it('detaches every listener on unmount', () => {
+    mount(options());
+    act(() => { root!.unmount(); });
+    root = null;
+    press('Escape');
+    press('z', { ctrlKey: true });
+    press('Alt');
+    assert.equal(calls.closeNow + calls.undo + calls.abortCurrentOp + calls.modifiers.length, 0,
+      'a closed tool listens for nothing');
+    assert.equal(globalSpy.length, 3, 'and every key is handed back to the app');
+  });
+});

--- a/apps/viewer/src/components/viewer/tools/space-sketch/useSpaceSketchKeys.ts
+++ b/apps/viewer/src/components/viewer/tools/space-sketch/useSpaceSketchKeys.ts
@@ -1,0 +1,130 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Keyboard ownership for the Space Sketch overlay.
+ *
+ * While the panel is open, three keys belong to the sketch rather than to the
+ * app: Ctrl/Cmd+Z, Escape, and Enter. The global handler in
+ * `useKeyboardShortcuts` registers `keydown` in the BUBBLE phase; all three
+ * listeners here register with the capture flag, and Escape additionally calls
+ * `stopImmediatePropagation()`. That is the whole mechanism:
+ *
+ * - without capture, Ctrl+Z would undo the 3D model's mutation stack instead of
+ *   the sketch's plate history;
+ * - without capture + `stopImmediatePropagation`, the first Escape would close
+ *   the tool through the global handler and throw away every draft, instead of
+ *   aborting the in-progress operation.
+ *
+ * Dropping the third `addEventListener` argument is a one-character regression
+ * with no visible symptom until a user loses work, which is why this lives in
+ * one place with `useSpaceSketchKeys.test.tsx` pinned to it.
+ *
+ * The modifier listener is deliberately NOT capture: it only repaints the hover
+ * preview and must not shadow anything.
+ */
+
+import { useCallback, useEffect, useRef } from 'react';
+import { eventKey, isTextEntryTarget } from '@/lib/keyboard-event';
+
+/** Two Escapes within this window close the panel. */
+export const DOUBLE_ESC_MS = 400;
+
+export interface UseSpaceSketchKeysOptions {
+  undo: () => void;
+  redo: () => void;
+  /** Close any open disclosure popover. Returns true if one was open. */
+  closePopovers: () => boolean;
+  /** Abort the in-progress op (rect / draw / cut / drag). Returns true if it did. */
+  abortCurrentOp: () => boolean;
+  /** Leave the tool without creating anything. */
+  closeNow: () => void;
+  /** There are unconfirmed drafts, so the double-tap prompt says so. */
+  needsConfirm: boolean;
+  setStatus: (status: string) => void;
+  /** Close the drawn room on Enter; null when no draw is in progress. */
+  commitDraw: (() => void) | null;
+  /** A modifier key went down or up — repaint the hover preview in place. */
+  onModifiers: (e: KeyboardEvent) => void;
+}
+
+export function useSpaceSketchKeys({
+  undo,
+  redo,
+  closePopovers,
+  abortCurrentOp,
+  closeNow,
+  needsConfirm,
+  setStatus,
+  commitDraw,
+  onModifiers,
+}: UseSpaceSketchKeysOptions): void {
+  // Timestamp of the last bare Esc — a second within DOUBLE_ESC_MS closes.
+  const escTimeRef = useRef(0);
+
+  // Ctrl/Cmd+Z (Shift = redo) must drive THIS overlay's history, not the 3D
+  // model behind the panel. The global handler routes Ctrl+Z to the active
+  // model's mutation stack; a capture-phase listener here runs before it and
+  // stopPropagation()s, so the sketch and the in-panel Undo/Redo buttons share
+  // one history. Skip when a text input is focused so native field undo (and
+  // the global handler, which also skips inputs) is untouched. The overlay only
+  // mounts while the tool is active, so this listener's lifetime is exactly the
+  // tool's.
+  useEffect(() => {
+    const onUndoRedo = (e: KeyboardEvent) => {
+      if (eventKey(e) !== 'z' || !(e.ctrlKey || e.metaKey)) return;
+      if (isTextEntryTarget(e)) return;
+      e.preventDefault();
+      e.stopPropagation();
+      if (e.shiftKey) redo(); else undo();
+    };
+    window.addEventListener('keydown', onUndoRedo, true);
+    return () => window.removeEventListener('keydown', onUndoRedo, true);
+  }, [undo, redo]);
+
+  // Esc: close a popover → abort the current op → (double-tap) close, with an
+  // unconfirmed-drafts prompt. Enter closes a drawn room.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        e.stopImmediatePropagation(); // own Esc; don't let the global handler close us
+        if (closePopovers()) return;
+        const now = Date.now();
+        if (abortCurrentOp()) { escTimeRef.current = 0; return; }
+        // Double-tap Esc cancels (close without creating); the Confirm button is
+        // the only create path.
+        if (now - escTimeRef.current <= DOUBLE_ESC_MS) { escTimeRef.current = 0; closeNow(); }
+        else {
+          escTimeRef.current = now;
+          setStatus(needsConfirm
+            ? 'Esc again to close without creating (use Confirm to create).'
+            : 'Press Esc again to close.');
+        }
+      } else if (e.key === 'Enter' && commitDraw && !isTextEntryTarget(e)) {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        commitDraw();
+      }
+    };
+    window.addEventListener('keydown', onKey, true);
+    return () => window.removeEventListener('keydown', onKey, true);
+  }, [abortCurrentOp, closePopovers, closeNow, commitDraw, needsConfirm, setStatus]);
+
+  // Pressing/releasing a modifier re-evaluates the hover preview at the current
+  // cursor (so the action label + cues flip the instant you hold ⌥/Ctrl/Shift,
+  // without having to move). Bubble phase: it shadows nothing.
+  const onMod = useCallback((e: KeyboardEvent) => {
+    if (e.key !== 'Alt' && e.key !== 'Control' && e.key !== 'Meta' && e.key !== 'Shift') return;
+    onModifiers(e);
+  }, [onModifiers]);
+  useEffect(() => {
+    window.addEventListener('keydown', onMod);
+    window.addEventListener('keyup', onMod);
+    return () => {
+      window.removeEventListener('keydown', onMod);
+      window.removeEventListener('keyup', onMod);
+    };
+  }, [onMod]);
+}

--- a/apps/viewer/src/components/viewer/tools/space-sketch/useSpaceViewport.test.tsx
+++ b/apps/viewer/src/components/viewer/tools/space-sketch/useSpaceViewport.test.tsx
@@ -32,11 +32,16 @@ let api: UseSpaceViewport | null = null;
 /** Every `fitTick` React rendered with, in order. */
 let ticks: number[] = [];
 
-function Harness() {
+/**
+ * Mirrors the overlay: the canvas is UNMOUNTED while minimized (the overlay
+ * returns a reopen pill instead), and `attachSvg` — not `svgRef` — is what the
+ * canvas gets as its ref.
+ */
+function Harness({ minimized = false }: { minimized?: boolean }) {
   api = useSpaceViewport();
   ticks.push(api.fitTick);
-  // A real <svg> so the non-passive wheel listener has something to attach to.
-  return <svg ref={api.svgRef} width={api.size.w} height={api.size.h} />;
+  if (minimized) return <button type="button">reopen</button>;
+  return <svg ref={api.attachSvg} width={api.size.w} height={api.size.h} />;
 }
 
 /** The tick React last rendered with. */
@@ -150,6 +155,35 @@ describe('useSpaceViewport — every transform write bumps the tick', () => {
       api!.resizeHandlers.onPointerMove({ clientX: -5000, clientY: -5000 } as unknown as React.PointerEvent);
     });
     assert.ok(api!.size.w >= 320 && api!.size.h >= 240, `got ${api!.size.w}x${api!.size.h}`);
+  });
+
+  it('still zooms after the canvas is unmounted and remounted (minimize → reopen)', () => {
+    // The overlay swaps the whole canvas for a reopen pill while minimized, so
+    // reopening mounts a NEW <svg>. An effect that reads `svgRef.current` with a
+    // stable dependency list binds once, to the first element, and never
+    // re-binds — leaving wheel zoom silently dead and the page scrolling under
+    // the panel. Nothing else about the reopened panel looks wrong, which is
+    // why this needs a test rather than a glance.
+    const wheelAt = () => {
+      const svg = container!.querySelector('svg')!;
+      const before = { ...api!.fitRef.current };
+      const ev = new window.WheelEvent('wheel', { deltaY: -240, bubbles: true, cancelable: true });
+      act(() => { svg.dispatchEvent(ev); });
+      return { prevented: ev.defaultPrevented, zoomed: api!.fitRef.current.scale !== before.scale };
+    };
+
+    act(() => { root!.render(<Harness />); });
+    act(() => { api!.fitToPoints(PLAN); });
+    const first = wheelAt();
+    assert.deepEqual(first, { prevented: true, zoomed: true }, 'sanity: it works before minimizing');
+
+    act(() => { root!.render(<Harness minimized />); });
+    assert.equal(container!.querySelector('svg'), null, 'the canvas really is unmounted');
+    act(() => { root!.render(<Harness />); });
+
+    const second = wheelAt();
+    assert.equal(second.prevented, true, 'the reopened canvas must still swallow the page scroll');
+    assert.equal(second.zoomed, true, 'and must still zoom');
   });
 
   it('detaches the wheel listener on unmount', () => {

--- a/apps/viewer/src/components/viewer/tools/space-sketch/useSpaceViewport.test.tsx
+++ b/apps/viewer/src/components/viewer/tools/space-sketch/useSpaceViewport.test.tsx
@@ -1,0 +1,163 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The Space Sketch viewport invariant (#2438): EVERY write to `fitRef` bumps
+ * `fitTick`.
+ *
+ * `fitRef` has to be a ref — it is read synchronously many times per pointer
+ * event — but the overlay's building underlay is a memo that reads
+ * `fitRef.current` while depending on `fitTick`. A write that skips the tick
+ * therefore leaves hundreds of pre-rendered wall lines frozen at the old
+ * transform while the rooms move under them, which reads as the plan tearing
+ * apart rather than as a missing re-render.
+ *
+ * Before the split three call sites wrote `fitRef` and two open-coded the tick
+ * bump, so the invariant held by duplication. These tests exercise all three
+ * ways the transform can move — fit, pan, wheel — and assert the tick each time.
+ */
+
+import '@/test/setup-dom.js';
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import type { Pt } from '@/lib/space-sketch-geometry.js';
+import { useSpaceViewport, type UseSpaceViewport } from './useSpaceViewport.js';
+
+let root: Root | null = null;
+let container: HTMLElement | null = null;
+let api: UseSpaceViewport | null = null;
+/** Every `fitTick` React rendered with, in order. */
+let ticks: number[] = [];
+
+function Harness() {
+  api = useSpaceViewport();
+  ticks.push(api.fitTick);
+  // A real <svg> so the non-passive wheel listener has something to attach to.
+  return <svg ref={api.svgRef} width={api.size.w} height={api.size.h} />;
+}
+
+/** The tick React last rendered with. */
+const tick = () => ticks[ticks.length - 1];
+
+const PLAN: Pt[] = [[0, 0], [12, 0], [12, 8], [0, 8]];
+
+beforeEach(() => {
+  ticks = [];
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => { root!.render(<Harness />); });
+});
+
+afterEach(() => {
+  if (root) act(() => root!.unmount());
+  root = null;
+  container?.remove();
+});
+
+describe('useSpaceViewport — every transform write bumps the tick', () => {
+  it('fitToPoints reframes and bumps', () => {
+    const before = { ...api!.fitRef.current };
+    const t0 = tick();
+    act(() => { api!.fitToPoints(PLAN); });
+    assert.notDeepEqual(api!.fitRef.current, before, 'the transform actually moved');
+    assert.ok(tick() > t0, 'and the underlay memo was invalidated');
+  });
+
+  it('panBy translates and bumps, leaving the scale alone', () => {
+    act(() => { api!.fitToPoints(PLAN); });
+    const before = { ...api!.fitRef.current };
+    const t0 = tick();
+    act(() => { api!.panBy(17, -9); });
+    assert.equal(api!.fitRef.current.scale, before.scale, 'panning does not zoom');
+    assert.equal(api!.fitRef.current.offX, before.offX + 17);
+    assert.equal(api!.fitRef.current.offY, before.offY - 9);
+    assert.ok(tick() > t0);
+  });
+
+  it('a wheel notch zooms, bumps, and cancels the page scroll', () => {
+    act(() => { api!.fitToPoints(PLAN); });
+    const before = { ...api!.fitRef.current };
+    const t0 = tick();
+    const svg = container!.querySelector('svg')!;
+    const ev = new window.WheelEvent('wheel', { deltaY: -120, bubbles: true, cancelable: true });
+    act(() => { svg.dispatchEvent(ev); });
+    assert.ok(api!.fitRef.current.scale > before.scale, 'scroll up zooms in');
+    assert.ok(tick() > t0);
+    // NB this pins the preventDefault call, not the `passive: false` flag —
+    // happy-dom honours preventDefault either way, so the flag itself is only
+    // checkable in a real browser. Both are needed: without the flag the
+    // browser ignores the call and the page scrolls under the panel.
+    assert.equal(ev.defaultPrevented, true, 'the wheel gesture is consumed, not passed to the page');
+  });
+
+  it('a refused wheel notch moves nothing at all', () => {
+    // Past the zoom limit the gesture is dropped rather than scale-clamped: a
+    // clamped scale with the offset still applied would drift the plan sideways.
+    act(() => { api!.fitToPoints(PLAN); });
+    const svg = container!.querySelector('svg')!;
+    // Drive it hard against the far-out bound first.
+    for (let i = 0; i < 60; i++) {
+      act(() => { svg.dispatchEvent(new window.WheelEvent('wheel', { deltaY: 2000, bubbles: true, cancelable: true })); });
+    }
+    const parked = { ...api!.fitRef.current };
+    act(() => { svg.dispatchEvent(new window.WheelEvent('wheel', { deltaY: 2000, bubbles: true, cancelable: true })); });
+    assert.deepEqual(api!.fitRef.current, parked, 'a refused zoom leaves the transform byte-identical');
+  });
+
+  it('svgPoint clamps to the canvas the hook currently reports', () => {
+    const { w, h } = api!.size;
+    const svg = container!.querySelector('svg')! as unknown as { getBoundingClientRect: () => DOMRect };
+    svg.getBoundingClientRect = () => ({ left: 100, top: 50 }) as DOMRect;
+    assert.deepEqual(api!.svgPoint({ clientX: 100 + w + 500, clientY: 50 + h + 500 }), [w, h]);
+    assert.deepEqual(api!.svgPoint({ clientX: 0, clientY: 0 }), [0, 0]);
+    assert.deepEqual(api!.svgPoint({ clientX: 140, clientY: 90 }), [40, 40]);
+  });
+
+  it('a resize reaches a svgPoint that was bound before it', () => {
+    // `svgPoint` is stable across renders, and the overlay's `onPointerMove` is
+    // memoised on it — so React can dispatch a pointer event into a handler
+    // captured several renders ago. Read the size through a closure instead of
+    // the ref and that captured handler clamps to a canvas that no longer
+    // exists, which is how a drag past the edge escapes the clamp entirely.
+    const { w, h } = api!.size;
+    const boundBeforeResize = api!.svgPoint;
+    const grip = { setPointerCapture() {}, releasePointerCapture() {} };
+    const down = { clientX: 0, clientY: 0, pointerId: 1, currentTarget: grip, preventDefault() {}, stopPropagation() {} };
+    act(() => { api!.resizeHandlers.onPointerDown(down as unknown as React.PointerEvent); });
+    act(() => {
+      api!.resizeHandlers.onPointerMove({ clientX: 60, clientY: 40 } as unknown as React.PointerEvent);
+    });
+    assert.deepEqual(api!.size, { w: w + 60, h: h + 40 });
+    const svg = container!.querySelector('svg')! as unknown as { getBoundingClientRect: () => DOMRect };
+    svg.getBoundingClientRect = () => ({ left: 0, top: 0 }) as DOMRect;
+    assert.equal(api!.svgPoint, boundBeforeResize, 'svgPoint must stay referentially stable');
+    assert.deepEqual(boundBeforeResize({ clientX: 99_999, clientY: 99_999 }), [w + 60, h + 40],
+      'the pre-resize handler clamps to the new canvas');
+  });
+
+  it('will not shrink below the minimum usable canvas', () => {
+    const grip = { setPointerCapture() {}, releasePointerCapture() {} };
+    act(() => {
+      api!.resizeHandlers.onPointerDown(
+        { clientX: 0, clientY: 0, pointerId: 1, currentTarget: grip, preventDefault() {}, stopPropagation() {} } as unknown as React.PointerEvent,
+      );
+    });
+    act(() => {
+      api!.resizeHandlers.onPointerMove({ clientX: -5000, clientY: -5000 } as unknown as React.PointerEvent);
+    });
+    assert.ok(api!.size.w >= 320 && api!.size.h >= 240, `got ${api!.size.w}x${api!.size.h}`);
+  });
+
+  it('detaches the wheel listener on unmount', () => {
+    const svg = container!.querySelector('svg')!;
+    act(() => { root!.unmount(); });
+    root = null;
+    const ev = new window.WheelEvent('wheel', { deltaY: -120, bubbles: true, cancelable: true });
+    svg.dispatchEvent(ev);
+    assert.equal(ev.defaultPrevented, false, 'a closed panel no longer swallows the page scroll');
+  });
+});

--- a/apps/viewer/src/components/viewer/tools/space-sketch/useSpaceViewport.ts
+++ b/apps/viewer/src/components/viewer/tools/space-sketch/useSpaceViewport.ts
@@ -1,0 +1,125 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The Space Sketch canvas viewport: panel size, the world↔screen transform, and
+ * every gesture that moves it (fit, wheel zoom, drag pan, resize grip).
+ *
+ * Split out of `SpaceSketchOverlay.tsx` because the transform has an invariant
+ * the overlay was upholding by duplication rather than by structure. `fitRef` is
+ * a ref — it is read synchronously ~10 times per pointer event as
+ * `PICK_PX / fitRef.current.scale`, so it cannot be React state — but the
+ * underlay memo reads `fitRef.current` while depending on `fitTick`, so EVERY
+ * write must bump that tick or the pre-rendered building lines freeze at the
+ * old transform while the rooms move. Three call sites wrote `fitRef` and two
+ * open-coded the bump instead of going through `applyFit`. Here there is one
+ * writer, and no way to add a second from outside.
+ *
+ * `sizeRef` mirrors `size` with a render-phase write on purpose: `svgPoint`'s
+ * clamp and the fit computations read it synchronously, and syncing it in an
+ * effect instead would make the first pointer event after a resize use the
+ * stale size.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { computeFitFromPoints, PAD, type Fit, type Pt } from '@/lib/space-sketch-geometry';
+import { clampToCanvas, zoomStep } from './space-viewport';
+
+const DEFAULT_W = 420;
+const DEFAULT_H = 340;
+const MIN_W = 320;
+const MIN_H = 240;
+
+export interface UseSpaceViewport {
+  svgRef: React.RefObject<SVGSVGElement | null>;
+  /** The live transform. Read synchronously; never write it directly. */
+  fitRef: React.RefObject<Fit>;
+  /** Bumped by every transform write, so memos keyed on it re-render. */
+  fitTick: number;
+  size: { w: number; h: number };
+  /**
+   * Frame `pts` in the current canvas. Along with {@link panBy} and the wheel
+   * listener, one of exactly three ways the transform can move — `applyFit`
+   * itself stays private so no caller can write `fitRef` without the tick.
+   */
+  fitToPoints: (pts: Pt[]) => void;
+  /** Translate the view by a raw pointer delta (drag pan). */
+  panBy: (dx: number, dy: number) => void;
+  /** A mouse event's position in canvas pixels, clamped to the canvas. */
+  svgPoint: (e: { clientX: number; clientY: number }) => Pt;
+  /** Handlers for the corner resize grip. */
+  resizeHandlers: {
+    onPointerDown: (e: React.PointerEvent) => void;
+    onPointerMove: (e: React.PointerEvent) => void;
+    onPointerUp: (e: React.PointerEvent) => void;
+  };
+}
+
+export function useSpaceViewport(): UseSpaceViewport {
+  const svgRef = useRef<SVGSVGElement | null>(null);
+  const fitRef = useRef<Fit>({ scale: 1, offX: PAD, offY: DEFAULT_H - PAD });
+  const [fitTick, setFitTick] = useState(0);
+  const [size, setSize] = useState({ w: DEFAULT_W, h: DEFAULT_H });
+  const sizeRef = useRef(size);
+  sizeRef.current = size;
+  const resizeRef = useRef<{ x: number; y: number; w: number; h: number } | null>(null);
+
+  const applyFit = useCallback((next: Fit) => {
+    fitRef.current = next;
+    setFitTick((t) => t + 1);
+  }, []);
+
+  const fitToPoints = useCallback((pts: Pt[]) => {
+    applyFit(computeFitFromPoints(pts, sizeRef.current.w, sizeRef.current.h));
+  }, [applyFit]);
+
+  const panBy = useCallback((dx: number, dy: number) => {
+    const f = fitRef.current;
+    applyFit({ scale: f.scale, offX: f.offX + dx, offY: f.offY + dy });
+  }, [applyFit]);
+
+  const svgPoint = useCallback((e: { clientX: number; clientY: number }): Pt => {
+    const rect = svgRef.current!.getBoundingClientRect();
+    return clampToCanvas(e.clientX - rect.left, e.clientY - rect.top, sizeRef.current.w, sizeRef.current.h);
+  }, []);
+
+  // Wheel = zoom about the cursor. A native NON-PASSIVE listener so
+  // preventDefault() actually stops the page from scrolling under the panel;
+  // React's synthetic onWheel is passive and cannot.
+  useEffect(() => {
+    const el = svgRef.current;
+    if (!el) return;
+    const onWheel = (e: WheelEvent) => {
+      e.preventDefault();
+      const rect = el.getBoundingClientRect();
+      const next = zoomStep(fitRef.current, e.deltaY, e.clientX - rect.left, e.clientY - rect.top);
+      if (next) applyFit(next);
+    };
+    el.addEventListener('wheel', onWheel, { passive: false });
+    return () => el.removeEventListener('wheel', onWheel);
+  }, [applyFit]);
+
+  const resizeHandlers = {
+    onPointerDown: useCallback((e: React.PointerEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      resizeRef.current = { x: e.clientX, y: e.clientY, w: sizeRef.current.w, h: sizeRef.current.h };
+      (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+    }, []),
+    onPointerMove: useCallback((e: React.PointerEvent) => {
+      const r = resizeRef.current;
+      if (!r) return;
+      setSize({
+        w: Math.max(MIN_W, Math.round(r.w + (e.clientX - r.x))),
+        h: Math.max(MIN_H, Math.round(r.h + (e.clientY - r.y))),
+      });
+    }, []),
+    onPointerUp: useCallback((e: React.PointerEvent) => {
+      resizeRef.current = null;
+      (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
+    }, []),
+  };
+
+  return { svgRef, fitRef, fitTick, size, fitToPoints, panBy, svgPoint, resizeHandlers };
+}

--- a/apps/viewer/src/components/viewer/tools/space-sketch/useSpaceViewport.ts
+++ b/apps/viewer/src/components/viewer/tools/space-sketch/useSpaceViewport.ts
@@ -16,10 +16,19 @@
  * open-coded the bump instead of going through `applyFit`. Here there is one
  * writer, and no way to add a second from outside.
  *
- * `sizeRef` mirrors `size` with a render-phase write on purpose: `svgPoint`'s
- * clamp and the fit computations read it synchronously, and syncing it in an
- * effect instead would make the first pointer event after a resize use the
- * stale size.
+ * `sizeRef` mirrors `size` with a render-phase write. That is a deliberate
+ * carry-over, not an oversight: `svgPoint`'s clamp and the fit computations read
+ * it synchronously from event handlers, and moving the sync into a PASSIVE
+ * effect would let the first pointer event after a resize use the stale size.
+ * A `useLayoutEffect` would in fact be safe here (it commits before the browser
+ * can dispatch the next input event) and would satisfy React's don't-write-refs
+ * -during-render rule — but the difference between the two is not observable
+ * from a test, because `act()` flushes passive effects too, so
+ * `useSpaceViewport.test.tsx` cannot tell them apart. Changing untestable
+ * timing inside a refactor is the trade this file exists to avoid; the write
+ * stays as it was. What IS pinned there is the property that matters: `svgPoint`
+ * is referentially stable, so a handler bound before a resize still clamps to
+ * the new canvas.
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';

--- a/apps/viewer/src/components/viewer/tools/space-sketch/useSpaceViewport.ts
+++ b/apps/viewer/src/components/viewer/tools/space-sketch/useSpaceViewport.ts
@@ -41,7 +41,14 @@ const MIN_W = 320;
 const MIN_H = 240;
 
 export interface UseSpaceViewport {
+  /** Read-only access to the live canvas (pointer capture, bounding rect). */
   svgRef: React.RefObject<SVGSVGElement | null>;
+  /**
+   * Hand this to the canvas as its `ref`, not `svgRef`. It is a callback ref so
+   * the non-passive wheel listener re-binds when the canvas is unmounted and
+   * remounted — which the minimize/reopen pill does on every use.
+   */
+  attachSvg: (el: SVGSVGElement | null) => void;
   /** The live transform. Read synchronously; never write it directly. */
   fitRef: React.RefObject<Fit>;
   /** Bumped by every transform write, so memos keyed on it re-render. */
@@ -67,6 +74,16 @@ export interface UseSpaceViewport {
 
 export function useSpaceViewport(): UseSpaceViewport {
   const svgRef = useRef<SVGSVGElement | null>(null);
+  // The canvas element as STATE as well as a ref, so the wheel effect below can
+  // depend on it. The overlay unmounts the whole canvas while minimized, and a
+  // `[]`-dependency effect reading `svgRef.current` binds once to the first SVG
+  // and never re-binds to the one that replaces it — leaving wheel zoom dead
+  // and the page scrolling under the panel, with nothing else looking wrong.
+  const [svgEl, setSvgEl] = useState<SVGSVGElement | null>(null);
+  const attachSvg = useCallback((el: SVGSVGElement | null) => {
+    svgRef.current = el;
+    setSvgEl(el);
+  }, []);
   const fitRef = useRef<Fit>({ scale: 1, offX: PAD, offY: DEFAULT_H - PAD });
   const [fitTick, setFitTick] = useState(0);
   const [size, setSize] = useState({ w: DEFAULT_W, h: DEFAULT_H });
@@ -97,17 +114,16 @@ export function useSpaceViewport(): UseSpaceViewport {
   // preventDefault() actually stops the page from scrolling under the panel;
   // React's synthetic onWheel is passive and cannot.
   useEffect(() => {
-    const el = svgRef.current;
-    if (!el) return;
+    if (!svgEl) return;
     const onWheel = (e: WheelEvent) => {
       e.preventDefault();
-      const rect = el.getBoundingClientRect();
+      const rect = svgEl.getBoundingClientRect();
       const next = zoomStep(fitRef.current, e.deltaY, e.clientX - rect.left, e.clientY - rect.top);
       if (next) applyFit(next);
     };
-    el.addEventListener('wheel', onWheel, { passive: false });
-    return () => el.removeEventListener('wheel', onWheel);
-  }, [applyFit]);
+    svgEl.addEventListener('wheel', onWheel, { passive: false });
+    return () => svgEl.removeEventListener('wheel', onWheel);
+  }, [svgEl, applyFit]);
 
   const resizeHandlers = {
     onPointerDown: useCallback((e: React.PointerEvent) => {
@@ -130,5 +146,5 @@ export function useSpaceViewport(): UseSpaceViewport {
     }, []),
   };
 
-  return { svgRef, fitRef, fitTick, size, fitToPoints, panBy, svgPoint, resizeHandlers };
+  return { svgRef, attachSvg, fitRef, fitTick, size, fitToPoints, panBy, svgPoint, resizeHandlers };
 }


### PR DESCRIPTION
Fixes #2438.

`SpaceSketchOverlay.tsx` was **1710 lines** with all 32 `useState`/`useRef` in one contiguous block. As the measurement on the issue established, the regions that look easiest to extract are exactly the ones that own no state, and moving them lands the file near 1200 — 8% of the file, 0% of the issue. So this takes the cuts that **carry state out with them**.

## Say it plainly: the file lands at 1510, not 400

1710 → **1510** (-200). Counting the four new hooks and their two pure cores, the space-sketch code goes from 1710 lines in one file to 1510 + 760 across seven modules. The guideline is not met and cannot be met by this shape of change: a 1700-line interactive editor with one pointer-event ladder, one plate, and one canvas does not decompose into 400-line pieces without inventing seams that do not exist. What it can have is seams that are real subjects with their own failure stories. That is what these are.

## The seams

| module | lines | what moved | state it took |
|---|---|---|---|
| `useSpacePlateSessions.ts` | 180 | per-storey wasm plates, their lifetime, the async build | `sessionsRef`, `sessionRef`, `disposedRef`, `buildSeqRef` |
| `useSpaceViewport.ts` | 144 | panel size, world↔screen transform, fit/zoom/pan/resize | `size`, `sizeRef`, `fitRef`, `fitTick`, `resizeRef` |
| `useSpaceSketchKeys.ts` | 130 | Ctrl/Cmd+Z, Escape, Enter, modifier repaint | `escTimeRef` |
| `useSpaceBake.ts` | 164 | confirm-on-close: emit every storey's draft as IfcSpace | `generatedRef` |
| `space-bake.ts` | 97 | pure: dedup, floor-to-floor, which outline carries the area | — |
| `space-viewport.ts` | 45 | pure: the canvas clamp, the zoom step | — |

Each one exists because of a defect that already happened:

**`useSpacePlateSessions`** — `SpacePlateSession` owns raw Rust-heap handles freed only through `dispose()`, and the build suspends on `ensureSpaceWasm()`, so unmount can land in the middle of it. `session-registry.ts` decides whether a resumed build may allocate; this hook is the wiring that hands it a truthful `disposed` flag.

**`useSpaceViewport`** — `fitRef` has to stay a ref (read synchronously ~10× per pointer event as `PICK_PX / fitRef.current.scale`), but the building-underlay memo reads `fitRef.current` while depending on `fitTick`. Three call sites wrote `fitRef` and **two open-coded the tick bump** instead of going through `applyFit`, so the invariant held by duplication. There is now one writer, `applyFit` is private, and the only ways out are `fitToPoints` / `panBy` / the wheel listener.

**`useSpaceSketchKeys`** — the global handler in `useKeyboardShortcuts` registers `keydown` in the **bubble** phase; all three listeners here register with the **capture** flag and Escape calls `stopImmediatePropagation()`. That is what stops the first Escape closing the tool and discarding every drafted room. Dropping the third `addEventListener` argument is a one-character regression with no symptom until a user loses work.

**`useSpaceBake` + `space-bake.ts`** — reads the plate and never mutates it. Its failures are decisions: a room emitted on top of an authored space (duplicates in the file), a floor-to-floor taken from an unsorted storey list or a millimetre elevation, gross area measured on the emitted boundary rather than the centreline.

## Making the `buildFrom` wiring testable — the part worth more than the line count

`acquireSession` has been mutation-checked as a pure function since #1344, but **the component-level wiring around it had no executable test**: the overlay's only entry suspends on `ensureSpaceWasm()`, which rejects under the node harness, so the code that decides what `disposedRef.current` *is* at the moment `acquireSession` is called was verified by reading a three-line diff.

`useSpacePlateSessions` takes its two wasm touch points as ordinary parameters with production defaults (`defaultPlateDeps`). The overlay passes nothing and gets the real wasm. A test can now hold `ensureWasm` pending, unmount, resolve, and assert nothing was allocated — which is exactly the leak:

```
it('allocates NOTHING when the overlay unmounts while the build is suspended')
```

Mutating `disposedRef.current` → `false` at the `acquireSession` call kills that test and only that test.

## Behaviour changes (two, both fixes the split surfaced)

1. **`lastBuildRef` is recorded before the await, not after the build.** It used to be set after `ensureSpaceWasm()` resolved, so a build that *threw* (arrangement input cap, wasm load failure) left it holding the last storey that succeeded — and the corner-tolerance slider would then silently rebuild that storey instead of retrying the one that failed. Recording at call time is also strictly safer against interleaving, because the most recently requested build is the one `buildPlate` lets win.
2. **One `processMove` scheduler.** The pointer path and the modifier-repaint path each had their own `if (rafRef.current == null)` guard over the same ref. They now share `scheduleMove()`, which is what the issue's constraint (1) asked for.

Everything else is a move. `useSpaceSceneFraming` and `useSpaceGhostPreview` keep their exact relative order (framing before ghost — the X-ray-captures-its-own-X-ray bug), and the disposal cleanup still nulls `sessionRef` in the same cleanup that disposes, which is what makes every optional-chained call site a no-op rather than a use-after-free.

## Tests: +60, all new; the 3793 pre-existing viewer tests are untouched

| | before | after |
|---|---|---|
| `# tests` | 3799 | 3859 |
| `# pass` | 3793 | 3853 |
| `# fail` | 0 | 0 |
| `# skipped` | 6 | 6 |

3853 − 60 = 3793. No pre-existing test was changed, moved, or lost. No `.ts`/`.tsx` basename collision (checked). `node scripts/check-test-wiring.mjs`, `check-source-text-assertions.mjs` and `pnpm check:test-typecheck` (344/344 viewer test files in a program) all pass.

### Every new guard was mutated with the regression it exists for

| # | mutation | kills |
|---|---|---|
| 1 | `acquireSession(..., disposedRef.current → false)` | *allocates NOTHING when the overlay unmounts mid-build* |
| 2 | drop the capture flag on the Esc/Enter listener | 3 tests — Escape reaches the global handler |
| 3 | drop `stopImmediatePropagation()` on Escape | 2 tests |
| 4 | drop the capture flag on the Ctrl+Z listener | *takes Ctrl+Z away from the global model-undo handler* |
| 5 | drop the `generatedRef` removal loop | *REPLACES on a second confirm instead of duplicating the file* |
| 6 | `clampToCanvas` returns the raw point | 3 tests, incl. the browser-freeze one |
| 7 | `floorToFloorHeight` without the sanity range | zero/negative gap, millimetre elevation |
| 8 | gross area measured on the emitted boundary | *emits the BOUNDARY but measures on the CENTRELINE* |
| 9 | drop the authored-space dedup | *skips a room whose centroid sits inside an authored space* |
| 10 | `applyFit` writes `fitRef` without the tick | 3 tests — the underlay freezes |
| 13 | `svgPoint` closes over the render-time `size` | *a resize reaches a svgPoint bound before it* |
| 14 | wheel handler stops calling `preventDefault` | *a wheel notch zooms, bumps, and cancels the page scroll* |
| 15 | `>=`/`<=` on the zoom bounds become `>`/`<` | *accepts a step that lands exactly ON a bound* |
| 16 | wrong minimum-bound constant | 2 tests |
| 17 | `zoomStep` returns its input unchanged | 3 tests |

**Two mutations did NOT kill, and the tests were corrected rather than kept:**

- syncing `sizeRef` in an effect instead of during render is **not observable** under `act()`, because `act()` flushes passive effects. The test now pins what is real and does kill (mutation 13): `svgPoint` is referentially stable, so a handler bound before a resize must still clamp to the new canvas.
- `passive: false` on the wheel listener is not observable in happy-dom, which honours `preventDefault` either way. The assertion is kept — it pins the `preventDefault` call (mutation 14) — with a comment saying exactly what it does and does not cover.

## Verified by driving it, click by click

Dev server on :5199, `building-architecture.ifc`, WebGPU, Chrome DevTools.

- **Author → Space Sketch** — panel opens, storey `00 groundfloor` derives (`0 room(s), 0.0 m² · 4 walls`), the plan frames on the **walls** (the no-rooms `fitToPoints` fallback), the building underlay draws, the model X-rays.
- **Draw** — 4 clicks on the canvas + **Enter** → `Drew a room — 1 room(s).`, 9.82 m², badge `1 to confirm`, ghost mirrored into 3D.
- **Edit** — hover a corner (`Move node` telegraph), drag it → 9.8 → **11.9 m²**.
- **Undo** — `Ctrl+Z` → back to 9.8, status `Undo.`, and the ribbon's **model** Undo button is still disabled. That is the capture-phase win observed in a real browser.
- **Redo** — `Ctrl+Shift+Z` → 11.9, status `Redo.`
- **Zoom / pan** — wheel `defaultPrevented: true`; on a middle-drag pan the underlay and the room polygon translate by **exactly the same 40 px**. That is the `fitTick` invariant holding on the path that used to open-code the bump.
- **Resize grip** — 420×340 → 510×394; `svgPoint` clamps to the new canvas.
- **Rectangle tool** — mode status, rubber-band preview, two clicks → `Added a 0.91 x 0.64 m room — 2 room(s).`
- **Footprint** → one 32.5 m² room over the storey outline.
- **Right-click remove** → `Removed node — 1 room(s).`, 9 vertices → 8.
- **Split** → click a wall (`Cut from here` → `Node added…`), click another → `Split — 2 room(s).`, area conserved at 32.4 m².
- **Esc mid-draw** → `Draw cancelled.`, **panel stays open**. Bare Esc → `Esc again to close without creating (use Confirm to create).` Two Escapes within 400 ms → panel closes, drafts **discarded** (`Export Changes` stays 18, one Space in the tree).
- **Minimize → reopen pill** (`2 to confirm`) → drafts survive.
- **Confirm** → toast `Created 1 space`, `SPACE 1 / IfcSpace` selected in the inspector, spaces revealed, prior view restored.
- **Close mid-derive** — clicked *Derive all storeys* and *Close* in the same tick: clean unmount, no unhandled rejection, no error.
- **Switch tools** — Home → Measure while the panel is open: clean unmount.

A first Confirm attempt emitted **0** and I chased it before believing it: instrumentation showed `authored=1` — this sample model already has an `IfcSpace`, and my room's centroid fell inside it, so the dedup skipped it. Correct behaviour, not a regression. Redrawing outside that footprint created the space.

The only console errors across the whole session are two `NotFoundError: setPointerCapture … No active pointer with the given id`, thrown by **my synthetic `PointerEvent`s** (a dispatched event has no active pointer). A real mouse cannot produce them, and the drag they occurred in completed correctly.

## What I could not verify

- **`passive: false`** on the wheel listener, in a test. Verified by hand in Chrome (`defaultPrevented: true` and the page does not scroll under the panel); happy-dom cannot distinguish it.
- **The render-phase `sizeRef` write** as distinct from an effect, in a test — `act()` flushes both. Documented at the call site.
- **Actual wasm heap freed on close**, quantitatively. The disposal path is pinned structurally (`disposes every storey plate on unmount, exactly once`) and the mid-derive close produced no error, but I did not measure the dlmalloc arena before and after.
- **Multi-storey behaviour** beyond derive-all's happy path: the sample model has one building storey.

## Gates

Both run once, verbatim, `0 cached`:

- `npx turbo typecheck --force` — **77 successful, 77 total**, 0 cached
- `npx turbo test --force` — **86 successful, 86 total**, 0 cached

`apps/viewer` is `"private": true`, so no changeset.


## Review

`coderabbit review --committed --base origin/main`, run locally because the GitHub check on this PR literally reads **`pass` … `Review rate limited`** — the false green the process exists to catch. It is non-deterministic, so runs were taken as a union across **six completed runs**: `No findings` → `1` → `2` → `6` → `1` → `No new findings`, each ending in `Review complete`. (The hosted bot's own most valuable finding — the dead wheel listener — arrived only on GitHub, not from the CLI.)

**Every finding was triaged against `git show origin/main` before acting.** Two belong to this PR and are fixed; four are verbatim pre-existing defects and are filed, not smuggled into a refactor.

### Fixed here

1. *(minor)* the zoom-bound test could not fail — it never landed on a bound and passed even if `zoomStep` were a no-op. Rewritten as a zero-delta wheel at each limit (factor exactly 1, no float slop) plus a bisection for the accept/refuse flip, which must land on MIN/MAX to within 1e-9 relative. Mutations 15-17 are the proof; the old version survived all three.
2. *(major, wheel zoom silently dead)* minimizing unmounts the whole canvas, so reopening mounts a **new** `<svg>` — and the wheel listener was bound in an effect reading `svgRef.current` with a stable dep list, so it attached once and never re-attached. After one minimize/reopen, wheel zoom did nothing and the page scrolled under the panel. **My manual pass missed this**: I reopened the pill and checked the drafts survived, but did not think to scroll. Reproduced in Chrome before fixing (`defaultPrevented: false`, transform unchanged) and confirmed across two cycles after. The canvas now takes a callback ref that mirrors into `svgRef` for the synchronous readers and into state for the effect to depend on. Mutation 22 (revert to the bind-once form) fails the new case.
3. *(major ×2, plate lifetime)* `buildStoreyPlate` registered the new session **before** `buildFromRects` succeeded, and its failure path deleted the map entry — so a storey that already had a plate lost its draft *and* leaked the old plate. Registration now happens only on success; a successful replacement disposes what it replaces and re-points `sessionRef`. Separately, the unmount cleanup walked only the registry, so `acquireSession`'s deliberately-unregistered storey-less session was nulled away without `dispose()`. Cleanup now disposes the active session too (`dispose()` is idempotent). Neither is reachable from today's callers — `deriveAllStoreys` skips storeys that already have a session, and no caller passes a null storey — but **extracting this into a general hook method is what made them reachable**, so they are fixed rather than left as traps. Mutations 18-21, each killing only its own test.

### Filed, not fixed: #2553

Four defects in the emit half, all moved verbatim from `main` (confirmed with `git show origin/main`), all requiring a **second Confirm** to reach — which is only possible via the deliberate partial-failure path that keeps the tool open: non-atomic replacement, a now-empty draft leaving its old spaces behind, the dedup input possibly including this tool's own prior spaces, and `generatedRef` not being keyed by model. Fixing them here would have made this diff non-mechanical; they are a coherent change of their own.

4. *(minor, test hygiene)* `useSpaceBake.test.tsx` left `typeVisibility.spaces` set on the module-level store. Now restored in `afterEach` with the other two. Scope measured rather than assumed: node runs each test **file** in its own process, so it could never leak across files (a probe in a sibling file passed either way); it does leak **within** the file, where an appended probe fails without the restore. Today the reveal test happens to be last — the kind of accident that stops being true the next time a case is appended.

### Declined, with reasoning recorded in the code

*(major)* `sizeRef.current = size` is a render-phase ref write; use `useLayoutEffect`. `useLayoutEffect` would in fact be safe — it commits before the browser can dispatch the next input event — but the difference is **not observable from a test**, because `act()` flushes passive effects too. I found that out by mutating it: turning the render-phase write into a `useEffect` failed nothing, which is why the test now pins the property that *is* observable (`svgPoint` is referentially stable, so a handler bound before a resize still clamps to the new canvas). Changing untestable timing inside a refactor is the trade this split exists to avoid, and the line is a verbatim carry-over that #2438 lists as constraint (2). One-line change if a maintainer disagrees.



