### PR TITLE
test: make seven guard tests able to fail

### DIFF
--- a/packages/viewer/test/viewer-html-runtime.test.ts
+++ b/packages/viewer/test/viewer-html-runtime.test.ts
@@ -1013,11 +1013,31 @@ describe('viewer blob — handleCommand: camera and flyto', () => {
   });
 
   it('flyto frames the centre of the matching type at a distance scaled to its size', () => {
-    const v = makeViewer([wall(1, 0), wall(2, 0, 'IfcSlab')]);
+    // Deliberately anisotropic AND off-origin. The old fixture was the unit
+    // cube `wall(1, 0)`, whose extents are (1, 1, 1) and whose centre is
+    // (0.5, 0.5, 0.5): `Math.max(...extents, 0.1) * 1.5` yields 1.5 there under
+    // max, min, first-axis or a hardcoded 1, and the centre survives any axis
+    // permutation. Extents (1, 3, 2) and centre (2.5, 0.5, 5) separate all of
+    // those.
+    const v = makeViewer([
+      [
+        1,
+        {
+          ifcType: 'IfcWall',
+          defaultColor: [0.8, 0.8, 0.8, 1],
+          boundsMin: [2, -1, 4],
+          boundsMax: [3, 2, 6],
+          segments: [{ vertexStart: 0, vertexCount: 1, indexStart: 0, indexCount: 3 }],
+        },
+      ],
+      wall(2, 0, 'IfcSlab'),
+    ]);
     v.run({ action: 'flyto', type: 'IfcWall' });
     assert.equal(v.flyToCalls.length, 1);
-    assert.deepEqual(v.flyToCalls[0].target, [0.5, 0.5, 0.5]);
-    assert.equal(v.flyToCalls[0].dist, 1.5, 'distance must scale with the largest dimension');
+    assert.deepEqual(v.flyToCalls[0].target, [2.5, 0.5, 5]);
+    // Extents are (1, 3, 2): the LARGEST, 3, times 1.5. The unmatched IfcSlab
+    // at the origin would drag both numbers if the type filter leaked.
+    assert.equal(v.flyToCalls[0].dist, 4.5, 'distance must scale with the largest dimension');
   });
 
   it('flyto by explicit ids overrides the type filter', () => {
@@ -1036,7 +1056,12 @@ describe('viewer blob — handleCommand: camera and flyto', () => {
     const v = makeViewer([[1, { ifcType: 'IfcWall', boundsMin: [3, 3, 3], boundsMax: [3, 3, 3] }]]);
     v.run({ action: 'flyto', type: 'IfcWall' });
     assert.deepEqual(v.flyToCalls[0].target, [3, 3, 3]);
-    assert.ok(v.flyToCalls[0].dist > 0, 'a point selection must not fly to distance 0');
+    // Pin the floor itself (0.1 * 1.5), not just "> 0": every extent here is 0,
+    // so `dist > 0` holds for any positive floor and the 0.1 constant is inert.
+    assert.ok(
+      Math.abs(v.flyToCalls[0].dist - 0.15) < 1e-12,
+      `a point selection must fall back to the 0.1 m floor, scaled by 1.5; got ${v.flyToCalls[0].dist}`
+    );
   });
 });
 

--- a/rust/core/src/model_bounds.rs
+++ b/rust/core/src/model_bounds.rs
@@ -320,13 +320,13 @@ mod tests {
     #[test]
     fn test_large_coordinates_detection() {
         let mut bounds = ModelBounds::new();
+        // TWO distinct points: with a single sample min == max == centroid, so
+        // the assertion below cannot tell the bbox CENTRE from either corner.
         bounds.expand(2679012.0, 1247892.0, 432.0); // Swiss UTM coordinates
-
+        bounds.expand(2679112.0, 1248092.0, 632.0);
         assert!(bounds.has_large_coordinates());
-
-        let offset = bounds.rtc_offset();
-        assert_eq!(offset.0, 2679012.0);
-        assert_eq!(offset.1, 1247892.0);
+        // The RTC offset is the bbox centre, not a corner, on ALL THREE axes.
+        assert_eq!(bounds.rtc_offset(), (2679062.0, 1247992.0, 532.0));
     }
 
     #[test]
@@ -411,35 +411,34 @@ END-ISO-10303-21;
 
     #[test]
     fn test_precision_preserved_with_rtc() {
-        // Simulate what happens with and without RTC
-
-        // Large Swiss UTM coordinates
-        let x1 = 2679012.123456_f64;
-        let x2 = 2679012.223456_f64; // 0.1m apart
+        // The shift subtracted here is the PRODUCTION offset (`rtc_offset()` on a
+        // real `ModelBounds`), not an inline `(x1 + x2) / 2.0`. The earlier version
+        // called no production code at all, so it asserted only a property of
+        // IEEE-754 and stayed green even if the whole RTC feature were deleted.
+        let x1 = 2679012.123456_f64; // large Swiss UTM coordinates,
+        let x2 = 2679012.223456_f64; // 0.1 m apart
         let expected_diff = 0.1;
 
-        // WITHOUT RTC: Convert directly to f32 (loses precision)
-        let x1_f32_direct = x1 as f32;
-        let x2_f32_direct = x2 as f32;
-        let diff_direct = x2_f32_direct - x1_f32_direct;
-        let error_direct = (diff_direct as f64 - expected_diff).abs();
+        let mut bounds = ModelBounds::new();
+        bounds.expand(x1, 1247892.0, 432.0);
+        bounds.expand(x2, 1247892.5, 432.5);
+        assert!(bounds.has_large_coordinates(), "premise: large coords");
 
-        // WITH RTC: Subtract centroid first (in f64), then convert
-        let centroid = (x1 + x2) / 2.0;
-        let x1_shifted = (x1 - centroid) as f32;
-        let x2_shifted = (x2 - centroid) as f32;
-        let diff_rtc = x2_shifted - x1_shifted;
-        let error_rtc = (diff_rtc as f64 - expected_diff).abs();
+        // WITHOUT RTC: cast straight to f32. At ~2.7e6 the f32 ulp is 0.25 m, so
+        // this really does destroy the 0.1 m separation. Pinning that keeps the
+        // comparison below from passing on two equally-good numbers.
+        let diff_direct = ((x2 as f32) - (x1 as f32)) as f64;
+        let error_direct = (diff_direct - expected_diff).abs();
+        assert!(error_direct > 0.01, "premise: cast must lose 0.1 m");
 
-        println!("Without RTC: diff={}, error={}", diff_direct, error_direct);
-        println!("With RTC: diff={}, error={}", diff_rtc, error_rtc);
-
-        // RTC should give much better precision
-        // At ~2.7M magnitude, f32 has ~0.25m precision
-        // After shifting to small values, f32 has sub-mm precision
+        // WITH RTC: subtract the offset the pipeline applies (in f64), then cast.
+        let (offset_x, _, _) = bounds.rtc_offset();
+        let diff_rtc = (((x2 - offset_x) as f32) - ((x1 - offset_x) as f32)) as f64;
+        let error_rtc = (diff_rtc - expected_diff).abs();
         assert!(
-            error_rtc < error_direct * 0.1 || error_rtc < 0.0001,
-            "RTC should significantly improve precision"
+            error_rtc < 1.0e-6,
+            "RTC-shifted f32 must keep the 0.1 m separation (diff={diff_rtc}, err={error_rtc})"
         );
+        assert!(error_rtc < error_direct * 0.1, "RTC must improve precision");
     }
 }

--- a/rust/geometry/src/clash_solid_world_frame_tests.rs
+++ b/rust/geometry/src/clash_solid_world_frame_tests.rs
@@ -17,7 +17,12 @@
 //! The known-failing case asserts the CORRECT behaviour under
 //! `#[should_panic]`: when the gate learns the normal-projected band, the
 //! assertion stops panicking, the `should_panic` itself fails, and the
-//! attribute must be removed — the corpus cannot rot silently.
+//! attribute must be removed — the corpus cannot rot silently. The expectation
+//! string names the WITHHELD panic specifically (`world-frame corpus
+//! [withheld]`), so a partial fix that starts trusting the far solid but
+//! computes the wrong volume hits the textually distinct `[wrong-volume]`
+//! assertion and fails, instead of matching the attribute and still reading as
+//! the known failure.
 
 use super::{DegenerateReason, IntersectionSolid, intersection_solid};
 use crate::world_frame_fixture::{
@@ -89,20 +94,27 @@ fn counter_case_a_sub_band_overlap_at_the_origin_stays_withheld() {
 // stops panicking and the `should_panic` fails: remove the attribute (and
 // this comment) in that PR.
 #[test]
-#[should_panic(expected = "world-frame corpus")]
+// The expectation names the WITHHELD case specifically. The two panic sites in
+// this test say textually distinct things, so a partial fix that starts
+// trusting the solid but computes the WRONG volume fails loudly instead of
+// matching the `should_panic` and still reading as KNOWN-FAILING.
+#[should_panic(expected = "world-frame corpus [withheld]")]
 fn a_5mm_overlap_10km_out_in_x_must_still_be_a_solid() {
     let (a, b) = overlapping_pair(WorldFrameCase::FarBaked);
     let solid = intersection_solid(&a, &b);
     let volume = solid.volume_m3().unwrap_or_else(|| {
         panic!(
-            "world-frame corpus: the SAME genuine 5 mm overlap that is a Solid at the \
-             origin must be a Solid 10 km out in X (offset axis X, contact normal Z); \
-             got {solid:?}"
+            "world-frame corpus [withheld]: the SAME genuine 5 mm overlap that is a \
+             Solid at the origin must be a Solid 10 km out in X (offset axis X, \
+             contact normal Z); got {solid:?}"
         )
     });
     let expected = 1.0 * 1.0 * OVERLAP_M;
     assert!(
         (volume - expected).abs() < 1e-4,
-        "world-frame corpus: far-placement volume {volume} vs expected {expected}"
+        "world-frame corpus [wrong-volume]: the gate returned a Solid 10 km out, but \
+         its far-placement volume {volume} does not match the expected {expected} \
+         (this is NOT the known failure — the gate now trusts the solid and must \
+         compute it correctly)"
     );
 }

--- a/rust/geometry/src/kernel/retriangulate.rs
+++ b/rust/geometry/src/kernel/retriangulate.rs
@@ -744,13 +744,13 @@ mod tests {
 
     #[test]
     fn phase_a_is_deterministic_on_a_45_degree_face() {
-        // normal ∝ (1,1,0)/√2 — |n_x| == |n_y|; the index tiebreak must pick a
-        // stable axis (X before Y), exactly, on every platform.
+        // normal ∝ (1,1,0)/√2 — |n_x| == |n_y|, so the index tiebreak alone (never
+        // the f64 magnitude) must pick X before Y, exactly, on every platform.
+        // Assert the CHOSEN axis: comparing two calls to a pure function is a
+        // tautology that survives a reversed `ia.cmp(&ib)`.
         let t = [[0., 0., 0.], [1., -1., 0.], [1., -1., 2.]];
-        let a = projection_axis(&t);
-        let b = projection_axis(&t);
-        assert_eq!(a.map(|x| x.0), b.map(|x| x.0));
-        assert!(a.is_some());
+        assert_eq!(axis_candidates(&t)[..2], [DropAxis::X, DropAxis::Y]);
+        assert_eq!(projection_axis(&t).expect("not degenerate").0, DropAxis::X);
     }
 
     #[test]

--- a/rust/geometry/tests/rect_param_gate.rs
+++ b/rust/geometry/tests/rect_param_gate.rs
@@ -25,8 +25,14 @@ use rustc_hash::FxHashMap;
 /// Rotated (36.87 deg in plan, NON-axis-aligned so the world path defers and
 /// the placement-frame parametric path is what must fire) rectangular wall,
 /// 4.0 x 0.3 x 2.5 m, voided by one rectangular opening 1.0(len) x 1.5(height)
-/// cut straight through the 0.3 thickness, centred in the face with a wide
-/// margin (so it is on-face, through, and not near-edge -> the fire gate opens).
+/// cut straight through the 0.3 thickness. The opening is deliberately
+/// OFF-CENTRE on BOTH in-plane axes (profile Position #229 = (0.8, -0.15)) and
+/// non-square, with a wide margin on every side (so it is on-face, through, and
+/// not near-edge -> the fire gate opens). The asymmetry is load-bearing: with a
+/// doubly-centred, identity-Position opening, transposing the profile's
+/// x_dim/y_dim or dropping its Position offset entirely both leave the cut
+/// volume unchanged, so a volume-only oracle cannot see either defect and the
+/// whole profile-Position branch of `read_rect_profile_2d` is untested.
 /// Metre units, identity site (unit_scale 1, RTC 0) so the analytic volume is
 /// trivial to check.
 const IFC: &str = r#"ISO-10303-21;
@@ -63,7 +69,8 @@ DATA;
 #213=IFCDIRECTION((0.,1.,0.));
 #214=IFCDIRECTION((1.,0.,0.));
 #227=IFCRECTANGLEPROFILEDEF(.AREA.,'Opening',#228,1.0,1.5);
-#228=IFCAXIS2PLACEMENT2D(#132,#133);
+#228=IFCAXIS2PLACEMENT2D(#229,#133);
+#229=IFCCARTESIANPOINT((0.8,-0.15));
 #231=IFCEXTRUDEDAREASOLID(#227,#141,#142,1.0);
 #240=IFCSHAPEREPRESENTATION(#13,'Body','SweptSolid',(#231));
 #241=IFCPRODUCTDEFINITIONSHAPE($,$,(#240));
@@ -153,10 +160,12 @@ fn watertight(mesh: &Mesh) -> (bool, usize, usize) {
 ///     #211 sits at wall-local y=-0.5 and the 1.0 extrusion reaches y=+0.5,
 ///     i.e. it deliberately overshoots the wall's +/-0.15 half-thickness on
 ///     both sides so the cut always goes fully through, clamped by the host
-///     to exactly the wall's 0.3 thickness. The opening is centred on the
-///     host in length (wall-local x=0) and height (wall-local z=1.25, the
-///     host's own z-centre), both well inside the host's extents, so neither
-///     of those two axes is clamped.
+///     to exactly the wall's 0.3 thickness. The opening's profile Position
+///     #229 shifts it OFF-CENTRE by (+0.8, -0.15) in the profile plane, which
+///     maps to wall-local x in [0.3, 1.3] and wall-local z in [0.65, 2.15]
+///     (see `expected_hole_corners`); both stay well inside the host's
+///     x in [-2, 2] and z in [0, 2.5], so neither of those two axes is
+///     clamped and the cut volume is unaffected by the shift.
 ///   - Clamped opening volume: 1.0 (length) * 1.5 (height) * 0.3 (thickness,
 ///     clamped from the oversized 1.0 extrusion down to the host).
 ///
@@ -176,6 +185,101 @@ fn analytic_cut_volume() -> f64 {
     let host_vol = WALL_LENGTH * WALL_THICKNESS * WALL_HEIGHT;
     let opening_vol = OPENING_LENGTH * OPENING_HEIGHT * clamped_opening_depth;
     (host_vol - opening_vol).abs()
+}
+
+/// The wall's own orthonormal frame, read straight off the fixture's
+/// `IfcAxis2Placement3D` #111: Z = #112 = (0,0,1), X = #113 = (0.8,0.6,0)
+/// (already unit), Y = Z x X = (-0.6,0.8,0). Origin #12 = (0,0,0).
+///
+/// This is a literal transcription of the STEP, not a call into
+/// `parametric_rect_probe` — the same self-reference hazard `analytic_cut_volume`
+/// documents applies here.
+const WALL_X: [f64; 3] = [0.8, 0.6, 0.0];
+const WALL_Y: [f64; 3] = [-0.6, 0.8, 0.0];
+const WALL_Z: [f64; 3] = [0.0, 0.0, 1.0];
+
+/// Every mesh vertex expressed in the wall's own frame (the frame the fixture's
+/// dimensions are written in), so the rotation drops out and the numbers below
+/// are the fixture's literals.
+fn vertices_in_wall_frame(mesh: &Mesh) -> Vec<[f64; 3]> {
+    mesh.positions
+        .chunks_exact(3)
+        .map(|v| {
+            let p = [v[0] as f64, v[1] as f64, v[2] as f64];
+            let dot = |a: [f64; 3]| a[0] * p[0] + a[1] * p[1] + a[2] * p[2];
+            [dot(WALL_X), dot(WALL_Y), dot(WALL_Z)]
+        })
+        .collect()
+}
+
+/// Wall-frame axis-aligned bounds of the cut mesh, as `(min, max)`.
+fn wall_frame_bounds(pts: &[[f64; 3]]) -> ([f64; 3], [f64; 3]) {
+    let mut lo = [f64::INFINITY; 3];
+    let mut hi = [f64::NEG_INFINITY; 3];
+    for p in pts {
+        for k in 0..3 {
+            lo[k] = lo[k].min(p[k]);
+            hi[k] = hi[k].max(p[k]);
+        }
+    }
+    (lo, hi)
+}
+
+/// The eight corners of the hole in the WALL's frame, derived by hand from the
+/// LITERAL fixture parametrics.
+///
+/// A volume oracle alone is blind to WHERE the hole is: transposing the
+/// opening profile's `x_dim`/`y_dim`, swapping its Position `off_x`/`off_y`, or
+/// ignoring the Position offset entirely all preserve the cut volume exactly.
+/// These corners do not.
+///
+/// Derivation:
+///  - Wall body: profile #130 is 4.0 x 0.3 centred at the profile origin
+///    (#131 Position = (0,0)), extruded #140 depth 2.5 along the wall's +Z ->
+///    wall-frame box x in [-2,2], y in [-0.15,0.15], and a 2.5-tall z span.
+///  - Opening frame (#211, expressed in the wall's own frame since #210's
+///    parent placement is #110): origin #212 = (0,-0.5,1.25); local Z = #213 =
+///    (0,1,0); local X = #214 = (1,0,0); local Y = Z x X = (0,0,-1). So an
+///    opening-local point (px,py,pz) sits at wall-frame
+///    (px, -0.5 + pz, 1.25 - py).
+///  - Opening profile #227: 1.0 x 1.5 with Position #229 = (0.8,-0.15) ->
+///    px in [0.3, 1.3] and py in [-0.9, 0.6]; extrusion #231 depth 1.0 gives
+///    pz spanning 1.0 across the wall's 0.3 thickness.
+///  - Hence, relative to the wall body's own z base: hole x in [0.3, 1.3];
+///    y in [-0.15, 0.15] (the opening overshoots and is clamped to the host, so
+///    the cut is fully through); z in [base + 0.65, base + 2.15].
+///
+/// `z_base` is the host body's own wall-frame z minimum, read from the cut mesh
+/// rather than assumed: WHERE the extruded body's base sits relative to the
+/// placement origin is a host-extrusion convention, already pinned by the
+/// volume and watertightness oracles, and independent of the opening placement
+/// this assertion exists to check. Anchoring to it keeps this oracle aimed at
+/// exactly one property — the hole's position and dimensions WITHIN the host.
+fn expected_hole_corners(z_base: f64) -> Vec<[f64; 3]> {
+    let xs = [0.3_f64, 1.3];
+    let ys = [-0.15_f64, 0.15];
+    let zs = [z_base + 0.65, z_base + 2.15];
+    let mut out = Vec::with_capacity(8);
+    for &x in &xs {
+        for &y in &ys {
+            for &z in &zs {
+                out.push([x, y, z]);
+            }
+        }
+    }
+    out
+}
+
+/// Closest point in `pts` to `p`, as (distance, coordinates).
+fn nearest(pts: &[[f64; 3]], p: [f64; 3]) -> (f64, [f64; 3]) {
+    let mut best = (f64::INFINITY, [0.0; 3]);
+    for &q in pts {
+        let d = ((q[0] - p[0]).powi(2) + (q[1] - p[1]).powi(2) + (q[2] - p[2]).powi(2)).sqrt();
+        if d < best.0 {
+            best = (d, q);
+        }
+    }
+    best
 }
 
 #[test]
@@ -257,6 +361,31 @@ fn param_fast_path_fires_watertight_and_matches_analytic_on_the_shipped_default(
         rel < 0.02,
         "fired cut volume {pv:.5} must match analytic ground truth {truth:.5} within 2% (rel={rel:.4})"
     );
+
+    // (c2) PLACEMENT correctness: the volume oracle in (c) is blind to WHERE
+    // the hole is. Every one of these preserves the cut volume exactly and so
+    // passes (c): transposing the opening profile's `x_dim`/`y_dim`, swapping
+    // its Position `off_x`/`off_y`, or ignoring the Position offset outright
+    // (i.e. the whole `IfcAxis2Placement2D` branch of `read_rect_profile_2d`
+    // becoming a no-op). Pin the eight hole corners instead.
+    let local = vertices_in_wall_frame(&result);
+    let (lo, hi) = wall_frame_bounds(&local);
+    // The host box itself, so the z anchor below means something.
+    assert!((lo[0] - -2.0).abs() < 1e-3 && (hi[0] - 2.0).abs() < 1e-3,
+        "host wall-frame x extent {:?}..{:?} must be the fixture's 4.0 length", lo[0], hi[0]);
+    assert!((lo[1] - -0.15).abs() < 1e-3 && (hi[1] - 0.15).abs() < 1e-3,
+        "host wall-frame y extent {:?}..{:?} must be the fixture's 0.3 thickness", lo[1], hi[1]);
+    assert!((hi[2] - lo[2] - 2.5).abs() < 1e-3,
+        "host wall-frame z span {} must be the fixture's 2.5 height", hi[2] - lo[2]);
+    for corner in expected_hole_corners(lo[2]) {
+        let (dist, found) = nearest(&local, corner);
+        assert!(
+            dist < 1.0e-3,
+            "hole corner {corner:?} (wall frame) missing from the cut mesh: nearest \
+             vertex {found:?} is {dist:.5} m away — the opening landed in the wrong \
+             place or with the wrong in-plane dimensions"
+        );
+    }
 
     // (d) DRY-drift pin: the host frame (parametric_rect_probe) and the cutter
     // frame source (parametric_rect_probe_all -> rect_param_from_item) share one

--- a/rust/processing/tests/tessellation_quality_server.rs
+++ b/rust/processing/tests/tessellation_quality_server.rs
@@ -68,6 +68,24 @@ fn quality_threads_into_server_geometry() {
     );
 }
 
+/// The `Medium` output on `PIPE_IFC`, pinned as literals.
+///
+/// The equality assertion below cannot carry this test on its own:
+/// `process_geometry_filtered` IS
+/// `..._with_quality(content, filter, TessellationQuality::default())`
+/// (`processor/mod.rs`), and `TessellationQuality::default()` IS `Medium`
+/// (`geometry/src/tessellation.rs`) — so both sides run the identical code
+/// path and the equality only observes `default() == Medium`. Any change to
+/// what `Medium` actually produces moves both sides together and stays green.
+/// These literals are what make such a change visible; the doc comment on this
+/// module claims the default "stays byte-identical to the historical output"
+/// and cache keys for `medium` depend on it (`apps/server/src/routes/parse.rs`).
+///
+/// If a deliberate change to `Medium`'s densification lands, update these two
+/// numbers in the same commit — do not delete the assertion.
+const MEDIUM_VERTICES: usize = 50;
+const MEDIUM_TRIANGLES: usize = 96;
+
 #[test]
 fn default_quality_is_byte_identical_to_legacy_entrypoint() {
     let legacy = process_geometry_filtered(PIPE_IFC, OpeningFilterMode::Default);
@@ -78,6 +96,17 @@ fn default_quality_is_byte_identical_to_legacy_entrypoint() {
     );
     assert_eq!(legacy.stats.total_vertices, medium.stats.total_vertices);
     assert_eq!(legacy.stats.total_triangles, medium.stats.total_triangles);
+
+    assert_eq!(
+        (legacy.stats.total_vertices, legacy.stats.total_triangles),
+        (MEDIUM_VERTICES, MEDIUM_TRIANGLES),
+        "the legacy/default entrypoint's output on the pipe fixture changed"
+    );
+    assert_eq!(
+        (medium.stats.total_vertices, medium.stats.total_triangles),
+        (MEDIUM_VERTICES, MEDIUM_TRIANGLES),
+        "the explicit `Medium` level's output on the pipe fixture changed"
+    );
 }
 
 #[test]


### PR DESCRIPTION
A sweep found guard tests whose fixture or assertion could not express the
property they claimed to pin. Each was re-verified here before being changed,
and each fix carries a RED/GREEN proof: the named mutation was applied to the
**production** code, the test shown failing, the production file restored from
a `cp` backup, and the test shown passing again.

**No production behaviour changes.** Every Rust hunk lands inside `mod tests`
(verified with `git diff -U0`); the two `src/` files touched are test modules
and an inline `#[cfg(test)]` block.

## What each test now catches, and could not before

### 1. `rust/core/src/model_bounds.rs` — `test_precision_preserved_with_rtc`

Called no production code: two `f64` literals, an inline `centroid = (x1 + x2) / 2.0`,
two casts. Deleting `rtc_offset`, `centroid`, `scan_model_bounds` or the entire
RTC feature left it green — it asserted a property of IEEE-754.

Now builds a real `ModelBounds`, `expand()`s both points, and subtracts
`bounds.rtc_offset()`. It also pins the premise (the unshifted f32 cast really
does lose the 0.1 m separation), so the comparison cannot pass on two
equally-good numbers.

**Catches:** `rtc_offset()` returning `(0.0, 0.0, 0.0)` on the large-coordinate
branch. RED: `RTC-shifted f32 must keep the 0.1 m separation (diff=0.25, err=0.15)`.

### 2. `rust/core/src/model_bounds.rs` — `test_large_coordinates_detection`

One `expand()` call, so `min == max == centroid` on every axis and `offset.2`
was never asserted. Every other `rtc_offset()` assertion in the workspace is
equally degenerate (small-coordinate zero cases, plus a single-point fixture at
`rust/processing/src/stream_meta_tests.rs`), so mutating the large-coordinate
branch passed the whole workspace.

Now expands two distinct points and asserts all three components.

**Catches:** the large-coordinate branch returning `(min_x, min_y, min_z)`
instead of `self.centroid()`. RED: `left: 2679012.0, right: 2679062.0`.

### 3. `rust/geometry/src/kernel/retriangulate.rs` — `phase_a_is_deterministic_on_a_45_degree_face`

Claimed the index tiebreak picks X before Y on a tied normal, but called
`projection_axis(&t)` twice with the same argument and asserted the results
agree — a tautology for a pure function.

Now asserts the chosen axis directly, plus the candidate ordering (the tie is
genuine here: `mag[X] == mag[Y]`, so the order is the index tiebreak alone).

**Catches:** reversing `.then(ia.cmp(&ib))` to `.then(ib.cmp(&ia))` in
`axis_candidates`. RED: `left: [Y, X], right: [X, Y]`.

### 4. `rust/processing/tests/tessellation_quality_server.rs` — `default_quality_is_byte_identical_to_legacy_entrypoint`

`process_geometry_filtered` **is**
`..._with_quality(content, filter, TessellationQuality::default())`
(`processor/mod.rs`), and `default()` **is** `Medium`
(`geometry/src/tessellation.rs`). Both sides ran the identical code path, so the
equality only observed `default() == Medium`; any change to what `Medium`
produces moved both sides together.

The `Medium` vertex/triangle counts are now pinned as literals alongside the
equality.

**Catches:** changing the swept-disk base ring count `scale_segments(24, ...)` →
`scale_segments(32, ...)`, which `Medium` passes through unchanged. RED:
`left: (66, 128), right: (50, 96)`. Verified the pre-change test is **green**
under that same mutant.

### 5. `rust/geometry/tests/rect_param_gate.rs`

*Partially refuted, then fixed on the real gap.* The sweep predicted that
swapping `x_dim`/`y_dim` at `router/voids/probe.rs` would leave all assertions
passing. That is **not** so: `read_rect_profile_2d` is shared with the host
wall profile (4.0 x 0.3), so a global swap makes the host non-box and the test
already fails on `stats.fired > 0`. Reported rather than assumed.

The real gap is next door and confirmed: the opening was centred on both
in-plane axes with an identity profile `Position`, so **the whole profile-Position
branch of `read_rect_profile_2d` was a no-op** under a volume-only oracle.

The opening is now off-centre and non-transposable (profile `Position` #229 =
`(0.8, -0.15)`), and the test pins the hole's eight corners, not just the volume.
The corners are expressed in the wall's own frame (basis transcribed literally
from `IfcAxis2Placement3D` #111, never from `parametric_rect_probe`) and anchored
to the host body's own z base, so the assertion targets exactly one property —
the hole's position and dimensions *within* the host.

**Catches:** `read_rect_profile_2d` returning `(x_dim, y_dim, 0.0, 0.0, cos, sin)`
(ignoring the Position offset), and swapping `off_x`/`off_y`. Both are RED here
and both were verified **green** against the pre-change fixture.

### 6. `packages/viewer/test/viewer-html-runtime.test.ts` — flyto

The only matching entity was a unit cube, so `Math.max(...extents, 0.1) * 1.5`
gave 1.5 under max, min, first-axis or a hardcoded 1; the centre was
permutation-invariant; and the `0.1` floor was inert behind a `dist > 0` check.

Fixture is now anisotropic and off-origin (`boundsMin: [2, -1, 4]`,
`boundsMax: [3, 2, 6]` — extents `(1, 3, 2)`, centre `(2.5, 0.5, 5)`), asserting
`dist === 4.5`. The degenerate-selection test pins the floor exactly at `0.15`.

**Catches:** `Math.max(bounds.max[0] - bounds.min[0], 0.1)` (first axis only) —
RED `expected 4.5, actual 1.5`; and changing the floor `0.1` → `0.5` — RED
`got 0.75`. Both verified **green** against the pre-change fixture.

### 7. `rust/geometry/src/clash_solid_world_frame_tests.rs`

`#[should_panic(expected = "world-frame corpus")]` matched **both** panic sites:
the `unwrap_or_else` (gate withheld the solid) and the volume assertion (gate
returned a wrong solid). A partial fix that starts trusting the solid but
computes the wrong volume stayed green and still read as KNOWN-FAILING.

The expectation now names the withheld case (`world-frame corpus [withheld]`)
and the two messages are textually distinct (`[withheld]` vs `[wrong-volume]`).

**Catches:** a simulated partial fix — gate loosened so the far solid is trusted,
plus a wrong volume. RED: `panic did not contain expected string`. With the old
expectation the identical mutant was **green**, which is the whole point.

Checked first that no open PR touches this file (#2707, #2704 and #2697 are the
open clash PRs; none of them do).

## Notes

- **Line-count ratchet.** `module_size_ratchet` budgets `model_bounds.rs` at 445
  and `retriangulate.rs` at 935, exactly their current sizes. Rather than raise
  either budget, the added assertions were compressed to fit: both files are now
  **under** budget (444 and 935). The asserts in those two files were also kept
  within rustfmt's `fn_call_width`, so they do not become reformat churn.
- **No changeset.** `scripts/check-changesets.mjs` only validates that existing
  changesets name a real workspace package; nothing requires one, and its own
  docs say a change with no publishable package should have "no changeset at
  all". This is test-only.
- **Gates:** `cargo test -p ifc-lite-core`, `-p ifc-lite-geometry`,
  `-p ifc-lite-processing` all pass with zero failures. `packages/viewer`
  passes 172/172 (77 socket-binding server tests are cancelled by the local
  sandbox, unrelated to this change; the edited file is 114/114). `oxlint` clean
  on the touched TS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded viewer camera tests to validate centering and distance for off-origin, unevenly sized selections.
  - Improved precision coverage for large-coordinate models.
  - Strengthened geometry tests for far placements, rotated openings, offsets, and exact mesh bounds.
  - Added deterministic checks for projection-axis selection and medium tessellation output counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->