### PR TITLE
feat(renderer,viewer): light-hardness + terminator-softness controls (Phase 1, #2670)

### DIFF
--- a/.changeset/light-hardness-phase1.md
+++ b/.changeset/light-hardness-phase1.md
@@ -1,0 +1,10 @@
+---
+"@ifc-lite/renderer": minor
+"@ifc-lite/viewer": minor
+---
+
+Phase 1 of the Blender-like lighting work (#2670): expose light-hardness and shadow-feel controls in the standalone WebGPU viewer.
+
+**Renderer** — `LightingEnvironment` gains a `sunSoftness` field: the diffuse-wrap that sets the sun terminator, previously hardcoded to `0.3` in the shader. `0` is a crisp light/shadow boundary (harder shadows), larger values soften it (overcast). Resolved into the existing environment uniform (a spare pad slot, no UBO size change) and clamped to `[0, 1]`; omitting it reproduces the historic look exactly.
+
+**Viewer** — the Sun & Sky panel adds two sliders (WebGPU shading, hidden in world-context mode): **Light hardness** (deepens shadows by cutting hemisphere ambient + fill) and **Terminator softness** (trims the preset's `sunSoftness`). Both are user trims composed onto the active preset — switching presets changes the base, the trims persist — mirroring Exposure. Presets now carry per-preset softness (crisp Day/Evening, soft Overcast) so the terminator changes with the sky being simulated. Settings persist in localStorage.

--- a/apps/viewer/src/components/viewer/LightingTrimControls.tsx
+++ b/apps/viewer/src/components/viewer/LightingTrimControls.tsx
@@ -1,0 +1,89 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * WebGPU shading trim controls for the Sun & Sky panel: Exposure, Light
+ * hardness and Terminator softness. All three are user trims composed onto the
+ * active lighting preset (the preset supplies the base; switching preset
+ * changes the base, the trims persist), so they share one control shape — a
+ * labelled slider whose value doubles as a reset-to-neutral button.
+ *
+ * Rendered only in standalone (WebGPU) mode; in world-context the model is lit
+ * by Cesium, so the caller gates this on `!cesiumEnabled`.
+ */
+
+import { useViewerStore } from '@/store';
+import { cn } from '@/lib/utils';
+
+function TrimSlider({ label, resetTitle, value, min, max, onChange }: {
+  label: string;
+  resetTitle: string;
+  value: number;
+  min: number;
+  max: number;
+  onChange: (value: number) => void;
+}) {
+  return (
+    <label className="flex flex-col gap-0.5">
+      <span className="flex justify-between text-[9px] uppercase tracking-wider text-muted-foreground">
+        <span>{label}</span>
+        <button
+          type="button"
+          onClick={() => onChange(1)}
+          title={resetTitle}
+          className={cn('tabular-nums transition-colors', value !== 1 && 'text-foreground hover:text-teal-600')}
+        >
+          {value.toFixed(2)}×
+        </button>
+      </span>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={0.05}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="w-full accent-teal-600"
+      />
+    </label>
+  );
+}
+
+export function LightingTrimControls() {
+  const exposure = useViewerStore((s) => s.envExposure);
+  const setExposure = useViewerStore((s) => s.setEnvExposure);
+  const hardness = useViewerStore((s) => s.envHardness);
+  const setHardness = useViewerStore((s) => s.setEnvHardness);
+  const softness = useViewerStore((s) => s.envSoftness);
+  const setSoftness = useViewerStore((s) => s.setEnvSoftness);
+
+  return (
+    <>
+      <TrimSlider
+        label="Exposure"
+        resetTitle="Reset exposure"
+        value={exposure}
+        min={0.4}
+        max={2}
+        onChange={setExposure}
+      />
+      <TrimSlider
+        label="Light hardness"
+        resetTitle="Reset light hardness — higher deepens shadows by cutting ambient fill"
+        value={hardness}
+        min={0.5}
+        max={2}
+        onChange={setHardness}
+      />
+      <TrimSlider
+        label="Terminator softness"
+        resetTitle="Reset shadow softness — lower crisps the light/shadow edge, higher softens it"
+        value={softness}
+        min={0}
+        max={2}
+        onChange={setSoftness}
+      />
+    </>
+  );
+}

--- a/apps/viewer/src/components/viewer/SunSkyPanel.tsx
+++ b/apps/viewer/src/components/viewer/SunSkyPanel.tsx
@@ -55,6 +55,10 @@ export function SunSkyPanel() {
   const setPreset = useViewerStore((s) => s.setEnvPreset);
   const exposure = useViewerStore((s) => s.envExposure);
   const setExposure = useViewerStore((s) => s.setEnvExposure);
+  const hardness = useViewerStore((s) => s.envHardness);
+  const setHardness = useViewerStore((s) => s.setEnvHardness);
+  const softness = useViewerStore((s) => s.envSoftness);
+  const setSoftness = useViewerStore((s) => s.setEnvSoftness);
 
   const cesiumAvailable = useViewerStore((s) => s.cesiumAvailable);
   const cesiumEnabled = useViewerStore((s) => s.cesiumEnabled);
@@ -204,6 +208,60 @@ export function SunSkyPanel() {
                 className="w-full accent-teal-600"
               />
             </label>
+          )}
+
+          {/* Lighting hardness + shadow feel — WebGPU shading only. These are
+              user trims composed onto the active preset (the preset supplies
+              the base look; switching preset changes the base, the trims
+              persist), mirroring how Exposure works. */}
+          {!cesiumEnabled && (
+            <>
+              <label className="flex flex-col gap-0.5">
+                <span className="flex justify-between text-[9px] uppercase tracking-wider text-muted-foreground">
+                  <span>Light hardness</span>
+                  <button
+                    type="button"
+                    onClick={() => setHardness(1)}
+                    title="Reset light hardness — higher deepens shadows by cutting ambient fill"
+                    className={cn('tabular-nums transition-colors', hardness !== 1 && 'text-foreground hover:text-teal-600')}
+                  >
+                    {hardness.toFixed(2)}×
+                  </button>
+                </span>
+                <input
+                  type="range"
+                  min={0.5}
+                  max={2}
+                  step={0.05}
+                  value={hardness}
+                  onChange={(e) => setHardness(Number(e.target.value))}
+                  className="w-full accent-teal-600"
+                />
+              </label>
+
+              <label className="flex flex-col gap-0.5">
+                <span className="flex justify-between text-[9px] uppercase tracking-wider text-muted-foreground">
+                  <span>Terminator softness</span>
+                  <button
+                    type="button"
+                    onClick={() => setSoftness(1)}
+                    title="Reset shadow softness — lower crisps the light/shadow edge, higher softens it"
+                    className={cn('tabular-nums transition-colors', softness !== 1 && 'text-foreground hover:text-teal-600')}
+                  >
+                    {softness.toFixed(2)}×
+                  </button>
+                </span>
+                <input
+                  type="range"
+                  min={0}
+                  max={2}
+                  step={0.05}
+                  value={softness}
+                  onChange={(e) => setSoftness(Number(e.target.value))}
+                  className="w-full accent-teal-600"
+                />
+              </label>
+            </>
           )}
 
           {/* Sun study — needs a georeferenced model for the real sun */}

--- a/apps/viewer/src/components/viewer/SunSkyPanel.tsx
+++ b/apps/viewer/src/components/viewer/SunSkyPanel.tsx
@@ -26,6 +26,7 @@ import { cn } from '@/lib/utils';
 import type { CesiumDataSource } from '@/store/slices/cesiumSlice';
 import type { SolarSweepMode } from '@/store/slices/solarSlice';
 import { LIGHTING_PRESETS, LIGHTING_PRESET_ORDER, isLightingPresetId } from '@/lib/lighting-presets';
+import { LightingTrimControls } from './LightingTrimControls';
 import { posthog } from '@/lib/analytics';
 import {
   solarDisplayOffsetMinutes,
@@ -53,12 +54,6 @@ export function SunSkyPanel() {
   const setSkyEnabled = useViewerStore((s) => s.setEnvSkyEnabled);
   const preset = useViewerStore((s) => s.envPreset);
   const setPreset = useViewerStore((s) => s.setEnvPreset);
-  const exposure = useViewerStore((s) => s.envExposure);
-  const setExposure = useViewerStore((s) => s.setEnvExposure);
-  const hardness = useViewerStore((s) => s.envHardness);
-  const setHardness = useViewerStore((s) => s.setEnvHardness);
-  const softness = useViewerStore((s) => s.envSoftness);
-  const setSoftness = useViewerStore((s) => s.setEnvSoftness);
 
   const cesiumAvailable = useViewerStore((s) => s.cesiumAvailable);
   const cesiumEnabled = useViewerStore((s) => s.cesiumEnabled);
@@ -184,85 +179,9 @@ export function SunSkyPanel() {
             </label>
           )}
 
-          {/* Exposure — WebGPU shading only, hidden in world-context mode */}
-          {!cesiumEnabled && (
-            <label className="flex flex-col gap-0.5">
-              <span className="flex justify-between text-[9px] uppercase tracking-wider text-muted-foreground">
-                <span>Exposure</span>
-                <button
-                  type="button"
-                  onClick={() => setExposure(1)}
-                  title="Reset exposure"
-                  className={cn('tabular-nums transition-colors', exposure !== 1 && 'text-foreground hover:text-teal-600')}
-                >
-                  {exposure.toFixed(2)}×
-                </button>
-              </span>
-              <input
-                type="range"
-                min={0.4}
-                max={2}
-                step={0.05}
-                value={exposure}
-                onChange={(e) => setExposure(Number(e.target.value))}
-                className="w-full accent-teal-600"
-              />
-            </label>
-          )}
-
-          {/* Lighting hardness + shadow feel — WebGPU shading only. These are
-              user trims composed onto the active preset (the preset supplies
-              the base look; switching preset changes the base, the trims
-              persist), mirroring how Exposure works. */}
-          {!cesiumEnabled && (
-            <>
-              <label className="flex flex-col gap-0.5">
-                <span className="flex justify-between text-[9px] uppercase tracking-wider text-muted-foreground">
-                  <span>Light hardness</span>
-                  <button
-                    type="button"
-                    onClick={() => setHardness(1)}
-                    title="Reset light hardness — higher deepens shadows by cutting ambient fill"
-                    className={cn('tabular-nums transition-colors', hardness !== 1 && 'text-foreground hover:text-teal-600')}
-                  >
-                    {hardness.toFixed(2)}×
-                  </button>
-                </span>
-                <input
-                  type="range"
-                  min={0.5}
-                  max={2}
-                  step={0.05}
-                  value={hardness}
-                  onChange={(e) => setHardness(Number(e.target.value))}
-                  className="w-full accent-teal-600"
-                />
-              </label>
-
-              <label className="flex flex-col gap-0.5">
-                <span className="flex justify-between text-[9px] uppercase tracking-wider text-muted-foreground">
-                  <span>Terminator softness</span>
-                  <button
-                    type="button"
-                    onClick={() => setSoftness(1)}
-                    title="Reset shadow softness — lower crisps the light/shadow edge, higher softens it"
-                    className={cn('tabular-nums transition-colors', softness !== 1 && 'text-foreground hover:text-teal-600')}
-                  >
-                    {softness.toFixed(2)}×
-                  </button>
-                </span>
-                <input
-                  type="range"
-                  min={0}
-                  max={2}
-                  step={0.05}
-                  value={softness}
-                  onChange={(e) => setSoftness(Number(e.target.value))}
-                  className="w-full accent-teal-600"
-                />
-              </label>
-            </>
-          )}
+          {/* WebGPU shading trims (exposure + light hardness + terminator
+              softness) — hidden in world-context mode, where Cesium lights. */}
+          {!cesiumEnabled && <LightingTrimControls />}
 
           {/* Sun study — needs a georeferenced model for the real sun */}
           {cesiumAvailable && (

--- a/apps/viewer/src/components/viewer/Viewport.tsx
+++ b/apps/viewer/src/components/viewer/Viewport.tsx
@@ -14,7 +14,7 @@ import { LIGHTING_PRESETS } from '@/lib/lighting-presets';
 import { presetViewRotation } from '@/lib/preset-view-orientation';
 import { isGeometryLoadStreaming } from '@/lib/pick-gating';
 import { effectiveIsolatedIds } from '@/lib/effective-isolation';
-import { sunLightingForAltitude } from '@/lib/geo/solar-direction';
+import { composeLightingEnvironment } from '@/lib/compose-environment';
 import {
   useSelectionState,
   useVisibilityState,
@@ -420,32 +420,31 @@ export function Viewport({
   // clear, and Cesium draws its own atmosphere.
   const envPreset = useViewerStore((s) => s.envPreset);
   const envExposure = useViewerStore((s) => s.envExposure);
+  const envHardness = useViewerStore((s) => s.envHardness);
+  const envSoftness = useViewerStore((s) => s.envSoftness);
   const solarEnabledForEnv = useViewerStore((s) => s.solarEnabled);
   const solarSunDirection = useViewerStore((s) => s.solarSunDirection);
   const solarSunAltitude = useViewerStore((s) => s.solarSunInfo?.altitude);
 
   const environment = useMemo<LightingEnvironment>(() => {
     const preset = LIGHTING_PRESETS[envPreset].environment;
-    const env: LightingEnvironment = {
-      ...preset,
-      skyEnabled: (preset.skyEnabled ?? false) && !cesiumActive,
-      exposure: (preset.exposure ?? 0.85) * envExposure,
-    };
-    if (solarEnabledForEnv && solarSunDirection) {
-      const altitude = solarSunAltitude
-        ?? Math.asin(Math.max(-1, Math.min(1, solarSunDirection[1]))) * (180 / Math.PI);
-      const sun = sunLightingForAltitude(altitude);
-      env.sunDirection = solarSunDirection;
-      env.sunColor = sun.color;
-      env.sunIntensity = (preset.sunIntensity ?? 0.55) * sun.intensityFactor;
-      env.ambientIntensity = (preset.ambientIntensity ?? 0.25) * sun.ambientFactor;
-      // Let the sky derive its palette from the real sun altitude.
-      delete env.sky;
-    }
-    return env;
+    const solar = (solarEnabledForEnv && solarSunDirection)
+      ? {
+          sunDirection: solarSunDirection,
+          altitudeDeg: solarSunAltitude
+            ?? Math.asin(Math.max(-1, Math.min(1, solarSunDirection[1]))) * (180 / Math.PI),
+        }
+      : null;
+    return composeLightingEnvironment(
+      preset,
+      { exposure: envExposure, hardness: envHardness, softness: envSoftness },
+      { cesiumActive: !!cesiumActive, solar },
+    );
   }, [
     envPreset,
     envExposure,
+    envHardness,
+    envSoftness,
     cesiumActive,
     solarEnabledForEnv,
     solarSunDirection,

--- a/apps/viewer/src/lib/compose-environment.test.ts
+++ b/apps/viewer/src/lib/compose-environment.test.ts
@@ -1,0 +1,105 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { resolveEnvironment } from '@ifc-lite/renderer';
+import { composeLightingEnvironment } from './compose-environment.js';
+import { LIGHTING_PRESETS } from './lighting-presets.js';
+
+const NEUTRAL = { exposure: 1, hardness: 1, softness: 1 } as const;
+const NO_SOLAR = { cesiumActive: false, solar: null } as const;
+
+describe('composeLightingEnvironment — trims', () => {
+  it('neutral trims on the Default preset keep the legacy look (base wrap 0.3)', () => {
+    const env = composeLightingEnvironment(
+      LIGHTING_PRESETS.default.environment,
+      NEUTRAL,
+      NO_SOLAR,
+    );
+    assert.strictEqual(env.sunSoftness, 0.3);
+    assert.strictEqual(env.exposure, 0.85 * 1);
+    // Nothing forced ambient/fill on the empty preset.
+    assert.strictEqual(env.ambientIntensity, undefined);
+    assert.strictEqual(env.fillIntensity, undefined);
+  });
+
+  it('softness trim multiplies the preset base wrap (Overcast 0.85 × 0.5 = 0.425)', () => {
+    const env = composeLightingEnvironment(
+      LIGHTING_PRESETS.overcast.environment,
+      { ...NEUTRAL, softness: 0.5 },
+      NO_SOLAR,
+    );
+    assert.ok(Math.abs((env.sunSoftness ?? 0) - 0.425) < 1e-9);
+  });
+
+  it('hardness > 1 deepens shadows by dividing ambient and fill', () => {
+    // Day preset: ambient 0.3, no explicit fill (compose falls back to 0.15).
+    const env = composeLightingEnvironment(
+      LIGHTING_PRESETS.daylight.environment,
+      { ...NEUTRAL, hardness: 2 },
+      NO_SOLAR,
+    );
+    assert.ok(Math.abs((env.ambientIntensity ?? 0) - 0.15) < 1e-9);
+    assert.ok(Math.abs((env.fillIntensity ?? 0) - 0.075) < 1e-9);
+  });
+
+  it('hardness < 1 flattens the light (raises ambient/fill)', () => {
+    const env = composeLightingEnvironment(
+      LIGHTING_PRESETS.daylight.environment,
+      { ...NEUTRAL, hardness: 0.5 },
+      NO_SOLAR,
+    );
+    assert.ok((env.ambientIntensity ?? 0) > 0.3);
+  });
+
+  it('composes hardness OVER the solar override (ambient is scaled then divided)', () => {
+    const withSolar = composeLightingEnvironment(
+      LIGHTING_PRESETS.daylight.environment,
+      { ...NEUTRAL, hardness: 2 },
+      { cesiumActive: false, solar: { sunDirection: [0, 1, 0], altitudeDeg: 60 } },
+    );
+    const noHardness = composeLightingEnvironment(
+      LIGHTING_PRESETS.daylight.environment,
+      NEUTRAL,
+      { cesiumActive: false, solar: { sunDirection: [0, 1, 0], altitudeDeg: 60 } },
+    );
+    // The solar path set ambient from altitude; hardness=2 halves whatever it produced.
+    assert.ok(Math.abs((withSolar.ambientIntensity ?? 0) - (noHardness.ambientIntensity ?? 0) / 2) < 1e-9);
+    // The solar override also drives the sun direction.
+    assert.deepStrictEqual(withSolar.sunDirection, [0, 1, 0]);
+  });
+
+  it('keeps the sky OFF in world-context (Cesium) even when the preset enables it', () => {
+    assert.strictEqual(LIGHTING_PRESETS.daylight.environment.skyEnabled, true);
+    const env = composeLightingEnvironment(
+      LIGHTING_PRESETS.daylight.environment,
+      NEUTRAL,
+      { cesiumActive: true, solar: null },
+    );
+    assert.strictEqual(env.skyEnabled, false);
+  });
+});
+
+describe('composeLightingEnvironment — renderer clamp contract', () => {
+  it('an over-soft trim is clamped to 1 by the renderer, never exceeding a valid wrap', () => {
+    const composed = composeLightingEnvironment(
+      LIGHTING_PRESETS.overcast.environment, // base 0.85
+      { ...NEUTRAL, softness: 2 },            // → 1.7 before clamp
+      NO_SOLAR,
+    );
+    assert.ok((composed.sunSoftness ?? 0) > 1, 'compose passes the raw product through');
+    const resolved = resolveEnvironment(composed);
+    assert.strictEqual(resolved.sunSoftness, 1, 'renderer clamps the wrap to [0, 1]');
+  });
+
+  it('a zero softness trim yields a crisp terminator (wrap 0) end to end', () => {
+    const composed = composeLightingEnvironment(
+      LIGHTING_PRESETS.daylight.environment,
+      { ...NEUTRAL, softness: 0 },
+      NO_SOLAR,
+    );
+    assert.strictEqual(resolveEnvironment(composed).sunSoftness, 0);
+  });
+});

--- a/apps/viewer/src/lib/compose-environment.ts
+++ b/apps/viewer/src/lib/compose-environment.ts
@@ -1,0 +1,82 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Compose the renderer's lighting environment from a lighting preset and the
+ * user's Phase-1 trims (exposure, light hardness, terminator softness), plus
+ * the optional live sun override from the solar study.
+ *
+ * The trims mirror how Exposure already worked: the PRESET supplies the base
+ * look, so switching presets changes the base while the trims persist. That is
+ * the "if it describes the light it is a preset" split — hardness/softness are
+ * real properties of the sky being simulated (a clear day is crisp, overcast is
+ * soft), and the trim lets the user push that further without editing presets.
+ *
+ * Kept as a pure function (no store, no React) so it can be unit-tested against
+ * the resulting uniform values rather than through the Viewport component.
+ */
+
+import type { LightingEnvironment } from '@ifc-lite/renderer';
+import { sunLightingForAltitude } from './geo/solar-direction.js';
+
+export interface EnvironmentTrims {
+  /** Exposure trim, multiplied onto the preset exposure. 1 = neutral. */
+  exposure: number;
+  /**
+   * Light hardness. 1 = neutral. Above 1 deepens shadows by dividing the
+   * hemisphere ambient + fill; below 1 flattens the light.
+   */
+  hardness: number;
+  /**
+   * Terminator-softness trim, multiplied onto the preset's `sunSoftness`
+   * (renderer default 0.3). 1 = neutral. The renderer clamps to [0, 1].
+   */
+  softness: number;
+}
+
+export interface SolarOverride {
+  /** Sun direction in viewer world space (Y-up), toward the sun. */
+  sunDirection: [number, number, number];
+  /** Resolved sun altitude in degrees. */
+  altitudeDeg: number;
+}
+
+export interface ComposeOptions {
+  /** World-context (Cesium) active — the WebGPU sky stays off while it is. */
+  cesiumActive: boolean;
+  /** Live sun from the solar study, or null/undefined when it is off. */
+  solar?: SolarOverride | null;
+}
+
+export function composeLightingEnvironment(
+  preset: LightingEnvironment,
+  trims: EnvironmentTrims,
+  opts: ComposeOptions,
+): LightingEnvironment {
+  const { exposure, hardness, softness } = trims;
+  const env: LightingEnvironment = {
+    ...preset,
+    skyEnabled: (preset.skyEnabled ?? false) && !opts.cesiumActive,
+    exposure: (preset.exposure ?? 0.85) * exposure,
+    // Terminator softness: user trim on the preset's base wrap. The renderer
+    // clamps the product to [0, 1].
+    sunSoftness: (preset.sunSoftness ?? 0.3) * softness,
+  };
+  if (opts.solar) {
+    const sun = sunLightingForAltitude(opts.solar.altitudeDeg);
+    env.sunDirection = opts.solar.sunDirection;
+    env.sunColor = sun.color;
+    env.sunIntensity = (preset.sunIntensity ?? 0.55) * sun.intensityFactor;
+    env.ambientIntensity = (preset.ambientIntensity ?? 0.25) * sun.ambientFactor;
+    // Let the sky derive its palette from the real sun altitude.
+    delete env.sky;
+  }
+  // Light hardness: deepen shadows by cutting the hemisphere ambient + fill.
+  // Applied last so it composes over the solar override's ambient too.
+  if (hardness !== 1) {
+    env.ambientIntensity = (env.ambientIntensity ?? 0.25) / hardness;
+    env.fillIntensity = (env.fillIntensity ?? 0.15) / hardness;
+  }
+  return env;
+}

--- a/apps/viewer/src/lib/lighting-presets.ts
+++ b/apps/viewer/src/lib/lighting-presets.ts
@@ -49,6 +49,8 @@ export const LIGHTING_PRESETS: Record<LightingPresetId, LightingPreset> = {
       skyColor: [0.42, 0.52, 0.65],
       groundColor: [0.22, 0.19, 0.15],
       ambientIntensity: 0.3,
+      // A small clear-sky sun casts a crisp terminator.
+      sunSoftness: 0.12,
       exposure: 0.9,
     },
   },
@@ -66,6 +68,8 @@ export const LIGHTING_PRESETS: Record<LightingPresetId, LightingPreset> = {
       ambientIntensity: 0.45,
       fillIntensity: 0.1,
       rimIntensity: 0.08,
+      // A cloud-covered sky is a huge effective source — near-shadowless.
+      sunSoftness: 0.85,
       exposure: 0.85,
       sky: {
         zenith: [0.5, 0.54, 0.58],
@@ -86,6 +90,8 @@ export const LIGHTING_PRESETS: Record<LightingPresetId, LightingPreset> = {
       skyColor: [0.3, 0.26, 0.32],
       groundColor: [0.16, 0.11, 0.08],
       ambientIntensity: 0.22,
+      // Low sun, still a small source — crisp, long shadows.
+      sunSoftness: 0.18,
       exposure: 0.82,
     },
   },
@@ -103,6 +109,8 @@ export const LIGHTING_PRESETS: Record<LightingPresetId, LightingPreset> = {
       ambientIntensity: 0.3,
       fillIntensity: 0.08,
       rimIntensity: 0.2,
+      // Moonlight reads a touch softer than a clear-day sun.
+      sunSoftness: 0.4,
       exposure: 0.75,
       // Explicit night sky — the altitude-derived palette would read the
       // high moon direction as a midday sun and paint a blue daytime sky.

--- a/apps/viewer/src/store/slices/environmentSlice.ts
+++ b/apps/viewer/src/store/slices/environmentSlice.ts
@@ -30,12 +30,26 @@ export interface EnvironmentSlice {
   envSkyEnabled: boolean;
   /** User exposure trim, multiplied onto the preset exposure. 1 = neutral. */
   envExposure: number;
+  /**
+   * Light hardness trim. 1 = neutral. Above 1 deepens shadows by dividing the
+   * preset's hemisphere ambient + fill (more sun-vs-ambient contrast); below 1
+   * flattens the light. Composed onto the preset in Viewport.
+   */
+  envHardness: number;
+  /**
+   * Terminator-softness trim, multiplied onto the preset's `sunSoftness`.
+   * 1 = neutral. Below 1 crisps the light/shadow boundary (harder shadows),
+   * above 1 softens it. The renderer clamps the product to [0, 1].
+   */
+  envSoftness: number;
   /** Whether the Sun & Sky panel is open. */
   envPanelOpen: boolean;
 
   setEnvPreset: (preset: LightingPresetId) => void;
   setEnvSkyEnabled: (enabled: boolean) => void;
   setEnvExposure: (exposure: number) => void;
+  setEnvHardness: (hardness: number) => void;
+  setEnvSoftness: (softness: number) => void;
   setEnvPanelOpen: (open: boolean) => void;
   toggleEnvPanel: () => void;
 }
@@ -46,6 +60,8 @@ interface PersistedEnvironment {
   preset?: string;
   skyEnabled?: boolean;
   exposure?: number;
+  hardness?: number;
+  softness?: number;
 }
 
 function loadPersisted(): PersistedEnvironment {
@@ -59,12 +75,14 @@ function loadPersisted(): PersistedEnvironment {
   }
 }
 
-function persist(state: Pick<EnvironmentSlice, 'envPreset' | 'envSkyEnabled' | 'envExposure'>): void {
+function persist(state: Pick<EnvironmentSlice, 'envPreset' | 'envSkyEnabled' | 'envExposure' | 'envHardness' | 'envSoftness'>): void {
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify({
       preset: state.envPreset,
       skyEnabled: state.envSkyEnabled,
       exposure: state.envExposure,
+      hardness: state.envHardness,
+      softness: state.envSoftness,
     } satisfies PersistedEnvironment));
   } catch { /* storage unavailable */ }
 }
@@ -74,12 +92,24 @@ function clampExposure(value: number): number {
   return Math.min(2, Math.max(0.4, value));
 }
 
+function clampHardness(value: number): number {
+  if (!Number.isFinite(value)) return 1;
+  return Math.min(2, Math.max(0.5, value));
+}
+
+function clampSoftness(value: number): number {
+  if (!Number.isFinite(value)) return 1;
+  return Math.min(2, Math.max(0, value));
+}
+
 export const createEnvironmentSlice: StateCreator<EnvironmentSlice, [], [], EnvironmentSlice> = (set, get) => {
   const stored = loadPersisted();
   const initial = {
     envPreset: (stored.preset && isLightingPresetId(stored.preset) ? stored.preset : 'default') as LightingPresetId,
     envSkyEnabled: stored.skyEnabled === true,
     envExposure: clampExposure(stored.exposure ?? 1),
+    envHardness: clampHardness(stored.hardness ?? 1),
+    envSoftness: clampSoftness(stored.softness ?? 1),
   };
 
   const update = (patch: Partial<EnvironmentSlice>) => {
@@ -95,6 +125,8 @@ export const createEnvironmentSlice: StateCreator<EnvironmentSlice, [], [], Envi
     setEnvPreset: (preset) => update({ envPreset: preset }),
     setEnvSkyEnabled: (enabled) => update({ envSkyEnabled: enabled }),
     setEnvExposure: (exposure) => update({ envExposure: clampExposure(exposure) }),
+    setEnvHardness: (hardness) => update({ envHardness: clampHardness(hardness) }),
+    setEnvSoftness: (softness) => update({ envSoftness: clampSoftness(softness) }),
     setEnvPanelOpen: (open) => set({ envPanelOpen: open }),
     toggleEnvPanel: () => set((s) => ({ envPanelOpen: !s.envPanelOpen })),
   };

--- a/packages/renderer/src/environment.test.ts
+++ b/packages/renderer/src/environment.test.ts
@@ -30,6 +30,7 @@ describe('resolveEnvironment', () => {
     assert.strictEqual(env.ambientIntensity, 0.25);
     assert.strictEqual(env.fillIntensity, 0.15);
     assert.strictEqual(env.rimIntensity, 0.15);
+    assert.strictEqual(env.sunSoftness, 0.3);
     assert.strictEqual(env.exposure, 0.85);
     assert.strictEqual(env.skyEnabled, false);
   });
@@ -129,6 +130,7 @@ describe('packEnvironmentUniforms', () => {
       ambientIntensity: 0.3,
       fillIntensity: 0.11,
       rimIntensity: 0.12,
+      sunSoftness: 0.42,
       exposure: 1.0,
     });
     const buf = packEnvironmentUniforms(env);
@@ -141,12 +143,32 @@ describe('packEnvironmentUniforms', () => {
     assertClose(buf[12], 0.4);
     assertClose(buf[15], 0.11);
     assertClose(buf[16], 0.12);
+    assertClose(buf[17], 0.42);
   });
 
   it('reuses the caller-provided output buffer', () => {
     const out = new Float32Array(ENVIRONMENT_UNIFORM_SIZE / 4);
     const env = resolveEnvironment();
     assert.strictEqual(packEnvironmentUniforms(env, out), out);
+  });
+});
+
+describe('sunSoftness (terminator wrap)', () => {
+  it('defaults to the historic hardcoded wrap of 0.3 and lands in float 17', () => {
+    const buf = packEnvironmentUniforms(resolveEnvironment());
+    assertClose(buf[17], 0.3);
+  });
+
+  it('clamps to [0, 1]', () => {
+    assert.strictEqual(resolveEnvironment({ sunSoftness: -0.5 }).sunSoftness, 0);
+    assert.strictEqual(resolveEnvironment({ sunSoftness: 2.5 }).sunSoftness, 1);
+    assert.strictEqual(resolveEnvironment({ sunSoftness: 0.6 }).sunSoftness, 0.6);
+  });
+
+  it('maps a non-finite softness to 0 (crisp terminator), never NaN in the uniform', () => {
+    assert.strictEqual(resolveEnvironment({ sunSoftness: NaN }).sunSoftness, 0);
+    const buf = packEnvironmentUniforms(resolveEnvironment({ sunSoftness: Infinity }));
+    assert.ok(Number.isFinite(buf[17]));
   });
 });
 

--- a/packages/renderer/src/environment.test.ts
+++ b/packages/renderer/src/environment.test.ts
@@ -167,8 +167,9 @@ describe('sunSoftness (terminator wrap)', () => {
 
   it('maps a non-finite softness to 0 (crisp terminator), never NaN in the uniform', () => {
     assert.strictEqual(resolveEnvironment({ sunSoftness: NaN }).sunSoftness, 0);
+    assert.strictEqual(resolveEnvironment({ sunSoftness: Infinity }).sunSoftness, 0);
     const buf = packEnvironmentUniforms(resolveEnvironment({ sunSoftness: Infinity }));
-    assert.ok(Number.isFinite(buf[17]));
+    assert.strictEqual(buf[17], 0);
   });
 });
 

--- a/packages/renderer/src/environment.ts
+++ b/packages/renderer/src/environment.ts
@@ -42,6 +42,14 @@ export interface LightingEnvironment {
   fillIntensity?: number;
   /** Rim-light strength (historic default 0.15). */
   rimIntensity?: number;
+  /**
+   * Sun terminator softness — the diffuse "wrap" that lifts the light/shadow
+   * boundary off a hard `max(N·L, 0)` toward wrap-around lighting. 0 is a crisp
+   * terminator (hard shadows); larger values soften it (overcast look). Historic
+   * default 0.3 (the value the term was hardcoded to before it was exposed).
+   * Clamped to [0, 1] on resolve.
+   */
+  sunSoftness?: number;
   /** Pre-tonemap exposure multiplier (historic default 0.85). */
   exposure?: number;
   /**
@@ -108,6 +116,12 @@ function lerp3(a: Vec3Color, b: Vec3Color, t: number): Vec3Color {
 function band(x: number, lo: number, hi: number): number {
   const t = Math.min(1, Math.max(0, (x - lo) / (hi - lo)));
   return t * t * (3 - 2 * t);
+}
+
+/** Clamp to [0, 1], mapping any non-finite input to 0. */
+function clamp01(x: number): number {
+  if (!Number.isFinite(x)) return 0;
+  return Math.min(1, Math.max(0, x));
 }
 
 /**
@@ -178,6 +192,7 @@ export function resolveEnvironment(env?: LightingEnvironment): ResolvedEnvironme
     ambientIntensity: env?.ambientIntensity ?? 0.25,
     fillIntensity: env?.fillIntensity ?? 0.15,
     rimIntensity: env?.rimIntensity ?? 0.15,
+    sunSoftness: clamp01(env?.sunSoftness ?? 0.3),
     exposure: env?.exposure ?? 0.85,
     skyEnabled: env?.skyEnabled ?? false,
     sky: {
@@ -198,7 +213,7 @@ export const ENVIRONMENT_UNIFORM_SIZE = 80;
  *   sunColor: vec3     + ambientIntensity: f32  → floats 4..7
  *   skyColor: vec3     + exposure: f32          → floats 8..11
  *   groundColor: vec3  + fillIntensity: f32     → floats 12..15
- *   rimIntensity: f32  + 3 pad floats           → floats 16..19
+ *   rimIntensity: f32  + sunSoftness: f32 + 2 pad → floats 16..19
  */
 export function packEnvironmentUniforms(
   env: ResolvedEnvironment,
@@ -222,7 +237,7 @@ export function packEnvironmentUniforms(
   buf[14] = env.groundColor[2];
   buf[15] = env.fillIntensity;
   buf[16] = env.rimIntensity;
-  buf[17] = 0;
+  buf[17] = env.sunSoftness;
   buf[18] = 0;
   buf[19] = 0;
   return buf;

--- a/packages/renderer/src/shaders/main.wgsl.ts
+++ b/packages/renderer/src/shaders/main.wgsl.ts
@@ -38,7 +38,7 @@ export const mainShaderSource = `
           groundColor: vec3<f32>,       // hemisphere-ambient ground tint
           fillIntensity: f32,
           rimIntensity: f32,
-          _pad0: f32,
+          sunSoftness: f32,
           _pad1: f32,
           _pad2: f32,
         }
@@ -364,9 +364,11 @@ export const mainShaderSource = `
           let hemisphereFactor = N.y * 0.5 + 0.5;
           let ambient = mix(env.groundColor, env.skyColor, hemisphereFactor) * env.ambientIntensity;
 
-          // Two-sided sun light so inner faces (I-beam channels) stay visible
+          // Two-sided sun light so inner faces (I-beam channels) stay visible.
+          // sunSoftness is the diffuse wrap (env uniform): 0 = crisp
+          // terminator (hard shadows), larger = softer wrap-around (overcast).
           let NdotL = abs(dot(N, sunLight));
-          let wrap = 0.3;
+          let wrap = env.sunSoftness;
           let diffuseSun = max((NdotL + wrap) / (1.0 + wrap), 0.0) * env.sunIntensity;
 
           // Fill light - two-sided

--- a/packages/renderer/src/sun-softness-wiring.test.ts
+++ b/packages/renderer/src/sun-softness-wiring.test.ts
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mainShaderSource } from './shaders/main.wgsl.js';
+
+/**
+ * The single line that makes the terminator-softness slider do anything.
+ *
+ * `main.wgsl.ts` used to hard-code `let wrap = 0.3;`. #2688 replaced that with
+ * a read of the environment uniform so the preset base and the user's trim
+ * actually reach the shading. Reverting just that one line to a numeric
+ * literal leaves the whole feature inert: the uniform is still packed, the
+ * slider still moves, the store still updates, the presets still differ — and
+ * nothing renders differently.
+ *
+ * That mutation was measured surviving with BYTE-IDENTICAL pass/fail counts
+ * across the renderer suite (843 pass / 3 fail) and the viewer suite
+ * (2722 / 206). Every other guard on this feature sits either upstream of the
+ * shader (uniform packing, clamp contract, preset composition) or downstream
+ * of it (the slider's store wiring), so none of them can observe the shader
+ * ceasing to read the value. This test is at the only level that can.
+ *
+ * Modelled on `sky-shader.test.ts`, including its guard-the-guard clause: a
+ * regex that finds nothing passes vacuously, so the construct's continued
+ * existence is asserted too.
+ */
+describe('sun softness reaches the shader (#2688)', () => {
+  it('reads the terminator wrap from the environment uniform, not a literal', () => {
+    const assignments = [...mainShaderSource.matchAll(/let\s+wrap\s*=\s*([^;]+);/g)];
+
+    // Guard the guard: if `wrap` is renamed or the diffuse-wrap term is
+    // removed, the regex below would find nothing and pass for no reason.
+    assert.ok(
+      assignments.length >= 1,
+      'expected the main shader to keep a `let wrap = ...` diffuse-wrap term',
+    );
+
+    for (const m of assignments) {
+      const rhs = m[1].trim();
+      assert.ok(
+        rhs.includes('env.sunSoftness'),
+        `\`let wrap = ${rhs}\` does not read env.sunSoftness — the softness slider is inert`,
+      );
+      assert.ok(
+        !/^-?\d+(\.\d+)?$/.test(rhs),
+        `\`let wrap = ${rhs}\` is a numeric literal — the softness slider is inert`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## What and why

Phase 1 of the Blender-like lighting work (#2670). In the standalone WebGPU viewer the lighting was preset + exposure only; there was no way to control shadow *feel*. This adds two user-facing controls and the one renderer field they need. Maintainer picked the phased plan in #2670 (cheap light-hardness controls now, real cast shadows as a separate perf-gated Phase 2), and endorsed the `sunSoftness`/trim design there.

**Renderer (`@ifc-lite/renderer`)** — `LightingEnvironment` gains a `sunSoftness` field: the diffuse wrap that sets the sun terminator, previously hardcoded to `0.3` in `main.wgsl`. `0` is a crisp light/shadow boundary (harder shadows), larger softens it (overcast). Packed into a spare pad slot of the existing environment uniform (**no UBO size change**) and clamped to `[0, 1]`; omitting it reproduces the historic look exactly.

**Viewer (`@ifc-lite/viewer`)** — the Sun & Sky panel adds two sliders (WebGPU shading, hidden in world-context mode):
- **Light hardness** — deepens shadows by cutting the hemisphere ambient + fill.
- **Terminator softness** — trims the preset's `sunSoftness`.

Both are user *trims* composed onto the active preset (the preset supplies the base, switching presets changes the base, the trims persist), mirroring how Exposure already works — the "if it describes the light, it's a preset" split from #2670. Presets now carry per-preset softness (crisp Day/Evening, soft Overcast) so the terminator changes with the sky being simulated. Settings persist in localStorage.

The composition is a pure `composeLightingEnvironment()` helper (no store, no React), so it is unit-tested against the resulting uniform values rather than through the Viewport component.

Not in this PR (deliberately, per #2670): real sun cast shadows (shadow mapping + softness = penumbra) — that is the perf-gated Phase 2. An SSAO "Contact shadows" slider was prototyped and dropped: the existing screen-space AO is a sub-pixel hairline on BIM models and can't deliver the "slab-on-wall" darkening users expect; that belongs to Phase 2's cast shadows.

## How it was verified

- `pnpm turbo run test typecheck --filter=@ifc-lite/renderer` — **929 pass, 0 fail**, typecheck clean.
- `@ifc-lite/viewer` typecheck clean; new `compose-environment.test.ts` passes (**8/8**), asserting behaviour through stated invariants:
  - softness trim multiplies the preset base wrap; hardness divides ambient + fill and composes *over* the solar override; Cesium keeps the sky off; and the end-to-end renderer clamp (an over-soft trim resolves to wrap `1`, a zero trim to `0`).
  - renderer `environment.test.ts` pins `sunSoftness` default `0.3`, `[0,1]` clamp, non-finite → `0`, and its uniform slot.
- `pnpm api-surface:update` — export surface matches (additive field only).
- Manual: dev viewer (Edge/WebGPU) — both sliders change the look live; trims persist across preset switches and reload; controls hide under world-context. Tested by the branch author.

- [x] `pnpm test` (renderer) passes locally; viewer typecheck clean (viewer's full `pnpm test` uses a unix-only `find | sort` invocation that fails on a Windows shell — unrelated to this change; runs on CI/Linux)
- [ ] Geometry/WASM change: n/a

## Checklist

- [x] A test asserts the new behavior through a stated invariant
- [x] Published `packages/*` touched: added a changeset (`@ifc-lite/renderer` + `@ifc-lite/viewer` minor); ran `pnpm api-surface:update` (additive field)
- [x] Geometry-output change: none (shading/lighting only)
- [x] House rules: no `as any` / `@ts-ignore`, no silent `catch {}`, no oversized module, no repo-wide `cargo fmt`
- [x] No client or project identifiers in code, tests, commit messages, or this PR

Addresses #2670 (Phase 1). Phase 2 (real sun cast shadows) remains open in the same issue — do NOT auto-close on merge.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added WebGPU controls for exposure, light hardness, and terminator softness.
  - Settings persist between sessions and can be reset to neutral values.
  - Lighting presets now provide distinct shadow characteristics for daylight, overcast, golden-hour, and night scenes.
  - Solar and world-context views automatically adapt lighting behavior; controls are hidden in world-context mode.
  - Added configurable sun softness for more natural, adjustable shadow transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->