### PR TITLE
test(world-frame): a shared corpus for the local-frame and large-coordinate class

### DIFF
--- a/packages/clash/package.json
+++ b/packages/clash/package.json
@@ -48,6 +48,7 @@
     "@ifc-lite/wasm": "workspace:^"
   },
   "devDependencies": {
+    "@ifc-lite/world-frame-fixtures": "workspace:^",
     "typescript": "^6.0.3",
     "vitest": "^4.1.10"
   },

--- a/packages/clash/src/contact/world-frame.test.ts
+++ b/packages/clash/src/contact/world-frame.test.ts
@@ -1,0 +1,138 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * World-frame corpus coverage for the contact pipeline (#2600, fix PR #2661).
+ *
+ * `scaledPlaneEps` (narrow-phase.ts) sizes the coplanarity tolerance from the
+ * max |coordinate| over ALL THREE axes of both AABBs, then compares it
+ * against a signed distance along ONE plane normal. A model 10 km out in X
+ * therefore hands a Z-normal test a ~2.4 mm epsilon derived entirely from
+ * the irrelevant X magnitude — and a genuine ~2 mm Z-clearance reads as
+ * coplanar contact. The corpus places the SAME pair at the origin and far
+ * out on an ORTHOGONAL axis; a frame-correct tolerance answers identically.
+ *
+ * Shape conforms to PR #2661's measured reproduction (`clearanceQuadsAt`):
+ * horizontal quads with the lower plane at z = 0, offset applied to X only,
+ * clearance above any legitimate Z noise yet INSIDE the default broad-phase
+ * inflation, so all 2x2 candidate pairs are emitted and the verdict rests on
+ * `planeEps` ALONE. One deliberate deviation: the corpus bakes coordinates
+ * through f32 (ingestion realism), and f32(0.002) lands a hair ABOVE the
+ * default 2 mm inflation — which would silently drop the candidates — so
+ * the clearance here is 1.9 mm, robustly inside the inflation and still
+ * comfortably swallowed by the defective ~2.4 mm far-placement epsilon.
+ *
+ * The clash contact `Mesh` has NO RTC-origin field (positions are world-
+ * frame by contract), so this file carries only the large-world-coordinate
+ * axis of the corpus; the per-element `MeshData.origin` axis lives in the
+ * viewer compare tests (#2529 path).
+ *
+ * The `it.fails` case asserts the CORRECT behaviour and is expected to fail
+ * on the live defect. When the #2661 projection fix lands, that test starts
+ * passing, vitest reports the `.fails` wrapper itself as a failure, and the
+ * wrapper must be removed — the corpus cannot silently rot in either
+ * direction.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  WORLD_FRAME_OFFSET_M,
+  bakedWorldPositions,
+  normalProjectedNoiseBound,
+  placeWorldFrame,
+  quadTriangles,
+  type PlacedMesh,
+  type WorldFrameCase,
+} from '@ifc-lite/world-frame-fixtures';
+import { contactClusters, narrowPhase, type Mesh } from './index.js';
+
+/** One f32 ULP up: adjacent-but-not-identical float32 values, the real shape
+ * of an intended-flush boundary after independent f32 authoring. */
+function nextF32(x: number): number {
+  const buf = new Float32Array([x]);
+  new Uint32Array(buf.buffer)[0] += 1;
+  return buf[0] as number;
+}
+
+/** A 1.9 mm clearance: three orders of magnitude above the legitimate
+ * Z-noise bound in every corpus case (asserted below, not assumed) and
+ * inside the default 2 mm broad-phase inflation, so `planeEps` alone
+ * decides. See the module doc for why not the nominal 2.0 mm. */
+const CLEARANCE_M = 0.0019;
+
+/** Two horizontal 1 m x 1 m faces (plane normal Z), the lower on z = 0 and
+ * the upper `gapM` above it, placed per the corpus case. The far case puts
+ * the offset on X — a DIFFERENT axis from the Z normal under test, so a
+ * max-over-axes tolerance is caught rather than coincidentally agreeing
+ * with the correct projection.
+ *
+ * `gapM === 0` builds the intended-FLUSH pair instead: both faces at
+ * z = 0.5, the upper one f32 ULP off (~6e-8) — adjacent-but-not-identical,
+ * the real shape of independently authored flush geometry at building-scale
+ * coordinates. */
+function horizontalFacePair(
+  frameCase: WorldFrameCase,
+  gapM: number,
+): { a: Mesh; b: Mesh; placed: [PlacedMesh, PlacedMesh] } {
+  const lower = quadTriangles('z', gapM === 0 ? 0.5 : 0);
+  const upper = quadTriangles('z', gapM === 0 ? nextF32(0.5) : gapM);
+  const pa = placeWorldFrame(lower.positions, { frameCase });
+  const pb = placeWorldFrame(upper.positions, { frameCase });
+  return {
+    a: { id: 'A', positions: bakedWorldPositions(pa), indices: lower.indices },
+    b: { id: 'B', positions: bakedWorldPositions(pb), indices: upper.indices },
+    placed: [pa, pb],
+  };
+}
+
+describe('contact world-frame corpus (#2600)', () => {
+  it('the clearance is provably above the legitimate Z-noise bound in every case', () => {
+    for (const frameCase of ['at-origin', 'far-baked'] as const) {
+      const { placed } = horizontalFacePair(frameCase, CLEARANCE_M);
+      const bound = Math.max(1e-6, normalProjectedNoiseBound([0, 0, 1], placed));
+      expect(CLEARANCE_M).toBeGreaterThan(1000 * bound);
+    }
+  });
+
+  it('counter-case: a genuinely flush pair at the origin is reported as surface contact', () => {
+    // Guards the other direction: a "fix" that simply tightens every
+    // tolerance re-drops the flush shared face that PR #2600 existed to keep.
+    const { a, b } = horizontalFacePair('at-origin', 0);
+    const clusters = contactClusters(a, b);
+    expect(clusters.some((c) => c.kind === 'surface')).toBe(true);
+  });
+
+  it('a genuinely flush pair stays reported 10 km out (offset on X, normal on Z)', () => {
+    // The positive case AT the large offset: without it, a naive
+    // "just use a smaller epsilon" change looks correct while silently
+    // breaking real coplanar detection far from the origin. The flush
+    // faces' Z values are identical to the at-origin pair (the offset
+    // touches only X), so this must hold before AND after the fix.
+    const { a, b } = horizontalFacePair('far-baked', 0);
+    const clusters = contactClusters(a, b);
+    expect(clusters.some((c) => c.kind === 'surface')).toBe(true);
+  });
+
+  it('counter-case: the Z-clearance at the origin produces no pairs and no contact', () => {
+    const { a, b } = horizontalFacePair('at-origin', CLEARANCE_M);
+    expect(narrowPhase(a, b)).toEqual([]);
+    expect(contactClusters(a, b)).toEqual([]);
+  });
+
+  // KNOWN-FAILING on the live #2600 defect: asserts the CORRECT behaviour.
+  // scaledPlaneEps derives ~2.4 mm from the 10 km X magnitude and swallows
+  // the genuine clearance as coplanar contact — measured on this code: 4
+  // fabricated coplanar triangle pairs (2 tris x 2 tris) and 1 fabricated
+  // surface cluster (area 1 m2, plane normal Z). When the #2661 projection
+  // fix lands this starts passing and vitest flags the `.fails` wrapper:
+  // remove the wrapper in that PR.
+  it.fails(
+    `the Z-clearance ${WORLD_FRAME_OFFSET_M / 1000} km out in X produces no pairs and no contact (#2600)`,
+    () => {
+      const { a, b } = horizontalFacePair('far-baked', CLEARANCE_M);
+      expect(narrowPhase(a, b)).toEqual([]);
+      expect(contactClusters(a, b)).toEqual([]);
+    },
+  );
+});

--- a/packages/world-frame-fixtures/README.md
+++ b/packages/world-frame-fixtures/README.md
@@ -1,0 +1,44 @@
+# @ifc-lite/world-frame-fixtures
+
+Private (unpublished) test fixture corpus for the world-frame defect class:
+consumers that read raw `positions` as world coordinates (ignoring the
+per-element RTC `MeshData.origin`, the wasm-path default), and tolerances
+sized from the max |coordinate| over all three axes but compared against a
+distance along one plane normal (#2598, #2600, #2529).
+
+Four placements of the same element:
+
+| Case | Positions | Origin | Catches |
+| --- | --- | --- | --- |
+| `at-origin` | world, near origin | none | counter-case: blanket tolerance changes |
+| `far-baked` | world, 10 km out in X (f32-baked) | none | max-over-axes tolerances tested along Y/Z |
+| `local-frame` | element-local | world centre | raw-positions-as-world consumers |
+| `far-local-frame` | element-local | centre + 10 km X | both composed |
+
+The far offset lives on ONE axis (default X). Test behaviour along a
+DIFFERENT axis: an offset on the tested axis coincidentally equals the
+correct projection and proves nothing. The expected tolerance shape is the
+normal-projected ULP sum `sum |n_i| * ulp32(extent_i)`
+(`normalProjectedNoiseBound`), the formulation
+`packages/drawing-2d/src/section-cutter.ts` documents (PR #2622).
+
+Carriers (do not force one type to serve both axes of the corpus):
+
+- `MeshData` (`asMeshData`, `translateWorld`) carries BOTH axes: RTC origin
+  cases and large-coordinate cases. The viewer compare instance (#2529) is
+  deliberately NOT wired here yet: PR #2659 fixes it and ships its own
+  origin-folding tests with hand-built meshes in
+  `apps/viewer/src/lib/compare/geometrySummary.test.ts`. Migrating those
+  onto this corpus once both branches land is the named follow-up.
+- World-only mesh types (clash contact `Mesh`, via `bakedWorldPositions`)
+  carry ONLY the large-coordinate axis — they have no origin field by
+  contract. Wired into `packages/clash/src/contact/world-frame.test.ts`
+  (#2600, fix PR #2661).
+- The Rust kernel mirror lives in
+  `rust/geometry/src/world_frame_fixture.rs` (baked cases only, same
+  reasoning), wired into `csg/world_frame_tests.rs` and
+  `clash_solid_world_frame_tests.rs`.
+
+Cases that pin a live defect assert the CORRECT behaviour inside a
+known-failing wrapper (`it.fails`, `assertKnownDefect`, `#[should_panic]`)
+that itself fails the moment the fix lands, forcing the unmark.

--- a/packages/world-frame-fixtures/package.json
+++ b/packages/world-frame-fixtures/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@ifc-lite/world-frame-fixtures",
+  "version": "0.1.0",
+  "private": true,
+  "description": "World-frame test fixture corpus: per-element RTC origins, far-from-origin coordinates, and the normal-projected f32 noise bound they demand",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "pnpm exec tsc",
+    "typecheck": "node ../../scripts/typecheck-tests.mjs",
+    "dev": "pnpm exec tsc --watch",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@ifc-lite/geometry": "workspace:^"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.10"
+  },
+  "license": "MPL-2.0",
+  "author": "Louis True",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LTplus-AG/ifc-lite.git",
+    "directory": "packages/world-frame-fixtures"
+  },
+  "homepage": "https://ifclite.dev/docs/",
+  "bugs": "https://github.com/LTplus-AG/ifc-lite/issues",
+  "keywords": [
+    "ifc",
+    "bim",
+    "test-fixture",
+    "rtc-origin",
+    "georeferenced",
+    "float32"
+  ]
+}

--- a/packages/world-frame-fixtures/src/index.ts
+++ b/packages/world-frame-fixtures/src/index.ts
@@ -1,0 +1,298 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * World-frame fixture corpus.
+ *
+ * One defect class produced four defects in a single day, all invisible to
+ * green CI (#2598 caught pre-merge, #2600 and #2529 merged live): code that
+ * consumes mesh geometry either
+ *
+ *  1. reads raw `positions` as world coordinates, ignoring the per-element
+ *     RTC `MeshData.origin` (local-frame is the DEFAULT on the wasm path:
+ *     `rust/geometry/src/router/transforms/mod.rs` sets origin = element AABB
+ *     centre, and a pure translation moves ONLY the origin), or
+ *  2. sizes a plane-distance tolerance from the max |coordinate| over ALL
+ *     THREE axes, then compares it against a signed distance along ONE plane
+ *     normal — so a model 10 km out in X hands a Z-normal test a
+ *     millimetre-scale epsilon derived entirely from the irrelevant X
+ *     magnitude.
+ *
+ * No test in the repo fed those paths a mesh with a non-zero `origin` or with
+ * large world coordinates; this corpus closes that gap. Its four cases:
+ *
+ *  - `'at-origin'`       counter-case: near the origin, no RTC origin. A "fix"
+ *                        that simply widens every tolerance fails here.
+ *  - `'far-baked'`       large world coordinates baked into f32 positions,
+ *                        offset on ONE axis (default X). Tests of behaviour
+ *                        along a DIFFERENT axis (a Z plane normal, a Z
+ *                        clearance) catch max-over-axes overreach; an offset
+ *                        on the tested axis itself would coincidentally agree
+ *                        with the correct projection and prove nothing.
+ *  - `'local-frame'`     positions element-local, `origin` carries the world
+ *                        centre (the wasm default). Consumers reading raw
+ *                        positions as world coordinates are wrong here.
+ *  - `'far-local-frame'` both composed: far world centre carried in `origin`,
+ *                        small local positions.
+ *
+ * All four place THE SAME element; a frame-correct consumer answers
+ * identically (up to the f32 noise of the offset axis) across the corpus.
+ *
+ * The expected tolerance shape this corpus encodes is the one
+ * `packages/drawing-2d/src/section-cutter.ts` (PR #2622) got right: f32 noise
+ * in a distance along plane normal n is bounded by the NORMAL-PROJECTED ULP
+ * sum `sum_i |n_i| * ulp32(extent_i)` over per-axis extents — never by
+ * `max |coordinate|` over all axes. See {@link normalProjectedNoiseBound}.
+ */
+
+import type { MeshData } from '@ifc-lite/geometry';
+
+export type Axis = 'x' | 'y' | 'z';
+export const AXIS_INDEX: Record<Axis, 0 | 1 | 2> = { x: 0, y: 1, z: 2 };
+
+/** Far-from-origin offset magnitude (metres). 10 km: the f32 ULP there is
+ *  ~0.98 mm, and a max-over-axes `extent * 2^-22` tolerance reads ~2.4 mm —
+ *  the regime of every reproduced defect in the class. */
+export const WORLD_FRAME_OFFSET_M = 10_000;
+
+export type WorldFrameCase = 'at-origin' | 'far-baked' | 'local-frame' | 'far-local-frame';
+
+/** The whole corpus, for `for..of` sweeps. */
+export const WORLD_FRAME_CASES: readonly WorldFrameCase[] = [
+  'at-origin',
+  'far-baked',
+  'local-frame',
+  'far-local-frame',
+];
+
+/** A placed mesh in `MeshData`'s frame convention:
+ *  world vertex i = `(origin ?? 0) + positions[3i..3i+3]`. */
+export interface PlacedMesh {
+  /** f32-quantized vertex buffer — exactly what a consumer ingests. */
+  positions: Float32Array;
+  /** RTC origin. Absent for the baked cases. */
+  origin?: [number, number, number];
+}
+
+export interface PlaceOptions {
+  frameCase: WorldFrameCase;
+  /** Axis carrying the far offset. MUST differ from the axis under test
+   *  (plane normal, clearance direction), or the fixture looks like coverage
+   *  while proving nothing. Default `'x'`. */
+  offsetAxis?: Axis;
+  /** Far offset magnitude in metres. Default {@link WORLD_FRAME_OFFSET_M}. */
+  offsetM?: number;
+}
+
+function offsetVec(opts: PlaceOptions): [number, number, number] {
+  const v: [number, number, number] = [0, 0, 0];
+  if (opts.frameCase === 'far-baked' || opts.frameCase === 'far-local-frame') {
+    v[AXIS_INDEX[opts.offsetAxis ?? 'x']] = opts.offsetM ?? WORLD_FRAME_OFFSET_M;
+  }
+  return v;
+}
+
+/** AABB centre of a flat position buffer (f64 arithmetic). */
+function aabbCentre(pos: ArrayLike<number>): [number, number, number] {
+  const min = [Infinity, Infinity, Infinity];
+  const max = [-Infinity, -Infinity, -Infinity];
+  for (let i = 0; i < pos.length; i += 3) {
+    for (let a = 0; a < 3; a++) {
+      const c = pos[i + a]!;
+      if (c < min[a]!) min[a] = c;
+      if (c > max[a]!) max[a] = c;
+    }
+  }
+  return [(min[0]! + max[0]!) / 2, (min[1]! + max[1]!) / 2, (min[2]! + max[2]!) / 2];
+}
+
+/**
+ * Place element-local geometry (authored near the origin, f64) into one of
+ * the four corpus cases. The local-frame cases mimic the wasm router: origin
+ * = element AABB centre, positions re-based around it.
+ */
+export function placeWorldFrame(local: ArrayLike<number>, opts: PlaceOptions): PlacedMesh {
+  const off = offsetVec(opts);
+  const n = local.length;
+  const out = new Float32Array(n);
+  if (opts.frameCase === 'at-origin' || opts.frameCase === 'far-baked') {
+    for (let i = 0; i < n; i++) out[i] = local[i]! + off[i % 3]!;
+    return { positions: out };
+  }
+  const centre = aabbCentre(local);
+  for (let i = 0; i < n; i++) out[i] = local[i]! - centre[i % 3]!;
+  return {
+    positions: out,
+    origin: [centre[0] + off[0], centre[1] + off[1], centre[2] + off[2]],
+  };
+}
+
+/**
+ * Translate a placed mesh by a world-space delta, in ITS OWN frame:
+ * an origin-carrying mesh moves only its origin (exactly how the wasm
+ * local-frame pipeline expresses a moved element — positions untouched, the
+ * #2529 trigger), a baked mesh moves its positions.
+ */
+export function translateWorld(placed: PlacedMesh, delta: readonly [number, number, number]): PlacedMesh {
+  if (placed.origin) {
+    return {
+      positions: placed.positions,
+      origin: [placed.origin[0] + delta[0], placed.origin[1] + delta[1], placed.origin[2] + delta[2]],
+    };
+  }
+  const out = new Float32Array(placed.positions.length);
+  for (let i = 0; i < out.length; i++) out[i] = placed.positions[i]! + delta[i % 3]!;
+  return { positions: out };
+}
+
+export interface WorldAabb {
+  min: [number, number, number];
+  max: [number, number, number];
+}
+
+/** Ground-truth world AABB of a placed mesh — folds `origin`. */
+export function worldAabb(placed: PlacedMesh): WorldAabb {
+  const o = placed.origin ?? [0, 0, 0];
+  const min: [number, number, number] = [Infinity, Infinity, Infinity];
+  const max: [number, number, number] = [-Infinity, -Infinity, -Infinity];
+  const p = placed.positions;
+  for (let i = 0; i < p.length; i += 3) {
+    for (let a = 0 as 0 | 1 | 2; a < 3; a++) {
+      const c = p[i + a]! + o[a]!;
+      if (c < min[a]) min[a] = c;
+      if (c > max[a]) max[a] = c;
+    }
+  }
+  return { min, max };
+}
+
+/** Baked world-coordinate buffer (origin folded, f64 values of f32 inputs).
+ *  What a consumer with no origin concept (e.g. the clash `Mesh`) ingests. */
+export function bakedWorldPositions(placed: PlacedMesh): Float64Array {
+  const o = placed.origin ?? [0, 0, 0];
+  const out = new Float64Array(placed.positions.length);
+  for (let i = 0; i < out.length; i++) out[i] = placed.positions[i]! + o[i % 3]!;
+  return out;
+}
+
+/** Unit of least precision of an f32 at the given magnitude. */
+export function ulp32(magnitude: number): number {
+  const m = Math.abs(magnitude);
+  if (m === 0) return 2 ** -149;
+  const e = Math.floor(Math.log2(m));
+  return 2 ** (Math.max(e, -126) - 23);
+}
+
+/**
+ * The CORRECT f32 noise bound for a signed distance along plane normal `n`:
+ * `sum_i |n_i| * ulp32(extent_i)`, with per-axis extents taken from the WORLD
+ * coordinates of the given meshes. This is the section-cutter formulation
+ * (PR #2622) generalised to an arbitrary normal: an axis orthogonal to `n`
+ * contributes nothing, however far from the origin it puts the model —
+ * which is exactly what `max |coordinate|` over all axes gets wrong.
+ *
+ * Tests use it to pick gaps that are provably ABOVE any legitimate tolerance
+ * in every corpus case, so a genuine clearance misread as contact is a
+ * defect, not a tolerance judgement call.
+ */
+export function normalProjectedNoiseBound(
+  normal: readonly [number, number, number],
+  meshes: readonly PlacedMesh[],
+): number {
+  const extent: [number, number, number] = [0, 0, 0];
+  for (const placed of meshes) {
+    const o = placed.origin ?? [0, 0, 0];
+    const p = placed.positions;
+    for (let i = 0; i < p.length; i += 3) {
+      for (let a = 0 as 0 | 1 | 2; a < 3; a++) {
+        const c = Math.abs(p[i + a]! + o[a]!);
+        if (c > extent[a]) extent[a] = c;
+      }
+    }
+  }
+  return (
+    Math.abs(normal[0]) * ulp32(extent[0]) +
+    Math.abs(normal[1]) * ulp32(extent[1]) +
+    Math.abs(normal[2]) * ulp32(extent[2])
+  );
+}
+
+export interface ShapeTriangles {
+  /** Element-local f64 positions, ready for {@link placeWorldFrame}. */
+  positions: number[];
+  indices: Uint32Array;
+}
+
+/**
+ * An axis-aligned square (two triangles) with the given normal axis, lying at
+ * `at` on that axis, spanning `[-size/2, size/2]` on the other two axes.
+ */
+export function quadTriangles(normalAxis: Axis, at: number, size = 1): ShapeTriangles {
+  const h = size / 2;
+  const n = AXIS_INDEX[normalAxis];
+  const u = ((n + 1) % 3) as 0 | 1 | 2;
+  const v = ((n + 2) % 3) as 0 | 1 | 2;
+  const corners: [number, number][] = [
+    [-h, -h],
+    [h, -h],
+    [h, h],
+    [-h, h],
+  ];
+  const positions: number[] = [];
+  for (const [cu, cv] of corners) {
+    const p = [0, 0, 0];
+    p[n] = at;
+    p[u] = cu;
+    p[v] = cv;
+    positions.push(p[0]!, p[1]!, p[2]!);
+  }
+  return { positions, indices: new Uint32Array([0, 1, 2, 0, 2, 3]) };
+}
+
+/** An axis-aligned box `[min..max]` as 12 triangles. */
+export function boxTriangles(
+  min: readonly [number, number, number],
+  max: readonly [number, number, number],
+): ShapeTriangles {
+  const [x0, y0, z0] = min;
+  const [x1, y1, z1] = max;
+  const v: number[][] = [
+    [x0, y0, z0], [x1, y0, z0], [x1, y1, z0], [x0, y1, z0],
+    [x0, y0, z1], [x1, y0, z1], [x1, y1, z1], [x0, y1, z1],
+  ];
+  const faces = [
+    [0, 2, 1], [0, 3, 2], [4, 5, 6], [4, 6, 7], [0, 1, 5], [0, 5, 4],
+    [1, 2, 6], [1, 6, 5], [2, 3, 7], [2, 7, 6], [3, 0, 4], [3, 4, 7],
+  ];
+  return { positions: v.flat(), indices: new Uint32Array(faces.flat()) };
+}
+
+export interface MeshDataOverrides {
+  expressId?: number;
+  ifcType?: string;
+  modelIndex?: number;
+}
+
+/**
+ * Wrap a placed shape as a `MeshData` (flat normals omitted as zeroes — none
+ * of the world-frame consumers under test shade). Keeps the fixture's frame
+ * convention type-checked against the real pipeline type.
+ */
+export function asMeshData(
+  placed: PlacedMesh,
+  indices: Uint32Array,
+  overrides: MeshDataOverrides = {},
+): MeshData {
+  const mesh: MeshData = {
+    expressId: overrides.expressId ?? 1,
+    ifcType: overrides.ifcType ?? 'IfcWall',
+    modelIndex: overrides.modelIndex ?? 0,
+    positions: placed.positions,
+    normals: new Float32Array(placed.positions.length),
+    indices,
+    color: [0.5, 0.5, 0.5, 1],
+  };
+  if (placed.origin) mesh.origin = placed.origin;
+  return mesh;
+}

--- a/packages/world-frame-fixtures/src/world-frame.test.ts
+++ b/packages/world-frame-fixtures/src/world-frame.test.ts
@@ -1,0 +1,116 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Self-tests for the world-frame corpus: prove the four cases really place
+ * THE SAME element, that the far offset contaminates ONLY the offset axis
+ * (the sharpness property the corpus exists for), and that the
+ * normal-projected noise bound is offset-invariant for an orthogonal normal.
+ * A fixture whose own frame arithmetic is wrong would "catch" defects that
+ * do not exist and miss ones that do.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  WORLD_FRAME_CASES,
+  WORLD_FRAME_OFFSET_M,
+  boxTriangles,
+  normalProjectedNoiseBound,
+  placeWorldFrame,
+  quadTriangles,
+  translateWorld,
+  ulp32,
+  worldAabb,
+} from './index.js';
+
+const LOCAL_BOX = boxTriangles([0, 0, 0], [3, 0.3, 2.7]);
+
+describe('world-frame corpus placements', () => {
+  it('all four cases place the same element (world AABBs agree up to offset-axis f32 noise)', () => {
+    const reference = worldAabb(placeWorldFrame(LOCAL_BOX.positions, { frameCase: 'at-origin' }));
+    for (const frameCase of WORLD_FRAME_CASES) {
+      const placed = placeWorldFrame(LOCAL_BOX.positions, { frameCase });
+      const far = frameCase === 'far-baked' || frameCase === 'far-local-frame';
+      const box = worldAabb(placed);
+      for (let a = 0; a < 3; a++) {
+        const off = far && a === 0 ? WORLD_FRAME_OFFSET_M : 0;
+        // The offset axis of a far placement may carry f32 quantization noise
+        // (that noise is the point of the corpus). A local-frame re-base also
+        // carries one f32 rounding of the small LOCAL values on every axis
+        // (~1e-7 here) — small precisely because it scales with the element,
+        // not with the world magnitude. Baked non-offset axes are exact.
+        const rebase = placed.origin ? 1e-6 : 0;
+        const tol = far && a === 0 ? ulp32(WORLD_FRAME_OFFSET_M) + rebase : rebase;
+        expect(Math.abs(box.min[a]! - (reference.min[a]! + off))).toBeLessThanOrEqual(tol);
+        expect(Math.abs(box.max[a]! - (reference.max[a]! + off))).toBeLessThanOrEqual(tol);
+      }
+    }
+  });
+
+  it('far-baked leaves the non-offset axes bit-identical to at-origin (sharpness property)', () => {
+    // The corpus catches max-over-axes tolerances precisely because the far
+    // offset perturbs nothing on the axes actually under test. If this ever
+    // breaks, a far-case test failure could be honest noise instead of the
+    // defect class.
+    const near = placeWorldFrame(LOCAL_BOX.positions, { frameCase: 'at-origin' });
+    const far = placeWorldFrame(LOCAL_BOX.positions, { frameCase: 'far-baked' });
+    for (let i = 0; i < near.positions.length; i++) {
+      if (i % 3 === 0) continue; // offset axis (x): allowed to differ
+      expect(far.positions[i]).toBe(near.positions[i]);
+    }
+  });
+
+  it('local-frame cases carry a non-zero origin and re-based positions', () => {
+    const placed = placeWorldFrame(LOCAL_BOX.positions, { frameCase: 'local-frame' });
+    expect(placed.origin).toBeDefined();
+    // Router convention: origin = element AABB centre, so the re-based local
+    // AABB is centred on zero.
+    const local = worldAabb({ positions: placed.positions });
+    for (let a = 0; a < 3; a++) {
+      expect(local.min[a]! + local.max[a]!).toBeCloseTo(0, 5);
+    }
+    expect(placed.origin).toEqual([1.5, 0.15, 1.35]);
+  });
+
+  it('translateWorld moves the world box by the delta in BOTH frames, and only the origin in the local frame', () => {
+    const delta: [number, number, number] = [5, 0, 0];
+    for (const frameCase of WORLD_FRAME_CASES) {
+      const placed = placeWorldFrame(LOCAL_BOX.positions, { frameCase });
+      const moved = translateWorld(placed, delta);
+      const before = worldAabb(placed);
+      const after = worldAabb(moved);
+      for (let a = 0; a < 3; a++) {
+        // 5 m is exactly representable and small against the offset, so the
+        // translation itself introduces no fresh f32 noise on these values.
+        expect(after.min[a]! - before.min[a]!).toBeCloseTo(delta[a]!, 9);
+      }
+      if (placed.origin) {
+        expect(moved.positions).toBe(placed.positions); // the #2529 trigger
+      }
+    }
+  });
+
+  it('normalProjectedNoiseBound ignores the offset axis for an orthogonal normal', () => {
+    // A Z-normal bound must not grow because the model sits 10 km out in X:
+    // the Z extents are identical across the corpus, so the bound is too.
+    // This is the expected tolerance shape (PR #2622) stated as an equality.
+    const zNormal: [number, number, number] = [0, 0, 1];
+    const near = placeWorldFrame(LOCAL_BOX.positions, { frameCase: 'at-origin' });
+    const far = placeWorldFrame(LOCAL_BOX.positions, { frameCase: 'far-baked' });
+    expect(normalProjectedNoiseBound(zNormal, [far])).toBe(normalProjectedNoiseBound(zNormal, [near]));
+    // ...while an X normal DOES see the far magnitude (that axis really is noisy).
+    const xNormal: [number, number, number] = [1, 0, 0];
+    expect(normalProjectedNoiseBound(xNormal, [far])).toBeGreaterThan(
+      normalProjectedNoiseBound(xNormal, [near]),
+    );
+  });
+
+  it('quadTriangles builds the plane the normal names', () => {
+    const quad = quadTriangles('z', 0.4, 2);
+    for (let i = 2; i < quad.positions.length; i += 3) {
+      expect(quad.positions[i]).toBe(0.4);
+    }
+    expect(quad.indices).toHaveLength(6);
+  });
+});

--- a/packages/world-frame-fixtures/tsconfig.json
+++ b/packages/world-frame-fixtures/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.packages.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -665,6 +665,9 @@ importers:
         specifier: workspace:^
         version: link:../wasm
     devDependencies:
+      '@ifc-lite/world-frame-fixtures':
+        specifier: workspace:^
+        version: link:../world-frame-fixtures
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -1474,6 +1477,19 @@ importers:
         version: 6.0.3
 
   packages/wasm: {}
+
+  packages/world-frame-fixtures:
+    dependencies:
+      '@ifc-lite/geometry':
+        specifier: workspace:^
+        version: link:../geometry
+    devDependencies:
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@26.1.2)(happy-dom@20.11.1)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
 packages:
 

--- a/rust/geometry/src/clash_solid.rs
+++ b/rust/geometry/src/clash_solid.rs
@@ -272,3 +272,7 @@ pub fn intersection_solid(a: &Mesh, b: &Mesh) -> IntersectionSolid {
         volume_m3: tri_volume(&tris),
     }
 }
+
+#[cfg(test)]
+#[path = "clash_solid_world_frame_tests.rs"]
+mod world_frame_tests;

--- a/rust/geometry/src/clash_solid_world_frame_tests.rs
+++ b/rust/geometry/src/clash_solid_world_frame_tests.rs
@@ -1,0 +1,108 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! World-frame corpus coverage for the intersection-solid trust gate.
+//!
+//! `intersection_solid` gates on `TRUST_BAND_MULTIPLE *
+//! near_band_from_extent(operand_extent(a, b))`, and `operand_extent` is the
+//! max |coordinate| over ALL THREE axes of both operands — the milder shared
+//! form of the #2598/#2600/#2529 class. The thickness it gates is measured
+//! along the contact normal (Z here), whose f32 noise does not grow with an
+//! X offset; deriving the requirement from the X magnitude makes the SAME
+//! genuine 5 mm overlap a `Solid` at the origin and `BelowKernelResolution`
+//! 10 km out. The corpus places the identical pair in both frames; a
+//! frame-correct gate answers identically.
+//!
+//! The known-failing case asserts the CORRECT behaviour under
+//! `#[should_panic]`: when the gate learns the normal-projected band, the
+//! assertion stops panicking, the `should_panic` itself fails, and the
+//! attribute must be removed — the corpus cannot rot silently.
+
+use super::{DegenerateReason, IntersectionSolid, intersection_solid};
+use crate::world_frame_fixture::{
+    WorldFrameCase, normal_projected_noise_bound, placed_box_mesh,
+};
+
+/// A 1 m x 1 m pair overlapping a genuine 5 mm in Z:
+/// A spans z [0, 0.3], B spans z [0.295, 0.6].
+const OVERLAP_M: f64 = 0.005;
+
+fn overlapping_pair(case: WorldFrameCase) -> (crate::mesh::Mesh, crate::mesh::Mesh) {
+    let a = placed_box_mesh(case, [0.0, 0.0, 0.0], [1.0, 1.0, 0.3]);
+    let b = placed_box_mesh(case, [0.0, 0.0, 0.3 - OVERLAP_M], [1.0, 1.0, 0.6]);
+    (a, b)
+}
+
+#[test]
+fn the_overlap_is_provably_above_the_z_noise_bound_in_every_case() {
+    // 5 mm is four orders of magnitude above the legitimate Z-noise bound in
+    // BOTH placements (the offset touches only X), so withholding the solid
+    // far from the origin is a defect, never a tolerance judgement call.
+    for case in crate::world_frame_fixture::WORLD_FRAME_CASES {
+        let (a, b) = overlapping_pair(case);
+        let bound = normal_projected_noise_bound([0.0, 0.0, 1.0], &[&a, &b]);
+        assert!(
+            OVERLAP_M > 10_000.0 * bound,
+            "corpus premise broken for {case:?}: overlap {OVERLAP_M} vs z-noise bound {bound}"
+        );
+    }
+}
+
+#[test]
+fn counter_case_a_5mm_overlap_at_the_origin_is_a_solid() {
+    let (a, b) = overlapping_pair(WorldFrameCase::AtOrigin);
+    let solid = intersection_solid(&a, &b);
+    let volume = solid
+        .volume_m3()
+        .unwrap_or_else(|| panic!("expected a Solid at the origin, got {solid:?}"));
+    let expected = 1.0 * 1.0 * OVERLAP_M;
+    assert!(
+        (volume - expected).abs() < 1e-4,
+        "volume {volume} vs expected {expected}"
+    );
+}
+
+#[test]
+fn counter_case_a_sub_band_overlap_at_the_origin_stays_withheld() {
+    // Guards the other direction: a "fix" that simply loosens the gate must
+    // not start trusting an overlap inside the kernel's own noise band.
+    let a = placed_box_mesh(WorldFrameCase::AtOrigin, [0.0, 0.0, 0.0], [1.0, 1.0, 0.3]);
+    let b = placed_box_mesh(
+        WorldFrameCase::AtOrigin,
+        [0.0, 0.0, 0.3 - 0.0002],
+        [1.0, 1.0, 0.6],
+    );
+    assert!(
+        matches!(
+            intersection_solid(&a, &b),
+            IntersectionSolid::Degenerate(DegenerateReason::BelowKernelResolution { .. })
+        ),
+        "a 0.2 mm overlap sits inside the kernel's near band and must stay withheld"
+    );
+}
+
+// KNOWN-FAILING on the live max-over-axes gate: asserts the CORRECT
+// behaviour. `operand_extent` reads ~10 km from the irrelevant X axis, the
+// required thickness balloons to ~9.5 mm, and the genuine 5 mm Z overlap is
+// withheld. When the gate projects the band onto the contact normal this
+// stops panicking and the `should_panic` fails: remove the attribute (and
+// this comment) in that PR.
+#[test]
+#[should_panic(expected = "world-frame corpus")]
+fn a_5mm_overlap_10km_out_in_x_must_still_be_a_solid() {
+    let (a, b) = overlapping_pair(WorldFrameCase::FarBaked);
+    let solid = intersection_solid(&a, &b);
+    let volume = solid.volume_m3().unwrap_or_else(|| {
+        panic!(
+            "world-frame corpus: the SAME genuine 5 mm overlap that is a Solid at the \
+             origin must be a Solid 10 km out in X (offset axis X, contact normal Z); \
+             got {solid:?}"
+        )
+    });
+    let expected = 1.0 * 1.0 * OVERLAP_M;
+    assert!(
+        (volume - expected).abs() < 1e-4,
+        "world-frame corpus: far-placement volume {volume} vs expected {expected}"
+    );
+}

--- a/rust/geometry/src/csg/csg_tests.rs
+++ b/rust/geometry/src/csg/csg_tests.rs
@@ -264,3 +264,10 @@ fn clip_mesh_never_emits_non_finite_normals() {
         );
     }
 }
+
+// World-frame corpus tests: a sibling test file, attached here rather than
+// from `mod.rs` because that allowlisted production module is at its
+// module-size-ratchet budget and test files are exempt. The file itself
+// imports via `crate::csg::`, so the attachment depth does not matter.
+#[path = "world_frame_tests.rs"]
+mod world_frame_tests;

--- a/rust/geometry/src/csg/world_frame_tests.rs
+++ b/rust/geometry/src/csg/world_frame_tests.rs
@@ -1,0 +1,95 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! World-frame corpus coverage for the boolean seam (#2598's area).
+//!
+//! #2598 (caught pre-merge) derived the clip epsilon from the max
+//! |coordinate| over all three axes plus the plane point: a georeferenced
+//! model 10 km out in X, cut by a roughly-Z-normal plane, got a ~2.4 mm
+//! epsilon from the irrelevant X magnitude and collapsed thin flush cuts.
+//! That code never merged, but the kernel's `near_band_from_extent` callers
+//! still take the operand extent as max-over-axes, so the corpus pins the
+//! invariant the class keeps violating: a boolean's result must not depend
+//! on how far along an ORTHOGONAL axis the operands sit (up to that axis's
+//! own f32 noise).
+//!
+//! Observable: result volume, which is translation-invariant by
+//! construction. Thin features are sized against the corpus's
+//! normal-projected noise bound so a far-placement collapse is a defect,
+//! never a tolerance judgement call.
+
+use crate::csg::ClippingProcessor;
+use crate::world_frame_fixture::{
+    WORLD_FRAME_CASES, WorldFrameCase, mesh_volume, normal_projected_noise_bound,
+    placed_box_mesh,
+};
+
+/// Host slab 1 m x 1 m x 0.3 m; cutter recesses `depth` into the TOP face
+/// (plane normal Z) over a 0.4 m x 0.4 m footprint.
+fn recess_volume(case: WorldFrameCase, depth: f64) -> f64 {
+    let host = placed_box_mesh(case, [0.0, 0.0, 0.0], [1.0, 1.0, 0.3]);
+    let cutter = placed_box_mesh(case, [0.3, 0.3, 0.3 - depth], [0.7, 0.7, 0.5]);
+    let processor = ClippingProcessor::new();
+    let result = processor
+        .subtract_mesh(&host, &cutter)
+        .expect("subtract must succeed");
+    mesh_volume(&result)
+}
+
+const THIN_DEPTH: f64 = 0.002;
+const EXPECTED_THIN: f64 = 0.3 - 0.4 * 0.4 * THIN_DEPTH;
+
+#[test]
+fn the_thin_recess_is_provably_above_the_z_noise_bound_in_every_case() {
+    for case in WORLD_FRAME_CASES {
+        let host = placed_box_mesh(case, [0.0, 0.0, 0.0], [1.0, 1.0, 0.3]);
+        let cutter = placed_box_mesh(case, [0.3, 0.3, 0.3 - THIN_DEPTH], [0.7, 0.7, 0.5]);
+        let bound = normal_projected_noise_bound([0.0, 0.0, 1.0], &[&host, &cutter]);
+        assert!(
+            THIN_DEPTH > 1_000.0 * bound,
+            "corpus premise broken for {case:?}: depth {THIN_DEPTH} vs z-noise bound {bound}"
+        );
+    }
+}
+
+#[test]
+fn a_deep_recess_is_placement_invariant() {
+    // Counter-case scale: 100 mm is far outside every band in play, so this
+    // must hold before and after any tolerance change.
+    let near = recess_volume(WorldFrameCase::AtOrigin, 0.1);
+    let far = recess_volume(WorldFrameCase::FarBaked, 0.1);
+    let expected = 0.3 - 0.4 * 0.4 * 0.1;
+    assert!((near - expected).abs() < 1e-4, "near {near} vs {expected}");
+    assert!((far - expected).abs() < 1e-4, "far {far} vs {expected}");
+}
+
+#[test]
+fn a_2mm_recess_cuts_at_the_origin() {
+    let near = recess_volume(WorldFrameCase::AtOrigin, THIN_DEPTH);
+    assert!(
+        (near - EXPECTED_THIN).abs() < 1e-4,
+        "near {near} vs {EXPECTED_THIN}"
+    );
+}
+
+// KNOWN-FAILING on the live max-over-axes near band: asserts the CORRECT
+// behaviour. Measured on this code: the far placement returns volume
+// 0.3000030517580399 — the full slab, the 2 mm recess VANISHED — because
+// `near_band_from_extent` reads ~2.4 mm from the irrelevant 10 km X
+// magnitude and welds the cutter's bottom face onto the host top plane.
+// This is exactly the thin-flush-cut collapse #2598 described, live in the
+// kernel's shared band today. When the band is projected onto the plane
+// normal this stops panicking and the `should_panic` fails: remove the
+// attribute (and this comment) in that PR.
+#[test]
+#[should_panic(expected = "world-frame corpus")]
+fn a_2mm_recess_cuts_identically_10km_out_in_x() {
+    let far = recess_volume(WorldFrameCase::FarBaked, THIN_DEPTH);
+    assert!(
+        (far - EXPECTED_THIN).abs() < 1e-4,
+        "world-frame corpus: the SAME 2 mm recess that cuts at the origin must cut \
+         10 km out in X (offset axis X, cut normal Z); far volume {far} vs expected \
+         {EXPECTED_THIN}"
+    );
+}

--- a/rust/geometry/src/lib.rs
+++ b/rust/geometry/src/lib.rs
@@ -152,6 +152,11 @@ pub mod space_dcel;
 pub(crate) mod transform;
 pub(crate) mod triangulation;
 pub(crate) mod void_index;
+/// World-frame test fixture corpus: far-from-origin placements whose offset
+/// axis differs from the axis under test, plus the normal-projected f32
+/// noise bound they demand (the #2598/#2600/#2529 defect class).
+#[cfg(test)]
+pub(crate) mod world_frame_fixture;
 /// Cut one element into one closed solid per location zone (#2508 item 2), on
 /// top of the exact kernel rather than beside it.
 pub mod zone_split;

--- a/rust/geometry/src/world_frame_fixture.rs
+++ b/rust/geometry/src/world_frame_fixture.rs
@@ -1,0 +1,174 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! World-frame test fixture corpus (Rust half).
+//!
+//! One defect class, four defects in a day, all invisible to green CI: code
+//! that sizes a plane/normal tolerance from the max |coordinate| over ALL
+//! THREE axes and then compares it against a distance along ONE axis. A
+//! model 10 km out in X hands a Z-normal test a ~2.4 mm epsilon derived
+//! entirely from the irrelevant X magnitude (#2598 caught pre-merge; #2600
+//! and #2529 merged live; `near_band_from_extent` callers carry the milder
+//! shared form). No test fed those paths large world coordinates whose
+//! offset axis DIFFERS from the axis under test — an offset on the tested
+//! axis coincidentally agrees with the correct projection and proves
+//! nothing.
+//!
+//! This corpus places THE SAME operands near the origin and far out on an
+//! orthogonal axis (offset baked through f32, as ingestion really is); a
+//! frame-correct tolerance answers identically across the two placements.
+//! The TS half (`packages/world-frame-fixtures`) additionally covers the
+//! per-element RTC `MeshData.origin` cases — that concept exists only on the
+//! TS `MeshData` surface; the Rust kernel API ingests baked world
+//! coordinates, so the Rust corpus is `{AtOrigin, FarBaked}`.
+//!
+//! The expected tolerance shape is the section-cutter formulation (PR
+//! #2622): f32 noise in a distance along plane normal `n` is bounded by the
+//! NORMAL-PROJECTED ULP sum `sum_i |n_i| * ulp32(extent_i)` over per-axis
+//! extents — see [`normal_projected_noise_bound`].
+
+use crate::mesh::Mesh;
+
+/// Far-from-origin offset magnitude (metres). 10 km: the f32 ULP there is
+/// ~0.98 mm and `extent * 2^-22` reads ~2.4 mm — the regime of every
+/// reproduced defect in the class.
+pub(crate) const WORLD_FRAME_OFFSET_M: f64 = 10_000.0;
+
+/// Corpus placement. The far case offsets along X ONLY, so tests of
+/// Z-behaviour (a Z plane normal, a Z clearance) catch max-over-axes
+/// tolerance overreach instead of coincidentally agreeing with it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum WorldFrameCase {
+    /// Counter-case: near the origin. A "fix" that simply widens or
+    /// tightens every tolerance fails here.
+    AtOrigin,
+    /// `WORLD_FRAME_OFFSET_M` out along X, baked through f32.
+    FarBaked,
+}
+
+pub(crate) const WORLD_FRAME_CASES: [WorldFrameCase; 2] =
+    [WorldFrameCase::AtOrigin, WorldFrameCase::FarBaked];
+
+impl WorldFrameCase {
+    pub(crate) fn offset(self) -> [f64; 3] {
+        match self {
+            WorldFrameCase::AtOrigin => [0.0, 0.0, 0.0],
+            WorldFrameCase::FarBaked => [WORLD_FRAME_OFFSET_M, 0.0, 0.0],
+        }
+    }
+}
+
+/// Closed axis-aligned box mesh spanning `[min, max]`, placed per the corpus
+/// case with the offset BAKED THROUGH f32 (per-face vertices, outward
+/// normals) — exactly the quantization a georeferenced model's world
+/// coordinates carry on ingestion.
+pub(crate) fn placed_box_mesh(case: WorldFrameCase, min: [f64; 3], max: [f64; 3]) -> Mesh {
+    let off = case.offset();
+    let c = |sx: usize, sy: usize, sz: usize| {
+        [
+            (if sx == 0 { min[0] } else { max[0] }) + off[0],
+            (if sy == 0 { min[1] } else { max[1] }) + off[1],
+            (if sz == 0 { min[2] } else { max[2] }) + off[2],
+        ]
+    };
+    let corners = [
+        c(0, 0, 0),
+        c(1, 0, 0),
+        c(1, 1, 0),
+        c(0, 1, 0),
+        c(0, 0, 1),
+        c(1, 0, 1),
+        c(1, 1, 1),
+        c(0, 1, 1),
+    ];
+    let faces: [[usize; 4]; 6] = [
+        [0, 3, 2, 1],
+        [4, 5, 6, 7],
+        [0, 1, 5, 4],
+        [2, 3, 7, 6],
+        [0, 4, 7, 3],
+        [1, 2, 6, 5],
+    ];
+    let mut m = Mesh::new();
+    for f in &faces {
+        let a = corners[f[0]];
+        let b = corners[f[1]];
+        let d = corners[f[2]];
+        let e1 = [b[0] - a[0], b[1] - a[1], b[2] - a[2]];
+        let e2 = [d[0] - a[0], d[1] - a[1], d[2] - a[2]];
+        let n = [
+            e1[1] * e2[2] - e1[2] * e2[1],
+            e1[2] * e2[0] - e1[0] * e2[2],
+            e1[0] * e2[1] - e1[1] * e2[0],
+        ];
+        let len = (n[0] * n[0] + n[1] * n[1] + n[2] * n[2]).sqrt().max(1e-30);
+        let nn = [(n[0] / len) as f32, (n[1] / len) as f32, (n[2] / len) as f32];
+        let base = (m.positions.len() / 3) as u32;
+        for &i in f {
+            m.positions.extend_from_slice(&[
+                corners[i][0] as f32,
+                corners[i][1] as f32,
+                corners[i][2] as f32,
+            ]);
+            m.normals.extend_from_slice(&nn);
+        }
+        m.indices
+            .extend_from_slice(&[base, base + 1, base + 2, base, base + 2, base + 3]);
+    }
+    m
+}
+
+/// Unit of least precision of an f32 at the given magnitude (exact, via the
+/// bit pattern).
+pub(crate) fn ulp32(magnitude: f64) -> f64 {
+    let f = (magnitude.abs()) as f32;
+    if f == 0.0 {
+        return f64::from(f32::from_bits(1));
+    }
+    f64::from(f32::from_bits(f.to_bits() + 1)) - f64::from(f)
+}
+
+/// The CORRECT f32 noise bound for a signed distance along plane normal `n`:
+/// `sum_i |n_i| * ulp32(extent_i)` with per-axis extents from the meshes'
+/// world coordinates. An axis orthogonal to `n` contributes nothing however
+/// far it puts the model from the origin — exactly what a max-over-axes
+/// extent gets wrong. Tests use it to pick clearances that are provably
+/// above any legitimate tolerance in every corpus case.
+pub(crate) fn normal_projected_noise_bound(normal: [f64; 3], meshes: &[&Mesh]) -> f64 {
+    let mut extent = [0.0f64; 3];
+    for mesh in meshes {
+        for (i, &p) in mesh.positions.iter().enumerate() {
+            let a = i % 3;
+            let c = f64::from(p).abs();
+            if c > extent[a] {
+                extent[a] = c;
+            }
+        }
+    }
+    normal[0].abs() * ulp32(extent[0])
+        + normal[1].abs() * ulp32(extent[1])
+        + normal[2].abs() * ulp32(extent[2])
+}
+
+/// Enclosed volume of a closed f32 mesh (divergence theorem, f64 sums) —
+/// the corpus's placement-invariant observable.
+pub(crate) fn mesh_volume(mesh: &Mesh) -> f64 {
+    let p = |i: u32| {
+        let k = i as usize * 3;
+        [
+            f64::from(mesh.positions[k]),
+            f64::from(mesh.positions[k + 1]),
+            f64::from(mesh.positions[k + 2]),
+        ]
+    };
+    let mut v = 0.0;
+    for t in mesh.indices.chunks_exact(3) {
+        let (a, b, c) = (p(t[0]), p(t[1]), p(t[2]));
+        v += (a[0] * (b[1] * c[2] - b[2] * c[1])
+            - a[1] * (b[0] * c[2] - b[2] * c[0])
+            + a[2] * (b[0] * c[1] - b[1] * c[0]))
+            / 6.0;
+    }
+    v.abs()
+}

--- a/scripts/unused-locals-baseline.json
+++ b/scripts/unused-locals-baseline.json
@@ -44,5 +44,6 @@
   "packages/source-dalux": 0,
   "packages/source-fixture": 0,
   "packages/spatial": 0,
-  "packages/viewer": 0
+  "packages/viewer": 0,
+  "packages/world-frame-fixtures": 0
 }


### PR DESCRIPTION
Closes a defect class rather than a defect.

## Why

Four defects of ONE class landed in a single day, found by two sessions, **every one invisible to identical green CI gates**:

| | |
| --- | --- |
| #2598 | `mesh_plane_extent` takes max abs coordinate over all three axes with no projection onto the plane normal. Caught pre-merge. |
| #2600 | `scaledPlaneEps` does the same against a distance along one normal. **Merged, and now shipped in `@ifc-lite/clash@1.7.0`.** |
| #2529 | `meshBounds` sums `mesh.positions` without folding `MeshData.origin`, so a moved element reports `movedDistance = 0`. Merged. |
| - | A milder shared form of the same max-over-axes overreach. |

The cause is a **corpus gap, not a review gap**. No test in this repo feeds these paths a mesh with a non-zero per-element `MeshData.origin`, or with large world coordinates. Nothing could see the class, so review caught what review happened to look at, and the gates agreed every time.

Fixing each instance separately just waits for the fifth.

## What the corpus supplies

The cases that were missing, wired into the paths that have already failed (clash contact, the CSG clipper, `clash_solid`):

1. **Large world coordinates with the offset axis ORTHOGONAL to the tested normal.** This is the sharpest requirement and the easiest to get wrong: a model offset 10 km along X, tested with a plane normal also along X, would **pass**, because max-over-axes then coincides with the projection. The fixture would look like coverage while proving nothing.
2. **A counter-case at the large offset**: genuinely flush geometry must STILL be detected at 10 km. Without it, "just use a smaller epsilon" looks correct while silently breaking real coplanar detection.
3. **Origin-centred controls**, so a fix that merely widens every tolerance fails rather than passes.
4. Non-zero per-element `MeshData.origin` on the carrier types that have one.

The correct formulation is encoded from `packages/drawing-2d/src/section-cutter.ts` (#2622), which is the counter-example done right: it sizes tolerances off LOCAL pre-origin coordinates and documents why world magnitude is the wrong quantity. A plane-normal tolerance wants the normal-projected ULP sum, not `max abs coordinate`.

## Two properties that keep it honest

**Live defects are encoded as expected failures.** `a_2mm_recess_cuts_identically_10km_out_in_x` and `a_5mm_overlap_10km_out_in_x_must_still_be_a_solid` are `should_panic`; the contact case is an expected fail. They assert the CORRECT behaviour, so when the defect is fixed they turn **red** and force the marker to be removed. A fix cannot land and leave a stale "known broken" marker claiming coverage it no longer has.

**Every case carries a self-validating guard.** `the clearance is provably above the legitimate Z-noise bound in every case` and its Rust equivalents assert the fixture is exercising a real case before anything else is asserted. A fixture that stops reproducing its defect fails loudly instead of passing quietly, which is the failure mode that produced this class in the first place.

The clearance geometry is measured, not invented: a genuine 2.0 mm gap, above any legitimate f32 rounding noise (the true ULP at those coordinates is under 1e-9) yet **inside** the default 2 mm AABB inflation, so the broad phase emits all candidate pairs and the verdict rests on the epsilon alone. Offsets of 10000 and 10001 are exactly representable in f32 and f64, so no quantisation noise contaminates the result.

## Scope, stated plainly

- **The compare path is deliberately NOT wired here.** PR #2659 fixes #2529 and owns `geometrySummary.test.ts`, covering that path with hand-built meshes. Wiring both would be an add/add conflict for no benefit. Migrating #2659's meshes onto this corpus is the natural follow-up once both land.
- **This PR fixes none of the four defects.** #2659 fixes #2529; #2661 fixes #2600. This supplies the corpus and the failing evidence.
- The contact `Mesh` type has no origin field (its positions are world-frame), so that carrier covers only the large-coordinate axis. The per-element-origin axis rides on `MeshData`. Two carriers, one shared set of cases.

`@ifc-lite/world-frame-fixtures` is `private: true` test scaffolding: not published, no api-surface drift, no changeset.

## Sequencing

The expected-failure markers are the sequencing mechanism. As #2659 and #2661 merge, their cases flip red and the marker comes off in that PR, which is exactly the moment someone should confirm the fix is real. Nothing here needs to be remembered or chased.

Gates: typecheck 1115/1115, lint 0 errors, source-text-assertions clean (0 new), clippy `-D warnings` exit 0, `cargo test -p ifc-lite-geometry` green, clash contact 4 passed + 1 expected fail.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared world-frame geometry fixtures for origin, distant, and local-frame placements.
  * Added utilities for mesh placement, world-space bounds, translation, quantization noise, and generated shapes.

* **Tests**
  * Added cross-language regression coverage for contact detection, solid intersections, and CSG operations at large world offsets.
  * Added tolerance and precision checks, including documented known failures for thin geometry far from the origin.

* **Documentation**
  * Documented fixture scenarios, supported representations, tolerance expectations, and known defects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->