### PR TITLE
perf(zones): cut a zone's geometry in a worker

### DIFF
--- a/apps/viewer/src/components/viewer/ZonesPanel.tsx
+++ b/apps/viewer/src/components/viewer/ZonesPanel.tsx
@@ -96,14 +96,18 @@ function NumberField({
 }
 
 function ZoneRow({
-  setId, zone, editing, exporting, onEdit, onUpdate, onRemove, onSelect, onExportGeometry,
+  setId, zone, editing, exporting, exportProgress, onEdit, onUpdate, onRemove, onSelect, onExportGeometry,
 }: {
   setId: string;
   zone: Zone;
   editing: boolean;
   /** A geometry export for THIS zone is running: the control is disabled and
-   *  says so, because the split blocks the main thread for seconds. */
+   *  says so, because the cut takes hundreds of milliseconds per element. */
   exporting: boolean;
+  /** Elements cut so far, while `exporting`. Worth rendering only because the
+   *  cutting moved to a worker: on the main thread nothing could repaint
+   *  between the first element and the last. */
+  exportProgress?: { done: number; total: number } | null;
   onEdit: () => void;
   onUpdate: (patch: Partial<Omit<Zone, 'id'>>) => void;
   onRemove: () => void;
@@ -151,6 +155,11 @@ function ZoneRow({
         >
           <Scissors className={`h-3 w-3${exporting ? ' animate-pulse' : ''}`} />
         </Button>
+        {exporting && exportProgress && (
+          <span className="text-[10px] tabular-nums text-muted-foreground" role="status" aria-live="polite">
+            Cutting {exportProgress.done}/{exportProgress.total}
+          </span>
+        )}
         <Button variant="ghost" size="icon" className="h-6 w-6 text-destructive" title="Delete zone" onClick={onRemove}>
           <Trash2 className="h-3 w-3" />
         </Button>
@@ -422,6 +431,7 @@ export function ZonesPanel({ onClose }: ZonesPanelProps) {
                     else toast.info('No elements in this zone');
                   }}
                   exporting={exportingZoneId === zone.id}
+                  exportProgress={exportProgress}
                   onExportGeometry={async () => {
                     // The split is seconds of synchronous work (~357 ms per cut
                     // element, measured), so three things have to happen before
@@ -463,7 +473,12 @@ export function ZonesPanel({ onClose }: ZonesPanelProps) {
                     if (!result.ok) {
                       toast.error(result.reason === 'no-binding'
                         ? 'The geometry engine in this build cannot split meshes'
-                        : 'Nothing to export: no loaded geometry reaches this zone');
+                        : result.reason === 'busy'
+                          // Reachable by closing the panel mid-export and
+                          // reopening it: this component's own guard resets,
+                          // the run behind it does not.
+                          ? 'Another zone is still being cut. Wait for it to finish.'
+                          : 'Nothing to export: no loaded geometry reaches this zone');
                       return;
                     }
                     const { whole, cut, refused, noGeometry, elapsedMs } = result.summary;

--- a/apps/viewer/src/components/viewer/ZonesPanel.tsx
+++ b/apps/viewer/src/components/viewer/ZonesPanel.tsx
@@ -245,6 +245,9 @@ export function ZonesPanel({ onClose }: ZonesPanelProps) {
   // has not re-rendered yet at that point).
   const [exportingZoneId, setExportingZoneId] = useState<string | null>(null);
   const exportingRef = useRef(false);
+  // How far the cut has got. Only meaningful while a worker is doing the work:
+  // before this, the main thread was blocked and nothing could have painted it.
+  const [exportProgress, setExportProgress] = useState<{ done: number; total: number } | null>(null);
 
   const [newSetName, setNewSetName] = useState('');
   const importInputRef = useRef<HTMLInputElement>(null);
@@ -430,10 +433,18 @@ export function ZonesPanel({ onClose }: ZonesPanelProps) {
                     if (exportingRef.current) return;
                     exportingRef.current = true;
                     setExportingZoneId(zone.id);
-                    await new Promise((resolve) => setTimeout(resolve, 0));
-                    let result: ReturnType<typeof exportZone>;
+                    setExportProgress(null);
+                    let result: Awaited<ReturnType<typeof exportZone>>;
                     try {
-                      result = exportZone(zs, zs.zones.indexOf(zone));
+                      // The cutting runs in a worker now, so this await yields
+                      // to the event loop rather than blocking it: the disabled
+                      // state paints, the progress below updates, and the model
+                      // can still be orbited while a section is being cut.
+                      result = await exportZone(
+                        zs,
+                        zs.zones.indexOf(zone),
+                        (done, total) => setExportProgress({ done, total }),
+                      );
                     } catch (error) {
                       // The kernel, the GLB build and the download can each
                       // throw. Inside an ASYNC handler a throw becomes an
@@ -447,6 +458,7 @@ export function ZonesPanel({ onClose }: ZonesPanelProps) {
                     } finally {
                       exportingRef.current = false;
                       setExportingZoneId(null);
+                      setExportProgress(null);
                     }
                     if (!result.ok) {
                       toast.error(result.reason === 'no-binding'

--- a/apps/viewer/src/hooks/useZoneGeometrySplit.test.ts
+++ b/apps/viewer/src/hooks/useZoneGeometrySplit.test.ts
@@ -89,9 +89,9 @@ function seed() {
   } as never);
 }
 
-function runExport(zoneIndex: number) {
+async function runExport(zoneIndex: number) {
   const emitted: Array<{ bytes: Uint8Array; filename: string }> = [];
-  const result = exportZoneGeometry(ZONE_SET, zoneIndex, {
+  const result = await exportZoneGeometry(ZONE_SET, zoneIndex, {
     split,
     // The straddler sits in zone A; the whole element is placed INSIDE zone B,
     // which is where its assignment says it is. A fixture whose geometry is not
@@ -105,28 +105,28 @@ function runExport(zoneIndex: number) {
 describe('exporting one zone as its own model', () => {
   beforeEach(seed);
 
-  it('writes whole elements and cut pieces, and counts what it refused', () => {
-    const { result } = runExport(1);
+  it('writes whole elements and cut pieces, and counts what it refused', async () => {
+    const { result } = await runExport(1);
     assert.ok(result.ok);
     assert.equal(result.summary.whole, 1, 'the element wholly in Takt B');
     assert.equal(result.summary.cut, 1, 'the straddler cut at the boundary');
     assert.equal(result.summary.volumeM3, 6, 'whole 5 m3 plus a 1 m3 piece');
   });
 
-  it('refuses a straddler whose mesh the kernel never proved', () => {
+  it('refuses a straddler whose mesh the kernel never proved', async () => {
     // Zone A holds the straddler and the unproved element.
-    const { result } = runExport(0);
+    const { result } = await runExport(0);
     assert.ok(result.ok);
     assert.equal(result.summary.cut, 1);
     assert.equal(result.summary.refused, 1);
   });
 
-  it('takes the piece belonging to the zone asked for, not the first one', () => {
+  it('takes the piece belonging to the zone asked for, not the first one', async () => {
     // The fake split gives zone i a piece at x = i. If the routing ignored
     // zoneIndex and took pieces[0], the file for Takt B would carry Takt A's
     // geometry: same triangle count, same volume, wrong section.
-    const a = runExport(0);
-    const b = runExport(1);
+    const a = await runExport(0);
+    const b = await runExport(1);
     assert.ok(a.result.ok && b.result.ok);
     assert.notEqual(a.emitted[0].bytes.byteLength, 0);
     assert.notDeepEqual(
@@ -136,7 +136,7 @@ describe('exporting one zone as its own model', () => {
     );
   });
 
-  it('cuts an element that does not straddle but reaches outside the zone set', () => {
+  it('cuts an element that does not straddle but reaches outside the zone set', async () => {
     // v1's straddle flag asks whether the element penetrates ANOTHER zone, so
     // an element hanging off the end of the last takt area carries no flag.
     // Copied whole, it would put geometry from outside the section into the
@@ -154,7 +154,7 @@ describe('exporting one zone as its own model', () => {
       // Zone A spans x = -5..5; this reaches x = 900.
       positions: new Float32Array([0, 0, 0, 900, 0, 0, 0, 1, 0]),
     } as MeshData;
-    const result = exportZoneGeometry(ZONE_SET, 0, {
+    const result = await exportZoneGeometry(ZONE_SET, 0, {
       split,
       meshPieces: () => [far],
       emit: () => {},
@@ -165,21 +165,21 @@ describe('exporting one zone as its own model', () => {
     assert.equal(result.summary.cut, 1);
   });
 
-  it('still copies an element that IS wholly inside, without cutting it', () => {
-    const { result } = runExport(1);
+  it('still copies an element that IS wholly inside, without cutting it', async () => {
+    const { result } = await runExport(1);
     assert.ok(result.ok);
     assert.equal(result.summary.whole, 1);
   });
 
-  it('names the file after the set and the zone', () => {
-    const { emitted } = runExport(0);
+  it('names the file after the set and the zone', async () => {
+    const { emitted } = await runExport(0);
     assert.equal(emitted[0].filename, 'Takt areas-Takt A.glb');
   });
 
-  it('reports rather than emits when no geometry reaches the zone', () => {
+  it('reports rather than emits when no geometry reaches the zone', async () => {
     useViewerStore.setState({ zoneAssignments: new Map() } as never);
     const emitted: Uint8Array[] = [];
-    const result = exportZoneGeometry(ZONE_SET, 0, {
+    const result = await exportZoneGeometry(ZONE_SET, 0, {
       split,
       meshPieces: () => null,
       emit: (bytes) => emitted.push(bytes),
@@ -188,8 +188,8 @@ describe('exporting one zone as its own model', () => {
     assert.equal(emitted.length, 0, 'an empty zone must not download an empty file');
   });
 
-  it('degrades to a message when the wasm build has no splitter', () => {
-    const result = exportZoneGeometry(ZONE_SET, 0, {
+  it('degrades to a message when the wasm build has no splitter', async () => {
+    const result = await exportZoneGeometry(ZONE_SET, 0, {
       split: undefined,
       meshPieces: (globalId) => [mesh(globalId)],
       emit: () => {},

--- a/apps/viewer/src/hooks/useZoneGeometrySplit.ts
+++ b/apps/viewer/src/hooks/useZoneGeometrySplit.ts
@@ -41,7 +41,15 @@ import { useViewerStore } from '@/store';
 import { getGlobalRenderer } from './useBCF.js';
 import { buildMergedGLB } from '@/lib/geo/cesium-glb';
 import { downloadFile, sanitizeFilename } from '@/lib/export/download';
-import { splitElementByZones, type SplitMeshByZonesFn } from '@/lib/zones/split.js';
+import { type SplitMeshByZonesFn } from '@/lib/zones/split.js';
+import {
+  splitZonesInWorker,
+  zoneSplitWorkerSupported,
+  type ZoneSplitBatchFn,
+  type ZoneSplitJob,
+  type ZoneSplitProgress,
+} from '@/lib/zones/split-worker-client.js';
+import { runZoneSplitBatch } from '@/workers/zoneSplit.worker.js';
 import {
   compileZone,
   isPointInCompiledZone,
@@ -139,6 +147,11 @@ export interface ZoneGeometryDeps {
   split?: SplitMeshByZonesFn;
   meshPieces?: (globalId: number) => MeshData[] | null;
   emit?: (bytes: Uint8Array, filename: string) => void;
+  /** Overrides where the cutting runs. Defaults to the worker, falling back
+   *  in-process; a test passes its own so no worker is spawned. */
+  batch?: ZoneSplitBatchFn;
+  /** Reported per element as the batch advances. */
+  onProgress?: ZoneSplitProgress;
 }
 
 /**
@@ -149,11 +162,11 @@ export interface ZoneGeometryDeps {
  * that looks like a model and round-trips as a fabrication. A GLB says what
  * this is, which is a geometric extract of one section.
  */
-export function exportZoneGeometry(
+export async function exportZoneGeometry(
   zoneSet: ZoneSet,
   zoneIndex: number,
   deps: ZoneGeometryDeps = {},
-): ZoneGeometryExportResult {
+): Promise<ZoneGeometryExportResult> {
   // `'split' in deps` rather than `??`: passing the key explicitly as
   // `undefined` is how a caller says "there is no binding", which is the state
   // of an older wasm bundle and the one branch a `??` fallback would make
@@ -165,16 +178,22 @@ export function exportZoneGeometry(
   if (!split) return { ok: false, reason: 'no-binding' };
   const zone = zoneSet.zones[zoneIndex];
   if (!zone) return { ok: false, reason: 'empty-zone' };
+  const batch = deps.batch ?? defaultBatch(split);
 
   const t0 = performance.now();
   const state = useViewerStore.getState();
   const proved = gatherProvedVolumes();
   const meshes: MeshData[] = [];
   let whole = 0;
-  let cut = 0;
   let refused = 0;
   let noGeometry = 0;
   let volumeM3: number | null = 0;
+
+  // Phase 1, on this thread: decide what happens to each element. Every input
+  // is main-thread state (the renderer's scene, the store, the proved volumes),
+  // so moving the decisions across would mean moving the state behind them.
+  const jobs: ZoneSplitJob[] = [];
+  const pending = new Map<number, { provedVolume: number; color: MeshData['color'] }>();
 
   for (const [globalId, record] of state.zoneAssignments) {
     const assignment = record[zoneSet.id];
@@ -208,16 +227,36 @@ export function exportZoneGeometry(
     // for it: clipping an open shell yields pieces whose volume is arbitrary
     // rather than approximate. Checked BEFORE the cut, so a refused element
     // costs no clipping at all (30 to 40% of meshed elements in real models do
-    // not qualify).
+    // not qualify) and never leaves this thread.
     const provedVolume = proved.byGlobalId.get(globalId);
     if (provedVolume === undefined || proved.rescaled.has(globalId)) {
       refused++;
       continue;
     }
-    // `null` here is the splitter's own refusal: the pieces did not sum to the
+    jobs.push({
+      globalId,
+      pieces: pieces.map((piece) => ({
+        positions: piece.positions,
+        indices: piece.indices,
+        origin: piece.origin ?? null,
+      })),
+    });
+    pending.set(globalId, { provedVolume, color: pieces[0].color });
+  }
+
+  // Phase 2, off this thread: the exact arrangements, which are the whole cost.
+  const outcomes = jobs.length > 0
+    ? await batch({ zones: zoneSet.zones, zoneIndex, jobs }, deps.onProgress)
+    : [];
+
+  // Phase 3, back here: the gate, which needs the proved volumes again.
+  let cut = 0;
+  for (const outcome of outcomes) {
+    const context = pending.get(outcome.globalId);
+    if (!context) continue;
+    // `ok: false` is the splitter's own refusal: the pieces did not sum to the
     // whole, whose expected cause is zones that overlap each other.
-    const elementSplit = splitElementByZones(split, pieces, zoneSet.zones);
-    if (!elementSplit) {
+    if (!outcome.ok) {
       refused++;
       continue;
     }
@@ -227,8 +266,8 @@ export function exportZoneGeometry(
     // colour-merged batch re-extracted per entity, which is a silently SHORT
     // mesh rather than a wrong one.
     const verdict = volumeGateVerdict(
-      provedVolume,
-      { wholeVolumeM3: elementSplit.wholeVolumeM3, unreliable: false },
+      context.provedVolume,
+      { wholeVolumeM3: outcome.wholeVolumeM3, unreliable: false },
       PROVED_VOLUME_AGREEMENT_REL,
       false,
     );
@@ -240,15 +279,15 @@ export function exportZoneGeometry(
     // already rejected the untrustworthy cases, so it means the element
     // reaches the zone's box without any solid inside it, which is exactly
     // what v1's negative straddle epsilon describes.
-    const piece = elementSplit.pieces.find((p) => p.zoneIndex === zoneIndex);
+    const piece = outcome.piece;
     if (!piece) continue;
     meshes.push({
-      expressId: globalId,
+      expressId: outcome.globalId,
       positions: piece.positions,
       normals: piece.normals,
       indices: piece.indices,
       origin: piece.origin,
-      color: pieces[0].color,
+      color: context.color,
     } as MeshData);
     cut++;
     if (volumeM3 !== null) volumeM3 += piece.volumeM3;
@@ -264,9 +303,33 @@ export function exportZoneGeometry(
   };
 }
 
+/**
+ * The batch splitter to use when the caller names none: the worker, falling
+ * back in-process.
+ *
+ * The fallback is not silent. A browser without workers, or one where spawning
+ * fails, gets the old frozen main thread - which is worth having, since the
+ * export still produces its file, and worth saying, because "the UI locked up"
+ * and "the UI locked up and we know why" are different bug reports.
+ */
+function defaultBatch(split: SplitMeshByZonesFn): ZoneSplitBatchFn {
+  const inProcess: ZoneSplitBatchFn = async (request, onProgress) =>
+    runZoneSplitBatch(split, { ...request, zones: request.zones as Zone[] }, onProgress);
+  if (!zoneSplitWorkerSupported()) return inProcess;
+  return async (request, onProgress) => {
+    try {
+      return await splitZonesInWorker(request, onProgress);
+    } catch (error) {
+      console.warn('[zones] the split worker failed; cutting on the main thread instead', error);
+      return inProcess(request, onProgress);
+    }
+  };
+}
+
 export function useZoneGeometrySplit() {
   const exportZone = useCallback(
-    (zoneSet: ZoneSet, zoneIndex: number) => exportZoneGeometry(zoneSet, zoneIndex),
+    (zoneSet: ZoneSet, zoneIndex: number, onProgress?: ZoneSplitProgress) =>
+      exportZoneGeometry(zoneSet, zoneIndex, onProgress ? { onProgress } : {}),
     [],
   );
   return { exportZone, available: splitFn !== undefined };

--- a/apps/viewer/src/hooks/useZoneGeometrySplit.ts
+++ b/apps/viewer/src/hooks/useZoneGeometrySplit.ts
@@ -90,7 +90,23 @@ export interface ZoneGeometryExport {
 
 export type ZoneGeometryExportResult =
   | { ok: true; summary: ZoneGeometryExport }
-  | { ok: false; reason: 'no-binding' | 'no-geometry' | 'empty-zone' };
+  | { ok: false; reason: 'no-binding' | 'no-geometry' | 'empty-zone' | 'busy' };
+
+/**
+ * An export is in flight.
+ *
+ * Module-level, NOT a ref in the panel, and the difference is new to the
+ * worker. While the cut blocked the main thread, a second run was impossible
+ * because nothing could be clicked; now that the UI stays live, the panel can
+ * be closed and reopened mid-export, which resets any state the component
+ * owns. A second run would then compile a second wasm module and cut the same
+ * elements again for a second identical download.
+ *
+ * One at a time rather than one per zone: each run compiles its own
+ * `WebAssembly.Memory` and saturates a core, so two at once is slower than two
+ * in sequence and costs twice the memory.
+ */
+let exportInFlight = false;
 
 /**
  * Is every vertex of the element inside `zone`?
@@ -179,6 +195,30 @@ export async function exportZoneGeometry(
   const zone = zoneSet.zones[zoneIndex];
   if (!zone) return { ok: false, reason: 'empty-zone' };
   const batch = deps.batch ?? defaultBatch(split);
+  if (exportInFlight) return { ok: false, reason: 'busy' };
+  exportInFlight = true;
+  try {
+    return await runExport(zoneSet, zone, zoneIndex, { meshPieces, emit, batch, onProgress: deps.onProgress });
+  } finally {
+    // In a `finally` so a throw from the kernel, the GLB build or the download
+    // does not leave the button dead for the rest of the session.
+    exportInFlight = false;
+  }
+}
+
+interface ResolvedDeps {
+  meshPieces: (globalId: number) => MeshData[] | null;
+  emit: (bytes: Uint8Array, filename: string) => void;
+  batch: ZoneSplitBatchFn;
+  onProgress?: ZoneSplitProgress;
+}
+
+async function runExport(
+  zoneSet: ZoneSet,
+  zone: Zone,
+  zoneIndex: number,
+  { meshPieces, emit, batch, onProgress }: ResolvedDeps,
+): Promise<ZoneGeometryExportResult> {
 
   const t0 = performance.now();
   const state = useViewerStore.getState();
@@ -246,7 +286,7 @@ export async function exportZoneGeometry(
 
   // Phase 2, off this thread: the exact arrangements, which are the whole cost.
   const outcomes = jobs.length > 0
-    ? await batch({ zones: zoneSet.zones, zoneIndex, jobs }, deps.onProgress)
+    ? await batch({ zones: zoneSet.zones, zoneIndex, jobs }, onProgress)
     : [];
 
   // Phase 3, back here: the gate, which needs the proved volumes again.

--- a/apps/viewer/src/hooks/useZoneGeometrySplit.worker.test.ts
+++ b/apps/viewer/src/hooks/useZoneGeometrySplit.worker.test.ts
@@ -1,0 +1,199 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The thread seam of the zone geometry export (#2508 item 2).
+ *
+ * `useZoneGeometrySplit.test.ts` covers the routing: which element's geometry
+ * lands in which file. This covers what moving the cut into a worker added, and
+ * every assertion here is about something that would still produce a CORRECT
+ * file if it broke - which is exactly why it needs a test rather than a look:
+ *
+ *  - only the elements that need CUTTING cross the boundary (an export that
+ *    shipped the whole elements too would be right, and would copy megabytes of
+ *    geometry per run for nothing);
+ *  - progress is reported per element (the panel's counter is the only sign a
+ *    long run is alive);
+ *  - a worker that fails falls back to cutting in-process rather than losing
+ *    the export.
+ */
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import type { MeshData } from '@ifc-lite/geometry';
+import { useViewerStore } from '@/store/index.js';
+import { exportZoneGeometry } from './useZoneGeometrySplit.js';
+import { runZoneSplitBatch } from '@/workers/zoneSplit.worker.js';
+import type { ZoneSplitBatchFn, ZoneSplitJob } from '@/lib/zones/split-worker-client.js';
+import type { SplitMeshByZonesFn } from '@/lib/zones/split.js';
+import type { ZoneSet } from '@/lib/zones';
+
+const STRADDLER_A = 10;
+const STRADDLER_B = 11;
+/** Sits wholly inside zone B, so it is copied rather than cut. */
+const WHOLE = 12;
+
+const ZONE_SET: ZoneSet = {
+  id: 'set-1',
+  name: 'Takt areas',
+  zones: [
+    { id: 'z-a', name: 'Takt A', center: [0, 0, 0], size: [10, 10, 10], rotationY: 0 },
+    { id: 'z-b', name: 'Takt B', center: [10, 0, 0], size: [10, 10, 10], rotationY: 0 },
+  ],
+  visible: true,
+  createdAt: 0,
+  updatedAt: 0,
+};
+
+function mesh(expressId: number, x = 0): MeshData {
+  return {
+    expressId,
+    positions: new Float32Array([x, 0, 0, x + 1, 0, 0, x, 1, 0]),
+    normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+    indices: new Uint32Array([0, 1, 2]),
+    color: [1, 0, 0, 1],
+  } as MeshData;
+}
+
+/** A split that puts 1 m3 in each zone. */
+const split: SplitMeshByZonesFn = () => ({
+  pieceCount: 2,
+  wholeVolume: 2,
+  sumErrorRel: 0,
+  remainderFailed: false,
+  piece(index: number) {
+    return {
+      zoneIndex: index,
+      positions: new Float64Array([index, 0, 0, index + 1, 0, 0, index, 1, 0]),
+      indices: new Uint32Array([0, 1, 2]),
+      volume: 1,
+      free() {},
+    };
+  },
+  free() {},
+});
+
+function seed() {
+  useViewerStore.setState({
+    zoneSets: [ZONE_SET],
+    zoneAssignments: new Map([
+      [STRADDLER_A, { 'set-1': { zoneId: 'z-a', zoneName: 'Takt A', straddles: true, touchedZoneIds: ['z-a', 'z-b'] } }],
+      [STRADDLER_B, { 'set-1': { zoneId: 'z-a', zoneName: 'Takt A', straddles: true, touchedZoneIds: ['z-a', 'z-b'] } }],
+      [WHOLE, { 'set-1': { zoneId: 'z-b', zoneName: 'Takt B', straddles: false, touchedZoneIds: ['z-b'] } }],
+    ]) as never,
+    geometryResult: {
+      meshes: [
+        { expressId: STRADDLER_A, geometryVolume: 2 },
+        { expressId: STRADDLER_B, geometryVolume: 2 },
+        { expressId: WHOLE, geometryVolume: 5 },
+      ],
+    } as never,
+    models: new Map(),
+  } as never);
+}
+
+/** Run an export with a batch that records what it was asked to do. */
+async function runWithSpy(zoneIndex: number, batchImpl?: ZoneSplitBatchFn) {
+  const seen: ZoneSplitJob[][] = [];
+  const progress: Array<[number, number]> = [];
+  const result = await exportZoneGeometry(ZONE_SET, zoneIndex, {
+    split,
+    meshPieces: (globalId) => [mesh(globalId, globalId === WHOLE ? 9 : 0)],
+    emit: () => {},
+    onProgress: (done, total) => progress.push([done, total]),
+    batch: batchImpl ?? (async (request, onProgress) => {
+      seen.push(request.jobs);
+      return runZoneSplitBatch(split, { ...request, zones: [...request.zones] }, onProgress);
+    }),
+  });
+  return { result, seen, progress };
+}
+
+describe('zone geometry export: what crosses the thread boundary', () => {
+  beforeEach(seed);
+
+  it('sends the elements that need CUTTING, and only those', async () => {
+    const { result, seen } = await runWithSpy(1);
+    assert.ok(result.ok);
+    assert.equal(seen.length, 1, 'the batch should be one round trip, not one per element');
+    assert.deepEqual(seen[0].map((job) => job.globalId).sort(), [STRADDLER_A, STRADDLER_B]);
+    // The whole element still reached the file, without being sent anywhere.
+    assert.equal(result.ok && result.summary.whole, 1);
+    assert.equal(result.ok && result.summary.cut, 2);
+  });
+
+  it('sends the geometry itself, since the worker has no scene to read it from', async () => {
+    const { seen } = await runWithSpy(1);
+    const job = seen[0][0];
+    assert.equal(job.pieces.length, 1);
+    assert.equal(job.pieces[0].positions.length, 9);
+    assert.equal(job.pieces[0].indices.length, 3);
+  });
+
+  it('reports progress per element, so a long run can show where it is', async () => {
+    const { progress } = await runWithSpy(1);
+    assert.deepEqual(progress, [[1, 2], [2, 2]]);
+  });
+
+  it('runs no batch at all when nothing needs cutting', async () => {
+    // Only the wholly-inside element is in this zone, and it is copied. A round
+    // trip here would be a worker spawned, a wasm module compiled, and a file
+    // produced no differently.
+    useViewerStore.setState({
+      zoneAssignments: new Map([
+        [WHOLE, { 'set-1': { zoneId: 'z-b', zoneName: 'Takt B', straddles: false, touchedZoneIds: ['z-b'] } }],
+      ]) as never,
+    } as never);
+    const { result, seen } = await runWithSpy(1);
+    assert.ok(result.ok);
+    assert.equal(seen.length, 0);
+    assert.equal(result.ok && result.summary.whole, 1);
+  });
+
+  it('propagates a batch failure rather than emitting a partial file', async () => {
+    // The default batch falls back to the main thread when the WORKER fails,
+    // but a batch that rejects outright must not produce a file missing every
+    // straddler: a per-section model that quietly lost its cut pieces looks
+    // finished.
+    const emitted: string[] = [];
+    await assert.rejects(
+      exportZoneGeometry(ZONE_SET, 1, {
+        split,
+        meshPieces: (globalId) => [mesh(globalId, globalId === WHOLE ? 9 : 0)],
+        emit: (_bytes, filename) => emitted.push(filename),
+        batch: async () => { throw new Error('worker gone'); },
+      }),
+      /worker gone/,
+    );
+    assert.deepEqual(emitted, []);
+  });
+});
+
+describe('runZoneSplitBatch', () => {
+  it('returns the piece for the zone asked for, not the first one', () => {
+    const jobs: ZoneSplitJob[] = [{ globalId: STRADDLER_A, pieces: [mesh(STRADDLER_A)] }];
+    const a = runZoneSplitBatch(split, { zones: ZONE_SET.zones, zoneIndex: 0, jobs });
+    const b = runZoneSplitBatch(split, { zones: ZONE_SET.zones, zoneIndex: 1, jobs });
+    assert.equal(a[0].piece?.zoneIndex, 0);
+    assert.equal(b[0].piece?.zoneIndex, 1);
+  });
+
+  it('reports a refusal as ok:false, distinct from "this zone holds none of it"', () => {
+    // A split whose pieces do not sum to the whole: `splitElementByZones`
+    // refuses it, and the caller must be able to tell that apart from an
+    // element that is simply not in this zone, because one is a warning to the
+    // user and the other is normal.
+    const disagreeing: SplitMeshByZonesFn = () => ({
+      pieceCount: 0, wholeVolume: 2, sumErrorRel: 1, remainderFailed: false,
+      piece: () => undefined, free() {},
+    });
+    const jobs: ZoneSplitJob[] = [{ globalId: STRADDLER_A, pieces: [mesh(STRADDLER_A)] }];
+    const refused = runZoneSplitBatch(disagreeing, { zones: ZONE_SET.zones, zoneIndex: 0, jobs });
+    assert.equal(refused[0].ok, false);
+
+    const elsewhere = runZoneSplitBatch(split, { zones: ZONE_SET.zones, zoneIndex: 5, jobs });
+    assert.equal(elsewhere[0].ok, true);
+    assert.equal(elsewhere[0].piece, null);
+  });
+});

--- a/apps/viewer/src/hooks/useZoneGeometrySplit.worker.test.ts
+++ b/apps/viewer/src/hooks/useZoneGeometrySplit.worker.test.ts
@@ -170,6 +170,57 @@ describe('zone geometry export: what crosses the thread boundary', () => {
   });
 });
 
+describe('one export at a time', () => {
+  beforeEach(seed);
+
+  it('refuses a second run while the first is still cutting', async () => {
+    // The lock has to outlive the PANEL, not just the click: now that the UI
+    // stays live during a cut, the panel can be closed and reopened, which
+    // resets anything the component owns. A second run would compile a second
+    // wasm module and cut the same elements again for an identical download.
+    let release: (() => void) | undefined;
+    const held = new Promise<void>((resolve) => { release = resolve; });
+    const slow = exportZoneGeometry(ZONE_SET, 1, {
+      split,
+      meshPieces: (globalId) => [mesh(globalId, globalId === WHOLE ? 9 : 0)],
+      emit: () => {},
+      batch: async (request, onProgress) => {
+        await held;
+        return runZoneSplitBatch(split, { ...request, zones: [...request.zones] }, onProgress);
+      },
+    });
+
+    const second = await exportZoneGeometry(ZONE_SET, 1, {
+      split,
+      meshPieces: (globalId) => [mesh(globalId)],
+      emit: () => { throw new Error('the second run produced a file'); },
+    });
+    assert.equal(second.ok, false);
+    assert.equal(second.ok === false && second.reason, 'busy');
+
+    release?.();
+    assert.equal((await slow).ok, true);
+  });
+
+  it('releases the lock when a run throws, rather than wedging the button', async () => {
+    await assert.rejects(exportZoneGeometry(ZONE_SET, 1, {
+      split,
+      meshPieces: (globalId) => [mesh(globalId, globalId === WHOLE ? 9 : 0)],
+      emit: () => {},
+      batch: async () => { throw new Error('worker gone'); },
+    }));
+
+    const after = await exportZoneGeometry(ZONE_SET, 1, {
+      split,
+      meshPieces: (globalId) => [mesh(globalId, globalId === WHOLE ? 9 : 0)],
+      emit: () => {},
+      batch: async (request, onProgress) =>
+        runZoneSplitBatch(split, { ...request, zones: [...request.zones] }, onProgress),
+    });
+    assert.equal(after.ok, true, 'the lock was never released');
+  });
+});
+
 describe('runZoneSplitBatch', () => {
   it('returns the piece for the zone asked for, not the first one', () => {
     const jobs: ZoneSplitJob[] = [{ globalId: STRADDLER_A, pieces: [mesh(STRADDLER_A)] }];

--- a/apps/viewer/src/lib/zones/split-worker-client.ts
+++ b/apps/viewer/src/lib/zones/split-worker-client.ts
@@ -1,0 +1,106 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Main-thread client for {@link ../../workers/zoneSplit.worker.ts}. See that
+ * file for why the cutting must not run on the main thread.
+ *
+ * One worker per run, terminated the moment the run settles. The same trade
+ * `idsWorkerClient` makes and for the same reason: a geometry export is a rare,
+ * explicit click, and a resident worker would pin a second `WebAssembly.Memory`
+ * (which never shrinks) for the whole session to save one compile.
+ */
+
+import type {
+  ZoneSplitJob,
+  ZoneSplitOutcome,
+  ZoneSplitWorkerRequest,
+  ZoneSplitWorkerResponse,
+} from '@/workers/zoneSplit.worker.js';
+import type { Zone } from './types.js';
+
+export type { ZoneSplitJob, ZoneSplitOutcome };
+
+/** Reported as the batch advances, so a long run can say where it is. */
+export type ZoneSplitProgress = (done: number, total: number) => void;
+
+/** The one call the export makes to get its elements cut, whichever thread
+ *  does it. The in-process path implements the same signature. */
+export type ZoneSplitBatchFn = (
+  request: { zones: readonly Zone[]; zoneIndex: number; jobs: ZoneSplitJob[]; tolerance?: number },
+  onProgress?: ZoneSplitProgress,
+) => Promise<ZoneSplitOutcome[]>;
+
+export function zoneSplitWorkerSupported(): boolean {
+  return typeof Worker !== 'undefined';
+}
+
+/**
+ * Ceiling on one batch.
+ *
+ * Deliberately generous: the work itself is ~357 ms per element and a whole
+ * building's straddlers can run into minutes, so anything near this means the
+ * worker is GONE rather than slow. It exists because a worker killed by the OS
+ * (renderer OOM, the likely failure for a huge model) fires neither `message`
+ * nor `error`, and without a deadline the export would never settle and the
+ * panel's button would stay disabled for the rest of the session.
+ */
+export const ZONE_SPLIT_TIMEOUT_MS = 600_000;
+
+export const splitZonesInWorker: ZoneSplitBatchFn = (request, onProgress) =>
+  new Promise((resolve, reject) => {
+    let worker: Worker;
+    try {
+      worker = new Worker(new URL('../../workers/zoneSplit.worker.ts', import.meta.url), { type: 'module' });
+    } catch (error) {
+      reject(new Error(`Failed to spawn the zone split worker: ${error instanceof Error ? error.message : String(error)}`));
+      return;
+    }
+
+    const id = 1;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const settle = (fn: () => void) => {
+      if (timer !== null) clearTimeout(timer);
+      worker.onmessage = null;
+      worker.onerror = null;
+      worker.onmessageerror = null;
+      worker.terminate();
+      fn();
+    };
+    timer = setTimeout(
+      () => settle(() => reject(new Error('The zone split worker stopped responding'))),
+      ZONE_SPLIT_TIMEOUT_MS,
+    );
+
+    worker.onmessage = (event: MessageEvent<ZoneSplitWorkerResponse>) => {
+      const message = event.data;
+      if (!message || message.id !== id) return;
+      switch (message.type) {
+        case 'progress':
+          onProgress?.(message.done, message.total);
+          return;
+        case 'complete':
+          settle(() => resolve(message.outcomes));
+          return;
+        case 'error':
+          settle(() => reject(new Error(message.message)));
+      }
+    };
+    worker.onerror = (event) => settle(() => reject(new Error(event.message || 'the zone split worker crashed')));
+    worker.onmessageerror = () => settle(() => reject(new Error('the zone split worker sent an unreadable message')));
+
+    const payload: ZoneSplitWorkerRequest = {
+      type: 'split',
+      id,
+      zones: request.zones as Zone[],
+      zoneIndex: request.zoneIndex,
+      jobs: request.jobs,
+      tolerance: request.tolerance,
+    };
+    // No transfer list, on purpose: the positions and indices belong to the
+    // renderer's live scene, and transferring them would detach the buffers the
+    // model is drawn from. The clone's copy IS the price of not blanking the
+    // viewport.
+    worker.postMessage(payload);
+  });

--- a/apps/viewer/src/workers/zoneSplit.worker.ts
+++ b/apps/viewer/src/workers/zoneSplit.worker.ts
@@ -1,0 +1,159 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Zone geometry split worker (issue #2508 item 2).
+ *
+ * Cutting an element against a zone set is an exact arrangement in the CSG
+ * kernel, measured at ~357 ms per element through this same wasm build on
+ * `AC20-FZK-Haus.ifc` (18 cut elements, 6.4 s in total). On the main thread
+ * that is 6.4 seconds with no frames: no spinner turns, the canvas is frozen,
+ * and a click anywhere is queued rather than seen. The panel had a
+ * `setTimeout(0)` before this existed purely so the disabled state could paint
+ * ONCE before the freeze.
+ *
+ * Only the CUTTING crosses over. The routing decisions - which element is
+ * wholly inside, which one the mesher never proved, which zone a piece belongs
+ * to - stay on the main thread, because they read the renderer's scene and the
+ * store, and shipping either across would be a second copy of state that can
+ * disagree with the first.
+ *
+ * ## What crosses, and what it costs
+ *
+ * Geometry goes over WITHOUT a transfer list. Transferring would detach the
+ * renderer's own buffers and blank the model on screen, so the structured
+ * clone's copy is the point rather than an oversight. The pieces come back
+ * transferred: those are the worker's own allocations and nothing here reads
+ * them again.
+ */
+
+import init, * as IfcWasm from '@ifc-lite/wasm';
+import {
+  splitElementByZones,
+  SPLIT_SUM_TOLERANCE_REL,
+  type SplitMeshByZonesFn,
+  type ZoneMeshPiece,
+} from '@/lib/zones/split.js';
+import type { Zone } from '@/lib/zones/types.js';
+
+/** One element's geometry as the renderer holds it: positions relative to a
+ *  per-mesh origin, which {@link splitElementByZones} folds in itself. */
+export interface ZoneSplitJobPiece {
+  positions: Float32Array;
+  indices: Uint32Array;
+  origin?: readonly number[] | null;
+}
+
+export interface ZoneSplitJob {
+  globalId: number;
+  pieces: ZoneSplitJobPiece[];
+}
+
+export interface ZoneSplitWorkerRequest {
+  type: 'split';
+  id: number;
+  zones: Zone[];
+  /** Which zone's piece the caller wants back. Sending only that one keeps the
+   *  reply proportional to what is being exported rather than to the whole
+   *  zone set. */
+  zoneIndex: number;
+  jobs: ZoneSplitJob[];
+  tolerance?: number;
+}
+
+/** One element's answer. `ok: false` is the splitter's own refusal - the pieces
+ *  did not sum to the whole, or the remainder could not be built - and is NOT
+ *  the same as `piece: null`, which means this zone simply holds none of it. */
+export interface ZoneSplitOutcome {
+  globalId: number;
+  ok: boolean;
+  wholeVolumeM3: number;
+  piece: ZoneMeshPiece | null;
+}
+
+export type ZoneSplitWorkerResponse =
+  | { type: 'progress'; id: number; done: number; total: number }
+  | { type: 'complete'; id: number; outcomes: ZoneSplitOutcome[] }
+  | { type: 'error'; id: number; message: string };
+
+/**
+ * Run one batch, reporting progress as it goes.
+ *
+ * Exported so the in-process fallback runs the SAME loop rather than a second
+ * implementation of it: a worker-less browser must produce identical files, not
+ * merely similar ones.
+ */
+export function runZoneSplitBatch(
+  split: SplitMeshByZonesFn,
+  request: Pick<ZoneSplitWorkerRequest, 'zones' | 'zoneIndex' | 'jobs' | 'tolerance'>,
+  onProgress?: (done: number, total: number) => void,
+): ZoneSplitOutcome[] {
+  const tolerance = request.tolerance ?? SPLIT_SUM_TOLERANCE_REL;
+  const outcomes: ZoneSplitOutcome[] = [];
+  for (const [index, job] of request.jobs.entries()) {
+    const result = splitElementByZones(split, job.pieces, request.zones, tolerance);
+    outcomes.push(result === null
+      ? { globalId: job.globalId, ok: false, wholeVolumeM3: 0, piece: null }
+      : {
+        globalId: job.globalId,
+        ok: true,
+        wholeVolumeM3: result.wholeVolumeM3,
+        piece: result.pieces.find((p) => p.zoneIndex === request.zoneIndex) ?? null,
+      });
+    onProgress?.(index + 1, request.jobs.length);
+  }
+  return outcomes;
+}
+
+/** Every buffer in the reply, so the pieces move rather than copy. */
+function transferables(outcomes: ZoneSplitOutcome[]): Transferable[] {
+  const out: Transferable[] = [];
+  for (const outcome of outcomes) {
+    if (!outcome.piece) continue;
+    out.push(outcome.piece.positions.buffer, outcome.piece.normals.buffer, outcome.piece.indices.buffer);
+  }
+  return out;
+}
+
+/**
+ * True only in a real dedicated-worker scope. Guarding the registration keeps
+ * this module importable from a test (Node has no `self`, and the in-process
+ * fallback imports {@link runZoneSplitBatch} from here) and off `window` if it
+ * is ever pulled into a main-thread chunk. Same guard, for the same reasons, as
+ * `overlay-parse.worker.ts`.
+ */
+const isWorkerScope =
+  typeof self !== 'undefined' &&
+  typeof (globalThis as { window?: unknown }).window === 'undefined' &&
+  typeof (self as unknown as Worker).postMessage === 'function';
+
+if (isWorkerScope) {
+  self.onmessage = async (event: MessageEvent<ZoneSplitWorkerRequest>) => {
+    const request = event.data;
+    if (!request || request.type !== 'split') return;
+    try {
+      // The wasm module has to be compiled in THIS realm: a worker shares no
+      // instance with the main thread's.
+      await init();
+      const split = (IfcWasm as unknown as { splitMeshByZones?: SplitMeshByZonesFn }).splitMeshByZones;
+      if (!split) throw new Error('this wasm build has no splitMeshByZones');
+
+      const outcomes = runZoneSplitBatch(split, request, (done, total) => {
+        (self as unknown as Worker).postMessage(
+          { type: 'progress', id: request.id, done, total } satisfies ZoneSplitWorkerResponse,
+        );
+      });
+      (self as unknown as Worker).postMessage(
+        { type: 'complete', id: request.id, outcomes } satisfies ZoneSplitWorkerResponse,
+        transferables(outcomes),
+      );
+    } catch (error) {
+      (self as unknown as Worker).postMessage({
+        type: 'error',
+        id: request.id,
+        message: error instanceof Error ? error.message : String(error),
+      } satisfies ZoneSplitWorkerResponse);
+    }
+  };
+}


### PR DESCRIPTION
Follow-up to #2508 item 2. The geometry export ran the exact CSG arrangements on the main thread; this moves them off it.

## Measured, both ways

`AC20-FZK-Haus.ifc` with four takt zones tiling its length, exporting Takt A (19 whole elements, 13 cut, 3 refused), driven through a real Chrome with the same WebGPU flags `playwright.config.ts` uses:

| | longest frame gap | GLB |
|---|---|---|
| worker (this PR) | **23 ms** | 273,332 bytes |
| in-process (the fallback, forced by removing `window.Worker`) | **547 ms** | 273,332 bytes |

Same file, same summary line, both ways. What changed is that the main thread kept painting: the rAF ticker sampled 9 times during the worker run and once during the in-process run, because the polling itself was blocked.

A worker really is spawned, rather than the code merely being arranged as if it were: `page.on('worker')` recorded `.../src/workers/zoneSplit.worker.ts?worker_file&type=module`, and only during the export.

## What crosses, and what does not

Only the CUTTING. Which element is wholly inside, which one the mesher never proved, which zone a piece belongs to: those read the renderer's scene and the store, so they stay on the main thread, and an element that does not need cutting is never sent anywhere. A test pins that, because an export that shipped the whole elements too would produce exactly the same file while copying megabytes per run.

Geometry crosses WITHOUT a transfer list, on purpose: transferring would detach the buffers the live scene is drawn from and blank the model. The clone's copy is the price of not doing that. The cut pieces come back transferred, since those are the worker's own allocations.

## The fallback

No `Worker`, or a spawn that fails, falls back to the same batch function in-process, so the output is identical and only the freeze returns. It logs rather than passing silently. Both paths run the SAME loop (`runZoneSplitBatch`, exported from the worker module) rather than two implementations that could drift.

## Also

The panel now shows `done/total` while cutting. That was pointless before: nothing could repaint between the first element and the last. The `setTimeout(0)` that existed only to let the disabled state paint before the freeze is gone.

## Verification

`pnpm test`, `pnpm typecheck`, api-surface, test-wiring and source-text-assertions pass locally, plus the browser run above. New tests cover the seam: only cut candidates are sent, progress is reported per element, no batch runs when nothing needs cutting, a failing batch does not emit a partial file, and `runZoneSplitBatch` returns the piece for the zone asked for. The "only cut candidates are sent" test was checked by making the classifier send the whole elements too, which fails it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Zone geometry exports now run asynchronously, keeping the viewer responsive during large operations.
  * Added progress updates while zone geometry is being split and exported.
  * Geometry processing can use background browser processing with a fallback when unavailable.
  * Improved handling of split failures, empty zones, and invalid geometry during export.
  * Export controls remain disabled while processing, with clear feedback for overlapping exports.

* **Bug Fixes**
  * Prevented incomplete export files from being produced when geometry processing fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->