### PR TITLE
feat(zones): emit location zones as IfcSpatialZone

### DIFF
--- a/.changeset/spatial-zone-builder.md
+++ b/.changeset/spatial-zone-builder.md
@@ -1,0 +1,16 @@
+---
+"@ifc-lite/create": minor
+---
+
+Add `addSpatialZonesToStore`, an anchored builder for `IfcSpatialZone`.
+
+A location zone (a takt area, a construction section) is emitted as
+`IfcSpatialZone` rather than `IfcZone`: that type groups spaces, so assigning
+walls to one produces a file most readers, this one included, mis-read. Elements
+attach through `IfcRelReferencedInSpatialStructure`, which is many-to-many and
+additive, so emitting zones never re-parents anything and an element straddling
+two zones can belong to both.
+
+Boxes emit an `IfcRectangleProfileDef` with any rotation carried in the
+placement; a convex footprint emits the polygon instead. `spatialZonesSupported`
+reports whether the target schema has the type at all, since IFC2X3 does not.

--- a/apps/viewer/src/components/viewer/ZoneWriteBackControl.test.tsx
+++ b/apps/viewer/src/components/viewer/ZoneWriteBackControl.test.tsx
@@ -5,9 +5,9 @@
 /**
  * The write-back control, driven from the panel that hosts it (#2508 item 3).
  *
- * `useZoneWriteBack.test.ts` proves the write itself. What this proves is the
- * half that file cannot: the button exists ON the Zones panel, and CLICKING it
- * writes. A test that asserts the control renders would pass just as well with
+ * `useZoneWriteBack.test.ts` and `useZoneSpatialZones.test.ts` prove the writes
+ * themselves. What this proves is the half those files cannot: the buttons
+ * exist ON the Zones panel, and CLICKING them writes. A test that asserts the control renders would pass just as well with
  * `onClick={() => {}}`, which is the failure #2434 catalogued and #2396 shipped
  * - so the assertion here is the property set landing on the element.
  */
@@ -30,7 +30,12 @@ FILE_NAME('zones','',(''),(''),'','','');
 FILE_SCHEMA(('IFC4'));
 ENDSEC;
 DATA;
-#1=IFCPROJECT('0Project0000000000000a',$,'P',$,$,$,$,$,$);
+#1=IFCPROJECT('0Project0000000000000a',$,'P',$,$,$,$,(#5),$);
+#7=IFCCARTESIANPOINT((0.,0.,0.));
+#8=IFCAXIS2PLACEMENT3D(#7,$,$);
+#5=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-05,#8,$);
+#20=IFCLOCALPLACEMENT($,#8);
+#30=IFCBUILDINGSTOREY('0storey000000000000000',$,'Level 0',$,$,#20,$,$,.ELEMENT.,0.);
 #${WALL_ID}=IFCWALL('0Wall00000000000000042',$,'Wall A',$,$,$,$,$,$);
 ENDSEC;
 END-ISO-10303-21;
@@ -104,5 +109,41 @@ describe('ZonesPanel: writing zone data into the model', () => {
 
     const psets = useViewerStore.getState().getMutationView('m1')?.getForEntity(WALL_ID) ?? [];
     assert.ok(!psets.some((p) => p.name === zonePropertySetName('Takt areas')));
+  });
+});
+
+function button(container: HTMLElement, label: string): HTMLButtonElement {
+  const found = [...container.querySelectorAll('button')]
+    .find((b) => b.textContent?.trim() === label || b.getAttribute('aria-label') === label);
+  assert.ok(found, `no "${label}" control; buttons were: ${[...container.querySelectorAll('button')].map((b) => b.textContent?.trim() || b.getAttribute('aria-label')).join(' | ')}`);
+  return found as HTMLButtonElement;
+}
+
+function emittedZones(): string[] {
+  return (useViewerStore.getState().getMutationView('m1')?.getNewEntities() ?? [])
+    .filter((e) => e.type === 'IfcSpatialZone')
+    .map((e) => String(e.attributes[2]));
+}
+
+describe('ZonesPanel: emitting the zones themselves', () => {
+  beforeEach(async () => {
+    await seed();
+  });
+
+  it('emits an IfcSpatialZone when the panel button is clicked', () => {
+    const container = render(<ZonesPanel />);
+    assert.deepEqual(emittedZones(), [], 'the panel emitted on mount');
+
+    click(button(container, 'Emit zones as IfcSpatialZone'));
+
+    assert.deepEqual(emittedZones(), ['Takt A']);
+    assert.ok(useViewerStore.getState().dirtyModels.has('m1'));
+  });
+
+  it('takes them out again from the same panel', () => {
+    const container = render(<ZonesPanel />);
+    click(button(container, 'Emit zones as IfcSpatialZone'));
+    click(button(container, 'Remove emitted spatial zones'));
+    assert.deepEqual(emittedZones(), []);
   });
 });

--- a/apps/viewer/src/components/viewer/ZoneWriteBackControl.tsx
+++ b/apps/viewer/src/components/viewer/ZoneWriteBackControl.tsx
@@ -133,7 +133,11 @@ export function ZoneWriteBackControl({ zoneSet }: { zoneSet: ZoneSet }) {
               return;
             }
             if (result.blocked === 'no-members') {
-              toast.info('No element is in a zone of this set, so there is nothing to reference');
+              toast.info(
+                result.staleRemoved > 0
+                  ? `No element is in a zone of this set any more, so ${result.staleRemoved.toLocaleString()} emitted zone(s) were removed`
+                  : 'No element is in a zone of this set, so there is nothing to reference',
+              );
               return;
             }
             if (result.blocked === 'duplicate-set-name') {
@@ -162,7 +166,8 @@ export function ZoneWriteBackControl({ zoneSet }: { zoneSet: ZoneSet }) {
             toast.success(
               `Emitted ${zones.toLocaleString()} IfcSpatialZone(s) across ${written.length} model(s), `
               + `referencing ${elements.toLocaleString()} element(s)`
-              + (replaced > 0 ? `, replacing ${replaced.toLocaleString()} from an earlier run` : ''),
+              + (replaced > 0 ? `, replacing ${replaced.toLocaleString()} from an earlier run` : '')
+              + (result.staleRemoved > 0 ? `, and clearing ${result.staleRemoved.toLocaleString()} from a model this set no longer reaches` : ''),
             );
           }}
         >

--- a/apps/viewer/src/components/viewer/ZoneWriteBackControl.tsx
+++ b/apps/viewer/src/components/viewer/ZoneWriteBackControl.tsx
@@ -136,6 +136,12 @@ export function ZoneWriteBackControl({ zoneSet }: { zoneSet: ZoneSet }) {
               toast.info('No element is in a zone of this set, so there is nothing to reference');
               return;
             }
+            if (result.blocked === 'duplicate-set-name') {
+              // The set's name is what identifies its zones in the FILE, so two
+              // sets sharing one would each delete the other's on the next run.
+              toast.error(`Another zone set is also called "${zoneSet.name}". Rename one before emitting.`);
+              return;
+            }
             const written = result.models.filter((m) => m.zonesEmitted > 0);
             // Every refused model is named, rather than folded into a count: in
             // a federation the answer "which file did NOT get the zones" is the
@@ -168,6 +174,10 @@ export function ZoneWriteBackControl({ zoneSet }: { zoneSet: ZoneSet }) {
             const { removed, blocked } = removeZones(zoneSet);
             if (blocked === 'collab-role') {
               toast.error('Your role in this session is read-only, so nothing was removed');
+              return;
+            }
+            if (blocked === 'duplicate-set-name') {
+              toast.error(`Another zone set is also called "${zoneSet.name}". Rename one before removing.`);
               return;
             }
             if (removed === 0) toast.info('No emitted zones to remove for this set');

--- a/apps/viewer/src/components/viewer/ZoneWriteBackControl.tsx
+++ b/apps/viewer/src/components/viewer/ZoneWriteBackControl.tsx
@@ -19,7 +19,7 @@
  */
 
 import { useState } from 'react';
-import { FileOutput, Undo2 } from 'lucide-react';
+import { Box, FileOutput, Undo2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
   Select,
@@ -30,6 +30,8 @@ import {
 } from '@/components/ui/select';
 import { toast } from '@/components/ui/toast';
 import { useZoneWriteBack } from '@/hooks/useZoneWriteBack';
+import { useZoneSpatialZones } from '@/hooks/useZoneSpatialZones';
+import { emitRefusalText } from '@/lib/zones/emit-spatial-zones';
 import {
   zonePropertySetName,
   zoneQuantitySetName,
@@ -43,6 +45,7 @@ const BASES: readonly VolumeBasis[] = ['mesh', 'net', 'gross', 'unqualified'];
 export function ZoneWriteBackControl({ zoneSet }: { zoneSet: ZoneSet }) {
   const [basis, setBasis] = useState<VolumeBasis>('mesh');
   const { write, remove } = useZoneWriteBack();
+  const { emit: emitZones, remove: removeZones } = useZoneSpatialZones();
 
   return (
     <div className="space-y-1 rounded border-t pt-1.5">
@@ -117,6 +120,63 @@ export function ZoneWriteBackControl({ zoneSet }: { zoneSet: ZoneSet }) {
       <p className="text-[10px] text-muted-foreground leading-snug break-words">
         {zonePropertySetName(zoneSet.name)} · {zoneQuantitySetName(zoneSet.name, basis)}
       </p>
+      <div className="flex items-center gap-1">
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-6 flex-1 text-[11px]"
+          title="Emit the zones themselves as IfcSpatialZone entities, each referencing the elements it contains"
+          onClick={() => {
+            const result = emitZones(zoneSet);
+            if (result.blocked === 'collab-role') {
+              toast.error('Your role in this session is read-only, so nothing was emitted');
+              return;
+            }
+            if (result.blocked === 'no-members') {
+              toast.info('No element is in a zone of this set, so there is nothing to reference');
+              return;
+            }
+            const written = result.models.filter((m) => m.zonesEmitted > 0);
+            // Every refused model is named, rather than folded into a count: in
+            // a federation the answer "which file did NOT get the zones" is the
+            // one the user has to act on.
+            const refused = result.models.filter((m) => m.refusal);
+            for (const model of refused) {
+              toast.error(emitRefusalText(model.refusal as NonNullable<typeof model.refusal>, model.modelName));
+            }
+            if (written.length === 0) return;
+            const zones = written.reduce((sum, m) => sum + m.zonesEmitted, 0);
+            const elements = written.reduce((sum, m) => sum + m.elementsReferenced, 0);
+            const replaced = written.reduce((sum, m) => sum + m.zonesReplaced, 0);
+            toast.success(
+              `Emitted ${zones.toLocaleString()} IfcSpatialZone(s) across ${written.length} model(s), `
+              + `referencing ${elements.toLocaleString()} element(s)`
+              + (replaced > 0 ? `, replacing ${replaced.toLocaleString()} from an earlier run` : ''),
+            );
+          }}
+        >
+          <Box className="h-3 w-3 mr-1" />
+          Emit zones as IfcSpatialZone
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-6 w-6"
+          title="Remove the IfcSpatialZone entities emitted for this set"
+          aria-label="Remove emitted spatial zones"
+          onClick={() => {
+            const { removed, blocked } = removeZones(zoneSet);
+            if (blocked === 'collab-role') {
+              toast.error('Your role in this session is read-only, so nothing was removed');
+              return;
+            }
+            if (removed === 0) toast.info('No emitted zones to remove for this set');
+            else toast.success(`Removed ${removed.toLocaleString()} IfcSpatialZone(s)`);
+          }}
+        >
+          <Undo2 className="h-3 w-3" />
+        </Button>
+      </div>
     </div>
   );
 }

--- a/apps/viewer/src/components/viewer/ZoneWriteBackControl.tsx
+++ b/apps/viewer/src/components/viewer/ZoneWriteBackControl.tsx
@@ -150,7 +150,12 @@ export function ZoneWriteBackControl({ zoneSet }: { zoneSet: ZoneSet }) {
             for (const model of refused) {
               toast.error(emitRefusalText(model.refusal as NonNullable<typeof model.refusal>, model.modelName));
             }
-            if (written.length === 0) return;
+            if (written.length === 0) {
+              // A model with no parsed store is skipped without a refusal, so
+              // without this the click produces no feedback at all.
+              if (refused.length === 0) toast.info('No loaded model could take the zones');
+              return;
+            }
             const zones = written.reduce((sum, m) => sum + m.zonesEmitted, 0);
             const elements = written.reduce((sum, m) => sum + m.elementsReferenced, 0);
             const replaced = written.reduce((sum, m) => sum + m.zonesReplaced, 0);

--- a/apps/viewer/src/hooks/useRenderFrameOffsets.ts
+++ b/apps/viewer/src/hooks/useRenderFrameOffsets.ts
@@ -30,6 +30,7 @@
 import { useMemo } from 'react';
 import type { CoordinateInfo } from '@ifc-lite/geometry';
 import { useViewerStore } from '@/store';
+import type { FederatedModel } from '@/store/types';
 import { geometryVolumesSurviveAlignment } from '@/lib/compare/alignmentTrust';
 import type { RenderFrameOffsets } from '@/components/viewer/tools/measure-modes/coordinates';
 
@@ -47,36 +48,48 @@ export interface RenderFrameProvenance {
 
 export type RenderFrameResult = RenderFrameOffsets & RenderFrameProvenance;
 
+/**
+ * The frame resolution itself, off React.
+ *
+ * Split out so a non-component caller (the `IfcSpatialZone` emission, which
+ * runs from a click rather than a render) resolves the frame by the SAME rule
+ * as the readouts. Two rules would be two answers about where a point is.
+ */
+export function resolveRenderFrame(
+  models: Map<string, FederatedModel>,
+  geometryResult: { coordinateInfo?: CoordinateInfo | null } | null | undefined,
+): RenderFrameResult {
+  // Federated: the earliest-loaded model owns the frame every other model
+  // was aligned to.
+  let earliest = Infinity;
+  let info: CoordinateInfo | null = null;
+  let anchorName: string | null = null;
+  let rebased = false;
+  for (const [, m] of models) {
+    if (m.loadedAt < earliest && m.geometryResult?.coordinateInfo) {
+      earliest = m.loadedAt;
+      info = m.geometryResult.coordinateInfo;
+      anchorName = m.name ?? null;
+    }
+    // `geometryVolumesSurviveAlignment` is the same two-status question
+    // asked of the same alignment pass (#1993): those are exactly the
+    // statuses under which vertices were re-baked into the anchor frame.
+    if (!geometryVolumesSurviveAlignment(m.federationAlignmentStatus)) rebased = true;
+  }
+  // Legacy single-model load: no federated entry, one geometry result.
+  if (!info) info = geometryResult?.coordinateInfo ?? null;
+
+  return {
+    originShift: info?.originShift ?? null,
+    wasmRtcOffsetIfc: info?.wasmRtcOffset ?? null,
+    rebased,
+    anchorName,
+  };
+}
+
 export function useRenderFrameOffsets(): RenderFrameResult {
   const models = useViewerStore((s) => s.models);
   const geometryResult = useViewerStore((s) => s.geometryResult);
 
-  return useMemo(() => {
-    // Federated: the earliest-loaded model owns the frame every other model
-    // was aligned to.
-    let earliest = Infinity;
-    let info: CoordinateInfo | null = null;
-    let anchorName: string | null = null;
-    let rebased = false;
-    for (const [, m] of models) {
-      if (m.loadedAt < earliest && m.geometryResult?.coordinateInfo) {
-        earliest = m.loadedAt;
-        info = m.geometryResult.coordinateInfo;
-        anchorName = m.name ?? null;
-      }
-      // `geometryVolumesSurviveAlignment` is the same two-status question
-      // asked of the same alignment pass (#1993): those are exactly the
-      // statuses under which vertices were re-baked into the anchor frame.
-      if (!geometryVolumesSurviveAlignment(m.federationAlignmentStatus)) rebased = true;
-    }
-    // Legacy single-model load: no federated entry, one geometry result.
-    if (!info) info = geometryResult?.coordinateInfo ?? null;
-
-    return {
-      originShift: info?.originShift ?? null,
-      wasmRtcOffsetIfc: info?.wasmRtcOffset ?? null,
-      rebased,
-      anchorName,
-    };
-  }, [models, geometryResult]);
+  return useMemo(() => resolveRenderFrame(models, geometryResult), [models, geometryResult]);
 }

--- a/apps/viewer/src/hooks/useZoneSpatialZones.test.ts
+++ b/apps/viewer/src/hooks/useZoneSpatialZones.test.ts
@@ -269,6 +269,29 @@ describe('emitZoneSpatialZones: what it refuses', () => {
     assert.equal(emitZoneSpatialZones(ZONE_SET).blocked, 'no-members');
   });
 
+  it('refuses a set whose name another set also uses', async () => {
+    // Both sets would write LongName 'Takt areas', so the second emission would
+    // sweep the first's zones out of the file. The panel asks for a rename
+    // rather than picking a winner.
+    await seedStore();
+    useViewerStore.setState({
+      zoneSets: [ZONE_SET, { ...ZONE_SET, id: 'set-2' }],
+    } as never);
+    assert.equal(emitZoneSpatialZones(ZONE_SET).blocked, 'duplicate-set-name');
+    assert.equal(removeZoneSpatialZones(ZONE_SET).blocked, 'duplicate-set-name');
+    assert.equal(zoneEntities().length, 0);
+  });
+
+  it('refuses a zone with no height, before writing any of the others', async () => {
+    await seedStore();
+    const flat = { ...ZONE_SET, zones: [ZONE_SET.zones[0], { ...ZONE_SET.zones[1], size: [10, 0, 8] as [number, number, number] }] };
+    const result = emitZoneSpatialZones(flat);
+    assert.equal(result.models[0].refusal, 'degenerate-zone');
+    // The good zone must not be in the file either: the builder emits zone by
+    // zone, so a half-written set is the failure this refusal exists to stop.
+    assert.equal(zoneEntities().length, 0);
+  });
+
   it('writes nothing at all for a read-only collab role', async () => {
     await seedStore();
     const canEdit = useViewerStore.getState().canCollabEdit;

--- a/apps/viewer/src/hooks/useZoneSpatialZones.test.ts
+++ b/apps/viewer/src/hooks/useZoneSpatialZones.test.ts
@@ -1,0 +1,284 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Zone sets emitted as `IfcSpatialZone`, and out again through a STEP export
+ * (#2508 item 3).
+ *
+ * Same rule as the write-back's own test: asserting on the overlay proves the
+ * writer wrote what it meant to, and re-reading the exported STEP proves the
+ * FILE means it. The overlay is where an entity that never reaches the
+ * exporter still looks fine, which is exactly the bug class this feature has
+ * already produced once (a quantity-set deletion the exporter ignored).
+ *
+ * The fixture declares MILLIMETRES, because emitting metres into a millimetre
+ * file is this feature's characteristic failure in geometric form: a zone a
+ * thousand times too small, in the right place, with the right name.
+ */
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { IfcParser, extractPropertiesOnDemand, type IfcDataStore } from '@ifc-lite/parser';
+import { StepExporter } from '@ifc-lite/export';
+import { useViewerStore } from '@/store/index.js';
+import { emitZoneSpatialZones, removeZoneSpatialZones } from './useZoneSpatialZones.js';
+import type { ZoneSet } from '@/lib/zones';
+
+const WALL_ID = 42;
+const BEAM_ID = 43;
+const STOREY_ID = 30;
+
+/** A millimetre file with everything `resolveSpatialAnchor` needs: a 3D
+ *  representation context, a storey, and a placement under it. */
+function miniIfc(schema = 'IFC4', lengthUnit = '.MILLI.'): string {
+  return `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('zones','',(''),(''),'','','');
+FILE_SCHEMA(('${schema}'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0Project0000000000000a',#4,'P',$,$,$,$,(#5),#6);
+#2=IFCSIUNIT(*,.LENGTHUNIT.,${lengthUnit},.METRE.);
+#4=IFCOWNERHISTORY($,$,$,.NOCHANGE.,$,$,$,0);
+#6=IFCUNITASSIGNMENT((#2));
+#7=IFCCARTESIANPOINT((0.,0.,0.));
+#8=IFCAXIS2PLACEMENT3D(#7,$,$);
+#5=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-05,#8,$);
+#20=IFCLOCALPLACEMENT($,#8);
+#${STOREY_ID}=IFCBUILDINGSTOREY('0storey000000000000000',#4,'Level 0',$,$,#20,$,$,.ELEMENT.,0.);
+#${WALL_ID}=IFCWALL('0Wall00000000000000042',#4,'Wall A',$,$,$,$,$,$);
+#${BEAM_ID}=IFCBEAM('0Beam00000000000000043',#4,'Beam B',$,$,$,$,$,$);
+ENDSEC;
+END-ISO-10303-21;
+`;
+}
+
+async function parse(ifc: string): Promise<IfcDataStore> {
+  const bytes = new TextEncoder().encode(ifc);
+  return new IfcParser().parseColumnar(
+    bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+  );
+}
+
+/** Two zones tiling 0..20 m along X, both 4 m tall from y = 0. */
+const ZONE_SET: ZoneSet = {
+  id: 'set-1',
+  name: 'Takt areas',
+  zones: [
+    { id: 'z-a', name: 'Takt A', center: [5, 2, 0], size: [10, 4, 8], rotationY: 0 },
+    { id: 'z-b', name: 'Takt B', center: [15, 2, 0], size: [10, 4, 8], rotationY: 0 },
+  ],
+  visible: true,
+  createdAt: 0,
+  updatedAt: 0,
+};
+
+/** #42 straddles both zones; #43 sits in A alone. */
+function seedAssignments() {
+  return new Map([
+    [WALL_ID, { 'set-1': { zoneId: 'z-a', zoneName: 'Takt A', straddles: true, touchedZoneIds: ['z-a', 'z-b'] } }],
+    [BEAM_ID, { 'set-1': { zoneId: 'z-a', zoneName: 'Takt A', straddles: false, touchedZoneIds: ['z-a'] } }],
+  ]);
+}
+
+async function seedStore(options: { schema?: string; lengthUnit?: string; rebased?: boolean } = {}): Promise<IfcDataStore> {
+  const store = await parse(miniIfc(options.schema, options.lengthUnit));
+  useViewerStore.setState({
+    models: new Map([['m1', {
+      id: 'm1',
+      name: 'zones.ifc',
+      ifcDataStore: store,
+      visible: true,
+      loadedAt: 1,
+      // `'same-crs'` is one of the two statuses under which alignment re-baked
+      // this model's vertices into another file's frame.
+      federationAlignmentStatus: options.rebased ? 'same-crs' : undefined,
+    } as never]]),
+    zoneSets: [ZONE_SET],
+    zoneAssignments: seedAssignments() as never,
+    mutationViews: new Map(),
+    storeEditors: new Map(),
+    dirtyModels: new Set(),
+  } as never);
+  return store;
+}
+
+function overlay() {
+  return useViewerStore.getState().getMutationView('m1')?.getNewEntities() ?? [];
+}
+
+function zoneEntities() {
+  return overlay().filter((e) => e.type === 'IfcSpatialZone');
+}
+
+/** Export and hand back the STEP text, so assertions read the FILE. */
+function exportStep(store: IfcDataStore): string {
+  const view = useViewerStore.getState().getMutationView('m1');
+  const result = new StepExporter(store, view as never).export({ schema: 'IFC4', applyMutations: true });
+  return new TextDecoder().decode(result.content);
+}
+
+describe('emitZoneSpatialZones: what reaches the model', () => {
+  let store: IfcDataStore;
+  beforeEach(async () => {
+    store = await seedStore();
+    // The write path needs a real on-demand extractor for the model, same as
+    // any other overlay consumer.
+    const view = useViewerStore.getState().getMutationView('m1');
+    view?.setOnDemandExtractor?.((entityId: number) => extractPropertiesOnDemand(store, entityId));
+  });
+
+  it('emits one zone per zone in the set, referencing the elements it holds', () => {
+    const result = emitZoneSpatialZones(ZONE_SET);
+    assert.equal(result.blocked, null);
+    assert.equal(result.models.length, 1);
+    assert.equal(result.models[0].refusal, null);
+    assert.equal(result.models[0].zonesEmitted, 2);
+    // The straddler counts under both zones, the beam under one.
+    assert.equal(result.models[0].elementsReferenced, 3);
+
+    const rels = overlay().filter((e) => e.type === 'IfcRelReferencedInSpatialStructure');
+    assert.equal(rels.length, 2);
+    const a = rels.find((r) => (r.attributes[4] as string[]).includes(`#${BEAM_ID}`));
+    assert.deepEqual(a?.attributes[4], [`#${WALL_ID}`, `#${BEAM_ID}`]);
+  });
+
+  it('the exported FILE carries the zones, by reference and never by containment', () => {
+    emitZoneSpatialZones(ZONE_SET);
+    const step = exportStep(store);
+
+    // Nine arguments, the zone's own name in Name and the SET's in LongName:
+    // the whole record, so a tenth argument (the `CompositionType` this type
+    // does not have) or a swapped name pair cannot pass.
+    assert.match(step, /=IFCSPATIALZONE\('.{22}',#4,'Takt A',\$,\$,#\d+,#\d+,'Takt areas',\.CONSTRUCTION\.\);/);
+    assert.match(step, /=IFCSPATIALZONE\('.{22}',#4,'Takt B',\$,\$,#\d+,#\d+,'Takt areas',\.CONSTRUCTION\.\);/);
+    assert.equal((step.match(/=IFCSPATIALZONE\(/g) ?? []).length, 2);
+    assert.match(step, /=IFCRELREFERENCEDINSPATIALSTRUCTURE\(/);
+    // Containment is the exclusive relation that carries the building's real
+    // hierarchy. Emitting one here would move an element out of its storey.
+    assert.doesNotMatch(step, /=IFCRELCONTAINEDINSPATIALSTRUCTURE\(/);
+  });
+
+  it('writes the zone in the file\'s own length unit', () => {
+    emitZoneSpatialZones(ZONE_SET);
+    const step = exportStep(store);
+    // Takt A is 10 m x 8 m x 4 m in a MILLIMETRE file.
+    assert.match(step, /=IFCRECTANGLEPROFILEDEF\(\.AREA\.,\$,#\d+,10000\.?,8000\.?\)/);
+    assert.match(step, /=IFCEXTRUDEDAREASOLID\(#\d+,#\d+,#\d+,4000\.?\)/);
+  });
+
+  it('re-parses into a store that has the zones as real entities', async () => {
+    emitZoneSpatialZones(ZONE_SET);
+    const reparsed = await parse(exportStep(store));
+    const ids = reparsed.entityIndex.byType.get('IFCSPATIALZONE') ?? [];
+    assert.equal(ids.length, 2, 'the exported file does not parse back into two zones');
+    assert.equal((reparsed.entityIndex.byType.get('IFCRELREFERENCEDINSPATIALSTRUCTURE') ?? []).length, 2);
+  });
+});
+
+describe('emitZoneSpatialZones: running it twice', () => {
+  let store: IfcDataStore;
+  beforeEach(async () => {
+    store = await seedStore();
+  });
+
+  it('replaces the previous run rather than stacking a second copy', () => {
+    emitZoneSpatialZones(ZONE_SET);
+    const second = emitZoneSpatialZones(ZONE_SET);
+    assert.equal(second.models[0].zonesReplaced, 2);
+    assert.equal(zoneEntities().length, 2, 'a second press left duplicate zones behind');
+    assert.equal((exportStep(store).match(/=IFCSPATIALZONE\(/g) ?? []).length, 2);
+  });
+
+  it('leaves nothing of the first run behind, not even its geometry', () => {
+    emitZoneSpatialZones(ZONE_SET);
+    const firstPass = overlay().length;
+    emitZoneSpatialZones(ZONE_SET);
+    // Every entity is per-zone, so a sweep that only removed the zone itself
+    // would leave the points, profiles and solids piling up run after run.
+    assert.equal(overlay().length, firstPass);
+  });
+
+  it('follows a rename: zones written under the old name are NOT swept', () => {
+    // The honest limit of a name-keyed sweep, pinned so it is a decision rather
+    // than a surprise. The zone set's name is what a receiving tool reads in
+    // LongName, and there is no id in the file to match on instead.
+    emitZoneSpatialZones(ZONE_SET);
+    const renamed = { ...ZONE_SET, name: 'Sections' };
+    const result = emitZoneSpatialZones(renamed);
+    assert.equal(result.models[0].zonesReplaced, 0);
+    assert.equal(zoneEntities().length, 4);
+    // Removing under the old name still reaches the old copies.
+    assert.equal(removeZoneSpatialZones(ZONE_SET).removed, 2);
+    assert.equal(zoneEntities().length, 2);
+  });
+});
+
+describe('removeZoneSpatialZones', () => {
+  let store: IfcDataStore;
+  beforeEach(async () => {
+    store = await seedStore();
+  });
+
+  it('takes the zones back out of the exported file', () => {
+    emitZoneSpatialZones(ZONE_SET);
+    const removal = removeZoneSpatialZones(ZONE_SET);
+    assert.equal(removal.removed, 2);
+    const step = exportStep(store);
+    assert.doesNotMatch(step, /=IFCSPATIALZONE\(/);
+    assert.doesNotMatch(step, /=IFCRELREFERENCEDINSPATIALSTRUCTURE\(/);
+  });
+
+  it('reports nothing removed when nothing was emitted', () => {
+    assert.equal(removeZoneSpatialZones(ZONE_SET).removed, 0);
+  });
+
+  it('leaves the model\'s own entities alone', () => {
+    emitZoneSpatialZones(ZONE_SET);
+    removeZoneSpatialZones(ZONE_SET);
+    const step = exportStep(store);
+    // The elements the zones referenced, and the storey they anchored against,
+    // are file entities: a sweep that walked into them would tombstone the
+    // model itself.
+    assert.match(step, /=IFCWALL\('0Wall00000000000000042'/);
+    assert.match(step, /=IFCBEAM\('0Beam00000000000000043'/);
+    assert.match(step, /=IFCBUILDINGSTOREY\('0storey000000000000000'/);
+  });
+});
+
+describe('emitZoneSpatialZones: what it refuses', () => {
+  it('refuses a model federation alignment re-based', async () => {
+    await seedStore({ rebased: true });
+    const result = emitZoneSpatialZones(ZONE_SET);
+    assert.equal(result.models[0].refusal, 'rescaled-by-alignment');
+    assert.equal(zoneEntities().length, 0);
+  });
+
+  it('refuses IFC2X3, which has no IfcSpatialZone', async () => {
+    await seedStore({ schema: 'IFC2X3' });
+    const result = emitZoneSpatialZones(ZONE_SET);
+    assert.equal(result.models[0].refusal, 'schema-too-old');
+    assert.equal(zoneEntities().length, 0);
+  });
+
+  it('says so when no element is in any zone', async () => {
+    await seedStore();
+    useViewerStore.setState({ zoneAssignments: new Map() } as never);
+    assert.equal(emitZoneSpatialZones(ZONE_SET).blocked, 'no-members');
+  });
+
+  it('writes nothing at all for a read-only collab role', async () => {
+    await seedStore();
+    const canEdit = useViewerStore.getState().canCollabEdit;
+    useViewerStore.setState({ canCollabEdit: () => false } as never);
+    try {
+      assert.equal(emitZoneSpatialZones(ZONE_SET).blocked, 'collab-role');
+      assert.equal(removeZoneSpatialZones(ZONE_SET).blocked, 'collab-role');
+      assert.equal(zoneEntities().length, 0);
+    } finally {
+      useViewerStore.setState({ canCollabEdit: canEdit } as never);
+    }
+  });
+});

--- a/apps/viewer/src/hooks/useZoneSpatialZones.test.ts
+++ b/apps/viewer/src/hooks/useZoneSpatialZones.test.ts
@@ -83,7 +83,13 @@ function seedAssignments() {
   ]);
 }
 
-async function seedStore(options: { schema?: string; lengthUnit?: string; rebased?: boolean } = {}): Promise<IfcDataStore> {
+async function seedStore(options: {
+  schema?: string;
+  lengthUnit?: string;
+  rebased?: boolean;
+  /** This model's OWN render offsets, as its geometry pass recorded them. */
+  coordinateInfo?: unknown;
+} = {}): Promise<IfcDataStore> {
   const store = await parse(miniIfc(options.schema, options.lengthUnit));
   useViewerStore.setState({
     models: new Map([['m1', {
@@ -92,6 +98,7 @@ async function seedStore(options: { schema?: string; lengthUnit?: string; rebase
       ifcDataStore: store,
       visible: true,
       loadedAt: 1,
+      geometryResult: options.coordinateInfo ? { coordinateInfo: options.coordinateInfo } : undefined,
       // `'same-crs'` is one of the two statuses under which alignment re-baked
       // this model's vertices into another file's frame.
       federationAlignmentStatus: options.rebased ? 'same-crs' : undefined,
@@ -245,6 +252,43 @@ describe('removeZoneSpatialZones', () => {
     assert.match(step, /=IFCWALL\('0Wall00000000000000042'/);
     assert.match(step, /=IFCBEAM\('0Beam00000000000000043'/);
     assert.match(step, /=IFCBUILDINGSTOREY\('0storey000000000000000'/);
+  });
+});
+
+describe('emitZoneSpatialZones: whose frame', () => {
+  it('undoes THIS model\'s offsets, not the scene anchor\'s', async () => {
+    // A model alignment did not re-base (`'none'`, `'failed'`) is drawn in its
+    // OWN local frame, so undoing another model's offsets would move its zones
+    // by the difference between the two files' origins - kilometres on a
+    // georeferenced pair, and perfectly plausible in the file.
+    const store = await seedStore({
+      lengthUnit: '$',
+      coordinateInfo: { originShift: { x: 1000, y: 0, z: 0 }, wasmRtcOffset: null },
+    });
+    // An EARLIER model, which is the one the scene frame resolves to. Without a
+    // second model the two rules agree and the test would prove nothing.
+    // Appended rather than prepended: `resolveRenderFrame` picks by `loadedAt`,
+    // while `resolveEntityRef` falls back to the FIRST entry of the map, so
+    // putting the anchor first would send the elements to a model with no store.
+    useViewerStore.setState({
+      models: new Map([
+        ...useViewerStore.getState().models,
+        ['m0', {
+          id: 'm0',
+          name: 'anchor.ifc',
+          visible: true,
+          loadedAt: 0,
+          geometryResult: { coordinateInfo: { originShift: { x: -7, y: 0, z: 0 }, wasmRtcOffset: null } },
+        } as never],
+      ]) as never,
+    } as never);
+
+    emitZoneSpatialZones(ZONE_SET);
+    const step = exportStep(store);
+    // Takt A's base centre is render x = 5, so this model's own +1000 shift
+    // puts it at 1005 and the scene's -7 would put it at -2.
+    assert.match(step, /=IFCCARTESIANPOINT\(\(1005\.?,/);
+    assert.doesNotMatch(step, /=IFCCARTESIANPOINT\(\(-2\.?,/);
   });
 });
 

--- a/apps/viewer/src/hooks/useZoneSpatialZones.test.ts
+++ b/apps/viewer/src/hooks/useZoneSpatialZones.test.ts
@@ -19,7 +19,7 @@
 
 import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { IfcParser, extractPropertiesOnDemand, type IfcDataStore } from '@ifc-lite/parser';
+import { EntityExtractor, IfcParser, extractPropertiesOnDemand, type IfcDataStore } from '@ifc-lite/parser';
 import { StepExporter } from '@ifc-lite/export';
 import { useViewerStore } from '@/store/index.js';
 import { emitZoneSpatialZones, removeZoneSpatialZones } from './useZoneSpatialZones.js';
@@ -125,6 +125,29 @@ function exportStep(store: IfcDataStore): string {
   const view = useViewerStore.getState().getMutationView('m1');
   const result = new StepExporter(store, view as never).export({ schema: 'IFC4', applyMutations: true });
   return new TextDecoder().decode(result.content);
+}
+
+/**
+ * Re-parse an exported file and return each zone's placement point, by zone
+ * name, following IfcSpatialZone -> ObjectPlacement -> RelativePlacement ->
+ * Location. Reading the real graph rather than the text is what makes the
+ * coordinate assertion about the ZONE rather than about some point.
+ */
+async function zonePlacements(step: string): Promise<Map<string, number[]>> {
+  const store = await parse(step);
+  const extractor = new EntityExtractor(store.source);
+  const attributes = (id: number): unknown[] => {
+    const ref = store.entityIndex.byId.get(id);
+    return ref ? (extractor.extractEntity(ref)?.attributes ?? []) : [];
+  };
+  const out = new Map<string, number[]>();
+  for (const zoneId of store.entityIndex.byType.get('IFCSPATIALZONE') ?? []) {
+    const zone = attributes(zoneId);
+    const axis = attributes(zone[5] as number)[1] as number;
+    const location = attributes(axis)[0] as number;
+    out.set(String(zone[2]), attributes(location)[0] as number[]);
+  }
+  return out;
 }
 
 describe('emitZoneSpatialZones: what reaches the model', () => {
@@ -238,6 +261,21 @@ describe('removeZoneSpatialZones', () => {
     assert.doesNotMatch(step, /=IFCRELREFERENCEDINSPATIALSTRUCTURE\(/);
   });
 
+  it('clears a model the set no longer reaches, on the next emit', () => {
+    // The zones moved off this model entirely. It is absent from the
+    // membership map, so the emit loop never visits it, and its copies would
+    // otherwise stay in its file describing takt areas that no longer touch it.
+    emitZoneSpatialZones(ZONE_SET);
+    assert.equal(zoneEntities().length, 2);
+
+    useViewerStore.setState({ zoneAssignments: new Map() } as never);
+    const again = emitZoneSpatialZones(ZONE_SET);
+    assert.equal(again.blocked, 'no-members');
+    assert.equal(again.staleRemoved, 2);
+    assert.equal(zoneEntities().length, 0);
+    assert.doesNotMatch(exportStep(store), /=IFCSPATIALZONE\(/);
+  });
+
   it('reports nothing removed when nothing was emitted', () => {
     assert.equal(removeZoneSpatialZones(ZONE_SET).removed, 0);
   });
@@ -284,11 +322,14 @@ describe('emitZoneSpatialZones: whose frame', () => {
     } as never);
 
     emitZoneSpatialZones(ZONE_SET);
-    const step = exportStep(store);
+    // Read the coordinate through the PLACEMENT CHAIN of a re-parsed zone
+    // rather than off the serialized text: a regex for the number would also
+    // match an unrelated point, and would break on a formatting change that
+    // leaves the zone exactly where it belongs.
+    const placed = await zonePlacements(exportStep(store));
     // Takt A's base centre is render x = 5, so this model's own +1000 shift
     // puts it at 1005 and the scene's -7 would put it at -2.
-    assert.match(step, /=IFCCARTESIANPOINT\(\(1005\.?,/);
-    assert.doesNotMatch(step, /=IFCCARTESIANPOINT\(\(-2\.?,/);
+    assert.deepEqual(placed.get('Takt A')?.slice(0, 1), [1005]);
   });
 });
 

--- a/apps/viewer/src/hooks/useZoneSpatialZones.test.ts
+++ b/apps/viewer/src/hooks/useZoneSpatialZones.test.ts
@@ -182,8 +182,8 @@ describe('emitZoneSpatialZones: what reaches the model', () => {
     // Nine arguments, the zone's own name in Name and the SET's in LongName:
     // the whole record, so a tenth argument (the `CompositionType` this type
     // does not have) or a swapped name pair cannot pass.
-    assert.match(step, /=IFCSPATIALZONE\('.{22}',#4,'Takt A',\$,\$,#\d+,#\d+,'Takt areas',\.CONSTRUCTION\.\);/);
-    assert.match(step, /=IFCSPATIALZONE\('.{22}',#4,'Takt B',\$,\$,#\d+,#\d+,'Takt areas',\.CONSTRUCTION\.\);/);
+    assert.match(step, /=IFCSPATIALZONE\('.{22}',#4,'Takt A','IfcLite zone set set-1',\$,#\d+,#\d+,'Takt areas',\.CONSTRUCTION\.\);/);
+    assert.match(step, /=IFCSPATIALZONE\('.{22}',#4,'Takt B','IfcLite zone set set-1',\$,#\d+,#\d+,'Takt areas',\.CONSTRUCTION\.\);/);
     assert.equal((step.match(/=IFCSPATIALZONE\(/g) ?? []).length, 2);
     assert.match(step, /=IFCRELREFERENCEDINSPATIALSTRUCTURE\(/);
     // Containment is the exclusive relation that carries the building's real
@@ -231,18 +231,29 @@ describe('emitZoneSpatialZones: running it twice', () => {
     assert.equal(overlay().length, firstPass);
   });
 
-  it('follows a rename: zones written under the old name are NOT swept', () => {
-    // The honest limit of a name-keyed sweep, pinned so it is a decision rather
-    // than a surprise. The zone set's name is what a receiving tool reads in
-    // LongName, and there is no id in the file to match on instead.
+  it('follows a RENAME, because the set is identified by its id in the file', () => {
+    // The case a name-keyed sweep gets wrong: emit, rename the set, emit again.
+    // Matching on LongName alone would leave the first run's zones behind for
+    // good, under a name nothing in the session refers to any more.
     emitZoneSpatialZones(ZONE_SET);
     const renamed = { ...ZONE_SET, name: 'Sections' };
+    useViewerStore.setState({ zoneSets: [renamed] } as never);
+
     const result = emitZoneSpatialZones(renamed);
-    assert.equal(result.models[0].zonesReplaced, 0);
-    assert.equal(zoneEntities().length, 4);
-    // Removing under the old name still reaches the old copies.
-    assert.equal(removeZoneSpatialZones(ZONE_SET).removed, 2);
-    assert.equal(zoneEntities().length, 2);
+    assert.equal(result.models[0].zonesReplaced, 2);
+    assert.equal(zoneEntities().length, 2, 'the rename left the old zones behind');
+    // ...and what is in the file now carries the NEW name.
+    const step = exportStep(store);
+    assert.equal((step.match(/'Takt areas'/g) ?? []).length, 0);
+    assert.match(step, /=IFCSPATIALZONE\('.{22}',#4,'Takt A','IfcLite zone set set-1',\$,#\d+,#\d+,'Sections',/);
+  });
+
+  it('removes a renamed set\'s zones under its NEW name', () => {
+    emitZoneSpatialZones(ZONE_SET);
+    const renamed = { ...ZONE_SET, name: 'Sections' };
+    useViewerStore.setState({ zoneSets: [renamed] } as never);
+    assert.equal(removeZoneSpatialZones(renamed).removed, 2);
+    assert.equal(zoneEntities().length, 0);
   });
 });
 

--- a/apps/viewer/src/hooks/useZoneSpatialZones.ts
+++ b/apps/viewer/src/hooks/useZoneSpatialZones.ts
@@ -39,6 +39,7 @@ import { resolveEntityRef } from '@/store/resolveEntityRef';
 import { configureMutationView } from '@/utils/configureMutationView';
 import { geometryVolumesSurviveAlignment } from '@/lib/compare/alignmentTrust';
 import { resolveRenderFrame } from './useRenderFrameOffsets.js';
+import { collidesByName } from './useZoneWriteBack.js';
 import {
   emitSpatialZones,
   removeSpatialZones,
@@ -60,7 +61,7 @@ export interface ModelEmitOutcome {
 export interface ZoneEmitResult {
   models: ModelEmitOutcome[];
   /** Set when nothing was emitted anywhere, and why. */
-  blocked: 'collab-role' | 'no-members' | null;
+  blocked: 'collab-role' | 'no-members' | 'duplicate-set-name' | null;
   elapsedMs: number;
 }
 
@@ -133,6 +134,11 @@ function membersByModel(zoneSet: ZoneSet): Map<string, ZoneMembership[]> {
 export function emitZoneSpatialZones(zoneSet: ZoneSet): ZoneEmitResult {
   const state = useViewerStore.getState();
   if (!state.canCollabEdit()) return { models: [], blocked: 'collab-role', elapsedMs: 0 };
+  // The set's name is the only handle the FILE has on which run wrote which
+  // zones (`LongName`), so two sets sharing one would make each emission delete
+  // the other's zones. Refused for the same reason, and by the same test, as
+  // the write-back's own name collision.
+  if (collidesByName(zoneSet)) return { models: [], blocked: 'duplicate-set-name', elapsedMs: 0 };
 
   const t0 = performance.now();
   const byModel = membersByModel(zoneSet);
@@ -171,7 +177,7 @@ export function emitZoneSpatialZones(zoneSet: ZoneSet): ZoneEmitResult {
 export interface ZoneEmitRemoval {
   /** Zones removed, across every model. */
   removed: number;
-  blocked: 'collab-role' | null;
+  blocked: 'collab-role' | 'duplicate-set-name' | null;
 }
 
 /**
@@ -184,6 +190,9 @@ export interface ZoneEmitRemoval {
 export function removeZoneSpatialZones(zoneSet: ZoneSet): ZoneEmitRemoval {
   const state = useViewerStore.getState();
   if (!state.canCollabEdit()) return { removed: 0, blocked: 'collab-role' };
+  // Removal sweeps by name too, so a collision here would take the other set's
+  // zones with it.
+  if (collidesByName(zoneSet)) return { removed: 0, blocked: 'duplicate-set-name' };
 
   const contexts = new Map<string, ModelContext | null>();
   const touchedModels: string[] = [];

--- a/apps/viewer/src/hooks/useZoneSpatialZones.ts
+++ b/apps/viewer/src/hooks/useZoneSpatialZones.ts
@@ -64,6 +64,9 @@ export interface ModelEmitOutcome {
 
 export interface ZoneEmitResult {
   models: ModelEmitOutcome[];
+  /** Zones swept out of models this set no longer reaches at all. Counted
+   *  apart from `zonesReplaced`, which is a model that got new zones back. */
+  staleRemoved: number;
   /** Set when nothing was emitted anywhere, and why. */
   blocked: 'collab-role' | 'no-members' | 'duplicate-set-name' | null;
   elapsedMs: number;
@@ -164,22 +167,33 @@ function membersByModel(zoneSet: ZoneSet): Map<string, ZoneMembership[]> {
 /** Emit `zoneSet` into every model it reaches. */
 export function emitZoneSpatialZones(zoneSet: ZoneSet): ZoneEmitResult {
   const state = useViewerStore.getState();
-  if (!state.canCollabEdit()) return { models: [], blocked: 'collab-role', elapsedMs: 0 };
+  if (!state.canCollabEdit()) return { models: [], staleRemoved: 0, blocked: 'collab-role', elapsedMs: 0 };
   // The set's name is the only handle the FILE has on which run wrote which
   // zones (`LongName`), so two sets sharing one would make each emission delete
   // the other's zones. Refused for the same reason, and by the same test, as
   // the write-back's own name collision.
-  if (collidesByName(zoneSet)) return { models: [], blocked: 'duplicate-set-name', elapsedMs: 0 };
+  if (collidesByName(zoneSet)) return { models: [], staleRemoved: 0, blocked: 'duplicate-set-name', elapsedMs: 0 };
 
   const t0 = performance.now();
   const byModel = membersByModel(zoneSet);
-  if (byModel.size === 0) return { models: [], blocked: 'no-members', elapsedMs: performance.now() - t0 };
 
   // The scene-wide frame, resolved by the readouts' own rule, is only the
   // FALLBACK here: each model is written in its own frame (see `frameFor`).
   const scene = resolveRenderFrame(state.models, state.geometryResult);
 
   const contexts = new Map<string, ModelContext | null>();
+
+  // A model this set no longer reaches - every zone moved off it, or the set
+  // shrank - is not in `byModel` and so is never visited by the emit loop. Its
+  // zones from an earlier run would stay in its file forever, describing takt
+  // areas that no longer touch it. Swept FIRST, and unconditionally, so that
+  // holds even when nothing is left to emit anywhere.
+  const stale = sweepModelsWithoutMembers(zoneSet, byModel, contexts, scene);
+
+  if (byModel.size === 0) {
+    return { models: [], staleRemoved: stale, blocked: 'no-members', elapsedMs: performance.now() - t0 };
+  }
+
   const outcomes: ModelEmitOutcome[] = [];
   const touchedModels: string[] = [];
 
@@ -201,7 +215,31 @@ export function emitZoneSpatialZones(zoneSet: ZoneSet): ZoneEmitResult {
   }
 
   if (touchedModels.length > 0) useViewerStore.getState().markModelsDirty(touchedModels);
-  return { models: outcomes, blocked: null, elapsedMs: performance.now() - t0 };
+  return { models: outcomes, staleRemoved: stale, blocked: null, elapsedMs: performance.now() - t0 };
+}
+
+/** Take this set's zones out of every model it no longer reaches. Returns how
+ *  many zones went. */
+function sweepModelsWithoutMembers(
+  zoneSet: ZoneSet,
+  byModel: Map<string, ZoneMembership[]>,
+  contexts: Map<string, ModelContext | null>,
+  scene: RenderFrameOffsets,
+): number {
+  const state = useViewerStore.getState();
+  const touched: string[] = [];
+  let removed = 0;
+  for (const [modelId] of state.mutationViews) {
+    if (byModel.has(modelId)) continue;
+    const context = contextFor(modelId, contexts, scene);
+    if (!context) continue;
+    const count = removeSpatialZones(context.editor, zoneSet.name);
+    if (count === 0) continue;
+    removed += count;
+    touched.push(modelId);
+  }
+  if (touched.length > 0) state.markModelsDirty(touched);
+  return removed;
 }
 
 export interface ZoneEmitRemoval {

--- a/apps/viewer/src/hooks/useZoneSpatialZones.ts
+++ b/apps/viewer/src/hooks/useZoneSpatialZones.ts
@@ -16,8 +16,10 @@
  *
  * Zones are authored against the shared scene, so one set can reach elements in
  * several loaded models. There is no such thing as a federated IFC file, so
- * each model gets its OWN copy of the zones, referencing its own elements. The
- * copies agree because they are all built from the same world coordinates.
+ * each model gets its OWN copy of the zones, referencing its own elements -
+ * each converted out of the render frame by THAT model's own offsets, because
+ * an unaligned model is drawn in its own local frame rather than the anchor's
+ * (see {@link frameFor}).
  *
  * A model that federation alignment RE-BASED is refused rather than emitted
  * into: its render coordinates undo to the anchor file's coordinate system, so
@@ -35,6 +37,8 @@ import { useCallback } from 'react';
 import { MutablePropertyView, StoreEditor } from '@ifc-lite/mutations';
 import type { IfcDataStore } from '@ifc-lite/parser';
 import { useViewerStore } from '@/store';
+import type { FederatedModel } from '@/store/types';
+import type { RenderFrameOffsets } from '@/components/viewer/tools/measure-modes/coordinates';
 import { resolveEntityRef } from '@/store/resolveEntityRef';
 import { configureMutationView } from '@/utils/configureMutationView';
 import { geometryVolumesSurviveAlignment } from '@/lib/compare/alignmentTrust';
@@ -71,6 +75,28 @@ interface ModelContext {
   store: IfcDataStore;
   name: string;
   rebased: boolean;
+  /** THIS model's offsets, not the scene's. See {@link frameFor}. */
+  frame: RenderFrameOffsets;
+}
+
+/**
+ * The offsets to undo for one model's own coordinates.
+ *
+ * Per model rather than per scene, and the difference is not cosmetic. A
+ * federated model is only re-based into the anchor's frame when alignment
+ * SUCCEEDS: `'failed'` says so in as many words ("the model is shown in its own
+ * local frame"), and `'none'` never attempted it. Those models keep their own
+ * RTC offset and origin shift, so undoing the ANCHOR's offsets would move their
+ * zones by the difference between the two files' origins - which on a
+ * georeferenced pair is kilometres, and looks perfectly plausible in the file.
+ *
+ * The scene-wide frame remains the fallback for the legacy single-model path,
+ * where there is no per-model geometry result to read.
+ */
+function frameFor(model: FederatedModel | undefined, scene: RenderFrameOffsets): RenderFrameOffsets {
+  const info = model?.geometryResult?.coordinateInfo;
+  if (!info) return scene;
+  return { originShift: info.originShift ?? null, wasmRtcOffsetIfc: info.wasmRtcOffset ?? null };
 }
 
 /**
@@ -81,7 +107,11 @@ interface ModelContext {
  * view holds: two editors over one view are safe, but reusing the cached one
  * keeps that a fact rather than a thing to re-check.
  */
-function contextFor(modelId: string, cache: Map<string, ModelContext | null>): ModelContext | null {
+function contextFor(
+  modelId: string,
+  cache: Map<string, ModelContext | null>,
+  scene: RenderFrameOffsets,
+): ModelContext | null {
   const cached = cache.get(modelId);
   if (cached !== undefined) return cached;
 
@@ -110,6 +140,7 @@ function contextFor(modelId: string, cache: Map<string, ModelContext | null>): M
     store,
     name: model?.name ?? modelId,
     rebased: model ? !geometryVolumesSurviveAlignment(model.federationAlignmentStatus) : false,
+    frame: frameFor(model, scene),
   };
   cache.set(modelId, context);
   return context;
@@ -144,19 +175,18 @@ export function emitZoneSpatialZones(zoneSet: ZoneSet): ZoneEmitResult {
   const byModel = membersByModel(zoneSet);
   if (byModel.size === 0) return { models: [], blocked: 'no-members', elapsedMs: performance.now() - t0 };
 
-  // One frame for the whole scene, resolved by the readouts' own rule: the
-  // federation is aligned to the earliest-loaded model's frame at load, so that
-  // model's offsets are what every model on screen was drawn with.
-  const frame = resolveRenderFrame(state.models, state.geometryResult);
+  // The scene-wide frame, resolved by the readouts' own rule, is only the
+  // FALLBACK here: each model is written in its own frame (see `frameFor`).
+  const scene = resolveRenderFrame(state.models, state.geometryResult);
 
   const contexts = new Map<string, ModelContext | null>();
   const outcomes: ModelEmitOutcome[] = [];
   const touchedModels: string[] = [];
 
   for (const [modelId, members] of byModel) {
-    const context = contextFor(modelId, contexts);
+    const context = contextFor(modelId, contexts, scene);
     if (!context) continue;
-    const result = emitSpatialZones(context.editor, context.store, zoneSet, members, frame, {
+    const result = emitSpatialZones(context.editor, context.store, zoneSet, members, context.frame, {
       rebased: context.rebased,
     });
     outcomes.push({
@@ -197,8 +227,10 @@ export function removeZoneSpatialZones(zoneSet: ZoneSet): ZoneEmitRemoval {
   const contexts = new Map<string, ModelContext | null>();
   const touchedModels: string[] = [];
   let removed = 0;
+  // Removal reads no coordinates, so the frame it carries is irrelevant here.
+  const scene = resolveRenderFrame(state.models, state.geometryResult);
   for (const [modelId] of state.mutationViews) {
-    const context = contextFor(modelId, contexts);
+    const context = contextFor(modelId, contexts, scene);
     if (!context) continue;
     const count = removeSpatialZones(context.editor, zoneSet.name);
     if (count === 0) continue;

--- a/apps/viewer/src/hooks/useZoneSpatialZones.ts
+++ b/apps/viewer/src/hooks/useZoneSpatialZones.ts
@@ -233,7 +233,7 @@ function sweepModelsWithoutMembers(
     if (byModel.has(modelId)) continue;
     const context = contextFor(modelId, contexts, scene);
     if (!context) continue;
-    const count = removeSpatialZones(context.editor, zoneSet.name);
+    const count = removeSpatialZones(context.editor, zoneSet);
     if (count === 0) continue;
     removed += count;
     touched.push(modelId);
@@ -270,7 +270,7 @@ export function removeZoneSpatialZones(zoneSet: ZoneSet): ZoneEmitRemoval {
   for (const [modelId] of state.mutationViews) {
     const context = contextFor(modelId, contexts, scene);
     if (!context) continue;
-    const count = removeSpatialZones(context.editor, zoneSet.name);
+    const count = removeSpatialZones(context.editor, zoneSet);
     if (count === 0) continue;
     removed += count;
     touchedModels.push(modelId);

--- a/apps/viewer/src/hooks/useZoneSpatialZones.ts
+++ b/apps/viewer/src/hooks/useZoneSpatialZones.ts
@@ -1,0 +1,208 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Emit a zone set as `IfcSpatialZone` entities (issue #2508 item 3), so the
+ * zones themselves - not just the numbers about them - survive an export.
+ *
+ * The write-back (`useZoneWriteBack`) says how much of each ELEMENT is in each
+ * zone. This says what the ZONES ARE: named regions with a shape and a
+ * position, which a receiving tool can select, colour and filter by without
+ * parsing a property value. The two are complementary, and this deliberately
+ * does not replace either half.
+ *
+ * ## Per model, because a zone set spans a federation
+ *
+ * Zones are authored against the shared scene, so one set can reach elements in
+ * several loaded models. There is no such thing as a federated IFC file, so
+ * each model gets its OWN copy of the zones, referencing its own elements. The
+ * copies agree because they are all built from the same world coordinates.
+ *
+ * A model that federation alignment RE-BASED is refused rather than emitted
+ * into: its render coordinates undo to the anchor file's coordinate system, so
+ * the zone would be written into this file by someone else's origin. Same
+ * refusal, for the same reason, as the apportionment's `rescaled-by-alignment`.
+ *
+ * ## Why this does not enter the undo stack
+ *
+ * Like the write-back, it writes through each model's `MutablePropertyView`
+ * directly and commits one `markModelsDirty`. Its inverse is the panel's
+ * explicit Remove, which sweeps by the zone set's name.
+ */
+
+import { useCallback } from 'react';
+import { MutablePropertyView, StoreEditor } from '@ifc-lite/mutations';
+import type { IfcDataStore } from '@ifc-lite/parser';
+import { useViewerStore } from '@/store';
+import { resolveEntityRef } from '@/store/resolveEntityRef';
+import { configureMutationView } from '@/utils/configureMutationView';
+import { geometryVolumesSurviveAlignment } from '@/lib/compare/alignmentTrust';
+import { resolveRenderFrame } from './useRenderFrameOffsets.js';
+import {
+  emitSpatialZones,
+  removeSpatialZones,
+  type EmitRefusal,
+  type ZoneMembership,
+} from '@/lib/zones/emit-spatial-zones.js';
+import type { ZoneSet } from '@/lib/zones';
+
+/** What one model's emission did, named so the panel can say which model. */
+export interface ModelEmitOutcome {
+  modelId: string;
+  modelName: string;
+  zonesEmitted: number;
+  elementsReferenced: number;
+  zonesReplaced: number;
+  refusal: EmitRefusal | null;
+}
+
+export interface ZoneEmitResult {
+  models: ModelEmitOutcome[];
+  /** Set when nothing was emitted anywhere, and why. */
+  blocked: 'collab-role' | 'no-members' | null;
+  elapsedMs: number;
+}
+
+/** Per-model handles the loop would otherwise re-derive. */
+interface ModelContext {
+  editor: StoreEditor;
+  store: IfcDataStore;
+  name: string;
+  rebased: boolean;
+}
+
+/**
+ * Get-or-create a model's overlay AND its editor.
+ *
+ * The editor cache is the store's own (`storeEditors`), shared with the
+ * authoring actions, because express-id allocation runs off the watermark the
+ * view holds: two editors over one view are safe, but reusing the cached one
+ * keeps that a fact rather than a thing to re-check.
+ */
+function contextFor(modelId: string, cache: Map<string, ModelContext | null>): ModelContext | null {
+  const cached = cache.get(modelId);
+  if (cached !== undefined) return cached;
+
+  const state = useViewerStore.getState();
+  const model = state.models.get(modelId);
+  const store = (model?.ifcDataStore ?? (modelId === 'legacy' ? state.ifcDataStore : null)) as IfcDataStore | null;
+  if (!store) {
+    cache.set(modelId, null);
+    return null;
+  }
+
+  let view = state.getMutationView(modelId);
+  if (!view) {
+    view = new MutablePropertyView(store.properties || null, modelId);
+    configureMutationView(view, store);
+    state.registerMutationView(modelId, view);
+  }
+  let editor = state.storeEditors.get(modelId);
+  if (!editor) {
+    editor = new StoreEditor(store, view);
+    state.storeEditors.set(modelId, editor);
+  }
+
+  const context: ModelContext = {
+    editor,
+    store,
+    name: model?.name ?? modelId,
+    rebased: model ? !geometryVolumesSurviveAlignment(model.federationAlignmentStatus) : false,
+  };
+  cache.set(modelId, context);
+  return context;
+}
+
+/** The set's elements, grouped by the model whose file they live in. */
+function membersByModel(zoneSet: ZoneSet): Map<string, ZoneMembership[]> {
+  const byModel = new Map<string, ZoneMembership[]>();
+  for (const [globalId, record] of useViewerStore.getState().zoneAssignments) {
+    const assignment = record[zoneSet.id];
+    if (!assignment || assignment.touchedZoneIds.length === 0) continue;
+    const ref = resolveEntityRef(globalId);
+    const list = byModel.get(ref.modelId);
+    const member: ZoneMembership = { expressId: ref.expressId, touchedZoneIds: assignment.touchedZoneIds };
+    if (list) list.push(member);
+    else byModel.set(ref.modelId, [member]);
+  }
+  return byModel;
+}
+
+/** Emit `zoneSet` into every model it reaches. */
+export function emitZoneSpatialZones(zoneSet: ZoneSet): ZoneEmitResult {
+  const state = useViewerStore.getState();
+  if (!state.canCollabEdit()) return { models: [], blocked: 'collab-role', elapsedMs: 0 };
+
+  const t0 = performance.now();
+  const byModel = membersByModel(zoneSet);
+  if (byModel.size === 0) return { models: [], blocked: 'no-members', elapsedMs: performance.now() - t0 };
+
+  // One frame for the whole scene, resolved by the readouts' own rule: the
+  // federation is aligned to the earliest-loaded model's frame at load, so that
+  // model's offsets are what every model on screen was drawn with.
+  const frame = resolveRenderFrame(state.models, state.geometryResult);
+
+  const contexts = new Map<string, ModelContext | null>();
+  const outcomes: ModelEmitOutcome[] = [];
+  const touchedModels: string[] = [];
+
+  for (const [modelId, members] of byModel) {
+    const context = contextFor(modelId, contexts);
+    if (!context) continue;
+    const result = emitSpatialZones(context.editor, context.store, zoneSet, members, frame, {
+      rebased: context.rebased,
+    });
+    outcomes.push({
+      modelId,
+      modelName: context.name,
+      zonesEmitted: result.zonesEmitted,
+      elementsReferenced: result.elementsReferenced,
+      zonesReplaced: result.zonesReplaced,
+      refusal: result.refusal,
+    });
+    if (result.zonesEmitted > 0 || result.zonesReplaced > 0) touchedModels.push(modelId);
+  }
+
+  if (touchedModels.length > 0) useViewerStore.getState().markModelsDirty(touchedModels);
+  return { models: outcomes, blocked: null, elapsedMs: performance.now() - t0 };
+}
+
+export interface ZoneEmitRemoval {
+  /** Zones removed, across every model. */
+  removed: number;
+  blocked: 'collab-role' | null;
+}
+
+/**
+ * Remove the zones an emission wrote, from every model that has any.
+ *
+ * Sweeps every model with an overlay rather than only the ones the set
+ * currently reaches: a zone that has since moved off a model leaves its
+ * `IfcSpatialZone` behind, and that is exactly the copy nothing else clears.
+ */
+export function removeZoneSpatialZones(zoneSet: ZoneSet): ZoneEmitRemoval {
+  const state = useViewerStore.getState();
+  if (!state.canCollabEdit()) return { removed: 0, blocked: 'collab-role' };
+
+  const contexts = new Map<string, ModelContext | null>();
+  const touchedModels: string[] = [];
+  let removed = 0;
+  for (const [modelId] of state.mutationViews) {
+    const context = contextFor(modelId, contexts);
+    if (!context) continue;
+    const count = removeSpatialZones(context.editor, zoneSet.name);
+    if (count === 0) continue;
+    removed += count;
+    touchedModels.push(modelId);
+  }
+  if (touchedModels.length > 0) useViewerStore.getState().markModelsDirty(touchedModels);
+  return { removed, blocked: null };
+}
+
+/** React-facing handles. */
+export function useZoneSpatialZones() {
+  const emit = useCallback((zoneSet: ZoneSet) => emitZoneSpatialZones(zoneSet), []);
+  const remove = useCallback((zoneSet: ZoneSet) => removeZoneSpatialZones(zoneSet), []);
+  return { emit, remove };
+}

--- a/apps/viewer/src/hooks/useZoneWriteBack.ts
+++ b/apps/viewer/src/hooks/useZoneWriteBack.ts
@@ -81,7 +81,7 @@ export interface ZoneWriteBackResult {
  * either silently merging two takt plans or burying an id in the name a user
  * reads in another tool.
  */
-function collidesByName(zoneSet: ZoneSet): boolean {
+export function collidesByName(zoneSet: ZoneSet): boolean {
   return useViewerStore.getState().zoneSets
     .some((other) => other.id !== zoneSet.id && other.name.trim() === zoneSet.name.trim());
 }

--- a/apps/viewer/src/lib/zones/emit-spatial-zones.test.ts
+++ b/apps/viewer/src/lib/zones/emit-spatial-zones.test.ts
@@ -1,0 +1,111 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The FRAME half of `IfcSpatialZone` emission (#2508 item 3).
+ *
+ * The schema half is tested in `@ifc-lite/create`. What only the viewer can get
+ * wrong is which frame the numbers are in, and that failure is invisible in a
+ * shape check: a zone placed by the wrong origin is a valid IfcSpatialZone that
+ * sits somewhere else. So every assertion here is about WHERE the zone lands.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { zoneToIfcWorld } from './emit-spatial-zones.js';
+import type { Zone } from './types.js';
+
+const ZONE: Zone = {
+  id: 'z-a',
+  name: 'Takt A',
+  // Render frame: centre 2 m up, so the base is at y = 0.
+  center: [10, 2, 5],
+  size: [6, 4, 8],
+  rotationY: 0,
+};
+
+/** No shift at all: the identity case that isolates the axis swap. */
+const NO_SHIFT = {};
+
+describe('zoneToIfcWorld: axes', () => {
+  it('swaps Y-up to Z-up, and places the BASE rather than the centre', () => {
+    const out = zoneToIfcWorld(ZONE, NO_SHIFT);
+    // Viewer (x=10, y=0 base, z=5) -> IFC (x=10, y=-5, z=0).
+    assert.deepEqual(out.Position, [10, -5, 0]);
+    // An extruded solid grows along +Z from its placement, so handing it the
+    // centre would raise the zone by half its height.
+    assert.equal(out.Height, 4);
+  });
+
+  it('maps the horizontal extents to the axes they became', () => {
+    const out = zoneToIfcWorld(ZONE, NO_SHIFT);
+    assert.equal(out.Width, 6);   // render X stays X
+    assert.equal(out.Depth, 8);   // render Z becomes IFC Y
+  });
+});
+
+describe('zoneToIfcWorld: the render shift', () => {
+  it('adds back the wasm RTC offset, which is recorded in IFC axes', () => {
+    // The RTC offset is subtracted by the wasm mesh pass and recorded Z-up,
+    // unlike the origin shift. Adding the two in the same axes would fold a
+    // model's north offset into its height, which is why this goes through
+    // `renderToWorldViewer` rather than a hand-rolled add.
+    const out = zoneToIfcWorld(ZONE, { wasmRtcOffsetIfc: { x: 1000, y: 2000, z: 3 } });
+    assert.deepEqual(out.Position, [1010, 1995, 3]);
+  });
+
+  it('adds back the origin shift, which is recorded in renderer axes', () => {
+    const out = zoneToIfcWorld(ZONE, { originShift: { x: 1, y: 2, z: 3 } });
+    // Viewer base (11, 2, 8) -> IFC (11, -8, 2).
+    assert.deepEqual(out.Position, [11, -8, 2]);
+  });
+
+  it('applies BOTH shifts, each in its own axes', () => {
+    const out = zoneToIfcWorld(ZONE, {
+      originShift: { x: 1, y: 2, z: 3 },
+      wasmRtcOffsetIfc: { x: 100, y: 200, z: 300 },
+    });
+    // Worked by hand, because this is the assertion that would otherwise just
+    // echo whatever the code does: base (10, 0, 5) + originShift (1, 2, 3) in
+    // renderer axes + RTC (100, 200, 300) converted to renderer axes
+    // (100, 300, -200) = (111, 302, -192), which swaps to (111, 192, 302).
+    // A far-from-origin model is exactly the case where getting this wrong is
+    // invisible on screen and catastrophic in the file.
+    assert.deepEqual(out.Position, [111, 192, 302]);
+  });
+});
+
+describe('zoneToIfcWorld: rotation', () => {
+  it('flips the sign, because the axis swap mirrors the horizontal plane', () => {
+    const out = zoneToIfcWorld({ ...ZONE, rotationY: Math.PI / 4 }, NO_SHIFT);
+    assert.equal(out.RotationZ, 0 - Math.PI / 4);
+  });
+
+  it('emits no rotation for a prism, whose footprint is already world-aligned', () => {
+    const out = zoneToIfcWorld(
+      { ...ZONE, rotationY: 1.2, footprint: [[0, 0], [6, 0], [6, 8]] },
+      NO_SHIFT,
+    );
+    assert.equal(out.RotationZ, 0);
+  });
+});
+
+describe('zoneToIfcWorld: prisms', () => {
+  it('carries the footprint through the same shift and swap as the position', () => {
+    const out = zoneToIfcWorld(
+      { ...ZONE, footprint: [[10, 5], [16, 5], [16, 13]] },
+      { originShift: { x: 1, y: 0, z: 0 } },
+    );
+    assert.ok(out.Footprint);
+    // Each render X/Z pair becomes an IFC X/Y pair, shifted: x + 1, y = -z.
+    assert.deepEqual(out.Footprint, [[11, -5], [17, -5], [17, -13]]);
+  });
+
+  it('drops a footprint too small to be a polygon rather than emitting one', () => {
+    const out = zoneToIfcWorld({ ...ZONE, footprint: [[0, 0], [1, 0]] }, NO_SHIFT);
+    assert.equal(out.Footprint, undefined);
+    // ...and falls back to the box extents, so the zone still has a shape.
+    assert.equal(out.Width, 6);
+  });
+});

--- a/apps/viewer/src/lib/zones/emit-spatial-zones.test.ts
+++ b/apps/viewer/src/lib/zones/emit-spatial-zones.test.ts
@@ -103,9 +103,13 @@ describe('zoneToIfcWorld: prisms', () => {
   });
 
   it('drops a footprint too small to be a polygon rather than emitting one', () => {
-    const out = zoneToIfcWorld({ ...ZONE, footprint: [[0, 0], [1, 0]] }, NO_SHIFT);
+    const out = zoneToIfcWorld({ ...ZONE, rotationY: 1.2, footprint: [[0, 0], [1, 0]] }, NO_SHIFT);
     assert.equal(out.Footprint, undefined);
     // ...and falls back to the box extents, so the zone still has a shape.
     assert.equal(out.Width, 6);
+    // ...INCLUDING its rotation. Deciding the shape and the rotation from two
+    // different predicates put an axis-aligned zone where a turned one was
+    // drawn, which is a wrong zone that looks like a right one.
+    assert.equal(out.RotationZ, 0 - 1.2);
   });
 });

--- a/apps/viewer/src/lib/zones/emit-spatial-zones.ts
+++ b/apps/viewer/src/lib/zones/emit-spatial-zones.ts
@@ -71,7 +71,7 @@ export type EmitRefusal =
    *  A zone still needs a body context for its shape even though it is placed
    *  absolutely and contained by nothing. */
   | 'no-anchor'
-  /** A zone in the set has no height (or a non-finite one), which would emit a
+  /** A zone in the set has a zero or non-finite extent, which would emit a
    *  degenerate solid. Refused for the WHOLE set rather than per zone: the
    *  builder emits zone by zone, so stopping halfway would leave one takt area
    *  in the file and the rest not. */
@@ -98,7 +98,7 @@ export function emitRefusalText(refusal: EmitRefusal, modelName: string): string
     case 'no-anchor':
       return `${modelName} has no storey or representation context to anchor zones against`;
     case 'degenerate-zone':
-      return 'A zone in this set has no height, so nothing was emitted. Give it one and try again.';
+      return 'A zone in this set has a zero extent, so nothing was emitted. Give it a real size and try again.';
   }
 }
 
@@ -119,6 +119,12 @@ export function zoneToIfcWorld(zone: Zone, frame: RenderFrameOffsets): SpatialZo
     return [p.x, p.y];
   });
 
+  // ONE predicate for both halves of the decision. Keying the rotation off "has
+  // a footprint" and the shape off "has three points" would, for a footprint
+  // too small to be a polygon, emit the box fallback with the rotation thrown
+  // away - an axis-aligned zone where the user drew a turned one.
+  const usePolygon = footprint !== undefined && footprint.length >= 3;
+
   return {
     Name: zone.name,
     // The base, not the centre: an extruded solid grows along +Z from its
@@ -130,9 +136,10 @@ export function zoneToIfcWorld(zone: Zone, frame: RenderFrameOffsets): SpatialZo
     Height: zone.size[1],
     // The viewer rotates about its Y, the file about its Z, and the axis swap
     // above turns one into the other. The SIGN flips with it: viewer +Y and IFC
-    // +Z point the same way, but the swap mirrors the horizontal plane.
-    RotationZ: zone.footprint ? 0 : 0 - zone.rotationY,
-    ...(footprint && footprint.length >= 3 ? { Footprint: footprint } : {}),
+    // +Z point the same way, but the swap mirrors the horizontal plane. A
+    // polygon needs none of this: its points are already world-aligned.
+    RotationZ: usePolygon ? 0 : 0 - zone.rotationY,
+    ...(usePolygon ? { Footprint: footprint } : {}),
   };
 }
 
@@ -168,8 +175,10 @@ export function emitSpatialZones(
 
   // Checked for EVERY zone before the first is written. The builder refuses a
   // degenerate zone by throwing, and it emits zone by zone, so validating as it
-  // goes would leave the file holding whichever takt areas came first.
-  if (zoneSet.zones.some((zone) => !(Number.isFinite(zone.size[1]) && zone.size[1] > 0))) {
+  // goes would leave the file holding whichever takt areas came first. All
+  // three extents, not just the height: a zero width emits a rectangle profile
+  // no reader can use, and the run would report success.
+  if (zoneSet.zones.some((zone) => zone.size.some((extent) => !(Number.isFinite(extent) && extent > 0)))) {
     return { ...empty, refusal: 'degenerate-zone' };
   }
 

--- a/apps/viewer/src/lib/zones/emit-spatial-zones.ts
+++ b/apps/viewer/src/lib/zones/emit-spatial-zones.ts
@@ -191,10 +191,11 @@ export function emitSpatialZones(
   // leave two `IfcSpatialZone` entities per zone in the same place, and the
   // second run's numbers would be indistinguishable from the first's in the
   // exported file. Same principle as the write-back's per-element sweep.
-  const zonesReplaced = removeSpatialZones(editor, zoneSet.name);
+  const zonesReplaced = removeSpatialZones(editor, zoneSet);
 
   const result = addSpatialZonesToStore(editor, anchor, {
     LongName: zoneSet.name,
+    Description: zoneSetMarker(zoneSet.id),
     zones: zoneSet.zones.map((zone) => zoneToIfcWorld(zone, frame)),
     RelatedElements: referenced,
   });
@@ -207,15 +208,37 @@ export function emitSpatialZones(
   };
 }
 
-/** Attribute index of `IfcSpatialZone.LongName`, which carries the zone SET's
- *  name and is what identifies one run's output. */
+/** `IfcRoot.Description`, where the emitting run stamps which zone SET the zone
+ *  belongs to. */
+const DESCRIPTION = 3;
+/** Attribute index of `IfcSpatialZone.LongName`, which carries the zone set's
+ *  NAME - readable, and not stable across a rename. */
 const LONG_NAME = 7;
 /** `IfcRelReferencedInSpatialStructure.RelatingStructure`. */
 const RELATING_STRUCTURE = 5;
 
 /**
- * Remove the zones one earlier run of `longName` emitted, and everything only
+ * What a zone's `Description` says about which set emitted it.
+ *
+ * The set's NAME is what a receiving tool reads in `LongName`, and a user can
+ * change it at any time; matching on it alone means a rename between two runs
+ * leaves the first run's zones behind for good. The set's ID never changes, so
+ * it goes in the file too - as a legible sentence rather than a bare uuid,
+ * because this is a field people read in a property panel.
+ */
+export function zoneSetMarker(zoneSetId: string): string {
+  return `IfcLite zone set ${zoneSetId}`;
+}
+
+/**
+ * Remove the zones an earlier run of this set emitted, and everything only
  * those zones referred to.
+ *
+ * A zone is this set's if its `Description` carries the set's ID, whatever the
+ * set is CALLED now. Zones with no marker at all - emitted by a build older
+ * than the marker - fall back to matching the current `LongName`, which is the
+ * best that can be done for them and is safe because two sets sharing a name
+ * are refused before either is written.
  *
  * Overlay-only, by construction: `editor.removeEntity` tombstones an entity
  * that exists in the FILE, so restricting the walk to entities this session
@@ -230,12 +253,17 @@ const RELATING_STRUCTURE = 5;
  * - they are the user's own elements, and one of them may itself be an overlay
  * entity the user authored this session.
  */
-export function removeSpatialZones(editor: StoreEditor, longName: string): number {
+export function removeSpatialZones(editor: StoreEditor, zoneSet: Pick<ZoneSet, 'id' | 'name'>): number {
   const overlay = new Map(editor.getNewEntities().map((e) => [e.expressId, e]));
+  const marker = zoneSetMarker(zoneSet.id);
   const zoneIds = new Set<number>();
   for (const entity of overlay.values()) {
     if (entity.type !== 'IfcSpatialZone') continue;
-    if (entity.attributes[LONG_NAME] !== longName) continue;
+    const description = entity.attributes[DESCRIPTION];
+    const mine = description === undefined || description === null
+      ? entity.attributes[LONG_NAME] === zoneSet.name
+      : description === marker;
+    if (!mine) continue;
     zoneIds.add(entity.expressId);
   }
   if (zoneIds.size === 0) return 0;

--- a/apps/viewer/src/lib/zones/emit-spatial-zones.ts
+++ b/apps/viewer/src/lib/zones/emit-spatial-zones.ts
@@ -70,7 +70,12 @@ export type EmitRefusal =
   /** The model has no storey, or no representation context, to anchor against.
    *  A zone still needs a body context for its shape even though it is placed
    *  absolutely and contained by nothing. */
-  | 'no-anchor';
+  | 'no-anchor'
+  /** A zone in the set has no height (or a non-finite one), which would emit a
+   *  degenerate solid. Refused for the WHOLE set rather than per zone: the
+   *  builder emits zone by zone, so stopping halfway would leave one takt area
+   *  in the file and the rest not. */
+  | 'degenerate-zone';
 
 export interface EmitResult {
   zonesEmitted: number;
@@ -92,6 +97,8 @@ export function emitRefusalText(refusal: EmitRefusal, modelName: string): string
       return `No element of ${modelName} is in a zone of this set`;
     case 'no-anchor':
       return `${modelName} has no storey or representation context to anchor zones against`;
+    case 'degenerate-zone':
+      return 'A zone in this set has no height, so nothing was emitted. Give it one and try again.';
   }
 }
 
@@ -158,6 +165,13 @@ export function emitSpatialZones(
     return { ...empty, refusal: 'no-anchor' };
   }
   if (!spatialZonesSupported(anchor.schema)) return { ...empty, refusal: 'schema-too-old' };
+
+  // Checked for EVERY zone before the first is written. The builder refuses a
+  // degenerate zone by throwing, and it emits zone by zone, so validating as it
+  // goes would leave the file holding whichever takt areas came first.
+  if (zoneSet.zones.some((zone) => !(Number.isFinite(zone.size[1]) && zone.size[1] > 0))) {
+    return { ...empty, refusal: 'degenerate-zone' };
+  }
 
   const referenced = zoneSet.zones.map((zone) =>
     members.filter((m) => m.touchedZoneIds.includes(zone.id)).map((m) => m.expressId));

--- a/apps/viewer/src/lib/zones/emit-spatial-zones.ts
+++ b/apps/viewer/src/lib/zones/emit-spatial-zones.ts
@@ -1,0 +1,265 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Turning a zone set into `IfcSpatialZone` entities (issue #2508 item 3).
+ *
+ * The emission itself is `@ifc-lite/create`'s `addSpatialZonesToStore`, which
+ * knows the schema and nothing about the viewer. This module owns the one thing
+ * only the viewer can answer: WHICH FRAME the numbers are in.
+ *
+ * ## The frame chain, which is the part that goes wrong quietly
+ *
+ * A zone is authored against the rendered scene, so its coordinates are in the
+ * render frame: Y-up, RTC-subtracted, unit-scaled to metres. An
+ * `IfcSpatialZone` has to land in the file's own frame: Z-up, un-shifted, in
+ * the file's declared length unit. Three separate conversions, and getting any
+ * one wrong produces a zone that is plausible and in the wrong place:
+ *
+ * 1. **Un-shift** with {@link renderToWorldViewer}, which adds back both the
+ *    wasm RTC offset and the coordinate handler's origin shift. Reusing
+ *    #2199's helper rather than re-deriving it: the two offsets are recorded in
+ *    DIFFERENT axes, and adding them in the same axes folds a model's north
+ *    offset into its height.
+ * 2. **Swap axes** with {@link viewerToIfcAxes} (Y-up to Z-up).
+ * 3. **Scale to native units**, which the builder does from the anchor rather
+ *    than this module, so there is one place that knows the file's unit.
+ *
+ * ## Why a re-based model is refused
+ *
+ * Federation alignment can re-base a model into the anchor file's frame
+ * (`'same-crs'` / `'reprojected'`). Undoing the render shift then yields
+ * coordinates in the ANCHOR's coordinate system, not in this model's own, so
+ * writing them into this model's file would place the zone by someone else's
+ * origin. That is the same condition the apportionment refuses as
+ * `'rescaled-by-alignment'`, refused here for the same reason.
+ */
+
+import {
+  addSpatialZonesToStore,
+  spatialZonesSupported,
+  resolveSpatialAnchor,
+  type SpatialZoneInput,
+} from '@ifc-lite/create';
+import type { IfcDataStore } from '@ifc-lite/parser';
+import type { StoreEditor } from '@ifc-lite/mutations';
+import {
+  renderToWorldViewer,
+  viewerToIfcAxes,
+  type RenderFrameOffsets,
+} from '@/components/viewer/tools/measure-modes/coordinates';
+import type { Zone, ZoneSet } from './types.js';
+
+/** One element's membership, as the assignment engine reports it. */
+export interface ZoneMembership {
+  /** Model-local expressId - the caller has already resolved the federated id. */
+  expressId: number;
+  /** Zone ids this element reaches, straddlers included. */
+  touchedZoneIds: string[];
+}
+
+export type EmitRefusal =
+  /** The file predates `IfcSpatialZone` (IFC2X3). */
+  | 'schema-too-old'
+  /** Federation alignment re-based this model, so the render frame is not
+   *  invertible back into its own coordinates. */
+  | 'rescaled-by-alignment'
+  /** No zone in the set has any elements, so there is nothing to reference. */
+  | 'no-members'
+  /** The model has no storey, or no representation context, to anchor against.
+   *  A zone still needs a body context for its shape even though it is placed
+   *  absolutely and contained by nothing. */
+  | 'no-anchor';
+
+export interface EmitResult {
+  zonesEmitted: number;
+  elementsReferenced: number;
+  /** Zones from an earlier run of this set that this one replaced. */
+  zonesReplaced: number;
+  refusal: EmitRefusal | null;
+}
+
+/** Why one model got no zones, as a sentence rather than a code. Kept beside
+ *  the refusals so a new one cannot be added without a way to say it. */
+export function emitRefusalText(refusal: EmitRefusal, modelName: string): string {
+  switch (refusal) {
+    case 'schema-too-old':
+      return `${modelName} is IFC2X3, which has no IfcSpatialZone`;
+    case 'rescaled-by-alignment':
+      return `${modelName} was re-based to align with another model, so its own coordinates cannot be recovered`;
+    case 'no-members':
+      return `No element of ${modelName} is in a zone of this set`;
+    case 'no-anchor':
+      return `${modelName} has no storey or representation context to anchor zones against`;
+  }
+}
+
+/** Render-frame zone to IFC-world zone. Exported for the frame test: this is
+ *  the conversion, and it is worth pinning apart from the emission. */
+export function zoneToIfcWorld(zone: Zone, frame: RenderFrameOffsets): SpatialZoneInput {
+  const base = renderToWorldViewer(
+    { x: zone.center[0], y: zone.center[1] - zone.size[1] / 2, z: zone.center[2] },
+    frame,
+  );
+  const ifcBase = viewerToIfcAxes(base);
+
+  const footprint = zone.footprint?.map(([x, z]): [number, number] => {
+    // A footprint point is a render-frame X/Z pair at no particular height, so
+    // it rides through the same un-shift at the zone's own base height. Only
+    // the horizontal components are kept: the extrusion supplies the rest.
+    const p = viewerToIfcAxes(renderToWorldViewer({ x, y: zone.center[1], z }, frame));
+    return [p.x, p.y];
+  });
+
+  return {
+    Name: zone.name,
+    // The base, not the centre: an extruded solid grows along +Z from its
+    // placement, so handing it the centre would raise the zone by half its
+    // height.
+    Position: [ifcBase.x, ifcBase.y, ifcBase.z],
+    Width: zone.size[0],
+    Depth: zone.size[2],
+    Height: zone.size[1],
+    // The viewer rotates about its Y, the file about its Z, and the axis swap
+    // above turns one into the other. The SIGN flips with it: viewer +Y and IFC
+    // +Z point the same way, but the swap mirrors the horizontal plane.
+    RotationZ: zone.footprint ? 0 : 0 - zone.rotationY,
+    ...(footprint && footprint.length >= 3 ? { Footprint: footprint } : {}),
+  };
+}
+
+/**
+ * Emit `zoneSet` into `store`'s overlay as `IfcSpatialZone` entities.
+ *
+ * Returns what it did, or which condition stopped it. Never throws for a
+ * refusable condition: the panel turns each into a sentence.
+ */
+export function emitSpatialZones(
+  editor: StoreEditor,
+  store: IfcDataStore,
+  zoneSet: ZoneSet,
+  members: ZoneMembership[],
+  frame: RenderFrameOffsets,
+  options: { rebased?: boolean; storeyId?: number } = {},
+): EmitResult {
+  const empty = { zonesEmitted: 0, elementsReferenced: 0, zonesReplaced: 0 };
+  if (options.rebased) return { ...empty, refusal: 'rescaled-by-alignment' };
+
+  const storeyId = options.storeyId ?? firstStoreyId(store);
+  if (storeyId === null) return { ...empty, refusal: 'no-anchor' };
+  let anchor;
+  try {
+    anchor = resolveSpatialAnchor(store, storeyId);
+  } catch {
+    // Thrown for a model with no representation context or an unplaced storey.
+    // A refusal the panel can put in a sentence beats an exception from a
+    // button press.
+    return { ...empty, refusal: 'no-anchor' };
+  }
+  if (!spatialZonesSupported(anchor.schema)) return { ...empty, refusal: 'schema-too-old' };
+
+  const referenced = zoneSet.zones.map((zone) =>
+    members.filter((m) => m.touchedZoneIds.includes(zone.id)).map((m) => m.expressId));
+  const total = referenced.reduce((sum, ids) => sum + ids.length, 0);
+  if (total === 0) return { ...empty, refusal: 'no-members' };
+
+  // Replace rather than accumulate. Pressing the button twice would otherwise
+  // leave two `IfcSpatialZone` entities per zone in the same place, and the
+  // second run's numbers would be indistinguishable from the first's in the
+  // exported file. Same principle as the write-back's per-element sweep.
+  const zonesReplaced = removeSpatialZones(editor, zoneSet.name);
+
+  const result = addSpatialZonesToStore(editor, anchor, {
+    LongName: zoneSet.name,
+    zones: zoneSet.zones.map((zone) => zoneToIfcWorld(zone, frame)),
+    referencedElements: referenced,
+  });
+
+  return {
+    zonesEmitted: result.zoneIds.length,
+    elementsReferenced: total,
+    zonesReplaced,
+    refusal: null,
+  };
+}
+
+/** Attribute index of `IfcSpatialZone.LongName`, which carries the zone SET's
+ *  name and is what identifies one run's output. */
+const LONG_NAME = 7;
+/** `IfcRelReferencedInSpatialStructure.RelatingStructure`. */
+const RELATING_STRUCTURE = 5;
+
+/**
+ * Remove the zones one earlier run of `longName` emitted, and everything only
+ * those zones referred to.
+ *
+ * Overlay-only, by construction: `editor.removeEntity` tombstones an entity
+ * that exists in the FILE, so restricting the walk to entities this session
+ * created is what keeps a re-import of a previous export from being gutted by a
+ * later run. Zones re-imported that way are left alone and would be duplicated;
+ * that is the honest limit of an overlay with no persistent identity.
+ *
+ * The walk follows references OUT of a zone and no further, which is safe
+ * because every entity the builder emits per zone belongs to that zone alone:
+ * the anchor's context and owner history are file entities, so the walk stops
+ * at them. The relationship's `RelatedElements` are deliberately NOT traversed
+ * - they are the user's own elements, and one of them may itself be an overlay
+ * entity the user authored this session.
+ */
+export function removeSpatialZones(editor: StoreEditor, longName: string): number {
+  const overlay = new Map(editor.getNewEntities().map((e) => [e.expressId, e]));
+  const zoneIds = new Set<number>();
+  for (const entity of overlay.values()) {
+    if (entity.type !== 'IfcSpatialZone') continue;
+    if (entity.attributes[LONG_NAME] !== longName) continue;
+    zoneIds.add(entity.expressId);
+  }
+  if (zoneIds.size === 0) return 0;
+
+  const doomed = new Set<number>(zoneIds);
+  const queue = [...zoneIds];
+  while (queue.length > 0) {
+    const entity = overlay.get(queue.pop() as number);
+    if (!entity) continue;
+    for (const ref of refsOf(entity.attributes)) {
+      // Only overlay entities: a `#N` pointing into the file is an anchor
+      // reference, and deleting it would tombstone part of the model.
+      if (!overlay.has(ref) || doomed.has(ref)) continue;
+      doomed.add(ref);
+      queue.push(ref);
+    }
+  }
+
+  for (const entity of overlay.values()) {
+    if (entity.type !== 'IfcRelReferencedInSpatialStructure') continue;
+    const structure = entity.attributes[RELATING_STRUCTURE];
+    if (typeof structure === 'string' && zoneIds.has(Number(structure.slice(1)))) {
+      doomed.add(entity.expressId);
+    }
+  }
+
+  for (const id of doomed) editor.removeEntity(id);
+  return zoneIds.size;
+}
+
+/** Every `#N` an attribute list points at, one level deep, flattening lists. */
+function refsOf(attributes: readonly unknown[]): number[] {
+  const out: number[] = [];
+  for (const attribute of attributes) {
+    for (const value of Array.isArray(attribute) ? attribute : [attribute]) {
+      if (typeof value !== 'string' || !value.startsWith('#')) continue;
+      const id = Number(value.slice(1));
+      if (Number.isInteger(id)) out.push(id);
+    }
+  }
+  return out;
+}
+
+/** The anchor needs a storey for its owner history and body context; any storey
+ *  serves, since the zones themselves are placed absolutely and referenced
+ *  rather than contained. */
+function firstStoreyId(store: IfcDataStore): number | null {
+  const storeys = store.entityIndex.byType?.get('IFCBUILDINGSTOREY');
+  return storeys && storeys.length > 0 ? storeys[0] : null;
+}

--- a/apps/viewer/src/lib/zones/emit-spatial-zones.ts
+++ b/apps/viewer/src/lib/zones/emit-spatial-zones.ts
@@ -196,7 +196,7 @@ export function emitSpatialZones(
   const result = addSpatialZonesToStore(editor, anchor, {
     LongName: zoneSet.name,
     zones: zoneSet.zones.map((zone) => zoneToIfcWorld(zone, frame)),
-    referencedElements: referenced,
+    RelatedElements: referenced,
   });
 
   return {

--- a/apps/viewer/src/lib/zones/index.ts
+++ b/apps/viewer/src/lib/zones/index.ts
@@ -108,3 +108,13 @@ export {
   type QuantityLike,
   type QuantitySetLike,
 } from './volume-basis.js';
+
+export {
+  emitSpatialZones,
+  emitRefusalText,
+  removeSpatialZones,
+  zoneToIfcWorld,
+  type EmitRefusal,
+  type EmitResult,
+  type ZoneMembership,
+} from './emit-spatial-zones.js';

--- a/docs/design/zone-emission.md
+++ b/docs/design/zone-emission.md
@@ -1,9 +1,10 @@
 # Emitting location zones as IFC entities (design)
 
-**Status:** decided, partly built. The property/quantity write-back ships
-(#2508 item 3b). `IfcZone` emission is **refused** on schema grounds.
-`IfcSpatialZone` is the correct vehicle for the zone boxes themselves and is
-deferred to its own PR, with the shape below.
+**Status:** decided and built. The property/quantity write-back ships (#2508
+item 3b), and so does the `IfcSpatialZone` emission this document argued for:
+`packages/create/src/in-store/spatial-zone.ts` for the schema half,
+`apps/viewer/src/lib/zones/emit-spatial-zones.ts` for the frame half.
+`IfcZone` emission remains **refused** on schema grounds.
 
 Issue #2508 asks the question rather than assuming the answer: "Whether
 user-drawn takt boxes *should* become `IfcZone` is a genuine modelling
@@ -84,17 +85,23 @@ is 40% in this zone*, which is the number #2508 exists to produce. So an
 replacement for it: the zone entity carries the region, the quantity set
 carries the split.
 
-### Why it is deferred rather than done here
+### Why it took its own PR
+
+Each of these was a reason to defer it, and each is now a property of what
+shipped:
 
 - It writes new **spatial** entities into someone else's model, which is a
-  heavier act than adding property sets, and needs its own review and its own
-  opt-in.
-- It needs a placement chain and a swept-solid or brep representation in IFC
-  **Z-up**, converted out of the viewer's Y-up frame, anchored on the site.
-  That is geometry authoring, not data authoring.
+  heavier act than adding property sets. So it is a separate, explicitly
+  labelled button, and its inverse removes exactly what it wrote.
+- It needs a placement chain and a swept-solid representation in IFC **Z-up**,
+  converted out of the viewer's Y-up frame. That conversion is the part only
+  the viewer can do, and it is the part that fails invisibly, so it lives in
+  one exported function with a test per shift
+  (`emit-spatial-zones.test.ts`). A model federation alignment re-based is
+  refused rather than written by another file's origin.
 - Zones change several times a week (property 3 above). Baking planning state
-  into the spatial structure of a design model is a decision a user should make
-  deliberately, on export, not as a side effect of drawing a box.
+  into a design model stays a deliberate act: nothing emits on load, on
+  assignment, or on export.
 
 ## What ships instead, and why it is the right default
 
@@ -108,17 +115,37 @@ The property and quantity write-back (#2508 item 3b,
 - lands in the one place every downstream tool already looks, which is what the
   reporter of #1763 was doing by hand in a spreadsheet.
 
-## If the `IfcSpatialZone` PR is written
-
-Sketch, so the next person does not re-derive it:
+## What the `IfcSpatialZone` emission does
 
 - One `IfcSpatialZone` per zone, `PredefinedType = CONSTRUCTION`, `LongName` =
-  the zone set's name, `Name` = the zone's name.
-- Placement relative to the site, representation as an extruded rectangle
-  profile carrying `rotationY` in the placement rather than in the profile.
+  the zone set's name, `Name` = the zone's name. **Nine** attributes, not ten:
+  the type derives from `IfcSpatialElement` rather than
+  `IfcSpatialStructureElement`, so it has no `CompositionType` - which is the
+  schema saying a zone is not part of the containment hierarchy.
+- An **absolute** placement (`PlacementRelTo = $`) rather than one chained to
+  the site: the zone's coordinates are world coordinates already, because the
+  mesh pipeline resolved every placement chain to world before the user drew
+  the box against it. Inverting that chain to recover a local offset would be
+  arithmetic with nothing to gain.
+- Representation as an extruded rectangle profile carrying `rotationY` in the
+  placement rather than in the profile, so a receiving tool reads a rectangle
+  as one. A prism zone emits its convex footprint as an
+  `IfcArbitraryClosedProfileDef`, with the points made relative to the
+  placement.
 - `IfcRelReferencedInSpatialStructure` per zone, listing every element the
   assignment says it touches (not just the elements whose home it is).
-- Aggregate the set's zones under one `IfcZone` **only** if every member is an
-  `IfcSpatialZone`, which is admissible and is the one legitimate use of
-  `IfcZone` here.
-- Emit alongside the property sets, never instead of them.
+- Emitted alongside the property sets, never instead of them.
+
+Not done, and deliberately: aggregating the set's zones under one `IfcZone`.
+That is admissible once every member is an `IfcSpatialZone`, and it is the one
+legitimate use of `IfcZone` here, but nothing yet asks for the extra grouping
+level.
+
+### The limit worth knowing
+
+A re-run replaces its own output by matching the zone set's **name**, because
+the file has no id to match on. Renaming a set between runs therefore leaves
+the previous run's zones in place, and removing them means removing under the
+old name. Zones from a re-imported earlier export are likewise left alone: the
+sweep only touches entities this session created, which is what keeps it from
+gutting a model that already contains zones.

--- a/docs/design/zone-emission.md
+++ b/docs/design/zone-emission.md
@@ -127,9 +127,10 @@ The property and quantity write-back (#2508 item 3b,
   mesh pipeline resolved every placement chain to world before the user drew
   the box against it. Inverting that chain to recover a local offset would be
   arithmetic with nothing to gain.
-- Representation as an extruded rectangle profile carrying `rotationY` in the
-  placement rather than in the profile, so a receiving tool reads a rectangle
-  as one. A prism zone emits its convex footprint as an
+- Representation as an extruded rectangle profile carrying the zone's rotation
+  in the placement rather than in the profile, so a receiving tool reads a
+  rectangle as one. The viewer's `rotationY` becomes `RotationZ` on the way in:
+  the output is Z-up, and the axis swap flips the sign with it. A prism zone emits its convex footprint as an
   `IfcArbitraryClosedProfileDef`, with the points made relative to the
   placement.
 - `IfcRelReferencedInSpatialStructure` per zone, listing every element the

--- a/docs/design/zone-emission.md
+++ b/docs/design/zone-emission.md
@@ -142,11 +142,15 @@ That is admissible once every member is an `IfcSpatialZone`, and it is the one
 legitimate use of `IfcZone` here, but nothing yet asks for the extra grouping
 level.
 
-### The limit worth knowing
+### How a re-run finds its own zones
 
-A re-run replaces its own output by matching the zone set's **name**, because
-the file has no id to match on. Renaming a set between runs therefore leaves
-the previous run's zones in place, and removing them means removing under the
-old name. Zones from a re-imported earlier export are likewise left alone: the
-sweep only touches entities this session created, which is what keeps it from
-gutting a model that already contains zones.
+Each emitted zone carries `IfcRoot.Description = "IfcLite zone set <id>"`, the
+zone set's stable id. A re-run sweeps by that rather than by the set's name, so
+renaming a set between runs replaces its zones instead of leaving a second,
+obsolete copy under the old name. The name still goes in `LongName`, which is
+what a receiving tool shows.
+
+The limit that remains: the sweep only touches entities THIS SESSION created.
+Zones from a re-imported earlier export are left alone and would be duplicated,
+which is what keeps a later run from gutting a model that already contains
+zones.

--- a/packages/create/src/in-store/spatial-zone.test.ts
+++ b/packages/create/src/in-store/spatial-zone.test.ts
@@ -1,0 +1,230 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `IfcSpatialZone` emission (#2508 item 3).
+ *
+ * The assertions that matter here are the SCHEMA ones, because the whole
+ * argument for this type over `IfcZone` rests on them: nine attributes rather
+ * than ten (no `CompositionType`, since a zone is not part of the containment
+ * hierarchy), and elements attached by REFERENCE rather than by containment.
+ * A test that only checked "an entity was emitted" would pass on the very
+ * shape `docs/design/zone-emission.md` argues against.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  MutablePropertyView,
+  StoreEditor,
+  type MutationEntityRef,
+  type MutationStoreShape,
+} from '@ifc-lite/mutations';
+import { addSpatialZonesToStore, spatialZonesSupported } from './spatial-zone.js';
+import type { SpatialAnchor } from './anchor.js';
+
+function makeStore(maxId: number): MutationStoreShape {
+  const byId = new Map<number, MutationEntityRef>();
+  for (let id = 1; id <= maxId; id++) {
+    byId.set(id, { expressId: id, type: 'IFCDUMMY', byteOffset: 0, byteLength: 1, lineNumber: id });
+  }
+  return { entityIndex: { byId } };
+}
+
+const ANCHOR: SpatialAnchor = {
+  ownerHistoryId: 5,
+  bodyContextId: 14,
+  axisContextId: 15,
+  storeyId: 43,
+  storeyPlacementId: 54,
+};
+
+function session(anchor: SpatialAnchor = ANCHOR) {
+  const view = new MutablePropertyView(null, 'm1');
+  const editor = new StoreEditor(makeStore(50), view);
+  return { view, editor, anchor };
+}
+
+const BOX = {
+  Name: 'Takt A',
+  Position: [10, 20, 0] as [number, number, number],
+  Width: 6,
+  Depth: 4,
+  Height: 3,
+};
+
+describe('addSpatialZonesToStore', () => {
+  it('emits an IfcSpatialZone with the NINE attributes the schema gives it', () => {
+    const { editor, view } = session();
+    const result = addSpatialZonesToStore(editor, ANCHOR, {
+      LongName: 'Takt areas',
+      zones: [BOX],
+      referencedElements: [[]],
+    });
+
+    const zone = view.getNewEntities().find((e) => e.expressId === result.zoneIds[0]);
+    expect(zone?.type).toBe('IfcSpatialZone');
+    // Nine, not ten: `IfcSpatialZone` derives from `IfcSpatialElement`, not
+    // `IfcSpatialStructureElement`, so there is no `CompositionType`. Emitting
+    // a tenth would produce a record no IFC4 reader can parse.
+    expect(zone?.attributes).toHaveLength(9);
+    expect(zone?.attributes[1]).toBe('#5');            // OwnerHistory
+    expect(zone?.attributes[2]).toBe('Takt A');        // Name = the zone
+    expect(zone?.attributes[7]).toBe('Takt areas');    // LongName = the set
+    expect(zone?.attributes[8]).toBe('.CONSTRUCTION.'); // PredefinedType
+  });
+
+  it('attaches elements by REFERENCE, never by containment', () => {
+    // The distinction the whole design rests on: containment is exclusive, so
+    // re-pointing it would move the element out of the storey that owns it.
+    const { editor, view } = session();
+    const result = addSpatialZonesToStore(editor, ANCHOR, {
+      LongName: 'Takt areas',
+      zones: [BOX],
+      referencedElements: [[11, 22, 33]],
+    });
+
+    const entities = view.getNewEntities();
+    expect(entities.some((e) => e.type === 'IfcRelContainedInSpatialStructure')).toBe(false);
+
+    const rel = entities.find((e) => e.expressId === result.relReferencedIds[0]);
+    expect(rel?.type).toBe('IfcRelReferencedInSpatialStructure');
+    expect(rel?.attributes[4]).toEqual(['#11', '#22', '#33']);  // RelatedElements
+    expect(rel?.attributes[5]).toBe(`#${result.zoneIds[0]}`);   // RelatingStructure
+  });
+
+  it('lets one element belong to every zone it crosses', () => {
+    // A straddler is referenced twice. That is legal precisely because
+    // referencing is many-to-many, and it is the truthful topology.
+    const { editor, view } = session();
+    const result = addSpatialZonesToStore(editor, ANCHOR, {
+      LongName: 'Takt areas',
+      zones: [BOX, { ...BOX, Name: 'Takt B', Position: [16, 20, 0] }],
+      referencedElements: [[77], [77]],
+    });
+
+    expect(result.zoneIds).toHaveLength(2);
+    const rels = view.getNewEntities().filter((e) => e.type === 'IfcRelReferencedInSpatialStructure');
+    expect(rels).toHaveLength(2);
+    expect(rels.every((r) => (r.attributes[4] as string[]).includes('#77'))).toBe(true);
+  });
+
+  it('emits no relationship for a zone nothing touches', () => {
+    const { editor, view } = session();
+    addSpatialZonesToStore(editor, ANCHOR, {
+      LongName: 'Takt areas',
+      zones: [BOX],
+      referencedElements: [[]],
+    });
+    expect(view.getNewEntities().some((e) => e.type === 'IfcRelReferencedInSpatialStructure')).toBe(false);
+  });
+
+  it('converts every dimension into the file\'s native length unit', () => {
+    // A millimetre file. Emitting metres here is the #2508 write-back's own
+    // failure mode in geometric form: a zone a thousand times too small.
+    const { editor, view } = session({ ...ANCHOR, lengthUnitScale: 0.001 });
+    const result = addSpatialZonesToStore(editor, { ...ANCHOR, lengthUnitScale: 0.001 }, {
+      LongName: 'Takt areas',
+      zones: [BOX],
+      referencedElements: [[]],
+    });
+
+    const entities = view.getNewEntities();
+    const zone = entities.find((e) => e.expressId === result.zoneIds[0]);
+    const placement = entities.find((e) => `#${e.expressId}` === zone?.attributes[5]);
+    const axis = entities.find((e) => `#${e.expressId}` === placement?.attributes[1]);
+    const origin = entities.find((e) => `#${e.expressId}` === axis?.attributes[0]);
+    expect(origin?.attributes[0]).toEqual([10000, 20000, 0]);
+
+    const profile = entities.find((e) => e.type === 'IfcRectangleProfileDef');
+    expect(profile?.attributes[3]).toBe(6000);
+    expect(profile?.attributes[4]).toBe(4000);
+    const solid = entities.find((e) => e.type === 'IfcExtrudedAreaSolid');
+    expect(solid?.attributes[3]).toBe(3000);
+  });
+
+  it('carries rotation in the placement, leaving the profile a plain rectangle', () => {
+    const { editor, view } = session();
+    const result = addSpatialZonesToStore(editor, ANCHOR, {
+      LongName: 'Takt areas',
+      zones: [{ ...BOX, RotationZ: Math.PI / 2 }],
+      referencedElements: [[]],
+    });
+
+    const entities = view.getNewEntities();
+    const zone = entities.find((e) => e.expressId === result.zoneIds[0]);
+    const placement = entities.find((e) => `#${e.expressId}` === zone?.attributes[5]);
+    const axis = entities.find((e) => `#${e.expressId}` === placement?.attributes[1]);
+    const refDir = entities.find((e) => `#${e.expressId}` === axis?.attributes[2]);
+    const dir = refDir?.attributes[0] as number[];
+    expect(Math.abs(dir[0] - 0)).toBeLessThan(1e-9);
+    expect(Math.abs(dir[1] - 1)).toBeLessThan(1e-9);
+
+    // Still a rectangle: a receiving tool reads the shape without unpicking a
+    // rotated polygon.
+    expect(entities.some((e) => e.type === 'IfcRectangleProfileDef')).toBe(true);
+  });
+
+  it('emits an unrotated placement with no RefDirection at all', () => {
+    const { editor, view } = session();
+    const result = addSpatialZonesToStore(editor, ANCHOR, {
+      LongName: 'Takt areas', zones: [BOX], referencedElements: [[]],
+    });
+    const entities = view.getNewEntities();
+    const zone = entities.find((e) => e.expressId === result.zoneIds[0]);
+    const placement = entities.find((e) => `#${e.expressId}` === zone?.attributes[5]);
+    const axis = entities.find((e) => `#${e.expressId}` === placement?.attributes[1]);
+    expect(axis?.attributes[2]).toBeNull();
+  });
+
+  it('places a prism by its polygon, relative to the placement rather than twice', () => {
+    // The footprint arrives in world coordinates and the placement already
+    // carries the position, so the points must be made relative. Emitting both
+    // absolute would put the zone at twice its coordinates.
+    const { editor, view } = session();
+    const result = addSpatialZonesToStore(editor, ANCHOR, {
+      LongName: 'Takt areas',
+      zones: [{ ...BOX, Footprint: [[10, 20], [16, 20], [16, 24]] }],
+      referencedElements: [[]],
+    });
+
+    const entities = view.getNewEntities();
+    const zone = entities.find((e) => e.expressId === result.zoneIds[0]);
+    const placement = entities.find((e) => `#${e.expressId}` === zone?.attributes[5]);
+    const axis = entities.find((e) => `#${e.expressId}` === placement?.attributes[1]);
+    const origin = entities.find((e) => `#${e.expressId}` === axis?.attributes[0]);
+    expect(origin?.attributes[0]).toEqual([10, 20, 0]);
+
+    expect(entities.some((e) => e.type === 'IfcArbitraryClosedProfileDef')).toBe(true);
+    expect(entities.some((e) => e.type === 'IfcRectangleProfileDef')).toBe(false);
+
+    const polyline = entities.find((e) => e.type === 'IfcPolyline');
+    const pointRefs = polyline?.attributes[0] as string[];
+    const points = pointRefs.map((ref) => entities.find((e) => `#${e.expressId}` === ref)?.attributes[0]);
+    // Relative to (10, 20), and closed back to the first point.
+    expect(points[0]).toEqual([0, 0]);
+    expect(points[1]).toEqual([6, 0]);
+    expect(points[2]).toEqual([6, 4]);
+    expect(points[3]).toEqual([0, 0]);
+  });
+
+  it('refuses IFC2X3, where the type does not exist', () => {
+    expect(spatialZonesSupported('IFC2X3')).toBe(false);
+    expect(spatialZonesSupported('IFC4')).toBe(true);
+    expect(spatialZonesSupported(undefined)).toBe(true);
+
+    const { editor } = session({ ...ANCHOR, schema: 'IFC2X3' });
+    expect(() => addSpatialZonesToStore(editor, { ...ANCHOR, schema: 'IFC2X3' }, {
+      LongName: 'Takt areas', zones: [BOX], referencedElements: [[]],
+    })).toThrow(/IFC4 or later/);
+  });
+
+  it('refuses a zone with no height rather than emitting a flat solid', () => {
+    const { editor } = session();
+    expect(() => addSpatialZonesToStore(editor, ANCHOR, {
+      LongName: 'Takt areas',
+      zones: [{ ...BOX, Height: 0 }],
+      referencedElements: [[]],
+    })).toThrow(/Height/);
+  });
+});

--- a/packages/create/src/in-store/spatial-zone.test.ts
+++ b/packages/create/src/in-store/spatial-zone.test.ts
@@ -59,7 +59,7 @@ describe('addSpatialZonesToStore', () => {
     const result = addSpatialZonesToStore(editor, ANCHOR, {
       LongName: 'Takt areas',
       zones: [BOX],
-      referencedElements: [[]],
+      RelatedElements: [[]],
     });
 
     const zone = view.getNewEntities().find((e) => e.expressId === result.zoneIds[0]);
@@ -81,7 +81,7 @@ describe('addSpatialZonesToStore', () => {
     const result = addSpatialZonesToStore(editor, ANCHOR, {
       LongName: 'Takt areas',
       zones: [BOX],
-      referencedElements: [[11, 22, 33]],
+      RelatedElements: [[11, 22, 33]],
     });
 
     const entities = view.getNewEntities();
@@ -100,7 +100,7 @@ describe('addSpatialZonesToStore', () => {
     const result = addSpatialZonesToStore(editor, ANCHOR, {
       LongName: 'Takt areas',
       zones: [BOX, { ...BOX, Name: 'Takt B', Position: [16, 20, 0] }],
-      referencedElements: [[77], [77]],
+      RelatedElements: [[77], [77]],
     });
 
     expect(result.zoneIds).toHaveLength(2);
@@ -114,7 +114,7 @@ describe('addSpatialZonesToStore', () => {
     addSpatialZonesToStore(editor, ANCHOR, {
       LongName: 'Takt areas',
       zones: [BOX],
-      referencedElements: [[]],
+      RelatedElements: [[]],
     });
     expect(view.getNewEntities().some((e) => e.type === 'IfcRelReferencedInSpatialStructure')).toBe(false);
   });
@@ -126,7 +126,7 @@ describe('addSpatialZonesToStore', () => {
     const result = addSpatialZonesToStore(editor, { ...ANCHOR, lengthUnitScale: 0.001 }, {
       LongName: 'Takt areas',
       zones: [BOX],
-      referencedElements: [[]],
+      RelatedElements: [[]],
     });
 
     const entities = view.getNewEntities();
@@ -148,7 +148,7 @@ describe('addSpatialZonesToStore', () => {
     const result = addSpatialZonesToStore(editor, ANCHOR, {
       LongName: 'Takt areas',
       zones: [{ ...BOX, RotationZ: Math.PI / 2 }],
-      referencedElements: [[]],
+      RelatedElements: [[]],
     });
 
     const entities = view.getNewEntities();
@@ -168,7 +168,7 @@ describe('addSpatialZonesToStore', () => {
   it('emits an unrotated placement with no RefDirection at all', () => {
     const { editor, view } = session();
     const result = addSpatialZonesToStore(editor, ANCHOR, {
-      LongName: 'Takt areas', zones: [BOX], referencedElements: [[]],
+      LongName: 'Takt areas', zones: [BOX], RelatedElements: [[]],
     });
     const entities = view.getNewEntities();
     const zone = entities.find((e) => e.expressId === result.zoneIds[0]);
@@ -185,7 +185,7 @@ describe('addSpatialZonesToStore', () => {
     const result = addSpatialZonesToStore(editor, ANCHOR, {
       LongName: 'Takt areas',
       zones: [{ ...BOX, Footprint: [[10, 20], [16, 20], [16, 24]] }],
-      referencedElements: [[]],
+      RelatedElements: [[]],
     });
 
     const entities = view.getNewEntities();
@@ -215,7 +215,7 @@ describe('addSpatialZonesToStore', () => {
 
     const { editor } = session({ ...ANCHOR, schema: 'IFC2X3' });
     expect(() => addSpatialZonesToStore(editor, { ...ANCHOR, schema: 'IFC2X3' }, {
-      LongName: 'Takt areas', zones: [BOX], referencedElements: [[]],
+      LongName: 'Takt areas', zones: [BOX], RelatedElements: [[]],
     })).toThrow(/IFC4 or later/);
   });
 
@@ -227,7 +227,7 @@ describe('addSpatialZonesToStore', () => {
     expect(() => addSpatialZonesToStore(editor, ANCHOR, {
       LongName: 'Takt areas',
       zones: [{ ...BOX, Footprint: [[0, 0], [1, 0]] }],
-      referencedElements: [[]],
+      RelatedElements: [[]],
     })).toThrow(/fewer than 3 points/);
   });
 
@@ -239,7 +239,7 @@ describe('addSpatialZonesToStore', () => {
       expect(() => addSpatialZonesToStore(editor, ANCHOR, {
         LongName: 'Takt areas',
         zones: [{ ...BOX, ...bad }],
-        referencedElements: [[]],
+        RelatedElements: [[]],
       })).toThrow(/finite positive (Width|Depth)/);
     }
   });
@@ -251,9 +251,61 @@ describe('addSpatialZonesToStore', () => {
     addSpatialZonesToStore(editor, ANCHOR, {
       LongName: 'Takt areas',
       zones: [{ ...BOX, Width: 0, Depth: 0, Footprint: [[10, 20], [16, 20], [16, 24]] }],
-      referencedElements: [[]],
+      RelatedElements: [[]],
     });
     expect(view.getNewEntities().some((e) => e.type === 'IfcArbitraryClosedProfileDef')).toBe(true);
+  });
+
+  it('writes NOTHING when a later zone is invalid', () => {
+    // The one that makes prevalidation worth having: a caller told the call
+    // failed, with the first zone already in the overlay, has a half-built
+    // takt plan and no way to know it.
+    const { editor, view } = session();
+    expect(() => addSpatialZonesToStore(editor, ANCHOR, {
+      LongName: 'Takt areas',
+      zones: [BOX, { ...BOX, Name: 'Takt B', Height: 0 }],
+      RelatedElements: [[], []],
+    })).toThrow(/Height/);
+    expect(view.getNewEntities()).toHaveLength(0);
+  });
+
+  it('refuses a PredefinedType outside IfcSpatialZoneTypeEnum', () => {
+    const { editor } = session();
+    expect(() => addSpatialZonesToStore(editor, ANCHOR, {
+      LongName: 'Takt areas',
+      zones: [BOX],
+      RelatedElements: [[]],
+      PredefinedType: 'TAKT' as never,
+    })).toThrow(/IfcSpatialZoneTypeEnum/);
+  });
+
+  it('requires ObjectType with USERDEFINED, and writes it', () => {
+    // IFC4's `CorrectPredefinedType`: USERDEFINED means the type is named in
+    // ObjectType, so emitting `$` there is a file that breaks the rule.
+    const { editor, view } = session();
+    expect(() => addSpatialZonesToStore(editor, ANCHOR, {
+      LongName: 'Takt areas', zones: [BOX], RelatedElements: [[]], PredefinedType: 'USERDEFINED',
+    })).toThrow(/ObjectType/);
+
+    const result = addSpatialZonesToStore(editor, ANCHOR, {
+      LongName: 'Takt areas',
+      zones: [BOX],
+      RelatedElements: [[]],
+      PredefinedType: 'USERDEFINED',
+      ObjectType: 'Takt area',
+    });
+    const zone = view.getNewEntities().find((e) => e.expressId === result.zoneIds[0]);
+    expect(zone?.attributes[4]).toBe('Takt area');
+    expect(zone?.attributes[8]).toBe('.USERDEFINED.');
+  });
+
+  it('refuses a non-finite Position rather than emitting NaN coordinates', () => {
+    const { editor } = session();
+    expect(() => addSpatialZonesToStore(editor, ANCHOR, {
+      LongName: 'Takt areas',
+      zones: [{ ...BOX, Position: [Number.NaN, 0, 0] }],
+      RelatedElements: [[]],
+    })).toThrow(/finite Position/);
   });
 
   it('refuses a zone with no height rather than emitting a flat solid', () => {
@@ -261,7 +313,7 @@ describe('addSpatialZonesToStore', () => {
     expect(() => addSpatialZonesToStore(editor, ANCHOR, {
       LongName: 'Takt areas',
       zones: [{ ...BOX, Height: 0 }],
-      referencedElements: [[]],
+      RelatedElements: [[]],
     })).toThrow(/Height/);
   });
 });

--- a/packages/create/src/in-store/spatial-zone.test.ts
+++ b/packages/create/src/in-store/spatial-zone.test.ts
@@ -219,6 +219,43 @@ describe('addSpatialZonesToStore', () => {
     })).toThrow(/IFC4 or later/);
   });
 
+  it('refuses a degenerate footprint rather than quietly emitting a box', () => {
+    // Two points cannot be a profile. Falling back to Width/Depth would emit a
+    // shape the caller did not ask for, and (before the fix) would also discard
+    // the rotation, since the fallback path is the rotated one.
+    const { editor } = session();
+    expect(() => addSpatialZonesToStore(editor, ANCHOR, {
+      LongName: 'Takt areas',
+      zones: [{ ...BOX, Footprint: [[0, 0], [1, 0]] }],
+      referencedElements: [[]],
+    })).toThrow(/fewer than 3 points/);
+  });
+
+  it('refuses a box with a zero extent', () => {
+    // An IfcRectangleProfileDef with XDim 0 is a shape no reader can use, and
+    // the emission would report success.
+    const { editor } = session();
+    for (const bad of [{ Width: 0 }, { Depth: Number.NaN }]) {
+      expect(() => addSpatialZonesToStore(editor, ANCHOR, {
+        LongName: 'Takt areas',
+        zones: [{ ...BOX, ...bad }],
+        referencedElements: [[]],
+      })).toThrow(/finite positive (Width|Depth)/);
+    }
+  });
+
+  it('does not check the extents of a zone whose shape is a polygon', () => {
+    // A prism carries its own extents, so a caller that leaves Width/Depth at
+    // zero is not wrong.
+    const { editor, view } = session();
+    addSpatialZonesToStore(editor, ANCHOR, {
+      LongName: 'Takt areas',
+      zones: [{ ...BOX, Width: 0, Depth: 0, Footprint: [[10, 20], [16, 20], [16, 24]] }],
+      referencedElements: [[]],
+    });
+    expect(view.getNewEntities().some((e) => e.type === 'IfcArbitraryClosedProfileDef')).toBe(true);
+  });
+
   it('refuses a zone with no height rather than emitting a flat solid', () => {
     const { editor } = session();
     expect(() => addSpatialZonesToStore(editor, ANCHOR, {

--- a/packages/create/src/in-store/spatial-zone.ts
+++ b/packages/create/src/in-store/spatial-zone.ts
@@ -1,0 +1,229 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Anchored builder for `IfcSpatialZone` - the schema's own name for a region
+ * that is not bounded by physical elements (issue #2508 item 3).
+ *
+ * A location zone is a construction section or takt area a user drew against
+ * the rendered scene. `docs/design/zone-emission.md` argues why it must NOT be
+ * emitted as an `IfcZone`: that type groups SPACES, its `IsGroupedBy` admits
+ * only `IfcSpace` / `IfcSpatialZone` / nested `IfcZone`, and this repo's own
+ * reader (`extractGroupMembersOnDemand`) describes an `IfcZone`'s members that
+ * way. Assigning walls to one produces a file we would mis-read ourselves.
+ *
+ * `IfcSpatialZone` is the type that means this, and two of its properties are
+ * why it fits where `IfcZone` does not:
+ *
+ * - Elements attach through **`IfcRelReferencedInSpatialStructure`**, which is
+ *   many-to-many and ADDITIVE. It leaves `IfcRelContainedInSpatialStructure` -
+ *   the exclusive relation that carries the building's real hierarchy -
+ *   untouched, so emitting zones never re-parents anything.
+ * - A straddling element can therefore be referenced in BOTH zones it crosses,
+ *   which is the truthful statement of the topology.
+ *
+ * What this cannot say is HOW MUCH of an element is in a zone. That is the
+ * quantity write-back's job (`IfcLite_ZoneVolumes`), and the two are
+ * complementary rather than alternatives: emit alongside the property sets,
+ * never instead of them.
+ *
+ * Pure: no I/O, no parser access - operates entirely through the editor, like
+ * every other builder here.
+ */
+
+import { generateIfcGuid } from '@ifc-lite/encoding';
+import type { StoreEditor } from '@ifc-lite/mutations';
+import { toNativeLength, toNativePoint3, type SpatialAnchor } from './anchor.js';
+import { emitPolygonProfile, ownerHistoryRef } from './_emit-helpers.js';
+
+/**
+ * One zone to emit. Coordinates are IFC-AXES (Z-up) WORLD metres: the caller
+ * has already undone the render frame and swapped axes, because only the
+ * viewer knows what shifts its own pipeline applied. See
+ * `apps/viewer/src/lib/zones/emit-spatial-zones.ts`.
+ */
+export interface SpatialZoneInput {
+  /** `IfcRoot.Name` - the zone's own name, e.g. "Takt A". */
+  Name: string;
+  /** Base centre of the zone in IFC world metres (Z-up). */
+  Position: [number, number, number];
+  /** Extent along world X, metres. Ignored when `Footprint` is given. */
+  Width: number;
+  /** Extent along world Y, metres. Ignored when `Footprint` is given. */
+  Depth: number;
+  /** Extrusion height along +Z, metres. */
+  Height: number;
+  /** Rotation about the vertical axis, radians. Carried in the PLACEMENT
+   *  rather than baked into the profile, so the profile stays a plain
+   *  rectangle a receiving tool can read as one. Ignored with `Footprint`. */
+  RotationZ?: number;
+  /**
+   * Convex footprint in IFC world metres (X/Y pairs), for a prism zone. When
+   * present the zone is this polygon extruded by `Height`, and the profile is
+   * emitted RELATIVE to `Position` so the placement stays the one thing that
+   * positions the zone.
+   */
+  Footprint?: Array<[number, number]>;
+}
+
+export interface SpatialZoneInStoreParams {
+  /** `IfcSpatialZone.LongName` - the zone SET's name, e.g. "Takt areas". */
+  LongName: string;
+  zones: SpatialZoneInput[];
+  /**
+   * `globalId -> expressIds` the zone references, per zone index. An element
+   * appears under every zone it touches, straddlers included.
+   */
+  referencedElements: Array<number[]>;
+  /** `IfcSpatialZone.PredefinedType`. CONSTRUCTION is what a takt area is;
+   *  the enum also has FIRESAFETY, LIGHTING, OCCUPANCY, SECURITY, THERMAL,
+   *  TRANSPORT, VENTILATION, USERDEFINED, NOTDEFINED. */
+  PredefinedType?: string;
+}
+
+export interface SpatialZoneBuildResult {
+  /** One `IfcSpatialZone` expressId per input zone, in input order. */
+  zoneIds: number[];
+  /** One `IfcRelReferencedInSpatialStructure` per zone that had elements. */
+  relReferencedIds: number[];
+}
+
+/**
+ * `IfcSpatialZone` does not exist before IFC4. Emitting one into an IFC2X3
+ * file would produce an entity no reader of that schema can resolve, so the
+ * caller is told rather than handed a file that fails on import.
+ */
+export function spatialZonesSupported(schema: SpatialAnchor['schema']): boolean {
+  return (schema ?? 'IFC4') !== 'IFC2X3';
+}
+
+/**
+ * Emit one `IfcSpatialZone` per zone, plus the reference relationships.
+ *
+ * Placement is ABSOLUTE (`PlacementRelTo = $`): the caller supplies world
+ * coordinates because that is what it has - the mesh pipeline already resolved
+ * every placement chain to world when it drew the zone against the model.
+ * Chaining to the site instead would mean inverting that chain to get back a
+ * local offset, which is arithmetic with nothing to gain: an absolute local
+ * placement is valid IFC and says exactly where the user put the box.
+ */
+export function addSpatialZonesToStore(
+  editor: StoreEditor,
+  anchor: SpatialAnchor,
+  params: SpatialZoneInStoreParams,
+): SpatialZoneBuildResult {
+  if (!spatialZonesSupported(anchor.schema)) {
+    throw new Error('addSpatialZonesToStore: IfcSpatialZone requires IFC4 or later');
+  }
+
+  const zoneIds: number[] = [];
+  const relReferencedIds: number[] = [];
+
+  params.zones.forEach((zone, index) => {
+    if (!Number.isFinite(zone.Height) || zone.Height <= 0) {
+      throw new Error(`addSpatialZonesToStore: zone "${zone.Name}" needs a finite positive Height`);
+    }
+
+    const position = toNativePoint3(anchor, zone.Position);
+    const height = toNativeLength(anchor, zone.Height);
+
+    // Placement: absolute, with the vertical rotation carried as the RefDirection
+    // rather than rotated into the profile.
+    const originPt = editor.addEntity('IfcCartesianPoint', [position]).expressId;
+    const rotation = zone.Footprint ? 0 : (zone.RotationZ ?? 0);
+    const refDirectionId = rotation === 0
+      ? null
+      : editor.addEntity('IfcDirection', [[Math.cos(rotation), Math.sin(rotation), 0]]).expressId;
+    const axisId = editor.addEntity('IfcAxis2Placement3D', [
+      `#${originPt}`,
+      null,
+      refDirectionId === null ? null : `#${refDirectionId}`,
+    ]).expressId;
+    const placementId = editor.addEntity('IfcLocalPlacement', [null, `#${axisId}`]).expressId;
+
+    // Profile: a rectangle for a box, the polygon for a prism. The prism's
+    // points are made RELATIVE to the placement origin so the two do not both
+    // carry the position (which would put the zone at twice its coordinates).
+    let profileId: number;
+    if (zone.Footprint && zone.Footprint.length >= 3) {
+      profileId = emitPolygonProfile(
+        editor,
+        zone.Footprint.map(([x, y]): [number, number] => [
+          toNativeLength(anchor, x - zone.Position[0]),
+          toNativeLength(anchor, y - zone.Position[1]),
+        ]),
+      );
+    } else {
+      const profileOriginPt = editor.addEntity('IfcCartesianPoint', [[0, 0]]).expressId;
+      const profilePos = editor.addEntity('IfcAxis2Placement2D', [`#${profileOriginPt}`, null]).expressId;
+      profileId = editor.addEntity('IfcRectangleProfileDef', [
+        '.AREA.',
+        null,
+        `#${profilePos}`,
+        toNativeLength(anchor, zone.Width),
+        toNativeLength(anchor, zone.Depth),
+      ]).expressId;
+    }
+
+    const solidOriginPt = editor.addEntity('IfcCartesianPoint', [[0, 0, 0]]).expressId;
+    const solidAxis = editor.addEntity('IfcAxis2Placement3D', [`#${solidOriginPt}`, null, null]).expressId;
+    const extrudeDirection = editor.addEntity('IfcDirection', [[0, 0, 1]]).expressId;
+    const solidId = editor.addEntity('IfcExtrudedAreaSolid', [
+      `#${profileId}`,
+      `#${solidAxis}`,
+      `#${extrudeDirection}`,
+      height,
+    ]).expressId;
+
+    const shapeRepId = editor.addEntity('IfcShapeRepresentation', [
+      `#${anchor.bodyContextId}`,
+      'Body',
+      'SweptSolid',
+      [`#${solidId}`],
+    ]).expressId;
+    const productShapeId = editor.addEntity('IfcProductDefinitionShape', [
+      null,
+      null,
+      [`#${shapeRepId}`],
+    ]).expressId;
+
+    // IfcSpatialZone: GlobalId, OwnerHistory, Name, Description, ObjectType,
+    // ObjectPlacement, Representation, LongName, PredefinedType.
+    //
+    // NINE attributes, not ten: `IfcSpatialZone` derives from
+    // `IfcSpatialElement`, NOT from `IfcSpatialStructureElement`, so it has no
+    // `CompositionType`. That difference is the schema saying what this type is
+    // for - a zone is not part of the containment hierarchy.
+    const zoneId = editor.addEntity('IfcSpatialZone', [
+      generateIfcGuid(anchor.guidRandom),
+      ownerHistoryRef(anchor.ownerHistoryId),
+      zone.Name,
+      null,
+      null,
+      `#${placementId}`,
+      `#${productShapeId}`,
+      params.LongName,
+      `.${params.PredefinedType ?? 'CONSTRUCTION'}.`,
+    ] as Parameters<StoreEditor['addEntity']>[1]).expressId;
+    zoneIds.push(zoneId);
+
+    // REFERENCED, not CONTAINED. The containment relation is exclusive: an
+    // element has exactly one, and re-pointing it would move the element out of
+    // the storey that owns it. Referencing is additive and many-to-many, which
+    // is what lets a straddler belong to both zones it crosses.
+    const elements = params.referencedElements[index] ?? [];
+    if (elements.length > 0) {
+      relReferencedIds.push(editor.addEntity('IfcRelReferencedInSpatialStructure', [
+        generateIfcGuid(anchor.guidRandom),
+        ownerHistoryRef(anchor.ownerHistoryId),
+        null,
+        null,
+        elements.map((id) => `#${id}`),
+        `#${zoneId}`,
+      ]).expressId);
+    }
+  });
+
+  return { zoneIds, relReferencedIds };
+}

--- a/packages/create/src/in-store/spatial-zone.ts
+++ b/packages/create/src/in-store/spatial-zone.ts
@@ -33,6 +33,7 @@
  */
 
 import { generateIfcGuid } from '@ifc-lite/encoding';
+import { IfcSpatialZoneTypeEnum } from '@ifc-lite/parser';
 import type { StoreEditor } from '@ifc-lite/mutations';
 import { toNativeLength, toNativePoint3, type SpatialAnchor } from './anchor.js';
 import { emitPolygonProfile, ownerHistoryRef } from './_emit-helpers.js';
@@ -67,19 +68,36 @@ export interface SpatialZoneInput {
   Footprint?: Array<[number, number]>;
 }
 
+/**
+ * A `PredefinedType` this builder accepts: the SCHEMA's own enum, or any of its
+ * values as a plain string.
+ *
+ * Typed rather than left as `string` because the value is written as a STEP
+ * ENUMERATION, so anything outside the set produces an `IfcSpatialZone` no
+ * reader can parse. Taken from the generated schema (`@ifc-lite/parser`) rather
+ * than re-listed here: a second copy of an enum is a second thing to keep in
+ * step with the schema.
+ */
+export type SpatialZoneType = IfcSpatialZoneTypeEnum | `${IfcSpatialZoneTypeEnum}`;
+
+const SPATIAL_ZONE_TYPES: ReadonlySet<string> = new Set<string>(Object.values(IfcSpatialZoneTypeEnum));
+
 export interface SpatialZoneInStoreParams {
   /** `IfcSpatialZone.LongName` - the zone SET's name, e.g. "Takt areas". */
   LongName: string;
   zones: SpatialZoneInput[];
   /**
-   * `globalId -> expressIds` the zone references, per zone index. An element
-   * appears under every zone it touches, straddlers included.
+   * `IfcRelReferencedInSpatialStructure.RelatedElements` per zone, by zone
+   * index: the expressIds each zone references. An element appears under every
+   * zone it touches, straddlers included.
    */
-  referencedElements: Array<number[]>;
-  /** `IfcSpatialZone.PredefinedType`. CONSTRUCTION is what a takt area is;
-   *  the enum also has FIRESAFETY, LIGHTING, OCCUPANCY, SECURITY, THERMAL,
-   *  TRANSPORT, VENTILATION, USERDEFINED, NOTDEFINED. */
-  PredefinedType?: string;
+  RelatedElements: Array<number[]>;
+  /** `IfcSpatialZone.PredefinedType`. CONSTRUCTION is what a takt area is. */
+  PredefinedType?: SpatialZoneType;
+  /** `IfcSpatialZone.ObjectType`, which IFC4 REQUIRES when `PredefinedType` is
+   *  `USERDEFINED` (rule `CorrectPredefinedType`): the enum says "named
+   *  elsewhere", and `ObjectType` is where. */
+  ObjectType?: string;
 }
 
 export interface SpatialZoneBuildResult {
@@ -87,6 +105,47 @@ export interface SpatialZoneBuildResult {
   zoneIds: number[];
   /** One `IfcRelReferencedInSpatialStructure` per zone that had elements. */
   relReferencedIds: number[];
+}
+
+/**
+ * Check one zone, and report whether its shape is a polygon.
+ *
+ * ONE predicate decides the shape, so the rotation and the profile cannot
+ * disagree: keying the rotation off "has a Footprint" while the profile needs
+ * three points would silently emit a rectangle with the caller's rotation
+ * discarded. A Footprint too small to be a polygon is a caller error, not a
+ * reason to emit a different shape than was asked for.
+ */
+function validateZone(zone: SpatialZoneInput): boolean {
+  const usePolygon = zone.Footprint !== undefined;
+  if (usePolygon && zone.Footprint!.length < 3) {
+    throw new Error(`addSpatialZonesToStore: zone "${zone.Name}" has a Footprint of fewer than 3 points`);
+  }
+  for (const value of zone.Position) {
+    if (!Number.isFinite(value)) {
+      throw new Error(`addSpatialZonesToStore: zone "${zone.Name}" needs a finite Position`);
+    }
+  }
+  if (zone.RotationZ !== undefined && !Number.isFinite(zone.RotationZ)) {
+    throw new Error(`addSpatialZonesToStore: zone "${zone.Name}" needs a finite RotationZ`);
+  }
+  const extents: Array<readonly [string, number]> = usePolygon
+    // A polygon carries its own extents, so Width and Depth are not read.
+    ? [['Height', zone.Height]]
+    : [['Width', zone.Width], ['Depth', zone.Depth], ['Height', zone.Height]];
+  for (const [name, value] of extents) {
+    if (!Number.isFinite(value) || value <= 0) {
+      throw new Error(`addSpatialZonesToStore: zone "${zone.Name}" needs a finite positive ${name}`);
+    }
+  }
+  if (usePolygon) {
+    for (const point of zone.Footprint!) {
+      if (!Number.isFinite(point[0]) || !Number.isFinite(point[1])) {
+        throw new Error(`addSpatialZonesToStore: zone "${zone.Name}" has a non-finite Footprint point`);
+      }
+    }
+  }
+  return usePolygon;
 }
 
 /**
@@ -117,30 +176,28 @@ export function addSpatialZonesToStore(
     throw new Error('addSpatialZonesToStore: IfcSpatialZone requires IFC4 or later');
   }
 
+  const predefinedType = params.PredefinedType ?? 'CONSTRUCTION';
+  if (!SPATIAL_ZONE_TYPES.has(predefinedType)) {
+    throw new Error(`addSpatialZonesToStore: "${predefinedType}" is not an IfcSpatialZoneTypeEnum value`);
+  }
+  // IFC4's `CorrectPredefinedType` rule: USERDEFINED means "the type is named
+  // in ObjectType", so emitting it with ObjectType = $ is a file that fails
+  // that rule while looking fine.
+  if (predefinedType === 'USERDEFINED' && !params.ObjectType) {
+    throw new Error('addSpatialZonesToStore: PredefinedType USERDEFINED requires an ObjectType');
+  }
+
+  // EVERY zone is checked before the FIRST entity is added. Validating inside
+  // the emit loop would leave a caller who passed one bad zone with the good
+  // ones already written into the overlay and an exception saying the call
+  // failed - a half-applied build is worse than either outcome.
+  const shapes = params.zones.map((zone) => validateZone(zone));
+
   const zoneIds: number[] = [];
   const relReferencedIds: number[] = [];
 
   params.zones.forEach((zone, index) => {
-    if (!Number.isFinite(zone.Height) || zone.Height <= 0) {
-      throw new Error(`addSpatialZonesToStore: zone "${zone.Name}" needs a finite positive Height`);
-    }
-    // ONE predicate decides the shape, so the rotation and the profile cannot
-    // disagree: keying the rotation off "has a Footprint" while the profile
-    // needs three points would silently emit a rectangle with the caller's
-    // rotation discarded. A Footprint too small to be a polygon is a caller
-    // error, not a reason to emit a different shape than was asked for.
-    const usePolygon = zone.Footprint !== undefined;
-    if (usePolygon && (zone.Footprint as Array<[number, number]>).length < 3) {
-      throw new Error(`addSpatialZonesToStore: zone "${zone.Name}" has a Footprint of fewer than 3 points`);
-    }
-    // Only meaningful for a box: a polygon carries its own extents.
-    if (!usePolygon) {
-      for (const [name, value] of [['Width', zone.Width], ['Depth', zone.Depth]] as const) {
-        if (!Number.isFinite(value) || value <= 0) {
-          throw new Error(`addSpatialZonesToStore: zone "${zone.Name}" needs a finite positive ${name}`);
-        }
-      }
-    }
+    const usePolygon = shapes[index];
 
     const position = toNativePoint3(anchor, zone.Position);
     const height = toNativeLength(anchor, zone.Height);
@@ -217,11 +274,11 @@ export function addSpatialZonesToStore(
       ownerHistoryRef(anchor.ownerHistoryId),
       zone.Name,
       null,
-      null,
+      params.ObjectType ?? null,
       `#${placementId}`,
       `#${productShapeId}`,
       params.LongName,
-      `.${params.PredefinedType ?? 'CONSTRUCTION'}.`,
+      `.${predefinedType}.`,
     ] as Parameters<StoreEditor['addEntity']>[1]).expressId;
     zoneIds.push(zoneId);
 
@@ -229,7 +286,7 @@ export function addSpatialZonesToStore(
     // element has exactly one, and re-pointing it would move the element out of
     // the storey that owns it. Referencing is additive and many-to-many, which
     // is what lets a straddler belong to both zones it crosses.
-    const elements = params.referencedElements[index] ?? [];
+    const elements = params.RelatedElements[index] ?? [];
     if (elements.length > 0) {
       relReferencedIds.push(editor.addEntity('IfcRelReferencedInSpatialStructure', [
         generateIfcGuid(anchor.guidRandom),

--- a/packages/create/src/in-store/spatial-zone.ts
+++ b/packages/create/src/in-store/spatial-zone.ts
@@ -124,6 +124,23 @@ export function addSpatialZonesToStore(
     if (!Number.isFinite(zone.Height) || zone.Height <= 0) {
       throw new Error(`addSpatialZonesToStore: zone "${zone.Name}" needs a finite positive Height`);
     }
+    // ONE predicate decides the shape, so the rotation and the profile cannot
+    // disagree: keying the rotation off "has a Footprint" while the profile
+    // needs three points would silently emit a rectangle with the caller's
+    // rotation discarded. A Footprint too small to be a polygon is a caller
+    // error, not a reason to emit a different shape than was asked for.
+    const usePolygon = zone.Footprint !== undefined;
+    if (usePolygon && (zone.Footprint as Array<[number, number]>).length < 3) {
+      throw new Error(`addSpatialZonesToStore: zone "${zone.Name}" has a Footprint of fewer than 3 points`);
+    }
+    // Only meaningful for a box: a polygon carries its own extents.
+    if (!usePolygon) {
+      for (const [name, value] of [['Width', zone.Width], ['Depth', zone.Depth]] as const) {
+        if (!Number.isFinite(value) || value <= 0) {
+          throw new Error(`addSpatialZonesToStore: zone "${zone.Name}" needs a finite positive ${name}`);
+        }
+      }
+    }
 
     const position = toNativePoint3(anchor, zone.Position);
     const height = toNativeLength(anchor, zone.Height);
@@ -131,7 +148,7 @@ export function addSpatialZonesToStore(
     // Placement: absolute, with the vertical rotation carried as the RefDirection
     // rather than rotated into the profile.
     const originPt = editor.addEntity('IfcCartesianPoint', [position]).expressId;
-    const rotation = zone.Footprint ? 0 : (zone.RotationZ ?? 0);
+    const rotation = usePolygon ? 0 : (zone.RotationZ ?? 0);
     const refDirectionId = rotation === 0
       ? null
       : editor.addEntity('IfcDirection', [[Math.cos(rotation), Math.sin(rotation), 0]]).expressId;
@@ -146,7 +163,7 @@ export function addSpatialZonesToStore(
     // points are made RELATIVE to the placement origin so the two do not both
     // carry the position (which would put the zone at twice its coordinates).
     let profileId: number;
-    if (zone.Footprint && zone.Footprint.length >= 3) {
+    if (usePolygon && zone.Footprint) {
       profileId = emitPolygonProfile(
         editor,
         zone.Footprint.map(([x, y]): [number, number] => [

--- a/packages/create/src/in-store/spatial-zone.ts
+++ b/packages/create/src/in-store/spatial-zone.ts
@@ -98,6 +98,11 @@ export interface SpatialZoneInStoreParams {
    *  `USERDEFINED` (rule `CorrectPredefinedType`): the enum says "named
    *  elsewhere", and `ObjectType` is where. */
   ObjectType?: string;
+  /** `IfcRoot.Description`, written on every zone of the set. The caller's to
+   *  use: the viewer puts its zone set's stable id here so a later run can
+   *  find its own zones after the set has been RENAMED, which `LongName`
+   *  cannot survive. */
+  Description?: string;
 }
 
 export interface SpatialZoneBuildResult {
@@ -273,7 +278,7 @@ export function addSpatialZonesToStore(
       generateIfcGuid(anchor.guidRandom),
       ownerHistoryRef(anchor.ownerHistoryId),
       zone.Name,
-      null,
+      params.Description ?? null,
       params.ObjectType ?? null,
       `#${placementId}`,
       `#${productShapeId}`,

--- a/packages/create/src/index.ts
+++ b/packages/create/src/index.ts
@@ -37,6 +37,13 @@ export { addBeamToStore, type BeamInStoreParams, type BeamBuildResult } from './
 export { addDoorToStore, type DoorInStoreParams, type DoorBuildResult } from './in-store/door.js';
 export { addWindowToStore, type WindowInStoreParams, type WindowBuildResult } from './in-store/window.js';
 export { addSpaceToStore, type SpaceInStoreParams, type SpaceRectangleParams, type SpacePolygonParams, type SpaceBuildResult } from './in-store/space.js';
+export {
+  addSpatialZonesToStore,
+  spatialZonesSupported,
+  type SpatialZoneInput,
+  type SpatialZoneInStoreParams,
+  type SpatialZoneBuildResult,
+} from './in-store/spatial-zone.js';
 export { addRoofToStore, type RoofInStoreParams, type RoofRectangleParams, type RoofPolygonParams, type RoofBuildResult } from './in-store/roof.js';
 export { addPlateToStore, type PlateInStoreParams, type PlateRectangleParams, type PlatePolygonParams, type PlateBuildResult } from './in-store/plate.js';
 export { addMemberToStore, type MemberInStoreParams, type MemberBuildResult } from './in-store/member.js';

--- a/packages/create/src/index.ts
+++ b/packages/create/src/index.ts
@@ -43,6 +43,7 @@ export {
   type SpatialZoneInput,
   type SpatialZoneInStoreParams,
   type SpatialZoneBuildResult,
+  type SpatialZoneType,
 } from './in-store/spatial-zone.js';
 export { addRoofToStore, type RoofInStoreParams, type RoofRectangleParams, type RoofPolygonParams, type RoofBuildResult } from './in-store/roof.js';
 export { addPlateToStore, type PlateInStoreParams, type PlateRectangleParams, type PlatePolygonParams, type PlateBuildResult } from './in-store/plate.js';

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -856,6 +856,7 @@
     "SpatialZoneBuildResult: interface",
     "SpatialZoneInStoreParams: interface",
     "SpatialZoneInput: interface",
+    "SpatialZoneType: type",
     "StairParams: interface",
     "StoreyInfo: interface",
     "StoreyParams: interface",

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -853,6 +853,9 @@
     "SpacePolygonParams: interface",
     "SpaceRectangleParams: interface",
     "SpatialAnchor: interface",
+    "SpatialZoneBuildResult: interface",
+    "SpatialZoneInStoreParams: interface",
+    "SpatialZoneInput: interface",
     "StairParams: interface",
     "StoreyInfo: interface",
     "StoreyParams: interface",
@@ -881,6 +884,7 @@
     "addRoofToStore: function",
     "addSlabToStore: function",
     "addSpaceToStore: function",
+    "addSpatialZonesToStore: function",
     "addWallToStore: function",
     "addWindowToStore: function",
     "detectEnclosedAreas: function",
@@ -892,7 +896,8 @@
     "listStoreys: function",
     "offsetRoomFootprint: function",
     "resolveDuplicateSource: function",
-    "resolveSpatialAnchor: function"
+    "resolveSpatialAnchor: function",
+    "spatialZonesSupported: function"
   ],
   "@ifc-lite/data": [
     "BUILDING_LIKE_SPATIAL_TYPE_ENUMS: const",


### PR DESCRIPTION
Closes the last unbuilt half of #2508 item 3, and does what `docs/design/zone-emission.md` argued for when the write-back shipped.

The property/quantity write-back (#2579) says how much of each ELEMENT is in each zone. This says what the ZONES ARE: named regions with a shape and a position, which a receiving tool can select, colour and filter by without parsing a property value back into a region. The two are complementary, and this replaces neither.

## Why `IfcSpatialZone` and not `IfcZone`

`IfcZone` groups SPACES. Its `IsGroupedBy` admits `IfcSpace` / `IfcSpatialZone` / nested `IfcZone` only, and this repo's own reader (`extractGroupMembersOnDemand`) describes an `IfcZone`'s members that way, so assigning walls to one produces a file we would mis-read ourselves.

Two properties of `IfcSpatialZone` make it fit:

- Elements attach through **`IfcRelReferencedInSpatialStructure`**, which is many-to-many and ADDITIVE. It leaves `IfcRelContainedInSpatialStructure` (the exclusive relation carrying the building's real hierarchy) untouched, so emitting zones never re-parents anything.
- A straddler is therefore referenced in BOTH zones it crosses, which is the truthful topology.

Nine attributes, not ten: the type derives from `IfcSpatialElement`, not `IfcSpatialStructureElement`, so it has no `CompositionType`. A tenth argument would be a record no IFC4 reader can parse, which is what the schema test pins.

## The part that fails invisibly

A zone is authored against the rendered scene: Y-up, RTC-subtracted, metres. An `IfcSpatialZone` has to land Z-up, un-shifted, in the file's declared length unit. Get any one wrong and the result is a valid zone that sits somewhere else.

So the frame chain reuses #2199's `renderToWorldViewer` rather than re-deriving it (the RTC offset is recorded in IFC axes and the origin shift in renderer axes; adding them in one axes folds a model's north offset into its height), and `emit-spatial-zones.test.ts` has an assertion per shift with the arithmetic worked by hand in the comment. A model federation alignment re-based is refused with `rescaled-by-alignment` rather than written into by another file's origin, same condition the apportionment already refuses.

## Split

- `packages/create/src/in-store/spatial-zone.ts` - the schema half. Knows IFC, knows nothing about the viewer. New public API, changeset included.
- `apps/viewer/src/lib/zones/emit-spatial-zones.ts` - the frame half, plus the sweep.
- `apps/viewer/src/hooks/useZoneSpatialZones.ts` - per-model orchestration. A zone set spans a federation and there is no federated IFC file, so each model gets its own copy of the zones referencing its own elements.
- `ZoneWriteBackControl` - one button, one inverse, beside the write-back's.

## Re-running it

A second press REPLACES rather than accumulates, by sweeping the sub-graph reachable from the previous run's zones. Overlay entities only, so a re-imported earlier export is never gutted, and the relationship's `RelatedElements` are deliberately not traversed (one of them may be an element the user authored this session).

The honest limit, pinned by a test rather than left to be discovered: the sweep matches the zone set's NAME, because the file has no id to match on. Renaming a set between runs leaves the previous run's zones in place.

## Verification

`pnpm test`, `pnpm lint`, `pnpm typecheck`, api-surface, test-wiring, source-text-assertions and the docs checks all pass locally.

Driven in a real browser on `AC20-FZK-Haus.ifc`, not just in tests:

- Generate from storeys -> 2 zones -> Emit -> 28 overlay entities.
- The EXPORTED file carries `#79120=IFCSPATIALZONE('...',#12,'Erdgeschoss',$,$,#79110,#79119,'Storeys',.CONSTRUCTION.)` and the same for Dachgeschoss.
- Placements `(6., 5., 0.)` and `(6., 5., 2.7)` with `18. x 16.` profiles and `2.7` / `3.5` extrusions: the storey elevations, in the file's own metres, with the render frame's Y-up centre correctly turned into a Z-up base.
- `#14502` appears in BOTH `IFCRELREFERENCEDINSPATIALSTRUCTURE` lists: a straddler, referenced twice.
- `IFCRELCONTAINEDINSPATIALSTRUCTURE` count unchanged at 2, storeys and walls intact.
- Second press: change count 28 -> 28, no duplicates.
- Remove: back to no changes at all.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added IFC spatial-zone creation with rectangular or polygonal footprints, placement, rotation, unit conversion, and element associations.
  - Added viewer controls to emit and remove spatial zones across supported models.
  - Added replacement behavior that preserves existing model entities and referenced elements.
  - Added status messages for unsupported schemas, alignment issues, permissions, and invalid memberships.
  - Spatial-zone creation supports compatible schemas; IFC2X3 is not supported.

- **Documentation**
  - Documented spatial-zone emission, removal, coordinate conversion, reruns, and supported behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->