### PR TITLE
fix(scripts): make check-unused-locals ANSI-proof under FORCE_COLOR

### DIFF
--- a/scripts/check-unused-locals.mjs
+++ b/scripts/check-unused-locals.mjs
@@ -53,6 +53,25 @@ function packageDirs() {
 const UNUSED_CODES = [6133, 6138, 6192, 6196, 6198, 6199];
 const UNUSED_RE = new RegExp(`error TS(${UNUSED_CODES.join('|')}):`, 'g');
 const OTHER_ERROR_RE = new RegExp(`error TS(?!(?:${UNUSED_CODES.join('|')})\\b)\\d+:`);
+// A generic "tsc did print at least one diagnostic" signal, independent of the
+// two regexes above. Used only to tell "tsc ran and reported something we
+// failed to parse" apart from "tsc genuinely produced no diagnostic text",
+// which need different, honest failure messages (see countViolations).
+const ANY_TS_DIAGNOSTIC_RE = /TS\d{4}/;
+
+/**
+ * Strip ANSI escape sequences (SGR colour/style codes) from captured child
+ * output before matching. `--pretty false` below already asks tsc for plain
+ * text, but this is the defense-in-depth layer: it also covers colour
+ * injected by pnpm's own wrapper output, or by any future tool in this
+ * spawn chain that doesn't have an equivalent flag. Un-stripped ANSI codes
+ * land mid-token (`\x1b[91merror\x1b[0m TS6196:`) and silently break both
+ * regexes above — two contributors independently hit this via `FORCE_COLOR`
+ * in their shell, and the failure looked exactly like ~30 broken packages.
+ */
+function stripAnsi(str) {
+  return str.replace(/\x1b\[[0-9;]*[A-Za-z]/g, '');
+}
 
 /**
  * The project to measure a package through.
@@ -78,12 +97,23 @@ function projectFor(dir) {
 function countViolations(dir) {
   const project = projectFor(dir);
   try {
-    execFileSync('pnpm', ['exec', 'tsc', '--noEmit', '--noUnusedLocals', '-p', project], {
+    execFileSync('pnpm', ['exec', 'tsc', '--noEmit', '--noUnusedLocals', '--pretty', 'false', '-p', project], {
       cwd: join(repoRoot, dir), encoding: 'utf8', stdio: 'pipe', maxBuffer: 32 * 1024 * 1024,
+      // `--pretty false` is the primary defense: it is tsc's own supported flag
+      // for stable, colour-free, machine-readable diagnostics, verified against
+      // the pinned TypeScript 6.0.3 (`--help` lists it; a plain-text run under
+      // FORCE_COLOR=3 confirmed it strips colour regardless of the parent
+      // environment). FORCE_COLOR/NO_COLOR here are the belt-and-suspenders
+      // second layer, covering pnpm's own wrapper output in case a future pnpm
+      // version colourises it even when the child doesn't.
+      env: { ...process.env, FORCE_COLOR: '0', NO_COLOR: '1' },
     });
     return { count: 0, unmeasurable: false };
   } catch (err) {
-    const output = `${err.stdout ?? ''}${err.stderr ?? ''}`;
+    // Third layer: strip any ANSI that made it through anyway (e.g. a tool
+    // upstream of tsc in this spawn chain that ignores both of the above)
+    // before matching, rather than trusting the two defenses above blindly.
+    const output = stripAnsi(`${err.stdout ?? ''}${err.stderr ?? ''}`);
     const count = output.match(UNUSED_RE)?.length ?? 0;
     if (OTHER_ERROR_RE.test(output)) {
       // The package does not compile. That belongs to the typecheck lane, not
@@ -92,12 +122,29 @@ function countViolations(dir) {
       return { count, unmeasurable: true };
     }
     if (count === 0) {
+      if (ANY_TS_DIAGNOSTIC_RE.test(output)) {
+        // tsc printed at least one `TS####` diagnostic, but it matched neither
+        // the unused-locals codes nor the "any other error" pattern. That is
+        // not a compile error to report and fold into the ratchet like the
+        // branch above — it means this script's own parsing is broken (a tsc
+        // output-format change, an escape sequence the strip above doesn't
+        // cover, etc). Reporting that as "does not compile standalone" would
+        // be a confidently wrong answer wearing the same clothes as a real
+        // compile failure. Fail the whole run loudly instead of guessing.
+        console.error(`❌ check-unused-locals cannot parse tsc's output for ${dir}.`);
+        console.error('   tsc reported at least one TS diagnostic, but it matched neither the');
+        console.error('   unused-locals codes nor the generic "other error" pattern — this is a');
+        console.error('   bug in the check\'s parsing, not a compile error in the package.');
+        console.error('\n   Raw (ANSI-stripped) output:\n');
+        console.error(output.split('\n').map((l) => `   ${l}`).join('\n'));
+        process.exit(1);
+      }
       // Non-zero exit, and nothing here explains it: no unused diagnostics, no
-      // other `error TS####`. tsc never ran, or died without reporting — a
-      // missing binary, a killed process, a failure printed in a shape this
-      // does not parse. The one thing that must not happen is calling it zero,
-      // which would read as a clean package and could be written into the
-      // baseline as one (review, #2603).
+      // other `error TS####`, no TS diagnostic of any kind. tsc never ran, or
+      // died without reporting — a missing binary, a killed process, a failure
+      // printed in a shape this does not parse. The one thing that must not
+      // happen is calling it zero, which would read as a clean package and
+      // could be written into the baseline as one (review, #2603).
       return { count: 0, unmeasurable: true };
     }
     return { count, unmeasurable: false };

--- a/scripts/check-unused-locals.mjs
+++ b/scripts/check-unused-locals.mjs
@@ -69,8 +69,15 @@ const ANY_TS_DIAGNOSTIC_RE = /TS\d{4}/;
  * regexes above — two contributors independently hit this via `FORCE_COLOR`
  * in their shell, and the failure looked exactly like ~30 broken packages.
  */
+// Built from String.fromCharCode rather than a /\x1b.../ literal: a literal
+// control-character escape in a regex trips oxlint's no-control-regex rule
+// (scripts/ is linted, see check-lint-ran.mjs), and that lint failure is
+// exactly the kind of thing this script's own defense-in-depth is meant to
+// avoid becoming collateral damage from.
+const ANSI_ESCAPE_RE = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*[A-Za-z]`, 'g');
+
 function stripAnsi(str) {
-  return str.replace(/\x1b\[[0-9;]*[A-Za-z]/g, '');
+  return str.replace(ANSI_ESCAPE_RE, '');
 }
 
 /**


### PR DESCRIPTION
## What broke

`scripts/check-unused-locals.mjs` runs `tsc --noEmit --noUnusedLocals` per package (via `pnpm exec`) and parses the captured stdout/stderr with plain-text regexes anchored on the literal string `error TS####`. When the environment forces colour (`FORCE_COLOR` set — e.g. a shell profile, a CI wrapper), tsc emits ANSI escapes around the word "error" itself:

```
\x1b[91merror\x1b[0m\x1b[90m TS6196: \x1b[0m'Vec3' is declared but never used.
```

That splits `error` from `TS6196:`, so both `UNUSED_RE` and `OTHER_ERROR_RE` match nothing. The existing "count is 0 and nothing explains it" fallback — written for a genuinely crashed/missing `tsc` — then fires and reports the package as **"does not compile standalone."** The script doesn't crash; it produces a confidently wrong answer for a check whose whole job is to be trusted.

Two contributors hit this independently the same day, and each initially believed they'd broken ~30 packages.

## Reproduction

Built the workspace first (`pnpm build` — packages resolve each other via built `dist/`, so an unbuilt workspace makes every cross-package import "not compile standalone" for an unrelated, legitimate reason and would confound this repro):

```
$ FORCE_COLOR= node scripts/check-unused-locals.mjs
✅ No new unused locals (46 packages, 976 known, none increased).

$ FORCE_COLOR=3 node scripts/check-unused-locals.mjs
❌ These packages do not compile standalone, so nothing measures their
   unused locals. [...]
   apps/viewer (baseline 355)
   apps/viewer-embed (baseline 358)
   [... 31 packages total ...]
```

Confirmed the mechanism directly by running `tsc` on one package under `FORCE_COLOR=3` and inspecting the raw bytes (`cat -v`):

```
^[[96msrc/contact/index.ts^[[0m:^[[93m27^[[0m:^[[93m21^[[0m - ^[[91merror^[[0m^[[90m TS6196: ^[[0m'Vec3' is declared but never used.
```

Exactly the split described above.

## Fix

Three layers, since this check exists specifically to be trusted and a single point of failure defeats that:

1. **`--pretty false` on the spawned tsc.** This is tsc's own supported flag for stable, colour-free, machine-readable diagnostics — verified against the pinned TypeScript 6.0.3 (`--help` lists it, and a direct run under `FORCE_COLOR=3` confirmed it strips colour regardless of the parent environment). Primary fix, since the script never wants coloured output and this is the tool's sanctioned way to say so.
2. **`FORCE_COLOR=0` / `NO_COLOR=1` in the child's env**, as a second layer — covers `pnpm`'s own wrapper output in case a future `pnpm` version colourises something even when the child tool doesn't.
3. **Strip ANSI from the captured output before matching**, as a third layer — catches anything upstream of tsc in the spawn chain that ignores both of the above.

## Fail loudly, not silently

Even with all three layers, if a package's tsc output ever contains a `TS####` diagnostic that matches neither the unused-locals codes nor the generic "other error" pattern, that means *this check's own parsing broke* (a future tsc output-format change, an escape sequence none of the three layers caught, etc) — not that the package has a compile error. Previously this was silently folded into the same "does not compile standalone" bucket as a real compile failure. It now prints the raw (ANSI-stripped) tsc output and exits loudly with an explicit "this is a bug in the check's parsing" message, so nobody chases a phantom build failure again.

## Verified after the fix

```
$ FORCE_COLOR=3 node scripts/check-unused-locals.mjs
✅ No new unused locals (46 packages, 976 known, none increased).

$ FORCE_COLOR= node scripts/check-unused-locals.mjs
✅ No new unused locals (46 packages, 976 known, none increased).
```

`diff` on the two runs' output is empty — byte-identical.

## Audit: same shape elsewhere in scripts/

Grepped `scripts/` for `execFileSync`/`execSync`/`spawnSync` calls that regex-parse a child's human-readable stdout:

- **`scripts/check-lint-ran.mjs`** shares the exact shape (spawns `oxlint`, regex-matches its `"Finished in ... on N files with M rules"` summary line). Checked it under `FORCE_COLOR=3` directly — oxlint's summary line stays plain/uncoloured even with colour forced elsewhere in its output, so this one is not actually broken. Verified `pnpm exec oxlint ...` output under both settings and confirmed the summary counts match.
- **`scripts/docs/check-doc-samples.mjs`** already passes `tsc ... --pretty false` — already immune.
- Everything else that spawns a subprocess in `scripts/` either compares exact machine-generated strings (`npm view ... version`, `pnpm -r exec node -e "console.log(process.cwd())"`), reads exit codes only (`git diff --quiet`), or inherits stdio without parsing it (`cargo publish`, `git diff --stat` for display). None of those are exposed to this failure mode.

No changes made beyond `check-unused-locals.mjs` — the other spawn/regex script (`check-lint-ran.mjs`) was verified safe rather than changed, per "fix only if small and obviously correct, otherwise report."

## Not covered / left to the maintainer

Nothing outstanding — the only broken script is fixed, the one sibling with the same shape was checked and found unaffected (not blindly "fixed" without evidence).

## Testing

`scripts/` has no `package.json` (it's outside the pnpm workspace) and carries no test harness by convention — confirmed no existing `*.test.*` files or test runner target it. Rather than inventing a new harness for a one-file script fix, the proof here is the before/after reproduction above: `FORCE_COLOR=3` and unset now produce byte-identical, correct output, where before the colour-forced run misreported 31 packages.

No changeset — this only touches `scripts/`, not a published `packages/*` surface (per PR #2631's precedent for scripts-only changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unused-local checks to reliably process compiler output across different environments.
  * Added clearer failure reporting when unexpected diagnostics are encountered, preventing inaccurate results.

* **Chores**
  * Strengthened validation safeguards so tooling failures are surfaced instead of being misclassified as successful or ordinary compilation outcomes.
  * Improved consistency and reliability of automated code-quality checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->