### PR TITLE
chore(scripts): add the missing MPL-2.0 headers

### DIFF
--- a/scripts/add-license-headers.mjs
+++ b/scripts/add-license-headers.mjs
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { readFileSync, writeFileSync, existsSync } from 'fs';
 import { join, dirname } from 'path';

--- a/scripts/check-api-surface.mjs
+++ b/scripts/check-api-surface.mjs
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 /**
  * Guard: the exported API surface of every published (non-private)
  * package in packages/* is snapshotted in scripts/api-surface.json.

--- a/scripts/check-git-lfs.mjs
+++ b/scripts/check-git-lfs.mjs
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 /**
  * check-git-lfs.mjs - a READ-ONLY detector for leftover Git LFS hooks.
  *

--- a/scripts/check-test-wiring.mjs
+++ b/scripts/check-test-wiring.mjs
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 /**
  * Guard: every workspace package that contains test files must have a
  * `test` script in its package.json, otherwise `turbo test` silently

--- a/scripts/release-crates.mjs
+++ b/scripts/release-crates.mjs
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
  * Publishes the publishable Rust crates to crates.io.

--- a/scripts/space-diag.mjs
+++ b/scripts/space-diag.mjs
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 /* Diagnostic: why does a model yield no walls / no rooms in Space Sketch?
  * Usage: node scripts/space-diag.mjs <path-to.ifc>
  * Parses headlessly and reports, per storey: byStorey count, walls considered,

--- a/scripts/sync-versions.js
+++ b/scripts/sync-versions.js
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
  * Syncs the root release version to the highest workspace version found.

--- a/scripts/test-integration-pipeline.mjs
+++ b/scripts/test-integration-pipeline.mjs
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 /**
  * Integration Pipeline Tests
  *

--- a/scripts/test-integration.mjs
+++ b/scripts/test-integration.mjs
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 /**
  * IFC-Lite Integration Test
  * Tests the parseMeshes API with a sample IFC file

--- a/scripts/test-wasm-contract.mjs
+++ b/scripts/test-wasm-contract.mjs
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 /**
  * WASM API Contract Tests
  *


### PR DESCRIPTION
## What and why

AGENTS.md requires the MPL-2.0 header on every source file, but nothing in CI enforces it, so `scripts/` drifted. Ten files had none:

```
add-license-headers.mjs   check-api-surface.mjs   check-git-lfs.mjs
check-test-wiring.mjs     release-crates.mjs      space-diag.mjs
sync-versions.js          test-integration-pipeline.mjs
test-integration.mjs      test-wasm-contract.mjs
```

Including `add-license-headers.mjs` itself, which is the tool whose job is adding them.

This came out of #2560, where CodeRabbit and Codex both flagged the missing header on a newly added script. Fixing only the new file would have left the rest of the directory in the same state.

## How it was verified

- Header goes after the shebang where one exists, so executables still resolve. Confirmed the shebang is still line 1 in all nine.
- `node --check` passes on every script in `scripts/`.
- `check-test-wiring.mjs` still runs clean, as a smoke test that the insertion did not disturb execution.
- The two files my first scan flagged (`test-geometry-reference.mjs`, `test-geometry-regression.mjs`) turned out to already carry the header lower in the file and were correctly left alone.

## Not included

No CI enforcement. A lane that checks headers is a real cost decision and belongs in its own PR; this is the cheap half that makes the tree compliant today.

- [x] A test asserts the new behavior through a fixture or a stated invariant: n/a, comment-only change, verified by parse + smoke run
- [x] Published `packages/*` touched: none
- [x] Geometry-output change: none
- [x] House rules: no `as any` / `@ts-ignore`, no silent `catch {}`, no repo-wide `cargo fmt`
- [x] No client or project identifiers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Mozilla Public License 2.0 notices to project maintenance and testing scripts.
  * No changes were made to application functionality or runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->