### PR TITLE
perf(export,processing): drop a dead entity index, share the one already built

### DIFF
--- a/docs/api/rust.md
+++ b/docs/api/rust.md
@@ -480,7 +480,9 @@ pub use processor::{
 // Analysis-ready export document (welded, Z-up, world metres)
 pub use geometry_export::{build_geometry_data_export, ExportedElement, GeometryDataExport};
 
-pub use georeferencing::{extract_georeferencing, Georeferencing};
+pub use georeferencing::{
+    extract_georeferencing, extract_georeferencing_with_index, Georeferencing,
+};
 pub use ifc_lite_geometry::TessellationQuality;
 pub use style::{default_color_for_type, Rgba};
 pub use types::mesh::{InstanceRecord, MeshData, RawInstanceOccurrence};

--- a/rust/export/examples/index_vs_scan.rs
+++ b/rust/export/examples/index_vs_scan.rs
@@ -100,13 +100,17 @@ fn main() {
     println!("  build_entity_index_parallel     {parallel:8.1} ms");
     println!("  bare type-name scan             {scan:8.1} ms");
     println!("  ---");
-    println!("  relationships()                 {rel:8.1} ms   index is {:4.1}% of it", 100.0 * parallel / rel);
-    println!("  extract_georeferencing()        {geo:8.1} ms   index is {:4.1}% of it", 100.0 * parallel / geo);
+    // No index share for `relationships()`: it builds none, so a ratio here would
+    // dress a cost it does not pay as an observed component. Compare it to the
+    // bare scan above instead.
+    println!("  relationships()                 {rel:8.1} ms");
+    println!(
+        "  extract_georeferencing()        {geo:8.1} ms   index is {:4.1}% of it",
+        100.0 * parallel / geo
+    );
     println!("  ---");
     println!(
-        "  index a caller can still save   {:8.1} ms  ({:.1}% of the two helpers' {:.1} ms)",
-        parallel,
-        100.0 * parallel / (rel + geo),
-        rel + geo
+        "  index a caller can still save   {parallel:8.1} ms  ({:.1}% of extract_georeferencing)",
+        100.0 * parallel / geo
     );
 }

--- a/rust/export/examples/index_vs_scan.rs
+++ b/rust/export/examples/index_vs_scan.rs
@@ -1,0 +1,112 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Split `relationships` and `extract_georeferencing` into the two costs they
+//! actually pay, so a fix aims at the bigger one.
+//!
+//! Both walk every entity with an `EntityScanner`, and that scan is the larger
+//! half. An entity index is the smaller one, which is why "share the index" is
+//! worth doing and is not worth overselling.
+//!
+//! Read the two rows against `bare type-name scan`:
+//!
+//! * `relationships()` builds no index and should sit near the bare scan. If it
+//!   drifts well above, someone has given it one again.
+//! * `extract_georeferencing()` needs an index, because the extractor resolves
+//!   its references by id. It builds one unless the caller passes it in through
+//!   `extract_georeferencing_with_index`.
+//!
+//!     cargo run --release -p ifc-lite-export --example index_vs_scan -- <file.ifc>
+
+use std::time::Instant;
+
+use ifc_lite_core::{build_entity_index, EntityScanner};
+use ifc_lite_processing::build_entity_index_parallel;
+
+fn ms(t: Instant) -> f64 {
+    t.elapsed().as_secs_f64() * 1000.0
+}
+
+/// Best of `n`, to shave scheduler noise the way `perf_probe` does.
+fn best<F: FnMut() -> f64>(n: usize, mut f: F) -> f64 {
+    (0..n).map(|_| f()).fold(f64::INFINITY, f64::min)
+}
+
+fn main() {
+    let path = std::env::args().nth(1).expect("usage: index_vs_scan <file.ifc>");
+    let content = std::fs::read(&path).expect("read input");
+    let mb = content.len() as f64 / (1024.0 * 1024.0);
+
+    let serial = best(3, || {
+        let t = Instant::now();
+        let idx = build_entity_index(&content[..]);
+        let e = ms(t);
+        std::hint::black_box(&idx);
+        e
+    });
+
+    let parallel = best(3, || {
+        let t = Instant::now();
+        let idx = build_entity_index_parallel(&content[..]);
+        let e = ms(t);
+        std::hint::black_box(&idx);
+        e
+    });
+
+    // The bare scan both helpers run on top of their index: iterate every entity
+    // and look at its type name, which is all the candidate collection does.
+    let scan = best(3, || {
+        let t = Instant::now();
+        let mut n = 0usize;
+        let mut scanner = EntityScanner::new(&content);
+        while let Some((_id, type_name, _s, _e)) = scanner.next_entity() {
+            if matches!(
+                type_name,
+                "IFCMAPCONVERSION"
+                    | "IFCPROJECTEDCRS"
+                    | "IFCPROPERTYSET"
+                    | "IFCSITE"
+                    | "IFCRELAGGREGATES"
+                    | "IFCRELCONTAINEDINSPATIALSTRUCTURE"
+                    | "IFCRELDEFINESBYTYPE"
+            ) {
+                n += 1;
+            }
+        }
+        let e = ms(t);
+        std::hint::black_box(n);
+        e
+    });
+
+    let rel = best(3, || {
+        let t = Instant::now();
+        let r = ifc_lite_export::relationships(&content);
+        let e = ms(t);
+        std::hint::black_box(&r);
+        e
+    });
+
+    let geo = best(3, || {
+        let t = Instant::now();
+        let g = ifc_lite_processing::extract_georeferencing(&content[..]);
+        let e = ms(t);
+        std::hint::black_box(&g);
+        e
+    });
+
+    println!("{path}  ({mb:.1} MB)");
+    println!("  build_entity_index (serial)     {serial:8.1} ms");
+    println!("  build_entity_index_parallel     {parallel:8.1} ms");
+    println!("  bare type-name scan             {scan:8.1} ms");
+    println!("  ---");
+    println!("  relationships()                 {rel:8.1} ms   index is {:4.1}% of it", 100.0 * parallel / rel);
+    println!("  extract_georeferencing()        {geo:8.1} ms   index is {:4.1}% of it", 100.0 * parallel / geo);
+    println!("  ---");
+    println!(
+        "  index a caller can still save   {:8.1} ms  ({:.1}% of the two helpers' {:.1} ms)",
+        parallel,
+        100.0 * parallel / (rel + geo),
+        rel + geo
+    );
+}

--- a/rust/export/src/csv.rs
+++ b/rust/export/src/csv.rs
@@ -73,9 +73,7 @@ fn spatial_csv(content: &[u8], model: &ExportModel, opts: &CsvOptions) -> String
     // The project node isn't an IfcProduct, so decode its GlobalId + Name directly.
     let (mut proj_gid, mut proj_name) = (String::new(), String::new());
     if let Some(pid) = project {
-        let index = ifc_lite_core::build_entity_index(content);
-        let mut dec = ifc_lite_core::EntityDecoder::with_index(content, index);
-        if let Ok(e) = dec.decode_by_id(pid) {
+        if let Some(e) = crate::ifc5::decode_one(content, pid) {
             proj_gid = e.get(0).and_then(|a| a.as_string()).unwrap_or("").to_string();
             proj_name = e.get(2).and_then(|a| a.as_string()).unwrap_or("").to_string();
         }

--- a/rust/export/src/dfjson/spatial.rs
+++ b/rust/export/src/dfjson/spatial.rs
@@ -79,8 +79,10 @@ pub(crate) fn spatial_index(content: &[u8]) -> SpatialIndex {
     let mut out = SpatialIndex::default();
     // Decode the storey/building rows in one scan, recording file order for
     // buildings so the emitted `unique_stories` ordering is stable.
-    let index = ifc_lite_processing::build_entity_index_parallel(content);
-    let mut decoder = EntityDecoder::with_index(content, index);
+    //
+    // No entity index: the only decode below is `decode_at_with_id` over the
+    // scanner's own spans, and an index is read by `decode_by_id` alone.
+    let mut decoder = EntityDecoder::new(content);
     let mut storey_rows: HashMap<u32, (String, Option<f64>)> = HashMap::new();
     let mut buildings: Vec<u32> = Vec::new();
     let mut scanner = EntityScanner::new(content);

--- a/rust/export/src/ifc5.rs
+++ b/rust/export/src/ifc5.rs
@@ -7,7 +7,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use ifc_lite_core::{build_entity_index, EntityDecoder};
+use ifc_lite_core::{DecodedEntity, EntityDecoder, EntityScanner};
 use serde_json::{json, Map, Value};
 
 use crate::json::typed_value;
@@ -86,14 +86,28 @@ pub(crate) fn spatial_children(content: &[u8]) -> (HashMap<u32, Vec<u32>>, Optio
     (r.spatial_children, r.project)
 }
 
+/// Decode exactly one entity, found by scanning for its id.
+///
+/// The alternative is `build_entity_index` plus `decode_by_id`, which builds a
+/// map of every entity in the file to answer one question: a full serial scan
+/// and a multi-million-entry allocation on a large model. This walks until it
+/// finds the id and stops, so a project node near the top of `DATA` costs almost
+/// nothing. Worth it only for a handful of lookups, which is what the callers do.
+pub(crate) fn decode_one(content: &[u8], id: u32) -> Option<DecodedEntity> {
+    let mut decoder = EntityDecoder::new(content);
+    let mut scanner = EntityScanner::new(content);
+    while let Some((entity_id, _type_name, start, end)) = scanner.next_entity() {
+        if entity_id == id {
+            return decoder.decode_at(start, end).ok();
+        }
+    }
+    None
+}
+
 /// Decode the IfcProject node (id, name) — it is not an IfcProduct so the export
 /// model doesn't carry it. Shared with the USD exporter (`crate::usd`).
 pub(crate) fn project_name(content: &[u8], project_id: u32) -> String {
-    let index = build_entity_index(content);
-    let mut decoder = EntityDecoder::with_index(content, index);
-    decoder
-        .decode_by_id(project_id)
-        .ok()
+    decode_one(content, project_id)
         .and_then(|e| e.get(2).and_then(|a| a.as_string()).map(|s| s.to_string()))
         .filter(|s| !s.is_empty())
         .unwrap_or_else(|| "Project".to_string())

--- a/rust/export/src/relationships.rs
+++ b/rust/export/src/relationships.rs
@@ -46,9 +46,12 @@ pub struct Relationships {
 /// one dangling reference still has a usable tree, and the alternative is
 /// returning nothing for a defect the caller cannot act on.
 pub fn relationships(content: &[u8]) -> Relationships {
-    // Parallel on native (byte-identical to `build_entity_index`), serial on wasm.
-    let index = ifc_lite_processing::build_entity_index_parallel(content);
-    let mut decoder = EntityDecoder::with_index(content, index);
+    // No entity index, deliberately. Every decode below is `decode_at_with_id`
+    // over the scanner's own spans; only `decode_by_id` consults an index, and
+    // nothing here calls it. Building one costs a full extra scan whose result
+    // is never read: ~57 ms of a 235 ms call on a 327 MB model. Do not add one
+    // back without a `decode_by_id` to justify it.
+    let mut decoder = EntityDecoder::new(content);
     let mut out = Relationships::default();
 
     let mut scanner = EntityScanner::new(content);

--- a/rust/processing/src/georeferencing.rs
+++ b/rust/processing/src/georeferencing.rs
@@ -13,7 +13,9 @@
 //! serializable, server-friendly shape carried inline on every geometry
 //! endpoint's `ModelMetadata` (issue #900 parity follow-up).
 
-use ifc_lite_core::{EntityDecoder, EntityScanner, GeoRefExtractor, IfcType};
+use std::sync::Arc;
+
+use ifc_lite_core::{EntityDecoder, EntityIndex, EntityScanner, GeoRefExtractor, IfcType};
 use serde::{Deserialize, Serialize};
 
 /// Georeferencing metadata (`IfcMapConversion` + `IfcProjectedCRS`).
@@ -108,8 +110,25 @@ where
     T: AsRef<[u8]> + ?Sized,
 {
     let content = content.as_ref();
-    let entity_index = crate::build_entity_index_parallel(content);
-    let mut decoder = EntityDecoder::with_index(content, entity_index);
+    // Parallel on native (byte-identical to `build_entity_index`), serial on wasm.
+    let entity_index = Arc::new(crate::build_entity_index_parallel(content));
+    extract_georeferencing_with_index(content, &entity_index)
+}
+
+/// [`extract_georeferencing`], reusing an index the caller already holds.
+///
+/// The extractor resolves its references by id, so this pass genuinely needs an
+/// index; what it does not need is a second one. A caller that has already
+/// scanned the file (the geometry pipeline holds one for its whole run) was
+/// paying a full extra scan to build a map it had in hand.
+///
+/// `entity_index` must have been built from this same `content`. Given that, the
+/// result is identical to the wrapper's.
+pub fn extract_georeferencing_with_index(
+    content: &[u8],
+    entity_index: &Arc<EntityIndex>,
+) -> Option<Georeferencing> {
+    let mut decoder = EntityDecoder::with_arc_index(content, entity_index.clone());
 
     let mut entity_types: Vec<(u32, IfcType)> = Vec::new();
     let mut scanner = EntityScanner::new(content);
@@ -139,330 +158,5 @@ where
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    const GEOREF_IFC: &str = r#"ISO-10303-21;
-HEADER;
-FILE_DESCRIPTION(('georef fixture'),'2;1');
-FILE_NAME('georef.ifc','2026-06-01T00:00:00',(''),(''),'','','');
-FILE_SCHEMA(('IFC4'));
-ENDSEC;
-DATA;
-#1=IFCPROJECT('0$ScRe4drECQ4DMSqUjd6d',$,'P',$,$,$,$,(#2),#3);
-#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
-#3=IFCUNITASSIGNMENT((#6));
-#4=IFCCARTESIANPOINT((0.,0.,0.));
-#5=IFCAXIS2PLACEMENT3D(#4,$,$);
-#6=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
-#10=IFCPROJECTEDCRS('EPSG:32632','WGS84 / UTM zone 32N','WGS84',$,'UTM','32N',$);
-#11=IFCMAPCONVERSION(#2,#10,1000.5,2000.25,42.0,0.866025,0.5,1.0);
-ENDSEC;
-END-ISO-10303-21;
-"#;
-
-    #[test]
-    fn extracts_map_conversion_and_crs() {
-        let geo = extract_georeferencing(GEOREF_IFC).expect("expected georeferencing");
-        assert_eq!(geo.crs_name.as_deref(), Some("EPSG:32632"));
-        assert_eq!(geo.geodetic_datum.as_deref(), Some("WGS84"));
-        assert_eq!(geo.map_projection.as_deref(), Some("UTM"));
-        assert!((geo.eastings - 1000.5).abs() < 1e-6);
-        assert!((geo.northings - 2000.25).abs() < 1e-6);
-        assert!((geo.orthogonal_height - 42.0).abs() < 1e-6);
-        // XAxisAbscissa/Ordinate = cos/sin(30°) → rotation_degrees ≈ 30.
-        assert!(
-            (geo.rotation_degrees - 30.0).abs() < 1e-3,
-            "rotation should be ~30°, got {}",
-            geo.rotation_degrees
-        );
-        // Translation column of the local→map matrix carries the offsets.
-        assert!((geo.transform_matrix[12] - 1000.5).abs() < 1e-6);
-        assert!((geo.transform_matrix[13] - 2000.25).abs() < 1e-6);
-        // New parity fields (alignment audit): description/zone + provenance.
-        assert_eq!(geo.crs_description.as_deref(), Some("WGS84 / UTM zone 32N"));
-        assert_eq!(geo.map_zone.as_deref(), Some("32N"));
-        // No MapUnit authored → project length unit applies (both None).
-        assert_eq!(geo.map_unit, None);
-        assert_eq!(geo.map_unit_scale, None);
-        assert_eq!(geo.source.as_deref(), Some("mapConversion"));
-    }
-
-    /// IFC2x3 models carry georeferencing via an `ePSet_MapConversion` property
-    /// set rather than `IfcMapConversion`. Regression for the core extractor bug
-    /// that read `IfcPropertySet.Name` from attribute 0 (GlobalId) instead of 2.
-    const IFC2X3_PSET_IFC: &str = r#"ISO-10303-21;
-HEADER;
-FILE_DESCRIPTION(('ifc2x3 georef pset fixture'),'2;1');
-FILE_NAME('georef2x3.ifc','2026-06-01T00:00:00',(''),(''),'','','');
-FILE_SCHEMA(('IFC2X3'));
-ENDSEC;
-DATA;
-#1=IFCPROPERTYSINGLEVALUE('Eastings',$,IFCLENGTHMEASURE(1000.5),$);
-#2=IFCPROPERTYSINGLEVALUE('Northings',$,IFCLENGTHMEASURE(2000.25),$);
-#3=IFCPROPERTYSINGLEVALUE('OrthogonalHeight',$,IFCLENGTHMEASURE(42.),$);
-#4=IFCPROPERTYSET('0PSet00000000000000001',$,'ePSet_MapConversion',$,(#1,#2,#3));
-ENDSEC;
-END-ISO-10303-21;
-"#;
-
-    #[test]
-    fn extracts_ifc2x3_epset_map_conversion_fallback() {
-        let geo = extract_georeferencing(IFC2X3_PSET_IFC)
-            .expect("expected georeferencing from ePSet_MapConversion");
-        assert!((geo.eastings - 1000.5).abs() < 1e-6);
-        assert!((geo.northings - 2000.25).abs() < 1e-6);
-        assert!((geo.orthogonal_height - 42.0).abs() < 1e-6);
-    }
-
-    /// Real-world fixture mirroring the `ifc-georeferencer` post-processor:
-    /// lowercase `ePset_…` property-set names and a separate `ePset_ProjectedCRS`
-    /// carrying the EPSG `Name`. The exact-match + missing-CRS bug dropped these
-    /// to the legacy IfcSite EPSG:4326 and showed the wrong CRS.
-    const IFC2X3_EPSET_LOWERCASE_IFC: &str = r#"ISO-10303-21;
-HEADER;
-FILE_DESCRIPTION(('ifc-georeferencer pset fixture'),'2;1');
-FILE_NAME('georef-lc.ifc','2026-06-26T00:00:00',(''),(''),'','','');
-FILE_SCHEMA(('IFC2X3'));
-ENDSEC;
-DATA;
-#1=IFCPROPERTYSINGLEVALUE('TargetCRS',$,IFCLABEL('EPSG:7415'),$);
-#2=IFCPROPERTYSINGLEVALUE('Eastings',$,IFCLENGTHMEASURE(160073528.13858587),$);
-#3=IFCPROPERTYSINGLEVALUE('Northings',$,IFCLENGTHMEASURE(384153306.2191765),$);
-#4=IFCPROPERTYSINGLEVALUE('OrthogonalHeight',$,IFCLENGTHMEASURE(0.),$);
-#5=IFCPROPERTYSET('2If4Y3Lpv6dgTDkC5x_dnr',$,'ePset_MapConversion',$,(#1,#2,#3,#4));
-#6=IFCPROPERTYSINGLEVALUE('Name',$,IFCLABEL('EPSG:7415'),$);
-#7=IFCPROPERTYSET('27AKTMp8j58fBEhvkJkcNJ',$,'ePset_ProjectedCRS',$,(#6));
-ENDSEC;
-END-ISO-10303-21;
-"#;
-
-    #[test]
-    fn extracts_ifc2x3_lowercase_epset_with_projected_crs_name() {
-        let geo = extract_georeferencing(IFC2X3_EPSET_LOWERCASE_IFC)
-            .expect("expected georeferencing from lowercase ePset_ sets");
-        assert_eq!(geo.source.as_deref(), Some("ePSetMapConversion"));
-        // CRS name surfaced from ePset_ProjectedCRS.Name (was previously lost).
-        assert_eq!(geo.crs_name.as_deref(), Some("EPSG:7415"));
-        assert!((geo.eastings - 160073528.13858587).abs() < 1e-3);
-    }
-
-    /// Without an ePset_ProjectedCRS set, the CRS name falls back to the
-    /// MapConversion's own `TargetCRS` label.
-    const IFC2X3_EPSET_TARGETCRS_ONLY_IFC: &str = r#"ISO-10303-21;
-HEADER;
-FILE_DESCRIPTION(('ifc-georeferencer targetcrs-only fixture'),'2;1');
-FILE_NAME('georef-tc.ifc','2026-06-26T00:00:00',(''),(''),'','','');
-FILE_SCHEMA(('IFC2X3'));
-ENDSEC;
-DATA;
-#1=IFCPROPERTYSINGLEVALUE('TargetCRS',$,IFCLABEL('EPSG:28992'),$);
-#2=IFCPROPERTYSINGLEVALUE('Eastings',$,IFCLENGTHMEASURE(1000.5),$);
-#3=IFCPROPERTYSINGLEVALUE('Northings',$,IFCLENGTHMEASURE(2000.25),$);
-#4=IFCPROPERTYSINGLEVALUE('OrthogonalHeight',$,IFCLENGTHMEASURE(0.),$);
-#5=IFCPROPERTYSET('2If4Y3Lpv6dgTDkC5x_dnr',$,'ePset_MapConversion',$,(#1,#2,#3,#4));
-ENDSEC;
-END-ISO-10303-21;
-"#;
-
-    #[test]
-    fn falls_back_to_target_crs_when_no_projected_crs_pset() {
-        let geo = extract_georeferencing(IFC2X3_EPSET_TARGETCRS_ONLY_IFC)
-            .expect("expected georeferencing from ePset_MapConversion");
-        assert_eq!(geo.crs_name.as_deref(), Some("EPSG:28992"));
-    }
-
-    /// Millimetre MapUnit: the conversion offsets are authored in mm and the
-    /// served `map_unit_scale` must say 0.001 — the TS parser already did
-    /// this; the server previously ignored MapUnit entirely (alignment
-    /// audit). Values mirror packages/parser/test/georef-extractor.test.ts.
-    const MM_MAPUNIT_IFC: &str = r#"ISO-10303-21;
-HEADER;
-FILE_DESCRIPTION(('georef mm fixture'),'2;1');
-FILE_NAME('georef-mm.ifc','2026-06-12T00:00:00',(''),(''),'','','');
-FILE_SCHEMA(('IFC4'));
-ENDSEC;
-DATA;
-#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
-#4=IFCCARTESIANPOINT((0.,0.,0.));
-#5=IFCAXIS2PLACEMENT3D(#4,$,$);
-#7=IFCSIUNIT(*,.LENGTHUNIT.,.MILLI.,.METRE.);
-#10=IFCPROJECTEDCRS('EPSG:25832',$,'ETRS89',$,'UTM','32N',#7);
-#11=IFCMAPCONVERSION(#2,#10,512000000.,5400000000.,0.,1.,0.,1.0);
-ENDSEC;
-END-ISO-10303-21;
-"#;
-
-    #[test]
-    fn resolves_millimetre_map_unit_scale() {
-        let geo = extract_georeferencing(MM_MAPUNIT_IFC).expect("georef");
-        assert_eq!(geo.map_unit.as_deref(), Some("MILLIMETRE"));
-        assert_eq!(geo.map_unit_scale, Some(0.001));
-        assert_eq!(geo.map_zone.as_deref(), Some("32N"));
-    }
-
-    /// An empty `ePset_ProjectedCRS.Name` must not block the `TargetCRS`
-    /// fallback — otherwise `crs_name` stays "" and the viewer gate (which
-    /// requires a truthy name) silently drops the model to EPSG:4326.
-    const IFC2X3_EPSET_EMPTY_CRS_NAME_IFC: &str = r#"ISO-10303-21;
-HEADER;
-FILE_DESCRIPTION(('ifc-georeferencer empty-crs-name fixture'),'2;1');
-FILE_NAME('georef-empty.ifc','2026-06-26T00:00:00',(''),(''),'','','');
-FILE_SCHEMA(('IFC2X3'));
-ENDSEC;
-DATA;
-#1=IFCPROPERTYSINGLEVALUE('TargetCRS',$,IFCLABEL('EPSG:28992'),$);
-#2=IFCPROPERTYSINGLEVALUE('Eastings',$,IFCLENGTHMEASURE(1000.5),$);
-#3=IFCPROPERTYSINGLEVALUE('Northings',$,IFCLENGTHMEASURE(2000.25),$);
-#4=IFCPROPERTYSINGLEVALUE('OrthogonalHeight',$,IFCLENGTHMEASURE(0.),$);
-#5=IFCPROPERTYSET('2If4Y3Lpv6dgTDkC5x_dnr',$,'ePset_MapConversion',$,(#1,#2,#3,#4));
-#6=IFCPROPERTYSINGLEVALUE('Name',$,IFCLABEL(''),$);
-#7=IFCPROPERTYSET('27AKTMp8j58fBEhvkJkcNJ',$,'ePset_ProjectedCRS',$,(#6));
-ENDSEC;
-END-ISO-10303-21;
-"#;
-
-    #[test]
-    fn empty_projected_crs_name_falls_back_to_target_crs() {
-        let geo = extract_georeferencing(IFC2X3_EPSET_EMPTY_CRS_NAME_IFC)
-            .expect("expected georeferencing from ePset_MapConversion");
-        assert_eq!(geo.crs_name.as_deref(), Some("EPSG:28992"));
-    }
-
-    /// An explicit ePSet `MapUnit` label resolves to the matching metre scale,
-    /// parity with the native IfcProjectedCRS path (which reads it from the
-    /// unit entity). Direct consumers must not default these offsets to metres.
-    const IFC2X3_EPSET_FOOT_MAPUNIT_IFC: &str = r#"ISO-10303-21;
-HEADER;
-FILE_DESCRIPTION(('ifc-georeferencer foot-mapunit fixture'),'2;1');
-FILE_NAME('georef-foot.ifc','2026-06-26T00:00:00',(''),(''),'','','');
-FILE_SCHEMA(('IFC2X3'));
-ENDSEC;
-DATA;
-#2=IFCPROPERTYSINGLEVALUE('Eastings',$,IFCLENGTHMEASURE(1000.5),$);
-#3=IFCPROPERTYSINGLEVALUE('Northings',$,IFCLENGTHMEASURE(2000.25),$);
-#4=IFCPROPERTYSINGLEVALUE('OrthogonalHeight',$,IFCLENGTHMEASURE(0.),$);
-#5=IFCPROPERTYSET('2If4Y3Lpv6dgTDkC5x_dnr',$,'ePset_MapConversion',$,(#2,#3,#4));
-#6=IFCPROPERTYSINGLEVALUE('Name',$,IFCLABEL('EPSG:2225'),$);
-#8=IFCPROPERTYSINGLEVALUE('MapUnit',$,IFCLABEL('FOOT'),$);
-#7=IFCPROPERTYSET('27AKTMp8j58fBEhvkJkcNJ',$,'ePset_ProjectedCRS',$,(#6,#8));
-ENDSEC;
-END-ISO-10303-21;
-"#;
-
-    #[test]
-    fn epset_map_unit_label_resolves_scale() {
-        let geo = extract_georeferencing(IFC2X3_EPSET_FOOT_MAPUNIT_IFC).expect("georef");
-        assert_eq!(geo.crs_name.as_deref(), Some("EPSG:2225"));
-        assert_eq!(geo.map_unit.as_deref(), Some("FOOT"));
-        assert_eq!(geo.map_unit_scale, Some(0.3048));
-    }
-
-    /// Two authored IfcMapConversions: the FIRST one wins, matching the TS
-    /// parser's `mapConversionIds[0]` pick (the server used to serve the
-    /// LAST one — alignment audit).
-    const TWO_CONVERSIONS_IFC: &str = r#"ISO-10303-21;
-HEADER;
-FILE_DESCRIPTION(('georef two-conversions fixture'),'2;1');
-FILE_NAME('georef-two.ifc','2026-06-12T00:00:00',(''),(''),'','','');
-FILE_SCHEMA(('IFC4'));
-ENDSEC;
-DATA;
-#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
-#4=IFCCARTESIANPOINT((0.,0.,0.));
-#5=IFCAXIS2PLACEMENT3D(#4,$,$);
-#10=IFCPROJECTEDCRS('EPSG:32632',$,'WGS84',$,'UTM','32N',$);
-#11=IFCMAPCONVERSION(#2,#10,111.0,222.0,0.,1.,0.,1.0);
-#12=IFCMAPCONVERSION(#2,#10,999.0,888.0,0.,1.,0.,1.0);
-ENDSEC;
-END-ISO-10303-21;
-"#;
-
-    #[test]
-    fn first_map_conversion_wins() {
-        let geo = extract_georeferencing(TWO_CONVERSIONS_IFC).expect("georef");
-        assert!((geo.eastings - 111.0).abs() < 1e-9);
-        assert!((geo.northings - 222.0).abs() < 1e-9);
-    }
-
-    /// Non-unit XAxisAbscissa/Ordinate (a DIRECTION, not cos/sin): the
-    /// rotation and the transform matrix must agree with each other and
-    /// with the TS parser's atan2-normalised matrix. Pre-fix, the matrix
-    /// used the raw components as cos/sin and disagreed with
-    /// `rotation_degrees` inside the same payload (alignment audit).
-    const NON_UNIT_AXIS_IFC: &str = r#"ISO-10303-21;
-HEADER;
-FILE_DESCRIPTION(('georef non-unit-axis fixture'),'2;1');
-FILE_NAME('georef-axis.ifc','2026-06-12T00:00:00',(''),(''),'','','');
-FILE_SCHEMA(('IFC4'));
-ENDSEC;
-DATA;
-#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
-#4=IFCCARTESIANPOINT((0.,0.,0.));
-#5=IFCAXIS2PLACEMENT3D(#4,$,$);
-#10=IFCPROJECTEDCRS('EPSG:32632',$,'WGS84',$,'UTM','32N',$);
-#11=IFCMAPCONVERSION(#2,#10,1000.,2000.,0.,3.0,4.0,1.0);
-ENDSEC;
-END-ISO-10303-21;
-"#;
-
-    #[test]
-    fn non_unit_axis_is_normalised() {
-        let geo = extract_georeferencing(NON_UNIT_AXIS_IFC).expect("georef");
-        // (3,4) direction → unit (0.6, 0.8); rotation ≈ 53.130°.
-        assert!((geo.x_axis_abscissa - 0.6).abs() < 1e-9);
-        assert!((geo.x_axis_ordinate - 0.8).abs() < 1e-9);
-        assert!((geo.rotation_degrees - 53.13010235415598).abs() < 1e-9);
-        // Matrix rotation cell == cos(rotation) — self-consistent payload.
-        assert!((geo.transform_matrix[0] - 0.6).abs() < 1e-9);
-        assert!((geo.transform_matrix[1] - 0.8).abs() < 1e-9);
-    }
-
-    /// Site-only model: `IfcSite.RefLatitude/RefLongitude` must produce a
-    /// georeference exactly like the TS parser's legacy-site fallback —
-    /// previously the server reported NO georeferencing for these models
-    /// while the browser said `hasGeoreference: true` (alignment audit).
-    /// Mirrors the values in packages/parser/test/georef-extractor.test.ts.
-    const SITE_ONLY_IFC: &str = r#"ISO-10303-21;
-HEADER;
-FILE_DESCRIPTION(('georef site-only fixture'),'2;1');
-FILE_NAME('georef-site.ifc','2026-06-12T00:00:00',(''),(''),'','','');
-FILE_SCHEMA(('IFC2X3'));
-ENDSEC;
-DATA;
-#4=IFCCARTESIANPOINT((0.,0.,0.));
-#5=IFCAXIS2PLACEMENT3D(#4,$,$);
-#11=IFCLOCALPLACEMENT($,#5);
-#10=IFCSITE('0Site0000000000000001',$,'Site',$,$,#11,$,$,.ELEMENT.,(47,22,30,0),(8,32,15,0),420.5,$,$);
-ENDSEC;
-END-ISO-10303-21;
-"#;
-
-    #[test]
-    fn site_lat_long_fallback_matches_ts_parser() {
-        let geo = extract_georeferencing(SITE_ONLY_IFC).expect("site georef");
-        assert_eq!(geo.source.as_deref(), Some("siteLocation"));
-        assert_eq!(geo.crs_name.as_deref(), Some("EPSG:4326"));
-        assert_eq!(geo.geodetic_datum.as_deref(), Some("WGS84"));
-        assert_eq!(geo.map_unit.as_deref(), Some("DEGREE"));
-        // 47°22'30" → 47.375; 8°32'15" → 8.5375 (longitude in eastings,
-        // latitude in northings — same packing as the TS fallback).
-        assert!((geo.northings - 47.375).abs() < 1e-9, "lat {}", geo.northings);
-        assert!((geo.eastings - 8.5375).abs() < 1e-9, "long {}", geo.eastings);
-        assert!((geo.orthogonal_height - 420.5).abs() < 1e-9);
-    }
-
-    #[test]
-    fn returns_none_without_georeferencing() {
-        let plain = r#"ISO-10303-21;
-HEADER;
-FILE_SCHEMA(('IFC4'));
-ENDSEC;
-DATA;
-#1=IFCPROJECT('0$ScRe4drECQ4DMSqUjd6d',$,'P',$,$,$,$,$,$);
-ENDSEC;
-END-ISO-10303-21;
-"#;
-        assert!(extract_georeferencing(plain).is_none());
-    }
-}
+#[path = "georeferencing_tests.rs"]
+mod tests;

--- a/rust/processing/src/georeferencing_tests.rs
+++ b/rust/processing/src/georeferencing_tests.rs
@@ -1,0 +1,373 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Tests for [`super`]. Split out so the module stays under its size budget,
+//! the same shape `stream_meta.rs` uses.
+
+use super::*;
+
+const GEOREF_IFC: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('georef fixture'),'2;1');
+FILE_NAME('georef.ifc','2026-06-01T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0$ScRe4drECQ4DMSqUjd6d',$,'P',$,$,$,$,(#2),#3);
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
+#3=IFCUNITASSIGNMENT((#6));
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#6=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#10=IFCPROJECTEDCRS('EPSG:32632','WGS84 / UTM zone 32N','WGS84',$,'UTM','32N',$);
+#11=IFCMAPCONVERSION(#2,#10,1000.5,2000.25,42.0,0.866025,0.5,1.0);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+#[test]
+fn extracts_map_conversion_and_crs() {
+    let geo = extract_georeferencing(GEOREF_IFC).expect("expected georeferencing");
+    assert_eq!(geo.crs_name.as_deref(), Some("EPSG:32632"));
+    assert_eq!(geo.geodetic_datum.as_deref(), Some("WGS84"));
+    assert_eq!(geo.map_projection.as_deref(), Some("UTM"));
+    assert!((geo.eastings - 1000.5).abs() < 1e-6);
+    assert!((geo.northings - 2000.25).abs() < 1e-6);
+    assert!((geo.orthogonal_height - 42.0).abs() < 1e-6);
+    // XAxisAbscissa/Ordinate = cos/sin(30°) → rotation_degrees ≈ 30.
+    assert!(
+        (geo.rotation_degrees - 30.0).abs() < 1e-3,
+        "rotation should be ~30°, got {}",
+        geo.rotation_degrees
+    );
+    // Translation column of the local→map matrix carries the offsets.
+    assert!((geo.transform_matrix[12] - 1000.5).abs() < 1e-6);
+    assert!((geo.transform_matrix[13] - 2000.25).abs() < 1e-6);
+    // New parity fields (alignment audit): description/zone + provenance.
+    assert_eq!(geo.crs_description.as_deref(), Some("WGS84 / UTM zone 32N"));
+    assert_eq!(geo.map_zone.as_deref(), Some("32N"));
+    // No MapUnit authored → project length unit applies (both None).
+    assert_eq!(geo.map_unit, None);
+    assert_eq!(geo.map_unit_scale, None);
+    assert_eq!(geo.source.as_deref(), Some("mapConversion"));
+}
+
+/// IFC2x3 models carry georeferencing via an `ePSet_MapConversion` property
+/// set rather than `IfcMapConversion`. Regression for the core extractor bug
+/// that read `IfcPropertySet.Name` from attribute 0 (GlobalId) instead of 2.
+const IFC2X3_PSET_IFC: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ifc2x3 georef pset fixture'),'2;1');
+FILE_NAME('georef2x3.ifc','2026-06-01T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC2X3'));
+ENDSEC;
+DATA;
+#1=IFCPROPERTYSINGLEVALUE('Eastings',$,IFCLENGTHMEASURE(1000.5),$);
+#2=IFCPROPERTYSINGLEVALUE('Northings',$,IFCLENGTHMEASURE(2000.25),$);
+#3=IFCPROPERTYSINGLEVALUE('OrthogonalHeight',$,IFCLENGTHMEASURE(42.),$);
+#4=IFCPROPERTYSET('0PSet00000000000000001',$,'ePSet_MapConversion',$,(#1,#2,#3));
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+#[test]
+fn extracts_ifc2x3_epset_map_conversion_fallback() {
+    let geo = extract_georeferencing(IFC2X3_PSET_IFC)
+        .expect("expected georeferencing from ePSet_MapConversion");
+    assert!((geo.eastings - 1000.5).abs() < 1e-6);
+    assert!((geo.northings - 2000.25).abs() < 1e-6);
+    assert!((geo.orthogonal_height - 42.0).abs() < 1e-6);
+}
+
+/// Real-world fixture mirroring the `ifc-georeferencer` post-processor:
+/// lowercase `ePset_…` property-set names and a separate `ePset_ProjectedCRS`
+/// carrying the EPSG `Name`. The exact-match + missing-CRS bug dropped these
+/// to the legacy IfcSite EPSG:4326 and showed the wrong CRS.
+const IFC2X3_EPSET_LOWERCASE_IFC: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ifc-georeferencer pset fixture'),'2;1');
+FILE_NAME('georef-lc.ifc','2026-06-26T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC2X3'));
+ENDSEC;
+DATA;
+#1=IFCPROPERTYSINGLEVALUE('TargetCRS',$,IFCLABEL('EPSG:7415'),$);
+#2=IFCPROPERTYSINGLEVALUE('Eastings',$,IFCLENGTHMEASURE(160073528.13858587),$);
+#3=IFCPROPERTYSINGLEVALUE('Northings',$,IFCLENGTHMEASURE(384153306.2191765),$);
+#4=IFCPROPERTYSINGLEVALUE('OrthogonalHeight',$,IFCLENGTHMEASURE(0.),$);
+#5=IFCPROPERTYSET('2If4Y3Lpv6dgTDkC5x_dnr',$,'ePset_MapConversion',$,(#1,#2,#3,#4));
+#6=IFCPROPERTYSINGLEVALUE('Name',$,IFCLABEL('EPSG:7415'),$);
+#7=IFCPROPERTYSET('27AKTMp8j58fBEhvkJkcNJ',$,'ePset_ProjectedCRS',$,(#6));
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+#[test]
+fn extracts_ifc2x3_lowercase_epset_with_projected_crs_name() {
+    let geo = extract_georeferencing(IFC2X3_EPSET_LOWERCASE_IFC)
+        .expect("expected georeferencing from lowercase ePset_ sets");
+    assert_eq!(geo.source.as_deref(), Some("ePSetMapConversion"));
+    // CRS name surfaced from ePset_ProjectedCRS.Name (was previously lost).
+    assert_eq!(geo.crs_name.as_deref(), Some("EPSG:7415"));
+    assert!((geo.eastings - 160073528.13858587).abs() < 1e-3);
+}
+
+/// Without an ePset_ProjectedCRS set, the CRS name falls back to the
+/// MapConversion's own `TargetCRS` label.
+const IFC2X3_EPSET_TARGETCRS_ONLY_IFC: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ifc-georeferencer targetcrs-only fixture'),'2;1');
+FILE_NAME('georef-tc.ifc','2026-06-26T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC2X3'));
+ENDSEC;
+DATA;
+#1=IFCPROPERTYSINGLEVALUE('TargetCRS',$,IFCLABEL('EPSG:28992'),$);
+#2=IFCPROPERTYSINGLEVALUE('Eastings',$,IFCLENGTHMEASURE(1000.5),$);
+#3=IFCPROPERTYSINGLEVALUE('Northings',$,IFCLENGTHMEASURE(2000.25),$);
+#4=IFCPROPERTYSINGLEVALUE('OrthogonalHeight',$,IFCLENGTHMEASURE(0.),$);
+#5=IFCPROPERTYSET('2If4Y3Lpv6dgTDkC5x_dnr',$,'ePset_MapConversion',$,(#1,#2,#3,#4));
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+#[test]
+fn falls_back_to_target_crs_when_no_projected_crs_pset() {
+    let geo = extract_georeferencing(IFC2X3_EPSET_TARGETCRS_ONLY_IFC)
+        .expect("expected georeferencing from ePset_MapConversion");
+    assert_eq!(geo.crs_name.as_deref(), Some("EPSG:28992"));
+}
+
+/// Millimetre MapUnit: the conversion offsets are authored in mm and the
+/// served `map_unit_scale` must say 0.001 — the TS parser already did
+/// this; the server previously ignored MapUnit entirely (alignment
+/// audit). Values mirror packages/parser/test/georef-extractor.test.ts.
+const MM_MAPUNIT_IFC: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('georef mm fixture'),'2;1');
+FILE_NAME('georef-mm.ifc','2026-06-12T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#7=IFCSIUNIT(*,.LENGTHUNIT.,.MILLI.,.METRE.);
+#10=IFCPROJECTEDCRS('EPSG:25832',$,'ETRS89',$,'UTM','32N',#7);
+#11=IFCMAPCONVERSION(#2,#10,512000000.,5400000000.,0.,1.,0.,1.0);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+#[test]
+fn resolves_millimetre_map_unit_scale() {
+    let geo = extract_georeferencing(MM_MAPUNIT_IFC).expect("georef");
+    assert_eq!(geo.map_unit.as_deref(), Some("MILLIMETRE"));
+    assert_eq!(geo.map_unit_scale, Some(0.001));
+    assert_eq!(geo.map_zone.as_deref(), Some("32N"));
+}
+
+/// An empty `ePset_ProjectedCRS.Name` must not block the `TargetCRS`
+/// fallback — otherwise `crs_name` stays "" and the viewer gate (which
+/// requires a truthy name) silently drops the model to EPSG:4326.
+const IFC2X3_EPSET_EMPTY_CRS_NAME_IFC: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ifc-georeferencer empty-crs-name fixture'),'2;1');
+FILE_NAME('georef-empty.ifc','2026-06-26T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC2X3'));
+ENDSEC;
+DATA;
+#1=IFCPROPERTYSINGLEVALUE('TargetCRS',$,IFCLABEL('EPSG:28992'),$);
+#2=IFCPROPERTYSINGLEVALUE('Eastings',$,IFCLENGTHMEASURE(1000.5),$);
+#3=IFCPROPERTYSINGLEVALUE('Northings',$,IFCLENGTHMEASURE(2000.25),$);
+#4=IFCPROPERTYSINGLEVALUE('OrthogonalHeight',$,IFCLENGTHMEASURE(0.),$);
+#5=IFCPROPERTYSET('2If4Y3Lpv6dgTDkC5x_dnr',$,'ePset_MapConversion',$,(#1,#2,#3,#4));
+#6=IFCPROPERTYSINGLEVALUE('Name',$,IFCLABEL(''),$);
+#7=IFCPROPERTYSET('27AKTMp8j58fBEhvkJkcNJ',$,'ePset_ProjectedCRS',$,(#6));
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+#[test]
+fn empty_projected_crs_name_falls_back_to_target_crs() {
+    let geo = extract_georeferencing(IFC2X3_EPSET_EMPTY_CRS_NAME_IFC)
+        .expect("expected georeferencing from ePset_MapConversion");
+    assert_eq!(geo.crs_name.as_deref(), Some("EPSG:28992"));
+}
+
+/// An explicit ePSet `MapUnit` label resolves to the matching metre scale,
+/// parity with the native IfcProjectedCRS path (which reads it from the
+/// unit entity). Direct consumers must not default these offsets to metres.
+const IFC2X3_EPSET_FOOT_MAPUNIT_IFC: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ifc-georeferencer foot-mapunit fixture'),'2;1');
+FILE_NAME('georef-foot.ifc','2026-06-26T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC2X3'));
+ENDSEC;
+DATA;
+#2=IFCPROPERTYSINGLEVALUE('Eastings',$,IFCLENGTHMEASURE(1000.5),$);
+#3=IFCPROPERTYSINGLEVALUE('Northings',$,IFCLENGTHMEASURE(2000.25),$);
+#4=IFCPROPERTYSINGLEVALUE('OrthogonalHeight',$,IFCLENGTHMEASURE(0.),$);
+#5=IFCPROPERTYSET('2If4Y3Lpv6dgTDkC5x_dnr',$,'ePset_MapConversion',$,(#2,#3,#4));
+#6=IFCPROPERTYSINGLEVALUE('Name',$,IFCLABEL('EPSG:2225'),$);
+#8=IFCPROPERTYSINGLEVALUE('MapUnit',$,IFCLABEL('FOOT'),$);
+#7=IFCPROPERTYSET('27AKTMp8j58fBEhvkJkcNJ',$,'ePset_ProjectedCRS',$,(#6,#8));
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+#[test]
+fn epset_map_unit_label_resolves_scale() {
+    let geo = extract_georeferencing(IFC2X3_EPSET_FOOT_MAPUNIT_IFC).expect("georef");
+    assert_eq!(geo.crs_name.as_deref(), Some("EPSG:2225"));
+    assert_eq!(geo.map_unit.as_deref(), Some("FOOT"));
+    assert_eq!(geo.map_unit_scale, Some(0.3048));
+}
+
+/// Two authored IfcMapConversions: the FIRST one wins, matching the TS
+/// parser's `mapConversionIds[0]` pick (the server used to serve the
+/// LAST one — alignment audit).
+const TWO_CONVERSIONS_IFC: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('georef two-conversions fixture'),'2;1');
+FILE_NAME('georef-two.ifc','2026-06-12T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#10=IFCPROJECTEDCRS('EPSG:32632',$,'WGS84',$,'UTM','32N',$);
+#11=IFCMAPCONVERSION(#2,#10,111.0,222.0,0.,1.,0.,1.0);
+#12=IFCMAPCONVERSION(#2,#10,999.0,888.0,0.,1.,0.,1.0);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+#[test]
+fn first_map_conversion_wins() {
+    let geo = extract_georeferencing(TWO_CONVERSIONS_IFC).expect("georef");
+    assert!((geo.eastings - 111.0).abs() < 1e-9);
+    assert!((geo.northings - 222.0).abs() < 1e-9);
+}
+
+/// Non-unit XAxisAbscissa/Ordinate (a DIRECTION, not cos/sin): the
+/// rotation and the transform matrix must agree with each other and
+/// with the TS parser's atan2-normalised matrix. Pre-fix, the matrix
+/// used the raw components as cos/sin and disagreed with
+/// `rotation_degrees` inside the same payload (alignment audit).
+const NON_UNIT_AXIS_IFC: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('georef non-unit-axis fixture'),'2;1');
+FILE_NAME('georef-axis.ifc','2026-06-12T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#10=IFCPROJECTEDCRS('EPSG:32632',$,'WGS84',$,'UTM','32N',$);
+#11=IFCMAPCONVERSION(#2,#10,1000.,2000.,0.,3.0,4.0,1.0);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+#[test]
+fn non_unit_axis_is_normalised() {
+    let geo = extract_georeferencing(NON_UNIT_AXIS_IFC).expect("georef");
+    // (3,4) direction → unit (0.6, 0.8); rotation ≈ 53.130°.
+    assert!((geo.x_axis_abscissa - 0.6).abs() < 1e-9);
+    assert!((geo.x_axis_ordinate - 0.8).abs() < 1e-9);
+    assert!((geo.rotation_degrees - 53.13010235415598).abs() < 1e-9);
+    // Matrix rotation cell == cos(rotation) — self-consistent payload.
+    assert!((geo.transform_matrix[0] - 0.6).abs() < 1e-9);
+    assert!((geo.transform_matrix[1] - 0.8).abs() < 1e-9);
+}
+
+/// Site-only model: `IfcSite.RefLatitude/RefLongitude` must produce a
+/// georeference exactly like the TS parser's legacy-site fallback —
+/// previously the server reported NO georeferencing for these models
+/// while the browser said `hasGeoreference: true` (alignment audit).
+/// Mirrors the values in packages/parser/test/georef-extractor.test.ts.
+const SITE_ONLY_IFC: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('georef site-only fixture'),'2;1');
+FILE_NAME('georef-site.ifc','2026-06-12T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC2X3'));
+ENDSEC;
+DATA;
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#11=IFCLOCALPLACEMENT($,#5);
+#10=IFCSITE('0Site0000000000000001',$,'Site',$,$,#11,$,$,.ELEMENT.,(47,22,30,0),(8,32,15,0),420.5,$,$);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+#[test]
+fn site_lat_long_fallback_matches_ts_parser() {
+    let geo = extract_georeferencing(SITE_ONLY_IFC).expect("site georef");
+    assert_eq!(geo.source.as_deref(), Some("siteLocation"));
+    assert_eq!(geo.crs_name.as_deref(), Some("EPSG:4326"));
+    assert_eq!(geo.geodetic_datum.as_deref(), Some("WGS84"));
+    assert_eq!(geo.map_unit.as_deref(), Some("DEGREE"));
+    // 47°22'30" → 47.375; 8°32'15" → 8.5375 (longitude in eastings,
+    // latitude in northings — same packing as the TS fallback).
+    assert!((geo.northings - 47.375).abs() < 1e-9, "lat {}", geo.northings);
+    assert!((geo.eastings - 8.5375).abs() < 1e-9, "long {}", geo.eastings);
+    assert!((geo.orthogonal_height - 420.5).abs() < 1e-9);
+}
+
+#[test]
+fn returns_none_without_georeferencing() {
+    let plain = r#"ISO-10303-21;
+HEADER;
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0$ScRe4drECQ4DMSqUjd6d',$,'P',$,$,$,$,$,$);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+    assert!(extract_georeferencing(plain).is_none());
+}
+
+/// The wrapper and the index-taking variant are one implementation, so they have
+/// to agree on every input. This is what lets a caller hand in an index it
+/// already holds without having to think about it.
+#[test]
+fn the_index_taking_variant_agrees_with_the_wrapper() {
+    for content in [
+        GEOREF_IFC.as_bytes(),
+        SITE_ONLY_IFC.as_bytes(),
+        MM_MAPUNIT_IFC.as_bytes(),
+    ] {
+        let index = Arc::new(ifc_lite_core::build_entity_index(content));
+        assert_eq!(
+            extract_georeferencing(content),
+            extract_georeferencing_with_index(content, &index),
+            "the wrapper and the index-taking variant disagreed",
+        );
+    }
+}
+
+/// The index passed in is the one consulted, rather than a fresh one built
+/// inside. Handed an empty index, the references the extractor resolves by id
+/// all miss, so a file that otherwise georeferences comes back `None`.
+///
+/// The assertion is about which index is used, not about how a wrong index is
+/// reported. It exists because reintroducing an internal build would otherwise
+/// be invisible: it costs a full extra scan and changes no output.
+#[test]
+fn the_passed_index_is_the_one_consulted() {
+    let content = GEOREF_IFC.as_bytes();
+    assert!(
+        extract_georeferencing(content).is_some(),
+        "the fixture has to georeference, or the assertion below proves nothing",
+    );
+
+    let empty = Arc::new(EntityIndex::default());
+    assert!(
+        extract_georeferencing_with_index(content, &empty).is_none(),
+        "an empty index was ignored, so the function built one of its own",
+    );
+}

--- a/rust/processing/src/lib.rs
+++ b/rust/processing/src/lib.rs
@@ -52,7 +52,9 @@ mod symbolic;
 mod types;
 
 pub use geometry_export::{build_geometry_data_export, ExportedElement, GeometryDataExport};
-pub use georeferencing::{extract_georeferencing, Georeferencing};
+pub use georeferencing::{
+    extract_georeferencing, extract_georeferencing_with_index, Georeferencing,
+};
 pub use pipeline_diagnostics::{
     PipelineDiagnostics, PipelinePhaseTimings, PIPELINE_DIAGNOSTICS_SCHEMA_VERSION,
 };

--- a/rust/processing/src/processor/mod.rs
+++ b/rust/processing/src/processor/mod.rs
@@ -1629,7 +1629,7 @@ pub fn process_geometry_streaming_filtered_with_options(
                 is_geo_referenced: has_rtc_offset,
             },
             length_unit_scale: Some(unit_scale),
-            georeferencing: crate::extract_georeferencing(content),
+            georeferencing: crate::extract_georeferencing_with_index(content, &entity_index_arc),
         },
         stats: ProcessingStats {
             total_meshes,

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -205,7 +205,6 @@
 # +35: #1891 closedness — ProducedElementMeshes.geometry_volume + .geometry_closure (the volume and the four-clause verdict that gates it), the widened emit-together match, and threading orient_mesh_outward_verdict's per-mesh verdict from BOTH orient call sites into the hasher. The verdict has to be taken exactly where the orienter already runs and handed to the hasher segment it describes, so it cannot move out of this decision tree; the gate's own 190 lines of rationale live in rust/geometry/src/geom_closure.rs (new, sub-400) rather than here.
 # -22: #1891 review (PR #1993) — the f32-collapse degenerate backstop (env switch, the drop, the per-element tally) moved to the child module element_degenerate.rs (new, 72), which is where the ordering story now belongs: the tally stopped being a diagnostic and became the input to the closure retraction. Budget refreshed downward; the retraction call site itself costs 7 lines here.
      910 rust/processing/src/element.rs
-     468 rust/processing/src/georeferencing.rs
 # +9: #2019 — canonicalise each host's opening order so the world geometry
 # hash stops depending on IFCRELVOIDSELEMENT statement order (sequential void
 # cuts are not associative). Three lines of code plus the why.

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -105,6 +105,7 @@ WASM-specific structural cost (not in the native probe, by design):
 |------|--------------------|
 | `rust/processing/examples/csg_scaling_bench.rs` (`--features csg-capture`) | Does native CSG scale with cores? (captures + replays the void-cut corpus under 1/2/4/8 threads) |
 | `rust/export/examples/glb_export_profile.rs` | GLB export phase split (index / mesh / assemble+serialize) + per-type triangle mass |
+| `rust/export/examples/index_vs_scan.rs` | For a whole-file helper: how much is the entity index and how much is the scan? |
 | `rust/csg-thread-bench/` (detached crate, `build.sh` + `web/serve.mjs`) | Threaded-WASM CSG: atomics tax + SharedArrayBuffer scaling in the browser |
 
 ## Lever ledger (read before spiking)
@@ -112,6 +113,25 @@ WASM-specific structural cost (not in the native probe, by design):
 Encoded so a spike does not re-walk a dead end. History lives in the PRs cited.
 
 ### Shipped wins
+- **Entity indexes built and never read** (`index_vs_scan.rs`): `relationships()`
+  built a full parallel index and handed it to the decoder, but every decode in it
+  is `decode_at_with_id` over the scanner's own spans and only `decode_by_id`
+  consults an index. Dead work, deleted. `extract_georeferencing` does need one, so
+  it gained a `_with_index` variant and `process_geometry` now passes the index it
+  already holds instead of paying a second scan.
+  Measured best-of-3 on the release fixtures, ms: O-S1-BWK 327 MB, parallel index
+  58.3, bare type scan 180.8, `relationships()` 234.6, `extract_georeferencing()`
+  337.6; schependomlaan 47 MB, 8.5 / 27.3 / 38.1 / 48.5. **Honest size: about 1% of
+  a large conversion.** It is worth having because it is free and hits every model,
+  not because it is big.
+  **Lesson, and the reason this entry exists:** check which decode family a helper
+  uses before handing it an index. The scan is the larger half of both of these, so
+  "share the index" was never going to be the lever it looked like from a sampled
+  profile that folded index build, scan and decode into one bucket.
+  **Harness gap, third of its kind:** `probe.sh` cannot see this change at all.
+  `ProcessingStats` closes its timers before the metadata block that calls
+  georeferencing runs, so the probe table is flat on this diff by construction.
+  A flat table here is a control, not a measurement.
 - **CDT: kill the three O(T)-per-item scans**: ISSUE_129 geometry 1568 -> 646 ms
   (main, pre-seam-conform, is 979), **byte-identical output** on 8 fixtures incl.
   advanced_model (FNV over every mesh). The quality CDT — not the seam conform —
@@ -188,6 +208,15 @@ Encoded so a spike does not re-walk a dead end. History lives in the PRs cited.
 Entries below are tagged individually: CANDIDATE (measured once, not validated end-to-end),
 SHIPPED (landed with a PR), or RE-REFUTED / NOT SHIPPABLE. Do not read the section as
 "all unshipped".
+- **GLB export computes georeferencing nobody on that path reads** (CANDIDATE — the cost is
+  measured, the fix is not designed): `process_geometry`'s metadata block always runs the
+  georeferencing extraction, and `rust/export` has no reference to
+  `metadata.georeferencing` anywhere. The streaming GLB paths run the pipeline twice, so a
+  large export pays it twice. After the index sharing above, what remains is the scan and
+  decode: roughly 280 ms per pass on a 327 MB fixture, so about 560 ms on a streaming
+  export. The field cannot simply go — the server serves it — so this needs an opt-out on
+  the options struct, defaulting to on, plus a per-exporter audit. That is its own review
+  unit and its own measurement, which is why it is not in the PR that shipped the sharing.
 - **Brotli -q11 on the served bundle** (CANDIDATE — unvalidated): a single local estimate
   suggested Vercel serves ~1266 KB where brotli -q11 reaches ~947 KB (~25% smaller cold
   download). NOT confirmed against the real served response — Vercel controls its own


### PR DESCRIPTION
## What and why

Two whole-file helpers were paying for entity indexes they did not need.

`relationships()` built a full parallel entity index, handed it to the decoder, and never
read it. Every decode in that function is `decode_at_with_id` over spans the scanner has
already produced, and that path falls through to `decode_at`. Only `decode_by_id` consults
an index, and nothing in the function calls it. So the build was a whole extra scan of the
file producing a map nobody looked at. It is gone.

`extract_georeferencing` genuinely does need an index, because the extractor resolves its
references by id. What it did not need was to build its own when the caller already had
one. It gains `extract_georeferencing_with_index`, and `process_geometry` now passes the
index it has held since the start of the run instead of paying a second scan. The existing
signature stays as a thin wrapper, so no caller has to change.

### Measured

Best of 3, release build, on this repo's own release fixtures (ms):

| fixture | parallel index | bare type-name scan | `relationships()` before | after |
|---|---:|---:|---:|---:|
| O-S1-BWK (327 MB) | 59.7 | 190.7 | 234.6 | **181.1** |
| ISSUE_053 (169 MB) | 35.6 | 88.5 | 118.9 | **86.4** |
| ISSUE_068 (54 MB) | 11.7 | 29.0 | 40.8 | **28.2** |
| schependomlaan (47 MB) | 8.6 | 28.4 | 38.1 | **27.1** |
| advanced_model (34 MB) | 6.6 | 16.5 | 22.3 | **16.3** |

`relationships()` now lands just under the bare type-name scan on every fixture, which is
what a function that walks the file once should cost. The georeferencing half saves one
index build per `process_geometry` run, about 60 ms on the largest fixture.

### Sizing it honestly

This is roughly **1% of a large conversion**, not more. The scan is the bigger half of both
helpers and this change does not touch it. The reason to take it is that it is free, it is
output-identical, and it applies to every model rather than to one pathological fixture.

The bigger half is a separate problem and is recorded in the ledger: a whole-file scan runs
several times over the same bytes in a typical run, and `IFCRELDEFINESBYTYPE` and
`IFCPROJECT` are matched and decoded in both the model pass and `relationships()`. That is
worth several times this PR and needs its own design.

## How it was verified

- `cargo test --workspace` — 162 suites, 1766 tests, 0 failures.
- `cargo clippy -p ifc-lite-export -p ifc-lite-processing --all-targets -- -D warnings` — clean,
  including the new example.
- `cargo test -p ifc-lite-processing --test module_size_ratchet` — green.
- Before/after numbers from the harness this PR adds,
  `cargo run --release -p ifc-lite-export --example index_vs_scan -- <file.ifc>`.

Output is unchanged by construction. The removed index was never read. The shared index is
the same map the callee would have built, and `build_entity_index_parallel ==
build_entity_index` is already pinned by the `parallel_scan` tests.

Two new tests hold the georeferencing half:

- `the_index_taking_variant_agrees_with_the_wrapper` pins the variant equal to the wrapper
  across three fixtures.
- `the_passed_index_is_the_one_consulted` passes a deliberately empty index and asserts the
  result collapses to `None`. If someone reintroduces an internal index build, that test
  fails rather than the change going unnoticed.

**No test can honestly guard the `relationships()` deletion.** A dead index has no output
effect, timing assertions are flake, and source-text assertions are out under the house
rules. The comment in that function is the guard, and it says why not to add one back.

**`probe.sh` reads flat on this diff by construction.** `ProcessingStats` closes its timers
before the metadata block that calls georeferencing runs, so the probe table cannot see
this change at all. That is now recorded in the perf ledger next to the two existing
harness gaps, so a flat table there is read as a control rather than as a result.

`georeferencing.rs` sat at exactly its 468-line ratchet budget, so adding one line would
have failed CI. Its tests move to a sibling `georeferencing_tests.rs` following the
`stream_meta.rs` pattern, and the module leaves the allowlist at 162 lines.

## Checklist

- [x] A test asserts the new behavior through a fixture or a stated invariant
- [x] Published `packages/*` touched: not touched, no changeset needed
- [x] Geometry-output change: none, no re-pin needed
- [x] House rules: no module pushed past its budget, no repo-wide `cargo fmt`
- [x] No client or project identifiers in code, tests, commit messages, or this PR

---

## Second commit: stop indexing the whole file to read one entity

Looking for the same shape found three more sites.

`dfjson::spatial_index` built a parallel index and handed it to the decoder, then only ever
called `decode_at_with_id` over the scanner's own spans. Identical to the `relationships()`
case: a full scan producing a map nobody read.

`ifc5::project_name` and the CSV exporter's project row each built a **serial**
`build_entity_index` to decode exactly one entity. Both sit immediately after
`relationships()` has already walked the same bytes, so the spatial export path was making
two full passes to answer one question. They now share `decode_one`, which scans for the id
and stops at it.

Sizes, from the same harness: the serial index build those two avoided is 205 ms on the
327 MB fixture and 99 ms on the 169 MB one; the dead parallel index in the DFJSON path is
60 ms and 36 ms. What `decode_one` costs instead depends on where the entity sits, and an
`IfcProject` is near the top of `DATA` in every fixture here.

`decode_one` is linear per call and is deliberately not a general replacement for an index.
It is right for a handful of lookups and wrong for many, and its doc comment says so. Every
caller invokes it once, guarded by `if let Some(pid)` and behind `or_insert_with`, never in
a loop.

Output is unchanged by construction throughout: the removed indexes were never read, and
`decode_one` decodes the same entity at the same span an index would have pointed at.
