### PR TITLE
fix(drawing-2d): inward-wound solids lose their line work entirely (#2682)

### DIFF
--- a/.changeset/tidy-drawings-face-outward.md
+++ b/.changeset/tidy-drawings-face-outward.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/drawing-2d": patch
+---
+
+Orient mesh normals by signed volume before silhouette extraction, so an inward-wound solid no longer loses its projected line work (#2682). The silhouette test is winding-sensitive: on an inward-wound mesh it picked the far side of the solid, which the projection band then dropped, producing a blank drawing with no error. A mesh and its reversed twin now yield identical line work.

--- a/packages/drawing-2d/src/drawing-generator.test.ts
+++ b/packages/drawing-2d/src/drawing-generator.test.ts
@@ -369,3 +369,99 @@ describe('generate() outline provider basis agreement (PR #2644 review)', () => 
     expect(farLines.every((l) => l.line.start.x <= -90 && l.line.end.x <= -90)).toBe(true);
   });
 });
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Issue #2682 — line work must survive a mesh that is not outward-wound
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * The same mesh with every triangle's last two indices swapped: identical
+ * positions and identical edges, every face wound INWARD.
+ *
+ * ifc-lite's winding is explicitly unreliable (`MeshData.indices`), so this is
+ * a shape the generator really receives — not a synthetic curiosity.
+ */
+function reverseWinding(mesh: MeshData): MeshData {
+  const indices = new Uint32Array(mesh.indices.length);
+  for (let t = 0; t + 2 < mesh.indices.length; t += 3) {
+    indices[t] = mesh.indices[t];
+    indices[t + 1] = mesh.indices[t + 2];
+    indices[t + 2] = mesh.indices[t + 1];
+  }
+  return { ...mesh, indices };
+}
+
+/** Order-independent identity of a drawing line: endpoints, band and depths. */
+function lineIdentity(l: DrawingLine): string {
+  const a = `${l.line.start.x.toFixed(6)},${l.line.start.y.toFixed(6)}`;
+  const b = `${l.line.end.x.toFixed(6)},${l.line.end.y.toFixed(6)}`;
+  const [lo, hi] = a <= b ? [a, b] : [b, a];
+  const depths = [l.depth ?? 0, l.depthEnd ?? l.depth ?? 0].map((d) => d.toFixed(6)).sort();
+  return `${lo}|${hi}|${l.category}|${l.visibility}|${depths.join('~')}`;
+}
+
+/** Bounded projection bands, i.e. what a real floor plan uses. */
+function bandedPlanConfig(position: number): SectionConfig {
+  return {
+    plane: { axis: 'y', position, flipped: false },
+    projectionDepth: 3,
+    projectionBelowDepth: 3,
+    projectionAboveDepth: 3,
+    includeHiddenLines: true,
+    creaseAngle: 30,
+    scale: 100,
+  };
+}
+
+async function drawingFor(meshes: MeshData[], config: SectionConfig) {
+  const generator = new Drawing2DGenerator();
+  await generator.initialize();
+  return generator.generate(meshes, config, GEN_OPTIONS);
+}
+
+describe('generate() line work on non-outward-wound meshes (issue #2682)', () => {
+  // A tall element — a shaft/core wall spanning several storeys, world Y in
+  // [0, 10] — cut in plan at Y = 9.5 with the usual 3 m projection bands.
+  // Its NEAR rim (the top, Y = 10) is in band; its FAR rim (the base, Y = 0)
+  // is 9.5 m away and the band drops it.
+  const tallOutward = () => boxMesh(1, [0, 0, 0], [4, 10, 4]);
+
+  it('draws the outline of an INWARD-wound element instead of a blank sheet', async () => {
+    const config = bandedPlanConfig(9.5);
+
+    const outward = await drawingFor([tallOutward()], config);
+    const inward = await drawingFor([reverseWinding(tallOutward())], config);
+
+    const outwardLines = projectionLinesOf(outward.lines, 1);
+    const inwardLines = projectionLinesOf(inward.lines, 1);
+
+    // The control: an outward-wound box gets its four outline lines.
+    expect(outwardLines.length).toBe(4);
+
+    // The defect: the inward-wound twin used to silhouette the FAR rim, which
+    // the projection band culls, leaving ZERO projection lines. The winding
+    // must not decide whether the element is drawn at all.
+    expect(inwardLines.length).toBe(4);
+
+    // Acceptance (issue #2682): same positions, reversed index order, SAME
+    // line work — right down to the band and the hidden-line depths.
+    expect(inwardLines.map(lineIdentity).sort()).toEqual(outwardLines.map(lineIdentity).sort());
+  });
+
+  it('keeps the whole drawing identical for the inward-wound twin of a multi-element scene', async () => {
+    // Two boxes, one occluding the other, viewed with generous bands — the
+    // uncut "3D view" shape the PDF export uses. Every line the generator can
+    // emit (cut, projection, visibility, depth) must be winding-independent.
+    const config = sectionConfig({ axis: 'z', position: 0, flipped: false });
+
+    const outward = await drawingFor([farBox(), nearBox()], config);
+    const inward = await drawingFor(
+      [reverseWinding(farBox()), reverseWinding(nearBox())],
+      config,
+    );
+
+    expect(outward.lines.length).toBeGreaterThan(0);
+    expect(inward.lines.map(lineIdentity).sort()).toEqual(outward.lines.map(lineIdentity).sort());
+    expect(inward.bounds).toEqual(outward.bounds);
+  });
+});

--- a/packages/drawing-2d/src/edge-extractor.test.ts
+++ b/packages/drawing-2d/src/edge-extractor.test.ts
@@ -166,3 +166,94 @@ describe('EdgeExtractor origin lift (world = origin + local)', () => {
     }
   });
 });
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Issue #2682 — winding-robust silhouettes
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * The same mesh with every triangle's last two indices swapped: identical
+ * positions, identical edges, every face wound INWARD.
+ */
+function reverseWinding(mesh: MeshData): MeshData {
+  const indices = new Uint32Array(mesh.indices.length);
+  for (let t = 0; t + 2 < mesh.indices.length; t += 3) {
+    indices[t] = mesh.indices[t];
+    indices[t + 1] = mesh.indices[t + 2];
+    indices[t + 2] = mesh.indices[t + 1];
+  }
+  return { ...mesh, indices };
+}
+
+/** Order-independent identity of a projection line: endpoints + band + depth. */
+function lineKey(line: {
+  line: { start: { x: number; y: number }; end: { x: number; y: number } };
+  visibility: string;
+  depth?: number;
+  depthEnd?: number;
+}): string {
+  const a = `${line.line.start.x.toFixed(6)},${line.line.start.y.toFixed(6)}`;
+  const b = `${line.line.end.x.toFixed(6)},${line.line.end.y.toFixed(6)}`;
+  const [lo, hi] = a <= b ? [a, b] : [b, a];
+  const depths = [line.depth ?? 0, line.depthEnd ?? line.depth ?? 0]
+    .map((d) => d.toFixed(6))
+    .sort();
+  return `${lo}|${hi}|${line.visibility}|${depths.join('~')}`;
+}
+
+function silhouetteLinesFor(mesh: MeshData) {
+  const extractor = new EdgeExtractor(30);
+  const edges = extractor.extractEdges(mesh);
+  const silhouettes = extractor.extractSilhouettes(edges, getViewDirectionForPlane(planPlane));
+  return extractor.edgesToProjectionLines(silhouettes, planPlane, { below: 3, above: 3 });
+}
+
+describe('EdgeExtractor winding robustness (issue #2682)', () => {
+  // A TALL element (local Y in [-5, 0.5]) cut in plan at Y = 1 with a 3 m
+  // projection band: the NEAR rim (Y = 0.5) is in band, the FAR rim (Y = -5)
+  // is not. The winding-sensitive silhouette test picks the far rim on an
+  // inward-wound solid, and the band then drops it — a blank drawing.
+  //
+  // NOTE: this file's shared `boxMesh` is itself wound INWARD (signed volume
+  // -4 for the 2 x h x 2 box). That is not a slip in the fixture, it is
+  // ifc-lite winding in the wild, and it is why the tests above never noticed:
+  // their boxes are short enough for the far rim to stay inside the band. The
+  // outward-wound twin is the REVERSED one.
+  const tallInward = () => boxMesh(7, -5, 0.5);
+  const tallOutward = () => reverseWinding(boxMesh(7, -5, 0.5));
+
+  it('gives an inward-wound solid the same silhouette line work as its outward twin', () => {
+    const outward = silhouetteLinesFor(tallOutward());
+    const inward = silhouetteLinesFor(tallInward());
+
+    // Existence first, so the equality below cannot pass on two empty sets.
+    expect(outward.length).toBe(4);
+    expect(inward.length).toBe(4);
+    expect(inward.map(lineKey).sort()).toEqual(outward.map(lineKey).sort());
+  });
+
+  // CONTROL, not a guard: an open sheet has no enclosed volume, so the
+  // orientation test is inconclusive and the mesh is left alone. This is green
+  // both with and without the fix by construction — its job is to pin that a
+  // zero-volume mesh survives the new code path unchanged, not to catch a
+  // regression in it. The falsifiable anti-overcorrection assertion is
+  // `expect(outward.length).toBe(4)` above: invert the sign test and a
+  // correctly wound solid loses its near rim.
+  it('leaves an open (zero-volume) sheet alone — the orientation test stays inconclusive', () => {
+    const positions = new Float32Array([0, 0, 0, 2, 0, 0, 2, 0, 2, 0, 0, 2]);
+    const sheet: MeshData = {
+      expressId: 8,
+      ifcType: 'IfcSlab',
+      modelIndex: 0,
+      positions,
+      normals: new Float32Array(positions.length),
+      indices: new Uint32Array([0, 1, 2, 0, 2, 3]),
+      color: [1, 1, 1, 1],
+    };
+    const outward = silhouetteLinesFor(sheet);
+    const inward = silhouetteLinesFor(reverseWinding(sheet));
+
+    expect(outward.length).toBeGreaterThan(0);
+    expect(inward.map(lineKey).sort()).toEqual(outward.map(lineKey).sort());
+  });
+});

--- a/packages/drawing-2d/src/edge-extractor.ts
+++ b/packages/drawing-2d/src/edge-extractor.ts
@@ -66,6 +66,30 @@ import {
  */
 const SILHOUETTE_EPSILON = 1e-4;
 
+/**
+ * Scale-relative floor for trusting the signed-volume winding test (issue
+ * #2682).
+ *
+ * The silhouette test is NOT symmetric under a global winding flip: it keeps
+ * an edge whose faces differ in "is front-facing", and the deadband lumps
+ * perpendicular faces in with back-facing ones. For an outward-wound box in
+ * plan that yields the TOP rim (the face pointing at the viewer against the
+ * four perpendicular sides); flip the winding and the same test yields the
+ * BOTTOM rim instead — the far side of the solid. Both project to the same
+ * square, so the defect hides until the far rim falls outside the projection
+ * band, at which point the line work is simply GONE (a blank sheet, produced
+ * successfully). See `windingSign`.
+ *
+ * The fix orients the mesh by its signed volume before classifying, which is
+ * only meaningful when the volume is decisively non-zero. An open shell or a
+ * flat sheet integrates to ~0 and an inconsistently wound mesh to something
+ * arbitrary, so the sign is only trusted when |V| clears this fraction of the
+ * mesh's bounding-box volume (diagonal³). A closed box sits around 0.19 of
+ * that; a 1 mm sheet spanning 4 m sits near 1e-4. 1e-6 is far below any real
+ * solid and far above f32 integration noise.
+ */
+const WINDING_VOLUME_EPSILON = 1e-6;
+
 // ═══════════════════════════════════════════════════════════════════════════
 // TYPES
 // ═══════════════════════════════════════════════════════════════════════════
@@ -125,6 +149,21 @@ export class EdgeExtractor {
       this.registerEdge(edgeMap, i0, i1, t);
       this.registerEdge(edgeMap, i1, i2, t);
       this.registerEdge(edgeMap, i2, i0, t);
+    }
+
+    // Orient the face normals OUTWARD before classification (issue #2682).
+    // ifc-lite's winding is explicitly unreliable (see `MeshData.indices`), and
+    // the silhouette test is winding-sensitive, so an inward-wound solid
+    // silhouettes its far side and can lose its line work entirely. Negating
+    // every normal is exactly what reversing every triangle does, so a mesh and
+    // its reversed twin now classify identically. Crease classification is
+    // unaffected: the dihedral angle between two normals is invariant under
+    // negating both.
+    if (this.windingSign(positions, indices) < 0) {
+      for (let f = 0; f < faceNormals.length; f++) {
+        const n = faceNormals[f];
+        faceNormals[f] = vec3(-n.x, -n.y, -n.z);
+      }
     }
 
     // Second pass: classify edges
@@ -295,6 +334,67 @@ export class EdgeExtractor {
           positions[base + 2] + origin[2],
         )
       : vec3(positions[base], positions[base + 1], positions[base + 2]);
+  }
+
+  /**
+   * `-1` when the mesh is a closed solid wound INWARD, `+1` otherwise
+   * (issue #2682).
+   *
+   * Six times the enclosed signed volume is `Σ v0 · (v1 × v2)`, positive for
+   * outward winding. It is translation-invariant for a closed mesh, so the sum
+   * is taken relative to the first vertex to keep the terms small and the
+   * cancellation honest on RTC-shifted coordinates.
+   *
+   * `+1` is the deliberate answer whenever the test is inconclusive — an open
+   * shell, a flat sheet, or an inconsistently wound mesh integrates to ~0 (or
+   * to an arbitrary number) and gets the pre-existing behaviour rather than a
+   * coin-flip reorientation. Positions are read directly rather than through
+   * `getVertex` because the per-element `origin` is a pure translation and
+   * therefore cannot change the result.
+   */
+  private windingSign(positions: Float32Array, indices: Uint32Array): 1 | -1 {
+    const triangleCount = Math.floor(indices.length / 3);
+    if (triangleCount === 0 || positions.length < 3) return 1;
+
+    const rx = positions[indices[0] * 3];
+    const ry = positions[indices[0] * 3 + 1];
+    const rz = positions[indices[0] * 3 + 2];
+
+    let volume6 = 0;
+    let minX = Infinity, minY = Infinity, minZ = Infinity;
+    let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
+
+    const track = (x: number, y: number, z: number): void => {
+      if (x < minX) minX = x;
+      if (x > maxX) maxX = x;
+      if (y < minY) minY = y;
+      if (y > maxY) maxY = y;
+      if (z < minZ) minZ = z;
+      if (z > maxZ) maxZ = z;
+    };
+
+    for (let t = 0; t < triangleCount; t++) {
+      const b0 = indices[t * 3] * 3;
+      const b1 = indices[t * 3 + 1] * 3;
+      const b2 = indices[t * 3 + 2] * 3;
+
+      const ax = positions[b0] - rx, ay = positions[b0 + 1] - ry, az = positions[b0 + 2] - rz;
+      const bx = positions[b1] - rx, by = positions[b1 + 1] - ry, bz = positions[b1 + 2] - rz;
+      const cx = positions[b2] - rx, cy = positions[b2 + 1] - ry, cz = positions[b2 + 2] - rz;
+
+      // a · (b × c)
+      volume6 += ax * (by * cz - bz * cy) + ay * (bz * cx - bx * cz) + az * (bx * cy - by * cx);
+
+      track(ax, ay, az);
+      track(bx, by, bz);
+      track(cx, cy, cz);
+    }
+
+    const dx = maxX - minX, dy = maxY - minY, dz = maxZ - minZ;
+    const diagonal = Math.sqrt(dx * dx + dy * dy + dz * dz);
+    const floor = WINDING_VOLUME_EPSILON * diagonal * diagonal * diagonal;
+
+    return volume6 / 6 < -floor ? -1 : 1;
   }
 
   private computeFaceNormal(v0: Vec3, v1: Vec3, v2: Vec3): Vec3 {


### PR DESCRIPTION
Closes #2682.

## The defect

`EdgeExtractor.extractSilhouettes` keeps an edge whose two adjacent faces disagree about being front-facing. That test is winding-sensitive, and ifc-lite winding is explicitly unreliable (`MeshData.indices` in `packages/geometry/src/types.ts` says so).

For an outward-wound box in plan the test yields the NEAR rim. Flip the winding and the same test yields the FAR rim instead. Both rims project to the same outline, so the defect is invisible on a short element. On a tall one - a shaft wall, a multi-storey core - the far rim falls outside the projection band, the band drops it, and the sheet comes out blank. Produced successfully. No error, no warning.

## The fix

`EdgeExtractor` integrates the mesh's signed volume once per mesh and, when the solid is wound inward, negates every face normal. That is exactly what reversing every triangle does, so a mesh and its reversed twin classify identically - which is the issue's stated acceptance criterion.

The sign is only trusted when `|V|` clears `1e-6` of the bounding-box diagonal cubed. An open shell or a flat sheet integrates to ~0 and carries no meaningful orientation, so it keeps the previous behaviour rather than being flipped on integration noise (a closed box sits around 0.19 of that bound; a 1 mm sheet spanning 4 m near 1e-4). Crease classification is untouched: the dihedral angle between two normals is invariant under negating both.

The fix is at the extractor, so it covers the custom-plane path too - the cardinal-plan-only Rust `outlineProvider` is bypassed on every camera-direction export, which is where #2042 / PR #2657 hit this.

## Guards, mutation-checked BOTH directions

Mutation: `git show origin/main:packages/drawing-2d/src/edge-extractor.ts` over the fixed file, tests only.

| state | result |
| --- | --- |
| fix in place | exit 0, `Test Files 2 passed`, `Tests 13 passed (13)` |
| fix reverted | exit 1, `Tests 3 failed | 10 passed (13)` |

The three that red are the three that are new. Two of them fail with `expected +0 to be 4`, i.e. the guard observes the actual blank sheet, not a proxy for it. The third fails on whole-drawing equality (`[10] vs [8]`).

`edge-extractor.test.ts` also carries an explicitly labelled CONTROL - the zero-volume open sheet - which is green with and without the fix by construction. It is marked as a control in the file, not counted as a guard. Its anti-overcorrection partner is falsifiable: `expect(outward.length).toBe(4)` reds if the sign test is inverted, because a correctly wound solid would then lose its near rim.

Worth knowing for review: this file's pre-existing shared `boxMesh` fixture is itself wound INWARD. That is not a slip - it is ifc-lite winding in the wild, and it is why the existing tests never noticed. Their boxes are short enough that the far rim stays inside the band.

## Lane, every exit code, fresh worktree off `origin/main` @ a4a5ae714

| command | exit |
| --- | --- |
| `pnpm install --frozen-lockfile` | 0 |
| `pnpm build` | 0 |
| `pnpm typecheck` | 0 |
| `pnpm lint` | 0 |
| `node scripts/check-source-text-assertions.mjs` | 0 (7 allowlisted, 0 new) |
| `pnpm test` | 0 (88/88 tasks) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 2D drawings now produce consistent silhouette lines regardless of whether a solid mesh’s triangles are wound inward or outward.
  * Preserved projected line details, visibility, depth, and drawing bounds across reversed mesh orientations.
  * Open, flat, empty, and zero-volume meshes retain their existing behavior.

* **Tests**
  * Added coverage for single- and multi-element scenes, silhouette extraction, and winding-independent drawing results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->