### PR TITLE
docs(viewer): restore the clash-exclusions note to the viewer changelog

### DIFF
--- a/.changeset/viewer-clash-exclusions-note.md
+++ b/.changeset/viewer-clash-exclusions-note.md
@@ -1,0 +1,16 @@
+---
+'@ifc-lite/viewer': minor
+---
+
+Clash exclusions: mark an overlap as by design and stop it counting.
+
+A coordinator can exclude a whole IFC type pair, a one-sided type rule that
+excludes every clash involving one type regardless of what it meets, or one
+specific element pair. Each rule shows how many clashes it is hiding, and rules
+can be disabled or removed. They persist in local storage and apply to the last
+run without re-detecting.
+
+This note exists because the feature shipped in #2535 under a changeset that
+named only `@ifc-lite/clash`. Consuming a changeset deletes it, so the
+viewer-facing description of a viewer feature would otherwise have been lost
+from `apps/viewer/CHANGELOG.md` permanently rather than merely delayed.


### PR DESCRIPTION
Fixes the P2 on the release PR #2667 at its source rather than in the generated output.

## What is lost, and why it is permanent

#2535 shipped user-defined clash exclusions, a **viewer** feature, under a changeset naming only `@ifc-lite/clash`. So `apps/viewer/CHANGELOG.md`'s 1.35.0 section gets the clash dependency bump and the spatial issue grouping, but nothing describing the exclusions workflow.

Consuming a changeset **deletes** it. So when #2667 merges, that description is not delayed, it is gone: no file in the repo will say the exclusions workflow shipped, and a user reading the viewer changelog to find out what changed will not learn it did.

## Why a changeset rather than editing #2667

#2667 is generated by the changesets action and regenerates whenever main moves, so a hand-edit to `apps/viewer/CHANGELOG.md` there would be overwritten.

`@ifc-lite/viewer` is `private: true` so it never publishes, but it IS versioned (1.33.6) and carries its own changelog, and changesets versions private packages exactly like public ones. Naming it in a changeset is therefore the supported way to get the entry, and #2667 will pick it up on its next regeneration.

Verified with the repo's own gate: `node scripts/check-changesets.mjs` reports `7 pending, all naming workspace packages`.

## Note on the release PR

I am deliberately not merging #2667. It publishes packages to npm, which is an owner decision rather than a green-CI one, and this PR should land first so the release carries the note.