### PR TITLE
fix(geometry): return coaxial_union.rs to its 704-line budget

### DIFF
--- a/rust/geometry/src/router/voids/coaxial_union.rs
+++ b/rust/geometry/src/router/voids/coaxial_union.rs
@@ -332,7 +332,7 @@ impl GeometryRouter {
         if !span_lo.is_finite() || !span_hi.is_finite() || (span_hi - span_lo) <= NORMALIZE_EPSILON {
             return None;
         }
-        let z_tol = (span_hi - span_lo) * 0.01 + 1.0e-3; // 1% of span + 1 mm; >=1mm makes the depth test above redundant for finite spans
+        let z_tol = (span_hi - span_lo) * 0.01 + 1.0e-3; // 1% of span + 1 mm; the >=1mm floor is what makes the later slab-depth check defensive
 
         // Depth breakpoints = every cutter's z_lo / z_hi, sorted and coalesced
         // within z_tol. The intervals between consecutive breakpoints are the slabs.

--- a/rust/geometry/src/router/voids/coaxial_union.rs
+++ b/rust/geometry/src/router/voids/coaxial_union.rs
@@ -329,13 +329,10 @@ impl GeometryRouter {
         // Total depth span + a tolerance for coalescing near-identical z-boundaries.
         let span_lo = fps.iter().map(|f| f.z_lo).fold(f64::INFINITY, f64::min);
         let span_hi = fps.iter().map(|f| f.z_hi).fold(f64::NEG_INFINITY, f64::max);
-        // `z_tol` (computed below) is at least 1 mm; later breakpoint
-        // coalescing makes this depth check redundant for finite spans, but
-        // the finite/degenerate check itself stays explicit.
         if !span_lo.is_finite() || !span_hi.is_finite() || (span_hi - span_lo) <= NORMALIZE_EPSILON {
             return None;
         }
-        let z_tol = (span_hi - span_lo) * 0.01 + 1.0e-3; // 1% of the span + 1 mm
+        let z_tol = (span_hi - span_lo) * 0.01 + 1.0e-3; // 1% of span + 1 mm; >=1mm makes the depth test above redundant for finite spans
 
         // Depth breakpoints = every cutter's z_lo / z_hi, sorted and coalesced
         // within z_tol. The intervals between consecutive breakpoints are the slabs.
@@ -368,8 +365,7 @@ impl GeometryRouter {
         let mut contributed = vec![false; fps.len()];
         for w in coalesced.windows(2) {
             let (slab_lo, slab_hi) = (w[0], w[1]);
-            let slab_depth = slab_hi - slab_lo;
-            // Coalesced breakpoints already differ by more than `z_tol`.
+            let slab_depth = slab_hi - slab_lo; // coalesced breakpoints already differ by > `z_tol`
             if slab_depth <= NORMALIZE_EPSILON {
                 continue;
             }
@@ -634,10 +630,7 @@ fn cutter_footprint(
         z_lo = z_lo.min(s);
         z_hi = z_hi.max(s);
     }
-    // Reject a degenerate projected depth. `cutter_footprint` has no
-    // `z_tol` of its own — the caller applies it when it coalesces depth
-    // breakpoints across footprints.
-    if !z_lo.is_finite() || !z_hi.is_finite() || (z_hi - z_lo) <= NORMALIZE_EPSILON {
+    if !z_lo.is_finite() || !z_hi.is_finite() || (z_hi - z_lo) <= NORMALIZE_EPSILON { // no `z_tol` here; the caller applies it when coalescing breakpoints
         return None;
     }
     for t in mesh.indices.chunks_exact(3) {
@@ -684,9 +677,7 @@ fn cutter_footprint(
         .sum();
     let area = 0.5 * cap_area_sum;
     let depth = z_hi - z_lo;
-    // `z_tol` applies only to depth. Keep the area guard separate: the
-    // 1 mm depth floor does not establish an area lower bound.
-    if area <= NORMALIZE_EPSILON || depth <= NORMALIZE_EPSILON {
+    if area <= NORMALIZE_EPSILON || depth <= NORMALIZE_EPSILON { // `z_tol` bounds depth only; area guard stays separate
         return None;
     }
     // PRISM RECONCILIATION: a true prism along `d` satisfies `area × depth ==

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -189,7 +189,7 @@
 # commits, while a through-cut of a host thicker than the opening is not mistaken for one.
 # +9 (#2616): doc-only comments recording the z_tol coalescing rationale at the
 # depth-guard call sites; no code change.
-     713 rust/geometry/src/router/voids/coaxial_union.rs
+     704 rust/geometry/src/router/voids/coaxial_union.rs
 # probe.rs +134: the 2D bool-path host/opening extraction — `extruded_solid_from_item`
 # (unwrap IfcMappedItem chains to a single IfcExtrudedAreaSolid + composed transform),
 # `host_extruded_solid` and `opening_extruded_solids` (single-body eligibility gates).


### PR DESCRIPTION
Undoes a module-size budget raise I made in #2616, without losing the documentation it added.

## What went wrong

#2616 (`3ec3304a0`) added nine lines of doc comment to `rust/geometry/src/router/voids/coaxial_union.rs` and paid for them by moving the allowlist entry **704 -> 713**.

That is the exact pattern the ratchet exists to prevent, and I blocked #2628 for the same thing a few hours later. Budgets may only stay flat or shrink. Buying room with a raise freezes debt, and it passes CI silently because the ratchet only compares actual-against-allowlist, so a raise is always green.

Worth stating plainly since it affects how much the gate can be trusted: this landed on `main` reviewed and green. The gate cannot catch it by construction.

## What this does

Nothing is deleted. The four tolerance notes are folded into **trailing comments on the lines they describe**, which costs zero lines:

- the `z_tol` rationale joins the existing trailing comment on the `z_tol` assignment
- the coalesced-breakpoint note becomes a trailing comment on `slab_depth`
- the `cutter_footprint` depth-guard and area-guard notes become trailing comments on their own guards

File is now exactly **704**, and the allowlist entry returns to **704**.

An em dash that the same commit introduced goes with it, per the house writing style.

## Verified

- `cargo test -p ifc-lite-processing --no-fail-fast --test module_size_ratchet` -> **4 tests genuinely ran, 4 passed**. Checked the count deliberately: a name filter matching zero tests also exits 0 and proves nothing, which caught me out earlier today.
- `cargo clippy -p ifc-lite-geometry --all-targets -- -D warnings` -> exit 0
- `cargo test -p ifc-lite-geometry --no-fail-fast` -> exit 0

## Related

The same sweep found `scripts/source-text-assertion-allowlist.txt` grew 5 -> 6 entries via #2531, for the same structural reason: `check-source-text-assertions.mjs` fails on new offenders and on stale entries, but *adding* a line is a clean pass. That one is not addressed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified technical comments describing depth tolerance handling and the separation of depth and area validation in coaxial geometry processing.
  * Improved the maintainability and readability of internal geometry-processing documentation without changing functionality.
* **Chores**
  * Updated internal size-tracking metadata to reflect the reduced implementation size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->