### PR TITLE
feat(sources): favourite a folder or file in any cloud source

### DIFF
--- a/apps/viewer/src/components/sources/SourceBrowser.tsx
+++ b/apps/viewer/src/components/sources/SourceBrowser.tsx
@@ -11,6 +11,9 @@ import type {
   SourceFile,
 } from '@ifc-lite/plugin-api';
 import { loadDownloadedSourceFileRecords } from '@/lib/sources/persistence';
+import type { SourceFavourite } from '@/lib/sources/favourites';
+import { useSourceFavourites } from './useSourceFavourites';
+import { useSourceFavouriteJump } from './useSourceFavouriteJump';
 import { useSourceCatalogSync } from './useSourceCatalogSync';
 import { useSourceFileSearch } from './useSourceFileSearch';
 import { useLoadedSourceModels } from './useLoadedSourceModels';
@@ -28,11 +31,23 @@ interface SourceBrowserProps {
   onBack: () => void;
   /** True while a previously submitted selection is downloading — disables the load button. */
   busy?: boolean;
+  /** A favourite to jump straight to, consumed once on mount. */
+  openTarget?: SourceFavourite | null;
+  /** Fires when a star is pressed here, so the panel's favourites list re-reads storage. */
+  onFavouritesChanged?: () => void;
 }
 
 type Step = 'projects' | 'file-areas' | 'folders';
 
-export function SourceBrowser({ provider, ctx, onDownload, onBack, busy = false }: SourceBrowserProps) {
+export function SourceBrowser({
+  provider,
+  ctx,
+  onDownload,
+  onBack,
+  busy = false,
+  openTarget = null,
+  onFavouritesChanged,
+}: SourceBrowserProps) {
   const capabilities = provider.manifest.capabilities;
   const [step, setStep] = useState<Step>('projects');
   const [selectedProject, setSelectedProject] = useState<SourceProject | null>(null);
@@ -149,6 +164,14 @@ export function SourceBrowser({ provider, ctx, onDownload, onBack, busy = false 
     [catalog, clearSearch, selectedProject],
   );
 
+  const favourites = useSourceFavourites({
+    providerId: provider.manifest.name,
+    selectedProject,
+    selectedFileArea,
+    folders: sortedFolders,
+    onChanged: onFavouritesChanged,
+  });
+
   const toggleFile = useCallback((file: SourceFile) => {
     setSelectedFiles((prev) => {
       const next = new Map(prev);
@@ -224,6 +247,44 @@ export function SourceBrowser({ provider, ctx, onDownload, onBack, busy = false 
       return changed ? next : previous;
     });
   }, [allFiles, search.items]);
+
+  // Opening a favourite is one entry point plus the hook that drives the
+  // two-phase jump. It cannot reuse `openFileArea` above: that one reads the
+  // already-chosen `selectedProject`, and a jump has not chosen one yet — it
+  // sets both from stored ids in the same pass. Nothing needs clearing here
+  // that `openFileArea` clears, because the jump only ever runs on a freshly
+  // mounted browser. Keep the callback referentially stable (see the hook).
+  const openFileAreaFromCatalog = catalog.openFileArea;
+  const startFileAreas = fileAreasPaged.start;
+  const enterFileAreaDirect = useCallback(
+    (project: SourceProject, fileArea: SourceContainer) => {
+      projectIdRef.current = project.id;
+      setSelectedProject(project);
+      // Required even though this skips the file-areas step: Back lands there,
+      // and an unstarted list renders "No file areas found".
+      startFileAreas();
+      setSelectedFileArea(fileArea);
+      setSelectedContainer(fileArea);
+      setStep('folders');
+      openFileAreaFromCatalog(project.id, fileArea.id);
+    },
+    [openFileAreaFromCatalog, startFileAreas],
+  );
+
+  useSourceFavouriteJump({
+    target: openTarget,
+    selectedProject,
+    selectedFileArea,
+    selectedContainer,
+    sortedFolders,
+    allFiles,
+    loadingFolders: catalog.loadingFolders,
+    loadingFiles: catalog.loadingFiles,
+    enterFileArea: enterFileAreaDirect,
+    selectContainer,
+    toggleFile,
+    renameFavourite: favourites.rename,
+  });
 
   const selectedContainerId = selectedContainer?.id ?? null;
 
@@ -314,6 +375,10 @@ export function SourceBrowser({ provider, ctx, onDownload, onBack, busy = false 
           onSearchQueryChange={search.setQuery}
           onSearchSubmit={search.submit}
           onSearchClear={search.clear}
+          isFolderFavourite={favourites.isFolderFavourite}
+          onToggleFolderFavourite={favourites.toggleFolderFavourite}
+          isFileFavourite={favourites.isFileFavourite}
+          onToggleFileFavourite={favourites.toggleFileFavourite}
         />
       )}
     </div>

--- a/apps/viewer/src/components/sources/SourceBrowser.tsx
+++ b/apps/viewer/src/components/sources/SourceBrowser.tsx
@@ -271,6 +271,8 @@ export function SourceBrowser({
     [openFileAreaFromCatalog, startFileAreas],
   );
 
+  const selectedContainerId = selectedContainer?.id ?? null;
+
   useSourceFavouriteJump({
     target: openTarget,
     selectedProject,
@@ -280,13 +282,12 @@ export function SourceBrowser({
     allFiles,
     loadingFolders: catalog.loadingFolders,
     loadingFiles: catalog.loadingFiles,
+    filesHaveMore: catalog.hasMoreFiles(selectedContainerId),
     enterFileArea: enterFileAreaDirect,
     selectContainer,
     toggleFile,
     renameFavourite: favourites.rename,
   });
-
-  const selectedContainerId = selectedContainer?.id ?? null;
 
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden">

--- a/apps/viewer/src/components/sources/SourceBrowserFavouriteJump.test.tsx
+++ b/apps/viewer/src/components/sources/SourceBrowserFavouriteJump.test.tsx
@@ -1,0 +1,321 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Jumping to a favourite, mounted under `<StrictMode>` because that is where
+ * it broke.
+ *
+ * The browser is a three-step wizard, so a favourite has to rebuild the state
+ * the user would have reached by hand and then wait a render for the id-only
+ * listing it requested. The first version of that fired once, guarded by a ref
+ * — and StrictMode's mount runs effect -> cleanup -> effect, while both
+ * `useSourceCatalogSync` and `usePagedList` abort their in-flight request and
+ * bump their request generation in their own unmount cleanups. So the listing
+ * the first pass started was aborted by the teardown in between, the second
+ * pass skipped (ref already set), and because the generation was now stale the
+ * `finally` that clears `loadingFolders`/`loadingFiles` no longer applied: two
+ * spinners, forever, with no request outstanding. Every test here therefore
+ * renders inside `<StrictMode>` — under a plain mount they pass either way.
+ *
+ * The provider fixture mirrors Dalux (`flat-subtree` + recursive files), which
+ * is the shipped capability pair this ran into.
+ */
+
+import '@/test/setup-dom.js';
+import { beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { act, StrictMode } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import type {
+  FileSourceProvider,
+  Page,
+  PluginContext,
+  PluginManifest,
+  SourceContainer,
+  SourceFile,
+  SourceProject,
+} from '@ifc-lite/plugin-api';
+import { SourceHostProvider } from '@/services/sources/SourceHostProvider';
+import type { SourceFavourite } from '@/lib/sources/favourites';
+import { SourceBrowser } from './SourceBrowser.js';
+
+const ctx: PluginContext = {
+  fetch: (() => Promise.reject(new Error('not exercised'))) as typeof fetch,
+  fetchPublic: () => Promise.reject(new Error('not exercised')),
+  getPreference: () => Promise.resolve(undefined),
+  storage: {
+    get: () => Promise.resolve(undefined),
+    set: () => Promise.resolve(),
+    delete: () => Promise.resolve(),
+    keys: () => Promise.resolve([]),
+  },
+  log: { debug() {}, info() {}, warn() {}, error() {} },
+};
+
+const manifest: PluginManifest = {
+  name: 'fixture-provider',
+  title: 'Fixture Provider',
+  api: '^2.0.0',
+  permissions: { network: [] },
+  auth: 'preferences',
+  preferences: [],
+  capabilities: {
+    containerListing: 'flat-subtree',
+    listFilesIsRecursive: true,
+    revisionHistory: false,
+    downloadHistoricalRevisions: false,
+    changeDetection: false,
+    search: false,
+  },
+  contributes: { fileSources: [] },
+};
+
+const FOLDER: SourceContainer = { id: 'folder-1', name: 'Models', parentId: 'area-1' };
+const OTHER_FOLDER: SourceContainer = { id: 'folder-2', name: 'Drawings', parentId: 'area-1' };
+const IN_FOLDER: SourceFile = {
+  id: 'file-1', name: 'Tower.ifc', containerId: 'folder-1', currentRevisionId: 'rev-1',
+};
+const ELSEWHERE: SourceFile = {
+  id: 'file-2', name: 'Podium.ifc', containerId: 'folder-2', currentRevisionId: 'rev-1',
+};
+
+class FakeProvider implements FileSourceProvider {
+  readonly manifest = manifest;
+  folderListings = 0;
+  fileListings = 0;
+
+  listProjects(): Promise<Page<SourceProject>> {
+    return Promise.resolve({ items: [{ id: 'project-1', name: 'Tower Project' }] });
+  }
+
+  listContainers(_ctx: PluginContext, _projectId: string, parentId?: string): Promise<Page<SourceContainer>> {
+    if (!parentId) return Promise.resolve({ items: [{ id: 'area-1', name: 'Documents' }] });
+    this.folderListings += 1;
+    return Promise.resolve({ items: [FOLDER, OTHER_FOLDER] });
+  }
+
+  listFiles(): Promise<Page<SourceFile>> {
+    this.fileListings += 1;
+    return Promise.resolve({ items: [IN_FOLDER, ELSEWHERE] });
+  }
+
+  download(): Promise<ArrayBuffer> {
+    return Promise.reject(new Error('not exercised'));
+  }
+}
+
+function favourite(overrides: Partial<SourceFavourite> = {}): SourceFavourite {
+  return {
+    providerId: 'fixture-provider',
+    kind: 'folder',
+    projectId: 'project-1',
+    projectName: 'Tower Project',
+    fileAreaId: 'area-1',
+    fileAreaName: 'Documents',
+    containerId: 'folder-1',
+    containerName: 'Models',
+    identityId: null,
+    addedAt: 1,
+    ...overrides,
+  };
+}
+
+/**
+ * A provider that holds a listing back until released, so the second phase is
+ * forced to run while the data it needs is still in flight. `FakeProvider`
+ * resolves in a microtask, which happens to hand the effect a complete listing
+ * on its first useful run — the "is it still loading?" guards are then inert,
+ * and a build that dropped them passes. Deferring is what makes them
+ * load-bearing.
+ */
+class DeferringProvider extends FakeProvider {
+  private releaseFolders: (() => void) | null = null;
+  private releaseFiles: (() => void) | null = null;
+
+  constructor(private readonly defer: 'folders' | 'files') {
+    super();
+  }
+
+  override listContainers(
+    c: PluginContext,
+    projectId: string,
+    parentId?: string,
+  ): Promise<Page<SourceContainer>> {
+    const page = super.listContainers(c, projectId, parentId);
+    if (this.defer !== 'folders' || !parentId) return page;
+    return new Promise((resolve) => {
+      this.releaseFolders = () => resolve(page);
+    });
+  }
+
+  override listFiles(): Promise<Page<SourceFile>> {
+    const page = super.listFiles();
+    if (this.defer !== 'files') return page;
+    return new Promise((resolve) => {
+      this.releaseFiles = () => resolve(page);
+    });
+  }
+
+  release(): void {
+    this.releaseFolders?.();
+    this.releaseFiles?.();
+  }
+}
+
+const mounted: Array<{ root: Root; container: HTMLElement }> = [];
+
+// Several microtask turns: the area sync fetches folders and files in
+// sequence, and the second phase runs on the render after each arrives.
+async function pump(turns = 8): Promise<void> {
+  for (let i = 0; i < turns; i++) {
+    await act(async () => {
+      await Promise.resolve();
+    });
+  }
+}
+
+async function jumpTo(target: SourceFavourite, provider: FakeProvider): Promise<void> {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  mounted.push({ root, container });
+
+  await act(async () => {
+    root.render(
+      <StrictMode>
+        <SourceHostProvider>
+          <SourceBrowser
+            provider={provider}
+            ctx={ctx}
+            onDownload={() => {}}
+            onBack={() => {}}
+            openTarget={target}
+          />
+        </SourceHostProvider>
+      </StrictMode>,
+    );
+  });
+  await pump();
+}
+
+function text(): string {
+  return document.body.textContent ?? '';
+}
+
+beforeEach(() => {
+  for (const { root, container } of mounted.splice(0)) {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  }
+  document.body.innerHTML = '';
+  localStorage.clear();
+});
+
+describe('jumping to a favourite folder', () => {
+  it('fetches the area listing and lands inside the favourited folder', async () => {
+    const provider = new FakeProvider();
+    await jumpTo(favourite(), provider);
+
+    assert.ok(
+      provider.folderListings > 0,
+      'the jump must actually request the area catalog, not sit on a spinner',
+    );
+    assert.ok(provider.fileListings > 0, 'the file listing must be requested too');
+    assert.ok(text().includes('Tower.ifc'), "the favourited folder's file must be listed");
+    assert.equal(
+      text().includes('Podium.ifc'),
+      false,
+      'a file from a sibling folder must not leak into the favourited one',
+    );
+  });
+
+  it('refreshes a label the source renamed underneath the favourite', async () => {
+    const provider = new FakeProvider();
+    const { loadFavourites, saveFavourites } = await import('@/lib/sources/favourites');
+    const stale = favourite({ containerName: 'Old Name' });
+    saveFavourites('fixture-provider', [stale]);
+
+    await jumpTo(stale, provider);
+
+    assert.equal(
+      loadFavourites('fixture-provider')[0]?.containerName,
+      'Models',
+      'an id-addressed favourite still opens after a rename; the stored label must catch up',
+    );
+  });
+});
+
+describe('jumping to a favourite file', () => {
+  it('preselects the file so one click loads it', async () => {
+    const provider = new FakeProvider();
+    await jumpTo(
+      favourite({ kind: 'file', fileId: 'file-1', fileName: 'Tower.ifc' }),
+      provider,
+    );
+
+    assert.ok(
+      text().includes('Load 1 file as federated model'),
+      'the favourited file must arrive already selected',
+    );
+  });
+
+  it('says so instead of hanging when the file is gone from its folder', async () => {
+    const provider = new FakeProvider();
+    await jumpTo(
+      favourite({ kind: 'file', fileId: 'file-deleted', fileName: 'Gone.ifc' }),
+      provider,
+    );
+
+    assert.ok(text().includes('Tower.ifc'), 'the folder still opens');
+    assert.equal(
+      text().includes('Load 1 file as federated model'),
+      false,
+      'nothing may end up selected',
+    );
+  });
+
+  it('waits for a slow file listing instead of giving up on the first empty one', async () => {
+    const provider = new DeferringProvider('files');
+    await jumpTo(favourite({ kind: 'file', fileId: 'file-1', fileName: 'Tower.ifc' }), provider);
+
+    // The listing is still in flight: an absent file here means "not yet",
+    // never "deleted", so the jump must still be pending.
+    assert.equal(
+      text().includes('Load 1 file as federated model'),
+      false,
+      'nothing can be selected before the listing arrives',
+    );
+
+    provider.release();
+    await pump();
+
+    assert.ok(
+      text().includes('Load 1 file as federated model'),
+      'the favourited file must be selected once the slow listing lands',
+    );
+  });
+});
+
+describe('jumping while the listing is still in flight', () => {
+  it('waits for a slow folder listing before resolving the favourited folder', async () => {
+    const provider = new DeferringProvider('folders');
+    const { loadFavourites, saveFavourites } = await import('@/lib/sources/favourites');
+    const stale = favourite({ containerName: 'Old Name' });
+    saveFavourites('fixture-provider', [stale]);
+
+    await jumpTo(stale, provider);
+    provider.release();
+    await pump();
+
+    // Resolving against an empty in-flight listing would fall back to the
+    // stored name and settle for it, leaving the label wrong forever.
+    assert.equal(
+      loadFavourites('fixture-provider')[0]?.containerName,
+      'Models',
+      'the real folder must be the one that resolves the favourite, not a synthesised stand-in',
+    );
+  });
+});

--- a/apps/viewer/src/components/sources/SourceBrowserFavouriteJump.test.tsx
+++ b/apps/viewer/src/components/sources/SourceBrowserFavouriteJump.test.tsx
@@ -190,6 +190,15 @@ class DirectChildrenProvider extends FakeProvider {
   override readonly manifest = directChildrenManifest;
   private releaseChildren: (() => void) | null = null;
 
+  /**
+   * Splits the file listing over two pages, the favourited file on the second.
+   * `eagerFileSweep` is off by default, so this is the SHIPPED shape for every
+   * provider but Dalux: `useSourceCatalogSync` fetches page one and stops.
+   */
+  constructor(private readonly pageFiles = false) {
+    super();
+  }
+
   override listContainers(
     _ctx: PluginContext,
     _projectId: string,
@@ -210,17 +219,27 @@ class DirectChildrenProvider extends FakeProvider {
     _ctx?: PluginContext,
     _projectId?: string,
     containerId?: string,
+    _filter?: unknown,
+    options?: { cursor?: string },
   ): Promise<Page<SourceFile>> {
     this.fileListings += 1;
-    return Promise.resolve({
-      items: [IN_FOLDER, ELSEWHERE].filter((file) => file.containerId === containerId),
-    });
+    const items = [IN_FOLDER, ELSEWHERE].filter((file) => file.containerId === containerId);
+    if (!this.pageFiles) return Promise.resolve({ items });
+    return options?.cursor === undefined
+      ? Promise.resolve({ items: [], cursor: 'page-2' })
+      : Promise.resolve({ items });
   }
 
   release(): void {
     this.releaseChildren?.();
     this.releaseChildren = null;
   }
+}
+
+function button(label: string): HTMLButtonElement | undefined {
+  return [...document.body.querySelectorAll('button')].find(
+    (candidate) => candidate.textContent?.includes(label),
+  ) as HTMLButtonElement | undefined;
 }
 
 const mounted: Array<{ root: Root; container: HTMLElement }> = [];
@@ -412,6 +431,48 @@ describe('jumping while the listing is still in flight', () => {
       assert.ok(
         text().includes('Load 1 file as federated model'),
         'the pending jump must survive the window and preselect the file once listed',
+      );
+    } finally {
+      toast.info = originalInfo;
+    }
+  });
+
+  it('does not call a favourite gone while its folder has file pages outstanding', async () => {
+    // The default shape: without `eagerFileSweep` only the FIRST page of a
+    // folder's files is fetched, so "not in the listing" says nothing about
+    // whether the file exists. Reporting it gone here is a lie about a file
+    // sitting on page two.
+    const provider = new DirectChildrenProvider(true);
+    const infoToasts: string[] = [];
+    const originalInfo = toast.info;
+    toast.info = (message: string) => {
+      infoToasts.push(message);
+      originalInfo(message);
+    };
+    try {
+      await jumpTo(favourite({ kind: 'file', fileId: 'file-1', fileName: 'Tower.ifc' }), provider);
+      provider.release();
+      await pump();
+
+      assert.deepStrictEqual(
+        infoToasts,
+        [],
+        'page one being short of the file is not the file being deleted',
+      );
+
+      // And the jump is still pending, so the user's own "Load more files"
+      // finishes it — the residual gap is that nothing drains those pages for
+      // them, not that the jump was thrown away.
+      const loadMore = button('Load more files');
+      assert.ok(loadMore, 'the outstanding page must still be offered');
+      await act(async () => {
+        loadMore.click();
+      });
+      await pump();
+
+      assert.ok(
+        text().includes('Load 1 file as federated model'),
+        'the favourited file must be selected once its page arrives',
       );
     } finally {
       toast.info = originalInfo;

--- a/apps/viewer/src/components/sources/SourceBrowserFavouriteJump.test.tsx
+++ b/apps/viewer/src/components/sources/SourceBrowserFavouriteJump.test.tsx
@@ -19,7 +19,10 @@
  * renders inside `<StrictMode>` — under a plain mount they pass either way.
  *
  * The provider fixture mirrors Dalux (`flat-subtree` + recursive files), which
- * is the shipped capability pair this ran into.
+ * is the shipped capability pair this ran into. A second fixture mirrors
+ * Dropbox/msgraph (`direct-children` + per-folder files), whose two-step
+ * `openContainer` is the only way to reach the folders-before-files window the
+ * last test pins down.
  */
 
 import '@/test/setup-dom.js';
@@ -37,6 +40,7 @@ import type {
   SourceProject,
 } from '@ifc-lite/plugin-api';
 import { SourceHostProvider } from '@/services/sources/SourceHostProvider';
+import { toast } from '@/components/ui/toast';
 import type { SourceFavourite } from '@/lib/sources/favourites';
 import { SourceBrowser } from './SourceBrowser.js';
 
@@ -160,6 +164,62 @@ class DeferringProvider extends FakeProvider {
   release(): void {
     this.releaseFolders?.();
     this.releaseFiles?.();
+  }
+}
+
+const directChildrenManifest: PluginManifest = {
+  ...manifest,
+  capabilities: {
+    ...manifest.capabilities,
+    containerListing: 'direct-children',
+    listFilesIsRecursive: false,
+  },
+};
+
+/**
+ * Dropbox/msgraph-shaped: one children listing per browsed folder, one file
+ * listing per folder. On this capability pair `openContainer` fetches the
+ * child folders FIRST and flips `loadingFiles` only after they resolve, so
+ * there is a window where `loadingFolders` is true, `loadingFiles` is false
+ * and the favourited file is simply not listed yet. `DeferringProvider` cannot
+ * park the jump there — it holds back every folder listing including the area
+ * root's, which the jump needs to get going — so this one holds back exactly
+ * the favourited folder's children listing.
+ */
+class DirectChildrenProvider extends FakeProvider {
+  override readonly manifest = directChildrenManifest;
+  private releaseChildren: (() => void) | null = null;
+
+  override listContainers(
+    _ctx: PluginContext,
+    _projectId: string,
+    parentId?: string,
+  ): Promise<Page<SourceContainer>> {
+    if (!parentId) return Promise.resolve({ items: [{ id: 'area-1', name: 'Documents' }] });
+    this.folderListings += 1;
+    const page = Promise.resolve({
+      items: [FOLDER, OTHER_FOLDER].filter((folder) => folder.parentId === parentId),
+    });
+    if (parentId !== FOLDER.id) return page;
+    return new Promise((resolve) => {
+      this.releaseChildren = () => resolve(page);
+    });
+  }
+
+  override listFiles(
+    _ctx?: PluginContext,
+    _projectId?: string,
+    containerId?: string,
+  ): Promise<Page<SourceFile>> {
+    this.fileListings += 1;
+    return Promise.resolve({
+      items: [IN_FOLDER, ELSEWHERE].filter((file) => file.containerId === containerId),
+    });
+  }
+
+  release(): void {
+    this.releaseChildren?.();
+    this.releaseChildren = null;
   }
 }
 
@@ -317,5 +377,44 @@ describe('jumping while the listing is still in flight', () => {
       'Models',
       'the real folder must be the one that resolves the favourite, not a synthesised stand-in',
     );
+  });
+
+  it('survives the folders-before-files window of a direct-children provider', async () => {
+    // The real ordering on Dropbox/msgraph: entering the favourited folder
+    // fetches its child folders first, so the effect runs with
+    // `loadingFolders === true`, `loadingFiles === false` and the file absent
+    // from the catalog. Guarding on `loadingFiles` alone gives up right there.
+    const provider = new DirectChildrenProvider();
+    const infoToasts: string[] = [];
+    const originalInfo = toast.info;
+    toast.info = (message: string) => {
+      infoToasts.push(message);
+      originalInfo(message);
+    };
+    try {
+      await jumpTo(favourite({ kind: 'file', fileId: 'file-1', fileName: 'Tower.ifc' }), provider);
+
+      assert.equal(
+        infoToasts.some((message) => message.includes('no longer in this folder')),
+        false,
+        'a file whose folder listing is still in flight must not be reported as gone',
+      );
+      assert.equal(
+        text().includes('Load 1 file as federated model'),
+        false,
+        'nothing can be selected before the listing arrives',
+      );
+
+      provider.release();
+      await pump();
+
+      assert.equal(infoToasts.length, 0, 'no give-up toast may have fired along the way');
+      assert.ok(
+        text().includes('Load 1 file as federated model'),
+        'the pending jump must survive the window and preselect the file once listed',
+      );
+    } finally {
+      toast.info = originalInfo;
+    }
   });
 });

--- a/apps/viewer/src/components/sources/SourceFavouritesList.test.tsx
+++ b/apps/viewer/src/components/sources/SourceFavouritesList.test.tsx
@@ -1,0 +1,285 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The quick-access list. What matters is not that rows render but that the
+ * right rows render and that a click hands the panel an address it can
+ * actually re-open, so every test here clicks or asserts on absence:
+ *
+ * - another account's favourites are not on screen, and are still in storage;
+ * - a provider this build no longer registers renders DISABLED rather than
+ *   vanishing, because dropping bookmarks on a plugin change is worse than
+ *   showing a dead one;
+ * - a preference-auth provider missing its required settings is disabled with
+ *   the same wording the provider row uses, so the two cannot disagree;
+ * - clicking a row emits the stored favourite verbatim;
+ * - the X removes exactly that row from storage.
+ */
+
+import '@/test/setup-dom.js';
+import { beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import type {
+  FileSourceProvider,
+  Page,
+  PluginContext,
+  PluginManifest,
+  SourceContainer,
+  SourceFile,
+  SourceProject,
+} from '@ifc-lite/plugin-api';
+import { SourceHost } from '@/services/sources/source-host';
+import { saveFavourites, loadFavourites, type SourceFavourite } from '@/lib/sources/favourites';
+import { syncSourceCatalogCacheOwner } from '@/lib/sources/persistence';
+import { saveSourcePrefs } from '@/lib/sources/preferences';
+import { SourceFavouritesList } from './SourceFavouritesList.js';
+
+function manifest(overrides: Partial<PluginManifest> = {}): PluginManifest {
+  return {
+    name: 'fixture-provider',
+    title: 'Fixture Provider',
+    api: '^2.0.0',
+    permissions: { network: [] },
+    auth: 'preferences',
+    preferences: [],
+    capabilities: {
+      containerListing: 'direct-children',
+      listFilesIsRecursive: false,
+      revisionHistory: false,
+      downloadHistoricalRevisions: false,
+      changeDetection: false,
+      search: false,
+    },
+    contributes: { fileSources: [] },
+    ...overrides,
+  };
+}
+
+class FakeProvider implements FileSourceProvider {
+  constructor(readonly manifest: PluginManifest) {}
+  listProjects(): Promise<Page<SourceProject>> {
+    return Promise.resolve({ items: [] });
+  }
+  listContainers(): Promise<Page<SourceContainer>> {
+    return Promise.resolve({ items: [] });
+  }
+  listFiles(): Promise<Page<SourceFile>> {
+    return Promise.resolve({ items: [] });
+  }
+  download(_ctx: PluginContext): Promise<ArrayBuffer> {
+    return Promise.reject(new Error('not exercised'));
+  }
+}
+
+function favourite(overrides: Partial<SourceFavourite> = {}): SourceFavourite {
+  return {
+    providerId: 'fixture-provider',
+    kind: 'folder',
+    projectId: 'project-1',
+    projectName: 'Tower Project',
+    fileAreaId: 'area-1',
+    fileAreaName: 'Documents',
+    containerId: 'folder-1',
+    containerName: 'Models',
+    identityId: null,
+    addedAt: 1_000,
+    ...overrides,
+  };
+}
+
+const mounted: Array<{ root: Root; container: HTMLElement }> = [];
+
+function renderList(host: SourceHost): { opened: SourceFavourite[]; rerender: () => void } {
+  const opened: SourceFavourite[] = [];
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  let version = 0;
+
+  const paint = () => {
+    act(() => {
+      root.render(
+        <SourceFavouritesList
+          sourceHost={host}
+          favouritesVersion={version}
+          identityVersion={0}
+          onOpen={(item) => opened.push(item)}
+          onChanged={() => {
+            version += 1;
+            paint();
+          }}
+        />,
+      );
+    });
+  };
+  paint();
+  mounted.push({ root, container });
+
+  return {
+    opened,
+    rerender: () => {
+      version += 1;
+      paint();
+    },
+  };
+}
+
+function rowButton(label: string): HTMLButtonElement | undefined {
+  return [...document.body.querySelectorAll('button')].find(
+    (button) => button.textContent?.includes(label),
+  ) as HTMLButtonElement | undefined;
+}
+
+function removeButton(label: string): HTMLButtonElement {
+  const found = [...document.body.querySelectorAll('button')].find(
+    (button) => button.getAttribute('aria-label') === label,
+  );
+  assert.ok(found, `a button labelled "${label}" must render`);
+  return found as HTMLButtonElement;
+}
+
+beforeEach(() => {
+  for (const { root, container } of mounted.splice(0)) {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  }
+  document.body.innerHTML = '';
+  localStorage.clear();
+});
+
+describe('SourceFavouritesList — what is shown', () => {
+  it('renders nothing at all when there are no favourites', () => {
+    const host = new SourceHost();
+    host.register(new FakeProvider(manifest()));
+    renderList(host);
+    assert.equal(document.body.textContent?.includes('Favourites'), false);
+  });
+
+  it('opens a favourite by handing back the stored address', () => {
+    const host = new SourceHost();
+    host.register(new FakeProvider(manifest()));
+    saveFavourites('fixture-provider', [favourite()]);
+
+    const { opened } = renderList(host);
+    const row = rowButton('Models');
+    assert.ok(row, 'the favourite must render a clickable row');
+    act(() => {
+      row.click();
+    });
+
+    assert.equal(opened.length, 1);
+    assert.deepStrictEqual(opened[0], favourite());
+  });
+
+  it('labels a row with its provider, project and file area so two sources can be told apart', () => {
+    const host = new SourceHost();
+    host.register(new FakeProvider(manifest()));
+    saveFavourites('fixture-provider', [favourite()]);
+    renderList(host);
+    assert.ok(
+      document.body.textContent?.includes('Fixture Provider / Tower Project / Documents'),
+      'the sub-line must carry the full source path',
+    );
+  });
+
+  it('removes exactly the clicked row from storage', () => {
+    const host = new SourceHost();
+    host.register(new FakeProvider(manifest()));
+    saveFavourites('fixture-provider', [
+      favourite({ containerId: 'folder-1', containerName: 'Models', addedAt: 2 }),
+      favourite({ containerId: 'folder-2', containerName: 'Drawings', addedAt: 1 }),
+    ]);
+    renderList(host);
+
+    act(() => {
+      removeButton('Remove favourite: Models').click();
+    });
+
+    assert.deepStrictEqual(
+      loadFavourites('fixture-provider').map((item) => item.containerName),
+      ['Drawings'],
+    );
+    assert.equal(rowButton('Models'), undefined, 'the removed row must leave the screen');
+  });
+});
+
+describe('SourceFavouritesList — identity scoping', () => {
+  it("hides another identity's favourites while leaving them in storage", () => {
+    const host = new SourceHost();
+    host.register(new FakeProvider(manifest({ auth: 'interactive' })));
+    // The provider is signed in as user-a.
+    syncSourceCatalogCacheOwner('fixture-provider', 'user-a');
+    saveFavourites('fixture-provider', [
+      favourite({ identityId: 'user-a', containerName: 'Mine' }),
+      favourite({ identityId: 'user-b', containerId: 'folder-2', containerName: 'Theirs' }),
+    ]);
+
+    renderList(host);
+
+    assert.ok(rowButton('Mine'), "the signed-in identity's favourite must render");
+    assert.equal(rowButton('Theirs'), undefined, "another identity's favourite must not render");
+    assert.equal(loadFavourites('fixture-provider').length, 2, 'nothing is deleted by the filter');
+  });
+});
+
+describe('SourceFavouritesList — providers that cannot be browsed', () => {
+  it('renders a favourite for an unregistered provider disabled rather than dropping it', () => {
+    // Nothing registered: the plugin was removed, or failed to register.
+    const host = new SourceHost();
+    saveFavourites('retired-provider', [favourite({ providerId: 'retired-provider' })]);
+
+    const { opened } = renderList(host);
+    const row = rowButton('Models');
+    assert.ok(row, 'a bookmark must never vanish because a build dropped its provider');
+    assert.equal(row.disabled, true);
+    assert.ok(document.body.textContent?.includes('Provider unavailable'));
+
+    act(() => {
+      row.click();
+    });
+    assert.equal(opened.length, 0, 'a disabled row must not navigate anywhere');
+  });
+
+  it('disables a preference-auth provider that is missing a required setting', () => {
+    const host = new SourceHost();
+    host.register(
+      new FakeProvider(
+        manifest({
+          preferences: [{ name: 'apiKey', title: 'API key', type: 'password', required: true }],
+        }),
+      ),
+    );
+    saveFavourites('fixture-provider', [favourite()]);
+
+    renderList(host);
+    const row = rowButton('Models');
+    assert.ok(row);
+    assert.equal(row.disabled, true);
+    assert.ok(document.body.textContent?.includes('Add the required settings to browse'));
+  });
+
+  it('enables the row once the required setting is saved', () => {
+    const host = new SourceHost();
+    host.register(
+      new FakeProvider(
+        manifest({
+          preferences: [{ name: 'apiKey', title: 'API key', type: 'password', required: true }],
+        }),
+      ),
+    );
+    saveFavourites('fixture-provider', [favourite()]);
+    const handle = renderList(host);
+
+    saveSourcePrefs('fixture-provider', { apiKey: 'secret' });
+    handle.rerender();
+
+    const row = rowButton('Models');
+    assert.ok(row);
+    assert.equal(row.disabled, false);
+  });
+});

--- a/apps/viewer/src/components/sources/SourceFavouritesList.test.tsx
+++ b/apps/viewer/src/components/sources/SourceFavouritesList.test.tsx
@@ -8,6 +8,10 @@
  * actually re-open, so every test here clicks or asserts on absence:
  *
  * - another account's favourites are not on screen, and are still in storage;
+ * - visibility follows LIVE auth state, so an interactive provider shows
+ *   nothing until its silent restore settles and nothing at all once that
+ *   restore comes back signed-out — the persisted owner stamp outlives the tab
+ *   and would otherwise render last session's account to whoever is here now;
  * - a provider this build no longer registers renders DISABLED rather than
  *   vanishing, because dropping bookmarks on a plugin change is worse than
  *   showing a dead one;
@@ -92,12 +96,17 @@ function favourite(overrides: Partial<SourceFavourite> = {}): SourceFavourite {
 
 const mounted: Array<{ root: Root; container: HTMLElement }> = [];
 
-function renderList(host: SourceHost): { opened: SourceFavourite[]; rerender: () => void } {
+function renderList(
+  host: SourceHost,
+  /** What the provider rows have reported; empty means "auth has not settled". */
+  liveIdentities: ReadonlyMap<string, string | null> = new Map(),
+): { opened: SourceFavourite[]; rerender: (identities?: ReadonlyMap<string, string | null>) => void } {
   const opened: SourceFavourite[] = [];
   const container = document.createElement('div');
   document.body.appendChild(container);
   const root = createRoot(container);
   let version = 0;
+  let identities = liveIdentities;
 
   const paint = () => {
     act(() => {
@@ -105,7 +114,7 @@ function renderList(host: SourceHost): { opened: SourceFavourite[]; rerender: ()
         <SourceFavouritesList
           sourceHost={host}
           favouritesVersion={version}
-          identityVersion={0}
+          liveIdentities={identities}
           onOpen={(item) => opened.push(item)}
           onChanged={() => {
             version += 1;
@@ -120,7 +129,8 @@ function renderList(host: SourceHost): { opened: SourceFavourite[]; rerender: ()
 
   return {
     opened,
-    rerender: () => {
+    rerender: (next?: ReadonlyMap<string, string | null>) => {
+      if (next) identities = next;
       version += 1;
       paint();
     },
@@ -219,11 +229,59 @@ describe('SourceFavouritesList — identity scoping', () => {
       favourite({ identityId: 'user-b', containerId: 'folder-2', containerName: 'Theirs' }),
     ]);
 
-    renderList(host);
+    renderList(host, new Map([['fixture-provider', 'user-a']]));
 
     assert.ok(rowButton('Mine'), "the signed-in identity's favourite must render");
     assert.equal(rowButton('Theirs'), undefined, "another identity's favourite must not render");
     assert.equal(loadFavourites('fixture-provider').length, 2, 'nothing is deleted by the filter');
+  });
+
+  it('shows nothing for an interactive provider whose session has not restored yet', () => {
+    // The catalog-cache owner is written to localStorage and outlives the tab,
+    // so on a fresh mount it still names LAST session's account while
+    // `restore()` is in flight. Deriving visibility from it put user-a's folder
+    // names in front of whoever opened the panel next.
+    const host = new SourceHost();
+    host.register(new FakeProvider(manifest({ auth: 'interactive' })));
+    syncSourceCatalogCacheOwner('fixture-provider', 'user-a');
+    saveFavourites('fixture-provider', [favourite({ identityId: 'user-a', containerName: 'Mine' })]);
+
+    // Empty map: no row has reported a settled identity.
+    const handle = renderList(host);
+    // Compared as a boolean, not as the element: `assert` formats the actual
+    // value on failure, and inspecting a happy-dom node OOMs the runner.
+    assert.equal(
+      rowButton('Mine') === undefined,
+      true,
+      'a stamped-but-unconfirmed identity must not put rows on screen',
+    );
+
+    handle.rerender(new Map([['fixture-provider', 'user-a']]));
+    assert.ok(rowButton('Mine'), 'and they come back the moment the restore confirms user-a');
+  });
+
+  it('hides them for good when the restore resolves signed-out, stamp or no stamp', () => {
+    // The half that made this permanent rather than transient: a restore that
+    // resolves no session leaves the row's identity at the `null` it already
+    // held, so nothing about the id changes and the stale stamp was never
+    // re-read. Signed out must mean no rows.
+    const host = new SourceHost();
+    host.register(new FakeProvider(manifest({ auth: 'interactive' })));
+    syncSourceCatalogCacheOwner('fixture-provider', 'user-a');
+    saveFavourites('fixture-provider', [favourite({ identityId: 'user-a', containerName: 'Mine' })]);
+    // A failed silent restore clears the owner key, but a stale one is exactly
+    // what this must survive, so leave it in place and report signed-out.
+    const handle = renderList(host, new Map([['fixture-provider', 'user-a']]));
+    assert.ok(rowButton('Mine'), 'precondition: they are on screen while signed in');
+
+    handle.rerender(new Map([['fixture-provider', null]]));
+
+    assert.equal(
+      rowButton('Mine') === undefined,
+      true,
+      'a signed-out provider shows no favourites',
+    );
+    assert.equal(loadFavourites('fixture-provider').length, 1, 'and nothing was deleted');
   });
 });
 

--- a/apps/viewer/src/components/sources/SourceFavouritesList.tsx
+++ b/apps/viewer/src/components/sources/SourceFavouritesList.tsx
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { useMemo } from 'react';
+import type { FileSourceProvider } from '@ifc-lite/plugin-api';
 import type { SourceHost } from '@/services/sources/source-host';
 import { readSourceCatalogCacheOwner } from '@/lib/sources/persistence';
 import { isPrefsConfigured, loadResolvedSourcePrefs } from '@/lib/sources/preferences';
@@ -20,8 +21,11 @@ interface SourceFavouritesListProps {
   sourceHost: SourceHost;
   /** Bumped by the panel whenever a favourite is added, removed or renamed. */
   favouritesVersion: number;
-  /** Bumped whenever any provider row reports a new signed-in identity. */
-  identityVersion: number;
+  /**
+   * Signed-in identity per provider id, as the provider rows report it once
+   * their auth has settled. A provider absent from the map has not settled yet.
+   */
+  liveIdentities: ReadonlyMap<string, string | null>;
   onOpen: (favourite: SourceFavourite) => void;
   onChanged: () => void;
 }
@@ -32,6 +36,33 @@ interface FavouriteRow {
   readonly providerTitle: string;
   /** Non-null when the row cannot be opened, and says why. */
   readonly disabledReason: string | null;
+}
+
+/**
+ * Which identity's favourites a provider may show, or `undefined` for "its auth
+ * has not settled yet, so show none".
+ *
+ * Live auth state wherever there is any, NOT the persisted catalog-cache stamp.
+ * That stamp outlives the tab by design, so between mount and the moment
+ * `restore()` settles it still names the LAST session's account: reading it
+ * here put account A's folder and file names in front of whoever opened the
+ * panel next. Worse, it kept them there — a restore that resolves signed-out
+ * leaves the row's identity at `null`, which is what it already was on mount,
+ * so the row's report never re-fires and the list never re-derived.
+ */
+function visibleOwner(
+  providerId: string,
+  provider: FileSourceProvider | undefined,
+  liveIdentities: ReadonlyMap<string, string | null>,
+): string | null | undefined {
+  // A provider this build no longer registers has no row and so no live state.
+  // Its stamp outlives the plugin, which is exactly what still keeps another
+  // account's rows off screen here.
+  if (provider === undefined) return readSourceCatalogCacheOwner(providerId);
+  // Preference-auth providers have no identity at all and stamp `null` at
+  // creation time; there is nothing to wait for.
+  if (provider.manifest.auth !== 'interactive') return null;
+  return liveIdentities.has(providerId) ? (liveIdentities.get(providerId) ?? null) : undefined;
 }
 
 /**
@@ -46,22 +77,22 @@ interface FavouriteRow {
 export function SourceFavouritesList({
   sourceHost,
   favouritesVersion,
-  identityVersion,
+  liveIdentities,
   onOpen,
   onChanged,
 }: SourceFavouritesListProps) {
   const rows = useMemo<FavouriteRow[]>(() => {
-    // Neither counter is read directly — they exist to re-derive this list
-    // after a star press elsewhere or a sign-in while the panel is open.
+    // The counter is not read directly — it exists to re-derive this list after
+    // a star press elsewhere in the panel.
     void favouritesVersion;
-    void identityVersion;
 
     const all: FavouriteRow[] = [];
     for (const providerId of listFavouriteProviderIds()) {
       const provider = sourceHost.get(providerId);
-      // The stamp filter runs even for an unregistered provider: its owner key
-      // outlives the plugin, so another account still must not see the rows.
-      const items = visibleFavourites(loadFavourites(providerId), readSourceCatalogCacheOwner(providerId));
+      const owner = visibleOwner(providerId, provider, liveIdentities);
+      // Auth still in flight: show nothing rather than last session's rows.
+      if (owner === undefined) continue;
+      const items = visibleFavourites(loadFavourites(providerId), owner);
       if (items.length === 0) continue;
 
       const configured =
@@ -83,7 +114,7 @@ export function SourceFavouritesList({
       }
     }
     return all.sort((left, right) => right.favourite.addedAt - left.favourite.addedAt);
-  }, [favouritesVersion, identityVersion, sourceHost]);
+  }, [favouritesVersion, liveIdentities, sourceHost]);
 
   if (rows.length === 0) return null;
 

--- a/apps/viewer/src/components/sources/SourceFavouritesList.tsx
+++ b/apps/viewer/src/components/sources/SourceFavouritesList.tsx
@@ -1,0 +1,136 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { useMemo } from 'react';
+import type { SourceHost } from '@/services/sources/source-host';
+import { readSourceCatalogCacheOwner } from '@/lib/sources/persistence';
+import { isPrefsConfigured, loadResolvedSourcePrefs } from '@/lib/sources/preferences';
+import {
+  favouriteKey,
+  listFavouriteProviderIds,
+  loadFavourites,
+  removeFavourite,
+  visibleFavourites,
+  type SourceFavourite,
+} from '@/lib/sources/favourites';
+import { FileBox, Folder, X } from 'lucide-react';
+
+interface SourceFavouritesListProps {
+  sourceHost: SourceHost;
+  /** Bumped by the panel whenever a favourite is added, removed or renamed. */
+  favouritesVersion: number;
+  /** Bumped whenever any provider row reports a new signed-in identity. */
+  identityVersion: number;
+  onOpen: (favourite: SourceFavourite) => void;
+  onChanged: () => void;
+}
+
+interface FavouriteRow {
+  readonly favourite: SourceFavourite;
+  readonly key: string;
+  readonly providerTitle: string;
+  /** Non-null when the row cannot be opened, and says why. */
+  readonly disabledReason: string | null;
+}
+
+/**
+ * The quick-access list above the provider rows: every favourited folder and
+ * file the identity now signed in is allowed to see, newest first.
+ *
+ * Two states are rendered rather than hidden, because silently dropping a
+ * bookmark is worse than showing a dead one: a provider this build no longer
+ * registers, and a preference-auth provider whose required settings are
+ * missing. Neither is ever deleted from storage — removal is the user's `X`.
+ */
+export function SourceFavouritesList({
+  sourceHost,
+  favouritesVersion,
+  identityVersion,
+  onOpen,
+  onChanged,
+}: SourceFavouritesListProps) {
+  const rows = useMemo<FavouriteRow[]>(() => {
+    // Neither counter is read directly — they exist to re-derive this list
+    // after a star press elsewhere or a sign-in while the panel is open.
+    void favouritesVersion;
+    void identityVersion;
+
+    const all: FavouriteRow[] = [];
+    for (const providerId of listFavouriteProviderIds()) {
+      const provider = sourceHost.get(providerId);
+      // The stamp filter runs even for an unregistered provider: its owner key
+      // outlives the plugin, so another account still must not see the rows.
+      const items = visibleFavourites(loadFavourites(providerId), readSourceCatalogCacheOwner(providerId));
+      if (items.length === 0) continue;
+
+      const configured =
+        provider === undefined ||
+        isPrefsConfigured(provider.manifest, loadResolvedSourcePrefs(provider.manifest));
+      const disabledReason = provider === undefined
+        ? 'Provider unavailable'
+        : configured
+          ? null
+          : 'Add the required settings to browse';
+
+      for (const favourite of items) {
+        all.push({
+          favourite,
+          key: favouriteKey(favourite),
+          providerTitle: provider?.manifest.title ?? providerId,
+          disabledReason,
+        });
+      }
+    }
+    return all.sort((left, right) => right.favourite.addedAt - left.favourite.addedAt);
+  }, [favouritesVersion, identityVersion, sourceHost]);
+
+  if (rows.length === 0) return null;
+
+  return (
+    <div className="border-b px-3 py-2">
+      <div className="mb-1 text-[11px] uppercase tracking-wide text-muted-foreground">
+        Favourites
+      </div>
+      <ul className="flex flex-col">
+        {rows.map((row) => (
+          <li key={`${row.favourite.providerId}:${row.key}`} className="flex items-center gap-1">
+            <button
+              type="button"
+              className="flex min-w-0 flex-1 items-center gap-2 rounded-sm px-1 py-1 text-left hover:bg-accent disabled:cursor-default disabled:opacity-60 disabled:hover:bg-transparent"
+              disabled={row.disabledReason !== null}
+              title={row.disabledReason ?? undefined}
+              onClick={() => onOpen(row.favourite)}
+            >
+              {row.favourite.kind === 'file' ? (
+                <FileBox className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />
+              ) : (
+                <Folder className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />
+              )}
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-sm">
+                  {row.favourite.kind === 'file' ? row.favourite.fileName : row.favourite.containerName}
+                </span>
+                <span className="block truncate text-xs text-muted-foreground">
+                  {row.disabledReason ??
+                    `${row.providerTitle} / ${row.favourite.projectName} / ${row.favourite.fileAreaName}`}
+                </span>
+              </span>
+            </button>
+            <button
+              type="button"
+              className="shrink-0 rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-foreground"
+              aria-label={`Remove favourite: ${row.favourite.kind === 'file' ? row.favourite.fileName : row.favourite.containerName}`}
+              onClick={() => {
+                removeFavourite(row.favourite.providerId, row.key);
+                onChanged();
+              }}
+            >
+              <X className="h-3.5 w-3.5" aria-hidden />
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/viewer/src/components/sources/SourceFileRow.tsx
+++ b/apps/viewer/src/components/sources/SourceFileRow.tsx
@@ -4,7 +4,7 @@
 
 import type { SourceFile } from '@ifc-lite/plugin-api';
 import type { DownloadedSourceFileStatus } from '@/lib/sources/persistence';
-import { FileBox, RefreshCw } from 'lucide-react';
+import { FileBox, RefreshCw, Star } from 'lucide-react';
 
 interface SourceFileRowProps {
   file: SourceFile;
@@ -14,6 +14,8 @@ interface SourceFileRowProps {
   syncingFile: boolean;
   onSyncLoadedFile: () => void;
   downloadedStatus: DownloadedSourceFileStatus;
+  favourited: boolean;
+  onToggleFavourite: () => void;
 }
 
 export function SourceFileRow({
@@ -24,6 +26,8 @@ export function SourceFileRow({
   syncingFile,
   onSyncLoadedFile,
   downloadedStatus,
+  favourited,
+  onToggleFavourite,
 }: SourceFileRowProps) {
   const isLoadedInHierarchy = loadedModelNames.length > 0;
   const isUpdateAvailable = downloadedStatus === 'update-available';
@@ -69,6 +73,17 @@ export function SourceFileRow({
               )}
             </span>
           </span>
+        </button>
+        <button
+          type="button"
+          className={`mt-0.5 shrink-0 rounded p-0.5 hover:bg-accent hover:text-foreground ${
+            favourited ? 'text-amber-500' : 'text-muted-foreground'
+          }`}
+          aria-label={`${favourited ? 'Remove' : 'Add'} favourite: ${file.name}`}
+          aria-pressed={favourited}
+          onClick={onToggleFavourite}
+        >
+          <Star className={`h-3.5 w-3.5 ${favourited ? 'fill-current' : ''}`} />
         </button>
         {isLoadedInHierarchy && (
           <span className="flex shrink-0 items-center gap-1">

--- a/apps/viewer/src/components/sources/SourceFolderStep.tsx
+++ b/apps/viewer/src/components/sources/SourceFolderStep.tsx
@@ -11,7 +11,7 @@ import { Input } from '@/components/ui/input';
 import { SourceFolderTree } from './SourceFolderTree';
 import { SourceFileRow } from './SourceFileRow';
 import { LoadMoreRow } from './SourceEntityList';
-import { Download, FolderOpen, Loader2, Search, X } from 'lucide-react';
+import { Download, FolderOpen, Loader2, Search, Star, X } from 'lucide-react';
 
 interface SourceFolderStepProps {
   providerName: string;
@@ -48,6 +48,11 @@ interface SourceFolderStepProps {
   onSearchQueryChange: (query: string) => void;
   onSearchSubmit: () => void;
   onSearchClear: () => void;
+  /** Favourites — `isFolderFavourite` covers the file area itself as well as the tree. */
+  isFolderFavourite: (containerId: string) => boolean;
+  onToggleFolderFavourite: (container: SourceContainer) => void;
+  isFileFavourite: (file: SourceFile) => boolean;
+  onToggleFileFavourite: (file: SourceFile) => void;
 }
 
 export function SourceFolderStep({
@@ -81,6 +86,10 @@ export function SourceFolderStep({
   onSearchQueryChange,
   onSearchSubmit,
   onSearchClear,
+  isFolderFavourite,
+  onToggleFolderFavourite,
+  isFileFavourite,
+  onToggleFileFavourite,
 }: SourceFolderStepProps) {
   const containerById = useMemo(() => {
     const entries = sortedFolders.map((folder) => [folder.id, folder] as const);
@@ -137,16 +146,36 @@ export function SourceFolderStep({
     <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
       <div className="grid min-h-0 flex-1 grid-cols-2 overflow-hidden">
         <div className="flex min-h-0 flex-col overflow-hidden border-r">
-          <button
-            type="button"
-            className={`flex w-full items-center gap-2 px-2 py-1.5 text-left text-sm hover:bg-accent ${
+          {/* The star is a sibling of the button, not inside it: a button
+              cannot nest inside a button. This is how the file area ITSELF
+              gets favourited — the tree below only covers its subfolders. */}
+          <div
+            className={`flex w-full items-center gap-1 pr-1 text-sm hover:bg-accent ${
               selectedContainer?.id === selectedFileArea.id ? 'bg-accent font-medium' : ''
             }`}
-            onClick={() => onSelectContainer(selectedFileArea)}
           >
-            <FolderOpen className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />
-            <span className="truncate">{selectedFileArea.name}</span>
-          </button>
+            <button
+              type="button"
+              className="flex min-w-0 flex-1 items-center gap-2 px-2 py-1.5 text-left"
+              onClick={() => onSelectContainer(selectedFileArea)}
+            >
+              <FolderOpen className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />
+              <span className="truncate">{selectedFileArea.name}</span>
+            </button>
+            <button
+              type="button"
+              className={`shrink-0 rounded p-0.5 hover:bg-accent hover:text-foreground ${
+                isFolderFavourite(selectedFileArea.id) ? 'text-amber-500' : 'text-muted-foreground'
+              }`}
+              aria-label={`${isFolderFavourite(selectedFileArea.id) ? 'Remove' : 'Add'} favourite: ${selectedFileArea.name}`}
+              aria-pressed={isFolderFavourite(selectedFileArea.id)}
+              onClick={() => onToggleFolderFavourite(selectedFileArea)}
+            >
+              <Star
+                className={`h-3.5 w-3.5 ${isFolderFavourite(selectedFileArea.id) ? 'fill-current' : ''}`}
+              />
+            </button>
+          </div>
 
           <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
             {loadingFolders && sortedFolders.length === 0 ? (
@@ -167,6 +196,8 @@ export function SourceFolderStep({
                   selectedId={selectedContainer?.id}
                   activeIds={activeFolderIds}
                   onSelect={onSelectContainer}
+                  isFavourite={isFolderFavourite}
+                  onToggleFavourite={onToggleFolderFavourite}
                 />
                 <LoadMoreRow
                   hasMore={foldersHaveMore}
@@ -282,6 +313,8 @@ export function SourceFolderStep({
                         syncingFile={syncingFileIds.has(f.id)}
                         onSyncLoadedFile={() => onSyncLoadedFile(f)}
                         downloadedStatus={getDownloadedSourceFileStatus(f, downloadedRecord)}
+                        favourited={isFileFavourite(f)}
+                        onToggleFavourite={() => onToggleFileFavourite(f)}
                       />
                     );
                   })}

--- a/apps/viewer/src/components/sources/SourceFolderTree.tsx
+++ b/apps/viewer/src/components/sources/SourceFolderTree.tsx
@@ -6,7 +6,7 @@ import { useEffect, useMemo, useState } from 'react';
 import type { SourceContainer } from '@ifc-lite/plugin-api';
 import { Collapsible, CollapsibleContent } from '@/components/ui/collapsible';
 import { cn } from '@/lib/utils';
-import { ChevronRight, Folder } from 'lucide-react';
+import { ChevronRight, Folder, Star } from 'lucide-react';
 
 export interface ContainerTreeNode extends SourceContainer {
   children: ContainerTreeNode[];
@@ -72,9 +72,20 @@ interface SourceFolderTreeProps {
   selectedId?: string;
   activeIds?: ReadonlySet<string>;
   onSelect: (container: SourceContainer) => void;
+  /** Omitted together with `onToggleFavourite` when the tree renders outside a favouritable context. */
+  isFavourite?: (containerId: string) => boolean;
+  onToggleFavourite?: (container: SourceContainer) => void;
 }
 
-export function SourceFolderTree({ containers, rootId, selectedId, activeIds, onSelect }: SourceFolderTreeProps) {
+export function SourceFolderTree({
+  containers,
+  rootId,
+  selectedId,
+  activeIds,
+  onSelect,
+  isFavourite,
+  onToggleFavourite,
+}: SourceFolderTreeProps) {
   const tree = useMemo(() => buildContainerTree(containers, rootId), [containers, rootId]);
   const parentById = useMemo(
     () => buildContainerParentIndex(containers, rootId),
@@ -113,6 +124,8 @@ export function SourceFolderTree({ containers, rootId, selectedId, activeIds, on
           selectedId={selectedId}
           activeIds={activeIds}
           onSelect={onSelect}
+          isFavourite={isFavourite}
+          onToggleFavourite={onToggleFavourite}
           onToggle={(id) =>
             setOpenIds((previous) => {
               const next = new Set(previous);
@@ -134,6 +147,8 @@ function TreeRow({
   selectedId,
   activeIds,
   onSelect,
+  isFavourite,
+  onToggleFavourite,
   onToggle,
 }: {
   node: ContainerTreeNode;
@@ -142,12 +157,15 @@ function TreeRow({
   selectedId?: string;
   activeIds?: ReadonlySet<string>;
   onSelect: (container: SourceContainer) => void;
+  isFavourite?: (containerId: string) => boolean;
+  onToggleFavourite?: (container: SourceContainer) => void;
   onToggle: (id: string) => void;
 }) {
   const hasChildren = node.children.length > 0;
   const open = openIds.has(node.id);
   const isSelected = selectedId === node.id;
   const isActive = activeIds?.has(node.id) ?? true;
+  const favourited = isFavourite?.(node.id) ?? false;
 
   return (
     <Collapsible open={open}>
@@ -183,6 +201,20 @@ function TreeRow({
           <Folder className="h-4 w-4 shrink-0 text-muted-foreground" />
           <span className="truncate">{node.name}</span>
         </button>
+        {onToggleFavourite && (
+          <button
+            type="button"
+            className={cn(
+              'shrink-0 rounded p-0.5 hover:bg-accent hover:text-foreground',
+              favourited ? 'text-amber-500' : 'text-muted-foreground',
+            )}
+            aria-label={`${favourited ? 'Remove' : 'Add'} favourite: ${node.name}`}
+            aria-pressed={favourited}
+            onClick={() => onToggleFavourite(node)}
+          >
+            <Star className={cn('h-3.5 w-3.5', favourited && 'fill-current')} />
+          </button>
+        )}
       </div>
       {hasChildren && (
         <CollapsibleContent>

--- a/apps/viewer/src/components/sources/SourceProviderRow.test.tsx
+++ b/apps/viewer/src/components/sources/SourceProviderRow.test.tsx
@@ -31,7 +31,19 @@
 import '@/test/setup-dom.js';
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { safeIconUrl } from './SourceProviderRow.js';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import type {
+  FileSourceProvider,
+  Page,
+  PluginManifest,
+  SourceContainer,
+  SourceFile,
+  SourceIdentity,
+  SourceProject,
+} from '@ifc-lite/plugin-api';
+import { SourceHost } from '@/services/sources/source-host';
+import { safeIconUrl, SourceProviderRow } from './SourceProviderRow.js';
 
 /** The origin `setup-dom` registers happy-dom with. */
 const ORIGIN = 'http://localhost';
@@ -140,5 +152,148 @@ describe('safeIconUrl — the permissions.network gate', () => {
       safeIconUrl('https://cdn.icons.example.evil/i.png', ['*.icons.example']),
       undefined,
     );
+  });
+});
+
+/**
+ * The identity report. The favourites list above this row is filtered by the
+ * signed-in identity, and this row is the only place that knows it, so WHEN the
+ * report fires is load-bearing: a report made while `restore()` is still in
+ * flight says "signed out" about a session that is about to come back, and a
+ * restore that resolves nothing never changes the identity id at all, so an
+ * effect keyed on the id alone has no edge to fire on.
+ */
+describe('SourceProviderRow — reporting the signed-in identity', () => {
+  class InteractiveProvider implements FileSourceProvider {
+    readonly manifest: PluginManifest = {
+      name: 'interactive-fixture',
+      title: 'Interactive Fixture',
+      api: '^2.0.0',
+      permissions: { network: [] },
+      auth: 'interactive',
+      preferences: [],
+      capabilities: {
+        containerListing: 'direct-children',
+        listFilesIsRecursive: false,
+        revisionHistory: false,
+        downloadHistoricalRevisions: false,
+        changeDetection: false,
+        search: false,
+      },
+      contributes: { fileSources: [] },
+    };
+
+    private release: (() => void) | null = null;
+
+    constructor(private readonly restored: SourceIdentity | null) {}
+
+    readonly auth = {
+      restore: (): Promise<SourceIdentity | null> =>
+        new Promise((resolve) => {
+          this.release = () => resolve(this.restored);
+        }),
+      signIn: (): Promise<SourceIdentity> => Promise.reject(new Error('not exercised')),
+      signOut: (): Promise<void> => Promise.resolve(),
+      getIdentity: (): Promise<SourceIdentity | null> => Promise.resolve(this.restored),
+    };
+
+    settleRestore(): void {
+      this.release?.();
+    }
+
+    listProjects(): Promise<Page<SourceProject>> {
+      return Promise.resolve({ items: [] });
+    }
+    listContainers(): Promise<Page<SourceContainer>> {
+      return Promise.resolve({ items: [] });
+    }
+    listFiles(): Promise<Page<SourceFile>> {
+      return Promise.resolve({ items: [] });
+    }
+    download(): Promise<ArrayBuffer> {
+      return Promise.reject(new Error('not exercised'));
+    }
+  }
+
+  async function mountRow(provider: InteractiveProvider): Promise<{
+    reports: Array<readonly [string, string | null]>;
+    root: Root;
+    container: HTMLElement;
+  }> {
+    const reports: Array<readonly [string, string | null]> = [];
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <SourceProviderRow
+          provider={provider}
+          sourceHost={new SourceHost()}
+          prefsVersion={0}
+          onOpenSettings={() => {}}
+          onBrowse={() => {}}
+          onIdentityChange={(providerId, identityId) => reports.push([providerId, identityId])}
+        />,
+      );
+    });
+    return { reports, root, container };
+  }
+
+  async function pump(): Promise<void> {
+    for (let i = 0; i < 4; i++) {
+      await act(async () => {
+        await Promise.resolve();
+      });
+    }
+  }
+
+  it('reports nothing until the silent restore has settled', async () => {
+    const provider = new InteractiveProvider({ id: 'user-a' });
+    const { reports, root, container } = await mountRow(provider);
+    try {
+      assert.deepStrictEqual(
+        reports,
+        [],
+        'a report made mid-restore claims signed-out about a live session',
+      );
+
+      provider.settleRestore();
+      await pump();
+
+      assert.deepStrictEqual(reports, [['interactive-fixture', 'user-a']]);
+    } finally {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    }
+  });
+
+  it('reports signed-out when the restore resolves no session', async () => {
+    // The id never leaves `null` across this whole sequence, so there is no id
+    // change to fire on — only the status settling.
+    const provider = new InteractiveProvider(null);
+    const { reports, root, container } = await mountRow(provider);
+    try {
+      assert.deepStrictEqual(
+        reports,
+        [],
+        'the mount-time null is not an answer about the session, it is the absence of one',
+      );
+
+      provider.settleRestore();
+      await pump();
+
+      assert.deepStrictEqual(
+        reports,
+        [['interactive-fixture', null]],
+        'a session that did not come back must be reported, or the list keeps the old identity',
+      );
+    } finally {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    }
   });
 });

--- a/apps/viewer/src/components/sources/SourceProviderRow.tsx
+++ b/apps/viewer/src/components/sources/SourceProviderRow.tsx
@@ -19,11 +19,12 @@ interface SourceProviderRowProps {
   onOpenSettings: () => void;
   onBrowse: () => void;
   /**
-   * Fires whenever this provider's signed-in identity changes. Auth lives in
-   * this row, but the favourites list above it is filtered by identity, so it
-   * has to learn about a sign-in that happens while the panel is open.
+   * Reports this provider's signed-in identity once its auth has SETTLED. Auth
+   * lives in this row, but the favourites list above it is filtered by
+   * identity, so it has to learn about a sign-in that happens while the panel
+   * is open — and, just as much, about a silent restore that resolves nothing.
    */
-  onIdentityChange?: (identityId: string | null) => void;
+  onIdentityChange?: (providerId: string, identityId: string | null) => void;
 }
 
 /**
@@ -85,9 +86,18 @@ export function SourceProviderRow({
   const interactive = auth.status !== 'not-interactive';
 
   const identityId = auth.identity?.id ?? null;
+  // Gated on the auth being settled, and that gate is the whole point rather
+  // than tidiness. A silent `restore()` that resolves no session leaves
+  // `identityId` at the `null` it already held while restoring, so an effect
+  // keyed on the id alone never re-runs — the listener above would keep
+  // whatever it last heard, which on a fresh mount is nothing at all. The
+  // status transition is the only edge that "signed out after all" produces.
+  const settled = auth.status !== 'restoring' && auth.status !== 'busy';
+  const providerId = manifest.name;
   useEffect(() => {
-    onIdentityChange?.(identityId);
-  }, [identityId, onIdentityChange]);
+    if (!settled) return;
+    onIdentityChange?.(providerId, identityId);
+  }, [identityId, onIdentityChange, providerId, settled]);
 
   // prefsVersion is not read directly — it exists to re-run this derivation
   // after the settings dialog saves or forgets values.

--- a/apps/viewer/src/components/sources/SourceProviderRow.tsx
+++ b/apps/viewer/src/components/sources/SourceProviderRow.tsx
@@ -2,9 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { useEffect } from 'react';
 import type { FileSourceProvider } from '@ifc-lite/plugin-api';
 import type { SourceHost } from '@/services/sources/source-host';
-import { loadResolvedSourcePrefs } from '@/lib/sources/preferences';
+import { isPrefsConfigured, loadResolvedSourcePrefs } from '@/lib/sources/preferences';
 import { isAllowedHost, isHttpsUrl } from '@/services/sources/host-fetch';
 import { useSourceAuth } from './useSourceAuth';
 import { Button } from '@/components/ui/button';
@@ -17,6 +18,12 @@ interface SourceProviderRowProps {
   prefsVersion: number;
   onOpenSettings: () => void;
   onBrowse: () => void;
+  /**
+   * Fires whenever this provider's signed-in identity changes. Auth lives in
+   * this row, but the favourites list above it is filtered by identity, so it
+   * has to learn about a sign-in that happens while the panel is open.
+   */
+  onIdentityChange?: (identityId: string | null) => void;
 }
 
 /**
@@ -70,19 +77,23 @@ export function SourceProviderRow({
   prefsVersion,
   onOpenSettings,
   onBrowse,
+  onIdentityChange,
 }: SourceProviderRowProps) {
   const { manifest } = provider;
   const iconUrl = safeIconUrl(manifest.iconUrl, manifest.permissions.network);
   const auth = useSourceAuth(provider, sourceHost);
   const interactive = auth.status !== 'not-interactive';
 
+  const identityId = auth.identity?.id ?? null;
+  useEffect(() => {
+    onIdentityChange?.(identityId);
+  }, [identityId, onIdentityChange]);
+
   // prefsVersion is not read directly — it exists to re-run this derivation
   // after the settings dialog saves or forgets values.
   void prefsVersion;
   const prefs = loadResolvedSourcePrefs(manifest);
-  const prefsConfigured = manifest.preferences
-    .filter((pref) => pref.required)
-    .every((pref) => Boolean(prefs[pref.name]?.trim()));
+  const prefsConfigured = isPrefsConfigured(manifest, prefs);
 
   const canBrowse = interactive ? auth.status === 'signed-in' : prefsConfigured;
   // Interactive providers can still require preferences (e.g. a client id for

--- a/apps/viewer/src/components/sources/SourcesPanel.tsx
+++ b/apps/viewer/src/components/sources/SourcesPanel.tsx
@@ -41,15 +41,26 @@ export function SourcesPanel({ onClose }: SourcesPanelProps) {
   const [downloading, setDownloading] = useState(false);
   // Bumped when saved prefs change so rows/contexts re-derive configured state.
   const [prefsVersion, setPrefsVersion] = useState(0);
-  // Same pattern for the favourites list: one counter for stored favourites,
-  // one for the signed-in identity a favourite is filtered by.
+  // Same counter pattern for the favourites the list reads from storage. Its
+  // other half, the identity those favourites are filtered by, is live auth
+  // state rather than a counter: only the provider rows know it.
   const [favouritesVersion, setFavouritesVersion] = useState(0);
-  const [identityVersion, setIdentityVersion] = useState(0);
+  const [liveIdentities, setLiveIdentities] = useState<ReadonlyMap<string, string | null>>(
+    () => new Map(),
+  );
   // The favourite a click asked to jump to; consumed once by the browser.
   const [browseTarget, setBrowseTarget] = useState<SourceFavourite | null>(null);
 
   const bumpFavourites = useCallback(() => setFavouritesVersion((v) => v + 1), []);
-  const bumpIdentity = useCallback(() => setIdentityVersion((v) => v + 1), []);
+  // Referentially stable, and a no-op when the reported identity is unchanged:
+  // the rows call this from an effect, so a fresh Map every time would re-render
+  // the list on every render of the panel.
+  const recordIdentity = useCallback((providerId: string, identityId: string | null) => {
+    setLiveIdentities((previous) => {
+      if (previous.has(providerId) && previous.get(providerId) === identityId) return previous;
+      return new Map(previous).set(providerId, identityId);
+    });
+  }, []);
 
   const openFavourite = useCallback((favourite: SourceFavourite) => {
     setBrowseTarget(favourite);
@@ -249,7 +260,7 @@ export function SourcesPanel({ onClose }: SourcesPanelProps) {
         <SourceFavouritesList
           sourceHost={sourceHost}
           favouritesVersion={favouritesVersion}
-          identityVersion={identityVersion}
+          liveIdentities={liveIdentities}
           onOpen={openFavourite}
           onChanged={bumpFavourites}
         />
@@ -263,7 +274,7 @@ export function SourcesPanel({ onClose }: SourcesPanelProps) {
               prefsVersion={prefsVersion}
               onOpenSettings={() => setSettingsFor(p.manifest.name)}
               onBrowse={() => setBrowsing(p.manifest.name)}
-              onIdentityChange={bumpIdentity}
+              onIdentityChange={recordIdentity}
             />
           ))}
         </ul>

--- a/apps/viewer/src/components/sources/SourcesPanel.tsx
+++ b/apps/viewer/src/components/sources/SourcesPanel.tsx
@@ -9,6 +9,8 @@ import { dispatchSourceDownload } from '@/services/sources/source-host';
 import { SourceSettingsDialog } from './SourceSettingsDialog';
 import { SourceBrowser } from './SourceBrowser';
 import { SourceProviderRow } from './SourceProviderRow';
+import { SourceFavouritesList } from './SourceFavouritesList';
+import type { SourceFavourite } from '@/lib/sources/favourites';
 import { Button } from '@/components/ui/button';
 import { toast } from '@/components/ui/toast';
 import { AlertCircle, Cloud, X } from 'lucide-react';
@@ -39,6 +41,25 @@ export function SourcesPanel({ onClose }: SourcesPanelProps) {
   const [downloading, setDownloading] = useState(false);
   // Bumped when saved prefs change so rows/contexts re-derive configured state.
   const [prefsVersion, setPrefsVersion] = useState(0);
+  // Same pattern for the favourites list: one counter for stored favourites,
+  // one for the signed-in identity a favourite is filtered by.
+  const [favouritesVersion, setFavouritesVersion] = useState(0);
+  const [identityVersion, setIdentityVersion] = useState(0);
+  // The favourite a click asked to jump to; consumed once by the browser.
+  const [browseTarget, setBrowseTarget] = useState<SourceFavourite | null>(null);
+
+  const bumpFavourites = useCallback(() => setFavouritesVersion((v) => v + 1), []);
+  const bumpIdentity = useCallback(() => setIdentityVersion((v) => v + 1), []);
+
+  const openFavourite = useCallback((favourite: SourceFavourite) => {
+    setBrowseTarget(favourite);
+    setBrowsing(favourite.providerId);
+  }, []);
+
+  const closeBrowser = useCallback(() => {
+    setBrowsing(null);
+    setBrowseTarget(null);
+  }, []);
 
   // Cancels in-flight downloads when the panel unmounts (close / navigate away).
   const downloadAbortRef = useRef<AbortController | null>(null);
@@ -89,8 +110,11 @@ export function SourcesPanel({ onClose }: SourcesPanelProps) {
       // mean all of it.
       clearAllSourceData(settingsFor);
       setPrefsVersion((v) => v + 1);
+      // The sweep takes this provider's favourites with it (they hold folder
+      // and file names), so the list has to re-read storage.
+      bumpFavourites();
     }
-  }, [settingsFor]);
+  }, [bumpFavourites, settingsFor]);
 
   const handleTestConnection = useCallback(
     async (values: Record<string, string>): Promise<ConnectionTestResult> => {
@@ -159,12 +183,12 @@ export function SourcesPanel({ onClose }: SourcesPanelProps) {
             );
           }
         }
-        if (queued > 0) setBrowsing(null);
+        if (queued > 0) closeBrowser();
       } finally {
         setDownloading(false);
       }
     },
-    [activeProvider, browsing, sourceHost],
+    [activeProvider, browsing, closeBrowser, sourceHost],
   );
 
   const browsingCtx = useMemo(() => {
@@ -191,8 +215,10 @@ export function SourcesPanel({ onClose }: SourcesPanelProps) {
         provider={activeProvider}
         ctx={browsingCtx}
         onDownload={(selection) => void handleDownload(selection)}
-        onBack={() => setBrowsing(null)}
+        onBack={closeBrowser}
         busy={downloading}
+        openTarget={browseTarget}
+        onFavouritesChanged={bumpFavourites}
       />
     );
   }
@@ -220,6 +246,14 @@ export function SourcesPanel({ onClose }: SourcesPanelProps) {
           </div>
         )}
 
+        <SourceFavouritesList
+          sourceHost={sourceHost}
+          favouritesVersion={favouritesVersion}
+          identityVersion={identityVersion}
+          onOpen={openFavourite}
+          onChanged={bumpFavourites}
+        />
+
         <ul className="divide-y">
           {providers.map((p) => (
             <SourceProviderRow
@@ -229,6 +263,7 @@ export function SourcesPanel({ onClose }: SourcesPanelProps) {
               prefsVersion={prefsVersion}
               onOpenSettings={() => setSettingsFor(p.manifest.name)}
               onBrowse={() => setBrowsing(p.manifest.name)}
+              onIdentityChange={bumpIdentity}
             />
           ))}
         </ul>

--- a/apps/viewer/src/components/sources/useSourceFavouriteJump.ts
+++ b/apps/viewer/src/components/sources/useSourceFavouriteJump.ts
@@ -1,0 +1,128 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { useEffect, useRef } from 'react';
+import type { SourceContainer, SourceFile, SourceProject } from '@ifc-lite/plugin-api';
+import { toast } from '@/components/ui/toast';
+import { favouriteKey, type SourceFavourite } from '@/lib/sources/favourites';
+
+interface UseSourceFavouriteJumpOptions {
+  /** The favourite to open, or null when the browser was entered normally. */
+  target: SourceFavourite | null;
+  selectedProject: SourceProject | null;
+  selectedFileArea: SourceContainer | null;
+  selectedContainer: SourceContainer | null;
+  sortedFolders: readonly SourceContainer[];
+  allFiles: readonly SourceFile[];
+  loadingFolders: boolean;
+  loadingFiles: boolean;
+  /** Browser state the jump rebuilds, in the order the wizard would have reached it. */
+  enterFileArea: (project: SourceProject, fileArea: SourceContainer) => void;
+  selectContainer: (container: SourceContainer) => void;
+  toggleFile: (file: SourceFile) => void;
+  /** Refreshes a stored label the source renamed underneath the favourite. */
+  renameFavourite: (key: string, name: string) => void;
+}
+
+/**
+ * Opens a favourite in the browser, in two phases — because `SourceBrowser` is
+ * a three-step wizard and each step is an id-only listing call whose data
+ * arrives a render later.
+ *
+ * Phase 1 rebuilds the state the user would have reached by hand (project,
+ * file area, folders step) and requests the area's catalog. Phase 2 waits for
+ * that listing before descending into the favourited folder, and — for a file
+ * favourite — before preselecting the file, which cannot be selected earlier
+ * because `SourceBrowser`'s reconcile effect drops a selection that is not in
+ * the current listing.
+ */
+export function useSourceFavouriteJump({
+  target,
+  selectedProject,
+  selectedFileArea,
+  selectedContainer,
+  sortedFolders,
+  allFiles,
+  loadingFolders,
+  loadingFiles,
+  enterFileArea,
+  selectContainer,
+  toggleFile,
+  renameFavourite,
+}: UseSourceFavouriteJumpOptions): void {
+  const appliedRef = useRef<SourceFavourite | null>(null);
+  const pendingRef = useRef<SourceFavourite | null>(null);
+
+  // The cleanup re-arming the jump is load-bearing rather than tidy. Under
+  // StrictMode a mount runs effect -> cleanup -> effect, and both
+  // `useSourceCatalogSync` and `usePagedList` abort their in-flight request and
+  // bump their request generation in their own unmount cleanups. A jump that
+  // fired only on the first pass therefore had its listing aborted by the
+  // teardown in between and — generation now stale — the `finally` that clears
+  // `loadingFolders`/`loadingFiles` no longer applied: two spinners forever,
+  // with no request outstanding. Re-arming makes the second pass re-issue it.
+  // `enterFileArea` must stay referentially stable for the same reason; an
+  // unstable one would tear down and restart the listing on every render.
+  useEffect(() => {
+    if (!target || appliedRef.current === target) return;
+    appliedRef.current = target;
+    enterFileArea(
+      { id: target.projectId, name: target.projectName },
+      { id: target.fileAreaId, name: target.fileAreaName },
+    );
+    pendingRef.current = target;
+
+    return () => {
+      appliedRef.current = null;
+      pendingRef.current = null;
+    };
+  }, [enterFileArea, target]);
+
+  useEffect(() => {
+    const pending = pendingRef.current;
+    if (!pending || !selectedProject || !selectedFileArea) return;
+
+    // Descend into the favourited folder when it is deeper than the area root.
+    if (pending.containerId !== pending.fileAreaId && selectedContainer?.id !== pending.containerId) {
+      const match = sortedFolders.find((folder) => folder.id === pending.containerId);
+      if (!match && loadingFolders) return;
+      // Renamed upstream: the id still opens it and only the label went stale,
+      // so refresh the label rather than leave the favourites list lying.
+      if (match && match.name !== pending.containerName) {
+        renameFavourite(favouriteKey(pending), match.name);
+      }
+      selectContainer(
+        match ?? { id: pending.containerId, name: pending.containerName, parentId: pending.fileAreaId },
+      );
+      if (pending.kind === 'folder') pendingRef.current = null;
+      return;
+    }
+    if (pending.kind === 'folder') {
+      pendingRef.current = null;
+      return;
+    }
+
+    const file = allFiles.find((candidate) => candidate.id === pending.fileId);
+    if (!file) {
+      if (loadingFiles) return;
+      pendingRef.current = null;
+      toast.info('That file is no longer in this folder');
+      return;
+    }
+    pendingRef.current = null;
+    if (file.name !== pending.fileName) renameFavourite(favouriteKey(pending), file.name);
+    toggleFile(file);
+  }, [
+    allFiles,
+    loadingFiles,
+    loadingFolders,
+    renameFavourite,
+    selectContainer,
+    selectedContainer,
+    selectedFileArea,
+    selectedProject,
+    sortedFolders,
+    toggleFile,
+  ]);
+}

--- a/apps/viewer/src/components/sources/useSourceFavouriteJump.ts
+++ b/apps/viewer/src/components/sources/useSourceFavouriteJump.ts
@@ -17,6 +17,8 @@ interface UseSourceFavouriteJumpOptions {
   allFiles: readonly SourceFile[];
   loadingFolders: boolean;
   loadingFiles: boolean;
+  /** True while the current selection's file listing still has pages outstanding. */
+  filesHaveMore: boolean;
   /** Browser state the jump rebuilds, in the order the wizard would have reached it. */
   enterFileArea: (project: SourceProject, fileArea: SourceContainer) => void;
   selectContainer: (container: SourceContainer) => void;
@@ -46,6 +48,7 @@ export function useSourceFavouriteJump({
   allFiles,
   loadingFolders,
   loadingFiles,
+  filesHaveMore,
   enterFileArea,
   selectContainer,
   toggleFile,
@@ -115,6 +118,20 @@ export function useSourceFavouriteJump({
       // no-op and `syncFileArea` sets both flags together), which is why the
       // direct-children fixture exists in `SourceBrowserFavouriteJump.test.tsx`.
       if (loadingFiles || loadingFolders) return;
+      // "Not in the listing" only means "gone" once the listing is the WHOLE
+      // listing. Without `eagerFileSweep` (off by default — Dalux is the only
+      // provider that opts in) `useSourceCatalogSync` fetches the first page
+      // only, so a favourited file further down is absent for a reason that
+      // has nothing to do with it being deleted.
+      //
+      // Residual gap, deliberately left open rather than papered over: nothing
+      // here drains the remaining pages. A favourite past page one therefore
+      // stays pending and silently does not preselect until the user presses
+      // "Load more files", at which point this effect re-runs and completes the
+      // jump. Draining instead is unbounded — a folder can hold thousands of
+      // files across dozens of round trips — and a wrong "no longer in this
+      // folder" on a file that is right there is the worse of the two failures.
+      if (filesHaveMore) return;
       pendingRef.current = null;
       toast.info('That file is no longer in this folder');
       return;
@@ -124,6 +141,7 @@ export function useSourceFavouriteJump({
     toggleFile(file);
   }, [
     allFiles,
+    filesHaveMore,
     loadingFiles,
     loadingFolders,
     renameFavourite,

--- a/apps/viewer/src/components/sources/useSourceFavouriteJump.ts
+++ b/apps/viewer/src/components/sources/useSourceFavouriteJump.ts
@@ -105,7 +105,16 @@ export function useSourceFavouriteJump({
 
     const file = allFiles.find((candidate) => candidate.id === pending.fileId);
     if (!file) {
-      if (loadingFiles) return;
+      // Both flags, not just `loadingFiles`. On a `direct-children` provider
+      // (Dropbox, msgraph) `openContainer` fetches the child folders FIRST and
+      // only sets `loadingFiles` once `fetchContainers` resolves, so there is a
+      // render where `loadingFolders` is true, `loadingFiles` is false and the
+      // file is simply not listed yet. Guarding on `loadingFiles` alone falls
+      // through there and reports a file that is still in flight as missing.
+      // Unreachable on Dalux (flat-subtree + recursive makes `openContainer` a
+      // no-op and `syncFileArea` sets both flags together), which is why the
+      // direct-children fixture exists in `SourceBrowserFavouriteJump.test.tsx`.
+      if (loadingFiles || loadingFolders) return;
       pendingRef.current = null;
       toast.info('That file is no longer in this folder');
       return;

--- a/apps/viewer/src/components/sources/useSourceFavourites.test.tsx
+++ b/apps/viewer/src/components/sources/useSourceFavourites.test.tsx
@@ -1,0 +1,201 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The star affordance, driven the way a user drives it: mount the real folder
+ * step with the real favourites hook behind it and CLICK.
+ *
+ * Presence of a star proves nothing — the defect this guards against is a
+ * button that renders and stores nothing, or stores something that cannot be
+ * re-opened. So every assertion here is on what landed in `localStorage` after
+ * the click, and on the button reporting its new state back to the user.
+ *
+ * Three affordances exist and all three are exercised, because they are three
+ * separate call sites: the file area itself (a sibling of its own button — a
+ * star cannot nest inside a button), a folder in the tree, and a file row.
+ */
+
+import '@/test/setup-dom.js';
+import { beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import type { SourceContainer, SourceFile, SourceProject } from '@ifc-lite/plugin-api';
+import { loadFavourites, favouriteKey } from '@/lib/sources/favourites';
+import { SourceFolderStep } from './SourceFolderStep.js';
+import { useSourceFavourites } from './useSourceFavourites.js';
+
+const PROVIDER = 'fixture-provider';
+const project: SourceProject = { id: 'project-1', name: 'Tower Project' };
+const fileArea: SourceContainer = { id: 'area-1', name: 'Documents' };
+const folder: SourceContainer = { id: 'folder-1', name: 'Models', parentId: 'area-1' };
+const file: SourceFile = {
+  id: 'file-1',
+  name: 'tower.ifc',
+  containerId: 'folder-1',
+  currentRevisionId: 'rev-1',
+};
+
+const mounted: Array<{ root: Root; container: HTMLElement }> = [];
+
+/** Wires the real hook to the real step, exactly as `SourceBrowser` does. */
+function Harness() {
+  const favourites = useSourceFavourites({
+    providerId: PROVIDER,
+    selectedProject: project,
+    selectedFileArea: fileArea,
+    folders: [folder],
+  });
+
+  return (
+    <SourceFolderStep
+      providerName={PROVIDER}
+      selectedProject={project}
+      selectedFileArea={fileArea}
+      selectedContainer={folder}
+      onSelectContainer={() => {}}
+      sortedFolders={[folder]}
+      allFiles={[file]}
+      gateEmptyFolders={false}
+      loadingFolders={false}
+      loadingFiles={false}
+      sortedFiles={[file]}
+      selectedFiles={new Map()}
+      onToggleFile={() => {}}
+      downloadedRecords={new Map()}
+      loadedModelNamesByFileId={new Map()}
+      syncingFileIds={new Set()}
+      onSyncLoadedFile={() => {}}
+      busy={false}
+      onLoad={() => {}}
+      foldersHaveMore={false}
+      onLoadMoreFolders={() => {}}
+      filesHaveMore={false}
+      onLoadMoreFiles={() => {}}
+      loadingMore={false}
+      searchEnabled={false}
+      searchQuery=""
+      searchActive={false}
+      onSearchQueryChange={() => {}}
+      onSearchSubmit={() => {}}
+      onSearchClear={() => {}}
+      isFolderFavourite={favourites.isFolderFavourite}
+      onToggleFolderFavourite={favourites.toggleFolderFavourite}
+      isFileFavourite={favourites.isFileFavourite}
+      onToggleFileFavourite={favourites.toggleFileFavourite}
+    />
+  );
+}
+
+function renderStep(): void {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(<Harness />);
+  });
+  mounted.push({ root, container });
+}
+
+/** Finds a star by the label it advertises, which is also what a screen reader reads. */
+function star(label: string): HTMLButtonElement {
+  const found = [...document.body.querySelectorAll('button')].find(
+    (button) => button.getAttribute('aria-label') === label,
+  );
+  assert.ok(found, `a button labelled "${label}" must render`);
+  return found as HTMLButtonElement;
+}
+
+function click(button: HTMLButtonElement): void {
+  act(() => {
+    button.click();
+  });
+}
+
+beforeEach(() => {
+  for (const { root, container } of mounted.splice(0)) {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  }
+  document.body.innerHTML = '';
+  localStorage.clear();
+});
+
+describe('favouriting a folder from the browser', () => {
+  it('stores the whole re-entry tuple when the file area itself is starred', () => {
+    renderStep();
+    click(star('Add favourite: Documents'));
+
+    const [stored] = loadFavourites(PROVIDER);
+    assert.ok(stored, 'the click must persist a favourite');
+    assert.equal(stored.kind, 'folder');
+    assert.equal(stored.projectId, 'project-1');
+    assert.equal(stored.projectName, 'Tower Project');
+    assert.equal(stored.fileAreaId, 'area-1');
+    assert.equal(stored.containerId, 'area-1', 'the area root favourites itself');
+    assert.equal(stored.containerName, 'Documents');
+  });
+
+  it('stores a subfolder starred in the tree, addressed by its own id', () => {
+    renderStep();
+    click(star('Add favourite: Models'));
+
+    const [stored] = loadFavourites(PROVIDER);
+    assert.ok(stored);
+    assert.equal(stored.containerId, 'folder-1');
+    assert.equal(stored.fileAreaId, 'area-1', 'the area is needed to re-enter the wizard');
+  });
+
+  it('reports the new state on the button, and un-favourites on a second press', () => {
+    renderStep();
+    const add = star('Add favourite: Models');
+    assert.equal(add.getAttribute('aria-pressed'), 'false');
+    click(add);
+
+    const remove = star('Remove favourite: Models');
+    assert.equal(remove.getAttribute('aria-pressed'), 'true');
+    click(remove);
+
+    assert.deepStrictEqual(loadFavourites(PROVIDER), []);
+    assert.equal(star('Add favourite: Models').getAttribute('aria-pressed'), 'false');
+  });
+});
+
+describe('favouriting a file from the browser', () => {
+  it("stores the file's own folder, not the folder currently selected", () => {
+    renderStep();
+    click(star('Add favourite: tower.ifc'));
+
+    const [stored] = loadFavourites(PROVIDER);
+    assert.ok(stored);
+    assert.equal(stored.kind, 'file');
+    assert.equal(stored.fileId, 'file-1');
+    assert.equal(stored.fileName, 'tower.ifc');
+    assert.equal(stored.containerId, 'folder-1');
+    assert.equal(stored.containerName, 'Models', 'the folder name is resolved, not left as an id');
+  });
+
+  it('addresses a file favourite by fileId, so a folder favourite of the same id is separate', () => {
+    renderStep();
+    click(star('Add favourite: tower.ifc'));
+    click(star('Add favourite: Models'));
+
+    const stored = loadFavourites(PROVIDER);
+    assert.equal(stored.length, 2);
+    assert.equal(new Set(stored.map((item) => favouriteKey(item))).size, 2);
+  });
+
+  it('does not stamp a revision — a favourite is a location, not a version', () => {
+    renderStep();
+    click(star('Add favourite: tower.ifc'));
+    const [stored] = loadFavourites(PROVIDER);
+    assert.equal(
+      Object.values(stored ?? {}).includes('rev-1'),
+      false,
+      'pinning a revision would poison the loaded/update-available status',
+    );
+  });
+});

--- a/apps/viewer/src/components/sources/useSourceFavourites.test.tsx
+++ b/apps/viewer/src/components/sources/useSourceFavourites.test.tsx
@@ -22,7 +22,8 @@ import assert from 'node:assert/strict';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import type { SourceContainer, SourceFile, SourceProject } from '@ifc-lite/plugin-api';
-import { loadFavourites, favouriteKey } from '@/lib/sources/favourites';
+import { loadFavourites, favouriteKey, saveFavourites } from '@/lib/sources/favourites';
+import { syncSourceCatalogCacheOwner } from '@/lib/sources/persistence';
 import { SourceFolderStep } from './SourceFolderStep.js';
 import { useSourceFavourites } from './useSourceFavourites.js';
 
@@ -197,5 +198,46 @@ describe('favouriting a file from the browser', () => {
       false,
       'pinning a revision would poison the loaded/update-available status',
     );
+  });
+});
+
+describe('two accounts sharing one browser profile', () => {
+  it("shows account A's favourite as unstarred to account B, and B's press adds rather than deletes", () => {
+    // A and B are the same provider in the same browser profile, so they share
+    // one favourites blob and receive the same provider-side folder id. Only
+    // the identity stamp tells their records apart.
+    saveFavourites(PROVIDER, [
+      {
+        providerId: PROVIDER,
+        kind: 'folder',
+        projectId: project.id,
+        projectName: project.name,
+        fileAreaId: fileArea.id,
+        fileAreaName: fileArea.name,
+        containerId: folder.id,
+        containerName: folder.name,
+        identityId: 'user-a',
+        addedAt: 1_000,
+      },
+    ]);
+    syncSourceCatalogCacheOwner(PROVIDER, 'user-b');
+
+    renderStep();
+
+    const add = star('Add favourite: Models');
+    assert.equal(
+      add.getAttribute('aria-pressed'),
+      'false',
+      "B never starred this folder, so it cannot render starred to B",
+    );
+
+    click(add);
+
+    assert.deepStrictEqual(
+      loadFavourites(PROVIDER).map((item) => item.identityId).sort(),
+      ['user-a', 'user-b'],
+      "B's press must add B's own record and leave A's alone",
+    );
+    assert.equal(star('Remove favourite: Models').getAttribute('aria-pressed'), 'true');
   });
 });

--- a/apps/viewer/src/components/sources/useSourceFavourites.ts
+++ b/apps/viewer/src/components/sources/useSourceFavourites.ts
@@ -40,6 +40,12 @@ export function useSourceFavourites({
 }: UseSourceFavouritesOptions) {
   const [items, setItems] = useState<SourceFavourite[]>(() => loadFavourites(providerId));
 
+  // The identity every key on this screen is scoped to. Read per render rather
+  // than memoised: it is the same stamp a star press writes, and the stored
+  // blob holds every account that has used this browser profile, so a key built
+  // without it would match another account's record.
+  const identityId = readSourceCatalogCacheOwner(providerId);
+
   const keys = useMemo(() => new Set(items.map((item) => favouriteKey(item))), [items]);
 
   const apply = useCallback(
@@ -62,9 +68,11 @@ export function useSourceFavourites({
   const isFolderFavourite = useCallback(
     (containerId: string) =>
       selectedProject
-        ? keys.has(favouriteKey({ providerId, projectId: selectedProject.id, kind: 'folder', containerId }))
+        ? keys.has(
+            favouriteKey({ providerId, projectId: selectedProject.id, kind: 'folder', containerId, identityId }),
+          )
         : false,
-    [keys, providerId, selectedProject],
+    [identityId, keys, providerId, selectedProject],
   );
 
   const isFileFavourite = useCallback(
@@ -77,10 +85,11 @@ export function useSourceFavourites({
               kind: 'file',
               containerId: file.containerId,
               fileId: file.id,
+              identityId,
             }),
           )
         : false,
-    [keys, providerId, selectedProject],
+    [identityId, keys, providerId, selectedProject],
   );
 
   const toggleFolderFavourite = useCallback(
@@ -95,11 +104,11 @@ export function useSourceFavourites({
         fileAreaName: selectedFileArea.name,
         containerId: container.id,
         containerName: container.name,
-        identityId: readSourceCatalogCacheOwner(providerId),
+        identityId,
         addedAt: Date.now(),
       });
     },
-    [apply, providerId, selectedFileArea, selectedProject],
+    [apply, identityId, providerId, selectedFileArea, selectedProject],
   );
 
   const toggleFileFavourite = useCallback(
@@ -125,11 +134,11 @@ export function useSourceFavourites({
         containerName,
         fileId: file.id,
         fileName: file.name,
-        identityId: readSourceCatalogCacheOwner(providerId),
+        identityId,
         addedAt: Date.now(),
       });
     },
-    [apply, folders, providerId, selectedFileArea, selectedProject],
+    [apply, folders, identityId, providerId, selectedFileArea, selectedProject],
   );
 
   /** Refreshes a stale label after the source renamed the folder or file underneath the favourite. */

--- a/apps/viewer/src/components/sources/useSourceFavourites.ts
+++ b/apps/viewer/src/components/sources/useSourceFavourites.ts
@@ -1,0 +1,151 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { useCallback, useMemo, useState } from 'react';
+import type { SourceContainer, SourceFile, SourceProject } from '@ifc-lite/plugin-api';
+import { toast } from '@/components/ui/toast';
+import { readSourceCatalogCacheOwner } from '@/lib/sources/persistence';
+import {
+  favouriteKey,
+  loadFavourites,
+  MAX_FAVOURITES_PER_PROVIDER,
+  renameFavourite,
+  toggleFavourite,
+  type SourceFavourite,
+} from '@/lib/sources/favourites';
+
+interface UseSourceFavouritesOptions {
+  providerId: string;
+  selectedProject: SourceProject | null;
+  selectedFileArea: SourceContainer | null;
+  /** Every folder known for the area — used to label a file's own folder, which is not always the selected one. */
+  folders: readonly SourceContainer[];
+  /** Lets the panel re-read storage after the browser changed a favourite. */
+  onChanged?: () => void;
+}
+
+/**
+ * The browser's half of favourites: which of the folders and files on screen
+ * are starred, and what a star press does. Storage lives in
+ * `lib/sources/favourites.ts`; what is here is the wizard context a favourite
+ * needs (project + file area) and the user feedback a refused write needs.
+ */
+export function useSourceFavourites({
+  providerId,
+  selectedProject,
+  selectedFileArea,
+  folders,
+  onChanged,
+}: UseSourceFavouritesOptions) {
+  const [items, setItems] = useState<SourceFavourite[]>(() => loadFavourites(providerId));
+
+  const keys = useMemo(() => new Set(items.map((item) => favouriteKey(item))), [items]);
+
+  const apply = useCallback(
+    (favourite: SourceFavourite) => {
+      const result = toggleFavourite(favourite);
+      setItems(result.items);
+      if (!result.ok) {
+        toast.error(
+          result.reason === 'cap'
+            ? `Favourites are limited to ${MAX_FAVOURITES_PER_PROVIDER} per source — remove one first`
+            : 'Could not save favourite — browser storage is full or unavailable',
+        );
+        return;
+      }
+      onChanged?.();
+    },
+    [onChanged],
+  );
+
+  const isFolderFavourite = useCallback(
+    (containerId: string) =>
+      selectedProject
+        ? keys.has(favouriteKey({ providerId, projectId: selectedProject.id, kind: 'folder', containerId }))
+        : false,
+    [keys, providerId, selectedProject],
+  );
+
+  const isFileFavourite = useCallback(
+    (file: SourceFile) =>
+      selectedProject
+        ? keys.has(
+            favouriteKey({
+              providerId,
+              projectId: selectedProject.id,
+              kind: 'file',
+              containerId: file.containerId,
+              fileId: file.id,
+            }),
+          )
+        : false,
+    [keys, providerId, selectedProject],
+  );
+
+  const toggleFolderFavourite = useCallback(
+    (container: SourceContainer) => {
+      if (!selectedProject || !selectedFileArea) return;
+      apply({
+        providerId,
+        kind: 'folder',
+        projectId: selectedProject.id,
+        projectName: selectedProject.name,
+        fileAreaId: selectedFileArea.id,
+        fileAreaName: selectedFileArea.name,
+        containerId: container.id,
+        containerName: container.name,
+        identityId: readSourceCatalogCacheOwner(providerId),
+        addedAt: Date.now(),
+      });
+    },
+    [apply, providerId, selectedFileArea, selectedProject],
+  );
+
+  const toggleFileFavourite = useCallback(
+    (file: SourceFile) => {
+      if (!selectedProject || !selectedFileArea) return;
+      // `file.containerId` is the folder the file actually lives in, which for
+      // a recursive provider is not the folder currently selected — a file
+      // favourited from a search result must re-open its OWN folder. The name
+      // is only a label; falling back to the id keeps the record complete when
+      // the folder is not in the loaded listing (a search hit deeper in).
+      const containerName =
+        file.containerId === selectedFileArea.id
+          ? selectedFileArea.name
+          : (folders.find((folder) => folder.id === file.containerId)?.name ?? file.containerId);
+      apply({
+        providerId,
+        kind: 'file',
+        projectId: selectedProject.id,
+        projectName: selectedProject.name,
+        fileAreaId: selectedFileArea.id,
+        fileAreaName: selectedFileArea.name,
+        containerId: file.containerId,
+        containerName,
+        fileId: file.id,
+        fileName: file.name,
+        identityId: readSourceCatalogCacheOwner(providerId),
+        addedAt: Date.now(),
+      });
+    },
+    [apply, folders, providerId, selectedFileArea, selectedProject],
+  );
+
+  /** Refreshes a stale label after the source renamed the folder or file underneath the favourite. */
+  const rename = useCallback(
+    (key: string, name: string) => {
+      const next = renameFavourite(providerId, key, name);
+      setItems(next);
+      onChanged?.();
+    },
+    [onChanged, providerId],
+  );
+
+  // Memoised: the browser's favourite-jump effect lists this object in its
+  // dependencies, and a fresh literal every render would re-run it every render.
+  return useMemo(
+    () => ({ isFolderFavourite, toggleFolderFavourite, isFileFavourite, toggleFileFavourite, rename }),
+    [isFileFavourite, isFolderFavourite, rename, toggleFileFavourite, toggleFolderFavourite],
+  );
+}

--- a/apps/viewer/src/lib/sources/favourites.test.ts
+++ b/apps/viewer/src/lib/sources/favourites.test.ts
@@ -1,0 +1,308 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Favourites storage. Four properties are pinned because each one is a way the
+ * feature can look fine and be wrong:
+ *
+ * 1. A favourite survives a round trip through `localStorage` with the whole
+ *    addressing tuple intact — an id dropped in the blob is a bookmark that
+ *    opens the wrong folder, or nothing.
+ * 2. One malformed record drops out on its own, rather than taking every other
+ *    bookmark with it. `localStorage` outlives app versions.
+ * 3. A refused write (quota, private mode) is REPORTED. Unlike the caches in
+ *    `persistence.ts` this is a user gesture, so failing silently would leave a
+ *    star that looks set and is not.
+ * 4. The owner stamp hides another account's bookmarks without deleting them,
+ *    which is the whole point of stamping rather than clearing on sign-out.
+ */
+
+import { beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  FAVOURITES_KEY_PREFIX,
+  favouriteKey,
+  isFavourited,
+  listFavouriteProviderIds,
+  loadFavourites,
+  MAX_FAVOURITES_PER_PROVIDER,
+  removeFavourite,
+  renameFavourite,
+  saveFavourites,
+  toggleFavourite,
+  visibleFavourites,
+  type SourceFavourite,
+} from './favourites.js';
+import { clearAllSourceData } from './persistence.js';
+
+class MemoryStorage implements Storage {
+  private readonly map = new Map<string, string>();
+  /** When true, every write throws like a QuotaExceededError would. */
+  failWrites = false;
+
+  get length(): number {
+    return this.map.size;
+  }
+
+  clear(): void {
+    this.map.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.map.get(key) ?? null;
+  }
+
+  key(index: number): string | null {
+    return [...this.map.keys()][index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.map.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    if (this.failWrites) {
+      throw new DOMException('Quota exceeded', 'QuotaExceededError');
+    }
+    this.map.set(key, value);
+  }
+}
+
+const localStorageMock = new MemoryStorage();
+
+Object.defineProperty(globalThis, 'localStorage', {
+  configurable: true,
+  value: localStorageMock,
+});
+
+function folderFavourite(overrides: Partial<SourceFavourite> = {}): SourceFavourite {
+  return {
+    providerId: 'dropbox',
+    kind: 'folder',
+    projectId: 'me',
+    projectName: 'My Dropbox',
+    fileAreaId: 'id:area',
+    fileAreaName: 'Documents',
+    containerId: 'id:folder',
+    containerName: 'Models',
+    identityId: 'user-a',
+    addedAt: 1_000,
+    ...overrides,
+  };
+}
+
+function fileFavourite(overrides: Partial<SourceFavourite> = {}): SourceFavourite {
+  return folderFavourite({
+    kind: 'file',
+    containerId: 'id:folder',
+    containerName: 'Models',
+    fileId: 'id:file',
+    fileName: 'tower.ifc',
+    addedAt: 2_000,
+    ...overrides,
+  });
+}
+
+beforeEach(() => {
+  localStorageMock.clear();
+  localStorageMock.failWrites = false;
+});
+
+describe('favourites round trip', () => {
+  it('restores every addressing field a re-entry needs', () => {
+    const favourite = fileFavourite();
+    assert.equal(saveFavourites('dropbox', [favourite]), true);
+
+    const [restored] = loadFavourites('dropbox');
+    assert.deepStrictEqual(restored, favourite);
+  });
+
+  it('returns favourites newest first, whatever order they were written in', () => {
+    saveFavourites('dropbox', [
+      folderFavourite({ containerId: 'a', addedAt: 1 }),
+      folderFavourite({ containerId: 'b', addedAt: 3 }),
+      folderFavourite({ containerId: 'c', addedAt: 2 }),
+    ]);
+    assert.deepStrictEqual(
+      loadFavourites('dropbox').map((item) => item.containerId),
+      ['b', 'c', 'a'],
+    );
+  });
+
+  it('toggles a favourite off and on again, and reports which happened', () => {
+    const favourite = folderFavourite();
+    const added = toggleFavourite(favourite);
+    assert.equal(added.added, true);
+    assert.equal(added.ok, true);
+    assert.equal(isFavourited(loadFavourites('dropbox'), favouriteKey(favourite)), true);
+
+    const removed = toggleFavourite(favourite);
+    assert.equal(removed.added, false);
+    assert.equal(removed.ok, true);
+    assert.deepStrictEqual(loadFavourites('dropbox'), []);
+  });
+
+  it('scopes the key by provider, so the same file in two sources is two favourites', () => {
+    const dropbox = fileFavourite();
+    const msgraph = fileFavourite({ providerId: 'msgraph-onedrive' });
+    assert.notEqual(favouriteKey(dropbox), favouriteKey(msgraph));
+
+    toggleFavourite(dropbox);
+    toggleFavourite(msgraph);
+    assert.equal(loadFavourites('dropbox').length, 1);
+    assert.equal(loadFavourites('msgraph-onedrive').length, 1);
+  });
+
+  it('removes by key and leaves the rest', () => {
+    const keep = folderFavourite({ containerId: 'keep' });
+    const drop = folderFavourite({ containerId: 'drop' });
+    saveFavourites('dropbox', [keep, drop]);
+
+    const remaining = removeFavourite('dropbox', favouriteKey(drop));
+    assert.deepStrictEqual(remaining.map((item) => item.containerId), ['keep']);
+    assert.deepStrictEqual(loadFavourites('dropbox').map((item) => item.containerId), ['keep']);
+  });
+
+  it('renames a stale label without changing the key that addresses it', () => {
+    const favourite = folderFavourite();
+    saveFavourites('dropbox', [favourite]);
+    const key = favouriteKey(favourite);
+
+    const next = renameFavourite('dropbox', key, 'Models (2026)');
+    assert.equal(next[0]?.containerName, 'Models (2026)');
+    assert.equal(favouriteKey(next[0]!), key, 'a rename must not re-address the favourite');
+    assert.equal(loadFavourites('dropbox')[0]?.containerName, 'Models (2026)');
+  });
+
+  it('renames a favourited file by its file name, not its folder name', () => {
+    const favourite = fileFavourite();
+    saveFavourites('dropbox', [favourite]);
+    const next = renameFavourite('dropbox', favouriteKey(favourite), 'tower-rev-b.ifc');
+    assert.equal(next[0]?.fileName, 'tower-rev-b.ifc');
+    assert.equal(next[0]?.containerName, 'Models');
+  });
+
+  it('lists provider ids from storage, including providers this build does not register', () => {
+    saveFavourites('dropbox', [folderFavourite()]);
+    saveFavourites('retired-provider', [folderFavourite({ providerId: 'retired-provider' })]);
+    assert.deepStrictEqual(listFavouriteProviderIds(), ['dropbox', 'retired-provider']);
+  });
+});
+
+describe('favourites validation', () => {
+  it('drops one malformed record and keeps the rest', () => {
+    localStorage.setItem(
+      `${FAVOURITES_KEY_PREFIX}dropbox`,
+      JSON.stringify({
+        version: 1,
+        providerId: 'dropbox',
+        items: [
+          folderFavourite({ containerId: 'good' }),
+          // A file favourite with no fileId cannot be re-opened.
+          { ...fileFavourite(), fileId: undefined },
+          // Written by a build that had no fileAreaId; re-entry is impossible.
+          { ...folderFavourite({ containerId: 'legacy' }), fileAreaId: undefined },
+        ],
+      }),
+    );
+    assert.deepStrictEqual(
+      loadFavourites('dropbox').map((item) => item.containerId),
+      ['good'],
+    );
+  });
+
+  it('ignores a blob written under a different version', () => {
+    localStorage.setItem(
+      `${FAVOURITES_KEY_PREFIX}dropbox`,
+      JSON.stringify({ version: 99, providerId: 'dropbox', items: [folderFavourite()] }),
+    );
+    assert.deepStrictEqual(loadFavourites('dropbox'), []);
+  });
+
+  it('ignores records stamped with a different provider than the key they sit under', () => {
+    localStorage.setItem(
+      `${FAVOURITES_KEY_PREFIX}dropbox`,
+      JSON.stringify({
+        version: 1,
+        providerId: 'dropbox',
+        items: [folderFavourite({ providerId: 'msgraph-onedrive' })],
+      }),
+    );
+    assert.deepStrictEqual(loadFavourites('dropbox'), []);
+  });
+
+  it('survives unparseable JSON', () => {
+    localStorage.setItem(`${FAVOURITES_KEY_PREFIX}dropbox`, '{not json');
+    assert.deepStrictEqual(loadFavourites('dropbox'), []);
+  });
+});
+
+describe('favourites refusals are reported, never silent', () => {
+  it('reports a failed write and does not pretend the favourite was added', () => {
+    localStorageMock.failWrites = true;
+    const result = toggleFavourite(folderFavourite());
+    assert.equal(result.ok, false);
+    assert.equal(result.added, false);
+    assert.equal(result.reason, 'storage');
+    assert.deepStrictEqual(result.items, [], 'the caller must not be handed an optimistic list');
+  });
+
+  it('refuses past the per-provider cap instead of growing the blob', () => {
+    const items = Array.from({ length: MAX_FAVOURITES_PER_PROVIDER }, (_unused, index) =>
+      folderFavourite({ containerId: `folder-${index}`, addedAt: index }),
+    );
+    saveFavourites('dropbox', items);
+
+    const result = toggleFavourite(folderFavourite({ containerId: 'one-too-many' }));
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, 'cap');
+    assert.equal(loadFavourites('dropbox').length, MAX_FAVOURITES_PER_PROVIDER);
+  });
+
+  it('still allows removing when the list sits exactly on the cap', () => {
+    const items = Array.from({ length: MAX_FAVOURITES_PER_PROVIDER }, (_unused, index) =>
+      folderFavourite({ containerId: `folder-${index}`, addedAt: index }),
+    );
+    saveFavourites('dropbox', items);
+
+    const result = toggleFavourite(folderFavourite({ containerId: 'folder-0', addedAt: 0 }));
+    assert.equal(result.ok, true);
+    assert.equal(result.added, false);
+    assert.equal(loadFavourites('dropbox').length, MAX_FAVOURITES_PER_PROVIDER - 1);
+  });
+});
+
+describe('favourites identity stamping', () => {
+  it('hides another identity\'s favourites without deleting them', () => {
+    const mine = folderFavourite({ identityId: 'user-a', containerId: 'mine' });
+    const theirs = folderFavourite({ identityId: 'user-b', containerId: 'theirs' });
+    saveFavourites('dropbox', [mine, theirs]);
+
+    assert.deepStrictEqual(
+      visibleFavourites(loadFavourites('dropbox'), 'user-a').map((item) => item.containerId),
+      ['mine'],
+    );
+    // Signed out: an interactive provider shows nothing, and nothing is lost.
+    assert.deepStrictEqual(visibleFavourites(loadFavourites('dropbox'), null), []);
+    assert.equal(loadFavourites('dropbox').length, 2, 'storage must survive the filter');
+  });
+
+  it('shows a preference-auth provider\'s null-stamped favourites', () => {
+    const dalux = folderFavourite({ providerId: 'dalux-build', identityId: null });
+    saveFavourites('dalux-build', [dalux]);
+    assert.equal(visibleFavourites(loadFavourites('dalux-build'), null).length, 1);
+  });
+});
+
+describe('forget saved values sweeps favourites', () => {
+  it('removes the favourites key for that provider only', () => {
+    saveFavourites('dalux-build', [folderFavourite({ providerId: 'dalux-build' })]);
+    saveFavourites('dropbox', [folderFavourite()]);
+
+    clearAllSourceData('dalux-build');
+
+    assert.deepStrictEqual(loadFavourites('dalux-build'), []);
+    assert.equal(loadFavourites('dropbox').length, 1, "another provider's favourites must survive");
+  });
+});

--- a/apps/viewer/src/lib/sources/favourites.test.ts
+++ b/apps/viewer/src/lib/sources/favourites.test.ts
@@ -15,7 +15,9 @@
  *    `persistence.ts` this is a user gesture, so failing silently would leave a
  *    star that looks set and is not.
  * 4. The owner stamp hides another account's bookmarks without deleting them,
- *    which is the whole point of stamping rather than clearing on sign-out.
+ *    which is the whole point of stamping rather than clearing on sign-out —
+ *    and ADDRESSES them apart, so account B's star press adds B's own record
+ *    instead of consuming the identical one A already stored.
  */
 
 import { beforeEach, describe, it } from 'node:test';
@@ -292,6 +294,44 @@ describe('favourites identity stamping', () => {
     const dalux = folderFavourite({ providerId: 'dalux-build', identityId: null });
     saveFavourites('dalux-build', [dalux]);
     assert.equal(visibleFavourites(loadFavourites('dalux-build'), null).length, 1);
+  });
+
+  // Filtering the LIST is only half of it. Storage is one blob per provider
+  // holding every account that has used this browser profile, and the provider
+  // hands both of them the same folder and file ids, so the key that addresses
+  // a record has to carry the identity too.
+  it('addresses two accounts\' identical favourites as two different keys', () => {
+    assert.notEqual(
+      favouriteKey(folderFavourite({ identityId: 'user-a' })),
+      favouriteKey(folderFavourite({ identityId: 'user-b' })),
+    );
+  });
+
+  it("does not let account B's star press delete account A's identical favourite", () => {
+    const theirs = folderFavourite({ identityId: 'user-a' });
+    saveFavourites('dropbox', [theirs]);
+
+    // Same provider, same project, same folder id — a different account.
+    const result = toggleFavourite(folderFavourite({ identityId: 'user-b', addedAt: 2_000 }));
+
+    assert.equal(result.added, true, 'B starred a folder B had not starred before');
+    assert.deepStrictEqual(
+      loadFavourites('dropbox').map((item) => item.identityId).sort(),
+      ['user-a', 'user-b'],
+      "B's press must add B's record, not consume A's",
+    );
+  });
+
+  it("does not report account A's favourite as already starred to account B", () => {
+    saveFavourites('dropbox', [folderFavourite({ identityId: 'user-a' })]);
+    const items = loadFavourites('dropbox');
+
+    assert.equal(isFavourited(items, favouriteKey(folderFavourite({ identityId: 'user-a' }))), true);
+    assert.equal(
+      isFavourited(items, favouriteKey(folderFavourite({ identityId: 'user-b' }))),
+      false,
+      'a filled star on a folder B never starred is what makes the delete above happen',
+    );
   });
 });
 

--- a/apps/viewer/src/lib/sources/favourites.ts
+++ b/apps/viewer/src/lib/sources/favourites.ts
@@ -1,0 +1,247 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Favourited folders and files, per source provider.
+ *
+ * A favourite is nothing but the addressing tuple `FileSourceProvider` already
+ * speaks — `projectId` / `fileAreaId` / `containerId` / `fileId`, all opaque
+ * provider ids — plus the names to render and the identity that created it. No
+ * provider capability is involved: re-entering a favourite is `listContainers`
+ * and `listFiles` by id, which every provider already supports, so this is
+ * host state exactly like the catalog cache and the downloaded-file records in
+ * `persistence.ts`, and follows that module's idioms.
+ *
+ * Deliberately NOT stored: the revision id. A favourite is a location, not a
+ * version — the live revision arrives with the listing.
+ *
+ * One sharp edge worth knowing before debugging a dangling favourite: ids are
+ * stable across a rename on all three shipped providers, and across a move on
+ * Dropbox and msgraph, but a Dalux container id is the composite
+ * `${fileAreaId}::${folderId}`, so a folder moved to another file area gets a
+ * new id; and a Dropbox file favourited from a SEARCH result carries a
+ * path-derived `containerId` rather than an id (`searchResultContainerId`),
+ * which breaks if any ancestor is renamed or moved. Both degrade to the same
+ * "the folder is gone" path — the provider's own error — and are never
+ * auto-deleted, because a 403 after a permission change looks identical here.
+ */
+
+export const FAVOURITES_KEY_PREFIX = 'ifc-lite-source-favourites:';
+const FAVOURITES_VERSION = 1;
+
+/** A blob this big is already unusable as a list; refuse rather than grow it. */
+export const MAX_FAVOURITES_PER_PROVIDER = 200;
+
+export type SourceFavouriteKind = 'folder' | 'file';
+
+export interface SourceFavourite {
+  readonly providerId: string;
+  readonly kind: SourceFavouriteKind;
+  readonly projectId: string;
+  readonly projectName: string;
+  /** Top-level container the browser enters; needed to re-run the wizard's second step by id. */
+  readonly fileAreaId: string;
+  readonly fileAreaName: string;
+  /** The favourited folder, or the folder a favourited file lives in. Equals `fileAreaId` at the area root. */
+  readonly containerId: string;
+  readonly containerName: string;
+  readonly fileId?: string;
+  readonly fileName?: string;
+  /**
+   * Identity that created the favourite, as stamped from the provider's
+   * catalog-cache owner — `null` for preference-auth providers, which never
+   * write that key. The list renders only favourites whose stamp matches the
+   * provider's current owner, so one browser profile cannot show account A's
+   * bookmarks to account B. Storage is never filtered by it: sign back in as
+   * the same account and they return.
+   */
+  readonly identityId: string | null;
+  readonly addedAt: number;
+}
+
+interface FavouritesBlob {
+  readonly version: number;
+  readonly providerId: string;
+  readonly items: readonly SourceFavourite[];
+}
+
+function storageKey(providerId: string): string {
+  return `${FAVOURITES_KEY_PREFIX}${providerId}`;
+}
+
+/**
+ * Unlike the caches in `persistence.ts` a failed favourite write IS
+ * user-visible — the user pressed a star and expects it to stick — so this
+ * reports failure to the caller instead of only warning.
+ */
+function tryWrite(key: string, value: string, what: string): boolean {
+  try {
+    localStorage.setItem(key, value);
+    return true;
+  } catch (err) {
+    console.warn(`[sources] Failed to persist ${what} (quota exceeded or storage unavailable)`, err);
+    return false;
+  }
+}
+
+/** Identity of a favourite for toggling and dedupe. Provider-scoped, so the same file in two providers is two favourites. */
+export function favouriteKey(
+  favourite: Pick<SourceFavourite, 'providerId' | 'projectId' | 'kind' | 'containerId' | 'fileId'>,
+): string {
+  const target = favourite.kind === 'file' ? (favourite.fileId ?? '') : favourite.containerId;
+  return `${favourite.providerId}:${favourite.projectId}:${favourite.kind}:${target}`;
+}
+
+/** Per-record validation, so one hand-edited or older-build entry drops out instead of taking the whole list with it. */
+function parseFavourite(value: unknown, providerId: string): SourceFavourite | null {
+  if (typeof value !== 'object' || value === null) return null;
+  const record = value as Partial<SourceFavourite>;
+  if (
+    record.providerId !== providerId ||
+    (record.kind !== 'folder' && record.kind !== 'file') ||
+    typeof record.projectId !== 'string' ||
+    typeof record.projectName !== 'string' ||
+    typeof record.fileAreaId !== 'string' ||
+    typeof record.fileAreaName !== 'string' ||
+    typeof record.containerId !== 'string' ||
+    typeof record.containerName !== 'string' ||
+    typeof record.addedAt !== 'number' ||
+    !(typeof record.identityId === 'string' || record.identityId === null)
+  ) {
+    return null;
+  }
+  if (record.kind === 'file' && (typeof record.fileId !== 'string' || typeof record.fileName !== 'string')) {
+    return null;
+  }
+  return {
+    providerId,
+    kind: record.kind,
+    projectId: record.projectId,
+    projectName: record.projectName,
+    fileAreaId: record.fileAreaId,
+    fileAreaName: record.fileAreaName,
+    containerId: record.containerId,
+    containerName: record.containerName,
+    // Only on a file favourite: a folder record carrying `fileId: undefined`
+    // is a different object shape from the one that was stored, which a
+    // deep-equality check downstream would notice.
+    ...(record.kind === 'file' ? { fileId: record.fileId, fileName: record.fileName } : {}),
+    identityId: record.identityId,
+    addedAt: record.addedAt,
+  };
+}
+
+/** Newest first — the only order this feature has; see the design's out-of-scope list. */
+function byAddedAtDesc(left: SourceFavourite, right: SourceFavourite): number {
+  return right.addedAt - left.addedAt;
+}
+
+export function loadFavourites(providerId: string): SourceFavourite[] {
+  try {
+    const raw = localStorage.getItem(storageKey(providerId));
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as Partial<FavouritesBlob>;
+    if (parsed.version !== FAVOURITES_VERSION || !Array.isArray(parsed.items)) return [];
+    return parsed.items
+      .flatMap((item) => {
+        const favourite = parseFavourite(item, providerId);
+        return favourite ? [favourite] : [];
+      })
+      .sort(byAddedAtDesc);
+  } catch (err) {
+    console.warn(`[sources] Failed to parse favourites for "${providerId}"`, err);
+    return [];
+  }
+}
+
+/** Returns false when the write failed (quota, private mode) so the caller can tell the user. */
+export function saveFavourites(providerId: string, items: readonly SourceFavourite[]): boolean {
+  const blob: FavouritesBlob = { version: FAVOURITES_VERSION, providerId, items: [...items] };
+  return tryWrite(storageKey(providerId), JSON.stringify(blob), `favourites for "${providerId}"`);
+}
+
+export function isFavourited(items: readonly SourceFavourite[], key: string): boolean {
+  return items.some((item) => favouriteKey(item) === key);
+}
+
+/** Provider ids with a stored favourites blob, including providers no longer registered in this build. */
+export function listFavouriteProviderIds(): string[] {
+  const ids: string[] = [];
+  try {
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key?.startsWith(FAVOURITES_KEY_PREFIX)) ids.push(key.slice(FAVOURITES_KEY_PREFIX.length));
+    }
+  } catch (err) {
+    console.warn('[sources] Failed to enumerate stored favourites', err);
+  }
+  return ids.sort();
+}
+
+export interface ToggleFavouriteResult {
+  /** True when the favourite was added, false when it was removed or refused. */
+  readonly added: boolean;
+  /** False when nothing was persisted — a full/unavailable storage, or the per-provider cap. */
+  readonly ok: boolean;
+  readonly items: SourceFavourite[];
+  readonly reason?: 'storage' | 'cap';
+}
+
+export function toggleFavourite(favourite: SourceFavourite): ToggleFavouriteResult {
+  const key = favouriteKey(favourite);
+  const items = loadFavourites(favourite.providerId);
+  const remaining = items.filter((item) => favouriteKey(item) !== key);
+
+  if (remaining.length !== items.length) {
+    const ok = saveFavourites(favourite.providerId, remaining);
+    return { added: false, ok, items: ok ? remaining : items, reason: ok ? undefined : 'storage' };
+  }
+
+  if (items.length >= MAX_FAVOURITES_PER_PROVIDER) {
+    return { added: false, ok: false, items, reason: 'cap' };
+  }
+
+  const next = [favourite, ...items].sort(byAddedAtDesc);
+  const ok = saveFavourites(favourite.providerId, next);
+  return { added: ok, ok, items: ok ? next : items, reason: ok ? undefined : 'storage' };
+}
+
+export function removeFavourite(providerId: string, key: string): SourceFavourite[] {
+  const items = loadFavourites(providerId);
+  const remaining = items.filter((item) => favouriteKey(item) !== key);
+  if (remaining.length === items.length) return items;
+  return saveFavourites(providerId, remaining) ? remaining : items;
+}
+
+/**
+ * Refreshes the stored display name after the source renamed the folder or
+ * file underneath us. Ids address the favourite, so a rename never breaks it —
+ * only the label goes stale, and this is where the fresh one arrives.
+ */
+export function renameFavourite(providerId: string, key: string, name: string): SourceFavourite[] {
+  const items = loadFavourites(providerId);
+  let changed = false;
+  const next = items.map((item) => {
+    if (favouriteKey(item) !== key) return item;
+    const current = item.kind === 'file' ? item.fileName : item.containerName;
+    if (current === name) return item;
+    changed = true;
+    return item.kind === 'file' ? { ...item, fileName: name } : { ...item, containerName: name };
+  });
+  if (!changed) return items;
+  return saveFavourites(providerId, next) ? next : items;
+}
+
+/**
+ * Favourites the identity now signed in is allowed to see. `currentOwner` is
+ * the provider's catalog-cache owner (`readSourceCatalogCacheOwner`), which is
+ * `null` both for a signed-out interactive provider and for a preference-auth
+ * one — the latter stamps `null` at creation time too, so its favourites match.
+ */
+export function visibleFavourites(
+  items: readonly SourceFavourite[],
+  currentOwner: string | null,
+): SourceFavourite[] {
+  return items.filter((item) => item.identityId === currentOwner);
+}

--- a/apps/viewer/src/lib/sources/favourites.ts
+++ b/apps/viewer/src/lib/sources/favourites.ts
@@ -85,12 +85,21 @@ function tryWrite(key: string, value: string, what: string): boolean {
   }
 }
 
-/** Identity of a favourite for toggling and dedupe. Provider-scoped, so the same file in two providers is two favourites. */
+/**
+ * Identity of a favourite for toggling and dedupe. Provider-scoped, so the same
+ * file in two providers is two favourites — and identity-scoped for the same
+ * reason the catalog cache is (see `syncSourceCatalogCacheOwner`): storage is
+ * one blob per provider holding every account that ever used this browser
+ * profile, and the provider hands the same project/folder/file ids to all of
+ * them. Without the identity segment account B's star press matched account A's
+ * stored record: it DELETED it instead of adding B's own, and until then the
+ * folder rendered already-starred to B, who had never starred it.
+ */
 export function favouriteKey(
-  favourite: Pick<SourceFavourite, 'providerId' | 'projectId' | 'kind' | 'containerId' | 'fileId'>,
+  favourite: Pick<SourceFavourite, 'providerId' | 'projectId' | 'kind' | 'containerId' | 'fileId' | 'identityId'>,
 ): string {
   const target = favourite.kind === 'file' ? (favourite.fileId ?? '') : favourite.containerId;
-  return `${favourite.providerId}:${favourite.projectId}:${favourite.kind}:${target}`;
+  return `${favourite.providerId}:${favourite.identityId ?? ''}:${favourite.projectId}:${favourite.kind}:${target}`;
 }
 
 /** Per-record validation, so one hand-edited or older-build entry drops out instead of taking the whole list with it. */

--- a/apps/viewer/src/lib/sources/persistence.test.ts
+++ b/apps/viewer/src/lib/sources/persistence.test.ts
@@ -19,6 +19,7 @@ import {
   syncSourceCatalogCacheOwner,
 } from './persistence.js';
 import { saveSourcePrefs, loadSavedSourcePrefs } from './preferences.js';
+import { loadFavourites, saveFavourites } from './favourites.js';
 
 class MemoryStorage implements Storage {
   private readonly map = new Map<string, string>();
@@ -168,6 +169,21 @@ describe('source persistence', () => {
     saveRevisionWatchCursor('dalux-build', 'project-1', 'cursor-1');
     // Provider ctx.storage namespace (mirrors host-storage's prefix).
     localStorage.setItem('ifc-lite-source:dalux-build:rev:p:a:f', 'rev-3');
+    // Favourites carry folder and file NAMES, so the sweep has to take them.
+    saveFavourites('dalux-build', [
+      {
+        providerId: 'dalux-build',
+        kind: 'folder',
+        projectId: 'project-1',
+        projectName: 'Project 1',
+        fileAreaId: 'file-area-1',
+        fileAreaName: 'Documents',
+        containerId: 'folder-1',
+        containerName: 'Models',
+        identityId: null,
+        addedAt: 1,
+      },
+    ]);
     // Another provider's data must survive the sweep.
     saveSourcePrefs('other-provider', { apiKey: 'keep' });
     recordDownloadedSourceFile(
@@ -181,6 +197,7 @@ describe('source persistence', () => {
     assert.strictEqual(loadSourceCatalogCache('dalux-build', 'project-1', 'file-area-1'), null);
     assert.strictEqual(loadRevisionWatchCursor('dalux-build', 'project-1'), undefined);
     assert.strictEqual(localStorage.getItem('ifc-lite-source:dalux-build:rev:p:a:f'), null);
+    assert.deepStrictEqual(loadFavourites('dalux-build'), []);
     const records = loadDownloadedSourceFileRecords();
     assert.strictEqual(
       getDownloadedSourceFileRecord(records, 'dalux-build', 'project-1', 'file-1'),

--- a/apps/viewer/src/lib/sources/persistence.ts
+++ b/apps/viewer/src/lib/sources/persistence.ts
@@ -4,6 +4,7 @@
 
 import type { SourceContainer, SourceFile, SourceTag } from '@ifc-lite/plugin-api';
 import { clearSourcePrefs } from './preferences';
+import { FAVOURITES_KEY_PREFIX } from './favourites';
 
 const CATALOG_KEY_PREFIX = 'ifc-lite-source-catalog:';
 /** Identity that populated the catalog cache for a provider. Persisted because
@@ -308,6 +309,22 @@ export function clearSourceCatalogCache(providerId: string): void {
 }
 
 /**
+ * The identity that currently owns a provider's persisted state, or `null` for
+ * signed out and for preference-auth providers (which never write the key).
+ * Read-only companion to `syncSourceCatalogCacheOwner`, so other host state
+ * scoped to the signed-in identity — favourites — can be filtered by the same
+ * stamp instead of inventing a second notion of "who is signed in".
+ */
+export function readSourceCatalogCacheOwner(providerId: string): string | null {
+  try {
+    return localStorage.getItem(`${CATALOG_OWNER_KEY_PREFIX}${providerId}`);
+  } catch (err) {
+    console.warn(`[sources] Failed to read catalog cache owner for "${providerId}"`, err);
+    return null;
+  }
+}
+
+/**
  * Drops the cached catalog whenever the identity it belongs to is not the one
  * now signed in, and records the new owner.
  *
@@ -369,7 +386,11 @@ export function clearAllSourceData(providerId: string): void {
         key.startsWith(`${CATALOG_KEY_PREFIX}${providerId}:`) ||
         key === `${CATALOG_OWNER_KEY_PREFIX}${providerId}` ||
         key.startsWith(`${WATCH_CURSOR_KEY_PREFIX}${providerId}:`) ||
-        key.startsWith(`${PROVIDER_STORAGE_KEY_PREFIX}${providerId}:`)
+        key.startsWith(`${PROVIDER_STORAGE_KEY_PREFIX}${providerId}:`) ||
+        // Favourites hold folder and file NAMES — the same identity-sensitive
+        // data as the catalog cache above — so "forget saved values" has to
+        // take them too. One key per provider, no trailing separator.
+        key === `${FAVOURITES_KEY_PREFIX}${providerId}`
       ) {
         doomed.push(key);
       }

--- a/apps/viewer/src/lib/sources/preferences.ts
+++ b/apps/viewer/src/lib/sources/preferences.ts
@@ -51,6 +51,18 @@ export function loadResolvedSourcePrefs(manifest: PluginManifest): Record<string
   return { ...manifestPreferenceDefaults(manifest), ...loadSavedSourcePrefs(manifest.name) };
 }
 
+/**
+ * Whether every preference the manifest marks `required` has a non-blank
+ * value. Gates both "Browse" on the provider row and a favourite's jump, which
+ * have to agree — a favourite that opens a browser the row itself refuses to
+ * open would dead-end on the provider's own "missing API key" error.
+ */
+export function isPrefsConfigured(manifest: PluginManifest, prefs: Record<string, string>): boolean {
+  return manifest.preferences
+    .filter((pref) => pref.required)
+    .every((pref) => Boolean(prefs[pref.name]?.trim()));
+}
+
 export function saveSourcePrefs(providerId: string, values: Record<string, string>): void {
   try {
     localStorage.setItem(PREFS_KEY_PREFIX + providerId, JSON.stringify(values));


### PR DESCRIPTION
Star a folder or a file in any cloud source and reach it again from the Cloud Sources panel, instead of re-walking project -> file area -> folders every time.

## The seam

Host-side only. A favourite is the addressing tuple every `FileSourceProvider` already speaks (`projectId` / `fileAreaId` / `containerId` / `fileId`, all opaque provider ids), so re-entry is `listContainers` and `listFiles` by id. No provider, manifest or plugin-api change. A provider-level `favourites` capability was rejected deliberately: it would force all three shipped providers to reimplement identical bookkeeping, and would land in `ctx.storage`, which is namespaced per provider and therefore cannot back a cross-provider list.

Storage follows `lib/sources/persistence.ts` idioms exactly: `ifc-lite-source-favourites:<providerId>`, one key per provider, per-record validation so a stale entry drops out alone rather than taking the list with it, and `clearAllSourceData` ("Forget saved values") sweeps it because a favourite holds folder and file names.

The revision id is deliberately **not** stored: a favourite is a location, not a version. Each record is stamped with the provider's catalog-cache owner, so a second account on the same browser profile never sees the first one's bookmarks, and the first one's return on re-sign-in rather than being deleted.

## Known-degrading cases, by design

Recorded in the module doc comment rather than special-cased. Both fall through to the normal "the folder is gone" path (the provider's own error), and neither auto-deletes the favourite, because a 403 after a permission change is indistinguishable from a delete here:

- a Dalux container id is the composite `${fileAreaId}::${folderId}`, so a folder moved to a different file area dangles;
- a Dropbox file favourited from a **search result** carries a path-derived `containerId`, so it breaks if an ancestor is renamed or moved.

## Verified by executing the real UI

Chrome, dev server on 5215, own isolated profile. Screenshots attached to the review thread. Only `@ifc-lite/source-dalux` is registered in the viewer and it is preference-auth, so to drive the star gestures a **temporary** fixture provider was registered in the dev build only; it was deleted before commit and is not in this diff. Nothing was signed into a real CDE, so no real network path was exercised.

Executed, not merely asserted present:

- opened Cloud Sources: no favourites section when there are none;
- starred the file area itself, a subfolder, and a file: each wrote the exact addressing tuple to `localStorage`, star filled, `aria-pressed` flipped;
- back to the panel: the FAVOURITES section renders all three, each labelled `Provider / Project / File area`;
- **reloaded the page**: all three still there;
- clicked the file favourite: the browser jumped straight into `Documents / Models` and arrived with the file preselected ("Load 1 file as federated model");
- un-starred from inside the browser: gone from storage and from the list;
- removed the remaining two with the list's `X`: the section disappears when the last one goes;
- unregistered the provider with a favourite still stored: the row renders disabled with "Provider unavailable" and is **not** deleted.

## Verified by unit test only

Never exercised in a browser here: the identity-stamp filter across two different accounts, quota-exhausted and private-mode writes, the 200-per-provider cap, malformed and wrong-version stored blobs, the missing-required-preference row state, and the upstream-rename label refresh. All are covered by node:test cases, and each was mutation-checked (break it, watch it fail, restore, watch it pass).

Two guards initially passed under mutation because the test fixture resolved its listings in a microtask, which handed the effect complete data on its first useful run. A `DeferringProvider` was added so the "still loading" guards are load-bearing; both now fail when removed.

## Out of scope

Tags or labels; folders/groups of favourites; manual reordering (sort is `addedAt` descending, full stop); cross-device or account sync; any server component; a favourites entry in the ribbon or File menu; favouriting a whole project or a whole provider; pinning a specific revision; one-click download straight from a favourite (it preselects instead, so the audited download path is reused rather than fabricating a revision id); auto-repair of a dangling favourite by name search; per-favourite change notifications.

## Gates

`pnpm install --frozen-lockfile`, `pnpm build`, `pnpm typecheck`, `pnpm lint`, `node scripts/check-source-text-assertions.mjs` and the `apps/viewer` suite (4615 tests) all exit 0. `pnpm test` at the repo root exits 1 on `@ifc-lite/clash` `src/contact/world-frame.test.ts` ("Expect test to fail") - reproduced on a clean `origin/main` checkout, pre-existing and unrelated to this change.

No changeset: `@ifc-lite/viewer` is private and nothing under `packages/` is touched.
