### PR TITLE
feat(viewer): hold Ctrl/Cmd for a finer wheel zoom (#2683)

### DIFF
--- a/apps/viewer/src/components/viewer/useMouseControls.ts
+++ b/apps/viewer/src/components/viewer/useMouseControls.ts
@@ -33,6 +33,7 @@ import {
   updateMeasureScreenCoords,
 } from './measureHandlers.js';
 import { handleSelectionClick, handleContextMenu as handleContextMenuSelection, handleAddElementHover, handleSplitHover } from './selectionHandlers.js';
+import { applyWheelZoom, createFineZoomModifierTracker } from './wheelZoom.js';
 
 export interface MouseState {
   isDragging: boolean;
@@ -811,8 +812,22 @@ export function useMouseControls(params: UseMouseControlsParams): void {
     // Debounce: clear isInteracting 150ms after the last wheel event
     let wheelIdleTimer: ReturnType<typeof setTimeout> | null = null;
 
+    // Ctrl/Cmd held = finer zoom step (#2683). Tracked from keyboard events
+    // rather than read off the wheel event, because a trackpad pinch arrives
+    // as a wheel event with `ctrlKey: true` and no key ever pressed - see
+    // wheelZoom.ts.
+    const fineZoomModifier = createFineZoomModifierTracker();
+
     const handleWheel = (e: WheelEvent) => {
-      e.preventDefault();
+      // Cancels the browser's own Ctrl+wheel page zoom as well as scrolling;
+      // works only because the listener below is registered `passive: false`.
+      applyWheelZoom(e, {
+        camera,
+        canvas,
+        fastZoom: e.shiftKey || params.fastZoomRef.current,
+        fineModifierHeld: fineZoomModifier.isHeld(),
+      });
+
       if (wheelIdleTimer) clearTimeout(wheelIdleTimer);
       wheelIdleTimer = setTimeout(() => {
         isInteractingRef.current = false;
@@ -820,11 +835,6 @@ export function useMouseControls(params: UseMouseControlsParams): void {
         // One signal per zoom gesture, on the trailing edge of the debounce.
         emitCameraInteracted('zoom');
       }, 150);
-      const rect = canvas.getBoundingClientRect();
-      const mouseX = e.clientX - rect.left;
-      const mouseY = e.clientY - rect.top;
-      const fastZoom = e.shiftKey || params.fastZoomRef.current;
-      camera.zoom(e.deltaY, false, mouseX, mouseY, canvas.width, canvas.height, fastZoom);
 
       isInteractingRef.current = true;
       renderer.requestRender();
@@ -858,6 +868,7 @@ export function useMouseControls(params: UseMouseControlsParams): void {
       canvas.removeEventListener('contextmenu', handleContextMenu);
       canvas.removeEventListener('wheel', handleWheel);
       canvas.removeEventListener('click', handleClick);
+      fineZoomModifier.dispose();
       if (wheelIdleTimer) clearTimeout(wheelIdleTimer);
 
       // Cancel pending raycast requests

--- a/apps/viewer/src/components/viewer/useMouseControls.wheelZoom.test.tsx
+++ b/apps/viewer/src/components/viewer/useMouseControls.wheelZoom.test.tsx
@@ -1,0 +1,243 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * #2683 - the wheel path as the canvas actually sees it.
+ *
+ * `wheelZoom.test.ts` covers the step maths in isolation. This file mounts the
+ * real hook and dispatches a real wheel event at the real canvas, because two
+ * things can only break here:
+ *
+ *  - the listener registration. Ctrl+wheel is the browser's page-zoom
+ *    shortcut, and `preventDefault()` from a PASSIVE listener does nothing -
+ *    the page would zoom instead of the model. happy-dom models that faithfully
+ *    (a passive listener leaves `defaultPrevented` false), so flipping
+ *    `{ passive: false }` here turns this file red.
+ *  - the wiring. A handler that computes a fine step and then hands the raw
+ *    delta to the camera would pass every unit test in the other file.
+ */
+
+import '@/test/setup-dom.js';
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { Camera, type Renderer } from '@ifc-lite/renderer';
+import { useViewerStore } from '@/store';
+import { useMouseControls, type UseMouseControlsParams, type MouseState } from './useMouseControls.js';
+
+const NOTCH_DELTA_Y = 120;
+
+/**
+ * happy-dom's `WheelEvent` implements only the delta half of the init dict, so
+ * `ctrlKey` and `clientX` have to be defined explicitly - a browser supplies
+ * both. Same reasoning as in `wheelZoom.test.ts`; without it the ctrl cases
+ * would quietly test the unmodified path.
+ */
+function wheelEvent(init: { ctrlKey?: boolean } = {}): WheelEvent {
+  const e = new WheelEvent('wheel', {
+    deltaY: NOTCH_DELTA_Y,
+    deltaMode: 0,
+    bubbles: true,
+    cancelable: true,
+  });
+  Object.defineProperties(e, {
+    ctrlKey: { value: init.ctrlKey ?? false, configurable: true },
+    metaKey: { value: false, configurable: true },
+    clientX: { value: 400, configurable: true },
+    clientY: { value: 300, configurable: true },
+  });
+  return e;
+}
+
+const ref = <T,>(current: T) => ({ current });
+const noop = () => {};
+
+function makeParams(canvas: HTMLCanvasElement, camera: Camera): UseMouseControlsParams {
+  const renderer = {
+    getCamera: () => camera,
+    requestRender: noop,
+    pick: () => null,
+    pickRect: () => [],
+  } as unknown as Renderer;
+
+  const state = useViewerStore.getState();
+
+  return {
+    canvasRef: ref<HTMLCanvasElement | null>(canvas),
+    rendererRef: ref<Renderer | null>(renderer),
+    isInitialized: true,
+    mouseStateRef: ref<MouseState>({
+      isDragging: false,
+      isPanning: false,
+      lastX: 0,
+      lastY: 0,
+      button: 0,
+      startX: 0,
+      startY: 0,
+      didDrag: false,
+    }),
+    activeToolRef: ref('select'),
+    activeMeasurementRef: ref(null),
+    snapEnabledRef: ref(false),
+    edgeLockStateRef: ref(state.edgeLockState),
+    measurementConstraintEdgeRef: ref(null),
+    sectionPickModeRef: ref(false),
+    modelBoundsRef: ref(null),
+    hiddenEntitiesRef: ref(new Set<number>()),
+    isolatedEntitiesRef: ref<Set<number> | null>(null),
+    selectedEntityIdRef: ref<number | null>(null),
+    selectedModelIndexRef: ref<number | undefined>(undefined),
+    clearColorRef: ref<[number, number, number, number]>([0, 0, 0, 1]),
+    sectionPlaneRef: ref(state.sectionPlane),
+    sectionRangeRef: ref(null),
+    geometryRef: ref(null),
+    measureRaycastPendingRef: ref(false),
+    measureRaycastFrameRef: ref<number | null>(null),
+    lastMeasureRaycastDurationRef: ref(0),
+    lastHoverSnapTimeRef: ref(0),
+    lastHoverCheckRef: ref(0),
+    hoverTooltipsEnabledRef: ref(false),
+    lastRenderTimeRef: ref(0),
+    renderPendingRef: ref(false),
+    isInteractingRef: ref(false),
+    lastClickTimeRef: ref(0),
+    lastClickPosRef: ref(null),
+    lastCameraStateRef: ref(null),
+    handlePickForSelection: noop,
+    setHoverState: noop,
+    clearHover: noop,
+    openContextMenu: noop,
+    startMeasurement: noop,
+    updateMeasurement: noop,
+    finalizeMeasurement: noop,
+    setSnapTarget: noop,
+    setSnapVisualization: noop,
+    setEdgeLock: noop,
+    updateEdgeLockPosition: noop,
+    clearEdgeLock: noop,
+    incrementEdgeLockStrength: noop,
+    setMeasurementConstraintEdge: noop,
+    updateConstraintActiveAxis: noop,
+    updateMeasurementScreenCoords: noop,
+    updateCameraRotationRealtime: noop,
+    toggleSelection: noop,
+    calculateScale: noop,
+    getPickOptions: () => ({ isStreaming: false, hiddenIds: new Set<number>(), isolatedIds: null }),
+    hasPendingMeasurements: () => false,
+    setSectionPlaneFromFace: noop,
+    setSectionPickMode: noop,
+    setSectionPickPreview: noop,
+    HOVER_SNAP_THROTTLE_MS: 50,
+    SLOW_RAYCAST_THRESHOLD_MS: 50,
+    hoverThrottleMs: 50,
+    RENDER_THROTTLE_MS_SMALL: 16,
+    RENDER_THROTTLE_MS_LARGE: 33,
+    RENDER_THROTTLE_MS_HUGE: 66,
+    fastZoomRef: ref(false),
+  };
+}
+
+const mounted: { root: Root; host: HTMLDivElement }[] = [];
+
+/** Mounts the hook against a canvas and returns both. */
+function mountViewport(): { canvas: HTMLCanvasElement; camera: Camera } {
+  const canvas = document.createElement('canvas');
+  canvas.width = 800;
+  canvas.height = 600;
+  document.body.appendChild(canvas);
+
+  const camera = new Camera();
+  const params = makeParams(canvas, camera);
+
+  function Probe() {
+    useMouseControls(params);
+    return null;
+  }
+
+  const host = document.createElement('div');
+  document.body.appendChild(host);
+  const root = createRoot(host);
+  act(() => {
+    root.render(<Probe />);
+  });
+  mounted.push({ root, host });
+
+  return { canvas, camera };
+}
+
+/** Camera travel produced by one dispatched wheel event. */
+function travelOf(canvas: HTMLCanvasElement, camera: Camera, e: WheelEvent): number {
+  const before = { ...camera.getPosition() };
+  canvas.dispatchEvent(e);
+  const after = camera.getPosition();
+  return Math.hypot(after.x - before.x, after.y - before.y, after.z - before.z);
+}
+
+describe('useMouseControls wheel zoom - registration and wiring (#2683)', () => {
+  beforeEach(() => {
+    // No stray Control from a previous test: the tracker listens on window.
+    window.dispatchEvent(new Event('blur'));
+  });
+
+  afterEach(() => {
+    // Unmount every mount: each one added a window key listener that would
+    // otherwise keep answering for the next test.
+    while (mounted.length > 0) {
+      const { root, host } = mounted.pop()!;
+      act(() => {
+        root.unmount();
+      });
+      host.remove();
+    }
+    document.body.innerHTML = '';
+  });
+
+  it('cancels the browser default on a ctrl+wheel, so the page does not zoom', () => {
+    const { canvas } = mountViewport();
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Control', ctrlKey: true }));
+
+    const e = wheelEvent({ ctrlKey: true });
+    canvas.dispatchEvent(e);
+
+    assert.equal(
+      e.defaultPrevented,
+      true,
+      'a passive listener cannot cancel this, and the browser would page-zoom instead',
+    );
+  });
+
+  it('cancels the browser default on a plain wheel too', () => {
+    const { canvas } = mountViewport();
+    const e = wheelEvent();
+    canvas.dispatchEvent(e);
+    assert.equal(e.defaultPrevented, true);
+  });
+
+  it('zooms a real Ctrl+wheel FINER than the same unmodified notch', () => {
+    const plainView = mountViewport();
+    const plain = travelOf(plainView.canvas, plainView.camera, wheelEvent());
+
+    // A genuine key press, which is what separates a held Ctrl from a pinch.
+    // Dispatched AFTER the mount, as it is in life: the viewport is already
+    // listening when the user reaches for the key.
+    const fineView = mountViewport();
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Control', ctrlKey: true }));
+    const fine = travelOf(fineView.canvas, fineView.camera, wheelEvent({ ctrlKey: true }));
+
+    assert.ok(plain > 0, 'the unmodified notch must move the camera');
+    assert.ok(fine > 0, 'the fine notch must still move the camera');
+    assert.ok(fine < plain, `ctrl travel ${fine} should be smaller than plain travel ${plain}`);
+  });
+
+  it('leaves a pinch (ctrlKey, no key pressed) at the normal step', () => {
+    const pinchView = mountViewport();
+    const pinch = travelOf(pinchView.canvas, pinchView.camera, wheelEvent({ ctrlKey: true }));
+
+    const plainView = mountViewport();
+    const plain = travelOf(plainView.canvas, plainView.camera, wheelEvent());
+
+    assert.equal(pinch, plain, 'pinch-zoom must keep its usual speed');
+  });
+});

--- a/apps/viewer/src/components/viewer/wheelZoom.test.ts
+++ b/apps/viewer/src/components/viewer/wheelZoom.test.ts
@@ -1,0 +1,290 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * #2683 - Ctrl/Cmd held gives a finer wheel zoom, QGIS-style.
+ *
+ * The fixture is a real `WheelEvent` dispatched at a real canvas through a
+ * real `Camera`, because every trap in this feature lives in the gap between a
+ * hand-rolled event object and the one a browser sends:
+ *
+ *  - a trackpad pinch arrives as a wheel event with `ctrlKey: true` and
+ *    `deltaMode: 0` and no key ever pressed, so a naive `e.ctrlKey` test
+ *    silently rewrites pinch-zoom;
+ *  - Ctrl+wheel is the browser's page-zoom shortcut, so the handler has to
+ *    cancel the default or the whole page zooms instead of the model.
+ *
+ * The assertions are at the camera level (how far the camera actually moved),
+ * not at the delta level, so a change that scales the delta but never reaches
+ * the camera cannot pass.
+ */
+
+import '../../test/setup-dom.js';
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert';
+
+import { Camera } from '@ifc-lite/renderer';
+
+import {
+  applyWheelZoom,
+  createFineZoomModifierTracker,
+  isFineZoomWheel,
+  wheelZoomDelta,
+  FINE_ZOOM_STEP_FACTOR,
+} from './wheelZoom.js';
+
+/** One ordinary mouse-wheel notch, as Chrome sends it. */
+const NOTCH_DELTA_Y = 120;
+
+function makeCanvas(): HTMLCanvasElement {
+  const canvas = document.createElement('canvas');
+  canvas.width = 800;
+  canvas.height = 600;
+  document.body.appendChild(canvas);
+  return canvas;
+}
+
+/**
+ * A wheel event as a browser dispatches it: a real `WheelEvent`, cancelable,
+ * with `deltaMode` set and the modifier flags a pinch or a held key carries.
+ *
+ * The `defineProperties` is load-bearing, not decoration. happy-dom's
+ * `WheelEvent` constructor implements only the delta half of the init dict and
+ * drops the `MouseEvent` half: `new WheelEvent('wheel', { ctrlKey: true,
+ * clientX: 400 })` comes back with `ctrlKey === undefined` and
+ * `clientX === undefined`. Without this, every assertion about the modifier
+ * would run against an event that never had one - the tests would pass while
+ * testing nothing, which is the exact failure they exist to catch. The
+ * fixture-integrity test below keeps that honest.
+ */
+function wheelEvent(init: { ctrlKey?: boolean; metaKey?: boolean; deltaY?: number } = {}): WheelEvent {
+  const e = new WheelEvent('wheel', {
+    deltaY: init.deltaY ?? NOTCH_DELTA_Y,
+    deltaMode: 0, // WheelEvent.DOM_DELTA_PIXEL
+    bubbles: true,
+    cancelable: true,
+  });
+  Object.defineProperties(e, {
+    ctrlKey: { value: init.ctrlKey ?? false, configurable: true },
+    metaKey: { value: init.metaKey ?? false, configurable: true },
+    // Canvas centre: the cursor anchor then contributes no lateral drift, so
+    // the modified and unmodified runs differ only in step size.
+    clientX: { value: 400, configurable: true },
+    clientY: { value: 300, configurable: true },
+  });
+  return e;
+}
+
+/** Camera travel and distance change produced by one wheel event. */
+function zoomOnce(e: WheelEvent, opts: { fineModifierHeld: boolean }): { travel: number; distanceDelta: number } {
+  const canvas = makeCanvas();
+  const camera = new Camera();
+  const before = { ...camera.getPosition() };
+  const distanceBefore = camera.getDistance();
+
+  applyWheelZoom(e, { camera, canvas, fastZoom: false, fineModifierHeld: opts.fineModifierHeld });
+
+  const after = camera.getPosition();
+  return {
+    travel: Math.hypot(after.x - before.x, after.y - before.y, after.z - before.z),
+    distanceDelta: Math.abs(camera.getDistance() - distanceBefore),
+  };
+}
+
+describe('wheel zoom - the fine-step modifier (#2683)', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('has a fixture that carries what a browser actually dispatches', () => {
+    // If this drifts, every modifier assertion below silently stops testing
+    // the modifier. happy-dom already dropped these once.
+    const e = wheelEvent({ ctrlKey: true });
+    assert.strictEqual(e.deltaY, NOTCH_DELTA_Y, 'a notch must have a delta');
+    assert.strictEqual(e.deltaMode, 0, 'deltaMode must exist and be pixel mode');
+    assert.strictEqual(e.ctrlKey, true, 'a pinch/ctrl wheel event carries ctrlKey');
+    assert.strictEqual(e.metaKey, false);
+    assert.strictEqual(e.clientX, 400, 'the cursor anchor needs client coordinates');
+    assert.strictEqual(e.clientY, 300);
+    assert.strictEqual(e.cancelable, true, 'preventDefault is only observable on a cancelable event');
+    assert.strictEqual(wheelEvent().ctrlKey, false, 'the unmodified fixture must be unmodified');
+  });
+
+  it('moves the camera LESS for the same deltaY when the modifier is held', () => {
+    const plain = zoomOnce(wheelEvent(), { fineModifierHeld: false });
+    const fine = zoomOnce(wheelEvent({ ctrlKey: true }), { fineModifierHeld: true });
+
+    assert.ok(plain.travel > 0, 'the unmodified notch must move the camera at all');
+    assert.ok(fine.travel > 0, 'the fine notch must still move the camera - finer, not dead');
+    assert.ok(
+      fine.travel < plain.travel,
+      `fine travel ${fine.travel} should be smaller than plain travel ${plain.travel}`,
+    );
+    assert.ok(
+      fine.distanceDelta < plain.distanceDelta,
+      `fine distance delta ${fine.distanceDelta} should be smaller than plain ${plain.distanceDelta}`,
+    );
+    // Not merely "smaller": a step the user can feel as finer. The renderer
+    // clamps a 120px notch at MAX_ZOOM_DELTA, so the observed ratio is wider
+    // than FINE_ZOOM_STEP_FACTOR itself; half is a floor either way.
+    assert.ok(
+      fine.travel < plain.travel * 0.5,
+      `fine travel ${fine.travel} should be well under half of ${plain.travel}`,
+    );
+  });
+
+  it('leaves the unmodified wheel bit-for-bit as it was', () => {
+    // The reference is the call the handler used to make: raw deltaY straight
+    // into camera.zoom with the same cursor anchor.
+    const canvas = makeCanvas();
+    const reference = new Camera();
+    reference.zoom(NOTCH_DELTA_Y, false, 400, 300, canvas.width, canvas.height, false);
+
+    const subject = new Camera();
+    applyWheelZoom(wheelEvent(), {
+      camera: subject,
+      canvas,
+      fastZoom: false,
+      fineModifierHeld: false,
+    });
+
+    assert.deepStrictEqual(subject.getPosition(), reference.getPosition());
+    assert.deepStrictEqual(subject.getTarget(), reference.getTarget());
+    assert.strictEqual(subject.getDistance(), reference.getDistance());
+  });
+
+  it('calls preventDefault when the modifier is active, so the browser does not zoom the page', () => {
+    const canvas = makeCanvas();
+    const camera = new Camera();
+    const e = wheelEvent({ ctrlKey: true });
+
+    // Dispatched, not just constructed: `defaultPrevented` is what the browser
+    // reads to decide whether to run its own Ctrl+wheel page zoom, and the
+    // listener is registered non-passive exactly as useMouseControls does.
+    canvas.addEventListener(
+      'wheel',
+      (ev) => {
+        applyWheelZoom(ev as WheelEvent, {
+          camera,
+          canvas,
+          fastZoom: false,
+          fineModifierHeld: true,
+        });
+      },
+      { passive: false },
+    );
+    canvas.dispatchEvent(e);
+
+    assert.strictEqual(e.defaultPrevented, true, 'ctrl+wheel must be cancelled');
+  });
+
+  it('also calls preventDefault on the unmodified wheel', () => {
+    const canvas = makeCanvas();
+    const camera = new Camera();
+    const e = wheelEvent();
+    canvas.addEventListener(
+      'wheel',
+      (ev) => {
+        applyWheelZoom(ev as WheelEvent, {
+          camera,
+          canvas,
+          fastZoom: false,
+          fineModifierHeld: false,
+        });
+      },
+      { passive: false },
+    );
+    canvas.dispatchEvent(e);
+
+    assert.strictEqual(e.defaultPrevented, true, 'plain wheel must stay cancelled too');
+  });
+
+  it('treats a trackpad pinch (synthesised ctrlKey, no key pressed) as a normal-speed zoom', () => {
+    // macOS, and Chromium precision touchpads elsewhere, send exactly this.
+    const pinch = zoomOnce(wheelEvent({ ctrlKey: true }), { fineModifierHeld: false });
+    const plain = zoomOnce(wheelEvent(), { fineModifierHeld: false });
+
+    assert.strictEqual(pinch.travel, plain.travel, 'a pinch must not be slowed to the fine step');
+  });
+
+  it('ignores a stale held-flag when the wheel event says the key is up', () => {
+    // Focus can be lost with Ctrl down, stranding the flag; the wheel event
+    // still reports the truth, and both halves are required.
+    assert.strictEqual(isFineZoomWheel({ ctrlKey: false, metaKey: false }, true), false);
+    assert.strictEqual(isFineZoomWheel({ ctrlKey: true, metaKey: false }, true), true);
+    assert.strictEqual(isFineZoomWheel({ ctrlKey: false, metaKey: true }, true), true);
+    assert.strictEqual(isFineZoomWheel({ ctrlKey: true, metaKey: false }, false), false);
+  });
+
+  it('scales the delta by the fine factor and leaves it alone otherwise', () => {
+    assert.strictEqual(
+      wheelZoomDelta({ deltaY: NOTCH_DELTA_Y, ctrlKey: true, metaKey: false }, true),
+      NOTCH_DELTA_Y * FINE_ZOOM_STEP_FACTOR,
+    );
+    assert.strictEqual(
+      wheelZoomDelta({ deltaY: NOTCH_DELTA_Y, ctrlKey: false, metaKey: false }, false),
+      NOTCH_DELTA_Y,
+    );
+    assert.ok(FINE_ZOOM_STEP_FACTOR > 0 && FINE_ZOOM_STEP_FACTOR < 1, 'finer, not faster and not dead');
+  });
+});
+
+describe('fine-zoom modifier tracker - real key presses only (#2683)', () => {
+  it('opens on a Ctrl keydown and closes on its keyup', () => {
+    const tracker = createFineZoomModifierTracker(window);
+    try {
+      assert.strictEqual(tracker.isHeld(), false, 'starts closed');
+
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Control', ctrlKey: true }));
+      assert.strictEqual(tracker.isHeld(), true);
+
+      window.dispatchEvent(new KeyboardEvent('keyup', { key: 'Control', ctrlKey: false }));
+      assert.strictEqual(tracker.isHeld(), false);
+    } finally {
+      tracker.dispose();
+    }
+  });
+
+  it('accepts Cmd on macOS keyboards', () => {
+    const tracker = createFineZoomModifierTracker(window);
+    try {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Meta', metaKey: true }));
+      assert.strictEqual(tracker.isHeld(), true);
+    } finally {
+      tracker.dispose();
+    }
+  });
+
+  it('stays closed for a pinch, which fires no keyboard event at all', () => {
+    const canvas = makeCanvas();
+    const tracker = createFineZoomModifierTracker(window);
+    try {
+      canvas.dispatchEvent(wheelEvent({ ctrlKey: true }));
+      assert.strictEqual(tracker.isHeld(), false, 'a wheel event must never open the gate');
+    } finally {
+      tracker.dispose();
+    }
+  });
+
+  it('resets when the window loses focus with the key down', () => {
+    const tracker = createFineZoomModifierTracker(window);
+    try {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Control', ctrlKey: true }));
+      assert.strictEqual(tracker.isHeld(), true);
+
+      window.dispatchEvent(new Event('blur'));
+      assert.strictEqual(tracker.isHeld(), false);
+    } finally {
+      tracker.dispose();
+    }
+  });
+
+  it('stops listening after dispose', () => {
+    const tracker = createFineZoomModifierTracker(window);
+    tracker.dispose();
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Control', ctrlKey: true }));
+    assert.strictEqual(tracker.isHeld(), false);
+  });
+});

--- a/apps/viewer/src/components/viewer/wheelZoom.test.ts
+++ b/apps/viewer/src/components/viewer/wheelZoom.test.ts
@@ -247,6 +247,39 @@ describe('fine-zoom modifier tracker - real key presses only (#2683)', () => {
     }
   });
 
+  it('still sees the key when a focused editor stops it from bubbling', () => {
+    // `TextAnnotationEditor.tsx:63` calls `e.stopPropagation()` on every
+    // keydown so the canvas does not act on typing. A bubble-phase listener on
+    // `window` would never observe the Ctrl press while that editor has focus,
+    // and the next wheel gesture over the canvas would silently take the
+    // normal step. Capture runs window-first, before any child can stop it.
+    const editor = document.createElement('textarea');
+    document.body.appendChild(editor);
+    const swallow = (e: Event) => e.stopPropagation();
+    editor.addEventListener('keydown', swallow);
+    editor.addEventListener('keyup', swallow);
+
+    const tracker = createFineZoomModifierTracker(window);
+    try {
+      editor.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Control', ctrlKey: true, bubbles: true }),
+      );
+      assert.strictEqual(
+        tracker.isHeld(),
+        true,
+        'a focused editor swallowing keydown must not disable the fine-zoom modifier',
+      );
+
+      editor.dispatchEvent(
+        new KeyboardEvent('keyup', { key: 'Control', ctrlKey: false, bubbles: true }),
+      );
+      assert.strictEqual(tracker.isHeld(), false, 'and the release must still be seen');
+    } finally {
+      tracker.dispose();
+      editor.remove();
+    }
+  });
+
   it('accepts Cmd on macOS keyboards', () => {
     const tracker = createFineZoomModifierTracker(window);
     try {

--- a/apps/viewer/src/components/viewer/wheelZoom.ts
+++ b/apps/viewer/src/components/viewer/wheelZoom.ts
@@ -95,16 +95,25 @@ export function createFineZoomModifierTracker(
     held = false;
   };
 
-  target.addEventListener('keydown', onKey);
-  target.addEventListener('keyup', onKey);
-  target.addEventListener('blur', onBlur);
+  // CAPTURE phase, deliberately. Focused editors in this app stop key events
+  // from bubbling -- `TextAnnotationEditor.tsx:63` calls `e.stopPropagation()`
+  // on every keydown so the canvas does not act on typing. A bubble-phase
+  // listener on `window` therefore never sees the physical Ctrl press while
+  // such an editor holds focus, and the next wheel gesture over the canvas
+  // would silently use the normal step. Capture runs window-first, before any
+  // child can stop propagation, so the tracker observes the key regardless of
+  // what is focused. The removals must pass the SAME option or they do not
+  // match the registration and the listeners leak.
+  target.addEventListener('keydown', onKey, true);
+  target.addEventListener('keyup', onKey, true);
+  target.addEventListener('blur', onBlur, true);
 
   return {
     isHeld: () => held,
     dispose() {
-      target.removeEventListener('keydown', onKey);
-      target.removeEventListener('keyup', onKey);
-      target.removeEventListener('blur', onBlur);
+      target.removeEventListener('keydown', onKey, true);
+      target.removeEventListener('keyup', onKey, true);
+      target.removeEventListener('blur', onBlur, true);
     },
   };
 }

--- a/apps/viewer/src/components/viewer/wheelZoom.ts
+++ b/apps/viewer/src/components/viewer/wheelZoom.ts
@@ -1,0 +1,169 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Wheel zoom: the step the wheel applies, and the modifier that makes it finer
+ * (#2683).
+ *
+ * QGIS is the reference the request cited. Its map canvas divides the *excess
+ * over 1* of the wheel zoom factor by 20 while Ctrl is down, under the comment
+ * "holding ctrl while wheel zooming results in a finer zoom"
+ * (`QgsMapCanvas::wheelEvent`, src/gui/qgsmapcanvas.cpp), and the user manual
+ * says the same. So the convention is FINER, not faster, and it is a change of
+ * step size, not of direction.
+ *
+ * We follow the intent rather than the literal divisor. QGIS' unmodified notch
+ * is a 2x jump (100% of the current scale); ours is a tenth of that -- the
+ * renderer clamps a notch at `MAX_ZOOM_DELTA` = 0.1, so a wheel notch moves
+ * ~10% -- and dividing that by 20 would leave ~0.5% per notch, several hundred
+ * notches to halve the view distance. A fifth of the default step lands at ~2%
+ * per notch: finer than QGIS' fine zoom in absolute terms, still responsive
+ * enough that a flick of the wheel visibly moves.
+ *
+ * The unmodified wheel is untouched, so existing muscle memory is unchanged.
+ */
+
+/** Fraction of the normal wheel step applied while the fine modifier is held. */
+export const FINE_ZOOM_STEP_FACTOR = 0.2;
+
+/** The part of `Camera` this module drives. Keeps the unit testable. */
+export interface WheelZoomCamera {
+  zoom(
+    delta: number,
+    addVelocity?: boolean,
+    mouseX?: number,
+    mouseY?: number,
+    canvasWidth?: number,
+    canvasHeight?: number,
+    fastZoom?: boolean,
+  ): void;
+}
+
+/** The part of a wheel event this module reads. */
+export interface WheelZoomEvent {
+  deltaY: number;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  clientX: number;
+  clientY: number;
+  preventDefault(): void;
+}
+
+/**
+ * Tracks whether Ctrl or Cmd is PHYSICALLY held, from keyboard events.
+ *
+ * A wheel event's own `ctrlKey` cannot answer that question. Browsers
+ * synthesise a wheel event with `ctrlKey: true` for a trackpad pinch -- macOS
+ * is the familiar case, but Chromium does it for precision touchpads on
+ * Windows and Linux too -- and no keyboard event accompanies it. Reading
+ * `e.ctrlKey` alone would therefore hand every pinch-zoom the fine step, which
+ * is exactly the gesture users expect to move the camera at full speed.
+ *
+ * Keyboard events do not lie: they only fire for real key presses, and every
+ * one of them reports the true modifier state, so `keydown` for Ctrl (which
+ * itself carries `ctrlKey: true`) opens the gate and its `keyup` closes it.
+ * That is why the modifier is Ctrl *and* Cmd on every platform rather than a
+ * per-platform mapping: with a real key press required, Ctrl means Ctrl on a
+ * Mac as well, which is what the request asked for, and Cmd is accepted
+ * alongside it because that is the modifier Mac users reach for.
+ *
+ * Focus can be lost with the key down (Ctrl+Tab, a Space switch), which would
+ * leave the flag stuck on; `blur` resets it, and {@link isFineZoomWheel} also
+ * requires the wheel event to agree, so a stale flag alone can never engage
+ * the fine step. The mirror case is a key already down when the tracker is
+ * created, which no keyboard event announces: the fine step then waits for the
+ * next press. The viewport mounts once at startup, well before anyone reaches
+ * for Ctrl, so that costs at most the very first gesture of a session.
+ */
+export interface FineZoomModifierTracker {
+  /** True while Ctrl or Cmd is held, as witnessed by a keyboard event. */
+  isHeld(): boolean;
+  dispose(): void;
+}
+
+export function createFineZoomModifierTracker(
+  target: Pick<Window, 'addEventListener' | 'removeEventListener'> = window,
+): FineZoomModifierTracker {
+  let held = false;
+
+  const onKey = (e: Event) => {
+    const ke = e as KeyboardEvent;
+    held = ke.ctrlKey || ke.metaKey;
+  };
+  const onBlur = () => {
+    held = false;
+  };
+
+  target.addEventListener('keydown', onKey);
+  target.addEventListener('keyup', onKey);
+  target.addEventListener('blur', onBlur);
+
+  return {
+    isHeld: () => held,
+    dispose() {
+      target.removeEventListener('keydown', onKey);
+      target.removeEventListener('keyup', onKey);
+      target.removeEventListener('blur', onBlur);
+    },
+  };
+}
+
+/**
+ * Does this wheel event carry the fine-zoom modifier?
+ *
+ * Both halves are required: the keyboard must have witnessed a real Ctrl/Cmd
+ * press (so a synthesised pinch cannot pass) and the wheel event must still
+ * report the modifier down (so a flag stranded by a lost `keyup` cannot).
+ */
+export function isFineZoomWheel(
+  e: Pick<WheelZoomEvent, 'ctrlKey' | 'metaKey'>,
+  modifierKeyHeld: boolean,
+): boolean {
+  return modifierKeyHeld && (e.ctrlKey || e.metaKey);
+}
+
+/** Wheel delta to feed the camera: the raw one, or a fraction of it. */
+export function wheelZoomDelta(
+  e: Pick<WheelZoomEvent, 'deltaY' | 'ctrlKey' | 'metaKey'>,
+  modifierKeyHeld: boolean,
+): number {
+  return isFineZoomWheel(e, modifierKeyHeld) ? e.deltaY * FINE_ZOOM_STEP_FACTOR : e.deltaY;
+}
+
+export interface WheelZoomOptions {
+  camera: WheelZoomCamera;
+  canvas: HTMLCanvasElement;
+  /** Shift, or Cesium mode: pure dolly. Orthogonal to the fine step. */
+  fastZoom: boolean;
+  /** {@link FineZoomModifierTracker.isHeld} at the time of the event. */
+  fineModifierHeld: boolean;
+}
+
+/**
+ * Applies one wheel notch to the camera, anchored at the cursor.
+ *
+ * `preventDefault` is unconditional and comes first. Ctrl+wheel is the
+ * browser's own page-zoom shortcut (and its pinch-zoom gesture), so without it
+ * the fine-zoom modifier would scale the whole page instead of the model. It
+ * only takes effect because the listener is registered with
+ * `{ passive: false }` in `useMouseControls`; a passive listener cannot cancel
+ * the default and the browser would zoom the page regardless.
+ */
+export function applyWheelZoom(e: WheelZoomEvent, opts: WheelZoomOptions): void {
+  e.preventDefault();
+
+  const rect = opts.canvas.getBoundingClientRect();
+  const mouseX = e.clientX - rect.left;
+  const mouseY = e.clientY - rect.top;
+
+  opts.camera.zoom(
+    wheelZoomDelta(e, opts.fineModifierHeld),
+    false,
+    mouseX,
+    mouseY,
+    opts.canvas.width,
+    opts.canvas.height,
+    opts.fastZoom,
+  );
+}


### PR DESCRIPTION
Closes #2683.

@Hans-Lammerts asked for CTRL as a zoom modifier "like in QGIS", so I went and read what QGIS actually does rather than paraphrasing it.

## The convention, and why

QGIS makes Ctrl+wheel **finer**, not faster. From `QgsMapCanvas::wheelEvent` (`src/gui/qgsmapcanvas.cpp`):

```cpp
if ( e->modifiers() & Qt::ControlModifier )
{
  //holding ctrl while wheel zooming results in a finer zoom
  zoomFactor = 1.0 + ( zoomFactor - 1.0 ) / 20.0;
}
```

and the QGIS user manual (7.1, 2D Map View) says the same: "With `Ctrl` key pressed while rolling the mouse wheel results in a finer zoom."

So this PR implements a finer step, which also matches the part of the request that names the use case: "especially when zooming in on detailed geometry". Precision is what a smaller step buys.

**The number is not copied literally, deliberately.** QGIS' unmodified notch is a 2x jump (100% of the current scale), so dividing by 20 leaves it at 5% per notch. Our unmodified notch is already about 10% (the renderer clamps a wheel notch at `MAX_ZOOM_DELTA`), so the same divisor would leave roughly 0.5% per notch, several hundred notches to halve the view distance, which would read as broken rather than fine. The fine step here is a fifth of the default, about 2% per notch: finer than QGIS' fine zoom in absolute terms, still responsive enough that a flick of the wheel visibly moves. One named constant, `FINE_ZOOM_STEP_FACTOR`.

The unmodified wheel is bit-for-bit unchanged, so nobody's muscle memory breaks. There is a test that asserts exactly that.

## The two findings worth writing down

**Passive listeners.** Ctrl+wheel is the browser's own page-zoom shortcut, so the handler has to call `preventDefault()`, and that only works from a listener registered `{ passive: false }`. The 3D canvas listener in `useMouseControls.ts` already was non-passive and already called `preventDefault` unconditionally, so nothing had to change; the risk was that a later edit flips it and the feature starts zooming the whole page instead. `useMouseControls.wheelZoom.test.tsx` now mounts the real hook, dispatches a real cancelable wheel event at the real canvas and asserts `defaultPrevented`. happy-dom models passive faithfully, so flipping that flag to `true` turns the test red (verified, see the mutation table).

**macOS pinch, and it is not only macOS.** A trackpad pinch arrives as a wheel event with `ctrlKey: true` synthesised by the browser. macOS is the familiar case, but Chromium does the same for precision touchpads on Windows and Linux, so a naive `e.ctrlKey` check would have made every pinch-zoom take the fine step on every platform.

The fix is to require a *physically held* key: the modifier state is tracked from keyboard events (which only fire for real presses) and the wheel event must agree. That gave a better answer than a per-platform key mapping:

- **Ctrl works on every platform, macOS included**, which is literally what the issue asked for. Mapping macOS to Cmd-only would have denied Hans his Ctrl on a Mac.
- **Cmd is accepted alongside it**, because that is the modifier Mac users reach for.
- **Pinch keeps its normal speed everywhere**, because it fires no keyboard event.
- A flag stranded by a lost `keyup` (Ctrl+Tab, a Space switch) cannot engage the fine step on its own: `blur` resets it, and the wheel event has to report the modifier as well. The mirror case, a key already down before the viewport mounts, costs at most the first gesture of a session.

The reasoning lives in a comment in `wheelZoom.ts`, not just here.

**No conflict with the existing Ctrl binding.** `useMouseControls.ts` binds Ctrl/Cmd + LMB to rectangle-select on `pointerdown`; a wheel event never produces a `pointerdown`, and nothing in the selection path reads a wheel. Holding Ctrl to zoom finely does not start a rectangle, and dragging a rectangle with Ctrl still works.

## Tests

`apps/viewer/src/components/viewer/wheelZoom.test.ts` (13) covers the step maths against a real `Camera`; `useMouseControls.wheelZoom.test.tsx` (4) mounts the real hook.

One thing the fixture caught, which is the reason both files build their wheel events the long way: **happy-dom's `WheelEvent` constructor implements only the delta half of the init dict and silently drops the `MouseEvent` half.** `new WheelEvent('wheel', { ctrlKey: true })` comes back with `ctrlKey === undefined`. The first version of the modifier tests passed for the wrong reason until that was found, so `ctrlKey`/`metaKey`/`clientX`/`clientY` are defined explicitly and a dedicated test asserts the fixture carries what a browser dispatches (`deltaY`, `deltaMode`, the modifier flags, `cancelable`).

Every assertion is at the camera level (how far the camera actually moved), so a change that scales a delta but never reaches the camera cannot pass.

Mutation-checked in both directions:

| mutation | result | restored |
| --- | --- | --- |
| fine factor removed (`deltaY` unscaled) | 2 fail / 11 pass | 13 pass |
| `preventDefault()` removed | 2 fail / 11 pass | 13 pass |
| naive `e.ctrlKey` (ignore the real key press) | 2 fail / 11 pass | 13 pass |
| listener flipped to `{ passive: true }` | 2 fail / 2 pass | 4 pass |
| handler unwired (raw `camera.zoom(e.deltaY, ...)`) | 1 fail / 3 pass | 4 pass |

## Deliberately out of scope

- No settings panel, no persisted preference, no configurable multiplier. One constant in code.
- No entry in the keyboard-shortcuts dialog: the existing mouse gestures, Shift+wheel fast zoom included, are not documented there either, and adding the surface for one gesture is a different change.
- The 2D section-view wheel zoom (`useViewControls.ts`) is untouched; the issue is about the model viewport.
- No dynamic "accelerate the longer you hold" ramp. The issue mentions accelerating or decelerating "depending on how far you press or hold CTRL"; a keyboard modifier is binary, and the QGIS behaviour being referenced is a fixed finer step. If a ramp is genuinely wanted, that is a separate issue with a separate feel to tune.

## Verification

`pnpm install --frozen-lockfile` 0, `pnpm build` 0, `pnpm typecheck` 0, `pnpm lint` 0, `node scripts/check-source-text-assertions.mjs` 0, `pnpm test` 0 (88/88 tasks, viewer 4704 pass / 0 fail / 6 skipped).

No changeset: the change is confined to the private `apps/viewer`, no published package surface moves.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added finer zoom control when using Ctrl/Cmd plus the mouse wheel.
  * Zoom remains centered on the cursor for more precise navigation.
  * Trackpad pinch gestures continue to use normal zoom speed.
* **Bug Fixes**
  * Improved modifier-key handling to prevent stale Ctrl/Cmd states from affecting zoom.
  * Wheel interactions consistently prevent unintended browser page scrolling.
* **Tests**
  * Added comprehensive coverage for wheel zoom, pinch gestures, keyboard modifiers, and interaction cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->