### PR TITLE
fix(zones): zone selection resolves nothing inside a collaborative room

### DIFF
--- a/.changeset/zone-selection-in-a-collab-room.md
+++ b/.changeset/zone-selection-in-a-collab-room.md
@@ -1,0 +1,20 @@
+---
+"@ifc-lite/viewer": patch
+---
+
+Fix "select elements in this zone" selecting nothing inside a collaborative room.
+
+Zone selection resolved each matched element through the `federationRegistry`
+singleton alone, and dropped every id the registry could not place. The collab
+recipient seeds its room model with `upsertModel` and never calls
+`registerModelOffset` (`collabSlice.ts`), so the registry knew none of the
+room's ids: every match was dropped and the command was a silent no-op that
+still reported success. Federated-IFCX composition seeds its layers the same
+way.
+
+Resolution now goes through the store's canonical `resolveGlobalIdFromModels`
+— the resolver `resolveEntityRef.ts` calls the single source of truth, and the
+only one that also sees overlay-allocated ids via its `mutationViews` pass —
+falling back to the registry for a model that has left `state.models` but is
+still registered. `useIfcFederation`'s `findModelForEntity` / `resolveGlobalId`
+get the same delegation. Sibling of the clash-path fix in #2697.

--- a/.changeset/zone-selection-in-a-collab-room.md
+++ b/.changeset/zone-selection-in-a-collab-room.md
@@ -8,9 +8,10 @@ Zone selection resolved each matched element through the `federationRegistry`
 singleton alone, and dropped every id the registry could not place. The collab
 recipient seeds its room model with `upsertModel` and never calls
 `registerModelOffset` (`collabSlice.ts`), so the registry knew none of the
-room's ids: every match was dropped and the command was a silent no-op that
-still reported success. Federated-IFCX composition seeds its layers the same
-way.
+room's ids: every match was dropped, and the panel then took its empty-result
+branch and answered `No elements in this zone` — a confident, false statement
+about the zone's contents rather than a silent no-op. Federated-IFCX
+composition seeds its layers the same way.
 
 Resolution now goes through the store's canonical `resolveGlobalIdFromModels`
 — the resolver `resolveEntityRef.ts` calls the single source of truth, and the
@@ -18,3 +19,14 @@ only one that also sees overlay-allocated ids via its `mutationViews` pass —
 falling back to the registry for a model that has left `state.models` but is
 still registered. `useIfcFederation`'s `findModelForEntity` / `resolveGlobalId`
 get the same delegation. Sibling of the clash-path fix in #2697.
+
+This is complete only while the room's id space stays inside the first
+snapshot's maximum. `collabSlice` computes the room model's `maxExpressId` in
+its first-reconstruct branch only; every later peer edit goes through
+`setIfcDataStore`, which replaces the store and leaves `maxExpressId` at the
+first value. Ids allocated after that snapshot fall outside the model's
+recorded range and still resolve to nothing — measured in review at 3 of 4
+assigned elements once a peer adds one, and 0 of 3 when the first build saw an
+empty doc and the bound froze at 0. That is a pre-existing `collabSlice`
+defect, degrading every `resolveGlobalIdFromModels` consumer in a room rather
+than zone selection specifically, and it is not fixed here.

--- a/apps/viewer/src/hooks/useIfcFederation.ts
+++ b/apps/viewer/src/hooks/useIfcFederation.ts
@@ -80,6 +80,7 @@ export function useIfcFederation(
     registerModelOffset,
     fromGlobalId,
     findModelForGlobalId,
+    resolveGlobalIdFromModels,
   } = useViewerStore(useShallow((s) => ({
     setLoading: s.setLoading,
     setError: s.setError,
@@ -94,6 +95,7 @@ export function useIfcFederation(
     registerModelOffset: s.registerModelOffset,
     fromGlobalId: s.fromGlobalId,
     findModelForGlobalId: s.findModelForGlobalId,
+    resolveGlobalIdFromModels: s.resolveGlobalIdFromModels,
   })));
 
   // Per-call ownership token. Each addModel() bumps this; state writes
@@ -638,22 +640,30 @@ export function useIfcFederation(
     await loadFederatedIfcxFromBuffers(allBuffers);
   }, [setError, loadFederatedIfcxFromBuffers]);
 
+  // Both resolvers below go through the store's canonical
+  // `resolveGlobalIdFromModels` first, falling back to the `federationRegistry`
+  // singleton only for a model that has left `state.models` but is still
+  // registered. Consulting the registry alone missed every model seeded
+  // without `registerModelOffset` — the collab room (`collabSlice.ts`) and the
+  // federated-IFCX composition just above both do exactly that. See
+  // `useZoneSelection.ts` for the same delegation, and PR #2697 for the clash
+  // path.
+
   /**
-   * Find which model contains a given globalId
-   * Uses FederationRegistry for O(log N) lookup - BULLETPROOF
-   * Returns the modelId or null if not found
+   * Find which model contains a given globalId.
+   * Returns the modelId, or null if no loaded or registered model owns it.
    */
   const findModelForEntity = useCallback((globalId: number): string | null => {
-    return findModelForGlobalId(globalId);
-  }, [findModelForGlobalId]);
+    return resolveGlobalIdFromModels(globalId)?.modelId ?? findModelForGlobalId(globalId);
+  }, [resolveGlobalIdFromModels, findModelForGlobalId]);
 
   /**
    * Convert a globalId back to the original (modelId, expressId) pair
    * Use this when you need to look up properties in the IfcDataStore
    */
   const resolveGlobalId = useCallback((globalId: number): { modelId: string; expressId: number } | null => {
-    return fromGlobalId(globalId);
-  }, [fromGlobalId]);
+    return resolveGlobalIdFromModels(globalId) ?? fromGlobalId(globalId);
+  }, [resolveGlobalIdFromModels, fromGlobalId]);
 
   return {
     addModel,

--- a/apps/viewer/src/hooks/useZoneSelection.collab-room.test.ts
+++ b/apps/viewer/src/hooks/useZoneSelection.collab-room.test.ts
@@ -1,0 +1,129 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * "Select elements in this zone" must work inside a collaborative room.
+ *
+ * The collab recipient seeds its room model through `upsertModel` alone
+ * (`collabSlice.ts`, "First build: register a real model record") and never
+ * calls `registerModelOffset`. `FederationRegistry.fromGlobalId` only knows
+ * the ranges handed to it by `registerModelOffset`, so it answers `null` for
+ * every id in the room — and `resolveZoneSelection` drops what it cannot
+ * place. The result was a silent no-op: the zone matched its elements and
+ * selected none of them.
+ *
+ * Sibling fix to PR #2697, which found the same registry-vs-store split on
+ * the clash path. Both resolve through the store's canonical
+ * `resolveGlobalIdFromModels` instead of the registry singleton.
+ */
+
+import assert from 'node:assert/strict';
+import { beforeEach, describe, it } from 'node:test';
+import { useViewerStore } from '@/store';
+import { selectElementsInZone } from './useZoneSelection.js';
+import type { ZoneAssignment, ZoneAssignmentsByElement } from '@/lib/zones/types';
+import { entityRefToString, type FederatedModel } from '@/store/types';
+
+const ROOM_ID = 'abc123';
+const ROOM_MODEL_ID = `room:${ROOM_ID}`;
+const SET = 'zone-set-1';
+const ZONE = 'zone-a';
+
+function assignment(overrides: Partial<ZoneAssignment>): ZoneAssignment {
+  return { zoneId: null, zoneName: null, straddles: false, touchedZoneIds: [], ...overrides };
+}
+
+/** Express ids as a reconstructed room store hands them out: raw, dense, small. */
+const ROOM_ELEMENT_IDS = [12, 34, 56];
+const MAX_EXPRESS_ID = 100;
+
+function roomAssignments(): ZoneAssignmentsByElement {
+  const map: ZoneAssignmentsByElement = new Map();
+  for (const id of ROOM_ELEMENT_IDS) {
+    map.set(id, { [SET]: assignment({ zoneId: ZONE, zoneName: 'A', touchedZoneIds: [ZONE] }) });
+  }
+  return map;
+}
+
+/**
+ * Seed the store exactly the way the collab recipient does: `upsertModel`
+ * with a `room:<roomId>` id, `idOffset: 0`, a real `maxExpressId`, and NO
+ * `registerModelOffset` call. Copied field-for-field from `collabSlice.ts`.
+ */
+function seedRoomModelLikeCollabSlice(): void {
+  const state = useViewerStore.getState();
+  state.clearAllModels();
+  state.upsertModel({
+    id: ROOM_MODEL_ID,
+    name: 'Shared model',
+    ifcDataStore: null,
+    geometryResult: null,
+    visible: true,
+    collapsed: false,
+    schemaVersion: 'IFC4',
+    loadedAt: Date.now(),
+    fileSize: 0,
+    idOffset: 0,
+    maxExpressId: MAX_EXPRESS_ID,
+    loadState: 'complete',
+  } as FederatedModel);
+}
+
+describe('zones: select-in-zone inside a collaborative room (sibling of PR #2697)', () => {
+  beforeEach(() => {
+    seedRoomModelLikeCollabSlice();
+    useViewerStore.setState({ zoneAssignments: roomAssignments() });
+  });
+
+  it('setup sanity: the room model is in the store but NOT in the federation registry', () => {
+    const state = useViewerStore.getState();
+    assert.ok(state.models.get(ROOM_MODEL_ID), 'room model must be in state.models');
+    // This is the defect's precondition, not the defect itself.
+    assert.equal(
+      state.fromGlobalId(ROOM_ELEMENT_IDS[0]),
+      null,
+      'the registry must not know the room model — that is what makes the bug reachable',
+    );
+  });
+
+  it('selects every element in the zone (it must not be a silent no-op)', () => {
+    const count = selectElementsInZone(SET, ZONE);
+    assert.equal(count, ROOM_ELEMENT_IDS.length, 'every zone member must be selected');
+  });
+
+  it('drives BOTH selection channels with the room model id', () => {
+    selectElementsInZone(SET, ZONE);
+    const state = useViewerStore.getState();
+
+    assert.deepEqual(
+      [...state.selectedEntityIds].sort((a, b) => a - b),
+      [...ROOM_ELEMENT_IDS].sort((a, b) => a - b),
+      'highlight channel must carry the zone members',
+    );
+
+    // The model-aware channel keys refs as `modelId:expressId`
+    // (`entityRefToString`), so it pins the model id AND the express id.
+    assert.deepEqual(
+      [...state.selectedEntitiesSet].sort(),
+      ROOM_ELEMENT_IDS.map((id) => entityRefToString({ modelId: ROOM_MODEL_ID, expressId: id })).sort(),
+      'refs must name the room model (not `legacy`) with the express ids unchanged at idOffset 0',
+    );
+  });
+
+  it('still drops an id no loaded model owns, so the count matches the highlight', () => {
+    const withStranger = roomAssignments();
+    // Above the room model's maxExpressId and outside every other model:
+    // nothing owns it, so it must not be selected or counted.
+    withStranger.set(9999, { [SET]: assignment({ zoneId: ZONE, zoneName: 'A', touchedZoneIds: [ZONE] }) });
+    useViewerStore.setState({ zoneAssignments: withStranger });
+
+    const count = selectElementsInZone(SET, ZONE);
+    assert.equal(count, ROOM_ELEMENT_IDS.length, 'the unowned id must not inflate the toast count');
+    assert.equal(
+      useViewerStore.getState().selectedEntityIds.has(9999),
+      false,
+      'the unowned id must not be highlighted',
+    );
+  });
+});

--- a/apps/viewer/src/hooks/useZoneSelection.ts
+++ b/apps/viewer/src/hooks/useZoneSelection.ts
@@ -21,7 +21,7 @@ import type { EntityRef } from '@/store/types';
 import type { ZoneAssignmentsByElement } from '@/lib/zones/types';
 
 export interface ZoneSelectionResolution {
-  /** Global ids that matched AND resolved through `fromGlobalId` — feeds
+  /** Global ids that matched AND resolved to a loaded model — feeds
    *  `setSelectedEntityIds` (the channel that drives highlight and
    *  frameSelection). */
   globalIds: number[];
@@ -33,17 +33,19 @@ export interface ZoneSelectionResolution {
 /**
  * Pure core of {@link selectElementsInZone}, extracted for unit tests.
  *
- * A matched assignment whose global id no longer resolves through
- * `fromGlobalId` (e.g. the model was unloaded between the last assignment
- * recompute and this call) is dropped from BOTH outputs — the two selection
- * channels must never diverge, and the caller's "Selected N element(s)"
- * toast must count what was actually selected (PR #1869 review).
+ * A matched assignment whose global id no longer resolves to a loaded model
+ * (e.g. the model was unloaded between the last assignment recompute and this
+ * call) is dropped from BOTH outputs — the two selection channels must never
+ * diverge, and the caller's "Selected N element(s)" toast must count what was
+ * actually selected (PR #1869 review).
+ *
+ * `resolve` is supplied by {@link selectElementsInZone}; tests pass their own.
  */
 export function resolveZoneSelection(
   zoneAssignments: ZoneAssignmentsByElement,
   setId: string,
   zoneId: string | null,
-  fromGlobalId: (globalId: number) => { modelId: string; expressId: number } | null | undefined,
+  resolve: (globalId: number) => { modelId: string; expressId: number } | null | undefined,
 ): ZoneSelectionResolution {
   const globalIds: number[] = [];
   const refs: EntityRef[] = [];
@@ -54,7 +56,7 @@ export function resolveZoneSelection(
       ? assignment.touchedZoneIds.length === 0
       : assignment.zoneId === zoneId || assignment.touchedZoneIds.includes(zoneId);
     if (!matches) continue;
-    const lookup = fromGlobalId(globalId);
+    const lookup = resolve(globalId);
     if (!lookup) continue;
     globalIds.push(globalId);
     refs.push({ modelId: lookup.modelId, expressId: lookup.expressId });
@@ -72,6 +74,21 @@ export function resolveZoneSelection(
  * for that row).
  *
  * Returns the number of elements actually selected (matched AND resolved).
+ *
+ * Resolution goes through the store's canonical `resolveGlobalIdFromModels`
+ * (`modelSlice.ts`) — the same resolver `resolveEntityRef.ts` calls "the single
+ * source of truth" — and only falls back to the `federationRegistry` singleton
+ * (`fromGlobalId`) for a model that has left `state.models` but is still
+ * registered. It used to consult the registry ALONE, which made this a silent
+ * no-op in a collaborative room: `collabSlice.ts` seeds the room model with
+ * `upsertModel` and never calls `registerModelOffset`, so the registry knew
+ * none of its ids, every lookup returned `null`, and every matched element was
+ * dropped. Federated-IFCX composition (`useIfcFederation.ts`) has the same gap.
+ * PR #2697 is the sibling fix for the clash path.
+ *
+ * The store pass is also the only one that sees overlay-allocated ids (its
+ * documented second pass through `mutationViews`), which a plain offset-range
+ * check misses.
  */
 export function selectElementsInZone(setId: string, zoneId: string | null): number {
   const state = useViewerStore.getState();
@@ -79,7 +96,7 @@ export function selectElementsInZone(setId: string, zoneId: string | null): numb
     state.zoneAssignments,
     setId,
     zoneId,
-    (globalId) => state.fromGlobalId(globalId),
+    (globalId) => state.resolveGlobalIdFromModels(globalId) ?? state.fromGlobalId(globalId),
   );
 
   state.clearEntitySelection();


### PR DESCRIPTION
## The problem

**This is a pre-existing defect, not a regression from this branch.** It is the sibling of #2697, which found the same root cause on the clash path.

"Select elements in this zone" selects **nothing** inside a collaborative room, and tells the user the zone is empty. (`ZonesPanel.tsx:429-431` takes the `count > 0 ? toast.success(...) : toast.info('No elements in this zone')` else-branch — not a success toast, but a confident and false answer about the zone's contents.)

`selectElementsInZone` resolved every matched element through the `federationRegistry` singleton alone:

```ts
(globalId) => state.fromGlobalId(globalId),
```

`FederationRegistry.fromGlobalId` only knows the ranges handed to it by `registerModelOffset`, and returns `null` for anything else. The collab recipient never makes that call — `collabSlice.ts` puts the room model straight into the store:

```ts
get().upsertModel({
  id: roomModelId,        // `room:<roomId>`
  idOffset: 0,            // mesh expressIds are already in the reconstructed store's id space
  maxExpressId,
});
```

So in a room every lookup answered `null`, and `resolveZoneSelection` drops what it cannot place (`if (!lookup) continue`) — by design, so the two selection channels and the "Selected N element(s)" toast can never diverge (PR #1869 review). Correct policy, fed a resolver that could not see the model. The result: zero elements selected, no error, and a toast that had nothing to report.

Federated-IFCX composition has the same gap: `useIfcFederation.ts` seeds each layer with `idOffset: 0` after `clearAllModels()` (which clears the registry) and never registers it.

### Reproduction

`useZoneSelection.collab-room.test.ts` drives the **real store**, seeding the room model field-for-field the way `collabSlice.ts` does (`upsertModel`, `room:<roomId>`, `idOffset: 0`, real `maxExpressId`, no `registerModelOffset`), then calls `selectElementsInZone`. Before the fix, with 3 elements assigned to the zone:

```
    ok 1 - setup sanity: the room model is in the store but NOT in the federation registry
not ok 2 - selects every element in the zone (it must not be a silent no-op)
             the toast count: expected 3, actual 0
not ok 3 - drives BOTH selection channels with the room model id
not ok 4 - still drops an id no loaded model owns, so the count matches the highlight
# pass 1  # fail 3
```

Case 1 passing is the precondition, not the bug: the model is in `state.models` and absent from the registry. All 4 green with the fix.

## The fix

Delegate to the store's canonical resolver rather than hand-roll another offset-range check:

```ts
(globalId) => state.resolveGlobalIdFromModels(globalId) ?? state.fromGlobalId(globalId),
```

`resolveGlobalIdFromModels` (`modelSlice.ts`) is what `resolveEntityRef.ts` calls "the single source of truth for resolving a globalId". It reads Zustand state, so it sees any model in `state.models` whether or not anything registered it — and it carries a documented **second pass through `mutationViews`** for overlay-allocated ids (duplicates, scripted adds) that land above a model's parse-time `maxExpressId` and that a naive range check misses. Hand-rolling the range check here would have silently dropped those.

The registry stays as the fallback, so a model that has left `state.models` but is still registered resolves exactly as before, and `null` survives for an id nothing owns — the drop-unresolvable policy is preserved, now with a resolver that can actually see the room. `registerModelOffset`'s returned offset **is** what gets stored as the model's `idOffset` (`useIfcLoader.ts:499,551`), so for any registered model loaded through that path the two passes agree.

**Correction:** the earlier claim here that this is "strictly more-resolving, never less" and that the passes always agree is wrong. Review built an executed counterexample: `FederationRegistry.clear()` resets `nextOffset` to 0 and joining a room registers nothing, so a federated model added *after* joining a room lands at registry offset 0 alongside the room model, and the store pass and the registry pass then disagree on the same id. Both answers are guesses over an already-collided id space, so this is not a regression this PR introduces — but the passes are not guaranteed to agree.

**"Could someone add a fourth resolver tomorrow and reintroduce this?"** — the honest answer is that this change removes one divergent caller rather than making the class impossible. The viewer still exposes several ways to ask one question: `resolveGlobalIdFromModels` (store, canonical), `fromGlobalId` (registry), and `fromGlobalIdFromModels` (`store/globalId.ts`, a third offset-range check with its own single-model fallback). Collapsing those into one is a larger change than this bug warrants and would collide with #2697; I'd rather flag it than smuggle it in. Happy to open a follow-up if you want the consolidation.

## Scope

`useIfcFederation`'s `findModelForEntity` / `resolveGlobalId` had the identical registry-only nullness. I traced their consumers: **there are none** — the only references anywhere in the repo are the definitions and the `useIfc.ts:82-83,131-132` re-export. They are given the same one-line delegation because it is the same bug and the change is trivially safe, but it is defensive: with no caller, there is no behaviour to test, and I did not invent one to manufacture a green assertion. Their JSDoc also lost a "Uses FederationRegistry - BULLETPROOF" claim that is no longer what the code does.

**Deliberately NOT fixed here:** the underlying registration gap in `collabSlice` / `useIfcFederation`. Adding `registerModelOffset` calls would assign the room model a non-zero offset and change its global id space — the mesh expressIds are already in the reconstructed store's id space, and ids may already have been published to peers. That is a data-consistency change, not a lookup fix, and it belongs to whoever owns the room protocol.

**Also not fixed, and it bounds what this PR buys:** review established that `collabSlice` computes the room model's `maxExpressId` inside the first-reconstruct branch, while the re-derivation branch calls `setIfcDataStore` only, which does not touch it. Ids a peer allocates after that first snapshot therefore fall outside the model's recorded range and still resolve to nothing. Executed by the reviewer in this PR's own fixture shape: with a peer adding one element the selection reports 3 of 4 assigned; if the first build saw an empty doc, `maxExpressId` freezes at 0 and the selection is still 0 of 3. That is a pre-existing `collabSlice` defect degrading every `resolveGlobalIdFromModels` consumer in a room, not zone selection specifically — but it means this fix is complete only while the room's id space stays inside the first snapshot's maximum.

Review also raised, as plausible-but-not-driven-live, that inside the stale-`zoneAssignments` window a peer **delete** renumbers ids downward — all still under the frozen maximum — so assignments that previously resolved to nothing would resolve to the *wrong* element under a confident "Selected N element(s)", until the debounced recompute heals it. Recording it here rather than claiming this change is purely more-resolving; it was not executed.

## Tests

- `apps/viewer/src/hooks/useZoneSelection.collab-room.test.ts` (new, 4 cases) — RED evidence above, produced by restoring the pre-fix file from a backup, not by reverting the branch.
- Existing `useZoneSelection.test.ts` (4 cases) still green; its resolver parameter was renamed `fromGlobalId` → `resolve`, since it is no longer the registry function.
- Full `apps/viewer` suite: **4943 passing, 0 failing**, 6 skipped (pre-existing). `tsc --noEmit` clean. `check:test-wiring` and `check:api-surface` clean.

No assertion was weakened, no fixture adjusted, no skip or allowlist added.


