### PR TITLE
fix(export): StepExporter answered from the wrong record on an out-of-range source ref — and main documented it as safe

### DIFF
--- a/.changeset/step-exporter-line-reader-bounds.md
+++ b/.changeset/step-exporter-line-reader-bounds.md
@@ -1,0 +1,20 @@
+---
+"@ifc-lite/export": patch
+---
+
+`StepExporter`'s incidental line readers no longer answer from another entity's record when a source ref is out of range.
+
+`entityLineText` gated on `byteLength === 0`, on the stated grounds that an out-of-range ref degrades to "a clamped, empty decode, which is the same answer". It does not. `IfcSourceBytes.decodeUtf8` clamps an unaddressable range onto real file bytes, so the window that survives holds a DIFFERENT record. On a two-record source, giving `#1` the ref `(byteOffset: 0, byteLength: 9999)`:
+
+```
+getPropertySetName(#1)  = "SetA"      <- right, by luck: that pattern is unanchored
+getPropertyIdsInSet(#1) = [201, 202]  <- wrong: those are #2's members (#1's are [101, 102])
+```
+
+The `$`-anchored patterns (`getPropertyIdsInSet`, `getRelatedPropertySet`) match at the end of the CLAMPED window, i.e. against whatever record the file ends on. `retainSharedAtoms` then calls `skipIds.delete(atomId)` for every id returned, so a member list read out of the wrong record un-skips the wrong atoms.
+
+The readers are now gated on `isReadableSourceRef` (#2491), the same predicate the source-iteration pass already uses to decide whether a record's line is emitted at all — so the two passes agree, instead of one making decisions on behalf of a container the other had decided not to write. A record with an unreadable ref degrades to the shape the exporter already handles: nothing generated for it, nothing naming it.
+
+The defect is pre-existing, not introduced by #2398 — the same probe gives `[201, 202]` on the commit before it. What #2398 added was a docstring arguing the behaviour was safe for every out-of-range shape except a negative offset; that docstring, and the matching rationale in `source-ref-bounds.ts`, are corrected to the measured behaviour, in one place with the other citing it.
+
+Also pinned: the byte range's START. Advancing `byteOffset` by one while leaving the end alone previously passed every test in the package, because no reader parses anything from the record's first byte.

--- a/.changeset/step-exporter-source-guards.md
+++ b/.changeset/step-exporter-source-guards.md
@@ -2,7 +2,7 @@
 "@ifc-lite/export": patch
 ---
 
-Make the dead `if (!dataStore.source)` guards in `StepExporter`'s six line readers live, without changing an answer. `IfcDataStore.source` is a mandatory accessor — a model that kept no bytes carries `EMPTY_SOURCE_BYTES`, not `null` — so those guards never fired. They were also redundant where they sat: a zero-length range decodes to `''`, which fails every regex the readers below them run.
+Make the dead `if (!dataStore.source)` guards in `StepExporter`'s five line readers live, without changing an answer. `IfcDataStore.source` is a mandatory accessor — a model that kept no bytes carries `EMPTY_SOURCE_BYTES`, not `null` — so those guards never fired. They were also redundant where they sat: a zero-length range decodes to `''`, which fails every regex the readers below them run.
 
 `getRelatedEntities`, `getRelatedPropertySet`, `getPropertySetName`, `getElementQuantityName` and `getPropertyIdsInSet` now share one `entityLineText` reader whose check is on the entity's BYTE RANGE rather than on `source`. Strictly equivalent, verified by mutation: swapping the range check back for the old guard leaves every test in the package passing.
 

--- a/packages/export/src/entity-line-text-bounds.test.ts
+++ b/packages/export/src/entity-line-text-bounds.test.ts
@@ -1,0 +1,166 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `StepExporter.entityLineText` — the byte range the incidental line readers
+ * (`getPropertySetName`, `getPropertyIdsInSet`, …) decode.
+ *
+ * Two things were unpinned here, and they are different failures:
+ *
+ * 1. **The range's START.** Advancing `byteOffset` by one while leaving the
+ *    end where it is — the record's line minus its leading `#` — passed all
+ *    699 runnable tests in this package. Nothing any reader parses lives in
+ *    the first byte: every pattern they run is either unanchored or anchored
+ *    at `$`, and the express id is supplied by the caller rather than read
+ *    out of the text. So no existing case can see the start move.
+ *
+ * 2. **Out-of-range refs.** `IfcSourceBytes.decodeUtf8` CLAMPS a range it
+ *    cannot address, and a clamped window is still a window over real file
+ *    bytes. The readers therefore answered from another record rather than
+ *    answering nothing — see `source-ref-bounds.ts` for the measured account
+ *    of both directions, which is not restated here.
+ *
+ * The fixtures below are built through `CompactEntityIndexBuilder`, the same
+ * index the real producers build, rather than by mutating refs in place: a
+ * `CompactEntityIndex` serves `EntityRef` objects out of an LRU over typed
+ * arrays, so an in-place edit survives only until that entry is rebuilt.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  asSourceBytes,
+  CompactEntityIndexBuilder,
+  type IfcDataStore,
+} from '@ifc-lite/parser';
+import { StepExporter } from './step-exporter.js';
+
+/**
+ * The private line readers, named. These are the unit under test: no PUBLIC
+ * path is sensitive to the range's start (that is finding 1 above), so a
+ * behavioural test alone cannot pin it.
+ */
+type LineReaders = {
+  entityLineText(entityId: number): string | null;
+  getPropertySetName(psetId: number): string | null;
+  getPropertyIdsInSet(psetId: number): number[];
+};
+
+const SET_A = "#1=IFCPROPERTYSET('0setA0000000000000000',$,'SetA',$,(#101,#102));";
+const SET_B = "#2=IFCPROPERTYSET('0setB0000000000000000',$,'SetB',$,(#201,#202));";
+
+/**
+ * A two-record source. `ranges` overrides an entity's `(byteOffset,
+ * byteLength)` to model a corrupt index over an intact file.
+ */
+function storeOf(ranges?: Map<number, [number, number]>): IfcDataStore {
+  const encoder = new TextEncoder();
+  const lines: Array<[number, string, string]> = [
+    [1, 'IFCPROPERTYSET', SET_A],
+    [2, 'IFCPROPERTYSET', SET_B],
+  ];
+  const builder = new CompactEntityIndexBuilder(lines.length);
+  const byType = new Map<string, number[]>();
+  const parts: Uint8Array[] = [];
+  let offset = 0;
+  for (const [id, type, text] of lines) {
+    const encoded = encoder.encode(text);
+    const range = ranges?.get(id) ?? [offset, encoded.byteLength];
+    builder.add(id, type, range[0], range[1]);
+    if (!byType.has(type)) byType.set(type, []);
+    byType.get(type)!.push(id);
+    parts.push(encoded);
+    offset += encoded.byteLength;
+  }
+
+  const source = new Uint8Array(offset);
+  let position = 0;
+  for (const part of parts) {
+    source.set(part, position);
+    position += part.byteLength;
+  }
+
+  return {
+    fileSize: offset,
+    schemaVersion: 'IFC4',
+    entityCount: lines.length,
+    parseTime: 0,
+    source: asSourceBytes(source),
+    entityIndex: { byId: builder.build(), byType },
+  } as unknown as IfcDataStore;
+}
+
+function readersOf(ranges?: Map<number, [number, number]>): LineReaders {
+  return new StepExporter(storeOf(ranges)) as unknown as LineReaders;
+}
+
+describe('entityLineText byte range', () => {
+  /**
+   * The START pin. `entityLineText` must decode the record's line from its
+   * FIRST byte, and the only assertion that can see that is one over the
+   * whole decoded text — hence the equality rather than a reader's answer.
+   *
+   * RED on `byteOffset + 1` (start advanced, end left alone), the mutation
+   * that otherwise passes every test in the package.
+   */
+  it('decodes the record from its first byte, not one byte in', () => {
+    const readers = readersOf();
+    expect(readers.entityLineText(1)).toBe(SET_A);
+    expect(readers.entityLineText(2)).toBe(SET_B);
+  });
+
+  /**
+   * The END pin, stated as the answer rather than the text: `#1`'s member
+   * list is `#1`'s, whatever the window does past its close.
+   */
+  it("reads a mid-file record's own member list, not the next record's", () => {
+    expect(readersOf().getPropertyIdsInSet(1)).toEqual([101, 102]);
+  });
+
+  /**
+   * An overrunning END is NOT benign. `(0, 9999)` for `#1` clamps to EOF, so
+   * the `$`-anchored member-list pattern matches at the end of the CLAMPED
+   * window — the file's last record. Before the readers were gated on
+   * `isReadableSourceRef` this returned `[201, 202]`, `#2`'s members, and
+   * `retainSharedAtoms` un-skipped them on `#1`'s behalf.
+   */
+  it('answers nothing for a ref whose end runs past the source', () => {
+    const readers = readersOf(new Map([[1, [0, 9999]]]));
+    expect(readers.getPropertyIdsInSet(1)).toEqual([]);
+    expect(readers.getPropertySetName(1)).toBeNull();
+    expect(readers.entityLineText(1)).toBeNull();
+  });
+
+  /**
+   * The same for the file's LAST record, where the clamp happened to land on
+   * exactly the right text and the old answer was right by luck. The
+   * source-iteration pass drops such a record anyway (`isReadableSourceRef`),
+   * so an answer here only made the two passes disagree.
+   */
+  it('answers nothing for an overrunning ref on the last record too', () => {
+    const readers = readersOf(new Map([[2, [SET_A.length, 9999]]]));
+    expect(readers.getPropertySetName(2)).toBeNull();
+    expect(readers.getPropertyIdsInSet(2)).toEqual([]);
+  });
+
+  /**
+   * A ref starting before the source. This one is green on `main` too, and
+   * for a reason worth recording rather than for the gate: `CompactEntityIndex`
+   * keeps offsets in a `Uint32Array`, so `-2` comes back out as 4294967294 and
+   * is out of range at the far end instead. A negative offset is not
+   * representable through the index these readers consult — which is why the
+   * REACHABLE bad shape is the overrun above, not this one. Over a plain-`Map`
+   * index (the test doubles in `sourceless-store-export.test.ts`) `-2` survives
+   * as `-2`, floors to 0, and used to name `#2` `'SetA'`; the gate rejects that
+   * too.
+   */
+  it('answers nothing for a ref that starts before the source', () => {
+    const readers = readersOf(new Map([[2, [-2, SET_A.length]]]));
+    expect(readers.getPropertySetName(2)).toBeNull();
+  });
+
+  /** A zero-length ref is the canonical "no source line" marker. */
+  it('answers nothing for a zero-length ref', () => {
+    expect(readersOf(new Map([[1, [0, 0]]])).entityLineText(1)).toBeNull();
+  });
+});

--- a/packages/export/src/source-ref-bounds.ts
+++ b/packages/export/src/source-ref-bounds.ts
@@ -34,10 +34,41 @@
  * nothing that names it is written, and it does not appear in the file — the
  * same outcome as the source-less store the server path builds.
  *
- * This predicate is deliberately NOT applied to the incidental readers
- * (`getRelatedEntities`, `getPropertySetName`, …). Those decode a range and
- * match a pattern in it; a clamped, empty decode already yields "no match",
- * which is the same answer and needs no gate of its own.
+ * ## Why an out-of-range ref is never "no match"
+ *
+ * This predicate was once exempted from the incidental readers
+ * (`getRelatedEntities`, `getPropertySetName`, `getPropertyIdsInSet`, …) on
+ * the grounds that "a clamped, empty decode already yields no match, which is
+ * the same answer". That is false, and it is false in BOTH directions the
+ * range can leave the source. A clamp does not empty a range; it moves an
+ * endpoint onto a real file byte, and the window that survives still holds
+ * somebody else's record. Measured on a two-record source
+ * (`#1=IFCPROPERTYSET(...,(#101,#102));#2=IFCPROPERTYSET(...,(#201,#202));`):
+ *
+ * - **Negative offset.** `(-2, n)` floors to 0 and decodes from the START OF
+ *   THE FILE: `getPropertySetName(#2)` answers `'SetA'` — `#1`'s name.
+ * - **Overrunning end.** `(0, 9999)` for `#1` clamps to EOF, so the window
+ *   ends at the file's LAST record. `getPropertySetName(#1)` answers `'SetA'`
+ *   — right, by luck, because that pattern is unanchored — while
+ *   `getPropertyIdsInSet(#1)` answers `[201, 202]`, which are `#2`'s members.
+ *   The readers whose patterns are `$`-anchored match at the end of the
+ *   CLAMPED window, i.e. against whatever record the file happens to end on.
+ *
+ * A confidently wrong answer, not "no match". The overrun is also the shape
+ * that is REACHABLE — it is the #2491 corrupt-store shape above, a ref
+ * claiming bytes the source cannot serve. The negative offset is not, twice
+ * over: `OVERLAY_BYTE_OFFSET = -1` (`mutations/src/store-editor.ts`) is the
+ * only negative offset in the repo and every site that writes it pairs it
+ * with `byteLength: 0`; and `CompactEntityIndex` — the index those readers
+ * consult — keeps offsets in a `Uint32Array`, so a negative value cannot
+ * round-trip through it at all. The two-record measurements above were taken
+ * over a plain-`Map` index, which can hold one.
+ *
+ * The readers are therefore gated on this predicate too (`entityLineText` in
+ * `step-exporter.ts`), which also makes them agree with the source-iteration
+ * pass: that pass already skips a record whose ref fails this test, so an
+ * exempt reader was answering questions about a record the same export had
+ * decided not to write.
  */
 
 import type { ExportEntityRef } from './entity-iteration.js';

--- a/packages/export/src/sourceless-store-export.test.ts
+++ b/packages/export/src/sourceless-store-export.test.ts
@@ -177,10 +177,11 @@ describe('StepExporter over a store with no source bytes', () => {
   });
 
   /**
-   * Bounding control for the six byte readers (`getRelatedEntities`,
+   * Bounding control for the five byte readers (`getRelatedEntities`,
    * `getRelatedPropertySet`, `getPropertySetName`, `getElementQuantityName`,
-   * `getPropertyIdsInSet`, `replaceEntityAttribute`), which now share
-   * `entityLineText` and its byte-range check.
+   * `getPropertyIdsInSet`), which share `entityLineText` and its byte-range
+   * check. (#2398's description named a sixth, `replaceEntityAttribute`; that
+   * method was deleted by #2469 and never shared this reader.)
    *
    * Editing `Pset_WallCommon` must replace the original: exactly one
    * `IFCPROPERTYSET` line named `Pset_WallCommon` in the output, and neither
@@ -271,7 +272,7 @@ describe('StepExporter over a store with no source bytes', () => {
     // ConnectionGeometry, RelatingElement, RelatedElement): RelatedElement is
     // a single mandatory reference, so once it is excluded the relationship
     // itself carries no valid meaning and must be withheld — see
-    // `filterHiddenRefsFromRelationshipLine` (#2398).
+    // `filterHiddenRefsFromRelationshipLine` (#2580, extended by #2637).
     const connection = view.createEntity('IFCRELCONNECTSELEMENTS', [
       "'guidC'",
       null,

--- a/packages/export/src/step-exporter.ts
+++ b/packages/export/src/step-exporter.ts
@@ -74,7 +74,7 @@ import { serializeNominalValue } from './declared-property-type.js';
  * or the {@link IfcSourceBytes} accessor (#2183). Replaces the direct
  * `safeUtf8Decode(source, …)` calls this file used to make: `decodeUtf8` is
  * SAB-safe in exactly the same way, and routing through the accessor is what
- * lets `IfcDataStore.source` change shape without touching these eight reads.
+ * lets `IfcDataStore.source` change shape without touching these four reads.
  */
 function decodeRange(src: Uint8Array | IfcSourceBytes, start: number, end: number): string {
   return asSourceBytes(src).decodeUtf8(start, end);
@@ -255,9 +255,17 @@ export class StepExporter {
   private ownerHistoryFallbackRef: string | undefined;
   /** Per-host cache of an element's own OwnerHistory ref (`#id` or null). */
   private ownerHistoryByEntity = new Map<number, string | null>();
+  /**
+   * "Can this record's line actually be read out of this store's source?"
+   * (`source-ref-bounds.ts`, #2491). Built once — `dataStore` is assigned in
+   * the constructor and never reassigned — so the gates outside `export`'s
+   * closure share one predicate instead of rebuilding it per call.
+   */
+  private isReadableSourceRef: ReturnType<typeof createSourceRefReader>;
 
   constructor(dataStore: IfcDataStore, mutationView?: MutablePropertyView) {
     this.dataStore = dataStore;
+    this.isReadableSourceRef = createSourceRefReader(dataStore.source);
     this.mutationView = mutationView || null;
     const maxExisting = this.findMaxExpressId();
     const overlayWatermark = typeof mutationView?.peekNextExpressId === 'function'
@@ -1662,7 +1670,7 @@ export class StepExporter {
     // Readability rather than presence, as everywhere else (#2491). A clamped
     // decode would match nothing here, so this is tidiness rather than a bug —
     // but the gates in this file agree on one predicate now.
-    if (entityRef && createSourceRefReader(this.dataStore.source)(entityRef)) {
+    if (entityRef && this.isReadableSourceRef(entityRef)) {
       const entityText = decodeRange(
         this.dataStore.source,
         entityRef.byteOffset,
@@ -2364,31 +2372,35 @@ export class StepExporter {
    * path. That is why an early return is safe HERE and is NOT safe at the
    * visible-only closure in `export` — see the comment there.
    *
-   * ## Why `byteLength === 0` and not `isReadableSourceRef`
+   * ## Why `isReadableSourceRef` and not `byteLength === 0`
    *
-   * `source-ref-bounds.ts` (#2491) has the stronger predicate and states it is
-   * deliberately not applied to these incidental readers, on the grounds that
-   * "a clamped, empty decode already yields no match, which is the same
-   * answer". Measured, that rationale holds for every out-of-range shape
-   * EXCEPT a negative offset. `clampRange` floors a negative start at 0, so a
-   * ref at `(byteOffset: -2, byteLength: n)` decodes from the START OF THE
-   * FILE: driving `getPropertySetName` with such a ref for `#2` returns the
-   * name of `#1`. That is not "no match", it is a confidently wrong answer.
+   * An out-of-range ref does NOT degrade to "no match" here. `decodeUtf8`
+   * clamps the range it cannot address, and the clamped window is still a
+   * window over real file bytes — so these readers answer from somebody
+   * ELSE's record. `source-ref-bounds.ts` (#2491) carries the measured
+   * account of both shapes and of why "a clamped, empty decode already yields
+   * no match" is false; it is not restated here, because an argument kept in
+   * two files is an argument that has to stay true in two files.
    *
-   * It stays a `byteLength === 0` check anyway, because that shape is not
-   * representable: the only negative offset in the repo is
-   * `OVERLAY_BYTE_OFFSET = -1` (`mutations/src/store-editor.ts:30`), which is
-   * written at exactly two sites (`effective-index.ts:282,304`) and one
-   * constructor (`store-editor.ts:166`), each pairing it with `byteLength: 0`
-   * — already `null` here — and none of them writes into
-   * `dataStore.entityIndex.byId`, which is the only map this reads. Tightening
-   * to `isReadableSourceRef` would therefore change no reachable answer while
-   * breaking this change's no-op premise, so it belongs in whatever change
-   * makes a negative offset representable, not here.
+   * The consequence specific to THIS site is that the wrong answer is acted
+   * on. `retainSharedAtoms` un-skips every id `getPropertyIdsInSet` returns,
+   * so a member list read out of the wrong record un-skips the wrong atoms;
+   * and the source-iteration pass already refuses to emit a record whose ref
+   * fails `isReadableSourceRef` (see the `continue` in `export`), so before
+   * this gate these readers were making decisions on behalf of a container
+   * that the same export had decided not to write. Gating them on the same
+   * predicate is what makes the two passes agree.
+   *
+   * The degradation is the one the exporter already handles: a record with no
+   * emittable bytes, generating nothing and named by nothing. It costs one
+   * answer that used to be right by luck — an overrunning ref on the file's
+   * LAST record clamps back to exactly that record's text — but that record
+   * is one the emission pass drops anyway, so keeping the answer only kept
+   * the disagreement.
    */
   private entityLineText(entityId: number): string | null {
     const entityRef = this.dataStore.entityIndex.byId.get(entityId);
-    if (!entityRef || entityRef.byteLength === 0) return null;
+    if (!entityRef || !this.isReadableSourceRef(entityRef)) return null;
     return decodeRange(
       this.dataStore.source,
       entityRef.byteOffset,


### PR DESCRIPTION
## The claim, and the probe that refutes it

`step-exporter.ts` documented its byte-range gate like this (#2398, merged — this is `main`'s code):

> "Measured, that rationale holds for every out-of-range shape EXCEPT a negative offset."

It does not. An **overrunning end** is equally dangerous, and unlike the negative offset it is *reachable*.

`IfcSourceBytes.decodeUtf8` **clamps** a range it cannot address. A clamp does not empty the range — it moves an endpoint onto a real file byte, and the window that survives still holds somebody else's record. Probe on a two-record source, `#1` given `byteOffset: 0, byteLength: 9999`:

```
overrun name(#1)    = "SetA"        <- right, by luck: that pattern is unanchored
overrun propIds(#1) = [201,202]     <- WRONG: these are #2's members (#1's are [101,102])
isReadableSourceRef(#1) = false
```

The readers whose patterns are `$`-anchored match at the end of the **clamped** window, i.e. against whatever record the file ends on:

```js
entityText.match(/\(\s*(#[^)]+)\s*\)\s*\)\s*;$/)   // getPropertyIdsInSet
entityText.match(/,\s*#(\d+)\s*\)\s*;$/)           // getRelatedPropertySet
```

That is a confidently wrong answer, exactly what the docstring reserved for negative offsets. Downstream, `retainSharedAtoms` does `skipIds.delete(atomId)` for every id `getPropertyIdsInSet` returns, so a member list read out of the wrong record un-skips the wrong atoms.

The reasoning was also inverted. The docstring argued the dangerous shape was the one `isReadableSourceRef` **accepts**; measured, the dangerous shape is the one it **rejects**:

```
last isReadableSourceRef(#2) = false
last name(#2)    = "SetB"          <- entityLineText answers anyway
last propIds(#2) = [201,202]
```

So the claim that tightening to `isReadableSourceRef` "would change no reachable answer" was wrong on both counts.

**This defect is pre-existing, not introduced by #2398.** Running the same probe against `79503d334^` — the commit before #2398 — gives byte-identical output, `[201,202]` included. #2398 collapsed five reads into one `entityLineText` and left every reader's regex untouched. What it added was prose documenting the behaviour away.

The negative-offset direction the docstring did argue about is genuinely unrepresentable, and for a stronger reason than the one given: `CompactEntityIndex` keeps offsets in a `Uint32Array`, so `-2` cannot round-trip through the index those readers consult at all. The probe above used a plain-`Map` index, which can hold one.

## What changed

**1. The readers are gated on `isReadableSourceRef`.** This is the decision the review asked for, taken on the following evidence rather than on the aesthetics of one predicate:

- The source-iteration pass in `export` **already** does `if (!isReadableSourceRef(entityRef)) continue;`. A record whose ref is unreadable does not get its line written. Before this change, the incidental readers were making decisions — which atoms to keep, which pset is being replaced — on behalf of a container that the same export had decided not to emit. Two paths, one question, two answers.
- The only answer the tightening costs is one that was right *by luck*: an overrunning ref on the file's **last** record clamps back to exactly that record's text. That record is dropped by the emission pass anyway, so keeping the answer only preserved the disagreement.
- The degradation is the shape the exporter already handles and has tests for: a record with no emittable bytes — nothing generated for it, nothing naming it, no dangling ref.
- Measured cost: **zero existing tests change answer.** 705 passed / 30 skipped, against 699 / 30 before, the difference being the six new cases.

`isReadableSourceRef` is now built once in the constructor rather than per call, which also removes the per-call `createSourceRefReader` allocation at the owner-history read.

**2. The rationale lives in one file.** The measured account of both out-of-range directions is in `source-ref-bounds.ts`, which owns the predicate. `step-exporter.ts`'s `entityLineText` docstring cites it and adds only what is specific to that call site (the `retainSharedAtoms` consequence and the agreement with the emission pass). An argument kept in two files is an argument that has to stay true in two files.

**3. The byte range's START is pinned.** Mutating `entityLineText`'s decode to `byteOffset + 1` while leaving the end alone — the record's line minus its leading `#` — passed **all 699** runnable tests in the package. Nothing any reader parses lives in the first byte: every pattern is unanchored or `$`-anchored, and the express id is supplied by the caller rather than read out of the text. `entity-line-text-bounds.test.ts` now asserts the decoded text equals the record's line, which is the only assertion that can see the start move.

RED evidence, that mutation applied to this branch:

```
× decodes the record from its first byte, not one byte in
Tests  1 failed | 704 passed | 30 skipped (735)
```

(For the record, the *whole-window* shift — `byteOffset + 1` at both ends — is already pinned; it turns 17 tests red. It is the start alone that nothing sees.)

The two overrun cases were shown RED against unmodified `main`:

```
× answers nothing for a ref whose end runs past the source
    expected [] to deeply equal [ 201, 202 ]
× answers nothing for an overrunning ref on the last record too
    expected 'SetB' to be null
```

**4. Three factual prose errors on `main`, and one misattribution:**

| Where | Said | Is |
|---|---|---|
| `sourceless-store-export.test.ts:180` | six readers, incl. `replaceEntityAttribute` | five — that method was deleted by #2469 |
| `.changeset/step-exporter-source-guards.md:6` | "six line readers" | five (its own body already lists five) |
| `step-exporter.ts:77` | "without touching these **eight** reads" | four — #2398 collapsed five into one |
| `sourceless-store-export.test.ts:274` | `filterHiddenRefsFromRelationshipLine` (#2398) | #2580, extended by #2637 |

## Verification

- `pnpm --filter @ifc-lite/export test` — **705 passed, 30 skipped**. One file, `lod1-generator.test.ts`, is excluded in this environment only: it fails to resolve an unbuilt `@ifc-lite/wasm` and does not touch this diff.
- `pnpm --filter @ifc-lite/export typecheck` — OK (51 test files)
- `node scripts/check-source-text-assertions.mjs` — OK (6 allowlisted, 0 new)
- `node scripts/check-test-wiring.mjs` — OK
- `pnpm exec oxlint packages/export/src` — no new findings

No assertion weakened, no fixture adjusted, no skip added, no allowlist entry, no ratchet raised.

## References

- #2398 — where the false rationale was written. The defect predates it; the prose does not.
- #2668 — draft, and was about to copy the same claim into `source-ref-bounds.ts` ("An overrunning END, by contrast, is genuinely benign"). Corrected on that branch in `df2f09efc`, prose only: the argument stays in `source-ref-bounds.ts` there too, so the two branches do not each carry a copy. It remains a draft.
- #2491 — introduced `isReadableSourceRef` and `source-ref-bounds.ts`.
