### PR TITLE
fix(viewer): lens rule isolation resolves geometry-less assemblies to their parts

### DIFF
--- a/apps/viewer/src/components/viewer/LensPanel.isolate.wiring.test.tsx
+++ b/apps/viewer/src/components/viewer/LensPanel.isolate.wiring.test.tsx
@@ -68,6 +68,17 @@ const LENS: Lens = {
       color: '#00ff00',
     },
     {
+      // Raw matches DIFFERENT from rule-assembly's, but the same set once
+      // resolved: the assembly resolves to its parts, the parts resolve to
+      // themselves. Exactly the collision the expansion widened into reach.
+      id: 'rule-parts',
+      name: 'Assembly parts',
+      enabled: true,
+      criteria: { type: 'ifcType', ifcType: 'IfcBuildingElementPart' },
+      action: 'colorize',
+      color: '#ffff00',
+    },
+    {
       // The mixed match: an ordinary lens over an attribute matches a wall, an
       // assembly and a space at once.
       id: 'rule-mixed',
@@ -92,10 +103,13 @@ function seedLens(options: {
   useViewerStore.setState({
     savedLenses: [LENS],
     activeLensId: LENS.id,
-    lensRuleCounts: new Map([['rule-assembly', 1], ['rule-wall', 1], ['rule-mixed', 3]]),
+    lensRuleCounts: new Map([
+      ['rule-assembly', 1], ['rule-wall', 1], ['rule-parts', 3], ['rule-mixed', 3],
+    ]),
     lensRuleEntityIds: new Map([
       ['rule-assembly', [ASSEMBLY]],
       ['rule-wall', [WALL]],
+      ['rule-parts', [ASSEMBLY, PART_A, PART_B]],
       ['rule-mixed', [WALL, ASSEMBLY, HIDDEN_SPACE]],
     ]),
     lensRuleIsolation: null,
@@ -159,7 +173,7 @@ describe('LensPanel: isolating a rule resolves geometry-less assemblies to their
 
     // A count of 0 renders the row un-clickable (RuleRow's `isEmpty`), which
     // would make every assertion below vacuously unreachable instead of red.
-    assert.equal(container.querySelectorAll('div[role="button"]').length, 3);
+    assert.equal(container.querySelectorAll('div[role="button"]').length, 4);
   });
 
   it('isolates the assembly\'s geometry-bearing parts, not its bare id', () => {
@@ -242,6 +256,44 @@ describe('LensPanel: isolating a rule resolves geometry-less assemblies to their
       'a rule whose matches already own meshes must isolate exactly those ids',
     );
     assert.deepEqual(useViewerStore.getState().lensRuleIsolation?.entityIds, [WALL]);
+  });
+
+  it('switches to another rule that resolves to the SAME set without the toggle clearing it', () => {
+    // `isolateEntities` is a same-set TOGGLE (visibilitySlice.ts:176-194): fed
+    // the ids the channel already holds it CLEARS. So switching from the
+    // assembly rule to a rule whose DIFFERENT raw matches resolve to the same
+    // set un-isolated the model while the panel recorded the new rule as the
+    // owner of an isolation that no longer existed. Pre-existing for two rules
+    // with identical raw matches; the resolution widened it to an assembly
+    // rule versus a parts rule, which is an ordinary pair of lens rules.
+    seedLens({ resolveHighlightIds: assemblyResolver });
+    const container = render(<LensPanel onClose={() => {}} />);
+    const expected = new Set([PART_A, PART_B, ASSEMBLY]);
+
+    click(ruleRow(container, 'Assemblies'));
+    assert.deepEqual(useViewerStore.getState().isolatedEntities, expected, 'precondition: rule A isolates the set');
+    assert.equal(useViewerStore.getState().lensRuleIsolation?.ruleId, 'rule-assembly');
+
+    click(ruleRow(container, 'Assembly parts'));
+
+    const s = useViewerStore.getState();
+    assert.deepEqual(
+      s.isolatedEntities,
+      expected,
+      'switching rules must leave the model isolated over the set, not blank the channel via the toggle',
+    );
+    assert.equal(s.lensRuleIsolation?.ruleId, 'rule-parts', 'the new rule must be recorded as the owner');
+    assert.deepEqual(
+      [...(s.lensRuleIsolation?.entityIds ?? [])].sort((a, b) => a - b),
+      [ASSEMBLY, PART_A, PART_B],
+      'the record must hold the set actually in the channel',
+    );
+
+    // And the handover must leave the release path working: the new owner
+    // still owns the channel, so its own re-click clears.
+    click(ruleRow(container, 'Assembly parts'));
+    assert.equal(useViewerStore.getState().isolatedEntities, null, 'releasing the new owner must clear the channel');
+    assert.equal(useViewerStore.getState().lensRuleIsolation, null);
   });
 
   it('keeps every matched id on a MIXED rule, where some resolve and some resolve to nothing', () => {

--- a/apps/viewer/src/components/viewer/LensPanel.isolate.wiring.test.tsx
+++ b/apps/viewer/src/components/viewer/LensPanel.isolate.wiring.test.tsx
@@ -42,6 +42,10 @@ const ASSEMBLY = 4_000_042;
 const PART_A = 4_000_101;
 const PART_B = 4_000_102;
 const WALL = 4_000_500;
+/** An IfcSpace: real geometry, but a type hidden by default
+ *  (TYPE_VISIBILITY_SEMANTIC_DEFAULTS), so it is absent from the filtered mesh
+ *  list the resolver bounds-checks against and resolves to nothing. */
+const HIDDEN_SPACE = 4_000_700;
 
 const LENS: Lens = {
   id: 'lens-under-test',
@@ -63,6 +67,16 @@ const LENS: Lens = {
       action: 'colorize',
       color: '#00ff00',
     },
+    {
+      // The mixed match: an ordinary lens over an attribute matches a wall, an
+      // assembly and a space at once.
+      id: 'rule-mixed',
+      name: 'Level 1',
+      enabled: true,
+      criteria: { type: 'attribute', attributeName: 'Name', operator: 'contains', attributeValue: 'L1' },
+      action: 'colorize',
+      color: '#0000ff',
+    },
   ],
 };
 
@@ -78,8 +92,12 @@ function seedLens(options: {
   useViewerStore.setState({
     savedLenses: [LENS],
     activeLensId: LENS.id,
-    lensRuleCounts: new Map([['rule-assembly', 1], ['rule-wall', 1]]),
-    lensRuleEntityIds: new Map([['rule-assembly', [ASSEMBLY]], ['rule-wall', [WALL]]]),
+    lensRuleCounts: new Map([['rule-assembly', 1], ['rule-wall', 1], ['rule-mixed', 3]]),
+    lensRuleEntityIds: new Map([
+      ['rule-assembly', [ASSEMBLY]],
+      ['rule-wall', [WALL]],
+      ['rule-mixed', [WALL, ASSEMBLY, HIDDEN_SPACE]],
+    ]),
     lensRuleIsolation: null,
     lensHiddenIds: new Set<number>(),
     lensAppliedHiddenIds: [],
@@ -107,10 +125,19 @@ function ruleRow(container: HTMLElement, ruleName: string): HTMLElement {
   return rows[0];
 }
 
-/** A resolver with the real one's contract: geometry-bearing ids pass through,
- *  the geometry-less assembly is replaced by its parts and never by itself. */
+/**
+ * A resolver with the real one's contract (`expandToGeometryBearingIds`):
+ * geometry-bearing ids pass through untouched, the geometry-less assembly is
+ * replaced by its parts and never by itself, and an id that is invisible to
+ * the FILTERED mesh list the resolver bounds-checks against (a hidden-type
+ * IfcSpace) comes back as nothing at all.
+ */
 const assemblyResolver = (ids: number[]) =>
-  ids.flatMap((id) => (id === ASSEMBLY ? [PART_A, PART_B] : [id]));
+  ids.flatMap((id) => {
+    if (id === ASSEMBLY) return [PART_A, PART_B];
+    if (id === HIDDEN_SPACE) return [];
+    return [id];
+  });
 
 describe('LensPanel: isolating a rule resolves geometry-less assemblies to their parts', () => {
   before(() => {
@@ -132,7 +159,7 @@ describe('LensPanel: isolating a rule resolves geometry-less assemblies to their
 
     // A count of 0 renders the row un-clickable (RuleRow's `isEmpty`), which
     // would make every assertion below vacuously unreachable instead of red.
-    assert.equal(container.querySelectorAll('div[role="button"]').length, 2);
+    assert.equal(container.querySelectorAll('div[role="button"]').length, 3);
   });
 
   it('isolates the assembly\'s geometry-bearing parts, not its bare id', () => {
@@ -141,10 +168,13 @@ describe('LensPanel: isolating a rule resolves geometry-less assemblies to their
 
     click(ruleRow(container, 'Assemblies'));
 
+    // Append, not replace: the parts MUST be there (the bare assembly renders
+    // nothing), and the matched id rides along free because an id with no mesh
+    // never matches the renderer's whitelist anyway (#2680).
     assert.deepEqual(
       useViewerStore.getState().isolatedEntities,
-      new Set([PART_A, PART_B]),
-      'the isolation set must hold the renderable parts; the bare assembly id renders nothing',
+      new Set([PART_A, PART_B, ASSEMBLY]),
+      'the isolation set must hold the renderable parts; the bare assembly id alone renders nothing',
     );
   });
 
@@ -159,7 +189,7 @@ describe('LensPanel: isolating a rule resolves geometry-less assemblies to their
     assert.equal(isolation.ruleId, 'rule-assembly');
     assert.deepEqual(
       [...isolation.entityIds].sort((a, b) => a - b),
-      [PART_A, PART_B],
+      [ASSEMBLY, PART_A, PART_B],
       'the ownership record is compared set-wise against the channel by ruleIsolationOwnsChannel; recording the raw matches while pushing the expanded ones disowns the isolation',
     );
   });
@@ -170,7 +200,7 @@ describe('LensPanel: isolating a rule resolves geometry-less assemblies to their
     const container = render(<LensPanel onClose={() => {}} />);
 
     click(ruleRow(container, 'Assemblies'));
-    assert.deepEqual(useViewerStore.getState().isolatedEntities, new Set([PART_A, PART_B]), 'precondition: the first click isolates');
+    assert.deepEqual(useViewerStore.getState().isolatedEntities, new Set([PART_A, PART_B, ASSEMBLY]), 'precondition: the first click isolates');
 
     click(ruleRow(container, 'Assemblies'));
 
@@ -189,7 +219,7 @@ describe('LensPanel: isolating a rule resolves geometry-less assemblies to their
     const container = render(<LensPanel onClose={() => {}} />);
 
     click(ruleRow(container, 'Assemblies'));
-    assert.deepEqual(useViewerStore.getState().isolatedEntities, new Set([PART_A, PART_B]), 'precondition: the click isolates');
+    assert.deepEqual(useViewerStore.getState().isolatedEntities, new Set([PART_A, PART_B, ASSEMBLY]), 'precondition: the click isolates');
 
     // Turning the lens off runs the same releaseRuleIsolation ownership check.
     const card = container.querySelector<HTMLElement>(`div[data-tour="lens-card-${LENS.id}"]`);
@@ -212,6 +242,34 @@ describe('LensPanel: isolating a rule resolves geometry-less assemblies to their
       'a rule whose matches already own meshes must isolate exactly those ids',
     );
     assert.deepEqual(useViewerStore.getState().lensRuleIsolation?.entityIds, [WALL]);
+  });
+
+  it('keeps every matched id on a MIXED rule, where some resolve and some resolve to nothing', () => {
+    // The hole replace semantics leaves (#2680): the resolver bounds-checks
+    // against the type-visibility FILTERED mesh list, and
+    // TYPE_VISIBILITY_SEMANTIC_DEFAULTS starts spaces/spatialZones/openings/
+    // virtualElements OFF, so a rule matching a wall, an assembly AND a space
+    // resolves the first two, comes back non-empty, and the space silently
+    // vanishes from the isolation set. Nothing looks wrong at first (the space
+    // is hidden anyway); it goes wrong when the user turns spaces back on with
+    // the isolation still active and they stay hidden with no way to tell why.
+    // Carrying a mesh-less id is free: it never matches the renderer whitelist.
+    seedLens({ resolveHighlightIds: assemblyResolver });
+    const container = render(<LensPanel onClose={() => {}} />);
+
+    click(ruleRow(container, 'Level 1'));
+
+    const s = useViewerStore.getState();
+    assert.deepEqual(
+      s.isolatedEntities,
+      new Set([WALL, PART_A, PART_B, ASSEMBLY, HIDDEN_SPACE]),
+      'a matched id that resolves to nothing must survive alongside the ones that resolved',
+    );
+    assert.deepEqual(
+      [...(s.lensRuleIsolation?.entityIds ?? [])].sort((a, b) => a - b),
+      [ASSEMBLY, PART_A, PART_B, WALL, HIDDEN_SPACE].sort((a, b) => a - b),
+      'the ownership record must hold the same set that was pushed, or the release check disowns it',
+    );
   });
 
   it('keeps the raw ids when the resolver returns nothing, rather than isolating an empty set', () => {

--- a/apps/viewer/src/components/viewer/LensPanel.isolate.wiring.test.tsx
+++ b/apps/viewer/src/components/viewer/LensPanel.isolate.wiring.test.tsx
@@ -1,0 +1,241 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Clicking a rule row in the active lens isolates that rule's matches.
+ * Driven by rendering `LensPanel` and clicking the row a user would click,
+ * then reading the store, never by grepping the handler's source.
+ *
+ * The defect these cover: `handleIsolateRule` pushed the raw
+ * `lensRuleEntityIds` into the shared isolation channel. The renderer resolves
+ * `isolatedEntities` against MESH ids (viewportUtils' `buildRenderOptions` ->
+ * `isolatedIds`), so a rule matching an `IfcElementAssembly` (whose geometry
+ * hangs off its `IfcRelAggregates` parts, never off the assembly id itself)
+ * isolated an id that owns no mesh and the viewport went blank. Same family as
+ * #2531 (Viewport's resolver), #2660 (the advanced filter's "Isolate in 3D")
+ * and #1133 (assemblies are renderable through their parts).
+ *
+ * The lens-specific hazard is the OWNERSHIP RECORD: `lensRuleIsolation` stores
+ * the exact ids the panel pushed, and `releaseRuleIsolation` only clears the
+ * channel when `ruleIsolationOwnsChannel` finds the channel still holding
+ * exactly those ids. Recording the raw matches while pushing the expanded ones
+ * makes the lens permanently disown its own isolation: the un-isolate click
+ * leaves the model stuck. That is why the round-trip lives in its own test
+ * rather than as a trailing assertion.
+ *
+ * No models are seeded on purpose: with `models` empty and `ifcDataStore` null
+ * `useLens` returns before re-evaluating, so the seeded `lensRuleEntityIds`
+ * survives and the click exercises the handler with known inputs.
+ */
+
+import '@/test/setup-dom.js';
+import { after, afterEach, before, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { render, cleanup, click } from '@/test/render.js';
+import { useViewerStore } from '@/store';
+import type { Lens } from '@/store/slices/lensSlice';
+import { LensPanel } from './LensPanel.js';
+
+/** Global ids, the space `lensRuleEntityIds` is already in. */
+const ASSEMBLY = 4_000_042;
+const PART_A = 4_000_101;
+const PART_B = 4_000_102;
+const WALL = 4_000_500;
+
+const LENS: Lens = {
+  id: 'lens-under-test',
+  name: 'Test lens',
+  rules: [
+    {
+      id: 'rule-assembly',
+      name: 'Assemblies',
+      enabled: true,
+      criteria: { type: 'ifcType', ifcType: 'IfcElementAssembly' },
+      action: 'colorize',
+      color: '#ff0000',
+    },
+    {
+      id: 'rule-wall',
+      name: 'Walls',
+      enabled: true,
+      criteria: { type: 'ifcType', ifcType: 'IfcWall' },
+      action: 'colorize',
+      color: '#00ff00',
+    },
+  ],
+};
+
+let initialState: ReturnType<typeof useViewerStore.getState>;
+
+function seedLens(options: {
+  /** Viewport's aggregation resolver (#2531). Omitted = a renderer that has
+   *  not registered its camera callbacks yet. */
+  resolveHighlightIds?: (ids: number[]) => number[];
+  /** Pre-existing hides, to prove the round-trip restores them untouched. */
+  hiddenEntities?: Set<number>;
+} = {}) {
+  useViewerStore.setState({
+    savedLenses: [LENS],
+    activeLensId: LENS.id,
+    lensRuleCounts: new Map([['rule-assembly', 1], ['rule-wall', 1]]),
+    lensRuleEntityIds: new Map([['rule-assembly', [ASSEMBLY]], ['rule-wall', [WALL]]]),
+    lensRuleIsolation: null,
+    lensHiddenIds: new Set<number>(),
+    lensAppliedHiddenIds: [],
+    lensColorMap: new Map(),
+    lensAutoColorLegend: [],
+    hiddenEntities: options.hiddenEntities ?? new Set<number>(),
+    isolatedEntities: null,
+    // Empty federation: keeps `useLens` from recomputing lensRuleEntityIds.
+    models: new Map(),
+    activeModelId: null,
+    ifcDataStore: null,
+    cameraCallbacks: {
+      ...(options.resolveHighlightIds ? { resolveHighlightIds: options.resolveHighlightIds } : {}),
+    } as never,
+  });
+}
+
+/** The legend row for `ruleName`, matched the way a user finds it: by the
+ *  visible rule name on a clickable row. */
+function ruleRow(container: HTMLElement, ruleName: string): HTMLElement {
+  const rows = [...container.querySelectorAll<HTMLElement>('div[role="button"]')].filter(
+    (el) => el.textContent?.includes(ruleName),
+  );
+  assert.equal(rows.length, 1, `expected exactly one clickable legend row for ${JSON.stringify(ruleName)}, found ${rows.length}`);
+  return rows[0];
+}
+
+/** A resolver with the real one's contract: geometry-bearing ids pass through,
+ *  the geometry-less assembly is replaced by its parts and never by itself. */
+const assemblyResolver = (ids: number[]) =>
+  ids.flatMap((id) => (id === ASSEMBLY ? [PART_A, PART_B] : [id]));
+
+describe('LensPanel: isolating a rule resolves geometry-less assemblies to their parts', () => {
+  before(() => {
+    initialState = useViewerStore.getState();
+  });
+
+  afterEach(() => {
+    cleanup();
+    useViewerStore.setState(initialState, true);
+  });
+
+  after(() => {
+    useViewerStore.setState(initialState, true);
+  });
+
+  it('renders a clickable legend row per rule (guards the harness, not the feature)', () => {
+    seedLens({ resolveHighlightIds: assemblyResolver });
+    const container = render(<LensPanel onClose={() => {}} />);
+
+    // A count of 0 renders the row un-clickable (RuleRow's `isEmpty`), which
+    // would make every assertion below vacuously unreachable instead of red.
+    assert.equal(container.querySelectorAll('div[role="button"]').length, 2);
+  });
+
+  it('isolates the assembly\'s geometry-bearing parts, not its bare id', () => {
+    seedLens({ resolveHighlightIds: assemblyResolver });
+    const container = render(<LensPanel onClose={() => {}} />);
+
+    click(ruleRow(container, 'Assemblies'));
+
+    assert.deepEqual(
+      useViewerStore.getState().isolatedEntities,
+      new Set([PART_A, PART_B]),
+      'the isolation set must hold the renderable parts; the bare assembly id renders nothing',
+    );
+  });
+
+  it('records the ids it actually pushed, so the lens still owns the channel', () => {
+    seedLens({ resolveHighlightIds: assemblyResolver });
+    const container = render(<LensPanel onClose={() => {}} />);
+
+    click(ruleRow(container, 'Assemblies'));
+
+    const isolation = useViewerStore.getState().lensRuleIsolation;
+    assert.ok(isolation, 'the lens must record its isolation');
+    assert.equal(isolation.ruleId, 'rule-assembly');
+    assert.deepEqual(
+      [...isolation.entityIds].sort((a, b) => a - b),
+      [PART_A, PART_B],
+      'the ownership record is compared set-wise against the channel by ruleIsolationOwnsChannel; recording the raw matches while pushing the expanded ones disowns the isolation',
+    );
+  });
+
+  it('round-trips: clicking the isolated rule again restores the prior visibility exactly', () => {
+    const userHidden = new Set([9_000_001]);
+    seedLens({ resolveHighlightIds: assemblyResolver, hiddenEntities: userHidden });
+    const container = render(<LensPanel onClose={() => {}} />);
+
+    click(ruleRow(container, 'Assemblies'));
+    assert.deepEqual(useViewerStore.getState().isolatedEntities, new Set([PART_A, PART_B]), 'precondition: the first click isolates');
+
+    click(ruleRow(container, 'Assemblies'));
+
+    const s = useViewerStore.getState();
+    assert.equal(
+      s.isolatedEntities,
+      null,
+      'the un-isolate click must clear the channel; a mismatched ownership record leaves the model stuck isolated',
+    );
+    assert.equal(s.lensRuleIsolation, null, 'the claim must drop with the isolation');
+    assert.deepEqual(s.hiddenEntities, userHidden, 'the user\'s own hides must survive the round-trip untouched');
+  });
+
+  it('round-trips through lens deactivation too, not just the rule row', () => {
+    seedLens({ resolveHighlightIds: assemblyResolver });
+    const container = render(<LensPanel onClose={() => {}} />);
+
+    click(ruleRow(container, 'Assemblies'));
+    assert.deepEqual(useViewerStore.getState().isolatedEntities, new Set([PART_A, PART_B]), 'precondition: the click isolates');
+
+    // Turning the lens off runs the same releaseRuleIsolation ownership check.
+    const card = container.querySelector<HTMLElement>(`div[data-tour="lens-card-${LENS.id}"]`);
+    assert.ok(card, 'the lens card must render');
+    click(card);
+
+    assert.equal(useViewerStore.getState().isolatedEntities, null, 'deactivating the lens must release its isolation');
+    assert.equal(useViewerStore.getState().lensRuleIsolation, null);
+  });
+
+  it('leaves a geometry-bearing rule alone, so the fix does not broaden every isolation', () => {
+    seedLens({ resolveHighlightIds: assemblyResolver });
+    const container = render(<LensPanel onClose={() => {}} />);
+
+    click(ruleRow(container, 'Walls'));
+
+    assert.deepEqual(
+      useViewerStore.getState().isolatedEntities,
+      new Set([WALL]),
+      'a rule whose matches already own meshes must isolate exactly those ids',
+    );
+    assert.deepEqual(useViewerStore.getState().lensRuleIsolation?.entityIds, [WALL]);
+  });
+
+  it('keeps the raw ids when the resolver returns nothing, rather than isolating an empty set', () => {
+    // An assembly with neither geometry nor geometry-bearing parts resolves to
+    // nothing at all (expandToGeometryBearingIds drops it). Isolating the empty
+    // set would hide the ENTIRE model, strictly worse than the raw id.
+    seedLens({ resolveHighlightIds: () => [] });
+    const container = render(<LensPanel onClose={() => {}} />);
+
+    click(ruleRow(container, 'Assemblies'));
+
+    assert.deepEqual(useViewerStore.getState().isolatedEntities, new Set([ASSEMBLY]));
+    assert.deepEqual(useViewerStore.getState().lensRuleIsolation?.entityIds, [ASSEMBLY]);
+  });
+
+  it('keeps the raw ids when no renderer has registered a resolver yet', () => {
+    seedLens();
+    const container = render(<LensPanel onClose={() => {}} />);
+
+    click(ruleRow(container, 'Assemblies'));
+
+    assert.deepEqual(useViewerStore.getState().isolatedEntities, new Set([ASSEMBLY]));
+    // And that pre-resolution path must still round-trip.
+    click(ruleRow(container, 'Assemblies'));
+    assert.equal(useViewerStore.getState().isolatedEntities, null);
+  });
+});

--- a/apps/viewer/src/components/viewer/LensPanel.isolate.wiring.test.tsx
+++ b/apps/viewer/src/components/viewer/LensPanel.isolate.wiring.test.tsx
@@ -68,13 +68,14 @@ const LENS: Lens = {
       color: '#00ff00',
     },
     {
-      // Raw matches DIFFERENT from rule-assembly's, but the same set once
-      // resolved: the assembly resolves to its parts, the parts resolve to
-      // themselves. Exactly the collision the expansion widened into reach.
-      id: 'rule-parts',
-      name: 'Assembly parts',
+      // DIFFERENT criteria from rule-assembly, same matched entities: an
+      // ordinary coincidence in a real model (every assembly here is precast).
+      // Two rules landing on one id set is the only way the isolate toggle can
+      // be reached by a rule switch; it does not depend on the resolution.
+      id: 'rule-precast',
+      name: 'Precast',
       enabled: true,
-      criteria: { type: 'ifcType', ifcType: 'IfcBuildingElementPart' },
+      criteria: { type: 'property', propertySet: 'Pset_ConcreteElementGeneral', propertyName: 'Precast', operator: 'equals', propertyValue: 'TRUE' },
       action: 'colorize',
       color: '#ffff00',
     },
@@ -104,12 +105,14 @@ function seedLens(options: {
     savedLenses: [LENS],
     activeLensId: LENS.id,
     lensRuleCounts: new Map([
-      ['rule-assembly', 1], ['rule-wall', 1], ['rule-parts', 3], ['rule-mixed', 3],
+      ['rule-assembly', 1], ['rule-wall', 1], ['rule-precast', 1], ['rule-mixed', 3],
     ]),
     lensRuleEntityIds: new Map([
       ['rule-assembly', [ASSEMBLY]],
       ['rule-wall', [WALL]],
-      ['rule-parts', [ASSEMBLY, PART_A, PART_B]],
+      // The same matches as rule-assembly, reached by other criteria.
+      // Deliberately a fresh array, not a shared reference.
+      ['rule-precast', [ASSEMBLY]],
       ['rule-mixed', [WALL, ASSEMBLY, HIDDEN_SPACE]],
     ]),
     lensRuleIsolation: null,
@@ -258,23 +261,29 @@ describe('LensPanel: isolating a rule resolves geometry-less assemblies to their
     assert.deepEqual(useViewerStore.getState().lensRuleIsolation?.entityIds, [WALL]);
   });
 
-  it('switches to another rule that resolves to the SAME set without the toggle clearing it', () => {
+  it('switches to a DIFFERENT rule matching the same entities without the toggle clearing the channel', () => {
     // `isolateEntities` is a same-set TOGGLE (visibilitySlice.ts:176-194): fed
-    // the ids the channel already holds it CLEARS. So switching from the
-    // assembly rule to a rule whose DIFFERENT raw matches resolve to the same
-    // set un-isolated the model while the panel recorded the new rule as the
-    // owner of an isolation that no longer existed. Pre-existing for two rules
-    // with identical raw matches; the resolution widened it to an assembly
-    // rule versus a parts rule, which is an ordinary pair of lens rules.
+    // the ids the channel already holds it CLEARS. So switching from one rule
+    // to another whose criteria differ but whose matches coincide un-isolated
+    // the model, while the panel went on to record the new rule as the owner
+    // of an isolation that no longer existed, leaving the next release with an
+    // empty channel to disown.
+    //
+    // Scope, stated honestly: this is PRE-EXISTING and the resolution added in
+    // this PR does not widen it. Appending the raw matches unconditionally
+    // keeps an assembly rule ({assembly, ...parts}) and a parts rule
+    // ({...parts}) distinguishable, so only genuinely coincident matches
+    // collide -- which is why this fixture uses two rules that match the same
+    // entity by different criteria rather than an assembly/parts pair.
     seedLens({ resolveHighlightIds: assemblyResolver });
     const container = render(<LensPanel onClose={() => {}} />);
     const expected = new Set([PART_A, PART_B, ASSEMBLY]);
 
     click(ruleRow(container, 'Assemblies'));
-    assert.deepEqual(useViewerStore.getState().isolatedEntities, expected, 'precondition: rule A isolates the set');
+    assert.deepEqual(useViewerStore.getState().isolatedEntities, expected, 'precondition: the first rule isolates the set');
     assert.equal(useViewerStore.getState().lensRuleIsolation?.ruleId, 'rule-assembly');
 
-    click(ruleRow(container, 'Assembly parts'));
+    click(ruleRow(container, 'Precast'));
 
     const s = useViewerStore.getState();
     assert.deepEqual(
@@ -282,7 +291,7 @@ describe('LensPanel: isolating a rule resolves geometry-less assemblies to their
       expected,
       'switching rules must leave the model isolated over the set, not blank the channel via the toggle',
     );
-    assert.equal(s.lensRuleIsolation?.ruleId, 'rule-parts', 'the new rule must be recorded as the owner');
+    assert.equal(s.lensRuleIsolation?.ruleId, 'rule-precast', 'the new rule must be recorded as the owner');
     assert.deepEqual(
       [...(s.lensRuleIsolation?.entityIds ?? [])].sort((a, b) => a - b),
       [ASSEMBLY, PART_A, PART_B],
@@ -291,7 +300,7 @@ describe('LensPanel: isolating a rule resolves geometry-less assemblies to their
 
     // And the handover must leave the release path working: the new owner
     // still owns the channel, so its own re-click clears.
-    click(ruleRow(container, 'Assembly parts'));
+    click(ruleRow(container, 'Precast'));
     assert.equal(useViewerStore.getState().isolatedEntities, null, 'releasing the new owner must clear the channel');
     assert.equal(useViewerStore.getState().lensRuleIsolation, null);
   });

--- a/apps/viewer/src/components/viewer/LensPanel.tsx
+++ b/apps/viewer/src/components/viewer/LensPanel.tsx
@@ -1376,11 +1376,17 @@ export function LensPanel({ onClose }: LensPanelProps) {
     // owns an isolation that no longer exists -- and the next release, finding
     // an empty channel, would disown it silently.
     //
-    // Pre-existing (two rules matching identical raw ids always collided this
-    // way), but the resolution above WIDENS it: a rule matching an assembly
-    // and a rule matching that assembly's parts now land on the same resolved
-    // set where their raw matches differed. Release the channel first so the
-    // isolate call below always takes its isolate branch -- same
+    // This is PRE-EXISTING and the resolution above does not widen it: two
+    // rules whose criteria differ but whose matches coincide ("walls with a
+    // fire rating of 60" and "walls on level 2" over a model where those are
+    // the same walls) always collided this way, and appending the raw matches
+    // unconditionally keeps every other pair distinguishable -- an
+    // assembly-matching rule yields {assembly, ...parts} while a
+    // parts-matching rule yields {...parts}, sets that differ by the
+    // assembly's own id and cannot collapse onto each other.
+    //
+    // Release the channel first so the isolate call below always takes its
+    // isolate branch -- same
     // `ruleIsolationOwnsChannel` set-equality predicate the teardown path uses,
     // so both ends agree on when the channel holds a given set, and the
     // re-isolate re-runs the un-hide the toggle branch would have skipped.

--- a/apps/viewer/src/components/viewer/LensPanel.tsx
+++ b/apps/viewer/src/components/viewer/LensPanel.tsx
@@ -1340,10 +1340,23 @@ export function LensPanel({ onClose }: LensPanelProps) {
     // as SearchModal.text.tsx's commit and SearchModal.filter.tsx's "Isolate
     // in 3D" (#2660) do: a geometry-bearing id passes through untouched and
     // deduplicated, a geometry-less one is replaced by its geometry-bearing
-    // parts. When nothing resolves (renderer not registered yet, or the whole
-    // match has no geometry at all) the raw ids are kept: isolating an empty
-    // set hides the ENTIRE model, strictly worse than the pre-resolution
-    // behaviour.
+    // parts.
+    //
+    // The resolved ids are APPENDED to the raw matches, never substituted for
+    // them (#2680). The resolver bounds-checks against the type-visibility
+    // FILTERED mesh list, and TYPE_VISIBILITY_SEMANTIC_DEFAULTS starts
+    // `spaces`, `spatialZones`, `openings` and `virtualElements` all OFF
+    // (store/constants.ts) -- so a rule matching walls AND spaces (colouring
+    // spaces by area is an ordinary lens) resolves the walls, returns
+    // non-empty, and the spaces would silently drop out of the isolation set
+    // under replace semantics. Nothing looks wrong at first, because those
+    // types are hidden anyway; it goes wrong when the user turns spaces back
+    // on with the isolation still active and they stay hidden with no way to
+    // tell why. Carrying an id that owns no mesh is free: it simply never
+    // matches the renderer's whitelist. That also subsumes the
+    // nothing-resolved case (renderer not registered yet, or the whole match
+    // geometry-less), where the raw ids are all that is left -- and isolating
+    // an empty set would hide the ENTIRE model.
     //
     // #2660's second fallback -- walking IfcRelAggregates in the data store
     // when the resolver comes back empty because the parts are HIDDEN types
@@ -1354,12 +1367,12 @@ export function LensPanel({ onClose }: LensPanelProps) {
     // panel has no such gate, so isolating hidden-type parts would still
     // render nothing. Adding one is a feature, not this fix.
     const resolved = cameraCallbacks.resolveHighlightIds?.(matchingIds) ?? [];
-    const isolationIds = resolved.length > 0 ? resolved : matchingIds;
+    const isolationIds = [...new Set([...resolved, ...matchingIds])];
 
     isolateEntities(isolationIds);
     // Record ownership: rule id + the exact ids pushed into the channel, so a
     // later release can verify the channel still holds what the lens applied.
-    // These MUST be the resolved ids, not the raw matches: releaseRuleIsolation
+    // These MUST be the ids just isolated, not the raw matches: releaseRuleIsolation
     // compares this record set-wise against the channel
     // (ruleIsolationOwnsChannel), so recording the raw matches while pushing
     // the expanded ones makes the lens disown its own isolation and the

--- a/apps/viewer/src/components/viewer/LensPanel.tsx
+++ b/apps/viewer/src/components/viewer/LensPanel.tsx
@@ -1217,6 +1217,9 @@ export function LensPanel({ onClose }: LensPanelProps) {
   const showEntities = useViewerStore((s) => s.showEntities);
   const isolateEntities = useViewerStore((s) => s.isolateEntities);
   const clearIsolation = useViewerStore((s) => s.clearIsolation);
+  // Viewport's aggregation resolver (#2531): rule isolation runs a rule's
+  // matches through it so a geometry-less assembly isolates as its parts.
+  const cameraCallbacks = useViewerStore((s) => s.cameraCallbacks);
   // Ownership bookkeeping lives in the STORE (not component state/refs) so a
   // panel unmount/remount neither loses which hidden ids the lens owns nor
   // strands a rule isolation it can no longer release.
@@ -1327,11 +1330,42 @@ export function LensPanel({ onClose }: LensPanelProps) {
     const matchingIds = useViewerStore.getState().lensRuleEntityIds.get(ruleId);
     if (!matchingIds || matchingIds.length === 0) return;
 
-    isolateEntities(matchingIds);
+    // A geometry-less assembly (IfcElementAssembly, an IfcStair used as a
+    // container, ...) owns no mesh: its geometry hangs off the
+    // IfcRelAggregates parts, and the renderer resolves `isolatedEntities`
+    // against mesh ids directly (viewportUtils' buildRenderOptions ->
+    // `isolatedIds`). Isolating the bare matched id therefore blanks the view.
+    // Resolve through the Viewport channel #2531 added
+    // (`resolveHighlightIds`, backed by expandToGeometryBearingIds), exactly
+    // as SearchModal.text.tsx's commit and SearchModal.filter.tsx's "Isolate
+    // in 3D" (#2660) do: a geometry-bearing id passes through untouched and
+    // deduplicated, a geometry-less one is replaced by its geometry-bearing
+    // parts. When nothing resolves (renderer not registered yet, or the whole
+    // match has no geometry at all) the raw ids are kept: isolating an empty
+    // set hides the ENTIRE model, strictly worse than the pre-resolution
+    // behaviour.
+    //
+    // #2660's second fallback -- walking IfcRelAggregates in the data store
+    // when the resolver comes back empty because the parts are HIDDEN types
+    // -- is deliberately not replicated here, and `expandFilterRowsThroughAggregation`
+    // does not fit anyway (it consumes filter-result rows, while a lens rule
+    // hands over globalIds). That fallback only pays off next to a
+    // type-visibility gate that flips the parts' toggles back on; the lens
+    // panel has no such gate, so isolating hidden-type parts would still
+    // render nothing. Adding one is a feature, not this fix.
+    const resolved = cameraCallbacks.resolveHighlightIds?.(matchingIds) ?? [];
+    const isolationIds = resolved.length > 0 ? resolved : matchingIds;
+
+    isolateEntities(isolationIds);
     // Record ownership: rule id + the exact ids pushed into the channel, so a
     // later release can verify the channel still holds what the lens applied.
-    setLensRuleIsolation({ ruleId, entityIds: [...matchingIds] });
-  }, [isolateEntities, releaseRuleIsolation, setLensRuleIsolation]);
+    // These MUST be the resolved ids, not the raw matches: releaseRuleIsolation
+    // compares this record set-wise against the channel
+    // (ruleIsolationOwnsChannel), so recording the raw matches while pushing
+    // the expanded ones makes the lens disown its own isolation and the
+    // un-isolate click leaves the model stuck isolated.
+    setLensRuleIsolation({ ruleId, entityIds: [...isolationIds] });
+  }, [cameraCallbacks, isolateEntities, releaseRuleIsolation, setLensRuleIsolation]);
 
   // Safety net: if the lens got deactivated while the panel was unmounted
   // (e.g. a flavor switch cleared activeLensId), a recorded rule isolation

--- a/apps/viewer/src/components/viewer/LensPanel.tsx
+++ b/apps/viewer/src/components/viewer/LensPanel.tsx
@@ -1369,6 +1369,25 @@ export function LensPanel({ onClose }: LensPanelProps) {
     const resolved = cameraCallbacks.resolveHighlightIds?.(matchingIds) ?? [];
     const isolationIds = [...new Set([...resolved, ...matchingIds])];
 
+    // `isolateEntities` is a same-set TOGGLE (visibilitySlice.ts:176-194): if
+    // the channel already holds exactly these ids it CLEARS instead of
+    // isolating. Switching from rule A to a rule B that lands on the SAME set
+    // would therefore un-isolate the model while the record below claims B
+    // owns an isolation that no longer exists -- and the next release, finding
+    // an empty channel, would disown it silently.
+    //
+    // Pre-existing (two rules matching identical raw ids always collided this
+    // way), but the resolution above WIDENS it: a rule matching an assembly
+    // and a rule matching that assembly's parts now land on the same resolved
+    // set where their raw matches differed. Release the channel first so the
+    // isolate call below always takes its isolate branch -- same
+    // `ruleIsolationOwnsChannel` set-equality predicate the teardown path uses,
+    // so both ends agree on when the channel holds a given set, and the
+    // re-isolate re-runs the un-hide the toggle branch would have skipped.
+    // Clicking the SAME rule again still un-isolates: that path returned above.
+    if (ruleIsolationOwnsChannel(useViewerStore.getState().isolatedEntities, isolationIds)) {
+      clearIsolation();
+    }
     isolateEntities(isolationIds);
     // Record ownership: rule id + the exact ids pushed into the channel, so a
     // later release can verify the channel still holds what the lens applied.
@@ -1378,7 +1397,7 @@ export function LensPanel({ onClose }: LensPanelProps) {
     // the expanded ones makes the lens disown its own isolation and the
     // un-isolate click leaves the model stuck isolated.
     setLensRuleIsolation({ ruleId, entityIds: [...isolationIds] });
-  }, [cameraCallbacks, isolateEntities, releaseRuleIsolation, setLensRuleIsolation]);
+  }, [cameraCallbacks, clearIsolation, isolateEntities, releaseRuleIsolation, setLensRuleIsolation]);
 
   // Safety net: if the lens got deactivated while the panel was unmounted
   // (e.g. a flavor switch cleared activeLensId), a recorded rule isolation


### PR DESCRIPTION
## The defect

`handleIsolateRule` (LensPanel.tsx) isolated the raw `lensRuleEntityIds` for the clicked rule. The renderer resolves `isolatedEntities` against **mesh ids** directly (`viewportUtils.buildRenderOptions` -> `isolatedIds`), so a lens rule whose matches include an `IfcElementAssembly` (or any element whose geometry lives on its `IfcRelAggregates` parts rather than on itself) isolated an id that owns no mesh, and the viewport went blank.

Last member of the family fixed in #2531 (Viewport's `resolveHighlightIds`, backed by `expandToGeometryBearingIds`), `SearchModal.text.tsx`, `HierarchyPanel.tsx`, #2660 (the advanced filter's "Isolate in 3D") and #2680 (PropertiesPanel). Same #1133 root cause: an assembly is renderable only through its parts.

## The fix, in three parts

**1. Resolve.** Run the rule's matched ids through `cameraCallbacks.resolveHighlightIds` before isolating.

**2. Append, not replace.** The resolved ids are unioned with the raw matches (deduplicated, order stable). `resolveHighlightIds` bounds-checks against the type-visibility FILTERED mesh list, and `TYPE_VISIBILITY_SEMANTIC_DEFAULTS` (`store/constants.ts`) starts `spaces`, `spatialZones`, `openings` and `virtualElements` all OFF. Under replace semantics a rule matching walls AND spaces (colouring spaces by area is an ordinary lens) resolves the walls, returns non-empty, and the spaces silently drop out of the isolation set. Nothing looks wrong at first because those types are hidden anyway; it surfaces only when the user turns spaces back on with the isolation still active and they stay hidden with nothing to explain why. Carrying an id that owns no mesh is free: it never matches the renderer's whitelist. The union also subsumes the nothing-resolved case (renderer not registered yet, or the whole match geometry-less), so isolating an empty set, which would hide the entire model, stays impossible.

**3. Do not route a rule SWITCH through the isolate toggle.** `isolateEntities` is a same-set toggle (`visibilitySlice.ts:176-194`): fed the ids the channel already holds it returns `{ isolatedEntities: null }`. Isolating rule A over a set and then clicking a rule B that lands on the same set cleared the channel, after which the handler recorded B as owner of an isolation that no longer existed: the model reads un-isolated while the lens believes it is isolated, and the next release finds an empty channel and disowns it silently. The channel is now released first when it already holds the target set, using the same `ruleIsolationOwnsChannel` set-equality predicate the teardown path uses, so the isolate call always takes its isolate branch. Clicking the SAME rule again still un-isolates: that path returns earlier, untouched.

Scope of part 3, stated precisely: it is **pre-existing** and **this PR does not widen it**. It is reachable only when two rules whose criteria differ match the same entities ("walls with a fire rating of 60" and "walls on level 2" over a model where those coincide), which is plausible enough to be worth fixing. An earlier revision of this PR claimed the expansion widened it via assembly-versus-parts rules; that is true of replace semantics but false of the append this branch ships, since `matchingIds` is included unconditionally and {assembly, ...parts} can never equal {...parts}. The claim has been retracted from the code comment and the commit history.

### What made this one different: the ownership record

The lens does not own the isolation channel outright. `lensRuleIsolation` stores the **exact ids the panel pushed**, and `releaseRuleIsolation` clears the channel only when `ruleIsolationOwnsChannel` finds it still holding exactly those ids (otherwise the user's or the basket's own isolation would be wiped). So the record must move with the pushed set. The naive shape (expand what you isolate, record what you matched) makes the lens permanently disown its own isolation: the un-isolate click, the lens toggle and the delete path all fall through the ownership check and the model stays stuck isolated. `setLensRuleIsolation` therefore records `isolationIds`, and both round-trip paths are pinned by tests.

### Not replicated from #2660, on purpose

#2660's second fallback walks `IfcRelAggregates` in the data store when the resolver returns empty because the parts are HIDDEN types, then feeds the part types into the type-visibility gate. `expandFilterRowsThroughAggregation` does not fit here (it consumes filter-result rows; a lens rule hands over globalIds), and more importantly that fallback only pays off next to a type-visibility gate that flips the parts' toggles back on. LensPanel has no such gate, so isolating hidden-type parts would still render nothing. Documented in the handler rather than pretended closed.

## Tests (test-first, mutation-proven)

New `LensPanel.isolate.wiring.test.tsx`: renders `LensPanel`, clicks the legend row a user clicks, reads the store. No source-text assertions.

| state | pass | fail |
| --- | --- | --- |
| pre-fix (defect present) | 4 | 6 |
| fix | 10 | 0 |
| mutation: expand but record the raw matches | 5 | 5 |
| mutation: drop the resolution (`isolationIds = matchingIds`) | 4 | 6 |
| mutation: replace instead of append | 4 | 6 |
| mutation: collision guard removed | 9 | 1 |

Observed values. Pre-fix, `isolatedEntities` was `Set(1) { 4000042 }` (the bare assembly global id) where the parts were expected. Under expand-but-record-raw the round-trip test reads `Set { 4000101, 4000102 }` where `null` is expected, i.e. the "stuck isolated" regression. Under replace semantics the mixed-match test reads `Set(3) { 4000101, 4000102, 4000500 }` where `Set(5) { 4000042, 4000101, 4000102, 4000500, 4000700 }` is expected. With the collision guard removed the rule-switch test reads `null` where `Set(3) { 4000042, 4000101, 4000102 }` is expected, and it reds on its own subject assertion rather than on a precondition.

Covered: assembly expansion, the ownership record contents, the rule-row round trip (with a pre-existing user hide that must survive), the lens-deactivation round trip, a plain geometry-bearing rule (the fix must not broaden every isolation), a switch between two rules matching the same entities by different criteria, the mixed match (wall + assembly + hidden-type space), the empty-resolver fallback and the no-resolver-registered fallback.

## Verification (every exit code)

| command | exit |
| --- | --- |
| `pnpm install --frozen-lockfile` | 0 |
| `pnpm build` | 0 |
| `pnpm typecheck` | 0 |
| `pnpm lint` | 0 |
| `node scripts/check-source-text-assertions.mjs` | 0 |
| viewer lens tests (`LensPanel.isolate.wiring`, `LensPanel`, `lens-visibility-ownership`) | 0 (29/29) |
| full `apps/viewer` suite | 0 (4638 pass, 0 fail) |

apps/viewer only, no changeset. `PropertiesPanel.tsx`'s `handleIsolateGroupMembers` is #2680, untouched here.

Refs #2531, #2660, #2680, #1133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)