### PR TITLE
fix(renderer): make the section plane basis continuous in the normal

### DIFF
--- a/.changeset/section-plane-basis-continuity.md
+++ b/.changeset/section-plane-basis-continuity.md
@@ -1,0 +1,50 @@
+---
+'@ifc-lite/renderer': patch
+'@ifc-lite/viewer': patch
+---
+
+Make the section plane's in-plane basis continuous in the normal.
+
+`planeBasis` picked its reference axis with `Math.abs(ny) < 0.9`, switching
+from world-Y to world-X at that threshold. `|ny| = 0.9` is a plane 25.8 degrees
+off horizontal — an ordinary ~6:12 roof pitch — and `setSectionPlaneFromFace`
+reaches it from a face pick, so two picks on roof faces either side of that
+pitch got bases that were nowhere near each other. Measured across the
+boundary: at `nz = 0` the tangent inverted exactly (`dot = -1`, a 180-degree
+flip); at `nz = 0.3` it was an arbitrary 133-degree rotation, the size of the
+jump depending on `nz`; and it was asymmetric — the `ny < 0` crossing did not
+move at all. Nothing pinned it: the existing test asserted only orthonormality,
+which every rotation and sign flip of an in-plane basis satisfies.
+
+That basis is the coordinate frame a face-picked drawing is generated in —
+`useDrawingGeneration` hands `custom.tangent`/`custom.bitangent` to the cutter
+as `customPlane`, and `drawing-generator` works in it — so the jump was a
+drawing that came out rotated between two nearly identical picks. (The cap
+hatch is screen-space and its 2D→3D round-trip uses one basis at both ends, so
+it self-cancels; the module doc's stated victim was in fact immune.)
+
+The threshold is gone. World-Y is now the reference for every normal except
+exactly `±Y`, where the cross product genuinely vanishes; the tangent is
+`normalize(normal × Ŷ)`, which depends only on the normal's azimuth and is
+continuous over the whole sphere minus those two points. Continuity everywhere
+is not available — the hairy-ball theorem forbids a nowhere-zero tangent field
+on a sphere, so some normal has to be singular — and `±Y` is the cheapest place
+for it: the plane is exactly horizontal there, so the drawing is a plan whose
+in-plane rotation carries no meaning. At those two normals the historical basis
+is kept unchanged, so a picked horizontal floor still reproduces the "Down"
+preset's hatch orientation. The branchless Frisvad/Duff construction was
+measured and rejected: its `copysign` variant is itself discontinuous across
+`nz = 0` (`dot = -1` at `n = +X`), and pinning the singularity to one point
+costs `bitangent · Y = -nx`, i.e. every elevation on half the sphere upside
+down. The chosen field keeps `bitangent · Y = sin(tilt) >= 0` everywhere, so
+face-picked elevations stay upright — which the old code did not manage either,
+since its X-fallback pointed the bitangent downward for every `ny > 0.9`.
+
+Behaviour change: for normals with `|ny| > 0.9` — near-horizontal planes,
+including every horizontal-ish face pick except an exactly axis-aligned one —
+the basis is different from before. A section drawing regenerated from such a
+pick can come out rotated relative to one generated before this change, and a
+saved section plane reloads with the new basis. Cardinal presets, exactly
+axis-aligned picks (`±X`, `±Y`, `±Z`) and every normal with `|ny| < 0.9` are
+bit-for-bit unchanged. No golden or snapshot moved: the renderer, drawing-2d
+and viewer suites pass unmodified.

--- a/apps/viewer/src/components/viewer/tools/sectionPickPreviewAnchors.ts
+++ b/apps/viewer/src/components/viewer/tools/sectionPickPreviewAnchors.ts
@@ -29,9 +29,10 @@
  * square with the hatch axes of the cut a click would actually commit — the
  * same call #2494 made for the renderer's billboard bases, where routing to
  * one derivation fixed defects no local floor would have caught. (2) is fixed
- * here, at the seam, by screening the inputs: `planeBasis`'s own `|ny| < 0.9`
- * reference-axis test is only meaningful for a UNIT normal, so normalising
- * before the call is required for correctness, not merely tidy.
+ * here, at the seam, by screening the inputs: `planeBasis` degrades a
+ * non-finite normal to a cardinal basis rather than reporting it, and a hover
+ * hint with nothing drawable should paint nothing rather than a square in an
+ * unrelated orientation — so the finiteness screen belongs on this side.
  */
 
 import { planeBasis } from '@ifc-lite/renderer';

--- a/packages/renderer/src/section-plane-basis.test.ts
+++ b/packages/renderer/src/section-plane-basis.test.ts
@@ -41,7 +41,7 @@ describe('planeBasis', () => {
     const tilts: Array<[number, number, number]> = [
       [0.5, 0.5, Math.SQRT1_2],
       [Math.SQRT1_2, 0, Math.SQRT1_2],
-      [0.1, 0.99, 0.05],   // near-vertical — exercises the X-fallback branch
+      [0.1, 0.99, 0.05],   // near-vertical normal (near-horizontal plane)
       [-0.3, -0.6, 0.74],
       [Math.SQRT1_2, Math.SQRT1_2, 0],
     ];
@@ -60,12 +60,114 @@ describe('planeBasis', () => {
   });
 
   it('is sign-stable around the +Y / -Y boundary', () => {
-    // The reference-axis switch (Y vs X) happens at |ny| = 0.9. Stepping
-    // through the boundary should not produce a NaN or zero-length basis.
+    // Stepping through the old |ny| = 0.9 reference-axis switch must not
+    // produce a NaN or zero-length basis.
     for (let nyStep = 0.85; nyStep <= 0.95; nyStep += 0.01) {
       const ny = nyStep;
       const nx = Math.sqrt(Math.max(0, 1 - ny * ny));
       assertOrthonormal([nx, ny, 0], `near-Y ny=${ny.toFixed(2)}`);
+    }
+  });
+});
+
+/**
+ * Continuity.
+ *
+ * The basis IS the coordinate frame a face-picked drawing is generated in
+ * (`useDrawingGeneration` hands `custom.tangent`/`custom.bitangent` to the
+ * cutter as `customPlane`). A discontinuity in it is therefore a drawing that
+ * jumps orientation between two picks on nearly-identical faces.
+ *
+ * The old derivation switched its reference axis at `|ny| = 0.9` — a plane
+ * 25.8 degrees off horizontal, i.e. an ordinary ~6:12 roof pitch, reachable
+ * from `setSectionPlaneFromFace`. Measured across that boundary at nz = 0 the
+ * tangent inverted exactly (dot = -1); with nz = 0.3 it was an arbitrary
+ * 133-degree rotation, and the jump was asymmetric — `ny < 0` did not flip.
+ *
+ * Continuity everywhere is impossible (hairy-ball theorem: a tangent field on
+ * the sphere must vanish somewhere), so what is asserted is continuity
+ * everywhere EXCEPT the two poles `n = ±Y`, where the plane is exactly
+ * horizontal and its in-plane rotation is a free choice anyway.
+ */
+describe('planeBasis is continuous away from the ±Y poles', () => {
+  /** Neighbouring-sample floor: 1-degree steps may not move the frame >8deg. */
+  const MIN_DOT = 0.99;
+
+  const sphere = (theta: number, phi: number): [number, number, number] => [
+    Math.sin(theta) * Math.cos(phi),
+    Math.cos(theta),
+    Math.sin(theta) * Math.sin(phi),
+  ];
+
+  const assertClose = (
+    a: readonly [number, number, number],
+    b: readonly [number, number, number],
+    label: string,
+  ) => {
+    const A = planeBasis(a);
+    const B = planeBasis(b);
+    const dt = dot(A.tangent, B.tangent);
+    const db = dot(A.bitangent, B.bitangent);
+    assert.ok(dt > MIN_DOT, `${label}: tangent jumped, dot = ${dt.toFixed(4)}`);
+    assert.ok(db > MIN_DOT, `${label}: bitangent jumped, dot = ${db.toFixed(4)}`);
+  };
+
+  it('does not jump across the old |ny| = 0.9 reference-axis boundary', () => {
+    // Straddle the boundary at a range of nz, since the size of the old jump
+    // depended on nz (180 degrees at nz = 0, 133 degrees at nz = 0.3).
+    for (let nz = 0; nz <= 0.43; nz += 0.01) {
+      for (const sign of [1, -1]) {
+        const at = (ny: number): [number, number, number] => {
+          const nx = Math.sqrt(Math.max(0, 1 - ny * ny - nz * nz));
+          return [nx, sign * ny, nz];
+        };
+        assertClose(at(0.8999), at(0.9001), `nz=${nz.toFixed(2)} sign=${sign}`);
+      }
+    }
+  });
+
+  it('is continuous over the whole sphere except the poles', () => {
+    // 1-degree lat/long grid, skipping only a 1-degree cap around each pole.
+    const step = Math.PI / 180;
+    for (let theta = step; theta < Math.PI - step / 2; theta += step) {
+      for (let phi = 0; phi < 2 * Math.PI; phi += step) {
+        const label = `theta=${((theta * 180) / Math.PI).toFixed(0)} phi=${((phi * 180) / Math.PI).toFixed(0)}`;
+        assertClose(sphere(theta, phi), sphere(theta + step, phi), `${label} +dtheta`);
+        assertClose(sphere(theta, phi), sphere(theta, phi + step), `${label} +dphi`);
+      }
+    }
+  });
+
+  it('stays continuous in the pole neighbourhood the new construction is sensitive at', () => {
+    // The replacement's only singular points are n = ±Y. Approaching one and
+    // walking all the way around it must still move the frame smoothly — the
+    // fix must not trade the 0.9 circle for a new jump next to the pole.
+    const step = Math.PI / 180;
+    for (const theta of [1e-3, 1e-6, 1e-9, Math.PI - 1e-3, Math.PI - 1e-6]) {
+      for (let phi = 0; phi < 2 * Math.PI; phi += step) {
+        assertClose(
+          sphere(theta, phi),
+          sphere(theta, phi + step),
+          `pole theta=${theta} phi=${phi.toFixed(3)}`,
+        );
+      }
+    }
+  });
+
+  it('never points the bitangent downward, so elevations stay upright', () => {
+    // `bitangent` is the drawing's +Y (screen up). The old X-fallback branch
+    // gave `bitangent · Y < 0` for every normal with ny > 0.9 while the
+    // ny < -0.9 half stayed upright — the asymmetry, seen from the drawing's
+    // side: two picks either side of a ridge produced one upside-down sheet.
+    for (let theta = 0; theta <= Math.PI; theta += Math.PI / 180) {
+      for (let phi = 0; phi < 2 * Math.PI; phi += Math.PI / 12) {
+        const n = sphere(theta, phi);
+        const { bitangent } = planeBasis(n);
+        assert.ok(
+          bitangent[1] >= -EPS,
+          `theta=${((theta * 180) / Math.PI).toFixed(0)} phi=${((phi * 180) / Math.PI).toFixed(0)}: bitangent points down (${bitangent[1].toFixed(4)})`,
+        );
+      }
     }
   });
 });

--- a/packages/renderer/src/section-plane-basis.test.ts
+++ b/packages/renderer/src/section-plane-basis.test.ts
@@ -71,7 +71,7 @@ describe('planeBasis', () => {
 });
 
 /**
- * Continuity.
+ * Continuity (#2714).
  *
  * The basis IS the coordinate frame a face-picked drawing is generated in
  * (`useDrawingGeneration` hands `custom.tangent`/`custom.bitangent` to the
@@ -89,7 +89,7 @@ describe('planeBasis', () => {
  * everywhere EXCEPT the two poles `n = ±Y`, where the plane is exactly
  * horizontal and its in-plane rotation is a free choice anyway.
  */
-describe('planeBasis is continuous away from the ±Y poles', () => {
+describe('planeBasis is continuous away from the ±Y poles (#2714)', () => {
   /** Neighbouring-sample floor: 1-degree steps may not move the frame >8deg. */
   const MIN_DOT = 0.99;
 

--- a/packages/renderer/src/section-plane-basis.ts
+++ b/packages/renderer/src/section-plane-basis.ts
@@ -16,11 +16,13 @@
  * is the single source of truth.
  *
  * Convention:
- *   • The renderer/world is Y-up. We pick world-Y as the reference axis,
- *     unless the normal is too parallel to Y (within ~25°) — in that case
- *     we fall back to world-X to avoid a degenerate cross-product.
+ *   • The renderer/world is Y-up. World-Y is the reference axis for every
+ *     normal except exactly ±Y, where the cross product vanishes and we
+ *     fall back to world-X. `tangent` is therefore horizontal and
+ *     `bitangent` never points downward, so a face-picked elevation comes
+ *     out upright.
  *   • For the cardinal Y-axis plane (normal = [0,1,0]) the resulting
- *     basis is `tangent ≈ [1,0,0]`, `bitangent ≈ [0,0,-1]`. That matches
+ *     basis is `tangent = [0,0,-1]`, `bitangent = [1,0,0]`. That matches
  *     the cardinal-axis cap projection (`'down'` axis maps `(x, z) →
  *     (2D.x, 2D.y)` with z mirrored on flip), so face-picking a perfectly
  *     horizontal floor reproduces the same hatch orientation as the
@@ -66,6 +68,9 @@ function degenerateBasis(): PlaneBasis {
  *      hatch doesn't rotate when state is reconstructed (e.g. on reload
  *      or when the renderer rebuilds resources).
  *   5. Every component of both axes is finite, for every input.
+ *   6. The result is *continuous* in the normal, everywhere except the two
+ *      poles `n = ±Y` — nearby normals give nearby bases, so two
+ *      face picks on nearly the same face give nearly the same drawing.
  *
  * Normalising up front is what makes 3 and 5 true rather than aspirational
  * (#2489). Before it, the function read the caller's magnitudes directly and
@@ -75,16 +80,17 @@ function degenerateBasis(): PlaneBasis {
  *     is true and `NaN < 1e-9` is false — and reached the divisions as
  *     `Infinity / Infinity` / `NaN / NaN`. Both axes came back all-NaN and
  *     went into the section gizmo's vertex buffer and the cap's lift-to-3D.
- *   • The `|ny| < 0.9` reference-axis pick only measures the angle to Y when
- *     `|normal| = 1`. `[10, 1, 0]` is 6° off horizontal but was routed down
- *     the near-vertical fallback, flipping the hatch axis 180° purely
- *     because the caller had not normalised.
+ *   • The reference-axis pick of the day (`|ny| < 0.9`, since removed for
+ *     being discontinuous) only measures the angle to Y when `|normal| = 1`.
+ *     `[10, 1, 0]` is 6° off horizontal but was routed down that fallback,
+ *     flipping the hatch axis 180° purely because the caller had not
+ *     normalised.
  *   • The `1e-9` tangent floor is a length, so a short-but-perfectly-valid
  *     normal such as `[1e-12, 0, 0]` was declared degenerate and returned a
  *     zero-length bitangent.
- * A unit normal makes the cross product with the reference axis at least
- * 0.43 long, so the fallback below is now reachable only for a normal with
- * no direction at all.
+ * Normalisation keeps the sole remaining fallback below an exact test — it is
+ * reachable only for a normal with no direction at all, or one pointing
+ * exactly along ±Y.
  */
 export function planeBasis(normal: Vec3Tuple): PlaneBasis {
   const nlen = Math.hypot(normal[0], normal[1], normal[2]);
@@ -96,11 +102,43 @@ export function planeBasis(normal: Vec3Tuple): PlaneBasis {
   const ny = normal[1] / nlen;
   const nz = normal[2] / nlen;
 
-  // Reference axis: Y-up unless the normal is nearly parallel to Y, in
-  // which case fall back to X. The 0.9 threshold matches the gizmo's
-  // existing reference-axis pick in `section-plane.ts`, so the gizmo
-  // and the cap hatch never disagree on which fallback they used.
-  const useY = Math.abs(ny) < 0.9;
+  // Reference axis: world Y, for EVERY normal that is not exactly ±Y. The
+  // resulting tangent is `normalize(normal × Ŷ)` — the horizontal in-plane
+  // direction — which depends only on the normal's azimuth and is therefore
+  // continuous over the whole sphere minus the two poles.
+  //
+  // It used to switch to world X at `|ny| >= 0.9` "to avoid a degenerate
+  // cross-product", but 0.9 is nowhere near degenerate: the cross is still
+  // 0.436 long there. All the switch bought was a JUMP. Measured at the
+  // boundary, `ny = 0.8999 → 0.9001` inverted the tangent exactly (dot = -1)
+  // at `nz = 0` and rotated it 133 degrees at `nz = 0.3`, and it was
+  // asymmetric — the `ny < 0` crossing did not move at all. `|ny| = 0.9` is a
+  // plane 25.8 degrees off horizontal, an ordinary ~6:12 roof pitch, and
+  // `setSectionPlaneFromFace` reaches it from a face pick: two picks on roof
+  // faces straddling that pitch produced drawings rotated 133-180 degrees
+  // apart, because this basis IS the drawing's coordinate frame
+  // (`useDrawingGeneration` feeds it to the cutter as `customPlane`).
+  //
+  // No construction can be continuous everywhere — the hairy-ball theorem
+  // forbids a nowhere-zero tangent field on a sphere, so at least one normal
+  // must be singular. The two poles are the right place for it: `n = ±Y` is
+  // an exactly horizontal plane, whose drawing is a plan whose in-plane
+  // rotation is a free choice. (The branchless Frisvad/Duff construction gets
+  // that down to ONE singular point, but only by winding the frame twice
+  // around it, which puts `bitangent · Y = -nx` — i.e. it turns every
+  // elevation on one half of the sphere upside down. Two poles is the price
+  // of `bitangent · Y = sin(tilt) >= 0` everywhere, which is what keeps
+  // face-picked elevations upright.)
+  //
+  // At the poles themselves the X fallback keeps the historical answer
+  // (`planeBasis([0,1,0]) = tangent [0,0,-1], bitangent [1,0,0]`), which is
+  // what makes a picked horizontal floor reproduce the "Down" preset's hatch
+  // orientation. That value cannot also be the limit from every direction —
+  // the frame winds once around the pole, so `[1e-9, 1, 0]` and `[-1e-9, 1, 0]`
+  // are 180° apart no matter what is chosen here. That is the singularity, and
+  // it is parked where its cost is lowest: the plane is exactly horizontal, so
+  // the drawing is a plan and its in-plane rotation carries no meaning.
+  const useY = nx !== 0 || nz !== 0;
   const refX = useY ? 0 : 1;
   const refY = useY ? 1 : 0;
   const refZ = 0;
@@ -110,10 +148,13 @@ export function planeBasis(normal: Vec3Tuple): PlaneBasis {
   let ty = nz * refX - nx * refZ;
   let tz = nx * refY - ny * refX;
   let tlen = Math.hypot(tx, ty, tz);
-  if (tlen < 1e-9) {
-    // Unreachable for a unit normal — the reference-axis pick above keeps
-    // this cross product at least 0.43 long — but kept so a future edit to
-    // the 0.9 threshold degrades instead of dividing by zero.
+  if (!(tlen > 0)) {
+    // Unreachable: `useY` is false only for `n = ±Y`, whose cross with X is
+    // exactly unit. Kept so a future edit degrades instead of dividing by
+    // zero — and tested as `> 0` rather than against a fixed floor, because
+    // any floor here is a re-run of the same defect: `|normal × Ŷ|` is the
+    // tilt's sine, so a floor would restore a jump circle at the tilt where
+    // it bites.
     tx = 0; ty = 0; tz = -1;
     tlen = 1;
   }

--- a/packages/renderer/src/section-plane-basis.ts
+++ b/packages/renderer/src/section-plane-basis.ts
@@ -20,7 +20,7 @@
  *     normal except exactly ±Y, where the cross product vanishes and we
  *     fall back to world-X. `tangent` is therefore horizontal and
  *     `bitangent` never points downward, so a face-picked elevation comes
- *     out upright.
+ *     out upright (#2714).
  *   • For the cardinal Y-axis plane (normal = [0,1,0]) the resulting
  *     basis is `tangent = [0,0,-1]`, `bitangent = [1,0,0]`. That matches
  *     the cardinal-axis cap projection (`'down'` axis maps `(x, z) →
@@ -69,7 +69,7 @@ function degenerateBasis(): PlaneBasis {
  *      or when the renderer rebuilds resources).
  *   5. Every component of both axes is finite, for every input.
  *   6. The result is *continuous* in the normal, everywhere except the two
- *      poles `n = ±Y` — nearby normals give nearby bases, so two
+ *      poles `n = ±Y` (#2714) — nearby normals give nearby bases, so two
  *      face picks on nearly the same face give nearly the same drawing.
  *
  * Normalising up front is what makes 3 and 5 true rather than aspirational
@@ -105,7 +105,7 @@ export function planeBasis(normal: Vec3Tuple): PlaneBasis {
   // Reference axis: world Y, for EVERY normal that is not exactly ±Y. The
   // resulting tangent is `normalize(normal × Ŷ)` — the horizontal in-plane
   // direction — which depends only on the normal's azimuth and is therefore
-  // continuous over the whole sphere minus the two poles.
+  // continuous over the whole sphere minus the two poles (#2714).
   //
   // It used to switch to world X at `|ny| >= 0.9` "to avoid a degenerate
   // cross-product", but 0.9 is nowhere near degenerate: the cross is still


### PR DESCRIPTION
## The defect

`planeBasis` (`packages/renderer/src/section-plane-basis.ts`) picked its reference axis with

```ts
const useY = Math.abs(ny) < 0.9;
```

and the basis **jumps** across that threshold. Measured, not inferred:

| crossing | tangent before | tangent after | `dot` |
|---|---|---|---|
| `ny = 0.8999 → 0.9001`, `nz = 0` | `[0, 0, 1]` | `[0, 0, -1]` | **-1.0000** (180°) |
| `ny = 0.8999 → 0.9001`, `nz = 0.3` | `[-0.688, 0, 0.726]` | `[0, 0.316, -0.949]` | **-0.6885** (133.5°) |
| `ny = -0.8999 → -0.9001` | `[0, 0, 1]` | `[0, 0, 1]` | +1.0000 (no jump) |

So it is not a sign flip but an arbitrary rotation whose size depends on `nz`, and it is **asymmetric** — the `ny < 0` crossing does not move at all.

`|ny| = 0.9` is a plane **25.8° off horizontal** — an ordinary ~6:12 roof pitch — and normals reach it from `setSectionPlaneFromFace` (`sectionSlice.ts:468`). Two picks on roof faces straddling that pitch got bases 133–180° apart.

That matters because **this basis is the drawing's coordinate frame**: `useDrawingGeneration.ts:479-485` hands `custom.tangent` / `custom.bitangent` to the cutter as `customPlane`, and `drawing-generator.ts:272-279` works in it. The cap hatch is *not* affected (it is screen-space, `section-2d-overlay.wgsl.ts:215`, and its 2D→3D round-trip uses one basis at both ends, so it self-cancels) — the module doc's stated victim was immune.

Nothing pinned it: the test at `section-plane-basis.test.ts:62` asserted only `assertOrthonormal`, which is invariant under every in-plane rotation and sign flip.

## The fix

World-Y is the reference for **every** normal except exactly `±Y`, where the cross product genuinely vanishes. The tangent is `normalize(normal × Ŷ)` — it depends only on the normal's azimuth, so it is continuous over the whole sphere minus those two points. The tangent-length floor becomes an exact `> 0` test rather than `< 1e-9`: `|normal × Ŷ|` is the tilt's *sine*, so any floor there would restore a jump circle at the tilt where it bites — the same defect one threshold down.

Continuity everywhere is not on offer. The hairy-ball theorem forbids a nowhere-zero tangent field on a sphere, so at least one normal must be singular. `±Y` is the cheapest place to park it: the plane is exactly horizontal there, so the drawing is a plan whose in-plane rotation carries no meaning, and the historical basis is kept unchanged at those two normals so a picked horizontal floor still reproduces the "Down" preset's hatch orientation.

### Why not the branchless Frisvad/Duff construction

It was measured, not assumed:

* its `copysign` variant is **itself discontinuous** — across `nz = 0` at `n = +X` the frame inverts, `dot = -1`. It is branch-free, not jump-free;
* pinning the singularity to one point costs `bitangent · Ŷ = -nx`, i.e. **every elevation on half the sphere upside down**.

Two poles is the price of `bitangent · Ŷ = sin(tilt) ≥ 0` everywhere, which is what keeps face-picked elevations upright. The old code did not manage even that — its X-fallback pointed the bitangent *downward* for every `ny > 0.9`, which is the asymmetry seen from the drawing's side.

### Evidence the replacement is continuous

* min `dot` across the old `|ny| = 0.9` boundary, swept over `nz ∈ [0, 0.43]`: **0.999994** (was `-1`);
* dense whole-sphere scan, 0.05° steps in tilt: **max frame rotation 0.050000°** — Lipschitz with constant 1, no jump anywhere;
* approach to the pole along a meridian at `sin(tilt) = 1e-1, 1e-3, 1e-6, 1e-9, 1e-30, 1e-100, 1e-300, 5e-324`: the tangent is bit-identical at every step (`dot = 1.000000000000`). There is no hidden threshold — the singularity is the single exact value `±Y` and nothing near it;
* min `bitangent.y` over the sphere: **-0**.

## Tests

Four new assertions in `section-plane-basis.test.ts`, all on returned values:

1. no jump across the old `|ny| = 0.9` boundary, swept over `nz` and **both signs of `ny`** (the asymmetry);
2. continuity over the whole sphere on a 1° lat/long grid;
3. continuity in the **new** construction's own sensitive region — a full azimuth walk at `θ = 1e-3, 1e-6, 1e-9` from each pole, so the fix cannot trade the 0.9 circle for a jump next to the pole;
4. `bitangent` never points downward.

**RED on the old code** (1, 2, 4 fail: `tangent jumped, dot = -1.0000`; `bitangent points down (-0.0175)`) — 3 passes on the old code too, because its X-fallback happens to be locally constant inside the polar cap; it guards the new construction, not the old defect. **GREEN after**: 19/19.

No existing assertion was changed, weakened or skipped. In particular the three cardinal pins at `section-plane-basis.test.ts:170-172` (`[0,1,0]`, `[1,0,0]`, `[0,0,-1]`) still hold unmodified.

## Behaviour change — stated plainly

**For normals with `|ny| > 0.9` the basis is different from before.** That is every near-horizontal face pick except an exactly axis-aligned one. A section drawing regenerated from such a pick can come out **rotated** relative to one generated before this change, and a saved section plane reloads with the new basis. Cardinal presets, exactly axis-aligned picks (`±X`, `±Y`, `±Z`) and every normal with `|ny| < 0.9` are bit-for-bit unchanged.

No golden or snapshot moved: the renderer (934), drawing-2d (358) and viewer (4942) suites all pass unmodified.

## Stale docs corrected

* the comment claimed the 0.9 threshold "matches the gizmo's existing reference-axis pick in `section-plane.ts`". There is no `0.9` in that file — it calls `planeBasis` (`:455`). The claim was false and is gone with the threshold;
* the module header stated `planeBasis([0,1,0])` gives `tangent ≈ [1,0,0]`, `bitangent ≈ [0,0,-1]`. The values are the other way round, as the file's own pinned test says. Corrected;
* `sectionPickPreviewAnchors.ts` justified its input screen by `planeBasis`'s "`|ny| < 0.9` reference-axis test"; reworded to the reason that actually applies.

## Reported, not fixed

`packages/clash/src/contact/plane.ts:68` has an independent `planeBasis` with the same shape (`Math.abs(n[0]) < 0.9 ? [1,0,0] : [0,1,0]`) and therefore **the same discontinuity class** — a jump at `|nx| = 0.9`. It is left alone deliberately, and not only for scope: **nothing observable depends on it**. Its sole consumer (`shared-faces.ts:186`) uses it as a scratch frame within one call — `projectTo2D` → clip / area / convex hull → `liftTo3D` with the same basis — and every output is invariant under an in-plane rotation of `{u, v}`: `area_m2`, the 3D `centroid` and `boundary` (lifted back), and `spanMin` / `spanMax` (a diameter and a rotating-calipers width, both rotation-invariant). Handedness is fixed by `v = n × u` in both branches, so polygon winding is stable too. The trap is latent: any future consumer that reads the 2D coordinates themselves, rather than a rotation-invariant scalar derived from them, would inherit the bug.
