### PR TITLE
refactor(geometry): one divide behind mesh_volume

### DIFF
--- a/rust/geometry/src/kernel/mesh_volume.rs
+++ b/rust/geometry/src/kernel/mesh_volume.rs
@@ -5,7 +5,7 @@
 //! Public, documented home for reading a [`Mesh`]'s volume.
 
 use super::mesh_bridge::mesh_to_tris;
-use super::signed_volume::signed_volume6;
+use super::signed_volume::signed_volume_of;
 use crate::mesh::Mesh;
 
 /// Signed volume of a `Mesh`, via the divergence theorem.
@@ -33,9 +33,16 @@ use crate::mesh::Mesh;
 /// zone piece's volume) must establish closedness first, same requirement
 /// [`signed_volume6`] itself carries.
 ///
-/// Delegates to [`signed_volume6`] rather than re-deriving the sum: that is
-/// the crate's ONE divergence-theorem implementation, and it deliberately sums
-/// about the OPERAND'S OWN AABB CENTRE rather than the world origin. That
+/// Delegates to [`signed_volume_of`] - itself one line over [`signed_volume6`],
+/// which returns SIX times the volume - rather than dividing here as well.
+/// #2579 landed that helper an hour before this file did, with a doc that says
+/// exactly why the divide belongs in one place: "a caller that wants the VOLUME
+/// divides once, here, rather than growing a second hand-rolled sum in another
+/// module, which is how two producers of the same number start to disagree."
+///
+/// The reference point is what makes the shared implementation matter:
+/// [`signed_volume6`] deliberately sums about the OPERAND'S OWN AABB CENTRE
+/// rather than the world origin. That
 /// choice is not cosmetic — see `signed_volume::signed_volume6`'s doc for the
 /// #198779 incident where a world-origin reference turned a crack sliver on a
 /// far-from-origin operand into a wildly wrong, sign-flipping volume. A split
@@ -69,7 +76,7 @@ use crate::mesh::Mesh;
 /// world-origin arithmetic for test-only use. Reusing [`signed_volume6`]
 /// avoids adding another divergence-theorem implementation to reconcile.
 pub fn mesh_volume(mesh: &Mesh) -> f64 {
-    signed_volume6(&mesh_to_tris(mesh)) / 6.0
+    signed_volume_of(&mesh_to_tris(mesh))
 }
 
 #[cfg(test)]

--- a/rust/geometry/src/kernel/mesh_volume.rs
+++ b/rust/geometry/src/kernel/mesh_volume.rs
@@ -21,7 +21,7 @@ use crate::mesh::Mesh;
 /// vertex's rounding independently, so the sum drifts by roughly
 /// `surface_area * SNAP_GRID` (plus, at far-from-origin offsets, the
 /// coarser f32-ulp term the `Mesh` positions already carried on the way in).
-/// Because it delegates to [`signed_volume6`], which sums about the
+/// Because it delegates to `signed_volume6`, which sums about the
 /// operand's own AABB centre rather than a fixed point, that drift is the
 /// ONLY thing that moves the reading — a world-origin implementation would
 /// additionally vary with the reference point itself, wrong by orders of
@@ -31,9 +31,9 @@ use crate::mesh::Mesh;
 /// hard against that class of regression). It is still not the mesh's actual
 /// volume. Callers that need a trustworthy reading (e.g. reporting a split
 /// zone piece's volume) must establish closedness first, same requirement
-/// [`signed_volume6`] itself carries.
+/// `signed_volume6` itself carries.
 ///
-/// Delegates to [`signed_volume_of`] - itself one line over [`signed_volume6`],
+/// Delegates to `signed_volume_of` - itself one line over `signed_volume6`,
 /// which returns SIX times the volume - rather than dividing here as well.
 /// #2579 landed that helper an hour before this file did, with a doc that says
 /// exactly why the divide belongs in one place: "a caller that wants the VOLUME
@@ -41,7 +41,7 @@ use crate::mesh::Mesh;
 /// module, which is how two producers of the same number start to disagree."
 ///
 /// The reference point is what makes the shared implementation matter:
-/// [`signed_volume6`] deliberately sums about the OPERAND'S OWN AABB CENTRE
+/// `signed_volume6` deliberately sums about the OPERAND'S OWN AABB CENTRE
 /// rather than the world origin. That
 /// choice is not cosmetic — see `signed_volume::signed_volume6`'s doc for the
 /// #198779 incident where a world-origin reference turned a crack sliver on a
@@ -73,7 +73,7 @@ use crate::mesh::Mesh;
 /// sums about the world origin (fine for its own callers, which only ever see
 /// frame-local meshes near the origin — not true of an arbitrary zone piece),
 /// and `kernel::mesh_bridge`'s `#[cfg(test)]`-only helper duplicates that same
-/// world-origin arithmetic for test-only use. Reusing [`signed_volume6`]
+/// world-origin arithmetic for test-only use. Reusing `signed_volume6`
 /// avoids adding another divergence-theorem implementation to reconcile.
 pub fn mesh_volume(mesh: &Mesh) -> f64 {
     signed_volume_of(&mesh_to_tris(mesh))


### PR DESCRIPTION
Follow-up to #2260, taking over the one point of my review that was not applied before it landed.

#2260 and #2579 went in an hour apart and each added the same line:

```rust
// kernel/signed_volume.rs, from #2579
pub(crate) fn signed_volume_of(tris: &[Tri]) -> f64 { signed_volume6(tris) / 6.0 }

// kernel/mesh_volume.rs, from #2260
pub fn mesh_volume(mesh: &Mesh) -> f64 { signed_volume6(&mesh_to_tris(mesh)) / 6.0 }
```

`signed_volume_of`'s doc states the rule the second one breaks, verbatim:

> a caller that wants the VOLUME divides once, here, rather than growing a second hand-rolled sum in another module, which is how two producers of the same number start to disagree.

So `mesh_volume` delegates to it. One line of arithmetic changed.

**What deliberately did NOT change.** `mesh_volume` keeps its own file and all of its documentation. BIMvoice's analysis there was right and is worth having where a caller looking for a mesh's volume will find it: why the AABB-centred reference rather than the world origin (the #198779 sign-flip), which two other volume readings already in the crate are wrong for this job and why, and the quantization noise floor that makes the reading translation-STABLE rather than translation-invariant. None of that is duplicated anywhere else.

`cargo test -p ifc-lite-geometry --lib`: 630 passed, 1 ignored. Clippy clean on the crate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mesh volume calculations by using a shared volume computation approach.
  * Updated volume documentation to clarify scaling and reference behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->