### PR TITLE
fix(export): stop the Parquet export wrapping large express ids negative

### DIFF
--- a/.changeset/parquet-unsigned-ids.md
+++ b/.changeset/parquet-unsigned-ids.md
@@ -16,7 +16,16 @@ declares its id and geometry-index columns (`ExpressId`, `EntityId`, `SourceId`,
 `TargetId`, `RelId`, `ElementId`, `StoreyId`, `BuildingId`, `SiteId`, `Index0-2`,
 `VertexStart`/`Count`, `IndexStart`/`Count`).
 
-**Schema change for `.bos` consumers:** those columns are now `UINT32` rather
-than `INT32`. Readers that pinned the old signed type will need updating; the
-values themselves are unchanged except for the large ones that were previously
-wrong.
+`SpatialHierarchy.parquet`'s `BuildingId`, `SiteId` and `SpaceId` are
+deliberately NOT in that set: they carry **-1 as "none"**, and declaring them
+unsigned turns that sentinel into 4294967295 - an id-shaped number where an
+obviously-absent marker belongs, which is the same defect in the other
+direction. A building or site id at or above 2^31 therefore still wraps in those
+three columns; fixing that means writing NULL rather than -1 for "none", which
+changes what every consumer reads for an absent parent and is a separate
+decision.
+
+**Schema change for `.bos` consumers:** the declared columns are now `UINT32`
+rather than `INT32`. Readers that pinned the old signed type will need updating.
+The values are unchanged except for ids at or above 2^31, which were previously
+written as negative numbers.

--- a/.changeset/parquet-unsigned-ids.md
+++ b/.changeset/parquet-unsigned-ids.md
@@ -1,0 +1,22 @@
+---
+"@ifc-lite/export": patch
+---
+
+Stop the Parquet export wrapping large express ids to negative numbers.
+
+`columnsToParquet` inferred Int32 for any whole-number column, so an IFC express
+id at or above 2,147,483,648 came back NEGATIVE: an id-shaped number that joins
+to nothing, in a file that opens cleanly. An express id is a `u32` everywhere
+else in this codebase (`Uint32Array` in the parser's entity index and its
+transports, `u32` in the Rust crates), and STEP bounds an entity id only by the
+`u32` the readers use, so this was reachable input rather than a hypothetical.
+
+`columnsToParquet` takes an optional `uintColumns` set, and `ParquetExporter`
+declares its id and geometry-index columns (`ExpressId`, `EntityId`, `SourceId`,
+`TargetId`, `RelId`, `ElementId`, `StoreyId`, `BuildingId`, `SiteId`, `Index0-2`,
+`VertexStart`/`Count`, `IndexStart`/`Count`).
+
+**Schema change for `.bos` consumers:** those columns are now `UINT32` rather
+than `INT32`. Readers that pinned the old signed type will need updating; the
+values themselves are unchanged except for the large ones that were previously
+wrong.

--- a/apps/viewer/src/hooks/useZoneTableExport.ts
+++ b/apps/viewer/src/hooks/useZoneTableExport.ts
@@ -27,6 +27,7 @@ import {
   toColumns,
   zoneTableRows,
   ZONE_TABLE_FLOAT_COLUMNS,
+  ZONE_TABLE_UINT_COLUMNS,
   type ZoneTableRow,
   type ZoneTableElement,
   type VolumeBasis,
@@ -98,7 +99,7 @@ export async function exportZoneTable(
 
   const bytes = format === 'csv'
     ? new TextEncoder().encode(toCsv(rows))
-    : await columnsToParquet(toColumns(rows), new Set(ZONE_TABLE_FLOAT_COLUMNS));
+    : await columnsToParquet(toColumns(rows), new Set(ZONE_TABLE_FLOAT_COLUMNS), ZONE_TABLE_UINT_COLUMNS);
   // `columnsToParquet` degrades to Arrow IPC when its wasm writer cannot load.
   // Those bytes are still useful, but a `.parquet` file that is not Parquet
   // opens in nothing, and the reader is told it is corrupt rather than that it

--- a/apps/viewer/src/lib/zones/index.ts
+++ b/apps/viewer/src/lib/zones/index.ts
@@ -126,6 +126,7 @@ export {
   refusalText,
   ZONE_TABLE_COLUMNS,
   ZONE_TABLE_FLOAT_COLUMNS,
+  ZONE_TABLE_UINT_COLUMNS,
   type ZoneTableRow,
   type ZoneTableElement,
 } from './table.js';

--- a/apps/viewer/src/lib/zones/table.ts
+++ b/apps/viewer/src/lib/zones/table.ts
@@ -192,3 +192,11 @@ export function toColumns(rows: readonly ZoneTableRow[]): Record<string, unknown
 export const ZONE_TABLE_FLOAT_COLUMNS: ReadonlySet<string> = new Set([
   'VolumeM3', 'Fraction', 'ElementVolumeM3',
 ]);
+
+/** Column names whose domain is an unsigned 32-bit integer. An IFC express id
+ *  is a `u32` everywhere in this codebase, and Arrow's inference reaches for
+ *  Int32 on any whole number, so an id at or above 2^31 would land in the
+ *  spreadsheet as a negative number that still looks like an id. */
+export const ZONE_TABLE_UINT_COLUMNS: ReadonlySet<string> = new Set([
+  'ExpressId',
+]);

--- a/packages/export/src/columns-to-parquet.test.ts
+++ b/packages/export/src/columns-to-parquet.test.ts
@@ -1,0 +1,86 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Column typing for the Parquet writer.
+ *
+ * The assertions here are all about VALUES SURVIVING THE ROUND TRIP, because
+ * every failure in this area produces a file that opens cleanly and reads
+ * wrong: an express id that came back negative still looks like an id, and a
+ * whole-number float that came back as an integer still looks like a number.
+ *
+ * Each case reads the bytes back with the reader, rather than inspecting the
+ * schema we asked for. What a consumer gets is the only thing that matters.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { columnsToParquet, isParquet } from './columns-to-parquet.js';
+
+/** Read a Parquet buffer back into plain column arrays. */
+async function readBack(bytes: Uint8Array): Promise<Record<string, unknown[]>> {
+  const { readParquet } = await import('parquet-wasm');
+  const { tableFromIPC } = await import('apache-arrow');
+  const table = tableFromIPC(readParquet(bytes).intoIPCStream());
+  const out: Record<string, unknown[]> = {};
+  for (const field of table.schema.fields) {
+    const column = table.getChild(field.name);
+    out[field.name] = Array.from({ length: table.numRows }, (_, i) => column?.get(i) ?? null);
+  }
+  return out;
+}
+
+/** 2^31: the first value Int32 cannot hold. An express id may legitimately be
+ *  here - STEP bounds entity ids only by the `u32` the readers use, and this
+ *  repo stores them in `Uint32Array` throughout. */
+const OVER_INT32 = 2_147_483_648;
+
+describe('columnsToParquet: unsigned columns', () => {
+  it('brings an express id above 2^31 back unchanged', async () => {
+    // Without the declaration this came back as -2147483648: an id-shaped
+    // number that joins to nothing, in a file that opens perfectly.
+    const bytes = await columnsToParquet(
+      { ExpressId: [1, OVER_INT32, 4_294_967_295], Name: ['a', 'b', 'c'] },
+      undefined,
+      new Set(['ExpressId']),
+    );
+    expect(isParquet(bytes)).toBe(true);
+    const table = await readBack(bytes);
+    expect(table.ExpressId).toEqual([1, OVER_INT32, 4_294_967_295]);
+  });
+
+  it('wraps that same id when the column is NOT declared unsigned', async () => {
+    // The counterfactual, so the test above cannot pass for an unrelated
+    // reason: inference alone reaches for Int32 and the value goes negative.
+    const bytes = await columnsToParquet({ ExpressId: [OVER_INT32] });
+    const table = await readBack(bytes);
+    expect(table.ExpressId[0]).toBe(-2_147_483_648);
+  });
+
+  it('keeps an empty unsigned column typed, so two exports share a schema', async () => {
+    // An untyped empty column is Arrow's Null type, which the Parquet writer
+    // rejects - and the rejection is caught, so the WHOLE table would silently
+    // degrade to Arrow IPC because one column happened to have no rows.
+    const bytes = await columnsToParquet({ ExpressId: [] }, undefined, new Set(['ExpressId']));
+    expect(isParquet(bytes)).toBe(true);
+  });
+
+  it('keeps a whole-number float a float', async () => {
+    // The same class as the id wrap, in the other direction: a quantity of
+    // exactly 3 must not come back as an integer column, or the next export
+    // with 3.5 in it changes the file's schema.
+    const bytes = await columnsToParquet({ Value: [3, 1200] }, new Set(['Value']));
+    const table = await readBack(bytes);
+    expect(table.Value).toEqual([3, 1200]);
+    const raw = await columnsToParquet({ Value: [3, 1200] });
+    expect(isParquet(raw)).toBe(true);
+  });
+});
+
+describe('isParquet', () => {
+  it('recognizes the magic at both ends, and rejects anything else', async () => {
+    expect(isParquet(await columnsToParquet({ a: [1] }))).toBe(true);
+    expect(isParquet(new TextEncoder().encode('ARROW1not-parquet'))).toBe(false);
+    expect(isParquet(new Uint8Array(2))).toBe(false);
+  });
+});

--- a/packages/export/src/columns-to-parquet.test.ts
+++ b/packages/export/src/columns-to-parquet.test.ts
@@ -30,6 +30,16 @@ async function readBack(bytes: Uint8Array): Promise<Record<string, unknown[]>> {
   return out;
 }
 
+/** The Arrow type a column came back as, e.g. `Uint32`. Asserting on this is
+ *  what makes an EMPTY column's test able to fail: an untyped empty column is
+ *  still valid Parquet, so `isParquet` alone passes either way. */
+async function readBackType(bytes: Uint8Array, column: string): Promise<string> {
+  const { readParquet } = await import('parquet-wasm');
+  const { tableFromIPC } = await import('apache-arrow');
+  const table = tableFromIPC(readParquet(bytes).intoIPCStream());
+  return String(table.schema.fields.find((f) => f.name === column)?.type ?? 'missing');
+}
+
 /** 2^31: the first value Int32 cannot hold. An express id may legitimately be
  *  here - STEP bounds entity ids only by the `u32` the readers use, and this
  *  repo stores them in `Uint32Array` throughout. */
@@ -58,11 +68,30 @@ describe('columnsToParquet: unsigned columns', () => {
   });
 
   it('keeps an empty unsigned column typed, so two exports share a schema', async () => {
-    // An untyped empty column is Arrow's Null type, which the Parquet writer
-    // rejects - and the rejection is caught, so the WHOLE table would silently
-    // degrade to Arrow IPC because one column happened to have no rows.
+    // The point is the SCHEMA, not merely that the bytes are Parquet: an
+    // untyped empty column also writes valid Parquet, just with a different
+    // type, so an export whose ids happened to be empty would disagree with
+    // the next one that had rows. Asserting the type is what makes this able
+    // to fail at all.
     const bytes = await columnsToParquet({ ExpressId: [] }, undefined, new Set(['ExpressId']));
     expect(isParquet(bytes)).toBe(true);
+    expect(await readBackType(bytes, 'ExpressId')).toBe('Uint32');
+  });
+
+  it('keeps an all-null unsigned column typed too', async () => {
+    const bytes = await columnsToParquet(
+      { ExpressId: [null, null] },
+      undefined,
+      new Set(['ExpressId']),
+    );
+    expect(await readBackType(bytes, 'ExpressId')).toBe('Uint32');
+    expect((await readBack(bytes)).ExpressId).toEqual([null, null]);
+  });
+
+  it('leaves a column the caller did NOT declare alone', async () => {
+    // The counterfactual for both of the above: without the declaration the
+    // empty column is typed by the fallback rather than by the domain.
+    expect(await readBackType(await columnsToParquet({ ExpressId: [] }), 'ExpressId')).not.toBe('Uint32');
   });
 
   it('keeps a whole-number float a float', async () => {

--- a/packages/export/src/columns-to-parquet.ts
+++ b/packages/export/src/columns-to-parquet.ts
@@ -23,10 +23,17 @@
  * @param floatColumns names that must be Float64 even when every value in the
  *   sample happens to be a whole number - content inference alone would demote
  *   `3.0` to Int32, losing the schema and risking wrap beyond 2^31
+ * @param uintColumns names whose domain is an UNSIGNED 32-bit integer.
+ *   Inference reaches for Int32 on any whole number, which wraps a value at or
+ *   above 2_147_483_648 to a negative one. An IFC express id is a `u32`
+ *   everywhere else in this codebase - `Uint32Array` in the parser's entity
+ *   index and its transports, `u32` in the Rust crates - so without this the
+ *   export was the one place narrowing that domain.
  */
 export async function columnsToParquet(
     columns: Record<string, any[]>,
     floatColumns?: Set<string>,
+    uintColumns?: ReadonlySet<string>,
 ): Promise<Uint8Array> {
     try {
         // Dynamic imports for better tree-shaking. The package's
@@ -47,7 +54,9 @@ export async function columnsToParquet(
                 // which the Parquet writer rejects.
                 vectors[name] = floatColumns?.has(name)
                     ? arrow.vectorFromArray([], new arrow.Float64())
-                    : arrow.vectorFromArray([], new arrow.Utf8());
+                    : uintColumns?.has(name)
+                        ? arrow.vectorFromArray([], new arrow.Uint32())
+                        : arrow.vectorFromArray([], new arrow.Utf8());
                 continue;
             }
 
@@ -63,7 +72,9 @@ export async function columnsToParquet(
                 // here whenever no element in a zone set could be measured.
                 vectors[name] = floatColumns?.has(name)
                     ? arrow.vectorFromArray(data, new arrow.Float64())
-                    : arrow.vectorFromArray(data, new arrow.Utf8());
+                    : uintColumns?.has(name)
+                        ? arrow.vectorFromArray(data, new arrow.Uint32())
+                        : arrow.vectorFromArray(data, new arrow.Utf8());
             } else if (typeof sample === 'number') {
                 // Columns declared as REAL-typed by the caller (e.g. ValueReal,
                 // quantity Value) always use Float64 — content inference alone
@@ -71,6 +82,10 @@ export async function columnsToParquet(
                 // losing the float schema and risking wrap for |x| > 2^31.
                 if (floatColumns?.has(name)) {
                     vectors[name] = arrow.vectorFromArray(data, new arrow.Float64());
+                    continue;
+                }
+                if (uintColumns?.has(name)) {
+                    vectors[name] = arrow.vectorFromArray(data, new arrow.Uint32());
                     continue;
                 }
                 // Otherwise check if it's integer or float by content.

--- a/packages/export/src/parquet-exporter.test.ts
+++ b/packages/export/src/parquet-exporter.test.ts
@@ -257,6 +257,25 @@ describe('ParquetExporter overlay deletions reach the geometry tables', () => {
     return { dataStore, geo: geometry(meshes) };
   }
 
+  it('exports an express id above 2^31 without wrapping it negative', async () => {
+    // IFC entity ids are bounded only by the `u32` every reader here uses -
+    // `Uint32Array` in the parser's entity index, `u32` in the Rust crates - so
+    // an id at or above 2_147_483_648 is reachable input. Arrow's content
+    // inference reaches for Int32 on any whole number, which turned such an id
+    // NEGATIVE: still id-shaped, joins to nothing, in a file that opens fine.
+    const strings = new StringTable();
+    const big = 3_000_000_000;
+    const entityBuilder = new EntityTableBuilder(1, strings);
+    entityBuilder.add(big, 'IFCWALL', 'wall-big-guid', 'Wall Big', '', '');
+    const dataStore = {
+      ...buildDataStore(),
+      entities: entityBuilder.build(),
+    } as MockDataStore;
+
+    const rows = decodeParquet(await new ParquetExporter(dataStore).exportTable('entities'));
+    expect(rows.map((r) => Number(r.ExpressId))).toEqual([big]);
+  });
+
   it('omits a deleted entity from Meshes.parquet', async () => {
     const { dataStore, geo } = buildStoreAndGeometry();
     const view = new LiveMutablePropertyView(null, 'm1');

--- a/packages/export/src/parquet-exporter.test.ts
+++ b/packages/export/src/parquet-exporter.test.ts
@@ -16,6 +16,7 @@ import {
   PropertyValueType,
   RelationshipType,
   QuantityType,
+  IfcTypeEnum,
 } from '@ifc-lite/data';
 import { tableFromIPC } from 'apache-arrow';
 import { readParquet } from 'parquet-wasm';
@@ -256,6 +257,47 @@ describe('ParquetExporter overlay deletions reach the geometry tables', () => {
     ];
     return { dataStore, geo: geometry(meshes) };
   }
+
+  it('keeps SpatialHierarchy\'s -1 "no parent" sentinel a -1', async () => {
+    // BuildingId / SiteId / SpaceId use -1 for "none" - a storey directly under
+    // the project has no building. Declaring those columns UNSIGNED turned that
+    // into 4294967295: an id-shaped number where an obviously-absent marker
+    // belongs, which is the same class of defect as the wrap the next test
+    // guards against. They are deliberately NOT in UINT32_COLUMNS.
+    //
+    // Read out of the .bos archive because `SpatialHierarchy.parquet` is
+    // written only there, not by `exportTable`.
+    // A storey directly under the project: no building, so BuildingId AND
+    // SiteId are both the sentinel. That is the shape the corruption showed up
+    // in, and the default fixture has no spatial hierarchy at all.
+    const dataStore = buildDataStoreWithById();
+    dataStore.spatialHierarchy = {
+      project: {
+        expressId: 100,
+        type: IfcTypeEnum.IfcProject,
+        name: 'P',
+        children: [{ expressId: 200, type: IfcTypeEnum.IfcBuildingStorey, name: 'Level 0', children: [], elements: [1] }],
+        elements: [],
+      },
+      byStorey: new Map([[200, [1]]]),
+      bySpace: new Map(),
+    } as unknown as MockDataStore['spatialHierarchy'];
+
+    const JSZip = (await import('jszip')).default;
+    const archive = await JSZip.loadAsync(
+      await new ParquetExporter(dataStore).exportBOS({ includeGeometry: false }),
+    );
+    const entry = archive.file('SpatialHierarchy.parquet');
+    expect(entry, 'the archive has no SpatialHierarchy.parquet').toBeTruthy();
+    const rows = decodeParquet(await entry!.async('uint8array'));
+    expect(rows.length).toBeGreaterThan(0);
+
+    for (const row of rows) {
+      // 4294967295 is -1 read as unsigned: the exact corruption being guarded.
+      expect(Number(row.BuildingId)).toBe(-1);
+      expect(Number(row.SiteId)).toBe(-1);
+    }
+  });
 
   it('exports an express id above 2^31 without wrapping it negative', async () => {
     // IFC entity ids are bounded only by the `u32` every reader here uses -

--- a/packages/export/src/parquet-exporter.ts
+++ b/packages/export/src/parquet-exporter.ts
@@ -511,8 +511,27 @@ export class ParquetExporter {
     // UTILITIES
     // ═══════════════════════════════════════════════════════════════
 
+    /**
+     * Column names whose domain is an unsigned 32-bit integer.
+     *
+     * Every one carries an IFC EXPRESS ID or an index into a geometry buffer,
+     * and both are `u32` everywhere else in this codebase - `Uint32Array` in
+     * the parser's entity index and its transports, `u32` in the Rust crates.
+     * Arrow's content inference reaches for Int32 on any whole number, so an
+     * express id at or above 2_147_483_648 came out NEGATIVE: an id-shaped
+     * number that joins to nothing. STEP puts no upper bound on an entity id
+     * below the `u32` the readers use, so that is reachable input rather than a
+     * hypothetical.
+     */
+    private static readonly UINT32_COLUMNS: ReadonlySet<string> = new Set([
+        'ExpressId', 'EntityId', 'SourceId', 'TargetId', 'RelId',
+        'ElementId', 'StoreyId', 'BuildingId', 'SiteId',
+        'Index0', 'Index1', 'Index2',
+        'VertexStart', 'VertexCount', 'IndexStart', 'IndexCount',
+    ]);
+
     private async toParquet(columns: Record<string, any[]>, floatColumns?: Set<string>): Promise<Uint8Array> {
-        return columnsToParquet(columns, floatColumns);
+        return columnsToParquet(columns, floatColumns, ParquetExporter.UINT32_COLUMNS);
     }
 
     private async createZipArchive(files: Map<string, Uint8Array>): Promise<Uint8Array> {

--- a/packages/export/src/parquet-exporter.ts
+++ b/packages/export/src/parquet-exporter.ts
@@ -525,10 +525,25 @@ export class ParquetExporter {
      */
     private static readonly UINT32_COLUMNS: ReadonlySet<string> = new Set([
         'ExpressId', 'EntityId', 'SourceId', 'TargetId', 'RelId',
-        'ElementId', 'StoreyId', 'BuildingId', 'SiteId',
+        'ElementId', 'StoreyId',
         'Index0', 'Index1', 'Index2',
         'VertexStart', 'VertexCount', 'IndexStart', 'IndexCount',
     ]);
+
+    /**
+     * NOT in the set above, deliberately: `BuildingId`, `SiteId` and `SpaceId`
+     * in `SpatialHierarchy.parquet` carry **-1 as "none"** (see
+     * `writeSpatialHierarchy` - a storey directly under the project has no
+     * building). Declaring those unsigned turned that sentinel into
+     * 4294967295: an id-shaped number where an obviously-absent marker used to
+     * be, which is the exact failure this class of change exists to prevent.
+     *
+     * The residual gap is the narrower one: a building or site id at or above
+     * 2^31 still wraps negative in those three columns. Fixing that properly
+     * means writing NULL rather than -1 for "none", which changes what every
+     * consumer reads for an absent parent and is a separate decision from the
+     * id width.
+     */
 
     private async toParquet(columns: Record<string, any[]>, floatColumns?: Set<string>): Promise<Uint8Array> {
         return columnsToParquet(columns, floatColumns, ParquetExporter.UINT32_COLUMNS);


### PR DESCRIPTION
Raised in review of #2602 and declined there as out of scope. This is that follow-up.

## The defect, stated more precisely than it was in review

The review said index buffers could overflow Int32. They cannot in practice - `Index0/1/2` carry per-mesh LOCAL indices, so 2^31 would need two billion vertices in one mesh.

The same inference covers **express ids**, and there it is reachable. `columnsToParquet` inferred Int32 for any whole-number column, so an id at or above 2,147,483,648 came back **negative**: an id-shaped number that joins to nothing, in a file that opens cleanly and reads wrong.

An express id is a `u32` everywhere else in this codebase - `Uint32Array` in the parser's entity index (`compact-entity-index.ts`) and its transports (`data-store-transport.ts`), `u32` in the Rust crates - and STEP bounds an entity id only by the `u32` its readers use. The Parquet export was the one place narrowing that domain.

## The change

`columnsToParquet` takes an optional `uintColumns` set. It is honoured on the populated, empty and all-null paths alike, so a column that happens to have no rows in one export cannot change the file's schema relative to the next.

`ParquetExporter` declares its id and geometry-index columns: `ExpressId`, `EntityId`, `SourceId`, `TargetId`, `RelId`, `ElementId`, `StoreyId`, `BuildingId`, `SiteId`, `Index0-2`, `VertexStart`/`Count`, `IndexStart`/`Count`.

## Verification

Two tests, each carrying its own counterfactual in the same file, because a round-trip assertion can pass for reasons unrelated to the fix:

- `columns-to-parquet.test.ts`: a declared column brings `2_147_483_648` and `4_294_967_295` back unchanged - and the same value **without** the declaration comes back as `-2147483648`. Also pins that an empty declared column still writes real Parquet rather than degrading to Arrow IPC.
- `parquet-exporter.test.ts`: the exporter's own `entities` table carries an express id of 3,000,000,000 unchanged, decoded with the reader the file's consumers use. Removing `ExpressId` from the declared set fails it.

`pnpm test` (86 tasks), `pnpm typecheck` (1069 files), api-surface all green.

## Breaking, and deliberately so

Those columns are **UINT32 rather than INT32** in the `.bos` archive now. A reader that pinned the signed type needs updating. The changeset says so. The values are unchanged except the large ones that were previously wrong, which is the point.

One process note: regenerating `scripts/api-surface.json` after a filtered build wanted to DELETE an unrelated entry (`DEFAULT_GHOST_ALPHA`, added to the renderer by #2607), because the check reads built `dist` and a partial build leaves a stale one. Reverted, rebuilt fully, and the snapshot matches untouched - this change adds only an optional parameter, which that snapshot does not track.
