### PR TITLE
fix(server-bin): publish SHA-256 sidecars and fail closed on a missing checksum

### DIFF
--- a/.changeset/server-bin-fail-closed-checksum.md
+++ b/.changeset/server-bin-fail-closed-checksum.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/server-bin": patch
+---
+
+Fail closed when no SHA-256 checksum is available for a downloaded server binary. The release pipeline now publishes an `<archive>.sha256` sidecar next to every archive, so a missing or unfetchable checksum means the download cannot be verified and is refused instead of executed behind a warning (previously the fail-open branch was the only one that ever ran, because no sidecar was ever published). Releases without sidecars are only ever downloaded by older package versions, which keep their shipped behaviour.

--- a/.github/workflows/server-binaries.yml
+++ b/.github/workflows/server-binaries.yml
@@ -333,6 +333,35 @@ jobs:
                 # checksum.
                 mkdir -p published
                 gh release download "$RELEASE_TAG" --pattern "$asset" --dir published
+                # Probe the published archive before certifying it: a corrupt
+                # or truncated upload must not receive a valid sidecar, or the
+                # fail-closed install check would bless exactly the bytes it
+                # exists to reject. A listing probe catches corruption only,
+                # NOT tampering - a deliberately altered but well-formed
+                # archive still gets certified (see the limit above). Each
+                # matrix leg backfills its own archive type on its own runner:
+                # tar ships with ubuntu and macos; the win32 leg runs bash on
+                # windows-latest, where unzip may be absent but 7z is on PATH.
+                # No probe tool at all is a hard error, never a skip.
+                case "$asset" in
+                  *.zip)
+                    if command -v unzip >/dev/null 2>&1; then
+                      unzip -t "published/$asset" >/dev/null
+                    elif command -v 7z >/dev/null 2>&1; then
+                      7z t "published/$asset" >/dev/null
+                    else
+                      echo "ERROR: neither unzip nor 7z exists on this runner; refusing to certify an unprobed zip" >&2
+                      exit 1
+                    fi
+                    ;;
+                  *.tar.gz)
+                    tar -tzf "published/$asset" >/dev/null
+                    ;;
+                  *)
+                    echo "ERROR: no integrity probe for $asset; refusing to certify unprobed bytes" >&2
+                    exit 1
+                    ;;
+                esac
                 (cd published && $SHA256_TOOL "$asset" > "../$sidecar")
                 gh release upload "$RELEASE_TAG" "$sidecar"
               fi

--- a/.github/workflows/server-binaries.yml
+++ b/.github/workflows/server-binaries.yml
@@ -243,14 +243,50 @@ jobs:
         run: |
           Compress-Archive -Path "dist/ifc-lite-server.exe" -DestinationPath "ifc-lite-server-${{ matrix.target }}.zip"
 
+      - name: Create Checksum Sidecar
+        # The sidecar must hash the SAME bytes that get uploaded, so it is
+        # computed here, right after the archive is written, on the leg's own
+        # runner - never from a later rebuild. Forced to bash on all three
+        # OSes for the same reason as the build step above. sha256sum does
+        # not exist on the macOS runners (shasum is the macOS spelling), so
+        # probe for either and fail hard when neither exists: an archive
+        # published without its sidecar would defeat the fail-closed
+        # install-time verification in packages/server-bin/src/checksum.ts.
+        shell: bash
+        run: |
+          # Deliberately NOT named `asset`: that binding lives in the upload
+          # step below, where the parity gate pins it, and a second variable
+          # of the same name in another step invites edits to the wrong one.
+          # A drift between this name and the upload step's fails loudly at
+          # upload time (file not found), never silently.
+          built="ifc-lite-server-${{ matrix.target }}.${{ matrix.archive }}"
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256_tool="sha256sum"
+          elif command -v shasum >/dev/null 2>&1; then
+            sha256_tool="shasum -a 256"
+          else
+            echo "ERROR: neither sha256sum nor shasum exists on this runner; refusing to build an unverifiable archive" >&2
+            exit 1
+          fi
+          # The backfill branch of the upload step below hashes published
+          # bytes with the same tool; export the probed spelling once.
+          echo "SHA256_TOOL=$sha256_tool" >> "$GITHUB_ENV"
+          $sha256_tool "$built" > "$built.sha256"
+          # Self-check before anything can reach a release: exactly the
+          # "<64-hex>  <archive>" line the install-time parser accepts.
+          grep -Eq "^[0-9a-f]{64} [ *]?$built\$" "$built.sha256"
+          cat "$built.sha256"
+
       - name: Upload Build Artifact
         if: github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ifc-lite-server-${{ matrix.target }}
-          path: ifc-lite-server-${{ matrix.target }}.${{ matrix.archive }}
+          path: |
+            ifc-lite-server-${{ matrix.target }}.${{ matrix.archive }}
+            ifc-lite-server-${{ matrix.target }}.${{ matrix.archive }}.sha256
           if-no-files-found: error
-          # Ad-hoc rebuild artifacts only — keep them briefly so they
+          # Ad-hoc rebuild artifacts only - keep them briefly so they
           # don't accumulate against Actions storage.
           retention-days: 1
 
@@ -265,10 +301,13 @@ jobs:
         shell: bash
         run: |
           asset="ifc-lite-server-${{ matrix.target }}.${{ matrix.archive }}"
+          sidecar="$asset.sha256"
           if [ "$GITHUB_EVENT_NAME" = "release" ]; then
             # Fresh release: assets are being created for the first time, so
-            # --clobber is the correct idempotent choice for job re-runs.
-            gh release upload "$RELEASE_TAG" "$asset" --clobber
+            # --clobber is the correct idempotent choice for job re-runs. The
+            # sidecar is listed first so no upload ordering exists where the
+            # archive is downloadable while its checksum is not.
+            gh release upload "$RELEASE_TAG" "$sidecar" "$asset" --clobber
           else
             # Manual backfill of an existing release: every matrix leg runs,
             # including platforms whose assets are already healthy, and
@@ -276,12 +315,32 @@ jobs:
             # uploading ("If the upload fails, the original assets will be
             # lost"). A transient failure would then destroy a working
             # archive for a platform that was never broken. So only upload
-            # what is actually missing, and never clobber.
+            # what is actually missing, and never clobber a healthy archive.
             existing="$(gh release view "$RELEASE_TAG" --json assets --jq '.assets[].name')"
-            if printf '%s\n' "$existing" | grep -qxF "$asset"; then
+            have() { printf '%s\n' "$existing" | grep -qxF "$1"; }
+            if have "$asset"; then
               echo "$asset already exists on $RELEASE_TAG; leaving the healthy asset untouched"
+              if have "$sidecar"; then
+                echo "$sidecar already exists on $RELEASE_TAG; leaving it untouched"
+              else
+                # The sidecar must hash the bytes installs actually download,
+                # which are the PUBLISHED archive's: a fresh rebuild is byte-
+                # different (archive timestamps at minimum), so hashing this
+                # job's rebuild would make every install of the platform fail
+                # closed. Hashing the published bytes pins them against future
+                # tampering or corruption; it cannot retroactively prove where
+                # they came from, which is the honest limit of a backfilled
+                # checksum.
+                mkdir -p published
+                gh release download "$RELEASE_TAG" --pattern "$asset" --dir published
+                (cd published && $SHA256_TOOL "$asset" > "../$sidecar")
+                gh release upload "$RELEASE_TAG" "$sidecar"
+              fi
             else
-              gh release upload "$RELEASE_TAG" "$asset"
+              # The archive is missing, so any sidecar left on the release
+              # hashes bytes that no longer exist; --clobber replaces that
+              # stale sidecar (and is a no-op for the missing archive itself).
+              gh release upload "$RELEASE_TAG" "$sidecar" "$asset" --clobber
             fi
           fi
         env:
@@ -325,6 +384,10 @@ jobs:
           persist-credentials: false
 
       - name: Verify release carries every supported platform archive
+        # Also verifies one .sha256 sidecar per archive when the tag's own
+        # workflow publishes them (the checker inspects the tag's
+        # server-binaries.yml, so pre-sidecar releases stay verifiable
+        # without demanding assets they never claimed to ship).
         # The script reads the expected archive set from the TAG'S OWN
         # platform.ts (git show), not from this checkout: on a manual
         # backfill the checkout is the workflow ref (main), whose

--- a/.github/workflows/server-binaries.yml
+++ b/.github/workflows/server-binaries.yml
@@ -362,7 +362,18 @@ jobs:
                     exit 1
                     ;;
                 esac
+                if [ -z "${SHA256_TOOL:-}" ]; then
+                  echo "ERROR: SHA256_TOOL is unset; refusing to backfill a sidecar without a checksum tool" >&2
+                  exit 1
+                fi
                 (cd published && $SHA256_TOOL "$asset" > "../$sidecar")
+                # Same self-check the build path applies before anything can
+                # reach a release: exactly the "<64-hex>  <archive>" line the
+                # install-time parser accepts. A backfilled sidecar is what
+                # fail-closed installs will trust, so it must be validated on
+                # this path too, not only on the build path.
+                grep -Eq "^[0-9a-f]{64} [ *]?$asset\$" "$sidecar"
+                cat "$sidecar"
                 gh release upload "$RELEASE_TAG" "$sidecar"
               fi
             else

--- a/packages/server-bin/src/binary.ts
+++ b/packages/server-bin/src/binary.ts
@@ -255,8 +255,9 @@ export async function downloadBinary(onProgress?: ProgressCallback): Promise<str
   }
 
   // Verify archive integrity before we extract / chmod / execute it. Fails
-  // closed on a checksum mismatch; fails open (with a warning) for older
-  // releases that predate the checksum pipeline.
+  // closed on a mismatch AND on a missing checksum: every release this
+  // package version can download publishes a .sha256 sidecar per archive
+  // (see checksum.ts for why that mapping holds).
   await verifyArchiveChecksum(archivePath, resolvedAssetUrl, platformInfo.archiveName);
 
   console.log('Extracting archive...');

--- a/packages/server-bin/src/checksum.ts
+++ b/packages/server-bin/src/checksum.ts
@@ -5,14 +5,20 @@
 /**
  * Integrity verification for downloaded release archives.
  *
- * Implements a non-breaking SHA-256 check: the per-asset checksum sidecar is
- * fetched from the SAME release as the archive and compared before the archive
- * is extracted / chmod'd / executed. A mismatch fails closed (the artifact is
- * unlinked and an error thrown); a missing checksum asset fails open (warn and
- * proceed) for backward compatibility with older releases.
+ * Fail-closed SHA-256 check: the per-asset checksum sidecar ("<asset>.sha256",
+ * with a release-wide "SHA256SUMS" accepted as a fallback shape) is fetched
+ * from the SAME release as the archive and compared before the archive is
+ * extracted / chmod'd / executed. Both a MISMATCH and a MISSING/unfetchable
+ * checksum fail closed: the artifact is unlinked and an error thrown.
  *
- * NOTE: The release pipeline SHOULD publish "<asset>.sha256" alongside every
- * archive so this verification becomes fail-closed everywhere.
+ * Failing closed on a missing sidecar cannot break a supported install:
+ * binary.ts derives the release tag from this package's own version, so a
+ * given published version only ever downloads its own release, and every
+ * release cut at or after the version that ships this code publishes one
+ * sidecar per archive (.github/workflows/server-binaries.yml, "Create
+ * Checksum Sidecar" - enforced by scripts/check-server-bin-targets.mjs).
+ * Releases without sidecars are only downloaded by older published package
+ * versions, which carry their own fail-open copy of this check.
  */
 
 import { existsSync, unlinkSync, createReadStream } from 'fs';
@@ -58,8 +64,8 @@ function parseExpectedSha256(body: string, archiveName: string): string | null {
 /**
  * Fetch the expected SHA-256 for the resolved asset from the SAME release.
  * Tries the per-asset sidecar ("<assetUrl>.sha256") first, then a release-wide
- * "SHA256SUMS" asset. Returns null if no checksum asset is published (older
- * releases) so callers can fail open for backward compatibility.
+ * "SHA256SUMS" asset. Returns null when no checksum could be retrieved; the
+ * caller fails closed on that.
  */
 async function fetchExpectedSha256(
   assetUrl: string,
@@ -94,9 +100,10 @@ async function fetchExpectedSha256(
 /**
  * Verify the downloaded archive against its published SHA-256 checksum.
  *
- * Fail-closed when a checksum is found and MISMATCHES (the artifact is unlinked
- * and an error thrown). Fail-open when NO checksum asset exists (older releases
- * predating the checksum pipeline) by logging a warning and proceeding.
+ * Fail-closed in both failure modes: a MISMATCH and a checksum that could not
+ * be retrieved at all each unlink the artifact and throw, so an unverified
+ * archive is never extracted or executed. See the module header for why a
+ * missing sidecar cannot be a legitimate state for this package version.
  */
 export async function verifyArchiveChecksum(
   archivePath: string,
@@ -106,12 +113,20 @@ export async function verifyArchiveChecksum(
   const expected = await fetchExpectedSha256(assetUrl, archiveName);
 
   if (!expected) {
-    console.warn(
-      `Warning: no SHA-256 checksum published for ${archiveName}; ` +
-      `skipping integrity verification. The release pipeline should publish ` +
-      `"${archiveName}.sha256" so this becomes a hard requirement.`
+    if (existsSync(archivePath)) {
+      unlinkSync(archivePath);
+    }
+    throw new Error(
+      `No SHA-256 checksum is available for ${archiveName}; refusing to use the unverified download.\n` +
+      `Expected "${archiveName}.sha256" (or a SHA256SUMS entry) alongside the archive in the same release.\n` +
+      `Likely causes:\n` +
+      `  1. The release assets are still uploading - retry in a few minutes\n` +
+      `  2. A network problem blocked the checksum fetch\n` +
+      `  3. The release is incomplete - report at https://github.com/LTplus-AG/ifc-lite/issues\n` +
+      `Alternatives:\n` +
+      `  - Use Docker: npx create-ifc-lite my-app --template server\n` +
+      `  - Build from source: cargo build --release -p ifc-lite-server`
     );
-    return;
   }
 
   const actual = await computeFileSha256(archivePath);

--- a/packages/server-bin/test/binary.test.ts
+++ b/packages/server-bin/test/binary.test.ts
@@ -14,25 +14,42 @@ import { join } from 'node:path';
  */
 
 const spawnMock = vi.hoisted(() => vi.fn());
+const execFileSyncMock = vi.hoisted(() => vi.fn());
 const existsSyncMock = vi.hoisted(() => vi.fn((_path: string) => true));
+const chmodSyncMock = vi.hoisted(() => vi.fn());
+const unlinkSyncMock = vi.hoisted(() => vi.fn());
+const mkdirSyncMock = vi.hoisted(() => vi.fn());
 const readFileMock = vi.hoisted(() => vi.fn());
+const writeFileMock = vi.hoisted(() => vi.fn(async (..._args: unknown[]) => undefined));
+const verifyChecksumMock = vi.hoisted(() =>
+  vi.fn(async (_archivePath: string, _assetUrl: string, _archiveName: string) => undefined)
+);
+const tarExtractMock = vi.hoisted(() => vi.fn(async (..._args: unknown[]) => undefined));
 
 vi.mock('child_process', async (importOriginal) => ({
   ...(await importOriginal<typeof import('child_process')>()),
   spawn: spawnMock,
+  execFileSync: execFileSyncMock,
 }));
 
 vi.mock('fs', async (importOriginal) => ({
   ...(await importOriginal<typeof import('fs')>()),
   existsSync: existsSyncMock,
+  chmodSync: chmodSyncMock,
+  unlinkSync: unlinkSyncMock,
+  mkdirSync: mkdirSyncMock,
 }));
 
 vi.mock('fs/promises', async (importOriginal) => ({
   ...(await importOriginal<typeof import('fs/promises')>()),
   readFile: readFileMock,
+  writeFile: writeFileMock,
 }));
 
-import { runBinary, getBinaryPath, getBinaryInfo, isBinaryCached } from '../src/binary.js';
+vi.mock('../src/checksum.js', () => ({ verifyArchiveChecksum: verifyChecksumMock }));
+vi.mock('tar', () => ({ extract: tarExtractMock }));
+
+import { runBinary, downloadBinary, getBinaryPath, getBinaryInfo, isBinaryCached } from '../src/binary.js';
 
 const PKG_VERSION = '1.16.6';
 
@@ -60,8 +77,18 @@ beforeEach(() => {
   child = new FakeChild();
   spawnMock.mockReset();
   spawnMock.mockReturnValue(child);
+  execFileSyncMock.mockReset();
   existsSyncMock.mockReset();
   existsSyncMock.mockReturnValue(true);
+  chmodSyncMock.mockReset();
+  unlinkSyncMock.mockReset();
+  mkdirSyncMock.mockReset();
+  writeFileMock.mockReset();
+  writeFileMock.mockImplementation(async () => undefined);
+  verifyChecksumMock.mockReset();
+  verifyChecksumMock.mockImplementation(async () => undefined);
+  tarExtractMock.mockReset();
+  tarExtractMock.mockImplementation(async () => undefined);
   readFileMock.mockReset();
   readFileMock.mockImplementation(async (path: string) =>
     String(path).endsWith('package.json')
@@ -254,5 +281,84 @@ describe('runBinary - argument and signal plumbing', () => {
       await promise;
     }
     expect(process.listenerCount('SIGINT')).toBe(before);
+  });
+});
+
+/**
+ * The checksum gate exists so that unverified bytes are never extracted,
+ * chmod'd or executed - but until these tests, nothing pinned that ORDER:
+ * deleting the verifyArchiveChecksum call, or moving it after extraction,
+ * kept every test green while reinstating exactly the fail-open defect the
+ * gate replaced. Download, verification and extraction are all observable
+ * seams here (fetch, checksum.js, tar/execFileSync are mocked), so the
+ * assertions bind the sequence, not just the presence of a call.
+ */
+describe('downloadBinary - checksum verification gates extraction', () => {
+  /** Minimal fetch response whose body streams one chunk. */
+  function fakeDownloadResponse() {
+    const bytes = new TextEncoder().encode('archive-bytes');
+    let drained = false;
+    return {
+      ok: true,
+      headers: { get: () => String(bytes.length) },
+      body: {
+        getReader: () => ({
+          read: async () =>
+            drained ? { done: true, value: undefined } : ((drained = true), { done: false, value: bytes }),
+        }),
+      },
+    };
+  }
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn(async () => fakeDownloadResponse()));
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  /** Extraction is platform-forked: tar for tar.gz, execFileSync for zip. */
+  function extractionCallOrders(): number[] {
+    return [
+      ...tarExtractMock.mock.invocationCallOrder,
+      ...execFileSyncMock.mock.invocationCallOrder,
+    ];
+  }
+
+  it('verifies the downloaded archive before extracting or chmodding it', async () => {
+    await downloadBinary();
+
+    expect(verifyChecksumMock).toHaveBeenCalledTimes(1);
+    const [archivePath, assetUrl, archiveName] = verifyChecksumMock.mock.calls[0];
+    const { platform } = getBinaryInfo();
+    expect(archiveName).toBe(platform.archiveName);
+    expect(String(archivePath).endsWith(platform.archiveName)).toBe(true);
+    expect(String(assetUrl).endsWith(`/v${PKG_VERSION}/${platform.archiveName}`)).toBe(true);
+
+    // Extraction must actually have been observed, or the ordering claim
+    // below would be vacuously true.
+    const extractions = extractionCallOrders();
+    expect(extractions.length).toBeGreaterThan(0);
+
+    const verifiedAt = verifyChecksumMock.mock.invocationCallOrder[0];
+    for (const extractedAt of extractions) {
+      expect(verifiedAt).toBeLessThan(extractedAt);
+    }
+    for (const chmoddedAt of chmodSyncMock.mock.invocationCallOrder) {
+      expect(verifiedAt).toBeLessThan(chmoddedAt);
+    }
+  });
+
+  it('extracts, chmods and persists NOTHING when verification fails', async () => {
+    verifyChecksumMock.mockRejectedValueOnce(new Error('checksum mismatch (test)'));
+
+    await expect(downloadBinary()).rejects.toThrow(/checksum mismatch \(test\)/);
+
+    expect(extractionCallOrders()).toHaveLength(0);
+    expect(chmodSyncMock).not.toHaveBeenCalled();
+    const versionWrites = writeFileMock.mock.calls.filter(([p]) => String(p).endsWith('version.txt'));
+    expect(versionWrites).toHaveLength(0);
   });
 });

--- a/packages/server-bin/test/binary.test.ts
+++ b/packages/server-bin/test/binary.test.ts
@@ -293,7 +293,7 @@ describe('runBinary - argument and signal plumbing', () => {
  * seams here (fetch, checksum.js, tar/execFileSync are mocked), so the
  * assertions bind the sequence, not just the presence of a call.
  */
-describe('downloadBinary - checksum verification gates extraction', () => {
+describe('downloadBinary - checksum verification gates extraction (PR #2650)', () => {
   /** Minimal fetch response whose body streams one chunk. */
   function fakeDownloadResponse() {
     const bytes = new TextEncoder().encode('archive-bytes');

--- a/packages/server-bin/test/checksum.test.ts
+++ b/packages/server-bin/test/checksum.test.ts
@@ -209,7 +209,12 @@ describe('verifyArchiveChecksum - checksum source resolution', () => {
 
   it('does not fetch a third url after SHA256SUMS misses', async () => {
     serve({});
-    await expect(verifyArchiveChecksum(archivePath, ASSET_URL, ARCHIVE_NAME)).rejects.toThrow();
+    // Assert the missing-checksum reason, not merely that something threw:
+    // a bare rejects.toThrow() would also pass if a fetch bug threw a
+    // TypeError, hiding the fact that the fail-closed path never ran.
+    await expect(verifyArchiveChecksum(archivePath, ASSET_URL, ARCHIVE_NAME)).rejects.toThrow(
+      /No SHA-256 checksum is available/
+    );
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/server-bin/test/checksum.test.ts
+++ b/packages/server-bin/test/checksum.test.ts
@@ -108,18 +108,31 @@ describe('verifyArchiveChecksum - mismatching digest fails closed', () => {
   });
 });
 
-describe('verifyArchiveChecksum - missing checksum fails open', () => {
-  it('warns and proceeds when neither the sidecar nor SHA256SUMS exists', async () => {
+describe('verifyArchiveChecksum - missing checksum fails closed', () => {
+  // The fail-open branch this replaces was the ONLY branch that ever ran in
+  // production: no workflow published a sidecar, so every install executed an
+  // unverified binary while the code read as though a check existed. Failing
+  // closed is safe because a package version only downloads the release of
+  // its own version, and every release cut at or after the version shipping
+  // this code publishes one sidecar per archive.
+  it('throws when neither the sidecar nor SHA256SUMS exists', async () => {
     serve({});
-    await expect(verifyArchiveChecksum(archivePath, ASSET_URL, ARCHIVE_NAME)).resolves.toBeUndefined();
-    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('no SHA-256 checksum published'));
-    expect(existsSync(archivePath)).toBe(true);
+    await expect(verifyArchiveChecksum(archivePath, ASSET_URL, ARCHIVE_NAME)).rejects.toThrow(
+      /No SHA-256 checksum is available/
+    );
   });
 
-  it('names the archive in the fail-open warning', async () => {
+  it('deletes the archive so the unverified download can never be extracted or executed', async () => {
     serve({});
-    await verifyArchiveChecksum(archivePath, ASSET_URL, ARCHIVE_NAME);
-    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining(ARCHIVE_NAME));
+    await expect(verifyArchiveChecksum(archivePath, ASSET_URL, ARCHIVE_NAME)).rejects.toThrow();
+    expect(existsSync(archivePath)).toBe(false);
+  });
+
+  it('names the archive and the sidecar it expected in the error', async () => {
+    serve({});
+    await expect(verifyArchiveChecksum(archivePath, ASSET_URL, ARCHIVE_NAME)).rejects.toThrow(
+      new RegExp(`${ARCHIVE_NAME.replace(/\./g, '\\.')}\\.sha256`)
+    );
   });
 });
 
@@ -164,9 +177,10 @@ describe('verifyArchiveChecksum - checksum source resolution', () => {
     const other = 'c'.repeat(64);
     serve({ [SUMS_URL]: `${other}  ifc-lite-server-darwin-arm64.tar.gz` });
     // The first line parses cleanly but names a different asset, so no checksum
-    // applies to ours: fail open, never silently adopt another asset's digest.
-    await verifyArchiveChecksum(archivePath, ASSET_URL, ARCHIVE_NAME);
-    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('no SHA-256 checksum published'));
+    // applies to ours: fail closed, never silently adopt another asset's digest.
+    await expect(verifyArchiveChecksum(archivePath, ASSET_URL, ARCHIVE_NAME)).rejects.toThrow(
+      /No SHA-256 checksum is available/
+    );
   });
 
   it('accepts a path-qualified name ending in the archive name', async () => {
@@ -176,14 +190,16 @@ describe('verifyArchiveChecksum - checksum source resolution', () => {
 
   it('rejects a name that merely ends with the archive name without a path separator', async () => {
     serve({ [SUMS_URL]: `${DIGEST}  evil-${ARCHIVE_NAME}` });
-    await verifyArchiveChecksum(archivePath, ASSET_URL, ARCHIVE_NAME);
-    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('no SHA-256 checksum published'));
+    await expect(verifyArchiveChecksum(archivePath, ASSET_URL, ARCHIVE_NAME)).rejects.toThrow(
+      /No SHA-256 checksum is available/
+    );
   });
 
-  it('ignores lines whose digest is not exactly 64 hex chars', async () => {
+  it('ignores lines whose digest is not exactly 64 hex chars and fails closed', async () => {
     serve({ [SUMS_URL]: `${DIGEST.slice(0, 63)}  ${ARCHIVE_NAME}\n${DIGEST}xy  ${ARCHIVE_NAME}` });
-    await verifyArchiveChecksum(archivePath, ASSET_URL, ARCHIVE_NAME);
-    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('no SHA-256 checksum published'));
+    await expect(verifyArchiveChecksum(archivePath, ASSET_URL, ARCHIVE_NAME)).rejects.toThrow(
+      /No SHA-256 checksum is available/
+    );
   });
 
   it('ignores blank lines and comment noise before the real entry', async () => {
@@ -193,7 +209,7 @@ describe('verifyArchiveChecksum - checksum source resolution', () => {
 
   it('does not fetch a third url after SHA256SUMS misses', async () => {
     serve({});
-    await verifyArchiveChecksum(archivePath, ASSET_URL, ARCHIVE_NAME);
+    await expect(verifyArchiveChecksum(archivePath, ASSET_URL, ARCHIVE_NAME)).rejects.toThrow();
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/server-bin/test/checksum.test.ts
+++ b/packages/server-bin/test/checksum.test.ts
@@ -108,7 +108,7 @@ describe('verifyArchiveChecksum - mismatching digest fails closed', () => {
   });
 });
 
-describe('verifyArchiveChecksum - missing checksum fails closed', () => {
+describe('verifyArchiveChecksum - missing checksum fails closed (PR #2650)', () => {
   // The fail-open branch this replaces was the ONLY branch that ever ran in
   // production: no workflow published a sidecar, so every install executed an
   // unverified binary while the code read as though a check existed. Failing

--- a/scripts/check-server-bin-targets.mjs
+++ b/scripts/check-server-bin-targets.mjs
@@ -53,7 +53,10 @@
  * unreadable/empty release asset list, or a release tag whose ref is not
  * available locally is an ERROR, never a vacuous pass. In particular an
  * absent tag ref tells the operator to fetch it instead of silently
- * falling back to the checked-out tree's target set.
+ * falling back to the checked-out tree's target set - and that case is
+ * distinguished structurally (not by git's error prose) from a tag that IS
+ * fetched but simply predates a file, which is a fact about the revision:
+ * see scripts/lib/server-bin-tag-read.mjs.
  *
  * Source-text matching is comment-aware (rationale in
  * scripts/lib/server-bin-targets-parse.mjs); the upload check (in
@@ -77,6 +80,7 @@ import {
   checkUploadStep,
   uploadStepPublishesSidecars,
 } from './lib/server-bin-upload-check.mjs';
+import { readFileAtTag } from './lib/server-bin-tag-read.mjs';
 
 // --root <dir>: read the input files from an alternate tree (in --release
 // mode, git also runs there). Exists for the regression harness, which points
@@ -147,34 +151,6 @@ function assertSetEquals(label, actual, expected) {
 }
 
 /**
- * Read one file at the release tag's own revision via git show.
- *
- * Fail-closed: an absent tag ref is an ERROR telling the operator to fetch
- * it, never a silent fallback to the checked-out tree - that fallback would
- * recreate the vacuous pass this script exists to prevent. A path that does
- * not exist at an EXISTING tag is a different, answerable case: the caller
- * may treat it as a definite absence, so it is surfaced as null when
- * `optional` is set.
- */
-function readFileAtTag(tag, path, { optional = false } = {}) {
-  try {
-    return execFileSync('git', ['show', `refs/tags/${tag}:${path}`], {
-      cwd: repoRoot,
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
-  } catch (err) {
-    const detail = String(err?.stderr || err?.message || err).trim().split('\n')[0];
-    if (optional && /does not exist/.test(detail)) return null;
-    fail(
-      `cannot read ${path} at tag "${tag}" via git show (${detail}); ` +
-      `fetch the tag first (git fetch --depth=1 origin tag ${tag}) - refusing to fall back ` +
-      `to the checked-out tree, which may not be the tag's`,
-    );
-  }
-}
-
-/**
  * SUPPORTED_TARGETS as of the release tag's own source. A release is
  * verified against what ITS resolver downloads: the install-time resolver
  * ships inside the published package at that version, so the tag's
@@ -185,7 +161,7 @@ function readFileAtTag(tag, path, { optional = false } = {}) {
  * downloads, and is unfixable post-publish anyway.
  */
 function parseTagSupportedTargets(tag) {
-  const source = readFileAtTag(tag, PLATFORM_TS);
+  const source = readFileAtTag(repoRoot, tag, PLATFORM_TS);
   return parseSupportedTargets(source, `${PLATFORM_TS} at tag ${tag}`);
 }
 
@@ -203,7 +179,7 @@ function parseTagSupportedTargets(tag) {
  * silently disarming this detection for future releases.
  */
 function tagWorkflowPublishesSidecars(tag) {
-  const source = readFileAtTag(tag, WORKFLOW, { optional: true });
+  const source = readFileAtTag(repoRoot, tag, WORKFLOW, { optional: true });
   if (source === null) return false;
   return uploadStepPublishesSidecars(stripYamlComments(source));
 }

--- a/scripts/check-server-bin-targets.mjs
+++ b/scripts/check-server-bin-targets.mjs
@@ -35,16 +35,19 @@
  * (linux only), so it is checked as a subset, not for equality.
  *
  * With `--release <tag>` the script instead asserts the published release
- * carries every expected archive by name, so a failed matrix leg cannot
+ * carries every expected asset by name, so a failed matrix leg cannot
  * leave a silent hole. The expected set is read from the TAG'S OWN
  * platform.ts (`git show refs/tags/<tag>:...`), not from the checked-out
  * tree: a manual backfill dispatch checks out the workflow ref (main), and
  * as the platform set drifts, main's SUPPORTED_TARGETS would demand
  * archives an old release never claimed to ship (a false red on exactly
  * the repair path this check exists for) or miss ones it still needs (a
- * false green). The checked-out tree still gets the full source-parity
- * check first, and the checker code itself always runs from the workflow
- * ref.
+ * false green). The .sha256 sidecar expectation is keyed off the tag the
+ * same way: expected exactly when the tag's own workflow publishes
+ * sidecars, so pre-sidecar releases stay verifiable while a newer release
+ * cannot silently drop one (checksum.ts fails closed for those versions).
+ * The checked-out tree still gets the full source-parity check first, and
+ * the checker code itself always runs from the workflow ref.
  *
  * Fail-closed: an unfindable list, a parse yielding no entries, an
  * unreadable/empty release asset list, or a release tag whose ref is not
@@ -53,8 +56,9 @@
  * falling back to the checked-out tree's target set.
  *
  * Source-text matching is comment-aware (rationale in
- * scripts/lib/server-bin-targets-parse.mjs); the upload check binds the asset
- * literal to the actual `gh release upload` argument. Executable proof:
+ * scripts/lib/server-bin-targets-parse.mjs); the upload check (in
+ * scripts/lib/server-bin-upload-check.mjs) binds the asset and sidecar
+ * literals to the actual `gh release upload` arguments. Executable proof:
  * scripts/check-server-bin-targets.test.mjs, which drives this script via
  * `--root <dir>` against hostile mutations of the real inputs.
  */
@@ -65,12 +69,14 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join, resolve } from 'node:path';
 import {
   fail,
-  jobBlock,
   parseMatrix,
   parseSupportedTargets,
   stripYamlComments,
-  unquoteScalar,
 } from './lib/server-bin-targets-parse.mjs';
+import {
+  checkUploadStep,
+  uploadStepPublishesSidecars,
+} from './lib/server-bin-upload-check.mjs';
 
 // --root <dir>: read the input files from an alternate tree (in --release
 // mode, git also runs there). Exists for the regression harness, which points
@@ -141,6 +147,34 @@ function assertSetEquals(label, actual, expected) {
 }
 
 /**
+ * Read one file at the release tag's own revision via git show.
+ *
+ * Fail-closed: an absent tag ref is an ERROR telling the operator to fetch
+ * it, never a silent fallback to the checked-out tree - that fallback would
+ * recreate the vacuous pass this script exists to prevent. A path that does
+ * not exist at an EXISTING tag is a different, answerable case: the caller
+ * may treat it as a definite absence, so it is surfaced as null when
+ * `optional` is set.
+ */
+function readFileAtTag(tag, path, { optional = false } = {}) {
+  try {
+    return execFileSync('git', ['show', `refs/tags/${tag}:${path}`], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (err) {
+    const detail = String(err?.stderr || err?.message || err).trim().split('\n')[0];
+    if (optional && /does not exist/.test(detail)) return null;
+    fail(
+      `cannot read ${path} at tag "${tag}" via git show (${detail}); ` +
+      `fetch the tag first (git fetch --depth=1 origin tag ${tag}) - refusing to fall back ` +
+      `to the checked-out tree, which may not be the tag's`,
+    );
+  }
+}
+
+/**
  * SUPPORTED_TARGETS as of the release tag's own source. A release is
  * verified against what ITS resolver downloads: the install-time resolver
  * ships inside the published package at that version, so the tag's
@@ -149,108 +183,29 @@ function assertSetEquals(label, actual, expected) {
  * tag's package.json os/cpu is deliberately not consulted here - it only
  * gates npm installs, cannot change which archives the tag's resolver
  * downloads, and is unfixable post-publish anyway.
- *
- * Fail-closed: an absent tag ref is an ERROR telling the operator to fetch
- * it, never a silent fallback to the checked-out tree's set - that
- * fallback would recreate the vacuous pass this script exists to prevent.
  */
 function parseTagSupportedTargets(tag) {
-  let source;
-  try {
-    source = execFileSync('git', ['show', `refs/tags/${tag}:${PLATFORM_TS}`], {
-      cwd: repoRoot,
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
-  } catch (err) {
-    const detail = String(err?.stderr || err?.message || err).trim().split('\n')[0];
-    fail(
-      `cannot read ${PLATFORM_TS} at tag "${tag}" via git show (${detail}); ` +
-      `fetch the tag first (git fetch --depth=1 origin tag ${tag}) - refusing to fall back ` +
-      `to the checked-out tree's target set, which may not be the tag's`,
-    );
-  }
+  const source = readFileAtTag(tag, PLATFORM_TS);
   return parseSupportedTargets(source, `${PLATFORM_TS} at tag ${tag}`);
 }
 
 /**
- * The exact expression the upload step must use for the asset filename.
- * The resolver downloads `ifc-lite-server-<target>.<ext>`; pinning the
- * workflow to this literal makes the two names provably identical instead
- * of two hand-maintained strings that agree by luck.
+ * Whether the TAG's own pipeline publishes checksum sidecars, read from the
+ * tag's server-binaries.yml the same way the target set is read from the
+ * tag's platform.ts. Keying the sidecar expectation off the tag is what lets
+ * pre-sidecar releases (e.g. v1.16.6) stay verifiable without demanding
+ * assets they never claimed to ship, while a release cut from sidecar-
+ * publishing source cannot silently drop one. An absent workflow, job, step
+ * or binding at the tag is a definite "no sidecars", not an error; the
+ * strict counterpart (checkUploadStep, which fails closed on all of those)
+ * has already run against the checked-out tree by the time this is called,
+ * so a drifted binding on the workflow ref turns the gate red instead of
+ * silently disarming this detection for future releases.
  */
-// The ${{ }} is a GitHub Actions expression pinned as a literal, not a JS template.
-// eslint-disable-next-line no-template-curly-in-string
-const UPLOAD_ASSET_EXPR = 'ifc-lite-server-${{ matrix.target }}.${{ matrix.archive }}';
-
-/**
- * The release upload step must BIND the asset name to UPLOAD_ASSET_EXPR and
- * every `gh release upload` invocation in it must pass exactly that binding.
- * Mere presence of the literal in the step is not enough: a comment can carry
- * the old name while the assignment or the upload argument drifts, and then
- * every release 404s on every platform while the gate blesses it.
- */
-function checkUploadAssetName(workflow) {
-  const block = jobBlock(workflow, 'release-server-binaries', WORKFLOW);
-  const stepStart = block.indexOf('- name: Upload to GitHub Release');
-  if (stepStart === -1) {
-    fail(
-      `cannot find the "Upload to GitHub Release" step in job "release-server-binaries" of ${WORKFLOW}; ` +
-      `if the step was renamed, update this check - it must not pass without pinning the upload filename`,
-    );
-  }
-  const rest = block.slice(stepStart + 1);
-  const nextStep = /\n {6}- name:/.exec(rest);
-  const step = block.slice(stepStart, nextStep ? stepStart + 1 + nextStep.index : block.length);
-
-  // 1. The `asset=` binding must be exactly the expected expression and the
-  // ONLY line writing the variable - a later `asset=` or `asset+=` would
-  // rebind the name and reopen the hole the presence check had.
-  const assigns = [...step.matchAll(/^[ \t]*asset(\+?=)(.*)$/gm)];
-  if (assigns.length === 0) {
-    fail(
-      `the "Upload to GitHub Release" step in ${WORKFLOW} no longer assigns asset=...; the step must ` +
-      `bind asset to "${UPLOAD_ASSET_EXPR}" (the exact name the resolver in ${PLATFORM_TS} downloads) - ` +
-      `if the script was restructured, update this check`,
-    );
-  }
-  if (assigns.length > 1) {
-    fail(
-      `the "Upload to GitHub Release" step in ${WORKFLOW} writes the asset variable ${assigns.length} ` +
-      `times; a rebinding after the pinned assignment could upload a name the resolver in ` +
-      `${PLATFORM_TS} never downloads, so exactly one asset= line is allowed`,
-    );
-  }
-  const [, op, rawValue] = assigns[0];
-  const assigned = unquoteScalar(rawValue.trim());
-  if (op !== '=' || assigned !== UPLOAD_ASSET_EXPR) {
-    fail(
-      `the "Upload to GitHub Release" step in ${WORKFLOW} assigns asset${op}${rawValue.trim()} but the ` +
-      `resolver in ${PLATFORM_TS} downloads exactly "${UPLOAD_ASSET_EXPR}"; the two must be identical`,
-    );
-  }
-
-  // 2. Both paths (fresh release and backfill) must pass the $asset binding
-  // as the `gh release upload` asset argument. Only double quotes are
-  // stripped: a single-quoted '$asset' never expands in bash, so it must stay red.
-  const uploads = [...step.matchAll(/gh release upload[ \t]+(\S+)[ \t]+(\S+)/g)];
-  if (uploads.length < 2) {
-    fail(
-      `expected the release and backfill paths of the "Upload to GitHub Release" step in ${WORKFLOW} ` +
-      `to each invoke "gh release upload <tag> <asset>"; found ${uploads.length} invocation(s) - ` +
-      `if the step was restructured, update this check`,
-    );
-  }
-  for (const [, , assetArg] of uploads) {
-    const arg = assetArg.replace(/^"(.*)"$/s, '$1').replace(/^\$\{asset\}$/, '$asset');
-    if (arg !== '$asset') {
-      fail(
-        `a "gh release upload" invocation in the "Upload to GitHub Release" step of ${WORKFLOW} passes ` +
-        `${assetArg} as its asset argument instead of "$asset"; only the pinned $asset binding provably ` +
-        `uploads the name the resolver in ${PLATFORM_TS} downloads`,
-      );
-    }
-  }
+function tagWorkflowPublishesSidecars(tag) {
+  const source = readFileAtTag(tag, WORKFLOW, { optional: true });
+  if (source === null) return false;
+  return uploadStepPublishesSidecars(stripYamlComments(source));
 }
 
 /** Default mode: the three functional lists must agree. */
@@ -295,8 +250,10 @@ function checkSourceParity() {
   }
 
   // The upload step must name assets with the exact expression the resolver
-  // expects, or the six correct archives upload under the wrong names.
-  checkUploadAssetName(workflow);
+  // expects (or the six correct archives upload under the wrong names) and
+  // must ship a .sha256 sidecar with every archive (or the fail-closed
+  // install-time verification in checksum.ts breaks every install).
+  checkUploadStep(workflow, WORKFLOW, PLATFORM_TS);
 
   // Validate matrix: a deliberate cost-saving subset, never an unknown
   // target, and its legs must build the triple their target names.
@@ -355,32 +312,40 @@ async function fetchReleaseAssetNames(tag) {
 }
 
 /**
- * --release mode: every expected archive must exist on the release, by the
+ * --release mode: every expected asset must exist on the release, by the
  * exact name the resolver downloads. The expected set is the TAG's own
  * SUPPORTED_TARGETS (see parseTagSupportedTargets); the checked-out tree is
  * still source-parity-checked first, since on a `release` event it IS the
- * tag and on a backfill it is the gated workflow ref. Deliberately does NOT
- * expect .sha256 / SHA256SUMS sidecars: no workflow publishes them today,
- * so expecting them would turn every release red.
+ * tag and on a backfill it is the gated workflow ref. One .sha256 sidecar
+ * per archive is expected exactly when the tag's own workflow publishes
+ * sidecars (see tagWorkflowPublishesSidecars): the install-time check in
+ * checksum.ts fails closed for such versions, so a missing sidecar breaks
+ * every install of that platform just as surely as a missing archive -
+ * while pre-sidecar releases never claimed to ship one.
  */
 async function checkReleaseAssets(tag) {
   checkSourceParity();
   const targets = parseTagSupportedTargets(tag);
+  const sidecars = tagWorkflowPublishesSidecars(tag);
   const names = await fetchReleaseAssetNames(tag);
   if (names.length === 0) {
     fail(`release ${tag} has no assets at all; an empty list is a failure, not a pass`);
   }
-  const expected = targets.map((t) => `ifc-lite-server-${t}.${archiveExtFor(splitTriple(t).platform)}`);
+  const archives = targets.map((t) => `ifc-lite-server-${t}.${archiveExtFor(splitTriple(t).platform)}`);
+  const expected = sidecars ? archives.flatMap((a) => [a, `${a}.sha256`]) : archives;
   const missing = expected.filter((name) => !names.includes(name));
   if (missing.length) {
+    const kind = sidecars ? 'assets (one archive plus one .sha256 sidecar per target)' : 'archives';
     fail(
-      `release ${tag} is missing ${missing.length} of ${expected.length} archives its own SUPPORTED_TARGETS names:\n` +
+      `release ${tag} is missing ${missing.length} of ${expected.length} ${kind} its own SUPPORTED_TARGETS names:\n` +
       missing.map((name) => `  ${name}`).join('\n'),
     );
   }
   console.log(
-    `check-server-bin-targets: OK - release ${tag} carries all ${expected.length} archives ` +
-    `its own SUPPORTED_TARGETS names (${targets.join(', ')})`,
+    `check-server-bin-targets: OK - release ${tag} carries all ${archives.length} archives ` +
+    (sidecars
+      ? `and ${archives.length} checksum sidecars its own SUPPORTED_TARGETS names (${targets.join(', ')})`
+      : `its own SUPPORTED_TARGETS names (${targets.join(', ')}; tag predates checksum sidecars, none required)`),
   );
 }
 

--- a/scripts/check-server-bin-targets.test.mjs
+++ b/scripts/check-server-bin-targets.test.mjs
@@ -391,12 +391,18 @@ const preSidecarWorkflow = (s) => mutate(s, `${SIDECAR_ASSIGN_LINE}\n`, '');
  * Commit (optionally mutated) inputs as tag v9.9.9 in a temp repo, restore
  * the working tree to the real inputs (the workflow ref, exactly as on a
  * real run), and run the checker in --release mode against a fake gh that
- * reports `assets` as the release's asset names.
+ * reports `assets` as the release's asset names. `tagOmit` names input keys
+ * left OUT of the tagged commit while still restored to the working tree
+ * afterwards - reproducing git's "exists on disk, but not in <tag>" shape,
+ * the one a pre-package tag shows on a real checkout. `tag` overrides which
+ * tag the checker is asked to verify (the temp repo only ever tags v9.9.9,
+ * so any other name is an unfetched tag).
  */
-function runReleaseChecker({ tagMutations = {}, assets }) {
+function runReleaseChecker({ tagMutations = {}, tagOmit = [], tag = 'v9.9.9', assets }) {
   const dir = mkdtempSync(join(tmpdir(), 'server-bin-gate-rel-'));
   try {
     for (const [key, rel] of Object.entries(INPUTS)) {
+      if (tagOmit.includes(key)) continue;
       const target = join(dir, rel);
       mkdirSync(dirname(target), { recursive: true });
       writeFileSync(target, tagMutations[key] ? tagMutations[key](real[key]) : real[key]);
@@ -410,6 +416,7 @@ function runReleaseChecker({ tagMutations = {}, assets }) {
     git('-c', 'user.email=gate@test.invalid', '-c', 'user.name=gate', 'commit', '-qm', 'tag inputs');
     git('tag', 'v9.9.9');
     for (const [key, rel] of Object.entries(INPUTS)) {
+      mkdirSync(dirname(join(dir, rel)), { recursive: true });
       writeFileSync(join(dir, rel), real[key]);
     }
     const bin = join(dir, 'fake-bin');
@@ -418,7 +425,7 @@ function runReleaseChecker({ tagMutations = {}, assets }) {
     const shim = join(bin, 'gh');
     writeFileSync(shim, '#!/bin/sh\ncat "$(dirname "$0")/assets.json"\n');
     chmodSync(shim, 0o755);
-    const r = spawnSync(process.execPath, [CHECKER, '--root', dir, '--release', 'v9.9.9'], {
+    const r = spawnSync(process.execPath, [CHECKER, '--root', dir, '--release', tag], {
       encoding: 'utf8',
       env: { ...process.env, PATH: `${bin}:${process.env.PATH}` },
     });
@@ -459,4 +466,55 @@ releaseTest('release: a pre-sidecar tag missing an archive is still red', () => 
     assets: ARCHIVES.filter((a) => a !== 'ifc-lite-server-win32-x64.zip'),
   });
   assertRed(result, /missing 1 of 6[\s\S]*ifc-lite-server-win32-x64\.zip/);
+});
+
+// ---- Tag-vs-path classification. `git show refs/tags/<tag>:<path>` reports
+// an absent path with TWO different messages ("does not exist in" when the
+// path is nowhere, "exists on disk, but not in" when the working tree has
+// it - the shape every real pre-package tag produces on a real checkout, and
+// the shape tagOmit reproduces). The checker once matched only the first
+// form, so a fetched tag that merely predated a file was misreported as an
+// unfetched one with a wrong remedy. The classification must be structural:
+// tag resolvability and path presence are separate questions, and neither
+// may quietly degrade into "no sidecars expected".
+
+releaseTest('release: a tag predating the workflow file is classified pre-sidecar, not a read failure', () => {
+  const result = runReleaseChecker({ tagOmit: ['workflow'], assets: ARCHIVES });
+  assertGreen(result);
+  assert.match(result.output, /tag predates checksum sidecars, none required/);
+});
+
+releaseTest('release: a tag predating platform.ts is red naming the real cause, never the fetch remedy', () => {
+  const result = runReleaseChecker({ tagOmit: ['platform'], assets: ARCHIVES });
+  assertRed(result, /platform\.ts does not exist at tag "v9\.9\.9"/);
+  assert.match(result.output, /predates/, 'the message must state the tag predates the file');
+  assert.ok(!result.output.includes('git fetch'), `the tag IS fetched; the fetch remedy is a lie here: ${result.output}`);
+  assert.ok(!result.output.includes('none required'), `a missing required file must never read as "nothing expected": ${result.output}`);
+});
+
+releaseTest('release: an unfetched tag stays a hard error with the fetch remedy, never pre-sidecar', () => {
+  const result = runReleaseChecker({ tag: 'v0.0.0-unfetched', assets: ARCHIVES });
+  assertRed(result, /tag "v0\.0\.0-unfetched" does not resolve locally/);
+  assert.match(result.output, /git fetch --depth=1 origin tag v0\.0\.0-unfetched/, 'the unfetched case must keep the fetch remedy');
+  assert.ok(!result.output.includes('predates'), `an unclassifiable tag must not be presented as pre-anything: ${result.output}`);
+});
+
+// The same two facts against a REAL tag, so the suite binds to real git
+// behaviour rather than only to the temp-repo simulation: v1.0.0 predates
+// packages/server-bin entirely. Skipped when the tag is not fetched (CI
+// checkouts are shallow and tagless); the temp-repo cases above always run.
+const v1TagResolves = spawnSync(
+  'git',
+  ['rev-parse', '--verify', '--quiet', 'refs/tags/v1.0.0^{commit}'],
+  { cwd: ROOT },
+).status === 0;
+const realTagTest = v1TagResolves ? test : test.skip;
+
+realTagTest('release: the real v1.0.0 tag (predates the package) is red with an accurate message', () => {
+  // Fails at the tag's platform.ts read, before any gh/network call.
+  const r = spawnSync(process.execPath, [CHECKER, '--root', ROOT, '--release', 'v1.0.0'], { encoding: 'utf8' });
+  const result = { code: r.status, output: `${r.stdout}${r.stderr}` };
+  assertRed(result, /packages\/server-bin\/src\/platform\.ts does not exist at tag "v1\.0\.0"/);
+  assert.match(result.output, /predates/);
+  assert.ok(!result.output.includes('git fetch'), `v1.0.0 is fetched; the fetch remedy is a lie here: ${result.output}`);
 });

--- a/scripts/check-server-bin-targets.test.mjs
+++ b/scripts/check-server-bin-targets.test.mjs
@@ -24,7 +24,7 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, chmodSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
@@ -47,14 +47,20 @@ const real = Object.fromEntries(
 const ASSET_EXPR = 'ifc-lite-server-${{ matrix.target }}.${{ matrix.archive }}';
 // eslint-disable-next-line no-template-curly-in-string
 const BRACED_ASSET_ARG = '"${asset}"';
+// eslint-disable-next-line no-template-curly-in-string
+const BRACED_SIDECAR_ARG = '"${sidecar}"';
 const ASSIGN_LINE = `          asset="${ASSET_EXPR}"`;
+const SIDECAR_ASSIGN_LINE = '          sidecar="$asset.sha256"';
 const WIN32_ENTRY =
   '          - target: win32-x64\n' +
   '            os: windows-latest\n' +
   '            rust-target: x86_64-pc-windows-msvc\n' +
   '            archive: zip\n';
-const RELEASE_UPLOAD = 'gh release upload "$RELEASE_TAG" "$asset" --clobber';
-const BACKFILL_UPLOAD = '            else\n              gh release upload "$RELEASE_TAG" "$asset"\n';
+// The two archive-carrying invocations are the same command at different
+// nesting depths; the indentation is what disambiguates them as anchors.
+const RELEASE_UPLOAD = '            gh release upload "$RELEASE_TAG" "$sidecar" "$asset" --clobber';
+const BACKFILL_UPLOAD = '              gh release upload "$RELEASE_TAG" "$sidecar" "$asset" --clobber';
+const SIDECAR_ONLY_UPLOAD = '                gh release upload "$RELEASE_TAG" "$sidecar"';
 
 /** Replace `from` with `to`, failing loudly if the anchor is not present. */
 function mutate(source, from, to) {
@@ -131,7 +137,7 @@ test('false green 4: uploading a different name than the $asset binding is red',
   const result = runChecker({
     workflow: (s) => mutate(s, RELEASE_UPLOAD, RELEASE_UPLOAD.replace('"$asset"', '"renamed-$asset"')),
   });
-  assertRed(result, /passes "renamed-\$asset" as its asset argument instead of "\$asset"/);
+  assertRed(result, /passes "renamed-\$asset" as an asset argument/);
 });
 
 // Same weakness class, backfill path: both invocations are bound, not just one.
@@ -139,7 +145,7 @@ test('backfill-path upload drifting from the $asset binding is red', () => {
   const result = runChecker({
     workflow: (s) => mutate(s, BACKFILL_UPLOAD, BACKFILL_UPLOAD.replace('"$asset"', '"$asset.bak"')),
   });
-  assertRed(result, /passes "\$asset\.bak" as its asset argument instead of "\$asset"/);
+  assertRed(result, /passes "\$asset\.bak" as an asset argument/);
 });
 
 // Same class: shell single quotes never expand, so '$asset' would upload a
@@ -148,7 +154,7 @@ test('single-quoted upload argument is red', () => {
   const result = runChecker({
     workflow: (s) => mutate(s, RELEASE_UPLOAD, RELEASE_UPLOAD.replace('"$asset"', "'$asset'")),
   });
-  assertRed(result, /passes '\$asset' as its asset argument/);
+  assertRed(result, /passes '\$asset' as an asset argument/);
 });
 
 // Same class: a correct first assignment followed by a rebinding would upload
@@ -166,6 +172,67 @@ test('commented-out asset= assignment is red', () => {
     workflow: (s) => mutate(s, ASSIGN_LINE, ASSIGN_LINE.replace('          asset=', '          # asset=')),
   });
   assertRed(result, /no longer assigns asset=/);
+});
+
+// ---- Checksum sidecars (issue: the fail-open branch in
+// packages/server-bin/src/checksum.ts was the ONLY branch that ever ran,
+// because no workflow published a sidecar). The gate now pins the sidecar
+// binding and refuses any upload that ships an archive without one.
+
+test('removing the sidecar= binding is red', () => {
+  const result = runChecker({
+    workflow: (s) => mutate(s, `${SIDECAR_ASSIGN_LINE}\n`, ''),
+  });
+  assertRed(result, /no longer assigns sidecar=/);
+});
+
+test('a sidecar binding naming anything but $asset.sha256 is red', () => {
+  const result = runChecker({
+    workflow: (s) => mutate(s, SIDECAR_ASSIGN_LINE, SIDECAR_ASSIGN_LINE.replace('.sha256', '.sha512')),
+  });
+  assertRed(result, /assigns sidecar="\$asset\.sha512" but the install-time verification .* fetches exactly "\$asset\.sha256"/);
+});
+
+test('a commented-out sidecar= binding is red', () => {
+  const result = runChecker({
+    workflow: (s) => mutate(s, SIDECAR_ASSIGN_LINE, SIDECAR_ASSIGN_LINE.replace('          sidecar=', '          # sidecar=')),
+  });
+  assertRed(result, /no longer assigns sidecar=/);
+});
+
+test('rebinding sidecar after the pinned assignment is red', () => {
+  const result = runChecker({
+    workflow: (s) => mutate(s, SIDECAR_ASSIGN_LINE, `${SIDECAR_ASSIGN_LINE}\n          sidecar="$asset.txt"`),
+  });
+  assertRed(result, /writes the sidecar variable 2 times/);
+});
+
+test('release-path upload shipping the archive without its sidecar is red', () => {
+  const result = runChecker({
+    workflow: (s) => mutate(s, RELEASE_UPLOAD, RELEASE_UPLOAD.replace(' "$sidecar"', '')),
+  });
+  assertRed(result, /uploads the archive without its checksum sidecar/);
+});
+
+test('backfill-path upload shipping the archive without its sidecar is red', () => {
+  const result = runChecker({
+    workflow: (s) => mutate(s, BACKFILL_UPLOAD, BACKFILL_UPLOAD.replace(' "$sidecar"', '')),
+  });
+  assertRed(result, /uploads the archive without its checksum sidecar/);
+});
+
+test('an upload argument that is neither $asset nor $sidecar is red', () => {
+  const result = runChecker({
+    workflow: (s) => mutate(s, SIDECAR_ONLY_UPLOAD, `${SIDECAR_ONLY_UPLOAD} "extra-file.txt"`),
+  });
+  assertRed(result, /passes "extra-file\.txt" as an asset argument/);
+});
+
+test('an upload argument that braces the sidecar variable is green', () => {
+  const result = runChecker({
+    workflow: (s) => mutate(s, RELEASE_UPLOAD, RELEASE_UPLOAD.replace('"$sidecar"', BRACED_SIDECAR_ARG)),
+  });
+  assertGreen(result);
 });
 
 // ---- The three false reds from the review: legitimate states that were
@@ -292,4 +359,104 @@ test('regression: renaming SUPPORTED_TARGETS fails closed', () => {
     platform: (s) => mutate(s, 'const SUPPORTED_TARGETS = new Set([', 'const SUPPORTED_TRIPLES = new Set(['),
   });
   assertRed(result, /cannot find the "const SUPPORTED_TARGETS = new Set\(\[\.\.\.\]\)" list .* update this check/);
+});
+
+// ---- --release mode: the expected asset set must include the .sha256
+// sidecars exactly when the TAG'S OWN workflow publishes them, so a release
+// missing a sidecar fails while historical pre-sidecar releases stay
+// verifiable without demanding assets they never claimed to ship. Exercised
+// black-box like everything above: a temp git repo carries the tag's inputs,
+// the working tree carries the workflow-ref inputs, and a fake `gh` on PATH
+// serves a canned asset list - no network, no real release. The shim is a
+// POSIX script, so these cases skip on Windows (CI runs them on ubuntu).
+
+const releaseTest = process.platform === 'win32' ? test.skip : test;
+
+const ARCHIVES = [
+  'ifc-lite-server-linux-x64.tar.gz',
+  'ifc-lite-server-linux-arm64.tar.gz',
+  'ifc-lite-server-linux-x64-musl.tar.gz',
+  'ifc-lite-server-darwin-x64.tar.gz',
+  'ifc-lite-server-darwin-arm64.tar.gz',
+  'ifc-lite-server-win32-x64.zip',
+];
+const SIDECARS = ARCHIVES.map((a) => `${a}.sha256`);
+
+// A tag whose workflow predates sidecar publishing: the real workflow with
+// the sidecar binding removed. mutate() asserts the anchor, so if the real
+// binding line drifts this simulation fails loudly instead of testing nothing.
+const preSidecarWorkflow = (s) => mutate(s, `${SIDECAR_ASSIGN_LINE}\n`, '');
+
+/**
+ * Commit (optionally mutated) inputs as tag v9.9.9 in a temp repo, restore
+ * the working tree to the real inputs (the workflow ref, exactly as on a
+ * real run), and run the checker in --release mode against a fake gh that
+ * reports `assets` as the release's asset names.
+ */
+function runReleaseChecker({ tagMutations = {}, assets }) {
+  const dir = mkdtempSync(join(tmpdir(), 'server-bin-gate-rel-'));
+  try {
+    for (const [key, rel] of Object.entries(INPUTS)) {
+      const target = join(dir, rel);
+      mkdirSync(dirname(target), { recursive: true });
+      writeFileSync(target, tagMutations[key] ? tagMutations[key](real[key]) : real[key]);
+    }
+    const git = (...args) => {
+      const r = spawnSync('git', args, { cwd: dir, encoding: 'utf8' });
+      assert.equal(r.status, 0, `git ${args.join(' ')} failed: ${r.stdout}${r.stderr}`);
+    };
+    git('init', '-q');
+    git('add', '-A');
+    git('-c', 'user.email=gate@test.invalid', '-c', 'user.name=gate', 'commit', '-qm', 'tag inputs');
+    git('tag', 'v9.9.9');
+    for (const [key, rel] of Object.entries(INPUTS)) {
+      writeFileSync(join(dir, rel), real[key]);
+    }
+    const bin = join(dir, 'fake-bin');
+    mkdirSync(bin);
+    writeFileSync(join(bin, 'assets.json'), JSON.stringify({ assets: assets.map((name) => ({ name })) }));
+    const shim = join(bin, 'gh');
+    writeFileSync(shim, '#!/bin/sh\ncat "$(dirname "$0")/assets.json"\n');
+    chmodSync(shim, 0o755);
+    const r = spawnSync(process.execPath, [CHECKER, '--root', dir, '--release', 'v9.9.9'], {
+      encoding: 'utf8',
+      env: { ...process.env, PATH: `${bin}:${process.env.PATH}` },
+    });
+    return { code: r.status, output: `${r.stdout}${r.stderr}` };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+releaseTest('release: a sidecar-publishing tag with archives plus sidecars is green', () => {
+  const result = runReleaseChecker({ assets: [...ARCHIVES, ...SIDECARS] });
+  assertGreen(result);
+  assert.match(result.output, /carries all 6 archives and 6 checksum sidecars/);
+});
+
+releaseTest('release: a sidecar-publishing tag missing every sidecar is red and names one', () => {
+  const result = runReleaseChecker({ assets: ARCHIVES });
+  assertRed(result, /missing 6 of 12[\s\S]*ifc-lite-server-win32-x64\.zip\.sha256/);
+});
+
+releaseTest('release: a sidecar-publishing tag missing a single sidecar is red and names exactly it', () => {
+  const result = runReleaseChecker({
+    assets: [...ARCHIVES, ...SIDECARS.filter((s) => !s.startsWith('ifc-lite-server-darwin-arm64'))],
+  });
+  assertRed(result, /missing 1 of 12[\s\S]*ifc-lite-server-darwin-arm64\.tar\.gz\.sha256/);
+  assert.ok(!result.output.includes('ifc-lite-server-linux-x64.tar.gz.sha256'), 'must not name sidecars that exist');
+});
+
+releaseTest('release: a pre-sidecar tag with archives only is green, sidecars not demanded', () => {
+  const result = runReleaseChecker({ tagMutations: { workflow: preSidecarWorkflow }, assets: ARCHIVES });
+  assertGreen(result);
+  assert.match(result.output, /tag predates checksum sidecars/);
+});
+
+releaseTest('release: a pre-sidecar tag missing an archive is still red', () => {
+  const result = runReleaseChecker({
+    tagMutations: { workflow: preSidecarWorkflow },
+    assets: ARCHIVES.filter((a) => a !== 'ifc-lite-server-win32-x64.zip'),
+  });
+  assertRed(result, /missing 1 of 6[\s\S]*ifc-lite-server-win32-x64\.zip/);
 });

--- a/scripts/lib/server-bin-tag-read.mjs
+++ b/scripts/lib/server-bin-tag-read.mjs
@@ -1,0 +1,79 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Tag-revision file reading for scripts/check-server-bin-targets.mjs.
+ *
+ * Three genuinely different situations, told apart STRUCTURALLY - never by
+ * matching git's English error text, because `git show` reports an absent
+ * path with two different messages ("does not exist in" vs "exists on disk,
+ * but not in", depending on the working tree) and matching only one of them
+ * misclassified a pre-package tag as an unfetched one:
+ *
+ *   1. The tag ref does not resolve locally (unfetched / shallow clone):
+ *      ERROR telling the operator to fetch it - never a fallback to the
+ *      checked-out tree, which would recreate the vacuous pass the caller
+ *      exists to prevent.
+ *   2. The tag resolves but the path is absent at that revision (ls-tree
+ *      answers with an empty listing): a FACT about the revision, not a
+ *      read failure. Surfaced as null when `optional` is set. For a
+ *      REQUIRED path it is still an ERROR - the tag predates the file (a
+ *      release cut before packages/server-bin existed has no server-bin
+ *      contract to verify) or the file has since moved. Deliberately NOT a
+ *      "nothing to verify" pass: were this path ever renamed on the
+ *      workflow ref, every older tag would lack the new path, and a quiet
+ *      pass here would green real releases while verifying nothing.
+ *   3. Any other git failure (corrupt object, git missing): ERROR.
+ *
+ * Executable proof: scripts/check-server-bin-targets.test.mjs (tag-vs-path
+ * classification cases, including one against the real v1.0.0 tag).
+ */
+
+import { execFileSync } from 'node:child_process';
+import { fail } from './server-bin-targets-parse.mjs';
+
+/** Run one git command against repoRoot, capturing output. Throws on failure. */
+function git(repoRoot, args) {
+  return execFileSync('git', args, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+/** Read one file at a release tag's own revision, per the rules above. */
+export function readFileAtTag(repoRoot, tag, path, { optional = false } = {}) {
+  try {
+    git(repoRoot, ['rev-parse', '--verify', '--quiet', `refs/tags/${tag}^{commit}`]);
+  } catch {
+    fail(
+      `tag "${tag}" does not resolve locally; fetch the tag first ` +
+      `(git fetch --depth=1 origin tag ${tag}) - refusing to fall back ` +
+      `to the checked-out tree, which may not be the tag's`,
+    );
+  }
+  let entry;
+  try {
+    entry = git(repoRoot, ['ls-tree', `refs/tags/${tag}`, '--', path]);
+  } catch (err) {
+    const detail = String(err?.stderr || err?.message || err).trim().split('\n')[0];
+    fail(`cannot list ${path} at tag "${tag}" via git ls-tree (${detail})`);
+  }
+  if (entry.trim() === '') {
+    if (optional) return null;
+    fail(
+      `${path} does not exist at tag "${tag}" - the tag is present locally and resolves; ` +
+      `the path is simply absent at that revision. Either the tag predates ${path} ` +
+      `(a release cut before packages/server-bin existed shipped no server binaries, so ` +
+      `there is nothing this check can verify for it), or the file has since moved and ` +
+      `this check must learn its location at that tag; refusing to guess`,
+    );
+  }
+  try {
+    return git(repoRoot, ['show', `refs/tags/${tag}:${path}`]);
+  } catch (err) {
+    const detail = String(err?.stderr || err?.message || err).trim().split('\n')[0];
+    fail(`cannot read ${path} at tag "${tag}" via git show (${detail})`);
+  }
+}

--- a/scripts/lib/server-bin-upload-check.mjs
+++ b/scripts/lib/server-bin-upload-check.mjs
@@ -1,0 +1,187 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Upload-step verification for scripts/check-server-bin-targets.mjs.
+ *
+ * The "Upload to GitHub Release" step of server-binaries.yml is the one place
+ * where the built archives and their SHA-256 sidecars become release assets,
+ * and the install-time resolver (packages/server-bin/src/platform.ts) plus
+ * the fail-closed checksum verification (packages/server-bin/src/checksum.ts)
+ * download those assets by exact name. This module pins that step:
+ *
+ *   - the asset name must be bound once, to the exact expression the
+ *     resolver downloads (UPLOAD_ASSET_EXPR);
+ *   - the sidecar name must be bound once, to "$asset.sha256" - the exact
+ *     name checksum.ts fetches. Before this binding existed, checksum.ts's
+ *     fail-open branch was the ONLY branch that ever executed: the code read
+ *     as verified while nothing was;
+ *   - every `gh release upload` argument must be one of those two bindings,
+ *     and an invocation that ships the archive must ship the sidecar with it,
+ *     so no path can ever publish an unverifiable archive again.
+ *
+ * `uploadStepPublishesSidecars` answers a different question with different
+ * strictness: does a given REVISION's workflow publish sidecars at all? It is
+ * used on a release tag's own workflow (via git show) to decide whether the
+ * release-asset check may demand sidecars, so for it an absent job, step or
+ * binding is a definite "no" (historical tags), never an error. That cannot
+ * silently weaken the gate for new releases because `checkUploadStep` - which
+ * DOES fail closed on all of those - runs against the current tree first on
+ * every path that reaches the detector.
+ *
+ * Inputs are comment-stripped by the caller (see server-bin-targets-parse.mjs
+ * for why). Executable proof: scripts/check-server-bin-targets.test.mjs.
+ */
+
+import { fail, jobBlock, unquoteScalar } from './server-bin-targets-parse.mjs';
+
+/**
+ * The exact expression the upload step must use for the archive filename.
+ * The resolver downloads `ifc-lite-server-<target>.<ext>`; pinning the
+ * workflow to this literal makes the two names provably identical instead
+ * of two hand-maintained strings that agree by luck.
+ */
+// The ${{ }} is a GitHub Actions expression pinned as a literal, not a JS template.
+// eslint-disable-next-line no-template-curly-in-string
+export const UPLOAD_ASSET_EXPR = 'ifc-lite-server-${{ matrix.target }}.${{ matrix.archive }}';
+
+/** The exact sidecar name checksum.ts fetches: "<asset>.sha256". */
+export const SIDECAR_EXPR = '$asset.sha256';
+
+const UPLOAD_STEP = 'Upload to GitHub Release';
+const JOB = 'release-server-binaries';
+
+/** Slice the upload step out of a job block, or null when absent. */
+function sliceUploadStep(jobBody) {
+  const stepStart = jobBody.indexOf(`- name: ${UPLOAD_STEP}`);
+  if (stepStart === -1) return null;
+  const rest = jobBody.slice(stepStart + 1);
+  const nextStep = /\n {6}- name:/.exec(rest);
+  return jobBody.slice(stepStart, nextStep ? stepStart + 1 + nextStep.index : jobBody.length);
+}
+
+/** Extract the upload step's block from the (comment-stripped) workflow. */
+function uploadStepBlock(workflow, origin) {
+  const step = sliceUploadStep(jobBlock(workflow, JOB, origin));
+  if (step === null) {
+    fail(
+      `cannot find the "${UPLOAD_STEP}" step in job "${JOB}" of ${origin}; ` +
+      `if the step was renamed, update this check - it must not pass without pinning the upload filenames`,
+    );
+  }
+  return step;
+}
+
+/**
+ * Require exactly one `<name>=` binding in the step, with the given value.
+ * A missing binding, a rebinding (`=` again or `+=`) and a drifted value are
+ * each their own failure, because each reopens a distinct hole: no name, a
+ * later name the pin never saw, or a wrong name with the pin intact.
+ */
+function checkBinding(step, origin, name, expectedValue, consumer, verb) {
+  const assigns = [...step.matchAll(new RegExp(`^[ \\t]*${name}(\\+?=)(.*)$`, 'gm'))];
+  if (assigns.length === 0) {
+    fail(
+      `the "${UPLOAD_STEP}" step in ${origin} no longer assigns ${name}=...; the step must ` +
+      `bind ${name} to "${expectedValue}", the exact name ${consumer} ${verb} - ` +
+      `if the script was restructured, update this check`,
+    );
+  }
+  if (assigns.length > 1) {
+    fail(
+      `the "${UPLOAD_STEP}" step in ${origin} writes the ${name} variable ${assigns.length} ` +
+      `times; a rebinding after the pinned assignment could upload a name nothing ever ` +
+      `downloads, so exactly one ${name}= line is allowed`,
+    );
+  }
+  const [, op, rawValue] = assigns[0];
+  const assigned = unquoteScalar(rawValue.trim());
+  if (op !== '=' || assigned !== expectedValue) {
+    fail(
+      `the "${UPLOAD_STEP}" step in ${origin} assigns ${name}${op}${rawValue.trim()} but ` +
+      `${consumer} ${verb} exactly "${expectedValue}"; the two must be identical`,
+    );
+  }
+}
+
+/**
+ * Normalise one shell token to compare against the pinned bindings: strip
+ * one layer of double quotes (single quotes never expand in bash, so they
+ * stay - '$asset' must remain red) and fold ${asset}/${sidecar} braces.
+ */
+function normaliseArg(token) {
+  return token
+    .replace(/^"(.*)"$/s, '$1')
+    .replace(/^\$\{(asset|sidecar)\}$/, (_, name) => `$${name}`);
+}
+
+/**
+ * The release upload step must bind the archive name to UPLOAD_ASSET_EXPR and
+ * the sidecar name to SIDECAR_EXPR, and every `gh release upload` invocation
+ * must pass only those bindings - with the sidecar accompanying the archive
+ * wherever the archive is shipped. Mere presence of the literals is not
+ * enough: a comment can carry the old name while the assignment or the upload
+ * argument drifts, and then every release 404s (archive) or every install
+ * fails closed (sidecar) while the gate blesses it.
+ */
+export function checkUploadStep(workflow, origin, platformTs) {
+  const step = uploadStepBlock(workflow, origin);
+
+  checkBinding(step, origin, 'asset', UPLOAD_ASSET_EXPR,
+    `the resolver in ${platformTs}`, 'downloads');
+  checkBinding(step, origin, 'sidecar', SIDECAR_EXPR,
+    'the install-time verification in packages/server-bin/src/checksum.ts', 'fetches');
+
+  const uploads = [...step.matchAll(/gh release upload[ \t]+([^\n]+)/g)];
+  let archiveCarrying = 0;
+  for (const [, rawArgs] of uploads) {
+    // First token is the tag; flags (--clobber) are not asset arguments.
+    const args = rawArgs.trim().split(/[ \t]+/).slice(1).filter((t) => !t.startsWith('-'));
+    const names = args.map(normaliseArg);
+    for (let i = 0; i < names.length; i++) {
+      if (names[i] !== '$asset' && names[i] !== '$sidecar') {
+        fail(
+          `a "gh release upload" invocation in the "${UPLOAD_STEP}" step of ${origin} passes ` +
+          `${args[i]} as an asset argument; only the pinned "$asset" and "$sidecar" bindings ` +
+          `provably upload the names the resolver in ${platformTs} downloads and checksum.ts verifies`,
+        );
+      }
+    }
+    if (names.includes('$asset')) {
+      archiveCarrying += 1;
+      if (!names.includes('$sidecar')) {
+        fail(
+          `a "gh release upload" invocation in the "${UPLOAD_STEP}" step of ${origin} uploads the ` +
+          `archive without its checksum sidecar; checksum.ts fails closed on a missing sidecar, so ` +
+          `every path that ships "$asset" must ship "$sidecar" with it`,
+        );
+      }
+    }
+  }
+  if (archiveCarrying < 2) {
+    fail(
+      `expected the release and backfill paths of the "${UPLOAD_STEP}" step in ${origin} ` +
+      `to each invoke "gh release upload <tag> ... $asset ..."; found ${archiveCarrying} ` +
+      `archive-carrying invocation(s) - if the step was restructured, update this check`,
+    );
+  }
+}
+
+/**
+ * Whether a workflow revision publishes checksum sidecars: true exactly when
+ * its upload step carries the pinned SIDECAR_EXPR binding. Deliberately
+ * lenient where checkUploadStep is strict - see the module header for why an
+ * absent job/step/binding is a definite "no" here, not an error.
+ */
+export function uploadStepPublishesSidecars(workflow) {
+  const job = new RegExp(`^  ${JOB}:[ \\t]*$`, 'm').exec(workflow);
+  if (!job) return false;
+  const bodyStart = job.index + job[0].length;
+  const next = /^  [A-Za-z0-9_-]+:/m.exec(workflow.slice(bodyStart));
+  const body = next ? workflow.slice(bodyStart, bodyStart + next.index) : workflow.slice(bodyStart);
+  const step = sliceUploadStep(body);
+  if (step === null) return false;
+  const assign = /^[ \t]*sidecar=(.*)$/m.exec(step);
+  return assign !== null && unquoteScalar(assign[1].trim()) === SIDECAR_EXPR;
+}


### PR DESCRIPTION
Closes the integrity gap surfaced while building #2642.

## Every server-bin install today verifies nothing

`packages/server-bin/src/checksum.ts` documents SHA-256 verification: fetch a `<asset>.sha256` (or a `SHA256SUMS` entry) from the same release, verify the archive, and on a missing sidecar "fail open (warn and proceed)".

**No workflow has ever published a sidecar.** `server-binaries.yml` uploaded only archives, so the fail-open branch is the only branch that has ever executed. `binary.ts` calls the checker before extract, chmod and execute, so in practice every `npx @ifc-lite/server-bin` install downloads and runs an unverified binary while the code reads as though a check exists.

That is worse than having no checksum code: it looks handled.

## Three parts

**1. Publish the sidecars.** A `shell: bash` step right after archive creation, on the same runner over the same bytes, writes `<asset>.sha256`. `sha256sum` where present, `shasum -a 256` on macOS, a hard error if neither, plus a format self-check on the emitted line. The upload puts the sidecar up **before** the archive, so there is no window in which a downloadable archive has no checksum.

Per-asset rather than an aggregated `SHA256SUMS`: an aggregate needs a fan-in job across six parallel legs and would have to be clobbered on every backfill, which fights the non-clobber guarantee #2642 just added. The client tries `.sha256` first anyway.

The logic is inline in the workflow rather than in a repo script, because the backfill checks out the *tag's* source where a new script would not exist, while the workflow itself always runs from the workflow ref.

**2. Backfill semantics, which are subtler than they look.** A healthy archive is never touched. When the archive is present but its sidecar is missing, the step hashes the **published bytes** (downloaded first) rather than the local rebuild: builds are not byte-reproducible, so hashing the rebuild would publish a checksum that does not match what users actually download, bricking every install of that version. When the archive is missing, sidecar and archive upload together.

This also retroactively arms old releases. Shipped fail-open clients already *look* for sidecars, so backfilling one upgrades existing v1.16.6-era installs to genuinely verified.

**3. Fail closed.** On a missing or mismatched checksum the archive is deleted and an error is thrown naming likely causes and alternatives.

The obvious objection is that this breaks installs against older sidecar-less releases. It does not, and the reason is worth stating: a published package version only ever downloads the release matching *its own* version (all three URL shapes in `binary.ts` use it). Every release cut at or after this change carries sidecars. Older releases are only ever fetched by older npm versions, whose fail-open code is already published and immutable. There is no supported combination that this breaks.

## The gate now expects sidecars, keyed off the tag

Making `--release` require sidecars naively would false-red against every historical tag. Instead the expectation is derived from **the tag's own workflow**: `git show refs/tags/<tag>:.github/workflows/server-binaries.yml`, detecting the pinned `sidecar="$asset.sha256"` binding.

It cannot silently pass. The default-mode gate fails the PR if that binding ever drifts on main, so the detector cannot be disarmed for future tags; absence at a tag is a definite "this revision never published sidecars", while an unreadable tag ref stays a hard error.

Verified against the real tag: `--release v1.16.6` correctly expects 6 archives and no sidecars, and stays honestly red only on the genuinely missing `ifc-lite-server-win32-x64.zip`, which is #2619's original hole and still unbackfilled.

## Verification

Every test was watched failing first.

| Mutation | Result |
| --- | --- |
| revert `checksum.ts` to fail-open | 7 tests red, incl. one pinning that the archive is deleted so an unverified download cannot be extracted or executed |
| run the new gate harness against the old checker | 28 of 37 red |

The harness also caught a real ambiguity mid-flight that I would not have found by reading: the new sidecar step's own `asset=` binding **absorbed four mutations** aimed at the pinned upload-step binding, so four cases went green that should have been red. Fixed by renaming the sidecar step's variable to `built`, with a comment saying why. That is the harness from #2642 earning its keep on the very next change.

All four upload branches were smoke-run locally against a stubbed `gh` with `bash -n` on the matrix-substituted scripts: release uploads sidecar-then-archive with `--clobber`; backfill leaves healthy pairs alone; the sidecar-only path provably hashed the published bytes (`7e5a2c...`) and not the rebuild (`6980a2...`).

Gates: root lint, typecheck (1089/1089), test (86/86), `check-api-surface` (checksum.ts is not exported, surface unchanged), `check-source-text-assertions` clean, gate harness 50/50, package suite 62/62.

## What only a real release can prove

Runner tool availability, `GITHUB_ENV` propagation and `gh` behaviour on real releases are confirmed by inspection, YAML parse and the local smoke harness, not by a live release run. The first real release, plus `verify-release-assets`, is what demonstrates it end to end.

Changeset: `@ifc-lite/server-bin` patch. No API change; this is behaviour hardening.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Downloads now require a valid SHA-256 checksum before installation.
  * Missing, unavailable, or mismatched checksums reject downloads before extraction or execution.

* **Release Improvements**
  * New server-binary releases publish checksum sidecar files alongside archives.
  * Release validation confirms each archive has a matching checksum.

* **Compatibility**
  * Older package versions retain their existing checksum behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->