### PR TITLE
docs(geometry): record two incidental tolerance dependencies, correct a calibration claim

### DIFF
--- a/rust/geometry/src/geom_hash.rs
+++ b/rust/geometry/src/geom_hash.rs
@@ -109,8 +109,17 @@ mod surface;
 mod accumulate;
 
 /// Default quantization grid in metres (1 mm). Chosen as a starting point near
-/// the `f32` precision floor of RTC-local coordinates; tune empirically with
-/// the `tolerance_sweep` test against real revision pairs.
+/// the `f32` precision floor of RTC-local coordinates; `tolerance_sweep` only
+/// exercises a synthetic cube today; real-revision-pair calibration is still
+/// open (see that test's doc comment).
+///
+/// Safety margin is narrower than the "near-origin" framing above suggests:
+/// measured `f32` ULP is 9.77e-4 m (98% of this bucket) at both 8192 m and
+/// 10 km, only just under 1 mm before crossing it at 16384 m. It stays safe
+/// only because [`LARGE_COORD_THRESHOLD_METERS`](crate::LARGE_COORD_THRESHOLD_METERS)
+/// re-centres coordinates before they reach that range — an incidental
+/// dependency, not a designed one. Raising that threshold past ~16 km would
+/// need this tolerance revisited.
 pub const DEFAULT_GEOM_HASH_TOLERANCE: f64 = 1.0e-3;
 
 /// Floor on the quantization tolerance ([`GeometryHasher::new`] clamps any

--- a/rust/geometry/src/geom_hash.rs
+++ b/rust/geometry/src/geom_hash.rs
@@ -115,11 +115,25 @@ mod accumulate;
 ///
 /// Safety margin is narrower than the "near-origin" framing above suggests:
 /// measured `f32` ULP is 9.77e-4 m (98% of this bucket) at both 8192 m and
-/// 10 km, only just under 1 mm before crossing it at 16384 m. It stays safe
-/// only because [`LARGE_COORD_THRESHOLD_METERS`](crate::LARGE_COORD_THRESHOLD_METERS)
-/// re-centres coordinates before they reach that range — an incidental
-/// dependency, not a designed one. Raising that threshold past ~16 km would
-/// need this tolerance revisited.
+/// 10 km, only just under 1 mm before crossing it at 16384 m.
+///
+/// What it actually depends on is the **post-rebase coordinate spread** staying
+/// under ~16 km — an incidental dependency, not a designed one. RTC re-centring
+/// makes that typical but does not guarantee it, in two ways worth stating
+/// rather than implying:
+///
+///  - `rtc_offset_from_translations` takes the **median** element translation
+///    and returns `(0,0,0)` unless it exceeds
+///    [`LARGE_COORD_THRESHOLD_METERS`](crate::LARGE_COORD_THRESHOLD_METERS).
+///    A model whose bulk sits near the origin but whose outlying elements sit
+///    on a national grid is therefore not re-centred at all, and those vertices
+///    are hashed from `f32` world coordinates already past this bucket.
+///  - Even when the rebase does fire, it subtracts one offset. A model spanning
+///    more than ~32 km still leaves local coordinates beyond 16384 m.
+///
+/// So raising that threshold is not the only thing that would need this
+/// tolerance revisited; a wide-spread model reaches the same place without any
+/// constant changing.
 pub const DEFAULT_GEOM_HASH_TOLERANCE: f64 = 1.0e-3;
 
 /// Floor on the quantization tolerance ([`GeometryHasher::new`] clamps any

--- a/rust/geometry/src/geom_hash.rs
+++ b/rust/geometry/src/geom_hash.rs
@@ -117,10 +117,13 @@ mod accumulate;
 /// measured `f32` ULP is 9.77e-4 m (98% of this bucket) at both 8192 m and
 /// 10 km, only just under 1 mm before crossing it at 16384 m.
 ///
-/// What it actually depends on is the **post-rebase coordinate spread** staying
-/// under ~16 km — an incidental dependency, not a designed one. RTC re-centring
-/// makes that typical but does not guarantee it, in two ways worth stating
-/// rather than implying:
+/// What it actually depends on is the **largest absolute post-rebase
+/// coordinate** staying under ~16384 m (where the `f32` ULP crosses 1 mm) — an
+/// incidental dependency, not a designed one. Note that is a magnitude, not a
+/// span: a model centred on the origin can span ~32 km and still satisfy it,
+/// while one sitting 20 km out fails it however small it is. RTC re-centring
+/// makes the condition typical but does not guarantee it, in two ways worth
+/// stating rather than implying:
 ///
 ///  - `rtc_offset_from_translations` takes the **median** element translation
 ///    and returns `(0,0,0)` unless it exceeds
@@ -128,12 +131,14 @@ mod accumulate;
 ///    A model whose bulk sits near the origin but whose outlying elements sit
 ///    on a national grid is therefore not re-centred at all, and those vertices
 ///    are hashed from `f32` world coordinates already past this bucket.
-///  - Even when the rebase does fire, it subtracts one offset. A model spanning
-///    more than ~32 km still leaves local coordinates beyond 16384 m.
+///  - Even when the rebase does fire, the offset it subtracts is the median
+///    element translation, not the model's centre. A model is therefore not
+///    centred on it, so an outlier can still land past 16384 m even when the
+///    overall span would have fitted had the rebase been centred.
 ///
 /// So raising that threshold is not the only thing that would need this
-/// tolerance revisited; a wide-spread model reaches the same place without any
-/// constant changing.
+/// tolerance revisited; a far-flung or widely spread model reaches the same
+/// place without any constant changing.
 pub const DEFAULT_GEOM_HASH_TOLERANCE: f64 = 1.0e-3;
 
 /// Floor on the quantization tolerance ([`GeometryHasher::new`] clamps any

--- a/rust/geometry/src/router/voids/coaxial_union.rs
+++ b/rust/geometry/src/router/voids/coaxial_union.rs
@@ -329,7 +329,7 @@ impl GeometryRouter {
         // Total depth span + a tolerance for coalescing near-identical z-boundaries.
         let span_lo = fps.iter().map(|f| f.z_lo).fold(f64::INFINITY, f64::min);
         let span_hi = fps.iter().map(|f| f.z_hi).fold(f64::NEG_INFINITY, f64::max);
-        if !span_lo.is_finite() || !span_hi.is_finite() || (span_hi - span_lo) <= NORMALIZE_EPSILON {
+        if !span_lo.is_finite() || !span_hi.is_finite() || (span_hi - span_lo) <= NORMALIZE_EPSILON { // NORMALIZE_EPSILON is a 1e-12 direction-vector guard (voids/mod.rs), a no-op vs this world-scale span; inert only because z_tol's 1mm floor (below) dominates first
             return None;
         }
         let z_tol = (span_hi - span_lo) * 0.01 + 1.0e-3; // 1% of the span + 1 mm
@@ -366,7 +366,7 @@ impl GeometryRouter {
         for w in coalesced.windows(2) {
             let (slab_lo, slab_hi) = (w[0], w[1]);
             let slab_depth = slab_hi - slab_lo;
-            if slab_depth <= NORMALIZE_EPSILON {
+            if slab_depth <= NORMALIZE_EPSILON { // same world-scale-vs-direction-vector gap as above; z_tol dominates
                 continue;
             }
             let mid = 0.5 * (slab_lo + slab_hi);
@@ -630,7 +630,7 @@ fn cutter_footprint(
         z_lo = z_lo.min(s);
         z_hi = z_hi.max(s);
     }
-    if !z_lo.is_finite() || !z_hi.is_finite() || (z_hi - z_lo) <= NORMALIZE_EPSILON {
+    if !z_lo.is_finite() || !z_hi.is_finite() || (z_hi - z_lo) <= NORMALIZE_EPSILON { // same gap noted in union_many above; z_tol dominates
         return None;
     }
     for t in mesh.indices.chunks_exact(3) {
@@ -677,7 +677,7 @@ fn cutter_footprint(
         .sum();
     let area = 0.5 * cap_area_sum;
     let depth = z_hi - z_lo;
-    if area <= NORMALIZE_EPSILON || depth <= NORMALIZE_EPSILON {
+    if area <= NORMALIZE_EPSILON || depth <= NORMALIZE_EPSILON { // area/depth are world-scale too; same z_tol-dominated gap
         return None;
     }
     // PRISM RECONCILIATION: a true prism along `d` satisfies `area × depth ==

--- a/rust/geometry/src/router/voids/coaxial_union.rs
+++ b/rust/geometry/src/router/voids/coaxial_union.rs
@@ -329,7 +329,10 @@ impl GeometryRouter {
         // Total depth span + a tolerance for coalescing near-identical z-boundaries.
         let span_lo = fps.iter().map(|f| f.z_lo).fold(f64::INFINITY, f64::min);
         let span_hi = fps.iter().map(|f| f.z_hi).fold(f64::NEG_INFINITY, f64::max);
-        if !span_lo.is_finite() || !span_hi.is_finite() || (span_hi - span_lo) <= NORMALIZE_EPSILON { // NORMALIZE_EPSILON is a 1e-12 direction-vector guard (voids/mod.rs), a no-op vs this world-scale span; inert only because z_tol's 1mm floor (below) dominates first
+        // `z_tol` (computed below) is at least 1 mm; later breakpoint
+        // coalescing makes this depth check redundant for finite spans, but
+        // the finite/degenerate check itself stays explicit.
+        if !span_lo.is_finite() || !span_hi.is_finite() || (span_hi - span_lo) <= NORMALIZE_EPSILON {
             return None;
         }
         let z_tol = (span_hi - span_lo) * 0.01 + 1.0e-3; // 1% of the span + 1 mm
@@ -366,7 +369,8 @@ impl GeometryRouter {
         for w in coalesced.windows(2) {
             let (slab_lo, slab_hi) = (w[0], w[1]);
             let slab_depth = slab_hi - slab_lo;
-            if slab_depth <= NORMALIZE_EPSILON { // same world-scale-vs-direction-vector gap as above; z_tol dominates
+            // Coalesced breakpoints already differ by more than `z_tol`.
+            if slab_depth <= NORMALIZE_EPSILON {
                 continue;
             }
             let mid = 0.5 * (slab_lo + slab_hi);
@@ -630,7 +634,10 @@ fn cutter_footprint(
         z_lo = z_lo.min(s);
         z_hi = z_hi.max(s);
     }
-    if !z_lo.is_finite() || !z_hi.is_finite() || (z_hi - z_lo) <= NORMALIZE_EPSILON { // same gap noted in union_many above; z_tol dominates
+    // Reject a degenerate projected depth. `cutter_footprint` has no
+    // `z_tol` of its own — the caller applies it when it coalesces depth
+    // breakpoints across footprints.
+    if !z_lo.is_finite() || !z_hi.is_finite() || (z_hi - z_lo) <= NORMALIZE_EPSILON {
         return None;
     }
     for t in mesh.indices.chunks_exact(3) {
@@ -677,7 +684,9 @@ fn cutter_footprint(
         .sum();
     let area = 0.5 * cap_area_sum;
     let depth = z_hi - z_lo;
-    if area <= NORMALIZE_EPSILON || depth <= NORMALIZE_EPSILON { // area/depth are world-scale too; same z_tol-dominated gap
+    // `z_tol` applies only to depth. Keep the area guard separate: the
+    // 1 mm depth floor does not establish an area lower bound.
+    if area <= NORMALIZE_EPSILON || depth <= NORMALIZE_EPSILON {
         return None;
     }
     // PRISM RECONCILIATION: a true prism along `d` satisfies `area × depth ==

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -175,7 +175,9 @@
 # per-cutter prism reconciliation (area·depth ≈ |vol|) defers non-prisms; and a
 # removed-volume upper bound (Σ extended-cutter volume) rejects an over-cut before it
 # commits, while a through-cut of a host thicker than the opening is not mistaken for one.
-     704 rust/geometry/src/router/voids/coaxial_union.rs
+# +9 (#2616): doc-only comments recording the z_tol coalescing rationale at the
+# depth-guard call sites; no code change.
+     713 rust/geometry/src/router/voids/coaxial_union.rs
 # probe.rs +134: the 2D bool-path host/opening extraction — `extruded_solid_from_item`
 # (unwrap IfcMappedItem chains to a single IfcExtrudedAreaSolid + composed transform),
 # `host_extruded_solid` and `opening_extruded_solids` (single-body eligibility gates).


### PR DESCRIPTION
Documentation only — no constant, no logic, no test behaviour changes. Two places that are currently safe **by accident**, where the safety rests on an unrelated constant nobody had written down, plus one doc claim that is untrue.

Both were established by measurement while auditing the f32-precision defect family (#2594, #2598, #2600, #2604, #2611).

## 1. `geom_hash.rs` — a false calibration claim

The doc for `DEFAULT_GEOM_HASH_TOLERANCE` said it was "tuned empirically with the `tolerance_sweep` test against real revision pairs."

That test (`geom_hash_tests.rs:170`) uses a synthetic cube at `[100.0, 50.0, 25.0]`, and its own comment says it *"is the harness to extend with real revision pairs when tuning `DEFAULT_GEOM_HASH_TOLERANCE`"* — describing the real-pair calibration as future work. The doc claimed it as done. Corrected to what's actually true, without overstating in the other direction.

## 2. `geom_hash.rs` — the margin is 98% consumed, for an undocumented reason

The 1 mm tolerance **is** safe, and the module's existing reasoning (the f32 floor of local positions, ~1e-4 m near origin) is correct *for a recentred model*. But the margin is thinner than that framing suggests. Measured f32 ULP:

| magnitude | ULP | vs 1 mm bucket |
|---|---|---|
| 5 km | 4.88e-04 | under |
| 8192 m | 9.77e-04 | **98% of bucket** |
| 10 km | 9.77e-04 | **98% of bucket** |
| 16384 m | 1.95e-03 | **over** |

It stays safe only because `LARGE_COORD_THRESHOLD_METERS = 10_000.0` recentres before the crossover at 16 km, so positions become small local values again first. That's incidental, not designed. Now noted, so raising that threshold past ~16 km flags this tolerance for review instead of silently invalidating it.

Worth being explicit, since I raised the alarm on this one: I initially believed this tolerance *was* broken at a few km, from an ULP figure I'd extrapolated wrongly (overshooting 4-8×). It isn't. This PR records the real margin rather than a fix that was never needed.

## 3. `coaxial_union.rs` — four inert-but-wrong guards

Lines 332, 369, 633, 680 compare world-scale quantities — cutter span, slab depth, cross-section area — against `NORMALIZE_EPSILON = 1e-12`, which is defined in `voids/mod.rs` as a **direction-vector** zero-guard. Measured: `cutter_footprint` accepts a cutter with a one-f32-ULP extent at 300 m (3.05e-5) *and* at 1 m (5.96e-8). The guard is ineffective at any nonzero coordinate.

It produces no artifact only because `z_tol = span*0.01 + 1e-3` has a hard 1 mm floor — twelve orders of magnitude coarser — which absorbs that noise before it can earn a slab. End-to-end removed volume was byte-identical with and without such a noise cutter (`2.880021972581744`), both watertight.

No fix, because there's no demonstrable defect. But the inertness is incidental: lower or remove that floor and four sites go live. Now recorded at the point of use.

## One thing worth your call

`coaxial_union.rs` sits at **exactly** its ratchet budget (704 lines, zero slack), so the notes are fitted as trailing comments on existing lines rather than a proper comment block. That keeps the ratchet green but the first one is a long line. If you'd rather have it as a normal block above the condition, that needs a +4 allowlist bump and I'm happy to do it — I defaulted to not touching the ratchet for a docs change.

Verification: full `cargo test -p ifc-lite-geometry` green, `module_size_ratchet` all 4 tests pass. No changeset — no published behaviour change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified geometric hash precision limits at large coordinate distances, including coordinate recentering and model-size boundaries.
  - Added context for normalization thresholds, depth tolerances, breakpoint coalescing, and separate area/depth validation.

- **Chores**
  - Updated internal size and validation allowances to reflect geometry-processing guidance.

- **Refactor**
  - No runtime behavior or exported interfaces changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->