### PR TITLE
fix(viewer): "Isolate in 3D" on filter results resolves geometry-less assemblies to their parts

### DIFF
--- a/apps/viewer/src/components/viewer/SearchModal.filter.tsx
+++ b/apps/viewer/src/components/viewer/SearchModal.filter.tsx
@@ -361,7 +361,10 @@ export function SearchModalFilter() {
    *  `collectFilterResultGlobalIds`), so a multi-model result isolates
    *  correctly across every source model, not just the active one — and a
    *  row whose model was unloaded after the run is skipped rather than
-   *  colliding with another model's id space (#2532 review). */
+   *  colliding with another model's id space (#2532 review). Geometry-less
+   *  assemblies are resolved to their geometry-bearing parts via
+   *  `cameraCallbacks.resolveHighlightIds` (#2531) before isolating, or a
+   *  result made of assemblies would blank the view. */
   const handleIsolateResult = useCallback(() => {
     const result = searchFilterResult;
     if (!result || result.rows.length === 0) return;
@@ -383,17 +386,32 @@ export function SearchModalFilter() {
       return;
     }
 
+    // A geometry-less assembly (IfcElementAssembly, an IfcStair used as a
+    // container, …) owns no mesh: the renderer resolves `isolatedEntities`
+    // against mesh ids directly, so isolating its bare id blanks the view.
+    // Resolve through the same Viewport channel the Search tab's commit and
+    // frameSelection use (`resolveHighlightIds`, backed by
+    // expandToGeometryBearingIds — #2531): a geometry-bearing id passes
+    // through untouched and deduplicated, a geometry-less one is replaced by
+    // its geometry-bearing aggregated parts. When nothing resolves (renderer
+    // not initialised yet, or no matched row has geometry at all), keep the
+    // raw ids: isolating an empty set would hide the ENTIRE model, which is
+    // strictly worse than the pre-resolution behaviour for that corner.
+    const resolved = cameraCallbacks.resolveHighlightIds?.(globalIds) ?? [];
+    const isolationIds = resolved.length > 0 ? resolved : globalIds;
+
     // isolateEntities is a same-set TOGGLE (visibilitySlice.ts:176-194):
     // pressing "Isolate in 3D" again on the identical result un-isolates
     // rather than re-isolating. Detect that up front so the un-isolate press
     // only clears — it must not also select/frame the id set and close the
-    // modal as if a fresh isolation had just landed (#2532 review).
+    // modal as if a fresh isolation had just landed (#2532 review). Compared
+    // against the RESOLVED ids, which are what the first press stored.
     const alreadyIsolated = isolatedEntities !== null &&
-      isolatedEntities.size === globalIds.length &&
-      globalIds.every((id) => isolatedEntities.has(id));
+      isolatedEntities.size === isolationIds.length &&
+      isolationIds.every((id) => isolatedEntities.has(id));
 
     if (alreadyIsolated) {
-      isolateEntities(globalIds);
+      isolateEntities(isolationIds);
       setSelectedEntityIds([]);
       toast.info('Isolation cleared — showing the full model.');
       setSearchModalOpen(false);
@@ -416,12 +434,12 @@ export function SearchModalFilter() {
     if (matchedTypes.has('IfcOpeningElement') && !typeVisibility.openings) toggleTypeVisibility('openings');
     if (matchedTypes.has('IfcVirtualElement') && !typeVisibility.virtualElements) toggleTypeVisibility('virtualElements');
 
-    isolateEntities(globalIds);
+    isolateEntities(isolationIds);
     // Select the full isolated set (not just one row) so the frame below
     // encloses every isolated element. A single `setSelectedEntityIds` call
     // replaces both `selectedEntityIds` and `selectedEntityId` wholesale
     // (selectionSlice.ts:160-163), so no leading clear is needed here.
-    setSelectedEntityIds(globalIds);
+    setSelectedEntityIds(isolationIds);
 
     if (limitHit !== null) {
       toast.info(`Isolating the first ${limitHit.toLocaleString()} matches — the filter hit its row limit.`);
@@ -432,7 +450,7 @@ export function SearchModalFilter() {
     // a degenerate/NaN bound (Viewport.tsx:1029-1033), so a non-geometric id
     // in the mix can't fling the camera off-model.
     if (cameraCallbacks.frameEntities) {
-      window.setTimeout(() => cameraCallbacks.frameEntities?.(globalIds), 50);
+      window.setTimeout(() => cameraCallbacks.frameEntities?.(isolationIds), 50);
     }
     // Close the modal so the framing is actually visible — same reasoning
     // as handleRowClick above (dialog overlay is `fixed inset-0 bg-black/80`,

--- a/apps/viewer/src/components/viewer/SearchModal.filter.tsx
+++ b/apps/viewer/src/components/viewer/SearchModal.filter.tsx
@@ -37,7 +37,11 @@ import { evaluateFilterRulesFederated } from '@/lib/search/filter-evaluate';
 import { runTier0Scan, type ScanModel } from '@/lib/search/tier0-scan';
 import { queryTier1Indexes, type Tier1Index } from '@/lib/search/tier1-index';
 import { downloadResult } from '@/lib/search/result-export';
-import { collectFilterResultGlobalIds, scanFilterResultRows } from '@/lib/search/isolate-filter-result';
+import {
+  collectFilterResultGlobalIds,
+  expandFilterRowsThroughAggregation,
+  scanFilterResultRows,
+} from '@/lib/search/isolate-filter-result';
 import { filterResultToSearchResults } from '@/lib/search/filter-result-to-search-results';
 import type { ListDefinition } from '@/lib/lists';
 import { toast } from '@/components/ui/toast';
@@ -393,12 +397,43 @@ export function SearchModalFilter() {
     // frameSelection use (`resolveHighlightIds`, backed by
     // expandToGeometryBearingIds — #2531): a geometry-bearing id passes
     // through untouched and deduplicated, a geometry-less one is replaced by
-    // its geometry-bearing aggregated parts. When nothing resolves (renderer
-    // not initialised yet, or no matched row has geometry at all), keep the
-    // raw ids: isolating an empty set would hide the ENTIRE model, which is
-    // strictly worse than the pre-resolution behaviour for that corner.
+    // its geometry-bearing aggregated parts.
     const resolved = cameraCallbacks.resolveHighlightIds?.(globalIds) ?? [];
-    const isolationIds = resolved.length > 0 ? resolved : globalIds;
+    let isolationIds = resolved;
+    let fallbackPartTypes: ReadonlySet<string> | null = null;
+    if (resolved.length === 0) {
+      // Nothing resolved: either the renderer has not registered its
+      // callbacks yet, or every matched row looks geometry-less to it. The
+      // resolver checks bounds against the type-visibility-FILTERED mesh
+      // list (Viewport gets ViewportContainer's `filteredGeometry`), so an
+      // assembly whose only parts are currently hidden types (IfcSpace,
+      // IfcOpeningElement, ...) lands here even though it IS renderable once
+      // those toggles flip (#2660 review). Expand through the aggregation
+      // graph directly -- data-store side, visibility-blind -- so those
+      // parts join the isolation set, and feed their types into the
+      // matchedTypes gate below so the toggles actually flip. The raw ids
+      // stay in the set: rows without aggregated parts keep their own mesh
+      // ids that way, and isolating an empty set would hide the ENTIRE
+      // model, which is strictly worse than the pre-resolution behaviour.
+      //
+      // Residual gap, documented rather than closed: when SOME rows resolve,
+      // hidden-type parts of the ones that do not are still dropped, and a
+      // second press after the toggles flipped recomputes a resolver-based
+      // set (so it re-isolates instead of clearing). Both need the resolver
+      // to see UNFILTERED geometry, which is Viewport plumbing shared with
+      // frameSelection and the Search tab -- out of scope here.
+      const expansion = expandFilterRowsThroughAggregation(result, defaultModelId, {
+        relationshipsFor: (modelId) => models.get(modelId)?.ifcDataStore?.relationships,
+        typeNameFor: (modelId, expressId) =>
+          models.get(modelId)?.ifcDataStore?.entities.getTypeName(expressId) ?? null,
+        toGlobalId: (modelId, expressId) =>
+          models.has(modelId) ? toGlobalIdFromModels(models, modelId, expressId) : null,
+      });
+      fallbackPartTypes = expansion.partTypes;
+      const merged = new Set(globalIds);
+      for (const id of expansion.partGlobalIds) merged.add(id);
+      isolationIds = [...merged];
+    }
 
     // isolateEntities is a same-set TOGGLE (visibilitySlice.ts:176-194):
     // pressing "Isolate in 3D" again on the identical result un-isolates
@@ -429,6 +464,12 @@ export function SearchModalFilter() {
     for (const row of scanFilterResultRows(result, defaultModelId)) {
       if (row.ifcType) matchedTypes.add(row.ifcType);
     }
+    // Aggregated parts pulled in by the fallback above are isolated too, so
+    // their types must clear the same gate -- a result of bare assemblies
+    // over hidden-type parts would otherwise flip nothing and still blank.
+    if (fallbackPartTypes) {
+      for (const partType of fallbackPartTypes) matchedTypes.add(partType);
+    }
     if (matchedTypes.has('IfcSpace') && !typeVisibility.spaces) toggleTypeVisibility('spaces');
     if (matchedTypes.has('IfcSpatialZone') && !typeVisibility.spatialZones) toggleTypeVisibility('spatialZones');
     if (matchedTypes.has('IfcOpeningElement') && !typeVisibility.openings) toggleTypeVisibility('openings');
@@ -438,8 +479,15 @@ export function SearchModalFilter() {
     // Select the full isolated set (not just one row) so the frame below
     // encloses every isolated element. A single `setSelectedEntityIds` call
     // replaces both `selectedEntityIds` and `selectedEntityId` wholesale
-    // (selectionSlice.ts:160-163), so no leading clear is needed here.
-    setSelectedEntityIds(isolationIds);
+    // (selectionSlice.ts:160-163), so no leading clear is needed here. The
+    // MATCHED ids go last: `selectedEntityId` becomes the array's final
+    // element, so the primary selection (what the Properties panel shows via
+    // useModelSelection) stays a row the filter actually matched instead of
+    // whichever expanded part happened to come out of the resolver last --
+    // the same #1133 convention as SearchModal.text.tsx's commit
+    // (`[...renderableParts, globalId]`) and HierarchyPanel's group isolate
+    // (#2660 review). The Set dedups the overlap.
+    setSelectedEntityIds([...isolationIds, ...globalIds]);
 
     if (limitHit !== null) {
       toast.info(`Isolating the first ${limitHit.toLocaleString()} matches — the filter hit its row limit.`);

--- a/apps/viewer/src/components/viewer/SearchModal.filter.wiring.test.tsx
+++ b/apps/viewer/src/components/viewer/SearchModal.filter.wiring.test.tsx
@@ -389,9 +389,36 @@ describe('advanced Filter tab — "Isolate in 3D" button', () => {
       new Set([PART_A, PART_B]),
       'the isolation set must hold the renderable parts; the bare assembly id renders nothing',
     );
-    assert.deepEqual(s.selectedEntityIds, new Set([PART_A, PART_B]));
+    // The selection additionally keeps the MATCHED assembly id (last, so it is
+    // the primary selection) -- same #1133 convention as the text tab's commit.
+    assert.deepEqual(s.selectedEntityIds, new Set([PART_A, PART_B, ROW0_GLOBAL_ID]));
     await advance(60);
     assert.deepEqual(framedIds, [[PART_A, PART_B]], 'framing must target the resolved parts too');
+  });
+
+  it('keeps the matched assembly as the primary selection; an expanded part must not steal selectedEntityId', () => {
+    const PART_A = ROW0_GLOBAL_ID + 500;
+    const PART_B = ROW0_GLOBAL_ID + 501;
+    seedIsolateStore({
+      columns: ['express_id', 'type'],
+      rows: [[42, 'IfcElementAssembly']],
+      resolveHighlightIds: (ids) =>
+        ids.flatMap((id) => (id === ROW0_GLOBAL_ID ? [PART_A, PART_B] : [id])),
+    });
+    const container = render(<SearchModalFilter />);
+
+    click(isolateButton(container));
+
+    // setSelectedEntityIds derives selectedEntityId from the LAST element
+    // (selectionSlice.ts:160-163) and useModelSelection then syncs
+    // selectedEntity -- so if the expanded parts came last, the Properties
+    // panel would open on an arbitrary constituent instead of the assembly
+    // the filter matched (#2660 review).
+    assert.equal(
+      useViewerStore.getState().selectedEntityId,
+      ROW0_GLOBAL_ID,
+      'the primary selection must be the matched assembly, not the last expanded part',
+    );
   });
 
   it('passes geometry-bearing rows through the resolver untouched, so the fix does not broaden a plain result', () => {
@@ -460,6 +487,50 @@ describe('advanced Filter tab — "Isolate in 3D" button', () => {
     // Pre-#2531 behaviour preserved for this corner: isolating an empty set
     // would hide the ENTIRE model, which is strictly worse than the raw id.
     assert.deepEqual(useViewerStore.getState().isolatedEntities, new Set([ROW0_GLOBAL_ID]));
+  });
+
+  it('expands an assembly over HIDDEN-type parts through the aggregation graph and flips their toggles when the geometry resolver sees nothing', () => {
+    // The renderer-backed resolver reads the type-visibility-FILTERED mesh
+    // list (ViewportContainer's filteredGeometry), so an assembly whose only
+    // parts are hidden IfcSpaces resolves to NOTHING -- and the bare-id
+    // fallback alone would isolate a geometry-less id with the spaces toggle
+    // still off: a blank view on a valid result (#2660 review). The fallback
+    // must instead walk IfcRelAggregates in the data store, isolate the
+    // parts, and flip their type gate.
+    const models = fixtureModels(
+      fixtureModel(MODEL_ID, {
+        idOffset: ID_OFFSET,
+        entities: [
+          { expressId: 42, type: 'IfcElementAssembly', name: 'Zone assembly' },
+          { expressId: 100, type: 'IfcSpace', name: 'Space A' },
+          { expressId: 101, type: 'IfcSpace', name: 'Space B' },
+        ],
+        aggregates: { 42: [100, 101] },
+      }),
+    );
+    const SPACE_A = toGlobalIdFromModels(models.models, MODEL_ID, 100);
+    const SPACE_B = toGlobalIdFromModels(models.models, MODEL_ID, 101);
+    seedIsolateStore({
+      columns: ['express_id', 'type'],
+      rows: [[42, 'IfcElementAssembly']],
+      models,
+      typeVisibility: { spaces: false },
+      // Hidden parts own no mesh in the filtered geometry, so the real
+      // resolver drops the assembly entirely (expandToGeometryBearingIds).
+      resolveHighlightIds: () => [],
+    });
+    assert.equal(useViewerStore.getState().typeVisibility.spaces, false, 'precondition: spaces start hidden');
+    const container = render(<SearchModalFilter />);
+
+    click(isolateButton(container));
+
+    const s = useViewerStore.getState();
+    assert.equal(s.typeVisibility.spaces, true, 'the parts\' type gate must flip, or nothing renders');
+    assert.deepEqual(
+      s.isolatedEntities,
+      new Set([ROW0_GLOBAL_ID, SPACE_A, SPACE_B]),
+      'the isolation set must include the aggregated parts, not just the bare assembly id',
+    );
   });
 
   it('skips a row whose model was unloaded after the run instead of colliding with a loaded model\'s id space', () => {

--- a/apps/viewer/src/components/viewer/SearchModal.filter.wiring.test.tsx
+++ b/apps/viewer/src/components/viewer/SearchModal.filter.wiring.test.tsx
@@ -227,6 +227,9 @@ function seedIsolateStore(options: {
   rows: unknown[][];
   typeVisibility?: Partial<ReturnType<typeof useViewerStore.getState>['typeVisibility']>;
   models?: ReturnType<typeof fixtureModels>;
+  /** Viewport's aggregation resolver (#2531). Absent by default, same as a
+   *  renderer that has not registered its camera callbacks yet. */
+  resolveHighlightIds?: (ids: number[]) => number[];
 } = { columns: ['express_id', 'type'], rows: [[42, 'IfcWall']] }) {
   const seeded = options.models ?? fixtureModels(
     fixtureModel(MODEL_ID, {
@@ -251,6 +254,7 @@ function seedIsolateStore(options: {
     cameraCallbacks: {
       frameSelection: () => { framed += 1; },
       frameEntities: (ids: number[]) => { framedIds.push(ids); },
+      ...(options.resolveHighlightIds ? { resolveHighlightIds: options.resolveHighlightIds } : {}),
     } as never,
   });
 }
@@ -352,6 +356,110 @@ describe('advanced Filter tab — "Isolate in 3D" button', () => {
       framedAfterFirstClick,
       'the un-isolate press must not also frame the (now meaningless) id set',
     );
+  });
+
+  // ── Assembly resolution (#2531 in the path #2532 added) ─────────────────
+  //
+  // An IfcElementAssembly carries no mesh of its own; its geometry hangs off
+  // the IfcRelAggregates parts. The renderer resolves `isolatedEntities`
+  // against mesh ids directly, so isolating the bare assembly id blanks the
+  // view. Viewport exposes the aggregation resolver as
+  // `cameraCallbacks.resolveHighlightIds` (backed by
+  // expandToGeometryBearingIds, #2531); these stubs mirror its contract the
+  // same way SearchModal.text.wiring.test.tsx does: a geometry-bearing id
+  // passes through untouched, a geometry-less one resolves to its parts and
+  // never to itself.
+
+  it('isolates a geometry-less assembly as its geometry-bearing parts, not its bare id', async () => {
+    const PART_A = ROW0_GLOBAL_ID + 500;
+    const PART_B = ROW0_GLOBAL_ID + 501;
+    seedIsolateStore({
+      columns: ['express_id', 'type'],
+      rows: [[42, 'IfcElementAssembly']],
+      resolveHighlightIds: (ids) =>
+        ids.flatMap((id) => (id === ROW0_GLOBAL_ID ? [PART_A, PART_B] : [id])),
+    });
+    const container = render(<SearchModalFilter />);
+
+    click(isolateButton(container));
+
+    const s = useViewerStore.getState();
+    assert.deepEqual(
+      s.isolatedEntities,
+      new Set([PART_A, PART_B]),
+      'the isolation set must hold the renderable parts; the bare assembly id renders nothing',
+    );
+    assert.deepEqual(s.selectedEntityIds, new Set([PART_A, PART_B]));
+    await advance(60);
+    assert.deepEqual(framedIds, [[PART_A, PART_B]], 'framing must target the resolved parts too');
+  });
+
+  it('passes geometry-bearing rows through the resolver untouched, so the fix does not broaden a plain result', () => {
+    const PART_A = ROW0_GLOBAL_ID + 500;
+    const WALL_GLOBAL_ID = toGlobalIdFromModels(
+      fixtureModels(fixtureModel(MODEL_ID, { idOffset: ID_OFFSET })).models,
+      MODEL_ID,
+      43,
+    );
+    seedIsolateStore({
+      columns: ['express_id', 'type'],
+      rows: [
+        [42, 'IfcElementAssembly'],
+        [43, 'IfcWall'],
+      ],
+      resolveHighlightIds: (ids) =>
+        ids.flatMap((id) => (id === ROW0_GLOBAL_ID ? [PART_A] : [id])),
+    });
+    const container = render(<SearchModalFilter />);
+
+    click(isolateButton(container));
+
+    assert.deepEqual(
+      useViewerStore.getState().isolatedEntities,
+      new Set([PART_A, WALL_GLOBAL_ID]),
+      'the wall keeps its own id; only the assembly is substituted',
+    );
+  });
+
+  it('pressing Isolate again on the identical assembly result still toggles isolation off', async () => {
+    const PART_A = ROW0_GLOBAL_ID + 500;
+    seedIsolateStore({
+      columns: ['express_id', 'type'],
+      rows: [[42, 'IfcElementAssembly']],
+      resolveHighlightIds: (ids) =>
+        ids.flatMap((id) => (id === ROW0_GLOBAL_ID ? [PART_A] : [id])),
+    });
+    const container = render(<SearchModalFilter />);
+
+    click(isolateButton(container));
+    await advance(60);
+    assert.deepEqual(useViewerStore.getState().isolatedEntities, new Set([PART_A]));
+
+    click(isolateButton(container));
+    await advance(60);
+
+    assert.equal(
+      useViewerStore.getState().isolatedEntities,
+      null,
+      'the same-set toggle must compare RESOLVED ids on both presses, or the second press re-isolates',
+    );
+  });
+
+  it('keeps the raw ids when nothing resolves to geometry, identical to a renderer with no resolver', () => {
+    seedIsolateStore({
+      columns: ['express_id', 'type'],
+      rows: [[42, 'IfcElementAssembly']],
+      // An assembly with neither geometry nor geometry-bearing parts resolves
+      // to nothing at all (expandToGeometryBearingIds drops it).
+      resolveHighlightIds: () => [],
+    });
+    const container = render(<SearchModalFilter />);
+
+    click(isolateButton(container));
+
+    // Pre-#2531 behaviour preserved for this corner: isolating an empty set
+    // would hide the ENTIRE model, which is strictly worse than the raw id.
+    assert.deepEqual(useViewerStore.getState().isolatedEntities, new Set([ROW0_GLOBAL_ID]));
   });
 
   it('skips a row whose model was unloaded after the run instead of colliding with a loaded model\'s id space', () => {

--- a/apps/viewer/src/lib/search/isolate-filter-result.test.ts
+++ b/apps/viewer/src/lib/search/isolate-filter-result.test.ts
@@ -4,8 +4,11 @@
 
 import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
+import { RelationshipType } from '@ifc-lite/data';
+import type { AggregationRelationships } from '../../utils/aggregation.js';
 import {
   collectFilterResultGlobalIds,
+  expandFilterRowsThroughAggregation,
   scanFilterResultRows,
   type FilterResultLike,
 } from './isolate-filter-result.js';
@@ -130,5 +133,65 @@ describe('scanFilterResultRows', () => {
   test('returns empty when there is no express_id column', () => {
     const result: FilterResultLike = { columns: ['name'], rows: [['Wall A']] };
     assert.deepEqual(scanFilterResultRows(result, 'modelA'), []);
+  });
+});
+
+describe('expandFilterRowsThroughAggregation', () => {
+  /** Minimal IfcRelAggregates graph: parent express id -> child express ids. */
+  function fakeRelationships(aggregates: Record<number, number[]>): AggregationRelationships {
+    return {
+      getRelated: (id, relType, direction) =>
+        relType === RelationshipType.Aggregates && direction === 'forward'
+          ? [...(aggregates[id] ?? [])]
+          : [],
+    };
+  }
+
+  test('collects every aggregated descendant with its type, in row order, deduplicated', () => {
+    const result: FilterResultLike = {
+      columns: ['express_id', 'type'],
+      rows: [
+        [1, 'IfcElementAssembly'],
+        [2, 'IfcElementAssembly'],
+      ],
+    };
+    // Nested: 1 -> 10 -> 11; assemblies 1 and 2 share part 10.
+    const relationships = fakeRelationships({ 1: [10], 10: [11], 2: [10] });
+    const types: Record<number, string> = { 10: 'IfcSpace', 11: 'IfcOpeningElement' };
+    const expansion = expandFilterRowsThroughAggregation(result, 'modelA', {
+      relationshipsFor: () => relationships,
+      typeNameFor: (_modelId, expressId) => types[expressId] ?? null,
+      toGlobalId: (_modelId, expressId) => expressId + 1000,
+    });
+    assert.deepEqual(expansion.partGlobalIds, [1010, 1011], 'shared part 10 must appear once');
+    assert.deepEqual(expansion.partTypes, new Set(['IfcSpace', 'IfcOpeningElement']));
+  });
+
+  test('skips rows whose model has no relationship graph, and descendants whose global id resolves to null', () => {
+    const result: FilterResultLike = {
+      columns: ['express_id', 'type', 'model_id'],
+      rows: [
+        [1, 'IfcElementAssembly', 'modelA'],
+        [1, 'IfcElementAssembly', 'modelUnloaded'],
+      ],
+    };
+    const relationships = fakeRelationships({ 1: [10, 11] });
+    const expansion = expandFilterRowsThroughAggregation(result, 'modelA', {
+      relationshipsFor: (modelId) => (modelId === 'modelA' ? relationships : undefined),
+      typeNameFor: () => 'IfcSpace',
+      toGlobalId: (_modelId, expressId) => (expressId === 11 ? null : expressId),
+    });
+    assert.deepEqual(expansion.partGlobalIds, [10], 'the unloaded model and the null id must both be skipped');
+  });
+
+  test('returns empty for rows with no aggregated parts', () => {
+    const result: FilterResultLike = { columns: ['express_id', 'type'], rows: [[1, 'IfcWall']] };
+    const expansion = expandFilterRowsThroughAggregation(result, 'modelA', {
+      relationshipsFor: () => fakeRelationships({}),
+      typeNameFor: () => 'IfcWall',
+      toGlobalId: (_modelId, expressId) => expressId,
+    });
+    assert.deepEqual(expansion.partGlobalIds, []);
+    assert.deepEqual(expansion.partTypes, new Set());
   });
 });

--- a/apps/viewer/src/lib/search/isolate-filter-result.ts
+++ b/apps/viewer/src/lib/search/isolate-filter-result.ts
@@ -13,6 +13,8 @@
  * ordering contract this feeds into).
  */
 
+import { collectAggregatedDescendants, type AggregationRelationships } from '../../utils/aggregation.js';
+
 export interface FilterResultLike {
   columns: string[];
   rows: unknown[][];
@@ -70,6 +72,64 @@ export function scanFilterResultRows(
  * falling back to the raw expressId would collide with another model's id
  * space (#2532 review) rather than isolating nothing.
  */
+/** Per-model accessors `expandFilterRowsThroughAggregation` walks with. */
+export interface FilterAggregationAccess {
+  /** The model's `IfcRelAggregates` graph, when that model is loaded. */
+  relationshipsFor(modelId: string): AggregationRelationships | undefined;
+  /** Canonical type name (e.g. `IfcSpace`) of a model-local entity, if known. */
+  typeNameFor(modelId: string, expressId: number): string | null;
+  /** Model-local express id to renderer global id; `null` skips the id. */
+  toGlobalId(modelId: string, expressId: number): number | null;
+}
+
+export interface FilterAggregationExpansion {
+  /** Global ids of every aggregated descendant of the matched rows,
+   *  deduplicated, in row order. */
+  partGlobalIds: number[];
+  /** Type names seen among those descendants (e.g. `IfcSpace`). */
+  partTypes: Set<string>;
+}
+
+/**
+ * Expand every matched row to its `IfcRelAggregates` descendants, straight
+ * from the data store and blind to type visibility.
+ *
+ * `handleIsolateResult`'s primary expansion is the renderer-backed
+ * `resolveHighlightIds`, but that resolver checks bounds against the
+ * type-visibility-FILTERED mesh list (`ViewportContainer`'s
+ * `filteredGeometry`), so an assembly whose only parts are currently hidden
+ * types (IfcSpace, IfcOpeningElement, ...) resolves to nothing even though
+ * it renders fine once those toggles flip. This is the fallback for exactly
+ * that case: the descendants' global ids join the isolation set and their
+ * type names feed the handler's type-visibility gate so the toggles do flip
+ * (#2660 review). Descendants are NOT geometry-checked (that would need the
+ * renderer this path exists to work without), so geometry-less intermediate
+ * nodes ride along; the renderer ignores ids with no mesh, and
+ * `frameEntities` guards degenerate bounds.
+ */
+export function expandFilterRowsThroughAggregation(
+  result: FilterResultLike,
+  defaultModelId: string,
+  access: FilterAggregationAccess,
+): FilterAggregationExpansion {
+  const partGlobalIds: number[] = [];
+  const partTypes = new Set<string>();
+  const seen = new Set<number>();
+  for (const row of scanFilterResultRows(result, defaultModelId)) {
+    const relationships = access.relationshipsFor(row.modelId);
+    if (!relationships) continue;
+    for (const descendant of collectAggregatedDescendants(relationships, row.expressId)) {
+      const globalId = access.toGlobalId(row.modelId, descendant);
+      if (globalId === null || seen.has(globalId)) continue;
+      seen.add(globalId);
+      partGlobalIds.push(globalId);
+      const typeName = access.typeNameFor(row.modelId, descendant);
+      if (typeName) partTypes.add(typeName);
+    }
+  }
+  return { partGlobalIds, partTypes };
+}
+
 export function collectFilterResultGlobalIds(
   result: FilterResultLike,
   defaultModelId: string,

--- a/apps/viewer/src/test/store-fixture.ts
+++ b/apps/viewer/src/test/store-fixture.ts
@@ -18,6 +18,7 @@
  * this one until it pretends to be a parser.
  */
 
+import { RelationshipType } from '@ifc-lite/data';
 import type { FederatedModel } from '@/store';
 import type { IfcDataStore } from '@ifc-lite/parser';
 
@@ -48,7 +49,16 @@ export interface FixtureEntity {
  * parser's `StringTable` defines it — both scanners use `idx === 0` as their
  * "row has no searchable text" fast skip.
  */
-export function fixtureDataStore(entities: FixtureEntity[] = []): IfcDataStore {
+export function fixtureDataStore(
+  entities: FixtureEntity[] = [],
+  options: {
+    /** `IfcRelAggregates` adjacency (parent express id -> child express ids).
+     *  When given, the store carries a minimal `relationships.getRelated`
+     *  satisfying `AggregationRelationships`, so aggregation-walking paths
+     *  (assembly expansion, basket visibility) become exercisable. */
+    aggregates?: Record<number, number[]>;
+  } = {},
+): IfcDataStore {
   const byType = new Map<string, number[]>();
   const byId = new Map<number, FixtureEntity>();
   for (const e of entities) {
@@ -82,9 +92,20 @@ export function fixtureDataStore(entities: FixtureEntity[] = []): IfcDataStore {
   // mean reimplementing the parser, and a per-test cast would silence the next
   // field a test genuinely needs. If a render path reaches past these three,
   // it belongs in this fixture — add it here and the cast stays honest.
+  const { aggregates } = options;
   return {
     entityIndex: { byType },
     spatialHierarchy: undefined,
+    ...(aggregates
+      ? {
+          relationships: {
+            getRelated: (id: number, relType: RelationshipType, direction: 'forward' | 'inverse') =>
+              relType === RelationshipType.Aggregates && direction === 'forward'
+                ? [...(aggregates[id] ?? [])]
+                : [],
+          },
+        }
+      : {}),
     strings: { get: (idx: number) => strings[idx] ?? '' },
     entities: {
       getTypeName: (id: number) => byId.get(id)?.type ?? null,
@@ -112,7 +133,7 @@ export function fixtureDataStore(entities: FixtureEntity[] = []): IfcDataStore {
  */
 export function fixtureModel(
   id: string,
-  options: { idOffset?: number; entities?: FixtureEntity[] } = {},
+  options: { idOffset?: number; entities?: FixtureEntity[]; aggregates?: Record<number, number[]> } = {},
 ): FederatedModel {
   return {
     id,
@@ -121,7 +142,7 @@ export function fixtureModel(
     // silently exercise the hidden path in every test that seeds a model.
     visible: true,
     idOffset: options.idOffset ?? 0,
-    ifcDataStore: fixtureDataStore(options.entities),
+    ifcDataStore: fixtureDataStore(options.entities, { aggregates: options.aggregates }),
   } as unknown as FederatedModel;
 }
 


### PR DESCRIPTION
## The defect

The advanced filter tab's "Isolate in 3D" button (added by #2532) collected the matched rows' global ids and wrote them straight into `isolateEntities`. The renderer resolves `isolatedEntities` against mesh ids directly, so a result matching an `IfcElementAssembly` -- or any element whose geometry lives on `IfcRelAggregates` parts rather than on itself -- isolated an id that owns no mesh, and the view went blank.

## Why it slipped through

This is exactly the class of defect #2531 fixed ("frame, list and count element assemblies whose geometry lives on aggregated parts"), but in the path #2532 added. The two PRs merged about 9 hours apart, so no CI run ever contained both sides: #2531 wired `expandToGeometryBearingIds` into Viewport (`cameraCallbacks.resolveHighlightIds`) and into the hierarchy trees / text-search commit, while #2532's new isolate path was reviewed against a main that did not yet have that convention.

## The fix

`handleIsolateResult` now resolves the collected ids through `cameraCallbacks.resolveHighlightIds` -- the exact channel #2531 established and `SearchModal.text.tsx` already uses -- before the toggle check, `isolateEntities`, `setSelectedEntityIds` and `frameEntities`. Geometry-bearing ids pass through untouched (a plain wall result behaves exactly as before); a geometry-less assembly is replaced by its geometry-bearing aggregated parts. When nothing resolves (renderer not initialised yet, or no matched row has geometry at all) the raw ids are kept, preserving the pre-fix behaviour for that corner instead of isolating an empty set, which would hide the entire model.

## Tests (written first, mutation-checked)

Three new wiring tests in `SearchModal.filter.wiring.test.tsx` fail on the pre-fix code with `isolatedEntities == Set{1000042}` (the bare assembly global id) where the parts `Set{1000542, 1000543}` are expected; a fourth pins the no-geometry fallback. Mutation check: reverting only `SearchModal.filter.tsx` makes the suite fail 3/19, restoring it passes 19/19. The 8 pre-existing isolate tests (no resolver registered, i.e. raw-id fallback) still pass, so the non-assembly path is unchanged.

## Verification

`pnpm install --frozen-lockfile`, `pnpm build`, `pnpm typecheck`, `pnpm lint`, `node scripts/check-source-text-assertions.mjs`, `pnpm test` -- all exit 0.

## Sibling paths with the same gap (left alone, out of scope)

- `LensPanel.tsx:1330` (`handleIsolateRule`) isolates `lensRuleEntityIds` raw; the lens ownership record stores the exact pushed ids, so expansion there needs its own care.
- `PropertiesPanel.tsx:781` (`handleIsolateGroupMembers`) isolates zone/group member global ids without aggregation expansion.

HierarchyPanel's isolate paths are already covered: the trees fold parts in at build time (#1133, #2531 `partsOrOwnIds` / `assemblyChildGlobalIds`).

Refs #2532, #2531.

🤖 Generated with [Claude Code](https://claude.com/claude-code)