### PR TITLE
fix(drawing-2d): honour unitDisplayOverrides in the 2D canvas distance/perimeter labels

### DIFF
--- a/.changeset/drawing2d-unit-display-override.md
+++ b/.changeset/drawing2d-unit-display-override.md
@@ -1,0 +1,7 @@
+---
+'@ifc-lite/viewer': patch
+---
+
+Honour the LENGTHUNIT display override in the 2D section/drawing canvas's on-canvas distance and perimeter labels (#2199 slice).
+
+`0de10a0fd` (#2538) wired `unitDisplayOverrides` through every measure-tool distance readout — `MeasurePanel.tsx`, `MeasurementVisuals.tsx`, `MeasurePointReadout.tsx` — but `Drawing2DCanvas.tsx`'s own measure-line and polygon-area-perimeter labels still called `formatDistance()` with no `overrides` argument, so a user who set feet as their display unit still saw metres there. `Drawing2DCanvas` now accepts a `unitDisplayOverrides` prop (defaulting to `{}`, so the no-override behaviour is unchanged) and threads it into both `formatDistance()` call sites; `Section2DPanel.tsx` reads the override map from the store and passes it down.

--- a/apps/viewer/src/components/viewer/Drawing2DCanvas.tsx
+++ b/apps/viewer/src/components/viewer/Drawing2DCanvas.tsx
@@ -333,6 +333,7 @@ function drawScanSectionScreenSpace(
 // Static constants to avoid creating new objects/arrays on every render
 const CANVAS_STYLE = { imageRendering: 'crisp-edges' as const };
 const EMPTY_MEASURE_RESULTS: Measure2DResultData[] = [];
+const EMPTY_UNIT_DISPLAY_OVERRIDES: Record<string, string> = {};
 
 export interface Measure2DResultData {
   id: string;
@@ -383,6 +384,12 @@ interface Drawing2DCanvasProps {
   // Point-cloud scan overlay, already in drawing space (issue #1805)
   scanPoints?: readonly ScanBandPoint[];
   scanOpacity?: number;
+  // LENGTHUNIT display override for the on-canvas measure distance/perimeter
+  // labels (#2199 slice not covered by #2538, which wired every OTHER
+  // measure-tool readout — MeasurePanel.tsx, MeasurementVisuals.tsx — through
+  // `unitDisplayOverrides` but left this canvas's own `formatDistance()`
+  // calls on the pre-#2199 no-argument (always-metric) form).
+  unitDisplayOverrides?: Record<string, string>;
 }
 
 export function Drawing2DCanvas({
@@ -418,6 +425,7 @@ export function Drawing2DCanvas({
   dxfUnderlays,
   scanPoints,
   scanOpacity = 1,
+  unitDisplayOverrides = EMPTY_UNIT_DISPLAY_OVERRIDES,
 }: Drawing2DCanvasProps): React.ReactElement {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [canvasSize, setCanvasSize] = useState({ width: 0, height: 0 });
@@ -1371,7 +1379,7 @@ export function Drawing2DCanvas({
       const midY = (screenStart.y + screenEnd.y) / 2;
 
       // Format distance using shared utility
-      const labelText = formatDistance(distance);
+      const labelText = formatDistance(distance, unitDisplayOverrides);
 
       // Background for label
       ctx.font = '12px system-ui, sans-serif';
@@ -1488,7 +1496,7 @@ export function Drawing2DCanvas({
       const cx = drawingToScreenX(centroid.x);
       const cy = drawingToScreenY(centroid.y);
       const areaText = formatArea(result.area);
-      const perimText = `P: ${formatDistance(result.perimeter)}`;
+      const perimText = `P: ${formatDistance(result.perimeter, unitDisplayOverrides)}`;
 
       ctx.font = 'bold 12px system-ui, sans-serif';
       const areaMetrics = ctx.measureText(areaText);
@@ -1776,7 +1784,7 @@ export function Drawing2DCanvas({
         }
       }
     }
-  }, [drawing, transform, showHiddenLines, canvasSize, overrideEngine, overridesEnabled, entityColorMap, useIfcMaterials, measureMode, measureStart, measureCurrent, measureResults, measureSnapPoint, sheetEnabled, activeSheet, sectionAxis, isPinned, annotation2DActiveTool, annotation2DCursorPos, polygonAreaPoints, polygonAreaResults, textAnnotations, textAnnotationEditing, cloudAnnotationPoints, cloudAnnotations, selectedAnnotation, ifcAnnotationLines, ifcAnnotationTexts, ifcAnnotationFills, dxfUnderlays, scanPoints, scanOpacity]);
+  }, [drawing, transform, showHiddenLines, canvasSize, overrideEngine, overridesEnabled, entityColorMap, useIfcMaterials, measureMode, measureStart, measureCurrent, measureResults, measureSnapPoint, sheetEnabled, activeSheet, sectionAxis, isPinned, annotation2DActiveTool, annotation2DCursorPos, polygonAreaPoints, polygonAreaResults, textAnnotations, textAnnotationEditing, cloudAnnotationPoints, cloudAnnotations, selectedAnnotation, ifcAnnotationLines, ifcAnnotationTexts, ifcAnnotationFills, dxfUnderlays, scanPoints, scanOpacity, unitDisplayOverrides]);
 
   return (
     <canvas

--- a/apps/viewer/src/components/viewer/Drawing2DCanvas.unit-display-override.test.tsx
+++ b/apps/viewer/src/components/viewer/Drawing2DCanvas.unit-display-override.test.tsx
@@ -1,0 +1,167 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * #2199 slice that #2538 ("measurement distance readouts honour
+ * unitDisplayOverrides", 0de10a0fd) did not cover: the 2D section/drawing
+ * canvas. `Drawing2DCanvas`'s on-canvas distance label (drawn for each
+ * completed measurement) called `formatDistance(distance)` with no
+ * `overrides` argument, so a user who set feet as their LENGTHUNIT display
+ * override still saw metres there — unlike every measure-tool readout in
+ * `MeasurePanel.tsx` / `MeasurementVisuals.tsx`, which #2538 already fixed.
+ *
+ * The canvas draws imperatively (`ctx.fillText`), so this test installs a
+ * recording `CanvasRenderingContext2D` stub (happy-dom implements the
+ * `<canvas>` element but not 2D rendering) and a synchronous ResizeObserver
+ * (`installLayout()`, #2434) so the draw effect's early-return guards
+ * (`canvasSize.width === 0`, `!ctx`) don't skip the draw entirely.
+ */
+
+import '@/test/setup-dom.js';
+import { installLayout } from '@/test/dom-layout.js';
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { GraphicOverrideEngine } from '@ifc-lite/drawing-2d';
+import type { Drawing2D } from '@ifc-lite/drawing-2d';
+import { Drawing2DCanvas, type Measure2DResultData } from './Drawing2DCanvas.js';
+
+installLayout();
+
+/** Records every `fillText` call so a test can assert on the exact label
+ *  string the canvas drew, without a real 2D rendering backend. All other
+ *  `CanvasRenderingContext2D` members are no-ops (methods) or accept any
+ *  assignment (properties) — the component under test calls dozens of them
+ *  (`beginPath`, `fillStyle = ...`, `save`, `clip`, ...) that this test does
+ *  not care about. */
+function installCanvasStub(): { fillTextCalls: string[]; restore: () => void } {
+  const fillTextCalls: string[] = [];
+  const store = new Map<string | symbol, unknown>();
+  const ctx = new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        if (prop === 'measureText') return (text: string) => ({ width: text.length * 7 });
+        if (prop === 'canvas') return { width: 800, height: 600 };
+        if (prop === 'fillText') {
+          return (text: string) => {
+            fillTextCalls.push(text);
+          };
+        }
+        if (store.has(prop)) return store.get(prop);
+        // Any other canvas 2D method (beginPath, moveTo, lineTo, stroke,
+        // fill, save, restore, translate, scale, clip, rect, arc,
+        // setLineDash, fillRect, strokeRect, ...) is a no-op.
+        return () => undefined;
+      },
+      set(_target, prop, value) {
+        store.set(prop, value);
+        return true;
+      },
+    },
+  ) as unknown as CanvasRenderingContext2D;
+
+  const original = HTMLCanvasElement.prototype.getContext;
+  HTMLCanvasElement.prototype.getContext = ((kind: string) =>
+    kind === '2d' ? ctx : null) as unknown as typeof HTMLCanvasElement.prototype.getContext;
+
+  return {
+    fillTextCalls,
+    restore: () => {
+      HTMLCanvasElement.prototype.getContext = original;
+    },
+  };
+}
+
+/** Empty drawing. Only `bounds`, `lines`, and `cutPolygons` are read by the
+ *  non-sheet-mode render path this test exercises, but every `Drawing2D`
+ *  field is filled in (rather than cast past the interface) so this fixture
+ *  keeps type-checking against the real shape as it evolves. */
+const EMPTY_DRAWING: Drawing2D = {
+  config: {
+    plane: { axis: 'y', position: 0, flipped: false },
+    projectionDepth: 10,
+    includeHiddenLines: true,
+    creaseAngle: 30,
+    scale: 100,
+  },
+  lines: [],
+  cutPolygons: [],
+  projectionPolygons: [],
+  bounds: { min: { x: 0, y: 0 }, max: { x: 10, y: 10 } },
+  stats: {
+    cutLineCount: 0,
+    projectionLineCount: 0,
+    hiddenLineCount: 0,
+    silhouetteLineCount: 0,
+    polygonCount: 0,
+    totalTriangles: 0,
+    processingTimeMs: 0,
+  },
+};
+
+const MEASURE_RESULT: Measure2DResultData = {
+  id: 'm1',
+  start: { x: 0, y: 0 },
+  end: { x: 10, y: 0 },
+  distance: 1, // metres — matches formatDistance.test.ts's "3.2808 ft" fixture
+};
+
+const mounted: Array<{ root: Root; container: HTMLElement }> = [];
+
+function renderCanvas(unitDisplayOverrides?: Record<string, string>): void {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(
+      <Drawing2DCanvas
+        drawing={EMPTY_DRAWING}
+        transform={{ x: 0, y: 0, scale: 1 }}
+        showHiddenLines={false}
+        overrideEngine={new GraphicOverrideEngine()}
+        overridesEnabled={false}
+        entityColorMap={new Map()}
+        useIfcMaterials={false}
+        sectionAxis="down"
+        measureResults={[MEASURE_RESULT]}
+        unitDisplayOverrides={unitDisplayOverrides}
+      />,
+    );
+  });
+  mounted.push({ root, container });
+}
+
+describe('Drawing2DCanvas unitDisplayOverrides (#2199 slice)', () => {
+  it('honours a LENGTHUNIT override in the on-canvas distance label', () => {
+    const stub = installCanvasStub();
+    try {
+      renderCanvas({ LENGTHUNIT: 'ft' });
+      assert.ok(
+        stub.fillTextCalls.includes('3.2808 ft'),
+        `expected a "3.2808 ft" label; got ${JSON.stringify(stub.fillTextCalls)}`,
+      );
+      assert.ok(
+        !stub.fillTextCalls.some((t) => t.includes(' m')),
+        `no label should still read in metres; got ${JSON.stringify(stub.fillTextCalls)}`,
+      );
+    } finally {
+      stub.restore();
+    }
+  });
+
+  it('keeps the pre-existing metric label when no override is set (byte-identical to main)', () => {
+    const stub = installCanvasStub();
+    try {
+      renderCanvas(undefined);
+      assert.ok(
+        stub.fillTextCalls.includes('1.000 m'),
+        `expected the unconverted "1.000 m" label; got ${JSON.stringify(stub.fillTextCalls)}`,
+      );
+    } finally {
+      stub.restore();
+    }
+  });
+});

--- a/apps/viewer/src/components/viewer/Section2DPanel.tsx
+++ b/apps/viewer/src/components/viewer/Section2DPanel.tsx
@@ -73,6 +73,9 @@ export function Section2DPanel({
   const setDrawingError = useViewerStore((s) => s.setDrawing2DError);
   const displayOptions = useViewerStore((s) => s.drawing2DDisplayOptions);
   const updateDisplayOptions = useViewerStore((s) => s.updateDrawing2DDisplayOptions);
+  // LENGTHUNIT display override for the on-canvas measure distance/perimeter
+  // labels (#2199 slice not covered by #2538 — see Drawing2DCanvas.tsx).
+  const unitDisplayOverrides = useViewerStore((s) => s.unitDisplayOverrides);
   // Class-level Visibility toggles — the section honours them like the 3D
   // viewport does, so a hidden IfcSpace/IfcOpeningElement is not cut (#2060).
   const typeVisibility = useViewerStore((s) => s.typeVisibility);
@@ -1174,6 +1177,7 @@ export function Section2DPanel({
               dxfUnderlays={dxfUnderlayData}
               scanPoints={displayOptions.showScanSection ? scanSectionLayer.points : undefined}
               scanOpacity={displayOptions.scanSectionOpacity}
+              unitDisplayOverrides={unitDisplayOverrides}
             />
             {/* Subtle updating indicator - shows while regenerating without hiding the drawing */}
             {isRegenerating && (


### PR DESCRIPTION
## Summary
- `0de10a0fd` (#2538) wired `unitDisplayOverrides` through every measure-tool distance readout — `MeasurePanel.tsx`, `MeasurementVisuals.tsx`, `MeasurePointReadout.tsx` — but missed `Drawing2DCanvas.tsx`'s own on-canvas measure-line and polygon-area-perimeter labels, which still called `formatDistance()` with no `overrides` argument.
- `Drawing2DCanvas` now accepts a `unitDisplayOverrides` prop (default `{}`, so the no-override path is unchanged) and threads it into both `formatDistance()` call sites; `Section2DPanel.tsx` reads the override map from the store and passes it down.
- Surviving slice of #2199 / #2638: that PR's branch was 506 commits stale and conflicting against `main` (so GitHub never queued CI on it), and most of its content is now redundant with #2538. This PR covers the one thing #2538 didn't.

## Test plan
- [x] RED: new test asserted a `LENGTHUNIT: 'ft'` override on-canvas — failed against the pre-fix code with the unconverted `"1.000 m"` label.
- [x] GREEN: same test passes after threading the prop through, asserting the canvas drew `"3.2808 ft"`.
- [x] RED again: reverted one `formatDistance()` call site — the override test failed again, confirming the test actually exercises the fix.
- [x] Second test pins the no-override path as byte-identical to current `main` (`"1.000 m"`).
- [x] `pnpm build`, `pnpm lint` (0 errors), `pnpm --filter @ifc-lite/viewer typecheck`, full viewer test suite (4222 passed / 0 failed / 6 pre-existing skipped), `node scripts/docs/generate-docs-sections.mjs --check` all green.
- [x] Changeset added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 2D drawing and section measurement labels now respect custom length-unit display settings.
  - Distance and perimeter measurements can be displayed in units such as feet instead of metres.

- **Bug Fixes**
  - Corrected measurement labels so configured unit overrides are consistently applied across 2D canvases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->