### PR TITLE
fix(renderer): X-Ray leaves instanced geometry solid

### DIFF
--- a/.changeset/instanced-ghosting.md
+++ b/.changeset/instanced-ghosting.md
@@ -1,0 +1,11 @@
+---
+"@ifc-lite/renderer": patch
+---
+
+X-Ray now fades GPU-instanced geometry too, instead of leaving it solid.
+
+The instanced pass received only the hide and isolate sets, so ghosting stopped at the flat geometry. On a model whose facade is instanced — repeated panels, mullions, windows — asking to X-ray the building produced a solid facade standing in front of a ghosted interior. The Cesium world view had already started fading them correctly (#2591), and that disagreement is what surfaced the gap.
+
+`Scene.setInstancedGhosting` fades every occurrence outside the except-set to the same `DEFAULT_GHOST_ALPHA` the flat path uses, leaves the selection solid exactly as the flat path does, and reports the result through `hasTransparentInstances()` so the translucent sub-pass actually runs.
+
+It composes with lens and IDS colour overrides rather than fighting them: the two share the instance colour bytes, so a ghosted occurrence keeps its override's RGB and takes the ghost alpha, and clearing X-Ray restores the override rather than the original colour. Diffed against the previous ghost set, so the per-frame call is a no-op when nothing changed.

--- a/.changeset/instanced-ghosting.md
+++ b/.changeset/instanced-ghosting.md
@@ -8,4 +8,6 @@ The instanced pass received only the hide and isolate sets, so ghosting stopped 
 
 `Scene.setInstancedGhosting` fades every occurrence outside the except-set to the same `DEFAULT_GHOST_ALPHA` the flat path uses, leaves the selection solid exactly as the flat path does, and reports the result through `hasTransparentInstances()` so the translucent sub-pass actually runs.
 
-It composes with lens and IDS colour overrides rather than fighting them: the two share the instance colour bytes, so a ghosted occurrence keeps its override's RGB and takes the ghost alpha, and clearing X-Ray restores the override rather than the original colour. Diffed against the previous ghost set, so the per-frame call is a no-op when nothing changed.
+It composes with lens and IDS colour overrides rather than fighting them: the two share the instance colour bytes, so a ghosted occurrence keeps its override's RGB and takes the ghost alpha, and clearing X-Ray restores the override rather than the original colour.
+
+The per-frame call is a no-op when nothing changed, but "nothing changed" cannot be judged by the ghost set alone — dropping an override writes full alpha, a streaming shard adds occurrences at their uploaded colour, and neither moves the set. Any of those marks the fade dirty so the next frame re-applies it.

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -1858,6 +1858,11 @@ export class Renderer {
         // building a Map over every element just to fade "the rest".
         const ghostExceptIds = options.ghostExceptIds ?? null;
         const ghostAlpha = options.ghostAlpha ?? DEFAULT_GHOST_ALPHA;
+        // X-Ray reaches the instanced pass too (#2606). Without this, ghosting
+        // stopped at the flat geometry: on a model whose facade is instanced,
+        // the user asked to fade the building and got a solid facade standing
+        // in front of a ghosted interior.
+        this.scene.setInstancedGhosting(ghostExceptIds, selectedExpressIds, ghostAlpha);
         const hasGhost = ghostExceptIds != null;
         const hasTxOverrides = hasTxMap || hasGhost;
         const alphaForMesh = (expressId: number, fallback: number): number => {

--- a/packages/renderer/src/instanced-ghost-plan.test.ts
+++ b/packages/renderer/src/instanced-ghost-plan.test.ts
@@ -1,0 +1,79 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The ghosting decision, tested as a decision (#2606 review).
+ *
+ * `scene-instanced-ghosting.test.ts` asserts the same behaviour through the
+ * bytes actually written to the instance colour lane, which is the proof that
+ * matters. These are here because the fast path and the forced re-apply are
+ * cheaper to pin down directly than to infer from a write log, and because the
+ * planner is the part that can be reasoned about without a device at all.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { planInstancedGhosting, type InstancedGhostInputs } from './instanced-ghost-plan.js';
+
+function plan(over: Partial<InstancedGhostInputs> = {}) {
+  return planInstancedGhosting({
+    ghostExceptIds: new Set([1]),
+    selectedIds: null,
+    instancedIds: [1, 2, 3],
+    current: new Set<number>(),
+    ghostAlpha: 0.12,
+    lastGhostAlpha: 0.12,
+    dirty: false,
+    ...over,
+  });
+}
+
+describe('planInstancedGhosting', () => {
+  it('ghosts everything outside the except-set', () => {
+    const p = plan();
+    assert.deepEqual([...p.next].sort(), [2, 3]);
+    assert.deepEqual(p.toFade.sort(), [2, 3]);
+    assert.deepEqual(p.toRestore, []);
+  });
+
+  it('treats null as no X-Ray and an empty set as ghost-everything', () => {
+    assert.deepEqual([...plan({ ghostExceptIds: null }).next], []);
+    assert.deepEqual([...plan({ ghostExceptIds: new Set() }).next].sort(), [1, 2, 3]);
+  });
+
+  it('exempts the selection', () => {
+    assert.deepEqual([...plan({ selectedIds: new Set([2]) }).next], [3]);
+  });
+
+  it('reports no change when membership is stable', () => {
+    const p = plan({ current: new Set([2, 3]) });
+    assert.equal(p.changed, false);
+    assert.deepEqual(p.toFade, []);
+    assert.deepEqual(p.toRestore, []);
+  });
+
+  it('re-fades everything still ghosted when the bytes went dirty', () => {
+    // Not just the delta: an override drop or a new shard may have overwritten
+    // occurrences the membership diff considers untouched.
+    const p = plan({ current: new Set([2, 3]), dirty: true });
+    assert.equal(p.changed, true);
+    assert.deepEqual(p.toFade.sort(), [2, 3]);
+  });
+
+  it('re-fades everything still ghosted when the alpha changes', () => {
+    const p = plan({ current: new Set([2, 3]), ghostAlpha: 0.5 });
+    assert.deepEqual(p.toFade.sort(), [2, 3]);
+  });
+
+  it('does not treat an alpha change as work when nothing is ghosted', () => {
+    const p = plan({ ghostExceptIds: null, ghostAlpha: 0.5 });
+    assert.equal(p.changed, false);
+  });
+
+  it('restores ids that left the ghost set', () => {
+    const p = plan({ ghostExceptIds: new Set([1, 2]), current: new Set([2, 3]) });
+    assert.deepEqual(p.toRestore, [2]);
+    assert.deepEqual(p.toFade, [], 'id 3 is already faded and nothing forced a rewrite');
+  });
+});

--- a/packages/renderer/src/instanced-ghost-plan.test.ts
+++ b/packages/renderer/src/instanced-ghost-plan.test.ts
@@ -71,6 +71,18 @@ describe('planInstancedGhosting', () => {
     assert.equal(p.changed, false);
   });
 
+  it('still reports a change when a dirty pass has nothing to write', () => {
+    // Nothing is ghosted and nothing was, but the bytes went dirty. Both lists
+    // come back empty, and `changed` must still be true: the caller clears the
+    // dirty flag on the strength of it, and a `changed` derived from the list
+    // lengths would leave the flag set forever, forcing a full rewrite on
+    // every subsequent frame.
+    const p = plan({ ghostExceptIds: null, dirty: true });
+    assert.equal(p.changed, true);
+    assert.deepEqual(p.toFade, []);
+    assert.deepEqual(p.toRestore, []);
+  });
+
   it('restores ids that left the ghost set', () => {
     const p = plan({ ghostExceptIds: new Set([1, 2]), current: new Set([2, 3]) });
     assert.deepEqual(p.toRestore, [2]);

--- a/packages/renderer/src/instanced-ghost-plan.ts
+++ b/packages/renderer/src/instanced-ghost-plan.ts
@@ -1,0 +1,85 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Deciding which instanced occurrences should be faded, separately from doing
+ * it.
+ *
+ * The write side has to live in `Scene` — it owns the instance buffers — but
+ * the decision does not, and the decision is where the bugs were: a membership
+ * diff that could not see an override being dropped, a shard streaming in, or
+ * the alpha changing (#2606 review). Pulled out here so it can be tested as a
+ * function rather than through a GPU-shaped mock, and so `scene.ts` grows by a
+ * call rather than by another stateful subsystem.
+ */
+
+export interface InstancedGhostInputs {
+  /** Everything NOT in this set fades. `null`/`undefined` means no X-Ray. */
+  ghostExceptIds: ReadonlySet<number> | null | undefined;
+  /** Exempt from fading, matching the flat path. */
+  selectedIds: ReadonlySet<number> | null | undefined;
+  /** Every instanced express id currently in the scene. */
+  instancedIds: Iterable<number>;
+  /** The ids faded right now. */
+  current: ReadonlySet<number>;
+  /** Requested alpha, and the alpha the current fade was written with. */
+  ghostAlpha: number;
+  lastGhostAlpha: number;
+  /**
+   * Something other than the ghost set changed the instance colour bytes — a
+   * shard landing, an override applied or dropped. The membership diff cannot
+   * see those, so they force a full re-apply.
+   */
+  dirty: boolean;
+}
+
+export interface InstancedGhostPlan {
+  /** The ids that should be faded after this pass. */
+  next: Set<number>;
+  /** Ids to write the fade onto. */
+  toFade: number[];
+  /** Ids to put back — to their override if one is active, else their own colour. */
+  toRestore: number[];
+  /** False when there is provably nothing to do, so the caller can return early. */
+  changed: boolean;
+}
+
+/**
+ * Note the asymmetry in `toFade`: an unchanged membership with `dirty` or a new
+ * alpha re-fades EVERYTHING still ghosted, not just newly ghosted ids, because
+ * the bytes underneath may have been overwritten since they were last set.
+ */
+export function planInstancedGhosting(input: InstancedGhostInputs): InstancedGhostPlan {
+  const { ghostExceptIds, selectedIds, instancedIds, current, ghostAlpha, lastGhostAlpha, dirty } = input;
+
+  const next = new Set<number>();
+  if (ghostExceptIds != null) {
+    for (const eid of instancedIds) {
+      if (!ghostExceptIds.has(eid) && !selectedIds?.has(eid)) next.add(eid);
+    }
+  }
+
+  const alphaChanged = next.size > 0 && ghostAlpha !== lastGhostAlpha;
+  const forced = dirty || alphaChanged;
+
+  if (!forced && next.size === current.size) {
+    let same = true;
+    for (const eid of next) {
+      if (!current.has(eid)) { same = false; break; }
+    }
+    if (same) return { next, toFade: [], toRestore: [], changed: false };
+  }
+
+  const toRestore: number[] = [];
+  for (const eid of current) {
+    if (!next.has(eid)) toRestore.push(eid);
+  }
+
+  const toFade: number[] = [];
+  for (const eid of next) {
+    if (forced || !current.has(eid)) toFade.push(eid);
+  }
+
+  return { next, toFade, toRestore, changed: true };
+}

--- a/packages/renderer/src/scene-instanced-ghosting.test.ts
+++ b/packages/renderer/src/scene-instanced-ghosting.test.ts
@@ -1,0 +1,187 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * X-Ray on GPU-instanced occurrences (#2606).
+ *
+ * The instanced pass used to receive only the hide and isolate sets, so
+ * ghosting stopped at the flat geometry: on a model whose facade is instanced —
+ * the #2558 tower is exactly that — the user asked to fade the building and got
+ * a solid facade standing in front of a ghosted interior. The Cesium world view
+ * had already started fading them (#2591), which is how the gap surfaced.
+ *
+ * These assert on the bytes written to the instance colour lane, since that is
+ * where the fade actually lives. No GPU is needed: the scene only asks the
+ * device for sized buffers and writes into them.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { Scene } from './scene.js';
+import { DEFAULT_GHOST_ALPHA } from './overlay-routing.js';
+import type { DecodedInstancedShard } from '@ifc-lite/geometry';
+
+(globalThis as Record<string, unknown>).GPUBufferUsage = {
+  MAP_READ: 1, MAP_WRITE: 2, COPY_SRC: 4, COPY_DST: 8, INDEX: 16,
+  VERTEX: 32, UNIFORM: 64, STORAGE: 128, INDIRECT: 256, QUERY_RESOLVE: 512,
+};
+
+/** Records every colour write so the fade can be read back. */
+function fakeDevice() {
+  const writes: Array<{ offset: number; data: number[] }> = [];
+  const device = {
+    limits: { maxBufferSize: 1 << 30, maxStorageBufferBindingSize: 1 << 30 },
+    createBuffer: (desc: { size: number }) => {
+      const backing = new ArrayBuffer(desc.size);
+      return {
+        size: desc.size,
+        getMappedRange: () => backing,
+        unmap() {},
+        destroy() {},
+      };
+    },
+    queue: {
+      writeBuffer: (_buf: unknown, offset: number, data: ArrayBufferView) => {
+        writes.push({ offset, data: Array.from(new Float32Array((data as Float32Array).buffer)) });
+      },
+    },
+  };
+  return { device: device as unknown as GPUDevice, writes };
+}
+
+function rowMajorTranslation(x: number): Float32Array {
+  return new Float32Array([1, 0, 0, x, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+}
+
+/** One opaque unit-triangle occurrence per entity id. */
+function shard(entityIds: number[]): DecodedInstancedShard {
+  const templates = [];
+  const instances = [];
+  for (let t = 0; t < entityIds.length; t++) {
+    templates.push({
+      positions: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+      normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+      indices: new Uint32Array([0, 1, 2]),
+      origin: [0, 0, 0] as [number, number, number],
+    });
+    instances.push({
+      templateIndex: t,
+      entityId: entityIds[t],
+      color: [0.4, 0.5, 0.6, 1] as [number, number, number, number],
+      transform: rowMajorTranslation(t),
+    });
+  }
+  return { templates, instances };
+}
+
+/** The instance colour lane is f32, so 0.12 reads back as 0.11999999…. Compare
+ *  at the precision the GPU actually stores. */
+const F32 = (n: number) => Math.fround(n);
+const GHOST = F32(DEFAULT_GHOST_ALPHA);
+
+/** The alphas written since the marker, in write order. */
+function alphasSince(writes: Array<{ data: number[] }>, from: number): number[] {
+  return writes.slice(from).filter((w) => w.data.length === 4).map((w) => w.data[3]);
+}
+
+function sceneWith(ids: number[]) {
+  const { device, writes } = fakeDevice();
+  const scene = new Scene();
+  scene.addInstancedShard(device, shard(ids), 0);
+  return { scene, device, writes };
+}
+
+describe('setInstancedGhosting (#2606)', () => {
+  it('fades occurrences outside the except-set to the ghost alpha', () => {
+    const { scene, writes } = sceneWith([1, 2]);
+    const mark = writes.length;
+
+    scene.setInstancedGhosting(new Set([1]), null, DEFAULT_GHOST_ALPHA);
+
+    // Only entity 2 is outside the set, so exactly one fade is written.
+    assert.deepEqual(alphasSince(writes, mark), [GHOST]);
+  });
+
+  it('leaves the excepted set solid', () => {
+    const { scene, writes } = sceneWith([1, 2]);
+    const mark = writes.length;
+
+    scene.setInstancedGhosting(new Set([1, 2]), null, DEFAULT_GHOST_ALPHA);
+
+    assert.deepEqual(alphasSince(writes, mark), [], 'nothing to fade, nothing written');
+  });
+
+  it('exempts the selection, as the flat path does', () => {
+    const { scene, writes } = sceneWith([1, 2]);
+    const mark = writes.length;
+
+    scene.setInstancedGhosting(new Set([1]), new Set([2]), DEFAULT_GHOST_ALPHA);
+
+    assert.deepEqual(alphasSince(writes, mark), [], 'the selected occurrence stays solid');
+  });
+
+  it('restores the original alpha when X-Ray is cleared', () => {
+    const { scene, writes } = sceneWith([1, 2]);
+    scene.setInstancedGhosting(new Set([1]), null, DEFAULT_GHOST_ALPHA);
+    const mark = writes.length;
+
+    scene.setInstancedGhosting(null, null, DEFAULT_GHOST_ALPHA);
+
+    assert.deepEqual(alphasSince(writes, mark), [1], 'back to the occurrence colour');
+  });
+
+  it('reports translucent instances, so the transparent sub-pass runs', () => {
+    const { scene } = sceneWith([1, 2]);
+    assert.equal(scene.hasTransparentInstances(), false);
+
+    scene.setInstancedGhosting(new Set([1]), null, DEFAULT_GHOST_ALPHA);
+    assert.equal(scene.hasTransparentInstances(), true, 'a fade nobody draws is not a fade');
+
+    scene.setInstancedGhosting(null, null, DEFAULT_GHOST_ALPHA);
+    assert.equal(scene.hasTransparentInstances(), false);
+  });
+
+  it('writes nothing when the ghost set has not changed', () => {
+    const { scene, writes } = sceneWith([1, 2]);
+    scene.setInstancedGhosting(new Set([1]), null, DEFAULT_GHOST_ALPHA);
+    const mark = writes.length;
+
+    scene.setInstancedGhosting(new Set([1]), null, DEFAULT_GHOST_ALPHA);
+
+    assert.deepEqual(alphasSince(writes, mark), [], 'a per-frame call must be a no-op');
+  });
+
+  it('ghosts everything for an empty except-set, which is not the same as null', () => {
+    const { scene, writes } = sceneWith([1, 2]);
+    const mark = writes.length;
+
+    scene.setInstancedGhosting(new Set(), null, DEFAULT_GHOST_ALPHA);
+
+    assert.deepEqual(alphasSince(writes, mark), [GHOST, GHOST]);
+  });
+
+  it('keeps a colour override\'s RGB while ghosting it', () => {
+    const { scene, writes } = sceneWith([1, 2]);
+    scene.setInstancedColorOverrides(new Map([[2, [1, 0, 0, 1] as const]]));
+    const mark = writes.length;
+
+    scene.setInstancedGhosting(new Set([1]), null, DEFAULT_GHOST_ALPHA);
+
+    const faded = writes.slice(mark).filter((w) => w.data.length === 4).at(-1);
+    assert.deepEqual(faded?.data.slice(0, 3), [1, 0, 0], 'the lens tint survives the fade');
+    assert.equal(faded?.data[3], GHOST);
+  });
+
+  it('restores to the override, not the original colour, when X-Ray clears', () => {
+    const { scene, writes } = sceneWith([1, 2]);
+    scene.setInstancedColorOverrides(new Map([[2, [1, 0, 0, 1] as const]]));
+    scene.setInstancedGhosting(new Set([1]), null, DEFAULT_GHOST_ALPHA);
+    const mark = writes.length;
+
+    scene.setInstancedGhosting(null, null, DEFAULT_GHOST_ALPHA);
+
+    const restored = writes.slice(mark).filter((w) => w.data.length === 4).at(-1);
+    assert.deepEqual(restored?.data, [1, 0, 0, 1], 'the lens tint must not be lost');
+  });
+});

--- a/packages/renderer/src/scene-instanced-ghosting.test.ts
+++ b/packages/renderer/src/scene-instanced-ghosting.test.ts
@@ -173,6 +173,50 @@ describe('setInstancedGhosting (#2606)', () => {
     assert.equal(faded?.data[3], GHOST);
   });
 
+  it('keeps the fade when an override is DROPPED while ghosted', () => {
+    // The composition seam's other direction, and the one that reintroduced the
+    // bug: dropping an override restores full alpha, and the ghost set has not
+    // changed — so without a dirty flag the per-frame call early-returns and the
+    // occurrence sits solid inside an otherwise ghosted model, forever.
+    const { scene, writes } = sceneWith([1, 2]);
+    scene.setInstancedColorOverrides(new Map([[2, [1, 0, 0, 1] as const]]));
+    scene.setInstancedGhosting(new Set([1]), null, DEFAULT_GHOST_ALPHA);
+
+    scene.setInstancedColorOverrides(null);
+    const mark = writes.length;
+    scene.setInstancedGhosting(new Set([1]), null, DEFAULT_GHOST_ALPHA); // next frame
+
+    assert.deepEqual(alphasSince(writes, mark), [GHOST], 'the fade must be re-applied');
+  });
+
+  it('fades occurrences that stream in while X-Ray is already on', () => {
+    // A shard arriving mid-session adds occurrences at their uploaded solid
+    // colour under an id the ghost set already contains — invisible to a
+    // membership diff.
+    // Deliberately an id ALREADY in the ghost set: a new id would change
+    // membership and be caught by the diff, so it would not test this at all.
+    const { scene, device, writes } = sceneWith([1, 2]);
+    scene.setInstancedGhosting(new Set([1]), null, DEFAULT_GHOST_ALPHA);
+
+    scene.addInstancedShard(device, shard([2]), 0);
+    const mark = writes.length;
+    scene.setInstancedGhosting(new Set([1]), null, DEFAULT_GHOST_ALPHA); // next frame
+
+    // Two writes: the fade is re-applied to BOTH occurrences of id 2 — the one
+    // that was already there and the one that just streamed in.
+    assert.deepEqual(alphasSince(writes, mark), [GHOST, GHOST], 'the new occurrence must fade too');
+  });
+
+  it('re-applies when the ghost alpha changes but the set does not', () => {
+    const { scene, writes } = sceneWith([1, 2]);
+    scene.setInstancedGhosting(new Set([1]), null, DEFAULT_GHOST_ALPHA);
+    const mark = writes.length;
+
+    scene.setInstancedGhosting(new Set([1]), null, 0.5);
+
+    assert.deepEqual(alphasSince(writes, mark), [F32(0.5)]);
+  });
+
   it('restores to the override, not the original colour, when X-Ray clears', () => {
     const { scene, writes } = sceneWith([1, 2]);
     scene.setInstancedColorOverrides(new Map([[2, [1, 0, 0, 1] as const]]));

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -26,6 +26,7 @@ import { quantizeInterleaved } from './quantize.js';
 import { bucketBaseKeyFor, type SpatialChunkingConfig } from './chunk-grid.js';
 import { VisibilityEpochTracker } from './visibility-epoch.js';
 import { isEntityVisible } from './entity-visibility.js';
+import { planInstancedGhosting } from './instanced-ghost-plan.js';
 import { selectEvictions, type ResidencyShell, type ColdGeometryProvider } from './residency.js';
 import { OPAQUE_ALPHA_CUTOFF } from './overlay-routing.js';
 import type { DecodedInstancedShard } from '@ifc-lite/geometry';
@@ -3676,27 +3677,18 @@ export class Scene {
     const device = this.instancedDevice;
     if (!device || this.instancedTemplates.length === 0) return;
 
-    const next = new Set<number>();
-    if (ghostExceptIds != null) {
-      for (const eid of this.instancedEntityMap.keys()) {
-        if (!ghostExceptIds.has(eid) && !selectedIds?.has(eid)) next.add(eid);
-      }
-    }
+    const { next, toFade, toRestore, changed } = planInstancedGhosting({
+      ghostExceptIds,
+      selectedIds,
+      instancedIds: this.instancedEntityMap.keys(),
+      current: this.instancedGhosted,
+      ghostAlpha,
+      lastGhostAlpha: this.lastGhostAlpha,
+      dirty: this.instancedGhostDirty,
+    });
+    if (!changed) return;
 
-    // A forced pass rewrites every fade rather than just the delta: the colour
-    // bytes underneath may have been replaced since they were last written.
-    const alphaChanged = next.size > 0 && ghostAlpha !== this.lastGhostAlpha;
-    const forced = this.instancedGhostDirty || alphaChanged;
-    if (!forced && next.size === this.instancedGhosted.size) {
-      let same = true;
-      for (const eid of next) {
-        if (!this.instancedGhosted.has(eid)) { same = false; break; }
-      }
-      if (same) return;
-    }
-
-    for (const eid of this.instancedGhosted) {
-      if (next.has(eid)) continue;
+    for (const eid of toRestore) {
       // Back to whatever owns the colour now: an override if one is active,
       // otherwise the occurrence's baked colour.
       const override = this.instancedOverrideColors?.get(eid);
@@ -3704,8 +3696,7 @@ export class Scene {
       else this.restoreInstanceColor(device, eid);
     }
 
-    for (const eid of next) {
-      if (!forced && this.instancedGhosted.has(eid)) continue;
+    for (const eid of toFade) {
       const base = this.instancedOverrideColors?.get(eid) ?? this.originalInstanceColor(eid);
       if (!base) continue;
       this.writeInstanceColor(device, eid, [base[0], base[1], base[2], ghostAlpha]);

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -252,7 +252,15 @@ export class Scene {
   private instancedSelected: Set<number> = new Set();              // currently flag-selected instanced express_ids
   private instancedHidden: Set<number> = new Set();               // currently hidden instanced express_ids (hide/isolate)
   private instancedOverridden: Set<number> = new Set();            // currently colour-overridden instanced express_ids
+  private instancedGhosted: Set<number> = new Set();               // currently X-Ray ghosted instanced express_ids
+  // The colours the instanced channel was last overridden with. Ghosting reads
+  // THIS rather than the flat path's `colorOverrides`: the two are set by
+  // different calls and can diverge, and a fade must compose with whatever is
+  // actually on the instance buffer.
+  private instancedOverrideColors: ReadonlyMap<number, readonly [number, number, number, number]> | null = null;
+  private lastGhostAlpha = 1;                                      // alpha the active X-Ray fade was written with
   private instancedHasTransparent = false;                         // an override made some instanced occurrence translucent
+  private instancedGhostTransparent = false;                       // X-Ray ghosting made some instanced occurrence translucent
   // Content-based change guard for setInstancedVisibility — same contract as
   // RenderOptions.hiddenIds (in-place mutation and fresh identical Sets both
   // behave), keeping the instanced path in lockstep with the batched path.
@@ -3608,20 +3616,96 @@ export class Scene {
     }
     let hasTransparent = false;
     for (const [eid, rgba] of next) {
-      this.writeInstanceColor(device, eid, rgba);
+      // An occurrence that is currently ghosted keeps the ghost alpha: X-Ray is
+      // a stronger statement about visibility than a lens tint, and the flat
+      // path resolves the same way.
+      const ghosted = this.instancedGhosted.has(eid);
+      this.writeInstanceColor(device, eid, ghosted ? [rgba[0], rgba[1], rgba[2], this.lastGhostAlpha] : rgba);
       // Instanced occurrences are opaque by partition; only an override can drop alpha
       // below the cutoff (lens-ghost / x-ray / compare). Track it so the renderer runs
       // the transparent instanced sub-pass only when something is actually translucent.
       if (rgba[3] < OPAQUE_ALPHA_CUTOFF) hasTransparent = true;
     }
     this.instancedOverridden = new Set(next.keys());
+    this.instancedOverrideColors = next.size > 0 ? next : null;
     this.instancedHasTransparent = hasTransparent;
   }
 
   /** True when an active colour override made some instanced occurrence translucent,
    *  so the renderer should run the transparent instanced sub-pass. */
   hasTransparentInstances(): boolean {
-    return this.instancedHasTransparent;
+    return this.instancedHasTransparent || this.instancedGhostTransparent;
+  }
+
+  /**
+   * Per-instance X-RAY GHOSTING: fade every instanced occurrence outside
+   * `ghostExceptIds` to `ghostAlpha`, leaving the excepted set and the current
+   * selection solid.
+   *
+   * The instanced pass used to receive only the hide and isolate sets, so
+   * ghosting stopped at the flat geometry: on a model whose facade is
+   * instanced, X-Ray left a solid facade in front of a ghosted interior
+   * (#2606). The Cesium world view had already started doing this correctly
+   * (#2591), which is what surfaced the gap.
+   *
+   * Composes with colour overrides instead of clobbering them: a ghosted
+   * occurrence keeps its override's RGB and takes the ghost alpha, and
+   * restoring re-applies the override rather than the original colour. The two
+   * channels share the instance colour bytes, so whichever wrote last would
+   * otherwise win.
+   *
+   * `ghostExceptIds == null` means no X-Ray: everything ghosted is restored.
+   */
+  setInstancedGhosting(
+    ghostExceptIds: ReadonlySet<number> | null | undefined,
+    selectedIds: ReadonlySet<number> | null | undefined,
+    ghostAlpha: number,
+  ): void {
+    const device = this.instancedDevice;
+    if (!device || this.instancedTemplates.length === 0) return;
+
+    const next = new Set<number>();
+    if (ghostExceptIds != null) {
+      for (const eid of this.instancedEntityMap.keys()) {
+        if (!ghostExceptIds.has(eid) && !selectedIds?.has(eid)) next.add(eid);
+      }
+    }
+
+    // Nothing to do — including the common case of no X-Ray and none ghosted.
+    if (next.size === this.instancedGhosted.size) {
+      let same = true;
+      for (const eid of next) {
+        if (!this.instancedGhosted.has(eid)) { same = false; break; }
+      }
+      if (same) return;
+    }
+
+    for (const eid of this.instancedGhosted) {
+      if (next.has(eid)) continue;
+      // Back to whatever owns the colour now: an override if one is active,
+      // otherwise the occurrence's baked colour.
+      const override = this.instancedOverrideColors?.get(eid);
+      if (override) this.writeInstanceColor(device, eid, override);
+      else this.restoreInstanceColor(device, eid);
+    }
+
+    for (const eid of next) {
+      if (this.instancedGhosted.has(eid)) continue;
+      const base = this.instancedOverrideColors?.get(eid) ?? this.originalInstanceColor(eid);
+      if (!base) continue;
+      this.writeInstanceColor(device, eid, [base[0], base[1], base[2], ghostAlpha]);
+    }
+
+    this.instancedGhosted = next;
+    this.lastGhostAlpha = ghostAlpha;
+    this.instancedGhostTransparent = next.size > 0 && ghostAlpha < OPAQUE_ALPHA_CUTOFF;
+  }
+
+  /** The colour an occurrence was uploaded with, before any override or ghost. */
+  private originalInstanceColor(eid: number): readonly [number, number, number, number] | null {
+    const locs = this.instancedEntityMap.get(eid);
+    const first = locs?.[0];
+    return first ? first.originalColor : null;
   }
 
   /** Write the combined flag lane (selected | hidden) for every occurrence of `eid`.
@@ -3857,7 +3941,10 @@ export class Scene {
     this.instancedSelected.clear();
     this.instancedHidden.clear();
     this.instancedOverridden.clear();
+    this.instancedGhosted.clear();
+    this.instancedOverrideColors = null;
     this.instancedHasTransparent = false;
+    this.instancedGhostTransparent = false;
     // Force the next setInstancedVisibility to recompute against fresh state.
     this.lastInstancedVisibilityVersion = -1;
     this.instancedVisibilityDirty = false;

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -259,6 +259,11 @@ export class Scene {
   // actually on the instance buffer.
   private instancedOverrideColors: ReadonlyMap<number, readonly [number, number, number, number]> | null = null;
   private lastGhostAlpha = 1;                                      // alpha the active X-Ray fade was written with
+  // Set when something OTHER than the ghost set changed the instance colour
+  // bytes — a shard streaming in, or an override applied/dropped. The
+  // membership diff cannot see those, so without this an occurrence can sit
+  // solid while the set says it is ghosted (#2606 review).
+  private instancedGhostDirty = false;
   private instancedHasTransparent = false;                         // an override made some instanced occurrence translucent
   private instancedGhostTransparent = false;                       // X-Ray ghosting made some instanced occurrence translucent
   // Content-based change guard for setInstancedVisibility — same contract as
@@ -3359,8 +3364,11 @@ export class Scene {
     }
     // New occurrences default to flags=0 (visible). Force the next setInstancedVisibility
     // to recompute so an already-active isolate/hide also applies to geometry that
-    // streamed in after the visibility was set.
+    // streamed in after the visibility was set. X-Ray needs the same: new
+    // occurrences of an already-ghosted id arrive at their uploaded, solid
+    // colour, and the ghost set's membership has not changed to reveal it.
     this.instancedVisibilityDirty = true;
+    this.instancedGhostDirty = true;
   }
 
   /** Transform a template's local AABB by an occurrence's column-major mat4 (read
@@ -3629,6 +3637,10 @@ export class Scene {
     this.instancedOverridden = new Set(next.keys());
     this.instancedOverrideColors = next.size > 0 ? next : null;
     this.instancedHasTransparent = hasTransparent;
+    // Restoring a dropped override writes FULL alpha, which un-fades a ghosted
+    // occurrence. The ghost set has not changed, so only this flag gets the
+    // fade re-applied on the next frame.
+    this.instancedGhostDirty = true;
   }
 
   /** True when an active colour override made some instanced occurrence translucent,
@@ -3671,8 +3683,11 @@ export class Scene {
       }
     }
 
-    // Nothing to do — including the common case of no X-Ray and none ghosted.
-    if (next.size === this.instancedGhosted.size) {
+    // A forced pass rewrites every fade rather than just the delta: the colour
+    // bytes underneath may have been replaced since they were last written.
+    const alphaChanged = next.size > 0 && ghostAlpha !== this.lastGhostAlpha;
+    const forced = this.instancedGhostDirty || alphaChanged;
+    if (!forced && next.size === this.instancedGhosted.size) {
       let same = true;
       for (const eid of next) {
         if (!this.instancedGhosted.has(eid)) { same = false; break; }
@@ -3690,7 +3705,7 @@ export class Scene {
     }
 
     for (const eid of next) {
-      if (this.instancedGhosted.has(eid)) continue;
+      if (!forced && this.instancedGhosted.has(eid)) continue;
       const base = this.instancedOverrideColors?.get(eid) ?? this.originalInstanceColor(eid);
       if (!base) continue;
       this.writeInstanceColor(device, eid, [base[0], base[1], base[2], ghostAlpha]);
@@ -3698,6 +3713,7 @@ export class Scene {
 
     this.instancedGhosted = next;
     this.lastGhostAlpha = ghostAlpha;
+    this.instancedGhostDirty = false;
     this.instancedGhostTransparent = next.size > 0 && ghostAlpha < OPAQUE_ALPHA_CUTOFF;
   }
 
@@ -3942,6 +3958,7 @@ export class Scene {
     this.instancedHidden.clear();
     this.instancedOverridden.clear();
     this.instancedGhosted.clear();
+    this.instancedGhostDirty = false;
     this.instancedOverrideColors = null;
     this.instancedHasTransparent = false;
     this.instancedGhostTransparent = false;


### PR DESCRIPTION
Fixes #2606.

## The gap

`Renderer.render` mirrored only hide and isolate onto the instanced pass:

```ts
this.scene.setInstancedVisibility(options.hiddenIds, options.isolatedIds);
```

So ghosting stopped at the flat geometry. On a model whose facade is instanced — repeated panels, mullions, windows; the #2558 tower is exactly this — clash focus in ghost mode, the Space Sketch preview or layer diff produced **a solid facade standing in front of a ghosted interior**.

This is the divergence #2591 deliberately created: the Cesium world view bakes alpha into its own glTF and so began fading them correctly, while the viewport did not. Closing it the right way round — the viewport now agrees with the map, rather than the map being reverted to match a defect.

## The fix

`Scene.setInstancedGhosting(ghostExceptIds, selectedIds, ghostAlpha)`:

- fades every occurrence outside the except-set to the same `DEFAULT_GHOST_ALPHA` the flat path uses;
- exempts the selection, exactly as the flat path does;
- reports through `hasTransparentInstances()` so the translucent sub-pass runs — a fade nobody draws is not a fade;
- diffs against the previous ghost set, so the per-frame call is a no-op when nothing changed.

**It composes with colour overrides rather than clobbering them.** Lens, IDS, compare and 4D overrides write the same instance colour bytes, so whichever wrote last would otherwise win. A ghosted occurrence keeps its override's RGB and takes the ghost alpha; clearing X-Ray restores the *override*, not the original colour.

One design correction found while testing: ghosting initially read the flat path's `colorOverrides`, but the instanced channel has its own map set by a different call, and the two can diverge. A fade has to compose with what is actually on the instance buffer, so it now reads that.

## Tests

12 cases in `scene-instanced-ghosting.test.ts`, asserting on the bytes written to the instance colour lane — that is where the fade lives, and no GPU is needed since the scene only asks the device for sized buffers. Plus 9 in `instanced-ghost-plan.test.ts` against the extracted decision (below).

Covered: the fade itself, the excepted set staying solid, selection exemption, restore on clear, `hasTransparentInstances()` flipping both ways, the per-frame no-op, the empty except-set (ghost everything — not the same as `null`), and both colour-override compositions.

**Reverting the fade fails 6 of the 12**, and forcing the re-apply flag to `false` fails 5. They compare at f32 precision, because `0.12` comes back out of the lane as `0.11999999731779099` — the lane is `f32`, and asserting against the double would be asserting against something the GPU never stores.

Renderer suite 889 passing, `tsc --noEmit` clean, API surface unchanged (the new method is on `Scene`, already exported).

## Not covered

The visual result on a real model — this is a GPU write path, and the repo's renderer tests deliberately stop at the buffer contents, leaving pixels to the browser/E2E lanes. The bytes are asserted; the shader discard/blend behaviour they feed is pre-existing and shared with the lens-ghost path that already used it.


## Review follow-ups

Three findings came back on the first commit; all three are addressed.

**Dropping a colour override left the occurrence solid** (Codex P1, Fable). Restoring an override writes full alpha, and the ghost set does not move — so the next frame's membership diff early-returned and that occurrence sat solid inside an otherwise ghosted model, permanently. The same hole swallowed a shard streaming in while X-Ray was already on. Fixed with a dirty flag set by everything that writes those bytes behind ghosting's back, so the diff is no longer the only thing trusted.

**Changing `ghostAlpha` without changing the set did nothing** (Codex P2). The alpha now participates in change detection.

**"Extract this out of `scene.ts`"** (Codex P1). The write side cannot leave `Scene` — it owns the instance buffers — but the decision can, and the decision is where the other two findings lived. `planInstancedGhosting` is now a pure function over (except-set, selection, current fades, alpha, dirty) returning what to fade and what to restore.

Worth being plain about the size effect: `scene.ts` goes 4,402 → 4,393 lines, because the loops that do the writing stay behind. That is not compliance with the ~400-line rule and I am not claiming it is; splitting a 4,400-line renderer core is its own job. What it buys is that the deciding half is testable as a function rather than through a device mock.

Reviewed by the CodeRabbit CLI locally, since the hosted check on this head reports `Review rate limited` — no findings across all 6 changed files.
