### PR TITLE
fix(clash): project the contact planeEps onto the tested normal, not max over axes

### DIFF
--- a/.changeset/clash-contact-plane-eps-projection.md
+++ b/.changeset/clash-contact-plane-eps-projection.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/clash": patch
+---
+
+Fix fabricated coplanar contacts far from the origin in the contact narrow phase. The scaled plane-distance tolerance took the max abs coordinate over all three axes of both world AABBs, so an axis orthogonal to the tested plane normal could inflate the tolerance past a genuine clearance (2 mm clearance read as coplanar at 10 km along an unrelated axis). Per-axis f32-ULP noise amplitudes are now projected onto each tested plane's own normal, preserving the 1e-6 floor.

--- a/packages/clash/src/contact/contact.test.ts
+++ b/packages/clash/src/contact/contact.test.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { describe, it, expect } from 'vitest';
-import { contactClusters, type Mesh } from './index.js';
+import { contactClusters, narrowPhase, type Mesh } from './index.js';
 
 // The "scale-relative planeEps", "scale-relative planeDistSnap", and
 // "planeDistSnap floor" describe blocks below are regression coverage for
@@ -235,6 +235,88 @@ describe('contactClusters (contact interface geometry)', () => {
         const withFixed = contactClusters(a, b, { planeDistSnap: 1e-3 });
         expect(withDefault).toEqual(withFixed);
       }
+    });
+  });
+
+  // Regression for the other direction of the scaled-planeEps trade-off in
+  // narrow-phase.ts (#2600): `scaledPlaneEps` originally took the max abs
+  // coordinate over ALL THREE axes of both world AABBs, but the epsilon it
+  // produces is compared against a signed distance measured along ONE plane
+  // normal. An axis orthogonal to that normal contributes no rounding noise
+  // to the distance, yet under max-over-axes it still inflates the
+  // tolerance: two horizontal faces (normal Z) with a genuine 2.0 mm
+  // Z-clearance read correctly as clear at the origin, but authored 10 km
+  // along X the tolerance becomes 10001 * 2^-22 = 2.385 mm > 2 mm and every
+  // candidate triangle pair is FABRICATED as a coplanar contact. The offset
+  // axis here is deliberately DIFFERENT from the tested normal axis:
+  // max-over-axes and the normal projection coincide when they share an
+  // axis, so only a cross-axis fixture can tell the two formulations apart.
+  describe('planeEps normal projection (large offset on an orthogonal axis must not fabricate contact)', () => {
+    /**
+     * Two horizontal unit quads (normal Z, 2 triangles each) with identical
+     * local geometry: both span x in [xOffset, xOffset + 1], y in [0, 1].
+     * A sits at z = 0, B at z = 0.002 - a genuine 2.0 mm clearance, well
+     * above any legitimate Z rounding noise (the quads' own z coordinates
+     * have magnitude <= 0.002, so their true f32 ULP is < 1e-9) and inside
+     * the default 2 mm AABB inflation, so the broad phase still emits all
+     * 2 x 2 candidate pairs and the verdict rests on planeEps alone.
+     */
+    function clearanceQuadsAt(xOffset: number): { a: Mesh; b: Mesh } {
+      const quad = (id: string, z: number): Mesh => ({
+        id,
+        positions: new Float64Array([
+          xOffset, 0, z,
+          xOffset + 1, 0, z,
+          xOffset + 1, 1, z,
+          xOffset, 1, z,
+        ]),
+        indices: new Uint32Array([0, 1, 2, 0, 2, 3]),
+      });
+      return { a: quad('A', 0), b: quad('B', 0.002) };
+    }
+
+    it('no contact at the origin: a 2.0 mm Z-clearance reads as clear', () => {
+      const { a, b } = clearanceQuadsAt(0);
+      expect(narrowPhase(a, b).length).toBe(0);
+      expect(contactClusters(a, b)).toEqual([]);
+    });
+
+    it('no contact 10 km along X: the same 2.0 mm Z-clearance must still read as clear', () => {
+      const { a, b } = clearanceQuadsAt(10_000);
+      const pairs = narrowPhase(a, b);
+      expect(pairs.filter((p) => p.kind === 'coplanar').length).toBe(0);
+      expect(pairs.length).toBe(0);
+      expect(contactClusters(a, b)).toEqual([]);
+    });
+
+    it('RED: the max-over-axes epsilon fabricates the coplanar contact when passed explicitly', () => {
+      // The pre-fix default: max abs coordinate over both AABBs and all
+      // three axes (10001, from the irrelevant X axis) times 2^-22.
+      const { a, b } = clearanceQuadsAt(10_000);
+      const maxOverAxesEps = 10_001 * (1 / 4_194_304); // 2.385 mm > the real 2 mm gap
+      const pairs = narrowPhase(a, b, { planeEps: maxOverAxesEps });
+      expect(pairs.filter((p) => p.kind === 'coplanar').length).toBe(4);
+      expect(contactClusters(a, b, { planeEps: maxOverAxesEps }).some((c) => c.kind === 'surface')).toBe(true);
+    });
+
+    it('still recovers a genuinely flush pair when the offset IS along the tested normal', () => {
+      // Counter-counter-case: projection must not narrow the tolerance for
+      // the case #2600 exists to fix. Same flush-boxes mechanism as the
+      // scale-relative planeEps block above (shared face normal X, offset
+      // along X): the offset axis and the normal axis coincide, so the
+      // projected epsilon equals the old max-over-axes one and the shared
+      // face is still recovered.
+      const nextF32 = (x: number): number => {
+        const buf = new Float32Array([x]);
+        new Uint32Array(buf.buffer)[0] += 1;
+        return buf[0] as number;
+      };
+      const offset = 10_000;
+      const xA = Math.fround(offset + 0.5);
+      const xB = nextF32(xA);
+      const a = box('A', [offset, 0, 0], [xA, 1, 1]);
+      const b = box('B', [xB, 0, 0], [offset + 1, 1, 1]);
+      expect(contactClusters(a, b).some((c) => c.kind === 'surface')).toBe(true);
     });
   });
 

--- a/packages/clash/src/contact/narrow-phase.ts
+++ b/packages/clash/src/contact/narrow-phase.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { buildMeshBvh, queryMeshCross } from "./mesh-bvh.js";
-import { triTriIntersect } from "./tri-tri.js";
+import { triTriIntersect, type ProjectedPlaneEps } from "./tri-tri.js";
 import type { Triangle } from "./triangle.js";
 import { triangleAt, triangleCount } from "./triangle.js";
 import type { AABB, Mesh, Vec3 } from "./types.js";
@@ -30,25 +30,43 @@ const F32_ULP_SCALE = 1 / 4_194_304; // 2^-22
  * bit-identical — f32 values, and a too-tight fixed epsilon then reads that
  * rounding noise as a genuine non-coplanar separation, discarding the
  * shared-face contact entirely rather than reporting it as
- * `touch`/`coplanar`. Extent is the max abs coordinate over both meshes'
- * AABBs (already computed by the BVH build, so this costs nothing extra).
- * The result is floored at the old fixed `1e-6`: scaling must only ever
- * *widen* the tolerance relative to the constant it replaces, never narrow
- * it — a bare `extent * F32_ULP_SCALE` with only the 1.0 extent floor is far
- * tighter than `1e-6` for any extent under ~4.19 m, which reintroduces the
- * exact dropped-shared-face bug this function exists to fix.
+ * `touch`/`coplanar`.
+ *
+ * Crucially, the extent must be taken PER AXIS and projected onto each
+ * plane's own normal (`epsForPlane` in `./tri-tri.js`), not collapsed to a
+ * single max over all three axes of both AABBs. The tolerance is compared
+ * against a signed distance measured along ONE plane normal, and each
+ * coordinate's rounding noise enters that distance weighted by its axis's
+ * normal component; an axis orthogonal to the normal contributes nothing.
+ * A max-over-axes scalar instead scales the tolerance to the meshes'
+ * DISTANCE FROM THE WORLD ORIGIN along whichever axis happens to be
+ * largest, even when that axis is irrelevant to the plane being tested:
+ * two horizontal faces (normal Z) with a genuine 2.0 mm Z-clearance
+ * authored 10 km along X got planeEps = 10000 * 2^-22 = 2.384 mm, inflated
+ * entirely by the irrelevant X axis, and were fabricated as coplanar
+ * contact (above ~8.4 km extent every near-parallel candidate pair reads
+ * as coplanar). Same reasoning as the LOCAL-vs-world tolerance sizing in
+ * `section-cutter.ts` (#2622): size the tolerance off the quantity the
+ * noise actually scales with, never off an unrelated world magnitude.
+ *
+ * The projected result is floored at the old fixed `1e-6`
+ * (`ProjectedPlaneEps.floor`): scaling must only ever *widen* the tolerance
+ * relative to the constant it replaces, never narrow it: a bare
+ * `extent * F32_ULP_SCALE` is far tighter than `1e-6` for any extent under
+ * ~4.19 m, which reintroduces the exact dropped-shared-face bug this
+ * function exists to fix.
  */
-function scaledPlaneEps(aabbA: AABB, aabbB: AABB): number {
-  let extent = 1.0;
+function scaledPlaneEps(aabbA: AABB, aabbB: AABB): ProjectedPlaneEps {
+  const axisNoise: [number, number, number] = [0, 0, 0];
   for (const aabb of [aabbA, aabbB]) {
     for (const v of [aabb.min, aabb.max]) {
-      for (const c of v) {
-        const a = Math.abs(c);
-        if (a > extent) extent = a;
+      for (let i = 0; i < 3; i++) {
+        const a = Math.abs(v[i] as number) * F32_ULP_SCALE;
+        if (a > (axisNoise[i] as number)) axisNoise[i] = a;
       }
     }
   }
-  return Math.max(1e-6, extent * F32_ULP_SCALE);
+  return { axisNoise, floor: 1e-6 };
 }
 
 export type TrianglePair =
@@ -75,8 +93,9 @@ export interface NarrowPhaseOptions {
   readonly epsilon?: number;
   /**
    * Plane-distance tolerance for coplanarity and Möller sign tests. Defaults
-   * to {@link scaledPlaneEps}'s f32-ULP floor for this pair's coordinate
-   * magnitude, not a fixed constant — see that function's doc.
+   * to {@link scaledPlaneEps}'s per-axis f32-ULP noise, projected onto each
+   * tested plane's own normal, not a fixed constant nor a single max over
+   * all axes; see that function's doc.
    */
   readonly planeEps?: number;
   /** BVH leaf size for per-mesh triangle BVHs. Default 8. */

--- a/packages/clash/src/contact/tri-tri.ts
+++ b/packages/clash/src/contact/tri-tri.ts
@@ -21,40 +21,83 @@ export type TriTriResult =
   | { readonly kind: "coplanar" };
 
 /**
+ * Direction-aware plane-distance tolerance: per-axis absolute rounding-noise
+ * amplitudes (world units), resolved into a scalar tolerance per plane by
+ * projecting them onto that plane's own unit normal:
+ *
+ *   eps(n) = max(floor, |n_x| * axisNoise_x + |n_y| * axisNoise_y + |n_z| * axisNoise_z)
+ *
+ * A signed plane distance is `dot(n, v) + d` for a unit normal `n`, so each
+ * coordinate's rounding noise enters it weighted by that axis's normal
+ * component; an axis orthogonal to the normal contributes nothing. A single
+ * scalar built from the max coordinate over ALL axes (the pre-fix
+ * `scaledPlaneEps`) is compared against a quantity it was not derived from:
+ * it lets one large-magnitude axis inflate the tolerance for planes whose
+ * normal has no component on that axis at all, fabricating coplanar verdicts
+ * across genuine clearances (see `scaledPlaneEps` in `./narrow-phase.js`).
+ */
+export interface ProjectedPlaneEps {
+  /** Per-axis absolute rounding-noise amplitude (world units). */
+  readonly axisNoise: Vec3;
+  /** Minimum tolerance, applied after projection. */
+  readonly floor: number;
+}
+
+export type PlaneEps = number | ProjectedPlaneEps;
+
+/** Resolve a {@link PlaneEps} into a scalar tolerance for the plane with
+ * (unnormalised) normal `n` of length `ln`. */
+function epsForPlane(planeEps: PlaneEps, n: Vec3, ln: number): number {
+  if (typeof planeEps === "number") return planeEps;
+  const { axisNoise, floor } = planeEps;
+  const projected =
+    (Math.abs(n[0]) * axisNoise[0] +
+      Math.abs(n[1]) * axisNoise[1] +
+      Math.abs(n[2]) * axisNoise[2]) /
+    ln;
+  return Math.max(floor, projected);
+}
+
+/**
  * Full Möller test.
  *
- * `planeEps` is the absolute tolerance on signed plane distance — distances
- * with |d| / |N| ≤ planeEps are treated as zero (on-plane). Defaults to 1e-6
- * in model-native units, which is only valid near the origin (see
- * `scaledPlaneEps` in `./narrow-phase.js`); the production call path
- * (`narrowPhase`) always supplies an explicit, coordinate-scaled value, so
- * this default only applies to direct/standalone callers.
+ * `planeEps` is the tolerance on signed plane distance: distances with
+ * |d| / |N| <= eps are treated as zero (on-plane). A scalar is used as-is; a
+ * {@link ProjectedPlaneEps} is resolved per plane against that plane's own
+ * normal, so each of the two plane tests gets its own direction-correct
+ * tolerance. Defaults to 1e-6 in model-native units, which is only valid
+ * near the origin (see `scaledPlaneEps` in `./narrow-phase.js`); the
+ * production call path (`narrowPhase`) always supplies an explicit,
+ * coordinate-scaled value, so this default only applies to
+ * direct/standalone callers.
  */
-export function triTriIntersect(a: Triangle, b: Triangle, planeEps = 1e-6): TriTriResult {
+export function triTriIntersect(a: Triangle, b: Triangle, planeEps: PlaneEps = 1e-6): TriTriResult {
   if (isDegenerate(a) || isDegenerate(b)) return { kind: "none" };
 
   // Plane of B
   const N2 = triangleNormalRaw(b);
   const ln2 = length3(N2);
   const d2 = -dot3(N2, b.v0);
+  const epsB = epsForPlane(planeEps, N2, ln2);
   const dA0 = (dot3(N2, a.v0) + d2) / ln2;
   const dA1 = (dot3(N2, a.v1) + d2) / ln2;
   const dA2 = (dot3(N2, a.v2) + d2) / ln2;
-  const sA0 = signOf(dA0, planeEps);
-  const sA1 = signOf(dA1, planeEps);
-  const sA2 = signOf(dA2, planeEps);
+  const sA0 = signOf(dA0, epsB);
+  const sA1 = signOf(dA1, epsB);
+  const sA2 = signOf(dA2, epsB);
   if (sA0 === sA1 && sA1 === sA2 && sA0 !== 0) return { kind: "none" };
 
   // Plane of A
   const N1 = triangleNormalRaw(a);
   const ln1 = length3(N1);
   const d1 = -dot3(N1, a.v0);
+  const epsA = epsForPlane(planeEps, N1, ln1);
   const dB0 = (dot3(N1, b.v0) + d1) / ln1;
   const dB1 = (dot3(N1, b.v1) + d1) / ln1;
   const dB2 = (dot3(N1, b.v2) + d1) / ln1;
-  const sB0 = signOf(dB0, planeEps);
-  const sB1 = signOf(dB1, planeEps);
-  const sB2 = signOf(dB2, planeEps);
+  const sB0 = signOf(dB0, epsA);
+  const sB1 = signOf(dB1, epsA);
+  const sB2 = signOf(dB2, epsA);
   if (sB0 === sB1 && sB1 === sB2 && sB0 !== 0) return { kind: "none" };
 
   // All-zero on either side → coplanar
@@ -66,9 +109,16 @@ export function triTriIntersect(a: Triangle, b: Triangle, planeEps = 1e-6): TriT
   const chordB = triChord(b, dB0, dB1, dB2);
   if (!chordA || !chordB) return { kind: "none" };
 
-  // Overlap along the common intersection line.
+  // Overlap along the common intersection line. The slop here compares
+  // coordinates along one world axis (`dAxis`), so a ProjectedPlaneEps
+  // resolves to that axis's own noise amplitude (the projection of
+  // `axisNoise` onto the axis unit vector), floored the same way.
   const D = cross3(N1, N2);
   const dAxis = dominantAxis(D);
+  const lineEps =
+    typeof planeEps === "number"
+      ? planeEps
+      : Math.max(planeEps.floor, planeEps.axisNoise[dAxis] as number);
   const ta0 = chordA[0][dAxis] as number;
   const ta1 = chordA[1][dAxis] as number;
   const tb0 = chordB[0][dAxis] as number;
@@ -79,7 +129,7 @@ export function triTriIntersect(a: Triangle, b: Triangle, planeEps = 1e-6): TriT
   const bMax = Math.max(tb0, tb1);
   const oMin = Math.max(aMin, bMin);
   const oMax = Math.min(aMax, bMax);
-  if (oMax < oMin - planeEps) return { kind: "none" };
+  if (oMax < oMin - lineEps) return { kind: "none" };
 
   // Reconstruct 3D endpoints of the overlap on the intersection line by
   // picking the chord whose parameter interval matches the overlap.


### PR DESCRIPTION
## What shipped broken

#2600 scaled the contact narrow phase's plane-distance tolerance to coordinate magnitude, but `scaledPlaneEps` in `packages/clash/src/contact/narrow-phase.ts` took the max abs coordinate over ALL THREE axes of both world AABBs. That epsilon is compared against a signed distance measured along ONE plane normal, so the tolerance was derived from a quantity it is not being compared against: an axis orthogonal to the normal contributes zero rounding noise to the distance, yet still inflated the tolerance.

## Measured reproduction

Two horizontal unit quads (normal Z, identical local geometry) with a genuine 2.0 mm Z-clearance:

- at the origin: 0 contacts (correct)
- at X = 10 km: 4 FABRICATED coplanar triangle pairs, clustered into a fabricated `surface` contact, because planeEps = 10001 * 2^-22 = 2.385 mm exceeds the real 2 mm gap, inflated entirely by the irrelevant X axis. Above roughly 8.4 km extent every near-parallel candidate pair reads as coplanar.

The new test encodes exactly this (offset axis deliberately different from the tested normal axis; max-over-axes and the projection coincide when they share an axis) and failed on unfixed code with `expected 4 to be +0`.

## Formulation adopted

Per-axis f32-ULP noise amplitudes, projected onto each tested plane's own unit normal:

    eps(n) = max(1e-6, |n_x| * ULP(extent_x) + |n_y| * ULP(extent_y) + |n_z| * ULP(extent_z))

resolved per plane inside `triTriIntersect` (each of the two Moller plane tests gets its own direction-correct tolerance; the intersection-line overlap slop resolves to the dominant axis's own noise). This follows the pattern #2622 established in `section-cutter.ts`: size a tolerance off the quantity the rounding noise actually scales with, never off an unrelated world magnitude.

The 1e-6 floor is preserved: the scaled tolerance must only ever widen relative to the fixed constant it replaced, never narrow it. A bare `extent * F32_ULP_SCALE` is far tighter than 1e-6 for any extent under ~4.19 m, which would reintroduce the dropped-shared-face bug #2600 exists to fix. A counter-counter-case test pins that a genuinely flush pair offset ALONG the tested normal (the #2600 case) is still recovered at 10 km.

## Blast radius

The contact module is consumed in-repo only by `useClash`'s focused-clash overlay (`contactClusters` builds the contact patch for the one focused pair), so the defect fabricated and merged contact VISUALISATION, not clash counts. The `@ifc-lite/clash` main export only re-exports `triangleArea` from the contact directory; the bulk detection engine (`engine-ts`) uses a separate triangle test. External consumers of the published `@ifc-lite/clash/contact` subpath would also have been affected, hence the changeset.

## Verification

- pnpm install --frozen-lockfile, pnpm build, pnpm typecheck, pnpm lint, node scripts/check-source-text-assertions.mjs, pnpm test: all exit 0
- Mutation check: fix reverted, test fails (`expected 4 to be +0`, exit 1); fix restored, 17/17 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)