### PR TITLE
test(export,geometry): an absent fixture must skip, not panic

### DIFF
--- a/rust/export/src/csv.rs
+++ b/rust/export/src/csv.rs
@@ -233,14 +233,9 @@ fn quantities_csv(model: &ExportModel, opts: &CsvOptions) -> String {
 mod tests {
     use super::*;
 
-    fn fixture(rel: &str) -> Vec<u8> {
-        let path = format!("{}/../../tests/models/{}", env!("CARGO_MANIFEST_DIR"), rel);
-        std::fs::read(&path).unwrap_or_else(|e| panic!("read {path}: {e}"))
-    }
-
     #[test]
     fn entities_csv_has_header_and_rows() {
-        let csv = export_csv(&fixture("ara3d/duplex.ifc"), CsvMode::Entities, &CsvOptions::default());
+        let csv = export_csv(&fixture_or_skip!("ara3d/duplex.ifc"), CsvMode::Entities, &CsvOptions::default());
         let mut lines = csv.lines();
         assert_eq!(lines.next().unwrap(), "expressId,globalId,name,type,description,objectType,hasGeometry");
         assert!(csv.lines().count() > 50, "expected many product rows");
@@ -254,9 +249,9 @@ mod tests {
 
     #[test]
     fn flatten_adds_property_columns() {
-        let plain = export_csv(&fixture("ara3d/duplex.ifc"), CsvMode::Entities, &CsvOptions::default());
+        let plain = export_csv(&fixture_or_skip!("ara3d/duplex.ifc"), CsvMode::Entities, &CsvOptions::default());
         let flat = export_csv(
-            &fixture("ara3d/duplex.ifc"),
+            &fixture_or_skip!("ara3d/duplex.ifc"),
             CsvMode::Entities,
             &CsvOptions { include_properties: true, ..CsvOptions::default() },
         );
@@ -267,7 +262,7 @@ mod tests {
 
     #[test]
     fn properties_csv_one_row_per_value() {
-        let csv = export_csv(&fixture("ara3d/duplex.ifc"), CsvMode::Properties, &CsvOptions::default());
+        let csv = export_csv(&fixture_or_skip!("ara3d/duplex.ifc"), CsvMode::Properties, &CsvOptions::default());
         assert_eq!(
             csv.lines().next().unwrap(),
             "entityId,globalId,entityName,entityType,psetName,propName,value,type"
@@ -278,7 +273,7 @@ mod tests {
     #[test]
     fn spatial_hierarchy_csv() {
         let csv = export_csv(
-            &fixture("ara3d/duplex.ifc"),
+            &fixture_or_skip!("ara3d/duplex.ifc"),
             CsvMode::SpatialHierarchy,
             &CsvOptions::default(),
         );

--- a/rust/export/src/gltf_tests.rs
+++ b/rust/export/src/gltf_tests.rs
@@ -7,24 +7,6 @@
 
 use super::*;
 
-fn fixture(rel: &str) -> Vec<u8> {
-    let path = format!("{}/../../tests/models/{}", env!("CARGO_MANIFEST_DIR"), rel);
-    std::fs::read(&path).unwrap_or_else(|e| panic!("read {path}: {e}"))
-}
-
-/// Like [`fixture`] but returns `None` when the catalogued fixture has not
-/// been fetched, so the test can SKIP (never throw) per the house rule.
-fn fixture_opt(rel: &str) -> Option<Vec<u8>> {
-    let path = format!("{}/../../tests/models/{}", env!("CARGO_MANIFEST_DIR"), rel);
-    match std::fs::read(&path) {
-        Ok(bytes) => Some(bytes),
-        Err(_) => {
-            eprintln!("skipping: fixture {rel} not fetched (run `pnpm fixtures`)");
-            None
-        }
-    }
-}
-
 /// Parse a GLB and return (json: Value, bin: Vec<u8>).
 fn parse_glb(glb: &[u8]) -> (Value, Vec<u8>) {
     // Assert the literal magic bytes (not a derived constant) so a wrong magic
@@ -173,7 +155,7 @@ fn with_index_glb_is_byte_identical() {
     // The shared-index path must emit byte-for-byte the same GLB as the
     // self-indexing path — it only injects an index equal to the one
     // `export_glb_with_stats` builds internally. Guards the two from drifting.
-    let bytes = fixture("ara3d/duplex.ifc");
+    let bytes = fixture_or_skip!("ara3d/duplex.ifc");
     let opts = GltfOptions::default();
     let (plain, _) = export_glb_with_stats(&bytes, &opts);
     let idx = Arc::new(crate::build_entity_index(&bytes));
@@ -203,7 +185,7 @@ fn glb_container_size_does_not_truncate() {
 /// assembler builds internally, so only the redundant scan is removed.
 #[test]
 fn bounded_glb_with_index_is_byte_identical() {
-    let bytes = fixture("ara3d/duplex.ifc");
+    let bytes = fixture_or_skip!("ara3d/duplex.ifc");
     for quantize in [false, true] {
         let opts = GltfOptions { quantize, ..GltfOptions::default() };
         let (plain, ps) = export_glb_streaming_bounded(&bytes, &opts);
@@ -218,7 +200,7 @@ fn bounded_glb_with_index_is_byte_identical() {
 /// and identical external buffers as the self-indexing one.
 #[test]
 fn gltf_streaming_with_index_is_byte_identical() {
-    let bytes = fixture("ara3d/duplex.ifc");
+    let bytes = fixture_or_skip!("ara3d/duplex.ifc");
     let opts = GltfOptions::default();
     let cap = 256 * 1024;
 
@@ -240,7 +222,7 @@ fn gltf_streaming_with_index_is_byte_identical() {
 /// GLB vs multi-buffer without meshing to completion twice.
 #[test]
 fn project_glb_size_matches_bounded_output() {
-    let bytes = fixture("ara3d/duplex.ifc");
+    let bytes = fixture_or_skip!("ara3d/duplex.ifc");
     for quantize in [false, true] {
         let opts = GltfOptions { quantize, ..GltfOptions::default() };
         let proj = project_glb_size(&bytes, &opts);
@@ -265,7 +247,7 @@ fn project_glb_size_matches_bounded_output() {
 /// changes the oversize behaviour (typed error vs panic).
 #[test]
 fn try_export_bounded_matches_export_for_fitting_model() {
-    let bytes = fixture("ara3d/duplex.ifc");
+    let bytes = fixture_or_skip!("ara3d/duplex.ifc");
     let opts = GltfOptions::default();
     let (want, wstats) = export_glb_streaming_bounded(&bytes, &opts);
     let (got, gstats) = try_export_glb_streaming_bounded(&bytes, &opts)
@@ -396,7 +378,7 @@ fn quantized_glb_matches_f32_world_bounds() {
     // The quantized path reconstructs the same WORLD geometry as f32 — proves the
     // per-mesh dequant + placement (incl. the nested instanced dequant nodes)
     // compose correctly. Compared via world-space AABB within a few mm.
-    let bytes = fixture("ara3d/duplex.ifc");
+    let bytes = fixture_or_skip!("ara3d/duplex.ifc");
     let (f32_glb, _) = export_glb_with_stats(&bytes, &GltfOptions::default());
     let (q_glb, _) = export_glb_with_stats(
         &bytes,
@@ -433,7 +415,7 @@ fn multibuffer_splits_and_matches_single_glb() {
     // A tiny cap forces the geometry across several < cap buffers; the reconstructed
     // world geometry must equal the single-GLB output exactly (f32, same bytes, just
     // split). Proves the chunked bufferView/accessor reindexing is correct.
-    let bytes = fixture("ara3d/duplex.ifc");
+    let bytes = fixture_or_skip!("ara3d/duplex.ifc");
     let opts = GltfOptions::default();
     let (glb, _) = export_glb_with_stats(&bytes, &opts);
     let (gj, gb) = parse_glb(&glb);
@@ -469,7 +451,7 @@ fn multibuffer_splits_and_matches_single_glb() {
 fn multibuffer_quantized_roundtrips() {
     // Quantization + multi-buffer compose: quantized geometry split across chunks
     // still reconstructs the f32 world bounds (within mm) and stays < cap.
-    let bytes = fixture("ara3d/duplex.ifc");
+    let bytes = fixture_or_skip!("ara3d/duplex.ifc");
     let (glb, _) = export_glb_with_stats(&bytes, &GltfOptions::default());
     let (gj, gb) = parse_glb(&glb);
     let (lo0, hi0) = world_aabb(&gj, &[&gb]);
@@ -519,7 +501,7 @@ fn quantized_normal_compensation_survives_nonuniform_scale() {
 
 #[test]
 fn multibuffer_is_deterministic() {
-    let bytes = fixture("ara3d/duplex.ifc");
+    let bytes = fixture_or_skip!("ara3d/duplex.ifc");
     let opts = GltfOptions::default();
     let (j1, b1) = streaming_export(&bytes, &opts, 64 * 1024);
     let (j2, b2) = streaming_export(&bytes, &opts, 64 * 1024);
@@ -529,7 +511,7 @@ fn multibuffer_is_deterministic() {
 
 #[test]
 fn quantized_glb_is_structurally_valid() {
-    let bytes = fixture("ara3d/duplex.ifc");
+    let bytes = fixture_or_skip!("ara3d/duplex.ifc");
     let (glb, stats) = export_glb_with_stats(
         &bytes,
         &GltfOptions { quantize: true, ..Default::default() },
@@ -579,7 +561,7 @@ fn quantized_glb_is_structurally_valid() {
 
 #[test]
 fn quantized_glb_is_byte_deterministic() {
-    let bytes = fixture("ara3d/duplex.ifc");
+    let bytes = fixture_or_skip!("ara3d/duplex.ifc");
     let opts = GltfOptions { quantize: true, ..Default::default() };
     let (a, _) = export_glb_with_stats(&bytes, &opts);
     let (b, _) = export_glb_with_stats(&bytes, &opts);
@@ -619,7 +601,7 @@ fn quantization_roundtrip_precision() {
 #[test]
 fn duplex_exports_valid_glb() {
     let (glb, stats) =
-        export_glb_with_stats(&fixture("ara3d/duplex.ifc"), &GltfOptions::default());
+        export_glb_with_stats(&fixture_or_skip!("ara3d/duplex.ifc"), &GltfOptions::default());
     assert!(stats.meshes > 0 && stats.triangles > 0);
 
     let (json, bin) = parse_glb(&glb);
@@ -969,7 +951,7 @@ fn try_from_meshes_rejects_index_counts_past_buffer() {
 fn export_is_byte_deterministic() {
     // Instancing groups by HashMap keys (rep colour buckets, material dedup);
     // emission order must be fixed so repeated exports are byte-identical.
-    let content = fixture("ara3d/C20-Institute-Var-2.ifc");
+    let content = fixture_or_skip!("ara3d/C20-Institute-Var-2.ifc");
     let a = export_glb(&content, &GltfOptions { include_metadata: true, ..Default::default() });
     let b = export_glb(&content, &GltfOptions { include_metadata: true, ..Default::default() });
     assert_eq!(a, b, "repeated GLB exports must be byte-identical");
@@ -979,7 +961,7 @@ fn export_is_byte_deterministic() {
 fn nodes_carry_global_id_and_model_id() {
     // From-bytes export with metadata + a model id: every element node carries
     // `modelId`, and elements with an IFC GlobalId carry `GlobalId`.
-    let content = fixture("ara3d/duplex.ifc");
+    let content = fixture_or_skip!("ara3d/duplex.ifc");
     let opts = GltfOptions {
         include_metadata: true,
         model_id: Some("model-42".to_string()),
@@ -1040,7 +1022,7 @@ fn glb_nodes_have_export_rows_for_legacy_products() {
         "ifcopenshell/1032-curve.ifc",
         "issues/860_solid_stratum.ifc",
     ] {
-        let Some(content) = fixture_opt(rel) else { continue };
+        let Some(content) = crate::test_support::fixture_opt(rel) else { continue };
         found += 1;
         let opts = GltfOptions {
             include_metadata: true,
@@ -1089,7 +1071,7 @@ fn instanced_occurrences_reconstruct_world_positions() {
     // position). This exercises the full chain — rep-identity grouping, the
     // Z-up→Y-up conjugation, scene-center folding, and the f32 node matrix — on
     // genuinely rotated, placed occurrences, so any frame/RTC error surfaces.
-    let content = fixture("ara3d/C20-Institute-Var-2.ifc");
+    let content = fixture_or_skip!("ara3d/C20-Institute-Var-2.ifc");
     let opts = GltfOptions { include_metadata: true, ..GltfOptions::default() };
     let (glb, _stats) = export_glb_with_stats(&content, &opts);
     let (json, bin) = parse_glb(&glb);
@@ -1297,7 +1279,7 @@ fn emissive_takes_precedence_over_unlit() {
 #[test]
 fn metadata_and_isolation() {
     let with_meta = export_glb_with_stats(
-        &fixture("ara3d/duplex.ifc"),
+        &fixture_or_skip!("ara3d/duplex.ifc"),
         &GltfOptions { include_metadata: true, ..GltfOptions::default() },
     )
     .0;
@@ -1306,15 +1288,15 @@ fn metadata_and_isolation() {
     assert!(json["nodes"][0]["extras"]["expressId"].is_number());
 
     // Isolate one id ⇒ fewer or equal meshes than the full export.
-    let full = export_glb_with_stats(&fixture("ara3d/duplex.ifc"), &GltfOptions::default()).1;
-    let some_id = process_geometry(&fixture("ara3d/duplex.ifc")[..])
+    let full = export_glb_with_stats(&fixture_or_skip!("ara3d/duplex.ifc"), &GltfOptions::default()).1;
+    let some_id = process_geometry(&fixture_or_skip!("ara3d/duplex.ifc")[..])
         .meshes
         .iter()
         .find(|m| super::mesh_visible(m, &GltfOptions::default()))
         .map(|m| m.express_id)
         .unwrap();
     let iso = export_glb_with_stats(
-        &fixture("ara3d/duplex.ifc"),
+        &fixture_or_skip!("ara3d/duplex.ifc"),
         &GltfOptions { isolated: vec![some_id], ..GltfOptions::default() },
     )
     .1;
@@ -1407,7 +1389,7 @@ fn too_large_error_code_and_message() {
 
 #[test]
 fn try_export_glb_matches_fail_open_path_when_nonempty() {
-    let Some(content) = fixture_opt("ifcopenshell/1019-column.ifc") else { return };
+    let Some(content) = crate::test_support::fixture_opt("ifcopenshell/1019-column.ifc") else { return };
     let (glb, stats) =
         try_export_glb_with_stats(&content, &GltfOptions::default()).expect("has geometry");
     assert!(stats.meshes >= 1);
@@ -1436,7 +1418,7 @@ fn streaming_bounded_is_byte_identical_on_flat_models() {
     // assemblers share (flat emission + content dedup); their output must be
     // byte-for-byte identical, JSON and BIN.
     for rel in ["ifcopenshell/1019-column.ifc", "ifcopenshell/1030-sphere.ifc"] {
-        let Some(content) = fixture_opt(rel) else { continue };
+        let Some(content) = crate::test_support::fixture_opt(rel) else { continue };
         let opts = GltfOptions { include_metadata: true, ..GltfOptions::default() };
         let (in_memory, mem_stats) = export_glb_from_result(process_geometry(&content), &opts);
         let (streamed, stream_stats) = export_glb_streaming_bounded(&content, &opts);
@@ -1450,7 +1432,7 @@ fn streaming_bounded_preserves_world_geometry_on_instanced_model() {
     // duplex has rep-identity groups the streaming path deliberately skips
     // (bounded memory cannot hold every occurrence). World geometry must be
     // identical anyway: same element nodes, same total placed triangles.
-    let Some(content) = fixture_opt("ara3d/duplex.ifc") else { return };
+    let Some(content) = crate::test_support::fixture_opt("ara3d/duplex.ifc") else { return };
     let opts = GltfOptions::default();
     let (in_memory, _) = export_glb_from_result(process_geometry(&content), &opts);
     let (streamed, stream_stats) = export_glb_streaming_bounded(&content, &opts);
@@ -1483,7 +1465,7 @@ fn streaming_bounded_preserves_world_geometry_on_instanced_model() {
 #[test]
 fn streaming_bounded_quantized_is_byte_identical_on_flat_models() {
     for rel in ["ifcopenshell/1019-column.ifc", "ifcopenshell/1030-sphere.ifc"] {
-        let Some(content) = fixture_opt(rel) else { continue };
+        let Some(content) = crate::test_support::fixture_opt(rel) else { continue };
         let opts = GltfOptions {
             quantize: true,
             include_metadata: true,
@@ -1498,7 +1480,7 @@ fn streaming_bounded_quantized_is_byte_identical_on_flat_models() {
 
 #[test]
 fn streaming_bounded_quantized_preserves_world_geometry_on_instanced_model() {
-    let Some(content) = fixture_opt("ara3d/duplex.ifc") else { return };
+    let Some(content) = crate::test_support::fixture_opt("ara3d/duplex.ifc") else { return };
     let opts = GltfOptions { quantize: true, ..GltfOptions::default() };
     let (in_memory, _) = export_glb_from_result(process_geometry(&content), &opts);
     let (streamed, stream_stats) = export_glb_streaming_bounded(&content, &opts);

--- a/rust/export/src/ifc5.rs
+++ b/rust/export/src/ifc5.rs
@@ -220,14 +220,9 @@ pub fn export_ifc5(content: &[u8], opts: &Ifc5Options) -> String {
 mod tests {
     use super::*;
 
-    fn fixture(rel: &str) -> Vec<u8> {
-        let path = format!("{}/../../tests/models/{}", env!("CARGO_MANIFEST_DIR"), rel);
-        std::fs::read(&path).unwrap_or_else(|e| panic!("read {path}: {e}"))
-    }
-
     #[test]
     fn duplex_exports_valid_ifcx() {
-        let s = export_ifc5(&fixture("ara3d/duplex.ifc"), &Ifc5Options::default());
+        let s = export_ifc5(&fixture_or_skip!("ara3d/duplex.ifc"), &Ifc5Options::default());
         let v: Value = serde_json::from_str(&s).expect("valid JSON");
         assert_eq!(v["header"]["ifcxVersion"], IFCX_VERSION);
         assert_eq!(v["imports"][0]["uri"], IMPORT_CORE);
@@ -277,7 +272,7 @@ mod tests {
     /// other end of a round-trip.
     #[test]
     fn header_uses_the_key_readers_look_for() {
-        let s = export_ifc5(&fixture("ara3d/duplex.ifc"), &Ifc5Options::default());
+        let s = export_ifc5(&fixture_or_skip!("ara3d/duplex.ifc"), &Ifc5Options::default());
         let v: Value = serde_json::from_str(&s).expect("valid JSON");
 
         let header = v["header"].as_object().expect("header object");
@@ -299,7 +294,7 @@ mod tests {
 
     #[test]
     fn unknown_props_filtered_by_default() {
-        let s = export_ifc5(&fixture("ara3d/duplex.ifc"), &Ifc5Options::default());
+        let s = export_ifc5(&fixture_or_skip!("ara3d/duplex.ifc"), &Ifc5Options::default());
         // 'LoadBearing' / 'Reference' are IFC4 props NOT in the IFC5 known set.
         assert!(!s.contains("bsi::ifc::prop::LoadBearing"));
         assert!(!s.contains("bsi::ifc::prop::Reference\""));

--- a/rust/export/src/json.rs
+++ b/rust/export/src/json.rs
@@ -109,14 +109,9 @@ pub fn export_json(content: &[u8], opts: &JsonOptions) -> String {
 mod tests {
     use super::*;
 
-    fn fixture(rel: &str) -> Vec<u8> {
-        let path = format!("{}/../../tests/models/{}", env!("CARGO_MANIFEST_DIR"), rel);
-        std::fs::read(&path).unwrap_or_else(|e| panic!("read {path}: {e}"))
-    }
-
     #[test]
     fn duplex_exports_json_array() {
-        let s = export_json(&fixture("ara3d/duplex.ifc"), &JsonOptions::default());
+        let s = export_json(&fixture_or_skip!("ara3d/duplex.ifc"), &JsonOptions::default());
         let v: Value = serde_json::from_str(&s).expect("valid JSON");
         let arr = v.as_array().expect("array");
         assert!(arr.len() > 50);

--- a/rust/export/src/jsonld.rs
+++ b/rust/export/src/jsonld.rs
@@ -123,14 +123,9 @@ pub fn export_jsonld(content: &[u8], opts: &JsonLdOptions) -> String {
 mod tests {
     use super::*;
 
-    fn fixture(rel: &str) -> Vec<u8> {
-        let path = format!("{}/../../tests/models/{}", env!("CARGO_MANIFEST_DIR"), rel);
-        std::fs::read(&path).unwrap_or_else(|e| panic!("read {path}: {e}"))
-    }
-
     #[test]
     fn duplex_exports_valid_jsonld() {
-        let s = export_jsonld(&fixture("ara3d/duplex.ifc"), &JsonLdOptions::default());
+        let s = export_jsonld(&fixture_or_skip!("ara3d/duplex.ifc"), &JsonLdOptions::default());
         let v: Value = serde_json::from_str(&s).expect("valid JSON");
         assert!(v["@context"]["ifc"].as_str().unwrap().ends_with("OWL#"));
         let graph = v["@graph"].as_array().expect("graph array");
@@ -146,7 +141,7 @@ mod tests {
 
     #[test]
     fn included_filter_restricts_the_graph() {
-        let bytes = fixture("ara3d/duplex.ifc");
+        let bytes = fixture_or_skip!("ara3d/duplex.ifc");
         // Full model graph → pick two express ids → re-export isolated to them.
         let full: Value =
             serde_json::from_str(&export_jsonld(&bytes, &JsonLdOptions::default())).unwrap();

--- a/rust/export/src/lib.rs
+++ b/rust/export/src/lib.rs
@@ -7,6 +7,10 @@
 //! This is the Rust source of truth; CLI / SDK / wasm become thin callers (mirroring how
 //! geometry already flows through `ifc-lite-wasm`).
 
+#[cfg(test)]
+#[macro_use]
+mod test_support;
+
 mod adjacency;
 mod collada;
 mod constructions;
@@ -223,18 +227,13 @@ mod tests {
 
     /// Skip-if-absent fixture loader (matches the geometry crate convention — test
     /// models are staged, not git-tracked, so a fresh checkout returns `None`).
-    fn fixture(rel: &str) -> Option<Vec<u8>> {
-        let path = format!("{}/../../tests/models/{}", env!("CARGO_MANIFEST_DIR"), rel);
-        std::fs::read(path).ok()
-    }
-
     #[test]
     fn entity_count_reexport_matches_index() {
         // The re-exported cheap tally must equal the full index's entity count
         // (both walk the same scanner) — so a downstream can gate on the count
         // without paying for the index. Well-formed fixtures have unique ids, so
         // the index map length equals the scanned entity count.
-        let Some(bytes) = fixture("ara3d/duplex.ifc") else {
+        let Some(bytes) = crate::test_support::fixture_opt("ara3d/duplex.ifc") else {
             eprintln!(
                 "skipping entity_count_reexport_matches_index: fixture absent — run `pnpm fixtures`"
             );
@@ -248,7 +247,7 @@ mod tests {
 
     #[test]
     fn duplex_exports_valid_room_model() {
-        let Some(bytes) = fixture("ara3d/duplex.ifc") else {
+        let Some(bytes) = crate::test_support::fixture_opt("ara3d/duplex.ifc") else {
             return;
         };
         let (json, stats) = export_hbjson_with_stats(&bytes, &HbjsonOptions::default());
@@ -317,7 +316,7 @@ mod tests {
     /// pins wall faces to the wall build-up and floor/roof faces to the slab build-up.
     #[test]
     fn duplex_faces_get_construction_by_face_type_not_swapped() {
-        let Some(bytes) = fixture("ara3d/duplex.ifc") else {
+        let Some(bytes) = crate::test_support::fixture_opt("ara3d/duplex.ifc") else {
             return;
         };
         let (json, stats) = export_hbjson_with_stats(&bytes, &HbjsonOptions::default());
@@ -352,7 +351,7 @@ mod tests {
     fn revit_georeferenced_model_does_not_collapse() {
         // rvt01 carries national-grid coordinates (~2.78e6); the origin-rebase must keep
         // room footprints sane (no f32 collapse).
-        let Some(bytes) = fixture("various/rvt01.ifc") else {
+        let Some(bytes) = crate::test_support::fixture_opt("various/rvt01.ifc") else {
             return;
         };
         let (json, stats) = export_hbjson_with_stats(&bytes, &HbjsonOptions::default());

--- a/rust/export/src/merged_tests.rs
+++ b/rust/export/src/merged_tests.rs
@@ -7,11 +7,6 @@
 
 use super::*;
 
-fn fixture(rel: &str) -> Vec<u8> {
-    let path = format!("{}/../../tests/models/{}", env!("CARGO_MANIFEST_DIR"), rel);
-    std::fs::read(&path).unwrap_or_else(|e| panic!("read {path}: {e}"))
-}
-
 fn scan_ids(step: &str) -> Vec<u32> {
     let bytes = step.as_bytes();
     let mut ids = Vec::new();
@@ -24,7 +19,7 @@ fn scan_ids(step: &str) -> Vec<u32> {
 
 #[test]
 fn merge_two_models_unifies_project_and_offsets_ids() {
-    let a = fixture("ara3d/duplex.ifc");
+    let a = fixture_or_skip!("ara3d/duplex.ifc");
     let single = scan_ids(&String::from_utf8_lossy(&a)).len();
 
     let (merged, stats) = export_merged_with_stats(&[&a, &a], &MergedOptions::default());
@@ -198,7 +193,7 @@ fn header_fields_round_trip_apostrophe_and_backslash_per_spec() {
         description: "ViewDefinition [CoordinationView]".to_string(),
         application: r"O'Brien\Docs\ifc-lite".to_string(),
     };
-    let a = fixture("ara3d/duplex.ifc");
+    let a = fixture_or_skip!("ara3d/duplex.ifc");
     let (step, _stats) = export_merged_with_stats(&[&a], &opts);
 
     // Pull the quoted application field out of

--- a/rust/export/src/model_tests.rs
+++ b/rust/export/src/model_tests.rs
@@ -8,26 +8,6 @@
 use super::*;
 use std::sync::Arc;
 
-fn fixture(rel: &str) -> Vec<u8> {
-    let path = format!("{}/../../tests/models/{}", env!("CARGO_MANIFEST_DIR"), rel);
-    std::fs::read(&path).unwrap_or_else(|e| panic!("read {path}: {e}"))
-}
-
-/// Skip-if-absent loader (test models are staged, not git-tracked). Only a
-/// genuinely-missing file is a skip; any other read error (permission, I/O)
-/// fails the test rather than passing as a false green.
-fn fixture_opt(rel: &str) -> Option<Vec<u8>> {
-    let path = format!("{}/../../tests/models/{}", env!("CARGO_MANIFEST_DIR"), rel);
-    match std::fs::read(&path) {
-        Ok(b) => Some(b),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            eprintln!("skipping {rel}: fixture absent — run `pnpm fixtures`");
-            None
-        }
-        Err(e) => panic!("read {path}: {e}"),
-    }
-}
-
 /// #1518: a buildingSMART annex-E showcase file declares its geometry ONLY on
 /// an `IfcBoilerType` (an IfcTypeProduct, not an IfcProduct). #957 Route B
 /// meshes it under the type's expressId; the attribute pass must now emit a
@@ -36,7 +16,7 @@ fn fixture_opt(rel: &str) -> Option<Vec<u8>> {
 fn type_only_geometry_emits_attribute_row() {
     let rel =
         "buildingsmart/annex_e/tessellated-shape-with-style/tessellation-with-blob-texture.ifc";
-    let Some(bytes) = fixture_opt(rel) else {
+    let Some(bytes) = crate::test_support::fixture_opt(rel) else {
         return;
     };
     let mut rows = Vec::new();
@@ -69,7 +49,7 @@ fn type_product_meshes_all_have_rows() {
         "buildingsmart/annex_e/tessellated-shape-with-style/tessellation-with-image-texture.ifc",
         "buildingsmart/annex_e/tessellated-shape-with-style/tessellation-with-pixel-texture.ifc",
     ] {
-        let Some(bytes) = fixture_opt(rel) else {
+        let Some(bytes) = crate::test_support::fixture_opt(rel) else {
             continue;
         };
         let result = ifc_lite_processing::process_geometry(&bytes);
@@ -99,7 +79,7 @@ fn type_product_meshes_all_have_rows() {
 
 #[test]
 fn duplex_model_has_products_and_psets() {
-    let model = build_export_model(&fixture("ara3d/duplex.ifc"));
+    let model = build_export_model(&fixture_or_skip!("ara3d/duplex.ifc"));
     assert!(model.entities.len() > 50, "expected many products, got {}", model.entities.len());
 
     // Every row carries a GlobalId + type.
@@ -127,12 +107,7 @@ fn stream_matches_build_row_for_row() {
     // two must agree byte-for-byte, in the same order, on the same input.
     // Guards against the streaming path ever drifting from the collected one.
     let rel = "ara3d/duplex.ifc";
-    let path = format!("{}/../../tests/models/{}", env!("CARGO_MANIFEST_DIR"), rel);
-    if !std::path::Path::new(&path).exists() {
-        eprintln!("skipping {rel}: fixture absent — run `pnpm fixtures`");
-        return;
-    }
-    let bytes = fixture(rel);
+    let bytes = fixture_or_skip!(rel);
     let collected = build_export_model(&bytes).entities;
     let mut streamed = Vec::new();
     stream_export_model(&bytes, |r| streamed.push(r));
@@ -145,12 +120,7 @@ fn stream_with_index_matches_plain() {
     // The injected-index path shares one index across passes; it must yield
     // identical rows to the self-indexing path. Guards the two from drifting.
     let rel = "ara3d/duplex.ifc";
-    let path = format!("{}/../../tests/models/{}", env!("CARGO_MANIFEST_DIR"), rel);
-    if !std::path::Path::new(&path).exists() {
-        eprintln!("skipping {rel}: fixture absent — run `pnpm fixtures`");
-        return;
-    }
-    let bytes = fixture(rel);
+    let bytes = fixture_or_skip!(rel);
     let mut plain = Vec::new();
     stream_export_model(&bytes, |r| plain.push(r));
     let idx = Arc::new(ifc_lite_core::build_entity_index(&bytes));
@@ -690,7 +660,7 @@ fn type_specific_attributes_are_rendered_by_schema_name() {
 fn orphan_type_rows_carry_attributes_as_well() {
     let rel =
         "buildingsmart/annex_e/tessellated-shape-with-style/tessellation-with-blob-texture.ifc";
-    let Some(bytes) = fixture_opt(rel) else {
+    let Some(bytes) = crate::test_support::fixture_opt(rel) else {
         return;
     };
     let opts = ModelOptions::default().with_attributes(true);

--- a/rust/export/src/obj.rs
+++ b/rust/export/src/obj.rs
@@ -137,15 +137,10 @@ pub fn export_obj_with_stats(content: &[u8], opts: &ObjOptions) -> (String, ObjS
 mod tests {
     use super::*;
 
-    fn fixture(rel: &str) -> Vec<u8> {
-        let path = format!("{}/../../tests/models/{}", env!("CARGO_MANIFEST_DIR"), rel);
-        std::fs::read(&path).unwrap_or_else(|e| panic!("read {path}: {e}"))
-    }
-
     #[test]
     fn duplex_exports_well_formed_obj() {
         let (obj, stats) =
-            export_obj_with_stats(&fixture("ara3d/duplex.ifc"), &ObjOptions::default());
+            export_obj_with_stats(&fixture_or_skip!("ara3d/duplex.ifc"), &ObjOptions::default());
         assert!(stats.meshes > 0, "expected meshes");
         assert!(stats.vertices > 0, "expected vertices");
         assert!(stats.triangles > 0, "expected triangles");
@@ -165,9 +160,9 @@ mod tests {
 
     #[test]
     fn isolation_filter_limits_output() {
-        let all = export_obj_with_stats(&fixture("ara3d/duplex.ifc"), &ObjOptions::default()).1;
+        let all = export_obj_with_stats(&fixture_or_skip!("ara3d/duplex.ifc"), &ObjOptions::default()).1;
         // Find one express id that was emitted by re-reading meshes through the pipeline.
-        let result = process_geometry(&fixture("ara3d/duplex.ifc")[..]);
+        let result = process_geometry(&fixture_or_skip!("ara3d/duplex.ifc")[..]);
         let some_id = result
             .meshes
             .iter()
@@ -176,7 +171,7 @@ mod tests {
             .expect("at least one visible mesh");
 
         let isolated = export_obj_with_stats(
-            &fixture("ara3d/duplex.ifc"),
+            &fixture_or_skip!("ara3d/duplex.ifc"),
             &ObjOptions { isolated: vec![some_id], ..ObjOptions::default() },
         )
         .1;
@@ -196,7 +191,7 @@ mod tests {
     /// mutation applied to both.
     #[test]
     fn obj_faces_reverse_the_source_mesh_winding() {
-        let bytes = fixture("ara3d/duplex.ifc");
+        let bytes = fixture_or_skip!("ara3d/duplex.ifc");
         let result = process_geometry(&bytes);
 
         // `mesh_visible` only requires a NON-EMPTY index buffer, so a visible

--- a/rust/export/src/parquet_bos.rs
+++ b/rust/export/src/parquet_bos.rs
@@ -294,14 +294,9 @@ mod tests {
     use super::*;
     use std::io::Read;
 
-    fn fixture(rel: &str) -> Vec<u8> {
-        let path = format!("{}/../../tests/models/{}", env!("CARGO_MANIFEST_DIR"), rel);
-        std::fs::read(&path).unwrap_or_else(|e| panic!("read {path}: {e}"))
-    }
-
     #[test]
     fn duplex_exports_valid_bos() {
-        let bos = export_bos(&fixture("ara3d/duplex.ifc"), &ParquetBosOptions::default())
+        let bos = export_bos(&fixture_or_skip!("ara3d/duplex.ifc"), &ParquetBosOptions::default())
             .expect("bos export");
         assert!(bos.len() > 1000, "non-trivial archive");
 

--- a/rust/export/src/step.rs
+++ b/rust/export/src/step.rs
@@ -303,11 +303,6 @@ pub fn export_step_with_stats(content: &[u8], opts: &StepOptions) -> (String, St
 mod tests {
     use super::*;
 
-    fn fixture(rel: &str) -> Vec<u8> {
-        let path = format!("{}/../../tests/models/{}", env!("CARGO_MANIFEST_DIR"), rel);
-        std::fs::read(&path).unwrap_or_else(|e| panic!("read {path}: {e}"))
-    }
-
     /// Count `#id=` entity lines in a STEP DATA section + grab the FILE_SCHEMA label.
     fn parse_back(step: &str) -> (usize, HashSet<u32>, String) {
         let bytes = step.as_bytes();
@@ -322,7 +317,7 @@ mod tests {
 
     #[test]
     fn full_roundtrip_preserves_all_entities() {
-        let src = fixture("ara3d/duplex.ifc");
+        let src = fixture_or_skip!("ara3d/duplex.ifc");
         let (step, stats) = export_step_with_stats(&src, &StepOptions::default());
 
         // Source entity count == written count == re-parsed count.
@@ -336,7 +331,7 @@ mod tests {
 
     #[test]
     fn subset_export_is_reference_closed() {
-        let src = fixture("ara3d/duplex.ifc");
+        let src = fixture_or_skip!("ara3d/duplex.ifc");
         // Pick a real wall id from the model.
         let mut scanner = EntityScanner::new(&src[..]);
         let mut wall_id = None;
@@ -369,7 +364,7 @@ mod tests {
 
     #[test]
     fn attribute_mutation_renames_entity() {
-        let src = fixture("ara3d/duplex.ifc");
+        let src = fixture_or_skip!("ara3d/duplex.ifc");
         // Find a wall to rename (attribute index 2 = Name on IfcRoot products).
         let mut scanner = EntityScanner::new(&src[..]);
         let mut wall_id = None;
@@ -409,7 +404,7 @@ mod tests {
 
     #[test]
     fn property_synthesis_attaches_new_pset() {
-        let src = fixture("ara3d/duplex.ifc");
+        let src = fixture_or_skip!("ara3d/duplex.ifc");
         let mut scanner = EntityScanner::new(&src[..]);
         let mut wall = None;
         while let Some((id, t, _s, _e)) = scanner.next_entity() {
@@ -455,7 +450,7 @@ mod tests {
 
     #[test]
     fn schema_conversion_to_ifc4_keeps_model_parseable() {
-        let src = fixture("ara3d/duplex.ifc");
+        let src = fixture_or_skip!("ara3d/duplex.ifc");
         let (step, stats) = export_step_with_stats(
             &src,
             &StepOptions { schema: Some("IFC4".to_string()), ..StepOptions::default() },

--- a/rust/export/src/step_text_tests.rs
+++ b/rust/export/src/step_text_tests.rs
@@ -176,11 +176,6 @@ fn property_synthesis_round_trips_apostrophe_and_backslash_per_spec() {
     use crate::step::{export_step_with_stats, PropMutation, StepOptions};
     use ifc_lite_core::EntityScanner;
 
-    fn fixture(rel: &str) -> Vec<u8> {
-        let path = format!("{}/../../tests/models/{}", env!("CARGO_MANIFEST_DIR"), rel);
-        std::fs::read(&path).unwrap_or_else(|e| panic!("read {path}: {e}"))
-    }
-
     // A STRICT ISO 10303-21 6.3.2.4/6.3.2.5 un-escaper: every literal `'`
     // and `\` in the string's plain-text value MUST appear doubled in the
     // literal. A run of backslashes with an ODD length is malformed under
@@ -225,7 +220,7 @@ fn property_synthesis_round_trips_apostrophe_and_backslash_per_spec() {
         out
     }
 
-    let src = fixture("ara3d/duplex.ifc");
+    let src = fixture_or_skip!("ara3d/duplex.ifc");
     let mut scanner = EntityScanner::new(&src[..]);
     let mut wall = None;
     while let Some((id, t, _s, _e)) = scanner.next_entity() {

--- a/rust/export/src/test_support.rs
+++ b/rust/export/src/test_support.rs
@@ -1,0 +1,49 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Shared fixture access for this crate's tests.
+//!
+//! Catalogued fixtures under `tests/models/` are not committed (see
+//! `tests/models/manifest.json`), so a test that needs one must SKIP when it is
+//! absent rather than throw or panic (AGENTS.md). Eleven modules here had each
+//! grown their own `fixture()` helper that did the opposite -- `unwrap_or_else(|e|
+//! panic!(...))` -- which turned a plain `cargo test --workspace` on a fresh
+//! checkout into 38 failures that look like real defects. Three of the eleven had
+//! separately grown a correct `fixture_opt` beside the panicking one, so both
+//! behaviours shipped side by side in the same file.
+//!
+//! This is the one place that decides. Use [`fixture_or_skip!`] from a test.
+
+/// Bytes of the catalogued fixture at `rel` (relative to `tests/models/`), or
+/// `None` when it has not been fetched.
+///
+/// Only an absent/unreadable fixture yields `None`. Anything the test then does
+/// with the bytes is still expected to succeed, so callers must not use `None`
+/// to paper over a genuine failure.
+pub(crate) fn fixture_opt(rel: &str) -> Option<Vec<u8>> {
+    let path = format!("{}/../../tests/models/{}", env!("CARGO_MANIFEST_DIR"), rel);
+    match std::fs::read(&path) {
+        Ok(bytes) => Some(bytes),
+        Err(e) => {
+            eprintln!(
+                "skipping: fixture {rel} not present ({e}) — run `pnpm fixtures` to download (sha256 in tests/models/manifest.json)"
+            );
+            None
+        }
+    }
+}
+
+/// Bind the fixture's bytes, or return from the enclosing test when it is absent.
+///
+/// The early return is the skip: Rust has no native skip, so this matches the
+/// house convention already used by `processors/tests.rs`. CI always runs
+/// `pnpm fixtures` first, so a skip there would be a CI-config bug, not silence.
+macro_rules! fixture_or_skip {
+    ($rel:expr) => {
+        match $crate::test_support::fixture_opt($rel) {
+            Some(bytes) => bytes,
+            None => return,
+        }
+    };
+}

--- a/rust/export/src/test_support.rs
+++ b/rust/export/src/test_support.rs
@@ -18,19 +18,22 @@
 /// Bytes of the catalogued fixture at `rel` (relative to `tests/models/`), or
 /// `None` when it has not been fetched.
 ///
-/// Only an absent/unreadable fixture yields `None`. Anything the test then does
-/// with the bytes is still expected to succeed, so callers must not use `None`
-/// to paper over a genuine failure.
+/// `None` means **`NotFound` specifically**, never "unreadable". A permission
+/// error, a directory where a file belongs, or any other I/O failure is a broken
+/// fixture setup, not an unfetched fixture, and it panics: treating those as
+/// absence would let a whole crate's tests skip while CI reported green, which
+/// is the exact failure mode this module exists to remove.
 pub(crate) fn fixture_opt(rel: &str) -> Option<Vec<u8>> {
     let path = format!("{}/../../tests/models/{}", env!("CARGO_MANIFEST_DIR"), rel);
     match std::fs::read(&path) {
         Ok(bytes) => Some(bytes),
-        Err(e) => {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             eprintln!(
-                "skipping: fixture {rel} not present ({e}) — run `pnpm fixtures` to download (sha256 in tests/models/manifest.json)"
+                "skipping: fixture {rel} not present — run `pnpm fixtures` to download (sha256 in tests/models/manifest.json)"
             );
             None
         }
+        Err(e) => panic!("fixture {rel} exists but could not be read: {e}"),
     }
 }
 

--- a/rust/export/src/usd/tests.rs
+++ b/rust/export/src/usd/tests.rs
@@ -398,11 +398,7 @@ fn type_product_geometry_lands_in_unassigned() {
     // keeping it from being dropped. Same fixture model.rs uses for the join.
     let rel =
         "buildingsmart/annex_e/tessellated-shape-with-style/tessellation-with-blob-texture.ifc";
-    let path = format!("{}/../../tests/models/{}", env!("CARGO_MANIFEST_DIR"), rel);
-    let Ok(bytes) = std::fs::read(&path) else {
-        eprintln!("skipping {rel}: fixture absent — run `pnpm fixtures`");
-        return;
-    };
+    let bytes = fixture_or_skip!(rel);
     let usda = export(&bytes);
     let ids = xform_ids(&scan(&usda));
 

--- a/rust/geometry/tests/wall_opening_cut_regression.rs
+++ b/rust/geometry/tests/wall_opening_cut_regression.rs
@@ -102,17 +102,30 @@ fn build_void_index(content: &str) -> FxHashMap<u32, Vec<u32>> {
     void_index
 }
 
-fn process(host_id: u32) -> Option<Mesh> {
-    if !std::path::Path::new(FIXTURE).exists() {
-        // Match the `read_fixture` convention in processors/tests.rs so a
-        // missing fixture surfaces a clear hint instead of silently passing
-        // the test. CI always has the full fixture set.
-        eprintln!(
-            "skipping: fixture {} not present — run `pnpm fixtures` to download (sha256 in tests/models/manifest.json)",
-            FIXTURE,
-        );
-        return None;
+/// `true` when the catalogued fixture is on disk.
+///
+/// An absent fixture must SKIP, never panic (AGENTS.md); CI always has the full
+/// set. This is deliberately separate from [`process`] so the two failure modes
+/// stay distinguishable: "no fixture" ends the test quietly, while "the fixture
+/// is here and the kernel could not process this host" is a real failure that
+/// must still panic. Folding both into one `Option` is what let three tests
+/// here read as skippable while actually panicking, and would equally let the
+/// other four silently pass on a genuine regression.
+fn fixture_present() -> bool {
+    if std::path::Path::new(FIXTURE).exists() {
+        return true;
     }
+    eprintln!(
+        "skipping: fixture {} not present — run `pnpm fixtures` to download (sha256 in tests/models/manifest.json)",
+        FIXTURE,
+    );
+    false
+}
+
+/// Process one host. Callers must have checked [`fixture_present`] first, so
+/// every `None` here is a genuine processing failure and is `expect`ed at the
+/// call site rather than skipped.
+fn process(host_id: u32) -> Option<Mesh> {
     let content = std::fs::read_to_string(FIXTURE).ok()?;
     let entity_index = build_entity_index(&content);
     let mut decoder = EntityDecoder::with_index(&content, entity_index);
@@ -128,11 +141,25 @@ fn process(host_id: u32) -> Option<Mesh> {
         .ok()
 }
 
+/// Skip the enclosing test when the fixture is absent, else process `$id` and
+/// bind the mesh. Keeps the guard and the `expect` adjacent so a new test in
+/// this file cannot reintroduce either half of the defect.
+macro_rules! mesh_or_skip {
+    ($id:expr) => {{
+        if !fixture_present() {
+            return;
+        }
+        process($id).unwrap_or_else(|| {
+            panic!("fixture present but host {} did not process", $id)
+        })
+    }};
+}
+
 // ──────────────────────────── working cases ────────────────────────────
 
 #[test]
 fn wall_552611_2_openings_matches_ios() {
-    let Some(mesh) = process(552611) else { return; };
+    let mesh = mesh_or_skip!(552611);
     let (mn, mx) = bbox(&mesh.positions).expect("non-empty");
     let ext = (mx.0 - mn.0, mx.1 - mn.1, mx.2 - mn.2);
     // IOS: v=32 t=60, min=(7.764,-0.620,0.094), ext=(0.200,8.404,10.506)
@@ -179,7 +206,7 @@ fn wall_552611_2_openings_matches_ios() {
 
 #[test]
 fn wall_552761_2_openings_matches_ios() {
-    let Some(mesh) = process(552761) else { return; };
+    let mesh = mesh_or_skip!(552761);
     let (_mn, mx) = bbox(&mesh.positions).expect("non-empty");
     // Oracle volume 16.396679 (uncut 17.117, openings 0.7206 removed).
     let vol = mesh_volume(&mesh);
@@ -197,7 +224,7 @@ fn wall_552761_2_openings_matches_ios() {
 
 #[test]
 fn wall_555082_1_opening_matches_ios() {
-    let Some(mesh) = process(555082) else { return; };
+    let mesh = mesh_or_skip!(555082);
     let (_, _) = bbox(&mesh.positions).expect("non-empty");
     // Oracle volume 11.065037 (uncut 11.424, opening 0.359 removed).
     let vol = mesh_volume(&mesh);
@@ -235,7 +262,7 @@ fn wall_555082_1_opening_matches_ios() {
 /// opening is subtracted with its authored extent.
 #[test]
 fn wall_553010_opening_does_not_empty_wall() {
-    let mesh = process(553010).expect("fixture available");
+    let mesh = mesh_or_skip!(553010);
     let (mn, mx) = bbox(&mesh.positions).expect(
         "opening cut wiped the entire wall — extend_opening_along_direction \
          is over-extending along the wrong axis again",
@@ -280,7 +307,7 @@ fn wall_553010_opening_does_not_empty_wall() {
 /// produces a real wall-with-3-holes mesh covering the full host extent.
 #[test]
 fn wall_612315_bbox_must_not_collapse() {
-    let mesh = process(612315).expect("fixture available");
+    let mesh = mesh_or_skip!(612315);
     let (mn, mx) = bbox(&mesh.positions).expect("non-empty");
     let ext = (mx.0 - mn.0, mx.1 - mn.1, mx.2 - mn.2);
     // IOS extent: (11.839, 0.115, 3.406). Pin all three axes — the prior
@@ -318,7 +345,7 @@ fn wall_612315_bbox_must_not_collapse() {
 /// vertex welding separately).
 #[test]
 fn wall_555268_7_openings_cuts_take_effect() {
-    let mesh = process(555268).expect("fixture available");
+    let mesh = mesh_or_skip!(555268);
     let (mn, mx) = bbox(&mesh.positions).expect("non-empty");
     let ext = (mx.0 - mn.0, mx.1 - mn.1, mx.2 - mn.2);
     let tol = 0.01_f32;
@@ -348,7 +375,7 @@ fn wall_555268_7_openings_cuts_take_effect() {
 /// is ~0.30 × 9.015 × 4.292 m; assert it survives at near-full extent.
 #[test]
 fn wall_555433_engulfing_opening_does_not_collapse_wall() {
-    let Some(mesh) = process(555433) else { return };
+    let mesh = mesh_or_skip!(555433);
     let (mn, mx) = bbox(&mesh.positions).expect(
         "engulfing-opening fallback deleted the wall — the near-engulf guard in \
          apply_void_context regressed",

--- a/rust/geometry/tests/wall_opening_cut_regression.rs
+++ b/rust/geometry/tests/wall_opening_cut_regression.rs
@@ -149,9 +149,12 @@ macro_rules! mesh_or_skip {
         if !fixture_present() {
             return;
         }
-        process($id).unwrap_or_else(|| {
-            panic!("fixture present but host {} did not process", $id)
-        })
+        // Bind once: `$id` must not be expanded twice (call + panic message),
+        // or an argument with side effects would run twice, and it must not be
+        // evaluated at all when the fixture is absent.
+        let host_id = $id;
+        process(host_id)
+            .unwrap_or_else(|| panic!("fixture present but host {host_id} did not process"))
     }};
 }
 

--- a/rust/geometry/tests/wall_opening_cut_regression.rs
+++ b/rust/geometry/tests/wall_opening_cut_regression.rs
@@ -111,15 +111,22 @@ fn build_void_index(content: &str) -> FxHashMap<u32, Vec<u32>> {
 /// must still panic. Folding both into one `Option` is what let three tests
 /// here read as skippable while actually panicking, and would equally let the
 /// other four silently pass on a genuine regression.
+/// `try_exists`, not `exists`: `Path::exists` collapses a permission error into
+/// `false`, which would skip the whole file while CI reported green. Only a
+/// definite "not there" is a skip; an undecidable answer is a broken setup and
+/// panics.
 fn fixture_present() -> bool {
-    if std::path::Path::new(FIXTURE).exists() {
-        return true;
+    match std::path::Path::new(FIXTURE).try_exists() {
+        Ok(true) => true,
+        Ok(false) => {
+            eprintln!(
+                "skipping: fixture {} not present — run `pnpm fixtures` to download (sha256 in tests/models/manifest.json)",
+                FIXTURE,
+            );
+            false
+        }
+        Err(e) => panic!("cannot determine whether fixture {FIXTURE} exists: {e}"),
     }
-    eprintln!(
-        "skipping: fixture {} not present — run `pnpm fixtures` to download (sha256 in tests/models/manifest.json)",
-        FIXTURE,
-    );
-    false
 }
 
 /// Process one host. Callers must have checked [`fixture_present`] first, so


### PR DESCRIPTION
`cargo test --workspace` on a fresh checkout reports **41 failures that look like real defects** but are only uncatalogued fixtures. AGENTS.md has required the opposite since fixtures stopped being committed:

> Tests must **skip** (never throw/panic) when a fixture is absent; point to `pnpm fixtures` in the skip message.

This makes that true. Test-only: no production path changes, so no changeset.

## Two root causes

**1. `ifc-lite-export`: eleven duplicated helpers, all panicking.** Eleven modules had each grown their own

```rust
fn fixture(rel: &str) -> Vec<u8> {
    let path = format!("{}/../../tests/models/{}", env!("CARGO_MANIFEST_DIR"), rel);
    std::fs::read(&path).unwrap_or_else(|e| panic!("read {path}: {e}"))
}
```

Three of the eleven had *also* grown a correct `fixture_opt` beside the panicking one, so both behaviours shipped in the same file. Replaced by one `test_support::fixture_opt` plus a `fixture_or_skip!` macro, now the only place that decides.

**2. `wall_opening_cut_regression`: the inverse defect.** `process()` already printed the skip hint and returned `None`, but three call sites did `.expect("fixture available")` — panicking on exactly the path the message promised to skip.

The other four call sites used `let Some(..) else { return }`. That skips correctly, but it **also swallows a genuine processing failure as a silent pass**: point one at a nonexistent host id with the fixture present and it goes green. So fixing only the panic would have left four tests that cannot fail.

The two concerns are now split. `fixture_present()` decides skip-or-run; a `None` from `process()` means the fixture was there and the kernel did not process the host, which always panics. All seven go through one `mesh_or_skip!`.

## Verification

Both directions, because a skip that cannot fail is its own defect:

| Check | Result |
|---|---|
| fresh checkout, no fixtures | `cargo test --workspace --no-fail-fast` **exit 0, 0 failures, 160 binaries** (was 41 failures) |
| fixtures present | 225 `ifc-lite-export` + 7 `wall_opening_cut_regression` pass, doing real work |
| **mutation** — nonexistent host id, fixture present | panics `fixture present but host 999999999 did not process`, where four of them previously passed silently |
| `cargo clippy --workspace --exclude ifc-lite-wasm --all-targets -- -D warnings` | exit 0, 0 warnings |
| `module_size_ratchet` | 4/4 (new `test_support.rs` is 49 lines) |

Net **-9 lines** (+171 / -180 across 15 files).

> Correction: this line first read "net -67 lines", which was wrong. It came from `git diff --numstat` taken while the new `test_support.rs` was still **untracked** — `git diff` silently omits untracked files, so the measurement counted the deletions without the new file. Caught in review.

## Notes

- The TS suite never had this defect: it already guards with `existsSync` + `describe.skipIf`. Vitest has a native skip and Rust does not, which is why this was Rust-only.
- `rust/ffi`'s `read committed fixture` panic is deliberately **left alone** — a missing *committed* fixture is a real error, not a skip.
- Reviewed with the CodeRabbit CLI. It raised two points: `$id` was expanded twice in `mesh_or_skip!` (fixed in the second commit), and a suggestion to route the skip message through `diag_warn!`, which is **not applied** — that is a crate-internal production macro used in zero test files, and under the `observability` feature it routes to `tracing::warn!`, which has no subscriber in an integration test, so the hint would vanish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved fixture handling so tests skip gracefully when required test files are unavailable.
  * Standardized fixture loading across export and geometry test suites.
  * Updated wall-opening regression tests to distinguish missing fixtures from genuine processing failures.
* **Refactor**
  * Centralized shared test-fixture utilities, reducing duplicated test setup and improving consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
