### PR TITLE
fix(clash): stop applying the federation offset twice to clash element refs

### DIFF
--- a/.changeset/clash-federated-mesh-id-offset.md
+++ b/.changeset/clash-federated-mesh-id-offset.md
@@ -1,0 +1,27 @@
+---
+'@ifc-lite/clash': patch
+'@ifc-lite/viewer': patch
+---
+
+Fix clash element identity for federated models past the first.
+
+The viewer's loader shifts every `mesh.expressId` into the federated global id
+space in place, while `IfcDataStore` keeps local express ids. `elementsFromStep`
+used `mesh.expressId` to address the store anyway, so for any model with a
+non-zero `idOffset` every lookup missed: `key` fell back to the synthetic
+`expressid:N`, `tag` read `Unknown`, name and storey came back empty, and
+`buildStepExclusions` found no relationships — so the void / host / assembly
+exclusions silently stopped excluding. `ref` was wrong in the other direction,
+with `federation.toGlobalId` adding the offset a second time.
+
+`elementsFromStep` now takes `meshIdOffset`: the shift the host has already
+applied to `mesh.expressId`. It subtracts that back out before touching the
+store, so the store is addressed locally and the federation offset is applied
+exactly once. Callers that pass local meshes (CLI, MCP, the playground) leave it
+at its `0` default and are unaffected.
+
+No clash result is persisted, and both the review state and the user exclusion
+rules are keyed on the durable element key rather than on `ref`, so nothing
+stored has to be migrated. Review status that a pre-fix session saved against a
+federated model past the first was keyed on the synthetic `expressid:N`
+fallback, though, so it no longer matches and those clashes come back as `open`.

--- a/.changeset/clash-federated-mesh-id-offset.md
+++ b/.changeset/clash-federated-mesh-id-offset.md
@@ -9,12 +9,11 @@ The viewer's loader shifts every `mesh.expressId` into the federated global id
 space in place, while `IfcDataStore` keeps local express ids. `elementsFromStep`
 used `mesh.expressId` to address the store anyway, so for any model with a
 non-zero `idOffset` every lookup missed: `key` fell back to the synthetic
-`expressid:N`, name and storey came back empty, and `buildStepExclusions` found
-no relationships — so the void / host / assembly exclusions silently stopped
-excluding, and a door in the opening it fills was reported as a hard clash.
-`ref` was wrong in the other direction, with `federation.toGlobalId` adding the
-offset a second time. (`tag` survived: it falls back to `mesh.ifcType`, which
-the loader sets correctly, so nothing on screen looked wrong.)
+`expressid:N`, `tag` read `Unknown`, name and storey came back empty, and
+`buildStepExclusions` found no relationships — so the void / host / assembly
+exclusions silently stopped excluding, and a door in the opening it fills was
+reported as a hard clash. `ref` was wrong in the other direction, with
+`federation.toGlobalId` adding the offset a second time.
 
 `elementsFromStep` now takes `meshIdOffset`: the shift the host has already
 applied to `mesh.expressId`. It subtracts that back out before touching the

--- a/.changeset/clash-federated-mesh-id-offset.md
+++ b/.changeset/clash-federated-mesh-id-offset.md
@@ -23,11 +23,28 @@ exactly once. Callers that pass local meshes (CLI, MCP, the playground) leave it
 at its `0` default and are unaffected — it stays optional deliberately, since
 `elementsFromStep` is published API and requiring it would break every external
 caller. To keep a forgotten offset from being silent in any host, the adapter
-now also warns once when EVERY element in a model resolves to an empty
-GlobalId, which is the signature of exactly this wiring mistake.
+now also warns once when every element in a model resolves to an empty GlobalId
+*and the store does hold GlobalIds* — the signature of exactly this wiring
+mistake. A model whose store has none (a GLB import, whose store carries
+geometry and no IFC entities) is left alone: there, every element missing is the
+normal state, not a defect.
 
-No clash result is persisted, and both the review state and the user exclusion
-rules are keyed on the durable element key rather than on `ref`, so nothing
-stored has to be migrated. Review status that a pre-fix session saved against a
-federated model past the first was keyed on the synthetic `expressid:N`
-fallback, though, so it no longer matches and those clashes come back as `open`.
+The synthetic key an element without a GlobalId falls back to is now scoped to
+its model — `expressid:<encoded modelId>:<expressId>` rather than
+`expressid:<expressId>`. Express ids are only unique within a model, and review
+state and user element-pair exclusions are keyed on the element key alone
+(deliberately, so they survive a reload), so in a federation the unqualified
+form made two models' elements one identity: a review status or an exclusion set
+on one model's element silently covered another model's element. Two federated
+GLB models produced ONE review key where there should have been two.
+
+Migration: elements that have a GlobalId — nearly all of them, and every one
+this fix restores — are unaffected; only the fallback changes shape. A review
+status or an element-pair exclusion a previous session stored against the old
+`expressid:N` string stops matching: the clash comes back as `open`, the
+exclusion rule stays listed but suppresses nothing. Nothing is mis-applied, and
+nothing else reads the string. In the viewer that fallback is per-load anyway
+(the model id is a per-load uuid), which is the honest position for an element
+that carries no durable identity of its own. Review status a pre-fix session
+saved against a federated model past the first was likewise keyed on the old
+fallback and no longer matches.

--- a/.changeset/clash-federated-mesh-id-offset.md
+++ b/.changeset/clash-federated-mesh-id-offset.md
@@ -9,16 +9,22 @@ The viewer's loader shifts every `mesh.expressId` into the federated global id
 space in place, while `IfcDataStore` keeps local express ids. `elementsFromStep`
 used `mesh.expressId` to address the store anyway, so for any model with a
 non-zero `idOffset` every lookup missed: `key` fell back to the synthetic
-`expressid:N`, `tag` read `Unknown`, name and storey came back empty, and
-`buildStepExclusions` found no relationships — so the void / host / assembly
-exclusions silently stopped excluding. `ref` was wrong in the other direction,
-with `federation.toGlobalId` adding the offset a second time.
+`expressid:N`, name and storey came back empty, and `buildStepExclusions` found
+no relationships — so the void / host / assembly exclusions silently stopped
+excluding, and a door in the opening it fills was reported as a hard clash.
+`ref` was wrong in the other direction, with `federation.toGlobalId` adding the
+offset a second time. (`tag` survived: it falls back to `mesh.ifcType`, which
+the loader sets correctly, so nothing on screen looked wrong.)
 
 `elementsFromStep` now takes `meshIdOffset`: the shift the host has already
 applied to `mesh.expressId`. It subtracts that back out before touching the
 store, so the store is addressed locally and the federation offset is applied
 exactly once. Callers that pass local meshes (CLI, MCP, the playground) leave it
-at its `0` default and are unaffected.
+at its `0` default and are unaffected — it stays optional deliberately, since
+`elementsFromStep` is published API and requiring it would break every external
+caller. To keep a forgotten offset from being silent in any host, the adapter
+now also warns once when EVERY element in a model resolves to an empty
+GlobalId, which is the signature of exactly this wiring mistake.
 
 No clash result is persisted, and both the review state and the user exclusion
 rules are keyed on the durable element key rather than on `ref`, so nothing

--- a/apps/viewer/src/hooks/useClash.federated-id-offset.test.tsx
+++ b/apps/viewer/src/hooks/useClash.federated-id-offset.test.tsx
@@ -28,13 +28,15 @@
  * and pre-shifted mesh ids, exactly as the loader leaves it, and drives the real
  * `useClash().run()`.
  *
- * ## What actually dies without the wiring, and what does not
+ * ## What actually dies without the wiring
  *
- * `tag` is NOT a reliable discriminator here, contrary to what a store-only
- * reading suggests: `elementsFromStep` computes `node.type || mesh.ifcType ||
- * 'IfcProduct'`, and the viewer's `MeshData` carries a correct `ifcType`, so a
- * missed store lookup still reads `IfcWall` off the mesh. The signals that do
- * die are asserted below:
+ * `tag` dies too, contrary to what the `node.type || mesh.ifcType ||
+ * 'IfcProduct'` expression in `elementsFromStep` reads like: every production
+ * `EntityTable` returns the literal `'Unknown'` from `getTypeName` on a miss,
+ * and `'Unknown'` is truthy, so the `mesh.ifcType` arm never runs and the
+ * correct `ifcType` on the viewer's `MeshData` cannot rescue it. The adapter
+ * asserts this directly (`packages/clash/src/adapters/step.test.ts`). The
+ * signals asserted below:
  *
  *  - `key` degrades from the durable IfcGUID to the synthetic `expressid:N` —
  *    the key every review state and user exclusion rule is stored against;

--- a/apps/viewer/src/hooks/useClash.federated-id-offset.test.tsx
+++ b/apps/viewer/src/hooks/useClash.federated-id-offset.test.tsx
@@ -1,0 +1,329 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `gatherElements` must hand `elementsFromStep` the offset the LOADER already
+ * applied to `mesh.expressId`.
+ *
+ * `useIfcLoader` shifts every `mesh.expressId` into the federated global id
+ * space in place (`mesh.expressId = mesh.expressId + idOffset`) while the
+ * model's `ifcDataStore` keeps LOCAL express ids. For every federated model
+ * past the first — the only ones with a non-zero `idOffset` — addressing the
+ * store with `mesh.expressId` misses on every lookup.
+ *
+ * ## Why this file exists
+ *
+ * The adapter half of that fix (`meshIdOffset` on `elementsFromStep`) is pinned
+ * in `packages/clash/src/adapters/step.test.ts`, but those tests pass a literal
+ * `meshIdOffset` themselves, so they cannot see whether the VIEWER passes one.
+ * Deleting `meshIdOffset: model.idOffset ?? 0` from `useClash.gatherElements` —
+ * reverting the entire viewer half and restoring the exact defect — left the
+ * clash package green, all 20 viewer clash test files green (119/119), and
+ * `tsc` clean, because `meshIdOffset?: number` defaults to `0`. The one viewer
+ * test that reached `gatherElements` seeded `idOffset: 0`, the single value that
+ * hides the bug.
+ *
+ * So this file seeds a federation whose SECOND model has a real non-zero offset
+ * and pre-shifted mesh ids, exactly as the loader leaves it, and drives the real
+ * `useClash().run()`.
+ *
+ * ## What actually dies without the wiring, and what does not
+ *
+ * `tag` is NOT a reliable discriminator here, contrary to what a store-only
+ * reading suggests: `elementsFromStep` computes `node.type || mesh.ifcType ||
+ * 'IfcProduct'`, and the viewer's `MeshData` carries a correct `ifcType`, so a
+ * missed store lookup still reads `IfcWall` off the mesh. The signals that do
+ * die are asserted below:
+ *
+ *  - `key` degrades from the durable IfcGUID to the synthetic `expressid:N` —
+ *    the key every review state and user exclusion rule is stored against;
+ *  - `name` comes back empty;
+ *  - `ref` gets the offset applied TWICE (`toGlobalId` adds it again to an id
+ *    that was never reduced), so it addresses nothing the renderer knows;
+ *  - `buildStepExclusions` walks the same relationship graph with the same
+ *    unusable ids and finds NOTHING, so the void/host exclusions silently stop
+ *    excluding — a door in the opening it fills is reported as a hard clash.
+ *
+ * That last one is the user-visible harm and it is what the clash-count
+ * assertion pins.
+ */
+
+import '@/test/setup-dom.js';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { IfcParser, type IfcDataStore } from '@ifc-lite/parser';
+import type { ClashRule } from '@ifc-lite/clash';
+import type { CoordinateInfo, GeometryResult, MeshData } from '@ifc-lite/geometry';
+import { useViewerStore, type FederatedModel } from '@/store';
+import { useClash } from './useClash.js';
+
+// ─── Fixtures ───────────────────────────────────────────────────────────────
+
+const HOST_WALL_GUID = '0h0sTW4LLX4xv5uCqZZG05';
+const FED_WALL_GUID = '0fEdW4LLX4xv5uCqZZG05x';
+const FED_DOOR_GUID = '0fEdD00RX4xv5uCqZZG05x';
+
+function ifc4(body: string): string {
+  return [
+    'ISO-10303-21;',
+    'HEADER;',
+    "FILE_DESCRIPTION((''),'2;1');",
+    "FILE_NAME('','',(''),(''),'','','');",
+    "FILE_SCHEMA(('IFC4'));",
+    'ENDSEC;',
+    'DATA;',
+    body,
+    'ENDSEC;',
+    'END-ISO-10303-21;',
+    '',
+  ].join('\n');
+}
+
+/** The FIRST model of the federation: one plain wall, nothing related to it. */
+const HOST_BODY = `#1=IFCWALL('${HOST_WALL_GUID}',$,'Host Wall',$,$,$,$,$,.STANDARD.);`;
+
+/**
+ * The SECOND model: a wall hosting an opening that a door fills, both contained
+ * in a storey. The wall/door pair is precisely the void/host exclusion the
+ * engine must honour — and precisely what stops being honoured when the
+ * relationship walk is handed global ids.
+ */
+const FEDERATED_BODY = [
+  "#1=IFCBUILDINGSTOREY('0fEdSt0YX4xv5uCqZZG05x',$,'Level 3',$,$,$,$,$,.ELEMENT.,9.);",
+  `#2=IFCWALL('${FED_WALL_GUID}',$,'Federated Wall',$,$,$,$,$,.STANDARD.);`,
+  "#3=IFCOPENINGELEMENT('0fEd0pENX4xv5uCqZZG05x',$,'Door Opening',$,$,$,$,$,$);",
+  `#4=IFCDOOR('${FED_DOOR_GUID}',$,'Federated Door',$,$,$,$,$,$,$,$,$,$);`,
+  "#5=IFCRELVOIDSELEMENT('1v01d00AX4xv5uCqZZG05x',$,$,$,#2,#3);",
+  "#6=IFCRELFILLSELEMENT('1f1LLs0AX4xv5uCqZZG05x',$,$,$,#3,#4);",
+  "#7=IFCRELCONTAINEDINSPATIALSTRUCTURE('1c0nt40AX4xv5uCqZZG05x',$,$,$,(#2,#4),#1);",
+].join('\n');
+
+async function parse(body: string): Promise<IfcDataStore> {
+  const bytes = new TextEncoder().encode(ifc4(body));
+  return new IfcParser().parseColumnar(bytes.buffer as ArrayBuffer, { disableWorkerScan: true });
+}
+
+/** A unit box (12 triangles) spanning `[dx, dx + 1]` on x, `[0, 1]` on y and z. */
+function boxMesh(expressId: number, dx: number, ifcType: string): MeshData {
+  const positions = new Float32Array([
+    dx, 0, 0, dx + 1, 0, 0, dx + 1, 1, 0, dx, 1, 0,
+    dx, 0, 1, dx + 1, 0, 1, dx + 1, 1, 1, dx, 1, 1,
+  ]);
+  const indices = new Uint32Array([
+    0, 1, 2, 0, 2, 3, 4, 6, 5, 4, 7, 6,
+    0, 4, 5, 0, 5, 1, 1, 5, 6, 1, 6, 2,
+    2, 6, 7, 2, 7, 3, 3, 7, 4, 3, 4, 0,
+  ]);
+  return {
+    expressId,
+    ifcType,
+    positions,
+    normals: new Float32Array(positions.length),
+    indices,
+    color: [0.5, 0.5, 0.5, 1],
+  };
+}
+
+function geometry(meshes: MeshData[]): GeometryResult {
+  const bounds = { min: { x: 0, y: 0, z: 0 }, max: { x: 3, y: 1, z: 1 } };
+  const coordinateInfo: CoordinateInfo = {
+    originShift: { x: 0, y: 0, z: 0 },
+    originalBounds: bounds,
+    shiftedBounds: bounds,
+    hasLargeCoordinates: false,
+  };
+  return {
+    meshes,
+    totalTriangles: 12 * meshes.length,
+    totalVertices: 8 * meshes.length,
+    coordinateInfo,
+  };
+}
+
+function model(
+  id: string,
+  store: IfcDataStore,
+  meshes: MeshData[],
+  idOffset: number,
+  maxExpressId: number,
+): FederatedModel {
+  return {
+    id,
+    name: `${id}.ifc`,
+    ifcDataStore: store,
+    geometryResult: geometry(meshes),
+    visible: true,
+    collapsed: false,
+    schemaVersion: 'IFC4',
+    loadedAt: 0,
+    fileSize: 0,
+    idOffset,
+    maxExpressId,
+  };
+}
+
+const ALL_RULE: ClashRule = { id: 'all-clashes', name: 'All elements', a: '*', mode: 'hard' };
+
+/** Room for a realistic offset: model B lands at 1_000_000. */
+const MODEL_RANGE = 999_999;
+
+// ─── Harness ────────────────────────────────────────────────────────────────
+
+type ClashApi = ReturnType<typeof useClash>;
+
+let api: ClashApi | null = null;
+
+function Probe(): null {
+  api = useClash();
+  return null;
+}
+
+let root: Root | null = null;
+
+/**
+ * Seed the two-model federation the loader would produce, and mount the REAL
+ * hook. Returns model B's registered offset and its LOCAL wall/door ids.
+ *
+ * Layout on x, chosen so exactly one cross-model overlap exists and the
+ * intra-B wall/door overlap is the only other candidate:
+ *
+ *   host wall  [0.0, 1.0]
+ *   fed wall   [0.5, 1.5]   overlaps the host wall  → one legitimate clash
+ *   fed door   [1.2, 2.2]   overlaps the fed wall   → excluded (voids/fills)
+ *                           clear of the host wall by 0.2m → no hard clash
+ */
+async function seedFederation(): Promise<{ offset: number; wallId: number; doorId: number }> {
+  // `registerModelOffset` resolves through the `federationRegistry` SINGLETON,
+  // which outlives a test. Clearing the models clears the registry with it, so
+  // model A really registers at 0 and model B really lands past it.
+  useViewerStore.getState().clearAllModels();
+
+  const hostStore = await parse(HOST_BODY);
+  const fedStore = await parse(FEDERATED_BODY);
+
+  const wallId = (fedStore.entityIndex.byType.get('IFCWALL') ?? [])[0];
+  const doorId = (fedStore.entityIndex.byType.get('IFCDOOR') ?? [])[0];
+  assert.ok(wallId > 0 && doorId > 0, 'fixture sanity: the federated wall and door must parse');
+
+  const hostOffset = useViewerStore.getState().registerModelOffset('A', MODEL_RANGE);
+  const offset = useViewerStore.getState().registerModelOffset('B', MODEL_RANGE);
+  assert.equal(hostOffset, 0, 'setup sanity: the FIRST model always registers at offset 0');
+  assert.ok(offset > 0, 'setup sanity: the SECOND model must get a non-zero offset — the whole point');
+
+  const models = new Map<string, FederatedModel>([
+    ['A', model('A', hostStore, [boxMesh(1, 0, 'IfcWall')], hostOffset, MODEL_RANGE)],
+    [
+      'B',
+      model(
+        'B',
+        fedStore,
+        // As `useIfcLoader` leaves them: SHIFTED into the global id space, while
+        // `fedStore` above stays local. This is the state under test.
+        [boxMesh(wallId + offset, 0.5, 'IfcWall'), boxMesh(doorId + offset, 1.2, 'IfcDoor')],
+        offset,
+        MODEL_RANGE,
+      ),
+    ],
+  ]);
+
+  useViewerStore.setState({
+    models,
+    activeModelId: 'A',
+    clashResult: null,
+    clashRawResult: null,
+    clashGroups: null,
+    clashError: null,
+    clashRunning: false,
+    clashSelectedId: null,
+    isolatedEntities: null,
+    ghostExceptEntities: null,
+  });
+
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root!.render(<Probe />);
+  });
+  assert.ok(api, 'useClash must be mounted');
+  return { offset, wallId, doorId };
+}
+
+beforeEach(() => {
+  api = null;
+});
+
+afterEach(async () => {
+  const current = root;
+  root = null;
+  if (current) await act(async () => current.unmount());
+  useViewerStore.getState().clearAllModels();
+});
+
+// ─── The tests ──────────────────────────────────────────────────────────────
+
+describe('useClash gathers a federated model past the first with the offset the loader applied', () => {
+  it('resolves the DURABLE key, name and ref for a model whose meshes are already shifted', async () => {
+    const { offset, wallId } = await seedFederation();
+
+    await act(async () => {
+      await api!.run([ALL_RULE]);
+    });
+
+    const s = useViewerStore.getState();
+    assert.equal(s.clashError, null, 'the run must not error');
+    assert.ok(s.clashResult, 'the run must publish a result');
+
+    const fedRefs = s.clashResult!.clashes
+      .flatMap((c) => [c.a, c.b])
+      .filter((r) => r.model === 'B');
+    assert.ok(fedRefs.length > 0, 'setup sanity: the second model must take part in a clash at all');
+
+    for (const ref of fedRefs) {
+      assert.ok(
+        !ref.key.startsWith('expressid:'),
+        `the federated element fell back to the synthetic key "${ref.key}": ` +
+          'gatherElements addressed the LOCAL store with a GLOBAL mesh id',
+      );
+    }
+
+    const wall = fedRefs.find((r) => r.key === FED_WALL_GUID);
+    assert.ok(wall, `the federated wall must carry its real IfcGUID ${FED_WALL_GUID}`);
+    assert.equal(wall!.name, 'Federated Wall', 'the stored Name must resolve, not come back empty');
+    // Applied exactly ONCE: the ref IS the mesh id the renderer and the
+    // selection channel already address this element by. Double-offsetting puts
+    // it past every registered range, where `fromGlobalId` returns null and the
+    // panel row is inert.
+    assert.equal(wall!.ref, wallId + offset, 'the federation offset must be applied exactly once');
+    assert.notEqual(wall!.ref, wallId + 2 * offset, 'the double-offset defect');
+  });
+
+  it('honours the federated model\'s void/host exclusions: a door in its opening is not a clash', async () => {
+    await seedFederation();
+
+    await act(async () => {
+      await api!.run([ALL_RULE]);
+    });
+
+    const s = useViewerStore.getState();
+    assert.equal(s.clashError, null, 'the run must not error');
+    const clashes = s.clashResult!.clashes;
+
+    const intraB = clashes.filter((c) => c.a.model === 'B' && c.b.model === 'B');
+    assert.deepEqual(
+      intraB.map((c) => `${c.a.key} x ${c.b.key}`),
+      [],
+      'the door fills an opening in that wall, so IfcRelVoids/IfcRelFills must exclude the pair — ' +
+        'an empty exclusion set means buildStepExclusions was handed unusable ids',
+    );
+
+    // The GREEN half: the exclusion must not have swallowed the real clash too.
+    const crossModel = clashes.filter((c) => c.a.model !== c.b.model);
+    assert.equal(crossModel.length, 1, 'the host wall and the federated wall really do overlap');
+    const keys = [crossModel[0].a.key, crossModel[0].b.key].sort();
+    assert.deepEqual(keys, [HOST_WALL_GUID, FED_WALL_GUID].sort(), 'both sides keep their durable key');
+  });
+});

--- a/apps/viewer/src/hooks/useClash.federated-id-offset.test.tsx
+++ b/apps/viewer/src/hooks/useClash.federated-id-offset.test.tsx
@@ -54,8 +54,9 @@ import { afterEach, beforeEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
-import { IfcParser, type IfcDataStore } from '@ifc-lite/parser';
-import type { ClashRule } from '@ifc-lite/clash';
+import { createSyntheticDataStore, IfcParser, type IfcDataStore } from '@ifc-lite/parser';
+import { clashReviewKey, type ClashRule } from '@ifc-lite/clash';
+import { applyClashExclusions, elementPairExclusion } from '@/lib/clash/exclusions.js';
 import type { CoordinateInfo, GeometryResult, MeshData } from '@ifc-lite/geometry';
 import { useViewerStore, type FederatedModel } from '@/store';
 import { useClash } from './useClash.js';
@@ -325,5 +326,126 @@ describe('useClash gathers a federated model past the first with the offset the 
     assert.equal(crossModel.length, 1, 'the host wall and the federated wall really do overlap');
     const keys = [crossModel[0].a.key, crossModel[0].b.key].sort();
     assert.deepEqual(keys, [HOST_WALL_GUID, FED_WALL_GUID].sort(), 'both sides keep their durable key');
+  });
+});
+
+// ─── The other half: elements that have NO durable key ──────────────────────
+
+/**
+ * Subtracting the offset put the adapter back in the LOCAL id space, which is
+ * where the fallback key lives too — and local ids repeat across a federation.
+ * Every model's elements are numbered from 1, so a bare `expressid:2` names an
+ * element in EVERY model at once.
+ *
+ * `clashReviewKey` (`@ifc-lite/clash`) and `elementPairExclusion`
+ * (`@/lib/clash/exclusions`) key on the durable element key ALONE, dropping
+ * `model` on purpose: it is a per-load `crypto.randomUUID()`, so folding it in
+ * would make every saved review and rule go inert on the next reload. That
+ * design is what turns a repeated key into cross-model bleed rather than a
+ * cosmetic duplicate — one review status, one exclusion, two different models'
+ * elements.
+ *
+ * A GLB-sourced federation is the natural population: the viewer's GLB ingest
+ * builds an ENTITY-LESS store (`createMinimalGlbDataStore` ->
+ * `createSyntheticDataStore`), so there is no GlobalId to key on for any
+ * element in the file, and the fallback is all there is. This seeds exactly
+ * that, through the real hook, and asserts on the two consumers.
+ */
+const GLB_RULE: ClashRule = { id: 'all-clashes', name: 'All elements', a: '*', mode: 'hard' };
+
+/** Two GLB models, each with its own pair of overlapping boxes, local ids 1 and 2. */
+async function seedGlbFederation(): Promise<void> {
+  useViewerStore.getState().clearAllModels();
+
+  // The viewer's GLB path: renderable meshes, no IFC entity rows at all.
+  const glbStore = (): IfcDataStore =>
+    createSyntheticDataStore({ schemaVersion: 'IFC4', fileSize: 1, entityCount: 2 });
+
+  const offsetA = useViewerStore.getState().registerModelOffset('A', MODEL_RANGE);
+  const offsetB = useViewerStore.getState().registerModelOffset('B', MODEL_RANGE);
+  assert.equal(offsetA, 0, 'setup sanity: the FIRST model always registers at offset 0');
+  assert.ok(offsetB > 0, 'setup sanity: the SECOND model must get a non-zero offset');
+
+  const models = new Map<string, FederatedModel>([
+    // Overlapping pair at x ∈ [0, 1.5] — one clash inside model A.
+    ['A', model('A', glbStore(), [boxMesh(1, 0, 'IfcWall'), boxMesh(2, 0.5, 'IfcWall')], offsetA, MODEL_RANGE)],
+    [
+      'B',
+      model(
+        'B',
+        glbStore(),
+        // Same LOCAL ids 1 and 2, meshes shifted as the loader leaves them, and
+        // parked far away on x so B's pair only ever clashes with itself.
+        [boxMesh(1 + offsetB, 10, 'IfcWall'), boxMesh(2 + offsetB, 10.5, 'IfcWall')],
+        offsetB,
+        MODEL_RANGE,
+      ),
+    ],
+  ]);
+
+  useViewerStore.setState({
+    models,
+    activeModelId: 'A',
+    clashResult: null,
+    clashRawResult: null,
+    clashGroups: null,
+    clashError: null,
+    clashRunning: false,
+    clashSelectedId: null,
+    isolatedEntities: null,
+    ghostExceptEntities: null,
+  });
+
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root!.render(<Probe />);
+  });
+  assert.ok(api, 'useClash must be mounted');
+}
+
+describe('useClash keeps two GLB models apart when neither has a stored GlobalId', () => {
+  it('gives each model its own review key and its own element-pair exclusion', async () => {
+    await seedGlbFederation();
+
+    await act(async () => {
+      await api!.run([GLB_RULE]);
+    });
+
+    const s = useViewerStore.getState();
+    assert.equal(s.clashError, null, 'the run must not error');
+    const clashes = s.clashResult!.clashes;
+
+    const inA = clashes.filter((c) => c.a.model === 'A' && c.b.model === 'A');
+    const inB = clashes.filter((c) => c.a.model === 'B' && c.b.model === 'B');
+    assert.equal(inA.length, 1, 'setup sanity: model A\'s two boxes overlap');
+    assert.equal(inB.length, 1, 'setup sanity: model B\'s two boxes overlap');
+    assert.equal(clashes.length, 2, 'setup sanity: and nothing crosses between the models');
+
+    // Every element here legitimately falls back — that is what a GLB is.
+    for (const ref of clashes.flatMap((c) => [c.a, c.b])) {
+      assert.ok(ref.key.startsWith('expressid:'), 'a GLB element has no GlobalId to key on');
+    }
+
+    // 1. Review state. Two clashes in two models are two coordination items.
+    const reviewKeys = new Set([clashReviewKey(inA[0]), clashReviewKey(inB[0])]);
+    assert.equal(
+      reviewKeys.size,
+      2,
+      'one review key for two models: marking A\'s clash resolved also resolves B\'s',
+    );
+
+    // 2. User exclusions. A rule the user draws on model A must not silently
+    //    suppress the equivalent pair in model B.
+    const rule = elementPairExclusion(inA[0].a, inA[0].b);
+    const outcome = applyClashExclusions(s.clashResult, [rule]);
+    assert.equal(
+      outcome.suppressed,
+      1,
+      'the exclusion set on model A also swallowed model B\'s clash',
+    );
+    assert.equal(outcome.result!.clashes.length, 1, 'model B\'s clash must survive');
+    assert.equal(outcome.result!.clashes[0].a.model, 'B', 'and it is model B\'s that survives');
   });
 });

--- a/apps/viewer/src/hooks/useClash.ts
+++ b/apps/viewer/src/hooks/useClash.ts
@@ -280,7 +280,31 @@ export function useClash() {
       const store = model.ifcDataStore;
       const meshes = model.geometryResult?.meshes;
       if (!store || !meshes || meshes.length === 0) continue;
-      const built = elementsFromStep({ store, meshes, modelId, federation });
+      // `useIfcLoader` shifts every `mesh.expressId` into the GLOBAL id space by
+      // this model's `idOffset` while `ifcDataStore` stays LOCAL, so the adapter
+      // has to be told the offset or it addresses the store with ids that are
+      // not in it.
+      //
+      // `model.idOffset` is the right number to hand over, and it agrees with
+      // `federation.toGlobalId` (which resolves through the `federationRegistry`
+      // singleton, not through this map) because both come from the SAME
+      // `registerModelOffset` call: `useIfcLoader` stores that return value as
+      // `idOffset` on the model record at the same moment it shifts the meshes
+      // by it. A PRIMARY load cannot skew them either — it runs
+      // `clearAllModels()` first, which calls `federationRegistry.clear()`, so
+      // the primary always registers at offset 0 and its meshes are left
+      // unshifted. Federated IFCX layers (`useIfcFederation`) likewise keep
+      // `idOffset: 0` and unshifted meshes.
+      //
+      // Only the secondary (federated add) path assigns a non-zero offset, and
+      // it is the one path that shifts the meshes.
+      const built = elementsFromStep({
+        store,
+        meshes,
+        modelId,
+        federation,
+        meshIdOffset: model.idOffset ?? 0,
+      });
       elements.push(...built.elements);
       for (const key of built.exclusions) exclusions.add(key);
       // Only models that actually CONTRIBUTED elements — the condition the

--- a/packages/clash/README.md
+++ b/packages/clash/README.md
@@ -32,6 +32,15 @@ const result = await engine.run(elements, [
 console.log(result.summary.total, 'clashes');
 ```
 
+If your host has already shifted `mesh.expressId` into a federated global id
+space (as the viewer's loader does for every model past the first) while the
+`IfcDataStore` keeps local ids, pass that shift as `meshIdOffset` so the adapter
+can address the store correctly:
+
+```ts
+elementsFromStep({ store, meshes, modelId, federation, meshIdOffset: model.idOffset });
+```
+
 Includes the TypeScript reference engine, a Rust→WASM kernel kept in lockstep by a
 differential test (opt-in via `@ifc-lite/clash/wasm`; `backend: 'auto'` currently
 resolves to the TS engine), STEP and IFC5/USD source adapters, spatial grouping,

--- a/packages/clash/README.md
+++ b/packages/clash/README.md
@@ -41,6 +41,15 @@ can address the store correctly:
 elementsFromStep({ store, meshes, modelId, federation, meshIdOffset: model.idOffset });
 ```
 
+`ClashElement.key` is the element's IFC GlobalId. An element that has none — a
+malformed root, or every element of a GLB-sourced model, whose store carries no
+IFC entities — falls back to `expressid:<encoded modelId>:<expressId>`. Express
+ids are only unique within a model, so the model id is part of that key:
+`clashReviewKey` and the viewer's element-pair exclusions key on the element key
+alone, and an unqualified fallback would let a review or an exclusion set on one
+model apply to another model's element. That fallback is stable only for as long
+as the host's `modelId` is (in the viewer it is a per-load uuid).
+
 Includes the TypeScript reference engine, a Rust→WASM kernel kept in lockstep by a
 differential test (opt-in via `@ifc-lite/clash/wasm`; `backend: 'auto'` currently
 resolves to the TS engine), STEP and IFC5/USD source adapters, spatial grouping,

--- a/packages/clash/src/adapters/step.test.ts
+++ b/packages/clash/src/adapters/step.test.ts
@@ -300,3 +300,125 @@ describe('elementsFromStep', () => {
     expect(elements).toHaveLength(0);
   });
 });
+
+// A federated model past the first: the viewer's loader (`useIfcLoader`) shifts
+// every `mesh.expressId` into the global id space by that model's `idOffset`
+// BEFORE anything downstream sees the meshes. The `IfcDataStore` is untouched
+// and stays in the LOCAL id space, so an adapter handed those meshes has to
+// subtract the offset back out before it can look anything up.
+const FED_OFFSET = 1_000_000;
+
+const FED_WALL_GUID = '0fEdW4LLX4xv5uCqZZG05x';
+const FED_DOOR_GUID = '0fEdD00RX4xv5uCqZZG05x';
+const FED_OPENING_GUID = '0fEd0pENX4xv5uCqZZG05x';
+const FED_STOREY_GUID = '0fEdSt0YX4xv5uCqZZG05x';
+
+// Wall hosting an opening that a door fills, both contained in a storey. The
+// wall/door pair is exactly the void/host exclusion the engine must honour.
+const FEDERATED_IFC = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('federated.ifc','',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCBUILDINGSTOREY('${FED_STOREY_GUID}',$,'Level 3',$,$,$,$,$,.ELEMENT.,9.);
+#2=IFCWALL('${FED_WALL_GUID}',$,'Federated Wall',$,$,$,$,$,$);
+#3=IFCOPENINGELEMENT('${FED_OPENING_GUID}',$,'Door Opening',$,$,$,$,$,$);
+#4=IFCDOOR('${FED_DOOR_GUID}',$,'Federated Door',$,$,$,$,$,$,$,$,$,$);
+#5=IFCRELVOIDSELEMENT('1v01d00AX4xv5uCqZZG05x',$,$,$,#2,#3);
+#6=IFCRELFILLSELEMENT('1f1LLs0AX4xv5uCqZZG05x',$,$,$,#3,#4);
+#7=IFCRELCONTAINEDINSPATIALSTRUCTURE('1c0nt40AX4xv5uCqZZG05x',$,$,$,(#2,#4),#1);
+ENDSEC;
+END-ISO-10303-21;
+`;
+
+/** The viewer's federation bridge: local expressId -> global id. */
+const fedFederation = { toGlobalId: (_modelId: string, expressId: number) => expressId + FED_OFFSET };
+
+describe('elementsFromStep - federated model at a non-zero id offset', () => {
+  it('resolves key / tag / name / storey / ref from meshes the loader already shifted', async () => {
+    const store = await new IfcParser().parseColumnar(
+      new TextEncoder().encode(FEDERATED_IFC).buffer as ArrayBuffer,
+    );
+    const wallId = (store.entityIndex.byType.get('IFCWALL') ?? [])[0];
+    expect(wallId).toBeGreaterThan(0);
+
+    const { elements } = elementsFromStep({
+      store,
+      // As the loader leaves them: already in the global id space.
+      meshes: [solidBoxMesh(wallId + FED_OFFSET, 0)],
+      modelId: 'model-2',
+      federation: fedFederation,
+      meshIdOffset: FED_OFFSET,
+    });
+
+    expect(elements).toHaveLength(1);
+    const el = elements[0];
+    // The DURABLE key must be the real IfcGUID, never the synthetic fallback.
+    expect(el.key).toBe(FED_WALL_GUID);
+    expect(el.key.startsWith('expressid:')).toBe(false);
+    expect(el.tag).toBe('IfcWall');
+    expect(el.name).toBe('Federated Wall');
+    expect(el.storey).toBe('Level 3');
+    // The offset is applied exactly ONCE, so the ref IS the mesh's own
+    // (already global) id — the one the renderer and the selection channel
+    // address this element by, and the one `fromGlobalId` in `useClash.refOf`
+    // round-trips back to (model-2, wallId).
+    expect(el.ref).toBe(wallId + FED_OFFSET);
+    expect(el.ref).not.toBe(wallId + 2 * FED_OFFSET); // the double-offset defect
+  });
+
+  it('honours the void/host exclusion for a federated model (silent-failure half)', async () => {
+    const store = await new IfcParser().parseColumnar(
+      new TextEncoder().encode(FEDERATED_IFC).buffer as ArrayBuffer,
+    );
+    const wallId = (store.entityIndex.byType.get('IFCWALL') ?? [])[0];
+    const doorId = (store.entityIndex.byType.get('IFCDOOR') ?? [])[0];
+    expect(wallId).toBeGreaterThan(0);
+    expect(doorId).toBeGreaterThan(0);
+
+    // Overlapping bodies: without the exclusion this is one hard clash.
+    const { elements, exclusions } = elementsFromStep({
+      store,
+      meshes: [solidBoxMesh(wallId + FED_OFFSET, 0), solidBoxMesh(doorId + FED_OFFSET, 0.5)],
+      modelId: 'model-2',
+      federation: fedFederation,
+      meshIdOffset: FED_OFFSET,
+    });
+    expect(elements).toHaveLength(2);
+
+    const engine = createClashEngine({ backend: 'ts' });
+    const result = await engine.run(
+      elements,
+      [{ id: 'r', name: 'all', a: '*', mode: 'hard' }],
+      { exclusions },
+    );
+
+    // A door in the opening it fills is not a clash — for the second model too.
+    expect(result.clashes).toHaveLength(0);
+  });
+
+  it('control: the same fixture at offset 0 already worked', async () => {
+    const store = await new IfcParser().parseColumnar(
+      new TextEncoder().encode(FEDERATED_IFC).buffer as ArrayBuffer,
+    );
+    const wallId = (store.entityIndex.byType.get('IFCWALL') ?? [])[0];
+    const doorId = (store.entityIndex.byType.get('IFCDOOR') ?? [])[0];
+
+    const { elements, exclusions } = elementsFromStep({
+      store,
+      meshes: [solidBoxMesh(wallId, 0), solidBoxMesh(doorId, 0.5)],
+      modelId: 'model-1',
+      federation: { toGlobalId: (_m, id) => id },
+      meshIdOffset: 0,
+    });
+
+    expect(elements.find((e) => e.tag === 'IfcWall')?.key).toBe(FED_WALL_GUID);
+    const engine = createClashEngine({ backend: 'ts' });
+    const result = await engine.run(elements, [{ id: 'r', name: 'all', a: '*', mode: 'hard' }], {
+      exclusions,
+    });
+    expect(result.clashes).toHaveLength(0);
+  });
+});

--- a/packages/clash/src/adapters/step.test.ts
+++ b/packages/clash/src/adapters/step.test.ts
@@ -3,9 +3,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { describe, expect, it, vi } from 'vitest';
-import { IfcParser } from '@ifc-lite/parser';
+import { createSyntheticDataStore, IfcParser } from '@ifc-lite/parser';
 import type { MeshData } from '@ifc-lite/geometry';
 import { createClashEngine } from '../engine.js';
+import { clashReviewKey } from '../review.js';
 import { elementsFromStep } from './step.js';
 
 const WALL_GUID = '3vB2YO$MX4xv5uCqZZG05x';
@@ -517,5 +518,126 @@ describe('elementsFromStep - total GlobalId miss warning', () => {
     } finally {
       warn.mockRestore();
     }
+  });
+
+  it('stays silent for an entity-less (GLB) store, where every miss is EXPECTED', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      // Exactly what the viewer's GLB ingest builds (`createMinimalGlbDataStore`):
+      // renderable meshes, no IFC entity rows at all. Every element falling back
+      // is the normal state of that model, not a host wiring bug.
+      const { elements } = elementsFromStep({
+        store: createSyntheticDataStore({ schemaVersion: 'IFC4', fileSize: 1, entityCount: 2 }),
+        meshes: [solidBoxMesh(1, 0), solidBoxMesh(2, 0.5)],
+        modelId: 'glb-model',
+      });
+      expect(elements).toHaveLength(2);
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('stays silent when the store HAS rows but none of them carries a GlobalId', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      elementsFromStep({
+        store: createSyntheticDataStore({
+          schemaVersion: 'IFC4',
+          fileSize: 1,
+          // Rows the ids DO hit — they simply have no GlobalId. A malformed
+          // export, not an offset the host forgot.
+          entities: [
+            { expressId: 1, type: 'IfcWall' },
+            { expressId: 2, type: 'IfcWall' },
+          ],
+        }),
+        meshes: [solidBoxMesh(1, 0), solidBoxMesh(2, 0.5)],
+        modelId: 'guidless-model',
+      });
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});
+
+/**
+ * The SYNTHETIC FALLBACK KEY has to be unique per model.
+ *
+ * `key` is the durable element identity, and both `clashReviewKey`
+ * (`../review.ts`) and the viewer's `elementPairExclusion`
+ * (`apps/viewer/src/lib/clash/exclusions.ts`) key on it ALONE — dropping
+ * `model` on purpose, because in the viewer that is a per-load
+ * `crypto.randomUUID()` and folding it in would make every saved rule go inert
+ * on the next reload. That makes an UNQUALIFIED fallback dangerous the moment
+ * two models are federated: a bare `expressid:2` means "element 2" in both of
+ * them, so a review status or a user exclusion set on one model's element also
+ * covers a different model's element.
+ *
+ * The natural population is a GLB-sourced federation: the viewer's GLB ingest
+ * builds an entity-less store, so every element legitimately falls back, and
+ * two such models fall back onto the same ids from 1 upwards.
+ */
+describe('elementsFromStep - the fallback key is model-scoped', () => {
+  function glbStore() {
+    return createSyntheticDataStore({ schemaVersion: 'IFC4', fileSize: 1, entityCount: 2 });
+  }
+
+  it('mints DIFFERENT keys for the same local express id in two models', () => {
+    const a = elementsFromStep({ store: glbStore(), meshes: [solidBoxMesh(2, 0)], modelId: 'model-a' });
+    const b = elementsFromStep({ store: glbStore(), meshes: [solidBoxMesh(2, 0)], modelId: 'model-b' });
+
+    expect(a.elements[0].key.startsWith('expressid:')).toBe(true);
+    expect(b.elements[0].key.startsWith('expressid:')).toBe(true);
+    expect(a.elements[0].key).not.toBe(b.elements[0].key);
+  });
+
+  it('keeps the two models apart in `clashReviewKey` — the durable review identity', () => {
+    const build = (modelId: string) =>
+      elementsFromStep({
+        store: glbStore(),
+        meshes: [solidBoxMesh(1, 0), solidBoxMesh(2, 0.5)],
+        modelId,
+      }).elements;
+    const a = build('model-a');
+    const b = build('model-b');
+
+    const keyA = clashReviewKey({ rule: 'r', a: a[0], b: a[1] });
+    const keyB = clashReviewKey({ rule: 'r', a: b[0], b: b[1] });
+
+    // Two clashes in two models must be two review keys. One key here means a
+    // status set on model A's pair silently marks model B's pair reviewed too.
+    expect(new Set([keyA, keyB]).size).toBe(2);
+  });
+
+  it('never lets a model id put a SPACE inside the key — `clashReviewKey` separates on one', () => {
+    // A CLI run keys the model on `basename(filePath)`, and file names have spaces.
+    const { elements } = elementsFromStep({
+      store: glbStore(),
+      meshes: [solidBoxMesh(2, 0)],
+      modelId: 'Bridge Model rev B.ifc',
+    });
+    expect(elements[0].key).not.toMatch(/\s/);
+    // ...and the encoding stays injective: a different model is a different key.
+    const other = elementsFromStep({
+      store: glbStore(),
+      meshes: [solidBoxMesh(2, 0)],
+      modelId: 'Bridge Model rev C.ifc',
+    });
+    expect(other.elements[0].key).not.toBe(elements[0].key);
+  });
+
+  it('leaves a real IfcGUID untouched: only the FALLBACK changes shape', async () => {
+    const store = await new IfcParser().parseColumnar(
+      new TextEncoder().encode(FEDERATED_IFC).buffer as ArrayBuffer,
+    );
+    const wallId = (store.entityIndex.byType.get('IFCWALL') ?? [])[0];
+    const { elements } = elementsFromStep({
+      store,
+      meshes: [solidBoxMesh(wallId, 0)],
+      modelId: 'model-2',
+    });
+    expect(elements[0].key).toBe(FED_WALL_GUID);
   });
 });

--- a/packages/clash/src/adapters/step.test.ts
+++ b/packages/clash/src/adapters/step.test.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { IfcParser } from '@ifc-lite/parser';
 import type { MeshData } from '@ifc-lite/geometry';
 import { createClashEngine } from '../engine.js';
@@ -420,5 +420,102 @@ describe('elementsFromStep - federated model at a non-zero id offset', () => {
       exclusions,
     });
     expect(result.clashes).toHaveLength(0);
+  });
+});
+
+/**
+ * The TOTAL-MISS guard.
+ *
+ * A forgotten `meshIdOffset` produces nothing an assertion on the id itself
+ * could catch: `mesh.expressId - 0` is positive, plausible, and simply
+ * addresses the wrong row. What IS distinctive is the SHAPE of the damage —
+ * every single GlobalId lookup misses, never some. Real IFC does have the
+ * occasional fallback-only root with no GlobalId, but "not one element in this
+ * model has one" is a wiring bug, not a file.
+ *
+ * See the `meshIdOffset` JSDoc on `StepAdapterOptions` for why a dev-only
+ * `expressId < 0` assert was rejected instead: it fires only on a too-LARGE
+ * subtrahend, the mirror image of the failure that actually shipped.
+ */
+describe('elementsFromStep - total GlobalId miss warning', () => {
+  async function fedStore() {
+    return new IfcParser().parseColumnar(
+      new TextEncoder().encode(FEDERATED_IFC).buffer as ArrayBuffer,
+    );
+  }
+
+  it('warns ONCE when every element misses, naming the model and the offset it used', async () => {
+    const store = await fedStore();
+    const wallId = (store.entityIndex.byType.get('IFCWALL') ?? [])[0];
+    const doorId = (store.entityIndex.byType.get('IFCDOOR') ?? [])[0];
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      // The defect verbatim: meshes already shifted, `meshIdOffset` forgotten.
+      const { elements } = elementsFromStep({
+        store,
+        meshes: [solidBoxMesh(wallId + FED_OFFSET, 0), solidBoxMesh(doorId + FED_OFFSET, 0.5)],
+        modelId: 'model-2',
+        federation: fedFederation,
+      });
+      expect(elements).toHaveLength(2);
+      expect(warn).toHaveBeenCalledTimes(1);
+      const msg = warn.mock.calls[0].join(' ');
+      expect(msg).toContain('[clash/step]');
+      expect(msg).toContain('model-2');
+      expect(msg).toContain('meshIdOffset');
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('stays silent when the offset IS passed', async () => {
+    const store = await fedStore();
+    const wallId = (store.entityIndex.byType.get('IFCWALL') ?? [])[0];
+    const doorId = (store.entityIndex.byType.get('IFCDOOR') ?? [])[0];
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      elementsFromStep({
+        store,
+        meshes: [solidBoxMesh(wallId + FED_OFFSET, 0), solidBoxMesh(doorId + FED_OFFSET, 0.5)],
+        modelId: 'model-2',
+        federation: fedFederation,
+        meshIdOffset: FED_OFFSET,
+      });
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('stays silent on a PARTIAL miss: that is a file with fallback-only roots, not a wiring bug', async () => {
+    const store = await fedStore();
+    const wallId = (store.entityIndex.byType.get('IFCWALL') ?? [])[0];
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { elements } = elementsFromStep({
+        store,
+        // One real wall, one mesh for an id the store simply does not have.
+        meshes: [solidBoxMesh(wallId, 0), solidBoxMesh(987_654, 0.5)],
+        modelId: 'model-1',
+        meshIdOffset: 0,
+      });
+      expect(elements).toHaveLength(2);
+      expect(elements.filter((e) => e.key.startsWith('expressid:'))).toHaveLength(1);
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('stays silent when there are no elements at all', async () => {
+    const store = await fedStore();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { elements } = elementsFromStep({ store, meshes: [], modelId: 'model-1' });
+      expect(elements).toHaveLength(0);
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
   });
 });

--- a/packages/clash/src/adapters/step.ts
+++ b/packages/clash/src/adapters/step.ts
@@ -97,15 +97,46 @@ export interface StepAdapterOptions {
    * (`useIfcLoader`: `mesh.expressId = mesh.expressId + idOffset`) while
    * `IfcDataStore` keeps LOCAL ids, so for every federated model past the first
    * `mesh.expressId` is NOT a key into `store`. Without this, every lookup in
-   * the loop below misses: `key` degrades to the synthetic `expressid:N`, `tag`
-   * reads `Unknown`, name/storey come back empty, and `buildStepExclusions`
-   * finds no relationships at all — so void/host/assembly pairs silently stop
-   * being excluded. `ref` was wrong in the other direction, with
+   * the loop below misses: `key` degrades to the synthetic `expressid:N`,
+   * name/storey come back empty, and `buildStepExclusions` finds no
+   * relationships at all — so void/host/assembly pairs silently stop being
+   * excluded. `ref` was wrong in the other direction, with
    * `federation.toGlobalId` adding the offset a second time.
+   *
+   * `tag` is the one field that does NOT degrade, and that is what made this so
+   * quiet: it reads `node.type || mesh.ifcType`, and the host's `mesh.ifcType`
+   * is correct, so the panel kept showing plausible type names throughout.
    *
    * The viewer's own compare path (`lib/compare/buildFingerprints.ts`) does the
    * same subtraction for the same reason. The CLI / MCP / playground callers
    * hand over local meshes and leave this at its `0` default.
+   *
+   * ## Optional ON PURPOSE — not an oversight
+   *
+   * The obvious hardening is to make this REQUIRED, and the repo has the
+   * precedent: `buildFingerprints.ts` declares `idOffset: number` and does this
+   * exact subtraction, which is why compare never had this bug. It is
+   * deliberately NOT copied here. `buildFingerprints` is app-internal
+   * (`apps/viewer`), free to break at will; `elementsFromStep` is published API
+   * — `@ifc-lite/clash` exposes it as the `./step` subpath export — so
+   * requiring the member is a breaking change for every external caller, all of
+   * which legitimately pass local meshes and would have to add a `0` to keep
+   * compiling. That is a major bump to harden one in-repo call site, on a
+   * patch-level bugfix.
+   *
+   * What covers the gap instead, since the optional signature is exactly what
+   * let the viewer wiring be deleted and stay green:
+   *   - `apps/viewer/src/hooks/useClash.federated-id-offset.test.tsx` pins the
+   *     viewer's call at the level that actually broke (it fails if
+   *     `meshIdOffset` is dropped from `gatherElements`);
+   *   - the total-miss `console.warn` at the end of `elementsFromStep` reports
+   *     a forgotten offset at RUNTIME, in any host, including new ones.
+   *
+   * A dev-only `expressId < 0` assert was considered and rejected: it fires
+   * only when the subtrahend is too LARGE, whereas the failure that shipped was
+   * a forgotten offset, i.e. a subtrahend of 0 producing positive, plausible,
+   * entirely wrong ids. It would not have caught this bug. The total-miss check
+   * keys on the damage instead, so it catches both directions.
    */
   meshIdOffset?: number;
   /** Aligns this model into the common world frame (RTC + building rotation). */
@@ -147,6 +178,8 @@ export function elementsFromStep(options: StepAdapterOptions): StepAdapterResult
 
   const elements: ClashElement[] = [];
   const byExpressId = new Map<number, ClashElement>();
+  /** Elements whose GlobalId lookup came back empty — see the check below. */
+  let missingGlobalIds = 0;
 
   for (const mesh of meshes) {
     if (!mesh.positions || mesh.positions.length === 0) continue;
@@ -207,6 +240,7 @@ export function elementsFromStep(options: StepAdapterOptions): StepAdapterResult
     // Fall back to a model-scoped synthetic key rather than dropping geometry:
     // malformed IFC roots / fallback-only elements still participate in clashes.
     const key = storedGlobalId || `expressid:${expressId}`;
+    if (!storedGlobalId) missingGlobalIds += 1;
 
     const element: ClashElement = {
       key,
@@ -228,6 +262,27 @@ export function elementsFromStep(options: StepAdapterOptions): StepAdapterResult
 
     elements.push(element);
     byExpressId.set(expressId, element);
+  }
+
+  // A wrong `meshIdOffset` — above all a FORGOTTEN one — leaves ids that are
+  // positive, plausible and simply address the wrong rows, so nothing about an
+  // individual id gives it away. Its signature is the SHAPE of the damage:
+  // EVERY GlobalId lookup misses, never just some. A real file can carry the
+  // occasional fallback-only root with no GlobalId, but "not one element in
+  // this model has one" is a host wiring bug, and it is silent otherwise —
+  // `key` degrades to `expressid:N`, `buildStepExclusions` below finds no
+  // relationships, and the caller gets a plausible-looking result set with the
+  // void/host/assembly exclusions quietly disabled.
+  //
+  // One `if` outside the loop: no per-element cost.
+  if (elements.length > 0 && missingGlobalIds === elements.length) {
+    console.warn(
+      `[clash/step] every element in model "${modelId}" (${elements.length}) resolved to an ` +
+        `empty GlobalId. This usually means \`meshIdOffset\` (used: ${meshIdOffset}) does not ` +
+        'match the shift the host applied to `mesh.expressId`, so the store is being addressed ' +
+        'with ids it does not contain — element keys, names and the void/host exclusions are ' +
+        'all degraded.',
+    );
   }
 
   const exclusions = buildExclusions

--- a/packages/clash/src/adapters/step.ts
+++ b/packages/clash/src/adapters/step.ts
@@ -88,6 +88,26 @@ export interface StepAdapterOptions {
   modelId: string;
   /** When provided, `ref` is the federated globalId; otherwise the expressId. */
   federation?: FederationLike;
+  /**
+   * The federation offset the HOST has ALREADY added to every `mesh.expressId`,
+   * so this adapter can subtract it back out and address `store` in its own
+   * (local) id space. Default 0 — meshes are local.
+   *
+   * The viewer's loader shifts meshes into the global id space in place
+   * (`useIfcLoader`: `mesh.expressId = mesh.expressId + idOffset`) while
+   * `IfcDataStore` keeps LOCAL ids, so for every federated model past the first
+   * `mesh.expressId` is NOT a key into `store`. Without this, every lookup in
+   * the loop below misses: `key` degrades to the synthetic `expressid:N`, `tag`
+   * reads `Unknown`, name/storey come back empty, and `buildStepExclusions`
+   * finds no relationships at all — so void/host/assembly pairs silently stop
+   * being excluded. `ref` was wrong in the other direction, with
+   * `federation.toGlobalId` adding the offset a second time.
+   *
+   * The viewer's own compare path (`lib/compare/buildFingerprints.ts`) does the
+   * same subtraction for the same reason. The CLI / MCP / playground callers
+   * hand over local meshes and leave this at its `0` default.
+   */
+  meshIdOffset?: number;
   /** Aligns this model into the common world frame (RTC + building rotation). */
   worldTransform?: Mat4;
   /** Precompute void/host/assembly exclusions. Default true. */
@@ -115,14 +135,26 @@ function worldFramePositions(local: Float32Array, o: [number, number, number]): 
 }
 
 export function elementsFromStep(options: StepAdapterOptions): StepAdapterResult {
-  const { store, meshes, modelId, federation, worldTransform, buildExclusions = true } = options;
+  const {
+    store,
+    meshes,
+    modelId,
+    federation,
+    worldTransform,
+    buildExclusions = true,
+    meshIdOffset = 0,
+  } = options;
 
   const elements: ClashElement[] = [];
   const byExpressId = new Map<number, ClashElement>();
 
   for (const mesh of meshes) {
     if (!mesh.positions || mesh.positions.length === 0) continue;
-    const expressId = mesh.expressId;
+    // STORE-LOCAL id. Everything below that touches `store` — the entity table,
+    // `EntityNode`, the relationship graph in `buildStepExclusions` — must use
+    // this, never `mesh.expressId`, which the host may already have shifted
+    // into the global id space (see `meshIdOffset`).
+    const expressId = mesh.expressId - meshIdOffset;
     const node = new EntityNode(store, expressId);
 
     // Drop non-physical / non-product geometry up front so it never becomes a
@@ -178,6 +210,11 @@ export function elementsFromStep(options: StepAdapterOptions): StepAdapterResult
 
     const element: ClashElement = {
       key,
+      // `expressId` is local here, so the offset is applied exactly ONCE and
+      // the result is the id the renderer/selection channel already uses for
+      // this mesh — i.e. `mesh.expressId` again, whenever `meshIdOffset` and
+      // the federation agree (they are both read off the same `model.idOffset`
+      // in the viewer). See the federated round-trip test in `step.test.ts`.
       ref: federation ? federation.toGlobalId(modelId, expressId) : expressId,
       model: modelId,
       tag,

--- a/packages/clash/src/adapters/step.ts
+++ b/packages/clash/src/adapters/step.ts
@@ -97,15 +97,18 @@ export interface StepAdapterOptions {
    * (`useIfcLoader`: `mesh.expressId = mesh.expressId + idOffset`) while
    * `IfcDataStore` keeps LOCAL ids, so for every federated model past the first
    * `mesh.expressId` is NOT a key into `store`. Without this, every lookup in
-   * the loop below misses: `key` degrades to the synthetic fallback,
-   * name/storey come back empty, and `buildStepExclusions` finds no
-   * relationships at all — so void/host/assembly pairs silently stop being
-   * excluded. `ref` was wrong in the other direction, with
+   * the loop below misses: `key` degrades to the synthetic fallback, `tag`
+   * reads `Unknown`, name/storey come back empty, and `buildStepExclusions`
+   * finds no relationships at all — so void/host/assembly pairs silently stop
+   * being excluded. `ref` was wrong in the other direction, with
    * `federation.toGlobalId` adding the offset a second time.
    *
-   * `tag` is the one field that does NOT degrade, and that is what made this so
-   * quiet: it reads `node.type || mesh.ifcType`, and the host's `mesh.ifcType`
-   * is correct, so the panel kept showing plausible type names throughout.
+   * `tag` degrades with the rest, despite the `node.type || mesh.ifcType`
+   * expression below reading as though the mesh could rescue it: every
+   * production `EntityTable` returns the literal string `'Unknown'` from
+   * `getTypeName` on a miss, and `'Unknown'` is truthy, so the `mesh.ifcType`
+   * arm is unreachable on a store lookup that missed. `Unknown` next to a blank
+   * name is the loudest on-screen symptom of this bug.
    *
    * The viewer's own compare path (`lib/compare/buildFingerprints.ts`) does the
    * same subtraction for the same reason. The CLI / MCP / playground callers

--- a/packages/clash/src/adapters/step.ts
+++ b/packages/clash/src/adapters/step.ts
@@ -97,7 +97,7 @@ export interface StepAdapterOptions {
    * (`useIfcLoader`: `mesh.expressId = mesh.expressId + idOffset`) while
    * `IfcDataStore` keeps LOCAL ids, so for every federated model past the first
    * `mesh.expressId` is NOT a key into `store`. Without this, every lookup in
-   * the loop below misses: `key` degrades to the synthetic `expressid:N`,
+   * the loop below misses: `key` degrades to the synthetic fallback,
    * name/storey come back empty, and `buildStepExclusions` finds no
    * relationships at all — so void/host/assembly pairs silently stop being
    * excluded. `ref` was wrong in the other direction, with
@@ -130,7 +130,10 @@ export interface StepAdapterOptions {
    *     viewer's call at the level that actually broke (it fails if
    *     `meshIdOffset` is dropped from `gatherElements`);
    *   - the total-miss `console.warn` at the end of `elementsFromStep` reports
-   *     a forgotten offset at RUNTIME, in any host, including new ones.
+   *     a forgotten offset at RUNTIME, in any host, including new ones — for
+   *     any model whose store actually holds GlobalIds. It stays silent for a
+   *     store that holds none (a GLB import), where a total miss is the normal
+   *     state and warning would only teach the reader to ignore the message.
    *
    * A dev-only `expressId < 0` assert was considered and rejected: it fires
    * only when the subtrahend is too LARGE, whereas the failure that shipped was
@@ -163,6 +166,54 @@ function worldFramePositions(local: Float32Array, o: [number, number, number]): 
     out[i + 2] = local[i + 2] + o[2];
   }
   return out;
+}
+
+/**
+ * The durable key for an element that has NO stored GlobalId — a malformed /
+ * fallback-only IFC root, or every element of a GLB-sourced model, whose store
+ * carries geometry and no IFC entities at all.
+ *
+ * ## Why the model id is in it
+ *
+ * `key` is the element identity that `clashReviewKey` (`../review.ts`) and the
+ * viewer's `elementPairExclusion` (`apps/viewer/src/lib/clash/exclusions.ts`)
+ * are BOTH keyed on, and both drop `model` on purpose — in the viewer that is a
+ * per-load `crypto.randomUUID()`, so folding it in would make every saved
+ * review and every saved rule go inert on the next reload. A GlobalId is
+ * globally unique, so that works. An express id is only unique WITHIN a model:
+ * every file is numbered from 1, so a bare `expressid:2` names an element in
+ * every model of a federation at once, and a review status or an exclusion set
+ * on one model's element would silently cover another model's element.
+ *
+ * ## Why it is encoded
+ *
+ * `clashReviewKey` composes `rule`, `a.key` and `b.key` with a SPACE, on the
+ * stated ground that a space never occurs inside an IfcGUID. A model id is not
+ * an IfcGUID — the CLI passes `basename(filePath)` — so it can. Percent-
+ * encoding is injective (distinct model ids stay distinct keys) and emits no
+ * space, so the separator assumption keeps holding.
+ *
+ * The `expressid:` prefix is unchanged, and this is a pure fallback: an element
+ * WITH a GlobalId is keyed on it exactly as before.
+ */
+function syntheticKey(modelId: string, expressId: number): string {
+  return `expressid:${encodeURIComponent(modelId)}:${expressId}`;
+}
+
+/**
+ * Whether this store carries ANY GlobalId at all — i.e. whether a total miss
+ * says something about the ids we used, or only about the file.
+ *
+ * Called at most once per `elementsFromStep`, and only on the already-degraded
+ * path, so the scan is off every normal run. It short-circuits on the first
+ * hit, which is the answer for any real IFC.
+ */
+function storeHasAnyGlobalId(store: IfcDataStore): boolean {
+  const { entities } = store;
+  for (let i = 0; i < entities.count; i += 1) {
+    if (entities.getGlobalId(entities.expressId[i])) return true;
+  }
+  return false;
 }
 
 export function elementsFromStep(options: StepAdapterOptions): StepAdapterResult {
@@ -237,9 +288,10 @@ export function elementsFromStep(options: StepAdapterOptions): StepAdapterResult
     const storedGlobalId = store.entities.getGlobalId(expressId);
     const storedName = store.entities.getName(expressId);
 
-    // Fall back to a model-scoped synthetic key rather than dropping geometry:
-    // malformed IFC roots / fallback-only elements still participate in clashes.
-    const key = storedGlobalId || `expressid:${expressId}`;
+    // Fall back to a MODEL-SCOPED synthetic key rather than dropping geometry:
+    // malformed IFC roots, and whole GLB-sourced models, still participate in
+    // clashes. See {@link syntheticKey} for why the model id belongs in it.
+    const key = storedGlobalId || syntheticKey(modelId, expressId);
     if (!storedGlobalId) missingGlobalIds += 1;
 
     const element: ClashElement = {
@@ -270,12 +322,27 @@ export function elementsFromStep(options: StepAdapterOptions): StepAdapterResult
   // EVERY GlobalId lookup misses, never just some. A real file can carry the
   // occasional fallback-only root with no GlobalId, but "not one element in
   // this model has one" is a host wiring bug, and it is silent otherwise —
-  // `key` degrades to `expressid:N`, `buildStepExclusions` below finds no
-  // relationships, and the caller gets a plausible-looking result set with the
-  // void/host/assembly exclusions quietly disabled.
+  // `key` degrades to the synthetic fallback, `buildStepExclusions` below finds
+  // no relationships, and the caller gets a plausible-looking result set with
+  // the void/host/assembly exclusions quietly disabled.
   //
-  // One `if` outside the loop: no per-element cost.
-  if (elements.length > 0 && missingGlobalIds === elements.length) {
+  // The `storeHasAnyGlobalId` guard is what keeps that from crying wolf. A
+  // total miss means "the ids we used are wrong" only if there was something to
+  // hit: a GLB-sourced model has an ENTITY-LESS store
+  // (`createMinimalGlbDataStore` -> `createSyntheticDataStore` in the viewer),
+  // so EVERY element missing is its normal, correct state, and warning on it
+  // would fire on a correct configuration on every run — which teaches people
+  // to ignore the one message that reports the real defect. The same goes for a
+  // file whose roots carry no GlobalId at all. When the store does hold
+  // GlobalIds and not one of our ids reached them, the ids are the problem.
+  //
+  // One `if` outside the loop, and the scan behind it runs only when the whole
+  // model already missed: no per-element cost.
+  if (
+    elements.length > 0 &&
+    missingGlobalIds === elements.length &&
+    storeHasAnyGlobalId(store)
+  ) {
     console.warn(
       `[clash/step] every element in model "${modelId}" (${elements.length}) resolved to an ` +
         `empty GlobalId. This usually means \`meshIdOffset\` (used: ${meshIdOffset}) does not ` +


### PR DESCRIPTION
## The defect (pre-existing, not introduced by anything in flight)

`useIfcLoader` shifts every mesh into the federated global id space in place:

```ts
// apps/viewer/src/hooks/useIfcLoader.ts:562-565
const idOffset = registerModelOffset(modelId, maxExpressId);
if (idOffset > 0) {
  for (const mesh of geometryResult.meshes) {
    mesh.expressId = mesh.expressId + idOffset;
```

The `IfcDataStore` is untouched and keeps **local** express ids. `elementsFromStep` used `mesh.expressId` to address the store anyway, so for every federated model past the first — the first has `idOffset: 0`, which is why this has gone unnoticed — every lookup missed.

Reproduced with a two-model federation, second model at offset `1_000_000`, wall at local express id 2:

| | `key` | `tag` | `name` | `storey` | `ref` | exclusions built |
|---|---|---|---|---|---|---|
| **before** | `expressid:1000002` | `Unknown` | — | — | `2000002` | **0** |
| **after** | `0fEdW4LLX4xv5uCqZZG05x` | `IfcWall` | `Federated Wall` | `Level 3` | `1000002` | 1 |

Two independent halves:

- **Identity.** `store.entities.getGlobalId` / `getName` / `EntityNode` are all handed an id that is not in the store, so `key` falls back to the synthetic `expressid:N`, `tag` reads `Unknown`, and name/storey come back empty.
- **Exclusions — the silent half.** `buildStepExclusions` walks the same relationship graph with the same ids and finds nothing, so `exclusions` comes back **empty** for that model and the void / host / assembly pairs stop excluding. In the fixture a door sitting in the opening it fills is reported as a hard clash.

`ref` was wrong in the other direction: `federation.toGlobalId(modelId, mesh.expressId)` added the offset a **second** time. Where that number lands depends on the relative offsets: it may fall in the gap past the last range, so `FederationRegistry.fromGlobalId` returns `null` and the row is inert — or inside a **different model's own range**, resolving to a real but unrelated element. Review established the wrong-element case is reachable with as few as **two** models when the offsets are asymmetric (a small site/context file loaded before a large model is an ordinary federation), not only with three or more; the original "merely inert with two models" claim held only for the symmetric case.

## The fix, and why at this level

`elementsFromStep` now takes `meshIdOffset` — the shift the **host** has already applied — and subtracts it back out once, at the top of the loop. Everything that touches `store` then uses local ids, and the federation offset is applied exactly once.

This is the level the brief asks for: one up from `refOf`, at the adapter boundary. Doing it inside `refOf` would have fixed `ref` and left identity and exclusions broken; doing it in the loader would have changed the id space the renderer, selection channel and every other consumer already depend on. `elementsFromStep` is the one place that needs both spaces at once, so it is the one place that should be told about both.

`model.idOffset` is the right number to hand over and it cannot skew against `federation.toGlobalId` (which resolves through the `federationRegistry` singleton, not through the models map): both come from the same `registerModelOffset` call, whose return value the loader stores as `idOffset` at the same moment it shifts the meshes by it. A PRIMARY load cannot skew them either — it runs `clearAllModels()` first, which calls `federationRegistry.clear()`, so the primary always registers at offset 0 with unshifted meshes. Federated IFCX layers and the collab room model likewise keep `idOffset: 0` and unshifted meshes. Only the federated-add path assigns a non-zero offset, and it is the one path that shifts.

Every other caller — `packages/cli/src/commands/clash.ts`, `packages/cli/src/commands/gym/channels.ts`, `packages/mcp/src/tools/clash.ts`, `apps/viewer/src/components/mcp/playground-dispatcher.ts` — meshes its own bytes and hands over local ids, so it leaves `meshIdOffset` at its `0` default and is unchanged.

## Consumers of `ref`, and what happens to published results

Enumerated before changing anything. `ref` is read in six non-test modules:

- **Renderer / selection** (`useClash.ts`): `refOf` → `fromGlobalId`, the framing/highlight global-id set, `buildClashPairColors`, the `elementsByRef` geometry cache behind the contact-interface solid, and the BCF snapshot isolation set. All in-memory, all repaired by this change.
- **Identity/dedup** inside `packages/clash`: `duplicates.ts` and `duplicate-sets.ts` fold `ref` into their grouping keys.
- **JSON output**: CLI `--json` and the MCP/playground rows.

Nothing persists a `ref`. No `ClashResult` is stored at all; the four localStorage keys hold presets, settings, reviews and exclusions. `clashReviewKey` is keyed on the rule plus the two **durable** element keys, and the user exclusion rules on the durable key alone — deliberately, so they survive a reload. BCF export reads `key` too (`bcf-bridge.ts` contains no `.ref`).

So no stored artifact has to be migrated. The one honest consequence, noted in the changeset: review status a **pre-fix** session saved against a federated model past the first was keyed on the `expressid:N` fallback, so it no longer matches and those clashes come back as `open`. That state was already meaningless — the synthetic key depended on load order — so this is a repair rather than a loss.

**Two things review added here that this section previously got wrong or left out. Both are fixed in the third commit:**

- **The exclusion half of the same upgrade consequence.** The durable key *is* what changes for a federated model past the first, so a pre-fix `elementPairExclusion` also stops matching: the rule stays listed and enabled in the panel while suppressing nothing, and the clashes it hid reappear. Safe direction, but this body named only the review-status half.
- **A blocker on the synthetic fallback key.** `key` fell back to `expressid:${expressId}`, and `expressId` is now the **local** id, so two models minted the same string — while `clashReviewKey` and `elementPairExclusion` are both model-independent by design. Executed by review on two federated GLBs (a GLB store carries no entity rows, so every element takes the fallback): the two models yielded 1 distinct review key instead of 2, so marking one model's pair resolved silently resolved the other's. Pre-fix these keys were load-order-unstable but unique; the collision direction is "hide a real clash".

### The collision fix (third commit)

The fallback is now `expressid:<encodeURIComponent(modelId)>:<expressId>`. Reproduced first, through the real hook, with two GLB-sourced models each holding two overlapping boxes at local ids 1 and 2:

| | before | after |
|---|---|---|
| clashes | 2 | 2 |
| distinct `clashReviewKey` | **1** | 2 |
| `elementPairExclusion` drawn on model A | suppresses **2** of 2 | suppresses 1 |

The model id is percent-encoded rather than interpolated raw: `clashReviewKey` composes `rule`, `a.key` and `b.key` with a **space**, on the stated ground that a space never occurs inside an IfcGUID — and a model id is not an IfcGUID (the CLI passes `basename(filePath)`, and file names have spaces). The encoding is injective, so distinct models keep distinct keys.

**What else consumes that string.** Nothing parses it. Element keys are only compared, sorted, concatenated into composite keys (`review.ts`, `duplicates.ts`, `orchestrator.ts`), run through `pairKey`, or displayed (`triage.ts` truncates to 8 chars for a label). The one place a key leaves the process is BCF export: `bcf-bridge.ts` puts `key` straight into a viewpoint's `IfcGuid` attributes. On import those resolve through `entities.getExpressIdByGlobalId`, an exact-match map of literal GlobalId strings — so a synthetic key was a dead reference there before this change and still is, in both shapes.

**Migration.** Elements that have a GlobalId — nearly all of them, and every one this PR repairs — are untouched; only the fallback changes shape. A review status or an element-pair exclusion a previous session stored against the old `expressid:N` string stops matching: the clash comes back as `open`, and the exclusion rule stays listed while suppressing nothing (the panel shows its count as 0). Nothing is mis-applied in either direction. In the viewer that fallback is per-load anyway — `modelId` is a `crypto.randomUUID()` — which is the honest position for an element carrying no durable identity of its own; the alternative, keeping the bare local id, buys apparent stability by pointing at whichever model loads that id first.

## Composition with #2696 and #2697

- **#2696** (merged) keys its publish gate on the model's entity **table** by reference, i.e. on the id space rather than on any id value. This change does not touch the entity table, so that guard is unaffected.
- **#2697** (open) resolves a row through `resolveGlobalIdInModel(ref.model, ref.ref)` against the named model's own range. Under the double-offset defect `local + 2·offset` is outside that range, so #2697 makes these rows reliably **inert** instead of mis-targeted — a strictly better failure, but still a failure. With this fix `local + offset` is inside the range and the row resolves. The two compose: #2697 decides *which* model answers, this decides *what number* to ask it about. No third notion of the id space is introduced — `meshIdOffset` is a statement about the mesh array, not a new mapping.

## Tests

RED first, both halves, in `packages/clash/src/adapters/step.test.ts`:

- **Identity** — asserts `key` is the real GlobalId (not `expressid:N`), `tag` is `IfcWall`, name and storey resolve, and `ref` is `wallId + FED_OFFSET` and explicitly not `wallId + 2·FED_OFFSET`. Before the fix: `expected 'expressid:1000002' to be '0fEdW4LLX4xv5uCqZZG05x'`.
- **Exclusion** — a door in the opening it fills, overlapping the wall, through the real engine. Before the fix: `expected [ { …(10) } ] to have a length of +0 but got 1`.
- **Control** — the same fixture at offset 0, which already worked, so the two above are pinned against a known-good baseline rather than against nothing.

The **viewer half was unpinned** until the second commit: deleting `meshIdOffset: model.idOffset ?? 0` from `useClash.gatherElements` restored the whole defect with every gate still green — the `step.test.ts` cases pass a literal `meshIdOffset` themselves and so can only see the adapter, the member is optional with a `0` default so the deletion still compiles, and the only viewer test that reached `gatherElements` seeded `idOffset: 0`. Added since:

- `apps/viewer/src/hooks/useClash.federated-id-offset.test.tsx` (2 cases) — seeds the two-model federation the loader actually produces (model B registered at a non-zero offset, meshes pre-shifted, `ifcDataStore` left local) and drives the real `useClash().run()`. Review reproduced it going 0 pass / 2 fail under that mutation.
- Four further `step.test.ts` cases pin the total-miss `console.warn` (fires; silent when the offset is passed; silent on a partial miss; silent with no elements). Review found that warning to be a guaranteed false positive on federated GLB, whose store has no entity rows at all, so every run tripped it — fixed in the third commit, see below.

Mutated afterwards, one at a time: reverting `mesh.expressId - meshIdOffset` to `mesh.expressId` kills both new tests; reverting only the `ref` argument to `mesh.expressId` kills the identity test. The exclusion assertion is not vacuous — the pre-existing test at `step.test.ts:217` proves with the same helper that these two boxes yield exactly one hard clash when nothing excludes them.

### Third commit — RED for both findings, unit and wiring

- `step.test.ts`, five new cases, all failing on the pre-fix source: `expected 'expressid:2' not to be 'expressid:2'` (two models, one key); `expected 1 to be 2` for the distinct review keys; `expected 'expressid:2' not to be 'expressid:2'` for the space-in-model-id case; and two warning cases that fired when they should not have (entity-less store, and a store whose rows carry no GlobalId at all).
- `useClash.federated-id-offset.test.tsx`, one new case at the **wiring** level: two GLB-sourced models seeded exactly as the loader leaves them (entity-less `createSyntheticDataStore`, model B pre-shifted at a registered non-zero offset), driven through the real `useClash().run()`, then measured with `clashReviewKey` and with `applyClashExclusions` over a real `elementPairExclusion`. Before the fix it failed `1 !== 2` on the review keys, and the run log carried a `[clash/step]` warning for **both** models — the false positive, verbatim. After: 3/3 pass in that file and the log is silent.

### The warning, rescoped rather than dropped

It now fires only when the store holds at least one GlobalId. A total miss means "the ids we used are wrong" only if there was something to hit: the viewer's GLB ingest builds an entity-less store (`createMinimalGlbDataStore` → `createSyntheticDataStore`), so every element resolving empty is that model's normal, correct state. The forgotten-offset case the guard exists for is unchanged — that store is a real IFC full of GlobalIds — and the check that answers the question short-circuits on the first hit and runs only on the already-degraded path, so it costs nothing on a normal run.

## Gates

- `@ifc-lite/clash`: 353 passed, 1 skipped — green. `typecheck` clean (24 test files).
- `apps/viewer`: 4942 passed, 6 skipped, **0 failed**. `tsc --noEmit` clean.

(All figures re-run at the third commit. Earlier heads published 343/4939 and then 347/4941; those no longer describe this head.)
- `@ifc-lite/cli`: 391 passed, 8 skipped. `@ifc-lite/mcp`: 261 passed.
- `check-changesets.mjs`, `check-unused-locals.mjs` (`49 packages, 959 known, none increased`) and `check-lint-ran.mjs` (`3,219 files, 98 rules, no errors`) green.
- `check-api-surface.mjs`: `API surface matches snapshot (41 packages, 62 export surfaces, 4166 exports)` — the two helpers added in the third commit are module-private.
- Branched from `upstream/main`; `git log --oneline upstream/main ^HEAD` is 0 at push time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected clash detection for federated models with offset element IDs.
  - Preserved element names, durable identifiers, and cross-model clash references.
  - Improved void/fill and host relationship exclusions to prevent false results.
  - Existing saved reviews using synthetic IDs reopen as **Open**; no migration is required.

- **Enhancements**
  - Added clearer diagnostics when element identifiers cannot be resolved.

- **Documentation**
  - Added guidance for configuring federated model ID offsets and synthetic element keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


