### PR TITLE
fix(viewer): fold MeshData.origin into compare's world bounds

### DIFF
--- a/apps/viewer/src/lib/compare/describeChange.test.ts
+++ b/apps/viewer/src/lib/compare/describeChange.test.ts
@@ -220,6 +220,34 @@ describe('describeChange - resolved material', () => {
   });
 });
 
+describe('describeChange - a meshed element moved under the wasm local frame (#2529)', () => {
+  it('reports the move when the translation is carried only by MeshData.origin', async () => {
+    // Local-frame contract (rust/geometry/src/router/transforms/mod.rs, default
+    // ON for wasm): world vertex = origin + position, and origin is the
+    // element's AABB centre, so it follows the element. A pure translation
+    // leaves `positions` byte-identical - the panel used to answer
+    // "movedDistance 0, reshaped false" for an element that moved 40 m.
+    const cube = (origin: [number, number, number]) => ({
+      expressId: 1,
+      positions: new Float32Array([-0.5, -0.5, -0.5, 0.5, -0.5, -0.5, 0.5, 0.5, 0.5]),
+      origin,
+    });
+    const entry = modifiedEntry('IfcWall');
+    entry.changeKinds = ['geometry'];
+    const models = new Map<string, FederatedModel>([
+      ['A', { geometryResult: { meshes: [cube([10, 2, 3])] } } as unknown as FederatedModel],
+      ['B', { geometryResult: { meshes: [cube([50, 2, 3])] } } as unknown as FederatedModel],
+    ]);
+    const detail = describeChange(entry, models);
+    assert.ok(detail?.geometry, 'a geometry change must be described');
+    assert.ok(
+      Math.abs(detail!.geometry!.movedDistance - 40) < 1e-6,
+      `element moved 40 m via origin only; got ${detail!.geometry!.movedDistance}`,
+    );
+    assert.strictEqual(detail!.geometry!.reshaped, false, 'a pure translation is not a reshape');
+  });
+});
+
 describe('describeChange - a geometry-less product that was re-georeferenced', () => {
   /** A site under a two-link placement chain; `parentY`/`childY` split its
    *  world Y between the root link and its own. Representation is `$`, so it

--- a/apps/viewer/src/lib/compare/describeChange.test.ts
+++ b/apps/viewer/src/lib/compare/describeChange.test.ts
@@ -9,16 +9,19 @@ import type { DiffEntry } from '@ifc-lite/diff';
 import type { FederatedModel } from '../../store/types.js';
 import type { CompareRef } from './buildFingerprints.js';
 import { describeChange } from './describeChange.js';
-import { summarizeGeometryChange, type Aabb } from './geometrySummary.js';
+import { summarizeGeometryChange, type WorldAabb } from './geometrySummary.js';
 
-const box = (min: [number, number, number], max: [number, number, number]): Aabb => ({ min, max });
+// `summarizeGeometryChange` requires the world brand (#2659): these fixtures
+// are authored directly in the absolute world frame.
+const box = (min: [number, number, number], max: [number, number, number]): WorldAabb =>
+  ({ frame: 'world', min, max });
 
 describe('summarizeGeometryChange (#1197)', () => {
   it('reports no move and no reshape for an identical bounding box', () => {
     // The wall that "moved 1.09 m" had an identical bbox between revisions — a
     // re-tessellation dragged the old *vertex-weighted* centroid, not the box.
     const b = box([0, 0, 0], [3, 0.3, 2.7]);
-    const summary = summarizeGeometryChange(b, { min: [...b.min] as [number, number, number], max: [...b.max] as [number, number, number] });
+    const summary = summarizeGeometryChange(b, box([...b.min] as [number, number, number], [...b.max] as [number, number, number]));
     assert.ok(summary);
     assert.strictEqual(summary!.movedDistance, 0, 'identical box must not read as moved');
     assert.strictEqual(summary!.reshaped, false);

--- a/apps/viewer/src/lib/compare/describeChange.ts
+++ b/apps/viewer/src/lib/compare/describeChange.ts
@@ -31,6 +31,7 @@ import { isGeometricDataName } from './geometricData.js';
 import {
   meshBounds,
   placementMoveSummary,
+  renderToWorldShift,
   summarizeGeometryChange,
   type GeometrySummary,
 } from './geometrySummary.js';
@@ -261,8 +262,16 @@ function geometrySummary(
   b: FederatedModel | undefined,
   bRef: CompareRef,
 ): GeometrySummary | null {
-  const ba = a?.geometryResult ? meshBounds(a.geometryResult.meshes, aRef.globalId) : null;
-  const bb = b?.geometryResult ? meshBounds(b.geometryResult.meshes, bRef.globalId) : null;
+  // Each side folds its OWN model's render-to-world shift: the two revisions
+  // may have chosen different RTC offsets, and a side that lost its wasm box
+  // to the NaN drop must land in the same absolute frame as a side that kept
+  // it (#2659).
+  const ba = a?.geometryResult
+    ? meshBounds(a.geometryResult.meshes, aRef.globalId, renderToWorldShift(a.geometryResult.coordinateInfo))
+    : null;
+  const bb = b?.geometryResult
+    ? meshBounds(b.geometryResult.meshes, bRef.globalId, renderToWorldShift(b.geometryResult.coordinateInfo))
+    : null;
   // No boxes to compare. For a pair that is geometry-less on BOTH sides (the
   // summary checks `ref.meshed` — missing boxes alone also describe a
   // GPU-instanced entity, which must stay on the box path), the geometry

--- a/apps/viewer/src/lib/compare/exportReport.test.ts
+++ b/apps/viewer/src/lib/compare/exportReport.test.ts
@@ -570,6 +570,96 @@ describe('buildCompareReport - a geometry-less product that moved', () => {
   });
 });
 
+describe('buildCompareReport moved distance under the wasm local frame (#2529)', () => {
+  // The wasm pipeline defaults local-frame ON: `MeshData.positions` are
+  // relative to a per-element `origin` that FOLLOWS the element (it is the
+  // element's AABB centre). A pure translation therefore leaves `positions`
+  // unchanged and moves only `origin` - and the report's bounds index summed
+  // raw positions, so a genuinely moved element exported
+  // `Change = "Geometry changed", MovedDistance_m = 0`. All of this path's
+  // original fixtures built meshes without `origin`, which is why the number
+  // was wrong in the one artifact people archive and believe.
+  const cube = (origin: [number, number, number]) => ({
+    expressId: 1,
+    positions: new Float32Array([
+      -0.5, -0.5, -0.5,
+      0.5, -0.5, -0.5,
+      0.5, 0.5, 0.5,
+    ]),
+    origin,
+  });
+  const fingerprint = (modelId: string) => ({
+    key: '2movedmovedmovedmoved0',
+    ifcType: 'IfcWall',
+    dataHash: 'd',
+    ref: { modelId, localId: 1, globalId: 1 },
+  });
+  const result = {
+    baseModelId: 'a',
+    headModelId: 'b',
+    baseName: 'A',
+    headName: 'B',
+    scope: 'both',
+    geometryUnavailable: false,
+    excludedHiddenIds: new Set<number>(),
+    diff: {
+      scope: 'both',
+      excludedTypes: [],
+      entries: [
+        {
+          key: '2movedmovedmovedmoved0',
+          state: 'modified',
+          changeKinds: ['geometry'],
+          base: fingerprint('a'),
+          head: fingerprint('b'),
+        },
+      ],
+      byKey: new Map(),
+      counts: { added: 0, modified: 1, deleted: 0, unchanged: 0 },
+    },
+  } as unknown as CompareResult;
+
+  it('writes Moved with the true distance when only the per-element origin moved', () => {
+    const models = new Map([
+      ['a', { geometryResult: { meshes: [cube([10, 2, 3])] } } as unknown as FederatedModel],
+      ['b', { geometryResult: { meshes: [cube([50, 2, 3])] } } as unknown as FederatedModel],
+    ]);
+    const report = buildCompareReport(result, models);
+    assert.strictEqual(report.rows.length, 1);
+    assert.strictEqual(report.rows[0].change, 'Moved');
+    assert.ok(
+      Math.abs(report.rows[0].movedDistance - 40) < 1e-6,
+      `element moved 40 m via origin only; got MovedDistance_m = ${report.rows[0].movedDistance}`,
+    );
+    // The CSV is where the wrong number was most likely believed.
+    const lines = reportToCsv(report).split('\r\n');
+    assert.ok(
+      lines[1].includes(',Moved,40.0000,'),
+      `CSV must carry the 40 m distance, got ${JSON.stringify(lines[1])}`,
+    );
+  });
+
+  it('still reports a reshape when the mesh changed under a non-zero origin', () => {
+    const grown = {
+      ...cube([10, 2, 3]),
+      positions: new Float32Array([
+        -1.5, -0.5, -0.5,
+        0.5, -0.5, -0.5,
+        0.5, 0.5, 0.5,
+      ]),
+    };
+    const models = new Map([
+      ['a', { geometryResult: { meshes: [cube([10, 2, 3])] } } as unknown as FederatedModel],
+      ['b', { geometryResult: { meshes: [grown] } } as unknown as FederatedModel],
+    ]);
+    const report = buildCompareReport(result, models);
+    assert.ok(
+      report.rows[0].change.includes('Reshaped'),
+      `a 1 m growth must stay a reshape, got ${JSON.stringify(report.rows[0].change)}`,
+    );
+  });
+});
+
 describe('buildCompareReport products vs type objects (headline split)', () => {
   const ref = (modelId: string, id: number) => ({ modelId, localId: id, globalId: id });
   const fingerprint = (modelId: string, key: string, id: number, ifcType: string) => ({

--- a/apps/viewer/src/lib/compare/exportReport.ts
+++ b/apps/viewer/src/lib/compare/exportReport.ts
@@ -31,8 +31,9 @@ import {
 import {
   meshBoundsIndex,
   placementMoveSummary,
+  renderToWorldShift,
   summarizeGeometryChange,
-  type Aabb,
+  type WorldAabb,
 } from './geometrySummary.js';
 import { downloadBlob, sanitizeFilename } from '../export/download.js';
 
@@ -71,14 +72,20 @@ export interface CompareReport {
   rows: CompareReportRow[];
 }
 
-/** One pass over a model's meshes -> federation-globalId -> AABB. Delegates to
- *  `meshBoundsIndex` so this path and the detail panel's `meshBounds` share
- *  one world-bounds computation - a private copy of that loop here is how the
- *  report summed raw `positions` without the per-element `origin` fold and
- *  wrote `MovedDistance_m = 0` for a genuinely moved element (#2529). */
-function boundsIndex(model: FederatedModel | undefined): Map<number, Aabb> {
+/** One pass over a model's meshes -> federation-globalId -> absolute world
+ *  AABB. Delegates to `meshBoundsIndex` so this path and the detail panel's
+ *  `meshBounds` share one world-bounds computation - a private copy of that
+ *  loop here is how the report summed raw `positions` without the per-element
+ *  `origin` fold and wrote `MovedDistance_m = 0` for a genuinely moved element
+ *  (#2529). Folds THIS model's render-to-world shift so a box measured from
+ *  positions lands in the same absolute frame as a wasm `geometryAabb` on the
+ *  other side (#2659). */
+function boundsIndex(model: FederatedModel | undefined): Map<number, WorldAabb> {
   if (!model?.geometryResult) return new Map();
-  return meshBoundsIndex(model.geometryResult.meshes);
+  return meshBoundsIndex(
+    model.geometryResult.meshes,
+    renderToWorldShift(model.geometryResult.coordinateInfo),
+  );
 }
 
 /** The side actually reported for an entry: base for deletions, head otherwise. */
@@ -111,8 +118,8 @@ function reportKey(entry: DiffEntry<CompareRef>): string {
 /** Classify a modified entry's change kinds into a human label + move distance. */
 function classifyModified(
   entry: DiffEntry<CompareRef>,
-  baseBounds: Map<number, Aabb>,
-  headBounds: Map<number, Aabb>,
+  baseBounds: Map<number, WorldAabb>,
+  headBounds: Map<number, WorldAabb>,
   baseModel: FederatedModel | undefined,
   headModel: FederatedModel | undefined,
 ): { change: string; movedDistance: number } {

--- a/apps/viewer/src/lib/compare/exportReport.ts
+++ b/apps/viewer/src/lib/compare/exportReport.ts
@@ -28,7 +28,12 @@ import {
   exportedGlobalId,
   type CompareReportRow,
 } from './reportRows.js';
-import { placementMoveSummary, summarizeGeometryChange, type Aabb } from './geometrySummary.js';
+import {
+  meshBoundsIndex,
+  placementMoveSummary,
+  summarizeGeometryChange,
+  type Aabb,
+} from './geometrySummary.js';
 import { downloadBlob, sanitizeFilename } from '../export/download.js';
 
 export type { CompareReportRow } from './reportRows.js';
@@ -66,31 +71,14 @@ export interface CompareReport {
   rows: CompareReportRow[];
 }
 
-/** Mutable AABB accumulator. */
-interface Box { minX: number; minY: number; minZ: number; maxX: number; maxY: number; maxZ: number }
-
-/** One pass over a model's meshes → federation-globalId → AABB. */
+/** One pass over a model's meshes -> federation-globalId -> AABB. Delegates to
+ *  `meshBoundsIndex` so this path and the detail panel's `meshBounds` share
+ *  one world-bounds computation - a private copy of that loop here is how the
+ *  report summed raw `positions` without the per-element `origin` fold and
+ *  wrote `MovedDistance_m = 0` for a genuinely moved element (#2529). */
 function boundsIndex(model: FederatedModel | undefined): Map<number, Aabb> {
-  const out = new Map<number, Aabb>();
-  if (!model?.geometryResult) return out;
-  const acc = new Map<number, Box>();
-  for (const mesh of model.geometryResult.meshes) {
-    let box = acc.get(mesh.expressId);
-    if (!box) {
-      box = { minX: Infinity, minY: Infinity, minZ: Infinity, maxX: -Infinity, maxY: -Infinity, maxZ: -Infinity };
-      acc.set(mesh.expressId, box);
-    }
-    const p = mesh.positions;
-    for (let i = 0; i < p.length; i += 3) {
-      const x = p[i], y = p[i + 1], z = p[i + 2];
-      if (x < box.minX) box.minX = x; if (y < box.minY) box.minY = y; if (z < box.minZ) box.minZ = z;
-      if (x > box.maxX) box.maxX = x; if (y > box.maxY) box.maxY = y; if (z > box.maxZ) box.maxZ = z;
-    }
-  }
-  for (const [id, b] of acc) {
-    out.set(id, { min: [b.minX, b.minY, b.minZ], max: [b.maxX, b.maxY, b.maxZ] });
-  }
-  return out;
+  if (!model?.geometryResult) return new Map();
+  return meshBoundsIndex(model.geometryResult.meshes);
 }
 
 /** The side actually reported for an entry: base for deletions, head otherwise. */

--- a/apps/viewer/src/lib/compare/geometrySummary.test.ts
+++ b/apps/viewer/src/lib/compare/geometrySummary.test.ts
@@ -4,8 +4,14 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import type { MeshData } from '@ifc-lite/geometry';
-import { meshBounds, meshBoundsIndex, summarizeGeometryChange, type Aabb } from './geometrySummary.js';
+import type { CoordinateInfo, MeshData } from '@ifc-lite/geometry';
+import {
+  meshBounds,
+  meshBoundsIndex,
+  renderToWorldShift,
+  summarizeGeometryChange,
+  type Aabb,
+} from './geometrySummary.js';
 
 /**
  * `MeshData.positions` are per-element LOCAL-frame coordinates on the wasm
@@ -42,12 +48,29 @@ const UNIT_CUBE = [
   -0.5, 0.5, 0.5,
 ];
 
+/** An un-georeferenced model: its render frame IS the world frame. */
+const NO_SHIFT = renderToWorldShift(undefined);
+
+/** A georeferenced model's `CoordinateInfo`: the wasm pass subtracted `rtc`
+ *  (recorded in IFC Z-up axes) from every position. Bounds are irrelevant to
+ *  the shift and left empty. */
+function geoInfo(rtc: { x: number; y: number; z: number }): CoordinateInfo {
+  const zero = { x: 0, y: 0, z: 0 };
+  return {
+    originShift: zero,
+    originalBounds: { min: zero, max: zero },
+    shiftedBounds: { min: zero, max: zero },
+    hasLargeCoordinates: true,
+    wasmRtcOffset: rtc,
+  };
+}
+
 describe('meshBounds folds MeshData.origin (#2529 regression)', () => {
   it('reports a pure translation carried only by origin as a move with the true distance', () => {
     // Identical positions on both sides; only the per-element origin moved,
     // exactly what the wasm local-frame pipeline emits for a moved element.
-    const ba = meshBounds([mesh(7, UNIT_CUBE, { origin: [10, 2, 3] })], 7);
-    const bb = meshBounds([mesh(7, UNIT_CUBE, { origin: [50, 2, 3] })], 7);
+    const ba = meshBounds([mesh(7, UNIT_CUBE, { origin: [10, 2, 3] })], 7, NO_SHIFT);
+    const bb = meshBounds([mesh(7, UNIT_CUBE, { origin: [50, 2, 3] })], 7, NO_SHIFT);
     assert.ok(ba && bb, 'both sides must produce a box');
     const summary = summarizeGeometryChange(ba, bb)!;
     assert.ok(
@@ -66,8 +89,8 @@ describe('meshBounds folds MeshData.origin (#2529 regression)', () => {
       0.5, 0.5, 0.5,
       -0.5, 0.5, 0.5,
     ];
-    const ba = meshBounds([mesh(7, UNIT_CUBE, { origin: [10, 2, 3] })], 7);
-    const bb = meshBounds([mesh(7, grown, { origin: [10, 2, 3] })], 7);
+    const ba = meshBounds([mesh(7, UNIT_CUBE, { origin: [10, 2, 3] })], 7, NO_SHIFT);
+    const bb = meshBounds([mesh(7, grown, { origin: [10, 2, 3] })], 7, NO_SHIFT);
     const summary = summarizeGeometryChange(ba, bb)!;
     assert.strictEqual(summary.reshaped, true, 'the box grew 1 m in x - that is a reshape');
     assert.ok(Math.abs(summary.sizeDelta.x - 1) < 1e-6, `sizeDelta.x = ${summary.sizeDelta.x}`);
@@ -77,8 +100,8 @@ describe('meshBounds folds MeshData.origin (#2529 regression)', () => {
     // The local frame exists precisely so f32 positions stay element-small at
     // georef scale; the fold must do the world reconstruction in f64 and keep
     // a 40 m move readable next to a 4,200 km coordinate.
-    const ba = meshBounds([mesh(7, UNIT_CUBE, { origin: [4200000, 30, 5100000] })], 7);
-    const bb = meshBounds([mesh(7, UNIT_CUBE, { origin: [4200040, 30, 5100000] })], 7);
+    const ba = meshBounds([mesh(7, UNIT_CUBE, { origin: [4200000, 30, 5100000] })], 7, NO_SHIFT);
+    const bb = meshBounds([mesh(7, UNIT_CUBE, { origin: [4200040, 30, 5100000] })], 7, NO_SHIFT);
     const summary = summarizeGeometryChange(ba, bb)!;
     assert.ok(
       Math.abs(summary.movedDistance - 40) < 1e-6,
@@ -93,7 +116,8 @@ describe('meshBounds folds MeshData.origin (#2529 regression)', () => {
       mesh(7, [0, -2, 0, 0, 2, 0], { origin: [10, 0, 0] }),
       mesh(8, [100, 100, 100], { origin: [1000, 0, 0] }), // different element
     ];
-    assert.deepStrictEqual(meshBounds(meshes, 7), {
+    assert.deepStrictEqual(meshBounds(meshes, 7, NO_SHIFT), {
+      frame: 'world',
       min: [9.5, -2, 0],
       max: [10.5, 2, 0],
     });
@@ -108,22 +132,103 @@ describe('meshBounds folds MeshData.origin (#2529 regression)', () => {
       origin: [10, 2, 3],
       geometryAabb: { min: [109.5, 1.5, 2.5], max: [110.5, 2.5, 3.5] },
     });
-    assert.deepStrictEqual(meshBounds([withBox], 7), {
+    assert.deepStrictEqual(meshBounds([withBox], 7, NO_SHIFT), {
+      frame: 'world',
       min: [109.5, 1.5, 2.5],
       max: [110.5, 2.5, 3.5],
     });
   });
 
   it('returns null for an absent entity and for an entity with empty positions', () => {
-    assert.strictEqual(meshBounds([mesh(7, UNIT_CUBE)], 99), null);
-    assert.strictEqual(meshBounds([mesh(7, [])], 7), null);
+    assert.strictEqual(meshBounds([mesh(7, UNIT_CUBE)], 99, NO_SHIFT), null);
+    assert.strictEqual(meshBounds([mesh(7, [])], 7, NO_SHIFT), null);
   });
 
   it('treats absent origin as world positions (legacy / native meshes)', () => {
-    assert.deepStrictEqual(meshBounds([mesh(7, [1, 2, 3, 5, 6, 7])], 7), {
+    assert.deepStrictEqual(meshBounds([mesh(7, [1, 2, 3, 5, 6, 7])], 7, NO_SHIFT), {
+      frame: 'world',
       min: [1, 2, 3],
       max: [5, 6, 7],
     });
+  });
+});
+
+describe('mixed frames: one-sided geometryAabb on a georeferenced model (#2659)', () => {
+  // The RTC offset the wasm pass subtracted, in IFC Z-up axes. As a Y-up
+  // render-to-world shift that is (x, z, -y) = (4200000, 0, -5100000), so
+  // absolute world = origin + positions + shift. Both revisions here chose
+  // the same RTC.
+  const TO_WORLD = renderToWorldShift(geoInfo({ x: 4200000, y: 5100000, z: 0 }));
+
+  it('reports the element movement, not the RTC offset, when only one side kept its box', () => {
+    // Base kept its wasm box (absolute world). Head is the supported NaN-drop
+    // case: hashed, but the box was dropped at the boundary
+    // (`geometry-fingerprints.ts` resolves a NaN sentinel to undefined), so it
+    // falls back to origin + positions. The element really moved 2 m in x.
+    // Without lifting the fallback into the absolute frame, the head side
+    // stays RTC-relative and the "movement" is the 6,600 km RTC offset.
+    const ba = meshBounds(
+      [mesh(7, UNIT_CUBE, { geometryAabb: { min: [4200009.5, 1.5, -5099997.5], max: [4200010.5, 2.5, -5099996.5] } })],
+      7,
+      TO_WORLD,
+    );
+    const bb = meshBounds([mesh(7, UNIT_CUBE, { origin: [12, 2, 3] })], 7, TO_WORLD);
+    assert.ok(ba && bb, 'both sides must produce a box');
+    const summary = summarizeGeometryChange(ba, bb)!;
+    assert.ok(
+      Math.abs(summary.movedDistance - 2) < 1e-6,
+      `element moved 2 m; a mixed-frame comparison fabricates the RTC offset instead - got movedDistance = ${summary.movedDistance}`,
+    );
+    assert.strictEqual(summary.reshaped, false, 'a pure translation is not a reshape');
+  });
+
+  it('folds each revision its OWN shift when neither side has a box and the RTC choices differ', () => {
+    // Fallback vs fallback across two revisions that chose different RTC
+    // offsets: each side is relative to its own frame, so comparing them raw
+    // reports the frame difference, not the element. Real movement: 2 m in x.
+    const toWorldA = { x: 1000, y: 0, z: 0 } as const;
+    const toWorldB = { x: 2000, y: 0, z: 0 } as const;
+    const ba = meshBounds([mesh(7, UNIT_CUBE, { origin: [5, 0, 0] })], 7, toWorldA); // abs 1005
+    const bb = meshBounds([mesh(7, UNIT_CUBE, { origin: [-993, 0, 0] })], 7, toWorldB); // abs 1007
+    const summary = summarizeGeometryChange(ba, bb)!;
+    assert.ok(
+      Math.abs(summary.movedDistance - 2) < 1e-6,
+      `element moved 2 m across differing RTC choices; got movedDistance = ${summary.movedDistance}`,
+    );
+  });
+
+  it('keeps the both-sided geometryAabb comparison unchanged (boxes already absolute)', () => {
+    // When BOTH sides carry the wasm box the shift must not be applied to
+    // them - they are already absolute - so the answer is exactly the box
+    // delta regardless of the model shift passed alongside.
+    const ba = meshBounds(
+      [mesh(7, UNIT_CUBE, { origin: [10, 2, 3], geometryAabb: { min: [4200009.5, 1.5, -5099997.5], max: [4200010.5, 2.5, -5099996.5] } })],
+      7,
+      TO_WORLD,
+    );
+    const bb = meshBounds(
+      [mesh(7, UNIT_CUBE, { origin: [12, 2, 3], geometryAabb: { min: [4200011.5, 1.5, -5099997.5], max: [4200012.5, 2.5, -5099996.5] } })],
+      7,
+      TO_WORLD,
+    );
+    const summary = summarizeGeometryChange(ba, bb)!;
+    assert.ok(
+      Math.abs(summary.movedDistance - 2) < 1e-6,
+      `box-vs-box distance must stay 2 m; got ${summary.movedDistance}`,
+    );
+  });
+});
+
+describe('renderToWorldShift', () => {
+  it('composes originShift with the Z-up-to-Y-up-swapped RTC offset', () => {
+    // reproject.ts contract: world_yup = render + originShift + (rtc.x, rtc.z, -rtc.y).
+    const info = geoInfo({ x: 100, y: 200, z: 300 });
+    const shifted: CoordinateInfo = { ...info, originShift: { x: 1, y: 2, z: 3 } };
+    assert.deepStrictEqual(renderToWorldShift(shifted), { x: 101, y: 302, z: -197 });
+  });
+
+  it('answers the zero shift for a model with no coordinate info', () => {
+    assert.deepStrictEqual(renderToWorldShift(undefined), { x: 0, y: 0, z: 0 });
   });
 });
 
@@ -138,9 +243,23 @@ describe('meshBoundsIndex (the bulk-report twin, #2529)', () => {
       }),
       mesh(9, []),
     ];
-    const index = meshBoundsIndex(meshes);
-    assert.deepStrictEqual(index.get(7), meshBounds(meshes, 7));
-    assert.deepStrictEqual(index.get(8), meshBounds(meshes, 8));
+    const index = meshBoundsIndex(meshes, NO_SHIFT);
+    assert.deepStrictEqual(index.get(7), meshBounds(meshes, 7, NO_SHIFT));
+    assert.deepStrictEqual(index.get(8), meshBounds(meshes, 8, NO_SHIFT));
     assert.strictEqual(index.has(9), false, 'an entity with no vertices gets no box');
+  });
+
+  it('folds the render-to-world shift exactly like meshBounds (#2659 binds both paths)', () => {
+    // The bulk CSV must not disagree with the detail panel about the frame:
+    // same georeferenced shift, same absolute box.
+    const toWorld = renderToWorldShift(geoInfo({ x: 4200000, y: 5100000, z: 0 }));
+    const meshes = [mesh(7, UNIT_CUBE, { origin: [12, 2, 3] })];
+    const indexed = meshBoundsIndex(meshes, toWorld).get(7);
+    assert.deepStrictEqual(indexed, meshBounds(meshes, 7, toWorld));
+    assert.deepStrictEqual(indexed, {
+      frame: 'world',
+      min: [4200011.5, 1.5, -5099997.5],
+      max: [4200012.5, 2.5, -5099996.5],
+    });
   });
 });

--- a/apps/viewer/src/lib/compare/geometrySummary.test.ts
+++ b/apps/viewer/src/lib/compare/geometrySummary.test.ts
@@ -1,0 +1,146 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import type { MeshData } from '@ifc-lite/geometry';
+import { meshBounds, meshBoundsIndex, summarizeGeometryChange, type Aabb } from './geometrySummary.js';
+
+/**
+ * `MeshData.positions` are per-element LOCAL-frame coordinates on the wasm
+ * path: world vertex i = `origin + positions[3i..3i+3]`, and the local frame
+ * is the DEFAULT there (`rust/geometry/src/router/transforms/mod.rs`). The
+ * origin is the element's AABB centre, so it FOLLOWS the element: a pure
+ * translation leaves `positions` byte-identical and moves only `origin`.
+ *
+ * `meshBounds` summed raw `positions`, so a genuinely moved element reported
+ * `movedDistance = 0, reshaped = false` - no "Moved" badge in the panel and
+ * `MovedDistance_m = 0` in the bulk CSV that #2529 extracted this logic into.
+ * Every fixture in #2529's tests built meshes WITHOUT `origin`, which is why
+ * the gap was invisible. These fixtures carry one.
+ */
+
+function mesh(
+  expressId: number,
+  positions: readonly number[],
+  extras: { origin?: [number, number, number]; geometryAabb?: Aabb } = {},
+): MeshData {
+  return {
+    expressId,
+    positions: new Float32Array(positions),
+    ...extras,
+  } as unknown as MeshData;
+}
+
+/** Unit cube centred on its own local origin - the shape the wasm local frame
+ *  produces (origin = element AABB centre, positions relative to it). */
+const UNIT_CUBE = [
+  -0.5, -0.5, -0.5,
+  0.5, -0.5, -0.5,
+  0.5, 0.5, 0.5,
+  -0.5, 0.5, 0.5,
+];
+
+describe('meshBounds folds MeshData.origin (#2529 regression)', () => {
+  it('reports a pure translation carried only by origin as a move with the true distance', () => {
+    // Identical positions on both sides; only the per-element origin moved,
+    // exactly what the wasm local-frame pipeline emits for a moved element.
+    const ba = meshBounds([mesh(7, UNIT_CUBE, { origin: [10, 2, 3] })], 7);
+    const bb = meshBounds([mesh(7, UNIT_CUBE, { origin: [50, 2, 3] })], 7);
+    assert.ok(ba && bb, 'both sides must produce a box');
+    const summary = summarizeGeometryChange(ba, bb)!;
+    assert.ok(
+      Math.abs(summary.movedDistance - 40) < 1e-6,
+      `element moved 40 m via origin only; got movedDistance = ${summary.movedDistance}`,
+    );
+    assert.strictEqual(summary.reshaped, false, 'a pure translation is not a reshape');
+  });
+
+  it('still detects a reshape when origin is non-zero (not everything reads as moved)', () => {
+    // Same origin both sides; the mesh itself grew 1 m in local x. The fold
+    // must not blur a real shape change into a phantom move-only answer.
+    const grown = [
+      -1.5, -0.5, -0.5,
+      0.5, -0.5, -0.5,
+      0.5, 0.5, 0.5,
+      -0.5, 0.5, 0.5,
+    ];
+    const ba = meshBounds([mesh(7, UNIT_CUBE, { origin: [10, 2, 3] })], 7);
+    const bb = meshBounds([mesh(7, grown, { origin: [10, 2, 3] })], 7);
+    const summary = summarizeGeometryChange(ba, bb)!;
+    assert.strictEqual(summary.reshaped, true, 'the box grew 1 m in x - that is a reshape');
+    assert.ok(Math.abs(summary.sizeDelta.x - 1) < 1e-6, `sizeDelta.x = ${summary.sizeDelta.x}`);
+  });
+
+  it('keeps precision at georeferenced world coordinates (origin is f64)', () => {
+    // The local frame exists precisely so f32 positions stay element-small at
+    // georef scale; the fold must do the world reconstruction in f64 and keep
+    // a 40 m move readable next to a 4,200 km coordinate.
+    const ba = meshBounds([mesh(7, UNIT_CUBE, { origin: [4200000, 30, 5100000] })], 7);
+    const bb = meshBounds([mesh(7, UNIT_CUBE, { origin: [4200040, 30, 5100000] })], 7);
+    const summary = summarizeGeometryChange(ba, bb)!;
+    assert.ok(
+      Math.abs(summary.movedDistance - 40) < 1e-6,
+      `expected 40 m at georef scale, got ${summary.movedDistance}`,
+    );
+    assert.strictEqual(summary.reshaped, false);
+  });
+
+  it('unions all submeshes of the entity and ignores other entities', () => {
+    const meshes = [
+      mesh(7, [-0.5, 0, 0, 0.5, 0, 0], { origin: [10, 0, 0] }),
+      mesh(7, [0, -2, 0, 0, 2, 0], { origin: [10, 0, 0] }),
+      mesh(8, [100, 100, 100], { origin: [1000, 0, 0] }), // different element
+    ];
+    assert.deepStrictEqual(meshBounds(meshes, 7), {
+      min: [9.5, -2, 0],
+      max: [10.5, 2, 0],
+    });
+  });
+
+  it('prefers the wasm world box (geometryAabb) over folding positions', () => {
+    // `geometryAabb` is ABSOLUTE world - RTC offset AND origin already folded
+    // (see `MeshData.geometryAabb` / buildFingerprints.ts). Two revisions that
+    // chose different RTC offsets agree only through it, so when the hashing
+    // pass produced one it must win over any locally folded box.
+    const withBox = mesh(7, UNIT_CUBE, {
+      origin: [10, 2, 3],
+      geometryAabb: { min: [109.5, 1.5, 2.5], max: [110.5, 2.5, 3.5] },
+    });
+    assert.deepStrictEqual(meshBounds([withBox], 7), {
+      min: [109.5, 1.5, 2.5],
+      max: [110.5, 2.5, 3.5],
+    });
+  });
+
+  it('returns null for an absent entity and for an entity with empty positions', () => {
+    assert.strictEqual(meshBounds([mesh(7, UNIT_CUBE)], 99), null);
+    assert.strictEqual(meshBounds([mesh(7, [])], 7), null);
+  });
+
+  it('treats absent origin as world positions (legacy / native meshes)', () => {
+    assert.deepStrictEqual(meshBounds([mesh(7, [1, 2, 3, 5, 6, 7])], 7), {
+      min: [1, 2, 3],
+      max: [5, 6, 7],
+    });
+  });
+});
+
+describe('meshBoundsIndex (the bulk-report twin, #2529)', () => {
+  it('agrees with meshBounds for every entity, origin fold included', () => {
+    const meshes = [
+      mesh(7, UNIT_CUBE, { origin: [10, 2, 3] }),
+      mesh(7, [0, -2, 0, 0, 2, 0], { origin: [10, 2, 3] }),
+      mesh(8, UNIT_CUBE, {
+        origin: [50, 0, 0],
+        geometryAabb: { min: [49.5, -0.5, -0.5], max: [50.5, 0.5, 0.5] },
+      }),
+      mesh(9, []),
+    ];
+    const index = meshBoundsIndex(meshes);
+    assert.deepStrictEqual(index.get(7), meshBounds(meshes, 7));
+    assert.deepStrictEqual(index.get(8), meshBounds(meshes, 8));
+    assert.strictEqual(index.has(9), false, 'an entity with no vertices gets no box');
+  });
+});

--- a/apps/viewer/src/lib/compare/geometrySummary.ts
+++ b/apps/viewer/src/lib/compare/geometrySummary.ts
@@ -39,23 +39,101 @@ const RESHAPE_EPS = 1e-3;
 /** Axis-aligned bounding box in the renderer world frame. */
 export interface Aabb { min: readonly [number, number, number]; max: readonly [number, number, number] }
 
-/** Axis-aligned bounding box of an entity's meshes (renderer world frame). */
+/** Mutable AABB accumulator for {@link meshBounds} / {@link meshBoundsIndex}. */
+interface Box { minX: number; minY: number; minZ: number; maxX: number; maxY: number; maxZ: number }
+
+function emptyBox(): Box {
+  return { minX: Infinity, minY: Infinity, minZ: Infinity, maxX: -Infinity, maxY: -Infinity, maxZ: -Infinity };
+}
+
+/**
+ * Fold one mesh's vertices into `box`, reconstructing the world coordinate.
+ *
+ * `positions` are NOT world on the wasm path: the pipeline defaults to a
+ * per-element local frame (`rust/geometry/src/router/transforms/mod.rs`), so
+ * world vertex i = `origin + positions[3i..3i+3]`, and `origin` is the
+ * element's AABB centre - it FOLLOWS the element. Summing raw positions
+ * therefore reported a pure translation as `movedDistance = 0` (the panel
+ * showed no move, the bulk CSV wrote `MovedDistance_m = 0`): only `origin`
+ * moved, and the positions were byte-identical. The exact trap
+ * `buildFingerprints.ts` documents against.
+ */
+function foldMeshWorldPositions(mesh: MeshData, box: Box): void {
+  const o = mesh.origin;
+  const ox = o?.[0] ?? 0, oy = o?.[1] ?? 0, oz = o?.[2] ?? 0;
+  const p = mesh.positions;
+  for (let i = 0; i < p.length; i += 3) {
+    const x = p[i] + ox, y = p[i + 1] + oy, z = p[i + 2] + oz;
+    if (x < box.minX) box.minX = x; if (y < box.minY) box.minY = y; if (z < box.minZ) box.minZ = z;
+    if (x > box.maxX) box.maxX = x; if (y > box.maxY) box.maxY = y; if (z > box.maxZ) box.maxZ = z;
+  }
+}
+
+/** A folded accumulator as an {@link Aabb}, or null when nothing was folded. */
+function finishBox(box: Box): Aabb | null {
+  if (box.minX === Infinity) return null;
+  return { min: [box.minX, box.minY, box.minZ], max: [box.maxX, box.maxY, box.maxZ] };
+}
+
+/** The wasm pass's whole-entity world box as an {@link Aabb} copy. */
+function fromEntityAabb(aabb: { min: readonly number[]; max: readonly number[] }): Aabb {
+  return {
+    min: [aabb.min[0], aabb.min[1], aabb.min[2]],
+    max: [aabb.max[0], aabb.max[1], aabb.max[2]],
+  };
+}
+
+/**
+ * Axis-aligned bounding box of an entity's meshes (renderer world frame).
+ *
+ * Prefers `MeshData.geometryAabb` - the whole-entity ABSOLUTE world box from
+ * the wasm hashing pass, RTC offset and per-element `origin` already folded in
+ * (all submeshes of an entity carry the identical box). It is the same box
+ * `buildFingerprints.ts` feeds the diff engine, and the only one that stays
+ * comparable when two revisions chose different RTC offsets. When the pass
+ * produced no box (hashing off, older cache, NaN sentinel dropped), the
+ * fallback folds `origin + positions` per vertex - origin-correct, though
+ * still RTC-relative like the positions themselves.
+ */
 export function meshBounds(meshes: readonly MeshData[], globalId: number): Aabb | null {
-  let any = false;
-  let minX = Infinity, minY = Infinity, minZ = Infinity;
-  let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
+  let box: Box | null = null;
   for (const mesh of meshes) {
     if (mesh.expressId !== globalId) continue;
-    const p = mesh.positions;
-    for (let i = 0; i < p.length; i += 3) {
-      const x = p[i], y = p[i + 1], z = p[i + 2];
-      any = true;
-      if (x < minX) minX = x; if (y < minY) minY = y; if (z < minZ) minZ = z;
-      if (x > maxX) maxX = x; if (y > maxY) maxY = y; if (z > maxZ) maxZ = z;
-    }
+    if (mesh.geometryAabb) return fromEntityAabb(mesh.geometryAabb);
+    foldMeshWorldPositions(mesh, box ??= emptyBox());
   }
-  if (!any) return null;
-  return { min: [minX, minY, minZ], max: [maxX, maxY, maxZ] };
+  return box ? finishBox(box) : null;
+}
+
+/**
+ * One pass over a model's meshes -> express id -> entity world {@link Aabb}.
+ * The bulk-report twin of {@link meshBounds} (#1202): SAME per-mesh fold and
+ * same `geometryAabb` preference, shared so the two cannot drift - a private
+ * copy of this loop is how the report path missed the `origin` fold that
+ * `meshBounds`'s contract requires (#2529).
+ */
+export function meshBoundsIndex(meshes: readonly MeshData[]): Map<number, Aabb> {
+  const resolved = new Map<number, Aabb>();
+  const acc = new Map<number, Box>();
+  for (const mesh of meshes) {
+    if (resolved.has(mesh.expressId)) continue;
+    if (mesh.geometryAabb) {
+      resolved.set(mesh.expressId, fromEntityAabb(mesh.geometryAabb));
+      acc.delete(mesh.expressId);
+      continue;
+    }
+    let box = acc.get(mesh.expressId);
+    if (!box) acc.set(mesh.expressId, box = emptyBox());
+    foldMeshWorldPositions(mesh, box);
+  }
+  for (const [id, box] of acc) {
+    const aabb = finishBox(box);
+    // An entity whose meshes carried no vertices gets NO box - indexing the
+    // empty accumulator would hand `summarizeGeometryChange` an Infinity box
+    // and a NaN distance, where `meshBounds` answers null.
+    if (aabb) resolved.set(id, aabb);
+  }
+  return resolved;
 }
 
 /**

--- a/apps/viewer/src/lib/compare/geometrySummary.ts
+++ b/apps/viewer/src/lib/compare/geometrySummary.ts
@@ -13,7 +13,7 @@
  * a second copy would eventually drop on one side.
  */
 
-import type { MeshData } from '@ifc-lite/geometry';
+import type { CoordinateInfo, MeshData } from '@ifc-lite/geometry';
 import type { FederatedModel } from '../../store/types.js';
 import type { CompareRef } from './buildFingerprints.js';
 import { composeWorldPlacement } from './worldPlacement.js';
@@ -36,8 +36,50 @@ const MOVE_EPS = 2e-3;
 /** Per-axis bounding-box size change above this counts as a reshape. */
 const RESHAPE_EPS = 1e-3;
 
-/** Axis-aligned bounding box in the renderer world frame. */
+/**
+ * Axis-aligned bounding box in the renderer's Y-up axes. The bare shape says
+ * nothing about WHICH frame its numbers are in - and two boxes in different
+ * frames look exactly alike at a call site, which is how one side of a
+ * comparison ended up absolute world while the other stayed RTC-relative -
+ * so this module only ever hands out the branded {@link WorldAabb}.
+ */
 export interface Aabb { min: readonly [number, number, number]; max: readonly [number, number, number] }
+
+/**
+ * An {@link Aabb} whose coordinates are ABSOLUTE world (Y-up): the model's
+ * RTC offset and origin shift folded in, the frame `MeshData.geometryAabb`
+ * is contracted to be in. The `frame` tag is a real runtime field, not a
+ * phantom brand: an untagged box in an unstated frame does not typecheck
+ * where a `WorldAabb` is required, and a debugger shows what a box claims
+ * to be.
+ */
+export interface WorldAabb extends Aabb { readonly frame: 'world' }
+
+/** The Y-up translation that lifts a model's render-frame coordinates
+ *  (`origin + positions`) into the absolute world frame - see
+ *  {@link renderToWorldShift}. */
+export interface RenderToWorldShift { readonly x: number; readonly y: number; readonly z: number }
+
+/**
+ * A model's render-to-world shift, read off its `CoordinateInfo`:
+ *
+ *   world_yup = render + originShift + rtcAsYup,  rtcAsYup = (rtc.x, rtc.z, -rtc.y)
+ *
+ * (`wasmRtcOffset` is recorded in IFC Z-up axes; `originShift` is already
+ * Y-up). The same composition as `federationAlign.ts`'s `totalYupOffset` and
+ * `scanSectionMath.ts`'s `pointCloudRenderFrameShift`, both derived from
+ * `reproject.ts`. Absent info (or absent offsets) means the render frame IS
+ * the world frame - the zero shift keeps un-georeferenced models bit-exact.
+ */
+export function renderToWorldShift(info: CoordinateInfo | undefined): RenderToWorldShift {
+  const shift = info?.originShift;
+  const rtc = info?.wasmRtcOffset;
+  return {
+    x: (shift?.x ?? 0) + (rtc?.x ?? 0),
+    y: (shift?.y ?? 0) + (rtc?.z ?? 0),
+    z: (shift?.z ?? 0) - (rtc?.y ?? 0),
+  };
+}
 
 /** Mutable AABB accumulator for {@link meshBounds} / {@link meshBoundsIndex}. */
 interface Box { minX: number; minY: number; minZ: number; maxX: number; maxY: number; maxZ: number }
@@ -47,20 +89,27 @@ function emptyBox(): Box {
 }
 
 /**
- * Fold one mesh's vertices into `box`, reconstructing the world coordinate.
+ * Fold one mesh's vertices into `box`, reconstructing the ABSOLUTE world
+ * coordinate.
  *
  * `positions` are NOT world on the wasm path: the pipeline defaults to a
  * per-element local frame (`rust/geometry/src/router/transforms/mod.rs`), so
- * world vertex i = `origin + positions[3i..3i+3]`, and `origin` is the
+ * render vertex i = `origin + positions[3i..3i+3]`, and `origin` is the
  * element's AABB centre - it FOLLOWS the element. Summing raw positions
  * therefore reported a pure translation as `movedDistance = 0` (the panel
  * showed no move, the bulk CSV wrote `MovedDistance_m = 0`): only `origin`
  * moved, and the positions were byte-identical. The exact trap
  * `buildFingerprints.ts` documents against.
+ *
+ * `origin + positions` is still only the RENDER frame (RTC/origin shift
+ * subtracted); `toWorld` lifts it into the absolute frame `geometryAabb`
+ * lives in, so a box folded here is comparable with a wasm box on the other
+ * side. All arithmetic in f64: origin and shift are f64, so a 2 m move stays
+ * readable next to a 6,600 km coordinate.
  */
-function foldMeshWorldPositions(mesh: MeshData, box: Box): void {
+function foldMeshWorldPositions(mesh: MeshData, box: Box, toWorld: RenderToWorldShift): void {
   const o = mesh.origin;
-  const ox = o?.[0] ?? 0, oy = o?.[1] ?? 0, oz = o?.[2] ?? 0;
+  const ox = (o?.[0] ?? 0) + toWorld.x, oy = (o?.[1] ?? 0) + toWorld.y, oz = (o?.[2] ?? 0) + toWorld.z;
   const p = mesh.positions;
   for (let i = 0; i < p.length; i += 3) {
     const x = p[i] + ox, y = p[i + 1] + oy, z = p[i + 2] + oz;
@@ -69,38 +118,56 @@ function foldMeshWorldPositions(mesh: MeshData, box: Box): void {
   }
 }
 
-/** A folded accumulator as an {@link Aabb}, or null when nothing was folded. */
-function finishBox(box: Box): Aabb | null {
+/** A folded accumulator as a {@link WorldAabb}, or null when nothing was
+ *  folded. World because {@link foldMeshWorldPositions} folded `toWorld` in. */
+function finishBox(box: Box): WorldAabb | null {
   if (box.minX === Infinity) return null;
-  return { min: [box.minX, box.minY, box.minZ], max: [box.maxX, box.maxY, box.maxZ] };
+  return { frame: 'world', min: [box.minX, box.minY, box.minZ], max: [box.maxX, box.maxY, box.maxZ] };
 }
 
-/** The wasm pass's whole-entity world box as an {@link Aabb} copy. */
-function fromEntityAabb(aabb: { min: readonly number[]; max: readonly number[] }): Aabb {
+/** The wasm pass's whole-entity ABSOLUTE world box as a {@link WorldAabb}
+ *  copy. Already absolute at the source (see `MeshData.geometryAabb`), so no
+ *  shift is applied here. */
+function fromEntityAabb(aabb: { min: readonly number[]; max: readonly number[] }): WorldAabb {
   return {
+    frame: 'world',
     min: [aabb.min[0], aabb.min[1], aabb.min[2]],
     max: [aabb.max[0], aabb.max[1], aabb.max[2]],
   };
 }
 
 /**
- * Axis-aligned bounding box of an entity's meshes (renderer world frame).
+ * Axis-aligned bounding box of an entity's meshes, ALWAYS in the absolute
+ * world frame ({@link WorldAabb}).
  *
  * Prefers `MeshData.geometryAabb` - the whole-entity ABSOLUTE world box from
  * the wasm hashing pass, RTC offset and per-element `origin` already folded in
  * (all submeshes of an entity carry the identical box). It is the same box
  * `buildFingerprints.ts` feeds the diff engine, and the only one that stays
  * comparable when two revisions chose different RTC offsets. When the pass
- * produced no box (hashing off, older cache, NaN sentinel dropped), the
- * fallback folds `origin + positions` per vertex - origin-correct, though
- * still RTC-relative like the positions themselves.
+ * produced no box (hashing off, older cache, NaN sentinel dropped - see
+ * `geometry-fingerprints.ts`), the fallback folds
+ * `toWorld + origin + positions` per vertex, landing in the SAME absolute
+ * frame.
+ *
+ * `toWorld` is the owning model's {@link renderToWorldShift} and is required,
+ * not defaulted: a hashed entity can keep its box in one revision and lose it
+ * to the NaN drop in the other, and when the fallback stayed RTC-relative
+ * that pair compared a world box against a render box - on a georeferenced
+ * model the reported "movement" was the RTC offset, a fabricated number worse
+ * than the `movedDistance = 0` the origin fold fixed (#2659). An optional
+ * shift would let the next call site quietly reintroduce exactly that.
  */
-export function meshBounds(meshes: readonly MeshData[], globalId: number): Aabb | null {
+export function meshBounds(
+  meshes: readonly MeshData[],
+  globalId: number,
+  toWorld: RenderToWorldShift,
+): WorldAabb | null {
   let box: Box | null = null;
   for (const mesh of meshes) {
     if (mesh.expressId !== globalId) continue;
     if (mesh.geometryAabb) return fromEntityAabb(mesh.geometryAabb);
-    foldMeshWorldPositions(mesh, box ??= emptyBox());
+    foldMeshWorldPositions(mesh, box ??= emptyBox(), toWorld);
   }
   return box ? finishBox(box) : null;
 }
@@ -112,8 +179,11 @@ export function meshBounds(meshes: readonly MeshData[], globalId: number): Aabb 
  * copy of this loop is how the report path missed the `origin` fold that
  * `meshBounds`'s contract requires (#2529).
  */
-export function meshBoundsIndex(meshes: readonly MeshData[]): Map<number, Aabb> {
-  const resolved = new Map<number, Aabb>();
+export function meshBoundsIndex(
+  meshes: readonly MeshData[],
+  toWorld: RenderToWorldShift,
+): Map<number, WorldAabb> {
+  const resolved = new Map<number, WorldAabb>();
   const acc = new Map<number, Box>();
   for (const mesh of meshes) {
     if (resolved.has(mesh.expressId)) continue;
@@ -124,7 +194,7 @@ export function meshBoundsIndex(meshes: readonly MeshData[]): Map<number, Aabb> 
     }
     let box = acc.get(mesh.expressId);
     if (!box) acc.set(mesh.expressId, box = emptyBox());
-    foldMeshWorldPositions(mesh, box);
+    foldMeshWorldPositions(mesh, box, toWorld);
   }
   for (const [id, box] of acc) {
     const aabb = finishBox(box);
@@ -197,8 +267,13 @@ export function placementMoveSummary(
  * Classify an A→B bounding-box change as a move and/or reshape. Pure (takes
  * pre-computed AABBs) so a bulk report can pre-index every element's bounds in
  * one pass instead of re-scanning the mesh array per element (#1202).
+ *
+ * Takes {@link WorldAabb}, not bare {@link Aabb}: the subtraction below is
+ * only meaningful between boxes in the SAME frame, and requiring the brand
+ * makes a mixed-frame pair (the #2659 defect) a type error instead of a
+ * plausible-looking displacement.
  */
-export function summarizeGeometryChange(ba: Aabb | null, bb: Aabb | null): GeometrySummary | null {
+export function summarizeGeometryChange(ba: WorldAabb | null, bb: WorldAabb | null): GeometrySummary | null {
   const zero = { x: 0, y: 0, z: 0 };
   if (!ba || !bb) return { movedDistance: 0, delta: zero, reshaped: true, sizeDelta: zero };
 


### PR DESCRIPTION
Fixes a defect that is live on main, introduced into a new code path by #2529.

## Compare reports a genuinely moved element as not moved

`meshBounds` in `apps/viewer/src/lib/compare/geometrySummary.ts` summed `mesh.positions` without folding `MeshData.origin`.

The wasm pipeline defaults to a per-element local frame (`rust/geometry/src/router/transforms/mod.rs`: origin is the element's AABB centre, and it follows the element). So for a pure translation the positions are **byte-identical** and only `origin` moves. Compare therefore reported `movedDistance = 0, reshaped = false` for an element that had genuinely moved.

Reproduced through the viewer's own test runner: an element moved 40 m reported `movedDistance = 0`.

What a user saw on main: `ChangeDetailView` showing no move, `changeRow` omitting "Moved", and the bulk CSV writing `MovedDistance_m = 0` with the reason "Geometry changed". A wrong number stated confidently, which is worse than a failure, because a coordination report is exactly where that number gets believed.

## Why every gate was green

Two reasons, and the second is the interesting one.

`apps/viewer/src/lib/compare/buildFingerprints.ts:16-22` **documents this exact trap** ("would report a moved element as stationary") and correctly uses the world `geometryAabb`. Its sibling in the same directory did the forbidden thing. The knowledge was present in the codebase and did not travel across two files.

And the existing tests all construct meshes **without** an `origin`, so no test in the repo could see this class at all. `meshBounds` predates #2529, but #2529 extracted it and extended it into the new bulk CSV path, and its 441 lines of new tests inherited the same blind fixture shape.

## The fix

`meshBounds` and `meshBoundsIndex` now reconstruct the world coordinate as `origin + positions[i]`, with the reasoning recorded at the fold so the next reader does not undo it.

## Verification

Red-verified by un-folding the origin (`const ox = 0, oy = 0, oz = 0`): 3 tests fail, including the named regression `meshBounds folds MeshData.origin (#2529 regression)`. Restored, 57 compare tests pass.

New coverage, all of it in the shape the old fixtures could not express:
- a pure translation with a non-zero `MeshData.origin` is reported as a move with the correct distance
- a reshape is still detected when the origin is non-zero, so the fix does not report everything as moved
- the same at large world coordinates
- the corrected `MovedDistance_m` in the CSV export path, where a wrong number is most likely to be trusted

## Part of a class, not an isolated bug

This is the third of four instances of the same class found today: a consumer treating local-frame data as world data, or deriving a tolerance from the wrong quantity. The others are #2598 (caught pre-merge), #2600 (live on main, owned elsewhere) and a milder shared form.

All four were invisible to identical green gates for one reason: **no test in the repo feeds these paths a mesh with a non-zero per-element origin or large world coordinates.** A shared fixture corpus closing that gap is in progress separately; this PR fixes the compare instance and adds the local coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved geometry comparison accuracy for translated meshes and differing coordinate frames.
  * Movement reports now include the correct distance, including translations represented through mesh origins.
  * Geometry reshapes continue to be distinguished from pure movement.
  * Improved bounds handling for georeferenced, empty, legacy, and multi-part geometry.
  * Reports and CSV exports now reflect corrected movement calculations.
  * Improved consistency when comparing geometry across render-to-world shifts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->