### PR TITLE
fix: Windows release upload fails in server-binaries workflow

### DIFF
--- a/.github/workflows/server-binaries.yml
+++ b/.github/workflows/server-binaries.yml
@@ -233,6 +233,7 @@ jobs:
 
       - name: Upload to GitHub Release
         if: github.event_name == 'release'
+        shell: bash
         run: |
           gh release upload "${{ github.event.release.tag_name }}" \
             ifc-lite-server-${{ matrix.target }}.${{ matrix.archive }} \


### PR DESCRIPTION
## Summary

The **"Upload to GitHub Release"** step in `.github/workflows/server-binaries.yml` (lines 234–241) lacks a `shell:` key. On Windows runners, PowerShell is the default shell and misinterprets the `--clobber` flag as a unary decrement operator (`--`), causing the upload command to fail silently. This prevents Windows binaries from reaching GitHub Releases, making @ifc-lite/server-bin uninstallable on Windows (issue #2619).

## Root Cause

**Broken step** (lines 234–241):
```yaml
      - name: Upload to GitHub Release
        if: github.event_name == 'release'
        run: |
          gh release upload "${{ github.event.release.tag_name }}" \
            ifc-lite-server-${{ matrix.target }}.${{ matrix.archive }} \
            --clobber
        env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```

In PowerShell, `--` is the unary decrement operator, so the `--clobber` flag is parsed as a syntax error rather than a GitHub CLI option. The fix is to explicitly declare `shell: bash` to force bash parsing, matching the precedent set in the sibling "Build Server Binary" step (PR #1118, line 187).

## Fix

Added `shell: bash` to the "Upload to GitHub Release" step, making it:
```yaml
      - name: Upload to GitHub Release
        if: github.event_name == 'release'
        shell: bash
        run: |
          gh release upload "${{ github.event.release.tag_name }}" \
            ifc-lite-server-${{ matrix.target }}.${{ matrix.archive }} \
            --clobber
        env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```

## Steps Checked for Same Issue

- **"Build Server Binary"** (line 187): Already has `shell: bash` ✓ (precedent from PR #1118)
- **"Create Archive (tar.gz)"** (lines 211–215): No `shell:` key, but conditional `if: matrix.archive == 'tar.gz'` limits it to Linux/Darwin, not Windows → not at risk
- **"Create Archive (zip)"** (line 219): Has `shell: pwsh` → safe
- **"Prepare Binary (Windows)"** (line 206): Has `shell: pwsh` → safe
- **"Prepare Binary (Unix)"** (line 198): Has `if: runner.os != 'Windows'` → safe
- All other steps either use actions or platform-specific guards → safe

Fixes #2619


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release automation by explicitly using Bash when uploading server binaries to GitHub Releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->