### PR TITLE
feat(sources): gate the eager file sweep on a provider capability

### DIFF
--- a/.changeset/gate-eager-file-sweep.md
+++ b/.changeset/gate-eager-file-sweep.md
@@ -1,0 +1,13 @@
+---
+'@ifc-lite/plugin-api': minor
+'@ifc-lite/source-dalux': patch
+'@ifc-lite/source-fixture': minor
+---
+
+Gate the eager file-listing sweep on a new provider capability, `eagerFileSweep` (#2613).
+
+`fetchAllFilePages` in the viewer's source browser used to drain every page of a container's `listFiles` up front, unconditionally, for any `FileSourceProvider` — capped at 100,000 items / 5,000 pages, throwing above that. That was fine while Dalux was the only provider (its own UI has no per-folder "load more files" concept, so a full sweep matches its UX), but a provider with a real per-folder file endpoint would have blocked a folder's first render on a full drain, and risked hitting the cap outright on a large folder.
+
+`ProviderCapabilities` gains `eagerFileSweep?: boolean`, defaulting to off. Off means the viewer pages a container's files incrementally — one page loads eagerly, further pages via a new `loadMoreFiles` (mirroring the existing `loadMoreFolders`) — the same way folder listings already work. `@ifc-lite/source-dalux` sets `eagerFileSweep: true` to keep its existing full-sweep behaviour unchanged. `@ifc-lite/source-fixture`'s `createFixtureSourceProvider` gains a matching `eagerFileSweep` option (default `false`) for testing either path.
+
+No behaviour change for Dalux, the only provider in production. A future provider that leaves the capability off gets incremental file paging instead of an eager, possibly-failing sweep.

--- a/apps/viewer/src/components/sources/SourceBrowser.tsx
+++ b/apps/viewer/src/components/sources/SourceBrowser.tsx
@@ -301,10 +301,11 @@ export function SourceBrowser({ provider, ctx, onDownload, onBack, busy = false 
             setError(null);
             catalog.loadMoreFolders(selectedContainerId);
           }}
-          filesHaveMore={search.active && search.hasMore}
+          filesHaveMore={search.active ? search.hasMore : catalog.hasMoreFiles(selectedContainerId)}
           onLoadMoreFiles={() => {
             setError(null);
             if (search.active) search.loadMore();
+            else catalog.loadMoreFiles(selectedContainerId);
           }}
           loadingMore={catalog.loadingMore || search.loadingMore}
           searchEnabled={capabilities.search && provider.searchFiles !== undefined}

--- a/apps/viewer/src/components/sources/useSourceCatalogSync.test.tsx
+++ b/apps/viewer/src/components/sources/useSourceCatalogSync.test.tsx
@@ -273,3 +273,140 @@ describe('useSourceCatalogSync -- cached-catalog path (#1976)', () => {
     assert.deepEqual(harness.get().folders.map((f) => f.id), ['folder-1']);
   });
 });
+
+/**
+ * Coverage for #2613: gating the eager file sweep on `capabilities.eagerFileSweep`.
+ *
+ * `eagerFileSweep` defaults to off, so a provider that doesn't set it gets
+ * ordinary incremental file paging (one page eagerly, `loadMoreFiles` for the
+ * rest) -- the same shape folders already have via `loadMoreFolders`. Only a
+ * provider that opts in (Dalux, in production) keeps the full up-front drain.
+ *
+ * `PagedFileProvider` serves `pages` of files in order, one page per call,
+ * threading the cursor exactly like `sourceCatalogPaging.test.ts`'s
+ * `providerOf` helper -- so a bug that stops paginating after the first call
+ * (undetected by a single-page fixture) or that fetches every page
+ * regardless of the capability (undetected by a fixture with only one page)
+ * would both be caught.
+ */
+function pagedManifest(eagerFileSweep: boolean | undefined): PluginManifest {
+  return manifest({
+    containerListing: 'direct-children',
+    listFilesIsRecursive: false,
+    ...(eagerFileSweep !== undefined ? { eagerFileSweep } : {}),
+  });
+}
+
+class PagedFileProvider implements FileSourceProvider {
+  readonly manifest: PluginManifest;
+  listFilesCalls: Array<string | undefined> = [];
+  readonly containers: readonly SourceContainer[] = [];
+
+  constructor(
+    private readonly pages: readonly SourceFile[][],
+    eagerFileSweep: boolean | undefined,
+  ) {
+    this.manifest = pagedManifest(eagerFileSweep);
+  }
+
+  async listProjects(): Promise<Page<SourceProject>> {
+    return { items: [] };
+  }
+
+  async listContainers(): Promise<Page<SourceContainer>> {
+    return { items: this.containers };
+  }
+
+  async listFiles(
+    _ctx: PluginContext,
+    _projectId: string,
+    _containerId: string,
+    _filter: unknown,
+    options?: ListOptions,
+  ): Promise<Page<SourceFile>> {
+    const cursor = options?.cursor;
+    this.listFilesCalls.push(cursor);
+    const idx = cursor === undefined ? 0 : Number(cursor);
+    const isLast = idx >= this.pages.length - 1;
+    return { items: this.pages[idx] ?? [], cursor: isLast ? undefined : String(idx + 1) };
+  }
+
+  download(): Promise<ArrayBuffer> {
+    return Promise.reject(new Error('not exercised'));
+  }
+}
+
+function fileOf(id: string): SourceFile {
+  return { id, name: `${id}.ifc`, containerId: 'area-1', currentRevisionId: `${id}-rev`, sizeBytes: 1 };
+}
+
+describe('useSourceCatalogSync -- eagerFileSweep gate (#2613)', () => {
+  beforeEach(() => {
+    for (const { root, container } of mounted.splice(0)) {
+      act(() => { root.unmount(); });
+      container.remove();
+    }
+    localStorageMock.clear();
+  });
+
+  it('Dalux-shaped provider (eagerFileSweep: true) still drains every page up front, unchanged', async () => {
+    const pages = [[fileOf('a')], [fileOf('b')], [fileOf('c')]];
+    const provider = new PagedFileProvider(pages, true);
+    const harness = renderCatalogSync(provider);
+
+    await act(async () => {
+      harness.get().openFileArea('project-1', 'area-1');
+    });
+
+    // The sweep must have followed every cursor in one go, with nothing left
+    // to page manually -- this is the "must not change at all" contract.
+    assert.deepEqual(provider.listFilesCalls, [undefined, '1', '2'], 'every page must be fetched eagerly');
+    assert.deepEqual(harness.get().allFiles.map((f) => f.id), ['a', 'b', 'c']);
+    assert.equal(harness.get().hasMoreFiles(null), false, 'a fully-swept catalog has nothing left to load more of');
+  });
+
+  it('a provider without eagerFileSweep gets only the first page, and loadMoreFiles fetches the next', async () => {
+    const pages = [[fileOf('a')], [fileOf('b')], [fileOf('c')]];
+    const provider = new PagedFileProvider(pages, undefined);
+    const harness = renderCatalogSync(provider);
+
+    await act(async () => {
+      harness.get().openFileArea('project-1', 'area-1');
+    });
+
+    assert.deepEqual(provider.listFilesCalls, [undefined], 'only the first page should be fetched up front');
+    assert.deepEqual(harness.get().allFiles.map((f) => f.id), ['a']);
+    assert.equal(harness.get().hasMoreFiles(null), true, 'a cursor is outstanding after the first page');
+
+    await act(async () => {
+      harness.get().loadMoreFiles(null);
+    });
+    await act(async () => {}); // flush the async loadMoreFiles body
+
+    assert.deepEqual(provider.listFilesCalls, [undefined, '1'], 'loadMoreFiles must thread the prior cursor');
+    assert.deepEqual(harness.get().allFiles.map((f) => f.id), ['a', 'b']);
+    assert.equal(harness.get().hasMoreFiles(null), true, 'one more page remains');
+
+    await act(async () => {
+      harness.get().loadMoreFiles(null);
+    });
+    await act(async () => {});
+
+    assert.deepEqual(provider.listFilesCalls, [undefined, '1', '2']);
+    assert.deepEqual(harness.get().allFiles.map((f) => f.id), ['a', 'b', 'c']);
+    assert.equal(harness.get().hasMoreFiles(null), false, 'the last page has no cursor');
+  });
+
+  it('explicitly setting eagerFileSweep: false behaves the same as omitting it', async () => {
+    const pages = [[fileOf('a')], [fileOf('b')]];
+    const provider = new PagedFileProvider(pages, false);
+    const harness = renderCatalogSync(provider);
+
+    await act(async () => {
+      harness.get().openFileArea('project-1', 'area-1');
+    });
+
+    assert.deepEqual(provider.listFilesCalls, [undefined]);
+    assert.equal(harness.get().hasMoreFiles(null), true);
+  });
+});

--- a/apps/viewer/src/components/sources/useSourceCatalogSync.ts
+++ b/apps/viewer/src/components/sources/useSourceCatalogSync.ts
@@ -6,7 +6,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { FileSourceProvider, PluginContext, SourceContainer, SourceFile } from '@ifc-lite/plugin-api';
 import { toast } from '@/components/ui/toast';
 import { isCatalogCacheable, persistCompleteCatalog, readCachedCatalog } from './sourceCatalogCache';
-import { appendPage, fetchAllFilePages, fetchContainerPage, type PagedItems } from './sourceCatalogPaging';
+import { appendPage, fetchAllFilePages, fetchContainerPage, fetchFilePage, type PagedItems } from './sourceCatalogPaging';
 import {
   collectUniqueById,
   isCatalogComplete,
@@ -32,12 +32,16 @@ interface UseSourceCatalogSyncOptions {
  *   entering a folder fetches its children on demand.
  * - `listFilesIsRecursive` — files are fetched once per area and filtered
  *   client-side per folder; otherwise entering a folder fetches its files.
+ * - `eagerFileSweep` — file listings are swept in full up front, the same way
+ *   Dalux always has been (no source exposes "load more files" as a real user
+ *   concept in its own UI; see `fetchAllFilePages`). Off by default: file
+ *   listings are cursor-paged exactly like folders, first page eager, further
+ *   pages on demand via `loadMoreFiles`.
  *
  * Folder listings are cursor-paged: the first page loads eagerly, further
  * pages on demand via `loadMoreFolders` (never an eager drain, never a silent
- * truncation). File listings are swept in full up front instead — no source
- * (currently just Dalux) exposes "load more files" as a real user concept in
- * its own UI, so there's nothing to page manually; see `fetchAllFilePages`.
+ * truncation). File listings follow the same pattern unless `eagerFileSweep`
+ * opts a provider into the full up-front drain instead.
  * Fully-fetched flat-subtree catalogs are cached in localStorage; partial or
  * per-folder catalogs stay in memory only.
  *
@@ -46,7 +50,7 @@ interface UseSourceCatalogSyncOptions {
  * what remains here is the request lifecycle (generations, aborts, flags).
  */
 export function useSourceCatalogSync({ provider, ctx, setError, onSynced }: UseSourceCatalogSyncOptions) {
-  const { containerListing, listFilesIsRecursive } = provider.manifest.capabilities;
+  const { containerListing, listFilesIsRecursive, eagerFileSweep } = provider.manifest.capabilities;
   const flatSubtree = containerListing === 'flat-subtree';
   const cacheable = isCatalogCacheable(provider.manifest.capabilities);
   const providerName = provider.manifest.name;
@@ -102,8 +106,10 @@ export function useSourceCatalogSync({ provider, ctx, setError, onSynced }: UseS
 
   const fetchFiles = useCallback(
     (projectId: string, containerId: string, signal: AbortSignal) =>
-      fetchAllFilePages(provider, ctx, projectId, containerId, signal),
-    [ctx, provider],
+      eagerFileSweep
+        ? fetchAllFilePages(provider, ctx, projectId, containerId, signal)
+        : fetchFilePage(provider, ctx, projectId, containerId, undefined, signal),
+    [ctx, eagerFileSweep, provider],
   );
 
   const maybePersist = useCallback(
@@ -309,6 +315,48 @@ export function useSourceCatalogSync({ provider, ctx, setError, onSynced }: UseS
     [containersByParent, fetchContainers, filesByContainer, folderKeyFor, loadingMore, maybePersist, setError],
   );
 
+  /** The map key holding files for the current selection. */
+  const fileKeyFor = useCallback(
+    (selectedContainerId: string | null) =>
+      resolveCatalogKey(areaRef.current, selectedContainerId, listFilesIsRecursive),
+    [listFilesIsRecursive],
+  );
+
+  const hasMoreFiles = useCallback(
+    (selectedContainerId: string | null) => pageHasMore(filesByContainer, fileKeyFor(selectedContainerId)),
+    [filesByContainer, fileKeyFor],
+  );
+
+  const loadMoreFiles = useCallback(
+    (selectedContainerId: string | null) => {
+      const area = areaRef.current;
+      const key = fileKeyFor(selectedContainerId);
+      if (!area || key === null || loadingMore) return;
+      const current = filesByContainer.get(key);
+      if (current?.cursor === undefined) return;
+
+      const gen = requestGenRef.current;
+      const signal = abortRef.current?.signal ?? new AbortController().signal;
+      setLoadingMore(true);
+      void (async () => {
+        try {
+          const page = await fetchFilePage(provider, ctx, area.projectId, key, current.cursor, signal);
+          if (requestGenRef.current !== gen) return;
+          const next = new Map(filesByContainer).set(key, appendPage(current, page));
+          setFilesByContainer(next);
+          maybePersist(area.projectId, area.fileAreaId, containersByParent, next);
+        } catch (err) {
+          if (requestGenRef.current === gen && !(err instanceof DOMException && err.name === 'AbortError')) {
+            setError(err instanceof Error ? err.message : String(err));
+          }
+        } finally {
+          if (requestGenRef.current === gen) setLoadingMore(false);
+        }
+      })();
+    },
+    [containersByParent, ctx, fileKeyFor, filesByContainer, loadingMore, maybePersist, provider, setError],
+  );
+
   const resetCatalog = useCallback(() => {
     // Same gap as openFileArea above: null the ref after aborting so a later
     // on-demand fetch (openContainer, loadMore*) does not inherit an
@@ -343,5 +391,7 @@ export function useSourceCatalogSync({ provider, ctx, setError, onSynced }: UseS
     resetCatalog,
     hasMoreFolders,
     loadMoreFolders,
+    hasMoreFiles,
+    loadMoreFiles,
   };
 }

--- a/packages/plugin-api/src/types.ts
+++ b/packages/plugin-api/src/types.ts
@@ -138,6 +138,27 @@ export interface ProviderCapabilities {
    * paste-a-URL affordance instead of presenting a list as complete.
    */
   readonly projectsAreDiscoverableOnly?: boolean;
+  /**
+   * Whether the host should eagerly drain every page of a container's file
+   * listing up front, rather than loading one page at a time with an
+   * explicit "load more" (the same incremental pattern already used for
+   * folders — see `containerListing`).
+   *
+   * Defaults to `false` (off) when omitted, so a provider that does not set
+   * this gets ordinary incremental file paging. Set `true` only when the
+   * provider's own UI has no per-folder "load more files" concept — Dalux is
+   * the reference case: its UI always shows a folder's files as one complete
+   * set, with no paginated affordance to partially match, so partial paging
+   * in the host would be inventing UX the provider itself doesn't have.
+   *
+   * A provider with a genuine per-folder file endpoint (the expected case for
+   * anything landing after Dalux — Graph-backed stores included) should leave
+   * this off: incremental paging avoids blocking a folder's first render on a
+   * full drain, and avoids the sweep's bounded-but-real cap on very large
+   * folders (`MAX_FILE_SWEEP_ITEMS` / `MAX_FILE_SWEEP_PAGES` in
+   * `apps/viewer/src/components/sources/sourceCatalogPaging.ts`).
+   */
+  readonly eagerFileSweep?: boolean;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/source-dalux/src/manifest.ts
+++ b/packages/source-dalux/src/manifest.ts
@@ -35,6 +35,12 @@ export const DALUX_MANIFEST: PluginManifest = {
     // A file-area-level `listFiles` call returns every descendant file,
     // not just the ones directly in the area's root.
     listFilesIsRecursive: true,
+    // Dalux's own UI has no per-folder "load more files" concept — it always
+    // shows a folder's files as one complete set — so incremental paging in
+    // the host would invent UX Dalux itself doesn't have. Keep the eager
+    // sweep for this provider only; see `eagerFileSweep`'s doc comment in
+    // `@ifc-lite/plugin-api` for why new providers should default off.
+    eagerFileSweep: true,
     // No endpoint returns revision history for a file — only "fetch this
     // exact revision's content" if you already have its id.
     revisionHistory: false,

--- a/packages/source-dalux/test/provider.test.ts
+++ b/packages/source-dalux/test/provider.test.ts
@@ -80,6 +80,10 @@ describe('DaluxBuildProvider', () => {
       downloadHistoricalRevisions: true,
       changeDetection: true,
       search: false,
+      // #2613: Dalux opts into the eager file sweep -- its own UI has no
+      // per-folder "load more files" concept, so the host must keep draining
+      // a folder's file listing in full rather than paging it incrementally.
+      eagerFileSweep: true,
     });
   });
 

--- a/packages/source-fixture/src/provider.ts
+++ b/packages/source-fixture/src/provider.ts
@@ -57,6 +57,8 @@ export interface FixtureProviderOptions {
   readonly containerListing?: 'direct-children' | 'flat-subtree';
   /** Default `false`. */
   readonly listFilesIsRecursive?: boolean;
+  /** Default `false`. */
+  readonly eagerFileSweep?: boolean;
   /** Server-side page size cap, matching a real provider's own clamp. Default `25`. */
   readonly pageSize?: number;
   /** Default `'preferences'`. */
@@ -97,6 +99,7 @@ export function createFixtureSourceProvider(options: FixtureProviderOptions): Fi
     ...(options.capabilities?.projectsAreDiscoverableOnly !== undefined
       ? { projectsAreDiscoverableOnly: options.capabilities.projectsAreDiscoverableOnly }
       : {}),
+    ...(options.eagerFileSweep !== undefined ? { eagerFileSweep: options.eagerFileSweep } : {}),
   };
 
   const manifest = buildFixtureManifest({


### PR DESCRIPTION
Closes #2613. Gates the eager file sweep on a new provider capability, so a provider with a real per-folder endpoint pages incrementally instead of draining a folder's entire listing before rendering anything.

## Why now

The sweep (`sourceCatalogPaging.ts:86-126`) drains every page of a container's `listFiles`, capped at 100,000 items / 5,000 pages and **throwing** above that. Dalux needs it — its manifest sets `listFilesIsRecursive: true` because a file-area call returns every descendant, and its UI has no "load more files" concept.

But it runs unconditionally, for every provider. A `direct-children` provider registering today inherits the blocking drain, and on a large document library hits the ceiling and fails outright rather than merely being slow. With `@ifc-lite/source-msgraph` named in `registered-providers.ts` as "follows in its own PR", that's imminent.

No existing flag covered this: `listFilesIsRecursive` decides *how often* `listFiles` is called, not *how* its pages are drained.

## The change

`ProviderCapabilities.eagerFileSweep?: boolean`, **default off** — omit it and you get incremental paging. Dalux opts in with a rationale comment.

It follows the pattern already in the file rather than inventing one: containers do exactly this split via `fetchContainerPage` + `loadMoreFolders`, so `fileKeyFor` / `hasMoreFiles` / `loadMoreFiles` mirror that trio. `SourceBrowser.tsx` now wires `onLoadMoreFiles` for the browse path, not just search.

Two things needed no change, which is a good sign for the seam: `SourceFolderStep.tsx` already accepted generic `filesHaveMore`/`onLoadMoreFiles` props, and `sourceCatalogCache.ts`'s helpers are already generic over `PagedItems`, so the files path reuses them exactly as folders do.

## Dalux must not change — proven, not asserted

Dalux is the only provider in production, so it's the only thing that can regress. New test: *"Dalux-shaped provider (eagerFileSweep: true) still drains every page up front, unchanged"* — asserts all three pages fetched (`[undefined, '1', '2']`) in one `openFileArea`, all items present, `hasMoreFiles` false.

New-path tests: flag off gets page 1 only with `hasMoreFiles` true, then `loadMoreFiles` threads the cursor through pages 2 and 3; plus one confirming explicit `false` behaves like omitted.

## One test updated, deliberately

`packages/source-dalux/test/provider.test.ts` has an exhaustive `toEqual` on the manifest's capabilities, so adding a field to that manifest necessarily changes it. That's the declared shape changing as intended, not a behaviour regression — flagging it explicitly since updating a test to accommodate one's own change is normally the thing to stop and ask about.

## Verification

`pnpm build` 43/43; `pnpm typecheck` 77/77 tasks across 1084 files; `apps/viewer` full suite 4220 pass / 0 fail; `source-dalux` 146 pass; `source-fixture` 192 pass; `plugin-api` 46 pass. No exported names changed — only a field on an existing interface — so `check-api-surface` passes against the current snapshot with no regeneration.

Changeset: `plugin-api` minor, `source-dalux` patch, `source-fixture` minor.

## Sequencing note

If a second provider is coming, this is arguably a prerequisite rather than follow-up: registering one before the gate exists means it ships slow on day one and fails on large folders, then needs fixing anyway.
