### PR TITLE
fix(ci): force bash on the release upload step so the Windows binary publishes

### DIFF
--- a/.github/workflows/server-binaries.yml
+++ b/.github/workflows/server-binaries.yml
@@ -233,6 +233,11 @@ jobs:
 
       - name: Upload to GitHub Release
         if: github.event_name == 'release'
+        # Force bash so the backslash line-continuation parses on Windows
+        # runners too (default shell there is PowerShell, which reads the
+        # bare `--clobber` continuation as the unary decrement operator →
+        # win32-x64 release upload failed with a ParserError).
+        shell: bash
         run: |
           gh release upload "${{ github.event.release.tag_name }}" \
             ifc-lite-server-${{ matrix.target }}.${{ matrix.archive }} \


### PR DESCRIPTION
Closes the packaging half of #2619: the Windows server binary builds successfully on every release and is then silently dropped.

## Evidence

From a real failing release run — [v4.4.1, run 31590565844](https://github.com/LTplus-AG/ifc-lite/actions/runs/31590565844), conclusion `failure`. The `win32-x64` job compiled fine (`Finished release profile in 10m 10s`) and archived fine, then died at the last step:

```
Run gh release upload "v4.4.1" \
  ifc-lite-server-win32-x64.zip \
  --clobber
ParserError: ...ps1:4
   4 |   --clobber
     |   ~
     | Missing expression after unary operator '--'.
```

The "Upload to GitHub Release" step had no `shell:` key, so on a Windows runner it defaults to PowerShell, which reads the bare `--clobber` continuation line as the unary decrement operator.

**This file already fixes the same bug one step earlier.** "Build Server Binary" carries `shell: bash` with the comment from #1118 — *"default shell there is PowerShell, which choked on the POSIX test → win32-x64 release build failed with a ParserError"*. It just never reached the upload step.

## The change

`shell: bash` on that one step, plus a comment matching the existing one's style so it isn't stripped later. Five lines, one file.

## Checked for a second instance

Walked every step in both jobs. `validate-server-binaries` has no upload step at all, so this is confined to `release-server-binaries`. Every other `run:` step there is action-based, Linux-only guarded, OS-guarded to skip Windows (`Create Archive (tar.gz)` never runs on win32 — that matrix entry uses `archive: zip`), or already carries an explicit `shell: pwsh`. **No second instance of "multi-line bash, no shell, runs on Windows" exists.**

## What this PR cannot demonstrate

`release-server-binaries` only fires on a published release, so **CI here proves nothing about the fix.** A green tick means the workflow file still parses, not that the upload works.

The safety argument is that the failing step's shell now matches the passing sibling step's shell for an identical syntax pattern — not that anything was executed. I'm deliberately not claiming it works, and I did not trigger a release to find out.

That untestability is also why the bug survived: nothing exercises this path until a release is cut, and when one is, the failure is one red job among five green ones and a release that still publishes.

## A separate overclaim, reported not fixed

`packages/server-bin/package.json` declares `"os": ["darwin","linux","win32"]` and `"cpu": ["x64","arm64"]`. That cross product claims **win32-arm64**, which the release matrix never builds — only `win32-x64` exists.

So even with this fix, a Windows-on-ARM user installs cleanly and then gets a 404 at first run. That needs a decision rather than a patch: add a `win32-arm64` target, or narrow the `os`/`cpu` claim. Left alone here.

No changeset — CI-only, `packages/server-bin` is untouched in this diff.
