### PR TITLE
fix(scripts): flush stdout before exiting, so a failing lint log is not truncated

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -453,6 +453,16 @@ jobs:
       # untrustworthyExitReason is pinned in the same file.
       - name: Check unused-locals output classification
         run: node --test scripts/lib/unused-locals-classify.test.mjs
+      # check-lint-ran.mjs buffered oxlint's whole output, wrote it, then
+      # process.exit()'d. On a PIPE — every CI log — stdout is asynchronous, so
+      # the exit discarded most of the write: a 120k-line failing run reached
+      # the log as ~1k lines, cut mid-diagnostic, with no summary and no error
+      # line. A genuine eslint(no-control-regex) failure was diagnosed off such
+      # a log as "pre-existing warnings, not ours". A TTY or a file kept
+      # everything, so hand-testing never showed it — this drives the gate
+      # through a pipe and asserts the bytes that arrive.
+      - name: Check lint gate survives a piped stdout
+        run: node --test scripts/check-lint-ran.test.mjs
       # The server-parse root-attribute table (attr_indices.rs) is generated
       # from @ifc-lite/parser's SCHEMA_REGISTRY — the SAME table the in-browser
       # parse resolves names against. Guard that the committed file is in sync

--- a/scripts/check-lint-ran.mjs
+++ b/scripts/check-lint-ran.mjs
@@ -16,6 +16,19 @@
  * So the file count is asserted, not assumed. If a future refactor moves the
  * source, renames a directory or breaks the config's globs, this fails loudly
  * instead of quietly going back to linting zero files.
+ *
+ * NOTHING in this file may call `process.exit()`. On a pipe — which is every
+ * CI log and every `pnpm lint | tee` — Node's stdout is asynchronous, and
+ * `process.exit()` tears the process down with the queued write still queued.
+ * oxlint's output is far larger than the pipe buffer, so the log stopped
+ * mid-diagnostic with no summary and no error line: a real
+ * `eslint(no-control-regex)` failure was read off such a log as "pre-existing
+ * warnings, not ours". Set `process.exitCode` and let the process end on its
+ * own instead; Node then drains stdout first, at any output size, on a pipe,
+ * a file or a TTY alike. `fs.writeSync(1, …)` would also flush, but fd 1 is
+ * non-blocking when it is a pipe, so a large enough write can throw EAGAIN —
+ * i.e. it regresses precisely as output grows, which is the direction this
+ * output only ever moves.
  */
 
 import { spawnSync } from 'node:child_process';
@@ -48,7 +61,8 @@ const TARGETS = [
  *  unanchored first-match read report one file and fail a healthy run. */
 const SUMMARY_RE = /Finished in [^\n]*? on (\d[\d,]*) files with (\d+) rules/g;
 
-/** Run oxlint over one directory and return what it says it did. */
+/** Run oxlint over one directory and return what it says it did, or `null` if
+ *  the run cannot be trusted — the caller then stops with exit code 1. */
 function lint(dir) {
   // `pnpm exec` rather than `npx`: npx silently DOWNLOADS the latest oxlint when
   // the workspace copy is missing, so a broken install would lint with an
@@ -61,7 +75,7 @@ function lint(dir) {
 
   if (result.error) {
     console.error(`lint: could not run oxlint on ${dir}: ${result.error.message}`);
-    process.exit(1);
+    return null;
   }
 
   const output = `${result.stdout ?? ''}${result.stderr ?? ''}`;
@@ -70,7 +84,7 @@ function lint(dir) {
   const finished = [...output.matchAll(SUMMARY_RE)].at(-1);
   if (!finished) {
     console.error(`lint: oxlint printed no summary for ${dir}, so it is not clear it ran at all`);
-    process.exit(1);
+    return null;
   }
   return {
     files: Number(finished[1].replace(/,/g, '')),
@@ -79,31 +93,41 @@ function lint(dir) {
   };
 }
 
-let totalFiles = 0;
-let ruleCount = 0;
-let failed = 0;
-const short = [];
+/** Returns the exit code. Every path RETURNS it — see the header: an exit code
+ *  assigned to `process.exitCode` lets Node drain stdout, `process.exit()`
+ *  does not. */
+function main() {
+  let totalFiles = 0;
+  let ruleCount = 0;
+  let failed = 0;
+  const short = [];
 
-for (const { dir, min } of TARGETS) {
-  const { files, rules, status } = lint(dir);
-  totalFiles += files;
-  ruleCount = Math.max(ruleCount, rules);
-  if (status !== 0) failed = status;
-  if (files < min) short.push({ dir, files, min });
-  if (rules === 0) {
-    console.error(`lint: oxlint ran with zero rules enabled on ${dir}, so it checked nothing`);
-    process.exit(1);
+  for (const { dir, min } of TARGETS) {
+    const run = lint(dir);
+    if (run === null) return 1; // lint() has already said why
+    const { files, rules, status } = run;
+    totalFiles += files;
+    ruleCount = Math.max(ruleCount, rules);
+    if (status !== 0) failed = status;
+    if (files < min) short.push({ dir, files, min });
+    if (rules === 0) {
+      console.error(`lint: oxlint ran with zero rules enabled on ${dir}, so it checked nothing`);
+      return 1;
+    }
   }
+
+  if (short.length > 0) {
+    console.error('lint: a lint target shrank past its floor, which is how this gate goes');
+    console.error('      quiet — the config globs no longer match the source there:\n');
+    for (const { dir, files, min } of short) {
+      console.error(`      ${dir}: ${files} files (expected at least ${min})`);
+    }
+    return 1;
+  }
+
+  if (failed !== 0) return failed;
+  console.log(`lint: ${totalFiles.toLocaleString()} files across ${TARGETS.length} targets, ${ruleCount} rules, no errors.`);
+  return 0;
 }
 
-if (short.length > 0) {
-  console.error('lint: a lint target shrank past its floor, which is how this gate goes');
-  console.error('      quiet — the config globs no longer match the source there:\n');
-  for (const { dir, files, min } of short) {
-    console.error(`      ${dir}: ${files} files (expected at least ${min})`);
-  }
-  process.exit(1);
-}
-
-if (failed !== 0) process.exit(failed);
-console.log(`lint: ${totalFiles.toLocaleString()} files across ${TARGETS.length} targets, ${ruleCount} rules, no errors.`);
+process.exitCode = main();

--- a/scripts/check-lint-ran.test.mjs
+++ b/scripts/check-lint-ran.test.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Regression test for check-lint-ran.mjs losing its output on a pipe.
+ *
+ * The defect: the gate buffered oxlint's whole output, `process.stdout.write`
+ * it, and then `process.exit(status)`. On a PIPE — which is every CI log —
+ * Node's stdout is asynchronous, so the exit tore the process down with most
+ * of that write still queued. A run producing 120k lines reached the log as
+ * ~1k lines, cut off mid-diagnostic, with no summary line and no error line:
+ * nothing in the log said the lint had failed, or why. A real CI lint failure
+ * (one `eslint(no-control-regex)` error among 226 warnings) was read off such
+ * a log as "pre-existing warnings elsewhere, not ours". It was ours.
+ *
+ * The same run against a TTY or a regular file kept everything, which is why
+ * hand-testing never showed it — so the test drives the script through a pipe
+ * specifically, and asserts on the BYTES that arrive, not on the exit code
+ * (the exit code was always right; the log was the casualty).
+ *
+ * Run: node --test scripts/check-lint-ran.test.mjs
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, chmodSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const GATE = join(HERE, 'check-lint-ran.mjs');
+const ROOT = join(HERE, '..');
+
+/** One diagnostic line per source finding, repeated until the output is far
+ *  past any pipe buffer (~64KiB on Linux and macOS). 40k lines per target is
+ *  ~3MiB, the order of magnitude a failing oxlint run over this repo produces. */
+const LINES_PER_TARGET = 40_000;
+const TAIL_MARKER = 'LAST-DIAGNOSTIC-LINE';
+
+/**
+ * A stand-in for `pnpm exec oxlint …` that prints a realistically large body,
+ * then oxlint's summary line, then exits non-zero the way a lint error does.
+ *
+ * It writes with `fs.writeSync` rather than `process.stdout.write` on purpose:
+ * a shim written the natural way reproduces the very bug under test one level
+ * down — its own output is truncated before the gate ever sees it — and the
+ * test then passes or fails for the wrong reason.
+ */
+function makeFakeOxlint(status) {
+  const dir = mkdtempSync(join(tmpdir(), 'check-lint-ran-'));
+  const bin = join(dir, 'bin');
+  mkdirSync(bin);
+  const shim = join(bin, 'pnpm');
+  writeFileSync(
+    shim,
+    `#!/usr/bin/env node
+const fs = require('node:fs');
+const target = process.argv[process.argv.length - 1];
+let out = '';
+for (let i = 0; i < ${LINES_PER_TARGET}; i++) {
+  out += '  x eslint(no-control-regex): Unexpected control character ' + target + ' ' + i + '\\n';
+}
+out += '${TAIL_MARKER} ' + target + '\\n';
+out += 'Finished in 120ms on 2000 files with 300 rules using 8 threads.\\n';
+fs.writeSync(1, out);
+process.exitCode = ${status};
+`,
+    'utf8',
+  );
+  chmodSync(shim, 0o755);
+  return { dir, bin };
+}
+
+/** Run the gate with its stdout on a PIPE (spawnSync captures through one). */
+function runGate(binDir) {
+  return spawnSync(process.execPath, [GATE], {
+    cwd: ROOT,
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+    env: { ...process.env, PATH: `${binDir}:${process.env.PATH}` },
+  });
+}
+
+test('a failing lint keeps its whole output when stdout is a pipe', () => {
+  const { dir, bin } = makeFakeOxlint(1);
+  try {
+    const run = runGate(bin);
+    const stdout = run.stdout ?? '';
+
+    // The gate must still fail — the fix must not swallow the status.
+    assert.equal(run.status, 1, `expected exit 1, got ${run.status}\n${run.stderr}`);
+
+    // One summary per target. This is what vanished: the truncated log ended
+    // roughly 1% in, so a reader saw diagnostics and no verdict.
+    const summaries = stdout.match(/Finished in [^\n]*? on [\d,]+ files with \d+ rules/g) ?? [];
+    assert.equal(summaries.length, 3, `expected 3 oxlint summaries, got ${summaries.length}`);
+
+    // And the last line before each summary, so this cannot pass on a log that
+    // dropped the middle and happened to keep the tail.
+    const markers = stdout.match(new RegExp(TAIL_MARKER, 'g')) ?? [];
+    assert.equal(markers.length, 3, `expected 3 tail markers, got ${markers.length}`);
+
+    // Byte-exact: every diagnostic line of every target arrived. Asserting the
+    // count rather than "more than a pipe buffer" keeps the test honest if the
+    // output grows or the buffer size differs between platforms.
+    const diagnostics = stdout.match(/eslint\(no-control-regex\)/g) ?? [];
+    assert.equal(diagnostics.length, LINES_PER_TARGET * 3);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('a clean lint still reports its own summary line through a pipe', () => {
+  const { dir, bin } = makeFakeOxlint(0);
+  try {
+    const run = runGate(bin);
+    assert.equal(run.status, 0, `expected exit 0, got ${run.status}\n${run.stderr}`);
+    // 2,000 files per target from the shim, three targets.
+    assert.match(run.stdout, /lint: 6,000 files across 3 targets, 300 rules, no errors\./);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/scripts/xmatch/run.mjs
+++ b/scripts/xmatch/run.mjs
@@ -252,6 +252,15 @@ async function main() {
     pairs,
   };
 
+  // `report()` prints a block per corpus pair, so stdout here holds far more
+  // than a pipe buffer — and on a pipe (every CI log) stdout is asynchronous.
+  // A bare `process.exit()` tears the process down with that remainder still
+  // queued, cutting the log off mid-report without the verdict line, which is
+  // the only part anyone reads. So exit from the write CALLBACK: writes are
+  // ordered, so it fires only once everything before it has reached the pipe.
+  // Setting `process.exitCode` and returning would flush too, but this run
+  // holds a live IfcAPI, and an immediate exit is what keeps a lingering
+  // handle from parking the job instead of ending it.
   report(scorecard);
   if (SELF_TEST) {
     const broken = harnessBroken || pairs.some((pair) => pair.fixtureFailures.length > 0);
@@ -261,14 +270,15 @@ async function main() {
           ? 'FAIL — the harness cannot be trusted'
           : 'PASS — all three mutants rejected on every pair, on per-pair clauses alone'
       }\n`,
+      () => process.exit(broken ? 1 : 0),
     );
-    process.exit(broken ? 1 : 0);
+    return;
   }
   if (WRITE) {
     writeFileSync(SCORECARD, `${JSON.stringify(scorecard, replacer, 2)}\n`);
     process.stdout.write(`\nwrote ${SCORECARD}\n`);
   }
-  process.exit(failed ? 1 : 0);
+  process.stdout.write('', () => process.exit(failed ? 1 : 0));
 }
 
 /** Durations are wall clock and would churn the committed artifact on every

--- a/tools/world-gym/determinism-check.mjs
+++ b/tools/world-gym/determinism-check.mjs
@@ -171,16 +171,24 @@ async function main() {
     perSeed: results.map(({ seed, family, identical, byteLength }) => ({ seed, family, identical, byteLength })),
   };
 
+  // The summary carries a perSeed row for every seed, so on a pipe — every CI
+  // log — it is far past the pipe buffer, and stdout on a pipe is asynchronous.
+  // `process.exit()` on the next line would discard whatever has not drained,
+  // leaving a log that stops mid-JSON with no verdict at all. Exit from the
+  // write CALLBACK instead: writes are ordered, so it fires only once the JSON
+  // has reached the pipe, and the exit stays immediate (this run generates
+  // models through the WASM kernel; waiting on a natural exit could park it).
   if (saltFailures.length > 0) {
     process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
     process.stderr.write(`SALT INVARIANTS FAILED: ${saltFailures.map((f) => f.why).join('; ')}\n`);
-    process.exit(1);
+    process.stdout.write('', () => process.exit(1));
+    return;
   }
 
   process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
   if (failures.length > 0) {
     process.stderr.write(`DETERMINISM CHECK FAILED: ${failures.length}/${seedCount} seeds produced non-identical output across two runs.\n`);
-    process.exit(1);
+    process.stdout.write('', () => process.exit(1));
   } else {
     process.stderr.write(`DETERMINISM CHECK PASSED: ${seedCount}/${seedCount} seeds byte-identical across two runs (${delayMs}ms apart).\n`);
   }


### PR DESCRIPTION
`scripts/check-lint-ran.mjs` buffers oxlint's whole output, `process.stdout.write`s it, then `process.exit(status)`. On a **pipe** — which is every CI log and every `pnpm lint | tee` — Node's stdout is asynchronous, so `process.exit()` tears the process down with most of that write still queued.

## The concrete cost

A CI Lint job failed on **one** `eslint(no-control-regex)` error among 226 warnings. Its log cut off mid-diagnostic and jumped straight to `ELIFECYCLE` — no summary line, and critically **no visible error**. Reading that log, the failure was diagnosed as pre-existing warnings elsewhere and not ours. It was ours. Because every lint failure in this repo is read through this script, the same truncation misleads every one of those diagnoses.

## Reproduction

A fake `oxlint` on `PATH` emitting 40,000 diagnostic lines per target (~3 MiB total), a tail marker, oxlint's summary line, then a non-zero exit:

**Piped** (`node scripts/check-lint-ran.mjs | cat > out.txt`), before the fix:

```
exit=1
stdout lines:      965      # of 120,006
summary lines present: 0
marker present: 0
--- last 120 bytes ---
ontrol character apps 963
  x eslint(no-control-regex): Unexpected control character apps 964
  x eslint(no-control-rege     <- cut mid-line
```

**TTY** (same binary, run under `script(1)`), before the fix:

```
exit=1
stdout lines:   120,006
summary lines present: 3
marker present: 3
```

Identical code, identical input; only the descriptor differs. That asymmetry is why hand-testing never showed it — Node's stdout is synchronous for files and TTYs and asynchronous only for pipes.

After the fix, the piped run matches the TTY run byte for byte (120,006 lines, 3 summaries, exit still 1).

Side note from building the reproduction: the first fake oxlint was written the natural way (`process.stdout.write(out); process.exit(1)`) and reproduced the bug one level down — the gate received 122 of its 40,000 lines. The shim in the committed test uses `fs.writeSync` for that reason, documented inline.

## The fix, and why this one

`process.exitCode` + return, letting the process end on its own. Node then drains stdout before exiting, at **any** output size, on a pipe, a file or a TTY alike — and it covers `console.error` too, which is where this gate's own verdict lines go.

The alternatives were weighed and rejected for the main gate:

- `fs.writeSync(1, …)` — fd 1 is **non-blocking** when it is a pipe, so a large enough write can throw `EAGAIN`. It regresses precisely as output grows, which is the only direction this output moves.
- awaiting the write callback — works (it is used in the two secondary files below), but it only covers the stream you attach it to, and leaves the `process.exit()` shape in place for the next edit to copy.

`lint()` now returns `null` instead of exiting, and the top-level flow moved into a `main()` that returns the exit code. No status semantics changed: every previous `process.exit(n)` is the same `n` returned.

## Same shape elsewhere — what was checked

Enumerated every file under `scripts/` and `tools/` that combines a raw `process.stdout/stderr.write` with `process.exit(` — 41 files with raw writes, 30 of them also calling `process.exit`, each inspected at the call site.

**Fixed here** (bulk write immediately followed by `process.exit`, and both are CI gates whose logs get read):

- `scripts/xmatch/run.mjs` — `report(scorecard)` prints a block per corpus pair, then `process.exit(failed ? 1 : 0)`. Run by `xmatch-fixture.yml`.
- `tools/world-gym/determinism-check.mjs` — a `perSeed` JSON row per seed, then `process.exit(1)`. Run by `moonshot.yml`.

Both hold live WASM / `IfcAPI` state, where an immediate exit is plausibly load-bearing against a lingering handle parking the job. Converting them to `process.exitCode` would risk turning a fast failure into a hang, so they exit from the **write callback** instead — writes are ordered, so it fires only once everything before it has reached the pipe, and the exit stays immediate. Verified empirically that both the trailing-content and the zero-length (`write('', cb)`) forms flush the full 40k-line backlog through a pipe.

**Deliberately left:**

- `tools/world-gym/oracle-validate.mjs` — already uses `process.exitCode` after its bulk `process.stdout.write(stdout)`. Correct as-is.
- `scripts/verify-esm-entrypoints.mjs`, `scripts/check-*.mjs` (api-surface, changesets, generated, git-lfs, source-text-assertions, test-wiring, tla-chunk-await, unbounded-frame-wait, unused-locals, wasm-disposal), `scripts/typecheck-tests.mjs` — these `process.exit` after `console.log`/`console.error` of a bounded handful of lines, well under a pipe buffer. Not the identical shape, and converting them means restructuring control flow rather than a one-line change.
- The `main().catch(err => { write(stack); process.exit(1) })` tail shared by the `tools/world-gym/*` and `scripts/moonshot/**` runners — a single short stack trace, always under the buffer.
- `scripts/moonshot/b52-foreign-ifc/*.mjs`, `scripts/moonshot/b55-*`, `tools/plato/scalar-codemod.mjs`, `tools/world-gym/{run-pilot,channel-report,labeler,generator,benchmark/*}.mjs` — their bulk `process.stdout.write` is the **last** statement, with no `process.exit` after it, so the process ends naturally and the write drains.
- `scripts/collab-demo.mjs`, `scripts/collab-demo-3d.mjs` — `setTimeout(() => process.exit(code), 500)`; local demos, and the delay already covers the drain.
- `scripts/test-ids-corpus.mjs` — line-at-a-time progress writes interleaved with awaits, not a bulk write.

## Test

The repo has a `node --test` harness for `scripts/` (`typecheck-tests.test.mjs`, `check-server-bin-targets.test.mjs`, `lib/unused-locals-classify.test.mjs`), each wired individually into the `node-tests` job. `scripts/check-lint-ran.test.mjs` follows that pattern: it puts a fake `oxlint` on `PATH`, spawns the gate with stdout on a **pipe**, and asserts on the bytes that arrive — three oxlint summaries, three tail markers, and all 120,000 diagnostic lines — plus that the exit status is still 1. A second case pins the clean path.

Wired into `.github/workflows/test.yml` (`node-tests`); `scripts/**` is already in the `frontend` path filter, so the job fires on changes to the gate.

RED / GREEN, run against the committed test:

```
# with scripts/check-lint-ran.mjs restored from main:
not ok 1 - a failing lint keeps its whole output when stdout is a pipe
    expected 3 oxlint summaries, got 0
ok 2 - a clean lint still reports its own summary line through a pipe
# pass 1  # fail 1

# with the fix applied:
ok 1 - a failing lint keeps its whole output when stdout is a pipe
ok 2 - a clean lint still reports its own summary line through a pipe
# pass 2  # fail 0
```

Test 2 passing in both columns is itself the diagnosis: the success path already fell through to a natural exit, so only the failure path ever lost its output — the failure path being the only one anyone reads a log for.

## Gates

- `node scripts/check-lint-ran.mjs` against the real repo, piped: exit 0, 4,464 lines delivered, all three summaries, `lint: 3,118 files across 3 targets, 98 rules, no errors.`
- `node --test scripts/check-lint-ran.test.mjs`: 2/2.
- `oxlint` on every changed file: 0 warnings, 0 errors.
- `node scripts/check-changesets.mjs`, `check-test-wiring.mjs`, `check-source-text-assertions.mjs`: pass.
- `node --check` on all three changed `.mjs` files, and `test.yml` parses with the new step present.
- `pnpm lint` as a whole fails locally at `check-unused-locals.mjs` with "these packages do not compile standalone" listing **all 30** workspace packages — an unbuilt local tree (no `pnpm build`, no WASM), unrelated to this change, which touches no TypeScript. Stated rather than claimed green.

No changeset: `check-changesets.mjs` validates existing changesets but does not require one, and its own header states the honest answer for a tooling-only change with no publishable package is no changeset at all.
