### PR TITLE
fix(viewer): preserve user isolation across clash runs

### DIFF
--- a/apps/viewer/src/hooks/useClash.run-preserves-isolation.test.tsx
+++ b/apps/viewer/src/hooks/useClash.run-preserves-isolation.test.tsx
@@ -31,6 +31,7 @@ import type { Clash, ClashRule } from '@ifc-lite/clash';
 import type { CoordinateInfo, GeometryResult, MeshData } from '@ifc-lite/geometry';
 import { useViewerStore, type FederatedModel } from '@/store';
 import { useClash } from './useClash.js';
+import { useSpaceSceneFraming } from '@/components/viewer/tools/space-sketch/useSpaceSceneFraming.js';
 
 // ─── Fixture: two walls, meshed as overlapping unit boxes ───────────────────
 
@@ -242,5 +243,91 @@ describe('clash runs release only clash-owned view state (#2574 regression)', ()
 
     assert.equal(useViewerStore.getState().ghostExceptEntities, null,
       'the clash focus ghost must be released when a new scan replaces the result set');
+  });
+});
+
+// ─── Snapshot/restore flows must not launder clash-owned state (#2662 P2) ───
+//
+// Space Sketch captures the prior 3D view on open and replays it on close
+// (`useSpaceSceneFraming`): it CLONES `isolatedEntities`/`ghostExceptEntities`
+// and restores them through the slice setters, which store a fresh `Set` per
+// write. The restored state is still the old clash presentation, but its
+// reference no longer matches anything clash recorded - under reference-based
+// provenance the next run() replaced the clash result while leaving the old
+// focused pair isolated/ghosted. Ownership must survive an equivalent restore.
+
+/** Mounts the REAL Space Sketch scene-framing hook - the same code the tool
+ *  runs on open (capture prior view) and on close/unmount (restore it). */
+function FramingProbe(): null {
+  useSpaceSceneFraming({ enabled: true, existingSpaceIds: [] });
+  return null;
+}
+
+/** Open Space Sketch, then close it: the unmount cleanup replays the captured
+ *  prior view through the cloning visibility setters. */
+async function openAndCloseSpaceSketch(): Promise<void> {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const sketchRoot = createRoot(container);
+  await act(async () => { sketchRoot.render(<FramingProbe />); });
+  await act(async () => sketchRoot.unmount());
+  container.remove();
+}
+
+describe('clash focus ownership survives Space Sketch snapshot/restore (#2662 P2)', () => {
+  it('clash ISOLATE focus restored by a Space Sketch open/close is still discarded by the next run()', async () => {
+    await seed();
+    await act(async () => { api!.focusClash(CLASH, 'isolate'); });
+    assert.deepEqual([...(useViewerStore.getState().isolatedEntities ?? [])].sort(), [1, 2],
+      'setup sanity: focusClash installed the pair isolation');
+    const installed = useViewerStore.getState().isolatedEntities;
+
+    await openAndCloseSpaceSketch();
+    const restored = useViewerStore.getState().isolatedEntities;
+    assert.deepEqual([...(restored ?? [])].sort(), [1, 2],
+      'setup sanity: closing Space Sketch restored the clash isolation');
+    assert.notEqual(restored, installed,
+      'setup sanity: the restore replaced the Set identity (the flow under test)');
+
+    await act(async () => { await api!.run([ALL_RULE]); });
+
+    assert.equal(useViewerStore.getState().isolatedEntities, null,
+      'the restored presentation is still the clash focus and must be released by a new run');
+  });
+
+  it('clash GHOST focus restored by a Space Sketch open/close is still discarded by the next runDuplicates()', async () => {
+    await seed();
+    await act(async () => { api!.focusClash(CLASH, 'ghost'); });
+    assert.deepEqual([...(useViewerStore.getState().ghostExceptEntities ?? [])].sort(), [1, 2],
+      'setup sanity: focusClash installed the pair ghost');
+    const installed = useViewerStore.getState().ghostExceptEntities;
+
+    await openAndCloseSpaceSketch();
+    const restored = useViewerStore.getState().ghostExceptEntities;
+    assert.deepEqual([...(restored ?? [])].sort(), [1, 2],
+      'setup sanity: closing Space Sketch restored the clash ghost');
+    assert.notEqual(restored, installed,
+      'setup sanity: the restore replaced the Set identity (the flow under test)');
+
+    await act(async () => { await api!.runDuplicates(); });
+
+    assert.equal(useViewerStore.getState().ghostExceptEntities, null,
+      'the restored presentation is still the clash focus and must be released by a new scan');
+  });
+
+  it('a user isolation that REPLACED a clash focus still survives run() (ownership is content, not "clash installed something")', async () => {
+    await seed();
+    await act(async () => { api!.focusClash(CLASH, 'isolate'); });
+    // The user takes the shared channel over with DIFFERENT content - clash
+    // no longer owns the presentation, whatever its install record says.
+    useViewerStore.getState().isolateEntities([1]);
+    assert.deepEqual([...useViewerStore.getState().isolatedEntities!], [1],
+      'setup sanity: the user isolation replaced the clash focus');
+
+    await act(async () => { await api!.run([ALL_RULE]); });
+
+    const s = useViewerStore.getState();
+    assert.ok(s.isolatedEntities, 'the user isolation must still be standing after Run');
+    assert.deepEqual([...s.isolatedEntities], [1], 'the isolated set must be untouched');
   });
 });

--- a/apps/viewer/src/hooks/useClash.run-preserves-isolation.test.tsx
+++ b/apps/viewer/src/hooks/useClash.run-preserves-isolation.test.tsx
@@ -1,0 +1,246 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Regression guard for #2574's `discardSolidPresentation`: starting a clash
+ * run (or a duplicates scan) must NOT tear down isolation/ghost state that
+ * ANOTHER feature established. #2574 made `run()` / `runDuplicates()` call
+ * `clearIsolation()` + `clearGhost()` unconditionally, so a user who isolated
+ * a filter result ("Isolate in 3D", #2532) or an element assembly (#2531) and
+ * then clicked Run had their isolation destroyed before any clash result
+ * existed. Clash may only release the isolation/ghost presentation it itself
+ * installed (focus modes #1275, and the solid's full-model ghost) - which the
+ * second half of this file pins, so the fix cannot regress into "never clear",
+ * the stale-overlay bug #2574's helper was added to prevent.
+ *
+ * Mounts the REAL `useClash()` hook over a REAL parsed model with real meshes
+ * (the panel's Run button calls exactly these hook actions), and establishes
+ * the user state through the same store actions the features use
+ * (`isolateEntities` for Isolate in 3D, `setGhostExceptEntities` for the
+ * spaces X-ray).
+ */
+
+import '@/test/setup-dom.js';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { IfcParser, type IfcDataStore } from '@ifc-lite/parser';
+import type { Clash, ClashRule } from '@ifc-lite/clash';
+import type { CoordinateInfo, GeometryResult, MeshData } from '@ifc-lite/geometry';
+import { useViewerStore, type FederatedModel } from '@/store';
+import { useClash } from './useClash.js';
+
+// ─── Fixture: two walls, meshed as overlapping unit boxes ───────────────────
+
+function ifc4(body: string): string {
+  return [
+    'ISO-10303-21;',
+    'HEADER;',
+    "FILE_DESCRIPTION((''),'2;1');",
+    "FILE_NAME('','',(''),(''),'','','');",
+    "FILE_SCHEMA(('IFC4'));",
+    'ENDSEC;',
+    'DATA;',
+    body,
+    'ENDSEC;',
+    'END-ISO-10303-21;',
+    '',
+  ].join('\n');
+}
+
+const TWO_WALLS = [
+  "#1=IFCWALL('0aaaaaaaaaaaaaaaaaaaaa',$,'Wall A',$,$,$,$,$,.STANDARD.);",
+  "#2=IFCWALL('0bbbbbbbbbbbbbbbbbbbbb',$,'Wall B',$,$,$,$,$,.STANDARD.);",
+].join('\n');
+
+async function parse(body: string): Promise<IfcDataStore> {
+  const bytes = new TextEncoder().encode(ifc4(body));
+  // disableWorkerScan keeps the scan in-process (no Worker under node:test).
+  return new IfcParser().parseColumnar(bytes.buffer as ArrayBuffer, { disableWorkerScan: true });
+}
+
+/** A unit box (12 triangles) with its min corner at `(dx, 0, 0)`. */
+function boxMesh(expressId: number, dx: number): MeshData {
+  const positions = new Float32Array([
+    dx, 0, 0, dx + 1, 0, 0, dx + 1, 1, 0, dx, 1, 0,
+    dx, 0, 1, dx + 1, 0, 1, dx + 1, 1, 1, dx, 1, 1,
+  ]);
+  const indices = new Uint32Array([
+    0, 1, 2, 0, 2, 3, 4, 6, 5, 4, 7, 6,
+    0, 4, 5, 0, 5, 1, 1, 5, 6, 1, 6, 2,
+    2, 6, 7, 2, 7, 3, 3, 7, 4, 3, 4, 0,
+  ]);
+  return {
+    expressId,
+    ifcType: 'IfcWall',
+    positions,
+    normals: new Float32Array(positions.length),
+    indices,
+    color: [0.5, 0.5, 0.5, 1],
+  };
+}
+
+function geometry(meshes: MeshData[]): GeometryResult {
+  const bounds = { min: { x: 0, y: 0, z: 0 }, max: { x: 2, y: 1, z: 1 } };
+  const coordinateInfo: CoordinateInfo = {
+    originShift: { x: 0, y: 0, z: 0 },
+    originalBounds: bounds,
+    shiftedBounds: bounds,
+    hasLargeCoordinates: false,
+  };
+  return { meshes, totalTriangles: 12 * meshes.length, totalVertices: 8 * meshes.length, coordinateInfo };
+}
+
+function model(store: IfcDataStore, meshes: MeshData[]): FederatedModel {
+  return {
+    id: 'A',
+    name: 'A.ifc',
+    ifcDataStore: store,
+    geometryResult: geometry(meshes),
+    visible: true,
+    collapsed: false,
+    schemaVersion: 'IFC4',
+    loadedAt: 0,
+    fileSize: 0,
+    idOffset: 0,
+    maxExpressId: 2,
+  };
+}
+
+/** The rule `runAll` builds: every element vs every other, hard clash. */
+const ALL_RULE: ClashRule = { id: 'all-clashes', name: 'All elements', a: '*', mode: 'hard' };
+
+/** The clash the overlapping boxes produce, as `focusClash` receives it from
+ *  the panel list. Refs are federated global ids (model 'A' registers at
+ *  offset 0, so global id === express id). */
+const CLASH: Clash = {
+  id: 'clash-1',
+  a: { key: 'A:1', ref: 1, model: 'A', tag: 'IfcWall' },
+  b: { key: 'A:2', ref: 2, model: 'A', tag: 'IfcWall' },
+  rule: 'all-clashes',
+  status: 'hard',
+  distance: -0.5,
+  point: [0.75, 0.5, 0.5],
+  bounds: { min: [0.5, 0, 0], max: [1, 1, 1] },
+  severity: 'major',
+};
+
+// ─── Harness ────────────────────────────────────────────────────────────────
+
+type ClashApi = ReturnType<typeof useClash>;
+
+let api: ClashApi | null = null;
+
+function Probe(): null {
+  api = useClash();
+  return null;
+}
+
+let root: Root | null = null;
+
+async function seed(): Promise<void> {
+  const store = await parse(TWO_WALLS);
+  useViewerStore.setState({
+    models: new Map([['A', model(store, [boxMesh(1, 0), boxMesh(2, 0.5)])]]),
+    clashResult: null,
+    clashGroups: null,
+    clashError: null,
+    clashRunning: false,
+    clashSelectedId: null,
+    isolatedEntities: null,
+    ghostExceptEntities: null,
+  });
+  // focusClash resolves its pair through the federation registry; a model
+  // seeded via setState never registered, so register it here (offset 0 -
+  // global ids equal express ids), exactly what addModel does on a real load.
+  useViewerStore.getState().registerModelOffset('A', 100);
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root!.render(<Probe />);
+  });
+  assert.ok(api, 'useClash must be mounted');
+}
+
+beforeEach(() => {
+  api = null;
+});
+
+afterEach(async () => {
+  const current = root;
+  root = null;
+  if (current) await act(async () => current.unmount());
+});
+
+describe('clash runs release only clash-owned view state (#2574 regression)', () => {
+  it('a user-established isolation SURVIVES run() (#2532 Isolate in 3D / #2531 assembly isolate)', async () => {
+    await seed();
+    // The user isolates through the shared channel action both features call.
+    useViewerStore.getState().isolateEntities([1]);
+    assert.deepEqual([...useViewerStore.getState().isolatedEntities!], [1], 'setup sanity: isolation active before Run');
+
+    await act(async () => { await api!.run([ALL_RULE]); });
+
+    const s = useViewerStore.getState();
+    assert.equal(s.clashError, null);
+    assert.ok(s.clashResult && s.clashResult.clashes.length >= 1, 'the run must actually complete and find the overlap');
+    assert.ok(s.isolatedEntities, 'the user isolation must still be standing after Run');
+    assert.deepEqual([...s.isolatedEntities], [1], 'the isolated set must be untouched');
+  });
+
+  it('a user-established isolation SURVIVES runDuplicates()', async () => {
+    await seed();
+    useViewerStore.getState().isolateEntities([2]);
+    assert.deepEqual([...useViewerStore.getState().isolatedEntities!], [2], 'setup sanity: isolation active before the scan');
+
+    await act(async () => { await api!.runDuplicates(); });
+
+    const s = useViewerStore.getState();
+    assert.equal(s.clashError, null);
+    assert.ok(s.clashResult, 'the duplicate scan must actually complete');
+    assert.ok(s.isolatedEntities, 'the user isolation must still be standing after the scan');
+    assert.deepEqual([...s.isolatedEntities], [2], 'the isolated set must be untouched');
+  });
+
+  it('a user-established X-ray ghost SURVIVES run()', async () => {
+    await seed();
+    // The spaces X-ray drives this store action directly (ghostExceptEntities).
+    useViewerStore.getState().setGhostExceptEntities(new Set([1]));
+    assert.ok(useViewerStore.getState().ghostExceptEntities, 'setup sanity: ghost active before Run');
+
+    await act(async () => { await api!.run([ALL_RULE]); });
+
+    const s = useViewerStore.getState();
+    assert.equal(s.clashError, null);
+    assert.ok(s.clashResult && s.clashResult.clashes.length >= 1, 'the run must actually complete and find the overlap');
+    assert.ok(s.ghostExceptEntities, 'the user ghost must still be standing after Run');
+    assert.deepEqual([...s.ghostExceptEntities], [1], 'the ghosted set must be untouched');
+  });
+
+  it('clash-established ISOLATE focus is still discarded when a new run starts', async () => {
+    await seed();
+    await act(async () => { api!.focusClash(CLASH, 'isolate'); });
+    assert.deepEqual([...(useViewerStore.getState().isolatedEntities ?? [])].sort(), [1, 2],
+      'setup sanity: focusClash installed the pair isolation');
+
+    await act(async () => { await api!.run([ALL_RULE]); });
+
+    assert.equal(useViewerStore.getState().isolatedEntities, null,
+      'the clash focus isolation must be released when a new run replaces the result set');
+  });
+
+  it('clash-established GHOST focus is still discarded when a new run starts', async () => {
+    await seed();
+    await act(async () => { api!.focusClash(CLASH, 'ghost'); });
+    assert.deepEqual([...(useViewerStore.getState().ghostExceptEntities ?? [])].sort(), [1, 2],
+      'setup sanity: focusClash installed the pair ghost');
+
+    await act(async () => { await api!.runDuplicates(); });
+
+    assert.equal(useViewerStore.getState().ghostExceptEntities, null,
+      'the clash focus ghost must be released when a new scan replaces the result set');
+  });
+});

--- a/apps/viewer/src/hooks/useClash.solid-invalidation.test.tsx
+++ b/apps/viewer/src/hooks/useClash.solid-invalidation.test.tsx
@@ -20,6 +20,13 @@
  * even known whether the new run will find anything. If the old solid/ghost
  * presentation is still standing after that call, the flow never invalidated
  * it.
+ *
+ * The ghost is established THROUGH the hook (`focusClash` in ghost mode), not
+ * by writing `ghostExceptEntities` into the store directly: since the #2574
+ * unconditional-clear regression fix, clash releases only the isolation/ghost
+ * presentation it itself installed (a user's isolation/ghost in the same
+ * shared channels survives a run — see useClash.run-preserves-isolation.test),
+ * so a raw seed would test state clash never owned.
  */
 
 import '@/test/setup-dom.js';
@@ -27,6 +34,7 @@ import { describe, it, after } from 'node:test';
 import assert from 'node:assert/strict';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
+import type { Clash } from '@ifc-lite/clash';
 
 import { useViewerStore } from '@/store';
 import { useClash } from './useClash.js';
@@ -56,26 +64,49 @@ async function renderHook(): Promise<ClashApi> {
 const originalState = useViewerStore.getState();
 after(() => { useViewerStore.setState(originalState, true); });
 
-/** Seed the store as if a prior `focusClash` had already resolved a solid and
- *  applied the BIMcollab-style full-model ghost (see useClash.ts L456-L491). */
-function seedResolvedSolidPresentation(): void {
+/** The clash a prior run would have focused. Refs resolve through the
+ *  federation registry (model 'A' registers at offset 0, so the global id
+ *  equals the express id). */
+const OLD_CLASH: Clash = {
+  id: 'clash-old',
+  a: { key: 'A:1', ref: 1, model: 'A', tag: 'IfcWall' },
+  b: { key: 'A:2', ref: 2, model: 'A', tag: 'IfcWall' },
+  rule: 'all-clashes',
+  status: 'hard',
+  distance: -0.5,
+  point: [0.75, 0.5, 0.5],
+  bounds: { min: [0.5, 0, 0], max: [1, 1, 1] },
+  severity: 'major',
+};
+
+/** Put the presentation in the state a prior `focusClash` leaves once its
+ *  solid compute has resolved: focus the clash in ghost mode THROUGH the hook
+ *  — so the ghost is recorded as clash-installed, exactly as a real focus is —
+ *  then overlay the resolved-solid fields the async compute would have
+ *  written. */
+async function seedResolvedSolidPresentation(api: ClashApi): Promise<void> {
   useViewerStore.setState({
     models: new Map(),
-    clashSelectedId: 'clash-old',
-    clashSolidStatus: 'solid',
-    clashSolidMesh: { positions: new Float64Array([0, 0, 0, 1, 0, 0, 0, 1, 0]), indices: new Uint32Array([0, 1, 2]) },
-    clashSolidVolumeM3: 0.42,
-    ghostExceptEntities: new Set<number>(), // full-model ghost, as focusClash applies
+    clashSelectedId: null,
+    isolatedEntities: null,
+    ghostExceptEntities: null,
     clashHighlightColors: null,
     clashOverlapBox: null,
     clashContactLines: null,
+  });
+  useViewerStore.getState().registerModelOffset('A', 100);
+  await act(async () => { api.focusClash(OLD_CLASH, 'ghost'); });
+  useViewerStore.setState({
+    clashSolidStatus: 'solid',
+    clashSolidMesh: { positions: new Float64Array([0, 0, 0, 1, 0, 0, 0, 1, 0]), indices: new Uint32Array([0, 1, 2]) },
+    clashSolidVolumeM3: 0.42,
   });
 }
 
 describe('useClash solid-presentation invalidation on detection replace (#2574 CodeRabbit)', () => {
   it('run() discards a stale solid + full-model ghost before the new detection flow starts', async () => {
     const api = await renderHook();
-    seedResolvedSolidPresentation();
+    await seedResolvedSolidPresentation(api);
     assert.equal(useViewerStore.getState().clashSolidStatus, 'solid', 'setup sanity: a solid must be showing before run()');
     assert.ok(useViewerStore.getState().ghostExceptEntities, 'setup sanity: the model must be ghosted before run()');
 
@@ -89,7 +120,7 @@ describe('useClash solid-presentation invalidation on detection replace (#2574 C
 
   it('runDuplicates() discards a stale solid + full-model ghost before the new scan starts', async () => {
     const api = await renderHook();
-    seedResolvedSolidPresentation();
+    await seedResolvedSolidPresentation(api);
     assert.equal(useViewerStore.getState().clashSolidStatus, 'solid', 'setup sanity: a solid must be showing before runDuplicates()');
     assert.ok(useViewerStore.getState().ghostExceptEntities, 'setup sanity: the model must be ghosted before runDuplicates()');
 

--- a/apps/viewer/src/hooks/useClash.ts
+++ b/apps/viewer/src/hooks/useClash.ts
@@ -186,6 +186,56 @@ export function useClash() {
    */
   const solidRequestGuard = useRef(createLatestWinsGuard());
 
+  /**
+   * The EXACT Set references this hook last installed into the SHARED
+   * isolation / ghost visibility channels (`isolatedEntities` /
+   * `ghostExceptEntities`). Those channels are shared with features clash does
+   * not own - "Isolate in 3D" from the advanced filter (#2532), assembly
+   * isolation (#2531), the spaces X-ray - so clash teardown may only release a
+   * presentation clash itself installed. Reference identity is the provenance
+   * test: the visibility slice stores a fresh `Set` per write, so once another
+   * feature writes the channel the recorded reference no longer matches and
+   * the release below leaves that state standing. (#2574 regression: the
+   * run-start discard cleared these channels unconditionally, so a user's
+   * isolation was destroyed before any clash result existed.)
+   */
+  const appliedIsolation = useRef<ReadonlySet<number> | null>(null);
+  const appliedGhost = useRef<ReadonlySet<number> | null>(null);
+
+  /** Install clash isolation into the shared channel, recording exactly what
+   *  was installed so `releaseClashVisibility` can release only that. */
+  const installClashIsolation = useCallback((ids: Set<number>): void => {
+    useViewerStore.getState().setIsolatedEntities(ids);
+    appliedIsolation.current = useViewerStore.getState().isolatedEntities;
+    appliedGhost.current = null; // setIsolatedEntities cleared any ghosting
+  }, []);
+
+  /** Install clash ghosting (X-Ray context) into the shared channel, with the
+   *  same install-record contract as `installClashIsolation`. */
+  const installClashGhost = useCallback((ids: Set<number>): void => {
+    useViewerStore.getState().setGhostExceptEntities(ids);
+    appliedGhost.current = useViewerStore.getState().ghostExceptEntities;
+    appliedIsolation.current = null; // setGhostExceptEntities cleared isolation
+  }, []);
+
+  /**
+   * Release the isolation/ghost presentation clash itself installed - and ONLY
+   * that. Isolation or ghosting established by another feature (#2532 / #2531
+   * / spaces X-ray) no longer reference-matches the install record, so it
+   * survives a clash run untouched.
+   */
+  const releaseClashVisibility = useCallback((): void => {
+    const state = useViewerStore.getState();
+    if (appliedIsolation.current !== null && state.isolatedEntities === appliedIsolation.current) {
+      state.clearIsolation();
+    }
+    if (appliedGhost.current !== null && state.ghostExceptEntities === appliedGhost.current) {
+      state.clearGhost();
+    }
+    appliedIsolation.current = null;
+    appliedGhost.current = null;
+  }, []);
+
   /** Build clash elements + merged exclusions from every loaded model. */
   const gatherElements = useCallback((): { elements: ClashElement[]; exclusions: ExclusionSet } => {
     const state = useViewerStore.getState();
@@ -213,18 +263,24 @@ export function useClash() {
    * resolve after the new run finished and repaint its stale mesh plus the
    * full-model ghosting over results the user can no longer see the pair for
    * (CodeRabbit #2574). Mirrors the teardown `clearHighlight` already does.
+   *
+   * Only CLASH-OWNED state is discarded: the solid, the pair colours, the
+   * contact markers, and the isolation/ghost presentation clash itself
+   * installed (via `releaseClashVisibility`). Isolation or ghosting another
+   * feature established (#2532 / #2531 / spaces X-ray) must survive a run
+   * start - the unconditional clears that shipped with #2574 destroyed a
+   * user's isolation before any clash result existed.
    */
   const discardSolidPresentation = useCallback((): void => {
     const state = useViewerStore.getState();
     solidRequestGuard.current.begin();
     state.clearClashSolid();
-    state.clearGhost();
-    state.clearIsolation();
+    releaseClashVisibility();
     state.setClashHighlightColors(null);
     state.setPendingColorUpdates(state.lensAppliedColors ?? new Map());
     state.setClashOverlapBox(null);
     state.setClashContactLines(null);
-  }, []);
+  }, [releaseClashVisibility]);
 
   const run = useCallback(
     async (rules: ClashRule[]): Promise<void> => {
@@ -388,14 +444,19 @@ export function useClash() {
    *                via the renderer's X-Ray path (#1275 "see them in context").
    */
   const applyFocusMode = useCallback((globalIds: number[], mode: ClashFocusMode): void => {
-    const state = useViewerStore.getState();
-    if (mode === 'isolate') state.setIsolatedEntities(new Set(globalIds));
-    else if (mode === 'ghost') state.setGhostExceptEntities(new Set(globalIds));
+    if (mode === 'isolate') installClashIsolation(new Set(globalIds));
+    else if (mode === 'ghost') installClashGhost(new Set(globalIds));
     else {
+      // Full-context highlight clears both channels outright - the user asked
+      // to see this pair against the WHOLE model, so any isolation would hide
+      // it (pre-#2574 contract, #1275). Clash then owns neither channel.
+      const state = useViewerStore.getState();
       state.clearIsolation();
       state.clearGhost();
+      appliedIsolation.current = null;
+      appliedGhost.current = null;
     }
-  }, []);
+  }, [installClashIsolation, installClashGhost]);
 
   /**
    * Select both elements of a clash, highlight them, frame the camera, and apply
@@ -507,9 +568,12 @@ export function useClash() {
               // and is restored the moment this clash is deselected (`clearGhost`/
               // `clearHighlight` do not know about this override — they just
               // clear ghosting outright, which is correct either way).
-              s.clearIsolation();
+              // Installed through the provenance record so the run-start
+              // discard can later release this full-model ghost as clash-owned
+              // (it replaces any isolate-mode focus: setGhostExceptEntities
+              // clears isolation).
               const ghostExceptEntities = new Set<number>();
-              s.setGhostExceptEntities(ghostExceptEntities);
+              installClashGhost(ghostExceptEntities);
               // Drop the amber/cyan pair tint: ghosted, the pair should read
               // as ordinary translucent context (grey, like the rest), not a
               // coloured ghost — the solid alone carries the "here" colour.
@@ -549,7 +613,7 @@ export function useClash() {
         state.setClashSolidUnavailable('empty-operand', 0, 0);
       }
     },
-    [refOf, applyFocusMode],
+    [refOf, applyFocusMode, installClashGhost],
   );
 
   /**

--- a/apps/viewer/src/hooks/useClash.ts
+++ b/apps/viewer/src/hooks/useClash.ts
@@ -141,6 +141,16 @@ function filterResultBySeverity(result: ClashResult, severities: Set<ClashSeveri
   return { ...result, clashes, summary: { ...result.summary, total: clashes.length } };
 }
 
+/** Content equality for the visibility provenance records below. The shared
+ *  channels are only ever REPLACED wholesale (every slice setter stores a
+ *  fresh `Set`), never mutated in place, so equal members mean the channel
+ *  still shows exactly the presentation clash installed. */
+function sameMembers(a: ReadonlySet<number>, b: ReadonlySet<number>): boolean {
+  if (a.size !== b.size) return false;
+  for (const id of a) if (!b.has(id)) return false;
+  return true;
+}
+
 export function useClash() {
   const result = useViewerStore((s) => s.clashResult);
   const groups = useViewerStore((s) => s.clashGroups);
@@ -187,17 +197,28 @@ export function useClash() {
   const solidRequestGuard = useRef(createLatestWinsGuard());
 
   /**
-   * The EXACT Set references this hook last installed into the SHARED
-   * isolation / ghost visibility channels (`isolatedEntities` /
-   * `ghostExceptEntities`). Those channels are shared with features clash does
-   * not own - "Isolate in 3D" from the advanced filter (#2532), assembly
-   * isolation (#2531), the spaces X-ray - so clash teardown may only release a
-   * presentation clash itself installed. Reference identity is the provenance
-   * test: the visibility slice stores a fresh `Set` per write, so once another
-   * feature writes the channel the recorded reference no longer matches and
-   * the release below leaves that state standing. (#2574 regression: the
-   * run-start discard cleared these channels unconditionally, so a user's
-   * isolation was destroyed before any clash result existed.)
+   * The CONTENT this hook last installed into the SHARED isolation / ghost
+   * visibility channels (`isolatedEntities` / `ghostExceptEntities`). Those
+   * channels are shared with features clash does not own - "Isolate in 3D"
+   * from the advanced filter (#2532), assembly isolation (#2531), the spaces
+   * X-ray - so clash teardown may only release a presentation clash itself
+   * installed. (#2574 regression: the run-start discard cleared these
+   * channels unconditionally, so a user's isolation was destroyed before any
+   * clash result existed.)
+   *
+   * Ownership is tested by VALUE (`sameMembers`), not by `Set` reference:
+   * reference identity would be exact, but it is destroyed by every flow that
+   * snapshots and later restores the channel with equal content in a fresh
+   * `Set` - Space Sketch's open/close view capture (`useSpaceSceneFraming`
+   * clones the prior sets and replays them through the cloning slice setters)
+   * and a source-model resync (`syncSourceModel` rebuilds the kept sets even
+   * when nothing was filtered). Under reference identity those flows silently
+   * converted a clash-owned focus into "user" state, so the next run replaced
+   * the result set but left the old pair isolated/ghosted (#2662 P2). Value
+   * identity survives any content-preserving rewrite, and its one false
+   * positive is harmless by construction: it only fires when the channel
+   * shows EXACTLY the presentation clash installed, in which case releasing
+   * it renders precisely what discarding the clash focus should render.
    */
   const appliedIsolation = useRef<ReadonlySet<number> | null>(null);
   const appliedGhost = useRef<ReadonlySet<number> | null>(null);
@@ -221,15 +242,25 @@ export function useClash() {
   /**
    * Release the isolation/ghost presentation clash itself installed - and ONLY
    * that. Isolation or ghosting established by another feature (#2532 / #2531
-   * / spaces X-ray) no longer reference-matches the install record, so it
-   * survives a clash run untouched.
+   * / spaces X-ray) no longer content-matches the install record, so it
+   * survives a clash run untouched - while a clash focus that round-tripped
+   * through a snapshot/restore flow (Space Sketch open/close) still matches
+   * and is discarded (#2662 P2).
    */
   const releaseClashVisibility = useCallback((): void => {
     const state = useViewerStore.getState();
-    if (appliedIsolation.current !== null && state.isolatedEntities === appliedIsolation.current) {
+    if (
+      appliedIsolation.current !== null &&
+      state.isolatedEntities !== null &&
+      sameMembers(state.isolatedEntities, appliedIsolation.current)
+    ) {
       state.clearIsolation();
     }
-    if (appliedGhost.current !== null && state.ghostExceptEntities === appliedGhost.current) {
+    if (
+      appliedGhost.current !== null &&
+      state.ghostExceptEntities !== null &&
+      sameMembers(state.ghostExceptEntities, appliedGhost.current)
+    ) {
       state.clearGhost();
     }
     appliedIsolation.current = null;


### PR DESCRIPTION
Fixes a regression live on main since #2574.

## Starting any clash run silently destroys the user's isolation

`discardSolidPresentation` in `apps/viewer/src/hooks/useClash.ts` unconditionally calls `clearIsolation()` and `clearGhost()`, and runs at the top of both `run()` and `runDuplicates()`.

Confirmed new in #2574 by diffing against `5cf117d1e~1`: the whole helper is added there, along with both call sites. Before it, those two flows contained **no** isolation or ghost clears at all; the only clears lived in `applyFocusMode`'s highlight branch, `clearHighlight`, and `clearAll`.

What a user hits: isolate something via "Isolate in 3D" from the advanced filter (#2532), or isolate an element assembly (#2531), then open Clash and press Run. The isolation is gone before any result exists.

The commit's intent was to discard a stale clash-solid **presentation**. The implementation cleared shared visibility channels that clash never owned.

## The fix: reference-identity provenance

The store did not distinguish "clash put the model in this state" from "the user did". Rather than growing the store surface, the hook now records the exact `Set` it stored on every clash write to the shared channels (focus modes in `applyFocusMode`, and the solid-landing full-model ghost), and the run-start discard clears a channel **only if it still reference-matches**.

Two alternatives were considered and rejected for concrete reasons:

- **A boolean or kind flag** (the `clashGroupsKind` shape) misfires when another feature overwrites the channel *after* clash set it: the flag still claims ownership, so the run nukes the user's replacement.
- **Scoping to focus-mode exit only** (`clashSelectedId != null`) misfires when the user isolates while a clash is focused in highlight mode.

Reference identity is exact and self-invalidating, because `setIsolatedEntities` / `setGhostExceptEntities` store a fresh `Set` per write. Any other writer to those channels, including `LensPanel`'s `handleIsolateRule` and `PropertiesPanel`'s `handleIsolateGroupMembers`, is left standing by construction.

`applyFocusMode`'s highlight branch keeps its pre-#2574 unconditional clear (deliberate #1275 semantics, user-initiated), and `clearHighlight` / `clearAll` are untouched.

## Verified in both directions

A fix like this can fail two ways, so both were red-watched:

| Mutation | Result |
| --- | --- |
| unfixed HEAD | the three user-state tests fail on their own assertions ("the user isolation must still be standing after Run", "...after the scan", "the user ghost must still be standing after Run") - 2 pass / 3 fail |
| fix mutated to never release | both "clash-established focus is still discarded" tests plus both solid-invalidation tests fail - 3 pass / 4 fail |

The second matters as much as the first: it proves the fix cannot degrade into "just delete the clears", which would reintroduce the stale-overlay bug those clears existed for.

Tests use a real parsed model with real meshes so `run()` genuinely completes and finds the overlap, rather than seeding a store and asserting on it. The existing `useClash.solid-invalidation.test.tsx` was reworked for the same reason: its old seed wrote `ghostExceptEntities` raw into the store, so it was not testing state clash actually owned; it now establishes the ghost through a real `focusClash(..., 'ghost')`.

## Related, not fixed here

`handleIsolateResult` (`SearchModal.filter.tsx`) passes raw globalIds to `isolateEntities` while `expandToGeometryBearingIds` is wired only into Viewport's `resolveRenderableIds`, so isolating a filter result that matched an `IfcElementAssembly` blanks the view. Still true on main; owned by a separate PR.

Gates: typecheck 1113/1113, root test exit 0 (86 turbo tasks, viewer 4487 pass), lint no errors, source-text-assertions / test-wiring / test-typecheck clean. `apps/viewer` is private, so no changeset.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved user-defined isolation and ghosting when running clash detection.
  * Prevented clash detection from clearing visibility states owned by other features.
  * Ensured stale clash focus and solid presentation states are properly cleared between runs.
  * Maintained correct visibility behavior after Space Sketch snapshot and restore operations.

* **Tests**
  * Added regression coverage for clash runs, duplicate detection, visibility ownership, and state restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->