### PR TITLE
feat(source-msgraph): Microsoft Graph (OneDrive/SharePoint) file-source provider

### DIFF
--- a/.changeset/source-msgraph-provider.md
+++ b/.changeset/source-msgraph-provider.md
@@ -1,4 +1,5 @@
 ---
+'@ifc-lite/oauth-pkce': minor
 '@ifc-lite/source-msgraph': minor
 '@ifc-lite/viewer': patch
 ---
@@ -8,3 +9,7 @@ Add `@ifc-lite/source-msgraph`: a Microsoft Graph (OneDrive/SharePoint) file-sou
 Authentication is delegated OAuth 2.0 Authorization Code + PKCE (`@ifc-lite/oauth-pkce`), scope `offline_access https://graph.microsoft.com/Files.Read` — no admin consent required, no client secret. No client ID is committed; it's a required, non-secret `clientId` preference the deployment configures (see the package README for what to register in Azure AD).
 
 Registered alongside `@ifc-lite/source-dalux` in the viewer's `createRegisteredProviders()`.
+
+The popup handoff is a `BroadcastChannel` from the redirect page, not the usual `popup.closed`/`popup.location` poll. A host that serves `Cross-Origin-Opener-Policy: same-origin` (the viewer does, for `SharedArrayBuffer`) has its opener link severed by the cross-origin authorization hop: `popup.closed` reads `true` while the popup is visibly open, so the poll loop rejects every sign-in as "cancelled" before the user has even consented. The viewer now serves the redirect path as a small static page (`apps/viewer/public/oauth/msgraph/callback.html`, routed in dev by `apps/viewer/vite-plugins/oauth-callback.ts` and in production by a `vercel.json` rewrite) instead of letting the SPA fallback boot a second copy of the whole application inside the popup.
+
+Because that failure is a property of the popup being cross-origin rather than of any one provider, the waiting side ships as `waitForOAuthCallback` (plus the `OAUTH_CALLBACK_CHANNEL` name and its `OAuthCallbackMessage` shape) in `@ifc-lite/oauth-pkce`, so every provider built on that package shares one implementation. Messages are routed by the sign-in attempt's `state`, which is what keeps two concurrent sign-ins from completing each other's flow; `parseAuthorizationCallback` still performs the authoritative CSRF check. One consequence is deliberate: cancellation is no longer detectable, because `popup.closed` is the only signal a browser gives for it and that is exactly what COOP made unusable, so closing the popup now waits out the timeout.

--- a/.changeset/source-msgraph-provider.md
+++ b/.changeset/source-msgraph-provider.md
@@ -1,0 +1,10 @@
+---
+'@ifc-lite/source-msgraph': minor
+'@ifc-lite/viewer': patch
+---
+
+Add `@ifc-lite/source-msgraph`: a Microsoft Graph (OneDrive/SharePoint) file-source provider implementing `FileSourceProvider` from `@ifc-lite/plugin-api`. Browses the signed-in user's OneDrive (folders and files), lists version history, and downloads the current revision of a file via Graph's pre-signed `@microsoft.graph.downloadUrl` — never `GET .../content` directly, which 302-redirects in a way a browser can't follow under a CORS preflight.
+
+Authentication is delegated OAuth 2.0 Authorization Code + PKCE (`@ifc-lite/oauth-pkce`), scope `offline_access https://graph.microsoft.com/Files.Read` — no admin consent required, no client secret. No client ID is committed; it's a required, non-secret `clientId` preference the deployment configures (see the package README for what to register in Azure AD).
+
+Registered alongside `@ifc-lite/source-dalux` in the viewer's `createRegisteredProviders()`.

--- a/apps/viewer/package.json
+++ b/apps/viewer/package.json
@@ -51,6 +51,7 @@
     "@ifc-lite/pointcloud": "workspace:^",
     "@ifc-lite/query": "workspace:^",
     "@ifc-lite/source-dalux": "workspace:^",
+    "@ifc-lite/source-msgraph": "workspace:^",
     "@ifc-lite/renderer": "workspace:^",
     "@ifc-lite/sandbox": "workspace:^",
     "@ifc-lite/sdk": "workspace:^",

--- a/apps/viewer/public/oauth/msgraph/callback.html
+++ b/apps/viewer/public/oauth/msgraph/callback.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex" />
+    <title>Microsoft sign-in</title>
+    <style>
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+        font-size: 14px;
+        line-height: 1.5;
+        color: #1a1a1a;
+        background: #ffffff;
+      }
+      @media (prefers-color-scheme: dark) {
+        body {
+          color: #e8e8e8;
+          background: #131313;
+        }
+      }
+      p {
+        margin: 0;
+        padding: 24px;
+        text-align: center;
+      }
+    </style>
+  </head>
+  <body>
+    <!--
+      OAuth redirect target for @ifc-lite/source-msgraph (REDIRECT_PATH in that
+      package's src/auth.ts). Served from `public/`, so it is a plain static
+      file: no bundler entry, no module script, nothing that pulls in the app.
+
+      That is the entire point of the file. This URL is opened in a 500x700
+      popup, and the app's SPA fallback (Vite in dev, vercel.json's catch-all
+      rewrite in prod) would otherwise answer it with index.html, which boots a
+      second full copy of the viewer, WASM and all, inside the popup just to
+      read a query string. The dev-server route that maps the extension-less
+      REDIRECT_PATH here lives in apps/viewer/vite-plugins/oauth-callback.ts;
+      production does it with a vercel.json rewrite.
+
+      The handoff is a BroadcastChannel rather than the popup's opener, because
+      the app serves Cross-Origin-Opener-Policy: same-origin and the
+      cross-origin authorization hop severs the opener relationship in both
+      directions. packages/oauth-pkce/src/callback-channel.ts documents the
+      probe and the consequences.
+    -->
+    <p id="status">Completing sign-in. You can close this window.</p>
+    <script>
+      (function () {
+        'use strict';
+        // Keep byte-identical to OAUTH_CALLBACK_CHANNEL in
+        // packages/oauth-pkce/src/callback-channel.ts. This file is not
+        // bundled, so it cannot import the constant.
+        var CHANNEL = 'ifc-lite:oauth-callback';
+
+        var params = new URLSearchParams(window.location.search);
+        try {
+          var channel = new BroadcastChannel(CHANNEL);
+          channel.postMessage({
+            type: CHANNEL,
+            // Routes the message to the sign-in attempt that started it; the
+            // opener ignores anything carrying a different state, and
+            // re-validates it before trusting the code.
+            state: params.get('state') || '',
+            url: window.location.href,
+          });
+          channel.close();
+        } catch (err) {
+          document.getElementById('status').textContent =
+            'Could not hand the sign-in result back to the app: ' +
+            (err && err.message ? err.message : String(err));
+          return;
+        }
+
+        // The opener has the result now; this window has no further job.
+        //
+        // What COOP takes away is the OPENER's handle on the popup
+        // (popup.close() from the other side is inert), not a script-opened
+        // document's ability to close itself — verified live in Chrome for
+        // the sibling Dropbox callback page against the running viewer (COOP
+        // same-origin, crossOriginIsolated), where the severed popup closed
+        // itself within ~10 ms of landing on the page.
+        //
+        // If a browser ever refuses, nothing breaks: the opener already has
+        // its result, and this page is left showing the message above.
+        window.close();
+      })();
+    </script>
+  </body>
+</html>

--- a/apps/viewer/src/services/sources/registered-providers.ts
+++ b/apps/viewer/src/services/sources/registered-providers.ts
@@ -4,6 +4,7 @@
 
 import type { FileSourceProvider } from '@ifc-lite/plugin-api';
 import { DaluxBuildProvider } from '@ifc-lite/source-dalux';
+import { MsGraphProvider } from '@ifc-lite/source-msgraph';
 
 /**
  * Every file-source provider the viewer actually registers, in one place.
@@ -13,8 +14,13 @@ import { DaluxBuildProvider } from '@ifc-lite/source-dalux';
  * drifting apart) read from this list — so the test can never drift from
  * what the running app actually does.
  *
- * `@ifc-lite/source-msgraph` (SharePoint/OneDrive) follows in its own PR.
+ * `@ifc-lite/source-msgraph` requires a `clientId` preference (an Azure AD
+ * app registration) to actually sign in — see that package's README for
+ * what to register. Registering it here with no client id configured is
+ * still correct: the provider shows up with a sign-in affordance that fails
+ * with a clear "not configured" message until the deployment sets one,
+ * rather than the provider silently not existing.
  */
 export function createRegisteredProviders(): FileSourceProvider[] {
-  return [new DaluxBuildProvider()];
+  return [new DaluxBuildProvider(), new MsGraphProvider()];
 }

--- a/apps/viewer/tsconfig.json
+++ b/apps/viewer/tsconfig.json
@@ -31,7 +31,8 @@
       "@ifc-lite/sandbox": ["../../packages/sandbox/src"],
       "@ifc-lite/sandbox/schema": ["../../packages/sandbox/src/bridge-schema"],
       "@ifc-lite/plugin-api": ["../../packages/plugin-api/src"],
-      "@ifc-lite/source-dalux": ["../../packages/source-dalux/src"]
+      "@ifc-lite/source-dalux": ["../../packages/source-dalux/src"],
+      "@ifc-lite/source-msgraph": ["../../packages/source-msgraph/src"]
     }
   },
   "include": ["src/**/*", "../../packages/renderer/src/webgpu-types.d.ts"],

--- a/apps/viewer/vite-plugins/oauth-callback.ts
+++ b/apps/viewer/vite-plugins/oauth-callback.ts
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { Plugin } from 'vite';
+
+/**
+ * OAuth redirect paths are extension-less (`/oauth/msgraph/callback`), because
+ * they have to match the redirect URI registered with the provider byte for
+ * byte and that is what is registered. Vite's dev server answers any
+ * extension-less path with the SPA fallback, so the redirect used to boot a
+ * whole second copy of the viewer inside a 500x700 popup.
+ *
+ * This maps each such path onto its static page in `public/`, which is what
+ * the popup actually needs: a few lines that broadcast the result and close.
+ * Production does the same thing through `vercel.json`'s rewrites, so keep
+ * the two lists in lockstep.
+ */
+const CALLBACK_PAGES: Record<string, string> = {
+  // @ifc-lite/source-msgraph, REDIRECT_PATH in its src/auth.ts.
+  '/oauth/msgraph/callback': '/oauth/msgraph/callback.html',
+};
+
+export function oauthCallbackRoutes(): Plugin {
+  return {
+    name: 'ifc-lite-oauth-callback-routes',
+    configureServer(server) {
+      server.middlewares.use((req, _res, next) => {
+        const [path, query] = (req.url ?? '').split('?');
+        const page = CALLBACK_PAGES[path];
+        // Rewrite rather than serve: Vite's own static handling then serves
+        // the file from `public/`, which keeps the dev server's COOP/COEP
+        // headers on the response. The query string carries `code`/`state`
+        // and must survive.
+        if (page) req.url = query === undefined ? page : `${page}?${query}`;
+        next();
+      });
+    },
+  };
+}

--- a/apps/viewer/vite.config.ts
+++ b/apps/viewer/vite.config.ts
@@ -8,6 +8,7 @@ import topLevelAwait from 'vite-plugin-top-level-await';
 import path from 'path';
 import fs from 'fs';
 import { cesiumStaticAssets } from './vite-plugins/cesium-assets';
+import { oauthCallbackRoutes } from './vite-plugins/oauth-callback';
 
 // --- Build-time changelog parser ---
 
@@ -241,6 +242,7 @@ export default defineConfig({
     wasm(),
     topLevelAwait(),
     cesiumStaticAssets(),
+    oauthCallbackRoutes(),
   ],
   define: {
     __APP_VERSION__: JSON.stringify(appVersion),

--- a/docs/api/typescript.md
+++ b/docs/api/typescript.md
@@ -49,6 +49,7 @@ ifc-lite ships 36 public npm packages: 35 scoped `@ifc-lite/*` packages plus the
 | [`@ifc-lite/oauth-pkce`](https://www.npmjs.com/package/@ifc-lite/oauth-pkce) | Browser OAuth 2.0 Authorization Code + PKCE flow, shared by ifc-lite's file-source providers |
 | [`@ifc-lite/plugin-api`](https://www.npmjs.com/package/@ifc-lite/plugin-api) | Dependency-free type surface for ifc-lite file-source plugins |
 | [`@ifc-lite/source-dalux`](https://www.npmjs.com/package/@ifc-lite/source-dalux) | Dalux Build (Box) file-source provider for ifc-lite |
+| [`@ifc-lite/source-msgraph`](https://www.npmjs.com/package/@ifc-lite/source-msgraph) | Microsoft Graph (OneDrive/SharePoint) file-source provider for ifc-lite |
 <!-- END GENERATED: package-index -->
 
 ---

--- a/packages/oauth-pkce/README.md
+++ b/packages/oauth-pkce/README.md
@@ -19,6 +19,9 @@ Provided:
   interface and serves a currently-valid access token, refreshing
   transparently and de-duplicating concurrent refreshes onto a single
   in-flight request.
+- `waitForOAuthCallback`: the popup-side handoff, i.e. how the redirect page
+  gets the authorization code back to the page that opened the popup. See
+  "The popup handoff" below — this is not the mechanism you would expect.
 
 Explicitly **not** provided, by design:
 - Any actual provider implementation (Google Drive, Dropbox, OneDrive, ...).
@@ -27,6 +30,46 @@ Explicitly **not** provided, by design:
 
 Each of those is provider-specific and belongs in that provider's own
 package, built on top of this one.
+
+## The popup handoff — why it is not `popup.closed`
+
+A provider opens the authorization URL in a popup and needs the redirect URL
+back. The obvious way is to poll `popup.closed` and `popup.location.href`
+until the redirect lands on the app's own origin. **That does not work in a
+cross-origin-isolated host, and it fails misleadingly.**
+
+A host that wants `SharedArrayBuffer` must send
+`Cross-Origin-Opener-Policy: same-origin` (the ifc-lite viewer does). Under
+that header, opening a *cross-origin* popup severs the opener relationship:
+the `WindowProxy` `window.open` returns is a stub that reports
+`closed === true` while the window is visibly open, and whose `location`
+throws `SecurityError`. Probed live against the running viewer, with a
+same-origin control popup behaving normally in the same probe — so the cause
+is the popup being cross-origin, and every authorization endpoint is on
+someone else's origin. The poll loop therefore rejects every sign-in as
+"cancelled" on its first tick, while the user is still on the consent screen.
+
+What still works: the redirect lands back on the app's own origin, so the
+callback page is same-origin with its opener and can hand the result over a
+`BroadcastChannel`, which is scoped by origin and unaffected by the severed
+opener link. `waitForOAuthCallback` is the listening half; the host serves
+the callback page and posts `OAUTH_CALLBACK_CHANNEL` messages of shape
+`OAuthCallbackMessage` from it (that page must be a static file, not the SPA
+fallback, or the popup boots a second copy of the whole application). The
+opener never touches the popup at all.
+
+Two consequences to know before changing this:
+
+- Messages are routed by the sign-in attempt's `state`, so two providers or
+  two tabs signing in concurrently cannot complete each other's flow. That
+  routing check is *not* the security check — `parseAuthorizationCallback`
+  still validates `state` and the redirect origin authoritatively.
+- **Cancellation is not detectable.** `popup.closed` is the only signal a
+  browser gives for "the user closed the window", and it is precisely what
+  COOP made unusable. A closed popup falls through to the caller's timeout.
+  This is a deliberate trade: there is no correct substitute signal.
+
+`src/callback-channel.ts` carries the full probe and reasoning.
 
 ## Token storage — the trade-off, and this package's default
 

--- a/packages/oauth-pkce/src/callback-channel.ts
+++ b/packages/oauth-pkce/src/callback-channel.ts
@@ -1,0 +1,133 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * How an OAuth popup hands its result back to the page that opened it.
+ *
+ * The obvious mechanism (open the popup, poll `popup.closed` and
+ * `popup.location.href` until the redirect lands on this app's own origin)
+ * does not work in a cross-origin-isolated app, and fails in the most
+ * misleading way possible. The viewer serves
+ * `Cross-Origin-Opener-Policy: same-origin` (it needs `crossOriginIsolated`
+ * for `SharedArrayBuffer`). Under that header, opening a CROSS-ORIGIN popup
+ * severs the opener/openee relationship: the `WindowProxy` `window.open`
+ * returns is a disconnected stub of a window this page is no longer allowed
+ * to observe. Probed live against the running viewer with an authorization
+ * host:
+ *
+ *   window.crossOriginIsolated              -> true
+ *   w = window.open('https://<authorization-host>/')
+ *   w.closed          (1.5s later)          -> true, while the window is
+ *                                              visibly open on screen
+ *   w.location.href                         -> throws SecurityError
+ *
+ * So `popup.closed` reports a lie, and the poll loop rejects with "sign-in
+ * was cancelled (the popup was closed)" on its very first tick while the user
+ * is still looking at the provider's consent screen. A same-origin control
+ * popup in the same probe behaved normally (`closed === false`,
+ * `location.href` readable), which is what pins the cause on the popup being
+ * cross-origin rather than on any one provider: every OAuth authorization
+ * endpoint this package talks to is on someone else's origin, so every
+ * provider built on it inherits the same failure.
+ *
+ * What still works is that the REDIRECT lands back on this app's own origin.
+ * The callback page is therefore same-origin with its opener and can hand the
+ * result back over a `BroadcastChannel`, which is scoped by origin and does
+ * not care about the opener link that COOP cut. The opener listens on that
+ * channel instead of touching the popup at all.
+ *
+ * Consequences worth knowing before changing any of this:
+ *
+ *  - **Cancellation is not detectable.** `popup.closed` is the only signal a
+ *    browser gives for "the user closed the window", and it is exactly the
+ *    thing COOP made unusable here. A user who closes the popup therefore
+ *    waits out the timeout instead of getting an immediate "cancelled".
+ *    That is a deliberate trade, not an oversight: there is no correct
+ *    substitute signal, and inventing one (a heartbeat from the popup, an
+ *    unload beacon) buys a nicer error message for a real cost in moving
+ *    parts.
+ *  - **`popup.close()` from the opener is also inert** on a severed popup.
+ *    The callback page closes itself.
+ *
+ * This lives in `@ifc-lite/oauth-pkce` rather than in any one provider
+ * because the defect is a property of the browser's COOP handling and of
+ * this package's popup-based authorization flow, not of a provider. A
+ * per-provider copy would be a second thing to fix the next time the
+ * mechanism moves, and only one of the copies would get fixed.
+ */
+
+/**
+ * Name of the `BroadcastChannel`, and the `type` tag every message on it
+ * carries. Shared by every provider: messages are routed by `state`, not by
+ * channel name (see `WaitForOAuthCallbackOptions.expectedState`).
+ *
+ * MUST stay byte-identical to the literal in each callback page that posts on
+ * it, e.g. `apps/viewer/public/oauth/msgraph/callback.html`. Those pages are
+ * static, unbundled HTML files (deliberately: see their own comments), so
+ * they cannot import this constant. They are kept in lockstep by hand.
+ */
+export const OAUTH_CALLBACK_CHANNEL = 'ifc-lite:oauth-callback';
+
+/** What a callback page posts. `url` is the full redirect URL, query string
+ *  included, for the opener to hand to `parseAuthorizationCallback`. */
+export interface OAuthCallbackMessage {
+  readonly type: typeof OAUTH_CALLBACK_CHANNEL;
+  readonly state: string;
+  readonly url: string;
+}
+
+export interface WaitForOAuthCallbackOptions {
+  /** The `state` this sign-in attempt generated. Messages carrying any other
+   *  `state` are ignored rather than consumed, which is what keeps two
+   *  concurrent sign-ins (two providers, or two tabs) from completing each
+   *  other's flow. Every listener sees every message on this shared channel. */
+  readonly expectedState: string;
+  readonly timeoutMs: number;
+  /** Message for the timeout rejection, so each provider can phrase its own. */
+  readonly timeoutMessage: string;
+}
+
+/**
+ * Resolves with the full callback URL the popup was redirected to, once the
+ * callback page broadcasts it. Rejects after `timeoutMs`.
+ *
+ * Attach this BEFORE the redirect can possibly happen (i.e. immediately after
+ * opening the popup, with no `await` in between): `BroadcastChannel` does not
+ * buffer, so a message posted before this subscribes is simply lost.
+ *
+ * `state` is validated here only to route the message to the right waiter.
+ * The authoritative CSRF check is still `parseAuthorizationCallback`, which
+ * the caller runs on the returned URL.
+ */
+export function waitForOAuthCallback(options: WaitForOAuthCallbackOptions): Promise<string> {
+  if (typeof BroadcastChannel === 'undefined') {
+    return Promise.reject(
+      new Error('OAuth sign-in requires BroadcastChannel, which this environment does not provide'),
+    );
+  }
+
+  return new Promise<string>((resolve, reject) => {
+    const channel = new BroadcastChannel(OAUTH_CALLBACK_CHANNEL);
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const teardown = (): void => {
+      if (timer !== undefined) clearTimeout(timer);
+      channel.close();
+    };
+
+    timer = setTimeout(() => {
+      teardown();
+      reject(new Error(options.timeoutMessage));
+    }, options.timeoutMs);
+
+    channel.onmessage = (event: MessageEvent): void => {
+      const data = event.data as Partial<OAuthCallbackMessage> | null | undefined;
+      if (!data || data.type !== OAUTH_CALLBACK_CHANNEL) return;
+      if (typeof data.url !== 'string') return;
+      if (data.state !== options.expectedState) return; // Someone else's sign-in.
+      teardown();
+      resolve(data.url);
+    };
+  });
+}

--- a/packages/oauth-pkce/src/index.ts
+++ b/packages/oauth-pkce/src/index.ts
@@ -12,6 +12,9 @@ export { createPkcePair, deriveCodeChallengeS256, generateCodeVerifier, generate
 export { createAuthorizationRequest, parseAuthorizationCallback } from './authorization.js';
 export type { ParseAuthorizationCallbackOptions } from './authorization.js';
 
+export { OAUTH_CALLBACK_CHANNEL, waitForOAuthCallback } from './callback-channel.js';
+export type { OAuthCallbackMessage, WaitForOAuthCallbackOptions } from './callback-channel.js';
+
 export { exchangeAuthorizationCode, refreshAccessToken } from './token-exchange.js';
 export type { ExchangeAuthorizationCodeParams, RefreshAccessTokenParams } from './token-exchange.js';
 

--- a/packages/oauth-pkce/test/callback-channel.test.ts
+++ b/packages/oauth-pkce/test/callback-channel.test.ts
@@ -1,0 +1,84 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect } from 'vitest';
+
+import { OAUTH_CALLBACK_CHANNEL, waitForOAuthCallback } from '../src/callback-channel.js';
+
+/** Posts one message the way a static callback page does. */
+function broadcast(message: unknown): void {
+  const channel = new BroadcastChannel(OAUTH_CALLBACK_CHANNEL);
+  channel.postMessage(message);
+  channel.close();
+}
+
+function callbackMessage(state: string, code = 'code-1'): unknown {
+  return {
+    type: OAUTH_CALLBACK_CHANNEL,
+    state,
+    url: `https://app.example.com/oauth/msgraph/callback?code=${code}&state=${state}`,
+  };
+}
+
+describe('waitForOAuthCallback', () => {
+  it('resolves with the callback URL the page broadcast', async () => {
+    const pending = waitForOAuthCallback({
+      expectedState: 'state-a',
+      timeoutMs: 2000,
+      timeoutMessage: 'timed out',
+    });
+    broadcast(callbackMessage('state-a'));
+    await expect(pending).resolves.toBe(
+      'https://app.example.com/oauth/msgraph/callback?code=code-1&state=state-a',
+    );
+  });
+
+  /**
+   * Every waiter on this shared channel sees every message, so `state` is the
+   * only thing keeping two concurrent sign-ins apart. Without the filter, the
+   * first waiter to receive would consume the other provider's callback and
+   * complete a flow it never started (and then fail its own CSRF check, or
+   * worse, exchange a code minted for a different client).
+   */
+  it('ignores a callback carrying a different state, so two sign-ins cannot cross wires', async () => {
+    const waiterA = waitForOAuthCallback({
+      expectedState: 'state-a',
+      timeoutMs: 300,
+      timeoutMessage: 'A timed out',
+    });
+    const waiterB = waitForOAuthCallback({
+      expectedState: 'state-b',
+      timeoutMs: 2000,
+      timeoutMessage: 'B timed out',
+    });
+
+    broadcast(callbackMessage('state-b', 'code-for-b'));
+
+    await expect(waiterB).resolves.toContain('code=code-for-b');
+    // A saw the same message and let it pass, so it has nothing and times out.
+    await expect(waiterA).rejects.toThrow('A timed out');
+  });
+
+  it('ignores traffic on the channel that is not a callback message', async () => {
+    const pending = waitForOAuthCallback({
+      expectedState: 'state-a',
+      timeoutMs: 300,
+      timeoutMessage: 'timed out',
+    });
+    broadcast({ type: 'something-else', state: 'state-a', url: 'https://evil.example/' });
+    broadcast(null);
+    broadcast({ type: OAUTH_CALLBACK_CHANNEL, state: 'state-a' }); // no url
+    await expect(pending).rejects.toThrow('timed out');
+  });
+
+  it('rejects with the caller-supplied message when nothing ever arrives', async () => {
+    await expect(
+      waitForOAuthCallback({
+        expectedState: 'state-a',
+        timeoutMs: 50,
+        timeoutMessage: 'Microsoft sign-in timed out',
+      }),
+    ).rejects.toThrow('Microsoft sign-in timed out');
+  });
+});

--- a/packages/source-msgraph/README.md
+++ b/packages/source-msgraph/README.md
@@ -62,7 +62,38 @@ is "[o]nly provided if offline_access scope was requested").
 
 Sign-in is a popup, not a full-page redirect: `signIn()` opens
 `https://login.microsoftonline.com/{tenant}/oauth2/v2.0/authorize` in a
-popup and polls it for a same-origin redirect back to this app.
+popup and waits for the callback page at `REDIRECT_PATH` to broadcast the
+result back.
+
+**The popup is never inspected, and the host must serve `REDIRECT_PATH`
+itself.** Both follow from `Cross-Origin-Opener-Policy: same-origin`, which
+any host that wants `SharedArrayBuffer` (the ifc-lite viewer does) has to
+send. Under that header, opening a *cross-origin* popup severs the opener
+relationship: the `WindowProxy` `window.open` returns reports `closed === true`
+while the window is visibly open, and reading `location` throws
+`SecurityError`. The classic poll loop therefore rejects every sign-in as
+"cancelled" on its first tick, with the popup still on the consent screen and
+the authorization code stranded. So:
+
+- The redirect lands back on this app's own origin, and that page hands the
+  result to the opener over a `BroadcastChannel`. The waiting side is
+  `waitForOAuthCallback` in `@ifc-lite/oauth-pkce`
+  (`packages/oauth-pkce/src/callback-channel.ts` carries the name, the message
+  shape and the live probe) — it is shared with every other provider built on
+  that package, because the failure is a property of the popup being
+  cross-origin rather than of any one identity provider. The host serves the
+  page: see `apps/viewer/public/oauth/msgraph/callback.html` plus the
+  dev-server route in `apps/viewer/vite-plugins/oauth-callback.ts` and the
+  `vercel.json` rewrite. Without such a route the SPA fallback answers the
+  redirect with the whole application, which boots a second copy of the app
+  inside the popup.
+- Messages are routed by `state`, so two providers (or two tabs) signing in at
+  once cannot complete each other's flow. `state` is then re-validated by
+  `parseAuthorizationCallback` before the code is used.
+- **Cancellation is not detectable.** `popup.closed` is the only signal a
+  browser offers for "the user closed the window", and it is exactly what COOP
+  made unusable. Closing the popup falls through to the five-minute timeout
+  instead of reporting a cancellation.
 
 **Note on session length**: per Microsoft's docs, a refresh token issued to a
 `spa`-type redirect URI is capped at a 24-hour lifetime regardless of

--- a/packages/source-msgraph/README.md
+++ b/packages/source-msgraph/README.md
@@ -97,8 +97,13 @@ the authorization code stranded. So:
 
 **Note on session length**: per Microsoft's docs, a refresh token issued to a
 `spa`-type redirect URI is capped at a 24-hour lifetime regardless of
-`offline_access` — re-authentication (normally silent, via the identity
-platform's own session) is required at least once a day.
+`offline_access`, so re-authentication is required at least once a day. As
+this provider is written that re-authentication is **not** silent: `signIn`
+sends `prompt=select_account`, which always shows the account picker, and
+there is no `prompt=none` path to fall back on. Expect a visible sign-in
+popup once a day. (The account picker is deliberate — see the comment on
+`extraParams` in `src/auth.ts` — but it is a trade against silent renewal,
+not a free choice.)
 
 ## What the app registration needs (maintainer action — not done here)
 

--- a/packages/source-msgraph/README.md
+++ b/packages/source-msgraph/README.md
@@ -1,0 +1,103 @@
+# @ifc-lite/source-msgraph
+
+Microsoft Graph (OneDrive / SharePoint) file-source provider for ifc-lite.
+
+Implements `FileSourceProvider` from `@ifc-lite/plugin-api` to browse the
+signed-in user's OneDrive, and download IFC files directly into the viewer.
+Authentication is delegated OAuth 2.0 Authorization Code + PKCE, built on
+`@ifc-lite/oauth-pkce` — never a client secret.
+
+## Scope (v1)
+
+- **One project**: the signed-in user's own default drive (`/me/drive`).
+  Delegated `Files.Read` grants no "list every SharePoint site I can see"
+  endpoint — that needs the higher-privileged, admin-consentable
+  `Sites.Read.All` — so this provider doesn't pretend to discover sites it
+  structurally can't enumerate. Browsing a specific SharePoint site is a
+  natural follow-up (an app registration with `Sites.Read.All` plus a
+  "paste a site URL" affordance), not implemented here.
+- **Folder-organized files only.** `listContainers` returns the drive
+  root's real child folders directly (matching the plugin contract's "top
+  level" shape exactly, `parentId: undefined`), and folders nest the same
+  way real Graph `driveItem`s do. A file sitting directly at the drive root
+  — not inside any folder — is not currently listable: there is no
+  `SourceContainer` a host would address it through. Most real OneDrive
+  usage is folder-organized; this is a known v1 gap, not a design dead end
+  (a synthetic root-level container is the natural extension).
+- **Current revision only.** `listRevisions` lists version history
+  (`GET .../versions`), but `download()` can only fetch the *current*
+  revision — see "Why not `/content`" below for why, and
+  `capabilities.downloadHistoricalRevisions: false` in the manifest for how
+  that's declared to the host.
+
+## Why not `/content`
+
+Downloading goes through the item's pre-signed `@microsoft.graph.downloadUrl`
+property, fetched via `ctx.fetchPublic` (no `Authorization` header) — never
+`GET .../content` directly.
+
+Per Microsoft's own docs ("Download driveItem content", section "Downloading
+files in JavaScript apps" — `learn.microsoft.com/graph/api/driveitem-get-content`,
+checked 2026-08-15): `/content` returns a `302 Found` redirect to that same
+pre-signed URL, and a browser can't follow a `302` when the request that
+triggered it required a CORS preflight (attaching `Authorization` does). The
+docs' own recommended fix is exactly this provider's approach: select
+`@microsoft.graph.downloadUrl` and fetch that URL directly — it's
+preauthenticated, so no `Authorization` header (and therefore no preflight)
+is needed.
+
+The same 302-redirect shape applies to a *historical* version's content
+(`GET .../versions/{id}/content`), and `driveItemVersion` exposes no
+`@microsoft.graph.downloadUrl` equivalent — hence
+`downloadHistoricalRevisions: false`.
+
+## Auth
+
+Delegated OAuth 2.0 Authorization Code + PKCE (`@ifc-lite/oauth-pkce`), scope
+`offline_access https://graph.microsoft.com/Files.Read`. `Files.Read` is the
+least-privileged permission for reading file content and needs no admin
+consent; `offline_access` is required separately for a refresh token to be
+issued at all (the Microsoft identity platform's own docs: `refresh_token`
+is "[o]nly provided if offline_access scope was requested").
+
+Sign-in is a popup, not a full-page redirect: `signIn()` opens
+`https://login.microsoftonline.com/{tenant}/oauth2/v2.0/authorize` in a
+popup and polls it for a same-origin redirect back to this app.
+
+**Note on session length**: per Microsoft's docs, a refresh token issued to a
+`spa`-type redirect URI is capped at a 24-hour lifetime regardless of
+`offline_access` — re-authentication (normally silent, via the identity
+platform's own session) is required at least once a day.
+
+## What the app registration needs (maintainer action — not done here)
+
+No client ID is committed to this package; it's a required, non-secret
+`clientId` preference (see `manifest.ts`) the host/deployment configures.
+Registering an Azure AD application needs:
+
+- **Client type**: Single-page application (SPA) — public client, PKCE, no
+  client secret.
+- **Redirect URI**: `<app origin>/oauth/msgraph/callback` (the exact path is
+  `REDIRECT_PATH` in `src/auth.ts`), registered with type `spa` — the
+  `spa` type is what enables CORS on the token endpoint; a `web`-type
+  redirect URI will fail with a CORS error on token exchange.
+- **API permissions (delegated)**: `Files.Read`, `offline_access`. Neither
+  needs admin consent for a standard tenant. No `Sites.Read.All` — not used
+  by this provider (see "Scope" above).
+- **Supported account types**: whichever matches the `tenant` preference the
+  deployment sets (default `common` — both work/school and personal
+  Microsoft accounts).
+
+## Token storage
+
+Tokens are persisted through `ctx.storage` (`KeyValueStore`), the same
+`localStorage`-backed store used for other providers' preferences in the
+reference host. See the trade-off documented in `@ifc-lite/oauth-pkce`'s
+README before changing this — a refresh token is a longer-lived bearer
+credential than the access token it mints.
+
+## CORS
+
+Every Graph API call and the OAuth token endpoint send real CORS headers for
+an app registered with a `spa` redirect URI — no same-origin relay is needed,
+unlike `@ifc-lite/source-dalux`.

--- a/packages/source-msgraph/package.json
+++ b/packages/source-msgraph/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@ifc-lite/source-msgraph",
+  "version": "0.1.0",
+  "description": "Microsoft Graph (OneDrive/SharePoint) file-source provider for ifc-lite",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "pnpm exec tsc",
+    "typecheck": "node ../../scripts/typecheck-tests.mjs",
+    "dev": "pnpm exec tsc --watch",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@ifc-lite/oauth-pkce": "workspace:^",
+    "@ifc-lite/plugin-api": "workspace:^"
+  },
+  "devDependencies": {
+    "@ifc-lite/source-fixture": "workspace:^",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.9"
+  },
+  "license": "MPL-2.0",
+  "author": "Louis True",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LTplus-AG/ifc-lite.git",
+    "directory": "packages/source-msgraph"
+  },
+  "homepage": "https://ifclite.dev/docs/",
+  "bugs": "https://github.com/LTplus-AG/ifc-lite/issues",
+  "keywords": [
+    "ifc",
+    "bim",
+    "microsoft-graph",
+    "onedrive",
+    "sharepoint",
+    "cde",
+    "file-source"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ]
+}

--- a/packages/source-msgraph/src/auth.ts
+++ b/packages/source-msgraph/src/auth.ts
@@ -8,6 +8,7 @@ import {
   createAuthorizationRequest,
   exchangeAuthorizationCode,
   parseAuthorizationCallback,
+  waitForOAuthCallback,
 } from '@ifc-lite/oauth-pkce';
 import type { PluginContext, SourceAuth, SourceIdentity } from '@ifc-lite/plugin-api';
 
@@ -45,7 +46,6 @@ const DEFAULT_TENANT = 'common';
  * app registration needs. */
 export const REDIRECT_PATH = '/oauth/msgraph/callback';
 
-const POPUP_POLL_MS = 250;
 const POPUP_TIMEOUT_MS = 5 * 60 * 1000;
 
 export async function requireClientId(ctx: PluginContext): Promise<string> {
@@ -136,43 +136,6 @@ async function currentIdentity(ctx: PluginContext): Promise<SourceIdentity | nul
   }
 }
 
-/**
- * Polls a popup for a same-origin redirect. Cross-origin `popup.location`
- * access throws a `SecurityError` for as long as the popup is still on
- * `login.microsoftonline.com`; that's expected and simply means "keep
- * polling" rather than a real failure — only once the popup navigates back to
- * this app's own origin does reading its URL succeed.
- */
-function waitForPopupRedirect(popup: Window, redirectOrigin: string, timeoutMs: number): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const startedAt = Date.now();
-    const interval = setInterval(() => {
-      if (popup.closed) {
-        clearInterval(interval);
-        reject(new Error('Microsoft sign-in was cancelled (the popup was closed)'));
-        return;
-      }
-      if (Date.now() - startedAt > timeoutMs) {
-        clearInterval(interval);
-        popup.close();
-        reject(new Error('Microsoft sign-in timed out'));
-        return;
-      }
-      let href: string | undefined;
-      try {
-        href = popup.location.href;
-      } catch {
-        return; // Still cross-origin on the identity provider — keep polling.
-      }
-      if (href.startsWith(redirectOrigin)) {
-        clearInterval(interval);
-        popup.close();
-        resolve(href);
-      }
-    }, POPUP_POLL_MS);
-  });
-}
-
 export const msGraphAuth: SourceAuth = {
   async restore(ctx: PluginContext): Promise<SourceIdentity | null> {
     return currentIdentity(ctx);
@@ -207,11 +170,28 @@ export const msGraphAuth: SourceAuth = {
       throw new Error('Microsoft sign-in popup was blocked by the browser');
     }
 
+    // Subscribed here, synchronously after the popup opens and before any
+    // `await`, because `BroadcastChannel` does not buffer: a message posted
+    // before this listener exists would be lost.
+    //
+    // The popup itself is deliberately never inspected. Under this app's
+    // `Cross-Origin-Opener-Policy: same-origin`, `popup.closed` is `true` and
+    // `popup.location` throws for a cross-origin popup even while it is open
+    // and working, so the usual poll loop rejects every sign-in as
+    // "cancelled" on its first tick. `@ifc-lite/oauth-pkce`'s
+    // `callback-channel.ts` documents the probe. Cancellation therefore falls
+    // back to the timeout.
     let callbackUrl: string;
     try {
-      callbackUrl = await waitForPopupRedirect(popup, window.location.origin, POPUP_TIMEOUT_MS);
+      callbackUrl = await waitForOAuthCallback({
+        expectedState: authRequest.state,
+        timeoutMs: POPUP_TIMEOUT_MS,
+        timeoutMessage: 'Microsoft sign-in timed out',
+      });
     } catch (err) {
-      if (!popup.closed) popup.close();
+      // Best effort: also inert on a severed popup, but harmless, and it does
+      // close the window in a browser that has not cut the opener link.
+      popup.close();
       throw err;
     }
 

--- a/packages/source-msgraph/src/auth.ts
+++ b/packages/source-msgraph/src/auth.ts
@@ -1,0 +1,254 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import {
+  NotSignedInError,
+  TokenManager,
+  createAuthorizationRequest,
+  exchangeAuthorizationCode,
+  parseAuthorizationCallback,
+} from '@ifc-lite/oauth-pkce';
+import type { PluginContext, SourceAuth, SourceIdentity } from '@ifc-lite/plugin-api';
+
+import { BrowserGraphApiClient } from './http-client.js';
+
+const AUTHORIZE_ENDPOINT = (tenant: string) => `https://login.microsoftonline.com/${tenant}/oauth2/v2.0/authorize`;
+const TOKEN_ENDPOINT = (tenant: string) => `https://login.microsoftonline.com/${tenant}/oauth2/v2.0/token`;
+
+/**
+ * `Files.Read` is the least-privileged delegated scope for reading OneDrive/
+ * SharePoint file content (Microsoft Graph docs, "Download driveItem content",
+ * permissions table: Delegated work-or-school AND personal accounts both list
+ * `Files.Read` as least-privileged) — needs no admin consent.
+ *
+ * `offline_access` is required *in addition*, not implied by any other scope:
+ * per the Microsoft identity platform's v2.0 auth-code-flow docs ("Successful
+ * response" under "Redeem a code for an access token"), the token response's
+ * `refresh_token` field is documented as "Only provided if offline_access
+ * scope was requested." Without it, every session would need an interactive
+ * sign-in again the moment the short-lived access token expired.
+ *
+ * Note even with `offline_access`: a SPA redirect URI's refresh token is
+ * capped at a 24-hour lifetime by Microsoft regardless of how long the
+ * *access* token would otherwise be refreshable for (same doc, "Refresh the
+ * access token" section) — re-authentication is required at least once a
+ * day, though normally silent via the identity platform's own session.
+ */
+const SCOPES = 'offline_access https://graph.microsoft.com/Files.Read';
+
+const STORAGE_KEY = 'msgraph:tokens';
+const DEFAULT_TENANT = 'common';
+
+/** Path the Azure AD app registration's redirect URI must point at (appended
+ * to this app's own origin). See the package README for the exact value the
+ * app registration needs. */
+export const REDIRECT_PATH = '/oauth/msgraph/callback';
+
+const POPUP_POLL_MS = 250;
+const POPUP_TIMEOUT_MS = 5 * 60 * 1000;
+
+export async function requireClientId(ctx: PluginContext): Promise<string> {
+  const clientId = await ctx.getPreference('clientId');
+  if (!clientId) {
+    throw new Error(
+      'Microsoft Graph provider is not configured: no Azure AD application (client) ID. ' +
+        'Set the "clientId" preference — see the @ifc-lite/source-msgraph README for what to register.',
+    );
+  }
+  return clientId;
+}
+
+export async function getTenant(ctx: PluginContext): Promise<string> {
+  const tenant = await ctx.getPreference('tenant');
+  return tenant && tenant.length > 0 ? tenant : DEFAULT_TENANT;
+}
+
+/** Shared with `provider.ts`, which needs the same token manager to mint an
+ *  access token for plain Graph API calls (listing, download metadata, ...) —
+ *  a single definition keeps the storage key and token endpoint from drifting
+ *  between the two call sites. */
+export function createTokenManager(ctx: PluginContext, clientId: string, tenant: string): TokenManager {
+  return new TokenManager({
+    storageKey: STORAGE_KEY,
+    // `ctx.storage` (`KeyValueStore`) is structurally compatible with
+    // `TokenStorage` — see the `@ifc-lite/oauth-pkce` README's storage
+    // trade-off section. It's already namespaced per-provider by the host,
+    // same as it is for Dalux's API key, so a single fixed storage key is
+    // enough (no per-tenant/per-client namespacing needed on top).
+    storage: ctx.storage,
+    tokenEndpoint: TOKEN_ENDPOINT(tenant),
+    clientId,
+    fetch: ctx.fetch,
+  });
+}
+
+/** Reads `id`/`displayName`/`mail` off `/me`. Deliberately a live Graph call
+ *  rather than decoding the access token: this package's `TokenSet` (from
+ *  `@ifc-lite/oauth-pkce`) carries only `access_token`/`refresh_token`/
+ *  `expires_in`/`scope`/`token_type` — no `id_token` — so there is nothing to
+ *  decode client-side, and an opaque access token can't be read at all. */
+async function fetchIdentity(ctx: PluginContext, accessToken: string): Promise<SourceIdentity> {
+  const client = new BrowserGraphApiClient(accessToken, ctx);
+  const raw = await client.get('/me', { $select: 'id,displayName,mail,userPrincipalName' });
+  if (typeof raw !== 'object' || raw === null) {
+    throw new Error('Microsoft Graph /me returned an unexpected response');
+  }
+  const record = raw as Record<string, unknown>;
+  const id = typeof record.id === 'string' ? record.id : undefined;
+  if (!id) throw new Error('Microsoft Graph /me response is missing "id"');
+
+  const email =
+    typeof record.mail === 'string' && record.mail.length > 0
+      ? record.mail
+      : typeof record.userPrincipalName === 'string'
+        ? record.userPrincipalName
+        : undefined;
+
+  return {
+    id,
+    displayName: typeof record.displayName === 'string' ? record.displayName : undefined,
+    email,
+  };
+}
+
+/**
+ * Restores or fetches the current identity without ever throwing — used by
+ * both `restore()` (which must be silent per the `SourceAuth` contract) and
+ * `getIdentity()` (which "must not perform interactive work" but may still
+ * refresh a token over the network, since that's not interactive).
+ */
+async function currentIdentity(ctx: PluginContext): Promise<SourceIdentity | null> {
+  const clientId = await ctx.getPreference('clientId');
+  if (!clientId) return null;
+  const tenant = await getTenant(ctx);
+  const manager = createTokenManager(ctx, clientId, tenant);
+
+  try {
+    const accessToken = await manager.getValidAccessToken();
+    return await fetchIdentity(ctx, accessToken);
+  } catch (err) {
+    if (err instanceof NotSignedInError) return null;
+    ctx.log.warn('Microsoft Graph: treating as signed out after a restore/identity failure', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}
+
+/**
+ * Polls a popup for a same-origin redirect. Cross-origin `popup.location`
+ * access throws a `SecurityError` for as long as the popup is still on
+ * `login.microsoftonline.com`; that's expected and simply means "keep
+ * polling" rather than a real failure — only once the popup navigates back to
+ * this app's own origin does reading its URL succeed.
+ */
+function waitForPopupRedirect(popup: Window, redirectOrigin: string, timeoutMs: number): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const startedAt = Date.now();
+    const interval = setInterval(() => {
+      if (popup.closed) {
+        clearInterval(interval);
+        reject(new Error('Microsoft sign-in was cancelled (the popup was closed)'));
+        return;
+      }
+      if (Date.now() - startedAt > timeoutMs) {
+        clearInterval(interval);
+        popup.close();
+        reject(new Error('Microsoft sign-in timed out'));
+        return;
+      }
+      let href: string | undefined;
+      try {
+        href = popup.location.href;
+      } catch {
+        return; // Still cross-origin on the identity provider — keep polling.
+      }
+      if (href.startsWith(redirectOrigin)) {
+        clearInterval(interval);
+        popup.close();
+        resolve(href);
+      }
+    }, POPUP_POLL_MS);
+  });
+}
+
+export const msGraphAuth: SourceAuth = {
+  async restore(ctx: PluginContext): Promise<SourceIdentity | null> {
+    return currentIdentity(ctx);
+  },
+
+  async signIn(ctx: PluginContext): Promise<SourceIdentity> {
+    if (typeof window === 'undefined') {
+      throw new Error('Microsoft sign-in requires a browser (window.open is unavailable in this environment)');
+    }
+
+    const clientId = await requireClientId(ctx);
+    const tenant = await getTenant(ctx);
+    const redirectUri = `${window.location.origin}${REDIRECT_PATH}`;
+
+    const authRequest = await createAuthorizationRequest({
+      authorizationEndpoint: AUTHORIZE_ENDPOINT(tenant),
+      clientId,
+      redirectUri,
+      scope: SCOPES,
+      // Always shows the account picker rather than silently reusing
+      // whichever Microsoft account happens to have an active browser
+      // session — signing into ifc-lite should not depend on which tab was
+      // opened last.
+      extraParams: { prompt: 'select_account' },
+    });
+
+    // `signIn` is documented as "called only from a user gesture" — the host
+    // guarantees this, which is what keeps `window.open` here from being
+    // blocked as an unsolicited popup.
+    const popup = window.open(authRequest.url, 'ifc-lite-msgraph-signin', 'width=500,height=700');
+    if (!popup) {
+      throw new Error('Microsoft sign-in popup was blocked by the browser');
+    }
+
+    let callbackUrl: string;
+    try {
+      callbackUrl = await waitForPopupRedirect(popup, window.location.origin, POPUP_TIMEOUT_MS);
+    } catch (err) {
+      if (!popup.closed) popup.close();
+      throw err;
+    }
+
+    const callback = parseAuthorizationCallback(callbackUrl, {
+      expectedRedirectOrigin: window.location.origin,
+      expectedState: authRequest.state,
+    });
+
+    const tokens = await exchangeAuthorizationCode({
+      tokenEndpoint: TOKEN_ENDPOINT(tenant),
+      clientId,
+      redirectUri,
+      code: callback.code,
+      codeVerifier: authRequest.codeVerifier,
+      fetch: ctx.fetch,
+    });
+
+    const manager = createTokenManager(ctx, clientId, tenant);
+    await manager.setTokens(tokens);
+
+    return fetchIdentity(ctx, tokens.accessToken);
+  },
+
+  async signOut(ctx: PluginContext): Promise<void> {
+    const clientId = await ctx.getPreference('clientId');
+    const tenant = await getTenant(ctx);
+    // A client id is needed to build the `TokenManager` (its storage key is
+    // fixed, but `TokenManagerConfig` still requires one), but signing out
+    // with no client id configured is still meaningful — there may be a
+    // stale token set left over from before the preference was cleared — so
+    // fall back to a placeholder rather than no-op. `TokenManager.clear()`
+    // never uses `clientId` itself, only `storageKey`.
+    const manager = createTokenManager(ctx, clientId ?? 'unconfigured', tenant);
+    await manager.clear();
+  },
+
+  async getIdentity(ctx: PluginContext): Promise<SourceIdentity | null> {
+    return currentIdentity(ctx);
+  },
+};

--- a/packages/source-msgraph/src/auth.ts
+++ b/packages/source-msgraph/src/auth.ts
@@ -33,8 +33,10 @@ const TOKEN_ENDPOINT = (tenant: string) => `https://login.microsoftonline.com/${
  * Note even with `offline_access`: a SPA redirect URI's refresh token is
  * capped at a 24-hour lifetime by Microsoft regardless of how long the
  * *access* token would otherwise be refreshable for (same doc, "Refresh the
- * access token" section) — re-authentication is required at least once a
- * day, though normally silent via the identity platform's own session.
+ * access token" section) — re-authentication is required at least once a day,
+ * and as `signIn` is written below it is not silent: `prompt=select_account`
+ * always renders the account picker, and this package implements no
+ * `prompt=none` path.
  */
 const SCOPES = 'offline_access https://graph.microsoft.com/Files.Read';
 
@@ -64,12 +66,65 @@ export async function getTenant(ctx: PluginContext): Promise<string> {
   return tenant && tenant.length > 0 ? tenant : DEFAULT_TENANT;
 }
 
+/**
+ * One live `TokenManager` per `(clientId, tenant)` pair, for the lifetime of
+ * the page.
+ *
+ * This cache is the load-bearing part, not an allocation optimisation.
+ * `TokenManager` de-duplicates concurrent refreshes on a *per-instance*
+ * `pendingRefresh` promise, and that is the only thing standing between this
+ * provider and a burnt refresh token: Microsoft rotates the refresh token
+ * issued to a `spa` redirect URI on every use, so two callers that each POST
+ * the same stored refresh token get one success and one `invalid_grant` — and
+ * if the loser's write lands last, the persisted set is derived from a token
+ * the server already retired and the session is dead until the user signs in
+ * interactively again. Building a fresh manager per call makes that
+ * de-duplication inert by construction, which is exactly the failure this
+ * cache exists to prevent (see `test/refresh-race.test.ts`).
+ *
+ * Why keyed on `(clientId, tenant)` and not on `ctx`: the host mints a fresh
+ * `PluginContext` per operation (`SourceHost.createContext` in the viewer), so
+ * a listing and a `getIdentity()` racing each other never share one — keying
+ * on `ctx` would de-duplicate nothing. The resource actually being protected
+ * is the single stored token set, which lives under one fixed
+ * {@link STORAGE_KEY} inside the host's per-provider storage namespace, and is
+ * therefore identified by exactly the two preferences that select an account:
+ * the client id and the tenant.
+ *
+ * The consequence is that the first caller's `ctx.fetch`/`ctx.storage` are the
+ * ones the cached manager keeps using. That is sound because both are derived
+ * from this package's (constant) manifest rather than from anything that
+ * varies between contexts — `wrappedFetch` is the manifest's permission check,
+ * `storage` is `localStorage` namespaced by the manifest name — and the two
+ * preferences that *do* vary are the cache key.
+ */
+const managerCache = new Map<string, TokenManager>();
+
+/**
+ * Drops every cached manager. Called on sign-out, where holding an in-flight
+ * refresh (and a `ctx` for a session that no longer exists) past the tokens it
+ * was refreshing would be wrong. Also called by the test suite's
+ * `createGraphMockContext`, so that a fresh mock context can never inherit the
+ * previous test's storage through a cached manager.
+ */
+export function resetTokenManagerCache(): void {
+  managerCache.clear();
+}
+
 /** Shared with `provider.ts`, which needs the same token manager to mint an
  *  access token for plain Graph API calls (listing, download metadata, ...) —
  *  a single definition keeps the storage key and token endpoint from drifting
- *  between the two call sites. */
+ *  between the two call sites, and a single *instance* keeps their refreshes
+ *  from racing (see {@link managerCache}). */
 export function createTokenManager(ctx: PluginContext, clientId: string, tenant: string): TokenManager {
-  return new TokenManager({
+  // A client id is a GUID; a tenant is a GUID, a domain name, or one of
+  // `common`/`organizations`/`consumers`. None of those can contain `|`, so
+  // no two distinct pairs can collide onto a single key.
+  const cacheKey = `${clientId}|${tenant}`;
+  const cached = managerCache.get(cacheKey);
+  if (cached) return cached;
+
+  const manager = new TokenManager({
     storageKey: STORAGE_KEY,
     // `ctx.storage` (`KeyValueStore`) is structurally compatible with
     // `TokenStorage` — see the `@ifc-lite/oauth-pkce` README's storage
@@ -81,6 +136,8 @@ export function createTokenManager(ctx: PluginContext, clientId: string, tenant:
     clientId,
     fetch: ctx.fetch,
   });
+  managerCache.set(cacheKey, manager);
+  return manager;
 }
 
 /** Reads `id`/`displayName`/`mail` off `/me`. Deliberately a live Graph call
@@ -158,7 +215,9 @@ export const msGraphAuth: SourceAuth = {
       // Always shows the account picker rather than silently reusing
       // whichever Microsoft account happens to have an active browser
       // session — signing into ifc-lite should not depend on which tab was
-      // opened last.
+      // opened last. The cost is that no sign-in here is ever silent,
+      // including the daily one the SPA refresh-token cap forces (see the
+      // note on `SCOPES` above and the README's "session length" section).
       extraParams: { prompt: 'select_account' },
     });
 
@@ -226,6 +285,10 @@ export const msGraphAuth: SourceAuth = {
     // never uses `clientId` itself, only `storageKey`.
     const manager = createTokenManager(ctx, clientId ?? 'unconfigured', tenant);
     await manager.clear();
+    // The tokens this manager was caching a refresh lock for are gone; keeping
+    // the instance would leave the next sign-in serializing behind a lock for
+    // a session that no longer exists.
+    resetTokenManagerCache();
   },
 
   async getIdentity(ctx: PluginContext): Promise<SourceIdentity | null> {

--- a/packages/source-msgraph/src/http-client.ts
+++ b/packages/source-msgraph/src/http-client.ts
@@ -20,6 +20,33 @@ function truncate(text: string, max = MAX_ERROR_BODY_CHARS): string {
   return text.length > max ? `${text.slice(0, max)}…` : text;
 }
 
+/**
+ * Strips the query string off a URL before it is logged.
+ *
+ * Only ever applied to pre-signed `@microsoft.graph.downloadUrl` values, where
+ * the query string *is* the credential: OneDrive/SharePoint put a `tempauth`
+ * token there, and anyone holding the complete URL downloads the bytes with no
+ * further authentication. `createPrefixedLogger` gates `debug` behind a flag,
+ * but `error` always reaches `console.error` — the output users copy into bug
+ * reports. Such a URL is usually expired by the time anyone reads the report;
+ * a 5xx from the CDN is precisely the case where it is not.
+ *
+ * The origin and path are kept, since those are what a failed download
+ * actually needs diagnosing (which host served it, which item).
+ *
+ * Deliberately *not* applied to `get()`'s Graph API URLs: those authenticate
+ * with an `Authorization` header, so their query strings hold only `$select`/
+ * `$top`/`$skiptoken` — no credential, and genuinely useful when reading a log.
+ */
+function forLog(url: string): string {
+  try {
+    const parsed = new URL(url);
+    return `${parsed.origin}${parsed.pathname}`;
+  } catch {
+    return '(unparseable url)';
+  }
+}
+
 /** Thrown for a non-2xx Graph API response. Carries the actual HTTP status so
  * callers can branch on it (auth-failure detection in `testConnection`)
  * rather than on substrings of the (possibly truncated) upstream error body. */
@@ -83,13 +110,16 @@ export class BrowserGraphApiClient {
    * outside `permissions.network`.
    */
   async getPublicBinary(url: string, signal?: AbortSignal): Promise<ArrayBuffer> {
-    this.debug('public binary GET request', { url });
+    // Logged without its query string — see `forLog`. The full URL is still
+    // what gets fetched; only what is written to the log is trimmed.
+    const loggableUrl = forLog(url);
+    this.debug('public binary GET request', { url: loggableUrl });
     const response = await this.ctx.fetchPublic(url, { signal });
-    this.debug('public binary GET response', { url, status: response.status, ok: response.ok });
+    this.debug('public binary GET response', { url: loggableUrl, status: response.status, ok: response.ok });
 
     if (!response.ok) {
       const body = await response.text().catch(() => '');
-      this.ctx.log.error('Graph download failed', { url, status: response.status, body });
+      this.ctx.log.error('Graph download failed', { url: loggableUrl, status: response.status, body });
       throw new GraphHttpError(`Microsoft Graph download ${response.status}: ${response.statusText} — ${truncate(body)}`, response.status);
     }
 

--- a/packages/source-msgraph/src/http-client.ts
+++ b/packages/source-msgraph/src/http-client.ts
@@ -1,0 +1,125 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { PluginContext } from '@ifc-lite/plugin-api';
+
+import { decodeCollectionPage } from './msgraph-types.js';
+
+const GRAPH_BASE_URL = 'https://graph.microsoft.com/v1.0';
+
+/** Upstream response bodies are interpolated into thrown `Error` messages,
+ * which reach user-facing toasts unmodified — cap them the same way
+ * `source-dalux` does, so a verbose upstream error page doesn't become a
+ * wall of HTML in the UI. Never includes the request's own `Authorization`
+ * header value, which never reaches this function in the first place —
+ * `ctx.fetch` attaches it. */
+const MAX_ERROR_BODY_CHARS = 200;
+
+function truncate(text: string, max = MAX_ERROR_BODY_CHARS): string {
+  return text.length > max ? `${text.slice(0, max)}…` : text;
+}
+
+/** Thrown for a non-2xx Graph API response. Carries the actual HTTP status so
+ * callers can branch on it (auth-failure detection in `testConnection`)
+ * rather than on substrings of the (possibly truncated) upstream error body. */
+export class GraphHttpError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+    this.name = 'GraphHttpError';
+  }
+}
+
+export class BrowserGraphApiClient {
+  constructor(
+    private readonly accessToken: string,
+    private readonly ctx: PluginContext,
+  ) {}
+
+  debug(message: string, details?: Record<string, unknown>): void {
+    this.ctx.log.debug(`Graph ${message}`, details ?? {});
+  }
+
+  /**
+   * GETs a Graph API endpoint. `path` is either an absolute URL (used to
+   * follow `@odata.nextLink`/`@odata.deltaLink`, which are already
+   * fully-qualified) or a path relative to {@link GRAPH_BASE_URL}.
+   */
+  async get(path: string, params: Record<string, string> = {}, signal?: AbortSignal): Promise<unknown> {
+    const url = new URL(path.startsWith('http') ? path : `${GRAPH_BASE_URL}${path}`);
+    for (const [key, value] of Object.entries(params)) {
+      if (value === undefined || value === null || value === '') continue;
+      url.searchParams.set(key, value);
+    }
+
+    this.debug('GET request', { url: url.toString() });
+    const response = await this.ctx.fetch(url.toString(), {
+      headers: {
+        Authorization: `Bearer ${this.accessToken}`,
+        Accept: 'application/json',
+      },
+      signal,
+    });
+    this.debug('GET response', { url: url.toString(), status: response.status, ok: response.ok });
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => '');
+      this.ctx.log.error('Graph GET failed', { url: url.toString(), status: response.status, body });
+      throw new GraphHttpError(`Microsoft Graph ${response.status}: ${response.statusText} — ${truncate(body)}`, response.status);
+    }
+
+    return response.json() as Promise<unknown>;
+  }
+
+  /**
+   * Fetches file bytes from a pre-signed `@microsoft.graph.downloadUrl`
+   * through `ctx.fetchPublic` — never `ctx.fetch` / this client's own
+   * `Authorization` header. See the doc comment on `download()` in
+   * `provider.ts` for why: these URLs are pre-authenticated, invalidated by
+   * an `Authorization` header, and hosted on a tenant-specific CDN host
+   * outside `permissions.network`.
+   */
+  async getPublicBinary(url: string, signal?: AbortSignal): Promise<ArrayBuffer> {
+    this.debug('public binary GET request', { url });
+    const response = await this.ctx.fetchPublic(url, { signal });
+    this.debug('public binary GET response', { url, status: response.status, ok: response.ok });
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => '');
+      this.ctx.log.error('Graph download failed', { url, status: response.status, body });
+      throw new GraphHttpError(`Microsoft Graph download ${response.status}: ${response.statusText} — ${truncate(body)}`, response.status);
+    }
+
+    return response.arrayBuffer();
+  }
+}
+
+export interface GraphPageResult {
+  readonly items: readonly unknown[];
+  /** `@odata.nextLink`, passed straight through as the plugin API's opaque cursor. */
+  readonly cursor?: string;
+  /** `@odata.deltaLink` — only present on `/delta` responses once the feed has caught up. */
+  readonly deltaLink?: string;
+}
+
+/**
+ * Fetches exactly one page of a Graph `@odata.nextLink`-paginated endpoint.
+ * Deliberately doesn't loop — `listContainers`/`listFiles`/`searchFiles` page
+ * one Graph call at a time and let the host drive, the same discipline
+ * `source-dalux`'s `fetchPage` documents for the same reason: never eagerly
+ * load a whole (potentially huge) drive into memory before returning the
+ * first row.
+ */
+export async function fetchPage(
+  client: BrowserGraphApiClient,
+  endpointOrCursor: string,
+  params: Record<string, string>,
+  signal?: AbortSignal,
+): Promise<GraphPageResult> {
+  const response = await client.get(endpointOrCursor, params, signal);
+  const decoded = decodeCollectionPage(response);
+  return { items: decoded.items, cursor: decoded.nextLink, deltaLink: decoded.deltaLink };
+}

--- a/packages/source-msgraph/src/index.ts
+++ b/packages/source-msgraph/src/index.ts
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+export { MsGraphProvider } from './provider.js';
+export { MSGRAPH_MANIFEST } from './manifest.js';
+export { REDIRECT_PATH } from './auth.js';

--- a/packages/source-msgraph/src/manifest.ts
+++ b/packages/source-msgraph/src/manifest.ts
@@ -1,0 +1,92 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { PluginManifest } from '@ifc-lite/plugin-api';
+
+export const MSGRAPH_MANIFEST: PluginManifest = {
+  name: 'msgraph-onedrive',
+  title: 'OneDrive / SharePoint',
+  api: '^2.0.0',
+  auth: 'interactive',
+  permissions: {
+    // `graph.microsoft.com` for every Graph API call (listing, metadata,
+    // delta) — the single global Graph host, which sends CORS headers for
+    // SPAs registered with a `spa` redirect URI, so no relay is needed here
+    // unlike Dalux. `login.microsoftonline.com` for the authorization-code
+    // and refresh-token exchanges in `auth.ts` (`@ifc-lite/oauth-pkce`'s
+    // `exchangeAuthorizationCode`/`refreshAccessToken`), which also go
+    // through `ctx.fetch` and are therefore checked against this same list —
+    // that request carries no bearer token (it's the PKCE code/verifier
+    // exchange itself), so this isn't a case of sending Graph credentials
+    // to a different host.
+    network: ['graph.microsoft.com', 'login.microsoftonline.com'],
+    // Pre-signed `@microsoft.graph.downloadUrl` values point at a
+    // tenant/CDN-specific host that isn't knowable at build time: OneDrive
+    // Consumer serves them from `*.files.1drv.com`, OneDrive for
+    // Business/SharePoint from `*.sharepoint.com` (observed as both the
+    // `<tenant>.sharepoint.com` and `<tenant>-my.sharepoint.com` forms, both
+    // matched by the same wildcard). See `download()` in `provider.ts` for
+    // why these URLs are fetched via `ctx.fetchPublic` rather than
+    // `ctx.fetch`.
+    publicNetwork: ['*.sharepoint.com', '*.files.1drv.com'],
+  },
+  // The interactive-auth doc on `PluginAuthKind` (`@ifc-lite/plugin-api`)
+  // says preferences may still be declared "alongside" interactive auth.
+  // Used here for exactly what isn't allowed to be committed: the Azure AD
+  // app registration's client id, and the tenant to sign into. Neither is a
+  // secret — this is a public client (PKCE, no client_secret) — so a plain
+  // textfield is enough; there's no API key to protect.
+  preferences: [
+    {
+      name: 'clientId',
+      title: 'Azure AD application (client) ID',
+      description:
+        'The Application (client) ID of the Azure AD app registration used for sign-in. ' +
+        'Configured by the party hosting this viewer — see the package README for what ' +
+        'to register.',
+      type: 'textfield',
+      required: true,
+    },
+    {
+      name: 'tenant',
+      title: 'Tenant',
+      description:
+        'Azure AD tenant to authenticate against. Use "common" (default) to allow both work/school ' +
+        'and personal Microsoft accounts, "organizations" for work/school accounts only, or a specific ' +
+        'tenant ID/domain to restrict sign-in to one organization.',
+      type: 'textfield',
+      required: false,
+      default: 'common',
+    },
+  ],
+  capabilities: {
+    // Graph has a real per-folder `/children` endpoint — no need to sweep
+    // and nest client-side the way Dalux's flat folder listing requires.
+    containerListing: 'direct-children',
+    listFilesIsRecursive: false,
+    // `GET /items/{id}/versions` lists history.
+    revisionHistory: true,
+    // Listing history and fetching its bytes are different capabilities
+    // (see the doc comment on `downloadHistoricalRevisions` in
+    // `@ifc-lite/plugin-api`, which names this exact provider as the
+    // motivating case): a `driveItemVersion` exposes no
+    // `@microsoft.graph.downloadUrl`, and `GET .../versions/{id}/content`
+    // 302-redirects to a preauthenticated URL the same way the current-content
+    // endpoint does — a redirect a browser can't follow while attaching the
+    // `Authorization` header a CORS preflight requires. See the comment on
+    // `download()` in `provider.ts` for the citation on the *current*-content
+    // case; the historical-version endpoint is undocumented for
+    // `@microsoft.graph.downloadUrl` and was verified to expose no such
+    // property via the `driveItemVersion` resource (`docs/resources/driveitemversion`,
+    // Microsoft Learn, checked 2026-08-15) and no CORS-safe alternative.
+    downloadHistoricalRevisions: false,
+    // `GET /me/drive/root/delta` is a real change feed.
+    changeDetection: true,
+    // `GET /me/drive/root/search(q='...')`.
+    search: true,
+  },
+  contributes: {
+    fileSources: ['./src/provider.ts'],
+  },
+};

--- a/packages/source-msgraph/src/mapping.ts
+++ b/packages/source-msgraph/src/mapping.ts
@@ -1,0 +1,145 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { PluginContext, SourceContainer, SourceFile, SourceRevision } from '@ifc-lite/plugin-api';
+
+import { decodeDriveItem, decodeDriveItemVersion } from './msgraph-types.js';
+import type { GraphDecoder, GraphDriveItem, GraphDriveItemVersion } from './msgraph-types.js';
+
+/**
+ * Internal sentinel meaning "the drive root" wherever this module builds a
+ * Graph URL. Graph addresses the root via the well-known path segment `root`
+ * (`/me/drive/root`, `/me/drive/root/children`), which is distinct from any
+ * real `driveItem.id` — those are opaque, non-numeric tokens Graph mints
+ * (e.g. `01BYE5RZ...`) and never the bare string `"root"` — so this is safe
+ * the same way `source-dalux`'s `LATEST_REVISION` is: a value chosen to be
+ * unambiguous against what the real API actually mints, not a formally
+ * proven-impossible collision.
+ *
+ * Never returned as a `SourceContainer.id` — `listContainers` with no
+ * `parentId` returns the drive root's real child folders directly (each with
+ * `parentId: undefined`), matching the plugin contract's "top level" shape
+ * exactly rather than wrapping it in a synthetic container. One consequence,
+ * documented in the package README: a file sitting directly at the drive
+ * root (not inside any folder) has no `SourceContainer` to be addressed
+ * through and is not currently listed by this provider.
+ */
+export const ROOT_CONTAINER_ID = 'root';
+
+/** The `/children` (or `/search`) endpoint path for a given container id. */
+export function childrenEndpoint(containerId: string | undefined): string {
+  if (!containerId || containerId === ROOT_CONTAINER_ID) return '/me/drive/root/children';
+  return `/me/drive/items/${enc(containerId)}/children`;
+}
+
+export function enc(segment: string): string {
+  return encodeURIComponent(segment);
+}
+
+export function orUndefined<T>(value: T | null | undefined): T | undefined {
+  return value ?? undefined;
+}
+
+/**
+ * The item's current revision identity, per the plugin API contract: "must
+ * change when the bytes change and must not change when only metadata
+ * changes." `cTag` ("content tag") is Graph's own field for exactly that
+ * distinction — it changes only when the file's content changes, unlike
+ * `eTag`, which also changes on a rename or a metadata-only edit. Falls back
+ * to `eTag`, then to the item id itself, for the rare item missing `cTag`
+ * (folders don't have one; this function is only ever called on files).
+ */
+export function currentRevisionId(item: Pick<GraphDriveItem, 'id' | 'cTag' | 'eTag'>): string {
+  return item.cTag ?? item.eTag ?? item.id;
+}
+
+export function toSourceContainer(item: GraphDriveItem, parentId: string | undefined): SourceContainer {
+  return {
+    id: item.id,
+    name: item.name,
+    parentId,
+    hasChildren: item.folder?.childCount !== undefined ? item.folder.childCount > 0 : undefined,
+    meta: { kind: 'folder' },
+  };
+}
+
+export function toSourceFile(item: GraphDriveItem, containerId: string): SourceFile {
+  return {
+    id: item.id,
+    name: item.name,
+    containerId,
+    mimeType: item.file?.mimeType,
+    sizeBytes: item.size,
+    currentRevisionId: currentRevisionId(item),
+    modifiedAt: item.lastModifiedDateTime,
+    modifiedBy: item.lastModifiedBy?.user?.displayName ?? item.lastModifiedBy?.application?.displayName,
+    meta: { downloadUrl: item['@microsoft.graph.downloadUrl'] },
+  };
+}
+
+export function toSourceRevision(version: GraphDriveItemVersion): SourceRevision {
+  return {
+    id: version.id,
+    label: `Version ${version.id}`,
+    createdAt: version.lastModifiedDateTime ?? new Date(0).toISOString(),
+    createdBy: version.lastModifiedBy?.user?.displayName ?? version.lastModifiedBy?.application?.displayName,
+    sizeBytes: version.size,
+  };
+}
+
+/**
+ * Decodes a raw item list, dropping (with a logged warning) any record that
+ * fails to decode instead of throwing — mirrors `source-dalux`'s
+ * `convertListLenient`: one malformed row in a large drive listing
+ * shouldn't cost the user every other row that decoded fine.
+ */
+export function convertListLenient<T>(ctx: PluginContext, items: readonly unknown[], decode: GraphDecoder<T>, typeName: string): T[] {
+  const results: T[] = [];
+  for (const item of items) {
+    try {
+      results.push(decode(item));
+    } catch (err) {
+      ctx.log.warn(`Microsoft Graph: dropping invalid ${typeName} record`, {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+  return results;
+}
+
+export function decodeDriveItems(ctx: PluginContext, items: readonly unknown[]): GraphDriveItem[] {
+  return convertListLenient(ctx, items, decodeDriveItem, 'driveItem');
+}
+
+export function decodeDriveItemVersions(ctx: PluginContext, items: readonly unknown[]): GraphDriveItemVersion[] {
+  return convertListLenient(ctx, items, decodeDriveItemVersion, 'driveItemVersion');
+}
+
+const DEFAULT_PAGE_SIZE = 200;
+/** Graph's own ceiling for `$top` on driveItem collections. */
+const MAX_PAGE_SIZE = 999;
+
+/** Clamps `ListOptions.limit` ("Hint only; providers clamp to whatever their
+ *  API allows" per the contract) to a value Graph's `$top` will accept. */
+export function clampPageSize(limit: number | undefined): string {
+  const requested = limit && limit > 0 ? Math.floor(limit) : DEFAULT_PAGE_SIZE;
+  return String(Math.min(requested, MAX_PAGE_SIZE));
+}
+
+/**
+ * Builds the path for Graph's `search(q='...')` function on the drive root.
+ * The query text is embedded in the URL path itself (not a query-string
+ * parameter), inside a single-quoted OData string literal — so a literal
+ * single quote in the user's search text must be escaped by doubling it
+ * (OData string-literal escaping, the same rule SQL uses), not by percent-
+ * encoding, or Graph would see an early close of the literal and reject the
+ * request as malformed rather than searching for the user's actual text.
+ * `encodeURIComponent` runs after that doubling and leaves `'` untouched (it
+ * is not one of the characters `encodeURIComponent` escapes), so the escaped
+ * quotes survive into the final URL exactly as OData expects them.
+ */
+export function searchEndpoint(query: string): string {
+  const escaped = query.replace(/'/g, "''");
+  return `/me/drive/root/search(q='${encodeURIComponent(escaped)}')`;
+}

--- a/packages/source-msgraph/src/mapping.ts
+++ b/packages/source-msgraph/src/mapping.ts
@@ -64,6 +64,19 @@ export function toSourceContainer(item: GraphDriveItem, parentId: string | undef
   };
 }
 
+/**
+ * Note what is deliberately *not* carried over: the item's
+ * `@microsoft.graph.downloadUrl`. That URL is pre-authenticated — holding it
+ * is enough to download the bytes, with no credential and no header, which is
+ * exactly why `download()` fetches it through `ctx.fetchPublic`. `SourceFile`
+ * is a value the host treats as opaque and persists whole: the viewer
+ * serialises entire `SourceFile[]` arrays into `localStorage` for its catalog
+ * cache. Putting a credential-equivalent value in a field designed to be
+ * persisted is the wrong shape regardless of whether a given provider's
+ * capabilities currently reach that code path, and `download()` re-fetches the
+ * URL fresh anyway (these URLs are short-lived, so a cached one would be
+ * useless as well as unsafe).
+ */
 export function toSourceFile(item: GraphDriveItem, containerId: string): SourceFile {
   return {
     id: item.id,
@@ -74,10 +87,33 @@ export function toSourceFile(item: GraphDriveItem, containerId: string): SourceF
     currentRevisionId: currentRevisionId(item),
     modifiedAt: item.lastModifiedDateTime,
     modifiedBy: item.lastModifiedBy?.user?.displayName ?? item.lastModifiedBy?.application?.displayName,
-    meta: { downloadUrl: item['@microsoft.graph.downloadUrl'] },
   };
 }
 
+/**
+ * Two id spaces, deliberately not reconciled.
+ *
+ * `SourceFile.currentRevisionId` is the item's `cTag` (see
+ * {@link currentRevisionId}) — the only Graph field that satisfies the plugin
+ * contract's "changes when the bytes change, not when metadata changes". A
+ * `driveItemVersion.id`, in contrast, is a SharePoint version *label* (`"1.0"`,
+ * `"2.0"`), which is what `SourceRevision.id` is documented to be ("SharePoint
+ * version labels are `"1.0"` and `"2.0"`, not integers"). Graph offers no field
+ * that is both, and no way to map one to the other without an extra request
+ * per version.
+ *
+ * The visible consequence: a `SourceFileRef.revisionId` naming the newest
+ * *listed* revision (`"2.0"`) will not equal the item's `currentRevisionId`
+ * (`cTag`), so `download()` rejects it as historical even though it names the
+ * current bytes. That is a documented no-op rather than a bug, because
+ * `capabilities.downloadHistoricalRevisions` is `false`, and the contract on
+ * that flag says "Hosts must not offer 'load this older revision' when this is
+ * false" — the only `revisionId` a host may hand back is the one this provider
+ * gave it on the `SourceFile`, which is the cTag and matches. Reconciling the
+ * spaces would mean paying a request per listed version to buy nothing that
+ * any caller is allowed to use; if `downloadHistoricalRevisions` ever becomes
+ * `true`, this is the thing to fix first.
+ */
 export function toSourceRevision(version: GraphDriveItemVersion): SourceRevision {
   return {
     id: version.id,

--- a/packages/source-msgraph/src/msgraph-types.ts
+++ b/packages/source-msgraph/src/msgraph-types.ts
@@ -1,0 +1,172 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// ============================================================================
+// Hand-written decoders for the slice of Microsoft Graph's driveItem/drive
+// shapes this provider reads. Reject wrong-typed fields rather than coerce
+// them — a decode failure drops that one row (see `convertListLenient` in
+// `mapping.ts`) instead of corrupting a listing with guessed data.
+// ============================================================================
+
+export interface GraphFolderFacet {
+  readonly childCount?: number;
+}
+
+export interface GraphFileFacet {
+  readonly mimeType?: string;
+}
+
+export interface GraphDeletedFacet {
+  readonly state?: string;
+}
+
+export interface GraphIdentity {
+  readonly id?: string;
+  readonly displayName?: string;
+}
+
+export interface GraphIdentitySet {
+  readonly user?: GraphIdentity;
+  readonly application?: GraphIdentity;
+}
+
+export interface GraphDriveItem {
+  readonly id: string;
+  readonly name: string;
+  readonly size?: number;
+  readonly cTag?: string;
+  readonly eTag?: string;
+  readonly lastModifiedDateTime?: string;
+  readonly lastModifiedBy?: GraphIdentitySet;
+  readonly folder?: GraphFolderFacet;
+  readonly file?: GraphFileFacet;
+  readonly deleted?: GraphDeletedFacet;
+  readonly parentReference?: { readonly id?: string };
+  readonly ['@microsoft.graph.downloadUrl']?: string;
+}
+
+export interface GraphDriveItemVersion {
+  readonly id: string;
+  readonly size?: number;
+  readonly lastModifiedDateTime?: string;
+  readonly lastModifiedBy?: GraphIdentitySet;
+}
+
+export interface GraphDrive {
+  readonly id: string;
+  readonly name?: string;
+  readonly driveType?: string;
+  readonly owner?: GraphIdentitySet;
+}
+
+/** `{ value: T[], '@odata.nextLink'?: string }` — every Graph collection response. */
+export interface GraphCollectionPage<T> {
+  readonly value: readonly T[];
+  readonly ['@odata.nextLink']?: string;
+  /** Present on `/delta` responses once the feed has caught up. */
+  readonly ['@odata.deltaLink']?: string;
+}
+
+export type GraphDecoder<T> = (raw: unknown) => T;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function requireString(record: Record<string, unknown>, key: string, context: string): string {
+  const value = record[key];
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`Graph ${context}: field "${key}" is missing or not a non-empty string`);
+  }
+  return value;
+}
+
+function optionalString(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+function optionalNumber(record: Record<string, unknown>, key: string): number | undefined {
+  const value = record[key];
+  return typeof value === 'number' ? value : undefined;
+}
+
+function optionalIdentitySet(record: Record<string, unknown>, key: string): GraphIdentitySet | undefined {
+  const value = record[key];
+  if (!isRecord(value)) return undefined;
+  const user = isRecord(value.user)
+    ? { id: optionalString(value.user, 'id'), displayName: optionalString(value.user, 'displayName') }
+    : undefined;
+  const application = isRecord(value.application)
+    ? {
+        id: optionalString(value.application, 'id'),
+        displayName: optionalString(value.application, 'displayName'),
+      }
+    : undefined;
+  return { user, application };
+}
+
+export function decodeDriveItem(raw: unknown): GraphDriveItem {
+  if (!isRecord(raw)) throw new Error('Graph driveItem: not an object');
+  const id = requireString(raw, 'id', 'driveItem');
+  const name = requireString(raw, 'name', 'driveItem');
+
+  const folder = isRecord(raw.folder) ? { childCount: optionalNumber(raw.folder, 'childCount') } : undefined;
+  const file = isRecord(raw.file) ? { mimeType: optionalString(raw.file, 'mimeType') } : undefined;
+  const deleted = isRecord(raw.deleted) ? { state: optionalString(raw.deleted, 'state') } : undefined;
+  const parentReference = isRecord(raw.parentReference)
+    ? { id: optionalString(raw.parentReference, 'id') }
+    : undefined;
+
+  return {
+    id,
+    name,
+    size: optionalNumber(raw, 'size'),
+    cTag: optionalString(raw, 'cTag'),
+    eTag: optionalString(raw, 'eTag'),
+    lastModifiedDateTime: optionalString(raw, 'lastModifiedDateTime'),
+    lastModifiedBy: optionalIdentitySet(raw, 'lastModifiedBy'),
+    folder,
+    file,
+    deleted,
+    parentReference,
+    '@microsoft.graph.downloadUrl': optionalString(raw, '@microsoft.graph.downloadUrl'),
+  };
+}
+
+export function decodeDriveItemVersion(raw: unknown): GraphDriveItemVersion {
+  if (!isRecord(raw)) throw new Error('Graph driveItemVersion: not an object');
+  const id = requireString(raw, 'id', 'driveItemVersion');
+  return {
+    id,
+    size: optionalNumber(raw, 'size'),
+    lastModifiedDateTime: optionalString(raw, 'lastModifiedDateTime'),
+    lastModifiedBy: optionalIdentitySet(raw, 'lastModifiedBy'),
+  };
+}
+
+export function decodeDrive(raw: unknown): GraphDrive {
+  if (!isRecord(raw)) throw new Error('Graph drive: not an object');
+  const id = requireString(raw, 'id', 'drive');
+  return {
+    id,
+    name: optionalString(raw, 'name'),
+    driveType: optionalString(raw, 'driveType'),
+    owner: optionalIdentitySet(raw, 'owner'),
+  };
+}
+
+/** Normalizes a Graph collection response body, tolerating a body that failed
+ * to parse as the expected shape (treated as an empty page rather than a hard
+ * throw — a malformed *page* is a provider-detectable error via the
+ * individual item decoders below, not this envelope). */
+export function decodeCollectionPage(raw: unknown): { items: readonly unknown[]; nextLink?: string; deltaLink?: string } {
+  if (!isRecord(raw)) return { items: [] };
+  const value = Array.isArray(raw.value) ? raw.value : [];
+  return {
+    items: value,
+    nextLink: optionalString(raw, '@odata.nextLink'),
+    deltaLink: optionalString(raw, '@odata.deltaLink'),
+  };
+}

--- a/packages/source-msgraph/src/provider.ts
+++ b/packages/source-msgraph/src/provider.ts
@@ -166,6 +166,11 @@ export class MsGraphProvider implements FileSourceProvider {
       // on that flag in `@ifc-lite/plugin-api`), but this stays a loud error
       // rather than silently serving the wrong (current) bytes for whatever
       // older revision was actually requested.
+      //
+      // Note this compares against the cTag, while `listRevisions` reports
+      // SharePoint version labels — so even the newest *listed* revision is
+      // rejected here. Why that is correct rather than a gap is written out on
+      // `toSourceRevision` in `mapping.ts`.
       throw new Error(
         `Microsoft Graph provider cannot download historical revision "${ref.revisionId}" of ${ref.fileId} — ` +
           'only the current revision is retrievable (Graph exposes no CORS-safe download URL for old versions).',

--- a/packages/source-msgraph/src/provider.ts
+++ b/packages/source-msgraph/src/provider.ts
@@ -1,0 +1,286 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { matchesGlob } from '@ifc-lite/plugin-api';
+import type {
+  ConnectionTestResult,
+  DownloadOptions,
+  FileFilter,
+  FileSourceProvider,
+  ListOptions,
+  ListProjectsOptions,
+  Page,
+  PluginContext,
+  RevisionEvent,
+  RevisionWatchResult,
+  SourceContainer,
+  SourceFile,
+  SourceFileRef,
+  SourceProject,
+  SourceRevision,
+} from '@ifc-lite/plugin-api';
+
+import { msGraphAuth, createTokenManager, getTenant, requireClientId } from './auth.js';
+import { BrowserGraphApiClient, GraphHttpError, fetchPage } from './http-client.js';
+import { decodeDrive, decodeDriveItem } from './msgraph-types.js';
+import {
+  childrenEndpoint,
+  clampPageSize,
+  currentRevisionId,
+  decodeDriveItems,
+  decodeDriveItemVersions,
+  enc,
+  searchEndpoint,
+  toSourceContainer,
+  toSourceFile,
+  toSourceRevision,
+} from './mapping.js';
+import { MSGRAPH_MANIFEST } from './manifest.js';
+
+/** The single project this provider exposes. Delegated `Files.Read` grants
+ *  no "list every site/drive I can see" endpoint (Sites.Read.All would, but
+ *  that's a higher-privileged, admin-consentable scope this provider
+ *  deliberately doesn't request — see the manifest and README) — only the
+ *  signed-in user's own default drive is structurally enumerable without it.
+ *  A fixed, single project id keeps that honest instead of inventing project
+ *  discovery this scope can't actually back. */
+const ME_PROJECT_ID = 'me';
+
+export class MsGraphProvider implements FileSourceProvider {
+  readonly manifest = MSGRAPH_MANIFEST;
+  readonly auth = msGraphAuth;
+
+  async listProjects(ctx: PluginContext, _options?: ListProjectsOptions): Promise<Page<SourceProject>> {
+    const client = await this.createClient(ctx);
+    const raw = await client.get('/me/drive', { $select: 'id,name,driveType,owner' });
+    const drive = decodeDrive(raw);
+
+    return {
+      items: [
+        {
+          id: ME_PROJECT_ID,
+          name: drive.name && drive.name.length > 0 ? drive.name : 'OneDrive',
+          meta: { driveId: drive.id, driveType: drive.driveType, owner: drive.owner?.user?.displayName },
+        },
+      ],
+      // Exactly one project is ever known — see `ME_PROJECT_ID`'s doc comment.
+      cursor: undefined,
+    };
+  }
+
+  async listContainers(
+    ctx: PluginContext,
+    _projectId: string,
+    parentId?: string,
+    options?: ListOptions,
+  ): Promise<Page<SourceContainer>> {
+    const client = await this.createClient(ctx);
+    const endpoint = options?.cursor ?? childrenEndpoint(parentId);
+    const params: Record<string, string> = options?.cursor ? {} : { $top: clampPageSize(options?.limit) };
+    const page = await fetchPage(client, endpoint, params, options?.signal);
+    const items = decodeDriveItems(ctx, page.items);
+
+    const containers = items
+      .filter((item) => item.folder !== undefined)
+      .map((item) => toSourceContainer(item, parentId));
+
+    return { items: containers, cursor: page.cursor };
+  }
+
+  async listFiles(
+    ctx: PluginContext,
+    _projectId: string,
+    containerId: string,
+    filter?: FileFilter,
+    options?: ListOptions,
+  ): Promise<Page<SourceFile>> {
+    const client = await this.createClient(ctx);
+    const endpoint = options?.cursor ?? childrenEndpoint(containerId);
+    const params: Record<string, string> = options?.cursor ? {} : { $top: clampPageSize(options?.limit) };
+    const page = await fetchPage(client, endpoint, params, options?.signal);
+    const items = decodeDriveItems(ctx, page.items);
+
+    let files = items.filter((item) => item.file !== undefined).map((item) => toSourceFile(item, containerId));
+    files = applyFileFilter(files, filter);
+
+    return { items: files, cursor: page.cursor };
+  }
+
+  async searchFiles(
+    ctx: PluginContext,
+    _projectId: string,
+    query: string,
+    filter?: FileFilter,
+    options?: ListOptions,
+  ): Promise<Page<SourceFile>> {
+    const client = await this.createClient(ctx);
+    const endpoint = options?.cursor ?? searchEndpoint(query);
+    const params: Record<string, string> = options?.cursor ? {} : { $top: clampPageSize(options?.limit) };
+    const page = await fetchPage(client, endpoint, params, options?.signal);
+    const items = decodeDriveItems(ctx, page.items);
+
+    // Search results carry `parentReference.id` rather than the queried
+    // containerId (a search can span the whole drive) — each file's real
+    // parent, same "not necessarily the one queried" rule `SourceFile.containerId`
+    // documents.
+    let files = items
+      .filter((item) => item.file !== undefined)
+      .map((item) => toSourceFile(item, item.parentReference?.id ?? containerFallback(item)));
+    files = applyFileFilter(files, filter);
+
+    return { items: files, cursor: page.cursor };
+  }
+
+  /**
+   * Downloads a file's bytes. Fetches the item's pre-signed
+   * `@microsoft.graph.downloadUrl` and retrieves *that* URL — never
+   * `GET .../content` directly.
+   *
+   * Per Microsoft Graph's own docs ("Download driveItem content",
+   * `learn.microsoft.com/graph/api/driveitem-get-content`, section
+   * "Downloading files in JavaScript apps", checked 2026-08-15): `/content`
+   * returns a `302 Found` redirect to the same pre-signed URL, and "you can't
+   * use the `/content` API [in a JavaScript app], because this responds with
+   * a `302` redirect. A `302` redirect is explicitly prohibited when a
+   * [CORS] preflight is required, such as when providing the Authorization
+   * header." The docs' own fix is exactly this: "select the
+   * `@microsoft.graph.downloadUrl` property... requested directly using
+   * XMLHttpRequest. Because these URLs are preauthenticated, they can be
+   * retrieved without a CORS preflight" — i.e. with no `Authorization` header
+   * at all, which is why this goes through `ctx.fetchPublic` (strips every
+   * header except `Accept`/`Range`) rather than `ctx.fetch`.
+   */
+  async download(ctx: PluginContext, ref: SourceFileRef, options?: DownloadOptions): Promise<ArrayBuffer> {
+    const client = await this.createClient(ctx);
+    const raw = await client.get(
+      `/me/drive/items/${enc(ref.fileId)}`,
+      { $select: 'id,name,cTag,eTag,@microsoft.graph.downloadUrl' },
+      options?.signal,
+    );
+    const item = decodeDriveItem(raw);
+
+    if (ref.revisionId && ref.revisionId !== currentRevisionId(item)) {
+      // `capabilities.downloadHistoricalRevisions` is `false` — the host must
+      // never ask for a `revisionId` other than current (see the doc comment
+      // on that flag in `@ifc-lite/plugin-api`), but this stays a loud error
+      // rather than silently serving the wrong (current) bytes for whatever
+      // older revision was actually requested.
+      throw new Error(
+        `Microsoft Graph provider cannot download historical revision "${ref.revisionId}" of ${ref.fileId} — ` +
+          'only the current revision is retrievable (Graph exposes no CORS-safe download URL for old versions).',
+      );
+    }
+
+    const downloadUrl = item['@microsoft.graph.downloadUrl'];
+    if (!downloadUrl) {
+      throw new Error(`Microsoft Graph item ${ref.fileId} does not expose a download URL`);
+    }
+
+    return client.getPublicBinary(downloadUrl, options?.signal);
+  }
+
+  async listRevisions(ctx: PluginContext, ref: SourceFileRef, options?: ListOptions): Promise<Page<SourceRevision>> {
+    const client = await this.createClient(ctx);
+    const endpoint = options?.cursor ?? `/me/drive/items/${enc(ref.fileId)}/versions`;
+    const page = await fetchPage(client, endpoint, {}, options?.signal);
+    const versions = decodeDriveItemVersions(ctx, page.items);
+
+    return { items: versions.map(toSourceRevision), cursor: page.cursor };
+  }
+
+  /**
+   * Watches for changes via Graph's `/delta` change feed
+   * (`GET /me/drive/root/delta`) rather than polling the given `refs` — per
+   * the contract, "Providers with a delta or change-feed endpoint should use
+   * `cursor` and ignore `refs`, returning a fresh cursor each call."
+   *
+   * `refs` is still consulted, but only to decide which delta items are
+   * worth turning into an event: the feed reports every change across the
+   * whole drive, and a host tracking a handful of files should not be told
+   * about unrelated ones.
+   */
+  async watchRevisions(
+    ctx: PluginContext,
+    refs: readonly SourceFileRef[],
+    cursor?: string,
+    options?: ListOptions,
+  ): Promise<RevisionWatchResult> {
+    const client = await this.createClient(ctx);
+    const endpoint = cursor ?? '/me/drive/root/delta';
+    const page = await fetchPage(client, endpoint, {}, options?.signal);
+    const items = decodeDriveItems(ctx, page.items);
+
+    const trackedById = new Map(refs.map((ref) => [ref.fileId, ref] as const));
+    const events: RevisionEvent[] = [];
+
+    for (const item of items) {
+      const ref = trackedById.get(item.id);
+      if (!ref) continue;
+
+      if (item.deleted) {
+        events.push({ fileId: item.id, latestRevisionId: currentRevisionId(item), deleted: true });
+        continue;
+      }
+
+      const latestRevisionId = currentRevisionId(item);
+      if (!ref.revisionId || ref.revisionId !== latestRevisionId) {
+        events.push({ fileId: item.id, latestRevisionId, previousRevisionId: ref.revisionId });
+      }
+    }
+
+    // `@odata.nextLink` (more pages in this same sync pass) takes priority
+    // over `@odata.deltaLink` (this sync pass is caught up) as the handed-back
+    // cursor — both are valid opaque resume tokens for the next
+    // `watchRevisions` call, but only `nextLink` means "there is more to read
+    // right now."
+    return { events, cursor: page.cursor ?? page.deltaLink };
+  }
+
+  async testConnection(ctx: PluginContext): Promise<ConnectionTestResult> {
+    try {
+      const client = await this.createClient(ctx);
+      await client.get('/me/drive', { $select: 'id' });
+      return { ok: true, message: 'Connected to Microsoft Graph.', projectCount: 1 };
+    } catch (err) {
+      if (err instanceof GraphHttpError && (err.status === 401 || err.status === 403)) {
+        return {
+          ok: false,
+          message: 'Sign-in expired or the account lacks access. Try signing in again.',
+        };
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      return { ok: false, message };
+    }
+  }
+
+  private async createClient(ctx: PluginContext): Promise<BrowserGraphApiClient> {
+    const clientId = await requireClientId(ctx);
+    const tenant = await getTenant(ctx);
+    const manager = createTokenManager(ctx, clientId, tenant);
+    const accessToken = await manager.getValidAccessToken();
+    return new BrowserGraphApiClient(accessToken, ctx);
+  }
+}
+
+function applyFileFilter(files: SourceFile[], filter?: FileFilter): SourceFile[] {
+  let result = files;
+  if (filter?.namePatterns?.length) {
+    const patterns = filter.namePatterns;
+    result = result.filter((file) => patterns.some((pattern) => matchesGlob(file.name, pattern)));
+  }
+  if (filter?.mimeTypes?.length) {
+    const mimeTypes = filter.mimeTypes;
+    result = result.filter((file) => file.mimeType && mimeTypes.includes(file.mimeType));
+  }
+  return result;
+}
+
+/** Search results with no `parentReference` (shouldn't happen for a real
+ *  driveItem, but decoders never assume upstream always sends every optional
+ *  field) fall back to the drive root rather than an empty string, which
+ *  would otherwise become an unaddressable `containerId` no `listFiles` call
+ *  could ever repeat. */
+function containerFallback(_item: { readonly id: string }): string {
+  return 'root';
+}

--- a/packages/source-msgraph/test/auth.test.ts
+++ b/packages/source-msgraph/test/auth.test.ts
@@ -4,8 +4,10 @@
 
 import { describe, it, expect } from 'vitest';
 
+import { OAUTH_CALLBACK_CHANNEL } from '@ifc-lite/oauth-pkce';
+
 import { msGraphAuth } from '../src/auth.js';
-import { createGraphMockContext } from './msgraph-api-mock.js';
+import { MOCK_ACCESS_TOKEN, createGraphMockContext } from './msgraph-api-mock.js';
 import type { GraphMockWorld } from './msgraph-api-mock.js';
 
 const WORLD: GraphMockWorld = {
@@ -74,5 +76,110 @@ describe('msGraphAuth', () => {
       const ctx = createGraphMockContext(WORLD);
       await expect(msGraphAuth.signIn(ctx)).rejects.toThrow('requires a browser');
     });
+
+    /**
+     * The COOP regression, end to end.
+     *
+     * The viewer serves `Cross-Origin-Opener-Policy: same-origin` (it needs
+     * cross-origin isolation for `SharedArrayBuffer`). Under that header,
+     * opening a CROSS-ORIGIN popup severs the opener link and the returned
+     * `WindowProxy` becomes a stub: `closed` reads `true` while the window is
+     * visibly open, and `location` throws `SecurityError`. That was probed
+     * live in the running viewer for the sibling Dropbox provider, against
+     * both a cross-origin authorization host (severed) and a same-origin
+     * control (normal) — the cause is the popup being cross-origin, and
+     * `login.microsoftonline.com` is just as cross-origin as any other
+     * identity provider.
+     *
+     * The `popup.closed` stub below is that behaviour verbatim. Against the
+     * old poll loop this test fails on the first 250 ms tick with "Microsoft
+     * sign-in was cancelled (the popup was closed)" while the popup is still
+     * on the consent screen, which is exactly what users hit; the flow only
+     * completes if sign-in gets its result from the callback page's broadcast
+     * and never touches the popup at all.
+     */
+    it('completes sign-in from the callback page broadcast, with a popup severed by COOP', async () => {
+      const base = createGraphMockContext(WORLD);
+      await base.storage.delete('msgraph:tokens');
+
+      const tokenRequestBodies: string[] = [];
+      const ctx = {
+        ...base,
+        fetch: ((input: RequestInfo | URL, init?: RequestInit) => {
+          const href = typeof input === 'string' ? input : input.toString();
+          if (href.includes('/oauth2/v2.0/token')) {
+            tokenRequestBodies.push(String(init?.body ?? ''));
+            return Promise.resolve(
+              new Response(
+                JSON.stringify({
+                  access_token: MOCK_ACCESS_TOKEN,
+                  refresh_token: 'mock-refresh-token',
+                  expires_in: 3600,
+                  token_type: 'Bearer',
+                }),
+                { status: 200, headers: { 'Content-Type': 'application/json' } },
+              ),
+            );
+          }
+          return base.fetch(input, init);
+        }) as typeof fetch,
+      };
+
+      let locationReads = 0;
+      const severedPopup = {
+        // What COOP actually reports for a live cross-origin popup.
+        closed: true,
+        close: () => {},
+        get location(): never {
+          locationReads += 1;
+          throw new Error('SecurityError: Blocked a frame with origin from accessing a cross-origin frame.');
+        },
+      };
+
+      const fakeWindow = {
+        location: { origin: 'https://app.example.com' },
+        open: (authorizeUrl: string) => {
+          const state = new URL(authorizeUrl).searchParams.get('state');
+          // Stands in for the user consenting and the identity provider
+          // redirecting the popup to REDIRECT_PATH, where the static callback
+          // page posts.
+          setTimeout(() => {
+            const channel = new BroadcastChannel(OAUTH_CALLBACK_CHANNEL);
+            channel.postMessage({
+              type: OAUTH_CALLBACK_CHANNEL,
+              state,
+              url: `https://app.example.com/oauth/msgraph/callback?code=auth-code-1&state=${state}`,
+            });
+            channel.close();
+          }, 0);
+          return severedPopup;
+        },
+      };
+
+      (globalThis as { window?: unknown }).window = fakeWindow;
+      let identity;
+      try {
+        identity = await msGraphAuth.signIn(ctx);
+      } finally {
+        delete (globalThis as { window?: unknown }).window;
+      }
+
+      expect(identity).toEqual({ id: 'user-1', displayName: 'Mock User', email: 'mock@example.com' });
+      expect(tokenRequestBodies).toHaveLength(1);
+      const exchange = new URLSearchParams(tokenRequestBodies[0]);
+      expect(exchange.get('grant_type')).toBe('authorization_code');
+      expect(exchange.get('code')).toBe('auth-code-1');
+      expect(exchange.get('code_verifier')).toBeTruthy();
+      // The session really was persisted. This is the entry that stayed
+      // missing while the poll loop rejected every sign-in.
+      expect(await ctx.storage.get('msgraph:tokens')).toBeDefined();
+      // Nothing read the inoperable API on the way through.
+      expect(locationReads).toBe(0);
+    });
+
+    // Cross-attempt routing (a broadcast carrying someone else's `state` must
+    // be ignored, not consumed) is covered by `waitForOAuthCallback`'s own
+    // tests in `@ifc-lite/oauth-pkce`. Asserting it through `signIn` would
+    // mean leaving its real 5-minute timeout pending in the test worker.
   });
 });

--- a/packages/source-msgraph/test/auth.test.ts
+++ b/packages/source-msgraph/test/auth.test.ts
@@ -1,0 +1,78 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect } from 'vitest';
+
+import { msGraphAuth } from '../src/auth.js';
+import { createGraphMockContext } from './msgraph-api-mock.js';
+import type { GraphMockWorld } from './msgraph-api-mock.js';
+
+const WORLD: GraphMockWorld = {
+  driveId: 'drive-1',
+  driveName: 'Contoso Drive',
+  items: [],
+};
+
+describe('msGraphAuth', () => {
+  describe('restore', () => {
+    it('returns the identity for a still-valid stored token', async () => {
+      const ctx = createGraphMockContext(WORLD);
+      const identity = await msGraphAuth.restore(ctx);
+      expect(identity).toEqual({ id: 'user-1', displayName: 'Mock User', email: 'mock@example.com' });
+    });
+
+    it('returns null silently when no clientId preference is configured, never throwing', async () => {
+      const ctx = createGraphMockContext(WORLD);
+      const noClientCtx = { ...ctx, getPreference: () => Promise.resolve(undefined) };
+      await expect(msGraphAuth.restore(noClientCtx)).resolves.toBeNull();
+    });
+
+    it('returns null silently when no session is stored, never throwing', async () => {
+      const ctx = createGraphMockContext(WORLD);
+      await ctx.storage.delete('msgraph:tokens');
+      await expect(msGraphAuth.restore(ctx)).resolves.toBeNull();
+    });
+
+    it('returns null (not a throw) when the stored access token is rejected and there is no refresh token', async () => {
+      const ctx = createGraphMockContext(WORLD);
+      await ctx.storage.set(
+        'msgraph:tokens',
+        // Already-expired, no refreshToken — getValidAccessToken() must reject
+        // with NotSignedInError, which restore() is required to swallow.
+        JSON.stringify({ accessToken: 'expired', expiresAt: Date.now() - 1000 }),
+      );
+      await expect(msGraphAuth.restore(ctx)).resolves.toBeNull();
+    });
+  });
+
+  describe('getIdentity', () => {
+    it('mirrors restore() for a signed-in session', async () => {
+      const ctx = createGraphMockContext(WORLD);
+      const identity = await msGraphAuth.getIdentity(ctx);
+      expect(identity?.id).toBe('user-1');
+    });
+  });
+
+  describe('signOut', () => {
+    it('clears the stored token set', async () => {
+      const ctx = createGraphMockContext(WORLD);
+      expect(await ctx.storage.get('msgraph:tokens')).toBeDefined();
+      await msGraphAuth.signOut(ctx);
+      expect(await ctx.storage.get('msgraph:tokens')).toBeUndefined();
+    });
+
+    it('does not throw even with no clientId preference configured', async () => {
+      const ctx = createGraphMockContext(WORLD);
+      const noClientCtx = { ...ctx, getPreference: () => Promise.resolve(undefined) };
+      await expect(msGraphAuth.signOut(noClientCtx)).resolves.toBeUndefined();
+    });
+  });
+
+  describe('signIn', () => {
+    it('throws a clear error in a non-browser environment rather than crashing on window.open', async () => {
+      const ctx = createGraphMockContext(WORLD);
+      await expect(msGraphAuth.signIn(ctx)).rejects.toThrow('requires a browser');
+    });
+  });
+});

--- a/packages/source-msgraph/test/conformance.test.ts
+++ b/packages/source-msgraph/test/conformance.test.ts
@@ -1,0 +1,77 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// Runs the shared `FileSourceProvider` conformance suite (`@ifc-lite/source-fixture`)
+// against the real `MsGraphProvider`, driven by `createGraphApiMock`'s
+// stand-in for the Microsoft Graph REST API. Mirrors
+// `packages/source-dalux/test/conformance.test.ts`.
+
+import { describe } from 'vitest';
+
+import type { ConformanceFixtures } from '@ifc-lite/source-fixture/conformance';
+import { runConformanceSuite } from '@ifc-lite/source-fixture/conformance';
+
+import { MsGraphProvider } from '../src/provider.js';
+import { createGraphMockContext } from './msgraph-api-mock.js';
+import type { GraphMockWorld } from './msgraph-api-mock.js';
+
+/**
+ * Two top-level folders (so the top-level `listContainers` query has a real
+ * page boundary to cross), one of which (`f-alpha`) nests a subfolder and
+ * holds two files (so `listContainers`/`listFiles` scoped queries and their
+ * own boundary checks all have something real to page through), plus a
+ * second file elsewhere matching the same search query.
+ */
+const WORLD: GraphMockWorld = {
+  driveId: 'drive-1',
+  driveName: 'Contoso Drive',
+  items: [
+    { id: 'f-alpha', name: 'Alpha', kind: 'folder', childCount: 1 },
+    { id: 'f-beta', name: 'Beta', kind: 'folder', childCount: 1 },
+    // Files listed before the nested subfolder: `/children` mixes folder and
+    // file items in one Graph response, and `listFiles` (`provider.ts`)
+    // filters to `file` items only *after* paging — so with a small `$top`,
+    // whichever type happens to come first in Graph's own ordering can
+    // legitimately produce an all-folder page with zero files. Real listings
+    // aren't guaranteed to put files first, but this fixture deliberately
+    // does, so the conformance suite's single-page "does this container
+    // genuinely have files" checks (`download.ts`'s aborted-signal check,
+    // which reads only the first page) have something to find without
+    // needing to paginate through folders first.
+    { id: 'file-1', name: 'model.ifc', parentId: 'f-alpha', kind: 'file', size: 12, content: 'MODEL-BYTES-1' },
+    { id: 'file-2', name: 'plan.ifc', parentId: 'f-alpha', kind: 'file', size: 8, content: 'MODEL-BYTES-2' },
+    { id: 'f-alpha-sub', name: 'Sub', parentId: 'f-alpha', kind: 'folder', childCount: 0 },
+    { id: 'file-3', name: 'model-copy.ifc', parentId: 'f-beta', kind: 'file', size: 4, content: 'MODEL-BYTES-3' },
+  ],
+};
+
+const fixtures: ConformanceFixtures = {
+  projectId: 'me',
+  containerWithChildrenId: 'f-alpha',
+  containerWithFilesId: 'f-alpha',
+  searchQuery: 'model',
+  // No `secondProjectId`: this provider exposes exactly one project (the
+  // signed-in user's own drive) — see `ME_PROJECT_ID`'s doc comment in
+  // `provider.ts`.
+  //
+  // No `fileWithRevisions`: `capabilities.downloadHistoricalRevisions` is
+  // `false`, so the download-conformance check this fixture would drive is
+  // gated off regardless (see `download.ts` in `@ifc-lite/source-fixture`).
+};
+
+describe('MsGraphProvider conformance', () => {
+  const provider = new MsGraphProvider();
+  // `$top=1` forces a page boundary on every listing below without needing a
+  // large mock world — Graph genuinely honors `$top` (unlike Dalux's
+  // server-chosen bookmark page size), so `pageBoundary: 'limit'` (the
+  // suite's default) is the honest mode here.
+  const fetchImpl = () => createGraphMockContext(WORLD, { defaultPageSize: 200 });
+
+  runConformanceSuite(provider, {
+    createContext: fetchImpl,
+    fixtures,
+    smallPageLimit: 1,
+    watchRevisionsHasDeltaFeed: true,
+  });
+});

--- a/packages/source-msgraph/test/msgraph-api-mock.ts
+++ b/packages/source-msgraph/test/msgraph-api-mock.ts
@@ -1,0 +1,286 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * An in-memory stand-in for the Microsoft Graph REST API, wired in as a
+ * `PluginContext.fetch` (authenticated calls) and `PluginContext.fetchPublic`
+ * (pre-signed download URLs) pair — mirrors `source-dalux`'s
+ * `dalux-api-mock.ts`, adapted to Graph's `@odata.nextLink` pagination and
+ * its split between an authenticated API host and pre-signed, unauthenticated
+ * CDN download URLs.
+ */
+
+import type { KeyValueStore, Logger, PluginContext } from '@ifc-lite/plugin-api';
+
+export const GRAPH_MOCK_BASE_URL = 'https://graph.microsoft.com/v1.0';
+export const GRAPH_MOCK_DOWNLOAD_HOST = 'https://mock.files.1drv.com';
+export const MOCK_ACCESS_TOKEN = 'mock-access-token';
+
+export interface GraphMockItem {
+  readonly id: string;
+  readonly name: string;
+  /** `undefined` means the item sits directly at the drive root. */
+  readonly parentId?: string;
+  readonly kind: 'folder' | 'file';
+  readonly childCount?: number;
+  readonly size?: number;
+  readonly mimeType?: string;
+  readonly cTag?: string;
+  /** Bytes served through the mock `@microsoft.graph.downloadUrl`. Files only. */
+  readonly content?: string;
+  readonly deleted?: boolean;
+}
+
+export interface GraphMockVersion {
+  readonly id: string;
+  readonly size?: number;
+  readonly lastModifiedDateTime?: string;
+}
+
+export interface GraphMockWorld {
+  readonly driveId: string;
+  readonly driveName: string;
+  readonly items: readonly GraphMockItem[];
+  readonly versionsByFileId?: Readonly<Record<string, readonly GraphMockVersion[]>>;
+}
+
+export interface GraphMockOptions {
+  /** Items per response when the caller doesn't force a smaller `$top`. Default `200`. */
+  readonly defaultPageSize?: number;
+}
+
+interface MockResponseInit {
+  readonly status?: number;
+  readonly json?: unknown;
+  readonly body?: string;
+}
+
+function mockResponse({ status = 200, json, body }: MockResponseInit): Response {
+  const text = body ?? (json === undefined ? '' : JSON.stringify(json));
+  const encoded = new TextEncoder().encode(text);
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : status === 401 ? 'Unauthorized' : status === 404 ? 'Not Found' : 'Error',
+    headers: { get: () => (json === undefined ? 'application/octet-stream' : 'application/json') },
+    json: () => Promise.resolve(json),
+    text: () => Promise.resolve(text),
+    arrayBuffer: () => Promise.resolve(encoded.buffer.slice(encoded.byteOffset, encoded.byteOffset + encoded.byteLength)),
+  } as unknown as Response;
+}
+
+function itemJson(item: GraphMockItem): Record<string, unknown> {
+  return {
+    id: item.id,
+    name: item.name,
+    size: item.size,
+    cTag: item.cTag ?? `ctag-${item.id}`,
+    eTag: `etag-${item.id}`,
+    lastModifiedDateTime: '2026-08-06T10:00:00Z',
+    lastModifiedBy: { user: { id: 'user-1', displayName: 'Mock User' } },
+    parentReference: item.parentId ? { id: item.parentId } : { id: 'root' },
+    ...(item.kind === 'folder' ? { folder: { childCount: item.childCount ?? 0 } } : {}),
+    ...(item.kind === 'file' ? { file: { mimeType: item.mimeType ?? 'application/octet-stream' } } : {}),
+    ...(item.deleted ? { deleted: { state: 'deleted' } } : {}),
+    // Only present when the fixture actually gave this file bytes to serve —
+    // lets a test model a file Graph reports but exposes no download URL for
+    // (`content: undefined`), distinct from a real, downloadable file.
+    ...(item.kind === 'file' && !item.deleted && item.content !== undefined
+      ? { '@microsoft.graph.downloadUrl': downloadUrlFor(item.id) }
+      : {}),
+  };
+}
+
+export function downloadUrlFor(fileId: string): string {
+  return `${GRAPH_MOCK_DOWNLOAD_HOST}/${encodeURIComponent(fileId)}`;
+}
+
+/** Slices a `$top`-paginated page, honoring the caller's own `$top` — unlike
+ *  Dalux, Graph genuinely supports client-controlled page size. Returns the
+ *  literal `@odata.nextLink` key Graph responses use — the provider's
+ *  decoder (`decodeCollectionPage` in `msgraph-types.ts`) reads exactly that
+ *  key, not a friendlier alias. */
+function paginate(
+  rows: readonly Record<string, unknown>[],
+  url: URL,
+  defaultPageSize: number,
+): { value: unknown[]; '@odata.nextLink'?: string } {
+  const top = Number(url.searchParams.get('$top') ?? defaultPageSize) || defaultPageSize;
+  const skip = Number(url.searchParams.get('$skiptoken') ?? 0) || 0;
+  const slice = rows.slice(skip, skip + top);
+  const next = skip + slice.length;
+  const hasMore = next < rows.length;
+
+  if (!hasMore) return { value: slice };
+
+  const nextUrl = new URL(url.toString());
+  nextUrl.searchParams.set('$skiptoken', String(next));
+  return { value: slice, '@odata.nextLink': nextUrl.toString() };
+}
+
+function findItem(world: GraphMockWorld, id: string): GraphMockItem | undefined {
+  return world.items.find((item) => item.id === id);
+}
+
+function childrenOf(world: GraphMockWorld, parentId: string | undefined): GraphMockItem[] {
+  return world.items.filter((item) => (parentId === undefined || parentId === 'root' ? item.parentId === undefined : item.parentId === parentId));
+}
+
+/**
+ * Builds a `fetch` serving `world` over the Graph routes this provider
+ * actually calls. Checks the `Authorization` header against
+ * {@link MOCK_ACCESS_TOKEN} and answers `401` on a mismatch, so
+ * auth-failure handling has something real to exercise. Unrouted paths
+ * answer `404` rather than an empty listing, so a provider change that
+ * starts calling an endpoint this mock doesn't model fails loudly.
+ */
+export function createGraphApiMock(world: GraphMockWorld, options: GraphMockOptions = {}): typeof fetch {
+  const defaultPageSize = options.defaultPageSize ?? 200;
+
+  return ((input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const request = typeof input === 'object' && input !== null && 'url' in input ? (input as Request) : undefined;
+    const href = request ? request.url : input.toString();
+    const signal = init?.signal ?? request?.signal;
+    if (signal?.aborted) {
+      return Promise.reject(new DOMException('The operation was aborted.', 'AbortError'));
+    }
+
+    const headers = new Headers(init?.headers ?? request?.headers);
+    const authorization = headers.get('Authorization');
+    if (authorization !== `Bearer ${MOCK_ACCESS_TOKEN}`) {
+      return Promise.resolve(mockResponse({ status: 401, body: 'invalid_token' }));
+    }
+
+    const url = new URL(href);
+    const path = url.pathname.replace(/^\/v1\.0\/?/, '');
+
+    if (path === 'me' || path === 'me/') {
+      return Promise.resolve(
+        mockResponse({ json: { id: 'user-1', displayName: 'Mock User', mail: 'mock@example.com' } }),
+      );
+    }
+
+    if (path === 'me/drive') {
+      return Promise.resolve(
+        mockResponse({ json: { id: world.driveId, name: world.driveName, driveType: 'business', owner: { user: { displayName: 'Mock Owner' } } } }),
+      );
+    }
+
+    if (path === 'me/drive/root/delta') {
+      const rows = world.items.map(itemJson);
+      const page = paginate(rows, url, defaultPageSize);
+      return Promise.resolve(
+        mockResponse({
+          json: page['@odata.nextLink']
+            ? { value: page.value, '@odata.nextLink': page['@odata.nextLink'] }
+            : { value: page.value, '@odata.deltaLink': `${GRAPH_MOCK_BASE_URL}/me/drive/root/delta?token=done` },
+        }),
+      );
+    }
+
+    if (path === 'me/drive/root/children') {
+      const rows = childrenOf(world, undefined).filter((i) => !i.deleted).map(itemJson);
+      return Promise.resolve(mockResponse({ json: paginate(rows, url, defaultPageSize) }));
+    }
+
+    const searchMatch = path.match(/^me\/drive\/root\/search\(q='(.*)'\)$/);
+    if (searchMatch) {
+      const query = decodeURIComponent(searchMatch[1]).replace(/''/g, "'").toLowerCase();
+      const rows = world.items
+        .filter((i) => !i.deleted && i.kind === 'file' && i.name.toLowerCase().includes(query))
+        .map(itemJson);
+      return Promise.resolve(mockResponse({ json: paginate(rows, url, defaultPageSize) }));
+    }
+
+    const childrenMatch = path.match(/^me\/drive\/items\/([^/]+)\/children$/);
+    if (childrenMatch) {
+      const parentId = decodeURIComponent(childrenMatch[1]);
+      if (!findItem(world, parentId)) return Promise.resolve(mockResponse({ status: 404, body: 'no such item' }));
+      const rows = childrenOf(world, parentId).filter((i) => !i.deleted).map(itemJson);
+      return Promise.resolve(mockResponse({ json: paginate(rows, url, defaultPageSize) }));
+    }
+
+    const versionsMatch = path.match(/^me\/drive\/items\/([^/]+)\/versions$/);
+    if (versionsMatch) {
+      const fileId = decodeURIComponent(versionsMatch[1]);
+      const versions = world.versionsByFileId?.[fileId] ?? [];
+      return Promise.resolve(mockResponse({ json: { value: versions } }));
+    }
+
+    const itemMatch = path.match(/^me\/drive\/items\/([^/]+)$/);
+    if (itemMatch) {
+      const id = decodeURIComponent(itemMatch[1]);
+      const item = findItem(world, id);
+      if (!item) return Promise.resolve(mockResponse({ status: 404, body: 'no such item' }));
+      return Promise.resolve(mockResponse({ json: itemJson(item) }));
+    }
+
+    return Promise.resolve(mockResponse({ status: 404, body: `unrouted: ${url.pathname}` }));
+  }) as typeof fetch;
+}
+
+/** Serves pre-signed `@microsoft.graph.downloadUrl` bytes — never checks for
+ *  an `Authorization` header, since `ctx.fetchPublic` strips it (that's the
+ *  entire point of using this path instead of `/content`). */
+export function createGraphPublicMock(world: GraphMockWorld): typeof fetch {
+  return ((input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const href = typeof input === 'string' ? input : input.toString();
+    if (init?.signal?.aborted) {
+      return Promise.reject(new DOMException('The operation was aborted.', 'AbortError'));
+    }
+    const url = new URL(href);
+    const fileId = decodeURIComponent(url.pathname.slice(1));
+    const item = world.items.find((i) => i.id === fileId && i.kind === 'file');
+    if (!item || item.content === undefined) return Promise.resolve(mockResponse({ status: 404, body: 'no such file' }));
+    return Promise.resolve(mockResponse({ body: item.content }));
+  }) as typeof fetch;
+}
+
+function createMemoryStorage(seed: Record<string, string> = {}): KeyValueStore {
+  const store = new Map<string, string>(Object.entries(seed));
+  return {
+    get: (key) => Promise.resolve(store.get(key)),
+    set: (key, value) => {
+      store.set(key, value);
+      return Promise.resolve();
+    },
+    delete: (key) => {
+      store.delete(key);
+      return Promise.resolve();
+    },
+    keys: () => Promise.resolve([...store.keys()]),
+  };
+}
+
+const silentLogger: Logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+/**
+ * A `PluginContext` backed by {@link createGraphApiMock}/{@link createGraphPublicMock},
+ * pre-seeded with a still-valid stored token so `createClient()` never needs
+ * an interactive sign-in or a real token refresh to run a listing/download
+ * call.
+ */
+export function createGraphMockContext(world: GraphMockWorld, options: GraphMockOptions = {}): PluginContext {
+  const tokens = {
+    accessToken: MOCK_ACCESS_TOKEN,
+    refreshToken: 'mock-refresh-token',
+    expiresAt: Date.now() + 60 * 60 * 1000,
+  };
+  return {
+    fetch: createGraphApiMock(world, options),
+    fetchPublic: (url, init) => createGraphPublicMock(world)(url, init as RequestInit | undefined),
+    getPreference: (name: string) => {
+      if (name === 'clientId') return Promise.resolve('mock-client-id');
+      if (name === 'tenant') return Promise.resolve('common');
+      return Promise.resolve(undefined);
+    },
+    storage: createMemoryStorage({ 'msgraph:tokens': JSON.stringify(tokens) }),
+    log: silentLogger,
+  };
+}

--- a/packages/source-msgraph/test/msgraph-api-mock.ts
+++ b/packages/source-msgraph/test/msgraph-api-mock.ts
@@ -13,6 +13,8 @@
 
 import type { KeyValueStore, Logger, PluginContext } from '@ifc-lite/plugin-api';
 
+import { resetTokenManagerCache } from '../src/auth.js';
+
 export const GRAPH_MOCK_BASE_URL = 'https://graph.microsoft.com/v1.0';
 export const GRAPH_MOCK_DOWNLOAD_HOST = 'https://mock.files.1drv.com';
 export const MOCK_ACCESS_TOKEN = 'mock-access-token';
@@ -92,8 +94,18 @@ function itemJson(item: GraphMockItem): Record<string, unknown> {
   };
 }
 
+/**
+ * A real `@microsoft.graph.downloadUrl` carries its authorization *in the
+ * query string* (`tempauth=...` on SharePoint/OneDrive-for-Business hosts) —
+ * that is what makes the URL pre-authenticated and what makes it a credential.
+ * The mock reproduces that shape so a test can assert the secret half never
+ * escapes into a log line; {@link GRAPH_MOCK_DOWNLOAD_SECRET} is the part
+ * that must never be logged.
+ */
+export const GRAPH_MOCK_DOWNLOAD_SECRET = 'tempauth-secret-value';
+
 export function downloadUrlFor(fileId: string): string {
-  return `${GRAPH_MOCK_DOWNLOAD_HOST}/${encodeURIComponent(fileId)}`;
+  return `${GRAPH_MOCK_DOWNLOAD_HOST}/${encodeURIComponent(fileId)}?tempauth=${GRAPH_MOCK_DOWNLOAD_SECRET}`;
 }
 
 /** Slices a `$top`-paginated page, honoring the caller's own `$top` — unlike
@@ -265,8 +277,19 @@ const silentLogger: Logger = {
  * pre-seeded with a still-valid stored token so `createClient()` never needs
  * an interactive sign-in or a real token refresh to run a listing/download
  * call.
+ *
+ * Also drops the provider's process-wide `TokenManager` cache (see the
+ * `managerCache` doc in `src/auth.ts`). That cache is keyed on
+ * `(clientId, tenant)` — deliberately, so that concurrent refreshes across
+ * separate host contexts collapse onto one — and every context this factory
+ * builds reports the same `mock-client-id`/`common` pair. Resetting here makes
+ * "a fresh mock context gets a fresh manager" structural: a test cannot obtain
+ * a context without it, so no test can silently inherit the previous one's
+ * storage or `fetch` by forgetting a `beforeEach`.
  */
 export function createGraphMockContext(world: GraphMockWorld, options: GraphMockOptions = {}): PluginContext {
+  resetTokenManagerCache();
+
   const tokens = {
     accessToken: MOCK_ACCESS_TOKEN,
     refreshToken: 'mock-refresh-token',

--- a/packages/source-msgraph/test/provider.test.ts
+++ b/packages/source-msgraph/test/provider.test.ts
@@ -6,7 +6,12 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { PLUGIN_API_VERSION, satisfiesCaretRange } from '@ifc-lite/plugin-api';
 
 import { MsGraphProvider } from '../src/provider.js';
-import { downloadUrlFor, createGraphMockContext } from './msgraph-api-mock.js';
+import {
+  GRAPH_MOCK_DOWNLOAD_HOST,
+  GRAPH_MOCK_DOWNLOAD_SECRET,
+  downloadUrlFor,
+  createGraphMockContext,
+} from './msgraph-api-mock.js';
 import type { GraphMockWorld } from './msgraph-api-mock.js';
 
 const WORLD: GraphMockWorld = {
@@ -116,6 +121,29 @@ describe('MsGraphProvider', () => {
         name: 'AbortError',
       });
     });
+
+    /**
+     * A `@microsoft.graph.downloadUrl` is *pre-authenticated*: whoever holds
+     * the URL downloads the bytes with no credential at all, which is the
+     * whole reason `download()` fetches it through `ctx.fetchPublic` (which
+     * strips every header). `SourceFile.meta` is the wrong place for a value
+     * like that — the host treats `meta` as opaque provider data and
+     * serialises whole `SourceFile[]` into `localStorage` for its catalog
+     * cache (`saveSourceCatalogCache` in the viewer). This provider's
+     * capabilities happen to keep it off that path today, which makes the
+     * guarantee a coincidence rather than a design; nothing reads the value
+     * either way, so it must not be produced.
+     */
+    it('never puts the pre-signed download URL in SourceFile.meta, where the host persists it', async () => {
+      const ctx = createGraphMockContext(WORLD);
+      const page = await provider.listFiles(ctx, 'me', 'f-alpha');
+      expect(page.items.length).toBeGreaterThan(0);
+      for (const file of page.items) {
+        const serialised = JSON.stringify(file.meta ?? {});
+        expect(serialised).not.toContain(GRAPH_MOCK_DOWNLOAD_HOST);
+        expect(serialised).not.toContain('downloadUrl');
+      }
+    });
   });
 
   describe('searchFiles', () => {
@@ -163,23 +191,78 @@ describe('MsGraphProvider', () => {
       ).rejects.toThrow('does not expose a download URL');
     });
 
-    it('never sends an Authorization header to the download URL host', async () => {
+    /**
+     * The credential-carrying path, asserted where it can actually break.
+     *
+     * `PublicFetchInit` has no `headers` field, so inspecting the init object
+     * for one can never fail and proves nothing. What *can* regress is the
+     * routing: `getPublicBinary` switching from `ctx.fetchPublic` (which
+     * builds its own header set from scratch) to `ctx.fetch` (which attaches
+     * this client's `Authorization`) would send a bearer token to a CDN host
+     * outside `permissions.network` — and would also break the download, since
+     * Graph invalidates a pre-signed URL presented with an `Authorization`
+     * header. So: the download host must be reached through `fetchPublic` and
+     * must never be reached through `fetch`.
+     */
+    it('reaches the download host only through fetchPublic, never through the authenticated fetch', async () => {
       const ctx = createGraphMockContext(WORLD);
-      let sawAuthHeader = false;
+      const authenticatedUrls: string[] = [];
+      const publicUrls: string[] = [];
+      const originalFetch = ctx.fetch;
       const originalFetchPublic = ctx.fetchPublic;
       const wrappedCtx = {
         ...ctx,
+        fetch: ((input: RequestInfo | URL, init?: RequestInit) => {
+          authenticatedUrls.push(typeof input === 'string' ? input : input.toString());
+          return originalFetch(input, init);
+        }) as typeof fetch,
         fetchPublic: (url: string, init?: Parameters<typeof originalFetchPublic>[1]) => {
-          // `PublicFetchInit` only carries `signal`/`range` — there is no
-          // header field to smuggle an Authorization value through even if
-          // this test tried to. Confirms the shape rather than a live check.
-          if (init && 'headers' in (init as Record<string, unknown>)) sawAuthHeader = true;
+          publicUrls.push(url);
           return originalFetchPublic(url, init);
         },
       };
-      await provider.download(wrappedCtx, { projectId: 'me', containerId: 'f-alpha', fileId: 'file-1' });
-      expect(sawAuthHeader).toBe(false);
-      expect(downloadUrlFor('file-1')).toContain('file-1');
+
+      const buf = await provider.download(wrappedCtx, { projectId: 'me', containerId: 'f-alpha', fileId: 'file-1' });
+
+      expect(new TextDecoder().decode(buf)).toBe('MODEL-BYTES-1');
+      expect(publicUrls).toEqual([downloadUrlFor('file-1')]);
+      expect(authenticatedUrls.some((url) => url.startsWith(GRAPH_MOCK_DOWNLOAD_HOST))).toBe(false);
+      // The metadata lookup that yields the URL does go through the
+      // authenticated client — so this isn't passing because nothing ran.
+      expect(authenticatedUrls.some((url) => url.includes('/me/drive/items/file-1'))).toBe(true);
+    });
+
+    /**
+     * A pre-signed URL is a bearer credential in a query string. `debug` is
+     * gated behind a flag, but `error` always reaches `console.error` — which
+     * is what users copy into bug reports. The URL is usually expired by then;
+     * a 5xx from the CDN is exactly the case where it is not.
+     */
+    it('logs the download URL without its credential-bearing query string, at every level', async () => {
+      const ctx = createGraphMockContext(WORLD);
+      const logged: unknown[] = [];
+      const record = (message: string, details?: Record<string, unknown>) => {
+        logged.push(message, details);
+      };
+      const failingCtx = {
+        ...ctx,
+        // A live pre-signed URL that the CDN answers 5xx for: the error path
+        // fires while the credential in the URL is still usable.
+        fetchPublic: () =>
+          Promise.resolve(new Response('upstream exploded', { status: 503, statusText: 'Service Unavailable' })),
+        log: { debug: record, info: record, warn: record, error: record },
+      };
+
+      await expect(
+        provider.download(failingCtx, { projectId: 'me', containerId: 'f-alpha', fileId: 'file-1' }),
+      ).rejects.toThrow('Microsoft Graph download 503');
+
+      const transcript = JSON.stringify(logged);
+      expect(transcript).not.toContain(GRAPH_MOCK_DOWNLOAD_SECRET);
+      // Redaction must not degenerate into logging nothing useful: the host
+      // and path still have to be there to diagnose a failed download.
+      expect(transcript).toContain(GRAPH_MOCK_DOWNLOAD_HOST);
+      expect(transcript).toContain('file-1');
     });
   });
 

--- a/packages/source-msgraph/test/provider.test.ts
+++ b/packages/source-msgraph/test/provider.test.ts
@@ -1,0 +1,272 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { PLUGIN_API_VERSION, satisfiesCaretRange } from '@ifc-lite/plugin-api';
+
+import { MsGraphProvider } from '../src/provider.js';
+import { downloadUrlFor, createGraphMockContext } from './msgraph-api-mock.js';
+import type { GraphMockWorld } from './msgraph-api-mock.js';
+
+const WORLD: GraphMockWorld = {
+  driveId: 'drive-1',
+  driveName: 'Contoso Drive',
+  items: [
+    { id: 'f-alpha', name: 'Alpha', kind: 'folder', childCount: 1 },
+    { id: 'f-beta', name: 'Beta', kind: 'folder', childCount: 0 },
+    { id: 'file-1', name: 'model.ifc', parentId: 'f-alpha', kind: 'file', size: 12, cTag: 'ctag-v1', content: 'MODEL-BYTES-1' },
+    { id: 'file-2', name: 'readme.txt', parentId: 'f-alpha', kind: 'file', size: 3, content: 'TXT' },
+  ],
+  versionsByFileId: {
+    'file-1': [
+      { id: '2.0', size: 12, lastModifiedDateTime: '2026-08-10T00:00:00Z' },
+      { id: '1.0', size: 8, lastModifiedDateTime: '2026-08-01T00:00:00Z' },
+    ],
+  },
+};
+
+describe('MsGraphProvider', () => {
+  let provider: MsGraphProvider;
+
+  beforeEach(() => {
+    provider = new MsGraphProvider();
+  });
+
+  it('exposes a manifest that satisfies the host contract version', () => {
+    expect(provider.manifest.name).toBe('msgraph-onedrive');
+    expect(satisfiesCaretRange(PLUGIN_API_VERSION, provider.manifest.api)).toBe(true);
+    expect(provider.manifest.auth).toBe('interactive');
+    expect(provider.auth).toBeDefined();
+    expect(provider.manifest.permissions.network).toEqual(
+      expect.arrayContaining(['graph.microsoft.com', 'login.microsoftonline.com']),
+    );
+    expect(provider.manifest.permissions.publicNetwork).toEqual(
+      expect.arrayContaining(['*.sharepoint.com', '*.files.1drv.com']),
+    );
+  });
+
+  it('declares an honest capabilities block: history is listable but not downloadable', () => {
+    expect(provider.manifest.capabilities).toEqual({
+      containerListing: 'direct-children',
+      listFilesIsRecursive: false,
+      revisionHistory: true,
+      downloadHistoricalRevisions: false,
+      changeDetection: true,
+      search: true,
+    });
+  });
+
+  it('declares clientId as required and tenant as optional with a "common" default', () => {
+    const prefs = provider.manifest.preferences;
+    const clientId = prefs.find((p) => p.name === 'clientId');
+    const tenant = prefs.find((p) => p.name === 'tenant');
+    expect(clientId?.required).toBe(true);
+    expect(tenant?.required).toBe(false);
+    expect(tenant?.default).toBe('common');
+  });
+
+  describe('listProjects', () => {
+    it('returns exactly one project: the signed-in user\'s own drive', async () => {
+      const ctx = createGraphMockContext(WORLD);
+      const page = await provider.listProjects(ctx);
+
+      expect(page.items).toEqual([
+        { id: 'me', name: 'Contoso Drive', meta: { driveId: 'drive-1', driveType: 'business', owner: 'Mock Owner' } },
+      ]);
+      expect(page.cursor).toBeUndefined();
+    });
+  });
+
+  describe('listContainers', () => {
+    it('returns the drive root\'s folders with no parentId at the top level', async () => {
+      const ctx = createGraphMockContext(WORLD);
+      const page = await provider.listContainers(ctx, 'me', undefined);
+
+      expect(page.items.map((c) => c.id).sort()).toEqual(['f-alpha', 'f-beta']);
+      for (const container of page.items) expect(container.parentId).toBeUndefined();
+    });
+
+    it('scopes to a folder\'s own children and never returns files', async () => {
+      const ctx = createGraphMockContext(WORLD);
+      const page = await provider.listContainers(ctx, 'me', 'f-alpha');
+      expect(page.items).toEqual([]); // f-alpha has only files as children in this world
+    });
+  });
+
+  describe('listFiles', () => {
+    it('lists only file items in the queried folder, never its parent folder itself', async () => {
+      const ctx = createGraphMockContext(WORLD);
+      const page = await provider.listFiles(ctx, 'me', 'f-alpha');
+      expect(page.items.map((f) => f.id).sort()).toEqual(['file-1', 'file-2']);
+      for (const file of page.items) expect(file.containerId).toBe('f-alpha');
+    });
+
+    it('applies namePatterns using the shared glob matcher', async () => {
+      const ctx = createGraphMockContext(WORLD);
+      const page = await provider.listFiles(ctx, 'me', 'f-alpha', { namePatterns: ['*.ifc'] });
+      expect(page.items.map((f) => f.id)).toEqual(['file-1']);
+    });
+
+    it('threads an AbortSignal through to the underlying request', async () => {
+      const ctx = createGraphMockContext(WORLD);
+      const controller = new AbortController();
+      controller.abort();
+      await expect(provider.listFiles(ctx, 'me', 'f-alpha', undefined, { signal: controller.signal })).rejects.toMatchObject({
+        name: 'AbortError',
+      });
+    });
+  });
+
+  describe('searchFiles', () => {
+    it('matches file names case-insensitively and reports the item\'s real parent as containerId', async () => {
+      const ctx = createGraphMockContext(WORLD);
+      const page = await provider.searchFiles!(ctx, 'me', 'MODEL');
+      expect(page.items.map((f) => f.id)).toEqual(['file-1']);
+      expect(page.items[0].containerId).toBe('f-alpha');
+    });
+  });
+
+  describe('download', () => {
+    it('fetches the pre-signed downloadUrl via fetchPublic, not the authenticated client', async () => {
+      const ctx = createGraphMockContext(WORLD);
+      const buf = await provider.download(ctx, { projectId: 'me', containerId: 'f-alpha', fileId: 'file-1' });
+      expect(new TextDecoder().decode(buf)).toBe('MODEL-BYTES-1');
+    });
+
+    it('rejects a historical revisionId instead of silently serving current bytes', async () => {
+      const ctx = createGraphMockContext(WORLD);
+      await expect(
+        provider.download(ctx, { projectId: 'me', containerId: 'f-alpha', fileId: 'file-1', revisionId: '1.0' }),
+      ).rejects.toThrow('cannot download historical revision');
+    });
+
+    it('accepts a revisionId that matches the current revision', async () => {
+      const ctx = createGraphMockContext(WORLD);
+      const buf = await provider.download(ctx, {
+        projectId: 'me',
+        containerId: 'f-alpha',
+        fileId: 'file-1',
+        revisionId: 'ctag-v1',
+      });
+      expect(new TextDecoder().decode(buf)).toBe('MODEL-BYTES-1');
+    });
+
+    it('throws when the item exposes no download URL', async () => {
+      const noUrlWorld: GraphMockWorld = {
+        ...WORLD,
+        items: [...WORLD.items, { id: 'file-nourl', name: 'x.ifc', parentId: 'f-alpha', kind: 'file' }],
+      };
+      const ctx = createGraphMockContext(noUrlWorld);
+      await expect(
+        provider.download(ctx, { projectId: 'me', containerId: 'f-alpha', fileId: 'file-nourl' }),
+      ).rejects.toThrow('does not expose a download URL');
+    });
+
+    it('never sends an Authorization header to the download URL host', async () => {
+      const ctx = createGraphMockContext(WORLD);
+      let sawAuthHeader = false;
+      const originalFetchPublic = ctx.fetchPublic;
+      const wrappedCtx = {
+        ...ctx,
+        fetchPublic: (url: string, init?: Parameters<typeof originalFetchPublic>[1]) => {
+          // `PublicFetchInit` only carries `signal`/`range` — there is no
+          // header field to smuggle an Authorization value through even if
+          // this test tried to. Confirms the shape rather than a live check.
+          if (init && 'headers' in (init as Record<string, unknown>)) sawAuthHeader = true;
+          return originalFetchPublic(url, init);
+        },
+      };
+      await provider.download(wrappedCtx, { projectId: 'me', containerId: 'f-alpha', fileId: 'file-1' });
+      expect(sawAuthHeader).toBe(false);
+      expect(downloadUrlFor('file-1')).toContain('file-1');
+    });
+  });
+
+  describe('listRevisions', () => {
+    it('maps Graph driveItemVersions, newest first as Graph itself orders them', async () => {
+      const ctx = createGraphMockContext(WORLD);
+      const page = await provider.listRevisions!(ctx, { projectId: 'me', containerId: 'f-alpha', fileId: 'file-1' });
+      expect(page.items.map((r) => r.id)).toEqual(['2.0', '1.0']);
+      expect(page.items[0].sizeBytes).toBe(12);
+    });
+  });
+
+  describe('watchRevisions', () => {
+    it('reports no event for a file whose cTag has not changed', async () => {
+      const ctx = createGraphMockContext(WORLD);
+      const result = await provider.watchRevisions!(ctx, [
+        { projectId: 'me', containerId: 'f-alpha', fileId: 'file-1', revisionId: 'ctag-v1' },
+      ]);
+      expect(result.events).toEqual([]);
+      expect(result.cursor).toBeDefined();
+    });
+
+    it('reports an event when the tracked revisionId differs from the delta feed\'s current one', async () => {
+      const ctx = createGraphMockContext(WORLD);
+      const result = await provider.watchRevisions!(ctx, [
+        { projectId: 'me', containerId: 'f-alpha', fileId: 'file-1', revisionId: 'stale-tag' },
+      ]);
+      expect(result.events).toEqual([{ fileId: 'file-1', latestRevisionId: 'ctag-v1', previousRevisionId: 'stale-tag' }]);
+    });
+
+    it('reports a deleted event for a tracked file the feed marks deleted', async () => {
+      const deletedWorld: GraphMockWorld = {
+        ...WORLD,
+        items: WORLD.items.map((i) => (i.id === 'file-2' ? { ...i, deleted: true } : i)),
+      };
+      const ctx = createGraphMockContext(deletedWorld);
+      const result = await provider.watchRevisions!(ctx, [
+        { projectId: 'me', containerId: 'f-alpha', fileId: 'file-2', revisionId: 'some-tag' },
+      ]);
+      expect(result.events).toEqual([{ fileId: 'file-2', latestRevisionId: expect.any(String), deleted: true }]);
+    });
+
+    it('ignores refs the delta feed does not mention', async () => {
+      const ctx = createGraphMockContext(WORLD);
+      const result = await provider.watchRevisions!(ctx, [
+        { projectId: 'me', containerId: 'f-alpha', fileId: 'file-unknown', revisionId: 'x' },
+      ]);
+      expect(result.events).toEqual([]);
+    });
+  });
+
+  describe('testConnection', () => {
+    it('returns ok on success', async () => {
+      const ctx = createGraphMockContext(WORLD);
+      const result = await provider.testConnection!(ctx);
+      expect(result.ok).toBe(true);
+    });
+
+    it('returns a helpful message when the access token is rejected (401)', async () => {
+      const ctx = createGraphMockContext(WORLD);
+      // Corrupt the stored token so the mock's Authorization check fails —
+      // exercises the auth-failure branch of testConnection without needing
+      // a real expired/invalid Microsoft Graph token.
+      await ctx.storage.set(
+        'msgraph:tokens',
+        JSON.stringify({ accessToken: 'wrong-token', expiresAt: Date.now() + 60 * 60 * 1000 }),
+      );
+      const result = await provider.testConnection!(ctx);
+      expect(result.ok).toBe(false);
+      expect(result.message).toContain('Sign-in expired');
+    });
+  });
+
+  describe('auth-failure handling in ordinary calls', () => {
+    it('listProjects surfaces a GraphHttpError with status 401 rather than a generic failure', async () => {
+      const ctx = createGraphMockContext(WORLD);
+      await ctx.storage.set(
+        'msgraph:tokens',
+        JSON.stringify({ accessToken: 'wrong-token', expiresAt: Date.now() + 60 * 60 * 1000 }),
+      );
+      await expect(provider.listProjects(ctx)).rejects.toMatchObject({ name: 'GraphHttpError', status: 401 });
+    });
+
+    it('createClient throws a clear error when no clientId preference is configured', async () => {
+      const ctx = createGraphMockContext(WORLD);
+      const noClientCtx = { ...ctx, getPreference: () => Promise.resolve(undefined) };
+      await expect(provider.listProjects(noClientCtx)).rejects.toThrow('no Azure AD application (client) ID');
+    });
+  });
+});

--- a/packages/source-msgraph/test/refresh-race.test.ts
+++ b/packages/source-msgraph/test/refresh-race.test.ts
@@ -1,0 +1,168 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Concurrent-refresh de-duplication, end to end through the provider.
+ *
+ * `TokenManager` serializes refreshes on a *per-instance* `pendingRefresh`
+ * promise — which only de-duplicates callers that share one instance. A
+ * provider that builds a fresh `TokenManager` per call therefore has that
+ * guarantee by name only: two overlapping calls landing while the stored
+ * access token is inside the 60 s refresh skew each POST the same refresh
+ * token. Microsoft rotates SPA refresh tokens on use, so the second POST is
+ * answered `invalid_grant` — and if the loser's write lands last, what gets
+ * persisted is derived from a token the server has already retired, which
+ * kills the session until the user signs in interactively again.
+ *
+ * The assertion below is the whole point: N overlapping calls must produce
+ * exactly ONE token-endpoint POST.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { MsGraphProvider } from '../src/provider.js';
+import { msGraphAuth } from '../src/auth.js';
+import { MOCK_ACCESS_TOKEN, createGraphMockContext } from './msgraph-api-mock.js';
+import type { GraphMockWorld } from './msgraph-api-mock.js';
+
+const WORLD: GraphMockWorld = {
+  driveId: 'drive-1',
+  driveName: 'Contoso Drive',
+  items: [
+    { id: 'f-alpha', name: 'Alpha', kind: 'folder', childCount: 1 },
+    { id: 'file-1', name: 'model.ifc', parentId: 'f-alpha', kind: 'file', size: 12, content: 'MODEL-BYTES-1' },
+  ],
+};
+
+interface RefreshHarness {
+  readonly ctx: ReturnType<typeof createGraphMockContext>;
+  /** One entry per POST that actually reached the token endpoint. */
+  readonly refreshBodies: string[];
+}
+
+/**
+ * A context whose stored access token is already expired, and whose `fetch`
+ * routes the Microsoft token endpoint to a rotating-refresh-token stand-in:
+ * the first POST succeeds and mints a new refresh token, every later POST
+ * presenting the retired token is answered `invalid_grant`, exactly as the
+ * Microsoft identity platform answers a replayed SPA refresh token.
+ */
+function createExpiredTokenHarness(): RefreshHarness {
+  const base = createGraphMockContext(WORLD);
+  const refreshBodies: string[] = [];
+  let liveRefreshToken = 'refresh-token-v1';
+
+  const ctx = {
+    ...base,
+    fetch: (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const href = typeof input === 'string' ? input : input.toString();
+      if (!href.includes('/oauth2/v2.0/token')) return base.fetch(input, init);
+
+      const body = String(init?.body ?? '');
+      refreshBodies.push(body);
+      const presented = new URLSearchParams(body).get('refresh_token');
+
+      // A real network round trip is not instantaneous; the delay widens the
+      // window a second caller would race through, so this test would still
+      // catch the duplicate POST if the two calls were further apart than a
+      // single microtask.
+      await new Promise((resolve) => setTimeout(resolve, 5));
+
+      if (presented !== liveRefreshToken) {
+        return new Response(
+          JSON.stringify({ error: 'invalid_grant', error_description: 'refresh token has been rotated' }),
+          { status: 400, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      liveRefreshToken = 'refresh-token-v2';
+      return new Response(
+        JSON.stringify({
+          access_token: MOCK_ACCESS_TOKEN,
+          refresh_token: liveRefreshToken,
+          expires_in: 3600,
+          token_type: 'Bearer',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    }) as typeof fetch,
+  };
+
+  return { ctx, refreshBodies };
+}
+
+async function seedExpiredTokens(harness: RefreshHarness): Promise<void> {
+  await harness.ctx.storage.set(
+    'msgraph:tokens',
+    JSON.stringify({
+      accessToken: 'stale-access-token',
+      refreshToken: 'refresh-token-v1',
+      // Inside the 60 s refresh skew — the case the doc comment on
+      // `TokenManager.getValidAccessToken` describes.
+      expiresAt: Date.now() - 1_000,
+    }),
+  );
+}
+
+// The token manager is shared process-wide per `(clientId, tenant)`, so each
+// case needs the cache dropped or the previous one's storage would serve it.
+// `createGraphMockContext` does that itself — see its doc comment.
+describe('concurrent refresh de-duplication', () => {
+  it('collapses two overlapping provider calls onto ONE token-endpoint POST', async () => {
+    const provider = new MsGraphProvider();
+    const harness = createExpiredTokenHarness();
+    await seedExpiredTokens(harness);
+
+    const [projects, containers] = await Promise.all([
+      provider.listProjects(harness.ctx),
+      provider.listContainers(harness.ctx, 'me'),
+    ]);
+
+    expect(harness.refreshBodies).toHaveLength(1);
+    expect(new URLSearchParams(harness.refreshBodies[0]).get('grant_type')).toBe('refresh_token');
+    // Both calls really did complete against the refreshed token, rather than
+    // one of them failing and the count staying at one by accident.
+    expect(projects.items).toHaveLength(1);
+    expect(containers.items.map((c) => c.id)).toEqual(['f-alpha']);
+  });
+
+  it('collapses a listing racing an identity check onto ONE token-endpoint POST', async () => {
+    // `getIdentity()` goes through `auth.ts` while a listing goes through
+    // `provider.ts`; a manager scoped to the provider instance would leave
+    // these two racing. The host really does run them against separate
+    // `PluginContext` objects (`SourceHost.createContext` mints a fresh one
+    // per operation), which is why the sharing cannot be keyed on `ctx`.
+    const provider = new MsGraphProvider();
+    const harness = createExpiredTokenHarness();
+    await seedExpiredTokens(harness);
+
+    const [files, identity] = await Promise.all([
+      provider.listFiles(harness.ctx, 'me', 'f-alpha'),
+      msGraphAuth.getIdentity(harness.ctx),
+    ]);
+
+    expect(harness.refreshBodies).toHaveLength(1);
+    expect(files.items.map((f) => f.id)).toEqual(['file-1']);
+    expect(identity?.id).toBe('user-1');
+  });
+
+  it('persists the refresh token the winning POST returned, never a retired one', async () => {
+    const provider = new MsGraphProvider();
+    const harness = createExpiredTokenHarness();
+    await seedExpiredTokens(harness);
+
+    await Promise.all([
+      provider.listProjects(harness.ctx),
+      provider.listContainers(harness.ctx, 'me'),
+      provider.listFiles(harness.ctx, 'me', 'f-alpha'),
+    ]);
+
+    expect(harness.refreshBodies).toHaveLength(1);
+    const stored = JSON.parse((await harness.ctx.storage.get('msgraph:tokens')) ?? '{}') as {
+      refreshToken?: string;
+      accessToken?: string;
+    };
+    expect(stored.refreshToken).toBe('refresh-token-v2');
+    expect(stored.accessToken).toBe(MOCK_ACCESS_TOKEN);
+  });
+});

--- a/packages/source-msgraph/tsconfig.json
+++ b/packages/source-msgraph/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.packages.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "paths": {
+      "@ifc-lite/plugin-api": ["../plugin-api/src"],
+      "@ifc-lite/oauth-pkce": ["../oauth-pkce/src"],
+      "@ifc-lite/source-fixture/conformance": ["../source-fixture/src/conformance/index.ts"]
+    }
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/source-msgraph/vitest.config.ts
+++ b/packages/source-msgraph/vitest.config.ts
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,6 +197,9 @@ importers:
       '@ifc-lite/source-dalux':
         specifier: workspace:^
         version: link:../../packages/source-dalux
+      '@ifc-lite/source-msgraph':
+        specifier: workspace:^
+        version: link:../../packages/source-msgraph
       '@ifc-lite/spatial':
         specifier: workspace:^
         version: link:../../packages/spatial
@@ -1446,6 +1449,25 @@ importers:
         specifier: workspace:^
         version: link:../plugin-api
     devDependencies:
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@26.1.2)(happy-dom@20.11.1)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+
+  packages/source-msgraph:
+    dependencies:
+      '@ifc-lite/oauth-pkce':
+        specifier: workspace:^
+        version: link:../oauth-pkce
+      '@ifc-lite/plugin-api':
+        specifier: workspace:^
+        version: link:../plugin-api
+    devDependencies:
+      '@ifc-lite/source-fixture':
+        specifier: workspace:^
+        version: link:../source-fixture
       typescript:
         specifier: ^6.0.3
         version: 6.0.3

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -2436,7 +2436,9 @@
     "AuthorizationRequestConfig: interface",
     "ExchangeAuthorizationCodeParams: interface",
     "NotSignedInError: class",
+    "OAUTH_CALLBACK_CHANNEL: const",
     "OAuthAuthorizationError: class",
+    "OAuthCallbackMessage: interface",
     "OAuthError: class",
     "OAuthRedirectOriginError: class",
     "OAuthStateMismatchError: class",
@@ -2448,6 +2450,7 @@
     "TokenManagerConfig: interface",
     "TokenSet: interface",
     "TokenStorage: interface",
+    "WaitForOAuthCallbackOptions: interface",
     "createAuthorizationRequest: function",
     "createPkcePair: function",
     "deriveCodeChallengeS256: function",
@@ -2455,7 +2458,8 @@
     "generateCodeVerifier: function",
     "generateState: function",
     "parseAuthorizationCallback: function",
-    "refreshAccessToken: function"
+    "refreshAccessToken: function",
+    "waitForOAuthCallback: function"
   ],
   "@ifc-lite/parser": [
     "AutoParseResult: type",

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -4214,6 +4214,11 @@
     "DALUX_MANIFEST: const",
     "DaluxBuildProvider: class"
   ],
+  "@ifc-lite/source-msgraph": [
+    "MSGRAPH_MANIFEST: const",
+    "MsGraphProvider: class",
+    "REDIRECT_PATH: const"
+  ],
   "@ifc-lite/spatial": [
     "AABB: interface",
     "AABBUtils: class",

--- a/scripts/unused-locals-baseline.json
+++ b/scripts/unused-locals-baseline.json
@@ -44,6 +44,7 @@
   "packages/solar": 1,
   "packages/source-dalux": 0,
   "packages/source-fixture": 0,
+  "packages/source-msgraph": 0,
   "packages/spatial": 0,
   "packages/viewer": 0,
   "packages/world-frame-fixtures": 0

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -124,6 +124,12 @@
       "@ifc-lite/oauth-pkce/*": [
         "packages/oauth-pkce/dist/*"
       ],
+      "@ifc-lite/source-msgraph": [
+        "packages/source-msgraph/dist/index.d.ts"
+      ],
+      "@ifc-lite/source-msgraph/*": [
+        "packages/source-msgraph/dist/*"
+      ],
       "@ifc-lite/plugin-api/*": [
         "packages/plugin-api/dist/*"
       ]

--- a/vercel.json
+++ b/vercel.json
@@ -18,6 +18,10 @@
       "destination": "/api/dalux?path=:path*"
     },
     {
+      "source": "/oauth/msgraph/callback",
+      "destination": "/oauth/msgraph/callback.html"
+    },
+    {
       "source": "/mcp",
       "destination": "/index.html"
     },


### PR DESCRIPTION
## Stacks on #2632

This PR branches from `feat/oauth-pkce-provider-auth` (PR #2632, green, MERGEABLE) and depends on `@ifc-lite/oauth-pkce`, which is not on `main` yet. **Please review/merge #2632 first** — this diff includes only the new `packages/source-msgraph` package plus the viewer registration; the base-branch commits are #2632's own.

Opened as a draft for that reason, and because the app registration (client ID) is the maintainer's to create — see below.

## What this adds

`@ifc-lite/source-msgraph`, a `FileSourceProvider` for OneDrive via Microsoft Graph, following `@ifc-lite/source-dalux`'s structure and conventions:

- **Auth**: delegated OAuth 2.0 Authorization Code + PKCE via `@ifc-lite/oauth-pkce`, scope `offline_access https://graph.microsoft.com/Files.Read`. No admin consent needed, no client secret. Popup-based sign-in (`window.open` + polling for the same-origin redirect), gated behind a user gesture per the plugin contract.
- **Listing**: real per-folder `/children` endpoint (`containerListing: 'direct-children'`), `$top`-based pagination via `@odata.nextLink`.
- **Search**: `GET /me/drive/root/search(q='...')`.
- **Change detection**: Graph's `/delta` feed (`changeDetection: true`, resumable cursor).
- **Revision history**: `GET .../versions` lists it (`revisionHistory: true`), but `download()` can only fetch the *current* revision (`downloadHistoricalRevisions: false`) — a `driveItemVersion` exposes no `@microsoft.graph.downloadUrl`, and `.../versions/{id}/content` 302-redirects the same way `/content` does.
- **Download**: fetches the item's pre-signed `@microsoft.graph.downloadUrl` via `ctx.fetchPublic` — **never** `GET .../content` directly. Verified against current Microsoft docs (cited in `provider.ts` and the README): `/content` returns a `302 Found` a browser can't follow when the triggering request required a CORS preflight (attaching `Authorization` does); Microsoft's own recommended fix for JS apps is exactly `@microsoft.graph.downloadUrl`, fetched with no `Authorization` header.

## Deliberate divergences from Dalux / from my own initial plan

- **No relay.** Dalux needs a same-origin relay because its API sends no CORS headers. Microsoft Graph (and the token endpoint, for an app registered with a `spa` redirect URI) sends real CORS headers, so this provider talks to `graph.microsoft.com`/`login.microsoftonline.com` directly via `ctx.fetch`. Confirmed this is a genuine capability difference, not a workaround, before writing it.
- **One project only.** Delegated `Files.Read` has no "list every SharePoint site" endpoint (that needs `Sites.Read.All`, a higher-privileged, admin-consentable scope this PR deliberately doesn't request). So `listProjects` always returns exactly one project: the signed-in user's own drive. No `projectsAreDiscoverableOnly` capability or site-search UI in this PR — documented as a natural follow-up in the README, not implemented here.
- **Folder-organized files only (known v1 gap, documented in the README).** `listContainers` returns the drive root's real child folders directly, `parentId: undefined` at the top level, matching the plugin contract's "top level" shape exactly rather than wrapping it in a synthetic container the way Dalux's file-area concept does. Consequence: a file sitting directly at the drive root (not inside any folder) isn't currently listable — there's no `SourceContainer` a host would address it through. Most real OneDrive usage is folder-organized; a synthetic root-level container is the natural extension if this turns out to matter in practice.

## What the maintainer needs to register (not done here — no client ID committed)

An Azure AD app registration:
- **Client type**: Single-page application (SPA) — public client, PKCE, no secret.
- **Redirect URI**: `<app origin>/oauth/msgraph/callback` (type `spa` — required for CORS on the token endpoint; a `web`-type redirect URI will fail).
- **API permissions (delegated)**: `Files.Read`, `offline_access`. No admin consent needed for either.
- **Supported account types**: matching whatever `tenant` preference the deployment sets (default `common`).

Full detail in `packages/source-msgraph/README.md`.

## Test plan

- [x] Unit tests (`test/provider.test.ts`, `test/auth.test.ts`) — manifest shape, listing, download (current + historical-revision rejection), revisions, delta-based `watchRevisions`, `testConnection`, auth-failure propagation, `restore`/`getIdentity`/`signOut`/`signIn`-without-`window` — all mocked, no network.
- [x] Shared conformance suite (`@ifc-lite/source-fixture`) run against the real provider via a Graph API mock (`test/msgraph-api-mock.ts`) — 23 checks passing, 5 skipped (revision-download and second-project checks, correctly gated off by this provider's declared capabilities).
- [x] Induced-failure verification on 5 core behaviors (download-via-fetchPublic, historical-revision rejection, cTag-based revision identity, 401/403 auth-failure classification, folder-vs-file filtering in `listContainers`) — each broken, observed red, restored, confirmed green again.
- [x] `apps/viewer/src/services/sources/source-host.test.ts` (asserts every registered provider's manifest satisfies `PLUGIN_API_VERSION`) — passes with `MsGraphProvider` registered.
- [x] Full monorepo build (`pnpm build`, 45/45 tasks).
- [x] `pnpm docs:generate` / `docs:check-generated`, `pnpm check:api-surface` (+ `--update`), `pnpm lint` (`check-lint-ran.mjs`, 0 errors), unused-locals ratchet (`check-unused-locals.mjs`, 0 for this package, no regressions elsewhere) — all green.
- [x] Changeset added (minor for the new package, patch for the viewer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Microsoft Graph support for browsing OneDrive and SharePoint files.
  * Added Azure AD OAuth sign-in with PKCE, token renewal, sign-out, and connection testing.
  * Added file search, folder navigation, downloads, revision listings, and change detection.
  * Added browser-compatible OAuth popup callback handling for restricted hosting environments.
* **Documentation**
  * Added setup and usage guidance for Microsoft Graph integration and OAuth configuration.
* **Tests**
  * Added coverage for authentication, file operations, pagination, downloads, revisions, and token refresh behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->