### PR TITLE
fix(release): the publish verifier could not run when publishing failed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -358,7 +358,18 @@ jobs:
   verify-npm-publish:
     name: Verify npm publish
     needs: release
-    if: needs.release.outputs.published == 'true'
+    # `always()` is the load-bearing part. A failed `needs:` skips the dependent
+    # whatever the condition says, so the job that exists to confirm packages
+    # reached npm could not run on the case it exists for: a PARTIAL publish.
+    # On 2026-08-14 nine packages went out, @ifc-lite/source-dalux 404'd, the
+    # release job failed — and this was skipped, so nothing named the missing
+    # package. It was found by hand afterwards.
+    #
+    # `published` is still the right gate: changesets/action sets it true
+    # whenever any package published, INCLUDING the partial-failure path, and
+    # false on a run that merely opened the version PR. So this now runs exactly
+    # when something was published and never on the PR-opening runs.
+    if: always() && needs.release.outputs.published == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo


### PR DESCRIPTION
Cleanup step 1 of 2 for the broken release. **This one must merge with zero pending changesets** — see the ordering note at the bottom.

## The defect

```yaml
verify-npm-publish:
  needs: release
  if: needs.release.outputs.published == 'true'   # release.yml:358-361
```

A failed `needs:` skips the dependent whatever the condition says. So the job whose entire purpose is confirming packages reached npm **could not run on a partial publish** — the one case it exists for.

That is not hypothetical. In [run 31761910461](https://github.com/LTplus-AG/ifc-lite/actions/runs/31761910461): nine packages published, `@ifc-lite/source-dalux@0.2.2` 404'd on PUT, the release job failed, and this job was skipped. `scripts/verify-npm-publish.js` never got to name the missing package — I found it by hand, comparing every workspace version against the registry.

`always()` is the fix. `published` stays the gate and is the right one: changesets/action returns `published: true` whenever any package published — **including the partial-failure path** (it sets the output and leaves failure to its caller, [run.ts](https://github.com/changesets/action/blob/a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d/src/run.ts)) — and `false` on a run that merely opens the version PR. So this now runs exactly when something published, and still never on PR-opening runs.

## What else that failure cost

Everything downstream of the failed step was skipped, not just the verifier:

| skipped | consequence |
|---|---|
| Verify npm publish | nobody named the missing package |
| Create GitHub Release + v-tag | **no `v4.5.1` tag or release** — `git tag -l "v4.5.*"` stops at v4.5.0 |
| Release Server Binary ×9 | no server binaries for this version |

## Ordering — why this PR carries no changeset

`Decide release artifacts` (release.yml:211) already backfills a missing tag: with `PENDING=0` and `published != true` it asks npm whether the package carrying the root version is really out, and creates the release if `gh release view v4.5.1` finds nothing. `@ifc-lite/wasm@4.5.1` is on npm, so a run with **no pending changesets** will backfill `v4.5.1`.

Add a changeset here and that same run opens a version PR instead, moves the root version to 4.5.2, and `v4.5.1` is stranded permanently — the gate only ever considers the current version.

So: merge this first (backfills the tag), then the follow-up adds the `@ifc-lite/source-dalux` changeset that publishes 0.2.3, closes the npm drift from #2615, and exercises the newly configured trusted publisher.
