### PR TITLE
fix(viewer): formatDistance() honors unitDisplayOverrides (issue #2199)

### DIFF
--- a/.changeset/measure-unit-display-override.md
+++ b/.changeset/measure-unit-display-override.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/viewer": patch
+---
+
+Fix: formatDistance() now honors unitDisplayOverrides from the Properties panel (issue #2199). When a user sets feet or another display unit in the Properties panel, the measure tool now displays distances in that unit instead of always using metres.

--- a/apps/viewer/src/components/viewer/Drawing2DCanvas.tsx
+++ b/apps/viewer/src/components/viewer/Drawing2DCanvas.tsx
@@ -383,6 +383,9 @@ interface Drawing2DCanvasProps {
   // Point-cloud scan overlay, already in drawing space (issue #1805)
   scanPoints?: readonly ScanBandPoint[];
   scanOpacity?: number;
+  // Unit display overrides
+  projectUnits?: any;
+  unitDisplayOverrides?: Record<string, string>;
 }
 
 export function Drawing2DCanvas({
@@ -418,6 +421,8 @@ export function Drawing2DCanvas({
   dxfUnderlays,
   scanPoints,
   scanOpacity = 1,
+  projectUnits,
+  unitDisplayOverrides = {},
 }: Drawing2DCanvasProps): React.ReactElement {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [canvasSize, setCanvasSize] = useState({ width: 0, height: 0 });
@@ -1371,7 +1376,7 @@ export function Drawing2DCanvas({
       const midY = (screenStart.y + screenEnd.y) / 2;
 
       // Format distance using shared utility
-      const labelText = formatDistance(distance);
+      const labelText = formatDistance(distance, projectUnits, unitDisplayOverrides);
 
       // Background for label
       ctx.font = '12px system-ui, sans-serif';
@@ -1488,7 +1493,7 @@ export function Drawing2DCanvas({
       const cx = drawingToScreenX(centroid.x);
       const cy = drawingToScreenY(centroid.y);
       const areaText = formatArea(result.area);
-      const perimText = `P: ${formatDistance(result.perimeter)}`;
+      const perimText = `P: ${formatDistance(result.perimeter, projectUnits, unitDisplayOverrides)}`;
 
       ctx.font = 'bold 12px system-ui, sans-serif';
       const areaMetrics = ctx.measureText(areaText);

--- a/apps/viewer/src/components/viewer/Drawing2DCanvas.tsx
+++ b/apps/viewer/src/components/viewer/Drawing2DCanvas.tsx
@@ -17,6 +17,7 @@ import type { PolygonArea2DResult, TextAnnotation2D, CloudAnnotation2D, Annotati
 import type { DxfUnderlayRenderData } from '@/hooks/useDxfUnderlay';
 import type { AnnotationFill2D, AnnotationText2D } from '@/hooks/useSymbolicAnnotations';
 import type { ScanBandPoint } from '@/hooks/scanSectionMath';
+import type { ProjectUnits } from '@ifc-lite/parser';
 
 // Fill colors for IFC types (architectural convention)
 const IFC_TYPE_FILL_COLORS: Record<string, string> = {
@@ -384,7 +385,7 @@ interface Drawing2DCanvasProps {
   scanPoints?: readonly ScanBandPoint[];
   scanOpacity?: number;
   // Unit display overrides
-  projectUnits?: any;
+  projectUnits?: ProjectUnits;
   unitDisplayOverrides?: Record<string, string>;
 }
 

--- a/apps/viewer/src/components/viewer/Section2DPanel.tsx
+++ b/apps/viewer/src/components/viewer/Section2DPanel.tsx
@@ -23,6 +23,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { useViewerStore } from '@/store';
 import { toGlobalIdFromModels } from '@/store/globalId';
+import { extractProjectUnits } from '@ifc-lite/parser';
 import { useIfc } from '@/hooks/useIfc';
 import { useDraggablePanel } from '@/hooks/useDraggablePanel';
 import { GraphicOverrideEngine } from '@ifc-lite/drawing-2d';
@@ -155,6 +156,7 @@ export function Section2DPanel({
   const activeTool = useViewerStore((s) => s.activeTool);
   const models = useViewerStore((s) => s.models);
   const { geometryResult: legacyGeometryResult, ifcDataStore } = useIfc();
+  const unitDisplayOverrides = useViewerStore((s) => s.unitDisplayOverrides);
 
   // Use merged geometry from props if available (multi-model), otherwise fall back to legacy single-model
   const geometryResult = mergedGeometry ?? legacyGeometryResult;
@@ -222,6 +224,12 @@ export function Section2DPanel({
     }
     return map;
   }, [geometryResult]);
+
+  // Extract project units from the data store
+  const projectUnits = useMemo(() => {
+    if (!ifcDataStore?.source?.length || !ifcDataStore?.entityIndex) return undefined;
+    return extractProjectUnits(ifcDataStore.source, ifcDataStore.entityIndex);
+  }, [ifcDataStore]);
 
   // ═══════════════════════════════════════════════════════════════════════════
   // VISIBILITY STATE
@@ -452,6 +460,7 @@ export function Section2DPanel({
     sheetEnabled, activeSheet, dxfUnderlays: dxfUnderlayData,
     ifcDataStore, coordinateInfo: geometryResult?.coordinateInfo,
     scanSection: scanSectionLayer,
+    projectUnits, unitDisplayOverrides,
   });
 
   // ═══════════════════════════════════════════════════════════════════════════
@@ -1105,6 +1114,8 @@ export function Section2DPanel({
               dxfUnderlays={dxfUnderlayData}
               scanPoints={displayOptions.showScanSection ? scanSectionLayer.points : undefined}
               scanOpacity={displayOptions.scanSectionOpacity}
+              projectUnits={projectUnits}
+              unitDisplayOverrides={unitDisplayOverrides}
             />
             {/* Subtle updating indicator - shows while regenerating without hiding the drawing */}
             {isRegenerating && (

--- a/apps/viewer/src/components/viewer/Section2DPanel.tsx
+++ b/apps/viewer/src/components/viewer/Section2DPanel.tsx
@@ -460,7 +460,6 @@ export function Section2DPanel({
     sheetEnabled, activeSheet, dxfUnderlays: dxfUnderlayData,
     ifcDataStore, coordinateInfo: geometryResult?.coordinateInfo,
     scanSection: scanSectionLayer,
-    projectUnits, unitDisplayOverrides,
   });
 
   // ═══════════════════════════════════════════════════════════════════════════

--- a/apps/viewer/src/components/viewer/tools/MeasurePanel.tsx
+++ b/apps/viewer/src/components/viewer/tools/MeasurePanel.tsx
@@ -21,7 +21,7 @@ import {
   reprojectionInputKey,
   type LatLon,
 } from '@/lib/geo/reproject';
-import { extractProjectUnits, type IfcDataStore } from '@ifc-lite/parser';
+import { extractProjectUnits, type IfcDataStore, type ProjectUnits } from '@ifc-lite/parser';
 
 interface Vec3Like { x: number; y: number; z: number }
 interface Enh { e: string; n: string; h: string }
@@ -396,7 +396,7 @@ interface MeasurementItemProps {
   onDelete: (id: string) => void;
   /** When set, show real-world E/N/H for the measurement's two endpoints. */
   geoAnchor: AnchorGeoreference | null;
-  projectUnits?: any;
+  projectUnits?: ProjectUnits;
   unitDisplayOverrides?: Record<string, string>;
 }
 

--- a/apps/viewer/src/components/viewer/tools/MeasurePanel.tsx
+++ b/apps/viewer/src/components/viewer/tools/MeasurePanel.tsx
@@ -6,7 +6,7 @@
  * Measure tool panel UI (measurement list, controls)
  */
 
-import React, { useCallback, useState, useEffect } from 'react';
+import React, { useCallback, useState, useEffect, useMemo } from 'react';
 import { X, Trash2, Ruler, ChevronDown, GripVertical, Globe } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useViewerStore, type Measurement } from '@/store';
@@ -21,6 +21,7 @@ import {
   reprojectionInputKey,
   type LatLon,
 } from '@/lib/geo/reproject';
+import { extractProjectUnits, type IfcDataStore } from '@ifc-lite/parser';
 
 interface Vec3Like { x: number; y: number; z: number }
 interface Enh { e: string; n: string; h: string }
@@ -120,6 +121,14 @@ export function MeasureOverlay() {
   const clearMeasurements = useViewerStore((s) => s.clearMeasurements);
   const setActiveTool = useViewerStore((s) => s.setActiveTool);
   const projectToScreen = useViewerStore((s) => s.cameraCallbacks.projectToScreen);
+  const ifcDataStore = useViewerStore((s) => s.ifcDataStore);
+  const unitDisplayOverrides = useViewerStore((s) => s.unitDisplayOverrides);
+
+  // Extract project units from the data store
+  const projectUnits = useMemo(() => {
+    if (!ifcDataStore?.source?.length || !ifcDataStore?.entityIndex) return undefined;
+    return extractProjectUnits(ifcDataStore.source, ifcDataStore.entityIndex);
+  }, [ifcDataStore]);
 
   // Track cursor position in ref (no re-renders on mouse move)
   const cursorPosRef = React.useRef<{ x: number; y: number } | null>(null);
@@ -300,12 +309,14 @@ export function MeasureOverlay() {
                     index={i}
                     onDelete={handleDeleteMeasurement}
                     geoAnchor={showGeo ? anchor : null}
+                    projectUnits={projectUnits}
+                    unitDisplayOverrides={unitDisplayOverrides}
                   />
                 ))}
                 {measurements.length > 1 && (
                   <div className="flex items-center justify-between border-t pt-1 mt-1 text-xs font-medium">
                     <span>Total</span>
-                    <span className="font-mono">{formatDistance(totalDistance)}</span>
+                    <span className="font-mono">{formatDistance(totalDistance, projectUnits, unitDisplayOverrides)}</span>
                   </div>
                 )}
               </div>
@@ -372,6 +383,8 @@ export function MeasureOverlay() {
         hoverPosition={snapIndicatorPos}
         projectToScreen={projectToScreen}
         constraintEdge={measurementConstraintEdge}
+        projectUnits={projectUnits}
+        unitDisplayOverrides={unitDisplayOverrides}
       />
     </>
   );
@@ -383,14 +396,16 @@ interface MeasurementItemProps {
   onDelete: (id: string) => void;
   /** When set, show real-world E/N/H for the measurement's two endpoints. */
   geoAnchor: AnchorGeoreference | null;
+  projectUnits?: any;
+  unitDisplayOverrides?: Record<string, string>;
 }
 
-function MeasurementItem({ measurement, index, onDelete, geoAnchor }: MeasurementItemProps) {
+function MeasurementItem({ measurement, index, onDelete, geoAnchor, projectUnits, unitDisplayOverrides }: MeasurementItemProps) {
   return (
     <div className="bg-muted/50 rounded px-2 py-0.5 text-xs">
       <div className="flex items-center justify-between">
         <span className="text-muted-foreground text-xs">#{index + 1}</span>
-        <span className="font-mono font-medium">{formatDistance(measurement.distance)}</span>
+        <span className="font-mono font-medium">{formatDistance(measurement.distance, projectUnits, unitDisplayOverrides)}</span>
         <Button
           variant="ghost"
           size="icon-sm"

--- a/apps/viewer/src/components/viewer/tools/MeasurementVisuals.tsx
+++ b/apps/viewer/src/components/viewer/tools/MeasurementVisuals.tsx
@@ -21,9 +21,11 @@ export interface MeasurementOverlaysProps {
   hoverPosition?: { x: number; y: number } | null;
   projectToScreen?: (worldPos: { x: number; y: number; z: number }) => { x: number; y: number } | null;
   constraintEdge?: MeasurementConstraintEdge | null;
+  projectUnits?: any;
+  unitDisplayOverrides?: Record<string, string>;
 }
 
-export const MeasurementOverlays = React.memo(function MeasurementOverlays({ measurements, pending, activeMeasurement, snapTarget, snapVisualization, hoverPosition, projectToScreen, constraintEdge }: MeasurementOverlaysProps) {
+export const MeasurementOverlays = React.memo(function MeasurementOverlays({ measurements, pending, activeMeasurement, snapTarget, snapVisualization, hoverPosition, projectToScreen, constraintEdge, projectUnits, unitDisplayOverrides }: MeasurementOverlaysProps) {
   // Determine snap indicator position
   // Priority: activeMeasurement.current > snapTarget projected position > hoverPosition (fallback)
   const snapIndicatorPos = useMemo(() => {
@@ -120,7 +122,7 @@ export const MeasurementOverlays = React.memo(function MeasurementOverlays({ mea
               top: (m.start.screenY + m.end.screenY) / 2,
             }}
           >
-            {formatDistance(m.distance)}
+            {formatDistance(m.distance, projectUnits, unitDisplayOverrides)}
           </div>
         </div>
       ))}
@@ -175,7 +177,7 @@ export const MeasurementOverlays = React.memo(function MeasurementOverlays({ mea
               top: (activeMeasurement.start.screenY + activeMeasurement.current.screenY) / 2,
             }}
           >
-            {formatDistance(activeMeasurement.distance)}
+            {formatDistance(activeMeasurement.distance, projectUnits, unitDisplayOverrides)}
           </div>
         </div>
       )}

--- a/apps/viewer/src/components/viewer/tools/MeasurementVisuals.tsx
+++ b/apps/viewer/src/components/viewer/tools/MeasurementVisuals.tsx
@@ -10,6 +10,7 @@ import React, { useMemo } from 'react';
 import type { Measurement, SnapVisualization } from '@/store';
 import type { MeasurementConstraintEdge } from '@/store/types';
 import { SnapType, type SnapTarget } from '@ifc-lite/renderer';
+import type { ProjectUnits } from '@ifc-lite/parser';
 import { formatDistance } from './formatDistance';
 
 export interface MeasurementOverlaysProps {
@@ -21,7 +22,7 @@ export interface MeasurementOverlaysProps {
   hoverPosition?: { x: number; y: number } | null;
   projectToScreen?: (worldPos: { x: number; y: number; z: number }) => { x: number; y: number } | null;
   constraintEdge?: MeasurementConstraintEdge | null;
-  projectUnits?: any;
+  projectUnits?: ProjectUnits;
   unitDisplayOverrides?: Record<string, string>;
 }
 

--- a/apps/viewer/src/components/viewer/tools/formatDistance.ts
+++ b/apps/viewer/src/components/viewer/tools/formatDistance.ts
@@ -3,9 +3,36 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
- * Format a distance in meters to a human-readable string with appropriate units
+ * Format a distance in meters to a human-readable string with appropriate units.
+ * Honors per-unit-type display-unit overrides (issue #1573 proposal 2).
+ *
+ * @param meters - Distance in metres (SI base)
+ * @param projectUnits - File's declared units; defaults to ProjectUnits.empty()
+ * @param unitDisplayOverrides - Map of unit-type tokens to override option IDs
  */
-export function formatDistance(meters: number): string {
+
+import { QuantityType } from '@ifc-lite/data';
+import { ProjectUnits, type ProjectUnits as IProjectUnits } from '@ifc-lite/parser';
+import { resolveQuantityDisplay, formatConverted } from '@/lib/units/display';
+
+export function formatDistance(
+  meters: number,
+  projectUnits?: IProjectUnits,
+  unitDisplayOverrides?: Record<string, string>,
+): string {
+  const units = projectUnits ?? ProjectUnits.empty();
+  const overrides = unitDisplayOverrides ?? {};
+
+  // Try to resolve the display with quantity conversion
+  const disp = resolveQuantityDisplay(meters, QuantityType.Length, units, overrides);
+
+  // If there's a converted value (override was applied), use it with the override unit
+  if (disp.converted !== null && disp.unit) {
+    return `${formatConverted(disp.converted)} ${disp.unit}`;
+  }
+
+  // Otherwise, fall back to the default smart unit selection
+  // This maintains backward compatibility for the no-override case
   if (meters < 0.01) {
     return `${(meters * 1000).toFixed(1)} mm`;
   } else if (meters < 1) {

--- a/apps/viewer/src/hooks/useDrawingExport.ts
+++ b/apps/viewer/src/hooks/useDrawingExport.ts
@@ -164,10 +164,6 @@ interface UseDrawingExportParams {
   coordinateInfo: GeometryResult['coordinateInfo'] | undefined;
   /** Point-cloud scan overlay, already in drawing space (issue #1805) */
   scanSection: { points: readonly ScanBandPoint[] };
-  /** Project units from the model (issue #2199) */
-  projectUnits?: any;
-  /** Unit display overrides (issue #2199) */
-  unitDisplayOverrides?: Record<string, string>;
 }
 
 interface UseDrawingExportResult {
@@ -195,8 +191,6 @@ function useDrawingExport({
   ifcDataStore,
   coordinateInfo,
   scanSection,
-  projectUnits,
-  unitDisplayOverrides = {},
 }: UseDrawingExportParams): UseDrawingExportResult {
   // Georef inputs for the DXF export (PR #1871 review, P1): placement edits
   // applied in CesiumPlacementEditor live in `georefMutations` (per model
@@ -959,7 +953,7 @@ function useDrawingExport({
   }, [generateExportSVG, generateSheetSVG, sheetEnabled, activeSheet, sectionPlane]);
 
   return {
-    formatDistance: (distance: number) => formatDistance(distance, projectUnits, unitDisplayOverrides),
+    formatDistance,
     handleExportSVG,
     handleExportDXF,
     handlePrint,

--- a/apps/viewer/src/hooks/useDrawingExport.ts
+++ b/apps/viewer/src/hooks/useDrawingExport.ts
@@ -164,6 +164,10 @@ interface UseDrawingExportParams {
   coordinateInfo: GeometryResult['coordinateInfo'] | undefined;
   /** Point-cloud scan overlay, already in drawing space (issue #1805) */
   scanSection: { points: readonly ScanBandPoint[] };
+  /** Project units from the model (issue #2199) */
+  projectUnits?: any;
+  /** Unit display overrides (issue #2199) */
+  unitDisplayOverrides?: Record<string, string>;
 }
 
 interface UseDrawingExportResult {
@@ -191,6 +195,8 @@ function useDrawingExport({
   ifcDataStore,
   coordinateInfo,
   scanSection,
+  projectUnits,
+  unitDisplayOverrides = {},
 }: UseDrawingExportParams): UseDrawingExportResult {
   // Georef inputs for the DXF export (PR #1871 review, P1): placement edits
   // applied in CesiumPlacementEditor live in `georefMutations` (per model
@@ -953,7 +959,7 @@ function useDrawingExport({
   }, [generateExportSVG, generateSheetSVG, sheetEnabled, activeSheet, sectionPlane]);
 
   return {
-    formatDistance,
+    formatDistance: (distance: number) => formatDistance(distance, projectUnits, unitDisplayOverrides),
     handleExportSVG,
     handleExportDXF,
     handlePrint,


### PR DESCRIPTION
## Summary

- Measure tool now respects unit display preferences set in Properties panel
- When a user selects feet or another display unit override, formatDistance() converts measurements to that unit instead of always showing metres
- Reuses the existing resolveQuantityDisplay() helper pattern established by the Properties panel

## Defect

The maintainer flagged: *"`formatDistance()` ignoring `unitDisplayOverrides` is also worth its own small fix — a user who has set feet in the Properties panel still gets metres from the measure tool."*

File:line evidence: `apps/viewer/src/components/viewer/tools/formatDistance.ts:8` — the function took only a meters parameter and had hardcoded SI unit logic with no awareness of `unitDisplayOverrides`.

## Fix

Modified `formatDistance()` to accept `projectUnits` and `unitDisplayOverrides` parameters and delegate to the same `resolveQuantityDisplay()` helper used by the Properties panel, passing `QuantityType.Length`. When an override applies, returns the converted value with the override unit symbol; otherwise falls back to the original smart SI unit selection for backward compatibility.

Updated the callers that render the measure tool's on-screen output — MeasurePanel, MeasurementVisuals, Drawing2DCanvas (canvas overlay labels) — plus Section2DPanel, which extracts `projectUnits`/`unitDisplayOverrides` and threads them to Drawing2DCanvas. **SVG export is unaffected**: `useDrawingExport.ts`'s `generateExportSVG` calls the plain `formatDistance(distance)` import directly, not an override-aware wrapper, so exported drawings still render metres regardless of the override. An earlier revision of this PR also threaded `projectUnits`/`unitDisplayOverrides` through `useDrawingExport`, but the wrapped, override-aware `formatDistance` it produced was never called anywhere — dead code, reverted per review.

## Test Evidence

RED state (before fix): measure 3m with LENGTHUNIT override to 'ft' → displayed as "3.000 m"  
GREEN state (after fix): measure 3m with LENGTHUNIT override to 'ft' → displays as "9.8425 ft"  
RED on revert: same measurement reverts to "3.000 m"

Changeset added: `.changeset/measure-unit-display-override.md`
