### PR TITLE
fix(release): stop a failed npm publish from stranding the Rust crates

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "docs:check-readmes": "node scripts/docs/check-package-readmes.mjs",
     "changeset": "changeset",
     "version": "changeset version && node scripts/sync-versions.js",
-    "release": "pnpm build && pnpm test:esm && pnpm release:npm && pnpm release:crates",
+    "release": "pnpm build && pnpm test:esm && node scripts/release-all.mjs",
     "release:npm": "changeset publish",
     "release:crates": "node scripts/release-crates.mjs",
     "publish:npm": "pnpm -r publish --access public",

--- a/scripts/release-all.mjs
+++ b/scripts/release-all.mjs
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
  * Runs both halves of a release — npm, then crates.io — and reports on both.

--- a/scripts/release-all.mjs
+++ b/scripts/release-all.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+
+/**
+ * Runs both halves of a release — npm, then crates.io — and reports on both.
+ *
+ * This exists because the two were chained with `&&`:
+ *
+ *     pnpm release:npm && pnpm release:crates
+ *
+ * which makes the Rust half a hostage of the JavaScript half. On 2026-08-12
+ * `changeset publish` exited non-zero on ONE package (`@ifc-lite/source-dalux`,
+ * never published, so trusted publishing cannot create it — npm 404 on PUT).
+ * Every other npm package published fine, and `release:crates` then never ran.
+ * crates.io had been stranded at 4.3.0 since 2026-08-03 for that reason, while
+ * npm advanced through 4.4.0 to 4.4.1 — nine days in which the Rust fixes those
+ * npm changelogs advertised were not reachable from crates.io at all.
+ *
+ * Neither half is a precondition of the other: they publish to different
+ * registries from the same already-built artifacts. So both always run, and
+ * the exit code is non-zero if EITHER failed. A failure is never masked — the
+ * summary names which half broke, and a half that succeeded is not re-run or
+ * rolled back by the other's failure.
+ *
+ * `scripts/release-crates.mjs` skips versions already on crates.io, and
+ * `changeset publish` skips versions already on npm, so re-running after a
+ * partial failure is safe and picks up only what is missing.
+ */
+
+import { spawnSync } from 'child_process';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const rootDir = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+/** The two halves, in the order their output reads best. npm first: it is the
+ *  primary distribution channel and the one whose log the release action parses
+ *  for the published-package list. */
+const STEPS = [
+  { name: 'npm', script: 'release:npm' },
+  { name: 'crates.io', script: 'release:crates' },
+];
+
+const failed = [];
+
+for (const step of STEPS) {
+  console.log(`\n▶️  release: ${step.name} (pnpm ${step.script})`);
+  const result = spawnSync('pnpm', [step.script], {
+    cwd: rootDir,
+    stdio: 'inherit',
+    shell: process.platform === 'win32',
+  });
+  // A signal-killed child reports status null; treat anything that is not a
+  // clean 0 as a failure rather than letting `null !== 0` decide it silently.
+  const code = result.status ?? (result.error ? 1 : 1);
+  if (code === 0) {
+    console.log(`✅ release: ${step.name} finished`);
+    continue;
+  }
+  failed.push({ ...step, code, error: result.error });
+  // Keep going: the other registry is independent, and stranding it is the
+  // exact defect this script was written to remove.
+  console.error(`❌ release: ${step.name} FAILED (exit ${code}) — continuing with the remaining registries`);
+}
+
+if (failed.length > 0) {
+  console.error(
+    `\n❌ release incomplete — failed: ${failed.map((f) => f.name).join(', ')}`,
+  );
+  for (const f of failed) {
+    if (f.error) console.error(`   ${f.name}: ${f.error.message}`);
+  }
+  process.exit(1);
+}
+
+console.log('\n✅ release complete — npm and crates.io both published');


### PR DESCRIPTION
## What and why

crates.io has been stranded at **4.3.0 since 2026-08-03** while npm advanced through 4.4.0 to 4.4.1. `ifc-lite-core@4.4.0`, `@4.4.1`, `ifc-lite-wasm@4.4.0` and `@4.4.1` all 404 right now. The Rust exporter fixes that the npm changelogs advertise are not reachable from crates.io at all.

The cause is one `&&`:

```
pnpm build && pnpm test:esm && pnpm release:npm && pnpm release:crates
```

In today's release run, `changeset publish` exited non-zero on exactly one package. `@ifc-lite/source-dalux` has never been published, so trusted publishing cannot create it and npm 404s the PUT:

```
npm error 404 Not Found - PUT https://registry.npmjs.org/@ifc-lite%2fsource-dalux
```

Sixteen other packages published fine in that same run. `release:crates` never ran.

`scripts/release-crates.mjs` was written precisely so publish failures stop being invisible (it replaced a `cargo publish … || true` chain that had left `ifc-lite-wasm` broken at 2.3.0 for months). It cannot do that job if it never executes.

## The fix

The two halves publish already-built artifacts to different registries. Neither is a precondition of the other, so `scripts/release-all.mjs` runs both and exits non-zero if **either** failed. A failure is reported, not masked, and a half that succeeded is not held back by the other's failure.

Re-running after a partial failure is safe: `release-crates.mjs` skips versions already on crates.io, `changeset publish` skips versions already on npm.

**This does not fix the npm-side 404.** `@ifc-lite/source-dalux` still needs its name claimed by a manual first publish before trusted publishing can take over. What this changes is the blast radius: one unpublishable package no longer takes the entire Rust toolchain down with it. After this lands, the next push to main publishes the stranded crates through CI's OIDC token even while the npm half is still failing.

## How it was verified

The real command publishes, so the orchestrator was exercised against controlled exit codes in a throwaway workspace:

```
npm fails, crates ok  ->  crates STILL RUNS, exit 1, summary names npm   <- today's defect
both ok               ->  exit 0
crates fails          ->  exit 1, summary names crates.io
```

- [ ] A test asserts the new behavior through a fixture or a stated invariant

**Deliberately unticked.** There is no lane that runs root `scripts/*.mjs` tests, so an automated test needs a new test lane, which is a bigger call than this fix and one I would rather you make. The verification matrix above was run by hand. Say the word and I'll wire up the lane.

- [x] Published `packages/*` touched: none (root scripts only, so no changeset)
- [x] Geometry-output change: none
- [x] House rules: no `as any` / `@ts-ignore`, no silent `catch {}`, no repo-wide `cargo fmt`
- [x] No client or project identifiers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved release processing so package and crate releases are attempted independently.
  - Release results now clearly report successful and failed registry operations.
  - Failures are surfaced with actionable error details while allowing remaining release steps to complete.
  - The overall release process now exits with an appropriate status when any release operation fails.
  - A final success message is shown only when all release operations complete successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->