### PR TITLE
feat(viewer,geometry,mutations): zones v2 - write the assignment into the model, cut straddlers, and drop the box constraint (#2508)

### DIFF
--- a/.changeset/export-honour-deleted-quantity-sets.md
+++ b/.changeset/export-honour-deleted-quantity-sets.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/export": patch
+---
+
+`StepExporter` now honours a quantity set the session DELETED.
+
+It withholds a source `IfcElementQuantity` when it is writing a replacement for it, and a deletion has no replacement to be recognised by, so a deleted set stayed in the exported bytes while the panel showed it gone. #2487 wrote that rule when `MutablePropertyView` had no public quantity-set delete; `deleteQuantitySet` (#2508) gives it one, so the exporter asks `isQuantitySetDeleted` as well.
+
+Behaviour is unchanged for every session that does not delete a quantity set, which is every session before this one could exist.

--- a/.changeset/mutations-delete-quantity-set.md
+++ b/.changeset/mutations-delete-quantity-set.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/mutations": minor
+---
+
+`MutablePropertyView.deleteQuantitySet(entityId, qsetName)` - the inverse of `createQuantitySet`, and the exact mirror of the `deletePropertySet` that has always existed one level up.
+
+It was missing, which is why `deletedQsets` was read by `getQuantitiesForEntity`, `hasPendingChanges` and `collectSetLevelChanges` while nothing populated it outside the restore path. Without it, a writer that REPLACES an entity's quantity set can shrink it but never empty it: re-running with nothing left to write leaves the previous run's numbers standing. #2508's zone write-back hits that directly, where it produces a file stating cubic metres beside a property saying the volume could not be computed.
+
+Semantics follow `deletePropertySet`: an in-session quantity set is dropped along with the per-quantity mutations its creation recorded, and a DELETE marker is recorded only against a set that genuinely exists in the base file, so a create-then-delete in one session nets to no reported change.

--- a/.changeset/mutations-delete-quantity-set.md
+++ b/.changeset/mutations-delete-quantity-set.md
@@ -6,4 +6,8 @@
 
 It was missing, which is why `deletedQsets` was read by `getQuantitiesForEntity`, `hasPendingChanges` and `collectSetLevelChanges` while nothing populated it outside the restore path. Without it, a writer that REPLACES an entity's quantity set can shrink it but never empty it: re-running with nothing left to write leaves the previous run's numbers standing. #2508's zone write-back hits that directly, where it produces a file stating cubic metres beside a property saying the volume could not be computed.
 
+It records its own `DELETE_QUANTITY_SET` mutation type rather than a `DELETE_QUANTITY` with no property name: both replay consumers (`applyMutations` and `change-set-to-ops`) key the member-delete case off the property name, so a whole-set removal filed under it matched nothing, resurrected the set on import and vanished from a layer publish without reaching `skipped`.
+
 Semantics follow `deletePropertySet`: an in-session quantity set is dropped along with the per-quantity mutations its creation recorded, and a DELETE marker is recorded only against a set that genuinely exists in the base file, so a create-then-delete in one session nets to no reported change.
+
+Paired with it, `MutablePropertyView.isQuantitySetDeleted(entityId, qsetName)`: `getQuantitiesForEntity` reports a deleted set and a never-existing one identically, and the STEP exporter needs the difference. It withholds a source `IfcElementQuantity` when it is writing a replacement for it, and a deletion has no replacement to be recognised by, so without this a set the session deleted was still in the exported bytes.

--- a/.changeset/wasm-split-mesh-by-zones.md
+++ b/.changeset/wasm-split-mesh-by-zones.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/wasm": minor
+---
+
+`splitMeshByZones(positions, indices, zones, footprints?, footprintCounts?)` cuts one element into one closed solid per location zone, plus the remainder (issue #2508 item 2).
+
+Everything is in the caller's frame, and positions cross as f64: the split's whole value over an AABB estimate is exactness, and an f64 to f32 round trip at the boundary would put a crack back into every shared zone plane. A zone is an oriented box by default, or a vertical prism when its `footprintCounts` entry is non-zero.
+
+Each result carries its own enclosed volume, and the handle carries `sumErrorRel` - how far the pieces are from summing to the whole. That is the invariant the issue puts above every other for this feature, and it is exposed rather than enforced: the expected cause of a failure is zones that overlap each other, and a number the caller can show beats a silent refusal.

--- a/apps/viewer/src/components/viewer/ZoneWriteBackControl.test.tsx
+++ b/apps/viewer/src/components/viewer/ZoneWriteBackControl.test.tsx
@@ -1,0 +1,108 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The write-back control, driven from the panel that hosts it (#2508 item 3).
+ *
+ * `useZoneWriteBack.test.ts` proves the write itself. What this proves is the
+ * half that file cannot: the button exists ON the Zones panel, and CLICKING it
+ * writes. A test that asserts the control renders would pass just as well with
+ * `onClick={() => {}}`, which is the failure #2434 catalogued and #2396 shipped
+ * - so the assertion here is the property set landing on the element.
+ */
+
+import '@/test/setup-dom.js';
+import { describe, it, beforeEach, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { render, click, cleanup } from '@/test/render.js';
+import { IfcParser, type IfcDataStore } from '@ifc-lite/parser';
+import { useViewerStore } from '@/store/index.js';
+import { ZonesPanel } from './ZonesPanel.js';
+import { zonePropertySetName, type ZoneSet } from '@/lib/zones';
+
+const WALL_ID = 42;
+
+const MINI_IFC = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('zones','',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0Project0000000000000a',$,'P',$,$,$,$,$,$);
+#${WALL_ID}=IFCWALL('0Wall00000000000000042',$,'Wall A',$,$,$,$,$,$);
+ENDSEC;
+END-ISO-10303-21;
+`;
+
+const ZONE_SET: ZoneSet = {
+  id: 'set-1',
+  name: 'Takt areas',
+  zones: [{ id: 'z-a', name: 'Takt A', center: [0, 0, 0], size: [10, 10, 10], rotationY: 0 }],
+  visible: true,
+  createdAt: 0,
+  updatedAt: 0,
+};
+
+async function seed(): Promise<IfcDataStore> {
+  const bytes = new TextEncoder().encode(MINI_IFC);
+  const store = await new IfcParser().parseColumnar(
+    bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+  );
+  useViewerStore.setState({
+    models: new Map([['m1', { id: 'm1', name: 'zones.ifc', ifcDataStore: store, visible: true } as never]]),
+    zoneSets: [ZONE_SET],
+    zoneAssignments: new Map([[WALL_ID, {
+      'set-1': { zoneId: 'z-a', zoneName: 'Takt A', straddles: false, touchedZoneIds: ['z-a'] },
+    }]]) as never,
+    zoneApportionment: new Map(),
+    mutationViews: new Map(),
+    dirtyModels: new Set(),
+  } as never);
+  return store;
+}
+
+function writeButton(container: HTMLElement): HTMLButtonElement {
+  const button = [...container.querySelectorAll('button')]
+    .find((b) => b.textContent?.trim() === 'Write to model');
+  assert.ok(button, `no write button; buttons were: ${[...container.querySelectorAll('button')].map((b) => b.textContent?.trim()).join(' | ')}`);
+  return button as HTMLButtonElement;
+}
+
+after(cleanup);
+
+describe('ZonesPanel: writing zone data into the model', () => {
+  beforeEach(async () => {
+    await seed();
+  });
+
+  it('writes the property set when the panel button is clicked', () => {
+    const container = render(<ZonesPanel />);
+
+    // Nothing before the click: the panel must not write on mount.
+    assert.equal(useViewerStore.getState().getMutationView('m1'), null);
+
+    click(writeButton(container));
+
+    const psets = useViewerStore.getState().getMutationView('m1')?.getForEntity(WALL_ID) ?? [];
+    assert.ok(
+      psets.some((p) => p.name === zonePropertySetName('Takt areas')),
+      `zone pset not written; got ${psets.map((p) => p.name).join(', ')}`,
+    );
+    assert.ok(useViewerStore.getState().dirtyModels.has('m1'));
+  });
+
+  it('removes it again from the same panel', () => {
+    const container = render(<ZonesPanel />);
+    click(writeButton(container));
+
+    const remove = [...container.querySelectorAll('button')]
+      .find((b) => b.getAttribute('aria-label') === 'Remove zone properties');
+    assert.ok(remove, 'no remove control');
+    click(remove);
+
+    const psets = useViewerStore.getState().getMutationView('m1')?.getForEntity(WALL_ID) ?? [];
+    assert.ok(!psets.some((p) => p.name === zonePropertySetName('Takt areas')));
+  });
+});

--- a/apps/viewer/src/components/viewer/ZoneWriteBackControl.tsx
+++ b/apps/viewer/src/components/viewer/ZoneWriteBackControl.tsx
@@ -1,0 +1,107 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * "Get zone data out of the viewer" (issue #2508, item 3), in the panel that
+ * authored the zones.
+ *
+ * Writes the set's assignment onto the elements as an IFC property set plus a
+ * quantity set, so an export carries it. The names it writes are shown here
+ * rather than only in a doc: whoever runs this is about to go looking for them
+ * in another tool.
+ *
+ * The basis is a deliberate CHOICE, not a default that hides: a `net` breakdown
+ * reconciles with the file's own NetVolume by construction, while `mesh` is the
+ * one that was measured. #2199's convention says the tool labels rather than
+ * decides, so both are offered and the name of the chosen one ends up in the
+ * quantity set's name.
+ */
+
+import { useState } from 'react';
+import { FileOutput, Undo2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { toast } from '@/components/ui/toast';
+import { useZoneWriteBack } from '@/hooks/useZoneWriteBack';
+import {
+  zonePropertySetName,
+  zoneQuantitySetName,
+  volumeBasisLabel,
+  type VolumeBasis,
+  type ZoneSet,
+} from '@/lib/zones';
+
+const BASES: readonly VolumeBasis[] = ['mesh', 'net', 'gross', 'unqualified'];
+
+export function ZoneWriteBackControl({ zoneSet }: { zoneSet: ZoneSet }) {
+  const [basis, setBasis] = useState<VolumeBasis>('mesh');
+  const { write, remove } = useZoneWriteBack();
+
+  return (
+    <div className="space-y-1 rounded border-t pt-1.5">
+      <div className="flex items-center gap-1">
+        <Select value={basis} onValueChange={(v) => setBasis(v as VolumeBasis)}>
+          <SelectTrigger className="h-6 w-[104px] text-[11px]" aria-label="Volume basis">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {BASES.map((b) => (
+              <SelectItem key={b} value={b} className="text-[11px]">{volumeBasisLabel(b)}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-6 flex-1 text-[11px]"
+          title={`Write this set's zone assignment onto the elements as ${zonePropertySetName(zoneSet.name)}`}
+          onClick={() => {
+            const result = write(zoneSet, basis);
+            if (result.blocked === 'collab-role') {
+              toast.error('Your role in this session is read-only, so nothing was written');
+              return;
+            }
+            if (result.summary.written === 0) {
+              toast.info('No element is in a zone of this set, so nothing was written');
+              return;
+            }
+            const { written, withVolumes, refused } = result.summary;
+            toast.success(
+              `Wrote ${written.toLocaleString()} element(s): ${withVolumes.toLocaleString()} with volumes`
+              + (refused > 0 ? `, ${refused.toLocaleString()} with a stated reason instead` : ''),
+            );
+          }}
+        >
+          <FileOutput className="h-3 w-3 mr-1" />
+          Write to model
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-6 w-6"
+          title={`Remove ${zonePropertySetName(zoneSet.name)} from every element of this set`}
+          aria-label="Remove zone properties"
+          onClick={() => {
+            const { removed } = remove(zoneSet);
+            if (removed === 0) toast.info('Nothing to remove for this set');
+            else toast.success(`Removed the zone property set from ${removed.toLocaleString()} element(s)`);
+          }}
+        >
+          <Undo2 className="h-3 w-3" />
+        </Button>
+      </div>
+      {/* Named here because the next place these are looked for is another
+          tool's property browser, not this panel. */}
+      <p className="text-[10px] text-muted-foreground leading-snug break-words">
+        {zonePropertySetName(zoneSet.name)} · {zoneQuantitySetName(zoneSet.name, basis)}
+      </p>
+    </div>
+  );
+}

--- a/apps/viewer/src/components/viewer/ZoneWriteBackControl.tsx
+++ b/apps/viewer/src/components/viewer/ZoneWriteBackControl.tsx
@@ -96,7 +96,15 @@ export function ZoneWriteBackControl({ zoneSet }: { zoneSet: ZoneSet }) {
           title={`Remove ${zonePropertySetName(zoneSet.name)} from every element of this set`}
           aria-label="Remove zone properties"
           onClick={() => {
-            const { removed } = remove(zoneSet);
+            const { removed, blocked } = remove(zoneSet);
+            if (blocked === 'collab-role') {
+              toast.error('Your role in this session is read-only, so nothing was removed');
+              return;
+            }
+            if (blocked === 'duplicate-set-name') {
+              toast.error(`Another zone set is also called "${zoneSet.name}". Rename one before removing.`);
+              return;
+            }
             if (removed === 0) toast.info('Nothing to remove for this set');
             else toast.success(`Removed the zone property set from ${removed.toLocaleString()} element(s)`);
           }}

--- a/apps/viewer/src/components/viewer/ZoneWriteBackControl.tsx
+++ b/apps/viewer/src/components/viewer/ZoneWriteBackControl.tsx
@@ -68,6 +68,13 @@ export function ZoneWriteBackControl({ zoneSet }: { zoneSet: ZoneSet }) {
               toast.error('Your role in this session is read-only, so nothing was written');
               return;
             }
+            if (result.blocked === 'duplicate-set-name') {
+              // Both set names carry the display name, so two sets sharing one
+              // would write to the same place and each would clear the other's
+              // numbers. Renaming is the user's call, not this run's.
+              toast.error(`Another zone set is also called "${zoneSet.name}". Rename one before writing.`);
+              return;
+            }
             if (result.summary.written === 0) {
               toast.info('No element is in a zone of this set, so nothing was written');
               return;

--- a/apps/viewer/src/components/viewer/ZonesPanel.tsx
+++ b/apps/viewer/src/components/viewer/ZonesPanel.tsx
@@ -434,6 +434,16 @@ export function ZonesPanel({ onClose }: ZonesPanelProps) {
                     let result: ReturnType<typeof exportZone>;
                     try {
                       result = exportZone(zs, zs.zones.indexOf(zone));
+                    } catch (error) {
+                      // The kernel, the GLB build and the download can each
+                      // throw. Inside an ASYNC handler a throw becomes an
+                      // unhandled rejection, so the user would sit in front of
+                      // a control that reset itself and said nothing.
+                      console.error('[zones] geometry export failed', error);
+                      toast.error(
+                        `Could not export ${zone.name}: ${error instanceof Error ? error.message : 'unknown error'}`,
+                      );
+                      return;
                     } finally {
                       exportingRef.current = false;
                       setExportingZoneId(null);

--- a/apps/viewer/src/components/viewer/ZonesPanel.tsx
+++ b/apps/viewer/src/components/viewer/ZonesPanel.tsx
@@ -38,6 +38,7 @@ import { generateZonesFromStoreys } from '@/hooks/useZoneStoreyGeneration';
 import { selectElementsInZone } from '@/hooks/useZoneSelection';
 import type { Zone } from '@/lib/zones';
 import { ZoneApportionSummary } from './ZoneApportionSummary';
+import { ZoneWriteBackControl } from './ZoneWriteBackControl';
 
 interface ZonesPanelProps {
   onClose?: () => void;
@@ -356,6 +357,8 @@ export function ZonesPanel({ onClose }: ZonesPanelProps) {
               {/* Volume apportionment for this set's straddlers (#2508). On
                   demand only — never part of load. */}
               {zs.zones.length > 0 && <ZoneApportionSummary zoneSet={zs} />}
+              {/* ...and the way that result leaves the viewer (#2508 item 3). */}
+              {zs.zones.length > 0 && <ZoneWriteBackControl zoneSet={zs} />}
             </CollapsibleContent>
           </Collapsible>
         ))}

--- a/apps/viewer/src/components/viewer/ZonesPanel.tsx
+++ b/apps/viewer/src/components/viewer/ZonesPanel.tsx
@@ -26,6 +26,7 @@ import {
   Upload,
   MousePointerClick,
   Pencil,
+  Scissors,
   X,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -36,6 +37,7 @@ import { downloadFile, sanitizeFilename } from '@/lib/export/download';
 import { toast } from '@/components/ui/toast';
 import { generateZonesFromStoreys } from '@/hooks/useZoneStoreyGeneration';
 import { selectElementsInZone } from '@/hooks/useZoneSelection';
+import { useZoneGeometrySplit } from '@/hooks/useZoneGeometrySplit';
 import type { Zone } from '@/lib/zones';
 import { ZoneApportionSummary } from './ZoneApportionSummary';
 import { ZoneWriteBackControl } from './ZoneWriteBackControl';
@@ -94,7 +96,7 @@ function NumberField({
 }
 
 function ZoneRow({
-  setId, zone, editing, onEdit, onUpdate, onRemove, onSelect,
+  setId, zone, editing, onEdit, onUpdate, onRemove, onSelect, onExportGeometry,
 }: {
   setId: string;
   zone: Zone;
@@ -103,6 +105,7 @@ function ZoneRow({
   onUpdate: (patch: Partial<Omit<Zone, 'id'>>) => void;
   onRemove: () => void;
   onSelect: () => void;
+  onExportGeometry: () => void;
 }) {
   return (
     <div className={`rounded-md border p-2 text-xs space-y-1.5 ${editing ? 'border-amber-500 bg-amber-500/5' : 'border-border/60'}`}>
@@ -123,6 +126,18 @@ function ZoneRow({
         </Button>
         <Button variant="ghost" size="icon" className="h-6 w-6" title="Select elements in this zone" onClick={onSelect}>
           <MousePointerClick className="h-3 w-3" />
+        </Button>
+        {/* The geometry half of #2508: elements wholly in this zone plus the
+            CUT pieces of the straddlers, as one model of this section. */}
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-6 w-6"
+          title="Export this zone's geometry (straddlers cut at the boundary) as GLB"
+          aria-label={`Export ${zone.name} geometry`}
+          onClick={onExportGeometry}
+        >
+          <Scissors className="h-3 w-3" />
         </Button>
         <Button variant="ghost" size="icon" className="h-6 w-6 text-destructive" title="Delete zone" onClick={onRemove}>
           <Trash2 className="h-3 w-3" />
@@ -179,6 +194,7 @@ export function ZonesPanel({ onClose }: ZonesPanelProps) {
   const replaceZonesInSet = useViewerStore((s) => s.replaceZonesInSet);
   const exportZoneSetsJSON = useViewerStore((s) => s.exportZoneSetsJSON);
   const importZoneSetsJSON = useViewerStore((s) => s.importZoneSetsJSON);
+  const { exportZone } = useZoneGeometrySplit();
 
   const [newSetName, setNewSetName] = useState('');
   const importInputRef = useRef<HTMLInputElement>(null);
@@ -351,6 +367,20 @@ export function ZonesPanel({ onClose }: ZonesPanelProps) {
                     const count = selectElementsInZone(zs.id, zone.id);
                     if (count > 0) toast.success(`Selected ${count} element(s)`);
                     else toast.info('No elements in this zone');
+                  }}
+                  onExportGeometry={() => {
+                    const result = exportZone(zs, zs.zones.indexOf(zone));
+                    if (!result.ok) {
+                      toast.error(result.reason === 'no-binding'
+                        ? 'The geometry engine in this build cannot split meshes'
+                        : 'Nothing to export: no loaded geometry reaches this zone');
+                      return;
+                    }
+                    const { whole, cut, refused } = result.summary;
+                    toast.success(
+                      `Exported ${whole} whole and ${cut} cut element(s)`
+                      + (refused > 0 ? `, ${refused} skipped (mesh not a proven closed solid)` : ''),
+                    );
                   }}
                 />
               ))}

--- a/apps/viewer/src/components/viewer/ZonesPanel.tsx
+++ b/apps/viewer/src/components/viewer/ZonesPanel.tsx
@@ -143,6 +143,38 @@ function ZoneRow({
           <Trash2 className="h-3 w-3" />
         </Button>
       </div>
+      {/* A PRISM zone (#2508 item 4) owns only its vertical extent: its X/Z
+          centre, size and rotation are DERIVED from the footprint, so offering
+          them as editable fields would show numbers that snap back on the next
+          import and change nothing in between. */}
+      {zone.footprint ? (
+        <div className="grid grid-cols-3 gap-1">
+          <label className="flex flex-col gap-0.5">
+            <span className="text-muted-foreground">Base (Y)</span>
+            <NumberField
+              value={zone.center[1] - zone.size[1] / 2}
+              onCommit={(v) => onUpdate({ center: [zone.center[0], v + zone.size[1] / 2, zone.center[2]] })}
+            />
+          </label>
+          <label className="flex flex-col gap-0.5">
+            <span className="text-muted-foreground">Height (Y)</span>
+            <NumberField
+              value={zone.size[1]}
+              onCommit={(v) => {
+                const height = Math.max(0.05, v);
+                const base = zone.center[1] - zone.size[1] / 2;
+                onUpdate({
+                  size: [zone.size[0], height, zone.size[2]],
+                  center: [zone.center[0], base + height / 2, zone.center[2]],
+                });
+              }}
+            />
+          </label>
+          <span className="self-end text-[10px] text-muted-foreground truncate" title="Footprint imported from JSON; the 3D handles edit boxes only">
+            prism, {zone.footprint.length} pts
+          </span>
+        </div>
+      ) : (
       <div className="grid grid-cols-3 gap-1">
         {(['Center X', 'Center Y', 'Center Z'] as const).map((label, i) => (
           <label key={label} className="flex flex-col gap-0.5">
@@ -175,6 +207,7 @@ function ZoneRow({
           <NumberField value={toDeg(zone.rotationY)} onCommit={(v) => onUpdate({ rotationY: fromDeg(v) })} />
         </label>
       </div>
+      )}
     </div>
   );
 }

--- a/apps/viewer/src/components/viewer/ZonesPanel.tsx
+++ b/apps/viewer/src/components/viewer/ZonesPanel.tsx
@@ -409,9 +409,9 @@ export function ZonesPanel({ onClose }: ZonesPanelProps) {
                         : 'Nothing to export: no loaded geometry reaches this zone');
                       return;
                     }
-                    const { whole, cut, refused } = result.summary;
+                    const { whole, cut, refused, elapsedMs } = result.summary;
                     toast.success(
-                      `Exported ${whole} whole and ${cut} cut element(s)`
+                      `Exported ${whole} whole and ${cut} cut element(s) in ${(elapsedMs / 1000).toFixed(1)}s`
                       + (refused > 0 ? `, ${refused} skipped (mesh not a proven closed solid)` : ''),
                     );
                   }}

--- a/apps/viewer/src/components/viewer/ZonesPanel.tsx
+++ b/apps/viewer/src/components/viewer/ZonesPanel.tsx
@@ -115,15 +115,21 @@ function ZoneRow({
           onChange={(e) => onUpdate({ name: e.target.value })}
           className="h-6 flex-1 px-1.5 text-xs font-medium"
         />
-        <Button
-          variant={editing ? 'default' : 'ghost'}
-          size="icon"
-          className="h-6 w-6"
-          title={editing ? 'Stop editing in 3D' : 'Edit in 3D (move / resize / rotate handles)'}
-          onClick={onEdit}
-        >
-          <Pencil className="h-3 w-3" />
-        </Button>
+        {/* Hidden for a prism: the 3D gizmo edits the box fields, which a
+            prism derives from its footprint, so the handles would move nothing
+            (see `ZoneOverlay`). A control that does nothing is worse than no
+            control. */}
+        {!zone.footprint && (
+          <Button
+            variant={editing ? 'default' : 'ghost'}
+            size="icon"
+            className="h-6 w-6"
+            title={editing ? 'Stop editing in 3D' : 'Edit in 3D (move / resize / rotate handles)'}
+            onClick={onEdit}
+          >
+            <Pencil className="h-3 w-3" />
+          </Button>
+        )}
         <Button variant="ghost" size="icon" className="h-6 w-6" title="Select elements in this zone" onClick={onSelect}>
           <MousePointerClick className="h-3 w-3" />
         </Button>
@@ -409,10 +415,11 @@ export function ZonesPanel({ onClose }: ZonesPanelProps) {
                         : 'Nothing to export: no loaded geometry reaches this zone');
                       return;
                     }
-                    const { whole, cut, refused, elapsedMs } = result.summary;
+                    const { whole, cut, refused, noGeometry, elapsedMs } = result.summary;
                     toast.success(
                       `Exported ${whole} whole and ${cut} cut element(s) in ${(elapsedMs / 1000).toFixed(1)}s`
-                      + (refused > 0 ? `, ${refused} skipped (mesh not a proven closed solid)` : ''),
+                      + (refused > 0 ? `, ${refused} not cut (mesh not a proven closed solid, or the pieces did not add up)` : '')
+                      + (noGeometry > 0 ? `, ${noGeometry} with no loaded geometry` : ''),
                     );
                   }}
                 />

--- a/apps/viewer/src/components/viewer/ZonesPanel.tsx
+++ b/apps/viewer/src/components/viewer/ZonesPanel.tsx
@@ -96,11 +96,14 @@ function NumberField({
 }
 
 function ZoneRow({
-  setId, zone, editing, onEdit, onUpdate, onRemove, onSelect, onExportGeometry,
+  setId, zone, editing, exporting, onEdit, onUpdate, onRemove, onSelect, onExportGeometry,
 }: {
   setId: string;
   zone: Zone;
   editing: boolean;
+  /** A geometry export for THIS zone is running: the control is disabled and
+   *  says so, because the split blocks the main thread for seconds. */
+  exporting: boolean;
   onEdit: () => void;
   onUpdate: (patch: Partial<Omit<Zone, 'id'>>) => void;
   onRemove: () => void;
@@ -139,11 +142,14 @@ function ZoneRow({
           variant="ghost"
           size="icon"
           className="h-6 w-6"
-          title="Export this zone's geometry (straddlers cut at the boundary) as GLB"
+          title={exporting
+            ? 'Cutting this zone\'s geometry, this can take a while'
+            : "Export this zone's geometry (straddlers cut at the boundary) as GLB"}
           aria-label={`Export ${zone.name} geometry`}
+          disabled={exporting}
           onClick={onExportGeometry}
         >
-          <Scissors className="h-3 w-3" />
+          <Scissors className={`h-3 w-3${exporting ? ' animate-pulse' : ''}`} />
         </Button>
         <Button variant="ghost" size="icon" className="h-6 w-6 text-destructive" title="Delete zone" onClick={onRemove}>
           <Trash2 className="h-3 w-3" />
@@ -234,6 +240,11 @@ export function ZonesPanel({ onClose }: ZonesPanelProps) {
   const exportZoneSetsJSON = useViewerStore((s) => s.exportZoneSetsJSON);
   const importZoneSetsJSON = useViewerStore((s) => s.importZoneSetsJSON);
   const { exportZone } = useZoneGeometrySplit();
+  // Which zone's geometry export is running, for the disabled state, plus a ref
+  // so a second click is refused in the same tick the first one starts (state
+  // has not re-rendered yet at that point).
+  const [exportingZoneId, setExportingZoneId] = useState<string | null>(null);
+  const exportingRef = useRef(false);
 
   const [newSetName, setNewSetName] = useState('');
   const importInputRef = useRef<HTMLInputElement>(null);
@@ -407,8 +418,26 @@ export function ZonesPanel({ onClose }: ZonesPanelProps) {
                     if (count > 0) toast.success(`Selected ${count} element(s)`);
                     else toast.info('No elements in this zone');
                   }}
-                  onExportGeometry={() => {
-                    const result = exportZone(zs, zs.zones.indexOf(zone));
+                  exporting={exportingZoneId === zone.id}
+                  onExportGeometry={async () => {
+                    // The split is seconds of synchronous work (~357 ms per cut
+                    // element, measured), so three things have to happen before
+                    // it starts: mark the zone busy, let the browser PAINT that
+                    // (a state change alone does not, since the handler blocks
+                    // the same frame), and refuse a second click. Without the
+                    // last one a queued click starts a whole second run the
+                    // moment the first returns.
+                    if (exportingRef.current) return;
+                    exportingRef.current = true;
+                    setExportingZoneId(zone.id);
+                    await new Promise((resolve) => setTimeout(resolve, 0));
+                    let result: ReturnType<typeof exportZone>;
+                    try {
+                      result = exportZone(zs, zs.zones.indexOf(zone));
+                    } finally {
+                      exportingRef.current = false;
+                      setExportingZoneId(null);
+                    }
                     if (!result.ok) {
                       toast.error(result.reason === 'no-binding'
                         ? 'The geometry engine in this build cannot split meshes'

--- a/apps/viewer/src/components/viewer/tools/ZoneOverlay.tsx
+++ b/apps/viewer/src/components/viewer/tools/ZoneOverlay.tsx
@@ -26,13 +26,23 @@ import { computeZoneDragPatch, type DragKind, type DragState, type Vec2, type Ve
 
 type Project = (worldPos: Vec3) => Vec2 | null;
 
-/** Wireframe edges as pairs of corner indices, matching `zoneWorldCorners`'
- *  bottom-face-then-top-face order (0-3 bottom, 4-7 top). */
-const BOX_EDGES: ReadonlyArray<readonly [number, number]> = [
-  [0, 1], [1, 2], [2, 3], [3, 0], // bottom
-  [4, 5], [5, 6], [6, 7], [7, 4], // top
-  [0, 4], [1, 5], [2, 6], [3, 7], // verticals
-];
+/**
+ * Wireframe edges as pairs of corner indices, for a hull of `2n` corners in
+ * `zoneWorldCorners`' bottom-ring-then-top-ring order.
+ *
+ * Derived rather than listed since #2508 item 4: a box is the `n = 4` case, and
+ * a prism zone has as many corners as its footprint has points. A hardcoded
+ * 12-edge table drew a box-shaped lie around every prism.
+ */
+function hullEdges(cornerCount: number): Array<readonly [number, number]> {
+  const n = cornerCount / 2;
+  const edges: Array<readonly [number, number]> = [];
+  for (let i = 0; i < n; i++) {
+    const next = (i + 1) % n;
+    edges.push([i, next], [n + i, n + next], [i, n + i]);
+  }
+  return edges;
+}
 
 function rgbToCss([r, g, b]: readonly [number, number, number], alpha: number): string {
   return `rgba(${Math.round(r * 255)}, ${Math.round(g * 255)}, ${Math.round(b * 255)}, ${alpha})`;
@@ -67,12 +77,13 @@ function projectZones(
         corners.push(p);
       }
       if (!ok) return;
-      // Label anchors above the top face's center (average of corners 4-7).
-      const top = worldCorners.slice(4);
+      // Label anchors above the centre of the TOP ring, which is the second
+      // half of the corner list whatever the footprint's point count.
+      const top = worldCorners.slice(worldCorners.length / 2);
       const topCenter: Vec3 = {
-        x: top.reduce((s, c) => s + c[0], 0) / 4,
-        y: top.reduce((s, c) => s + c[1], 0) / 4 + 0.3,
-        z: top.reduce((s, c) => s + c[2], 0) / 4,
+        x: top.reduce((s, c) => s + c[0], 0) / top.length,
+        y: top.reduce((s, c) => s + c[1], 0) / top.length + 0.3,
+        z: top.reduce((s, c) => s + c[2], 0) / top.length,
       };
       const labelAnchor = project(topCenter);
       if (!labelAnchor) return;
@@ -121,6 +132,13 @@ export function ZoneOverlay() {
   const editingEntry = editingZone
     ? projected.find((p) => p.setId === editingZone.setId && p.zone.id === editingZone.zoneId)
     : undefined;
+  // The move/resize/rotate gizmo edits `center` / `size` / `rotationY`, which
+  // for a PRISM are derived from its footprint rather than authoritative
+  // (#2508 item 4). Dragging them would move a bounding box the exact tests do
+  // not read, so the zone would visibly change and behave identically. No
+  // handles is the honest state until a footprint editor exists; the numeric
+  // fields stay available for the vertical extent, which IS authoritative.
+  const gizmoEntry = editingEntry?.zone.footprint ? undefined : editingEntry;
 
   /** Probe `+1` world unit along `dir` from `origin`, returning screen
    *  pixels-per-metre in that direction (or null if degenerate/offscreen). */
@@ -186,12 +204,12 @@ export function ZoneOverlay() {
         const isEditing = editingZone?.setId === entry.setId && editingZone.zoneId === entry.zone.id;
         const stroke = rgbToCss(entry.color, isEditing ? 1 : 0.85);
         const fill = rgbToCss(entry.color, isEditing ? 0.18 : 0.1);
-        const topFace = [entry.corners[4], entry.corners[5], entry.corners[6], entry.corners[7]]
+        const topFace = entry.corners.slice(entry.corners.length / 2)
           .map((p) => `${p.x},${p.y}`).join(' ');
         return (
           <g key={`${entry.setId}:${entry.zone.id}`}>
             <polygon points={topFace} fill={fill} stroke="none" />
-            {BOX_EDGES.map(([a, b], i) => (
+            {hullEdges(entry.corners.length).map(([a, b], i) => (
               <line
                 key={i}
                 x1={entry.corners[a].x} y1={entry.corners[a].y}
@@ -212,8 +230,8 @@ export function ZoneOverlay() {
         );
       })}
 
-      {editingEntry && (() => {
-        const zone = editingEntry.zone;
+      {gizmoEntry && (() => {
+        const zone = gizmoEntry.zone;
         const center: Vec3 = { x: zone.center[0], y: zone.center[1], z: zone.center[2] };
         const cos = Math.cos(zone.rotationY);
         const sin = Math.sin(zone.rotationY);
@@ -301,7 +319,7 @@ export function ZoneOverlay() {
                   stroke="#18181b"
                   strokeWidth={1.5}
                   style={{ cursor: h.op.kind === 'rotate' ? 'grab' : 'move' }}
-                  onPointerDown={(e) => startDrag(e, editingEntry, h.op, h.probeOrigin, h.probeDir)}
+                  onPointerDown={(e) => startDrag(e, gizmoEntry, h.op, h.probeOrigin, h.probeDir)}
                   onPointerMove={onDragMove}
                   onPointerUp={onDragEnd}
                   onPointerCancel={onDragEnd}

--- a/apps/viewer/src/hooks/useZoneGeometrySplit.test.ts
+++ b/apps/viewer/src/hooks/useZoneGeometrySplit.test.ts
@@ -1,0 +1,159 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Which element's geometry lands in which zone's file (#2508 item 2).
+ *
+ * The cutting is the kernel's and is tested in Rust plus across the real wasm
+ * boundary. The routing is this module's, and it is where a plausible-looking
+ * mistake hides: a per-section model that quietly contains the wrong section's
+ * straddler pieces still opens, still looks like a building, and is wrong.
+ */
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import type { MeshData } from '@ifc-lite/geometry';
+import { useViewerStore } from '@/store/index.js';
+import { exportZoneGeometry } from './useZoneGeometrySplit.js';
+import type { SplitMeshByZonesFn } from '@/lib/zones/split.js';
+import type { ZoneSet } from '@/lib/zones';
+
+const STRADDLER = 10;
+const WHOLE = 11;
+const UNPROVED = 12;
+
+const ZONE_SET: ZoneSet = {
+  id: 'set-1',
+  name: 'Takt areas',
+  zones: [
+    { id: 'z-a', name: 'Takt A', center: [0, 0, 0], size: [10, 10, 10], rotationY: 0 },
+    { id: 'z-b', name: 'Takt B', center: [10, 0, 0], size: [10, 10, 10], rotationY: 0 },
+  ],
+  visible: true,
+  createdAt: 0,
+  updatedAt: 0,
+};
+
+function mesh(expressId: number): MeshData {
+  return {
+    expressId,
+    positions: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+    normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+    indices: new Uint32Array([0, 1, 2]),
+    color: [1, 0, 0, 1],
+  } as MeshData;
+}
+
+/** A split that puts 1 m3 in each zone, so both zones have a piece and the
+ *  routing has something to get wrong. */
+const split: SplitMeshByZonesFn = () => ({
+  pieceCount: 2,
+  wholeVolume: 2,
+  sumErrorRel: 0,
+  piece(index: number) {
+    return {
+      zoneIndex: index,
+      // A distinct x per zone, so the emitted file can be checked for WHICH
+      // piece it received rather than merely that it received one.
+      positions: Float64Array.from([index, 0, 0, index + 1, 0, 0, index, 1, 0]),
+      indices: Uint32Array.from([0, 1, 2]),
+      volume: 1,
+      free: () => {},
+    };
+  },
+  free: () => {},
+});
+
+function seed() {
+  useViewerStore.setState({
+    zoneSets: [ZONE_SET],
+    zoneAssignments: new Map([
+      [STRADDLER, { 'set-1': { zoneId: 'z-a', zoneName: 'Takt A', straddles: true, touchedZoneIds: ['z-a', 'z-b'] } }],
+      [WHOLE, { 'set-1': { zoneId: 'z-b', zoneName: 'Takt B', straddles: false, touchedZoneIds: ['z-b'] } }],
+      [UNPROVED, { 'set-1': { zoneId: 'z-a', zoneName: 'Takt A', straddles: true, touchedZoneIds: ['z-a'] } }],
+    ]) as never,
+    // The kernel proved a volume for the first two only. `geometryResult` is
+    // the legacy single-model channel `gatherProvedVolumes` reads first.
+    geometryResult: {
+      meshes: [
+        { expressId: STRADDLER, geometryVolume: 2 },
+        { expressId: WHOLE, geometryVolume: 5 },
+        { expressId: UNPROVED },
+      ],
+    } as never,
+    models: new Map(),
+  } as never);
+}
+
+function runExport(zoneIndex: number) {
+  const emitted: Array<{ bytes: Uint8Array; filename: string }> = [];
+  const result = exportZoneGeometry(ZONE_SET, zoneIndex, {
+    split,
+    meshPieces: (globalId) => [mesh(globalId)],
+    emit: (bytes, filename) => emitted.push({ bytes, filename }),
+  });
+  return { result, emitted };
+}
+
+describe('exporting one zone as its own model', () => {
+  beforeEach(seed);
+
+  it('writes whole elements and cut pieces, and counts what it refused', () => {
+    const { result } = runExport(1);
+    assert.ok(result.ok);
+    assert.equal(result.summary.whole, 1, 'the element wholly in Takt B');
+    assert.equal(result.summary.cut, 1, 'the straddler cut at the boundary');
+    assert.equal(result.summary.volumeM3, 6, 'whole 5 m3 plus a 1 m3 piece');
+  });
+
+  it('refuses a straddler whose mesh the kernel never proved', () => {
+    // Zone A holds the straddler and the unproved element.
+    const { result } = runExport(0);
+    assert.ok(result.ok);
+    assert.equal(result.summary.cut, 1);
+    assert.equal(result.summary.refused, 1);
+  });
+
+  it('takes the piece belonging to the zone asked for, not the first one', () => {
+    // The fake split gives zone i a piece at x = i. If the routing ignored
+    // zoneIndex and took pieces[0], the file for Takt B would carry Takt A's
+    // geometry: same triangle count, same volume, wrong section.
+    const a = runExport(0);
+    const b = runExport(1);
+    assert.ok(a.result.ok && b.result.ok);
+    assert.notEqual(a.emitted[0].bytes.byteLength, 0);
+    assert.notDeepEqual(
+      [...a.emitted[0].bytes.slice(0, 512)],
+      [...b.emitted[0].bytes.slice(0, 512)],
+      'both zones produced byte-identical files, so the piece was not selected by zone',
+    );
+  });
+
+  it('names the file after the set and the zone', () => {
+    const { emitted } = runExport(0);
+    assert.equal(emitted[0].filename, 'Takt areas-Takt A.glb');
+  });
+
+  it('reports rather than emits when no geometry reaches the zone', () => {
+    useViewerStore.setState({ zoneAssignments: new Map() } as never);
+    const emitted: Uint8Array[] = [];
+    const result = exportZoneGeometry(ZONE_SET, 0, {
+      split,
+      meshPieces: () => null,
+      emit: (bytes) => emitted.push(bytes),
+    });
+    assert.equal(result.ok, false);
+    assert.equal(emitted.length, 0, 'an empty zone must not download an empty file');
+  });
+
+  it('degrades to a message when the wasm build has no splitter', () => {
+    const result = exportZoneGeometry(ZONE_SET, 0, {
+      split: undefined,
+      meshPieces: (globalId) => [mesh(globalId)],
+      emit: () => {},
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.ok === false && result.reason, 'no-binding');
+  });
+});

--- a/apps/viewer/src/hooks/useZoneGeometrySplit.test.ts
+++ b/apps/viewer/src/hooks/useZoneGeometrySplit.test.ts
@@ -35,10 +35,12 @@ const ZONE_SET: ZoneSet = {
   updatedAt: 0,
 };
 
-function mesh(expressId: number): MeshData {
+/** A triangle at `x`, so a fixture can put an element inside a given zone.
+ *  Zone A spans x = -5..5 and zone B x = 5..15. */
+function mesh(expressId: number, x = 0): MeshData {
   return {
     expressId,
-    positions: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+    positions: new Float32Array([x, 0, 0, x + 1, 0, 0, x, 1, 0]),
     normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
     indices: new Uint32Array([0, 1, 2]),
     color: [1, 0, 0, 1],
@@ -51,6 +53,7 @@ const split: SplitMeshByZonesFn = () => ({
   pieceCount: 2,
   wholeVolume: 2,
   sumErrorRel: 0,
+  remainderFailed: false,
   piece(index: number) {
     return {
       zoneIndex: index,
@@ -90,7 +93,10 @@ function runExport(zoneIndex: number) {
   const emitted: Array<{ bytes: Uint8Array; filename: string }> = [];
   const result = exportZoneGeometry(ZONE_SET, zoneIndex, {
     split,
-    meshPieces: (globalId) => [mesh(globalId)],
+    // The straddler sits in zone A; the whole element is placed INSIDE zone B,
+    // which is where its assignment says it is. A fixture whose geometry is not
+    // in its own zone would exercise the outside-the-set path by accident.
+    meshPieces: (globalId) => [mesh(globalId, globalId === WHOLE ? 9 : 0)],
     emit: (bytes, filename) => emitted.push({ bytes, filename }),
   });
   return { result, emitted };
@@ -128,6 +134,41 @@ describe('exporting one zone as its own model', () => {
       [...b.emitted[0].bytes.slice(0, 512)],
       'both zones produced byte-identical files, so the piece was not selected by zone',
     );
+  });
+
+  it('cuts an element that does not straddle but reaches outside the zone set', () => {
+    // v1's straddle flag asks whether the element penetrates ANOTHER zone, so
+    // an element hanging off the end of the last takt area carries no flag.
+    // Copied whole, it would put geometry from outside the section into the
+    // section's file.
+    const OUTSIDE = 13;
+    useViewerStore.setState({
+      zoneAssignments: new Map([
+        [OUTSIDE, { 'set-1': { zoneId: 'z-a', zoneName: 'Takt A', straddles: false, touchedZoneIds: ['z-a'] } }],
+      ]) as never,
+      geometryResult: { meshes: [{ expressId: OUTSIDE, geometryVolume: 2 }] } as never,
+    } as never);
+
+    const far: MeshData = {
+      ...mesh(OUTSIDE),
+      // Zone A spans x = -5..5; this reaches x = 900.
+      positions: new Float32Array([0, 0, 0, 900, 0, 0, 0, 1, 0]),
+    } as MeshData;
+    const result = exportZoneGeometry(ZONE_SET, 0, {
+      split,
+      meshPieces: () => [far],
+      emit: () => {},
+    });
+
+    assert.ok(result.ok);
+    assert.equal(result.summary.whole, 0, 'it was copied whole instead of being cut');
+    assert.equal(result.summary.cut, 1);
+  });
+
+  it('still copies an element that IS wholly inside, without cutting it', () => {
+    const { result } = runExport(1);
+    assert.ok(result.ok);
+    assert.equal(result.summary.whole, 1);
   });
 
   it('names the file after the set and the zone', () => {

--- a/apps/viewer/src/hooks/useZoneGeometrySplit.ts
+++ b/apps/viewer/src/hooks/useZoneGeometrySplit.ts
@@ -42,7 +42,14 @@ import { getGlobalRenderer } from './useBCF.js';
 import { buildMergedGLB } from '@/lib/geo/cesium-glb';
 import { downloadFile, sanitizeFilename } from '@/lib/export/download';
 import { splitElementByZones, type SplitMeshByZonesFn } from '@/lib/zones/split.js';
-import { volumeGateVerdict, PROVED_VOLUME_AGREEMENT_REL, type ZoneSet } from '@/lib/zones';
+import {
+  compileZone,
+  isPointInCompiledZone,
+  volumeGateVerdict,
+  PROVED_VOLUME_AGREEMENT_REL,
+  type Zone,
+  type ZoneSet,
+} from '@/lib/zones';
 import { gatherProvedVolumes } from './useZoneApportionment.js';
 
 /**
@@ -76,6 +83,42 @@ export interface ZoneGeometryExport {
 export type ZoneGeometryExportResult =
   | { ok: true; summary: ZoneGeometryExport }
   | { ok: false; reason: 'no-binding' | 'no-geometry' | 'empty-zone' };
+
+/**
+ * Is every vertex of the element inside `zone`?
+ *
+ * Tested on the element's own AABB corners rather than on every vertex: the box
+ * (or prism) is convex, so a bounding box entirely inside it contains only
+ * points inside it. Conservative in the safe direction -- an element whose AABB
+ * pokes out while its geometry does not is merely cut instead of copied, which
+ * costs time and changes no number.
+ */
+function aabbInsideZone(pieces: readonly MeshData[], zone: Zone): boolean {
+  const compiled = compileZone(zone);
+  let minX = Infinity, minY = Infinity, minZ = Infinity;
+  let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
+  for (const piece of pieces) {
+    const ox = piece.origin?.[0] ?? 0;
+    const oy = piece.origin?.[1] ?? 0;
+    const oz = piece.origin?.[2] ?? 0;
+    const p = piece.positions;
+    for (let i = 0; i + 2 < p.length; i += 3) {
+      const x = p[i] + ox, y = p[i + 1] + oy, z = p[i + 2] + oz;
+      if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) continue;
+      if (x < minX) minX = x; if (y < minY) minY = y; if (z < minZ) minZ = z;
+      if (x > maxX) maxX = x; if (y > maxY) maxY = y; if (z > maxZ) maxZ = z;
+    }
+  }
+  if (!Number.isFinite(minX)) return false;
+  for (const x of [minX, maxX]) {
+    for (const y of [minY, maxY]) {
+      for (const z of [minZ, maxZ]) {
+        if (!isPointInCompiledZone(x, y, z, compiled)) return false;
+      }
+    }
+  }
+  return true;
+}
 
 /** World-space `MeshData` pieces for one element, or `null`. */
 function meshPiecesFor(globalId: number): MeshData[] | null {
@@ -142,7 +185,15 @@ export function exportZoneGeometry(
       continue;
     }
 
-    if (!assignment.straddles) {
+    // "Does not straddle" is not "wholly inside". v1's straddle flag asks
+    // whether the element penetrates ANOTHER zone by more than a millimetre, so
+    // an element that pokes out of the zone set entirely -- past the end of the
+    // last takt area, over the edge of the top one -- carries no flag at all.
+    // Writing it whole would put geometry from OUTSIDE the section into the
+    // section's file, and the volume total would say so too. Containment is
+    // therefore tested rather than inferred, on the element's own bounds.
+    const inside = assignment.straddles ? false : aabbInsideZone(pieces, zone);
+    if (inside) {
       // Wholly inside: nothing to cut, and nothing to prove either. Its
       // geometry is already the answer.
       meshes.push(...pieces);
@@ -153,7 +204,7 @@ export function exportZoneGeometry(
       continue;
     }
 
-    // A straddler is cut, and only if the mesher proved a single closed solid
+    // Anything else is cut, and only if the mesher proved a single closed solid
     // for it: clipping an open shell yields pieces whose volume is arbitrary
     // rather than approximate. Checked BEFORE the cut, so a refused element
     // costs no clipping at all (30 to 40% of meshed elements in real models do

--- a/apps/viewer/src/hooks/useZoneGeometrySplit.ts
+++ b/apps/viewer/src/hooks/useZoneGeometrySplit.ts
@@ -19,8 +19,14 @@
  * Three things it refuses to do, each for a reason that already has a
  * precedent in this feature:
  *
- *  - **Run on load.** It is an explicit click, like the apportionment. Clipping
- *    is memory-bandwidth bound; the only lever is doing less of it.
+ *  - **Run on load.** It is an explicit click, like the apportionment, and for
+ *    a stronger reason: an exact arrangement per (element x zone) is orders of
+ *    magnitude dearer than the divergence clip that produces the NUMBERS.
+ *    Measured through this same wasm build on `AC20-FZK-Haus.ifc` with four
+ *    zones tiling its 18 m length: 18 elements produced more than one piece, at
+ *    ~357 ms each (6.4 s in total). So this runs per zone, on demand, over the
+ *    elements that reach that zone, and its cost is reported back to the user
+ *    rather than hidden.
  *  - **Split what the mesher could not prove.** A clip of an open shell
  *    produces pieces whose volumes are arbitrary, not approximate. Those
  *    elements are counted and reported, never quietly dropped.

--- a/apps/viewer/src/hooks/useZoneGeometrySplit.ts
+++ b/apps/viewer/src/hooks/useZoneGeometrySplit.ts
@@ -1,0 +1,210 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Export one zone's geometry as a model of its own (issue #2508 item 2).
+ *
+ * #1810 asked for "either geometric splitting or a per-zone quantity
+ * breakdown". #2515 shipped the breakdown; this is the splitting, and the
+ * reason to want it is the sentence in #2508: actual splitting is what a user
+ * needs to EXPORT a per-section model. So the deliverable is a file, not a
+ * viewport state.
+ *
+ * What goes into one zone's file:
+ *
+ *  - every element whose home zone it is and which does not straddle, whole;
+ *  - the CUT PIECE of every straddler that reaches it, from the exact kernel.
+ *
+ * Three things it refuses to do, each for a reason that already has a
+ * precedent in this feature:
+ *
+ *  - **Run on load.** It is an explicit click, like the apportionment. Clipping
+ *    is memory-bandwidth bound; the only lever is doing less of it.
+ *  - **Split what the mesher could not prove.** A clip of an open shell
+ *    produces pieces whose volumes are arbitrary, not approximate. Those
+ *    elements are counted and reported, never quietly dropped.
+ *  - **Publish a split that does not add up.** `splitElementByZones` refuses
+ *    per element; the count reaches the user.
+ */
+
+import { useCallback } from 'react';
+import * as IfcWasm from '@ifc-lite/wasm';
+import type { MeshData } from '@ifc-lite/geometry';
+import { useViewerStore } from '@/store';
+import { getGlobalRenderer } from './useBCF.js';
+import { buildMergedGLB } from '@/lib/geo/cesium-glb';
+import { downloadFile, sanitizeFilename } from '@/lib/export/download';
+import { splitElementByZones, type SplitMeshByZonesFn } from '@/lib/zones/split.js';
+import { volumeGateVerdict, PROVED_VOLUME_AGREEMENT_REL, type ZoneSet } from '@/lib/zones';
+import { gatherProvedVolumes } from './useZoneApportionment.js';
+
+/**
+ * The binding, read off the namespace rather than imported by name.
+ *
+ * The wasm runtime is gitignored and rebuilt per host, so a named import would
+ * make this module fail to load wherever the bundle is older than this source
+ * (the deployment-skew class of #2079) instead of degrading to a message.
+ */
+const splitFn = (IfcWasm as unknown as { splitMeshByZones?: SplitMeshByZonesFn }).splitMeshByZones;
+
+export interface ZoneGeometryExport {
+  /** Elements written whole (their home zone, no straddle). */
+  whole: number;
+  /** Straddlers contributed as a cut piece. */
+  cut: number;
+  /** Straddlers the kernel would not split, or whose pieces did not add up. */
+  refused: number;
+  /** Total volume in the exported file, cubic metres. `null` when a whole
+   *  element's volume was never proved, so the total would understate. */
+  volumeM3: number | null;
+  bytes: number;
+  elapsedMs: number;
+}
+
+export type ZoneGeometryExportResult =
+  | { ok: true; summary: ZoneGeometryExport }
+  | { ok: false; reason: 'no-binding' | 'no-geometry' | 'empty-zone' };
+
+/** World-space `MeshData` pieces for one element, or `null`. */
+function meshPiecesFor(globalId: number): MeshData[] | null {
+  const scene = getGlobalRenderer()?.getScene();
+  if (!scene) return null;
+  const pieces = scene.getMeshDataPieces(globalId) ?? scene.getInstancedMeshDataPieces?.(globalId);
+  return pieces && pieces.length > 0 ? pieces : null;
+}
+
+/**
+ * The three things this reaches outside itself for, injectable so the ROUTING
+ * (which element's geometry lands in which file) is testable without a GPU, a
+ * loaded model or a wasm runtime. The kernel's cutting is tested in Rust and
+ * across the real boundary in `scripts/test-wasm-contract.mjs`; what is worth
+ * testing here is that a straddler's piece goes to the zone that was asked for.
+ */
+export interface ZoneGeometryDeps {
+  split?: SplitMeshByZonesFn;
+  meshPieces?: (globalId: number) => MeshData[] | null;
+  emit?: (bytes: Uint8Array, filename: string) => void;
+}
+
+/**
+ * Build and download one zone's geometry as a GLB.
+ *
+ * GLB rather than IFC on purpose: the cut pieces are new solids with no IFC
+ * identity of their own, and inventing GlobalIds for them would produce a file
+ * that looks like a model and round-trips as a fabrication. A GLB says what
+ * this is, which is a geometric extract of one section.
+ */
+export function exportZoneGeometry(
+  zoneSet: ZoneSet,
+  zoneIndex: number,
+  deps: ZoneGeometryDeps = {},
+): ZoneGeometryExportResult {
+  // `'split' in deps` rather than `??`: passing the key explicitly as
+  // `undefined` is how a caller says "there is no binding", which is the state
+  // of an older wasm bundle and the one branch a `??` fallback would make
+  // untestable by silently reaching for the real one.
+  const split = 'split' in deps ? deps.split : splitFn;
+  const meshPieces = deps.meshPieces ?? meshPiecesFor;
+  const emit = deps.emit ?? ((bytes: Uint8Array, filename: string) =>
+    downloadFile(bytes, filename, 'model/gltf-binary'));
+  if (!split) return { ok: false, reason: 'no-binding' };
+  const zone = zoneSet.zones[zoneIndex];
+  if (!zone) return { ok: false, reason: 'empty-zone' };
+
+  const t0 = performance.now();
+  const state = useViewerStore.getState();
+  const proved = gatherProvedVolumes();
+  const meshes: MeshData[] = [];
+  let whole = 0;
+  let cut = 0;
+  let refused = 0;
+  let volumeM3: number | null = 0;
+
+  for (const [globalId, record] of state.zoneAssignments) {
+    const assignment = record[zoneSet.id];
+    if (!assignment || !assignment.touchedZoneIds.includes(zone.id)) continue;
+    const pieces = meshPieces(globalId);
+    if (!pieces) {
+      refused++;
+      continue;
+    }
+
+    if (!assignment.straddles) {
+      // Wholly inside: nothing to cut, and nothing to prove either. Its
+      // geometry is already the answer.
+      meshes.push(...pieces);
+      whole++;
+      const provedVolume = proved.byGlobalId.get(globalId);
+      if (provedVolume === undefined || proved.rescaled.has(globalId)) volumeM3 = null;
+      else if (volumeM3 !== null) volumeM3 += Math.abs(provedVolume);
+      continue;
+    }
+
+    // A straddler is cut, and only if the mesher proved a single closed solid
+    // for it: clipping an open shell yields pieces whose volume is arbitrary
+    // rather than approximate. Checked BEFORE the cut, so a refused element
+    // costs no clipping at all (30 to 40% of meshed elements in real models do
+    // not qualify).
+    const provedVolume = proved.byGlobalId.get(globalId);
+    if (provedVolume === undefined || proved.rescaled.has(globalId)) {
+      refused++;
+      continue;
+    }
+    // `null` here is the splitter's own refusal: the pieces did not sum to the
+    // whole, whose expected cause is zones that overlap each other.
+    const elementSplit = splitElementByZones(split, pieces, zoneSet.zones);
+    if (!elementSplit) {
+      refused++;
+      continue;
+    }
+    // The same two-producer cross-check the apportionment runs: the kernel's
+    // volume at mesh time against the split's own whole. They disagree when the
+    // geometry the Scene holds is not the geometry the kernel measured, e.g. a
+    // colour-merged batch re-extracted per entity, which is a silently SHORT
+    // mesh rather than a wrong one.
+    const verdict = volumeGateVerdict(
+      provedVolume,
+      { wholeVolumeM3: elementSplit.wholeVolumeM3, unreliable: false },
+      PROVED_VOLUME_AGREEMENT_REL,
+      false,
+    );
+    if (verdict !== 'ok') {
+      refused++;
+      continue;
+    }
+    // A missing piece for THIS zone is not a refusal: the verdict above
+    // already rejected the untrustworthy cases, so it means the element
+    // reaches the zone's box without any solid inside it, which is exactly
+    // what v1's negative straddle epsilon describes.
+    const piece = elementSplit.pieces.find((p) => p.zoneIndex === zoneIndex);
+    if (!piece) continue;
+    meshes.push({
+      expressId: globalId,
+      positions: piece.positions,
+      normals: piece.normals,
+      indices: piece.indices,
+      origin: piece.origin,
+      color: pieces[0].color,
+    } as MeshData);
+    cut++;
+    if (volumeM3 !== null) volumeM3 += piece.volumeM3;
+  }
+
+  if (meshes.length === 0) return { ok: false, reason: 'no-geometry' };
+
+  const glb = buildMergedGLB(meshes);
+  emit(glb, `${sanitizeFilename(`${zoneSet.name}-${zone.name}`)}.glb`);
+  return {
+    ok: true,
+    summary: { whole, cut, refused, volumeM3, bytes: glb.byteLength, elapsedMs: performance.now() - t0 },
+  };
+}
+
+export function useZoneGeometrySplit() {
+  const exportZone = useCallback(
+    (zoneSet: ZoneSet, zoneIndex: number) => exportZoneGeometry(zoneSet, zoneIndex),
+    [],
+  );
+  return { exportZone, available: splitFn !== undefined };
+}

--- a/apps/viewer/src/hooks/useZoneGeometrySplit.ts
+++ b/apps/viewer/src/hooks/useZoneGeometrySplit.ts
@@ -61,6 +61,11 @@ export interface ZoneGeometryExport {
   cut: number;
   /** Straddlers the kernel would not split, or whose pieces did not add up. */
   refused: number;
+  /** Elements the renderer holds no triangles for at all (never had geometry,
+   *  or it was released to reclaim memory). Counted apart from `refused`
+   *  because the fix is different: load or re-load the model, rather than look
+   *  at the element's own geometry. */
+  noGeometry: number;
   /** Total volume in the exported file, cubic metres. `null` when a whole
    *  element's volume was never proved, so the total would understate. */
   volumeM3: number | null;
@@ -125,6 +130,7 @@ export function exportZoneGeometry(
   let whole = 0;
   let cut = 0;
   let refused = 0;
+  let noGeometry = 0;
   let volumeM3: number | null = 0;
 
   for (const [globalId, record] of state.zoneAssignments) {
@@ -132,7 +138,7 @@ export function exportZoneGeometry(
     if (!assignment || !assignment.touchedZoneIds.includes(zone.id)) continue;
     const pieces = meshPieces(globalId);
     if (!pieces) {
-      refused++;
+      noGeometry++;
       continue;
     }
 
@@ -203,7 +209,7 @@ export function exportZoneGeometry(
   emit(glb, `${sanitizeFilename(`${zoneSet.name}-${zone.name}`)}.glb`);
   return {
     ok: true,
-    summary: { whole, cut, refused, volumeM3, bytes: glb.byteLength, elapsedMs: performance.now() - t0 },
+    summary: { whole, cut, refused, noGeometry, volumeM3, bytes: glb.byteLength, elapsedMs: performance.now() - t0 },
   };
 }
 

--- a/apps/viewer/src/hooks/useZoneWriteBack.test.ts
+++ b/apps/viewer/src/hooks/useZoneWriteBack.test.ts
@@ -1,0 +1,313 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Zone assignment written into the model, and out again through a STEP export
+ * (#2508 item 3).
+ *
+ * The claim under test is not "a pset object appeared in a map". It is that a
+ * file handed to someone else carries the zone assignment, in that file's own
+ * units, with the basis named. So the assertions re-PARSE the exported STEP
+ * wherever they can, following the rule `overlay-effective-model.test.ts`
+ * states: asserting on the overlay proves the writer wrote what it meant to;
+ * re-parsing proves the file means it.
+ *
+ * Everything here runs against a REAL columnar store parsed from inline STEP,
+ * including a real declared VOLUMEUNIT, because the unit conversion is the one
+ * thing a stub would silently make vacuous.
+ */
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  IfcParser,
+  extractPropertiesOnDemand,
+  extractQuantitiesOnDemand,
+  type IfcDataStore,
+} from '@ifc-lite/parser';
+import { StepExporter } from '@ifc-lite/export';
+import { useViewerStore } from '@/store/index.js';
+import { applyZoneWriteBack, removeZoneWriteBack } from './useZoneWriteBack.js';
+import {
+  zonePropertySetName,
+  zoneQuantitySetName,
+  ZONE_PROPERTY_NAMES,
+  type ZoneApportionmentEntry,
+  type ZoneSet,
+} from '@/lib/zones';
+
+const WALL_ID = 42;
+const BEAM_ID = 43;
+
+/** A file that declares CUBIC MILLIMETRE volumes, so a value written as if it
+ *  were cubic metres is wrong by 1e9 and cannot pass by luck. `#42` also
+ *  carries a declared NetVolume of 2e9 mm3 (2 m3). */
+function miniIfc(volumeUnitPrefix: string): string {
+  return `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('zones','',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0Project0000000000000a',$,'P',$,$,$,$,(#5),#6);
+#2=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#3=IFCSIUNIT(*,.VOLUMEUNIT.,${volumeUnitPrefix},.CUBIC_METRE.);
+#6=IFCUNITASSIGNMENT((#2,#3));
+#5=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-05,$,$);
+#${WALL_ID}=IFCWALL('0Wall00000000000000042',$,'Wall A',$,$,$,$,$,$);
+#${BEAM_ID}=IFCBEAM('0Beam00000000000000043',$,'Beam B',$,$,$,$,$,$);
+#50=IFCQUANTITYVOLUME('NetVolume',$,$,2.E+09,$);
+#51=IFCELEMENTQUANTITY('0Qto000000000000000051',$,'Qto_WallBaseQuantities',$,$,(#50));
+#52=IFCRELDEFINESBYPROPERTIES('0Rel000000000000000052',$,$,$,(#${WALL_ID}),#51);
+ENDSEC;
+END-ISO-10303-21;
+`;
+}
+
+async function parse(ifc: string): Promise<IfcDataStore> {
+  const bytes = new TextEncoder().encode(ifc);
+  return new IfcParser().parseColumnar(
+    bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+  );
+}
+
+const ZONE_SET: ZoneSet = {
+  id: 'set-1',
+  name: 'Takt areas',
+  zones: [
+    { id: 'z-a', name: 'Takt A', center: [0, 0, 0], size: [10, 10, 10], rotationY: 0 },
+    { id: 'z-b', name: 'Takt B', center: [10, 0, 0], size: [10, 10, 10], rotationY: 0 },
+  ],
+  visible: true,
+  createdAt: 0,
+  updatedAt: 0,
+};
+
+/** #42 straddles A/B 40/60; #43 sits wholly in A. */
+function seedAssignments() {
+  return new Map([
+    [WALL_ID, { 'set-1': { zoneId: 'z-a', zoneName: 'Takt A', straddles: true, touchedZoneIds: ['z-a', 'z-b'] } }],
+    [BEAM_ID, { 'set-1': { zoneId: 'z-a', zoneName: 'Takt A', straddles: false, touchedZoneIds: ['z-a'] } }],
+  ]);
+}
+
+/** A cache entry as `computeZoneApportionmentNow` would leave it, so the write
+ *  path reads the SAME source the panel and the Lists columns read rather than
+ *  re-deriving one for the test. */
+function seedApportionment(revision: string): Map<string, ZoneApportionmentEntry> {
+  return new Map([['set-1', {
+    revision,
+    byElement: new Map([[WALL_ID, {
+      wholeVolumeM3: 5,
+      shares: [
+        { zoneId: 'z-a', zoneName: 'Takt A', volumeM3: 2, fraction: 0.4 },
+        { zoneId: 'z-b', zoneName: 'Takt B', volumeM3: 3, fraction: 0.6 },
+      ],
+      outsideVolumeM3: 0,
+      outsideFraction: 0,
+      overlapping: false,
+      unreliable: false,
+    }]]),
+    refused: new Map(),
+    computedAt: 0,
+    elapsedMs: 1,
+  }]]);
+}
+
+async function seedStore(volumeUnitPrefix = '.MILLI.'): Promise<IfcDataStore> {
+  const store = await parse(miniIfc(volumeUnitPrefix));
+  const { zoneSetRevision } = await import('@/lib/zones');
+  useViewerStore.setState({
+    models: new Map([['m1', {
+      id: 'm1',
+      name: 'zones.ifc',
+      ifcDataStore: store,
+      visible: true,
+    } as never]]),
+    zoneSets: [ZONE_SET],
+    zoneAssignments: seedAssignments() as never,
+    zoneApportionment: seedApportionment(zoneSetRevision(ZONE_SET)),
+    mutationViews: new Map(),
+    dirtyModels: new Set(),
+  } as never);
+  return store;
+}
+
+function view() {
+  return useViewerStore.getState().getMutationView('m1');
+}
+
+function psetOn(entityId: number, name: string) {
+  return view()?.getForEntity(entityId).find((p) => p.name === name) ?? null;
+}
+
+function qsetOn(entityId: number, name: string) {
+  return view()?.getQuantitiesForEntity(entityId).find((q) => q.name === name) ?? null;
+}
+
+describe('zone write-back: what reaches the model', () => {
+  beforeEach(async () => {
+    await seedStore();
+  });
+
+  it('writes the classification onto a straddler and a non-straddler alike', () => {
+    const result = applyZoneWriteBack(ZONE_SET, 'mesh');
+    assert.equal(result.blocked, null);
+    assert.equal(result.summary.written, 2);
+
+    const pset = psetOn(WALL_ID, zonePropertySetName('Takt areas'));
+    assert.ok(pset, 'straddler got no property set');
+    const props = new Map(pset.properties.map((p) => [p.name, p.value]));
+    assert.equal(props.get(ZONE_PROPERTY_NAMES.zone), 'Takt A');
+    assert.equal(props.get(ZONE_PROPERTY_NAMES.zones), 'Takt A, Takt B');
+    assert.equal(props.get(ZONE_PROPERTY_NAMES.straddles), true);
+
+    const beam = psetOn(BEAM_ID, zonePropertySetName('Takt areas'));
+    assert.ok(beam, 'non-straddler got no property set');
+    assert.equal(
+      new Map(beam.properties.map((p) => [p.name, p.value])).get(ZONE_PROPERTY_NAMES.straddles),
+      false,
+    );
+  });
+
+  it('converts the apportioned volumes into the file\'s declared unit', () => {
+    applyZoneWriteBack(ZONE_SET, 'mesh');
+    const qset = qsetOn(WALL_ID, zoneQuantitySetName('Takt areas', 'mesh'));
+    assert.ok(qset, 'no quantity set was written');
+    const values = new Map(qset.quantities.map((q) => [q.name, q.value]));
+    // 2 m3 and 3 m3 in a file that declares CUBIC MILLIMETRES. Writing 2 and 3
+    // would state two and three cubic millimetres.
+    assert.ok(Math.abs((values.get('Takt A') ?? 0) / 2e9 - 1) < 1e-9, `Takt A = ${values.get('Takt A')}`);
+    assert.ok(Math.abs((values.get('Takt B') ?? 0) / 3e9 - 1) < 1e-9, `Takt B = ${values.get('Takt B')}`);
+  });
+
+  it('leaves the same numbers unscaled in a file that declares cubic metres', async () => {
+    await seedStore('$');
+    applyZoneWriteBack(ZONE_SET, 'mesh');
+    const values = new Map(
+      (qsetOn(WALL_ID, zoneQuantitySetName('Takt areas', 'mesh'))?.quantities ?? []).map((q) => [q.name, q.value]),
+    );
+    assert.equal(values.get('Takt A'), 2);
+    assert.equal(values.get('Takt B'), 3);
+  });
+
+  it('marks the model dirty, so the session reports the unsaved change', () => {
+    applyZoneWriteBack(ZONE_SET, 'mesh');
+    assert.ok(useViewerStore.getState().dirtyModels.has('m1'));
+  });
+
+  it('splits a DECLARED quantity by the measured fractions, and names it', () => {
+    applyZoneWriteBack(ZONE_SET, 'net');
+    const qset = qsetOn(WALL_ID, zoneQuantitySetName('Takt areas', 'net'));
+    assert.ok(qset, 'no net quantity set');
+    const values = new Map(qset.quantities.map((q) => [q.name, q.value]));
+    // Declared NetVolume is 2e9 mm3; the split is 40/60 measured on the mesh.
+    assert.ok(Math.abs((values.get('Takt A') ?? 0) / 0.8e9 - 1) < 1e-9, `${values.get('Takt A')}`);
+    assert.ok(Math.abs((values.get('Takt B') ?? 0) / 1.2e9 - 1) < 1e-9, `${values.get('Takt B')}`);
+    // Summing to the declared total by construction is the whole point of the
+    // declared basis: the user already trusts that number.
+    const total = [...values.values()].reduce((a, b) => a + b, 0);
+    assert.ok(Math.abs(total / 2e9 - 1) < 1e-9, `net shares summed to ${total}`);
+
+    const props = new Map((psetOn(WALL_ID, zonePropertySetName('Takt areas'))?.properties ?? [])
+      .map((p) => [p.name, p.value]));
+    assert.equal(props.get(ZONE_PROPERTY_NAMES.volumeBasis), 'net');
+    assert.equal(props.get(ZONE_PROPERTY_NAMES.volumeQuantity), 'NetVolume');
+  });
+
+  it('refuses rather than falling back when the element declares nothing on that basis', () => {
+    // The beam carries no quantities at all, so a `net` run has nothing to
+    // apportion for it. Falling back to its mesh volume would put a mesh number
+    // inside a quantity set named net.
+    applyZoneWriteBack(ZONE_SET, 'net');
+    assert.equal(qsetOn(BEAM_ID, zoneQuantitySetName('Takt areas', 'net')), null);
+    const props = new Map((psetOn(BEAM_ID, zonePropertySetName('Takt areas'))?.properties ?? [])
+      .map((p) => [p.name, p.value]));
+    assert.match(String(props.get(ZONE_PROPERTY_NAMES.volumeUnavailable)), /declares no volume quantity/);
+  });
+
+  it('switching basis replaces the previous run rather than stacking one set per basis', () => {
+    applyZoneWriteBack(ZONE_SET, 'mesh');
+    applyZoneWriteBack(ZONE_SET, 'net');
+    const all = (view()?.getQuantitiesForEntity(WALL_ID) ?? [])
+      .filter((q) => q.name.startsWith('IfcLite_ZoneVolumes'));
+    assert.deepEqual(all.map((q) => q.name), [zoneQuantitySetName('Takt areas', 'net')]);
+  });
+
+  it('a re-run that can no longer state a volume clears the numbers it stated before', () => {
+    // The contradiction this prevents: the property set says the volume could
+    // not be computed while a quantity set beside it still carries the previous
+    // run's cubic metres. Reached here by moving a zone, which invalidates the
+    // apportionment cache by revision; with no renderer in this runner, the
+    // recompute refuses.
+    applyZoneWriteBack(ZONE_SET, 'mesh');
+    assert.ok(qsetOn(WALL_ID, zoneQuantitySetName('Takt areas', 'mesh')));
+
+    const moved: ZoneSet = {
+      ...ZONE_SET,
+      zones: [{ ...ZONE_SET.zones[0], center: [1, 0, 0] as [number, number, number] }, ZONE_SET.zones[1]],
+    };
+    applyZoneWriteBack(moved, 'mesh');
+
+    assert.equal(qsetOn(WALL_ID, zoneQuantitySetName('Takt areas', 'mesh')), null);
+    const props = new Map((psetOn(WALL_ID, zonePropertySetName('Takt areas'))?.properties ?? [])
+      .map((p) => [p.name, p.value]));
+    assert.equal(props.get(ZONE_PROPERTY_NAMES.volumeUnavailable) !== undefined, true);
+  });
+
+  it('never reads its own output back as a declared quantity', () => {
+    // An `unqualified` run writes volume quantities with no qualifying name.
+    // Read back on the next run they would look like the element's declared
+    // total, so each run would apportion the previous run's shares again.
+    applyZoneWriteBack(ZONE_SET, 'unqualified');
+    const first = qsetOn(BEAM_ID, zoneQuantitySetName('Takt areas', 'unqualified'));
+    applyZoneWriteBack(ZONE_SET, 'unqualified');
+    const second = qsetOn(BEAM_ID, zoneQuantitySetName('Takt areas', 'unqualified'));
+    assert.deepEqual(
+      second?.quantities.map((q) => q.value) ?? null,
+      first?.quantities.map((q) => q.value) ?? null,
+    );
+  });
+
+  it('removes what it wrote', () => {
+    applyZoneWriteBack(ZONE_SET, 'mesh');
+    const { removed } = removeZoneWriteBack(ZONE_SET);
+    assert.equal(removed, 2);
+    assert.equal(psetOn(WALL_ID, zonePropertySetName('Takt areas')), null);
+  });
+});
+
+describe('zone write-back: the exported file carries it', () => {
+  beforeEach(async () => {
+    await seedStore();
+  });
+
+  it('survives a STEP export and re-parse, with the value still in file units', async () => {
+    applyZoneWriteBack(ZONE_SET, 'mesh');
+    const store = useViewerStore.getState().models.get('m1')!.ifcDataStore as IfcDataStore;
+    const exported = new StepExporter(store, view()!).export({
+      schema: 'IFC4',
+      visibleOnly: false,
+      hiddenEntityIds: new Set<number>(),
+    });
+
+    const reparsed = await parse(new TextDecoder().decode(exported.content));
+    // Through the ON-DEMAND extractors, which is how the viewer itself reads a
+    // lazily-parsed model: the `properties` / `quantities` tables are empty
+    // until something asks, so reading them directly would assert nothing.
+    const psets = extractPropertiesOnDemand(reparsed, WALL_ID);
+    const zonePset = psets.find((p) => p.name === zonePropertySetName('Takt areas'));
+    assert.ok(zonePset, `zone pset missing from the export; got ${psets.map((p) => p.name).join(', ')}`);
+    const props = new Map(zonePset.properties.map((p) => [p.name, p.value]));
+    assert.equal(props.get(ZONE_PROPERTY_NAMES.zones), 'Takt A, Takt B');
+    assert.equal(props.get(ZONE_PROPERTY_NAMES.straddles), true);
+
+    const qsets = extractQuantitiesOnDemand(reparsed, WALL_ID);
+    const zoneQset = qsets.find((q) => q.name === zoneQuantitySetName('Takt areas', 'mesh'));
+    assert.ok(zoneQset, `zone qset missing from the export; got ${qsets.map((q) => q.name).join(', ')}`);
+    const values = new Map(zoneQset.quantities.map((q) => [q.name, q.value]));
+    assert.ok(Math.abs((values.get('Takt A') ?? 0) / 2e9 - 1) < 1e-6, `Takt A = ${values.get('Takt A')}`);
+  });
+});

--- a/apps/viewer/src/hooks/useZoneWriteBack.test.ts
+++ b/apps/viewer/src/hooks/useZoneWriteBack.test.ts
@@ -311,3 +311,91 @@ describe('zone write-back: the exported file carries it', () => {
     assert.ok(Math.abs((values.get('Takt A') ?? 0) / 2e9 - 1) < 1e-6, `Takt A = ${values.get('Takt A')}`);
   });
 });
+
+describe('zone write-back: what a later run has to clean up', () => {
+  beforeEach(async () => {
+    await seedStore();
+  });
+
+  it('an element that has LEFT the set loses what the last run wrote onto it', () => {
+    applyZoneWriteBack(ZONE_SET, 'mesh');
+    assert.ok(psetOn(BEAM_ID, zonePropertySetName('Takt areas')));
+
+    // The zone moved away, so the beam is in no zone of the set any more. The
+    // old run's "Zone: Takt A" would otherwise stay on it forever: nothing else
+    // visits an element that is no longer a member.
+    useViewerStore.setState({
+      zoneAssignments: new Map([
+        [WALL_ID, { 'set-1': { zoneId: 'z-a', zoneName: 'Takt A', straddles: true, touchedZoneIds: ['z-a', 'z-b'] } }],
+        [BEAM_ID, { 'set-1': { zoneId: null, zoneName: null, straddles: false, touchedZoneIds: [] } }],
+      ]) as never,
+    } as never);
+    applyZoneWriteBack(ZONE_SET, 'mesh');
+
+    assert.equal(psetOn(BEAM_ID, zonePropertySetName('Takt areas')), null);
+    assert.equal(qsetOn(BEAM_ID, zoneQuantitySetName('Takt areas', 'mesh')), null);
+  });
+
+  it('renaming the set does not strand the sets written under the old name', () => {
+    // The set names carry the DISPLAY name, so a run after a rename writes to
+    // new names. Matching the old output by name would miss it; the property
+    // set carries the set's stable id for exactly this.
+    applyZoneWriteBack(ZONE_SET, 'mesh');
+    applyZoneWriteBack({ ...ZONE_SET, name: 'Sections' }, 'mesh');
+
+    const names = (view()?.getForEntity(WALL_ID) ?? []).map((p) => p.name)
+      .filter((n) => n.startsWith('IfcLite_Zones'));
+    assert.deepEqual(names, ['IfcLite_Zones [Sections]']);
+    const qnames = (view()?.getQuantitiesForEntity(WALL_ID) ?? []).map((q) => q.name)
+      .filter((n) => n.startsWith('IfcLite_ZoneVolumes'));
+    assert.deepEqual(qnames, [zoneQuantitySetName('Sections', 'mesh')]);
+  });
+
+  it('removing reports nothing, and dirties nothing, on a model never written to', () => {
+    // `deletePropertySet` returns a mutation whether or not anything was there,
+    // so counting calls rather than deletions claimed an edit over a
+    // byte-identical model and offered to save it.
+    const { removed } = removeZoneWriteBack(ZONE_SET);
+    assert.equal(removed, 0);
+    assert.equal(useViewerStore.getState().dirtyModels.has('m1'), false);
+  });
+
+  it('removing reaches an element that has since left the set', () => {
+    applyZoneWriteBack(ZONE_SET, 'mesh');
+    useViewerStore.setState({
+      zoneAssignments: new Map([
+        [WALL_ID, { 'set-1': { zoneId: null, zoneName: null, straddles: false, touchedZoneIds: [] } }],
+        [BEAM_ID, { 'set-1': { zoneId: null, zoneName: null, straddles: false, touchedZoneIds: [] } }],
+      ]) as never,
+    } as never);
+
+    const { removed } = removeZoneWriteBack(ZONE_SET);
+    assert.equal(removed, 2);
+    assert.equal(psetOn(WALL_ID, zonePropertySetName('Takt areas')), null);
+  });
+
+  it('does not touch another zone set\'s output', () => {
+    applyZoneWriteBack(ZONE_SET, 'mesh');
+    const other: ZoneSet = { ...ZONE_SET, id: 'set-2', name: 'Sections' };
+    useViewerStore.setState({
+      zoneAssignments: new Map([
+        [WALL_ID, {
+          'set-1': { zoneId: 'z-a', zoneName: 'Takt A', straddles: true, touchedZoneIds: ['z-a', 'z-b'] },
+          'set-2': { zoneId: 'z-a', zoneName: 'Takt A', straddles: false, touchedZoneIds: ['z-a'] },
+        }],
+      ]) as never,
+    } as never);
+    applyZoneWriteBack(other, 'mesh');
+
+    // Both sets coexist: an element genuinely belongs to several zone sets at
+    // once, which is v1's whole point.
+    const names = (view()?.getForEntity(WALL_ID) ?? []).map((p) => p.name)
+      .filter((n) => n.startsWith('IfcLite_Zones')).sort();
+    assert.deepEqual(names, ['IfcLite_Zones [Sections]', 'IfcLite_Zones [Takt areas]']);
+
+    removeZoneWriteBack(other);
+    const left = (view()?.getForEntity(WALL_ID) ?? []).map((p) => p.name)
+      .filter((n) => n.startsWith('IfcLite_Zones'));
+    assert.deepEqual(left, ['IfcLite_Zones [Takt areas]']);
+  });
+});

--- a/apps/viewer/src/hooks/useZoneWriteBack.test.ts
+++ b/apps/viewer/src/hooks/useZoneWriteBack.test.ts
@@ -261,13 +261,18 @@ describe('zone write-back: what reaches the model', () => {
     // An `unqualified` run writes volume quantities with no qualifying name.
     // Read back on the next run they would look like the element's declared
     // total, so each run would apportion the previous run's shares again.
-    applyZoneWriteBack(ZONE_SET, 'unqualified');
-    const first = qsetOn(BEAM_ID, zoneQuantitySetName('Takt areas', 'unqualified'));
-    applyZoneWriteBack(ZONE_SET, 'unqualified');
-    const second = qsetOn(BEAM_ID, zoneQuantitySetName('Takt areas', 'unqualified'));
+    // The WALL on its declared NET basis: the beam declares no quantities at
+    // all, so any declared-basis run refuses it and both reads would be null -
+    // the assertion would then hold for a run that wrote nothing.
+    applyZoneWriteBack(ZONE_SET, 'net');
+    const first = qsetOn(WALL_ID, zoneQuantitySetName('Takt areas', 'net'));
+    assert.ok(first && first.quantities.length > 0, 'the first run wrote nothing to compare');
+    applyZoneWriteBack(ZONE_SET, 'net');
+    const second = qsetOn(WALL_ID, zoneQuantitySetName('Takt areas', 'net'));
+    assert.ok(second);
     assert.deepEqual(
-      second?.quantities.map((q) => q.value) ?? null,
-      first?.quantities.map((q) => q.value) ?? null,
+      second.quantities.map((q) => q.value),
+      first.quantities.map((q) => q.value),
     );
   });
 
@@ -372,6 +377,32 @@ describe('zone write-back: what a later run has to clean up', () => {
     const { removed } = removeZoneWriteBack(ZONE_SET);
     assert.equal(removed, 2);
     assert.equal(psetOn(WALL_ID, zonePropertySetName('Takt areas')), null);
+  });
+
+  it('refuses to write when another zone set has the same display name', () => {
+    // Both set names carry the display name, so two sets sharing one would
+    // write to the same property set and each sweep would clear the other's
+    // quantity sets.
+    useViewerStore.setState({
+      zoneSets: [ZONE_SET, { ...ZONE_SET, id: 'set-2' }],
+    } as never);
+    const result = applyZoneWriteBack(ZONE_SET, 'mesh');
+    assert.equal(result.blocked, 'duplicate-set-name');
+    assert.equal(result.summary.written, 0);
+    assert.equal(view(), null, 'nothing was written at all');
+  });
+
+  it('removes from an element the assignment cache no longer holds', () => {
+    // Geometry released to reclaim memory (#2183) drops the element from
+    // `zoneAssignments`, but not its property set. The session's own mutation
+    // history still names every element it wrote to.
+    applyZoneWriteBack(ZONE_SET, 'mesh');
+    useViewerStore.setState({ zoneAssignments: new Map() } as never);
+
+    const { removed } = removeZoneWriteBack(ZONE_SET);
+    assert.equal(removed, 2);
+    assert.equal(psetOn(WALL_ID, zonePropertySetName('Takt areas')), null);
+    assert.equal(psetOn(BEAM_ID, zonePropertySetName('Takt areas')), null);
   });
 
   it('does not touch another zone set\'s output', () => {

--- a/apps/viewer/src/hooks/useZoneWriteBack.test.ts
+++ b/apps/viewer/src/hooks/useZoneWriteBack.test.ts
@@ -392,6 +392,15 @@ describe('zone write-back: what a later run has to clean up', () => {
     assert.equal(view(), null, 'nothing was written at all');
   });
 
+  it('says WHY a removal did nothing, rather than reporting an empty success', () => {
+    // "Nothing to remove" and "you were not allowed to" are different answers,
+    // and only one of them means the user should do something next.
+    useViewerStore.setState({
+      zoneSets: [ZONE_SET, { ...ZONE_SET, id: 'set-2' }],
+    } as never);
+    assert.equal(removeZoneWriteBack(ZONE_SET).blocked, 'duplicate-set-name');
+  });
+
   it('removes from an element the assignment cache no longer holds', () => {
     // Geometry released to reclaim memory (#2183) drops the element from
     // `zoneAssignments`, but not its property set. The session's own mutation

--- a/apps/viewer/src/hooks/useZoneWriteBack.ts
+++ b/apps/viewer/src/hooks/useZoneWriteBack.ts
@@ -1,0 +1,363 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Writes one zone set's assignment into the models as IFC property/quantity
+ * sets (issue #2508, item 3), so the classification survives an export and
+ * stops being viewer-only state.
+ *
+ * The gathering half of `lib/zones/writeback.ts`: which elements, which model,
+ * which volume, in which units. Everything about NAMING and LABELLING lives
+ * there and is pure; everything about the store lives here.
+ *
+ * ## Where each number comes from
+ *
+ * - A STRADDLER's fractions come from the apportionment cache - the same entry
+ *   #2515 fills and the Lists columns read, so the file cannot disagree with the
+ *   panel. Missing or stale, it is computed first rather than silently skipped.
+ * - A NON-STRADDLER needs no clip at all: all of it is in its home zone. On a
+ *   declared basis that means it needs no geometry either, which is why an
+ *   element the kernel could not prove still gets a `net` breakdown.
+ * - Every value is converted to the model's OWN declared volume unit. Federated
+ *   models are converted with their own scale, not the active model's.
+ *
+ * ## Why this bypasses the per-mutation store actions
+ *
+ * `createPropertySet` copies the model's whole undo stack on every call, so
+ * driving it once per element is quadratic - 10k elements would copy ~10k-entry
+ * arrays 20k times. This writes straight to each model's `MutablePropertyView`
+ * (the same object those actions write to) and then commits ONE store update.
+ * The trade is that the run does not enter the undo stack, which is the same
+ * trade `BulkPropertyEditor` already makes for the same reason; the inverse is
+ * an explicit "remove" action rather than 20k presses of Ctrl+Z.
+ *
+ * The collab role gate those actions carry is NOT skipped - it is checked once,
+ * up front, for the whole run.
+ */
+
+import { useCallback } from 'react';
+import { MutablePropertyView } from '@ifc-lite/mutations';
+import { QuantityType, PropertyValueType } from '@ifc-lite/data';
+import { extractProjectUnits, type IfcDataStore } from '@ifc-lite/parser';
+import { useViewerStore } from '@/store';
+import { resolveEntityRef } from '@/store/resolveEntityRef';
+import { configureMutationView } from '@/utils/configureMutationView';
+import {
+  buildElementWriteBack,
+  summarize,
+  declaredVolumeBases,
+  validEntry,
+  zonePropertySetName,
+  zoneQuantitySetPrefix,
+  ZONE_QUANTITY_SET_NAME_PREFIX,
+  type ElementWriteBack,
+  type ElementZoneFacts,
+  type VolumeBasis,
+  type WriteBackRefusal,
+  type WriteBackSummary,
+  type ZoneSet,
+} from '@/lib/zones';
+import { computeZoneApportionmentNow, gatherProvedVolumes, type ProvedVolumes } from './useZoneApportionment.js';
+
+export interface ZoneWriteBackResult {
+  summary: WriteBackSummary;
+  /** Model ids that gained properties. */
+  modelIds: string[];
+  elapsedMs: number;
+  /** Set when nothing was written because the session forbids editing. */
+  blocked: 'collab-role' | null;
+}
+
+const EMPTY: ZoneWriteBackResult = {
+  summary: { written: 0, withVolumes: 0, refused: 0, skippedNoZone: 0 },
+  modelIds: [],
+  elapsedMs: 0,
+  blocked: null,
+};
+
+/** Per-model things the loop would otherwise re-derive per element. */
+interface ModelContext {
+  view: MutablePropertyView;
+  volumeSiScale: number;
+  store: IfcDataStore | null;
+}
+
+function volumeScaleOf(store: IfcDataStore | null): number {
+  if (!store || !(store.source?.length > 0)) return 1;
+  const scale = extractProjectUnits(store.source, store.entityIndex).resolvedForUnitType('VOLUMEUNIT')?.siScale;
+  return Number.isFinite(scale) && (scale ?? 0) > 0 ? (scale as number) : 1;
+}
+
+/** Get-or-create a model's overlay. Write-back is often the FIRST thing in a
+ *  session to touch a model's properties, so unlike the panels it cannot assume
+ *  a view already exists. */
+function contextFor(modelId: string, cache: Map<string, ModelContext | null>): ModelContext | null {
+  const cached = cache.get(modelId);
+  if (cached !== undefined) return cached;
+
+  const state = useViewerStore.getState();
+  const store = (state.models.get(modelId)?.ifcDataStore ?? (modelId === 'legacy' ? state.ifcDataStore : null)) as IfcDataStore | null;
+  let view = state.getMutationView(modelId);
+  if (!view) {
+    if (!store) {
+      cache.set(modelId, null);
+      return null;
+    }
+    view = new MutablePropertyView(store.properties || null, modelId);
+    configureMutationView(view, store);
+    state.registerMutationView(modelId, view);
+  }
+  const context: ModelContext = { view, volumeSiScale: volumeScaleOf(store), store };
+  cache.set(modelId, context);
+  return context;
+}
+
+/**
+ * The element's quantity sets as the session sees them: the file's own, plus
+ * any this session edited or created.
+ *
+ * Read through the mutation VIEW rather than the data store for two reasons.
+ * The store's `quantities` table is empty on a lazily-parsed model (quantities
+ * live behind `onDemandQuantityMap`, which the view's configured extractor
+ * uses), and a NetVolume the user corrected this session is the number they
+ * expect to see apportioned.
+ */
+function quantitySetsFor(context: ModelContext, expressId: number) {
+  return context.view.getQuantitiesForEntity(expressId);
+}
+
+/** Resolve the whole-element total on `basis`, plus the quantity name it came
+ *  from. `null` total means the file declares nothing on that basis. */
+function declaredTotal(
+  qsets: ReturnType<typeof quantitySetsFor>,
+  volumeSiScale: number,
+  basis: Exclude<VolumeBasis, 'mesh'>,
+): { totalM3: number; quantityName: string } | null {
+  // A previous run's OWN output is excluded before anything is read off it.
+  // Its rows are volumes with no qualifying name, so `unqualified` would
+  // otherwise apportion a zone's share as if it were the element's total and
+  // feed the result back in on every run.
+  const declaredSets = qsets.filter((q) => !q.name.startsWith(ZONE_QUANTITY_SET_NAME_PREFIX));
+  const declared = declaredVolumeBases(declaredSets, volumeSiScale);
+  const match = declared.find((d) => d.basis === basis);
+  return match ? { totalM3: match.valueM3, quantityName: match.quantityName } : null;
+}
+
+interface VolumeResolution {
+  shares: Array<{ zoneName: string; valueM3: number }>;
+  outsideM3: number;
+  refusal: WriteBackRefusal | null;
+  quantityName: string | null;
+}
+
+/**
+ * How much of this element is in each zone, on the chosen basis.
+ *
+ * A straddler's split is measured (the apportionment cache); a non-straddler's
+ * is trivially "all of it, in its home zone" and skips the clip entirely. Both
+ * take their MAGNITUDE from the same basis, which is what keeps the two
+ * populations addable in one column.
+ */
+function resolveVolumes(
+  globalId: number,
+  straddles: boolean,
+  homeZoneName: string | null,
+  basis: VolumeBasis,
+  qsets: ReturnType<typeof quantitySetsFor>,
+  volumeSiScale: number,
+  proved: ProvedVolumes,
+  apportioned: ReturnType<typeof validEntry>,
+): VolumeResolution {
+  const declared = basis === 'mesh' ? null : declaredTotal(qsets, volumeSiScale, basis);
+  if (basis !== 'mesh' && !declared) {
+    return { shares: [], outsideM3: 0, refusal: 'no-declared-quantity', quantityName: null };
+  }
+  const quantityName = declared?.quantityName ?? null;
+
+  if (straddles) {
+    const entry = apportioned?.byElement.get(globalId) ?? null;
+    if (!entry) {
+      const refusal = (apportioned?.refused.get(globalId) ?? 'no-geometry') as WriteBackRefusal;
+      return { shares: [], outsideM3: 0, refusal, quantityName };
+    }
+    // Overlapping zones double-count, so the shares are individually right but
+    // do not add up. A panel can say that beside the numbers; a quantity set
+    // cannot, and a reader will add the rows up.
+    if (entry.overlapping) {
+      return { shares: [], outsideM3: 0, refusal: 'overlapping-zones', quantityName };
+    }
+    const total = declared ? declared.totalM3 : entry.wholeVolumeM3;
+    return {
+      shares: entry.shares.map((s) => ({ zoneName: s.zoneName, valueM3: s.fraction * total })),
+      outsideM3: entry.outsideFraction * total,
+      refusal: null,
+      quantityName,
+    };
+  }
+
+  // Wholly inside one zone. Nothing to split, so nothing to prove about the
+  // geometry - on a declared basis this element never touches the renderer.
+  if (!homeZoneName) return { shares: [], outsideM3: 0, refusal: 'no-geometry', quantityName };
+  if (declared) {
+    return { shares: [{ zoneName: homeZoneName, valueM3: declared.totalM3 }], outsideM3: 0, refusal: null, quantityName };
+  }
+  if (proved.rescaled.has(globalId)) {
+    return { shares: [], outsideM3: 0, refusal: 'rescaled-by-alignment', quantityName };
+  }
+  const mesh = proved.byGlobalId.get(globalId);
+  if (mesh === undefined || !Number.isFinite(mesh)) {
+    return { shares: [], outsideM3: 0, refusal: 'unproved-solid', quantityName };
+  }
+  return { shares: [{ zoneName: homeZoneName, valueM3: Math.abs(mesh) }], outsideM3: 0, refusal: null, quantityName };
+}
+
+/**
+ * Write `zoneSet`'s assignment into every model it reaches.
+ *
+ * Recomputes the apportionment first when the cache is stale, so the file can
+ * never carry volumes from zones that have since moved.
+ */
+export function applyZoneWriteBack(zoneSet: ZoneSet, basis: VolumeBasis): ZoneWriteBackResult {
+  const state = useViewerStore.getState();
+  // Checked ONCE for the run rather than per element, which is the only
+  // difference from the per-mutation actions' own gate: a read-only collab
+  // participant must not accumulate local edits no peer will ever see.
+  if (!state.canCollabEdit()) return { ...EMPTY, blocked: 'collab-role' };
+
+  const t0 = performance.now();
+  const zoneNameById = new Map(zoneSet.zones.map((z) => [z.id, z.name]));
+  const apportioned = validEntry(state.zoneApportionment, zoneSet) ?? computeZoneApportionmentNow(zoneSet);
+  const proved = gatherProvedVolumes();
+
+  const contexts = new Map<string, ModelContext | null>();
+  const results: Array<ElementWriteBack | null> = [];
+  const touchedModels = new Set<string>();
+
+  for (const [globalId, record] of state.zoneAssignments) {
+    const assignment = record[zoneSet.id];
+    if (!assignment || assignment.touchedZoneIds.length === 0) {
+      results.push(null);
+      continue;
+    }
+    const ref = resolveEntityRef(globalId);
+    const context = contextFor(ref.modelId, contexts);
+    if (!context) {
+      results.push(null);
+      continue;
+    }
+
+    // ONE read of the entity's quantity sets per element, serving both the
+    // declared basis and the stale-zone-qset sweep below. Each read is an
+    // on-demand extraction, so asking twice would double the run's cost.
+    const qsets = quantitySetsFor(context, ref.expressId);
+    const volumes = resolveVolumes(
+      globalId,
+      assignment.straddles,
+      assignment.zoneName,
+      basis,
+      qsets,
+      context.volumeSiScale,
+      proved,
+      apportioned,
+    );
+    const facts: ElementZoneFacts = {
+      globalId,
+      homeZoneName: assignment.zoneName,
+      // Mapped through the set rather than trusting stored names: the
+      // assignment holds zone IDS precisely so a rename cannot leave stale
+      // names behind (types.ts).
+      touchedZoneNames: assignment.touchedZoneIds.map((id) => zoneNameById.get(id) ?? ''),
+      straddles: assignment.straddles,
+      ...volumes,
+    };
+    const built = buildElementWriteBack(facts, {
+      zoneSetName: zoneSet.name,
+      basis,
+      volumeSiScale: context.volumeSiScale,
+    });
+    results.push(built);
+    if (!built) continue;
+
+    context.view.createPropertySet(
+      ref.expressId,
+      built.psetName,
+      built.properties.map((p) => ({
+        name: p.name,
+        value: p.value,
+        type: p.kind === 'BOOLEAN' ? PropertyValueType.Boolean : PropertyValueType.Label,
+      })),
+    );
+    if (built.qsetName) {
+      context.view.createQuantitySet(
+        ref.expressId,
+        built.qsetName,
+        built.quantities.map((q) => ({ name: q.name, value: q.value, quantityType: QuantityType.Volume })),
+      );
+    }
+    // Whatever a previous run left on this element for this zone set, under a
+    // different basis or under this one when the volume is now refused, is
+    // removed. Otherwise switching basis accumulates one quantity set per basis
+    // ever chosen, and a re-run that refuses leaves stale numbers standing
+    // beside a property saying no volume could be computed.
+    const scope = zoneQuantitySetPrefix(zoneSet.name);
+    for (const q of qsets) {
+      if (q.name.startsWith(scope) && q.name !== built.qsetName) {
+        context.view.deleteQuantitySet(ref.expressId, q.name);
+      }
+    }
+    touchedModels.add(ref.modelId);
+  }
+
+  const modelIds = [...touchedModels];
+  if (modelIds.length > 0) useViewerStore.getState().markModelsDirty(modelIds);
+  return {
+    summary: summarize(results),
+    modelIds,
+    elapsedMs: performance.now() - t0,
+    blocked: null,
+  };
+}
+
+/**
+ * Remove what a previous run wrote, for one zone set.
+ *
+ * The inverse exists because the run does not enter the undo stack (see the
+ * module doc). It deletes by NAME, so it also clears sets written in an earlier
+ * session and re-imported, and it clears the quantity set on EVERY basis rather
+ * than only the one currently selected in the panel.
+ */
+export function removeZoneWriteBack(zoneSet: ZoneSet): { removed: number; modelIds: string[] } {
+  const state = useViewerStore.getState();
+  if (!state.canCollabEdit()) return { removed: 0, modelIds: [] };
+  const psetName = zonePropertySetName(zoneSet.name);
+  const scope = zoneQuantitySetPrefix(zoneSet.name);
+  const contexts = new Map<string, ModelContext | null>();
+  const touchedModels = new Set<string>();
+  let removed = 0;
+
+  for (const [globalId, record] of state.zoneAssignments) {
+    const assignment = record[zoneSet.id];
+    if (!assignment || assignment.touchedZoneIds.length === 0) continue;
+    const ref = resolveEntityRef(globalId);
+    const context = contextFor(ref.modelId, contexts);
+    if (!context) continue;
+    context.view.deletePropertySet(ref.expressId, psetName);
+    for (const q of context.view.getQuantitiesForEntity(ref.expressId)) {
+      if (q.name.startsWith(scope)) context.view.deleteQuantitySet(ref.expressId, q.name);
+    }
+    touchedModels.add(ref.modelId);
+    removed++;
+  }
+
+  const modelIds = [...touchedModels];
+  if (modelIds.length > 0) useViewerStore.getState().markModelsDirty(modelIds);
+  return { removed, modelIds };
+}
+
+/** React-facing handles. */
+export function useZoneWriteBack() {
+  const write = useCallback((zoneSet: ZoneSet, basis: VolumeBasis) => applyZoneWriteBack(zoneSet, basis), []);
+  const remove = useCallback((zoneSet: ZoneSet) => removeZoneWriteBack(zoneSet), []);
+  return { write, remove };
+}

--- a/apps/viewer/src/hooks/useZoneWriteBack.ts
+++ b/apps/viewer/src/hooks/useZoneWriteBack.ts
@@ -402,6 +402,14 @@ export function applyZoneWriteBack(zoneSet: ZoneSet, basis: VolumeBasis): ZoneWr
   };
 }
 
+/** What a removal did, or why it did nothing. */
+export interface ZoneWriteBackRemoval {
+  /** Elements something was actually deleted from. */
+  removed: number;
+  modelIds: string[];
+  blocked: 'collab-role' | 'duplicate-set-name' | null;
+}
+
 /**
  * Remove what any run wrote for one zone set, from every element.
  *
@@ -417,10 +425,13 @@ export function applyZoneWriteBack(zoneSet: ZoneSet, basis: VolumeBasis): ZoneWr
  *    "removed from 12,000 elements" on a model that was never written to, with
  *    an unsaved-changes flag to match, is a false report of an edit.
  */
-export function removeZoneWriteBack(zoneSet: ZoneSet): { removed: number; modelIds: string[] } {
+export function removeZoneWriteBack(zoneSet: ZoneSet): ZoneWriteBackRemoval {
   const state = useViewerStore.getState();
-  if (!state.canCollabEdit()) return { removed: 0, modelIds: [] };
-  if (collidesByName(zoneSet)) return { removed: 0, modelIds: [] };
+  // Reported rather than folded into `removed: 0`: "nothing to remove" and "you
+  // were not allowed to" are different answers, and only one of them means the
+  // user should do something next.
+  if (!state.canCollabEdit()) return { removed: 0, modelIds: [], blocked: 'collab-role' };
+  if (collidesByName(zoneSet)) return { removed: 0, modelIds: [], blocked: 'duplicate-set-name' };
   const contexts = new Map<string, ModelContext | null>();
   const touchedModels = new Set<string>();
   let removed = 0;
@@ -459,7 +470,7 @@ export function removeZoneWriteBack(zoneSet: ZoneSet): { removed: number; modelI
 
   const modelIds = [...touchedModels];
   if (modelIds.length > 0) useViewerStore.getState().markModelsDirty(modelIds);
-  return { removed, modelIds };
+  return { removed, modelIds, blocked: null };
 }
 
 /** React-facing handles. */

--- a/apps/viewer/src/hooks/useZoneWriteBack.ts
+++ b/apps/viewer/src/hooks/useZoneWriteBack.ts
@@ -66,8 +66,24 @@ export interface ZoneWriteBackResult {
   /** Model ids that gained properties. */
   modelIds: string[];
   elapsedMs: number;
-  /** Set when nothing was written because the session forbids editing. */
-  blocked: 'collab-role' | null;
+  /** Set when nothing was written, and why. */
+  blocked: 'collab-role' | 'duplicate-set-name' | null;
+}
+
+/**
+ * Is another loaded zone set using this one's display name?
+ *
+ * Both set names carry the DISPLAY name, and `ZoneSet.name` is unique only by
+ * convention (`types.ts`: ids are what disambiguate). Two sets sharing a name
+ * would write to the same property-set name and, worse, one's sweep would
+ * delete the other's quantity sets, because a quantity set is matched by the
+ * bracket text of the property set that names it. Refusing is better than
+ * either silently merging two takt plans or burying an id in the name a user
+ * reads in another tool.
+ */
+function collidesByName(zoneSet: ZoneSet): boolean {
+  return useViewerStore.getState().zoneSets
+    .some((other) => other.id !== zoneSet.id && other.name.trim() === zoneSet.name.trim());
 }
 
 const EMPTY: ZoneWriteBackResult = {
@@ -159,6 +175,7 @@ function zoneSetsOnElement(
   context: ModelContext,
   expressId: number,
   zoneSetId: string,
+  knownQsets?: ReturnType<typeof quantitySetsFor>,
 ): { psets: string[]; qsets: string[] } {
   const psets: string[] = [];
   const brackets: string[] = [];
@@ -169,8 +186,11 @@ function zoneSetsOnElement(
     psets.push(pset.name);
     brackets.push(pset.name.slice(`${ZONE_SET_NAME_PREFIX} [`.length, -1));
   }
-  const qsets = context.view
-    .getQuantitiesForEntity(expressId)
+  // Reuses the caller's read when it has one. Each of these is an on-demand
+  // extraction, and the write path already reads the element's quantity sets to
+  // resolve its declared basis, so asking again would double the run's cost for
+  // an answer that cannot have changed in between.
+  const qsets = (knownQsets ?? quantitySetsFor(context, expressId))
     .map((q) => q.name)
     .filter((name) => brackets.some((b) => name.startsWith(zoneQuantitySetPrefix(b))));
   return { psets, qsets };
@@ -187,8 +207,13 @@ function zoneSetsOnElement(
  * survives the re-run. Deleting first makes each run's output exactly what that
  * run computed.
  */
-function sweepZoneSets(context: ModelContext, expressId: number, zoneSetId: string): number {
-  const { psets, qsets } = zoneSetsOnElement(context, expressId, zoneSetId);
+function sweepZoneSets(
+  context: ModelContext,
+  expressId: number,
+  zoneSetId: string,
+  knownQsets?: ReturnType<typeof quantitySetsFor>,
+): number {
+  const { psets, qsets } = zoneSetsOnElement(context, expressId, zoneSetId, knownQsets);
   for (const name of psets) context.view.deletePropertySet(expressId, name);
   for (const name of qsets) context.view.deleteQuantitySet(expressId, name);
   return psets.length + qsets.length;
@@ -274,6 +299,7 @@ export function applyZoneWriteBack(zoneSet: ZoneSet, basis: VolumeBasis): ZoneWr
   // difference from the per-mutation actions' own gate: a read-only collab
   // participant must not accumulate local edits no peer will ever see.
   if (!state.canCollabEdit()) return { ...EMPTY, blocked: 'collab-role' };
+  if (collidesByName(zoneSet)) return { ...EMPTY, blocked: 'duplicate-set-name' };
 
   const t0 = performance.now();
   const zoneNameById = new Map(zoneSet.zones.map((z) => [z.id, z.name]));
@@ -345,7 +371,7 @@ export function applyZoneWriteBack(zoneSet: ZoneSet, basis: VolumeBasis): ZoneWr
     // over a same-named set that exists in the FILE, so without this a re-run
     // keeps rows it did not compute: a zone the element no longer reaches, or a
     // `VolumeBasis` label standing beside a fresh `VolumeUnavailable`.
-    if (sweepZoneSets(context, ref.expressId, zoneSet.id) > 0) touchedModels.add(ref.modelId);
+    if (sweepZoneSets(context, ref.expressId, zoneSet.id, qsets) > 0) touchedModels.add(ref.modelId);
 
     context.view.createPropertySet(
       ref.expressId,
@@ -394,6 +420,7 @@ export function applyZoneWriteBack(zoneSet: ZoneSet, basis: VolumeBasis): ZoneWr
 export function removeZoneWriteBack(zoneSet: ZoneSet): { removed: number; modelIds: string[] } {
   const state = useViewerStore.getState();
   if (!state.canCollabEdit()) return { removed: 0, modelIds: [] };
+  if (collidesByName(zoneSet)) return { removed: 0, modelIds: [] };
   const contexts = new Map<string, ModelContext | null>();
   const touchedModels = new Set<string>();
   let removed = 0;
@@ -405,6 +432,29 @@ export function removeZoneWriteBack(zoneSet: ZoneSet): { removed: number; modelI
     if (sweepZoneSets(context, ref.expressId, zoneSet.id) === 0) continue;
     touchedModels.add(ref.modelId);
     removed++;
+  }
+
+  // The assignment cache holds only elements the renderer has geometry for, so
+  // an element whose geometry was released to reclaim memory (#2183) has left
+  // it while its property set has not. Every element THIS SESSION wrote to is
+  // still named in its model's mutation history, which is an in-memory walk
+  // with no extraction behind it, so the two together cover everything the
+  // feature can have produced. What remains out of reach is an element written
+  // in an EARLIER session whose geometry is not loaded now; loading the model's
+  // geometry brings it back into the first pass.
+  for (const [modelId, view] of state.mutationViews) {
+    const context = contextFor(modelId, contexts);
+    if (!context) continue;
+    const seen = new Set<number>();
+    for (const mutation of view.getMutations()) {
+      if (!mutation.psetName?.startsWith(ZONE_SET_NAME_PREFIX)
+        && !mutation.psetName?.startsWith(ZONE_QUANTITY_SET_NAME_PREFIX)) continue;
+      if (seen.has(mutation.entityId)) continue;
+      seen.add(mutation.entityId);
+      if (sweepZoneSets(context, mutation.entityId, zoneSet.id) === 0) continue;
+      touchedModels.add(modelId);
+      removed++;
+    }
   }
 
   const modelIds = [...touchedModels];

--- a/apps/viewer/src/hooks/useZoneWriteBack.ts
+++ b/apps/viewer/src/hooks/useZoneWriteBack.ts
@@ -48,9 +48,10 @@ import {
   summarize,
   declaredVolumeBases,
   validEntry,
-  zonePropertySetName,
   zoneQuantitySetPrefix,
+  ZONE_PROPERTY_NAMES,
   ZONE_QUANTITY_SET_NAME_PREFIX,
+  ZONE_SET_NAME_PREFIX,
   type ElementWriteBack,
   type ElementZoneFacts,
   type VolumeBasis,
@@ -142,6 +143,55 @@ function declaredTotal(
   const declared = declaredVolumeBases(declaredSets, volumeSiScale);
   const match = declared.find((d) => d.basis === basis);
   return match ? { totalM3: match.valueM3, quantityName: match.quantityName } : null;
+}
+
+/**
+ * Every zone property/quantity set on this element that belongs to `zoneSetId`,
+ * whatever the set was CALLED when it was written.
+ *
+ * The names carry the zone set's display name, which a user can rename at any
+ * time, so matching on the current name alone would orphan everything written
+ * under the old one. The property set carries its set's ID, so the id is what
+ * is matched, and the quantity sets are then found by the bracket text of the
+ * property set that names them.
+ */
+function zoneSetsOnElement(
+  context: ModelContext,
+  expressId: number,
+  zoneSetId: string,
+): { psets: string[]; qsets: string[] } {
+  const psets: string[] = [];
+  const brackets: string[] = [];
+  for (const pset of context.view.getForEntity(expressId)) {
+    if (!pset.name.startsWith(`${ZONE_SET_NAME_PREFIX} [`)) continue;
+    const owner = pset.properties.find((p) => p.name === ZONE_PROPERTY_NAMES.zoneSetId)?.value;
+    if (owner !== zoneSetId) continue;
+    psets.push(pset.name);
+    brackets.push(pset.name.slice(`${ZONE_SET_NAME_PREFIX} [`.length, -1));
+  }
+  const qsets = context.view
+    .getQuantitiesForEntity(expressId)
+    .map((q) => q.name)
+    .filter((name) => brackets.some((b) => name.startsWith(zoneQuantitySetPrefix(b))));
+  return { psets, qsets };
+}
+
+/**
+ * Remove every trace of one zone set from one element, and report how many sets
+ * went.
+ *
+ * Run before each write as well as by the panel's Remove: `createPropertySet`
+ * MERGES over a set of the same name that exists in the FILE (a re-imported
+ * export of a previous run), so a row that should have disappeared -- a zone the
+ * element no longer reaches, a `VolumeBasis` on an element now refused --
+ * survives the re-run. Deleting first makes each run's output exactly what that
+ * run computed.
+ */
+function sweepZoneSets(context: ModelContext, expressId: number, zoneSetId: string): number {
+  const { psets, qsets } = zoneSetsOnElement(context, expressId, zoneSetId);
+  for (const name of psets) context.view.deletePropertySet(expressId, name);
+  for (const name of qsets) context.view.deleteQuantitySet(expressId, name);
+  return psets.length + qsets.length;
 }
 
 interface VolumeResolution {
@@ -236,12 +286,22 @@ export function applyZoneWriteBack(zoneSet: ZoneSet, basis: VolumeBasis): ZoneWr
 
   for (const [globalId, record] of state.zoneAssignments) {
     const assignment = record[zoneSet.id];
+    const ref = resolveEntityRef(globalId);
+    const context = contextFor(ref.modelId, contexts);
     if (!assignment || assignment.touchedZoneIds.length === 0) {
+      // An element that has LEFT the set (a zone moved or was deleted) would
+      // otherwise keep the previous run's zone and volumes forever, since the
+      // old loop never visited it again. `hasChanges` is an in-memory map check
+      // with no extraction behind it, so the common case -- an element this
+      // session never touched -- costs nothing. An element written in an
+      // EARLIER session and re-imported is not reachable this cheaply; the
+      // panel's Remove sweeps unconditionally for exactly that.
+      if (context && context.view.hasChanges(ref.expressId)) {
+        if (sweepZoneSets(context, ref.expressId, zoneSet.id) > 0) touchedModels.add(ref.modelId);
+      }
       results.push(null);
       continue;
     }
-    const ref = resolveEntityRef(globalId);
-    const context = contextFor(ref.modelId, contexts);
     if (!context) {
       results.push(null);
       continue;
@@ -273,11 +333,19 @@ export function applyZoneWriteBack(zoneSet: ZoneSet, basis: VolumeBasis): ZoneWr
     };
     const built = buildElementWriteBack(facts, {
       zoneSetName: zoneSet.name,
+      zoneSetId: zoneSet.id,
       basis,
       volumeSiScale: context.volumeSiScale,
     });
     results.push(built);
     if (!built) continue;
+
+    // Everything this set left here before goes first, whatever it was named
+    // and on whatever basis. `createPropertySet` / `createQuantitySet` MERGE
+    // over a same-named set that exists in the FILE, so without this a re-run
+    // keeps rows it did not compute: a zone the element no longer reaches, or a
+    // `VolumeBasis` label standing beside a fresh `VolumeUnavailable`.
+    if (sweepZoneSets(context, ref.expressId, zoneSet.id) > 0) touchedModels.add(ref.modelId);
 
     context.view.createPropertySet(
       ref.expressId,
@@ -295,17 +363,6 @@ export function applyZoneWriteBack(zoneSet: ZoneSet, basis: VolumeBasis): ZoneWr
         built.quantities.map((q) => ({ name: q.name, value: q.value, quantityType: QuantityType.Volume })),
       );
     }
-    // Whatever a previous run left on this element for this zone set, under a
-    // different basis or under this one when the volume is now refused, is
-    // removed. Otherwise switching basis accumulates one quantity set per basis
-    // ever chosen, and a re-run that refuses leaves stale numbers standing
-    // beside a property saying no volume could be computed.
-    const scope = zoneQuantitySetPrefix(zoneSet.name);
-    for (const q of qsets) {
-      if (q.name.startsWith(scope) && q.name !== built.qsetName) {
-        context.view.deleteQuantitySet(ref.expressId, q.name);
-      }
-    }
     touchedModels.add(ref.modelId);
   }
 
@@ -320,32 +377,32 @@ export function applyZoneWriteBack(zoneSet: ZoneSet, basis: VolumeBasis): ZoneWr
 }
 
 /**
- * Remove what a previous run wrote, for one zone set.
+ * Remove what any run wrote for one zone set, from every element.
  *
  * The inverse exists because the run does not enter the undo stack (see the
- * module doc). It deletes by NAME, so it also clears sets written in an earlier
- * session and re-imported, and it clears the quantity set on EVERY basis rather
- * than only the one currently selected in the panel.
+ * module doc). Three things it deliberately does not narrow:
+ *
+ *  - it visits EVERY element, not only the ones currently in the set, because
+ *    an element that has since left it is exactly the one carrying a stale
+ *    assignment nothing else will clear;
+ *  - it matches on the set's ID rather than its name, so a rename does not
+ *    strand the earlier output;
+ *  - it counts only elements where something was actually deleted. A count of
+ *    "removed from 12,000 elements" on a model that was never written to, with
+ *    an unsaved-changes flag to match, is a false report of an edit.
  */
 export function removeZoneWriteBack(zoneSet: ZoneSet): { removed: number; modelIds: string[] } {
   const state = useViewerStore.getState();
   if (!state.canCollabEdit()) return { removed: 0, modelIds: [] };
-  const psetName = zonePropertySetName(zoneSet.name);
-  const scope = zoneQuantitySetPrefix(zoneSet.name);
   const contexts = new Map<string, ModelContext | null>();
   const touchedModels = new Set<string>();
   let removed = 0;
 
-  for (const [globalId, record] of state.zoneAssignments) {
-    const assignment = record[zoneSet.id];
-    if (!assignment || assignment.touchedZoneIds.length === 0) continue;
+  for (const [globalId] of state.zoneAssignments) {
     const ref = resolveEntityRef(globalId);
     const context = contextFor(ref.modelId, contexts);
     if (!context) continue;
-    context.view.deletePropertySet(ref.expressId, psetName);
-    for (const q of context.view.getQuantitiesForEntity(ref.expressId)) {
-      if (q.name.startsWith(scope)) context.view.deleteQuantitySet(ref.expressId, q.name);
-    }
+    if (sweepZoneSets(context, ref.expressId, zoneSet.id) === 0) continue;
     touchedModels.add(ref.modelId);
     removed++;
   }

--- a/apps/viewer/src/lib/zones/apportionment-cache.ts
+++ b/apps/viewer/src/lib/zones/apportionment-cache.ts
@@ -83,6 +83,12 @@ export function zoneSetRevision(zoneSet: ZoneSet): string {
       `${z.id.length}:${z.id}${z.name.length}:${z.name}`,
       `${z.center[0]},${z.center[1]},${z.center[2]};`,
       `${z.size[0]},${z.size[1]},${z.size[2]};${z.rotationY};`,
+      // The FOOTPRINT of a prism zone (#2508 item 4). Two prisms can share a
+      // bounding box and cut differently -- move any vertex that is not a
+      // bounding-box extreme and the box fields above do not move at all -- so
+      // omitting it serves the old polygon's cubic metres for the new one.
+      // Length-prefixed like the ids, for the same reason.
+      z.footprint ? `${z.footprint.length}:${z.footprint.map((p) => `${p[0]},${p[1]}`).join(';')};` : '0;',
     );
   }
   return parts.join('');

--- a/apps/viewer/src/lib/zones/apportionment.ts
+++ b/apps/viewer/src/lib/zones/apportionment.ts
@@ -25,6 +25,7 @@ import {
   piecesAabb,
   type ElementMeshPiece,
 } from './apportionment-clip.js';
+import { clippedVolumeForPrism, compilePrism } from './prism.js';
 
 // Re-exported so `./apportionment-clip.js` stays an implementation detail for
 // every existing consumer (`lib/zones/index.ts`, the hook, the tests).
@@ -150,7 +151,12 @@ export function apportionElementVolume(
     for (const zone of zones) {
       const compiled = compileZone(zone);
       if (!zoneOverlapsAABBCompiled(aabb[0], aabb[1], aabb[2], aabb[3], aabb[4], aabb[5], compiled)) continue;
-      const v = clippedVolumeForZone(pieces, compiled) * sign;
+      // A prism integrates the same way against a different decomposition of
+      // the same field (see `prism.ts`). Routed here rather than inside the box
+      // clipper so the measured box path keeps its shape exactly.
+      const v = (zone.footprint
+        ? clippedVolumeForPrism(pieces, compilePrism(zone.footprint, compiled.minY, compiled.maxY))
+        : clippedVolumeForZone(pieces, compiled)) * sign;
       if (!Number.isFinite(v) || v <= negligible) {
         if (v < -negligible) unreliable = true;
         continue;

--- a/apps/viewer/src/lib/zones/assignment.test.ts
+++ b/apps/viewer/src/lib/zones/assignment.test.ts
@@ -206,3 +206,55 @@ describe('zones/assignment', () => {
     });
   });
 });
+
+describe('prism zones classify by the polygon (#2508 item 4)', () => {
+  /** A triangular takt area covering the lower-left half of a 10 x 10 plan. */
+  const prism: Zone = {
+    id: 'p',
+    name: 'Takt triangle',
+    center: [5, 5, 5],
+    size: [10, 10, 10],
+    rotationY: 0,
+    footprint: [[0, 0], [10, 0], [0, 10]],
+  };
+  const set: ZoneSet = {
+    id: 's', name: 'Takt', zones: [prism], visible: true, createdAt: 0, updatedAt: 0,
+  };
+
+  it('takes an element inside the polygon', () => {
+    const result = assignElementsToZoneSet(
+      [{ globalId: 1, min: [1, 1, 1], max: [2, 2, 2] }],
+      set,
+    );
+    assert.equal(result.get(1)?.zoneId, 'p');
+  });
+
+  it('leaves an element that is inside the BOUNDING BOX but outside the polygon', () => {
+    // (8, 8) is well inside the 10 x 10 bounding box and clearly on the far
+    // side of the diagonal. A box-shaped implementation claims it.
+    const result = assignElementsToZoneSet(
+      [{ globalId: 2, min: [8, 1, 8], max: [9, 2, 9] }],
+      set,
+    );
+    assert.equal(result.get(2)?.zoneId, null);
+    assert.deepEqual(result.get(2)?.touchedZoneIds, []);
+  });
+
+  it('flags an element crossing the polygon edge as a straddler', () => {
+    const second: Zone = {
+      id: 'q',
+      name: 'Takt other',
+      center: [5, 5, 5],
+      size: [10, 10, 10],
+      rotationY: 0,
+      footprint: [[10, 0], [10, 10], [0, 10]],
+    };
+    const both: ZoneSet = { ...set, zones: [prism, second] };
+    const result = assignElementsToZoneSet(
+      [{ globalId: 3, min: [4, 1, 4], max: [6, 2, 6] }],
+      both,
+    );
+    assert.equal(result.get(3)?.straddles, true);
+    assert.deepEqual(result.get(3)?.touchedZoneIds, ['p', 'q']);
+  });
+});

--- a/apps/viewer/src/lib/zones/geometry.prism.test.ts
+++ b/apps/viewer/src/lib/zones/geometry.prism.test.ts
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The zone-shape seam (#2508 item 4): `compileZone`, the point test, the
+ * overlap test and the corner list all have to answer for a PRISM as well as a
+ * box, and each of them is consumed by something different (assignment, the
+ * apportionment prefilter, the 3D overlay).
+ *
+ * Kept out of `geometry.test.ts` because that file pins v1's box behaviour and
+ * these are the questions v1 could not be asked.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { compileZone, isPointInCompiledZone, zoneOverlapsAABBCompiled, zoneWorldCorners } from './geometry.js';
+import type { Zone } from './types.js';
+
+/** A triangular takt area over the lower-left half of a 10 x 10 plan, 3 m tall
+ *  from y = 0. Its bounding box is the whole 10 x 10. */
+const PRISM: Zone = {
+  id: 'p',
+  name: 'Takt triangle',
+  center: [5, 1.5, 5],
+  size: [10, 3, 10],
+  rotationY: 0,
+  footprint: [[0, 0], [10, 0], [0, 10]],
+};
+
+describe('compiled prism zones', () => {
+  it('contains a point inside the polygon and not one merely inside the box', () => {
+    const compiled = compileZone(PRISM);
+    assert.equal(isPointInCompiledZone(1, 1.5, 1, compiled), true);
+    // Inside the bounding box, past the diagonal.
+    assert.equal(isPointInCompiledZone(9, 1.5, 9, compiled), false);
+  });
+
+  it('still applies the vertical extent, which the footprint says nothing about', () => {
+    const compiled = compileZone(PRISM);
+    assert.equal(isPointInCompiledZone(1, 10, 1, compiled), false);
+  });
+
+  it('overlaps an AABB by the polygon rather than by the bounding box', () => {
+    const compiled = compileZone(PRISM);
+    assert.equal(zoneOverlapsAABBCompiled(0.5, 0, 0.5, 1.5, 1, 1.5, compiled), true);
+    assert.equal(zoneOverlapsAABBCompiled(8, 0, 8, 9.5, 1, 9.5, compiled), false);
+  });
+
+  it('ignores rotationY, which a prism does not own', () => {
+    // The footprint is already in world coordinates. A compiled prism that
+    // rotated it would move a zone the user cannot see rotating.
+    const spun = compileZone({ ...PRISM, rotationY: Math.PI / 3 });
+    assert.equal(isPointInCompiledZone(1, 1.5, 1, spun), true);
+    assert.equal(isPointInCompiledZone(9, 1.5, 9, spun), false);
+  });
+
+  it('returns one corner per footprint point per level, for the overlay', () => {
+    // The 3D overlay derives its wireframe edges from this list's LENGTH since
+    // #2508 item 4. Eight corners for a box, 2n for a prism.
+    const corners = zoneWorldCorners(PRISM);
+    assert.equal(corners.length, 6);
+    assert.deepEqual(corners[0], [0, 0, 0], 'bottom ring first, at the base');
+    assert.deepEqual(corners[3], [0, 3, 0], 'top ring second, at the top');
+    assert.equal(zoneWorldCorners({ ...PRISM, footprint: undefined }).length, 8);
+  });
+});

--- a/apps/viewer/src/lib/zones/geometry.ts
+++ b/apps/viewer/src/lib/zones/geometry.ts
@@ -11,6 +11,7 @@
  * separating-axis machinery.
  */
 
+import { footprintOverlapsRect, isPointInFootprint } from './prism.js';
 import type { ElementAABB, Zone } from './types.js';
 
 export interface Vec3Like {
@@ -105,6 +106,10 @@ export interface CompiledZone {
   sin: number;
   minY: number;
   maxY: number;
+  /** Present only for a PRISM zone (#2508 item 4). When set, the box fields
+   *  above still hold its bounding box, and every exact test below uses the
+   *  polygon instead. */
+  footprint?: ReadonlyArray<readonly [number, number]>;
 }
 
 /** Precompute a zone's trig + half-extents once, for reuse across every
@@ -129,6 +134,7 @@ export function compileZone(zone: Zone): CompiledZone {
     sin,
     minY: cy - hy,
     maxY: cy + hy,
+    ...(zone.footprint ? { footprint: zone.footprint } : {}),
   };
 }
 
@@ -141,6 +147,9 @@ export function isPointInCompiledZone(
   eps = 1e-6,
 ): boolean {
   if (y < zone.minY - eps || y > zone.maxY + eps) return false;
+  // A prism's footprint is already world-aligned, so there is no rotation to
+  // undo: the vertical test above plus the polygon test is the whole answer.
+  if (zone.footprint) return isPointInFootprint(x, z, zone.footprint, eps);
   const dx = x - zone.cx;
   const dz = z - zone.cz;
   // World -> zone-local rotation by -rotationY: cos(-t)=cos(t), sin(-t)=-sin(t).
@@ -182,6 +191,10 @@ export function zoneOverlapsAABBCompiled(
   eps = 1e-6,
 ): boolean {
   if (maxY < zone.minY - eps || minY > zone.maxY + eps) return false;
+  // Same decomposition as the box case (independent vertical test plus a 2-D
+  // test in the footprint plane), with the rotated rectangle replaced by the
+  // polygon. `eps` keeps its meaning, sign included.
+  if (zone.footprint) return footprintOverlapsRect(minX, minZ, maxX, maxZ, zone.footprint, eps);
 
   const acx = (minX + maxX) / 2;
   const acz = (minZ + maxZ) / 2;
@@ -204,11 +217,27 @@ export function zoneOverlapsAABBCompiled(
   return true;
 }
 
-/** World-space corners of a zone's box (for rendering a wireframe/translucent
- *  hull). Order: bottom face (0-3) then top face (4-7), each CCW looking
- *  down -Y, matching the common "box corner index" convention used by
- *  `AddElementOverlay`'s box-hull projection. */
+/**
+ * World-space corners of a zone's hull, for rendering.
+ *
+ * For a BOX: the eight corners, bottom face (0-3) then top face (4-7), each CCW
+ * looking down -Y, matching the "box corner index" convention
+ * `AddElementOverlay`'s box-hull projection uses.
+ *
+ * For a PRISM: the footprint's `n` points at the bottom followed by the same
+ * `n` at the top, which is the same convention generalised (a box IS the
+ * four-point case). Callers that index corners by hand must therefore read the
+ * length rather than assume eight.
+ */
 export function zoneWorldCorners(zone: Zone): Array<[number, number, number]> {
+  if (zone.footprint) {
+    const y0 = zone.center[1] - zone.size[1] / 2;
+    const y1 = zone.center[1] + zone.size[1] / 2;
+    return [
+      ...zone.footprint.map(([x, z]) => [x, y0, z] as [number, number, number]),
+      ...zone.footprint.map(([x, z]) => [x, y1, z] as [number, number, number]),
+    ];
+  }
   const hx = zone.size[0] / 2;
   const hy = zone.size[1] / 2;
   const hz = zone.size[2] / 2;

--- a/apps/viewer/src/lib/zones/index.ts
+++ b/apps/viewer/src/lib/zones/index.ts
@@ -28,10 +28,10 @@ export {
 
 export { assignElementsToZoneSet, assignElementsToZoneSets, STRADDLE_PENETRATION_M } from './assignment.js';
 
-// `prism.ts` is deliberately NOT re-exported here: every consumer of a prism so
-// far is inside this folder (`geometry`, `apportionment`, `persistence`), and
-// an unused re-export is a maintenance liability rather than an affordance.
-// Add one when something outside needs it.
+// `prism.ts` is deliberately NOT re-exported here. Its consumers are this
+// folder (`geometry`, `apportionment`, `persistence`) plus `zonesSlice`, which
+// deep-imports it exactly as it already deep-imports `types` and `persistence`.
+// Re-exporting would widen this barrel for one caller that does not use it.
 
 export {
   generateStoreyZones,

--- a/apps/viewer/src/lib/zones/index.ts
+++ b/apps/viewer/src/lib/zones/index.ts
@@ -70,6 +70,24 @@ export {
 } from './apportionment-cache.js';
 
 export {
+  buildElementWriteBack,
+  summarize,
+  zonePropertySetName,
+  zoneQuantitySetName,
+  zoneQuantitySetPrefix,
+  OUTSIDE_QUANTITY_NAME,
+  UNNAMED_ZONE,
+  ZONE_PROPERTY_NAMES,
+  ZONE_SET_NAME_PREFIX,
+  ZONE_QUANTITY_SET_NAME_PREFIX,
+  type ElementZoneFacts,
+  type ElementWriteBack,
+  type WriteBackRefusal,
+  type WriteBackSummary,
+  type ZoneWriteBackOptions,
+} from './writeback.js';
+
+export {
   allBasisBreakdowns,
   basisBreakdown,
   declaredVolumeBases,

--- a/apps/viewer/src/lib/zones/index.ts
+++ b/apps/viewer/src/lib/zones/index.ts
@@ -28,6 +28,11 @@ export {
 
 export { assignElementsToZoneSet, assignElementsToZoneSets, STRADDLE_PENETRATION_M } from './assignment.js';
 
+// `prism.ts` is deliberately NOT re-exported here: every consumer of a prism so
+// far is inside this folder (`geometry`, `apportionment`, `persistence`), and
+// an unused re-export is a maintenance liability rather than an affordance.
+// Add one when something outside needs it.
+
 export {
   generateStoreyZones,
   DEFAULT_STOREY_ZONE_HEIGHT_M,

--- a/apps/viewer/src/lib/zones/persistence.test.ts
+++ b/apps/viewer/src/lib/zones/persistence.test.ts
@@ -139,3 +139,67 @@ describe('zones/persistence', () => {
     });
   });
 });
+
+describe('prism zones on import (#2508 item 4)', () => {
+  function fileWith(zone: Record<string, unknown>): unknown {
+    return {
+      version: 1,
+      exportedAt: '2026-08-13T00:00:00.000Z',
+      zoneSets: [{
+        id: 'set-1', name: 'Takt', visible: true, createdAt: 0, updatedAt: 0,
+        zones: [{ id: 'z-1', name: 'A', center: [0, 1, 0], size: [1, 2, 1], rotationY: 0.7, ...zone }],
+      }],
+    };
+  }
+
+  it('derives the bounding box from the footprint rather than trusting the file', () => {
+    // A hand-written or CAD-exported footprint carries no bounding box, or a
+    // stale one. Every bounds consumer (overlay culling, framing, the broad
+    // phase) reads center/size, so a wrong box silently over- or under-selects.
+    const result = parseZoneSetFile(fileWith({ footprint: [[10, 20], [14, 20], [14, 26]] }));
+    assert.ok(result.ok);
+    const zone = result.zoneSets[0].zones[0];
+    assert.deepEqual(zone.center, [12, 1, 23]);
+    assert.deepEqual(zone.size, [4, 2, 6]);
+    // The vertical extent is NOT derived: it is the only box field a prism
+    // still owns.
+    assert.equal(zone.size[1], 2);
+    // A stale rotation would let a box-path consumer rotate a bounding box
+    // that is not rotated.
+    assert.equal(zone.rotationY, 0);
+  });
+
+  it('rejects a concave footprint rather than importing one that misreports volumes', () => {
+    // An L. The trapezoidal sweep, the point test and the SAT overlap are each
+    // silently wrong for it, so this file must fail loudly like every other
+    // malformed field.
+    const result = parseZoneSetFile(fileWith({
+      footprint: [[0, 0], [3, 0], [3, 1], [1, 1], [1, 3], [0, 3]],
+    }));
+    assert.equal(result.ok, false);
+  });
+
+  it('rejects a footprint that is not pairs of finite numbers', () => {
+    assert.equal(parseZoneSetFile(fileWith({ footprint: [[0, 0], [1, 'x']] })).ok, false);
+    assert.equal(parseZoneSetFile(fileWith({ footprint: [[0, 0], [1, 0]] })).ok, false, 'two points are a line');
+    assert.equal(parseZoneSetFile(fileWith({ footprint: 'square' })).ok, false);
+  });
+
+  it('round-trips a footprint without aliasing it to live state', () => {
+    const zoneSet: ZoneSet = {
+      id: 'set-1', name: 'Takt', visible: true, createdAt: 0, updatedAt: 0,
+      zones: [{
+        id: 'z-1', name: 'A', center: [0, 1, 0], size: [2, 2, 2], rotationY: 0,
+        footprint: [[0, 0], [2, 0], [2, 2]],
+      }],
+    };
+    const file = serializeZoneSets([zoneSet]);
+    const serialized = file.zoneSets[0].zones[0].footprint as Array<[number, number]>;
+    serialized[0][0] = 999;
+    assert.equal(zoneSet.zones[0].footprint![0][0], 0, 'serialize aliased the store');
+
+    const parsed = parseZoneSetFile(JSON.parse(JSON.stringify(serializeZoneSets([zoneSet]))));
+    assert.ok(parsed.ok);
+    assert.deepEqual(parsed.zoneSets[0].zones[0].footprint, [[0, 0], [2, 0], [2, 2]]);
+  });
+});

--- a/apps/viewer/src/lib/zones/persistence.ts
+++ b/apps/viewer/src/lib/zones/persistence.ts
@@ -10,6 +10,7 @@
  * this into the browser download/file-picker flow.
  */
 
+import { isConvexFootprint, normalizePrismBounds } from './prism.js';
 import { ZONE_SET_FILE_VERSION, type Zone, type ZoneSet, type ZoneSetFile } from './types.js';
 
 export type ParseZoneSetFileResult =
@@ -37,6 +38,11 @@ export function serializeZoneSets(zoneSets: readonly ZoneSet[]): ZoneSetFile {
         center: copyVec3(z.center),
         size: copyVec3(z.size),
         ...(z.color !== undefined ? { color: copyVec3(z.color) } : {}),
+        // Deep-copied for the same reason as the vectors above: a shallow
+        // spread would leave the polygon aliased to live Zustand state.
+        ...(z.footprint !== undefined
+          ? { footprint: z.footprint.map((p) => [p[0], p[1]] as [number, number]) }
+          : {}),
       })),
     })),
   };
@@ -50,6 +56,11 @@ function isVec3(v: unknown): v is [number, number, number] {
   return Array.isArray(v) && v.length === 3 && v.every(isFiniteNumber);
 }
 
+function isFootprint(v: unknown): v is Array<[number, number]> {
+  return Array.isArray(v)
+    && v.every((p) => Array.isArray(p) && p.length === 2 && p.every(isFiniteNumber));
+}
+
 function isValidZone(v: unknown): v is Zone {
   if (!v || typeof v !== 'object') return false;
   const z = v as Record<string, unknown>;
@@ -60,6 +71,14 @@ function isValidZone(v: unknown): v is Zone {
   if (!isFiniteNumber(z.rotationY)) return false;
   if (z.size[0] < 0 || z.size[1] < 0 || z.size[2] < 0) return false;
   if (z.color !== undefined && !isVec3(z.color)) return false;
+  if (z.footprint !== undefined) {
+    // Convexity is checked HERE, at the only door a footprint comes through,
+    // because everything downstream (the trapezoidal sweep, the point test, the
+    // separating-axis overlap) is silently wrong for a concave polygon rather
+    // than visibly broken. An import that would misreport volumes must fail
+    // loudly, which is this file's existing policy for every other field.
+    if (!isFootprint(z.footprint) || !isConvexFootprint(z.footprint)) return false;
+  }
   return true;
 }
 
@@ -114,5 +133,11 @@ export function parseZoneSetFile(json: unknown): ParseZoneSetFileResult {
       zoneIds.add(zone.id);
     }
   }
-  return { ok: true, zoneSets };
+  // A hand-written or CAD-exported footprint carries no bounding box, or a
+  // stale one. Deriving it here means the rest of the app can rely on
+  // `center`/`size` being the footprint's bounds without asking who wrote them.
+  return {
+    ok: true,
+    zoneSets: zoneSets.map((zs) => ({ ...zs, zones: zs.zones.map(normalizePrismBounds) })),
+  };
 }

--- a/apps/viewer/src/lib/zones/prism-clip.ts
+++ b/apps/viewer/src/lib/zones/prism-clip.ts
@@ -1,0 +1,204 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The divergence integral for a PRISM zone (issue #2508 item 4).
+ *
+ * Split out of `./prism.js`, which owns the footprint itself: its validity, its
+ * bounds, its trapezoidal sweep, and the point/rectangle tests the assignment
+ * engine uses. Everything here is arithmetic over triangles against one
+ * already-compiled prism and knows nothing of zones, zone sets or assignment.
+ * The seam mirrors `apportionment.ts` / `apportionment-clip.ts` one level up,
+ * for the same reason: the integrator is the part with the maths in it.
+ *
+ * WHY the field works for a prism at all, and why it stays exact, is in
+ * `./prism.js`'s module doc. Read that first; this file is the loop.
+ */
+
+import type { ElementMeshPiece } from './apportionment-clip.js';
+import type { CompiledPrism, Trapezoid } from './prism.js';
+
+/** Scratch polygons. A triangle clipped by six planes has at most nine
+ *  vertices; twelve is headroom, and module scope keeps the loop allocation
+ *  free, as in the box path. */
+const SCRATCH_A = new Float64Array(12 * 3);
+const SCRATCH_B = new Float64Array(12 * 3);
+
+/**
+ * Clip a polygon against `nx*x + ny*y + nz*z <= d`, writing to `dst`.
+ *
+ * The general-plane counterpart of the box path's axis-aligned clip. The edge
+ * parameter is clamped behind a denominator guard for the same reason it is
+ * there: without it a near-coincident plane extrapolates the cut vertex off the
+ * end of the edge (#1155).
+ */
+function clipPlane(
+  src: Float64Array,
+  srcCount: number,
+  dst: Float64Array,
+  nx: number,
+  ny: number,
+  nz: number,
+  d: number,
+): number {
+  let out = 0;
+  for (let i = 0; i < srcCount; i++) {
+    const ai = i * 3;
+    const bi = ((i + 1) % srcCount) * 3;
+    const da = d - (nx * src[ai] + ny * src[ai + 1] + nz * src[ai + 2]);
+    const db = d - (nx * src[bi] + ny * src[bi + 1] + nz * src[bi + 2]);
+    if (da >= 0) {
+      dst[out * 3] = src[ai];
+      dst[out * 3 + 1] = src[ai + 1];
+      dst[out * 3 + 2] = src[ai + 2];
+      out++;
+    }
+    if ((da > 0 && db < 0) || (da < 0 && db > 0)) {
+      const denom = da - db;
+      let t = Math.abs(denom) > 1e-12 ? da / denom : 0;
+      if (!(t > 0)) t = 0;
+      else if (t > 1) t = 1;
+      dst[out * 3] = src[ai] + (src[bi] - src[ai]) * t;
+      dst[out * 3 + 1] = src[ai + 1] + (src[bi + 1] - src[ai + 1]) * t;
+      dst[out * 3 + 2] = src[ai + 2] + (src[bi + 2] - src[ai + 2]) * t;
+      out++;
+    }
+  }
+  return out;
+}
+
+/** Fan-triangulate and accumulate `a.x * f(centroid)`, where `f` is the linear
+ *  weight of the region this polygon was clipped into. */
+function accumulate(
+  poly: Float64Array,
+  count: number,
+  constant: number,
+  perZ: number,
+  perX: number,
+): number {
+  if (count < 3) return 0;
+  let sum = 0;
+  const p0x = poly[0];
+  const p0y = poly[1];
+  const p0z = poly[2];
+  for (let i = 1; i + 1 < count; i++) {
+    const ii = i * 3;
+    const ji = (i + 1) * 3;
+    const uy = poly[ii + 1] - p0y;
+    const uz = poly[ii + 2] - p0z;
+    const vy = poly[ji + 1] - p0y;
+    const vz = poly[ji + 2] - p0z;
+    const ax = 0.5 * (uy * vz - uz * vy);
+    if (ax === 0) continue;
+    const cx = (p0x + poly[ii] + poly[ji]) / 3;
+    const cz = (p0z + poly[ii + 2] + poly[ji + 2]) / 3;
+    sum += ax * (constant + perX * cx + perZ * cz);
+  }
+  return sum;
+}
+
+/** Integrate one trapezoid's contribution over one already-transformed
+ *  triangle held in `SCRATCH_A`. */
+function accumulateTrapezoid(trap: Trapezoid, minY: number, maxY: number): number {
+  let count = clipPlane(SCRATCH_A, 3, SCRATCH_B, 0, 1, 0, maxY);
+  if (count < 3) return 0;
+  count = clipPlane(SCRATCH_B, count, SCRATCH_A, 0, -1, 0, -minY);
+  if (count < 3) return 0;
+  count = clipPlane(SCRATCH_A, count, SCRATCH_B, 0, 0, 1, trap.z1);
+  if (count < 3) return 0;
+  count = clipPlane(SCRATCH_B, count, SCRATCH_A, 0, 0, -1, -trap.z0);
+  if (count < 3) return 0;
+
+  // Keep only x >= lo(z), i.e. -(x - bLo*z) <= -aLo. Below it the field is
+  // zero, so the region contributes nothing at all.
+  count = clipPlane(SCRATCH_A, count, SCRATCH_B, -1, 0, trap.bLo, -trap.aLo);
+  if (count < 3) return 0;
+
+  // Split at hi(z): inside the chord the weight is `x - lo(z)`; beyond it the
+  // weight is the whole chord width `hi(z) - lo(z)`, which is how a face on the
+  // far side accounts for the material it shadows. A polygon lying exactly on
+  // the split plane must go to ONE side: Sutherland-Hodgman would keep it whole
+  // on both and double that face's contribution, and a face sitting precisely
+  // on a zone boundary is the common case in a tiling plan, not an edge case.
+  let minD = Infinity;
+  let maxD = -Infinity;
+  for (let i = 0; i < count; i++) {
+    const d = SCRATCH_B[i * 3] - (trap.aHi + trap.bHi * SCRATCH_B[i * 3 + 2]);
+    if (d < minD) minD = d;
+    if (d > maxD) maxD = d;
+  }
+  const inside = (): number => accumulate(SCRATCH_A, count, -trap.aLo, -trap.bLo, 1);
+  if (maxD <= 0) {
+    SCRATCH_A.set(SCRATCH_B.subarray(0, count * 3));
+    return inside();
+  }
+  if (minD >= 0) {
+    SCRATCH_A.set(SCRATCH_B.subarray(0, count * 3));
+    return accumulate(SCRATCH_A, count, trap.aHi - trap.aLo, trap.bHi - trap.bLo, 0);
+  }
+  const near = clipPlane(SCRATCH_B, count, SCRATCH_A, 1, 0, -trap.bHi, trap.aHi);
+  let sum = accumulate(SCRATCH_A, near, -trap.aLo, -trap.bLo, 1);
+  const far = clipPlane(SCRATCH_B, count, SCRATCH_A, -1, 0, trap.bHi, -trap.aHi);
+  sum += accumulate(SCRATCH_A, far, trap.aHi - trap.aLo, trap.bHi - trap.bLo, 0);
+  return sum;
+}
+
+/**
+ * Volume (cubic metres) of the closed mesh `pieces` inside `prism`.
+ *
+ * Signed exactly as the mesh's own volume is, like
+ * `clippedVolumeForZone`: a globally inward-wound mesh yields a negative number
+ * here AND a negative whole volume, and their ratio is still right.
+ */
+export function clippedVolumeForPrism(pieces: readonly ElementMeshPiece[], prism: CompiledPrism): number {
+  if (prism.traps.length === 0) return 0;
+  let vol = 0;
+  for (const piece of pieces) {
+    const positions = piece.positions;
+    const indices = piece.indices;
+    const ox = piece.origin?.[0] ?? 0;
+    const oy = piece.origin?.[1] ?? 0;
+    const oz = piece.origin?.[2] ?? 0;
+
+    for (let t = 0; t + 2 < indices.length; t += 3) {
+      let degenerate = false;
+      let allAboveY = true, allBelowY = true, allBelowX = true, allBelowZ = true, allAboveZ = true;
+      for (let k = 0; k < 3; k++) {
+        const vi = indices[t + k] * 3;
+        const x = positions[vi] + ox;
+        const y = positions[vi + 1] + oy;
+        const z = positions[vi + 2] + oz;
+        if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) {
+          degenerate = true;
+          break;
+        }
+        SCRATCH_A[k * 3] = x;
+        SCRATCH_A[k * 3 + 1] = y;
+        SCRATCH_A[k * 3 + 2] = z;
+        if (y < prism.maxY) allAboveY = false;
+        if (y > prism.minY) allBelowY = false;
+        if (x > prism.minX) allBelowX = false;
+        if (z > prism.minZ) allBelowZ = false;
+        if (z < prism.maxZ) allAboveZ = false;
+      }
+      // Nothing is rejected for lying beyond maxX: that region carries the
+      // full-chord weight and is exactly how a far face accounts for the
+      // material between it and the prism.
+      if (degenerate || allAboveY || allBelowY || allBelowX || allBelowZ || allAboveZ) continue;
+
+      const x0 = SCRATCH_A[0], y0 = SCRATCH_A[1], z0 = SCRATCH_A[2];
+      const x1 = SCRATCH_A[3], y1 = SCRATCH_A[4], z1 = SCRATCH_A[5];
+      const x2 = SCRATCH_A[6], y2 = SCRATCH_A[7], z2 = SCRATCH_A[8];
+      for (const trap of prism.traps) {
+        // Each trapezoid clips the ORIGINAL triangle: the scratch buffer is
+        // overwritten by the previous strip's clipping.
+        SCRATCH_A[0] = x0; SCRATCH_A[1] = y0; SCRATCH_A[2] = z0;
+        SCRATCH_A[3] = x1; SCRATCH_A[4] = y1; SCRATCH_A[5] = z1;
+        SCRATCH_A[6] = x2; SCRATCH_A[7] = y2; SCRATCH_A[8] = z2;
+        vol += accumulateTrapezoid(trap, prism.minY, prism.maxY);
+      }
+    }
+  }
+  return vol;
+}

--- a/apps/viewer/src/lib/zones/prism.test.ts
+++ b/apps/viewer/src/lib/zones/prism.test.ts
@@ -1,0 +1,220 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Prism zones (#2508 item 4).
+ *
+ * The strongest test here is not a hand-computed number, it is the ORACLE: a
+ * rectangular footprint is a box, so the prism integrator and the box
+ * integrator must agree to the last bits on every fixture. They share no code
+ * (different decomposition, different clip, different weights), so agreement is
+ * evidence rather than tautology. The hand-computed cases then pin the cases a
+ * box cannot express at all.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import {
+  clippedVolumeForPrism,
+  compilePrism,
+  footprintOverlapsRect,
+  isConvexFootprint,
+  isPointInFootprint,
+  trapezoidsOfFootprint,
+  type FootprintPoint,
+} from './prism.js';
+import { clippedVolumeForZone, meshVolume } from './apportionment.js';
+import { compileZone } from './geometry.js';
+import type { Zone } from './types.js';
+
+interface Mesh {
+  positions: Float64Array;
+  indices: Uint32Array;
+}
+
+/** Extrude a positively-wound loop from y0 to y1. Same convention as
+ *  `apportionment.test.ts`, deliberately: the two files' fixtures have to be
+ *  comparable for the oracle below to mean anything. */
+function extrudeLoop(loop: Array<[number, number]>, y0: number, y1: number): Mesh {
+  const area = loop.reduce((a, [x0, z0], i) => {
+    const [x1, z1] = loop[(i + 1) % loop.length];
+    return a + (x0 * z1 - x1 * z0);
+  }, 0) / 2;
+  const l = area < 0 ? [...loop].reverse() : loop;
+  const out: number[] = [];
+  const n = l.length;
+  for (let i = 0; i < n; i++) {
+    const [xa, za] = l[i];
+    const [xb, zb] = l[(i + 1) % n];
+    out.push(xa, y0, za, xa, y1, za, xb, y1, zb);
+    out.push(xa, y0, za, xb, y1, zb, xb, y0, zb);
+  }
+  const [x0, z0] = l[0];
+  for (let i = 1; i + 1 < n; i++) {
+    const [xa, za] = l[i];
+    const [xb, zb] = l[i + 1];
+    out.push(x0, y0, z0, xa, y0, za, xb, y0, zb);
+    out.push(x0, y1, z0, xb, y1, zb, xa, y1, za);
+  }
+  const indices = new Uint32Array(out.length / 3);
+  for (let i = 0; i < indices.length; i++) indices[i] = i;
+  return { positions: new Float64Array(out), indices };
+}
+
+/** A 6 x 1 x 1 m wall from x = 0..6, z = 0..1, y = 0..1. Volume 6. */
+function wall(): Mesh {
+  return extrudeLoop([[0, 0], [6, 0], [6, 1], [0, 1]], 0, 1);
+}
+
+const EPS = 1e-9;
+
+describe('footprint validation', () => {
+  it('accepts a convex polygon and one with collinear vertices', () => {
+    assert.equal(isConvexFootprint([[0, 0], [2, 0], [2, 2], [0, 2]]), true);
+    // Collinear points are common in a polygon traced off a plan.
+    assert.equal(isConvexFootprint([[0, 0], [1, 0], [2, 0], [2, 2], [0, 2]]), true);
+  });
+
+  it('rejects a concave polygon, which every test below would silently mis-answer', () => {
+    // An L. The chord at some z is TWO intervals, so the trapezoidal sweep, the
+    // point test and the SAT overlap are all wrong for it, quietly.
+    assert.equal(isConvexFootprint([[0, 0], [3, 0], [3, 1], [1, 1], [1, 3], [0, 3]]), false);
+  });
+
+  it('rejects degenerate input rather than treating it as a zone', () => {
+    assert.equal(isConvexFootprint([[0, 0], [1, 1]]), false);
+    assert.equal(isConvexFootprint([[0, 0], [1, 1], [2, 2]]), false, 'a line has no area');
+    assert.equal(isConvexFootprint([[0, 0], [1, 0], [Number.NaN, 1]]), false);
+  });
+});
+
+describe('trapezoidal decomposition', () => {
+  it('gives one strip for a rectangle and two for a diamond', () => {
+    assert.equal(trapezoidsOfFootprint([[0, 0], [2, 0], [2, 2], [0, 2]]).length, 1);
+    // A diamond has a vertex at mid-height on each side, so the sweep breaks
+    // there: below it the chord widens, above it it narrows.
+    assert.equal(trapezoidsOfFootprint([[1, 0], [2, 1], [1, 2], [0, 1]]).length, 2);
+  });
+
+  it('reports the chord lines of a strip, not just its bounds', () => {
+    // The diamond's lower strip runs from the apex at (1,0) outward: lo(z) =
+    // 1 - z and hi(z) = 1 + z.
+    const [lower] = trapezoidsOfFootprint([[1, 0], [2, 1], [1, 2], [0, 1]]);
+    assert.ok(Math.abs(lower.aLo - 1) < EPS && Math.abs(lower.bLo + 1) < EPS, `lo = ${lower.aLo} + ${lower.bLo}z`);
+    assert.ok(Math.abs(lower.aHi - 1) < EPS && Math.abs(lower.bHi - 1) < EPS, `hi = ${lower.aHi} + ${lower.bHi}z`);
+  });
+});
+
+describe('point and rectangle tests', () => {
+  const diamond: FootprintPoint[] = [[1, 0], [2, 1], [1, 2], [0, 1]];
+
+  it('places a point by the polygon, not by its bounding box', () => {
+    assert.equal(isPointInFootprint(1, 1, diamond), true);
+    // Inside the diamond's AABB, outside the diamond: the corner a box zone
+    // would wrongly include.
+    assert.equal(isPointInFootprint(0.1, 0.1, diamond), false);
+  });
+
+  it('overlaps a rectangle by the polygon, not by its bounding box', () => {
+    assert.equal(footprintOverlapsRect(0.9, 0.9, 1.1, 1.1, diamond), true);
+    assert.equal(footprintOverlapsRect(-0.5, -0.5, 0.2, 0.2, diamond), false);
+  });
+
+  it('honours a negative epsilon as a penetration requirement, like the box path', () => {
+    const square: FootprintPoint[] = [[0, 0], [2, 0], [2, 2], [0, 2]];
+    // Abutting exactly on x = 2: inclusive by default, not a straddle under
+    // v1's negative epsilon.
+    assert.equal(footprintOverlapsRect(2, 0, 3, 2, square), true);
+    assert.equal(footprintOverlapsRect(2, 0, 3, 2, square, -0.001), false);
+  });
+});
+
+describe('prism volume against the box path (oracle)', () => {
+  /** The same region as a box zone and as a rectangular footprint. */
+  function bothWays(zone: Zone): { box: number; prism: number } {
+    const pieces = [wall()];
+    const hx = zone.size[0] / 2;
+    const hz = zone.size[2] / 2;
+    const [cx, cy, cz] = zone.center;
+    const footprint: FootprintPoint[] = [
+      [cx - hx, cz - hz], [cx + hx, cz - hz], [cx + hx, cz + hz], [cx - hx, cz + hz],
+    ];
+    return {
+      box: clippedVolumeForZone(pieces, compileZone(zone)),
+      prism: clippedVolumeForPrism(
+        pieces,
+        compilePrism(footprint, cy - zone.size[1] / 2, cy + zone.size[1] / 2),
+      ),
+    };
+  }
+
+  const cases: Array<[string, Zone]> = [
+    ['a zone cutting the wall in two', { id: 'a', name: 'A', center: [1, 0.5, 0.5], size: [4, 4, 4], rotationY: 0 }],
+    ['a zone holding all of it', { id: 'b', name: 'B', center: [3, 0.5, 0.5], size: [20, 20, 20], rotationY: 0 }],
+    ['a zone holding none of it', { id: 'c', name: 'C', center: [50, 0.5, 0.5], size: [4, 4, 4], rotationY: 0 }],
+    ['a zone abutting its end exactly', { id: 'd', name: 'D', center: [9, 0.5, 0.5], size: [6, 4, 4], rotationY: 0 }],
+    ['a zone cutting it vertically', { id: 'e', name: 'E', center: [3, 0.25, 0.5], size: [20, 0.5, 4], rotationY: 0 }],
+  ];
+
+  for (const [label, zone] of cases) {
+    it(`agrees with the box integrator: ${label}`, () => {
+      const { box, prism } = bothWays(zone);
+      assert.ok(
+        Math.abs(box - prism) < 1e-12 * Math.max(1, Math.abs(box)),
+        `box ${box} vs prism ${prism}`,
+      );
+    });
+  }
+});
+
+describe('prism volume on shapes a box cannot express', () => {
+  it('takes a diagonal band by its own edges', () => {
+    // A 45-degree band 0.4 m wide across the wall, the same case #2508 uses to
+    // show an AABB estimate crediting 20% of a brace to a zone it never
+    // enters. As a footprint it is four points; the intersection with the
+    // 1 m-deep wall is a parallelogram of area 0.4 * sqrt(2) ... times the
+    // wall's 1 m height.
+    const c = 3;
+    const half = 0.4 / Math.SQRT2 / 2 * Math.SQRT2; // 0.2*sqrt(2) along x at z=0
+    const footprint: FootprintPoint[] = [
+      [c - 0.2 * Math.SQRT2, -1], [c + 0.2 * Math.SQRT2, -1],
+      [c + 0.2 * Math.SQRT2 + 2, 1], [c - 0.2 * Math.SQRT2 + 2, 1],
+    ];
+    void half;
+    const volume = clippedVolumeForPrism([wall()], compilePrism(footprint, -1, 2));
+    // The band's width along x is constant at 0.4*sqrt(2); it crosses the
+    // wall's full 1 m depth and 1 m height inside the wall's own x range.
+    assert.ok(Math.abs(volume - 0.4 * Math.SQRT2) < 1e-9, `diagonal band took ${volume}`);
+  });
+
+  it('sums to the whole across a footprint tiling, which is the invariant that matters', () => {
+    // Two triangles that tile the wall's plan exactly, sharing the diagonal.
+    const lower: FootprintPoint[] = [[-1, -1], [8, -1], [8, 2]];
+    const upper: FootprintPoint[] = [[-1, -1], [8, 2], [-1, 2]];
+    const pieces = [wall()];
+    const a = clippedVolumeForPrism(pieces, compilePrism(lower, -1, 2));
+    const b = clippedVolumeForPrism(pieces, compilePrism(upper, -1, 2));
+    const whole = meshVolume(pieces);
+    assert.ok(Math.abs(a + b - whole) < 1e-9, `${a} + ${b} != ${whole}`);
+    // ... and neither piece is the whole thing, or the test would pass on an
+    // integrator that ignored the footprint entirely.
+    assert.ok(a > 0.1 && b > 0.1, `degenerate split ${a} / ${b}`);
+  });
+
+  it('reports zero for a footprint the element never reaches', () => {
+    const away: FootprintPoint[] = [[100, 100], [102, 100], [102, 102]];
+    assert.equal(Math.abs(clippedVolumeForPrism([wall()], compilePrism(away, -1, 2))) < 1e-12, true);
+  });
+
+  it('is bounded above by the element, whatever the footprint', () => {
+    const huge: FootprintPoint[] = [[-100, -100], [100, -100], [100, 100], [-100, 100]];
+    const volume = clippedVolumeForPrism([wall()], compilePrism(huge, -100, 100));
+    assert.ok(Math.abs(volume - meshVolume([wall()])) < 1e-9, `got ${volume}`);
+  });
+
+  it('takes nothing from a prism whose vertical extent misses the element', () => {
+    const over: FootprintPoint[] = [[-1, -1], [8, -1], [8, 2], [-1, 2]];
+    assert.ok(Math.abs(clippedVolumeForPrism([wall()], compilePrism(over, 10, 12))) < 1e-12);
+  });
+});

--- a/apps/viewer/src/lib/zones/prism.test.ts
+++ b/apps/viewer/src/lib/zones/prism.test.ts
@@ -176,12 +176,10 @@ describe('prism volume on shapes a box cannot express', () => {
     // 1 m-deep wall is a parallelogram of area 0.4 * sqrt(2) ... times the
     // wall's 1 m height.
     const c = 3;
-    const half = 0.4 / Math.SQRT2 / 2 * Math.SQRT2; // 0.2*sqrt(2) along x at z=0
     const footprint: FootprintPoint[] = [
       [c - 0.2 * Math.SQRT2, -1], [c + 0.2 * Math.SQRT2, -1],
       [c + 0.2 * Math.SQRT2 + 2, 1], [c - 0.2 * Math.SQRT2 + 2, 1],
     ];
-    void half;
     const volume = clippedVolumeForPrism([wall()], compilePrism(footprint, -1, 2));
     // The band's width along x is constant at 0.4*sqrt(2); it crosses the
     // wall's full 1 m depth and 1 m height inside the wall's own x range.

--- a/apps/viewer/src/lib/zones/prism.test.ts
+++ b/apps/viewer/src/lib/zones/prism.test.ts
@@ -82,6 +82,23 @@ describe('footprint validation', () => {
     assert.equal(isConvexFootprint([[0, 0], [3, 0], [3, 1], [1, 1], [1, 3], [0, 3]]), false);
   });
 
+  it('rejects a self-intersecting star, which turns the same way at every vertex', () => {
+    // A pentagram traced point to point: every turn has the same sign, so a
+    // convexity test built on sign alone accepts it. The sweep would then find
+    // more than two spanning edges in a strip and silently report the volume of
+    // the HULL, which is the shape the user did not draw.
+    const pentagram: FootprintPoint[] = [
+      [0, 1], [0.588, -0.809], [-0.951, 0.309], [0.951, 0.309], [-0.588, -0.809],
+    ];
+    assert.equal(isConvexFootprint(pentagram), false);
+    // The convex pentagon through the same five outer points is still accepted,
+    // so the check rejects the crossing rather than the vertex count.
+    const pentagon: FootprintPoint[] = [
+      [0, 1], [0.951, 0.309], [0.588, -0.809], [-0.588, -0.809], [-0.951, 0.309],
+    ];
+    assert.equal(isConvexFootprint(pentagon), true);
+  });
+
   it('rejects degenerate input rather than treating it as a zone', () => {
     assert.equal(isConvexFootprint([[0, 0], [1, 1]]), false);
     assert.equal(isConvexFootprint([[0, 0], [1, 1], [2, 2]]), false, 'a line has no area');

--- a/apps/viewer/src/lib/zones/prism.ts
+++ b/apps/viewer/src/lib/zones/prism.ts
@@ -1,0 +1,459 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Zones that are not boxes (issue #2508 item 4): a vertical PRISM over a convex
+ * footprint.
+ *
+ * A box tiling covers most takt and section planning, which is why v1 shipped
+ * only boxes. What it does not cover is a plan drawn around the building rather
+ * than across it: an L-shaped pour, a wing, a crane radius. Those arrive as a
+ * polygon, and forcing them into an axis box either includes a neighbour's work
+ * or excludes your own.
+ *
+ * ## Why the same divergence trick still works, and how
+ *
+ * `apportionment-clip.ts` integrates the BOX's indicator function over the
+ * element's own boundary, which is what lets it produce an exact clipped volume
+ * with no cut, no cap and no boolean. The field it uses,
+ * `f = X_y * X_z * (clamp(x, x0, x1) - x0)`, is specific to a box only because
+ * `x0` and `x1` are constants there.
+ *
+ * Decompose the convex footprint into TRAPEZOIDS between consecutive vertex z
+ * values (a standard trapezoidal sweep). Inside one trapezoid the footprint's
+ * x-chord is bounded by two LINES, `lo(z) = aLo + bLo*z` and
+ * `hi(z) = aHi + bHi*z`, so the same field works with the constants replaced by
+ * those linear functions:
+ *
+ *     f = X_[y0,y1](y) * X_[z0,z1](z) * (clamp(x, lo(z), hi(z)) - lo(z))
+ *     div F = X_(trapezoidal prism)
+ *
+ * and the prism's volume is the sum over trapezoids, which tile the footprint
+ * with disjoint interiors. Two properties make this exact rather than
+ * approximate:
+ *
+ * - `f` is CONTINUOUS across the two slanted planes (it reaches 0 at `lo` and
+ *   `hi - lo` at `hi` from both sides), so those interfaces contribute nothing.
+ *   Across the y and z planes `f` does jump, but there `n` is perpendicular to
+ *   x and `F . n = 0`, exactly as in the box case.
+ * - Within each clipped region `f` is LINEAR in `(x, z)`, so its integral over a
+ *   polygon is the polygon's area times its value at the centroid. No
+ *   quadrature, no subdivision beyond the plane clips.
+ *
+ * The cost is `O(triangles x trapezoids)`, and a takt polygon has three to six
+ * trapezoids, so a prism zone costs a few times a box zone rather than a
+ * different order.
+ *
+ * ## Why the clip here is a general plane and the box's is not
+ *
+ * The two slanted planes are not axis-aligned, so this module carries its own
+ * `clipPlane`. It is deliberately NOT used to replace the box path's
+ * axis-aligned `clipHalfSpace`: that path is measured (44 to 52 us per element
+ * over 241 real straddlers) and every zone set that exists today goes through
+ * it. Generalising the hot loop to earn a shared function would trade a
+ * measured number for a tidier one.
+ */
+
+import type { ElementMeshPiece } from './apportionment-clip.js';
+
+/** A point of a footprint: world `[x, z]` metres. Y is the extrusion axis. */
+export type FootprintPoint = readonly [x: number, z: number];
+
+/**
+ * One strip of the trapezoidal decomposition: between `z0` and `z1` the
+ * footprint spans `x` from `aLo + bLo*z` to `aHi + bHi*z`.
+ */
+export interface Trapezoid {
+  z0: number;
+  z1: number;
+  aLo: number;
+  bLo: number;
+  aHi: number;
+  bHi: number;
+}
+
+/** A prism ready to integrate against. */
+export interface CompiledPrism {
+  minY: number;
+  maxY: number;
+  traps: Trapezoid[];
+  /** World bounds, for the same cheap reject the box path does first. */
+  minX: number;
+  maxX: number;
+  minZ: number;
+  maxZ: number;
+}
+
+/** Strips thinner than this contribute nothing and are skipped: they are the
+ *  degenerate output of two vertices at the same z, not real area. */
+const MIN_STRIP_M = 1e-12;
+
+/**
+ * Is `poly` convex and non-self-intersecting, walked in one consistent turn
+ * direction?
+ *
+ * Everything below (the chord being a single interval, exactly two edges
+ * crossing each strip, the SAT overlap test) is true for convex polygons and
+ * silently wrong for others, so this is a gate rather than a nicety. Collinear
+ * vertices are allowed: they are common in a polygon traced off a plan and they
+ * break nothing.
+ */
+export function isConvexFootprint(poly: readonly FootprintPoint[]): boolean {
+  if (poly.length < 3) return false;
+  if (!poly.every((p) => Number.isFinite(p[0]) && Number.isFinite(p[1]))) return false;
+  let sign = 0;
+  for (let i = 0; i < poly.length; i++) {
+    const a = poly[i];
+    const b = poly[(i + 1) % poly.length];
+    const c = poly[(i + 2) % poly.length];
+    const cross = (b[0] - a[0]) * (c[1] - b[1]) - (b[1] - a[1]) * (c[0] - b[0]);
+    if (Math.abs(cross) < 1e-12) continue;
+    const s = cross > 0 ? 1 : -1;
+    if (sign === 0) sign = s;
+    else if (s !== sign) return false;
+  }
+  // All cross products vanished: the "polygon" is a line, which has no area and
+  // cannot contain anything.
+  return sign !== 0;
+}
+
+/** Axis-aligned bounds of a footprint, `[minX, minZ, maxX, maxZ]`. */
+export function footprintBounds(poly: readonly FootprintPoint[]): [number, number, number, number] {
+  let minX = Infinity, minZ = Infinity, maxX = -Infinity, maxZ = -Infinity;
+  for (const [x, z] of poly) {
+    if (x < minX) minX = x;
+    if (z < minZ) minZ = z;
+    if (x > maxX) maxX = x;
+    if (z > maxZ) maxZ = z;
+  }
+  return [minX, minZ, maxX, maxZ];
+}
+
+/**
+ * Decompose a convex footprint into trapezoidal strips between consecutive
+ * vertex z values.
+ *
+ * Exactly two edges cross the interior of each strip in a convex polygon (one
+ * per chain), so each strip's chord is bounded by two lines. They are
+ * identified by evaluating every spanning edge at the strip's MIDPOINT rather
+ * than by chain-walking: the midpoint is strictly inside the strip, so the
+ * comparison cannot be decided by a shared endpoint.
+ */
+export function trapezoidsOfFootprint(poly: readonly FootprintPoint[]): Trapezoid[] {
+  const zs = [...new Set(poly.map((p) => p[1]))].sort((a, b) => a - b);
+  const traps: Trapezoid[] = [];
+  for (let i = 0; i + 1 < zs.length; i++) {
+    const z0 = zs[i];
+    const z1 = zs[i + 1];
+    if (z1 - z0 <= MIN_STRIP_M) continue;
+    const mid = (z0 + z1) / 2;
+    let lo: { a: number; b: number; x: number } | null = null;
+    let hi: { a: number; b: number; x: number } | null = null;
+    for (let e = 0; e < poly.length; e++) {
+      const [x1, za] = poly[e];
+      const [x2, zb] = poly[(e + 1) % poly.length];
+      if (za === zb) continue;
+      if (mid <= Math.min(za, zb) || mid >= Math.max(za, zb)) continue;
+      const b = (x2 - x1) / (zb - za);
+      const a = x1 - b * za;
+      const x = a + b * mid;
+      if (!lo || x < lo.x) lo = { a, b, x };
+      if (!hi || x > hi.x) hi = { a, b, x };
+    }
+    if (!lo || !hi || lo === hi) continue;
+    traps.push({ z0, z1, aLo: lo.a, bLo: lo.b, aHi: hi.a, bHi: hi.b });
+  }
+  return traps;
+}
+
+/**
+ * The single place a prism zone's box fields are derived from its footprint.
+ *
+ * `Zone.center` / `Zone.size` stay the footprint's bounding box (see the type's
+ * doc) so every bounds consumer keeps working. Deriving that in one function
+ * rather than at each entry point is what makes the invariant true rather than
+ * hoped for: an importer, a future drawing tool and a test would otherwise each
+ * compute it, and one of them would drift.
+ */
+export function normalizePrismBounds<T extends {
+  center: [number, number, number];
+  size: [number, number, number];
+  rotationY: number;
+  footprint?: ReadonlyArray<FootprintPoint>;
+}>(zone: T): T {
+  if (!zone.footprint) return zone;
+  const [minX, minZ, maxX, maxZ] = footprintBounds(zone.footprint);
+  return {
+    ...zone,
+    center: [(minX + maxX) / 2, zone.center[1], (minZ + maxZ) / 2],
+    size: [maxX - minX, zone.size[1], maxZ - minZ],
+    // Not a stored orientation: the footprint is already in world coordinates,
+    // so leaving a stale angle here would let a box-path consumer rotate a
+    // bounding box that is not rotated.
+    rotationY: 0,
+  };
+}
+
+/** Compile a prism zone for repeated integration. */
+export function compilePrism(
+  poly: readonly FootprintPoint[],
+  minY: number,
+  maxY: number,
+): CompiledPrism {
+  const [minX, minZ, maxX, maxZ] = footprintBounds(poly);
+  return { minY, maxY, traps: trapezoidsOfFootprint(poly), minX, maxX, minZ, maxZ };
+}
+
+/** Is `[x, z]` inside the convex footprint, within `eps` metres? */
+export function isPointInFootprint(x: number, z: number, poly: readonly FootprintPoint[], eps = 1e-6): boolean {
+  let positive = false;
+  let negative = false;
+  for (let i = 0; i < poly.length; i++) {
+    const a = poly[i];
+    const b = poly[(i + 1) % poly.length];
+    const ex = b[0] - a[0];
+    const ez = b[1] - a[1];
+    const len = Math.hypot(ex, ez);
+    if (len === 0) continue;
+    // Signed distance to the edge line, so `eps` is metres rather than an
+    // area-scaled cross product that means something different per polygon.
+    const d = ((x - a[0]) * ez - (z - a[1]) * ex) / len;
+    if (d > eps) positive = true;
+    if (d < -eps) negative = true;
+  }
+  return !(positive && negative);
+}
+
+/**
+ * Does the world AABB `[minX, minZ] .. [maxX, maxZ]` overlap the footprint?
+ *
+ * 2D separating-axis test between two convex polygons: the rectangle's two axes
+ * plus the footprint's edge normals. `eps`'s sign means what it means in
+ * `zoneOverlapsAABBCompiled`: positive is inclusive (touching counts), negative
+ * demands that much real penetration, which is how v1 keeps a tiling zone set
+ * from flagging every boundary-abutting element as a straddler.
+ */
+export function footprintOverlapsRect(
+  minX: number,
+  minZ: number,
+  maxX: number,
+  maxZ: number,
+  poly: readonly FootprintPoint[],
+  eps = 1e-6,
+): boolean {
+  const [pMinX, pMinZ, pMaxX, pMaxZ] = footprintBounds(poly);
+  if (pMinX > maxX + eps || pMaxX < minX - eps) return false;
+  if (pMinZ > maxZ + eps || pMaxZ < minZ - eps) return false;
+
+  for (let i = 0; i < poly.length; i++) {
+    const a = poly[i];
+    const b = poly[(i + 1) % poly.length];
+    const ex = b[0] - a[0];
+    const ez = b[1] - a[1];
+    const len = Math.hypot(ex, ez);
+    if (len === 0) continue;
+    const nx = ez / len;
+    const nz = -ex / len;
+    let polyMin = Infinity;
+    let polyMax = -Infinity;
+    for (const [px, pz] of poly) {
+      const p = px * nx + pz * nz;
+      if (p < polyMin) polyMin = p;
+      if (p > polyMax) polyMax = p;
+    }
+    // The rectangle's extent on this axis, in closed form.
+    const cx = (minX + maxX) / 2;
+    const cz = (minZ + maxZ) / 2;
+    const hx = (maxX - minX) / 2;
+    const hz = (maxZ - minZ) / 2;
+    const centre = cx * nx + cz * nz;
+    const radius = Math.abs(nx) * hx + Math.abs(nz) * hz;
+    if (centre - radius > polyMax + eps || centre + radius < polyMin - eps) return false;
+  }
+  return true;
+}
+
+/** Scratch polygons. A triangle clipped by six planes has at most nine
+ *  vertices; twelve is headroom, and module scope keeps the loop allocation
+ *  free, as in the box path. */
+const SCRATCH_A = new Float64Array(12 * 3);
+const SCRATCH_B = new Float64Array(12 * 3);
+
+/**
+ * Clip a polygon against `nx*x + ny*y + nz*z <= d`, writing to `dst`.
+ *
+ * The general-plane counterpart of the box path's axis-aligned clip. The edge
+ * parameter is clamped behind a denominator guard for the same reason it is
+ * there: without it a near-coincident plane extrapolates the cut vertex off the
+ * end of the edge (#1155).
+ */
+function clipPlane(
+  src: Float64Array,
+  srcCount: number,
+  dst: Float64Array,
+  nx: number,
+  ny: number,
+  nz: number,
+  d: number,
+): number {
+  let out = 0;
+  for (let i = 0; i < srcCount; i++) {
+    const ai = i * 3;
+    const bi = ((i + 1) % srcCount) * 3;
+    const da = d - (nx * src[ai] + ny * src[ai + 1] + nz * src[ai + 2]);
+    const db = d - (nx * src[bi] + ny * src[bi + 1] + nz * src[bi + 2]);
+    if (da >= 0) {
+      dst[out * 3] = src[ai];
+      dst[out * 3 + 1] = src[ai + 1];
+      dst[out * 3 + 2] = src[ai + 2];
+      out++;
+    }
+    if ((da > 0 && db < 0) || (da < 0 && db > 0)) {
+      const denom = da - db;
+      let t = Math.abs(denom) > 1e-12 ? da / denom : 0;
+      if (!(t > 0)) t = 0;
+      else if (t > 1) t = 1;
+      dst[out * 3] = src[ai] + (src[bi] - src[ai]) * t;
+      dst[out * 3 + 1] = src[ai + 1] + (src[bi + 1] - src[ai + 1]) * t;
+      dst[out * 3 + 2] = src[ai + 2] + (src[bi + 2] - src[ai + 2]) * t;
+      out++;
+    }
+  }
+  return out;
+}
+
+/** Fan-triangulate and accumulate `a.x * f(centroid)`, where `f` is the linear
+ *  weight of the region this polygon was clipped into. */
+function accumulate(
+  poly: Float64Array,
+  count: number,
+  constant: number,
+  perZ: number,
+  perX: number,
+): number {
+  if (count < 3) return 0;
+  let sum = 0;
+  const p0x = poly[0];
+  const p0y = poly[1];
+  const p0z = poly[2];
+  for (let i = 1; i + 1 < count; i++) {
+    const ii = i * 3;
+    const ji = (i + 1) * 3;
+    const uy = poly[ii + 1] - p0y;
+    const uz = poly[ii + 2] - p0z;
+    const vy = poly[ji + 1] - p0y;
+    const vz = poly[ji + 2] - p0z;
+    const ax = 0.5 * (uy * vz - uz * vy);
+    if (ax === 0) continue;
+    const cx = (p0x + poly[ii] + poly[ji]) / 3;
+    const cz = (p0z + poly[ii + 2] + poly[ji + 2]) / 3;
+    sum += ax * (constant + perX * cx + perZ * cz);
+  }
+  return sum;
+}
+
+/** Integrate one trapezoid's contribution over one already-transformed
+ *  triangle held in `SCRATCH_A`. */
+function accumulateTrapezoid(trap: Trapezoid, minY: number, maxY: number): number {
+  let count = clipPlane(SCRATCH_A, 3, SCRATCH_B, 0, 1, 0, maxY);
+  if (count < 3) return 0;
+  count = clipPlane(SCRATCH_B, count, SCRATCH_A, 0, -1, 0, -minY);
+  if (count < 3) return 0;
+  count = clipPlane(SCRATCH_A, count, SCRATCH_B, 0, 0, 1, trap.z1);
+  if (count < 3) return 0;
+  count = clipPlane(SCRATCH_B, count, SCRATCH_A, 0, 0, -1, -trap.z0);
+  if (count < 3) return 0;
+
+  // Keep only x >= lo(z), i.e. -(x - bLo*z) <= -aLo. Below it the field is
+  // zero, so the region contributes nothing at all.
+  count = clipPlane(SCRATCH_A, count, SCRATCH_B, -1, 0, trap.bLo, -trap.aLo);
+  if (count < 3) return 0;
+
+  // Split at hi(z): inside the chord the weight is `x - lo(z)`; beyond it the
+  // weight is the whole chord width `hi(z) - lo(z)`, which is how a face on the
+  // far side accounts for the material it shadows. A polygon lying exactly on
+  // the split plane must go to ONE side: Sutherland-Hodgman would keep it whole
+  // on both and double that face's contribution, and a face sitting precisely
+  // on a zone boundary is the common case in a tiling plan, not an edge case.
+  let minD = Infinity;
+  let maxD = -Infinity;
+  for (let i = 0; i < count; i++) {
+    const d = SCRATCH_B[i * 3] - (trap.aHi + trap.bHi * SCRATCH_B[i * 3 + 2]);
+    if (d < minD) minD = d;
+    if (d > maxD) maxD = d;
+  }
+  const inside = (): number => accumulate(SCRATCH_A, count, -trap.aLo, -trap.bLo, 1);
+  if (maxD <= 0) {
+    SCRATCH_A.set(SCRATCH_B.subarray(0, count * 3));
+    return inside();
+  }
+  if (minD >= 0) {
+    SCRATCH_A.set(SCRATCH_B.subarray(0, count * 3));
+    return accumulate(SCRATCH_A, count, trap.aHi - trap.aLo, trap.bHi - trap.bLo, 0);
+  }
+  const near = clipPlane(SCRATCH_B, count, SCRATCH_A, 1, 0, -trap.bHi, trap.aHi);
+  let sum = accumulate(SCRATCH_A, near, -trap.aLo, -trap.bLo, 1);
+  const far = clipPlane(SCRATCH_B, count, SCRATCH_A, -1, 0, trap.bHi, -trap.aHi);
+  sum += accumulate(SCRATCH_A, far, trap.aHi - trap.aLo, trap.bHi - trap.bLo, 0);
+  return sum;
+}
+
+/**
+ * Volume (cubic metres) of the closed mesh `pieces` inside `prism`.
+ *
+ * Signed exactly as the mesh's own volume is, like
+ * `clippedVolumeForZone`: a globally inward-wound mesh yields a negative number
+ * here AND a negative whole volume, and their ratio is still right.
+ */
+export function clippedVolumeForPrism(pieces: readonly ElementMeshPiece[], prism: CompiledPrism): number {
+  if (prism.traps.length === 0) return 0;
+  let vol = 0;
+  for (const piece of pieces) {
+    const positions = piece.positions;
+    const indices = piece.indices;
+    const ox = piece.origin?.[0] ?? 0;
+    const oy = piece.origin?.[1] ?? 0;
+    const oz = piece.origin?.[2] ?? 0;
+
+    for (let t = 0; t + 2 < indices.length; t += 3) {
+      let degenerate = false;
+      let allAboveY = true, allBelowY = true, allBelowX = true, allBelowZ = true, allAboveZ = true;
+      for (let k = 0; k < 3; k++) {
+        const vi = indices[t + k] * 3;
+        const x = positions[vi] + ox;
+        const y = positions[vi + 1] + oy;
+        const z = positions[vi + 2] + oz;
+        if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) {
+          degenerate = true;
+          break;
+        }
+        SCRATCH_A[k * 3] = x;
+        SCRATCH_A[k * 3 + 1] = y;
+        SCRATCH_A[k * 3 + 2] = z;
+        if (y < prism.maxY) allAboveY = false;
+        if (y > prism.minY) allBelowY = false;
+        if (x > prism.minX) allBelowX = false;
+        if (z > prism.minZ) allBelowZ = false;
+        if (z < prism.maxZ) allAboveZ = false;
+      }
+      // Nothing is rejected for lying beyond maxX: that region carries the
+      // full-chord weight and is exactly how a far face accounts for the
+      // material between it and the prism.
+      if (degenerate || allAboveY || allBelowY || allBelowX || allBelowZ || allAboveZ) continue;
+
+      const x0 = SCRATCH_A[0], y0 = SCRATCH_A[1], z0 = SCRATCH_A[2];
+      const x1 = SCRATCH_A[3], y1 = SCRATCH_A[4], z1 = SCRATCH_A[5];
+      const x2 = SCRATCH_A[6], y2 = SCRATCH_A[7], z2 = SCRATCH_A[8];
+      for (const trap of prism.traps) {
+        // Each trapezoid clips the ORIGINAL triangle: the scratch buffer is
+        // overwritten by the previous strip's clipping.
+        SCRATCH_A[0] = x0; SCRATCH_A[1] = y0; SCRATCH_A[2] = z0;
+        SCRATCH_A[3] = x1; SCRATCH_A[4] = y1; SCRATCH_A[5] = z1;
+        SCRATCH_A[6] = x2; SCRATCH_A[7] = y2; SCRATCH_A[8] = z2;
+        vol += accumulateTrapezoid(trap, prism.minY, prism.maxY);
+      }
+    }
+  }
+  return vol;
+}

--- a/apps/viewer/src/lib/zones/prism.ts
+++ b/apps/viewer/src/lib/zones/prism.ts
@@ -55,8 +55,6 @@
  * measured number for a tidier one.
  */
 
-import type { ElementMeshPiece } from './apportionment-clip.js';
-
 /** A point of a footprint: world `[x, z]` metres. Y is the extrusion axis. */
 export type FootprintPoint = readonly [x: number, z: number];
 
@@ -103,19 +101,29 @@ export function isConvexFootprint(poly: readonly FootprintPoint[]): boolean {
   if (poly.length < 3) return false;
   if (!poly.every((p) => Number.isFinite(p[0]) && Number.isFinite(p[1]))) return false;
   let sign = 0;
+  let turn = 0;
   for (let i = 0; i < poly.length; i++) {
     const a = poly[i];
     const b = poly[(i + 1) % poly.length];
     const c = poly[(i + 2) % poly.length];
     const cross = (b[0] - a[0]) * (c[1] - b[1]) - (b[1] - a[1]) * (c[0] - b[0]);
+    const dot = (b[0] - a[0]) * (c[0] - b[0]) + (b[1] - a[1]) * (c[1] - b[1]);
+    turn += Math.atan2(cross, dot);
     if (Math.abs(cross) < 1e-12) continue;
     const s = cross > 0 ? 1 : -1;
     if (sign === 0) sign = s;
     else if (s !== sign) return false;
   }
-  // All cross products vanished: the "polygon" is a line, which has no area and
-  // cannot contain anything.
-  return sign !== 0;
+  // `sign !== 0`: all cross products vanished, so the "polygon" is a line, which
+  // has no area and cannot contain anything.
+  //
+  // The TURNING NUMBER is what makes this a self-intersection test rather than
+  // only a convexity test. A star polygon (a pentagram traced point to point)
+  // turns the same way at every vertex, so the sign check alone accepts it,
+  // and `trapezoidsOfFootprint` then finds more than two spanning edges in a
+  // strip and silently reports the volume of the HULL. A simple polygon turns
+  // exactly once; a star turns twice or more.
+  return sign !== 0 && Math.abs(Math.abs(turn) - 2 * Math.PI) < 1e-6;
 }
 
 /** Axis-aligned bounds of a footprint, `[minX, minZ, maxX, maxZ]`. */
@@ -274,186 +282,8 @@ export function footprintOverlapsRect(
   return true;
 }
 
-/** Scratch polygons. A triangle clipped by six planes has at most nine
- *  vertices; twelve is headroom, and module scope keeps the loop allocation
- *  free, as in the box path. */
-const SCRATCH_A = new Float64Array(12 * 3);
-const SCRATCH_B = new Float64Array(12 * 3);
-
-/**
- * Clip a polygon against `nx*x + ny*y + nz*z <= d`, writing to `dst`.
- *
- * The general-plane counterpart of the box path's axis-aligned clip. The edge
- * parameter is clamped behind a denominator guard for the same reason it is
- * there: without it a near-coincident plane extrapolates the cut vertex off the
- * end of the edge (#1155).
- */
-function clipPlane(
-  src: Float64Array,
-  srcCount: number,
-  dst: Float64Array,
-  nx: number,
-  ny: number,
-  nz: number,
-  d: number,
-): number {
-  let out = 0;
-  for (let i = 0; i < srcCount; i++) {
-    const ai = i * 3;
-    const bi = ((i + 1) % srcCount) * 3;
-    const da = d - (nx * src[ai] + ny * src[ai + 1] + nz * src[ai + 2]);
-    const db = d - (nx * src[bi] + ny * src[bi + 1] + nz * src[bi + 2]);
-    if (da >= 0) {
-      dst[out * 3] = src[ai];
-      dst[out * 3 + 1] = src[ai + 1];
-      dst[out * 3 + 2] = src[ai + 2];
-      out++;
-    }
-    if ((da > 0 && db < 0) || (da < 0 && db > 0)) {
-      const denom = da - db;
-      let t = Math.abs(denom) > 1e-12 ? da / denom : 0;
-      if (!(t > 0)) t = 0;
-      else if (t > 1) t = 1;
-      dst[out * 3] = src[ai] + (src[bi] - src[ai]) * t;
-      dst[out * 3 + 1] = src[ai + 1] + (src[bi + 1] - src[ai + 1]) * t;
-      dst[out * 3 + 2] = src[ai + 2] + (src[bi + 2] - src[ai + 2]) * t;
-      out++;
-    }
-  }
-  return out;
-}
-
-/** Fan-triangulate and accumulate `a.x * f(centroid)`, where `f` is the linear
- *  weight of the region this polygon was clipped into. */
-function accumulate(
-  poly: Float64Array,
-  count: number,
-  constant: number,
-  perZ: number,
-  perX: number,
-): number {
-  if (count < 3) return 0;
-  let sum = 0;
-  const p0x = poly[0];
-  const p0y = poly[1];
-  const p0z = poly[2];
-  for (let i = 1; i + 1 < count; i++) {
-    const ii = i * 3;
-    const ji = (i + 1) * 3;
-    const uy = poly[ii + 1] - p0y;
-    const uz = poly[ii + 2] - p0z;
-    const vy = poly[ji + 1] - p0y;
-    const vz = poly[ji + 2] - p0z;
-    const ax = 0.5 * (uy * vz - uz * vy);
-    if (ax === 0) continue;
-    const cx = (p0x + poly[ii] + poly[ji]) / 3;
-    const cz = (p0z + poly[ii + 2] + poly[ji + 2]) / 3;
-    sum += ax * (constant + perX * cx + perZ * cz);
-  }
-  return sum;
-}
-
-/** Integrate one trapezoid's contribution over one already-transformed
- *  triangle held in `SCRATCH_A`. */
-function accumulateTrapezoid(trap: Trapezoid, minY: number, maxY: number): number {
-  let count = clipPlane(SCRATCH_A, 3, SCRATCH_B, 0, 1, 0, maxY);
-  if (count < 3) return 0;
-  count = clipPlane(SCRATCH_B, count, SCRATCH_A, 0, -1, 0, -minY);
-  if (count < 3) return 0;
-  count = clipPlane(SCRATCH_A, count, SCRATCH_B, 0, 0, 1, trap.z1);
-  if (count < 3) return 0;
-  count = clipPlane(SCRATCH_B, count, SCRATCH_A, 0, 0, -1, -trap.z0);
-  if (count < 3) return 0;
-
-  // Keep only x >= lo(z), i.e. -(x - bLo*z) <= -aLo. Below it the field is
-  // zero, so the region contributes nothing at all.
-  count = clipPlane(SCRATCH_A, count, SCRATCH_B, -1, 0, trap.bLo, -trap.aLo);
-  if (count < 3) return 0;
-
-  // Split at hi(z): inside the chord the weight is `x - lo(z)`; beyond it the
-  // weight is the whole chord width `hi(z) - lo(z)`, which is how a face on the
-  // far side accounts for the material it shadows. A polygon lying exactly on
-  // the split plane must go to ONE side: Sutherland-Hodgman would keep it whole
-  // on both and double that face's contribution, and a face sitting precisely
-  // on a zone boundary is the common case in a tiling plan, not an edge case.
-  let minD = Infinity;
-  let maxD = -Infinity;
-  for (let i = 0; i < count; i++) {
-    const d = SCRATCH_B[i * 3] - (trap.aHi + trap.bHi * SCRATCH_B[i * 3 + 2]);
-    if (d < minD) minD = d;
-    if (d > maxD) maxD = d;
-  }
-  const inside = (): number => accumulate(SCRATCH_A, count, -trap.aLo, -trap.bLo, 1);
-  if (maxD <= 0) {
-    SCRATCH_A.set(SCRATCH_B.subarray(0, count * 3));
-    return inside();
-  }
-  if (minD >= 0) {
-    SCRATCH_A.set(SCRATCH_B.subarray(0, count * 3));
-    return accumulate(SCRATCH_A, count, trap.aHi - trap.aLo, trap.bHi - trap.bLo, 0);
-  }
-  const near = clipPlane(SCRATCH_B, count, SCRATCH_A, 1, 0, -trap.bHi, trap.aHi);
-  let sum = accumulate(SCRATCH_A, near, -trap.aLo, -trap.bLo, 1);
-  const far = clipPlane(SCRATCH_B, count, SCRATCH_A, -1, 0, trap.bHi, -trap.aHi);
-  sum += accumulate(SCRATCH_A, far, trap.aHi - trap.aLo, trap.bHi - trap.bLo, 0);
-  return sum;
-}
-
-/**
- * Volume (cubic metres) of the closed mesh `pieces` inside `prism`.
- *
- * Signed exactly as the mesh's own volume is, like
- * `clippedVolumeForZone`: a globally inward-wound mesh yields a negative number
- * here AND a negative whole volume, and their ratio is still right.
- */
-export function clippedVolumeForPrism(pieces: readonly ElementMeshPiece[], prism: CompiledPrism): number {
-  if (prism.traps.length === 0) return 0;
-  let vol = 0;
-  for (const piece of pieces) {
-    const positions = piece.positions;
-    const indices = piece.indices;
-    const ox = piece.origin?.[0] ?? 0;
-    const oy = piece.origin?.[1] ?? 0;
-    const oz = piece.origin?.[2] ?? 0;
-
-    for (let t = 0; t + 2 < indices.length; t += 3) {
-      let degenerate = false;
-      let allAboveY = true, allBelowY = true, allBelowX = true, allBelowZ = true, allAboveZ = true;
-      for (let k = 0; k < 3; k++) {
-        const vi = indices[t + k] * 3;
-        const x = positions[vi] + ox;
-        const y = positions[vi + 1] + oy;
-        const z = positions[vi + 2] + oz;
-        if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) {
-          degenerate = true;
-          break;
-        }
-        SCRATCH_A[k * 3] = x;
-        SCRATCH_A[k * 3 + 1] = y;
-        SCRATCH_A[k * 3 + 2] = z;
-        if (y < prism.maxY) allAboveY = false;
-        if (y > prism.minY) allBelowY = false;
-        if (x > prism.minX) allBelowX = false;
-        if (z > prism.minZ) allBelowZ = false;
-        if (z < prism.maxZ) allAboveZ = false;
-      }
-      // Nothing is rejected for lying beyond maxX: that region carries the
-      // full-chord weight and is exactly how a far face accounts for the
-      // material between it and the prism.
-      if (degenerate || allAboveY || allBelowY || allBelowX || allBelowZ || allAboveZ) continue;
-
-      const x0 = SCRATCH_A[0], y0 = SCRATCH_A[1], z0 = SCRATCH_A[2];
-      const x1 = SCRATCH_A[3], y1 = SCRATCH_A[4], z1 = SCRATCH_A[5];
-      const x2 = SCRATCH_A[6], y2 = SCRATCH_A[7], z2 = SCRATCH_A[8];
-      for (const trap of prism.traps) {
-        // Each trapezoid clips the ORIGINAL triangle: the scratch buffer is
-        // overwritten by the previous strip's clipping.
-        SCRATCH_A[0] = x0; SCRATCH_A[1] = y0; SCRATCH_A[2] = z0;
-        SCRATCH_A[3] = x1; SCRATCH_A[4] = y1; SCRATCH_A[5] = z1;
-        SCRATCH_A[6] = x2; SCRATCH_A[7] = y2; SCRATCH_A[8] = z2;
-        vol += accumulateTrapezoid(trap, prism.minY, prism.maxY);
-      }
-    }
-  }
-  return vol;
-}
+// The integrator lives in `./prism-clip.js` (the same seam `apportionment.ts`
+// has with `apportionment-clip.ts`). Re-exported so a caller asks this module
+// for "the volume of an element inside a prism" without needing to know which
+// half of the pair computes it.
+export { clippedVolumeForPrism } from './prism-clip.js';

--- a/apps/viewer/src/lib/zones/split.test.ts
+++ b/apps/viewer/src/lib/zones/split.test.ts
@@ -48,7 +48,7 @@ function piece(origin: [number, number, number], offset = 0) {
  *  around it is what the assertions see. */
 function fakeSplit(
   pieces: Array<{ zoneIndex: number; positions: number[]; volume: number }>,
-  options: { wholeVolume?: number; sumErrorRel?: number; onFree?: () => void } = {},
+  options: { wholeVolume?: number; sumErrorRel?: number; remainderFailed?: boolean; onFree?: () => void } = {},
 ): { fn: SplitMeshByZonesFn; calls: Array<{ positions: Float64Array; zones: Float64Array }> } {
   const calls: Array<{ positions: Float64Array; zones: Float64Array }> = [];
   const fn: SplitMeshByZonesFn = (positions, _indices, zones) => {
@@ -57,6 +57,7 @@ function fakeSplit(
       pieceCount: pieces.length,
       wholeVolume: options.wholeVolume ?? 1,
       sumErrorRel: options.sumErrorRel ?? 0,
+      remainderFailed: options.remainderFailed ?? false,
       piece(index: number): ZoneSplitPieceHandle | undefined {
         const p = pieces[index];
         if (!p) return undefined;
@@ -146,6 +147,27 @@ describe('splitElementByZones', () => {
     const { fn } = fakeSplit(
       [{ zoneIndex: 0, positions: [0, 0, 0, 1, 0, 0, 0, 1, 0], volume: 5 }],
       { sumErrorRel: 0.5 },
+    );
+    assert.equal(splitElementByZones(fn, [piece([0, 0, 0])], [ZONE]), null);
+  });
+
+  it('refuses a split whose sum error is NaN rather than publishing it', () => {
+    // `NaN > tolerance` is false, so a naive comparison PASSES the one report a
+    // degenerate or unclosed solid actually produces.
+    const { fn } = fakeSplit(
+      [{ zoneIndex: 0, positions: [0, 0, 0, 1, 0, 0, 0, 1, 0], volume: 5 }],
+      { sumErrorRel: Number.NaN },
+    );
+    assert.equal(splitElementByZones(fn, [piece([0, 0, 0])], [ZONE]), null);
+  });
+
+  it('refuses when the kernel could not build the remainder', () => {
+    // The pieces can add up perfectly and still be missing the part of the
+    // element inside no zone. Publishing them deletes real volume from a
+    // per-section model while every number left in the result looks right.
+    const { fn } = fakeSplit(
+      [{ zoneIndex: 0, positions: [0, 0, 0, 1, 0, 0, 0, 1, 0], volume: 5 }],
+      { sumErrorRel: 0, remainderFailed: true },
     );
     assert.equal(splitElementByZones(fn, [piece([0, 0, 0])], [ZONE]), null);
   });

--- a/apps/viewer/src/lib/zones/split.test.ts
+++ b/apps/viewer/src/lib/zones/split.test.ts
@@ -78,14 +78,25 @@ function fakeSplit(
 describe('flattenZones', () => {
   it('writes seven numbers per zone, sizes as full extents', () => {
     const flat = flattenZones([ZONE]);
-    assert.equal(flat.length, ZONE_STRIDE);
-    assert.deepEqual([...flat], [1, 2, 3, 4, 5, 6, 0.5]);
+    assert.equal(flat.zones.length, ZONE_STRIDE);
+    assert.deepEqual([...flat.zones], [1, 2, 3, 4, 5, 6, 0.5]);
+    assert.deepEqual([...flat.footprintCounts], [0], 'a box must not claim footprint points');
   });
 
   it('keeps zone order, so a piece\'s zoneIndex means what the caller thinks', () => {
     const second: Zone = { ...ZONE, id: 'z-b', center: [9, 9, 9] };
     const flat = flattenZones([ZONE, second]);
-    assert.equal(flat[ZONE_STRIDE], 9);
+    assert.equal(flat.zones[ZONE_STRIDE], 9);
+  });
+
+  it('carries a prism\'s footprint alongside, index-aligned by its point count', () => {
+    // The counts array is what lets the binding find each zone's points
+    // without an offset table, so a box between two prisms must contribute a
+    // zero rather than nothing.
+    const prism: Zone = { ...ZONE, id: 'z-p', footprint: [[0, 0], [1, 0], [1, 1]] };
+    const flat = flattenZones([ZONE, prism, ZONE]);
+    assert.deepEqual([...flat.footprintCounts], [0, 3, 0]);
+    assert.deepEqual([...flat.footprints], [0, 0, 1, 0, 1, 1]);
   });
 });
 

--- a/apps/viewer/src/lib/zones/split.test.ts
+++ b/apps/viewer/src/lib/zones/split.test.ts
@@ -1,0 +1,174 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The viewer half of the zone geometry split (#2508 item 2).
+ *
+ * The cutting itself is the Rust kernel's and is tested there (hand-computable
+ * fractions, rotated zones, degenerate input) plus across the real wasm
+ * boundary in `scripts/test-wasm-contract.mjs`. What is testable HERE, and is
+ * where this half can go wrong quietly, is the frame arithmetic: the renderer
+ * stores positions relative to a per-mesh origin and zones are absolute, so an
+ * unfolded origin produces a split that is correct and in the wrong place.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  flattenZones,
+  foldPiecesToWorld,
+  flatNormals,
+  splitElementByZones,
+  ZONE_STRIDE,
+  type SplitMeshByZonesFn,
+  type ZoneSplitHandle,
+  type ZoneSplitPieceHandle,
+} from './split.js';
+import type { Zone } from './types.js';
+
+const ZONE: Zone = {
+  id: 'z-a',
+  name: 'Takt A',
+  center: [1, 2, 3],
+  size: [4, 5, 6],
+  rotationY: 0.5,
+};
+
+/** A single triangle, stored relative to `origin`. */
+function piece(origin: [number, number, number], offset = 0) {
+  return {
+    positions: new Float32Array([offset, 0, 0, 1 + offset, 0, 0, 0, 1, 0]),
+    indices: new Uint32Array([0, 1, 2]),
+    origin,
+  };
+}
+
+/** A fake binding whose output is fully controlled, so the frame arithmetic
+ *  around it is what the assertions see. */
+function fakeSplit(
+  pieces: Array<{ zoneIndex: number; positions: number[]; volume: number }>,
+  options: { wholeVolume?: number; sumErrorRel?: number; onFree?: () => void } = {},
+): { fn: SplitMeshByZonesFn; calls: Array<{ positions: Float64Array; zones: Float64Array }> } {
+  const calls: Array<{ positions: Float64Array; zones: Float64Array }> = [];
+  const fn: SplitMeshByZonesFn = (positions, _indices, zones) => {
+    calls.push({ positions, zones });
+    const handle: ZoneSplitHandle = {
+      pieceCount: pieces.length,
+      wholeVolume: options.wholeVolume ?? 1,
+      sumErrorRel: options.sumErrorRel ?? 0,
+      piece(index: number): ZoneSplitPieceHandle | undefined {
+        const p = pieces[index];
+        if (!p) return undefined;
+        return {
+          zoneIndex: p.zoneIndex,
+          positions: Float64Array.from(p.positions),
+          indices: Uint32Array.from(p.positions.map((_, i) => i / 3).filter((v) => Number.isInteger(v))),
+          volume: p.volume,
+          free: () => { options.onFree?.(); },
+        };
+      },
+      free: () => { options.onFree?.(); },
+    };
+    return handle;
+  };
+  return { fn, calls };
+}
+
+describe('flattenZones', () => {
+  it('writes seven numbers per zone, sizes as full extents', () => {
+    const flat = flattenZones([ZONE]);
+    assert.equal(flat.length, ZONE_STRIDE);
+    assert.deepEqual([...flat], [1, 2, 3, 4, 5, 6, 0.5]);
+  });
+
+  it('keeps zone order, so a piece\'s zoneIndex means what the caller thinks', () => {
+    const second: Zone = { ...ZONE, id: 'z-b', center: [9, 9, 9] };
+    const flat = flattenZones([ZONE, second]);
+    assert.equal(flat[ZONE_STRIDE], 9);
+  });
+});
+
+describe('foldPiecesToWorld', () => {
+  it('folds each piece\'s own origin in, not the first piece\'s', () => {
+    // Submeshes of one element can carry different origins. Folding them all
+    // with the first origin would move every later submesh.
+    const world = foldPiecesToWorld([piece([10, 0, 0]), piece([0, 20, 0])]);
+    assert.equal(world.positions[0], 10, 'first piece not at its own origin');
+    assert.equal(world.positions[10], 20, 'second piece folded with the wrong origin');
+  });
+
+  it('offsets indices so concatenated submeshes still index their own vertices', () => {
+    const world = foldPiecesToWorld([piece([0, 0, 0]), piece([0, 0, 0], 5)]);
+    assert.deepEqual([...world.indices], [0, 1, 2, 3, 4, 5]);
+  });
+
+  it('reports the origin it will take back out', () => {
+    assert.deepEqual(foldPiecesToWorld([piece([7, 8, 9])]).origin, [7, 8, 9]);
+  });
+});
+
+describe('splitElementByZones', () => {
+  it('hands the binding ABSOLUTE coordinates and takes the origin back out', () => {
+    // The whole point of the fold/unfold pair: zones are absolute, the
+    // renderer is origin-relative, and the output has to go back to the
+    // renderer's frame or a far-from-origin model collapses in f32.
+    const { fn, calls } = fakeSplit([{ zoneIndex: 0, positions: [1000, 0, 0, 1001, 0, 0, 1000, 1, 0], volume: 1 }]);
+    const result = splitElementByZones(fn, [piece([1000, 0, 0])], [ZONE]);
+
+    assert.ok(result);
+    assert.equal(calls[0].positions[0], 1000, 'the binding was given relative coordinates');
+    assert.equal(result.pieces[0].positions[0], 0, 'the origin was not taken back out');
+    assert.deepEqual(result.pieces[0].origin, [1000, 0, 0]);
+  });
+
+  it('maps the remainder\'s -1 to null rather than to zone zero', () => {
+    const { fn } = fakeSplit([{ zoneIndex: -1, positions: [0, 0, 0, 1, 0, 0, 0, 1, 0], volume: 2 }]);
+    const result = splitElementByZones(fn, [piece([0, 0, 0])], [ZONE]);
+    assert.equal(result?.pieces[0].zoneIndex, null);
+  });
+
+  it('refuses the whole split when the pieces do not sum to the whole', () => {
+    // A per-section model whose sections do not add up to the building is
+    // worse than none, because it looks finished. The expected cause is zones
+    // that overlap each other.
+    const { fn } = fakeSplit(
+      [{ zoneIndex: 0, positions: [0, 0, 0, 1, 0, 0, 0, 1, 0], volume: 5 }],
+      { sumErrorRel: 0.5 },
+    );
+    assert.equal(splitElementByZones(fn, [piece([0, 0, 0])], [ZONE]), null);
+  });
+
+  it('frees the wasm handle even when the split is refused', () => {
+    let freed = 0;
+    const { fn } = fakeSplit(
+      [{ zoneIndex: 0, positions: [0, 0, 0, 1, 0, 0, 0, 1, 0], volume: 5 }],
+      { sumErrorRel: 0.5, onFree: () => { freed++; } },
+    );
+    splitElementByZones(fn, [piece([0, 0, 0])], [ZONE]);
+    assert.ok(freed > 0, 'a refused split leaked its handle');
+  });
+
+  it('does not call the binding at all when there is nothing to split', () => {
+    const { fn, calls } = fakeSplit([]);
+    assert.equal(splitElementByZones(fn, [], [ZONE]), null);
+    assert.equal(splitElementByZones(fn, [piece([0, 0, 0])], []), null);
+    assert.equal(calls.length, 0);
+  });
+});
+
+describe('flatNormals', () => {
+  it('gives every vertex of a triangle its own face normal, unit length', () => {
+    const positions = new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]);
+    const normals = flatNormals(positions, new Uint32Array([0, 1, 2]));
+    assert.deepEqual([...normals], [0, 0, 1, 0, 0, 1, 0, 0, 1]);
+  });
+
+  it('falls back rather than emitting NaN for a degenerate triangle', () => {
+    // A zero-area triangle has no normal. NaN would propagate into the GLB and
+    // render as a black hole rather than as nothing.
+    const positions = new Float32Array([0, 0, 0, 0, 0, 0, 0, 0, 0]);
+    const normals = flatNormals(positions, new Uint32Array([0, 1, 2]));
+    assert.ok([...normals].every(Number.isFinite));
+  });
+});

--- a/apps/viewer/src/lib/zones/split.ts
+++ b/apps/viewer/src/lib/zones/split.ts
@@ -46,6 +46,9 @@ export interface ZoneSplitHandle {
   readonly pieceCount: number;
   readonly wholeVolume: number;
   readonly sumErrorRel: number;
+  /** The remainder could not be built. Distinct from a raised `sumErrorRel`:
+   *  that one means the zones overlap, this one means volume is MISSING. */
+  readonly remainderFailed: boolean;
   piece(index: number): ZoneSplitPieceHandle | undefined;
   free(): void;
 }
@@ -202,7 +205,14 @@ export function splitElementByZones(
   const flat = flattenZones(zones);
   const handle = split(positions, indices, flat.zones, flat.footprints, flat.footprintCounts);
   try {
-    if (handle.sumErrorRel > tolerance) return null;
+    // Inverted rather than `> tolerance`, so a NaN report REFUSES: `NaN >
+    // tolerance` is false, and NaN is exactly what a degenerate or unclosed
+    // solid produces, which is the case this gate exists for.
+    if (!(handle.sumErrorRel <= tolerance)) return null;
+    // The part of the element inside no zone could not be built, so the pieces
+    // are not the whole element. Publishing them would delete real volume from
+    // a per-section model while every number left in the result looks right.
+    if (handle.remainderFailed) return null;
     const out: ZoneMeshPiece[] = [];
     for (let i = 0; i < handle.pieceCount; i++) {
       const piece = handle.piece(i);

--- a/apps/viewer/src/lib/zones/split.ts
+++ b/apps/viewer/src/lib/zones/split.ts
@@ -55,15 +55,31 @@ export type SplitMeshByZonesFn = (
   positions: Float64Array,
   indices: Uint32Array,
   zones: Float64Array,
+  footprints?: Float64Array,
+  footprintCounts?: Uint32Array,
 ) => ZoneSplitHandle;
 
 /** Seven numbers per zone, the order the binding documents. */
 export const ZONE_STRIDE = 7;
 
+/** Everything the binding needs to describe a zone set's shapes. */
+export interface FlatZones {
+  zones: Float64Array;
+  /** Every prism's footprint, `[x, z]` pairs concatenated in zone order. */
+  footprints: Float64Array;
+  /** Points per zone; `0` marks a box, so the two arrays stay index-aligned
+   *  with `zones` without a per-zone offset table. */
+  footprintCounts: Uint32Array;
+}
+
 /** Zones flattened for the binding: `[cx, cy, cz, sx, sy, sz, rotationY]` each,
- *  sizes as FULL extents, matching `Zone.size` rather than half-extents. */
-export function flattenZones(zones: readonly Zone[]): Float64Array {
+ *  sizes as FULL extents, matching `Zone.size` rather than half-extents. A
+ *  prism zone additionally contributes its footprint, and the binding then uses
+ *  the 7-tuple only for the vertical extent. */
+export function flattenZones(zones: readonly Zone[]): FlatZones {
   const out = new Float64Array(zones.length * ZONE_STRIDE);
+  const counts = new Uint32Array(zones.length);
+  const points: number[] = [];
   zones.forEach((zone, i) => {
     const b = i * ZONE_STRIDE;
     out[b] = zone.center[0];
@@ -73,8 +89,12 @@ export function flattenZones(zones: readonly Zone[]): Float64Array {
     out[b + 4] = zone.size[1];
     out[b + 5] = zone.size[2];
     out[b + 6] = zone.rotationY;
+    if (zone.footprint) {
+      counts[i] = zone.footprint.length;
+      for (const [x, z] of zone.footprint) points.push(x, z);
+    }
   });
-  return out;
+  return { zones: out, footprints: Float64Array.from(points), footprintCounts: counts };
 }
 
 /** One element's renderer pieces as a single absolute-world f64 mesh.
@@ -179,7 +199,8 @@ export function splitElementByZones(
   const { positions, indices, origin } = foldPiecesToWorld(pieces);
   if (indices.length === 0) return null;
 
-  const handle = split(positions, indices, flattenZones(zones));
+  const flat = flattenZones(zones);
+  const handle = split(positions, indices, flat.zones, flat.footprints, flat.footprintCounts);
   try {
     if (handle.sumErrorRel > tolerance) return null;
     const out: ZoneMeshPiece[] = [];

--- a/apps/viewer/src/lib/zones/split.ts
+++ b/apps/viewer/src/lib/zones/split.ts
@@ -1,0 +1,256 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Turning one element into one mesh per zone (issue #2508 item 2), around the
+ * Rust `splitMeshByZones` binding.
+ *
+ * #2515 answers "how much of this wall is in Takt A" with a number and produces
+ * no geometry. This produces the geometry, so a per-section model can be
+ * exported rather than described. It is a separate, explicit action for the
+ * reason the apportionment is: clipping is memory-bandwidth bound, so the only
+ * lever is doing less of it.
+ *
+ * The binding is INJECTED rather than imported here, exactly as
+ * `meshOutlineProvider` does for `meshOutline2d`: the wasm runtime is
+ * gitignored and absent in the node test runner, and a module that reached for
+ * it at import time could not be tested at all. Everything in this file except
+ * the one call is therefore ordinary arithmetic with a test around it.
+ *
+ * ## The frame, which is the part that goes wrong quietly
+ *
+ * The renderer stores each element's positions RELATIVE to a per-mesh origin
+ * (`MeshData.origin`), so building-scale coordinates stay f32-precise. Zones are
+ * authored in absolute world coordinates. So the split folds the origin in on
+ * the way down (f64, absolute) and takes it back out on the way up, which keeps
+ * the output exactly as f32-precise as the input was. Skipping the unfold would
+ * hand the GPU absolute metre coordinates in f32 and collapse a 5 km-away model
+ * onto a visible grid.
+ */
+
+import type { Zone } from './types.js';
+import type { ElementMeshPiece } from './apportionment.js';
+
+/** One solid of a split, as the wasm handle exposes it. */
+export interface ZoneSplitPieceHandle {
+  readonly zoneIndex: number;
+  readonly positions: Float64Array;
+  readonly indices: Uint32Array;
+  readonly volume: number;
+  free?(): void;
+}
+
+/** The wasm result handle. Freed by {@link splitElementByZones}. */
+export interface ZoneSplitHandle {
+  readonly pieceCount: number;
+  readonly wholeVolume: number;
+  readonly sumErrorRel: number;
+  piece(index: number): ZoneSplitPieceHandle | undefined;
+  free(): void;
+}
+
+/** The `splitMeshByZones` free function as exported by `@ifc-lite/wasm`. */
+export type SplitMeshByZonesFn = (
+  positions: Float64Array,
+  indices: Uint32Array,
+  zones: Float64Array,
+) => ZoneSplitHandle;
+
+/** Seven numbers per zone, the order the binding documents. */
+export const ZONE_STRIDE = 7;
+
+/** Zones flattened for the binding: `[cx, cy, cz, sx, sy, sz, rotationY]` each,
+ *  sizes as FULL extents, matching `Zone.size` rather than half-extents. */
+export function flattenZones(zones: readonly Zone[]): Float64Array {
+  const out = new Float64Array(zones.length * ZONE_STRIDE);
+  zones.forEach((zone, i) => {
+    const b = i * ZONE_STRIDE;
+    out[b] = zone.center[0];
+    out[b + 1] = zone.center[1];
+    out[b + 2] = zone.center[2];
+    out[b + 3] = zone.size[0];
+    out[b + 4] = zone.size[1];
+    out[b + 5] = zone.size[2];
+    out[b + 6] = zone.rotationY;
+  });
+  return out;
+}
+
+/** One element's renderer pieces as a single absolute-world f64 mesh.
+ *
+ *  Concatenating first is not an optimisation: the pieces of one element are
+ *  submeshes of ONE solid (a wall and its own reveals), and splitting each
+ *  separately would ask the kernel to close a surface that is only closed when
+ *  they are taken together. */
+export function foldPiecesToWorld(pieces: readonly ElementMeshPiece[]): {
+  positions: Float64Array;
+  indices: Uint32Array;
+  /** The origin taken out again on the way back, so the output keeps the
+   *  input's f32 precision. */
+  origin: [number, number, number];
+} {
+  let vertexCount = 0;
+  let indexCount = 0;
+  for (const p of pieces) {
+    vertexCount += p.positions.length / 3;
+    indexCount += p.indices.length;
+  }
+  const positions = new Float64Array(vertexCount * 3);
+  const indices = new Uint32Array(indexCount);
+  const origin: [number, number, number] = [
+    pieces[0]?.origin?.[0] ?? 0,
+    pieces[0]?.origin?.[1] ?? 0,
+    pieces[0]?.origin?.[2] ?? 0,
+  ];
+
+  let vertexBase = 0;
+  let indexBase = 0;
+  for (const p of pieces) {
+    const ox = p.origin?.[0] ?? 0;
+    const oy = p.origin?.[1] ?? 0;
+    const oz = p.origin?.[2] ?? 0;
+    const count = p.positions.length / 3;
+    for (let i = 0; i < count; i++) {
+      const s = (vertexBase + i) * 3;
+      const t = i * 3;
+      positions[s] = p.positions[t] + ox;
+      positions[s + 1] = p.positions[t + 1] + oy;
+      positions[s + 2] = p.positions[t + 2] + oz;
+    }
+    for (let i = 0; i < p.indices.length; i++) {
+      indices[indexBase + i] = p.indices[i] + vertexBase;
+    }
+    vertexBase += count;
+    indexBase += p.indices.length;
+  }
+  return { positions, indices, origin };
+}
+
+/** A piece of an element, expressed the way the renderer and the GLB exporter
+ *  already consume geometry. */
+export interface ZoneMeshPiece {
+  /** Index into the zone array that was split against, or `null` for the part
+   *  of the element in no zone. */
+  zoneIndex: number | null;
+  positions: Float32Array;
+  normals: Float32Array;
+  indices: Uint32Array;
+  origin: [number, number, number];
+  /** Enclosed volume of this piece, cubic metres. */
+  volumeM3: number;
+}
+
+export interface ElementSplit {
+  pieces: ZoneMeshPiece[];
+  wholeVolumeM3: number;
+  /** How far the pieces are from summing to the whole, relative. */
+  sumErrorRel: number;
+}
+
+/**
+ * Above this relative error, a split is not published.
+ *
+ * The pieces summing to the whole is the invariant #2508 puts above every other
+ * for this feature, and unlike the apportionment path the failure here is not
+ * subtle: the expected cause is zones that overlap each other, which
+ * double-counts entire fractions of an element. 1e-4 matches the apportionment
+ * tolerance, which was set from a measured f32-crack worst case of 3.4e-6 over
+ * 241 real straddlers.
+ */
+export const SPLIT_SUM_TOLERANCE_REL = 1e-4;
+
+/**
+ * Split one element's geometry by `zones`.
+ *
+ * Returns `null` when the element has no geometry, or when the pieces do not
+ * sum to the whole within {@link SPLIT_SUM_TOLERANCE_REL}. Refusing the whole
+ * split rather than publishing part of it is deliberate: a per-section model
+ * whose sections do not add up to the building is worse than no per-section
+ * model, because it looks finished.
+ */
+export function splitElementByZones(
+  split: SplitMeshByZonesFn,
+  pieces: readonly ElementMeshPiece[],
+  zones: readonly Zone[],
+  tolerance = SPLIT_SUM_TOLERANCE_REL,
+): ElementSplit | null {
+  if (pieces.length === 0 || zones.length === 0) return null;
+  const { positions, indices, origin } = foldPiecesToWorld(pieces);
+  if (indices.length === 0) return null;
+
+  const handle = split(positions, indices, flattenZones(zones));
+  try {
+    if (handle.sumErrorRel > tolerance) return null;
+    const out: ZoneMeshPiece[] = [];
+    for (let i = 0; i < handle.pieceCount; i++) {
+      const piece = handle.piece(i);
+      if (!piece) continue;
+      try {
+        out.push(toMeshPiece(piece, origin));
+      } finally {
+        piece.free?.();
+      }
+    }
+    return { pieces: out, wholeVolumeM3: handle.wholeVolume, sumErrorRel: handle.sumErrorRel };
+  } finally {
+    handle.free();
+  }
+}
+
+/** Absolute f64 kernel output back into the renderer's origin-relative f32
+ *  form, with flat per-face normals (the kernel emits an unwelded triangle
+ *  soup, so a shared-vertex normal would be meaningless). */
+function toMeshPiece(piece: ZoneSplitPieceHandle, origin: [number, number, number]): ZoneMeshPiece {
+  const src = piece.positions;
+  const positions = new Float32Array(src.length);
+  for (let i = 0; i < src.length; i += 3) {
+    positions[i] = src[i] - origin[0];
+    positions[i + 1] = src[i + 1] - origin[1];
+    positions[i + 2] = src[i + 2] - origin[2];
+  }
+  const indices = Uint32Array.from(piece.indices);
+  return {
+    zoneIndex: piece.zoneIndex < 0 ? null : piece.zoneIndex,
+    positions,
+    normals: flatNormals(positions, indices),
+    indices,
+    origin,
+    volumeM3: piece.volume,
+  };
+}
+
+/** Per-face normals, written to all three vertices of each triangle. */
+export function flatNormals(positions: Float32Array, indices: Uint32Array): Float32Array {
+  const normals = new Float32Array(positions.length);
+  for (let i = 0; i + 2 < indices.length; i += 3) {
+    const a = indices[i] * 3;
+    const b = indices[i + 1] * 3;
+    const c = indices[i + 2] * 3;
+    const ux = positions[b] - positions[a];
+    const uy = positions[b + 1] - positions[a + 1];
+    const uz = positions[b + 2] - positions[a + 2];
+    const vx = positions[c] - positions[a];
+    const vy = positions[c + 1] - positions[a + 1];
+    const vz = positions[c + 2] - positions[a + 2];
+    let nx = uy * vz - uz * vy;
+    let ny = uz * vx - ux * vz;
+    let nz = ux * vy - uy * vx;
+    const len = Math.hypot(nx, ny, nz);
+    if (len > 0) {
+      nx /= len;
+      ny /= len;
+      nz /= len;
+    } else {
+      nx = 0;
+      ny = 0;
+      nz = 1;
+    }
+    for (const v of [a, b, c]) {
+      normals[v] = nx;
+      normals[v + 1] = ny;
+      normals[v + 2] = nz;
+    }
+  }
+  return normals;
+}

--- a/apps/viewer/src/lib/zones/types.ts
+++ b/apps/viewer/src/lib/zones/types.ts
@@ -38,6 +38,23 @@ export interface Zone {
   /** Optional display colour (0-1 RGB). Falls back to the parent set's
    *  palette-derived colour when absent. */
   color?: [r: number, g: number, b: number];
+  /**
+   * Optional CONVEX footprint in world X/Z metres (issue #2508 item 4). When
+   * present the zone is a vertical PRISM over this polygon rather than a box:
+   * `center[1] +/- size[1]/2` is still its vertical extent, and `rotationY` is
+   * ignored because the polygon is already in world coordinates.
+   *
+   * `center` and `size` in X/Z stay the footprint's BOUNDING BOX, maintained by
+   * whoever writes the footprint (`normalizePrismBounds`). Every existing
+   * bounds consumer -- overlay culling, viewport framing, storey generation --
+   * therefore keeps working unchanged and merely over-approximates, and the
+   * exact tests refine it.
+   *
+   * Convexity is a REQUIREMENT, not a convention: the trapezoidal sweep, the
+   * point test and the separating-axis overlap are each silently wrong for a
+   * concave polygon. `isConvexFootprint` gates every entry point.
+   */
+  footprint?: ReadonlyArray<readonly [x: number, z: number]>;
 }
 
 /** A named, independent collection of zones (e.g. "Sections", "Takt areas").

--- a/apps/viewer/src/lib/zones/writeback.test.ts
+++ b/apps/viewer/src/lib/zones/writeback.test.ts
@@ -18,6 +18,7 @@ import {
 
 const MESH: ZoneWriteBackOptions = {
   zoneSetName: 'Takt areas',
+  zoneSetId: 'set-1',
   basis: 'mesh',
   volumeSiScale: 1,
 };
@@ -193,6 +194,7 @@ describe('zone write-back: the basis travels with the numbers', () => {
   it('records the declared quantity name and the as-built-split disclosure for a net basis', () => {
     const result = buildElementWriteBack(straddler({ quantityName: 'NetVolume' }), {
       zoneSetName: 'Sections',
+      zoneSetId: 'set-1',
       basis: 'net',
       volumeSiScale: 1,
     });
@@ -236,7 +238,7 @@ describe('zone write-back: refusals', () => {
     // prevent.
     const result = buildElementWriteBack(
       straddler({ shares: [], refusal: 'no-declared-quantity' }),
-      { zoneSetName: 'Sections', basis: 'net', volumeSiScale: 1 },
+      { zoneSetName: 'Sections', zoneSetId: 'set-1', basis: 'net', volumeSiScale: 1 },
     );
     assert.ok(result);
     assert.equal(result.qsetName, null);

--- a/apps/viewer/src/lib/zones/writeback.test.ts
+++ b/apps/viewer/src/lib/zones/writeback.test.ts
@@ -1,0 +1,280 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import {
+  buildElementWriteBack,
+  summarize,
+  zonePropertySetName,
+  zoneQuantitySetName,
+  OUTSIDE_QUANTITY_NAME,
+  UNNAMED_ZONE,
+  ZONE_PROPERTY_NAMES,
+  type ElementZoneFacts,
+  type ZoneWriteBackOptions,
+} from './writeback.js';
+
+const MESH: ZoneWriteBackOptions = {
+  zoneSetName: 'Takt areas',
+  basis: 'mesh',
+  volumeSiScale: 1,
+};
+
+/** A wall of 10 m3 split 4 / 6 across two takt areas, nothing outside. */
+function straddler(overrides: Partial<ElementZoneFacts> = {}): ElementZoneFacts {
+  return {
+    globalId: 42,
+    homeZoneName: 'Takt A',
+    touchedZoneNames: ['Takt A', 'Takt B'],
+    straddles: true,
+    shares: [
+      { zoneName: 'Takt A', valueM3: 4 },
+      { zoneName: 'Takt B', valueM3: 6 },
+    ],
+    outsideM3: 0,
+    refusal: null,
+    quantityName: null,
+    ...overrides,
+  };
+}
+
+function propValue(
+  result: NonNullable<ReturnType<typeof buildElementWriteBack>>,
+  name: string,
+): string | boolean | undefined {
+  return result.properties.find((p) => p.name === name)?.value;
+}
+
+describe('zone write-back: what lands on the element', () => {
+  it('names both sets after the zone set, and the quantity set after the basis too', () => {
+    const result = buildElementWriteBack(straddler(), MESH);
+    assert.ok(result);
+    assert.equal(result.psetName, 'IfcLite_Zones [Takt areas]');
+    assert.equal(result.qsetName, 'IfcLite_ZoneVolumes [Takt areas] (mesh)');
+    // The basis is in the NAME, so two bases written for the same set cannot
+    // merge into one column downstream.
+    assert.notEqual(
+      zoneQuantitySetName('Takt areas', 'net'),
+      zoneQuantitySetName('Takt areas', 'gross'),
+    );
+    assert.equal(zonePropertySetName('Takt areas'), 'IfcLite_Zones [Takt areas]');
+  });
+
+  it('carries the home zone, every touched zone, and the straddle flag', () => {
+    const result = buildElementWriteBack(straddler(), MESH);
+    assert.ok(result);
+    assert.equal(propValue(result, ZONE_PROPERTY_NAMES.zone), 'Takt A');
+    // ", " matches the Lists convention: `equals` excludes straddlers,
+    // `contains` includes them (#1869).
+    assert.equal(propValue(result, ZONE_PROPERTY_NAMES.zones), 'Takt A, Takt B');
+    assert.equal(propValue(result, ZONE_PROPERTY_NAMES.straddles), true);
+    assert.equal(propValue(result, ZONE_PROPERTY_NAMES.zoneSet), 'Takt areas');
+  });
+
+  it('writes an empty home zone rather than a sentinel when the centroid is in no zone', () => {
+    const result = buildElementWriteBack(
+      straddler({ homeZoneName: null }),
+      MESH,
+    );
+    assert.ok(result);
+    // Not '(none)' / '-' / 'None': any of those is a value a downstream filter
+    // cannot tell apart from a zone actually named that.
+    assert.equal(propValue(result, ZONE_PROPERTY_NAMES.zone), '');
+  });
+
+  it('writes nothing at all for an element in no zone of the set', () => {
+    const result = buildElementWriteBack(
+      straddler({ touchedZoneNames: [], shares: [], homeZoneName: null, straddles: false }),
+      MESH,
+    );
+    assert.equal(result, null);
+  });
+});
+
+describe('zone write-back: units', () => {
+  it('divides by the model\'s own VOLUMEUNIT scale, inverting the read path', () => {
+    // A file declaring cubic millimetres: siScale 1e-9. 4 m3 is 4e9 mm3, and
+    // writing "4" into it would state four cubic millimetres.
+    const result = buildElementWriteBack(straddler(), { ...MESH, volumeSiScale: 1e-9 });
+    assert.ok(result);
+    // Relative, not exact: 4 / 1e-9 is 3999999999.9999995 in f64. Pinning the
+    // exact bits would assert the order of one division rather than the unit
+    // conversion, which is what this is about.
+    assert.ok(Math.abs(result.quantities[0].value / 4e9 - 1) < 1e-12, `${result.quantities[0].value}`);
+    assert.ok(Math.abs(result.quantities[1].value / 6e9 - 1) < 1e-12, `${result.quantities[1].value}`);
+  });
+
+  it('falls back to 1 for a missing or nonsensical scale rather than producing NaN', () => {
+    for (const scale of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      const result = buildElementWriteBack(straddler(), { ...MESH, volumeSiScale: scale });
+      assert.ok(result, `scale ${scale}`);
+      assert.equal(result.quantities[0].value, 4, `scale ${scale}`);
+    }
+  });
+});
+
+describe('zone write-back: the numbers reconcile', () => {
+  it('quantities sum to the element whole, including the part in no zone', () => {
+    const facts = straddler({
+      shares: [
+        { zoneName: 'Takt A', valueM3: 4 },
+        { zoneName: 'Takt B', valueM3: 5 },
+      ],
+      outsideM3: 1,
+    });
+    const result = buildElementWriteBack(facts, MESH);
+    assert.ok(result);
+    const total = result.quantities.reduce((a, q) => a + q.value, 0);
+    assert.ok(Math.abs(total - 10) < 1e-9, `quantities summed to ${total}`);
+    assert.ok(result.quantities.some((q) => q.name === OUTSIDE_QUANTITY_NAME));
+  });
+
+  it('omits the outside row when the element is wholly inside the set', () => {
+    const result = buildElementWriteBack(straddler(), MESH);
+    assert.ok(result);
+    assert.ok(!result.quantities.some((q) => q.name === OUTSIDE_QUANTITY_NAME));
+  });
+
+  it('drops a zone whose share is clip noise rather than writing a nanolitre row', () => {
+    const result = buildElementWriteBack(
+      straddler({
+        shares: [
+          { zoneName: 'Takt A', valueM3: 10 },
+          { zoneName: 'Takt B', valueM3: 1e-17 },
+        ],
+      }),
+      MESH,
+    );
+    assert.ok(result);
+    assert.equal(result.quantities.length, 1);
+    assert.equal(result.quantities[0].name, 'Takt A');
+  });
+});
+
+describe('zone write-back: names that collide', () => {
+  it('disambiguates two zones sharing a name instead of losing one', () => {
+    // Zone names are free text and not unique-enforced (types.ts: ids
+    // disambiguate). Writing "Section 2" twice would silently replace the first
+    // quantity with the second, losing a whole zone's volume with no error.
+    const result = buildElementWriteBack(
+      straddler({
+        touchedZoneNames: ['Section 2', 'Section 2'],
+        shares: [
+          { zoneName: 'Section 2', valueM3: 4 },
+          { zoneName: 'Section 2', valueM3: 6 },
+        ],
+      }),
+      MESH,
+    );
+    assert.ok(result);
+    assert.deepEqual(result.quantities.map((q) => q.name), ['Section 2', 'Section 2 (2)']);
+    assert.deepEqual(result.quantities.map((q) => q.value), [4, 6]);
+  });
+
+  it('names a blank zone rather than writing an unaddressable empty quantity', () => {
+    const result = buildElementWriteBack(
+      straddler({
+        touchedZoneNames: ['  ', 'Takt B'],
+        shares: [
+          { zoneName: '  ', valueM3: 4 },
+          { zoneName: 'Takt B', valueM3: 6 },
+        ],
+      }),
+      MESH,
+    );
+    assert.ok(result);
+    assert.equal(result.quantities[0].name, UNNAMED_ZONE);
+  });
+});
+
+describe('zone write-back: the basis travels with the numbers', () => {
+  it('records the declared quantity name and the as-built-split disclosure for a net basis', () => {
+    const result = buildElementWriteBack(straddler({ quantityName: 'NetVolume' }), {
+      zoneSetName: 'Sections',
+      basis: 'net',
+      volumeSiScale: 1,
+    });
+    assert.ok(result);
+    assert.equal(propValue(result, ZONE_PROPERTY_NAMES.volumeBasis), 'net');
+    assert.equal(propValue(result, ZONE_PROPERTY_NAMES.volumeQuantity), 'NetVolume');
+    // The ratio was measured on the as-built mesh; applying it to a declared
+    // total is an approximation, and the file has to say so (#2199's rule).
+    assert.match(String(propValue(result, ZONE_PROPERTY_NAMES.volumeNote)), /as-built mesh/);
+  });
+
+  it('states no such disclosure for the mesh basis, which was measured directly', () => {
+    const result = buildElementWriteBack(straddler(), MESH);
+    assert.ok(result);
+    assert.equal(propValue(result, ZONE_PROPERTY_NAMES.volumeNote), undefined);
+    assert.equal(propValue(result, ZONE_PROPERTY_NAMES.volumeQuantity), undefined);
+  });
+});
+
+describe('zone write-back: refusals', () => {
+  it('writes the zone names and a stated reason, and no quantity set at all', () => {
+    const result = buildElementWriteBack(
+      straddler({ shares: [], refusal: 'unproved-solid' }),
+      MESH,
+    );
+    assert.ok(result);
+    assert.equal(result.qsetName, null);
+    assert.equal(result.quantities.length, 0);
+    // Still classified - the classification is geometric-AABB and did not need
+    // a proven solid.
+    assert.equal(propValue(result, ZONE_PROPERTY_NAMES.zones), 'Takt A, Takt B');
+    assert.match(String(propValue(result, ZONE_PROPERTY_NAMES.volumeUnavailable)), /proven closed solid/);
+    // A basis label on an element with no numbers would claim a measurement
+    // that was refused.
+    assert.equal(propValue(result, ZONE_PROPERTY_NAMES.volumeBasis), undefined);
+  });
+
+  it('refuses rather than silently falling back to the mesh when the basis is not declared', () => {
+    // Falling back would put a mesh number inside a quantity set NAMED net,
+    // which is precisely the mixed-basis confusion volume-basis.ts exists to
+    // prevent.
+    const result = buildElementWriteBack(
+      straddler({ shares: [], refusal: 'no-declared-quantity' }),
+      { zoneSetName: 'Sections', basis: 'net', volumeSiScale: 1 },
+    );
+    assert.ok(result);
+    assert.equal(result.qsetName, null);
+    assert.match(String(propValue(result, ZONE_PROPERTY_NAMES.volumeUnavailable)), /declares no volume quantity/);
+  });
+
+  it('distinguishes the federation-rescaled refusal, whose fix is elsewhere', () => {
+    const result = buildElementWriteBack(
+      straddler({ shares: [], refusal: 'rescaled-by-alignment' }),
+      MESH,
+    );
+    assert.ok(result);
+    assert.match(String(propValue(result, ZONE_PROPERTY_NAMES.volumeUnavailable)), /Federation alignment/);
+  });
+
+  it('writes the pset without a quantity set when every share was negligible', () => {
+    const result = buildElementWriteBack(
+      straddler({ shares: [{ zoneName: 'Takt A', valueM3: 0 }], outsideM3: 0 }),
+      MESH,
+    );
+    assert.ok(result);
+    assert.equal(result.qsetName, null);
+    assert.equal(propValue(result, ZONE_PROPERTY_NAMES.volumeBasis), undefined);
+  });
+});
+
+describe('zone write-back: run summary', () => {
+  it('counts written, volume-bearing, refused and skipped separately', () => {
+    const results = [
+      buildElementWriteBack(straddler(), MESH),
+      buildElementWriteBack(straddler({ shares: [], refusal: 'no-geometry' }), MESH),
+      buildElementWriteBack(straddler({ touchedZoneNames: [] }), MESH),
+    ];
+    assert.deepEqual(summarize(results), {
+      written: 2,
+      withVolumes: 1,
+      refused: 1,
+      skippedNoZone: 1,
+    });
+  });
+});

--- a/apps/viewer/src/lib/zones/writeback.ts
+++ b/apps/viewer/src/lib/zones/writeback.ts
@@ -118,6 +118,9 @@ export interface ElementZoneFacts {
 
 export interface ZoneWriteBackOptions {
   zoneSetName: string;
+  /** The set's stable id, written into the property set so a later run can
+   *  recognise its own output across a rename. */
+  zoneSetId: string;
   basis: VolumeBasis;
   /** The model's own VOLUMEUNIT scale to SI, from
    *  `ProjectUnits.resolvedForUnitType('VOLUMEUNIT').siScale`. Values are
@@ -154,6 +157,11 @@ export interface ElementWriteBack {
 /** Property names, exported so tests and the removal path name them once. */
 export const ZONE_PROPERTY_NAMES = {
   zoneSet: 'ZoneSet',
+  /** The set's stable id. Written so a later run can find what an EARLIER one
+   *  left on this element after the set was renamed: the set names carry the
+   *  display name, and matching on that alone orphans everything written under
+   *  the old one. Ids are what disambiguate a zone set (`types.ts`). */
+  zoneSetId: 'ZoneSetId',
   zone: 'Zone',
   zones: 'Zones',
   straddles: 'Straddles',
@@ -236,6 +244,7 @@ export function buildElementWriteBack(
 
   const properties: WriteBackProperty[] = [
     { name: ZONE_PROPERTY_NAMES.zoneSet, value: options.zoneSetName, kind: 'LABEL' },
+    { name: ZONE_PROPERTY_NAMES.zoneSetId, value: options.zoneSetId, kind: 'LABEL' },
     // Empty rather than a sentinel like "(none)": a straddler whose centroid
     // falls between zones genuinely has no home zone, and any placeholder string
     // is a value a filter cannot tell apart from a zone actually named that.

--- a/apps/viewer/src/lib/zones/writeback.ts
+++ b/apps/viewer/src/lib/zones/writeback.ts
@@ -1,0 +1,329 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Zone assignment as IFC data (issue #2508, item 3: "get zone data out of the
+ * viewer" - the pset write-back half).
+ *
+ * v1 and #2515 leave every zone number inside the viewer: store state, a JSON
+ * side file, and columns in Lists. None of that survives handing the model to
+ * someone else. This module turns one element's classification into the
+ * property set and quantity set an IFC export can carry, so the assignment
+ * travels with the file.
+ *
+ * It is PURE: it decides names, labels, units and collisions, and nothing else.
+ * Gathering the facts (which elements, which apportionment, which model) is the
+ * caller's job - see `hooks/useZoneWriteBack.ts`.
+ *
+ * ## Three rules this file exists to enforce
+ *
+ * 1. **Values are written in the FILE's units, not in metres.** Everything
+ *    upstream of here is SI cubic metres (the render frame is metres), but an
+ *    `IfcQuantityVolume` with no explicit unit is read in the project's declared
+ *    VOLUMEUNIT. Writing 3.4 into a file that declares cubic millimetres states
+ *    3.4 mm3. So every value divides by the model's own `volumeSiScale`, and
+ *    federated models are converted with their own scale rather than the active
+ *    one.
+ * 2. **The basis travels with the number** (#2199's convention, adopted by
+ *    `volume-basis.ts` and kept here): the quantity set NAMES the basis, and the
+ *    property set repeats it along with the declared quantity it came from, so a
+ *    net breakdown can never be mistaken for a gross one downstream.
+ * 3. **A refusal is written down, not omitted.** An element whose volume the
+ *    kernel would not prove gets its zone names and a stated reason, and no
+ *    quantities at all. A missing row reads as "zero"; a stated reason does not.
+ */
+
+import type { ApportionmentRefusal } from './apportionment-cache.js';
+import type { VolumeBasis } from './volume-basis.js';
+import { volumeBasisLabel, volumeBasisRatioNote } from './volume-basis.js';
+
+/**
+ * Prefix for both sets this module writes.
+ *
+ * NOT `Pset_` / `Qto_`: buildingSMART reserves those for its own published
+ * definitions, and "which takt area is this wall in" is not one of them. A
+ * vendor-prefixed name says where the data came from and cannot collide with a
+ * standard set a checker validates against.
+ */
+export const ZONE_SET_NAME_PREFIX = 'IfcLite_Zones';
+export const ZONE_QUANTITY_SET_NAME_PREFIX = 'IfcLite_ZoneVolumes';
+
+/** Property set name for one zone set, e.g. `IfcLite_Zones [Takt areas]`. */
+export function zonePropertySetName(zoneSetName: string): string {
+  return `${ZONE_SET_NAME_PREFIX} [${zoneSetName}]`;
+}
+
+/** Quantity set name for one zone set on one basis, e.g.
+ *  `IfcLite_ZoneVolumes [Takt areas] (net)`. The basis is IN THE NAME rather
+ *  than only in a sibling property: a spreadsheet that pivots on quantity-set
+ *  name would otherwise merge a net breakdown into a gross one silently. */
+export function zoneQuantitySetName(zoneSetName: string, basis: VolumeBasis): string {
+  return `${zoneQuantitySetPrefix(zoneSetName)}${volumeBasisLabel(basis)})`;
+}
+
+/**
+ * What every basis's quantity-set name for ONE zone set starts with.
+ *
+ * A run has to recognise the quantity sets a PREVIOUS run left on an element,
+ * on a different basis and therefore under a different name, to replace them
+ * rather than accumulate one set per basis ever chosen. Scoped to the zone set,
+ * so a run on "Sections" can never delete "Takt areas"'s numbers.
+ */
+export function zoneQuantitySetPrefix(zoneSetName: string): string {
+  return `${ZONE_QUANTITY_SET_NAME_PREFIX} [${zoneSetName}] (`;
+}
+
+/** Quantity name for the part of an element in no zone of the set. Written so
+ *  the quantities of one element sum to its whole volume - the reconciliation
+ *  invariant #2508 asks for, made checkable in the exported file itself. */
+export const OUTSIDE_QUANTITY_NAME = 'Outside zones';
+
+/** Zone name substituted when a user has cleared one. Never left blank: a blank
+ *  quantity name is not addressable in any downstream tool. */
+export const UNNAMED_ZONE = 'Unnamed zone';
+
+/** What the caller has established about one element, in SI. */
+export interface ElementZoneFacts {
+  /** Federated global id, resolved to model + expressId by the caller. */
+  globalId: number;
+  /** Name of the zone containing the element's centroid; `null` when its
+   *  centroid is in no zone of the set (it can still touch zones). */
+  homeZoneName: string | null;
+  /** Every zone the element reaches, in zone-set order. Empty means the element
+   *  belongs to this set not at all - those are skipped, not written blank. */
+  touchedZoneNames: readonly string[];
+  straddles: boolean;
+  /** Per-zone volume, SI cubic metres, on the basis named in the options. Empty
+   *  when no volume could be established. */
+  shares: ReadonlyArray<{ zoneName: string; valueM3: number }>;
+  /** SI cubic metres inside no zone of the set. */
+  outsideM3: number;
+  /** Why there are no volumes. `null` when `shares` is trustworthy - including
+   *  the legitimate case of an element wholly inside one zone, whose single
+   *  share is its whole volume and needed no clip. */
+  refusal: WriteBackRefusal | null;
+  /**
+   * The declared quantity these magnitudes came from (`NetVolume`,
+   * `NetSideVolume`, ...), or `null` for the `mesh` basis, which is measured.
+   *
+   * PER ELEMENT rather than per run, because one basis is not one quantity
+   * name: `volumeBasisFromQuantityName` reads both `NetVolume` and
+   * `NetSideVolume` as net, and a run that stamped a single name onto every
+   * element would misattribute the number for whichever elements carry the
+   * other one.
+   */
+  quantityName: string | null;
+}
+
+export interface ZoneWriteBackOptions {
+  zoneSetName: string;
+  basis: VolumeBasis;
+  /** The model's own VOLUMEUNIT scale to SI, from
+   *  `ProjectUnits.resolvedForUnitType('VOLUMEUNIT').siScale`. Values are
+   *  DIVIDED by it on the way in, inverting the multiplication
+   *  `declaredVolumeBases` does on the way out. */
+  volumeSiScale: number;
+}
+
+export type WriteBackPropertyKind = 'LABEL' | 'BOOLEAN';
+
+export interface WriteBackProperty {
+  name: string;
+  value: string | boolean;
+  kind: WriteBackPropertyKind;
+}
+
+export interface WriteBackQuantity {
+  name: string;
+  /** In the FILE's declared volume unit, ready to write. */
+  value: number;
+}
+
+/** Everything to write onto one element for one zone set. */
+export interface ElementWriteBack {
+  globalId: number;
+  psetName: string;
+  properties: WriteBackProperty[];
+  /** `null` when no volume could be stated - the pset still carries the zone
+   *  names and the reason. */
+  qsetName: string | null;
+  quantities: WriteBackQuantity[];
+}
+
+/** Property names, exported so tests and the removal path name them once. */
+export const ZONE_PROPERTY_NAMES = {
+  zoneSet: 'ZoneSet',
+  zone: 'Zone',
+  zones: 'Zones',
+  straddles: 'Straddles',
+  volumeBasis: 'VolumeBasis',
+  volumeQuantity: 'VolumeQuantityName',
+  volumeNote: 'VolumeNote',
+  volumeUnavailable: 'VolumeUnavailable',
+} as const;
+
+/**
+ * Why an element carries zone names but no volumes.
+ *
+ * The three geometric ones are `apportionment-cache.ts`'s, unchanged. The other
+ * two are this module's own and could not arise before write-back existed:
+ *
+ * - `no-declared-quantity` - a run on a DECLARED basis reaches elements whose
+ *   file declares no such quantity. Falling back to the mesh for those would put
+ *   two different bases in one quantity set under one basis name, the exact
+ *   confusion `volume-basis.ts` exists to prevent.
+ * - `overlapping-zones` - the set's own zones overlap, so the shares
+ *   double-count (`ElementApportionment.overlapping`). Each is individually
+ *   correct and their sum is not, which is fine in a panel that says so and not
+ *   fine in a quantity set, where a reader will add the rows up.
+ */
+export type WriteBackRefusal = ApportionmentRefusal | 'no-declared-quantity' | 'overlapping-zones';
+
+/** One sentence per refusal, written INTO the file rather than left to the
+ *  viewer. Whoever opens the export next does not have the zone panel. */
+const REFUSAL_TEXT: Record<WriteBackRefusal, string> = {
+  'no-geometry': 'No geometry was loaded for this element, so its volume could not be split.',
+  'unproved-solid': 'Its mesh is not a proven closed solid, so no volume can be stated for it.',
+  'rescaled-by-alignment':
+    'Federation alignment rescaled this element\'s model, so its proved volume does not describe the geometry that was split.',
+  'no-declared-quantity':
+    'This element declares no volume quantity on the requested basis, so no volume was written for it.',
+  'overlapping-zones':
+    'The zones of this set overlap each other, so the per-zone volumes would double-count and not add up to the whole.',
+};
+
+/** A zone name safe to use as a quantity name, with collisions resolved.
+ *
+ *  Zone names are free text and are NOT unique-enforced (`types.ts` says so
+ *  outright: ids disambiguate, names are convention). Two zones called "Section
+ *  2" would otherwise write one quantity name twice, and the second silently
+ *  replaces the first - a whole zone's volume vanishing with no error. The
+ *  suffix is positional and therefore stable for a given zone order. */
+function disambiguate(names: readonly string[]): string[] {
+  const used = new Map<string, number>();
+  return names.map((raw) => {
+    const base = raw.trim() === '' ? UNNAMED_ZONE : raw.trim();
+    const seen = used.get(base) ?? 0;
+    used.set(base, seen + 1);
+    return seen === 0 ? base : `${base} (${seen + 1})`;
+  });
+}
+
+/** Values below this many cubic metres are not written as a quantity row.
+ *  Matches `NEGLIGIBLE_SHARE_REL`'s intent one level up: a zone the element only
+ *  abuts contributes clip noise, and a nanolitre row in an exported file is
+ *  noise a reader has to discard by hand. */
+const NEGLIGIBLE_M3 = 1e-12;
+
+/**
+ * Build the write-back for one element.
+ *
+ * Returns `null` when the element belongs to no zone in this set - those get no
+ * property set at all. Writing "this element is in no zone" onto every element
+ * of a model would multiply the file's property sets by its element count to
+ * say nothing; the absence of the pset already says it.
+ */
+export function buildElementWriteBack(
+  facts: ElementZoneFacts,
+  options: ZoneWriteBackOptions,
+): ElementWriteBack | null {
+  if (facts.touchedZoneNames.length === 0) return null;
+
+  const scale = Number.isFinite(options.volumeSiScale) && options.volumeSiScale > 0
+    ? options.volumeSiScale
+    : 1;
+
+  const properties: WriteBackProperty[] = [
+    { name: ZONE_PROPERTY_NAMES.zoneSet, value: options.zoneSetName, kind: 'LABEL' },
+    // Empty rather than a sentinel like "(none)": a straddler whose centroid
+    // falls between zones genuinely has no home zone, and any placeholder string
+    // is a value a filter cannot tell apart from a zone actually named that.
+    { name: ZONE_PROPERTY_NAMES.zone, value: facts.homeZoneName ?? '', kind: 'LABEL' },
+    // Joined with ", " to match the Lists straddler convention (#1869), where
+    // `equals` therefore excludes straddlers and `contains` includes them.
+    { name: ZONE_PROPERTY_NAMES.zones, value: facts.touchedZoneNames.join(', '), kind: 'LABEL' },
+    { name: ZONE_PROPERTY_NAMES.straddles, value: facts.straddles, kind: 'BOOLEAN' },
+  ];
+
+  if (facts.refusal) {
+    properties.push({
+      name: ZONE_PROPERTY_NAMES.volumeUnavailable,
+      value: REFUSAL_TEXT[facts.refusal] ?? facts.refusal,
+      kind: 'LABEL',
+    });
+    return { globalId: facts.globalId, psetName: zonePropertySetName(options.zoneSetName), properties, qsetName: null, quantities: [] };
+  }
+
+  const rows: Array<{ name: string; valueM3: number }> = facts.shares.map((s) => ({
+    name: s.zoneName,
+    valueM3: s.valueM3,
+  }));
+  if (facts.outsideM3 > NEGLIGIBLE_M3) {
+    rows.push({ name: OUTSIDE_QUANTITY_NAME, valueM3: facts.outsideM3 });
+  }
+  const kept = rows.filter((r) => Number.isFinite(r.valueM3) && r.valueM3 > NEGLIGIBLE_M3);
+  const names = disambiguate(kept.map((r) => r.name));
+  const quantities: WriteBackQuantity[] = kept.map((r, i) => ({
+    name: names[i],
+    value: r.valueM3 / scale,
+  }));
+
+  if (quantities.length === 0) {
+    return {
+      globalId: facts.globalId,
+      psetName: zonePropertySetName(options.zoneSetName),
+      properties,
+      qsetName: null,
+      quantities: [],
+    };
+  }
+
+  properties.push({ name: ZONE_PROPERTY_NAMES.volumeBasis, value: volumeBasisLabel(options.basis), kind: 'LABEL' });
+  if (facts.quantityName) {
+    properties.push({ name: ZONE_PROPERTY_NAMES.volumeQuantity, value: facts.quantityName, kind: 'LABEL' });
+  }
+  const note = volumeBasisRatioNote(options.basis);
+  if (note) {
+    properties.push({ name: ZONE_PROPERTY_NAMES.volumeNote, value: note, kind: 'LABEL' });
+  }
+
+  return {
+    globalId: facts.globalId,
+    psetName: zonePropertySetName(options.zoneSetName),
+    properties,
+    qsetName: zoneQuantitySetName(options.zoneSetName, options.basis),
+    quantities,
+  };
+}
+
+/** Summary of one write-back run, for the panel line and for tests. */
+export interface WriteBackSummary {
+  /** Elements that got a property set. */
+  written: number;
+  /** Of those, how many also got volumes. */
+  withVolumes: number;
+  /** Of those, how many carry a stated refusal instead. */
+  refused: number;
+  /** Elements in the set's assignments that touch no zone, so were skipped. */
+  skippedNoZone: number;
+}
+
+export function summarize(
+  results: ReadonlyArray<ElementWriteBack | null>,
+): WriteBackSummary {
+  let written = 0;
+  let withVolumes = 0;
+  let refused = 0;
+  let skippedNoZone = 0;
+  for (const r of results) {
+    if (!r) {
+      skippedNoZone++;
+      continue;
+    }
+    written++;
+    if (r.quantities.length > 0) withVolumes++;
+    if (r.properties.some((p) => p.name === ZONE_PROPERTY_NAMES.volumeUnavailable)) refused++;
+  }
+  return { written, withVolumes, refused, skippedNoZone };
+}

--- a/apps/viewer/src/lib/zones/writeback.ts
+++ b/apps/viewer/src/lib/zones/writeback.ts
@@ -209,12 +209,17 @@ const REFUSAL_TEXT: Record<WriteBackRefusal, string> = {
  *  replaces the first - a whole zone's volume vanishing with no error. The
  *  suffix is positional and therefore stable for a given zone order. */
 function disambiguate(names: readonly string[]): string[] {
-  const used = new Map<string, number>();
+  const taken = new Set<string>();
   return names.map((raw) => {
     const base = raw.trim() === '' ? UNNAMED_ZONE : raw.trim();
-    const seen = used.get(base) ?? 0;
-    used.set(base, seen + 1);
-    return seen === 0 ? base : `${base} (${seen + 1})`;
+    let candidate = base;
+    // The suffixed candidate is checked against the names already taken, not
+    // just counted: zones named ['A', 'A', 'A (2)'] would otherwise produce
+    // 'A (2)' twice and lose the third zone's volume, which is the same failure
+    // the plain duplicate would have caused.
+    for (let n = 2; taken.has(candidate); n++) candidate = `${base} (${n})`;
+    taken.add(candidate);
+    return candidate;
   });
 }
 

--- a/apps/viewer/src/store/slices/mutationSlice.ts
+++ b/apps/viewer/src/store/slices/mutationSlice.ts
@@ -3237,9 +3237,18 @@ export const createMutationSlice: StateCreator<
     if (modelIds.length === 0) return;
     set((state) => {
       const newDirty = new Set(state.dirtyModels);
-      for (const id of modelIds) newDirty.add(id);
+      // Redo is cleared for the same reason every per-mutation action clears
+      // it: a new edit invalidates the branch an undone one could be replayed
+      // onto. A bulk writer is no different, and leaving it alone let Ctrl+Y
+      // replay an edit made before the bulk write, on top of it.
+      const newRedo = new Map(state.redoStacks);
+      for (const id of modelIds) {
+        newDirty.add(id);
+        newRedo.set(id, []);
+      }
       return {
         dirtyModels: newDirty,
+        redoStacks: newRedo,
         mutationVersion: state.mutationVersion + 1,
       };
     });

--- a/apps/viewer/src/store/slices/mutationSlice.ts
+++ b/apps/viewer/src/store/slices/mutationSlice.ts
@@ -700,6 +700,18 @@ export interface MutationSlice {
   clearAllMutations: () => void;
   /** Manually bump mutation version (for bulk operations that bypass store) */
   bumpMutationVersion: () => void;
+  /**
+   * Mark models as having unsaved changes, and bump the mutation version, in
+   * ONE update.
+   *
+   * For bulk writers that go straight to a model's `MutablePropertyView`
+   * (zone write-back, #2508). Those cannot drive the per-mutation actions
+   * above: each of them copies the model's whole undo stack, so calling one
+   * per element is quadratic. `bumpMutationVersion` alone is not enough  - 
+   * without the dirty flag the model reports no unsaved changes while its
+   * overlay holds thousands of them.
+   */
+  markModelsDirty: (modelIds: readonly string[]) => void;
 }
 
 function generateChangeSetId(): string {
@@ -3219,5 +3231,17 @@ export const createMutationSlice: StateCreator<
     set((state) => ({
       mutationVersion: state.mutationVersion + 1,
     }));
+  },
+
+  markModelsDirty: (modelIds) => {
+    if (modelIds.length === 0) return;
+    set((state) => {
+      const newDirty = new Set(state.dirtyModels);
+      for (const id of modelIds) newDirty.add(id);
+      return {
+        dirtyModels: newDirty,
+        mutationVersion: state.mutationVersion + 1,
+      };
+    });
   },
 });

--- a/apps/viewer/src/store/slices/zonesSlice.ts
+++ b/apps/viewer/src/store/slices/zonesSlice.ts
@@ -21,6 +21,7 @@ import type { StateCreator } from 'zustand';
 import type { Zone, ZoneSet, ZoneAssignmentsByElement } from '../../lib/zones/types.js';
 import type { ZoneApportionmentEntry } from '../../lib/zones/apportionment-cache.js';
 import { serializeZoneSets, parseZoneSetFile } from '../../lib/zones/persistence.js';
+import { isConvexFootprint, normalizePrismBounds } from '../../lib/zones/prism.js';
 
 const ZONE_SETS_STORAGE_KEY = 'ifc-lite:zone-sets';
 
@@ -139,6 +140,29 @@ const DEFAULT_ZONE: Omit<Zone, 'id'> = {
   rotationY: 0,
 };
 
+/**
+ * The one door every zone goes through on its way INTO the store.
+ *
+ * A prism zone (#2508 item 4) carries two things the rest of the app relies on
+ * and cannot check for itself: its footprint is CONVEX (the sweep, the point
+ * test and the overlap test are each silently wrong otherwise), and its
+ * `center` / `size` in X/Z are that footprint's bounding box (every bounds
+ * consumer reads them). `parseZoneSetFile` enforces both for the import path;
+ * these three mutators are the other way in, and a caller reaching them with a
+ * hand-built footprint would otherwise install a zone that misreports volumes.
+ * A non-convex footprint is dropped rather than kept, leaving a plain box: a
+ * zone that is visibly the wrong shape beats one that quietly answers wrong.
+ */
+function acceptZone(zone: Zone): Zone {
+  if (!zone.footprint) return zone;
+  if (!isConvexFootprint(zone.footprint)) {
+    const { footprint: _dropped, ...box } = zone;
+    console.warn('[zones] ignoring a non-convex footprint; the zone stays a box', zone.id);
+    return box;
+  }
+  return normalizePrismBounds(zone);
+}
+
 export const createZonesSlice: StateCreator<ZonesSlice, [], [], ZonesSlice> = (set, get) => ({
   zoneSets: loadPersistedZoneSets(),
   zoneAssignments: new Map(),
@@ -185,7 +209,9 @@ export const createZonesSlice: StateCreator<ZonesSlice, [], [], ZonesSlice> = (s
   }),
 
   replaceZonesInSet: (setId, zones) => set((state) => {
-    const zoneSets = state.zoneSets.map((zs) => (zs.id === setId ? { ...zs, zones, updatedAt: Date.now() } : zs));
+    const zoneSets = state.zoneSets.map((zs) => (zs.id === setId
+      ? { ...zs, zones: zones.map(acceptZone), updatedAt: Date.now() }
+      : zs));
     savePersistedZoneSets(zoneSets);
     // Replacing a set's zones wholesale (e.g. "generate from storeys") can
     // remove the zone an edit session points at — same invariant as
@@ -202,7 +228,7 @@ export const createZonesSlice: StateCreator<ZonesSlice, [], [], ZonesSlice> = (s
     const zoneSet = get().zoneSets.find((zs) => zs.id === setId);
     if (!zoneSet) return null;
     const id = crypto.randomUUID();
-    const newZone: Zone = { ...DEFAULT_ZONE, ...zone, id };
+    const newZone: Zone = acceptZone({ ...DEFAULT_ZONE, ...zone, id });
     set((state) => {
       const zoneSets = state.zoneSets.map((zs) => (zs.id === setId ? { ...zs, zones: [...zs.zones, newZone], updatedAt: Date.now() } : zs));
       savePersistedZoneSets(zoneSets);
@@ -216,7 +242,7 @@ export const createZonesSlice: StateCreator<ZonesSlice, [], [], ZonesSlice> = (s
       if (zs.id !== setId) return zs;
       return {
         ...zs,
-        zones: zs.zones.map((z) => (z.id === zoneId ? { ...z, ...patch } : z)),
+        zones: zs.zones.map((z) => (z.id === zoneId ? acceptZone({ ...z, ...patch }) : z)),
         updatedAt: Date.now(),
       };
     });

--- a/docs/design/zone-emission.md
+++ b/docs/design/zone-emission.md
@@ -1,0 +1,124 @@
+# Emitting location zones as IFC entities (design)
+
+**Status:** decided, partly built. The property/quantity write-back ships
+(#2508 item 3b). `IfcZone` emission is **refused** on schema grounds.
+`IfcSpatialZone` is the correct vehicle for the zone boxes themselves and is
+deferred to its own PR, with the shape below.
+
+Issue #2508 asks the question rather than assuming the answer: "Whether
+user-drawn takt boxes *should* become `IfcZone` is a genuine modelling
+question, not an obvious yes". This is the argument.
+
+## What a location zone is
+
+A zone (`apps/viewer/src/lib/zones/types.ts`) is a user-drawn oriented box in
+the **viewer's** world frame: a construction section, a takt area, a delivery
+sequence. It has a name, a colour, a stable id, and no relationship to the
+model's spatial structure. Elements are classified into it geometrically, by
+where their geometry actually is, and an element can be in several zone sets at
+once ("Section 2" and "Takt Area B").
+
+Three properties matter for what follows:
+
+1. A zone is **not a room**. Nothing bounds it, nothing was designed to it, and
+   it usually cuts through walls and slabs rather than following them.
+2. An element can belong to **several zones at once**, which is the entire
+   point of #2508: the straddlers are the interesting population.
+3. Zones are **planning state**, not design state. They change when the
+   programme changes, several times a week, and two people planning the same
+   building will draw different ones.
+
+## `IfcZone`: no
+
+`IfcZone` is a grouping of **spaces**. Its `IsGroupedBy`
+(`IfcRelAssignsToGroup`) accepts `IfcSpace`, `IfcSpatialZone` and nested
+`IfcZone` only; a wall is not an admissible member. This repo already reads it
+that way: `extractGroupMembersOnDemand`
+(`packages/parser/src/on-demand-extractors.ts`) documents an `IfcZone`'s
+members as the `IfcSpace` / `IfcSpatialZone` ones, and the GROUPS panel (#1672)
+browses them on that assumption.
+
+So emitting takt boxes as `IfcZone` with walls and slabs assigned to them
+produces a file that our own reader would mis-describe and a validator would
+reject. The attraction is only that the word matches; the semantics do not.
+Refused.
+
+## `IfcGroup`: possible, and it says nothing
+
+`IfcRelAssignsToGroup` onto a plain `IfcGroup` accepts any
+`IfcObjectDefinition`, so the schema permits assigning walls to a group named
+"Takt Area B". It is the unconstrained fallback, and that is also its problem:
+a plain group carries no spatial meaning, so a receiving tool learns that these
+elements are *associated*, not that they occupy a *region*. It also cannot
+express a straddler honestly, because group membership is a yes/no while a
+straddling wall is 40% one and 60% the other.
+
+Worth having only if a specific downstream consumer asks for groups. It is a
+transport, not a model.
+
+## `IfcSpatialZone`: yes, and it is a separate PR
+
+`IfcSpatialZone` (IFC4) is exactly this concept: a spatial region that is
+"not necessarily bounded by physical elements", intended for thermal,
+lighting, occupancy and **construction** zones, with a `PredefinedType` that
+includes `CONSTRUCTION`. It carries an `ObjectPlacement` and a
+`Representation`, so the box a user drew can be emitted as geometry rather than
+described in prose. This repo already surfaces it (#1094, #1075).
+
+Two schema details make it fit where `IfcZone` does not:
+
+- Elements are attached with **`IfcRelReferencedInSpatialStructure`**, which is
+  many-to-many and *additive*. It does not disturb
+  `IfcRelContainedInSpatialStructure`, which is exclusive and holds the
+  building's real hierarchy. The parser already indexes the referenced
+  relation (`packages/parser/src/columnar-parser-indexes.ts`), so a file we
+  emit is a file we can read back.
+- A straddler can be referenced in **both** zones, which is the truthful
+  statement of the topology.
+
+### What it does not solve
+
+Referencing says *this element reaches this zone*. It cannot say *this element
+is 40% in this zone*, which is the number #2508 exists to produce. So an
+`IfcSpatialZone` emission is complementary to the quantity write-back, never a
+replacement for it: the zone entity carries the region, the quantity set
+carries the split.
+
+### Why it is deferred rather than done here
+
+- It writes new **spatial** entities into someone else's model, which is a
+  heavier act than adding property sets, and needs its own review and its own
+  opt-in.
+- It needs a placement chain and a swept-solid or brep representation in IFC
+  **Z-up**, converted out of the viewer's Y-up frame, anchored on the site.
+  That is geometry authoring, not data authoring.
+- Zones change several times a week (property 3 above). Baking planning state
+  into the spatial structure of a design model is a decision a user should make
+  deliberately, on export, not as a side effect of drawing a box.
+
+## What ships instead, and why it is the right default
+
+The property and quantity write-back (#2508 item 3b,
+`apps/viewer/src/lib/zones/writeback.ts`):
+
+- is **additive and reversible**: it touches no spatial structure and the panel
+  removes exactly what it wrote;
+- expresses the straddler honestly, as a per-zone volume breakdown that sums to
+  the whole;
+- lands in the one place every downstream tool already looks, which is what the
+  reporter of #1763 was doing by hand in a spreadsheet.
+
+## If the `IfcSpatialZone` PR is written
+
+Sketch, so the next person does not re-derive it:
+
+- One `IfcSpatialZone` per zone, `PredefinedType = CONSTRUCTION`, `LongName` =
+  the zone set's name, `Name` = the zone's name.
+- Placement relative to the site, representation as an extruded rectangle
+  profile carrying `rotationY` in the placement rather than in the profile.
+- `IfcRelReferencedInSpatialStructure` per zone, listing every element the
+  assignment says it touches (not just the elements whose home it is).
+- Aggregate the set's zones under one `IfcZone` **only** if every member is an
+  `IfcSpatialZone`, which is admissible and is the one legitimate use of
+  `IfcZone` here.
+- Emit alongside the property sets, never instead of them.

--- a/docs/guide/mutations.md
+++ b/docs/guide/mutations.md
@@ -166,11 +166,29 @@ In the IFClite viewer:
 | Tab | Edits | Backed by |
 |---|---|---|
 | **Properties** | IfcRoot named attributes (Name, Description, …), property sets, classifications, materials, documents | `setProperty` / `setAttribute` |
-| **Quantities** | Quantity sets and individual quantities | `setQuantity` |
+| **Quantities** | Quantity sets and individual quantities | `setQuantity` / `createQuantitySet` / `deleteQuantitySet` |
 | **bSDD** | Add buildingSMART Data Dictionary properties | `setProperty` |
 | **Raw STEP** | Positional STEP arguments on the selected entity (one row per arg, inline pen-icon editor). Mutated rows show a purple dot. | `setPositionalAttribute` |
 
 The Raw STEP tab is the right place for non-IfcRoot edits — `IfcRectangleProfileDef.XDim`, `IfcCartesianPoint.Coordinates`, anything without a symbolic attribute name.
+
+### Zone assignment write-back
+
+The Zones panel writes a zone set's assignment onto the elements, so it survives an export instead of staying viewer state (issue #2508). Per element in the set:
+
+| Set | Name | Carries |
+|---|---|---|
+| Property set | `IfcLite_Zones [<set name>]` | `ZoneSet`, `Zone` (the home zone, empty when the centroid is in no zone), `Zones` (every touched zone, joined with `", "`), `Straddles`, and the basis labels |
+| Quantity set | `IfcLite_ZoneVolumes [<set name>] (<basis>)` | one `IfcQuantityVolume` per zone the element reaches, plus `Outside zones` when part of it is in none |
+
+Neither name uses the `Pset_` / `Qto_` prefix, which buildingSMART reserves for its own published definitions.
+
+Four things are deliberate:
+
+- **The basis is chosen, and it is in the name.** `mesh` is the as-built geometry; `net` / `gross` / `unqualified` apportion the file's own declared quantity by the measured fractions, so a `net` breakdown sums to the declared `NetVolume` by construction. Elements that declare nothing on the chosen basis are refused rather than quietly falling back to the mesh.
+- **Values are written in the model's declared volume unit**, converted per model, so a federated file in cubic millimetres and one in cubic metres both come out right.
+- **A refusal is written down.** An element whose mesh is not a proven closed solid gets its zone names plus a `VolumeUnavailable` sentence, and no quantities. A missing row would read as zero.
+- **The run does not enter the undo stack** - it writes to the overlay directly, because driving the per-mutation actions once per element is quadratic in the undo stack. Its inverse is the panel's own remove button, which clears the property set and the quantity set on every basis.
 
 ### Selection context menu
 

--- a/docs/guide/mutations.md
+++ b/docs/guide/mutations.md
@@ -172,6 +172,19 @@ In the IFClite viewer:
 
 The Raw STEP tab is the right place for non-IfcRoot edits — `IfcRectangleProfileDef.XDim`, `IfcCartesianPoint.Coordinates`, anything without a symbolic attribute name.
 
+### Zone shapes
+
+A zone is an oriented box by default. A zone whose JSON carries a `footprint` (an array of `[x, z]` points in world metres) is a vertical **prism** over that polygon instead, spanning the same `center[1] +/- size[1]/2`:
+
+```json
+{ "id": "z-1", "name": "Takt A", "center": [0, 1.5, 0], "size": [0, 3, 0], "rotationY": 0,
+  "footprint": [[0, 0], [12, 0], [12, 5], [4, 9]] }
+```
+
+- The polygon must be **convex**; a concave one is rejected on import, because the sweep, the point test and the overlap test are each silently wrong for it rather than visibly broken.
+- `center` / `size` in X/Z and `rotationY` are **derived** from the footprint on import, so every bounds consumer keeps working. The vertical extent stays yours to edit; the 3D handles stay off, since dragging a derived bounding box would change nothing.
+- Classification, apportionment and geometry splitting all follow the polygon. Apportionment costs a few times a box zone (one trapezoidal strip per footprint vertex pair), not a different order.
+
 ### Zone assignment write-back
 
 The Zones panel writes a zone set's assignment onto the elements, so it survives an export instead of staying viewer state (issue #2508). Per element in the set:

--- a/packages/export/src/pset-nomination-effect.test.ts
+++ b/packages/export/src/pset-nomination-effect.test.ts
@@ -42,7 +42,7 @@
 
 import { describe, expect, it } from 'vitest';
 import { QuantityType } from '@ifc-lite/data';
-import { IfcParser, extractPropertiesOnDemand, type IfcDataStore } from '@ifc-lite/parser';
+import { IfcParser, extractPropertiesOnDemand, extractQuantitiesOnDemand, type IfcDataStore } from '@ifc-lite/parser';
 import { MutablePropertyView, StoreEditor } from '@ifc-lite/mutations';
 import { StepExporter } from './step-exporter.js';
 
@@ -252,12 +252,11 @@ describe('a set edit that changes the file still counts', () => {
   });
 
   it('REPLACING a source quantity set counts, and the source lines are gone', async () => {
-    // No user-facing DELETE for a source quantity set — there is no
-    // delete-quantity-set on the view, `DELETE_QUANTITY` reaches no handler, and
-    // `deletedQsets` has no public populator. Editing one quantity is what a
-    // session can do to a source qset, and it is the case the count has to get
-    // right. It is NOT the only way the qset skip loop withholds source lines —
-    // see the undo-onto-a-colliding-name case below.
+    // Editing one quantity is the commonest thing a session does to a source
+    // qset, and the case the count has to get right. It is NOT the only way the
+    // qset skip loop withholds source lines: see the undo-onto-a-colliding-name
+    // case below, and the outright DELETE case after it (#2508 gave the view a
+    // `deleteQuantitySet`, which the comment here used to say did not exist).
     const store = await parseBaseWithQto();
     const view = new MutablePropertyView(null, 'test-model');
     view.setOnDemandExtractor((id: number) => extractPropertiesOnDemand(store, id));
@@ -274,6 +273,28 @@ describe('a set edit that changes the file still counts', () => {
     expect(text).not.toContain("'0OSuGGYUFyIf0LtE29OSuW'");
     expect(text).toContain('Qto_WallBaseQuantities');
     expect(text).toContain('2.5');
+    expect(result.stats.modifiedEntityCount).toBe(1);
+  });
+
+  it('DELETING a source quantity set leaves the file without it (#2508)', async () => {
+    // The case #2487's comment called impossible, because the view had no
+    // public qset delete then. Now it does, and a set the panel hid must not
+    // still be in the exported bytes: the skip loop withholds source lines when
+    // it is writing a REPLACEMENT, and a deletion has no replacement to be
+    // recognised by, so the exporter has to ask whether the set was deleted.
+    const store = await parseBaseWithQto();
+    const view = new MutablePropertyView(null, 'test-model');
+    view.setOnDemandExtractor((id: number) => extractPropertiesOnDemand(store, id));
+    view.setQuantityExtractor((id: number) => extractQuantitiesOnDemand(store, id) as never);
+
+    view.deleteQuantitySet(WALL_ID, 'Qto_WallBaseQuantities');
+
+    const result = new StepExporter(store, view).export({ schema: 'IFC4' });
+    const text = new TextDecoder().decode(result.content);
+
+    expect(text).not.toContain('Qto_WallBaseQuantities');
+    expect(text).not.toContain('IFCQUANTITYVOLUME');
+    expect(text).not.toContain("'0OSuGGYUFyIf0LtE29OSuW'");
     expect(result.stats.modifiedEntityCount).toBe(1);
   });
 

--- a/packages/export/src/step-exporter.ts
+++ b/packages/export/src/step-exporter.ts
@@ -509,7 +509,8 @@ export class StepExporter {
 
         if (!mutation.psetName) continue;
 
-        const isQuantity = mutation.type === 'CREATE_QUANTITY' || mutation.type === 'UPDATE_QUANTITY' || mutation.type === 'DELETE_QUANTITY';
+        const isQuantity = mutation.type === 'CREATE_QUANTITY' || mutation.type === 'UPDATE_QUANTITY'
+          || mutation.type === 'DELETE_QUANTITY' || mutation.type === 'DELETE_QUANTITY_SET';
         const targetMap = isQuantity ? entityQuantMutations : entityPropMutations;
 
         if (!targetMap.has(mutation.entityId)) {
@@ -731,10 +732,14 @@ export class StepExporter {
         // affected-name set is not the same thing: it comes from the session's
         // append-only mutation history, which keeps naming a quantity set after
         // an undo has taken it back out of the overlay, so a Ctrl+Z used to
-        // withhold a source `IfcElementQuantity` that nothing regenerated. There
-        // is no quantity-set REMOVAL to preserve here — `deletedQsets` has no
-        // public populator, so withholding without a replacement is always the
-        // bug and never the intent (#2487).
+        // withhold a source `IfcElementQuantity` that nothing regenerated.
+        //
+        // A quantity-set REMOVAL is the one case where withholding WITHOUT a
+        // replacement is the intent rather than the bug. It had no public
+        // populator when #2487 wrote that rule, so the rule read "always the
+        // bug"; `MutablePropertyView.deleteQuantitySet` (#2508) gives it one,
+        // and the deleted set is now asked for by name below. Without that, the
+        // panel hid a base quantity set the exported file still carried.
         const regeneratedQsetNames = new Set(relevantQsets.map((qset: QuantitySet) => qset.name));
 
         // Skip original quantity set entities (IfcElementQuantity).
@@ -743,7 +748,9 @@ export class StepExporter {
         if (rels) {
           for (const { relId, psetId: relatedPsetId } of rels) {
             const qsetName = this.getElementQuantityName(relatedPsetId);
-            if (qsetName && regeneratedQsetNames.has(qsetName)) {
+            const deleted = qsetName !== null
+              && this.mutationView.isQuantitySetDeleted?.(entityId, qsetName) === true;
+            if (qsetName && (regeneratedQsetNames.has(qsetName) || deleted)) {
               skipRelationshipIds.add(relId);
               skipPropertySetIds.add(relatedPsetId);
               const quantIds = this.getPropertyIdsInSet(relatedPsetId);

--- a/packages/mutations/src/change-set-to-ops.ts
+++ b/packages/mutations/src/change-set-to-ops.ts
@@ -261,6 +261,11 @@ function applyMutation(
         componentFor(entity, `pset:${mutation.psetName}`).set(`pset:${mutation.psetName}`, null);
       }
       break;
+    case 'DELETE_QUANTITY_SET':
+      if (mutation.psetName) {
+        componentFor(entity, `qset:${mutation.psetName}`).set(`qset:${mutation.psetName}`, null);
+      }
+      break;
     case 'UPDATE_ATTRIBUTE':
     case 'UPDATE_POSITIONAL_ATTRIBUTE':
       if (mutation.attributeName) {

--- a/packages/mutations/src/mutable-property-view.ts
+++ b/packages/mutations/src/mutable-property-view.ts
@@ -983,8 +983,13 @@ export class MutablePropertyView {
     }
 
     const mutation: Mutation = {
+      // Its OWN type rather than a `DELETE_QUANTITY` with no `propName`: both
+      // replay consumers (`applyMutations` here, `change-set-to-ops`) key the
+      // member-delete case off `propName`, so a set removal filed under it
+      // matched nothing, resurrected the set on import and vanished from a
+      // layer publish without reaching `skipped`.
       id: generateMutationId(),
-      type: 'DELETE_QUANTITY',
+      type: 'DELETE_QUANTITY_SET',
       timestamp: Date.now(),
       modelId: this.modelId,
       entityId,
@@ -993,6 +998,20 @@ export class MutablePropertyView {
 
     this.mutationHistory.push(mutation);
     return mutation;
+  }
+
+  /**
+   * Has this entity's quantity set been DELETED this session?
+   *
+   * `getQuantitiesForEntity` cannot answer it: a deleted set and a set that
+   * never existed both come back absent. The exporter needs the difference,
+   * because it withholds a source `IfcElementQuantity` when it is writing a
+   * REPLACEMENT for it, and a deletion has no replacement to recognise it by.
+   * Without this, `deleteQuantitySet` masked a base set in the panel while the
+   * exported file still carried it.
+   */
+  isQuantitySetDeleted(entityId: number, qsetName: string): boolean {
+    return this.deletedQsets.has(`${entityId}:${qsetName}`);
   }
 
   // ---------------------------------------------------------------------------
@@ -1895,6 +1914,12 @@ export class MutablePropertyView {
         case 'DELETE_PROPERTY_SET':
           if (mutation.psetName) {
             this.deletePropertySet(mutation.entityId, mutation.psetName);
+          }
+          break;
+
+        case 'DELETE_QUANTITY_SET':
+          if (mutation.psetName) {
+            this.deleteQuantitySet(mutation.entityId, mutation.psetName);
           }
           break;
 

--- a/packages/mutations/src/mutable-property-view.ts
+++ b/packages/mutations/src/mutable-property-view.ts
@@ -941,6 +941,60 @@ export class MutablePropertyView {
     return mutation;
   }
 
+  /**
+   * Delete an entire quantity set - the inverse of `createQuantitySet`, and the
+   * exact mirror of `deletePropertySet` one level up.
+   *
+   * It was missing until #2508's zone write-back needed it, which is why
+   * `deletedQsets` existed but was only ever populated by the restore path.
+   * Without it, a writer that REPLACES an entity's quantity set can shrink it
+   * but never empty it: re-running with no quantities to write leaves the
+   * previous run's numbers in place, so the file states volumes beside a
+   * property saying the volume could not be computed.
+   */
+  deleteQuantitySet(entityId: number, qsetName: string): Mutation {
+    // In-session qsets carry their own quantity mutations, recorded by
+    // `createQuantitySet`. Drop both, for `deletePropertySet`'s reasons: an
+    // empty Map left behind keeps reporting the entity as modified, and an
+    // orphaned SET mutation re-adds the quantity to a base qset of the same
+    // name.
+    const entityQsets = this.newQsets.get(entityId);
+    const inSessionQset = entityQsets?.get(qsetName);
+    if (entityQsets && inSessionQset) {
+      entityQsets.delete(qsetName);
+      if (entityQsets.size === 0) {
+        this.newQsets.delete(entityId);
+      }
+      for (const quantity of inSessionQset.quantities) {
+        this.deleteQuantityMutation(entityId, quantityKey(entityId, qsetName, quantity.name));
+      }
+    }
+
+    // A DELETE marker only earns its keep against a qset that genuinely exists
+    // in the base file - same argument as `deletePropertySet`'s. A purely
+    // in-session qset has nothing to mask, and recording one would tell the
+    // export review a set is being removed when the net change is zero.
+    const baseQset = this.getBaseQuantitiesForEntity(entityId).find(q => q.name === qsetName);
+    if (baseQset) {
+      this.deletedQsets.add(`${entityId}:${qsetName}`);
+      for (const quantity of baseQset.quantities) {
+        this.setQuantityMutation(entityId, quantityKey(entityId, qsetName, quantity.name), { operation: 'DELETE' });
+      }
+    }
+
+    const mutation: Mutation = {
+      id: generateMutationId(),
+      type: 'DELETE_QUANTITY',
+      timestamp: Date.now(),
+      modelId: this.modelId,
+      entityId,
+      psetName: qsetName,
+    };
+
+    this.mutationHistory.push(mutation);
+    return mutation;
+  }
+
   // ---------------------------------------------------------------------------
   // Attribute mutations
   // ---------------------------------------------------------------------------

--- a/packages/mutations/src/mutable-property-view.ts
+++ b/packages/mutations/src/mutable-property-view.ts
@@ -1920,6 +1920,16 @@ export class MutablePropertyView {
         case 'DELETE_QUANTITY_SET':
           if (mutation.psetName) {
             this.deleteQuantitySet(mutation.entityId, mutation.psetName);
+            // The marker is recorded even when this view cannot SEE the base
+            // set, unlike the live path. `deleteQuantitySet` only masks a set
+            // the quantity extractor reports, and that extractor is opt-in
+            // (null by default, and several in-tree callers wire the property
+            // one beside it and not it). A replayed deletion is a decision the
+            // origin session already made, so dropping it here would let a
+            // later export regenerate a set the user removed. An inert marker
+            // on a set that does not exist costs a row in the change list;
+            // losing the deletion costs the user's edit.
+            this.deletedQsets.add(`${mutation.entityId}:${mutation.psetName}`);
           }
           break;
 

--- a/packages/mutations/src/types.ts
+++ b/packages/mutations/src/types.ts
@@ -61,6 +61,11 @@ export type MutationType =
   | 'CREATE_QUANTITY'
   | 'UPDATE_QUANTITY'
   | 'DELETE_QUANTITY'
+  /** A whole quantity set removed, the twin of `DELETE_PROPERTY_SET`. Distinct
+   *  from `DELETE_QUANTITY`, which names one quantity inside a set: replaying a
+   *  set removal as a member removal drops the set's other members on the
+   *  floor, and both replay consumers key off `propName` being present. */
+  | 'DELETE_QUANTITY_SET'
   | 'UPDATE_ATTRIBUTE'
   | 'UPDATE_POSITIONAL_ATTRIBUTE'
   | 'UPDATE_ENTITY_TYPE'

--- a/packages/mutations/test/effective-changes.test.ts
+++ b/packages/mutations/test/effective-changes.test.ts
@@ -586,16 +586,22 @@ describe('collectQuantityChanges coverage (previously zero — maintainer findin
     ]);
   });
 
-  it('reports a deleted quantity set as a single qset-deleted row (pure function — no MutablePropertyView setter exists yet)', () => {
-    // Unlike pset deletes (`deletePropertySet`), `MutablePropertyView` has no
-    // public qset-delete method — `deletedQsets` is read by `getQuantitiesForEntity`
-    // / `hasPendingChanges` / `collectSetLevelChanges` but nothing populates it.
-    // Exercise the enumeration directly against the snapshot shape so this row
-    // kind has coverage even though the view can't produce it yet.
-    const snapshot = emptySnapshot();
-    (snapshot.deletedQsets as Set<string>).add('12:Qto_Base');
+  it('reports a deleted quantity set as a single qset-deleted row', () => {
+    // This used to drive `collectEffectiveChanges` against a hand-built
+    // snapshot, because `deletedQsets` was read by `getQuantitiesForEntity` /
+    // `hasPendingChanges` / `collectSetLevelChanges` and populated by nothing:
+    // there was no public qset delete to mirror `deletePropertySet`. #2508's
+    // zone write-back needed one, so the row kind is now driven through the
+    // real method rather than through its storage.
+    const view = new MutablePropertyView(null, 'model-1');
+    view.setQuantityExtractor((entityId) => entityId === 12 ? [{
+      name: 'Qto_Base',
+      quantities: [{ name: 'Area', type: QuantityType.Area, value: 10 }],
+    }] : []);
 
-    expect(collectEffectiveChanges(snapshot, noopResolvers)).toEqual([
+    view.deleteQuantitySet(12, 'Qto_Base');
+
+    expect(view.getEffectiveChanges()).toEqual([
       { entityId: 12, kind: 'qset-deleted', setName: 'Qto_Base' },
     ]);
   });

--- a/packages/mutations/test/mutable-property-view.test.ts
+++ b/packages/mutations/test/mutable-property-view.test.ts
@@ -442,6 +442,27 @@ describe('deleteQuantitySet (#2508)', () => {
     expect(view.hasChanges(7)).toBe(true);
   });
 
+  it('replays a serialized deletion even where this view cannot see the base', () => {
+    // The quantity extractor is opt-in and several in-tree callers wire the
+    // property one beside it and not it. A replayed deletion is a decision the
+    // origin session already made, so a view with no base must still mask the
+    // set: otherwise a later export regenerates what the user removed.
+    const origin = new MutablePropertyView(null, 'model-1');
+    origin.setOnDemandExtractor(() => []);
+    origin.setQuantityExtractor((entityId) => entityId === 7 ? [{
+      name: 'Qto_WallBaseQuantities',
+      quantities: [{ name: 'NetVolume', type: QuantityType.Volume, value: 1.5 }],
+    }] : []);
+    origin.deleteQuantitySet(7, 'Qto_WallBaseQuantities');
+
+    const replayed = new MutablePropertyView(null, 'model-1');
+    replayed.setOnDemandExtractor(() => []);
+    // No quantity extractor here, on purpose.
+    replayed.applyMutations(origin.getMutations());
+
+    expect(replayed.isQuantitySetDeleted(7, 'Qto_WallBaseQuantities')).toBe(true);
+  });
+
   it('leaves other quantity sets on the same entity alone', () => {
     const view = new MutablePropertyView(null, 'model-1');
     view.setOnDemandExtractor(() => []);

--- a/packages/mutations/test/mutable-property-view.test.ts
+++ b/packages/mutations/test/mutable-property-view.test.ts
@@ -405,3 +405,53 @@ describe('hasQuantityBase (github.com/LTplus-AG/ifc-lite/issues/2487)', () => {
     ]);
   });
 });
+
+describe('deleteQuantitySet (#2508)', () => {
+  it('removes a quantity set created in this session, along with its quantities', () => {
+    const view = new MutablePropertyView(null, 'model-1');
+    view.setOnDemandExtractor(() => []);
+    view.setQuantityExtractor(() => []);
+
+    view.createQuantitySet(7, 'IfcLite_ZoneVolumes [Takt] (mesh)', [
+      { name: 'Takt A', value: 2, quantityType: QuantityType.Volume },
+    ]);
+    expect(view.getQuantitiesForEntity(7)).toHaveLength(1);
+
+    view.deleteQuantitySet(7, 'IfcLite_ZoneVolumes [Takt] (mesh)');
+
+    // Not merely absent from the set list: the per-quantity SET mutations the
+    // create recorded are dropped too, so nothing can re-add the quantity to a
+    // base set of the same name later, and the entity stops reporting itself
+    // as modified with nothing to show for it.
+    expect(view.getQuantitiesForEntity(7)).toEqual([]);
+    expect(view.hasChanges(7)).toBe(false);
+  });
+
+  it('masks a quantity set that exists in the base file', () => {
+    const view = new MutablePropertyView(null, 'model-1');
+    view.setOnDemandExtractor(() => []);
+    view.setQuantityExtractor((entityId) => entityId === 7 ? [{
+      name: 'Qto_WallBaseQuantities',
+      quantities: [{ name: 'NetVolume', type: QuantityType.Volume, value: 1.5 }],
+    }] : []);
+
+    view.deleteQuantitySet(7, 'Qto_WallBaseQuantities');
+
+    expect(view.getQuantitiesForEntity(7)).toEqual([]);
+    // A base deletion IS a change, unlike dropping a set this session created.
+    expect(view.hasChanges(7)).toBe(true);
+  });
+
+  it('leaves other quantity sets on the same entity alone', () => {
+    const view = new MutablePropertyView(null, 'model-1');
+    view.setOnDemandExtractor(() => []);
+    view.setQuantityExtractor(() => []);
+
+    view.createQuantitySet(7, 'Kept', [{ name: 'A', value: 1, quantityType: QuantityType.Volume }]);
+    view.createQuantitySet(7, 'Dropped', [{ name: 'B', value: 2, quantityType: QuantityType.Volume }]);
+
+    view.deleteQuantitySet(7, 'Dropped');
+
+    expect(view.getQuantitiesForEntity(7).map((q) => q.name)).toEqual(['Kept']);
+  });
+});

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -1654,6 +1654,13 @@ export function resolve2d(a: Contours2D): Contours2D;
  * (matching the viewer's `Zone.size`) and the rotation is radians about the
  * vertical axis. A trailing partial zone is ignored rather than guessed at.
  *
+ * A zone becomes a PRISM (#2508 item 4) when `footprint_counts[i]` is
+ * non-zero: it then takes that many `[x, z]` pairs from `footprints`, in
+ * order, and uses the 7-tuple only for its vertical extent
+ * (`cy +/- sy/2`). The footprint must be CONVEX; the viewer gates that on
+ * import, because a concave polygon fans into overlapping triangles and would
+ * cut wrong rather than fail. Passing empty arrays keeps every zone a box.
+ *
  * The caller must have established that the mesh is a closed orientable solid
  * first, exactly as it must before quoting a volume at all (#1891/#1993): a
  * clip of an open shell produces pieces whose volumes are arbitrary rather
@@ -1671,7 +1678,7 @@ export function resolve2d(a: Contours2D): Contours2D;
  * split.free();
  * ```
  */
-export function splitMeshByZones(positions: Float64Array, indices: Uint32Array, zones: Float64Array): ZoneSplitJs;
+export function splitMeshByZones(positions: Float64Array, indices: Uint32Array, zones: Float64Array, footprints?: Float64Array | null, footprint_counts?: Uint32Array | null): ZoneSplitJs;
 
 /**
  * `a ∪ b`.
@@ -1894,7 +1901,7 @@ export interface InitOutput {
     readonly spaceplatehandle_snapshot: (a: number, b: number) => void;
     readonly spaceplatehandle_splitEdge: (a: number, b: number, c: number, d: number, e: number) => void;
     readonly spaceplatehandle_splitFace: (a: number, b: number, c: number, d: number, e: number, f: number) => void;
-    readonly splitMeshByZones: (a: number, b: number, c: number, d: number, e: number, f: number) => number;
+    readonly splitMeshByZones: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number, j: number) => number;
     readonly symboliccircle_centerX: (a: number) => number;
     readonly symboliccircle_centerY: (a: number) => number;
     readonly symboliccircle_endAngle: (a: number) => number;

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -1666,6 +1666,13 @@ export function resolve2d(a: Contours2D): Contours2D;
  * clip of an open shell produces pieces whose volumes are arbitrary rather
  * than approximate.
  *
+ * A triangle with an out-of-range index or a non-finite coordinate is DROPPED
+ * rather than reported, matching `kernel::mesh_bridge::mesh_to_tris`, which is
+ * panic-free for the same reason: the alternative is a crash deep in the
+ * predicates. It does mean a malformed caller can open the surface and get
+ * meaningless volumes with a plausible `sumErrorRel`, so the closure proof
+ * above is the caller's responsibility and not a formality.
+ *
  * ```javascript
  * const split = splitMeshByZones(positions, indices, new Float64Array([
  *   0, 0, 0, 10, 10, 10, 0,

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -1536,6 +1536,60 @@ export class SymbolicText {
 }
 
 /**
+ * One closed solid of a split element.
+ */
+export class ZonePieceJs {
+    private constructor();
+    free(): void;
+    [Symbol.dispose](): void;
+    /**
+     * Flat triangle indices into `positions`.
+     */
+    readonly indices: Uint32Array;
+    /**
+     * Flat `[x, y, z, ...]` in the caller's frame.
+     */
+    readonly positions: Float64Array;
+    /**
+     * Enclosed volume of this piece, cubic units of the caller's frame.
+     */
+    readonly volume: number;
+    /**
+     * Index into the zone array that was passed in, or `-1` for the part of
+     * the element inside no zone.
+     */
+    readonly zoneIndex: number;
+}
+
+/**
+ * The result of splitting one element.
+ */
+export class ZoneSplitJs {
+    private constructor();
+    free(): void;
+    [Symbol.dispose](): void;
+    /**
+     * Piece `index`, or `undefined` when out of range. Each call COPIES the
+     * piece out, matching the rest of this API surface.
+     */
+    piece(index: number): ZonePieceJs | undefined;
+    readonly pieceCount: number;
+    /**
+     * How far the pieces are from summing to the whole, relative.
+     *
+     * The invariant #2508 puts above everything else here. Exposed rather than
+     * enforced: the caller decides what to do with a split that does not add
+     * up (the expected cause is zones that overlap each other), and a number
+     * it can show beats a silent refusal.
+     */
+    readonly sumErrorRel: number;
+    /**
+     * Enclosed volume of the input element.
+     */
+    readonly wholeVolume: number;
+}
+
+/**
  * `a - b`, keeping EVERY disjoint remnant.
  *
  * This is the operation the existing `subtract_2d` could not stand in for: it
@@ -1592,6 +1646,34 @@ export function meshOutline2d(positions: Float32Array, indices: Uint32Array, axi
 export function resolve2d(a: Contours2D): Contours2D;
 
 /**
+ * Split a mesh into one closed solid per zone, plus the remainder.
+ *
+ * `positions` is flat XYZ (f64, caller's frame), `indices` flat triangle
+ * indices. `zones` is flat, SEVEN numbers per zone:
+ * `[cx, cy, cz, sx, sy, sz, rotationY]`, where the sizes are FULL extents
+ * (matching the viewer's `Zone.size`) and the rotation is radians about the
+ * vertical axis. A trailing partial zone is ignored rather than guessed at.
+ *
+ * The caller must have established that the mesh is a closed orientable solid
+ * first, exactly as it must before quoting a volume at all (#1891/#1993): a
+ * clip of an open shell produces pieces whose volumes are arbitrary rather
+ * than approximate.
+ *
+ * ```javascript
+ * const split = splitMeshByZones(positions, indices, new Float64Array([
+ *   0, 0, 0, 10, 10, 10, 0,
+ * ]));
+ * for (let i = 0; i < split.pieceCount; i++) {
+ *   const piece = split.piece(i);
+ *   // piece.zoneIndex, piece.positions, piece.indices, piece.volume
+ *   piece.free();
+ * }
+ * split.free();
+ * ```
+ */
+export function splitMeshByZones(positions: Float64Array, indices: Uint32Array, zones: Float64Array): ZoneSplitJs;
+
+/**
  * `a ∪ b`.
  */
 export function union2d(a: Contours2D, b: Contours2D): Contours2D;
@@ -1634,6 +1716,8 @@ export interface InitOutput {
     readonly __wbg_symbolicpolyline_free: (a: number, b: number) => void;
     readonly __wbg_symbolicrepresentationcollection_free: (a: number, b: number) => void;
     readonly __wbg_symbolictext_free: (a: number, b: number) => void;
+    readonly __wbg_zonepiecejs_free: (a: number, b: number) => void;
+    readonly __wbg_zonesplitjs_free: (a: number, b: number) => void;
     readonly clashrunresult_a: (a: number, b: number) => void;
     readonly clashrunresult_b: (a: number, b: number) => void;
     readonly clashrunresult_bounds: (a: number, b: number) => void;
@@ -1810,6 +1894,7 @@ export interface InitOutput {
     readonly spaceplatehandle_snapshot: (a: number, b: number) => void;
     readonly spaceplatehandle_splitEdge: (a: number, b: number, c: number, d: number, e: number) => void;
     readonly spaceplatehandle_splitFace: (a: number, b: number, c: number, d: number, e: number, f: number) => void;
+    readonly splitMeshByZones: (a: number, b: number, c: number, d: number, e: number, f: number) => number;
     readonly symboliccircle_centerX: (a: number) => number;
     readonly symboliccircle_centerY: (a: number) => number;
     readonly symboliccircle_endAngle: (a: number) => number;
@@ -1860,6 +1945,13 @@ export interface InitOutput {
     readonly symbolictext_targetPx: (a: number) => number;
     readonly union2d: (a: number, b: number) => number;
     readonly version: (a: number) => void;
+    readonly zonepiecejs_indices: (a: number) => number;
+    readonly zonepiecejs_positions: (a: number) => number;
+    readonly zonepiecejs_volume: (a: number) => number;
+    readonly zonepiecejs_zoneIndex: (a: number) => number;
+    readonly zonesplitjs_piece: (a: number, b: number) => number;
+    readonly zonesplitjs_pieceCount: (a: number) => number;
+    readonly zonesplitjs_sumErrorRel: (a: number) => number;
     readonly init: () => void;
     readonly meshoutlinejs_contourCount: (a: number) => number;
     readonly symbolicpolyline_pointCount: (a: number) => number;
@@ -1876,6 +1968,7 @@ export interface InitOutput {
     readonly symbolictext_worldY: (a: number) => number;
     readonly symbolictext_x: (a: number) => number;
     readonly symbolictext_y: (a: number) => number;
+    readonly zonesplitjs_wholeVolume: (a: number) => number;
     readonly __wbindgen_export: (a: number, b: number) => number;
     readonly __wbindgen_export2: (a: number, b: number, c: number, d: number) => number;
     readonly __wbindgen_export3: (a: number) => void;

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -1575,6 +1575,15 @@ export class ZoneSplitJs {
     piece(index: number): ZonePieceJs | undefined;
     readonly pieceCount: number;
     /**
+     * The part of the element inside NO zone could not be built.
+     *
+     * Separate from `sumErrorRel` because the two have opposite fixes: a
+     * raised sum means the zones overlap and want redrawing, while this means
+     * real volume is MISSING from the result. A caller must refuse the split
+     * outright rather than publish the zone pieces alone.
+     */
+    readonly remainderFailed: boolean;
+    /**
      * How far the pieces are from summing to the whole, relative.
      *
      * The invariant #2508 puts above everything else here. Exposed rather than
@@ -1654,12 +1663,14 @@ export function resolve2d(a: Contours2D): Contours2D;
  * (matching the viewer's `Zone.size`) and the rotation is radians about the
  * vertical axis. A trailing partial zone is ignored rather than guessed at.
  *
- * A zone becomes a PRISM (#2508 item 4) when `footprint_counts[i]` is
- * non-zero: it then takes that many `[x, z]` pairs from `footprints`, in
- * order, and uses the 7-tuple only for its vertical extent
- * (`cy +/- sy/2`). The footprint must be CONVEX; the viewer gates that on
- * import, because a concave polygon fans into overlapping triangles and would
- * cut wrong rather than fail. Passing empty arrays keeps every zone a box.
+ * A zone becomes a PRISM (#2508 item 4) when `footprint_counts[i]` is at
+ * least 3: it then takes that many `[x, z]` pairs from `footprints`, in order,
+ * and uses the 7-tuple only for its vertical extent (`cy +/- sy/2`). The
+ * footprint must be CONVEX; the viewer gates that on import, because a concave
+ * polygon fans into overlapping triangles and would cut wrong rather than
+ * fail. A count of 1 or 2 is not a polygon: it still consumes its pairs, so
+ * later zones stay aligned, and leaves that zone a box. Passing empty arrays
+ * keeps every zone a box.
  *
  * The caller must have established that the mesh is a closed orientable solid
  * first, exactly as it must before quoting a volume at all (#1891/#1993): a
@@ -1965,6 +1976,7 @@ export interface InitOutput {
     readonly zonepiecejs_zoneIndex: (a: number) => number;
     readonly zonesplitjs_piece: (a: number, b: number) => number;
     readonly zonesplitjs_pieceCount: (a: number) => number;
+    readonly zonesplitjs_remainderFailed: (a: number) => number;
     readonly zonesplitjs_sumErrorRel: (a: number) => number;
     readonly init: () => void;
     readonly meshoutlinejs_contourCount: (a: number) => number;

--- a/rust/geometry/src/kernel/mesh_bridge.rs
+++ b/rust/geometry/src/kernel/mesh_bridge.rs
@@ -113,13 +113,23 @@ pub fn tris_to_mesh(tris: &[Tri]) -> Mesh {
 /// volume is negative, so every operand the kernel sees is outward. The flip is a
 /// no-op for already-outward inputs (every pinned box−box manifest: `cube_mesh`
 /// has volume `+8`/`+27`), so determinism manifests are unperturbed.
-fn orient_outward(mut tris: Vec<Tri>) -> Vec<Tri> {
+pub(crate) fn orient_outward(mut tris: Vec<Tri>) -> Vec<Tri> {
     if signed_volume6(&tris) < 0.0 {
         for t in &mut tris {
             t.swap(1, 2);
         }
     }
     tris
+}
+
+/// Enclosed volume of a closed triangle soup, in the operands' own units.
+///
+/// `signed_volume6` is the kernel's own divergence sum and returns SIX times
+/// the volume (it skips the constant divide per tetra). Callers outside the
+/// keep/flip rules want the volume itself, and a second hand-rolled sum in
+/// another module is how two producers of the same number start to disagree.
+pub(crate) fn signed_volume_of(tris: &[Tri]) -> f64 {
+    signed_volume6(tris) / 6.0
 }
 
 /// Cross-operand near-coincidence promotion: weld every CUTTER vertex that

--- a/rust/geometry/src/kernel/mesh_bridge.rs
+++ b/rust/geometry/src/kernel/mesh_bridge.rs
@@ -122,16 +122,6 @@ pub(crate) fn orient_outward(mut tris: Vec<Tri>) -> Vec<Tri> {
     tris
 }
 
-/// Enclosed volume of a closed triangle soup, in the operands' own units.
-///
-/// `signed_volume6` is the kernel's own divergence sum and returns SIX times
-/// the volume (it skips the constant divide per tetra). Callers outside the
-/// keep/flip rules want the volume itself, and a second hand-rolled sum in
-/// another module is how two producers of the same number start to disagree.
-pub(crate) fn signed_volume_of(tris: &[Tri]) -> f64 {
-    signed_volume6(tris) / 6.0
-}
-
 /// Cross-operand near-coincidence promotion: weld every CUTTER vertex that
 /// sits within the snap-scatter band of a HOST face plane — and projects
 /// STRICTLY inside that face — onto the plane, then back onto the snap grid.

--- a/rust/geometry/src/kernel/signed_volume.rs
+++ b/rust/geometry/src/kernel/signed_volume.rs
@@ -76,3 +76,14 @@ pub(crate) fn signed_volume6(tris: &[Tri]) -> f64 {
         .map(|t| tetra_volume6(&t[0], &t[1], &t[2], &o))
         .sum()
 }
+
+/// Enclosed volume of a closed triangle soup, in the operands' own units.
+///
+/// [`signed_volume6`] returns SIX times the volume: it skips the constant
+/// divide per tetrahedron, which is free for the sign tests the boolean's
+/// keep/flip rules use it for. A caller that wants the VOLUME divides once,
+/// here, rather than growing a second hand-rolled sum in another module, which
+/// is how two producers of the same number start to disagree.
+pub(crate) fn signed_volume_of(tris: &[Tri]) -> f64 {
+    signed_volume6(tris) / 6.0
+}

--- a/rust/geometry/src/lib.rs
+++ b/rust/geometry/src/lib.rs
@@ -147,6 +147,9 @@ pub mod space_dcel;
 pub(crate) mod transform;
 pub(crate) mod triangulation;
 pub(crate) mod void_index;
+/// Cut one element into one closed solid per location zone (#2508 item 2), on
+/// top of the exact kernel rather than beside it.
+pub mod zone_split;
 
 // Re-export nalgebra types for convenience
 pub use nalgebra::{Point2, Point3, Vector2, Vector3};

--- a/rust/geometry/src/zone_split.rs
+++ b/rust/geometry/src/zone_split.rs
@@ -49,6 +49,71 @@ pub struct ZoneBox {
     pub rotation_y: f64,
 }
 
+/// What a zone actually is: v1's oriented box, or the convex prism #2508 item 4
+/// adds. Both are convex, which is what keeps each piece one intersection.
+#[derive(Clone, Debug)]
+pub enum ZoneShape {
+    Box(ZoneBox),
+    /// A vertical prism over a CONVEX footprint in the caller's X/Z plane. The
+    /// convexity is the caller's guarantee (the viewer gates it at import);
+    /// a concave polygon fans into overlapping triangles and would cut wrong.
+    Prism {
+        footprint: Vec<[f64; 2]>,
+        min_y: f64,
+        max_y: f64,
+    },
+}
+
+impl ZoneShape {
+    fn to_tris(&self) -> Vec<Tri> {
+        match self {
+            ZoneShape::Box(b) => b.to_tris(),
+            ZoneShape::Prism { footprint, min_y, max_y } => prism_tris(footprint, *min_y, *max_y),
+        }
+    }
+
+    fn world_aabb(&self) -> ([f64; 3], [f64; 3]) {
+        match self {
+            ZoneShape::Box(b) => b.world_aabb(),
+            ZoneShape::Prism { footprint, min_y, max_y } => {
+                let mut lo = [f64::INFINITY, *min_y, f64::INFINITY];
+                let mut hi = [f64::NEG_INFINITY, *max_y, f64::NEG_INFINITY];
+                for p in footprint {
+                    lo[0] = lo[0].min(p[0]);
+                    hi[0] = hi[0].max(p[0]);
+                    lo[2] = lo[2].min(p[1]);
+                    hi[2] = hi[2].max(p[1]);
+                }
+                (lo, hi)
+            }
+        }
+    }
+}
+
+/// A convex footprint extruded between two heights: a triangle fan per cap and
+/// two triangles per side. Winding is CONSISTENT rather than provably outward,
+/// which is all the kernel needs -- `orient_outward` flips the whole operand if
+/// the signed volume comes out negative.
+fn prism_tris(footprint: &[[f64; 2]], min_y: f64, max_y: f64) -> Vec<Tri> {
+    let n = footprint.len();
+    if n < 3 {
+        return Vec::new();
+    }
+    let lo = |i: usize| [footprint[i][0], min_y, footprint[i][1]];
+    let hi = |i: usize| [footprint[i][0], max_y, footprint[i][1]];
+    let mut tris = Vec::with_capacity(4 * n);
+    for i in 1..n - 1 {
+        tris.push([lo(0), lo(i + 1), lo(i)]);
+        tris.push([hi(0), hi(i), hi(i + 1)]);
+    }
+    for i in 0..n {
+        let j = (i + 1) % n;
+        tris.push([lo(i), lo(j), hi(j)]);
+        tris.push([lo(i), hi(j), hi(i)]);
+    }
+    tris
+}
+
 impl ZoneBox {
     /// The box as an outward-wound triangle soup in world coordinates.
     fn to_tris(self) -> Vec<Tri> {
@@ -146,7 +211,7 @@ pub const NEGLIGIBLE_PIECE_REL: f64 = 1e-9;
 /// double-count, so [`ZoneSplit::sum_error_rel`] rises far above any floating
 /// point residue and the caller can refuse on it. That is the same signal the
 /// apportionment path reports as `overlapping`.
-pub fn split_mesh_by_zones(host: &[Tri], zones: &[ZoneBox]) -> ZoneSplit {
+pub fn split_mesh_by_zones(host: &[Tri], zones: &[ZoneShape]) -> ZoneSplit {
     let host = orient_outward(host.to_vec());
     let whole_volume = signed_volume_of(&host);
     let negligible = whole_volume.abs() * NEGLIGIBLE_PIECE_REL;

--- a/rust/geometry/src/zone_split.rs
+++ b/rust/geometry/src/zone_split.rs
@@ -33,7 +33,8 @@
 //!   f64 round trip is what turns a shared zone boundary into a crack.
 
 use crate::kernel::arrangement::{boolean, box_mesh, difference_all, union_all, BoolOp, Tri};
-use crate::kernel::mesh_bridge::{orient_outward, signed_volume_of};
+use crate::kernel::mesh_bridge::orient_outward;
+use crate::kernel::signed_volume::signed_volume_of;
 
 /// A zone as the viewer authors it: an oriented box that rotates about the
 /// VERTICAL axis only. Coordinates are the caller's frame; the viewer passes

--- a/rust/geometry/src/zone_split.rs
+++ b/rust/geometry/src/zone_split.rs
@@ -171,6 +171,16 @@ pub struct ZoneSplit {
     /// Enclosed volume of the input, so a caller can check the pieces against
     /// it without re-deriving it from a different producer.
     pub whole_volume: f64,
+    /// The remainder could not be built: the arrangement was left
+    /// non-conforming and `difference_all` refused rather than risk an
+    /// over- or under-cut.
+    ///
+    /// Reported SEPARATELY from [`ZoneSplit::sum_error_rel`] because the two
+    /// have opposite fixes. A raised sum means the zones overlap and the user
+    /// should redraw them; this means the part of the element inside NO zone is
+    /// missing from the result, which a caller must refuse outright -- publishing
+    /// the zone pieces alone silently deletes real volume from the model.
+    pub remainder_failed: bool,
 }
 
 impl ZoneSplit {
@@ -220,6 +230,7 @@ pub fn split_mesh_by_zones(host: &[Tri], zones: &[ZoneShape]) -> ZoneSplit {
 
     let mut pieces = Vec::new();
     let mut reached: Vec<Vec<Tri>> = Vec::new();
+    let mut remainder_failed = false;
     for (index, zone) in zones.iter().enumerate() {
         let (lo, hi) = zone.world_aabb();
         if (0..3).any(|k| lo[k] > host_hi[k] || hi[k] < host_lo[k]) {
@@ -256,19 +267,26 @@ pub fn split_mesh_by_zones(host: &[Tri], zones: &[ZoneShape]) -> ZoneSplit {
         // co-oriented duplicate, so the difference sees one clean operand.
         let operands: Vec<&[Tri]> = reached.iter().map(|t| t.as_slice()).collect();
         let (cutter, _conforming) = union_all(&operands);
-        if let Some(rest) = difference_all(&host, &[&cutter]) {
-            let volume = signed_volume_of(&rest);
-            if !rest.is_empty() && volume > negligible {
-                pieces.push(ZonePiece { zone: None, tris: rest, volume });
+        match difference_all(&host, &[&cutter]) {
+            Some(rest) => {
+                let volume = signed_volume_of(&rest);
+                if !rest.is_empty() && volume > negligible {
+                    pieces.push(ZonePiece { zone: None, tris: rest, volume });
+                }
             }
+            // Said out loud rather than left to `sum_error_rel`, which a caller
+            // cannot tell apart from overlapping zones and which would point
+            // them at redrawing zones that are not the problem.
+            None => remainder_failed = true,
         }
     } else {
         // No zone reaches the element at all, so all of it is the remainder.
         // Returning nothing here would state that the element vanished.
-        pieces.push(ZonePiece { zone: None, tris: host, volume: whole_volume });
+        let volume = whole_volume;
+        pieces.push(ZonePiece { zone: None, tris: host, volume });
     }
 
-    ZoneSplit { pieces, whole_volume }
+    ZoneSplit { pieces, whole_volume, remainder_failed }
 }
 
 fn tris_aabb(tris: &[Tri]) -> ([f64; 3], [f64; 3]) {

--- a/rust/geometry/src/zone_split.rs
+++ b/rust/geometry/src/zone_split.rs
@@ -1,0 +1,210 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Cut one element into one solid per location zone (issue #2508 item 2).
+//!
+//! #2515 answers "how much of this wall is in Takt A" with a number, by
+//! integrating the zone's indicator function over the element's own boundary.
+//! That is the right tool for a quantity and it produces no geometry at all:
+//! there is nothing to look at, select, or export as a per-section model. This
+//! module produces the geometry, on the explicit request of a user who asked
+//! for it.
+//!
+//! ## Why this is a kernel call and not new geometry code
+//!
+//! Clipping a solid to a convex box is an INTERSECTION against a convex
+//! operand, which is strictly easier than the general difference the exact
+//! kernel already runs on every opening void of every model. So each piece is
+//! one `boolean(host, box, Intersection)`, and the remainder is one
+//! `difference_all` against every box at once. Nothing here re-derives cutting,
+//! capping or classification.
+//!
+//! ## Two decisions worth stating
+//!
+//! - **One arrangement per piece, N+1 in total, not N composed operations.**
+//!   Composing (cut by A, then cut the rest by B, ...) feeds each step the
+//!   PREVIOUS step's output, so every cut re-snaps and re-jitters seams the
+//!   last one made. Each piece instead arranges the ORIGINAL host against one
+//!   box, and the remainder arranges the original host against all the boxes
+//!   together.
+//! - **f64 from end to end.** Operands stay `Tri` (f64) for the whole split and
+//!   only reach `Mesh` (f32) at the caller's boundary. A per-piece f64 -> f32 ->
+//!   f64 round trip is what turns a shared zone boundary into a crack.
+
+use crate::kernel::arrangement::{boolean, box_mesh, difference_all, BoolOp, Tri};
+use crate::kernel::mesh_bridge::{orient_outward, signed_volume_of};
+
+/// A zone as the viewer authors it: an oriented box that rotates about the
+/// VERTICAL axis only. Coordinates are the caller's frame; the viewer passes
+/// its Y-up render frame, and nothing here assumes which axis is up except
+/// `rotation_axis`.
+#[derive(Clone, Copy, Debug)]
+pub struct ZoneBox {
+    pub center: [f64; 3],
+    /// FULL extents along the box's own local axes, matching the viewer's
+    /// `Zone.size` (not half-extents).
+    pub size: [f64; 3],
+    /// Rotation about the vertical axis, radians.
+    pub rotation_y: f64,
+}
+
+impl ZoneBox {
+    /// The box as an outward-wound triangle soup in world coordinates.
+    fn to_tris(self) -> Vec<Tri> {
+        let h = [self.size[0] / 2.0, self.size[1] / 2.0, self.size[2] / 2.0];
+        let local = box_mesh([-h[0], -h[1], -h[2]], [h[0], h[1], h[2]]);
+        let (sin, cos) = self.rotation_y.sin_cos();
+        local
+            .into_iter()
+            .map(|t| {
+                t.map(|p| {
+                    [
+                        self.center[0] + p[0] * cos - p[2] * sin,
+                        self.center[1] + p[1],
+                        self.center[2] + p[0] * sin + p[2] * cos,
+                    ]
+                })
+            })
+            .collect()
+    }
+
+    /// World-space axis-aligned bounds, for the cheap reject below.
+    fn world_aabb(self) -> ([f64; 3], [f64; 3]) {
+        let mut lo = [f64::INFINITY; 3];
+        let mut hi = [f64::NEG_INFINITY; 3];
+        for t in self.to_tris() {
+            for p in t {
+                for k in 0..3 {
+                    lo[k] = lo[k].min(p[k]);
+                    hi[k] = hi[k].max(p[k]);
+                }
+            }
+        }
+        (lo, hi)
+    }
+}
+
+/// One solid produced by the split.
+#[derive(Clone, Debug)]
+pub struct ZonePiece {
+    /// Index into the `zones` slice, or `None` for the remainder (the part of
+    /// the element inside no zone).
+    pub zone: Option<usize>,
+    pub tris: Vec<Tri>,
+    /// Enclosed volume of THIS piece, from the same divergence sum the kernel
+    /// uses for a whole element.
+    pub volume: f64,
+}
+
+/// The whole split of one element.
+#[derive(Clone, Debug)]
+pub struct ZoneSplit {
+    /// Non-empty pieces only, in zone order, remainder last.
+    pub pieces: Vec<ZonePiece>,
+    /// Enclosed volume of the input, so a caller can check the pieces against
+    /// it without re-deriving it from a different producer.
+    pub whole_volume: f64,
+}
+
+impl ZoneSplit {
+    /// How far the pieces are from summing to the whole, RELATIVE to the whole.
+    ///
+    /// The invariant #2508 puts above every other for this feature. Exposed
+    /// rather than asserted here: a caller that wants to refuse an untrustworthy
+    /// split needs the number, and a caller displaying a warning needs it too.
+    pub fn sum_error_rel(&self) -> f64 {
+        if self.whole_volume.abs() <= f64::MIN_POSITIVE {
+            return 0.0;
+        }
+        let sum: f64 = self.pieces.iter().map(|p| p.volume).sum();
+        ((sum - self.whole_volume) / self.whole_volume).abs()
+    }
+}
+
+/// A piece whose volume is below this fraction of the whole is dropped.
+///
+/// The kernel can return a few slivers where two zone boxes share a boundary
+/// plane, and a piece of a nanolitre is not a piece: it is noise a user would
+/// have to identify and delete by hand. Matches the intent of the
+/// apportionment path's own negligible-share threshold, one level up.
+pub const NEGLIGIBLE_PIECE_REL: f64 = 1e-9;
+
+/// Split `host` into one solid per zone it reaches, plus the remainder.
+///
+/// `host` must be a closed orientable solid; the caller is responsible for that
+/// gate (in the viewer, the same `GeometryClosure` proof that gates a stated
+/// volume at all). Winding need not be outward: each operand is oriented before
+/// it enters the arrangement, exactly as `subtract` / `intersection` do.
+///
+/// Zones that cannot reach the host's bounds are skipped without touching a
+/// triangle, so the cost is `O(triangles x zones the element actually reaches)`.
+///
+/// Zones are expected to be pairwise non-overlapping, the same contract
+/// `subtract_many` states for its cutter group. Nothing forbids a user drawing
+/// overlapping zones, and the failure is not silent: overlapping pieces
+/// double-count, so [`ZoneSplit::sum_error_rel`] rises far above any floating
+/// point residue and the caller can refuse on it. That is the same signal the
+/// apportionment path reports as `overlapping`.
+pub fn split_mesh_by_zones(host: &[Tri], zones: &[ZoneBox]) -> ZoneSplit {
+    let host = orient_outward(host.to_vec());
+    let whole_volume = signed_volume_of(&host);
+    let negligible = whole_volume.abs() * NEGLIGIBLE_PIECE_REL;
+    let (host_lo, host_hi) = tris_aabb(&host);
+
+    let mut pieces = Vec::new();
+    let mut reached: Vec<Vec<Tri>> = Vec::new();
+    for (index, zone) in zones.iter().enumerate() {
+        let (lo, hi) = zone.world_aabb();
+        if (0..3).any(|k| lo[k] > host_hi[k] || hi[k] < host_lo[k]) {
+            continue;
+        }
+        let box_tris = orient_outward(zone.to_tris());
+        let piece = boolean(&host, &box_tris, BoolOp::Intersection);
+        let volume = signed_volume_of(&piece);
+        // Kept for the remainder even when the piece itself is negligible: a
+        // box the element merely abuts contributes no solid but must still be
+        // subtracted, or the remainder would double-count the boundary.
+        reached.push(box_tris);
+        if piece.is_empty() || volume <= negligible {
+            continue;
+        }
+        pieces.push(ZonePiece { zone: Some(index), tris: piece, volume });
+    }
+
+    if !reached.is_empty() {
+        let operands: Vec<&[Tri]> = reached.iter().map(|t| t.as_slice()).collect();
+        // ONE arrangement against every box, not a chain of differences: a
+        // chain would re-snap the previous cut's seams on every step.
+        if let Some(rest) = difference_all(&host, &operands) {
+            let volume = signed_volume_of(&rest);
+            if !rest.is_empty() && volume > negligible {
+                pieces.push(ZonePiece { zone: None, tris: rest, volume });
+            }
+        }
+    } else {
+        // No zone reaches the element at all, so all of it is the remainder.
+        // Returning nothing here would state that the element vanished.
+        pieces.push(ZonePiece { zone: None, tris: host, volume: whole_volume });
+    }
+
+    ZoneSplit { pieces, whole_volume }
+}
+
+fn tris_aabb(tris: &[Tri]) -> ([f64; 3], [f64; 3]) {
+    let mut lo = [f64::INFINITY; 3];
+    let mut hi = [f64::NEG_INFINITY; 3];
+    for t in tris {
+        for p in t {
+            for k in 0..3 {
+                lo[k] = lo[k].min(p[k]);
+                hi[k] = hi[k].max(p[k]);
+            }
+        }
+    }
+    (lo, hi)
+}
+
+#[cfg(test)]
+#[path = "zone_split_tests.rs"]
+mod tests;

--- a/rust/geometry/src/zone_split.rs
+++ b/rust/geometry/src/zone_split.rs
@@ -32,7 +32,7 @@
 //!   only reach `Mesh` (f32) at the caller's boundary. A per-piece f64 -> f32 ->
 //!   f64 round trip is what turns a shared zone boundary into a crack.
 
-use crate::kernel::arrangement::{boolean, box_mesh, difference_all, BoolOp, Tri};
+use crate::kernel::arrangement::{boolean, box_mesh, difference_all, union_all, BoolOp, Tri};
 use crate::kernel::mesh_bridge::{orient_outward, signed_volume_of};
 
 /// A zone as the viewer authors it: an oriented box that rotates about the
@@ -227,21 +227,35 @@ pub fn split_mesh_by_zones(host: &[Tri], zones: &[ZoneShape]) -> ZoneSplit {
         let box_tris = orient_outward(zone.to_tris());
         let piece = boolean(&host, &box_tris, BoolOp::Intersection);
         let volume = signed_volume_of(&piece);
-        // Kept for the remainder even when the piece itself is negligible: a
-        // box the element merely abuts contributes no solid but must still be
-        // subtracted, or the remainder would double-count the boundary.
-        reached.push(box_tris);
         if piece.is_empty() || volume <= negligible {
+            // NOT subtracted from the remainder. A zone the element merely
+            // abuts takes nothing, so leaving it out cannot double-count: the
+            // sliver simply stays in the remainder and the sum stays exact.
+            // Subtracting it would instead feed the arrangement an
+            // exactly-coplanar operand with no intersection to show for it,
+            // which is the kernel's hardest case for no benefit.
             continue;
         }
+        reached.push(box_tris);
         pieces.push(ZonePiece { zone: Some(index), tris: piece, volume });
     }
 
     if !reached.is_empty() {
+        // UNIONED first, then subtracted as ONE operand.
+        //
+        // `difference_all` requires its cutters to be pairwise disjoint, and a
+        // zone set that TILES shares boundary planes: two coincident,
+        // opposite-wound cutter faces at each shared plane are classified only
+        // against the host, so both survive into the result as a zero-volume
+        // membrane inside the remainder. The volume is unaffected (the pair
+        // cancels), which is exactly why no volume-based check can see it --
+        // but the remainder is published as a closed solid, and a consumer that
+        // renders or exports it would show a phantom wall at every zone
+        // boundary. `union_all` merges the tiles first and drops each
+        // co-oriented duplicate, so the difference sees one clean operand.
         let operands: Vec<&[Tri]> = reached.iter().map(|t| t.as_slice()).collect();
-        // ONE arrangement against every box, not a chain of differences: a
-        // chain would re-snap the previous cut's seams on every step.
-        if let Some(rest) = difference_all(&host, &operands) {
+        let (cutter, _conforming) = union_all(&operands);
+        if let Some(rest) = difference_all(&host, &[&cutter]) {
             let volume = signed_volume_of(&rest);
             if !rest.is_empty() && volume > negligible {
                 pieces.push(ZonePiece { zone: None, tris: rest, volume });

--- a/rust/geometry/src/zone_split.rs
+++ b/rust/geometry/src/zone_split.rs
@@ -266,17 +266,25 @@ pub fn split_mesh_by_zones(host: &[Tri], zones: &[ZoneShape]) -> ZoneSplit {
         // boundary. `union_all` merges the tiles first and drops each
         // co-oriented duplicate, so the difference sees one clean operand.
         let operands: Vec<&[Tri]> = reached.iter().map(|t| t.as_slice()).collect();
-        let (cutter, _conforming) = union_all(&operands);
-        match difference_all(&host, &[&cutter]) {
+        let (cutter, conforming) = union_all(&operands);
+        // A non-conforming union is refused BEFORE the difference sees it: the
+        // cutter would already be torn, and `difference_all`'s own conformity
+        // gate is about ITS arrangement, not about the operand it was handed.
+        // `union_many` does trust a torn union, but only because its one caller
+        // verifies the subtract that follows; nothing verifies this one, so a
+        // remainder built on it would be the piece nobody checked.
+        //
+        // Either way the failure is SAID rather than left to `sum_error_rel`,
+        // which a caller cannot tell apart from overlapping zones and which
+        // would point them at redrawing zones that are not the problem.
+        let rest = if conforming { difference_all(&host, &[&cutter]) } else { None };
+        match rest {
             Some(rest) => {
                 let volume = signed_volume_of(&rest);
                 if !rest.is_empty() && volume > negligible {
                     pieces.push(ZonePiece { zone: None, tris: rest, volume });
                 }
             }
-            // Said out loud rather than left to `sum_error_rel`, which a caller
-            // cannot tell apart from overlapping zones and which would point
-            // them at redrawing zones that are not the problem.
             None => remainder_failed = true,
         }
     } else {

--- a/rust/geometry/src/zone_split_tests.rs
+++ b/rust/geometry/src/zone_split_tests.rs
@@ -21,12 +21,12 @@ fn wall() -> Vec<Tri> {
 }
 
 /// A zone spanning `[x0, x1]` in x and covering the wall entirely in y and z.
-fn slab(x0: f64, x1: f64) -> ZoneBox {
-    ZoneBox {
+fn slab(x0: f64, x1: f64) -> ZoneShape {
+    ZoneShape::Box(ZoneBox {
         center: [(x0 + x1) / 2.0, 0.5, 0.5],
         size: [x1 - x0, 4.0, 4.0],
         rotation_y: 0.0,
-    }
+    })
 }
 
 fn volume_of(split: &ZoneSplit, zone: Option<usize>) -> f64 {
@@ -119,7 +119,7 @@ fn a_rotated_zone_cuts_where_its_own_axes_are() {
     // rotation ignored, the same box is an axis-aligned 8 x 4 x 0.5 slab whose
     // z extent (0.5 m, centred at z = 0.5) still covers the wall, so a naive
     // implementation passes. Hence the second, tighter zone below.
-    let inside = ZoneBox { center: [3.0, 0.5, 0.5], size: [8.0, 4.0, 8.0], rotation_y: 45f64.to_radians() };
+    let inside = ZoneShape::Box(ZoneBox { center: [3.0, 0.5, 0.5], size: [8.0, 4.0, 8.0], rotation_y: 45f64.to_radians() });
     let split = split_mesh_by_zones(&wall(), &[inside]);
     assert!((volume_of(&split, Some(0)) - 6.0).abs() < EPS);
 
@@ -129,7 +129,7 @@ fn a_rotated_zone_cuts_where_its_own_axes_are() {
     // depth projected, i.e. the intersection is a parallelogram prism of area
     // (0.4/cos45) * 1 in the x/z plane... which is 0.5656854 m2, times the 1 m
     // height = 0.5656854 m3. Unrotated, the same blade would take 0.4 m3.
-    let blade = ZoneBox { center: [3.0, 0.5, 0.5], size: [0.4, 4.0, 8.0], rotation_y: 45f64.to_radians() };
+    let blade = ZoneShape::Box(ZoneBox { center: [3.0, 0.5, 0.5], size: [0.4, 4.0, 8.0], rotation_y: 45f64.to_radians() });
     let split = split_mesh_by_zones(&wall(), &[blade]);
     let expected = 0.4 * 2f64.sqrt();
     assert!(
@@ -145,7 +145,7 @@ fn a_rotated_zone_cuts_where_its_own_axes_are() {
 fn a_zone_bigger_than_the_element_takes_all_of_it_and_leaves_no_remainder() {
     let split = split_mesh_by_zones(
         &wall(),
-        &[ZoneBox { center: [3.0, 0.5, 0.5], size: [100.0, 100.0, 100.0], rotation_y: 0.0 }],
+        &[ZoneShape::Box(ZoneBox { center: [3.0, 0.5, 0.5], size: [100.0, 100.0, 100.0], rotation_y: 0.0 })],
     );
     assert_eq!(split.pieces.len(), 1);
     assert!((split.pieces[0].volume - 6.0).abs() < EPS);
@@ -155,7 +155,7 @@ fn a_zone_bigger_than_the_element_takes_all_of_it_and_leaves_no_remainder() {
 fn a_zero_size_zone_takes_nothing_and_does_not_crash() {
     let split = split_mesh_by_zones(
         &wall(),
-        &[ZoneBox { center: [3.0, 0.5, 0.5], size: [0.0, 0.0, 0.0], rotation_y: 0.0 }],
+        &[ZoneShape::Box(ZoneBox { center: [3.0, 0.5, 0.5], size: [0.0, 0.0, 0.0], rotation_y: 0.0 })],
     );
     assert!(volume_of(&split, Some(0)) < EPS);
     assert!((volume_of(&split, None) - 6.0).abs() < EPS);
@@ -222,4 +222,56 @@ fn the_pieces_are_closed_solids_and_not_merely_clipped_shells() {
             about_far,
         );
     }
+}
+
+#[test]
+fn a_prism_zone_cuts_by_its_polygon_and_not_by_its_bounding_box() {
+    // A triangle in plan whose bounding box covers the whole wall but which
+    // itself covers a known fraction of it. The wall spans x = 0..6, z = 0..1.
+    // The triangle (0,0) - (6,0) - (0,1) cuts the wall's plan rectangle along
+    // the diagonal, taking exactly half of its 6 m2 footprint, so half its
+    // volume. A box-shaped implementation would take all 6 m3.
+    let prism = ZoneShape::Prism {
+        footprint: vec![[0.0, 0.0], [6.0, 0.0], [0.0, 1.0]],
+        min_y: -1.0,
+        max_y: 2.0,
+    };
+    let split = split_mesh_by_zones(&wall(), &[prism]);
+
+    assert!(
+        (volume_of(&split, Some(0)) - 3.0).abs() < 1e-6,
+        "prism took {} m3, expected 3",
+        volume_of(&split, Some(0)),
+    );
+    assert!((volume_of(&split, None) - 3.0).abs() < 1e-6, "remainder {}", volume_of(&split, None));
+    assert!(split.sum_error_rel() < 1e-9, "sum error {}", split.sum_error_rel());
+}
+
+#[test]
+fn two_prisms_tiling_the_plan_split_the_element_between_them() {
+    let lower = ZoneShape::Prism {
+        footprint: vec![[-1.0, -1.0], [8.0, -1.0], [8.0, 2.0]],
+        min_y: -1.0,
+        max_y: 2.0,
+    };
+    let upper = ZoneShape::Prism {
+        footprint: vec![[-1.0, -1.0], [8.0, 2.0], [-1.0, 2.0]],
+        min_y: -1.0,
+        max_y: 2.0,
+    };
+    let split = split_mesh_by_zones(&wall(), &[lower, upper]);
+
+    assert!(volume_of(&split, None) < 1e-6, "the tiling should leave no remainder");
+    assert!(split.sum_error_rel() < 1e-9, "sum error {}", split.sum_error_rel());
+    // Neither zone took the lot, or the test would pass on a splitter that
+    // ignored the second polygon.
+    assert!(volume_of(&split, Some(0)) > 0.5 && volume_of(&split, Some(1)) > 0.5);
+}
+
+#[test]
+fn a_prism_with_too_few_points_takes_nothing_rather_than_panicking() {
+    let degenerate = ZoneShape::Prism { footprint: vec![[0.0, 0.0], [1.0, 0.0]], min_y: -1.0, max_y: 2.0 };
+    let split = split_mesh_by_zones(&wall(), &[degenerate]);
+    assert!(volume_of(&split, Some(0)) < EPS);
+    assert!((volume_of(&split, None) - 6.0).abs() < EPS);
 }

--- a/rust/geometry/src/zone_split_tests.rs
+++ b/rust/geometry/src/zone_split_tests.rs
@@ -1,0 +1,225 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Tests for the zone split (#2508 item 2).
+//!
+//! Every expected number here is hand-computable from the fixture, which is
+//! what #2508's verification bar asks for: "a box wall crossing one boundary at
+//! a known fraction, a wall crossing two boundaries, an element wholly inside,
+//! an element wholly outside, an element touching exactly at a boundary plane".
+//! A test that only asserted "the pieces sum to the whole" would pass on a
+//! split that put every cubic metre in the wrong zone.
+
+use super::*;
+use crate::kernel::arrangement::box_mesh;
+
+/// A 6 x 1 x 1 m wall from x = 0 to x = 6, so a boundary at x = c leaves
+/// exactly `c` m3 below it. Volume 6.
+fn wall() -> Vec<Tri> {
+    box_mesh([0.0, 0.0, 0.0], [6.0, 1.0, 1.0])
+}
+
+/// A zone spanning `[x0, x1]` in x and covering the wall entirely in y and z.
+fn slab(x0: f64, x1: f64) -> ZoneBox {
+    ZoneBox {
+        center: [(x0 + x1) / 2.0, 0.5, 0.5],
+        size: [x1 - x0, 4.0, 4.0],
+        rotation_y: 0.0,
+    }
+}
+
+fn volume_of(split: &ZoneSplit, zone: Option<usize>) -> f64 {
+    split
+        .pieces
+        .iter()
+        .filter(|p| p.zone == zone)
+        .map(|p| p.volume)
+        .sum()
+}
+
+/// Tight, because these are exact-arithmetic cuts of axis-aligned boxes: the
+/// residue is f64 accumulation in the divergence sum and nothing else.
+const EPS: f64 = 1e-9;
+
+#[test]
+fn wall_crossing_one_boundary_splits_at_the_known_fraction() {
+    let split = split_mesh_by_zones(&wall(), &[slab(-1.0, 2.0), slab(2.0, 7.0)]);
+
+    assert!((split.whole_volume - 6.0).abs() < EPS, "whole {}", split.whole_volume);
+    assert!((volume_of(&split, Some(0)) - 2.0).abs() < EPS, "{:?}", split.pieces.iter().map(|p| (p.zone, p.volume)).collect::<Vec<_>>());
+    assert!((volume_of(&split, Some(1)) - 4.0).abs() < EPS);
+    assert!(split.sum_error_rel() < 1e-12, "sum error {}", split.sum_error_rel());
+}
+
+#[test]
+fn wall_crossing_two_boundaries_gives_three_pieces() {
+    let split = split_mesh_by_zones(&wall(), &[slab(-1.0, 1.5), slab(1.5, 4.5), slab(4.5, 7.0)]);
+
+    assert!((volume_of(&split, Some(0)) - 1.5).abs() < EPS);
+    assert!((volume_of(&split, Some(1)) - 3.0).abs() < EPS);
+    assert!((volume_of(&split, Some(2)) - 1.5).abs() < EPS);
+    assert!(volume_of(&split, None) < EPS, "nothing should be left over");
+    assert!(split.sum_error_rel() < 1e-12);
+}
+
+#[test]
+fn an_element_wholly_inside_one_zone_is_one_piece_of_the_whole() {
+    let split = split_mesh_by_zones(&wall(), &[slab(-1.0, 7.0)]);
+
+    assert_eq!(split.pieces.len(), 1);
+    assert_eq!(split.pieces[0].zone, Some(0));
+    assert!((split.pieces[0].volume - 6.0).abs() < EPS);
+}
+
+#[test]
+fn an_element_in_no_zone_becomes_the_remainder_rather_than_vanishing() {
+    // The zone is far away in x. Returning no pieces here would say the
+    // element ceased to exist, which is the one answer a split must never give.
+    let split = split_mesh_by_zones(&wall(), &[slab(100.0, 110.0)]);
+
+    assert_eq!(split.pieces.len(), 1);
+    assert_eq!(split.pieces[0].zone, None);
+    assert!((split.pieces[0].volume - 6.0).abs() < EPS);
+    assert!(split.sum_error_rel() < 1e-12);
+}
+
+#[test]
+fn part_of_an_element_outside_every_zone_survives_as_the_remainder() {
+    let split = split_mesh_by_zones(&wall(), &[slab(-1.0, 2.0)]);
+
+    assert!((volume_of(&split, Some(0)) - 2.0).abs() < EPS);
+    assert!((volume_of(&split, None) - 4.0).abs() < EPS);
+    assert!(split.sum_error_rel() < 1e-12);
+}
+
+#[test]
+fn an_element_ending_exactly_on_a_boundary_plane_produces_no_second_piece() {
+    // The wall ends at x = 6 and the second zone starts there. This is the
+    // common case in takt planning, where sets tile a building on shared
+    // planes, and it is why v1's straddle epsilon is negative. A zero-thickness
+    // "piece" here would be a solid of no volume for a user to wonder about.
+    let split = split_mesh_by_zones(&wall(), &[slab(-1.0, 6.0), slab(6.0, 9.0)]);
+
+    assert_eq!(split.pieces.len(), 1, "{:?}", split.pieces.iter().map(|p| (p.zone, p.volume)).collect::<Vec<_>>());
+    assert_eq!(split.pieces[0].zone, Some(0));
+    assert!((split.pieces[0].volume - 6.0).abs() < EPS);
+}
+
+#[test]
+fn a_rotated_zone_cuts_where_its_own_axes_are() {
+    // A zone rotated 45 degrees about Y, centred on the wall's own centre line
+    // at x = 3. Its local +x axis points along (1, 0, 1)/sqrt(2), and the plane
+    // through the centre normal to that axis crosses the wall's centre line at
+    // x = 3, so it takes exactly the half of the wall below x = 3 minus what
+    // the rotation trims in z. The box is made long enough (8 m local x, 8 m
+    // local z) that the only face cutting the wall is the one at local
+    // x = -4... which the placement below puts far outside, so the whole wall
+    // is inside. What this pins is that ROTATION IS APPLIED AT ALL: with
+    // rotation ignored, the same box is an axis-aligned 8 x 4 x 0.5 slab whose
+    // z extent (0.5 m, centred at z = 0.5) still covers the wall, so a naive
+    // implementation passes. Hence the second, tighter zone below.
+    let inside = ZoneBox { center: [3.0, 0.5, 0.5], size: [8.0, 4.0, 8.0], rotation_y: 45f64.to_radians() };
+    let split = split_mesh_by_zones(&wall(), &[inside]);
+    assert!((volume_of(&split, Some(0)) - 6.0).abs() < EPS);
+
+    // A thin blade, 0.4 m across its local x, standing at 45 degrees through
+    // the wall at x = 3. Rotated, it sweeps a diagonal band across the wall's
+    // 1 m depth: the band's extent along x is 0.4*sqrt(2) plus the 1 m of z
+    // depth projected, i.e. the intersection is a parallelogram prism of area
+    // (0.4/cos45) * 1 in the x/z plane... which is 0.5656854 m2, times the 1 m
+    // height = 0.5656854 m3. Unrotated, the same blade would take 0.4 m3.
+    let blade = ZoneBox { center: [3.0, 0.5, 0.5], size: [0.4, 4.0, 8.0], rotation_y: 45f64.to_radians() };
+    let split = split_mesh_by_zones(&wall(), &[blade]);
+    let expected = 0.4 * 2f64.sqrt();
+    assert!(
+        (volume_of(&split, Some(0)) - expected).abs() < 1e-6,
+        "rotated blade took {} m3, expected {}",
+        volume_of(&split, Some(0)),
+        expected,
+    );
+    assert!(split.sum_error_rel() < 1e-9, "sum error {}", split.sum_error_rel());
+}
+
+#[test]
+fn a_zone_bigger_than_the_element_takes_all_of_it_and_leaves_no_remainder() {
+    let split = split_mesh_by_zones(
+        &wall(),
+        &[ZoneBox { center: [3.0, 0.5, 0.5], size: [100.0, 100.0, 100.0], rotation_y: 0.0 }],
+    );
+    assert_eq!(split.pieces.len(), 1);
+    assert!((split.pieces[0].volume - 6.0).abs() < EPS);
+}
+
+#[test]
+fn a_zero_size_zone_takes_nothing_and_does_not_crash() {
+    let split = split_mesh_by_zones(
+        &wall(),
+        &[ZoneBox { center: [3.0, 0.5, 0.5], size: [0.0, 0.0, 0.0], rotation_y: 0.0 }],
+    );
+    assert!(volume_of(&split, Some(0)) < EPS);
+    assert!((volume_of(&split, None) - 6.0).abs() < EPS);
+}
+
+#[test]
+fn an_empty_host_produces_nothing_rather_than_panicking() {
+    let split = split_mesh_by_zones(&[], &[slab(0.0, 1.0)]);
+    assert_eq!(split.whole_volume, 0.0);
+    assert!(split.pieces.iter().all(|p| p.volume.abs() < EPS));
+}
+
+#[test]
+fn an_inward_wound_host_still_yields_positive_pieces() {
+    // Real IFC winding is not reliably outward (see `orient_outward`'s doc). A
+    // split that reported negative volumes for an inward-wound wall would be
+    // reporting the winding, not the geometry.
+    let mut flipped = wall();
+    for t in &mut flipped {
+        t.swap(1, 2);
+    }
+    let split = split_mesh_by_zones(&flipped, &[slab(-1.0, 2.0), slab(2.0, 7.0)]);
+
+    assert!(split.whole_volume > 0.0, "whole {}", split.whole_volume);
+    assert!((volume_of(&split, Some(0)) - 2.0).abs() < EPS);
+    assert!((volume_of(&split, Some(1)) - 4.0).abs() < EPS);
+}
+
+#[test]
+fn overlapping_zones_are_reported_by_the_sum_invariant_rather_than_hidden() {
+    // v1 does not forbid overlapping zones. Both pieces are individually
+    // correct and together they double-count the overlap, so the honest signal
+    // is the invariant failing loudly rather than a plausible-looking split.
+    let split = split_mesh_by_zones(&wall(), &[slab(-1.0, 4.0), slab(2.0, 7.0)]);
+
+    assert!((volume_of(&split, Some(0)) - 4.0).abs() < EPS);
+    assert!((volume_of(&split, Some(1)) - 4.0).abs() < EPS);
+    assert!(
+        split.sum_error_rel() > 0.1,
+        "overlap should be visible in the sum, got {}",
+        split.sum_error_rel(),
+    );
+}
+
+#[test]
+fn the_pieces_are_closed_solids_and_not_merely_clipped_shells() {
+    // A volume measured about the origin and about a far-away point agree only
+    // for a CLOSED surface: the divergence sum of an open shell depends on the
+    // point it is measured about. This is what distinguishes a real split from
+    // a set of cut-open faces that happen to sum correctly.
+    let split = split_mesh_by_zones(&wall(), &[slab(-1.0, 2.0), slab(2.0, 7.0)]);
+    for piece in &split.pieces {
+        let shifted: Vec<Tri> = piece
+            .tris
+            .iter()
+            .map(|t| t.map(|p| [p[0] + 1000.0, p[1] - 500.0, p[2] + 250.0]))
+            .collect();
+        let about_far = crate::kernel::mesh_bridge::signed_volume_of(&shifted);
+        assert!(
+            (about_far - piece.volume).abs() < 1e-6,
+            "piece {:?} is not closed: {} about the origin, {} about a far point",
+            piece.zone,
+            piece.volume,
+            about_far,
+        );
+    }
+}

--- a/rust/geometry/src/zone_split_tests.rs
+++ b/rust/geometry/src/zone_split_tests.rs
@@ -294,6 +294,16 @@ fn oriented_key(t: &Tri) -> String {
         .join("|")
 }
 
+/// The first face whose opposite winding is also present, for a failure message
+/// that points at the membrane instead of at triangle zero.
+fn first_membrane_face(tris: &[Tri]) -> Option<Tri> {
+    use std::collections::HashSet;
+    let forward: HashSet<String> = tris.iter().map(oriented_key).collect();
+    tris.iter()
+        .find(|t| forward.contains(&oriented_key(&[t[0], t[2], t[1]])))
+        .copied()
+}
+
 /// Faces that appear both ways round in one solid: a zero-volume membrane.
 fn back_to_back_pairs(tris: &[Tri]) -> usize {
     use std::collections::HashSet;
@@ -325,15 +335,16 @@ fn a_tiling_leaves_no_membrane_inside_the_remainder() {
         .find(|p| p.zone.is_none())
         .expect("the wall's x = 4..6 tail must survive as the remainder");
     assert!((remainder.volume - 2.0).abs() < EPS, "remainder volume {}", remainder.volume);
+    let membranes = back_to_back_pairs(&remainder.tris);
     assert_eq!(
-        back_to_back_pairs(&remainder.tris),
+        membranes,
         0,
         "the remainder carries {} membrane faces, e.g. {:?}",
-        back_to_back_pairs(&remainder.tris),
-        remainder.tris.iter().find(|t| {
-            let flipped = [t[0], t[2], t[1]];
-            back_to_back_pairs(&[**t, flipped]) > 0
-        }),
+        membranes,
+        // The FIRST triangle whose flip is also present, rather than the first
+        // triangle of the piece: a message that always names triangle 0 tells
+        // the next reader nothing about where the membrane is.
+        first_membrane_face(&remainder.tris),
     );
 }
 

--- a/rust/geometry/src/zone_split_tests.rs
+++ b/rust/geometry/src/zone_split_tests.rs
@@ -213,7 +213,7 @@ fn the_pieces_are_closed_solids_and_not_merely_clipped_shells() {
             .iter()
             .map(|t| t.map(|p| [p[0] + 1000.0, p[1] - 500.0, p[2] + 250.0]))
             .collect();
-        let about_far = crate::kernel::mesh_bridge::signed_volume_of(&shifted);
+        let about_far = crate::kernel::signed_volume::signed_volume_of(&shifted);
         assert!(
             (about_far - piece.volume).abs() < 1e-6,
             "piece {:?} is not closed: {} about the origin, {} about a far point",

--- a/rust/geometry/src/zone_split_tests.rs
+++ b/rust/geometry/src/zone_split_tests.rs
@@ -275,3 +275,100 @@ fn a_prism_with_too_few_points_takes_nothing_rather_than_panicking() {
     assert!(volume_of(&split, Some(0)) < EPS);
     assert!((volume_of(&split, None) - 6.0).abs() < EPS);
 }
+
+/// A triangle's vertices in a rotation-independent, winding-SENSITIVE key, so
+/// two copies of the same face wound oppositely hash differently.
+fn oriented_key(t: &Tri) -> String {
+    let start = (0..3)
+        .min_by(|&a, &b| {
+            let (x, y) = (t[a], t[b]);
+            x.partial_cmp(&y).unwrap_or(std::cmp::Ordering::Equal)
+        })
+        .unwrap_or(0);
+    (0..3)
+        .map(|i| {
+            let p = t[(start + i) % 3];
+            format!("{:.9},{:.9},{:.9}", p[0], p[1], p[2])
+        })
+        .collect::<Vec<_>>()
+        .join("|")
+}
+
+/// Faces that appear both ways round in one solid: a zero-volume membrane.
+fn back_to_back_pairs(tris: &[Tri]) -> usize {
+    use std::collections::HashSet;
+    let forward: HashSet<String> = tris.iter().map(oriented_key).collect();
+    tris.iter()
+        .filter(|t| {
+            let flipped = [t[0], t[2], t[1]];
+            forward.contains(&oriented_key(&flipped))
+        })
+        .count()
+}
+
+#[test]
+fn a_tiling_leaves_no_membrane_inside_the_remainder() {
+    // Two zones sharing the plane x = 2, covering only part of the wall, so the
+    // remainder is a real solid rather than a dropped sliver.
+    //
+    // `difference_all` documents that its cutters must be pairwise disjoint,
+    // and a tiling zone set is precisely the case that violates it: the two
+    // coincident, opposite-wound cutter faces at x = 2 are each classified only
+    // against the host, so BOTH survive into the remainder as a zero-volume
+    // membrane. Volume cannot see it (the pair cancels), which is why the
+    // assertion is on the faces rather than on any number.
+    let split = split_mesh_by_zones(&wall(), &[slab(0.0, 2.0), slab(2.0, 4.0)]);
+
+    let remainder = split
+        .pieces
+        .iter()
+        .find(|p| p.zone.is_none())
+        .expect("the wall's x = 4..6 tail must survive as the remainder");
+    assert!((remainder.volume - 2.0).abs() < EPS, "remainder volume {}", remainder.volume);
+    assert_eq!(
+        back_to_back_pairs(&remainder.tris),
+        0,
+        "the remainder carries {} membrane faces, e.g. {:?}",
+        back_to_back_pairs(&remainder.tris),
+        remainder.tris.iter().find(|t| {
+            let flipped = [t[0], t[2], t[1]];
+            back_to_back_pairs(&[**t, flipped]) > 0
+        }),
+    );
+}
+
+#[test]
+fn a_prism_tiling_leaves_no_membrane_either() {
+    let lower = ZoneShape::Prism {
+        footprint: vec![[-1.0, -1.0], [3.0, -1.0], [3.0, 2.0], [-1.0, 2.0]],
+        min_y: -1.0,
+        max_y: 2.0,
+    };
+    let upper = ZoneShape::Prism {
+        footprint: vec![[3.0, -1.0], [5.0, -1.0], [5.0, 2.0], [3.0, 2.0]],
+        min_y: -1.0,
+        max_y: 2.0,
+    };
+    let split = split_mesh_by_zones(&wall(), &[lower, upper]);
+    let remainder = split
+        .pieces
+        .iter()
+        .find(|p| p.zone.is_none())
+        .expect("x = 5..6 must survive as the remainder");
+    assert_eq!(back_to_back_pairs(&remainder.tris), 0);
+    assert!(split.sum_error_rel() < 1e-9, "sum error {}", split.sum_error_rel());
+}
+
+#[test]
+fn a_zone_the_element_only_abuts_is_not_subtracted_from_the_remainder() {
+    // The second zone starts exactly where the wall ends, so it takes nothing.
+    // Subtracting it anyway would hand the arrangement an exactly-coplanar
+    // operand with no intersection to show for it, and a refusal there
+    // (`difference_all` returns None) would lose the remainder entirely.
+    let split = split_mesh_by_zones(&wall(), &[slab(0.0, 2.0), slab(6.0, 9.0)]);
+
+    let remainder = split.pieces.iter().find(|p| p.zone.is_none());
+    assert!(remainder.is_some(), "the x = 2..6 remainder was lost");
+    assert!((remainder.unwrap().volume - 4.0).abs() < EPS);
+    assert!(split.sum_error_rel() < 1e-12);
+}

--- a/rust/wasm-bindings/src/api/mod.rs
+++ b/rust/wasm-bindings/src/api/mod.rs
@@ -27,6 +27,7 @@ mod simplify;
 mod space_plate;
 pub(crate) mod styling;
 mod symbolic;
+mod zone_split;
 
 use csg_diagnostics::drain_and_log_csg_diagnostics;
 

--- a/rust/wasm-bindings/src/api/zone_split.rs
+++ b/rust/wasm-bindings/src/api/zone_split.rs
@@ -122,6 +122,13 @@ impl ZoneSplitJs {
 /// clip of an open shell produces pieces whose volumes are arbitrary rather
 /// than approximate.
 ///
+/// A triangle with an out-of-range index or a non-finite coordinate is DROPPED
+/// rather than reported, matching `kernel::mesh_bridge::mesh_to_tris`, which is
+/// panic-free for the same reason: the alternative is a crash deep in the
+/// predicates. It does mean a malformed caller can open the surface and get
+/// meaningless volumes with a plausible `sumErrorRel`, so the closure proof
+/// above is the caller's responsibility and not a formality.
+///
 /// ```javascript
 /// const split = splitMeshByZones(positions, indices, new Float64Array([
 ///   0, 0, 0, 10, 10, 10, 0,

--- a/rust/wasm-bindings/src/api/zone_split.rs
+++ b/rust/wasm-bindings/src/api/zone_split.rs
@@ -1,0 +1,189 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! WASM API: splitMeshByZones - cut one element into one closed solid per
+//! location zone (issue #2508 item 2).
+//!
+//! The kernel side is `ifc_lite_geometry::zone_split`; this is the boundary.
+//! Two things about the contract matter more than the shape:
+//!
+//! - **Everything is in the CALLER's frame.** The viewer passes render-frame
+//!   positions (Y-up, RTC-subtracted, metres) and zone boxes authored against
+//!   that same frame, so no conversion happens here and none is implied. The
+//!   only axis assumption is that zone rotation is about Y, which is the
+//!   viewer's own zone model.
+//! - **Positions cross as f64.** The split's whole value over an AABB estimate
+//!   is exactness, and a per-piece f64 -> f32 -> f64 round trip at this
+//!   boundary would put a crack back into every shared zone plane. The caller
+//!   narrows to f32 when it uploads to the GPU, once, at the end.
+
+use ifc_lite_geometry::zone_split::{split_mesh_by_zones, ZoneBox};
+use wasm_bindgen::prelude::*;
+
+/// One closed solid of a split element.
+#[wasm_bindgen]
+pub struct ZonePieceJs {
+    zone: i32,
+    positions: Vec<f64>,
+    indices: Vec<u32>,
+    volume: f64,
+}
+
+#[wasm_bindgen]
+impl ZonePieceJs {
+    /// Index into the zone array that was passed in, or `-1` for the part of
+    /// the element inside no zone.
+    #[wasm_bindgen(getter, js_name = zoneIndex)]
+    pub fn zone_index(&self) -> i32 {
+        self.zone
+    }
+
+    /// Flat `[x, y, z, ...]` in the caller's frame.
+    #[wasm_bindgen(getter)]
+    pub fn positions(&self) -> js_sys::Float64Array {
+        js_sys::Float64Array::from(&self.positions[..])
+    }
+
+    /// Flat triangle indices into `positions`.
+    #[wasm_bindgen(getter)]
+    pub fn indices(&self) -> js_sys::Uint32Array {
+        js_sys::Uint32Array::from(&self.indices[..])
+    }
+
+    /// Enclosed volume of this piece, cubic units of the caller's frame.
+    #[wasm_bindgen(getter)]
+    pub fn volume(&self) -> f64 {
+        self.volume
+    }
+}
+
+/// The result of splitting one element.
+#[wasm_bindgen]
+pub struct ZoneSplitJs {
+    pieces: Vec<ZonePieceJs>,
+    whole_volume: f64,
+    sum_error_rel: f64,
+}
+
+#[wasm_bindgen]
+impl ZoneSplitJs {
+    #[wasm_bindgen(getter, js_name = pieceCount)]
+    pub fn piece_count(&self) -> usize {
+        self.pieces.len()
+    }
+
+    /// Piece `index`, or `undefined` when out of range. Each call COPIES the
+    /// piece out, matching the rest of this API surface.
+    pub fn piece(&self, index: usize) -> Option<ZonePieceJs> {
+        self.pieces.get(index).map(|p| ZonePieceJs {
+            zone: p.zone,
+            positions: p.positions.clone(),
+            indices: p.indices.clone(),
+            volume: p.volume,
+        })
+    }
+
+    /// Enclosed volume of the input element.
+    #[wasm_bindgen(getter, js_name = wholeVolume)]
+    pub fn whole_volume(&self) -> f64 {
+        self.whole_volume
+    }
+
+    /// How far the pieces are from summing to the whole, relative.
+    ///
+    /// The invariant #2508 puts above everything else here. Exposed rather than
+    /// enforced: the caller decides what to do with a split that does not add
+    /// up (the expected cause is zones that overlap each other), and a number
+    /// it can show beats a silent refusal.
+    #[wasm_bindgen(getter, js_name = sumErrorRel)]
+    pub fn sum_error_rel(&self) -> f64 {
+        self.sum_error_rel
+    }
+}
+
+/// Split a mesh into one closed solid per zone, plus the remainder.
+///
+/// `positions` is flat XYZ (f64, caller's frame), `indices` flat triangle
+/// indices. `zones` is flat, SEVEN numbers per zone:
+/// `[cx, cy, cz, sx, sy, sz, rotationY]`, where the sizes are FULL extents
+/// (matching the viewer's `Zone.size`) and the rotation is radians about the
+/// vertical axis. A trailing partial zone is ignored rather than guessed at.
+///
+/// The caller must have established that the mesh is a closed orientable solid
+/// first, exactly as it must before quoting a volume at all (#1891/#1993): a
+/// clip of an open shell produces pieces whose volumes are arbitrary rather
+/// than approximate.
+///
+/// ```javascript
+/// const split = splitMeshByZones(positions, indices, new Float64Array([
+///   0, 0, 0, 10, 10, 10, 0,
+/// ]));
+/// for (let i = 0; i < split.pieceCount; i++) {
+///   const piece = split.piece(i);
+///   // piece.zoneIndex, piece.positions, piece.indices, piece.volume
+///   piece.free();
+/// }
+/// split.free();
+/// ```
+#[wasm_bindgen(js_name = splitMeshByZones)]
+pub fn split_mesh_by_zones_js(
+    positions: &[f64],
+    indices: &[u32],
+    zones: &[f64],
+) -> ZoneSplitJs {
+    let tris: Vec<[[f64; 3]; 3]> = indices
+        .chunks_exact(3)
+        .filter_map(|c| {
+            let vertex = |i: u32| -> Option<[f64; 3]> {
+                let b = (i as usize) * 3;
+                let p = [
+                    *positions.get(b)?,
+                    *positions.get(b + 1)?,
+                    *positions.get(b + 2)?,
+                ];
+                p.iter().all(|v| v.is_finite()).then_some(p)
+            };
+            Some([vertex(c[0])?, vertex(c[1])?, vertex(c[2])?])
+        })
+        .collect();
+
+    let boxes: Vec<ZoneBox> = zones
+        .chunks_exact(7)
+        .map(|z| ZoneBox {
+            center: [z[0], z[1], z[2]],
+            size: [z[3], z[4], z[5]],
+            rotation_y: z[6],
+        })
+        .collect();
+
+    let split = split_mesh_by_zones(&tris, &boxes);
+    let sum_error_rel = split.sum_error_rel();
+    let pieces = split
+        .pieces
+        .into_iter()
+        .map(|p| {
+            let mut flat = Vec::with_capacity(p.tris.len() * 9);
+            let mut idx = Vec::with_capacity(p.tris.len() * 3);
+            for t in &p.tris {
+                let base = (flat.len() / 3) as u32;
+                for v in t {
+                    flat.extend_from_slice(v);
+                }
+                idx.extend_from_slice(&[base, base + 1, base + 2]);
+            }
+            ZonePieceJs {
+                zone: p.zone.map_or(-1, |z| z as i32),
+                positions: flat,
+                indices: idx,
+                volume: p.volume,
+            }
+        })
+        .collect();
+
+    ZoneSplitJs {
+        pieces,
+        whole_volume: split.whole_volume,
+        sum_error_rel,
+    }
+}

--- a/rust/wasm-bindings/src/api/zone_split.rs
+++ b/rust/wasm-bindings/src/api/zone_split.rs
@@ -18,7 +18,7 @@
 //!   boundary would put a crack back into every shared zone plane. The caller
 //!   narrows to f32 when it uploads to the GPU, once, at the end.
 
-use ifc_lite_geometry::zone_split::{split_mesh_by_zones, ZoneBox};
+use ifc_lite_geometry::zone_split::{split_mesh_by_zones, ZoneBox, ZoneShape};
 use wasm_bindgen::prelude::*;
 
 /// One closed solid of a split element.
@@ -110,6 +110,13 @@ impl ZoneSplitJs {
 /// (matching the viewer's `Zone.size`) and the rotation is radians about the
 /// vertical axis. A trailing partial zone is ignored rather than guessed at.
 ///
+/// A zone becomes a PRISM (#2508 item 4) when `footprint_counts[i]` is
+/// non-zero: it then takes that many `[x, z]` pairs from `footprints`, in
+/// order, and uses the 7-tuple only for its vertical extent
+/// (`cy +/- sy/2`). The footprint must be CONVEX; the viewer gates that on
+/// import, because a concave polygon fans into overlapping triangles and would
+/// cut wrong rather than fail. Passing empty arrays keeps every zone a box.
+///
 /// The caller must have established that the mesh is a closed orientable solid
 /// first, exactly as it must before quoting a volume at all (#1891/#1993): a
 /// clip of an open shell produces pieces whose volumes are arbitrary rather
@@ -131,6 +138,8 @@ pub fn split_mesh_by_zones_js(
     positions: &[f64],
     indices: &[u32],
     zones: &[f64],
+    footprints: Option<Vec<f64>>,
+    footprint_counts: Option<Vec<u32>>,
 ) -> ZoneSplitJs {
     let tris: Vec<[[f64; 3]; 3]> = indices
         .chunks_exact(3)
@@ -148,16 +157,40 @@ pub fn split_mesh_by_zones_js(
         })
         .collect();
 
-    let boxes: Vec<ZoneBox> = zones
+    let footprints = footprints.unwrap_or_default();
+    let counts = footprint_counts.unwrap_or_default();
+    let mut cursor = 0usize;
+    let shapes: Vec<ZoneShape> = zones
         .chunks_exact(7)
-        .map(|z| ZoneBox {
-            center: [z[0], z[1], z[2]],
-            size: [z[3], z[4], z[5]],
-            rotation_y: z[6],
+        .enumerate()
+        .map(|(i, z)| {
+            let points = counts.get(i).copied().unwrap_or(0) as usize;
+            let start = cursor * 2;
+            let end = start + points * 2;
+            cursor += points;
+            // A count that runs past the buffer is a caller bug; falling back to
+            // the box rather than panicking keeps one malformed zone from
+            // taking down the whole split.
+            if points >= 3 && end <= footprints.len() {
+                ZoneShape::Prism {
+                    footprint: footprints[start..end]
+                        .chunks_exact(2)
+                        .map(|p| [p[0], p[1]])
+                        .collect(),
+                    min_y: z[1] - z[4] / 2.0,
+                    max_y: z[1] + z[4] / 2.0,
+                }
+            } else {
+                ZoneShape::Box(ZoneBox {
+                    center: [z[0], z[1], z[2]],
+                    size: [z[3], z[4], z[5]],
+                    rotation_y: z[6],
+                })
+            }
         })
         .collect();
 
-    let split = split_mesh_by_zones(&tris, &boxes);
+    let split = split_mesh_by_zones(&tris, &shapes);
     let sum_error_rel = split.sum_error_rel();
     let pieces = split
         .pieces

--- a/rust/wasm-bindings/src/api/zone_split.rs
+++ b/rust/wasm-bindings/src/api/zone_split.rs
@@ -64,6 +64,7 @@ pub struct ZoneSplitJs {
     pieces: Vec<ZonePieceJs>,
     whole_volume: f64,
     sum_error_rel: f64,
+    remainder_failed: bool,
 }
 
 #[wasm_bindgen]
@@ -100,6 +101,17 @@ impl ZoneSplitJs {
     pub fn sum_error_rel(&self) -> f64 {
         self.sum_error_rel
     }
+
+    /// The part of the element inside NO zone could not be built.
+    ///
+    /// Separate from `sumErrorRel` because the two have opposite fixes: a
+    /// raised sum means the zones overlap and want redrawing, while this means
+    /// real volume is MISSING from the result. A caller must refuse the split
+    /// outright rather than publish the zone pieces alone.
+    #[wasm_bindgen(getter, js_name = remainderFailed)]
+    pub fn remainder_failed(&self) -> bool {
+        self.remainder_failed
+    }
 }
 
 /// Split a mesh into one closed solid per zone, plus the remainder.
@@ -110,12 +122,14 @@ impl ZoneSplitJs {
 /// (matching the viewer's `Zone.size`) and the rotation is radians about the
 /// vertical axis. A trailing partial zone is ignored rather than guessed at.
 ///
-/// A zone becomes a PRISM (#2508 item 4) when `footprint_counts[i]` is
-/// non-zero: it then takes that many `[x, z]` pairs from `footprints`, in
-/// order, and uses the 7-tuple only for its vertical extent
-/// (`cy +/- sy/2`). The footprint must be CONVEX; the viewer gates that on
-/// import, because a concave polygon fans into overlapping triangles and would
-/// cut wrong rather than fail. Passing empty arrays keeps every zone a box.
+/// A zone becomes a PRISM (#2508 item 4) when `footprint_counts[i]` is at
+/// least 3: it then takes that many `[x, z]` pairs from `footprints`, in order,
+/// and uses the 7-tuple only for its vertical extent (`cy +/- sy/2`). The
+/// footprint must be CONVEX; the viewer gates that on import, because a concave
+/// polygon fans into overlapping triangles and would cut wrong rather than
+/// fail. A count of 1 or 2 is not a polygon: it still consumes its pairs, so
+/// later zones stay aligned, and leaves that zone a box. Passing empty arrays
+/// keeps every zone a box.
 ///
 /// The caller must have established that the mesh is a closed orientable solid
 /// first, exactly as it must before quoting a volume at all (#1891/#1993): a
@@ -172,18 +186,24 @@ pub fn split_mesh_by_zones_js(
         .enumerate()
         .map(|(i, z)| {
             let points = counts.get(i).copied().unwrap_or(0) as usize;
-            let start = cursor * 2;
-            let end = start + points * 2;
-            cursor += points;
+            // CHECKED, because `usize` is 32 bits on wasm32 and `points` comes
+            // from a u32: `points * 2` can wrap in a release build, and a
+            // wrapped end then satisfies the bounds test and panics on the
+            // slice. Bounds-checking the arithmetic is what makes the fallback
+            // below actually a fallback.
+            let span = points.checked_mul(2);
+            let start = cursor.checked_mul(2);
+            let slice = match (start, span) {
+                (Some(s), Some(n)) => s.checked_add(n).and_then(|e| footprints.get(s..e)),
+                _ => None,
+            };
+            cursor = cursor.saturating_add(points);
             // A count that runs past the buffer is a caller bug; falling back to
             // the box rather than panicking keeps one malformed zone from
             // taking down the whole split.
-            if points >= 3 && end <= footprints.len() {
+            if let (true, Some(slice)) = (points >= 3, slice) {
                 ZoneShape::Prism {
-                    footprint: footprints[start..end]
-                        .chunks_exact(2)
-                        .map(|p| [p[0], p[1]])
-                        .collect(),
+                    footprint: slice.chunks_exact(2).map(|p| [p[0], p[1]]).collect(),
                     min_y: z[1] - z[4] / 2.0,
                     max_y: z[1] + z[4] / 2.0,
                 }
@@ -199,6 +219,7 @@ pub fn split_mesh_by_zones_js(
 
     let split = split_mesh_by_zones(&tris, &shapes);
     let sum_error_rel = split.sum_error_rel();
+    let remainder_failed = split.remainder_failed;
     let pieces = split
         .pieces
         .into_iter()
@@ -225,5 +246,6 @@ pub fn split_mesh_by_zones_js(
         pieces,
         whole_volume: split.whole_volume,
         sum_error_rel,
+        remainder_failed,
     }
 }

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -4177,6 +4177,8 @@
     "SymbolicRepresentationCollection: class",
     "SymbolicText: class",
     "SyncInitInput: type",
+    "ZonePieceJs: class",
+    "ZoneSplitJs: class",
     "default: function",
     "difference2d: function",
     "get_memory: function",
@@ -4185,6 +4187,7 @@
     "intersection2d: function",
     "meshOutline2d: function",
     "resolve2d: function",
+    "splitMeshByZones: function",
     "union2d: function",
     "version: function"
   ],

--- a/scripts/test-wasm-contract.mjs
+++ b/scripts/test-wasm-contract.mjs
@@ -22,6 +22,7 @@ import {
   intersection2d,
   resolve2d,
   meshOutline2d,
+  splitMeshByZones,
 } from '../packages/wasm/pkg/ifc-lite.js';
 import { parseMeshesViaPrePass } from './lib/mesh-via-prepass.mjs';
 import { runPrepassClassBoundaryTests } from './lib/prepass-class-boundary.mjs';
@@ -1440,6 +1441,74 @@ test('operations return new handles and leave their operands usable', () => {
     second.free();
     b.free();
     a.free();
+  }
+});
+
+// ===== splitMeshByZones across the real WASM boundary (#2508) =====
+
+/** A 6 x 1 x 1 m box from the origin, as flat f64 positions + indices. */
+function boxMesh(x0, y0, z0, x1, y1, z1) {
+  const positions = Float64Array.from([
+    x0, y0, z0, x1, y0, z0, x1, y1, z0, x0, y1, z0,
+    x0, y0, z1, x1, y0, z1, x1, y1, z1, x0, y1, z1,
+  ]);
+  const indices = Uint32Array.from([
+    0, 3, 2, 0, 2, 1, 4, 5, 6, 4, 6, 7,
+    0, 4, 7, 0, 7, 3, 1, 2, 6, 1, 6, 5,
+    0, 1, 5, 0, 5, 4, 3, 7, 6, 3, 6, 2,
+  ]);
+  return { positions, indices };
+}
+
+test('splitMeshByZones cuts a wall at a known fraction and the pieces add up', () => {
+  // The wall spans x = 0..6, so a boundary at x = 2 leaves exactly 2 m3 below
+  // it. Crossing the real boundary matters here beyond the Rust unit test:
+  // the zones arrive as a FLAT Float64Array whose stride and field order this
+  // side has to agree on, and a transposed size/centre would still produce a
+  // plausible-looking split.
+  const { positions, indices } = boxMesh(0, 0, 0, 6, 1, 1);
+  const zones = Float64Array.from([
+    0.5, 0.5, 0.5, 3, 4, 4, 0,   // covers x = -1..2
+    4.5, 0.5, 0.5, 5, 4, 4, 0,   // covers x = 2..7
+  ]);
+  const split = splitMeshByZones(positions, indices, zones);
+  try {
+    assert.ok(Math.abs(split.wholeVolume - 6) < 1e-9, `whole volume ${split.wholeVolume}`);
+    assert.ok(split.sumErrorRel < 1e-9, `pieces do not sum to the whole: ${split.sumErrorRel}`);
+    const byZone = new Map();
+    for (let i = 0; i < split.pieceCount; i++) {
+      const piece = split.piece(i);
+      try {
+        byZone.set(piece.zoneIndex, piece.volume);
+        assert.ok(piece.positions.length > 0 && piece.indices.length > 0, 'piece has geometry');
+      } finally {
+        piece.free();
+      }
+    }
+    assert.ok(Math.abs(byZone.get(0) - 2) < 1e-9, `zone 0 got ${byZone.get(0)}`);
+    assert.ok(Math.abs(byZone.get(1) - 4) < 1e-9, `zone 1 got ${byZone.get(1)}`);
+  } finally {
+    split.free();
+  }
+});
+
+test('splitMeshByZones keeps an element no zone reaches, as the remainder', () => {
+  const { positions, indices } = boxMesh(0, 0, 0, 6, 1, 1);
+  const zones = Float64Array.from([100, 0, 0, 2, 2, 2, 0]);
+  const split = splitMeshByZones(positions, indices, zones);
+  try {
+    assert.equal(split.pieceCount, 1);
+    const piece = split.piece(0);
+    try {
+      // -1, not 0: an element in no zone must not be reported as being in the
+      // first one.
+      assert.equal(piece.zoneIndex, -1);
+      assert.ok(Math.abs(piece.volume - 6) < 1e-9);
+    } finally {
+      piece.free();
+    }
+  } finally {
+    split.free();
   }
 });
 

--- a/scripts/test-wasm-contract.mjs
+++ b/scripts/test-wasm-contract.mjs
@@ -1512,6 +1512,33 @@ test('splitMeshByZones keeps an element no zone reaches, as the remainder', () =
   }
 });
 
+test('splitMeshByZones cuts by a prism footprint, not by its bounding box', () => {
+  // The triangle (0,0) - (6,0) - (0,1) halves the wall's 6 x 1 m plan along the
+  // diagonal, so it takes exactly half the volume. Its BOUNDING BOX is the
+  // whole wall, so a binding that dropped the footprint would answer 6.
+  const { positions, indices } = boxMesh(0, 0, 0, 6, 1, 1);
+  const zones = Float64Array.from([3, 0.5, 0.5, 6, 4, 1, 0]);
+  const split = splitMeshByZones(
+    positions,
+    indices,
+    zones,
+    Float64Array.from([0, 0, 6, 0, 0, 1]),
+    Uint32Array.from([3]),
+  );
+  try {
+    const piece = split.piece(0);
+    try {
+      assert.equal(piece.zoneIndex, 0);
+      assert.ok(Math.abs(piece.volume - 3) < 1e-6, `prism piece is ${piece.volume} m3, expected 3`);
+    } finally {
+      piece.free();
+    }
+    assert.ok(split.sumErrorRel < 1e-9, `sum error ${split.sumErrorRel}`);
+  } finally {
+    split.free();
+  }
+});
+
 // ===== Prepass class column across the real WASM boundary (#2088) =====
 // Self-contained suite in its own module (this file is already several times
 // the size guideline); it owns its fixture and its own IfcAPI handles.


### PR DESCRIPTION
Closes the four unclaimed slices of #2508. Item 1 (apportionment) shipped in #2515; item 3a (CSV/Parquet of the per-element table) is BIMvoice's and is deliberately untouched here.

The four slices are separate commits rather than separate PRs. #2508 asks for separate PRs and I take the point, but the review-fix commit spans the geometry and the data halves at once, so splitting after the fact would mean rewriting the fixes across four branches. Say the word and I will split it.

## Item 3b: the assignment as IFC data

Per element in a zone set, the Zones panel now writes:

```
IfcLite_Zones [<set>]                    ZoneSet, ZoneSetId, Zone, Zones, Straddles
IfcLite_ZoneVolumes [<set>] (<basis>)    one IfcQuantityVolume per zone
```

Neither name uses the `Pset_` / `Qto_` prefix buildingSMART reserves for its own published definitions.

**The basis is a choice and it is in the name.** `mesh` is the as-built geometry; `net` / `gross` / `unqualified` apportion the file's OWN declared quantity by the measured fractions, so a net breakdown sums to the `NetVolume` the user already trusts, by construction. An element declaring nothing on the chosen basis is refused rather than quietly falling back to the mesh: a mesh number inside a quantity set named `net` is the exact mixed-basis confusion `volume-basis.ts` exists to prevent.

**Values convert into each model's own declared VOLUMEUNIT**, per model. The same 5 m3 written into a cubic-millimetre file and a cubic-metre file are different numbers, and federated models do not share a scale.

A straddler's fractions come from the apportionment cache #2515 fills, so the file cannot disagree with the panel. A non-straddler needs no clip at all, which on a declared basis means it needs no geometry either, so an element the kernel could not prove still gets a net breakdown. Where no volume can be stated the reason is written INTO the file as `VolumeUnavailable`, because a missing row reads as zero.

The run writes to each model's `MutablePropertyView` directly and commits one store update: driving the per-mutation store actions once per element is quadratic (each copies the model's whole undo stack). Same trade `BulkPropertyEditor` already makes; the inverse is the panel's Remove rather than 20k presses of Ctrl+Z. The collab role gate is not skipped, only hoisted to once per run.

## Item 2: cutting a straddler into one solid per zone

`ifc_lite_geometry::zone_split`. Clipping a solid to a convex zone is an INTERSECTION against a convex operand, strictly easier than the general difference the kernel already runs on every opening void of every model, so each piece is one `boolean(host, zone, Intersection)`. Two decisions worth stating: one arrangement per piece rather than N composed operations (a chain feeds each step the previous step's output and re-jitters the seams the last one made), and f64 end to end (a per-piece f64 to f32 round trip is what turns a shared zone boundary into a crack).

`splitMeshByZones` exposes it; the panel gets a per-zone GLB export carrying every element whose home it is, whole, plus the CUT piece of every straddler that reaches it. **GLB rather than IFC deliberately**: the cut pieces are new solids with no IFC identity, and minting GlobalIds for them would produce a file that looks like a model and round-trips as a fabrication.

## Item 4: zones that are not boxes

A zone with a convex `footprint` is a vertical prism. Apportionment stays exact and stays cheap: the divergence field #2515 integrates is box-specific only because `x0`/`x1` are constants, so a trapezoidal sweep of the footprint replaces them with lines. The field stays continuous across the two slanted planes and linear inside each region, so the integral over a polygon is still its area times the value at the centroid.

The strongest evidence it is right is not a hand-computed number, it is the ORACLE: a rectangular footprint IS a box, the two integrators share no code, and they agree to 1e-12 on five fixtures.

Authoring is JSON import, which #2508 lists as acceptable ("or an imported volume") and is how takt polygons usually arrive. Drawing one is a follow-up.

## Item 3c: the IfcZone question, argued

`docs/design/zone-emission.md`. The answer is **no**, on schema grounds rather than taste: `IfcZone` groups spaces, its `IsGroupedBy` admits `IfcSpace` / `IfcSpatialZone` / nested `IfcZone`, and this repo already reads it that way (`extractGroupMembersOnDemand`, the GROUPS panel of #1672). `IfcSpatialZone` with `IfcRelReferencedInSpatialStructure` is the entity that means this, and it is sketched for its own PR: it is additive, many-to-many (so a straddler is referenced in both zones), and it still cannot say HOW MUCH, so it complements the quantity write-back rather than replacing it.

## Defects two review passes found, all fixed

Each has a test that fails without the fix, verified by reverting the fix rather than by assertion.

1. **A tiling zone set left zero-volume MEMBRANES inside the published remainder solid.** `difference_all` requires pairwise-disjoint cutters and a tiling shares boundary planes, so both coincident opposite-wound cutter faces survived. Volume cannot see it (the pair cancels), which is why every test passed with 12 stray triangles at x=2. Cutters are unioned first now.
2. A zone the element merely ABUTS is no longer subtracted; the old comment's double-count justification was wrong, and subtracting only fed the arrangement an exactly-coplanar operand for nothing.
3. **`deleteQuantitySet` never reached the STEP export.** The exporter withholds a source `IfcElementQuantity` only when writing a REPLACEMENT, and a deletion has none, so the panel hid a set the exported file still carried.
4. The whole-set delete was filed as `DELETE_QUANTITY` with no property name; both replay consumers key the member-delete case off that name, so it resurrected the set on import and vanished from a layer publish without reaching `skipped`. It has its own `DELETE_QUANTITY_SET` type now.
5. **Write-back left stale sets three ways**: an element that LEFT the set kept the last run's zone forever, a RENAME orphaned everything under the old name, and `createPropertySet` MERGES over a same-named set from a re-imported file. One fix: the pset carries the set's stable id and both paths sweep by it before writing.
6. Remove reported removals and dirtied the model on a model never written to.
7. `zoneSetRevision` omitted the footprint, so two prisms with the same bounding box served each other's cubic metres.

Smaller: `markModelsDirty` clears redo stacks like every other mutator; the GLB export counts no-geometry apart from refused; the store's three zone mutators are the same door as import for convexity and bounds; the inert "edit in 3D" pencil is hidden for prisms.

## Verification

- **Rust**: 19 `zone_split` tests on hand-computable fractions (a 6 m wall crossing one boundary at 2 m, two boundaries, wholly inside, wholly outside, ending exactly on a shared plane, a rotated blade taking 0.4*sqrt(2) m3, inward winding, zero size, empty host, overlap surfaced by the invariant, a translation-variance probe that fails for a merely-clipped shell, and the membrane check above). `cargo test --workspace` clean; `cargo clippy --workspace --exclude ifc-lite-wasm --all-targets -- -D warnings` clean.
- **Viewer**: 18 prism-integrator tests including the box oracle, 16 write-back tests, 18 split/routing tests, 5 geometry-seam tests, panel tests that CLICK the controls and assert the resulting data rather than their presence.
- **Boundaries**: a STEP export re-parsed to prove the file carries the assignment and the unit conversion; 3 new cases in `pnpm test:wasm-contract` (61 passed).
- `pnpm test` 86/86 tasks, `pnpm typecheck` green, API surface and test-wiring green, committed wasm types regenerated.
- **Perf**, measured through this wasm build on `AC20-FZK-Haus.ifc` with four zones tiling its 18 m length: 18 elements produced more than one piece, at ~357 ms each, 6.4 s total. An exact arrangement per (element x zone) is orders of magnitude dearer than the divergence clip that produces the numbers, which is why the split is per zone and on demand. **The number reaches the user in the completion toast**, and a large model's per-zone export will be a real wait. A worker is the honest fix and is not in this PR.

## Known limits, stated rather than discovered

- Per-zone geometry export runs on the main thread (see the number above).
- Prism zones are authored by JSON import only; the 3D gizmo edits boxes.
- The UI was verified by mounted-component tests that execute each action, not by driving a browser against a real model.

Refs #2508, #1810.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added polygon-footprint prism zones with validation, persistence, classification, and volume calculations.
  - Added zone geometry export with split meshes for zone-specific solids and unassigned remainder geometry.
  - Added controls to write zone assignments and volume data to IFC properties and quantities, or remove them.
  - Added quantity-set deletion with replay and export support.

- **Bug Fixes**
  - Improved prism overlay editing, cache invalidation, volume accuracy, and coordinate handling.

- **Documentation**
  - Documented prism zones, zone write-back, and quantity-set operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->