### PR TITLE
refactor(renderer): one definition of the hide/isolate rule, not six

### DIFF
--- a/.changeset/visibility-rule-one-definition.md
+++ b/.changeset/visibility-rule-one-definition.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/renderer": patch
+---
+
+The hide/isolate rule now has one definition inside the renderer, not six.
+
+`isEntityVisible` was introduced for the draw paths so the Cesium world view could reach the same verdict the viewport does. Picking and raycasting still restated the rule inline — `pick`, `pickRect`, the pick piece-scan, both raycast-engine loops and the scene's instanced raycast each spelled out "not hidden, and isolated if isolation is active" in their own words. They agreed, but nothing held them together: the world view's disagreement began exactly this way.
+
+Behaviour is unchanged; this is the same predicate, called instead of copied. The point-cloud query keeps its own rule deliberately — it filters whole assets on `hiddenIds` only, because a point cloud has no per-element ids to isolate on.

--- a/packages/renderer/src/picking-manager.ts
+++ b/packages/renderer/src/picking-manager.ts
@@ -8,6 +8,7 @@
  */
 
 import { Camera } from './camera.js';
+import { isEntityVisible } from './entity-visibility.js';
 import { Scene } from './scene.js';
 import { Picker, type PointPickSizing } from './picker.js';
 import type { MeshData } from '@ifc-lite/geometry';
@@ -101,8 +102,7 @@ export class PickingManager {
         const requiredPieceCounts = new Map<string, number>();
         const visibleExpressIds: number[] = [];
         for (const expressId of expressIds) {
-            if (options?.hiddenIds?.has(expressId)) continue;
-            if (options?.isolatedIds !== null && options?.isolatedIds !== undefined && !options.isolatedIds.has(expressId)) continue;
+            if (!isEntityVisible(expressId, options?.hiddenIds, options?.isolatedIds)) continue;
             visibleExpressIds.push(expressId);
 
             const pieces = this.scene.getMeshDataPieces(expressId);
@@ -199,14 +199,9 @@ export class PickingManager {
 
         let meshes = this.scene.getMeshes();
 
-        // Apply visibility filtering to meshes before picking
-        // This ensures users can only select elements that are actually visible
-        if (options?.hiddenIds && options.hiddenIds.size > 0) {
-            meshes = meshes.filter(mesh => !options.hiddenIds!.has(mesh.expressId));
-        }
-        if (options?.isolatedIds !== null && options?.isolatedIds !== undefined) {
-            meshes = meshes.filter(mesh => options.isolatedIds!.has(mesh.expressId));
-        }
+        // Apply visibility filtering to meshes before picking, with the same
+        // rule the draw paths use — users can only select what they can see.
+        meshes = meshes.filter(mesh => isEntityVisible(mesh.expressId, options?.hiddenIds, options?.isolatedIds));
 
         const viewProj = this.camera.getViewProjMatrix().m;
         const pointSnap = this.pointPickProvider?.() ?? null;
@@ -334,12 +329,7 @@ export class PickingManager {
         }
 
         let meshes = this.scene.getMeshes();
-        if (options?.hiddenIds && options.hiddenIds.size > 0) {
-            meshes = meshes.filter((m) => !options.hiddenIds!.has(m.expressId));
-        }
-        if (options?.isolatedIds !== null && options?.isolatedIds !== undefined) {
-            meshes = meshes.filter((m) => options.isolatedIds!.has(m.expressId));
-        }
+        meshes = meshes.filter((m) => isEntityVisible(m.expressId, options?.hiddenIds, options?.isolatedIds));
         const viewProj = this.camera.getViewProjMatrix().m;
         const pointSnap = this.pointPickProvider?.() ?? null;
         return this.picker.pickRect(

--- a/packages/renderer/src/raycast-engine.ts
+++ b/packages/renderer/src/raycast-engine.ts
@@ -8,6 +8,7 @@
  */
 
 import { Camera } from './camera.js';
+import { isEntityVisible } from './entity-visibility.js';
 import { Scene } from './scene.js';
 import { Raycaster, type Intersection, type Ray } from './raycaster.js';
 import { SnapDetector, SnapType, type SnapTarget, type SnapOptions, type EdgeLockInput, type MagneticSnapResult } from './snap-detector.js';
@@ -113,14 +114,7 @@ export class RaycastEngine {
 
             for (const piece of pieces) {
                 // Apply visibility filtering
-                if (options?.hiddenIds?.has(piece.expressId)) continue;
-                if (
-                    options?.isolatedIds !== null &&
-                    options?.isolatedIds !== undefined &&
-                    !options.isolatedIds.has(piece.expressId)
-                ) {
-                    continue;
-                }
+                if (!isEntityVisible(piece.expressId, options?.hiddenIds, options?.isolatedIds)) continue;
 
                 // Avoid duplicates when a piece is reachable from both regular and
                 // batched passes — but DON'T collapse distinct pieces of one entity.
@@ -162,14 +156,7 @@ export class RaycastEngine {
         // is supplied (defensive) we skip instanced rather than expand everything.
         if (ray) {
             for (const eid of this.scene.getInstancedEntityIds()) {
-                if (options?.hiddenIds?.has(eid)) continue;
-                if (
-                    options?.isolatedIds !== null &&
-                    options?.isolatedIds !== undefined &&
-                    !options.isolatedIds.has(eid)
-                ) {
-                    continue;
-                }
+                if (!isEntityVisible(eid, options?.hiddenIds, options?.isolatedIds)) continue;
                 const bounds = this.scene.getInstancedEntityBounds(eid);
                 if (!bounds || !this.rayHitsBounds(ray, bounds)) continue;
                 const pieces = this.scene.getInstancedMeshDataPieces(eid);

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -4213,8 +4213,7 @@ export class Scene {
     if (this.instancedEntityMap.size > 0) {
       const instancedMap = new Map<number, MeshData[]>();
       for (const eid of this.instancedEntityMap.keys()) {
-        if (hiddenIds?.has(eid)) continue;
-        if (isolatedIds != null && !isolatedIds.has(eid)) continue;
+        if (!isEntityVisible(eid, hiddenIds, isolatedIds)) continue;
         const bounds = this.getInstancedEntityBounds(eid);
         if (!bounds || !rayIntersectsBox(rayOrigin, rayDirInv, rayDirSign, bounds)) continue;
         const pieces = this.getInstancedMeshDataPieces(eid);


### PR DESCRIPTION
Follow-up to #2581, which flagged this and deliberately left it out of a correctness fix.

## Why

`isEntityVisible` was introduced there so the Cesium world view could reach the same verdict the viewport does. The two **draw** paths now call it. Picking and raycasting still restated the rule inline, in five more places:

- `PickingManager.pick` — mesh filter
- `PickingManager.pickRect` — mesh filter
- `PickingManager` piece-scan — per-id `continue`
- `RaycastEngine` flat pieces, and `RaycastEngine` instanced occurrences
- `Scene.raycast` instanced occurrences

They agreed with each other today. Nothing held them together, and the bug that started this whole thread began exactly that way: a rule restated once too often, in a place nobody thought to check. Six statements of "not hidden, and isolated if isolation is active" is six chances to disagree about the two things that are easy to get wrong — that an **empty** isolation set hides everything (and is not the same as `null`), and that hiding wins over isolation.

## What this is not

No behaviour change. The same predicate, called instead of copied. Each replaced block was checked to be exactly equivalent before conversion.

The renderer's **868 tests pass untouched** — that is the guard for a refactor like this, and it is a real one here: the suite covers pick and pickRect under `isolatedIds`, the raycast paths, and specifically pins that point splats are *not* filtered by `hiddenIds`/`isolatedIds`.

## Deliberately left alone

`raycast-point-cloud-query` keeps its own rule: it filters whole assets on `hiddenIds` only, because a point cloud has no per-element ids to isolate on. That difference is a decision rather than a drift, so it stays written out where it can be read, with its existing comment.

Root `pnpm typecheck` clean (1052/1052 test files in a typecheck program). Changeset: patch for `@ifc-lite/renderer` — internal only, no API surface change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency of visibility handling when selecting, picking, and raycasting scene entities.
  - Hidden and isolated objects are now filtered uniformly across rendering interactions.
  - Preserved existing behavior for point-cloud visibility filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->