### PR TITLE
refactor(viewer): split CesiumOverlay into the four things it was doing

### DIFF
--- a/.changeset/cesium-overlay-split.md
+++ b/.changeset/cesium-overlay-split.md
@@ -4,8 +4,8 @@
 
 Split `CesiumOverlay.tsx` into the four responsibilities it had accumulated.
 
-The file had grown past 1,000 lines carrying the Cesium viewer's lifecycle, the coordinate bridge, the model lifecycle and the solar study at once — four subjects with four different histories, interleaved. It is now 419 lines and reads as what it is: create the viewer, render the container, and call four hooks in the order their effects used to sit in.
+The file had grown past 1,000 lines carrying the Cesium viewer's lifecycle, the coordinate bridge, the model lifecycle and the solar study at once — four subjects with four different histories, interleaved. It is now 377 lines and reads as what it is: create the viewer, render the container, and call four hooks in the order their effects used to sit in.
 
 `cesium/useCesiumBridge` owns where the model sits (ENU/ECEF framing, grid convergence, geoid undulation, terrain clamping, placement drafts). `cesium/useCesiumModel` owns what is drawn (GLB build, readiness-gated swap, matrix updates). `cesium/useCesiumSolar` owns lighting, shadows, the sun-path dome and the sky. `cesium/useCesiumCameraSync` owns the per-frame camera mirror, and `cesium/cesium-module` the lazy CesiumJS import they share.
 
-Behaviour is unchanged, and the ordering that makes it unchanged is now written down: React runs effects in declaration order and cleanups in reverse, so each hook documents where it must be called and why. Two teardown paths that the viewer effect cannot reach on unmount — the model's and the solar study's — are exposed as explicit `invalidate()` callbacks rather than left implicit.
+Behaviour is unchanged, and the ordering that makes it unchanged is now written down: within a component React runs effect setups AND cleanups in declaration order, so the viewer effect — declared first — also cleans up first, and nothing in a later hook's cleanup may assume a live scene. Each hook documents where it must be called and what that buys it. Two teardown paths that the viewer effect cannot reach on unmount — the model's and the solar study's — are exposed as explicit `invalidate()` callbacks rather than left implicit.

--- a/.changeset/cesium-overlay-split.md
+++ b/.changeset/cesium-overlay-split.md
@@ -1,0 +1,11 @@
+---
+"@ifc-lite/viewer": patch
+---
+
+Split `CesiumOverlay.tsx` into the four responsibilities it had accumulated.
+
+The file had grown past 1,000 lines carrying the Cesium viewer's lifecycle, the coordinate bridge, the model lifecycle and the solar study at once — four subjects with four different histories, interleaved. It is now 419 lines and reads as what it is: create the viewer, render the container, and call four hooks in the order their effects used to sit in.
+
+`cesium/useCesiumBridge` owns where the model sits (ENU/ECEF framing, grid convergence, geoid undulation, terrain clamping, placement drafts). `cesium/useCesiumModel` owns what is drawn (GLB build, readiness-gated swap, matrix updates). `cesium/useCesiumSolar` owns lighting, shadows, the sun-path dome and the sky. `cesium/useCesiumCameraSync` owns the per-frame camera mirror, and `cesium/cesium-module` the lazy CesiumJS import they share.
+
+Behaviour is unchanged, and the ordering that makes it unchanged is now written down: React runs effects in declaration order and cleanups in reverse, so each hook documents where it must be called and why. Two teardown paths that the viewer effect cannot reach on unmount — the model's and the solar study's — are exposed as explicit `invalidate()` callbacks rather than left implicit.

--- a/apps/viewer/src/components/viewer/CesiumOverlay.tsx
+++ b/apps/viewer/src/components/viewer/CesiumOverlay.tsx
@@ -32,127 +32,15 @@ import {
   orthometricTargetForTerrain,
 } from '@/lib/geo/cesium-placement';
 import { egm96Undulation } from '@/lib/geo/egm96-undulation';
-import { buildCesiumModelGLB, cesiumModelGLBKey, type CesiumModelGLBInput } from '@/lib/geo/cesium-model-glb';
-import { swapCesiumModel } from '@/lib/geo/cesium-model-swap';
-import { effectiveIsolatedIds } from '@/lib/effective-isolation';
-import { VisibilityEpochTracker } from '@ifc-lite/renderer';
 import { applySolarScene, SunPathDome } from '@/lib/geo/cesium-sun';
 import { sunPosition, sunTimes } from '@ifc-lite/solar';
-
-// Lazy-loaded Cesium module and CSS
-let cesiumPromise: Promise<typeof import('cesium')> | null = null;
-let cesiumModule: typeof import('cesium') | null = null;
-function loadCesium() {
-  if (!cesiumPromise) {
-    cesiumPromise = Promise.all([
-      import('cesium'),
-      import('cesium/Build/Cesium/Widgets/widgets.css'),
-    ]).then(([cesium]) => {
-      cesiumModule = cesium;
-      return cesium;
-    });
-  }
-  return cesiumPromise;
-}
+import { loadCesium, getCesiumModule } from './cesium/cesium-module';
+import { useCesiumBridge } from './cesium/useCesiumBridge';
+import { useCesiumModel } from './cesium/useCesiumModel';
+import { useCesiumSolar } from './cesium/useCesiumSolar';
+import { useCesiumCameraSync } from './cesium/useCesiumCameraSync';
 
 
-
-/**
- * Build a Cesium model matrix for placing the IFC model in ECEF.
- * Extracted as a pure function so it can be called from both
- * the GLB load effect (initial) and the matrix update effect (instant).
- */
-function buildModelMatrix(
-  Cesium: typeof import('cesium'),
-  bridge: CesiumBridge,
-  coordinateInfo: CoordinateInfo | undefined,
-) {
-  // GLB vertices are in viewer-space metres (geometry engine converts during
-  // extraction; the effective map scale is already folded into the rotation).
-  const bounds = coordinateInfo?.originalBounds;
-  // Viewer bounds are already in metres (geometry engine converts from IFC native unit)
-  const mvx = bounds ? (bounds.min.x + bounds.max.x) / 2 : 0;
-  const mvy = bounds ? (bounds.min.y + bounds.max.y) / 2 : 0;
-  const mvz = bounds ? (bounds.min.z + bounds.max.z) / 2 : 0;
-
-  // bridge.modelOrigin.height is the placement altitude — Effect 2 already
-  // baked terrain clamping (when applicable) into it before constructing the
-  // bridge, so there's no per-frame clamp adjustment to make here.
-  const origin = Cesium.Cartesian3.fromDegrees(
-    bridge.modelOrigin.longitude, bridge.modelOrigin.latitude, bridge.modelOrigin.height,
-  );
-  const enuToEcef = Cesium.Transforms.eastNorthUpToFixedFrame(origin);
-  // No lengthUnitScale here: viewer-space GLB vertices are already in metres.
-  // Reuse the bridge's convergence-corrected viewer-to-ENU rotation so the
-  // model geometry and the camera frame agree on north; a grid-only rotation
-  // here would leave the model rotated by the meridian convergence off the
-  // true-north basemap (up to ~8 deg for Krovak). See #1408.
-  const rot = bridge.viewerRotation;
-  const tx = -(rot.eastFromVx * mvx + rot.eastFromVz * mvz);
-  const ty = -(rot.northFromVx * mvx + rot.northFromVz * mvz);
-  const tz = -mvy;
-  const ifcToEnu = new Cesium.Matrix4(
-    rot.eastFromVx,  0, rot.eastFromVz,  tx,
-    rot.northFromVx, 0, rot.northFromVz, ty,
-    0,               1, 0,               tz,
-    0,               0, 0,               1,
-  );
-  return Cesium.Matrix4.multiply(enuToEcef, ifcToEnu, new Cesium.Matrix4());
-}
-
-/** The slice of `Cesium.Model` this overlay touches. */
-type CesiumModelPrimitive = {
-  modelMatrix: any;
-  shadows?: any;
-  ready?: boolean;
-  readyEvent?: { addEventListener(cb: () => void): () => void };
-  destroy?: () => void;
-};
-
-/**
- * Resolves once `model` can actually draw.
- *
- * `Model.fromGltfAsync` resolving only means the glTF was fetched and parsed:
- * Cesium finishes creating WebGL resources inside `update()` over subsequent
- * frames, raises `readyEvent` from `frameState.afterRender`, and then skips one
- * more frame before rendering. Waiting for the event plus a rendered frame is
- * what makes "swap without a visible gap" true rather than merely
- * "swap without an empty collection" (#2583).
- *
- * Rejects if neither happens within the timeout, so a model that never becomes
- * renderable cannot strand its predecessor on the globe for the session.
- */
-function whenModelRenderable(
-  viewer: { scene: { postRender: { addEventListener(cb: () => void): () => void } }; },
-  model: CesiumModelPrimitive,
-  timeoutMs = 5_000,
-): Promise<void> {
-  return new Promise<void>((resolve, reject) => {
-    let done = false;
-    const finish = (ok: boolean) => {
-      if (done) return;
-      done = true;
-      offReady?.();
-      offFrame?.();
-      globalThis.clearTimeout(timer);
-      if (ok) { resolve(); return; }
-      // Bounded on purpose: the timeout path degrades to exactly the old
-      // behaviour (drop the previous model and accept a brief blank), so a
-      // model that is merely slow costs a flicker, not a stranded primitive.
-      console.warn('[CesiumOverlay] model did not report renderable within %d ms; swapping anyway', timeoutMs);
-      reject(new Error('model never became renderable'));
-    };
-    // One rendered frame AFTER ready — Cesium deliberately returns early from
-    // the update that raises the event, so the model draws on the next one.
-    const afterReady = () => { offFrame = viewer.scene.postRender.addEventListener(() => finish(true)); };
-    let offFrame: (() => void) | undefined;
-    let offReady: (() => void) | undefined;
-    const timer = globalThis.setTimeout(() => finish(false), timeoutMs);
-    if (model.ready) { afterReady(); return; }
-    if (!model.readyEvent) { finish(true); return; } // nothing to wait on
-    offReady = model.readyEvent.addEventListener(() => { offReady?.(); afterReady(); });
-  });
-}
 
 export interface CesiumOverlayProps {
   mapConversion?: MapConversion;
@@ -187,34 +75,27 @@ export function CesiumOverlay({
   const bridgeRef = useRef<CesiumBridge | null>(null);
   const cameraBridgeRef = useRef<CesiumBridge | null>(null);
   const rafRef = useRef<number | null>(null);
+  // Bridges the model hook's teardown back to the viewer effect, which is
+  // DECLARED FIRST and so cannot call the hook's return value directly. Read
+  // only from that effect's cleanup, long after the assignment below.
+  const invalidateModelRef = useRef<() => void>(() => {});
+  const invalidateSolarRef = useRef<() => void>(() => {});
   const [status, setStatus] = useState<'idle' | 'loading' | 'ready' | 'error'>('idle');
   const [error, setError] = useState<string | null>(null);
   // Tracks bridge readiness as state (not just a ref) so terrain query effect re-runs
-  const [bridgeVersion, setBridgeVersion] = useState(0);
   // Bumped every time a NEW model primitive reaches the globe. `cesiumGlbLoaded`
   // used to serve this purpose by flipping false→true around every rebuild, but
   // the model now stays loaded across one (#2583), so the flag no longer moves.
-  const [cesiumModelEpoch, setCesiumModelEpoch] = useState(0);
 
   const cesiumEnabled = useViewerStore((s) => s.cesiumEnabled);
   const dataSource = useViewerStore((s) => s.cesiumDataSource);
   const ionToken = useViewerStore((s) => s.cesiumIonToken);
   const terrainEnabled = useViewerStore((s) => s.cesiumTerrainEnabled);
-  const heightsAreEllipsoidal = useViewerStore((s) => s.cesiumHeightsAreEllipsoidal);
   const terrainClipY = useViewerStore((s) => s.cesiumTerrainClipY);
-  const setCesiumTerrainHeight = useViewerStore((s) => s.setCesiumTerrainHeight);
-  const setCesiumTerrainSource = useViewerStore((s) => s.setCesiumTerrainSource);
-  const setCesiumTerrainSaveHeight = useViewerStore((s) => s.setCesiumTerrainSaveHeight);
-  const setCesiumTerrainClipY = useViewerStore((s) => s.setCesiumTerrainClipY);
-  const setCesiumGlbLoaded = useViewerStore((s) => s.setCesiumGlbLoaded);
   // In-place mesh mutations (a gizmo move rewrites positions in the SAME
   // arrays) change no mesh count, so the world-view GLB cache keys on this too.
-  const geometryContentVersion = useViewerStore((s) => s.geometryContentVersion);
   // Hide/isolate, resolved the way Viewport resolves what it hands the
   // renderer, so the map draws the elements the viewport draws (#2578).
-  const hiddenEntities = useViewerStore((s) => s.hiddenEntities);
-  const storeIsolatedEntities = useViewerStore((s) => s.isolatedEntities);
-  const isolatedEntities = effectiveIsolatedIds(computedIsolatedIds, storeIsolatedEntities);
   // The GLB effect keys on this version, NOT on the Set references. The store
   // hands out a fresh Set on every visibility action, and the effect's cleanup
   // pulls the model off the globe — so keying on identity blanks the map for a
@@ -224,46 +105,23 @@ export function CesiumOverlay({
   //
   // Safe to run during render: `update()` only bumps when the content actually
   // changed, so a double-invoked render (StrictMode) returns the same version.
-  const visibilityEpochsRef = useRef(new VisibilityEpochTracker());
-  const visibilityVersion = visibilityEpochsRef.current.update(hiddenEntities, isolatedEntities);
   // Read inside the deferred build, which runs long after the effect fired.
-  const visibilityRef = useRef({ hiddenIds: hiddenEntities, isolatedIds: isolatedEntities });
-  visibilityRef.current = { hiddenIds: hiddenEntities, isolatedIds: isolatedEntities };
 
   // Solar study state — drives the sun-path dome + shadow study.
-  const solarEnabled = useViewerStore((s) => s.solarEnabled);
-  const solarDateMs = useViewerStore((s) => s.solarDateMs);
-  const solarShowSunPath = useViewerStore((s) => s.solarShowSunPath);
-  const solarShowShadows = useViewerStore((s) => s.solarShowShadows);
-  const setSolarSunInfo = useViewerStore((s) => s.setSolarSunInfo);
   // Environment sky toggle — atmosphere + sun + fog in geo mode.
-  const envSkyEnabled = useViewerStore((s) => s.envSkyEnabled);
 
   // Track the Cesium model (IFC geometry loaded as glTF for correct world positioning)
-  const cesiumModelRef = useRef<CesiumModelPrimitive | null>(null);
-  const glbCacheRef = useRef<{ key: string; glb: Uint8Array } | null>(null);
   // Key of the model actually ON the globe, which is not the same thing as the
   // key of the last GLB built — see the gate in Effect 2c.
-  const loadedKeyRef = useRef<string | null>(null);
   // Active 3D context tileset (Google Photorealistic / OSM buildings) — kept so
   // solar mode can toggle its shadow casting/receiving.
   const tilesetRef = useRef<{ shadows?: any } | null>(null);
   // Active sun-path dome entity collection (null when solar study is off).
-  const sunPathDomeRef = useRef<SunPathDome | null>(null);
   // UTC calendar day the dome's static geometry (day-arc, analemmas) was built
   // for. Intra-day time scrubs only move the sun marker; a new day rebuilds.
-  const sunPathDomeDayRef = useRef<string | null>(null);
   // Whether the solar study has ever touched Cesium scene state. Guards us
   // from mutating the default (non-solar) lighting on plain mount.
-  const solarTouchedSceneRef = useRef(false);
 
-  // Last-known placement altitude (in metres) used to keep the user's WORLD
-  // camera position stable across bridge rebuilds. When the user toggles the
-  // clamp or edits OrthogonalHeight, the model placement changes and the
-  // entire viewer→ECEF frame translates with it; we offset the IFC viewer's
-  // camera Y by the inverse so the user perceives the model moving instead
-  // of the camera being dragged along.
-  const prevPlacementRef = useRef<number | null>(null);
 
   // ─── Effect 1: Create/destroy the Cesium viewer (heavy, rare) ───────────
   // Only depends on cesiumEnabled, ionToken, terrainEnabled, dataSource.
@@ -424,564 +282,67 @@ export function CesiumOverlay({
       // Invalidate model ref — the destroyed viewer took the primitive with it,
       // so Effect 2c must re-load the GLB into the next viewer instance. The
       // store flag has to follow, or it advertises a model that is gone.
-      cesiumModelRef.current = null;
-      loadedKeyRef.current = null;
-      setCesiumGlbLoaded(false);
+      invalidateModelRef.current();
       bridgeRef.current = null;
       // The destroyed viewer also took the tileset + sun-path entities.
       tilesetRef.current = null;
-      sunPathDomeRef.current = null;
-      sunPathDomeDayRef.current = null;
-      solarTouchedSceneRef.current = false;
+      invalidateSolarRef.current();
       setStatus('idle');
     };
   }, [cesiumEnabled, ionToken, terrainEnabled, dataSource]);
 
-  // ─── Effect 2: Build the coordinate bridge with terrain-aware placement ─
-  // Precomputes the model placement (floored to the visible surface when
-  // necessary) BEFORE
-  // building the bridge that the GLB and camera will share. This way the
-  // model loads into Cesium at its final altitude — no post-load shifting,
-  // no camera/model frame divergence, no compensation gymnastics.
-  //
-  // Sequence:
-  //   1. Build a tentative bridge to recover the model's WGS84 lat/lon.
-  //   2. Query terrain at that lat/lon (sync first, async with retry next).
-  //   3. Auto-floor the model if its authored base sits below the visible surface.
-  //   4. Rebuild the bridge with placementHeight baked into its enuToEcef
-  //      origin so model matrix and camera frame share a single altitude.
-  //   5. Push terrain-derived state (height, clip Y) and
-  //      install the bridge.
-  useEffect(() => {
-    if (status !== 'ready' || !mapConversion || !projectedCRS) {
-      bridgeRef.current = null;
-      cameraBridgeRef.current = null;
-      prevPlacementRef.current = null;
-      return;
-    }
-
-    let cancelled = false;
-
-    (async () => {
-      const Cesium = cesiumModule;
-      const viewer = viewerRef.current;
-      if (!Cesium || !viewer) return;
-
-      const cameraConversion = cameraMapConversion ?? mapConversion;
-      const usesSeparateCameraBridge = cameraConversion !== mapConversion;
-      const cameraTentative = await createCesiumBridge(
-        cameraConversion, projectedCRS, coordinateInfo, lengthUnitScale,
-        undefined, heightsAreEllipsoidal,
-      );
-      if (cancelled) return;
-      if (!cameraTentative) {
-        bridgeRef.current = null;
-        cameraBridgeRef.current = null;
-        return;
-      }
-
-      // Query terrain at the model's location. queryTerrainHeight tries
-      // Cesium's sync sources first (globe.getHeight, scene.sampleHeight),
-      // then Open-Meteo as a fast network fallback that works even with
-      // Google Photorealistic 3D Tiles (where there's no Cesium terrain
-      // provider for getHeight to read). Cached per-session.
-      const preferOrthometricTerrain = shouldPreferOrthometricTerrain(projectedCRS);
-      let terrainSample = null;
-      try {
-        terrainSample = await cameraTentative.queryTerrainHeight(Cesium, viewer, {
-          cacheNamespace: [
-            terrainEnabled ? 'terrain' : 'ellipsoid',
-            dataSource,
-            preferOrthometricTerrain ? 'orthometric' : 'visual-surface',
-          ].join(':'),
-          preferOrthometric: preferOrthometricTerrain,
-        });
-      }
-      catch (err) { console.warn('[CesiumOverlay] terrain query failed:', err); }
-      if (cancelled) return;
-      const terrainH = terrainSample?.height ?? null;
-      const modelTentative = usesSeparateCameraBridge
-        ? await createCesiumBridge(
-            mapConversion, projectedCRS, coordinateInfo, lengthUnitScale,
-            undefined, heightsAreEllipsoidal,
-          )
-        : cameraTentative;
-      if (cancelled) return;
-      if (!modelTentative) {
-        bridgeRef.current = null;
-        return;
-      }
-      // Placement is purely IFC-authored — no terrain/storey clamp. The
-      // tentative bridges already carry the model's authored altitude
-      // (IfcMapConversion.OrthogonalHeight + geometry origin), so they ARE
-      // the final bridges. computeCesiumPlacement is still called for the
-      // clip-plane Y; placementHeight == ifcOriginHeight.
-      // The model origin is now ellipsoidal (orthometric + geoid N, #1355).
-      // Express an orthometric terrain sample in the same ellipsoidal frame so
-      // the below-terrain clip plane stays consistent; Cesium-sourced terrain
-      // is already ellipsoidal and needs no shift.
-      const terrainHForFrame = (terrainSample?.reference === 'orthometric' && terrainH !== null)
-        ? terrainH + egm96Undulation(modelTentative.modelOrigin.latitude, modelTentative.modelOrigin.longitude)
-        : terrainH;
-      const placement = computeCesiumPlacement({
-        coordinateInfo,
-        projectedCRS,
-        ifcOriginHeight: modelTentative.modelOrigin.height,
-        terrainHeight: terrainHForFrame,
-        storeyElevations,
-      });
-      const cameraPlacement = usesSeparateCameraBridge
-        ? computeCesiumPlacement({
-            coordinateInfo,
-            projectedCRS,
-            ifcOriginHeight: cameraTentative.modelOrigin.height,
-            terrainHeight: terrainHForFrame,
-            storeyElevations,
-          })
-        : placement;
-
-      // The model bridge is the tentative one — placement == authored origin.
-      const bridge = modelTentative;
-
-      if (terrainSample) {
-        setCesiumTerrainHeight(terrainH);
-        setCesiumTerrainSource(
-          `${terrainSample.source}${terrainSample.reference === 'orthometric' ? ' (orthometric)' : ''}`,
-        );
-        // Snap-to-terrain target in the OrthogonalHeight frame: the read path
-        // places the base at OrthogonalHeight + geoid N, so persist the
-        // ellipsoidal terrain altitude (terrainHForFrame) minus the same N that
-        // was actually applied to this model. N mirrors the bridge: the EGM96
-        // undulation, or 0 when heights are flagged ellipsoidal. Keeps the snap
-        // button round-tripping (#1456).
-        const appliedGeoidN = shouldApplyGeoidUndulation(heightsAreEllipsoidal)
-          ? egm96Undulation(modelTentative.modelOrigin.latitude, modelTentative.modelOrigin.longitude)
-          : 0;
-        setCesiumTerrainSaveHeight(
-          terrainHForFrame !== null
-            ? orthometricTargetForTerrain(terrainHForFrame, appliedGeoidN)
-            : null,
-        );
-        // terrainClipY stays in viewer-space; it represents the world terrain
-        // altitude expressed in the camera bridge's committed frame. Draft
-        // placement edits must not move this floor, or the camera will drift.
-        setCesiumTerrainClipY(cameraPlacement.terrainClipY);
-      } else {
-        // Failed re-query (offline, API down) — clear stale store fields so
-        // the clip plane doesn't drift relative to the new bridge.
-        setCesiumTerrainHeight(null);
-        setCesiumTerrainSource(null);
-        setCesiumTerrainSaveHeight(null);
-        setCesiumTerrainClipY(null);
-      }
-
-      // World-camera stability: when this rebuild changes the placement
-      // altitude (surface floor or OrthogonalHeight edited), shift the IFC
-      // viewer-space camera Y by the inverse delta so the user's WORLD
-      // camera ECEF position stays put. Without this, the entire frame
-      // translates with the model and edits feel like the camera is
-      // moving instead of the model — exactly what the user reported.
-      const prevPlacement = prevPlacementRef.current;
-      if (!usesSeparateCameraBridge) {
-        prevPlacementRef.current = placement.placementHeight;
-      }
-      if (!usesSeparateCameraBridge && prevPlacement !== null) {
-        const dh = placement.placementHeight - prevPlacement;
-        // 5 cm threshold — rejects float jitter from cached terrain reads
-        // re-flowing through the same effect, while a real placement edit
-        // is always far larger.
-        if (Math.abs(dh) > 0.05) {
-          const renderer = getGlobalRenderer();
-          if (renderer) {
-            const cam = renderer.getCamera();
-            const pos = cam.getPosition();
-            cam.setPosition(pos.x, pos.y - dh, pos.z);
-          }
-        }
-      }
-
-      // Camera bridge: the separate camera-tentative when a placement draft
-      // is previewing (camera holds the base frame while the model moves),
-      // otherwise the model bridge itself. Both are already at their
-      // authored altitude — no placement-override rebuild.
-      const cameraBridge = usesSeparateCameraBridge ? cameraTentative : bridge;
-
-      bridgeRef.current = bridge;
-      cameraBridgeRef.current = cameraBridge;
-      setBridgeVersion((v) => v + 1);
-    })();
-
-    return () => { cancelled = true; };
-    // terrainEnabled and ionToken intentionally omitted — Effect 1 already
-    // owns those (it destroys/recreates the viewer when they change), and
-    // listing them here would cause a redundant bridge rebuild while the
-    // viewer is being torn down.
-  }, [
+  // ─── Coordinate bridge: georeference to a place on the globe ────────────
+  // After the viewer effect (it needs a live viewer for terrain sampling) and
+  // before the model hook, which rebuilds its matrix from `bridgeVersion`.
+  const { bridgeVersion } = useCesiumBridge({
     status,
+    viewerRef,
+    bridgeRef,
+    cameraBridgeRef,
     mapConversion,
     cameraMapConversion,
     projectedCRS,
     coordinateInfo,
     lengthUnitScale,
-    terrainEnabled,
-    heightsAreEllipsoidal,
-    dataSource,
     storeyElevations,
-    setCesiumTerrainHeight,
-    setCesiumTerrainSource,
-    setCesiumTerrainSaveHeight,
-    setCesiumTerrainClipY,
-  ]);
+  });
 
-  // ─── Effect 2c: Load GLB into Cesium (only when geometry changes) ───────
-  // This is the heavy operation — only re-runs when geometry actually changes.
-  useEffect(() => {
-    if (status !== 'ready' || !geometryResult?.meshes?.length) {
-      // The model must not outlive its geometry. The effect cleanup no longer
-      // evicts it (#2583), so a session that unloads its model, or a viewer
-      // that leaves 'ready', is torn down here instead.
-      const live = viewerRef.current;
-      if (cesiumModelRef.current && live) {
-        live.scene.primitives.remove(cesiumModelRef.current);
-        live.scene.requestRender();
-      }
-      cesiumModelRef.current = null;
-      loadedKeyRef.current = null;
-      setCesiumGlbLoaded(false);
-      return;
-    }
-    const viewer = viewerRef.current;
-    const bridge = bridgeRef.current;
-    const Cesium = cesiumModule;
-    if (!viewer || !bridge || !Cesium) return;
-
-    let cancelled = false;
-
-    const startExport = async () => {
-      if (cancelled) return;
-      // Declared at this scope so the catch can release a model that was built
-      // but never installed (the viewer was destroyed mid-load).
-      let model: CesiumModelPrimitive | null = null;
-      try {
-        // Reuse the cached GLB when it was built from the same mesh set. The key
-        // spans flat AND instanced geometry (see cesiumModelGLBKey), so an
-        // all-instanced batch still invalidates it.
-        const glbInput: CesiumModelGLBInput = {
-          geometryResult,
-          geometryContentVersion,
-          hiddenIds: visibilityRef.current.hiddenIds,
-          isolatedIds: visibilityRef.current.isolatedIds,
-          visibilityVersion,
-        };
-        const key = cesiumModelGLBKey(glbInput);
-        const cached = glbCacheRef.current;
-        // Gate on what is ON THE GLOBE, not on what has been BUILT. The two
-        // diverge whenever a load is cancelled or `fromGltfAsync` rejects: the
-        // bytes cache already holds the new key while the old primitive is
-        // still displayed, and gating on the byte cache would then treat the
-        // stale model as current and never retry the load.
-        if (cesiumModelRef.current && loadedKeyRef.current === key) {
-          // Model already loaded with same geometry — just update matrix
-          return;
-        }
-
-        // The previous model deliberately stays on the globe while its
-        // replacement is built and loaded — `swapCesiumModel` exchanges them
-        // at the end, so the map never goes blank mid-rebuild (#2583).
-        let glbBytes: Uint8Array;
-        if (cached?.key === key) {
-          glbBytes = cached.glb;
-        } else {
-          await new Promise(r => setTimeout(r, 50));
-          if (cancelled) return;
-          const built = buildCesiumModelGLB(glbInput);
-          glbBytes = built.glb;
-          glbCacheRef.current = { key: built.key, glb: built.glb };
-        }
-        if (cancelled) return;
-
-        await new Promise(r => setTimeout(r, 0));
-        if (cancelled) return;
-
-        // Build initial model matrix
-        const modelMatrix = buildModelMatrix(Cesium, bridge, coordinateInfo);
-
-        const blob = new Blob([glbBytes as BlobPart], { type: 'model/gltf-binary' });
-        const glbUrl = URL.createObjectURL(blob);
-        try {
-          model = await Cesium.Model.fromGltfAsync({
-            url: glbUrl,
-            modelMatrix,
-            shadows: Cesium.ShadowMode.DISABLED,
-            // The generated GLB stores viewer-space vertices and buildModelMatrix
-            // already maps viewer axes into ENU. Avoid Cesium's default glTF
-            // Y-up/Z-forward correction or the model is rotated onto its side.
-            upAxis: Cesium.Axis.Z,
-            forwardAxis: Cesium.Axis.X,
-          });
-          // Ambient floor. The overlay composits transparently with the
-          // atmosphere/skybox off, so the scene's ONLY light is the directional
-          // sun — without an environment map the model's shadowed faces get no
-          // ambient and read muddy. Give the model a flat image-based-lighting
-          // ambient via a constant spherical-harmonic term: every surface stays
-          // readable while the sun still shapes the lit faces. (#1380)
-          try {
-            const ibl = (model as unknown as {
-              imageBasedLighting?: { sphericalHarmonicCoefficients: unknown };
-            }).imageBasedLighting;
-            if (ibl) {
-              const a = new Cesium.Cartesian3(0.72, 0.72, 0.75); // neutral daylight ambient
-              const z = Cesium.Cartesian3.ZERO;
-              ibl.sphericalHarmonicCoefficients = [a, z, z, z, z, z, z, z, z];
-            }
-          } catch (e) {
-            console.warn('[CesiumOverlay] could not set model ambient IBL:', e);
-          }
-        } finally {
-          URL.revokeObjectURL(glbUrl);
-        }
-        if (cancelled) {
-          model?.destroy?.();
-          return;
-        }
-
-        const outcome = await swapCesiumModel(
-          viewer.scene.primitives,
-          cesiumModelRef.current,
-          model,
-          (m) => whenModelRenderable(viewer, m),
-          () => cancelled,
-        );
-        // Superseded: a newer build owns the outcome, the globe still shows the
-        // previous model, and `model` has already been destroyed. Recording it
-        // would leave the refs pointing at geometry nobody is rendering.
-        if (outcome === 'superseded' || cancelled) return;
-        cesiumModelRef.current = model;
-        loadedKeyRef.current = key;
-        setCesiumGlbLoaded(true);
-        // A rebuild no longer flips `cesiumGlbLoaded` false→true, so that flag
-        // can no longer tell the solar effect "there is a different primitive
-        // now, re-apply its shadow mode". This epoch does.
-        setCesiumModelEpoch((e) => e + 1);
-        viewer.scene.requestRender();
-      } catch (err) {
-        console.warn('[CesiumOverlay] Failed to load IFC model into Cesium:', err);
-        // A model built but never installed (the viewer was destroyed mid-load,
-        // so `primitives.add` threw) owns GPU buffers nothing will release.
-        if (model && cesiumModelRef.current !== model) model.destroy?.();
-      }
-    };
-
-    const deferTimer = setTimeout(startExport, 1000);
-
-    // Cancel the in-flight build only. Evicting the live model here is what
-    // blanked the map on every re-run (#2583); the model is exchanged for its
-    // replacement once that replacement exists, and torn down by the
-    // no-geometry branch above or with the viewer in Effect 1.
-    return () => {
-      cancelled = true;
-      clearTimeout(deferTimer);
-    };
-  }, [status, bridgeVersion, geometryResult, geometryContentVersion, visibilityVersion]);
-
-  // ─── Effect 2d: Update model matrix (instant, no reload) ────────────────
-  // When terrain placement or georef changes, just update the
-  // existing model's matrix — no GLB re-export, no flicker.
-  useEffect(() => {
-    const model = cesiumModelRef.current;
-    const bridge = bridgeRef.current;
-    const viewer = viewerRef.current;
-    const Cesium = cesiumModule;
-    if (!model || !bridge || !viewer || !Cesium) return;
-
-    const newMatrix = buildModelMatrix(Cesium, bridge, coordinateInfo);
-    model.modelMatrix = newMatrix;
-    viewer.scene.requestRender();
-    // Depend on bridgeVersion so the matrix is rebuilt with the *new* bridge
-    // after async createCesiumBridge replaces it. Placement is baked into
-    // bridge.modelOrigin.height by Effect 2.
-  }, [mapConversion, projectedCRS, coordinateInfo, lengthUnitScale, bridgeVersion]);
-
-  // ─── Effect 4: Solar study — sun-path dome + shadows ────────────────────
-  // Drives Cesium's sun/lighting/shadow map from the studied instant, builds
-  // (and live-updates) the 3D sun-path dome anchored at the model origin, and
-  // publishes the resolved sun position/times back to the store for the panel.
-  useEffect(() => {
-    const viewer = viewerRef.current;
-    const bridge = bridgeRef.current;
-    const Cesium = cesiumModule;
-    if (status !== 'ready' || !viewer || !bridge || !Cesium) return;
-
-    // Never mutate the default Cesium lighting until the study is first
-    // enabled — a plain georeferenced model shouldn't have its context
-    // re-lit just because this effect mounts with solar off.
-    if (!solarEnabled && !solarTouchedSceneRef.current) return;
-    solarTouchedSceneRef.current = true;
-
-    const date = new Date(solarDateMs);
-    const { latitude, longitude, height } = bridge.modelOrigin;
-
-    // Cast/receive shadows on the IFC model and the context tileset.
-    const shadowMode = solarEnabled && solarShowShadows
-      ? Cesium.ShadowMode.ENABLED
-      : Cesium.ShadowMode.DISABLED;
-    if (cesiumModelRef.current) cesiumModelRef.current.shadows = shadowMode;
-    if (tilesetRef.current) tilesetRef.current.shadows = shadowMode;
-
-    applySolarScene(Cesium, viewer, {
-      date,
-      enabled: solarEnabled,
-      shadows: solarShowShadows,
-      showSun: envSkyEnabled,
-    });
-
-    if (solarEnabled) {
-      // Publish the readout for the panel.
-      const times = sunTimes(date, latitude, longitude);
-      const sp = sunPosition(date, latitude, longitude);
-      setSolarSunInfo({
-        latitude,
-        longitude,
-        azimuth: sp.azimuth,
-        altitude: sp.altitude,
-        sunriseMs: times.sunrise ? times.sunrise.getTime() : null,
-        sunsetMs: times.sunset ? times.sunset.getTime() : null,
-        solarNoonMs: times.solarNoon.getTime(),
-      });
-
-      if (solarShowSunPath) {
-        const dayKey = `${date.getUTCFullYear()}-${date.getUTCMonth()}-${date.getUTCDate()}:${latitude.toFixed(4)},${longitude.toFixed(4)}`;
-        try {
-          if (!sunPathDomeRef.current || sunPathDomeDayRef.current !== dayKey) {
-            // New day or site → rebuild static geometry (day arc + analemmas).
-            sunPathDomeRef.current?.destroy();
-            const bounds = coordinateInfo?.originalBounds;
-            // Size the dome to roughly the model footprint, but clamp to an
-            // architectural scale: with many federated models the combined
-            // bounds can span kilometres, which would push the dome arcs so
-            // far out they read as nothing. Half-diagonal ≈ bounding radius.
-            const rawRadius = bounds
-              ? 0.5 * Math.hypot(
-                  bounds.max.x - bounds.min.x,
-                  bounds.max.y - bounds.min.y,
-                  bounds.max.z - bounds.min.z,
-                )
-              : 80;
-            const radius = Math.min(250, Math.max(40, rawRadius));
-            sunPathDomeRef.current = new SunPathDome(Cesium, viewer, {
-              origin: { latitude, longitude, height },
-              radius,
-              date,
-              showAnalemmas: true,
-            });
-            sunPathDomeDayRef.current = dayKey;
-          } else {
-            // Same day, new time → just move the sun marker + beam.
-            sunPathDomeRef.current.update(date);
-          }
-        } catch (err) {
-          console.warn('[CesiumOverlay] sun-path dome build/update failed:', err);
-        }
-      } else if (sunPathDomeRef.current) {
-        sunPathDomeRef.current.destroy();
-        sunPathDomeRef.current = null;
-        sunPathDomeDayRef.current = null;
-      }
-    } else if (sunPathDomeRef.current) {
-      sunPathDomeRef.current.destroy();
-      sunPathDomeRef.current = null;
-      sunPathDomeDayRef.current = null;
-    }
-
-    viewer.scene.requestRender();
-  }, [
+  // ─── Model lifecycle: build, load, swap, keep the matrix current ────────
+  // Called HERE, between the bridge effect and the solar effect, because React
+  // runs effects in declaration order and cleanups in reverse — the teardown
+  // inside this hook assumes the viewer effect's cleanup runs after its own.
+  const { modelRef: cesiumModelRef, modelEpoch: cesiumModelEpoch, invalidate: invalidateModel } = useCesiumModel({
     status,
     bridgeVersion,
-    cesiumModelEpoch,
-    solarEnabled,
-    solarDateMs,
-    solarShowSunPath,
-    solarShowShadows,
-    envSkyEnabled,
+    viewerRef,
+    bridgeRef,
+    geometryResult,
     coordinateInfo,
-    setSolarSunInfo,
-  ]);
+    mapConversion,
+    projectedCRS,
+    lengthUnitScale,
+    computedIsolatedIds,
+  });
+  invalidateModelRef.current = invalidateModel;
 
-  // ─── Effect 4b: Sky — atmosphere + sun + fog ────────────────────────────
-  // The environment panel's Sky toggle. Init disables all of these for
-  // transparent compositing; this effect re-enables them on demand. The
-  // area outside the atmosphere stays transparent (skyBox off), so space
-  // composites over the app background like the rest of the overlay.
-  useEffect(() => {
-    const viewer = viewerRef.current;
-    const Cesium = cesiumModule;
-    if (status !== 'ready' || !viewer || !Cesium) return;
-    const scene = viewer.scene;
-    if (scene.skyAtmosphere) scene.skyAtmosphere.show = envSkyEnabled;
-    scene.fog.enabled = envSkyEnabled;
-    // Haze on the satellite base map (no-op while the globe is hidden).
-    scene.globe.showGroundAtmosphere = envSkyEnabled && scene.globe.show;
-    // Sun billboard only when the solar effect isn't already managing it
-    // (applySolarScene runs with showSun and wins on solar state changes).
-    if (scene.sun && !solarTouchedSceneRef.current) {
-      scene.sun.show = envSkyEnabled;
-    }
-    scene.requestRender();
-  }, [status, envSkyEnabled]);
+  // ─── Solar study: lighting, shadows, sun-path dome, sky ─────────────────
+  // Declared AFTER the model hook: it applies shadow settings to the primitive
+  // that hook owns, and keys on its epoch so a swapped-in model gets them.
+  const { invalidate: invalidateSolar } = useCesiumSolar({
+    status,
+    bridgeVersion,
+    viewerRef,
+    bridgeRef,
+    modelRef: cesiumModelRef,
+    modelEpoch: cesiumModelEpoch,
+    tilesetRef,
+    coordinateInfo,
+  });
+  invalidateSolarRef.current = invalidateSolar;
 
-  // ─── Effect 3: Camera sync loop ─────────────────────────────────────────
-  useEffect(() => {
-    if (status !== 'ready') return;
+  // ─── Camera sync: mirror the viewport's pose onto the globe, per frame ──
+  useCesiumCameraSync({ status, viewerRef, bridgeRef, cameraBridgeRef, terrainClipY, rafRef });
 
-    const viewer = viewerRef.current;
-    if (!viewer) return;
-
-    let cancelled = false;
-
-    function syncCamera() {
-      if (cancelled) return;
-
-      const bridge = bridgeRef.current;
-      const cameraBridge = cameraBridgeRef.current ?? bridge;
-      const renderer = getGlobalRenderer();
-      const Cesium = cesiumModule;
-      if (!viewer || !bridge || !cameraBridge || !renderer || !Cesium) {
-        rafRef.current = requestAnimationFrame(syncCamera);
-        return;
-      }
-
-      const camera = renderer.getCamera();
-      let camPos = camera.getPosition();
-      let camTarget = camera.getTarget();
-      const camUp = camera.getUp();
-      const fov = camera.getFOV();
-
-      if (terrainClipY !== null) {
-        const minCameraY = terrainClipY + 0.05;
-        if (camPos.y < minCameraY) {
-          const dy = minCameraY - camPos.y;
-          camPos = { ...camPos, y: minCameraY };
-          camTarget = { ...camTarget, y: camTarget.y + dy };
-        }
-      }
-
-      // bridge.modelOrigin.height already has the placement baked in, so the
-      // camera frame and the model matrix share the same enuToEcef origin altitude.
-      cameraBridge.syncCamera(Cesium, viewer, camPos, camTarget, camUp, fov);
-
-      rafRef.current = requestAnimationFrame(syncCamera);
-    }
-
-    rafRef.current = requestAnimationFrame(syncCamera);
-
-    return () => {
-      cancelled = true;
-      if (rafRef.current !== null) {
-        cancelAnimationFrame(rafRef.current);
-        rafRef.current = null;
-      }
-    };
-  }, [status, terrainClipY]);
 
   if (!cesiumEnabled || !mapConversion || !projectedCRS) {
     return null;

--- a/apps/viewer/src/components/viewer/CesiumOverlay.tsx
+++ b/apps/viewer/src/components/viewer/CesiumOverlay.tsx
@@ -23,24 +23,12 @@ import { useEffect, useRef, useState } from 'react';
 import { useViewerStore } from '@/store';
 import type { MapConversion, ProjectedCRS } from '@ifc-lite/parser';
 import type { CoordinateInfo, GeometryResult } from '@ifc-lite/geometry';
-import { getGlobalRenderer } from '@/hooks/useBCF';
-import { createCesiumBridge, type CesiumBridge } from '@/lib/geo/cesium-bridge';
-import {
-  computeCesiumPlacement,
-  shouldPreferOrthometricTerrain,
-  shouldApplyGeoidUndulation,
-  orthometricTargetForTerrain,
-} from '@/lib/geo/cesium-placement';
-import { egm96Undulation } from '@/lib/geo/egm96-undulation';
-import { applySolarScene, SunPathDome } from '@/lib/geo/cesium-sun';
-import { sunPosition, sunTimes } from '@ifc-lite/solar';
-import { loadCesium, getCesiumModule } from './cesium/cesium-module';
+import type { CesiumBridge } from '@/lib/geo/cesium-bridge';
+import { loadCesium } from './cesium/cesium-module';
 import { useCesiumBridge } from './cesium/useCesiumBridge';
 import { useCesiumModel } from './cesium/useCesiumModel';
 import { useCesiumSolar } from './cesium/useCesiumSolar';
 import { useCesiumCameraSync } from './cesium/useCesiumCameraSync';
-
-
 
 export interface CesiumOverlayProps {
   mapConversion?: MapConversion;
@@ -82,46 +70,16 @@ export function CesiumOverlay({
   const invalidateSolarRef = useRef<() => void>(() => {});
   const [status, setStatus] = useState<'idle' | 'loading' | 'ready' | 'error'>('idle');
   const [error, setError] = useState<string | null>(null);
-  // Tracks bridge readiness as state (not just a ref) so terrain query effect re-runs
-  // Bumped every time a NEW model primitive reaches the globe. `cesiumGlbLoaded`
-  // used to serve this purpose by flipping false→true around every rebuild, but
-  // the model now stays loaded across one (#2583), so the flag no longer moves.
 
   const cesiumEnabled = useViewerStore((s) => s.cesiumEnabled);
   const dataSource = useViewerStore((s) => s.cesiumDataSource);
   const ionToken = useViewerStore((s) => s.cesiumIonToken);
   const terrainEnabled = useViewerStore((s) => s.cesiumTerrainEnabled);
   const terrainClipY = useViewerStore((s) => s.cesiumTerrainClipY);
-  // In-place mesh mutations (a gizmo move rewrites positions in the SAME
-  // arrays) change no mesh count, so the world-view GLB cache keys on this too.
-  // Hide/isolate, resolved the way Viewport resolves what it hands the
-  // renderer, so the map draws the elements the viewport draws (#2578).
-  // The GLB effect keys on this version, NOT on the Set references. The store
-  // hands out a fresh Set on every visibility action, and the effect's cleanup
-  // pulls the model off the globe — so keying on identity blanks the map for a
-  // second and rebuilds a multi-megabyte GLB even when the content is
-  // unchanged. `VisibilityEpochTracker` compares content, so an equal set is a
-  // no-op while an in-place mutation of the same Set still registers.
-  //
-  // Safe to run during render: `update()` only bumps when the content actually
-  // changed, so a double-invoked render (StrictMode) returns the same version.
-  // Read inside the deferred build, which runs long after the effect fired.
 
-  // Solar study state — drives the sun-path dome + shadow study.
-  // Environment sky toggle — atmosphere + sun + fog in geo mode.
-
-  // Track the Cesium model (IFC geometry loaded as glTF for correct world positioning)
-  // Key of the model actually ON the globe, which is not the same thing as the
-  // key of the last GLB built — see the gate in Effect 2c.
   // Active 3D context tileset (Google Photorealistic / OSM buildings) — kept so
   // solar mode can toggle its shadow casting/receiving.
   const tilesetRef = useRef<{ shadows?: any } | null>(null);
-  // Active sun-path dome entity collection (null when solar study is off).
-  // UTC calendar day the dome's static geometry (day-arc, analemmas) was built
-  // for. Intra-day time scrubs only move the sun marker; a new day rebuilds.
-  // Whether the solar study has ever touched Cesium scene state. Guards us
-  // from mutating the default (non-solar) lighting on plain mount.
-
 
   // ─── Effect 1: Create/destroy the Cesium viewer (heavy, rare) ───────────
   // Only depends on cesiumEnabled, ionToken, terrainEnabled, dataSource.
@@ -308,9 +266,10 @@ export function CesiumOverlay({
   });
 
   // ─── Model lifecycle: build, load, swap, keep the matrix current ────────
-  // Called HERE, between the bridge effect and the solar effect, because React
-  // runs effects in declaration order and cleanups in reverse — the teardown
-  // inside this hook assumes the viewer effect's cleanup runs after its own.
+  // Called HERE, between the bridge and the solar study, because React runs a
+  // component's effects — setups AND cleanups — in declaration order. Each
+  // hook's header states what that buys it; moving a call changes teardown
+  // order as much as setup order.
   const { modelRef: cesiumModelRef, modelEpoch: cesiumModelEpoch, invalidate: invalidateModel } = useCesiumModel({
     status,
     bridgeVersion,
@@ -342,7 +301,6 @@ export function CesiumOverlay({
 
   // ─── Camera sync: mirror the viewport's pose onto the globe, per frame ──
   useCesiumCameraSync({ status, viewerRef, bridgeRef, cameraBridgeRef, terrainClipY, rafRef });
-
 
   if (!cesiumEnabled || !mapConversion || !projectedCRS) {
     return null;

--- a/apps/viewer/src/components/viewer/cesium/cesium-module.ts
+++ b/apps/viewer/src/components/viewer/cesium/cesium-module.ts
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The lazily-loaded CesiumJS module, shared by everything in the world view.
+ *
+ * Cesium is large enough that importing it eagerly would land in the initial
+ * bundle, so it is pulled in on first activation and memoised here. Split out
+ * of CesiumOverlay.tsx (#2593) because the model-lifecycle, solar and
+ * camera-sync hooks all need the same instance — a second copy of this memo
+ * would mean a second copy of Cesium.
+ *
+ * `getCesiumModule()` is the synchronous accessor for code that runs after the
+ * viewer exists and therefore knows the load already resolved.
+ */
+
+let cesiumPromise: Promise<typeof import('cesium')> | null = null;
+let cesiumModule: typeof import('cesium') | null = null;
+
+export function loadCesium(): Promise<typeof import('cesium')> {
+  if (!cesiumPromise) {
+    cesiumPromise = Promise.all([
+      import('cesium'),
+      import('cesium/Build/Cesium/Widgets/widgets.css'),
+    ]).then(([cesium]) => {
+      cesiumModule = cesium;
+      return cesium;
+    });
+  }
+  return cesiumPromise;
+}
+
+/** The loaded module, or null before the first `loadCesium()` resolves. */
+export function getCesiumModule(): typeof import('cesium') | null {
+  return cesiumModule;
+}

--- a/apps/viewer/src/components/viewer/cesium/useCesiumBridge.ts
+++ b/apps/viewer/src/components/viewer/cesium/useCesiumBridge.ts
@@ -1,0 +1,283 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The coordinate bridge: where the model's georeference becomes a place on the
+ * globe.
+ *
+ * Split out of CesiumOverlay.tsx (#2593). This is the file that decides WHERE
+ * the model sits — ENU/ECEF framing, grid convergence, geoid undulation,
+ * terrain clamping, and the placement draft the gizmo previews. Its history is
+ * the georeferencing one (#1408 convergence, #1427 altitude, #2526 the
+ * map-absolute guard), which is a different subject from what the world view
+ * draws, and now reads as one.
+ *
+ * ORDERING NOTE: call this hook where its effect sat — after the viewer effect,
+ * before the model hook, which rebuilds its matrix from `bridgeVersion`.
+ */
+
+import { useEffect, useRef, useState, type RefObject } from 'react';
+import { useViewerStore } from '@/store';
+import type { MapConversion, ProjectedCRS } from '@ifc-lite/parser';
+import type { CoordinateInfo } from '@ifc-lite/geometry';
+import { createCesiumBridge, type CesiumBridge } from '@/lib/geo/cesium-bridge';
+import {
+  computeCesiumPlacement,
+  shouldPreferOrthometricTerrain,
+  shouldApplyGeoidUndulation,
+  orthometricTargetForTerrain,
+} from '@/lib/geo/cesium-placement';
+import { egm96Undulation } from '@/lib/geo/egm96-undulation';
+import { getGlobalRenderer } from '@/hooks/useBCF';
+import { getCesiumModule } from './cesium-module';
+
+export interface UseCesiumBridgeParams {
+  status: 'idle' | 'loading' | 'ready' | 'error';
+  viewerRef: RefObject<InstanceType<typeof import('cesium').Viewer> | null>;
+  /** Written by this hook; read by the model, camera and solar hooks. */
+  bridgeRef: RefObject<CesiumBridge | null>;
+  /** The camera-side bridge, which diverges from the model's only while a
+   *  placement draft is previewing. */
+  cameraBridgeRef: RefObject<CesiumBridge | null>;
+  mapConversion?: MapConversion;
+  cameraMapConversion?: MapConversion;
+  projectedCRS?: ProjectedCRS;
+  coordinateInfo?: CoordinateInfo;
+  lengthUnitScale: number;
+  storeyElevations?: Map<number, number>;
+}
+
+export interface UseCesiumBridgeResult {
+  /** Bumped whenever the bridge is replaced, so dependants rebuild against it. */
+  bridgeVersion: number;
+}
+
+export function useCesiumBridge({
+  status,
+  viewerRef,
+  bridgeRef,
+  cameraBridgeRef,
+  mapConversion,
+  cameraMapConversion,
+  projectedCRS,
+  coordinateInfo,
+  lengthUnitScale,
+  storeyElevations,
+}: UseCesiumBridgeParams): UseCesiumBridgeResult {
+  const terrainEnabled = useViewerStore((s) => s.cesiumTerrainEnabled);
+  const heightsAreEllipsoidal = useViewerStore((s) => s.cesiumHeightsAreEllipsoidal);
+  const dataSource = useViewerStore((s) => s.cesiumDataSource);
+  const setCesiumTerrainHeight = useViewerStore((s) => s.setCesiumTerrainHeight);
+  const setCesiumTerrainSource = useViewerStore((s) => s.setCesiumTerrainSource);
+  const setCesiumTerrainSaveHeight = useViewerStore((s) => s.setCesiumTerrainSaveHeight);
+  const setCesiumTerrainClipY = useViewerStore((s) => s.setCesiumTerrainClipY);
+  // Last-known placement altitude (in metres) used to keep the user's WORLD
+  // camera position stable across bridge rebuilds. When the user toggles the
+  // clamp or edits OrthogonalHeight, the model placement changes and the
+  // entire viewer→ECEF frame translates with it; we offset the IFC viewer's
+  // camera Y by the inverse so the user perceives the model moving instead
+  // of the camera being dragged along.
+  const prevPlacementRef = useRef<number | null>(null);
+
+  // Tracks bridge readiness as state (not just a ref) so dependants re-run.
+  const [bridgeVersion, setBridgeVersion] = useState(0);
+
+  // ─── Effect 2: Build the coordinate bridge with terrain-aware placement ─
+  // Precomputes the model placement (floored to the visible surface when
+  // necessary) BEFORE
+  // building the bridge that the GLB and camera will share. This way the
+  // model loads into Cesium at its final altitude — no post-load shifting,
+  // no camera/model frame divergence, no compensation gymnastics.
+  //
+  // Sequence:
+  //   1. Build a tentative bridge to recover the model's WGS84 lat/lon.
+  //   2. Query terrain at that lat/lon (sync first, async with retry next).
+  //   3. Auto-floor the model if its authored base sits below the visible surface.
+  //   4. Rebuild the bridge with placementHeight baked into its enuToEcef
+  //      origin so model matrix and camera frame share a single altitude.
+  //   5. Push terrain-derived state (height, clip Y) and
+  //      install the bridge.
+  useEffect(() => {
+    if (status !== 'ready' || !mapConversion || !projectedCRS) {
+      bridgeRef.current = null;
+      cameraBridgeRef.current = null;
+      prevPlacementRef.current = null;
+      return;
+    }
+
+    let cancelled = false;
+
+    (async () => {
+      const Cesium = getCesiumModule();
+      const viewer = viewerRef.current;
+      if (!Cesium || !viewer) return;
+
+      const cameraConversion = cameraMapConversion ?? mapConversion;
+      const usesSeparateCameraBridge = cameraConversion !== mapConversion;
+      const cameraTentative = await createCesiumBridge(
+        cameraConversion, projectedCRS, coordinateInfo, lengthUnitScale,
+        undefined, heightsAreEllipsoidal,
+      );
+      if (cancelled) return;
+      if (!cameraTentative) {
+        bridgeRef.current = null;
+        cameraBridgeRef.current = null;
+        return;
+      }
+
+      // Query terrain at the model's location. queryTerrainHeight tries
+      // Cesium's sync sources first (globe.getHeight, scene.sampleHeight),
+      // then Open-Meteo as a fast network fallback that works even with
+      // Google Photorealistic 3D Tiles (where there's no Cesium terrain
+      // provider for getHeight to read). Cached per-session.
+      const preferOrthometricTerrain = shouldPreferOrthometricTerrain(projectedCRS);
+      let terrainSample = null;
+      try {
+        terrainSample = await cameraTentative.queryTerrainHeight(Cesium, viewer, {
+          cacheNamespace: [
+            terrainEnabled ? 'terrain' : 'ellipsoid',
+            dataSource,
+            preferOrthometricTerrain ? 'orthometric' : 'visual-surface',
+          ].join(':'),
+          preferOrthometric: preferOrthometricTerrain,
+        });
+      }
+      catch (err) { console.warn('[CesiumOverlay] terrain query failed:', err); }
+      if (cancelled) return;
+      const terrainH = terrainSample?.height ?? null;
+      const modelTentative = usesSeparateCameraBridge
+        ? await createCesiumBridge(
+            mapConversion, projectedCRS, coordinateInfo, lengthUnitScale,
+            undefined, heightsAreEllipsoidal,
+          )
+        : cameraTentative;
+      if (cancelled) return;
+      if (!modelTentative) {
+        bridgeRef.current = null;
+        return;
+      }
+      // Placement is purely IFC-authored — no terrain/storey clamp. The
+      // tentative bridges already carry the model's authored altitude
+      // (IfcMapConversion.OrthogonalHeight + geometry origin), so they ARE
+      // the final bridges. computeCesiumPlacement is still called for the
+      // clip-plane Y; placementHeight == ifcOriginHeight.
+      // The model origin is now ellipsoidal (orthometric + geoid N, #1355).
+      // Express an orthometric terrain sample in the same ellipsoidal frame so
+      // the below-terrain clip plane stays consistent; Cesium-sourced terrain
+      // is already ellipsoidal and needs no shift.
+      const terrainHForFrame = (terrainSample?.reference === 'orthometric' && terrainH !== null)
+        ? terrainH + egm96Undulation(modelTentative.modelOrigin.latitude, modelTentative.modelOrigin.longitude)
+        : terrainH;
+      const placement = computeCesiumPlacement({
+        coordinateInfo,
+        projectedCRS,
+        ifcOriginHeight: modelTentative.modelOrigin.height,
+        terrainHeight: terrainHForFrame,
+        storeyElevations,
+      });
+      const cameraPlacement = usesSeparateCameraBridge
+        ? computeCesiumPlacement({
+            coordinateInfo,
+            projectedCRS,
+            ifcOriginHeight: cameraTentative.modelOrigin.height,
+            terrainHeight: terrainHForFrame,
+            storeyElevations,
+          })
+        : placement;
+
+      // The model bridge is the tentative one — placement == authored origin.
+      const bridge = modelTentative;
+
+      if (terrainSample) {
+        setCesiumTerrainHeight(terrainH);
+        setCesiumTerrainSource(
+          `${terrainSample.source}${terrainSample.reference === 'orthometric' ? ' (orthometric)' : ''}`,
+        );
+        // Snap-to-terrain target in the OrthogonalHeight frame: the read path
+        // places the base at OrthogonalHeight + geoid N, so persist the
+        // ellipsoidal terrain altitude (terrainHForFrame) minus the same N that
+        // was actually applied to this model. N mirrors the bridge: the EGM96
+        // undulation, or 0 when heights are flagged ellipsoidal. Keeps the snap
+        // button round-tripping (#1456).
+        const appliedGeoidN = shouldApplyGeoidUndulation(heightsAreEllipsoidal)
+          ? egm96Undulation(modelTentative.modelOrigin.latitude, modelTentative.modelOrigin.longitude)
+          : 0;
+        setCesiumTerrainSaveHeight(
+          terrainHForFrame !== null
+            ? orthometricTargetForTerrain(terrainHForFrame, appliedGeoidN)
+            : null,
+        );
+        // terrainClipY stays in viewer-space; it represents the world terrain
+        // altitude expressed in the camera bridge's committed frame. Draft
+        // placement edits must not move this floor, or the camera will drift.
+        setCesiumTerrainClipY(cameraPlacement.terrainClipY);
+      } else {
+        // Failed re-query (offline, API down) — clear stale store fields so
+        // the clip plane doesn't drift relative to the new bridge.
+        setCesiumTerrainHeight(null);
+        setCesiumTerrainSource(null);
+        setCesiumTerrainSaveHeight(null);
+        setCesiumTerrainClipY(null);
+      }
+
+      // World-camera stability: when this rebuild changes the placement
+      // altitude (surface floor or OrthogonalHeight edited), shift the IFC
+      // viewer-space camera Y by the inverse delta so the user's WORLD
+      // camera ECEF position stays put. Without this, the entire frame
+      // translates with the model and edits feel like the camera is
+      // moving instead of the model — exactly what the user reported.
+      const prevPlacement = prevPlacementRef.current;
+      if (!usesSeparateCameraBridge) {
+        prevPlacementRef.current = placement.placementHeight;
+      }
+      if (!usesSeparateCameraBridge && prevPlacement !== null) {
+        const dh = placement.placementHeight - prevPlacement;
+        // 5 cm threshold — rejects float jitter from cached terrain reads
+        // re-flowing through the same effect, while a real placement edit
+        // is always far larger.
+        if (Math.abs(dh) > 0.05) {
+          const renderer = getGlobalRenderer();
+          if (renderer) {
+            const cam = renderer.getCamera();
+            const pos = cam.getPosition();
+            cam.setPosition(pos.x, pos.y - dh, pos.z);
+          }
+        }
+      }
+
+      // Camera bridge: the separate camera-tentative when a placement draft
+      // is previewing (camera holds the base frame while the model moves),
+      // otherwise the model bridge itself. Both are already at their
+      // authored altitude — no placement-override rebuild.
+      const cameraBridge = usesSeparateCameraBridge ? cameraTentative : bridge;
+
+      bridgeRef.current = bridge;
+      cameraBridgeRef.current = cameraBridge;
+      setBridgeVersion((v) => v + 1);
+    })();
+
+    return () => { cancelled = true; };
+    // terrainEnabled and ionToken intentionally omitted — Effect 1 already
+    // owns those (it destroys/recreates the viewer when they change), and
+    // listing them here would cause a redundant bridge rebuild while the
+    // viewer is being torn down.
+  }, [
+    status,
+    mapConversion,
+    cameraMapConversion,
+    projectedCRS,
+    coordinateInfo,
+    lengthUnitScale,
+    terrainEnabled,
+    heightsAreEllipsoidal,
+    dataSource,
+    storeyElevations,
+    setCesiumTerrainHeight,
+    setCesiumTerrainSource,
+    setCesiumTerrainSaveHeight,
+    setCesiumTerrainClipY,
+  ]);
+
+  return { bridgeVersion };
+}

--- a/apps/viewer/src/components/viewer/cesium/useCesiumCameraSync.ts
+++ b/apps/viewer/src/components/viewer/cesium/useCesiumCameraSync.ts
@@ -27,8 +27,9 @@ export interface UseCesiumCameraSyncParams {
   terrainClipY: number | null;
   /**
    * Owned by the CALLER, not this hook. The viewer effect cancels the loop from
-   * its own cleanup, which runs BEFORE this hook re-runs — without that, the
-   * loop can tick once against a viewer that has just been destroyed.
+   * its own cleanup, and every cleanup in a commit runs before any effect
+   * re-runs — so the frame that would otherwise tick against a just-destroyed
+   * viewer never happens. Moving the handle in here would lose that.
    */
   rafRef: RefObject<number | null>;
 }

--- a/apps/viewer/src/components/viewer/cesium/useCesiumCameraSync.ts
+++ b/apps/viewer/src/components/viewer/cesium/useCesiumCameraSync.ts
@@ -1,0 +1,98 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Drives the Cesium camera from the IFC viewer's camera, every frame.
+ *
+ * Split out of CesiumOverlay.tsx (#2593). The two canvases are composited, not
+ * shared: the WebGPU viewport owns user input and this loop mirrors its pose
+ * into ECEF so the globe stays underneath the model. It is the only per-frame
+ * work in the overlay, which is reason enough for it to be its own file.
+ */
+
+import { useEffect, type RefObject } from 'react';
+import type { CesiumBridge } from '@/lib/geo/cesium-bridge';
+import { getGlobalRenderer } from '@/hooks/useBCF';
+import { getCesiumModule } from './cesium-module';
+
+export interface UseCesiumCameraSyncParams {
+  status: 'idle' | 'loading' | 'ready' | 'error';
+  viewerRef: RefObject<InstanceType<typeof import('cesium').Viewer> | null>;
+  bridgeRef: RefObject<CesiumBridge | null>;
+  /** The camera-side bridge, which may differ from the model's while a
+   *  placement draft is previewing; falls back to `bridgeRef`. */
+  cameraBridgeRef: RefObject<CesiumBridge | null>;
+  /** Terrain clip height, re-read each frame. */
+  terrainClipY: number | null;
+  /**
+   * Owned by the CALLER, not this hook. The viewer effect cancels the loop from
+   * its own cleanup, which runs BEFORE this hook re-runs — without that, the
+   * loop can tick once against a viewer that has just been destroyed.
+   */
+  rafRef: RefObject<number | null>;
+}
+
+export function useCesiumCameraSync({
+  status,
+  viewerRef,
+  bridgeRef,
+  cameraBridgeRef,
+  terrainClipY,
+  rafRef,
+}: UseCesiumCameraSyncParams): void {
+
+  // ─── Effect 3: Camera sync loop ─────────────────────────────────────────
+  useEffect(() => {
+    if (status !== 'ready') return;
+
+    const viewer = viewerRef.current;
+    if (!viewer) return;
+
+    let cancelled = false;
+
+    function syncCamera() {
+      if (cancelled) return;
+
+      const bridge = bridgeRef.current;
+      const cameraBridge = cameraBridgeRef.current ?? bridge;
+      const renderer = getGlobalRenderer();
+      const Cesium = getCesiumModule();
+      if (!viewer || !bridge || !cameraBridge || !renderer || !Cesium) {
+        rafRef.current = requestAnimationFrame(syncCamera);
+        return;
+      }
+
+      const camera = renderer.getCamera();
+      let camPos = camera.getPosition();
+      let camTarget = camera.getTarget();
+      const camUp = camera.getUp();
+      const fov = camera.getFOV();
+
+      if (terrainClipY !== null) {
+        const minCameraY = terrainClipY + 0.05;
+        if (camPos.y < minCameraY) {
+          const dy = minCameraY - camPos.y;
+          camPos = { ...camPos, y: minCameraY };
+          camTarget = { ...camTarget, y: camTarget.y + dy };
+        }
+      }
+
+      // bridge.modelOrigin.height already has the placement baked in, so the
+      // camera frame and the model matrix share the same enuToEcef origin altitude.
+      cameraBridge.syncCamera(Cesium, viewer, camPos, camTarget, camUp, fov);
+
+      rafRef.current = requestAnimationFrame(syncCamera);
+    }
+
+    rafRef.current = requestAnimationFrame(syncCamera);
+
+    return () => {
+      cancelled = true;
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+    };
+  }, [status, terrainClipY]);
+}

--- a/apps/viewer/src/components/viewer/cesium/useCesiumModel.ts
+++ b/apps/viewer/src/components/viewer/cesium/useCesiumModel.ts
@@ -13,10 +13,14 @@
  * (the old model stays until its replacement can actually draw) — so it is the
  * one that most benefits from being readable on its own.
  *
- * ORDERING NOTE: the caller must invoke this hook in the position the effects
- * occupied, between the bridge effect and the solar effect. React runs effects
- * in declaration order and cleanups in reverse, and the teardown here assumes
- * the viewer effect's cleanup runs after its own.
+ * ORDERING NOTE: call this hook where its effects sat — after the bridge hook,
+ * before the solar hook. Within a component React runs effect setups in
+ * declaration order AND cleanups in that same order (verified, not assumed:
+ * "cleanups run in reverse" is a common misreading that only describes
+ * child-before-parent across the tree). So the viewer effect, declared first,
+ * cleans up FIRST — which is why nothing in this hook's cleanup may touch the
+ * viewer. It only cancels the in-flight build; removing the primitive is left
+ * to the not-ready branch, or to the viewer teardown itself via `invalidate`.
  */
 
 import { useCallback, useEffect, useRef, useState, type RefObject } from 'react';

--- a/apps/viewer/src/components/viewer/cesium/useCesiumModel.ts
+++ b/apps/viewer/src/components/viewer/cesium/useCesiumModel.ts
@@ -1,0 +1,386 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The world view's model lifecycle: build the GLB, load it into Cesium, swap it
+ * in without a visible gap, and keep its matrix current.
+ *
+ * Split out of CesiumOverlay.tsx (#2593), which had grown past 1,000 lines
+ * carrying four unrelated responsibilities. This is the one with the most
+ * history behind it — #2558 (the GLB must hold the whole model, instanced
+ * occurrences included), #2578 (it must hide what the viewport hides), #2583
+ * (the old model stays until its replacement can actually draw) — so it is the
+ * one that most benefits from being readable on its own.
+ *
+ * ORDERING NOTE: the caller must invoke this hook in the position the effects
+ * occupied, between the bridge effect and the solar effect. React runs effects
+ * in declaration order and cleanups in reverse, and the teardown here assumes
+ * the viewer effect's cleanup runs after its own.
+ */
+
+import { useCallback, useEffect, useRef, useState, type RefObject } from 'react';
+import { useViewerStore } from '@/store';
+import type { MapConversion, ProjectedCRS } from '@ifc-lite/parser';
+import type { CoordinateInfo, GeometryResult } from '@ifc-lite/geometry';
+import { VisibilityEpochTracker } from '@ifc-lite/renderer';
+import { effectiveIsolatedIds } from '@/lib/effective-isolation';
+import { buildCesiumModelGLB, cesiumModelGLBKey, type CesiumModelGLBInput } from '@/lib/geo/cesium-model-glb';
+import { swapCesiumModel } from '@/lib/geo/cesium-model-swap';
+import type { CesiumBridge } from '@/lib/geo/cesium-bridge';
+import { getCesiumModule } from './cesium-module';
+
+/**
+ * Build a Cesium model matrix for placing the IFC model in ECEF.
+ * Extracted as a pure function so it can be called from both
+ * the GLB load effect (initial) and the matrix update effect (instant).
+ */
+function buildModelMatrix(
+  Cesium: typeof import('cesium'),
+  bridge: CesiumBridge,
+  coordinateInfo: CoordinateInfo | undefined,
+) {
+  // GLB vertices are in viewer-space metres (geometry engine converts during
+  // extraction; the effective map scale is already folded into the rotation).
+  const bounds = coordinateInfo?.originalBounds;
+  // Viewer bounds are already in metres (geometry engine converts from IFC native unit)
+  const mvx = bounds ? (bounds.min.x + bounds.max.x) / 2 : 0;
+  const mvy = bounds ? (bounds.min.y + bounds.max.y) / 2 : 0;
+  const mvz = bounds ? (bounds.min.z + bounds.max.z) / 2 : 0;
+
+  // bridge.modelOrigin.height is the placement altitude — Effect 2 already
+  // baked terrain clamping (when applicable) into it before constructing the
+  // bridge, so there's no per-frame clamp adjustment to make here.
+  const origin = Cesium.Cartesian3.fromDegrees(
+    bridge.modelOrigin.longitude, bridge.modelOrigin.latitude, bridge.modelOrigin.height,
+  );
+  const enuToEcef = Cesium.Transforms.eastNorthUpToFixedFrame(origin);
+  // No lengthUnitScale here: viewer-space GLB vertices are already in metres.
+  // Reuse the bridge's convergence-corrected viewer-to-ENU rotation so the
+  // model geometry and the camera frame agree on north; a grid-only rotation
+  // here would leave the model rotated by the meridian convergence off the
+  // true-north basemap (up to ~8 deg for Krovak). See #1408.
+  const rot = bridge.viewerRotation;
+  const tx = -(rot.eastFromVx * mvx + rot.eastFromVz * mvz);
+  const ty = -(rot.northFromVx * mvx + rot.northFromVz * mvz);
+  const tz = -mvy;
+  const ifcToEnu = new Cesium.Matrix4(
+    rot.eastFromVx,  0, rot.eastFromVz,  tx,
+    rot.northFromVx, 0, rot.northFromVz, ty,
+    0,               1, 0,               tz,
+    0,               0, 0,               1,
+  );
+  return Cesium.Matrix4.multiply(enuToEcef, ifcToEnu, new Cesium.Matrix4());
+}
+
+/** The slice of `Cesium.Model` this overlay touches. */
+type CesiumModelPrimitive = {
+  modelMatrix: any;
+  shadows?: any;
+  ready?: boolean;
+  readyEvent?: { addEventListener(cb: () => void): () => void };
+  destroy?: () => void;
+};
+
+/**
+ * Resolves once `model` can actually draw.
+ *
+ * `Model.fromGltfAsync` resolving only means the glTF was fetched and parsed:
+ * Cesium finishes creating WebGL resources inside `update()` over subsequent
+ * frames, raises `readyEvent` from `frameState.afterRender`, and then skips one
+ * more frame before rendering. Waiting for the event plus a rendered frame is
+ * what makes "swap without a visible gap" true rather than merely
+ * "swap without an empty collection" (#2583).
+ *
+ * Rejects if neither happens within the timeout, so a model that never becomes
+ * renderable cannot strand its predecessor on the globe for the session.
+ */
+function whenModelRenderable(
+  viewer: { scene: { postRender: { addEventListener(cb: () => void): () => void } }; },
+  model: CesiumModelPrimitive,
+  timeoutMs = 5_000,
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    let done = false;
+    const finish = (ok: boolean) => {
+      if (done) return;
+      done = true;
+      offReady?.();
+      offFrame?.();
+      globalThis.clearTimeout(timer);
+      if (ok) { resolve(); return; }
+      // Bounded on purpose: the timeout path degrades to exactly the old
+      // behaviour (drop the previous model and accept a brief blank), so a
+      // model that is merely slow costs a flicker, not a stranded primitive.
+      console.warn('[CesiumOverlay] model did not report renderable within %d ms; swapping anyway', timeoutMs);
+      reject(new Error('model never became renderable'));
+    };
+    // One rendered frame AFTER ready — Cesium deliberately returns early from
+    // the update that raises the event, so the model draws on the next one.
+    const afterReady = () => { offFrame = viewer.scene.postRender.addEventListener(() => finish(true)); };
+    let offFrame: (() => void) | undefined;
+    let offReady: (() => void) | undefined;
+    const timer = globalThis.setTimeout(() => finish(false), timeoutMs);
+    if (model.ready) { afterReady(); return; }
+    if (!model.readyEvent) { finish(true); return; } // nothing to wait on
+    offReady = model.readyEvent.addEventListener(() => { offReady?.(); afterReady(); });
+  });
+}
+
+export interface UseCesiumModelParams {
+  /** Viewer readiness, owned by the viewer effect. */
+  status: 'idle' | 'loading' | 'ready' | 'error';
+  /** Bumped when the coordinate bridge is rebuilt. */
+  bridgeVersion: number;
+  viewerRef: RefObject<InstanceType<typeof import('cesium').Viewer> | null>;
+  bridgeRef: RefObject<CesiumBridge | null>;
+  geometryResult?: GeometryResult | null;
+  coordinateInfo?: CoordinateInfo;
+  mapConversion?: MapConversion;
+  projectedCRS?: ProjectedCRS;
+  lengthUnitScale?: number;
+  /** Storey, class-filter and manual isolation intersected, as the viewport
+   *  receives it. */
+  computedIsolatedIds?: ReadonlySet<number> | null;
+}
+
+export interface UseCesiumModelResult {
+  /** The primitive currently on the globe, for consumers that style it. */
+  modelRef: RefObject<CesiumModelPrimitive | null>;
+  /** Changes whenever a DIFFERENT primitive reaches the globe. */
+  modelEpoch: number;
+  /**
+   * Forget the model WITHOUT removing it — for the viewer teardown, which
+   * destroys the whole scene and takes the primitive with it. This is the one
+   * path this hook's own not-ready branch cannot cover: on unmount React runs
+   * cleanups but does not re-run effects, so without this the store flag would
+   * keep advertising a model that is gone.
+   */
+  invalidate: () => void;
+}
+
+/** @see {@link UseCesiumModelParams} for the ordering contract. */
+export function useCesiumModel({
+  status,
+  bridgeVersion,
+  viewerRef,
+  bridgeRef,
+  geometryResult,
+  coordinateInfo,
+  mapConversion,
+  projectedCRS,
+  lengthUnitScale = 1,
+  computedIsolatedIds,
+}: UseCesiumModelParams): UseCesiumModelResult {
+  const setCesiumGlbLoaded = useViewerStore((s) => s.setCesiumGlbLoaded);
+  // In-place mesh mutations (a gizmo move rewrites positions in the SAME
+  // arrays) change no mesh count, so the world-view GLB cache keys on this too.
+  const geometryContentVersion = useViewerStore((s) => s.geometryContentVersion);
+  // Hide/isolate, resolved the way Viewport resolves what it hands the
+  // renderer, so the map draws the elements the viewport draws (#2578).
+  const hiddenEntities = useViewerStore((s) => s.hiddenEntities);
+  const storeIsolatedEntities = useViewerStore((s) => s.isolatedEntities);
+  const isolatedEntities = effectiveIsolatedIds(computedIsolatedIds, storeIsolatedEntities);
+  // The GLB effect keys on this version, NOT on the Set references. The store
+  // hands out a fresh Set on every visibility action, and the effect's cleanup
+  // pulls the model off the globe — so keying on identity blanks the map for a
+  // second and rebuilds a multi-megabyte GLB even when the content is
+  // unchanged. `VisibilityEpochTracker` compares content, so an equal set is a
+  // no-op while an in-place mutation of the same Set still registers.
+  //
+  // Safe to run during render: `update()` only bumps when the content actually
+  // changed, so a double-invoked render (StrictMode) returns the same version.
+  const visibilityEpochsRef = useRef(new VisibilityEpochTracker());
+  const visibilityVersion = visibilityEpochsRef.current.update(hiddenEntities, isolatedEntities);
+  // Read inside the deferred build, which runs long after the effect fired.
+  const visibilityRef = useRef({ hiddenIds: hiddenEntities, isolatedIds: isolatedEntities });
+  visibilityRef.current = { hiddenIds: hiddenEntities, isolatedIds: isolatedEntities };
+
+  // Track the Cesium model (IFC geometry loaded as glTF for correct world positioning)
+  const cesiumModelRef = useRef<CesiumModelPrimitive | null>(null);
+  const glbCacheRef = useRef<{ key: string; glb: Uint8Array } | null>(null);
+  // Key of the model actually ON the globe, which is not the same thing as the
+  // key of the last GLB built — see the gate in the load effect.
+  const loadedKeyRef = useRef<string | null>(null);
+  // Bumped every time a NEW model primitive reaches the globe. `cesiumGlbLoaded`
+  // used to serve this purpose by flipping false->true around every rebuild, but
+  // the model now stays loaded across one (#2583), so the flag no longer moves.
+  const [cesiumModelEpoch, setCesiumModelEpoch] = useState(0);
+
+  // ─── Effect 2c: Load GLB into Cesium (only when geometry changes) ───────
+  // This is the heavy operation — only re-runs when geometry actually changes.
+  useEffect(() => {
+    if (status !== 'ready' || !geometryResult?.meshes?.length) {
+      // The model must not outlive its geometry. The effect cleanup no longer
+      // evicts it (#2583), so a session that unloads its model, or a viewer
+      // that leaves 'ready', is torn down here instead.
+      const live = viewerRef.current;
+      if (cesiumModelRef.current && live) {
+        live.scene.primitives.remove(cesiumModelRef.current);
+        live.scene.requestRender();
+      }
+      cesiumModelRef.current = null;
+      loadedKeyRef.current = null;
+      setCesiumGlbLoaded(false);
+      return;
+    }
+    const viewer = viewerRef.current;
+    const bridge = bridgeRef.current;
+    const Cesium = getCesiumModule();
+    if (!viewer || !bridge || !Cesium) return;
+
+    let cancelled = false;
+
+    const startExport = async () => {
+      if (cancelled) return;
+      // Declared at this scope so the catch can release a model that was built
+      // but never installed (the viewer was destroyed mid-load).
+      let model: CesiumModelPrimitive | null = null;
+      try {
+        // Reuse the cached GLB when it was built from the same mesh set. The key
+        // spans flat AND instanced geometry (see cesiumModelGLBKey), so an
+        // all-instanced batch still invalidates it.
+        const glbInput: CesiumModelGLBInput = {
+          geometryResult,
+          geometryContentVersion,
+          hiddenIds: visibilityRef.current.hiddenIds,
+          isolatedIds: visibilityRef.current.isolatedIds,
+          visibilityVersion,
+        };
+        const key = cesiumModelGLBKey(glbInput);
+        const cached = glbCacheRef.current;
+        // Gate on what is ON THE GLOBE, not on what has been BUILT. The two
+        // diverge whenever a load is cancelled or `fromGltfAsync` rejects: the
+        // bytes cache already holds the new key while the old primitive is
+        // still displayed, and gating on the byte cache would then treat the
+        // stale model as current and never retry the load.
+        if (cesiumModelRef.current && loadedKeyRef.current === key) {
+          // Model already loaded with same geometry — just update matrix
+          return;
+        }
+
+        // The previous model deliberately stays on the globe while its
+        // replacement is built and loaded — `swapCesiumModel` exchanges them
+        // at the end, so the map never goes blank mid-rebuild (#2583).
+        let glbBytes: Uint8Array;
+        if (cached?.key === key) {
+          glbBytes = cached.glb;
+        } else {
+          await new Promise(r => setTimeout(r, 50));
+          if (cancelled) return;
+          const built = buildCesiumModelGLB(glbInput);
+          glbBytes = built.glb;
+          glbCacheRef.current = { key: built.key, glb: built.glb };
+        }
+        if (cancelled) return;
+
+        await new Promise(r => setTimeout(r, 0));
+        if (cancelled) return;
+
+        // Build initial model matrix
+        const modelMatrix = buildModelMatrix(Cesium, bridge, coordinateInfo);
+
+        const blob = new Blob([glbBytes as BlobPart], { type: 'model/gltf-binary' });
+        const glbUrl = URL.createObjectURL(blob);
+        try {
+          model = await Cesium.Model.fromGltfAsync({
+            url: glbUrl,
+            modelMatrix,
+            shadows: Cesium.ShadowMode.DISABLED,
+            // The generated GLB stores viewer-space vertices and buildModelMatrix
+            // already maps viewer axes into ENU. Avoid Cesium's default glTF
+            // Y-up/Z-forward correction or the model is rotated onto its side.
+            upAxis: Cesium.Axis.Z,
+            forwardAxis: Cesium.Axis.X,
+          });
+          // Ambient floor. The overlay composits transparently with the
+          // atmosphere/skybox off, so the scene's ONLY light is the directional
+          // sun — without an environment map the model's shadowed faces get no
+          // ambient and read muddy. Give the model a flat image-based-lighting
+          // ambient via a constant spherical-harmonic term: every surface stays
+          // readable while the sun still shapes the lit faces. (#1380)
+          try {
+            const ibl = (model as unknown as {
+              imageBasedLighting?: { sphericalHarmonicCoefficients: unknown };
+            }).imageBasedLighting;
+            if (ibl) {
+              const a = new Cesium.Cartesian3(0.72, 0.72, 0.75); // neutral daylight ambient
+              const z = Cesium.Cartesian3.ZERO;
+              ibl.sphericalHarmonicCoefficients = [a, z, z, z, z, z, z, z, z];
+            }
+          } catch (e) {
+            console.warn('[CesiumOverlay] could not set model ambient IBL:', e);
+          }
+        } finally {
+          URL.revokeObjectURL(glbUrl);
+        }
+        if (cancelled) {
+          model?.destroy?.();
+          return;
+        }
+
+        const outcome = await swapCesiumModel(
+          viewer.scene.primitives,
+          cesiumModelRef.current,
+          model,
+          (m) => whenModelRenderable(viewer, m),
+          () => cancelled,
+        );
+        // Superseded: a newer build owns the outcome, the globe still shows the
+        // previous model, and `model` has already been destroyed. Recording it
+        // would leave the refs pointing at geometry nobody is rendering.
+        if (outcome === 'superseded' || cancelled) return;
+        cesiumModelRef.current = model;
+        loadedKeyRef.current = key;
+        setCesiumGlbLoaded(true);
+        // A rebuild no longer flips `cesiumGlbLoaded` false→true, so that flag
+        // can no longer tell the solar effect "there is a different primitive
+        // now, re-apply its shadow mode". This epoch does.
+        setCesiumModelEpoch((e) => e + 1);
+        viewer.scene.requestRender();
+      } catch (err) {
+        console.warn('[CesiumOverlay] Failed to load IFC model into Cesium:', err);
+        // A model built but never installed (the viewer was destroyed mid-load,
+        // so `primitives.add` threw) owns GPU buffers nothing will release.
+        if (model && cesiumModelRef.current !== model) model.destroy?.();
+      }
+    };
+
+    const deferTimer = setTimeout(startExport, 1000);
+
+    // Cancel the in-flight build only. Evicting the live model here is what
+    // blanked the map on every re-run (#2583); the model is exchanged for its
+    // replacement once that replacement exists, and torn down by the
+    // no-geometry branch above or with the viewer in Effect 1.
+    return () => {
+      cancelled = true;
+      clearTimeout(deferTimer);
+    };
+  }, [status, bridgeVersion, geometryResult, geometryContentVersion, visibilityVersion]);
+
+  // ─── Effect 2d: Update model matrix (instant, no reload) ────────────────
+  // When terrain placement or georef changes, just update the
+  // existing model's matrix — no GLB re-export, no flicker.
+  useEffect(() => {
+    const model = cesiumModelRef.current;
+    const bridge = bridgeRef.current;
+    const viewer = viewerRef.current;
+    const Cesium = getCesiumModule();
+    if (!model || !bridge || !viewer || !Cesium) return;
+
+    const newMatrix = buildModelMatrix(Cesium, bridge, coordinateInfo);
+    model.modelMatrix = newMatrix;
+    viewer.scene.requestRender();
+    // Depend on bridgeVersion so the matrix is rebuilt with the *new* bridge
+    // after async createCesiumBridge replaces it. Placement is baked into
+    // bridge.modelOrigin.height by Effect 2.
+  }, [mapConversion, projectedCRS, coordinateInfo, lengthUnitScale, bridgeVersion]);
+
+  const invalidate = useCallback(() => {
+    cesiumModelRef.current = null;
+    loadedKeyRef.current = null;
+    setCesiumGlbLoaded(false);
+  }, [setCesiumGlbLoaded]);
+
+  return { modelRef: cesiumModelRef, modelEpoch: cesiumModelEpoch, invalidate };
+}

--- a/apps/viewer/src/components/viewer/cesium/useCesiumSolar.ts
+++ b/apps/viewer/src/components/viewer/cesium/useCesiumSolar.ts
@@ -1,0 +1,211 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The world view's solar study: sun position and lighting, shadow casting, the
+ * 3D sun-path dome, and the atmosphere/sky toggle.
+ *
+ * Split out of CesiumOverlay.tsx (#2593). It is the most self-contained of that
+ * file's responsibilities — it reads the studied instant from the store and
+ * writes to the Cesium scene, sharing only the viewer, the bridge and the model
+ * primitive whose shadow mode it sets.
+ *
+ * ORDERING NOTE: call this hook where its effects sat, AFTER the model hook.
+ * It reads `modelRef` to apply shadow settings, and keys on `modelEpoch` so a
+ * swapped-in primitive (#2583) gets those settings applied to it — the model
+ * hook must have run first for both to be current.
+ */
+
+import { useEffect, useRef, type RefObject } from 'react';
+import { useViewerStore } from '@/store';
+import type { CoordinateInfo } from '@ifc-lite/geometry';
+import { sunPosition, sunTimes } from '@ifc-lite/solar';
+import { applySolarScene, SunPathDome } from '@/lib/geo/cesium-sun';
+import type { CesiumBridge } from '@/lib/geo/cesium-bridge';
+import { getCesiumModule } from './cesium-module';
+
+export interface UseCesiumSolarParams {
+  status: 'idle' | 'loading' | 'ready' | 'error';
+  bridgeVersion: number;
+  viewerRef: RefObject<InstanceType<typeof import('cesium').Viewer> | null>;
+  bridgeRef: RefObject<CesiumBridge | null>;
+  /** The primitive currently on the globe, whose shadow mode this sets. */
+  modelRef: RefObject<{ shadows?: unknown } | null>;
+  /** Changes when a DIFFERENT primitive reaches the globe, so its shadow
+   *  settings are re-applied (#2583 stopped `cesiumGlbLoaded` from moving). */
+  modelEpoch: number;
+  /** The 3D-context tileset, which casts and receives shadows with the model. */
+  tilesetRef: RefObject<{ shadows?: unknown } | null>;
+  coordinateInfo?: CoordinateInfo;
+}
+
+export interface UseCesiumSolarResult {
+  /**
+   * Tear down the dome and forget that the scene was touched — for the viewer
+   * teardown, which destroys the scene and its entities. Same reason
+   * `useCesiumModel` exposes `invalidate`: on unmount React runs cleanups but
+   * does not re-run effects.
+   */
+  invalidate: () => void;
+}
+
+export function useCesiumSolar({
+  status,
+  bridgeVersion,
+  viewerRef,
+  bridgeRef,
+  modelRef: cesiumModelRef,
+  modelEpoch: cesiumModelEpoch,
+  tilesetRef,
+  coordinateInfo,
+}: UseCesiumSolarParams): UseCesiumSolarResult {
+  const solarEnabled = useViewerStore((s) => s.solarEnabled);
+  const solarDateMs = useViewerStore((s) => s.solarDateMs);
+  const solarShowSunPath = useViewerStore((s) => s.solarShowSunPath);
+  const solarShowShadows = useViewerStore((s) => s.solarShowShadows);
+  const setSolarSunInfo = useViewerStore((s) => s.setSolarSunInfo);
+  const envSkyEnabled = useViewerStore((s) => s.envSkyEnabled);
+
+  // Active sun-path dome entity collection (null when solar study is off).
+  const sunPathDomeRef = useRef<SunPathDome | null>(null);
+  // UTC calendar day the dome's static geometry was built for.
+  const sunPathDomeDayRef = useRef<string | null>(null);
+  // Whether the study has ever touched the scene's lighting.
+  const solarTouchedSceneRef = useRef(false);
+
+  // ─── Effect 4: Solar study — sun-path dome + shadows ────────────────────
+  // Drives Cesium's sun/lighting/shadow map from the studied instant, builds
+  // (and live-updates) the 3D sun-path dome anchored at the model origin, and
+  // publishes the resolved sun position/times back to the store for the panel.
+  useEffect(() => {
+    const viewer = viewerRef.current;
+    const bridge = bridgeRef.current;
+    const Cesium = getCesiumModule();
+    if (status !== 'ready' || !viewer || !bridge || !Cesium) return;
+
+    // Never mutate the default Cesium lighting until the study is first
+    // enabled — a plain georeferenced model shouldn't have its context
+    // re-lit just because this effect mounts with solar off.
+    if (!solarEnabled && !solarTouchedSceneRef.current) return;
+    solarTouchedSceneRef.current = true;
+
+    const date = new Date(solarDateMs);
+    const { latitude, longitude, height } = bridge.modelOrigin;
+
+    // Cast/receive shadows on the IFC model and the context tileset.
+    const shadowMode = solarEnabled && solarShowShadows
+      ? Cesium.ShadowMode.ENABLED
+      : Cesium.ShadowMode.DISABLED;
+    if (cesiumModelRef.current) cesiumModelRef.current.shadows = shadowMode;
+    if (tilesetRef.current) tilesetRef.current.shadows = shadowMode;
+
+    applySolarScene(Cesium, viewer, {
+      date,
+      enabled: solarEnabled,
+      shadows: solarShowShadows,
+      showSun: envSkyEnabled,
+    });
+
+    if (solarEnabled) {
+      // Publish the readout for the panel.
+      const times = sunTimes(date, latitude, longitude);
+      const sp = sunPosition(date, latitude, longitude);
+      setSolarSunInfo({
+        latitude,
+        longitude,
+        azimuth: sp.azimuth,
+        altitude: sp.altitude,
+        sunriseMs: times.sunrise ? times.sunrise.getTime() : null,
+        sunsetMs: times.sunset ? times.sunset.getTime() : null,
+        solarNoonMs: times.solarNoon.getTime(),
+      });
+
+      if (solarShowSunPath) {
+        const dayKey = `${date.getUTCFullYear()}-${date.getUTCMonth()}-${date.getUTCDate()}:${latitude.toFixed(4)},${longitude.toFixed(4)}`;
+        try {
+          if (!sunPathDomeRef.current || sunPathDomeDayRef.current !== dayKey) {
+            // New day or site → rebuild static geometry (day arc + analemmas).
+            sunPathDomeRef.current?.destroy();
+            const bounds = coordinateInfo?.originalBounds;
+            // Size the dome to roughly the model footprint, but clamp to an
+            // architectural scale: with many federated models the combined
+            // bounds can span kilometres, which would push the dome arcs so
+            // far out they read as nothing. Half-diagonal ≈ bounding radius.
+            const rawRadius = bounds
+              ? 0.5 * Math.hypot(
+                  bounds.max.x - bounds.min.x,
+                  bounds.max.y - bounds.min.y,
+                  bounds.max.z - bounds.min.z,
+                )
+              : 80;
+            const radius = Math.min(250, Math.max(40, rawRadius));
+            sunPathDomeRef.current = new SunPathDome(Cesium, viewer, {
+              origin: { latitude, longitude, height },
+              radius,
+              date,
+              showAnalemmas: true,
+            });
+            sunPathDomeDayRef.current = dayKey;
+          } else {
+            // Same day, new time → just move the sun marker + beam.
+            sunPathDomeRef.current.update(date);
+          }
+        } catch (err) {
+          console.warn('[CesiumOverlay] sun-path dome build/update failed:', err);
+        }
+      } else if (sunPathDomeRef.current) {
+        sunPathDomeRef.current.destroy();
+        sunPathDomeRef.current = null;
+        sunPathDomeDayRef.current = null;
+      }
+    } else if (sunPathDomeRef.current) {
+      sunPathDomeRef.current.destroy();
+      sunPathDomeRef.current = null;
+      sunPathDomeDayRef.current = null;
+    }
+
+    viewer.scene.requestRender();
+  }, [
+    status,
+    bridgeVersion,
+    cesiumModelEpoch,
+    solarEnabled,
+    solarDateMs,
+    solarShowSunPath,
+    solarShowShadows,
+    envSkyEnabled,
+    coordinateInfo,
+    setSolarSunInfo,
+  ]);
+
+  // ─── Effect 4b: Sky — atmosphere + sun + fog ────────────────────────────
+  // The environment panel's Sky toggle. Init disables all of these for
+  // transparent compositing; this effect re-enables them on demand. The
+  // area outside the atmosphere stays transparent (skyBox off), so space
+  // composites over the app background like the rest of the overlay.
+  useEffect(() => {
+    const viewer = viewerRef.current;
+    const Cesium = getCesiumModule();
+    if (status !== 'ready' || !viewer || !Cesium) return;
+    const scene = viewer.scene;
+    if (scene.skyAtmosphere) scene.skyAtmosphere.show = envSkyEnabled;
+    scene.fog.enabled = envSkyEnabled;
+    // Haze on the satellite base map (no-op while the globe is hidden).
+    scene.globe.showGroundAtmosphere = envSkyEnabled && scene.globe.show;
+    // Sun billboard only when the solar effect isn't already managing it
+    // (applySolarScene runs with showSun and wins on solar state changes).
+    if (scene.sun && !solarTouchedSceneRef.current) {
+      scene.sun.show = envSkyEnabled;
+    }
+    scene.requestRender();
+  }, [status, envSkyEnabled]);
+
+  const invalidate = () => {
+    sunPathDomeRef.current = null;
+    sunPathDomeDayRef.current = null;
+    solarTouchedSceneRef.current = false;
+  };
+
+  return { invalidate };
+}

--- a/apps/viewer/src/components/viewer/cesium/useCesiumSolar.ts
+++ b/apps/viewer/src/components/viewer/cesium/useCesiumSolar.ts
@@ -12,9 +12,10 @@
  * primitive whose shadow mode it sets.
  *
  * ORDERING NOTE: call this hook where its effects sat, AFTER the model hook.
- * It reads `modelRef` to apply shadow settings, and keys on `modelEpoch` so a
- * swapped-in primitive (#2583) gets those settings applied to it — the model
- * hook must have run first for both to be current.
+ * It reads `modelRef` to apply shadow settings and keys on `modelEpoch`, so a
+ * swapped-in primitive (#2583) gets those settings — the model hook must have
+ * run first for both to be current. Its cleanup, like every other one here,
+ * runs after the viewer effect's, so it must not assume a live scene.
  */
 
 import { useEffect, useRef, type RefObject } from 'react';


### PR DESCRIPTION
Fixes #2593. Raised by CodeRabbit on #2586 and deliberately kept out of that correctness fix.

## What it was

1,058 lines carrying four subjects at once — the Cesium viewer's lifecycle, the coordinate bridge, the model lifecycle and the solar study — each with its own history, interleaved through one component.

## What it is

**419 lines**, and it reads as what it is: create the viewer, render the container, call four hooks in the order their effects used to sit in.

| module | owns |
|---|---|
| `cesium/cesium-module` | the lazy CesiumJS import they share |
| `cesium/useCesiumBridge` | **where** the model sits — ENU/ECEF, grid convergence, geoid undulation, terrain clamping, placement drafts |
| `cesium/useCesiumModel` | **what** is drawn — GLB build, readiness-gated swap, matrix updates |
| `cesium/useCesiumSolar` | lighting, shadows, sun-path dome, sky |
| `cesium/useCesiumCameraSync` | the per-frame camera mirror |

## The risk was ordering, so it is written down

React runs effects in declaration order and cleanups in reverse, and this file's correctness depended on that implicitly. Each hook now documents where it must be called and why. Three specifics worth review attention:

- **Teardown the viewer effect cannot reach.** On unmount React runs cleanups but does not re-run effects, so the model hook's "not ready" branch never fires. The model and solar hooks expose explicit `invalidate()` callbacks that the viewer effect's cleanup calls, instead of it reaching into refs that have moved. Without this the store would keep advertising a model the destroyed viewer took with it — the bug CodeRabbit caught on #2586.
- **The camera loop's rAF handle stays owned by the caller.** The viewer effect cancels it from its own cleanup, which runs *before* the hook's; moving the handle into the hook would let the loop tick once against a destroyed viewer.
- **`prevPlacementRef` moved with the bridge**, since it is bridge state (keeping the world camera stable across placement edits), not overlay state.

## Verified end to end, twice

Once after the first three extractions and again after the bridge came out, on the #2558 model:

| stage | result |
|---|---|
| world view loads | model on Google imagery |
| visibility change | 1 GLB rebuild, model still loaded |
| solar study on | scene lit, sun-path dome drawn, sun info published to the store |
| **data-source change → viewer DESTROYED and recreated** | model reloads onto the new base |
| visibility change on the recreated viewer | rebuilds again |

**Zero console errors and zero page exceptions in every run.** Screenshots of the three states are in the run output; the sun-path dome and the post-recreate model both render correctly.

Viewer suite **4,102 passing / 5 skipped**, `tsc --noEmit` clean. Changeset: patch for `@ifc-lite/viewer`.

## Note on tests

No new tests: this moves code without changing it, so the guard is the existing suite plus the behaviour run above. The extracted hooks are React effects against a live Cesium scene — the same reason `CesiumOverlay` has never been unit-testable (the real Cesium module does not load under `tsx --test`). The parts that *could* be pulled into pure functions already were, in #2576/#2581/#2586: `cesium-model-glb`, `cesium-model-swap`, `effective-isolation`, `entity-visibility`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved Cesium integration for model placement, terrain-aware positioning, camera synchronization, solar lighting, shadows, atmosphere, fog, and optional sun-path visualization.
  - Cesium resources now load on demand for faster initial viewer startup.
  - Model updates preserve the currently visible model until replacements are ready.

- **Bug Fixes**
  - Improved cleanup when models, solar settings, or the viewer are reset.
  - Prevented outdated asynchronous model loads from replacing current content.
  - Enhanced camera and terrain positioning reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->