### PR TITLE
fix(clash): drop the stale dead-code suppressions on the distance_to_surface family

### DIFF
--- a/packages/clash/src/engine-ts/tri-mesh.ts
+++ b/packages/clash/src/engine-ts/tri-mesh.ts
@@ -199,19 +199,23 @@ export class TriMesh {
    * Exact distance from `p` to this mesh's surface: the minimum point-to-
    * triangle distance over the whole mesh.
    *
-   * Not on the narrow-phase hot path as of PR #2536 (its former caller,
-   * `maxPenetrationInto`, was removed — see `obb.ts`): a nearest-crossing-
-   * VERTEX distance-to-surface probe is a sampling artifact that converges to
-   * 0 under retessellation rather than to the true penetration depth. Kept as
-   * a genuinely exact, independently tested primitive (see the shared probe
-   * fixture in `tri-mesh.test.ts` / `kernel_tests.rs`) for future callers that
-   * need it — e.g. clearance-to-nearest-surface — not as dead weight. Driven
-   * by the triangle BVH rather than a linear scan so it stays cheap when it IS
-   * called. The BVH is used through a plain `queryAABB`, so the value is still
-   * the exact global minimum:
+   * Its sole production client is `crossingVertexPenetration` in `depth.ts`,
+   * which feeds the f32 noise-floor gate for an AABB-contained pair — a
+   * yes/no evidence input to `hard` vs `touch`, never a reported depth. It
+   * took over from `maxPenetrationInto`, removed in PR #2536 because a
+   * nearest-crossing-VERTEX distance-to-surface probe is a sampling artifact
+   * that converges to 0 under retessellation rather than to the true
+   * penetration depth; see `crossingVertexPenetration`'s own doc comment for
+   * why that underestimation is harmless for a floor test and disqualifying
+   * for a depth. Beyond that client it is a genuinely exact, independently
+   * tested primitive (see the shared probe fixture in `tri-mesh.test.ts` /
+   * `kernel_tests.rs`). Driven by the triangle BVH rather than a linear scan
+   * so it stays cheap. The BVH is used through a plain `queryAABB`, so the
+   * value is still the exact global minimum:
    *
-   * TODO(remove-by: no production caller has appeared by the next
-   * clash-engine feature pass, or on maintainer request): tracking issue
+   * TODO(remove-by: `crossingVertexPenetration` stops needing a
+   * point-to-surface distance for the contained-pair floor test, or on
+   * maintainer request; owner @BIMvoice): tracking issue
    * https://github.com/LTplus-AG/ifc-lite/issues/2646.
    *
    * 1. Query the cube of half-size `h` centred on `p`. Every triangle within

--- a/rust/clash/src/tri_mesh.rs
+++ b/rust/clash/src/tri_mesh.rs
@@ -38,7 +38,6 @@ pub struct TriMesh {
     /// size. Derived with exact power-of-two arithmetic (no `powi`/`cbrt`, whose
     /// last bit is not guaranteed to agree with JS) — the TS `TriMesh.probeSeed`
     /// computes the identical value.
-    #[allow(dead_code)]
     probe_seed: f64,
     /// Memoized `detect_obb(self)` result; `None` until first requested (the
     /// outer `Option` is the "not yet computed" marker, the inner one is
@@ -48,7 +47,6 @@ pub struct TriMesh {
 }
 
 /// The axis-aligned cube of half-size `h` centred on `p`.
-#[allow(dead_code)]
 fn cube_around(p: Vec3, h: f64) -> Aabb {
     Aabb::new([p[0] - h, p[1] - h, p[2] - h], [p[0] + h, p[1] + h, p[2] + h])
 }
@@ -199,7 +197,6 @@ impl TriMesh {
     }
 
     /// Minimum point-to-triangle distance over `tris`, as a squared distance.
-    #[allow(dead_code)]
     fn min_dist_sq_over(&self, p: Vec3, tris: &[u32]) -> f64 {
         let mut best = f64::INFINITY;
         for &t in tris {
@@ -214,7 +211,6 @@ impl TriMesh {
     }
 
     /// Exhaustive fallback for `distance_to_surface`: every triangle, index order.
-    #[allow(dead_code)]
     fn distance_to_surface_scan(&self, p: Vec3) -> f64 {
         let mut best = f64::INFINITY;
         for t in 0..self.count {
@@ -231,18 +227,22 @@ impl TriMesh {
     /// Exact distance from `p` to this mesh's surface: the minimum point-to-
     /// triangle distance over the whole mesh.
     ///
-    /// Not on the narrow-phase hot path as of PR #2536 (its former caller,
-    /// `max_penetration_into`, was removed — see `obb.rs`): a nearest-crossing-
-    /// VERTEX distance-to-surface probe is a sampling artifact that converges
-    /// to 0 under retessellation rather than to the true penetration depth.
-    /// Kept as a genuinely exact, independently tested primitive (see the
-    /// shared probe fixture in `kernel_tests.rs` / `tri-mesh.test.ts`) for
-    /// future callers that need it — e.g. clearance-to-nearest-surface — not
-    /// as dead weight. Driven by the triangle BVH rather than a linear scan so
-    /// it stays cheap when it IS called:
+    /// Its sole production client is `depth::crossing_vertex_penetration`,
+    /// which feeds the f32 noise-floor gate for an AABB-contained pair — a
+    /// yes/no evidence input to `Hard` vs `Touch`, never a reported depth. It
+    /// took over from `max_penetration_into`, removed in PR #2536 because a
+    /// nearest-crossing-VERTEX distance-to-surface probe is a sampling
+    /// artifact that converges to 0 under retessellation rather than to the
+    /// true penetration depth; see `crossing_vertex_penetration`'s own doc
+    /// comment for why that underestimation is harmless for a floor test and
+    /// disqualifying for a depth. Beyond that client it is a genuinely exact,
+    /// independently tested primitive (see the shared probe fixture in
+    /// `kernel_tests.rs` / `tri-mesh.test.ts`). Driven by the triangle BVH
+    /// rather than a linear scan so it stays cheap:
     ///
-    /// TODO(remove-by: no production caller has appeared by the next
-    /// clash-engine feature pass, or on maintainer request): tracking issue
+    /// TODO(remove-by: `crossing_vertex_penetration` stops needing a
+    /// point-to-surface distance for the contained-pair floor test, or on
+    /// maintainer request; owner @BIMvoice): tracking issue
     /// https://github.com/LTplus-AG/ifc-lite/issues/2646.
     ///
     /// 1. Query the cube of half-size `h` centred on `p`. Every triangle within
@@ -266,7 +266,6 @@ impl TriMesh {
     /// empty. It is kept only as defence-in-depth against a future
     /// `query_tris` regression, not as a code path with coverage; do not read
     /// it as a tested safety net.
-    #[allow(dead_code)]
     pub fn distance_to_surface(&self, p: Vec3) -> f64 {
         if self.count == 0 {
             return f64::INFINITY;


### PR DESCRIPTION
Follow-up to #2646, and **not** the deletion that issue tracks — the deletion is still blocked, for the reason recorded in the last comment there. This removes the stale signal that made it look unblocked.

## The problem

#2646 proposes `grep -c 'allow(dead_code)'` in `rust/clash/src/tri_mesh.rs` as the compiler oracle for whether the `distance_to_surface` family is dead. On `main` today that count is **5**, which reads as "still dead". It is not.

#2536 removed `max_penetration_into`, the family's caller at the time the attributes were added. But the same PR introduced `crossing_vertex_penetration` / `crossingVertexPenetration` in the new `depth.rs` / `depth.ts`, and that calls straight back into it. Live production chains, both kernels, reachable from the shipped package entry point:

- Rust: `narrow.rs:233-234` → `depth.rs:90` → `tri_mesh.rs:270`
- TS: `narrow.ts:184-185` → `depth.ts:137` → `tri-mesh.ts:239`

Neither call site is under `#[cfg(test)]` or in a `*.test.ts`. So the five attributes suppress nothing, and the oracle #2646 relies on reports the opposite of the truth.

## Measurement, both directions

On a clean worktree off `upstream/main`, `--lib` so only production reachability counts:

**1. All 5 attributes deleted, caller intact**

```
$ cargo clippy -p ifc-lite-clash --lib -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s)
exit 0
```

No `dead_code` diagnostics. The family is live.

**2. Same, plus one mutation severing the caller** — `depth.rs:90` `let d = other.distance_to_surface(v);` → `let d = 0.0f64;`

```
error: field `probe_seed` is never read
error: function `cube_around` is never used
error: methods `min_dist_sq_over`, `distance_to_surface_scan`, and `distance_to_surface` are never used
```

Run 1 proves the family is live; run 2 proves the oracle can actually observe deadness, so run 1 is not vacuous. `mod tri_mesh` is private in `lib.rs` and `TriMesh` is not re-exported, which is why `dead_code` applies to a `pub fn` here at all. The mutation was reverted and is not in this branch.

Run 2 is also the reason to remove the attributes rather than leave them harmless: with them in place, whoever eventually drops `crossing_vertex_penetration` gets **no warning** that the family died with it. That is the exact failure mode #2646 exists to catch, and today it is disarmed.

## Also: the doc comments described a branch, not `main`

Both kernels' `distance_to_surface` / `distanceToSurface` doc comments still said the function is "not on the narrow-phase hot path as of PR #2536 (its former caller, `max_penetration_into`, was removed)" and is "kept … for future callers that need it … not as dead weight". True of #2536's branch at one point in its history; false of the merged result, whose own rebase gave the function a caller again.

They now name the sole production client, say what it is for (the f32 noise-floor gate for an AABB-contained pair — a yes/no evidence input to `hard` vs `touch`, never a reported depth), and point at `crossing_vertex_penetration`'s doc comment for why the probe's underestimation is harmless for a floor test and disqualifying for a depth.

The `TODO(remove-by:)` in both kernels is restated against the real blocker rather than the one that has already been resolved — it becomes deletable when `crossing_vertex_penetration` stops needing a point-to-surface distance, not "when no production caller has appeared" — and now carries the owner AGENTS.md asks for alongside the condition. It still points at #2646, which stays open.

## Scope

Attributes and comments only; no behaviour change, no code path touched.

## Gates

| gate | result |
| --- | --- |
| `cargo clippy -p ifc-lite-clash --all-targets -- -D warnings` | clean |
| `cargo test -p ifc-lite-clash` | 66 passed, + 1 doctest |
| `pnpm --filter @ifc-lite/clash test` | 340 passed, 1 skipped |
| `pnpm --filter @ifc-lite/clash typecheck` | OK (24 test files) |
| `pnpm check:api-surface` | matches snapshot (41 packages, 4166 exports) |
| module-size ratchet (`cargo test -p ifc-lite-processing --test module_size_ratchet`) | 5 passed |
| `pnpm lint` | no errors |

**No changeset:** `TriMesh` is internal to `packages/clash/src/engine-ts/` and not exported from the package index — confirmed by `check:api-surface` being unchanged, not assumed — and nothing here is user-visible.

Does not close #2646.
