### PR TITLE
ci(test): run the test lane on push to main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,10 +7,22 @@ name: Test
 on:
   pull_request:
     branches: [main]
+  # Post-merge guard. Two PRs can each be green against their own base and be
+  # broken as a pair on main: #2551 removed a helper from
+  # measure-parity.test.tsx at 01:41 on 2026-08-12, #2538 added a caller of it
+  # at 06:35, and main was red from then on. Nothing ran on main, so it
+  # surfaced hours later on an unrelated first-time contributor's PR, and every
+  # open PR's Node lane was red until it was fixed.
+  push:
+    branches: [main]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Include the event so a push-to-main run and a PR run never share a group.
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  # Superseding a PR run is free (the newer commit is what matters). Superseding
+  # a main run is not: each merge is a distinct state that nothing else checks,
+  # and cancelling it is how a broken main goes unnoticed.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read
@@ -50,6 +62,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          # A push event filters against the previous commit, which a depth-1
+          # clone does not contain. PRs filter against the base ref and are
+          # unaffected, so only the push path pays the extra object.
+          fetch-depth: ${{ github.event_name == 'push' && 2 || 1 }}
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
         with:
@@ -420,7 +436,9 @@ jobs:
   viewer-e2e:
     name: Viewer E2E smoke
     needs: [changes, build]
-    if: needs.changes.outputs.frontend == 'true' || needs.changes.outputs.rust == 'true'
+    # PR-only: see the `push:` trigger comment. The post-merge run repeats the
+    # cheap unit lanes that catch cross-PR collisions, not the whole matrix.
+    if: (needs.changes.outputs.frontend == 'true' || needs.changes.outputs.rust == 'true') && github.event_name == 'pull_request'
     # Free runner — vite build + a ~2.4MB model; not compute-bound.
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -541,7 +559,8 @@ jobs:
   geometry-census:
     name: Geometry watertightness census
     needs: changes
-    if: needs.changes.outputs.geometry == 'true'
+    # PR-only — see viewer-e2e.
+    if: needs.changes.outputs.geometry == 'true' && github.event_name == 'pull_request'
     runs-on: depot-ubuntu-24.04-4
     timeout-minutes: 45
     steps:
@@ -589,7 +608,8 @@ jobs:
   plato-check:
     name: Plato clash-math freshness
     needs: changes
-    if: needs.changes.outputs.plato == 'true'
+    # PR-only — see viewer-e2e.
+    if: needs.changes.outputs.plato == 'true' && github.event_name == 'pull_request'
     # Free runner - the generator clones + builds Plato.CLI with dotnet; no
     # Depot cores needed.
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,11 +17,17 @@ on:
     branches: [main]
 
 concurrency:
-  # Include the event so a push-to-main run and a PR run never share a group.
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
-  # Superseding a PR run is free (the newer commit is what matters). Superseding
-  # a main run is not: each merge is a distinct state that nothing else checks,
-  # and cancelling it is how a broken main goes unnoticed.
+  # PR runs share a group per ref, so a new commit supersedes the old run — the
+  # newer commit is the only one whose verdict matters.
+  #
+  # Push runs get a group PER COMMIT. Not merely `cancel-in-progress: false`:
+  # GitHub keeps only one running plus one PENDING run per group, and a newer
+  # queued run EVICTS the pending one even when cancellation is off. With three
+  # merges in quick succession, a docs-only third merge would evict the queued
+  # run for a frontend-breaking second merge, and its path filters would then
+  # skip the Node lane — leaving exactly the broken state this guard exists to
+  # catch unchecked. A per-commit group means no merge can displace another.
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'push' && github.sha || 'pull_request' }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:


### PR DESCRIPTION
## What and why

Nothing runs on `main`. Two PRs can each be green against their own base and be broken as a pair once merged, and the only thing that notices is the next person's PR.

That happened today. #2551 (01:41) removed the `read` helper from `measure-parity.test.tsx` along with the assertions it served; #2538 (06:35) added a guard in the same file calling it five times. Each was green against its own base. `main` was red from 06:35 and it surfaced hours later on **#2556, a first-time contributor's PR touching only `rust/export`**, whose Node lane failed for reasons that had nothing to do with their change. Every open PR was in that state until #2557 landed.

This is the third time this class of failure has cost real time.

## Cost, which is why this did not already exist

The post-merge run is deliberately not the full matrix:

| | on main | PR only |
|---|---|---|
| changes, build, typecheck, lint, node-tests, rust-tests | yes | yes |
| viewer-e2e, geometry-census, plato-check | no | yes |

The collision being guarded against is unit-level: a symbol that stopped existing. The cheap lanes catch that. The existing path filter still applies, so a merge touching neither frontend nor Rust runs nothing beyond `changes`.

If you would rather trade latency for even less spend, the alternative is a scheduled run instead of per-push. Say so and I'll switch it, though a merge-to-detection gap of an hour puts the discovery back on whoever opens the next PR.

## Two details that decide whether this works at all

- **`cancel-in-progress` is now PR-only.** Superseding a PR run is free, the newer commit is what matters. Superseding a main run silently drops the only check that state will ever get, which is exactly how a broken main goes unnoticed. The concurrency group also includes `github.event_name` so PR and push runs never share a group.
- **The `changes` checkout fetches depth 2 on push.** A push event filters against the previous commit, which a depth-1 clone does not contain. PRs filter against the base ref and are unaffected, so only the push path pays the extra object.

## How it was verified

YAML validated with a parser, and every job's resolved `if:` inspected to confirm the intended split:

```
build, typecheck, lint, node-tests, rust-tests   -> unchanged, run on both events
viewer-e2e, geometry-census, plato-check         -> ... && github.event_name == 'pull_request'
```

Traced against today's incident: the merge commit for #2538 touches `apps/viewer/**`, so the `frontend` filter is true on push, `node-tests` runs, and `read is not defined` fails the lane at merge time instead of on a stranger's PR.

- [x] A test asserts the new behavior through a fixture or a stated invariant: workflow change, verified by parsing + resolved-condition inspection
- [x] Published `packages/*` touched: none
- [x] Geometry-output change: none
- [x] House rules: no `as any` / `@ts-ignore`, no silent `catch {}`, no repo-wide `cargo fmt`
- [x] No client or project identifiers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automated checks now run for pushes to the main branch as well as pull requests.
  * Push-based checks use improved revision comparison and remain independent from cancelable pull-request runs.
  * Pull-request-only validation jobs continue to run exclusively during pull-request workflows.
  * This improves the reliability and efficiency of automated project validation across different development workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->