### PR TITLE
feat(export): withhold or rewrite relationship refs that name entities the export won't emit

### DIFF
--- a/.changeset/step-exporter-relationship-filtering.md
+++ b/.changeset/step-exporter-relationship-filtering.md
@@ -1,0 +1,16 @@
+---
+"@ifc-lite/export": patch
+---
+
+`StepExporter` no longer emits a relationship record that names an entity the export itself excluded. A hidden PRODUCT under `visibleOnly` keeps its own defining line out of the file, but `IFCREL*` records are unconditional roots and their bytes used to be copied to the output verbatim — so a relationship naming both a kept and a hidden product still named the hidden one, shipping a `#N` reference with no `#N=` defining line. Strict STEP readers reject that file; lenient ones silently mis-place the geometry it pointed at.
+
+A new `filterHiddenRefsFromRelationshipLine` (`reference-collector.ts`) runs on every relationship's line right before it is written, for both source-parsed and overlay-authored relationships: a hidden or deleted id is dropped from a nested list attribute (`RelatedObjects`, `RelatedElements`, …), and the relationship is withheld entirely when a hidden/deleted id sits in a bare scalar attribute (`RelatingSpace`, `RelatedOpeningElement`, …) or when dropping it from a list would leave that list empty.
+
+Two exclusion sources are covered, both previously unhandled:
+
+- **`visibleOnly` hidden products** — the case above.
+- **Deleted (tombstoned) entities, on any export, `visibleOnly` or not.** The existing deletion-path guard only withholds an `IfcRelDefinesByProperties` when *every* related object was deleted, and only for that one relationship class — a spatial-containment relation (or any other `IFCREL*` type) still naming a partially-deleted related list shipped the same dangling reference on a plain full export.
+
+The relationship's excluded/effective type is resolved through `EffectiveEntityIndex.effectiveType`, not the record's authored (pre-retype) class: an entity retyped across the `IFCREL*` boundary — into or out of a relationship class — is now classified by what the export actually writes, not by the class it started as. Classifying by the authored class alone let a retyped relationship skip the filter (or apply it wrongly) depending on retype direction.
+
+This is a behaviour change to STEP export output, split out of #2398 to stand on its own: the surrounding source-guard refactor in that PR is a provable no-op and does not touch this code path.

--- a/packages/export/src/overlay-effective-model.test.ts
+++ b/packages/export/src/overlay-effective-model.test.ts
@@ -340,6 +340,35 @@ describe('visibleOnly export sees overlay-created entities (#2012 instance 4)', 
     expect(out.typeOf(opening.expressId)).toBeNull();
   });
 
+  it('withholds a SOURCE record retyped ACROSS the IFCREL boundary that now names a hidden entity (#2398)', async () => {
+    // #13 is authored IFCWALLTYPE — not a relationship, so the source-iteration
+    // pass's hidden-ref filter must be OFF for it. Retyped here into
+    // IfcRelAggregates, it becomes one. `filterHiddenRefsFromRelationshipLine`
+    // has to key off the EFFECTIVE (post-retype) class, not the authored one:
+    // classifying by `entityRef.type` (frozen at parse time) would still read
+    // "IFCWALLTYPE" after the retype and skip the filter entirely, shipping a
+    // `#N` with no defining line — the exact dangling ref #2398 exists to close.
+    const store = await parseBase();
+    const { view, editor } = newView(store);
+    expect(editor.setEntityType(EXISTING_TYPE_ID, 'IfcRelAggregates')).toBe(true);
+    editor.setPositionalAttribute(EXISTING_TYPE_ID, 4, `#${STOREY_ID}`);
+    editor.setPositionalAttribute(EXISTING_TYPE_ID, 5, [`#${EXISTING_WALL_ID}`]);
+
+    const result = new StepExporter(store, view).export({
+      schema: 'IFC4',
+      visibleOnly: true,
+      hiddenEntityIds: new Set<number>([EXISTING_WALL_ID]),
+    });
+    const out = await reparse(result.content);
+
+    expect(out.typeOf(EXISTING_WALL_ID)).toBeNull();
+    // RelatedObjects names only the hidden wall, so removing it empties the
+    // list and the whole retyped relation must be withheld — not shipped with
+    // a dangling `#8`.
+    expect(out.typeOf(EXISTING_TYPE_ID)).toBeNull();
+    expect(out.danglingRefs()).toEqual([]);
+  });
+
   it('emits no pset for a host the closure excluded', async () => {
     const store = await parseBase();
     const { view, editor } = newView(store);
@@ -358,13 +387,19 @@ describe('visibleOnly export sees overlay-created entities (#2012 instance 4)', 
     const out = await reparse(result.content);
 
     expect(out.typeOf(LONE_WALL_ID)).toBeNull();
-    // Only the source relation survives (relationships are always closure
-    // roots); no NEW one was generated for a host outside the export.
-    expect(out.relDefinesTargeting(LONE_WALL_ID)).toEqual([LONE_REL_ID]);
+    // The source relation is itself withheld now, not merely un-augmented:
+    // relationships are always closure roots, so `LONE_REL_ID`'s bytes would
+    // otherwise be copied verbatim into the file naming a host with no
+    // defining line — a dangling reference and an invalid file (#2398). Its
+    // RelatedObjects list names only the excluded host, so removing that id
+    // leaves it empty and `filterHiddenRefsFromRelationshipLine` withholds
+    // the whole relation rather than emit `(...)` with nothing in it.
+    expect(out.relDefinesTargeting(LONE_WALL_ID)).toEqual([]);
     const psetNames = (out.store.entityIndex.byType.get('IFCPROPERTYSET') ?? []).map(
       (id) => out.attributes(id)?.[2],
     );
     expect(psetNames).not.toContain('Pset_Fresh');
+    expect(out.danglingRefs()).toEqual([]);
   });
 });
 
@@ -938,6 +973,38 @@ END-ISO-10303-21;`;
 
     expect(out.typeOf(EXISTING_REL_ID)).toBe('IFCRELDEFINESBYPROPERTIES');
     expect(out.relDefinesTargeting(EXISTING_WALL_ID)).toEqual([EXISTING_REL_ID]);
+  });
+
+  it('rewrites a SOURCE containment relation instead of shipping a tombstoned member (#2398)', async () => {
+    // The deletion sweep a few lines up in `step-exporter.ts` only withholds
+    // an `IfcRelDefinesByProperties` whose RelatedObjects is EMPTIED entirely,
+    // and only for that one relationship class — it says so in its own
+    // comment ("nothing here rewrites a RelatedObjects list"). A
+    // spatial-containment relation naming two walls, one of which the session
+    // deletes, is untouched by that sweep: pre-fix, #9's bytes are copied
+    // verbatim and the tombstoned wall's id ships with no defining line — the
+    // exact invalid-file shape `filterHiddenRefsFromRelationshipLine` exists
+    // to close for `visibleOnly`, on a plain full export with no
+    // `visibleOnly` involved at all.
+    const store = await parseBase();
+    const { view, editor } = newView(store);
+    // #9 authored contains only #8 (EXISTING_WALL_ID). Widen it to also name
+    // #14 (LONE_WALL_ID) — a second, otherwise-independent source wall — so
+    // deleting #14 exercises a PARTIAL-list rewrite, not a whole-relation
+    // withhold.
+    editor.setPositionalAttribute(9, 4, [`#${EXISTING_WALL_ID}`, `#${LONE_WALL_ID}`]);
+    editor.removeEntity(LONE_WALL_ID);
+
+    const result = new StepExporter(store, view).export({ schema: 'IFC4' });
+    const out = await reparse(result.content);
+
+    expect(out.typeOf(LONE_WALL_ID)).toBeNull();
+    // The relation survives — #8 is still validly contained — but must no
+    // longer name #14.
+    expect(out.typeOf(9)).toBe('IFCRELCONTAINEDINSPATIALSTRUCTURE');
+    const containment = (out.attributes(9) ?? [])[4];
+    expect(Array.isArray(containment) ? containment : []).toEqual([EXISTING_WALL_ID]);
+    expect(out.danglingRefs()).toEqual([]);
   });
 });
 

--- a/packages/export/src/reference-collector.ts
+++ b/packages/export/src/reference-collector.ts
@@ -30,6 +30,7 @@
 import type { IfcDataStore, IfcSourceBytes } from '@ifc-lite/parser';
 import { asSourceBytes } from '@ifc-lite/parser';
 import type { EffectiveEntityIndex } from './effective-index.js';
+import { splitTopLevelArgs } from './step-argument-parser.js';
 
 /** ASCII code points for byte-level scanning. */
 const HASH = 0x23;  // '#'
@@ -352,6 +353,93 @@ export function collectReferencedEntityIds(
   }
 
   return visited;
+}
+
+/**
+ * Rewrite (or withhold) a relationship's OWN line so it never names an
+ * excluded entity — the id, not just the byte range, has to disappear.
+ *
+ * `getVisibleEntityIds` keeps a hidden PRODUCT's own defining line out of the
+ * export, and `collectReferencedEntityIds` refuses to WALK INTO one (that is
+ * what `hiddenIds` is passed as `excludeIds` for). Neither touches the
+ * relationship that named it: `IFCREL*` is an unconditional root — relationships
+ * point at products, never the reverse, so they must stay reachable for psets,
+ * materials and types to survive the closure — and a root's own bytes are
+ * copied to the output VERBATIM. So a `IfcRelContainedInSpatialStructure`
+ * naming both a kept and a hidden wall keeps naming the hidden one; the file
+ * that ships has a `#N` with no `#N=` line, which strict readers reject and
+ * lenient ones silently mis-place (confirmed on #2398, root-caused to this
+ * exact gap).
+ *
+ * Fixed here rather than by teaching the closure to special-case every
+ * `IFCREL*` subtype: the two shapes below are SYNTACTIC, not semantic, so one
+ * function covers every relationship class without a table of which attribute
+ * index means what per type.
+ *
+ *  - A `#N` inside a NESTED parenthesised list (`RelatedObjects`,
+ *    `RelatedElements`, …): drop just that member. If every member of the
+ *    list was hidden, the list is empty — a SET attribute of a real IFC schema
+ *    is never empty, so an empty list is not "no forward reference", it is a
+ *    second, different kind of invalid file. Withhold the whole line instead.
+ *  - A bare top-level `#N` (`RelatingSpace`, `RelatedOpeningElement`, …): a
+ *    single-valued STEP attribute has no spelling for "omitted but this one
+ *    was mandatory", so a hidden reference here withholds the whole line —
+ *    the same choice `propagateOpeningExclusions` already makes for the one
+ *    case (`IfcRelVoidsElement`, relating side hidden) it special-cased before
+ *    this function existed.
+ *
+ * Returns the line unchanged when it names nothing excluded, a rewritten line
+ * when a list member was dropped, or `null` to mean "do not emit this
+ * relationship at all". A line this cannot parse as a single `#N=TYPE(...);`
+ * record is returned unchanged — the source-iteration pass's own byte-range
+ * and mutation passes are what validate that shape; this function only ever
+ * narrows what a well-formed one contains.
+ *
+ * `isExcluded` is a predicate rather than a fixed `Set` because "excluded"
+ * has two independent sources that a caller may need to combine: a
+ * `visibleOnly` hidden PRODUCT id (`hiddenProductIds`, a plain membership
+ * test) and a TOMBSTONED id (`effective.isDeleted`, answered by the overlay
+ * for every id, not just a precomputed set) — the DELETION-path instance of
+ * this exact dangling-ref shape (#2398): a relationship that still names an
+ * entity the session deleted ships the same `#N` with no `#N=` line, on a
+ * path with no `visibleOnly` involved at all.
+ */
+export function filterHiddenRefsFromRelationshipLine(
+  line: string,
+  isExcluded: (id: number) => boolean,
+): string | null {
+  const match = line.match(/^(#\d+\s*=\s*\w+\()([\s\S]*)(\)\s*;)\s*$/);
+  if (!match) return line;
+  const [, prefix, argsText, suffix] = match;
+  const attrs = splitTopLevelArgs(argsText);
+
+  let changed = false;
+  const nextAttrs: string[] = [];
+  for (const attr of attrs) {
+    if (attr.length >= 2 && attr.charCodeAt(0) === 0x28 /* '(' */ && attr.charCodeAt(attr.length - 1) === 0x29 /* ')' */) {
+      const inner = attr.slice(1, -1);
+      const items = inner.trim() === '' ? [] : splitTopLevelArgs(inner);
+      const survivors = items.filter((item) => {
+        const refMatch = item.match(/^#(\d+)$/);
+        return !(refMatch && isExcluded(Number(refMatch[1])));
+      });
+      if (survivors.length !== items.length) {
+        if (survivors.length === 0) return null;
+        changed = true;
+        nextAttrs.push(`(${survivors.join(',')})`);
+        continue;
+      }
+      nextAttrs.push(attr);
+      continue;
+    }
+
+    const refMatch = attr.match(/^#(\d+)$/);
+    if (refMatch && isExcluded(Number(refMatch[1]))) return null;
+    nextAttrs.push(attr);
+  }
+
+  if (!changed) return line;
+  return `${prefix}${nextAttrs.join(',')}${suffix}`;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/export/src/step-exporter.ts
+++ b/packages/export/src/step-exporter.ts
@@ -25,7 +25,12 @@ import {
 import type { MutablePropertyView } from '@ifc-lite/mutations';
 import type { PropertySet, QuantitySet } from '@ifc-lite/data';
 import { generateIfcGuid, type RandomSource } from '@ifc-lite/encoding';
-import { collectReferencedEntityIds, getVisibleEntityIds, collectStyleEntities } from './reference-collector.js';
+import {
+  collectReferencedEntityIds,
+  getVisibleEntityIds,
+  collectStyleEntities,
+  filterHiddenRefsFromRelationshipLine,
+} from './reference-collector.js';
 import { convertStepLine, needsConversion, type IfcSchemaVersion } from './schema-converter.js';
 import { retypeStepLine, retypeArgTokens } from './retype.js';
 import { getCompleteEntityIndex, getMaxExpressId } from './entity-iteration.js';
@@ -380,18 +385,29 @@ export class StepExporter {
     // either, so counting it as "modified" would make the header claim a
     // change the DATA section does not contain (CodeRabbit finding on #2414).
     let allowedEntityIds: Set<number> | null = null;
+    // Populated alongside `allowedEntityIds` below. `getVisibleEntityIds`
+    // excludes a hidden PRODUCT's own line from the closure, but `IFCREL*` is
+    // an unconditional root a few lines down and its bytes are copied verbatim
+    // by the source-iteration pass — nothing there filters a `#N` the closure
+    // just excluded out of the relationship's own attribute list. Kept so the
+    // source-iteration and overlay new-entity passes can run
+    // `filterHiddenRefsFromRelationshipLine` against the SAME exclusion set
+    // `collectReferencedEntityIds` used, rather than a second, possibly
+    // divergent notion of "hidden" (#2398).
+    let hiddenProductIds: ReadonlySet<number> | null = null;
     if (options.visibleOnly && this.dataStore.source) {
-      const { roots, hiddenProductIds } = getVisibleEntityIds(
+      const visible = getVisibleEntityIds(
         this.dataStore,
         options.hiddenEntityIds ?? new Set(),
         options.isolatedEntityIds ?? null,
         effective,
       );
+      hiddenProductIds = visible.hiddenProductIds;
       allowedEntityIds = collectReferencedEntityIds(
-        roots,
+        visible.roots,
         this.dataStore.source,
         effective,
-        hiddenProductIds,
+        visible.hiddenProductIds,
       );
       // Second pass: collect IFCSTYLEDITEM entities that reference included
       // geometry. Styled items reference geometry items but nothing references
@@ -402,6 +418,23 @@ export class StepExporter {
         { byId: effective, byType: effective.byType },
       );
     }
+    // A relationship can name an excluded entity two ways that have nothing
+    // to do with each other: a `visibleOnly` hidden PRODUCT (`hiddenProductIds`,
+    // above), and a TOMBSTONED one — `editor.removeEntity` on a related object
+    // named by a relationship the deletion sweep below does not reach (that
+    // sweep only withholds an `IfcRelDefinesByProperties` when EVERY related
+    // object is gone, and only for that one relationship class). Left alone, a
+    // relationship still naming a deleted entity ships the identical `#N` with
+    // no `#N=` line, on a path with no `visibleOnly` involved at all (#2398).
+    // `effective.isDeleted` answers for every id, not just a precomputed set,
+    // so this predicate covers both sources without a second exclusion set.
+    // `overlayActive` proper (used everywhere else) is declared further below,
+    // ahead of the mutation-processing block it gates; duplicated here as the
+    // same expression rather than reordering that declaration.
+    const mayNameExcludedRefs = (hiddenProductIds !== null && hiddenProductIds.size > 0)
+      || (!!this.mutationView && options.applyMutations !== false);
+    const isExcludedFromRelationshipRefs = (id: number): boolean =>
+      (hiddenProductIds !== null && hiddenProductIds.has(id)) || effective.isDeleted(id);
 
     // Will THIS entity's own line ever land in the file? The same byte-range
     // test `willBeEmitted` uses (defined further below) and the source-
@@ -1118,7 +1151,30 @@ export class StepExporter {
           sourceSchema,
           overlayActive,
         );
-        const nextEntityText = mutated.text;
+        let nextEntityText = mutated.text;
+
+        // A hidden PRODUCT's own line is already out of the export via
+        // `allowedEntityIds`, and a TOMBSTONED entity's via `effective` — this
+        // is the relationship that NAMED either one. `IFCREL*` is an
+        // unconditional root (see `getVisibleEntityIds`), so its bytes reach
+        // here unfiltered even when one of the ids they name was just
+        // excluded; left alone that ships a `#N` with no `#N=` line, whether
+        // the exclusion came from `visibleOnly` or from a plain deletion
+        // (#2398). Checked before the nomination below: a relationship this
+        // withholds must not also be counted as a delivered modification.
+        //
+        // Classified by the EFFECTIVE type (`effective.effectiveType`), not
+        // the authored `entityType` above: a retype can move a record across
+        // the `IFCREL*` boundary in either direction (`applySourceLineMutations`
+        // already rewrote `nextEntityText` to the new class), and this check
+        // has to agree with what actually got written, the same way
+        // `getVisibleEntityIds` already does for the visibility walk itself.
+        const effectiveRelType = effective.effectiveType(expressId, entityRef.type).toUpperCase();
+        if (mayNameExcludedRefs && effectiveRelType.startsWith('IFCREL')) {
+          const filtered = filterHiddenRefsFromRelationshipLine(nextEntityText, isExcludedFromRelationshipRefs);
+          if (filtered === null) continue;
+          nextEntityText = filtered;
+        }
 
         // A retype or a positional edit that CHANGED the line is what makes
         // this entity count; a named attribute edit was already nominated by
@@ -1416,7 +1472,13 @@ export class StepExporter {
             sourceSchema,
           );
         }
-        const line = `#${entity.expressId}=${upperType}(${argsText});`;
+        let line: string | null = `#${entity.expressId}=${upperType}(${argsText});`;
+        // Same gap as the source-iteration pass, for an overlay-authored
+        // relationship instead of a parsed one (#2398).
+        if (mayNameExcludedRefs && upperType.startsWith('IFCREL')) {
+          line = filterHiddenRefsFromRelationshipLine(line, isExcludedFromRelationshipRefs);
+          if (line === null) continue;
+        }
         if (converting) {
           const converted = convertStepLine(line, sourceSchema, schema, options.guidRandom);
           if (converted !== null) {

--- a/packages/export/src/visible-only-dangling-refs.test.ts
+++ b/packages/export/src/visible-only-dangling-refs.test.ts
@@ -1,0 +1,244 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Regression guard for a dangling-reference class confirmed on #2398: a
+ * `visibleOnly` STEP export drops hidden products from the DATA section but
+ * used to emit every `IFCREL*` record verbatim from the source bytes.
+ * `IFCREL*` is an unconditional root in `getVisibleEntityIds` (relationships
+ * reference products, never the other way round, so they must be roots for
+ * psets/materials/types to stay reachable), and the source-iteration loop in
+ * `step-exporter.ts` copies a source record's bytes with only retype /
+ * attribute / positional mutations applied — nothing filtered a `#N` whose
+ * target the closure had just excluded.
+ *
+ * The result was a file with `#N` references that have no `#N=` defining
+ * line. `entity-iteration.ts` states this package's own position on that
+ * shape: "STEP output with dangling `#`-references that strict viewers (e.g.
+ * BIM Vision) reject, and that makes lenient viewers fall geometry back to
+ * the origin".
+ *
+ * Fixed by `filterHiddenRefsFromRelationshipLine` (`reference-collector.ts`),
+ * called from both entity-emission passes in `step-exporter.ts` right after a
+ * relationship's line is otherwise ready to write: a hidden id is dropped
+ * from a nested list attribute (`RelatedObjects`, `RelatedElements`, …), and
+ * a relationship is withheld outright when a hidden id sits in a bare scalar
+ * attribute (`RelatingSpace`, `RelatedOpeningElement`, …) or when dropping it
+ * from a list would leave that list empty. One syntactic rule covers every
+ * `IFCREL*` subtype, including `IFCRELVOIDSELEMENT`'s mirror case (hidden
+ * opening, visible host) that `propagateOpeningExclusions` did not reach —
+ * that function only deletes the relation when the RELATING element is
+ * hidden.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { asSourceBytes, type IfcDataStore } from '@ifc-lite/parser';
+import { StepExporter } from './step-exporter.js';
+
+const decode = (bytes: Uint8Array) => new TextDecoder().decode(bytes);
+
+type MockEntityRef = {
+  expressId: number;
+  type: string;
+  byteOffset: number;
+  byteLength: number;
+  lineNumber: number;
+};
+
+/** Same shape as `sourceless-store-export.test.ts`'s file-parsed store. */
+function buildParsedStore(entries: Array<[number, string, string]>): IfcDataStore {
+  const encoder = new TextEncoder();
+  const parts: Uint8Array[] = [];
+  const byId = new Map<number, MockEntityRef>();
+  const byType = new Map<string, number[]>();
+  let offset = 0;
+
+  for (const [id, type, text] of entries) {
+    const encoded = encoder.encode(text);
+    const upper = type.toUpperCase();
+    byId.set(id, { expressId: id, type: upper, byteOffset: offset, byteLength: encoded.byteLength, lineNumber: 0 });
+    if (!byType.has(upper)) byType.set(upper, []);
+    byType.get(upper)!.push(id);
+    parts.push(encoded);
+    offset += encoded.byteLength;
+  }
+
+  const source = new Uint8Array(offset);
+  let position = 0;
+  for (const part of parts) {
+    source.set(part, position);
+    position += part.byteLength;
+  }
+
+  return {
+    fileSize: offset,
+    schemaVersion: 'IFC4',
+    entityCount: entries.length,
+    parseTime: 0,
+    source: asSourceBytes(source),
+    entityIndex: { byId, byType },
+  } as unknown as IfcDataStore;
+}
+
+/** Every `#N` referenced in the output that has no `#N=` defining line. */
+function findDanglingRefs(content: string): number[] {
+  const defined = new Set<number>();
+  for (const m of content.matchAll(/(^|\n)#(\d+)=/g)) defined.add(+m[2]);
+  const dangling = new Set<number>();
+  for (const m of content.matchAll(/#(\d+)/g)) {
+    const id = +m[1];
+    if (!defined.has(id)) dangling.add(id);
+  }
+  return [...dangling].sort((a, b) => a - b);
+}
+
+const PROJECT = "#1=IFCPROJECT('0proj0000000000000000',$,'P',$,$,$,$,$,$);\n";
+const STOREY = "#2=IFCBUILDINGSTOREY('0stor0000000000000000',$,'S',$,$,$,$,$,$,0.);\n";
+
+describe('visibleOnly does not emit dangling references to excluded products', () => {
+  it('leaves the hidden wall in IfcRelContainedInSpatialStructure.RelatedElements', () => {
+    const store = buildParsedStore([
+      [1, 'IFCPROJECT', PROJECT],
+      [2, 'IFCBUILDINGSTOREY', STOREY],
+      [3, 'IFCWALL', "#3=IFCWALL('0walA0000000000000000',$,'KeptWall',$,$,$,$,$);\n"],
+      [4, 'IFCWALL', "#4=IFCWALL('0walB0000000000000000',$,'HiddenWall',$,$,$,$,$);\n"],
+      [21, 'IFCRELCONTAINEDINSPATIALSTRUCTURE', "#21=IFCRELCONTAINEDINSPATIALSTRUCTURE('0cont0000000000000000',$,$,$,(#3,#4),#2);\n"],
+      [24, 'IFCRELAGGREGATES', "#24=IFCRELAGGREGATES('0aggr0000000000000000',$,$,$,#1,(#2));\n"],
+    ]);
+
+    const content = decode(new StepExporter(store).export({
+      schema: 'IFC4',
+      visibleOnly: true,
+      hiddenEntityIds: new Set([4]),
+    }).content);
+
+    // The exclusion itself is correct and deliberate.
+    expect(content).not.toContain('#4=IFCWALL');
+    // The reference to it is not. Measured: the emitted line is
+    // `#21=IFCRELCONTAINEDINSPATIALSTRUCTURE(...,(#3,#4),#2);` — `#4` dangles.
+    expect(findDanglingRefs(content)).toEqual([]);
+    // No dangling refs must come from REWRITING the list, not from
+    // withholding #21 wholesale: the relationship survives with the kept
+    // wall still contained and only the hidden one dropped.
+    const rel21 = content.match(/^#21=IFCRELCONTAINEDINSPATIALSTRUCTURE\((.*)\);$/m);
+    expect(rel21).not.toBeNull();
+    expect(rel21![1]).toContain('(#3)');
+    expect(rel21![1]).not.toContain('#4');
+  });
+
+  it('leaves the hidden wall in IfcRelDefinesByProperties / IfcRelDefinesByType RelatedObjects', () => {
+    const store = buildParsedStore([
+      [1, 'IFCPROJECT', PROJECT],
+      [2, 'IFCBUILDINGSTOREY', STOREY],
+      [4, 'IFCWALL', "#4=IFCWALL('0walB0000000000000000',$,'HiddenWall',$,$,$,$,$);\n"],
+      [10, 'IFCPROPERTYSET', "#10=IFCPROPERTYSET('0pset0000000000000000',$,'Pset_WallCommon',$,(#11));\n"],
+      [11, 'IFCPROPERTYSINGLEVALUE', "#11=IFCPROPERTYSINGLEVALUE('Reference',$,IFCTEXT('R1'),$);\n"],
+      [12, 'IFCWALLTYPE', "#12=IFCWALLTYPE('0wtyp0000000000000000',$,'WT',$,$,$,$,$,$,.STANDARD.);\n"],
+      [22, 'IFCRELDEFINESBYPROPERTIES', "#22=IFCRELDEFINESBYPROPERTIES('0rdbp0000000000000000',$,$,$,(#4),#10);\n"],
+      [23, 'IFCRELDEFINESBYTYPE', "#23=IFCRELDEFINESBYTYPE('0rdbt0000000000000000',$,$,$,(#4),#12);\n"],
+    ]);
+
+    const content = decode(new StepExporter(store).export({
+      schema: 'IFC4',
+      visibleOnly: true,
+      hiddenEntityIds: new Set([4]),
+    }).content);
+
+    expect(content).not.toContain('#4=IFCWALL');
+    expect(findDanglingRefs(content)).toEqual([]);
+  });
+
+  it('leaves the hidden space in IfcRelSpaceBoundary.RelatingSpace', () => {
+    const store = buildParsedStore([
+      [1, 'IFCPROJECT', PROJECT],
+      [2, 'IFCBUILDINGSTOREY', STOREY],
+      [3, 'IFCWALL', "#3=IFCWALL('0walA0000000000000000',$,'KeptWall',$,$,$,$,$);\n"],
+      [6, 'IFCSPACE', "#6=IFCSPACE('0spac0000000000000000',$,'HiddenSpace',$,$,$,$,$,$,$);\n"],
+      [25, 'IFCRELSPACEBOUNDARY', "#25=IFCRELSPACEBOUNDARY('0rsbd0000000000000000',$,$,$,#6,#3,$,.PHYSICAL.,.EXTERNAL.);\n"],
+    ]);
+
+    const content = decode(new StepExporter(store).export({
+      schema: 'IFC4',
+      visibleOnly: true,
+      hiddenEntityIds: new Set([6]),
+    }).content);
+
+    expect(content).not.toContain('#6=IFCSPACE');
+    expect(findDanglingRefs(content)).toEqual([]);
+  });
+
+  it('leaves a hidden OPENING in IfcRelVoidsElement — the mirror of the case propagateOpeningExclusions covers', () => {
+    // `propagateOpeningExclusions` deletes the relation from `roots` when the
+    // RELATING element is hidden. Here the relating wall is visible and the
+    // RELATED opening is what the caller hid, so that branch never fires.
+    const store = buildParsedStore([
+      [1, 'IFCPROJECT', PROJECT],
+      [2, 'IFCBUILDINGSTOREY', STOREY],
+      [3, 'IFCWALL', "#3=IFCWALL('0walA0000000000000000',$,'VisibleWall',$,$,$,$,$);\n"],
+      [5, 'IFCOPENINGELEMENT', "#5=IFCOPENINGELEMENT('0open0000000000000000',$,'HiddenOpening',$,$,$,$,$);\n"],
+      [20, 'IFCRELVOIDSELEMENT', "#20=IFCRELVOIDSELEMENT('0void0000000000000000',$,$,$,#3,#5);\n"],
+    ]);
+
+    const content = decode(new StepExporter(store).export({
+      schema: 'IFC4',
+      visibleOnly: true,
+      hiddenEntityIds: new Set([5]),
+    }).content);
+
+    expect(content).not.toContain('#5=IFCOPENINGELEMENT');
+    expect(findDanglingRefs(content)).toEqual([]);
+  });
+
+  it('leaves the non-isolated wall in the containment relation under isolation', () => {
+    const store = buildParsedStore([
+      [1, 'IFCPROJECT', PROJECT],
+      [2, 'IFCBUILDINGSTOREY', STOREY],
+      [3, 'IFCWALL', "#3=IFCWALL('0walA0000000000000000',$,'Isolated',$,$,$,$,$);\n"],
+      [4, 'IFCWALL', "#4=IFCWALL('0walB0000000000000000',$,'Other',$,$,$,$,$);\n"],
+      [21, 'IFCRELCONTAINEDINSPATIALSTRUCTURE', "#21=IFCRELCONTAINEDINSPATIALSTRUCTURE('0cont0000000000000000',$,$,$,(#3,#4),#2);\n"],
+    ]);
+
+    const content = decode(new StepExporter(store).export({
+      schema: 'IFC4',
+      visibleOnly: true,
+      hiddenEntityIds: new Set<number>(),
+      isolatedEntityIds: new Set([3]),
+    }).content);
+
+    expect(content).not.toContain('#4=IFCWALL');
+    expect(findDanglingRefs(content)).toEqual([]);
+  });
+});
+
+/**
+ * A second, independent consequence of the same design, recorded here because
+ * it is what a user is most likely to notice: hiding an element does NOT keep
+ * its property data out of the file. The `IFCRELDEFINESBYPROPERTIES` root is
+ * emitted, and the closure walks THROUGH it into the pset and its atoms, which
+ * are not products and so are never in `excludeIds`.
+ *
+ * This case passes on this branch: it characterises current behaviour rather
+ * than asserting the desired one, because "should a filtered export carry a
+ * hidden element's properties" is a product question, not a spec violation.
+ */
+describe('visibleOnly still exports a hidden element’s property set (characterisation)', () => {
+  it('keeps Pset content reachable only from the hidden wall', () => {
+    const store = buildParsedStore([
+      [1, 'IFCPROJECT', PROJECT],
+      [4, 'IFCWALL', "#4=IFCWALL('0walB0000000000000000',$,'HiddenWall',$,$,$,$,$);\n"],
+      [10, 'IFCPROPERTYSET', "#10=IFCPROPERTYSET('0pset0000000000000000',$,'Pset_Custom',$,(#11));\n"],
+      [11, 'IFCPROPERTYSINGLEVALUE', "#11=IFCPROPERTYSINGLEVALUE('Cost',$,IFCTEXT('CONFIDENTIAL'),$);\n"],
+      [22, 'IFCRELDEFINESBYPROPERTIES', "#22=IFCRELDEFINESBYPROPERTIES('0rdbp0000000000000000',$,$,$,(#4),#10);\n"],
+    ]);
+
+    const content = decode(new StepExporter(store).export({
+      schema: 'IFC4',
+      visibleOnly: true,
+      hiddenEntityIds: new Set([4]),
+    }).content);
+
+    expect(content).not.toContain('#4=IFCWALL');
+    expect(content).toContain('CONFIDENTIAL');
+  });
+});


### PR DESCRIPTION
The feature half of the split you asked for on #2398. That PR bundled an ~80-line relationship-filtering feature inside a claimed no-op refactor without disclosing it; this branch carries the feature alone, off current `main`, with its own tests and justification. #2398 is untouched and still contains only the refactor.

## What it does

An export can emit a relationship that names an entity whose own line was withheld — a visible-only export dropping a hidden product, or a full export after `removeEntity`. The result is an **invalid** IFC file, not merely an incomplete one: a `#N` reference with no `#N=` line.

`filterHiddenRefsFromRelationshipLine` drops such an id from a nested list attribute, and withholds the relationship outright when the id sits in a bare scalar attribute or when dropping it would empty a list. Applied at both emission sites (source-iteration and overlay new-entities).

## Two findings from your review fixed in place

**Authored-vs-effective type mismatch.** The source-iteration pass classified "is this a relationship" from `entityRef.type` — frozen at parse time — while the overlay pass already used `typeMut?.newType ?? entity.type`. A retype across the IFCREL boundary made the check disagree with what `applySourceLineMutations` actually wrote. Now uses `effective.effectiveType()`, with a regression test that retypes a source `IfcWallType` into `IfcRelAggregates` naming a hidden entity.

**The deletion path.** This was the wider gap: the pre-existing sweep only withholds `IfcRelDefinesByProperties`, and only when *every* related object is deleted ("nothing here rewrites a RelatedObjects list" is verbatim in the comment). A containment relation naming one deleted and one live entity shipped a dangling ref on a plain full export. The filter is now a predicate combining `hiddenProductIds` and `effective.isDeleted`, applied on **any** export rather than visible-only. Regression test drives the real export path after `editor.removeEntity` on one of two related walls — not a unit assertion on the helper.

Both mutation-verified: each fix reverted in isolation broke its own test, restored `diff`-identical.

## On your third finding

The "weaker readable-source-ref check" I'm **not** actioning, with reasoning rather than silence: `entityLineText`'s `byteLength === 0` guard is behaviourally identical to pre-PR main for that case (`decodeUtf8` returns `''` either way, failing every downstream regex identically), and main previously had no bounds check there at all — only a dead `!this.dataStore.source` guard. Strengthening it to `isReadableSourceRef`'s full check would *change* answers on corrupted refs, which contradicts the refactor half's "provably no-op" premise. Happy to do it as its own change if you want the stronger behaviour.

## Split mechanics

Commits divided cleanly by history (`548088aad`+`d44b8a2c2` refactor, `e10be9d77`+`3b112a7ec` feature) except one 5-line hunk where the refactor's dead-guard removal sits adjacent to the feature's destructuring. Resolved by hand-applying the feature's restructuring on top of main's original guard, since removing it belongs to the refactor.

export 686 passed / 30 skipped (654 → 656 passing, 2 new tests), `tsc --noEmit` clean. The helper isn't re-exported from the package index, so no API-surface impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `visibleOnly` STEP exports to remove references to hidden or deleted entities.
  * Prevented dangling relationship references, including nested lists, scalar links, containment, property, boundary, and void relationships.
  * Preserved valid relationship members when only some referenced entities are excluded.
  * Improved relationship handling when entity types are changed during export.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->