### PR TITLE
fix(release): publish ifc-lite-clash before ifc-lite-geometry, and gate the order

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -463,6 +463,14 @@ jobs:
       # through a pipe and asserts the bytes that arrive.
       - name: Check lint gate survives a piped stdout
         run: node --test scripts/check-lint-ran.test.mjs
+      # The Release workflow runs ONLY on main, and only on an actual publish,
+      # so nothing on a PR ever read release-crates.mjs's publish ORDER. #2574
+      # added a versioned dev-dependency (ifc-lite-clash) to rust/geometry and
+      # it sat latent until the next release, where cargo refused to publish
+      # geometry ahead of clash — AFTER npm had already gone out, leaving
+      # crates.io behind npm. This makes that order a PR-visible gate.
+      - name: Check the crates publish order matches the dependency graph
+        run: node --test scripts/release-crates-order.test.mjs
       # The server-parse root-attribute table (attr_indices.rs) is generated
       # from @ifc-lite/parser's SCHEMA_REGISTRY — the SAME table the in-browser
       # parse resolves names against. Guard that the committed file is in sync

--- a/scripts/release-crates-order.test.mjs
+++ b/scripts/release-crates-order.test.mjs
@@ -73,8 +73,15 @@ function versionedIfcDeps(crateDir) {
     if (!inDeps || line.startsWith('#') || !line.startsWith('ifc-lite-')) continue;
     const name = line.match(/^(ifc-lite-[a-z0-9-]+)/)?.[1];
     if (!name) continue;
-    // Inherits the workspace entry, which carries a version.
-    if (/\.workspace\s*=\s*true/.test(line)) out.add(name);
+    // Inherits the workspace entry, which carries a version. BOTH spellings
+    // must be recognised, and the repo uses both: `rust/geometry` writes the
+    // dotted `ifc-lite-clash.workspace = true`, while `rust/export` writes the
+    // inline-table `ifc-lite-core = { workspace = true }`. Matching only the
+    // dotted form left every one of export's three versioned dependencies
+    // invisible here, so this gate would have passed an order that publishes
+    // export before core, geometry and processing -- exactly the failure it
+    // exists to prevent.
+    if (/(^|[.{,\s])workspace\s*=\s*true/.test(line)) out.add(name);
     // Or states one inline.
     else if (/version\s*=/.test(line)) out.add(name);
     // Otherwise path-only: stripped at publish time, no ordering constraint.

--- a/scripts/release-crates-order.test.mjs
+++ b/scripts/release-crates-order.test.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The `CRATES` list in `release-crates.mjs` must be a valid publish order.
+ *
+ * Why this test exists rather than a comment: the Release workflow **only runs
+ * on main**, and only on an actual publish. So a dependency edge added in any
+ * PR sat latent until the next release, where it failed after npm had already
+ * published — leaving crates.io behind npm with no failing signal anywhere
+ * beforehand. That is the whole point: nothing on a PR read this ordering.
+ *
+ * The live instance: #2574 added `ifc-lite-clash.workspace = true` to
+ * `rust/geometry`'s dev-dependencies. A workspace dep resolves to
+ * `{ version = "x.y.z", path = ... }`, so it carries a VERSION, and
+ * `cargo publish` resolves versioned dev-dependencies against crates.io even
+ * though they add nothing to a shipping build. `geometry` was published before
+ * `clash`, so it failed with:
+ *
+ *   error: failed to prepare local package for uploading
+ *     failed to select a version for the requirement `ifc-lite-clash = "^4.7.0"`
+ *
+ * The distinction that matters, and the reason a blanket "no dev-deps" rule
+ * would be wrong: `rust/core` has `ifc-lite-geometry = { path = "../geometry" }`
+ * — path-only, no version. Cargo STRIPS that at publish time, so it imposes no
+ * ordering constraint at all and core publishes cleanly despite the same shape
+ * of cycle. Only a VERSIONED dependency (normal or dev) constrains the order.
+ *
+ * Run: node --test scripts/release-crates-order.test.mjs
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+/** The publish order as the release script actually declares it. */
+function publishOrder() {
+  const src = readFileSync(join(ROOT, 'scripts', 'release-crates.mjs'), 'utf8');
+  const block = src.match(/const CRATES = \[([\s\S]*?)\n\];/);
+  assert.ok(block, 'release-crates.mjs no longer declares a CRATES array');
+  return block[1]
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith("'") || line.startsWith('"'))
+    .map((line) => line.match(/['"]([^'"]+)['"]/)[1]);
+}
+
+/**
+ * Every `ifc-lite-*` dependency of `crateDir` that carries a VERSION, from
+ * `[dependencies]`, `[dev-dependencies]` and `[build-dependencies]` alike.
+ *
+ * `foo.workspace = true` counts: it inherits the root's
+ * `{ version = "...", path = "..." }`, version included. A bare
+ * `{ path = "..." }` does not count — cargo strips it when packaging.
+ */
+function versionedIfcDeps(crateDir) {
+  const manifest = join(ROOT, 'rust', crateDir, 'Cargo.toml');
+  if (!existsSync(manifest)) return [];
+  const out = new Set();
+  let inDeps = false;
+  for (const raw of readFileSync(manifest, 'utf8').split('\n')) {
+    const line = raw.trim();
+    if (line.startsWith('[')) {
+      inDeps = /^\[(dev-|build-)?dependencies\]$/.test(line);
+      continue;
+    }
+    if (!inDeps || line.startsWith('#') || !line.startsWith('ifc-lite-')) continue;
+    const name = line.match(/^(ifc-lite-[a-z0-9-]+)/)?.[1];
+    if (!name) continue;
+    // Inherits the workspace entry, which carries a version.
+    if (/\.workspace\s*=\s*true/.test(line)) out.add(name);
+    // Or states one inline.
+    else if (/version\s*=/.test(line)) out.add(name);
+    // Otherwise path-only: stripped at publish time, no ordering constraint.
+  }
+  return [...out];
+}
+
+/** crate name (`ifc-lite-core`) -> directory under rust/ (`core`). */
+function crateDirs() {
+  const map = new Map();
+  for (const dir of readdirSync(join(ROOT, 'rust'))) {
+    const manifest = join(ROOT, 'rust', dir, 'Cargo.toml');
+    if (!existsSync(manifest)) continue;
+    const name = readFileSync(manifest, 'utf8').match(/^name\s*=\s*"([^"]+)"/m)?.[1];
+    if (name) map.set(name, dir);
+  }
+  return map;
+}
+
+test('every published crate comes after the crates it pins by version', () => {
+  const order = publishOrder();
+  const dirs = crateDirs();
+  const position = new Map(order.map((name, i) => [name, i]));
+
+  const violations = [];
+  for (const [i, crate] of order.entries()) {
+    const dir = dirs.get(crate);
+    assert.ok(dir, `${crate} is in CRATES but has no rust/*/Cargo.toml`);
+    for (const dep of versionedIfcDeps(dir)) {
+      if (!position.has(dep)) continue; // not published; irrelevant to order
+      if (position.get(dep) > i) {
+        violations.push(
+          `  ${crate} (position ${i}) pins ${dep} by version, but ${dep} is published later (position ${position.get(dep)})`
+        );
+      }
+    }
+  }
+
+  assert.equal(
+    violations.length,
+    0,
+    `\nrelease-crates.mjs would publish a crate before something it pins by version.\n` +
+      `cargo publish resolves versioned dependencies — INCLUDING dev-dependencies —\n` +
+      `against crates.io, so this fails the real publish on main, after npm has already\n` +
+      `gone out. Reorder CRATES, or drop the version from the dependency (a bare\n` +
+      `{ path = "..." } dev-dep is stripped at publish time, as rust/core does).\n\n` +
+      violations.join('\n')
+  );
+});
+
+test('the ordering check can actually see a violation', () => {
+  // Guards the guard: if `versionedIfcDeps` silently stopped parsing, the test
+  // above would pass on any order at all and report nothing. This pins that the
+  // real manifest of the real regression is still readable and still counted.
+  const deps = versionedIfcDeps('geometry');
+  assert.ok(
+    deps.includes('ifc-lite-clash'),
+    `rust/geometry should still show a versioned ifc-lite-clash dependency (the #2574 dev-dep). ` +
+      `Got: ${JSON.stringify(deps)}. If that dep was intentionally removed or made path-only, ` +
+      `this assertion should move to whichever crate now exercises the constraint — ` +
+      `deleting it leaves the ordering test unable to fail.`
+  );
+});

--- a/scripts/release-crates.mjs
+++ b/scripts/release-crates.mjs
@@ -33,8 +33,24 @@ const rootDir = join(dirname(fileURLToPath(import.meta.url)), '..');
 // processing; wasm depends on core+geometry+clash+processing.
 const CRATES = [
   'ifc-lite-core',
-  'ifc-lite-geometry',
+  // ifc-lite-clash must precede ifc-lite-geometry. geometry carries a
+  // dev-dependency on clash (`ifc-lite-clash.workspace = true`, added with the
+  // intersection-solid oracle in #2574) and a workspace dep resolves to
+  // `{ version = "x.y.z", path = ... }` — so it carries a VERSION, and
+  // `cargo publish` resolves versioned dev-dependencies against crates.io even
+  // though they add nothing to a shipping build. Publishing geometry first
+  // therefore fails with "failed to select a version for the requirement
+  // `ifc-lite-clash = ^x.y.z`" until clash is already up.
+  //
+  // Contrast rust/core, whose geometry dev-dep is written `{ path = "../geometry" }`
+  // with no version: cargo strips that one at publish time, which is why core
+  // publishes cleanly despite the same shape of cycle. Either form works; what
+  // must not happen is a versioned dev-dep on a crate published later.
+  //
+  // clash has zero dependencies and zero dev-dependencies, so it is safe at the
+  // front.
   'ifc-lite-clash',
+  'ifc-lite-geometry',
   'ifc-lite-processing',
   // ifc-lite-export must precede ffi/wasm: wasm-bindings pins it by version
   // (HBJSON/KMZ exporters, #1235) and cargo resolves that against crates.io


### PR DESCRIPTION
## What broke

Tonight's release (#2667) published **all six npm packages successfully** — clash 1.8.0, cli 0.24.3, create 2.1.1, export 2.9.3, renderer 1.48.1, wasm 4.7.0, all tagged — and then failed on crates.io:

```
error: failed to prepare local package for uploading
  failed to select a version for the requirement `ifc-lite-clash = "^4.7.0"`
Error: Command failed: cargo publish -p ifc-lite-geometry --allow-dirty
❌ release: crates.io FAILED (exit 1) — continuing with the remaining registries
```

**npm is at 4.7.0 and crates.io is behind.** I verified the npm side against the registry directly rather than trusting the workflow status, which is what made the split visible: the run is red, but six packages really are live and correct.

## Why

#2574 added `ifc-lite-clash.workspace = true` to `rust/geometry`'s **dev**-dependencies, for the intersection-solid oracle. A workspace dep resolves to `{ version = "x.y.z", path = ... }` — it carries a **version** — and `cargo publish` resolves versioned dev-dependencies against crates.io even though they contribute nothing to a shipping build. `CRATES` published `geometry` second and `clash` third, so geometry could never resolve it.

The manifest comment is right that the dep "adds nothing to a shipping build" and is not circular. That is true of *building*; it is not true of *packaging*.

The distinction that matters, and why a blanket "no dev-deps between crates" rule would be wrong: `rust/core` declares `ifc-lite-geometry = { path = "../geometry" }` with **no version**, and cargo strips that at publish time. That is precisely why `ifc-lite-core` published cleanly tonight despite the same shape of cycle. Only a *versioned* dependency constrains the order.

`ifc-lite-clash` has zero dependencies and zero dev-dependencies, so it is safe at the front.

## The test is the actual fix

Reordering unbreaks today. The reason it was breakable at all is the part worth closing:

**The Release workflow runs only on `main`, and only on a real publish.** Nothing on a PR read this ordering. So the edge #2574 introduced this morning sat latent all day and surfaced tonight *after npm had already gone out* — with no failing signal anywhere beforehand. Every check on every PR in between was green and correct about what it measured.

`scripts/release-crates-order.test.mjs` derives the constraint from the Cargo manifests themselves (versioned deps from `[dependencies]`, `[dev-dependencies]` and `[build-dependencies]`, treating `.workspace = true` as versioned and bare `{ path }` as not) and asserts `CRATES` is a valid topological order. It runs in `node-tests`, so the next such edge fails on the PR that adds it.

**Mutation-verified.** Restoring the exact order that broke tonight:

```
not ok 1 - every published crate comes after the crates it pins by version
  ifc-lite-geometry (position 1) pins ifc-lite-clash by version,
  but ifc-lite-clash is published later (position 2)
```

A second test guards the guard: if the manifest parser silently stopped working, the first test would pass on *any* order and report nothing, so the second pins that the real regression's dependency is still visible to it.

## What this PR does not do

It does not publish the missing crates. crates.io is still behind npm at 4.7.0 and that needs a decision — a re-run of Release on main, or a manual `cargo publish` pass — which I am deliberately leaving to @louistrue rather than improvising a publish.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected package publication order so dependencies are released before dependent crates, including publishing the clash package before the geometry package.

- **Tests**
  - Added automated validation for publication ordering across standard, development, and build dependencies.
  - Added coverage for workspace and versioned dependency relationships, including geometry and clash packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->