### PR TITLE
test(parser): bound the gc-liveness probe by cycles, not wall clock (#2651)

### DIFF
--- a/packages/parser/test/source-compression-swap.test.ts
+++ b/packages/parser/test/source-compression-swap.test.ts
@@ -301,12 +301,21 @@ describe('the original buffer becomes collectable', () => {
     // proves that loop reports retention -- i.e. that the sibling CAN fail.
     const clearedAfter = await gcUntilCollected(probe);
 
+    // Read `leaked` HERE, before the assertion below, so the strong reference
+    // is provably live across the whole polling loop. Reading it only after
+    // the assertion would leave the keep-alive resting on the optimiser's
+    // liveness analysis reaching past an expect() that can throw; if that
+    // analysis ever let `leaked` die early, this control would report "the
+    // probe cannot detect retention" for the wrong reason and the sibling
+    // test would stop meaning anything without saying so.
+    const heldBytes = leaked.byteLength;
+    expect(heldBytes, 'the leaked reference must still address its bytes').toBeGreaterThan(0);
+
     // Held by `leaked`, so it must survive every cycle. If this ever fails,
     // the harness's gc semantics changed and the sibling test above has
     // stopped meaning anything -- this fails loudly instead of that passing
     // quietly.
     expect(clearedAfter, 'a strongly-held buffer was collected; the probe is broken')
       .toBe(null);
-    expect(leaked.byteLength).toBeGreaterThan(0);
   });
 });

--- a/packages/parser/test/source-compression-swap.test.ts
+++ b/packages/parser/test/source-compression-swap.test.ts
@@ -165,15 +165,64 @@ describe('in-place compression swap (#2183)', () => {
 /**
  * Liveness. Requires `--expose-gc`, and HARD-FAILS without it rather than
  * skipping: a lane that loses the flag must turn red, not quietly green.
+ *
+ * The property pinned here is "no live reference path reaches the original
+ * bytes after the swap". A structural check (`isResident === false`, the
+ * private view nulled) can only prove OUR field dropped its reference; the
+ * WeakRef probe proves nobody else kept one either -- a captured extractor, an
+ * internal alias, a cache -- which is the retention class #2183 exists to
+ * kill. That is why the probe stays despite costing a gc loop.
+ *
+ * Flake-hardening (#2651): this block used to run a FIXED 20 gc+yield cycles
+ * per wait under vitest's default 5000ms budget, and a contended CI runner
+ * (124s wall for a 64-file suite) turned both tests into bare timeouts.
+ * Reproduced locally at background QoS under full CPU load: 7.1s / 8.5s
+ * against the 5s budget, every other test in the file green. Now the wait
+ * exits as soon as the probe clears (1-3 cycles when healthy), the cycle
+ * bound -- not the wall clock -- is what detects failure, the failure message
+ * says what actually happened, and the two gc tests carry their own generous
+ * timeout so a starved runner cannot convert a pass into a timeout.
  */
 describe('the original buffer becomes collectable', () => {
   const gc = (globalThis as { gc?: () => void }).gc;
 
-  async function collect(): Promise<void> {
-    for (let i = 0; i < 20; i++) {
+  /**
+   * Forced-gc cycles before declaring the buffer retained. Node core's own
+   * gcUntil gives up after 10; 40 is generous for conservative-stack-scanning
+   * stragglers while keeping the failure path bounded. The healthy path exits
+   * after 1-3 cycles and never feels this number.
+   */
+  const MAX_GC_CYCLES = 40;
+
+  /**
+   * Wall-clock ceiling for the two gc tests ONLY (the rest of the file keeps
+   * the default). This is not the failure detector -- MAX_GC_CYCLES is -- it
+   * only stops a starved runner from turning a slow pass into a timeout. The
+   * reproduced worst case (background QoS, saturated CPU) ran the old fixed
+   * loop in ~8.5s; 30s clears that with margin even for the full 40-cycle
+   * failure path.
+   */
+  const LIVENESS_TIMEOUT_MS = 30_000;
+
+  /** One fresh macrotask turn, so each gc starts with the previous turn's
+   *  [[KeptAlive]] set (populated by `deref`) already cleared. */
+  const nextTurn = (): Promise<void> => new Promise((r) => setImmediate(r));
+
+  /**
+   * Force gc until the probe clears. Returns the number of cycles it took, or
+   * null when the probe survived all MAX_GC_CYCLES -- i.e. something still
+   * references the buffer. gc runs at the START of a fresh turn, BEFORE the
+   * `deref` in that turn: a `deref` pins its target until its turn ends, so
+   * gc-after-deref in one turn can never collect and the loop would spin its
+   * whole budget for nothing.
+   */
+  async function gcUntilCollected(probe: WeakRef<Uint8Array>): Promise<number | null> {
+    for (let cycle = 1; cycle <= MAX_GC_CYCLES; cycle++) {
+      await nextTurn();
       gc!();
-      await new Promise((r) => setImmediate(r));
+      if (probe.deref() === undefined) return cycle;
     }
+    return null;
   }
 
   it('exposes gc, or this whole file is decorative', () => {
@@ -202,24 +251,34 @@ describe('the original buffer becomes collectable', () => {
     return { store, probe: new WeakRef(view), payload: compressSource(view, 1024) };
   }
 
-  it('drops the resident buffer after the swap, while the store stays alive', async () => {
+  it('drops the resident buffer after the swap, while the store stays alive', {
+    timeout: LIVENESS_TIMEOUT_MS,
+  }, async () => {
     const { store, probe, payload } = await arrange();
 
     // CONTROL FIRST. If the probe cannot observe retention at all, the
-    // assertion below would pass for the wrong reason. Proving the detector
-    // works is what stops this being a test that cannot fail.
-    await collect();
-    expect(probe.deref(), 'control: the source still holds the buffer before the swap')
-      .not.toBe(undefined);
+    // assertion below would pass for the wrong reason. A few gc opportunities
+    // suffice: a strongly-held buffer can never be collected, the cycles only
+    // give gc a real chance to prove that. Checked as a boolean so the
+    // dereffed buffer never lands inside assertion internals that might
+    // retain it past this turn.
+    for (let i = 0; i < 5; i++) { gc!(); await nextTurn(); }
+    expect(
+      probe.deref() !== undefined,
+      'control: the source must still hold the buffer before the swap',
+    ).toBe(true);
 
     compressSourceInPlace(store.source, payload);
-    await collect();
+    const clearedAfter = await gcUntilCollected(probe);
 
     // THE assertion this whole feature rests on: nothing still reaches the
     // original bytes, so the 275 MB is genuinely returned rather than merely
     // duplicated into blocks.
-    expect(probe.deref(), 'the original source buffer is still reachable after the swap')
-      .toBe(undefined);
+    expect(
+      clearedAfter,
+      `the original source buffer was still reachable after ${MAX_GC_CYCLES} forced gc `
+      + 'cycles -- something still references the pre-swap bytes',
+    ).not.toBe(null);
 
     // ...and the store, still strongly held, keeps working from blocks.
     expect(store.source.isResident).toBe(false);
@@ -228,21 +287,26 @@ describe('the original buffer becomes collectable', () => {
     expect(store.getProperties?.(1)).toBeDefined();
   });
 
-  it('a deliberately leaked reference SURVIVES gc (proves the probe detects retention)', async () => {
+  it('a deliberately leaked reference SURVIVES gc (proves the probe detects retention)', {
+    timeout: LIVENESS_TIMEOUT_MS,
+  }, async () => {
     const bytes = new TextEncoder().encode(STEP.repeat(200));
     const store = await parsedStore(bytes);
     const leaked = store.source.materialize();
     const probe = new WeakRef(leaked);
 
     compressSourceInPlace(store.source, compressSource(leaked, 1024));
-    await collect();
     // `leaked` is deliberately still in scope here -- that is the point.
+    // Drive the EXACT loop the sibling test uses to declare victory, so this
+    // proves that loop reports retention -- i.e. that the sibling CAN fail.
+    const clearedAfter = await gcUntilCollected(probe);
 
-    // Held by `leaked`, so it must NOT be collected. If this ever fails, the
-    // harness's gc semantics changed and the sibling test above has stopped
-    // meaning anything -- this fails loudly instead of that passing quietly.
-    expect(probe.deref(), 'a strongly-held buffer was collected; the probe is broken')
-      .not.toBe(undefined);
+    // Held by `leaked`, so it must survive every cycle. If this ever fails,
+    // the harness's gc semantics changed and the sibling test above has
+    // stopped meaning anything -- this fails loudly instead of that passing
+    // quietly.
+    expect(clearedAfter, 'a strongly-held buffer was collected; the probe is broken')
+      .toBe(null);
     expect(leaked.byteLength).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
Closes #2651

## The flake, reproduced

`packages/parser/test/source-compression-swap.test.ts` timed out at 5000ms on a PR whose diff never touched `packages/parser`.

Reproduced locally, which matters because the fix depends on knowing *why* it times out. Plain CPU load was not enough: 40 busy loops took the tests from 100ms to 360ms, still green. Pinning the vitest process to background QoS (`taskpolicy -c background`) while saturating the CPU produced the exact CI signature: only the two GC tests fail, at 7119ms and 8497ms, every other test in the file green. The reported CI job shows the same shape, a 64-file parser suite taking 124s wall with 211s import time, i.e. a starved runner.

The mechanism: the probe ran a **fixed** 20 `gc()` + `setImmediate` cycles per wait, three waits per test, so 60 forced full GCs regardless of whether the buffer had already been collected. On a healthy runner that is wasted work; on a starved one it blows the 5s default budget.

## Why not just raise the timeout

Because that treats the symptom. A GC-liveness probe racing a wall clock is nondeterministic by construction: a bigger budget makes it fail less often on a contended runner without making the check correct, and the next contended runner brings it back.

## The property being pinned

Worth stating precisely, because it decides the whole design. The tests are not asserting "V8 collected it" for its own sake. They assert **no live reference path anywhere reaches the original resident buffer after `compressInPlace`** — a property of our code. The `WeakRef` probe is the only formulation that covers retention paths the code does not own, such as a captured extractor or an internal alias. That is exactly the #2183 bug class, where whole-source retention pinned about 950MB.

## The fix

Keep the probe, fix its mechanics:

- `gcUntilCollected(probe)` returns the cycle count as soon as the probe clears (1 to 3 cycles on a healthy runner, previously always 20), or `null` after `MAX_GC_CYCLES = 40`. For scale, Node core's own `gcUntil` gives up at 10.
- `gc()` runs at the **start** of a fresh macrotask turn, before any `deref`. This is load-bearing: a `deref` pins its target via `[[KeptAlive]]` until its turn ends, so a gc issued after a `deref` can never collect the thing being probed.
- **The failure detector is now the cycle bound, not the clock**, with a message that says what happened: `still reachable after 40 forced gc cycles -- something still references the pre-swap bytes`. A bare vitest timeout told the next person nothing.
- The leaked-reference control test drives the **same** loop and asserts it returns `null`, so the proof that the main test *can* fail exercises the exact detector path rather than a parallel one.
- `{ timeout: 30_000 }` is scoped to the two GC tests only, and the comment states plainly that it is not the detector, just anti-starvation headroom above the 8.5s worst case actually measured.

## Verification

Both directions red-verified, since a fix that quietly disables the test would be worse than the flake:

| Mutation | Result |
| --- | --- |
| test leaks the view to `globalThis` | red: `the original source buffer was still reachable after 40 forced gc cycles ... expected null not to be null` |
| shipped source stashes the old `#view` before nulling (retention with `isResident` false) | red, same assertion |

Under the reproduction harness after the fix: 9/9 green, test 1 at 694ms (was a 7119ms timeout), test 2 at 4144ms (was 8497ms), both well inside the narrow budget.

## Rejected alternatives

- **Structural-only assertion** (`isResident === false` plus the view nulled): deterministic but strictly weaker. It proves our field dropped its reference and is blind to every other holder, which is the coverage #2183 exists for. It remains as a secondary assertion; promoting it to primary would trade away the point of the suite.
- **`FinalizationRegistry`**: same GC-timing dependence with less controllable callback scheduling. No gain.
- **`v8.getHeapStatistics()` deltas**: the ~120KB fixture is far below heap-noise amplitude, and the measure is itself GC-timing-dependent. Strictly worse.

**Coverage traded away: none.** Residual nondeterminism is inherent, since V8's conservative stack scanning means "collected within N cycles" cannot be a hard guarantee. It is now bounded by cycles rather than by wall clock, generous at 4x Node core's bound, and self-describing when it fails.

No other liveness suites exist in the repo: the only other `FinalizationRegistry` mentions are comments about wasm-bindgen handle ownership.

Test-only change, so no changeset. Gates: typecheck 1097/1097, test 86/86, lint 0 errors, source-text-assertions, test-wiring and test-typecheck all clean.
