### PR TITLE
fix(viewer): make the double-georeference note agree with the correction, and stop printing 6,004 km as "6.004 km" (#2526)

### DIFF
--- a/apps/viewer/src/components/viewer/properties/GeoreferencingPanel.tsx
+++ b/apps/viewer/src/components/viewer/properties/GeoreferencingPanel.tsx
@@ -698,7 +698,7 @@ export function GeoreferencingPanel({ georef, modelId, enableEditing, schemaVers
           <div className="flex items-start gap-1.5 text-[10px] text-sky-700 dark:text-sky-400">
             <Info className="h-3 w-3 mt-0.5 shrink-0" />
             <span className="leading-snug">
-              <strong>This model is georeferenced twice — ifc-lite corrected it.</strong>{' '}
+              <strong>This model is georeferenced twice. ifc-lite corrected it.</strong>{' '}
               The geometry already sits at map coordinates (E{' '}
               {doubleGeoref.worldCenter.x.toFixed(0)} N {doubleGeoref.worldCenter.y.toFixed(0)}),
               and this IfcMapConversion repeats the same offset. ifc-lite places the geometry
@@ -710,7 +710,7 @@ export function GeoreferencingPanel({ georef, modelId, enableEditing, schemaVers
               {doubleGeoref.overridesAuthoredRotation && (
                 <>
                   {' '}This file also authors a map rotation that cannot be reconciled with its own
-                  coordinates, so the model is placed grid-aligned — check the orientation, and set
+                  coordinates, so the model is placed grid-aligned. Check the orientation, and set
                   Angle to Grid North by hand if it looks wrong.
                 </>
               )}

--- a/apps/viewer/src/components/viewer/properties/GeoreferencingPanel.tsx
+++ b/apps/viewer/src/components/viewer/properties/GeoreferencingPanel.tsx
@@ -26,7 +26,7 @@ import {
   mergeProjectedCRS,
   supportsStandardGeoreferencing,
 } from '@/lib/geo/effective-georef';
-import { detectDoubleGeoreference, formatApproxDistance } from '@/lib/geo/double-georeference';
+import { detectDoubleGeoreference, formatApproxDistance, trimFloat } from '@/lib/geo/double-georeference';
 import { useIfc } from '@/hooks/useIfc';
 import { toast } from '@/components/ui/toast';
 
@@ -714,15 +714,21 @@ export function GeoreferencingPanel({ georef, modelId, enableEditing, schemaVers
                   Angle to Grid North by hand if it looks wrong.
                 </>
               )}
-              {doubleGeoref.overridesAuthoredScale && (
+              {doubleGeoref.scaleForExport !== null && (
                 <>
                   {' '}Its Scale is not applied either: on map-sized coordinates it would re-scale
                   the model about the map origin.
                 </>
               )}
               {' '}The file&apos;s own values are shown below exactly as authored. The export is
-              worth fixing at source; to bake the correction in here, set Eastings and Northings
-              to 0 and Angle to Grid North to 0, then use Export IFC (with changes).
+              worth fixing at source; to bake the correction in here,{' '}
+              {/* Zeroing the offsets is NOT enough when Scale is being
+                  overridden: a spec-strict consumer reading the exported file
+                  back would still multiply the map-sized coordinates by it. */}
+              {doubleGeoref.scaleForExport !== null
+                ? `set Eastings and Northings to 0, Angle to Grid North to 0, and Scale to ${trimFloat(doubleGeoref.scaleForExport)}`
+                : 'set Eastings and Northings to 0 and Angle to Grid North to 0'}
+              , then use Export IFC (with changes).
             </span>
           </div>
         </div>

--- a/apps/viewer/src/components/viewer/properties/GeoreferencingPanel.tsx
+++ b/apps/viewer/src/components/viewer/properties/GeoreferencingPanel.tsx
@@ -8,7 +8,7 @@
  */
 
 import { useState, useCallback, useMemo } from 'react';
-import { Globe, MapPin, PenLine, Check, X, Search, ChevronRight, Mountain, AlertTriangle } from 'lucide-react';
+import { Globe, MapPin, PenLine, Check, X, Search, ChevronRight, Mountain, AlertTriangle, Info } from 'lucide-react';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { Badge } from '@/components/ui/badge';
 import { computeAngleToGridNorth, type GeoreferenceInfo, type MapConversion, type ProjectedCRS } from '@ifc-lite/parser';
@@ -26,26 +26,11 @@ import {
   mergeProjectedCRS,
   supportsStandardGeoreferencing,
 } from '@/lib/geo/effective-georef';
-import { detectDoubleGeoreference, identityConversionFields } from '@/lib/geo/double-georeference';
+import { detectDoubleGeoreference, formatApproxDistance } from '@/lib/geo/double-georeference';
 import { useIfc } from '@/hooks/useIfc';
 import { toast } from '@/components/ui/toast';
 
 // ── Field-specific assistance data ─────────────────────────────────────
-
-/**
- * Metres → a short human-readable distance ("6,004 km", "820 m").
- *
- * Past ~2.5 Earth circumferences the figure stops meaning anything to a reader
- * and starts looking like a formatting bug, so say what it actually implies
- * instead. A file that also mis-scales lands there easily: a 1000× scale on
- * map-sized coordinates produces billions of km.
- */
-function formatDistance(metres: number): string {
-  if (!Number.isFinite(metres)) return 'an unknown distance';
-  if (metres > 100_000_000) return 'more than a planet-width';
-  if (metres >= 1000) return `about ${Math.round(metres / 1000).toLocaleString()} km`;
-  return `about ${Math.round(metres).toLocaleString()} m`;
-}
 
 const COMMON_DATUMS = ['WGS84', 'ETRS89', 'NAD83', 'NAD27', 'GRS80', 'Bessel 1841', 'Clarke 1866'];
 const COMMON_PROJECTIONS = ['Transverse Mercator', 'UTM', 'Lambert Conformal Conic', 'Mercator', 'Stereographic', 'Oblique Mercator'];
@@ -404,8 +389,10 @@ export function GeoreferencingPanel({ georef, modelId, enableEditing, schemaVers
   }, [mergedConversion, mergedCRS?.mapUnitScale, lengthUnitScale]);
 
   // Geometry already at absolute map coordinates AND a MapConversion repeating
-  // the same offset — applying it a second time throws the model thousands of
-  // km off (#2526). Report only; the user decides.
+  // the same offset (#2526). `effectiveMapConversionForGeometry` has ALREADY
+  // neutralised the duplicate for every geometry consumer by the time this
+  // runs — this is the note that says so, and it fires on exactly the same
+  // predicate, so the panel can never disagree with the model on screen.
   const doubleGeoref = useMemo(() => {
     return detectDoubleGeoreference(
       mergedConversion,
@@ -530,24 +517,6 @@ export function GeoreferencingPanel({ georef, modelId, enableEditing, schemaVers
       { field: 'xAxisOrdinate', value: ordinate, oldValue: mergedConversion?.xAxisOrdinate },
     ]);
     posthog.capture('georeference_set', { method: 'true_north' });
-    requestAlignmentReload();
-  }, [modelId, setGeorefFields, mergedConversion, requestAlignmentReload]);
-
-  // Clear a duplicated MapConversion offset (#2526): the geometry is already in
-  // the map CRS, so the conversion has to be a horizontal identity.
-  const applyIdentityConversion = useCallback((scaleCorrection: number | null) => {
-    if (!modelId || !setGeorefFields) return;
-    setGeorefFields(
-      modelId,
-      'mapConversion',
-      identityConversionFields(scaleCorrection).map(({ field, value }) => ({
-        field,
-        value,
-        oldValue: mergedConversion?.[field as keyof MapConversion] as number | undefined,
-      })),
-    );
-    posthog.capture('georeference_set', { method: 'double_georeference_identity' });
-    setConversionOpen(true);
     requestAlignmentReload();
   }, [modelId, setGeorefFields, mergedConversion, requestAlignmentReload]);
 
@@ -715,46 +684,47 @@ export function GeoreferencingPanel({ georef, modelId, enableEditing, schemaVers
         )}
       </div>
 
-      {/* Doubly-georeferenced model (#2526). Sits ABOVE the collapsibles and
-          outside them: a multi-thousand-km placement error must not be hidden
-          behind a collapsed section the way the scale note is. */}
+      {/* Doubly-georeferenced model (#2526). Informational, not a warning, and
+          deliberately without an action: the model on screen is already
+          correct — `effectiveMapConversionForGeometry` neutralised the
+          duplicated conversion before anything was placed. An alarm here would
+          tell the user their model is thousands of km out while they are
+          looking at it in the right place, and a "fix it" button would only
+          bake OUR substituted rotation into their authored data. Sits above the
+          collapsibles because it explains a difference between the file and the
+          view, which must not be hidden behind a collapsed section. */}
       {doubleGeoref && (
-        <div className="px-3 py-2 border-b border-zinc-100 dark:border-zinc-900 bg-amber-50/60 dark:bg-amber-950/25">
-          <div className="flex items-start gap-1.5 text-[10px] text-amber-700 dark:text-amber-400">
-            <AlertTriangle className="h-3 w-3 mt-0.5 shrink-0" />
+        <div className="px-3 py-2 border-b border-zinc-100 dark:border-zinc-900 bg-sky-50/60 dark:bg-sky-950/25">
+          <div className="flex items-start gap-1.5 text-[10px] text-sky-700 dark:text-sky-400">
+            <Info className="h-3 w-3 mt-0.5 shrink-0" />
             <span className="leading-snug">
-              <strong>Model is georeferenced twice.</strong>{' '}
+              <strong>This model is georeferenced twice — ifc-lite corrected it.</strong>{' '}
               The geometry already sits at map coordinates (E{' '}
               {doubleGeoref.worldCenter.x.toFixed(0)} N {doubleGeoref.worldCenter.y.toFixed(0)}),
-              and this IfcMapConversion repeats the same offset. Applying it displaces the model
-              by {formatDistance(doubleGeoref.displacement)}.
-              {editable
-                ? ` The fix below zeroes Eastings/Northings and resets the rotation to grid-aligned${
-                  doubleGeoref.scaleCorrection !== null
-                    ? `, sets Scale to ${doubleGeoref.scaleCorrection.toPrecision(4)} so the geometry is no longer re-scaled about the map origin,`
-                    : ''
-                } and treats the geometry as already being in the map CRS. OrthogonalHeight is left as authored.`
-                : ' Enable editing to correct it.'}
+              and this IfcMapConversion repeats the same offset. ifc-lite places the geometry
+              where it already is; a tool that applied the conversion on top would put the model{' '}
+              {formatApproxDistance(doubleGeoref.displacement)} away.
               {/* The fingerprint matches on TRANSLATION, so when the file authors
                   a rotation of its own we are choosing the orientation, not
-                  restating it. Say so rather than applying it silently. */}
-              {editable && doubleGeoref.overridesAuthoredRotation && (
+                  restating it. Say so rather than leaving it implicit. */}
+              {doubleGeoref.overridesAuthoredRotation && (
                 <>
-                  {' '}This file authors a rotation that cannot be reconciled with its own
-                  coordinates, so check the orientation afterwards and set Angle to Grid North
-                  by hand if it looks wrong.
+                  {' '}This file also authors a map rotation that cannot be reconciled with its own
+                  coordinates, so the model is placed grid-aligned — check the orientation, and set
+                  Angle to Grid North by hand if it looks wrong.
                 </>
               )}
+              {doubleGeoref.overridesAuthoredScale && (
+                <>
+                  {' '}Its Scale is not applied either: on map-sized coordinates it would re-scale
+                  the model about the map origin.
+                </>
+              )}
+              {' '}The file&apos;s own values are shown below exactly as authored. The export is
+              worth fixing at source; to bake the correction in here, set Eastings and Northings
+              to 0 and Angle to Grid North to 0, then use Export IFC (with changes).
             </span>
           </div>
-          {editable && (
-            <button
-              onClick={() => applyIdentityConversion(doubleGeoref.scaleCorrection)}
-              className="mt-1.5 ml-[18px] text-[10px] text-amber-800 dark:text-amber-300 hover:text-amber-950 dark:hover:text-amber-200 px-1.5 py-0.5 border border-amber-400/60 dark:border-amber-700/60 hover:bg-amber-100/70 dark:hover:bg-amber-900/40 transition-colors"
-            >
-              Treat geometry as already in the map CRS
-            </button>
-          )}
         </div>
       )}
 

--- a/apps/viewer/src/components/viewer/properties/LocationMap.kmz.test.tsx
+++ b/apps/viewer/src/components/viewer/properties/LocationMap.kmz.test.tsx
@@ -1,0 +1,173 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The Location panel's "Google Earth" button, driven through the REAL
+ * component (#2526 follow-up).
+ *
+ * Codex on PR #2552: "For a map-absolute model whose authored axis is
+ * non-identity, this correction only reaches `buildKmzForModel`, which is used
+ * by `KmzExportDialog`. The Location panel still calls `buildKmz` directly in
+ * `LocationMap.tsx`, passing the raw `mapConversion`." Confirmed, and it was
+ * worse than reported: the raw call also passed `mapConversion.orthogonalHeight`
+ * straight through as the KML altitude, skipping BOTH the map-unit scaling and
+ * the wasm RTC Z fold-back that `computeKmzAltitude` exists for. On the #2526
+ * file that is a 90-degree rotation AND a 14 m sink, from the button sitting
+ * inches away from the one that got it right.
+ *
+ * A unit test on `buildKmzForResolvedGeoref` cannot catch this: it passes just
+ * as happily while the component calls something else entirely. So this mounts
+ * `LocationMap` and clicks the actual button, and asserts on what reached the
+ * exporter. Reverting the component to `buildKmz({ ...mapConversion })` fails
+ * all three assertions below.
+ *
+ * The wasm engine cannot load under `tsx --test`, so the export is driven
+ * through the `createKmzProcessor` seam — the same seam `buildKmz` has always
+ * exposed to `kmz-exporter.test.ts`, threaded one level up so this call site is
+ * reachable at all.
+ */
+
+import '@/test/setup-dom.js';
+import { describe, it, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+
+import type { CoordinateInfo, GeometryResult, MeshData, KmzAltitudeMode } from '@ifc-lite/geometry';
+import type { MapConversion, ProjectedCRS } from '@ifc-lite/parser';
+
+import { render, cleanup } from '@/test/render.js';
+import { LocationMap } from './LocationMap.js';
+import type { KmzProcessor } from '@/lib/geo/kmz-exporter.js';
+
+/**
+ * The #2526 file: IfcSite placed at the absolute EPSG:25833 coordinate (the
+ * wasm RTC pre-pass rebased it, so the offset lives in `wasmRtcOffset`, Z = 14 m)
+ * and an IfcMapConversion repeating the same anchor with a 90-degree rotation.
+ */
+const MAP_ABSOLUTE_CONVERSION: MapConversion = {
+  id: 73, sourceCRS: 41, targetCRS: 71,
+  eastings: 311_988.181, northings: 5_996_148.565, orthogonalHeight: 0,
+  xAxisAbscissa: 0, xAxisOrdinate: 1, scale: 1,
+};
+
+const EPSG_25833: ProjectedCRS = {
+  id: 71,
+  name: 'EPSG:25833',
+  description: 'ETRS89 / UTM zone 33N',
+  geodeticDatum: 'ETRS89',
+  mapUnitScale: 1,
+} as ProjectedCRS;
+
+const MAP_ABSOLUTE_COORDINATE_INFO = {
+  originShift: { x: 0, y: 0, z: 0 },
+  wasmRtcOffset: { x: 312_018.898, y: 5_996_169.654, z: 14 },
+  originalBounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 0, y: 0, z: 0 } },
+  shiftedBounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 0, y: 0, z: 0 } },
+  hasLargeCoordinates: true,
+  lengthUnitScale: 1,
+} as CoordinateInfo;
+
+const GEOMETRY_RESULT = {
+  meshes: [{ expressId: 1, geometryClass: 0 }] as unknown as MeshData[],
+} as GeometryResult;
+
+interface RecordedCall {
+  altitude: number;
+  xAxisAbscissa: number | undefined;
+  xAxisOrdinate: number | undefined;
+  altitudeMode: KmzAltitudeMode | undefined;
+}
+
+/** A stub `GeometryProcessor` slice that records the placement it was driven with. */
+function makeStub() {
+  const calls: RecordedCall[] = [];
+  const gp: KmzProcessor = {
+    async init() {},
+    exportKmzFromMeshes(_meshes, _lat, _lon, altitude, xAxisAbscissa, xAxisOrdinate, _name, altitudeMode) {
+      calls.push({ altitude, xAxisAbscissa, xAxisOrdinate, altitudeMode });
+      return new Uint8Array([0x50, 0x4b, 0x03, 0x04]); // "PK\x03\x04"
+    },
+    dispose() {},
+  };
+  return { gp, calls };
+}
+
+/** Mount the panel and click Google Earth, returning what reached the exporter. */
+async function exportViaButton(): Promise<RecordedCall[]> {
+  const { gp, calls } = makeStub();
+  const container = render(
+    <LocationMap
+      mapConversion={MAP_ABSOLUTE_CONVERSION}
+      projectedCRS={EPSG_25833}
+      coordinateInfo={MAP_ABSOLUTE_COORDINATE_INFO}
+      geometryResult={GEOMETRY_RESULT}
+      lengthUnitScale={1}
+      createKmzProcessor={() => gp}
+    />,
+  );
+
+  // The button is gated on `latLon`, which the panel resolves asynchronously —
+  // and `resolveProjection` loads the generated EPSG index, so this is real I/O
+  // and NOT reachable by flushing microtasks. Poll on a timer instead. (The
+  // index is cached after the first resolve, which is why a microtask-only
+  // flush passed for whichever test happened to run third and failed for the
+  // rest — a source of order-dependent flake, not a real pass.)
+  let button: HTMLButtonElement | undefined;
+  for (let i = 0; i < 200 && !button; i++) {
+    await act(async () => { await new Promise(resolve => setTimeout(resolve, 25)); });
+    button = Array.from(container.querySelectorAll('button'))
+      .find(b => (b.textContent ?? '').includes('Google Earth'));
+  }
+  assert.ok(button, 'expected the Google Earth button to render once the pin resolved');
+
+  await act(async () => {
+    button!.click();
+    // Let the handler's awaits settle (reproject → build → download).
+    await new Promise(resolve => setTimeout(resolve, 50));
+  });
+  return calls;
+}
+
+describe('LocationMap — Google Earth (KMZ) export', () => {
+  afterEach(cleanup);
+
+  it('exports a map-absolute model with the GUARDED heading, not the authored 90-degree axis', async () => {
+    const calls = await exportViaButton();
+    assert.strictEqual(calls.length, 1, 'expected exactly one KMZ export');
+    // Authored axis is (0, 1) — a 90-degree rotation. The geometry is already
+    // map-axis-aligned (that is the map-absolute premise), so applying it would
+    // rotate an otherwise correctly-placed .dae by 90 degrees in Google Earth.
+    assert.strictEqual(calls[0].xAxisAbscissa, 1, 'heading must be the identity axis');
+    assert.strictEqual(calls[0].xAxisOrdinate, 0, 'heading must be the identity axis');
+  });
+
+  it('folds the RTC Z offset into the altitude instead of passing OrthogonalHeight raw', async () => {
+    const calls = await exportViaButton();
+    // OrthogonalHeight is 0, but the RTC pre-pass subtracted 14 m from every
+    // mesh Z the COLLADA exporter bakes. Passing the raw 0 sinks the model by
+    // its whole site elevation — the same 14 m #2526 reported losing.
+    assert.strictEqual(calls[0].altitude, 14);
+  });
+
+  it('agrees with the Export KMZ dialog, which is the point of sharing one builder', async () => {
+    const { gp, calls } = makeStub();
+    const { buildKmzForResolvedGeoref } = await import('@/lib/geo/kmz-export.js');
+    const out = await buildKmzForResolvedGeoref({
+      conversion: MAP_ABSOLUTE_CONVERSION,
+      crs: EPSG_25833,
+      coordinateInfo: MAP_ABSOLUTE_COORDINATE_INFO,
+      lengthUnitScale: 1,
+      meshes: GEOMETRY_RESULT.meshes as MeshData[],
+      name: 'IFC Model',
+    }, () => gp);
+    assert.ok(out instanceof Uint8Array);
+
+    const viaPanel = await exportViaButton();
+    assert.deepStrictEqual(
+      viaPanel[0],
+      calls[0],
+      'the panel and the dialog must place the same model identically',
+    );
+  });
+});

--- a/apps/viewer/src/components/viewer/properties/LocationMap.kmz.test.tsx
+++ b/apps/viewer/src/components/viewer/properties/LocationMap.kmz.test.tsx
@@ -144,6 +144,7 @@ describe('LocationMap — Google Earth (KMZ) export', () => {
 
   it('folds the RTC Z offset into the altitude instead of passing OrthogonalHeight raw', async () => {
     const calls = await exportViaButton();
+    assert.strictEqual(calls.length, 1, 'expected exactly one KMZ export');
     // OrthogonalHeight is 0, but the RTC pre-pass subtracted 14 m from every
     // mesh Z the COLLADA exporter bakes. Passing the raw 0 sinks the model by
     // its whole site elevation — the same 14 m #2526 reported losing.
@@ -164,6 +165,8 @@ describe('LocationMap — Google Earth (KMZ) export', () => {
     assert.ok(out instanceof Uint8Array);
 
     const viaPanel = await exportViaButton();
+    assert.strictEqual(viaPanel.length, 1, 'expected exactly one KMZ export from the panel');
+    assert.strictEqual(calls.length, 1, 'expected exactly one KMZ export from the builder');
     assert.deepStrictEqual(
       viaPanel[0],
       calls[0],

--- a/apps/viewer/src/components/viewer/properties/LocationMap.tsx
+++ b/apps/viewer/src/components/viewer/properties/LocationMap.tsx
@@ -30,7 +30,8 @@ import type { MapConversion, ProjectedCRS } from '@ifc-lite/parser';
 import type { CoordinateInfo, GeometryResult, MeshData } from '@ifc-lite/geometry';
 import { downloadBlob } from '@/lib/export/download';
 import { reprojectToLatLon, reprojectFromLatLon, queryTerrainElevation, computeFootprintGeoJSON, type LatLon } from '@/lib/geo/reproject';
-import { buildKmz } from '@/lib/geo/kmz-exporter';
+import { buildKmzForResolvedGeoref } from '@/lib/geo/kmz-export';
+import type { KmzProcessor } from '@/lib/geo/kmz-exporter';
 import {
   probeMapWebglSupport, markMapWebglUnsupported, takeMapWebglReportSlot,
   getMapWebglVerdict, describeMapInitFailure, watchContextCreationStatus,
@@ -111,6 +112,16 @@ export interface LocationMapProps {
   editable?: boolean;
   /** Called when the user applies a new position from the map */
   onApplyPosition?: (position: PickedPosition) => void;
+  /**
+   * wasm seam for the KMZ export, forwarded to `buildKmzForResolvedGeoref`.
+   * Production leaves it undefined and gets the real `GeometryProcessor`;
+   * `LocationMap.kmz.test.tsx` passes a stub so the Google Earth button can be
+   * driven end to end under `tsx --test`, where the engine cannot load. Same
+   * seam `buildKmz` has always exposed to `kmz-exporter.test.ts`, one level up
+   * — without it this call site is untestable, which is exactly how it drifted
+   * out of sync with the Export KMZ dialog (#2526 follow-up).
+   */
+  createKmzProcessor?: () => KmzProcessor;
 }
 
 type MapState = 'idle' | 'loading' | 'ready' | 'error';
@@ -239,7 +250,7 @@ function removeFootprintFromMap(map: InstanceType<typeof import('maplibre-gl').M
 
 export function LocationMap({
   mapConversion, projectedCRS, coordinateInfo, geometryResult,
-  lengthUnitScale = 1, editable, onApplyPosition,
+  lengthUnitScale = 1, editable, onApplyPosition, createKmzProcessor,
 }: LocationMapProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<InstanceType<typeof import('maplibre-gl').Map> | null>(null);
@@ -707,24 +718,35 @@ export function LocationMap({
   }, [latLon]);
 
   const handleExportKmz = useCallback(async () => {
-    if (!latLon || !geometryResult || !mapConversion) return;
+    if (!latLon || !geometryResult || !mapConversion || !projectedCRS) return;
     try {
       // Embed the model as COLLADA (Rust exporter): Google Earth's <Model> only loads
       // COLLADA, renders it bright via emission, and clampToGround keeps it on the
       // terrain so the MSL orthogonal height no longer floats it (#1427).
-      const kmz = await buildKmz({
-        latLon,
-        altitude: mapConversion.orthogonalHeight,
-        xAxisAbscissa: mapConversion.xAxisAbscissa,
-        xAxisOrdinate: mapConversion.xAxisOrdinate,
+      //
+      // Placement is NOT computed here. This used to call `buildKmz` directly
+      // with the authored axis and a raw `orthogonalHeight`, which skipped all
+      // three corrections the Export KMZ dialog got: the map-absolute guard
+      // (#2526), the map-unit altitude scaling, and the RTC Z fold-back. Same
+      // model, two buttons, two different files. `buildKmzForResolvedGeoref` is
+      // now the single source for both (#2526 follow-up).
+      const kmz = await buildKmzForResolvedGeoref({
+        conversion: mapConversion,
+        crs: projectedCRS,
+        coordinateInfo,
+        lengthUnitScale: lengthUnitScale ?? 1,
         meshes: geometryResult.meshes as MeshData[],
         name: 'IFC Model',
-      });
+      }, createKmzProcessor);
+      if (typeof kmz === 'string') {
+        console.error('KMZ export failed:', kmz);
+        return;
+      }
       downloadBlob(new Blob([kmz as BlobPart], { type: 'application/vnd.google-earth.kmz' }), 'model.kmz');
     } catch (err) {
       console.error('KMZ export failed:', err);
     }
-  }, [latLon, geometryResult, mapConversion]);
+  }, [latLon, geometryResult, mapConversion, projectedCRS, coordinateInfo, lengthUnitScale, createKmzProcessor]);
 
   const isDarkRef = useRef(false);
 

--- a/apps/viewer/src/lib/geo/double-georeference.test.ts
+++ b/apps/viewer/src/lib/geo/double-georeference.test.ts
@@ -8,7 +8,8 @@ import assert from 'node:assert';
 import type { MapConversion, ProjectedCRS } from '@ifc-lite/parser';
 import type { CoordinateInfo } from '@ifc-lite/geometry';
 
-import { detectDoubleGeoreference, identityConversionFields } from './double-georeference.js';
+import { detectDoubleGeoreference, formatApproxDistance } from './double-georeference.js';
+import { effectiveMapConversionForGeometry } from './map-absolute.js';
 
 /**
  * Build a CoordinateInfo whose model centre lands on the given IFC world
@@ -64,15 +65,17 @@ const ISSUE_2526_CONVERSION: MapConversion = {
   scale: undefined,
 };
 
+/** Site placement #49 = (311988180.54, 5996148564.99) mm, i.e. the anchor. */
+const ISSUE_2526_CENTER = { x: 311988.18054, y: 5996148.56499 };
+
 const METRE_CRS: Pick<ProjectedCRS, 'mapUnitScale'> = { mapUnitScale: 1 };
 
 describe('detectDoubleGeoreference', () => {
-  it('flags the issue #2526 file and reports the real displacement', () => {
+  it('reports the issue #2526 file and quotes the displacement a literal tool would produce', () => {
     const found = detectDoubleGeoreference(
       ISSUE_2526_CONVERSION,
       METRE_CRS,
-      // Site placement #49 = (311988180.54, 5996148564.99) mm.
-      coordInfoAt(311988.18054, 5996148.56499),
+      coordInfoAt(ISSUE_2526_CENTER.x, ISSUE_2526_CENTER.y),
       0.001,
     );
     assert.ok(found, 'expected a double georeference report');
@@ -88,18 +91,84 @@ describe('detectDoubleGeoreference', () => {
     );
   });
 
-  describe('overridesAuthoredRotation (PR #2543 review)', () => {
+  /**
+   * The whole point of this module after #2534: the note the panel shows and
+   * the correction the geometry pipeline applies must be the SAME decision.
+   * A model that is silently corrected but not explained, or explained but not
+   * corrected, is the incoherence this reconciliation exists to remove.
+   */
+  describe('agrees with the geometry correction, model for model', () => {
+    it('reports exactly when the geometry guard neutralises — no gap in either direction', () => {
+      // Residuals sweeping across the guard's 10 km window, including 6 004 m
+      // and 8 000 m, which straddle the tolerance the DETECTOR used to carry
+      // (max(1 km, 0.1% of ‖offset‖) ≈ 6 004 m for this anchor). Anything in
+      // that band was corrected without being reported.
+      for (const residual of [0, 1_000, 6_004, 8_000, 9_999, 10_001, 20_000, 400_000]) {
+        const info = coordInfoAt(ISSUE_2526_CENTER.x + residual, ISSUE_2526_CENTER.y);
+        const reported = detectDoubleGeoreference(
+          ISSUE_2526_CONVERSION,
+          METRE_CRS,
+          info,
+          0.001,
+        ) !== null;
+        const corrected = effectiveMapConversionForGeometry(
+          ISSUE_2526_CONVERSION,
+          1,
+          info,
+        ) !== ISSUE_2526_CONVERSION;
+        assert.strictEqual(
+          reported,
+          corrected,
+          `residual ${residual} m: reported=${reported} but corrected=${corrected}`,
+        );
+      }
+    });
+
+    it('reports a model 8 km from its anchor, which the old detector tolerance missed', () => {
+      // The specific gap: 8 km > max(1 km, 0.1% × 6 004 km) = 6 004 m, so the
+      // pre-reconciliation detector stayed silent while the geometry was
+      // already being moved.
+      const info = coordInfoAt(ISSUE_2526_CENTER.x + 8_000, ISSUE_2526_CENTER.y);
+      assert.notStrictEqual(
+        effectiveMapConversionForGeometry(ISSUE_2526_CONVERSION, 1, info),
+        ISSUE_2526_CONVERSION,
+        'precondition: the geometry guard corrects this model',
+      );
+      assert.ok(
+        detectDoubleGeoreference(ISSUE_2526_CONVERSION, METRE_CRS, info, 0.001),
+        'a corrected model must also be explained',
+      );
+    });
+
+    it('stays silent whenever the guard returns the conversion untouched', () => {
+      // Same anchor, geometry 400 km away: the guard cannot fire, so there is
+      // nothing to explain and a note would describe a correction that never
+      // happened.
+      const info = coordInfoAt(ISSUE_2526_CENTER.x, ISSUE_2526_CENTER.y - 400_000);
+      assert.strictEqual(
+        effectiveMapConversionForGeometry(ISSUE_2526_CONVERSION, 1, info),
+        ISSUE_2526_CONVERSION,
+        'precondition: the geometry guard leaves this model alone',
+      );
+      assert.strictEqual(
+        detectDoubleGeoreference(ISSUE_2526_CONVERSION, METRE_CRS, info, 0.001),
+        null,
+      );
+    });
+  });
+
+  describe('overridesAuthoredRotation', () => {
     // The fingerprint matches on TRANSLATION, so it does not prove the model's
-    // local axes are grid-aligned. The fix resets the axis anyway (a
+    // local axes are grid-aligned. The guard resets the axis anyway (a
     // non-identity rotation acting on a map-sized coordinate is unrecoverable
-    // whatever the offsets are), so this flag tells the UI when that reset is
-    // OUR choice of orientation rather than a restatement of the file's.
+    // whatever the offsets are), so this flag tells the UI when the orientation
+    // on screen is OUR choice rather than a restatement of the file's.
 
     it('is true whenever the file authors a rotation of its own', () => {
       const found = detectDoubleGeoreference(
         ISSUE_2526_CONVERSION,
         METRE_CRS,
-        coordInfoAt(311988.18054, 5996148.56499),
+        coordInfoAt(ISSUE_2526_CENTER.x, ISSUE_2526_CENTER.y),
         0.001,
       );
       assert.ok(found);
@@ -115,7 +184,7 @@ describe('detectDoubleGeoreference', () => {
       const found = detectDoubleGeoreference(
         ISSUE_2526_CONVERSION,
         METRE_CRS,
-        coordInfoAt(311988.18054, 5996148.56499, 0, -2.0566),
+        coordInfoAt(ISSUE_2526_CENTER.x, ISSUE_2526_CENTER.y, 0, -2.0566),
         0.001,
       );
       assert.ok(found);
@@ -131,7 +200,7 @@ describe('detectDoubleGeoreference', () => {
       const found = detectDoubleGeoreference(
         noRotation,
         METRE_CRS,
-        coordInfoAt(311988.18054, 5996148.56499),
+        coordInfoAt(ISSUE_2526_CENTER.x, ISSUE_2526_CENTER.y),
         0.001,
       );
       assert.ok(found);
@@ -139,89 +208,55 @@ describe('detectDoubleGeoreference', () => {
     });
   });
 
-  describe('scaleCorrection (PR #2543 review)', () => {
-    it('is null when the effective horizontal scale is already 1', () => {
+  describe('overridesAuthoredScale', () => {
+    it('is false when the effective horizontal scale is already 1', () => {
       // #2526's file: Scale unset on a mm project with a metre MapUnit, which
-      // getEffectiveHorizontalScale already resolves to 1.
+      // getEffectiveHorizontalScale already resolves to 1. Nothing about the
+      // model's size is being overridden, so the note must not claim it is.
       const found = detectDoubleGeoreference(
         ISSUE_2526_CONVERSION,
         METRE_CRS,
-        coordInfoAt(311988.18054, 5996148.56499),
+        coordInfoAt(ISSUE_2526_CENTER.x, ISSUE_2526_CENTER.y),
         0.001,
       );
       assert.ok(found);
-      assert.strictEqual(found!.scaleCorrection, null);
+      assert.strictEqual(found!.overridesAuthoredScale, false);
     });
 
-    it('supplies the unit bridge when a non-unit scale really is applied', () => {
-      // Scale explicitly 1000 on a mm project: the unset-Scale heuristic does
-      // not rescue it, so 1e6 is applied and would keep re-scaling the map-sized
-      // coordinates about the map origin after the offsets are cleared.
-      const scaled: MapConversion = { ...ISSUE_2526_CONVERSION, scale: 1000 };
-      const found = detectDoubleGeoreference(
-        scaled,
-        METRE_CRS,
-        coordInfoAt(311988.18054, 5996148.56499),
-        0.001,
-      );
-      assert.ok(found);
-      assert.ok(found!.scaleCorrection !== null);
-      // lengthUnitScale / mapUnitScale = 0.001 / 1.
-      assert.ok(Math.abs(found!.scaleCorrection! - 0.001) < 1e-12);
-      // And it must actually neutralise: (0.001 * 1) / 0.001 = 1.
-      const fixed: MapConversion = {
-        ...scaled,
-        ...Object.fromEntries(
-          identityConversionFields(found!.scaleCorrection).map(f => [f.field, f.value]),
-        ),
-      };
-      assert.strictEqual(
-        detectDoubleGeoreference(fixed, METRE_CRS, coordInfoAt(311988.18054, 5996148.56499), 0.001),
-        null,
-      );
-    });
-
-    it('corrects a NEAR-unit scale whose induced drift is still kilometres', () => {
+    it('is true for a NEAR-unit scale whose induced drift is still kilometres', () => {
       // Effective scale 1.004 is inside detectScaleUnitMismatch's 0.5% band,
       // but multiplied by a ~6 000 km coordinate it drags the model ~24 km. A
-      // fraction-based tolerance would wave this through.
+      // fraction-based tolerance would wave this through; the guard pins
+      // Scale to 1, and the user is entitled to know their Scale was dropped.
       const nearUnit: MapConversion = { ...ISSUE_2526_CONVERSION, scale: 1.004 };
-      const info = coordInfoAt(311988.18054, 5996148.56499);
-      const found = detectDoubleGeoreference(nearUnit, METRE_CRS, info, 1);
+      const found = detectDoubleGeoreference(
+        nearUnit,
+        METRE_CRS,
+        coordInfoAt(ISSUE_2526_CENTER.x, ISSUE_2526_CENTER.y),
+        1,
+      );
       assert.ok(found);
-      assert.ok(found!.scaleCorrection !== null, 'a 24 km drift must be corrected');
-      const fixed: MapConversion = {
-        ...nearUnit,
-        ...Object.fromEntries(
-          identityConversionFields(found!.scaleCorrection).map(f => [f.field, f.value]),
-        ),
-      };
-      assert.strictEqual(detectDoubleGeoreference(fixed, METRE_CRS, info, 1), null);
+      assert.strictEqual(found!.overridesAuthoredScale, true);
     });
 
-    it('leaves a genuine foot/metre bridge alone', () => {
+    it('is false for a genuine foot/metre bridge', () => {
       // A real bridge needs the units to DIFFER: a foot project with a metre
       // MapUnit, and Scale = 0.3048 doing exactly what the schema asks. The
-      // effective scale is then (0.3048 × 1) / 0.3048 = 1, so there is nothing
-      // to correct and the authored Scale must survive untouched — this is the
-      // case the "only correct a non-unit effective scale" rule exists to
-      // protect. (An earlier version of this test used foot units on BOTH
-      // sides with Scale = 1, which bridges nothing and so never exercised the
-      // rule it was named after — CodeRabbit, PR #2543.)
+      // effective scale is then (0.3048 × 1) / 0.3048 = 1 — nothing is
+      // overridden, so nothing is claimed.
       const footProject: MapConversion = { ...ISSUE_2526_CONVERSION, scale: 0.3048 };
       const found = detectDoubleGeoreference(
         footProject,
         METRE_CRS,
-        coordInfoAt(311988.18054, 5996148.56499),
+        coordInfoAt(ISSUE_2526_CENTER.x, ISSUE_2526_CENTER.y),
         0.3048,
       );
       assert.ok(found);
-      assert.strictEqual(found!.scaleCorrection, null);
-      assert.ok(!identityConversionFields(found!.scaleCorrection).some(f => f.field === 'scale'));
+      assert.strictEqual(found!.overridesAuthoredScale, false);
     });
   });
 
-  it('does NOT flag a correctly authored local-frame model', () => {
+  it('does NOT report a correctly authored local-frame model', () => {
     // Geometry near the IFC origin, conversion carries the real site offset.
     assert.strictEqual(
       detectDoubleGeoreference(ISSUE_2526_CONVERSION, METRE_CRS, coordInfoAt(12, -30), 0.001),
@@ -229,9 +264,25 @@ describe('detectDoubleGeoreference', () => {
     );
   });
 
-  it('does NOT flag a correctly authored absolute-coordinate model (LoGeoRef 20)', () => {
-    // Geometry at map coordinates, conversion is already the identity — the
-    // world centre is map-sized but does not coincide with a 0/0 offset.
+  it('does NOT report a correctly authored LoGeoRef-30 model', () => {
+    // The safety control for #2534: site placement at the LOCAL origin, the
+    // MapConversion carrying the single, legitimate offset. Nothing is
+    // duplicated, so nothing may be corrected and nothing may be said.
+    const info = coordInfoAt(12, -30);
+    assert.strictEqual(
+      effectiveMapConversionForGeometry(ISSUE_2526_CONVERSION, 1, info),
+      ISSUE_2526_CONVERSION,
+      'a LoGeoRef-30 file must keep its authored conversion',
+    );
+    assert.strictEqual(
+      detectDoubleGeoreference(ISSUE_2526_CONVERSION, METRE_CRS, info, 0.001),
+      null,
+    );
+  });
+
+  it('does NOT report a correctly authored absolute-coordinate model (LoGeoRef 20)', () => {
+    // Geometry at map coordinates, conversion is already the identity — there
+    // is no second offset to drop.
     const identity: MapConversion = {
       ...ISSUE_2526_CONVERSION,
       eastings: 0,
@@ -245,7 +296,7 @@ describe('detectDoubleGeoreference', () => {
     );
   });
 
-  it('does NOT flag a map-sized model whose offset is an unrelated location', () => {
+  it('does NOT report a map-sized model whose offset is an unrelated location', () => {
     // Same CRS, but the conversion points 400 km away: not a duplication.
     const elsewhere: MapConversion = { ...ISSUE_2526_CONVERSION, northings: 5596148.565 };
     assert.strictEqual(
@@ -255,8 +306,8 @@ describe('detectDoubleGeoreference', () => {
   });
 
   it('tolerates a large-extent site (centre offset from the placement origin)', () => {
-    // A 3 km-wide site puts its centre ~1.5 km from the site origin; the
-    // relative tolerance (0.1% of ‖offset‖ ≈ 6 km here) must still catch it.
+    // A 3 km-wide site puts its centre ~1.5 km from the site origin, well
+    // inside the guard's window.
     const found = detectDoubleGeoreference(
       ISSUE_2526_CONVERSION,
       METRE_CRS,
@@ -277,7 +328,7 @@ describe('detectDoubleGeoreference', () => {
     const found = detectDoubleGeoreference(
       mmConversion,
       { mapUnitScale: 0.001 },
-      coordInfoAt(311988.18054, 5996148.56499),
+      coordInfoAt(ISSUE_2526_CENTER.x, ISSUE_2526_CENTER.y),
       0.001,
     );
     assert.ok(found, 'expected the mm-unit duplication to be caught');
@@ -295,84 +346,108 @@ describe('detectDoubleGeoreference', () => {
     );
   });
 
-  it('returns null for a non-finite offset rather than reporting NaN', () => {
+  it('returns null for a non-finite offset, because the guard cannot fire on one', () => {
     const broken: MapConversion = { ...ISSUE_2526_CONVERSION, eastings: NaN };
+    assert.strictEqual(
+      effectiveMapConversionForGeometry(broken, 1, coordInfoAt(311988, 5996149)),
+      broken,
+    );
     assert.strictEqual(
       detectDoubleGeoreference(broken, METRE_CRS, coordInfoAt(311988, 5996149), 0.001),
       null,
     );
   });
 
-  it('returns null for a non-finite axis rather than quoting a NaN distance', () => {
-    // hasStandardGeoreferencing deliberately lets a non-finite axis through (it
-    // has downstream fallbacks elsewhere), so the guard has to live here: a NaN
-    // axis would poison `displacement` and flip `overridesAuthoredRotation` by
-    // accident.
-    const info = coordInfoAt(311988.18054, 5996148.56499);
+  it('still reports a non-finite axis, quoting an unknown distance rather than going silent', () => {
+    // The guard does not inspect the axis, so a malformed file IS still
+    // corrected on screen and its authored axis IS still replaced. Suppressing
+    // the note here would move the model and say nothing about it — the
+    // failure mode this reconciliation exists to remove. Quote the uncertainty
+    // instead.
+    const info = coordInfoAt(ISSUE_2526_CENTER.x, ISSUE_2526_CENTER.y);
     for (const broken of [
       { ...ISSUE_2526_CONVERSION, xAxisAbscissa: NaN },
       { ...ISSUE_2526_CONVERSION, xAxisOrdinate: Number.POSITIVE_INFINITY },
     ] satisfies MapConversion[]) {
-      assert.strictEqual(detectDoubleGeoreference(broken, METRE_CRS, info, 0.001), null);
+      assert.notStrictEqual(
+        effectiveMapConversionForGeometry(broken, 1, info),
+        broken,
+        'precondition: the geometry guard still corrects a malformed-axis file',
+      );
+      const found = detectDoubleGeoreference(broken, METRE_CRS, info, 0.001);
+      assert.ok(found, 'a corrected model must be explained even when malformed');
+      assert.strictEqual(found!.overridesAuthoredRotation, true);
+      assert.strictEqual(formatApproxDistance(found!.displacement), 'an unknown distance');
     }
   });
 
-  it('still flags when Scale is NaN, because the effective scale resolves to 1', () => {
+  it('still reports when Scale is NaN, because the effective scale resolves to 1', () => {
     // Not an oversight: getEffectiveHorizontalScale's unset/1 heuristic treats a
     // NaN Scale as "not provided" (NaN fails its `> 1e-9` test) and returns 1,
     // so the effective scale is well defined and the duplicated offsets are
-    // still the real defect. The finite guard above is for the axis, which has
-    // no such upstream normalisation.
+    // still the real defect.
     const found = detectDoubleGeoreference(
       { ...ISSUE_2526_CONVERSION, scale: NaN },
       METRE_CRS,
-      coordInfoAt(311988.18054, 5996148.56499),
+      coordInfoAt(ISSUE_2526_CENTER.x, ISSUE_2526_CENTER.y),
       0.001,
     );
     assert.ok(found);
-    assert.strictEqual(found!.scaleCorrection, null);
+    assert.strictEqual(found!.overridesAuthoredScale, false);
     assert.ok(Number.isFinite(found!.displacement));
   });
 });
 
-describe('identityConversionFields', () => {
-  it('zeroes the horizontal offset and resets the axis, and touches nothing else', () => {
-    const fields = identityConversionFields();
-    assert.deepStrictEqual(
-      Object.fromEntries(fields.map(f => [f.field, f.value])),
-      { eastings: 0, northings: 0, xAxisAbscissa: 1, xAxisOrdinate: 0 },
-    );
-    // OrthogonalHeight must NOT be in the fix: the fingerprint is horizontal,
-    // and zeroing a height that legitimately carries the site altitude would
-    // trade one error for another. Scale only joins when it is actually being
-    // applied as non-unit (see the scaleCorrection suite).
-    const names = fields.map(f => f.field);
-    assert.ok(!names.includes('orthogonalHeight'));
-    assert.ok(!names.includes('scale'));
-  });
-
-  it('adds Scale only when a correction was supplied', () => {
-    const fields = identityConversionFields(0.001);
-    assert.deepStrictEqual(
-      Object.fromEntries(fields.map(f => [f.field, f.value])),
-      { eastings: 0, northings: 0, xAxisAbscissa: 1, xAxisOrdinate: 0, scale: 0.001 },
-    );
-    assert.ok(!fields.some(f => f.field === 'orthogonalHeight'));
-  });
-
-  it('makes the flagged model stop being flagged', () => {
-    const fixed: MapConversion = {
-      ...ISSUE_2526_CONVERSION,
-      ...Object.fromEntries(identityConversionFields().map(f => [f.field, f.value])),
+describe('formatApproxDistance', () => {
+  /**
+   * Run `fn` with `Number.prototype.toLocaleString` behaving as it does in a
+   * German browser — i.e. an UN-TAGGED call groups thousands with '.', while a
+   * call that names its locale is honoured. This is the reporter's actual
+   * environment on #2526.
+   */
+  function withGermanAmbientLocale(fn: () => void): void {
+    const original = Number.prototype.toLocaleString;
+    Number.prototype.toLocaleString = function (
+      this: number,
+      locales?: Intl.LocalesArgument,
+      options?: Intl.NumberFormatOptions,
+    ): string {
+      return original.call(this, locales ?? 'de-DE', options);
     };
-    assert.strictEqual(
-      detectDoubleGeoreference(
-        fixed,
-        METRE_CRS,
-        coordInfoAt(311988.18054, 5996148.56499),
-        0.001,
-      ),
-      null,
-    );
+    try {
+      fn();
+    } finally {
+      Number.prototype.toLocaleString = original;
+    }
+  }
+
+  it('groups thousands in the language of the sentence, not the browser (#2526)', () => {
+    withGermanAmbientLocale(() => {
+      // The hazard, pinned: this is what an un-tagged toLocaleString() does on
+      // the reporter's machine, and "displaced by about 6.004 km" inside an
+      // English sentence reads as six metres.
+      assert.strictEqual((6004).toLocaleString(), '6.004');
+      assert.strictEqual(formatApproxDistance(6_004_291), 'about 6,004 km');
+    });
+  });
+
+  it('groups the metre branch the same way', () => {
+    withGermanAmbientLocale(() => {
+      assert.strictEqual(formatApproxDistance(999.4), 'about 999 m');
+    });
+  });
+
+  it('formats identically whatever the ambient locale is', () => {
+    let underGerman = '';
+    withGermanAmbientLocale(() => {
+      underGerman = formatApproxDistance(6_004_291);
+    });
+    assert.strictEqual(underGerman, formatApproxDistance(6_004_291));
+  });
+
+  it('says what an unreadable magnitude implies instead of quoting it', () => {
+    assert.strictEqual(formatApproxDistance(1e12), 'more than a planet-width');
+    assert.strictEqual(formatApproxDistance(NaN), 'an unknown distance');
+    assert.strictEqual(formatApproxDistance(Number.POSITIVE_INFINITY), 'an unknown distance');
   });
 });

--- a/apps/viewer/src/lib/geo/double-georeference.test.ts
+++ b/apps/viewer/src/lib/geo/double-georeference.test.ts
@@ -8,8 +8,9 @@ import assert from 'node:assert';
 import type { MapConversion, ProjectedCRS } from '@ifc-lite/parser';
 import type { CoordinateInfo } from '@ifc-lite/geometry';
 
-import { detectDoubleGeoreference, formatApproxDistance } from './double-georeference.js';
+import { detectDoubleGeoreference, formatApproxDistance, trimFloat } from './double-georeference.js';
 import { effectiveMapConversionForGeometry } from './map-absolute.js';
+import { getEffectiveHorizontalScale } from './geo-scale.js';
 
 /**
  * Build a CoordinateInfo whose model centre lands on the given IFC world
@@ -208,8 +209,8 @@ describe('detectDoubleGeoreference', () => {
     });
   });
 
-  describe('overridesAuthoredScale', () => {
-    it('is false when the effective horizontal scale is already 1', () => {
+  describe('scaleForExport', () => {
+    it('is null when the effective horizontal scale is already 1', () => {
       // #2526's file: Scale unset on a mm project with a metre MapUnit, which
       // getEffectiveHorizontalScale already resolves to 1. Nothing about the
       // model's size is being overridden, so the note must not claim it is.
@@ -220,10 +221,10 @@ describe('detectDoubleGeoreference', () => {
         0.001,
       );
       assert.ok(found);
-      assert.strictEqual(found!.overridesAuthoredScale, false);
+      assert.strictEqual(found!.scaleForExport, null);
     });
 
-    it('is true for a NEAR-unit scale whose induced drift is still kilometres', () => {
+    it('carries the unit bridge for a NEAR-unit scale whose induced drift is still kilometres', () => {
       // Effective scale 1.004 is inside detectScaleUnitMismatch's 0.5% band,
       // but multiplied by a ~6 000 km coordinate it drags the model ~24 km. A
       // fraction-based tolerance would wave this through; the guard pins
@@ -236,10 +237,35 @@ describe('detectDoubleGeoreference', () => {
         1,
       );
       assert.ok(found);
-      assert.strictEqual(found!.overridesAuthoredScale, true);
+      // Metre project + metre MapUnit, so the bridge is 1 / 1 = 1 — writing
+      // that back is what makes the EXPORTED file read at 1x in a spec-strict
+      // consumer, which zeroing the offsets alone would not achieve.
+      assert.ok(found!.scaleForExport !== null, 'a 24 km drift must be correctable on export');
+      assert.ok(Math.abs(found!.scaleForExport! - 1) < 1e-12);
     });
 
-    it('is false for a genuine foot/metre bridge', () => {
+    it('carries the mm/metre unit bridge when Scale is explicitly off-spec', () => {
+      // Scale explicitly 1000 on a mm project: the unset-Scale heuristic does
+      // not rescue it, so 1e6 is applied. The value the file needs is
+      // lengthUnitScale / mapUnitScale = 0.001.
+      const scaled: MapConversion = { ...ISSUE_2526_CONVERSION, scale: 1000 };
+      const found = detectDoubleGeoreference(
+        scaled,
+        METRE_CRS,
+        coordInfoAt(ISSUE_2526_CENTER.x, ISSUE_2526_CENTER.y),
+        0.001,
+      );
+      assert.ok(found);
+      assert.ok(found!.scaleForExport !== null);
+      assert.ok(Math.abs(found!.scaleForExport! - 0.001) < 1e-12);
+      // And it must actually neutralise: (0.001 x 1) / 0.001 = 1.
+      assert.strictEqual(
+        getEffectiveHorizontalScale(found!.scaleForExport!, 1, 0.001),
+        1,
+      );
+    });
+
+    it('is null for a genuine foot/metre bridge', () => {
       // A real bridge needs the units to DIFFER: a foot project with a metre
       // MapUnit, and Scale = 0.3048 doing exactly what the schema asks. The
       // effective scale is then (0.3048 × 1) / 0.3048 = 1 — nothing is
@@ -252,7 +278,7 @@ describe('detectDoubleGeoreference', () => {
         0.3048,
       );
       assert.ok(found);
-      assert.strictEqual(found!.overridesAuthoredScale, false);
+      assert.strictEqual(found!.scaleForExport, null);
     });
   });
 
@@ -393,8 +419,23 @@ describe('detectDoubleGeoreference', () => {
       0.001,
     );
     assert.ok(found);
-    assert.strictEqual(found!.overridesAuthoredScale, false);
+    assert.strictEqual(found!.scaleForExport, null);
     assert.ok(Number.isFinite(found!.displacement));
+  });
+});
+
+describe('trimFloat', () => {
+  it('drops the trailing zeros toPrecision leaves on a value the user must retype', () => {
+    // The Scale the note names goes into a text field. `toPrecision(4)` renders
+    // the mm/metre unit bridge as "0.001000", which reads as a precision claim
+    // the value does not make.
+    assert.strictEqual(trimFloat(0.001), '0.001');
+    assert.strictEqual(trimFloat(1), '1');
+    assert.strictEqual(trimFloat(0.3048), '0.3048');
+  });
+
+  it('still rounds a value that genuinely needs it', () => {
+    assert.strictEqual(trimFloat(1 / 3), '0.333333');
   });
 });
 

--- a/apps/viewer/src/lib/geo/double-georeference.ts
+++ b/apps/viewer/src/lib/geo/double-georeference.ts
@@ -81,16 +81,26 @@ export interface DoubleGeoreference {
    */
   overridesAuthoredRotation: boolean;
   /**
-   * True when the neutralised conversion also replaces an authored `Scale`
+   * Non-null when the neutralised conversion also replaces an authored `Scale`
    * that ifc-lite would otherwise have applied — i.e. the effective horizontal
    * scale for this file is not 1. Left alone it would keep re-scaling the
    * map-sized coordinates about the map origin (a UTM point scale of 0.9996 on
    * a 6 000 km northing is ~2.4 km of drift), so the guard pins it to 1.
    *
-   * Reported for the same reason as the rotation: it is a value of the user's
-   * file that the placement on screen does not honour.
+   * Carries the `Scale` value the FILE would need for the spec-strict formula
+   * to leave its own absolute coordinates alone: the unit bridge
+   * `lengthUnitScale / mapUnitScale`. Reported for two reasons — it is a value
+   * of the user's file that the placement on screen does not honour, and
+   * zeroing only the offsets is then not enough to bake the correction into an
+   * export. A spec-compliant consumer reading such a file back would still
+   * rescale the map-sized coordinates about the map origin, so any instruction
+   * that stops at Eastings/Northings/rotation would be wrong. (PR review.)
+   *
+   * Null when the effective horizontal scale is already 1, which covers both a
+   * spec-correct unit bridge and the unset-Scale heuristic — so a genuine
+   * foot/metre bridge is neither overridden nor mentioned.
    */
-  overridesAuthoredScale: boolean;
+  scaleForExport: number | null;
 }
 
 /**
@@ -147,6 +157,8 @@ export function detectDoubleGeoreference(
   // One metre at the model's own distance from the origin is what matters.
   const worldMagnitude = Math.hypot(ifcX, ifcY);
   const scaleIsUnit = Math.abs(scale - 1) * worldMagnitude <= 1;
+  const mapUnitScale = mapScale > 0 ? mapScale : 1;
+  const lengthScale = lengthUnitScale > 0 ? lengthUnitScale : 1;
 
   return {
     worldCenter: { x: ifcX, y: ifcY },
@@ -154,7 +166,7 @@ export function detectDoubleGeoreference(
     residual: Math.hypot(ifcX - easting, ifcY - northing),
     displacement: Math.hypot(appliedE - ifcX, appliedN - ifcY),
     overridesAuthoredRotation: !rotationIsIdentity,
-    overridesAuthoredScale: !scaleIsUnit,
+    scaleForExport: scaleIsUnit ? null : lengthScale / mapUnitScale,
   };
 }
 
@@ -175,6 +187,17 @@ export function detectDoubleGeoreference(
  * actually implies instead. A file that also mis-scales lands there easily: a
  * 1000× scale on map-sized coordinates produces billions of km.
  */
+/**
+ * A float as the shortest string that still round-trips to the same value at 6
+ * significant figures — `0.001`, not `toPrecision(4)`'s `0.001000`. Used for
+ * the `Scale` value the note tells the user to type into a field, where
+ * trailing zeros read as a precision claim the number does not carry.
+ */
+export function trimFloat(value: number): string {
+  if (!Number.isFinite(value)) return String(value);
+  return String(Number(value.toPrecision(6)));
+}
+
 export function formatApproxDistance(metres: number): string {
   if (!Number.isFinite(metres)) return 'an unknown distance';
   if (metres > 100_000_000) return 'more than a planet-width';

--- a/apps/viewer/src/lib/geo/double-georeference.ts
+++ b/apps/viewer/src/lib/geo/double-georeference.ts
@@ -3,114 +3,106 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
- * Detect a model that is georeferenced TWICE.
+ * REPORT a model that is georeferenced TWICE — the user-facing half of #2526.
  *
  * Some authoring tools place the `IfcSite` (and therefore every element under
  * it) at absolute map coordinates via its `IfcLocalPlacement`, AND also emit an
  * `IfcMapConversion` carrying the very same eastings/northings. Per IFC4 the
  * conversion is defined on the `IfcGeometricRepresentationContext`'s world
- * coordinate system, so the correct reading is to apply it on top of those
- * already-absolute coordinates — which adds the offset a second time and flings
- * the model roughly `‖(E, N)‖` away from where it belongs. Issue #2526: a
- * Vectorworks export in EPSG:25833 (E 311 988 / N 5 996 149) landed thousands
- * of km out in the North Atlantic, on an empty basemap.
+ * coordinate system, so the spec-strict reading applies it on top of those
+ * already-absolute coordinates — adding the offset a second time and flinging
+ * the model thousands of km away. Issue #2526: a Vectorworks export in
+ * EPSG:25833 (E 311 988 / N 5 996 149) landed in the North Atlantic.
  *
- * The fingerprint is unusually crisp, which is why this is a translation match
- * rather than an "is the result inside the CRS's area of use" test (we ship no
- * area-of-use extents, and that test has a far larger false-positive surface):
+ * ## One threshold, one code path
  *
- *   1. the model's world centre is itself already map-sized (>= 100 km from the
- *      IFC origin — no ordinary local-frame model is), AND
- *   2. that centre coincides with the MapConversion offset to within a
- *      tolerance that a duplicated value clears trivially and an independent
- *      value essentially never does.
+ * ifc-lite does not render that reading. `effectiveMapConversionForGeometry`
+ * ({@link ./map-absolute}) neutralises the duplicated conversion for every
+ * geometry-derived consumer, so the model lands where it belongs. This module
+ * exists purely to TELL the user that happened — and it must agree with the
+ * correction exactly, or the panel ends up describing a model that is not the
+ * one on screen.
  *
- * A correctly authored absolute-coordinate model (buildingSMART LoGeoRef 20/30)
- * fails (2) precisely because its conversion offset is 0/0, so it is not
- * flagged. A correctly authored local-frame model fails (1).
- *
- * This module only REPORTS. Nothing here changes placement: the viewer keeps
- * rendering the file as authored, and the georeferencing panel offers the user
- * a one-click correction.
+ * So the fingerprint is NOT re-implemented here. {@link detectDoubleGeoreference}
+ * calls the very same guard the geometry pipeline calls and reports iff that
+ * guard fired. There is one predicate and one set of constants, and they live
+ * with the correction. An earlier version of this module carried its own
+ * thresholds (world magnitude >= 100 km, residual <= max(1 km, 0.1% of the
+ * offset)); those were close to the guard's but not identical, which left a
+ * band of models that would be silently corrected without being flagged, and
+ * another that would be flagged without being corrected. (#2526, #2543/#2534
+ * reconciliation.)
  */
 
 import type { MapConversion, ProjectedCRS } from '@ifc-lite/parser';
 import type { CoordinateInfo } from '@ifc-lite/geometry';
 
-import { computeModelCenterInIfcMeters } from './reproject';
+import { computeModelCenterInIfcMeters, effectiveMapConversionForGeometry } from './map-absolute';
 import { getEffectiveHorizontalScale, resolveMapUnitToMetreScale } from './geo-scale';
-
-/**
- * How far the model centre must sit from the IFC origin before a coincidence
- * with the MapConversion offset means anything. A local-frame building model
- * lives within a few km of its origin; 100 km is comfortably clear of even a
- * sprawling site or an infrastructure alignment, while every map-coordinate
- * easting/northing pair worth worrying about is in the 10^5..10^7 m range.
- */
-const MIN_WORLD_MAGNITUDE_M = 100_000;
-
-/**
- * Absolute floor on the coincidence tolerance. The model CENTRE is compared
- * against the offset, and the offset is normally the site/project origin, so
- * the two differ by roughly half the model's plan extent. 1 km covers any
- * building and most sites outright.
- */
-const MIN_RESIDUAL_TOLERANCE_M = 1_000;
-
-/**
- * Relative part of the coincidence tolerance, applied to the magnitude of the
- * offset. Keeps large-extent models (infrastructure alignments, whole
- * districts) inside the tolerance without widening it for small coordinates.
- */
-const RESIDUAL_TOLERANCE_FRACTION = 0.001;
 
 export interface DoubleGeoreference {
   /** Model centre in IFC world metres, Z-up (X ≈ easting, Y ≈ northing). */
   worldCenter: { x: number; y: number };
   /** `IfcMapConversion` eastings/northings converted to metres. */
   offset: { easting: number; northing: number };
-  /** Distance between the two, metres. Small by construction when flagged. */
+  /** Distance between the two, metres. Small by construction when reported. */
   residual: number;
   /**
-   * How far the duplicated offset displaces the model, in projected metres:
-   * the distance from where the geometry already sits in the map CRS to where
-   * applying the conversion puts it. This is the size of the error the user
-   * sees, and it is NOT simply ‖offset‖ — the conversion's rotation swings the
-   * (already map-sized) world centre around as well.
+   * How far the duplicated offset WOULD displace the model, in projected
+   * metres: the distance from where the geometry already sits in the map CRS
+   * to where a spec-strict application of the conversion would put it.
+   *
+   * Counterfactual, not current state — ifc-lite has already neutralised the
+   * conversion by the time this is reported. It is the size of the error the
+   * user would see in a tool that applies the file literally, which is what
+   * makes it worth quoting: it is the number that explains why this file needs
+   * fixing at source.
+   *
+   * NOT simply ‖offset‖ — the conversion's rotation swings the (already
+   * map-sized) world centre around as well. Non-finite when the file authors a
+   * non-finite axis or scale; callers must render that as "unknown" rather
+   * than a number (see `formatApproxDistance`).
    */
   displacement: number;
   /**
-   * True when the fix would REPLACE a rotation the file actually authors,
-   * rather than just restating an already-identity one.
+   * True when the neutralised conversion REPLACES a rotation the file actually
+   * authors, rather than just restating an already-identity one.
    *
    * The fingerprint matches on translation, so it says nothing about whether
-   * the model's local axes are grid-aligned. The fix resets the axis anyway,
-   * because there is no translation-only alternative to offer (see
-   * {@link identityConversionFields}) — but when this is true, the orientation
-   * it lands on is OUR choice rather than the file's, and callers must say so
-   * instead of applying it silently. (PR #2543 review.)
+   * the model's local axes are grid-aligned. The guard resets the axis anyway,
+   * because a non-identity rotation acting on a map-sized coordinate is
+   * unrecoverable whatever the offsets are — but when this is true, the
+   * orientation on screen is OUR choice rather than the file's, and callers
+   * must say so instead of leaving it implicit.
    *
-   * An earlier version also treated a non-zero `CoordinateInfo.buildingRotation`
-   * as corroboration, on the theory that a rotating site placement is what
-   * turns the local frame INTO the map frame. That is evidence, not proof: the
-   * placement rotation and the conversion's axis can simply disagree (they do
-   * in #2526 — -117.833° versus +90°), and picking the placement silently is
-   * exactly the outcome the flag exists to prevent. A caveat sentence costs a
-   * line of prose; a silently mis-oriented model costs a re-export.
+   * (The site placement's own rotation is NOT taken as corroboration: the
+   * placement rotation and the conversion's axis can simply disagree, and they
+   * do in #2526 — −117.833° versus +90°.)
    */
   overridesAuthoredRotation: boolean;
   /**
-   * True when the fix must also rewrite `Scale`, because the scale the viewer
-   * currently applies is not 1 and would keep mis-sizing the geometry about the
-   * map origin after the offsets are cleared. Carries the value to write.
+   * True when the neutralised conversion also replaces an authored `Scale`
+   * that ifc-lite would otherwise have applied — i.e. the effective horizontal
+   * scale for this file is not 1. Left alone it would keep re-scaling the
+   * map-sized coordinates about the map origin (a UTM point scale of 0.9996 on
+   * a 6 000 km northing is ~2.4 km of drift), so the guard pins it to 1.
+   *
+   * Reported for the same reason as the rotation: it is a value of the user's
+   * file that the placement on screen does not honour.
    */
-  scaleCorrection: number | null;
+  overridesAuthoredScale: boolean;
 }
 
 /**
  * Report a duplicated georeference, or `null` when the model does not match the
- * fingerprint. See the module header for the two conditions and why they are
- * safe against correctly authored files.
+ * fingerprint.
+ *
+ * Fires **iff** {@link effectiveMapConversionForGeometry} neutralised the
+ * conversion for the geometry — see the module header. That guard returns its
+ * argument unchanged when it does not fire and a fresh object when it does, so
+ * reference identity is the exact question "did the placement on screen differ
+ * from the file?". `map-absolute.test.ts` pins the unchanged-return half of
+ * that contract; `double-georeference.test.ts` pins both halves from here.
  *
  * @param conversion      Effective `IfcMapConversion` (file values + any edits).
  * @param crs             Effective `IfcProjectedCRS` (for `mapUnitScale`).
@@ -126,106 +118,66 @@ export function detectDoubleGeoreference(
   if (!conversion || !coordinateInfo) return null;
 
   const mapScale = resolveMapUnitToMetreScale(crs?.mapUnitScale, lengthUnitScale);
+  const neutralised = effectiveMapConversionForGeometry(conversion, mapScale, coordinateInfo);
+  if (neutralised === conversion) return null;
+
   const easting = conversion.eastings * mapScale;
   const northing = conversion.northings * mapScale;
-  if (!Number.isFinite(easting) || !Number.isFinite(northing)) return null;
-
   const { ifcX, ifcY } = computeModelCenterInIfcMeters(coordinateInfo);
-  if (!Number.isFinite(ifcX) || !Number.isFinite(ifcY)) return null;
 
-  const worldMagnitude = Math.hypot(ifcX, ifcY);
-  if (worldMagnitude < MIN_WORLD_MAGNITUDE_M) return null;
-
-  const offsetMagnitude = Math.hypot(easting, northing);
-  const residual = Math.hypot(ifcX - easting, ifcY - northing);
-  const tolerance = Math.max(
-    MIN_RESIDUAL_TOLERANCE_M,
-    RESIDUAL_TOLERANCE_FRACTION * offsetMagnitude,
-  );
-  if (residual > tolerance) return null;
-
-  // Where applying the conversion puts the model, versus where its geometry
-  // already sits in the map CRS. Mirrors `computeProjectedCenter` exactly,
+  // Where a spec-strict tool would put the model, versus where its geometry
+  // already sits in the map CRS. Mirrors `computeProjectedCenter` exactly —
   // including the `?? 1 / ?? 0` axis defaults and the effective (not raw)
-  // horizontal scale, so the reported error is the one the viewer renders.
+  // horizontal scale — so the quoted error is the one such a tool renders.
+  //
+  // Deliberately NOT guarded against a non-finite axis or Scale. The guard
+  // above does not inspect either, so a malformed file is still corrected on
+  // screen; bailing here would move it silently and say nothing. Quote "an
+  // unknown distance" instead of suppressing the whole message. (#2526.)
   const abscissa = conversion.xAxisAbscissa ?? 1;
   const ordinate = conversion.xAxisOrdinate ?? 0;
   const scale = getEffectiveHorizontalScale(conversion.scale, mapScale, lengthUnitScale);
-  // `hasStandardGeoreferencing` deliberately does NOT gate on the axis pair or
-  // Scale being finite (see effective-georef.ts), so a NaN can reach here. It
-  // would poison `displacement` and make `rotationIsIdentity` false by
-  // accident, i.e. we would flag a malformed file and quote it a nonsense
-  // number. Stay quiet instead. (PR #2543 review.)
-  if (!Number.isFinite(abscissa) || !Number.isFinite(ordinate) || !Number.isFinite(scale)) {
-    return null;
-  }
   const appliedE = easting + scale * (abscissa * ifcX - ordinate * ifcY);
   const appliedN = northing + scale * (ordinate * ifcX + abscissa * ifcY);
 
   const rotationIsIdentity = Math.abs(abscissa - 1) < 1e-9 && Math.abs(ordinate) < 1e-9;
-  // `scale` above is the EFFECTIVE horizontal scale, i.e. what the viewer
-  // actually applies to metre geometry. Anything other than 1 keeps re-scaling
-  // the map-sized coordinates about the map origin after the offsets are
-  // cleared, so "already in the map CRS" would still be false. The Scale value
-  // that makes the effective scale 1 is the spec unit bridge,
-  // lengthUnitScale / mapUnitScale.
-  //
-  // The tolerance is expressed as INDUCED POSITION ERROR, not as a fraction.
-  // `detectScaleUnitMismatch`'s 0.5% band is calibrated for geometry sitting a
-  // few tens of metres from its own origin; here the scale multiplies a
-  // map-sized coordinate, so 0.4% of a 6 000 km easting is 24 km of drift — a
-  // fraction-based band would wave that through. One metre at the model's own
-  // distance from the origin is the threshold that matters. (PR #2543 review.)
+  // The tolerance is expressed as INDUCED POSITION ERROR, not as a fraction:
+  // this scale multiplies a map-sized coordinate, so 0.4% of a 6 000 km
+  // easting is 24 km of drift and a fraction-based band would wave it through.
+  // One metre at the model's own distance from the origin is what matters.
+  const worldMagnitude = Math.hypot(ifcX, ifcY);
   const scaleIsUnit = Math.abs(scale - 1) * worldMagnitude <= 1;
-  const mapUnitScale = mapScale > 0 ? mapScale : 1;
-  const lengthScale = lengthUnitScale > 0 ? lengthUnitScale : 1;
 
   return {
     worldCenter: { x: ifcX, y: ifcY },
     offset: { easting, northing },
-    residual,
+    residual: Math.hypot(ifcX - easting, ifcY - northing),
     displacement: Math.hypot(appliedE - ifcX, appliedN - ifcY),
     overridesAuthoredRotation: !rotationIsIdentity,
-    scaleCorrection: scaleIsUnit ? null : lengthScale / mapUnitScale,
+    overridesAuthoredScale: !scaleIsUnit,
   };
 }
 
 /**
- * The `IfcMapConversion` field values that make the conversion a horizontal
- * identity, i.e. "the geometry is already in the map CRS".
+ * Metres → a short human-readable distance for the sentence the banner builds
+ * around it ("about 6,004 km", "about 820 m").
  *
- * `OrthogonalHeight` is deliberately absent. The fingerprint this module matches
- * is a duplicated HORIZONTAL offset and says nothing about the vertical: zeroing
- * an `OrthogonalHeight` that legitimately carries the site altitude (while the
- * geometry Z is local) would trade a horizontal error for a vertical one.
+ * The grouping locale is pinned to `en-US` on purpose. The viewer's UI is
+ * English-only, and a bare `toLocaleString()` groups in the BROWSER's locale
+ * instead: on the reporter's German browser 6 004 km printed as
+ * "about 6.004 km", which inside an English sentence reads as six metres. That
+ * is the exact text quoted back on #2526 — a real placement error, made to
+ * look like a formatting bug. A number embedded in prose has to be formatted
+ * in the language of the prose.
  *
- * The axis pair is always included, and `Scale` is included when
- * {@link DoubleGeoreference.scaleCorrection} is set. Neither is symmetric with
- * `OrthogonalHeight`, because both act on the coordinates BEFORE the
- * translation: a non-identity rotation or scale applied to a map-sized world
- * coordinate moves the model by a distance of order ‖world‖ — millions of
- * metres — no matter what the offsets are. Leaving either while zeroing the
- * offsets would move the model from one wrong continent to another, so there is
- * no "offsets-only" fix to offer. (PR #2543 review.)
- *
- * `Scale` is left alone when the EFFECTIVE horizontal scale is already 1, which
- * covers both a spec-correct unit bridge and the unset-Scale heuristic — so a
- * genuine foot/metre bridge survives untouched.
- *
- * @param scaleCorrection `DoubleGeoreference.scaleCorrection`: the Scale value
- *   that makes the effective horizontal scale 1, or null to leave Scale alone.
+ * Past ~2.5 Earth circumferences the figure stops meaning anything to a reader
+ * and starts looking like a formatting bug in its own right, so say what it
+ * actually implies instead. A file that also mis-scales lands there easily: a
+ * 1000× scale on map-sized coordinates produces billions of km.
  */
-export function identityConversionFields(
-  scaleCorrection: number | null = null,
-): Array<{ field: string; value: number }> {
-  const fields = [
-    { field: 'eastings', value: 0 },
-    { field: 'northings', value: 0 },
-    { field: 'xAxisAbscissa', value: 1 },
-    { field: 'xAxisOrdinate', value: 0 },
-  ];
-  if (scaleCorrection !== null) {
-    fields.push({ field: 'scale', value: scaleCorrection });
-  }
-  return fields;
+export function formatApproxDistance(metres: number): string {
+  if (!Number.isFinite(metres)) return 'an unknown distance';
+  if (metres > 100_000_000) return 'more than a planet-width';
+  if (metres >= 1000) return `about ${Math.round(metres / 1000).toLocaleString('en-US')} km`;
+  return `about ${Math.round(metres).toLocaleString('en-US')} m`;
 }

--- a/apps/viewer/src/lib/geo/kmz-export.ts
+++ b/apps/viewer/src/lib/geo/kmz-export.ts
@@ -16,7 +16,7 @@ import { mergeMapConversion, mergeProjectedCRS } from './effective-georef';
 import { resolveMapUnitToMetreScale } from './geo-scale';
 import { effectiveMapConversionForGeometry } from './map-absolute';
 import { reprojectToLatLon } from './reproject';
-import { buildKmz, type KmzAltitudeMode } from './kmz-exporter';
+import { buildKmz, type KmzAltitudeMode, type KmzProcessor } from './kmz-exporter';
 import { suggestAbsoluteAltitudeForKmz } from './kmz-altitude-hint';
 
 /** True if the data store carries usable georeferencing (so a KMZ export can run). */
@@ -106,11 +106,81 @@ export function resolveKmzHeading(
 }
 
 /**
+ * A georeference that has ALREADY been merged with pending edits — what a panel
+ * holding `mergedConversion`/`mergedCRS` props has in hand, and what
+ * {@link buildKmzForModel} produces after extracting from the data store.
+ */
+export interface ResolvedKmzGeorefInput {
+  /** Merged `IfcMapConversion`. Passed AUTHORED; the map-absolute guard is applied here. */
+  conversion: MapConversion;
+  /** Merged `IfcProjectedCRS`. */
+  crs: ProjectedCRS;
+  /** From the model's `GeometryResult` (bounds + RTC offset). */
+  coordinateInfo: CoordinateInfo | undefined;
+  /** IFC project length unit to metres. */
+  lengthUnitScale: number;
+  meshes: MeshData[];
+  /** Display name / file stem. */
+  name: string;
+  altitudeMode?: KmzAltitudeMode;
+}
+
+/**
+ * THE place a georeference becomes a KMZ placement. Every surface that exports
+ * a KMZ goes through here, and none of them computes lat/lon, altitude or
+ * heading itself.
+ *
+ * That is the whole point of the function existing (#2526 follow-up). The
+ * Location panel's "Google Earth" button used to call {@link buildKmz}
+ * directly with `mapConversion.xAxisAbscissa/xAxisOrdinate` and a raw
+ * `mapConversion.orthogonalHeight`, while the Export KMZ dialog went through
+ * `buildKmzForModel`. So the dialog got the map-absolute guard, the map-unit
+ * altitude scaling and the RTC Z fold-back, and the panel beside it got none
+ * of the three — same model, same button label, two different files, no type
+ * error and no failing test to say so. A map-absolute file (#2526) exported
+ * from the panel came out rotated by the very axis the guard exists to
+ * suppress AND sunk by its whole site elevation.
+ *
+ * Callers hand over the AUTHORED (merged) conversion and get the corrected
+ * placement back; there is deliberately no way to pass a pre-guarded one, so
+ * a call site cannot opt out of the correction by accident.
+ *
+ * `createProcessor` is the same wasm seam {@link buildKmz} takes, forwarded so
+ * tests can drive this end to end without the engine.
+ */
+export async function buildKmzForResolvedGeoref(
+  input: ResolvedKmzGeorefInput,
+  createProcessor?: () => KmzProcessor,
+): Promise<Uint8Array | KmzBuildError> {
+  if (!input.meshes.length) return 'no-geometry';
+  const { conversion, crs, coordinateInfo, lengthUnitScale } = input;
+  const latLon = await reprojectToLatLon(conversion, crs, coordinateInfo, lengthUnitScale);
+  if (!latLon) return 'unprojectable';
+  const heading = resolveKmzHeading(conversion, crs, lengthUnitScale, coordinateInfo);
+  const opts = {
+    latLon,
+    altitude: computeKmzAltitude(conversion.orthogonalHeight, crs, lengthUnitScale, coordinateInfo),
+    xAxisAbscissa: heading.xAxisAbscissa,
+    xAxisOrdinate: heading.xAxisOrdinate,
+    meshes: input.meshes,
+    name: input.name,
+    altitudeMode: input.altitudeMode,
+  };
+  return createProcessor ? buildKmz(opts, createProcessor) : buildKmz(opts);
+}
+
+/**
  * Resolve a model's (merged) georeference to WGS84 and build a Google Earth KMZ
  * (a COLLADA model + KML placement). Returns the KMZ bytes, or a `KmzBuildError`
  * string when the model isn't georeferenced or its location can't be projected.
+ *
+ * Extraction + merge only; the placement itself is
+ * {@link buildKmzForResolvedGeoref}'s, shared with the Location panel.
  */
-export async function buildKmzForModel(input: BuildKmzInput): Promise<Uint8Array | KmzBuildError> {
+export async function buildKmzForModel(
+  input: BuildKmzInput,
+  createProcessor?: () => KmzProcessor,
+): Promise<Uint8Array | KmzBuildError> {
   if (!input.geometryResult.meshes?.length) return 'no-geometry';
   const info = extractGeoreferencingOnDemand(input.dataStore);
   const scale = extractLengthUnitScale(input.dataStore.source, input.dataStore.entityIndex) ?? 1;
@@ -121,21 +191,13 @@ export async function buildKmzForModel(input: BuildKmzInput): Promise<Uint8Array
   const conversion = mergeMapConversion(info?.mapConversion, input.mutations?.mapConversion);
   const crs = mergeProjectedCRS(info?.projectedCRS, input.mutations?.projectedCRS, scale);
   if (!conversion || !crs) return 'not-georeferenced';
-  const latLon = await reprojectToLatLon(conversion, crs, input.geometryResult.coordinateInfo, scale);
-  if (!latLon) return 'unprojectable';
-  const heading = resolveKmzHeading(conversion, crs, scale, input.geometryResult.coordinateInfo);
-  return buildKmz({
-    latLon,
-    altitude: computeKmzAltitude(
-      conversion.orthogonalHeight,
-      crs,
-      scale,
-      input.geometryResult.coordinateInfo,
-    ),
-    xAxisAbscissa: heading.xAxisAbscissa,
-    xAxisOrdinate: heading.xAxisOrdinate,
+  return buildKmzForResolvedGeoref({
+    conversion,
+    crs,
+    coordinateInfo: input.geometryResult.coordinateInfo,
+    lengthUnitScale: scale,
     meshes: input.geometryResult.meshes as MeshData[],
     name: input.name,
     altitudeMode: input.altitudeMode,
-  });
+  }, createProcessor);
 }


### PR DESCRIPTION
## What

Reconciles the **detection** half of #2526 (#2543, merged) with the **correction** half (#2534, @BIMvoice, open), and fixes the display bug the reporter quoted back.

**#2534 has merged; this is rebased onto `main` and now contains only its own three-commit change.**

## Why

With both changes present, the outcome was incoherent. `effectiveMapConversionForGeometry` places the reporter's model correctly in Rostock, and `detectDoubleGeoreference` still reported `displacement: 6004291` — so the panel told the user their model was 6 000 km out while they were looking at it in the right place, and offered a button to "fix" it. The two also used different windows (#2534's fixed 10 km against #2543's `max(1 km, 0.1%)`), so a model could be corrected without being flagged, or flagged without being corrected.

## One threshold, one code path

`detectDoubleGeoreference` no longer re-implements the fingerprint. It calls the same guard the geometry pipeline calls and reports **iff** that guard neutralised the conversion:

```ts
const neutralised = effectiveMapConversionForGeometry(conversion, mapScale, coordinateInfo);
if (neutralised === conversion) return null;
```

The constants live with the correction, in `map-absolute.ts`, and there is now exactly one of them. The panel cannot disagree with the placement in either direction, at any threshold. `double-georeference.ts` loses `MIN_WORLD_MAGNITUDE_M`, `MIN_RESIDUAL_TOLERANCE_M` and `RESIDUAL_TOLERANCE_FRACTION`.

Pinned by an invariant test sweeping residuals across the window — `reported === corrected` at 0, 1 000, 6 004, 8 000, 9 999, 10 001, 20 000 and 400 000 m — plus a named test for the 8 km case that sat in the gap between the two old tolerances.

## Correct it, and say so

The note becomes informational and loses its button. The model on screen is already right, so an amber alarm misreports it; and the button's only remaining effect was to write **our** substituted rotation into the user's authored data and export it. The manual route is named in the note instead, for anyone who wants a corrected file to take to another tool.

## The display bug

The displacement was rendered with a bare `toLocaleString()`, which groups in the **browser's** locale while the sentence around it is English. On the reporter's German browser, 6 004 km printed as `about 6.004 km` — six metres. Pinned to `en-US` (the viewer has no i18n), and tested under a simulated German ambient locale: under an en-US runner the old code produces the identical string, so a test that does not move the locale cannot fail.

`scaleCorrection` (a value for the removed button to write) becomes `scaleForExport: number | null`, which the note names — zeroing only the offsets does not bake the correction into an export when the authored `Scale` is one ifc-lite overrides. A malformed axis is now reported rather than suppressed: the guard does not inspect the axis, so such a file **is** still moved, and going silent would move it without explanation.

## Verification

Browser, the reporter's actual file (attached to #2526), coordinate readout and note read together:

| | pin | note |
|---|---|---|
| this branch | **54.07927, 12.12622** (Rostock, basemap under it) | present, informational, "about 6,004 km", no button |
| correction disabled | **33.71362, -49.11519** — his exact reported point | **absent** |
| LoGeoRef-30 control | 54.07932, 12.12573, offset intact, no RTC rebase | **absent** |

The second row is the coupling: the note and the correction move together, so the panel can never claim a correction that did not happen. The third is the safety control — site placement at the local origin, `IfcMapConversion` carrying the single legitimate offset — which is neither corrected nor flagged.

The panel feeds `LocationMap` the same `mergedConversion` object the detector reads, so the pin and the note cannot drift even after a user edit. Checked by doing: setting Eastings, Northings and Angle to Grid North to 0 through the real fields clears the note (nothing left to correct) and leaves the pin at **54.07927, 12.12622**. That is the removed button's action performed by hand — it converges on the same place, so dropping the button loses nothing, and the instruction the note now gives is correct.

Site elevation intact: `wasmRtcOffset.z = 14`, model centre 14 + 1.78 = **15.78 m**.

Mutations, all killed, read off the test count with a control run first (27→28→30 pass / 0 fail):

| mutation | result |
|---|---|
| `toLocaleString('en-US')` → `toLocaleString()` | 2 fail |
| re-introduce a second threshold in the detector | 2 fail |
| remove the shared-guard gate | 7 fail |
| `scaleForExport` → wrong value | 1 fail |
| `overridesAuthoredRotation` → constant | 1 fail |
| (#2534's) batch-path `wasmMetadataProps()` dropped | geometry 325 → 1 fail |

The last row is not mine to fix, but it is the one that carries the reporter's *height*, so I confirmed it is genuinely guarded rather than taking it on trust.

Gates, `--force`, "0 cached": `npx turbo typecheck` 77/77; `npx turbo test` 86/86 — viewer 3844 tests / 3838 pass / 0 fail / 6 skipped, geometry 325 pass. No Rust touched. `apps/viewer` is private, so no changeset.

Closes #2526 once #2534 has merged.


## Follow-up in the same PR: the sibling KMZ call site

Codex (P2) found the map-absolute guard reaching only `buildKmzForModel`, so the Export KMZ dialog got it and the Location panel's "Google Earth" button did not. Confirmed on the reporter's file, and the panel was skipping **three** corrections, not one — it also bypassed `computeKmzAltitude`, losing both the map-unit scaling and the wasm RTC Z fold-back:

| | heading axis | KML altitude |
|---|---|---|
| before | `(0, 1)` — the authored 90 deg rotation | `0` |
| after | `(1, 0)` — guarded identity | `14` (the reporter's site elevation) |

Swept every caller rather than fixing only the named site: `buildKmz` has exactly two production callers and there is no third. Both now go through one `buildKmzForResolvedGeoref`, which takes the **authored** conversion and guards internally — a call site can no longer opt out by accident.

The call site was untestable, which is how it drifted: the wasm engine cannot load under `tsx --test`. `buildKmz`'s existing `createProcessor` seam is threaded one level up to a `createKmzProcessor` prop, and `LocationMap.kmz.test.tsx` mounts the real component and clicks the real button. Mutations: reverting the component to the raw call fails all three tests with exactly the pre-fix values; removing the guard from the shared builder fails the panel test *and* the dialog's unit test together.

Verified end to end in a browser as well — the real exporter's `doc.kml` for the reporter's file reads `latitude 54.0793`, `longitude 12.1262`, `altitude 14`.

### Flagged, not fixed: `ifc_angle_to_kml_heading` looks off by 90 degrees

`rust/export/src/kmz.rs`'s own test asserts `None -> 0`, `(0,0) -> 0`, but `(1,0) -> 90` — and `(1,0)` is the same geometric fact as the absent case, no rotation. The formula computes the compass **bearing** of the model's X axis and feeds it to KML `<heading>`, which is a **rotation**. Pre-existing, but #2534 moved map-absolute files from the authored `(0,1)` (heading 0, accidentally correct) onto the guarded `(1,0)` (heading 90). Not touched here: it is Rust with its own CI gate, it changes every KMZ export with an explicit axis, and confirming it really wants the file opened in Google Earth. Worth its own issue.
