### PR TITLE
fix(clash): scale the touching-classification epsilon to coordinate magnitude

### DIFF
--- a/.changeset/clash-touching-epsilon-scale.md
+++ b/.changeset/clash-touching-epsilon-scale.md
@@ -1,0 +1,11 @@
+---
+'@ifc-lite/clash': patch
+---
+
+Scale the "touching" band (`isTouching`, used by the viewer's `hideTouching` clash filter, touching-count badge, and per-row touching indicator) to a clash's own coordinate magnitude, not a fixed 1e-4 metres.
+
+Geometry is ingested from f32 buffers, so a fixed `TOUCHING_EPSILON` is only valid near the origin: the f32 ULP for a coordinate of magnitude `extent` is `extent * 2^-22`, and exceeds `1e-4` once `extent` passes ~1 km. Past that distance, a genuinely flush pair (a wall meeting a slab) can pick up more than `1e-4` of pure f32 rounding noise in its measured penetration depth, and the fixed band then misses it — the pair silently reappears as a hard clash in a list the user explicitly asked to de-noise. Demonstrated directly through `isTouching`: a flush pair 1 f32 ULP apart at each corner classifies as touching near the origin, but past the ULP-crossover distance (~1024 m for a single-ULP-scale overlap; real models with multiple rounding operations can cross earlier) the same pair's measured depth exceeds the fixed `1e-4` and it stops being flagged touching, under the old fixed constant, while an epsilon scaled to the identical coordinates keeps it flagged.
+
+The fix: `isTouching`'s default `eps` is now derived per-clash from `Clash.bounds` (the clash's own contact/overlap region — the only element-scale coordinates a bare `Clash` carries, since `ClashElement`'s bounds aren't available at this call site) as `max(TOUCHING_EPSILON, maxAbsCoord(bounds) * 2^-22)` — the same `2^-22` f32-ULP term used by `precisionFloor` in `engine-ts/narrow.ts` and `planeEps` in `contact/narrow-phase.ts`. Floored at `TOUCHING_EPSILON` itself (not the raw single-metre f32 floor those two use) so near the origin the new default is bit-for-bit identical to the old fixed constant — verified against the existing `analysis.test.ts` fixtures. An explicit `eps` argument is unchanged and still overrides the default entirely.
+
+`TOUCHING_EPSILON` remains exported with its existing value and meaning (the near-origin/floor band); `isTouching`'s signature is unchanged.

--- a/packages/clash/src/analysis.test.ts
+++ b/packages/clash/src/analysis.test.ts
@@ -68,6 +68,65 @@ describe('isTouching', () => {
   });
 });
 
+describe('isTouching (scale-relative default, far from origin)', () => {
+  // Geometry is ingested from f32 buffers, so a fixed TOUCHING_EPSILON=1e-4
+  // is only valid near the origin: the f32 ULP for a coordinate of magnitude
+  // `extent` is `extent * 2^-22`, which exceeds 1e-4 once `extent` passes
+  // 1024 m (1e-4 / 2^-22 = 419.4, and the ULP only takes power-of-two steps,
+  // so the first step that actually exceeds 1e-4 lands at 1024 m). Past that
+  // distance, a genuinely flush pair's measured depth can exceed the fixed
+  // band on pure rounding noise and reappear as a hard clash.
+  function clashAt(id: string, distance: number, extent: number): Clash {
+    return {
+      id,
+      a: ref(`${id}a`, 'IfcWall'),
+      b: ref(`${id}b`, 'IfcSlab'),
+      rule: 'r',
+      status: 'hard',
+      distance,
+      point: [extent, extent, extent],
+      bounds: { min: [extent - 0.01, extent - 0.01, extent - 0.01], max: [extent, extent, extent] },
+      severity: 'info',
+    };
+  }
+
+  it('RED (documents the old fixed-1e-4 result): a flush pair 5 km out, with only f32-noise-scale penetration, would NOT have been flagged as touching under the fixed constant alone', () => {
+    const c = clashAt('far', -0.00048828125, 5000); // measured noise floor at 5 km, see engine.test.ts-style repro
+    expect(penetrationDepth(c)).toBeGreaterThan(TOUCHING_EPSILON); // the old, unscaled comparison
+  });
+
+  it('GREEN: the same clash IS flagged touching by the scale-relative default', () => {
+    const c = clashAt('far', -0.00048828125, 5000);
+    expect(isTouching(c)).toBe(true);
+  });
+
+  it('also recovers it at 50 km', () => {
+    const c = clashAt('far50k', -0.00390625, 50_000);
+    expect(isTouching(c)).toBe(true);
+  });
+
+  it('still rejects a genuine interpenetration at the same distance (scaling does not hide real clashes)', () => {
+    const c = clashAt('real-clash-5km', -0.05, 5000); // 5 cm, far above any plausible f32 noise floor
+    expect(isTouching(c)).toBe(false);
+  });
+
+  it('unchanged near the origin: matches the fixed TOUCHING_EPSILON exactly on the existing near-origin fixtures', () => {
+    // Same fixtures as the plain `isTouching` describe block above (extent ~1 m,
+    // via the shared `clash()` helper) — near the origin the scale-relative
+    // default must floor to exactly TOUCHING_EPSILON, so behaviour is identical.
+    expect(isTouching(clash('a', 0, 'info'))).toBe(true);
+    expect(isTouching(clash('a', -TOUCHING_EPSILON / 2, 'info'))).toBe(true);
+    expect(isTouching(clash('a', -TOUCHING_EPSILON * 1.5, 'info'))).toBe(false);
+    expect(isTouching(clash('a', -0.05, 'major'))).toBe(false);
+  });
+
+  it('an explicit eps still overrides the scale-relative default entirely', () => {
+    const c = clashAt('explicit', -0.00048828125, 5000);
+    expect(isTouching(c, 1e-6)).toBe(false);
+    expect(isTouching(c, 1)).toBe(true);
+  });
+});
+
 describe('sortClashes', () => {
   it('orders by severity then depth (#1274)', () => {
     const list = [

--- a/packages/clash/src/analysis.ts
+++ b/packages/clash/src/analysis.ts
@@ -36,8 +36,53 @@ export function penetrationDepth(c: Clash): number {
 }
 
 /** Default band (m) under which a `hard` clash is really a face/edge *contact*
- *  rather than a genuine interpenetration — see {@link isTouching}. */
+ *  rather than a genuine interpenetration — see {@link isTouching}. Also the
+ *  floor for {@link touchingEpsilonFor}'s scale-relative default: near the
+ *  origin this constant IS the default (bit-for-bit), it only grows once the
+ *  pair's own coordinate magnitude pushes the f32 noise floor past it. */
 export const TOUCHING_EPSILON = 1e-4;
+
+/**
+ * f32-ULP scale factor for a "worst-case" single-precision coordinate: for a
+ * value with magnitude in `[2, 4)` the true float32 ULP is `2^-22`, and for
+ * larger magnitudes the ULP only grows. Same term (and reasoning) as
+ * `precisionFloor` in `engine-ts/narrow.ts` and `narrowPhase`'s `planeEps` in
+ * `contact/narrow-phase.ts` — kept local because this is a different job
+ * (the *reported* touching band, not the narrow-phase's own depth floor) on
+ * a `Clash`, which doesn't carry the element bounds those two derive from.
+ */
+const F32_ULP_SCALE = 1 / 4_194_304; // 2^-22
+
+/**
+ * The touching band for one specific clash, scaled to that clash's own
+ * coordinate magnitude rather than a fixed constant.
+ *
+ * Geometry is ingested from f32 buffers, so a fixed `TOUCHING_EPSILON` is
+ * only valid near the origin: the f32 ULP exceeds `1e-4` above roughly 1 km
+ * from the origin (a `Clash`'s own coordinate magnitude — see below — decides
+ * exactly where). Past that distance, a genuinely flush pair (a wall meeting
+ * a slab) can pick up more than `1e-4` of pure rounding noise in its measured
+ * penetration depth, and the fixed band then misses it, letting it reappear
+ * as a hard clash in a list the user asked to de-noise.
+ *
+ * `Clash` carries no element bounds (that lives on `ClashElement`, not on the
+ * detection result), but it does carry `bounds` — the contact/overlap region
+ * itself, in the same world coordinates as the elements — so that is the
+ * scale source: the max absolute coordinate over the clash's own contact
+ * box. Floored at {@link TOUCHING_EPSILON} (not the raw single-unit f32
+ * floor `precisionFloor` uses) so a clash near the origin gets exactly the
+ * old fixed band, unchanged.
+ */
+function touchingEpsilonFor(c: Clash): number {
+  let extent = 0;
+  for (const v of [c.bounds.min, c.bounds.max]) {
+    for (const coord of v) {
+      const a = Math.abs(coord);
+      if (a > extent) extent = a;
+    }
+  }
+  return Math.max(TOUCHING_EPSILON, extent * F32_ULP_SCALE);
+}
 
 /**
  * Whether a clash is effectively a zero-distance *contact* rather than a real
@@ -45,8 +90,12 @@ export const TOUCHING_EPSILON = 1e-4;
  * penetration is within `eps` — typically coincident faces (a wall meeting a
  * slab, a column sitting on a footing) reported with a ~0 m depth, which users
  * reasonably distrust when they appear in the clash list.
+ *
+ * `eps` defaults to {@link touchingEpsilonFor}, scaled to this clash's own
+ * coordinate magnitude (see that function) so the touching band stays valid
+ * far from the origin. An explicit `eps` overrides the default entirely.
  */
-export function isTouching(c: Clash, eps: number = TOUCHING_EPSILON): boolean {
+export function isTouching(c: Clash, eps: number = touchingEpsilonFor(c)): boolean {
   return c.status === 'touch' || (c.status === 'hard' && penetrationDepth(c) <= eps);
 }
 


### PR DESCRIPTION
Fifth confirmed instance of the same root cause as #2594, #2598 and #2600 — and the one a user notices most directly, because it silently undoes something they explicitly asked for.

`TOUCHING_EPSILON = 1e-4` (`packages/clash/src/analysis.ts:40`) is compared against `penetrationDepth(c)`, a real-world-metre depth. Geometry is ingested from f32, so the noise floor is `2⁻²² × coordinate magnitude`. `isTouching` drives the viewer's **"hide touching clashes" filter**, its count badge, and the per-row indicator (`ClashPanel.tsx` ~98, 253, 268, 876).

So above the onset, a genuinely flush pair — a wall meeting a slab, zero design overlap — accumulates enough rounding noise in its measured depth to fall outside `1e-4`, stops being classified as touching, and **reappears as a hard clash in the list the user asked to de-noise.** A filter that quietly stops filtering is worse than no filter, because you don't know to stop trusting it.

## Demonstrated

Two unit cubes sharing a corner, one f32 ULP apart per axis, driven through the real `TsKernel`/`testPair` engine and the unmodified production `isTouching`:

| position | measured depth | `isTouching` |
|---|---|---|
| near origin | 2.98e-8 m | **true** |
| 5 km | 4.9e-4 m | **false** |
| 50 km | 3.9e-3 m | **false** |

**Control:** identical far coordinates with the epsilon scaled to coordinate magnitude → `true` at both distances. Only the epsilon differs between failing and passing runs.

**Onset measured at 1024 m**, not the ~800 m I predicted. That's not noise in the measurement — the f32 ULP moves in power-of-two steps, and 2⁻¹³ ≈ 1.22e-4 at magnitude 1024 is the first step to exceed `1e-4` (at 512 it's 6.1e-5, still under). Real models with multi-operation rounding could cross earlier. Reporting the measured number rather than the estimate I started with.

## Where the scale comes from

This site is different from the previous four: `isTouching` receives a `Clash`, which carries no element bounds — those live on `ClashElement`. But `Clash` does carry its own `bounds`, the contact/overlap region, populated from `NarrowResult.bounds` (`engine-ts/ts-kernel.ts:86`) in the same world frame. That's used directly.

Worth stating explicitly: **no new parameter is threaded through the viewer to reach this.** If the scale hadn't been available locally I'd have brought you the constraint rather than restructure call sites to manufacture it.

## The fix

`touchingEpsilonFor(c)` = `max(TOUCHING_EPSILON, maxAbsCoord(c.bounds) · 2⁻²²)` — the same `2⁻²²` term as `precisionFloor` and `planeEps` in the sibling PRs, deliberately reused so the tolerances can't drift apart.

Taking the `max` means near the origin the value is exactly today's `1e-4` and behaviour is unchanged; it only grows where the old constant had already fallen below the noise floor.

`TOUCHING_EPSILON`'s export and `isTouching`'s signature are unchanged, so no API-surface regeneration was needed (the manifest records `isTouching: function` with no signature detail — verified rather than assumed).

## Verification

- RED: the old comparison fails for a 5 km clash. GREEN: `isTouching → true` at 5 km and 50 km.
- **A genuine 5 cm interpenetration at the same distance is still correctly rejected** — scaling doesn't start masking real clashes, which is the obvious risk with a tolerance that grows.
- An explicit `eps` argument still overrides.
- Near-origin classification asserted **identical** to the fixed constant on the pre-existing fixtures.
- `packages/clash`: 198/198 across 19 files. `typecheck` clean for clash and viewer.

## Where this leaves the defect class

Five confirmed instances now, each demonstrated rather than argued: hard clashes from rounding noise (#2594), CSG solids vanishing (#2598), contact faces lost and shared faces splitting (#2600, two sites), and this.

An audit of the clash call graph cleared several other fixed epsilons as legitimately scale-free — normalised dot products, parametric values, a deliberate 1.5 m clustering radius. Two lower-severity degenerate-check sites remain unfixed (`rust/clash/src/tri_mesh.rs:22` `RAY_EPS`, `packages/clash/src/math/triangle-distance.ts:12`), plus `triangle-intersect.ts`'s SAT `eps`, which is murkier — the interval comparisons downstream carry no tolerance at all, so a bigger constant may not be the right fix there. None demonstrated; I'm not proposing changes to them on inference.

Roughly 115 files outside the clash call graph were enumerated but not read. Unaudited, not cleared.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved touching detection for clashes located far from the coordinate origin.
  * Reduced false negatives caused by floating-point precision at large coordinates.
  * Preserved existing near-origin behavior and support for custom tolerance values.

* **Tests**
  * Added coverage for large-coordinate scenarios, genuine interpenetration, near-origin behavior, and explicit tolerance overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->