### PR TITLE
fix(export): write the IFCX header version under `ifcxVersion`

### DIFF
--- a/.changeset/ifcx-export-header-version-key.md
+++ b/.changeset/ifcx-export-header-version-key.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Write the IFCX header version under `ifcxVersion`, so exported files can be read back. The Rust IFC5 exporter emitted `header.version`, but readers look for `header.ifcxVersion` — the key buildingSMART's own reference files use and the one `@ifc-lite/ifcx` requires. Every file `ifc-lite export --format ifcx` produced was therefore rejected by our own parser with "Invalid IFCX file: missing or invalid header.ifcxVersion", and `ifc-lite info` refused it as "not a valid IFC/STEP file". Every other IFCX writer in the repo (the TS `ifc5-exporter`, `packages/ifcx`'s writer, the layer-stack publish path) already used `ifcxVersion`; the Rust exporter was the only outlier. Verified by renaming just that key on an exported file: the same bytes go from rejected to parsed.

--- a/rust/export/src/ifc5.rs
+++ b/rust/export/src/ifc5.rs
@@ -186,7 +186,12 @@ pub fn export_ifc5(content: &[u8], opts: &Ifc5Options) -> String {
 
     let doc = json!({
         "header": {
-            "version": "ifcx_alpha",
+            // `ifcxVersion`, not `version`. That is the key buildingSMART's own
+            // reference files carry, and the one `@ifc-lite/ifcx` requires to
+            // recognise a file at all — so under the old name every file this
+            // exporter produced was rejected by our own parser with
+            // "Invalid IFCX file: missing or invalid header.ifcxVersion".
+            "ifcxVersion": "ifcx_alpha",
             "author": opts.author,
             "dataVersion": opts.data_version,
         },
@@ -215,7 +220,7 @@ mod tests {
     fn duplex_exports_valid_ifcx() {
         let s = export_ifc5(&fixture("ara3d/duplex.ifc"), &Ifc5Options::default());
         let v: Value = serde_json::from_str(&s).expect("valid JSON");
-        assert_eq!(v["header"]["version"], "ifcx_alpha");
+        assert_eq!(v["header"]["ifcxVersion"], "ifcx_alpha");
         assert_eq!(v["imports"][0]["uri"], IMPORT_CORE);
 
         let data = v["data"].as_array().expect("data array");
@@ -250,6 +255,37 @@ mod tests {
             })
         });
         assert!(has_prop, "expected a typed IFC5 property somewhere");
+    }
+
+    /// The header key a READER looks for, which is not the same thing as the
+    /// key this exporter happens to write.
+    ///
+    /// The assertion above was previously `header.version`, mirroring the
+    /// implementation — so it passed while every exported file was rejected by
+    /// `@ifc-lite/ifcx` ("missing or invalid header.ifcxVersion") and did not
+    /// match buildingSMART's own reference files either. Pinning the absence of
+    /// the old key is what makes that regression fail here instead of at the
+    /// other end of a round-trip.
+    #[test]
+    fn header_uses_the_key_readers_look_for() {
+        let s = export_ifc5(&fixture("ara3d/duplex.ifc"), &Ifc5Options::default());
+        let v: Value = serde_json::from_str(&s).expect("valid JSON");
+
+        let header = v["header"].as_object().expect("header object");
+        assert!(
+            header.contains_key("ifcxVersion"),
+            "header must carry ifcxVersion; got keys {:?}",
+            header.keys().collect::<Vec<_>>(),
+        );
+        assert!(
+            !header.contains_key("version"),
+            "the old `version` key is what readers ignore — it must not come back",
+        );
+        // Readers match case-insensitively on the substring "ifcx".
+        assert!(
+            header["ifcxVersion"].as_str().unwrap().to_lowercase().contains("ifcx"),
+            "ifcxVersion must contain 'ifcx'",
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What and why

The Rust IFC5 exporter wrote the header version under `version`. Readers look
for `ifcxVersion` — the key buildingSMART's own reference file carries
(`apps/viewer/public/samples/hello-wall.ifcx`) and the one `@ifc-lite/ifcx`
requires to recognise a file at all.

So every file `ifc-lite export --format ifcx` produced was rejected by this
repo's own parser with `Invalid IFCX file: missing or invalid
header.ifcxVersion`, and `ifc-lite info` refused it as "not a valid IFC/STEP
file".

Every other IFCX writer here already uses `ifcxVersion`: the TS
`ifc5-exporter`, `packages/ifcx`'s writer, the layer-stack publish path, the
clash adapter's fixtures. The Rust exporter was the only outlier. Nothing reads
the old key — the other `header.version` hits are the unrelated binary cache
format.

The existing assertion mirrored the implementation (`header.version`), so it
stayed green throughout. The added test pins what a *reader* needs instead:
`ifcxVersion` present, the old key absent, and a value carrying the `ifcx`
substring readers match on.

## How it was verified

Took a file produced by `ifc-lite export --format ifcx` and renamed **only**
that header key, changing nothing else. Fed both to `parseIfcx`:

```
Header before: {"author":"ifc-lite","dataVersion":"1.0.0","version":"ifcx_alpha"}
  -> REJECTED: Invalid IFCX file: missing or invalid header.ifcxVersion
Header after:  {"ifcxVersion":"ifcx_alpha","author":"ifc-lite","dataVersion":"1.0.0"}
  -> parsed: schema IFC5, 361 entities
```

Also checked against the reference file: `parseIfcx` reads `hello-wall.ifcx`
(IFC5, 9 entities, 10 meshes), and its header uses `ifcxVersion` too — so the
parser is right and the Rust writer was the one out of step.

- [ ] `cargo test --workspace` (Rust) and/or `pnpm test` (TS) pass locally
- [ ] Geometry/WASM change: ran `scripts/build-wasm.sh` then `pnpm test:wasm-contract`

**Both boxes are deliberately unticked.** There is no Rust toolchain on the
machine this was written on — builds there go through the prebuilt
`@ifc-lite/wasm` from npm — so neither the Rust suite nor the WASM contract
tests were run. That the Rust compiles and the suite stays green is for CI to
show. The behavioural claim above is independent of it.

## Checklist

- [x] A test asserts the new behavior through a fixture or a stated invariant
- [x] Published `packages/*` touched: added a changeset (`@ifc-lite/wasm`,
      patch). No TS export surface changed, so `api-surface:update` was not
      needed.
- [x] Geometry-output change: none
- [x] House rules: no `as any` / `@ts-ignore`, no silent `catch {}`, no module
      pushed past ~400 non-generated lines, no repo-wide `cargo fmt`
- [x] No client or project identifiers in code, tests, commit messages, or this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated IFCX exports to use the standard `ifcxVersion` header key.
  * Improved compatibility with IFCX readers by ensuring generated files include the expected version information.
  * Added validation to prevent the legacy `version` key from appearing in exported files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->