### PR TITLE
tooling: pnpm check:generated — catch stale generated files before pushing

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "check:bim-globals": "pnpm turbo build --filter=@ifc-lite/sandbox && node scripts/generate-bim-globals.mjs --check",
     "verify:epsg": "pnpm --filter @ifc-lite/data verify:epsg",
     "generate:epsg-index": "tsx scripts/generate-epsg-index.ts",
-    "check:templates": "pnpm --filter=@ifc-lite/viewer --fail-if-no-match check:templates"
+    "check:templates": "pnpm --filter=@ifc-lite/viewer --fail-if-no-match check:templates",
+    "check:generated": "node scripts/check-generated.mjs"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.7.0",

--- a/scripts/check-generated.mjs
+++ b/scripts/check-generated.mjs
@@ -14,19 +14,49 @@
  * test signal (this has happened on real PRs — see the PR description for
  * this change). Running the same gates before pushing catches it for free.
  *
- * Coverage — the five freshness gates in .github/workflows/test.yml:
- *   1. check:bim-globals        (node-tests, before `pnpm test`)
- *   2. check:api-surface        (node-tests, before `pnpm test`)
+ * Coverage was originally claimed as "the five freshness gates in
+ * .github/workflows/test.yml" — that claim was wrong. PR #2632 (a brand-new
+ * package, @ifc-lite/oauth-pkce) hit two more generated/baseline gates this
+ * script didn't run — `generate-docs-sections.mjs --check` (node-tests) and
+ * `check-unused-locals.mjs` (Lint) — and both fast-failed CI with zero test
+ * signal, exactly the failure mode this script exists to catch locally. The
+ * list below is re-derived from scratch against every step in the
+ * `build` / `lint` / `node-tests` jobs, not assumed:
+ *   1. check:bim-globals         (node-tests, before `pnpm test`)
+ *   2. check:api-surface         (node-tests, before `pnpm test`)
  *   3. check:server-attr-indices (node-tests, before `pnpm test`)
- *   4. plato clash-math freshness (plato-check job)          -- INFO only, see below
- *   5. committed wasm .d.ts vs Rust source (build job)        -- INFO only, see below
+ *   4. generate-docs-sections.mjs --check (node-tests, before `pnpm test`)
+ *   5. check-unused-locals.mjs   (lint job)
+ *   6. plato clash-math freshness (plato-check job)          -- INFO only, see below
+ *   7. committed wasm .d.ts vs Rust source (build job)        -- INFO only, see below
  *
- * (1)-(3) each need only a single-package `turbo build` (bim-globals ->
- * @ifc-lite/sandbox, server-attr-indices -> @ifc-lite/parser) or an
- * already-built `dist/` (api-surface, across all published packages) and run
- * in low tens of seconds, so they run unconditionally here.
+ * Steps deliberately NOT treated as a generated-artifact gate here, and why:
+ *   - `pnpm fixtures:check` (build job) compares downloaded test-fixture
+ *     checksums against tests/models/manifest.json. Not derived from repo
+ *     source — there's nothing in this repo to regenerate it from — and it
+ *     needs the ~1GB fixture set on disk. Wrong shape for a pre-push script.
+ *   - `check-changesets.mjs`, `check-lint-ran.mjs`, `check-test-wiring.mjs`,
+ *     `check-package-readmes.mjs` (docs/), `check-doc-samples.mjs` (docs/):
+ *     structural/policy checks (a script ran, a file exists, a changeset
+ *     names a real package) — nothing generated, nothing to regenerate.
+ *   - `check-source-text-assertions.mjs` and `check-wasm-disposal.mjs`
+ *     (node-tests): ratchets against an allowlist, but the allowlist is
+ *     hand-maintained (no `--update` / generator) — a violation means "don't
+ *     add that pattern", not "stale file, regenerate it". No fix command to
+ *     offer, so out of scope for this script.
+ *   - `check-unbounded-frame-wait.mjs` (node-tests): scans for an absent
+ *     pattern, no baseline file at all.
+ *   - `pnpm --filter=@ifc-lite/viewer check:templates` (node-tests):
+ *     typechecks against bim-globals.d.ts (gate 1's output) but doesn't
+ *     itself compare a generated artifact — covered transitively by gate 1.
  *
- * (4) and (5) are deliberately NOT run by default:
+ * (1)-(5) each need only a single-package `turbo build` (bim-globals ->
+ * @ifc-lite/sandbox, server-attr-indices -> @ifc-lite/parser), an
+ * already-built `dist/` across all published packages (api-surface,
+ * unused-locals), or nothing at all (docs-sections), and run in well under
+ * two minutes total, so they run unconditionally here.
+ *
+ * (6) and (7) are deliberately NOT run by default:
  *   - Plato clones `plato` + `ara3d-sdk` at pinned SHAs and does a `dotnet
  *     build` of Plato.CLI (needs the .NET 9 SDK) on first run. Minutes, plus
  *     a toolchain most contributors don't have installed.
@@ -144,7 +174,7 @@ if (BUILD_FIRST) {
     run('pnpm', ['build']);
     console.log('✅ pnpm build succeeded');
   } catch (e) {
-    console.log('❌ pnpm build failed — cannot evaluate check:api-surface reliably.');
+    console.log('❌ pnpm build failed — cannot evaluate check:api-surface / check-unused-locals reliably.');
     console.log((e.stdout || e.stderr || e.message).toString().trim().replace(/^/gm, '   '));
   }
 }
@@ -165,7 +195,47 @@ runGate(
   'pnpm generate:server-attr-indices   (then `cargo fmt -p ifc-lite-server` and commit attr_indices.rs)',
 );
 
-// 3. API surface — needs the FULL workspace dist/, which this script does
+// 3. Generated doc sections (docs/api/typescript.md package index,
+// docs/guide/cli.md, docs/guide/performance.md, apps/landing/app.jsx) — no
+// build needed, reads package.json/source directly. Fast (well under a
+// second). This is the gate PR #2632 actually hit: a new package's row was
+// missing from the package-index region.
+runGate(
+  'docs:check-generated',
+  'pnpm',
+  ['run', 'docs:check-generated'],
+  'pnpm docs:generate   (then commit the regenerated doc file(s))',
+);
+
+// 4. Unused-locals baseline (scripts/unused-locals-baseline.json) — a
+// package added but never `pnpm lint:baseline`-d silently has no ratchet at
+// all (this is the OTHER gate PR #2632 hit). Like api-surface, this
+// type-checks every package against its siblings' BUILT dist/ types, so it
+// shares the same "needs dist/" precondition — reuse allDistBuilt() below.
+if (!BUILD_FIRST && !allDistBuilt()) {
+  record(
+    'check-unused-locals',
+    'skip',
+    'No packages/*/dist found — nothing built yet, so this gate has nothing to\n' +
+      'type-check siblings against. This is a SKIP, not a pass.',
+    'pnpm build && node scripts/check-unused-locals.mjs   (or re-run this script with --build)',
+  );
+} else {
+  runGate(
+    'check-unused-locals',
+    'node',
+    ['scripts/check-unused-locals.mjs'],
+    'pnpm lint:baseline   (then commit scripts/unused-locals-baseline.json)',
+  );
+  if (!BUILD_FIRST) {
+    console.log(
+      '   note: ran against whatever dist/ was already on disk (no rebuild) — same\n' +
+        '   caveat as check:api-surface above. Re-run with --build for a from-scratch answer.',
+    );
+  }
+}
+
+// 5. API surface — needs the FULL workspace dist/, which this script does
 // not build by default (see header comment).
 if (!BUILD_FIRST && !allDistBuilt()) {
   record(
@@ -191,7 +261,7 @@ if (!BUILD_FIRST && !allDistBuilt()) {
   }
 }
 
-// 4. Plato clash-math freshness — INFO by default; needs .NET SDK + network.
+// 6. Plato clash-math freshness — INFO by default; needs .NET SDK + network.
 if (FULL) {
   if (which('dotnet')) {
     runGate(
@@ -219,7 +289,7 @@ if (FULL) {
   );
 }
 
-// 5. Committed wasm .d.ts vs Rust source — INFO by default; needs a wasm rebuild.
+// 7. Committed wasm .d.ts vs Rust source — INFO by default; needs a wasm rebuild.
 if (FULL) {
   if (which('wasm-pack') && which('cargo')) {
     hr();

--- a/scripts/check-generated.mjs
+++ b/scripts/check-generated.mjs
@@ -1,0 +1,290 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Run every generated-file freshness gate locally, in one command, and
+ * report ALL failures instead of stopping at the first.
+ *
+ * Why this exists: `check-api-surface.mjs` and `generate-bim-globals.mjs
+ * --check` run inside the `node-tests` CI job BEFORE `pnpm test`, so a stale
+ * generated file fails the job immediately and the whole test suite never
+ * runs. The PR looks fine locally, then fails in CI minutes later with zero
+ * test signal (this has happened on real PRs — see the PR description for
+ * this change). Running the same gates before pushing catches it for free.
+ *
+ * Coverage — the five freshness gates in .github/workflows/test.yml:
+ *   1. check:bim-globals        (node-tests, before `pnpm test`)
+ *   2. check:api-surface        (node-tests, before `pnpm test`)
+ *   3. check:server-attr-indices (node-tests, before `pnpm test`)
+ *   4. plato clash-math freshness (plato-check job)          -- INFO only, see below
+ *   5. committed wasm .d.ts vs Rust source (build job)        -- INFO only, see below
+ *
+ * (1)-(3) each need only a single-package `turbo build` (bim-globals ->
+ * @ifc-lite/sandbox, server-attr-indices -> @ifc-lite/parser) or an
+ * already-built `dist/` (api-surface, across all published packages) and run
+ * in low tens of seconds, so they run unconditionally here.
+ *
+ * (4) and (5) are deliberately NOT run by default:
+ *   - Plato clones `plato` + `ara3d-sdk` at pinned SHAs and does a `dotnet
+ *     build` of Plato.CLI (needs the .NET 9 SDK) on first run. Minutes, plus
+ *     a toolchain most contributors don't have installed.
+ *   - The wasm gate needs a full wasm32 Rust rebuild (`bash
+ *     scripts/build-wasm.sh`), which is minutes even warm and needs the Rust
+ *     + wasm-pack toolchain.
+ *   A check that slow would not get run before every push, which defeats the
+ *   point (see the CLAUDE.md guidance this script was written against). So
+ *   both print a reminder with the exact command instead of running it; pass
+ *   `--full` to actually run them (only if the required toolchain is on
+ *   PATH — otherwise this prints what's missing rather than pretending to
+ *   pass).
+ *
+ * The api-surface gate reads BUILT `dist/*.d.ts` files. This script does NOT
+ * run `pnpm build` first (that's the slow part — minutes, for the whole
+ * workspace) — it uses whatever `dist/` is already on disk. If no package has
+ * been built yet, that gate is SKIPPED with an explicit message rather than
+ * failing (an unbuilt tree isn't "stale", it's just unbuilt). If `dist/` IS
+ * present but older than the source that produced it, this can pass locally
+ * and still fail in CI (CI always builds fresh) — that's a known, stated
+ * limitation, not a silent gap. Pass `--build` to force a fresh `pnpm build`
+ * first and close that gap when you want certainty.
+ *
+ * Usage:
+ *   pnpm check:generated          # fast gates only (~seconds, if dist/ exists)
+ *   pnpm check:generated --build  # + `pnpm build` first, so api-surface is certain
+ *   pnpm check:generated --full   # + actually run plato/wasm gates (needs their toolchains)
+ *
+ * Exit code: non-zero if any gate FAILS. INFO/SKIP notices never fail the run.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const BUILD_FIRST = process.argv.includes('--build');
+const FULL = process.argv.includes('--full');
+
+const results = [];
+
+function hr() {
+  console.log('─'.repeat(72));
+}
+
+function run(cmd, args, opts = {}) {
+  return execFileSync(cmd, args, { cwd: ROOT, stdio: 'pipe', encoding: 'utf8', ...opts });
+}
+
+function which(bin) {
+  try {
+    execFileSync(process.platform === 'win32' ? 'where' : 'which', [bin], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * True when EVERY published (non-private) packages/* has a dist/ directory.
+ * A partial build (e.g. just @ifc-lite/sandbox, from check:bim-globals above)
+ * still leaves check:api-surface unable to resolve most packages' entry
+ * points — that's "not built yet", not "stale", and check-api-surface.mjs's
+ * own "declaration entry is missing" branch is the authority on which
+ * packages it needs; this is only a cheap pre-check to avoid printing that
+ * whole wall of missing-entry names on an unbuilt tree.
+ */
+function allDistBuilt() {
+  const pkgDir = join(ROOT, 'packages');
+  if (!existsSync(pkgDir)) return false;
+  return readdirSync(pkgDir).every((d) => {
+    const pkgJson = join(pkgDir, d, 'package.json');
+    if (!existsSync(pkgJson)) return true; // not a package dir
+    let pkg;
+    try {
+      pkg = JSON.parse(readFileSync(pkgJson, 'utf8'));
+    } catch {
+      return true;
+    }
+    if (pkg.private === true) return true;
+    // @ifc-lite/wasm ships from a committed pkg/ dir, not a built dist/ —
+    // its declarations are always "built" (see check-api-surface.mjs).
+    return existsSync(join(pkgDir, d, 'dist')) || existsSync(join(pkgDir, d, 'pkg'));
+  });
+}
+
+function record(name, status, detail, fix) {
+  results.push({ name, status, detail, fix });
+  const icon = { pass: '✅', fail: '❌', skip: '⏭️ ', info: 'ℹ️ ' }[status];
+  console.log(`${icon} ${name}: ${status.toUpperCase()}`);
+  if (detail) console.log(detail.trim().replace(/^/gm, '   '));
+  if (fix) console.log(`   fix: ${fix}`);
+}
+
+function runGate(name, cmd, args, fix) {
+  hr();
+  console.log(`Running ${name}: ${[cmd, ...args].join(' ')}`);
+  try {
+    run(cmd, args);
+    record(name, 'pass', null, null);
+  } catch (e) {
+    const output = [e.stdout, e.stderr].filter(Boolean).join('\n');
+    record(name, 'fail', output || e.message, fix);
+  }
+}
+
+hr();
+console.log('ifc-lite: checking every generated-file freshness gate');
+hr();
+
+if (BUILD_FIRST) {
+  console.log('--build: running `pnpm build` first (this is the slow part)…');
+  try {
+    run('pnpm', ['build']);
+    console.log('✅ pnpm build succeeded');
+  } catch (e) {
+    console.log('❌ pnpm build failed — cannot evaluate check:api-surface reliably.');
+    console.log((e.stdout || e.stderr || e.message).toString().trim().replace(/^/gm, '   '));
+  }
+}
+
+// 1. Sandbox ambient types (bim-globals.d.ts) — single-package build, fast.
+runGate(
+  'check:bim-globals',
+  'pnpm',
+  ['run', 'check:bim-globals'],
+  'pnpm generate:bim-globals   (then commit apps/viewer/src/lib/scripts/templates/bim-globals.d.ts)',
+);
+
+// 2. Server attr-indices — single-package build, fast.
+runGate(
+  'check:server-attr-indices',
+  'pnpm',
+  ['run', 'check:server-attr-indices'],
+  'pnpm generate:server-attr-indices   (then `cargo fmt -p ifc-lite-server` and commit attr_indices.rs)',
+);
+
+// 3. API surface — needs the FULL workspace dist/, which this script does
+// not build by default (see header comment).
+if (!BUILD_FIRST && !allDistBuilt()) {
+  record(
+    'check:api-surface',
+    'skip',
+    'No packages/*/dist found — nothing built yet, so this gate has nothing to read.\n' +
+      'This is a SKIP, not a pass: it proves nothing about whether the snapshot is stale.',
+    'pnpm build && pnpm check:api-surface   (or re-run this script with --build)',
+  );
+} else {
+  runGate(
+    'check:api-surface',
+    'pnpm',
+    ['run', 'check:api-surface'],
+    'pnpm api-surface:update   (then commit scripts/api-surface.json, and run `pnpm changeset` if the surface change is intentional)',
+  );
+  if (!BUILD_FIRST) {
+    console.log(
+      '   note: ran against whatever dist/ was already on disk (no rebuild). If you have\n' +
+        '   uncommitted source changes since your last build, this can pass here and still\n' +
+        '   fail in CI. Re-run with --build for a from-scratch answer.',
+    );
+  }
+}
+
+// 4. Plato clash-math freshness — INFO by default; needs .NET SDK + network.
+if (FULL) {
+  if (which('dotnet')) {
+    runGate(
+      'generate-plato-clash --check',
+      'node',
+      ['scripts/generate-plato-clash.mjs', '--check'],
+      'node scripts/generate-plato-clash.mjs   (then commit rust/clash/src/generated/plato.rs and packages/clash/src/math/generated/plato.g.ts)',
+    );
+  } else {
+    record(
+      'generate-plato-clash --check',
+      'fail',
+      '--full was passed but `dotnet` is not on PATH — the .NET 9 SDK is required to run this gate.',
+      'Install the .NET 9 SDK, or drop --full to skip this gate (see tools/plato/README.md).',
+    );
+  }
+} else {
+  record(
+    'generate-plato-clash --check',
+    'info',
+    'Not run by default — needs the .NET 9 SDK and clones `plato` + `ara3d-sdk` at pinned SHAs on\n' +
+      'first run (minutes, network). Only relevant if you touched tools/plato/**,\n' +
+      'rust/clash/src/generated/**, or packages/clash/src/math/generated/**.',
+    'node scripts/generate-plato-clash.mjs --check   (or re-run this script with --full)',
+  );
+}
+
+// 5. Committed wasm .d.ts vs Rust source — INFO by default; needs a wasm rebuild.
+if (FULL) {
+  if (which('wasm-pack') && which('cargo')) {
+    hr();
+    console.log('Running wasm gate: bash scripts/build-wasm.sh && git diff --quiet -- packages/wasm/pkg/ifc-lite.d.ts');
+    try {
+      run('bash', ['scripts/build-wasm.sh']);
+      try {
+        run('git', ['diff', '--quiet', '--', 'packages/wasm/pkg/ifc-lite.d.ts']);
+        record('wasm .d.ts freshness', 'pass', null, null);
+      } catch {
+        const diff = run('git', ['diff', '--', 'packages/wasm/pkg/ifc-lite.d.ts']);
+        record(
+          'wasm .d.ts freshness',
+          'fail',
+          diff,
+          'Rebuild committed the drift above — `git add packages/wasm/pkg/ifc-lite.d.ts` and commit it.',
+        );
+      }
+    } catch (e) {
+      record(
+        'wasm .d.ts freshness',
+        'fail',
+        (e.stdout || e.stderr || e.message).toString(),
+        'bash scripts/build-wasm.sh failed — see output above.',
+      );
+    }
+  } else {
+    record(
+      'wasm .d.ts freshness',
+      'fail',
+      '--full was passed but `cargo`/`wasm-pack` are not both on PATH.',
+      'Install the Rust + wasm-pack toolchain (see .github/actions/setup-wasm-build), or drop --full.',
+    );
+  }
+} else {
+  record(
+    'wasm .d.ts freshness',
+    'info',
+    'Not run by default — needs a full wasm32 Rust rebuild (minutes even warm) and the\n' +
+      'Rust + wasm-pack toolchain. Only relevant if you touched rust/wasm-bindings/** or\n' +
+      'anything it re-exports.',
+    'bash scripts/build-wasm.sh && git diff --quiet -- packages/wasm/pkg/ifc-lite.d.ts   (or re-run this script with --full)',
+  );
+}
+
+hr();
+const failed = results.filter((r) => r.status === 'fail');
+const skipped = results.filter((r) => r.status === 'skip');
+const info = results.filter((r) => r.status === 'info');
+const passed = results.filter((r) => r.status === 'pass');
+
+console.log(
+  `Summary: ${passed.length} passed, ${failed.length} failed, ${skipped.length} skipped, ${info.length} informational.`,
+);
+
+if (failed.length > 0) {
+  console.log('\n❌ Stale generated file(s) — regenerate and commit before pushing:\n');
+  for (const r of failed) {
+    console.log(`  - ${r.name}`);
+    if (r.fix) console.log(`      ${r.fix}`);
+  }
+  process.exit(1);
+}
+
+console.log('\n✅ Every gate that ran is clean.');
+if (skipped.length > 0 || (info.length > 0 && !FULL)) {
+  console.log('   (some gates were skipped/informational only — see notes above)');
+}


### PR DESCRIPTION
## What

Two of the five generated-file freshness gates in `.github/workflows/test.yml` — `check-api-surface.mjs` and `generate-bim-globals.mjs --check` — run inside the `node-tests` job **before `pnpm test`**. When either is stale the job fails immediately and zero tests run: the PR looks fine locally, then fails in CI minutes later with no test signal. This hit PR #2536 directly (`check:bim-globals` failed at 13:26:25, `pnpm test` never started).

This adds `pnpm check:generated` → `scripts/check-generated.mjs`, one local command that runs every generated-file freshness gate and reports **every** failure in one pass, not just the first.

## Correction: the original "five gates" claim was incomplete

The original version of this PR claimed coverage of "the five generated-file freshness gates" in `.github/workflows/test.yml`, verified "directly, not assumed from memory." That claim was wrong. PR #2632 (adding the brand-new `@ifc-lite/oauth-pkce` package) hit **two more** gates this script didn't run — `generate-docs-sections.mjs --check` (node-tests, before `pnpm test`) and `check-unused-locals.mjs` (the Lint job) — and both fast-failed CI with zero test signal, exactly the failure mode this check exists to catch locally. Neither showed up in the earlier pass over the workflow file.

Coverage is now **re-derived from scratch**, not assumed: every step in the `build`, `lint`, and `node-tests` jobs was individually classified as either a generated-artifact comparison (`--check`/`--verify`/a baseline file/a `git diff --quiet` after regeneration) or not, with the reasoning kept in the script's header comment so the next person doesn't have to redo this audit from zero. The two new gates are added to the unconditional set — see below.

## Coverage

Ran unconditionally (each is single-package, already-built, or needs no build at all — seconds, not minutes):
- `check:bim-globals` — sandbox `NAMESPACE_SCHEMAS` vs `bim-globals.d.ts` (`pnpm turbo build --filter=@ifc-lite/sandbox` first, per the existing script)
- `check:server-attr-indices` — parser `SCHEMA_REGISTRY` vs `attr_indices.rs` (`pnpm turbo build --filter=@ifc-lite/parser` first)
- `docs:check-generated` — the 4 generated regions in `docs/api/typescript.md`, `docs/guide/cli.md`, `docs/guide/performance.md`, `apps/landing/app.jsx` vs their source. No build needed. **New — this is the gate PR #2632 actually hit** (a new package's row was missing from the doc package-index).
- `check-unused-locals.mjs` — per-package unused-locals count vs `scripts/unused-locals-baseline.json`. **New — the other gate PR #2632 hit** (the new package had no baseline entry at all, so it had zero ratchet coverage). Shares `check:api-surface`'s "needs built `dist/`" precondition, since it type-checks each package against its siblings' built types.
- `check:api-surface` — exported `packages/*` surface vs `scripts/api-surface.json`. This one reads **already-built** `dist/`, not a fresh build (that's the slow part — the whole workspace, minutes). If no package has been built yet, it's SKIPPED with an explicit message rather than failing (unbuilt ≠ stale). If `dist/` is stale relative to uncommitted source changes, this can pass locally and still fail in CI, which always builds fresh — a stated, known gap, not a silent one. `--build` runs `pnpm build` first and closes it for both this gate and `check-unused-locals`.

Deliberately **not** run by default — printed as an INFO reminder with the exact command instead:
- **Plato clash-math freshness** (`generate-plato-clash.mjs --check`) — clones `plato` + `ara3d-sdk` at pinned SHAs and does a `dotnet build` of Plato.CLI on first run (the .NET 9 SDK, network, minutes).
- **Committed wasm `.d.ts` vs Rust source** (`build-wasm.sh` + `git diff`) — needs a full wasm32 Rust rebuild (minutes even warm) and the Rust + wasm-pack toolchain.

A check that slow doesn't get run before every push, which defeats the point. `--full` actually runs both when the toolchain is on `PATH` (and reports a clean failure naming what's missing, rather than pretending to pass, when it isn't).

## Steps deliberately NOT treated as a generated-artifact gate, and why

Enumerated against every step in the `build`, `lint`, and `node-tests` jobs, not just the ones already known about:
- `pnpm fixtures:check` (build job) — compares downloaded test-fixture checksums against `tests/models/manifest.json`. Not derived from repo source (nothing here to regenerate it from) and needs the ~1GB fixture set on disk. Wrong shape for a pre-push script.
- `check-changesets.mjs`, `check-lint-ran.mjs`, `check-test-wiring.mjs`, `check-package-readmes.mjs`, `check-doc-samples.mjs` — structural/policy checks (a script actually ran, a file exists, a changeset names a real package). Nothing generated, nothing to regenerate.
- `check-source-text-assertions.mjs`, `check-wasm-disposal.mjs` (node-tests) — ratchet against an allowlist, but the allowlist is hand-maintained (no generator / `--update` mode). A violation means "don't add that pattern," not "stale file, regenerate it" — there's no fix command to offer, so these are out of scope for a freshness-gate script.
- `check-unbounded-frame-wait.mjs` (node-tests) — scans for an absent pattern; no baseline file at all.
- `pnpm --filter=@ifc-lite/viewer check:templates` (node-tests) — typechecks against `bim-globals.d.ts`, but doesn't itself compare a generated artifact; covered transitively by the `check:bim-globals` gate that produces that file.

## Induced-failure evidence (this is the point of the check)

Each gate was deliberately broken in turn, confirmed the script named that specific gate as FAILED, then reverted with `git checkout <path>` on that one file only.

1. **bim-globals**: added an arg to `bim.lens.presets` in `packages/sandbox/src/bridge-schema.ts` without regenerating → `check:bim-globals: FAIL`, printed the `pnpm generate:bim-globals` fix.
2. **api-surface**: deleted one export line from `scripts/api-surface.json` by hand → `check:api-surface: FAIL`, printed the diff (`+ BUILDING_LIKE_SPATIAL_TYPE_ENUMS: const`) and the `pnpm api-surface:update` fix.
3. **server-attr-indices**: changed one index in the committed `attr_indices.rs` (`IFCWALL`'s `predefined_type: 8` → `99`) without regenerating → `check:server-attr-indices: FAIL`, printed the `pnpm generate:server-attr-indices` fix.
4. **wasm `.d.ts`**: added a throwaway `#[wasm_bindgen] pub fn __verification_probe()` to `rust/wasm-bindings/src/lib.rs`, ran `--full` → real rebuild, real diff shown (`+ export function __verification_probe(): string;`), gate correctly FAILED.
5. **Plato**: added a field to `Box3` in `tools/plato/clash_math.plato`, ran the underlying `generate-plato-clash.mjs --check` directly → correctly reported the committed `plato.rs`/`plato.g.ts` as stale, with the type-level diff shown.
6. **docs:check-generated** (new): deleted the `@ifc-lite/parser` row from the `package-index` region in `docs/api/typescript.md` → `docs:check-generated: FAIL`, printed the row-level diff and the `pnpm docs:generate` fix.
7. **check-unused-locals** (new): added a genuinely unused local (`const unusedLocalsProbe = ...`) to `packages/diff/src/content-match.ts`, a package baselined at 0 → `check-unused-locals: FAIL`, reported `packages/diff: 1 (baseline 0, +1)` and the `pnpm lint:baseline` fix.

For (5), this sandbox's installed .NET SDK is 10.0.301 with no 9.0.0 runtime, which the pinned Plato.CLI target requires — plain `--full` surfaced that as a clean toolchain-missing failure (not a false pass), and drift detection itself was proven separately with `DOTNET_ROLL_FORWARD=LatestMajor` as a workaround. That env quirk is local-machine-specific, not a defect in the check.

All seven gates: real detection confirmed, not assumed.

## Left to the maintainer: pre-push hook

Not wired into a git hook — an imposed hook changes everyone's workflow, not just adds a script. If you'd like `pnpm check:generated` (fast mode, no `--full`) wired into a pre-push hook, say so and I'll add it in a follow-up.

## Not covered

Everything currently in `.github/workflows/test.yml`'s `build`/`lint`/`node-tests` jobs that performs a generated-artifact comparison is now covered by one of the seven gates above, or explicitly listed and reasoned about in "Steps deliberately NOT treated as a generated-artifact gate" — see the script's own header comment for the same list, kept in sync with this description. Given that the original "five gates, verified directly" claim on this same PR turned out to be incomplete, this is stated as "covered as far as this audit found," not as a guarantee against future gates added elsewhere in the workflow.

No changeset: this only touches `scripts/` and root `package.json` scripts, not a published `packages/*` surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added a command to check whether generated files are up to date.
  - Checks now report clear pass, fail, skipped, and informational results.
  - Added options to build the workspace first or run more comprehensive validation.
  - Failed checks provide details and suggested remediation commands, with a nonzero exit status for easier automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
