### PR TITLE
fix(geometry): project the kernel's near-coplanar band onto the plane normal

### DIFF
--- a/.changeset/kernel-near-band-normal-projection.md
+++ b/.changeset/kernel-near-band-normal-projection.md
@@ -1,0 +1,31 @@
+---
+'@ifc-lite/wasm': patch
+---
+
+Fix the exact CSG kernel welding genuinely separate surfaces together in models
+placed far from the project origin. The kernel's near-coplanar band
+(`near_band_from_extent`) sized itself from ONE scalar extent, the max
+|coordinate| over all three axes of both operands, and then compared that band
+against a PERPENDICULAR distance to a specific plane. A signed plane distance is
+`dot(v - p, n)`, so each axis's f32 rounding noise enters it weighted by that
+axis's normal component and an axis orthogonal to the normal contributes
+nothing; collapsing to the max therefore sized the band from an axis the plane
+never sees.
+
+A georeferenced model 10 km out in X, cut by a Z-normal plane, got a ~2.4 mm
+band derived entirely from the X magnitude where the real f32 rounding step in Z
+is the ~122 um floor. Surfaces a genuine 2 mm apart fell inside it, were
+reconciled as flush, and thin cuts collapsed: the same 2 mm recess that cuts
+correctly at the origin returned the uncut slab 10 km out (volume
+0.3000030517580399 instead of 0.29968), i.e. the recess vanished from the
+result.
+
+The band is now kept PER AXIS and projected onto the plane's own normal,
+`sum_i |n_i| * extent_i * 2^-22`, floored at the unchanged `8 * SNAP_GRID` snap
+scatter envelope. This is the formulation already adopted for the CSG clipper's
+plane epsilon (`csg/plane_eps.rs`), the clash narrow phase
+(`packages/clash/src/contact/narrow-phase.ts`) and the section cutter
+(`packages/drawing-2d/src/section-cutter.ts`), not a fourth one. Comparisons are
+made in the `|n|`-scaled space, so no normal is normalised and no square root is
+taken: determinism (byte-identical native == wasm) is unchanged, as is behaviour
+at the origin.

--- a/packages/clash/src/contact/narrow-phase.ts
+++ b/packages/clash/src/contact/narrow-phase.ts
@@ -12,7 +12,7 @@ import type { AABB, Mesh, Vec3 } from "./types.js";
  * f32-ULP scale factor for a "worst-case" single-precision coordinate: for a
  * value with magnitude in `[2, 4)` the true float32 ULP is `2^-22`, and for
  * larger magnitudes the ULP only grows. Same `2^-22` term (and reasoning) as
- * `near_band_from_extent` in `rust/geometry/src/kernel/mesh_bridge.rs` and
+ * `near_band_from_extent` in `rust/geometry/src/kernel/near_band.rs` and
  * `precisionFloor` in `engine-ts/narrow.ts` — kept local rather than shared
  * because plane-distance tolerance and penetration-depth tolerance are
  * different jobs, even though both derive from the same f32 ingestion floor.

--- a/packages/clash/src/engine-ts/narrow.ts
+++ b/packages/clash/src/engine-ts/narrow.ts
@@ -20,7 +20,7 @@ export interface NarrowResult {
  * f32-ULP scale factor for a "worst-case" single-precision coordinate: for a
  * value with magnitude in `[2, 4)` the true float32 ULP is `2^-22`, and for
  * larger magnitudes the ULP only grows. Same `2^-22` term (and reasoning) as
- * `near_band_from_extent` in `rust/geometry/src/kernel/mesh_bridge.rs` — see
+ * `near_band_from_extent` in `rust/geometry/src/kernel/near_band.rs` — see
  * that function's doc for the derivation; kept here rather than shared
  * because the two live in different language runtimes.
  */

--- a/rust/clash/src/narrow.rs
+++ b/rust/clash/src/narrow.rs
@@ -32,7 +32,7 @@ pub struct NarrowResult {
 /// f32-ULP scale factor for a "worst-case" single-precision coordinate: for a
 /// value with magnitude in `[2, 4)` the true float32 ULP is `2^-22`, and for
 /// larger magnitudes the ULP only grows. Same `2^-22` term (and reasoning) as
-/// `near_band_from_extent` in `rust/geometry/src/kernel/mesh_bridge.rs` — see
+/// `near_band_from_extent` in `rust/geometry/src/kernel/near_band.rs` — see
 /// that function's doc for the derivation; kept here rather than shared
 /// because the two crates serve different callers.
 const F32_ULP_SCALE: f64 = 1.0 / 4_194_304.0; // 2^-22

--- a/rust/geometry/src/clash_solid.rs
+++ b/rust/geometry/src/clash_solid.rs
@@ -51,7 +51,8 @@
 
 use crate::clash_contact_axes::{dot3, gate_axes};
 use crate::kernel::arrangement::Tri;
-use crate::kernel::mesh_bridge::{intersection_tris, near_band_from_extent};
+use crate::kernel::mesh_bridge::intersection_tris;
+use crate::kernel::near_band::near_band_from_extent;
 use crate::mesh::Mesh;
 
 /// Multiple of the kernel's near-coplanar band above which the intersection

--- a/rust/geometry/src/csg/plane_eps.rs
+++ b/rust/geometry/src/csg/plane_eps.rs
@@ -76,7 +76,7 @@
 //! # Why not `near_band_from_extent`
 //!
 //! Despite sharing the `2^-22` term, `near_band_from_extent`
-//! (`kernel/mesh_bridge.rs`) is not reused here: its floor (`8*SNAP_GRID`
+//! (`kernel/near_band.rs`) is not reused here: its floor (`8*SNAP_GRID`
 //! ~= 1.22e-4) is sized for the exact kernel's snap grid and is only overtaken
 //! past ~512 m, so at building extents it would flatten the epsilon 122x
 //! looser.
@@ -89,7 +89,7 @@ use super::{ClipResult, Plane, Triangle};
 /// f32-ULP scale factor for a "worst-case" single-precision coordinate: for a
 /// value with magnitude in `[2, 4)` the true float32 ULP is `2^-22`, and for
 /// larger magnitudes the ULP only grows. Same `2^-22` term (and reasoning) as
-/// `near_band_from_extent` in `kernel/mesh_bridge.rs` and `F32_ULP_SCALE` in
+/// `NearBand` in `kernel/near_band.rs` and `F32_ULP_SCALE` in
 /// `packages/clash/src/contact/narrow-phase.ts` — kept local rather than
 /// shared because plane-distance tolerance and penetration-depth tolerance are
 /// different jobs, even though both derive from the same f32 ingestion floor.

--- a/rust/geometry/src/csg/world_frame_tests.rs
+++ b/rust/geometry/src/csg/world_frame_tests.rs
@@ -8,8 +8,11 @@
 //! |coordinate| over all three axes plus the plane point: a georeferenced
 //! model 10 km out in X, cut by a roughly-Z-normal plane, got a ~2.4 mm
 //! epsilon from the irrelevant X magnitude and collapsed thin flush cuts.
-//! That code never merged, but the kernel's `near_band_from_extent` callers
-//! still take the operand extent as max-over-axes, so the corpus pins the
+//! That code never merged; the kernel's near-coplanar band carried the same
+//! max-over-axes shape and DID reach production, which is what
+//! `a_2mm_recess_cuts_identically_10km_out_in_x` caught. The band now
+//! projects its per-axis extents onto the plane under test
+//! (`kernel/near_band.rs`), and this corpus stays as the live guard on the
 //! invariant the class keeps violating: a boolean's result must not depend
 //! on how far along an ORTHOGONAL axis the operands sit (up to that axis's
 //! own f32 noise).
@@ -73,17 +76,13 @@ fn a_2mm_recess_cuts_at_the_origin() {
     );
 }
 
-// KNOWN-FAILING on the live max-over-axes near band: asserts the CORRECT
-// behaviour. Measured on this code: the far placement returns volume
-// 0.3000030517580399 — the full slab, the 2 mm recess VANISHED — because
-// `near_band_from_extent` reads ~2.4 mm from the irrelevant 10 km X
-// magnitude and welds the cutter's bottom face onto the host top plane.
-// This is exactly the thin-flush-cut collapse #2598 described, live in the
-// kernel's shared band today. When the band is projected onto the plane
-// normal this stops panicking and the `should_panic` fails: remove the
-// attribute (and this comment) in that PR.
+// The live regression guard for the normal-projected near band. It was
+// KNOWN-FAILING under `#[should_panic]` until the band stopped reading the
+// irrelevant 10 km X magnitude: on the max-over-axes form the far placement
+// returns volume 0.3000030517580399, the full slab with the 2 mm recess
+// WELDED AWAY. Mutating the projection back to max-over-axes still reproduces
+// exactly that.
 #[test]
-#[should_panic(expected = "world-frame corpus")]
 fn a_2mm_recess_cuts_identically_10km_out_in_x() {
     let far = recess_volume(WorldFrameCase::FarBaked, THIN_DEPTH);
     assert!(

--- a/rust/geometry/src/kernel/arrangement/classify.rs
+++ b/rust/geometry/src/kernel/arrangement/classify.rs
@@ -181,16 +181,18 @@ fn on_surface_tri(c: [f64; 3], t: &Tri) -> Option<[f64; 3]> {
     point_in_tri_proj(c, t, n).then_some(n)
 }
 
-/// Per-triangle near-coplanar-flush test (see [`near_on_surface_normal`]); `band2`
-/// is the squared perpendicular plane-gap tolerance.
-fn near_on_surface_tri(c: [f64; 3], t: &Tri, band2: f64) -> Option<[f64; 3]> {
+/// Per-triangle near-coplanar-flush test (see [`near_on_surface_normal`]); the
+/// plane-gap tolerance is resolved from `band` against THIS triangle's own
+/// normal, so an operand offset along an axis this face does not face cannot
+/// widen it.
+fn near_on_surface_tri(c: [f64; 3], t: &Tri, band: &NearBand) -> Option<[f64; 3]> {
     let n = cross3(sub_f64(t[1], t[0]), sub_f64(t[2], t[0]));
     let nn = n[0] * n[0] + n[1] * n[1] + n[2] * n[2];
     if nn <= 0.0 || !nn.is_finite() {
         return None; // degenerate t
     }
-    let d = dot3(sub_f64(c, t[0]), n);
-    if (d * d) / nn > band2 {
+    let d = dot3(sub_f64(c, t[0]), n); // perp_dist · |n|, as `scaled_band2` is
+    if d * d > band.scaled_band2(n, nn) {
         return None; // c not within the snap band of t's plane
     }
     point_in_tri_proj(c, t, n).then_some(n)
@@ -200,9 +202,10 @@ fn on_surface_normal(c: [f64; 3], others: &[Tri]) -> Option<[f64; 3]> {
     others.iter().find_map(|t| on_surface_tri(c, t))
 }
 
-/// Canonical near-coplanar band formula (see [`near_on_surface_normal`]),
-/// defined once in `mesh_bridge` next to the `SNAP_GRID` it is sized from.
-use super::super::mesh_bridge::near_band_from_extent;
+/// Canonical near-coplanar band (see [`near_on_surface_normal`]): the
+/// `SNAP_GRID` scatter envelope plus the operands' per-axis extents projected
+/// onto the plane under test, defined once in `near_band`.
+use super::super::near_band::{NearBand, near_band_from_extent};
 
 /// The NEAR-coplanar analogue of [`on_surface_normal`], used ONLY for a
 /// sub-triangle whose parent face had a near-coplanar overlap with the other
@@ -224,49 +227,45 @@ use super::super::mesh_bridge::near_band_from_extent;
 /// plane-gap admitted (the `band` test); the in-plane containment still uses the
 /// EXACT `orient2d_any`. `band` is an absolute power-of-two multiple of `SNAP_GRID`
 /// (≈ the 2-operand scatter envelope) widened only for far-from-origin operands
-/// (coarser f32 import) — always THREE orders below the smallest real feature edge
-/// (~0.2 m), so a genuinely-distinct parallel face (a thin slab's two surfaces)
+/// (coarser f32 import) — and only along the axes the tested face's normal weighs,
+/// since [`NearBand`] projects the per-axis extents onto that normal: a 10 km X
+/// offset leaves a Z-normal face at the floor instead of opening it to ~2.4 mm and
+/// welding separate surfaces (`csg/world_frame_tests.rs`). Always THREE orders
+/// below the smallest real feature edge (~0.2 m), so a distinct parallel face
 /// can never be within it. All FMA-free f64 over input coords ⇒ byte-identical
 /// native==wasm. GATED on the near-coplanar-parent flag, so a transversal cut
 /// (every pinned box−box manifest face) never reaches it.
 fn near_on_surface_normal(c: [f64; 3], others: &[Tri]) -> Option<[f64; 3]> {
-    let mut extent = 1.0f64;
-    for &x in &c {
-        extent = extent.max(x.abs());
-    }
-    for t in others {
-        for v in t {
-            for &x in v {
-                extent = extent.max(x.abs());
-            }
-        }
-    }
-    let band2 = near_band_from_extent(extent).powi(2);
-    others.iter().find_map(|t| near_on_surface_tri(c, t, band2))
+    let mut band = NearBand::default();
+    band.observe_point(&c);
+    band.observe_tris(others);
+    others.iter().find_map(|t| near_on_surface_tri(c, t, &band))
 }
 
 /// BVH-accelerated equivalent of `on_surface_normal(c, a).is_some() ||
 /// near_on_surface_normal(c, a).is_some()` — does ANY triangle of `a` carry `c` on
-/// its face (exactly or within the snap band)? `a_coord_extent` is the max |coord|
-/// over `a` (hoisted once per arrangement, since only `c` varies per call). The
-/// query radius is the band, so candidates are a conservative superset and the
-/// exact per-triangle predicates decide; the result is `any`, so it is independent
-/// of candidate order and byte-identical to the linear scan.
+/// its face (exactly or within the snap band)? `a_band` carries `a`'s per-axis
+/// coordinate extents (hoisted once per arrangement, since only `c` varies per
+/// call). The query radius is [`NearBand::radius`], the isotropic UPPER bound
+/// over every plane normal — never the max-over-axes scalar, which is NOT such
+/// a bound and could drop a candidate the per-triangle test would accept — so
+/// candidates stay a superset and the exact per-triangle predicates decide; the
+/// result is `any`, so it is candidate-order independent and byte-identical to
+/// the linear scan.
 fn c_on_or_near_a(
     c: [f64; 3],
     a: &[Tri],
     bvh: &super::super::broadphase::Bvh,
-    a_coord_extent: f64,
+    a_band: &NearBand,
     scratch: &mut Vec<u32>,
 ) -> bool {
-    let extent = c.iter().fold(a_coord_extent, |m, &x| m.max(x.abs()));
-    let band = near_band_from_extent(extent);
-    let band2 = band * band;
+    let mut band = *a_band;
+    band.observe_point(&c);
     scratch.clear();
-    bvh.point_candidates(c, band, scratch);
+    bvh.point_candidates(c, band.radius(), scratch);
     scratch.iter().any(|&i| {
         let t = &a[i as usize];
-        on_surface_tri(c, t).is_some() || near_on_surface_tri(c, t, band2).is_some()
+        on_surface_tri(c, t).is_some() || near_on_surface_tri(c, t, &band).is_some()
     })
 }
 
@@ -328,6 +327,11 @@ impl<'a> BComponents<'a> {
         // band of a component face is always inside that component's inflated
         // AABB; also dwarfs any f64 rounding in the slab test. Deterministic
         // FMA-free f64.
+        // Deliberately still the SCALAR `near_band_from_extent`: this inflates
+        // an axis-aligned box in ALL axes, so there is no plane normal to
+        // project onto, and it is only a prefilter. `operand_extent` is
+        // `2·hi + 1` and the factor here a further 4x, against a projected band
+        // of at most `sqrt(3)·hi·2⁻²²` — a comfortable superset.
         let max_ext = exts.iter().cloned().fold(1.0f64, f64::max);
         let pad = 4.0 * near_band_from_extent(max_ext);
         let aabbs = comps
@@ -525,13 +529,9 @@ pub(super) fn boolean_vids_components(
     let ext_a = operand_extent(a);
     // One BVH over operand A, reused for every B-face inside/outside ray-cast AND
     // coincident/near-surface probe below (the dominant O(|tris_b|·|a|) scans on
-    // boolean-heavy meshes). `a_coord_extent` (hoisted) feeds the near-surface band.
+    // boolean-heavy meshes). `a_band` (hoisted) feeds the near-surface band.
     let bvh_a = super::super::broadphase::Bvh::build(a);
-    let a_coord_extent = a
-        .iter()
-        .flat_map(|t| t.iter())
-        .flat_map(|v| v.iter())
-        .fold(1.0f64, |m, &x| m.max(x.abs()));
+    let a_band = NearBand::from_tris(a);
     let mut scratch: Vec<u32> = Vec::new();
     let dedup = matches!(op, BoolOp::Union | BoolOp::Intersection);
     let mut a_kept: HashSet<[Vid; 3]> = HashSet::new();
@@ -600,7 +600,7 @@ pub(super) fn boolean_vids_components(
         // own (the host imposes none on it) so `coplanar_b` is unset for it, yet it
         // is still a coincident shared face that must drop (the #1007 flush roof cap
         // — without the near drop here it survives and bridges the opening).
-        if c_on_or_near_a(c, a, &bvh_a, a_coord_extent, &mut scratch) {
+        if c_on_or_near_a(c, a, &bvh_a, &a_band, &mut scratch) {
             continue; // coplanar-shared B-copy: dropped (the A-copy is the kept one)
         }
         if cop_parent {

--- a/rust/geometry/src/kernel/mesh_bridge.rs
+++ b/rust/geometry/src/kernel/mesh_bridge.rs
@@ -30,17 +30,12 @@ fn snap(c: f64) -> f64 {
     (c / SNAP_GRID).round() * SNAP_GRID
 }
 
-/// The near-coplanar perpendicular band (metres) from the operand+point
-/// coordinate magnitude `extent`. `8·SNAP_GRID` is the per-axis-snap scatter
-/// envelope near the origin; the `extent·2⁻²²` term widens it for far-from-
-/// origin operands where f32 import is coarser.
-///
-/// Canonical definition — `tritri`, `classify`, and this module all size their
-/// near-coplanar/scatter bands to this SAME formula, so they call this
-/// function rather than mirroring the expression.
-pub(crate) fn near_band_from_extent(extent: f64) -> f64 {
-    (8.0 * SNAP_GRID).max(extent * (1.0 / 4_194_304.0))
-}
+// The near-coplanar perpendicular band lives in `super::near_band`: it keeps
+// the operand extent PER AXIS and projects it onto the plane normal actually
+// being tested. `tritri`, `classify` and this module all size their
+// near-coplanar/scatter bands with that ONE type rather than mirroring the
+// expression.
+use super::near_band::NearBand;
 
 /// `Mesh` → the kernel's triangle list (f32 → f64, snapped to the reconcile
 /// grid). Panic-free: an out-of-range index OR a non-finite (NaN/Inf) coord drops
@@ -148,9 +143,12 @@ pub(crate) fn orient_outward(mut tris: Vec<Tri>) -> Vec<Tri> {
 /// smallest real feature edge, ~0.2 m — same argument as
 /// `near_on_surface_normal`), so welding the vertex onto the plane only
 /// removes noise. The CUTTER-ONLY direction suffices and never perturbs the
-/// host. The band and far-from-origin widening mirror
-/// `near_on_surface_normal` (8·SNAP_GRID ≈ 122 µm; the `extent·2⁻²²` term
-/// only dominates >32 km out). DETERMINISM: plain FMA-free f64 over
+/// host. The band and its far-from-origin widening mirror
+/// `near_on_surface_normal`: [`NearBand`], sized PER HOST PLANE from the
+/// operands' per-axis extents projected onto that plane's own normal
+/// (8·SNAP_GRID ≈ 122 µm until the projected extent passes ~512 m, so an
+/// offset along an axis this plane does not face never widens it).
+/// DETERMINISM: plain FMA-free f64 over
 /// already-snapped coords, fixed iteration order, nearest-plane ties broken
 /// by face index ⇒ byte-identical native==wasm. Every pinned box−box
 /// manifest is transversal (no cutter vertex within the band of a
@@ -159,16 +157,9 @@ fn promote_cutter_verts_onto_host_faces(cutter: &mut [Tri], host: &[Tri]) {
     if cutter.is_empty() || host.is_empty() {
         return;
     }
-    let mut extent = 1.0f64;
-    for t in cutter.iter().chain(host.iter()) {
-        for v in t {
-            for &x in v {
-                extent = extent.max(x.abs());
-            }
-        }
-    }
-    let band = near_band_from_extent(extent);
-    let band2 = band * band;
+    let mut band = NearBand::default();
+    band.observe_tris(cutter);
+    band.observe_tris(host);
 
     struct Face {
         t0: [f64; 3],
@@ -176,6 +167,12 @@ fn promote_cutter_verts_onto_host_faces(cutter: &mut [Tri], host: &[Tri]) {
         t2: [f64; 3],
         n: [f64; 3], // raw (unnormalised) plane normal
         nn: f64,     // |n|²
+        /// Squared PERPENDICULAR band for THIS face's plane. `NearBand`
+        /// returns it scaled by `nn` (its comparisons are made against a raw
+        /// `d = dot(v − t0, n)`); the `/ nn` here puts it back into true
+        /// distance units, because the nearest-plane search below compares
+        /// `d²/nn` ACROSS faces with different `|n|`.
+        band2: f64,
     }
     let faces: Vec<Face> = host
         .iter()
@@ -191,7 +188,8 @@ fn promote_cutter_verts_onto_host_faces(cutter: &mut [Tri], host: &[Tri]) {
             if nn <= 0.0 || !nn.is_finite() {
                 return None; // degenerate host triangle
             }
-            Some(Face { t0: t[0], t1: t[1], t2: t[2], n, nn })
+            let band2 = band.scaled_band2(n, nn) / nn;
+            Some(Face { t0: t[0], t1: t[1], t2: t[2], n, nn, band2 })
         })
         .collect();
 
@@ -213,7 +211,7 @@ fn promote_cutter_verts_onto_host_faces(cutter: &mut [Tri], host: &[Tri]) {
                     continue; // already exactly on this plane
                 }
                 let d2 = (d * d) / f.nn;
-                if d2 > band2 {
+                if d2 > f.band2 {
                     continue; // outside the snap-scatter band
                 }
                 if let Some((bd2, _)) = best {

--- a/rust/geometry/src/kernel/mod.rs
+++ b/rust/geometry/src/kernel/mod.rs
@@ -28,6 +28,7 @@ pub mod interval;
 pub mod manifest;
 pub mod mesh_bridge;
 pub mod mesh_volume;
+pub(crate) mod near_band;
 pub mod predicates;
 pub mod rational;
 pub(crate) mod signed_volume;

--- a/rust/geometry/src/kernel/near_band.rs
+++ b/rust/geometry/src/kernel/near_band.rs
@@ -1,0 +1,176 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Normal-projected near-coplanar band for the exact kernel.
+//!
+//! Extracted from `kernel/mesh_bridge.rs` so the band-sizing concern lives in
+//! one place, exactly as `csg/plane_eps.rs` (#2598) extracted the clipper's
+//! plane epsilon. Deliberately the SAME formulation as that module and as its
+//! TypeScript siblings — `epsForPlane` in
+//! `packages/clash/src/contact/tri-tri.ts` (#2661) and the LOCAL-coordinate
+//! tolerance sizing in `packages/drawing-2d/src/section-cutter.ts` (#2622) —
+//! not a fourth one.
+//!
+//! # What was wrong with the scalar band
+//!
+//! [`near_band_from_extent`] takes ONE scalar `extent`, the max |coordinate|
+//! over ALL THREE axes of both operands, and returns
+//! `max(8*SNAP_GRID, extent * 2^-22)`. Its consumers then compare that band
+//! against a PERPENDICULAR distance to a specific plane. A signed plane
+//! distance is `dot(v - p, n)`, so each coordinate's f32 rounding noise enters
+//! it weighted by that axis's normal component: an axis orthogonal to `n`
+//! contributes nothing however far it puts the model from the origin.
+//!
+//! Collapsing the three axes to their max therefore sizes the band from an
+//! axis the plane never sees. A model 10 km out in X, cut by a Z-normal
+//! plane, got `band = 1e4 * 2^-22 ~= 2.4 mm` from the irrelevant X magnitude
+//! where the real f32 rounding step in Z is ~1.2e-4 m (the `8*SNAP_GRID`
+//! floor). Two surfaces a genuine 2 mm apart then fell inside the band, were
+//! reconciled as flush, and a 2 mm recess VANISHED — the same thin-flush-cut
+//! collapse #2598 described for the clipper, live in the kernel's shared band
+//! (`csg/world_frame_tests.rs::a_2mm_recess_cuts_identically_10km_out_in_x`,
+//! far volume 0.3000030517580399 vs expected 0.29968).
+//!
+//! [`NearBand`] keeps the extent PER AXIS and projects it onto the plane's own
+//! normal instead.
+//!
+//! # Determinism
+//!
+//! Plain FMA-free f64 (abs/mul/add/max) over already-snapped input
+//! coordinates, fixed iteration order, no square root anywhere — the
+//! comparison is made in the scaled `|n|`-weighted space precisely so no
+//! normalisation is needed. Byte-identical native == wasm, like every other
+//! predicate in this kernel.
+
+use super::arrangement::Tri;
+use super::mesh_bridge::SNAP_GRID;
+
+/// f32-ULP scale factor for a "worst-case" single-precision coordinate: for a
+/// value with magnitude in `[2, 4)` the true float32 ULP is `2^-22`, and for
+/// larger magnitudes the ULP only grows. Same `2^-22` term (and reasoning) as
+/// `F32_ULP_SCALE` in `csg/plane_eps.rs` and in
+/// `packages/clash/src/contact/narrow-phase.ts`.
+const F32_ULP_SCALE: f64 = 1.0 / 4_194_304.0;
+
+/// The band's floor: the per-axis-snap scatter envelope near the origin, for
+/// two operands, with margin (~122 µm). Unchanged from the scalar formula and
+/// deliberately NOT projected: it is a tuned absolute allowance for
+/// [`SNAP_GRID`] quantization, not a coordinate-magnitude term, and tightening
+/// it is a tolerance change needing its own corpus evidence. Same split as
+/// `csg/plane_eps.rs`, which also projects only the magnitude term.
+pub(crate) const NEAR_BAND_FLOOR: f64 = 8.0 * SNAP_GRID;
+
+/// The near-coplanar band as PER-AXIS coordinate extents, resolved against a
+/// plane's own normal by [`NearBand::scaled_band2`].
+///
+/// Build it over exactly the coordinates whose f32 quantization can move the
+/// distance being tested (both operands, plus the probe point where there is
+/// one), then ask it per plane.
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct NearBand {
+    /// Max |coordinate| per axis, in metres.
+    axis_extent: [f64; 3],
+}
+
+impl NearBand {
+    /// Fold one point's coordinates into the per-axis extents.
+    pub(crate) fn observe_point(&mut self, p: &[f64; 3]) {
+        for k in 0..3 {
+            let a = p[k].abs();
+            if a > self.axis_extent[k] {
+                self.axis_extent[k] = a;
+            }
+        }
+    }
+
+    /// Fold every vertex of `tris` into the per-axis extents.
+    pub(crate) fn observe_tris(&mut self, tris: &[Tri]) {
+        for t in tris {
+            for v in t {
+                self.observe_point(v);
+            }
+        }
+    }
+
+    /// The band over `tris`.
+    pub(crate) fn from_tris(tris: &[Tri]) -> Self {
+        let mut band = Self::default();
+        band.observe_tris(tris);
+        band
+    }
+
+    /// Squared tolerance for the SCALED signed distance
+    /// `d = dot(v - t0, n)`, where `n` is the plane's RAW (unnormalised)
+    /// normal and `nn = |n|^2`:
+    ///
+    /// ```text
+    /// scaled_band2(n) = max(FLOOR^2 * nn, (sum_i |n_i| * extent_i * 2^-22)^2)
+    /// ```
+    ///
+    /// # Why the comparison happens in the scaled space
+    ///
+    /// The true test is `|d| / |n| <= max(FLOOR, sum_i |n_i|/|n| * noise_i)`.
+    /// Multiplying both sides by `|n|` clears every division AND the square
+    /// root: `|d| <= max(FLOOR * |n|, sum_i |n_i| * noise_i)`, which squares
+    /// to the expression above (both sides are non-negative, so the max
+    /// commutes with squaring). Callers therefore compare their raw `d * d`
+    /// against this directly and never normalise a normal.
+    ///
+    /// This is the same reasoning as the "why there is no division by `|n|`"
+    /// note on `PlaneEps::for_normal` in `csg/plane_eps.rs`: the tolerance must
+    /// carry exactly the same `|n|` factor the distance it is compared against
+    /// carries.
+    ///
+    /// # Relation to the scalar band: up to sqrt(3) LOOSER, not uniformly
+    /// tighter
+    ///
+    /// For a unit normal `sum_i |n_i| * M_i <= sqrt(3) * max_i M_i`, with
+    /// equality for a body-diagonal normal on an axis-symmetric operand — so a
+    /// diagonal normal measures exactly `sqrt(3)` looser than the max-over-axes
+    /// form above the floor crossover. That is the correct worst case when all
+    /// three axes' rounding errors align; the projection is a restriction of
+    /// WHICH axes may widen the band, not a uniform tightening.
+    pub(crate) fn scaled_band2(&self, n: [f64; 3], nn: f64) -> f64 {
+        let projected = (n[0].abs() * self.axis_extent[0]
+            + n[1].abs() * self.axis_extent[1]
+            + n[2].abs() * self.axis_extent[2])
+            * F32_ULP_SCALE;
+        (projected * projected).max(NEAR_BAND_FLOOR * NEAR_BAND_FLOOR * nn)
+    }
+
+    /// An isotropic UPPER bound on [`Self::scaled_band2`]'s unnormalised band
+    /// over every possible plane normal, for the prefilters (BVH query radii,
+    /// AABB pads) that must be a conservative superset rather than a decision.
+    ///
+    /// Every unit normal has `|n_i| <= 1`, so `sum_i |n_i| * noise_i <=
+    /// sum_i noise_i`. Note it is the SUM and not the max: the max-over-axes
+    /// scalar is NOT an upper bound on the projected band (see the sqrt(3)
+    /// note above), so a prefilter sized by it could drop a candidate the
+    /// per-plane test would have accepted.
+    pub(crate) fn radius(&self) -> f64 {
+        let sum = (self.axis_extent[0] + self.axis_extent[1] + self.axis_extent[2]) * F32_ULP_SCALE;
+        sum.max(NEAR_BAND_FLOOR)
+    }
+}
+
+/// The legacy SCALAR near-coplanar band: `max(8*SNAP_GRID, extent * 2^-22)`
+/// from a single max-over-axes `extent`.
+///
+/// Retained ONLY for consumers that are not testing a distance along a plane
+/// normal, where the collapse to a scalar is therefore not the defect
+/// described in this module's header:
+///
+/// - `kernel/arrangement/classify.rs` (`BComponents::new`) pads an AABB in
+///   every axis. An isotropic pad is what an axis-aligned box wants, and it is
+///   sized from `operand_extent` (`2 * hi + 1`) with a further 4x factor, so it
+///   stays a comfortable superset of every projected band inside it.
+/// - `clash_solid.rs` gates the trust threshold for `intersection_solid`. That
+///   caller IS in the defect class (its own known-failing corpus case,
+///   `clash_solid_world_frame_tests.rs::a_5mm_overlap_10km_out_in_x_must_still_be_a_solid`,
+///   pins it) but it measures a mesh THICKNESS, not a plane distance, so its
+///   fix is a different change with its own evidence and is deliberately not
+///   folded in here.
+pub(crate) fn near_band_from_extent(extent: f64) -> f64 {
+    NEAR_BAND_FLOOR.max(extent * F32_ULP_SCALE)
+}

--- a/rust/geometry/src/kernel/tritri.rs
+++ b/rust/geometry/src/kernel/tritri.rs
@@ -146,9 +146,10 @@ fn plane_interval(tri: &[[f64; 3]; 3], plane: &[[f64; 3]; 3]) -> PlaneInterval {
     }
 }
 
-/// Near-coplanar band formula, canonical in `mesh_bridge` (sized to the
-/// snap-scatter envelope `mesh_bridge::mesh_to_tris` produces).
-use super::mesh_bridge::near_band_from_extent;
+/// Near-coplanar band, canonical in `near_band` (sized to the snap-scatter
+/// envelope `mesh_bridge::mesh_to_tris` produces, then projected onto the
+/// plane being tested).
+use super::near_band::NearBand;
 
 #[inline]
 fn ti_sub(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
@@ -203,7 +204,11 @@ fn ti_normal(t: &[[f64; 3]; 3]) -> [f64; 3] {
 ///
 /// `band` is an absolute power-of-two multiple of `SNAP_GRID` (≈ the 2-operand
 /// scatter envelope, ~0.12 mm) widened only for far-from-origin operands where
-/// f32 import is coarser — always THREE orders below the smallest real feature
+/// f32 import is coarser — and only by the part of that offset the tested
+/// plane can actually see, since [`NearBand`] projects the per-axis extents
+/// onto that plane's normal. A model 10 km out in X therefore leaves a
+/// Z-normal slab at the floor rather than opening it to ~2.4 mm and welding
+/// genuinely separate faces. The band stays THREE orders below the smallest real feature
 /// edge (~0.2 m). A poke-through cap fails the slab test (its far vertices sit
 /// midway through the host, far from the surface) so it can never qualify; a
 /// sub-band-sized transversal micro-sliver CAN now qualify, but its entire
@@ -215,19 +220,18 @@ fn near_coplanar(t1: &[[f64; 3]; 3], t2: &[[f64; 3]; 3]) -> bool {
     if nn1 <= 0.0 || nn2 <= 0.0 || !nn1.is_finite() || !nn2.is_finite() {
         return false; // a degenerate triangle is never a flush coplanar partner
     }
-    let mut extent = 1.0f64;
+    let mut band = NearBand::default();
     for p in t1.iter().chain(t2.iter()) {
-        for &c in p {
-            extent = extent.max(c.abs());
-        }
+        band.observe_point(p);
     }
-    let band = near_band_from_extent(extent); // 2^-22
-    let band2 = band * band;
-    // All three vertices of `t` within `band` of `plane`'s supporting plane?
+    // All three vertices of `t` within the band of `plane`'s supporting plane?
+    // The band is resolved against THAT plane's own normal, so an operand far
+    // from the origin along an axis the plane does not face does not widen it.
     let in_slab = |t: &[[f64; 3]; 3], plane: &[[f64; 3]; 3], n: [f64; 3], nn: f64| {
+        let band2 = band.scaled_band2(n, nn); // scaled by |n|², like `d` below
         t.iter().all(|&v| {
             let d = ti_dot(ti_sub(v, plane[0]), n); // perp_dist · |n|
-            (d * d) / nn <= band2
+            d * d <= band2
         })
     };
     in_slab(t2, t1, n1, nn1) || in_slab(t1, t2, n2, nn2)

--- a/rust/geometry/tests/manifests/watertightness_census.tsv
+++ b/rust/geometry/tests/manifests/watertightness_census.tsv
@@ -166,24 +166,24 @@ ara3d/ISSUE_126_model.ifc	100504	SweptSolid	0	50	0	0	0	-
 ara3d/ISSUE_126_model.ifc	111997	SweptSolid	27	51	0	0	27	0
 ara3d/ISSUE_126_model.ifc	131771	SweptSolid	0	96	0	0	0	-
 ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	6891	Clipping	91	345	0	1	56	6
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	7526	SweptSolid	1113	958	1	1	993	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	7526	SweptSolid	1119	1157	0	1	931	0
 ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	8434	Clipping	0	44	0	1	0	-
 ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	8756	Clipping	4	28	0	1	3	3
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	9094	SweptSolid	864	1160	1	1	860	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	9094	SweptSolid	723	824	1	1	717	0
 ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	11115	Clipping	21	167	0	1	9	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	12381	SweptSolid	1674	1399	1	1	1234	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	32810	SweptSolid	252	1513	0	1	155	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	34385	SweptSolid	443	485	0	1	460	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	36735	SweptSolid	461	867	0	1	395	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	12381	SweptSolid	2106	2332	1	1	1811	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	32810	SweptSolid	260	1536	0	1	144	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	34385	SweptSolid	493	725	1	1	571	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	36735	SweptSolid	458	882	0	1	375	0
 ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	57084	SweptSolid	54	109	0	1	52	12
 ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	57776	SweptSolid	57	111	0	1	41	0
 ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	57944	Clipping	23	99	0	1	23	0
 ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	58297	Clipping	67	221	0	1	19	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	59111	SweptSolid	244	393	0	1	214	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	59111	SweptSolid	1723	1764	0	1	2008	0
 ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	59957	SweptSolid	37	55	0	1	37	0
 ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	60118	SweptSolid	17	123	1	1	17	0
 ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	60344	SweptSolid	0	36	0	1	0	-
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	61300	Clipping	728	1413	1	1	758	3
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	61300	Clipping	743	1429	1	1	768	3
 ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	63146	Clipping	20	106	0	1	23	0
 ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	63466	Clipping	16	164	0	1	22	0
 ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	63721	SweptSolid	6	22	0	1	6	0
@@ -204,34 +204,34 @@ ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	141060	SweptSoli
 ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	145270	SweptSolid	46	96	0	1	50	6
 ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	145756	SweptSolid	13	101	0	1	13	0
 ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	145897	SweptSolid	32	70	0	1	32	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	148665	SweptSolid	474	912	0	1	350	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	148665	SweptSolid	519	1008	0	1	388	0
 ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	148864	SweptSolid	3	97	0	1	3	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	149277	SweptSolid	221	447	1	1	261	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	149280	SweptSolid	230	825	0	1	187	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	196139	SweptSolid	145	161	0	1	130	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	196326	SweptSolid	88	68	0	1	91	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	149277	SweptSolid	356	562	0	1	312	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	149280	SweptSolid	214	993	0	1	284	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	196139	SweptSolid	148	174	0	1	129	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	196326	SweptSolid	92	83	0	1	101	0
 ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	233296	SweptSolid	0	46	0	1	0	-
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	244479	SweptSolid	356	394	0	1	267	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	244479	SweptSolid	403	639	0	1	340	0
 ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	247051	Clipping	29	164	1	1	29	0
 ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	247203	Clipping	18	88	0	1	18	0
 ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	247726	Clipping	38	180	0	1	38	0
 ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	247953	Clipping	37	165	0	1	38	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	295370	SweptSolid	1050	915	1	1	999	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	296868	SweptSolid	425	273	1	1	620	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	295370	SweptSolid	622	473	1	1	515	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	296868	SweptSolid	621	572	1	1	553	0
 ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	299369	SweptSolid	0	32	0	1	0	-
 ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	299638	SweptSolid	10	10	0	1	10	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	316547	SweptSolid	263	576	0	1	183	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	332017	SweptSolid	172	360	0	1	118	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	316547	SweptSolid	279	649	0	1	250	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	332017	SweptSolid	222	387	0	1	129	0
 ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	332205	SweptSolid	63	263	0	1	3	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	333923	SweptSolid	1124	1143	1	1	1311	6
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	335218	SweptSolid	791	764	1	1	1425	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	333923	SweptSolid	1326	1347	1	1	1209	6
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	335218	SweptSolid	1110	1095	1	1	1334	0
 ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	337691	SweptSolid	27	93	0	1	27	0
 ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	359157	SweptSolid	0	52	0	1	6	-
 ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	359305	SweptSolid	20	60	0	1	12	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	359480	SweptSolid	32	44	0	1	32	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	359480	SweptSolid	18	30	0	1	18	0
 ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	359627	SweptSolid	0	52	0	1	6	-
 ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	359926	SweptSolid	0	52	0	1	6	-
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	360075	SweptSolid	33	44	0	1	33	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	360075	SweptSolid	34	44	0	1	34	0
 ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	360237	SweptSolid	57	79	0	1	57	0
 ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	360384	SweptSolid	7	43	0	1	7	0
 ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	360680	SweptSolid	0	32	0	1	0	-
@@ -406,7 +406,7 @@ ara3d/S_Office_Integrated Design Archi.ifc	91968	CSG	0	120	0	0	0	-
 ara3d/S_Office_Integrated Design Archi.ifc	92642	CSG	12	68	1	0	13	12
 ara3d/S_Office_Integrated Design Archi.ifc	93316	CSG	0	64	0	0	0	-
 ara3d/S_Office_Integrated Design Archi.ifc	93990	CSG	0	108	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	94664	CSG	0	32	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	94664	CSG	4	160	0	0	4	4
 ara3d/S_Office_Integrated Design Archi.ifc	99549	SweptSolid	0	52	0	0	0	-
 ara3d/S_Office_Integrated Design Archi.ifc	368885	SweptSolid	0	36	0	0	0	-
 ara3d/S_Office_Integrated Design Archi.ifc	414959	SweptSolid	0	40	0	0	0	-
@@ -446,7 +446,7 @@ ara3d/S_Office_Integrated Design Archi.ifc	764543	CSG	0	124	0	0	0	-
 ara3d/S_Office_Integrated Design Archi.ifc	765185	CSG	0	118	0	0	0	-
 ara3d/S_Office_Integrated Design Archi.ifc	765827	CSG	0	64	0	0	0	-
 ara3d/S_Office_Integrated Design Archi.ifc	766469	CSG	0	112	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	767111	CSG	0	32	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	767111	CSG	0	108	0	0	0	-
 ara3d/S_Office_Integrated Design Archi.ifc	767445	Curve2D	0	0	0	0	0	-
 ara3d/S_Office_Integrated Design Archi.ifc	768209	CSG	0	224	0	0	0	-
 ara3d/S_Office_Integrated Design Archi.ifc	768976	CSG	0	232	0	0	0	-
@@ -475,7 +475,7 @@ ara3d/S_Office_Integrated Design Archi.ifc	868663	CSG	0	124	0	0	0	-
 ara3d/S_Office_Integrated Design Archi.ifc	869305	CSG	0	118	0	0	0	-
 ara3d/S_Office_Integrated Design Archi.ifc	869947	CSG	0	64	0	0	0	-
 ara3d/S_Office_Integrated Design Archi.ifc	870589	CSG	0	108	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	871231	CSG	0	32	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	871231	CSG	0	108	0	0	0	-
 ara3d/S_Office_Integrated Design Archi.ifc	902095	SweptSolid	0	36	0	0	0	-
 ara3d/S_Office_Integrated Design Archi.ifc	903633	SweptSolid	0	52	0	0	0	-
 ara3d/S_Office_Integrated Design Archi.ifc	904243	SweptSolid	0	32	0	0	0	-
@@ -484,7 +484,7 @@ ara3d/S_Office_Integrated Design Archi.ifc	905288	CSG	0	216	0	0	0	-
 ara3d/S_Office_Integrated Design Archi.ifc	905959	CSG	0	216	0	0	0	-
 ara3d/S_Office_Integrated Design Archi.ifc	906627	CSG	6	82	0	0	6	6
 ara3d/S_Office_Integrated Design Archi.ifc	907295	CSG	0	52	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	907963	CSG	0	216	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	907963	CSG	0	212	0	0	0	-
 ara3d/S_Office_Integrated Design Archi.ifc	908631	CSG	0	216	0	0	0	-
 ara3d/S_Office_Integrated Design Archi.ifc	909123	SweptSolid	0	32	0	0	0	-
 ara3d/S_Office_Integrated Design Archi.ifc	909362	SweptSolid	0	32	0	0	0	-
@@ -501,7 +501,7 @@ ara3d/S_Office_Integrated Design Archi.ifc	951723	CSG	0	216	0	0	0	-
 ara3d/S_Office_Integrated Design Archi.ifc	952413	CSG	0	216	0	0	0	-
 ara3d/S_Office_Integrated Design Archi.ifc	953100	CSG	3	137	1	0	3	3
 ara3d/S_Office_Integrated Design Archi.ifc	953787	CSG	0	116	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	954474	CSG	16	228	0	0	16	13
+ara3d/S_Office_Integrated Design Archi.ifc	954474	CSG	13	225	0	0	4	7
 ara3d/S_Office_Integrated Design Archi.ifc	955161	CSG	0	216	0	0	0	-
 ara3d/S_Office_Integrated Design Archi.ifc	955764	SweptSolid	0	32	0	0	0	-
 ara3d/S_Office_Integrated Design Archi.ifc	969935	Curve2D	0	0	0	0	0	-
@@ -520,10 +520,10 @@ ara3d/S_Office_Integrated Design Archi.ifc	974962	SweptSolid	0	156	0	0	0	-
 ara3d/S_Office_Integrated Design Archi.ifc	976762	Curve2D	0	0	0	0	0	-
 ara3d/S_Office_Integrated Design Archi.ifc	977404	CSG	0	120	0	0	0	-
 ara3d/S_Office_Integrated Design Archi.ifc	978049	CSG	0	120	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	978691	CSG	0	114	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	979333	CSG	0	60	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	978691	CSG	0	112	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	979333	CSG	0	32	0	0	0	-
 ara3d/S_Office_Integrated Design Archi.ifc	979975	CSG	0	114	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	980617	CSG	0	32	0	0	0	-
+ara3d/S_Office_Integrated Design Archi.ifc	980617	CSG	0	108	0	0	0	-
 ara3d/S_Office_Integrated Design Archi.ifc	986525	SweptSolid	0	36	0	0	0	-
 ara3d/S_Office_Integrated Design Archi.ifc	987406	SweptSolid	0	32	0	0	0	-
 ara3d/S_Office_Integrated Design Archi.ifc	997903	SweptSolid	0	36	0	0	0	-
@@ -1127,10 +1127,10 @@ various/rvt01.ifc	11168	Tessellation	26	66	0	1	23	0
 various/rvt01.ifc	11232	Tessellation	14	56	0	1	14	6
 various/rvt01.ifc	11304	Tessellation	7	27	0	1	7	0
 various/rvt01.ifc	11477	Tessellation	0	0	0	1	7	-
-various/rvt01.ifc	11563	Tessellation	15	15	0	1	11	0
-various/rvt01.ifc	11627	Tessellation	46	54	0	1	17	3
-various/rvt01.ifc	11690	Tessellation	26	82	0	1	26	6
-various/rvt01.ifc	11753	Tessellation	6	2	0	1	9	0
+various/rvt01.ifc	11563	Tessellation	23	18	0	1	26	0
+various/rvt01.ifc	11627	Tessellation	63	63	0	1	54	3
+various/rvt01.ifc	11690	Tessellation	72	93	0	1	56	6
+various/rvt01.ifc	11753	Tessellation	10	4	0	1	16	0
 various/rvt01.ifc	11803	SweptSolid	26	52	0	1	22	0
 various/rvt01.ifc	12235	SweptSolid	13	33	0	1	13	0
 various/rvt01.ifc	12345	SweptSolid	5	67	0	1	5	0
@@ -1149,7 +1149,7 @@ various/rvt01.ifc	15301	SweptSolid	69	188	0	1	72	8
 various/rvt01.ifc	15857	SweptSolid	61	178	0	1	67	12
 various/rvt01.ifc	15917	SweptSolid	64	187	0	1	83	16
 various/rvt01.ifc	16231	SweptSolid	45	100	0	1	42	0
-various/rvt01.ifc	16286	SweptSolid	53	130	1	1	66	8
+various/rvt01.ifc	16286	SweptSolid	53	146	1	1	66	8
 various/rvt01.ifc	16805	SweptSolid	45	95	0	1	39	8
 various/rvt01.ifc	17553	Tessellation	4	10	0	1	4	0
 various/rvt01.ifc	17615	Tessellation	20	44	0	1	20	0
@@ -1174,7 +1174,7 @@ various/rvt01.ifc	31430	Tessellation	17	41	0	1	14	0
 various/rvt01.ifc	31577	Tessellation	11	41	0	1	11	0
 various/rvt01.ifc	31648	Tessellation	13	39	0	1	6	0
 various/rvt01.ifc	32081	SweptSolid	62	175	1	1	52	0
-various/rvt01.ifc	33639	SweptSolid	168	214	0	1	169	24
+various/rvt01.ifc	33639	SweptSolid	122	308	0	1	157	24
 various/rvt01.ifc	37278	Tessellation	4	16	0	1	5	0
 various/rvt01.ifc	37347	Tessellation	49	106	0	1	46	0
 various/rvt01.ifc	37455	Tessellation	66	145	1	1	57	3


### PR DESCRIPTION
## The defect, still live on main

`near_band_from_extent` sized the exact CSG kernel's near-coplanar band from ONE scalar `extent` (the max |coordinate| over all three axes of both operands) and its consumers compared that band against a PERPENDICULAR distance to a specific plane. A signed plane distance is `dot(v - p, n)`, so each axis's f32 rounding noise enters it weighted by that axis's normal component; an axis orthogonal to `n` contributes nothing however far it puts the model from the origin. Collapsing to the max sized the band from an axis the plane never sees.

Confirmed live on `origin/main` @ 60917b7d8, with the marker removed and nothing else changed:

```
world-frame corpus: the SAME 2 mm recess that cuts at the origin must cut 10 km
out in X (offset axis X, cut normal Z); far volume 0.3000030517580399 vs
expected 0.29968
```

`0.3000030517580399` is the uncut slab: the 2 mm recess was welded away, because the band read ~2.4 mm from the irrelevant 10 km X magnitude where the real f32 rounding step in Z is the ~122 um floor.

## The formulation, copied not re-derived

`max(8*SNAP_GRID, sum_i |n_i| * extent_i * 2^-22)`, resolved per plane from per-axis extents. Same shape as `csg/plane_eps.rs` (#2598, the Rust sibling that fixed the CLIPPER's epsilon), `packages/clash/src/contact/narrow-phase.ts` (#2661) and `packages/drawing-2d/src/section-cutter.ts` (#2622).

`plane_eps.rs` was read first. Its `PlaneEps` is deliberately NOT reused: that module documents why (its floor is `ClippingProcessor::epsilon` = `1e-6`, while the near band's floor is `8*SNAP_GRID` ~= 1.22e-4, sized for the kernel's snap grid; sharing one type would either loosen the clipper 122x or tighten the kernel's snap allowance). What IS shared is the formulation, in a new `kernel/near_band.rs` extracted the way `plane_eps.rs` was. The `8*SNAP_GRID` floor stays flat and unprojected, the same split `plane_eps.rs` makes: it is a tuned allowance for `SNAP_GRID` quantization, not a coordinate-magnitude term.

Comparisons happen in the `|n|`-scaled space (`d*d` vs `scaled_band2(n, nn)`), which clears every division AND the square root, so no normal is normalised: FMA-free f64, fixed iteration order, byte-identical native == wasm. The pinned mesh-determinism manifest passes unchanged.

Converted (all plane-distance consumers):

- `kernel/tritri.rs::near_coplanar` (the flush-cap slab test)
- `kernel/arrangement/classify.rs::near_on_surface_tri` + its two callers
- `kernel/mesh_bridge.rs::promote_cutter_verts_onto_host_faces`, per host face

Deliberately NOT converted:

- `classify.rs::BComponents::new`'s AABB pad. It inflates an axis-aligned box in all three axes, so there is no plane normal to project onto, and it is only a prefilter; it stays a comfortable superset of every projected band inside it.
- `clash_solid.rs`'s trust gate. It IS in this defect class and has its own known-failing corpus case (`clash_solid_world_frame_tests.rs::a_5mm_overlap_10km_out_in_x_must_still_be_a_solid`), but it gates a mesh THICKNESS, not a plane distance, so its fix needs its own change and its own evidence. That second `#[should_panic]` is untouched and still panics for its stated reason.

The BVH query radius in `c_on_or_near_a` moves to `NearBand::radius`, the isotropic UPPER bound `sum_i extent_i * 2^-22`. The max-over-axes scalar is NOT an upper bound on the projected band (an L1 sum can be up to sqrt(3) larger), so leaving it there could have dropped a candidate the per-triangle test would accept.

## Why the fix and the marker removal are ONE commit

Removing the defect makes the marked assertion stop panicking, which makes `#[should_panic(expected = "world-frame corpus")]` itself FAIL. Landing either half alone turns main red. That trap already fired today: #2661 fixed the TypeScript sibling without removing its `it.fails` twin and main was red until #2672. So `csg/world_frame_tests.rs::a_2mm_recess_cuts_identically_10km_out_in_x` loses its attribute and its KNOWN-FAILING comment in the same commit as the kernel change. The assertion stays, as a live regression guard.

The two `should_panic` markers are in two DIFFERENT files. `csg/world_frame_tests.rs` has exactly one (the `near_band_from_extent` one, fixed here); the other lives in `clash_solid_world_frame_tests.rs` and is untouched.

## Mutation check, both directions

Revert the projection to max-over-axes with the attribute already removed:

```
test csg::csg_tests::world_frame_tests::a_2mm_recess_cuts_identically_10km_out_in_x ... FAILED
world-frame corpus: [...] far volume 0.3000030517580399 vs expected 0.29968
```

The same message, byte for byte, as before the fix. The other 7 world-frame tests stayed green under the mutation, so the guard is specific. Restore: `8 passed; 0 failed`.

---

# The watertightness census golden is re-baselined in this PR. Read this part.

The second commit replaces 36 of 1170 rows in `rust/geometry/tests/manifests/watertightness_census.tsv`. A golden that gets bumped whenever it goes red stops being a gate, so here is the evidence that decided it. The census reported `regressed: 29, improved: 7`, and `unmatched edges 20453 vs 18017`.

Rows are taken **verbatim from the CI run-rows artifact** (`watertightness-census-rows`, run 31968974522), never a local sweep. Only the 36 data rows differ; the header and all 1134 other rows are byte-identical.

### What the old numbers were actually measuring

**How much geometry an over-wide weld band had erased before the open-edge count was taken.**

### Scope: 3 of 33 void-hosting models, 36 of 1170 rows

The magnitude term only overtakes the `8*SNAP_GRID` floor above **512 KERNEL units**. A metre-authored model near the origin never reaches that: at 100 units the term is `2.4e-5`, five times BELOW the floor. Old band and new band both sit on the floor there, so the projection cannot move them, and 1134 rows are byte-identical. Only these changed:

| model | authoring | kernel-unit extents | legacy band |
| --- | --- | --- | --- |
| S_Office | `.MILLI.` `.METRE.`, 66 m from origin | 3750 x 20 x 3250 | 8.94e-4 |
| ISSUE_129 | `.METRE.`, georeferenced 8.18e6 | 1.66e6 x 8.18e6 x 5 | **1.95 m** |
| rvt01 | `.METRE.`, georeferenced 2.78e6 | 5.0e5 x 2.78e6 x 18 | **0.66 m** |

Worth noting for anyone reading the kernel: on the void path it does not necessarily see world metres. Measured on S_Office, the operands arrive with per-axis extents `[3750, 20, 3250]` for a panel whose world bounding box is 3.75 x 0.09 x 3.25 m at 66 m from the origin — neither the world position (66/41/16) nor metres, but the panel's own size in MILLIMETRES. So the extent that sizes the band is the element's own size in file units there, which is why a millimetre-authored 3.75 m panel (extent 3750) crosses the 512 threshold and a metre-authored one (extent 3.75) does not. `csg/plane_eps.rs` documents the same caller-dependent denomination for the half-space path. Filed as #2684.

### Split by the census's own f32-safety flag

| population | rows | open edges golden -> run | triangles |
| --- | --- | --- | --- |
| `far=0` (f32-safe, what this gate measures meaningfully) | 1006 | 1672 -> 1673 (**+1**) | +319 |
| `far=1` (below the RTC offset) | 164 | 16345 -> 18780 (**+2435**) | +3726 |

**2435 of the 2436 extra unmatched edges are in the `far=1` population**, which is a configuration production does not run: production sets the RTC offset (`processing/src/processor/mod.rs:1101`, `jobs.rs:197`, `wasm-bindings/.../batch.rs:253`) and raw world-coordinate items are rebased inside `process_representation_item` BEFORE the element-level boolean, while the harness builds the router with bare `with_units`, leaving `rtc_offset` at zero and handing the kernel 8.18e6-metre coordinates where the f32 ULP is 0.5 m. The census documents this bypass itself.

**The one new f32-safe defect is a host tear, not a boolean tear.** S_Office #94664 goes `open 0 -> 4`, and the census's own pre-void probe records `pre=4`: the host is torn with no voids applied at all.

### The old output was tidy, not right

Instrumenting the three band call sites and measuring every comparison the legacy band admitted and the projected band rejects, against the true f32 noise along the tested normal (`sum_i |n_i| * ulp32(extent_i)`, the corpus's own `normal_projected_noise_bound`):

| host | rejected welds | gap / true noise |
| --- | --- | --- |
| S_Office #979333 | 205, **all on `|n| = (0,1,0)`** | min 23x, median 73x, max 440x |
| ISSUE_129 #59111 | 4.3M | median **314592x**, max 1.7e6x |
| rvt01 #11563 | 69 | median 5248x, max 10480x |

The smallest ratio anywhere in the changed set is **3.2x**. Not one rejected weld is explicable as rounding noise.

On ISSUE_129 the legacy band was **1.95 m on a slab 0.515 m thick** — wide enough to weld the slab's top face to its bottom face, against `classify.rs`'s stated requirement that the band stay three orders BELOW the smallest real feature edge (~0.2 m). Its own written contract, violated by four orders of magnitude.

And the tidiness had a price the golden could not see.

**Correction to an earlier version of this analysis.** My first pass measured that price with the divergence-theorem volume, which is meaningless on a non-closed mesh — and these hosts are open. It produced a claimed "92% of the wall destroyed" for S_Office #94664 that is **wrong, and is withdrawn**. Re-measured with bounding box and total triangle surface area, both valid on an open mesh:

```
ISSUE_129 #59111  host, no voids : 768 tris, 1636.87 m2 surface
                  legacy band    :  393 tris,  241.58 m2   <- 85% of the host's surface gone,
                                                              from a difference that only carves openings
                  projected band : 1764 tris, 1577.70 m2   <- 96% preserved

S_Office #94664   host, no voids :  12 tris, 28.66 m2, bbox Z 3.870 m
                  legacy band    :  32 tris, 24.82 m2, bbox Z 3.805 m  <- top 65 mm trimmed, reported open=0
                  projected band : 160 tris, 24.94 m2, bbox Z 3.870 m

S_Office #954474  legacy    bbox X 0.020 m on a 0.010 m panel (doubled thickness), open=16
                  projected bbox X 0.010 m, open=13

S_Office #979333  legacy 21.7806 m2 / 60 tris  vs  projected 21.7805 m2 / 32 tris
                  -> the same solid at a coarser tessellation, filed as a regression
```

So on the **near-origin** model the two bands agree on surface area to within 0.5%: the legacy differences there are a 65 mm trim and a doubled-thickness artifact, not wholesale destruction. The **wholesale destruction is in the far population** (#59111, 85% of the host's surface), where the band was 1.95 m.

An emptied or trimmed mesh still reports `open == 0`, which the census's own module header names as the blind spot this golden format was created to close.

### CAVEAT 1: this PR does not fix the far case, and must not be read as doing so

The projected band still reads **0.4 to 1.95 m** for normals along the georeferenced axes on ISSUE_129 and rvt01. That is inherent to f32 at 8e6 m — the ULP there really is 0.5 m — and it is exactly what the RTC offset exists for. The projection fixes which axes may widen the band; it cannot conjure precision f32 does not have. Those rows are re-blessed as a record of what the harness measures, not as a claim that the geometry is now correct.

### CAVEAT 2: the golden files improvements as regressions

**7 of the 29 rows the census called REGRESSED have equal or fewer open edges** and were flagged purely on the triangle-count heuristic. Three improved substantially:

| host | open edges | flagged because |
| --- | --- | --- |
| ISSUE_129 #295370 | 1050 -> **622** | tris 915 -> 473 |
| ISSUE_129 #9094 | 864 -> **723** | tris 1160 -> 824 |
| S_Office #954474 | 16 -> **13** | tris 228 -> 225 |

`losing_triangles_regresses_even_while_open_stays_zero` is a deliberate rule and a good one — it is what catches an emptied mesh — but it cannot tell a coarser tessellation of the same solid from geometry loss. S_Office #979333 is the clearest case: tris 60 -> 32 with volume `0.899777` -> `0.899738`, a 0.004% difference. Same solid, fewer triangles, filed as a regression.

### Correction to the `32 -> 108` reading

These three CSG hosts (#767111, #871231, #980617) went `tris 32 -> 108` with `open` staying 0, which looks like cuts surviving that were previously collapsed. Measured, that is not what happened: volume goes `0.097766` -> `0.098205` with both meshes closed, so **the cut was present in both**. What changed is a properly conforming 108-triangle carve replacing a 32-triangle one, giving back 0.44 L that the over-weld had shaved off a 98 L panel. Real, but a finer and less destructive carve, not a resurrected cut.

### The floor was checked, and is doing the right work

Where the projected term collapses below it, the floor is **4.6x the two-operand snap-scatter envelope** and **20x to 240x the true f32 noise** along the tested normal. It is the generous side of both noise sources, and every weld the projection drops sits above that generous floor. No floor change is indicated.

### Side-finding filed, not fixed here: #2684

`SNAP_GRID` is documented in metres but applied in file units, so its physical size is 1000x finer in a millimetre-authored file. That is the reason the corpus split the way it did. `plane_eps.rs` already documents the same unit divergence as a KNOWN LIMITATION. Filed as #2684 rather than folded in.

---

## Verification (every exit code)

| command | exit |
| --- | --- |
| `cargo test -p ifc-lite-geometry --no-fail-fast` | 0 |
| `cargo test -p ifc-lite-processing --no-fail-fast` | 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | 0 |

Re-run after the re-baseline commit; all three still 0. The census golden's own 19 unit tests (`census_golden::tests::*`, which run in the default suite without the `triangulation-alt` feature) pass against the new file.

## Module-size allowlist: no change

`rust/processing/tests/module_size_allowlist.txt` is untouched, so the digest another session pinned today is unaffected. `classify.rs` first grew to 636 over its 633 budget; rather than raise it, the added prose was trimmed back to 633 exactly. `mesh_bridge.rs` shrinks 484 -> 482 (left flat, not lowered). `near_band.rs` is 176 lines, under 400, so it takes no row.

Changeset added for `@ifc-lite/wasm`, matching #2598's precedent.

Do not merge without review.
