### PR TITLE
fix(renderer): stop non-Default lighting presets blanking the model

### DIFF
--- a/.changeset/renderer-sky-smoothstep-and-env-rebind.md
+++ b/.changeset/renderer-sky-smoothstep-and-env-rebind.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/renderer": patch
+---
+
+Fix the model disappearing when a non-Default lighting preset (Day / Overcast / Evening / Night) is selected in the Sun & Sky panel. Two independent bugs on the procedural-sky path, both surfaced only on strict WebGPU implementations (Chromium/Edge on real hardware); permissive drivers such as SwiftShader hid them.
+
+- **Sky shader compile error (primary).** `sky.wgsl` called `smoothstep(0.0, -0.1, elevation)` with the edges reversed. WGSL requires `low < high`, so Tint rejected the whole shader module ("low 0.0 not less than high -0.1"); the sky pipeline was then invalid and encoding the frame failed, blanking the model. Rewritten as `1.0 - smoothstep(-0.1, 0.0, elevation)` (identical result, valid edges).
+
+- **Lighting environment bind-group invalidation (latent).** The global lighting environment was bound at `group(1)` before the sky pass, but the sky pipeline's layout is incompatible (its own `group(0)`, no `group(1)`), so drawing the sky invalidates that binding — and the flat batch loop only re-binds `group(0)` per batch. The environment is now (re)bound at `group(1)` after the sky pass and before the first geometry draw, matching what the instanced passes already did. This was masked by the shader bug (the sky never validly drew); it becomes reachable now that the sky compiles.

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -2025,13 +2025,14 @@ export class Renderer {
                 },
             });
 
-            // Global lighting environment: write the uniform once per frame
-            // and bind at group(1) — every pipeline derived from the main
-            // shader shares this layout, and bind groups persist across
-            // setPipeline calls within the pass.
+            // Global lighting environment: write the uniform once per frame.
+            // The group(1) bind is deferred until AFTER the sky pass below —
+            // the sky pipeline has an incompatible layout (its own group(0),
+            // no group(1)), so drawing the sky invalidates a group(1) binding
+            // on conformant WebGPU implementations (see the rebind after the
+            // sky block).
             const environment = resolveEnvironment(options.environment);
             this.pipeline.updateEnvironment(options.environment);
-            pass.setBindGroup(1, this.pipeline.getEnvironmentBindGroup());
 
             // Procedural sky background — replaces the flat clear colour.
             // Drawn before any geometry at the reverse-Z far plane with depth
@@ -2073,6 +2074,18 @@ export class Renderer {
             }
 
             pass.setPipeline(this.pipeline.getPipeline());
+
+            // Bind the global lighting environment at group(1) AFTER any sky
+            // draw. The sky pipeline's layout (its own group(0), no group(1))
+            // is incompatible with the main layout, so drawing the sky
+            // invalidates the group(1) binding on strict WebGPU
+            // implementations. The flat batch loops below re-set only group(0)
+            // per batch (the instanced passes re-bind group(1) themselves), so
+            // without this rebind every non-'default' lighting preset — the
+            // only presets that enable the sky — blanked the model on those
+            // drivers. Binding while the main pipeline is current keeps it
+            // valid for every main-family draw that follows.
+            pass.setBindGroup(1, this.pipeline.getEnvironmentBindGroup());
 
             // Check if we have batched meshes (preferred for performance)
             const allBatchedMeshes = this.scene.getBatchedMeshes();

--- a/packages/renderer/src/renderer-render-paths.test.ts
+++ b/packages/renderer/src/renderer-render-paths.test.ts
@@ -29,6 +29,10 @@ import type { RenderOptions, BatchedMesh } from './types.js';
 (globalThis as Record<string, unknown>).GPUTextureUsage = {
     COPY_SRC: 1, COPY_DST: 2, TEXTURE_BINDING: 4, STORAGE_BINDING: 8, RENDER_ATTACHMENT: 16,
 };
+// Used by the SkyPass bind-group layout (GPUShaderStage.FRAGMENT).
+(globalThis as Record<string, unknown>).GPUShaderStage = {
+    VERTEX: 1, FRAGMENT: 2, COMPUTE: 4,
+};
 
 /**
  * Verbatim Chromium/Dawn wording when a pending (or newly issued) buffer map
@@ -59,6 +63,12 @@ interface Harness {
         mapAsync: number;
         /** every `queue.writeBuffer` payload, copied at call time */
         writes: { buffer: unknown; floats: Float32Array }[];
+        /**
+         * Ordered log of `setPipeline` / `setBindGroup` / `drawIndexed` calls on
+         * the render pass, so a test can assert command ORDER (e.g. that the
+         * lighting environment is rebound at group(1) after the sky pass).
+         */
+        commands: { op: string; index?: number }[];
     };
     knobs: {
         /** 'texture' = getCurrentTexture succeeds; 'null' = returns null */
@@ -91,7 +101,7 @@ interface Harness {
 }
 
 function makeHarness(): Harness {
-    const stats: Harness['stats'] = { push: 0, pop: 0, draws: [], createdBuffers: [], mapAsync: 0, writes: [] };
+    const stats: Harness['stats'] = { push: 0, pop: 0, draws: [], createdBuffers: [], mapAsync: 0, writes: [], commands: [] };
     const knobs: Harness['knobs'] = {
         textureMode: 'texture', encodeThrows: false, popRejects: false, gpuDead: false,
         deferMaps: false,
@@ -129,8 +139,17 @@ function makeHarness(): Harness {
             if (prop === 'setVertexBuffer') {
                 return (slot: number, buf: unknown) => { if (slot === 0) boundVertexBuffer = buf; };
             }
+            if (prop === 'setPipeline') {
+                return () => { stats.commands.push({ op: 'setPipeline' }); };
+            }
+            if (prop === 'setBindGroup') {
+                return (index: number) => { stats.commands.push({ op: 'setBindGroup', index }); };
+            }
             if (prop === 'drawIndexed') {
-                return () => { stats.draws.push(boundVertexBuffer); };
+                return () => {
+                    stats.commands.push({ op: 'drawIndexed' });
+                    stats.draws.push(boundVertexBuffer);
+                };
             }
             return () => undefined;
         },
@@ -381,6 +400,49 @@ describe('destroy() lifecycle', () => {
         h.renderer.destroy();
         assert.strictEqual((grey.vertexBuffer as unknown as FakeBuffer).destroyed, 1);
         assert.strictEqual((red.vertexBuffer as unknown as FakeBuffer).destroyed, 1);
+    });
+});
+
+describe('lighting environment bind ordering', () => {
+    // Regression: switching the WebGPU "Environment" preset away from Default
+    // enables the procedural sky, whose pipeline has an incompatible layout
+    // (its own group(0), no group(1)). Drawing the sky invalidates the
+    // per-frame lighting group(1) binding on conformant WebGPU
+    // implementations; the flat batch loop re-sets only group(0) per batch, so
+    // when the env was bound BEFORE the sky pass every non-Default preset drew
+    // no geometry ("the model disappears when I change the environment") on
+    // strict drivers. The env must be (re)bound at group(1) AFTER the sky pass
+    // and BEFORE the first geometry draw.
+    it('rebinds the environment at group(1) after the sky pass, before geometry', () => {
+        const h = makeHarness();
+        seedBatches(h);
+        h.stats.commands.length = 0;
+        h.render({ environment: { skyEnabled: true, sunDirection: [0.45, 0.83, 0.33] } });
+
+        const cmds = h.stats.commands;
+        const firstPipeline = cmds.findIndex((c) => c.op === 'setPipeline');
+        const firstDraw = cmds.findIndex((c) => c.op === 'drawIndexed');
+        assert.ok(firstPipeline >= 0, 'the sky pass must set a pipeline');
+        assert.ok(firstDraw > firstPipeline, 'geometry must draw after a pipeline is set');
+        const envBind = cmds.findIndex(
+            (c, i) => c.op === 'setBindGroup' && c.index === 1 && i > firstPipeline && i < firstDraw,
+        );
+        assert.ok(envBind >= 0, 'group(1) must be re-bound after the sky pass and before geometry');
+    });
+
+    it('binds the environment at group(1) before geometry with the sky off (Default preset)', () => {
+        const h = makeHarness();
+        seedBatches(h);
+        h.stats.commands.length = 0;
+        h.render();
+
+        const cmds = h.stats.commands;
+        const firstDraw = cmds.findIndex((c) => c.op === 'drawIndexed');
+        assert.ok(firstDraw >= 0, 'geometry must draw');
+        const envBind = cmds.findIndex(
+            (c, i) => c.op === 'setBindGroup' && c.index === 1 && i < firstDraw,
+        );
+        assert.ok(envBind >= 0, 'group(1) must be bound before the first geometry draw');
     });
 });
 

--- a/packages/renderer/src/renderer-render-paths.test.ts
+++ b/packages/renderer/src/renderer-render-paths.test.ts
@@ -151,6 +151,13 @@ function makeHarness(): Harness {
                     stats.draws.push(boundVertexBuffer);
                 };
             }
+            // The sky pass issues a NON-indexed draw (pass.draw(3)); record it
+            // so a test can pin the env rebind to AFTER the sky draw, not merely
+            // after the sky pipeline was set (the boundary Greptile/CodeRabbit
+            // flagged on #2669).
+            if (prop === 'draw') {
+                return () => { stats.commands.push({ op: 'draw' }); };
+            }
             return () => undefined;
         },
     });
@@ -413,7 +420,7 @@ describe('lighting environment bind ordering', () => {
     // no geometry ("the model disappears when I change the environment") on
     // strict drivers. The env must be (re)bound at group(1) AFTER the sky pass
     // and BEFORE the first geometry draw.
-    it('rebinds the environment at group(1) after the sky pass, before geometry', () => {
+    it('rebinds the environment at group(1) after the sky draw, before geometry', () => {
         const h = makeHarness();
         seedBatches(h);
         h.stats.commands.length = 0;
@@ -421,13 +428,18 @@ describe('lighting environment bind ordering', () => {
 
         const cmds = h.stats.commands;
         const firstPipeline = cmds.findIndex((c) => c.op === 'setPipeline');
-        const firstDraw = cmds.findIndex((c) => c.op === 'drawIndexed');
+        // The sky pass's own non-indexed draw — the real boundary the env
+        // rebind must clear. Anchoring on this (not just on a setPipeline)
+        // is what rejects a rebind issued before the sky actually drew.
+        const skyDraw = cmds.findIndex((c) => c.op === 'draw');
+        const firstGeometryDraw = cmds.findIndex((c) => c.op === 'drawIndexed');
         assert.ok(firstPipeline >= 0, 'the sky pass must set a pipeline');
-        assert.ok(firstDraw > firstPipeline, 'geometry must draw after a pipeline is set');
+        assert.ok(skyDraw > firstPipeline, 'the sky must draw after its pipeline is set');
+        assert.ok(firstGeometryDraw > skyDraw, 'geometry must draw after the sky');
         const envBind = cmds.findIndex(
-            (c, i) => c.op === 'setBindGroup' && c.index === 1 && i > firstPipeline && i < firstDraw,
+            (c, i) => c.op === 'setBindGroup' && c.index === 1 && i > skyDraw && i < firstGeometryDraw,
         );
-        assert.ok(envBind >= 0, 'group(1) must be re-bound after the sky pass and before geometry');
+        assert.ok(envBind >= 0, 'group(1) must be re-bound after the sky draw and before geometry');
     });
 
     it('binds the environment at group(1) before geometry with the sky off (Default preset)', () => {

--- a/packages/renderer/src/shaders/sky.wgsl.ts
+++ b/packages/renderer/src/shaders/sky.wgsl.ts
@@ -83,7 +83,13 @@ export const skyShaderSource = `
           var color = mix(sky.horizonColor, sky.zenithColor, zenithMix);
 
           // Below the horizon: fade quickly into the ground colour.
-          let groundMix = smoothstep(0.0, -0.1, elevation);
+          // WGSL requires smoothstep's low < high, so express the
+          // downward ramp (0 at the horizon → 1 at elevation -0.1) as the
+          // complement of an ascending smoothstep rather than passing
+          // reversed edges, which Tint rejects as a shader-compile error
+          // (low 0.0 not less than high -0.1) — that invalidated the whole
+          // sky pipeline and blanked the frame on strict drivers.
+          let groundMix = 1.0 - smoothstep(-0.1, 0.0, elevation);
           color = mix(color, sky.groundColor, groundMix);
 
           // Sun disc + glow. The disc is slightly oversized vs the real

--- a/packages/renderer/src/sky-shader.test.ts
+++ b/packages/renderer/src/sky-shader.test.ts
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { skyShaderSource } from './shaders/sky.wgsl.js';
+
+/**
+ * Regression: a `smoothstep(low, high, x)` with `low >= high` is a WGSL
+ * compile error ("low not less than high"). Tint (Chromium/Edge on real
+ * hardware) rejects the whole shader module, so the sky pipeline becomes
+ * invalid and encoding the frame fails — the model blanks the moment a
+ * non-Default lighting preset enables the sky. Permissive drivers
+ * (SwiftShader) accepted the reversed edges, which is why it slipped through.
+ *
+ * `smoothstep(0.0, -0.1, elevation)` was the offender; it is now written as
+ * `1.0 - smoothstep(-0.1, 0.0, elevation)`. This pins the invariant for every
+ * numeric-literal `smoothstep` in the shipped sky shader, so a future
+ * reversed-edge call cannot silently invalidate the pipeline again.
+ */
+describe('sky shader smoothstep edges (WGSL low < high)', () => {
+  it('has no numeric-literal smoothstep with low >= high', () => {
+    // Match smoothstep(<number>, <number>, …) — only the literal-edge calls,
+    // which are the ones a human can statically verify (and the ones that
+    // trip Tint's constant-folding validation).
+    const re = /smoothstep\s*\(\s*(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s*,/g;
+    const seen: Array<{ low: number; high: number }> = [];
+    for (const m of skyShaderSource.matchAll(re)) {
+      const low = Number(m[1]);
+      const high = Number(m[2]);
+      seen.push({ low, high });
+      assert.ok(
+        low < high,
+        `smoothstep(${m[1]}, ${m[2]}, …) has low >= high — WGSL rejects this`,
+      );
+    }
+    // Guard the guard: if the shader stops using literal-edge smoothstep the
+    // regex silently passes, so require at least the two known calls.
+    assert.ok(seen.length >= 2, 'expected the sky shader to keep its literal-edge smoothstep calls');
+  });
+});


### PR DESCRIPTION
## What and why

Selecting any non-Default lighting preset (Day / Overcast / Evening / Night) in the **Sun & Sky** panel made the whole model disappear on real hardware (Chromium/Edge). Two independent bugs on the procedural-sky path were responsible; both were hidden by permissive drivers (SwiftShader in CI) and only bit on strict WebGPU implementations.

1. **Sky shader compile error (primary).** sky.wgsl called smoothstep(0.0, -0.1, elevation) with the edges reversed. WGSL requires `low < high`, so Tint rejected the entire shader module (`low 0.0 not less than high -0.1`); the `sky-pipeline` then became invalid and encoding the frame failed, blanking the model. Rewritten as 1.0 - smoothstep(-0.1, 0.0, elevation) — identical result, valid edges.

2. **Lighting environment bind-group invalidation (latent).** The global lighting environment was bound at `group(1)` *before* the sky pass, whose pipeline layout is incompatible (its own `group(0)`, no `group(1)`), so drawing the sky invalidates that binding — and the flat batch loop only re-binds `group(0)` per batch. The environment is now re-bound at `group(1)` after the sky pass and before the first geometry draw, matching what the instanced passes already did. This was masked by bug #1 (the sky never validly drew) and becomes reachable now that the shader compiles.

## How it was verified

- pnpm turbo run test typecheck --filter=@ifc-lite/renderer — **903 pass, 0 fail**, typecheck clean.
- New regression tests both fail on the pre-fix code and pass after:
  - `sky-shader.test.ts` pins the WGSL invariant (every numeric-literal `smoothstep` has `low < high`).
  - `renderer-render-paths.test.ts` drives the real render loop against a stub GPU and asserts `group(1)` is re-bound after the sky pass, before geometry.
- Manual: loaded a model in the dev viewer (Edge/WebGPU), switched Environment across Day/Overcast/Evening/Night — model stays visible and the procedural sky draws.

- [x] pnpm test (TS) passes locally (renderer package)
- [ ] Geometry/WASM change: n/a (no wasm boundary touched)

## Checklist

- [x] A test asserts the new behavior through a stated invariant
- [x] Published packages/* touched: added a changeset (@ifc-lite/renderer patch); export surface unchanged
- [x] Geometry-output change: none (shading/lighting only, no mesh output changed)
- [x] House rules: no s any / @ts-ignore, no silent catch {}, no oversized module, no repo-wide cargo fmt
- [x] No client or project identifiers in code, tests, commit messages, or this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed non-default Sun & Sky lighting presets that could render incorrectly due to invalid sky blending.
  * Improved lighting consistency for geometry rendered after the sky pass.
  * Preserved correct lighting behavior when the sky is disabled.
  * Corrected below-horizon sky and ground transitions for smoother, more accurate rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->