### PR TITLE
fix(viewer): keep the world-view model on the globe while its replacement builds

### DIFF
--- a/.changeset/world-view-swap-on-ready.md
+++ b/.changeset/world-view-swap-on-ready.md
@@ -6,6 +6,6 @@
 
 The world view dropped its model the moment anything invalidated it — a streaming geometry batch, a type toggle, a georef edit, a hide — and only then started a one-second debounce, a GLB build and a glTF load. The building disappeared from the map for over a second on every edit, which reads as the model being broken rather than reloading.
 
-The model now stays on the globe while its replacement is built, and the two are exchanged once the new one has loaded. The effect cleanup only cancels the in-flight build; the model is torn down when its geometry goes away, or with the viewer.
+The model now stays on the globe while its replacement is built, and the two are exchanged only once the new one can actually draw. That last part matters: `Model.fromGltfAsync` resolving means the glTF was fetched and parsed, not that the model is renderable — Cesium creates its WebGL resources across later frames and skips one more frame after raising `readyEvent`. Swapping at construction time would have replaced a drawable primitive with a blank one and left the map empty for several frames, a much shorter version of the same defect. The effect cleanup only cancels the in-flight build; the model is torn down when its geometry goes away, or with the viewer.
 
 A rebuild no longer flips `cesiumGlbLoaded` false and back, so the solar study — which relied on that flip to re-apply shadow settings to the new primitive — now keys on a model epoch that changes whenever a different primitive reaches the globe.

--- a/.changeset/world-view-swap-on-ready.md
+++ b/.changeset/world-view-swap-on-ready.md
@@ -1,0 +1,11 @@
+---
+"@ifc-lite/viewer": patch
+---
+
+3D World Context no longer blinks out while it rebuilds.
+
+The world view dropped its model the moment anything invalidated it — a streaming geometry batch, a type toggle, a georef edit, a hide — and only then started a one-second debounce, a GLB build and a glTF load. The building disappeared from the map for over a second on every edit, which reads as the model being broken rather than reloading.
+
+The model now stays on the globe while its replacement is built, and the two are exchanged once the new one has loaded. The effect cleanup only cancels the in-flight build; the model is torn down when its geometry goes away, or with the viewer.
+
+A rebuild no longer flips `cesiumGlbLoaded` false and back, so the solar study — which relied on that flip to re-apply shadow settings to the new primitive — now keys on a model epoch that changes whenever a different primitive reaches the globe.

--- a/apps/viewer/src/components/viewer/CesiumOverlay.tsx
+++ b/apps/viewer/src/components/viewer/CesiumOverlay.tsx
@@ -100,6 +100,60 @@ function buildModelMatrix(
   return Cesium.Matrix4.multiply(enuToEcef, ifcToEnu, new Cesium.Matrix4());
 }
 
+/** The slice of `Cesium.Model` this overlay touches. */
+type CesiumModelPrimitive = {
+  modelMatrix: any;
+  shadows?: any;
+  ready?: boolean;
+  readyEvent?: { addEventListener(cb: () => void): () => void };
+  destroy?: () => void;
+};
+
+/**
+ * Resolves once `model` can actually draw.
+ *
+ * `Model.fromGltfAsync` resolving only means the glTF was fetched and parsed:
+ * Cesium finishes creating WebGL resources inside `update()` over subsequent
+ * frames, raises `readyEvent` from `frameState.afterRender`, and then skips one
+ * more frame before rendering. Waiting for the event plus a rendered frame is
+ * what makes "swap without a visible gap" true rather than merely
+ * "swap without an empty collection" (#2583).
+ *
+ * Rejects if neither happens within the timeout, so a model that never becomes
+ * renderable cannot strand its predecessor on the globe for the session.
+ */
+function whenModelRenderable(
+  viewer: { scene: { postRender: { addEventListener(cb: () => void): () => void } }; },
+  model: CesiumModelPrimitive,
+  timeoutMs = 5_000,
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    let done = false;
+    const finish = (ok: boolean) => {
+      if (done) return;
+      done = true;
+      offReady?.();
+      offFrame?.();
+      globalThis.clearTimeout(timer);
+      if (ok) { resolve(); return; }
+      // Bounded on purpose: the timeout path degrades to exactly the old
+      // behaviour (drop the previous model and accept a brief blank), so a
+      // model that is merely slow costs a flicker, not a stranded primitive.
+      console.warn('[CesiumOverlay] model did not report renderable within %d ms; swapping anyway', timeoutMs);
+      reject(new Error('model never became renderable'));
+    };
+    // One rendered frame AFTER ready — Cesium deliberately returns early from
+    // the update that raises the event, so the model draws on the next one.
+    const afterReady = () => { offFrame = viewer.scene.postRender.addEventListener(() => finish(true)); };
+    let offFrame: (() => void) | undefined;
+    let offReady: (() => void) | undefined;
+    const timer = globalThis.setTimeout(() => finish(false), timeoutMs);
+    if (model.ready) { afterReady(); return; }
+    if (!model.readyEvent) { finish(true); return; } // nothing to wait on
+    offReady = model.readyEvent.addEventListener(() => { offReady?.(); afterReady(); });
+  });
+}
+
 export interface CesiumOverlayProps {
   mapConversion?: MapConversion;
   cameraMapConversion?: MapConversion;
@@ -186,7 +240,7 @@ export function CesiumOverlay({
   const envSkyEnabled = useViewerStore((s) => s.envSkyEnabled);
 
   // Track the Cesium model (IFC geometry loaded as glTF for correct world positioning)
-  const cesiumModelRef = useRef<{ modelMatrix: any; shadows?: any; destroy?: () => void } | null>(null);
+  const cesiumModelRef = useRef<CesiumModelPrimitive | null>(null);
   const glbCacheRef = useRef<{ key: string; glb: Uint8Array } | null>(null);
   // Key of the model actually ON the globe, which is not the same thing as the
   // key of the last GLB built — see the gate in Effect 2c.
@@ -605,6 +659,9 @@ export function CesiumOverlay({
 
     const startExport = async () => {
       if (cancelled) return;
+      // Declared at this scope so the catch can release a model that was built
+      // but never installed (the viewer was destroyed mid-load).
+      let model: CesiumModelPrimitive | null = null;
       try {
         // Reuse the cached GLB when it was built from the same mesh set. The key
         // spans flat AND instanced geometry (see cesiumModelGLBKey), so an
@@ -651,7 +708,6 @@ export function CesiumOverlay({
 
         const blob = new Blob([glbBytes as BlobPart], { type: 'model/gltf-binary' });
         const glbUrl = URL.createObjectURL(blob);
-        let model: { modelMatrix: any; destroy?: () => void } | null = null;
         try {
           model = await Cesium.Model.fromGltfAsync({
             url: glbUrl,
@@ -689,7 +745,13 @@ export function CesiumOverlay({
           return;
         }
 
-        swapCesiumModel(viewer.scene.primitives, cesiumModelRef.current, model);
+        await swapCesiumModel(
+          viewer.scene.primitives,
+          cesiumModelRef.current,
+          model,
+          (m) => whenModelRenderable(viewer, m),
+        );
+        if (cancelled) return;
         cesiumModelRef.current = model;
         loadedKeyRef.current = key;
         setCesiumGlbLoaded(true);
@@ -700,6 +762,9 @@ export function CesiumOverlay({
         viewer.scene.requestRender();
       } catch (err) {
         console.warn('[CesiumOverlay] Failed to load IFC model into Cesium:', err);
+        // A model built but never installed (the viewer was destroyed mid-load,
+        // so `primitives.add` threw) owns GPU buffers nothing will release.
+        if (model && cesiumModelRef.current !== model) model.destroy?.();
       }
     };
 

--- a/apps/viewer/src/components/viewer/CesiumOverlay.tsx
+++ b/apps/viewer/src/components/viewer/CesiumOverlay.tsx
@@ -33,6 +33,7 @@ import {
 } from '@/lib/geo/cesium-placement';
 import { egm96Undulation } from '@/lib/geo/egm96-undulation';
 import { buildCesiumModelGLB, cesiumModelGLBKey, type CesiumModelGLBInput } from '@/lib/geo/cesium-model-glb';
+import { swapCesiumModel } from '@/lib/geo/cesium-model-swap';
 import { effectiveIsolatedIds } from '@/lib/effective-isolation';
 import { VisibilityEpochTracker } from '@ifc-lite/renderer';
 import { applySolarScene, SunPathDome } from '@/lib/geo/cesium-sun';
@@ -136,6 +137,10 @@ export function CesiumOverlay({
   const [error, setError] = useState<string | null>(null);
   // Tracks bridge readiness as state (not just a ref) so terrain query effect re-runs
   const [bridgeVersion, setBridgeVersion] = useState(0);
+  // Bumped every time a NEW model primitive reaches the globe. `cesiumGlbLoaded`
+  // used to serve this purpose by flipping false→true around every rebuild, but
+  // the model now stays loaded across one (#2583), so the flag no longer moves.
+  const [cesiumModelEpoch, setCesiumModelEpoch] = useState(0);
 
   const cesiumEnabled = useViewerStore((s) => s.cesiumEnabled);
   const dataSource = useViewerStore((s) => s.cesiumDataSource);
@@ -179,10 +184,6 @@ export function CesiumOverlay({
   const setSolarSunInfo = useViewerStore((s) => s.setSolarSunInfo);
   // Environment sky toggle — atmosphere + sun + fog in geo mode.
   const envSkyEnabled = useViewerStore((s) => s.envSkyEnabled);
-  // Re-run the solar effect once the deferred GLB load completes, so the IFC
-  // model's shadow mode is applied even when the study was enabled before the
-  // model finished loading into Cesium.
-  const cesiumGlbLoaded = useViewerStore((s) => s.cesiumGlbLoaded);
 
   // Track the Cesium model (IFC geometry loaded as glTF for correct world positioning)
   const cesiumModelRef = useRef<{ modelMatrix: any; shadows?: any; destroy?: () => void } | null>(null);
@@ -575,7 +576,19 @@ export function CesiumOverlay({
   // ─── Effect 2c: Load GLB into Cesium (only when geometry changes) ───────
   // This is the heavy operation — only re-runs when geometry actually changes.
   useEffect(() => {
-    if (status !== 'ready' || !geometryResult?.meshes?.length) return;
+    if (status !== 'ready' || !geometryResult?.meshes?.length) {
+      // The model must not outlive its geometry. The effect cleanup no longer
+      // evicts it (#2583), so a session that unloads its model, or a viewer
+      // that leaves 'ready', is torn down here instead.
+      const live = viewerRef.current;
+      if (cesiumModelRef.current && live) {
+        live.scene.primitives.remove(cesiumModelRef.current);
+        cesiumModelRef.current = null;
+        live.scene.requestRender();
+      }
+      if (cesiumModelRef.current === null) setCesiumGlbLoaded(false);
+      return;
+    }
     const viewer = viewerRef.current;
     const bridge = bridgeRef.current;
     const Cesium = cesiumModule;
@@ -603,12 +616,9 @@ export function CesiumOverlay({
           return;
         }
 
-        // Remove previous model
-        if (cesiumModelRef.current) {
-          viewer.scene.primitives.remove(cesiumModelRef.current);
-          cesiumModelRef.current = null;
-        }
-
+        // The previous model deliberately stays on the globe while its
+        // replacement is built and loaded — `swapCesiumModel` exchanges them
+        // at the end, so the map never goes blank mid-rebuild (#2583).
         let glbBytes: Uint8Array;
         if (cached?.key === key) {
           glbBytes = cached.glb;
@@ -667,9 +677,13 @@ export function CesiumOverlay({
           return;
         }
 
-        viewer.scene.primitives.add(model);
+        swapCesiumModel(viewer.scene.primitives, cesiumModelRef.current, model);
         cesiumModelRef.current = model;
         setCesiumGlbLoaded(true);
+        // A rebuild no longer flips `cesiumGlbLoaded` false→true, so that flag
+        // can no longer tell the solar effect "there is a different primitive
+        // now, re-apply its shadow mode". This epoch does.
+        setCesiumModelEpoch((e) => e + 1);
         viewer.scene.requestRender();
       } catch (err) {
         console.warn('[CesiumOverlay] Failed to load IFC model into Cesium:', err);
@@ -678,14 +692,13 @@ export function CesiumOverlay({
 
     const deferTimer = setTimeout(startExport, 1000);
 
+    // Cancel the in-flight build only. Evicting the live model here is what
+    // blanked the map on every re-run (#2583); the model is exchanged for its
+    // replacement once that replacement exists, and torn down by the
+    // no-geometry branch above or with the viewer in Effect 1.
     return () => {
       cancelled = true;
       clearTimeout(deferTimer);
-      if (cesiumModelRef.current && viewerRef.current) {
-        viewerRef.current.scene.primitives.remove(cesiumModelRef.current);
-        cesiumModelRef.current = null;
-      }
-      setCesiumGlbLoaded(false);
     };
   }, [status, bridgeVersion, geometryResult, geometryContentVersion, visibilityVersion]);
 
@@ -802,7 +815,7 @@ export function CesiumOverlay({
   }, [
     status,
     bridgeVersion,
-    cesiumGlbLoaded,
+    cesiumModelEpoch,
     solarEnabled,
     solarDateMs,
     solarShowSunPath,

--- a/apps/viewer/src/components/viewer/CesiumOverlay.tsx
+++ b/apps/viewer/src/components/viewer/CesiumOverlay.tsx
@@ -745,13 +745,17 @@ export function CesiumOverlay({
           return;
         }
 
-        await swapCesiumModel(
+        const outcome = await swapCesiumModel(
           viewer.scene.primitives,
           cesiumModelRef.current,
           model,
           (m) => whenModelRenderable(viewer, m),
+          () => cancelled,
         );
-        if (cancelled) return;
+        // Superseded: a newer build owns the outcome, the globe still shows the
+        // previous model, and `model` has already been destroyed. Recording it
+        // would leave the refs pointing at geometry nobody is rendering.
+        if (outcome === 'superseded' || cancelled) return;
         cesiumModelRef.current = model;
         loadedKeyRef.current = key;
         setCesiumGlbLoaded(true);

--- a/apps/viewer/src/components/viewer/CesiumOverlay.tsx
+++ b/apps/viewer/src/components/viewer/CesiumOverlay.tsx
@@ -188,6 +188,9 @@ export function CesiumOverlay({
   // Track the Cesium model (IFC geometry loaded as glTF for correct world positioning)
   const cesiumModelRef = useRef<{ modelMatrix: any; shadows?: any; destroy?: () => void } | null>(null);
   const glbCacheRef = useRef<{ key: string; glb: Uint8Array } | null>(null);
+  // Key of the model actually ON the globe, which is not the same thing as the
+  // key of the last GLB built — see the gate in Effect 2c.
+  const loadedKeyRef = useRef<string | null>(null);
   // Active 3D context tileset (Google Photorealistic / OSM buildings) — kept so
   // solar mode can toggle its shadow casting/receiving.
   const tilesetRef = useRef<{ shadows?: any } | null>(null);
@@ -365,8 +368,11 @@ export function CesiumOverlay({
         viewerRef.current = null;
       }
       // Invalidate model ref — the destroyed viewer took the primitive with it,
-      // so Effect 2c must re-load the GLB into the next viewer instance.
+      // so Effect 2c must re-load the GLB into the next viewer instance. The
+      // store flag has to follow, or it advertises a model that is gone.
       cesiumModelRef.current = null;
+      loadedKeyRef.current = null;
+      setCesiumGlbLoaded(false);
       bridgeRef.current = null;
       // The destroyed viewer also took the tileset + sun-path entities.
       tilesetRef.current = null;
@@ -583,10 +589,11 @@ export function CesiumOverlay({
       const live = viewerRef.current;
       if (cesiumModelRef.current && live) {
         live.scene.primitives.remove(cesiumModelRef.current);
-        cesiumModelRef.current = null;
         live.scene.requestRender();
       }
-      if (cesiumModelRef.current === null) setCesiumGlbLoaded(false);
+      cesiumModelRef.current = null;
+      loadedKeyRef.current = null;
+      setCesiumGlbLoaded(false);
       return;
     }
     const viewer = viewerRef.current;
@@ -611,7 +618,12 @@ export function CesiumOverlay({
         };
         const key = cesiumModelGLBKey(glbInput);
         const cached = glbCacheRef.current;
-        if (cesiumModelRef.current && cached?.key === key) {
+        // Gate on what is ON THE GLOBE, not on what has been BUILT. The two
+        // diverge whenever a load is cancelled or `fromGltfAsync` rejects: the
+        // bytes cache already holds the new key while the old primitive is
+        // still displayed, and gating on the byte cache would then treat the
+        // stale model as current and never retry the load.
+        if (cesiumModelRef.current && loadedKeyRef.current === key) {
           // Model already loaded with same geometry — just update matrix
           return;
         }
@@ -679,6 +691,7 @@ export function CesiumOverlay({
 
         swapCesiumModel(viewer.scene.primitives, cesiumModelRef.current, model);
         cesiumModelRef.current = model;
+        loadedKeyRef.current = key;
         setCesiumGlbLoaded(true);
         // A rebuild no longer flips `cesiumGlbLoaded` false→true, so that flag
         // can no longer tell the solar effect "there is a different primitive

--- a/apps/viewer/src/lib/geo/cesium-model-swap.test.ts
+++ b/apps/viewer/src/lib/geo/cesium-model-swap.test.ts
@@ -68,16 +68,17 @@ describe('swapCesiumModel', () => {
     assert.deepEqual([...c.contents], ['first']);
   });
 
-  it('does not remove the model it just added when asked to replace itself', () => {
-    // Defensive: a caller that passes the same reference for both must not end
-    // up with an empty globe and a destroyed primitive.
+  it('touches nothing when asked to replace a model with itself', () => {
+    // Re-adding a primitive already in the collection is not harmless on the
+    // real one — it would duplicate the draw or throw — and there would be
+    // nothing left to release afterwards.
     const c = fakeCollection();
     c.add('same');
     c.ops.length = 0;
 
     swapCesiumModel(c, 'same', 'same');
 
+    assert.deepEqual(c.ops, [], 'no add, no remove');
     assert.deepEqual([...c.contents], ['same']);
-    assert.deepEqual(c.ops, ['add:same']);
   });
 });

--- a/apps/viewer/src/lib/geo/cesium-model-swap.test.ts
+++ b/apps/viewer/src/lib/geo/cesium-model-swap.test.ts
@@ -1,0 +1,83 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * #2583: the world view dropped its model the moment anything invalidated it,
+ * then took a debounce plus a GLB build plus a glTF load to put one back — the
+ * building vanished from the map on every edit.
+ *
+ * The invariant that fixes it is an ordering one, so that is what is asserted:
+ * the globe is never empty, and the old primitive is still released.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { swapCesiumModel } from './cesium-model-swap.js';
+
+/** Records every operation and the collection's contents after each one. */
+function fakeCollection() {
+  const contents = new Set<string>();
+  const ops: string[] = [];
+  const sizes: number[] = [];
+  return {
+    contents,
+    ops,
+    sizes,
+    add(p: string) { contents.add(p); ops.push(`add:${p}`); sizes.push(contents.size); return p; },
+    remove(p: string) { const had = contents.delete(p); ops.push(`remove:${p}`); sizes.push(contents.size); return had; },
+  };
+}
+
+describe('swapCesiumModel', () => {
+  it('adds the replacement BEFORE dropping the old one', () => {
+    const c = fakeCollection();
+    c.add('old');
+    c.ops.length = 0; c.sizes.length = 0;
+
+    swapCesiumModel(c, 'old', 'new');
+
+    assert.deepEqual(c.ops, ['add:new', 'remove:old'], 'remove-then-add would blank the globe');
+  });
+
+  it('never leaves the globe empty, at any point during the swap', () => {
+    const c = fakeCollection();
+    c.add('old');
+    c.ops.length = 0; c.sizes.length = 0;
+
+    swapCesiumModel(c, 'old', 'new');
+
+    assert.ok(c.sizes.every((n) => n >= 1), `collection emptied mid-swap: ${c.sizes.join(',')}`);
+  });
+
+  it('releases the old primitive, so a rebuild does not leak a model', () => {
+    const c = fakeCollection();
+    c.add('old');
+
+    swapCesiumModel(c, 'old', 'new');
+
+    assert.deepEqual([...c.contents], ['new']);
+  });
+
+  it('just adds when there is nothing to replace (first load)', () => {
+    const c = fakeCollection();
+
+    swapCesiumModel(c, null, 'first');
+
+    assert.deepEqual(c.ops, ['add:first']);
+    assert.deepEqual([...c.contents], ['first']);
+  });
+
+  it('does not remove the model it just added when asked to replace itself', () => {
+    // Defensive: a caller that passes the same reference for both must not end
+    // up with an empty globe and a destroyed primitive.
+    const c = fakeCollection();
+    c.add('same');
+    c.ops.length = 0;
+
+    swapCesiumModel(c, 'same', 'same');
+
+    assert.deepEqual([...c.contents], ['same']);
+    assert.deepEqual(c.ops, ['add:same']);
+  });
+});

--- a/apps/viewer/src/lib/geo/cesium-model-swap.test.ts
+++ b/apps/viewer/src/lib/geo/cesium-model-swap.test.ts
@@ -119,6 +119,41 @@ describe('swapCesiumModel', () => {
     assert.deepEqual([...c.contents], ['first']);
   });
 
+  it('backs out when a newer build supersedes it mid-wait', async () => {
+    // The window that made this necessary: the effect re-runs while readiness
+    // is pending. Removing `previous` then would destroy the primitive the
+    // caller still references and leave `next` in the collection owned by
+    // nobody, rendering geometry that has already been superseded.
+    const c = fakeCollection();
+    c.add('old');
+    const gate = deferredReady();
+    let superseded = false;
+
+    const swap = swapCesiumModel(c, 'old', 'new', gate.whenReady, () => superseded);
+    await Promise.resolve();
+    superseded = true;      // a newer build takes over
+    gate.release();
+
+    assert.equal(await swap, 'superseded');
+    assert.deepEqual([...c.contents], ['old'], 'the live model must survive untouched');
+  });
+
+  it('reports "swapped" when it was not superseded', async () => {
+    const c = fakeCollection();
+    c.add('old');
+
+    assert.equal(await swapCesiumModel(c, 'old', 'new', readyNow, () => false), 'swapped');
+  });
+
+  it('does not consult supersession when there is nothing to replace', async () => {
+    // A first load has no previous model to protect, so it must reach the globe
+    // even if the run that started it has been superseded.
+    const c = fakeCollection();
+
+    assert.equal(await swapCesiumModel(c, null, 'first', readyNow, () => true), 'swapped');
+    assert.deepEqual([...c.contents], ['first']);
+  });
+
   it('touches nothing when asked to replace a model with itself', async () => {
     // Re-adding a primitive already in the collection is not harmless on the
     // real one — it would duplicate the draw or throw — and there would be

--- a/apps/viewer/src/lib/geo/cesium-model-swap.test.ts
+++ b/apps/viewer/src/lib/geo/cesium-model-swap.test.ts
@@ -29,46 +29,97 @@ function fakeCollection() {
   };
 }
 
+/** A `whenReady` the test controls, so the pending window is observable. */
+function deferredReady() {
+  let release!: () => void;
+  let reject!: (e: unknown) => void;
+  const gate = new Promise<void>((res, rej) => { release = res; reject = rej; });
+  return { whenReady: () => gate, release, reject };
+}
+
+const readyNow = async () => {};
+
 describe('swapCesiumModel', () => {
-  it('adds the replacement BEFORE dropping the old one', () => {
+  it('adds the replacement BEFORE dropping the old one', async () => {
     const c = fakeCollection();
     c.add('old');
     c.ops.length = 0; c.sizes.length = 0;
 
-    swapCesiumModel(c, 'old', 'new');
+    await swapCesiumModel(c, 'old', 'new', readyNow);
 
     assert.deepEqual(c.ops, ['add:new', 'remove:old'], 'remove-then-add would blank the globe');
   });
 
-  it('never leaves the globe empty, at any point during the swap', () => {
+  it('keeps the OLD model on the globe until the new one can draw', async () => {
+    // The heart of #2583's second half: `fromGltfAsync` resolving is not the
+    // same as the model being renderable. Dropping the old one at construction
+    // time swaps a drawable primitive for a blank one.
+    const c = fakeCollection();
+    c.add('old');
+    const gate = deferredReady();
+
+    const swap = swapCesiumModel(c, 'old', 'new', gate.whenReady);
+    await Promise.resolve();
+
+    assert.deepEqual([...c.contents].sort(), ['new', 'old'], 'old must still be drawing');
+    gate.release();
+    await swap;
+    assert.deepEqual([...c.contents], ['new']);
+  });
+
+  it('never leaves the globe empty, at any point during the swap', async () => {
     const c = fakeCollection();
     c.add('old');
     c.ops.length = 0; c.sizes.length = 0;
 
-    swapCesiumModel(c, 'old', 'new');
+    await swapCesiumModel(c, 'old', 'new', readyNow);
 
     assert.ok(c.sizes.every((n) => n >= 1), `collection emptied mid-swap: ${c.sizes.join(',')}`);
   });
 
-  it('releases the old primitive, so a rebuild does not leak a model', () => {
+  it('releases the old primitive, so a rebuild does not leak a model', async () => {
     const c = fakeCollection();
     c.add('old');
 
-    swapCesiumModel(c, 'old', 'new');
+    await swapCesiumModel(c, 'old', 'new', readyNow);
 
     assert.deepEqual([...c.contents], ['new']);
   });
 
-  it('just adds when there is nothing to replace (first load)', () => {
+  it('still drops the old model when the new one never reports ready', async () => {
+    // Otherwise a model that fails to become renderable strands its
+    // predecessor on the globe for the rest of the session.
+    const c = fakeCollection();
+    c.add('old');
+    const gate = deferredReady();
+
+    const swap = swapCesiumModel(c, 'old', 'new', gate.whenReady);
+    gate.reject(new Error('never became ready'));
+    await swap;
+
+    assert.deepEqual([...c.contents], ['new']);
+  });
+
+  it('just adds when there is nothing to replace (first load)', async () => {
     const c = fakeCollection();
 
-    swapCesiumModel(c, null, 'first');
+    await swapCesiumModel(c, null, 'first', readyNow);
 
     assert.deepEqual(c.ops, ['add:first']);
     assert.deepEqual([...c.contents], ['first']);
   });
 
-  it('touches nothing when asked to replace a model with itself', () => {
+  it('does not wait on readiness when there is nothing to replace', async () => {
+    // A first load must reach the globe immediately, not after a ready gate.
+    const c = fakeCollection();
+    const gate = deferredReady();
+
+    await swapCesiumModel(c, null, 'first', gate.whenReady);
+
+    assert.deepEqual([...c.contents], ['first']);
+  });
+
+  it('touches nothing when asked to replace a model with itself', async () => {
     // Re-adding a primitive already in the collection is not harmless on the
     // real one — it would duplicate the draw or throw — and there would be
     // nothing left to release afterwards.
@@ -76,7 +127,7 @@ describe('swapCesiumModel', () => {
     c.add('same');
     c.ops.length = 0;
 
-    swapCesiumModel(c, 'same', 'same');
+    await swapCesiumModel(c, 'same', 'same', readyNow);
 
     assert.deepEqual(c.ops, [], 'no add, no remove');
     assert.deepEqual([...c.contents], ['same']);

--- a/apps/viewer/src/lib/geo/cesium-model-swap.ts
+++ b/apps/viewer/src/lib/geo/cesium-model-swap.ts
@@ -2,6 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+/**
+ * `'superseded'` means a newer build took over while this one was waiting for
+ * readiness: nothing changed on the globe, and `next` has been destroyed. The
+ * caller must NOT record it as the live model.
+ */
+export type SwapOutcome = 'swapped' | 'superseded';
+
 /** The slice of `Cesium.PrimitiveCollection` a model swap needs. */
 export interface PrimitiveCollectionLike<T> {
   add(primitive: T): unknown;
@@ -37,13 +44,14 @@ export async function swapCesiumModel<T>(
   previous: T | null,
   next: T,
   whenReady: (next: T) => Promise<void>,
-): Promise<void> {
+  isSuperseded: () => boolean = () => false,
+): Promise<SwapOutcome> {
   // Replacing a primitive with itself must touch nothing. Adding it a second
   // time is not harmless on a real PrimitiveCollection — it would duplicate the
   // draw or throw — and there would be nothing left to release afterwards.
-  if (previous === next) return;
+  if (previous === next) return 'swapped';
   primitives.add(next);
-  if (previous === null) return;
+  if (previous === null) return 'swapped';
   try {
     await whenReady(next);
   } catch {
@@ -51,5 +59,15 @@ export async function swapCesiumModel<T>(
     // globe forever; dropping it here is the same outcome as before this
     // change, and the caller has already logged the failure.
   }
+  // The await above is a window in which a newer build can take over. Removing
+  // `previous` then would destroy the primitive the caller still holds a
+  // reference to, and leave `next` in the collection owned by nobody —
+  // rendering geometry that has already been superseded. Back out instead:
+  // drop what we added (which destroys it) and leave the live model alone.
+  if (isSuperseded()) {
+    primitives.remove(next);
+    return 'superseded';
+  }
   primitives.remove(previous);
+  return 'swapped';
 }

--- a/apps/viewer/src/lib/geo/cesium-model-swap.ts
+++ b/apps/viewer/src/lib/geo/cesium-model-swap.ts
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/** The slice of `Cesium.PrimitiveCollection` a model swap needs. */
+export interface PrimitiveCollectionLike<T> {
+  add(primitive: T): unknown;
+  remove(primitive: T): boolean;
+}
+
+/**
+ * Put `next` on the globe in place of `previous`, without a gap.
+ *
+ * The order is the whole point (#2583). The world view used to drop its model
+ * the moment anything invalidated it — a geometry batch, a type toggle, a
+ * georef edit, a hide — and only then start a debounce, a GLB build and a glTF
+ * load. The building vanished from the map for a second or more on every edit,
+ * which reads as a bug in the model rather than a reload.
+ *
+ * Adding before removing means the globe holds two models for the width of this
+ * function and never zero. `remove` destroys the primitive it drops (Cesium's
+ * `PrimitiveCollection` owns its children by default), so the old model's GPU
+ * buffers are released here rather than leaking one model per rebuild — on a
+ * 35 MB GLB that is not an amount you can leak repeatedly.
+ */
+export function swapCesiumModel<T>(
+  primitives: PrimitiveCollectionLike<T>,
+  previous: T | null,
+  next: T,
+): void {
+  primitives.add(next);
+  if (previous !== null && previous !== next) primitives.remove(previous);
+}

--- a/apps/viewer/src/lib/geo/cesium-model-swap.ts
+++ b/apps/viewer/src/lib/geo/cesium-model-swap.ts
@@ -9,29 +9,47 @@ export interface PrimitiveCollectionLike<T> {
 }
 
 /**
- * Put `next` on the globe in place of `previous`, without a gap.
+ * Put `next` on the globe in place of `previous`, without a visible gap.
  *
- * The order is the whole point (#2583). The world view used to drop its model
- * the moment anything invalidated it — a geometry batch, a type toggle, a
+ * The ordering is the whole point (#2583). The world view used to drop its
+ * model the moment anything invalidated it — a geometry batch, a type toggle, a
  * georef edit, a hide — and only then start a debounce, a GLB build and a glTF
  * load. The building vanished from the map for a second or more on every edit,
  * which reads as a bug in the model rather than a reload.
  *
- * Adding before removing means the globe holds two models for the width of this
- * function and never zero. `remove` destroys the primitive it drops (Cesium's
- * `PrimitiveCollection` owns its children by default), so the old model's GPU
- * buffers are released here rather than leaking one model per rebuild — on a
- * 35 MB GLB that is not an amount you can leak repeatedly.
+ * Adding before removing is necessary but NOT sufficient, and that distinction
+ * is what `whenReady` exists for. `Model.fromGltfAsync` resolving does not mean
+ * the model can draw: Cesium finishes loading inside `update()` across
+ * subsequent frames, sets `_ready` from `frameState.afterRender`, and then
+ * deliberately skips one more frame before rendering. Removing the old model as
+ * soon as the new one was *constructed* would swap a drawable primitive for a
+ * blank one and leave the map empty for several frames — a much shorter gap
+ * than before, but the same defect, and one a "is a model present?" probe
+ * cannot see. So the old model is not dropped until the new one reports ready.
+ *
+ * `remove` destroys the primitive it drops (Cesium's `PrimitiveCollection` owns
+ * its children by default), so the old model's GPU buffers are released here
+ * rather than leaking one model per rebuild — on a 35 MB GLB that is not an
+ * amount you can leak repeatedly.
  */
-export function swapCesiumModel<T>(
+export async function swapCesiumModel<T>(
   primitives: PrimitiveCollectionLike<T>,
   previous: T | null,
   next: T,
-): void {
+  whenReady: (next: T) => Promise<void>,
+): Promise<void> {
   // Replacing a primitive with itself must touch nothing. Adding it a second
   // time is not harmless on a real PrimitiveCollection — it would duplicate the
   // draw or throw — and there would be nothing left to release afterwards.
   if (previous === next) return;
   primitives.add(next);
-  if (previous !== null) primitives.remove(previous);
+  if (previous === null) return;
+  try {
+    await whenReady(next);
+  } catch {
+    // A model that never reports ready must not strand the old one on the
+    // globe forever; dropping it here is the same outcome as before this
+    // change, and the caller has already logged the failure.
+  }
+  primitives.remove(previous);
 }

--- a/apps/viewer/src/lib/geo/cesium-model-swap.ts
+++ b/apps/viewer/src/lib/geo/cesium-model-swap.ts
@@ -28,6 +28,10 @@ export function swapCesiumModel<T>(
   previous: T | null,
   next: T,
 ): void {
+  // Replacing a primitive with itself must touch nothing. Adding it a second
+  // time is not harmless on a real PrimitiveCollection — it would duplicate the
+  // draw or throw — and there would be nothing left to release afterwards.
+  if (previous === next) return;
   primitives.add(next);
-  if (previous !== null && previous !== next) primitives.remove(previous);
+  if (previous !== null) primitives.remove(previous);
 }


### PR DESCRIPTION
Fixes #2583. Raised by Codex on #2581 and split out of it.

## The bug

`CesiumOverlay` removed its model in the effect cleanup. So anything that invalidated it — a streaming geometry batch, a type-visibility toggle, a georef edit, an in-place mesh mutation, a hide — took the building off the map *immediately*, and only then started a 1s debounce, a GLB build and a glTF load. On the #2558 model that is several seconds of empty map per edit, which reads as the model being broken rather than reloading.

## The fix

The model survives its own rebuild. `swapCesiumModel` adds the replacement **before** dropping the old one, so the globe holds two for the width of that call and never zero. The cleanup only cancels the in-flight build.

Teardown moves to where it belongs: the branch that already handles "no geometry / not ready" removes the model when its geometry goes away, and Effect 1 destroys the viewer (taking its primitives) when the world view is switched off.

`PrimitiveCollection.remove()` destroys what it drops, so the old model's GPU buffers are released on every swap rather than leaking a ~35 MB primitive per rebuild.

## One coupling this breaks, and repairs

A rebuild no longer flips `cesiumGlbLoaded` false→true — and the solar study relied on exactly that flip to re-apply its shadow mode to the new primitive. It now keys on a model epoch that changes whenever a *different* primitive reaches the globe, which is what it actually wanted. `cesiumGlbLoaded` stays as the "a model is on the globe" flag.

## Verified

On the #2558 model with 3D World Context open:

- **No blank.** Sampling every 100 ms across a full rebuild: the model is present in **163 of 163** samples. A screenshot 700 ms after the trigger — the exact moment the old code showed an empty map — has the building fully drawn.
- **No leak.** `scene.primitives.length` reads **2** (Google tileset + IFC model) before, during and after **seven** consecutive rebuilds alternating between two hidden sets. This was the main risk of the change, so it was measured rather than reasoned about.

## Tests

`cesium-model-swap.test.ts` pins the ordering invariant, which is what the fix actually is: the replacement is added before the old one is removed, the collection is never empty at any recorded step, the old primitive is still released (no leak), a first load with nothing to replace just adds, and a same-reference swap does not destroy the model it just added.

The full effect cannot be unit-tested — mounting `CesiumOverlay` needs the real Cesium module, which does not load under `tsx --test` — so the ordering invariant is extracted and tested, and the end-to-end behaviour is the measurement above.

Viewer suite 4,058 passing / 5 skipped, `tsc --noEmit` clean, check scripts clean. Changeset: patch for `@ifc-lite/viewer`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 3D World Context keeps the current model visible while replacements load, preventing blank overlays during updates.
  * Model replacements transition smoothly and clean up correctly when loading fails, is cancelled, or geometry or viewer availability changes.
  * Solar-study shadow settings are reapplied reliably after model replacements.

* **Tests**
  * Added coverage for replacement ordering, readiness handling, first loads, cleanup, failed replacements, and continuous visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->