### PR TITLE
test(geometry): pin signed_volume6's orientation sign against the #198779 flip

### DIFF
--- a/rust/geometry/src/kernel/signed_volume.rs
+++ b/rust/geometry/src/kernel/signed_volume.rs
@@ -87,3 +87,89 @@ pub(crate) fn signed_volume6(tris: &[Tri]) -> f64 {
 pub(crate) fn signed_volume_of(tris: &[Tri]) -> f64 {
     signed_volume6(tris) / 6.0
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A near-closed box with a thin sliver crack along one top edge: the
+    /// two triangles that should share vertex `p6` instead use two slightly
+    /// different copies of it, `eps` apart. The result is an OPEN surface
+    /// (not a full missing face, a genuine narrow gap), same defect shape as
+    /// #198779's flush-interface seam. `offset` places the whole box at a
+    /// given distance from the world origin without changing its own
+    /// geometry at all — same sliver, same box, only translated.
+    fn box_with_sliver_crack(offset: [f64; 3]) -> Vec<Tri> {
+        let lo = [offset[0], offset[1], offset[2]];
+        let hi = [offset[0] + 2.2, offset[1] + 2.2, offset[2] + 2.2];
+        let eps = 0.9; // sliver, comparable scale to #198779's 2.65 m crack
+        let p0 = [lo[0], lo[1], lo[2]];
+        let p1 = [hi[0], lo[1], lo[2]];
+        let p2 = [hi[0], hi[1], lo[2]];
+        let p3 = [lo[0], hi[1], lo[2]];
+        let p4 = [lo[0], lo[1], hi[2]];
+        let p5 = [hi[0], lo[1], hi[2]];
+        let p6 = [hi[0], hi[1], hi[2]];
+        // Asymmetric perturbation (NOT parallel to the offset vector below,
+        // i.e. not a scalar multiple of [1,1,1]) — a shift parallel to a
+        // uniform per-axis translation cancels out of the
+        // reference-point-dependence term entirely (t×delta = 0 when both
+        // are multiples of the same vector), which would silently make this
+        // fixture insensitive to the very regression it exists to catch.
+        // Only ONE of the two top-face triangles sees this copy, so the
+        // shared edge `(p4, p6)` no longer matches vertex-for-vertex between
+        // them: a thin open boundary, not a full missing face.
+        let p6_cracked = [hi[0] + eps, hi[1] + eps * 0.6, hi[2] + eps * 1.3];
+        let p7 = [lo[0], hi[1], hi[2]];
+        vec![
+            // bottom (closed)
+            [p0, p3, p2],
+            [p0, p2, p1],
+            // top (cracked: first tri uses p6_cracked, second uses p6)
+            [p4, p5, p6_cracked],
+            [p4, p6, p7],
+            // sides (closed)
+            [p0, p4, p7],
+            [p0, p7, p3],
+            [p1, p2, p6],
+            [p1, p6, p5],
+            [p0, p1, p5],
+            [p0, p5, p4],
+            [p3, p7, p6],
+            [p3, p6, p2],
+        ]
+    }
+
+    /// The #198779 orientation-sign regression, directly on
+    /// [`signed_volume6`]: a box carrying a thin sliver crack (open surface,
+    /// same defect shape as the flush-interface seam in #198779's tunnel
+    /// wall) must read the SAME sign whether it sits near the world origin
+    /// or hundreds of metres out — because the AABB-centre reference
+    /// co-moves with the operand, unlike a world-origin reference, whose
+    /// boundary-loop flux term grows with the distance to the reference
+    /// point and previously flipped an outward-wound operand's sign
+    /// negative purely from being far away (issue #198779's −59.8 from a
+    /// +0.30 m³ solid). The control (near the origin, where both reference
+    /// choices coincide) and the far case (translated only, same sliver)
+    /// isolate the reference-point choice as the only thing that can
+    /// explain a sign difference between them.
+    #[test]
+    fn far_from_origin_sliver_crack_does_not_flip_the_sign_198779() {
+        let near = box_with_sliver_crack([0.0, 0.0, 0.0]);
+        let far = box_with_sliver_crack([300.0, 250.0, 410.0]); // #198779's tunnel wall sat 250-410 m out
+
+        let v_near = signed_volume6(&near);
+        let v_far = signed_volume6(&far);
+
+        assert!(
+            v_near > 0.0,
+            "control (near origin) should read outward-wound positive, got {v_near}"
+        );
+        assert!(
+            v_far > 0.0,
+            "far-from-origin operand flipped sign to {v_far} (near-origin control was \
+             {v_near}): the AABB-centre reference should make the sign independent of \
+             where the operand sits, same defect shape as #198779"
+        );
+    }
+}


### PR DESCRIPTION
Adds a direct unit test pinning the **sign** of `signed_volume6`, which decides mesh orientation for every boolean in `mesh_bridge`.

## What wasn't covered, and how I checked

`signed_volume.rs` computes the divergence sum about the triangle list's **own AABB centre**, not the world origin. Its doc cites issue **#198779**: a far-from-origin tunnel wall with a sliver crack read `vol < 0` and flipped the whole host inside-out.

There is an integration test named for that issue — `tilted_flush_recess_cut_is_watertight_198779`. **It does not cover the sign.** Verified rather than assumed: hardcoding the reference point back to the world origin leaves that test *and all 12 of its siblings* passing.

The reason is instructive. That test asserts watertightness and volume magnitude of the **final, already-closed** `subtract()` result — and a closed mesh's divergence sum is translation-invariant regardless of reference point, exactly as the file's own doc says. The reference-point choice only matters on the **intermediate, possibly-open** operand mid-algorithm, which the test never inspects.

## The test

`far_from_origin_sliver_crack_does_not_flip_the_sign_198779` — a box where one top-face triangle uses a slightly displaced copy of a shared vertex, creating a genuine open boundary matching #198779's flush-interface seam. Compared near the origin (where both reference points agree) against the same shape translated `[300, 250, 410]`, matching the issue's "250–410 m out".

**RED/GREEN:** with a world-origin reference, `v_near = 66.5016` (correct, positive) and `v_far = −89.918` — the sign flip reproduced. With the actual AABB-centre reference, it passes.

One gotcha documented inline, found the hard way: a *symmetric* perturbation `[eps, eps, eps]` combined with a uniform offset `[T, T, T]` cancels to zero, because `t × delta = 0` for parallel vectors. The fixture uses an asymmetric perturbation deliberately.

## Worth knowing before you merge this

While investigating I found a **pre-existing** test that already catches this regression indirectly — `mesh_volume_is_stable_far_from_the_world_origin_for_an_open_mesh` (`kernel/mesh_volume.rs`, from #2260/#2605) fails under the same world-origin change, via `mesh_volume` → `signed_volume_of` → `signed_volume6` on an open cube.

So this file was **not** entirely unguarded, and I'd rather say that than let the PR imply otherwise. What this adds is a *direct* test at the decision point, named for the failure mode and built on the #198779 geometry class, rather than coverage that happens to fall out of a volume-stability test one layer up. If you'd rather not carry both, that's a reasonable call — the existing one does catch the regression.

## Verification

`cargo test -p ifc-lite-geometry`: 642 passed, 0 failed. `clippy --all-targets -D warnings`: clean for this crate (the four errors are pre-existing in `rust/core`'s `georef.rs` and `parser/scanner.rs`). Ratchet: 4/4, file at 175 lines. No existing test changed behaviour — additions only. No changeset; test-only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression coverage for signed-volume calculations on nearly closed shapes with thin cracks.
  * Verified consistent positive orientation results when the shape is translated to a distant location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->