### PR TITLE
test: make six TypeScript guard tests able to fail

### DIFF
--- a/apps/viewer/src/lib/level-offsets.test.ts
+++ b/apps/viewer/src/lib/level-offsets.test.ts
@@ -59,10 +59,16 @@ describe('level-offsets', () => {
       assert.strictEqual(offsets.get(3), 2);
     });
 
-    it('preserves elevation ordering with equal gaps', () => {
+    it('preserves elevation ordering with equal gaps, from unsorted input', () => {
       // Storeys with non-uniform original spacing should still
       // become uniformly spaced under Exploded.
-      const store = makeStore(new Map([[1, 0], [2, 4], [3, 5], [4, 12]]));
+      //
+      // The Map is deliberately NOT in ascending elevation order. Map iteration
+      // follows insertion order, and `storeyElevations` is built while walking
+      // the file, so storeys arrive in IFC entity order — arbitrary. Every
+      // fixture here used to be pre-sorted, which made both the `.sort()` and
+      // the `sorted[0][1]` base in computeStoreyOffsets deleted-equivalent.
+      const store = makeStore(new Map([[4, 12], [1, 0], [3, 5], [2, 4]]));
       const offsets = computeStoreyOffsets(store, 3);
       // Targets: 0, 3, 6, 9. Deltas: 0, -1, +1, -3.
       assert.strictEqual(offsets.get(1), undefined);

--- a/apps/viewer/src/lib/polygon-clip.test.ts
+++ b/apps/viewer/src/lib/polygon-clip.test.ts
@@ -10,6 +10,16 @@ function approxEqual(a: number, b: number, tol = 1e-6) {
   return Math.abs(a - b) <= tol;
 }
 
+/** Absolute shoelace area — orientation-independent, like the clipper. */
+function polygonArea(p: Point2D[]): number {
+  let s = 0;
+  for (let i = 0; i < p.length; i++) {
+    const q = p[(i + 1) % p.length];
+    s += p[i][0] * q[1] - q[0] * p[i][1];
+  }
+  return Math.abs(s) / 2;
+}
+
 function polygonsApproxEqual(a: Point2D[], b: Point2D[]): boolean {
   if (a.length !== b.length) return false;
   // Polygons may start at different vertices but should be the
@@ -79,6 +89,54 @@ describe('polygon-clip', () => {
       // Each half is a triangle.
       assert.strictEqual(r.left.length, 3);
       assert.strictEqual(r.right.length, 3);
+    });
+
+    // The fixture above puts the apex at signed distance EXACTLY 0, and every
+    // other fixture in this file uses exact integers or 0.5 — so the smallest
+    // non-zero |d| the suite ever sees is large, and EPS was pinned only from
+    // below (it must be > 0). Anything up to ~0.4 passed, including values that
+    // silently swallow real vertices. These two cases bracket it from both
+    // sides. The cut line here is [1,2] → [1,-1], so signedDistance of a vertex
+    // is 3·(x − 1): the apex offsets below are 3e-12 and 0.15 in EPS units.
+    it('treats an apex a hair off the cut line as ON the line (EPS lower bound)', () => {
+      const tri: Point2D[] = [
+        [0, 0],
+        [2, 0],
+        [1 + 1e-12, 2],
+      ];
+      const r = clipPolygonByLine(tri, [1, 2], [1, -1]);
+      assert.ok(r.ok);
+      // Within EPS the apex belongs to BOTH halves, so each stays a clean
+      // triangle of area 1. With EPS too small (0, or any value under 3e-12)
+      // the apex is a hair to the right, and the left half picks up a fourth
+      // vertex — a zero-width sliver that a mesher will choke on.
+      assert.strictEqual(r.left.length, 3, `left: ${JSON.stringify(r.left)}`);
+      assert.strictEqual(r.right.length, 3, `right: ${JSON.stringify(r.right)}`);
+      assert.ok(approxEqual(polygonArea(r.left), 1, 1e-9));
+      assert.ok(approxEqual(polygonArea(r.right), 1, 1e-9));
+    });
+
+    it('keeps an apex genuinely off the cut line off it (EPS upper bound)', () => {
+      const tri: Point2D[] = [
+        [0, 0],
+        [2, 0],
+        [1.05, 2],
+      ];
+      const r = clipPolygonByLine(tri, [1, 2], [1, -1]);
+      assert.ok(r.ok);
+      // The apex is 0.05 to the right of the cut: the right-of-cut half is a
+      // QUADRILATERAL and must still contain the apex verbatim. An oversized
+      // EPS (anything from ~0.05 up) snaps the apex onto the line, drops it
+      // from the output, and the two halves then cover 2.005 rather than the
+      // triangle's true area of 2 — geometry invented out of a tolerance.
+      assert.strictEqual(r.left.length, 4, `left: ${JSON.stringify(r.left)}`);
+      assert.strictEqual(r.right.length, 3, `right: ${JSON.stringify(r.right)}`);
+      assert.ok(
+        r.left.some((p) => approxEqual(p[0], 1.05, 1e-12) && approxEqual(p[1], 2, 1e-12)),
+        `apex must survive the clip: ${JSON.stringify(r.left)}`,
+      );
+      const total = polygonArea(r.left) + polygonArea(r.right);
+      assert.ok(approxEqual(total, 2, 1e-9), `halves must partition the triangle, got ${total}`);
     });
 
     it('rejects a cut that misses the polygon', () => {

--- a/apps/viewer/src/lib/search/filter-evaluate.test.ts
+++ b/apps/viewer/src/lib/search/filter-evaluate.test.ts
@@ -468,12 +468,41 @@ describe('orderRulesByCost — cheap-first reordering', () => {
     assert.deepStrictEqual(reordered.map((r) => r.kind), ['ifcType', 'name', 'property', 'quantity']);
   });
 
-  it('is a stable sort — two equal-cost rules keep their input order', () => {
+  // NOTE on what this can and cannot catch. `Array.prototype.sort` has been
+  // stable BY SPECIFICATION since ES2019, so no fixture at any size can make
+  // deleting the explicit `|| a.i - b.i` tie-break in orderRulesByCost fail —
+  // equal-comparing elements keep their input order either way. This test
+  // therefore does not guard the tie-break's existence; it guards its
+  // DIRECTION, which is a real mutation (`b.i - a.i` reverses equal-cost rules
+  // and reddens this assertion). The tie-break stays in production because it
+  // states the intended ordering at the comparator rather than leaving it to
+  // an implicit language guarantee — and because its direction is pinned here.
+  it('keeps equal-cost rules in authored order, ascending by input index', () => {
     const a = Rule.name('contains', 'a');
     const b = Rule.name('contains', 'b');
     const reordered = order([a, b]);
     assert.strictEqual(reordered[0], a);
     assert.strictEqual(reordered[1], b);
+
+    // Same guarantee when the sort actually has work to do: three equal-cost
+    // `name` rules interleaved with cheaper and dearer kinds must come out in
+    // authored order relative to one another, not merely undisturbed.
+    const n1 = Rule.name('contains', '1');
+    const n2 = Rule.name('contains', '2');
+    const n3 = Rule.name('contains', '3');
+    const mixed = order([
+      Rule.property('Pset_X', 'P', 'eq', 'v'),
+      n1,
+      Rule.ifcType(['IfcWall']),
+      n2,
+      Rule.quantity('Qto_X', 'Q', 'gt', 1),
+      n3,
+    ]);
+    assert.deepStrictEqual(
+      mixed.map((r) => r.kind),
+      ['ifcType', 'name', 'name', 'name', 'property', 'quantity'],
+    );
+    assert.deepStrictEqual(mixed.slice(1, 4), [n1, n2, n3]);
   });
 
   it('does not mutate the input array', () => {

--- a/packages/clash/src/analysis.test.ts
+++ b/packages/clash/src/analysis.test.ts
@@ -148,6 +148,33 @@ describe('sortClashes', () => {
     expect(sortClashes(list, 'distance').map((c) => c.id)).toEqual(['deep', 'touch', 'gap']);
   });
 
+  it('breaks a full tie by clash id, in every sort mode', () => {
+    // Every other fixture in this block has distinct primary keys, so the
+    // `|| cmpId(a, b)` fallback is never reached and deleting it from all three
+    // branches leaves the suite green. That fallback is not a rare edge: a
+    // clearance run reports positive distances, `penetrationDepth` returns 0 for
+    // ALL of them, and if the rule also fixes the severity then id decides the
+    // entire order of the panel (`ClashPanel.tsx` sorts thousands of rows).
+    //
+    // Input order is deliberately the reverse of id order. `Array.prototype.sort`
+    // is stable by specification, so an equal-comparing comparator would return
+    // the input untouched — only an id comparison can reorder it. Size is
+    // irrelevant here (unlike the >22-element TimSort fixture in
+    // duplicates.test.ts, which needs a run long enough for a comparator that
+    // answers NaN to corrupt the merge); this comparator stays a valid total
+    // order under the mutation, it just stops discriminating.
+    const clearance = (id: string) => clash(id, 0.5, 'major', 'clearance');
+    const gaps = [clearance('c'), clearance('b'), clearance('a')];
+    expect(sortClashes(gaps, 'severity').map((c) => c.id)).toEqual(['a', 'b', 'c']);
+    expect(sortClashes(gaps, 'depth').map((c) => c.id)).toEqual(['a', 'b', 'c']);
+    expect(sortClashes(gaps, 'distance').map((c) => c.id)).toEqual(['a', 'b', 'c']);
+
+    // And for the severity branch specifically: equal severity AND equal depth,
+    // so both of its leading terms are exhausted before the id is consulted.
+    const hard = [clash('h2', -0.3, 'critical'), clash('h1', -0.3, 'critical')];
+    expect(sortClashes(hard, 'severity').map((c) => c.id)).toEqual(['h1', 'h2']);
+  });
+
   it('does not mutate the input', () => {
     const list = [clash('b', -0.1, 'info'), clash('a', -0.2, 'info')];
     const before = list.map((c) => c.id);

--- a/packages/renderer/src/camera-fit-policy.test.ts
+++ b/packages/renderer/src/camera-fit-policy.test.ts
@@ -210,6 +210,49 @@ describe('pickFitPolicy', () => {
       assert.ok(policy.distance < 1000 * 0.31, `distance ${policy.distance} should stay under 310`);
     });
 
+    // Every other linear fixture saturates one of the two clamps, so the
+    // expression they are clamping is unobservable: TARGET_FEATURE_PIXELS,
+    // `fovY`, `viewportShortPx` and the featureSize floor can all be changed
+    // (or the whole `distanceForFeature` term replaced by a constant) without
+    // reddening the suite. Example: bounds(0,0,0,1000,0.0001,1) at the default
+    // 640 px viewport solves to 483 and clamps DOWN to maxDistance 300; delete
+    // the term entirely and the same input clamps UP to minDistance 120.7 —
+    // both satisfy that test's `> 1 && < 310`. This fixture is the same bbox
+    // with a viewport small enough to land strictly between the two clamps.
+    it('solves the feature-pixel equation when neither clamp binds', () => {
+      const policy = pickFitPolicy(bounds(0, 0, 0, 1000, 0.0001, 1), {
+        fovY: FOV_45,
+        viewportShortPx: 200,
+      });
+      assert.strictEqual(policy.kind, 'linear');
+      // featureSize = max(0.0001, 1000 * 0.01) = 10 (the 1% floor).
+      // distance = featureSize * viewportPx / (2 * TARGET_FEATURE_PIXELS * tan(fovY/2))
+      //          = 10 * 200 / (2 * 16 * tan(22.5°)) = 150.888…
+      const expected = (10 * 200) / (2 * 16 * Math.tan(FOV_45 / 2));
+      assertCloseTo(policy.distance, expected, 6);
+      assertCloseTo(policy.distance, 150.8879, 3);
+      // Prove neither clamp is active, so the number above really is the
+      // solved distance and not a clamp in disguise.
+      const minDistance = (1000 * 0.05) / Math.max(Math.tan(FOV_45 / 2), 0.05);
+      assert.ok(policy.distance > minDistance, `expected > minDistance ${minDistance}`);
+      assert.ok(policy.distance < 1000 * 0.3, 'expected below maxDistance 300');
+
+      // And the equation's variables must each move the answer. Both extra
+      // probes stay inside the unclamped window (120.7, 300): a taller
+      // viewport scales the distance linearly, a wider FOV pulls the camera in.
+      const tallerViewport = pickFitPolicy(bounds(0, 0, 0, 1000, 0.0001, 1), {
+        fovY: FOV_45,
+        viewportShortPx: 300,
+      });
+      assertCloseTo(tallerViewport.distance, expected * 1.5, 6);
+      const wideFov = pickFitPolicy(bounds(0, 0, 0, 1000, 0.0001, 1), {
+        fovY: (90 * Math.PI) / 180,
+        viewportShortPx: 200,
+      });
+      assertCloseTo(wideFov.distance, (10 * 200) / (2 * 16 * Math.tan(Math.PI / 4)), 6);
+      assert.ok(wideFov.distance < policy.distance, 'a wider FOV must need less distance');
+    });
+
     it('caps the linear distance at 30% of the longest axis', () => {
       // For an "okay" feature size that solves to a huge distance, the
       // cap keeps us inside a usable slice of the alignment.

--- a/packages/renderer/src/contribution-cull.test.ts
+++ b/packages/renderer/src/contribution-cull.test.ts
@@ -158,6 +158,28 @@ describe('projectedAabbRadiusPx (perspective)', () => {
     assert.ok(Number.isFinite(beyond), `depth > radius must project finitely, got ${beyond}`);
     assert.ok(beyond > 0, `expected a positive pixel radius, got ${beyond}`);
   });
+
+  // Every other perspective fixture in this file uses fovYRadians = PI/2, and
+  // tan(PI/4) = 1 is the multiplicative identity — so `/ (depth * tanHalfFov)`
+  // and `/ depth` are indistinguishable and the whole FOV term can be deleted
+  // with the suite still green. (The file's only other value is 0, which exits
+  // early at the `!(tanHalfFov > 0)` guard.) A non-identity FOV is the only
+  // thing that pins it, including the half-angle: `tan(fov)` instead of
+  // `tan(fov/2)`, and a degrees-for-radians mix-up of the kind documented in
+  // snap-geometry-utils.ts, all land on different numbers here.
+  it('divides by tan(fovY/2): a 60° FOV magnifies against the 90° baseline', () => {
+    const cam = perspectiveCam({ fovYRadians: Math.PI / 3 });
+    // radius = sqrt(12)/2 = sqrt(3), depth = 100, tan(PI/6) = 1/sqrt(3),
+    // halfViewport = 500 → sqrt(3) / (100 / sqrt(3)) * 500 = 3/100 * 500 = 15.
+    const px = projectedAabbRadiusPx([-1, -1, -101], [1, 1, -99], cam);
+    assert.ok(Math.abs(px - 15) < 1e-9, `expected 15 px at 60° FOV, got ${px}`);
+
+    // Same box at the 90° baseline: sqrt(3)/100*500 = 8.6602540…, i.e. exactly
+    // tan(PI/6) of the above. Dropping the FOV factor collapses both to this.
+    const baseline = projectedAabbRadiusPx([-1, -1, -101], [1, 1, -99], perspectiveCam());
+    assert.ok(Math.abs(baseline - Math.sqrt(3) * 5) < 1e-9, `got ${baseline}`);
+    assert.ok(px > baseline, 'a narrower FOV must project the same box LARGER');
+  });
 });
 
 describe('projectedAabbRadiusPx (orthographic)', () => {
@@ -191,6 +213,19 @@ describe('projectedInstancedRadiusPx (instanced templates)', () => {
     // Union box z ∈ [-200, -100] looking down -Z: nearest depth = 100.
     const px = projectedInstancedRadiusPx([-50, -50, -200], [50, 50, -100], 1, perspectiveCam());
     assert.ok(Math.abs(px - (1 / 100) * 500) < 1e-9, `got ${px}`);
+  });
+
+  // Same identity trap as the projectedAabbRadiusPx case above: this function
+  // has its own copy of the `/ (minDepth * tanHalfFov)` term, so it needs its
+  // own non-identity FOV to keep that copy observable.
+  it('divides by tan(fovY/2) at the nearest union depth too', () => {
+    const cam = perspectiveCam({ fovYRadians: Math.PI / 3 });
+    // maxOccRadius = 1, minDepth = 100, tan(PI/6) = 1/sqrt(3) → 1/(100/sqrt(3))*500
+    const px = projectedInstancedRadiusPx([-50, -50, -200], [50, 50, -100], 1, cam);
+    assert.ok(Math.abs(px - Math.sqrt(3) * 5) < 1e-9, `got ${px}`);
+    const baseline = projectedInstancedRadiusPx([-50, -50, -200], [50, 50, -100], 1, perspectiveCam());
+    assert.ok(Math.abs(baseline - 5) < 1e-9, `got ${baseline}`);
+    assert.ok(px > baseline, 'a narrower FOV must project the same template LARGER');
   });
 
   it('is an upper bound for every real occurrence in the box', () => {


### PR DESCRIPTION
Six TypeScript tests asserted a property their fixture could not express. Each one passed with the production code it claims to guard deleted or rewritten. This is the TypeScript counterpart of #2710, which did the same for the Rust side.

Every fix below was verified the same way: mutate production, run the suite and observe **RED**, restore production and observe **GREEN**. The diff is test-only — `git status` shows six `*.test.ts` files and nothing else.

## 1. `packages/clash/src/analysis.test.ts` — `sortClashes` tie-break

All four existing fixtures had distinct primary keys, so `|| cmpId(a, b)` was unreachable in all three branches.

**Now catches:** deleting `|| cmpId(a, b)` from the `severity`, `depth`, or `distance` branch — each independently. Verified: mutating one branch at a time reddens the new test in all three cases (previously 24/24 passed with the tie-break gone from all three at once).

The new fixture is three clearance clashes with equal severity and equal (zero) depth, supplied in reverse id order. This is the live case, not an edge case: `penetrationDepth` returns 0 for every positive-distance clash, so on a clearance run the id is the *only* thing ordering the panel.

Note on `duplicates.test.ts:554`, the repo's only >22-element TimSort fixture: that rule does not apply here. It exists because a comparator answering `NaN` breaks the total order TimSort's merge assumes, which needs a long run to express. Deleting `cmpId` leaves a *valid* comparator that merely stops discriminating, and `Array.prototype.sort` is stable by specification — so input order survives at any size, and a 3-element fixture in non-id order is sufficient. Stated in the test comment.

## 2. `packages/renderer/src/contribution-cull.test.ts` — the FOV term

Every perspective fixture used `fovYRadians: Math.PI / 2`, and `tan(PI/4) = 1`. The file's only other value, `0`, exits early at the `!(tanHalfFov > 0)` guard.

**Now catches:** deleting `* tanHalfFov` from `projectedAabbRadiusPx` and from `projectedInstancedRadiusPx` — previously 28/28 passed with the factor gone from both. Also pins the half-angle and would catch a degrees-for-radians mix-up of the kind documented at `snap-geometry-utils.ts:74-78`.

Both functions carry their own copy of the term, so each gets its own `Math.PI / 3` case with an exact expected value (15 px and 5·sqrt(3) px) plus a direction check against the 90° baseline.

## 3. `apps/viewer/src/lib/level-offsets.test.ts` — the elevation sort

`Map` iteration is insertion order and all four fixtures were already ascending, so `.sort((a, b) => a[1] - b[1])` in `computeStoreyOffsets` was a no-op.

**Now catches:** deleting the `.sort()` — previously 13/13 passed without it. The fixture is the same four storeys with the same expectations, re-ordered to `new Map([[4,12],[1,0],[3,5],[2,4]])`. Real input is `spatialHierarchy.storeyElevations`, built while walking the file, so storeys arrive in IFC entity order.

(The `sorted[0][1]` base assumption turned out to be already covered — the basement fixture has a non-zero minimum. Confirmed by mutating the base to a literal `0`.)

## 4. `apps/viewer/src/lib/polygon-clip.test.ts` — `EPS`

Partially refuted, and the fix is different from a straight fixture swap. `EPS = 0` **is** already caught, by the exact-apex triangle at line 69. What was unpinned is the *upper* bound: the smallest non-zero `|d|` anywhere in the file was 0.5, so `EPS = 0.3` passed all 12 tests while silently swallowing real vertices.

Both new cases were added; the existing exact-0 fixture is kept, since replacing it would have removed the lower-bound coverage it does provide.

- **Lower bound**, apex at `[1 + 1e-12, 2]` (signed distance 3e-12): both halves must stay 3-vertex triangles of area 1. **Now catches** `EPS = 1e-13` (and anything under 3e-12), where the left half picks up a fourth vertex — a zero-width sliver. Strictly stronger than the exact-0 fixture, which passes at `1e-13`.
- **Upper bound**, apex at `[1.05, 2]` (signed distance 0.15): the right-of-cut half must be a quadrilateral still containing `[1.05, 2]` verbatim, and the two halves must sum to the triangle's true area of 2. **Now catches** `EPS = 0.3`, which snaps the apex onto the cut, drops it from the output entirely, and returns halves covering 2.005 — area invented out of a tolerance.

## 5. `packages/renderer/src/camera-fit-policy.test.ts` — the feature-pixel equation

Every linear-branch fixture saturated one of the two clamps. `bounds(0,0,0,1000,0.0001,1)` at the default viewport solves to 483 and clamps *down* to `maxDistance` 300; delete the whole `distanceForFeature` term and the same input clamps *up* to `minDistance` 120.7 — and the assertion `distance > 1 && < 310` accepts both. So `TARGET_FEATURE_PIXELS`, `fovY`, `viewportShortPx` and the featureSize floor were all unobservable.

New case: same bbox at `viewportShortPx: 200`, which lands at 150.888 — strictly between the two clamps, asserted to be so. **Now catches**, each verified individually:

| mutation | result |
| --- | --- |
| `TARGET_FEATURE_PIXELS` 16 → 8 | RED |
| `viewportShortPx` option ignored (always the 640 default) | RED |
| `Math.tan(fovY / 2)` → `Math.tan(fovY)` | RED |
| featureSize floor `longest * 0.01` → `* 0.02` | RED |

Two extra probes (300 px viewport, 90° FOV) stay inside the same unclamped window and pin the equation's response to each variable.

## 6. `apps/viewer/src/lib/search/filter-evaluate.test.ts` — "is a stable sort"

Confirmed unfixable by fixture, as expected. `Array.prototype.sort` has been stable **by specification** since ES2019, so deleting `|| a.i - b.i` from `orderRulesByCost` cannot redden any fixture at any size — verified, 46/46 pass with it gone.

**Decision: keep the production tie-break, reword the test's claim.** The tie-break is not dead weight — it states the intended ordering at the comparator instead of leaving it to an implicit language guarantee, and its *direction* is a genuinely catchable mutation: `b.i - a.i` reverses equal-cost rules and reddens the assertion (verified, 2 tests fail). Deleting working production code purely to make a test meaningful would be the wrong trade.

So the test is renamed from "is a stable sort" to "keeps equal-cost rules in authored order, ascending by input index", with a comment stating plainly what it does and does not guard. It is also strengthened: three equal-cost `name` rules interleaved with cheaper and dearer kinds must come out in authored order relative to one another while the sort is actually doing work, rather than merely being left undisturbed in a two-element input.

## Gates

| gate | result |
| --- | --- |
| `pnpm --filter @ifc-lite/clash test` | 341 passed, 1 skipped |
| `pnpm --filter @ifc-lite/renderer test` | 933 passed, 0 failed |
| `apps/viewer` `pnpm test` | 4941 passed, 6 skipped, 0 failed |
| `typecheck` (clash, renderer, viewer) | clean |

No changeset: `scripts/check-changesets.mjs` states in its own guidance that a change to "scripts, workflows, tests" needs no changeset at all.
