### PR TITLE
feat(clash): tell the user when cluster grouping consolidated nothing

### DIFF
--- a/.changeset/clash-cluster-grouping-noop-signal.md
+++ b/.changeset/clash-cluster-grouping-noop-signal.md
@@ -1,0 +1,12 @@
+---
+"@ifc-lite/clash": patch
+"@ifc-lite/cli": patch
+---
+
+Report it when `groupClashes({ by: 'cluster' })` consolidates nothing, instead of silently returning one group per clash.
+
+Measured on a real MEP model (self-clash among drainage `IfcFlowSegment`s, distribution-run contact points scattered several metres apart): cluster grouping at the default 1.5 m epsilon produced 15 groups from 18 clashes — barely different from no grouping at all. The default epsilon was investigated separately and deliberately kept: across 12 public models there is no defensible constant (raising it to 2.0 m collapses an unrelated structural model's 10 real clashes into one group), so this is not a tuning fix.
+
+Adds `isClusterGroupingIneffective(clashes, groups)` to `@ifc-lite/clash`: a narrow, exact check — true only when every clash landed in its own singleton group (`groups.length === clashes.length`, with more than one clash) — deliberately not a fuzzy "mostly ineffective" threshold, which would repeat the epsilon problem with a different undefensible constant.
+
+`ifc-lite clash --bcf ... --group cluster` now prints a stderr note when this fires, naming the other grouping modes (`rule`, `typePair`, `element`) rather than picking one — none of them is a reliable universal answer either: on the measured model, `--group element` produced *more* groups than clashes (33 from 18), since it files each clash under both participating elements rather than merging along the run.

--- a/packages/clash/src/grouping.test.ts
+++ b/packages/clash/src/grouping.test.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { describe, expect, it } from 'vitest';
-import { groupClashes } from './grouping.js';
+import { groupClashes, isClusterGroupingIneffective } from './grouping.js';
 import type {
   AABB,
   Clash,
@@ -284,5 +284,51 @@ describe('groupClashes — determinism', () => {
     const clashes = [clash({ id: 'c1', a: PIPE, b: BEAM, rule: 'R', point: [0, 0, 0] })];
     const [group] = groupClashes(makeResult(clashes), { by: 'cluster' });
     expect(group.id).toMatch(/^grp-[0-9a-f]{8}$/);
+  });
+});
+
+describe('isClusterGroupingIneffective', () => {
+  it('is true when every clash landed in its own singleton group (MEP distribution-run shape)', () => {
+    // Points 3m apart: well outside the 1.5m default epsilon, so nothing merges.
+    const clashes = [
+      clash({ id: 'c1', a: PIPE, b: BEAM, rule: 'R', point: [0, 0, 0] }),
+      clash({ id: 'c2', a: PIPE, b: BEAM, rule: 'R', point: [3, 0, 0] }),
+      clash({ id: 'c3', a: PIPE, b: BEAM, rule: 'R', point: [6, 0, 0] }),
+    ];
+    const groups = groupClashes(makeResult(clashes), { by: 'cluster' });
+    expect(groups).toHaveLength(3);
+    expect(isClusterGroupingIneffective(clashes, groups)).toBe(true);
+  });
+
+  it('is false when clustering merged at least one pair', () => {
+    const clashes = [
+      clash({ id: 'c1', a: PIPE, b: BEAM, rule: 'R', point: [0, 0, 0] }),
+      clash({ id: 'c2', a: PIPE, b: BEAM, rule: 'R', point: [0.5, 0, 0] }),
+      clash({ id: 'c3', a: PIPE, b: BEAM, rule: 'R', point: [100, 0, 0] }),
+    ];
+    const groups = groupClashes(makeResult(clashes), { by: 'cluster' });
+    expect(groups).toHaveLength(2);
+    expect(isClusterGroupingIneffective(clashes, groups)).toBe(false);
+  });
+
+  it('is false for 0 or 1 clashes — nothing to consolidate', () => {
+    expect(isClusterGroupingIneffective([], [])).toBe(false);
+    const clashes = [clash({ id: 'c1', a: PIPE, b: BEAM, rule: 'R', point: [0, 0, 0] })];
+    const groups = groupClashes(makeResult(clashes), { by: 'cluster' });
+    expect(isClusterGroupingIneffective(clashes, groups)).toBe(false);
+  });
+
+  it('is not tied to a specific grouping mode — only compares clash count to group count', () => {
+    // element mode can produce MORE groups than clashes (each clash files under
+    // both participants); that is not "ineffective clustering", it's a
+    // different mode entirely, so this helper is only meaningful for by: 'cluster'
+    // output, and this test pins that it does not special-case other modes.
+    const clashes = [
+      clash({ id: 'c1', a: PIPE, b: BEAM, rule: 'R', point: [0, 0, 0] }),
+      clash({ id: 'c2', a: PIPE, b: BEAM2, rule: 'R', point: [5, 0, 0] }),
+    ];
+    const elementGroups = groupClashes(makeResult(clashes), { by: 'element' });
+    expect(elementGroups.length).toBeGreaterThan(clashes.length);
+    expect(isClusterGroupingIneffective(clashes, elementGroups)).toBe(false);
   });
 });

--- a/packages/clash/src/grouping.ts
+++ b/packages/clash/src/grouping.ts
@@ -358,5 +358,24 @@ export function groupClashes(result: ClashResult, opts: GroupOptions): ClashGrou
   return groups;
 }
 
+/**
+ * Whether `by: 'cluster'` grouping achieved any spatial consolidation at all.
+ *
+ * On MEP models, distribution-run contact points routinely sit metres apart —
+ * well outside any defensible clustering radius (measured across 12 public
+ * models: no epsilon separates every real shape, and raising it collapses
+ * unrelated clashes on other models). The result is `groups.length ===
+ * clashes.length`: every clash lands alone, and clustering did nothing.
+ *
+ * This is a narrow, exact signal (all-singleton), not a fuzzy "mostly
+ * ineffective" heuristic — a threshold like "90% singleton" would itself be
+ * an undefensible constant, the same trap the epsilon default fell into.
+ * Returns `false` for 0 or 1 clashes: there is nothing to consolidate, so
+ * "did nothing" is not a meaningful complaint.
+ */
+export function isClusterGroupingIneffective(clashes: readonly Clash[], groups: readonly ClashGroup[]): boolean {
+  return clashes.length > 1 && groups.length === clashes.length;
+}
+
 /** Re-exported for callers that want the cluster centre of a group's bounds. */
 export { center as groupCenter };

--- a/packages/clash/src/index.ts
+++ b/packages/clash/src/index.ts
@@ -32,7 +32,7 @@ export {
   parseTriageResponse,
   type ClashTriageResult,
 } from './triage.js';
-export { groupClashes, type GroupOptions } from './grouping.js';
+export { groupClashes, isClusterGroupingIneffective, type GroupOptions } from './grouping.js';
 export {
   clashReviewKey,
   aggregateReviewStatus,

--- a/packages/cli/src/commands/clash.test.ts
+++ b/packages/cli/src/commands/clash.test.ts
@@ -52,6 +52,78 @@ function buildClashModel(): string {
   return creator.toIfc().content;
 }
 
+/**
+ * Three wall-crossing pairs, spaced 10m apart along X — each pair produces
+ * exactly one self-clash, and every pair is well outside the 1.5m default
+ * cluster epsilon from every other pair. Models the MEP distribution-run
+ * shape (contact points metres apart) with plain walls, so `--group cluster`
+ * cannot consolidate any of the three clashes: 3 clashes in, 3 groups out.
+ */
+function buildScatteredClashModel(): string {
+  const creator = new IfcCreator({ Name: 'ScatteredClashTest' });
+  const storey = creator.addIfcBuildingStorey({ Name: 'L1', Elevation: 0 });
+  for (const offset of [0, 10, 20]) {
+    creator.addIfcWall(storey, { Start: [offset - 2, 0, 0], End: [offset + 2, 0, 0], Height: 3, Thickness: 0.2 });
+    creator.addIfcWall(storey, { Start: [offset, -2, 0], End: [offset, 2, 0], Height: 3, Thickness: 0.2 });
+  }
+  return creator.toIfc().content;
+}
+
+describe('clash --group cluster ineffectiveness note', () => {
+  it.skipIf(!canRun)(
+    'warns on stderr when cluster grouping consolidates nothing',
+    async () => {
+      const dir = await mkdtemp(join(tmpdir(), 'ifc-lite-clash-cluster-noop-'));
+      const modelPath = join(dir, 'model.ifc');
+      const bcfPath = join(dir, 'out.bcfzip');
+      try {
+        await writeFile(modelPath, buildScatteredClashModel());
+
+        const { stderr } = await execFileAsync(
+          process.execPath,
+          [CLI_ENTRY, 'clash', modelPath, '--a', 'IfcWall', '--group', 'cluster', '--bcf', bcfPath],
+          { timeout: 120_000, maxBuffer: 64 * 1024 * 1024 },
+        );
+
+        expect(stderr).toContain('did not consolidate any clashes');
+        expect(stderr).toContain('3 groups from 3 clashes');
+        expect(stderr).toContain('--group rule');
+        expect(stderr).toContain('--group typePair');
+        expect(stderr).toContain('--group element');
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    },
+    180_000,
+  );
+
+  it.skipIf(!canRun)(
+    'stays silent when cluster grouping actually consolidates',
+    async () => {
+      const dir = await mkdtemp(join(tmpdir(), 'ifc-lite-clash-cluster-ok-'));
+      const modelPath = join(dir, 'model.ifc');
+      const bcfPath = join(dir, 'out.bcfzip');
+      try {
+        // A single crossing model has co-located clashes at the crossing point,
+        // so nothing to warn about (also proves the model above is the only
+        // reason the first test's clashes land in separate groups).
+        await writeFile(modelPath, buildClashModel());
+
+        const { stderr } = await execFileAsync(
+          process.execPath,
+          [CLI_ENTRY, 'clash', modelPath, '--group', 'cluster', '--bcf', bcfPath],
+          { timeout: 120_000, maxBuffer: 64 * 1024 * 1024 },
+        );
+
+        expect(stderr).not.toContain('did not consolidate');
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    },
+    180_000,
+  );
+});
+
 describe('clash --json stdout hygiene', () => {
   it.skipIf(!canRun)(
     'stdout is exactly one parseable JSON document; diagnostics go to stderr',

--- a/packages/cli/src/commands/clash.test.ts
+++ b/packages/cli/src/commands/clash.test.ts
@@ -69,6 +69,22 @@ function buildScatteredClashModel(): string {
   return creator.toIfc().content;
 }
 
+/**
+ * Same shape as `buildScatteredClashModel`, but the three crossing pairs sit
+ * 0.5m apart along X — well within the 1.5m default cluster epsilon of each
+ * other, and all same rule/type-pair (self-clash on `IfcWall`) — so cluster
+ * grouping DOES consolidate: fewer groups than clashes come out.
+ */
+function buildClusteredClashModel(): string {
+  const creator = new IfcCreator({ Name: 'ClusteredClashTest' });
+  const storey = creator.addIfcBuildingStorey({ Name: 'L1', Elevation: 0 });
+  for (const offset of [0, 0.5, 1.0]) {
+    creator.addIfcWall(storey, { Start: [offset - 2, 0, 0], End: [offset + 2, 0, 0], Height: 3, Thickness: 0.2 });
+    creator.addIfcWall(storey, { Start: [offset, -2, 0], End: [offset, 2, 0], Height: 3, Thickness: 0.2 });
+  }
+  return creator.toIfc().content;
+}
+
 describe('clash --group cluster ineffectiveness note', () => {
   it.skipIf(!canRun)(
     'warns on stderr when cluster grouping consolidates nothing',
@@ -104,17 +120,25 @@ describe('clash --group cluster ineffectiveness note', () => {
       const modelPath = join(dir, 'model.ifc');
       const bcfPath = join(dir, 'out.bcfzip');
       try {
-        // A single crossing model has co-located clashes at the crossing point,
-        // so nothing to warn about (also proves the model above is the only
-        // reason the first test's clashes land in separate groups).
-        await writeFile(modelPath, buildClashModel());
+        // Same fixture shape as the noop test above, but the crossings sit
+        // within epsilon of each other, so clustering merges them: proves the
+        // note is conditioned on actual (in)effectiveness, not just present
+        // whenever --group cluster runs.
+        await writeFile(modelPath, buildClusteredClashModel());
 
         const { stderr } = await execFileAsync(
           process.execPath,
-          [CLI_ENTRY, 'clash', modelPath, '--group', 'cluster', '--bcf', bcfPath],
+          [CLI_ENTRY, 'clash', modelPath, '--a', 'IfcWall', '--group', 'cluster', '--bcf', bcfPath],
           { timeout: 120_000, maxBuffer: 64 * 1024 * 1024 },
         );
 
+        // Fewer groups than clashes proves clustering actually merged some of
+        // them (the fixture's 3 wall-crossing pairs sit within epsilon).
+        const match = stderr.match(/\((\d+) topic group\(s\)/);
+        expect(match).not.toBeNull();
+        const groupCount = Number(match?.[1]);
+        expect(groupCount).toBeGreaterThan(0);
+        expect(groupCount).toBeLessThan(12);
         expect(stderr).not.toContain('did not consolidate');
       } finally {
         await rm(dir, { recursive: true, force: true });

--- a/packages/cli/src/commands/clash.ts
+++ b/packages/cli/src/commands/clash.ts
@@ -22,6 +22,7 @@ import {
   createClashEngine,
   disciplineMatrixRules,
   groupClashes,
+  isClusterGroupingIneffective,
   type Clash,
   type ClashMode,
   type ClashResult,
@@ -215,6 +216,15 @@ export async function clashCommand(args: string[]): Promise<void> {
 
     if (bcfPath) {
       const groups = groupClashes(result, { by: bcfGroupBy });
+      if (bcfGroupBy === 'cluster' && isClusterGroupingIneffective(result.clashes, groups)) {
+        // Common on MEP models: distribution-run contact points sit metres apart,
+        // outside any defensible clustering radius, so clustering consolidates
+        // nothing (every clash landed in its own group). Say so and name the
+        // other modes rather than silently reporting one group per clash.
+        process.stderr.write(
+          `  Note: cluster grouping did not consolidate any clashes (${groups.length} groups from ${result.clashes.length} clashes) — try --group rule, --group typePair, or --group element instead.\n`,
+        );
+      }
       const project = await createBCFFromClashResult(result, groups, {
         author: 'ifc-lite clash',
         projectName: 'Clash report',

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -160,6 +160,7 @@
     "findDuplicates: function",
     "groupClashes: function",
     "inferClashSeverity: function",
+    "isClusterGroupingIneffective: function",
     "isExcluded: function",
     "isTouching: function",
     "makeExclusionSet: function",


### PR DESCRIPTION
On distribution-system models, `groupClashes({by: 'cluster'})` silently does nothing: contact points along pipe runs sit metres apart, so every clash lands in its own group. Reproduced on a public sample — 18 drainage `IfcFlowSegment` self-clashes → 15 groups at the default 1.5 m epsilon.

## Why not just raise the default

That was investigated across 12 public models and deliberately rejected: there is no plateau at any radius, and 2.0 m collapses a small structural model's 10 clashes into a single group. The requirements are strictly disjoint. Of 139 measured partition/side combinations, only ~20% are reachable by ANY isotropic radius — a grid of beams crossing walls can't be separated per-wall at any epsilon. Clustering is simply the wrong tool for some models, and no constant fixes that.

## Why not a smarter mode either

Two assumptions were tested and both failed:
- **`element` grouping doesn't rescue it** — on the same model it produced **33 groups from 18 clashes**, worse by count, because it files each clash under both participants rather than merging along a run.
- **A system/port-aware mode can't be relied on** — the very model where the no-op reproduces has **zero** `IfcSystem`, `IfcRelAssignsToGroup` and `IfcRelConnectsPorts` entities. A metadata-dependent grouping would be unavailable exactly where it's needed, repeating the epsilon mistake in a new register.

## What this does instead

Makes the engine honest about its own no-op. New exported `isClusterGroupingIneffective(clashes, groups)` — an **exact** boundary (`groups.length === clashes.length`, more than one clash), not a fuzzy threshold, deliberately avoiding a second tunable constant. The CLI's `--group cluster` path now prints a stderr note naming `rule`/`typePair`/`element` when clustering consolidated nothing, so a user isn't left reading a grouped view that isn't grouping.

## Verification

RED-GREEN at both library and CLI-subprocess level. Three surgical mutations — `>1`→`>0`, `===`→`<=`, and the CLI mode guard `'cluster'`→`'rule'` — each killed, each restored `diff`-identical. clash 189, cli 386, typecheck 1042/1042.

The viewer's mode selector (in the #2535 chain) is the UI half of this; this PR is the engine telling the truth about when the current mode isn't working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detection for ineffective clash clustering when each clash remains in its own group.
  * The CLI now displays a note when clustering produces no meaningful consolidation and suggests alternative grouping options.
  * Alternative grouping modes are identified to help users choose a more effective result.

* **Tests**
  * Added coverage for effective and ineffective clustering scenarios, including CLI warning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->