### PR TITLE
fix(scripts): fail loud on ANY unrecognised TS diagnostic, not only when nothing parsed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -438,7 +438,11 @@ jobs:
       # A #2634 review found the fail-loud branch only engaged when the whole
       # run was unparseable — a run with one recognised diagnostic and one
       # unrecognised one silently dropped the unrecognised one instead of
-      # failing. Pinned here so that gap can't reopen unnoticed.
+      # failing. Pinned here so that gap can't reopen unnoticed. The #2663
+      # review found the twin gap one level up: the exit status itself was
+      # never inspected, so an ENOBUFS-truncated or OOM-killed run handed the
+      # classifier a prefix that parsed cleanly into a confident undercount.
+      # untrustworthyExitReason is pinned in the same file.
       - name: Check unused-locals output classification
         run: node --test scripts/lib/unused-locals-classify.test.mjs
       # The server-parse root-attribute table (attr_indices.rs) is generated

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -433,6 +433,14 @@ jobs:
       # comment-awareness rests on (a lone apostrophe once blinded it).
       - name: Check server-bin parity gate regressions
         run: node --test scripts/check-server-bin-targets.test.mjs scripts/lib/server-bin-targets-parse.test.mjs
+      # Unit tests for the branching check-unused-locals.mjs uses to decide
+      # "real violation" vs "does not compile" vs "cannot parse this output".
+      # A #2634 review found the fail-loud branch only engaged when the whole
+      # run was unparseable — a run with one recognised diagnostic and one
+      # unrecognised one silently dropped the unrecognised one instead of
+      # failing. Pinned here so that gap can't reopen unnoticed.
+      - name: Check unused-locals output classification
+        run: node --test scripts/lib/unused-locals-classify.test.mjs
       # The server-parse root-attribute table (attr_indices.rs) is generated
       # from @ifc-lite/parser's SCHEMA_REGISTRY — the SAME table the in-browser
       # parse resolves names against. Guard that the committed file is in sync

--- a/scripts/check-unused-locals.mjs
+++ b/scripts/check-unused-locals.mjs
@@ -27,7 +27,7 @@ import { readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join, relative } from 'node:path';
 import { writeTestProgram, GENERATED_CONFIG } from './typecheck-tests.mjs';
-import { classifyTscOutput } from './lib/unused-locals-classify.mjs';
+import { classifyTscOutput, untrustworthyExitReason } from './lib/unused-locals-classify.mjs';
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
 const baselinePath = join(repoRoot, 'scripts', 'unused-locals-baseline.json');
@@ -107,6 +107,22 @@ function countViolations(dir) {
     // upstream of tsc in this spawn chain that ignores both of the above)
     // before matching, rather than trusting the two defenses above blindly.
     const output = stripAnsi(`${err.stdout ?? ''}${err.stderr ?? ''}`);
+    // Before the text is classified at all: was this even a tsc run that
+    // finished? A truncated capture (ENOBUFS) or a killed child (OOM/SIGKILL)
+    // hands back a PREFIX of tsc's diagnostics, and a prefix of well-formed
+    // diagnostics parses perfectly — 5000 diagnostics came back as a confident
+    // `{ kind: 'violations', count: 97 }` in the #2663 review, with err.code
+    // unread. `--update` would then bake that undercount into the baseline and
+    // lower the bar permanently. Only a plain numeric exit status is trusted.
+    const badExit = untrustworthyExitReason(err);
+    if (badExit) {
+      console.error(`❌ check-unused-locals could not run tsc to completion for ${dir}: ${badExit}.`);
+      console.error('   Any diagnostics captured are a truncated prefix, not a complete count,');
+      console.error('   so this run cannot be measured — and must never be written to the baseline.');
+      console.error('\n   Raw (ANSI-stripped) partial output:\n');
+      console.error(output.split('\n').map((l) => `   ${l}`).join('\n'));
+      process.exit(1);
+    }
     // The actual accounting lives in scripts/lib/unused-locals-classify.mjs,
     // unit-tested on its own (scripts/lib/unused-locals-classify.test.mjs) —
     // including the mixed-output case where one diagnostic parses fine and a
@@ -138,9 +154,10 @@ function countViolations(dir) {
     }
     if (result.kind === 'no-diagnostics') {
       // Non-zero exit, and nothing here explains it: no unused diagnostics, no
-      // other `error TS####`, no TS diagnostic of any kind. tsc never ran, or
-      // died without reporting — a missing binary, a killed process, a failure
-      // printed in a shape this does not parse. The one thing that must not
+      // other `error TS####`, no TS diagnostic of any kind. The exit itself
+      // was clean (a killed child, a truncated capture and a failed spawn all
+      // exited above), so tsc ran and returned non-zero while printing a
+      // failure in a shape this does not parse. The one thing that must not
       // happen is calling it zero, which would read as a clean package and
       // could be written into the baseline as one (review, #2603).
       return { count: 0, unmeasurable: true };

--- a/scripts/check-unused-locals.mjs
+++ b/scripts/check-unused-locals.mjs
@@ -27,6 +27,7 @@ import { readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join, relative } from 'node:path';
 import { writeTestProgram, GENERATED_CONFIG } from './typecheck-tests.mjs';
+import { classifyTscOutput } from './lib/unused-locals-classify.mjs';
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
 const baselinePath = join(repoRoot, 'scripts', 'unused-locals-baseline.json');
@@ -43,21 +44,6 @@ function packageDirs() {
     .map((dir) => relative(repoRoot, dir))
     .sort();
 }
-
-/**
- * The TypeScript diagnostics that mean "declared and never used". More than one
- * code matters: TS6192 is "all imports in this declaration are unused", which is
- * precisely the dead-import case this check exists for, and treating it as an
- * unrelated error made `apps/viewer` — where those imports were — unmeasurable.
- */
-const UNUSED_CODES = [6133, 6138, 6192, 6196, 6198, 6199];
-const UNUSED_RE = new RegExp(`error TS(${UNUSED_CODES.join('|')}):`, 'g');
-const OTHER_ERROR_RE = new RegExp(`error TS(?!(?:${UNUSED_CODES.join('|')})\\b)\\d+:`);
-// A generic "tsc did print at least one diagnostic" signal, independent of the
-// two regexes above. Used only to tell "tsc ran and reported something we
-// failed to parse" apart from "tsc genuinely produced no diagnostic text",
-// which need different, honest failure messages (see countViolations).
-const ANY_TS_DIAGNOSTIC_RE = /TS\d{4}/;
 
 /**
  * Strip ANSI escape sequences (SGR colour/style codes) from captured child
@@ -121,31 +107,36 @@ function countViolations(dir) {
     // upstream of tsc in this spawn chain that ignores both of the above)
     // before matching, rather than trusting the two defenses above blindly.
     const output = stripAnsi(`${err.stdout ?? ''}${err.stderr ?? ''}`);
-    const count = output.match(UNUSED_RE)?.length ?? 0;
-    if (OTHER_ERROR_RE.test(output)) {
+    // The actual accounting lives in scripts/lib/unused-locals-classify.mjs,
+    // unit-tested on its own (scripts/lib/unused-locals-classify.test.mjs) —
+    // including the mixed-output case where one diagnostic parses fine and a
+    // second, in the same run, does not. That case must fail loud too, not
+    // just the fully-unparseable one (#2634 review).
+    const result = classifyTscOutput(output);
+    if (result.kind === 'does-not-compile') {
       // The package does not compile. That belongs to the typecheck lane, not
       // here — but it must not silently drop out of the ratchet either, or
       // breaking a build becomes a way to lose the guard. Reported, not skipped.
-      return { count, unmeasurable: true };
+      return { count: result.count, unmeasurable: true };
     }
-    if (count === 0) {
-      if (ANY_TS_DIAGNOSTIC_RE.test(output)) {
-        // tsc printed at least one `TS####` diagnostic, but it matched neither
-        // the unused-locals codes nor the "any other error" pattern. That is
-        // not a compile error to report and fold into the ratchet like the
-        // branch above — it means this script's own parsing is broken (a tsc
-        // output-format change, an escape sequence the strip above doesn't
-        // cover, etc). Reporting that as "does not compile standalone" would
-        // be a confidently wrong answer wearing the same clothes as a real
-        // compile failure. Fail the whole run loudly instead of guessing.
-        console.error(`❌ check-unused-locals cannot parse tsc's output for ${dir}.`);
-        console.error('   tsc reported at least one TS diagnostic, but it matched neither the');
-        console.error('   unused-locals codes nor the generic "other error" pattern — this is a');
-        console.error('   bug in the check\'s parsing, not a compile error in the package.');
-        console.error('\n   Raw (ANSI-stripped) output:\n');
-        console.error(output.split('\n').map((l) => `   ${l}`).join('\n'));
-        process.exit(1);
-      }
+    if (result.kind === 'unparseable') {
+      // tsc printed at least one `TS####`-shaped diagnostic that classifyTscOutput
+      // could not fully account for — whether or not OTHER diagnostics in the
+      // same run parsed fine. That is not a compile error to report and fold
+      // into the ratchet; it means this script's own parsing is broken (a tsc
+      // output-format change, an escape sequence the strip above doesn't
+      // cover, etc). Reporting only the recognised diagnostics would be a
+      // confidently wrong answer wearing the same clothes as a real, complete
+      // count. Fail the whole run loudly instead of guessing.
+      console.error(`❌ check-unused-locals cannot parse tsc's output for ${dir}.`);
+      console.error('   tsc reported at least one TS diagnostic that matched neither the');
+      console.error('   unused-locals codes nor the generic "other error" pattern — this is a');
+      console.error('   bug in the check\'s parsing, not a compile error in the package.');
+      console.error('\n   Raw (ANSI-stripped) output:\n');
+      console.error(output.split('\n').map((l) => `   ${l}`).join('\n'));
+      process.exit(1);
+    }
+    if (result.kind === 'no-diagnostics') {
       // Non-zero exit, and nothing here explains it: no unused diagnostics, no
       // other `error TS####`, no TS diagnostic of any kind. tsc never ran, or
       // died without reporting — a missing binary, a killed process, a failure
@@ -154,7 +145,7 @@ function countViolations(dir) {
       // could be written into the baseline as one (review, #2603).
       return { count: 0, unmeasurable: true };
     }
-    return { count, unmeasurable: false };
+    return { count: result.count, unmeasurable: false };
   }
 }
 

--- a/scripts/lib/unused-locals-classify.mjs
+++ b/scripts/lib/unused-locals-classify.mjs
@@ -47,7 +47,9 @@ export const ANY_TS_DIAGNOSTIC_RE = /TS\d{4}/g;
  *    from the #2634 review — the original check only looked for this when
  *    the recognised count was zero).
  *  - { kind: 'no-diagnostics' } — non-zero exit, but no `TS####`-shaped text
- *    at all. tsc never ran, or died without reporting.
+ *    at all: tsc returned non-zero without reporting a diagnostic. (A run
+ *    that was killed or truncated never reaches here — see
+ *    untrustworthyExitReason below, which the caller applies first.)
  *  - { kind: 'violations', count } — every `TS####` in the output is either
  *    an unused-locals diagnostic or (impossible here, see does-not-compile
  *    above) another error; count is the number of unused-locals diagnostics.
@@ -73,4 +75,41 @@ export function classifyTscOutput(output) {
     return { kind: 'no-diagnostics' };
   }
   return { kind: 'violations', count: unusedCount };
+}
+
+/**
+ * Vet the child process's *exit* before its output is classified.
+ *
+ * classifyTscOutput above only ever sees text, and a TRUNCATED run's text is a
+ * prefix of well-formed diagnostics — which parses perfectly and returns a
+ * confident, wrong, low count. Reproduced for the #2663 review: a child
+ * emitting 5000 unused-locals diagnostics against a small maxBuffer came back
+ * as `{ kind: 'violations', count: 97 }`, with `err.code === 'ENOBUFS'` sitting
+ * unread on the error object. Under `--update` that undercount is written into
+ * the baseline, permanently lowering the bar for every future run — the exact
+ * failure mode the ratchet exists to prevent, reached from the other side.
+ *
+ * The only exit this check can stand behind is tsc running to completion and
+ * reporting: a numeric exit status with no signal and no spawn-level error
+ * code. Node populates the alternatives distinctly (verified against Node 22):
+ *   - normal diagnostics: `{ status: 1, signal: null }`, no `code`
+ *   - maxBuffer overflow: `{ code: 'ENOBUFS', status: null, signal: 'SIGTERM' }`
+ *   - OOM / external kill: `{ status: null, signal: 'SIGKILL' }`
+ *   - binary not found:   `{ code: 'ENOENT', status: null, signal: null }`
+ *
+ * @param {{ code?: string, status?: number|null, signal?: string|null }} err
+ * @returns {string|null} null when the exit is trustworthy, else a short
+ *   human-readable reason naming the code/signal for the failure message.
+ */
+export function untrustworthyExitReason(err) {
+  if (err?.code != null) {
+    return `the spawn failed with ${err.code}${err.signal ? ` (signal ${err.signal})` : ''}`;
+  }
+  if (err?.signal != null) {
+    return `the process was killed by ${err.signal}`;
+  }
+  if (typeof err?.status !== 'number') {
+    return 'the process exited without a status code';
+  }
+  return null;
 }

--- a/scripts/lib/unused-locals-classify.mjs
+++ b/scripts/lib/unused-locals-classify.mjs
@@ -57,11 +57,17 @@ export function classifyTscOutput(output) {
   const otherErrorCount = output.match(OTHER_ERROR_RE)?.length ?? 0;
   const totalDiagnostics = output.match(ANY_TS_DIAGNOSTIC_RE)?.length ?? 0;
 
-  if (otherErrorCount > 0) {
-    return { kind: 'does-not-compile', count: unusedCount };
-  }
+  // Unparseable is checked FIRST, ahead of does-not-compile: an unrecognised
+  // diagnostic sitting alongside a genuine compile error is just as much a
+  // parsing failure as one sitting alongside a recognised violation, and
+  // folding it into "this package doesn't compile" would report a number this
+  // script cannot actually stand behind. Any leftover `TS####` fails loud,
+  // whatever else matched.
   if (totalDiagnostics > unusedCount + otherErrorCount) {
     return { kind: 'unparseable' };
+  }
+  if (otherErrorCount > 0) {
+    return { kind: 'does-not-compile', count: unusedCount };
   }
   if (unusedCount === 0) {
     return { kind: 'no-diagnostics' };

--- a/scripts/lib/unused-locals-classify.mjs
+++ b/scripts/lib/unused-locals-classify.mjs
@@ -1,0 +1,70 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The pure classification step behind check-unused-locals.mjs: given one
+ * package's ANSI-stripped `tsc --noUnusedLocals` output (already non-zero
+ * exit, i.e. tsc reported *something*), decide what that something means.
+ *
+ * Split out from check-unused-locals.mjs so the branching can be unit-tested
+ * directly against captured text, without spawning a real tsc — the case
+ * this exists to catch (an unrecognised `TS####` diagnostic shape) is not
+ * something the pinned TypeScript version actually emits today, so it can
+ * only be exercised as a hand-built string, the same way review reproduced
+ * it (PR #2634 review thread).
+ */
+
+/**
+ * The TypeScript diagnostics that mean "declared and never used". More than
+ * one code matters: TS6192 is "all imports in this declaration are unused",
+ * which is precisely the dead-import case this check exists for, and
+ * treating it as an unrelated error made `apps/viewer` — where those
+ * imports were — unmeasurable.
+ */
+export const UNUSED_CODES = [6133, 6138, 6192, 6196, 6198, 6199];
+export const UNUSED_RE = new RegExp(`error TS(${UNUSED_CODES.join('|')}):`, 'g');
+export const OTHER_ERROR_RE = new RegExp(`error TS(?!(?:${UNUSED_CODES.join('|')})\\b)\\d+:`, 'g');
+// A generic "this looks like a TS diagnostic" signal, independent of the two
+// regexes above. Used to tell "tsc printed diagnostics we can fully account
+// for" apart from "tsc printed at least one diagnostic we cannot classify",
+// which need different, honest outcomes (see classifyTscOutput below).
+export const ANY_TS_DIAGNOSTIC_RE = /TS\d{4}/g;
+
+/**
+ * Classify one package's captured (ANSI-stripped) tsc output.
+ *
+ * Returns one of:
+ *  - { kind: 'does-not-compile', count } — at least one `error TS####:` that
+ *    is not an unused-locals code. The package doesn't compile standalone;
+ *    that belongs to the typecheck lane, not here, but it must not silently
+ *    drop out of the ratchet either.
+ *  - { kind: 'unparseable' } — some text matching the generic `TS####` shape
+ *    is not accounted for by either recognised pattern above. This must fire
+ *    even when OTHER diagnostics in the SAME output parsed fine: a run with
+ *    one recognised violation and one diagnostic this script cannot classify
+ *    must not silently report just the recognised one (the mixed-output gap
+ *    from the #2634 review — the original check only looked for this when
+ *    the recognised count was zero).
+ *  - { kind: 'no-diagnostics' } — non-zero exit, but no `TS####`-shaped text
+ *    at all. tsc never ran, or died without reporting.
+ *  - { kind: 'violations', count } — every `TS####` in the output is either
+ *    an unused-locals diagnostic or (impossible here, see does-not-compile
+ *    above) another error; count is the number of unused-locals diagnostics.
+ */
+export function classifyTscOutput(output) {
+  const unusedCount = output.match(UNUSED_RE)?.length ?? 0;
+  const otherErrorCount = output.match(OTHER_ERROR_RE)?.length ?? 0;
+  const totalDiagnostics = output.match(ANY_TS_DIAGNOSTIC_RE)?.length ?? 0;
+
+  if (otherErrorCount > 0) {
+    return { kind: 'does-not-compile', count: unusedCount };
+  }
+  if (totalDiagnostics > unusedCount + otherErrorCount) {
+    return { kind: 'unparseable' };
+  }
+  if (unusedCount === 0) {
+    return { kind: 'no-diagnostics' };
+  }
+  return { kind: 'violations', count: unusedCount };
+}

--- a/scripts/lib/unused-locals-classify.mjs
+++ b/scripts/lib/unused-locals-classify.mjs
@@ -23,13 +23,54 @@
  * imports were — unmeasurable.
  */
 export const UNUSED_CODES = [6133, 6138, 6192, 6196, 6198, 6199];
-export const UNUSED_RE = new RegExp(`error TS(${UNUSED_CODES.join('|')}):`, 'g');
-export const OTHER_ERROR_RE = new RegExp(`error TS(?!(?:${UNUSED_CODES.join('|')})\\b)\\d+:`, 'g');
-// A generic "this looks like a TS diagnostic" signal, independent of the two
-// regexes above. Used to tell "tsc printed diagnostics we can fully account
-// for" apart from "tsc printed at least one diagnostic we cannot classify",
-// which need different, honest outcomes (see classifyTscOutput below).
-export const ANY_TS_DIAGNOSTIC_RE = /TS\d{4}/g;
+
+/**
+ * Matches the HEADER of one tsc diagnostic, and nothing else.
+ *
+ * Under `--pretty false` tsc prints exactly one diagnostic per line, opening
+ * with an optional `file(line,col): ` location prefix, then a severity word,
+ * then the code: `src/a.ts(2,9): error TS6133: …`, or bare `error TS5083: …`
+ * for config/global diagnostics that have no file. Anchoring at `^` (with
+ * `m`) and taking the first severity word on the line means at most one match
+ * per line — the header — so text *inside* a message can never be read as a
+ * second diagnostic.
+ *
+ * That distinction is the whole point (PR #2663 review). The previous generic
+ * scan was a bare `/TS\d{4}/g` over the raw output, which counted any
+ * `TS####` sequence anywhere: `error TS6133: 'TS1234' is declared but its
+ * value is never read.` — verbatim tsc 6.0.3 output for an unused identifier
+ * named `TS1234` — scored two "diagnostics" against one recognised
+ * violation, so classifyTscOutput declared its own parsing broken and failed
+ * the gate over output it had in fact parsed correctly. A file path
+ * containing a code (`src/TS1234.ts`) did the same.
+ *
+ * `severity` is captured as well as the code because a diagnostic that is not
+ * an `error` is one this script cannot classify, and must therefore still
+ * reach the fail-loud branch rather than be quietly dropped.
+ */
+const DIAGNOSTIC_HEADER_RE = /^[^\n]*?(error|warning|message) TS(\d+):/gm;
+
+/**
+ * Tokenise tsc's output into the diagnostics it actually printed, one per
+ * header. Every count classifyTscOutput branches on is derived from this ONE
+ * scan, so "is this a diagnostic at all" and "which kind is it" cannot
+ * disagree about where a diagnostic starts.
+ *
+ * @param {string} output ANSI-stripped tsc output.
+ * @returns {{ total: number, unused: number, otherError: number }}
+ */
+function countDiagnostics(output) {
+  let total = 0;
+  let unused = 0;
+  let otherError = 0;
+  for (const [, severity, code] of output.matchAll(DIAGNOSTIC_HEADER_RE)) {
+    total++;
+    if (severity !== 'error') continue;
+    if (UNUSED_CODES.includes(Number(code))) unused++;
+    else otherError++;
+  }
+  return { total, unused, otherError };
+}
 
 /**
  * Classify one package's captured (ANSI-stripped) tsc output.
@@ -39,32 +80,32 @@ export const ANY_TS_DIAGNOSTIC_RE = /TS\d{4}/g;
  *    is not an unused-locals code. The package doesn't compile standalone;
  *    that belongs to the typecheck lane, not here, but it must not silently
  *    drop out of the ratchet either.
- *  - { kind: 'unparseable' } — some text matching the generic `TS####` shape
- *    is not accounted for by either recognised pattern above. This must fire
- *    even when OTHER diagnostics in the SAME output parsed fine: a run with
- *    one recognised violation and one diagnostic this script cannot classify
- *    must not silently report just the recognised one (the mixed-output gap
- *    from the #2634 review — the original check only looked for this when
- *    the recognised count was zero).
- *  - { kind: 'no-diagnostics' } — non-zero exit, but no `TS####`-shaped text
- *    at all: tsc returned non-zero without reporting a diagnostic. (A run
+ *  - { kind: 'unparseable' } — at least one diagnostic header (see
+ *    DIAGNOSTIC_HEADER_RE) is not accounted for by either recognised kind:
+ *    a non-`error` severity, or an `error` whose code the branching above
+ *    doesn't reach. This must fire even when OTHER diagnostics in the SAME
+ *    output parsed fine: a run with one recognised violation and one
+ *    diagnostic this script cannot classify must not silently report just
+ *    the recognised one (the mixed-output gap from the #2634 review — the
+ *    original check only looked for this when the recognised count was zero).
+ *  - { kind: 'no-diagnostics' } — non-zero exit, but no diagnostic header at
+ *    all: tsc returned non-zero without reporting a diagnostic. (A run
  *    that was killed or truncated never reaches here — see
  *    untrustworthyExitReason below, which the caller applies first.)
- *  - { kind: 'violations', count } — every `TS####` in the output is either
+ *  - { kind: 'violations', count } — every diagnostic in the output is either
  *    an unused-locals diagnostic or (impossible here, see does-not-compile
  *    above) another error; count is the number of unused-locals diagnostics.
  */
 export function classifyTscOutput(output) {
-  const unusedCount = output.match(UNUSED_RE)?.length ?? 0;
-  const otherErrorCount = output.match(OTHER_ERROR_RE)?.length ?? 0;
-  const totalDiagnostics = output.match(ANY_TS_DIAGNOSTIC_RE)?.length ?? 0;
+  const { total: totalDiagnostics, unused: unusedCount, otherError: otherErrorCount } =
+    countDiagnostics(output);
 
   // Unparseable is checked FIRST, ahead of does-not-compile: an unrecognised
   // diagnostic sitting alongside a genuine compile error is just as much a
   // parsing failure as one sitting alongside a recognised violation, and
   // folding it into "this package doesn't compile" would report a number this
-  // script cannot actually stand behind. Any leftover `TS####` fails loud,
-  // whatever else matched.
+  // script cannot actually stand behind. Any leftover diagnostic header fails
+  // loud, whatever else matched.
   if (totalDiagnostics > unusedCount + otherErrorCount) {
     return { kind: 'unparseable' };
   }

--- a/scripts/lib/unused-locals-classify.test.mjs
+++ b/scripts/lib/unused-locals-classify.test.mjs
@@ -88,6 +88,42 @@ test('multiple recognised violations alone all count', () => {
   assert.deepEqual(classifyTscOutput(output), { kind: 'violations', count: 2 });
 });
 
+// ---- `TS####`-shaped text that is NOT a diagnostic (PR #2663 review).
+//
+// The generic "is there a diagnostic here at all" scan used to be a bare
+// /TS\d{4}/ over the whole output, so any `TS####` sequence anywhere counted
+// as a diagnostic — including one sitting inside a message or a file path.
+// The identifier name quoted back by TS6133 is the everyday case: a variable
+// named `TS1234` made its own perfectly-recognised diagnostic come back as
+// `unparseable`, failing the whole gate with "this check's parsing is broken"
+// over a correctly parsed violation. The strings below are verbatim output
+// from the pinned TypeScript 6.0.3 under `--pretty false`.
+
+test('an unused identifier whose NAME looks like a TS code is one violation, not unparseable', () => {
+  // Verbatim tsc 6.0.3 output for `const TS1234 = 1;` under --noUnusedLocals.
+  const output = "src/a.ts(2,9): error TS6133: 'TS1234' is declared but its value is never read.\n";
+  assert.deepEqual(classifyTscOutput(output), { kind: 'violations', count: 1 });
+});
+
+test('a file PATH containing a TS code does not inflate the diagnostic count', () => {
+  const output = "src/TS1234.ts(1,1): error TS6133: 'x' is declared but its value is never read.\n";
+  assert.deepEqual(classifyTscOutput(output), { kind: 'violations', count: 1 });
+});
+
+test('a compile error quoting a TS code in its message is does-not-compile, not unparseable', () => {
+  const output = 'src/a.ts(1,1): error TS2304: Cannot find name \'TS1234\'.\n';
+  assert.deepEqual(classifyTscOutput(output), { kind: 'does-not-compile', count: 0 });
+});
+
+test('CONTROL: an unrecognised diagnostic is still unparseable when the run also quotes a code', () => {
+  // The fix must not buy its accuracy by loosening the fail-loud branch: a
+  // genuinely unclassifiable diagnostic still has to win, even when the
+  // recognised diagnostic next to it carries TS-code-shaped message text.
+  const output = "src/a.ts(2,9): error TS6133: 'TS1234' is declared but its value is never read.\n"
+    + "src/b.ts(4,3): warning TS6385: 'oldApi' is deprecated.\n";
+  assert.deepEqual(classifyTscOutput(output), { kind: 'unparseable' });
+});
+
 // ---- The truncated / killed-run gap (PR #2663 review).
 //
 // classifyTscOutput only ever sees TEXT. If the spawn itself was cut short —

--- a/scripts/lib/unused-locals-classify.test.mjs
+++ b/scripts/lib/unused-locals-classify.test.mjs
@@ -72,6 +72,16 @@ test('a recognised violation plus a genuine compile error is does-not-compile, c
   assert.deepEqual(classifyTscOutput(output), { kind: 'does-not-compile', count: 1 });
 });
 
+test('a genuine compile error does NOT mask an unrecognised diagnostic in the same run', () => {
+  // The other-error branch used to be evaluated first, so a run mixing a real
+  // compile error with a diagnostic the script cannot classify came back as
+  // does-not-compile — a count reported as if the output had been fully
+  // understood. Any leftover `TS####` must win.
+  const output = "src/c.ts(9,1): error TS2304: Cannot find name 'Bar'.\n"
+    + "src/b.ts(4,3): warning TS6385: 'oldApi' is deprecated.\n";
+  assert.deepEqual(classifyTscOutput(output), { kind: 'unparseable' });
+});
+
 test('multiple recognised violations alone all count', () => {
   const output = "src/a.ts(1,1): error TS6133: 'x' is declared but its value is never read.\n"
     + "src/a.ts(2,1): error TS6192: All imports in import declaration are unused.\n";

--- a/scripts/lib/unused-locals-classify.test.mjs
+++ b/scripts/lib/unused-locals-classify.test.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Unit tests for classifyTscOutput, the branching check-unused-locals.mjs
+ * uses to decide whether a non-zero tsc run is real violations, a genuine
+ * compile error, or output its own parsing can't account for.
+ *
+ * The defect class pinned here (PR #2634 review): the original inline
+ * version of this logic only checked for an unrecognised `TS####` diagnostic
+ * when the recognised count was exactly zero. A run containing ONE correctly
+ * parsed unused-locals diagnostic and ONE diagnostic in a shape the script
+ * doesn't recognise skipped that check entirely — the unrecognised one
+ * vanished with no trace, undercounted, no failure, no message. That is
+ * exactly the "I couldn't parse this output" failure this check exists to
+ * catch, just reached via a mixed run instead of a fully-unparseable one.
+ *
+ * Run: node --test scripts/lib/unused-locals-classify.test.mjs
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { classifyTscOutput } from './unused-locals-classify.mjs';
+
+test('a single recognised unused-locals diagnostic counts as a violation', () => {
+  const output = "src/a.ts(1,1): error TS6133: 'x' is declared but its value is never read.\n";
+  assert.deepEqual(classifyTscOutput(output), { kind: 'violations', count: 1 });
+});
+
+test('a genuine compile error is reported as does-not-compile, not silently zero', () => {
+  const output = "src/a.ts(1,1): error TS2304: Cannot find name 'Foo'.\n";
+  const result = classifyTscOutput(output);
+  assert.equal(result.kind, 'does-not-compile');
+});
+
+test('output with no TS-shaped diagnostic at all is no-diagnostics', () => {
+  assert.deepEqual(classifyTscOutput('some unrelated failure text\n'), { kind: 'no-diagnostics' });
+});
+
+test('a lone unrecognised TS#### diagnostic is unparseable', () => {
+  // Not "error TS...:" and not one of the unused-locals codes.
+  const output = "src/b.ts(4,3): warning TS6385: 'oldApi' is deprecated.\n";
+  assert.deepEqual(classifyTscOutput(output), { kind: 'unparseable' });
+});
+
+// ---- The mixed-output gap from the review.
+
+test('one recognised violation PLUS one unrecognised diagnostic is unparseable, not a silent count of 1', () => {
+  const output = "src/a.ts(1,1): error TS6133: 'x' is declared but its value is never read.\n"
+    + "src/b.ts(4,3): warning TS6385: 'oldApi' is deprecated.\n";
+  assert.deepEqual(classifyTscOutput(output), { kind: 'unparseable' });
+});
+
+test('order does not matter: unrecognised diagnostic first, recognised one second', () => {
+  const output = "src/b.ts(4,3): warning TS6385: 'oldApi' is deprecated.\n"
+    + "src/a.ts(1,1): error TS6133: 'x' is declared but its value is never read.\n";
+  assert.deepEqual(classifyTscOutput(output), { kind: 'unparseable' });
+});
+
+test('two recognised violations plus one unrecognised diagnostic is still unparseable', () => {
+  const output = "src/a.ts(1,1): error TS6133: 'x' is declared but its value is never read.\n"
+    + "src/a.ts(2,1): error TS6133: 'y' is declared but its value is never read.\n"
+    + "src/b.ts(4,3): warning TS6385: 'oldApi' is deprecated.\n";
+  assert.deepEqual(classifyTscOutput(output), { kind: 'unparseable' });
+});
+
+test('a recognised violation plus a genuine compile error is does-not-compile, count still reported', () => {
+  const output = "src/a.ts(1,1): error TS6133: 'x' is declared but its value is never read.\n"
+    + "src/c.ts(9,1): error TS2304: Cannot find name 'Bar'.\n";
+  assert.deepEqual(classifyTscOutput(output), { kind: 'does-not-compile', count: 1 });
+});
+
+test('multiple recognised violations alone all count', () => {
+  const output = "src/a.ts(1,1): error TS6133: 'x' is declared but its value is never read.\n"
+    + "src/a.ts(2,1): error TS6192: All imports in import declaration are unused.\n";
+  assert.deepEqual(classifyTscOutput(output), { kind: 'violations', count: 2 });
+});

--- a/scripts/lib/unused-locals-classify.test.mjs
+++ b/scripts/lib/unused-locals-classify.test.mjs
@@ -22,7 +22,7 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { classifyTscOutput } from './unused-locals-classify.mjs';
+import { classifyTscOutput, untrustworthyExitReason } from './unused-locals-classify.mjs';
 
 test('a single recognised unused-locals diagnostic counts as a violation', () => {
   const output = "src/a.ts(1,1): error TS6133: 'x' is declared but its value is never read.\n";
@@ -86,4 +86,45 @@ test('multiple recognised violations alone all count', () => {
   const output = "src/a.ts(1,1): error TS6133: 'x' is declared but its value is never read.\n"
     + "src/a.ts(2,1): error TS6192: All imports in import declaration are unused.\n";
   assert.deepEqual(classifyTscOutput(output), { kind: 'violations', count: 2 });
+});
+
+// ---- The truncated / killed-run gap (PR #2663 review).
+//
+// classifyTscOutput only ever sees TEXT. If the spawn itself was cut short —
+// maxBuffer overflow (ENOBUFS) or the child killed (OOM, SIGKILL) — the text
+// it receives is a *prefix* of what tsc actually printed, and a prefix of
+// well-formed diagnostics parses perfectly. Reproduced in review: a child
+// emitting 5000 diagnostics against a small maxBuffer yielded a confident
+// { kind: 'violations', count: 97 }. Under `--update` that undercount is
+// written into the baseline, permanently lowering the bar for every future
+// run. So the exit itself has to be vetted before its output is trusted.
+
+test('a normal tsc diagnostic exit is trusted', () => {
+  assert.equal(untrustworthyExitReason({ status: 1, signal: null }), null);
+});
+
+test('tsc exit code 2 is also a normal diagnostic exit', () => {
+  assert.equal(untrustworthyExitReason({ status: 2, signal: null }), null);
+});
+
+test('an ENOBUFS-truncated run is not trusted', () => {
+  // The exact shape Node produces: code ENOBUFS, no exit status, SIGTERM.
+  const reason = untrustworthyExitReason({ code: 'ENOBUFS', status: null, signal: 'SIGTERM' });
+  assert.match(reason ?? '', /ENOBUFS/);
+});
+
+test('a SIGKILLed (OOM) run is not trusted even though it carries no error code', () => {
+  const reason = untrustworthyExitReason({ status: null, signal: 'SIGKILL' });
+  assert.match(reason ?? '', /SIGKILL/);
+});
+
+test('a spawn failure (missing binary) is not trusted', () => {
+  const reason = untrustworthyExitReason({ code: 'ENOENT', status: null, signal: null });
+  assert.match(reason ?? '', /ENOENT/);
+});
+
+test('an exit with no status and no signal at all is not trusted', () => {
+  // Nothing here says tsc ran to completion, so its output cannot be assumed
+  // to be a complete diagnostic list.
+  assert.notEqual(untrustworthyExitReason({ status: null, signal: null }), null);
 });


### PR DESCRIPTION
Follow-up to #2634 (merged `dfd6d7177`), found by an adversarial review of that PR.

**The hole:** `scripts/check-unused-locals.mjs`'s loud-failure path — "I could not parse this output" — only fired when the **total matched count was 0**. A run containing one correctly-parsed diagnostic *and* one unparseable one silently dropped the unparseable and reported success.

That is the same failure #2634 exists to prevent, reached via a mixed run rather than a fully-unparseable one. A checking script that silently stops detecting is indistinguishable from a passing one, which is why this matters more than its size suggests.

**A second hole found while fixing the first:** the initial fix evaluated `does-not-compile` *before* `unparseable`, so a run mixing a genuine `error TS2304:` with an unclassifiable diagnostic still came back as `does-not-compile` **with a violation count attached** — a number presented as if the output had been understood. Unparseable now wins outright.

**Evidence (real output, mixed-run repro against the pre-fix code copied verbatim from `main`):**

```
mixed: 1 parseable unused-locals + 1 unparseable diagnostic
  OLD -> silently reports 1 violation(s)
  NEW -> unparseable  => check-unused-locals.mjs exits 1 loudly
control: lone unparseable diagnostic (old code already caught this)
  OLD -> LOUD FAILURE (exit 1)      NEW -> unparseable
control: 2 clean unused-locals diagnostics
  OLD -> silently reports 2         NEW -> violations (count 2)
```

Reverting to pre-fix semantics inside the fixed file turns the unit suite red (4 of 10 fail, including the new `a genuine compile error does NOT mask an unrecognised diagnostic` pin); restored, 10/10 pass.

**Not run:** the full `check-unused-locals` sweep across ~46 packages — it needs `node_modules`/`dist` the verification worktree does not have, and takes minutes. The targeted unit suite and the induced-failure repro were run; the full sweep was not.

---

## Third hole (review of this PR): a truncated run parses perfectly

`classifyTscOutput` only ever sees **text**. The `catch` in `countViolations` handed it `stripAnsi(stdout + stderr)` without ever inspecting `err.code` / `err.signal` — and a run that was cut short returns a *prefix* of tsc's diagnostics, which parses cleanly into a confident, wrong, low count.

**Reproduced** (child emitting 5,000 well-formed unused-locals diagnostics against a small `maxBuffer`):

```
err.code   = ENOBUFS
err.signal = SIGTERM
err.status = null
child emitted 5000 diagnostics; script saw 97
classifier = {"kind":"violations","count":97}      <- confident undercount
exit gate  = null                                  <- nothing looked at err.code
```

Under `--update` that 97 is written into the baseline, permanently lowering the bar for every future run — the exact failure the ratchet exists to prevent, reached from the other side. Likelihood is low in this repo today (the 32 MB `maxBuffer` is unreachable here; an OOM-kill is the plausible route), but the consequence is a corrupted baseline that nothing later would notice.

`untrustworthyExitReason` now vets the exit **before** the text is classified. Only a plain numeric exit status with no signal and no spawn-level error code is trusted; anything else fails loud with the code/signal named and the partial output printed. Node populates these distinctly (verified against Node 22):

| situation | shape |
|---|---|
| normal tsc diagnostics | `{ status: 1, signal: null }`, no `code` |
| maxBuffer overflow | `{ code: 'ENOBUFS', status: null, signal: 'SIGTERM' }` |
| OOM / external kill | `{ status: null, signal: 'SIGKILL' }` |
| binary not found | `{ code: 'ENOENT', status: null, signal: null }` |

**Path displaced:** the missing-binary (`ENOENT`) case used to land in `no-diagnostics` → `unmeasurable`, which failed the run at the end; it now fails loud immediately. The `no-diagnostics` comments, which claimed to cover "a killed process" and "a missing binary", are corrected to match — that branch now only sees a tsc that ran to completion and returned non-zero without a recognisable diagnostic.

**RED / GREEN / RED:** the six new pins fail to import before the fix; 16/16 pass after; narrowing the guard to `err.code === 'ENOENT'` turns the ENOBUFS pin red again. The suite is 16 tests now, not the 10 quoted above. Spot-checked against a real `pnpm exec tsc` run (`status 254, signal null, code undefined` → trusted, no false positive).

The unit suite is already wired into `node-tests` by this PR, so the new pins ride the existing step.

---

Worth landing before the sibling `fix/2631-cargo-lock-gate` branch, which references `scripts/lib/unused-locals-classify.test.mjs` — a file that only exists here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved unused-local checks to distinguish violations, compilation failures, and unsupported diagnostics.
  - Reports ambiguous, incomplete, or unparseable TypeScript output as explicit failures.
  - Preserves accurate violation counts when unused-local issues occur alongside other errors.
  - Rejects incomplete compiler runs and execution failures instead of producing unreliable results.

- **Tests**
  - Added coverage for violations, compile failures, missing diagnostics, mixed errors, unrecognized output, and invalid process exits.
  - Integrated the checks into the automated Node test workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
