### PR TITLE
test(clash): drop the stale it.fails wrapper the #2661 fix left behind (main is red)

### DIFF
--- a/packages/clash/src/contact/world-frame.test.ts
+++ b/packages/clash/src/contact/world-frame.test.ts
@@ -5,13 +5,16 @@
 /**
  * World-frame corpus coverage for the contact pipeline (#2600, fix PR #2661).
  *
- * `scaledPlaneEps` (narrow-phase.ts) sizes the coplanarity tolerance from the
- * max |coordinate| over ALL THREE axes of both AABBs, then compares it
- * against a signed distance along ONE plane normal. A model 10 km out in X
- * therefore hands a Z-normal test a ~2.4 mm epsilon derived entirely from
- * the irrelevant X magnitude — and a genuine ~2 mm Z-clearance reads as
- * coplanar contact. The corpus places the SAME pair at the origin and far
- * out on an ORTHOGONAL axis; a frame-correct tolerance answers identically.
+ * Before #2661, `scaledPlaneEps` (narrow-phase.ts) sized the coplanarity
+ * tolerance from the max |coordinate| over ALL THREE axes of both AABBs,
+ * then compared it against a signed distance along ONE plane normal. A model
+ * 10 km out in X therefore handed a Z-normal test a ~2.4 mm epsilon derived
+ * entirely from the irrelevant X magnitude — and a genuine ~2 mm
+ * Z-clearance read as coplanar contact. #2661 replaced that scalar with
+ * per-axis f32-ULP noise projected onto each tested plane's own normal. The
+ * corpus places the SAME pair at the origin and far out on an ORTHOGONAL
+ * axis; a frame-correct tolerance answers identically, and this file exists
+ * to keep it that way.
  *
  * Shape conforms to PR #2661's measured reproduction (`clearanceQuadsAt`):
  * horizontal quads with the lower plane at z = 0, offset applied to X only,
@@ -21,18 +24,18 @@
  * through f32 (ingestion realism), and f32(0.002) lands a hair ABOVE the
  * default 2 mm inflation — which would silently drop the candidates — so
  * the clearance here is 1.9 mm, robustly inside the inflation and still
- * comfortably swallowed by the defective ~2.4 mm far-placement epsilon.
+ * comfortably swallowed by the pre-#2661 ~2.4 mm far-placement epsilon, so
+ * the case remains a genuine discriminator against a regression.
  *
  * The clash contact `Mesh` has NO RTC-origin field (positions are world-
  * frame by contract), so this file carries only the large-world-coordinate
  * axis of the corpus; the per-element `MeshData.origin` axis lives in the
  * viewer compare tests (#2529 path).
  *
- * The `it.fails` case asserts the CORRECT behaviour and is expected to fail
- * on the live defect. When the #2661 projection fix lands, that test starts
- * passing, vitest reports the `.fails` wrapper itself as a failure, and the
- * wrapper must be removed — the corpus cannot silently rot in either
- * direction.
+ * The far-placement clearance case was authored as `it.fails` against the
+ * live defect and was un-wrapped once #2661 landed; it is now an ordinary
+ * passing test. The flush counter-cases guard the other direction, so the
+ * corpus cannot silently rot either way.
  */
 
 import { describe, expect, it } from 'vitest';
@@ -120,19 +123,16 @@ describe('contact world-frame corpus (#2600)', () => {
     expect(contactClusters(a, b)).toEqual([]);
   });
 
-  // KNOWN-FAILING on the live #2600 defect: asserts the CORRECT behaviour.
-  // scaledPlaneEps derives ~2.4 mm from the 10 km X magnitude and swallows
-  // the genuine clearance as coplanar contact — measured on this code: 4
+  // The case the corpus was built for. On the pre-#2661 code this failed:
+  // scaledPlaneEps derived ~2.4 mm from the 10 km X magnitude and swallowed
+  // the genuine clearance as coplanar contact — measured on that code, 4
   // fabricated coplanar triangle pairs (2 tris x 2 tris) and 1 fabricated
-  // surface cluster (area 1 m2, plane normal Z). When the #2661 projection
-  // fix lands this starts passing and vitest flags the `.fails` wrapper:
-  // remove the wrapper in that PR.
-  it.fails(
-    `the Z-clearance ${WORLD_FRAME_OFFSET_M / 1000} km out in X produces no pairs and no contact (#2600)`,
-    () => {
-      const { a, b } = horizontalFacePair('far-baked', CLEARANCE_M);
-      expect(narrowPhase(a, b)).toEqual([]);
-      expect(contactClusters(a, b)).toEqual([]);
-    },
-  );
+  // surface cluster (area 1 m2, plane normal Z). The projected tolerance
+  // takes only the Z-axis noise for a Z normal, so the clearance reads as
+  // clear at 10 km exactly as it does at the origin.
+  it(`the Z-clearance ${WORLD_FRAME_OFFSET_M / 1000} km out in X produces no pairs and no contact (#2600)`, () => {
+    const { a, b } = horizontalFacePair('far-baked', CLEARANCE_M);
+    expect(narrowPhase(a, b)).toEqual([]);
+    expect(contactClusters(a, b)).toEqual([]);
+  });
 });


### PR DESCRIPTION
`main` is currently red. At `90d5b3563` (#2661) the `Test` workflow fails:

```
FAIL packages/clash/src/contact/world-frame.test.ts
  > contact world-frame corpus (#2600)
  > the Z-clearance 10 km out in X produces no pairs and no contact (#2600)
Error: Expect test to fail
```

#2661 fixed the #2600 defect — it replaced the max-over-all-axes `scaledPlaneEps` with per-axis f32-ULP noise projected onto each tested plane's own normal — but did not remove the `it.fails` wrapper that documented the defect. The wrapped body asserts the *correct* behaviour, so it now passes and vitest fails the wrapper itself.

This removes the wrapper so the case is an ordinary passing test, and rewrites the module doc, which still described the defect in the present tense and predicted its own removal "when the #2661 projection fix lands".

**No production code changed, and no assertion changed.** Test file only.

### Verifying the body passes for the right reason

Not vacuously, and not because a fixture drifted:

- **The candidates are still emitted.** At the 10 km placement, running the same fixture pair through `narrowPhase` with an explicit loose `planeEps` (0.01) still yields all 4 candidate triangle pairs. So the empty verdict under the default tolerance is decided by `planeEps` alone, exactly as the corpus header claims — the geometry has not drifted out of broad-phase range.
- **The fix is what makes it pass.** Temporarily restoring the pre-#2661 behaviour (collapsing `axisNoise` back to its max across axes) reproduces precisely the numbers the old comment recorded: 4 fabricated coplanar pairs and 1 fabricated surface cluster at the far placement, 0 and 0 at the origin. Restored before committing.

That matches #2661's own reasoning: a Z-normal plane now draws its tolerance only from the Z-axis noise (~1.2e-7, floored at 1e-6), not from the irrelevant 10 km X magnitude that produced the ~2.4 mm epsilon which swallowed the 1.9 mm clearance.

### Staleness sweep

Grepped `packages/`, `apps/` and `crates/` for `it.fails`, `test.fails`, `.failing(`, `xfail` and `should_panic`: the only two hits in the repo are the wrapper and its own header reference, both in this file. The one skipped test in the clash package (`bridge-regression.test.ts`) is `describe.skipIf(!canRun)`, gated on an optional downloaded fixture, unrelated to #2661.

### Gates

| | before | after |
|---|---|---|
| `pnpm --filter @ifc-lite/clash test` | 1 failed, 271 passed, 1 skipped | **272 passed, 1 skipped** |
| `check-changesets` | pass | pass |
| `check-test-wiring` | pass | pass |

No changeset: nothing published changes, and the gate does not require one for a test-only change (verified — it validates the format of existing changesets and is not diff-gated).

This should clear the same failure for #2393, #2598, #2654, #2668 and likely #2632, which are all currently blocked by it.
