### PR TITLE
test(viewer): cover useZoneAssignmentSync's empty-zone-set path (#1810)

### DIFF
--- a/apps/viewer/src/hooks/useZoneAssignmentSync.test.ts
+++ b/apps/viewer/src/hooks/useZoneAssignmentSync.test.ts
@@ -1,0 +1,87 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import assert from 'node:assert/strict';
+import { beforeEach, describe, it } from 'node:test';
+import { recomputeZoneAssignmentsNow } from './useZoneAssignmentSync.js';
+import { useViewerStore } from '../store/index.js';
+import type { ZoneSet } from '../lib/zones/types.js';
+
+function makeZoneSet(id: string): ZoneSet {
+  return {
+    id,
+    name: `Set ${id}`,
+    zones: [
+      { id: `${id}-z1`, name: 'Zone A', center: [0, 0, 0], size: [5, 3, 5], rotationY: 0 },
+    ],
+    visible: true,
+    createdAt: 0,
+    updatedAt: 0,
+  };
+}
+
+beforeEach(() => {
+  useViewerStore.setState({
+    zoneSets: [],
+    zoneAssignments: new Map(),
+    zoneAssignmentTiming: null,
+  } as never);
+});
+
+describe('recomputeZoneAssignmentsNow (issue #1810)', () => {
+  it('no-ops when there are no zone sets AND nothing to clear (guard reject path)', () => {
+    // Baseline: empty assignments, no timing yet — exactly the initial state.
+    const before = useViewerStore.getState();
+    assert.equal(before.zoneAssignments.size, 0);
+    assert.equal(before.zoneAssignmentTiming, null);
+
+    recomputeZoneAssignmentsNow();
+
+    const after = useViewerStore.getState();
+    // The guard's reject path must be a true no-op: same Map reference (no
+    // spurious `setZoneAssignments` call to avoid needless re-renders /
+    // effect loops downstream), and timing stays null.
+    assert.equal(after.zoneAssignments, before.zoneAssignments);
+    assert.equal(after.zoneAssignmentTiming, null);
+  });
+
+  it('clears stale assignments + timing when the last zone set is removed', () => {
+    // Simulate a prior computation that left assignments + timing behind,
+    // then the user deletes their only zone set.
+    useViewerStore.setState({
+      zoneSets: [],
+      zoneAssignments: new Map([[1, {}]]),
+      zoneAssignmentTiming: { elapsedMs: 5, elementCount: 1, zoneSetCount: 1, computedAt: 123 },
+    } as never);
+
+    recomputeZoneAssignmentsNow();
+
+    const after = useViewerStore.getState();
+    assert.equal(after.zoneAssignments.size, 0);
+    // Shipped behaviour records the empty recompute rather than clearing the
+    // timing: the pass genuinely ran and found nothing, and a null here would
+    // be indistinguishable from "never computed".
+    assert.equal(after.zoneAssignmentTiming?.elementCount, 0);
+    assert.equal(after.zoneAssignmentTiming?.zoneSetCount, 0);
+  });
+
+  it('runs the assignment engine and writes timing when zone sets exist', () => {
+    useViewerStore.setState({
+      zoneSets: [makeZoneSet('s1')],
+      zoneAssignments: new Map(),
+      zoneAssignmentTiming: null,
+    } as never);
+
+    recomputeZoneAssignmentsNow();
+
+    const after = useViewerStore.getState();
+    // No renderer/scene is registered in this test environment, so
+    // gatherElementBounds() yields no elements — but the engine still runs
+    // and timing must be recorded (elementCount: 0, zoneSetCount: 1).
+    assert.equal(after.zoneAssignments.size, 0);
+    assert.ok(after.zoneAssignmentTiming !== null);
+    assert.equal(after.zoneAssignmentTiming?.zoneSetCount, 1);
+    assert.equal(after.zoneAssignmentTiming?.elementCount, 0);
+  });
+});

--- a/apps/viewer/src/hooks/useZoneAssignmentSync.test.ts
+++ b/apps/viewer/src/hooks/useZoneAssignmentSync.test.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import assert from 'node:assert/strict';
-import { beforeEach, describe, it } from 'node:test';
+import { afterEach, beforeEach, describe, it } from 'node:test';
 import { recomputeZoneAssignmentsNow } from './useZoneAssignmentSync.js';
 import { useViewerStore } from '../store/index.js';
 import type { ZoneSet } from '../lib/zones/types.js';
@@ -21,12 +21,23 @@ function makeZoneSet(id: string): ZoneSet {
   };
 }
 
+// apps/viewer's suite runs every *.test.ts file's node:test suite in one
+// process (see apps/viewer/package.json's "test" script), so useViewerStore
+// is a real shared singleton across files, not reset between them. The last
+// test below leaves zoneSets/zoneAssignmentTiming non-empty; restore the
+// pristine state afterward so a later file's test can't inherit it.
+const RESET_STATE = {
+  zoneSets: [],
+  zoneAssignments: new Map(),
+  zoneAssignmentTiming: null,
+} as never;
+
 beforeEach(() => {
-  useViewerStore.setState({
-    zoneSets: [],
-    zoneAssignments: new Map(),
-    zoneAssignmentTiming: null,
-  } as never);
+  useViewerStore.setState(RESET_STATE);
+});
+
+afterEach(() => {
+  useViewerStore.setState(RESET_STATE);
 });
 
 describe('recomputeZoneAssignmentsNow (issue #1810)', () => {


### PR DESCRIPTION
Three unit tests for `recomputeZoneAssignmentsNow`, covering the paths a zone-set deletion takes: the guard no-op when there is nothing to clear, the clear-and-record path when the last zone set is removed, and the normal recompute when zone sets exist.

**Provenance, stated plainly**: this file was written during earlier #1810 work, never committed, and surfaced during a worktree cleanup. One of its assertions expected the timing record to be *cleared* when the last zone set goes away — shipped behaviour records a zeroed entry instead, so that assertion now pins the shipped semantics, with a comment on why: a `null` there would be indistinguishable from "never computed", whereas `{elementCount: 0, zoneSetCount: 0}` says the pass ran and found nothing.

**Not vacuous**: disabling the empty-zone-set guard in `useZoneAssignmentSync.ts` fails the guard-reject test (`Values have same structure but are not reference-equal`) while the other two still pass; restored byte-identically.

No production code touched — the behaviour these pin is already correct and shipped. `scripts/check-source-text-assertions.mjs` → `OK (5 allowlisted, 0 new)`; viewer 3938 pass / 0 fail; typecheck 1043/1043. `apps/viewer`-only, so no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for zone assignment recomputation in empty states, after removing the final zone set, and with existing zone sets.
  * Verified assignment results, timing information, and recorded element and zone-set counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->