### PR TITLE
fix(release): create a missing v-tag instead of skipping it forever

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,6 +177,7 @@ jobs:
           # authored by a real user identity and CI triggers on them — see
           # the comment on the Checkout step for the full rationale.
           GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
+          SB_VERSION: ${{ steps.release-gate.outputs.sb_version }}
           # npm publishes use OIDC trusted publishing — no NPM_TOKEN.
           # `id-token: write` (set at job level) + npm CLI ≥ 11.5.1 +
           # NPM_CONFIG_PROVENANCE complete the handshake automatically
@@ -211,29 +212,61 @@ jobs:
       - name: Decide release artifacts
         id: release-gate
         run: |
-          VERSION="${{ steps.pre.outputs.version }}"
-          SB_VERSION="${{ steps.pre.outputs.sb_version }}"
-          PENDING="${{ steps.pre.outputs.pending }}"
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           echo "sb_version=${SB_VERSION}" >> $GITHUB_OUTPUT
 
-          released=false
-          if [ "${{ steps.changesets.outputs.published }}" = "true" ]; then
+          # Is each version actually OUT, as opposed to merely versioned?
+          #
+          # An empty `.changeset` directory does not answer that. After a
+          # version PR merges its changesets are already consumed, so a run
+          # whose publish fails outright — bad credentials, a build error, the
+          # npm 404 on an unbootstrapped package that stranded crates.io for
+          # nine days — still arrives here with PENDING=0. Inferring "released"
+          # from that would tag versions that never shipped.
+          #
+          # npm is the durable evidence, and each tag is gated on the version
+          # IT stands for: the root tag on whichever published package carries
+          # the root version (sync-versions.js keeps them aligned), the
+          # server-bin tag on @ifc-lite/server-bin itself. `published == true`
+          # short-circuits it — that IS this run publishing.
+          root_released=false
+          sb_released=false
+          if [ "${PUBLISHED}" = "true" ]; then
             echo "npm published in this run"
-            released=true
+            root_released=true
+            sb_released=true
           elif [ "${PENDING}" != "0" ]; then
             echo "${PENDING} changeset(s) were pending — this run opened the version PR, nothing to tag"
           else
-            echo "no changesets were pending — v${VERSION} is released; backfilling anything missing"
-            released=true
+            ROOT_PKG=$(node -e '
+              const fs = require("fs");
+              const want = process.env.VERSION;
+              const hit = fs.readdirSync("packages")
+                .map((d) => { try { return JSON.parse(fs.readFileSync(`packages/${d}/package.json`, "utf8")); } catch { return null; } })
+                .find((p) => p && p.private !== true && p.version === want);
+              process.stdout.write(hit ? hit.name : "");
+            ')
+            if [ -n "${ROOT_PKG}" ] && npm view "${ROOT_PKG}@${VERSION}" version > /dev/null 2>&1; then
+              echo "${ROOT_PKG}@${VERSION} is on npm — v${VERSION} is genuinely released"
+              root_released=true
+            else
+              echo "no published package carries v${VERSION} on npm — NOT tagging (publish likely failed)"
+            fi
+            if npm view "@ifc-lite/server-bin@${SB_VERSION}" version > /dev/null 2>&1; then
+              echo "@ifc-lite/server-bin@${SB_VERSION} is on npm"
+              sb_released=true
+            else
+              echo "@ifc-lite/server-bin@${SB_VERSION} is not on npm — NOT tagging it"
+            fi
           fi
 
+          # Root and server-bin are tracked SEPARATELY. A run that created the
+          # root release and then failed must still be able to backfill the
+          # server-bin one, which a single shared flag would skip forever.
           root=false
           server=false
-          if [ "$released" = "true" ]; then
-            gh release view "v${VERSION}"    > /dev/null 2>&1 || root=true
-            gh release view "v${SB_VERSION}" > /dev/null 2>&1 || server=true
-          fi
+          [ "$root_released" = "true" ] && { gh release view "v${VERSION}"    > /dev/null 2>&1 || root=true; }
+          [ "$sb_released"   = "true" ] && { gh release view "v${SB_VERSION}" > /dev/null 2>&1 || server=true; }
 
           # When the two versions coincide, the ONE release must be created by
           # the server-bin step, which uses the PAT. A GITHUB_TOKEN-created
@@ -250,6 +283,13 @@ jobs:
           echo "root=${root} server=${server}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Passed as env, not interpolated into the script: `${{ }}` expansion
+          # inside `run:` splices the value into the shell source itself
+          # (zizmor template-injection).
+          VERSION: ${{ steps.pre.outputs.version }}
+          SB_VERSION: ${{ steps.pre.outputs.sb_version }}
+          PENDING: ${{ steps.pre.outputs.pending }}
+          PUBLISHED: ${{ steps.changesets.outputs.published }}
 
       - name: Get Version
         id: get-version
@@ -257,24 +297,27 @@ jobs:
         run: |
           # The pre-action root version — NOT a fresh read of package.json, which
           # `changesets/action` may have bumped in this same tree.
-          echo "version=${{ steps.release-gate.outputs.version }}" >> $GITHUB_OUTPUT
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+        env:
+          VERSION: ${{ steps.release-gate.outputs.version }}
 
       - name: Create GitHub Release
         if: steps.release-gate.outputs.run_root == 'true'
         run: |
           # Create the v* tag (changesets creates @scope/package@version tags, not v* tags)
-          git tag "v${{ steps.get-version.outputs.version }}" || true
-          git push origin "v${{ steps.get-version.outputs.version }}" || true
+          git tag "v${VERSION}" || true
+          git push origin "v${VERSION}" || true
           # Create release, skipping if it already exists
-          if gh release view "v${{ steps.get-version.outputs.version }}" > /dev/null 2>&1; then
-            echo "Release v${{ steps.get-version.outputs.version }} already exists, skipping"
+          if gh release view "v${VERSION}" > /dev/null 2>&1; then
+            echo "Release v${VERSION} already exists, skipping"
           else
-            gh release create "v${{ steps.get-version.outputs.version }}" \
-              --title "v${{ steps.get-version.outputs.version }}" \
+            gh release create "v${VERSION}" \
+              --title "v${VERSION}" \
               --notes "See CHANGELOG.md for details"
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.get-version.outputs.version }}
 
       # @ifc-lite/server-bin downloads its native archive from a GitHub
       # release tagged `v<its-own-version>` (packages/server-bin/src/binary.ts).
@@ -288,7 +331,7 @@ jobs:
       - name: Create server-bin binary release
         if: steps.release-gate.outputs.run_server == 'true'
         run: |
-          SB_VERSION="${{ steps.release-gate.outputs.sb_version }}"
+          # SB_VERSION arrives via env (see below), not spliced into this script.
           TAG="v${SB_VERSION}"
           # Skip when the tag already exists (server-bin unchanged this cycle,
           # or it happens to equal the root release already created above).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,16 +171,57 @@ jobs:
           # crates.io token minted via OIDC above; expires in 30 minutes.
           CARGO_REGISTRY_TOKEN: ${{ steps.crates-auth.outputs.token }}
 
+      # Whether to create this version's release artifacts.
+      #
+      # This used to be `steps.changesets.outputs.published == 'true'`, which
+      # asks "did npm publish in THIS run?" — a different question from "does
+      # this released version still need its tag?". The two came apart on
+      # 2026-08-12 (v4.4.1): `changeset publish` published every package, then
+      # the step failed while pushing tags on a transient TLS error
+      # ("server certificate verification failed"). `published` was therefore
+      # not 'true', so the v-tag steps skipped — and every later run skipped
+      # them too, because by then npm had nothing left to publish. v4.4.0 and
+      # v4.4.1 both ended up with no `v*` tag or GitHub release at all, and no
+      # run would ever create them.
+      #
+      # So: publish-in-this-run still qualifies, and a released version whose
+      # tag is missing now qualifies too. "Released" means no changeset is
+      # pending — with changesets waiting, `package.json` still carries the
+      # PREVIOUS released version (the bump lands in the version PR), so its
+      # tag already exists and this is a no-op rather than a premature tag.
+      # Both downstream steps are already idempotent on an existing release.
+      - name: Decide release artifacts
+        id: release-gate
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          PENDING=$(find .changeset -maxdepth 1 -name '*.md' ! -name 'README.md' | wc -l | tr -d ' ')
+          if [ "${{ steps.changesets.outputs.published }}" = "true" ]; then
+            echo "npm published in this run — creating release artifacts for v${VERSION}"
+            echo "run=true" >> $GITHUB_OUTPUT
+          elif [ "${PENDING}" != "0" ]; then
+            echo "${PENDING} changeset(s) pending — v${VERSION} is the previous release, nothing to do"
+            echo "run=false" >> $GITHUB_OUTPUT
+          elif gh release view "v${VERSION}" > /dev/null 2>&1; then
+            echo "Release v${VERSION} already exists, nothing to do"
+            echo "run=false" >> $GITHUB_OUTPUT
+          else
+            echo "v${VERSION} is released but has no GitHub release — backfilling"
+            echo "run=true" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Get Version
         id: get-version
-        if: steps.changesets.outputs.published == 'true'
+        if: steps.release-gate.outputs.run == 'true'
         run: |
           # Read the root release version (sync-versions.js keeps it aligned to the highest released workspace package version)
           VERSION=$(node -p "require('./package.json').version")
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
-        if: steps.changesets.outputs.published == 'true'
+        if: steps.release-gate.outputs.run == 'true'
         run: |
           # Create the v* tag (changesets creates @scope/package@version tags, not v* tags)
           git tag "v${{ steps.get-version.outputs.version }}" || true
@@ -206,7 +247,7 @@ jobs:
       # event triggers server-binaries.yml to build + upload the per-platform
       # archives to this tag, so the download URL resolves with fresh binaries.
       - name: Create server-bin binary release
-        if: steps.changesets.outputs.published == 'true'
+        if: steps.release-gate.outputs.run == 'true'
         run: |
           SB_VERSION=$(node -p "require('./packages/server-bin/package.json').version")
           TAG="v${SB_VERSION}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,7 +177,6 @@ jobs:
           # authored by a real user identity and CI triggers on them — see
           # the comment on the Checkout step for the full rationale.
           GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
-          SB_VERSION: ${{ steps.release-gate.outputs.sb_version }}
           # npm publishes use OIDC trusted publishing — no NPM_TOKEN.
           # `id-token: write` (set at job level) + npm CLI ≥ 11.5.1 +
           # NPM_CONFIG_PROVENANCE complete the handshake automatically
@@ -352,6 +351,7 @@ jobs:
           # would sit empty and downloads would still 404. The PAT is a real
           # identity, so the event fires and binaries build + upload to this tag.
           GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
+          SB_VERSION: ${{ steps.release-gate.outputs.sb_version }}
 
   # Verify every published package is actually reachable on npm.
   # Catches packages accidentally skipped during release before users hit them.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,6 +150,20 @@ jobs:
         id: crates-auth
         uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
 
+      # Read the release state BEFORE `changesets/action` runs. That step invokes
+      # `pnpm run version` when changesets are pending, which CONSUMES
+      # `.changeset/*.md` and bumps `package.json` in this same working tree. A
+      # gate reading either of those afterwards sees "no changesets pending" and
+      # the NEW, not-yet-released version — and would tag a version whose
+      # packages have not been published, on the very run that only opened the
+      # version PR.
+      - name: Capture pre-release state
+        id: pre
+        run: |
+          echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+          echo "sb_version=$(node -p "require('./packages/server-bin/package.json').version")" >> $GITHUB_OUTPUT
+          echo "pending=$(find .changeset -maxdepth 1 -name '*.md' ! -name 'README.md' | wc -l | tr -d ' ')" >> $GITHUB_OUTPUT
+
       - name: Create Release Pull Request or Publish
         id: changesets
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
@@ -185,43 +199,68 @@ jobs:
       # run would ever create them.
       #
       # So: publish-in-this-run still qualifies, and a released version whose
-      # tag is missing now qualifies too. "Released" means no changeset is
-      # pending — with changesets waiting, `package.json` still carries the
-      # PREVIOUS released version (the bump lands in the version PR), so its
-      # tag already exists and this is a no-op rather than a premature tag.
-      # Both downstream steps are already idempotent on an existing release.
+      # tag is missing now qualifies too. "Released" is read from the PRE-action
+      # state (see `steps.pre`): with changesets pending, this run only opened
+      # the version PR, and the post-action tree already carries the bumped,
+      # unpublished version.
+      #
+      # Root and server-bin are tracked SEPARATELY. A run that created the root
+      # release and then failed must still be able to backfill the server-bin
+      # one, which a single shared flag would skip forever — the same
+      # "one flag, two questions" mistake in miniature.
       - name: Decide release artifacts
         id: release-gate
         run: |
-          VERSION=$(node -p "require('./package.json').version")
+          VERSION="${{ steps.pre.outputs.version }}"
+          SB_VERSION="${{ steps.pre.outputs.sb_version }}"
+          PENDING="${{ steps.pre.outputs.pending }}"
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
-          PENDING=$(find .changeset -maxdepth 1 -name '*.md' ! -name 'README.md' | wc -l | tr -d ' ')
+          echo "sb_version=${SB_VERSION}" >> $GITHUB_OUTPUT
+
+          released=false
           if [ "${{ steps.changesets.outputs.published }}" = "true" ]; then
-            echo "npm published in this run — creating release artifacts for v${VERSION}"
-            echo "run=true" >> $GITHUB_OUTPUT
+            echo "npm published in this run"
+            released=true
           elif [ "${PENDING}" != "0" ]; then
-            echo "${PENDING} changeset(s) pending — v${VERSION} is the previous release, nothing to do"
-            echo "run=false" >> $GITHUB_OUTPUT
-          elif gh release view "v${VERSION}" > /dev/null 2>&1; then
-            echo "Release v${VERSION} already exists, nothing to do"
-            echo "run=false" >> $GITHUB_OUTPUT
+            echo "${PENDING} changeset(s) were pending — this run opened the version PR, nothing to tag"
           else
-            echo "v${VERSION} is released but has no GitHub release — backfilling"
-            echo "run=true" >> $GITHUB_OUTPUT
+            echo "no changesets were pending — v${VERSION} is released; backfilling anything missing"
+            released=true
           fi
+
+          root=false
+          server=false
+          if [ "$released" = "true" ]; then
+            gh release view "v${VERSION}"    > /dev/null 2>&1 || root=true
+            gh release view "v${SB_VERSION}" > /dev/null 2>&1 || server=true
+          fi
+
+          # When the two versions coincide, the ONE release must be created by
+          # the server-bin step, which uses the PAT. A GITHUB_TOKEN-created
+          # release emits no `release: published` event (GitHub recursion
+          # guard), so server-binaries.yml would never upload the archives and
+          # `npx @ifc-lite/server-bin` would 404 against an empty release.
+          if [ "${VERSION}" = "${SB_VERSION}" ] && [ "$server" = "true" ]; then
+            echo "root and server-bin versions coincide — letting the PAT-authored server-bin step create v${VERSION}"
+            root=false
+          fi
+
+          echo "run_root=${root}" >> $GITHUB_OUTPUT
+          echo "run_server=${server}" >> $GITHUB_OUTPUT
+          echo "root=${root} server=${server}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get Version
         id: get-version
-        if: steps.release-gate.outputs.run == 'true'
+        if: steps.release-gate.outputs.run_root == 'true' || steps.release-gate.outputs.run_server == 'true'
         run: |
-          # Read the root release version (sync-versions.js keeps it aligned to the highest released workspace package version)
-          VERSION=$(node -p "require('./package.json').version")
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          # The pre-action root version — NOT a fresh read of package.json, which
+          # `changesets/action` may have bumped in this same tree.
+          echo "version=${{ steps.release-gate.outputs.version }}" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
-        if: steps.release-gate.outputs.run == 'true'
+        if: steps.release-gate.outputs.run_root == 'true'
         run: |
           # Create the v* tag (changesets creates @scope/package@version tags, not v* tags)
           git tag "v${{ steps.get-version.outputs.version }}" || true
@@ -247,9 +286,9 @@ jobs:
       # event triggers server-binaries.yml to build + upload the per-platform
       # archives to this tag, so the download URL resolves with fresh binaries.
       - name: Create server-bin binary release
-        if: steps.release-gate.outputs.run == 'true'
+        if: steps.release-gate.outputs.run_server == 'true'
         run: |
-          SB_VERSION=$(node -p "require('./packages/server-bin/package.json').version")
+          SB_VERSION="${{ steps.release-gate.outputs.sb_version }}"
           TAG="v${SB_VERSION}"
           # Skip when the tag already exists (server-bin unchanged this cycle,
           # or it happens to equal the root release already created above).


### PR DESCRIPTION
## What and why

The last `v*` tag in this repo is **v4.3.0**. v4.4.0 and v4.4.1 have no tag and no GitHub release, and no future run would ever create them.

The three release-artifact steps were gated on:

```yaml
if: steps.changesets.outputs.published == 'true'
```

That asks *"did npm publish in this run?"*, which is not the same question as *"does this released version still need its tag?"*. On 2026-08-12 the two came apart: `changeset publish` published every package for v4.4.1, then the step failed while pushing tags on a transient TLS error:

```
git push origin @ifc-lite/parser@4.0.2
fatal: server certificate verification failed. CAfile: none CRLfile: none
```

`published` was not `'true'`, so the steps skipped. Every later run skipped them too, because npm then had nothing left to publish, so the gate could never become true again. A one-off network blip permanently cost two releases their tags.

## The fix

A `Decide release artifacts` step that qualifies on either condition:

- npm published in this run (unchanged behaviour), or
- this version is released and its tag is missing (the backfill path).

"Released" means no changeset is pending. While changesets wait, `package.json` still carries the *previous* released version, since the bump lands in the version PR, so its tag already exists and the gate is a no-op rather than a premature tag. Both downstream steps were already idempotent against an existing release, so the new path cannot double-create.

## How it was verified

The workflow only runs on push to main, so the gate logic was simulated against a fake `gh` and a fake workspace:

```
published this run, tag missing   -> run=true   unchanged behaviour
NOT published, tag missing        -> run=true   the 2026-08-12 hole
NOT published, tag exists         -> run=false  no double-create
changesets pending (mid-cycle)    -> run=false  no premature tag
```

YAML validated with a parser, and the three `if:` conditions confirmed to point at the new gate.

## Note

`v4.4.1` was created by hand earlier today so the current release is not left bare. `v4.4.0` is still absent; with this merged, it stays absent (its version is behind), so backfill it manually if you want it.

- [x] A test asserts the new behavior through a fixture or a stated invariant: gate simulation above, all four branches
- [x] Published `packages/*` touched: none
- [x] Geometry-output change: none
- [x] House rules: no `as any` / `@ts-ignore`, no silent `catch {}`, no repo-wide `cargo fmt`
- [x] No client or project identifiers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release artifact creation to prevent duplicate or incomplete releases.
  * Artifacts are now generated only after successful publication and when all required release changes are ready.
  * Pending releases are skipped until their changes are complete.
  * Improved handling of matching versions to ensure the correct artifacts are produced.
  * Related artifacts can now be released independently when appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->