### PR TITLE
fix(viewer): KMZ export shipped the model with its repeated geometry missing

### DIFF
--- a/.changeset/kmz-export-instanced-geometry.md
+++ b/.changeset/kmz-export-instanced-geometry.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/viewer": patch
+---
+
+KMZ export no longer ships a model with its repeated geometry missing.
+
+`buildKmzForResolvedGeoref` was handed `geometryResult.meshes`, which holds only part of the model: GPU-instanced occurrences render from compact shards and are deliberately absent from that flat list. Both surfaces that export a KMZ — the Export KMZ dialog and the Location panel's "Google Earth" button — passed it, so a tower whose facade is repeated panels exported to Google Earth as bare floor slabs. Same defect #2576 fixed for the on-screen world view, in the file the user hands to someone else.
+
+The complete set is now derived inside the shared builder, from a `geometryResult` rather than a mesh array, so there is no way for a call site to pass a pre-flattened list — the same reason the builder refuses a pre-guarded conversion. Callers pass `isPrimaryModel` alongside it, since instanced shard occurrences live in the primary model's id space and a federated model must not adopt them.

--- a/apps/viewer/src/components/viewer/KmzExportDialog.tsx
+++ b/apps/viewer/src/components/viewer/KmzExportDialog.tsx
@@ -70,9 +70,10 @@ export function KmzExportDialog({ trigger }: KmzExportDialogProps) {
   const modelList = useMemo(() => {
     const list = Array.from(models.values())
       .filter((m) => m.geometryResult && m.ifcDataStore)
-      .map((m) => ({ id: m.id, name: m.name, geometryResult: m.geometryResult!, dataStore: m.ifcDataStore! }));
+      .map((m) => ({ id: m.id, name: m.name, geometryResult: m.geometryResult!, dataStore: m.ifcDataStore!, isPrimary: (m.idOffset ?? 0) === 0 }));
     if (list.length === 0 && legacyGeometryResult && legacyDataStore) {
-      list.push({ id: '__legacy__', name: 'Current Model', geometryResult: legacyGeometryResult, dataStore: legacyDataStore });
+      // The legacy single-model slot is always the primary model (idOffset 0).
+      list.push({ id: '__legacy__', name: 'Current Model', geometryResult: legacyGeometryResult, dataStore: legacyDataStore, isPrimary: true });
     }
     return list;
   }, [models, legacyGeometryResult, legacyDataStore]);
@@ -121,6 +122,7 @@ export function KmzExportDialog({ trigger }: KmzExportDialogProps) {
       const baseName = sanitizeFilename(selectedModel.name.replace(/\.[^.]+$/, ''), { fallback: 'model' });
       const result = await buildKmzForModel({
         geometryResult: selectedModel.geometryResult,
+        isPrimaryModel: selectedModel.isPrimary,
         dataStore: selectedModel.dataStore,
         mutations: selectedModelId === '__legacy__' ? undefined : georefMutations.get(selectedModelId),
         name: baseName,

--- a/apps/viewer/src/components/viewer/properties/LocationMap.kmz.test.tsx
+++ b/apps/viewer/src/components/viewer/properties/LocationMap.kmz.test.tsx
@@ -39,6 +39,36 @@ import type { MapConversion, ProjectedCRS } from '@ifc-lite/parser';
 import { render, cleanup } from '@/test/render.js';
 import { LocationMap } from './LocationMap.js';
 import type { KmzProcessor } from '@/lib/geo/kmz-exporter.js';
+import { setGlobalRendererRef } from '@/hooks/useBCF.js';
+import type { Renderer } from '@ifc-lite/renderer';
+import type { RefObject } from 'react';
+
+/** A materialised instanced occurrence, as `getAllInstancedMeshData` returns
+ *  them: world-space positions, no `origin`, real typed arrays (the export
+ *  path sums their lengths). */
+function instancedOccurrence(expressId: number): MeshData {
+  return {
+    expressId,
+    positions: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+    normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+    indices: new Uint32Array([0, 1, 2]),
+    color: [1, 1, 1, 1],
+  } as unknown as MeshData;
+}
+
+/** Install a fake global renderer whose scene reports `instanced` occurrences —
+ *  the compact-shard half of the model, absent from `geometryResult.meshes`. */
+function setInstancedScene(instanced: MeshData[] | null): void {
+  const scene = instanced === null
+    ? undefined
+    : {
+        getAllInstancedMeshData: () => instanced,
+        getInstancedEntityCount: () => new Set(instanced.map((m) => m.expressId)).size,
+      };
+  setGlobalRendererRef(
+    { current: { getScene: () => scene } as unknown as Renderer } as RefObject<Renderer | null>,
+  );
+}
 
 /**
  * The #2526 file: IfcSite placed at the absolute EPSG:25833 coordinate (the
@@ -73,6 +103,7 @@ const GEOMETRY_RESULT = {
 } as GeometryResult;
 
 interface RecordedCall {
+  meshes: MeshData[];
   altitude: number;
   xAxisAbscissa: number | undefined;
   xAxisOrdinate: number | undefined;
@@ -84,8 +115,8 @@ function makeStub() {
   const calls: RecordedCall[] = [];
   const gp: KmzProcessor = {
     async init() {},
-    exportKmzFromMeshes(_meshes, _lat, _lon, altitude, xAxisAbscissa, xAxisOrdinate, _name, altitudeMode) {
-      calls.push({ altitude, xAxisAbscissa, xAxisOrdinate, altitudeMode });
+    exportKmzFromMeshes(meshes, _lat, _lon, altitude, xAxisAbscissa, xAxisOrdinate, _name, altitudeMode) {
+      calls.push({ meshes: meshes as MeshData[], altitude, xAxisAbscissa, xAxisOrdinate, altitudeMode });
       return new Uint8Array([0x50, 0x4b, 0x03, 0x04]); // "PK\x03\x04"
     },
     dispose() {},
@@ -130,7 +161,10 @@ async function exportViaButton(): Promise<RecordedCall[]> {
 }
 
 describe('LocationMap — Google Earth (KMZ) export', () => {
-  afterEach(cleanup);
+  afterEach(() => {
+    cleanup();
+    setGlobalRendererRef({ current: null } as RefObject<Renderer | null>);
+  });
 
   it('exports a map-absolute model with the GUARDED heading, not the authored 90-degree axis', async () => {
     const calls = await exportViaButton();
@@ -151,6 +185,32 @@ describe('LocationMap — Google Earth (KMZ) export', () => {
     assert.strictEqual(calls[0].altitude, 14);
   });
 
+  it('exports the GPU-instanced occurrences too, not just the flat mesh list (#2577)', async () => {
+    // `geometryResult.meshes` is only part of the model: repeated opaque
+    // geometry (facade panels, mullions, windows) renders from compact shards
+    // and is deliberately absent from it. Passing that list straight to the
+    // exporter shipped a KMZ with the repeated geometry missing — the same
+    // defect #2576 fixed for the on-screen world view.
+    setInstancedScene([instancedOccurrence(42)]);
+
+    const calls = await exportViaButton();
+
+    assert.strictEqual(calls.length, 1, 'expected exactly one KMZ export');
+    assert.deepStrictEqual(
+      calls[0].meshes.map((m) => m.expressId).sort((a, b) => a - b),
+      [1, 42],
+      'the exported file must carry the flat mesh AND the instanced occurrence',
+    );
+  });
+
+  it('exports the flat model unchanged when the scene holds no instanced geometry', async () => {
+    setInstancedScene([]);
+
+    const calls = await exportViaButton();
+
+    assert.deepStrictEqual(calls[0].meshes.map((m) => m.expressId), [1]);
+  });
+
   it('agrees with the Export KMZ dialog, which is the point of sharing one builder', async () => {
     const { gp, calls } = makeStub();
     const { buildKmzForResolvedGeoref } = await import('@/lib/geo/kmz-export.js');
@@ -159,7 +219,8 @@ describe('LocationMap — Google Earth (KMZ) export', () => {
       crs: EPSG_25833,
       coordinateInfo: MAP_ABSOLUTE_COORDINATE_INFO,
       lengthUnitScale: 1,
-      meshes: GEOMETRY_RESULT.meshes as MeshData[],
+      geometryResult: GEOMETRY_RESULT,
+      isPrimaryModel: true,
       name: 'IFC Model',
     }, () => gp);
     assert.ok(out instanceof Uint8Array);
@@ -167,9 +228,10 @@ describe('LocationMap — Google Earth (KMZ) export', () => {
     const viaPanel = await exportViaButton();
     assert.strictEqual(viaPanel.length, 1, 'expected exactly one KMZ export from the panel');
     assert.strictEqual(calls.length, 1, 'expected exactly one KMZ export from the builder');
+    const placement = ({ meshes: _meshes, ...rest }: RecordedCall) => rest;
     assert.deepStrictEqual(
-      viaPanel[0],
-      calls[0],
+      placement(viaPanel[0]),
+      placement(calls[0]),
       'the panel and the dialog must place the same model identically',
     );
   });

--- a/apps/viewer/src/components/viewer/properties/LocationMap.tsx
+++ b/apps/viewer/src/components/viewer/properties/LocationMap.tsx
@@ -735,7 +735,12 @@ export function LocationMap({
         crs: projectedCRS,
         coordinateInfo,
         lengthUnitScale: lengthUnitScale ?? 1,
-        meshes: geometryResult.meshes as MeshData[],
+        // The COMPLETE mesh set is derived inside the builder — passing
+        // `geometryResult.meshes` here dropped every GPU-instanced occurrence
+        // from the exported file (#2577). The Location panel only ever shows
+        // the primary model's georeference.
+        geometryResult,
+        isPrimaryModel: true,
         name: 'IFC Model',
       }, createKmzProcessor);
       if (typeof kmz === 'string') {

--- a/apps/viewer/src/lib/geo/kmz-export.test.ts
+++ b/apps/viewer/src/lib/geo/kmz-export.test.ts
@@ -2,14 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { describe, it } from 'node:test';
+import { afterEach, describe, it } from 'node:test';
 import assert from 'node:assert';
+import type { RefObject } from 'react';
 
-import type { CoordinateInfo } from '@ifc-lite/geometry';
+import type { CoordinateInfo, GeometryResult, MeshData } from '@ifc-lite/geometry';
 
-import type { MapConversion } from '@ifc-lite/parser';
+import type { MapConversion, ProjectedCRS } from '@ifc-lite/parser';
+import type { Renderer } from '@ifc-lite/renderer';
 
-import { computeKmzAltitude, resolveKmzHeading } from './kmz-export.js';
+import { setGlobalRendererRef } from '../../hooks/useBCF.js';
+import type { KmzProcessor } from './kmz-exporter.js';
+import { buildKmzForResolvedGeoref, computeKmzAltitude, resolveKmzHeading } from './kmz-export.js';
 
 describe('computeKmzAltitude', () => {
   it('scales OrthogonalHeight from map units to metres (mm-CRS file is not 1000x off)', () => {
@@ -77,5 +81,105 @@ describe('resolveKmzHeading', () => {
     const heading = resolveKmzHeading(conversion, { mapUnitScale: 1 }, 1, coordinateInfo);
     assert.strictEqual(heading.xAxisAbscissa, 0.6);
     assert.strictEqual(heading.xAxisOrdinate, 0.8);
+  });
+});
+
+
+/**
+ * A model can have an EMPTY flat mesh list and still have geometry, because
+ * every occurrence is GPU-instanced. `buildKmzForModel` used to short-circuit
+ * on `geometryResult.meshes.length` and report "no geometry" for exactly that
+ * model; the check now lives here, against the complete set (#2577 review).
+ */
+describe('buildKmzForResolvedGeoref — the model is not the flat mesh list', () => {
+  afterEach(() => {
+    setGlobalRendererRef({ current: null } as RefObject<Renderer | null>);
+  });
+
+  const CONVERSION: MapConversion = {
+    id: 1, sourceCRS: 0, targetCRS: 0,
+    eastings: 311_988.181, northings: 5_996_148.565, orthogonalHeight: 0,
+    xAxisAbscissa: 1, xAxisOrdinate: 0, scale: 1,
+  };
+  const CRS = { id: 2, name: 'EPSG:25833', mapUnitScale: 1 } as ProjectedCRS;
+
+  function occurrence(expressId: number): MeshData {
+    return {
+      expressId,
+      positions: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+      normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+      indices: new Uint32Array([0, 1, 2]),
+      color: [1, 1, 1, 1],
+    } as unknown as MeshData;
+  }
+
+  function setInstancedScene(instanced: MeshData[]): void {
+    const scene = {
+      getAllInstancedMeshData: () => instanced,
+      getInstancedEntityCount: () => new Set(instanced.map((m) => m.expressId)).size,
+    };
+    setGlobalRendererRef(
+      { current: { getScene: () => scene } as unknown as Renderer } as RefObject<Renderer | null>,
+    );
+  }
+
+  function stub() {
+    const seen: MeshData[][] = [];
+    const gp: KmzProcessor = {
+      async init() {},
+      exportKmzFromMeshes(meshes) {
+        seen.push(meshes as MeshData[]);
+        return new Uint8Array([0x50, 0x4b, 0x03, 0x04]);
+      },
+      dispose() {},
+    };
+    return { gp, seen };
+  }
+
+  const build = (meshes: MeshData[], gp: KmzProcessor) => buildKmzForResolvedGeoref({
+    conversion: CONVERSION,
+    crs: CRS,
+    coordinateInfo: undefined,
+    lengthUnitScale: 1,
+    geometryResult: { meshes } as GeometryResult,
+    isPrimaryModel: true,
+    name: 'IFC Model',
+  }, () => gp);
+
+  it('exports an instanced-only model, whose flat mesh list is empty', async () => {
+    setInstancedScene([occurrence(42)]);
+    const { gp, seen } = stub();
+
+    const out = await build([], gp);
+
+    assert.ok(out instanceof Uint8Array, 'expected KMZ bytes, not a no-geometry error');
+    assert.deepStrictEqual(seen[0].map((m) => m.expressId), [42]);
+  });
+
+  it("still reports no-geometry when the COMPLETE set is empty", async () => {
+    setInstancedScene([]);
+    const { gp, seen } = stub();
+
+    assert.strictEqual(await build([], gp), 'no-geometry');
+    assert.strictEqual(seen.length, 0, 'the exporter must not be driven with nothing');
+  });
+
+  it('does not adopt instanced occurrences for a federated (non-primary) model', async () => {
+    // Shard occurrences live in the primary model's id space.
+    setInstancedScene([occurrence(42)]);
+    const { gp, seen } = stub();
+
+    const out = await buildKmzForResolvedGeoref({
+      conversion: CONVERSION,
+      crs: CRS,
+      coordinateInfo: undefined,
+      lengthUnitScale: 1,
+      geometryResult: { meshes: [occurrence(7)] } as GeometryResult,
+      isPrimaryModel: false,
+      name: 'IFC Model',
+    }, () => gp);
+
+    assert.ok(out instanceof Uint8Array);
+    assert.deepStrictEqual(seen[0].map((m) => m.expressId), [7]);
   });
 });

--- a/apps/viewer/src/lib/geo/kmz-export.ts
+++ b/apps/viewer/src/lib/geo/kmz-export.ts
@@ -14,6 +14,7 @@ import type { GeorefMutationData } from '@/store/slices/mutationSlice';
 import { getMapUnitScale } from './cesium-placement';
 import { mergeMapConversion, mergeProjectedCRS } from './effective-georef';
 import { resolveMapUnitToMetreScale } from './geo-scale';
+import { withInstancedMeshes } from '../../utils/instancedExport.js';
 import { effectiveMapConversionForGeometry } from './map-absolute';
 import { reprojectToLatLon } from './reproject';
 import { buildKmz, type KmzAltitudeMode, type KmzProcessor } from './kmz-exporter';
@@ -27,6 +28,9 @@ export function modelHasGeoreference(dataStore: IfcDataStore | null | undefined)
 
 export interface BuildKmzInput {
   geometryResult: GeometryResult;
+  /** True when this is the primary model (`idOffset === 0`) — see
+   *  {@link ResolvedKmzGeorefInput.isPrimaryModel}. */
+  isPrimaryModel: boolean;
   dataStore: IfcDataStore;
   /** Pending georef edits for this model (store `georefMutations.get(modelId)`). */
   mutations?: GeorefMutationData;
@@ -119,7 +123,21 @@ export interface ResolvedKmzGeorefInput {
   coordinateInfo: CoordinateInfo | undefined;
   /** IFC project length unit to metres. */
   lengthUnitScale: number;
-  meshes: MeshData[];
+  /**
+   * The model's geometry. Deliberately NOT a mesh array: the COMPLETE set is
+   * derived here via `withInstancedMeshes`, because `geometryResult.meshes`
+   * omits every GPU-instanced occurrence and a caller passing it directly
+   * exported a model with its repeated geometry missing (#2577) — the same way
+   * both call sites once passed a raw conversion and skipped the placement
+   * corrections. There is no way to hand in a pre-flattened list.
+   */
+  geometryResult: GeometryResult;
+  /**
+   * True when this is the primary model (`idOffset === 0`). Instanced shard
+   * occurrences live in the primary model's id space, so a federated model must
+   * not adopt them — same flag the glTF/IFC exporters pass.
+   */
+  isPrimaryModel: boolean;
   /** Display name / file stem. */
   name: string;
   altitudeMode?: KmzAltitudeMode;
@@ -152,7 +170,8 @@ export async function buildKmzForResolvedGeoref(
   input: ResolvedKmzGeorefInput,
   createProcessor?: () => KmzProcessor,
 ): Promise<Uint8Array | KmzBuildError> {
-  if (!input.meshes.length) return 'no-geometry';
+  const meshes = withInstancedMeshes(input.geometryResult, input.isPrimaryModel).meshes as MeshData[];
+  if (!meshes.length) return 'no-geometry';
   const { conversion, crs, coordinateInfo, lengthUnitScale } = input;
   const latLon = await reprojectToLatLon(conversion, crs, coordinateInfo, lengthUnitScale);
   if (!latLon) return 'unprojectable';
@@ -162,7 +181,7 @@ export async function buildKmzForResolvedGeoref(
     altitude: computeKmzAltitude(conversion.orthogonalHeight, crs, lengthUnitScale, coordinateInfo),
     xAxisAbscissa: heading.xAxisAbscissa,
     xAxisOrdinate: heading.xAxisOrdinate,
-    meshes: input.meshes,
+    meshes,
     name: input.name,
     altitudeMode: input.altitudeMode,
   };
@@ -196,7 +215,8 @@ export async function buildKmzForModel(
     crs,
     coordinateInfo: input.geometryResult.coordinateInfo,
     lengthUnitScale: scale,
-    meshes: input.geometryResult.meshes as MeshData[],
+    geometryResult: input.geometryResult,
+    isPrimaryModel: input.isPrimaryModel,
     name: input.name,
     altitudeMode: input.altitudeMode,
   }, createProcessor);

--- a/apps/viewer/src/lib/geo/kmz-export.ts
+++ b/apps/viewer/src/lib/geo/kmz-export.ts
@@ -200,7 +200,11 @@ export async function buildKmzForModel(
   input: BuildKmzInput,
   createProcessor?: () => KmzProcessor,
 ): Promise<Uint8Array | KmzBuildError> {
-  if (!input.geometryResult.meshes?.length) return 'no-geometry';
+  // No flat-mesh guard here: `meshes` can be empty while the model still has
+  // geometry, because every occurrence is GPU-instanced. Gating on it would
+  // report "no geometry" for a model that exports fine — the same
+  // flat-list-is-not-the-model mistake this function was fixed for (#2577).
+  // `buildKmzForResolvedGeoref` makes that call against the COMPLETE set.
   const info = extractGeoreferencingOnDemand(input.dataStore);
   const scale = extractLengthUnitScale(input.dataStore.source, input.dataStore.entityIndex) ?? 1;
   // Apply pending georef edits BEFORE deciding the model is unreferenced: a model


### PR DESCRIPTION
Fixes #2577. Sibling of #2576, which fixed the same defect for the on-screen world view.

## The bug

`buildKmzForResolvedGeoref` was handed `geometryResult.meshes`. That list holds only part of the model — GPU-instanced occurrences render from compact shards and are deliberately absent from it, as `utils/instancedExport.ts` documents. Both surfaces that export a KMZ passed it:

- `KmzExportDialog` → `buildKmzForModel` → `meshes: input.geometryResult.meshes`
- `LocationMap`'s "Google Earth" button → `buildKmzForResolvedGeoref` → `meshes: geometryResult.meshes`

So a tower whose facade is repeated panels exported to Google Earth as bare floor slabs. On the model from #2558 that is 9,950 of 18,555 meshes and 396K of 655K triangles — in the file the user hands to someone else, where the omission is not visible until it is opened somewhere you do not control.

## Fixed at the seam, not at the call sites

Patching the two call sites would leave the next one free to forget, in a file whose own docstring records exactly that history:

> Same model, two buttons, two different files. `buildKmzForResolvedGeoref` is now the single source for both (#2526 follow-up).
> ... there is deliberately no way to pass a pre-guarded one, so a call site cannot opt out of the correction by accident.

So `ResolvedKmzGeorefInput` now takes a `geometryResult` instead of a `meshes` array, and derives the complete set internally via the same `withInstancedMeshes` helper the glTF/IFC exporters and the world view use. There is no longer a way to hand the builder a pre-flattened mesh list.

Callers pass `isPrimaryModel` alongside it: instanced shard occurrences live in the primary model's id space, so a federated model must not adopt them. The dialog derives it from `idOffset === 0` (the legacy single-model slot is always primary), matching `ExportDialog.tsx:461`.

## Tests

Extends `LocationMap.kmz.test.tsx`, which already mounts the real panel and clicks the real button for the #2526 placement fix — and whose header states the reason this shape is required:

> A unit test on `buildKmzForResolvedGeoref` cannot catch this: it passes just as happily while the component calls something else entirely.

Two cases added: with an instanced occurrence in the scene the exported file carries flat **and** instanced meshes (`[1, 42]`), and with an empty instanced set it carries the flat model unchanged. Reverting the builder to `input.geometryResult.meshes` fails the first.

The existing "panel and dialog place the model identically" case now compares placement only, since the recorded call carries the mesh payload too.

Viewer suite 3,946 passing / 5 skipped, `tsc --noEmit` clean, `check-source-text-assertions` / `check-test-wiring` / `check-unbounded-frame-wait` clean. Changeset: patch for `@ifc-lite/viewer`.

## Not verified end to end

I did not open an exported KMZ in Google Earth. The assertion is on what reaches the COLLADA exporter, which is where the meshes were being lost; the placement maths this file is mostly about is untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - KMZ exports now include complete model geometry, including GPU-instanced occurrences.
  - Primary model exports correctly include instanced geometry, while federated models retain appropriate geometry selection.
  - KMZ exports from the export dialog and Location panel now produce consistent geometry and placement results.
  - Models containing only instanced geometry can now be exported successfully.

- **Tests**
  - Added coverage for instanced geometry, empty geometry handling, placement data, and federated model behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->