### PR TITLE
fix(clash): stop treating spatial containers as clash bodies

### DIFF
--- a/.changeset/clash-exclude-spatial-containers.md
+++ b/.changeset/clash-exclude-spatial-containers.md
@@ -1,0 +1,15 @@
+---
+'@ifc-lite/clash': patch
+---
+
+Stop treating spatial containers as clash bodies in the STEP adapter.
+
+`NON_CLASHABLE_TAGS` dropped `IfcSpace` and `IfcSpatialZone` (#1464) but nothing else from the spatial structure, so any container that carries tessellated geometry became a clash body and collided with the elements assigned to it. That is not a coordination problem — a storey's geometry is its extent, and by construction it encloses its contents.
+
+It bites hardest on IFC4.3 infrastructure models, where storeys and facility parts routinely carry real bodies. On one road/bridge certification model a default `ifc-lite clash` run reported 235 clashes, of which 89 (37.9%) were an `IfcBuildingStorey` against an element it contains.
+
+The check is now derived from the schema instead of enumerated: an element is dropped when `getInheritanceChainAcrossSchemas` puts `IfcSpatialElement` or `IfcSpatialStructureElement` in its chain. That walks the bundled IFC2X3 + IFC4 + IFC4X3 union, so `IfcSite`, `IfcBuilding`, `IfcBuildingStorey`, `IfcExternalSpatialElement` and the IFC4.3 facility leaves (`IfcFacility`, `IfcFacilityPart`, `IfcBridge`, `IfcRoad`, `IfcRailway`, `IfcMarineFacility`, …) are all covered without a second hand-maintained list, and `IfcSpatialStructureElement` is checked alongside `IfcSpatialElement` because IFC2X3 has no `IfcSpatialElement`. The two hand-listed space entries are removed as redundant.
+
+Elements *contained in* a container are unaffected — they still clash with each other, and still carry the storey name as metadata. Measured on the road/bridge model: 235 → 146 clashes, 89 pairs removed and none added, every removed pair involving `IfcBuildingStorey`. Building-model controls: 274 → 274 and 469 → 469 with byte-identical pair sets; 282 → 279 on a third, the three removed pairs all being the site's own terrain body.
+
+No API surface change.

--- a/packages/clash/src/adapters/step.test.ts
+++ b/packages/clash/src/adapters/step.test.ts
@@ -5,6 +5,7 @@
 import { describe, expect, it } from 'vitest';
 import { IfcParser } from '@ifc-lite/parser';
 import type { MeshData } from '@ifc-lite/geometry';
+import { createClashEngine } from '../engine.js';
 import { elementsFromStep } from './step.js';
 
 const WALL_GUID = '3vB2YO$MX4xv5uCqZZG05x';
@@ -22,6 +23,28 @@ END-ISO-10303-21;
 `;
 
 const SPACE_GUID = '1aB2cD3eF4gH5iJ6kL7mN8';
+
+const STOREY_GUID = '2sT0rEyAX4xv5uCqZZG05x';
+const SLAB_GUID = '3sL4bZZAX4xv5uCqZZG05x';
+
+// A storey that carries tessellated geometry (common in IFC4.3 infrastructure
+// exports) plus the two elements it contains. The storey is a spatial
+// *container*, so it is not a clash body; the two contained elements still are.
+// (follow-up to #1464)
+const STOREY_WITH_GEOMETRY_IFC = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('storey.ifc','',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCBUILDINGSTOREY('${STOREY_GUID}',$,'Level 0',$,$,$,$,$,.ELEMENT.,0.);
+#2=IFCSLAB('${SLAB_GUID}',$,'Approach slab',$,$,$,$,$,$);
+#3=IFCWALL('${WALL_GUID}',$,'Test Wall',$,$,$,$,$,$);
+#4=IFCRELCONTAINEDINSPATIALSTRUCTURE('0rEl00$MX4xv5uCqZZG05x',$,$,$,(#2,#3),#1);
+ENDSEC;
+END-ISO-10303-21;
+`;
 
 // A wall (clashable) plus a space (non-physical -> must be dropped). (#1464)
 const WALL_AND_SPACE_IFC = `ISO-10303-21;
@@ -48,6 +71,52 @@ function unitBoxMesh(expressId: number): MeshData {
     positions,
     normals: new Float32Array(positions.length),
     indices: new Uint32Array([0, 1, 2, 0, 2, 3]),
+    color: [0.5, 0.5, 0.5, 1],
+  };
+}
+
+// IFC4.3 infrastructure containers, none of which the parser's IFC4 codegen pin
+// knows: they only classify as spatial through the bundled schema union.
+const INFRA_IFC = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('infra.ifc','',(''),(''),'','','');
+FILE_SCHEMA(('IFC4X3'));
+ENDSEC;
+DATA;
+#1=IFCROAD('1rO4d00AX4xv5uCqZZG05x',$,'Road',$,$,$,$,$,.ELEMENT.);
+#2=IFCFACILITYPART('2fP4rt0AX4xv5uCqZZG05x',$,'Carriageway',$,$,$,$,$,.ELEMENT.,$,$);
+#3=IFCSITE('3sItE00AX4xv5uCqZZG05x',$,'Site',$,$,$,$,$,.ELEMENT.,$,$,$,$,$);
+#4=IFCWALL('${WALL_GUID}',$,'Test Wall',$,$,$,$,$,$);
+ENDSEC;
+END-ISO-10303-21;
+`;
+
+/**
+ * A closed unit cube (12 triangles) at `[ox, 0, 0]`, so two of them can be made
+ * to genuinely overlap in volume. `unitBoxMesh` above is a single coplanar quad
+ * and never produces a penetration.
+ */
+function solidBoxMesh(expressId: number, ox: number): MeshData {
+  const c = [
+    [0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0],
+    [0, 0, 1], [1, 0, 1], [1, 1, 1], [0, 1, 1],
+  ];
+  const positions = new Float32Array(c.flatMap(([x, y, z]) => [x + ox, y, z]));
+  const indices = new Uint32Array([
+    0, 2, 1, 0, 3, 2, // bottom
+    4, 5, 6, 4, 6, 7, // top
+    0, 1, 5, 0, 5, 4, // -y
+    1, 2, 6, 1, 6, 5, // +x
+    2, 3, 7, 2, 7, 6, // +y
+    3, 0, 4, 3, 4, 7, // -x
+  ]);
+  return {
+    expressId,
+    ifcType: 'IfcBuildingElementProxy',
+    positions,
+    normals: new Float32Array(positions.length),
+    indices,
     color: [0.5, 0.5, 0.5, 1],
   };
 }
@@ -97,6 +166,73 @@ describe('elementsFromStep', () => {
 
     expect(elements).toHaveLength(1);
     expect(elements[0].tag.toLowerCase()).toContain('wall');
+  });
+
+  it('drops spatial containers carrying geometry (IfcBuildingStorey) (follow-up to #1464)', async () => {
+    const store = await new IfcParser().parseColumnar(
+      new TextEncoder().encode(STOREY_WITH_GEOMETRY_IFC).buffer as ArrayBuffer,
+    );
+    const storeyId = (store.entityIndex.byType.get('IFCBUILDINGSTOREY') ?? [])[0];
+    const slabId = (store.entityIndex.byType.get('IFCSLAB') ?? [])[0];
+    const wallId = (store.entityIndex.byType.get('IFCWALL') ?? [])[0];
+    expect(storeyId).toBeGreaterThan(0);
+
+    // All three carry geometry; only the two contained elements are bodies.
+    const { elements } = elementsFromStep({
+      store,
+      meshes: [solidBoxMesh(storeyId, 0), solidBoxMesh(slabId, 0), solidBoxMesh(wallId, 0.5)],
+      modelId: 'm',
+    });
+
+    expect(elements.map((e) => e.tag).sort()).toEqual(['IfcSlab', 'IfcWall']);
+    // The storey survives as *metadata* on the elements it contains.
+    expect(elements.every((e) => e.storey === 'Level 0')).toBe(true);
+  });
+
+  it('still clashes two elements contained in the same storey (follow-up to #1464, control)', async () => {
+    const store = await new IfcParser().parseColumnar(
+      new TextEncoder().encode(STOREY_WITH_GEOMETRY_IFC).buffer as ArrayBuffer,
+    );
+    const storeyId = (store.entityIndex.byType.get('IFCBUILDINGSTOREY') ?? [])[0];
+    const slabId = (store.entityIndex.byType.get('IFCSLAB') ?? [])[0];
+    const wallId = (store.entityIndex.byType.get('IFCWALL') ?? [])[0];
+
+    const { elements, exclusions } = elementsFromStep({
+      store,
+      meshes: [solidBoxMesh(storeyId, 0), solidBoxMesh(slabId, 0), solidBoxMesh(wallId, 0.5)],
+      modelId: 'm',
+    });
+
+    const engine = createClashEngine({ backend: 'ts' });
+    const result = await engine.run(
+      elements,
+      [{ id: 'r', name: 'all', a: '*', mode: 'hard' }],
+      { exclusions },
+    );
+
+    // Exactly one pair remains: slab x wall. Dropping the storey body must not
+    // cost the contained elements their own clash.
+    expect(result.clashes).toHaveLength(1);
+    const tags = [result.clashes[0].a.tag, result.clashes[0].b.tag].sort();
+    expect(tags).toEqual(['IfcSlab', 'IfcWall']);
+  });
+
+  it('drops IFC4.3 facility containers the IFC4 pin does not know (follow-up to #1464)', async () => {
+    const store = await new IfcParser().parseColumnar(
+      new TextEncoder().encode(INFRA_IFC).buffer as ArrayBuffer,
+    );
+    const ids = ['IFCROAD', 'IFCFACILITYPART', 'IFCSITE', 'IFCWALL'].map(
+      (t) => (store.entityIndex.byType.get(t) ?? [])[0],
+    );
+    expect(ids.every((id) => id > 0)).toBe(true);
+
+    const { elements } = elementsFromStep({
+      store,
+      meshes: ids.map((id) => solidBoxMesh(id, 0)),
+      modelId: 'm',
+    });
+
+    expect(elements.map((e) => e.tag)).toEqual(['IfcWall']);
   });
 
   it('skips meshes with empty geometry', async () => {

--- a/packages/clash/src/adapters/step.ts
+++ b/packages/clash/src/adapters/step.ts
@@ -12,7 +12,7 @@
  * `@ifc-lite/clash/step` subpath so the core stays version-neutral.
  */
 
-import type { IfcDataStore } from '@ifc-lite/parser';
+import { getInheritanceChainAcrossSchemas, type IfcDataStore } from '@ifc-lite/parser';
 import { EntityNode } from '@ifc-lite/query';
 import type { MeshData } from '@ifc-lite/geometry';
 import { makeExclusionSet, qualifiedKey } from '../exclude.js';
@@ -25,16 +25,17 @@ export interface FederationLike {
 }
 
 /**
- * Types that are never physical clash candidates: spatial volumes, voids,
- * virtual/reference geometry, and non-product material associations. Including
- * them produced phantom clashes (IfcSpace, IfcVirtualElement, IfcOpeningElement,
- * even IfcMaterialConstituent) that no clash rule referenced - they are dropped
- * from the candidate set entirely, so "detect all" and per-rule runs only ever
+ * Types that are never physical clash candidates: voids, virtual/reference
+ * geometry, and non-product material associations. Including them produced
+ * phantom clashes (IfcVirtualElement, IfcOpeningElement, even
+ * IfcMaterialConstituent) that no clash rule referenced - they are dropped from
+ * the candidate set entirely, so "detect all" and per-rule runs only ever
  * consider real building elements. (#1464)
+ *
+ * Spatial containers are handled separately by {@link isSpatialContainerTag},
+ * which derives them from the schema rather than from a list.
  */
 const NON_CLASHABLE_TAGS: ReadonlySet<string> = new Set([
-  'IfcSpace',
-  'IfcSpatialZone',
   'IfcOpeningElement',
   'IfcOpeningStandardCase',
   'IfcVirtualElement',
@@ -45,6 +46,36 @@ const NON_CLASHABLE_TAGS: ReadonlySet<string> = new Set([
   'IfcMaterialConstituent',
   'IfcMaterialLayer',
 ]);
+
+/** Memoizes the schema walk below; IFC type names are a bounded vocabulary. */
+const spatialContainerByTag = new Map<string, boolean>();
+
+/**
+ * True for spatial *containers* - the entities whose geometry describes an
+ * extent that, by construction, encloses the elements assigned to it. A storey
+ * against the slab it contains is not a coordination problem, and IFC4.3
+ * infrastructure exports routinely give IfcBuildingStorey / IfcRoad / IfcBridge
+ * tessellated bodies, so every contained element clashed with its own
+ * container. (follow-up to #1464)
+ *
+ * Derived from the schema, not enumerated: `getInheritanceChainAcrossSchemas`
+ * walks the bundled IFC2X3 + IFC4 + IFC4X3 union, so the IFC4.3 facility leaves
+ * (IfcRoad, IfcBridge, IfcFacilityPart, ...) resolve even though the parser's
+ * own codegen pin is IFC4_ADD2_TC1 and would return an empty chain for them.
+ * Both supertypes are checked because IFC2X3 has no `IfcSpatialElement` -
+ * `IfcSpatialStructureElement` descends straight from `IfcProduct` there.
+ * This subsumes the IfcSpace / IfcSpatialZone entries that #1464 listed by hand.
+ */
+function isSpatialContainerTag(tag: string): boolean {
+  const cached = spatialContainerByTag.get(tag);
+  if (cached !== undefined) return cached;
+  const chain = getInheritanceChainAcrossSchemas(tag);
+  const spatial = chain.some(
+    (a) => a === 'IfcSpatialElement' || a === 'IfcSpatialStructureElement',
+  );
+  spatialContainerByTag.set(tag, spatial);
+  return spatial;
+}
 
 export interface StepAdapterOptions {
   store: IfcDataStore;
@@ -93,7 +124,7 @@ export function elementsFromStep(options: StepAdapterOptions): StepAdapterResult
     // Drop non-physical / non-product geometry up front so it never becomes a
     // clash candidate (no rule should have to exclude IfcSpace by hand). (#1464)
     const tag = node.type || mesh.ifcType || 'IfcProduct';
-    if (NON_CLASHABLE_TAGS.has(tag)) continue;
+    if (NON_CLASHABLE_TAGS.has(tag) || isSpatialContainerTag(tag)) continue;
 
     // The wasm geometry path stores positions in the element's LOCAL frame
     // (world = origin + position; see `MeshData.origin`). Clash works in world


### PR DESCRIPTION
Clash detection currently treats `IfcBuildingStorey`, `IfcSite` and `IfcBuilding` as physical bodies. Their geometry describes an *extent* — a storey slab-to-slab volume, a site terrain envelope — so every element inside a storey "clashes" with the storey containing it. On a real infrastructure model this was **235 clashes at CLI defaults, of which 89 were pure container artefacts**: excluding them alone drops the count to 146.

`main`'s `NON_CLASHABLE_TAGS` lists `IfcSpace` and `IfcSpatialZone` by hand (from #1464) but nothing above them in the spatial hierarchy, so storeys and sites still participate.

## How

Replaces the two hand-listed entries with a schema-driven predicate: an entity is excluded when its inheritance chain — read via `getInheritanceChainAcrossSchemas`, **not** the IFC4 pin — contains `IfcSpatialElement` or `IfcSpatialStructureElement`. That subsumes `IfcSpace`/`IfcSpatialZone` and covers the IFC4.3 spatial vocabulary (`IfcFacility`, `IfcFacilityPart`, …) that a hardcoded list would keep missing. Memoised per tag — IFC type names are a bounded vocabulary.

Using the cross-schema chain matters here: the IFC4 codegen pin answers an empty chain for ~251 IFC4.3-only classes, so a pinned lookup would silently fail to recognise infrastructure spatial types as spatial.

## Verification

Reverting the predicate (leaving only the hand-listed tags) fails 4 tests; restored byte-identically. clash suite 188 passing on current `main`.

Note: this fix has existed on a branch since 8 Aug and was never proposed — the measured "235 → 146" figure quoted in the clash work upstream depends on it, so several sibling PRs' numbers assume it has landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Spatial containers are now excluded from clash detection across supported IFC schemas, including IFC2X3, IFC4, and IFC4.3.
  * Clashes between contained elements, such as walls and slabs, continue to be detected.
  * Storey metadata remains available for contained elements.
  * Added coverage for IFC4.3 roads, facility parts, and sites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->