### PR TITLE
test(geometry): pin point_enclosed's 2-of-3 ray vote at its boundary

### DIFF
--- a/rust/geometry/src/simplify/ray_parity.rs
+++ b/rust/geometry/src/simplify/ray_parity.rs
@@ -85,3 +85,100 @@ fn count_crossings(
     }
     Some(crossings)
 }
+
+#[cfg(test)]
+mod tests {
+    //! Direct unit tests of the `point_enclosed` vote, pinning the
+    //! `valid >= 2 && inside >= 2` rule at its boundary rather than leaving
+    //! it as incidental behaviour of whatever fixtures `cavities.rs`
+    //! happens to send through. `simplify/mod.rs`'s cavity-drop tests only
+    //! ever produce a unanimous 3-of-3 vote (deep interior sample points),
+    //! so they pass unchanged under a 1-of-3 or 3-of-3 rule too and do not
+    //! pin this threshold — verified by hand-editing the rule locally and
+    //! re-running that suite before writing these.
+    //!
+    //! All three tests fix `point = [0, 0, 0]` and `scale = 1.0`, so the
+    //! per-ray jitter origins are known exactly:
+    //! ray0 (+X) origin = (1e-7, 1.3e-7, 1.7e-7)
+    //! ray1 (+Y) origin = (2e-7, 2.6e-7, 3.4e-7)
+    //! ray2 (+Z) origin = (3e-7, 3.9e-7, 5.1e-7)
+    //! and `t_eps = 1e-9`. A "trap" triangle lies exactly on the plane
+    //! matching one ray's own jittered coordinate on its axis, so that
+    //! ray's Moller-Trumbore `t` comes out at (numerically) zero: a grazing
+    //! hit, discarded. Because a trap triangle's normal is one of the other
+    //! two axes, the other two rays run parallel to it (`det == 0`) and
+    //! never see it at all — each trap affects exactly one ray.
+    use super::point_enclosed;
+
+    const POINT: [f64; 3] = [0.0, 0.0, 0.0];
+    const SCALE: f64 = 1.0;
+
+    /// Triangle on the plane x = ray0's jittered x-coordinate: grazes only
+    /// the +X ray (t == 0), parallel to +Y and +Z (their directions lie in
+    /// the x = const plane, so `det == 0` skips them).
+    fn trap_x() -> [[f64; 3]; 3] {
+        [[1e-7, -1.0, -1.0], [1e-7, 1.0, -1.0], [1e-7, 0.0, 1.0]]
+    }
+
+    /// Triangle on the plane y = ray1's jittered y-coordinate (1.3 * 2e-7):
+    /// grazes only the +Y ray.
+    fn trap_y() -> [[f64; 3]; 3] {
+        [[-1.0, 2.6e-7, -1.0], [1.0, 2.6e-7, -1.0], [0.0, 2.6e-7, 1.0]]
+    }
+
+    /// Triangle on the plane z = ray2's jittered z-coordinate (1.7 * 3e-7):
+    /// grazes only the +Z ray.
+    fn trap_z() -> [[f64; 3]; 3] {
+        [[-1.0, -1.0, 5.1e-7], [1.0, -1.0, 5.1e-7], [0.0, 1.0, 5.1e-7]]
+    }
+
+    /// Real, non-grazing crossing far down +X: gives ray0 an odd (inside)
+    /// count. Its normal is X, so rays 1 and 2 (in-plane) never see it.
+    fn far_hit_x() -> [[f64; 3]; 3] {
+        [[10.0, -100.0, -100.0], [10.0, 100.0, -100.0], [10.0, 0.0, 100.0]]
+    }
+
+    /// Real, non-grazing crossing far down +Y: gives ray1 an odd (inside)
+    /// count. Its normal is Y, so rays 0 and 2 never see it.
+    fn far_hit_y() -> [[f64; 3]; 3] {
+        [[-100.0, 10.0, -100.0], [100.0, 10.0, -100.0], [0.0, 10.0, 100.0]]
+    }
+
+    #[test]
+    fn grazing_hit_on_every_axis_conservatively_keeps_the_point() {
+        // All three rays graze their own trap triangle (t == 0 < t_eps) and
+        // are discarded, so valid == 0. valid >= 2 fails regardless of
+        // `inside`, so the point is NOT enclosed: conservative "keep".
+        let tris = [trap_x(), trap_y(), trap_z()];
+        assert!(
+            !point_enclosed(POINT, SCALE, &tris),
+            "a point straddling grazing hits on all three axes must be kept, never dropped"
+        );
+    }
+
+    #[test]
+    fn two_agreeing_valid_rays_mark_the_point_enclosed() {
+        // Ray0 and ray1 both cross exactly once (odd -> inside) via a real
+        // hit; ray2 grazes trap_z and is discarded. valid == 2, inside == 2:
+        // the 2-of-3 majority is met and the point IS enclosed.
+        let tris = [far_hit_x(), far_hit_y(), trap_z()];
+        assert!(
+            point_enclosed(POINT, SCALE, &tris),
+            "two valid rays that agree on 'inside' must satisfy the majority vote"
+        );
+    }
+
+    #[test]
+    fn two_disagreeing_valid_rays_conservatively_keep_the_point() {
+        // Ray0 crosses once (odd -> inside) via a real hit; ray1 sees no
+        // geometry at all (zero crossings, even -> outside, but still a
+        // valid/clean ray); ray2 grazes trap_z and is discarded. valid == 2
+        // but inside == 1: the two valid rays disagree, so the vote must
+        // NOT call it enclosed, even though two rays were clean.
+        let tris = [far_hit_x(), trap_z()];
+        assert!(
+            !point_enclosed(POINT, SCALE, &tris),
+            "two valid rays that disagree must not satisfy the majority vote"
+        );
+    }
+}


### PR DESCRIPTION
Adds direct tests for `point_enclosed`'s 2-of-3 ray vote, which decides whether a cavity mesh is silently dropped from geometry output.

## The gap, verified by mutation rather than assumed

`point_enclosed` casts three jittered axis rays, discards any that graze (`count_crossings` → `None`), and calls a point enclosed only when `valid >= 2 && inside >= 2`.

The existing cavity tests (`cavity_inside_box_is_dropped_and_outer_kept_bit_identical`, `fully_enclosed_component_in_nonconvex_outer_is_dropped`, and siblings) sample points deep inside or clearly outside axis-aligned and L-prism solids, so all three rays always agree unanimously — valid=3 with inside=3 or inside=0.

Confirmed empirically: changing the rule to **1-of-3**, then to **3-of-3**, left **all 19 pre-existing tests green under both**. The vote threshold was genuinely unpinned.

## The tests

Three, calling `point_enclosed` directly with hand-built triangle sets. Each "trap" triangle sits exactly on the plane of one ray's own jittered origin coordinate, so only that ray grazes — with the other two verified provably parallel (`det == 0`) to it.

| test | scenario | fails under |
|---|---|---|
| `grazing_hit_on_every_axis_conservatively_keeps_the_point` | all 3 graze, valid=0 → keep | grazing check disabled |
| `two_agreeing_valid_rays_mark_the_point_enclosed` | valid=2, both odd → enclosed | **3-of-3** |
| `two_disagreeing_valid_rays_conservatively_keep_the_point` | valid=2, one odd one even → keep | **1-of-3** |

**Each fails under a different mutation**, which is what shows they pin the rule rather than restating one another. A test that survives every variant isn't pinning anything.

## Verification

`cargo test -p ifc-lite-geometry --lib`: 537 pass, up from 534. All mutations reverted after each proof; `git diff` confirms the rule is byte-identical to the original and only the test module is added. Code matches its doc comment exactly — no divergence found. No changeset; test-only.

Three integration failures in `wall_opening_cut_regression.rs` are the pre-existing missing-fixture skips (`ara3d/advanced_model.ifc`, needs `pnpm fixtures`), unrelated.

## Separate observation, worth a look

`cargo clippy -p ifc-lite-geometry --all-targets -- -D warnings` currently reports **~150 pre-existing errors** from a new nightly lint (`chunks_exact_to_as_chunks`, on `rustc 1.99.0-nightly 2026-08-12`), scattered across `triangulation.rs`, `router/voids/*_tests.rs` and others. None are in the files this PR touches.

Flagging because it's toolchain drift rather than anything in this change — if the Lint lane ever runs clippy with `-D warnings` on the pinned nightly, it'll go red repo-wide independently of any PR. Not fixing it here; it isn't mine and it'd bury a 97-line test diff.
