### PR TITLE
chore: state the real Node and pnpm floors on the root

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,8 +90,8 @@
     "typescript": "^6.0.3"
   },
   "engines": {
-    "node": "22.x || 24.x",
-    "pnpm": ">=8.0.0"
+    "node": ">=22.11 <23 || 24.x",
+    "pnpm": ">=10.0.0"
   },
   "dependencies": {
     "@neondatabase/serverless": "^1.1.0"


### PR DESCRIPTION
`@changesets/cli` 3.0.0 declares:

```
node: ^22.11 || ^24 || >=26
pnpm: >=10.0.0
```

The root declared `22.x || 24.x` and `>=8.0.0`. So a contributor on Node 22.0–22.10, or pnpm 8/9, satisfied this repo's own metadata while failing the tool they have to run — `pnpm version` and `pnpm release` fail for them with an engine error that does not point at the cause.

**Node floor is `>=22.11 <23 || 24.x`, not a verbatim copy of the CLI's range.** 24.x is this repo's actual upper supported line (CI runs 22 and 24); admitting `>=26` because a devDependency happens to allow it would overstate what is tested.

**pnpm floor moves to `>=10.0.0`**, which `packageManager: pnpm@10.8.1` already guarantees for anyone using corepack. The old `>=8.0.0` described a configuration that can no longer install this workspace.

**Advisory only** — there is no `engine-strict` in `.npmrc` or anywhere else, so nothing begins failing because of this. It stops the metadata lying, which is what would send someone to a Node version the toolchain rejects.

Raised as a P2 by greptile on #2692. Deliberately not held for the release unbreak, since it blocks nothing.