### PR TITLE
ci(server-bin): gate the platform set and verify release assets (#2619)

### DIFF
--- a/.github/workflows/server-binaries.yml
+++ b/.github/workflows/server-binaries.yml
@@ -22,6 +22,17 @@ on:
     types:
       - published
   workflow_dispatch:
+    inputs:
+      upload-to-tag:
+        # Backfill lever: a plain dispatch only produces 1-day artifacts, so
+        # before this input existed a release missing an archive (issue
+        # #2619, v1.16.6 shipped without the win32-x64 zip) could not be
+        # repaired self-service. Supplying an existing v* tag uploads the
+        # rebuilt archives to that release and re-verifies its assets.
+        description: 'Existing release tag (e.g. v1.16.6) to upload the built archives to; leave empty for artifacts only'
+        required: false
+        type: string
+        default: ''
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -232,15 +243,52 @@ jobs:
           retention-days: 1
 
       - name: Upload to GitHub Release
-        if: github.event_name == 'release'
+        # Also runs on a manual dispatch that names an existing tag, so a
+        # release with a missing archive can be backfilled (issue #2619).
+        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.upload-to-tag != '')
         # Force bash so the backslash line-continuation parses on Windows
         # runners too (default shell there is PowerShell, which reads the
         # bare `--clobber` continuation as the unary decrement operator →
         # win32-x64 release upload failed with a ParserError).
         shell: bash
         run: |
-          gh release upload "${{ github.event.release.tag_name }}" \
+          gh release upload "${{ github.event_name == 'release' && github.event.release.tag_name || inputs.upload-to-tag }}" \
             ifc-lite-server-${{ matrix.target }}.${{ matrix.archive }} \
             --clobber
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Verify the release actually carries one archive per supported platform.
+  # The upload matrix above can partially fail, and a missing archive makes
+  # every install on that platform 404 at postinstall (issue #2619).
+  verify-release-assets:
+    name: Verify release assets
+    needs: release-server-binaries
+    # `always()` is the load-bearing part. A failed `needs:` skips the
+    # dependent whatever the condition says, so without it the job that
+    # exists to name a missing archive could not run on the case it exists
+    # for: a matrix leg that failed or was cancelled. That is exactly how
+    # v1.16.6 shipped without the win32-x64 zip and nothing said so.
+    #
+    # Runs on version-tagged releases, and on a manual dispatch that names
+    # a tag to backfill - the same two paths that upload assets.
+    if: |
+      always()
+      && (
+        (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'v'))
+        || (github.event_name == 'workflow_dispatch' && inputs.upload-to-tag != '')
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          lfs: false
+          persist-credentials: false
+
+      - name: Verify release carries every supported platform archive
+        run: node scripts/check-server-bin-targets.mjs --release "${{ github.event_name == 'release' && github.event.release.tag_name || inputs.upload-to-tag }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/server-binaries.yml
+++ b/.github/workflows/server-binaries.yml
@@ -264,12 +264,11 @@ jobs:
         # failed the win32-x64 release upload with a ParserError).
         shell: bash
         run: |
-          tag="${{ github.event_name == 'release' && github.event.release.tag_name || inputs.upload-to-tag }}"
           asset="ifc-lite-server-${{ matrix.target }}.${{ matrix.archive }}"
-          if [ "${{ github.event_name }}" = "release" ]; then
+          if [ "$GITHUB_EVENT_NAME" = "release" ]; then
             # Fresh release: assets are being created for the first time, so
             # --clobber is the correct idempotent choice for job re-runs.
-            gh release upload "$tag" "$asset" --clobber
+            gh release upload "$RELEASE_TAG" "$asset" --clobber
           else
             # Manual backfill of an existing release: every matrix leg runs,
             # including platforms whose assets are already healthy, and
@@ -278,15 +277,22 @@ jobs:
             # lost"). A transient failure would then destroy a working
             # archive for a platform that was never broken. So only upload
             # what is actually missing, and never clobber.
-            existing="$(gh release view "$tag" --json assets --jq '.assets[].name')"
+            existing="$(gh release view "$RELEASE_TAG" --json assets --jq '.assets[].name')"
             if printf '%s\n' "$existing" | grep -qxF "$asset"; then
-              echo "$asset already exists on $tag; leaving the healthy asset untouched"
+              echo "$asset already exists on $RELEASE_TAG; leaving the healthy asset untouched"
             else
-              gh release upload "$tag" "$asset"
+              gh release upload "$RELEASE_TAG" "$asset"
             fi
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # The tag must reach bash as DATA, never as source: `${{ }}` expands
+          # before bash parses the script, so inlining it would let a tag name
+          # or `upload-to-tag` input containing shell metacharacters (git
+          # refnames allow $, (, ), ; and friends) execute in a job holding a
+          # contents:write token. The matrix.* values inlined above are
+          # literals defined in this file, so they are not injectable.
+          RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.upload-to-tag }}
 
   # Verify the release actually carries one archive per supported platform.
   # The upload matrix above can partially fail, and a missing archive makes
@@ -319,6 +325,22 @@ jobs:
           persist-credentials: false
 
       - name: Verify release carries every supported platform archive
-        run: node scripts/check-server-bin-targets.mjs --release "${{ github.event_name == 'release' && github.event.release.tag_name || inputs.upload-to-tag }}"
+        # The script reads the expected archive set from the TAG'S OWN
+        # platform.ts (git show), not from this checkout: on a manual
+        # backfill the checkout is the workflow ref (main), whose
+        # SUPPORTED_TARGETS may have drifted since the tag - main's set
+        # would demand archives the old release never claimed to ship, a
+        # false red on exactly the repair path this job exists for. The
+        # checker code itself still runs from the workflow ref. A `release`
+        # event checkout already carries the tag ref, a backfill checkout
+        # does not, so fetch it explicitly (anonymous fetch works: the repo
+        # is public and persist-credentials is off); if the ref is absent
+        # the script fails closed rather than falling back to today's set.
+        run: |
+          git fetch --depth=1 origin "+refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
+          node scripts/check-server-bin-targets.mjs --release "$RELEASE_TAG"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Same hardening as the upload step: the tag reaches bash as data
+          # through env, never spliced into the script source via ${{ }}.
+          RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.upload-to-tag }}

--- a/.github/workflows/server-binaries.yml
+++ b/.github/workflows/server-binaries.yml
@@ -164,6 +164,18 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # The build ref and the workflow ref deliberately differ on a
+          # manual backfill. A dispatch runs the workflow DEFINITION from the
+          # dispatch ref (normally the default branch, which is the only ref
+          # that has the `upload-to-tag` input), but the SOURCE being built
+          # must be the tag under repair: the install-time resolver in
+          # packages/server-bin picks its release by the installed package
+          # version, so an archive built from any other revision would ship
+          # different code under that old version number. Do not "simplify"
+          # this to the default checkout. On a `release` event
+          # `inputs.upload-to-tag` is empty, so this falls back to
+          # `github.ref` (the release tag), identical to the default.
+          ref: ${{ inputs.upload-to-tag || github.ref }}
           lfs: false
           persist-credentials: false
 
@@ -246,15 +258,33 @@ jobs:
         # Also runs on a manual dispatch that names an existing tag, so a
         # release with a missing archive can be backfilled (issue #2619).
         if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.upload-to-tag != '')
-        # Force bash so the backslash line-continuation parses on Windows
-        # runners too (default shell there is PowerShell, which reads the
-        # bare `--clobber` continuation as the unary decrement operator →
-        # win32-x64 release upload failed with a ParserError).
+        # Force bash so multi-line scripts parse on Windows runners too
+        # (default shell there is PowerShell, which once read a bare
+        # `--clobber` line-continuation as the unary decrement operator and
+        # failed the win32-x64 release upload with a ParserError).
         shell: bash
         run: |
-          gh release upload "${{ github.event_name == 'release' && github.event.release.tag_name || inputs.upload-to-tag }}" \
-            ifc-lite-server-${{ matrix.target }}.${{ matrix.archive }} \
-            --clobber
+          tag="${{ github.event_name == 'release' && github.event.release.tag_name || inputs.upload-to-tag }}"
+          asset="ifc-lite-server-${{ matrix.target }}.${{ matrix.archive }}"
+          if [ "${{ github.event_name }}" = "release" ]; then
+            # Fresh release: assets are being created for the first time, so
+            # --clobber is the correct idempotent choice for job re-runs.
+            gh release upload "$tag" "$asset" --clobber
+          else
+            # Manual backfill of an existing release: every matrix leg runs,
+            # including platforms whose assets are already healthy, and
+            # `gh release upload --clobber` DELETES the existing asset before
+            # uploading ("If the upload fails, the original assets will be
+            # lost"). A transient failure would then destroy a working
+            # archive for a platform that was never broken. So only upload
+            # what is actually missing, and never clobber.
+            existing="$(gh release view "$tag" --json assets --jq '.assets[].name')"
+            if printf '%s\n' "$existing" | grep -qxF "$asset"; then
+              echo "$asset already exists on $tag; leaving the healthy asset untouched"
+            else
+              gh release upload "$tag" "$asset"
+            fi
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -429,8 +429,10 @@ jobs:
       # literal in a comment satisfied the upload check) that hand-testing
       # had missed. Each hostile mutation now runs against the real inputs
       # in a temp tree and must turn the gate red with an accurate message.
+      # The second file unit-tests stripYamlComments, the primitive the gate's
+      # comment-awareness rests on (a lone apostrophe once blinded it).
       - name: Check server-bin parity gate regressions
-        run: node --test scripts/check-server-bin-targets.test.mjs
+        run: node --test scripts/check-server-bin-targets.test.mjs scripts/lib/server-bin-targets-parse.test.mjs
       # The server-parse root-attribute table (attr_indices.rs) is generated
       # from @ifc-lite/parser's SCHEMA_REGISTRY — the SAME table the in-browser
       # parse resolves names against. Guard that the committed file is in sync

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,6 +107,10 @@ jobs:
               # Lint job that reads it. Absent CI reads as green here, and a
               # guard cannot fire in a job that never runs.
               - '.oxlintrc.json'
+              # The server-bin platform-parity check reads this workflow's
+              # release matrix, so a PR that only edits the matrix cannot
+              # skip the job that checks it (issue #2619).
+              - '.github/workflows/server-binaries.yml'
               - 'package.json'
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'
@@ -412,6 +416,13 @@ jobs:
       # can't ship silently.
       - name: Check API surface
         run: node scripts/check-api-surface.mjs
+      # A server-bin release must ship one archive per platform the package
+      # claims to support. Three lists encode that set (SUPPORTED_TARGETS in
+      # platform.ts, package.json os/cpu, the release matrix in
+      # server-binaries.yml) and agreed only by hand until v1.16.6 shipped
+      # without the win32-x64 zip and nothing noticed (issue #2619).
+      - name: Check server-bin platform parity
+        run: node scripts/check-server-bin-targets.mjs
       # The server-parse root-attribute table (attr_indices.rs) is generated
       # from @ifc-lite/parser's SCHEMA_REGISTRY — the SAME table the in-browser
       # parse resolves names against. Guard that the committed file is in sync

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -423,6 +423,14 @@ jobs:
       # without the win32-x64 zip and nothing noticed (issue #2619).
       - name: Check server-bin platform parity
         run: node scripts/check-server-bin-targets.mjs
+      # Executable proof that the parity gate itself cannot pass vacuously:
+      # an adversarial review of PR #2642 produced four false greens
+      # (commented-out matrix entries and targets still counted; a stale
+      # literal in a comment satisfied the upload check) that hand-testing
+      # had missed. Each hostile mutation now runs against the real inputs
+      # in a temp tree and must turn the gate red with an accurate message.
+      - name: Check server-bin parity gate regressions
+        run: node --test scripts/check-server-bin-targets.test.mjs
       # The server-parse root-attribute table (attr_indices.rs) is generated
       # from @ifc-lite/parser's SCHEMA_REGISTRY — the SAME table the in-browser
       # parse resolves names against. Guard that the committed file is in sync

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "check:api-surface": "node scripts/check-api-surface.mjs",
     "api-surface:update": "node scripts/check-api-surface.mjs --update",
     "check:git-lfs": "node scripts/check-git-lfs.mjs",
+    "check:server-bin-targets": "node scripts/check-server-bin-targets.mjs",
     "check:tla-chunk-await": "node scripts/check-tla-chunk-await.mjs",
     "generate:server-attr-indices": "pnpm turbo build --filter=@ifc-lite/parser && node scripts/generate-server-attr-indices.mjs",
     "check:server-attr-indices": "pnpm turbo build --filter=@ifc-lite/parser && node scripts/generate-server-attr-indices.mjs --check",

--- a/scripts/check-server-bin-targets.mjs
+++ b/scripts/check-server-bin-targets.mjs
@@ -51,22 +51,41 @@
  * available locally is an ERROR, never a vacuous pass. In particular an
  * absent tag ref tells the operator to fetch it instead of silently
  * falling back to the checked-out tree's target set.
+ *
+ * Source-text matching is comment-aware (rationale in
+ * scripts/lib/server-bin-targets-parse.mjs); the upload check binds the asset
+ * literal to the actual `gh release upload` argument. Executable proof:
+ * scripts/check-server-bin-targets.test.mjs, which drives this script via
+ * `--root <dir>` against hostile mutations of the real inputs.
  */
 
 import { readFileSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
-import { dirname, join } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
+import {
+  fail,
+  jobBlock,
+  parseMatrix,
+  parseSupportedTargets,
+  stripYamlComments,
+  unquoteScalar,
+} from './lib/server-bin-targets-parse.mjs';
 
-const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+// --root <dir>: read the input files from an alternate tree (in --release
+// mode, git also runs there). Exists for the regression harness, which points
+// the UNMODIFIED checker at mutated copies of the real inputs; CI never
+// passes it.
+const rootFlagIdx = process.argv.indexOf('--root');
+if (rootFlagIdx !== -1 && !process.argv[rootFlagIdx + 1]) {
+  fail('--root requires a directory argument');
+}
+const repoRoot = rootFlagIdx === -1
+  ? join(dirname(fileURLToPath(import.meta.url)), '..')
+  : resolve(process.argv[rootFlagIdx + 1]);
 const PLATFORM_TS = 'packages/server-bin/src/platform.ts';
 const PKG_JSON = 'packages/server-bin/package.json';
 const WORKFLOW = '.github/workflows/server-binaries.yml';
-
-function fail(message) {
-  console.error(`check-server-bin-targets: ERROR: ${message}`);
-  process.exit(1);
-}
 
 /** Archive extension the install-time resolver derives for a triple. */
 function archiveExtFor(platform) {
@@ -121,22 +140,6 @@ function assertSetEquals(label, actual, expected) {
   }
 }
 
-/** Parse the SUPPORTED_TARGETS set literal out of platform.ts source text. */
-function parseSupportedTargets(source, origin = PLATFORM_TS) {
-  const m = source.match(/const SUPPORTED_TARGETS = new Set\(\[([^\]]*)\]\)/);
-  if (!m) {
-    fail(
-      `cannot find the "const SUPPORTED_TARGETS = new Set([...])" list in ${origin}; ` +
-      `if the const moved or was renamed, update this check - it must not pass without the list`,
-    );
-  }
-  const targets = [...m[1].matchAll(/'([^']+)'/g)].map((q) => q[1]);
-  if (targets.length < 2) {
-    fail(`parsed only ${targets.length} target(s) from SUPPORTED_TARGETS in ${origin}; refusing a vacuous pass`);
-  }
-  return targets;
-}
-
 /**
  * SUPPORTED_TARGETS as of the release tag's own source. A release is
  * verified against what ITS resolver downloads: the install-time resolver
@@ -170,48 +173,6 @@ function parseTagSupportedTargets(tag) {
   return parseSupportedTargets(source, `${PLATFORM_TS} at tag ${tag}`);
 }
 
-/** Extract one job's block from the workflow (2-space-indented job keys). */
-function jobBlock(source, jobName) {
-  const start = new RegExp(`^  ${jobName}:[ \\t]*$`, 'm').exec(source);
-  if (!start) {
-    fail(`cannot find job "${jobName}" in ${WORKFLOW}; if it was renamed, update this check`);
-  }
-  const bodyStart = start.index + start[0].length;
-  const next = /^  [A-Za-z0-9_-]+:/m.exec(source.slice(bodyStart));
-  return next ? source.slice(bodyStart, bodyStart + next.index) : source.slice(bodyStart);
-}
-
-/** Parse `- target:` / `rust-target:` / `archive:` tuples from a job's matrix include list. */
-function parseMatrix(source, jobName, { requireArchive }) {
-  const block = jobBlock(source, jobName);
-  const includeIdx = block.indexOf('include:');
-  const steps = /^    steps:/m.exec(block);
-  if (includeIdx === -1 || !steps || steps.index < includeIdx) {
-    fail(`cannot find the matrix include list in job "${jobName}" of ${WORKFLOW}`);
-  }
-  const section = block.slice(includeIdx, steps.index);
-  const anchors = [...section.matchAll(/- target:[ \t]*([^\s]+)/g)];
-  if (anchors.length === 0) {
-    fail(`matrix include list in job "${jobName}" of ${WORKFLOW} yielded zero targets; refusing a vacuous pass`);
-  }
-  return anchors.map((anchor, i) => {
-    const end = i + 1 < anchors.length ? anchors[i + 1].index : section.length;
-    const chunk = section.slice(anchor.index, end);
-    const archive = chunk.match(/archive:[ \t]*([^\s]+)/);
-    if (requireArchive && !archive) {
-      fail(`matrix entry "${anchor[1]}" in job "${jobName}" of ${WORKFLOW} has no archive: key`);
-    }
-    const rustTarget = chunk.match(/rust-target:[ \t]*([^\s]+)/);
-    if (!rustTarget) {
-      fail(
-        `matrix entry "${anchor[1]}" in job "${jobName}" of ${WORKFLOW} has no rust-target: key; ` +
-        `refusing a vacuous pass - without it nothing pins which triple that leg builds`,
-      );
-    }
-    return { target: anchor[1], archive: archive ? archive[1] : null, rustTarget: rustTarget[1] };
-  });
-}
-
 /**
  * The exact expression the upload step must use for the asset filename.
  * The resolver downloads `ifc-lite-server-<target>.<ext>`; pinning the
@@ -222,9 +183,15 @@ function parseMatrix(source, jobName, { requireArchive }) {
 // eslint-disable-next-line no-template-curly-in-string
 const UPLOAD_ASSET_EXPR = 'ifc-lite-server-${{ matrix.target }}.${{ matrix.archive }}';
 
-/** The release upload step must name its asset via UPLOAD_ASSET_EXPR. */
+/**
+ * The release upload step must BIND the asset name to UPLOAD_ASSET_EXPR and
+ * every `gh release upload` invocation in it must pass exactly that binding.
+ * Mere presence of the literal in the step is not enough: a comment can carry
+ * the old name while the assignment or the upload argument drifts, and then
+ * every release 404s on every platform while the gate blesses it.
+ */
 function checkUploadAssetName(workflow) {
-  const block = jobBlock(workflow, 'release-server-binaries');
+  const block = jobBlock(workflow, 'release-server-binaries', WORKFLOW);
   const stepStart = block.indexOf('- name: Upload to GitHub Release');
   if (stepStart === -1) {
     fail(
@@ -235,18 +202,60 @@ function checkUploadAssetName(workflow) {
   const rest = block.slice(stepStart + 1);
   const nextStep = /\n {6}- name:/.exec(rest);
   const step = block.slice(stepStart, nextStep ? stepStart + 1 + nextStep.index : block.length);
-  if (!step.includes(UPLOAD_ASSET_EXPR)) {
+
+  // 1. The `asset=` binding must be exactly the expected expression and the
+  // ONLY line writing the variable - a later `asset=` or `asset+=` would
+  // rebind the name and reopen the hole the presence check had.
+  const assigns = [...step.matchAll(/^[ \t]*asset(\+?=)(.*)$/gm)];
+  if (assigns.length === 0) {
     fail(
-      `the "Upload to GitHub Release" step in ${WORKFLOW} does not use the literal asset expression ` +
-      `"${UPLOAD_ASSET_EXPR}"; the resolver in ${PLATFORM_TS} downloads exactly that name, so the ` +
-      `upload must provably produce it`,
+      `the "Upload to GitHub Release" step in ${WORKFLOW} no longer assigns asset=...; the step must ` +
+      `bind asset to "${UPLOAD_ASSET_EXPR}" (the exact name the resolver in ${PLATFORM_TS} downloads) - ` +
+      `if the script was restructured, update this check`,
     );
+  }
+  if (assigns.length > 1) {
+    fail(
+      `the "Upload to GitHub Release" step in ${WORKFLOW} writes the asset variable ${assigns.length} ` +
+      `times; a rebinding after the pinned assignment could upload a name the resolver in ` +
+      `${PLATFORM_TS} never downloads, so exactly one asset= line is allowed`,
+    );
+  }
+  const [, op, rawValue] = assigns[0];
+  const assigned = unquoteScalar(rawValue.trim());
+  if (op !== '=' || assigned !== UPLOAD_ASSET_EXPR) {
+    fail(
+      `the "Upload to GitHub Release" step in ${WORKFLOW} assigns asset${op}${rawValue.trim()} but the ` +
+      `resolver in ${PLATFORM_TS} downloads exactly "${UPLOAD_ASSET_EXPR}"; the two must be identical`,
+    );
+  }
+
+  // 2. Both paths (fresh release and backfill) must pass the $asset binding
+  // as the `gh release upload` asset argument. Only double quotes are
+  // stripped: a single-quoted '$asset' never expands in bash, so it must stay red.
+  const uploads = [...step.matchAll(/gh release upload[ \t]+(\S+)[ \t]+(\S+)/g)];
+  if (uploads.length < 2) {
+    fail(
+      `expected the release and backfill paths of the "Upload to GitHub Release" step in ${WORKFLOW} ` +
+      `to each invoke "gh release upload <tag> <asset>"; found ${uploads.length} invocation(s) - ` +
+      `if the step was restructured, update this check`,
+    );
+  }
+  for (const [, , assetArg] of uploads) {
+    const arg = assetArg.replace(/^"(.*)"$/s, '$1').replace(/^\$\{asset\}$/, '$asset');
+    if (arg !== '$asset') {
+      fail(
+        `a "gh release upload" invocation in the "Upload to GitHub Release" step of ${WORKFLOW} passes ` +
+        `${assetArg} as its asset argument instead of "$asset"; only the pinned $asset binding provably ` +
+        `uploads the name the resolver in ${PLATFORM_TS} downloads`,
+      );
+    }
   }
 }
 
 /** Default mode: the three functional lists must agree. */
 function checkSourceParity() {
-  const targets = parseSupportedTargets(readFileSync(join(repoRoot, PLATFORM_TS), 'utf8'));
+  const targets = parseSupportedTargets(readFileSync(join(repoRoot, PLATFORM_TS), 'utf8'), PLATFORM_TS);
   const targetSet = new Set(targets);
 
   // package.json os/cpu: prefix/arch projection of the triples.
@@ -259,12 +268,13 @@ function checkSourceParity() {
   assertSetEquals(`${PKG_JSON} "os"`, new Set(pkg.os), expectedOs);
   assertSetEquals(`${PKG_JSON} "cpu"`, new Set(pkg.cpu), expectedCpu);
 
-  const workflow = readFileSync(join(repoRoot, WORKFLOW), 'utf8');
+  // Comments stripped up front: a commented-out matrix entry or upload line counts as absent.
+  const workflow = stripYamlComments(readFileSync(join(repoRoot, WORKFLOW), 'utf8'));
 
   // Release matrix: exact target equality, the resolver's archive rule, and
   // the target-to-rust-triple mapping (a wrong triple ships an incompatible
   // binary under a perfectly valid archive name).
-  const release = parseMatrix(workflow, 'release-server-binaries', { requireArchive: true });
+  const release = parseMatrix(workflow, 'release-server-binaries', WORKFLOW, { requireArchive: true });
   assertSetEquals(`${WORKFLOW} release-server-binaries matrix`, new Set(release.map((e) => e.target)), targetSet);
   for (const entry of release) {
     const expectedExt = archiveExtFor(splitTriple(entry.target).platform);
@@ -290,7 +300,7 @@ function checkSourceParity() {
 
   // Validate matrix: a deliberate cost-saving subset, never an unknown
   // target, and its legs must build the triple their target names.
-  const validate = parseMatrix(workflow, 'validate-server-binaries', { requireArchive: false });
+  const validate = parseMatrix(workflow, 'validate-server-binaries', WORKFLOW, { requireArchive: false });
   for (const entry of validate) {
     if (!targetSet.has(entry.target)) {
       fail(`validate-server-binaries matrix names "${entry.target}", which is not in SUPPORTED_TARGETS`);
@@ -375,6 +385,8 @@ async function checkReleaseAssets(tag) {
 }
 
 const args = process.argv.slice(2);
+const rootIdx = args.indexOf('--root');
+if (rootIdx !== -1) args.splice(rootIdx, 2);
 const releaseIdx = args.indexOf('--release');
 if (releaseIdx !== -1) {
   const tag = args[releaseIdx + 1];

--- a/scripts/check-server-bin-targets.mjs
+++ b/scripts/check-server-bin-targets.mjs
@@ -1,0 +1,242 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * A server-bin release must carry one archive per platform the package
+ * claims to support - and nothing verified that until v1.16.6 shipped
+ * without ifc-lite-server-win32-x64.zip (issue #2619).
+ *
+ * Three functional lists encode the platform set and agreed only by hand:
+ *
+ *   1. SUPPORTED_TARGETS in packages/server-bin/src/platform.ts - the six
+ *      real target triples the install-time resolver accepts.
+ *   2. `os` / `cpu` in packages/server-bin/package.json - what npm gates
+ *      installs on. This is a strictly COARSER cross-product than the
+ *      triples: it admits win32-arm64 (npm checks os and cpu independently)
+ *      and cannot express linux-x64-musl at all. So the invariant is not
+ *      triple-for-triple: `os` must equal the set of platform prefixes in
+ *      SUPPORTED_TARGETS, and `cpu` must equal the set of arches with any
+ *      `-musl` suffix stripped.
+ *   3. The `release-server-binaries` matrix in
+ *      .github/workflows/server-binaries.yml - what actually gets built and
+ *      uploaded. Its target set must equal SUPPORTED_TARGETS, and each
+ *      entry's `archive` must match the resolver's naming rule (win32 =>
+ *      zip, else tar.gz), which is what makes the workflow's
+ *      `ifc-lite-server-<target>.<archive>` provably the same string the
+ *      resolver downloads.
+ *
+ * The `validate-server-binaries` matrix is a deliberate cost-saving SUBSET
+ * (linux only), so it is checked as a subset, not for equality.
+ *
+ * With `--release <tag>` the script instead asserts the published release
+ * carries every expected archive by name, so a failed matrix leg cannot
+ * leave a silent hole.
+ *
+ * Fail-closed: an unfindable list, a parse yielding no entries, or an
+ * unreadable/empty release asset list is an ERROR, never a vacuous pass.
+ */
+
+import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const PLATFORM_TS = 'packages/server-bin/src/platform.ts';
+const PKG_JSON = 'packages/server-bin/package.json';
+const WORKFLOW = '.github/workflows/server-binaries.yml';
+
+function fail(message) {
+  console.error(`check-server-bin-targets: ERROR: ${message}`);
+  process.exit(1);
+}
+
+/** Archive extension the install-time resolver derives for a triple. */
+function archiveExtFor(platform) {
+  return platform === 'win32' ? 'zip' : 'tar.gz';
+}
+
+/** Split "<platform>-<arch>[-musl]" or fail. */
+function splitTriple(triple) {
+  const m = triple.match(/^([a-z0-9]+)-([a-z0-9]+)(-musl)?$/);
+  if (!m) {
+    fail(`unrecognised target triple "${triple}" (expected <platform>-<arch>[-musl])`);
+  }
+  return { platform: m[1], arch: m[2] };
+}
+
+function assertSetEquals(label, actual, expected) {
+  const missing = [...expected].filter((v) => !actual.has(v));
+  const extra = [...actual].filter((v) => !expected.has(v));
+  if (missing.length || extra.length) {
+    const parts = [];
+    if (missing.length) parts.push(`missing: ${missing.join(', ')}`);
+    if (extra.length) parts.push(`unexpected: ${extra.join(', ')}`);
+    fail(`${label} disagrees with SUPPORTED_TARGETS (${parts.join('; ')})`);
+  }
+}
+
+/** Parse the SUPPORTED_TARGETS set literal out of platform.ts. */
+function parseSupportedTargets() {
+  const source = readFileSync(join(repoRoot, PLATFORM_TS), 'utf8');
+  const m = source.match(/const SUPPORTED_TARGETS = new Set\(\[([^\]]*)\]\)/);
+  if (!m) {
+    fail(
+      `cannot find the "const SUPPORTED_TARGETS = new Set([...])" list in ${PLATFORM_TS}; ` +
+      `if the const moved or was renamed, update this check - it must not pass without the list`,
+    );
+  }
+  const targets = [...m[1].matchAll(/'([^']+)'/g)].map((q) => q[1]);
+  if (targets.length < 2) {
+    fail(`parsed only ${targets.length} target(s) from SUPPORTED_TARGETS in ${PLATFORM_TS}; refusing a vacuous pass`);
+  }
+  return targets;
+}
+
+/** Extract one job's block from the workflow (2-space-indented job keys). */
+function jobBlock(source, jobName) {
+  const start = new RegExp(`^  ${jobName}:[ \\t]*$`, 'm').exec(source);
+  if (!start) {
+    fail(`cannot find job "${jobName}" in ${WORKFLOW}; if it was renamed, update this check`);
+  }
+  const bodyStart = start.index + start[0].length;
+  const next = /^  [A-Za-z0-9_-]+:/m.exec(source.slice(bodyStart));
+  return next ? source.slice(bodyStart, bodyStart + next.index) : source.slice(bodyStart);
+}
+
+/** Parse `- target:` / `archive:` pairs from a job's matrix include list. */
+function parseMatrix(source, jobName, { requireArchive }) {
+  const block = jobBlock(source, jobName);
+  const includeIdx = block.indexOf('include:');
+  const steps = /^    steps:/m.exec(block);
+  if (includeIdx === -1 || !steps || steps.index < includeIdx) {
+    fail(`cannot find the matrix include list in job "${jobName}" of ${WORKFLOW}`);
+  }
+  const section = block.slice(includeIdx, steps.index);
+  const anchors = [...section.matchAll(/- target:[ \t]*([^\s]+)/g)];
+  if (anchors.length === 0) {
+    fail(`matrix include list in job "${jobName}" of ${WORKFLOW} yielded zero targets; refusing a vacuous pass`);
+  }
+  return anchors.map((anchor, i) => {
+    const end = i + 1 < anchors.length ? anchors[i + 1].index : section.length;
+    const chunk = section.slice(anchor.index, end);
+    const archive = chunk.match(/archive:[ \t]*([^\s]+)/);
+    if (requireArchive && !archive) {
+      fail(`matrix entry "${anchor[1]}" in job "${jobName}" of ${WORKFLOW} has no archive: key`);
+    }
+    return { target: anchor[1], archive: archive ? archive[1] : null };
+  });
+}
+
+/** Default mode: the three functional lists must agree. */
+function checkSourceParity() {
+  const targets = parseSupportedTargets();
+  const targetSet = new Set(targets);
+
+  // package.json os/cpu: prefix/arch projection of the triples.
+  const pkg = JSON.parse(readFileSync(join(repoRoot, PKG_JSON), 'utf8'));
+  if (!Array.isArray(pkg.os) || !Array.isArray(pkg.cpu)) {
+    fail(`${PKG_JSON} has no "os"/"cpu" arrays; the npm install gate is gone`);
+  }
+  const expectedOs = new Set(targets.map((t) => splitTriple(t).platform));
+  const expectedCpu = new Set(targets.map((t) => splitTriple(t).arch));
+  assertSetEquals(`${PKG_JSON} "os"`, new Set(pkg.os), expectedOs);
+  assertSetEquals(`${PKG_JSON} "cpu"`, new Set(pkg.cpu), expectedCpu);
+
+  const workflow = readFileSync(join(repoRoot, WORKFLOW), 'utf8');
+
+  // Release matrix: exact target equality plus the resolver's archive rule.
+  const release = parseMatrix(workflow, 'release-server-binaries', { requireArchive: true });
+  assertSetEquals(`${WORKFLOW} release-server-binaries matrix`, new Set(release.map((e) => e.target)), targetSet);
+  for (const entry of release) {
+    const expectedExt = archiveExtFor(splitTriple(entry.target).platform);
+    if (entry.archive !== expectedExt) {
+      fail(
+        `release matrix entry "${entry.target}" archives as "${entry.archive}" but the resolver ` +
+        `in ${PLATFORM_TS} downloads "ifc-lite-server-${entry.target}.${expectedExt}"`,
+      );
+    }
+  }
+
+  // Validate matrix: a deliberate cost-saving subset, never an unknown target.
+  const validate = parseMatrix(workflow, 'validate-server-binaries', { requireArchive: false });
+  for (const entry of validate) {
+    if (!targetSet.has(entry.target)) {
+      fail(`validate-server-binaries matrix names "${entry.target}", which is not in SUPPORTED_TARGETS`);
+    }
+  }
+
+  console.log(
+    `check-server-bin-targets: OK - ${targets.length} targets ` +
+    `(${targets.join(', ')}) agree across ${PLATFORM_TS}, ${PKG_JSON} and ${WORKFLOW}`,
+  );
+  return targets;
+}
+
+/** Owner/repo slug, derived from the package manifest rather than hardcoded. */
+function repoSlug() {
+  const pkg = JSON.parse(readFileSync(join(repoRoot, PKG_JSON), 'utf8'));
+  const m = String(pkg.repository?.url ?? '').match(/github\.com[/:]([^/]+\/[^/.]+)/);
+  if (!m) fail(`cannot derive the GitHub repo slug from ${PKG_JSON} repository.url`);
+  return m[1];
+}
+
+/** Release asset names via gh, falling back to the REST API when gh is absent. */
+async function fetchReleaseAssetNames(tag) {
+  try {
+    const out = execFileSync('gh', ['release', 'view', tag, '--json', 'assets'], { encoding: 'utf8' });
+    const parsed = JSON.parse(out);
+    if (!Array.isArray(parsed.assets)) fail(`gh release view ${tag} returned no assets array`);
+    return parsed.assets.map((a) => a.name);
+  } catch (err) {
+    if (err?.code !== 'ENOENT') {
+      fail(`could not read release ${tag} via gh: ${err?.message ?? err}`);
+    }
+  }
+  const url = `https://api.github.com/repos/${repoSlug()}/releases/tags/${encodeURIComponent(tag)}`;
+  const headers = {
+    accept: 'application/vnd.github+json',
+    'user-agent': 'ifc-lite-check-server-bin-targets',
+  };
+  if (process.env.GITHUB_TOKEN) headers.authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+  const res = await fetch(url, { headers });
+  if (!res.ok) fail(`GitHub API returned ${res.status} for release ${tag} (${url})`);
+  const body = await res.json();
+  if (!Array.isArray(body.assets)) fail(`GitHub API response for release ${tag} has no assets array`);
+  return body.assets.map((a) => a.name);
+}
+
+/**
+ * --release mode: every expected archive must exist on the release, by the
+ * exact name the resolver downloads. Deliberately does NOT expect .sha256 /
+ * SHA256SUMS sidecars: no workflow publishes them today, so expecting them
+ * would turn every release red.
+ */
+async function checkReleaseAssets(tag) {
+  const targets = checkSourceParity();
+  const names = await fetchReleaseAssetNames(tag);
+  if (names.length === 0) {
+    fail(`release ${tag} has no assets at all; an empty list is a failure, not a pass`);
+  }
+  const expected = targets.map((t) => `ifc-lite-server-${t}.${archiveExtFor(splitTriple(t).platform)}`);
+  const missing = expected.filter((name) => !names.includes(name));
+  if (missing.length) {
+    fail(
+      `release ${tag} is missing ${missing.length} of ${expected.length} expected archives:\n` +
+      missing.map((name) => `  ${name}`).join('\n'),
+    );
+  }
+  console.log(`check-server-bin-targets: OK - release ${tag} carries all ${expected.length} expected archives`);
+}
+
+const args = process.argv.slice(2);
+const releaseIdx = args.indexOf('--release');
+if (releaseIdx !== -1) {
+  const tag = args[releaseIdx + 1];
+  if (!tag || tag.startsWith('--')) fail('--release requires a tag argument (e.g. --release v1.16.6)');
+  await checkReleaseAssets(tag);
+} else {
+  checkSourceParity();
+}

--- a/scripts/check-server-bin-targets.mjs
+++ b/scripts/check-server-bin-targets.mjs
@@ -36,10 +36,21 @@
  *
  * With `--release <tag>` the script instead asserts the published release
  * carries every expected archive by name, so a failed matrix leg cannot
- * leave a silent hole.
+ * leave a silent hole. The expected set is read from the TAG'S OWN
+ * platform.ts (`git show refs/tags/<tag>:...`), not from the checked-out
+ * tree: a manual backfill dispatch checks out the workflow ref (main), and
+ * as the platform set drifts, main's SUPPORTED_TARGETS would demand
+ * archives an old release never claimed to ship (a false red on exactly
+ * the repair path this check exists for) or miss ones it still needs (a
+ * false green). The checked-out tree still gets the full source-parity
+ * check first, and the checker code itself always runs from the workflow
+ * ref.
  *
- * Fail-closed: an unfindable list, a parse yielding no entries, or an
- * unreadable/empty release asset list is an ERROR, never a vacuous pass.
+ * Fail-closed: an unfindable list, a parse yielding no entries, an
+ * unreadable/empty release asset list, or a release tag whose ref is not
+ * available locally is an ERROR, never a vacuous pass. In particular an
+ * absent tag ref tells the operator to fetch it instead of silently
+ * falling back to the checked-out tree's target set.
  */
 
 import { readFileSync } from 'node:fs';
@@ -110,21 +121,53 @@ function assertSetEquals(label, actual, expected) {
   }
 }
 
-/** Parse the SUPPORTED_TARGETS set literal out of platform.ts. */
-function parseSupportedTargets() {
-  const source = readFileSync(join(repoRoot, PLATFORM_TS), 'utf8');
+/** Parse the SUPPORTED_TARGETS set literal out of platform.ts source text. */
+function parseSupportedTargets(source, origin = PLATFORM_TS) {
   const m = source.match(/const SUPPORTED_TARGETS = new Set\(\[([^\]]*)\]\)/);
   if (!m) {
     fail(
-      `cannot find the "const SUPPORTED_TARGETS = new Set([...])" list in ${PLATFORM_TS}; ` +
+      `cannot find the "const SUPPORTED_TARGETS = new Set([...])" list in ${origin}; ` +
       `if the const moved or was renamed, update this check - it must not pass without the list`,
     );
   }
   const targets = [...m[1].matchAll(/'([^']+)'/g)].map((q) => q[1]);
   if (targets.length < 2) {
-    fail(`parsed only ${targets.length} target(s) from SUPPORTED_TARGETS in ${PLATFORM_TS}; refusing a vacuous pass`);
+    fail(`parsed only ${targets.length} target(s) from SUPPORTED_TARGETS in ${origin}; refusing a vacuous pass`);
   }
   return targets;
+}
+
+/**
+ * SUPPORTED_TARGETS as of the release tag's own source. A release is
+ * verified against what ITS resolver downloads: the install-time resolver
+ * ships inside the published package at that version, so the tag's
+ * platform.ts is the contract, and the checked-out tree's may have drifted
+ * (a backfill dispatch checks out the workflow ref, not the tag). The
+ * tag's package.json os/cpu is deliberately not consulted here - it only
+ * gates npm installs, cannot change which archives the tag's resolver
+ * downloads, and is unfixable post-publish anyway.
+ *
+ * Fail-closed: an absent tag ref is an ERROR telling the operator to fetch
+ * it, never a silent fallback to the checked-out tree's set - that
+ * fallback would recreate the vacuous pass this script exists to prevent.
+ */
+function parseTagSupportedTargets(tag) {
+  let source;
+  try {
+    source = execFileSync('git', ['show', `refs/tags/${tag}:${PLATFORM_TS}`], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (err) {
+    const detail = String(err?.stderr || err?.message || err).trim().split('\n')[0];
+    fail(
+      `cannot read ${PLATFORM_TS} at tag "${tag}" via git show (${detail}); ` +
+      `fetch the tag first (git fetch --depth=1 origin tag ${tag}) - refusing to fall back ` +
+      `to the checked-out tree's target set, which may not be the tag's`,
+    );
+  }
+  return parseSupportedTargets(source, `${PLATFORM_TS} at tag ${tag}`);
 }
 
 /** Extract one job's block from the workflow (2-space-indented job keys). */
@@ -203,7 +246,7 @@ function checkUploadAssetName(workflow) {
 
 /** Default mode: the three functional lists must agree. */
 function checkSourceParity() {
-  const targets = parseSupportedTargets();
+  const targets = parseSupportedTargets(readFileSync(join(repoRoot, PLATFORM_TS), 'utf8'));
   const targetSet = new Set(targets);
 
   // package.json os/cpu: prefix/arch projection of the triples.
@@ -303,12 +346,16 @@ async function fetchReleaseAssetNames(tag) {
 
 /**
  * --release mode: every expected archive must exist on the release, by the
- * exact name the resolver downloads. Deliberately does NOT expect .sha256 /
- * SHA256SUMS sidecars: no workflow publishes them today, so expecting them
- * would turn every release red.
+ * exact name the resolver downloads. The expected set is the TAG's own
+ * SUPPORTED_TARGETS (see parseTagSupportedTargets); the checked-out tree is
+ * still source-parity-checked first, since on a `release` event it IS the
+ * tag and on a backfill it is the gated workflow ref. Deliberately does NOT
+ * expect .sha256 / SHA256SUMS sidecars: no workflow publishes them today,
+ * so expecting them would turn every release red.
  */
 async function checkReleaseAssets(tag) {
-  const targets = checkSourceParity();
+  checkSourceParity();
+  const targets = parseTagSupportedTargets(tag);
   const names = await fetchReleaseAssetNames(tag);
   if (names.length === 0) {
     fail(`release ${tag} has no assets at all; an empty list is a failure, not a pass`);
@@ -317,18 +364,23 @@ async function checkReleaseAssets(tag) {
   const missing = expected.filter((name) => !names.includes(name));
   if (missing.length) {
     fail(
-      `release ${tag} is missing ${missing.length} of ${expected.length} expected archives:\n` +
+      `release ${tag} is missing ${missing.length} of ${expected.length} archives its own SUPPORTED_TARGETS names:\n` +
       missing.map((name) => `  ${name}`).join('\n'),
     );
   }
-  console.log(`check-server-bin-targets: OK - release ${tag} carries all ${expected.length} expected archives`);
+  console.log(
+    `check-server-bin-targets: OK - release ${tag} carries all ${expected.length} archives ` +
+    `its own SUPPORTED_TARGETS names (${targets.join(', ')})`,
+  );
 }
 
 const args = process.argv.slice(2);
 const releaseIdx = args.indexOf('--release');
 if (releaseIdx !== -1) {
   const tag = args[releaseIdx + 1];
-  if (!tag || tag.startsWith('--')) fail('--release requires a tag argument (e.g. --release v1.16.6)');
+  // Reject a leading '-' outright: the tag is passed as an argv to gh, where
+  // it would parse as a flag (git refnames cannot start with '-' anyway).
+  if (!tag || tag.startsWith('-')) fail('--release requires a tag argument (e.g. --release v1.16.6)');
   await checkReleaseAssets(tag);
 } else {
   checkSourceParity();

--- a/scripts/check-server-bin-targets.mjs
+++ b/scripts/check-server-bin-targets.mjs
@@ -21,11 +21,15 @@
  *      `-musl` suffix stripped.
  *   3. The `release-server-binaries` matrix in
  *      .github/workflows/server-binaries.yml - what actually gets built and
- *      uploaded. Its target set must equal SUPPORTED_TARGETS, and each
- *      entry's `archive` must match the resolver's naming rule (win32 =>
- *      zip, else tar.gz), which is what makes the workflow's
- *      `ifc-lite-server-<target>.<archive>` provably the same string the
- *      resolver downloads.
+ *      uploaded. Its target set must equal SUPPORTED_TARGETS, each entry's
+ *      `archive` must match the resolver's naming rule (win32 => zip, else
+ *      tar.gz), and each entry's `rust-target` must be the triple the
+ *      install target actually needs - a wrong triple ships an incompatible
+ *      binary under a perfectly valid archive name (arm64 bits as x64).
+ *      The upload step must also use the literal
+ *      `ifc-lite-server-${{ matrix.target }}.${{ matrix.archive }}`
+ *      expression, which is what makes the uploaded name provably the same
+ *      string the resolver downloads rather than agreeing by luck.
  *
  * The `validate-server-binaries` matrix is a deliberate cost-saving SUBSET
  * (linux only), so it is checked as a subset, not for equality.
@@ -64,7 +68,35 @@ function splitTriple(triple) {
   if (!m) {
     fail(`unrecognised target triple "${triple}" (expected <platform>-<arch>[-musl])`);
   }
-  return { platform: m[1], arch: m[2] };
+  return { platform: m[1], arch: m[2], musl: Boolean(m[3]) };
+}
+
+/**
+ * The rust triple a matrix entry must build for an install target. Derived,
+ * not hardcoded: platform and arch map 1:1 onto the rust triple's components
+ * and `-musl` selects the musl libc. An underivable platform or arch is an
+ * ERROR, never a skip, so a brand-new target cannot enter the matrix without
+ * this mapping learning about it first.
+ */
+function rustTripleFor(target) {
+  const { platform, arch, musl } = splitTriple(target);
+  const rustArch = { x64: 'x86_64', arm64: 'aarch64' }[arch];
+  if (!rustArch) {
+    fail(`no rust-triple mapping for arch "${arch}" (target "${target}"); teach this check the new arch before adding the target`);
+  }
+  if (musl && platform !== 'linux') {
+    fail(`target "${target}" uses -musl on non-linux platform "${platform}"; no rust triple exists for that`);
+  }
+  switch (platform) {
+    case 'linux':
+      return `${rustArch}-unknown-linux-${musl ? 'musl' : 'gnu'}`;
+    case 'darwin':
+      return `${rustArch}-apple-darwin`;
+    case 'win32':
+      return `${rustArch}-pc-windows-msvc`;
+    default:
+      fail(`no rust-triple mapping for platform "${platform}" (target "${target}"); teach this check the new platform before adding the target`);
+  }
 }
 
 function assertSetEquals(label, actual, expected) {
@@ -106,7 +138,7 @@ function jobBlock(source, jobName) {
   return next ? source.slice(bodyStart, bodyStart + next.index) : source.slice(bodyStart);
 }
 
-/** Parse `- target:` / `archive:` pairs from a job's matrix include list. */
+/** Parse `- target:` / `rust-target:` / `archive:` tuples from a job's matrix include list. */
 function parseMatrix(source, jobName, { requireArchive }) {
   const block = jobBlock(source, jobName);
   const includeIdx = block.indexOf('include:');
@@ -126,8 +158,47 @@ function parseMatrix(source, jobName, { requireArchive }) {
     if (requireArchive && !archive) {
       fail(`matrix entry "${anchor[1]}" in job "${jobName}" of ${WORKFLOW} has no archive: key`);
     }
-    return { target: anchor[1], archive: archive ? archive[1] : null };
+    const rustTarget = chunk.match(/rust-target:[ \t]*([^\s]+)/);
+    if (!rustTarget) {
+      fail(
+        `matrix entry "${anchor[1]}" in job "${jobName}" of ${WORKFLOW} has no rust-target: key; ` +
+        `refusing a vacuous pass - without it nothing pins which triple that leg builds`,
+      );
+    }
+    return { target: anchor[1], archive: archive ? archive[1] : null, rustTarget: rustTarget[1] };
   });
+}
+
+/**
+ * The exact expression the upload step must use for the asset filename.
+ * The resolver downloads `ifc-lite-server-<target>.<ext>`; pinning the
+ * workflow to this literal makes the two names provably identical instead
+ * of two hand-maintained strings that agree by luck.
+ */
+// The ${{ }} is a GitHub Actions expression pinned as a literal, not a JS template.
+// eslint-disable-next-line no-template-curly-in-string
+const UPLOAD_ASSET_EXPR = 'ifc-lite-server-${{ matrix.target }}.${{ matrix.archive }}';
+
+/** The release upload step must name its asset via UPLOAD_ASSET_EXPR. */
+function checkUploadAssetName(workflow) {
+  const block = jobBlock(workflow, 'release-server-binaries');
+  const stepStart = block.indexOf('- name: Upload to GitHub Release');
+  if (stepStart === -1) {
+    fail(
+      `cannot find the "Upload to GitHub Release" step in job "release-server-binaries" of ${WORKFLOW}; ` +
+      `if the step was renamed, update this check - it must not pass without pinning the upload filename`,
+    );
+  }
+  const rest = block.slice(stepStart + 1);
+  const nextStep = /\n {6}- name:/.exec(rest);
+  const step = block.slice(stepStart, nextStep ? stepStart + 1 + nextStep.index : block.length);
+  if (!step.includes(UPLOAD_ASSET_EXPR)) {
+    fail(
+      `the "Upload to GitHub Release" step in ${WORKFLOW} does not use the literal asset expression ` +
+      `"${UPLOAD_ASSET_EXPR}"; the resolver in ${PLATFORM_TS} downloads exactly that name, so the ` +
+      `upload must provably produce it`,
+    );
+  }
 }
 
 /** Default mode: the three functional lists must agree. */
@@ -147,7 +218,9 @@ function checkSourceParity() {
 
   const workflow = readFileSync(join(repoRoot, WORKFLOW), 'utf8');
 
-  // Release matrix: exact target equality plus the resolver's archive rule.
+  // Release matrix: exact target equality, the resolver's archive rule, and
+  // the target-to-rust-triple mapping (a wrong triple ships an incompatible
+  // binary under a perfectly valid archive name).
   const release = parseMatrix(workflow, 'release-server-binaries', { requireArchive: true });
   assertSetEquals(`${WORKFLOW} release-server-binaries matrix`, new Set(release.map((e) => e.target)), targetSet);
   for (const entry of release) {
@@ -158,13 +231,33 @@ function checkSourceParity() {
         `in ${PLATFORM_TS} downloads "ifc-lite-server-${entry.target}.${expectedExt}"`,
       );
     }
+    const expectedTriple = rustTripleFor(entry.target);
+    if (entry.rustTarget !== expectedTriple) {
+      fail(
+        `release matrix entry "${entry.target}" builds rust-target "${entry.rustTarget}" but the ` +
+        `install target requires "${expectedTriple}"; the archive name would be valid while the ` +
+        `binary inside it targets the wrong platform`,
+      );
+    }
   }
 
-  // Validate matrix: a deliberate cost-saving subset, never an unknown target.
+  // The upload step must name assets with the exact expression the resolver
+  // expects, or the six correct archives upload under the wrong names.
+  checkUploadAssetName(workflow);
+
+  // Validate matrix: a deliberate cost-saving subset, never an unknown
+  // target, and its legs must build the triple their target names.
   const validate = parseMatrix(workflow, 'validate-server-binaries', { requireArchive: false });
   for (const entry of validate) {
     if (!targetSet.has(entry.target)) {
       fail(`validate-server-binaries matrix names "${entry.target}", which is not in SUPPORTED_TARGETS`);
+    }
+    const expectedTriple = rustTripleFor(entry.target);
+    if (entry.rustTarget !== expectedTriple) {
+      fail(
+        `validate matrix entry "${entry.target}" builds rust-target "${entry.rustTarget}" but the ` +
+        `target maps to "${expectedTriple}"; that leg would validate the wrong platform's build`,
+      );
     }
   }
 

--- a/scripts/check-server-bin-targets.test.mjs
+++ b/scripts/check-server-bin-targets.test.mjs
@@ -211,6 +211,21 @@ test('a block comment inside the Set is green', () => {
   assertGreen(result);
 });
 
+// Same class one level down: the comment stripper itself. A lone apostrophe
+// in unquoted shell text once opened a quote state that never closed, hiding
+// every later `#` on the line - here the hidden comment carries a hostile
+// upload invocation, so a stripper regression turns this green case red.
+test('an apostrophe in unquoted shell text does not blind the comment stripper', () => {
+  const result = runChecker({
+    workflow: (s) => mutate(
+      s,
+      ASSIGN_LINE,
+      `${ASSIGN_LINE}\n          echo the tag can't clobber healthy assets # gh release upload "$RELEASE_TAG" "stale-$asset"`,
+    ),
+  });
+  assertGreen(result);
+});
+
 test('an upload argument that braces the asset variable is green', () => {
   const result = runChecker({
     workflow: (s) => mutate(s, RELEASE_UPLOAD, RELEASE_UPLOAD.replace('"$asset"', BRACED_ASSET_ARG)),

--- a/scripts/check-server-bin-targets.test.mjs
+++ b/scripts/check-server-bin-targets.test.mjs
@@ -1,0 +1,280 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Regression harness for scripts/check-server-bin-targets.mjs, the server-bin
+ * platform parity gate. Hand-testing is what let four false greens through in
+ * PR #2642 (its regression table exercised deletion, never commenting-out),
+ * so every hostile mutation the adversarial review demonstrated lives here as
+ * an executable case, alongside the gate's original deliberate regressions.
+ *
+ * Method: each case writes a mutated copy of the REAL inputs (platform.ts,
+ * package.json, server-binaries.yml) to a temp dir outside the repo, runs the
+ * UNMODIFIED checker against it via its --root flag, and asserts the exit
+ * code plus the message. The checker is exercised as a black box - nothing
+ * here reads the checker's source, and every mutation anchor is asserted to
+ * exist in the real input first, so a drifted anchor fails the suite instead
+ * of silently testing nothing.
+ *
+ * Run: node --test scripts/check-server-bin-targets.test.mjs
+ * (wired as a step of the CI node-test job in .github/workflows/test.yml).
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const CHECKER = join(ROOT, 'scripts', 'check-server-bin-targets.mjs');
+
+const INPUTS = {
+  platform: 'packages/server-bin/src/platform.ts',
+  pkg: 'packages/server-bin/package.json',
+  workflow: '.github/workflows/server-binaries.yml',
+};
+const real = Object.fromEntries(
+  Object.entries(INPUTS).map(([key, rel]) => [key, readFileSync(join(ROOT, rel), 'utf8')]),
+);
+
+// GitHub Actions expressions used as literal mutation anchors, not JS templates.
+// eslint-disable-next-line no-template-curly-in-string
+const ASSET_EXPR = 'ifc-lite-server-${{ matrix.target }}.${{ matrix.archive }}';
+// eslint-disable-next-line no-template-curly-in-string
+const BRACED_ASSET_ARG = '"${asset}"';
+const ASSIGN_LINE = `          asset="${ASSET_EXPR}"`;
+const WIN32_ENTRY =
+  '          - target: win32-x64\n' +
+  '            os: windows-latest\n' +
+  '            rust-target: x86_64-pc-windows-msvc\n' +
+  '            archive: zip\n';
+const RELEASE_UPLOAD = 'gh release upload "$RELEASE_TAG" "$asset" --clobber';
+const BACKFILL_UPLOAD = '            else\n              gh release upload "$RELEASE_TAG" "$asset"\n';
+
+/** Replace `from` with `to`, failing loudly if the anchor is not present. */
+function mutate(source, from, to) {
+  assert.ok(source.includes(from), `mutation anchor not found in real input: ${JSON.stringify(from)}`);
+  const out = source.replace(from, to);
+  assert.notEqual(out, source, 'mutation did not change the input');
+  return out;
+}
+
+/**
+ * Write the (optionally mutated) real inputs to a fresh temp tree outside the
+ * repo and run the checker against it. Returns { code, output }.
+ */
+function runChecker(mutations = {}) {
+  const dir = mkdtempSync(join(tmpdir(), 'server-bin-gate-'));
+  try {
+    for (const [key, rel] of Object.entries(INPUTS)) {
+      const target = join(dir, rel);
+      mkdirSync(dirname(target), { recursive: true });
+      writeFileSync(target, mutations[key] ? mutations[key](real[key]) : real[key]);
+    }
+    const r = spawnSync(process.execPath, [CHECKER, '--root', dir], { encoding: 'utf8' });
+    return { code: r.status, output: `${r.stdout}${r.stderr}` };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function assertGreen({ code, output }) {
+  assert.equal(code, 0, `expected a pass, got exit ${code}: ${output}`);
+  assert.match(output, /OK - 6 targets/, 'a pass must state the target count, not merely exit 0');
+}
+
+function assertRed({ code, output }, messagePattern) {
+  assert.equal(code, 1, `expected a failure, got exit ${code}: ${output}`);
+  assert.match(output, messagePattern, `failure message must name the actual defect: ${output}`);
+}
+
+// Positive control: the harness itself must be able to pass, or every red
+// assertion below could be an artifact of a broken temp-tree setup.
+test('unmutated real inputs pass', () => {
+  assertGreen(runChecker());
+});
+
+// ---- The four false greens from the PR #2642 adversarial review. Each was
+// exit 0 before the fix; each must now be red and name the right thing.
+
+test('false green 1: commenting out the whole win32-x64 matrix entry is red', () => {
+  const result = runChecker({
+    workflow: (s) => mutate(s, WIN32_ENTRY, WIN32_ENTRY.replace(/^( *)(.)/gm, '$1# $2')),
+  });
+  assertRed(result, /release-server-binaries matrix disagrees with SUPPORTED_TARGETS \(missing: win32-x64\)/);
+});
+
+test('false green 2: commenting out win32-x64 inside SUPPORTED_TARGETS is red', () => {
+  const result = runChecker({
+    platform: (s) => mutate(s, "  'win32-x64',", "  // 'win32-x64',"),
+  });
+  assertRed(result, /"os" disagrees with SUPPORTED_TARGETS \(unexpected: win32\)/);
+});
+
+test('false green 3: renamed upload asset with the old literal in a comment is red', () => {
+  const result = runChecker({
+    workflow: (s) => mutate(
+      s,
+      ASSIGN_LINE,
+      `          # was: ${ASSET_EXPR}\n${ASSIGN_LINE.replace('ifc-lite-server-', 'server-bin-')}`,
+    ),
+  });
+  assertRed(result, /assigns asset="server-bin-.*but the resolver in .*platform\.ts downloads exactly/);
+});
+
+test('false green 4: uploading a different name than the $asset binding is red', () => {
+  const result = runChecker({
+    workflow: (s) => mutate(s, RELEASE_UPLOAD, RELEASE_UPLOAD.replace('"$asset"', '"renamed-$asset"')),
+  });
+  assertRed(result, /passes "renamed-\$asset" as its asset argument instead of "\$asset"/);
+});
+
+// Same weakness class, backfill path: both invocations are bound, not just one.
+test('backfill-path upload drifting from the $asset binding is red', () => {
+  const result = runChecker({
+    workflow: (s) => mutate(s, BACKFILL_UPLOAD, BACKFILL_UPLOAD.replace('"$asset"', '"$asset.bak"')),
+  });
+  assertRed(result, /passes "\$asset\.bak" as its asset argument instead of "\$asset"/);
+});
+
+// Same class: shell single quotes never expand, so '$asset' would upload a
+// file literally named $asset - unquoting must not bless it.
+test('single-quoted upload argument is red', () => {
+  const result = runChecker({
+    workflow: (s) => mutate(s, RELEASE_UPLOAD, RELEASE_UPLOAD.replace('"$asset"', "'$asset'")),
+  });
+  assertRed(result, /passes '\$asset' as its asset argument/);
+});
+
+// Same class: a correct first assignment followed by a rebinding would upload
+// a different name while the pinned literal is still present and exact.
+test('rebinding asset after the pinned assignment is red', () => {
+  const result = runChecker({
+    workflow: (s) => mutate(s, ASSIGN_LINE, `${ASSIGN_LINE}\n          asset="$asset.bak"`),
+  });
+  assertRed(result, /writes the asset variable 2 times/);
+});
+
+// Same class: a commented-out assignment with live uploads has no binding at all.
+test('commented-out asset= assignment is red', () => {
+  const result = runChecker({
+    workflow: (s) => mutate(s, ASSIGN_LINE, ASSIGN_LINE.replace('          asset=', '          # asset=')),
+  });
+  assertRed(result, /no longer assigns asset=/);
+});
+
+// ---- The three false reds from the review: legitimate states that were
+// rejected, or rejected while pointing the operator at the wrong file.
+
+test('false red 5: a TODO comment inside the Set is green', () => {
+  const result = runChecker({
+    platform: (s) => mutate(s, "  'win32-x64',", "  'win32-x64',\n  // TODO: 'win32-arm64' once runners exist"),
+  });
+  assertGreen(result);
+});
+
+test('false red 6: a matrix entry whose target: is not the first key is green', () => {
+  const result = runChecker({
+    workflow: (s) => mutate(
+      s,
+      '          - target: win32-x64\n            os: windows-latest\n',
+      '          - os: windows-latest\n            target: win32-x64\n',
+    ),
+  });
+  assertGreen(result);
+});
+
+test('false red 7: a quoted target scalar is green', () => {
+  const result = runChecker({
+    workflow: (s) => mutate(s, '- target: win32-x64', "- target: 'win32-x64'"),
+  });
+  assertGreen(result);
+});
+
+// More members of the same classes, kept green on purpose.
+test('a trailing YAML comment after a matrix value is green', () => {
+  const result = runChecker({
+    workflow: (s) => mutate(s, '- target: win32-x64', '- target: win32-x64  # the one zip target'),
+  });
+  assertGreen(result);
+});
+
+test('a block comment inside the Set is green', () => {
+  const result = runChecker({
+    platform: (s) => mutate(s, "  'win32-x64',", "  'win32-x64', /* the one zip target */"),
+  });
+  assertGreen(result);
+});
+
+test('an upload argument that braces the asset variable is green', () => {
+  const result = runChecker({
+    workflow: (s) => mutate(s, RELEASE_UPLOAD, RELEASE_UPLOAD.replace('"$asset"', BRACED_ASSET_ARG)),
+  });
+  assertGreen(result);
+});
+
+// ---- The gate's original eight deliberate regressions, re-confirmed so the
+// rewrite cannot have traded old coverage for new.
+
+test('regression: wrong rust-target on a matrix entry is red', () => {
+  const result = runChecker({
+    workflow: (s) => mutate(s, 'rust-target: x86_64-pc-windows-msvc', 'rust-target: aarch64-pc-windows-msvc'),
+  });
+  assertRed(result, /builds rust-target "aarch64-pc-windows-msvc" but the install target requires "x86_64-pc-windows-msvc"/);
+});
+
+test('regression: an unmapped platform cannot enter the set silently', () => {
+  const result = runChecker({
+    platform: (s) => mutate(s, "  'win32-x64',", "  'win32-x64',\n  'freebsd-x64',"),
+    pkg: (s) => mutate(s, '"win32"\n', '"win32",\n    "freebsd"\n'),
+    workflow: (s) => mutate(s, WIN32_ENTRY, `${WIN32_ENTRY}          - target: freebsd-x64\n            os: ubuntu-latest\n            rust-target: x86_64-unknown-freebsd\n            archive: tar.gz\n`),
+  });
+  assertRed(result, /no rust-triple mapping for platform "freebsd"/);
+});
+
+test('regression: a matrix entry without rust-target is red', () => {
+  const result = runChecker({
+    workflow: (s) => mutate(s, WIN32_ENTRY, WIN32_ENTRY.replace('            rust-target: x86_64-pc-windows-msvc\n', '')),
+  });
+  assertRed(result, /matrix entry "win32-x64" .* has no rust-target: key/);
+});
+
+test('regression: an altered upload asset expression is red', () => {
+  const result = runChecker({
+    workflow: (s) => mutate(s, ASSIGN_LINE, ASSIGN_LINE.replace('ifc-lite-server-', 'ifc-lite-srv-')),
+  });
+  assertRed(result, /assigns asset="ifc-lite-srv-.*the two must be identical/);
+});
+
+test('regression: deleting win32-x64 from the matrix is red', () => {
+  const result = runChecker({
+    workflow: (s) => mutate(s, WIN32_ENTRY, ''),
+  });
+  assertRed(result, /release-server-binaries matrix disagrees with SUPPORTED_TARGETS \(missing: win32-x64\)/);
+});
+
+test('regression: adding win32-arm64 to SUPPORTED_TARGETS alone is red', () => {
+  const result = runChecker({
+    platform: (s) => mutate(s, "  'win32-x64',", "  'win32-x64',\n  'win32-arm64',"),
+  });
+  assertRed(result, /matrix disagrees with SUPPORTED_TARGETS \(missing: win32-arm64\)/);
+});
+
+test('regression: removing win32 from package.json os is red', () => {
+  const result = runChecker({
+    pkg: (s) => mutate(s, ',\n    "win32"\n', '\n'),
+  });
+  assertRed(result, /"os" disagrees with SUPPORTED_TARGETS \(missing: win32\)/);
+});
+
+test('regression: renaming SUPPORTED_TARGETS fails closed', () => {
+  const result = runChecker({
+    platform: (s) => mutate(s, 'const SUPPORTED_TARGETS = new Set([', 'const SUPPORTED_TRIPLES = new Set(['),
+  });
+  assertRed(result, /cannot find the "const SUPPORTED_TARGETS = new Set\(\[\.\.\.\]\)" list .* update this check/);
+});

--- a/scripts/lib/server-bin-targets-parse.mjs
+++ b/scripts/lib/server-bin-targets-parse.mjs
@@ -36,6 +36,17 @@ export function fail(message) {
  * blocks uses the same `#`-to-end-of-line form, so one strip is correct for
  * both. Quote state is per-line on purpose - a stray quote in one line must
  * not hide a comment marker in the next.
+ *
+ * A quote only OPENS a scalar when its closing quote exists later on the same
+ * line. A lone apostrophe in unquoted prose ("it's a tag # note") is literal
+ * text; treating it as an opener left the line stuck in quote state with
+ * every later `#` invisible, so comment text leaked into parsed values - the
+ * same silent live-vs-commented confusion this module exists to prevent, one
+ * level down. The lookahead makes that stuck state unreachable: quote state
+ * always closes before the line ends. The residual misread is a matched
+ * FALSE pair straddling a `#` (it's a # x's), which UNDER-strips - the
+ * leaked text corrupts a value every consumer compares exactly, so that
+ * direction fails red, never green.
  */
 export function stripYamlComments(source) {
   return source.split('\n').map((line) => {
@@ -45,7 +56,7 @@ export function stripYamlComments(source) {
       if (quote) {
         if (quote === '"' && c === '\\') i++;
         else if (c === quote) quote = null;
-      } else if (c === "'" || c === '"') {
+      } else if ((c === "'" || c === '"') && hasClosingQuote(line, c, i + 1)) {
         quote = c;
       } else if (c === '#' && (i === 0 || line[i - 1] === ' ' || line[i - 1] === '\t')) {
         return line.slice(0, i).replace(/[ \t]+$/, '');
@@ -53,6 +64,20 @@ export function stripYamlComments(source) {
     }
     return line;
   }).join('\n');
+}
+
+/**
+ * True when `quote` closes again at or after `from`, with the same escape
+ * rule as the scanner above: a backslashed `"` never closes a double-quoted
+ * scalar. Sharing the rule matters - the scanner may only enter quote state
+ * when this predicate guarantees it will exit again on the same line.
+ */
+function hasClosingQuote(line, quote, from) {
+  for (let j = from; j < line.length; j++) {
+    if (quote === '"' && line[j] === '\\') j++;
+    else if (line[j] === quote) return true;
+  }
+  return false;
 }
 
 /**

--- a/scripts/lib/server-bin-targets-parse.mjs
+++ b/scripts/lib/server-bin-targets-parse.mjs
@@ -1,0 +1,172 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Text-extraction layer for scripts/check-server-bin-targets.mjs.
+ *
+ * Everything here is COMMENT-AWARE, and that is the point of the module: an
+ * adversarial review of PR #2642 showed that regex-anywhere matching gave the
+ * parity gate four false greens (a commented-out matrix entry still counted
+ * as a target; a commented-out entry in SUPPORTED_TARGETS still parsed; a
+ * stale literal in a comment satisfied the upload-name check) and three false
+ * reds (a TODO comment inside the Set demanded a matrix change; an entry
+ * whose target: was not the first key vanished; a quoted scalar leaked its
+ * quotes). So comments are stripped BEFORE any matching, matrix entries are
+ * parsed as key/value blocks whose key order is irrelevant, and quoted
+ * scalars are unquoted.
+ *
+ * This is deliberately NOT a YAML or TypeScript parser - the repo root has no
+ * YAML dependency, and two known files are the whole input domain. Where the
+ * simplification could misread an exotic construct (a regex literal
+ * containing `//`, flow-style YAML), the damage is over-stripping or a
+ * skipped entry, and every consumer treats a missing value as a hard error:
+ * a misparse fails closed, never green. The executable proof lives in
+ * scripts/check-server-bin-targets.test.mjs.
+ */
+
+export function fail(message) {
+  console.error(`check-server-bin-targets: ERROR: ${message}`);
+  process.exit(1);
+}
+
+/**
+ * Strip YAML comments: a `#` at line start or preceded by whitespace opens a
+ * comment unless it sits inside a quoted scalar. Shell embedded in `run: |`
+ * blocks uses the same `#`-to-end-of-line form, so one strip is correct for
+ * both. Quote state is per-line on purpose - a stray quote in one line must
+ * not hide a comment marker in the next.
+ */
+export function stripYamlComments(source) {
+  return source.split('\n').map((line) => {
+    let quote = null;
+    for (let i = 0; i < line.length; i++) {
+      const c = line[i];
+      if (quote) {
+        if (quote === '"' && c === '\\') i++;
+        else if (c === quote) quote = null;
+      } else if (c === "'" || c === '"') {
+        quote = c;
+      } else if (c === '#' && (i === 0 || line[i - 1] === ' ' || line[i - 1] === '\t')) {
+        return line.slice(0, i).replace(/[ \t]+$/, '');
+      }
+    }
+    return line;
+  }).join('\n');
+}
+
+/**
+ * Strip TypeScript `//` and block comments without touching string contents
+ * (', " and ` strings are tracked, so a slash inside a literal never opens a
+ * comment). Comments become a single space so token boundaries survive;
+ * newlines are kept. Regex literals are not modelled: platform.ts has none,
+ * and if one ever contains `//` the result is over-stripping, which the
+ * caller's fewer-than-2-targets guard turns into a hard error.
+ */
+export function stripTsComments(source) {
+  let out = '';
+  let state = null; // null = code; a quote char = in string; 'line'/'block' = in comment
+  for (let i = 0; i < source.length; i++) {
+    const c = source[i];
+    const d = source[i + 1];
+    if (state === 'line') {
+      if (c === '\n') { state = null; out += c; }
+    } else if (state === 'block') {
+      if (c === '*' && d === '/') { state = null; out += ' '; i++; }
+      else if (c === '\n') out += c;
+    } else if (state) {
+      out += c;
+      if (c === '\\') { out += d ?? ''; i++; }
+      else if (c === state) state = null;
+    } else if (c === '/' && d === '/') { state = 'line'; i++; }
+    else if (c === '/' && d === '*') { state = 'block'; i++; }
+    else {
+      out += c;
+      if (c === "'" || c === '"' || c === '`') state = c;
+    }
+  }
+  return out;
+}
+
+/** Strip one layer of matching surrounding quotes from a YAML scalar. */
+export function unquoteScalar(value) {
+  const m = /^'([^']*)'$/.exec(value) ?? /^"([^"]*)"$/.exec(value);
+  return m ? m[1] : value;
+}
+
+/**
+ * Extract one job's block from the workflow (2-space-indented job keys).
+ * Expects comment-stripped source, like every function below.
+ */
+export function jobBlock(source, jobName, origin) {
+  const start = new RegExp(`^  ${jobName}:[ \\t]*$`, 'm').exec(source);
+  if (!start) {
+    fail(`cannot find job "${jobName}" in ${origin}; if it was renamed, update this check`);
+  }
+  const bodyStart = start.index + start[0].length;
+  const next = /^  [A-Za-z0-9_-]+:/m.exec(source.slice(bodyStart));
+  return next ? source.slice(bodyStart, bodyStart + next.index) : source.slice(bodyStart);
+}
+
+/**
+ * Parse `- target:` / `rust-target:` / `archive:` tuples from a job's matrix
+ * include list. Entries are parsed as blocks - a `- ` line opens an entry and
+ * indented `key: value` lines extend it - so the target: key may sit anywhere
+ * in its entry, not only first. A `- ` line whose first key is missing still
+ * opens an entry, and an entry that never names a target is a hard error.
+ */
+export function parseMatrix(workflow, jobName, origin, { requireArchive }) {
+  const block = jobBlock(workflow, jobName, origin);
+  const includeIdx = block.indexOf('include:');
+  const steps = /^    steps:/m.exec(block);
+  if (includeIdx === -1 || !steps || steps.index < includeIdx) {
+    fail(`cannot find the matrix include list in job "${jobName}" of ${origin}`);
+  }
+  const entries = [];
+  let current = null;
+  for (const line of block.slice(includeIdx, steps.index).split('\n')) {
+    if (/^[ \t]*-[ \t]*$/.test(line)) {
+      entries.push((current = {}));
+      continue;
+    }
+    const kv = /^[ \t]*(-[ \t]+)?([A-Za-z0-9_-]+):[ \t]*(.*)$/.exec(line);
+    if (!kv) continue;
+    if (kv[1]) entries.push((current = {}));
+    if (current) current[kv[2]] = unquoteScalar(kv[3].trim());
+  }
+  if (entries.length === 0) {
+    fail(`matrix include list in job "${jobName}" of ${origin} yielded zero targets; refusing a vacuous pass`);
+  }
+  return entries.map((entry, i) => {
+    if (!entry.target) {
+      fail(`matrix include entry ${i + 1} in job "${jobName}" of ${origin} has no target: key; refusing a vacuous pass`);
+    }
+    if (requireArchive && !entry.archive) {
+      fail(`matrix entry "${entry.target}" in job "${jobName}" of ${origin} has no archive: key`);
+    }
+    if (!entry['rust-target']) {
+      fail(
+        `matrix entry "${entry.target}" in job "${jobName}" of ${origin} has no rust-target: key; ` +
+        `refusing a vacuous pass - without it nothing pins which triple that leg builds`,
+      );
+    }
+    return { target: entry.target, archive: entry.archive ?? null, rustTarget: entry['rust-target'] };
+  });
+}
+
+/** Parse the SUPPORTED_TARGETS set literal out of platform.ts source text. */
+export function parseSupportedTargets(rawSource, origin) {
+  const source = stripTsComments(rawSource);
+  const m = source.match(/const SUPPORTED_TARGETS = new Set\(\[([^\]]*)\]\)/);
+  if (!m) {
+    fail(
+      `cannot find the "const SUPPORTED_TARGETS = new Set([...])" list in ${origin}; ` +
+      `if the const moved or was renamed, update this check - it must not pass without the list`,
+    );
+  }
+  const targets = [...m[1].matchAll(/['"]([^'"]+)['"]/g)].map((q) => q[1]);
+  if (targets.length < 2) {
+    fail(`parsed only ${targets.length} target(s) from SUPPORTED_TARGETS in ${origin}; refusing a vacuous pass`);
+  }
+  return targets;
+}

--- a/scripts/lib/server-bin-targets-parse.test.mjs
+++ b/scripts/lib/server-bin-targets-parse.test.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Unit tests for stripYamlComments, the primitive the whole server-bin parity
+ * gate rests on (scripts/check-server-bin-targets.mjs strips comments BEFORE
+ * any matching, so a stripper defect reopens the four false greens of PR
+ * #2642 one level down).
+ *
+ * The defect class pinned here: the original stripper entered quote state on
+ * ANY apostrophe or double quote, so a lone apostrophe in unquoted prose
+ * ("it's a tag") left the line stuck in quote state and every later `#` on
+ * that line invisible - comment text leaked into parsed values, silently.
+ * The rule now is that a quote only OPENS a scalar when a matching closing
+ * quote exists later on the same line; a lone quote is literal text.
+ *
+ * These are direct input/output cases against the exported function - the
+ * black-box mutation harness for the checker lives next to the checker in
+ * scripts/check-server-bin-targets.test.mjs, and one apostrophe case runs
+ * end-to-end there too.
+ *
+ * Run: node --test scripts/lib/server-bin-targets-parse.test.mjs
+ * (wired into the same CI node-test step as the checker harness in
+ * .github/workflows/test.yml).
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { stripYamlComments } from './server-bin-targets-parse.mjs';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+// ---- The defect class: a lone quote in unquoted text must stay literal.
+
+test('a lone apostrophe in an unquoted scalar does not hide a trailing comment', () => {
+  assert.equal(
+    stripYamlComments("        description: it's a tag # trailing comment"),
+    "        description: it's a tag",
+  );
+});
+
+test('a lone apostrophe in embedded shell does not hide a trailing comment', () => {
+  // The comment carries checker-relevant text on purpose: if it leaks, the
+  // gate would see a gh release upload invocation that does not exist.
+  assert.equal(
+    stripYamlComments('          echo the tag can\'t clobber # gh release upload "$RELEASE_TAG" "stale-$asset"'),
+    "          echo the tag can't clobber",
+  );
+});
+
+test('quote state is per-line: a lone apostrophe never leaks into the next line', () => {
+  assert.equal(
+    stripYamlComments("first: it's open\nsecond: value # tail"),
+    "first: it's open\nsecond: value",
+  );
+});
+
+// ---- Behaviour that already worked and must keep working.
+
+test('a full-line comment may contain apostrophes', () => {
+  assert.equal(stripYamlComments("# PowerShell doesn't parse the bare --clobber"), '');
+  assert.equal(stripYamlComments("        # don't accumulate against Actions storage."), '');
+});
+
+test('a trailing comment containing apostrophes and further hashes is stripped whole', () => {
+  assert.equal(
+    stripYamlComments("- target: win32-x64 # don't remove # this"),
+    '- target: win32-x64',
+  );
+});
+
+test('a hash inside a single-quoted scalar is not a comment', () => {
+  assert.equal(stripYamlComments("key: 'a # b'"), "key: 'a # b'");
+});
+
+test('a hash inside a double-quoted scalar is not a comment, one after it is', () => {
+  assert.equal(stripYamlComments('key: "a # b" # tail'), 'key: "a # b"');
+});
+
+test('an escaped quote inside a double-quoted scalar does not end it', () => {
+  assert.equal(
+    stripYamlComments('run: echo "a \\" # b" # tail'),
+    'run: echo "a \\" # b"',
+  );
+});
+
+test('an apostrophe inside a double-quoted scalar is literal', () => {
+  assert.equal(stripYamlComments('run: echo "it\'s fine" # tail'), 'run: echo "it\'s fine"');
+});
+
+test('a hash not preceded by whitespace is not a comment', () => {
+  assert.equal(stripYamlComments('url: https://host/path#frag'), 'url: https://host/path#frag');
+  assert.equal(stripYamlComments('key: a#b # real comment'), 'key: a#b');
+});
+
+// ---- The matched-pair decision, made explicit.
+
+test('two apostrophes before the hash read as a quoted span and the comment still strips', () => {
+  // YAML would treat both apostrophes as literal characters; the naive pair
+  // is harmless here because the span opens AND closes before the `#`, so
+  // the comment is recognised either way.
+  assert.equal(
+    stripYamlComments("description: it's Bob's tag # c"),
+    "description: it's Bob's tag",
+  );
+});
+
+test('a false apostrophe pair spanning the hash keeps the comment (fails closed)', () => {
+  // Accepted limitation of not being a YAML parser: the pair straddles the
+  // `#`, so the stripper reads it as quoted and UNDER-strips. The leaked
+  // text corrupts a parsed value that every consumer compares exactly, so
+  // this direction fails red, never green - unlike the lone-apostrophe bug,
+  // which hid live-vs-commented distinctions silently.
+  assert.equal(
+    stripYamlComments("key: it's a # x's tag"),
+    "key: it's a # x's tag",
+  );
+});
+
+// ---- The real input this parser exists for.
+
+test('the real workflow description line survives stripping byte-identical', () => {
+  const workflow = readFileSync(join(ROOT, '.github/workflows/server-binaries.yml'), 'utf8');
+  const line = workflow.split('\n').find((l) => /^\s*description:/.test(l));
+  assert.ok(line, 'the workflow no longer has a description: line; update this test');
+  assert.equal(stripYamlComments(line), line);
+});


### PR DESCRIPTION
Closes #2619.

## Context: the 404 itself is already fixed

The reported symptom (`npx @ifc-lite/server-bin` 404s on Windows) was root-caused and fixed by #2629: the "Upload to GitHub Release" step had no `shell:` key, so on the Windows runner it ran under PowerShell, which parses the bare `--clobber` after a backslash continuation as the unary decrement operator. The win32 binary built fine and was then dropped on every release.

This PR is the other half the issue asks for:

> there is a gate missing: nothing verifies that a server-bin release carries one archive per platform the package claims to support.

## What the gate binds

The issue names three lists. There are six; three are functional and are what this binds:

1. `SUPPORTED_TARGETS` in `packages/server-bin/src/platform.ts` (the list the shipped resolver actually executes, so it is the source of truth)
2. `os`/`cpu` in `packages/server-bin/package.json`
3. the `release-server-binaries` matrix in `server-binaries.yml`

plus `validate-server-binaries` as a subset (it is deliberately linux-only to save PR cost, so shrinking is allowed, naming an unknown target is not). The README and `docs/api/typescript.md` tables are prose and left alone.

`os` x `cpu` is deliberately NOT compared triple-for-triple. It is a coarser cross-product: it admits `win32-arm64` (npm checks the two fields independently, so Windows-on-ARM installs and then throws at runtime) and cannot express `linux-x64-musl` at all. The check compares `os` against the set of platform prefixes and `cpu` against the set of arches with `-musl` stripped. Getting this wrong in either direction gives a gate that is red forever or vacuously loose.

The archive-name rule (win32 => zip, else tar.gz) is checked too, because the workflow re-derives the upload name independently of the resolver's download name. They agreed only by hand.

## Two modes

- PR lane: `node scripts/check-server-bin-targets.mjs`, wired as a `node-tests` step next to the other `check:*` scripts. Catches drift before a release is cut.
- Release lane: new `verify-release-assets` job runs `--release <tag>` against the real asset list. Catches an upload that failed or was skipped, which is the incident that actually happened.

`always()` on that job is load-bearing and commented as such: a failed `needs:` skips the dependent regardless of the condition, so without it the job that exists to name a missing archive could not run in the case it exists for.

## Where it could pass vacuously, and what guards that now

An earlier revision of this section claimed the gate "cannot pass vacuously".
An adversarial review refuted that. The fail-closed guards covered absent
inputs (unfindable const, fewer than 2 parsed targets, zero matrix entries,
empty asset list), but the parsing itself was regex-anywhere over raw source
text, and that admitted a class of false results:

- Commenting out the entire `win32-x64` release-matrix entry still counted it
  as a target: the `- target:` anchor matched inside YAML comments, and the
  commented `rust-target:`/`archive:` lines satisfied the per-entry checks
  too. A realistic "disable the windows leg during a runner outage" edit
  would have silently recreated the v1.16.6 outage under a green gate.
- Commenting out `'win32-x64'` inside `SUPPORTED_TARGETS` still parsed it:
  quoted strings were harvested from the whole `[...]` span, comments
  included, so the resolver could reject win32 while package.json still
  invited the install - green.
- The upload-name check tested for the PRESENCE of the asset literal anywhere
  in the step, not its USE: a stale literal in a comment kept the gate green
  while the actual `asset=` assignment or the actual `gh release upload`
  argument drifted, i.e. every release 404s on every platform, gate green.

The same weakness produced false reds that pointed operators at the wrong
fix: a `// TODO: 'win32-arm64'` comment inside the Set red-flagged the MATRIX
as missing that target; a matrix entry whose `target:` key was not first read
as absent; a quoted `target: 'win32-x64'` leaked its quotes into the triple.

The regression table in the earlier revision missed all of this because it
tested deletion, never commenting-out. A hand-run table proves exactly the
runs in the table and nothing more.

Fixed by making all source-text matching comment-aware
(`scripts/lib/server-bin-targets-parse.mjs`): YAML `#` and TS line/block
comments are stripped before anything matches, matrix entries parse as
key/value blocks whose key order is irrelevant, and quoted scalars unquote.
The upload check now BINDS the name instead of grepping for it: the step must
assign `asset=` exactly the pinned expression, that must be the only line
writing the variable (a later rebinding or `asset+=` is red), and every
`gh release upload` invocation - the fresh-release path and the backfill path
both - must pass exactly the `$asset` binding (double quotes stripped;
a single-quoted `'$asset'` never expands in bash and stays red).

The guarantee is executable now, not asserted:
`scripts/check-server-bin-targets.test.mjs` (a CI step directly after the
gate in the node-tests job) writes each hostile mutation of the REAL inputs
to a temp tree outside the repo, runs the unmodified checker against it via
`--root`, and asserts exit code plus a message naming the right list. It
covers the four false greens above (now red), the three false-red shapes (now
green), rebinding/single-quote/braced variants of the upload argument, and
re-confirms the original eight deliberate regressions (wrong rust-target,
unmapped platform, missing rust-target key, altered upload expression,
win32-x64 removed from the matrix, win32-arm64 added to SUPPORTED_TARGETS,
win32 removed from package.json `os`, renamed const).

The honest residual limit: the parser is deliberately not a full YAML or
TypeScript parser (the repo root has no YAML dependency, and two known files
are the whole input domain). A construct it misreads is over-stripped or
skipped, and every consumer treats a missing value as a hard error - so a
misparse lands on the fail-closed side, never on green. Shell dataflow beyond
the single `asset` binding (e.g. an `mv` between build and upload) is out of
scope for a text gate; the `--release` lane checking the published asset list
is the backstop for anything that slips a build-time text check.

The live bug is its own red fixture. Against the current release,
`--release v1.16.6` exits 1 naming `ifc-lite-server-win32-x64.zip`.

## Path-filter hole, fixed here

`.github/workflows/server-binaries.yml` was not in the `frontend` path filter, so a PR editing only the release matrix would skip the `node-tests` job, and now would skip the very check that reads it. Added, mirroring the `.oxlintrc.json` precedent.

## Backfill lever

A plain `workflow_dispatch` only produced 1-day artifacts and could never repair a release. Added an `upload-to-tag` input so a release missing an archive can be fixed self-service.

## What this does NOT prove

`verify-release-assets` only ever runs on a real `release` event, so its trigger and `gh` auth in that context are confirmed by inspection, not by observation. The identical script mode was exercised locally against v1.16.6, and the dispatch-with-tag path doubles as a live test.

**Backfill builds the tag's source, not `main`'s.** An earlier revision of this PR documented a source mismatch as unavoidable, reasoning that dispatching at the tag ref would read a workflow file without the `upload-to-tag` input. That conflated two independent refs: the workflow DEFINITION comes from the dispatch ref (`main`, which has the input), but `actions/checkout` can check out any ref. The Checkout step now checks out `inputs.upload-to-tag` when set, so a backfilled archive is built from the same revision as the release's other assets, which is what the installed package version actually selects. The `release` event path is unchanged (the input is empty there, so checkout falls back to `github.ref`, the release tag, identical to the default).

## Non-destructive backfill

The backfill path never uses `--clobber`. Every matrix leg runs against the existing release, including platforms whose assets are healthy, and `gh release upload --clobber` deletes the existing asset before uploading ("If the upload fails, the original assets will be lost"), so a transient failure repairing one archive could destroy a working one. The backfill uploads only assets missing from the release and skips the rest; the `release` event path keeps `--clobber` as the idempotent choice for re-runs on a fresh release.

## The gate also pins rust-target and the upload name

Review surfaced that naming alone was not enough: a wrong `rust-target` ships an incompatible binary under a perfectly valid archive name, and the first revision of the gate could not see it. The check now pins the target-to-`rust-target` mapping for every matrix entry in both jobs, and asserts the upload step names its asset with the literal `ifc-lite-server-<matrix.target>.<matrix.archive>` expression. Both fail closed: a missing `rust-target` key, an unmapped platform or arch, or an altered upload expression is an error, never a skip.

## Adjacent defect, deliberately not fixed here

`packages/server-bin/src/checksum.ts` documents SHA-256 verification against a `<asset>.sha256` or `SHA256SUMS` sidecar, and fails open (warn and proceed) when the sidecar is missing. No workflow publishes those sidecars, so the fail-open branch is the only branch that ever runs: every install today verifies nothing while the code reads as if it does. That is why this gate deliberately does not expect sidecars yet, expecting them now would turn every release red. Worth its own issue.

## Notes

No changeset: nothing under `packages/server-bin` changes (no published code, no version, no API surface), and `scripts/` and `.github/` are not workspace packages.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to rebuild and upload server archives to an existing release.
  * Added verification that all supported platform archives are present in a release.

* **Bug Fixes**
  * Added validation to detect mismatches between supported platforms, package compatibility settings, and release targets.
  * Improved checks for missing or invalid server archive configurations.

* **Tests**
  * Added automated platform-parity validation to the test workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

