### PR TITLE
ci: run the geometry census on rust/core changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,6 +121,7 @@ jobs:
               - '.github/workflows/test.yml'
             geometry:
               - 'rust/geometry/**'
+              - 'rust/core/**'
               - 'rust/processing/**'
               - 'apps/server/Cargo.toml'
               - 'Cargo.lock'
@@ -657,8 +658,24 @@ jobs:
   # so `cargo test --workspace` does not run it — without this job the suite
   # early-returns and its pinned baselines gate nothing.
   #
-  # `geometry`, not `rust`: only rust/geometry, rust/processing or the fixture
-  # manifest can move its numbers.
+  # `geometry`, not `rust`: the filter is scoped to what can actually move the
+  # numbers. That includes rust/core — `ifc-lite-core` is a direct, non-optional
+  # dependency of `ifc-lite-geometry`, and the census test itself imports
+  # `build_entity_index`, `EntityDecoder` and `EntityScanner` from it, so the
+  # whole IFC-bytes → entities → attributes path is in scope:
+  #   - `GeometryRouter::scan_unit_scale` (router/mod.rs) calls
+  #     `ifc_lite_core::extract_length_unit_scale` (core/src/units.rs) for the
+  #     global length scale; the census snaps positions to 1 mm, so any change
+  #     to unit-scale resolution shifts every coordinate and moves the baselines.
+  #   - `extract_coordinate_list_from_entity` / `parse_indices_direct`
+  #     (core/src/fast_parse.rs) are called from processors/tessellated/
+  #     {triangulated,polygonal}.rs — they *are* the triangle data for the
+  #     tessellation bucket.
+  #   - Float-parsing precision at the 1 mm snap boundary, and attribute
+  #     decoding deciding which hosts are found at all (MIN_MODELS /
+  #     MIN_VOID_HOSTS are the only floor).
+  # Still not `rust`: rust/clash, rust/export and the bindings crates are not on
+  # this test's path.
   geometry-census:
     name: Geometry watertightness census
     needs: changes


### PR DESCRIPTION
## The problem

`.github/workflows/test.yml`'s `geometry` path filter drives the `geometry-census` job — the `--features triangulation-alt` watertightness lane. It listed `rust/geometry/**`, `rust/processing/**`, `apps/server/Cargo.toml`, `Cargo.lock`, `tests/models/manifest.json` and the workflow itself, under a comment asserting:

> `geometry`, not `rust`: only rust/geometry, rust/processing or the fixture manifest can move its numbers.

That is false. A `rust/core`-only PR ran `rust-tests` but **skipped `geometry-census`**, and the gate treats `skipped` as pass.

## Dependency evidence

`cargo tree -p ifc-lite-geometry --features triangulation-alt --depth 1` — `ifc-lite-core` is a direct, non-optional dependency:

```
ifc-lite-geometry v4.2.0 (rust/geometry)
├── bnum v0.14.4
├── earcut v0.4.11
├── earcutr v0.5.0
├── geometry-predicates v0.3.0
├── i_overlay v7.0.2
├── ifc-lite-core v4.2.0 (rust/core)
├── jpeg-decoder v0.3.2
...
```

And the census test imports from it directly — `rust/geometry/tests/triangulation_invariance.rs:31`:

```rust
use ifc_lite_core::{build_entity_index, EntityDecoder, EntityScanner};
```

The whole IFC-bytes → entities → attributes path is `rust/core`.

## Concrete ways a core change moves the census

Verified by call graph, not inferred:

- **Unit scale.** `GeometryRouter::scan_unit_scale` (`rust/geometry/src/router/mod.rs:343`) calls `ifc_lite_core::extract_length_unit_scale` (`rust/core/src/units.rs:63`) for the router's global length scale. The census quantizes positions to 1 mm (`triangulation_invariance.rs:184`, `let q = |v: f32| (v as f64 * 1.0e3).round() as i64`), so any change to unit-scale resolution shifts every coordinate and moves the pinned baselines.
- **Triangle data.** `extract_coordinate_list_from_entity` (`rust/core/src/fast_parse.rs:172`) and `parse_indices_direct` (`:117`) are called from `rust/geometry/src/processors/tessellated/triangulated.rs:48,81` and `polygonal.rs:91`. They *are* the triangle data for the tessellation bucket.
- **Precision and discovery.** Float-parsing precision right at the 1 mm snap boundary, and attribute decoding determining which hosts are found at all — `MIN_MODELS` (105) / `MIN_VOID_HOSTS` (1100) at `triangulation_invariance.rs:119-120` are the only floor.

## Cost of widening

The census has `timeout-minutes: 45`, so this is not a cheap job to run more often. I measured how much more often it will actually fire.

Over the **last 300 first-parent commits on `main`**, bucketed by whether each commit touches `rust/core/` and whether it already matched the pre-existing `geometry` filter:

| bucket | commits |
| --- | --- |
| touches `rust/core` only — **newly triggers the census** | **2** |
| touches `rust/core` *and* already-triggering paths | 1 |
| already-triggering only | 55 |
| neither | 242 |

So the census currently fires on ~56/300 (~19%) of commits, and this change adds **2 more (~0.7% of commits, a ~4% increase in census runs)**.

The reason the marginal cost is so low is that `Cargo.lock` is already in the filter, and most Rust-touching PRs move it. The genuinely core-only population is small.

Derivation: `git log --first-parent -n 300 upstream/main`, then per commit `git show --name-only` matched against `^rust/core/` versus the pre-existing filter globs.

The two core-only commits in that window:

- `7ee619f8c` fix(codegen): two corrupted cells in the generated CRC32 table (#2359)
- `87a9206e6` fix(core): resolve imperial length units in `EntityDecoder::length_unit_scale` (#2308)

To be precise rather than to overstate: I did **not** verify that either of those two would in fact have moved the baselines. #2308 touched `EntityDecoder::length_unit_scale` in `decoder.rs`, which is a *sibling* of the router's `extract_length_unit_scale` path in `units.rs`, and geometry decoders are normally seeded with unit scales — so it may well have been census-neutral. I cite them to characterise the population that newly triggers, not as proof of a missed regression.

## `rust/processing` is not on this path — left alone deliberately

`cargo tree -p ifc-lite-geometry --features triangulation-alt` contains **no `ifc-lite-processing` node at all** (grep count: 0), and the census step runs only:

```
cargo test -p ifc-lite-geometry --features triangulation-alt --test triangulation_invariance
```

So `rust/processing/**` in this filter cannot affect the census result. **I have not removed it.** An over-broad filter runs a job unnecessarily; a narrow one skips a guard — the asymmetry favours leaving it. Whether to drop it is a separate judgement call and yours to make.

## Scope

Filter before → after:

```diff
 geometry:
   - 'rust/geometry/**'
+  - 'rust/core/**'
   - 'rust/processing/**'
   - 'apps/server/Cargo.toml'
   - 'Cargo.lock'
   - '.github/workflows/test.yml'
   - 'tests/models/manifest.json'
```

plus the corrected comment above `geometry-census`. No change to the census itself, its baselines, the job's `timeout-minutes`, its `if:` condition, or any other filter.

## Validation

Parsed `test.yml` with Ruby's Psych, and separately parsed the embedded `filters` string (it is a YAML document inside a YAML scalar, so a syntax error there fails silently at runtime). Both parse; `timeout-minutes: 45` and the `if:` condition are unchanged, and the filter keys are still `rust, frontend, geometry, plato, docs`.

Branch is at `upstream/main` with 0 commits behind (`git log --oneline upstream/main ^HEAD | wc -l` → 0).
