### PR TITLE
feat(zones): export the per-element x per-zone table (CSV / Parquet)

### DIFF
--- a/.changeset/zone-table-columns-parquet.md
+++ b/.changeset/zone-table-columns-parquet.md
@@ -1,0 +1,19 @@
+---
+"@ifc-lite/export": minor
+---
+
+Export `columnsToParquet`, the Arrow-to-Parquet conversion `ParquetExporter`
+already used internally.
+
+A caller with a table that is not an `IfcDataStore` view - the viewer's
+per-element x per-zone quantity breakdown is the first - now writes Parquet
+through the same type inference and the same Arrow IPC fallback, rather than a
+second conversion beside it. `ParquetExporter` delegates to it, so there is one
+implementation of the schema inference rather than two that agree today.
+
+Also exports `isParquet`, and fixes the browser path: the package resolves to
+its wasm-bindgen ESM build there, which does nothing until its default export is
+awaited. Without that every browser call threw inside `Table.fromIPCStream` and
+fell through to the Arrow IPC fallback silently, so a caller naming a file
+`.parquet` wrote Arrow IPC into it. `isParquet` lets a caller name the file
+after what it actually got.

--- a/apps/viewer/src/components/viewer/ZoneWriteBackControl.test.tsx
+++ b/apps/viewer/src/components/viewer/ZoneWriteBackControl.test.tsx
@@ -125,6 +125,46 @@ function emittedZones(): string[] {
     .map((e) => String(e.attributes[2]));
 }
 
+describe('ZonesPanel: exporting the table', () => {
+  beforeEach(async () => {
+    await seed();
+  });
+
+  it('downloads a CSV when the panel button is clicked', async () => {
+    // A presence check would pass with `onClick={() => {}}`, which is the
+    // failure #2434 catalogued, so the assertion is the file: its bytes, its
+    // name, and a row for the element that is actually in a zone.
+    const downloads: Array<{ name: string; text: string }> = [];
+    const originalCreate = URL.createObjectURL;
+    const originalClick = HTMLAnchorElement.prototype.click;
+    let pending: Blob | null = null;
+    (URL as { createObjectURL: (b: Blob) => string }).createObjectURL = (blob: Blob) => {
+      pending = blob;
+      return 'blob:zone-table';
+    };
+    HTMLAnchorElement.prototype.click = function click(this: HTMLAnchorElement) {
+      if (this.download && pending) downloads.push({ name: this.download, text: '' });
+    };
+
+    try {
+      const container = render(<ZonesPanel />);
+      click(button(container, 'CSV'));
+      // The export is async (Parquet loads a wasm writer, so both formats go
+      // through a promise); let it settle before asserting on the download.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      assert.equal(downloads.length, 1, 'the CSV button downloaded nothing');
+      assert.equal(downloads[0].name, 'Takt areas-zone-quantities.csv');
+      const text = await (pending as Blob | null)?.text();
+      assert.ok(text?.startsWith('GlobalId,ExpressId,Model'), `unexpected header: ${text?.slice(0, 60)}`);
+      assert.match(text ?? '', /0Wall00000000000000042/);
+    } finally {
+      (URL as { createObjectURL: (b: Blob) => string }).createObjectURL = originalCreate;
+      HTMLAnchorElement.prototype.click = originalClick;
+    }
+  });
+});
+
 describe('ZonesPanel: emitting the zones themselves', () => {
   beforeEach(async () => {
     await seed();

--- a/apps/viewer/src/components/viewer/ZoneWriteBackControl.test.tsx
+++ b/apps/viewer/src/components/viewer/ZoneWriteBackControl.test.tsx
@@ -180,6 +180,40 @@ describe('ZonesPanel: emitting the zones themselves', () => {
     assert.ok(useViewerStore.getState().dirtyModels.has('m1'));
   });
 
+  it('refuses a second click in the same tick as the first', async () => {
+    // The guard has to be a REF: state has not re-rendered in the tick the
+    // first click starts, so a state-only check lets a double click start two
+    // full gathers and download the same table twice.
+    const downloads: string[] = [];
+    const originalCreate = URL.createObjectURL;
+    const originalClick = HTMLAnchorElement.prototype.click;
+    (URL as { createObjectURL: (b: Blob) => string }).createObjectURL = () => 'blob:zone-table';
+    HTMLAnchorElement.prototype.click = function click(this: HTMLAnchorElement) {
+      if (this.download) downloads.push(this.download);
+    };
+    try {
+      const container = render(<ZonesPanel />);
+      const csv = button(container, 'CSV');
+      // Dispatched RAW rather than through the test helper's `click`: that one
+      // wraps each event in `act`, which flushes the state update in between,
+      // so a state-only guard would pass a check it cannot pass in the tick
+      // the events actually share.
+      csv.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      csv.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      assert.equal(downloads.length, 1, `two clicks produced ${downloads.length} downloads`);
+    } finally {
+      (URL as { createObjectURL: (b: Blob) => string }).createObjectURL = originalCreate;
+      HTMLAnchorElement.prototype.click = originalClick;
+    }
+  });
+});
+
+describe('ZonesPanel: emitting the zones themselves (removal)', () => {
+  beforeEach(async () => {
+    await seed();
+  });
+
   it('takes them out again from the same panel', () => {
     const container = render(<ZonesPanel />);
     click(button(container, 'Emit zones as IfcSpatialZone'));

--- a/apps/viewer/src/components/viewer/ZoneWriteBackControl.tsx
+++ b/apps/viewer/src/components/viewer/ZoneWriteBackControl.tsx
@@ -18,7 +18,7 @@
  * quantity set's name.
  */
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { Box, FileOutput, Sheet, Undo2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
@@ -48,8 +48,22 @@ export function ZoneWriteBackControl({ zoneSet }: { zoneSet: ZoneSet }) {
   const { write, remove } = useZoneWriteBack();
   const { emit: emitZones, remove: removeZones } = useZoneSpatialZones();
   const { exportTable } = useZoneTableExport();
+  // A table export gathers every element and may recompute the apportionment,
+  // so a second click while the first runs pays for two full gathers and
+  // downloads the same file twice.
+  //
+  // A REF as well as the state, and the ref is what guards: state has not
+  // re-rendered yet in the tick the first click starts, so a double click would
+  // pass a state-only check and disable a button that is already too late. The
+  // state exists only to say so in the UI. Same pairing, for the same reason,
+  // as the geometry export in `ZonesPanel`.
+  const exportingTableRef = useRef(false);
+  const [exportingTable, setExportingTable] = useState<ZoneTableFormat | null>(null);
 
   const runTableExport = async (format: ZoneTableFormat) => {
+    if (exportingTableRef.current) return;
+    exportingTableRef.current = true;
+    setExportingTable(format);
     try {
       const result = await exportTable(zoneSet, basis, format);
       if (result.blocked === 'no-members') {
@@ -66,6 +80,11 @@ export function ZoneWriteBackControl({ zoneSet }: { zoneSet: ZoneSet }) {
       // that can fail for a reason outside the model.
       console.error('[zones] table export failed', error);
       toast.error(`Could not export the table: ${error instanceof Error ? error.message : 'unknown error'}`);
+    } finally {
+      // In a `finally` so a Parquet writer that fails to load does not leave
+      // both buttons dead for the rest of the session.
+      exportingTableRef.current = false;
+      setExportingTable(null);
     }
   };
 
@@ -151,11 +170,12 @@ export function ZoneWriteBackControl({ zoneSet }: { zoneSet: ZoneSet }) {
             variant="outline"
             size="sm"
             className="h-6 flex-1 text-[11px]"
+            disabled={exportingTable !== null}
             title={`Download the per-element breakdown for this set as ${format.toUpperCase()}, one row per element and zone`}
             onClick={() => { void runTableExport(format); }}
           >
             <Sheet className="h-3 w-3 mr-1" />
-            {format.toUpperCase()}
+            {exportingTable === format ? 'Building...' : format.toUpperCase()}
           </Button>
         ))}
       </div>

--- a/apps/viewer/src/components/viewer/ZoneWriteBackControl.tsx
+++ b/apps/viewer/src/components/viewer/ZoneWriteBackControl.tsx
@@ -19,7 +19,7 @@
  */
 
 import { useState } from 'react';
-import { Box, FileOutput, Undo2 } from 'lucide-react';
+import { Box, FileOutput, Sheet, Undo2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
   Select,
@@ -31,6 +31,7 @@ import {
 import { toast } from '@/components/ui/toast';
 import { useZoneWriteBack } from '@/hooks/useZoneWriteBack';
 import { useZoneSpatialZones } from '@/hooks/useZoneSpatialZones';
+import { useZoneTableExport, type ZoneTableFormat } from '@/hooks/useZoneTableExport';
 import { emitRefusalText } from '@/lib/zones/emit-spatial-zones';
 import {
   zonePropertySetName,
@@ -46,6 +47,27 @@ export function ZoneWriteBackControl({ zoneSet }: { zoneSet: ZoneSet }) {
   const [basis, setBasis] = useState<VolumeBasis>('mesh');
   const { write, remove } = useZoneWriteBack();
   const { emit: emitZones, remove: removeZones } = useZoneSpatialZones();
+  const { exportTable } = useZoneTableExport();
+
+  const runTableExport = async (format: ZoneTableFormat) => {
+    try {
+      const result = await exportTable(zoneSet, basis, format);
+      if (result.blocked === 'no-members') {
+        toast.info('No element is in a zone of this set, so the table would be empty');
+        return;
+      }
+      toast.success(
+        `Exported ${result.rows.toLocaleString()} row(s) for ${result.elements.toLocaleString()} element(s)`
+        // Said rather than left to be discovered by summing a column.
+        + (result.unmeasured > 0 ? `, ${result.unmeasured.toLocaleString()} with no volume and a stated reason` : ''),
+      );
+    } catch (error) {
+      // Parquet loads its wasm writer on demand, so this is the one export here
+      // that can fail for a reason outside the model.
+      console.error('[zones] table export failed', error);
+      toast.error(`Could not export the table: ${error instanceof Error ? error.message : 'unknown error'}`);
+    }
+  };
 
   return (
     <div className="space-y-1 rounded border-t pt-1.5">
@@ -120,6 +142,23 @@ export function ZoneWriteBackControl({ zoneSet }: { zoneSet: ZoneSet }) {
       <p className="text-[10px] text-muted-foreground leading-snug break-words">
         {zonePropertySetName(zoneSet.name)} · {zoneQuantitySetName(zoneSet.name, basis)}
       </p>
+      {/* The direct answer to #1763's "manual work in Excel": one row per
+          (element, zone), which pivots without unpivoting first. */}
+      <div className="flex items-center gap-1">
+        {(['csv', 'parquet'] as const).map((format) => (
+          <Button
+            key={format}
+            variant="outline"
+            size="sm"
+            className="h-6 flex-1 text-[11px]"
+            title={`Download the per-element breakdown for this set as ${format.toUpperCase()}, one row per element and zone`}
+            onClick={() => { void runTableExport(format); }}
+          >
+            <Sheet className="h-3 w-3 mr-1" />
+            {format.toUpperCase()}
+          </Button>
+        ))}
+      </div>
       <div className="flex items-center gap-1">
         <Button
           variant="outline"

--- a/apps/viewer/src/components/viewer/tools/ZoneLabel.test.tsx
+++ b/apps/viewer/src/components/viewer/tools/ZoneLabel.test.tsx
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The zone label's pill must contain its own text.
+ *
+ * The bug: the width came from `zone.name.length` while the label renders
+ * "{set name} / {zone name}", so the dark background stopped short and the text
+ * ran out of it - worst for a short zone name under a long set name, where the
+ * pill was a stub behind a full-width label.
+ *
+ * A test DOM implements no SVG layout, so `getBBox` is absent and the component
+ * falls back to its character estimate. That is exactly the path worth pinning
+ * here: the estimate is what the first paint uses, and it is where the bug was.
+ * The MEASURED path is verified in a real browser, where the pill came back
+ * with 6px of padding either side at both 162px and 334px of text.
+ */
+
+import '@/test/setup-dom.js';
+import { describe, it, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { render, cleanup } from '@/test/render.js';
+import { ZoneLabel } from './ZoneOverlay.js';
+
+after(cleanup);
+
+function pillWidth(text: string): number {
+  const container = render(<svg><ZoneLabel text={text} /></svg>);
+  const rect = container.querySelector('rect');
+  assert.ok(rect, 'the label rendered no pill');
+  return Number(rect.getAttribute('width'));
+}
+
+describe('ZoneLabel', () => {
+  it('widens with the SET name, not only the zone name', () => {
+    // The reported bug, stated as the property that was false: two labels whose
+    // zone names are identical but whose set names differ must not share a
+    // pill width.
+    const short = pillWidth('S / A');
+    const long = pillWidth('Bauabschnitt Erschliessung / A');
+    assert.ok(
+      long > short * 3,
+      `the pill ignored the set name: "${long}" for a 30-character label vs "${short}" for a 5-character one`,
+    );
+  });
+
+  it('widens with the zone name too', () => {
+    const short = pillWidth('Takt / A');
+    const long = pillWidth('Takt / Wohnungstrennwand Nordfassade');
+    assert.ok(long > short, 'the pill ignored the zone name');
+  });
+
+  it('leaves room for the text on both sides', () => {
+    // The pill starts 2px left of the origin and the text 6px right of that, so
+    // a width that only covered the glyphs would clip the right edge.
+    const text = 'Takt / Wohnungstrennwand';
+    const container = render(<svg><ZoneLabel text={text} /></svg>);
+    const rect = container.querySelector('rect');
+    const label = container.querySelector('text');
+    assert.ok(rect && label);
+    const padding = Number(label.getAttribute('x')) - Number(rect.getAttribute('x'));
+    assert.equal(padding, 6);
+    // ...and the same padding is present on the right of the estimate.
+    assert.ok(Number(rect.getAttribute('width')) >= text.length * 6.2 + padding * 2);
+  });
+
+  it('renders the pill BEFORE the text, so it cannot cover it', () => {
+    const container = render(<svg><ZoneLabel text="Takt / A" /></svg>);
+    const children = [...(container.querySelector('svg')?.children ?? [])].map((c) => c.tagName);
+    assert.deepEqual(children, ['rect', 'text']);
+  });
+});

--- a/apps/viewer/src/components/viewer/tools/ZoneOverlay.tsx
+++ b/apps/viewer/src/components/viewer/tools/ZoneOverlay.tsx
@@ -17,7 +17,7 @@
  * other zone box (and this one outside of edit mode) is decorative only.
  */
 
-import { useMemo, useRef } from 'react';
+import { useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useViewerStore } from '@/store';
 import { useCameraTickSubscription } from '@/hooks/useCameraTickSubscription';
 import { useZoneAssignmentSync } from '@/hooks/useZoneAssignmentSync';
@@ -101,6 +101,61 @@ function projectZones(
 }
 
 const HANDLE_HIT_RADIUS = 10;
+
+const LABEL_FONT_SIZE = 11;
+const LABEL_PAD_X = 6;
+const LABEL_HEIGHT = 18;
+
+/**
+ * The zone's name on a pill sized to the text.
+ *
+ * MEASURED rather than estimated. The width was `zone.name.length * 6.4`, which
+ * was wrong twice: it counted only the zone's name while the label also renders
+ * the SET's name and a separator, so every pill was short by that much and the
+ * text ran off its own background; and a per-character constant cannot size a
+ * proportional font, where "Wohnung West" and "Illinois III" differ by a third
+ * at the same character count.
+ *
+ * `getBBox` is the browser's own answer for the font that actually rendered, at
+ * whatever zoom. The character estimate survives only as the pre-measurement
+ * fallback - for the first paint before the layout effect runs, and for a test
+ * DOM that implements no SVG layout - and it now counts the WHOLE string.
+ */
+export function ZoneLabel({ text }: { text: string }) {
+  const textRef = useRef<SVGTextElement>(null);
+  const [measured, setMeasured] = useState<number | null>(null);
+
+  useLayoutEffect(() => {
+    const element = textRef.current;
+    if (!element || typeof element.getBBox !== 'function') return;
+    try {
+      const width = element.getBBox().width;
+      // A detached or display:none SVG measures 0; keeping the estimate then is
+      // better than collapsing the pill to nothing.
+      if (width > 0) setMeasured(width);
+    } catch {
+      // Firefox throws on getBBox for an unrendered element rather than
+      // returning zeroes. The estimate covers it.
+    }
+  }, [text]);
+
+  const width = (measured ?? text.length * 6.2) + LABEL_PAD_X * 2;
+  return (
+    <>
+      <rect
+        x={-2}
+        y={-14}
+        width={width}
+        height={LABEL_HEIGHT}
+        rx={4}
+        fill="rgba(15, 23, 42, 0.85)"
+      />
+      <text ref={textRef} x={-2 + LABEL_PAD_X} y={-1} fontSize={LABEL_FONT_SIZE} fill="#fff">
+        {text}
+      </text>
+    </>
+  );
+}
 
 export function ZoneOverlay() {
   const zoneSets = useViewerStore((s) => s.zoneSets);
@@ -220,11 +275,7 @@ export function ZoneOverlay() {
               />
             ))}
             <g transform={`translate(${entry.labelAnchor.x}, ${entry.labelAnchor.y})`}>
-              <rect x={-2} y={-14} width={entry.zone.name.length * 6.4 + 12} height={18} rx={4}
-                fill="rgba(15, 23, 42, 0.85)" />
-              <text x={4} y={-1} fontSize={11} fill="#fff">
-                {entry.setName} / {entry.zone.name}
-              </text>
+              <ZoneLabel text={`${entry.setName} / ${entry.zone.name}`} />
             </g>
           </g>
         );

--- a/apps/viewer/src/hooks/useZoneTableExport.test.ts
+++ b/apps/viewer/src/hooks/useZoneTableExport.test.ts
@@ -1,0 +1,182 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The zone table against a real model (#2508 item 3).
+ *
+ * `lib/zones/table.test.ts` pins the SHAPE from hand-written facts. What only
+ * this file can check is that the facts arriving from the store are the same
+ * ones the pset write-back writes: the whole point of the table is that a
+ * planner can reconcile the spreadsheet against the model, and two producers of
+ * a per-zone volume is exactly how that stops being true.
+ *
+ * The fixture declares CUBIC MILLIMETRES, because a table that reports native
+ * units where it promises SI is wrong by 1e9 while looking entirely plausible.
+ */
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { IfcParser, type IfcDataStore } from '@ifc-lite/parser';
+import { useViewerStore } from '@/store/index.js';
+import { buildZoneTable, exportZoneTable } from './useZoneTableExport.js';
+import { applyZoneWriteBack } from './useZoneWriteBack.js';
+import { zoneQuantitySetName, type ZoneApportionmentEntry, type ZoneSet } from '@/lib/zones';
+
+const WALL_ID = 42;
+const BEAM_ID = 43;
+
+/** `#42` declares a NetVolume of 2e9 mm3 (2 m3) and straddles; `#43` is wholly
+ *  in Takt A and declares nothing. */
+const MINI_IFC = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('zones','',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0Project0000000000000a',$,'P',$,$,$,$,(#5),#6);
+#2=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#3=IFCSIUNIT(*,.VOLUMEUNIT.,.MILLI.,.CUBIC_METRE.);
+#6=IFCUNITASSIGNMENT((#2,#3));
+#5=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-05,$,$);
+#${WALL_ID}=IFCWALL('0Wall00000000000000042',$,'Wall, A',$,$,$,$,$,$);
+#${BEAM_ID}=IFCBEAM('0Beam00000000000000043',$,'Beam B',$,$,$,$,$,$);
+#50=IFCQUANTITYVOLUME('NetVolume',$,$,2.E+09,$);
+#51=IFCELEMENTQUANTITY('0Qto000000000000000051',$,'Qto_WallBaseQuantities',$,$,(#50));
+#52=IFCRELDEFINESBYPROPERTIES('0Rel000000000000000052',$,$,$,(#${WALL_ID}),#51);
+ENDSEC;
+END-ISO-10303-21;
+`;
+
+const ZONE_SET: ZoneSet = {
+  id: 'set-1',
+  name: 'Takt areas',
+  zones: [
+    { id: 'z-a', name: 'Takt A', center: [0, 0, 0], size: [10, 10, 10], rotationY: 0 },
+    { id: 'z-b', name: 'Takt B', center: [10, 0, 0], size: [10, 10, 10], rotationY: 0 },
+  ],
+  visible: true,
+  createdAt: 0,
+  updatedAt: 0,
+};
+
+function seedApportionment(revision: string): Map<string, ZoneApportionmentEntry> {
+  return new Map([['set-1', {
+    revision,
+    byElement: new Map([[WALL_ID, {
+      wholeVolumeM3: 5,
+      shares: [
+        { zoneId: 'z-a', zoneName: 'Takt A', volumeM3: 2, fraction: 0.4 },
+        { zoneId: 'z-b', zoneName: 'Takt B', volumeM3: 3, fraction: 0.6 },
+      ],
+      outsideVolumeM3: 0,
+      outsideFraction: 0,
+      overlapping: false,
+      unreliable: false,
+    }]]),
+    refused: new Map(),
+    computedAt: 0,
+    elapsedMs: 1,
+  }]]);
+}
+
+async function seed(): Promise<IfcDataStore> {
+  const bytes = new TextEncoder().encode(MINI_IFC);
+  const store = await new IfcParser().parseColumnar(
+    bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+  );
+  const { zoneSetRevision } = await import('@/lib/zones');
+  useViewerStore.setState({
+    models: new Map([['m1', { id: 'm1', name: 'zones.ifc', ifcDataStore: store, visible: true } as never]]),
+    zoneSets: [ZONE_SET],
+    zoneAssignments: new Map([
+      [WALL_ID, { 'set-1': { zoneId: 'z-a', zoneName: 'Takt A', straddles: true, touchedZoneIds: ['z-a', 'z-b'] } }],
+      [BEAM_ID, { 'set-1': { zoneId: 'z-a', zoneName: 'Takt A', straddles: false, touchedZoneIds: ['z-a'] } }],
+    ]) as never,
+    zoneApportionment: seedApportionment(zoneSetRevision(ZONE_SET)),
+    mutationViews: new Map(),
+    dirtyModels: new Set(),
+  } as never);
+  return store;
+}
+
+describe('the zone table against a real store', () => {
+  beforeEach(async () => { await seed(); });
+
+  it('names each element from the model rather than from its id', () => {
+    const rows = buildZoneTable(ZONE_SET, 'net');
+    const wall = rows.find((r) => r.ExpressId === WALL_ID);
+    assert.equal(wall?.GlobalId, '0Wall00000000000000042');
+    // PascalCase, as `getTypeName` gives it: this column is filtered on in a
+    // spreadsheet, and 'IfcWall' is what every other surface in the app shows.
+    assert.equal(wall?.IfcType, 'IfcWall');
+    assert.equal(wall?.Name, 'Wall, A');
+    assert.equal(wall?.Model, 'zones.ifc');
+  });
+
+  it('reports SI cubic metres, whatever the model declares', () => {
+    // The file's VOLUMEUNIT is CUBIC MILLIMETRE and its NetVolume is 2e9. A
+    // table that reported the native number would say 2,000,000,000.
+    const rows = buildZoneTable(ZONE_SET, 'net');
+    const wall = rows.filter((r) => r.ExpressId === WALL_ID);
+    assert.equal(wall.reduce((sum, r) => sum + (r.VolumeM3 ?? 0), 0), 2);
+    assert.deepEqual(wall.map((r) => r.VolumeM3), [0.8, 1.2]);
+  });
+
+  it('agrees with what the write-back puts in the model, to the last digit', () => {
+    // The reconciliation the whole table exists for. `applyZoneWriteBack`
+    // writes the model's NATIVE unit; the table writes SI; both come from the
+    // same resolved facts, so the ratio is exactly the declared unit scale.
+    const rows = buildZoneTable(ZONE_SET, 'net');
+    applyZoneWriteBack(ZONE_SET, 'net');
+    const qsets = useViewerStore.getState().getMutationView('m1')?.getQuantitiesForEntity(WALL_ID) ?? [];
+    const qset = qsets.find((q) => q.name === zoneQuantitySetName('Takt areas', 'net'));
+    assert.ok(qset, 'the write-back wrote no quantity set');
+
+    for (const row of rows.filter((r) => r.ExpressId === WALL_ID)) {
+      const written: { name: string; value: unknown } | undefined = qset.quantities
+        .find((q) => q.name === row.Zone);
+      assert.ok(written, `no written quantity for ${row.Zone}`);
+      // 1e9 mm3 per m3.
+      assert.equal(Number(written.value), (row.VolumeM3 as number) * 1e9);
+    }
+  });
+
+  it('states a reason rather than dropping an element it cannot measure', () => {
+    // The beam declares no NetVolume, so on the `net` basis it has no number -
+    // and it is still in Takt A, which the table must say.
+    const beam = buildZoneTable(ZONE_SET, 'net').filter((r) => r.ExpressId === BEAM_ID);
+    assert.equal(beam.length, 1);
+    assert.equal(beam[0].Zone, 'Takt A');
+    assert.equal(beam[0].VolumeM3, null);
+    assert.match(beam[0].Unavailable, /declares no quantity/);
+  });
+
+  it('downloads a CSV whose header and row count match what it reports', async () => {
+    const emitted: Array<{ bytes: Uint8Array; filename: string; mime: string }> = [];
+    const result = await exportZoneTable(ZONE_SET, 'net', 'csv', (bytes, filename, mime) =>
+      emitted.push({ bytes, filename, mime }));
+
+    assert.equal(result.blocked, null);
+    assert.equal(result.rows, 3, 'two zones for the straddler, one for the beam');
+    assert.equal(result.elements, 2);
+    assert.equal(result.unmeasured, 1);
+    assert.equal(emitted[0].filename, 'Takt areas-zone-quantities.csv');
+    assert.equal(emitted[0].mime, 'text/csv');
+
+    const text = new TextDecoder().decode(emitted[0].bytes);
+    assert.equal(text.trim().split('\n').length, result.rows + 1, 'header plus one line per row');
+    assert.equal(emitted[0].bytes.byteLength, result.bytes);
+    // The name with a comma is quoted, so the row still parses into columns.
+    assert.match(text, /"Wall, A"/);
+  });
+
+  it('refuses to download an empty table', async () => {
+    useViewerStore.setState({ zoneAssignments: new Map() } as never);
+    const emitted: string[] = [];
+    const result = await exportZoneTable(ZONE_SET, 'net', 'csv', (_b, filename) => emitted.push(filename));
+    assert.equal(result.blocked, 'no-members');
+    assert.deepEqual(emitted, [], 'an empty zone set must not download a header-only file');
+  });
+});

--- a/apps/viewer/src/hooks/useZoneTableExport.ts
+++ b/apps/viewer/src/hooks/useZoneTableExport.ts
@@ -112,7 +112,10 @@ export async function exportZoneTable(
 
   return {
     rows: rows.length,
-    elements: new Set(rows.map((row) => row.GlobalId)).size,
+    // By resolved identity rather than by GlobalId: `describeElement` leaves
+    // the id EMPTY when neither resolver answers, and every such element would
+    // otherwise share one bucket and be reported as one.
+    elements: new Set(rows.map((row) => `${row.Model}#${row.ExpressId}`)).size,
     unmeasured: rows.filter((row) => row.VolumeM3 === null).length,
     bytes: bytes.byteLength,
     filename,

--- a/apps/viewer/src/hooks/useZoneTableExport.ts
+++ b/apps/viewer/src/hooks/useZoneTableExport.ts
@@ -1,0 +1,130 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Download the per-element x per-zone table as CSV or Parquet (#2508 item 3).
+ *
+ * The gathering half of `lib/zones/table.ts`: which element, in which model,
+ * under which name. The numbers come from `gatherZoneFacts`, which is the same
+ * call `applyZoneWriteBack` makes, so the spreadsheet and the property sets can
+ * disagree only if the user exported them at different times - never because
+ * two code paths computed a volume differently.
+ *
+ * Parquet goes through `@ifc-lite/export`'s `columnsToParquet`, the same
+ * Arrow-to-Parquet conversion `ParquetExporter` uses, rather than a second one
+ * with its own type inference.
+ */
+
+import { useCallback } from 'react';
+import { columnsToParquet, isParquet } from '@ifc-lite/export';
+import type { IfcDataStore } from '@ifc-lite/parser';
+import { useViewerStore } from '@/store';
+import { resolveEntityRef, resolveGlobalId } from '@/store/resolveEntityRef';
+import { downloadFile, sanitizeFilename } from '@/lib/export/download';
+import {
+  toCsv,
+  toColumns,
+  zoneTableRows,
+  ZONE_TABLE_FLOAT_COLUMNS,
+  type ZoneTableRow,
+  type ZoneTableElement,
+  type VolumeBasis,
+  type ZoneSet,
+} from '@/lib/zones';
+import { gatherZoneFacts } from './zoneFacts.js';
+
+export type ZoneTableFormat = 'csv' | 'parquet';
+
+export interface ZoneTableExportResult {
+  rows: number;
+  elements: number;
+  /** Rows with no volume, each carrying its stated reason. Reported so a user
+   *  is told the table is partial rather than discovering it by summing. */
+  unmeasured: number;
+  bytes: number;
+  filename: string;
+  blocked: 'no-members' | null;
+}
+
+/**
+ * The element's own identity, through the columnar accessors the Lists engine
+ * uses (`getName` / `getTypeName`), which are O(1) table reads rather than an
+ * entity extraction per row.
+ *
+ * Missing pieces are left EMPTY rather than guessed: a wrong IfcType in a
+ * column people filter on is worse than a blank one.
+ */
+function describeElement(globalId: number, modelNames: Map<string, string>): ZoneTableElement {
+  const state = useViewerStore.getState();
+  const ref = resolveEntityRef(globalId);
+  const store = (ref.modelId === 'legacy'
+    ? state.ifcDataStore
+    : state.models.get(ref.modelId)?.ifcDataStore ?? null) as IfcDataStore | null;
+  const entities = store?.entities;
+  return {
+    // The federated GlobalId resolver, so a re-imported table joins back to the
+    // model on the one id that survives an export.
+    globalId: resolveGlobalId(globalId) ?? entities?.getGlobalId?.(ref.expressId) ?? '',
+    expressId: ref.expressId,
+    modelName: modelNames.get(ref.modelId) ?? '',
+    ifcType: entities?.getTypeName?.(ref.expressId) ?? '',
+    name: entities?.getName?.(ref.expressId) ?? '',
+  };
+}
+
+/** Build the table for one zone set. Exported for the test, which asserts on
+ *  the rows rather than on a downloaded blob. */
+export function buildZoneTable(zoneSet: ZoneSet, basis: VolumeBasis): ZoneTableRow[] {
+  const state = useViewerStore.getState();
+  const modelNames = new Map([...state.models].map(([id, model]) => [id, model.name ?? id]));
+  const rows: ZoneTableRow[] = [];
+  for (const row of gatherZoneFacts(zoneSet, basis)) {
+    rows.push(...zoneTableRows(describeElement(row.globalId, modelNames), row.facts, zoneSet.name, basis));
+  }
+  return rows;
+}
+
+/** Build and download the table. */
+export async function exportZoneTable(
+  zoneSet: ZoneSet,
+  basis: VolumeBasis,
+  format: ZoneTableFormat,
+  emit: (bytes: Uint8Array, filename: string, mime: string) => void = downloadFile,
+): Promise<ZoneTableExportResult> {
+  const rows = buildZoneTable(zoneSet, basis);
+  const empty = { rows: 0, elements: 0, unmeasured: 0, bytes: 0, filename: '' };
+  if (rows.length === 0) return { ...empty, blocked: 'no-members' };
+
+  const bytes = format === 'csv'
+    ? new TextEncoder().encode(toCsv(rows))
+    : await columnsToParquet(toColumns(rows), new Set(ZONE_TABLE_FLOAT_COLUMNS));
+  // `columnsToParquet` degrades to Arrow IPC when its wasm writer cannot load.
+  // Those bytes are still useful, but a `.parquet` file that is not Parquet
+  // opens in nothing, and the reader is told it is corrupt rather than that it
+  // is a different format. So the EXTENSION follows the bytes.
+  const extension = format === 'csv' ? 'csv' : (isParquet(bytes) ? 'parquet' : 'arrow');
+  const filename = `${sanitizeFilename(`${zoneSet.name}-zone-quantities`)}.${extension}`;
+  const mime = extension === 'csv'
+    ? 'text/csv'
+    : extension === 'parquet' ? 'application/vnd.apache.parquet' : 'application/vnd.apache.arrow.stream';
+  emit(bytes, filename, mime);
+
+  return {
+    rows: rows.length,
+    elements: new Set(rows.map((row) => row.GlobalId)).size,
+    unmeasured: rows.filter((row) => row.VolumeM3 === null).length,
+    bytes: bytes.byteLength,
+    filename,
+    blocked: null,
+  };
+}
+
+export function useZoneTableExport() {
+  const exportTable = useCallback(
+    (zoneSet: ZoneSet, basis: VolumeBasis, format: ZoneTableFormat) =>
+      exportZoneTable(zoneSet, basis, format),
+    [],
+  );
+  return { exportTable };
+}

--- a/apps/viewer/src/hooks/useZoneWriteBack.ts
+++ b/apps/viewer/src/hooks/useZoneWriteBack.ts
@@ -37,29 +37,27 @@
  */
 
 import { useCallback } from 'react';
-import { MutablePropertyView } from '@ifc-lite/mutations';
 import { QuantityType, PropertyValueType } from '@ifc-lite/data';
-import { extractProjectUnits, type IfcDataStore } from '@ifc-lite/parser';
 import { useViewerStore } from '@/store';
 import { resolveEntityRef } from '@/store/resolveEntityRef';
-import { configureMutationView } from '@/utils/configureMutationView';
 import {
   buildElementWriteBack,
   summarize,
-  declaredVolumeBases,
   validEntry,
   zoneQuantitySetPrefix,
   ZONE_PROPERTY_NAMES,
   ZONE_QUANTITY_SET_NAME_PREFIX,
   ZONE_SET_NAME_PREFIX,
   type ElementWriteBack,
-  type ElementZoneFacts,
   type VolumeBasis,
-  type WriteBackRefusal,
   type WriteBackSummary,
   type ZoneSet,
 } from '@/lib/zones';
-import { computeZoneApportionmentNow, gatherProvedVolumes, type ProvedVolumes } from './useZoneApportionment.js';
+import { computeZoneApportionmentNow, gatherProvedVolumes } from './useZoneApportionment.js';
+// The numbers themselves come from ONE place, shared with the table export:
+// two producers of a per-zone volume is exactly the disagreement #2508's
+// verification bar exists to prevent.
+import { contextFor, quantitySetsFor, zoneFactsFor, type ModelContext } from './zoneFacts.js';
 
 export interface ZoneWriteBackResult {
   summary: WriteBackSummary;
@@ -92,74 +90,6 @@ const EMPTY: ZoneWriteBackResult = {
   elapsedMs: 0,
   blocked: null,
 };
-
-/** Per-model things the loop would otherwise re-derive per element. */
-interface ModelContext {
-  view: MutablePropertyView;
-  volumeSiScale: number;
-  store: IfcDataStore | null;
-}
-
-function volumeScaleOf(store: IfcDataStore | null): number {
-  if (!store || !(store.source?.length > 0)) return 1;
-  const scale = extractProjectUnits(store.source, store.entityIndex).resolvedForUnitType('VOLUMEUNIT')?.siScale;
-  return Number.isFinite(scale) && (scale ?? 0) > 0 ? (scale as number) : 1;
-}
-
-/** Get-or-create a model's overlay. Write-back is often the FIRST thing in a
- *  session to touch a model's properties, so unlike the panels it cannot assume
- *  a view already exists. */
-function contextFor(modelId: string, cache: Map<string, ModelContext | null>): ModelContext | null {
-  const cached = cache.get(modelId);
-  if (cached !== undefined) return cached;
-
-  const state = useViewerStore.getState();
-  const store = (state.models.get(modelId)?.ifcDataStore ?? (modelId === 'legacy' ? state.ifcDataStore : null)) as IfcDataStore | null;
-  let view = state.getMutationView(modelId);
-  if (!view) {
-    if (!store) {
-      cache.set(modelId, null);
-      return null;
-    }
-    view = new MutablePropertyView(store.properties || null, modelId);
-    configureMutationView(view, store);
-    state.registerMutationView(modelId, view);
-  }
-  const context: ModelContext = { view, volumeSiScale: volumeScaleOf(store), store };
-  cache.set(modelId, context);
-  return context;
-}
-
-/**
- * The element's quantity sets as the session sees them: the file's own, plus
- * any this session edited or created.
- *
- * Read through the mutation VIEW rather than the data store for two reasons.
- * The store's `quantities` table is empty on a lazily-parsed model (quantities
- * live behind `onDemandQuantityMap`, which the view's configured extractor
- * uses), and a NetVolume the user corrected this session is the number they
- * expect to see apportioned.
- */
-function quantitySetsFor(context: ModelContext, expressId: number) {
-  return context.view.getQuantitiesForEntity(expressId);
-}
-
-/** Resolve the whole-element total on `basis`, plus the quantity name it came
- *  from. `null` total means the file declares nothing on that basis. */
-function declaredTotal(
-  qsets: ReturnType<typeof quantitySetsFor>,
-  volumeSiScale: number,
-  basis: Exclude<VolumeBasis, 'mesh'>,
-): { totalM3: number; quantityName: string } | null {
-  // A previous run's OWN output is excluded before anything is read off it.
-  // Its rows are volumes with no qualifying name, so `unqualified` would
-  // otherwise apportion a zone's share as if it were the element's total and
-  // feed the result back in on every run.
-  const declaredSets = qsets.filter((q) => !q.name.startsWith(ZONE_QUANTITY_SET_NAME_PREFIX));
-  const declared = declaredVolumeBases(declaredSets, volumeSiScale);
-  const match = declared.find((d) => d.basis === basis);
-  return match ? { totalM3: match.valueM3, quantityName: match.quantityName } : null;
-}
 
 /**
  * Every zone property/quantity set on this element that belongs to `zoneSetId`,
@@ -219,74 +149,6 @@ function sweepZoneSets(
   return psets.length + qsets.length;
 }
 
-interface VolumeResolution {
-  shares: Array<{ zoneName: string; valueM3: number }>;
-  outsideM3: number;
-  refusal: WriteBackRefusal | null;
-  quantityName: string | null;
-}
-
-/**
- * How much of this element is in each zone, on the chosen basis.
- *
- * A straddler's split is measured (the apportionment cache); a non-straddler's
- * is trivially "all of it, in its home zone" and skips the clip entirely. Both
- * take their MAGNITUDE from the same basis, which is what keeps the two
- * populations addable in one column.
- */
-function resolveVolumes(
-  globalId: number,
-  straddles: boolean,
-  homeZoneName: string | null,
-  basis: VolumeBasis,
-  qsets: ReturnType<typeof quantitySetsFor>,
-  volumeSiScale: number,
-  proved: ProvedVolumes,
-  apportioned: ReturnType<typeof validEntry>,
-): VolumeResolution {
-  const declared = basis === 'mesh' ? null : declaredTotal(qsets, volumeSiScale, basis);
-  if (basis !== 'mesh' && !declared) {
-    return { shares: [], outsideM3: 0, refusal: 'no-declared-quantity', quantityName: null };
-  }
-  const quantityName = declared?.quantityName ?? null;
-
-  if (straddles) {
-    const entry = apportioned?.byElement.get(globalId) ?? null;
-    if (!entry) {
-      const refusal = (apportioned?.refused.get(globalId) ?? 'no-geometry') as WriteBackRefusal;
-      return { shares: [], outsideM3: 0, refusal, quantityName };
-    }
-    // Overlapping zones double-count, so the shares are individually right but
-    // do not add up. A panel can say that beside the numbers; a quantity set
-    // cannot, and a reader will add the rows up.
-    if (entry.overlapping) {
-      return { shares: [], outsideM3: 0, refusal: 'overlapping-zones', quantityName };
-    }
-    const total = declared ? declared.totalM3 : entry.wholeVolumeM3;
-    return {
-      shares: entry.shares.map((s) => ({ zoneName: s.zoneName, valueM3: s.fraction * total })),
-      outsideM3: entry.outsideFraction * total,
-      refusal: null,
-      quantityName,
-    };
-  }
-
-  // Wholly inside one zone. Nothing to split, so nothing to prove about the
-  // geometry - on a declared basis this element never touches the renderer.
-  if (!homeZoneName) return { shares: [], outsideM3: 0, refusal: 'no-geometry', quantityName };
-  if (declared) {
-    return { shares: [{ zoneName: homeZoneName, valueM3: declared.totalM3 }], outsideM3: 0, refusal: null, quantityName };
-  }
-  if (proved.rescaled.has(globalId)) {
-    return { shares: [], outsideM3: 0, refusal: 'rescaled-by-alignment', quantityName };
-  }
-  const mesh = proved.byGlobalId.get(globalId);
-  if (mesh === undefined || !Number.isFinite(mesh)) {
-    return { shares: [], outsideM3: 0, refusal: 'unproved-solid', quantityName };
-  }
-  return { shares: [{ zoneName: homeZoneName, valueM3: Math.abs(mesh) }], outsideM3: 0, refusal: null, quantityName };
-}
-
 /**
  * Write `zoneSet`'s assignment into every model it reaches.
  *
@@ -337,26 +199,7 @@ export function applyZoneWriteBack(zoneSet: ZoneSet, basis: VolumeBasis): ZoneWr
     // declared basis and the stale-zone-qset sweep below. Each read is an
     // on-demand extraction, so asking twice would double the run's cost.
     const qsets = quantitySetsFor(context, ref.expressId);
-    const volumes = resolveVolumes(
-      globalId,
-      assignment.straddles,
-      assignment.zoneName,
-      basis,
-      qsets,
-      context.volumeSiScale,
-      proved,
-      apportioned,
-    );
-    const facts: ElementZoneFacts = {
-      globalId,
-      homeZoneName: assignment.zoneName,
-      // Mapped through the set rather than trusting stored names: the
-      // assignment holds zone IDS precisely so a rename cannot leave stale
-      // names behind (types.ts).
-      touchedZoneNames: assignment.touchedZoneIds.map((id) => zoneNameById.get(id) ?? ''),
-      straddles: assignment.straddles,
-      ...volumes,
-    };
+    const facts = zoneFactsFor(globalId, assignment, zoneNameById, basis, context, qsets, proved, apportioned);
     const built = buildElementWriteBack(facts, {
       zoneSetName: zoneSet.name,
       zoneSetId: zoneSet.id,

--- a/apps/viewer/src/hooks/zoneFacts.ts
+++ b/apps/viewer/src/hooks/zoneFacts.ts
@@ -1,0 +1,247 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * How much of each element is in each zone, resolved once for every consumer
+ * (issue #2508).
+ *
+ * Extracted from `useZoneWriteBack` when the CSV/Parquet table export arrived,
+ * because the two must not be two producers of the same number. A user who
+ * exports the table and then writes the psets, or who compares the spreadsheet
+ * against another tool's property panel, is comparing the SAME run of the same
+ * arithmetic - not two implementations that agree today.
+ *
+ * Everything here reads the store and the apportionment cache; nothing here
+ * writes. See `lib/zones/writeback.ts` for the pure naming/labelling half.
+ */
+
+import { MutablePropertyView } from '@ifc-lite/mutations';
+import { extractProjectUnits, type IfcDataStore } from '@ifc-lite/parser';
+import { useViewerStore } from '@/store';
+import { resolveEntityRef } from '@/store/resolveEntityRef';
+import { configureMutationView } from '@/utils/configureMutationView';
+import {
+  declaredVolumeBases,
+  validEntry,
+  ZONE_QUANTITY_SET_NAME_PREFIX,
+  type ElementZoneFacts,
+  type VolumeBasis,
+  type WriteBackRefusal,
+  type ZoneSet,
+} from '@/lib/zones';
+import { computeZoneApportionmentNow, gatherProvedVolumes, type ProvedVolumes } from './useZoneApportionment.js';
+
+/** Per-model things the loop would otherwise re-derive per element. */
+export interface ModelContext {
+  view: MutablePropertyView;
+  volumeSiScale: number;
+  store: IfcDataStore | null;
+}
+
+function volumeScaleOf(store: IfcDataStore | null): number {
+  if (!store || !(store.source?.length > 0)) return 1;
+  const scale = extractProjectUnits(store.source, store.entityIndex).resolvedForUnitType('VOLUMEUNIT')?.siScale;
+  return Number.isFinite(scale) && (scale ?? 0) > 0 ? (scale as number) : 1;
+}
+
+/** Get-or-create a model's overlay. Write-back is often the FIRST thing in a
+ *  session to touch a model's properties, so unlike the panels it cannot assume
+ *  a view already exists. */
+export function contextFor(modelId: string, cache: Map<string, ModelContext | null>): ModelContext | null {
+  const cached = cache.get(modelId);
+  if (cached !== undefined) return cached;
+
+  const state = useViewerStore.getState();
+  const store = (state.models.get(modelId)?.ifcDataStore ?? (modelId === 'legacy' ? state.ifcDataStore : null)) as IfcDataStore | null;
+  let view = state.getMutationView(modelId);
+  if (!view) {
+    if (!store) {
+      cache.set(modelId, null);
+      return null;
+    }
+    view = new MutablePropertyView(store.properties || null, modelId);
+    configureMutationView(view, store);
+    state.registerMutationView(modelId, view);
+  }
+  const context: ModelContext = { view, volumeSiScale: volumeScaleOf(store), store };
+  cache.set(modelId, context);
+  return context;
+}
+
+/**
+ * The element's quantity sets as the session sees them: the file's own, plus
+ * any this session edited or created.
+ *
+ * Read through the mutation VIEW rather than the data store for two reasons.
+ * The store's `quantities` table is empty on a lazily-parsed model (quantities
+ * live behind `onDemandQuantityMap`, which the view's configured extractor
+ * uses), and a NetVolume the user corrected this session is the number they
+ * expect to see apportioned.
+ */
+export function quantitySetsFor(context: ModelContext, expressId: number) {
+  return context.view.getQuantitiesForEntity(expressId);
+}
+
+/** Resolve the whole-element total on `basis`, plus the quantity name it came
+ *  from. `null` total means the file declares nothing on that basis. */
+export function declaredTotal(
+  qsets: ReturnType<typeof quantitySetsFor>,
+  volumeSiScale: number,
+  basis: Exclude<VolumeBasis, 'mesh'>,
+): { totalM3: number; quantityName: string } | null {
+  // A previous run's OWN output is excluded before anything is read off it.
+  // Its rows are volumes with no qualifying name, so `unqualified` would
+  // otherwise apportion a zone's share as if it were the element's total and
+  // feed the result back in on every run.
+  const declaredSets = qsets.filter((q) => !q.name.startsWith(ZONE_QUANTITY_SET_NAME_PREFIX));
+  const declared = declaredVolumeBases(declaredSets, volumeSiScale);
+  const match = declared.find((d) => d.basis === basis);
+  return match ? { totalM3: match.valueM3, quantityName: match.quantityName } : null;
+}
+
+export interface VolumeResolution {
+  shares: Array<{ zoneName: string; valueM3: number }>;
+  outsideM3: number;
+  refusal: WriteBackRefusal | null;
+  quantityName: string | null;
+}
+
+/**
+ * How much of this element is in each zone, on the chosen basis.
+ *
+ * A straddler's split is measured (the apportionment cache); a non-straddler's
+ * is trivially "all of it, in its home zone" and skips the clip entirely. Both
+ * take their MAGNITUDE from the same basis, which is what keeps the two
+ * populations addable in one column.
+ */
+export function resolveVolumes(
+  globalId: number,
+  straddles: boolean,
+  homeZoneName: string | null,
+  basis: VolumeBasis,
+  qsets: ReturnType<typeof quantitySetsFor>,
+  volumeSiScale: number,
+  proved: ProvedVolumes,
+  apportioned: ReturnType<typeof validEntry>,
+): VolumeResolution {
+  const declared = basis === 'mesh' ? null : declaredTotal(qsets, volumeSiScale, basis);
+  if (basis !== 'mesh' && !declared) {
+    return { shares: [], outsideM3: 0, refusal: 'no-declared-quantity', quantityName: null };
+  }
+  const quantityName = declared?.quantityName ?? null;
+
+  if (straddles) {
+    const entry = apportioned?.byElement.get(globalId) ?? null;
+    if (!entry) {
+      const refusal = (apportioned?.refused.get(globalId) ?? 'no-geometry') as WriteBackRefusal;
+      return { shares: [], outsideM3: 0, refusal, quantityName };
+    }
+    // Overlapping zones double-count, so the shares are individually right but
+    // do not add up. A panel can say that beside the numbers; a quantity set
+    // cannot, and a reader will add the rows up.
+    if (entry.overlapping) {
+      return { shares: [], outsideM3: 0, refusal: 'overlapping-zones', quantityName };
+    }
+    const total = declared ? declared.totalM3 : entry.wholeVolumeM3;
+    return {
+      shares: entry.shares.map((s) => ({ zoneName: s.zoneName, valueM3: s.fraction * total })),
+      outsideM3: entry.outsideFraction * total,
+      refusal: null,
+      quantityName,
+    };
+  }
+
+  // Wholly inside one zone. Nothing to split, so nothing to prove about the
+  // geometry - on a declared basis this element never touches the renderer.
+  if (!homeZoneName) return { shares: [], outsideM3: 0, refusal: 'no-geometry', quantityName };
+  if (declared) {
+    return { shares: [{ zoneName: homeZoneName, valueM3: declared.totalM3 }], outsideM3: 0, refusal: null, quantityName };
+  }
+  if (proved.rescaled.has(globalId)) {
+    return { shares: [], outsideM3: 0, refusal: 'rescaled-by-alignment', quantityName };
+  }
+  const mesh = proved.byGlobalId.get(globalId);
+  if (mesh === undefined || !Number.isFinite(mesh)) {
+    return { shares: [], outsideM3: 0, refusal: 'unproved-solid', quantityName };
+  }
+  return { shares: [{ zoneName: homeZoneName, valueM3: Math.abs(mesh) }], outsideM3: 0, refusal: null, quantityName };
+}
+
+/** One element's row: the facts, plus what a writer needs to reach it. */
+export interface ZoneFactsRow {
+  globalId: number;
+  modelId: string;
+  expressId: number;
+  facts: ElementZoneFacts;
+  /** The model's own declared volume unit, metres cubed per native unit. */
+  volumeSiScale: number;
+}
+
+/**
+ * Every element of `zoneSet`, with its per-zone volumes on `basis`.
+ *
+ * Recomputes the apportionment when the cache is stale, so a table can never
+ * carry volumes from zones that have since moved - the same guarantee, from the
+ * same call, that the write-back makes.
+ */
+export function gatherZoneFacts(zoneSet: ZoneSet, basis: VolumeBasis): ZoneFactsRow[] {
+  const state = useViewerStore.getState();
+  const zoneNameById = new Map(zoneSet.zones.map((z) => [z.id, z.name]));
+  const apportioned = validEntry(state.zoneApportionment, zoneSet) ?? computeZoneApportionmentNow(zoneSet);
+  const proved = gatherProvedVolumes();
+  const contexts = new Map<string, ModelContext | null>();
+  const rows: ZoneFactsRow[] = [];
+
+  for (const [globalId, record] of state.zoneAssignments) {
+    const assignment = record[zoneSet.id];
+    if (!assignment || assignment.touchedZoneIds.length === 0) continue;
+    const ref = resolveEntityRef(globalId);
+    const context = contextFor(ref.modelId, contexts);
+    if (!context) continue;
+    const qsets = quantitySetsFor(context, ref.expressId);
+    const facts = zoneFactsFor(globalId, assignment, zoneNameById, basis, context, qsets, proved, apportioned);
+    rows.push({
+      globalId,
+      modelId: ref.modelId,
+      expressId: ref.expressId,
+      facts,
+      volumeSiScale: context.volumeSiScale,
+    });
+  }
+  return rows;
+}
+
+/** One element's facts. The shape the assignment record carries is inlined
+ *  rather than imported to keep this module free of the store's types. */
+export function zoneFactsFor(
+  globalId: number,
+  assignment: { zoneName: string | null; straddles: boolean; touchedZoneIds: string[] },
+  zoneNameById: ReadonlyMap<string, string>,
+  basis: VolumeBasis,
+  context: ModelContext,
+  qsets: ReturnType<typeof quantitySetsFor>,
+  proved: ProvedVolumes,
+  apportioned: ReturnType<typeof validEntry>,
+): ElementZoneFacts {
+  const volumes = resolveVolumes(
+    globalId,
+    assignment.straddles,
+    assignment.zoneName,
+    basis,
+    qsets,
+    context.volumeSiScale,
+    proved,
+    apportioned,
+  );
+  return {
+    globalId,
+    homeZoneName: assignment.zoneName,
+    // Mapped through the set rather than trusting stored names: the assignment
+    // holds zone IDS precisely so a rename cannot leave stale names behind
+    // (types.ts).
+    touchedZoneNames: assignment.touchedZoneIds.map((id) => zoneNameById.get(id) ?? ''),
+    straddles: assignment.straddles,
+    ...volumes,
+  };
+}

--- a/apps/viewer/src/hooks/zoneFacts.ts
+++ b/apps/viewer/src/hooks/zoneFacts.ts
@@ -101,7 +101,7 @@ export function declaredTotal(
 }
 
 export interface VolumeResolution {
-  shares: Array<{ zoneName: string; valueM3: number }>;
+  shares: Array<{ zoneId: string; zoneName: string; valueM3: number }>;
   outsideM3: number;
   refusal: WriteBackRefusal | null;
   quantityName: string | null;
@@ -119,6 +119,7 @@ export function resolveVolumes(
   globalId: number,
   straddles: boolean,
   homeZoneName: string | null,
+  homeZoneId: string | null,
   basis: VolumeBasis,
   qsets: ReturnType<typeof quantitySetsFor>,
   volumeSiScale: number,
@@ -145,7 +146,7 @@ export function resolveVolumes(
     }
     const total = declared ? declared.totalM3 : entry.wholeVolumeM3;
     return {
-      shares: entry.shares.map((s) => ({ zoneName: s.zoneName, valueM3: s.fraction * total })),
+      shares: entry.shares.map((s) => ({ zoneId: s.zoneId, zoneName: s.zoneName, valueM3: s.fraction * total })),
       outsideM3: entry.outsideFraction * total,
       refusal: null,
       quantityName,
@@ -154,9 +155,14 @@ export function resolveVolumes(
 
   // Wholly inside one zone. Nothing to split, so nothing to prove about the
   // geometry - on a declared basis this element never touches the renderer.
-  if (!homeZoneName) return { shares: [], outsideM3: 0, refusal: 'no-geometry', quantityName };
+  if (!homeZoneName || !homeZoneId) return { shares: [], outsideM3: 0, refusal: 'no-geometry', quantityName };
   if (declared) {
-    return { shares: [{ zoneName: homeZoneName, valueM3: declared.totalM3 }], outsideM3: 0, refusal: null, quantityName };
+    return {
+      shares: [{ zoneId: homeZoneId, zoneName: homeZoneName, valueM3: declared.totalM3 }],
+      outsideM3: 0,
+      refusal: null,
+      quantityName,
+    };
   }
   if (proved.rescaled.has(globalId)) {
     return { shares: [], outsideM3: 0, refusal: 'rescaled-by-alignment', quantityName };
@@ -165,7 +171,12 @@ export function resolveVolumes(
   if (mesh === undefined || !Number.isFinite(mesh)) {
     return { shares: [], outsideM3: 0, refusal: 'unproved-solid', quantityName };
   }
-  return { shares: [{ zoneName: homeZoneName, valueM3: Math.abs(mesh) }], outsideM3: 0, refusal: null, quantityName };
+  return {
+    shares: [{ zoneId: homeZoneId, zoneName: homeZoneName, valueM3: Math.abs(mesh) }],
+    outsideM3: 0,
+    refusal: null,
+    quantityName,
+  };
 }
 
 /** One element's row: the facts, plus what a writer needs to reach it. */
@@ -216,7 +227,7 @@ export function gatherZoneFacts(zoneSet: ZoneSet, basis: VolumeBasis): ZoneFacts
  *  rather than imported to keep this module free of the store's types. */
 export function zoneFactsFor(
   globalId: number,
-  assignment: { zoneName: string | null; straddles: boolean; touchedZoneIds: string[] },
+  assignment: { zoneId: string | null; zoneName: string | null; straddles: boolean; touchedZoneIds: string[] },
   zoneNameById: ReadonlyMap<string, string>,
   basis: VolumeBasis,
   context: ModelContext,
@@ -228,6 +239,7 @@ export function zoneFactsFor(
     globalId,
     assignment.straddles,
     assignment.zoneName,
+    assignment.zoneId,
     basis,
     qsets,
     context.volumeSiScale,
@@ -241,6 +253,7 @@ export function zoneFactsFor(
     // holds zone IDS precisely so a rename cannot leave stale names behind
     // (types.ts).
     touchedZoneNames: assignment.touchedZoneIds.map((id) => zoneNameById.get(id) ?? ''),
+    touchedZoneIds: [...assignment.touchedZoneIds],
     straddles: assignment.straddles,
     ...volumes,
   };

--- a/apps/viewer/src/lib/zones/index.ts
+++ b/apps/viewer/src/lib/zones/index.ts
@@ -118,3 +118,14 @@ export {
   type EmitResult,
   type ZoneMembership,
 } from './emit-spatial-zones.js';
+
+export {
+  toCsv,
+  toColumns,
+  zoneTableRows,
+  refusalText,
+  ZONE_TABLE_COLUMNS,
+  ZONE_TABLE_FLOAT_COLUMNS,
+  type ZoneTableRow,
+  type ZoneTableElement,
+} from './table.js';

--- a/apps/viewer/src/lib/zones/table.test.ts
+++ b/apps/viewer/src/lib/zones/table.test.ts
@@ -29,10 +29,11 @@ const STRADDLER: ElementZoneFacts = {
   globalId: 42,
   homeZoneName: 'Takt A',
   touchedZoneNames: ['Takt A', 'Takt B'],
+  touchedZoneIds: ['z-a', 'z-b'],
   straddles: true,
   shares: [
-    { zoneName: 'Takt A', valueM3: 2 },
-    { zoneName: 'Takt B', valueM3: 3 },
+    { zoneId: 'z-a', zoneName: 'Takt A', valueM3: 2 },
+    { zoneId: 'z-b', zoneName: 'Takt B', valueM3: 3 },
   ],
   outsideM3: 0,
   refusal: null,
@@ -64,7 +65,7 @@ describe('zoneTableRows', () => {
     // geometry they do not.
     const rows = zoneTableRows(
       ELEMENT,
-      { ...STRADDLER, shares: [{ zoneName: 'Takt A', valueM3: 2 }], touchedZoneNames: ['Takt A'], outsideM3: 3 },
+      { ...STRADDLER, shares: [{ zoneId: 'z-a', zoneName: 'Takt A', valueM3: 2 }], touchedZoneNames: ['Takt A'], touchedZoneIds: ['z-a'], outsideM3: 3 },
       'Takt areas',
       'net',
     );
@@ -99,7 +100,7 @@ describe('zoneTableRows', () => {
   it('does not divide by a zero total', () => {
     const rows = zoneTableRows(
       ELEMENT,
-      { ...STRADDLER, shares: [{ zoneName: 'Takt A', valueM3: 0 }], touchedZoneNames: ['Takt A'], outsideM3: 0 },
+      { ...STRADDLER, shares: [{ zoneId: 'z-a', zoneName: 'Takt A', valueM3: 0 }], touchedZoneNames: ['Takt A'], touchedZoneIds: ['z-a'], outsideM3: 0 },
       'Takt areas',
       'net',
     );
@@ -165,6 +166,50 @@ describe('toCsv', () => {
     const body = toCsv(rows).split('\n')[1];
     assert.ok(!body.includes('null'), `null leaked into the CSV: ${body}`);
     assert.ok(body.includes(',,'), 'the empty volume should be an empty cell');
+  });
+});
+
+describe('zoneTableRows: zones that share a name', () => {
+  it('reports each zone its OWN share', () => {
+    // Zone names are unique only by convention, so a set can legitimately hold
+    // two zones called "Section 2" (a JSON import, a copy-paste). Keying the
+    // shares by name collapsed them into one entry and reported the last one's
+    // volume for BOTH rows - a wrong number that still adds up, which is the
+    // worst kind in a file people sum.
+    const rows = zoneTableRows(
+      ELEMENT,
+      {
+        ...STRADDLER,
+        touchedZoneNames: ['Section 2', 'Section 2'],
+        touchedZoneIds: ['z-a', 'z-b'],
+        shares: [
+          { zoneId: 'z-a', zoneName: 'Section 2', valueM3: 2 },
+          { zoneId: 'z-b', zoneName: 'Section 2', valueM3: 3 },
+        ],
+      },
+      'Takt areas',
+      'net',
+    );
+    assert.deepEqual(rows.map((r) => r.VolumeM3), [2, 3]);
+    assert.equal(rows.reduce((sum, r) => sum + (r.VolumeM3 ?? 0), 0), 5);
+  });
+});
+
+describe('toCsv: a cell a spreadsheet would EXECUTE', () => {
+  it('neutralizes a formula hiding in an IFC name', () => {
+    // An IFC Name is attacker-controlled in any federated project, and this
+    // file exists to be opened in Excel. Quoting alone does not stop a cell
+    // being re-read as a formula.
+    for (const hostile of ['=cmd|\'/c calc\'!A1', '+1+1', '-1+1', '@SUM(A1)']) {
+      const csv = toCsv(zoneTableRows({ ...ELEMENT, name: hostile }, STRADDLER, 'Takt areas', 'net'));
+      const cell = parseCsvLine(csv.trim().split('\n')[1])[4];
+      assert.equal(cell, `'${hostile}`, `\`${hostile}\` reached the sheet unguarded`);
+    }
+  });
+
+  it('leaves an ordinary name alone', () => {
+    const csv = toCsv(zoneTableRows(ELEMENT, STRADDLER, 'Takt areas', 'net'));
+    assert.equal(parseCsvLine(csv.trim().split('\n')[1])[4], 'Basic Wall');
   });
 });
 

--- a/apps/viewer/src/lib/zones/table.test.ts
+++ b/apps/viewer/src/lib/zones/table.test.ts
@@ -1,0 +1,179 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The per-element x per-zone table (#2508 item 3).
+ *
+ * The file's job is to be summed and pivoted by someone who cannot see the
+ * model, so the assertions are about the properties that survive that: the
+ * rows for one element add up to it, an unmeasurable element is present and
+ * says why rather than being dropped, and no value can escape its column.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { toCsv, toColumns, zoneTableRows, ZONE_TABLE_COLUMNS } from './table.js';
+import type { ElementZoneFacts } from './writeback.js';
+
+const ELEMENT = {
+  globalId: '0Wall00000000000000042',
+  expressId: 42,
+  modelName: 'tower.ifc',
+  ifcType: 'IfcWall',
+  name: 'Basic Wall',
+};
+
+/** A straddler split 40/60 across two zones, 5 m3 in total. */
+const STRADDLER: ElementZoneFacts = {
+  globalId: 42,
+  homeZoneName: 'Takt A',
+  touchedZoneNames: ['Takt A', 'Takt B'],
+  straddles: true,
+  shares: [
+    { zoneName: 'Takt A', valueM3: 2 },
+    { zoneName: 'Takt B', valueM3: 3 },
+  ],
+  outsideM3: 0,
+  refusal: null,
+  quantityName: 'NetVolume',
+};
+
+describe('zoneTableRows', () => {
+  it('emits one row per zone the element reaches', () => {
+    const rows = zoneTableRows(ELEMENT, STRADDLER, 'Takt areas', 'net');
+    assert.equal(rows.length, 2);
+    assert.deepEqual(rows.map((r) => r.Zone), ['Takt A', 'Takt B']);
+    // Long format: the element's identity repeats on every row, which is what
+    // lets a pivot group by it.
+    assert.ok(rows.every((r) => r.GlobalId === ELEMENT.globalId && r.HomeZone === 'Takt A'));
+  });
+
+  it('gives shares that add up to the element, and fractions that add to 1', () => {
+    // The invariant #2508 puts above every other for this feature, restated in
+    // the shape a spreadsheet will check it in.
+    const rows = zoneTableRows(ELEMENT, STRADDLER, 'Takt areas', 'net');
+    assert.equal(rows.reduce((sum, r) => sum + (r.VolumeM3 ?? 0), 0), 5);
+    assert.equal(rows.reduce((sum, r) => sum + (r.Fraction ?? 0), 0), 1);
+    assert.ok(rows.every((r) => r.ElementVolumeM3 === 5));
+  });
+
+  it('counts the part outside every zone in the element total, not in a zone', () => {
+    // An element hanging off the end of the last takt area: its rows must not
+    // sum to its whole volume, or the table would claim the zones contain
+    // geometry they do not.
+    const rows = zoneTableRows(
+      ELEMENT,
+      { ...STRADDLER, shares: [{ zoneName: 'Takt A', valueM3: 2 }], touchedZoneNames: ['Takt A'], outsideM3: 3 },
+      'Takt areas',
+      'net',
+    );
+    assert.equal(rows[0].VolumeM3, 2);
+    assert.equal(rows[0].ElementVolumeM3, 5);
+    assert.equal(rows[0].Fraction, 0.4);
+  });
+
+  it('keeps an unmeasurable element in the table, with the reason', () => {
+    // Dropping it would make the element look absent from a zone the
+    // assignment says it is in, and a reader summing the column would get a
+    // total that is quietly short.
+    const rows = zoneTableRows(
+      ELEMENT,
+      { ...STRADDLER, shares: [], outsideM3: 0, refusal: 'unproved-solid', quantityName: null },
+      'Takt areas',
+      'mesh',
+    );
+    assert.equal(rows.length, 2);
+    assert.equal(rows[0].VolumeM3, null);
+    assert.equal(rows[0].Fraction, null);
+    assert.match(rows[0].Unavailable, /proven closed solid/);
+  });
+
+  it('names the basis on every row, because the number means nothing without it', () => {
+    const mesh = zoneTableRows(ELEMENT, STRADDLER, 'Takt areas', 'mesh');
+    const net = zoneTableRows(ELEMENT, STRADDLER, 'Takt areas', 'net');
+    assert.notEqual(mesh[0].Basis, net[0].Basis);
+    assert.equal(net[0].Quantity, 'NetVolume');
+  });
+
+  it('does not divide by a zero total', () => {
+    const rows = zoneTableRows(
+      ELEMENT,
+      { ...STRADDLER, shares: [{ zoneName: 'Takt A', valueM3: 0 }], touchedZoneNames: ['Takt A'], outsideM3: 0 },
+      'Takt areas',
+      'net',
+    );
+    assert.equal(rows[0].Fraction, null, 'a NaN would reach the spreadsheet');
+  });
+});
+
+/** Minimal RFC 4180 reader, so the test parses the file the way a spreadsheet
+ *  does rather than pattern-matching the text it expected to write. */
+function parseCsvLine(line: string): string[] {
+  const fields: string[] = [];
+  let field = '';
+  let quoted = false;
+  for (let i = 0; i < line.length; i++) {
+    const c = line[i];
+    if (quoted) {
+      if (c === '"' && line[i + 1] === '"') { field += '"'; i++; }
+      else if (c === '"') quoted = false;
+      else field += c;
+    } else if (c === '"') quoted = true;
+    else if (c === ',') { fields.push(field); field = ''; }
+    else field += c;
+  }
+  fields.push(field);
+  return fields;
+}
+
+describe('toCsv', () => {
+  it('quotes a value that would otherwise shift every later column', () => {
+    // Real IFC names carry commas ("Basic Wall:SW 200,0"), and a shifted row is
+    // invisible until someone sums the wrong column.
+    const rows = zoneTableRows(
+      { ...ELEMENT, name: 'Basic Wall:SW 200,0', ifcType: 'IfcWall' },
+      STRADDLER,
+      'Takt "A" areas',
+      'net',
+    );
+    const csv = toCsv(rows);
+    assert.match(csv, /"Basic Wall:SW 200,0"/);
+    // A quote inside a quoted field is doubled, per RFC 4180.
+    assert.match(csv, /"Takt ""A"" areas"/);
+    // ...and the row parses back to exactly as many fields as the header, which
+    // is the property a shifted column breaks.
+    const [header, body] = csv.trim().split('\n');
+    assert.equal(parseCsvLine(body).length, parseCsvLine(header).length);
+    // The name survives the round trip with its comma intact.
+    assert.ok(parseCsvLine(body).includes('Basic Wall:SW 200,0'));
+  });
+
+  it('writes the header in the declared column order, and ends with a newline', () => {
+    const csv = toCsv(zoneTableRows(ELEMENT, STRADDLER, 'Takt areas', 'net'));
+    assert.equal(csv.split('\n')[0], ZONE_TABLE_COLUMNS.join(','));
+    assert.ok(csv.endsWith('\n'), 'cat of two exports would join two rows');
+  });
+
+  it('writes an empty cell for an absent number rather than "null"', () => {
+    const rows = zoneTableRows(
+      ELEMENT,
+      { ...STRADDLER, shares: [], refusal: 'no-geometry', quantityName: null },
+      'Takt areas',
+      'mesh',
+    );
+    const body = toCsv(rows).split('\n')[1];
+    assert.ok(!body.includes('null'), `null leaked into the CSV: ${body}`);
+    assert.ok(body.includes(',,'), 'the empty volume should be an empty cell');
+  });
+});
+
+describe('toColumns', () => {
+  it('produces one array per declared column, all the same length', () => {
+    const rows = zoneTableRows(ELEMENT, STRADDLER, 'Takt areas', 'net');
+    const columns = toColumns(rows);
+    assert.deepEqual(Object.keys(columns), [...ZONE_TABLE_COLUMNS]);
+    assert.ok(Object.values(columns).every((c) => c.length === rows.length));
+    assert.deepEqual(columns.VolumeM3, [2, 3]);
+  });
+});

--- a/apps/viewer/src/lib/zones/table.ts
+++ b/apps/viewer/src/lib/zones/table.ts
@@ -32,6 +32,7 @@
  * the same call the pset write-back makes. Nothing here recomputes a volume.
  */
 
+import { neutralizeSpreadsheetFormula } from '@/lib/lists/export/model';
 import { volumeBasisLabel, type VolumeBasis } from './volume-basis.js';
 import type { ElementZoneFacts, WriteBackRefusal } from './writeback.js';
 
@@ -109,12 +110,17 @@ export function zoneTableRows(
   zoneSetName: string,
   basis: VolumeBasis,
 ): ZoneTableRow[] {
-  const shares = new Map(facts.shares.map((s) => [s.zoneName, s.valueM3]));
+  // Keyed by ID, not by name. Zone names are unique only by convention
+  // (`types.ts`: ids are what disambiguate), so two zones a user called
+  // "Section 2" would collapse into ONE entry here and report the last one's
+  // volume for both rows - a wrong number that adds up, which is the worst
+  // kind in a file people sum.
+  const shares = new Map(facts.shares.map((s) => [s.zoneId, s.valueM3]));
   const total = facts.shares.reduce((sum, s) => sum + s.valueM3, 0) + facts.outsideM3;
   const unavailable = facts.refusal ? refusalText(facts.refusal) : '';
 
-  return facts.touchedZoneNames.map((zoneName) => {
-    const value = shares.get(zoneName);
+  return facts.touchedZoneNames.map((zoneName, index) => {
+    const value = shares.get(facts.touchedZoneIds[index]);
     const measured = value !== undefined && Number.isFinite(value);
     return {
       GlobalId: element.globalId,
@@ -150,7 +156,13 @@ export function zoneTableRows(
 export function toCsv(rows: readonly ZoneTableRow[], delimiter = ','): string {
   const cell = (value: unknown): string => {
     if (value === null || value === undefined) return '';
-    const text = typeof value === 'boolean' ? (value ? 'true' : 'false') : String(value);
+    const raw = typeof value === 'boolean' ? (value ? 'true' : 'false') : String(value);
+    // Quoting stops a comma breaking the COLUMNS; it does nothing about a cell
+    // a spreadsheet re-reads as a FORMULA. An IFC Name is attacker-controlled
+    // in any federated project, and this file exists to be opened in Excel, so
+    // it goes through the viewer's existing neutralizer rather than a second
+    // rule invented here.
+    const text = neutralizeSpreadsheetFormula(raw);
     return /["\n\r]|^\s|\s$/.test(text) || text.includes(delimiter)
       ? `"${text.replace(/"/g, '""')}"`
       : text;

--- a/apps/viewer/src/lib/zones/table.ts
+++ b/apps/viewer/src/lib/zones/table.ts
@@ -1,0 +1,182 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The per-element x per-zone table (issue #2508 item 3), which is the direct
+ * answer to the complaint that opened #1763:
+ *
+ * > you can't get clean quantities per zone without a lot of manual work in
+ * > Excel or similar.
+ *
+ * So the deliverable is a file that opens in Excel and pivots, not a panel.
+ *
+ * ## Long, not wide
+ *
+ * ONE ROW PER (element, zone) pair rather than one row per element with a
+ * column per zone. A wide table's columns change every time a zone is added,
+ * renamed or deleted, so every saved pivot, formula and Power Query step
+ * against it breaks; and a straddler - the population this feature exists for -
+ * is exactly the row that would need several columns filled. Long format
+ * pivots to wide in one step in any spreadsheet, and the reverse is a manual
+ * unpivot.
+ *
+ * An element that reaches no zone of the set is not in the table at all. An
+ * element the volumes could not be established for IS, with an empty volume and
+ * the reason stated, because "this wall is in Takt B and we could not measure
+ * it" is a different fact from "this wall is not in Takt B", and a total that
+ * silently omits the first is the kind of number #2508's verification bar
+ * exists to stop.
+ *
+ * Pure: the numbers arrive already resolved (`hooks/zoneFacts.ts`), which is
+ * the same call the pset write-back makes. Nothing here recomputes a volume.
+ */
+
+import { volumeBasisLabel, type VolumeBasis } from './volume-basis.js';
+import type { ElementZoneFacts, WriteBackRefusal } from './writeback.js';
+
+/** One row: what one element contributes to one zone. */
+export interface ZoneTableRow {
+  GlobalId: string;
+  ExpressId: number;
+  Model: string;
+  IfcType: string;
+  Name: string;
+  ZoneSet: string;
+  Zone: string;
+  /** The zone holding the element's centroid, which is what the Lists column
+   *  and the pset call its zone. Repeated on every row of the element so a
+   *  filtered sheet keeps it. */
+  HomeZone: string;
+  Straddles: boolean;
+  /** Cubic metres of this element in THIS zone, or null when unmeasurable. */
+  VolumeM3: number | null;
+  /** This zone's share of the element, 0..1, or null. Kept beside the volume
+   *  because a fraction survives a unit disagreement and a volume does not. */
+  Fraction: number | null;
+  /** The element's whole volume on this basis, so a reader can check the rows
+   *  against it without a second pass. */
+  ElementVolumeM3: number | null;
+  Basis: string;
+  /** Named quantity the magnitudes came from (`NetVolume`), or empty on the
+   *  mesh basis where there is no declared quantity behind them. */
+  Quantity: string;
+  /** Why `VolumeM3` is empty. Empty string when it is not. */
+  Unavailable: string;
+}
+
+/** Column order, which is also the CSV header order. Fixed here so the CSV and
+ *  the Parquet schema cannot drift apart. */
+export const ZONE_TABLE_COLUMNS: ReadonlyArray<keyof ZoneTableRow> = [
+  'GlobalId', 'ExpressId', 'Model', 'IfcType', 'Name',
+  'ZoneSet', 'Zone', 'HomeZone', 'Straddles',
+  'VolumeM3', 'Fraction', 'ElementVolumeM3', 'Basis', 'Quantity', 'Unavailable',
+];
+
+/** Everything about an element that the facts do not carry. */
+export interface ZoneTableElement {
+  globalId: string;
+  expressId: number;
+  modelName: string;
+  ifcType: string;
+  name: string;
+}
+
+/** A refusal as a sentence, because the column is read by a person in a
+ *  spreadsheet rather than switched on by code. Mirrors the pset's own
+ *  `VolumeUnavailable` wording, so the file and the model agree. */
+export function refusalText(refusal: WriteBackRefusal): string {
+  switch (refusal) {
+    case 'no-geometry': return 'no geometry loaded for this element';
+    case 'no-declared-quantity': return 'the model declares no quantity on this basis';
+    case 'unproved-solid': return 'the mesh is not a proven closed solid';
+    case 'overlapping-zones': return 'the zones of this set overlap, so shares would double-count';
+    case 'rescaled-by-alignment': return 'federation alignment rescaled this model';
+    default: return refusal;
+  }
+}
+
+/**
+ * One element's facts to rows, one per zone it reaches.
+ *
+ * A zone with no measured share still gets its row: the element reaches it (the
+ * assignment says so), and dropping the row would make the element look absent
+ * from a zone it is demonstrably in.
+ */
+export function zoneTableRows(
+  element: ZoneTableElement,
+  facts: ElementZoneFacts,
+  zoneSetName: string,
+  basis: VolumeBasis,
+): ZoneTableRow[] {
+  const shares = new Map(facts.shares.map((s) => [s.zoneName, s.valueM3]));
+  const total = facts.shares.reduce((sum, s) => sum + s.valueM3, 0) + facts.outsideM3;
+  const unavailable = facts.refusal ? refusalText(facts.refusal) : '';
+
+  return facts.touchedZoneNames.map((zoneName) => {
+    const value = shares.get(zoneName);
+    const measured = value !== undefined && Number.isFinite(value);
+    return {
+      GlobalId: element.globalId,
+      ExpressId: element.expressId,
+      Model: element.modelName,
+      IfcType: element.ifcType,
+      Name: element.name,
+      ZoneSet: zoneSetName,
+      Zone: zoneName,
+      HomeZone: facts.homeZoneName ?? '',
+      Straddles: facts.straddles,
+      VolumeM3: measured ? value : null,
+      // Guarded against a zero total: an element whose whole volume is 0 has no
+      // meaningful fraction, and 0/0 would put NaN in a spreadsheet.
+      Fraction: measured && total > 0 ? value / total : null,
+      ElementVolumeM3: measured || facts.shares.length > 0 ? total : null,
+      Basis: volumeBasisLabel(basis),
+      Quantity: facts.quantityName ?? '',
+      Unavailable: measured ? '' : unavailable,
+    };
+  });
+}
+
+/**
+ * RFC 4180 CSV.
+ *
+ * Quoting is not optional here: an IFC `Name` routinely contains a comma
+ * ("Basic Wall:SW 200,0"), German decimal commas appear in type names, and a
+ * zone a user called `Takt "A"` is legal. A file that shifts every column right
+ * on one row is worse than no file, because the shift is invisible until
+ * someone sums the wrong column.
+ */
+export function toCsv(rows: readonly ZoneTableRow[], delimiter = ','): string {
+  const cell = (value: unknown): string => {
+    if (value === null || value === undefined) return '';
+    const text = typeof value === 'boolean' ? (value ? 'true' : 'false') : String(value);
+    return /["\n\r]|^\s|\s$/.test(text) || text.includes(delimiter)
+      ? `"${text.replace(/"/g, '""')}"`
+      : text;
+  };
+  const lines = [ZONE_TABLE_COLUMNS.join(delimiter)];
+  for (const row of rows) {
+    lines.push(ZONE_TABLE_COLUMNS.map((column) => cell(row[column])).join(delimiter));
+  }
+  // Trailing newline: POSIX text files end with one, and its absence makes
+  // `cat a.csv b.csv` silently join two rows.
+  return `${lines.join('\n')}\n`;
+}
+
+/** The same rows as columns, for the Parquet writer. Column-major because
+ *  that is what Arrow wants, and building it here keeps the two formats on one
+ *  definition of the schema. */
+export function toColumns(rows: readonly ZoneTableRow[]): Record<string, unknown[]> {
+  const columns: Record<string, unknown[]> = {};
+  for (const column of ZONE_TABLE_COLUMNS) {
+    columns[column] = rows.map((row) => row[column]);
+  }
+  return columns;
+}
+
+/** Column names that must stay Float64 in Parquet even when every value in a
+ *  given export happens to be whole. */
+export const ZONE_TABLE_FLOAT_COLUMNS: ReadonlySet<string> = new Set([
+  'VolumeM3', 'Fraction', 'ElementVolumeM3',
+]);

--- a/apps/viewer/src/lib/zones/writeback.test.ts
+++ b/apps/viewer/src/lib/zones/writeback.test.ts
@@ -28,11 +28,11 @@ function straddler(overrides: Partial<ElementZoneFacts> = {}): ElementZoneFacts 
   return {
     globalId: 42,
     homeZoneName: 'Takt A',
-    touchedZoneNames: ['Takt A', 'Takt B'],
+    touchedZoneNames: ['Takt A', 'Takt B'], touchedZoneIds: ['z-takt-a', 'z-takt-b'],
     straddles: true,
     shares: [
-      { zoneName: 'Takt A', valueM3: 4 },
-      { zoneName: 'Takt B', valueM3: 6 },
+      { zoneId: 'z-takt-a', zoneName: 'Takt A', valueM3: 4 },
+      { zoneId: 'z-takt-b', zoneName: 'Takt B', valueM3: 6 },
     ],
     outsideM3: 0,
     refusal: null,
@@ -87,7 +87,7 @@ describe('zone write-back: what lands on the element', () => {
 
   it('writes nothing at all for an element in no zone of the set', () => {
     const result = buildElementWriteBack(
-      straddler({ touchedZoneNames: [], shares: [], homeZoneName: null, straddles: false }),
+      straddler({ touchedZoneNames: [], touchedZoneIds: [], shares: [], homeZoneName: null, straddles: false }),
       MESH,
     );
     assert.equal(result, null);
@@ -120,8 +120,8 @@ describe('zone write-back: the numbers reconcile', () => {
   it('quantities sum to the element whole, including the part in no zone', () => {
     const facts = straddler({
       shares: [
-        { zoneName: 'Takt A', valueM3: 4 },
-        { zoneName: 'Takt B', valueM3: 5 },
+        { zoneId: 'z-takt-a', zoneName: 'Takt A', valueM3: 4 },
+        { zoneId: 'z-takt-b', zoneName: 'Takt B', valueM3: 5 },
       ],
       outsideM3: 1,
     });
@@ -142,8 +142,8 @@ describe('zone write-back: the numbers reconcile', () => {
     const result = buildElementWriteBack(
       straddler({
         shares: [
-          { zoneName: 'Takt A', valueM3: 10 },
-          { zoneName: 'Takt B', valueM3: 1e-17 },
+          { zoneId: 'z-takt-a', zoneName: 'Takt A', valueM3: 10 },
+          { zoneId: 'z-takt-b', zoneName: 'Takt B', valueM3: 1e-17 },
         ],
       }),
       MESH,
@@ -161,10 +161,10 @@ describe('zone write-back: names that collide', () => {
     // quantity with the second, losing a whole zone's volume with no error.
     const result = buildElementWriteBack(
       straddler({
-        touchedZoneNames: ['Section 2', 'Section 2'],
+        touchedZoneNames: ['Section 2', 'Section 2'], touchedZoneIds: ['z-section-2', 'z-section-2'],
         shares: [
-          { zoneName: 'Section 2', valueM3: 4 },
-          { zoneName: 'Section 2', valueM3: 6 },
+          { zoneId: 'z-section-2', zoneName: 'Section 2', valueM3: 4 },
+          { zoneId: 'z-section-2', zoneName: 'Section 2', valueM3: 6 },
         ],
       }),
       MESH,
@@ -177,10 +177,10 @@ describe('zone write-back: names that collide', () => {
   it('names a blank zone rather than writing an unaddressable empty quantity', () => {
     const result = buildElementWriteBack(
       straddler({
-        touchedZoneNames: ['  ', 'Takt B'],
+        touchedZoneNames: ['  ', 'Takt B'], touchedZoneIds: ['z---', 'z-takt-b'],
         shares: [
-          { zoneName: '  ', valueM3: 4 },
-          { zoneName: 'Takt B', valueM3: 6 },
+          { zoneId: 'z---', zoneName: '  ', valueM3: 4 },
+          { zoneId: 'z-takt-b', zoneName: 'Takt B', valueM3: 6 },
         ],
       }),
       MESH,
@@ -256,7 +256,7 @@ describe('zone write-back: refusals', () => {
 
   it('writes the pset without a quantity set when every share was negligible', () => {
     const result = buildElementWriteBack(
-      straddler({ shares: [{ zoneName: 'Takt A', valueM3: 0 }], outsideM3: 0 }),
+      straddler({ shares: [{ zoneId: 'z-takt-a', zoneName: 'Takt A', valueM3: 0 }], outsideM3: 0 }),
       MESH,
     );
     assert.ok(result);
@@ -270,7 +270,7 @@ describe('zone write-back: run summary', () => {
     const results = [
       buildElementWriteBack(straddler(), MESH),
       buildElementWriteBack(straddler({ shares: [], refusal: 'no-geometry' }), MESH),
-      buildElementWriteBack(straddler({ touchedZoneNames: [] }), MESH),
+      buildElementWriteBack(straddler({ touchedZoneNames: [], touchedZoneIds: [] }), MESH),
     ];
     assert.deepEqual(summarize(results), {
       written: 2,

--- a/apps/viewer/src/lib/zones/writeback.ts
+++ b/apps/viewer/src/lib/zones/writeback.ts
@@ -93,10 +93,15 @@ export interface ElementZoneFacts {
   /** Every zone the element reaches, in zone-set order. Empty means the element
    *  belongs to this set not at all - those are skipped, not written blank. */
   touchedZoneNames: readonly string[];
+  /** The same zones, by ID and in the same order. Names are unique only by
+   *  convention (`types.ts`), so anything that MATCHES a zone must match on
+   *  this: two zones a user called "Section 2" would otherwise collapse into
+   *  one share and report it for both. */
+  touchedZoneIds: readonly string[];
   straddles: boolean;
   /** Per-zone volume, SI cubic metres, on the basis named in the options. Empty
    *  when no volume could be established. */
-  shares: ReadonlyArray<{ zoneName: string; valueM3: number }>;
+  shares: ReadonlyArray<{ zoneId: string; zoneName: string; valueM3: number }>;
   /** SI cubic metres inside no zone of the set. */
   outsideM3: number;
   /** Why there are no volumes. `null` when `shares` is trustworthy - including

--- a/packages/export/src/columns-to-parquet.ts
+++ b/packages/export/src/columns-to-parquet.ts
@@ -1,0 +1,133 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Columns to Parquet bytes.
+ *
+ * Extracted from `ParquetExporter` so a caller with a table that is NOT an
+ * `IfcDataStore` view - the viewer's per-element x per-zone breakdown (#2508)
+ * is the first - writes the same bytes through the same type inference rather
+ * than growing a second Arrow-to-Parquet path beside it. `ParquetExporter`
+ * itself now calls this.
+ *
+ * Falls back to Arrow IPC when `parquet-wasm` cannot load, which is still a
+ * binary format most tools read, and says so on the console rather than
+ * failing the export.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * @param columns column name to values, all arrays the same length
+ * @param floatColumns names that must be Float64 even when every value in the
+ *   sample happens to be a whole number - content inference alone would demote
+ *   `3.0` to Int32, losing the schema and risking wrap beyond 2^31
+ */
+export async function columnsToParquet(
+    columns: Record<string, any[]>,
+    floatColumns?: Set<string>,
+): Promise<Uint8Array> {
+    try {
+        // Dynamic imports for better tree-shaking. The package's
+        // browser/node exports map keeps `Arrow.dom.mjs` opaque to
+        // TS5's strict resolver, so the import is typed `any` here
+        // and consumers fall back to runtime checks. See:
+        // https://github.com/apache/arrow/issues/35835
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const arrow: any = await import('apache-arrow');
+
+        // Build Arrow vectors from column data
+        const vectors: Record<string, any> = {};
+
+        for (const [name, data] of Object.entries(columns)) {
+            if (data.length === 0) {
+                // Empty column - create empty vector with null type
+                vectors[name] = arrow.vectorFromArray([]);
+                continue;
+            }
+
+            // Infer type from first non-null element
+            const sample = data.find((v) => v !== null && v !== undefined);
+
+            if (sample === undefined) {
+                // All nulls - create string vector with nulls
+                vectors[name] = arrow.vectorFromArray(data);
+            } else if (typeof sample === 'number') {
+                // Columns declared as REAL-typed by the caller (e.g. ValueReal,
+                // quantity Value) always use Float64 — content inference alone
+                // would demote whole-number reals like 3.0/1200.0 to Int32,
+                // losing the float schema and risking wrap for |x| > 2^31.
+                if (floatColumns?.has(name)) {
+                    vectors[name] = arrow.vectorFromArray(data, new arrow.Float64());
+                    continue;
+                }
+                // Otherwise check if it's integer or float by content.
+                const isFloat = data.some((v) => typeof v === 'number' && !Number.isInteger(v));
+                if (isFloat) {
+                    vectors[name] = arrow.vectorFromArray(data, new arrow.Float64());
+                } else {
+                    // Use Int32 for integers (covers express IDs and most counts)
+                    vectors[name] = arrow.vectorFromArray(data, new arrow.Int32());
+                }
+            } else if (typeof sample === 'boolean') {
+                vectors[name] = arrow.vectorFromArray(data, new arrow.Bool());
+            } else {
+                // String or other - convert to string
+                vectors[name] = arrow.vectorFromArray(data.map((v) => v === null ? null : String(v)));
+            }
+        }
+
+        // Build Arrow Table
+        const table = new arrow.Table(vectors);
+
+        // Convert to Arrow IPC format
+        const ipcBuffer = arrow.tableToIPC(table, 'stream');
+
+        // Try to use parquet-wasm for conversion
+        try {
+            const parquet: any = await import('parquet-wasm');
+
+            // The package resolves to its wasm-bindgen ESM build in a BROWSER,
+            // and that build does nothing until its default export is awaited:
+            // without this every call threw `Cannot read properties of
+            // undefined (reading '__wbindgen_malloc')` and fell through to the
+            // Arrow IPC branch below - silently, since the fallback only warns,
+            // so the download was named `.parquet` and was not Parquet. The
+            // Node build auto-initialises and exposes no default init, hence
+            // the guard rather than an unconditional call.
+            if (typeof parquet.default === 'function') await parquet.default();
+
+            // parquet-wasm 0.5+ API: read Arrow IPC and write Parquet
+            const arrowTable = parquet.Table.fromIPCStream(ipcBuffer);
+            const parquetBuffer = parquet.writeParquet(arrowTable);
+
+            return new Uint8Array(parquetBuffer);
+        } catch (parquetError) {
+            // Fallback: If parquet-wasm fails, return Arrow IPC format instead
+            // This is still a valid binary format that can be read by many tools
+            console.warn('[columnsToParquet] parquet-wasm conversion failed, returning Arrow IPC format:', parquetError);
+            return new Uint8Array(ipcBuffer);
+        }
+    } catch (error) {
+        // If all else fails, throw a descriptive error
+        throw new Error(`Failed to convert to Parquet format: ${error}. Ensure apache-arrow and parquet-wasm are installed.`);
+    }
+}
+
+/** Parquet's file magic, at both ends of the file. */
+const PARQUET_MAGIC = 'PAR1';
+
+/**
+ * Are these bytes actually Parquet, or the Arrow IPC fallback?
+ *
+ * For callers that put the format in a FILENAME. A `.parquet` file containing
+ * Arrow IPC opens in nothing the extension promises, and the reader is told the
+ * file is corrupt rather than that it is a different format.
+ */
+export function isParquet(bytes: Uint8Array): boolean {
+    if (bytes.byteLength < 8) return false;
+    const head = String.fromCharCode(...bytes.subarray(0, 4));
+    const tail = String.fromCharCode(...bytes.subarray(bytes.byteLength - 4));
+    return head === PARQUET_MAGIC && tail === PARQUET_MAGIC;
+}

--- a/packages/export/src/columns-to-parquet.ts
+++ b/packages/export/src/columns-to-parquet.ts
@@ -42,8 +42,12 @@ export async function columnsToParquet(
 
         for (const [name, data] of Object.entries(columns)) {
             if (data.length === 0) {
-                // Empty column - create empty vector with null type
-                vectors[name] = arrow.vectorFromArray([]);
+                // No rows at all: same reasoning as the all-null case
+                // below - an untyped empty column is Arrow's Null type,
+                // which the Parquet writer rejects.
+                vectors[name] = floatColumns?.has(name)
+                    ? arrow.vectorFromArray([], new arrow.Float64())
+                    : arrow.vectorFromArray([], new arrow.Utf8());
                 continue;
             }
 
@@ -51,8 +55,15 @@ export async function columnsToParquet(
             const sample = data.find((v) => v !== null && v !== undefined);
 
             if (sample === undefined) {
-                // All nulls - create string vector with nulls
-                vectors[name] = arrow.vectorFromArray(data);
+                // All nulls. A caller that DECLARED the column numeric gets
+                // Float64 anyway: inference alone would give it Arrow's Null
+                // type, which parquet-wasm cannot write, and the failure lands
+                // in the catch below - so the whole table silently degrades to
+                // Arrow IPC because one column happened to be empty. Reachable
+                // here whenever no element in a zone set could be measured.
+                vectors[name] = floatColumns?.has(name)
+                    ? arrow.vectorFromArray(data, new arrow.Float64())
+                    : arrow.vectorFromArray(data, new arrow.Utf8());
             } else if (typeof sample === 'number') {
                 // Columns declared as REAL-typed by the caller (e.g. ValueReal,
                 // quantity Value) always use Float64 — content inference alone

--- a/packages/export/src/index.ts
+++ b/packages/export/src/index.ts
@@ -37,3 +37,5 @@ export {
 export { generateLod0 } from './lod0-generator.js';
 export { generateLod1, type GenerateLod1Options } from './lod1-generator.js';
 export { parseGLB, extractGlbMapping, parseGLBToMeshData, countGlbMeshes } from './glb.js';
+
+export { columnsToParquet, isParquet } from './columns-to-parquet.js';

--- a/packages/export/src/parquet-exporter.ts
+++ b/packages/export/src/parquet-exporter.ts
@@ -11,6 +11,7 @@ import type { GeometryResult } from '@ifc-lite/geometry';
 import type { MutablePropertyView } from '@ifc-lite/mutations';
 import { IfcTypeEnum, EntityFlags, PropertyValueType, QuantityType, RelationshipType, IFC_ENTITY_NAMES } from '@ifc-lite/data';
 import { getEffectiveEntityIndex, type EffectiveEntityIndex } from './effective-index.js';
+import { columnsToParquet } from './columns-to-parquet.js';
 
 export interface ParquetExportOptions {
     includeGeometry?: boolean;
@@ -511,81 +512,7 @@ export class ParquetExporter {
     // ═══════════════════════════════════════════════════════════════
 
     private async toParquet(columns: Record<string, any[]>, floatColumns?: Set<string>): Promise<Uint8Array> {
-        try {
-            // Dynamic imports for better tree-shaking. The package's
-            // browser/node exports map keeps `Arrow.dom.mjs` opaque to
-            // TS5's strict resolver, so the import is typed `any` here
-            // and consumers fall back to runtime checks. See:
-            // https://github.com/apache/arrow/issues/35835
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const arrow: any = await import('apache-arrow');
-
-            // Build Arrow vectors from column data
-            const vectors: Record<string, any> = {};
-
-            for (const [name, data] of Object.entries(columns)) {
-                if (data.length === 0) {
-                    // Empty column - create empty vector with null type
-                    vectors[name] = arrow.vectorFromArray([]);
-                    continue;
-                }
-
-                // Infer type from first non-null element
-                const sample = data.find((v) => v !== null && v !== undefined);
-
-                if (sample === undefined) {
-                    // All nulls - create string vector with nulls
-                    vectors[name] = arrow.vectorFromArray(data);
-                } else if (typeof sample === 'number') {
-                    // Columns declared as REAL-typed by the caller (e.g. ValueReal,
-                    // quantity Value) always use Float64 — content inference alone
-                    // would demote whole-number reals like 3.0/1200.0 to Int32,
-                    // losing the float schema and risking wrap for |x| > 2^31.
-                    if (floatColumns?.has(name)) {
-                        vectors[name] = arrow.vectorFromArray(data, new arrow.Float64());
-                        continue;
-                    }
-                    // Otherwise check if it's integer or float by content.
-                    const isFloat = data.some((v) => typeof v === 'number' && !Number.isInteger(v));
-                    if (isFloat) {
-                        vectors[name] = arrow.vectorFromArray(data, new arrow.Float64());
-                    } else {
-                        // Use Int32 for integers (covers express IDs and most counts)
-                        vectors[name] = arrow.vectorFromArray(data, new arrow.Int32());
-                    }
-                } else if (typeof sample === 'boolean') {
-                    vectors[name] = arrow.vectorFromArray(data, new arrow.Bool());
-                } else {
-                    // String or other - convert to string
-                    vectors[name] = arrow.vectorFromArray(data.map((v) => v === null ? null : String(v)));
-                }
-            }
-
-            // Build Arrow Table
-            const table = new arrow.Table(vectors);
-
-            // Convert to Arrow IPC format
-            const ipcBuffer = arrow.tableToIPC(table, 'stream');
-
-            // Try to use parquet-wasm for conversion
-            try {
-                const parquet = await import('parquet-wasm');
-
-                // parquet-wasm 0.5+ API: read Arrow IPC and write Parquet
-                const arrowTable = parquet.Table.fromIPCStream(ipcBuffer);
-                const parquetBuffer = parquet.writeParquet(arrowTable);
-
-                return new Uint8Array(parquetBuffer);
-            } catch (parquetError) {
-                // Fallback: If parquet-wasm fails, return Arrow IPC format instead
-                // This is still a valid binary format that can be read by many tools
-                console.warn('[ParquetExporter] parquet-wasm conversion failed, returning Arrow IPC format:', parquetError);
-                return new Uint8Array(ipcBuffer);
-            }
-        } catch (error) {
-            // If all else fails, throw a descriptive error
-            throw new Error(`Failed to convert to Parquet format: ${error}. Ensure apache-arrow and parquet-wasm are installed.`);
-        }
+        return columnsToParquet(columns, floatColumns);
     }
 
     private async createZipArchive(files: Map<string, Uint8Array>): Promise<Uint8Array> {

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -1440,6 +1440,7 @@
     "applySimplifiedGeometry: function",
     "collectReferencedEntityIds: function",
     "collectStyleEntities: function",
+    "columnsToParquet: function",
     "convertEntityType: function",
     "convertStepLine: function",
     "countGlbMeshes: function",
@@ -1449,6 +1450,7 @@
     "generateLod0: function",
     "generateLod1: function",
     "getVisibleEntityIds: function",
+    "isParquet: function",
     "needsConversion: function",
     "parseGLB: function",
     "parseGLBToMeshData: function"


### PR DESCRIPTION
The last unbuilt item of #2508, plus a UI bug found on the way.

## The table

The direct answer to the complaint that opened #1763:

> you can't get clean quantities per zone without a lot of manual work in Excel or similar

so the deliverable is a file that opens in Excel and pivots, not a panel.

**One row per (element, zone)**, not one column per zone. A wide table's columns change whenever a zone is added, renamed or deleted, so every saved pivot, formula and Power Query step against it breaks; and a straddler, the population this feature exists for, is exactly the row that would need several columns filled. Long pivots to wide in one step; the reverse is a manual unpivot.

Columns: `GlobalId, ExpressId, Model, IfcType, Name, ZoneSet, Zone, HomeZone, Straddles, VolumeM3, Fraction, ElementVolumeM3, Basis, Quantity, Unavailable`.

An element that reaches no zone of the set is absent. An element whose volume could not be established **is present**, with an empty number and the reason stated, because "this wall is in Takt B and we could not measure it" is a different fact from "this wall is not in Takt B" - and a total that silently omits the first is exactly what #2508's verification bar exists to stop.

## One producer of the number

`gatherZoneFacts` is extracted from `useZoneWriteBack` rather than reimplemented, so the spreadsheet and the property sets cannot disagree except by being exported at different times. A test asserts the table's SI cubic metres against what the write-back wrote into a **cubic-millimetre** model: they agree to the last digit, at exactly the declared unit scale. The 23 existing write-back tests pass unchanged through the refactor.

## The Parquet defect this surfaced

`columnsToParquet` is extracted from `ParquetExporter` rather than written a second time, and extracting it exposed a live bug: in a **browser** the package resolves to its wasm-bindgen ESM build, which does nothing until its default export is awaited. Every call threw inside `Table.fromIPCStream` and fell through to the Arrow IPC fallback - silently, since that path only `console.warn`s. A file named `.parquet` contained Arrow IPC.

It is initialised now, and `isParquet` lets a caller name the file after what it actually got. Changeset included for `@ifc-lite/export`.

## Verified in a real browser

AC20-FZK-Haus with four takt zones, both formats downloaded from the panel:

- **CSV**: 115 rows for 83 elements, 15 columns, **0 rows whose field count differs from the header**, `sum(VolumeM3) = 135.6175 m3`, 27 blanks each carrying a stated reason. A name containing a comma (`Wall, A` in the unit fixture; real ones like `Basic Wall:SW 200,0`) is quoted, so the row still parses.
- **Parquet**: `PAR1` at both ends, 10,233 bytes. Read back through an **independent** reader (`parquet-wasm` + `apache-arrow` in Node): same 115 rows, same `135.6175`, same 27 nulls, `VolumeM3:Float64`, `Straddles:Bool`, strings dictionary-encoded.

Before the init fix the same download was 15,824 bytes of Arrow IPC with a `.parquet` name.

## The UI bug (first commit)

The dark pill behind a zone's label in the viewport took its width from `zone.name.length`, while the label renders `"{set name} / {zone name}"`. Every pill was short by the set name plus the separator, and the text ran off its own background - worst where the zone name is short and the set name is not.

The per-character constant was the same mistake twice: it cannot size a proportional font either. The width is measured with `getBBox` now; the estimate survives only as the first-paint fallback and counts the whole string.

Measured in a real browser: 6px of padding either side at 162px and at 334px of label. Under the old formula the first of those was an **18px pill behind 162px of text**, because its zone name was one character.

## Gates

`pnpm test` (86 tasks), `pnpm typecheck` (1067 files), api-surface, test-wiring, source-text-assertions and doc samples all pass locally. Every new test was checked by reverting its fix: the label tests fail when the width goes back to counting one half of the string, and the panel's CSV click test fails with `onClick={() => {}}`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added CSV and Parquet export for zone breakdown tables.
  - Exports include element, zone, quantity, volume, and measurement details.
  - Added clear reporting for empty tables, unmeasured elements, row counts, and export failures.
  - Improved label sizing so zone labels adapt to their displayed text.
  - Added reusable data conversion for Parquet output.

- **Bug Fixes**
  - Prevented duplicate downloads from rapid repeated clicks.
  - Preserved distinct zones that share the same name.
  - Improved reliability of browser-based Parquet downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->